### PR TITLE
Potentially fixed error caused by PandasTools if pandas is not installed

### DIFF
--- a/rdkit/Chem/PandasTools.py
+++ b/rdkit/Chem/PandasTools.py
@@ -91,11 +91,12 @@ try:
     pd.set_option('display.height',100000000000)
   if 'display.max_colwidth' in  pd.core.config._registered_options:
     pd.set_option('display.max_colwidth',100000000000)
+  #saves the default pandas rendering to allow restauration
+  defPandasRendering = pd.core.frame.DataFrame.to_html
 except ImportError:
   pd = None
 
-#saves the default pandas rendering to allow restauration
-defPandasRendering = pd.core.frame.DataFrame.to_html
+
 
 def patchPandasHTMLrepr(self):
   '''


### PR DESCRIPTION
I was not fully able to reproduce the error reported on the mailing list today, by I assume it is caused by carelessly referring to pandas outside of the try block or a function definition . This should be fixed with moving the call into the try clause.
