### PR TITLE
Fixed inconsistent versions in InChI download script (1.04) and documentation (1.03)

### DIFF
--- a/External/INCHI-API/README
+++ b/External/INCHI-API/README
@@ -3,7 +3,7 @@ software distribution from the IUPAC website, and place the source code in this
 directory. Please follow these instructions.
 
 1. Download the zip file from
-   http://www.iupac.org/inchi/download/version1.03/INCHI-1-API.zip
+   http://www.inchi-trust.org/fileadmin/user_upload/software/inchi-v1.04/INCHI-1-API.ZIP
 
 2. Unzip the package. 
 

--- a/External/INCHI-API/download-inchi.sh
+++ b/External/INCHI-API/download-inchi.sh
@@ -30,9 +30,9 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-#
-# This script will download InChI software distribution version 1.03 and place
-# in the current directory
+# This script will download InChI software distribution version 1.04 and 
+# places it (temporarily) in a /tmp directory.  This directory will 
+# automatically dissappear after you reboot the machine.
 
 if ! which wget > /dev/null
 then


### PR DESCRIPTION
The download script was updated some time (perhaps a year ago) to download the then "latest" InChI stable software version (1.04).  This is the version which is recommended to use by IUPAC.  

However the documentation and some comments in the script still pointed to the old version 1.03.  Also the comments in the script were incorrect and have now been fixed.

Change tested on Ubuntu Linux 12.04.
