### PR TITLE
Rationalization of the MMFF API before it's too late

### DIFF
--- a/Code/ForceField/MMFF/testMMFFForceField.cpp
+++ b/Code/ForceField/MMFF/testMMFFForceField.cpp
@@ -430,8 +430,9 @@ int main(int argc, char *argv[])
             rdkFStream << molName << std::endl;
             nameArray.push_back(molName);
           }
-          if (!(mmffMolProperties = MMFF::setupMMFFForceField
-            (mol, *ffIt, MMFF::MMFF_VERBOSITY_HIGH, rdkFStream))) {
+          MMFF::MMFFMolProperties *mmffMolProperties = new
+            MMFF::MMFFMolProperties(*mol, *ffIt, MMFF::MMFF_VERBOSITY_HIGH, rdkFStream);
+          if ((!mmffMolProperties) || (!(mmffMolProperties->isValid()))) {
             std::cerr << molName + ": error setting up force-field" << std::endl;
             continue;
           }

--- a/Code/ForceField/Wrap/ForceField.cpp
+++ b/Code/ForceField/Wrap/ForceField.cpp
@@ -78,38 +78,38 @@ BOOST_PYTHON_MODULE(rdForceField) {
     .def("GetMMFFPartialCharge", &PyMMFFMolProperties::getMMFFPartialCharge,
     (python::arg("self"), python::arg("idx")),
     "Retrieves MMFF partial charge for atom with index idx")
-    .def("SetMMFFDielectricModel", &PyMMFFMolProperties::SetMMFFDielectricModel,
+    .def("SetMMFFDielectricModel", &PyMMFFMolProperties::setMMFFDielectricModel,
     (python::arg("self"), python::arg("dielModel") = 1),
     "Sets the DielModel MMFF property (1: constant; 2: distance-dependent; "
     "defaults to constant)")
-    .def("SetMMFFDielectricConstant", &PyMMFFMolProperties::SetMMFFDielectricConstant,
+    .def("SetMMFFDielectricConstant", &PyMMFFMolProperties::setMMFFDielectricConstant,
     (python::arg("self"), python::arg("dielConst") = 1.0),
     "Sets the DielConst MMFF property (defaults to 1.0)")
-    .def("SetMMFFBondTerm", &PyMMFFMolProperties::SetMMFFBondTerm,
+    .def("SetMMFFBondTerm", &PyMMFFMolProperties::setMMFFBondTerm,
     (python::arg("self"), python::arg("state") = true),
     "Sets the bond term to be included in the MMFF equation (defaults to True)")
-    .def("SetMMFFAngleTerm", &PyMMFFMolProperties::SetMMFFAngleTerm,
+    .def("SetMMFFAngleTerm", &PyMMFFMolProperties::setMMFFAngleTerm,
     (python::arg("self"), python::arg("state") = true),
     "Sets the angle term to be included in the MMFF equation (defaults to True)")
-    .def("SetMMFFStretchBendTerm", &PyMMFFMolProperties::SetMMFFStretchBendTerm,
+    .def("SetMMFFStretchBendTerm", &PyMMFFMolProperties::setMMFFStretchBendTerm,
     (python::arg("self"), python::arg("state") = true),
     "Sets the stretch-bend term to be included in the MMFF equation (defaults to True)")
-    .def("SetMMFFOopTerm", &PyMMFFMolProperties::SetMMFFOopTerm,
+    .def("SetMMFFOopTerm", &PyMMFFMolProperties::setMMFFOopTerm,
     (python::arg("self"), python::arg("state") = true),
     "Sets the out-of-plane bend term to be included in the MMFF equation (defaults to True)")
-    .def("SetMMFFTorsionTerm", &PyMMFFMolProperties::SetMMFFTorsionTerm,
+    .def("SetMMFFTorsionTerm", &PyMMFFMolProperties::setMMFFTorsionTerm,
     (python::arg("self"), python::arg("state") = true),
     "Sets the torsional term to be included in the MMFF equation (defaults to True)")
-    .def("SetMMFFVdWTerm", &PyMMFFMolProperties::SetMMFFVdWTerm,
+    .def("SetMMFFVdWTerm", &PyMMFFMolProperties::setMMFFVdWTerm,
     (python::arg("self"), python::arg("state") = true),
     "Sets the Van der Waals term to be included in the MMFF equation (defaults to True)")
-    .def("SetMMFFEleTerm", &PyMMFFMolProperties::SetMMFFEleTerm,
+    .def("SetMMFFEleTerm", &PyMMFFMolProperties::setMMFFEleTerm,
     (python::arg("self"), python::arg("state") = true),
     "Sets the electrostatic term to be included in the MMFF equation (defaults to True)")
-    .def("SetMMFFVariant", &PyMMFFMolProperties::SetMMFFVariant,
+    .def("SetMMFFVariant", &PyMMFFMolProperties::setMMFFVariant,
     (python::arg("self"), python::arg("mmffVariant") = "MMFF94"),
     "Sets the MMFF variant to be used (\"MMFF94\" or \"MMFF94s\"; defaults to \"MMFF94\")")
-    .def("SetMMFFVerbosity", &PyMMFFMolProperties::SetMMFFVerbosity,
+    .def("SetMMFFVerbosity", &PyMMFFMolProperties::setMMFFVerbosity,
     (python::arg("self"), python::arg("verbosity") = 0),
     "Sets the MMFF verbosity (0: none; 1: low; 2: high; defaults to 0)")
     ;

--- a/Code/ForceField/Wrap/PyForceField.h
+++ b/Code/ForceField/Wrap/PyForceField.h
@@ -68,57 +68,57 @@ namespace ForceFields {
     ~PyMMFFMolProperties() {};
       
     unsigned int getMMFFAtomType(unsigned int idx) {
-      return (unsigned int)(this->mmffMolProperties->getMMFFAtomType(idx));
+      return (unsigned int)(mmffMolProperties->getMMFFAtomType(idx));
     };
     double getMMFFFormalCharge(unsigned int idx) {
-      return this->mmffMolProperties->getMMFFFormalCharge(idx);
+      return mmffMolProperties->getMMFFFormalCharge(idx);
     };
     double getMMFFPartialCharge(unsigned int idx) {
-      return this->mmffMolProperties->getMMFFPartialCharge(idx);
+      return mmffMolProperties->getMMFFPartialCharge(idx);
     };
-    void SetMMFFDielectricModel(boost::uint8_t dielModel)
+    void setMMFFDielectricModel(boost::uint8_t dielModel)
     {
-      this->mmffMolProperties->setMMFFDielectricModel(dielModel);
+      mmffMolProperties->setMMFFDielectricModel(dielModel);
     };
-    void SetMMFFDielectricConstant(double dielConst)
+    void setMMFFDielectricConstant(double dielConst)
     {
-      this->mmffMolProperties->setMMFFDielectricConstant(dielConst);
+      mmffMolProperties->setMMFFDielectricConstant(dielConst);
     };
-    void SetMMFFBondTerm(bool state)
+    void setMMFFBondTerm(bool state)
     {
-      this->mmffMolProperties->setMMFFBondTerm(state);
+      mmffMolProperties->setMMFFBondTerm(state);
     };
-    void SetMMFFAngleTerm(const bool state)
+    void setMMFFAngleTerm(const bool state)
     {
-      this->mmffMolProperties->setMMFFAngleTerm(state);
+      mmffMolProperties->setMMFFAngleTerm(state);
     };
-    void SetMMFFStretchBendTerm(const bool state)
+    void setMMFFStretchBendTerm(const bool state)
     {
-      this->mmffMolProperties->setMMFFStretchBendTerm(state);
+      mmffMolProperties->setMMFFStretchBendTerm(state);
     };
-    void SetMMFFOopTerm(const bool state)
+    void setMMFFOopTerm(const bool state)
     {
-      this->mmffMolProperties->setMMFFOopTerm(state);
+      mmffMolProperties->setMMFFOopTerm(state);
     };
-    void SetMMFFTorsionTerm(const bool state)
+    void setMMFFTorsionTerm(const bool state)
     {
-      this->mmffMolProperties->setMMFFTorsionTerm(state);
+      mmffMolProperties->setMMFFTorsionTerm(state);
     };
-    void SetMMFFVdWTerm(const bool state)
+    void setMMFFVdWTerm(const bool state)
     {
-      this->mmffMolProperties->setMMFFVdWTerm(state);
+      mmffMolProperties->setMMFFVdWTerm(state);
     };
-    void SetMMFFEleTerm(const bool state)
+    void setMMFFEleTerm(const bool state)
     {
-      this->mmffMolProperties->setMMFFEleTerm(state);
+      mmffMolProperties->setMMFFEleTerm(state);
     };
-    void SetMMFFVariant(std::string mmffVariant)
+    void setMMFFVariant(std::string mmffVariant)
     {
-      this->mmffMolProperties->setMMFFVariant(mmffVariant);
+      mmffMolProperties->setMMFFVariant(mmffVariant);
     };
-    void SetMMFFVerbosity(unsigned int verbosity)
+    void setMMFFVerbosity(unsigned int verbosity)
     {
-      this->mmffMolProperties->setMMFFVerbosity(verbosity);
+      mmffMolProperties->setMMFFVerbosity(verbosity);
     };
     boost::shared_ptr<RDKit::MMFF::MMFFMolProperties> mmffMolProperties;
   };

--- a/Code/GraphMol/ForceFieldHelpers/MMFF/AtomTyper.h
+++ b/Code/GraphMol/ForceFieldHelpers/MMFF/AtomTyper.h
@@ -50,28 +50,10 @@ namespace RDKit {
     };
     class MMFFMolProperties {
     public:
-      MMFFMolProperties(unsigned int numAtoms) :
-        d_mmffs(false),
-        d_bondTerm(true),
-        d_angleTerm(true),
-        d_stretchBendTerm(true),
-        d_oopTerm(true),
-        d_torsionTerm(true),
-        d_vdWTerm(true),
-        d_eleTerm(true),
-        d_dielConst(1.0),       //!< the dielectric constant
-        d_dielModel(CONSTANT), //!< the dielectric model (1 = constant, 2 = distance-dependent)
-        d_verbosity(MMFF_VERBOSITY_NONE),
-        d_oStream(&(std::cout)),
-        d_MMFFAtomPropertiesPtrVect(numAtoms) {
-          for (unsigned int i = 0; i < numAtoms; ++i) {
-            d_MMFFAtomPropertiesPtrVect[i]
-              = MMFFAtomPropertiesPtr(new MMFFAtomProperties());
-          }
-        };
+      MMFFMolProperties(ROMol &mol, std::string mmffVariant = "MMFF94", 
+        boost::uint8_t verbosity = MMFF_VERBOSITY_NONE,
+        std::ostream &oStream = std::cout);
       ~MMFFMolProperties() {};
-      const boost::uint8_t setMMFFHeavyAtomType(const Atom *atom);
-      const boost::uint8_t setMMFFHydrogenType(const Atom *atom);
       const unsigned int getMMFFBondType(const Bond *bond);
       const unsigned int getMMFFAngleType(const ROMol &mol,
         const unsigned int idx1, const unsigned int idx2,
@@ -79,7 +61,7 @@ namespace RDKit {
       const std::pair<unsigned int, unsigned int> getMMFFTorsionType
         (const ROMol &mol, const unsigned int idx1, const unsigned int idx2,
         const unsigned int idx3, const unsigned int idx4);
-      void computeMMFFCharges(const ROMol *mol);
+      void computeMMFFCharges(const ROMol &mol);
       const ForceFields::MMFF::MMFFTor *getMMFFTorsionEmpiricalRuleParams
         (const ROMol &mol, unsigned int idx2, unsigned int idx3);
       const ForceFields::MMFF::MMFFBond *getMMFFBondStretchEmpiricalRuleParams
@@ -90,23 +72,11 @@ namespace RDKit {
         
         return this->d_MMFFAtomPropertiesPtrVect[idx]->mmffAtomType;
       };
-      void setMMFFFormalCharge(const unsigned int idx, const double fChg)
-      {
-        RANGE_CHECK(0, idx, this->d_MMFFAtomPropertiesPtrVect.size() - 1);
-        
-        this->d_MMFFAtomPropertiesPtrVect[idx]->mmffFormalCharge = fChg;
-      };
       const double getMMFFFormalCharge(const unsigned int idx)
       {
         RANGE_CHECK(0, idx, this->d_MMFFAtomPropertiesPtrVect.size() - 1);
         
         return this->d_MMFFAtomPropertiesPtrVect[idx]->mmffFormalCharge;
-      };
-      void setMMFFPartialCharge(const unsigned int idx, const double pChg)
-      {
-        RANGE_CHECK(0, idx, this->d_MMFFAtomPropertiesPtrVect.size() - 1);
-        
-        this->d_MMFFAtomPropertiesPtrVect[idx]->mmffPartialCharge = pChg;
       };
       const double getMMFFPartialCharge(const unsigned int idx)
       {
@@ -215,7 +185,26 @@ namespace RDKit {
       {
         return *(this->d_oStream);
       };
+      bool isValid()
+      {
+        return d_valid;
+      };
     private:
+      void setMMFFHeavyAtomType(const Atom *atom);
+      void setMMFFHydrogenType(const Atom *atom);
+      void setMMFFFormalCharge(const unsigned int idx, const double fChg)
+      {
+        RANGE_CHECK(0, idx, this->d_MMFFAtomPropertiesPtrVect.size() - 1);
+        
+        this->d_MMFFAtomPropertiesPtrVect[idx]->mmffFormalCharge = fChg;
+      };
+      void setMMFFPartialCharge(const unsigned int idx, const double pChg)
+      {
+        RANGE_CHECK(0, idx, this->d_MMFFAtomPropertiesPtrVect.size() - 1);
+        
+        this->d_MMFFAtomPropertiesPtrVect[idx]->mmffPartialCharge = pChg;
+      };
+      bool d_valid;
       bool d_mmffs;
       bool d_bondTerm;
       bool d_angleTerm;
@@ -230,9 +219,6 @@ namespace RDKit {
       std::ostream *d_oStream;
       std::vector<MMFFAtomPropertiesPtr> d_MMFFAtomPropertiesPtrVect;
     };
-    MMFFMolProperties *setupMMFFForceField(ROMol *mol,
-      std::string mmffVariant = "MMFF94", boost::uint8_t verbosity = MMFF_VERBOSITY_NONE,
-      std::ostream &oStream = std::cout);
     unsigned int isAngleInRingOfSize3or4(const ROMol &mol, const unsigned int idx1,
       const unsigned int idx2, const unsigned int idx3);
     unsigned int isTorsionInRingOfSize4or5(const ROMol &mol, const unsigned int idx1,
@@ -244,7 +230,7 @@ namespace RDKit {
     bool areAtomsInSameRingOfSize(const ROMol &mol,
       const unsigned int ringSize, const unsigned int numAtoms, ...);
     unsigned int sanitizeMMFFMol(RWMol &mol);
-    void setMMFFAromaticity(RWMol *mol);
+    void setMMFFAromaticity(RWMol &mol);
     const unsigned int getMMFFStretchBendType(const unsigned int angleType,
       const unsigned int bondType1, const unsigned int bondType2);
     const unsigned int getPeriodicTableRow(const int atomicNum);

--- a/Code/GraphMol/ForceFieldHelpers/MMFF/Builder.cpp
+++ b/Code/GraphMol/ForceFieldHelpers/MMFF/Builder.cpp
@@ -41,6 +41,7 @@ namespace RDKit {
       {
         PRECONDITION(field, "bad ForceField");
         PRECONDITION(mmffMolProperties, "bad MMFFMolProperties");
+        PRECONDITION(mmffMolProperties->isValid(), "missing atom types - invalid force-field");
 
         std::ostream &oStream = mmffMolProperties->getMMFFOStream();
         MMFFBondCollection *mmffBond = MMFFBondCollection::getMMFFBond();
@@ -234,6 +235,7 @@ namespace RDKit {
       {
         PRECONDITION(field, "bad ForceField");
         PRECONDITION(mmffMolProperties, "bad MMFFMolProperties");
+        PRECONDITION(mmffMolProperties->isValid(), "missing atom types - invalid force-field");
 
         std::ostream &oStream = mmffMolProperties->getMMFFOStream();
         unsigned int idx[3];
@@ -376,6 +378,7 @@ namespace RDKit {
       {
         PRECONDITION(field, "bad ForceField");
         PRECONDITION(mmffMolProperties, "bad MMFFMolProperties");
+        PRECONDITION(mmffMolProperties->isValid(), "missing atom types - invalid force-field");
 
         std::ostream &oStream = mmffMolProperties->getMMFFOStream();
         unsigned int idx[3];
@@ -566,6 +569,7 @@ namespace RDKit {
       {
         PRECONDITION(field, "bad ForceField");
         PRECONDITION(mmffMolProperties, "bad MMFFMolProperties");
+        PRECONDITION(mmffMolProperties->isValid(), "missing atom types - invalid force-field");
         
         std::ostream &oStream = mmffMolProperties->getMMFFOStream();
         unsigned int idx[4];
@@ -697,6 +701,7 @@ namespace RDKit {
       {
         PRECONDITION(field, "bad ForceField");
         PRECONDITION(mmffMolProperties, "bad MMFFMolProperties");
+        PRECONDITION(mmffMolProperties->isValid(), "missing atom types - invalid force-field");
 
         std::ostream &oStream = mmffMolProperties->getMMFFOStream();
         unsigned int idx1;
@@ -851,6 +856,7 @@ namespace RDKit {
       {
         PRECONDITION(field, "bad ForceField");
         PRECONDITION(mmffMolProperties, "bad MMFFMolProperties");
+        PRECONDITION(mmffMolProperties->isValid(), "missing atom types - invalid force-field");
 
         std::ostream &oStream = mmffMolProperties->getMMFFOStream();
         MMFFVdWCollection *mmffVdW = MMFFVdWCollection::getMMFFVdW();
@@ -942,6 +948,7 @@ namespace RDKit {
       {
         PRECONDITION(field, "bad ForceField");
         PRECONDITION(mmffMolProperties, "bad MMFFMolProperties");
+        PRECONDITION(mmffMolProperties->isValid(), "missing atom types - invalid force-field");
 
         std::ostream &oStream = mmffMolProperties->getMMFFOStream();
         MMFFVdWCollection *mmffVdW = MMFFVdWCollection::getMMFFVdW();
@@ -1029,11 +1036,10 @@ namespace RDKit {
     ForceFields::ForceField *constructForceField(ROMol &mol,
       double nonBondedThresh, int confId, bool ignoreInterfragInteractions)
     {
-      MMFFMolProperties *mmffMolProperties = MMFF::setupMMFFForceField(&mol);
-      PRECONDITION(mmffMolProperties, "Unable to setup MMFF force field");
+      MMFFMolProperties mmffMolProperties(mol);
+      PRECONDITION(mmffMolProperties.isValid(), "missing atom types - invalid force-field");
       ForceFields::ForceField *res = constructForceField(mol,
-        mmffMolProperties, nonBondedThresh, confId, ignoreInterfragInteractions);
-      delete mmffMolProperties;
+        &mmffMolProperties, nonBondedThresh, confId, ignoreInterfragInteractions);
         
       return res;
     }
@@ -1047,8 +1053,10 @@ namespace RDKit {
       MMFFMolProperties *mmffMolProperties, double nonBondedThresh,
       int confId, bool ignoreInterfragInteractions)
     {
-      ForceFields::ForceField *res = new ForceFields::ForceField();
+      PRECONDITION(mmffMolProperties, "bad MMFFMolProperties");
+      PRECONDITION(mmffMolProperties->isValid(), "missing atom types - invalid force-field");
 
+      ForceFields::ForceField *res = new ForceFields::ForceField();
       // add the atomic positions:
       Conformer &conf = mol.getConformer(confId);
       for (unsigned int i = 0; i < mol.getNumAtoms(); ++i) {

--- a/Code/GraphMol/ForceFieldHelpers/MMFF/testMMFFHelpers.cpp
+++ b/Code/GraphMol/ForceFieldHelpers/MMFF/testMMFFHelpers.cpp
@@ -31,112 +31,114 @@ void testMMFFTyper1()
   BOOST_LOG(rdErrorLog) << "-------------------------------------" << std::endl;
   BOOST_LOG(rdErrorLog) << "    Test MMFF atom types." << std::endl;
 
-  ROMol *mol;
-  boost::uint8_t type;
-  MMFF::MMFFMolProperties *mmffMolProperties;
+  {
+    boost::uint8_t type;
+    ROMol *mol = SmilesToMol("[SiH3]CC(=O)NC");
+    TEST_ASSERT(mol);
+    MMFF::MMFFMolProperties mmffMolProperties(*mol);
+    TEST_ASSERT(mmffMolProperties.isValid());
 
-  mol = SmilesToMol("[SiH3]CC(=O)NC");
-  TEST_ASSERT(mol);
-  mmffMolProperties = MMFF::setupMMFFForceField(mol);
-  TEST_ASSERT(mmffMolProperties);
+    type = mmffMolProperties.getMMFFAtomType(0);
+    TEST_ASSERT(type == 19);
+    type = mmffMolProperties.getMMFFAtomType(1);
+    TEST_ASSERT(type == 1);
+    type = mmffMolProperties.getMMFFAtomType(2);
+    TEST_ASSERT(type == 3);
+    type = mmffMolProperties.getMMFFAtomType(3);
+    TEST_ASSERT(type == 7);
+    type = mmffMolProperties.getMMFFAtomType(4);
+    TEST_ASSERT(type == 10);
+    delete mol;
+  }
 
-  type = mmffMolProperties->getMMFFAtomType(0);
-  TEST_ASSERT(type == 19);
-  type = mmffMolProperties->getMMFFAtomType(1);
-  TEST_ASSERT(type == 1);
-  type = mmffMolProperties->getMMFFAtomType(2);
-  TEST_ASSERT(type == 3);
-  type = mmffMolProperties->getMMFFAtomType(3);
-  TEST_ASSERT(type == 7);
-  type = mmffMolProperties->getMMFFAtomType(4);
-  TEST_ASSERT(type == 10);
+  {
+    boost::uint8_t type;
+    ROMol *mol = SmilesToMol("CC(=O)C");
+    TEST_ASSERT(mol);
+    MMFF::MMFFMolProperties mmffMolProperties(*mol);
+    TEST_ASSERT(mmffMolProperties.isValid());
 
-  delete mol;
-  delete mmffMolProperties;
-  mol = SmilesToMol("CC(=O)C");
-  TEST_ASSERT(mol);
-  mmffMolProperties = MMFF::setupMMFFForceField(mol);
-  TEST_ASSERT(mmffMolProperties);
+    type = mmffMolProperties.getMMFFAtomType(0);
+    TEST_ASSERT(type == 1);
+    type = mmffMolProperties.getMMFFAtomType(1);
+    TEST_ASSERT(type == 3);
+    type = mmffMolProperties.getMMFFAtomType(2);
+    TEST_ASSERT(type == 7);
+    type = mmffMolProperties.getMMFFAtomType(3);
+    TEST_ASSERT(type == 1);
+    delete mol;
+  }
 
-  type = mmffMolProperties->getMMFFAtomType(0);
-  TEST_ASSERT(type == 1);
-  type = mmffMolProperties->getMMFFAtomType(1);
-  TEST_ASSERT(type == 3);
-  type = mmffMolProperties->getMMFFAtomType(2);
-  TEST_ASSERT(type == 7);
-  type = mmffMolProperties->getMMFFAtomType(3);
-  TEST_ASSERT(type == 1);
-  
- 
-  delete mol;
-  delete mmffMolProperties;
-  mol = SmilesToMol("C(=O)S");
-  TEST_ASSERT(mol);
-  mmffMolProperties = MMFF::setupMMFFForceField(mol);
-  TEST_ASSERT(mmffMolProperties);
+  {
+    boost::uint8_t type;
+    ROMol *mol = SmilesToMol("C(=O)S");
+    TEST_ASSERT(mol);
+    MMFF::MMFFMolProperties mmffMolProperties(*mol);
+    TEST_ASSERT(mmffMolProperties.isValid());
 
-  type = mmffMolProperties->getMMFFAtomType(0);
-  TEST_ASSERT(type == 3);
-  type = mmffMolProperties->getMMFFAtomType(1);
-  TEST_ASSERT(type == 7);
-  type = mmffMolProperties->getMMFFAtomType(2);
-  TEST_ASSERT(type == 15);
+    type = mmffMolProperties.getMMFFAtomType(0);
+    TEST_ASSERT(type == 3);
+    type = mmffMolProperties.getMMFFAtomType(1);
+    TEST_ASSERT(type == 7);
+    type = mmffMolProperties.getMMFFAtomType(2);
+    TEST_ASSERT(type == 15);
+    delete mol;
+  }
+  {
+    boost::uint8_t type;
+    ROMol *mol = SmilesToMol("SCS(=O)S(=O)(=O)O");
+    TEST_ASSERT(mol);
+    MMFF::MMFFMolProperties mmffMolProperties(*mol);
+    TEST_ASSERT(mmffMolProperties.isValid());
 
-  delete mol;
-  delete mmffMolProperties;
-  mol = SmilesToMol("SCS(=O)S(=O)(=O)O");
-  TEST_ASSERT(mol);
-  mmffMolProperties = MMFF::setupMMFFForceField(mol);
-  TEST_ASSERT(mmffMolProperties);
+    type = mmffMolProperties.getMMFFAtomType(0);
+    TEST_ASSERT(type == 15);
+    type = mmffMolProperties.getMMFFAtomType(1);
+    TEST_ASSERT(type == 1);
+    type = mmffMolProperties.getMMFFAtomType(2);
+    TEST_ASSERT(type == 17);
+    type = mmffMolProperties.getMMFFAtomType(4);
+    TEST_ASSERT(type == 18);
+    delete mol;
+  }
+  {
+    boost::uint8_t type;
+    ROMol *mol = SmilesToMol("PCP(O)CP(=O)(=O)");
+    TEST_ASSERT(mol);
+    MMFF::MMFFMolProperties mmffMolProperties(*mol);
+    TEST_ASSERT(mmffMolProperties.isValid());
 
-  type = mmffMolProperties->getMMFFAtomType(0);
-  TEST_ASSERT(type == 15);
-  type = mmffMolProperties->getMMFFAtomType(1);
-  TEST_ASSERT(type == 1);
-  type = mmffMolProperties->getMMFFAtomType(2);
-  TEST_ASSERT(type == 17);
-  type = mmffMolProperties->getMMFFAtomType(4);
-  TEST_ASSERT(type == 18);
-  
-  delete mol;
-  delete mmffMolProperties;
-  mol = SmilesToMol("PCP(O)CP(=O)(=O)");
-  TEST_ASSERT(mol);
-  mmffMolProperties = MMFF::setupMMFFForceField(mol);
-  TEST_ASSERT(mmffMolProperties);
+    type = mmffMolProperties.getMMFFAtomType(0);
+    TEST_ASSERT(type == 26);
+    type = mmffMolProperties.getMMFFAtomType(1);
+    TEST_ASSERT(type == 1);
+    type = mmffMolProperties.getMMFFAtomType(2);
+    TEST_ASSERT(type == 26);
+    type = mmffMolProperties.getMMFFAtomType(5);
+    TEST_ASSERT(type == 26);
+    delete mol;
+  }
+  {
+    boost::uint8_t type;
+    ROMol *mol = SmilesToMol("C(F)(Cl)(Br)I");
+    TEST_ASSERT(mol);
+    MMFF::MMFFMolProperties mmffMolProperties(*mol);
+    TEST_ASSERT(mmffMolProperties.isValid());
 
-  type = mmffMolProperties->getMMFFAtomType(0);
-  TEST_ASSERT(type == 26);
-  type = mmffMolProperties->getMMFFAtomType(1);
-  TEST_ASSERT(type == 1);
-  type = mmffMolProperties->getMMFFAtomType(2);
-  TEST_ASSERT(type == 26);
-  type = mmffMolProperties->getMMFFAtomType(5);
-  TEST_ASSERT(type == 26);
-  
+    type = mmffMolProperties.getMMFFAtomType(0);
+    TEST_ASSERT(type == 1);
+    type = mmffMolProperties.getMMFFAtomType(1);
+    TEST_ASSERT(type == 11);
+    type = mmffMolProperties.getMMFFAtomType(2);
+    TEST_ASSERT(type == 12);
+    type = mmffMolProperties.getMMFFAtomType(3);
+    TEST_ASSERT(type == 13);
+    type = mmffMolProperties.getMMFFAtomType(4);
+    TEST_ASSERT(type == 14);
+    delete mol;
+  }
 
-  delete mol;
-  delete mmffMolProperties;
-  mol = SmilesToMol("C(F)(Cl)(Br)I");
-  TEST_ASSERT(mol);
-  mmffMolProperties = MMFF::setupMMFFForceField(mol);
-  TEST_ASSERT(mmffMolProperties);
 
-  type = mmffMolProperties->getMMFFAtomType(0);
-  TEST_ASSERT(type == 1);
-  type = mmffMolProperties->getMMFFAtomType(1);
-  TEST_ASSERT(type == 11);
-  type = mmffMolProperties->getMMFFAtomType(2);
-  TEST_ASSERT(type == 12);
-  type = mmffMolProperties->getMMFFAtomType(3);
-  TEST_ASSERT(type == 13);
-  type = mmffMolProperties->getMMFFAtomType(4);
-  TEST_ASSERT(type == 14);
-  
-  delete mol;
-  delete mmffMolProperties;
-
-  
   BOOST_LOG(rdErrorLog) << "  done" << std::endl;
 }
 
@@ -147,7 +149,6 @@ void testMMFFBuilder1()
 
   ROMol *mol,*mol2;
 
-  MMFF::MMFFMolProperties *mmffMolProperties;
   ForceFields::ForceField *field;
   boost::shared_array<boost::uint8_t> nbrMat;
 
@@ -155,8 +156,9 @@ void testMMFFBuilder1()
   Conformer *conf = new Conformer(mol->getNumAtoms());
   int cid = static_cast<int>(mol->addConformer(conf, true));
   TEST_ASSERT(mol);
-  mmffMolProperties = MMFF::setupMMFFForceField(mol);
+  MMFF::MMFFMolProperties *mmffMolProperties = new MMFF::MMFFMolProperties(*mol);
   TEST_ASSERT(mmffMolProperties);
+  TEST_ASSERT(mmffMolProperties->isValid());
   field = new ForceFields::ForceField();
   MMFF::Tools::addBonds(*mol, mmffMolProperties, field);
 
@@ -186,8 +188,9 @@ void testMMFFBuilder1()
   Conformer *conf2 = new Conformer(mol->getNumAtoms());
   cid = static_cast<int>(mol->addConformer(conf2, true));
   TEST_ASSERT(mol);
-  mmffMolProperties = MMFF::setupMMFFForceField(mol);
+  mmffMolProperties = new MMFF::MMFFMolProperties(*mol);
   TEST_ASSERT(mmffMolProperties);
+  TEST_ASSERT(mmffMolProperties->isValid());
   field = new ForceFields::ForceField();
   MMFF::Tools::addBonds(*mol, mmffMolProperties, field);
 
@@ -215,8 +218,9 @@ void testMMFFBuilder1()
   Conformer *conf3 = new Conformer(mol->getNumAtoms());
   cid = static_cast<int>(mol->addConformer(conf3, true));
   TEST_ASSERT(mol);
-  mmffMolProperties = MMFF::setupMMFFForceField(mol);
+  mmffMolProperties = new MMFF::MMFFMolProperties(*mol);
   TEST_ASSERT(mmffMolProperties);
+  TEST_ASSERT(mmffMolProperties->isValid());
 
   field = new ForceFields::ForceField();
   MMFF::Tools::addBonds(*mol, mmffMolProperties, field);
@@ -240,8 +244,9 @@ void testMMFFBuilder1()
   delete field;
   delete mmffMolProperties;
   
-  mmffMolProperties = MMFF::setupMMFFForceField(mol2);
+  mmffMolProperties = new MMFF::MMFFMolProperties(*mol2);
   TEST_ASSERT(mmffMolProperties);
+  TEST_ASSERT(mmffMolProperties->isValid());
 
   field = new ForceFields::ForceField();
   MMFF::Tools::addBonds(*mol2, mmffMolProperties, field);
@@ -496,7 +501,7 @@ void testSFIssue1653802()
   mol = MolFileToMol(pathName + "/cyclobutadiene.mol", false);
   TEST_ASSERT(mol);
   MMFF::sanitizeMMFFMol(*mol);
-  MMFF::MMFFMolProperties *mmffMolProperties = MMFF::setupMMFFForceField(mol);
+  MMFF::MMFFMolProperties *mmffMolProperties = new MMFF::MMFFMolProperties(*mol);
   TEST_ASSERT(mmffMolProperties);
 
   boost::shared_array<boost::uint8_t> nbrMat;
@@ -520,6 +525,7 @@ void testSFIssue1653802()
   
   delete mol;
   delete field;
+  delete mmffMolProperties;
   BOOST_LOG(rdErrorLog) << "  done" << std::endl;
 }
 


### PR DESCRIPTION
- Replaced the setupMMFFForceField() function (which returned a pointer
  to a newly allocated MMFFMolProperties object) with a simple
  constructor of the MMFFMolProperties object
- Replaced in a few MMFF-related functions the "ROMol *" argument
  with a "ROMol &" argument for consistency with similar RDKit
  functions
- Renamed the SetupMMFFForceField() function in Python into
  GetMMFFMolProperties() for consistency
- Updated the MMFF tests according to the aforementioned changes
  in the API
