### PR TITLE
Removed special sanitization/kekulization requirements for MMFF

### DIFF
--- a/Code/ForceField/MMFF/testMMFFForceField.cpp
+++ b/Code/ForceField/MMFF/testMMFFForceField.cpp
@@ -283,7 +283,7 @@ int main(int argc, char *argv[])
   unsigned int i = 1;
   unsigned int n = 0;
   bool error = false;
-  int fullTest = false;
+  bool fullTest = false;
   int inc = 4;
   bool testFailure = false;
   while (i < argc) {
@@ -316,6 +316,7 @@ int main(int argc, char *argv[])
       }
     }
     else if (arg == "-L") {
+      fullTest = true;
       inc = 1;
     }
     else if (arg == "-l") {
@@ -422,9 +423,9 @@ int main(int argc, char *argv[])
           }
           else {
             mol = MolOps::addHs(*(molVec[i]));
-            MMFF::sanitizeMMFFMol((RWMol &)(*mol));
             DGeomHelpers::EmbedMolecule(*mol);
           }
+          MMFF::sanitizeMMFFMol((RWMol &)(*mol));
           if (mol->hasProp("_Name")) {
             mol->getProp("_Name", molName);
             rdkFStream << molName << std::endl;

--- a/Code/GraphMol/ForceFieldHelpers/MMFF/testMMFFHelpers.cpp
+++ b/Code/GraphMol/ForceFieldHelpers/MMFF/testMMFFHelpers.cpp
@@ -280,9 +280,9 @@ void testMMFFBuilder2()
 
   std::string pathName = getenv("RDBASE");
   pathName += "/Code/GraphMol/ForceFieldHelpers/MMFF/test_data";
-  mol = MolFileToMol(pathName + "/small1.mol", false);
+  mol = MolFileToMol(pathName + "/small1.mol",false);
   TEST_ASSERT(mol);
-  MMFF::sanitizeMMFFMol(*mol);
+  MolOps::sanitizeMol(*mol);
 
   field = MMFF::constructForceField(*mol);
   TEST_ASSERT(field);
@@ -306,9 +306,9 @@ void testMMFFBuilder2()
   delete mol;
   delete field;
 
-  mol = MolFileToMol(pathName + "/benzene.mol", false);
+  mol = MolFileToMol(pathName + "/benzene.mol",false);
   TEST_ASSERT(mol);
-  MMFF::sanitizeMMFFMol(*mol);
+  MolOps::sanitizeMol(*mol);
 
   field = MMFF::constructForceField(*mol);
   TEST_ASSERT(field);
@@ -319,9 +319,9 @@ void testMMFFBuilder2()
   delete mol;
   delete field;
   
-  mol = MolFileToMol(pathName + "/toluene.mol", false);
+  mol = MolFileToMol(pathName + "/toluene.mol",false);
   TEST_ASSERT(mol);
-  MMFF::sanitizeMMFFMol(*mol);
+  MolOps::sanitizeMol(*mol);
 
   field = MMFF::constructForceField(*mol);
   TEST_ASSERT(field);
@@ -332,9 +332,9 @@ void testMMFFBuilder2()
   delete mol;
   delete field;
 
-  mol = MolFileToMol(pathName + "/complex1.mol", false);
+  mol = MolFileToMol(pathName + "/complex1.mol",false);
   TEST_ASSERT(mol);
-  MMFF::sanitizeMMFFMol(*mol);
+  MolOps::sanitizeMol(*mol);
 
   field = MMFF::constructForceField(*mol);
   TEST_ASSERT(field);
@@ -360,13 +360,12 @@ void testMMFFBatch()
 
   std::string pathName = getenv("RDBASE");
   pathName += "/Code/GraphMol/ForceFieldHelpers/MMFF/test_data";
-  SDMolSupplier suppl(pathName + "/bulk.sdf", false);
+  SDMolSupplier suppl(pathName + "/bulk.sdf");
 
   int count = 0;
   mol = suppl.next();
   while (mol && (!(suppl.atEnd()))) {
     ++count;
-    MMFF::sanitizeMMFFMol((RWMol &)*mol);
     std::string origMolBlock = MolToMolBlock(*mol);
 
     BOOST_LOG(rdErrorLog) << "Mol:" << count << std::endl;
@@ -405,10 +404,11 @@ void testIssue239()
 
   std::string pathName = getenv("RDBASE");
   pathName += "/Code/GraphMol/ForceFieldHelpers/MMFF/test_data";
-  mol = MolFileToMol(pathName + "/Issue239.mol", false);
+  mol = MolFileToMol(pathName + "/Issue239.mol",false);
   TEST_ASSERT(mol);
-  MMFF::sanitizeMMFFMol((RWMol &)*mol);
+  MolOps::sanitizeMol(*mol);
 
+  
   field = MMFF::constructForceField(*mol);
   TEST_ASSERT(field);
   field->initialize();
@@ -442,13 +442,11 @@ void testIssue242()
   std::string pathName = getenv("RDBASE");
   pathName += "/Code/GraphMol/ForceFieldHelpers/MMFF/test_data";
 
-  mol = MolFileToMol(pathName + "/Issue242-2.mol", false);
+  mol = MolFileToMol(pathName + "/Issue242-2.mol");
   TEST_ASSERT(mol);
-  MMFF::sanitizeMMFFMol((RWMol &)*mol);
 
-  mol2 = MolFileToMol(pathName + "/Issue242-2.mol", false);
+  mol2 = MolFileToMol(pathName + "/Issue242-2.mol");
   TEST_ASSERT(mol2);
-  MMFF::sanitizeMMFFMol((RWMol &)*mol2);
 
   TEST_ASSERT(DGeomHelpers::EmbedMolecule(*mol2, 30, 2370) >= 0);
   mb1 = MolToMolBlock(*mol);
@@ -500,7 +498,7 @@ void testSFIssue1653802()
 
   mol = MolFileToMol(pathName + "/cyclobutadiene.mol", false);
   TEST_ASSERT(mol);
-  MMFF::sanitizeMMFFMol(*mol);
+  MolOps::sanitizeMol(*mol);
   MMFF::MMFFMolProperties *mmffMolProperties = new MMFF::MMFFMolProperties(*mol);
   TEST_ASSERT(mmffMolProperties);
 

--- a/Code/GraphMol/ForceFieldHelpers/Wrap/testHelpers.py
+++ b/Code/GraphMol/ForceFieldHelpers/Wrap/testHelpers.py
@@ -83,25 +83,25 @@ M  END"""
 
   def test5(self) :
     fName = os.path.join(self.dirName,'benzene.mol')
-    m = Chem.MolFromMolFile(fName, False)
+    m = Chem.MolFromMolFile(fName)
     self.failIf(ChemicalForceFields.MMFFOptimizeMolecule(m))
     # make sure that keyword arguments work:
-    m = Chem.MolFromMolFile(fName, False)
+    m = Chem.MolFromMolFile(fName)
     self.failUnless(ChemicalForceFields.MMFFOptimizeMolecule(m, maxIters = 1))
 
-    m = Chem.MolFromMolFile(fName, False)
+    m = Chem.MolFromMolFile(fName)
     self.failIf(ChemicalForceFields.MMFFOptimizeMolecule(m, nonBondedThresh = 2.0))
 
-    m = Chem.MolFromMolFile(fName, False)
+    m = Chem.MolFromMolFile(fName)
     self.failIf(ChemicalForceFields.MMFFOptimizeMolecule(m, confId = -1))
 
-    m = Chem.MolFromMolFile(fName, False)
+    m = Chem.MolFromMolFile(fName)
     self.failUnlessRaises(ValueError, lambda :ChemicalForceFields.MMFFOptimizeMolecule(m, confId = 1))
 
 
   def test6(self) :
     fName = os.path.join(self.dirName, 'benzene.mol')
-    m = Chem.MolFromMolFile(fName, False)
+    m = Chem.MolFromMolFile(fName)
     mp = ChemicalForceFields.MMFFGetMoleculeProperties(m)
     ff = ChemicalForceFields.MMFFGetMoleculeForceField(m, mp)
     self.failUnless(ff)

--- a/Docs/Book/GettingStartedInPython.rst
+++ b/Docs/Book/GettingStartedInPython.rst
@@ -511,15 +511,14 @@ The full process of embedding and optimizing a molecule is easier than all the a
 0
 
 The RDKit also has an implementation of the MMFF94 force field available. [#mmff1]_, [#mmff2]_, [#mmff3]_, [#mmff4]_, [#mmffs]_
-There is an extra step required to use this because the MMFF atom typing 
-code needs to use its own aromaticity model, so the molecule should be 
-kekulized before minimization:
+Please note that the MMFF atom typing code uses its own aromaticity model,
+so the aromaticity flags of the molecule will be modified after calling
+MMFF-related methods.
 
 >>> m = Chem.MolFromSmiles('C1CCC1OC')
 >>> m2=Chem.AddHs(m)
 >>> AllChem.EmbedMolecule(m2)
 0
->>> Chem.Kekulize(m2,clearAromaticFlags=True)
 >>> AllChem.MMFFOptimizeMolecule(m2)
 0
 


### PR DESCRIPTION
- replaced  the call to sanitizeMMFFMol() in the MMFFMolProperties
  constructor (which is overkill, if the molecule had already been
  sanitized) with a call to MolOps::Kekulize(). Thus it is not
  necessary to call Kekulize() either from Python or from C++,
  and no changes are required to the scripts/source codes
  previously used for UFF
- removed the code which throws an exception asking to reload the
  molecule with sanitize=false since it is not necessary:
  only one test in the MMFF validation suite fails if the
  molecule is aromatized and then re-kekulized (CIKSEU10), and
  it represents a case where the position of double bonds in
  a conjugated, non-aromatic system makes a difference for atom
  type assignments, which in general is a nonsense. This is not
  due to a bug in the code, but rather depends on MMFF atom
  typing rules. Hence, I kept the sanitize=false and the call to
  sanitizeMMFFMol() in testMMFFForceField.cpp, but I would not
  generalize this requirement to "normal" molecules, because it
  is really not necessary, since you do not have a reference
  kekulization to refer to in the real world.
- updated Docs/Book/GettingStartedInPython.rst accordingly
- updated tests accordingly
