### PR TITLE
Critical bug fix in the MMFF stretch-bend gradient calculation

### DIFF
--- a/Code/ForceField/MMFF/AngleBend.cpp
+++ b/Code/ForceField/MMFF/AngleBend.cpp
@@ -126,7 +126,8 @@ namespace ForceFields {
       RDGeom::Point3D p12 = (p1 - p2) / dist1;
       RDGeom::Point3D p32 = (p3 - p2) / dist2;
       double cosTheta = p12.dotProduct(p32);
-      double sinTheta = std::max(sqrt(1.0 - cosTheta * cosTheta), 1.0e-8);
+      double sinThetaSq = 1.0 - cosTheta * cosTheta;
+      double sinTheta = std::max(((sinThetaSq > 0.0) ? sqrt(sinThetaSq) : 0.0), 1.0e-8);
 
       // use the chain rule:
       // dE/dx = dE/dTheta * dTheta/dx

--- a/Code/ForceField/MMFF/StretchBend.cpp
+++ b/Code/ForceField/MMFF/StretchBend.cpp
@@ -116,11 +116,8 @@ namespace ForceFields {
       double sinThetaSq = 1.0 - cosTheta * cosTheta;
       double sinTheta = std::max(((sinThetaSq > 0.0) ? sqrt(sinThetaSq) : 0.0), 1.0e-8);
       double angleTerm = RAD2DEG * acos(cosTheta) - this->d_theta0;
-      double distTerm = RAD2DEG * d_forceConstants.first * (dist1 - this->d_restLen1)
-        + d_forceConstants.second * (dist2 - this->d_restLen2);
-      if (isDoubleZero(sinTheta) || isDoubleZero(dist1) || isDoubleZero(dist2)) {
-        return;
-      }
+      double distTerm = RAD2DEG * (d_forceConstants.first * (dist1 - this->d_restLen1)
+        + d_forceConstants.second * (dist2 - this->d_restLen2));
       double dCos_dS1 = 1.0 / dist1 * (p32.x - cosTheta * p12.x);
       double dCos_dS2 = 1.0 / dist1 * (p32.y - cosTheta * p12.y);
       double dCos_dS3 = 1.0 / dist1 * (p32.z - cosTheta * p12.z);

--- a/Code/ForceField/UFF/AngleBend.cpp
+++ b/Code/ForceField/UFF/AngleBend.cpp
@@ -75,6 +75,7 @@ namespace ForceFields {
         }
         order = 0;
       }
+      // end of the hack
       dp_forceField = owner;
       d_at1Idx = idx1;
       d_at2Idx = idx2;

--- a/Code/GraphMol/ForceFieldHelpers/UFF/Builder.cpp
+++ b/Code/GraphMol/ForceFieldHelpers/UFF/Builder.cpp
@@ -181,10 +181,10 @@ namespace RDKit {
                 case Atom::SP:
                   order=1;
                   break;
-                // the following is a hack to get decent geometries
-                // with 3- and 4-membered rings incorporating sp2 atoms
                 case Atom::SP2:
                   order=3;
+                  // the following is a hack to get decent geometries
+                  // with 3- and 4-membered rings incorporating sp2 atoms
                   // if the central atom is in a ring of size 3
                   if (rings->isAtomInRingOfSize(j, 3)) {
                     // if the central atom and one of the bonded atoms, but not the
@@ -213,6 +213,7 @@ namespace RDKit {
                       order = 45;
                     }
                   }
+                  // end of the hack
                   break;
                 case Atom::SP3D2:
                   order=4;


### PR DESCRIPTION
- fixed a bug in the MMFF stretch-bend gradient calculation
  (when I converted the rad2deg() function into a simple RAD2DEG
  coefficient I removed all parentheses, but in this case it was still
  necessary!)
- put in better evidence the extents of the UFF hack so that it can be
  easily commented out if required
