### PR TITLE
PandasTools: Improved exception handling during initialization

### DIFF
--- a/rdkit/Chem/PandasTools.py
+++ b/rdkit/Chem/PandasTools.py
@@ -85,16 +85,23 @@ from StringIO import StringIO
 import types
 try:
   import pandas as pd
-  if 'display.width' in  pd.core.config._registered_options:
-    pd.set_option('display.width',100000000000)
-  if 'display.height' in  pd.core.config._registered_options:
-    pd.set_option('display.height',100000000000)
-  if 'display.max_colwidth' in  pd.core.config._registered_options:
-    pd.set_option('display.max_colwidth',100000000000)
-  #saves the default pandas rendering to allow restauration
-  defPandasRendering = pd.core.frame.DataFrame.to_html
-except ImportError:
+  v = pd.version.version.split('.')
+  if v[0]=='0' and int(v[1])<10:
+    pd = None
+  else:
+    if 'display.width' in  pd.core.config._registered_options:
+      pd.set_option('display.width',1000000000)
+    if 'display.height' in  pd.core.config._registered_options:
+      pd.set_option('display.height',1000000000)
+    if 'display.max_colwidth' in  pd.core.config._registered_options:
+      pd.set_option('display.max_colwidth',1000000000)
+    #saves the default pandas rendering to allow restauration
+    defPandasRendering = pd.core.frame.DataFrame.to_html
+except Exception as e:
   pd = None
+
+  
+  
 
 
 


### PR DESCRIPTION
Fixes #123: Pandas version is checked during initialization 
Fixes #128: Reduced integer size to 32bit range

General exception handling: any possible exception that might occur during initialization would lead to skipping the PandasTools test

All above problems where reproduced and solved by the fix.
