### PR TITLE
O3A::align() and O3A::trans() now return "true" RMSD value

### DIFF
--- a/Code/GraphMol/MolAlign/O3AAlignMolecules.cpp
+++ b/Code/GraphMol/MolAlign/O3AAlignMolecules.cpp
@@ -799,6 +799,46 @@ namespace RDKit {
     }
 
 
+    double _rmsdMatchVect(const RDGeom::POINT3D_VECT &prbPos,
+      const RDGeom::POINT3D_VECT &refPos,
+      const RDKit::MatchVectType *matchVect)
+    {
+      double rmsd = 0.0;
+      for (unsigned int i = 0; i < (*matchVect).size(); ++i) {
+        //first pair element is prb, second is ref
+        rmsd += (prbPos[(*matchVect)[i].first]
+          - refPos[(*matchVect)[i].second]).lengthSq();
+      }
+      rmsd /= (*matchVect).size();
+
+      return sqrt(rmsd);
+    };
+
+
+    double O3A::align() {
+      alignMol(*d_prbMol, *d_refMol, d_prbCid, d_refCid,
+        d_o3aMatchVect, d_o3aWeights, d_reflect, d_maxIters);
+      
+      return _rmsdMatchVect
+        (d_prbMol->getConformer(d_prbCid).getPositions(),
+        d_refMol->getConformer(d_refCid).getPositions(),
+        d_o3aMatchVect);
+    }
+
+
+    std::pair<double, RDGeom::Transform3D *> O3A::trans() {
+      RDGeom::Transform3D *trans = new RDGeom::Transform3D();
+      getAlignmentTransform(*d_prbMol, *d_refMol,
+        *trans, d_prbCid, d_refCid, d_o3aMatchVect, d_o3aWeights,
+        d_reflect, d_maxIters);
+      
+      return std::make_pair(_rmsdMatchVect
+        (d_prbMol->getConformer(d_prbCid).getPositions(),
+        d_refMol->getConformer(d_refCid).getPositions(),
+        d_o3aMatchVect), trans);
+    };
+
+
     void randomTransform(ROMol &mol, const int cid, const int seed)
     {
       if (seed > 0) {

--- a/Code/GraphMol/MolAlign/O3AAlignMolecules.h
+++ b/Code/GraphMol/MolAlign/O3AAlignMolecules.h
@@ -197,18 +197,8 @@ namespace RDKit {
           delete d_o3aWeights;
         }
       };
-      double align() {
-        return alignMol(*d_prbMol, *d_refMol, d_prbCid, d_refCid,
-          d_o3aMatchVect, d_o3aWeights, d_reflect, d_maxIters);
-      };
-      std::pair<double, RDGeom::Transform3D *> trans() {
-        RDGeom::Transform3D *trans = new RDGeom::Transform3D();
-        double rmsd = getAlignmentTransform(*d_prbMol, *d_refMol,
-          *trans, d_prbCid, d_refCid, d_o3aMatchVect, d_o3aWeights,
-          d_reflect, d_maxIters);
-        
-        return std::make_pair(rmsd, trans);
-      };
+      double align();
+      std::pair<double, RDGeom::Transform3D *> trans();
       double score() {
         return d_o3aScore;
       };

--- a/Code/GraphMol/MolAlign/Wrap/testMolAlign.py
+++ b/Code/GraphMol/MolAlign/Wrap/testMolAlign.py
@@ -127,7 +127,7 @@ class TestCase(unittest.TestCase):
         # molW.write(prbMol)
       cumMsd /= len(molS)
       self.failUnlessAlmostEqual(cumScore,6942,0)
-      self.failUnlessAlmostEqual(math.sqrt(cumMsd),.546,3)
+      self.failUnlessAlmostEqual(math.sqrt(cumMsd),.345,3)
 
     def test6O3A(self):
       " now test where the mmff parameters are generated on call "
@@ -145,7 +145,7 @@ class TestCase(unittest.TestCase):
         cumMsd += rmsd * rmsd
       cumMsd /= len(molS)
       self.failUnlessAlmostEqual(cumScore,6942,0)
-      self.failUnlessAlmostEqual(math.sqrt(cumMsd),.546,3)
+      self.failUnlessAlmostEqual(math.sqrt(cumMsd),.345,3)
 
     def test7O3A(self):
       " make sure we generate an error if parameters are missing (github issue 158) "

--- a/Code/GraphMol/MolAlign/testMolAlign.cpp
+++ b/Code/GraphMol/MolAlign/testMolAlign.cpp
@@ -142,7 +142,7 @@ void testO3A() {
   double cumScore = 0.0;
   double cumMsd = 0.0;
   for (int prbNum = 0; prbNum < nMol; ++prbNum) {
-    std::cerr<<"doing: "<<prbNum<<std::endl;
+    //std::cerr<<"doing: "<<prbNum<<std::endl;
     ROMol *prbMol = supplier[prbNum];
     MMFF::MMFFMolProperties prbMP(*prbMol);
     MolAlign::O3A o3a(*prbMol, *refMol, &prbMP, &refMP);
@@ -157,7 +157,7 @@ void testO3A() {
   //newMol->close();
   //std::cerr<<cumScore<<","<<sqrt(cumMsd)<<std::endl;
   TEST_ASSERT(RDKit::feq(cumScore, 6941.8,1));
-  TEST_ASSERT(RDKit::feq(sqrt(cumMsd),.546,.001));
+  TEST_ASSERT(RDKit::feq(sqrt(cumMsd),.345,.001));
 }
 
 


### PR DESCRIPTION
- the RMSD value returned by O3A::align() and O3A::trans() is now
  computed in the usual way, while previously the value computed
  by MolAlign::AlignMol(), which incorporates weights, was returned
- the C++ and Python test results were updated accordingly
