### PR TITLE
Two bugfixes in MMFF code

### DIFF
--- a/Code/ForceField/MMFF/testMMFFForceField.cpp
+++ b/Code/ForceField/MMFF/testMMFFForceField.cpp
@@ -2,8 +2,6 @@
 //
 // Copyright (C)  2013 Paolo Tosco
 //
-// Copyright (C)  2004-2008 Greg Landrum and Rational Discovery LLC
-//
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
 //  The contents are covered by the terms of the BSD license
@@ -73,7 +71,7 @@ bool fgrep(std::fstream &rdkFStream, std::string key)
 }
 
 
-bool getLineByNum(std::istream& stream,
+bool getLineByNum(std::fstream &stream,
   std::streampos startPos, unsigned int n, std::string& line)
 {
   std::streampos current = stream.tellg();
@@ -413,7 +411,8 @@ void mmffValidationSuite(int argc, char *argv[])
         std::vector<std::string> nameArray;
 
         rdkFStream.open(rdk.c_str(), (firstTest
-          ? std::fstream::out : (std::fstream::out | std::fstream::app)));
+          ? std::fstream::out | std::fstream::binary
+          : (std::fstream::out | std::fstream::binary | std::fstream::app)));
         std::string computingKey = (*ffIt) + " energies for " + (*molFileIt);
         std::cerr << std::endl << "Computing " << computingKey << "..." << std::endl;
         for (i = 0; i < computingKey.length(); ++i) {
@@ -458,8 +457,8 @@ void mmffValidationSuite(int argc, char *argv[])
         sdfWriter->close();
         rdkFStream.close();
         std::cerr << "Checking against " << ref << "..." << std::endl;
-        rdkFStream.open(rdk.c_str(), std::fstream::in);
-        refFStream.open(ref.c_str(), std::fstream::in);
+        rdkFStream.open(rdk.c_str(), std::fstream::in | std::fstream::binary);
+        refFStream.open(ref.c_str(), std::fstream::in | std::fstream::binary);
         
         bool found = false;
         std::string skip;

--- a/Code/ForceField/MMFF/testMMFFForceField.h
+++ b/Code/ForceField/MMFF/testMMFFForceField.h
@@ -1,3 +1,15 @@
+// $Id$
+//
+// Copyright (C)  2013 Paolo Tosco
+//
+//   @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
+//
+
+
 class BondStretchInstance {
   public:
     unsigned int idx;

--- a/Code/GraphMol/ForceFieldHelpers/MMFF/AtomTyper.cpp
+++ b/Code/GraphMol/ForceFieldHelpers/MMFF/AtomTyper.cpp
@@ -1975,8 +1975,7 @@ namespace RDKit {
     void MMFFMolProperties::setMMFFHydrogenType(const Atom *atom)
     {
       unsigned int atomType;
-      bool isHOCC = false;
-      bool isHOCN = false;
+      bool isHOCCorHOCN = false;
       bool isHOCO = false;
       bool isHOP = false;
       bool isHOS = false;
@@ -2122,18 +2121,13 @@ namespace RDKit {
                       if (nbr3Atom->getIdx() == nbrAtom->getIdx()) {
                         continue;
                       }
-                      // if the carbon neighbor is another carbon bonded
-                      // via a double or aromatic bond, ipso is HOCC
-                      if ((nbr3Atom->getAtomicNum() == 6)
+                      // if the carbon neighbor is another carbon or nitrogen
+                      // bonded via a double or aromatic bond, ipso is HOCC/HOCN
+                      if (((nbr3Atom->getAtomicNum() == 6)
+                        || (nbr3Atom->getAtomicNum() == 7))
                         && ((bond->getBondType() == Bond::DOUBLE)
                         || (bond->getBondType() == Bond::AROMATIC))) {
-                        isHOCC = true;
-                      }
-                      // if the carbon neighbor is a nitrogen bonded
-                      // via a double bond, ipso is HOCN
-                      if ((nbr3Atom->getAtomicNum() == 7)
-                        && (bond->getBondType() == Bond::DOUBLE)) {
-                        isHOCN = true;
+                        isHOCCorHOCN = true;
                       }
                       // if the carbon neighbor is an oxygen bonded
                       // via a double bond, ipso is HOCO
@@ -2158,7 +2152,7 @@ namespace RDKit {
                   atomType = 24;
                   break;
                 }
-                if (isHOCC || isHOCN) {
+                if (isHOCCorHOCN) {
                   // HOCC
                   // Enolic or phenolic hydroxyl hydrogen
                   // HOCN


### PR DESCRIPTION
- Added the std::fstream::binary flag in testMMFFForceField.cpp
  whose absence might cause intermittent problem in parsing the
  logs on Windows due to tellg/seekg not correctly handling CR/LF
- Fixed the code for assigning the HOCN MMFF94 atom type
  (thanks to Toby Wright for reporting this)
- Added a missing copyright notice in testMMFFForceField.h
- Removed a misplaced copyright notice in testMMFFForceField.cpp
  originated from copy-pasting from other MMFF files
