### PR TITLE
O3A refactoring and new features

### DIFF
--- a/Code/ForceField/MMFF/Params.h
+++ b/Code/ForceField/MMFF/Params.h
@@ -37,7 +37,7 @@ namespace ForceFields {
 
     const double DEG2RAD = M_PI / 180.0;
     const double RAD2DEG = 180.0 / M_PI;
-    inline const bool isDoubleZero(const double x) {
+    inline bool isDoubleZero(const double x) {
       return ((x < 1.0e-10) && (x > -1.0e-10));
     }
 
@@ -152,7 +152,7 @@ namespace ForceFields {
       /*!
 	\return a pointer to the MMFFArom object, NULL on failure.
       */
-      const bool isMMFFAromatic(const unsigned int atomType) const {
+      bool isMMFFAromatic(const unsigned int atomType) const {
         return ((std::find(d_params.begin(), d_params.end(),
           atomType) != d_params.end()) ? true : false);
       }

--- a/Code/ForceField/UFF/Params.h
+++ b/Code/ForceField/UFF/Params.h
@@ -23,7 +23,7 @@ namespace ForceFields {
 
     const double DEG2RAD = M_PI / 180.0;
     const double RAD2DEG = 180.0 / M_PI;
-    inline const bool isDoubleZero(const double x) {
+    inline bool isDoubleZero(const double x) {
       return ((x < 1.0e-10) && (x > -1.0e-10));
     }
     //! class to store atomic parameters for the Universal Force Field

--- a/Code/GraphMol/ForceFieldHelpers/MMFF/AtomTyper.cpp
+++ b/Code/GraphMol/ForceFieldHelpers/MMFF/AtomTyper.cpp
@@ -28,7 +28,7 @@ namespace RDKit {
 
     // given the atomic num, this function returns the periodic
     // table row number, starting from 0 for hydrogen
-    const unsigned int getPeriodicTableRow(const int atomicNum)
+    unsigned int getPeriodicTableRow(const int atomicNum)
     {
       unsigned int periodicTableRow = 0;
       
@@ -2308,7 +2308,7 @@ namespace RDKit {
 
     // returns the MMFF angle type of the angle formed
     // by atoms with indexes idx1, idx2, idx3
-    const unsigned int MMFFMolProperties::getMMFFAngleType
+    unsigned int MMFFMolProperties::getMMFFAngleType
       (const ROMol &mol, const unsigned int idx1,
       const unsigned int idx2, const unsigned int idx3)
     {
@@ -2346,7 +2346,7 @@ namespace RDKit {
     
 
     // returns the MMFF bond type of the bond
-    const unsigned int MMFFMolProperties::getMMFFBondType(const Bond *bond)
+    unsigned int MMFFMolProperties::getMMFFBondType(const Bond *bond)
     {
       PRECONDITION(this->isValid(), "missing atom types - invalid force-field");
 
@@ -2368,7 +2368,7 @@ namespace RDKit {
     // given the angle type and the two bond types of the bond
     // which compose the angle, it returns the MMFF stretch-bend
     // type of the angle
-    const unsigned int getMMFFStretchBendType(const unsigned int angleType,
+    unsigned int getMMFFStretchBendType(const unsigned int angleType,
       const unsigned int bondType1, const unsigned int bondType2)
     {
       unsigned int stretchBendType = 0;

--- a/Code/GraphMol/ForceFieldHelpers/MMFF/AtomTyper.h
+++ b/Code/GraphMol/ForceFieldHelpers/MMFF/AtomTyper.h
@@ -54,8 +54,8 @@ namespace RDKit {
         boost::uint8_t verbosity = MMFF_VERBOSITY_NONE,
         std::ostream &oStream = std::cout);
       ~MMFFMolProperties() {};
-      const unsigned int getMMFFBondType(const Bond *bond);
-      const unsigned int getMMFFAngleType(const ROMol &mol,
+      unsigned int getMMFFBondType(const Bond *bond);
+      unsigned int getMMFFAngleType(const ROMol &mol,
         const unsigned int idx1, const unsigned int idx2,
         const unsigned int idx3);
       const std::pair<unsigned int, unsigned int> getMMFFTorsionType
@@ -66,19 +66,19 @@ namespace RDKit {
         (const ROMol &mol, unsigned int idx2, unsigned int idx3);
       const ForceFields::MMFF::MMFFBond *getMMFFBondStretchEmpiricalRuleParams
         (const ROMol &mol, const Bond *bond);
-      const boost::uint8_t getMMFFAtomType(const unsigned int idx)
+      boost::uint8_t getMMFFAtomType(const unsigned int idx)
       {
         RANGE_CHECK(0, idx, this->d_MMFFAtomPropertiesPtrVect.size() - 1);
         
         return this->d_MMFFAtomPropertiesPtrVect[idx]->mmffAtomType;
       };
-      const double getMMFFFormalCharge(const unsigned int idx)
+      double getMMFFFormalCharge(const unsigned int idx)
       {
         RANGE_CHECK(0, idx, this->d_MMFFAtomPropertiesPtrVect.size() - 1);
         
         return this->d_MMFFAtomPropertiesPtrVect[idx]->mmffFormalCharge;
       };
-      const double getMMFFPartialCharge(const unsigned int idx)
+      double getMMFFPartialCharge(const unsigned int idx)
       {
         RANGE_CHECK(0, idx, this->d_MMFFAtomPropertiesPtrVect.size() - 1);
         
@@ -88,7 +88,7 @@ namespace RDKit {
       {
         this->d_bondTerm = state;
       };
-      const bool getMMFFBondTerm()
+      bool getMMFFBondTerm()
       {
         return this->d_bondTerm;
       };
@@ -96,7 +96,7 @@ namespace RDKit {
       {
         this->d_angleTerm = state;
       };
-      const bool getMMFFAngleTerm()
+      bool getMMFFAngleTerm()
       {
         return this->d_angleTerm;
       };
@@ -104,7 +104,7 @@ namespace RDKit {
       {
         this->d_stretchBendTerm = state;
       };
-      const bool getMMFFStretchBendTerm()
+      bool getMMFFStretchBendTerm()
       {
         return this->d_stretchBendTerm;
       };
@@ -112,7 +112,7 @@ namespace RDKit {
       {
         this->d_oopTerm = state;
       };
-      const bool getMMFFOopTerm()
+      bool getMMFFOopTerm()
       {
         return this->d_oopTerm;
       };
@@ -120,7 +120,7 @@ namespace RDKit {
       {
         this->d_torsionTerm = state;
       };
-      const bool getMMFFTorsionTerm()
+      bool getMMFFTorsionTerm()
       {
         return this->d_torsionTerm;
       };
@@ -128,7 +128,7 @@ namespace RDKit {
       {
         this->d_vdWTerm = state;
       };
-      const bool getMMFFVdWTerm()
+      bool getMMFFVdWTerm()
       {
         return this->d_vdWTerm;
       };
@@ -136,7 +136,7 @@ namespace RDKit {
       {
         this->d_eleTerm = state;
       };
-      const bool getMMFFEleTerm()
+      bool getMMFFEleTerm()
       {
         return this->d_eleTerm;
       };
@@ -231,9 +231,9 @@ namespace RDKit {
       const unsigned int ringSize, const unsigned int numAtoms, ...);
     unsigned int sanitizeMMFFMol(RWMol &mol);
     void setMMFFAromaticity(RWMol &mol);
-    const unsigned int getMMFFStretchBendType(const unsigned int angleType,
+    unsigned int getMMFFStretchBendType(const unsigned int angleType,
       const unsigned int bondType1, const unsigned int bondType2);
-    const unsigned int getPeriodicTableRow(const int atomicNum);
+    unsigned int getPeriodicTableRow(const int atomicNum);
     const ForceFields::MMFF::MMFFAngle *getMMFFAngleBendEmpiricalRuleParams
       (const ROMol &mol, const ForceFields::MMFF::MMFFAngle *oldMMFFAngleParams,
       const ForceFields::MMFF::MMFFProp *mmffPropParamsCentralAtom,


### PR DESCRIPTION
- removed a few spurious, though non harmful,  "const" keywords from
  Code/ForceField/MMFF/Params.h, Code/ForceField/UFF/Params.h,
  Code/GraphMol/ForceFieldHelpers/MMFF/AtomTyper.cpp
  and Code/GraphMol/ForceFieldHelpers/MMFF/AtomTyper.h (I realized
  their uselessness thanks to a warning issued by Intel C++ compiler)
- refactored O3A code; most notably:
  - modified the signature of the "expert" O3A::O3A() constructor
    to reduce calculations (e.g., heavy atom bit arrays can be passed rather
    than being recomputed at each iteration) and to fix an important issue
    which went unnoticed so far: since the "expert" constructor was
    called by the "normal user" constructor iteratively to obtain the
    best alignment, the original prbMol passed to the constructor was
    altered at each iteration, which is not nice, since there is an align()
    method to apply the final best transformation, while the constructor
    is supposed to simply find it leaving the original coordinates unaltered.
    This was especially troublesome using O3A::O3A in multithreaded
    applications, where it was mandatory to make a copy upfront.
    Even worse, the transformation returned by the trans() was basically
    meaningless since it did not refer to the original coordinates but to
    some intermediate coordinates of no relevance to the user.
    Now all this is fixed, since the "normal user" constructor makes a
    copy upfront, while the "expert" constructor allows to pass a pointer to
    a copy of the molecule to save time on making copies at each iteration.
    If the pointer is NULL or not specified, a copy is made on the fly.
    Other minor issues might arise when less than 3 matches were found;
    now the code is much more robust in that respect. If less than 3 matches
    are found, no alignment is performed, score is set to 0.0 and the returned
    is rmsd is the distance between the centroids of the original conformations.
  - added the possibility to set weighted constraints on selected
    atom pairs
  - added an option to carry out local-only optimization
  - removed obsolete and useless #ifdef O3A_CONSTRUCTOR preprocessor
    directives
