### PR TITLE
A few fixes to improve MMFF/UFF robustness

### DIFF
--- a/Code/ForceField/MMFF/AngleBend.cpp
+++ b/Code/ForceField/MMFF/AngleBend.cpp
@@ -35,8 +35,10 @@ namespace ForceFields {
       {
         RDGeom::Point3D p12 = p1 - p2;
         RDGeom::Point3D p32 = p3 - p2;
-        
-        return p12.dotProduct(p32) / (dist1 * dist2);
+        double cosTheta = p12.dotProduct(p32) / (dist1 * dist2);
+        clipToOne(cosTheta);
+
+        return cosTheta;
       }
       
       double calcAngleForceConstant(const MMFFAngle *mmffAngleParams)
@@ -51,13 +53,15 @@ namespace ForceFields {
       {
         double angle = RAD2DEG * acos(cosTheta) - theta0;
         double const cb = -0.006981317;
+        double const c1 = 143.9325;
+        double const c2 = 0.043844;
         double res = 0.0;
         
         if (isLinear) {
-          res = 143.9325 * ka * (1.0 + cosTheta);
+          res = c1 * ka * (1.0 + cosTheta);
         }
         else {
-          res = 0.5 * 0.043844 * ka * angle * angle * (1.0 + cb * angle);
+          res = 0.5 * c2 * ka * angle * angle * (1.0 + cb * angle);
         }
 
         return res;
@@ -158,6 +162,7 @@ namespace ForceFields {
         (p3 - p2) / dist[1]
       };
       double cosTheta = r[0].dotProduct(r[1]);
+      clipToOne(cosTheta);
       double sinThetaSq = 1.0 - cosTheta * cosTheta;
       double sinTheta = std::max(((sinThetaSq > 0.0) ? sqrt(sinThetaSq) : 0.0), 1.0e-8);
 
@@ -167,9 +172,11 @@ namespace ForceFields {
       // dE/dTheta is independent of cartesians:
       double angleTerm = RAD2DEG * acos(cosTheta) - d_theta0;
       double const cb = -0.006981317;
+      double const c1 = 143.9325;
+      double const c2 = 0.043844;
         
-      double dE_dTheta = (d_isLinear ? -143.9325 * d_ka * sinTheta
-        : RAD2DEG * 0.043844 * d_ka * angleTerm * (1.0 + 1.5 * cb * angleTerm));
+      double dE_dTheta = (d_isLinear ? -c1 * d_ka * sinTheta
+        : RAD2DEG * c2 * d_ka * angleTerm * (1.0 + 1.5 * cb * angleTerm));
     
       Utils::calcAngleBendGrad(r, dist, g, dE_dTheta, cosTheta, sinTheta);
     }

--- a/Code/ForceField/MMFF/AngleConstraint.cpp
+++ b/Code/ForceField/MMFF/AngleConstraint.cpp
@@ -59,6 +59,7 @@ namespace ForceFields {
         RDGeom::Point3D p12 = (p1 - p2) / dist1;
         RDGeom::Point3D p32 = (p3 - p2) / dist2;
         double cosTheta = p12.dotProduct(p32);
+        clipToOne(cosTheta);
         angle = RAD2DEG * acos(cosTheta);
       }
       dp_forceField = owner;
@@ -91,6 +92,7 @@ namespace ForceFields {
       RDGeom::Point3D p12 = (p1 - p2) / dist1;
       RDGeom::Point3D p32 = (p3 - p2) / dist2;
       double cosTheta = p12.dotProduct(p32);
+      clipToOne(cosTheta);
       double angle = RAD2DEG * acos(cosTheta);
       double angleTerm = 0.0;
       if (angle < d_minAngleDeg) {
@@ -132,6 +134,7 @@ namespace ForceFields {
         (p3 - p2) / dist[1]
       };
       double cosTheta = r[0].dotProduct(r[1]);
+      clipToOne(cosTheta);
       double sinThetaSq = 1.0 - cosTheta * cosTheta;
       double sinTheta = std::max(((sinThetaSq > 0.0) ? sqrt(sinThetaSq) : 0.0), 1.0e-8);
 

--- a/Code/ForceField/MMFF/BondStretch.cpp
+++ b/Code/ForceField/MMFF/BondStretch.cpp
@@ -40,10 +40,12 @@ namespace ForceFields {
       {
         double distTerm = distance - r0;
         double distTerm2 = distTerm * distTerm;
+        double const c1 = 143.9325;
         double const cs = -2.0;
+        double const c3 = 7.0 / 12.0;
         
-        return (143.9325 * kb / 2.0 * distTerm2
-          * (1.0 + cs * distTerm + 7.0 / 12.0 * cs * cs * distTerm2));
+        return (0.5 * c1 * kb * distTerm2
+          * (1.0 + cs * distTerm + c3 * cs * cs * distTerm2));
       }
     } // end of namespace Utils
   
@@ -85,9 +87,11 @@ namespace ForceFields {
       double *g1 = &(grad[3 * d_at1Idx]);
       double *g2 = &(grad[3 * d_at2Idx]);
       double const cs = -2.0;
+      double const c1 = 143.9325;
+      double const c3 = 7.0 / 12.0;
       double distTerm = dist - d_r0;
-      double dE_dr = 143.9325 * d_kb * distTerm
-        * (1.0 + 1.5 * cs * distTerm + 7.0 / 6.0 * cs * cs * distTerm * distTerm);
+      double dE_dr = c1 * d_kb * distTerm
+        * (1.0 + 1.5 * cs * distTerm + 2.0 * c3 * cs * cs * distTerm * distTerm);
       double dGrad;
       for (unsigned int i = 0; i < 3; ++i) {
         dGrad = ((dist > 0.0)

--- a/Code/ForceField/MMFF/Nonbonded.cpp
+++ b/Code/ForceField/MMFF/Nonbonded.cpp
@@ -36,8 +36,9 @@ namespace ForceFields {
         const MMFFVdW *mmffVdWParamsIAtom, const MMFFVdW *mmffVdWParamsJAtom)
       {
         double R_star_ij2 = R_star_ij * R_star_ij;
+        double const c4 = 181.16;
         
-        return (181.16 * mmffVdWParamsIAtom->G_i * mmffVdWParamsJAtom->G_i
+        return (c4 * mmffVdWParamsIAtom->G_i * mmffVdWParamsJAtom->G_i
           * mmffVdWParamsIAtom->alpha_i * mmffVdWParamsJAtom->alpha_i
           / ((sqrt(mmffVdWParamsIAtom->alpha_i / mmffVdWParamsIAtom->N_i)
           + sqrt(mmffVdWParamsJAtom->alpha_i / mmffVdWParamsJAtom->N_i))
@@ -47,14 +48,18 @@ namespace ForceFields {
       double calcVdWEnergy(const double dist,
         const double R_star_ij, const double wellDepth)
       {
+        double const vdw1 = 1.07;
+        double const vdw1m1 = vdw1 - 1.0;
+        double const vdw2 = 1.12;
+        double const vdw2m1 = vdw2 - 1.0;
         double dist2 = dist * dist;
         double dist7 = dist2 * dist2 * dist2 * dist;
-        double aTerm = 1.07 * R_star_ij / (dist + 0.07 * R_star_ij);
+        double aTerm = vdw1 * R_star_ij / (dist + vdw1m1 * R_star_ij);
         double aTerm2 = aTerm * aTerm;
         double aTerm7 = aTerm2 * aTerm2 * aTerm2 * aTerm;
         double R_star_ij2 = R_star_ij * R_star_ij;
         double R_star_ij7 = R_star_ij2 * R_star_ij2 * R_star_ij2 * R_star_ij;
-        double bTerm = 1.12 * R_star_ij7 / (dist7 + 0.12 * R_star_ij7) - 2.0;
+        double bTerm = vdw2 * R_star_ij7 / (dist7 + vdw2m1 * R_star_ij7) - 2.0;
         double res = wellDepth * aTerm7 * bTerm;
         
         return res;
@@ -75,10 +80,12 @@ namespace ForceFields {
         double chargeTerm, boost::uint8_t dielModel, bool is1_4)
       {
         double corr_dist = dist + 0.05;
+        double const diel = 332.0716;
+        double const sc1_4 = 0.75;
         if (dielModel == RDKit::MMFF::DISTANCE) {
           corr_dist *= corr_dist;
         }
-        return (332.0716 * chargeTerm / corr_dist * (is1_4 ? 0.75 : 1.0));
+        return (diel * chargeTerm / corr_dist * (is1_4 ? sc1_4 : 1.0));
       }
     } // end of namespace utils
     
@@ -123,6 +130,11 @@ namespace ForceFields {
       PRECONDITION(pos, "bad vector");
       PRECONDITION(grad, "bad vector");
 
+      double const vdw1 = 1.07;
+      double const vdw1m1 = vdw1 - 1.0;
+      double const vdw2 = 1.12;
+      double const vdw2m1 = vdw2 - 1.0;
+      double const vdw2t7 = vdw2 * 7.0;
       double dist = dp_forceField->distance
         (d_at1Idx, d_at2Idx, pos);
       double *at1Coords = &(pos[3 * d_at1Idx]);
@@ -133,12 +145,13 @@ namespace ForceFields {
       double q2 = q * q;
       double q6 = q2 * q2 * q2;
       double q7 = q6 * q;
-      double t = 1.07 / (q + 0.07);
+      double q7pvdw2m1 = q7 + vdw2m1;
+      double t = vdw1 / (q + vdw1 - 1.0);
       double t2 = t * t;
       double t7 = t2 * t2 * t2 * t;
       double dE_dr = d_wellDepth / d_R_star_ij
-        * t7 * (-7.84 * q6 / ((q7 + 0.12) * (q7 + 0.12))
-        + ((-7.84 / (q7 + 0.12) + 14.0) / (q + 0.07)));
+        * t7 * (-vdw2t7 * q6 / (q7pvdw2m1 * q7pvdw2m1)
+        + ((-vdw2t7 / q7pvdw2m1 + 14.0) / (q + vdw1m1)));
       for (unsigned int i = 0; i < 3; ++i) {
         double dGrad;
         dGrad = ((dist > 0.0)

--- a/Code/ForceField/MMFF/OopBend.cpp
+++ b/Code/ForceField/MMFF/OopBend.cpp
@@ -32,6 +32,7 @@ namespace ForceFields {
         RDGeom::Point3D n = rJI.crossProduct(rJK);
         n /= n.length();
         double sinChi = n.dotProduct(rJL);
+        clipToOne(sinChi);
 
         return RAD2DEG * asin(sinChi);
       }
@@ -45,7 +46,8 @@ namespace ForceFields {
 
       double calcOopBendEnergy(const double chi, const double koop)
       {
-        return (0.043844 * 0.5 * koop * chi * chi);
+        double const c2 = 0.043844;
+        return (0.5 * c2 * koop * chi * chi);
       }
     } // end of namespace Utils
 
@@ -123,15 +125,18 @@ namespace ForceFields {
       
       RDGeom::Point3D n = (-rJI).crossProduct(rJK);
       n /= n.length();
+      double const c2 = 0.043844;
       double sinChi = rJL.dotProduct(n);
+      clipToOne(sinChi);
       double cosChiSq = 1.0 - sinChi * sinChi;
       double cosChi = std::max(((cosChiSq > 0.0) ? sqrt(cosChiSq) : 0.0), 1.0e-8);
       double chi = RAD2DEG * asin(sinChi);
       double cosTheta = rJI.dotProduct(rJK);
+      clipToOne(cosTheta);
       double sinThetaSq = std::max(1.0 - cosTheta * cosTheta, 1.0e-8);
       double sinTheta = std::max(((sinThetaSq > 0.0) ? sqrt(sinThetaSq) : 0.0), 1.0e-8);
       
-      double dE_dChi = RAD2DEG * 0.043844 * d_koop * chi;
+      double dE_dChi = RAD2DEG * c2 * d_koop * chi;
       RDGeom::Point3D t1 = rJL.crossProduct(rJK);
       RDGeom::Point3D t2 = rJI.crossProduct(rJL);
       RDGeom::Point3D t3 = rJK.crossProduct(rJI);

--- a/Code/ForceField/MMFF/Params.h
+++ b/Code/ForceField/MMFF/Params.h
@@ -40,6 +40,14 @@ namespace ForceFields {
     inline bool isDoubleZero(const double x) {
       return ((x < 1.0e-10) && (x > -1.0e-10));
     }
+    inline void clipToOne(double &x) {
+      if (x > 1.0) {
+        x = 1.0;
+      }
+      else if (x < -1.0) {
+        x = -1.0;
+      }
+    }
 
     void _pretreatAngles(double &minDihedralDeg, double &maxDihedralDeg);
     

--- a/Code/ForceField/MMFF/StretchBend.cpp
+++ b/Code/ForceField/MMFF/StretchBend.cpp
@@ -38,7 +38,8 @@ namespace ForceFields {
         (const double deltaDist1, const double deltaDist2,
         const double deltaTheta, const std::pair<double, double> forceConstants)
       {
-        double factor = 2.51210 * deltaTheta;
+        double const c5 = 2.51210;
+        double factor = c5 * deltaTheta;
         
         return std::make_pair(factor * forceConstants.first * deltaDist1,
           factor * forceConstants.second * deltaDist2);
@@ -112,7 +113,9 @@ namespace ForceFields {
 
       RDGeom::Point3D p12 = (p1 - p2) / dist1;
       RDGeom::Point3D p32 = (p3 - p2) / dist2;
+      double const c5 = 2.51210;
       double cosTheta = p12.dotProduct(p32);
+      clipToOne(cosTheta);
       double sinThetaSq = 1.0 - cosTheta * cosTheta;
       double sinTheta = std::max(((sinThetaSq > 0.0) ? sqrt(sinThetaSq) : 0.0), 1.0e-8);
       double angleTerm = RAD2DEG * acos(cosTheta) - d_theta0;
@@ -126,28 +129,28 @@ namespace ForceFields {
       double dCos_dS5 = 1.0 / dist2 * (p12.y - cosTheta * p32.y);
       double dCos_dS6 = 1.0 / dist2 * (p12.z - cosTheta * p32.z);
 
-      g1[0] += 2.51210 * (p12.x * d_forceConstants.first
+      g1[0] += c5 * (p12.x * d_forceConstants.first
         * angleTerm + dCos_dS1 / (-sinTheta) * distTerm);
-      g1[1] += 2.51210 * (p12.y * d_forceConstants.first
+      g1[1] += c5 * (p12.y * d_forceConstants.first
         * angleTerm + dCos_dS2 / (-sinTheta) * distTerm);
-      g1[2] += 2.51210 * (p12.z * d_forceConstants.first
+      g1[2] += c5 * (p12.z * d_forceConstants.first
         * angleTerm + dCos_dS3 / (-sinTheta) * distTerm);
 
-      g2[0] += 2.51210 * ((-p12.x * d_forceConstants.first
+      g2[0] += c5 * ((-p12.x * d_forceConstants.first
         - p32.x * d_forceConstants.second) * angleTerm
         + (-dCos_dS1 - dCos_dS4) / (-sinTheta) * distTerm);
-      g2[1] += 2.51210 * ((-p12.y * d_forceConstants.first
+      g2[1] += c5 * ((-p12.y * d_forceConstants.first
         - p32.y * d_forceConstants.second) * angleTerm
         + (-dCos_dS2 - dCos_dS5) / (-sinTheta) * distTerm);
-      g2[2] += 2.51210 * ((-p12.z * d_forceConstants.first
+      g2[2] += c5 * ((-p12.z * d_forceConstants.first
         - p32.z * d_forceConstants.second) * angleTerm
         + (-dCos_dS3 - dCos_dS6) / (-sinTheta) * distTerm);
     
-      g3[0] += 2.51210 * (p32.x * d_forceConstants.second
+      g3[0] += c5 * (p32.x * d_forceConstants.second
         * angleTerm + dCos_dS4 / (-sinTheta) * distTerm);
-      g3[1] += 2.51210 * (p32.y * d_forceConstants.second
+      g3[1] += c5 * (p32.y * d_forceConstants.second
         * angleTerm + dCos_dS5 / (-sinTheta) * distTerm);
-      g3[2] += 2.51210 * (p32.z * d_forceConstants.second
+      g3[2] += c5 * (p32.z * d_forceConstants.second
         * angleTerm + dCos_dS6 / (-sinTheta) * distTerm);
     }
   }

--- a/Code/ForceField/MMFF/TorsionAngle.cpp
+++ b/Code/ForceField/MMFF/TorsionAngle.cpp
@@ -29,8 +29,10 @@ namespace ForceFields {
         RDGeom::Point3D r4 = lPoint - kPoint;
         RDGeom::Point3D t1 = r1.crossProduct(r2);
         RDGeom::Point3D t2 = r3.crossProduct(r4);
+        double cosPhi = t1.dotProduct(t2) / (t1.length() * t2.length());
+        clipToOne(cosPhi);
 
-        return (t1.dotProduct(t2) / (t1.length() * t2.length()));
+        return cosPhi;
       }
       
       boost::tuple<double, double, double>
@@ -171,6 +173,7 @@ namespace ForceFields {
       t[0] /= d[0];
       t[1] /= d[1];
       double cosPhi = t[0].dotProduct(t[1]);
+      clipToOne(cosPhi);
       double sinPhiSq = 1.0 - cosPhi * cosPhi;
       double sinPhi = ((sinPhiSq > 0.0) ? sqrt(sinPhiSq) : 0.0);
       double sin2Phi = 2.0 * sinPhi * cosPhi;

--- a/Code/ForceField/MMFF/TorsionConstraint.cpp
+++ b/Code/ForceField/MMFF/TorsionConstraint.cpp
@@ -176,6 +176,7 @@ namespace ForceFields {
       t[0] /= d[0];
       t[1] /= d[1];
       double cosPhi = t[0].dotProduct(t[1]);
+      clipToOne(cosPhi);
       double sinPhiSq = 1.0 - cosPhi * cosPhi;
       double sinPhi = ((sinPhiSq > 0.0) ? sqrt(sinPhiSq) : 0.0);
       // dE/dPhi is independent of cartesians:

--- a/Code/ForceField/MMFF/testMMFFForceField.cpp
+++ b/Code/ForceField/MMFF/testMMFFForceField.cpp
@@ -268,10 +268,8 @@ void fixTorsionInstance(TorsionInstance *torsionInstance)
 }
 
 
-void mmffValidationSuite(int argc, char *argv[])
+int mmffValidationSuite(int argc, char *argv[])
 {
-  std::cerr << "-------------------------------------" << std::endl;
-  std::cerr << "Official MMFF validation suite." << std::endl;
   std::string arg;
   std::string ffVariant = "";
   std::vector<std::string> ffVec;
@@ -341,8 +339,10 @@ void mmffValidationSuite(int argc, char *argv[])
       "[{-sdf [<sdf_file>] | -smi [<smiles_file>]}] [-l <log_file>]"
       << std::endl;
     
-    return;
+    return -1;
   }
+  std::cerr << "-------------------------------------" << std::endl;
+  std::cerr << "Official MMFF validation suite." << std::endl;
   std::string pathName = getenv("RDBASE");
   pathName += "/Code/ForceField/MMFF/test_data/";
   if (molFile != "") {
@@ -1376,6 +1376,7 @@ void mmffValidationSuite(int argc, char *argv[])
    
   TEST_ASSERT(!testFailure);
   std::cerr << "  done" << std::endl;
+  return 0;
 }
 
 void testMMFFAllConstraints(){
@@ -1552,6 +1553,9 @@ void testMMFFAllConstraints(){
 
 int main(int argc, char *argv[])
 {
-  mmffValidationSuite(argc, argv);
-  testMMFFAllConstraints();
+  if (!mmffValidationSuite(argc, argv)) {
+    testMMFFAllConstraints();
+  }
+  
+  return 0;
 }

--- a/Code/ForceField/UFF/AngleBend.cpp
+++ b/Code/ForceField/UFF/AngleBend.cpp
@@ -138,6 +138,7 @@ namespace ForceFields {
       RDGeom::Point3D p12=p1-p2;
       RDGeom::Point3D p32=p3-p2;
       double cosTheta = p12.dotProduct(p32)/(dist1*dist2);
+      clipToOne(cosTheta);
       // we need sin^2(theta) to get cos(2*theta), so compute that:
       double sinThetaSq = 1.-cosTheta*cosTheta;
     
@@ -173,6 +174,7 @@ namespace ForceFields {
         (p3 - p2) / dist[1]
       };
       double cosTheta = r[0].dotProduct(r[1]);
+      clipToOne(cosTheta);
       double sinThetaSq = 1.0 - cosTheta * cosTheta;
       double sinTheta = std::max(((sinThetaSq > 0.0) ? sqrt(sinThetaSq) : 0.0), 1.0e-8);
 

--- a/Code/ForceField/UFF/AngleConstraint.cpp
+++ b/Code/ForceField/UFF/AngleConstraint.cpp
@@ -60,6 +60,7 @@ namespace ForceFields {
         RDGeom::Point3D p12 = (p1 - p2) / dist1;
         RDGeom::Point3D p32 = (p3 - p2) / dist2;
         double cosTheta = p12.dotProduct(p32);
+        clipToOne(cosTheta);
         angle = RAD2DEG * acos(cosTheta);
       }
       dp_forceField = owner;
@@ -92,6 +93,7 @@ namespace ForceFields {
       RDGeom::Point3D p12 = (p1 - p2) / dist1;
       RDGeom::Point3D p32 = (p3 - p2) / dist2;
       double cosTheta = p12.dotProduct(p32);
+      clipToOne(cosTheta);
       double angle = RAD2DEG * acos(cosTheta);
       double angleTerm = 0.0;
       if (angle < d_minAngleDeg) {
@@ -133,6 +135,7 @@ namespace ForceFields {
         (p3 - p2) / dist[1]
       };
       double cosTheta = r[0].dotProduct(r[1]);
+      clipToOne(cosTheta);
       double sinThetaSq = 1.0 - cosTheta * cosTheta;
       double sinTheta = std::max(((sinThetaSq > 0.0) ? sqrt(sinThetaSq) : 0.0), 1.0e-8);
 

--- a/Code/ForceField/UFF/Inversion.cpp
+++ b/Code/ForceField/UFF/Inversion.cpp
@@ -178,9 +178,11 @@ namespace ForceFields {
       RDGeom::Point3D n = (-rJI).crossProduct(rJK);
       n /= n.length();
       double cosY = n.dotProduct(rJL);
+      clipToOne(cosY);
       double sinYSq = 1.0 - cosY * cosY;
       double sinY = std::max(((sinYSq > 0.0) ? sqrt(sinYSq) : 0.0), 1.0e-8);
       double cosTheta = rJI.dotProduct(rJK);
+      clipToOne(cosTheta);
       double sinThetaSq = std::max(1.0 - cosTheta * cosTheta, 1.0e-8);
       double sinTheta = std::max(((sinThetaSq > 0.0) ? sqrt(sinThetaSq) : 0.0), 1.0e-8);
       // sin(2 * W) = 2 * sin(W) * cos(W) = 2 * cos(Y) * sin(Y)

--- a/Code/ForceField/UFF/Params.h
+++ b/Code/ForceField/UFF/Params.h
@@ -26,6 +26,14 @@ namespace ForceFields {
     inline bool isDoubleZero(const double x) {
       return ((x < 1.0e-10) && (x > -1.0e-10));
     }
+    inline void clipToOne(double &x) {
+      if (x > 1.0) {
+        x = 1.0;
+      }
+      else if (x < -1.0) {
+        x = -1.0;
+      }
+    }
 
     void _pretreatAngles(double &minDihedralDeg, double &maxDihedralDeg);
 

--- a/Code/ForceField/UFF/TorsionAngle.cpp
+++ b/Code/ForceField/UFF/TorsionAngle.cpp
@@ -24,6 +24,7 @@ namespace ForceFields {
         RDGeom::Point3D t2=r3.crossProduct(r4);
         double d1=t1.length(),d2=t2.length();
         double cosPhi=t1.dotProduct(t2)/(d1*d2);
+        clipToOne(cosPhi);
         return cosPhi;
       }
 
@@ -247,6 +248,7 @@ namespace ForceFields {
       t[0] /= d[0];
       t[1] /= d[1];
       double cosPhi = t[0].dotProduct(t[1]);
+      clipToOne(cosPhi);
       double sinPhiSq = 1.0 - cosPhi * cosPhi;
       double sinPhi = ((sinPhiSq > 0.0) ? sqrt(sinPhiSq) : 0.0);
 

--- a/Code/ForceField/UFF/TorsionConstraint.cpp
+++ b/Code/ForceField/UFF/TorsionConstraint.cpp
@@ -177,6 +177,7 @@ namespace ForceFields {
       t[0] /= d[0];
       t[1] /= d[1];
       double cosPhi = t[0].dotProduct(t[1]);
+      clipToOne(cosPhi);
       double sinPhiSq = 1.0 - cosPhi * cosPhi;
       double sinPhi = ((sinPhiSq > 0.0) ? sqrt(sinPhiSq) : 0.0);
       // dE/dPhi is independent of cartesians:

--- a/Code/GraphMol/ForceFieldHelpers/MMFF/AtomTyper.cpp
+++ b/Code/GraphMol/ForceFieldHelpers/MMFF/AtomTyper.cpp
@@ -1111,10 +1111,11 @@ namespace RDKit {
                     if (elementDoubleBondedToC == 7) {
                       // if 2 nitrogens with 3 neighbors and no nitrogens with 2 neighbors
                       // are bonded to this carbon, and we have a formal charge,
-                      // but not a 6-membered aromatic ring,
-                      // then this is an amidinium nitrogen (>N-C=N+<)
+                      // but not a 6-membered aromatic ring, and the carbon atom
+                      // is not sp3, then this is an amidinium nitrogen (>N-C=N+<)
                       if ((nN3bondedToC == 2) && (!nN2bondedToC)
-                        && nFormalCharge && (!nInAromatic6Ring)) {
+                        && nFormalCharge && (!nInAromatic6Ring)
+                        && (nbrAtom->getTotalDegree() < 4)) {
                         isNCNplus = true;
                       }
                       // if 3 nitrogens with 3 neighbors are bonded


### PR DESCRIPTION
- fixed a bug in Code/ForceField/MMFF/testMMFFForceField.cpp
- fixed a bug in Code/GraphMol/ForceFieldHelpers/MMFF/AtomTyper.cpp
  which caused misassignment of atom types in CYGUAN01 upon shuffling
  the order of atoms in the validation SDF files
- changed hard-coded constants into const
- added checks for acos and asin function parameters to be within
  a (-1, 1) range
