### PR TITLE
fixed implicit relative import

### DIFF
--- a/rdkit/RDConfig.py
+++ b/rdkit/RDConfig.py
@@ -22,7 +22,7 @@ if 'RDBASE' in os.environ:
   RDBinDir=os.path.join(RDBaseDir,'bin')
   RDProjDir=os.path.join(RDBaseDir,'Projects')
 else:
-  from RDPaths import *
+  from rdkit.RDPaths import *
 
 rpcTestPort=8423
 pythonTestCommand="python"


### PR DESCRIPTION
an import statement I overlooked since it's not executed when $RDBASE is defined, but it for example breaks when a package is installed inside a conda environment.
