### PR TITLE
Revert #include ordering in SmilesMolSupplier.cpp

### DIFF
--- a/Code/GraphMol/Wrap/SmilesMolSupplier.cpp
+++ b/Code/GraphMol/Wrap/SmilesMolSupplier.cpp
@@ -8,11 +8,11 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-#include <string>
 
 #define NO_IMPORT_ARRAY
 #include <boost/python.hpp>
 #include <RDBoost/iterator_next.h>
+#include <string>
 
 //ours
 #include <GraphMol/FileParsers/MolSupplier.h>
@@ -23,12 +23,12 @@
 namespace python = boost::python;
 
 namespace RDKit {
-  
+
   SmilesMolSupplier *SmilesSupplierFromText(std::string text,
 				      std::string delimiter=" ",
 				      int smilesColumn=0,
-				      int nameColumn=1, 
-				      bool titleLine=true,		   
+				      int nameColumn=1,
+				      bool titleLine=true,
 				      bool sanitize=true){
     SmilesMolSupplier *res=new SmilesMolSupplier();
     res->setData(text,delimiter,smilesColumn,


### PR DESCRIPTION
Recent commit 3358ec592580bae8a22faee90336f396db69de01 swapped around `#include <string>` and `include <boost/python.hpp>` in SmilesMolSupplier.cpp.

This caused compilation to fail on Mac OS X with errors related to `toupper`, `tolower`, `isupper`, etc. macros being redefined in pyport.h within the Python installation. From a Google search, I believe it is related to this problem:  http://bugs.python.org/issue10910

This commit simply swaps back `#include <string>` to come after `include <boost/python.hpp>`, which appears to solve the problem.
