### PR TITLE
Herschbach-Laurie fallback implemented to fix GitHub 308

### DIFF
--- a/Code/ForceField/MMFF/Params.cpp
+++ b/Code/ForceField/MMFF/Params.cpp
@@ -1931,6 +1931,95 @@ namespace ForceFields {
       "53	53	2.67	1.6	E94\n";
 
 
+    class MMFFHerschbachLaurieCollection * MMFFHerschbachLaurieCollection::ds_instance = NULL;
+
+    extern const std::string defaultMMFFHerschbachLaurie ;
+
+    MMFFHerschbachLaurieCollection * MMFFHerschbachLaurieCollection::getMMFFHerschbachLaurie (const std::string &mmffHerschbachLaurie )
+    {
+      if (!ds_instance) {
+        ds_instance = new MMFFHerschbachLaurieCollection(mmffHerschbachLaurie );
+      }
+      else if (mmffHerschbachLaurie  != "") {
+        delete ds_instance;
+        ds_instance = new MMFFHerschbachLaurieCollection(mmffHerschbachLaurie );
+      }
+      return ds_instance;
+    }
+
+    MMFFHerschbachLaurieCollection::MMFFHerschbachLaurieCollection(std::string mmffHerschbachLaurie )
+    {
+      if (mmffHerschbachLaurie  == "") {
+        mmffHerschbachLaurie  = defaultMMFFHerschbachLaurie ;
+      }
+      std::istringstream inStream(mmffHerschbachLaurie );
+      std::string inLine = RDKit::getLine(inStream);
+      while (!(inStream.eof())) {
+        if (inLine[0] != '*') {
+          MMFFHerschbachLaurie mmffHerschbachLaurieObj;
+          boost::char_separator<char> tabSep("\t");
+          tokenizer tokens(inLine, tabSep);
+          tokenizer::iterator token = tokens.begin();
+
+          #ifdef RDKIT_MMFF_PARAMS_USE_STD_MAP
+          unsigned int iRow = boost::lexical_cast<unsigned int>(*token);
+          #else
+          d_iRow.push_back((boost::uint8_t)(boost::lexical_cast<unsigned int>(*token)));
+          #endif
+          ++token;
+          #ifdef RDKIT_MMFF_PARAMS_USE_STD_MAP
+          unsigned int jRow = boost::lexical_cast<unsigned int>(*token);
+          #else
+          d_jRow.push_back((boost::uint8_t)boost::lexical_cast<unsigned int>(*token));
+          #endif
+          ++token;
+          mmffHerschbachLaurieObj.a_ij = boost::lexical_cast<double>(*token);
+          ++token;
+          mmffHerschbachLaurieObj.d_ij = boost::lexical_cast<double>(*token);
+          ++token;
+          mmffHerschbachLaurieObj.dp_ij = boost::lexical_cast<double>(*token);
+          ++token;
+          #ifdef RDKIT_MMFF_PARAMS_USE_STD_MAP
+          d_params[iRow][jRow] = mmffHerschbachLaurieObj;
+          #else
+          d_params.push_back(mmffHerschbachLaurieObj);
+          #endif
+        }
+        inLine = RDKit::getLine(inStream);
+      }
+    }
+
+    const std::string defaultMMFFHerschbachLaurie  =
+      "*Table I. Parameters for Badger's Rule.\n"
+      "*\n"
+      "*	i j a_ij d_ij dp_ij\n"
+      "0	0	1.26	0.025	0.025\n"
+      "0	1	1.66	0.30	0.36\n"
+      "0	2	1.84	0.38	0.58\n"
+      "0	3	1.98	0.49	0.65\n"
+      "0	4	2.03	0.51	0.80\n"
+      "0	5	2.03	0.25	0.81\n"
+      "1	1	1.91	0.68	0.68\n"
+      "1	2	2.28	0.74	0.92\n"
+      "1	3	2.35	0.85	1.02\n"
+      "1	4	2.33	0.68	1.12\n"
+      "1	5	2.50	0.97	1.22\n"
+      "2	2	2.41	1.18	1.18\n"
+      "2	3	2.52	1.02	1.28\n"
+      "2	4	2.61	1.28	1.40\n"
+      "2	5	2.60	0.84	1.24\n"
+      "3	3	2.58	1.41	1.35\n"
+      "3	4	2.66	0.86	1.48\n"
+      "3	5	2.75	1.14	1.55\n"
+      "4	4	2.85	1.62	1.62\n"
+      "4	5	2.76	1.25	1.51\n"
+      "0	30	1.85	0.15	0.53\n"
+      "0	40	1.84	0.61	0.61\n"
+      "0	50	1.78	0.97	0.62\n"
+      "1	30	2.08	1.14	0.97\n"
+      "1	40	2.34	1.17	1.08\n";
+
+
     class MMFFCovRadPauEleCollection * MMFFCovRadPauEleCollection::ds_instance = NULL;
 
     extern const std::string defaultMMFFCovRadPauEle;

--- a/Code/GraphMol/ForceFieldHelpers/MMFF/AtomTyper.cpp
+++ b/Code/GraphMol/ForceFieldHelpers/MMFF/AtomTyper.cpp
@@ -48,6 +48,37 @@ namespace RDKit {
       return periodicTableRow;
     }
     
+    // given the atomic num, this function returns the periodic
+    // table row number, starting from 1 for helium
+    // Hydrogen has a special row number (0), while transition
+    // metals have the row number multiplied by 10
+    unsigned int getPeriodicTableRowHL(const int atomicNum)
+    {
+      unsigned int periodicTableRow = 0;
+      
+      if (atomicNum == 2) {
+        periodicTableRow = 1;
+      }
+      else if ((atomicNum >= 3) && (atomicNum <= 10)) {
+        periodicTableRow = 2;
+      }
+      else if ((atomicNum >= 11) && (atomicNum <= 18)) {
+        periodicTableRow = 3;
+      }
+      else if ((atomicNum >= 19) && (atomicNum <= 36)) {
+        periodicTableRow = 4;
+      }
+      else if ((atomicNum >= 37) && (atomicNum <= 54)) {
+        periodicTableRow = 5;
+      }
+      if (((atomicNum >= 21) && (atomicNum <= 30))
+        || ((atomicNum >= 39) && (atomicNum <= 48))
+        || ((atomicNum >= 39) && (atomicNum <= 48))) {
+        periodicTableRow *= 10;
+      }
+      
+      return periodicTableRow;
+    }
     
     // given the MMFF atom type, this function returns true
     // if it is aromatic
@@ -2473,9 +2504,12 @@ namespace RDKit {
       PRECONDITION(this->isValid(), "missing atom types - invalid force-field");
 
       const MMFFBond *mmffBndkParams;
+      const MMFFHerschbachLaurie *mmffHerschbachLaurieParams;
       const MMFFProp *mmffAtomPropParams[2];
       const MMFFCovRadPauEle *mmffAtomCovRadPauEleParams[2];
       MMFFBndkCollection *mmffBndk = MMFFBndkCollection::getMMFFBndk();
+      MMFFHerschbachLaurieCollection *mmffHerschbachLaurie =
+        MMFFHerschbachLaurieCollection::getMMFFHerschbachLaurie();
       MMFFCovRadPauEleCollection *mmffCovRadPauEle =
         MMFFCovRadPauEleCollection::getMMFFCovRadPauEle();
       MMFFPropCollection *mmffProp = MMFFPropCollection::getMMFFProp();
@@ -2593,11 +2627,23 @@ namespace RDKit {
       mmffBondParams->r0 = (r0_i[0] + r0_i[1] - c * pow(fabs
         (mmffAtomCovRadPauEleParams[0]->chi
         - mmffAtomCovRadPauEleParams[1]->chi), n) - delta);
-      // equation (19) - MMFF.V, page 625
-      double coeff = mmffBndkParams->r0 / mmffBondParams->r0;
-      double coeff2 = coeff * coeff;
-      double coeff6 = coeff2 * coeff2 * coeff2;
-      mmffBondParams->kb = mmffBndkParams->kb * coeff6;
+      if (mmffBndkParams) {
+        // equation (19) - MMFF.V, page 625
+        double coeff = mmffBndkParams->r0 / mmffBondParams->r0;
+        double coeff2 = coeff * coeff;
+        double coeff6 = coeff2 * coeff2 * coeff2;
+        mmffBondParams->kb = mmffBndkParams->kb * coeff6;
+      }
+      else {
+        // MMFF.V, page 627
+        // Herschbach-Laurie version of Badger's rule
+        // J. Chem. Phys. 35, 458 (1961); http://dx.doi.org/10.1063/1.1731952
+        // equation (8), page 5
+        mmffHerschbachLaurieParams = (*mmffHerschbachLaurie)
+          (getPeriodicTableRowHL(atomicNum1), getPeriodicTableRowHL(atomicNum2));
+        mmffBondParams->kb = pow(10.0, -(mmffBondParams->r0
+          - mmffHerschbachLaurieParams->a_ij) / mmffHerschbachLaurieParams->d_ij);
+      }
       
       return (const ForceFields::MMFF::MMFFBond *)mmffBondParams;
     }

--- a/Code/GraphMol/ForceFieldHelpers/MMFF/testMMFFHelpers.cpp
+++ b/Code/GraphMol/ForceFieldHelpers/MMFF/testMMFFHelpers.cpp
@@ -484,6 +484,24 @@ void testIssue242()
   BOOST_LOG(rdErrorLog) << "  done" << std::endl;
 }
 
+void testGithub308()
+{
+  BOOST_LOG(rdErrorLog) << "-------------------------------------" << std::endl;
+  BOOST_LOG(rdErrorLog) << "    Testing github 308: crash during MMFF parameterization ." << std::endl;
+  ROMol *mol = SmilesToMol("FF");
+  TEST_ASSERT(DGeomHelpers::EmbedMolecule(*mol) >= 0);
+  int needMore;
+  ForceFields::ForceField *field = 0;
+  TEST_ASSERT(mol);
+  MMFF::MMFFMolProperties mmffMolProperties(*mol);
+  TEST_ASSERT(mmffMolProperties.isValid());
+  field = MMFF::constructForceField(*mol);
+  TEST_ASSERT(field);
+  field->initialize();
+  needMore = field->minimize(200, 1.0e-6, 1.0e-3);
+  TEST_ASSERT(!needMore);
+}
+
 void testSFIssue1653802()
 {
   BOOST_LOG(rdErrorLog) << "-------------------------------------" << std::endl;
@@ -734,6 +752,7 @@ int main()
   testMMFFBuilder2();
   testIssue239();
   testIssue242();
+  testGithub308();
   testSFIssue1653802();
   testSFIssue2378119();
   testMMFFBatch();


### PR DESCRIPTION
- fixed a bug which caused the MMFF parameterization code
  to segfault when a system not listed in the MMFFBndk
  table was found. The Herschbach-Laurie fallback according
  to MMFF.V was implemented and a relevant test was added
  in testMMFFHelpers.cpp
