### PR TITLE
Fix defaults in ReactionFp parameter struct

### DIFF
--- a/Code/GraphMol/ChemReactions/ReactionFingerprints.h
+++ b/Code/GraphMol/ChemReactions/ReactionFingerprints.h
@@ -68,9 +68,9 @@ namespace RDKit{
 
 	  ReactionFingerprintParams():
 		includeAgents(false),
-		bitRatioAgents(0.0),
+		bitRatioAgents(0.2),
 		nonAgentWeight(10),
-		agentWeight(0),
+		agentWeight(1),
 		fpSize(2048),
 		fpType(AtomPairFP){}
 


### PR DESCRIPTION
Some defaults for the handling agents were not chosen that carefully. These are fixed now.
