### PR TITLE
Update URLs to InChI API after inchi-trust.org website redesign.

### DIFF
--- a/External/INCHI-API/README
+++ b/External/INCHI-API/README
@@ -3,7 +3,7 @@ software distribution from the IUPAC website, and place the source code in this
 directory. Please follow these instructions.
 
 1. Download the zip file from
-   http://www.inchi-trust.org/sites/default/files/inchi-1.04/INCHI-1-API.ZIP
+   http://www.inchi-trust.org/wp/wp-content/uploads/2014/06/INCHI-1-API.zip
 
 2. Unzip the package. 
 

--- a/External/INCHI-API/download-inchi.sh
+++ b/External/INCHI-API/download-inchi.sh
@@ -47,12 +47,13 @@ then
 	mkdir -p src
 	echo "================================================================"
 	echo "Downloading InChI software distribution version 1.04"
-	echo "  http://www.inchi-trust.org/sites/default/files/inchi-1.04/INCHI-1-API.ZIP"
+	echo "  http://www.inchi-trust.org/wp/wp-content/uploads/2014/06/INCHI-1-API.zip"
 	echo "  ====>"
 	echo "  $TEMPDIR"
 	echo "================================================================"
 	cd $TEMPDIR
-	wget http://www.inchi-trust.org/sites/default/files/inchi-1.04/INCHI-1-API.ZIP # transfered to a new url from 1.03
+	wget http://www.inchi-trust.org/wp/wp-content/uploads/2014/06/INCHI-1-API.zip
+	
 	echo "================================================================"
 	echo "Unarchiving"
 	echo "================================================================"


### PR DESCRIPTION
It would be nice if these things were stable, eg. with DOIs, 
perhaps hosted on figshare, for example. 
Any URL with 'wp-content' in doesn't seem very future-proof to me.
Just a thought for the inchi-trust.org folks.

Anyway, this seems to work for me.
