### PR TITLE
Improve locating of boost-python for Python 3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,7 +118,7 @@ if(RDK_BUILD_PYTHON_WRAPPERS)
   if(PYTHON_VERSION_MAJOR EQUAL 3)
     # Find boost-python3 using name specified as command line option then fall back to commonly used names
     set(RDK_BOOST_PYTHON3_NAME "python3" CACHE STRING "Name of the boost python3 library. If installed as libboost_python-xxx.so, use python-xxx.")
-    foreach(Boost_Python_Lib "${RDK_BOOST_PYTHON3_NAME}" "python-py34" "python-py33" "python-py32" "python-py31" "python3")
+    foreach(Boost_Python_Lib "${RDK_BOOST_PYTHON3_NAME}" "python-py3${PYTHON_VERSION_MINOR}" "python3")
       find_package(Boost 1.45.0 COMPONENTS "${Boost_Python_Lib}" QUIET)
       if(Boost_FOUND)
         break()


### PR DESCRIPTION
The name of the boost-python library can vary depending on how it is installed. For example, Homebrew on OS X installs boost-python as  `libboost_python` for python 2 and `libboost_python3` for python 3. I believe Ubuntu installs separate `libboost_python-py27`, `libboost_python-py33`, `libboost_python-py34`, etc.

This commit improves the way RDKit searches for boost-python when installing for Python 3 by using a list of commonly used install names: "python-py34", "python-py33", "python-py32", "python-py31", "python3" are tried in turn, before falling back to the previous behaviour of just using `libboost_python`. A command line option `RDK_BOOST_PYTHON3_NAME` is also added to provide a way to specify a custom boost-python library name.
