### PR TITLE
install the header file for the RDKit AvalonTools wrapper api

### DIFF
--- a/External/AvalonTools/CMakeLists.txt
+++ b/External/AvalonTools/CMakeLists.txt
@@ -48,6 +48,7 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 include_directories(${AVALON_SRC_PATH})
 
 rdkit_library(AvalonLib AvalonTools.cpp SHARED LINK_LIBRARIES avalon_clib FileParsers SmilesParse GraphMol DataStructs RDGeometryLib RDGeneral )
+rdkit_headers(AvalonTools.h DEST GraphMol)
 rdkit_test(testAvalonLib1 test1.cpp
            LINK_LIBRARIES AvalonLib avalon_clib FileParsers SmilesParse GraphMol DataStructs RDGeometryLib RDGeneral)
 


### PR DESCRIPTION
Adds the AvalonTools.h header file to the GraphMol headers so that client code can include it when compiled using an installed version of the toolkit
