### PR TITLE
fix some minor inconsistencies in the naming of a few guc variables

### DIFF
--- a/Code/PgSQL/rdkit/expected/reaction.out
+++ b/Code/PgSQL/rdkit/expected/reaction.out
@@ -1,7 +1,7 @@
 SET rdkit.ignore_reaction_agents=false;
 SET rdkit.agent_FP_bit_ratio=0.2;
-SET rdkit.rdkit_difference_FP_weight_agents=1;
-SET rdkit.rdkit_difference_FP_weight_nonagents=10;
+SET rdkit.difference_FP_weight_agents=1;
+SET rdkit.difference_FP_weight_nonagents=10;
 SET rdkit.move_unmmapped_reactants_to_agents=true;
 SET rdkit.threshold_unmapped_reactant_atoms=0.2;
 SET rdkit.init_reaction=true;
@@ -675,8 +675,8 @@ SELECT tanimoto_sml(reaction_structural_bfp('c1ccccc1>CC(=O)O.[Na+]>c1ccncc1',5)
 (1 row)
 
 SET rdkit.agent_FP_bit_ratio=0.5;
-SET rdkit.rdkit_difference_FP_weight_agents=-3;
-SET rdkit.rdkit_difference_FP_weight_nonagents=7;
+SET rdkit.difference_FP_weight_agents=-3;
+SET rdkit.difference_FP_weight_nonagents=7;
 SELECT tanimoto_sml(reaction_difference_fp('c1ccccc1>>c1ccncc1',1), reaction_difference_fp('c1ccccc1>>c1ccncc1',1));
  tanimoto_sml 
 --------------

--- a/Code/PgSQL/rdkit/guc.c
+++ b/Code/PgSQL/rdkit/guc.c
@@ -133,7 +133,7 @@ initRDKitGUC()
                            );
 
   DefineCustomIntVariable(
-                           "rdkit.ss_fp_size",
+                           "rdkit.sss_fp_size",
                            "Size (in bits) of the fingerprint used for substructure screening",
                            "Size (in bits) of the fingerprint used for substructure screening",
                            &rdkit_sss_fp_size,
@@ -383,7 +383,7 @@ initRDKitGUC()
                              NULL
                              );
   DefineCustomIntVariable(
-                           "rdkit.rdkit_difference_FP_weight_agents",
+                           "rdkit.difference_FP_weight_agents",
                            "In reaction difference fingerprints weight factor for agents comapred to reactants and products",
                            "In reaction difference fingerprints weight factor for agents comapred to reactants and products",
                            &rdkit_difference_FP_weight_agents,

--- a/Code/PgSQL/rdkit/sql/reaction.sql
+++ b/Code/PgSQL/rdkit/sql/reaction.sql
@@ -1,7 +1,7 @@
 SET rdkit.ignore_reaction_agents=false;
 SET rdkit.agent_FP_bit_ratio=0.2;
-SET rdkit.rdkit_difference_FP_weight_agents=1;
-SET rdkit.rdkit_difference_FP_weight_nonagents=10;
+SET rdkit.difference_FP_weight_agents=1;
+SET rdkit.difference_FP_weight_nonagents=10;
 SET rdkit.move_unmmapped_reactants_to_agents=true;
 SET rdkit.threshold_unmapped_reactant_atoms=0.2;
 SET rdkit.init_reaction=true;
@@ -164,8 +164,8 @@ SELECT tanimoto_sml(reaction_structural_bfp('c1ccccc1>CC(=O)O.[Na+]>c1ccncc1',5)
 SELECT tanimoto_sml(reaction_structural_bfp('c1ccccc1>CC(=O)O.[Na+]>c1ccncc1',5), reaction_structural_bfp('c1ncccc1>[Na+]>c1ncncc1',5));
 
 SET rdkit.agent_FP_bit_ratio=0.5;
-SET rdkit.rdkit_difference_FP_weight_agents=-3;
-SET rdkit.rdkit_difference_FP_weight_nonagents=7;
+SET rdkit.difference_FP_weight_agents=-3;
+SET rdkit.difference_FP_weight_nonagents=7;
 
 SELECT tanimoto_sml(reaction_difference_fp('c1ccccc1>>c1ccncc1',1), reaction_difference_fp('c1ccccc1>>c1ccncc1',1));
 SELECT tanimoto_sml(reaction_difference_fp('c1ccccc1>>c1ccncc1',1), reaction_difference_fp('c1ncccc1>>c1ncncc1',1));


### PR DESCRIPTION
the following guc variables have been renamed:

rdkit.ss_fp_size -> rdkit.sss_fp_size
rdkit.rdkit_difference_FP_weight_agents -> rdkit.difference_FP_weight_agents

references to rdkit.rdkit_difference_FP_weight_nonagents in the sql/expected files have been replaced with the actual name of the variable rdkit.difference_FP_weight_nonagents

NOTE: this changeset breaks the regression tests.
