### PR TITLE
Isomeric fix in PandasTools

### DIFF
--- a/rdkit/Chem/PandasTools.py
+++ b/rdkit/Chem/PandasTools.py
@@ -271,16 +271,15 @@ def FrameToGridImage(frame, column = 'ROMol', legendsCol=None, **kwargs):
   return img
 
 from rdkit.Chem.Scaffolds import MurckoScaffold
-from rdkit.Chem import MolToSmiles
 
 def AddMurckoToFrame(frame, molCol = 'ROMol', MurckoCol = 'Murcko_SMILES', Generic = False):
   '''
   Adds column with SMILES of Murcko scaffolds to pandas DataFrame. Generic set to true results in SMILES of generic framework.
   '''
   if Generic:
-    frame[MurckoCol] = frame.apply(lambda x: MolToSmiles(MurckoScaffold.MakeScaffoldGeneric(MurckoScaffold.GetScaffoldForMol(x[molCol]))), axis=1)
+    frame[MurckoCol] = frame.apply(lambda x: Chem.MolToSmiles(MurckoScaffold.MakeScaffoldGeneric(MurckoScaffold.GetScaffoldForMol(x[molCol]))), axis=1)
   else:
-    frame[MurckoCol] = frame.apply(lambda x: MolToSmiles(MurckoScaffold.GetScaffoldForMol(x[molCol])), axis=1)
+    frame[MurckoCol] = frame.apply(lambda x: Chem.MolToSmiles(MurckoScaffold.GetScaffoldForMol(x[molCol])), axis=1)
 
 
 from rdkit.Chem import AllChem


### PR DESCRIPTION
- SMILES column can now contain isomeric SMILES when loading from sdf
- Isomeric SMILES can now be saved with SaveSMILESFromFrame
- Removed `from rdkit.Chem import MolToSmiles` and fixed AddMurckoToFrame accordingly
