### PR TITLE
RDKit learns how to compute code coverage for tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,7 @@ option(RDK_BUILD_SWIG_CSHARP_WRAPPER "build the experimental SWIG C# wrappers (d
 option(RDK_TEST_MMFF_COMPLIANCE "run MMFF compliance tests (requires tar/gzip)" ON )
 option(RDK_BUILD_CPP_TESTS "build the c++ tests (disabing can speed up builds" ON)
 option(RDK_USE_FLEXBISON "use flex/bison, if available, to build the SMILES/SMARTS/SLN parsers" OFF)
+option(RDK_TEST_COVERAGE "Use G(L)COV to compute test coverage" OFF)
 
 if(RDK_BUILD_SWIG_WRAPPERS!=ON)
   set(RDK_BUILD_SWIG_JAVA_WRAPPER OFF)
@@ -194,12 +195,36 @@ endif()
 
 
 # setup our compiler flags:
-if(CMAKE_COMPILER_IS_GNUCXX)
-  ADD_DEFINITIONS("-Wno-deprecated -Wno-unused-function -fno-strict-aliasing -fPIC")
-endif()
-if(CMAKE_COMPILER_IS_CLANG)
-  ADD_DEFINITIONS("-Wno-array-bounds -fPIC")
-endif()
+if (RDK_TEST_COVERAGE)
+ if (NOT RDK_USE_FLEXBISON)
+   message(FATAL_ERROR, "Test coverage doesn't current work unless FLEX and BISON are run.")
+ endif(NOT RDK_USE_FLEXBISON)
+
+ message("====== Installing test coverage support ======")
+ message("  To run:")
+ message("   make install")
+ message("   make RDKit_coverage")
+ message("")
+ message(" open <build_dir>/coverage/index.html")
+ message("")
+ message(" If any of the RDKit tests fail, coverage will probably not be generated.")
+ message("====== Installing test coverage support ======")
+ message("")
+ 
+ INCLUDE(CodeCoverage)
+ SET(CMAKE_CXX_FLAGS "-g -O0 -fprofile-arcs -ftest-coverage")
+ SET(CMAKE_C_FLAGS "-g -O0 -fprofile-arcs -ftest-coverage")
+ message("== setup_target_for_coverage(${PROJECT_NAME}_coverage test coverage)")
+ setup_target_for_coverage(${PROJECT_NAME}_coverage ctest coverage)
+
+else(RDK_TEST_COVERAGE)
+ if(CMAKE_COMPILER_IS_GNUCXX)
+   ADD_DEFINITIONS("-Wno-deprecated -Wno-unused-function -fno-strict-aliasing -fPIC")
+ endif()
+ if(CMAKE_COMPILER_IS_CLANG)
+   ADD_DEFINITIONS("-Wno-array-bounds -fPIC")
+ endif()
+endif(RDK_TEST_COVERAGE)
 
 if(NOT RDK_INSTALL_INTREE)
   install(DIRECTORY Data DESTINATION
@@ -286,6 +311,7 @@ SET(CPACK_PACKAGE_INSTALL_DIRECTORY "CMake ${CMake_VERSION_MAJOR}.${CMake_VERSIO
 #  SET(CPACK_SOURCE_STRIP_FILES "")
 #ENDIF(WIN32 AND NOT UNIX)
 #SET(CPACK_PACKAGE_EXECUTABLES "MyExecutable" "My Executable")
+
 
 SET(CPACK_SET_DESTDIR ON)
 

--- a/Code/cmake/Modules/CodeCoverage.cmake
+++ b/Code/cmake/Modules/CodeCoverage.cmake
@@ -1,0 +1,170 @@
+#
+# 2012-01-31, Lars Bilke
+# - Enable Code Coverage
+#
+# 2013-09-17, Joakim Söderberg
+# - Added support for Clang.
+# - Some additional usage instructions.
+#
+# 2015-01-14, Brian Kelley
+# - Fix FLEX and BISON coverage (ignore certain files)
+#
+# USAGE:
+
+# 0. (Mac only) If you use Xcode 5.1 make sure to patch geninfo as described here:
+#      http://stackoverflow.com/a/22404544/80480
+#
+# 1. Copy this file into your cmake modules path.
+#
+# 2. Add the following line to your CMakeLists.txt:
+#      INCLUDE(CodeCoverage)
+#
+# 3. Set compiler flags to turn off optimization and enable coverage: 
+#    SET(CMAKE_CXX_FLAGS "-g -O0 -fprofile-arcs -ftest-coverage")
+#	 SET(CMAKE_C_FLAGS "-g -O0 -fprofile-arcs -ftest-coverage")
+#  
+# 3. Use the function SETUP_TARGET_FOR_COVERAGE to create a custom make target
+#    which runs your test executable and produces a lcov code coverage report:
+#    Example:
+#	 SETUP_TARGET_FOR_COVERAGE(
+#				my_coverage_target  # Name for custom target.
+#				test_driver         # Name of the test driver executable that runs the tests.
+#									# NOTE! This should always have a ZERO as exit code
+#									# otherwise the coverage generation will not complete.
+#				coverage            # Name of output directory.
+#				)
+#
+# 4. Build a Debug build:
+#	 cmake -DCMAKE_BUILD_TYPE=Debug ..
+#	 make
+#	 make my_coverage_target
+#
+#
+
+# Check prereqs
+FIND_PROGRAM( GCOV_PATH gcov )
+FIND_PROGRAM( LCOV_PATH lcov )
+FIND_PROGRAM( GENHTML_PATH genhtml )
+FIND_PROGRAM( GCOVR_PATH gcovr PATHS ${CMAKE_SOURCE_DIR}/tests)
+
+IF(NOT GCOV_PATH)
+	MESSAGE(FATAL_ERROR "gcov not found! Aborting...")
+ENDIF() # NOT GCOV_PATH
+
+IF(NOT CMAKE_COMPILER_IS_GNUCXX)
+	# Clang version 3.0.0 and greater now supports gcov as well.
+	MESSAGE(WARNING "Compiler is not GNU gcc! Clang Version 3.0.0 and greater supports gcov as well, but older versions don't.")
+	
+	IF(NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+		MESSAGE(FATAL_ERROR "Compiler is not GNU gcc! Aborting...")
+	ENDIF()
+ENDIF() # NOT CMAKE_COMPILER_IS_GNUCXX
+
+SET(CMAKE_CXX_FLAGS_COVERAGE
+    "-g -O0 --coverage -fprofile-arcs -ftest-coverage"
+    CACHE STRING "Flags used by the C++ compiler during coverage builds."
+    FORCE )
+SET(CMAKE_C_FLAGS_COVERAGE
+    "-g -O0 --coverage -fprofile-arcs -ftest-coverage"
+    CACHE STRING "Flags used by the C compiler during coverage builds."
+    FORCE )
+SET(CMAKE_EXE_LINKER_FLAGS_COVERAGE
+    ""
+    CACHE STRING "Flags used for linking binaries during coverage builds."
+    FORCE )
+SET(CMAKE_SHARED_LINKER_FLAGS_COVERAGE
+    ""
+    CACHE STRING "Flags used by the shared libraries linker during coverage builds."
+    FORCE )
+MARK_AS_ADVANCED(
+    CMAKE_CXX_FLAGS_COVERAGE
+    CMAKE_C_FLAGS_COVERAGE
+    CMAKE_EXE_LINKER_FLAGS_COVERAGE
+    CMAKE_SHARED_LINKER_FLAGS_COVERAGE )
+
+IF ( NOT (CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "Coverage"))
+  MESSAGE( WARNING "Code coverage results with an optimized (non-Debug) build may be misleading" )
+ENDIF() # NOT CMAKE_BUILD_TYPE STREQUAL "Debug"
+
+
+# Param _targetname     The name of new the custom make target
+# Param _testrunner     The name of the target which runs the tests.
+#						MUST return ZERO always, even on errors. 
+#						If not, no coverage report will be created!
+# Param _outputname     lcov output is generated as _outputname.info
+#                       HTML report is generated in _outputname/index.html
+# Optional fourth parameter is passed as arguments to _testrunner
+#   Pass them in list form, e.g.: "-j;2" for -j 2
+FUNCTION(SETUP_TARGET_FOR_COVERAGE _targetname _testrunner _outputname)
+
+	IF(NOT LCOV_PATH)
+		MESSAGE(FATAL_ERROR "lcov not found! Aborting...")
+	ENDIF() # NOT LCOV_PATH
+
+	IF(NOT GENHTML_PATH)
+		MESSAGE(FATAL_ERROR "genhtml not found! Aborting...")
+	ENDIF() # NOT GENHTML_PATH
+
+	SET(IN_TREE_FILE_FIXUP "${CMAKE_SOURCE_DIR}/CMakeModules/in_tree_file_fixup.py")
+
+	# Setup target
+	ADD_CUSTOM_TARGET(${_targetname}
+		
+		# Cleanup lcov
+		${LCOV_PATH} --directory . --zerocounters
+		
+		# Run tests
+		COMMAND ${_testrunner} ${ARGV3}
+		# Capturing lcov counters and generating report
+		COMMAND ${LCOV_PATH} --directory . --capture --output-file ${_outputname}.info
+		COMMAND ${LCOV_PATH} --remove ${_outputname}.info 'tests/*' '/usr/*' '*.ll' '*.yy' --output-file ${_outputname}.info.cleaned
+                COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/Code/cmake/Modules/fixup_coverage.py ${CMAKE_SOURCE_DIR} ${_outputname}.info.cleaned
+
+		COMMAND ${GENHTML_PATH} -o ${_outputname} ${_outputname}.info.cleaned
+		COMMAND ${CMAKE_COMMAND} -E remove ${_outputname}.info ${_outputname}.info.cleaned
+		
+		WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+		COMMENT "Resetting code coverage counters to zero.\nProcessing code coverage counters and generating report."
+	)
+
+	# Show info where to find the report
+	ADD_CUSTOM_COMMAND(TARGET ${_targetname} POST_BUILD
+		COMMAND ;
+		COMMENT "Open ./${_outputname}/index.html in your browser to view the coverage report."
+	)
+
+ENDFUNCTION() # SETUP_TARGET_FOR_COVERAGE
+
+# Param _targetname     The name of new the custom make target
+# Param _testrunner     The name of the target which runs the tests
+# Param _outputname     cobertura output is generated as _outputname.xml
+# Optional fourth parameter is passed as arguments to _testrunner
+#   Pass them in list form, e.g.: "-j;2" for -j 2
+FUNCTION(SETUP_TARGET_FOR_COVERAGE_COBERTURA _targetname _testrunner _outputname)
+
+	IF(NOT PYTHON_EXECUTABLE)
+		MESSAGE(FATAL_ERROR "Python not found! Aborting...")
+	ENDIF() # NOT PYTHON_EXECUTABLE
+
+	IF(NOT GCOVR_PATH)
+		MESSAGE(FATAL_ERROR "gcovr not found! Aborting...")
+	ENDIF() # NOT GCOVR_PATH
+
+	ADD_CUSTOM_TARGET(${_targetname}
+
+		# Run tests
+		${_testrunner} ${ARGV3}
+
+		# Running gcovr
+		COMMAND ${GCOVR_PATH} -x -r ${CMAKE_SOURCE_DIR} -e '${CMAKE_SOURCE_DIR}/tests/'  -o ${_outputname}.xml
+		WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+		COMMENT "Running gcovr to produce Cobertura code coverage report."
+	)
+
+	# Show info where to find the report
+	ADD_CUSTOM_COMMAND(TARGET ${_targetname} POST_BUILD
+		COMMAND ;
+		COMMENT "Cobertura code coverage report saved in ${_outputname}.xml."
+	)
+
+ENDFUNCTION() # SETUP_TARGET_FOR_COVERAGE_COBERTURA

--- a/Code/cmake/Modules/fixup_coverage.py
+++ b/Code/cmake/Modules/fixup_coverage.py
@@ -1,0 +1,34 @@
+"""This file searches the source directory for BISON and FLEX files that
+the coverage tool mistakenly finds in the build tree.
+It replaces the paths with the ones from the source tree
+n.b. if a file with the same name (i.e. sln.yy) is found twice
+ in the source tree, this will break"""
+
+import os,sys
+source_dir, info_file = sys.argv[1:3]
+print source_dir, info_file
+
+paths = {}
+for root, dir, files in os.walk(source_dir):
+    for f in files:
+        paths[f] = paths.get(f, []) + [os.path.join(root, f)]
+
+lines = open(info_file).readlines()
+
+newlines = []
+for line in lines:
+    if "SF:" in line:
+        fn = line.split("SF:")[-1].strip()
+        if not os.path.exists(fn):
+            print "Does not exist:", fn.strip()
+            head, rest = os.path.split(fn)
+            potential = paths[rest]
+            if len(potential) == 1:
+                line = "SF:"+potential[0]
+            else:
+                asdf
+    newlines.append(line)
+
+open(info_file, 'w').write("\n".join(newlines))
+                
+


### PR DESCRIPTION
To use code coverage:

cmake -DCMAKE_BUILD_TYPE=Debug \
      -DRDK_USE_FLEXBISON=ON \
      -DRDK_TEST_COVERAGE=ON \
      <path to rdkit source tree>

make install
make RDKit_coverage

Note, when making RDKit_coverage, your python paths, (DY)LD_LIBRARY paths must be
set up correctly.  If any of the tests fail, the coverage generator will most
likely fail and certainly will not be complete.

Here is an example from my OSX Box (note, I set the install directory to rdkit_build via)
cmake -DCMAKE_INSTALL_PREFIX=`pwd`/rdkit_build \
    ...

RDBASE=<path to rdkit source>  DYLD_LIBRARY_PATH=`pwd`/rdkit_build/lib \
 PYTHONPATH=`pwd`/rdkit_build/lib/python2.7/site-packages \
 make RDKit_coverage

open coverage/index.html in a browser