### PR TITLE
Dictionary access is saniztized and optimized.

### DIFF
--- a/Code/Demos/RDKit/Basement/BinaryIO/iotest.cpp
+++ b/Code/Demos/RDKit/Basement/BinaryIO/iotest.cpp
@@ -65,7 +65,7 @@ void test2(){
   m = SmilesToMol(smiles);
   TEST_ASSERT(m);
   TEST_ASSERT(m->getNumAtoms(5));
-  m->setProp("_Name","monkey");
+  m->setProp(common_properties::_Name,"monkey");
   io::filtering_ostream outStrm;
   outStrm.push(io::gzip_compressor());
   outStrm.push(io::back_inserter(buff));

--- a/Code/Demos/RDKit/Basement/Minimize/MinimizeCLI.cpp
+++ b/Code/Demos/RDKit/Basement/Minimize/MinimizeCLI.cpp
@@ -70,7 +70,7 @@ void runSDFile(std::string fileName,int checkEvery=10){
   mol = (RWMol *)suppl.next();
   while(mol){
     std::string name;
-    mol->getProp("_Name",name);
+    mol->getProp(common_properties::_Name,name);
     std::cerr << "Mol: " << name << std::endl;
     try{
       MolOps::sanitizeMol(*mol);

--- a/Code/Demos/RDKit/Basement/TemplEnum/TemplEnumTools.cpp
+++ b/Code/Demos/RDKit/Basement/TemplEnum/TemplEnumTools.cpp
@@ -184,14 +184,14 @@ namespace TemplateEnum {
   // Loop through all the atoms and bookmark the attachment points
   //
   //  attachment points are assumed to have one of these properties:
-  //   - "molFileAlias" (set by the mol file parser)
-  //   - "dummyLabel"   (set by the SMILES parser)
+  //   - common_properties::molFileAlias (set by the mol file parser)
+  //   - common_properties::dummyLabel   (set by the SMILES parser)
   //  frontMarker is the "recognition character" to be used to pick
   //  valid labels.  e.g. if the frontMarker is 'X', a label beginning
   //  with 'Y' will not be marked.
   //
   //  In addition to bookmarking the attachment points, we also set
-  //  the "maxAttachIdx" property, which holds an integer with the
+  //  the common_properties::maxAttachIdx property, which holds an integer with the
   //  maximum attachment bookmark index. This is used in the
   //  enumeration to prevent us from having to scan through all the
   //  molecule's bookmarks
@@ -212,10 +212,10 @@ namespace TemplateEnum {
     for(atomIt=mol->beginAtoms();atomIt!=mol->endAtoms();atomIt++){
       // start by finding possible attachment point properties:
       std::string attachLabel="";
-      if((*atomIt)->hasProp("molFileAlias")){
-	(*atomIt)->getProp("molFileAlias",attachLabel);
-      } else if((*atomIt)->hasProp("dummyLabel")){
-	(*atomIt)->getProp("dummyLabel",attachLabel);
+      if((*atomIt)->hasProp(common_properties::molFileAlias)){
+	(*atomIt)->getProp(common_properties::molFileAlias,attachLabel);
+      } else if((*atomIt)->hasProp(common_properties::dummyLabel)){
+	(*atomIt)->getProp(common_properties::dummyLabel,attachLabel);
       }
 
       // if we got one and it starts with the appropriate front
@@ -237,7 +237,7 @@ namespace TemplateEnum {
       }
     }
     if(maxAttachIdx){
-      mol->setProp("maxAttachIdx",maxAttachIdx);
+      mol->setProp(common_properties::maxAttachIdx,maxAttachIdx);
     }
   }
 
@@ -270,11 +270,11 @@ namespace TemplateEnum {
 
     // if there's no attachment point on the molecule or no
     // sidechains, return now: 
-    if(!templateMol->hasProp("maxAttachIdx") || sidechains.size()==0 )
+    if(!templateMol->hasProp(common_properties::maxAttachIdx) || sidechains.size()==0 )
       return res;
 
     int maxIdx;
-    templateMol->getProp("maxAttachIdx",maxIdx);
+    templateMol->getProp(common_properties::maxAttachIdx,maxIdx);
 
     tmp.clear();
     // loop over the sidechains and attach them
@@ -305,8 +305,8 @@ namespace TemplateEnum {
 	  for(templMolIt=res.begin();templMolIt!=res.end();templMolIt++){
 	    RWMol *templ =  new RWMol(**templMolIt);
 	    std::string name,tmpStr;
-	    if(templ->hasProp("_Name")){
-	      templ->getProp("_Name",tmpStr);
+	    if(templ->hasProp(common_properties::_Name)){
+	      templ->getProp(common_properties::_Name,tmpStr);
 	      name = name + " " + tmpStr;
 	    }
 	    while(templ->hasAtomBookmark(tgtMark)){
@@ -326,8 +326,8 @@ namespace TemplateEnum {
 	      molAddSidechain(templ,sidechain,
 			      at->getIdx(),sidechainAtomIdx,
 			      Bond::SINGLE);
-	      if(sidechain->hasProp("_Name")){
-		sidechain->getProp("_Name",tmpStr);
+	      if(sidechain->hasProp(common_properties::_Name)){
+		sidechain->getProp(common_properties::_Name,tmpStr);
 		name = name + " " + tmpStr;
 	      }
 	      templ->clearAtomBookmark(tgtMark,at);
@@ -336,7 +336,7 @@ namespace TemplateEnum {
 	      }
 	    }
 	    //std::cout << templ << "> " << MolToSmiles(*templ) << std::endl;
-	    if(name != "") templ->setProp("_Name",name);
+	    if(name != "") templ->setProp(common_properties::_Name,name);
 	    tmp.push_back(RWMOL_SPTR(templ));
 	  }
 	}

--- a/Code/Demos/RDKit/Basement/xpcom/RDMolImpl.cpp
+++ b/Code/Demos/RDKit/Basement/xpcom/RDMolImpl.cpp
@@ -63,13 +63,13 @@ NS_IMETHODIMP RDMolecule::LogP(double *_retval)
 {
   if(!dp_mol) return NS_ERROR_NOT_INITIALIZED;
   double logp;
-  if(dp_mol->hasProp("_CrippenLogP")) {
-    dp_mol->getProp("_CrippenLogP",logp);
+  if(dp_mol->hasProp(common_properties::_CrippenLogP)) {
+    dp_mol->getProp(common_properties::_CrippenLogP,logp);
   } else {
     double mr;
     RDKit::Descriptors::CalcCrippenDescriptors(dp_mol,logp,mr);
-    dp_mol->setProp("_CrippenLogP",logp,true);
-    dp_mol->setProp("_CrippenMR",mr,true);
+    dp_mol->setProp(common_properties::_CrippenLogP,logp,true);
+    dp_mol->setProp(common_properties::_CrippenMR,mr,true);
   }
   *_retval=logp;
   return NS_OK;
@@ -80,13 +80,13 @@ NS_IMETHODIMP RDMolecule::MR(double *_retval)
 {
   if(!dp_mol) return NS_ERROR_NOT_INITIALIZED;
   double mr;
-  if(dp_mol->hasProp("_CrippenMR")) {
-    dp_mol->getProp("_CrippenMR",mr);
+  if(dp_mol->hasProp(common_properties::_CrippenMR)) {
+    dp_mol->getProp(common_properties::_CrippenMR,mr);
   } else {
     double logp;
     RDKit::Descriptors::CalcCrippenDescriptors(dp_mol,logp,mr);
-    dp_mol->setProp("_CrippenLogP",logp,true);
-    dp_mol->setProp("_CrippenMR",mr,true);
+    dp_mol->setProp(common_properties::_CrippenLogP,logp,true);
+    dp_mol->setProp(common_properties::_CrippenMR,mr,true);
   }
   *_retval=mr;
   return NS_OK;

--- a/Code/ForceField/MMFF/testMMFFForceField.cpp
+++ b/Code/ForceField/MMFF/testMMFFForceField.cpp
@@ -432,8 +432,8 @@ int mmffValidationSuite(int argc, char *argv[])
             DGeomHelpers::EmbedMolecule(*mol);
           }
           MMFF::sanitizeMMFFMol((RWMol &)(*mol));
-          if (mol->hasProp("_Name")) {
-            mol->getProp("_Name", molName);
+          if (mol->hasProp(common_properties::_Name)) {
+            mol->getProp(common_properties::_Name, molName);
             rdkFStream << molName << std::endl;
             nameArray.push_back(molName);
           }

--- a/Code/ForceField/Wrap/testConstraints.py
+++ b/Code/ForceField/Wrap/testConstraints.py
@@ -90,7 +90,7 @@ M  END"""
     self.assertTrue(r == 0)
     conf = m.GetConformer()
     angle = rdMolTransforms.GetAngleDeg(conf, 1, 3, 6)
-    self.assertTrue(int(angle) == 10)
+    self.assertEqual(int(angle), 10)
 
   def testUFFTorsionConstraints(self) :
     m = Chem.MolFromMolBlock(self.molB, True, False)
@@ -111,7 +111,7 @@ M  END"""
     self.assertTrue(r == 0)
     conf = m.GetConformer()
     dihedral = rdMolTransforms.GetDihedralDeg(conf, 1, 3, 6, 8)
-    self.assertTrue(int(dihedral) == -40)
+    self.assertEquals(int(dihedral), -40)
     rdMolTransforms.SetDihedralDeg(conf, 1, 3, 6, 8, 30.0);
     ff = ChemicalForceFields.UFFGetMoleculeForceField(m)
     self.assertTrue(ff)
@@ -192,7 +192,7 @@ M  END"""
     self.assertTrue(r == 0)
     conf = m.GetConformer()
     angle = rdMolTransforms.GetAngleDeg(conf, 1, 3, 6)
-    self.assertTrue(int(angle) == 10)
+    self.assertEquals(int(angle), 10)#(int(angle) == 10)
 
   def testMMFFTorsionConstraints(self) :
     m = Chem.MolFromMolBlock(self.molB, True, False)
@@ -205,7 +205,7 @@ M  END"""
     r = ff.Minimize()
     self.assertTrue(r == 0)
     dihedral = rdMolTransforms.GetDihedralDeg(conf, 1, 3, 6, 8)
-    self.assertTrue(int(dihedral) == 20)
+    self.assertEquals(int(dihedral), 20)
     rdMolTransforms.SetDihedralDeg(conf, 1, 3, 6, 8, -30.0);
     ff = ChemicalForceFields.MMFFGetMoleculeForceField(m, mp)
     self.assertTrue(ff)

--- a/Code/GraphMol/Aromaticity.cpp
+++ b/Code/GraphMol/Aromaticity.cpp
@@ -715,7 +715,7 @@ namespace RDKit {
         }
       }
     
-      mol.setProp("numArom", narom, true);
+      mol.setProp(common_properties::numArom, narom, true);
 
       return narom;
     }

--- a/Code/GraphMol/Atom.cpp
+++ b/Code/GraphMol/Atom.cpp
@@ -130,10 +130,8 @@ void Atom::setOwningMol(ROMol *other)
 std::string Atom::getSymbol() const {
   std::string res;
   // handle dummies differently:
-  if(d_atomicNum != 0 || !hasProp("dummyLabel") ){
+  if(d_atomicNum != 0 || !getPropIfPresent<std::string>(common_properties::dummyLabel, res)) {
     res = PeriodicTable::getTable()->getElementSymbol(d_atomicNum);
-  } else {
-    res=getProp<std::string>("dummyLabel");
   }
   return res;
 }

--- a/Code/GraphMol/Atom.h
+++ b/Code/GraphMol/Atom.h
@@ -339,10 +339,10 @@ namespace RDKit{
 
     //! \overload
     template <typename T>
-    void setProp(const std::string key, T val, bool computed=false) const {
+    void setProp(const std::string &key, T val, bool computed=false) const {
       if (computed) {
 	STR_VECT compLst;
-	if(hasProp(detail::computedPropName)) getProp(detail::computedPropName, compLst);
+	getPropIfPresent(detail::computedPropName, compLst);
 	if (std::find(compLst.begin(), compLst.end(), key) == compLst.end()) {
 	  compLst.push_back(key);
 	  dp_props->setVal(detail::computedPropName, compLst);
@@ -372,9 +372,10 @@ namespace RDKit{
     }
     //! \overload
     template <typename T>
-    void getProp(const std::string key,T &res) const {
+    void getProp(const std::string &key,T &res) const {
       dp_props->getVal(key,res);
     }
+
     //! \overload
     template <typename T>
     T getProp(const char *key) const {
@@ -382,8 +383,20 @@ namespace RDKit{
     }
     //! \overload
     template <typename T>
-    T getProp(const std::string key) const {
+    T getProp(const std::string &key) const {
       return dp_props->getVal<T>(key);
+    }
+
+    //! returns whether or not we have a \c property with name \c key
+    //!  and assigns the value if we do
+    template <typename T>
+    bool getPropIfPresent(const char *key,T &res) const {
+        return dp_props->getValIfPresent(key,res);
+    }
+    //! \overload
+    template <typename T>
+    bool getPropIfPresent(const std::string &key,T &res) const {
+        return dp_props->getValIfPresent(key,res);
     }
 
     //! returns whether or not we have a \c property with name \c key
@@ -392,7 +405,7 @@ namespace RDKit{
       return dp_props->hasVal(key);
     };
     //! \overload
-    bool hasProp(const std::string key) const {
+    bool hasProp(const std::string &key) const {
       if(!dp_props) return false;
       return dp_props->hasVal(key);
     };
@@ -411,10 +424,9 @@ namespace RDKit{
       clearProp(what);
     };
     //! \overload
-    void clearProp(const std::string key) const {
-      if(hasProp(detail::computedPropName)){
-	STR_VECT compLst;
-	getProp(detail::computedPropName, compLst);
+    void clearProp(const std::string &key) const {
+      STR_VECT compLst;
+      if(getPropIfPresent(detail::computedPropName, compLst)) {
 	STR_VECT_I svi = std::find(compLst.begin(), compLst.end(), key);
 	if (svi != compLst.end()) {
 	  compLst.erase(svi);
@@ -426,14 +438,15 @@ namespace RDKit{
 
     //! clears all of our \c computed \c properties
     void clearComputedProps() const {
-      if(!hasProp(detail::computedPropName)) return;
       STR_VECT compLst;
-      getProp(detail::computedPropName, compLst);
-      BOOST_FOREACH(const std::string &sv,compLst){
-	dp_props->clearVal(sv);
+      if (getPropIfPresent(detail::computedPropName, compLst))
+      {
+	BOOST_FOREACH(const std::string &sv,compLst){
+	  dp_props->clearVal(sv);
+	}
+	compLst.clear();
+	dp_props->setVal(detail::computedPropName, compLst);
       }
-      compLst.clear();
-      dp_props->setVal(detail::computedPropName, compLst);
     }
 
     //! returns the perturbation order for a list of integers

--- a/Code/GraphMol/Canon.cpp
+++ b/Code/GraphMol/Canon.cpp
@@ -262,7 +262,7 @@ namespace Canon {
       firstFromAtom2->setBondDir(atom2Dir);
 
       // this block of code is no longer needed
-      // if(firstFromAtom2->hasProp("_TraversalRingClosureBond")){
+      // if(firstFromAtom2->hasProp(common_properties::_TraversalRingClosureBond)){
       //   // another nice one: we're traversing and come to a ring
       //   // closure bond that has directionality set. This is going to
       //   // have its direction swapped on writing so we need to
@@ -342,7 +342,7 @@ namespace Canon {
         // Here we set the bond direction to be opposite the other one (since
         // both come after the atom connected to the double bond).
         Bond::BondDir otherDir;
-        if(!secondFromAtom2->hasProp("_TraversalRingClosureBond")){
+        if(!secondFromAtom2->hasProp(common_properties::_TraversalRingClosureBond)){
           otherDir = (firstFromAtom2->getBondDir()==Bond::ENDUPRIGHT) ? Bond::ENDDOWNRIGHT : Bond::ENDUPRIGHT;
         } else {
           // another one those irritating little reversal things due to
@@ -374,7 +374,7 @@ namespace Canon {
       if( bondVisitOrders[atom1ControllingBond->getIdx()] >
           atomVisitOrders[atom1->getIdx()]){
         if(bondDirCounts[atom1ControllingBond->getIdx()]==1){
-          if(!atom1ControllingBond->hasProp("_TraversalRingClosureBond") ){
+          if(!atom1ControllingBond->hasProp(common_properties::_TraversalRingClosureBond) ){
             //std::cerr<<"  switcheroo 1"<<std::endl;
             switchBondDir(atom1ControllingBond);
           }
@@ -587,10 +587,10 @@ namespace Canon {
         travList.push_back(bIdx);
         Bond *bond = mol.getBondWithIdx(bIdx);
         seenFromHere.set(bond->getOtherAtomIdx(atomIdx));
-        if(bond->hasProp("_TraversalRingClosureBond")){
+        unsigned int ringIdx;
+        if(bond->getPropIfPresent(common_properties::_TraversalRingClosureBond, ringIdx)){
           // this is end of the ring closure
           // we can just pull the ring index from the bond itself:
-          unsigned int ringIdx=bond->getProp<unsigned int>("_TraversalRingClosureBond");
           molStack.push_back(MolStackElem(bond,atomIdx));
           bondVisitOrders[bIdx]=molStack.size();
           molStack.push_back(MolStackElem(ringIdx));
@@ -607,7 +607,7 @@ namespace Canon {
           unsigned int lowestRingIdx =  cAIt-cyclesAvailable.begin();
           cyclesAvailable[lowestRingIdx] = 0;
           ++lowestRingIdx;
-          bond->setProp("_TraversalRingClosureBond",lowestRingIdx);
+          bond->setProp(common_properties::_TraversalRingClosureBond,lowestRingIdx);
           molStack.push_back(MolStackElem(lowestRingIdx));
         }
       }
@@ -691,8 +691,8 @@ namespace Canon {
       unsigned int lowestRingIdx;
       INT_VECT::const_iterator cAIt;
       // ww might have some residual data from earlier calls, clean that up:
-      if(otherAtom->hasProp("_TraversalBondIndexOrder")){
-        otherAtom->clearProp("_TraversalBondIndexOrder");
+      if(otherAtom->hasProp(common_properties::_TraversalBondIndexOrder)){
+        otherAtom->clearProp(common_properties::_TraversalBondIndexOrder);
       }
       travList.push_back(bond->getIdx());
       if(possiblesIt+1 != possibles.end()){
@@ -903,7 +903,7 @@ namespace Canon {
     boost::dynamic_bitset<> ringStereoChemAdjusted(nAtoms);
     
     // make sure that we've done the stereo perception:
-    if(!mol.hasProp("_StereochemDone")){
+    if(!mol.hasProp(common_properties::_StereochemDone)){
       MolOps::assignStereochemistry(mol,false);
     }
 
@@ -924,7 +924,7 @@ namespace Canon {
     // used later in SMILES generation:
     for(ROMol::AtomIterator atomIt=mol.beginAtoms();atomIt!=mol.endAtoms();++atomIt){
       if((*atomIt)->getChiralTag()!=Atom::CHI_UNSPECIFIED){
-        (*atomIt)->setProp("_TraversalBondIndexOrder",atomTraversalBondOrder[(*atomIt)->getIdx()]);
+        (*atomIt)->setProp(common_properties::_TraversalBondIndexOrder,atomTraversalBondOrder[(*atomIt)->getIdx()]);
       }
     }
 
@@ -969,12 +969,12 @@ namespace Canon {
         }
       }
       if(msI->type == MOL_STACK_ATOM &&
-         msI->obj.atom->hasProp("_ringStereoAtoms")){
+         msI->obj.atom->hasProp(common_properties::_ringStereoAtoms)){
         if(!ringStereoChemAdjusted[msI->obj.atom->getIdx()]){
           msI->obj.atom->setChiralTag(Atom::CHI_TETRAHEDRAL_CW);
           ringStereoChemAdjusted.set(msI->obj.atom->getIdx());
         }
-        const INT_VECT &ringStereoAtoms=msI->obj.atom->getProp<INT_VECT>("_ringStereoAtoms");
+        const INT_VECT &ringStereoAtoms=msI->obj.atom->getProp<INT_VECT>(common_properties::_ringStereoAtoms);
         BOOST_FOREACH(int nbrV,ringStereoAtoms){
           int nbrIdx=abs(nbrV)-1;
           if(!ringStereoChemAdjusted[nbrIdx] &&

--- a/Code/GraphMol/ChemReactions/DaylightParser.cpp
+++ b/Code/GraphMol/ChemReactions/DaylightParser.cpp
@@ -47,20 +47,20 @@ namespace RDKit {
           prodIt!=rxn->endProductTemplates();++prodIt){
         for(ROMol::AtomIterator prodAtomIt=(*prodIt)->beginAtoms();
             prodAtomIt!=(*prodIt)->endAtoms();++prodAtomIt){
-          if(!(*prodAtomIt)->hasProp("molAtomMapNumber")){
+          int mapNum;
+          if(!(*prodAtomIt)->getPropIfPresent(common_properties::molAtomMapNumber, mapNum)){
             // if we have stereochemistry specified, it's automatically creating stereochem:
-            (*prodAtomIt)->setProp("molInversionFlag",4);
+            (*prodAtomIt)->setProp(common_properties::molInversionFlag,4);
             continue;
           } 
-          int mapNum;
-          (*prodAtomIt)->getProp("molAtomMapNumber",mapNum);
           for(MOL_SPTR_VECT::const_iterator reactIt=rxn->beginReactantTemplates();
               reactIt!=rxn->endReactantTemplates();++reactIt){
             for(ROMol::AtomIterator reactAtomIt=(*reactIt)->beginAtoms();
                 reactAtomIt!=(*reactIt)->endAtoms();++reactAtomIt){
-              if(!(*reactAtomIt)->hasProp("molAtomMapNumber")) continue;
               int reactMapNum;
-              (*reactAtomIt)->getProp("molAtomMapNumber",reactMapNum);
+              if(!(*reactAtomIt)->getPropIfPresent(common_properties::molAtomMapNumber,
+					       reactMapNum))
+                  continue;
               if(reactMapNum==mapNum){
                 // finally, in the bowels of the nesting, we get to some actual
                 // work:
@@ -70,22 +70,22 @@ namespace RDKit {
                      (*reactAtomIt)->getChiralTag()!=Atom::CHI_OTHER){
                     // both have stereochem specified:
                     if((*reactAtomIt)->getChiralTag()==(*prodAtomIt)->getChiralTag()){
-                      (*prodAtomIt)->setProp("molInversionFlag",2);
+                      (*prodAtomIt)->setProp(common_properties::molInversionFlag,2);
                     } else {
                       // FIX: this is technically fragile: it should be checking
                       // if the atoms both have tetrahedral chirality. However,
                       // at the moment that's the only chirality available, so there's
                       // no need to go monkeying around.
-                      (*prodAtomIt)->setProp("molInversionFlag",1);
+                      (*prodAtomIt)->setProp(common_properties::molInversionFlag,1);
                     }
                   } else {
                     // stereochem in the product, but not in the reactant
-                    (*prodAtomIt)->setProp("molInversionFlag",4);
+                    (*prodAtomIt)->setProp(common_properties::molInversionFlag,4);
                   }
                 } else if((*reactAtomIt)->getChiralTag()!=Atom::CHI_UNSPECIFIED &&
                           (*reactAtomIt)->getChiralTag()!=Atom::CHI_OTHER){
                   // stereochem in the reactant, but not the product:
-                  (*prodAtomIt)->setProp("molInversionFlag",3);                  
+                  (*prodAtomIt)->setProp(common_properties::molInversionFlag,3);                  
                 }
               }
             }

--- a/Code/GraphMol/ChemReactions/MoleculeParser.cpp
+++ b/Code/GraphMol/ChemReactions/MoleculeParser.cpp
@@ -42,7 +42,9 @@ bool testForSameRXNRoleOfAllMoleculeAtoms(const RDKit::ROMol &mol, int role)
   RDKit::ROMol::ATOM_ITER_PAIR atItP = mol.getVertices();
   while(atItP.first != atItP.second ){
     const RDKit::Atom *oAtom=mol[*(atItP.first++)].get();
-    if(oAtom->hasProp("molRxnRole") && oAtom->getProp<int>("molRxnRole")!=role){
+    int current_role;
+    if(oAtom->getPropIfPresent(RDKit::common_properties::molRxnRole, current_role) &&
+       current_role!=role){
   	  return false;
     }
   }
@@ -54,8 +56,9 @@ int getRXNRoleOfMolecule(const RDKit::ROMol &mol)
   RDKit::ROMol::ATOM_ITER_PAIR atItP = mol.getVertices();
   while(atItP.first != atItP.second ){
     const RDKit::Atom *oAtom=mol[*(atItP.first++)].get();
-    if(oAtom->hasProp("molRxnRole")){
-  	  return oAtom->getProp<int>("molRxnRole");
+    int molRxnRole;
+    if(oAtom->getPropIfPresent(RDKit::common_properties::molRxnRole, molRxnRole)){
+      return molRxnRole;
     }
   }
   return -1;

--- a/Code/GraphMol/ChemReactions/Reaction.cpp
+++ b/Code/GraphMol/ChemReactions/Reaction.cpp
@@ -95,10 +95,9 @@ namespace RDKit {
       bool thisMolMapped=false;
       for(ROMol::AtomIterator atomIt=(*molIter)->beginAtoms();
           atomIt!=(*molIter)->endAtoms();++atomIt){
-        if((*atomIt)->hasProp("molAtomMapNumber")){
+	    int mapNum;
+        if((*atomIt)->getPropIfPresent(common_properties::molAtomMapNumber, mapNum)){
           thisMolMapped=true;
-          int mapNum;
-          (*atomIt)->getProp("molAtomMapNumber",mapNum);
           if(std::find(mapNumbersSeen.begin(),mapNumbersSeen.end(),mapNum)!=mapNumbersSeen.end()){
             if(!silent){
               BOOST_LOG(rdErrorLog)<<"reactant atom-mapping number "<<mapNum<<" found multiple times.\n";
@@ -129,22 +128,21 @@ namespace RDKit {
       // misleading warnings
       for(ROMol::AtomIterator atomIt=(*molIter)->beginAtoms();
           atomIt!=(*molIter)->endAtoms();++atomIt){
-        if((*atomIt)->hasProp("_QueryFormalCharge"))
-          (*atomIt)->clearProp("_QueryFormalCharge");
-        if((*atomIt)->hasProp("_QueryHCount"))
-          (*atomIt)->clearProp("_QueryHCount");
-        if((*atomIt)->hasProp("_QueryMass"))
-          (*atomIt)->clearProp("_QueryMass");
-        if((*atomIt)->hasProp("_QueryIsotope"))
-          (*atomIt)->clearProp("_QueryIsotope");
+        if((*atomIt)->hasProp(common_properties::_QueryFormalCharge))
+          (*atomIt)->clearProp(common_properties::_QueryFormalCharge);
+        if((*atomIt)->hasProp(common_properties::_QueryHCount))
+          (*atomIt)->clearProp(common_properties::_QueryHCount);
+        if((*atomIt)->hasProp(common_properties::_QueryMass))
+          (*atomIt)->clearProp(common_properties::_QueryMass);
+        if((*atomIt)->hasProp(common_properties::_QueryIsotope))
+          (*atomIt)->clearProp(common_properties::_QueryIsotope);
       }
       bool thisMolMapped=false;
       for(ROMol::AtomIterator atomIt=(*molIter)->beginAtoms();
           atomIt!=(*molIter)->endAtoms();++atomIt){
-        if((*atomIt)->hasProp("molAtomMapNumber")){
+	    int mapNum;
+        if((*atomIt)->getPropIfPresent(common_properties::molAtomMapNumber, mapNum)){
           thisMolMapped=true;
-          int mapNum;
-          (*atomIt)->getProp("molAtomMapNumber",mapNum);
           bool seenAlready=std::find(productNumbersSeen.begin(),
                                      productNumbersSeen.end(),mapNum)!=productNumbersSeen.end();
           if(seenAlready){
@@ -158,7 +156,7 @@ namespace RDKit {
             const Atom *rAtom=reactingAtoms[mapNum];
             CHECK_INVARIANT(rAtom,"missing atom");
             if(rAtom->getDegree()!=(*atomIt)->getDegree()){
-              (*atomIt)->setProp("_ReactionDegreeChanged",1);
+              (*atomIt)->setProp(common_properties::_ReactionDegreeChanged,1);
             }
 
           } else {
@@ -182,7 +180,7 @@ namespace RDKit {
             const Atom *rAtom=reactingAtoms[mapNum];
             CHECK_INVARIANT(rAtom,"missing atom");
             if(rAtom->getDegree()!=(*atomIt)->getDegree()){
-              (*atomIt)->setProp("_ReactionDegreeChanged",1);
+              (*atomIt)->setProp(common_properties::_ReactionDegreeChanged,1);
             }
           }
         }
@@ -201,47 +199,47 @@ namespace RDKit {
               queries.push_back((*qIter).get());
             }
             if(query->getDescription()=="AtomFormalCharge"){
-              if((*atomIt)->hasProp("_QueryFormalCharge")){
+              if((*atomIt)->hasProp(common_properties::_QueryFormalCharge)){
                 if(!silent){
                   BOOST_LOG(rdWarningLog)<<"atom "<<(*atomIt)->getIdx()<<" in product " 
                                          << molIdx << " has multiple charge specifications.\n";
                 }
                 numWarnings++;
               } else {
-                (*atomIt)->setProp("_QueryFormalCharge",
+                (*atomIt)->setProp(common_properties::_QueryFormalCharge,
                                    ((const ATOM_EQUALS_QUERY *)query)->getVal());
               }
             } else if(query->getDescription()=="AtomHCount"){
-              if((*atomIt)->hasProp("_QueryHCount")){
+              if((*atomIt)->hasProp(common_properties::_QueryHCount)){
                 if(!silent){
                   BOOST_LOG(rdWarningLog)<<"atom "<<(*atomIt)->getIdx()<<" in product " 
                                          << molIdx << " has multiple H count specifications.\n";
                 }
                 numWarnings++;
               } else {
-                (*atomIt)->setProp("_QueryHCount",
+                (*atomIt)->setProp(common_properties::_QueryHCount,
                                    ((const ATOM_EQUALS_QUERY *)query)->getVal());
               }
             } else if(query->getDescription()=="AtomMass"){
-              if((*atomIt)->hasProp("_QueryMass")){
+              if((*atomIt)->hasProp(common_properties::_QueryMass)){
                 if(!silent) {
                   BOOST_LOG(rdWarningLog)<<"atom "<<(*atomIt)->getIdx()<<" in product " 
                                          << molIdx << " has multiple mass specifications.\n";
                 }
                 numWarnings++;
               } else {
-                (*atomIt)->setProp("_QueryMass",
+                (*atomIt)->setProp(common_properties::_QueryMass,
                                    ((const ATOM_EQUALS_QUERY *)query)->getVal()/massIntegerConversionFactor);
               }
             } else if(query->getDescription()=="AtomIsotope"){
-              if((*atomIt)->hasProp("_QueryIsotope")){
+              if((*atomIt)->hasProp(common_properties::_QueryIsotope)){
                 if(!silent) {
                   BOOST_LOG(rdWarningLog)<<"atom "<<(*atomIt)->getIdx()<<" in product " 
                                          << molIdx << " has multiple isotope specifications.\n";
                 }
                 numWarnings++;
               } else {
-                (*atomIt)->setProp("_QueryIsotope",
+                (*atomIt)->setProp(common_properties::_QueryIsotope,
                                    ((const ATOM_EQUALS_QUERY *)query)->getVal());
               }
             }
@@ -433,9 +431,8 @@ namespace RDKit {
       boost::tie(nbrIdx,endNbrs) = rAtom.getOwningMol().getAtomNeighbors(&rAtom);
       while(nbrIdx!=endNbrs){
         const ATOM_SPTR nbr=rAtom.getOwningMol()[*nbrIdx];
-        if(nbr->hasProp("molAtomMapNumber")){
-          int mapNum;
-          nbr->getProp("molAtomMapNumber",mapNum);
+	    int mapNum;
+        if(nbr->getPropIfPresent(common_properties::molAtomMapNumber, mapNum)){
           reactantBonds[mapNum]=rAtom.getOwningMol().getBondBetweenAtoms(rAtom.getIdx(),
                                                                          nbr->getIdx());
         } else {
@@ -447,9 +444,8 @@ namespace RDKit {
       boost::tie(nbrIdx,endNbrs) = pAtom.getOwningMol().getAtomNeighbors(&pAtom);
       while(nbrIdx!=endNbrs){
         const ATOM_SPTR nbr=pAtom.getOwningMol()[*nbrIdx];
-        if(nbr->hasProp("molAtomMapNumber")){
-          int mapNum;
-          nbr->getProp("molAtomMapNumber",mapNum);
+	    int mapNum;
+        if(nbr->getPropIfPresent(common_properties::molAtomMapNumber, mapNum)){
           // if we don't have a bond to a similarly mapped atom in the reactant,
           // we're done:
           if(reactantBonds.find(mapNum)==reactantBonds.end()){
@@ -517,9 +513,8 @@ namespace RDKit {
       while(atItP.first != atItP.second ){
         const Atom *oAtom=(*rIt)[*(atItP.first++)].get();
         // we only worry about mapped atoms:
-        if(oAtom->hasProp("molAtomMapNumber")){
-          int mapNum;
-          oAtom->getProp("molAtomMapNumber",mapNum);
+	    int mapNum;
+        if(oAtom->getPropIfPresent(common_properties::molAtomMapNumber, mapNum)){
           mappedAtoms[mapNum]=oAtom;
         } else {
           // unmapped atom, return it
@@ -553,14 +548,13 @@ namespace RDKit {
       while(atItP.first != atItP.second ){
         const Atom *oAtom=(**rIt)[*(atItP.first++)].get();
         // unmapped atoms are definitely changing:
-        if(!oAtom->hasProp("molAtomMapNumber")){
+	    int mapNum;
+        if(!oAtom->getPropIfPresent(common_properties::molAtomMapNumber, mapNum)){
           if(!mappedAtomsOnly){
             resIt->push_back(oAtom->getIdx());
           }
         } else {
           // but mapped ones require more careful consideration
-          int mapNum;
-          oAtom->getProp("molAtomMapNumber",mapNum);
           // if this is found in a reactant:
           if(mappedProductAtoms.find(mapNum)!=mappedProductAtoms.end()){
             if( isChangedAtom(*oAtom,*(mappedProductAtoms[mapNum]),

--- a/Code/GraphMol/ChemReactions/Reaction.h
+++ b/Code/GraphMol/ChemReactions/Reaction.h
@@ -86,7 +86,7 @@ namespace RDKit{
 
      NOTES:
        - to allow more control over the reaction, it is possible to flag reactant
-         atoms as being protected by setting the "_protected" property on those
+         atoms as being protected by setting the common_properties::_protected property on those
          atoms. Here's an example:
          \verbatim
             std::string smi="[O:1]>>[N:1]";
@@ -103,7 +103,7 @@ namespace RDKit{
             // here prods has two entries, because there are two Os in the
             // reactant. 
 
-            reacts[0]->getAtomWithIdx(0)->setProp("_protected",1);
+            reacts[0]->getAtomWithIdx(0)->setProp(common_properties::_protected,1);
             prods = rxn->runReactants(reacts);
             // here prods only has one entry, the reaction at atom 0
             // has been blocked by the _protected property

--- a/Code/GraphMol/ChemReactions/ReactionParser.h
+++ b/Code/GraphMol/ChemReactions/ReactionParser.h
@@ -81,7 +81,7 @@ namespace RDKit{
   //! Parse a ROMol into a ChemicalReaction, RXN role must be set before
   /*!
      Alternative to build a reaction from a molecule (fragments) which have RXN roles
-     set as atom properties: "molRxnRole" (1=reactant, 2=product, 3=agent) 
+     set as atom properties: common_properties::molRxnRole (1=reactant, 2=product, 3=agent) 
 
      \param mol           ROMol with RXN roles set
    */

--- a/Code/GraphMol/ChemReactions/ReactionRunner.cpp
+++ b/Code/GraphMol/ChemReactions/ReactionRunner.cpp
@@ -84,7 +84,7 @@ namespace RDKit {
           bool keep=true;
           int pIdx,mIdx;
           BOOST_FOREACH(boost::tie(pIdx,mIdx),match){
-            if(reactants[i]->getAtomWithIdx(mIdx)->hasProp("_protected")){
+            if(reactants[i]->getAtomWithIdx(mIdx)->hasProp(common_properties::_protected)){
               keep=false;
               break;
             }
@@ -131,14 +131,14 @@ namespace RDKit {
         // return
         return;
       }
-      if(!prodAtom->hasProp("_QueryFormalCharge")){
+      if(!prodAtom->hasProp(common_properties::_QueryFormalCharge)){
         prodAtom->setFormalCharge(reactAtom->getFormalCharge());
       }
-      if(!prodAtom->hasProp("_QueryIsotope")){
+      if(!prodAtom->hasProp(common_properties::_QueryIsotope)){
         prodAtom->setIsotope(reactAtom->getIsotope());
       }
-      if(!prodAtom->hasProp("_ReactionDegreeChanged")){
-        if(!prodAtom->hasProp("_QueryHCount")){
+      if(!prodAtom->hasProp(common_properties::_ReactionDegreeChanged)){
+        if(!prodAtom->hasProp(common_properties::_QueryHCount)){
           prodAtom->setNumExplicitHs(reactAtom->getNumExplicitHs());
         }
         prodAtom->setNoImplicit(reactAtom->getNoImplicit());
@@ -169,45 +169,36 @@ namespace RDKit {
         Atom *oAtom=(*prodTemplate)[*(atItP.first++)].get();
         Atom *newAtom=new Atom(*oAtom);
         res->addAtom(newAtom,false,true);
-        if(newAtom->hasProp("molAtomMapNumber")){
+        int mapNum;
+        if(newAtom->getPropIfPresent(common_properties::molAtomMapNumber, mapNum)){
           // set bookmarks for the mapped atoms:
-          int mapNum;
-          newAtom->getProp("molAtomMapNumber",mapNum);
           res->setAtomBookmark(newAtom,mapNum);
           // now clear the molAtomMapNumber property so that it doesn't
           // end up in the products (this was bug 3140490):
-          newAtom->clearProp("molAtomMapNumber");
+          newAtom->clearProp(common_properties::molAtomMapNumber);
         }
 
         newAtom->setChiralTag(Atom::CHI_UNSPECIFIED);
         // if the product-template atom has the inversion flag set
         // to 4 (=SET), then bring its stereochem over, otherwise we'll
         // ignore it:
-        if(oAtom->hasProp("molInversionFlag")){
-          int iFlag;
-          oAtom->getProp("molInversionFlag",iFlag);
+        int iFlag;
+        if(oAtom->getPropIfPresent(common_properties::molInversionFlag, iFlag)){
           if(iFlag==4) newAtom->setChiralTag(oAtom->getChiralTag());
         }
 
         // check for properties we need to set:
-        if(newAtom->hasProp("_QueryFormalCharge")){
-          int val;
-          newAtom->getProp("_QueryFormalCharge",val);
+        int val;
+        if(newAtom->getPropIfPresent(common_properties::_QueryFormalCharge, val)){
           newAtom->setFormalCharge(val);
         }
-        if(newAtom->hasProp("_QueryHCount")){
-          int val;
-          newAtom->getProp("_QueryHCount",val);
+        if(newAtom->getPropIfPresent(common_properties::_QueryHCount, val)){
           newAtom->setNumExplicitHs(val);
         }
-        if(newAtom->hasProp("_QueryMass")){
-          int val;
-          newAtom->getProp("_QueryMass",val);
+        if(newAtom->getPropIfPresent(common_properties::_QueryMass, val)){
           newAtom->setMass(val);
         }
-        if(newAtom->hasProp("_QueryIsotope")){
-          int val;
-          newAtom->getProp("_QueryIsotope",val);
+        if(newAtom->getPropIfPresent(common_properties::_QueryIsotope, val)){
           newAtom->setIsotope(val);
         }
       }
@@ -241,7 +232,7 @@ namespace RDKit {
               newB->setIsAromatic(false);
             }
           } else if(queryDescription=="BondNull") {
-            newB->setProp("NullBond",1);
+            newB->setProp(common_properties::NullBond,1);
           }
         }
       }
@@ -269,10 +260,8 @@ namespace RDKit {
       ReactantProductAtomMapping *mapping = new ReactantProductAtomMapping(numReactAtoms);
       for(unsigned int i=0;i<match.size();i++){
         const Atom *templateAtom=reactantTemplate.getAtomWithIdx(match[i].first);
-        if(templateAtom->hasProp("molAtomMapNumber")){
-          int molAtomMapNumber;
-          templateAtom->getProp("molAtomMapNumber",molAtomMapNumber);
-
+	    int molAtomMapNumber;
+        if(templateAtom->getPropIfPresent(common_properties::molAtomMapNumber, molAtomMapNumber)){
           if(product->hasAtomBookmark(molAtomMapNumber)){
         	RWMol::ATOM_PTR_LIST atomIdxs = product->getAllAtomsWithBookmark(molAtomMapNumber);
         	for(RWMol::ATOM_PTR_LIST::iterator iter = atomIdxs.begin();
@@ -306,7 +295,7 @@ namespace RDKit {
       while(bondItP.first != bondItP.second ){
         BOND_SPTR pBond=(*product)[*(bondItP.first)];
         ++bondItP.first;
-        if(pBond->hasProp("NullBond")){
+        if(pBond->hasProp(common_properties::NullBond)){
           if(mapping->prodReactAtomMap.find(pBond->getBeginAtomIdx())!=mapping->prodReactAtomMap.end() &&
         	  mapping->prodReactAtomMap.find(pBond->getEndAtomIdx())!=mapping->prodReactAtomMap.end() ){
             // the bond is between two mapped atoms from this reactant:
@@ -317,7 +306,7 @@ namespace RDKit {
             pBond->setBondType(rBond->getBondType());
             pBond->setBondDir(rBond->getBondDir());
             pBond->setIsAromatic(rBond->getIsAromatic());
-            pBond->clearProp("NullBond");
+            pBond->clearProp(common_properties::NullBond);
           }
         }
       }
@@ -326,7 +315,7 @@ namespace RDKit {
     void checkProductChirality(Atom::ChiralType reactantChirality, Atom *productAtom)
     {
       int flagVal;
-      productAtom->getProp("molInversionFlag",flagVal);
+      productAtom->getProp(common_properties::molInversionFlag,flagVal);
 
       switch(flagVal){
       case 0:
@@ -372,8 +361,8 @@ namespace RDKit {
         productAtom->setIsotope(reactantAtom.getIsotope());
 
         // remove dummy labels (if present)
-        if(productAtom->hasProp("dummyLabel")) productAtom->clearProp("dummyLabel");
-        if(productAtom->hasProp("_MolFileRLabel")) productAtom->clearProp("_MolFileRLabel");
+        if(productAtom->hasProp(common_properties::dummyLabel)) productAtom->clearProp(common_properties::dummyLabel);
+        if(productAtom->hasProp(common_properties::_MolFileRLabel)) productAtom->clearProp(common_properties::_MolFileRLabel);
       }
       if(setImplicitProperties){
         updateImplicitAtomProperties(productAtom,&reactantAtom);
@@ -388,7 +377,7 @@ namespace RDKit {
       // FIX: this should be free-standing, not in this function.
       if(reactantAtom.getChiralTag()!=Atom::CHI_UNSPECIFIED &&
          reactantAtom.getChiralTag()!=Atom::CHI_OTHER &&
-         productAtom->hasProp("molInversionFlag")){
+         productAtom->hasProp(common_properties::molInversionFlag)){
         checkProductChirality(reactantAtom.getChiralTag(), productAtom);
       }
     }
@@ -517,7 +506,7 @@ namespace RDKit {
         if(productAtom->getChiralTag() != Atom::CHI_UNSPECIFIED ||
            reactantAtom.getChiralTag() == Atom::CHI_UNSPECIFIED ||
            reactantAtom.getChiralTag() == Atom::CHI_OTHER ||
-           productAtom->hasProp("molInversionFlag")){
+           productAtom->hasProp(common_properties::molInversionFlag)){
         	continue;
         }
         // we can only do something sensible here if we have the same number of bonds

--- a/Code/GraphMol/ChemReactions/ReactionUtils.cpp
+++ b/Code/GraphMol/ChemReactions/ReactionUtils.cpp
@@ -153,7 +153,7 @@ bool hasReactionAtomMapping(const ChemicalReaction &rxn)
   RDKit::MOL_SPTR_VECT::const_iterator end = getEndIterator(rxn, Reactant);
   for(; begin != end; ++begin){
     const ROMol &reactant = *begin->get();
-    if(MolOps::getNumAtomsWithDistinctProperty(reactant, "molAtomMapNumber")){
+    if(MolOps::getNumAtomsWithDistinctProperty(reactant, common_properties::molAtomMapNumber)){
       return true;
     }
   }
@@ -161,7 +161,7 @@ bool hasReactionAtomMapping(const ChemicalReaction &rxn)
   end = getEndIterator(rxn, Product);
   for(; begin != end; ++begin){
     const ROMol &reactant = *begin->get();
-    if(MolOps::getNumAtomsWithDistinctProperty(reactant, "molAtomMapNumber")){
+    if(MolOps::getNumAtomsWithDistinctProperty(reactant, common_properties::molAtomMapNumber)){
       return true;
     }
   }
@@ -170,7 +170,7 @@ bool hasReactionAtomMapping(const ChemicalReaction &rxn)
 
 bool isReactionTemplateMoleculeAgent(const ROMol &mol, double agentThreshold)
 {
-  unsigned numMappedAtoms = MolOps::getNumAtomsWithDistinctProperty(mol, "molAtomMapNumber");
+  unsigned numMappedAtoms = MolOps::getNumAtomsWithDistinctProperty(mol, common_properties::molAtomMapNumber);
   unsigned numAtoms = mol.getNumHeavyAtoms();
   if(numAtoms > 0 &&
        static_cast<double>(numMappedAtoms)/static_cast<double>(numAtoms) >= agentThreshold){

--- a/Code/GraphMol/ChemReactions/ReactionWriter.cpp
+++ b/Code/GraphMol/ChemReactions/ReactionWriter.cpp
@@ -44,7 +44,7 @@ void setRXNRoleOfAllMoleculeAtoms(RDKit::ROMol &mol, int role)
   RDKit::ROMol::ATOM_ITER_PAIR atItP = mol.getVertices();
   while(atItP.first != atItP.second ){
     RDKit::Atom *oAtom=mol[*(atItP.first++)].get();
-  	oAtom->setProp("molRxnRole", role);
+  	oAtom->setProp(RDKit::common_properties::molRxnRole, role);
   }
 }
 

--- a/Code/GraphMol/ChemReactions/testReaction.cpp
+++ b/Code/GraphMol/ChemReactions/testReaction.cpp
@@ -1418,7 +1418,7 @@ void test14Issue1804420(){
   TEST_ASSERT(rxn->getNumReactantTemplates()==1);
   TEST_ASSERT(rxn->getNumProductTemplates()==2);
 
-  TEST_ASSERT((*rxn->beginReactantTemplates())->getAtomWithIdx(0)->hasProp("molAtomMapNumber"));
+  TEST_ASSERT((*rxn->beginReactantTemplates())->getAtomWithIdx(0)->hasProp(common_properties::molAtomMapNumber));
   
   reacts.clear();
   smi = "C1CCN1CCC";
@@ -1692,8 +1692,8 @@ void test17Issue1920627(){
   mol = SmilesToMol(smi);
   TEST_ASSERT(mol);
   MolOps::assignStereochemistry(*mol);
-  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  mol->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  mol->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="R");
   
   reacts.push_back(ROMOL_SPTR(mol));
@@ -1705,8 +1705,8 @@ void test17Issue1920627(){
   MolOps::sanitizeMol(*(static_cast<RWMol *>(prod.get())));
   MolOps::assignStereochemistry(*prod);
   TEST_ASSERT(prod->getNumAtoms()==10);
-  TEST_ASSERT(prod->getAtomWithIdx(4)->hasProp("_CIPCode"));
-  prod->getAtomWithIdx(4)->getProp("_CIPCode",cip);
+  TEST_ASSERT(prod->getAtomWithIdx(4)->hasProp(common_properties::_CIPCode));
+  prod->getAtomWithIdx(4)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="R");
   
   reacts.clear();
@@ -1714,8 +1714,8 @@ void test17Issue1920627(){
   mol = SmilesToMol(smi);
   TEST_ASSERT(mol);
   MolOps::assignStereochemistry(*mol);
-  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  mol->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  mol->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="S");
   
   reacts.push_back(ROMOL_SPTR(mol));
@@ -1726,8 +1726,8 @@ void test17Issue1920627(){
   MolOps::sanitizeMol(*(static_cast<RWMol *>(prod.get())));
   MolOps::assignStereochemistry(*prod);
   TEST_ASSERT(prod->getNumAtoms()==9);
-  TEST_ASSERT(prod->getAtomWithIdx(4)->hasProp("_CIPCode"));
-  prod->getAtomWithIdx(4)->getProp("_CIPCode",cip);
+  TEST_ASSERT(prod->getAtomWithIdx(4)->hasProp(common_properties::_CIPCode));
+  prod->getAtomWithIdx(4)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="S");
   
   // make sure the above two tests work "backwards":
@@ -1736,8 +1736,8 @@ void test17Issue1920627(){
   mol = SmilesToMol(smi);
   TEST_ASSERT(mol);
   MolOps::assignStereochemistry(*mol);
-  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  mol->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  mol->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="S");
   
   reacts.push_back(ROMOL_SPTR(mol));
@@ -1748,8 +1748,8 @@ void test17Issue1920627(){
   MolOps::sanitizeMol(*(static_cast<RWMol *>(prod.get())));
   MolOps::assignStereochemistry(*prod);
   TEST_ASSERT(prod->getNumAtoms()==10);
-  TEST_ASSERT(prod->getAtomWithIdx(4)->hasProp("_CIPCode"));
-  prod->getAtomWithIdx(4)->getProp("_CIPCode",cip);
+  TEST_ASSERT(prod->getAtomWithIdx(4)->hasProp(common_properties::_CIPCode));
+  prod->getAtomWithIdx(4)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="S");
   
   reacts.clear();
@@ -1757,8 +1757,8 @@ void test17Issue1920627(){
   mol = SmilesToMol(smi);
   TEST_ASSERT(mol);
   MolOps::assignStereochemistry(*mol);
-  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  mol->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  mol->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="R");
   reacts.push_back(ROMOL_SPTR(mol));
   prods = rxn->runReactants(reacts);
@@ -1768,8 +1768,8 @@ void test17Issue1920627(){
   MolOps::sanitizeMol(*(static_cast<RWMol *>(prod.get())));
   MolOps::assignStereochemistry(*prod);
   TEST_ASSERT(prod->getNumAtoms()==9);
-  TEST_ASSERT(prod->getAtomWithIdx(4)->hasProp("_CIPCode"));
-  prod->getAtomWithIdx(4)->getProp("_CIPCode",cip);
+  TEST_ASSERT(prod->getAtomWithIdx(4)->hasProp(common_properties::_CIPCode));
+  prod->getAtomWithIdx(4)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="R");
 
   // do some "restructuring" and make sure things still work:
@@ -1778,8 +1778,8 @@ void test17Issue1920627(){
   mol = SmilesToMol(smi);
   TEST_ASSERT(mol);
   MolOps::assignStereochemistry(*mol);
-  TEST_ASSERT(mol->getAtomWithIdx(0)->hasProp("_CIPCode"));
-  mol->getAtomWithIdx(0)->getProp("_CIPCode",cip);
+  TEST_ASSERT(mol->getAtomWithIdx(0)->hasProp(common_properties::_CIPCode));
+  mol->getAtomWithIdx(0)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="S");
   
   reacts.push_back(ROMOL_SPTR(mol));
@@ -1790,8 +1790,8 @@ void test17Issue1920627(){
   MolOps::sanitizeMol(*(static_cast<RWMol *>(prod.get())));
   MolOps::assignStereochemistry(*prod);
   TEST_ASSERT(prod->getNumAtoms()==10);
-  TEST_ASSERT(prod->getAtomWithIdx(4)->hasProp("_CIPCode"));
-  prod->getAtomWithIdx(4)->getProp("_CIPCode",cip);
+  TEST_ASSERT(prod->getAtomWithIdx(4)->hasProp(common_properties::_CIPCode));
+  prod->getAtomWithIdx(4)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="S");
   
   reacts.clear();
@@ -1799,8 +1799,8 @@ void test17Issue1920627(){
   mol = SmilesToMol(smi);
   TEST_ASSERT(mol);
   MolOps::assignStereochemistry(*mol);
-  TEST_ASSERT(mol->getAtomWithIdx(0)->hasProp("_CIPCode"));
-  mol->getAtomWithIdx(0)->getProp("_CIPCode",cip);
+  TEST_ASSERT(mol->getAtomWithIdx(0)->hasProp(common_properties::_CIPCode));
+  mol->getAtomWithIdx(0)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="R");
   
   reacts.push_back(ROMOL_SPTR(mol));
@@ -1811,8 +1811,8 @@ void test17Issue1920627(){
   MolOps::sanitizeMol(*(static_cast<RWMol *>(prod.get())));
   MolOps::assignStereochemistry(*prod);
   TEST_ASSERT(prod->getNumAtoms()==9);
-  TEST_ASSERT(prod->getAtomWithIdx(4)->hasProp("_CIPCode"));
-  prod->getAtomWithIdx(4)->getProp("_CIPCode",cip);
+  TEST_ASSERT(prod->getAtomWithIdx(4)->hasProp(common_properties::_CIPCode));
+  prod->getAtomWithIdx(4)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="R");
 #endif
 
@@ -1821,8 +1821,8 @@ void test17Issue1920627(){
   mol = SmilesToMol(smi);
   TEST_ASSERT(mol);
   MolOps::assignStereochemistry(*mol);
-  TEST_ASSERT(mol->getAtomWithIdx(3)->hasProp("_CIPCode"));
-  mol->getAtomWithIdx(3)->getProp("_CIPCode",cip);
+  TEST_ASSERT(mol->getAtomWithIdx(3)->hasProp(common_properties::_CIPCode));
+  mol->getAtomWithIdx(3)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="R");
   
   reacts.push_back(ROMOL_SPTR(mol));
@@ -1833,8 +1833,8 @@ void test17Issue1920627(){
   MolOps::sanitizeMol(*(static_cast<RWMol *>(prod.get())));
   MolOps::assignStereochemistry(*prod);
   TEST_ASSERT(prod->getNumAtoms()==7);
-  TEST_ASSERT(prod->getAtomWithIdx(3)->hasProp("_CIPCode"));
-  prod->getAtomWithIdx(3)->getProp("_CIPCode",cip);
+  TEST_ASSERT(prod->getAtomWithIdx(3)->hasProp(common_properties::_CIPCode));
+  prod->getAtomWithIdx(3)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="R");
 
   reacts.clear();
@@ -1842,8 +1842,8 @@ void test17Issue1920627(){
   mol = SmilesToMol(smi);
   TEST_ASSERT(mol);
   MolOps::assignStereochemistry(*mol);
-  TEST_ASSERT(mol->getAtomWithIdx(3)->hasProp("_CIPCode"));
-  mol->getAtomWithIdx(3)->getProp("_CIPCode",cip);
+  TEST_ASSERT(mol->getAtomWithIdx(3)->hasProp(common_properties::_CIPCode));
+  mol->getAtomWithIdx(3)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="R");
   
   reacts.push_back(ROMOL_SPTR(mol));
@@ -1854,8 +1854,8 @@ void test17Issue1920627(){
   MolOps::sanitizeMol(*(static_cast<RWMol *>(prod.get())));
   MolOps::assignStereochemistry(*prod);
   TEST_ASSERT(prod->getNumAtoms()==7);
-  TEST_ASSERT(prod->getAtomWithIdx(3)->hasProp("_CIPCode"));
-  prod->getAtomWithIdx(3)->getProp("_CIPCode",cip);
+  TEST_ASSERT(prod->getAtomWithIdx(3)->hasProp(common_properties::_CIPCode));
+  prod->getAtomWithIdx(3)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="R");
   
   delete rxn;
@@ -2463,9 +2463,9 @@ void test24AtomFlags(){
     TEST_ASSERT(rxn->validate(nWarn,nError,false));
     TEST_ASSERT(nWarn==0);
     TEST_ASSERT(nError==0);
-    TEST_ASSERT(rxn->beginReactantTemplates()->get()->getAtomWithIdx(0)->hasProp("molAtomMapNumber"));
-    TEST_ASSERT((++(rxn->beginReactantTemplates()))->get()->getAtomWithIdx(0)->hasProp("molAtomMapNumber"));
-    TEST_ASSERT((++(rxn->beginReactantTemplates()))->get()->getAtomWithIdx(1)->hasProp("molAtomMapNumber"));
+    TEST_ASSERT(rxn->beginReactantTemplates()->get()->getAtomWithIdx(0)->hasProp(common_properties::molAtomMapNumber));
+    TEST_ASSERT((++(rxn->beginReactantTemplates()))->get()->getAtomWithIdx(0)->hasProp(common_properties::molAtomMapNumber));
+    TEST_ASSERT((++(rxn->beginReactantTemplates()))->get()->getAtomWithIdx(1)->hasProp(common_properties::molAtomMapNumber));
     
     delete rxn;
   }
@@ -3109,8 +3109,8 @@ void test31Issue3140490(){
     prods = rxn->runReactants(reacts);
     TEST_ASSERT(prods.size()==1);
     TEST_ASSERT(prods[0].size()==1);
-    TEST_ASSERT(!prods[0][0]->getAtomWithIdx(0)->hasProp("molAtomMapNumber"));
-    TEST_ASSERT(!prods[0][0]->getAtomWithIdx(1)->hasProp("molAtomMapNumber"));
+    TEST_ASSERT(!prods[0][0]->getAtomWithIdx(0)->hasProp(common_properties::molAtomMapNumber));
+    TEST_ASSERT(!prods[0][0]->getAtomWithIdx(1)->hasProp(common_properties::molAtomMapNumber));
     delete(rxn);
   }
   BOOST_LOG(rdInfoLog) << "\tdone" << std::endl;
@@ -3611,7 +3611,7 @@ void test37ProtectOption(){
     TEST_ASSERT(prods[0].size()==1);
     TEST_ASSERT(prods[1].size()==1);
 
-    reacts[0]->getAtomWithIdx(0)->setProp("_protected",1);
+    reacts[0]->getAtomWithIdx(0)->setProp(common_properties::_protected,1);
     prods = rxn->runReactants(reacts);
     TEST_ASSERT(prods.size()==1);
     TEST_ASSERT(prods[0].size()==1);
@@ -4049,13 +4049,13 @@ void test43Github243(){
     TEST_ASSERT(prods.size()==1);
     TEST_ASSERT(prods[0].size()==1);
     TEST_ASSERT(prods[0][0]->getAtomWithIdx(9)->getAtomicNum()==6);
-    TEST_ASSERT(!prods[0][0]->getAtomWithIdx(9)->hasProp("dummyLabel"));
-    TEST_ASSERT(!prods[0][0]->getAtomWithIdx(9)->hasProp("_MolFileRLabel"));
+    TEST_ASSERT(!prods[0][0]->getAtomWithIdx(9)->hasProp(common_properties::dummyLabel));
+    TEST_ASSERT(!prods[0][0]->getAtomWithIdx(9)->hasProp(common_properties::_MolFileRLabel));
     TEST_ASSERT(prods[0][0]->getAtomWithIdx(9)->getIsotope()==0);
 
     TEST_ASSERT(prods[0][0]->getAtomWithIdx(10)->getAtomicNum()==0);
-    TEST_ASSERT(prods[0][0]->getAtomWithIdx(10)->hasProp("dummyLabel"));
-    TEST_ASSERT(prods[0][0]->getAtomWithIdx(10)->hasProp("_MolFileRLabel"));
+    TEST_ASSERT(prods[0][0]->getAtomWithIdx(10)->hasProp(common_properties::dummyLabel));
+    TEST_ASSERT(prods[0][0]->getAtomWithIdx(10)->hasProp(common_properties::_MolFileRLabel));
 
     delete(rxn);
   }
@@ -4394,10 +4394,10 @@ void test47TestReactionMoleculeConversion(){
 
     ROMol* mol = ChemicalReactionToRxnMol(*rxn);
 
-    TEST_ASSERT(mol->getAtomWithIdx(0)->hasProp("molRxnRole"));
-    TEST_ASSERT(mol->getAtomWithIdx(0)->getProp<int>("molRxnRole")==1);
-    TEST_ASSERT(mol->getAtomWithIdx(10)->hasProp("molRxnRole"));
-    TEST_ASSERT(mol->getAtomWithIdx(10)->getProp<int>("molRxnRole")==2);
+    TEST_ASSERT(mol->getAtomWithIdx(0)->hasProp(common_properties::molRxnRole));
+    TEST_ASSERT(mol->getAtomWithIdx(0)->getProp<int>(common_properties::molRxnRole)==1);
+    TEST_ASSERT(mol->getAtomWithIdx(10)->hasProp(common_properties::molRxnRole));
+    TEST_ASSERT(mol->getAtomWithIdx(10)->getProp<int>(common_properties::molRxnRole)==2);
 
     std::string smi1 = MolToSmiles(*m);
     std::string smi2 = MolToSmiles(*mol);
@@ -4462,12 +4462,12 @@ void test47TestReactionMoleculeConversion(){
 
     ROMol* mol = ChemicalReactionToRxnMol(*rxn);
 
-    TEST_ASSERT(mol->getAtomWithIdx(0)->hasProp("molRxnRole"));
-    TEST_ASSERT(mol->getAtomWithIdx(0)->getProp<int>("molRxnRole")==1);
-    TEST_ASSERT(mol->getAtomWithIdx(2)->hasProp("molRxnRole"));
-    TEST_ASSERT(mol->getAtomWithIdx(2)->getProp<int>("molRxnRole")==2);
-    TEST_ASSERT(mol->getAtomWithIdx(3)->hasProp("molRxnRole"));
-    TEST_ASSERT(mol->getAtomWithIdx(3)->getProp<int>("molRxnRole")==2);
+    TEST_ASSERT(mol->getAtomWithIdx(0)->hasProp(common_properties::molRxnRole));
+    TEST_ASSERT(mol->getAtomWithIdx(0)->getProp<int>(common_properties::molRxnRole)==1);
+    TEST_ASSERT(mol->getAtomWithIdx(2)->hasProp(common_properties::molRxnRole));
+    TEST_ASSERT(mol->getAtomWithIdx(2)->getProp<int>(common_properties::molRxnRole)==2);
+    TEST_ASSERT(mol->getAtomWithIdx(3)->hasProp(common_properties::molRxnRole));
+    TEST_ASSERT(mol->getAtomWithIdx(3)->getProp<int>(common_properties::molRxnRole)==2);
     delete rxn;
     delete mol;
 
@@ -4480,12 +4480,12 @@ void test47TestReactionMoleculeConversion(){
 
     mol = ChemicalReactionToRxnMol(*rxn);
 
-    TEST_ASSERT(mol->getAtomWithIdx(0)->hasProp("molRxnRole"));
-    TEST_ASSERT(mol->getAtomWithIdx(0)->getProp<int>("molRxnRole")==1);
-    TEST_ASSERT(mol->getAtomWithIdx(2)->hasProp("molRxnRole"));
-    TEST_ASSERT(mol->getAtomWithIdx(2)->getProp<int>("molRxnRole")==2);
-    TEST_ASSERT(mol->getAtomWithIdx(4)->hasProp("molRxnRole"));
-    TEST_ASSERT(mol->getAtomWithIdx(4)->getProp<int>("molRxnRole")==3);
+    TEST_ASSERT(mol->getAtomWithIdx(0)->hasProp(common_properties::molRxnRole));
+    TEST_ASSERT(mol->getAtomWithIdx(0)->getProp<int>(common_properties::molRxnRole)==1);
+    TEST_ASSERT(mol->getAtomWithIdx(2)->hasProp(common_properties::molRxnRole));
+    TEST_ASSERT(mol->getAtomWithIdx(2)->getProp<int>(common_properties::molRxnRole)==2);
+    TEST_ASSERT(mol->getAtomWithIdx(4)->hasProp(common_properties::molRxnRole));
+    TEST_ASSERT(mol->getAtomWithIdx(4)->getProp<int>(common_properties::molRxnRole)==3);
     delete rxn;
     delete mol;
 
@@ -4498,8 +4498,8 @@ void test47TestReactionMoleculeConversion(){
 
     mol = ChemicalReactionToRxnMol(*rxn);
 
-    TEST_ASSERT(mol->getAtomWithIdx(0)->hasProp("molRxnRole"));
-    TEST_ASSERT(mol->getAtomWithIdx(0)->getProp<int>("molRxnRole")==1);
+    TEST_ASSERT(mol->getAtomWithIdx(0)->hasProp(common_properties::molRxnRole));
+    TEST_ASSERT(mol->getAtomWithIdx(0)->getProp<int>(common_properties::molRxnRole)==1);
     delete rxn;
     delete mol;
 
@@ -4512,10 +4512,10 @@ void test47TestReactionMoleculeConversion(){
 
     mol = ChemicalReactionToRxnMol(*rxn);
 
-    TEST_ASSERT(mol->getAtomWithIdx(0)->hasProp("molRxnRole"));
-    TEST_ASSERT(mol->getAtomWithIdx(0)->getProp<int>("molRxnRole")==2);
-    TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp("molRxnRole"));
-    TEST_ASSERT(mol->getAtomWithIdx(1)->getProp<int>("molRxnRole")==2);
+    TEST_ASSERT(mol->getAtomWithIdx(0)->hasProp(common_properties::molRxnRole));
+    TEST_ASSERT(mol->getAtomWithIdx(0)->getProp<int>(common_properties::molRxnRole)==2);
+    TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp(common_properties::molRxnRole));
+    TEST_ASSERT(mol->getAtomWithIdx(1)->getProp<int>(common_properties::molRxnRole)==2);
 
     delete rxn;
     delete mol;
@@ -4950,8 +4950,8 @@ void test54RedundantProductMappingNumbersAndRSChirality(){
     ROMol *mol = SmilesToMol(smi);
     TEST_ASSERT(mol);
     MolOps::assignStereochemistry(*mol);
-    TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp("_CIPCode"));
-    mol->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+    TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+    mol->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="S");
 
     reacts.push_back(ROMOL_SPTR(mol));
@@ -4970,12 +4970,12 @@ void test54RedundantProductMappingNumbersAndRSChirality(){
     MolOps::sanitizeMol(*(static_cast<RWMol *>(prod.get())));
     MolOps::assignStereochemistry(*prod);
     TEST_ASSERT(prod->getAtomWithIdx(0)->getAtomicNum() == 6);
-    TEST_ASSERT(prod->getAtomWithIdx(0)->hasProp("_CIPCode"));
-    prod->getAtomWithIdx(0)->getProp("_CIPCode",cip);
+    TEST_ASSERT(prod->getAtomWithIdx(0)->hasProp(common_properties::_CIPCode));
+    prod->getAtomWithIdx(0)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="S");
     TEST_ASSERT(prod->getAtomWithIdx(4)->getAtomicNum() == 6);
-    TEST_ASSERT(prod->getAtomWithIdx(4)->hasProp("_CIPCode"));
-    prod->getAtomWithIdx(4)->getProp("_CIPCode",cip);
+    TEST_ASSERT(prod->getAtomWithIdx(4)->hasProp(common_properties::_CIPCode));
+    prod->getAtomWithIdx(4)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="S");
   }
   {
@@ -4992,8 +4992,8 @@ void test54RedundantProductMappingNumbersAndRSChirality(){
     smi = "[OH][C@](F)(Cl)Br";
     ROMol *mol = SmilesToMol(smi);
     MolOps::assignStereochemistry(*mol);
-    TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp("_CIPCode"));
-    mol->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+    TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+    mol->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="S");
     TEST_ASSERT(mol);
     reacts.push_back(ROMOL_SPTR(mol));
@@ -5012,12 +5012,12 @@ void test54RedundantProductMappingNumbersAndRSChirality(){
     MolOps::sanitizeMol(*(static_cast<RWMol *>(prod.get())));
     MolOps::assignStereochemistry(*prod);
     TEST_ASSERT(prod->getAtomWithIdx(0)->getAtomicNum() == 6);
-    TEST_ASSERT(prod->getAtomWithIdx(0)->hasProp("_CIPCode"));
-    prod->getAtomWithIdx(0)->getProp("_CIPCode",cip);
+    TEST_ASSERT(prod->getAtomWithIdx(0)->hasProp(common_properties::_CIPCode));
+    prod->getAtomWithIdx(0)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="S");
     TEST_ASSERT(prod->getAtomWithIdx(4)->getAtomicNum() == 6);
-    TEST_ASSERT(prod->getAtomWithIdx(4)->hasProp("_CIPCode"));
-    prod->getAtomWithIdx(4)->getProp("_CIPCode",cip);
+    TEST_ASSERT(prod->getAtomWithIdx(4)->hasProp(common_properties::_CIPCode));
+    prod->getAtomWithIdx(4)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="R");
   }
   {
@@ -5036,8 +5036,8 @@ void test54RedundantProductMappingNumbersAndRSChirality(){
     ROMol *mol = SmilesToMol(smi);
     TEST_ASSERT(mol);
     MolOps::assignStereochemistry(*mol);
-    TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp("_CIPCode"));
-    mol->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+    TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+    mol->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="S");
 
     reacts.push_back(ROMOL_SPTR(mol));
@@ -5055,11 +5055,11 @@ void test54RedundantProductMappingNumbersAndRSChirality(){
     ROMOL_SPTR prod = prods[0][0];
     MolOps::sanitizeMol(*(static_cast<RWMol *>(prod.get())));
     MolOps::assignStereochemistry(*prod);
-    TEST_ASSERT(prod->getAtomWithIdx(1)->hasProp("_CIPCode"));
-    prod->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+    TEST_ASSERT(prod->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+    prod->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="S");
-    TEST_ASSERT(prod->getAtomWithIdx(7)->hasProp("_CIPCode"));
-    prod->getAtomWithIdx(7)->getProp("_CIPCode",cip);
+    TEST_ASSERT(prod->getAtomWithIdx(7)->hasProp(common_properties::_CIPCode));
+    prod->getAtomWithIdx(7)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="S");
 
     delete rxn;
@@ -5080,8 +5080,8 @@ void test54RedundantProductMappingNumbersAndRSChirality(){
     ROMol *mol = SmilesToMol(smi);
     TEST_ASSERT(mol);
     MolOps::assignStereochemistry(*mol);
-    TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp("_CIPCode"));
-    mol->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+    TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+    mol->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="S");
 
     reacts.push_back(ROMOL_SPTR(mol));
@@ -5099,11 +5099,11 @@ void test54RedundantProductMappingNumbersAndRSChirality(){
     ROMOL_SPTR prod = prods[0][0];
     MolOps::sanitizeMol(*(static_cast<RWMol *>(prod.get())));
     MolOps::assignStereochemistry(*prod);
-    TEST_ASSERT(prod->getAtomWithIdx(1)->hasProp("_CIPCode"));
-    prod->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+    TEST_ASSERT(prod->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+    prod->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="S");
-    TEST_ASSERT(prod->getAtomWithIdx(7)->hasProp("_CIPCode"));
-    prod->getAtomWithIdx(7)->getProp("_CIPCode",cip);
+    TEST_ASSERT(prod->getAtomWithIdx(7)->hasProp(common_properties::_CIPCode));
+    prod->getAtomWithIdx(7)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="R");
 
     delete rxn;
@@ -5124,8 +5124,8 @@ void test54RedundantProductMappingNumbersAndRSChirality(){
     ROMol *mol = SmilesToMol(smi);
     TEST_ASSERT(mol);
     MolOps::assignStereochemistry(*mol);
-    TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp("_CIPCode"));
-    mol->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+    TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+    mol->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="S");
 
     reacts.push_back(ROMOL_SPTR(mol));
@@ -5143,11 +5143,11 @@ void test54RedundantProductMappingNumbersAndRSChirality(){
     ROMOL_SPTR prod = prods[0][0];
     MolOps::sanitizeMol(*(static_cast<RWMol *>(prod.get())));
     MolOps::assignStereochemistry(*prod);
-    TEST_ASSERT(prod->getAtomWithIdx(1)->hasProp("_CIPCode"));
-    prod->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+    TEST_ASSERT(prod->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+    prod->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="S");
-    TEST_ASSERT(prod->getAtomWithIdx(5)->hasProp("_CIPCode"));
-    prod->getAtomWithIdx(5)->getProp("_CIPCode",cip);
+    TEST_ASSERT(prod->getAtomWithIdx(5)->hasProp(common_properties::_CIPCode));
+    prod->getAtomWithIdx(5)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="S");
 
     delete rxn;
@@ -5168,8 +5168,8 @@ void test54RedundantProductMappingNumbersAndRSChirality(){
     ROMol *mol = SmilesToMol(smi);
     TEST_ASSERT(mol);
     MolOps::assignStereochemistry(*mol);
-    TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp("_CIPCode"));
-    mol->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+    TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+    mol->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="S");
 
     reacts.push_back(ROMOL_SPTR(mol));
@@ -5187,11 +5187,11 @@ void test54RedundantProductMappingNumbersAndRSChirality(){
     ROMOL_SPTR prod = prods[0][0];
     MolOps::sanitizeMol(*(static_cast<RWMol *>(prod.get())));
     MolOps::assignStereochemistry(*prod);
-    TEST_ASSERT(prod->getAtomWithIdx(1)->hasProp("_CIPCode"));
-    prod->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+    TEST_ASSERT(prod->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+    prod->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="S");
-    TEST_ASSERT(prod->getAtomWithIdx(5)->hasProp("_CIPCode"));
-    prod->getAtomWithIdx(5)->getProp("_CIPCode",cip);
+    TEST_ASSERT(prod->getAtomWithIdx(5)->hasProp(common_properties::_CIPCode));
+    prod->getAtomWithIdx(5)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="R");
 
     delete rxn;

--- a/Code/GraphMol/ChemTransforms/ChemTransforms.cpp
+++ b/Code/GraphMol/ChemTransforms/ChemTransforms.cpp
@@ -454,7 +454,7 @@ namespace RDKit{
     // start by getting the shortest paths matrix:
     MolOps::getDistanceMat(mol,false,false,true);
     boost::shared_array<int> pathMat;
-    mol.getProp("DistanceMatrix_Paths",pathMat);
+    mol.getProp(common_properties::DistanceMatrix_Paths,pathMat);
 
     boost::dynamic_bitset<> keepAtoms(nAtoms);
     const RingInfo *ringInfo=res->getRingInfo();

--- a/Code/GraphMol/Chirality.cpp
+++ b/Code/GraphMol/Chirality.cpp
@@ -283,7 +283,7 @@ namespace RDKit{
 
       // copy the ranks onto the atoms:
       for(unsigned int i=0;i<numAtoms;++i){
-        mol[i]->setProp("_CIPRank",ranks[i],1);
+        mol[i]->setProp(common_properties::_CIPRank,ranks[i],1);
       }
     }
    
@@ -307,10 +307,11 @@ namespace RDKit{
         const BOND_SPTR bond = mol[*beg];
         // check whether this bond is explictly set to have unknown stereo
         if (!hasExplicitUnknownStereo) {
-          if (bond->hasProp("_UnknownStereo") &&
-              bond->getProp<int>("_UnknownStereo")){
-              hasExplicitUnknownStereo = true;
-          }
+	  int explicit_unknown_stereo;
+	  if (bond->getPropIfPresent<int>(common_properties::_UnknownStereo,
+				      explicit_unknown_stereo) &&
+	      explicit_unknown_stereo)
+	    hasExplicitUnknownStereo = true;
         }
 
         Bond::BondDir dir=bond->getBondDir();
@@ -382,9 +383,7 @@ namespace RDKit{
     bool atomIsCandidateForRingStereochem(const ROMol &mol,const Atom *atom){
       PRECONDITION(atom,"bad atom");
       bool res=false;
-      if(atom->hasProp("_ringStereochemCand")){
-        res=atom->getProp<bool>("_ringStereochemCand");
-      } else {
+      if(!atom->getPropIfPresent(common_properties::_ringStereochemCand, res)) {
         const RingInfo *ringInfo=mol.getRingInfo();
         if(ringInfo->isInitialized() &&
            ringInfo->numAtomRings(atom->getIdx())){
@@ -412,10 +411,8 @@ namespace RDKit{
             if(ringNbrs.size()==2) res=true;
             break;
           case 2:
-            if( nonRingNbrs[0]->hasProp("_CIPRank") &&
-                nonRingNbrs[1]->hasProp("_CIPRank") ){
-              nonRingNbrs[0]->getProp("_CIPRank",rank1);
-              nonRingNbrs[1]->getProp("_CIPRank",rank2);
+            if( nonRingNbrs[0]->getPropIfPresent(common_properties::_CIPRank, rank1) &&
+                nonRingNbrs[1]->getPropIfPresent(common_properties::_CIPRank, rank2) ){
               if(rank1==rank2){
                 res=false;
               } else {
@@ -427,7 +424,7 @@ namespace RDKit{
             res=false;
           }
         }
-        atom->setProp("_ringStereochemCand",res,1);
+        atom->setProp(common_properties::_ringStereochemCand,res,1);
       }
       return res;
     }
@@ -450,9 +447,8 @@ namespace RDKit{
         // check for another chiral tagged
         // atom without stereochem in this atom's rings:
         INT_VECT ringStereoAtoms(0);
-        if(atom->hasProp("_ringStereoAtoms")){
-          ringStereoAtoms=atom->getProp<INT_VECT>("_ringStereoAtoms");
-        }
+        atom->getPropIfPresent(common_properties::_ringStereoAtoms, ringStereoAtoms);
+
         const VECT_INT_VECT atomRings=ringInfo->atomRings();
         for(VECT_INT_VECT::const_iterator ringIt=atomRings.begin();
             ringIt!=atomRings.end();++ringIt){
@@ -463,7 +459,7 @@ namespace RDKit{
               int same=1;
               if(*idxIt!=static_cast<int>(atom->getIdx()) &&
                  mol.getAtomWithIdx(*idxIt)->getChiralTag()!=Atom::CHI_UNSPECIFIED &&
-                 !mol.getAtomWithIdx(*idxIt)->hasProp("_CIPCode") &&
+                 !mol.getAtomWithIdx(*idxIt)->hasProp(common_properties::_CIPCode) &&
                  atomIsCandidateForRingStereochem(mol,mol.getAtomWithIdx(*idxIt)) ){
                 // we get to keep the stereochem specification on this atom:
                 if(mol.getAtomWithIdx(*idxIt)->getChiralTag()!=atom->getChiralTag()){
@@ -471,17 +467,17 @@ namespace RDKit{
                 }
                 ringStereoAtoms.push_back(same*(*idxIt+1));
                 INT_VECT oAtoms(0);
-                if(mol.getAtomWithIdx(*idxIt)->hasProp("_ringStereoAtoms")){
-                  oAtoms=mol.getAtomWithIdx(*idxIt)->getProp<INT_VECT>("_ringStereoAtoms");
-                }
+                mol.getAtomWithIdx(*idxIt)->getPropIfPresent(common_properties::_ringStereoAtoms,
+							 oAtoms);
+
                 oAtoms.push_back(same*(atom->getIdx()+1));
-                mol.getAtomWithIdx(*idxIt)->setProp("_ringStereoAtoms",oAtoms,true);
+                mol.getAtomWithIdx(*idxIt)->setProp(common_properties::_ringStereoAtoms,oAtoms,true);
               }
             }
           }
         }
         if(ringStereoAtoms.size()){
-          atom->setProp("_ringStereoAtoms",ringStereoAtoms,true);
+          atom->setProp(common_properties::_ringStereoAtoms,ringStereoAtoms,true);
           return true;
         }
       }
@@ -565,7 +561,7 @@ namespace RDKit{
         // we understand:
         if(flagPossibleStereoCenters || (tag != Atom::CHI_UNSPECIFIED &&
                                          tag != Atom::CHI_OTHER) ){
-          if(atom->hasProp("_CIPCode")){
+          if(atom->hasProp(common_properties::_CIPCode)){
             continue;
           }
 
@@ -580,7 +576,7 @@ namespace RDKit{
             ++unassignedAtoms;
           }
           if(legalCenter && !hasDupes && flagPossibleStereoCenters){
-            atom->setProp("_ChiralityPossible",1);
+            atom->setProp(common_properties::_ChiralityPossible,1);
           }
 
           if( legalCenter && !hasDupes &&
@@ -617,7 +613,7 @@ namespace RDKit{
             std::string cipCode;
             if(tag==Atom::CHI_TETRAHEDRAL_CCW) cipCode="S";
             else cipCode="R";
-            atom->setProp("_CIPCode",cipCode,true);
+            atom->setProp(common_properties::_CIPCode,cipCode,true);
           }
         }
       }
@@ -663,10 +659,11 @@ namespace RDKit{
               // the pairs here are: atomrank,bonddir
               Chirality::INT_PAIR_VECT begAtomNeighbors,endAtomNeighbors;
               bool hasExplicitUnknownStereo = false;
-              if((dblBond->getBeginAtom()->hasProp("_UnknownStereo") &&
-                  dblBond->getBeginAtom()->getProp<int>("_UnknownStereo")) ||
-                 (dblBond->getEndAtom()->hasProp("_UnknownStereo") &&
-                  dblBond->getEndAtom()->getProp<int>("_UnknownStereo")) ){
+              int bgn_stereo=false, end_stereo=false;
+              if((dblBond->getBeginAtom()->getPropIfPresent(common_properties::_UnknownStereo,
+						     bgn_stereo) && bgn_stereo) ||
+                 (dblBond->getEndAtom()->getPropIfPresent(common_properties::_UnknownStereo,
+						      end_stereo) && end_stereo)) {
                 hasExplicitUnknownStereo=true;
               }
               Chirality::findAtomNeighborDirHelper(mol,begAtom,dblBond,
@@ -747,9 +744,8 @@ namespace RDKit{
         invars[i] = ranks[i]*factor;
         const Atom *atom=mol.getAtomWithIdx(i);
         // Priority order: R > S > nothing
-        if(atom->hasProp("_CIPCode")){
-          std::string cipCode;
-          atom->getProp("_CIPCode",cipCode);
+        std::string cipCode;
+        if(atom->getPropIfPresent(common_properties::_CIPCode, cipCode)){
           if(cipCode=="S"){
             invars[i]+=10;
           } else if(cipCode=="R"){
@@ -773,7 +769,7 @@ namespace RDKit{
       iterateCIPRanks(mol,invars,ranks,true);
       // copy the ranks onto the atoms:
       for(unsigned int i=0;i<mol.getNumAtoms();i++){
-        mol.getAtomWithIdx(i)->setProp("_CIPRank",ranks[i],1);
+        mol.getAtomWithIdx(i)->setProp(common_properties::_CIPRank,ranks[i],1);
       }
 
 #ifdef VERBOSE_CANON
@@ -797,7 +793,7 @@ namespace RDKit{
              repeat the above steps as necessary
      */
     void assignStereochemistry(ROMol &mol,bool cleanIt,bool force,bool flagPossibleStereoCenters){
-      if(!force && mol.hasProp("_StereochemDone")){
+      if(!force && mol.hasProp(common_properties::_StereochemDone)){
         return;
       }
 
@@ -817,11 +813,11 @@ namespace RDKit{
       if(cleanIt){
         for(ROMol::AtomIterator atIt=mol.beginAtoms();
             atIt!=mol.endAtoms();++atIt){
-          if((*atIt)->hasProp("_CIPCode")){
-            (*atIt)->clearProp("_CIPCode");
+          if((*atIt)->hasProp(common_properties::_CIPCode)){
+            (*atIt)->clearProp(common_properties::_CIPCode);
           }
-          if((*atIt)->hasProp("_ChiralityPossible")){
-            (*atIt)->clearProp("_ChiralityPossible");
+          if((*atIt)->hasProp(common_properties::_ChiralityPossible)){
+            (*atIt)->clearProp(common_properties::_ChiralityPossible);
           }
         }        
         for(ROMol::BondIterator bondIt=mol.beginBonds();
@@ -866,14 +862,14 @@ namespace RDKit{
       if(cleanIt){
         for(ROMol::AtomIterator atIt=mol.beginAtoms();
             atIt!=mol.endAtoms();++atIt){
-          if((*atIt)->hasProp("_ringStereochemCand")) (*atIt)->clearProp("_ringStereochemCand");
-          if((*atIt)->hasProp("_ringStereoAtoms")) (*atIt)->clearProp("_ringStereoAtoms");
+          if((*atIt)->hasProp(common_properties::_ringStereochemCand)) (*atIt)->clearProp(common_properties::_ringStereochemCand);
+          if((*atIt)->hasProp(common_properties::_ringStereoAtoms)) (*atIt)->clearProp(common_properties::_ringStereoAtoms);
         }
         for(ROMol::AtomIterator atIt=mol.beginAtoms();
             atIt!=mol.endAtoms();++atIt){
           Atom *atom=*atIt;
           if(atom->getChiralTag()!=Atom::CHI_UNSPECIFIED
-             && !atom->hasProp("_CIPCode") &&
+             && !atom->hasProp(common_properties::_CIPCode) &&
              !Chirality::checkChiralAtomSpecialCases(mol,atom) ){
             atom->setChiralTag(Atom::CHI_UNSPECIFIED);
             
@@ -903,7 +899,7 @@ namespace RDKit{
           }
         }
       }
-      mol.setProp("_StereochemDone",1,true);
+      mol.setProp(common_properties::_StereochemDone,1,true);
 
 #if 0
       std::cerr<<"---\n";
@@ -937,7 +933,7 @@ namespace RDKit{
       //  more than just checking the CIPranks for the neighbors - SP 05/04/04
 
       // make this function callable multiple times
-      if ((mol.hasProp("_BondsPotentialStereo")) && (!cleanIt)) {
+      if ((mol.hasProp(common_properties::_BondsPotentialStereo)) && (!cleanIt)) {
         return;
       } else {
         INT_VECT ranks;
@@ -1024,7 +1020,7 @@ namespace RDKit{
             } // end of we want it or CIP code is not set
           } // end of double bond
         } // end of for loop over all bonds
-        mol.setProp("_BondsPotentialStereo", 1, true);
+        mol.setProp(common_properties::_BondsPotentialStereo, 1, true);
       }
     }
 
@@ -1050,8 +1046,8 @@ namespace RDKit{
       // perceived, remove the flags that indicate
       // this... what we're about to do will require
       // that we go again.
-      if(mol.hasProp("_StereochemDone")){
-        mol.clearProp("_StereochemDone");
+      if(mol.hasProp(common_properties::_StereochemDone)){
+        mol.clearProp(common_properties::_StereochemDone);
       }
       
       for(ROMol::AtomIterator atomIt=mol.beginAtoms();atomIt!=mol.endAtoms();++atomIt){
@@ -1094,17 +1090,17 @@ namespace RDKit{
     }
 
     void removeStereochemistry(ROMol &mol){
-      if(mol.hasProp("_StereochemDone")){
-        mol.clearProp("_StereochemDone");
+      if(mol.hasProp(common_properties::_StereochemDone)){
+        mol.clearProp(common_properties::_StereochemDone);
       }
       for(ROMol::AtomIterator atIt=mol.beginAtoms();
           atIt!=mol.endAtoms();++atIt){
         (*atIt)->setChiralTag(Atom::CHI_UNSPECIFIED);
-        if((*atIt)->hasProp("_CIPCode")){
-          (*atIt)->clearProp("_CIPCode");
+        if((*atIt)->hasProp(common_properties::_CIPCode)){
+          (*atIt)->clearProp(common_properties::_CIPCode);
         }
-        if((*atIt)->hasProp("_CIPRank")){
-          (*atIt)->clearProp("_CIPRank");
+        if((*atIt)->hasProp(common_properties::_CIPRank)){
+          (*atIt)->clearProp(common_properties::_CIPRank);
         }
 
       }        

--- a/Code/GraphMol/Chirality.h
+++ b/Code/GraphMol/Chirality.h
@@ -26,7 +26,7 @@ namespace RDKit{
                     Should be at least mol.getNumAtoms() long.
     
       <b>Notes:</b>
-         - All atoms gain a property "_CIPRank" with their overall
+         - All atoms gain a property common_properties::_CIPRank with their overall
            CIP ranking.
     
     */

--- a/Code/GraphMol/Depictor/DepictUtils.cpp
+++ b/Code/GraphMol/Depictor/DepictUtils.cpp
@@ -446,8 +446,8 @@ namespace RDDepict {
     int rank;
     for (ci = commAtms.begin(); ci != commAtms.end(); ci++) {
       const RDKit::Atom *at=mol.getAtomWithIdx(*ci);
-      if(at->hasProp("_CIPRank")){
-        at->getProp("_CIPRank", rank);
+      if(at->hasProp(RDKit::common_properties::_CIPRank)){
+        at->getProp(RDKit::common_properties::_CIPRank, rank);
       } else {
         rank = 2*mol.getNumAtoms()+(*ci);
       }

--- a/Code/GraphMol/Descriptors/ConnectivityDescriptors.cpp
+++ b/Code/GraphMol/Descriptors/ConnectivityDescriptors.cpp
@@ -21,8 +21,8 @@ namespace RDKit{
     namespace detail {
       void hkDeltas(const ROMol &mol,std::vector<double> &deltas,bool force){
         PRECONDITION(deltas.size()>=mol.getNumAtoms(),"bad vector size");
-        if(!force && mol.hasProp("_connectivityHKDeltas")){
-          mol.getProp("_connectivityHKDeltas",deltas);
+        if(!force && mol.hasProp(common_properties::_connectivityHKDeltas)){
+          mol.getProp(common_properties::_connectivityHKDeltas,deltas);
           return;
         }
         const PeriodicTable *tbl = PeriodicTable::getTable();
@@ -41,14 +41,14 @@ namespace RDKit{
           if(deltas[at->getIdx()]!=0.0) deltas[at->getIdx()]=1./sqrt(deltas[at->getIdx()]);
           ++atBegin;
         }
-        mol.setProp("_connectivityHKDeltas",deltas,true);
+        mol.setProp(common_properties::_connectivityHKDeltas,deltas,true);
       }
 
 
       void nVals(const ROMol &mol,std::vector<double> &nVs,bool force){
         PRECONDITION(nVs.size()>=mol.getNumAtoms(),"bad vector size");
-        if(!force && mol.hasProp("_connectivityNVals")){
-          mol.getProp("_connectivityNVals",nVs);
+        if(!force && mol.hasProp(common_properties::_connectivityNVals)){
+          mol.getProp(common_properties::_connectivityNVals,nVs);
           return;
         }
         const PeriodicTable *tbl = PeriodicTable::getTable();
@@ -63,7 +63,7 @@ namespace RDKit{
           nVs[at->getIdx()]=v;
           ++atBegin;
         }
-        mol.setProp("_connectivityNVals",nVs,true);
+        mol.setProp(common_properties::_connectivityNVals,nVs,true);
       }
 
       double getAlpha(const Atom &atom,bool &found){

--- a/Code/GraphMol/Descriptors/Crippen.cpp
+++ b/Code/GraphMol/Descriptors/Crippen.cpp
@@ -44,10 +44,10 @@ namespace RDKit{
                    "bad atomTypes vector");
       PRECONDITION((!atomTypeLabels || atomTypeLabels->size()==mol.getNumAtoms()),
                    "bad atomTypeLabels vector");
-      if(!force && mol.hasProp("_crippenLogPContribs")){
+      if(!force && mol.hasProp(common_properties::_crippenLogPContribs)){
 	std::vector<double> tmpVect1,tmpVect2;
-	mol.getProp("_crippenLogPContribs",tmpVect1);
-	mol.getProp("_crippenMRContribs",tmpVect2);
+	mol.getProp(common_properties::_crippenLogPContribs,tmpVect1);
+	mol.getProp(common_properties::_crippenMRContribs,tmpVect2);
 	if(tmpVect1.size()==mol.getNumAtoms() &&
 	   tmpVect2.size()==mol.getNumAtoms() ){
 	  logpContribs=tmpVect1;
@@ -78,14 +78,14 @@ namespace RDKit{
 	// no need to keep matching stuff if we already found all the atoms:
 	if(atomNeeded.none()) break;
       }
-      mol.setProp("_crippenLogPContribs",logpContribs,true);
-      mol.setProp("_crippenMRContribs",mrContribs,true);
+      mol.setProp(common_properties::_crippenLogPContribs,logpContribs,true);
+      mol.setProp(common_properties::_crippenMRContribs,mrContribs,true);
     }
     void calcCrippenDescriptors(const ROMol &mol,double &logp,double &mr,bool includeHs,
 				bool force){
-      if(!force && mol.hasProp("_crippenLogP")){
-	mol.getProp("_crippenLogP",logp);
-	mol.getProp("_crippenMR",mr);
+      if(!force && mol.hasProp(common_properties::_crippenLogP)){
+	mol.getProp(common_properties::_crippenLogP,logp);
+	mol.getProp(common_properties::_crippenMR,mr);
 	return;
       }
 
@@ -113,8 +113,8 @@ namespace RDKit{
 	delete workMol;
       }
 
-      mol.setProp("_crippenLogP",logp,true);
-      mol.setProp("_crippenMR",mr,true);
+      mol.setProp(common_properties::_crippenLogP,logp,true);
+      mol.setProp(common_properties::_crippenMR,mr,true);
     };
 
     typedef boost::flyweight<boost::flyweights::key_value<std::string,CrippenParamCollection>,

--- a/Code/GraphMol/Descriptors/MolSurf.cpp
+++ b/Code/GraphMol/Descriptors/MolSurf.cpp
@@ -27,11 +27,11 @@ namespace RDKit{
 				 bool includeHs,
 				 bool force){
       TEST_ASSERT(Vi.size()==mol.getNumAtoms());
-      if(!force && mol.hasProp("_labuteAtomContribs")){
-	mol.getProp("_labuteAtomContribs",Vi);
-	mol.getProp("_labuteAtomHContrib",hContrib);
+      if(!force && mol.hasProp(common_properties::_labuteAtomContribs)){
+	mol.getProp(common_properties::_labuteAtomContribs,Vi);
+	mol.getProp(common_properties::_labuteAtomHContrib,hContrib);
 	double res;
-	mol.getProp("_labuteASA",res);
+	mol.getProp(common_properties::_labuteASA,res);
 	return res;
       }
       unsigned int nAtoms=mol.getNumAtoms();
@@ -81,16 +81,16 @@ namespace RDKit{
 	hContrib = M_PI*Rj*(4.*Rj-hContrib);
 	res+=hContrib;
       }
-      mol.setProp("_labuteAtomContribs",Vi,true);
-      mol.setProp("_labuteAtomHContrib",hContrib,true);
-      mol.setProp("_labuteASA",res,true);
+      mol.setProp(common_properties::_labuteAtomContribs,Vi,true);
+      mol.setProp(common_properties::_labuteAtomHContrib,hContrib,true);
+      mol.setProp(common_properties::_labuteASA,res,true);
 
       return res;
     }
     double calcLabuteASA(const ROMol &mol,bool includeHs,bool force){
-      if(!force && mol.hasProp("_labuteASA")){
+      if(!force && mol.hasProp(common_properties::_labuteASA)){
 	double res;
-	mol.getProp("_labuteASA",res);
+	mol.getProp(common_properties::_labuteASA,res);
 	return res;
       }
       std::vector<double> contribs;
@@ -107,9 +107,9 @@ namespace RDKit{
                                bool force){
       TEST_ASSERT(Vi.size()>=mol.getNumAtoms());
       double res=0;
-      if(!force && mol.hasProp("_tpsaAtomContribs")){
-	mol.getProp("_tpsaAtomContribs",Vi);
-	mol.getProp("_tpsa",res);
+      if(!force && mol.hasProp(common_properties::_tpsaAtomContribs)){
+	mol.getProp(common_properties::_tpsaAtomContribs,Vi);
+	mol.getProp(common_properties::_tpsa,res);
 	return res;
       }
       unsigned int nAtoms=mol.getNumAtoms();
@@ -219,14 +219,14 @@ namespace RDKit{
         res+=tmp;
       }
 
-      mol.setProp("_tpsaAtomContribs",Vi,true);
-      mol.setProp("_tpsa",res,true);
+      mol.setProp(common_properties::_tpsaAtomContribs,Vi,true);
+      mol.setProp(common_properties::_tpsa,res,true);
       return res;
     }
     double calcTPSA(const ROMol &mol,bool force){
-      if(!force && mol.hasProp("_tpsa")){
+      if(!force && mol.hasProp(common_properties::_tpsa)){
 	double res;
-	mol.getProp("_tpsa",res);
+	mol.getProp(common_properties::_tpsa,res);
 	return res;
       }
       std::vector<double> contribs;

--- a/Code/GraphMol/DistGeomHelpers/Embedder.cpp
+++ b/Code/GraphMol/DistGeomHelpers/Embedder.cpp
@@ -143,7 +143,7 @@ namespace RDKit {
       Atom *oatom;
       for (ati = mol.beginAtoms(); ati != mol.endAtoms(); ati++) {
         if ((*ati)->getAtomicNum() != 1) { //skip hydrogens
-          if ((*ati)->hasProp("_CIPCode")) { 
+          if ((*ati)->hasProp(common_properties::_CIPCode)) { 
             // make a chiral set from the neighbors
             nbrs.clear();
             nbrs.reserve(4);
@@ -153,7 +153,7 @@ namespace RDKit {
             while (beg != end) {
               oatom = mol[*beg]->getOtherAtom(*ati);
               int rank;
-              oatom->getProp("_CIPRank", rank);
+              oatom->getProp(common_properties::_CIPRank, rank);
               INT_PAIR rAid(rank, oatom->getIdx());
               nbrs.push_back(rAid);
               ++beg;
@@ -167,7 +167,7 @@ namespace RDKit {
             std::sort(nbrs.begin(), nbrs.end());
             if (nbrs.size() < 4) {
               int rank;
-              (*ati)->getProp("_CIPRank", rank);
+              (*ati)->getProp(common_properties::_CIPRank, rank);
               INT_PAIR rAid(rank, (*ati)->getIdx());
               nbrs.insert(nbrs.begin(), rAid); 
               includeSelf = true;
@@ -175,7 +175,7 @@ namespace RDKit {
                             
             // now create a chiral set and set the upper and lower bound on the volume
             std::string cipCode;
-            (*ati)->getProp("_CIPCode", cipCode);
+            (*ati)->getProp(common_properties::_CIPCode, cipCode);
             
             if (cipCode == "S") { 
               // postive chiral volume

--- a/Code/GraphMol/DistGeomHelpers/testDgeomHelpers.cpp
+++ b/Code/GraphMol/DistGeomHelpers/testDgeomHelpers.cpp
@@ -333,7 +333,7 @@ void test3() {
   while (!sdsup.atEnd()) {
     ROMol *mol = sdsup.next();
     std::string mname;
-    mol->getProp("_Name", mname);
+    mol->getProp(common_properties::_Name, mname);
     RDGeom::PointPtrVect origCoords, newCoords;
     nat = mol->getNumAtoms();
     Conformer &conf = mol->getConformer(0);
@@ -480,7 +480,7 @@ void testTemp() {
     _computeStats(energies, mean, stdDev);
     std::string mname;
     cnt++;
-    m->getProp("_Name", mname);
+    m->getProp(common_properties::_Name, mname);
     BOOST_LOG(rdDebugLog) << cnt << "," << mname << "," << mean << "," << stdDev << "\n";
     delete m;
   }

--- a/Code/GraphMol/FMCS/Test/testFMCS.cpp
+++ b/Code/GraphMol/FMCS/Test/testFMCS.cpp
@@ -390,7 +390,7 @@ void test504() {
     unsigned nq = qm->getNumAtoms();
     for(size_t ai = 0; ai < nq; ai++) {
         Atom* atom = qm->getAtomWithIdx(ai);
-        atom->setProp("molAtomMapNumber", (int)ai);
+        atom->setProp(common_properties::molAtomMapNumber, (int)ai);
     }
     std::cout<<"Query +MAP "<< MolToSmiles(*qm) <<"\n";
     mols.push_back(ROMOL_SPTR(qm));   // with RING INFO

--- a/Code/GraphMol/FMCS/testFMCS_Unit.cpp
+++ b/Code/GraphMol/FMCS/testFMCS_Unit.cpp
@@ -269,7 +269,7 @@ void test504() {
     unsigned nq = qm->getNumAtoms();
     for(size_t ai = 0; ai < nq; ai++) {
         Atom* atom = qm->getAtomWithIdx(ai);
-        atom->setProp("molAtomMapNumber", (int)ai);
+        atom->setProp(common_properties::molAtomMapNumber, (int)ai);
     }
     std::cout<<"Query +MAP "<< MolToSmiles(*qm) <<"\n";
     mols.push_back(ROMOL_SPTR(qm));   // with RING INFO
@@ -306,7 +306,7 @@ void test18() {
     unsigned nq = qm->getNumAtoms();
     for(size_t ai = 0; ai < nq; ai++) {
         Atom* atom = qm->getAtomWithIdx(ai);
-        atom->setProp("molAtomMapNumber", (int)ai);
+        atom->setProp(common_properties::molAtomMapNumber, (int)ai);
     }
     std::cout<<"Query +MAP "<< MolToSmiles(*qm) <<"\n";
     mols.push_back(ROMOL_SPTR(qm));   // with RING INFO

--- a/Code/GraphMol/FileParsers/Mol2FileParser.cpp
+++ b/Code/GraphMol/FileParsers/Mol2FileParser.cpp
@@ -177,7 +177,7 @@ namespace RDKit{
           //e.g. 5ring with N.pl3 as NH atom or other atoms without ar specification in aromatic ring
           //FIX: do we need make sure this only happens for atoms in ring?
           std::string tATT;
-          at->getProp("_TriposAtomType",tATT);
+          at->getProp(common_properties::_TriposAtomType,tATT);
           MolOps::findSSSR(*res);
           if (tATT.find("ar")==std::string::npos && at->getIsAromatic() && 
               res->getRingInfo()->isAtomInRingOfSize(at->getIdx(),5)){
@@ -189,7 +189,7 @@ namespace RDKit{
           //(at least in most cases) - anyway, throw a warning!
           if (noAromBonds==3 && tATT=="N.ar"){
             std::string nm;
-            res->getProp("_Name",nm);
+            res->getProp(common_properties::_Name,nm);
             BOOST_LOG(rdWarningLog)<<nm<<": warning - aromatic N with 3 aromatic bonds - "
               "skipping charge guess for this atom"<<std::endl;
             continue;
@@ -267,7 +267,7 @@ namespace RDKit{
         std::string tAT;
         Atom *at = *atIt;
         unsigned int idx=at->getIdx();
-        at->getProp("_TriposAtomType",tAT);
+        at->getProp(common_properties::_TriposAtomType,tAT);
 
         if (tAT=="N.4"){
           at->setFormalCharge(1);
@@ -285,7 +285,7 @@ namespace RDKit{
           //this should return only the C.2 
           Atom *nbr=res->getAtomWithIdx(*nbrIdxIt);
           std::string tATT;
-          nbr->getProp("_TriposAtomType",tATT);
+          nbr->getProp(common_properties::_TriposAtomType,tATT);
           //carboxylates
           if (tATT=="C.2" || tATT=="S.o2" ){
             //this should return only the bond between C.2 and O.co2
@@ -308,7 +308,7 @@ namespace RDKit{
             }
           }else{
             std::string nm;
-            res->getProp("_Name",nm);
+            res->getProp(common_properties::_Name,nm);
             BOOST_LOG(rdWarningLog)<<nm<<": warning - O.co2 with non C.2 or S.o2 neighbor."<<std::endl;
             return false;
           }
@@ -338,7 +338,7 @@ namespace RDKit{
           }
           if(noNNeighbors<2 || noNNeighbors>3){
             std::string nm;
-            res->getProp("_Name",nm);
+            res->getProp(common_properties::_Name,nm);
             BOOST_LOG(rdWarningLog)<<nm<<": Error - C.Cat with bad number of N neighbors."<<std::endl;
             return false;
           } else if(noNNeighbors == 2){
@@ -360,7 +360,7 @@ namespace RDKit{
                 //since I cannot think of a case where this is a problem - throw a warning
                 if(isFixed[*nbrIdxIt]){
                    std::string nm;
-                   res->getProp("_Name",nm);
+                   res->getProp(common_properties::_Name,nm);
                    BOOST_LOG(rdWarningLog)<<nm<<": warning - charged amidine and isFixed atom."<<std::endl;
                 }
                 isFixed[*nbrIdxIt]=1;
@@ -415,7 +415,7 @@ namespace RDKit{
                 while (nbrNbrIdxIt!=nbrEndNbrsIdxIt){
                   if(res->getAtomWithIdx(*nbrNbrIdxIt)->getAtomicNum()>1){
                     std::string nbrAT;
-                    res->getAtomWithIdx(*nbrNbrIdxIt)->getProp("_TriposAtomType",nbrAT);
+                    res->getAtomWithIdx(*nbrNbrIdxIt)->getProp(common_properties::_TriposAtomType,nbrAT);
                     if (nbrAT=="C.cat"){
                       hvyAtDeg+=2;//that way we reduce the risk of ionising the N attached to another C.cat ...
                     } else{
@@ -545,7 +545,7 @@ namespace RDKit{
 
       //now assign the properties
       res->setProp("_TriposAtomName",tAN); //maybe remove that since it's useless?
-      res->setProp("_TriposAtomType",tAT);
+      res->setProp(common_properties::_TriposAtomType,tAT);
       //no implicit hydrogens for mol2 files
       res->setNoImplicit(true);
 
@@ -669,7 +669,7 @@ namespace RDKit{
       //mol2 files need to have hydrogen atoms otherwise formal charge estimation will be problematic
       if(!hasHAtoms){
         std::string nm;
-        res->getProp("_Name",nm);
+        res->getProp(common_properties::_Name,nm);
         BOOST_LOG(rdWarningLog) << nm<<": Warning - no explicit hydrogens in mol2 file but needed for formal charge estimation." << std::endl;
       }
       //create conformer based on 3DPoints and add to RWMol
@@ -777,7 +777,7 @@ namespace RDKit{
     tempStr = getLine(inStream);
     RWMol *res = new RWMol();
     boost::trim_right(tempStr);
-    res->setProp("_Name",tempStr);
+    res->setProp(common_properties::_Name,tempStr);
 
     tempStr = getLine(inStream);
     tokenizer tokens(tempStr,sep);
@@ -890,7 +890,7 @@ namespace RDKit{
       catch (MolSanitizeException &se){
         BOOST_LOG(rdWarningLog)<<"sanitise ";
         std::string molName;
-        res->getProp("_Name",molName);
+        res->getProp(common_properties::_Name,molName);
         BOOST_LOG(rdWarningLog)<<molName<<": ";
         delete res;
         throw se;

--- a/Code/GraphMol/FileParsers/MolFileParser.cpp
+++ b/Code/GraphMol/FileParsers/MolFileParser.cpp
@@ -109,7 +109,7 @@ namespace RDKit{
       if(atom->getFormalCharge()!=0){
 	qa.expandQuery(makeAtomFormalChargeQuery(atom->getFormalCharge()));
       }
-      if(atom->hasProp("_hasMassQuery")){
+      if(atom->hasProp(common_properties::_hasMassQuery)){
 	qa.expandQuery(makeAtomMassQuery(static_cast<int>(atom->getMass())));
       }
       mol->replaceAtom(idx,&qa);
@@ -541,7 +541,7 @@ namespace RDKit{
               q->setVal(0);break;
             case -2:
               q->setVal(-0xDEADBEEF);
-              mol->setProp("_NeedsQueryScan",1);
+              mol->setProp(common_properties::_NeedsQueryScan,1);
               break;
             case 1:
             case 2:
@@ -837,9 +837,9 @@ namespace RDKit{
           throw FileParseException(errout.str()) ;
         }
         atom=FileParserUtils::replaceAtomWithQueryAtom(mol,atom);
-        atom->setProp("_MolFileRLabel",rLabel);
+        atom->setProp(common_properties::_MolFileRLabel,rLabel);
         std::string dLabel="R"+boost::lexical_cast<std::string>(rLabel);
-        atom->setProp("dummyLabel",dLabel);
+        atom->setProp(common_properties::dummyLabel,dLabel);
         atom->setIsotope(rLabel);
         atom->setQuery(makeAtomNullQuery());
       }
@@ -886,13 +886,13 @@ namespace RDKit{
           throw FileParseException(errout.str()) ;
         }
         QueryAtom qatom(*(mol->getAtomWithIdx(atIdx)));
-        qatom.setProp("_MolFileRLabel",rLabel);
+        qatom.setProp(common_properties::_MolFileRLabel,rLabel);
 
         // set the dummy label so that this is shown correctly
         // in other pieces of the code :
         // (this was sf.net issue 3316600)
         std::string dLabel="R"+boost::lexical_cast<std::string>(rLabel);
-        qatom.setProp("dummyLabel",dLabel);
+        qatom.setProp(common_properties::dummyLabel,dLabel);
         
         // the CTFile spec (June 2005 version) technically only allows
         // R labels up to 32. Since there are three digits, we'll accept
@@ -920,7 +920,7 @@ namespace RDKit{
       }
       RANGE_CHECK(0,idx,mol->getNumAtoms()-1);
       Atom *at = mol->getAtomWithIdx(idx);
-      at->setProp("molFileAlias",nextLine);
+      at->setProp(common_properties::molFileAlias,nextLine);
     };
   
     void ParseAtomValue(RWMol *mol,std::string text,unsigned int line){
@@ -938,7 +938,7 @@ namespace RDKit{
       }
       RANGE_CHECK(0,idx,mol->getNumAtoms()-1);
       Atom *at = mol->getAtomWithIdx(idx);
-      at->setProp("molFileValue",text.substr(7,text.length()-7));
+      at->setProp(common_properties::molFileValue,text.substr(7,text.length()-7));
     };
 
     Atom *ParseMolFileAtomLine(const std::string text, RDGeom::Point3D &pos,unsigned int line) {
@@ -1065,7 +1065,7 @@ namespace RDKit{
         res->setIsotope(dIso);
         res->setMass(PeriodicTable::getTable()->getMassForIsotope(res->getAtomicNum(),
                                                                   dIso));
-	res->setProp("_hasMassQuery",true);
+	res->setProp(common_properties::_hasMassQuery,true);
       }
     
       if(text.size()>=42 && text.substr(39,3)!="  0"){
@@ -1078,7 +1078,7 @@ namespace RDKit{
           errout << "Cannot convert " << text.substr(39,3) << " to int on line "<<line;
           throw FileParseException(errout.str()) ;
         }
-        res->setProp("molParity",parity);
+        res->setProp(common_properties::molParity,parity);
       }
 
       if(text.size()>=48 && text.substr(45,3)!="  0"){
@@ -1105,7 +1105,7 @@ namespace RDKit{
         }
         if(totValence!=0){
           // only set if it's a non-default value
-          res->setProp("molTotValence",totValence);
+          res->setProp(common_properties::molTotValence,totValence);
         }
       }
       if(text.size()>=57 && text.substr(54,3)!="  0"){
@@ -1120,7 +1120,7 @@ namespace RDKit{
         }
         if(rxnRole!=0){
           // only set if it's a non-default value
-          res->setProp("molRxnRole",rxnRole);
+          res->setProp(common_properties::molRxnRole,rxnRole);
         }
       }
       if(text.size()>=60 && text.substr(57,3)!="  0"){
@@ -1135,7 +1135,7 @@ namespace RDKit{
         }
         if(rxnComponent!=0){
           // only set if it's a non-default value
-          res->setProp("molRxnComponent",rxnComponent);
+          res->setProp(common_properties::molRxnComponent,rxnComponent);
         }
       }
       if(text.size()>=63 && text.substr(60,3)!="  0"){
@@ -1148,7 +1148,7 @@ namespace RDKit{
           errout << "Cannot convert " << text.substr(60,3) << " to int on line "<<line;
           throw FileParseException(errout.str()) ;
         }
-        res->setProp("molAtomMapNumber",atomMapNumber);
+        res->setProp(common_properties::molAtomMapNumber,atomMapNumber);
       }
       if(text.size()>=66 && text.substr(63,3)!="  0"){
         int inversionFlag=0;
@@ -1160,7 +1160,7 @@ namespace RDKit{
           errout << "Cannot convert " << text.substr(63,3) << " to int on line "<<line;
           throw FileParseException(errout.str()) ;
         }
-        res->setProp("molInversionFlag",inversionFlag);
+        res->setProp(common_properties::molInversionFlag,inversionFlag);
       }
       if(text.size()>=69 && text.substr(66,3)!="  0"){
         int exactChangeFlag=0;
@@ -1611,7 +1611,7 @@ namespace RDKit{
           case 1:
           case 2:
           case 3:
-            atom->setProp("molParity",cfg);
+            atom->setProp(common_properties::molParity,cfg);
             break;
           default:
             errout << "Unrecognized CFG value : " << val << " for atom "<< atom->getIdx()+1 <<" on line " << line<< std::endl;
@@ -1645,7 +1645,7 @@ namespace RDKit{
         } else if(prop=="VAL"){
 	  if(val!="0"){
 	    int totval=FileParserUtils::toInt(val);
-	    atom->setProp("molTotValence",totval);
+	    atom->setProp(common_properties::molTotValence,totval);
 	  }
         } else if(prop=="RGROUPS"){
           ParseV3000RGroups(mol,atom,val,line);
@@ -1780,7 +1780,7 @@ namespace RDKit{
         }
         int mapNum=atoi(token->c_str());
 	if(mapNum>0){
-	  atom->setProp("molAtomMapNumber",mapNum);
+	  atom->setProp(common_properties::molAtomMapNumber,mapNum);
 	}
         ++token;
         
@@ -1800,12 +1800,12 @@ namespace RDKit{
         throw FileParseException(errout.str()) ;
       }
 
-      if(mol->hasProp("_2DConf")){
+      if(mol->hasProp(common_properties::_2DConf)){
         conf->set3D(false);
-        mol->clearProp("_2DConf");
-      } else if(mol->hasProp("_3DConf")){
+        mol->clearProp(common_properties::_2DConf);
+      } else if(mol->hasProp(common_properties::_3DConf)){
         conf->set3D(true);
-        mol->clearProp("_3DConf");
+        mol->clearProp(common_properties::_3DConf);
       }
     }
     void ParseV3000BondBlock(std::istream *inStream,unsigned int &line,
@@ -1963,9 +1963,9 @@ namespace RDKit{
           atomIt!=mol->endAtoms();
           ++atomIt) {
         Atom *atom=*atomIt;
-        if(atom->hasProp("molTotValence") && !atom->hasProp("_ZBO_H")){
-          int totV;
-          atom->getProp("molTotValence",totV);
+        int totV;
+        if(atom->getPropIfPresent(common_properties::molTotValence, totV) &&
+           !atom->hasProp("_ZBO_H")){
           if(totV==0) continue;
           atom->setNoImplicit(true);
           if(totV==15 // V2000
@@ -2139,12 +2139,12 @@ namespace RDKit{
         } else {
           ParseMolBlockAtoms(inStream,line,nAtoms,mol,conf);
 
-          if(mol->hasProp("_2DConf")){
+          if(mol->hasProp(common_properties::_2DConf)){
             conf->set3D(false);
-            mol->clearProp("_2DConf");
-          } else if(mol->hasProp("_3DConf")){
+            mol->clearProp(common_properties::_2DConf);
+          } else if(mol->hasProp(common_properties::_3DConf)){
             conf->set3D(true);
-            mol->clearProp("_3DConf");
+            mol->clearProp(common_properties::_3DConf);
           }
         }
         mol->addConformer(conf, true);
@@ -2177,7 +2177,7 @@ namespace RDKit{
       return NULL;
     }
     RWMol *res = new RWMol();
-    res->setProp("_Name", tempStr);
+    res->setProp(common_properties::_Name, tempStr);
 
     // info
     line++;
@@ -2185,10 +2185,10 @@ namespace RDKit{
     res->setProp("_MolFileInfo", tempStr);
     if(tempStr.length()>=22){
       std::string dimLabel=tempStr.substr(20,2);
-      if(dimLabel=="2d"||dimLabel=="2D"){
-        res->setProp("_2DConf",1);
+      if(dimLabel=="2d"||dimLabel==common_properties::TWOD){
+        res->setProp(common_properties::_2DConf,1);
       } else if(dimLabel=="3d"||dimLabel=="3D"){
-        res->setProp("_3DConf",1);
+        res->setProp(common_properties::_3DConf,1);
       }
     }
     // comments
@@ -2291,7 +2291,7 @@ namespace RDKit{
     }
 
     if(chiralFlag){
-      res->setProp("_MolFileChiralFlag",chiralFlag);
+      res->setProp(common_properties::_MolFileChiralFlag,chiralFlag);
     }
 
     Conformer *conf=0;
@@ -2417,8 +2417,8 @@ namespace RDKit{
         DetectBondStereoChemistry(*res, &conf);
       }
 
-      if(res->hasProp("_NeedsQueryScan")){
-        res->clearProp("_NeedsQueryScan");
+      if(res->hasProp(common_properties::_NeedsQueryScan)){
+        res->clearProp(common_properties::_NeedsQueryScan);
         CompleteMolQueries(res);
       }
     }

--- a/Code/GraphMol/FileParsers/MolFileStereochem.cpp
+++ b/Code/GraphMol/FileParsers/MolFileStereochem.cpp
@@ -907,7 +907,7 @@ namespace RDKit {
          bondIt != mol.endBonds(); ++bondIt) {
       if ((*bondIt)->getBondType() == Bond::SINGLE) {
         if ((*bondIt)->getBondDir() == Bond::UNKNOWN)
-          (*bondIt)->setProp("_UnknownStereo", 1);
+          (*bondIt)->setProp(common_properties::_UnknownStereo, 1);
         (*bondIt)->setBondDir(Bond::NONE);
       }
     }

--- a/Code/GraphMol/FileParsers/PDBParser.cpp
+++ b/Code/GraphMol/FileParsers/PDBParser.cpp
@@ -367,7 +367,7 @@ namespace RDKit {
     else if (len > 10)
       title = std::string(ptr+10,len-10);
     if (!title.empty())
-      mol->setProp("_Name",title);
+      mol->setProp(common_properties::_Name,title);
   }
 
   static void PDBConformerLine(RWMol *mol, const char *ptr, unsigned int len,
@@ -459,8 +459,8 @@ namespace RDKit {
             !StandardPDBChiralAtom(info->getResidueName().c_str(),
                                    info->getName().c_str())) {
           atom->setChiralTag(Atom::CHI_UNSPECIFIED);
-          if (atom->hasProp("_CIPCode"))
-            atom->clearProp("_CIPCode");
+          if (atom->hasProp(common_properties::_CIPCode))
+            atom->clearProp(common_properties::_CIPCode);
         }
       }
     }

--- a/Code/GraphMol/FileParsers/PDBWriter.cpp
+++ b/Code/GraphMol/FileParsers/PDBWriter.cpp
@@ -234,10 +234,8 @@ namespace RDKit {
     MolOps::Kekulize(trwmol);
 
     std::string res;
-
-    if(mol.hasProp("_Name")){
-      std::string name;
-      mol.getProp("_Name",name);
+    std::string name;
+    if(mol.getPropIfPresent(common_properties::_Name, name)){
       if(!name.empty()) {
         res += "COMPND    ";
         res += name;

--- a/Code/GraphMol/FileParsers/SDWriter.cpp
+++ b/Code/GraphMol/FileParsers/SDWriter.cpp
@@ -88,18 +88,17 @@ namespace RDKit {
       // out to the file
       STR_VECT properties = mol.getPropList();
       STR_VECT compLst;
-      if (mol.hasProp(detail::computedPropName)) {
-	mol.getProp(detail::computedPropName, compLst);
-      }
+      mol.getPropIfPresent(detail::computedPropName, compLst);
+
       STR_VECT_CI pi;
       for (pi = properties.begin(); pi != properties.end(); pi++) {
 
 	// ignore any of the following properties
 	if ( ((*pi) == detail::computedPropName) || 
-	     ((*pi) == "_Name") ||
+	     ((*pi) == common_properties::_Name) ||
 	     ((*pi) == "_MolFileInfo") ||
 	     ((*pi) == "_MolFileComments") ||
-             ((*pi) == "_MolFileChiralFlag")) {
+             ((*pi) == common_properties::_MolFileChiralFlag)) {
 	  continue;
 	}
 

--- a/Code/GraphMol/FileParsers/SmilesMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/SmilesMolSupplier.cpp
@@ -199,13 +199,13 @@ namespace RDKit {
         std::ostringstream tstr;
         tstr << d_line;
         std::string mname = tstr.str();
-        res->setProp("_Name", mname);
+        res->setProp(common_properties::_Name, mname);
       }
       else {
         if(d_name>=static_cast<int>(recs.size())){
           BOOST_LOG(rdWarningLog)<<"WARNING: no name column found on line "<<d_line<<std::endl;
         } else {
-          res->setProp("_Name", recs[d_name]);
+          res->setProp(common_properties::_Name, recs[d_name]);
         }
       }
 

--- a/Code/GraphMol/FileParsers/SmilesWriter.cpp
+++ b/Code/GraphMol/FileParsers/SmilesWriter.cpp
@@ -124,9 +124,7 @@ namespace RDKit {
     std::string name, smi = MolToSmiles(mol,df_isomericSmiles,df_kekuleSmiles);
     (*dp_ostream) << smi;
     if(d_nameHeader!=""){
-      if (mol.hasProp("_Name") ) {
-        mol.getProp("_Name", name);
-      } else {
+      if (!mol.getPropIfPresent(common_properties::_Name, name)) {
         std::stringstream tstream;
         tstream << d_molid;
         name = tstream.str();
@@ -138,15 +136,13 @@ namespace RDKit {
     STR_VECT_CI pi;
     for (pi = d_props.begin(); pi != d_props.end(); pi++) {
       std::string pval;
-      if (mol.hasProp(*pi)) {
-	// FIX: we will assume that any property that the user requests is castable to
-	// a std::string 
-	mol.getProp((*pi), pval);
+      // FIX: we will assume that any property that the user requests is castable to
+      // a std::string 
+      if(mol.getPropIfPresent(*pi, pval)) {
+        (*dp_ostream) << d_delim << pval;
+      } else {
+         (*dp_ostream) << d_delim << "";
       }
-      else {
-	pval = "";
-      }
-      (*dp_ostream) << d_delim << pval;
     }
     (*dp_ostream) << "\n";
     d_molid++;

--- a/Code/GraphMol/FileParsers/TDTMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/TDTMolSupplier.cpp
@@ -236,7 +236,7 @@ namespace RDKit {
         boost::trim_if(propName,boost::is_any_of(" \t"));
         startP = endP+1;
 
-        if(propName=="2D" && d_confId2D>=0){
+        if(propName==common_properties::TWOD && d_confId2D>=0){
           std::string rest=inLine.substr(startP,inLine.size()-startP);
           std::vector<double> coords;
           TDTParseUtils::ParseNumberList(rest,coords,dp_inStream);
@@ -277,7 +277,7 @@ namespace RDKit {
           } else {
             std::string propVal = inLine.substr(startP,endP-startP);
             res->setProp(propName,propVal);
-            if(propName==d_nameProp) res->setProp("_Name",propVal);
+            if(propName==d_nameProp) res->setProp(common_properties::_Name,propVal);
           }
         }
         std::getline(*dp_inStream,inLine);

--- a/Code/GraphMol/FileParsers/TDTWriter.cpp
+++ b/Code/GraphMol/FileParsers/TDTWriter.cpp
@@ -87,10 +87,9 @@ namespace RDKit {
 
     // write the molecule 
     (*dp_ostream) << "$SMI<" << MolToSmiles(mol) << ">\n";
-    
-    if(df_writeNames && mol.hasProp("_Name")){
-      std::string name;
-      mol.getProp("_Name",name);
+
+    std::string name;
+    if(df_writeNames && mol.getPropIfPresent(common_properties::_Name, name)){
       (*dp_ostream) << "NAME<" << name << ">\n";
     }
     
@@ -98,7 +97,7 @@ namespace RDKit {
     if(mol.getNumConformers()){
       // get the ordering of the atoms in the output SMILES:
       std::vector<unsigned int> atomOrdering;
-      mol.getProp("_smilesAtomOutputOrder",atomOrdering);
+      mol.getProp(common_properties::_smilesAtomOutputOrder,atomOrdering);
       
       const Conformer &conf = mol.getConformer(confId);
       if(df_write2D){
@@ -135,18 +134,17 @@ namespace RDKit {
       // out to the file
       STR_VECT properties = mol.getPropList();
       STR_VECT compLst;
-      if (mol.hasProp(detail::computedPropName)) {
-	mol.getProp(detail::computedPropName, compLst);
-      }
+      mol.getPropIfPresent(detail::computedPropName, compLst);
+
       STR_VECT_CI pi;
       for (pi = properties.begin(); pi != properties.end(); pi++) {
 
 	// ignore any of the following properties
 	if ( ((*pi) == detail::computedPropName) || 
-	     ((*pi) == "_Name") ||
+	     ((*pi) == common_properties::_Name) ||
 	     ((*pi) == "_MolFileInfo") ||
 	     ((*pi) == "_MolFileComments") ||
-             ((*pi) == "_MolFileChiralFlag")) {
+             ((*pi) == common_properties::_MolFileChiralFlag)) {
 	  continue;
 	}
 

--- a/Code/GraphMol/FileParsers/TplFileParser.cpp
+++ b/Code/GraphMol/FileParsers/TplFileParser.cpp
@@ -119,7 +119,7 @@ namespace RDKit{
       throw FileParseException(errout.str()) ;
     }
     std::ostringstream propName;
-    propName << "Conf_" <<mol->getNumConformers()<<"_Name";
+    propName << "Conf_" <<mol->getNumConformers()<<common_properties::_Name;
     mol->setProp(propName.str(),boost::trim_copy(tempStr.substr(4,tempStr.size()-4)));
     
     Conformer *conf=new Conformer(mol->getNumAtoms());
@@ -184,7 +184,7 @@ namespace RDKit{
     RWMol *res = new RWMol();
     if(tempStr.size()>=4 && tempStr.substr(0,4)=="NAME"){
       tempStr = boost::trim_copy(tempStr.substr(4,tempStr.size()-4));
-      res->setProp("_Name",tempStr);
+      res->setProp(common_properties::_Name,tempStr);
       line++;
       tempStr = getLine(inStream);
       if(inStream->eof()){

--- a/Code/GraphMol/FileParsers/TplFileWriter.cpp
+++ b/Code/GraphMol/FileParsers/TplFileWriter.cpp
@@ -104,11 +104,11 @@ namespace RDKit{
     std::string tempStr;
     res << "BioCAD format, all rights reserved"<<std::endl;
     res << "Output from RDKit"<<std::endl;
-    if(!mol.hasProp("_Name")){
+    if(!mol.hasProp(common_properties::_Name)){
       BOOST_LOG(rdWarningLog)<<"Molecule has no name; arbitrary name assigned.\n";
       tempStr = "Unnamed molecule";
     } else {
-      mol.getProp("_Name",tempStr);
+      mol.getProp(common_properties::_Name,tempStr);
     }
     res << "NAME "<<tempStr<<std::endl;
     res << "PROP 7 1"<<std::endl;

--- a/Code/GraphMol/FileParsers/test1.cpp
+++ b/Code/GraphMol/FileParsers/test1.cpp
@@ -425,8 +425,8 @@ void test6(){
   TEST_ASSERT(m);
   TEST_ASSERT(m->getNumAtoms()==4);
   MolOps::assignStereochemistry(*m);
-  TEST_ASSERT(m->getAtomWithIdx(0)->hasProp("_CIPCode"));
-  m->getAtomWithIdx(0)->getProp("_CIPCode",cip);
+  TEST_ASSERT(m->getAtomWithIdx(0)->hasProp(common_properties::_CIPCode));
+  m->getAtomWithIdx(0)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="R");  
 #if 1
   smi = MolToSmiles(*m,true);
@@ -440,8 +440,8 @@ void test6(){
   TEST_ASSERT(m);
   TEST_ASSERT(m->getNumAtoms()==4);
   MolOps::assignStereochemistry(*m);
-  TEST_ASSERT(m->getAtomWithIdx(0)->hasProp("_CIPCode"));
-  m->getAtomWithIdx(0)->getProp("_CIPCode",cip);
+  TEST_ASSERT(m->getAtomWithIdx(0)->hasProp(common_properties::_CIPCode));
+  m->getAtomWithIdx(0)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="R");  
 #if 1
   smi = MolToSmiles(*m,true);
@@ -454,8 +454,8 @@ void test6(){
   TEST_ASSERT(m);
   TEST_ASSERT(m->getNumAtoms()==4);
   MolOps::assignStereochemistry(*m);
-  TEST_ASSERT(m->getAtomWithIdx(0)->hasProp("_CIPCode"));
-  m->getAtomWithIdx(0)->getProp("_CIPCode",cip);
+  TEST_ASSERT(m->getAtomWithIdx(0)->hasProp(common_properties::_CIPCode));
+  m->getAtomWithIdx(0)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="S");  
 #if 1
   smi = MolToSmiles(*m,true);
@@ -468,8 +468,8 @@ void test6(){
   TEST_ASSERT(m);
   TEST_ASSERT(m->getNumAtoms()==4);
   MolOps::assignStereochemistry(*m);
-  TEST_ASSERT(m->getAtomWithIdx(0)->hasProp("_CIPCode"));
-  m->getAtomWithIdx(0)->getProp("_CIPCode",cip);
+  TEST_ASSERT(m->getAtomWithIdx(0)->hasProp(common_properties::_CIPCode));
+  m->getAtomWithIdx(0)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="S");  
 #if 1
   smi = MolToSmiles(*m,true);
@@ -482,7 +482,7 @@ void test6(){
   TEST_ASSERT(m);
   TEST_ASSERT(m->getNumAtoms()==5);
   MolOps::assignStereochemistry(*m);
-  TEST_ASSERT(!m->getAtomWithIdx(0)->hasProp("_CIPCode"));
+  TEST_ASSERT(!m->getAtomWithIdx(0)->hasProp(common_properties::_CIPCode));
 #if 1
   smi = MolToSmiles(*m,true);
   TEST_ASSERT(smi=="CC(C)(Cl)Br");
@@ -534,8 +534,8 @@ void test7(){
   TEST_ASSERT(m);
   TEST_ASSERT(m->getNumAtoms()==4);
   MolOps::assignStereochemistry(*m);
-  TEST_ASSERT(m->getAtomWithIdx(0)->hasProp("_CIPCode"));
-  m->getAtomWithIdx(0)->getProp("_CIPCode",cip);
+  TEST_ASSERT(m->getAtomWithIdx(0)->hasProp(common_properties::_CIPCode));
+  m->getAtomWithIdx(0)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="R");  
 #if 1
   smi = MolToSmiles(*m,true);
@@ -544,8 +544,8 @@ void test7(){
   m2=MolBlockToMol(molBlock);
   TEST_ASSERT(m2)
   MolOps::assignStereochemistry(*m2);
-  TEST_ASSERT(m2->getAtomWithIdx(0)->hasProp("_CIPCode"));
-  m2->getAtomWithIdx(0)->getProp("_CIPCode",cip);
+  TEST_ASSERT(m2->getAtomWithIdx(0)->hasProp(common_properties::_CIPCode));
+  m2->getAtomWithIdx(0)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="R");  
   smi2 = MolToSmiles(*m2,true);
   TEST_ASSERT(smi==smi2);
@@ -558,8 +558,8 @@ void test7(){
   TEST_ASSERT(m);
   TEST_ASSERT(m->getNumAtoms()==4);
   MolOps::assignStereochemistry(*m);
-  TEST_ASSERT(m->getAtomWithIdx(0)->hasProp("_CIPCode"));
-  m->getAtomWithIdx(0)->getProp("_CIPCode",cip);
+  TEST_ASSERT(m->getAtomWithIdx(0)->hasProp(common_properties::_CIPCode));
+  m->getAtomWithIdx(0)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="S");  
 #if 1
   smi = MolToSmiles(*m,true);
@@ -569,8 +569,8 @@ void test7(){
   m2=MolBlockToMol(molBlock);
   TEST_ASSERT(m2)
   MolOps::assignStereochemistry(*m2);
-  TEST_ASSERT(m2->getAtomWithIdx(0)->hasProp("_CIPCode"));
-  m2->getAtomWithIdx(0)->getProp("_CIPCode",cip);
+  TEST_ASSERT(m2->getAtomWithIdx(0)->hasProp(common_properties::_CIPCode));
+  m2->getAtomWithIdx(0)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="S");  
   //smi2 = MolToSmiles(*m2,true);
   //TEST_ASSERT(smi==smi2);
@@ -583,8 +583,8 @@ void test7(){
   TEST_ASSERT(m);
   TEST_ASSERT(m->getNumAtoms()==4);
   MolOps::assignStereochemistry(*m);
-  TEST_ASSERT(m->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  m->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+  TEST_ASSERT(m->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  m->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="R");  
 #if 1
   smi = MolToSmiles(*m,true);
@@ -616,14 +616,14 @@ void test7(){
   TEST_ASSERT(m);
   TEST_ASSERT(m->getNumAtoms()==9);
   MolOps::assignStereochemistry(*m);
-  TEST_ASSERT(m->getAtomWithIdx(0)->hasProp("_CIPCode"));
-  m->getAtomWithIdx(0)->getProp("_CIPCode",cip);
+  TEST_ASSERT(m->getAtomWithIdx(0)->hasProp(common_properties::_CIPCode));
+  m->getAtomWithIdx(0)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="R");
-  TEST_ASSERT(m->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  m->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+  TEST_ASSERT(m->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  m->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="R");
-  TEST_ASSERT(m->getAtomWithIdx(3)->hasProp("_CIPCode"));
-  m->getAtomWithIdx(3)->getProp("_CIPCode",cip);
+  TEST_ASSERT(m->getAtomWithIdx(3)->hasProp(common_properties::_CIPCode));
+  m->getAtomWithIdx(3)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="R");
 #if 1
   smi = MolToSmiles(*m,true);
@@ -842,8 +842,8 @@ void testIssue399(){
   TEST_ASSERT(smi1=="C[C@H]1CO1");
 #endif  
   MolOps::assignStereochemistry(*m1);
-  TEST_ASSERT(m1->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  m1->getAtomWithIdx(1)->getProp("_CIPCode",smi2);
+  TEST_ASSERT(m1->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  m1->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,smi2);
   TEST_ASSERT(smi2=="S");
 #if 1
   WedgeMolBonds(*m1,&m1->getConformer());
@@ -1083,27 +1083,27 @@ void testMolFileRGroups(){
   unsigned int idx;
   std::string label;
   
-  TEST_ASSERT(m->getAtomWithIdx(3)->hasProp("_MolFileRLabel"));
-  m->getAtomWithIdx(3)->getProp("_MolFileRLabel",idx);
+  TEST_ASSERT(m->getAtomWithIdx(3)->hasProp(common_properties::_MolFileRLabel));
+  m->getAtomWithIdx(3)->getProp(common_properties::_MolFileRLabel,idx);
   TEST_ASSERT(idx==2);
   TEST_ASSERT(m->getAtomWithIdx(3)->getAtomicNum()==0);
   TEST_ASSERT(feq(m->getAtomWithIdx(3)->getIsotope(),2));
 
  
-  TEST_ASSERT(m->getAtomWithIdx(4)->hasProp("_MolFileRLabel"));
-  m->getAtomWithIdx(4)->getProp("_MolFileRLabel",idx);
+  TEST_ASSERT(m->getAtomWithIdx(4)->hasProp(common_properties::_MolFileRLabel));
+  m->getAtomWithIdx(4)->getProp(common_properties::_MolFileRLabel,idx);
   TEST_ASSERT(idx==1);
   TEST_ASSERT(m->getAtomWithIdx(4)->getAtomicNum()==0);
   TEST_ASSERT(feq(m->getAtomWithIdx(4)->getIsotope(),1));
 
   //  test sf.net issue 3316600:
-  TEST_ASSERT(m->getAtomWithIdx(3)->hasProp("dummyLabel"));
-  m->getAtomWithIdx(3)->getProp("dummyLabel",label);
+  TEST_ASSERT(m->getAtomWithIdx(3)->hasProp(common_properties::dummyLabel));
+  m->getAtomWithIdx(3)->getProp(common_properties::dummyLabel,label);
   TEST_ASSERT(label=="R2");
   TEST_ASSERT(m->getAtomWithIdx(3)->getSymbol()=="R2");
   
-  TEST_ASSERT(m->getAtomWithIdx(4)->hasProp("dummyLabel"));
-  m->getAtomWithIdx(4)->getProp("dummyLabel",label);
+  TEST_ASSERT(m->getAtomWithIdx(4)->hasProp(common_properties::dummyLabel));
+  m->getAtomWithIdx(4)->getProp(common_properties::dummyLabel,label);
   TEST_ASSERT(label=="R1");
   TEST_ASSERT(m->getAtomWithIdx(4)->getSymbol()=="R1");
   
@@ -1137,14 +1137,14 @@ void testMolFileRGroups(){
   fName = rdbase + "/Code/GraphMol/FileParsers/test_data/rgroups2.mol";
   m = MolFileToMol(fName);
   TEST_ASSERT(m);
-  TEST_ASSERT(m->getAtomWithIdx(3)->hasProp("_MolFileRLabel"));
-  m->getAtomWithIdx(3)->getProp("_MolFileRLabel",idx);
+  TEST_ASSERT(m->getAtomWithIdx(3)->hasProp(common_properties::_MolFileRLabel));
+  m->getAtomWithIdx(3)->getProp(common_properties::_MolFileRLabel,idx);
   TEST_ASSERT(idx==1);
   TEST_ASSERT(m->getAtomWithIdx(3)->getAtomicNum()==0);
   TEST_ASSERT(feq(m->getAtomWithIdx(3)->getIsotope(),1));
   
-  TEST_ASSERT(m->getAtomWithIdx(4)->hasProp("_MolFileRLabel"));
-  m->getAtomWithIdx(4)->getProp("_MolFileRLabel",idx);
+  TEST_ASSERT(m->getAtomWithIdx(4)->hasProp(common_properties::_MolFileRLabel));
+  m->getAtomWithIdx(4)->getProp(common_properties::_MolFileRLabel,idx);
   TEST_ASSERT(idx==1);
   TEST_ASSERT(m->getAtomWithIdx(4)->getAtomicNum()==0);
   TEST_ASSERT(feq(m->getAtomWithIdx(4)->getIsotope(),1));
@@ -1175,13 +1175,13 @@ void testMolFileRGroups(){
   fName = rdbase + "/Code/GraphMol/FileParsers/test_data/rgroups3.mol";
   m = MolFileToMol(fName);
   TEST_ASSERT(m);
-  TEST_ASSERT(m->getAtomWithIdx(3)->hasProp("_MolFileRLabel"));
-  m->getAtomWithIdx(3)->getProp("_MolFileRLabel",idx);
+  TEST_ASSERT(m->getAtomWithIdx(3)->hasProp(common_properties::_MolFileRLabel));
+  m->getAtomWithIdx(3)->getProp(common_properties::_MolFileRLabel,idx);
   TEST_ASSERT(idx==11);
   TEST_ASSERT(m->getAtomWithIdx(3)->getAtomicNum()==0);
   TEST_ASSERT(feq(m->getAtomWithIdx(3)->getIsotope(),11));
-  TEST_ASSERT(m->getAtomWithIdx(4)->hasProp("_MolFileRLabel"));
-  m->getAtomWithIdx(4)->getProp("_MolFileRLabel",idx);
+  TEST_ASSERT(m->getAtomWithIdx(4)->hasProp(common_properties::_MolFileRLabel));
+  m->getAtomWithIdx(4)->getProp(common_properties::_MolFileRLabel,idx);
   TEST_ASSERT(idx==503);
   TEST_ASSERT(m->getAtomWithIdx(4)->getAtomicNum()==0);
   TEST_ASSERT(feq(m->getAtomWithIdx(4)->getIsotope(),503));
@@ -1711,9 +1711,9 @@ void testAtomParity(){
     std::string fName= rdbase + "/Code/GraphMol/FileParsers/test_data/parity.simple1.mol";
     RWMol *m = MolFileToMol(fName);
     TEST_ASSERT(m);
-    TEST_ASSERT(!m->getAtomWithIdx(0)->hasProp("molParity"));
-    TEST_ASSERT(m->getAtomWithIdx(1)->hasProp("molParity"));
-    m->getAtomWithIdx(1)->getProp("molParity",parity);
+    TEST_ASSERT(!m->getAtomWithIdx(0)->hasProp(common_properties::molParity));
+    TEST_ASSERT(m->getAtomWithIdx(1)->hasProp(common_properties::molParity));
+    m->getAtomWithIdx(1)->getProp(common_properties::molParity,parity);
     TEST_ASSERT(parity==1);
 
     // if we don't perceive the stereochem first, no parity
@@ -1721,8 +1721,8 @@ void testAtomParity(){
     std::string molBlock = MolToMolBlock(*m);
     RWMol *m2 = MolBlockToMol(molBlock);
     TEST_ASSERT(m2);
-    TEST_ASSERT(!m2->getAtomWithIdx(0)->hasProp("molParity"));
-    TEST_ASSERT(!m2->getAtomWithIdx(1)->hasProp("molParity"));
+    TEST_ASSERT(!m2->getAtomWithIdx(0)->hasProp(common_properties::molParity));
+    TEST_ASSERT(!m2->getAtomWithIdx(1)->hasProp(common_properties::molParity));
     delete m2;
     
     // now perceive stereochem, then look for the parity
@@ -1731,9 +1731,9 @@ void testAtomParity(){
     molBlock = MolToMolBlock(*m);
     m2 = MolBlockToMol(molBlock);
     TEST_ASSERT(m2);
-    TEST_ASSERT(!m2->getAtomWithIdx(0)->hasProp("molParity"));
-    TEST_ASSERT(m2->getAtomWithIdx(1)->hasProp("molParity"));
-    m2->getAtomWithIdx(1)->getProp("molParity",parity);
+    TEST_ASSERT(!m2->getAtomWithIdx(0)->hasProp(common_properties::molParity));
+    TEST_ASSERT(m2->getAtomWithIdx(1)->hasProp(common_properties::molParity));
+    m2->getAtomWithIdx(1)->getProp(common_properties::molParity,parity);
     TEST_ASSERT(parity==1);
     delete m2;
 
@@ -1745,18 +1745,18 @@ void testAtomParity(){
     std::string fName= rdbase + "/Code/GraphMol/FileParsers/test_data/parity.simple2.mol";
     RWMol *m = MolFileToMol(fName);
     TEST_ASSERT(m);
-    TEST_ASSERT(!m->getAtomWithIdx(0)->hasProp("molParity"));
-    TEST_ASSERT(m->getAtomWithIdx(1)->hasProp("molParity"));
-    m->getAtomWithIdx(1)->getProp("molParity",parity);
+    TEST_ASSERT(!m->getAtomWithIdx(0)->hasProp(common_properties::molParity));
+    TEST_ASSERT(m->getAtomWithIdx(1)->hasProp(common_properties::molParity));
+    m->getAtomWithIdx(1)->getProp(common_properties::molParity,parity);
     TEST_ASSERT(parity==2);
 
     MolOps::assignChiralTypesFrom3D(*m);
     std::string molBlock = MolToMolBlock(*m);
     RWMol *m2 = MolBlockToMol(molBlock);
     TEST_ASSERT(m2);
-    TEST_ASSERT(!m2->getAtomWithIdx(0)->hasProp("molParity"));
-    TEST_ASSERT(m2->getAtomWithIdx(1)->hasProp("molParity"));
-    m2->getAtomWithIdx(1)->getProp("molParity",parity);
+    TEST_ASSERT(!m2->getAtomWithIdx(0)->hasProp(common_properties::molParity));
+    TEST_ASSERT(m2->getAtomWithIdx(1)->hasProp(common_properties::molParity));
+    m2->getAtomWithIdx(1)->getProp(common_properties::molParity,parity);
     TEST_ASSERT(parity==2);
     delete m2;
 
@@ -1769,18 +1769,18 @@ void testAtomParity(){
     std::string fName= rdbase + "/Code/GraphMol/FileParsers/test_data/parity.simpleH1.mol";
     RWMol *m = MolFileToMol(fName,true,false);
     TEST_ASSERT(m);
-    TEST_ASSERT(!m->getAtomWithIdx(0)->hasProp("molParity"));
-    TEST_ASSERT(m->getAtomWithIdx(1)->hasProp("molParity"));
-    m->getAtomWithIdx(1)->getProp("molParity",parity);
+    TEST_ASSERT(!m->getAtomWithIdx(0)->hasProp(common_properties::molParity));
+    TEST_ASSERT(m->getAtomWithIdx(1)->hasProp(common_properties::molParity));
+    m->getAtomWithIdx(1)->getProp(common_properties::molParity,parity);
     TEST_ASSERT(parity==1);
 
     MolOps::assignChiralTypesFrom3D(*m);
     std::string molBlock = MolToMolBlock(*m);
     RWMol *m2 = MolBlockToMol(molBlock,true,false);
     TEST_ASSERT(m2);
-    TEST_ASSERT(!m2->getAtomWithIdx(0)->hasProp("molParity"));
-    TEST_ASSERT(m2->getAtomWithIdx(1)->hasProp("molParity"));
-    m2->getAtomWithIdx(1)->getProp("molParity",parity);
+    TEST_ASSERT(!m2->getAtomWithIdx(0)->hasProp(common_properties::molParity));
+    TEST_ASSERT(m2->getAtomWithIdx(1)->hasProp(common_properties::molParity));
+    m2->getAtomWithIdx(1)->getProp(common_properties::molParity,parity);
     TEST_ASSERT(parity==1);
     delete m2;
 
@@ -1791,9 +1791,9 @@ void testAtomParity(){
     delete m2;
     m2 = MolBlockToMol(molBlock);
     TEST_ASSERT(m2);
-    TEST_ASSERT(!m2->getAtomWithIdx(0)->hasProp("molParity"));
-    TEST_ASSERT(m2->getAtomWithIdx(1)->hasProp("molParity"));
-    m2->getAtomWithIdx(1)->getProp("molParity",parity);
+    TEST_ASSERT(!m2->getAtomWithIdx(0)->hasProp(common_properties::molParity));
+    TEST_ASSERT(m2->getAtomWithIdx(1)->hasProp(common_properties::molParity));
+    m2->getAtomWithIdx(1)->getProp(common_properties::molParity,parity);
     TEST_ASSERT(parity==1);
     delete m2;
     delete m;
@@ -1805,18 +1805,18 @@ void testAtomParity(){
     std::string fName= rdbase + "/Code/GraphMol/FileParsers/test_data/parity.simpleH2.mol";
     RWMol *m = MolFileToMol(fName,true,false);
     TEST_ASSERT(m);
-    TEST_ASSERT(!m->getAtomWithIdx(0)->hasProp("molParity"));
-    TEST_ASSERT(m->getAtomWithIdx(1)->hasProp("molParity"));
-    m->getAtomWithIdx(1)->getProp("molParity",parity);
+    TEST_ASSERT(!m->getAtomWithIdx(0)->hasProp(common_properties::molParity));
+    TEST_ASSERT(m->getAtomWithIdx(1)->hasProp(common_properties::molParity));
+    m->getAtomWithIdx(1)->getProp(common_properties::molParity,parity);
     TEST_ASSERT(parity==2);
 
     MolOps::assignChiralTypesFrom3D(*m);
     std::string molBlock = MolToMolBlock(*m);
     RWMol *m2 = MolBlockToMol(molBlock,true,false);
     TEST_ASSERT(m2);
-    TEST_ASSERT(!m2->getAtomWithIdx(0)->hasProp("molParity"));
-    TEST_ASSERT(m2->getAtomWithIdx(1)->hasProp("molParity"));
-    m2->getAtomWithIdx(1)->getProp("molParity",parity);
+    TEST_ASSERT(!m2->getAtomWithIdx(0)->hasProp(common_properties::molParity));
+    TEST_ASSERT(m2->getAtomWithIdx(1)->hasProp(common_properties::molParity));
+    m2->getAtomWithIdx(1)->getProp(common_properties::molParity,parity);
     TEST_ASSERT(parity==2);
     delete m2;
 
@@ -1825,9 +1825,9 @@ void testAtomParity(){
     delete m2;
     m2 = MolBlockToMol(molBlock);
     TEST_ASSERT(m2);
-    TEST_ASSERT(!m2->getAtomWithIdx(0)->hasProp("molParity"));
-    TEST_ASSERT(m2->getAtomWithIdx(1)->hasProp("molParity"));
-    m2->getAtomWithIdx(1)->getProp("molParity",parity);
+    TEST_ASSERT(!m2->getAtomWithIdx(0)->hasProp(common_properties::molParity));
+    TEST_ASSERT(m2->getAtomWithIdx(1)->hasProp(common_properties::molParity));
+    m2->getAtomWithIdx(1)->getProp(common_properties::molParity,parity);
     TEST_ASSERT(parity==2);
     delete m2;
     delete m;
@@ -1839,17 +1839,17 @@ void testAtomParity(){
     std::string fName= rdbase + "/Code/GraphMol/FileParsers/test_data/parity.nitrogen.mol";
     RWMol *m = MolFileToMol(fName,true,false);
     TEST_ASSERT(m);
-    TEST_ASSERT(!m->getAtomWithIdx(0)->hasProp("molParity"));
-    TEST_ASSERT(m->getAtomWithIdx(1)->hasProp("molParity"));
-    m->getAtomWithIdx(1)->getProp("molParity",parity);
+    TEST_ASSERT(!m->getAtomWithIdx(0)->hasProp(common_properties::molParity));
+    TEST_ASSERT(m->getAtomWithIdx(1)->hasProp(common_properties::molParity));
+    m->getAtomWithIdx(1)->getProp(common_properties::molParity,parity);
     TEST_ASSERT(parity==1);
 
     MolOps::assignChiralTypesFrom3D(*m);
     std::string molBlock = MolToMolBlock(*m);
     RWMol *m2 = MolBlockToMol(molBlock,true,false);
     TEST_ASSERT(m2);
-    TEST_ASSERT(!m2->getAtomWithIdx(0)->hasProp("molParity"));
-    TEST_ASSERT(!m2->getAtomWithIdx(1)->hasProp("molParity"));
+    TEST_ASSERT(!m2->getAtomWithIdx(0)->hasProp(common_properties::molParity));
+    TEST_ASSERT(!m2->getAtomWithIdx(1)->hasProp(common_properties::molParity));
     delete m2;
     delete m;
   }
@@ -1859,8 +1859,8 @@ void testAtomParity(){
     std::string fName= rdbase + "/Code/GraphMol/FileParsers/test_data/parity.twoHs.mol";
     RWMol *m = MolFileToMol(fName,true,false);
     TEST_ASSERT(m);
-    TEST_ASSERT(!m->getAtomWithIdx(0)->hasProp("molParity"));
-    TEST_ASSERT(!m->getAtomWithIdx(1)->hasProp("molParity"));
+    TEST_ASSERT(!m->getAtomWithIdx(0)->hasProp(common_properties::molParity));
+    TEST_ASSERT(!m->getAtomWithIdx(1)->hasProp(common_properties::molParity));
 
     // add a bogus chiral spec:
     m->getAtomWithIdx(0)->setChiralTag(Atom::CHI_TETRAHEDRAL_CW);
@@ -1870,8 +1870,8 @@ void testAtomParity(){
     delete m2;
     m2 = MolBlockToMol(molBlock,true,false);
     TEST_ASSERT(m2);
-    TEST_ASSERT(!m2->getAtomWithIdx(0)->hasProp("molParity"));
-    TEST_ASSERT(!m2->getAtomWithIdx(1)->hasProp("molParity"));
+    TEST_ASSERT(!m2->getAtomWithIdx(0)->hasProp(common_properties::molParity));
+    TEST_ASSERT(!m2->getAtomWithIdx(1)->hasProp(common_properties::molParity));
     delete m2;
     delete m;
   }
@@ -1930,9 +1930,9 @@ void testMolFileAtomValues(){
     fName = rdbase+"test_data/AtomProps1.mol";
     m = MolFileToMol(fName);
     TEST_ASSERT(m);
-    TEST_ASSERT(!m->getAtomWithIdx(0)->hasProp("molFileValue"));
-    TEST_ASSERT(m->getAtomWithIdx(1)->hasProp("molFileValue"));
-    m->getAtomWithIdx(1)->getProp("molFileValue",val);
+    TEST_ASSERT(!m->getAtomWithIdx(0)->hasProp(common_properties::molFileValue));
+    TEST_ASSERT(m->getAtomWithIdx(1)->hasProp(common_properties::molFileValue));
+    m->getAtomWithIdx(1)->getProp(common_properties::molFileValue,val);
     TEST_ASSERT(val=="acidchloride");
 
     delete m;
@@ -1945,13 +1945,13 @@ void testMolFileAtomValues(){
     fName = rdbase+"test_data/AtomProps2.mol";
     m = MolFileToMol(fName);
     TEST_ASSERT(m);
-    TEST_ASSERT(!m->getAtomWithIdx(0)->hasProp("molFileValue"));
-    TEST_ASSERT(m->getAtomWithIdx(1)->hasProp("molFileValue"));
-    m->getAtomWithIdx(1)->getProp("molFileValue",val);
+    TEST_ASSERT(!m->getAtomWithIdx(0)->hasProp(common_properties::molFileValue));
+    TEST_ASSERT(m->getAtomWithIdx(1)->hasProp(common_properties::molFileValue));
+    m->getAtomWithIdx(1)->getProp(common_properties::molFileValue,val);
     TEST_ASSERT(val=="acidchloride");
 
-    TEST_ASSERT(m->getAtomWithIdx(2)->hasProp("molFileValue"));
-    m->getAtomWithIdx(2)->getProp("molFileValue",val);
+    TEST_ASSERT(m->getAtomWithIdx(2)->hasProp(common_properties::molFileValue));
+    m->getAtomWithIdx(2)->getProp(common_properties::molFileValue,val);
     TEST_ASSERT(val=="testing");
 
     TEST_ASSERT(m->getAtomWithIdx(3)->getFormalCharge()==-1);
@@ -2071,8 +2071,8 @@ void testListsAndValues(){
 
     std::string value;
 
-    TEST_ASSERT(m->getAtomWithIdx(1)->hasProp("molFileValue"));
-    m->getAtomWithIdx(1)->getProp("molFileValue",value);
+    TEST_ASSERT(m->getAtomWithIdx(1)->hasProp(common_properties::molFileValue));
+    m->getAtomWithIdx(1)->getProp(common_properties::molFileValue,value);
     TEST_ASSERT(value=="halogen");
     
     TEST_ASSERT(m->getAtomWithIdx(1)->hasQuery());
@@ -2419,22 +2419,22 @@ void test3V3K(){
     unsigned int idx;
     std::string label;
   
-    TEST_ASSERT(m->getAtomWithIdx(3)->hasProp("_MolFileRLabel"));
-    m->getAtomWithIdx(3)->getProp("_MolFileRLabel",idx);
+    TEST_ASSERT(m->getAtomWithIdx(3)->hasProp(common_properties::_MolFileRLabel));
+    m->getAtomWithIdx(3)->getProp(common_properties::_MolFileRLabel,idx);
     TEST_ASSERT(idx==2);
     TEST_ASSERT(m->getAtomWithIdx(3)->getAtomicNum()==0);
     TEST_ASSERT(feq(m->getAtomWithIdx(3)->getIsotope(),2));
-    TEST_ASSERT(m->getAtomWithIdx(4)->hasProp("_MolFileRLabel"));
-    m->getAtomWithIdx(4)->getProp("_MolFileRLabel",idx);
+    TEST_ASSERT(m->getAtomWithIdx(4)->hasProp(common_properties::_MolFileRLabel));
+    m->getAtomWithIdx(4)->getProp(common_properties::_MolFileRLabel,idx);
     TEST_ASSERT(idx==1);
     TEST_ASSERT(m->getAtomWithIdx(4)->getAtomicNum()==0);
     TEST_ASSERT(feq(m->getAtomWithIdx(4)->getIsotope(),1));
-    TEST_ASSERT(m->getAtomWithIdx(3)->hasProp("dummyLabel"));
-    m->getAtomWithIdx(3)->getProp("dummyLabel",label);
+    TEST_ASSERT(m->getAtomWithIdx(3)->hasProp(common_properties::dummyLabel));
+    m->getAtomWithIdx(3)->getProp(common_properties::dummyLabel,label);
     TEST_ASSERT(label=="R2");
     TEST_ASSERT(m->getAtomWithIdx(3)->getSymbol()=="R2");
-    TEST_ASSERT(m->getAtomWithIdx(4)->hasProp("dummyLabel"));
-    m->getAtomWithIdx(4)->getProp("dummyLabel",label);
+    TEST_ASSERT(m->getAtomWithIdx(4)->hasProp(common_properties::dummyLabel));
+    m->getAtomWithIdx(4)->getProp(common_properties::dummyLabel,label);
     TEST_ASSERT(label=="R1");
     TEST_ASSERT(m->getAtomWithIdx(4)->getSymbol()=="R1");
 
@@ -2442,22 +2442,22 @@ void test3V3K(){
     delete m;
     m = MolBlockToMol(mb);
     TEST_ASSERT(m);
-    TEST_ASSERT(m->getAtomWithIdx(3)->hasProp("_MolFileRLabel"));
-    m->getAtomWithIdx(3)->getProp("_MolFileRLabel",idx);
+    TEST_ASSERT(m->getAtomWithIdx(3)->hasProp(common_properties::_MolFileRLabel));
+    m->getAtomWithIdx(3)->getProp(common_properties::_MolFileRLabel,idx);
     TEST_ASSERT(idx==2);
     TEST_ASSERT(m->getAtomWithIdx(3)->getAtomicNum()==0);
     TEST_ASSERT(feq(m->getAtomWithIdx(3)->getIsotope(),2));
-    TEST_ASSERT(m->getAtomWithIdx(4)->hasProp("_MolFileRLabel"));
-    m->getAtomWithIdx(4)->getProp("_MolFileRLabel",idx);
+    TEST_ASSERT(m->getAtomWithIdx(4)->hasProp(common_properties::_MolFileRLabel));
+    m->getAtomWithIdx(4)->getProp(common_properties::_MolFileRLabel,idx);
     TEST_ASSERT(idx==1);
     TEST_ASSERT(m->getAtomWithIdx(4)->getAtomicNum()==0);
     TEST_ASSERT(feq(m->getAtomWithIdx(4)->getIsotope(),1));
-    TEST_ASSERT(m->getAtomWithIdx(3)->hasProp("dummyLabel"));
-    m->getAtomWithIdx(3)->getProp("dummyLabel",label);
+    TEST_ASSERT(m->getAtomWithIdx(3)->hasProp(common_properties::dummyLabel));
+    m->getAtomWithIdx(3)->getProp(common_properties::dummyLabel,label);
     TEST_ASSERT(label=="R2");
     TEST_ASSERT(m->getAtomWithIdx(3)->getSymbol()=="R2");
-    TEST_ASSERT(m->getAtomWithIdx(4)->hasProp("dummyLabel"));
-    m->getAtomWithIdx(4)->getProp("dummyLabel",label);
+    TEST_ASSERT(m->getAtomWithIdx(4)->hasProp(common_properties::dummyLabel));
+    m->getAtomWithIdx(4)->getProp(common_properties::dummyLabel,label);
     TEST_ASSERT(label=="R1");
     TEST_ASSERT(m->getAtomWithIdx(4)->getSymbol()=="R1");
 
@@ -2866,24 +2866,24 @@ void testIssue3313540(){
     TEST_ASSERT(m);
     unsigned int idx;
   
-    TEST_ASSERT(m->getAtomWithIdx(3)->hasProp("_MolFileRLabel"));
-    m->getAtomWithIdx(3)->getProp("_MolFileRLabel",idx);
+    TEST_ASSERT(m->getAtomWithIdx(3)->hasProp(common_properties::_MolFileRLabel));
+    m->getAtomWithIdx(3)->getProp(common_properties::_MolFileRLabel,idx);
     TEST_ASSERT(idx==2);
   
-    TEST_ASSERT(m->getAtomWithIdx(4)->hasProp("_MolFileRLabel"));
-    m->getAtomWithIdx(4)->getProp("_MolFileRLabel",idx);
+    TEST_ASSERT(m->getAtomWithIdx(4)->hasProp(common_properties::_MolFileRLabel));
+    m->getAtomWithIdx(4)->getProp(common_properties::_MolFileRLabel,idx);
     TEST_ASSERT(idx==1);
 
     std::string mb=MolToMolBlock(*m);
     RWMol *m2=MolBlockToMol(mb);
     TEST_ASSERT(m2);
     
-    TEST_ASSERT(m2->getAtomWithIdx(3)->hasProp("_MolFileRLabel"));
-    m2->getAtomWithIdx(3)->getProp("_MolFileRLabel",idx);
+    TEST_ASSERT(m2->getAtomWithIdx(3)->hasProp(common_properties::_MolFileRLabel));
+    m2->getAtomWithIdx(3)->getProp(common_properties::_MolFileRLabel,idx);
     TEST_ASSERT(idx==2);
   
-    TEST_ASSERT(m2->getAtomWithIdx(4)->hasProp("_MolFileRLabel"));
-    m2->getAtomWithIdx(4)->getProp("_MolFileRLabel",idx);
+    TEST_ASSERT(m2->getAtomWithIdx(4)->hasProp(common_properties::_MolFileRLabel));
+    m2->getAtomWithIdx(4)->getProp(common_properties::_MolFileRLabel,idx);
     TEST_ASSERT(idx==1);
     
     delete m;
@@ -2923,9 +2923,9 @@ void testIssue3374639(){
     std::string fName = rdbase + "/Code/GraphMol/FileParsers/test_data/Issue3374639.2.mol";
     RWMol *m = MolFileToMol(fName);
 
-    TEST_ASSERT(m->getAtomWithIdx(1)->hasProp("_CIPCode"));
+    TEST_ASSERT(m->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
     std::string cip;
-    m->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+    m->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="S");  
     delete m;
   }
@@ -2933,9 +2933,9 @@ void testIssue3374639(){
     std::string fName = rdbase + "/Code/GraphMol/FileParsers/test_data/Issue3374639.1.mol";
     RWMol *m = MolFileToMol(fName);
 
-    TEST_ASSERT(m->getAtomWithIdx(1)->hasProp("_CIPCode"));
+    TEST_ASSERT(m->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
     std::string cip;
-    m->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+    m->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="S");  
     delete m;
   }
@@ -2943,9 +2943,9 @@ void testIssue3374639(){
     std::string fName = rdbase + "/Code/GraphMol/FileParsers/test_data/Issue3374639.full.mol";
     RWMol *m = MolFileToMol(fName);
 
-    TEST_ASSERT(m->getAtomWithIdx(16)->hasProp("_CIPCode"));
+    TEST_ASSERT(m->getAtomWithIdx(16)->hasProp(common_properties::_CIPCode));
     std::string cip;
-    m->getAtomWithIdx(16)->getProp("_CIPCode",cip);
+    m->getAtomWithIdx(16)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="S");  
     delete m;
   }
@@ -2962,9 +2962,9 @@ void testThreeCoordinateChirality(){
     std::string fName = rdbase + "/Code/GraphMol/FileParsers/test_data/three_coordinate_chirality.1.mol";
     RWMol *m = MolFileToMol(fName);
 
-    TEST_ASSERT(m->getAtomWithIdx(1)->hasProp("_CIPCode"));
+    TEST_ASSERT(m->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
     std::string cip;
-    m->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+    m->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="S");  
     delete m;
   }
@@ -2973,9 +2973,9 @@ void testThreeCoordinateChirality(){
     std::string fName = rdbase + "/Code/GraphMol/FileParsers/test_data/three_coordinate_chirality.2.mol";
     RWMol *m = MolFileToMol(fName);
 
-    TEST_ASSERT(m->getAtomWithIdx(1)->hasProp("_CIPCode"));
+    TEST_ASSERT(m->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
     std::string cip;
-    m->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+    m->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="S");  
     delete m;
   }
@@ -2984,7 +2984,7 @@ void testThreeCoordinateChirality(){
     std::string fName = rdbase + "/Code/GraphMol/FileParsers/test_data/three_coordinate_chirality.3.mol";
     RWMol *m = MolFileToMol(fName);
 
-    TEST_ASSERT(!m->getAtomWithIdx(1)->hasProp("_CIPCode"));
+    TEST_ASSERT(!m->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
     delete m;
   }
   
@@ -2992,7 +2992,7 @@ void testThreeCoordinateChirality(){
     std::string fName = rdbase + "/Code/GraphMol/FileParsers/test_data/three_coordinate_chirality.4.mol";
     RWMol *m = MolFileToMol(fName);
 
-    TEST_ASSERT(!m->getAtomWithIdx(1)->hasProp("_CIPCode"));
+    TEST_ASSERT(!m->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
     delete m;
   }
   
@@ -3000,9 +3000,9 @@ void testThreeCoordinateChirality(){
     std::string fName = rdbase + "/Code/GraphMol/FileParsers/test_data/three_coordinate_chirality.5.mol";
     RWMol *m = MolFileToMol(fName);
 
-    TEST_ASSERT(m->getAtomWithIdx(1)->hasProp("_CIPCode"));
+    TEST_ASSERT(m->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
     std::string cip;
-    m->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+    m->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="S");  
     delete m;
   }
@@ -3010,9 +3010,9 @@ void testThreeCoordinateChirality(){
     std::string fName = rdbase + "/Code/GraphMol/FileParsers/test_data/three_coordinate_chirality.6.mol";
     RWMol *m = MolFileToMol(fName);
 
-    TEST_ASSERT(m->getAtomWithIdx(1)->hasProp("_CIPCode"));
+    TEST_ASSERT(m->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
     std::string cip;
-    m->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+    m->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="S");  
     delete m;
   }
@@ -3082,9 +3082,9 @@ void testChiralPhosphorous(){
     RWMol *m = MolFileToMol(fName);
     TEST_ASSERT(m);
 
-    TEST_ASSERT(m->getAtomWithIdx(5)->hasProp("_CIPCode"));
+    TEST_ASSERT(m->getAtomWithIdx(5)->hasProp(common_properties::_CIPCode));
     std::string cip;
-    m->getAtomWithIdx(5)->getProp("_CIPCode",cip);
+    m->getAtomWithIdx(5)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="R");  
     delete m;
   }
@@ -3093,9 +3093,9 @@ void testChiralPhosphorous(){
     RWMol *m = MolFileToMol(fName);
     TEST_ASSERT(m);
 
-    TEST_ASSERT(m->getAtomWithIdx(5)->hasProp("_CIPCode"));
+    TEST_ASSERT(m->getAtomWithIdx(5)->hasProp(common_properties::_CIPCode));
     std::string cip;
-    m->getAtomWithIdx(5)->getProp("_CIPCode",cip);
+    m->getAtomWithIdx(5)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="S");  
     delete m;
   }
@@ -3104,7 +3104,7 @@ void testChiralPhosphorous(){
     RWMol *m = MolFileToMol(fName);
     TEST_ASSERT(m);
 
-    TEST_ASSERT(!m->getAtomWithIdx(5)->hasProp("_CIPCode"));
+    TEST_ASSERT(!m->getAtomWithIdx(5)->hasProp(common_properties::_CIPCode));
     delete m;
   }
   {
@@ -3112,7 +3112,7 @@ void testChiralPhosphorous(){
     RWMol *m = MolFileToMol(fName);
     TEST_ASSERT(m);
 
-    TEST_ASSERT(!m->getAtomWithIdx(5)->hasProp("_CIPCode"));
+    TEST_ASSERT(!m->getAtomWithIdx(5)->hasProp(common_properties::_CIPCode));
     delete m;
   }
   BOOST_LOG(rdInfoLog) << " Finished <---------- "<< std::endl;
@@ -3338,9 +3338,9 @@ void testMolFileChiralFlag(){
     fName = rdbase+"chiral_flag.mol";
     m1 = MolFileToMol(fName);
     TEST_ASSERT(m1);
-    TEST_ASSERT(m1->hasProp("_MolFileChiralFlag"));
+    TEST_ASSERT(m1->hasProp(common_properties::_MolFileChiralFlag));
     unsigned int cflag;
-    m1->getProp("_MolFileChiralFlag",cflag);
+    m1->getProp(common_properties::_MolFileChiralFlag,cflag);
     TEST_ASSERT(cflag==1);
     delete m1;
   }
@@ -3518,15 +3518,15 @@ void testMolFileWithRxn(){
     TEST_ASSERT(m->getNumAtoms()==18);
     TEST_ASSERT(m->getNumBonds()==16);
 
-    TEST_ASSERT(m->getAtomWithIdx(0)->hasProp("molRxnRole"));
-    TEST_ASSERT(m->getAtomWithIdx(0)->getProp<int>("molRxnRole")==1);
-    TEST_ASSERT(m->getAtomWithIdx(0)->hasProp("molRxnComponent"));
-    TEST_ASSERT(m->getAtomWithIdx(0)->getProp<int>("molRxnComponent")==1);
+    TEST_ASSERT(m->getAtomWithIdx(0)->hasProp(common_properties::molRxnRole));
+    TEST_ASSERT(m->getAtomWithIdx(0)->getProp<int>(common_properties::molRxnRole)==1);
+    TEST_ASSERT(m->getAtomWithIdx(0)->hasProp(common_properties::molRxnComponent));
+    TEST_ASSERT(m->getAtomWithIdx(0)->getProp<int>(common_properties::molRxnComponent)==1);
 
-    TEST_ASSERT(m->getAtomWithIdx(17)->hasProp("molRxnRole"));
-    TEST_ASSERT(m->getAtomWithIdx(17)->getProp<int>("molRxnRole")==2);
-    TEST_ASSERT(m->getAtomWithIdx(17)->hasProp("molRxnComponent"));
-    TEST_ASSERT(m->getAtomWithIdx(17)->getProp<int>("molRxnComponent")==3);
+    TEST_ASSERT(m->getAtomWithIdx(17)->hasProp(common_properties::molRxnRole));
+    TEST_ASSERT(m->getAtomWithIdx(17)->getProp<int>(common_properties::molRxnRole)==2);
+    TEST_ASSERT(m->getAtomWithIdx(17)->hasProp(common_properties::molRxnComponent));
+    TEST_ASSERT(m->getAtomWithIdx(17)->getProp<int>(common_properties::molRxnComponent)==3);
 
 
 
@@ -3823,8 +3823,8 @@ void testGithub210(){
     pathName += "/Code/GraphMol/FileParsers/test_data/";
     RWMol *m = MolFileToMol(pathName+"github210.mol");
     TEST_ASSERT(m);
-    TEST_ASSERT(m->getAtomWithIdx(1)->hasProp("_CIPCode"));
-    TEST_ASSERT(m->getAtomWithIdx(4)->hasProp("_ChiralityPossible"));
+    TEST_ASSERT(m->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+    TEST_ASSERT(m->getAtomWithIdx(4)->hasProp(common_properties::_ChiralityPossible));
     delete m;
   }
   BOOST_LOG(rdInfoLog) << "Finished" << std::endl;

--- a/Code/GraphMol/FileParsers/testMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/testMolSupplier.cpp
@@ -44,7 +44,7 @@ int testMolSup() {
     while (!sdsup.atEnd()) {
       ROMol *nmol = sdsup.next();
       if (nmol) {
-        TEST_ASSERT(nmol->hasProp("_Name"));
+        TEST_ASSERT(nmol->hasProp(common_properties::_Name));
         TEST_ASSERT(nmol->hasProp("NCI_AIDS_Antiviral_Screen_Conclusion"));
         delete nmol;
       }
@@ -57,7 +57,7 @@ int testMolSup() {
     for(unsigned int i=0;i<16;++i){
       ROMol *nmol = sdsup.next();
       if (nmol) {
-        TEST_ASSERT(nmol->hasProp("_Name"));
+        TEST_ASSERT(nmol->hasProp(common_properties::_Name));
         TEST_ASSERT(nmol->hasProp("NCI_AIDS_Antiviral_Screen_Conclusion"));
         delete nmol;
       }
@@ -79,7 +79,7 @@ int testMolSup() {
     while (!sdsup.atEnd()) {
       ROMol *nmol = sdsup.next();
       if (nmol) {
-        TEST_ASSERT(nmol->hasProp("_Name"));
+        TEST_ASSERT(nmol->hasProp(common_properties::_Name));
         TEST_ASSERT(nmol->hasProp("NCI_AIDS_Antiviral_Screen_Conclusion"));
         delete nmol;
       }
@@ -94,7 +94,7 @@ int testMolSup() {
     while (!sdsup.atEnd()) {
       ROMol *nmol = sdsup.next();
       if (nmol) {
-        TEST_ASSERT(nmol->hasProp("_Name"));
+        TEST_ASSERT(nmol->hasProp(common_properties::_Name));
         TEST_ASSERT(nmol->hasProp("NCI_AIDS_Antiviral_Screen_Conclusion"));
         delete nmol;
       }
@@ -130,7 +130,7 @@ void testRandMolSup() {
   for (i = 0; i < 8; i++) {
     ROMol *mol = sdsup[2*i];
     std::string mname;
-    mol->getProp("_Name", mname);
+    mol->getProp(common_properties::_Name, mname);
     CHECK_INVARIANT(mname == names[i], "");
     delete mol;
   }
@@ -139,7 +139,7 @@ void testRandMolSup() {
   ROMol *mol = sdsup[5];
   TEST_ASSERT(mol);
   std::string mname;
-  mol->getProp("_Name", mname);
+  mol->getProp(common_properties::_Name, mname);
   delete mol;
   CHECK_INVARIANT(mname == "170", "");
 
@@ -180,7 +180,7 @@ void testSmilesSup() {
     TEST_ASSERT(!nSup2.atEnd())
     TEST_ASSERT(nSup2.length() == 10);
 
-    mol->getProp("_Name", mname);
+    mol->getProp(common_properties::_Name, mname);
     CHECK_INVARIANT(mname == "4", "");
     mol->getProp("TPSA", mname);
     CHECK_INVARIANT(mname == "82.78", "");
@@ -201,7 +201,7 @@ void testSmilesSup() {
     mol = nSup2[3];
     CHECK_INVARIANT(nSup2.length() == 10, "");
 
-    mol->getProp("_Name", mname);
+    mol->getProp(common_properties::_Name, mname);
     CHECK_INVARIANT(mname == "4", "");
     mol->getProp("TPSA", mname);
     CHECK_INVARIANT(mname == "82.78", "");
@@ -239,7 +239,7 @@ void testSmilesSup() {
   mol = smiSup.next();
   while (1) {
     std::string mname;
-    mol->getProp("_Name", mname);
+    mol->getProp(common_properties::_Name, mname);
     i++;
     delete mol;
     try {
@@ -260,7 +260,7 @@ void testSmilesSup() {
   mol = (*nSup)[3];
   
 
-  mol->getProp("_Name", mname);
+  mol->getProp(common_properties::_Name, mname);
   CHECK_INVARIANT(mname == "4", "");
   mol->getProp("Column_2", mname);
   CHECK_INVARIANT(mname == "82.78", "");
@@ -318,8 +318,8 @@ void testSmilesSupFromText() {
     mol = nSup2[2];
     nAts = mol->getNumAtoms();
     TEST_ASSERT(nAts==4);
-    TEST_ASSERT(mol->hasProp("_Name"));
-    mol->getProp("_Name",mname);
+    TEST_ASSERT(mol->hasProp(common_properties::_Name));
+    mol->getProp(common_properties::_Name,mname);
     TEST_ASSERT(mname=="2");
   }
   {
@@ -328,15 +328,15 @@ void testSmilesSupFromText() {
     TEST_ASSERT(mol);
     nAts = mol->getNumAtoms();
     TEST_ASSERT(nAts==4);
-    TEST_ASSERT(mol->hasProp("_Name"));
-    mol->getProp("_Name",mname);
+    TEST_ASSERT(mol->hasProp(common_properties::_Name));
+    mol->getProp(common_properties::_Name,mname);
     TEST_ASSERT(mname=="2");
     mol = nSup2[3];
     TEST_ASSERT(mol);
     nAts = mol->getNumAtoms();
     TEST_ASSERT(nAts==6);
-    TEST_ASSERT(mol->hasProp("_Name"));
-    mol->getProp("_Name",mname);
+    TEST_ASSERT(mol->hasProp(common_properties::_Name));
+    mol->getProp(common_properties::_Name,mname);
     TEST_ASSERT(mname=="3");
   }
   {
@@ -345,15 +345,15 @@ void testSmilesSupFromText() {
     TEST_ASSERT(mol);
     nAts = mol->getNumAtoms();
     TEST_ASSERT(nAts==6);
-    TEST_ASSERT(mol->hasProp("_Name"));
-    mol->getProp("_Name",mname);
+    TEST_ASSERT(mol->hasProp(common_properties::_Name));
+    mol->getProp(common_properties::_Name,mname);
     TEST_ASSERT(mname=="3");
     mol = nSup2[2];
     TEST_ASSERT(mol);
     nAts = mol->getNumAtoms();
     TEST_ASSERT(nAts==4);
-    TEST_ASSERT(mol->hasProp("_Name"));
-    mol->getProp("_Name",mname);
+    TEST_ASSERT(mol->hasProp(common_properties::_Name));
+    mol->getProp(common_properties::_Name,mname);
     TEST_ASSERT(mname=="2");
   }
   // --------------
@@ -369,7 +369,7 @@ void testSmilesSupFromText() {
   mol = nSup2[3];
   //  BOOST_LOG(rdErrorLog) << "SIZE: " << nSup2.length() << std::endl;
   CHECK_INVARIANT(nSup2.length() == 4, "");
-  mol->getProp("_Name",mname);
+  mol->getProp(common_properties::_Name,mname);
   TEST_ASSERT(mname=="mol-4");
   mol->getProp("Column_2",mname);
   TEST_ASSERT(mname=="16.0");
@@ -383,7 +383,7 @@ void testSmilesSupFromText() {
   nSup2.setData(text," ",1,0,true,true);
   CHECK_INVARIANT(nSup2.length() == 3, "");
   mol = nSup2[2];
-  mol->getProp("_Name",mname);
+  mol->getProp(common_properties::_Name,mname);
   TEST_ASSERT(mname=="mol-3");
   mol->getProp("Column_2",mname);
   TEST_ASSERT(mname=="9.0");
@@ -400,7 +400,7 @@ void testSmilesSupFromText() {
   mol = nSup2[3];
   //  BOOST_LOG(rdErrorLog) << "SIZE: " << nSup2.length() << std::endl;
   TEST_ASSERT(nSup2.length() == 4);
-  mol->getProp("_Name",mname);
+  mol->getProp(common_properties::_Name,mname);
   TEST_ASSERT(mname=="mol-4");
   mol->getProp("Column_2",mname);
   TEST_ASSERT(mname=="16.0");
@@ -419,7 +419,7 @@ void testSmilesSupFromText() {
   TEST_ASSERT(nSup2.length() == 3);
   mol = nSup2[2];
   TEST_ASSERT(mol);
-  mol->getProp("_Name",mname);
+  mol->getProp(common_properties::_Name,mname);
   TEST_ASSERT(mname=="mol-4");
   mol->getProp("Column_2",mname);
   TEST_ASSERT(mname=="16.0");
@@ -435,7 +435,7 @@ void testSmilesSupFromText() {
   TEST_ASSERT(nSup2.length() == 3);
   mol = nSup2[2];
   TEST_ASSERT(mol);
-  mol->getProp("_Name",mname);
+  mol->getProp(common_properties::_Name,mname);
   TEST_ASSERT(mname=="mol-4");
   mol->getProp("Column_2",mname);
   TEST_ASSERT(mname=="16.0");
@@ -457,7 +457,7 @@ void testSmilesSupFromText() {
   TEST_ASSERT(nSup2.length() == 3);
   mol = nSup2[2];
   TEST_ASSERT(mol);
-  mol->getProp("_Name",mname);
+  mol->getProp(common_properties::_Name,mname);
   TEST_ASSERT(mname=="mol-4");
   mol->getProp("Column_2",mname);
   TEST_ASSERT(mname=="16.0");
@@ -534,12 +534,12 @@ void testSmilesSupFromText() {
     ;
   nSup2.setData(text," ",1,0,true,true);
   mol = nSup2[2];
-  mol->getProp("_Name",mname);
+  mol->getProp(common_properties::_Name,mname);
   TEST_ASSERT(mname=="mol-3");
   mol->getProp("Column_2",mname);
   TEST_ASSERT(mname=="9.0");
   mol = nSup2[1];
-  mol->getProp("_Name",mname);
+  mol->getProp(common_properties::_Name,mname);
   TEST_ASSERT(mname=="mol-2");
   mol->getProp("Column_2",mname);
   TEST_ASSERT(mname=="4.0");
@@ -585,7 +585,7 @@ void testSmilesWriter() {
   while (mol) {
     //BOOST_LOG(rdErrorLog) << "MOL: " << MolToSmiles(*mol) << std::endl;
     std::string mname, pval;
-    mol->getProp("_Name", mname);
+    mol->getProp(common_properties::_Name, mname);
     mol->getProp("Column_2", pval);
     names.push_back(mname);
     props.push_back(pval);
@@ -607,7 +607,7 @@ void testSmilesWriter() {
   mol = nSup->next();
   while (mol){
     std::string mname, pval;
-    mol->getProp("_Name", mname);
+    mol->getProp(common_properties::_Name, mname);
     mol->getProp("Column_2", pval);
     CHECK_INVARIANT(mname == names[i], "");
     CHECK_INVARIANT(pval == props[i], "");
@@ -637,7 +637,7 @@ void testSDWriter() {
   while (!sdsup.atEnd()) {
     ROMol *mol = sdsup.next();
     std::string mname;
-    mol->getProp("_Name", mname);
+    mol->getProp(common_properties::_Name, mname);
     names.push_back(mname);
 
     writer->write(*mol);
@@ -654,7 +654,7 @@ void testSDWriter() {
   while (!reader.atEnd()) {
     ROMol *mol = reader.next();
     std::string mname;
-    mol->getProp("_Name", mname);
+    mol->getProp(common_properties::_Name, mname);
     BOOST_LOG(rdInfoLog) << mname << "\n";
     //CHECK_INVARIANT(mname == names[i], "");
     
@@ -670,7 +670,7 @@ void testSDWriter() {
   while (!nreader.atEnd()) {
     ROMol *mol = nreader.next();
     std::string mname;
-    mol->getProp("_Name", mname);
+    mol->getProp(common_properties::_Name, mname);
     BOOST_LOG(rdInfoLog) << mname << "\n";
     //CHECK_INVARIANT(mname == names[i], "");
     i++;
@@ -692,7 +692,7 @@ void testSDSupplierEnding() {
   while (!reader.atEnd()) {
     ROMol *mol = reader.next();
     std::string mname;
-    mol->getProp("_Name", mname);
+    mol->getProp(common_properties::_Name, mname);
     i++;
     delete mol;
   }
@@ -806,7 +806,7 @@ void testCisTrans() {
   while (!reader->atEnd()) {
     ROMol *mol = reader->next();
     std::string mname;
-    mol->getProp("_Name", mname);
+    mol->getProp(common_properties::_Name, mname);
     BOOST_LOG(rdInfoLog) << mname << " ";
     BOOST_LOG(rdInfoLog) << MolToSmiles(*mol, 1) << "\n";
     delete mol;
@@ -837,7 +837,7 @@ void testStereoRound() {
     ROMol *mol = smiSup->next();
     //mol->debugMol(std::cout);
     std::string mname;
-    mol->getProp("_Name", mname);
+    mol->getProp(common_properties::_Name, mname);
     nameSmi[mname] = MolToSmiles(*mol, 1);
       
     ROMol *nmol = SmilesToMol(nameSmi[mname]);
@@ -876,7 +876,7 @@ void testStereoRound() {
     //mol->debugMol(std::cout);
     std::string smiles = MolToSmiles(*mol, 1);
     std::string mname;
-    mol->getProp("_Name", mname);
+    mol->getProp(common_properties::_Name, mname);
     if (nameSmi[mname] != smiles) {
       BOOST_LOG(rdInfoLog) << mname << " " << nameSmi[mname] << " " << smiles << "\n";
     }
@@ -917,15 +917,15 @@ int testTDTSupplier1() {
         std::string prop1,prop2;
         TEST_ASSERT(nmol->getNumAtoms()>0);
         TEST_ASSERT(nmol->hasProp("PN"));
-        TEST_ASSERT(nmol->hasProp("_Name"));
+        TEST_ASSERT(nmol->hasProp(common_properties::_Name));
         TEST_ASSERT(nmol->hasProp("MFCD"));
 
         nmol->getProp("PN",prop1);
-        nmol->getProp("_Name",prop2);
+        nmol->getProp(common_properties::_Name,prop2);
         TEST_ASSERT(prop1==prop2);
       
         // we didn't ask for 2D conformers, so there should be a property 2D:
-        TEST_ASSERT(nmol->hasProp("2D"));
+        TEST_ASSERT(nmol->hasProp(common_properties::TWOD));
         // and no conformer:
         TEST_ASSERT(!nmol->getNumConformers());
       
@@ -945,15 +945,15 @@ int testTDTSupplier1() {
         std::string prop1,prop2;
         TEST_ASSERT(nmol->getNumAtoms()>0);
         TEST_ASSERT(nmol->hasProp("PN"));
-        TEST_ASSERT(nmol->hasProp("_Name"));
+        TEST_ASSERT(nmol->hasProp(common_properties::_Name));
         TEST_ASSERT(nmol->hasProp("MFCD"));
 
         nmol->getProp("PN",prop1);
-        nmol->getProp("_Name",prop2);
+        nmol->getProp(common_properties::_Name,prop2);
         TEST_ASSERT(prop1==prop2);
       
         // we didn't ask for 2D conformers, so there should be a property 2D:
-        TEST_ASSERT(nmol->hasProp("2D"));
+        TEST_ASSERT(nmol->hasProp(common_properties::TWOD));
         // and no conformer:
         TEST_ASSERT(!nmol->getNumConformers());
       
@@ -978,15 +978,15 @@ int testTDTSupplier2() {
     if (nmol) {
       TEST_ASSERT(nmol->getNumAtoms()>0);
       TEST_ASSERT(nmol->hasProp("PN"));
-      TEST_ASSERT(nmol->hasProp("_Name"));
+      TEST_ASSERT(nmol->hasProp(common_properties::_Name));
       TEST_ASSERT(nmol->hasProp("MFCD"));
 
       nmol->getProp("PN",prop1);
-      nmol->getProp("_Name",prop2);
+      nmol->getProp(common_properties::_Name,prop2);
       TEST_ASSERT(prop1==prop2);
       
       // we asked for 2D conformers, so there should be no property 2D:
-      TEST_ASSERT(!nmol->hasProp("2D"));
+      TEST_ASSERT(!nmol->hasProp(common_properties::TWOD));
       // and a conformer:
       TEST_ASSERT(nmol->getNumConformers()==1);
       // with id "2":
@@ -1026,10 +1026,10 @@ int testTDTSupplier3() {
     if (nmol) {
       TEST_ASSERT(nmol->getNumAtoms()>0);
       TEST_ASSERT(nmol->hasProp("CAS"));
-      TEST_ASSERT(nmol->hasProp("_Name"));
+      TEST_ASSERT(nmol->hasProp(common_properties::_Name));
 
       nmol->getProp("CAS",prop1);
-      nmol->getProp("_Name",prop2);
+      nmol->getProp(common_properties::_Name,prop2);
       TEST_ASSERT(prop1==prop2);
       
       // no conformers should have been read:
@@ -1056,10 +1056,10 @@ int testTDTSupplier3() {
     if (nmol) {
       TEST_ASSERT(nmol->getNumAtoms()>0);
       TEST_ASSERT(nmol->hasProp("CAS"));
-      TEST_ASSERT(nmol->hasProp("_Name"));
+      TEST_ASSERT(nmol->hasProp(common_properties::_Name));
 
       nmol->getProp("CAS",prop1);
-      nmol->getProp("_Name",prop2);
+      nmol->getProp(common_properties::_Name,prop2);
       TEST_ASSERT(prop1==prop2);
       
       // no conformers should have been read:
@@ -1124,7 +1124,7 @@ void testSDSupplierFromText() {
   while (!reader.atEnd()) {
     ROMol *mol = reader.next();
     std::string mname;
-    TEST_ASSERT(mol->hasProp("_Name"));
+    TEST_ASSERT(mol->hasProp(common_properties::_Name));
     TEST_ASSERT(mol->hasProp("ID"));
     i++;
     delete mol;
@@ -1692,7 +1692,7 @@ int testForwardSDSupplier() {
       ROMol *nmol = sdsup.next();
       TEST_ASSERT(nmol || sdsup.atEnd());
       if (nmol) {
-        TEST_ASSERT(nmol->hasProp("_Name"));
+        TEST_ASSERT(nmol->hasProp(common_properties::_Name));
         TEST_ASSERT(nmol->hasProp("NCI_AIDS_Antiviral_Screen_Conclusion"));
         delete nmol;
         i++;
@@ -1740,7 +1740,7 @@ int testForwardSDSupplier() {
     while (!sdsup.atEnd()) {
       ROMol *nmol = sdsup.next();
       if (nmol) {
-        TEST_ASSERT(nmol->hasProp("_Name"));
+        TEST_ASSERT(nmol->hasProp(common_properties::_Name));
         TEST_ASSERT(nmol->hasProp("NCI_AIDS_Antiviral_Screen_Conclusion"));
         delete nmol;
         i++;

--- a/Code/GraphMol/FileParsers/testMolWriter.cpp
+++ b/Code/GraphMol/FileParsers/testMolWriter.cpp
@@ -41,7 +41,7 @@ void testSmilesWriter() {
   ROMol *mol = nSup->next();
   while (mol) {
     std::string mname, pval;
-    mol->getProp("_Name", mname);
+    mol->getProp(common_properties::_Name, mname);
     mol->getProp("Column_2", pval);
     names.push_back(mname);
     props.push_back(pval);
@@ -63,7 +63,7 @@ void testSmilesWriter() {
   mol = nSup->next();
   while (mol){
     std::string mname, pval;
-    mol->getProp("_Name", mname);
+    mol->getProp(common_properties::_Name, mname);
     mol->getProp("Column_2", pval);
     CHECK_INVARIANT(mname == names[i], "");
     CHECK_INVARIANT(pval == props[i], "");
@@ -130,7 +130,7 @@ void testSmilesWriterNoNames() {
   while (mol) {
     std::string mname, pval;
     mol->getProp("Column_2", pval);
-    mol->setProp("_Name","bogus");
+    mol->setProp(common_properties::_Name,"bogus");
     props.push_back(pval);
     writer->write(*mol);
     delete mol;
@@ -150,7 +150,7 @@ void testSmilesWriterNoNames() {
   mol = nSup->next();
   while (mol){
     std::string mname, pval;
-    mol->getProp("_Name", mname);
+    mol->getProp(common_properties::_Name, mname);
     TEST_ASSERT(mname!="bogus");
     mol->getProp("Column_2", pval);
     TEST_ASSERT(pval == props[i]);
@@ -180,7 +180,7 @@ void testSmilesWriterClose() {
   while (mol) {
     std::string mname, pval;
     mol->getProp("Column_2", pval);
-    mol->setProp("_Name","bogus");
+    mol->setProp(common_properties::_Name,"bogus");
     props.push_back(pval);
     writer->write(*mol);
     delete mol;
@@ -199,7 +199,7 @@ void testSmilesWriterClose() {
   mol = nSup->next();
   while (mol){
     std::string mname, pval;
-    mol->getProp("_Name", mname);
+    mol->getProp(common_properties::_Name, mname);
     TEST_ASSERT(mname!="bogus");
     mol->getProp("Column_2", pval);
     TEST_ASSERT(pval == props[i]);
@@ -226,7 +226,7 @@ void testSDWriter() {
   while (!sdsup.atEnd()) {
     ROMol *mol = sdsup.next();
     std::string mname;
-    mol->getProp("_Name", mname);
+    mol->getProp(common_properties::_Name, mname);
     names.push_back(mname);
 
     writer->write(*mol);
@@ -246,7 +246,7 @@ void testSDWriter() {
   while (!reader.atEnd()) {
     ROMol *mol = reader.next();
     std::string mname;
-    mol->getProp("_Name", mname);
+    mol->getProp(common_properties::_Name, mname);
     CHECK_INVARIANT(mname == names[i], "");
     
     delete mol;
@@ -260,7 +260,7 @@ void testSDWriter() {
   while (!nreader.atEnd()) {
     ROMol *mol = nreader.next();
     std::string mname;
-    mol->getProp("_Name", mname);
+    mol->getProp(common_properties::_Name, mname);
     CHECK_INVARIANT(mname == names[i], "");
     i++;
     
@@ -325,7 +325,7 @@ void testSmilesWriterStrm() {
   ROMol *mol = nSup->next();
   while (mol) {
     std::string mname, pval;
-    mol->getProp("_Name", mname);
+    mol->getProp(common_properties::_Name, mname);
     mol->getProp("Column_2", pval);
     names.push_back(mname);
     props.push_back(pval);
@@ -347,7 +347,7 @@ void testSmilesWriterStrm() {
   mol = nSup->next();
   while (mol){
     std::string mname, pval;
-    mol->getProp("_Name", mname);
+    mol->getProp(common_properties::_Name, mname);
     mol->getProp("Column_2", pval);
     CHECK_INVARIANT(mname == names[i], "");
     CHECK_INVARIANT(pval == props[i], "");
@@ -379,7 +379,7 @@ void testSDWriterStrm() {
     while (!sdsup.atEnd()) {
       ROMol *mol = sdsup.next();
       std::string mname;
-      mol->getProp("_Name", mname);
+      mol->getProp(common_properties::_Name, mname);
       names.push_back(mname);
 
       writer->write(*mol);
@@ -395,7 +395,7 @@ void testSDWriterStrm() {
     while (!reader.atEnd()) {
       ROMol *mol = reader.next();
       std::string mname;
-      mol->getProp("_Name", mname);
+      mol->getProp(common_properties::_Name, mname);
       CHECK_INVARIANT(mname == names[i], "");
     
       delete mol;
@@ -483,7 +483,7 @@ void testSDMemoryCorruption() {
     //std::cerr<<"m:"<<mol<<std::endl;
     TEST_ASSERT(mol);
     std::string mname;
-    mol->getProp("_Name", mname);
+    mol->getProp(common_properties::_Name, mname);
     names.push_back(mname);
     //std::cerr<<"  w"<<std::endl;
     writer->write(*mol);
@@ -505,7 +505,7 @@ void testSDMemoryCorruption() {
   while (!reader.atEnd()) {
     ROMol *mol = reader.next();
     std::string mname;
-    mol->getProp("_Name", mname);
+    mol->getProp(common_properties::_Name, mname);
     CHECK_INVARIANT(mname == names[i], "");
 
     
@@ -523,58 +523,58 @@ void testIssue3525000() {
     RWMol *mol = MolFileToMol(fname);
     TEST_ASSERT(mol);
     std::string cip;
-    TEST_ASSERT(mol->getAtomWithIdx(0)->hasProp("_CIPCode"));
-    mol->getAtomWithIdx(0)->getProp("_CIPCode",cip);
+    TEST_ASSERT(mol->getAtomWithIdx(0)->hasProp(common_properties::_CIPCode));
+    mol->getAtomWithIdx(0)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="R");
-    TEST_ASSERT(mol->getAtomWithIdx(3)->hasProp("_CIPCode"));
-    mol->getAtomWithIdx(3)->getProp("_CIPCode",cip);
+    TEST_ASSERT(mol->getAtomWithIdx(3)->hasProp(common_properties::_CIPCode));
+    mol->getAtomWithIdx(3)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="R");
-    TEST_ASSERT(mol->getAtomWithIdx(6)->hasProp("_CIPCode"));
-    mol->getAtomWithIdx(6)->getProp("_CIPCode",cip);
+    TEST_ASSERT(mol->getAtomWithIdx(6)->hasProp(common_properties::_CIPCode));
+    mol->getAtomWithIdx(6)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="R");
-    TEST_ASSERT(mol->getAtomWithIdx(8)->hasProp("_CIPCode"));
-    mol->getAtomWithIdx(8)->getProp("_CIPCode",cip);
+    TEST_ASSERT(mol->getAtomWithIdx(8)->hasProp(common_properties::_CIPCode));
+    mol->getAtomWithIdx(8)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="R");
-    TEST_ASSERT(mol->getAtomWithIdx(9)->hasProp("_CIPCode"));
-    mol->getAtomWithIdx(9)->getProp("_CIPCode",cip);
+    TEST_ASSERT(mol->getAtomWithIdx(9)->hasProp(common_properties::_CIPCode));
+    mol->getAtomWithIdx(9)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="R");
-    TEST_ASSERT(mol->getAtomWithIdx(10)->hasProp("_CIPCode"));
-    mol->getAtomWithIdx(10)->getProp("_CIPCode",cip);
+    TEST_ASSERT(mol->getAtomWithIdx(10)->hasProp(common_properties::_CIPCode));
+    mol->getAtomWithIdx(10)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="S");
-    TEST_ASSERT(mol->getAtomWithIdx(14)->hasProp("_CIPCode"));
-    mol->getAtomWithIdx(14)->getProp("_CIPCode",cip);
+    TEST_ASSERT(mol->getAtomWithIdx(14)->hasProp(common_properties::_CIPCode));
+    mol->getAtomWithIdx(14)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="R");
-    TEST_ASSERT(mol->getAtomWithIdx(15)->hasProp("_CIPCode"));
-    mol->getAtomWithIdx(15)->getProp("_CIPCode",cip);
+    TEST_ASSERT(mol->getAtomWithIdx(15)->hasProp(common_properties::_CIPCode));
+    mol->getAtomWithIdx(15)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="R");
 
     std::string mb=MolToMolBlock(*mol);
     delete mol;
     mol = MolBlockToMol(mb);
     TEST_ASSERT(mol);
-    TEST_ASSERT(mol->getAtomWithIdx(0)->hasProp("_CIPCode"));
-    mol->getAtomWithIdx(0)->getProp("_CIPCode",cip);
+    TEST_ASSERT(mol->getAtomWithIdx(0)->hasProp(common_properties::_CIPCode));
+    mol->getAtomWithIdx(0)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="R");
-    TEST_ASSERT(mol->getAtomWithIdx(3)->hasProp("_CIPCode"));
-    mol->getAtomWithIdx(3)->getProp("_CIPCode",cip);
+    TEST_ASSERT(mol->getAtomWithIdx(3)->hasProp(common_properties::_CIPCode));
+    mol->getAtomWithIdx(3)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="R");
-    TEST_ASSERT(mol->getAtomWithIdx(6)->hasProp("_CIPCode"));
-    mol->getAtomWithIdx(6)->getProp("_CIPCode",cip);
+    TEST_ASSERT(mol->getAtomWithIdx(6)->hasProp(common_properties::_CIPCode));
+    mol->getAtomWithIdx(6)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="R");
-    TEST_ASSERT(mol->getAtomWithIdx(8)->hasProp("_CIPCode"));
-    mol->getAtomWithIdx(8)->getProp("_CIPCode",cip);
+    TEST_ASSERT(mol->getAtomWithIdx(8)->hasProp(common_properties::_CIPCode));
+    mol->getAtomWithIdx(8)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="R");
-    TEST_ASSERT(mol->getAtomWithIdx(9)->hasProp("_CIPCode"));
-    mol->getAtomWithIdx(9)->getProp("_CIPCode",cip);
+    TEST_ASSERT(mol->getAtomWithIdx(9)->hasProp(common_properties::_CIPCode));
+    mol->getAtomWithIdx(9)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="R");
-    TEST_ASSERT(mol->getAtomWithIdx(10)->hasProp("_CIPCode"));
-    mol->getAtomWithIdx(10)->getProp("_CIPCode",cip);
+    TEST_ASSERT(mol->getAtomWithIdx(10)->hasProp(common_properties::_CIPCode));
+    mol->getAtomWithIdx(10)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="S");
-    TEST_ASSERT(mol->getAtomWithIdx(14)->hasProp("_CIPCode"));
-    mol->getAtomWithIdx(14)->getProp("_CIPCode",cip);
+    TEST_ASSERT(mol->getAtomWithIdx(14)->hasProp(common_properties::_CIPCode));
+    mol->getAtomWithIdx(14)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="R");
-    TEST_ASSERT(mol->getAtomWithIdx(15)->hasProp("_CIPCode"));
-    mol->getAtomWithIdx(15)->getProp("_CIPCode",cip);
+    TEST_ASSERT(mol->getAtomWithIdx(15)->hasProp(common_properties::_CIPCode));
+    mol->getAtomWithIdx(15)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="R");
   }  
   {
@@ -585,40 +585,40 @@ void testIssue3525000() {
     MolOps::assignChiralTypesFrom3D(*mol);
     MolOps::assignStereochemistry(*mol);
     std::string cip;
-    TEST_ASSERT(mol->getAtomWithIdx(0)->hasProp("_CIPCode"));
-    mol->getAtomWithIdx(0)->getProp("_CIPCode",cip);
+    TEST_ASSERT(mol->getAtomWithIdx(0)->hasProp(common_properties::_CIPCode));
+    mol->getAtomWithIdx(0)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="S");
-    TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp("_CIPCode"));
-    mol->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+    TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+    mol->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="S");
-    TEST_ASSERT(mol->getAtomWithIdx(2)->hasProp("_CIPCode"));
-    mol->getAtomWithIdx(2)->getProp("_CIPCode",cip);
+    TEST_ASSERT(mol->getAtomWithIdx(2)->hasProp(common_properties::_CIPCode));
+    mol->getAtomWithIdx(2)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="R");
-    TEST_ASSERT(mol->getAtomWithIdx(3)->hasProp("_CIPCode"));
-    mol->getAtomWithIdx(3)->getProp("_CIPCode",cip);
+    TEST_ASSERT(mol->getAtomWithIdx(3)->hasProp(common_properties::_CIPCode));
+    mol->getAtomWithIdx(3)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="R");
-    TEST_ASSERT(mol->getAtomWithIdx(4)->hasProp("_CIPCode"));
-    mol->getAtomWithIdx(4)->getProp("_CIPCode",cip);
+    TEST_ASSERT(mol->getAtomWithIdx(4)->hasProp(common_properties::_CIPCode));
+    mol->getAtomWithIdx(4)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="S");
 
     std::string mb=MolToMolBlock(*mol);
     delete mol;
     mol = MolBlockToMol(mb);
     TEST_ASSERT(mol);
-    TEST_ASSERT(mol->getAtomWithIdx(0)->hasProp("_CIPCode"));
-    mol->getAtomWithIdx(0)->getProp("_CIPCode",cip);
+    TEST_ASSERT(mol->getAtomWithIdx(0)->hasProp(common_properties::_CIPCode));
+    mol->getAtomWithIdx(0)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="S");
-    TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp("_CIPCode"));
-    mol->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+    TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+    mol->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="S");
-    TEST_ASSERT(mol->getAtomWithIdx(2)->hasProp("_CIPCode"));
-    mol->getAtomWithIdx(2)->getProp("_CIPCode",cip);
+    TEST_ASSERT(mol->getAtomWithIdx(2)->hasProp(common_properties::_CIPCode));
+    mol->getAtomWithIdx(2)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="R");
-    TEST_ASSERT(mol->getAtomWithIdx(3)->hasProp("_CIPCode"));
-    mol->getAtomWithIdx(3)->getProp("_CIPCode",cip);
+    TEST_ASSERT(mol->getAtomWithIdx(3)->hasProp(common_properties::_CIPCode));
+    mol->getAtomWithIdx(3)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="R");
-    TEST_ASSERT(mol->getAtomWithIdx(4)->hasProp("_CIPCode"));
-    mol->getAtomWithIdx(4)->getProp("_CIPCode",cip);
+    TEST_ASSERT(mol->getAtomWithIdx(4)->hasProp(common_properties::_CIPCode));
+    mol->getAtomWithIdx(4)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="S");
   }  
 }
@@ -655,16 +655,16 @@ void testMolFileChiralFlag() {
     std::string mb=MolToMolBlock(*m1);
     delete m1;
     m1 = MolBlockToMol(mb);
-    TEST_ASSERT(!m1->hasProp("_MolFileChiralFlag"));
+    TEST_ASSERT(!m1->hasProp(common_properties::_MolFileChiralFlag));
   }
   {
     ROMol *m1=SmilesToMol("C[C@H](Cl)F");
     TEST_ASSERT(m1);
-    m1->setProp("_MolFileChiralFlag",static_cast<unsigned int>(1));
+    m1->setProp(common_properties::_MolFileChiralFlag,static_cast<unsigned int>(1));
     std::string mb=MolToMolBlock(*m1);
     delete m1;
     m1 = MolBlockToMol(mb);
-    TEST_ASSERT(m1->hasProp("_MolFileChiralFlag"));
+    TEST_ASSERT(m1->hasProp(common_properties::_MolFileChiralFlag));
   }
 }
 
@@ -737,15 +737,15 @@ void testMolFileWithRxn(){
     TEST_ASSERT(m->getNumAtoms()==18);
     TEST_ASSERT(m->getNumBonds()==16);
 
-    TEST_ASSERT(m->getAtomWithIdx(0)->hasProp("molRxnRole"));
-    TEST_ASSERT(m->getAtomWithIdx(0)->getProp<int>("molRxnRole")==1);
-    TEST_ASSERT(m->getAtomWithIdx(0)->hasProp("molRxnComponent"));
-    TEST_ASSERT(m->getAtomWithIdx(0)->getProp<int>("molRxnComponent")==1);
+    TEST_ASSERT(m->getAtomWithIdx(0)->hasProp(common_properties::molRxnRole));
+    TEST_ASSERT(m->getAtomWithIdx(0)->getProp<int>(common_properties::molRxnRole)==1);
+    TEST_ASSERT(m->getAtomWithIdx(0)->hasProp(common_properties::molRxnComponent));
+    TEST_ASSERT(m->getAtomWithIdx(0)->getProp<int>(common_properties::molRxnComponent)==1);
 
-    TEST_ASSERT(m->getAtomWithIdx(17)->hasProp("molRxnRole"));
-    TEST_ASSERT(m->getAtomWithIdx(17)->getProp<int>("molRxnRole")==2);
-    TEST_ASSERT(m->getAtomWithIdx(17)->hasProp("molRxnComponent"));
-    TEST_ASSERT(m->getAtomWithIdx(17)->getProp<int>("molRxnComponent")==3);
+    TEST_ASSERT(m->getAtomWithIdx(17)->hasProp(common_properties::molRxnRole));
+    TEST_ASSERT(m->getAtomWithIdx(17)->getProp<int>(common_properties::molRxnRole)==2);
+    TEST_ASSERT(m->getAtomWithIdx(17)->hasProp(common_properties::molRxnComponent));
+    TEST_ASSERT(m->getAtomWithIdx(17)->getProp<int>(common_properties::molRxnComponent)==3);
 
     std::string mb=MolToMolBlock(*m);
     delete m;
@@ -754,15 +754,15 @@ void testMolFileWithRxn(){
     TEST_ASSERT(m->getNumAtoms()==18);
     TEST_ASSERT(m->getNumBonds()==16);
 
-    TEST_ASSERT(m->getAtomWithIdx(0)->hasProp("molRxnRole"));
-    TEST_ASSERT(m->getAtomWithIdx(0)->getProp<int>("molRxnRole")==1);
-    TEST_ASSERT(m->getAtomWithIdx(0)->hasProp("molRxnComponent"));
-    TEST_ASSERT(m->getAtomWithIdx(0)->getProp<int>("molRxnComponent")==1);
+    TEST_ASSERT(m->getAtomWithIdx(0)->hasProp(common_properties::molRxnRole));
+    TEST_ASSERT(m->getAtomWithIdx(0)->getProp<int>(common_properties::molRxnRole)==1);
+    TEST_ASSERT(m->getAtomWithIdx(0)->hasProp(common_properties::molRxnComponent));
+    TEST_ASSERT(m->getAtomWithIdx(0)->getProp<int>(common_properties::molRxnComponent)==1);
 
-    TEST_ASSERT(m->getAtomWithIdx(17)->hasProp("molRxnRole"));
-    TEST_ASSERT(m->getAtomWithIdx(17)->getProp<int>("molRxnRole")==2);
-    TEST_ASSERT(m->getAtomWithIdx(17)->hasProp("molRxnComponent"));
-    TEST_ASSERT(m->getAtomWithIdx(17)->getProp<int>("molRxnComponent")==3);
+    TEST_ASSERT(m->getAtomWithIdx(17)->hasProp(common_properties::molRxnRole));
+    TEST_ASSERT(m->getAtomWithIdx(17)->getProp<int>(common_properties::molRxnRole)==2);
+    TEST_ASSERT(m->getAtomWithIdx(17)->hasProp(common_properties::molRxnComponent));
+    TEST_ASSERT(m->getAtomWithIdx(17)->getProp<int>(common_properties::molRxnComponent)==3);
     delete m;
   }
   BOOST_LOG(rdInfoLog) << "done" << std::endl;

--- a/Code/GraphMol/FileParsers/testTpls.cpp
+++ b/Code/GraphMol/FileParsers/testTpls.cpp
@@ -32,8 +32,8 @@ void test1(){
   TEST_ASSERT(m->getNumAtoms()==12);
   TEST_ASSERT(m->getNumBonds()==12);
   TEST_ASSERT(m->getNumConformers()==2);
-  TEST_ASSERT(m->hasProp("_Name"));
-  m->getProp("_Name",propVal);
+  TEST_ASSERT(m->hasProp(common_properties::_Name));
+  m->getProp(common_properties::_Name,propVal);
   TEST_ASSERT(propVal=="compound 2");
   TEST_ASSERT(m->hasProp("Conf_1_Name"));
   m->getProp("Conf_1_Name",propVal);
@@ -79,8 +79,8 @@ void test2(){
   TEST_ASSERT(m->getNumAtoms()==18);
   TEST_ASSERT(m->getNumBonds()==18);
   TEST_ASSERT(m->getNumConformers()==9);
-  TEST_ASSERT(m->hasProp("_Name"));
-  m->getProp("_Name",propVal);
+  TEST_ASSERT(m->hasProp(common_properties::_Name));
+  m->getProp(common_properties::_Name,propVal);
   TEST_ASSERT(propVal=="compound 1");
   TEST_ASSERT(m->hasProp("Conf_1_Name"));
   m->getProp("Conf_1_Name",propVal);
@@ -95,8 +95,8 @@ void test2(){
   TEST_ASSERT(m2->getNumAtoms()==18);
   TEST_ASSERT(m2->getNumBonds()==18);
   TEST_ASSERT(m2->getNumConformers()==9);
-  TEST_ASSERT(m2->hasProp("_Name"));
-  m2->getProp("_Name",propVal);
+  TEST_ASSERT(m2->hasProp(common_properties::_Name));
+  m2->getProp(common_properties::_Name,propVal);
   TEST_ASSERT(propVal=="compound 1");
   TEST_ASSERT(m2->hasProp("Conf_1_Name"));
   m2->getProp("Conf_1_Name",propVal);
@@ -112,8 +112,8 @@ void test2(){
   TEST_ASSERT(m2->getNumAtoms()==18);
   TEST_ASSERT(m2->getNumBonds()==18);
   TEST_ASSERT(m2->getNumConformers()==8);
-  TEST_ASSERT(m2->hasProp("_Name"));
-  m2->getProp("_Name",propVal);
+  TEST_ASSERT(m2->hasProp(common_properties::_Name));
+  m2->getProp(common_properties::_Name,propVal);
   TEST_ASSERT(propVal=="compound 1");
   TEST_ASSERT(m2->hasProp("Conf_1_Name"));
   m2->getProp("Conf_1_Name",propVal);

--- a/Code/GraphMol/FindRings.cpp
+++ b/Code/GraphMol/FindRings.cpp
@@ -241,7 +241,7 @@ namespace FindRings {
       }
     }
   
-    mol.setProp("extraRings", extras, true);
+    mol.setProp(common_properties::extraRings, extras, true);
   }
 
   void findRingsD2nodes(const ROMol &tMol, VECT_INT_VECT &res, 
@@ -986,11 +986,11 @@ namespace RDKit {
       }
  
       // now check if there are any extra rings on the molecule 
-      if (!mol.hasProp("extraRings")) {
+      if (!mol.hasProp(common_properties::extraRings)) {
         // no extra rings nothign to be done
         return res.size();
       }
-      const VECT_INT_VECT &extras=mol.getProp<VECT_INT_VECT>("extraRings");
+      const VECT_INT_VECT &extras=mol.getProp<VECT_INT_VECT>(common_properties::extraRings);
 
 
       // convert the rings to bond ids
@@ -1039,8 +1039,8 @@ namespace RDKit {
         res.push_back(exr);
         FindRings::storeRingInfo(mol, exr);
       }
-      if (mol.hasProp("extraRings")) {
-        mol.clearProp("extraRings");
+      if (mol.hasProp(common_properties::extraRings)) {
+        mol.clearProp(common_properties::extraRings);
       }
       return res.size();
     }

--- a/Code/GraphMol/Fingerprints/AtomPairs.cpp
+++ b/Code/GraphMol/Fingerprints/AtomPairs.cpp
@@ -63,10 +63,9 @@ namespace RDKit{
       if(typeIdx==nTypes) --typeIdx;
       code |= typeIdx<<(numBranchBits+numPiBits);
       if(includeChirality){
-        if(atom->hasProp("_CIPCode")){
+        std::string cipCode;
+        if(atom->getPropIfPresent(common_properties::_CIPCode, cipCode)){
           boost::uint32_t offset=numBranchBits+numPiBits+numTypeBits;
-          std::string cipCode;
-          atom->getProp("_CIPCode",cipCode);
           if(cipCode=="R"){
             code |= 1<<offset;
           } else if (cipCode=="S"){

--- a/Code/GraphMol/Fingerprints/MorganFingerprints.cpp
+++ b/Code/GraphMol/Fingerprints/MorganFingerprints.cpp
@@ -298,8 +298,8 @@ $([N;H0&+0]([C;!$(C(=O))])([C;!$(C(=O))])[C;!$(C(=O))])]", // Basic
               // add an extra value to the invariant to reflect chirality:
               Atom const *tAt=mol.getAtomWithIdx(atomIdx);
               std::string cip="";
-              if(tAt->hasProp("_CIPCode")){
-                tAt->getProp("_CIPCode",cip);
+              if(tAt->hasProp(common_properties::_CIPCode)){
+                tAt->getProp(common_properties::_CIPCode,cip);
               }
               if(cip=="R"){
                 gboost::hash_combine(invar, 3);

--- a/Code/GraphMol/ForceFieldHelpers/MMFF/AtomTyper.cpp
+++ b/Code/GraphMol/ForceFieldHelpers/MMFF/AtomTyper.cpp
@@ -2247,8 +2247,8 @@ namespace RDKit {
                                            | MolOps::SANITIZE_SETHYBRIDIZATION
                                            | MolOps::SANITIZE_CLEANUPCHIRALITY
                                            | MolOps::SANITIZE_ADJUSTHS));
-        if (!(mol.hasProp("_MMFFSanitized"))) {
-          mol.setProp("_MMFFSanitized",1,true);
+        if (!(mol.hasProp(common_properties::_MMFFSanitized))) {
+          mol.setProp(common_properties::_MMFFSanitized,1,true);
         }
       } catch (MolSanitizeException &e){
       
@@ -2280,7 +2280,7 @@ namespace RDKit {
       d_oStream(&oStream),
       d_MMFFAtomPropertiesPtrVect(mol.getNumAtoms()) {
       ROMol::AtomIterator it;
-      if (!(mol.hasProp("_MMFFSanitized"))) {
+      if (!(mol.hasProp(common_properties::_MMFFSanitized))) {
         bool isAromaticSet = false;
         for (it = mol.beginAtoms(); (!isAromaticSet) && (it != mol.endAtoms()); ++it) {
           isAromaticSet = (*it)->getIsAromatic();
@@ -2288,7 +2288,7 @@ namespace RDKit {
         if (isAromaticSet) {
           MolOps::Kekulize((RWMol &)mol, true);
         }
-        mol.setProp("_MMFFSanitized",1,true);
+        mol.setProp(common_properties::_MMFFSanitized,1,true);
       }      
       for (unsigned int i = 0; i < mol.getNumAtoms(); ++i) {
         d_MMFFAtomPropertiesPtrVect[i]

--- a/Code/GraphMol/ForceFieldHelpers/UFF/testUFFHelpers.cpp
+++ b/Code/GraphMol/ForceFieldHelpers/UFF/testUFFHelpers.cpp
@@ -866,8 +866,8 @@ void testGitHubIssue62() {
       ROMol *mol = MolOps::addHs(*(smiSupplier[i]));
       TEST_ASSERT(mol);
       std::string molName = "";
-      if (mol->hasProp("_Name")) {
-        mol->getProp("_Name", molName);
+      if (mol->hasProp(common_properties::_Name)) {
+        mol->getProp(common_properties::_Name, molName);
       }
       DGeomHelpers::EmbedMolecule(*mol);
       ForceFields::ForceField *field = UFF::constructForceField(*mol);

--- a/Code/GraphMol/FragCatalog/FragCatParams.cpp
+++ b/Code/GraphMol/FragCatalog/FragCatParams.cpp
@@ -75,10 +75,10 @@ namespace RDKit{
 	funcGroup != d_funcGroups.end();
 	funcGroup++){
       std::string text;
-      (*funcGroup)->getProp("_Name",text);
+      (*funcGroup)->getProp(common_properties::_Name,text);
       ss << text;
       ss << "\t";
-      (*funcGroup)->getProp("_fragSMARTS",text);
+      (*funcGroup)->getProp(common_properties::_fragSMARTS,text);
       ss << text;
       ss << "\n";
     }

--- a/Code/GraphMol/FragCatalog/FragCatalogEntry.cpp
+++ b/Code/GraphMol/FragCatalog/FragCatalogEntry.cpp
@@ -79,14 +79,14 @@ namespace RDKit {
       const ROMol *fGroup;
       for(unsigned int i=0;i<fGroups.size()-1;i++){
 	fGroup=params->getFuncGroup(*fGroupIdx);
-	fGroup->getProp("_Name",temp);
+	fGroup->getProp(common_properties::_Name,temp);
 	label += "(<" + temp + ">)";
 	fGroupIdx++;
       }
       fGroup=params->getFuncGroup(*fGroupIdx);
-      fGroup->getProp("_Name",temp);
+      fGroup->getProp(common_properties::_Name,temp);
       label += "<"+temp+">";
-      dp_mol->getAtomWithIdx(atIdx)->setProp("_supplementalSmilesLabel",label);
+      dp_mol->getAtomWithIdx(atIdx)->setProp(common_properties::_supplementalSmilesLabel,label);
     }
     std::string smi = MolToSmiles(*dp_mol);
     //std::cout << "----" << smi << "----" << std::endl;
@@ -155,8 +155,8 @@ namespace RDKit {
 
   Subgraphs::DiscrimTuple FragCatalogEntry::getDiscrims() const {
     Subgraphs::DiscrimTuple res;
-    if (this->hasProp("Discrims")) {
-      this->getProp("Discrims", res);
+    if (this->hasProp(common_properties::Discrims)) {
+      this->getProp(common_properties::Discrims, res);
     }
     else {
       PATH_TYPE path;
@@ -179,7 +179,7 @@ namespace RDKit {
         funcGpInvars.push_back(invar);
       }
       res = Subgraphs::calcPathDiscriminators(*dp_mol,path,true,&funcGpInvars);
-      this->setProp("Discrims", res);
+      this->setProp(common_properties::Discrims, res);
     }
 
     //std::cout << "DISCRIMS: " << d_descrip  << " ";

--- a/Code/GraphMol/FragCatalog/FragCatalogEntry.h
+++ b/Code/GraphMol/FragCatalog/FragCatalogEntry.h
@@ -72,7 +72,7 @@ namespace RDKit {
       dp_props->setVal(key, val);
     }
 
-    template <typename T> void setProp(const std::string key, T &val) const {
+    template <typename T> void setProp(const std::string &key, T &val) const {
       setProp(key.c_str(), val);
     }
 
@@ -80,7 +80,7 @@ namespace RDKit {
       dp_props->setVal(key, val);
     }
 
-    void setProp(const std::string key, int val) const {
+    void setProp(const std::string &key, int val) const {
       setProp(key.c_str(), val);
     }
 
@@ -88,11 +88,11 @@ namespace RDKit {
       dp_props->setVal(key, val);
     }
 
-    void setProp(const std::string key, float val) const {
+    void setProp(const std::string &key, float val) const {
       setProp(key.c_str(), val);
     }
 
-    void setProp(const std::string key, std::string val) const {
+    void setProp(const std::string &key, std::string &val) const {
       setProp(key.c_str(), val);
     }
     
@@ -109,7 +109,7 @@ namespace RDKit {
       if (!dp_props) return false;
       return dp_props->hasVal(key);
     }
-    bool hasProp(const std::string key) const {
+    bool hasProp(const std::string &key) const {
       return hasProp(key.c_str());
     }
     
@@ -117,7 +117,7 @@ namespace RDKit {
       dp_props->clearVal(key);
     }
 
-    void clearProp(const std::string key) const {
+    void clearProp(const std::string &key) const {
       clearProp(key.c_str());
     }
 

--- a/Code/GraphMol/FragCatalog/FragCatalogUtils.cpp
+++ b/Code/GraphMol/FragCatalog/FragCatalogUtils.cpp
@@ -52,8 +52,8 @@ namespace RDKit {
 
       mol = SmartsToMol(smarts);
       CHECK_INVARIANT(mol,smarts);
-      mol->setProp("_Name", name);
-      mol->setProp("_fragSMARTS",smarts);
+      mol->setProp(common_properties::_Name, name);
+      mol->setProp(common_properties::_fragSMARTS,smarts);
       return mol;
     }    
   } // end of local utility namespace
@@ -118,7 +118,7 @@ namespace RDKit {
     for (fgci = fgrps.begin(); fgci != fgrps.end(); fgci++) {
       const ROMol *fgrp = fgci->get();
       std::string fname;
-      (*fgci)->getProp("_Name", fname);
+      (*fgci)->getProp(common_properties::_Name, fname);
       //std::cout << "Groups number: " << fname << "\n";
       //(*fgci)->debugMol(std::cout);
       //mol->debugMol(std::cout);

--- a/Code/GraphMol/MolCatalog/MolCatalogEntry.h
+++ b/Code/GraphMol/MolCatalog/MolCatalogEntry.h
@@ -59,7 +59,7 @@ namespace RDKit {
     }
 
     //! \overload
-    template <typename T> void setProp(const std::string key, T &val) const {
+    template <typename T> void setProp(const std::string &key, T &val) const {
       setProp(key.c_str(), val);
     }
 
@@ -70,7 +70,7 @@ namespace RDKit {
     }
     //! \overload
     template <typename T>
-      void getProp(const std::string key, T &res) const {
+      void getProp(const std::string &key, T &res) const {
       getProp(key.c_str(), res);
     }
     
@@ -80,7 +80,7 @@ namespace RDKit {
       return dp_props->hasVal(key);
     }
     //! \overload
-    bool hasProp(const std::string key) const {
+    bool hasProp(const std::string &key) const {
       return hasProp(key.c_str());
     }
     
@@ -89,7 +89,7 @@ namespace RDKit {
       dp_props->clearVal(key);
     }
     //! \overload
-    void clearProp(const std::string key) const {
+    void clearProp(const std::string &key) const {
       clearProp(key.c_str());
     }
 

--- a/Code/GraphMol/MolDiscriminators.cpp
+++ b/Code/GraphMol/MolDiscriminators.cpp
@@ -60,8 +60,8 @@ namespace RDKit {
                            const std::vector<int> *bondPath,
                            bool cacheIt) {
       double res=0.0;
-      if (!force && mol.hasProp("BalanbanJ")) {
-        mol.getProp("BalabanJ", res);
+      if (!force && mol.hasProp(common_properties::BalanbanJ)) {
+        mol.getProp(common_properties::BalabanJ, res);
       }
       else {
         double *dMat;
@@ -111,7 +111,7 @@ namespace RDKit {
         }
 
 
-        if(cacheIt) mol.setProp("BalabanJ", res, true);
+        if(cacheIt) mol.setProp(common_properties::BalabanJ, res, true);
       }
       return res;
     }

--- a/Code/GraphMol/MolDrawing/MolDrawing.h
+++ b/Code/GraphMol/MolDrawing/MolDrawing.h
@@ -78,7 +78,7 @@ namespace RDKit {
            atom.getFormalCharge()!=0 ||
            isotope ||
            atom.getNumRadicalElectrons()!=0 ||
-           atom.hasProp("molAtomMapNumber") ||
+           atom.hasProp(common_properties::molAtomMapNumber) ||
            atom.getDegree()==0 ){
           symbol=atom.getSymbol();
           bool leftToRight=true;
@@ -88,9 +88,9 @@ namespace RDKit {
           if(isotope){
             symbol = boost::lexical_cast<std::string>(isotope)+symbol;
           }
-          if(atom.hasProp("molAtomMapNumber")){
+          if(atom.hasProp(common_properties::molAtomMapNumber)){
             std::string mapNum;
-            atom.getProp("molAtomMapNumber",mapNum);
+            atom.getProp(common_properties::molAtomMapNumber,mapNum);
             symbol += ":" + mapNum;
           }
           int nHs=atom.getTotalNumHs();

--- a/Code/GraphMol/MolPickler.cpp
+++ b/Code/GraphMol/MolPickler.cpp
@@ -870,13 +870,13 @@ namespace RDKit{
   namespace {
     bool getAtomMapNumber(const Atom *atom,int &mapNum){
       PRECONDITION(atom,"bad atom");
-      if(!atom->hasProp("molAtomMapNumber")) return false;
+      if(!atom->hasProp(common_properties::molAtomMapNumber)) return false;
       bool res=true;
       int tmpInt;
       try{
-        atom->getProp("molAtomMapNumber",tmpInt);
+        atom->getProp(common_properties::molAtomMapNumber,tmpInt);
       } catch (boost::bad_any_cast &exc) {
-        const std::string &tmpSVal=atom->getProp<std::string>("molAtomMapNumber");
+        const std::string &tmpSVal=atom->getProp<std::string>(common_properties::molAtomMapNumber);
         try{
           tmpInt = boost::lexical_cast<int>(tmpSVal);
         } catch(boost::bad_lexical_cast &lexc) {
@@ -905,7 +905,7 @@ namespace RDKit{
     if(atom->getNoImplicit()) flags |= 0x1<<5;
     if(atom->hasQuery()) flags |= 0x1<<4;
     if(getAtomMapNumber(atom,tmpInt)) flags |= 0x1<<3;
-    if(atom->hasProp("dummyLabel")) flags |= 0x1<<2;
+    if(atom->hasProp(common_properties::dummyLabel)) flags |= 0x1<<2;
     if(atom->getMonomerInfo()) flags |= 0x1<<1;
 
     streamWrite(ss,flags);
@@ -972,8 +972,8 @@ namespace RDKit{
       tmpChar=static_cast<char>(tmpInt%256);
       streamWrite(ss,ATOM_MAPNUMBER,tmpChar);
     }
-    if(atom->hasProp("dummyLabel")){
-      streamWrite(ss,ATOM_DUMMYLABEL,atom->getProp<std::string>("dummyLabel"));
+    if(atom->hasProp(common_properties::dummyLabel)){
+      streamWrite(ss,ATOM_DUMMYLABEL,atom->getProp<std::string>(common_properties::dummyLabel));
     }
     if(atom->getMonomerInfo()){
       streamWrite(ss,BEGIN_ATOM_MONOMER);
@@ -1208,7 +1208,7 @@ namespace RDKit{
           int tmpInt;
           streamRead(ss,tmpChar,version);
           tmpInt=tmpChar;
-          atom->setProp("molAtomMapNumber",tmpInt);
+          atom->setProp(common_properties::molAtomMapNumber,tmpInt);
         } else {
           ss.seekg(sPos);
         }
@@ -1222,7 +1222,7 @@ namespace RDKit{
           int tmpInt;
           streamRead(ss,tmpChar,version);
           tmpInt=tmpChar;
-          atom->setProp("molAtomMapNumber",tmpInt);
+          atom->setProp(common_properties::molAtomMapNumber,tmpInt);
         }
         if(hasDummyLabel){
           streamRead(ss,tag,version);
@@ -1231,7 +1231,7 @@ namespace RDKit{
           }
           std::string tmpStr;
           streamRead(ss,tmpStr,version);
-          atom->setProp("dummyLabel",tmpStr);
+          atom->setProp(common_properties::dummyLabel,tmpStr);
         }
       }
     }

--- a/Code/GraphMol/ROMol.cpp
+++ b/Code/GraphMol/ROMol.cpp
@@ -492,8 +492,7 @@ namespace RDKit{
     if(includeRings) this->dp_ringInfo->reset();
 
     STR_VECT compLst;
-    if(hasProp(detail::computedPropName)){
-      getProp(detail::computedPropName, compLst);
+    if(getPropIfPresent(detail::computedPropName, compLst)){
       BOOST_FOREACH(std::string &sv,compLst){
         dp_props->clearVal(sv);
       }

--- a/Code/GraphMol/ROMol.h
+++ b/Code/GraphMol/ROMol.h
@@ -511,17 +511,16 @@ namespace RDKit{
                          bool includeComputed=true) const {
       const STR_VECT &tmp=dp_props->keys();
       STR_VECT res,computed;
-      if(!includeComputed && hasProp(detail::computedPropName)){
-        getProp(detail::computedPropName,computed);
+      if(!includeComputed && getPropIfPresent(detail::computedPropName, computed)){
         computed.push_back(detail::computedPropName);
       }
       
       STR_VECT::const_iterator pos = tmp.begin();
       while(pos!=tmp.end()){
         if((includePrivate || (*pos)[0]!='_') &&
-	 std::find(computed.begin(),computed.end(),*pos)==computed.end()){
+           std::find(computed.begin(),computed.end(),*pos)==computed.end()){
           res.push_back(*pos);
-	}
+        }
         pos++;
       }
       return res;
@@ -544,7 +543,7 @@ namespace RDKit{
     }
     //! \overload
     template <typename T>
-    void setProp(const std::string key, T val, bool computed=false) const {
+    void setProp(const std::string &key, T val, bool computed=false) const {
       if (computed) {
         STR_VECT compLst;
         dp_props->getVal(detail::computedPropName,compLst);
@@ -576,7 +575,7 @@ namespace RDKit{
     }
     //! \overload
     template <typename T>
-    void getProp(const std::string key, T &res) const {
+    void getProp(const std::string &key, T &res) const {
       dp_props->getVal(key, res);
     }
     //! \overload
@@ -586,8 +585,20 @@ namespace RDKit{
     }
     //! \overload
     template <typename T>
-    T getProp(const std::string key) const {
+    T getProp(const std::string &key) const {
       return dp_props->getVal<T>(key);
+    }
+
+    //! returns whether or not we have a \c property with name \c key
+    //!  and assigns the value if we do
+    template <typename T>
+    bool getPropIfPresent(const char *key,T &res) const {
+        return dp_props->getValIfPresent(key,res);
+    }
+    //! \overload
+    template <typename T>
+    bool getPropIfPresent(const std::string &key,T &res) const {
+        return dp_props->getValIfPresent(key,res);
     }
 
     //! returns whether or not we have a \c property with name \c key
@@ -596,7 +607,7 @@ namespace RDKit{
       return dp_props->hasVal(key);
     }
     //! \overload
-    bool hasProp(const std::string key) const {
+    bool hasProp(const std::string &key) const {
       if (!dp_props) return false;
       return dp_props->hasVal(key);
       //return hasProp(key.c_str());
@@ -615,7 +626,7 @@ namespace RDKit{
       clearProp(what);
     };
     //! \overload
-    void clearProp(const std::string key) const {
+    void clearProp(const std::string &key) const {
       STR_VECT compLst;
       getProp(detail::computedPropName, compLst);
       STR_VECT_I svi = std::find(compLst.begin(), compLst.end(), key);

--- a/Code/GraphMol/RankAtoms.cpp
+++ b/Code/GraphMol/RankAtoms.cpp
@@ -385,9 +385,8 @@ namespace RankAtoms{
       invariant = (invariant << 1) | chgSign;
       if(includeChirality ){
         int isR=0;
-        if( atom->hasProp("_CIPCode")){
-          std::string cipCode;
-          atom->getProp("_CIPCode",cipCode);
+        std::string cipCode;
+        if( atom->getPropIfPresent(common_properties::_CIPCode, cipCode)){
           if(cipCode=="R"){
             isR=1;
           } else {
@@ -431,9 +430,9 @@ namespace RankAtoms{
         Atom const *atom = *atIt;
         if((atom->getChiralTag()==Atom::CHI_TETRAHEDRAL_CW ||
             atom->getChiralTag()==Atom::CHI_TETRAHEDRAL_CCW) &&
-           atom->hasProp("_ringStereoAtoms")){
-          //atom->hasProp("_CIPRank") &&
-          //!atom->hasProp("_CIPCode")){
+           atom->hasProp(common_properties::_ringStereoAtoms)){
+          //atom->hasProp(common_properties::_CIPRank) &&
+          //!atom->hasProp(common_properties::_CIPCode)){
           ROMol::ADJ_ITER beg,end;
           boost::tie(beg,end) = mol.getAtomNeighbors(atom);
           unsigned int nCount=0;
@@ -511,9 +510,8 @@ namespace RankAtoms{
 
       if(includeChirality ){
         int isR=0;
-        if( atom->hasProp("_CIPCode")){
-          std::string cipCode;
-          atom->getProp("_CIPCode",cipCode);
+        std::string cipCode;
+        if( atom->getPropIfPresent(common_properties::_CIPCode, cipCode)){
           if(cipCode=="R"){
             isR=1;
           } else {

--- a/Code/GraphMol/Renumber.cpp
+++ b/Code/GraphMol/Renumber.cpp
@@ -43,10 +43,9 @@ namespace RDKit {
         res->addAtom(nAtom,false,true);
 
         // take care of atom-numbering-dependent properties:
-        if(nAtom->hasProp("_ringStereoAtoms")){
+        INT_VECT nAtoms;
+        if(nAtom->getPropIfPresent(common_properties::_ringStereoAtoms, nAtoms)){
           // FIX: ought to be able to avoid this copy.
-          INT_VECT nAtoms;
-          nAtom->getProp<INT_VECT>("_ringStereoAtoms",nAtoms);
           BOOST_FOREACH(int &val,nAtoms){
             if(val<0){
               val=-1*(revOrder[(-val-1)]+1);
@@ -54,7 +53,7 @@ namespace RDKit {
               val=revOrder[val-1]+1;
             }
           }
-          nAtom->setProp("_ringStereoAtoms",nAtoms,true);
+          nAtom->setProp(common_properties::_ringStereoAtoms,nAtoms,true);
         }
       }          
             

--- a/Code/GraphMol/SLNParse/SLNAttribs.cpp
+++ b/Code/GraphMol/SLNParse/SLNAttribs.cpp
@@ -207,7 +207,7 @@ namespace RDKit{
           int val;
           if(attribVal=="f" || attribName =="f"){
             fTag="_SLN_";
-            atom->setProp("_Unfinished_SLN_",1);
+            atom->setProp(common_properties::_Unfinished_SLN_,1);
             val=-666;
           }
           if(attribName=="rbc"){
@@ -317,8 +317,8 @@ namespace RDKit{
       // we need to loop over the atom's query tree and finalize any
       // attributes that had "f" in the original SLN. We will recognize
       // these by the fact that their names start with "_SLN_"
-      if(!doingQuery || !atom->hasQuery() || !atom->hasProp("_Unfinished_SLN_")) return;
-      atom->clearProp("_Unfinished_SLN_");
+      if(!doingQuery || !atom->hasQuery() || !atom->hasProp(common_properties::_Unfinished_SLN_)) return;
+      atom->clearProp(common_properties::_Unfinished_SLN_);
       std::list<QueryAtom::QUERYATOM_QUERY *> q;
       q.push_back(atom->getQuery());
       while(!q.empty()){
@@ -425,7 +425,7 @@ namespace RDKit{
           attribVal.erase(--(attribVal.end()));
         }
         if(attribName=="name"){
-          mol->setProp("_Name",attribVal);
+          mol->setProp(common_properties::_Name,attribVal);
         } else {
           mol->setProp(attribName,attribVal);
         }
@@ -437,11 +437,10 @@ namespace RDKit{
       for(RWMol::AtomIterator atomIt=mol->beginAtoms();
           atomIt != mol->endAtoms();
           atomIt++){
-        if((*atomIt)->hasProp("_SLN_s")){
+        std::string attribVal;
+        if((*atomIt)->getPropIfPresent(common_properties::_SLN_s, attribVal)){
           // the atom is marked as chiral, translate the sln chirality into
           // RDKit chirality
-          std::string attribVal;
-          (*atomIt)->getProp("_SLN_s",attribVal);
           
           // start with a straight map of the chirality value:
           // as a reminder, here are some SLN <-> SMILES pairs

--- a/Code/GraphMol/SLNParse/SLNParse.cpp
+++ b/Code/GraphMol/SLNParse/SLNParse.cpp
@@ -89,7 +89,7 @@ namespace RDKit {
       for(ROMol::AtomIterator atomIt=mol->beginAtoms();
           atomIt!=mol->endAtoms();++atomIt){
         SLNParse::parseFinalAtomAttribs(*atomIt,true);
-        if((*atomIt)->hasProp("_starred")){
+        if((*atomIt)->hasProp(common_properties::_starred)){
           if(rootIdx>-1){
             BOOST_LOG(rdErrorLog)<<"SLN Error: mulitple starred atoms in a recursive query. Extra stars ignored" << std::endl;
           } else {
@@ -98,7 +98,7 @@ namespace RDKit {
         }
       }
       if(rootIdx>-1){
-        mol->setProp("_queryRootAtom",rootIdx);
+        mol->setProp(common_properties::_queryRootAtom,rootIdx);
       }
     }
 

--- a/Code/GraphMol/SLNParse/SLNParseOps.h
+++ b/Code/GraphMol/SLNParse/SLNParseOps.h
@@ -48,9 +48,8 @@ namespace RDKit{
       void bookmarkAtomID(RWMol *mp,Atom *atom){
         PRECONDITION(mp,"bad molecule");
         PRECONDITION(atom,"bad atom");
-        if(atom->hasProp("_AtomID")){
-          unsigned int label;
-          atom->getProp("_AtomID",label);
+        unsigned int label;
+        if(atom->getPropIfPresent(common_properties::_AtomID, label)){
           if(mp->hasAtomBookmark(label)){
             std::stringstream err;
             err << "SLN Parser error: Atom ID " << label << " used a second time.";

--- a/Code/GraphMol/SLNParse/sln.tab.cpp.cmake
+++ b/Code/GraphMol/SLNParse/sln.tab.cpp.cmake
@@ -1910,7 +1910,7 @@ yyreduce:
   } else {
     (yyval.atom_T) = new RDKit::QueryAtom(1);
   }
-  (yyval.atom_T)->setProp("_starred",1,true);
+  (yyval.atom_T)->setProp(RDKit::common_properties::_starred,1,true);
 ;}
     break;
 
@@ -1922,7 +1922,7 @@ yyreduce:
   } else {
     (yyval.atom_T) = new RDKit::QueryAtom(1);
   }
-  (yyval.atom_T)->setProp("_AtomID",static_cast<unsigned int>((yyvsp[(2) - (3)].ival_T)));
+  (yyval.atom_T)->setProp(RDKit::common_properties::_AtomID,static_cast<unsigned int>((yyvsp[(2) - (3)].ival_T)));
 ;}
     break;
 
@@ -1934,7 +1934,7 @@ yyreduce:
   } else {
     (yyval.atom_T) = new RDKit::QueryAtom(1);
   }
-  (yyval.atom_T)->setProp("_AtomID",static_cast<unsigned int>((yyvsp[(2) - (5)].ival_T)));
+  (yyval.atom_T)->setProp(RDKit::common_properties::_AtomID,static_cast<unsigned int>((yyvsp[(2) - (5)].ival_T)));
   SLNParse::parseAtomAttribs((yyval.atom_T),*(yyvsp[(4) - (5)].attriblist_T),doQueries);
   delete (yyvsp[(4) - (5)].attriblist_T);
 ;}
@@ -1956,14 +1956,14 @@ yyreduce:
   case 35:
 #line 363 "sln.yy"
     {
-  (yyval.atom_T)->setProp("_starred",1,true);
+  (yyval.atom_T)->setProp(RDKit::common_properties::_starred,1,true);
 ;}
     break;
 
   case 36:
 #line 366 "sln.yy"
     {
-  (yyvsp[(1) - (4)].atom_T)->setProp("_AtomID",static_cast<unsigned int>((yyvsp[(3) - (4)].ival_T)));
+  (yyvsp[(1) - (4)].atom_T)->setProp(RDKit::common_properties::_AtomID,static_cast<unsigned int>((yyvsp[(3) - (4)].ival_T)));
   (yyval.atom_T)=(yyvsp[(1) - (4)].atom_T);
 ;}
     break;
@@ -1971,7 +1971,7 @@ yyreduce:
   case 37:
 #line 370 "sln.yy"
     {
-  (yyvsp[(1) - (6)].atom_T)->setProp("_AtomID",static_cast<unsigned int>((yyvsp[(3) - (6)].ival_T)));
+  (yyvsp[(1) - (6)].atom_T)->setProp(RDKit::common_properties::_AtomID,static_cast<unsigned int>((yyvsp[(3) - (6)].ival_T)));
   SLNParse::parseAtomAttribs((yyvsp[(1) - (6)].atom_T),*(yyvsp[(5) - (6)].attriblist_T),doQueries);
   delete (yyvsp[(5) - (6)].attriblist_T);
   (yyval.atom_T)=(yyvsp[(1) - (6)].atom_T);

--- a/Code/GraphMol/SLNParse/sln.yy
+++ b/Code/GraphMol/SLNParse/sln.yy
@@ -326,7 +326,7 @@ hatom: H_ASTERIX_TOKEN {
   } else {
     $$ = new RDKit::QueryAtom(1);
   }
-  $$->setProp("_starred",1,true);
+  $$->setProp(RDKit::common_properties::_starred,1,true);
 }
 | H_BRACKET_TOKEN  number CLOSE_BRACKET_TOKEN {
   if(!doQueries){
@@ -334,7 +334,7 @@ hatom: H_ASTERIX_TOKEN {
   } else {
     $$ = new RDKit::QueryAtom(1);
   }
-  $$->setProp("_AtomID",static_cast<unsigned int>($2));
+  $$->setProp(RDKit::common_properties::_AtomID,static_cast<unsigned int>($2));
 }
 | H_BRACKET_TOKEN number COLON_TOKEN attriblist CLOSE_BRACKET_TOKEN {
   if(!doQueries){
@@ -342,7 +342,7 @@ hatom: H_ASTERIX_TOKEN {
   } else {
     $$ = new RDKit::QueryAtom(1);
   }
-  $$->setProp("_AtomID",static_cast<unsigned int>($2));
+  $$->setProp(RDKit::common_properties::_AtomID,static_cast<unsigned int>($2));
   SLNParse::parseAtomAttribs($$,*$4,doQueries);
   delete $4;
 }
@@ -359,14 +359,14 @@ hatom: H_ASTERIX_TOKEN {
 
 primatom: ATOM_TOKEN 
 | primatom ASTERIX_TOKEN{
-  $$->setProp("_starred",1,true);
+  $$->setProp(RDKit::common_properties::_starred,1,true);
 }
 | primatom OPEN_BRACKET_TOKEN number CLOSE_BRACKET_TOKEN {
-  $1->setProp("_AtomID",static_cast<unsigned int>($3));
+  $1->setProp(RDKit::common_properties::_AtomID,static_cast<unsigned int>($3));
   $$=$1;
 }
 | primatom OPEN_BRACKET_TOKEN number COLON_TOKEN attriblist CLOSE_BRACKET_TOKEN {
-  $1->setProp("_AtomID",static_cast<unsigned int>($3));
+  $1->setProp(RDKit::common_properties::_AtomID,static_cast<unsigned int>($3));
   SLNParse::parseAtomAttribs($1,*$5,doQueries);
   delete $5;
   $$=$1;

--- a/Code/GraphMol/SLNParse/test.cpp
+++ b/Code/GraphMol/SLNParse/test.cpp
@@ -1281,8 +1281,8 @@ void test11(){
   //mol->debugMol(std::cerr);
 #if 0
   RDKit::MolOps::assignAtomChiralCodes(*mol);
-  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  mol->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp(RDKit::common_properties::_CIPCode));
+  mol->getAtomWithIdx(1)->getProp(RDKit::common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="R");
 #endif
   std::cerr << sln << " -> " << MolToSmiles(*mol,true) << " " << mol->getNumAtoms() << std::endl;
@@ -1621,9 +1621,9 @@ void test15(){
     sln = "CH4<name=methane>";
     mol=RDKit::SLNToMol(sln);
     TEST_ASSERT(mol);
-    TEST_ASSERT(mol->hasProp("_Name"));
+    TEST_ASSERT(mol->hasProp(RDKit::common_properties::_Name));
     std::string sval;
-    mol->getProp("_Name",sval);
+    mol->getProp(RDKit::common_properties::_Name,sval);
     TEST_ASSERT(sval=="methane");
     delete mol;
   }
@@ -1656,7 +1656,7 @@ void test15(){
     TEST_ASSERT(mol);
     TEST_ASSERT(mol->hasProp("blah"));
     std::string sval;
-    mol->getProp("_Name",sval);
+    mol->getProp(RDKit::common_properties::_Name,sval);
     TEST_ASSERT(sval=="methane");
     mol->getProp("coord2d",sval);
     TEST_ASSERT(sval=="(1,0)");

--- a/Code/GraphMol/SmilesParse/SmartsWrite.cpp
+++ b/Code/GraphMol/SmilesParse/SmartsWrite.cpp
@@ -641,11 +641,10 @@ namespace RDKit {
           res = "!" + res;
         }
       }
-      if(qatom->hasProp("molAtomMapNumber")){
-	needParen=true;
-	std::string mapNum;
-	qatom->getProp("molAtomMapNumber",mapNum);
-	res += ":"+mapNum;
+      std::string mapNum;
+      if(qatom->getPropIfPresent(common_properties::molAtomMapNumber, mapNum)){
+        needParen=true;
+        res += ":"+mapNum;
       }
       if (needParen ) {
         res = "[" + res + "]";

--- a/Code/GraphMol/SmilesParse/SmilesParseOps.cpp
+++ b/Code/GraphMol/SmilesParse/SmilesParseOps.cpp
@@ -72,15 +72,14 @@ namespace SmilesParseOps{
     //
     for(RWMol::AtomIterator atomIt=frag->beginAtoms();
         atomIt!=frag->endAtoms();atomIt++){
-      if((*atomIt)->hasProp("_RingClosures")){
-        INT_VECT tmpVect;
-        (*atomIt)->getProp("_RingClosures",tmpVect);
+      INT_VECT tmpVect;
+      if((*atomIt)->getPropIfPresent(common_properties::_RingClosures, tmpVect)){
         BOOST_FOREACH(int &v, tmpVect){
           // if the ring closure is not already a bond, don't touch it:
           if(v>=0) v += nOrigBonds;
         }
         Atom *newAtom = mol->getAtomWithIdx(nOrigAtoms+(*atomIt)->getIdx());
-        newAtom->setProp("_RingClosures",tmpVect);
+        newAtom->setProp(common_properties::_RingClosures,tmpVect);
       }
     }
 
@@ -229,8 +228,8 @@ namespace SmilesParseOps{
         // need to insert into the list in a particular order
         //
         INT_VECT ringClosures;
-        if((*atomIt)->hasProp("_RingClosures"))
-          (*atomIt)->getProp("_RingClosures",ringClosures);
+        (*atomIt)->getPropIfPresent(common_properties::_RingClosures, ringClosures);
+
 #if 0
         std::cout << "CLOSURES: ";
         std::copy(ringClosures.begin(),ringClosures.end(),
@@ -295,7 +294,7 @@ namespace SmilesParseOps{
         //
         int nSwaps=(*atomIt)->getPerturbationOrder(bondOrdering);
         // FIX: explain this one:
-        if((*atomIt)->getDegree()==3 && (*atomIt)->hasProp("_SmilesStart")) ++nSwaps;
+        if((*atomIt)->getDegree()==3 && (*atomIt)->hasProp(common_properties::_SmilesStart)) ++nSwaps;
         if(nSwaps%2){
           (*atomIt)->invertChirality();
         }
@@ -385,7 +384,7 @@ namespace SmilesParseOps{
             //   bond, we'll just take the first one and ignore others
             //   NOTE: we used to do this the other way (take the last specification),
             //   but that turned out to be troublesome in odd cases like C1CC11CC1.
-            if(!bond1->hasProp("_unspecifiedOrder")){
+            if(!bond1->hasProp(common_properties::_unspecifiedOrder)){
               matchedBond = bond1;
               matchedBond->setEndAtomIdx(atom2->getIdx());
               delete bond2;
@@ -433,27 +432,27 @@ namespace SmilesParseOps{
             // we found a bond, so update the atom's _RingClosures
             // property:
             if(bondIdx>-1){
-              CHECK_INVARIANT(atom1->hasProp("_RingClosures") &&
-                  atom2->hasProp("_RingClosures"),
+              CHECK_INVARIANT(atom1->hasProp(common_properties::_RingClosures) &&
+                  atom2->hasProp(common_properties::_RingClosures),
                   "somehow atom doesn't have _RingClosures property.");
               INT_VECT closures;
-              atom1->getProp("_RingClosures",closures);
+              atom1->getProp(common_properties::_RingClosures,closures);
               INT_VECT::iterator closurePos= std::find(closures.begin(),
                   closures.end(),
                   -(bookmarkIt->first+1));
               CHECK_INVARIANT(closurePos!=closures.end(),
                   "could not find bookmark in atom _RingClosures");
               *closurePos = bondIdx-1;
-              atom1->setProp("_RingClosures",closures);
+              atom1->setProp(common_properties::_RingClosures,closures);
 
-              atom2->getProp("_RingClosures",closures);
+              atom2->getProp(common_properties::_RingClosures,closures);
               closurePos= std::find(closures.begin(),
                   closures.end(),
                   -(bookmarkIt->first+1));
               CHECK_INVARIANT(closurePos!=closures.end(),
                   "could not find bookmark in atom _RingClosures");
               *closurePos = bondIdx-1;
-              atom2->setProp("_RingClosures",closures);
+              atom2->setProp(common_properties::_RingClosures,closures);
             }
             bookmarkedAtomsToRemove.push_back(atom1);
             bookmarkedAtomsToRemove.push_back(atom2);
@@ -479,15 +478,15 @@ namespace SmilesParseOps{
     PRECONDITION(mol,"no molecule");
     for(RWMol::AtomIterator atomIt=mol->beginAtoms();
         atomIt!=mol->endAtoms();++atomIt){
-      if((*atomIt)->hasProp("_RingClosures"))
-        (*atomIt)->clearProp("_RingClosures");
-      if((*atomIt)->hasProp("_SmilesStart"))
-        (*atomIt)->clearProp("_SmilesStart");
+      if((*atomIt)->hasProp(common_properties::_RingClosures))
+        (*atomIt)->clearProp(common_properties::_RingClosures);
+      if((*atomIt)->hasProp(common_properties::_SmilesStart))
+        (*atomIt)->clearProp(common_properties::_SmilesStart);
     }
     for(RWMol::BondIterator bondIt=mol->beginBonds();
         bondIt!=mol->endBonds();++bondIt){
-      if((*bondIt)->hasProp("_unspecifiedOrder"))
-        (*bondIt)->clearProp("_unspecifiedOrder");
+      if((*bondIt)->hasProp(common_properties::_unspecifiedOrder))
+        (*bondIt)->clearProp(common_properties::_unspecifiedOrder);
     }
   }
 

--- a/Code/GraphMol/SmilesParse/SmilesWrite.cpp
+++ b/Code/GraphMol/SmilesParse/SmilesWrite.cpp
@@ -50,9 +50,7 @@ namespace RDKit{
 
       bool needsBracket=false;
       std::string symb;
-      if(atom->hasProp("smilesSymbol")){
-        atom->getProp("smilesSymbol",symb);
-      } else {
+      if(!atom->getPropIfPresent(common_properties::smilesSymbol, symb)){
         symb=PeriodicTable::getTable()->getElementSymbol(num);
       }
       //symb = atom->getSymbol();
@@ -85,14 +83,14 @@ namespace RDKit{
         if(fc || nonStandard){
           needsBracket=true;
         }
-        if(atom->getOwningMol().hasProp("_doIsoSmiles")){
+        if(atom->getOwningMol().hasProp(common_properties::_doIsoSmiles)){
           if( atom->getChiralTag()!=Atom::CHI_UNSPECIFIED ){
             needsBracket = true;
           } else if(isotope){
             needsBracket=true;
           }
         }
-        if(atom->hasProp("molAtomMapNumber")){
+        if(atom->hasProp(common_properties::molAtomMapNumber)){
           needsBracket=true;
         }
       } else {
@@ -100,7 +98,7 @@ namespace RDKit{
       }
       if( needsBracket ) res << "[";
 
-      if(isotope && atom->getOwningMol().hasProp("_doIsoSmiles")){
+      if(isotope && atom->getOwningMol().hasProp(common_properties::_doIsoSmiles)){
         res <<isotope;
       }
       // this was originally only done for the organic subset,
@@ -110,10 +108,10 @@ namespace RDKit{
       }
       res << symb;
 
-      if(atom->getOwningMol().hasProp("_doIsoSmiles") &&
+      if(atom->getOwningMol().hasProp(common_properties::_doIsoSmiles) &&
          atom->getChiralTag()!=Atom::CHI_UNSPECIFIED ){
         INT_LIST trueOrder;
-        atom->getProp("_TraversalBondIndexOrder",trueOrder);
+        atom->getProp(common_properties::_TraversalBondIndexOrder,trueOrder);
         int nSwaps=  atom->getPerturbationOrder(trueOrder);
         if(atom->getDegree()==3 && !bondIn){
           // This is a special case. Here's an example:
@@ -157,10 +155,9 @@ namespace RDKit{
           res << "-";
           if(fc < -1) res << -fc;
         }
-    
-        if(atom->hasProp("molAtomMapNumber")){
-          int mapNum;
-          atom->getProp("molAtomMapNumber",mapNum);
+
+        int mapNum;
+        if(atom->getPropIfPresent(common_properties::molAtomMapNumber, mapNum)){
           res<<":"<<mapNum;
         }
         res << "]";
@@ -168,9 +165,8 @@ namespace RDKit{
 
       // If the atom has this property, the contained string will
       // be inserted directly in the SMILES:
-      if(atom->hasProp("_supplementalSmilesLabel")){
-        std::string label;
-        atom->getProp("_supplementalSmilesLabel",label);
+      std::string label;
+      if(atom->getPropIfPresent(common_properties::_supplementalSmilesLabel, label)){
         res << label;
       }
 
@@ -196,11 +192,11 @@ namespace RDKit{
 
       Bond::BondDir dir= bond->getBondDir();
 
-      if(bond->hasProp("_TraversalRingClosureBond")){
+      if(bond->hasProp(common_properties::_TraversalRingClosureBond)){
         //std::cerr<<"FLIP: "<<bond->getIdx()<<" "<<bond->getBeginAtomIdx()<<"-"<<bond->getEndAtomIdx()<<std::endl;
         //if(dir==Bond::ENDDOWNRIGHT) dir=Bond::ENDUPRIGHT;
         //else if(dir==Bond::ENDUPRIGHT) dir=Bond::ENDDOWNRIGHT;
-        bond->clearProp("_TraversalRingClosureBond");
+        bond->clearProp(common_properties::_TraversalRingClosureBond);
       }
   
       switch(bond->getBondType()){
@@ -208,10 +204,10 @@ namespace RDKit{
         if( dir != Bond::NONE && dir != Bond::UNKNOWN ){
           switch(dir){
           case Bond::ENDDOWNRIGHT:
-            if(bond->getOwningMol().hasProp("_doIsoSmiles"))  res << "\\";
+            if(bond->getOwningMol().hasProp(common_properties::_doIsoSmiles))  res << "\\";
             break;
           case Bond::ENDUPRIGHT:
-            if(bond->getOwningMol().hasProp("_doIsoSmiles"))  res << "/";
+            if(bond->getOwningMol().hasProp(common_properties::_doIsoSmiles))  res << "/";
             break;
           default:
             break;
@@ -236,10 +232,10 @@ namespace RDKit{
         if ( dir != Bond::NONE && dir != Bond::UNKNOWN ){
           switch(dir){
           case Bond::ENDDOWNRIGHT:
-            if(bond->getOwningMol().hasProp("_doIsoSmiles"))  res << "\\";
+            if(bond->getOwningMol().hasProp(common_properties::_doIsoSmiles))  res << "\\";
             break;
           case Bond::ENDUPRIGHT:
-            if(bond->getOwningMol().hasProp("_doIsoSmiles"))  res << "/";
+            if(bond->getOwningMol().hasProp(common_properties::_doIsoSmiles))  res << "/";
             break;
           default:
             break;
@@ -279,7 +275,7 @@ namespace RDKit{
 
       std::map<int,int> ringClosureMap;
       int ringIdx,closureVal;
-      if(!canonical) mol.setProp("_StereochemDone",1);
+      if(!canonical) mol.setProp(common_properties::_StereochemDone,1);
       std::list<unsigned int> ringClosuresToErase;
 
       Canon::canonicalizeFragment(mol,atomIdx,colors,ranks,
@@ -373,7 +369,7 @@ namespace RDKit{
 
     ROMol tmol(mol,true);
     if(doIsomericSmiles){
-      tmol.setProp("_doIsoSmiles",1);
+      tmol.setProp(common_properties::_doIsoSmiles,1);
     }
 #if 0
     std::cout << "----------------------------" << std::endl;
@@ -395,17 +391,16 @@ namespace RDKit{
     // clean up the chirality on any atom that is marked as chiral,
     // but that should not be:
     if(doIsomericSmiles){
-      if(!mol.hasProp("_StereochemDone")){
+      if(!mol.hasProp(common_properties::_StereochemDone)){
         MolOps::assignStereochemistry(tmol,true);
       } else {
-        tmol.setProp("_StereochemDone",1);
+        tmol.setProp(common_properties::_StereochemDone,1);
         // we need the CIP codes:
         for(unsigned int aidx=0;aidx<tmol.getNumAtoms();++aidx){
           const Atom *oAt=mol.getAtomWithIdx(aidx);
-          if(oAt->hasProp("_CIPCode")){
-            std::string cipCode;
-            oAt->getProp("_CIPCode",cipCode);
-            tmol.getAtomWithIdx(aidx)->setProp("_CIPCode",cipCode);
+          std::string cipCode;
+          if(oAt->getPropIfPresent(common_properties::_CIPCode, cipCode)){
+            tmol.getAtomWithIdx(aidx)->setProp(common_properties::_CIPCode,cipCode);
           }
         }
       }
@@ -455,7 +450,7 @@ namespace RDKit{
         res += ".";
       }
     }
-    mol.setProp("_smilesAtomOutputOrder",atomOrdering,true);
+    mol.setProp(common_properties::_smilesAtomOutputOrder,atomOrdering,true);
     return res;
   } // end of MolToSmiles()
 
@@ -484,7 +479,7 @@ namespace RDKit{
 
     ROMol tmol(mol,true);
     if(doIsomericSmiles){
-      tmol.setProp("_doIsoSmiles",1);
+      tmol.setProp(common_properties::_doIsoSmiles,1);
     }
     std::string res;
 
@@ -549,17 +544,16 @@ namespace RDKit{
     // clean up the chirality on any atom that is marked as chiral,
     // but that should not be:
     if(doIsomericSmiles){
-      if(!mol.hasProp("_StereochemDone")){
+      if(!mol.hasProp(common_properties::_StereochemDone)){
         MolOps::assignStereochemistry(tmol,true);
       } else {
-        tmol.setProp("_StereochemDone",1);
+        tmol.setProp(common_properties::_StereochemDone,1);
         // we need the CIP codes:
         BOOST_FOREACH(int aidx,atomsToUse){
           const Atom *oAt=mol.getAtomWithIdx(aidx);
-          if(oAt->hasProp("_CIPCode")){
-            std::string cipCode;
-            oAt->getProp("_CIPCode",cipCode);
-            tmol.getAtomWithIdx(aidx)->setProp("_CIPCode",cipCode);
+          std::string cipCode;
+          if(oAt->getPropIfPresent(common_properties::_CIPCode, cipCode)){
+            tmol.getAtomWithIdx(aidx)->setProp(common_properties::_CIPCode,cipCode);
           }
         }
       }
@@ -614,7 +608,7 @@ namespace RDKit{
         res += ".";
       }
     }
-    mol.setProp("_smilesAtomOutputOrder",atomOrdering,true);
+    mol.setProp(common_properties::_smilesAtomOutputOrder,atomOrdering,true);
     return res;
   } // end of MolFragmentToSmiles()
 }

--- a/Code/GraphMol/SmilesParse/lex.yysmiles.cpp.cmake
+++ b/Code/GraphMol/SmilesParse/lex.yysmiles.cpp.cmake
@@ -1258,7 +1258,7 @@ case 120:
 YY_RULE_SETUP
 #line 205 "smiles.ll"
 {   yylval->atom = new Atom( 0 );
-		            yylval->atom->setProp("dummyLabel",
+		            yylval->atom->setProp(RDKit::common_properties::dummyLabel,
                                                         std::string("*"));
                                 // must be ORGANIC_ATOM_TOKEN because
                                 // we aren't in square brackets:

--- a/Code/GraphMol/SmilesParse/smarts.tab.cpp.cmake
+++ b/Code/GraphMol/SmilesParse/smarts.tab.cpp.cmake
@@ -1477,7 +1477,7 @@ yyreduce:
   int sz     = molList->size();
   molList->resize( sz + 1);
   (*molList)[ sz ] = new RWMol();
-  (yyvsp[0].atom)->setProp("_SmilesStart",1);
+  (yyvsp[0].atom)->setProp(common_properties::_SmilesStart,1);
   (*molList)[ sz ]->addAtom((yyvsp[0].atom),true,true);
   //delete $1;
   (yyval.moli) = sz;
@@ -1507,7 +1507,7 @@ yyreduce:
   			    Queries::COMPOSITE_OR,
   			    true);
   }
-  newB->setProp("_unspecifiedOrder",1);
+  newB->setProp(common_properties::_unspecifiedOrder,1);
   newB->setOwningMol(mp);
   newB->setBeginAtomIdx(atomIdx1);
   newB->setEndAtomIdx(atomIdx2);
@@ -1546,7 +1546,7 @@ yyreduce:
 #line 165 "smarts.yy" /* yacc.c:1646  */
     {
   RWMol *mp = (*molList)[(yyval.moli)];
-  (yyvsp[0].atom)->setProp("_SmilesStart",1,true);
+  (yyvsp[0].atom)->setProp(common_properties::_SmilesStart,1,true);
   mp->addAtom((yyvsp[0].atom),true,true);
 }
 #line 1553 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
@@ -1572,18 +1572,17 @@ yyreduce:
   			    Queries::COMPOSITE_OR,
   			    true);
   }
-  newB->setProp("_unspecifiedOrder",1);
+  newB->setProp(common_properties::_unspecifiedOrder,1);
   newB->setOwningMol(mp);
   newB->setBeginAtomIdx(atom->getIdx());
   mp->setBondBookmark(newB,(yyvsp[0].ival));
 
   mp->setAtomBookmark(atom,(yyvsp[0].ival));
   INT_VECT tmp;
-  if(atom->hasProp("_RingClosures")){
-    atom->getProp("_RingClosures",tmp);
-  }
+  atom->getPropIfPresent(common_properties::_RingClosures,tmp);
+
   tmp.push_back(-((yyvsp[0].ival)+1));
-  atom->setProp("_RingClosures",tmp);
+  atom->setProp(common_properties::_RingClosures,tmp);
 
 }
 #line 1590 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
@@ -1601,11 +1600,10 @@ yyreduce:
 
   mp->setAtomBookmark(atom,(yyvsp[0].ival));
   INT_VECT tmp;
-  if(atom->hasProp("_RingClosures")){
-    atom->getProp("_RingClosures",tmp);
-  }
+  atom->getPropIfPresent(common_properties::_RingClosures,tmp);
+
   tmp.push_back(-((yyvsp[0].ival)+1));
-  atom->setProp("_RingClosures",tmp);
+  atom->setProp(common_properties::_RingClosures,tmp);
 
 }
 #line 1612 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
@@ -1615,7 +1613,7 @@ yyreduce:
 #line 222 "smarts.yy" /* yacc.c:1646  */
     {
   RWMol *m1_p = (*molList)[(yyval.moli)],*m2_p=(*molList)[(yyvsp[0].moli)];
-  m2_p->getAtomWithIdx(0)->setProp("_SmilesStart",1);
+  m2_p->getAtomWithIdx(0)->setProp(common_properties::_SmilesStart,1);
   // FIX: handle generic bonds here
   SmilesParseOps::AddFragToMol(m1_p,m2_p,Bond::UNSPECIFIED,Bond::NONE,false,true);
   delete m2_p;
@@ -1658,7 +1656,7 @@ yyreduce:
 #line 255 "smarts.yy" /* yacc.c:1646  */
     {
   (yyval.atom) = new QueryAtom(1);
-  (yyval.atom)->setProp("molAtomMapNumber",(yyvsp[-1].ival));
+  (yyval.atom)->setProp(common_properties::molAtomMapNumber,(yyvsp[-1].ival));
 }
 #line 1664 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
     break;
@@ -1675,7 +1673,7 @@ yyreduce:
 #line 264 "smarts.yy" /* yacc.c:1646  */
     {
   (yyval.atom) = (yyvsp[-3].atom);
-  (yyval.atom)->setProp("molAtomMapNumber",(yyvsp[-1].ival));
+  (yyval.atom)->setProp(common_properties::molAtomMapNumber,(yyvsp[-1].ival));
 }
 #line 1681 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
     break;

--- a/Code/GraphMol/SmilesParse/smarts.yy
+++ b/Code/GraphMol/SmilesParse/smarts.yy
@@ -108,7 +108,7 @@ mol: atomd {
   int sz     = molList->size();
   molList->resize( sz + 1);
   (*molList)[ sz ] = new RWMol();
-  $1->setProp("_SmilesStart",1);
+  $1->setProp(RDKit::common_properties::_SmilesStart,1);
   (*molList)[ sz ]->addAtom($1,true,true);
   //delete $1;
   $$ = sz;
@@ -133,7 +133,7 @@ mol: atomd {
   			    Queries::COMPOSITE_OR,
   			    true);
   }
-  newB->setProp("_unspecifiedOrder",1);
+  newB->setProp(RDKit::common_properties::_unspecifiedOrder,1);
   newB->setOwningMol(mp);
   newB->setBeginAtomIdx(atomIdx1);
   newB->setEndAtomIdx(atomIdx2);
@@ -164,7 +164,7 @@ mol: atomd {
 
 | mol SEPARATOR_TOKEN atomd {
   RWMol *mp = (*molList)[$$];
-  $3->setProp("_SmilesStart",1,true);
+  $3->setProp(RDKit::common_properties::_SmilesStart,1,true);
   mp->addAtom($3,true,true);
 }
 
@@ -186,18 +186,18 @@ mol: atomd {
   			    Queries::COMPOSITE_OR,
   			    true);
   }
-  newB->setProp("_unspecifiedOrder",1);
+  newB->setProp(RDKit::common_properties::_unspecifiedOrder,1);
   newB->setOwningMol(mp);
   newB->setBeginAtomIdx(atom->getIdx());
   mp->setBondBookmark(newB,$2);
 
   mp->setAtomBookmark(atom,$2);
   INT_VECT tmp;
-  if(atom->hasProp("_RingClosures")){
-    atom->getProp("_RingClosures",tmp);
+  if(atom->hasProp(RDKit::common_properties::_RingClosures)){
+    atom->getProp(RDKit::common_properties::_RingClosures,tmp);
   }
   tmp.push_back(-($2+1));
-  atom->setProp("_RingClosures",tmp);
+  atom->setProp(RDKit::common_properties::_RingClosures,tmp);
 
 }
 
@@ -211,17 +211,17 @@ mol: atomd {
 
   mp->setAtomBookmark(atom,$3);
   INT_VECT tmp;
-  if(atom->hasProp("_RingClosures")){
-    atom->getProp("_RingClosures",tmp);
+  if(atom->hasProp(RDKit::common_properties::_RingClosures)){
+    atom->getProp(RDKit::common_properties::_RingClosures,tmp);
   }
   tmp.push_back(-($3+1));
-  atom->setProp("_RingClosures",tmp);
+  atom->setProp(RDKit::common_properties::_RingClosures,tmp);
 
 }
 
 | mol branch {
   RWMol *m1_p = (*molList)[$$],*m2_p=(*molList)[$2];
-  m2_p->getAtomWithIdx(0)->setProp("_SmilesStart",1);
+  m2_p->getAtomWithIdx(0)->setProp(RDKit::common_properties::_SmilesStart,1);
   // FIX: handle generic bonds here
   SmilesParseOps::AddFragToMol(m1_p,m2_p,Bond::UNSPECIFIED,Bond::NONE,false,true);
   delete m2_p;
@@ -254,7 +254,7 @@ atomd:	simple_atom
 | ATOM_OPEN_TOKEN H_TOKEN COLON_TOKEN number ATOM_CLOSE_TOKEN
 {
   $$ = new QueryAtom(1);
-  $$->setProp("molAtomMapNumber",$4);
+  $$->setProp(RDKit::common_properties::molAtomMapNumber,$4);
 }
 | ATOM_OPEN_TOKEN atom_expr ATOM_CLOSE_TOKEN
 {
@@ -263,7 +263,7 @@ atomd:	simple_atom
 | ATOM_OPEN_TOKEN atom_expr COLON_TOKEN number ATOM_CLOSE_TOKEN
 {
   $$ = $2;
-  $$->setProp("molAtomMapNumber",$4);
+  $$->setProp(RDKit::common_properties::molAtomMapNumber,$4);
 }
 ;
 

--- a/Code/GraphMol/SmilesParse/smatest.cpp
+++ b/Code/GraphMol/SmilesParse/smatest.cpp
@@ -925,16 +925,16 @@ void testAtomMap(){
   sma = "[C:10]CC";
   matcher1 = SmartsToMol(sma);
   TEST_ASSERT(matcher1);
-  TEST_ASSERT(matcher1->getAtomWithIdx(0)->hasProp("molAtomMapNumber"));
-  matcher1->getAtomWithIdx(0)->getProp("molAtomMapNumber",mapNum);
+  TEST_ASSERT(matcher1->getAtomWithIdx(0)->hasProp(common_properties::molAtomMapNumber));
+  matcher1->getAtomWithIdx(0)->getProp(common_properties::molAtomMapNumber,mapNum);
   TEST_ASSERT(mapNum==10);
   delete matcher1;
 
   sma = "[CH3:10]CC";
   matcher1 = SmartsToMol(sma);
   TEST_ASSERT(matcher1);
-  TEST_ASSERT(matcher1->getAtomWithIdx(0)->hasProp("molAtomMapNumber"));
-  matcher1->getAtomWithIdx(0)->getProp("molAtomMapNumber",mapNum);
+  TEST_ASSERT(matcher1->getAtomWithIdx(0)->hasProp(common_properties::molAtomMapNumber));
+  matcher1->getAtomWithIdx(0)->getProp(common_properties::molAtomMapNumber,mapNum);
   TEST_ASSERT(mapNum==10);
   delete matcher1;
 
@@ -980,25 +980,25 @@ void testIssue1804420(){
   sma = "[N;D3:1]";
   matcher1 = SmartsToMol(sma);
   TEST_ASSERT(matcher1);
-  TEST_ASSERT(matcher1->getAtomWithIdx(0)->hasProp("molAtomMapNumber"));
+  TEST_ASSERT(matcher1->getAtomWithIdx(0)->hasProp(common_properties::molAtomMapNumber));
   delete matcher1;
 
   sma = "[N,O;D3:1]";
   matcher1 = SmartsToMol(sma);
   TEST_ASSERT(matcher1);
-  TEST_ASSERT(matcher1->getAtomWithIdx(0)->hasProp("molAtomMapNumber"));
+  TEST_ASSERT(matcher1->getAtomWithIdx(0)->hasProp(common_properties::molAtomMapNumber));
   delete matcher1;
 
   sma = "[N&R;X3:1]";
   matcher1 = SmartsToMol(sma);
   TEST_ASSERT(matcher1);
-  TEST_ASSERT(matcher1->getAtomWithIdx(0)->hasProp("molAtomMapNumber"));
+  TEST_ASSERT(matcher1->getAtomWithIdx(0)->hasProp(common_properties::molAtomMapNumber));
   delete matcher1;
 
   sma = "[NH0&R;D3,X3:1]";
   matcher1 = SmartsToMol(sma);
   TEST_ASSERT(matcher1);
-  TEST_ASSERT(matcher1->getAtomWithIdx(0)->hasProp("molAtomMapNumber"));
+  TEST_ASSERT(matcher1->getAtomWithIdx(0)->hasProp(common_properties::molAtomMapNumber));
   delete matcher1;
 
     

--- a/Code/GraphMol/SmilesParse/smiles.tab.cpp.cmake
+++ b/Code/GraphMol/SmilesParse/smiles.tab.cpp.cmake
@@ -1377,7 +1377,7 @@ yyreduce:
   molList->resize( sz + 1);
   (*molList)[ sz ] = new RWMol();
   RDKit::RWMol *curMol = (*molList)[ sz ];
-  (yyvsp[0].atom)->setProp("_SmilesStart",1);
+  (yyvsp[0].atom)->setProp(common_properties::_SmilesStart,1);
   curMol->addAtom((yyvsp[0].atom));
   delete (yyvsp[0].atom);
   (yyval.moli) = sz;
@@ -1439,7 +1439,7 @@ yyreduce:
 #line 148 "smiles.yy" /* yacc.c:1646  */
     {
   RWMol *mp = (*molList)[(yyval.moli)];
-  (yyvsp[0].atom)->setProp("_SmilesStart",1,true);
+  (yyvsp[0].atom)->setProp(common_properties::_SmilesStart,1,true);
   mp->addAtom((yyvsp[0].atom),true,true);
 }
 #line 1446 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
@@ -1455,13 +1455,12 @@ yyreduce:
   Bond *newB = mp->createPartialBond(atom->getIdx(),
 				     Bond::UNSPECIFIED);
   mp->setBondBookmark(newB,(yyvsp[0].ival));
-  newB->setProp("_unspecifiedOrder",1);
+  newB->setProp(common_properties::_unspecifiedOrder,1);
   INT_VECT tmp;
-  if(atom->hasProp("_RingClosures")){
-    atom->getProp("_RingClosures",tmp);
-  }
+  atom->getPropIfPresent(common_properties::_RingClosures,tmp);
+
   tmp.push_back(-((yyvsp[0].ival)+1));
-  atom->setProp("_RingClosures",tmp);
+  atom->setProp(common_properties::_RingClosures,tmp);
 }
 #line 1467 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
     break;
@@ -1477,11 +1476,10 @@ yyreduce:
   mp->setAtomBookmark(atom,(yyvsp[0].ival));
   mp->setBondBookmark(newB,(yyvsp[0].ival));
   INT_VECT tmp;
-  if(atom->hasProp("_RingClosures")){
-    atom->getProp("_RingClosures",tmp);
-  }
+  atom->getPropIfPresent(common_properties::_RingClosures,tmp);
+
   tmp.push_back(-((yyvsp[0].ival)+1));
-  atom->setProp("_RingClosures",tmp);
+  atom->setProp(common_properties::_RingClosures,tmp);
   delete (yyvsp[-1].bond);
 }
 #line 1488 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
@@ -1497,11 +1495,10 @@ yyreduce:
   mp->setAtomBookmark(atom,(yyvsp[0].ival));
   mp->setBondBookmark(newB,(yyvsp[0].ival));
   INT_VECT tmp;
-  if(atom->hasProp("_RingClosures")){
-    atom->getProp("_RingClosures",tmp);
-  }
+  atom->getPropIfPresent(common_properties::_RingClosures,tmp);
+
   tmp.push_back(-((yyvsp[0].ival)+1));
-  atom->setProp("_RingClosures",tmp);
+  atom->setProp(common_properties::_RingClosures,tmp);
 }
 #line 1507 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
     break;
@@ -1575,7 +1572,7 @@ yyreduce:
     {
   (yyval.atom) = (yyvsp[-3].atom);
   (yyval.atom)->setNoImplicit(true);
-  (yyval.atom)->setProp("molAtomMapNumber",(yyvsp[-1].ival));
+  (yyval.atom)->setProp(common_properties::molAtomMapNumber,(yyvsp[-1].ival));
 }
 #line 1581 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
     break;

--- a/Code/GraphMol/SmilesParse/smiles.yy
+++ b/Code/GraphMol/SmilesParse/smiles.yy
@@ -101,7 +101,7 @@ mol: atomd {
   molList->resize( sz + 1);
   (*molList)[ sz ] = new RWMol();
   RDKit::RWMol *curMol = (*molList)[ sz ];
-  $1->setProp("_SmilesStart",1);
+  $1->setProp(RDKit::common_properties::_SmilesStart,1);
   curMol->addAtom($1);
   delete $1;
   $$ = sz;
@@ -147,7 +147,7 @@ mol: atomd {
 
 | mol SEPARATOR_TOKEN atomd {
   RWMol *mp = (*molList)[$$];
-  $3->setProp("_SmilesStart",1,true);
+  $3->setProp(RDKit::common_properties::_SmilesStart,1,true);
   mp->addAtom($3,true,true);
 }
 
@@ -159,13 +159,12 @@ mol: atomd {
   Bond *newB = mp->createPartialBond(atom->getIdx(),
 				     Bond::UNSPECIFIED);
   mp->setBondBookmark(newB,$2);
-  newB->setProp("_unspecifiedOrder",1);
+  newB->setProp(RDKit::common_properties::_unspecifiedOrder,1);
   INT_VECT tmp;
-  if(atom->hasProp("_RingClosures")){
-    atom->getProp("_RingClosures",tmp);
-  }
+  atom->getPropIfPresent(RDKit::common_properties::_RingClosures,tmp);
+
   tmp.push_back(-($2+1));
-  atom->setProp("_RingClosures",tmp);
+  atom->setProp(RDKit::common_properties::_RingClosures,tmp);
 }
 
 | mol BOND_TOKEN ring_number {
@@ -177,11 +176,10 @@ mol: atomd {
   mp->setAtomBookmark(atom,$3);
   mp->setBondBookmark(newB,$3);
   INT_VECT tmp;
-  if(atom->hasProp("_RingClosures")){
-    atom->getProp("_RingClosures",tmp);
-  }
+  atom->getPropIfPresent(RDKit::common_properties::_RingClosures,tmp);
+
   tmp.push_back(-($3+1));
-  atom->setProp("_RingClosures",tmp);
+  atom->setProp(RDKit::common_properties::_RingClosures,tmp);
   delete $2;
 }
 
@@ -193,11 +191,10 @@ mol: atomd {
   mp->setAtomBookmark(atom,$3);
   mp->setBondBookmark(newB,$3);
   INT_VECT tmp;
-  if(atom->hasProp("_RingClosures")){
-    atom->getProp("_RingClosures",tmp);
-  }
+  atom->getPropIfPresent(RDKit::common_properties::_RingClosures,tmp);
+
   tmp.push_back(-($3+1));
-  atom->setProp("_RingClosures",tmp);
+  atom->setProp(RDKit::common_properties::_RingClosures,tmp);
 }
 
 | mol GROUP_OPEN_TOKEN atomd {
@@ -253,7 +250,7 @@ atomd:	simple_atom
 {
   $$ = $2;
   $$->setNoImplicit(true);
-  $$->setProp("molAtomMapNumber",$4);
+  $$->setProp(RDKit::common_properties::molAtomMapNumber,$4);
 }
 
 | ATOM_OPEN_TOKEN charge_element ATOM_CLOSE_TOKEN

--- a/Code/GraphMol/SmilesParse/test.cpp
+++ b/Code/GraphMol/SmilesParse/test.cpp
@@ -379,8 +379,8 @@ void testStereochem(){
   TEST_ASSERT(mol->getAtomWithIdx(1)->getChiralTag()==Atom::CHI_TETRAHEDRAL_CCW);
   TEST_ASSERT(mol->getAtomWithIdx(0)->getChiralTag()==Atom::CHI_UNSPECIFIED);
   MolOps::assignStereochemistry(*mol);
-  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  mol->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  mol->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="S");
   refSmi = MolToSmiles(*mol,1);
 
@@ -390,8 +390,8 @@ void testStereochem(){
   TEST_ASSERT(mol->getAtomWithIdx(1)->getChiralTag()==Atom::CHI_TETRAHEDRAL_CCW);
   TEST_ASSERT(mol->getAtomWithIdx(0)->getChiralTag()==Atom::CHI_UNSPECIFIED);
   MolOps::assignStereochemistry(*mol);
-  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  mol->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  mol->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="S");
   smi = MolToSmiles(*mol,1);
   TEST_ASSERT(smi==refSmi);
@@ -408,8 +408,8 @@ void testStereochem(){
   mol = SmilesToMol(smi);
   TEST_ASSERT(mol->getAtomWithIdx(1)->getChiralTag()==Atom::CHI_TETRAHEDRAL_CCW);
   MolOps::assignStereochemistry(*mol);
-  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  mol->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  mol->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="S");
   smi = MolToSmiles(*mol,1);
   TEST_ASSERT(smi==refSmi);
@@ -419,8 +419,8 @@ void testStereochem(){
   mol = SmilesToMol(smi);
   TEST_ASSERT(mol->getAtomWithIdx(1)->getChiralTag()==Atom::CHI_TETRAHEDRAL_CCW);
   MolOps::assignStereochemistry(*mol);
-  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  mol->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  mol->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="S");
   smi = MolToSmiles(*mol,1);
   TEST_ASSERT(smi==refSmi);
@@ -430,8 +430,8 @@ void testStereochem(){
   mol = SmilesToMol(smi);
   TEST_ASSERT(mol->getAtomWithIdx(1)->getChiralTag()==Atom::CHI_TETRAHEDRAL_CCW);
   MolOps::assignStereochemistry(*mol);
-  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  mol->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  mol->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="S");
   smi = MolToSmiles(*mol,1);
   TEST_ASSERT(smi==refSmi);
@@ -441,8 +441,8 @@ void testStereochem(){
   mol = SmilesToMol(smi);
   TEST_ASSERT(mol->getAtomWithIdx(1)->getChiralTag()==Atom::CHI_TETRAHEDRAL_CCW);
   MolOps::assignStereochemistry(*mol);
-  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  mol->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  mol->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="S");
   smi = MolToSmiles(*mol,1);
   TEST_ASSERT(smi==refSmi);
@@ -452,8 +452,8 @@ void testStereochem(){
   mol = SmilesToMol(smi);
   TEST_ASSERT(mol->getAtomWithIdx(1)->getChiralTag()==Atom::CHI_TETRAHEDRAL_CW);
   MolOps::assignStereochemistry(*mol);
-  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  mol->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  mol->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="S");
   smi = MolToSmiles(*mol,1);
   TEST_ASSERT(smi==refSmi);
@@ -463,8 +463,8 @@ void testStereochem(){
   mol = SmilesToMol(smi);
   TEST_ASSERT(mol->getAtomWithIdx(1)->getChiralTag()==Atom::CHI_TETRAHEDRAL_CW);
   MolOps::assignStereochemistry(*mol);
-  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  mol->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  mol->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="S");
   smi = MolToSmiles(*mol,1);
   TEST_ASSERT(smi==refSmi);
@@ -474,8 +474,8 @@ void testStereochem(){
   mol = SmilesToMol(smi);
   TEST_ASSERT(mol->getAtomWithIdx(1)->getChiralTag()==Atom::CHI_TETRAHEDRAL_CW);
   MolOps::assignStereochemistry(*mol);
-  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  mol->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  mol->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="S");
   smi = MolToSmiles(*mol,1);
   TEST_ASSERT(smi==refSmi);
@@ -485,8 +485,8 @@ void testStereochem(){
   mol = SmilesToMol(smi);
   TEST_ASSERT(mol->getAtomWithIdx(1)->getChiralTag()==Atom::CHI_TETRAHEDRAL_CW);
   MolOps::assignStereochemistry(*mol);
-  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  mol->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  mol->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="S");
   smi = MolToSmiles(*mol,1);
   TEST_ASSERT(smi==refSmi);
@@ -496,8 +496,8 @@ void testStereochem(){
   mol = SmilesToMol(smi);
   TEST_ASSERT(mol->getAtomWithIdx(0)->getChiralTag()==Atom::CHI_TETRAHEDRAL_CW);
   MolOps::assignStereochemistry(*mol);
-  TEST_ASSERT(mol->getAtomWithIdx(0)->hasProp("_CIPCode"));
-  mol->getAtomWithIdx(0)->getProp("_CIPCode",cip);
+  TEST_ASSERT(mol->getAtomWithIdx(0)->hasProp(common_properties::_CIPCode));
+  mol->getAtomWithIdx(0)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="S");
   smi = MolToSmiles(*mol,1);
   TEST_ASSERT(smi==refSmi);
@@ -507,8 +507,8 @@ void testStereochem(){
   mol = SmilesToMol(smi);
   TEST_ASSERT(mol->getAtomWithIdx(1)->getChiralTag()==Atom::CHI_TETRAHEDRAL_CCW);
   MolOps::assignStereochemistry(*mol);
-  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  mol->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  mol->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="R");
   refSmi = MolToSmiles(*mol,1);
 
@@ -518,8 +518,8 @@ void testStereochem(){
   TEST_ASSERT(mol->getAtomWithIdx(1)->getChiralTag()==Atom::CHI_TETRAHEDRAL_CCW);
   smi = MolToSmiles(*mol,1);
   MolOps::assignStereochemistry(*mol);
-  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  mol->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  mol->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="R");
   TEST_ASSERT(smi==refSmi);
 
@@ -528,8 +528,8 @@ void testStereochem(){
   mol = SmilesToMol(smi);
   TEST_ASSERT(mol->getAtomWithIdx(1)->getChiralTag()==Atom::CHI_TETRAHEDRAL_CCW);
   MolOps::assignStereochemistry(*mol);
-  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  mol->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  mol->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="R");
   smi = MolToSmiles(*mol,1);
   TEST_ASSERT(smi==refSmi);
@@ -539,8 +539,8 @@ void testStereochem(){
   mol = SmilesToMol(smi);
   TEST_ASSERT(mol->getAtomWithIdx(1)->getChiralTag()==Atom::CHI_TETRAHEDRAL_CCW);
   MolOps::assignStereochemistry(*mol);
-  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  mol->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  mol->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="R");
   smi = MolToSmiles(*mol,1);
   TEST_ASSERT(smi==refSmi);
@@ -550,8 +550,8 @@ void testStereochem(){
   mol = SmilesToMol(smi);
   TEST_ASSERT(mol->getAtomWithIdx(1)->getChiralTag()==Atom::CHI_TETRAHEDRAL_CCW);
   MolOps::assignStereochemistry(*mol);
-  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  mol->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  mol->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="R");
   smi = MolToSmiles(*mol,1);
   TEST_ASSERT(smi==refSmi);
@@ -561,8 +561,8 @@ void testStereochem(){
   mol = SmilesToMol(smi);
   TEST_ASSERT(mol->getAtomWithIdx(1)->getChiralTag()==Atom::CHI_TETRAHEDRAL_CW);
   MolOps::assignStereochemistry(*mol);
-  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  mol->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  mol->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="R");
   smi = MolToSmiles(*mol,1);
   TEST_ASSERT(smi==refSmi);
@@ -572,8 +572,8 @@ void testStereochem(){
   mol = SmilesToMol(smi);
   TEST_ASSERT(mol->getAtomWithIdx(1)->getChiralTag()==Atom::CHI_TETRAHEDRAL_CW);
   MolOps::assignStereochemistry(*mol);
-  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  mol->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  mol->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="R");
   smi = MolToSmiles(*mol,1);
   TEST_ASSERT(smi==refSmi);
@@ -583,8 +583,8 @@ void testStereochem(){
   mol = SmilesToMol(smi);
   TEST_ASSERT(mol->getAtomWithIdx(1)->getChiralTag()==Atom::CHI_TETRAHEDRAL_CW);
   MolOps::assignStereochemistry(*mol);
-  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  mol->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  mol->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="R");
   smi = MolToSmiles(*mol,1);
   TEST_ASSERT(smi==refSmi);
@@ -594,8 +594,8 @@ void testStereochem(){
   mol = SmilesToMol(smi);
   TEST_ASSERT(mol->getAtomWithIdx(0)->getChiralTag()==Atom::CHI_TETRAHEDRAL_CCW);
   MolOps::assignStereochemistry(*mol);
-  TEST_ASSERT(mol->getAtomWithIdx(0)->hasProp("_CIPCode"));
-  mol->getAtomWithIdx(0)->getProp("_CIPCode",cip);
+  TEST_ASSERT(mol->getAtomWithIdx(0)->hasProp(common_properties::_CIPCode));
+  mol->getAtomWithIdx(0)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="R");
   smi = MolToSmiles(*mol,1);
   TEST_ASSERT(smi==refSmi);
@@ -605,8 +605,8 @@ void testStereochem(){
   mol = SmilesToMol(smi);
   TEST_ASSERT(mol->getAtomWithIdx(0)->getChiralTag()==Atom::CHI_TETRAHEDRAL_CCW);
   MolOps::assignStereochemistry(*mol);
-  TEST_ASSERT(mol->getAtomWithIdx(0)->hasProp("_CIPCode"));
-  mol->getAtomWithIdx(0)->getProp("_CIPCode",cip);
+  TEST_ASSERT(mol->getAtomWithIdx(0)->hasProp(common_properties::_CIPCode));
+  mol->getAtomWithIdx(0)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="R");
   smi = MolToSmiles(*mol,1);
   TEST_ASSERT(smi==refSmi);
@@ -618,16 +618,16 @@ void testStereochem(){
   mol = SmilesToMol(smi);
   TEST_ASSERT(mol->getAtomWithIdx(1)->getChiralTag()==Atom::CHI_TETRAHEDRAL_CCW);
   MolOps::assignStereochemistry(*mol);
-  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  mol->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  mol->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="S");
   delete mol;
   smi = "F[C@]1([H])OC1";
   mol = SmilesToMol(smi);
   //TEST_ASSERT(mol->getAtomWithIdx(1)->getChiralTag()==Atom::CHI_TETRAHEDRAL_CW);
   MolOps::assignStereochemistry(*mol);
-  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  mol->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  mol->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="S");
 
   delete mol;
@@ -635,16 +635,16 @@ void testStereochem(){
   mol = SmilesToMol(smi);
   TEST_ASSERT(mol->getAtomWithIdx(1)->getChiralTag()==Atom::CHI_TETRAHEDRAL_CCW);
   MolOps::assignStereochemistry(*mol);
-  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  mol->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  mol->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="S");
   delete mol;
   smi = "F[C@@H]1OC1";
   mol = SmilesToMol(smi);
   //TEST_ASSERT(mol->getAtomWithIdx(1)->getChiralTag()==Atom::CHI_TETRAHEDRAL_CW);
   MolOps::assignStereochemistry(*mol);
-  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  mol->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  mol->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="S");
 
   delete mol;
@@ -652,16 +652,16 @@ void testStereochem(){
   mol = SmilesToMol(smi);
   //TEST_ASSERT(mol->getAtomWithIdx(0)->getChiralTag()==Atom::CHI_TETRAHEDRAL_CW);
   MolOps::assignStereochemistry(*mol);
-  TEST_ASSERT(mol->getAtomWithIdx(0)->hasProp("_CIPCode"));
-  mol->getAtomWithIdx(0)->getProp("_CIPCode",cip);
+  TEST_ASSERT(mol->getAtomWithIdx(0)->hasProp(common_properties::_CIPCode));
+  mol->getAtomWithIdx(0)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="S");
   delete mol;
   smi = "[C@@]1(F)([H])OC1";
   mol = SmilesToMol(smi);
   //TEST_ASSERT(mol->getAtomWithIdx(0)->getChiralTag()==Atom::CHI_TETRAHEDRAL_CW);
   MolOps::assignStereochemistry(*mol);
-  TEST_ASSERT(mol->getAtomWithIdx(0)->hasProp("_CIPCode"));
-  mol->getAtomWithIdx(0)->getProp("_CIPCode",cip);
+  TEST_ASSERT(mol->getAtomWithIdx(0)->hasProp(common_properties::_CIPCode));
+  mol->getAtomWithIdx(0)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="S");
 
   delete mol;
@@ -669,8 +669,8 @@ void testStereochem(){
   mol = SmilesToMol(smi);
   //TEST_ASSERT(mol->getAtomWithIdx(0)->getChiralTag()==Atom::CHI_TETRAHEDRAL_CW);
   MolOps::assignStereochemistry(*mol);
-  TEST_ASSERT(mol->getAtomWithIdx(0)->hasProp("_CIPCode"));
-  mol->getAtomWithIdx(0)->getProp("_CIPCode",cip);
+  TEST_ASSERT(mol->getAtomWithIdx(0)->hasProp(common_properties::_CIPCode));
+  mol->getAtomWithIdx(0)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="S");
   smi = MolToSmiles(*mol,true);
   TEST_ASSERT(smi=="C[C@@H](O)F")
@@ -682,8 +682,8 @@ void testStereochem(){
   mol = SmilesToMol(smi);
   //TEST_ASSERT(mol->getAtomWithIdx(0)->getChiralTag()==Atom::CHI_TETRAHEDRAL_CW);
   MolOps::assignStereochemistry(*mol);
-  TEST_ASSERT(mol->getAtomWithIdx(0)->hasProp("_CIPCode"));
-  mol->getAtomWithIdx(0)->getProp("_CIPCode",cip);
+  TEST_ASSERT(mol->getAtomWithIdx(0)->hasProp(common_properties::_CIPCode));
+  mol->getAtomWithIdx(0)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="S");
   smi = MolToSmiles(*mol,true);
   TEST_ASSERT(smi=="F[C@H]1CO1")
@@ -695,16 +695,16 @@ void testStereochem(){
   mol = SmilesToMol(smi);
   //TEST_ASSERT(mol->getAtomWithIdx(2)->getChiralTag()==Atom::CHI_TETRAHEDRAL_CW);
   MolOps::assignStereochemistry(*mol);
-  TEST_ASSERT(mol->getAtomWithIdx(2)->hasProp("_CIPCode"));
-  mol->getAtomWithIdx(2)->getProp("_CIPCode",cip);
+  TEST_ASSERT(mol->getAtomWithIdx(2)->hasProp(common_properties::_CIPCode));
+  mol->getAtomWithIdx(2)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="S");
   delete mol;
   smi = "C1O[C@@]1([H])F";
   mol = SmilesToMol(smi);
   //TEST_ASSERT(mol->getAtomWithIdx(2)->getChiralTag()==Atom::CHI_TETRAHEDRAL_CW);
   MolOps::assignStereochemistry(*mol);
-  TEST_ASSERT(mol->getAtomWithIdx(2)->hasProp("_CIPCode"));
-  mol->getAtomWithIdx(2)->getProp("_CIPCode",cip);
+  TEST_ASSERT(mol->getAtomWithIdx(2)->hasProp(common_properties::_CIPCode));
+  mol->getAtomWithIdx(2)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="S");
 
   // -----------------------------------
@@ -1003,8 +1003,8 @@ void testIssue153(){
   TEST_ASSERT(mol->getAtomWithIdx(2)->getChiralTag()!=Atom::CHI_UNSPECIFIED);
   TEST_ASSERT(mol->getAtomWithIdx(2)->getChiralTag()==Atom::CHI_TETRAHEDRAL_CCW);
   MolOps::assignStereochemistry(*mol);
-  TEST_ASSERT(mol->getAtomWithIdx(2)->hasProp("_CIPCode"));
-  mol->getAtomWithIdx(2)->getProp("_CIPCode",code);
+  TEST_ASSERT(mol->getAtomWithIdx(2)->hasProp(common_properties::_CIPCode));
+  mol->getAtomWithIdx(2)->getProp(common_properties::_CIPCode,code);
   TEST_ASSERT(code=="S");
   
 
@@ -1025,8 +1025,8 @@ void testIssue153(){
   TEST_ASSERT(mol->getAtomWithIdx(2)->getChiralTag()!=Atom::CHI_UNSPECIFIED);
   TEST_ASSERT(mol->getAtomWithIdx(2)->getChiralTag()==Atom::CHI_TETRAHEDRAL_CW);
   MolOps::assignStereochemistry(*mol);
-  TEST_ASSERT(mol->getAtomWithIdx(2)->hasProp("_CIPCode"));
-  mol->getAtomWithIdx(2)->getProp("_CIPCode",code);
+  TEST_ASSERT(mol->getAtomWithIdx(2)->hasProp(common_properties::_CIPCode));
+  mol->getAtomWithIdx(2)->getProp(common_properties::_CIPCode,code);
   TEST_ASSERT(code=="R");
 
   refSmi = MolToSmiles(*mol,true);
@@ -1060,11 +1060,11 @@ void testIssue157(){
   TEST_ASSERT(mol->getAtomWithIdx(4)->getChiralTag()==Atom::CHI_TETRAHEDRAL_CW);
 
   MolOps::assignStereochemistry(*mol);
-  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  mol->getAtomWithIdx(1)->getProp("_CIPCode",code);
+  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  mol->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,code);
   TEST_ASSERT(code=="R");
-  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  mol->getAtomWithIdx(4)->getProp("_CIPCode",code);
+  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  mol->getAtomWithIdx(4)->getProp(common_properties::_CIPCode,code);
   TEST_ASSERT(code=="S");
   
   refSmi = MolToSmiles(*mol,true);
@@ -1091,7 +1091,7 @@ void testIssue157(){
   mol = SmilesToMol(smi);
   TEST_ASSERT(mol);
   MolOps::assignStereochemistry(*mol);
-  mol->getAtomWithIdx(0)->getProp("_CIPCode",smi);
+  mol->getAtomWithIdx(0)->getProp(common_properties::_CIPCode,smi);
   TEST_ASSERT(smi=="S");
   refSmi = MolToSmiles(*mol,true);
   BOOST_LOG(rdInfoLog)<<refSmi<<std::endl;
@@ -1109,9 +1109,9 @@ void testIssue157(){
   mol = SmilesToMol(smi);
   TEST_ASSERT(mol);
   MolOps::assignStereochemistry(*mol);
-  mol->getAtomWithIdx(0)->getProp("_CIPCode",smi);
+  mol->getAtomWithIdx(0)->getProp(common_properties::_CIPCode,smi);
   TEST_ASSERT(smi=="R");
-  mol->getAtomWithIdx(2)->getProp("_CIPCode",smi);
+  mol->getAtomWithIdx(2)->getProp(common_properties::_CIPCode,smi);
   TEST_ASSERT(smi=="S");
   //mol->debugMol(std::cout);
   refSmi = MolToSmiles(*mol,true);
@@ -1898,8 +1898,8 @@ void testBug1844617(){
   TEST_ASSERT(mol);
   MolOps::assignStereochemistry(*mol);
   //mol->debugMol(std::cout);
-  TEST_ASSERT(mol->getAtomWithIdx(6)->hasProp("_CIPCode"));
-  mol->getAtomWithIdx(6)->getProp("_CIPCode",label);
+  TEST_ASSERT(mol->getAtomWithIdx(6)->hasProp(common_properties::_CIPCode));
+  mol->getAtomWithIdx(6)->getProp(common_properties::_CIPCode,label);
   TEST_ASSERT(label=="S");
   
   smi = MolToSmiles(*mol,true);
@@ -1919,20 +1919,20 @@ void testBug1844617(){
   //mol->debugMol(std::cout);
   MolOps::assignStereochemistry(*mol);
   //mol->debugMol(std::cout);
-  TEST_ASSERT(mol->getAtomWithIdx(4)->hasProp("_CIPCode"));
-  mol->getAtomWithIdx(4)->getProp("_CIPCode",label);
+  TEST_ASSERT(mol->getAtomWithIdx(4)->hasProp(common_properties::_CIPCode));
+  mol->getAtomWithIdx(4)->getProp(common_properties::_CIPCode,label);
   TEST_ASSERT(label=="S");
-  TEST_ASSERT(mol->getAtomWithIdx(6)->hasProp("_CIPCode"));
-  mol->getAtomWithIdx(6)->getProp("_CIPCode",label);
+  TEST_ASSERT(mol->getAtomWithIdx(6)->hasProp(common_properties::_CIPCode));
+  mol->getAtomWithIdx(6)->getProp(common_properties::_CIPCode,label);
   TEST_ASSERT(label=="R");
-  TEST_ASSERT(mol->getAtomWithIdx(11)->hasProp("_CIPCode"));
-  mol->getAtomWithIdx(11)->getProp("_CIPCode",label);
+  TEST_ASSERT(mol->getAtomWithIdx(11)->hasProp(common_properties::_CIPCode));
+  mol->getAtomWithIdx(11)->getProp(common_properties::_CIPCode,label);
   TEST_ASSERT(label=="S");
-  TEST_ASSERT(mol->getAtomWithIdx(12)->hasProp("_CIPCode"));
-  mol->getAtomWithIdx(12)->getProp("_CIPCode",label);
+  TEST_ASSERT(mol->getAtomWithIdx(12)->hasProp(common_properties::_CIPCode));
+  mol->getAtomWithIdx(12)->getProp(common_properties::_CIPCode,label);
   TEST_ASSERT(label=="R");
-  TEST_ASSERT(mol->getAtomWithIdx(15)->hasProp("_CIPCode"));
-  mol->getAtomWithIdx(15)->getProp("_CIPCode",label);
+  TEST_ASSERT(mol->getAtomWithIdx(15)->hasProp(common_properties::_CIPCode));
+  mol->getAtomWithIdx(15)->getProp(common_properties::_CIPCode,label);
   TEST_ASSERT(label=="S");
 #if 1  
   smi = MolToSmiles(*mol,true);
@@ -1953,20 +1953,20 @@ void testBug1844617(){
   //mol->debugMol(std::cout);
   MolOps::assignStereochemistry(*mol);
   //mol->debugMol(std::cout);
-  TEST_ASSERT(mol->getAtomWithIdx(4)->hasProp("_CIPCode"));
-  mol->getAtomWithIdx(4)->getProp("_CIPCode",label);
+  TEST_ASSERT(mol->getAtomWithIdx(4)->hasProp(common_properties::_CIPCode));
+  mol->getAtomWithIdx(4)->getProp(common_properties::_CIPCode,label);
   TEST_ASSERT(label=="S");
-  TEST_ASSERT(mol->getAtomWithIdx(6)->hasProp("_CIPCode"));
-  mol->getAtomWithIdx(6)->getProp("_CIPCode",label);
+  TEST_ASSERT(mol->getAtomWithIdx(6)->hasProp(common_properties::_CIPCode));
+  mol->getAtomWithIdx(6)->getProp(common_properties::_CIPCode,label);
   TEST_ASSERT(label=="R");
-  TEST_ASSERT(mol->getAtomWithIdx(11)->hasProp("_CIPCode"));
-  mol->getAtomWithIdx(11)->getProp("_CIPCode",label);
+  TEST_ASSERT(mol->getAtomWithIdx(11)->hasProp(common_properties::_CIPCode));
+  mol->getAtomWithIdx(11)->getProp(common_properties::_CIPCode,label);
   TEST_ASSERT(label=="S");
-  TEST_ASSERT(mol->getAtomWithIdx(12)->hasProp("_CIPCode"));
-  mol->getAtomWithIdx(12)->getProp("_CIPCode",label);
+  TEST_ASSERT(mol->getAtomWithIdx(12)->hasProp(common_properties::_CIPCode));
+  mol->getAtomWithIdx(12)->getProp(common_properties::_CIPCode,label);
   TEST_ASSERT(label=="R");
-  TEST_ASSERT(mol->getAtomWithIdx(15)->hasProp("_CIPCode"));
-  mol->getAtomWithIdx(15)->getProp("_CIPCode",label);
+  TEST_ASSERT(mol->getAtomWithIdx(15)->hasProp(common_properties::_CIPCode));
+  mol->getAtomWithIdx(15)->getProp(common_properties::_CIPCode,label);
   TEST_ASSERT(label=="S");
 #if 1  
   smi = MolToSmiles(*mol,true,false,0);
@@ -1987,20 +1987,20 @@ void testBug1844617(){
   TEST_ASSERT(mol);
   MolOps::assignStereochemistry(*mol);
   //mol->debugMol(std::cout);
-  TEST_ASSERT(mol->getAtomWithIdx(4)->hasProp("_CIPCode"));
-  mol->getAtomWithIdx(4)->getProp("_CIPCode",label);
+  TEST_ASSERT(mol->getAtomWithIdx(4)->hasProp(common_properties::_CIPCode));
+  mol->getAtomWithIdx(4)->getProp(common_properties::_CIPCode,label);
   TEST_ASSERT(label=="S");
-  TEST_ASSERT(mol->getAtomWithIdx(6)->hasProp("_CIPCode"));
-  mol->getAtomWithIdx(6)->getProp("_CIPCode",label);
+  TEST_ASSERT(mol->getAtomWithIdx(6)->hasProp(common_properties::_CIPCode));
+  mol->getAtomWithIdx(6)->getProp(common_properties::_CIPCode,label);
   TEST_ASSERT(label=="R");
-  TEST_ASSERT(mol->getAtomWithIdx(14)->hasProp("_CIPCode"));
-  mol->getAtomWithIdx(14)->getProp("_CIPCode",label);
+  TEST_ASSERT(mol->getAtomWithIdx(14)->hasProp(common_properties::_CIPCode));
+  mol->getAtomWithIdx(14)->getProp(common_properties::_CIPCode,label);
   TEST_ASSERT(label=="S");
-  TEST_ASSERT(mol->getAtomWithIdx(15)->hasProp("_CIPCode"));
-  mol->getAtomWithIdx(15)->getProp("_CIPCode",label);
+  TEST_ASSERT(mol->getAtomWithIdx(15)->hasProp(common_properties::_CIPCode));
+  mol->getAtomWithIdx(15)->getProp(common_properties::_CIPCode,label);
   TEST_ASSERT(label=="R");
-  TEST_ASSERT(mol->getAtomWithIdx(18)->hasProp("_CIPCode"));
-  mol->getAtomWithIdx(18)->getProp("_CIPCode",label);
+  TEST_ASSERT(mol->getAtomWithIdx(18)->hasProp(common_properties::_CIPCode));
+  mol->getAtomWithIdx(18)->getProp(common_properties::_CIPCode,label);
   TEST_ASSERT(label=="S");
 #if 1  
   smi = MolToSmiles(*mol,true);
@@ -2032,16 +2032,16 @@ void testBug1844959(){
   mol = SmilesToMol(smi);
   TEST_ASSERT(mol);
   MolOps::assignStereochemistry(*mol);
-  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  mol->getAtomWithIdx(1)->getProp("_CIPCode",label);
+  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  mol->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,label);
   TEST_ASSERT(label=="R");
   smi = MolToSmiles(*mol,true);
   delete mol;
   mol = SmilesToMol(smi);
   TEST_ASSERT(mol);
   MolOps::assignStereochemistry(*mol);
-  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  mol->getAtomWithIdx(1)->getProp("_CIPCode",label);
+  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  mol->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,label);
   TEST_ASSERT(label=="R");
   smi2 = MolToSmiles(*mol,true);
   TEST_ASSERT(smi==smi2);
@@ -2052,16 +2052,16 @@ void testBug1844959(){
   mol = SmilesToMol(smi);
   TEST_ASSERT(mol);
   MolOps::assignStereochemistry(*mol);
-  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  mol->getAtomWithIdx(1)->getProp("_CIPCode",label);
+  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  mol->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,label);
   TEST_ASSERT(label=="S");
   smi = MolToSmiles(*mol,true);
   delete mol;
   mol = SmilesToMol(smi);
   TEST_ASSERT(mol);
   MolOps::assignStereochemistry(*mol);
-  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  mol->getAtomWithIdx(1)->getProp("_CIPCode",label);
+  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  mol->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,label);
   TEST_ASSERT(label=="S");
   smi2 = MolToSmiles(*mol,true);
   TEST_ASSERT(smi==smi2);
@@ -2071,16 +2071,16 @@ void testBug1844959(){
   mol = SmilesToMol(smi);
   TEST_ASSERT(mol);
   MolOps::assignStereochemistry(*mol);
-  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  mol->getAtomWithIdx(1)->getProp("_CIPCode",label);
+  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  mol->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,label);
   TEST_ASSERT(label=="S");
   smi = MolToSmiles(*mol,true);
   delete mol;
   mol = SmilesToMol(smi);
   TEST_ASSERT(mol);
   MolOps::assignStereochemistry(*mol);
-  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  mol->getAtomWithIdx(1)->getProp("_CIPCode",label);
+  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  mol->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,label);
   TEST_ASSERT(label=="S");
   smi2 = MolToSmiles(*mol,true);
   TEST_ASSERT(smi==smi2);
@@ -2089,16 +2089,16 @@ void testBug1844959(){
   mol = SmilesToMol(smi);
   TEST_ASSERT(mol);
   MolOps::assignStereochemistry(*mol);
-  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  mol->getAtomWithIdx(1)->getProp("_CIPCode",label);
+  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  mol->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,label);
   TEST_ASSERT(label=="R");
   smi = MolToSmiles(*mol,true);
   delete mol;
   mol = SmilesToMol(smi);
   TEST_ASSERT(mol);
   MolOps::assignStereochemistry(*mol);
-  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  mol->getAtomWithIdx(1)->getProp("_CIPCode",label);
+  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  mol->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,label);
   TEST_ASSERT(label=="R");
   smi2 = MolToSmiles(*mol,true);
   TEST_ASSERT(smi==smi2);
@@ -2116,8 +2116,8 @@ void testBug1844959(){
   TEST_ASSERT(mol);
   MolOps::assignStereochemistry(*mol);
   //mol->debugMol(std::cerr);
-  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  mol->getAtomWithIdx(1)->getProp("_CIPCode",label);
+  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  mol->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,label);
   TEST_ASSERT(label=="S");
   smi = MolToSmiles(*mol,true);
   BOOST_LOG(rdInfoLog)<<smi<<std::endl;
@@ -2126,8 +2126,8 @@ void testBug1844959(){
   TEST_ASSERT(mol);
   MolOps::assignStereochemistry(*mol);
   //mol->debugMol(std::cerr);
-  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  mol->getAtomWithIdx(1)->getProp("_CIPCode",label);
+  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  mol->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,label);
   TEST_ASSERT(label=="S");
   smi2 = MolToSmiles(*mol,true);
   TEST_ASSERT(smi==smi2);
@@ -2138,16 +2138,16 @@ void testBug1844959(){
   mol = SmilesToMol(smi);
   TEST_ASSERT(mol);
   MolOps::assignStereochemistry(*mol);
-  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  mol->getAtomWithIdx(1)->getProp("_CIPCode",label);
+  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  mol->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,label);
   TEST_ASSERT(label=="R");
   smi = MolToSmiles(*mol,true);
   delete mol;
   mol = SmilesToMol(smi);
   TEST_ASSERT(mol);
   MolOps::assignStereochemistry(*mol);
-  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  mol->getAtomWithIdx(1)->getProp("_CIPCode",label);
+  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  mol->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,label);
   TEST_ASSERT(label=="R");
   smi2 = MolToSmiles(*mol,true);
   TEST_ASSERT(smi==smi2);
@@ -2157,16 +2157,16 @@ void testBug1844959(){
   mol = SmilesToMol(smi);
   TEST_ASSERT(mol);
   MolOps::assignStereochemistry(*mol);
-  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  mol->getAtomWithIdx(1)->getProp("_CIPCode",label);
+  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  mol->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,label);
   TEST_ASSERT(label=="R");
   smi = MolToSmiles(*mol,true);
   delete mol;
   mol = SmilesToMol(smi);
   TEST_ASSERT(mol);
   MolOps::assignStereochemistry(*mol);
-  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  mol->getAtomWithIdx(1)->getProp("_CIPCode",label);
+  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  mol->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,label);
   TEST_ASSERT(label=="R");
   smi2 = MolToSmiles(*mol,true);
   TEST_ASSERT(smi==smi2);
@@ -2175,16 +2175,16 @@ void testBug1844959(){
   mol = SmilesToMol(smi);
   TEST_ASSERT(mol);
   MolOps::assignStereochemistry(*mol);
-  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  mol->getAtomWithIdx(1)->getProp("_CIPCode",label);
+  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  mol->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,label);
   TEST_ASSERT(label=="S");
   smi = MolToSmiles(*mol,true);
   delete mol;
   mol = SmilesToMol(smi);
   TEST_ASSERT(mol);
   MolOps::assignStereochemistry(*mol);
-  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  mol->getAtomWithIdx(1)->getProp("_CIPCode",label);
+  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  mol->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,label);
   TEST_ASSERT(label=="S");
   smi2 = MolToSmiles(*mol,true);
   TEST_ASSERT(smi==smi2);
@@ -2256,10 +2256,10 @@ void testRingStereochemReporting(){
   TEST_ASSERT(m->getNumAtoms()==8);
 
   smi = MolToSmiles(*m,true);
-  TEST_ASSERT(m->hasProp("_ringStereoWarning"));
+  TEST_ASSERT(m->hasProp(common_properties::_ringStereoWarning));
 
   smi = MolToSmiles(*m,false);
-  TEST_ASSERT((!m->hasProp("_ringStereoWarning")));
+  TEST_ASSERT((!m->hasProp(common_properties::_ringStereoWarning)));
 
   
   delete m;
@@ -2523,7 +2523,7 @@ void testAtomMaps(){
     std::string smiles="[*:1]CCC([C:200])C";
     m = SmilesToMol(smiles);
     TEST_ASSERT(m);
-    TEST_ASSERT(m->getAtomWithIdx(0)->hasProp("molAtomMapNumber"));
+    TEST_ASSERT(m->getAtomWithIdx(0)->hasProp(common_properties::molAtomMapNumber));
 
     smiles = MolToSmiles(*m,true);
     TEST_ASSERT(smiles=="[*:1]CCC([C:200])C");
@@ -2753,7 +2753,7 @@ void testBug3525799(){
     TEST_ASSERT(m);
     smiles = MolToSmiles(*m,true);
     TEST_ASSERT(smiles=="[*]CC");
-    m->getAtomWithIdx(2)->setProp("dummyLabel","foo");
+    m->getAtomWithIdx(2)->setProp(common_properties::dummyLabel,"foo");
     smiles = MolToSmiles(*m,true);
     TEST_ASSERT(smiles=="[*]CC");
     delete m;
@@ -2766,7 +2766,7 @@ void testBug3525799(){
     TEST_ASSERT(m);
     smiles = MolToSmiles(*m,true);
     TEST_ASSERT(smiles=="[*]CC");
-    m->getAtomWithIdx(2)->setProp("smilesSymbol","Xa");
+    m->getAtomWithIdx(2)->setProp(common_properties::smilesSymbol,"Xa");
     smiles = MolToSmiles(*m,true);
     TEST_ASSERT(smiles=="[Xa]CC");
     delete m;
@@ -3375,8 +3375,8 @@ void testGithub210(){
     std::string smiles="O[C@H](F)CC(F)(Cl)I";
     m = SmilesToMol(smiles);
     TEST_ASSERT(m);
-    TEST_ASSERT(m->getAtomWithIdx(1)->hasProp("_CIPCode"));
-    TEST_ASSERT(m->getAtomWithIdx(4)->hasProp("_ChiralityPossible"));
+    TEST_ASSERT(m->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+    TEST_ASSERT(m->getAtomWithIdx(4)->hasProp(common_properties::_ChiralityPossible));
     delete m;
   }
   BOOST_LOG(rdInfoLog) << "done" << std::endl;

--- a/Code/GraphMol/Substruct/SubstructMatch.cpp
+++ b/Code/GraphMol/Substruct/SubstructMatch.cpp
@@ -346,11 +346,11 @@ namespace RDKit{
 	matches.reserve(pms.size());
 	for(std::list<detail::ssPairType>::const_iterator iter1=pms.begin();
 	    iter1!=pms.end();++iter1){
-	  if(!query.hasProp("_queryRootAtom")){
+	  if(!query.hasProp(common_properties::_queryRootAtom)){
 	    matches.push_back(iter1->begin()->second);
 	  } else {
 	    int rootIdx;
-	    query.getProp("_queryRootAtom",rootIdx);
+	    query.getProp(common_properties::_queryRootAtom,rootIdx);
 	    bool found=false;
 	    for(detail::ssPairType::const_iterator pairIter=iter1->begin();
 		pairIter!=iter1->end();++pairIter){

--- a/Code/GraphMol/Substruct/SubstructUtils.cpp
+++ b/Code/GraphMol/Substruct/SubstructUtils.cpp
@@ -35,16 +35,11 @@ namespace RDKit{
     //std::cerr << "\t\tatomCompat: "<< a1 << " " << a1->getIdx() << "-" << a2 << " " << a2->getIdx() << std::endl;
     bool res = a1->Match(a2);
     if(res){
-      if(a1->hasProp("_CIPCode") || a2->hasProp("_CIPCode")){
-        // if either atom has a CIPCode, they need to both have it and match:
-        if(a1->hasProp("_CIPCode") && a2->hasProp("_CIPCode")){
-          std::string s1,s2;
-          a1->getProp("_CIPCode",s1);
-          a2->getProp("_CIPCode",s2);
-          if(s1!=s2) res=false;
-        } else {
-          res=false;
-        }
+      std::string s1, s2;
+      bool hascode1 = a1->getPropIfPresent(common_properties::_CIPCode, s1);
+      bool hascode2 = a2->getPropIfPresent(common_properties::_CIPCode, s2);
+      if(hascode1 || hascode2) {
+          res = hascode1 && hascode2 && s1 == s2;
       }
     }
     return res;

--- a/Code/GraphMol/Substruct/test1.cpp
+++ b/Code/GraphMol/Substruct/test1.cpp
@@ -352,7 +352,7 @@ void test5QueryRoot(){
   q1->addAtom(new QueryAtom(8),true);
   q1->addAtom(new QueryAtom(6),true);
   q1->addBond(0,1,Bond::UNSPECIFIED);
-  q1->setProp("_queryRootAtom",1);
+  q1->setProp(common_properties::_queryRootAtom,1);
   
   // here's the main query
   q2 = new RWMol();

--- a/Code/GraphMol/molopstest.cpp
+++ b/Code/GraphMol/molopstest.cpp
@@ -206,7 +206,7 @@ void test3(){
   count = MolOps::findSSSR(*m,sssr);
   TEST_ASSERT(count==1);
   TEST_ASSERT(sssr[0].size()==4);
-  TEST_ASSERT(!m->getBondBetweenAtoms(0,1)->hasProp("ringMembership"));
+  TEST_ASSERT(!m->getBondBetweenAtoms(0,1)->hasProp(common_properties::ringMembership));
   TEST_ASSERT(!m->getRingInfo()->numBondRings(m->getBondBetweenAtoms(0,1)->getIdx()));
   TEST_ASSERT(m->getRingInfo()->numBondRings(m->getBondBetweenAtoms(1,2)->getIdx()));
   BOOST_LOG(rdInfoLog) << smi << "\n";
@@ -816,19 +816,19 @@ void test10()
   Chirality::assignAtomCIPRanks(*m,ranks);
 
   int cip1,cip2;
-  TEST_ASSERT(m->getAtomWithIdx(0)->hasProp("_CIPRank"));
-  m->getAtomWithIdx(0)->getProp("_CIPRank",cip1);
+  TEST_ASSERT(m->getAtomWithIdx(0)->hasProp(common_properties::_CIPRank));
+  m->getAtomWithIdx(0)->getProp(common_properties::_CIPRank,cip1);
   TEST_ASSERT(cip1==ranks[0]);
-  TEST_ASSERT(m->getAtomWithIdx(2)->hasProp("_CIPRank"));
-  m->getAtomWithIdx(2)->getProp("_CIPRank",cip2);
+  TEST_ASSERT(m->getAtomWithIdx(2)->hasProp(common_properties::_CIPRank));
+  m->getAtomWithIdx(2)->getProp(common_properties::_CIPRank,cip2);
   TEST_ASSERT(cip2==ranks[2]);
   TEST_ASSERT(cip1<cip2);
-  TEST_ASSERT(m->getAtomWithIdx(4)->hasProp("_CIPRank"));
-  m->getAtomWithIdx(4)->getProp("_CIPRank",cip2);
+  TEST_ASSERT(m->getAtomWithIdx(4)->hasProp(common_properties::_CIPRank));
+  m->getAtomWithIdx(4)->getProp(common_properties::_CIPRank,cip2);
   TEST_ASSERT(cip1>cip2);
-  m->getAtomWithIdx(2)->getProp("_CIPRank",cip1);
-  TEST_ASSERT(m->getAtomWithIdx(3)->hasProp("_CIPRank"));
-  m->getAtomWithIdx(3)->getProp("_CIPRank",cip2);
+  m->getAtomWithIdx(2)->getProp(common_properties::_CIPRank,cip1);
+  TEST_ASSERT(m->getAtomWithIdx(3)->hasProp(common_properties::_CIPRank));
+  m->getAtomWithIdx(3)->getProp(common_properties::_CIPRank,cip2);
   TEST_ASSERT(cip1<cip2);
   
   delete m;
@@ -839,8 +839,8 @@ void test10()
   Chirality::assignAtomCIPRanks(*m,ranks);
   for(unsigned int i=0;i<m->getNumAtoms();i++){
     int cip;
-    TEST_ASSERT(m->getAtomWithIdx(i)->hasProp("_CIPRank"));
-    m->getAtomWithIdx(i)->getProp("_CIPRank",cip);
+    TEST_ASSERT(m->getAtomWithIdx(i)->hasProp(common_properties::_CIPRank));
+    m->getAtomWithIdx(i)->getProp(common_properties::_CIPRank,cip);
   }
   
   BOOST_LOG(rdInfoLog) << "Finished" << std::endl;
@@ -860,10 +860,10 @@ void test11()
   // make sure the cleanup worked:
   TEST_ASSERT(m->getAtomWithIdx(2)->getChiralTag()==Atom::CHI_UNSPECIFIED);
 
-  TEST_ASSERT(!(m->getAtomWithIdx(0)->hasProp("_CIPCode")));
-  TEST_ASSERT(m->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  TEST_ASSERT(!(m->getAtomWithIdx(2)->hasProp("_CIPCode")));
-  m->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+  TEST_ASSERT(!(m->getAtomWithIdx(0)->hasProp(common_properties::_CIPCode)));
+  TEST_ASSERT(m->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  TEST_ASSERT(!(m->getAtomWithIdx(2)->hasProp(common_properties::_CIPCode)));
+  m->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="R");
 
 
@@ -873,9 +873,9 @@ void test11()
   TEST_ASSERT(m);
   MolOps::assignStereochemistry(*m,true);
   TEST_ASSERT(m->getAtomWithIdx(1)->getChiralTag()==Atom::CHI_UNSPECIFIED);
-  TEST_ASSERT(!(m->getAtomWithIdx(0)->hasProp("_CIPCode")));
-  TEST_ASSERT(!(m->getAtomWithIdx(1)->hasProp("_CIPCode")));
-  TEST_ASSERT(!(m->getAtomWithIdx(2)->hasProp("_CIPCode")));
+  TEST_ASSERT(!(m->getAtomWithIdx(0)->hasProp(common_properties::_CIPCode)));
+  TEST_ASSERT(!(m->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode)));
+  TEST_ASSERT(!(m->getAtomWithIdx(2)->hasProp(common_properties::_CIPCode)));
   // test Issue 194:
   TEST_ASSERT(m->getAtomWithIdx(1)->getNumExplicitHs()==0);
 
@@ -886,7 +886,7 @@ void test11()
   TEST_ASSERT(m);
   MolOps::assignStereochemistry(*m,true);
   TEST_ASSERT(m->getAtomWithIdx(1)->getChiralTag()==Atom::CHI_UNSPECIFIED);
-  TEST_ASSERT(!(m->getAtomWithIdx(1)->hasProp("_CIPCode")));
+  TEST_ASSERT(!(m->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode)));
 
   delete m;
   smi = "F[C@H]1C(Cl)CC1";
@@ -894,17 +894,17 @@ void test11()
   TEST_ASSERT(m);
   MolOps::assignStereochemistry(*m,true);
   TEST_ASSERT(m->getAtomWithIdx(1)->getChiralTag()!=Atom::CHI_UNSPECIFIED);
-  TEST_ASSERT(m->getAtomWithIdx(1)->hasProp("_CIPCode"));
+  TEST_ASSERT(m->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
 
   delete m;
   smi = "F[C@@](C)(Cl)Br";
   m = SmilesToMol(smi);
   TEST_ASSERT(m);
   MolOps::assignStereochemistry(*m,true);
-  TEST_ASSERT(!(m->getAtomWithIdx(0)->hasProp("_CIPCode")));
-  TEST_ASSERT(m->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  TEST_ASSERT(!(m->getAtomWithIdx(2)->hasProp("_CIPCode")));
-  m->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+  TEST_ASSERT(!(m->getAtomWithIdx(0)->hasProp(common_properties::_CIPCode)));
+  TEST_ASSERT(m->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  TEST_ASSERT(!(m->getAtomWithIdx(2)->hasProp(common_properties::_CIPCode)));
+  m->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="S");
 
   delete m;
@@ -912,16 +912,16 @@ void test11()
   m = SmilesToMol(smi);
   TEST_ASSERT(m);
   MolOps::assignStereochemistry(*m,true);
-  TEST_ASSERT(m->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  m->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+  TEST_ASSERT(m->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  m->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="R");
   delete m;
   smi = "F[C@](Cl)(Br)C";
   m = SmilesToMol(smi);
   TEST_ASSERT(m);
   MolOps::assignStereochemistry(*m,true);
-  TEST_ASSERT(m->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  m->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+  TEST_ASSERT(m->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  m->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="R");
 
   delete m;
@@ -929,8 +929,8 @@ void test11()
   m = SmilesToMol(smi);
   TEST_ASSERT(m);
   MolOps::assignStereochemistry(*m,true);
-  TEST_ASSERT(m->getAtomWithIdx(4)->hasProp("_CIPCode"));
-  m->getAtomWithIdx(4)->getProp("_CIPCode",cip);
+  TEST_ASSERT(m->getAtomWithIdx(4)->hasProp(common_properties::_CIPCode));
+  m->getAtomWithIdx(4)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="R");
 
   delete m;
@@ -938,8 +938,8 @@ void test11()
   m = SmilesToMol(smi);
   TEST_ASSERT(m);
   MolOps::assignStereochemistry(*m,true);
-  TEST_ASSERT(m->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  m->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+  TEST_ASSERT(m->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  m->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="S");
 
   delete m;
@@ -947,16 +947,16 @@ void test11()
   m = SmilesToMol(smi);
   TEST_ASSERT(m);
   MolOps::assignStereochemistry(*m,true);
-  TEST_ASSERT(m->getAtomWithIdx(2)->hasProp("_CIPCode"));
-  m->getAtomWithIdx(2)->getProp("_CIPCode",cip);
+  TEST_ASSERT(m->getAtomWithIdx(2)->hasProp(common_properties::_CIPCode));
+  m->getAtomWithIdx(2)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="S");
   delete m;
   smi = "[CH2-][C@](C)(F)Br";
   m = SmilesToMol(smi);
   TEST_ASSERT(m);
   MolOps::assignStereochemistry(*m,true);
-  TEST_ASSERT(m->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  m->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+  TEST_ASSERT(m->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  m->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="S");
 
   delete m;
@@ -964,8 +964,8 @@ void test11()
   m = SmilesToMol(smi);
   TEST_ASSERT(m);
   MolOps::assignStereochemistry(*m,true);
-  TEST_ASSERT(m->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  m->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+  TEST_ASSERT(m->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  m->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="R");
 
   delete m;
@@ -973,8 +973,8 @@ void test11()
   m = SmilesToMol(smi);
   TEST_ASSERT(m);
   MolOps::assignStereochemistry(*m,true);
-  TEST_ASSERT(m->getAtomWithIdx(0)->hasProp("_CIPCode"));
-  m->getAtomWithIdx(0)->getProp("_CIPCode",cip);
+  TEST_ASSERT(m->getAtomWithIdx(0)->hasProp(common_properties::_CIPCode));
+  m->getAtomWithIdx(0)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="R");
 
   delete m;
@@ -982,8 +982,8 @@ void test11()
   m = SmilesToMol(smi);
   TEST_ASSERT(m);
   MolOps::assignStereochemistry(*m,true);
-  TEST_ASSERT(m->getAtomWithIdx(0)->hasProp("_CIPCode"));
-  m->getAtomWithIdx(0)->getProp("_CIPCode",cip);
+  TEST_ASSERT(m->getAtomWithIdx(0)->hasProp(common_properties::_CIPCode));
+  m->getAtomWithIdx(0)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="R");
 
   delete m;
@@ -991,8 +991,8 @@ void test11()
   m = SmilesToMol(smi);
   TEST_ASSERT(m);
   MolOps::assignStereochemistry(*m,true);
-  TEST_ASSERT(m->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  m->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+  TEST_ASSERT(m->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  m->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="R");
   
   delete m;
@@ -1004,8 +1004,8 @@ void test11()
   m = SmilesToMol(smi);
   TEST_ASSERT(m);
   MolOps::assignStereochemistry(*m,true);
-  TEST_ASSERT(m->getAtomWithIdx(2)->hasProp("_CIPCode"));
-  m->getAtomWithIdx(2)->getProp("_CIPCode",cip);
+  TEST_ASSERT(m->getAtomWithIdx(2)->hasProp(common_properties::_CIPCode));
+  m->getAtomWithIdx(2)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="R");
 
   delete m;
@@ -1017,8 +1017,8 @@ void test11()
   m = SmilesToMol(smi);
   TEST_ASSERT(m);
   MolOps::assignStereochemistry(*m,true);
-  TEST_ASSERT(m->getAtomWithIdx(2)->hasProp("_CIPCode"));
-  m->getAtomWithIdx(2)->getProp("_CIPCode",cip);
+  TEST_ASSERT(m->getAtomWithIdx(2)->hasProp(common_properties::_CIPCode));
+  m->getAtomWithIdx(2)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="S");
 
   delete m;
@@ -1030,8 +1030,8 @@ void test11()
   m = SmilesToMol(smi);
   TEST_ASSERT(m);
   MolOps::assignStereochemistry(*m,true);
-  TEST_ASSERT(m->getAtomWithIdx(2)->hasProp("_CIPCode"));
-  m->getAtomWithIdx(2)->getProp("_CIPCode",cip);
+  TEST_ASSERT(m->getAtomWithIdx(2)->hasProp(common_properties::_CIPCode));
+  m->getAtomWithIdx(2)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="R");
 
   delete m;
@@ -1043,8 +1043,8 @@ void test11()
   m = SmilesToMol(smi);
   TEST_ASSERT(m);
   MolOps::assignStereochemistry(*m,true);
-  TEST_ASSERT(m->getAtomWithIdx(2)->hasProp("_CIPCode"));
-  m->getAtomWithIdx(2)->getProp("_CIPCode",cip);
+  TEST_ASSERT(m->getAtomWithIdx(2)->hasProp(common_properties::_CIPCode));
+  m->getAtomWithIdx(2)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="S");
 
   delete m;
@@ -1056,11 +1056,11 @@ void test11()
   m = SmilesToMol(smi);
   TEST_ASSERT(m);
   MolOps::assignStereochemistry(*m,true);
-  TEST_ASSERT(m->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  m->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+  TEST_ASSERT(m->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  m->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="S");
-  TEST_ASSERT(m->getAtomWithIdx(3)->hasProp("_CIPCode"));
-  m->getAtomWithIdx(3)->getProp("_CIPCode",cip);
+  TEST_ASSERT(m->getAtomWithIdx(3)->hasProp(common_properties::_CIPCode));
+  m->getAtomWithIdx(3)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="R");
 
   // a couple random molecules from the BBB data set
@@ -1073,11 +1073,11 @@ void test11()
   m = SmilesToMol(smi);
   TEST_ASSERT(m);
   MolOps::assignStereochemistry(*m,true);
-  TEST_ASSERT(m->getAtomWithIdx(2)->hasProp("_CIPCode"));
-  m->getAtomWithIdx(2)->getProp("_CIPCode",cip);
+  TEST_ASSERT(m->getAtomWithIdx(2)->hasProp(common_properties::_CIPCode));
+  m->getAtomWithIdx(2)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="S");
-  TEST_ASSERT(m->getAtomWithIdx(4)->hasProp("_CIPCode"));
-  m->getAtomWithIdx(4)->getProp("_CIPCode",cip);
+  TEST_ASSERT(m->getAtomWithIdx(4)->hasProp(common_properties::_CIPCode));
+  m->getAtomWithIdx(4)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="R");
 
 
@@ -1091,11 +1091,11 @@ void test11()
   m = SmilesToMol(smi);
   TEST_ASSERT(m);
   MolOps::assignStereochemistry(*m,true);
-  TEST_ASSERT(m->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  m->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+  TEST_ASSERT(m->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  m->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="S");
-  TEST_ASSERT(m->getAtomWithIdx(3)->hasProp("_CIPCode"));
-  m->getAtomWithIdx(3)->getProp("_CIPCode",cip);
+  TEST_ASSERT(m->getAtomWithIdx(3)->hasProp(common_properties::_CIPCode));
+  m->getAtomWithIdx(3)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="S");
 
 
@@ -1108,11 +1108,11 @@ void test11()
   m = SmilesToMol(smi);
   TEST_ASSERT(m);
   MolOps::assignStereochemistry(*m,true);
-  TEST_ASSERT(m->getAtomWithIdx(2)->hasProp("_CIPCode"));
-  m->getAtomWithIdx(2)->getProp("_CIPCode",cip);
+  TEST_ASSERT(m->getAtomWithIdx(2)->hasProp(common_properties::_CIPCode));
+  m->getAtomWithIdx(2)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="S");
-  TEST_ASSERT(m->getAtomWithIdx(4)->hasProp("_CIPCode"));
-  m->getAtomWithIdx(4)->getProp("_CIPCode",cip);
+  TEST_ASSERT(m->getAtomWithIdx(4)->hasProp(common_properties::_CIPCode));
+  m->getAtomWithIdx(4)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="S");
 
   // this is Issue 152:
@@ -1125,11 +1125,11 @@ void test11()
   m = SmilesToMol(smi);
   TEST_ASSERT(m);
   MolOps::assignStereochemistry(*m,true);
-  TEST_ASSERT(m->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  m->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+  TEST_ASSERT(m->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  m->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="R");
-  TEST_ASSERT(m->getAtomWithIdx(4)->hasProp("_CIPCode"));
-  m->getAtomWithIdx(4)->getProp("_CIPCode",cip);
+  TEST_ASSERT(m->getAtomWithIdx(4)->hasProp(common_properties::_CIPCode));
+  m->getAtomWithIdx(4)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="S");
 
   
@@ -1144,8 +1144,8 @@ void test11()
   m = SmilesToMol(smi);
   TEST_ASSERT(m);
   MolOps::assignStereochemistry(*m,true);
-  TEST_ASSERT(m->getAtomWithIdx(2)->hasProp("_CIPCode"));
-  m->getAtomWithIdx(2)->getProp("_CIPCode",cip);
+  TEST_ASSERT(m->getAtomWithIdx(2)->hasProp(common_properties::_CIPCode));
+  m->getAtomWithIdx(2)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="R");
 
   smi = "C(=O)[C@@H](CO)N";
@@ -1157,8 +1157,8 @@ void test11()
   m = SmilesToMol(smi);
   TEST_ASSERT(m);
   MolOps::assignStereochemistry(*m,true);
-  TEST_ASSERT(m->getAtomWithIdx(2)->hasProp("_CIPCode"));
-  m->getAtomWithIdx(2)->getProp("_CIPCode",cip);
+  TEST_ASSERT(m->getAtomWithIdx(2)->hasProp(common_properties::_CIPCode));
+  m->getAtomWithIdx(2)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="R");
 
   smi = "C(O)[C@@H](C)N";
@@ -1170,8 +1170,8 @@ void test11()
   m = SmilesToMol(smi);
   TEST_ASSERT(m);
   MolOps::assignStereochemistry(*m,true);
-  TEST_ASSERT(m->getAtomWithIdx(2)->hasProp("_CIPCode"));
-  m->getAtomWithIdx(2)->getProp("_CIPCode",cip);
+  TEST_ASSERT(m->getAtomWithIdx(2)->hasProp(common_properties::_CIPCode));
+  m->getAtomWithIdx(2)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="R");
   // -----------------------------------------------
 
@@ -1190,8 +1190,8 @@ void test11()
   m = SmilesToMol(smi);
   TEST_ASSERT(m);
   MolOps::assignStereochemistry(*m,true);
-  TEST_ASSERT(m->getAtomWithIdx(0)->hasProp("_CIPCode"));
-  m->getAtomWithIdx(0)->getProp("_CIPCode",cip);
+  TEST_ASSERT(m->getAtomWithIdx(0)->hasProp(common_properties::_CIPCode));
+  m->getAtomWithIdx(0)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="S");
 
   smi = "[H][C@@](O)(C=C)C(C)CO";
@@ -1203,8 +1203,8 @@ void test11()
   m = SmilesToMol(smi);
   TEST_ASSERT(m);
   MolOps::assignStereochemistry(*m,true);
-  TEST_ASSERT(m->getAtomWithIdx(0)->hasProp("_CIPCode"));
-  m->getAtomWithIdx(0)->getProp("_CIPCode",cip);
+  TEST_ASSERT(m->getAtomWithIdx(0)->hasProp(common_properties::_CIPCode));
+  m->getAtomWithIdx(0)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="R");
 
   smi = "[H][C@@]12C[C@@](NC1)(OC2)[H]";
@@ -1216,11 +1216,11 @@ void test11()
   m = SmilesToMol(smi);
   TEST_ASSERT(m);
   MolOps::assignStereochemistry(*m,true);
-  TEST_ASSERT(m->getAtomWithIdx(0)->hasProp("_CIPCode"));
-  m->getAtomWithIdx(0)->getProp("_CIPCode",cip);
+  TEST_ASSERT(m->getAtomWithIdx(0)->hasProp(common_properties::_CIPCode));
+  m->getAtomWithIdx(0)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="R");
-  TEST_ASSERT(m->getAtomWithIdx(2)->hasProp("_CIPCode"));
-  m->getAtomWithIdx(2)->getProp("_CIPCode",cip);
+  TEST_ASSERT(m->getAtomWithIdx(2)->hasProp(common_properties::_CIPCode));
+  m->getAtomWithIdx(2)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="S");
 
   smi = "[H][C@@]12C[C@@](C=C1)(CC2)[H]";
@@ -1232,11 +1232,11 @@ void test11()
   m = SmilesToMol(smi);
   TEST_ASSERT(m);
   MolOps::assignStereochemistry(*m,true);
-  TEST_ASSERT(m->getAtomWithIdx(0)->hasProp("_CIPCode"));
-  m->getAtomWithIdx(0)->getProp("_CIPCode",cip);
+  TEST_ASSERT(m->getAtomWithIdx(0)->hasProp(common_properties::_CIPCode));
+  m->getAtomWithIdx(0)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="R");
-  TEST_ASSERT(m->getAtomWithIdx(2)->hasProp("_CIPCode"));
-  m->getAtomWithIdx(2)->getProp("_CIPCode",cip);
+  TEST_ASSERT(m->getAtomWithIdx(2)->hasProp(common_properties::_CIPCode));
+  m->getAtomWithIdx(2)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="S");
 
   smi = "[H][C@@]12O[C@@](CC1)(C3C2C(NC3=O)=O)[H]";
@@ -1248,11 +1248,11 @@ void test11()
   m = SmilesToMol(smi);
   TEST_ASSERT(m);
   MolOps::assignStereochemistry(*m,true);
-  TEST_ASSERT(m->getAtomWithIdx(0)->hasProp("_CIPCode"));
-  m->getAtomWithIdx(0)->getProp("_CIPCode",cip);
+  TEST_ASSERT(m->getAtomWithIdx(0)->hasProp(common_properties::_CIPCode));
+  m->getAtomWithIdx(0)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="R");
-  TEST_ASSERT(m->getAtomWithIdx(2)->hasProp("_CIPCode"));
-  m->getAtomWithIdx(2)->getProp("_CIPCode",cip);
+  TEST_ASSERT(m->getAtomWithIdx(2)->hasProp(common_properties::_CIPCode));
+  m->getAtomWithIdx(2)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="S");
 
   smi = "[H][C@@]12O[C@@](C=C1)(C3C2C(NC3=O)=O)[H]";
@@ -1264,11 +1264,11 @@ void test11()
   m = SmilesToMol(smi);
   TEST_ASSERT(m);
   MolOps::assignStereochemistry(*m,true);
-  TEST_ASSERT(m->getAtomWithIdx(0)->hasProp("_CIPCode"));
-  m->getAtomWithIdx(0)->getProp("_CIPCode",cip);
+  TEST_ASSERT(m->getAtomWithIdx(0)->hasProp(common_properties::_CIPCode));
+  m->getAtomWithIdx(0)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="R");
-  TEST_ASSERT(m->getAtomWithIdx(2)->hasProp("_CIPCode"));
-  m->getAtomWithIdx(2)->getProp("_CIPCode",cip);
+  TEST_ASSERT(m->getAtomWithIdx(2)->hasProp(common_properties::_CIPCode));
+  m->getAtomWithIdx(2)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="S");
 
 
@@ -1460,13 +1460,13 @@ void testIssue188()
   ranks.resize(m->getNumAtoms());
   Chirality::assignAtomCIPRanks(*m,ranks);
   TEST_ASSERT(m);
-  TEST_ASSERT(m->getAtomWithIdx(1)->hasProp("_CIPRank"));
-  m->getAtomWithIdx(1)->getProp("_CIPRank",cip1);
-  TEST_ASSERT(m->getAtomWithIdx(3)->hasProp("_CIPRank"));
-  m->getAtomWithIdx(3)->getProp("_CIPRank",cip2);
+  TEST_ASSERT(m->getAtomWithIdx(1)->hasProp(common_properties::_CIPRank));
+  m->getAtomWithIdx(1)->getProp(common_properties::_CIPRank,cip1);
+  TEST_ASSERT(m->getAtomWithIdx(3)->hasProp(common_properties::_CIPRank));
+  m->getAtomWithIdx(3)->getProp(common_properties::_CIPRank,cip2);
   TEST_ASSERT(cip1>cip2);
-  TEST_ASSERT(m->getAtomWithIdx(5)->hasProp("_CIPRank"));
-  m->getAtomWithIdx(5)->getProp("_CIPRank",cip3);
+  TEST_ASSERT(m->getAtomWithIdx(5)->hasProp(common_properties::_CIPRank));
+  m->getAtomWithIdx(5)->getProp(common_properties::_CIPRank,cip3);
   TEST_ASSERT(cip1>cip3);
   TEST_ASSERT(cip2>cip3);
 
@@ -1476,13 +1476,13 @@ void testIssue188()
   TEST_ASSERT(m);
   ranks.resize(m->getNumAtoms());
   Chirality::assignAtomCIPRanks(*m,ranks);
-  TEST_ASSERT(m->getAtomWithIdx(0)->hasProp("_CIPRank"));
-  m->getAtomWithIdx(0)->getProp("_CIPRank",cip1);
-  TEST_ASSERT(m->getAtomWithIdx(1)->hasProp("_CIPRank"));
-  m->getAtomWithIdx(1)->getProp("_CIPRank",cip2);
+  TEST_ASSERT(m->getAtomWithIdx(0)->hasProp(common_properties::_CIPRank));
+  m->getAtomWithIdx(0)->getProp(common_properties::_CIPRank,cip1);
+  TEST_ASSERT(m->getAtomWithIdx(1)->hasProp(common_properties::_CIPRank));
+  m->getAtomWithIdx(1)->getProp(common_properties::_CIPRank,cip2);
   TEST_ASSERT(cip2>cip1);
-  TEST_ASSERT(m->getAtomWithIdx(4)->hasProp("_CIPRank"));
-  m->getAtomWithIdx(4)->getProp("_CIPRank",cip3);
+  TEST_ASSERT(m->getAtomWithIdx(4)->hasProp(common_properties::_CIPRank));
+  m->getAtomWithIdx(4)->getProp(common_properties::_CIPRank,cip3);
   TEST_ASSERT(cip3>cip1);
   TEST_ASSERT(cip2>cip3);
   delete m;
@@ -2334,14 +2334,14 @@ void testChiralityAndRemoveHs()
   m = SmilesToMol(smi,false,false);
   TEST_ASSERT(m);
   MolOps::assignStereochemistry(*m,true,true);
-  TEST_ASSERT(m->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  m->getAtomWithIdx(1)->getProp("_CIPCode",code);
+  TEST_ASSERT(m->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  m->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,code);
   TEST_ASSERT(code=="R");
   m2=MolOps::removeHs(*m);
   TEST_ASSERT(m2);
   MolOps::assignStereochemistry(*m2,true,true);
-  TEST_ASSERT(m2->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  m2->getAtomWithIdx(1)->getProp("_CIPCode",code);
+  TEST_ASSERT(m2->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  m2->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,code);
   TEST_ASSERT(code=="R");
   delete m;
   delete m2;
@@ -2350,14 +2350,14 @@ void testChiralityAndRemoveHs()
   m = SmilesToMol(smi,false,false);
   TEST_ASSERT(m);
   MolOps::assignStereochemistry(*m,true,true);
-  TEST_ASSERT(m->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  m->getAtomWithIdx(1)->getProp("_CIPCode",code);
+  TEST_ASSERT(m->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  m->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,code);
   TEST_ASSERT(code=="R");
   m2=MolOps::removeHs(*m);
   TEST_ASSERT(m2);
   MolOps::assignStereochemistry(*m2,true,true);
-  TEST_ASSERT(m2->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  m2->getAtomWithIdx(1)->getProp("_CIPCode",code);
+  TEST_ASSERT(m2->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  m2->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,code);
   TEST_ASSERT(code=="R");
   delete m;
   delete m2;
@@ -2366,14 +2366,14 @@ void testChiralityAndRemoveHs()
   m = SmilesToMol(smi,false,false);
   TEST_ASSERT(m);
   MolOps::assignStereochemistry(*m,true,true);
-  TEST_ASSERT(m->getAtomWithIdx(0)->hasProp("_CIPCode"));
-  m->getAtomWithIdx(0)->getProp("_CIPCode",code);
+  TEST_ASSERT(m->getAtomWithIdx(0)->hasProp(common_properties::_CIPCode));
+  m->getAtomWithIdx(0)->getProp(common_properties::_CIPCode,code);
   TEST_ASSERT(code=="R");
   m2=MolOps::removeHs(*m);
   TEST_ASSERT(m2);
   MolOps::assignStereochemistry(*m2,true,true);
-  TEST_ASSERT(m2->getAtomWithIdx(0)->hasProp("_CIPCode"));
-  m2->getAtomWithIdx(0)->getProp("_CIPCode",code);
+  TEST_ASSERT(m2->getAtomWithIdx(0)->hasProp(common_properties::_CIPCode));
+  m2->getAtomWithIdx(0)->getProp(common_properties::_CIPCode,code);
   TEST_ASSERT(code=="R");
   delete m;
   delete m2;
@@ -2382,14 +2382,14 @@ void testChiralityAndRemoveHs()
   m = SmilesToMol(smi,false,false);
   TEST_ASSERT(m);
   MolOps::assignStereochemistry(*m,true,true);
-  TEST_ASSERT(m->getAtomWithIdx(0)->hasProp("_CIPCode"));
-  m->getAtomWithIdx(0)->getProp("_CIPCode",code);
+  TEST_ASSERT(m->getAtomWithIdx(0)->hasProp(common_properties::_CIPCode));
+  m->getAtomWithIdx(0)->getProp(common_properties::_CIPCode,code);
   TEST_ASSERT(code=="R");
   m2=MolOps::removeHs(*m);
   TEST_ASSERT(m2);
   MolOps::assignStereochemistry(*m2,true,true);
-  TEST_ASSERT(m2->getAtomWithIdx(0)->hasProp("_CIPCode"));
-  m2->getAtomWithIdx(0)->getProp("_CIPCode",code);
+  TEST_ASSERT(m2->getAtomWithIdx(0)->hasProp(common_properties::_CIPCode));
+  m2->getAtomWithIdx(0)->getProp(common_properties::_CIPCode,code);
   TEST_ASSERT(code=="R");
   delete m;
   delete m2;
@@ -2398,14 +2398,14 @@ void testChiralityAndRemoveHs()
   m = SmilesToMol(smi,false,false);
   TEST_ASSERT(m);
   MolOps::assignStereochemistry(*m,true,true);
-  TEST_ASSERT(m->getAtomWithIdx(2)->hasProp("_CIPCode"));
-  m->getAtomWithIdx(2)->getProp("_CIPCode",code);
+  TEST_ASSERT(m->getAtomWithIdx(2)->hasProp(common_properties::_CIPCode));
+  m->getAtomWithIdx(2)->getProp(common_properties::_CIPCode,code);
   TEST_ASSERT(code=="R");
   m2=MolOps::removeHs(*m);
   TEST_ASSERT(m2);
   MolOps::assignStereochemistry(*m2,true,true);
-  TEST_ASSERT(m2->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  m2->getAtomWithIdx(1)->getProp("_CIPCode",code);
+  TEST_ASSERT(m2->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  m2->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,code);
   TEST_ASSERT(code=="R");
   delete m;
   delete m2;
@@ -2414,14 +2414,14 @@ void testChiralityAndRemoveHs()
   m = SmilesToMol(smi,false,false);
   TEST_ASSERT(m);
   MolOps::assignStereochemistry(*m,true,true);
-  TEST_ASSERT(m->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  m->getAtomWithIdx(1)->getProp("_CIPCode",code);
+  TEST_ASSERT(m->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  m->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,code);
   TEST_ASSERT(code=="R");
   m2=MolOps::removeHs(*m);
   TEST_ASSERT(m2);
   MolOps::assignStereochemistry(*m2,true,true);
-  TEST_ASSERT(m2->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  m2->getAtomWithIdx(1)->getProp("_CIPCode",code);
+  TEST_ASSERT(m2->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  m2->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,code);
   TEST_ASSERT(code=="R");
   delete m;
   delete m2;
@@ -2430,14 +2430,14 @@ void testChiralityAndRemoveHs()
   m = SmilesToMol(smi,false,false);
   TEST_ASSERT(m);
   MolOps::assignStereochemistry(*m,true,true);
-  TEST_ASSERT(m->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  m->getAtomWithIdx(1)->getProp("_CIPCode",code);
+  TEST_ASSERT(m->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  m->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,code);
   TEST_ASSERT(code=="R");
   m2=MolOps::removeHs(*m);
   TEST_ASSERT(m2);
   MolOps::assignStereochemistry(*m2,true,true);
-  TEST_ASSERT(m2->getAtomWithIdx(0)->hasProp("_CIPCode"));
-  m2->getAtomWithIdx(0)->getProp("_CIPCode",code);
+  TEST_ASSERT(m2->getAtomWithIdx(0)->hasProp(common_properties::_CIPCode));
+  m2->getAtomWithIdx(0)->getProp(common_properties::_CIPCode,code);
   TEST_ASSERT(code=="R");
   delete m;
   delete m2;
@@ -2446,14 +2446,14 @@ void testChiralityAndRemoveHs()
   m = SmilesToMol(smi,false,false);
   TEST_ASSERT(m);
   MolOps::assignStereochemistry(*m,true,true);
-  TEST_ASSERT(m->getAtomWithIdx(0)->hasProp("_CIPCode"));
-  m->getAtomWithIdx(0)->getProp("_CIPCode",code);
+  TEST_ASSERT(m->getAtomWithIdx(0)->hasProp(common_properties::_CIPCode));
+  m->getAtomWithIdx(0)->getProp(common_properties::_CIPCode,code);
   TEST_ASSERT(code=="R");
   m2=MolOps::removeHs(*m);
   TEST_ASSERT(m2);
   MolOps::assignStereochemistry(*m2,true,true);
-  TEST_ASSERT(m2->getAtomWithIdx(0)->hasProp("_CIPCode"));
-  m2->getAtomWithIdx(0)->getProp("_CIPCode",code);
+  TEST_ASSERT(m2->getAtomWithIdx(0)->hasProp(common_properties::_CIPCode));
+  m2->getAtomWithIdx(0)->getProp(common_properties::_CIPCode,code);
   TEST_ASSERT(code=="R");
   delete m;
   delete m2;
@@ -2463,8 +2463,8 @@ void testChiralityAndRemoveHs()
   m = SmilesToMol(smi,false,false);
   TEST_ASSERT(m);
   MolOps::assignStereochemistry(*m,true,true);
-  TEST_ASSERT(m->getAtomWithIdx(3)->hasProp("_CIPCode"));
-  m->getAtomWithIdx(3)->getProp("_CIPCode",code);
+  TEST_ASSERT(m->getAtomWithIdx(3)->hasProp(common_properties::_CIPCode));
+  m->getAtomWithIdx(3)->getProp(common_properties::_CIPCode,code);
   TEST_ASSERT(code=="R");
   delete m;
 
@@ -2472,8 +2472,8 @@ void testChiralityAndRemoveHs()
   m = SmilesToMol(smi,false,false);
   TEST_ASSERT(m);
   MolOps::assignStereochemistry(*m,true,true);
-  TEST_ASSERT(m->getAtomWithIdx(0)->hasProp("_CIPCode"));
-  m->getAtomWithIdx(0)->getProp("_CIPCode",code);
+  TEST_ASSERT(m->getAtomWithIdx(0)->hasProp(common_properties::_CIPCode));
+  m->getAtomWithIdx(0)->getProp(common_properties::_CIPCode,code);
   TEST_ASSERT(code=="R");
   delete m;
 
@@ -2481,8 +2481,8 @@ void testChiralityAndRemoveHs()
   m = SmilesToMol(smi,false,false);
   TEST_ASSERT(m);
   MolOps::assignStereochemistry(*m,true,true);
-  TEST_ASSERT(m->getAtomWithIdx(3)->hasProp("_CIPCode"));
-  m->getAtomWithIdx(3)->getProp("_CIPCode",code);
+  TEST_ASSERT(m->getAtomWithIdx(3)->hasProp(common_properties::_CIPCode));
+  m->getAtomWithIdx(3)->getProp(common_properties::_CIPCode,code);
   TEST_ASSERT(code=="R");
   delete m;
 
@@ -2491,8 +2491,8 @@ void testChiralityAndRemoveHs()
   m = SmilesToMol(smi,false,false);
   TEST_ASSERT(m);
   MolOps::assignStereochemistry(*m,true,true);
-  TEST_ASSERT(m->getAtomWithIdx(3)->hasProp("_CIPCode"));
-  m->getAtomWithIdx(3)->getProp("_CIPCode",code);
+  TEST_ASSERT(m->getAtomWithIdx(3)->hasProp(common_properties::_CIPCode));
+  m->getAtomWithIdx(3)->getProp(common_properties::_CIPCode,code);
   TEST_ASSERT(code=="R");
   delete m;
 
@@ -3080,7 +3080,7 @@ void testSFNetIssue2313979() {
       ROMol *m=suppl.next();
       TEST_ASSERT(m);
       std::string nm;
-      m->getProp("_Name",nm);
+      m->getProp(common_properties::_Name,nm);
       BOOST_LOG(rdInfoLog) << "   Doing molecule: "<<nm<< std::endl;
       
       BOOST_LOG(rdInfoLog) << "     This should finish in a few seconds.  >>>" << std::endl;
@@ -3177,9 +3177,9 @@ void testSFNetIssue2951221() {
     TEST_ASSERT(m2->getNumAtoms(false)==5);
     MolOps::assignChiralTypesFrom3D(*m2);
     MolOps::assignStereochemistry(*m2,true,true);
-    TEST_ASSERT(m2->getAtomWithIdx(1)->hasProp("_CIPCode"));
+    TEST_ASSERT(m2->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
     std::string cip;
-    m2->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+    m2->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="S");
   }
   {
@@ -3193,9 +3193,9 @@ void testSFNetIssue2951221() {
     TEST_ASSERT(m2->getNumAtoms(false)==5);
     MolOps::assignChiralTypesFrom3D(*m2);
     MolOps::assignStereochemistry(*m2,true,true);
-    TEST_ASSERT(m2->getAtomWithIdx(1)->hasProp("_CIPCode"));
+    TEST_ASSERT(m2->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
     std::string cip;
-    m2->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+    m2->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="R");
   }
 

--- a/Code/GraphMol/sanitTest.cpp
+++ b/Code/GraphMol/sanitTest.cpp
@@ -83,7 +83,7 @@ int main(int argc, char *argv[]) {
       MolOps::sanitizeMol(*m);
 
       int nar;
-      m->getProp("numArom", nar);
+      m->getProp(common_properties::numArom, nar);
       BOOST_LOG(rdInfoLog)<< nar << "\n";
 
       //MolOps::setHybridization(*m);

--- a/Code/GraphMol/test1.cpp
+++ b/Code/GraphMol/test1.cpp
@@ -145,7 +145,7 @@ void testMolProps()
   CHECK_INVARIANT(tmpS=="2","");
 
   tmpS="name";
-  m2.setProp("_Name",tmpS);
+  m2.setProp(common_properties::_Name,tmpS);
 
   propNames=m2.getPropList(false,false);
   TEST_ASSERT(propNames.size()==1);

--- a/Code/GraphMol/testChirality.cpp
+++ b/Code/GraphMol/testChirality.cpp
@@ -42,8 +42,8 @@ void testMol1(){
   TEST_ASSERT(m);
   TEST_ASSERT(m->getNumAtoms()==4);
   MolOps::assignStereochemistry(*m);
-  TEST_ASSERT(m->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  m->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+  TEST_ASSERT(m->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  m->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="R");
 
   smi="[C@H](O)(N)I";
@@ -52,11 +52,11 @@ void testMol1(){
   TEST_ASSERT(m);
   TEST_ASSERT(m->getNumAtoms()==4);
   MolOps::assignStereochemistry(*m);
-  TEST_ASSERT(m->getAtomWithIdx(0)->hasProp("_CIPCode"));
-  m->getAtomWithIdx(0)->getProp("_CIPCode",cip);
+  TEST_ASSERT(m->getAtomWithIdx(0)->hasProp(common_properties::_CIPCode));
+  m->getAtomWithIdx(0)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="R");
   MolOps::removeStereochemistry(*m);
-  TEST_ASSERT(!m->getAtomWithIdx(0)->hasProp("_CIPCode"));
+  TEST_ASSERT(!m->getAtomWithIdx(0)->hasProp(common_properties::_CIPCode));
 
   BOOST_LOG(rdInfoLog) << " >>>>>>>>>>>>> mol file <<<<<<<<<<<<<< " << std::endl;
   delete m;
@@ -65,8 +65,8 @@ void testMol1(){
   TEST_ASSERT(m);
   TEST_ASSERT(m->getNumAtoms()==4);
   MolOps::assignStereochemistry(*m);
-  TEST_ASSERT(m->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  m->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+  TEST_ASSERT(m->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  m->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="R");
 
   delete m;
@@ -75,11 +75,11 @@ void testMol1(){
   TEST_ASSERT(m);
   TEST_ASSERT(m->getNumAtoms()==4);
   MolOps::assignStereochemistry(*m);
-  TEST_ASSERT(m->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  m->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+  TEST_ASSERT(m->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  m->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="R");
   MolOps::removeStereochemistry(*m);
-  TEST_ASSERT(!m->getAtomWithIdx(1)->hasProp("_CIPCode"));
+  TEST_ASSERT(!m->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
 
   delete m;
   fName = rdbase+"/Code/GraphMol/FileParsers/test_data/ChiralityAndBondDir2a.mol";
@@ -87,11 +87,11 @@ void testMol1(){
   TEST_ASSERT(m);
   TEST_ASSERT(m->getNumAtoms()==4);
   MolOps::assignStereochemistry(*m);
-  TEST_ASSERT(m->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  m->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+  TEST_ASSERT(m->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  m->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="R");
   MolOps::removeStereochemistry(*m);
-  TEST_ASSERT(!m->getAtomWithIdx(1)->hasProp("_CIPCode"));
+  TEST_ASSERT(!m->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
 
   delete m;
   fName = rdbase+"/Code/GraphMol/FileParsers/test_data/ChiralityAndBondDir2b.mol";
@@ -99,11 +99,11 @@ void testMol1(){
   TEST_ASSERT(m);
   TEST_ASSERT(m->getNumAtoms()==4);
   MolOps::assignStereochemistry(*m);
-  TEST_ASSERT(m->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  m->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+  TEST_ASSERT(m->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  m->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="R");
   MolOps::removeStereochemistry(*m);
-  TEST_ASSERT(!m->getAtomWithIdx(1)->hasProp("_CIPCode"));
+  TEST_ASSERT(!m->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
 
   BOOST_LOG(rdInfoLog) << "done" << std::endl;
 };
@@ -123,8 +123,8 @@ void testRoundTrip(){
   TEST_ASSERT(m);
   TEST_ASSERT(m->getNumAtoms()==4);
   MolOps::assignStereochemistry(*m);
-  TEST_ASSERT(m->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  m->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+  TEST_ASSERT(m->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  m->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="R");
   smi=MolToSmiles(*m,true);
   delete m;
@@ -132,8 +132,8 @@ void testRoundTrip(){
   TEST_ASSERT(m);
   TEST_ASSERT(m->getNumAtoms()==4);
   MolOps::assignStereochemistry(*m);
-  TEST_ASSERT(m->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  m->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+  TEST_ASSERT(m->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  m->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="R");
   smi2=MolToSmiles(*m,true);
   TEST_ASSERT(smi==smi2);
@@ -145,8 +145,8 @@ void testRoundTrip(){
   TEST_ASSERT(m);
   TEST_ASSERT(m->getNumAtoms()==4);
   MolOps::assignStereochemistry(*m);
-  TEST_ASSERT(m->getAtomWithIdx(0)->hasProp("_CIPCode"));
-  m->getAtomWithIdx(0)->getProp("_CIPCode",cip);
+  TEST_ASSERT(m->getAtomWithIdx(0)->hasProp(common_properties::_CIPCode));
+  m->getAtomWithIdx(0)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="R");
 #if 1
   smi=MolToSmiles(*m,true);
@@ -157,8 +157,8 @@ void testRoundTrip(){
   TEST_ASSERT(m);
   TEST_ASSERT(m->getNumAtoms()==4);
   MolOps::assignStereochemistry(*m);
-  TEST_ASSERT(m->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  m->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+  TEST_ASSERT(m->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  m->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="R");
   smi2=MolToSmiles(*m,true);
   TEST_ASSERT(smi==smi2);
@@ -171,8 +171,8 @@ void testRoundTrip(){
   TEST_ASSERT(m);
   TEST_ASSERT(m->getNumAtoms()==4);
   MolOps::assignStereochemistry(*m);
-  TEST_ASSERT(m->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  m->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+  TEST_ASSERT(m->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  m->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="R");
 #if 1
   smi=MolToSmiles(*m,true);
@@ -181,8 +181,8 @@ void testRoundTrip(){
   TEST_ASSERT(m);
   TEST_ASSERT(m->getNumAtoms()==4);
   MolOps::assignStereochemistry(*m);
-  TEST_ASSERT(m->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  m->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+  TEST_ASSERT(m->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  m->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="R");
   smi2=MolToSmiles(*m,true);
   TEST_ASSERT(smi==smi2);
@@ -194,8 +194,8 @@ void testRoundTrip(){
   TEST_ASSERT(m);
   TEST_ASSERT(m->getNumAtoms()==4);
   MolOps::assignStereochemistry(*m);
-  TEST_ASSERT(m->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  m->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+  TEST_ASSERT(m->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  m->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="R");
 #if 1
   smi=MolToSmiles(*m,true);
@@ -204,8 +204,8 @@ void testRoundTrip(){
   TEST_ASSERT(m);
   TEST_ASSERT(m->getNumAtoms()==4);
   MolOps::assignStereochemistry(*m);
-  TEST_ASSERT(m->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  m->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+  TEST_ASSERT(m->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  m->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="R");
   smi2=MolToSmiles(*m,true);
   TEST_ASSERT(smi==smi2);
@@ -217,8 +217,8 @@ void testRoundTrip(){
   TEST_ASSERT(m);
   TEST_ASSERT(m->getNumAtoms()==4);
   MolOps::assignStereochemistry(*m);
-  TEST_ASSERT(m->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  m->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+  TEST_ASSERT(m->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  m->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="R");
 #if 1
   smi=MolToSmiles(*m,true);
@@ -227,8 +227,8 @@ void testRoundTrip(){
   TEST_ASSERT(m);
   TEST_ASSERT(m->getNumAtoms()==4);
   MolOps::assignStereochemistry(*m);
-  TEST_ASSERT(m->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  m->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+  TEST_ASSERT(m->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  m->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="R");
   smi2=MolToSmiles(*m,true);
   TEST_ASSERT(smi==smi2);
@@ -240,8 +240,8 @@ void testRoundTrip(){
   TEST_ASSERT(m);
   TEST_ASSERT(m->getNumAtoms()==4);
   MolOps::assignStereochemistry(*m);
-  TEST_ASSERT(m->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  m->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+  TEST_ASSERT(m->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  m->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="R");
 #if 1
   smi=MolToSmiles(*m,true);
@@ -250,8 +250,8 @@ void testRoundTrip(){
   TEST_ASSERT(m);
   TEST_ASSERT(m->getNumAtoms()==4);
   MolOps::assignStereochemistry(*m);
-  TEST_ASSERT(m->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  m->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+  TEST_ASSERT(m->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  m->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="R");
   smi2=MolToSmiles(*m,true);
   TEST_ASSERT(smi==smi2);
@@ -276,14 +276,14 @@ void testMol2(){
   TEST_ASSERT(m);
   TEST_ASSERT(m->getNumAtoms()==9);
   MolOps::assignStereochemistry(*m);
-  TEST_ASSERT(m->getAtomWithIdx(0)->hasProp("_CIPCode"));
-  m->getAtomWithIdx(0)->getProp("_CIPCode",cip);
+  TEST_ASSERT(m->getAtomWithIdx(0)->hasProp(common_properties::_CIPCode));
+  m->getAtomWithIdx(0)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="R");
-  TEST_ASSERT(m->getAtomWithIdx(3)->hasProp("_CIPCode"));
-  m->getAtomWithIdx(3)->getProp("_CIPCode",cip);
+  TEST_ASSERT(m->getAtomWithIdx(3)->hasProp(common_properties::_CIPCode));
+  m->getAtomWithIdx(3)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="R");
-  TEST_ASSERT(m->getAtomWithIdx(5)->hasProp("_CIPCode"));
-  m->getAtomWithIdx(5)->getProp("_CIPCode",cip);
+  TEST_ASSERT(m->getAtomWithIdx(5)->hasProp(common_properties::_CIPCode));
+  m->getAtomWithIdx(5)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="R");
 
   // same molecule, H combined with the first atom (reproduces 
@@ -295,14 +295,14 @@ void testMol2(){
   TEST_ASSERT(m);
   TEST_ASSERT(m->getNumAtoms()==9);
   MolOps::assignStereochemistry(*m);
-  TEST_ASSERT(m->getAtomWithIdx(0)->hasProp("_CIPCode"));
-  m->getAtomWithIdx(0)->getProp("_CIPCode",cip);
+  TEST_ASSERT(m->getAtomWithIdx(0)->hasProp(common_properties::_CIPCode));
+  m->getAtomWithIdx(0)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="R");
-  TEST_ASSERT(m->getAtomWithIdx(3)->hasProp("_CIPCode"));
-  m->getAtomWithIdx(3)->getProp("_CIPCode",cip);
+  TEST_ASSERT(m->getAtomWithIdx(3)->hasProp(common_properties::_CIPCode));
+  m->getAtomWithIdx(3)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="R");
-  TEST_ASSERT(m->getAtomWithIdx(5)->hasProp("_CIPCode"));
-  m->getAtomWithIdx(5)->getProp("_CIPCode",cip);
+  TEST_ASSERT(m->getAtomWithIdx(5)->hasProp(common_properties::_CIPCode));
+  m->getAtomWithIdx(5)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="R");
   
   delete m;
@@ -312,14 +312,14 @@ void testMol2(){
   TEST_ASSERT(m);
   TEST_ASSERT(m->getNumAtoms()==9);
   MolOps::assignStereochemistry(*m);
-  TEST_ASSERT(m->getAtomWithIdx(0)->hasProp("_CIPCode"));
-  m->getAtomWithIdx(0)->getProp("_CIPCode",cip);
+  TEST_ASSERT(m->getAtomWithIdx(0)->hasProp(common_properties::_CIPCode));
+  m->getAtomWithIdx(0)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="R");
-  TEST_ASSERT(m->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  m->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+  TEST_ASSERT(m->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  m->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="R");
-  TEST_ASSERT(m->getAtomWithIdx(3)->hasProp("_CIPCode"));
-  m->getAtomWithIdx(3)->getProp("_CIPCode",cip);
+  TEST_ASSERT(m->getAtomWithIdx(3)->hasProp(common_properties::_CIPCode));
+  m->getAtomWithIdx(3)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="R");
 
   BOOST_LOG(rdInfoLog) << "done" << std::endl;
@@ -337,8 +337,8 @@ void testSmiles1(){
   TEST_ASSERT(mol->getAtomWithIdx(1)->getChiralTag()==Atom::CHI_TETRAHEDRAL_CCW);
   TEST_ASSERT(mol->getAtomWithIdx(0)->getChiralTag()==Atom::CHI_UNSPECIFIED);
   MolOps::assignStereochemistry(*mol);
-  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  mol->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  mol->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="S");
 
   delete mol;
@@ -347,8 +347,8 @@ void testSmiles1(){
   TEST_ASSERT(mol->getAtomWithIdx(1)->getChiralTag()==Atom::CHI_TETRAHEDRAL_CCW);
   TEST_ASSERT(mol->getAtomWithIdx(0)->getChiralTag()==Atom::CHI_UNSPECIFIED);
   MolOps::assignStereochemistry(*mol);
-  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  mol->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  mol->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="S");
 
   delete mol;
@@ -356,8 +356,8 @@ void testSmiles1(){
   mol = SmilesToMol(smi);
   TEST_ASSERT(mol->getAtomWithIdx(1)->getChiralTag()==Atom::CHI_TETRAHEDRAL_CCW);
   MolOps::assignStereochemistry(*mol);
-  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  mol->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  mol->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="S");
 
   delete mol;
@@ -365,8 +365,8 @@ void testSmiles1(){
   mol = SmilesToMol(smi);
   TEST_ASSERT(mol->getAtomWithIdx(1)->getChiralTag()==Atom::CHI_TETRAHEDRAL_CCW);
   MolOps::assignStereochemistry(*mol);
-  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  mol->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  mol->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="S");
 
   delete mol;
@@ -374,8 +374,8 @@ void testSmiles1(){
   mol = SmilesToMol(smi);
   TEST_ASSERT(mol->getAtomWithIdx(1)->getChiralTag()==Atom::CHI_TETRAHEDRAL_CCW);
   MolOps::assignStereochemistry(*mol);
-  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  mol->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  mol->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="S");
 
   delete mol;
@@ -383,8 +383,8 @@ void testSmiles1(){
   mol = SmilesToMol(smi);
   TEST_ASSERT(mol->getAtomWithIdx(1)->getChiralTag()==Atom::CHI_TETRAHEDRAL_CCW);
   MolOps::assignStereochemistry(*mol);
-  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  mol->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  mol->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="S");
 
   delete mol;
@@ -392,8 +392,8 @@ void testSmiles1(){
   mol = SmilesToMol(smi);
   TEST_ASSERT(mol->getAtomWithIdx(1)->getChiralTag()==Atom::CHI_TETRAHEDRAL_CCW);
   MolOps::assignStereochemistry(*mol);
-  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  mol->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  mol->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="S");
 
   delete mol;
@@ -401,8 +401,8 @@ void testSmiles1(){
   mol = SmilesToMol(smi);
   TEST_ASSERT(mol->getAtomWithIdx(1)->getChiralTag()==Atom::CHI_TETRAHEDRAL_CW);
   MolOps::assignStereochemistry(*mol);
-  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  mol->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  mol->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="S");
 
   delete mol;
@@ -410,8 +410,8 @@ void testSmiles1(){
   mol = SmilesToMol(smi);
   TEST_ASSERT(mol->getAtomWithIdx(1)->getChiralTag()==Atom::CHI_TETRAHEDRAL_CW);
   MolOps::assignStereochemistry(*mol);
-  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  mol->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  mol->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="S");
 
   delete mol;
@@ -419,8 +419,8 @@ void testSmiles1(){
   mol = SmilesToMol(smi);
   TEST_ASSERT(mol->getAtomWithIdx(1)->getChiralTag()==Atom::CHI_TETRAHEDRAL_CW);
   MolOps::assignStereochemistry(*mol);
-  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  mol->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  mol->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="S");
 
   delete mol;
@@ -428,8 +428,8 @@ void testSmiles1(){
   mol = SmilesToMol(smi);
   TEST_ASSERT(mol->getAtomWithIdx(1)->getChiralTag()==Atom::CHI_TETRAHEDRAL_CW);
   MolOps::assignStereochemistry(*mol);
-  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  mol->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  mol->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="S");
 
   delete mol;
@@ -437,8 +437,8 @@ void testSmiles1(){
   mol = SmilesToMol(smi);
   TEST_ASSERT(mol->getAtomWithIdx(0)->getChiralTag()==Atom::CHI_TETRAHEDRAL_CW);
   MolOps::assignStereochemistry(*mol);
-  TEST_ASSERT(mol->getAtomWithIdx(0)->hasProp("_CIPCode"));
-  mol->getAtomWithIdx(0)->getProp("_CIPCode",cip);
+  TEST_ASSERT(mol->getAtomWithIdx(0)->hasProp(common_properties::_CIPCode));
+  mol->getAtomWithIdx(0)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="S");
 
   delete mol;
@@ -446,8 +446,8 @@ void testSmiles1(){
   mol = SmilesToMol(smi);
   TEST_ASSERT(mol->getAtomWithIdx(1)->getChiralTag()==Atom::CHI_TETRAHEDRAL_CCW);
   MolOps::assignStereochemistry(*mol);
-  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  mol->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  mol->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="R");
 
   delete mol;
@@ -455,8 +455,8 @@ void testSmiles1(){
   mol = SmilesToMol(smi);
   TEST_ASSERT(mol->getAtomWithIdx(1)->getChiralTag()==Atom::CHI_TETRAHEDRAL_CCW);
   MolOps::assignStereochemistry(*mol);
-  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  mol->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  mol->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="R");
 
   delete mol;
@@ -464,8 +464,8 @@ void testSmiles1(){
   mol = SmilesToMol(smi);
   TEST_ASSERT(mol->getAtomWithIdx(1)->getChiralTag()==Atom::CHI_TETRAHEDRAL_CCW);
   MolOps::assignStereochemistry(*mol);
-  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  mol->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  mol->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="R");
 
   delete mol;
@@ -473,8 +473,8 @@ void testSmiles1(){
   mol = SmilesToMol(smi);
   TEST_ASSERT(mol->getAtomWithIdx(1)->getChiralTag()==Atom::CHI_TETRAHEDRAL_CCW);
   MolOps::assignStereochemistry(*mol);
-  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  mol->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  mol->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="R");
 
   delete mol;
@@ -482,8 +482,8 @@ void testSmiles1(){
   mol = SmilesToMol(smi);
   TEST_ASSERT(mol->getAtomWithIdx(1)->getChiralTag()==Atom::CHI_TETRAHEDRAL_CCW);
   MolOps::assignStereochemistry(*mol);
-  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  mol->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  mol->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="R");
 
   delete mol;
@@ -491,8 +491,8 @@ void testSmiles1(){
   mol = SmilesToMol(smi);
   TEST_ASSERT(mol->getAtomWithIdx(1)->getChiralTag()==Atom::CHI_TETRAHEDRAL_CW);
   MolOps::assignStereochemistry(*mol);
-  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  mol->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  mol->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="R");
 
   delete mol;
@@ -500,8 +500,8 @@ void testSmiles1(){
   mol = SmilesToMol(smi);
   TEST_ASSERT(mol->getAtomWithIdx(1)->getChiralTag()==Atom::CHI_TETRAHEDRAL_CW);
   MolOps::assignStereochemistry(*mol);
-  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  mol->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  mol->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="R");
 
   delete mol;
@@ -509,8 +509,8 @@ void testSmiles1(){
   mol = SmilesToMol(smi);
   TEST_ASSERT(mol->getAtomWithIdx(1)->getChiralTag()==Atom::CHI_TETRAHEDRAL_CW);
   MolOps::assignStereochemistry(*mol);
-  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  mol->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  mol->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="R");
 
   delete mol;
@@ -518,8 +518,8 @@ void testSmiles1(){
   mol = SmilesToMol(smi);
   TEST_ASSERT(mol->getAtomWithIdx(1)->getChiralTag()==Atom::CHI_TETRAHEDRAL_CCW);
   MolOps::assignStereochemistry(*mol);
-  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  mol->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+  TEST_ASSERT(mol->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  mol->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="S");
 
   delete mol;
@@ -527,8 +527,8 @@ void testSmiles1(){
   mol = SmilesToMol(smi);
   TEST_ASSERT(mol->getAtomWithIdx(0)->getChiralTag()==Atom::CHI_TETRAHEDRAL_CW);
   MolOps::assignStereochemistry(*mol);
-  TEST_ASSERT(mol->getAtomWithIdx(0)->hasProp("_CIPCode"));
-  mol->getAtomWithIdx(0)->getProp("_CIPCode",cip);
+  TEST_ASSERT(mol->getAtomWithIdx(0)->hasProp(common_properties::_CIPCode));
+  mol->getAtomWithIdx(0)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="R");
 
   delete mol;
@@ -536,8 +536,8 @@ void testSmiles1(){
   mol = SmilesToMol(smi);
   TEST_ASSERT(mol->getAtomWithIdx(0)->getChiralTag()==Atom::CHI_TETRAHEDRAL_CCW);
   MolOps::assignStereochemistry(*mol);
-  TEST_ASSERT(mol->getAtomWithIdx(0)->hasProp("_CIPCode"));
-  mol->getAtomWithIdx(0)->getProp("_CIPCode",cip);
+  TEST_ASSERT(mol->getAtomWithIdx(0)->hasProp(common_properties::_CIPCode));
+  mol->getAtomWithIdx(0)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="R");
 
   delete mol;
@@ -545,8 +545,8 @@ void testSmiles1(){
   mol = SmilesToMol(smi);
   TEST_ASSERT(mol->getAtomWithIdx(0)->getChiralTag()==Atom::CHI_TETRAHEDRAL_CCW);
   MolOps::assignStereochemistry(*mol);
-  TEST_ASSERT(mol->getAtomWithIdx(0)->hasProp("_CIPCode"));
-  mol->getAtomWithIdx(0)->getProp("_CIPCode",cip);
+  TEST_ASSERT(mol->getAtomWithIdx(0)->hasProp(common_properties::_CIPCode));
+  mol->getAtomWithIdx(0)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="R");
 
   delete mol;
@@ -554,8 +554,8 @@ void testSmiles1(){
   mol = SmilesToMol(smi);
   TEST_ASSERT(mol->getAtomWithIdx(0)->getChiralTag()==Atom::CHI_TETRAHEDRAL_CCW);
   MolOps::assignStereochemistry(*mol);
-  TEST_ASSERT(mol->getAtomWithIdx(0)->hasProp("_CIPCode"));
-  mol->getAtomWithIdx(0)->getProp("_CIPCode",cip);
+  TEST_ASSERT(mol->getAtomWithIdx(0)->hasProp(common_properties::_CIPCode));
+  mol->getAtomWithIdx(0)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="R");
 
   delete mol;
@@ -577,7 +577,7 @@ void testChiralityCleanup(){
   mol=mol2;
   TEST_ASSERT(mol->getAtomWithIdx(1)->getChiralTag()==Atom::CHI_TETRAHEDRAL_CCW);
   MolOps::assignStereochemistry(*mol,true);
-  TEST_ASSERT(!mol->getAtomWithIdx(1)->hasProp("_CIPCode"));
+  TEST_ASSERT(!mol->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
   TEST_ASSERT(mol->getAtomWithIdx(1)->getChiralTag()==Atom::CHI_UNSPECIFIED);
   delete mol;
 
@@ -588,7 +588,7 @@ void testChiralityCleanup(){
   mol=mol2;
   TEST_ASSERT(mol->getAtomWithIdx(1)->getChiralTag()==Atom::CHI_TETRAHEDRAL_CCW);
   MolOps::assignStereochemistry(*mol,true);
-  TEST_ASSERT(!mol->getAtomWithIdx(1)->hasProp("_CIPCode"));
+  TEST_ASSERT(!mol->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
   TEST_ASSERT(mol->getAtomWithIdx(1)->getChiralTag()==Atom::CHI_UNSPECIFIED);
   delete mol;
 
@@ -765,9 +765,9 @@ void testChiralityFrom3D(){
 
   MolOps::assignChiralTypesFrom3D(*m);
   MolOps::assignStereochemistry(*m,true);
-  TEST_ASSERT(m->getAtomWithIdx(1)->hasProp("_CIPCode"));
+  TEST_ASSERT(m->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
   TEST_ASSERT(m->getAtomWithIdx(1)->getChiralTag()==Atom::CHI_TETRAHEDRAL_CW);
-  m->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+  m->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="R");
 
 
@@ -779,9 +779,9 @@ void testChiralityFrom3D(){
 
   MolOps::assignChiralTypesFrom3D(*m);
   MolOps::assignStereochemistry(*m,true);
-  TEST_ASSERT(m->getAtomWithIdx(1)->hasProp("_CIPCode"));
+  TEST_ASSERT(m->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
   TEST_ASSERT(m->getAtomWithIdx(1)->getChiralTag()==Atom::CHI_TETRAHEDRAL_CCW);
-  m->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+  m->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="S");
 
 
@@ -793,9 +793,9 @@ void testChiralityFrom3D(){
 
   MolOps::assignChiralTypesFrom3D(*m);
   MolOps::assignStereochemistry(*m,true);
-  TEST_ASSERT(m->getAtomWithIdx(0)->hasProp("_CIPCode"));
+  TEST_ASSERT(m->getAtomWithIdx(0)->hasProp(common_properties::_CIPCode));
   TEST_ASSERT(m->getAtomWithIdx(0)->getChiralTag()==Atom::CHI_TETRAHEDRAL_CCW);
-  m->getAtomWithIdx(0)->getProp("_CIPCode",cip);
+  m->getAtomWithIdx(0)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="R");
 
 
@@ -807,9 +807,9 @@ void testChiralityFrom3D(){
 
   MolOps::assignChiralTypesFrom3D(*m);
   MolOps::assignStereochemistry(*m,true);
-  TEST_ASSERT(m->getAtomWithIdx(0)->hasProp("_CIPCode"));
+  TEST_ASSERT(m->getAtomWithIdx(0)->hasProp(common_properties::_CIPCode));
   TEST_ASSERT(m->getAtomWithIdx(0)->getChiralTag()==Atom::CHI_TETRAHEDRAL_CW);
-  m->getAtomWithIdx(0)->getProp("_CIPCode",cip);
+  m->getAtomWithIdx(0)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="S");
 
   delete m;
@@ -821,15 +821,15 @@ void testChiralityFrom3D(){
   // this molecule starts out with incorrect stereochemistry (e.g. the bond wedging
   // does not match the 3D structure. Start by verifying that the start position is bad:
   MolOps::assignStereochemistry(*m,true);
-  TEST_ASSERT(m->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  m->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+  TEST_ASSERT(m->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  m->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="S");
   // now assign the stereochem based on the 3D structure and check that we get it
   // right:
   MolOps::assignChiralTypesFrom3D(*m,-1,true);
   MolOps::assignStereochemistry(*m,true,true);
-  TEST_ASSERT(m->getAtomWithIdx(1)->hasProp("_CIPCode"));
-  m->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+  TEST_ASSERT(m->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+  m->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
   TEST_ASSERT(cip=="R");
 
   delete m;
@@ -854,16 +854,16 @@ void testIterativeChirality(){
     TEST_ASSERT(m);
     TEST_ASSERT(m->getNumAtoms()==9);
  
-    TEST_ASSERT(m->getAtomWithIdx(1)->hasProp("_CIPCode"));
-    m->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+    TEST_ASSERT(m->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+    m->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="R");
 
-    TEST_ASSERT(m->getAtomWithIdx(5)->hasProp("_CIPCode"));
-    m->getAtomWithIdx(5)->getProp("_CIPCode",cip);
+    TEST_ASSERT(m->getAtomWithIdx(5)->hasProp(common_properties::_CIPCode));
+    m->getAtomWithIdx(5)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="S");
 
-    TEST_ASSERT(m->getAtomWithIdx(0)->hasProp("_CIPCode"));
-    m->getAtomWithIdx(0)->getProp("_CIPCode",cip);
+    TEST_ASSERT(m->getAtomWithIdx(0)->hasProp(common_properties::_CIPCode));
+    m->getAtomWithIdx(0)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="S");
 
     std::string smi1=MolToSmiles(*m,true);
@@ -885,16 +885,16 @@ void testIterativeChirality(){
     TEST_ASSERT(m);
     TEST_ASSERT(m->getNumAtoms()==9);
 
-    TEST_ASSERT(m->getAtomWithIdx(1)->hasProp("_CIPCode"));
-    m->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+    TEST_ASSERT(m->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+    m->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="R");
 
-    TEST_ASSERT(m->getAtomWithIdx(5)->hasProp("_CIPCode"));
-    m->getAtomWithIdx(5)->getProp("_CIPCode",cip);
+    TEST_ASSERT(m->getAtomWithIdx(5)->hasProp(common_properties::_CIPCode));
+    m->getAtomWithIdx(5)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="S");
 
-    TEST_ASSERT(m->getAtomWithIdx(0)->hasProp("_CIPCode"));
-    m->getAtomWithIdx(0)->getProp("_CIPCode",cip);
+    TEST_ASSERT(m->getAtomWithIdx(0)->hasProp(common_properties::_CIPCode));
+    m->getAtomWithIdx(0)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="R");
 
     std::string smi1=MolToSmiles(*m,true);
@@ -916,15 +916,15 @@ void testIterativeChirality(){
     TEST_ASSERT(m);
     TEST_ASSERT(m->getNumAtoms()==9);
 
-    TEST_ASSERT(m->getAtomWithIdx(1)->hasProp("_CIPCode"));
-    m->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+    TEST_ASSERT(m->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+    m->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="R");
 
-    TEST_ASSERT(m->getAtomWithIdx(5)->hasProp("_CIPCode"));
-    m->getAtomWithIdx(5)->getProp("_CIPCode",cip);
+    TEST_ASSERT(m->getAtomWithIdx(5)->hasProp(common_properties::_CIPCode));
+    m->getAtomWithIdx(5)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="R");
 
-    TEST_ASSERT(!m->getAtomWithIdx(0)->hasProp("_CIPCode"));
+    TEST_ASSERT(!m->getAtomWithIdx(0)->hasProp(common_properties::_CIPCode));
 
 #if 1 // this fails due to sf.net bug 1896935
     std::string smi1=MolToSmiles(*m,true);
@@ -947,15 +947,15 @@ void testIterativeChirality(){
     TEST_ASSERT(m);
     TEST_ASSERT(m->getNumAtoms()==9);
 
-    TEST_ASSERT(m->getAtomWithIdx(1)->hasProp("_CIPCode"));
-    m->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+    TEST_ASSERT(m->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+    m->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="R");
 
-    TEST_ASSERT(m->getAtomWithIdx(5)->hasProp("_CIPCode"));
-    m->getAtomWithIdx(5)->getProp("_CIPCode",cip);
+    TEST_ASSERT(m->getAtomWithIdx(5)->hasProp(common_properties::_CIPCode));
+    m->getAtomWithIdx(5)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="R");
 
-    TEST_ASSERT(!m->getAtomWithIdx(0)->hasProp("_CIPCode"));
+    TEST_ASSERT(!m->getAtomWithIdx(0)->hasProp(common_properties::_CIPCode));
 
 #if 1 // this fails due to sf.net bug 1896935
     std::string smi1=MolToSmiles(*m,true);
@@ -977,9 +977,9 @@ void testIterativeChirality(){
     TEST_ASSERT(m);
     TEST_ASSERT(m->getNumAtoms()==9);
 
-    TEST_ASSERT(!m->getAtomWithIdx(0)->hasProp("_CIPCode"));
-    TEST_ASSERT(!m->getAtomWithIdx(2)->hasProp("_CIPCode"));
-    TEST_ASSERT(!m->getAtomWithIdx(4)->hasProp("_CIPCode"));
+    TEST_ASSERT(!m->getAtomWithIdx(0)->hasProp(common_properties::_CIPCode));
+    TEST_ASSERT(!m->getAtomWithIdx(2)->hasProp(common_properties::_CIPCode));
+    TEST_ASSERT(!m->getAtomWithIdx(4)->hasProp(common_properties::_CIPCode));
 
 #if 0 // this fails due to sf.net bug 1896935
     std::cerr<<"m pre -----"<<std::endl;
@@ -1016,14 +1016,14 @@ void testIterativeChirality(){
     TEST_ASSERT(m->getBondBetweenAtoms(2,5)->getStereo()==Bond::STEREOE);
     TEST_ASSERT(m->getBondBetweenAtoms(0,4)->getStereo()==Bond::STEREOZ);
 
-    TEST_ASSERT(m->getAtomWithIdx(1)->hasProp("_CIPCode"));
-    m->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+    TEST_ASSERT(m->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+    m->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="S");  // this value is from ChemDraw, Marvin doesn't tag it.
 
     std::string smi1=MolToSmiles(*m,true);
 
     MolOps::removeStereochemistry(*m);
-    TEST_ASSERT(!m->getAtomWithIdx(1)->hasProp("_CIPCode"));
+    TEST_ASSERT(!m->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
     TEST_ASSERT(m->getBondBetweenAtoms(0,4)->getStereo()==Bond::STEREONONE);
     TEST_ASSERT(m->getBondBetweenAtoms(2,5)->getStereo()==Bond::STEREONONE);
     
@@ -1048,8 +1048,8 @@ void testIterativeChirality(){
     TEST_ASSERT(m->getBondBetweenAtoms(2,5)->getStereo()==Bond::STEREOE);
     TEST_ASSERT(m->getBondBetweenAtoms(0,4)->getStereo()==Bond::STEREOZ);
 
-    TEST_ASSERT(m->getAtomWithIdx(1)->hasProp("_CIPCode"));
-    m->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+    TEST_ASSERT(m->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+    m->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="R");  // this value is from ChemDraw, Marvin doesn't tag it.
 
     std::string smi1=MolToSmiles(*m,true);
@@ -1074,7 +1074,7 @@ void testIterativeChirality(){
     TEST_ASSERT(m->getBondBetweenAtoms(2,5)->getStereo()==Bond::STEREOE);
     TEST_ASSERT(m->getBondBetweenAtoms(0,4)->getStereo()==Bond::STEREOE);
 
-    TEST_ASSERT(!m->getAtomWithIdx(1)->hasProp("_CIPCode"));
+    TEST_ASSERT(!m->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
 
     std::string smi1=MolToSmiles(*m,true);
     delete m;
@@ -1098,8 +1098,8 @@ void testIterativeChirality(){
     TEST_ASSERT(m->getBondBetweenAtoms(2,5)->getStereo()==Bond::STEREOE);
     TEST_ASSERT(m->getBondBetweenAtoms(0,4)->getStereo()==Bond::STEREOANY);
 
-    TEST_ASSERT(m->getAtomWithIdx(1)->hasProp("_CIPCode"));
-    m->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+    TEST_ASSERT(m->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+    m->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="R");  // this value is from ChemDraw, Marvin doesn't tag it.
 
     std::string smi1=MolToSmiles(*m,true);
@@ -1124,8 +1124,8 @@ void testIterativeChirality(){
     TEST_ASSERT(m->getBondBetweenAtoms(2,5)->getStereo()==Bond::STEREOANY);
     TEST_ASSERT(m->getBondBetweenAtoms(0,4)->getStereo()==Bond::STEREOZ);
 
-    TEST_ASSERT(m->getAtomWithIdx(1)->hasProp("_CIPCode"));
-    m->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+    TEST_ASSERT(m->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+    m->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="S");  // this value is from ChemDraw, Marvin doesn't tag it.
 
     std::string smi1=MolToSmiles(*m,true);
@@ -1147,12 +1147,12 @@ void testIterativeChirality(){
     TEST_ASSERT(m);
     TEST_ASSERT(m->getNumAtoms()==11);
 
-    TEST_ASSERT(m->getAtomWithIdx(3)->hasProp("_CIPCode"));
-    m->getAtomWithIdx(3)->getProp("_CIPCode",cip);
+    TEST_ASSERT(m->getAtomWithIdx(3)->hasProp(common_properties::_CIPCode));
+    m->getAtomWithIdx(3)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="R");  
 
-    TEST_ASSERT(m->getAtomWithIdx(7)->hasProp("_CIPCode"));
-    m->getAtomWithIdx(7)->getProp("_CIPCode",cip);
+    TEST_ASSERT(m->getAtomWithIdx(7)->hasProp(common_properties::_CIPCode));
+    m->getAtomWithIdx(7)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="S");  
 
 
@@ -1177,12 +1177,12 @@ void testIterativeChirality(){
     TEST_ASSERT(m);
     TEST_ASSERT(m->getNumAtoms()==11);
 
-    TEST_ASSERT(m->getAtomWithIdx(3)->hasProp("_CIPCode"));
-    m->getAtomWithIdx(3)->getProp("_CIPCode",cip);
+    TEST_ASSERT(m->getAtomWithIdx(3)->hasProp(common_properties::_CIPCode));
+    m->getAtomWithIdx(3)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="S");  
 
-    TEST_ASSERT(m->getAtomWithIdx(7)->hasProp("_CIPCode"));
-    m->getAtomWithIdx(7)->getProp("_CIPCode",cip);
+    TEST_ASSERT(m->getAtomWithIdx(7)->hasProp(common_properties::_CIPCode));
+    m->getAtomWithIdx(7)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="R");  
 
 
@@ -1207,12 +1207,12 @@ void testIterativeChirality(){
     TEST_ASSERT(m);
     TEST_ASSERT(m->getNumAtoms()==11);
 
-    TEST_ASSERT(m->getAtomWithIdx(3)->hasProp("_CIPCode"));
-    m->getAtomWithIdx(3)->getProp("_CIPCode",cip);
+    TEST_ASSERT(m->getAtomWithIdx(3)->hasProp(common_properties::_CIPCode));
+    m->getAtomWithIdx(3)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="R");  
 
-    TEST_ASSERT(m->getAtomWithIdx(7)->hasProp("_CIPCode"));
-    m->getAtomWithIdx(7)->getProp("_CIPCode",cip);
+    TEST_ASSERT(m->getAtomWithIdx(7)->hasProp(common_properties::_CIPCode));
+    m->getAtomWithIdx(7)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="R");  
 
 
@@ -1400,24 +1400,24 @@ void testIssue2705543(){
     MolOps::assignChiralTypesFrom3D(*m);
     MolOps::assignStereochemistry(*m,true);
 
-    TEST_ASSERT(m->getAtomWithIdx(0)->hasProp("_CIPCode"));
-    m->getAtomWithIdx(0)->getProp("_CIPCode",cip);
+    TEST_ASSERT(m->getAtomWithIdx(0)->hasProp(common_properties::_CIPCode));
+    m->getAtomWithIdx(0)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="S");
 
-    TEST_ASSERT(m->getAtomWithIdx(1)->hasProp("_CIPCode"));
-    m->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+    TEST_ASSERT(m->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+    m->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="R");
 
-    TEST_ASSERT(m->getAtomWithIdx(2)->hasProp("_CIPCode"));
-    m->getAtomWithIdx(2)->getProp("_CIPCode",cip);
+    TEST_ASSERT(m->getAtomWithIdx(2)->hasProp(common_properties::_CIPCode));
+    m->getAtomWithIdx(2)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="S");
 
-    TEST_ASSERT(m->getAtomWithIdx(3)->hasProp("_CIPCode"));
-    m->getAtomWithIdx(3)->getProp("_CIPCode",cip);
+    TEST_ASSERT(m->getAtomWithIdx(3)->hasProp(common_properties::_CIPCode));
+    m->getAtomWithIdx(3)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="S");
 
-    TEST_ASSERT(m->getAtomWithIdx(4)->hasProp("_CIPCode"));
-    m->getAtomWithIdx(4)->getProp("_CIPCode",cip);
+    TEST_ASSERT(m->getAtomWithIdx(4)->hasProp(common_properties::_CIPCode));
+    m->getAtomWithIdx(4)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="R");
 
     delete m;
@@ -1430,24 +1430,24 @@ void testIssue2705543(){
     MolOps::assignChiralTypesFrom3D(*m);
     MolOps::assignStereochemistry(*m,true);
 
-    TEST_ASSERT(m->getAtomWithIdx(0)->hasProp("_CIPCode"));
-    m->getAtomWithIdx(0)->getProp("_CIPCode",cip);
+    TEST_ASSERT(m->getAtomWithIdx(0)->hasProp(common_properties::_CIPCode));
+    m->getAtomWithIdx(0)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="S");
 
-    TEST_ASSERT(m->getAtomWithIdx(1)->hasProp("_CIPCode"));
-    m->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+    TEST_ASSERT(m->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+    m->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="R");
 
-    TEST_ASSERT(m->getAtomWithIdx(2)->hasProp("_CIPCode"));
-    m->getAtomWithIdx(2)->getProp("_CIPCode",cip);
+    TEST_ASSERT(m->getAtomWithIdx(2)->hasProp(common_properties::_CIPCode));
+    m->getAtomWithIdx(2)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="S");
 
-    TEST_ASSERT(m->getAtomWithIdx(3)->hasProp("_CIPCode"));
-    m->getAtomWithIdx(3)->getProp("_CIPCode",cip);
+    TEST_ASSERT(m->getAtomWithIdx(3)->hasProp(common_properties::_CIPCode));
+    m->getAtomWithIdx(3)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="S");
 
-    TEST_ASSERT(m->getAtomWithIdx(4)->hasProp("_CIPCode"));
-    m->getAtomWithIdx(4)->getProp("_CIPCode",cip);
+    TEST_ASSERT(m->getAtomWithIdx(4)->hasProp(common_properties::_CIPCode));
+    m->getAtomWithIdx(4)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="R");
 
     delete m;
@@ -1461,29 +1461,29 @@ void testIssue2705543(){
     MolOps::assignChiralTypesFrom3D(*m);
     MolOps::assignStereochemistry(*m,true);
 
-    TEST_ASSERT(m->getAtomWithIdx(0)->hasProp("_CIPCode"));
+    TEST_ASSERT(m->getAtomWithIdx(0)->hasProp(common_properties::_CIPCode));
     TEST_ASSERT(m->getAtomWithIdx(0)->getChiralTag()==Atom::CHI_TETRAHEDRAL_CCW);
-    m->getAtomWithIdx(0)->getProp("_CIPCode",cip);
+    m->getAtomWithIdx(0)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="S");
 
-    TEST_ASSERT(m->getAtomWithIdx(1)->hasProp("_CIPCode"));
+    TEST_ASSERT(m->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
     TEST_ASSERT(m->getAtomWithIdx(1)->getChiralTag()==Atom::CHI_TETRAHEDRAL_CW);
-    m->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+    m->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="R");
 
-    TEST_ASSERT(m->getAtomWithIdx(2)->hasProp("_CIPCode"));
+    TEST_ASSERT(m->getAtomWithIdx(2)->hasProp(common_properties::_CIPCode));
     TEST_ASSERT(m->getAtomWithIdx(2)->getChiralTag()==Atom::CHI_TETRAHEDRAL_CCW);
-    m->getAtomWithIdx(2)->getProp("_CIPCode",cip);
+    m->getAtomWithIdx(2)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="S");
 
-    TEST_ASSERT(m->getAtomWithIdx(3)->hasProp("_CIPCode"));
+    TEST_ASSERT(m->getAtomWithIdx(3)->hasProp(common_properties::_CIPCode));
     TEST_ASSERT(m->getAtomWithIdx(3)->getChiralTag()==Atom::CHI_TETRAHEDRAL_CW);
-    m->getAtomWithIdx(3)->getProp("_CIPCode",cip);
+    m->getAtomWithIdx(3)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="S");
 
-    TEST_ASSERT(m->getAtomWithIdx(4)->hasProp("_CIPCode"));
+    TEST_ASSERT(m->getAtomWithIdx(4)->hasProp(common_properties::_CIPCode));
     TEST_ASSERT(m->getAtomWithIdx(4)->getChiralTag()==Atom::CHI_TETRAHEDRAL_CW);
-    m->getAtomWithIdx(4)->getProp("_CIPCode",cip);
+    m->getAtomWithIdx(4)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="R");
 
     delete m;
@@ -1499,35 +1499,35 @@ void testIssue2705543(){
 
 #if 0
     for(unsigned int i=0;i<m->getNumAtoms();++i){
-      if(m->getAtomWithIdx(i)->hasProp("_CIPCode")){
-        m->getAtomWithIdx(i)->getProp("_CIPCode",cip);
+      if(m->getAtomWithIdx(i)->hasProp(common_properties::_CIPCode)){
+        m->getAtomWithIdx(i)->getProp(common_properties::_CIPCode,cip);
         std::cerr<<"  >> "<<i<<" "<<cip<<std::endl;
       }
     }
 #endif    
-    TEST_ASSERT(m->getAtomWithIdx(0)->hasProp("_CIPCode"));
+    TEST_ASSERT(m->getAtomWithIdx(0)->hasProp(common_properties::_CIPCode));
     TEST_ASSERT(m->getAtomWithIdx(0)->getChiralTag()==Atom::CHI_TETRAHEDRAL_CCW);
-    m->getAtomWithIdx(0)->getProp("_CIPCode",cip);
+    m->getAtomWithIdx(0)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="S");
 
-    TEST_ASSERT(m->getAtomWithIdx(1)->hasProp("_CIPCode"));
+    TEST_ASSERT(m->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
     TEST_ASSERT(m->getAtomWithIdx(1)->getChiralTag()==Atom::CHI_TETRAHEDRAL_CW);
-    m->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+    m->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="R");
 
-    TEST_ASSERT(m->getAtomWithIdx(2)->hasProp("_CIPCode"));
+    TEST_ASSERT(m->getAtomWithIdx(2)->hasProp(common_properties::_CIPCode));
     TEST_ASSERT(m->getAtomWithIdx(2)->getChiralTag()==Atom::CHI_TETRAHEDRAL_CW);
-    m->getAtomWithIdx(2)->getProp("_CIPCode",cip);
+    m->getAtomWithIdx(2)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="S");
 
-    TEST_ASSERT(m->getAtomWithIdx(3)->hasProp("_CIPCode"));
+    TEST_ASSERT(m->getAtomWithIdx(3)->hasProp(common_properties::_CIPCode));
     TEST_ASSERT(m->getAtomWithIdx(3)->getChiralTag()==Atom::CHI_TETRAHEDRAL_CCW);
-    m->getAtomWithIdx(3)->getProp("_CIPCode",cip);
+    m->getAtomWithIdx(3)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="S");
 
-    TEST_ASSERT(m->getAtomWithIdx(4)->hasProp("_CIPCode"));
+    TEST_ASSERT(m->getAtomWithIdx(4)->hasProp(common_properties::_CIPCode));
     TEST_ASSERT(m->getAtomWithIdx(4)->getChiralTag()==Atom::CHI_TETRAHEDRAL_CCW);
-    m->getAtomWithIdx(4)->getProp("_CIPCode",cip);
+    m->getAtomWithIdx(4)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="R");
 
     delete m;
@@ -1555,15 +1555,15 @@ void testIssue2762917(){
 
     MolOps::assignStereochemistry(*m,true);
 
-    TEST_ASSERT(m->getAtomWithIdx(0)->hasProp("_CIPCode"));
-    m->getAtomWithIdx(0)->getProp("_CIPCode",cip);
+    TEST_ASSERT(m->getAtomWithIdx(0)->hasProp(common_properties::_CIPCode));
+    m->getAtomWithIdx(0)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="S");
 
     TEST_ASSERT(m->getAtomWithIdx(0)->getChiralTag()==Atom::CHI_TETRAHEDRAL_CCW);
     MolOps::assignStereochemistry(*m,true);
 
-    TEST_ASSERT(m->getAtomWithIdx(0)->hasProp("_CIPCode"));
-    m->getAtomWithIdx(0)->getProp("_CIPCode",cip);
+    TEST_ASSERT(m->getAtomWithIdx(0)->hasProp(common_properties::_CIPCode));
+    m->getAtomWithIdx(0)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="S");
 
     delete m;
@@ -1580,8 +1580,8 @@ void testIssue2762917(){
 
     MolOps::assignStereochemistry(*m,true);
 
-    TEST_ASSERT(m->getAtomWithIdx(3)->hasProp("_CIPCode"));
-    m->getAtomWithIdx(3)->getProp("_CIPCode",cip);
+    TEST_ASSERT(m->getAtomWithIdx(3)->hasProp(common_properties::_CIPCode));
+    m->getAtomWithIdx(3)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="S");
 
     MolOps::addHs(*m);
@@ -1589,8 +1589,8 @@ void testIssue2762917(){
     TEST_ASSERT(m->getAtomWithIdx(3)->getChiralTag()==Atom::CHI_TETRAHEDRAL_CCW);
     MolOps::assignStereochemistry(*m,true);
 
-    TEST_ASSERT(m->getAtomWithIdx(3)->hasProp("_CIPCode"));
-    m->getAtomWithIdx(3)->getProp("_CIPCode",cip);
+    TEST_ASSERT(m->getAtomWithIdx(3)->hasProp(common_properties::_CIPCode));
+    m->getAtomWithIdx(3)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="S");
 
     delete m;
@@ -1608,12 +1608,12 @@ void testIssue2762917(){
 
     MolOps::assignStereochemistry(*m,true);
 
-    TEST_ASSERT(m->getAtomWithIdx(0)->hasProp("_CIPCode"));
-    m->getAtomWithIdx(0)->getProp("_CIPCode",cip);
+    TEST_ASSERT(m->getAtomWithIdx(0)->hasProp(common_properties::_CIPCode));
+    m->getAtomWithIdx(0)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="S");
 
-    TEST_ASSERT(m->getAtomWithIdx(1)->hasProp("_CIPCode"));
-    m->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+    TEST_ASSERT(m->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+    m->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="S");
 
     MolOps::addHs(*m);
@@ -1623,12 +1623,12 @@ void testIssue2762917(){
 
     MolOps::assignStereochemistry(*m,true);
 
-    TEST_ASSERT(m->getAtomWithIdx(0)->hasProp("_CIPCode"));
-    m->getAtomWithIdx(0)->getProp("_CIPCode",cip);
+    TEST_ASSERT(m->getAtomWithIdx(0)->hasProp(common_properties::_CIPCode));
+    m->getAtomWithIdx(0)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="S");
 
-    TEST_ASSERT(m->getAtomWithIdx(1)->hasProp("_CIPCode"));
-    m->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+    TEST_ASSERT(m->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+    m->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="S");
 
     delete m;
@@ -1646,8 +1646,8 @@ void testIssue2762917(){
 
     MolOps::assignStereochemistry(*m,true);
 
-    TEST_ASSERT(m->getAtomWithIdx(3)->hasProp("_CIPCode"));
-    m->getAtomWithIdx(3)->getProp("_CIPCode",cip);
+    TEST_ASSERT(m->getAtomWithIdx(3)->hasProp(common_properties::_CIPCode));
+    m->getAtomWithIdx(3)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="S");
 
     MolOps::addHs(*m);
@@ -1655,8 +1655,8 @@ void testIssue2762917(){
     TEST_ASSERT(m->getAtomWithIdx(3)->getChiralTag()==Atom::CHI_TETRAHEDRAL_CCW);
     MolOps::assignStereochemistry(*m,true);
 
-    TEST_ASSERT(m->getAtomWithIdx(3)->hasProp("_CIPCode"));
-    m->getAtomWithIdx(3)->getProp("_CIPCode",cip);
+    TEST_ASSERT(m->getAtomWithIdx(3)->hasProp(common_properties::_CIPCode));
+    m->getAtomWithIdx(3)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="S");
 
     delete m;
@@ -1680,8 +1680,8 @@ void testIssue3009911(){
     MolOps::assignStereochemistry(*m,true);
     for(unsigned int i=0;i<m->getNumAtoms();++i){
       int rank;
-      TEST_ASSERT(m->getAtomWithIdx(i)->hasProp("_CIPRank"))
-      m->getAtomWithIdx(i)->getProp("_CIPRank",rank);
+      TEST_ASSERT(m->getAtomWithIdx(i)->hasProp(common_properties::_CIPRank))
+      m->getAtomWithIdx(i)->getProp(common_properties::_CIPRank,rank);
       ranks[i]=rank;
     }
     // basics:
@@ -1692,8 +1692,8 @@ void testIssue3009911(){
     TEST_ASSERT(ranks[3]<ranks[9]);
 
     std::string cip;
-    TEST_ASSERT(m->getAtomWithIdx(1)->hasProp("_CIPCode"));
-    m->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+    TEST_ASSERT(m->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+    m->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="R");
     delete m;
     delete [] ranks;
@@ -1708,8 +1708,8 @@ void testIssue3009911(){
     MolOps::assignStereochemistry(*m,true);
     for(unsigned int i=0;i<m->getNumAtoms();++i){
       int rank;
-      TEST_ASSERT(m->getAtomWithIdx(i)->hasProp("_CIPRank"))
-      m->getAtomWithIdx(i)->getProp("_CIPRank",rank);
+      TEST_ASSERT(m->getAtomWithIdx(i)->hasProp(common_properties::_CIPRank))
+      m->getAtomWithIdx(i)->getProp(common_properties::_CIPRank,rank);
       ranks[i]=rank;
     }
     // basics:
@@ -1720,8 +1720,8 @@ void testIssue3009911(){
     // due to a weakness in the CIP-ranking algorithm.
     //TEST_ASSERT(ranks[2]>ranks[9]);
     std::string cip;
-    TEST_ASSERT(m->getAtomWithIdx(6)->hasProp("_CIPCode"));
-    m->getAtomWithIdx(6)->getProp("_CIPCode",cip);
+    TEST_ASSERT(m->getAtomWithIdx(6)->hasProp(common_properties::_CIPCode));
+    m->getAtomWithIdx(6)->getProp(common_properties::_CIPCode,cip);
     //TEST_ASSERT(cip=="R");
 
     delete m;
@@ -1837,21 +1837,21 @@ void testFindChiralAtoms(){
     m = SmilesToMol(smiles);
     TEST_ASSERT(m);
     MolOps::assignStereochemistry(*m,true,true);
-    TEST_ASSERT(m->getAtomWithIdx(1)->hasProp("_CIPCode"));
-    TEST_ASSERT(!(m->getAtomWithIdx(3)->hasProp("_CIPCode")));
-    TEST_ASSERT(!(m->getAtomWithIdx(6)->hasProp("_CIPCode")));
-    TEST_ASSERT(!m->getAtomWithIdx(1)->hasProp("_ChiralityPossible"));
-    TEST_ASSERT(!m->getAtomWithIdx(3)->hasProp("_ChiralityPossible"));
-    TEST_ASSERT(!(m->getAtomWithIdx(6)->hasProp("_ChiralityPossible")));
+    TEST_ASSERT(m->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+    TEST_ASSERT(!(m->getAtomWithIdx(3)->hasProp(common_properties::_CIPCode)));
+    TEST_ASSERT(!(m->getAtomWithIdx(6)->hasProp(common_properties::_CIPCode)));
+    TEST_ASSERT(!m->getAtomWithIdx(1)->hasProp(common_properties::_ChiralityPossible));
+    TEST_ASSERT(!m->getAtomWithIdx(3)->hasProp(common_properties::_ChiralityPossible));
+    TEST_ASSERT(!(m->getAtomWithIdx(6)->hasProp(common_properties::_ChiralityPossible)));
 
     // but we can force it:
     MolOps::assignStereochemistry(*m,true,true,true);
-    TEST_ASSERT(m->getAtomWithIdx(1)->hasProp("_CIPCode"));
-    TEST_ASSERT(!(m->getAtomWithIdx(3)->hasProp("_CIPCode")));
-    TEST_ASSERT(!(m->getAtomWithIdx(6)->hasProp("_CIPCode")));
-    TEST_ASSERT(m->getAtomWithIdx(1)->hasProp("_ChiralityPossible"));
-    TEST_ASSERT(m->getAtomWithIdx(3)->hasProp("_ChiralityPossible"));
-    TEST_ASSERT(!(m->getAtomWithIdx(6)->hasProp("_ChiralityPossible")));
+    TEST_ASSERT(m->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+    TEST_ASSERT(!(m->getAtomWithIdx(3)->hasProp(common_properties::_CIPCode)));
+    TEST_ASSERT(!(m->getAtomWithIdx(6)->hasProp(common_properties::_CIPCode)));
+    TEST_ASSERT(m->getAtomWithIdx(1)->hasProp(common_properties::_ChiralityPossible));
+    TEST_ASSERT(m->getAtomWithIdx(3)->hasProp(common_properties::_ChiralityPossible));
+    TEST_ASSERT(!(m->getAtomWithIdx(6)->hasProp(common_properties::_ChiralityPossible)));
     
     delete m;
   }
@@ -1995,8 +1995,8 @@ void testGithub90(){
     MolOps::assignStereochemistry(*m,true,true);
 
     std::string cip;
-    TEST_ASSERT(m->getAtomWithIdx(1)->hasProp("_CIPCode"));
-    m->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+    TEST_ASSERT(m->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+    m->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="R");
     delete m;
   }
@@ -2009,8 +2009,8 @@ void testGithub90(){
     MolOps::assignStereochemistry(*m,true,true);
 
     std::string cip;
-    TEST_ASSERT(m->getAtomWithIdx(1)->hasProp("_CIPCode"));
-    m->getAtomWithIdx(1)->getProp("_CIPCode",cip);
+    TEST_ASSERT(m->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+    m->getAtomWithIdx(1)->getProp(common_properties::_CIPCode,cip);
     TEST_ASSERT(cip=="S");
     delete m;
   }
@@ -2021,7 +2021,7 @@ void testGithub90(){
     TEST_ASSERT(m->getNumAtoms()==4);
     TEST_ASSERT(m->getAtomWithIdx(1)->getChiralTag()==Atom::CHI_UNSPECIFIED);
     MolOps::assignStereochemistry(*m,true,true);
-    TEST_ASSERT(!m->getAtomWithIdx(1)->hasProp("_CIPCode"));
+    TEST_ASSERT(!m->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
     delete m;
   }
   {

--- a/Code/GraphMol/testPickler.cpp
+++ b/Code/GraphMol/testPickler.cpp
@@ -332,14 +332,14 @@ void testQueries(){
   smi="C";
   m1= SmilesToMol(smi);
   TEST_ASSERT(m1);
-  m1->getAtomWithIdx(0)->setProp("molAtomMapNumber",1);
+  m1->getAtomWithIdx(0)->setProp(common_properties::molAtomMapNumber,1);
   MolPickler::pickleMol(*m1,pickle);
   delete m1;
   m1 = new ROMol();
   MolPickler::molFromPickle(pickle,*m1);
   TEST_ASSERT(m1->getNumAtoms()==1);
-  TEST_ASSERT(m1->getAtomWithIdx(0)->hasProp("molAtomMapNumber"));
-  m1->getAtomWithIdx(0)->getProp("molAtomMapNumber",tmpInt);
+  TEST_ASSERT(m1->getAtomWithIdx(0)->hasProp(common_properties::molAtomMapNumber));
+  m1->getAtomWithIdx(0)->getProp(common_properties::molAtomMapNumber,tmpInt);
   TEST_ASSERT(tmpInt==1);
   delete m1;
 
@@ -779,8 +779,8 @@ void testIssue3316407(){
       TEST_ASSERT(m->getAtomWithIdx(i)->getImplicitValence()==m2->getAtomWithIdx(i)->getImplicitValence());
     }
     // part of sf.net issue 285:
-    TEST_ASSERT(m2->getAtomWithIdx(3)->hasProp("dummyLabel"));
-    TEST_ASSERT(m2->getAtomWithIdx(4)->hasProp("dummyLabel"));
+    TEST_ASSERT(m2->getAtomWithIdx(3)->hasProp(common_properties::dummyLabel));
+    TEST_ASSERT(m2->getAtomWithIdx(4)->hasProp(common_properties::dummyLabel));
     
     delete m;
     delete m2;
@@ -857,20 +857,20 @@ void testIssue280(){
     ROMol *m1 = SmilesToMol("CCC");
     TEST_ASSERT(m1);
     std::string v="1";
-    m1->getAtomWithIdx(0)->setProp("molAtomMapNumber",v);
+    m1->getAtomWithIdx(0)->setProp(common_properties::molAtomMapNumber,v);
     // ints still work
-    m1->getAtomWithIdx(1)->setProp("molAtomMapNumber",2);
+    m1->getAtomWithIdx(1)->setProp(common_properties::molAtomMapNumber,2);
     
     std::string pickle;
     MolPickler::pickleMol(*m1,pickle);
     RWMol *m2 = new RWMol(pickle);
     TEST_ASSERT(m2);
-    TEST_ASSERT(m2->getAtomWithIdx(0)->hasProp("molAtomMapNumber"));
-    TEST_ASSERT(m2->getAtomWithIdx(1)->hasProp("molAtomMapNumber"));
+    TEST_ASSERT(m2->getAtomWithIdx(0)->hasProp(common_properties::molAtomMapNumber));
+    TEST_ASSERT(m2->getAtomWithIdx(1)->hasProp(common_properties::molAtomMapNumber));
     int iv;
-    m2->getAtomWithIdx(0)->getProp("molAtomMapNumber",iv);
+    m2->getAtomWithIdx(0)->getProp(common_properties::molAtomMapNumber,iv);
     TEST_ASSERT(iv==1);
-    m2->getAtomWithIdx(1)->getProp("molAtomMapNumber",iv);
+    m2->getAtomWithIdx(1)->getProp(common_properties::molAtomMapNumber,iv);
     TEST_ASSERT(iv==2);
     delete m1;
     delete m2;
@@ -880,13 +880,13 @@ void testIssue280(){
     ROMol *m1 = SmilesToMol("CC");
     TEST_ASSERT(m1);
     std::string v="foo";
-    m1->getAtomWithIdx(0)->setProp("molAtomMapNumber",v);
+    m1->getAtomWithIdx(0)->setProp(common_properties::molAtomMapNumber,v);
 
     std::string pickle;
     MolPickler::pickleMol(*m1,pickle);
     RWMol *m2 = new RWMol(pickle);
     TEST_ASSERT(m2);
-    TEST_ASSERT(!m2->getAtomWithIdx(0)->hasProp("molAtomMapNumber"));
+    TEST_ASSERT(!m2->getAtomWithIdx(0)->hasProp(common_properties::molAtomMapNumber));
     delete m1;
     delete m2;
   }
@@ -902,14 +902,14 @@ void testIssue285(){
     ROMol *m1 = SmilesToMol("*C");
     TEST_ASSERT(m1);
     std::string v="R";
-    m1->getAtomWithIdx(0)->setProp("dummyLabel",v);
+    m1->getAtomWithIdx(0)->setProp(common_properties::dummyLabel,v);
     
     std::string pickle;
     MolPickler::pickleMol(*m1,pickle);
     RWMol *m2 = new RWMol(pickle);
     TEST_ASSERT(m2);
-    TEST_ASSERT(m2->getAtomWithIdx(0)->hasProp("dummyLabel"));
-    m2->getAtomWithIdx(0)->getProp("dummyLabel",v);
+    TEST_ASSERT(m2->getAtomWithIdx(0)->hasProp(common_properties::dummyLabel));
+    m2->getAtomWithIdx(0)->getProp(common_properties::dummyLabel,v);
     TEST_ASSERT(v=="R");
     delete m1;
     delete m2;

--- a/Code/RDGeneral/Dict.cpp
+++ b/Code/RDGeneral/Dict.cpp
@@ -71,6 +71,46 @@ namespace RDKit{
     }
   };
 
+    bool Dict::getValIfPresent(const std::string &what, std::string &res) const {
+    //
+    //  We're going to try and be somewhat crafty about this getVal stuff to make these
+    //  containers a little bit more generic.  The normal behavior here is that the
+    //  value being queried must be directly castable to type T.  We'll robustify a
+    //  little bit by trying that and, if the cast fails, attempting a couple of 
+    //  other casts, which will then be lexically cast to type T.
+    //
+    DataType::const_iterator pos=_data.find(what);
+    if (pos==_data.end())
+      return false;
+    const boost::any &val = pos->second;
+    try{
+      res = boost::any_cast<std::string>(val);
+    } catch (const boost::bad_any_cast &) {
+      if(val.type()==typeid(int)){
+        res = boost::lexical_cast<std::string>(boost::any_cast<int>(val));
+      } else if(val.type()==typeid(unsigned int)){
+        res = boost::lexical_cast<std::string>(boost::any_cast<unsigned int>(val));
+      } else if(val.type()==typeid(long)){
+        res = boost::lexical_cast<std::string>(boost::any_cast<long>(val));
+      } else if(val.type()==typeid(unsigned long)){
+        res = boost::lexical_cast<std::string>(boost::any_cast<unsigned long>(val));
+      } else if(val.type()==typeid(float)){
+        res = boost::lexical_cast<std::string>(boost::any_cast<float>(val));
+      } else if(val.type()==typeid(double)){
+        res = boost::lexical_cast<std::string>(boost::any_cast<double>(val));
+      } else if(val.type()==typeid(const char *)){
+        res = std::string(boost::any_cast<const char *>(val));
+      } else if(val.type()==typeid(std::vector<unsigned int>)){
+        res = vectToString<unsigned int>(val);
+      } else if(val.type()==typeid(std::vector<int>)){
+        res = vectToString<int>(val);
+      } else {
+        return false;
+      }
+    }
+    return true;
+  };
+
   namespace {
     template <class T>
     typename boost::enable_if<boost::is_arithmetic<T>, T>::type 

--- a/Code/RDGeneral/Dict.h
+++ b/Code/RDGeneral/Dict.h
@@ -116,6 +116,44 @@ namespace RDKit{
     void getVal(const char *what, std::string &res) const { getVal(std::string(what),res); };
 
     //----------------------------------------------------------
+    //! \brief Potentially gets the value associated with a particular key
+    //!        returns true on success/false on failure.
+    /*!
+       \param what  the key to lookup
+       \param res   a reference used to return the result
+    
+       <B>Notes:</b>
+        - If \c res is a \c std::string, every effort will be made
+          to convert the specified element to a string using the
+          \c boost::lexical_cast machinery.
+        - If the dictionary does not contain the key \c what,
+          a KeyErrorException will be thrown.
+    */
+
+    template <typename T>
+    bool getValIfPresent(const std::string &what,T &res) const {
+      DataType::const_iterator pos=_data.find(what);
+      if(pos==_data.end())
+	return false;
+      const boost::any &val = pos->second;
+      res = fromany<T>(val);
+      return true;
+    };
+
+    template <typename T>
+    bool getValIfPresent(const char *what,T &res) const {
+      std::string key(what);
+      return getValIfPresent<T>(key, res);
+    };
+
+    //! \overload
+    bool getValIfPresent(const std::string &what, std::string &res) const;
+    //! \overload
+    bool getValIfPresent(const char *what, std::string &res) const {
+      return getValIfPresent(std::string(what),res);
+    };
+    
+    //----------------------------------------------------------
     //! \brief Sets the value associated with a key
     /*!
       

--- a/Code/RDGeneral/types.cpp
+++ b/Code/RDGeneral/types.cpp
@@ -15,6 +15,84 @@
 #include "types.h"
 
 namespace RDKit{
+    namespace common_properties {
+        const std::string TWOD = "2D";
+        const std::string BalabanJ = "BalabanJ";
+        const std::string BalanbanJ = "BalanbanJ";
+        const std::string Discrims = "Discrims";
+        const std::string DistanceMatrix_Paths = "DistanceMatrix_Paths";
+        const std::string MolFileComments = "MolFileComments";
+        const std::string MolFileInfo = "MolFileInfo";
+        const std::string NullBond = "NullBond";
+        const std::string _2DConf = "_2DConf";
+        const std::string _3DConf = "_3DConf";
+        const std::string _AtomID = "_AtomID";
+        const std::string _BondsPotentialStereo = "_BondsPotentialStereo";
+        const std::string _CIPCode = "_CIPCode";
+        const std::string _CIPRank = "_CIPRank";
+        const std::string _ChiralityPossible = "_ChiralityPossible";
+        const std::string _CrippenLogP = "_CrippenLogP";
+        const std::string _CrippenMR = "_CrippenMR";
+        const std::string _MMFFSanitized = "_MMFFSanitized";
+        const std::string _MolFileChiralFlag = "_MolFileChiralFlag";
+        const std::string _MolFileRLabel = "_MolFileRLabel";
+        const std::string _Name = "_Name";
+        const std::string _NeedsQueryScan = "_NeedsQueryScan";
+        const std::string _QueryFormalCharge = "_QueryFormalCharge";
+        const std::string _QueryHCount = "_QueryHCount";
+        const std::string _QueryIsotope = "_QueryIsotope";
+        const std::string _QueryMass = "_QueryMass";
+        const std::string _ReactionDegreeChanged = "_ReactionDegreeChanged";
+        const std::string _RingClosures = "_RingClosures";
+        const std::string _SLN_s = "_SLN_s";
+        const std::string _SmilesStart = "_SmilesStart";
+        const std::string _StereochemDone = "_StereochemDone";
+        const std::string _TraversalBondIndexOrder = "_TraversalBondIndexOrder";
+        const std::string _TraversalRingClosureBond = "_TraversalRingClosureBond";
+        const std::string _TriposAtomType = "_TriposAtomType";
+        const std::string _Unfinished_SLN_ = "_Unfinished_SLN_";
+        const std::string _UnknownStereo = "_UnknownStereo";
+        const std::string _connectivityHKDeltas = "_connectivityHKDeltas";
+        const std::string _connectivityNVals = "_connectivityNVals";
+        const std::string _crippenLogP = "_crippenLogP";
+        const std::string _crippenLogPContribs = "_crippenLogPContribs";
+        const std::string _crippenMR = "_crippenMR";
+        const std::string _crippenMRContribs = "_crippenMRContribs";
+        const std::string _doIsoSmiles = "_doIsoSmiles";
+        const std::string _fragSMARTS = "_fragSMARTS";
+        const std::string _hasMassQuery = "_hasMassQuery";
+        const std::string _labuteASA = "_labuteASA";
+        const std::string _labuteAtomContribs = "_labuteAtomContribs";
+        const std::string _labuteAtomHContrib = "_labuteAtomHContrib";
+        const std::string _protected = "_protected";
+        const std::string _queryRootAtom = "_queryRootAtom";
+        const std::string _ringStereoAtoms = "_ringStereoAtoms";
+        const std::string _ringStereoWarning = "_ringStereoWarning";
+        const std::string _ringStereochemCand = "_ringStereochemCand";
+        const std::string _smilesAtomOutputOrder = "_smilesAtomOutputOrder";
+        const std::string _starred = "_starred";
+        const std::string _supplementalSmilesLabel = "_supplementalSmilesLabel";
+        const std::string _tpsa = "_tpsa";
+        const std::string _tpsaAtomContribs = "_tpsaAtomContribs";
+        const std::string _unspecifiedOrder = "_unspecifiedOrder";
+        const std::string dummyLabel = "dummyLabel";
+        const std::string extraRings = "extraRings";
+        const std::string isImplicit = "isImplicit";
+        const std::string maxAttachIdx = "maxAttachIdx";
+        const std::string molAtomMapNumber = "molAtomMapNumber";
+        const std::string molFileAlias = "molFileAlias";
+        const std::string molFileValue = "molFileValue";
+        const std::string molInversionFlag = "molInversionFlag";
+        const std::string molParity = "molParity";
+        const std::string molRxnComponent = "molRxnComponent";
+        const std::string molRxnRole = "molRxnRole";
+        const std::string molTotValence = "molTotValence";
+        const std::string numArom = "numArom";
+        const std::string origNoImplicit = "origNoImplicit";
+        const std::string ringMembership = "ringMembership";
+        const std::string smilesSymbol = "smilesSymbol";
+    } // end common_properties
+    
 //  template <typename T>
 //  T larger_of(T arg1,T arg2) { return arg1>arg2 ? arg1 : arg2; };
 

--- a/Code/RDGeneral/types.h
+++ b/Code/RDGeneral/types.h
@@ -43,7 +43,83 @@ namespace detail {
 
 
 namespace RDKit {
-
+    namespace common_properties {
+        extern const std::string TWOD;
+        extern const std::string BalabanJ;
+        extern const std::string BalanbanJ;
+        extern const std::string Discrims;
+        extern const std::string DistanceMatrix_Paths;
+        extern const std::string MolFileComments;
+        extern const std::string MolFileInfo;
+        extern const std::string NullBond;
+        extern const std::string _2DConf;
+        extern const std::string _3DConf;
+        extern const std::string _AtomID;
+        extern const std::string _BondsPotentialStereo;
+        extern const std::string _CIPCode;
+        extern const std::string _CIPRank;
+        extern const std::string _ChiralityPossible;
+        extern const std::string _CrippenLogP;
+        extern const std::string _CrippenMR;
+        extern const std::string _MMFFSanitized;
+        extern const std::string _MolFileChiralFlag;
+        extern const std::string _MolFileRLabel;
+        extern const std::string _Name;
+        extern const std::string _NeedsQueryScan;
+        extern const std::string _QueryFormalCharge;
+        extern const std::string _QueryHCount;
+        extern const std::string _QueryIsotope;
+        extern const std::string _QueryMass;
+        extern const std::string _ReactionDegreeChanged;
+        extern const std::string _RingClosures;
+        extern const std::string _SLN_s;
+        extern const std::string _SmilesStart;
+        extern const std::string _StereochemDone;
+        extern const std::string _TraversalBondIndexOrder;
+        extern const std::string _TraversalRingClosureBond;
+        extern const std::string _TriposAtomType;
+        extern const std::string _Unfinished_SLN_;
+        extern const std::string _UnknownStereo;
+        extern const std::string _connectivityHKDeltas;
+        extern const std::string _connectivityNVals;
+        extern const std::string _crippenLogP;
+        extern const std::string _crippenLogPContribs;
+        extern const std::string _crippenMR;
+        extern const std::string _crippenMRContribs;
+        extern const std::string _doIsoSmiles;
+        extern const std::string _fragSMARTS;
+        extern const std::string _hasMassQuery;
+        extern const std::string _labuteASA;
+        extern const std::string _labuteAtomContribs;
+        extern const std::string _labuteAtomHContrib;
+        extern const std::string _protected;
+        extern const std::string _queryRootAtom;
+        extern const std::string _ringStereoAtoms;
+        extern const std::string _ringStereoWarning;
+        extern const std::string _ringStereochemCand;
+        extern const std::string _smilesAtomOutputOrder;
+        extern const std::string _starred;
+        extern const std::string _supplementalSmilesLabel;
+        extern const std::string _tpsa;
+        extern const std::string _tpsaAtomContribs;
+        extern const std::string _unspecifiedOrder;
+        extern const std::string dummyLabel;
+        extern const std::string extraRings;
+        extern const std::string isImplicit;
+        extern const std::string maxAttachIdx;
+        extern const std::string molAtomMapNumber;
+        extern const std::string molFileAlias;
+        extern const std::string molFileValue;
+        extern const std::string molInversionFlag;
+        extern const std::string molParity;
+        extern const std::string molRxnComponent;
+        extern const std::string molRxnRole;
+        extern const std::string molTotValence;
+        extern const std::string numArom;
+        extern const std::string origNoImplicit;
+        extern const std::string ringMembership;
+        extern const std::string smilesSymbol;
+    } // end common_properties
 #ifndef WIN32
   typedef long long int LONGINT;
 #else


### PR DESCRIPTION
 o rdkit gains a RDKit::common_properties namespace that contains common string value properties

 o Dict.h and users (Atom.h) gain getPropIfPresent that attempts to retrieve a property and returns
  true/false on success or failure.  This is used to optimize access.

 o rdkit learns how to pass property keys by reference, not value.

A new namespace has been added to RDKit, common_properties that contains the std::string values for commonly used properties.  This helps to avoid typos in string values but also avoids a creation of std::strings from character values.  All accessors (has/get/clear and getPropIfPresent) now pass the key by reference to avoid copying.

Additionally, getPropIfPresent removes the double lookup of hasProp/getProp which can be a significant speedup in the smiles and smarts parsers (10-20%)

The original goal was to see if the speed of smiles parsing could be improved.  The following table is a result of running SmiToMol on ~50K compounds with and without the dictionary optimizations.  For kicks, we also compare usage of JEMALLOC(OSX) and TCMALLOC(Centos5) to see if small object memory allocation could also be improved:

OSX 10.9.5 -  2.3 GHZ core i7
Centos5 - Intel(R) Xeon(R) CPU E5-2620 0 @ 2.00GHz

OSX      | original  | optimized  | original+jemalloc    | optimized+jemalloc
------   | --------  | ---------  | -----------------    | ------------------
secs     | 2.25      | 2.08       | 1.5                  | 1.302
cmds/sec | 22218     | 24034      | 33327                | 38395   
speedup  | 1         | 1.08       | 1.5                  | 1.73
                
Centos5  |original  |optimized  |original+tcmalloc  |optimized+tcmalloc
------   |--------  |---------  |-----------------  |------------------
secs     |3.04      |2.551      |2.22               |1.87
cmds/sec |16444     |19596      |22518              |26733   
speedup  |1         |1.19       |1.37               |1.63
