### PR TITLE
RDKit learns how to round grip MOLFile values.

### DIFF
--- a/Code/GraphMol/ChemReactions/testReaction.cpp
+++ b/Code/GraphMol/ChemReactions/testReaction.cpp
@@ -5455,6 +5455,103 @@ void test57IntroductionOfNewChiralCenters(){
   BOOST_LOG(rdInfoLog) << "\tdone" << std::endl;
 }
 
+void test58MolFileValueRoundTrip(){
+  ChemicalReaction *rxn;
+    
+  BOOST_LOG(rdInfoLog) << "-------------------------------------" << std::endl;
+  BOOST_LOG(rdInfoLog) << "Testing round trip molFileValue" << std::endl;
+
+  
+  const char *rxnB="$RXN\n" \
+    "\n"                        \
+    "      ISIS     090220091541\n"               \
+    "\n"                                          \
+    "  2  1\n"                                    \
+    "$MOL\n"                                      \
+    "\n"                                          \
+    "  -ISIS-  09020915412D\n"                    \
+    "\n"                                          \
+    "  3  2  0  0  0  0  0  0  0  0999 V2000\n"                           \
+    "   -2.9083   -0.4708    0.0000 R#  0  0  0  0  0  0  0  0  0  1  0  0\n" \
+    "   -2.3995   -0.1771    0.0000 C   0  0  0  0  0  0  0  0  0  2  0  0\n" \
+    "   -2.4042    0.4125    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0\n" \
+    "  1  2  1  0  0  0  0\n"                                             \
+    "  2  3  2  0  0  0  0\n"                                             \
+    "V    2 aldehyde\n"                                                   \
+    "M  RGP  1   1   1\n"                                                 \
+    "M  END\n"                                                            \
+    "$MOL\n"                                                              \
+    "\n"                                                                  \
+    "  -ISIS-  09020915412D\n"                                            \
+    "\n"                                                                  \
+    "  2  1  0  0  0  0  0  0  0  0999 V2000\n"                           \
+    "    2.8375   -0.2500    0.0000 R#  0  0  0  0  0  0  0  0  0  3  0  0\n" \
+    "    3.3463    0.0438    0.0000 N   0  0  0  0  0  0  0  0  0  4  0  0\n" \
+    "  1  2  1  0  0  0  0\n"                                             \
+    "V    2 aldehyde\n"                                                      \
+    "M  RGP  1   1   2\n"                                                 \
+    "M  END\n"                                                            \
+    "$MOL\n"                                                              \
+    "\n"                                                                  \
+    "  -ISIS-  09020915412D\n"                                            \
+    "\n"                                                                  \
+    "  4  3  0  0  0  0  0  0  0  0999 V2000\n"                           \
+    "   13.3088    0.9436    0.0000 C   0  0  0  0  0  0  0  0  0  2  0  0\n" \
+    "   13.8206    1.2321    0.0000 R#  0  0  0  0  0  0  0  0  0  1  0  0\n" \
+    "   13.3028    0.3561    0.0000 N   0  0  0  0  0  0  0  0  0  4  0  0\n" \
+    "   12.7911    0.0676    0.0000 R#  0  0  0  0  0  0  0  0  0  3  0  0\n" \
+    "  1  3  1  0  0  0  0\n"                                             \
+    "  1  2  1  0  0  0  0\n"                                             \
+    "  3  4  1  0  0  0  0\n"                                             \
+    "M  RGP  2   2   1   4   2\n"                                         \
+    "M  END";
+  
+  rxn = RxnBlockToChemicalReaction(rxnB);
+  // ensure we have mol file values
+  bool found = false;
+  for (MOL_SPTR_VECT::const_iterator template_mol = rxn->beginReactantTemplates();
+       template_mol != rxn->endReactantTemplates(); ++template_mol)
+    {
+      for(ROMol::AtomIterator atIt=template_mol->get()->beginAtoms();
+          atIt!=template_mol->get()->endAtoms();++atIt){
+        if ((*atIt)->getIdx() == 1) {
+          found = true;
+          TEST_ASSERT((*atIt)->hasProp(common_properties::molFileValue));
+          TEST_ASSERT((*atIt)->getProp<std::string>(common_properties::molFileValue) ==
+                      "aldehyde");
+        }
+        
+      }
+    }
+  TEST_ASSERT(found);
+
+  found = false;  
+  ChemicalReaction *rxn2 = RxnBlockToChemicalReaction(ChemicalReactionToRxnBlock(*rxn));
+
+  for (MOL_SPTR_VECT::const_iterator template_mol = rxn2->beginReactantTemplates();
+       template_mol != rxn2->endReactantTemplates(); ++template_mol)
+    {
+      for(ROMol::AtomIterator atIt=template_mol->get()->beginAtoms();
+          atIt!=template_mol->get()->endAtoms();++atIt){
+        if ((*atIt)->getIdx() == 1) {
+          found = true;
+          TEST_ASSERT((*atIt)->hasProp(common_properties::molFileValue));
+          TEST_ASSERT((*atIt)->getProp<std::string>(common_properties::molFileValue) ==
+                      "aldehyde");
+        }
+        
+      }
+    }
+  
+  delete rxn;
+  delete rxn2;
+  
+  TEST_ASSERT(found);
+
+  
+  BOOST_LOG(rdInfoLog) << "\tdone" << std::endl;
+}
+
 int main() { 
   RDLog::InitLogs();
     
@@ -5523,6 +5620,8 @@ int main() {
   test56TestOldPickleVersion();
   test57IntroductionOfNewChiralCenters();
 
+  test58MolFileValueRoundTrip();
+  
   BOOST_LOG(rdInfoLog) << "*******************************************************\n";
   return(0);
 }

--- a/Code/GraphMol/FileParsers/MolFileWriter.cpp
+++ b/Code/GraphMol/FileParsers/MolFileWriter.cpp
@@ -258,10 +258,17 @@ namespace RDKit{
     }    
     for(ROMol::ConstAtomIterator atomIt=mol.beginAtoms();
 	atomIt!=mol.endAtoms();++atomIt){
+      bool wrote_query = false;
       if(!listQs[(*atomIt)->getIdx()] && hasComplexQuery(*atomIt)){
-	std::string sma=SmartsWrite::GetAtomSmarts(static_cast<const QueryAtom *>(*atomIt));
-	ss<< "V  "<<std::setw(3)<<(*atomIt)->getIdx()+1<<" "<<sma<<std::endl;
+        std::string sma=SmartsWrite::GetAtomSmarts(static_cast<const QueryAtom *>(*atomIt));
+        ss<< "V  "<<std::setw(3)<<(*atomIt)->getIdx()+1<<" "<<sma<<std::endl;
+        wrote_query = true;
       }
+      std::string molFileValue;
+      if (!wrote_query &&
+          (*atomIt)->getPropIfPresent(common_properties::molFileValue,
+                                      molFileValue))
+        ss<< "V  "<<std::setw(3)<<(*atomIt)->getIdx()+1<<" "<<molFileValue<<std::endl;
     }
     for(ROMol::ConstAtomIterator atomIt=mol.beginAtoms();
 	atomIt!=mol.endAtoms();++atomIt){


### PR DESCRIPTION
I was running into an issue where round-tripping a rxn block lost the mol file values.

This preserves them if they have not been converted into a smarts query.

n.b. the if statement is missing braces and I might add them back in for clarity.