### PR TITLE
Dev/expose rank atoms to python

### DIFF
--- a/Code/GraphMol/Wrap/rdmolfiles.cpp
+++ b/Code/GraphMol/Wrap/rdmolfiles.cpp
@@ -264,8 +264,9 @@ namespace RDKit{
     boost::dynamic_bitset<> atoms(mol.getNumAtoms());
     for(size_t i=0; i<avect->size(); ++i)
       atoms[(*avect)[i]] = true;
+    
     boost::dynamic_bitset<> bonds(mol.getNumBonds());
-    for(size_t i=0; i<bvect->size(); ++i)
+    for(size_t i=0; bvect && i<bvect->size(); ++i)
       bonds[(*bvect)[i]] = true;
     
     std::vector<int> ranks(mol.getNumAtoms());    
@@ -860,19 +861,25 @@ BOOST_PYTHON_MODULE(rdmolfiles)
 	       python::arg("confId")=-1,python::arg("flavor")=0),
 	      docString.c_str());
 
-  docString="Returns the canonical atom ranking for each atom of a molecule fragment\n\
+  docString="Returns the canonical atom ranking for each atom of a molecule fragment.\n\
+  If breakTies is False, this returns the symmetry class for each atom.  The symmetry\n\
+  class is used by the canonicalization routines to type each atom based on the whole\n\
+  chemistry of the molecular graph.  Any atom with the same rank (symmetry class) is\n\
+  indistinguishable.  For example:\n\
+\n\
+    > mol = MolFromSmiles('C1NCN1')\n\
+    > list(CanonicalRankAtoms(mol, breakTies=False))\n\
+    [0,1,0,1]\n\
+\n\
+  In this case the carbons have the same symmetry class and the nitrogens have the same\n\
+  symmetry class.  From the perspective of the Molecular Graph, they are indentical.\n\
+\n\
   ARGUMENTS:\n\
 \n\
     - mol: the molecule\n\
-    - atomsToUse : a list of atoms to include in the fragment\n\
-    - bondsToUse : (optional) a list of bonds to include in the fragment\n\
-                   if not provided, all bonds between the atoms provided\n\
-                   will be included.\n\
-    - atomSymbols : (optional) a list with the symbols to use for the atoms\n\
-                    in the SMILES. This should have be mol.GetNumAtoms() long.\n\
-    - bondSymbols : (optional) a list with the symbols to use for the bonds\n\
-                    in the SMILES. This should have be mol.GetNumBonds() long.\n\
-    - breakTies: (optional) force breaking of ranked ties\n\
+    - breakTies: (optional) force breaking of ranked ties [default=True]\n\
+    - includeChirality: (optional) use chiral information when computing rank [default=True]\n\
+    - includeIsotopes: (optional) use isotope information when computing rank [default=True]\n\
 \n\
   RETURNS:\n\
 \n\
@@ -886,6 +893,14 @@ BOOST_PYTHON_MODULE(rdmolfiles)
 	      docString.c_str());
   
   docString="Returns the canonical atom ranking for each atom of a molecule fragment\n\
+  See help(CanonicalRankAtoms) for more information.\n\
+\n\
+   > mol = MolFromSmiles('C1NCN1.C1NCN1')\n\
+   > list(CanonicalRankAtomsInFragment(mol, atomsToUse=range(0,4), breakTies=False))\n\
+   [0,1,0,1,-1,-1,-1,-1]\n\
+   > list(CanonicalRankAtomsInFragment(mol, atomsToUse=range(4,8), breakTies=False))\n\
+   [-1,-1,-1,-1,0,1,0,1]\n\
+\n\
   ARGUMENTS:\n\
 \n\
     - mol: the molecule\n\

--- a/Code/GraphMol/Wrap/rdmolfiles.cpp
+++ b/Code/GraphMol/Wrap/rdmolfiles.cpp
@@ -272,6 +272,14 @@ namespace RDKit{
     MolOps::rankAtomsInFragment(mol, ranks,
                                 atoms, bonds,
                                 asymbols, bsymbols, breakTies);
+
+    // set unused ranks to -1 for the Python interface
+    for(size_t i=0; i<atoms.size(); ++i)
+    {
+      if (!atoms[i])
+        ranks[i] = -1;
+    }
+    
     return ranks;
   }
 

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -2584,6 +2584,32 @@ CAS<~>
     self.assertEqual(len(cpa[0]),m.GetNumAtoms())
     print(cpa)
 
+  def test91RankAtoms(self):
+    m = Chem.MolFromSmiles('ONCS.ONCS')
+    ranks = Chem.CanonicalRankAtoms(m,breakTies=False)
+    self.assertEqual(list(ranks[0:4]), list(ranks[4:]))
+
+    m = Chem.MolFromSmiles("c1ccccc1")
+    ranks = Chem.CanonicalRankAtoms(m,breakTies=False)
+    for x in ranks:
+      self.assertEqual(x, 0)
+
+    m = Chem.MolFromSmiles("C1NCN1")
+    ranks = Chem.CanonicalRankAtoms(m,breakTies=False)
+    self.assertEqual(ranks[0], ranks[2])
+    self.assertEqual(ranks[1], ranks[3])
+    
+  def test91RankAtomsInFragment(self):
+    m = Chem.MolFromSmiles('ONCS.ONCS')
+    ranks = Chem.CanonicalRankAtomsInFragment(m,
+                                              [0,1,2,3],
+                                              [0,1,2])
+    
+    ranks2 = Chem.CanonicalRankAtomsInFragment(m,
+                                               [4,5,6,7],
+                                               [3,4,5])
+    self.assertEquals(list(ranks[0:4]),list(ranks2[4:]))
+
 
         
 if __name__ == '__main__':

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -2612,6 +2612,13 @@ CAS<~>
     self.assertEquals(list(ranks[4:]), [-1]*4)
     self.assertEquals(list(ranks2[0:4]), [-1]*4)
 
+    # doc tests
+    mol = Chem.MolFromSmiles('C1NCN1.C1NCN1')
+    self.assertEquals(list(Chem.CanonicalRankAtomsInFragment(mol, atomsToUse=range(0,4), breakTies=False)),
+                      [0,1,0,1,-1,-1,-1,-1])
+    self.assertEquals(list(Chem.CanonicalRankAtomsInFragment(mol, atomsToUse=range(4,8), breakTies=False)),
+                      [-1,-1,-1,-1,0,1,0,1])
+
 
         
 if __name__ == '__main__':

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -2609,6 +2609,8 @@ CAS<~>
                                                [4,5,6,7],
                                                [3,4,5])
     self.assertEquals(list(ranks[0:4]),list(ranks2[4:]))
+    self.assertEquals(list(ranks[4:]), [-1]*4)
+    self.assertEquals(list(ranks2[0:4]), [-1]*4)
 
 
         


### PR DESCRIPTION
Expose internal rankAtoms to Python.  This allows investigation of symmetry classes which is both useful from a computational science perspective and also to identify if two R-group positions can be identical during r-group analysis.