### PR TITLE
cairoCanvas.py python3 compatibility

### DIFF
--- a/rdkit/Chem/Draw/cairoCanvas.py
+++ b/rdkit/Chem/Draw/cairoCanvas.py
@@ -24,7 +24,7 @@ import math
 import rdkit.RDConfig
 import os,re
 import array
-if not os.environ.has_key('RDK_NOPANGO'):
+if not 'RDK_NOPANGO' in os.environ:
   try:
     import pangocairo
   except ImportError:


### PR DESCRIPTION
has_key() changed to in for python3 compatibility.

patch allowed running of Draw.MolsToGridImage in python3.4

probably relevant to #398