### PR TITLE
Increase limit for smallest ring size

### DIFF
--- a/Code/GraphMol/FindRings.cpp
+++ b/Code/GraphMol/FindRings.cpp
@@ -561,7 +561,7 @@ namespace FindRings {
     std::deque<int> bfsq;
     bfsq.push_back(root);
     int curr=-1;
-    unsigned int curSize=256;
+    unsigned int curSize=UINT_MAX;
     while (bfsq.size() > 0) {
       curr = bfsq.front();
       bfsq.pop_front();


### PR DESCRIPTION
Story: I have a PDB I want to read into RDKit. It has a disulfide bond
between two cysteines ~400 residues apart. This creates a very large
ring. RDKit throws an error because the number of found rings is less
than the expected number of rings. The ring wasn't found because RDKit
thought all "smallest" rings should be 256 or smaller.

Now, as long as your ring is UINT_MAX aka 4,294,967,295 or smaller, life
is beautiful. I hope no one has a ring bigger than 4 billion atoms.