### PR TITLE
Fixed a few tests failing when the Windows git client is used

### DIFF
--- a/Code/ChemicalFeatures/Wrap/testFeatures.py
+++ b/Code/ChemicalFeatures/Wrap/testFeatures.py
@@ -77,7 +77,7 @@ class TestCase(unittest.TestCase):
 
       # Check that the old pickled versions have not been broken        
       inF = open(os.path.join(RDConfig.RDBaseDir,
-                              'Code/ChemicalFeatures/Wrap/testData/feat.pkl'),'rb')
+                              'Code/ChemicalFeatures/Wrap/testData/feat.pkl'),'r')
       ffeat2=cPickle.load(inF, encoding='bytes')
       # this version (1.0) does not have an id in the byte stream 
       self.assertTrue(ffeat2.GetFamily()==ffeat.GetFamily())
@@ -90,7 +90,7 @@ class TestCase(unittest.TestCase):
       # data file
       #cPickle.dump(ffeat,file(os.path.join(RDConfig.RDBaseDir, 'Code/ChemicalFeatures/Wrap/testData/featv2.pkl'),'wb+'))
       inF = open(os.path.join(RDConfig.RDBaseDir,
-                              'Code/ChemicalFeatures/Wrap/testData/featv2.pkl'),'rb')
+                              'Code/ChemicalFeatures/Wrap/testData/featv2.pkl'),'r')
       ffeat2=cPickle.load(inF, encoding='bytes')
       self.assertTrue(ffeat2.GetId()==ffeat.GetId());
       self.assertTrue(ffeat2.GetFamily()==ffeat.GetFamily())

--- a/Code/DataStructs/Wrap/testDiscreteValueVect.py
+++ b/Code/DataStructs/Wrap/testDiscreteValueVect.py
@@ -130,7 +130,7 @@ class TestCase(unittest.TestCase):
     with open(
       os.path.join(RDConfig.RDBaseDir,
                    'Code/DataStructs/Wrap/testData/dvvs.pkl'),
-      'rb'
+      'r'
       ) as inF:
     
       v1 = ds.DiscreteValueVect(ds.DiscreteValueType.ONEBITVALUE, 30)

--- a/Code/DataStructs/Wrap/testSparseIntVect.py
+++ b/Code/DataStructs/Wrap/testSparseIntVect.py
@@ -87,7 +87,7 @@ class TestCase(unittest.TestCase):
     with open(
       os.path.join(RDConfig.RDBaseDir,
                    'Code/DataStructs/Wrap/testData/lsiv.pkl'), 
-      'rb'
+      'r'
       ) as f:
       v3 = cPickle.load(f)
       self.assertTrue(v3==v1)
@@ -115,7 +115,7 @@ class TestCase(unittest.TestCase):
     with open(
       os.path.join(RDConfig.RDBaseDir, 
                    'Code/DataStructs/Wrap/testData/isiv.pkl'),
-      'rb'
+      'r'
       ) as f:
       v3 = cPickle.load(f)
       self.assertTrue(v3==v1)

--- a/Code/GraphMol/FileParsers/testMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/testMolSupplier.cpp
@@ -1231,9 +1231,23 @@ void testIssue381() {
 void testSetStreamIndices() {
   std::string rdbase = getenv("RDBASE");
   std::string fname = rdbase + "/Code/GraphMol/FileParsers/test_data/NCI_aids_few.sdf";
-  int tmpIndices[16]={0, 2136, 6198, 8520, 11070, 12292, 14025, 15313, 17313, 20125, 22231,
-				     23729, 26147, 28331, 32541, 33991};
-  std::vector<std::streampos> indices(tmpIndices,tmpIndices+16);
+  std::ifstream ifs(fname.c_str(), std::ios_base::binary);
+  std::vector<std::streampos> indices;
+  bool addIndex = true;
+  bool notEof = true;
+  std::streampos pos = 0;
+  std::string line;
+  while (notEof) {
+    if (addIndex)
+      pos = ifs.tellg();
+    notEof = (std::getline(ifs, line) ? true : false);
+    if (notEof) {
+      if (addIndex)
+        indices.push_back(pos);
+      addIndex = (line.substr(0, 4) == "$$$$");
+    }
+  }
+  ifs.close();
   SDMolSupplier *sdsup;
 
   ROMol *nmol=0;  

--- a/Code/GraphMol/PartialCharges/Wrap/testPartialCharges.py
+++ b/Code/GraphMol/PartialCharges/Wrap/testPartialCharges.py
@@ -51,7 +51,7 @@ class TestCase(unittest.TestCase):
         infil.close()
 
         infile = os.path.join(RDConfig.RDBaseDir,'Code','GraphMol','PartialCharges','Wrap','test_data', 'PP_combi_charges.pkl')
-        with open(infile, 'rb') as cchFile:
+        with open(infile, 'r') as cchFile:
             combiCharges = pickle.load(cchFile)
 
         for lin in lines :

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -841,7 +841,7 @@ class TestCase(unittest.TestCase):
     self.assertTrue(m)
     self.assertTrue(m.GetNumAtoms()==30)
 
-    with open(fileN,'r') as dFile:
+    with open(fileN,'rb') as dFile:
       d = dFile.read()
     sdSup.SetData(d)
     m = six.next(sdSup)
@@ -1524,11 +1524,25 @@ CAS<~>
   def test41SetStreamIndices(self) :
     fileN = os.path.join(RDConfig.RDBaseDir,'Code','GraphMol','FileParsers',
                                             'test_data','NCI_aids_few.sdf')
+    allIndices = []
+    ifs = open(fileN, 'rb')
+    addIndex = True;
+    line = True;
+    pos = 0;
+    while (line):
+      if (addIndex):
+        pos = ifs.tell();
+      line = ifs.readline()
+      if (line):
+        if (addIndex):
+          allIndices.append(pos);
+        addIndex = (line[:4] == '$$$$')
+    ifs.close()
+    indices = allIndices
     sdSup = Chem.SDMolSupplier(fileN)
     molNames = ["48", "78", "128", "163", "164", "170", "180", "186",
             "192", "203", "210", "211", "213", "220", "229", "256"]
-    indices=[0, 2136, 6198, 8520, 11070, 12292, 14025, 15313, 17313, 20125, 22231,
-	     23729, 26147, 28331, 32541, 33991]
+    
     sdSup._SetStreamIndices(indices)
     self.assertTrue(len(sdSup) == 16)
     mol = sdSup[5]
@@ -1544,14 +1558,14 @@ CAS<~>
     self.assertTrue(ns == molNames)
 
     # this can also be used to skip molecules in the file:
-    indices=[0, 6198, 12292]
+    indices = [allIndices[0], allIndices[2], allIndices[5]]
     sdSup._SetStreamIndices(indices)
     self.assertTrue(len(sdSup) == 3)
     mol = sdSup[2]
     self.assertTrue(mol.GetProp("_Name") == "170")
 
     # or to reorder them:
-    indices=[0, 12292, 6198]
+    indices = [allIndices[0], allIndices[5], allIndices[2]]
     sdSup._SetStreamIndices(indices)
     self.assertTrue(len(sdSup) == 3)
     mol = sdSup[1]

--- a/Code/ML/InfoTheory/Wrap/testRanker.py
+++ b/Code/ML/InfoTheory/Wrap/testRanker.py
@@ -151,7 +151,7 @@ class TestCase(unittest.TestCase):
         self.assertTrue(res is not None)    
 
     def test4Issue237(self) :
-        with open(os.path.join(RDConfig.RDBaseDir,'Code','ML','InfoTheory','Wrap','testData','Issue237.pkl'),'rb') as inF:
+        with open(os.path.join(RDConfig.RDBaseDir,'Code','ML','InfoTheory','Wrap','testData','Issue237.pkl'),'r') as inF:
             examples,avail,bias,nB,nPoss = cPickle.load(inF, encoding='bytes')
         ranker = rdit.InfoBitRanker(nB,nPoss,rdit.InfoType.BIASENTROPY)
         ranker.SetMaskBits(avail)

--- a/Projects/DbCLI/CreateDb.py
+++ b/Projects/DbCLI/CreateDb.py
@@ -276,7 +276,7 @@ def CreateDb(options,dataFilename='',supplier=None):
 
   if options.doDescriptors:
     descrConn=DbConnect(os.path.join(options.outDir,options.descrDbName))
-    calc = cPickle.load(open(options.descriptorCalcFilename,'rb'))
+    calc = cPickle.load(open(options.descriptorCalcFilename,'r'))
     nms = [x for x in calc.GetDescriptorNames()]
     descrCurs = descrConn.GetCursor()
     descrs = ['guid integer not null primary key','%s varchar not null unique'%options.molIdName]

--- a/rdkit/Chem/Pharm3D/UnitTestEmbed.py
+++ b/rdkit/Chem/Pharm3D/UnitTestEmbed.py
@@ -73,7 +73,7 @@ class TestCase(unittest.TestCase):
       return 0
     
   def test1SearchFullMat(self):
-    inF = gzip.open(os.path.join(self.dataDir,'cdk2-syn-clip100.pkl.gz'),'rb')
+    inF = gzip.open(os.path.join(self.dataDir,'cdk2-syn-clip100.pkl.gz'),'r')
     #outF = gzip.open(os.path.join(self.dataDir,'cdk2-syn-clip100.pkl.new.gz'),'wb+')
     nDone = 0
     nHits = 0
@@ -94,7 +94,7 @@ class TestCase(unittest.TestCase):
     self.assertEqual(nHits,47)
     
   def test2SearchDownsample(self):
-    inF = gzip.open(os.path.join(self.dataDir,'cdk2-syn-clip100.pkl.gz'),'rb')
+    inF = gzip.open(os.path.join(self.dataDir,'cdk2-syn-clip100.pkl.gz'),'r')
     nDone = 0
     nHits = 0
     hits = []
@@ -118,7 +118,7 @@ class TestCase(unittest.TestCase):
       'mol_223':(259.19,6.27,134.13,1.12,134.06,1.12,85.74,0.61,0.00),
       'mol_269':(204.51,7.89,103.89,1.20,102.66,1.20,88.07,1.21,6.00),
       }
-    inF = gzip.open(os.path.join(self.dataDir,'cdk2-syn-clip100.pkl.gz'),'rb')
+    inF = gzip.open(os.path.join(self.dataDir,'cdk2-syn-clip100.pkl.gz'),'r')
     nDone = 0
     nHits = 0
     while 1:
@@ -182,7 +182,7 @@ class TestCase(unittest.TestCase):
     pcophore.setUpperBound(1,2,2.881)
     pcophore.setUpperBound2D(1,2,6)
 
-    inF = gzip.open(os.path.join(self.dataDir,'cdk2-syn-clip100.pkl.gz'),'rb')
+    inF = gzip.open(os.path.join(self.dataDir,'cdk2-syn-clip100.pkl.gz'),'r')
     nDone = 0
     nMatches = 0
     nHits = 0
@@ -227,7 +227,7 @@ class TestCase(unittest.TestCase):
     m2 = Chem.MolFromMolFile(os.path.join(self.dataDir,
                                           'Issue268_Mol2.mol'))
     with open(os.path.join(self.dataDir,
-                           'Issue268_Pcop.pkl'),'rb') as inF:
+                           'Issue268_Pcop.pkl'),'r') as inF:
       pcop = cPickle.load(inF, encoding='latin1')
     #pcop._boundsMat=numpy.array(pcop._boundsMat)
     #pcop._boundsMat2D=numpy.array(pcop._boundsMat2D)

--- a/rdkit/Chem/UnitTestCatalog.py
+++ b/rdkit/Chem/UnitTestCatalog.py
@@ -87,7 +87,7 @@ class TestCase(unittest.TestCase):
   def test3CatFilePickle(self):
     with open(os.path.join(RDConfig.RDCodeDir,'Chem',
                            'test_data','simple_catalog.pkl'),
-              'rb') as pklFile:
+              'r') as pklFile:
       cat = cPickle.load(pklFile, encoding='bytes')
     assert cat.GetNumEntries()==21
     assert cat.GetFPLength()==21

--- a/rdkit/Chem/UnitTestCrippen.py
+++ b/rdkit/Chem/UnitTestCrippen.py
@@ -154,7 +154,7 @@ class TestCase(unittest.TestCase):
     self.assertTrue(nFails<nFailsAllowed)
   def testDetails(self):
     Crippen._Init()
-    with open(self.detailName,'rb') as inF:
+    with open(self.detailName,'r') as inF:
       if 0:
         outF = open('tmp.pkl','wb+')
         self._writeDetailFile(inF,outF)
@@ -162,7 +162,7 @@ class TestCase(unittest.TestCase):
 
   def testDetails2(self):
     Crippen._Init()
-    with open(self.detailName2,'rb') as inF:
+    with open(self.detailName2,'r') as inF:
       if 0:
         outF = open('tmp.pkl','wb+')
         self._writeDetailFile(inF,outF)

--- a/rdkit/Chem/UnitTestDescriptors.py
+++ b/rdkit/Chem/UnitTestDescriptors.py
@@ -59,7 +59,7 @@ class TestCase(unittest.TestCase):
       self.assertEqual(actual,expected)
   def testMQNDetails(self):
     refFile = os.path.join(RDConfig.RDCodeDir,'Chem','test_data','MQNs_regress.pkl')
-    with open(refFile,'rb') as inf:
+    with open(refFile,'r') as inf:
       pkl = inf.read()
     refData  = cPickle.loads(pkl,encoding='bytes')
     fn = os.path.join(RDConfig.RDCodeDir,'Chem','test_data','aromat_regress.txt')

--- a/rdkit/ML/Composite/UnitTestComposite.py
+++ b/rdkit/ML/Composite/UnitTestComposite.py
@@ -17,7 +17,7 @@ from rdkit import RDConfig
 class TestCase(unittest.TestCase):
   def setUp(self):
     #print '\n%s: '%self.shortDescription(),
-    with open(RDConfig.RDCodeDir+'/ML/Composite/test_data/ferro.pkl','rb') as pklF:
+    with open(RDConfig.RDCodeDir+'/ML/Composite/test_data/ferro.pkl','r') as pklF:
       self.examples = cPickle.load(pklF)
     self.varNames = ['composition','max_atomic','has3d','has4d','has5d','elconc','atvol','isferro']
     self.qBounds = [[],[1.89,3.53],[],[],[],[0.55,0.73],[11.81,14.52],[]]
@@ -41,7 +41,7 @@ class TestCase(unittest.TestCase):
       
   def testTreeGrow(self):
     " testing tree-based composite "
-    with open(RDConfig.RDCodeDir+'/ML/Composite/test_data/composite_base.pkl','rb') as pklF:
+    with open(RDConfig.RDCodeDir+'/ML/Composite/test_data/composite_base.pkl','r') as pklF:
       self.refCompos = cPickle.load(pklF)
 
     composite = Composite.Composite()

--- a/rdkit/ML/DecTree/UnitTestID3.py
+++ b/rdkit/ML/DecTree/UnitTestID3.py
@@ -41,7 +41,7 @@ class ID3TestCase(unittest.TestCase):
   def testBasicTree(self):
     " testing basic tree growth "
     self._setupBasicTree()
-    with open(self.basicTreeName,'rb') as inFile:
+    with open(self.basicTreeName,'r') as inFile:
       t2 = cPickle.load(inFile)
     assert self.t1 == t2, 'Incorrect tree generated.'
 
@@ -65,7 +65,7 @@ class ID3TestCase(unittest.TestCase):
   def testMultiTree(self):
     " testing multivalued tree growth "
     self._setupMultiTree()
-    with open(self.multiTreeName,'rb') as inFile:
+    with open(self.multiTreeName,'r') as inFile:
       t2 = cPickle.load(inFile)
     assert self.t1 == t2, 'Incorrect tree generated.'
     
@@ -117,7 +117,7 @@ class ID3TestCase(unittest.TestCase):
   def testPyBasicTree(self):
     " testing basic tree growth (python entropy code) "
     self._setupPyBasicTree()
-    with open(self.basicTreeName,'rb') as inFile:
+    with open(self.basicTreeName,'r') as inFile:
       t2 = cPickle.load(inFile)
     assert self.t1 == t2, 'Incorrect tree generated.'
 
@@ -145,7 +145,7 @@ class ID3TestCase(unittest.TestCase):
   def testPyMultiTree(self):
     " testing multivalued tree growth (python entropy code) "
     self._setupPyMultiTree()
-    with open(self.multiTreeName,'rb') as inFile:
+    with open(self.multiTreeName,'r') as inFile:
       t2 = cPickle.load(inFile)
     assert self.t1 == t2, 'Incorrect tree generated.'
     

--- a/rdkit/ML/DecTree/UnitTestQuantTree.py
+++ b/rdkit/ML/DecTree/UnitTestQuantTree.py
@@ -83,14 +83,14 @@ class TestCase(unittest.TestCase):
   def test1Tree(self):
     " testing tree1 "
     self._setupTree1()
-    with open(self.qTree1Name,'rb') as inFile:
+    with open(self.qTree1Name,'r') as inFile:
       t2 = cPickle.load(inFile)
     assert self.t1 == t2, 'Incorrect tree generated.'
 
   def test2Tree(self):
     " testing tree2 "
     self._setupTree2()
-    with open(self.qTree2Name,'rb') as inFile:
+    with open(self.qTree2Name,'r') as inFile:
       t2 = cPickle.load(inFile)
     assert self.t2 == t2, 'Incorrect tree generated.'
 
@@ -108,7 +108,7 @@ class TestCase(unittest.TestCase):
   def test4UnusedVars(self):
     " testing unused variables "
     self._setupTree1a()
-    with open(self.qTree1Name,'rb') as inFile:
+    with open(self.qTree1Name,'r') as inFile:
       t2 = cPickle.load(inFile)
     assert self.t1 == t2, 'Incorrect tree generated.'
     for i in xrange(len(self.examples1)):
@@ -155,9 +155,9 @@ class TestCase(unittest.TestCase):
   def test6Bug29_2(self):
     """ a more extensive test of the cmp stuff using pickled trees"""
     import os
-    with open(os.path.join(RDConfig.RDCodeDir,'ML','DecTree','test_data','CmpTree1.pkl'),'rb') as t1File:
+    with open(os.path.join(RDConfig.RDCodeDir,'ML','DecTree','test_data','CmpTree1.pkl'),'r') as t1File:
       t1 = cPickle.load(t1File)
-    with open(os.path.join(RDConfig.RDCodeDir,'ML','DecTree','test_data','CmpTree2.pkl'),'rb') as t2File:
+    with open(os.path.join(RDConfig.RDCodeDir,'ML','DecTree','test_data','CmpTree2.pkl'),'r') as t2File:
       t2 = cPickle.load(t2File)
     assert cmp(t1,t2),'equality failed'
 

--- a/rdkit/ML/DecTree/UnitTestXVal.py
+++ b/rdkit/ML/DecTree/UnitTestXVal.py
@@ -40,7 +40,7 @@ class XValTestCase(unittest.TestCase):
 
     from rdkit.six.moves import cPickle
     #cPickle.dump(tree,open(self.origTreeName,'w+'))
-    with open(self.origTreeName,'rb') as inFile:
+    with open(self.origTreeName,'r') as inFile:
       oTree = cPickle.load(inFile)
 
     assert oTree==tree,'Random CrossValidation test failed'

--- a/rdkit/ML/Descriptors/UnitTestMolDescriptors.py
+++ b/rdkit/ML/Descriptors/UnitTestMolDescriptors.py
@@ -37,7 +37,7 @@ class TestCase(unittest.TestCase):
 
   def testSaveState(self):
     fName = os.path.join(RDConfig.RDCodeDir,'ML/Descriptors/test_data','molcalc.dsc')
-    with open(fName,'rb') as inF:
+    with open(fName,'r') as inF:
       calc = cPickle.load(inF)
     self.assertEqual(calc.GetDescriptorNames(),tuple(self.descs))
     self.assertEqual(calc.GetDescriptorVersions(),tuple(self.vers))

--- a/rdkit/ML/ModelPackage/UnitTestPackage.py
+++ b/rdkit/ML/ModelPackage/UnitTestPackage.py
@@ -53,7 +53,7 @@ class TestCase(unittest.TestCase):
       
   def testBuild(self):
     """ tests building and screening a packager """
-    with open(os.path.join(self.dataDir,'Jan9_build3_calc.dsc'),'rb') as calcF:
+    with open(os.path.join(self.dataDir,'Jan9_build3_calc.dsc'),'r') as calcF:
       calc = cPickle.load(calcF)
     with open(os.path.join(self.dataDir,'Jan9_build3_model.pkl'),'rb') as modelF:
       model = cPickle.load(modelF)
@@ -62,20 +62,20 @@ class TestCase(unittest.TestCase):
   
   def testLoad(self):
     """ tests loading and screening a packager """
-    with open(os.path.join(self.dataDir,'Jan9_build3_pkg.pkl'),'rb') as pkgF:
+    with open(os.path.join(self.dataDir,'Jan9_build3_pkg.pkl'),'r') as pkgF:
       pkg = cPickle.load(pkgF)
     self._verify(pkg,self.testD)
   
   def testLoad2(self):
     """ tests loading and screening a packager 2 """
-    with open(os.path.join(self.dataDir,'Jan9_build3_pkg.pkl'),'rb') as pkgF:
+    with open(os.path.join(self.dataDir,'Jan9_build3_pkg.pkl'),'r') as pkgF:
       pkg = cPickle.load(pkgF)
     self._verify2(pkg,self.testD)
   
   def testPerm1(self):
     """ tests the descriptor remapping stuff in a packager """
     from rdkit.Chem import Descriptors
-    with open(os.path.join(self.dataDir,'Jan9_build3_pkg.pkl'),'rb') as pkgF:
+    with open(os.path.join(self.dataDir,'Jan9_build3_pkg.pkl'),'r') as pkgF:
       pkg = cPickle.load(pkgF)
     calc = pkg.GetCalculator()
     names = calc.GetDescriptorNames()
@@ -103,7 +103,7 @@ class TestCase(unittest.TestCase):
 
   def testPerm2(self):
     """ tests the descriptor remapping stuff in a packager """
-    with open(os.path.join(self.dataDir,'Jan9_build3_pkg.pkl'),'rb') as pkgF:
+    with open(os.path.join(self.dataDir,'Jan9_build3_pkg.pkl'),'r') as pkgF:
       pkg = cPickle.load(pkgF)
     calc = pkg.GetCalculator()
     names = calc.GetDescriptorNames()

--- a/rdkit/ML/UnitTestBuildComposite.py
+++ b/rdkit/ML/UnitTestBuildComposite.py
@@ -78,7 +78,7 @@ class TestCase(unittest.TestCase):
     self.details.tableName = 'ferro_quant'
     refComposName = 'ferromag_quant_10.pkl'
 
-    with open(os.path.join(self.baseDir,refComposName), 'rb') as pklF:
+    with open(os.path.join(self.baseDir,refComposName), 'r') as pklF:
       refCompos = pickle.load(pklF)
 
     # first make sure the data are intact
@@ -96,7 +96,7 @@ class TestCase(unittest.TestCase):
     self.details.tableName = 'ferro_quant'
     refComposName = 'ferromag_quant_10_3.pkl'
 
-    with open(os.path.join(self.baseDir,refComposName), 'rb') as pklF:
+    with open(os.path.join(self.baseDir,refComposName), 'r') as pklF:
       refCompos = pickle.load(pklF)
 
     # first make sure the data are intact
@@ -111,7 +111,7 @@ class TestCase(unittest.TestCase):
     self.details.tableName = 'ferro_quant'
     refComposName = 'ferromag_quant_10_3_lessgreedy.pkl'
 
-    with open(os.path.join(self.baseDir,refComposName), 'rb') as pklF:
+    with open(os.path.join(self.baseDir,refComposName), 'r') as pklF:
       refCompos = pickle.load(pklF)
 
     # first make sure the data are intact
@@ -127,7 +127,7 @@ class TestCase(unittest.TestCase):
     self.details.tableName = 'ferro_quant'
     refComposName = 'ferromag_quant_50_3.pkl'
 
-    with open(os.path.join(self.baseDir,refComposName), 'rb') as pklF:
+    with open(os.path.join(self.baseDir,refComposName), 'r') as pklF:
       refCompos = pickle.load(pklF)
 
     # first make sure the data are intact
@@ -143,7 +143,7 @@ class TestCase(unittest.TestCase):
     self.details.tableName = 'ferro_noquant'
     refComposName = 'ferromag_auto_10_3.pkl'
 
-    with open(os.path.join(self.baseDir,refComposName), 'rb') as pklF:
+    with open(os.path.join(self.baseDir,refComposName), 'r') as pklF:
       refCompos = pickle.load(pklF)
 
     # first make sure the data are intact
@@ -159,7 +159,7 @@ class TestCase(unittest.TestCase):
     self.details.tableName = 'ferro_noquant_realact'
     refComposName = 'ferromag_auto_10_3.pkl'
 
-    with open(os.path.join(self.baseDir,refComposName), 'rb') as pklF:
+    with open(os.path.join(self.baseDir,refComposName), 'r') as pklF:
       refCompos = pickle.load(pklF)
 
     # first make sure the data are intact
@@ -175,7 +175,7 @@ class TestCase(unittest.TestCase):
     """ Test composite of naive bayes"""
     self.details.tableName = 'ferro_noquant'
     refComposName = 'ferromag_NaiveBayes.pkl'
-    with open(os.path.join(self.baseDir,refComposName), 'rb') as pklFile:
+    with open(os.path.join(self.baseDir,refComposName), 'r') as pklFile:
       refCompos = pickle.load(pklFile)
     self._init(refCompos,copyBounds=1)
     self.details.useTrees = 0

--- a/rdkit/ML/UnitTestScreenComposite.py
+++ b/rdkit/ML/UnitTestScreenComposite.py
@@ -34,7 +34,7 @@ class TestCase(unittest.TestCase):
   def test1(self):
     """ basics """
     self.details.tableName = 'ferro_quant'
-    with open(os.path.join(self.baseDir,'ferromag_quant_10.pkl'),'rb') as pklF:
+    with open(os.path.join(self.baseDir,'ferromag_quant_10.pkl'),'r') as pklF:
       compos = pickle.load(pklF)
     tgt = 5
     self.assertEqual(len(compos),tgt)
@@ -56,7 +56,7 @@ class TestCase(unittest.TestCase):
     self.details.doHoldout=1
     self.details.doTraining=0
     
-    with open(os.path.join(self.baseDir,'ferromag_quant_10.pkl'),'rb') as pklF:
+    with open(os.path.join(self.baseDir,'ferromag_quant_10.pkl'),'r') as pklF:
       compos = pickle.load(pklF)
     tgt = 5
     self.assertEqual(len(compos),tgt)
@@ -78,7 +78,7 @@ class TestCase(unittest.TestCase):
     self.details.doHoldout=0
     self.details.doTraining=1
 
-    with open(os.path.join(self.baseDir,'ferromag_quant_10.pkl'),'rb') as pklF:
+    with open(os.path.join(self.baseDir,'ferromag_quant_10.pkl'),'r') as pklF:
       compos = pickle.load(pklF)
     tgt = 5
     self.assertEqual(len(compos),tgt,'bad composite loaded: %d != %d'%(len(compos),tgt))
@@ -101,7 +101,7 @@ class TestCase(unittest.TestCase):
     self.details.doHoldout=0
     self.details.doTraining=0
 
-    with open(os.path.join(self.baseDir,'ferromag_quant_10.pkl'),'rb') as pklF:
+    with open(os.path.join(self.baseDir,'ferromag_quant_10.pkl'),'r') as pklF:
       compos = pickle.load(pklF)
     tgt = 5
     self.assertEqual(len(compos),tgt)
@@ -122,7 +122,7 @@ class TestCase(unittest.TestCase):
     """ basics """
     self.details.tableName = 'ferro_noquant'
 
-    with open(os.path.join(self.baseDir,'ferromag_auto_10_3.pkl'),'rb') as pklF:
+    with open(os.path.join(self.baseDir,'ferromag_auto_10_3.pkl'),'r') as pklF:
       compos = pickle.load(pklF)
     tgt = 10
     self.assertEqual(len(compos),tgt)
@@ -143,7 +143,7 @@ class TestCase(unittest.TestCase):
   def test6(self):
     """ multiple models """
     self.details.tableName = 'ferro_noquant'
-    with open(os.path.join(self.baseDir,'ferromag_auto_10_3.pkl'),'rb') as pklF:
+    with open(os.path.join(self.baseDir,'ferromag_auto_10_3.pkl'),'r') as pklF:
       compos = pickle.load(pklF)
     tgt = 10
     self.assertEqual(len(compos),tgt)
@@ -168,7 +168,7 @@ class TestCase(unittest.TestCase):
   def test7(self):
     """ shuffle """
     self.details.tableName = 'ferro_noquant'
-    with open(os.path.join(self.baseDir,'ferromag_shuffle_10_3.pkl'),'rb') as pklF:
+    with open(os.path.join(self.baseDir,'ferromag_shuffle_10_3.pkl'),'r') as pklF:
       compos = pickle.load(pklF)
     tgt = 10
     self.assertEqual(len(compos),tgt)
@@ -188,7 +188,7 @@ class TestCase(unittest.TestCase):
     """ shuffle with segmentation """
     self.details.tableName = 'ferro_noquant'
     with open(os.path.join(self.baseDir,'ferromag_shuffle_10_3.pkl'),
-              'rb') as pklF:
+              'r') as pklF:
       compos = pickle.load(pklF)
     tgt = 10
     self.assertEqual(len(compos),tgt)
@@ -209,7 +209,7 @@ class TestCase(unittest.TestCase):
     """ shuffle with segmentation2 """
     self.details.tableName = 'ferro_noquant'
     with open(os.path.join(self.baseDir,'ferromag_shuffle_10_3.pkl'),
-              'rb') as pklF:
+              'r') as pklF:
       compos = pickle.load(pklF)
     tgt = 10
     self.assertEqual(len(compos),tgt)
@@ -230,7 +230,7 @@ class TestCase(unittest.TestCase):
     """ filtering """
     self.details.tableName = 'ferro_noquant'
     with open(os.path.join(self.baseDir,'ferromag_filt_10_3.pkl'),
-              'rb') as pklF:
+              'r') as pklF:
       compos = pickle.load(pklF)
     tgt = 10
     self.assertEqual(len(compos),tgt)
@@ -252,7 +252,7 @@ class TestCase(unittest.TestCase):
     """ filtering with segmentation """
     self.details.tableName = 'ferro_noquant'
     with open(os.path.join(self.baseDir,'ferromag_filt_10_3.pkl'),
-              'rb') as pklF:
+              'r') as pklF:
       compos = pickle.load(pklF)
     tgt = 10
     self.assertEqual(len(compos),tgt)
@@ -276,7 +276,7 @@ class TestCase(unittest.TestCase):
     """ test the naive bayes composite"""
     self.details.tableName = 'ferro_noquant'
     with open(os.path.join(self.baseDir,'ferromag_NaiveBayes.pkl'),
-              'rb') as pklF:
+              'r') as pklF:
       compos = pickle.load(pklF)
     tgt = 10
     self.assertEqual(len(compos),tgt)


### PR DESCRIPTION
- Fixed a few tests to prevent them from failing on Windows
  due to conversion of line terminators to CR+LF on text files
  when the Windows git client is used to retrieve sources