### PR TITLE
Fixed tests failing on Windows when retrieving sources through the  Windows git client

### DIFF
--- a/Code/ChemicalFeatures/Wrap/testFeatures.py
+++ b/Code/ChemicalFeatures/Wrap/testFeatures.py
@@ -6,6 +6,7 @@
 #
 from __future__ import print_function
 import os,sys
+import io
 import unittest
 from rdkit.six.moves import cPickle
 from rdkit import RDConfig
@@ -76,8 +77,11 @@ class TestCase(unittest.TestCase):
       self.assertTrue(ptFeq(ffeat2.GetPos(),ffeat.GetPos()))
 
       # Check that the old pickled versions have not been broken        
-      inF = open(os.path.join(RDConfig.RDBaseDir,
-                              'Code/ChemicalFeatures/Wrap/testData/feat.pkl'),'rb')
+      inTF = open(os.path.join(RDConfig.RDBaseDir,
+                              'Code/ChemicalFeatures/Wrap/testData/feat.pkl'),'r')
+      buf = inTF.read().replace('\r\n', '\n').encode('utf-8')
+      inTF.close()
+      inF = io.BytesIO(buf)
       ffeat2=cPickle.load(inF, encoding='bytes')
       # this version (1.0) does not have an id in the byte stream 
       self.assertTrue(ffeat2.GetFamily()==ffeat.GetFamily())
@@ -89,8 +93,11 @@ class TestCase(unittest.TestCase):
       # uncomment the following to generate (overrwrite) new version of pickled
       # data file
       #cPickle.dump(ffeat,file(os.path.join(RDConfig.RDBaseDir, 'Code/ChemicalFeatures/Wrap/testData/featv2.pkl'),'wb+'))
-      inF = open(os.path.join(RDConfig.RDBaseDir,
-                              'Code/ChemicalFeatures/Wrap/testData/featv2.pkl'),'rb')
+      inTF = open(os.path.join(RDConfig.RDBaseDir,
+                              'Code/ChemicalFeatures/Wrap/testData/featv2.pkl'),'r')
+      buf = inTF.read().replace('\r\n', '\n').encode('utf-8')
+      inTF.close()
+      inF = io.BytesIO(buf)
       ffeat2=cPickle.load(inF, encoding='bytes')
       self.assertTrue(ffeat2.GetId()==ffeat.GetId());
       self.assertTrue(ffeat2.GetFamily()==ffeat.GetFamily())

--- a/Code/DataStructs/Wrap/testDiscreteValueVect.py
+++ b/Code/DataStructs/Wrap/testDiscreteValueVect.py
@@ -5,6 +5,7 @@
 #  @@ All Rights Reserved @@
 #
 import os
+import io
 import sys
 import unittest
 
@@ -130,9 +131,11 @@ class TestCase(unittest.TestCase):
     with open(
       os.path.join(RDConfig.RDBaseDir,
                    'Code/DataStructs/Wrap/testData/dvvs.pkl'),
-      'rb'
-      ) as inF:
-    
+      'r'
+      ) as inTF:
+      buf = inTF.read().replace('\r\n', '\n').encode('utf-8')
+      inTF.close()
+    with io.BytesIO(buf) as inF:
       v1 = ds.DiscreteValueVect(ds.DiscreteValueType.ONEBITVALUE, 30)
       for i in range(15):
         v1[2*i] = 1

--- a/Code/DataStructs/Wrap/testSparseIntVect.py
+++ b/Code/DataStructs/Wrap/testSparseIntVect.py
@@ -5,6 +5,7 @@
 #  @@ All Rights Reserved @@
 #
 import os,sys
+import io
 import unittest
 from rdkit.six.moves import cPickle
 from rdkit import RDConfig
@@ -87,8 +88,11 @@ class TestCase(unittest.TestCase):
     with open(
       os.path.join(RDConfig.RDBaseDir,
                    'Code/DataStructs/Wrap/testData/lsiv.pkl'), 
-      'rb'
-      ) as f:
+      'r'
+      ) as tf:
+      buf = tf.read().replace('\r\n', '\n').encode('utf-8')
+      tf.close()
+    with io.BytesIO(buf) as f:
       v3 = cPickle.load(f)
       self.assertTrue(v3==v1)
     
@@ -115,8 +119,11 @@ class TestCase(unittest.TestCase):
     with open(
       os.path.join(RDConfig.RDBaseDir, 
                    'Code/DataStructs/Wrap/testData/isiv.pkl'),
-      'rb'
-      ) as f:
+      'r'
+      ) as tf:
+      buf = tf.read().replace('\r\n', '\n').encode('utf-8')
+      tf.close()
+    with io.BytesIO(buf) as f:
       v3 = cPickle.load(f)
       self.assertTrue(v3==v1)
 

--- a/Code/GraphMol/PartialCharges/Wrap/testPartialCharges.py
+++ b/Code/GraphMol/PartialCharges/Wrap/testPartialCharges.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 import unittest
 import os
+import io
 
 from rdkit.six.moves import cPickle as pickle
 
@@ -51,7 +52,10 @@ class TestCase(unittest.TestCase):
         infil.close()
 
         infile = os.path.join(RDConfig.RDBaseDir,'Code','GraphMol','PartialCharges','Wrap','test_data', 'PP_combi_charges.pkl')
-        with open(infile, 'rb') as cchFile:
+        with open(infile, 'r') as cchtFile:
+            buf = cchtFile.read().replace('\r\n', '\n').encode('utf-8')
+            cchtFile.close()
+        with io.BytesIO(buf) as cchFile:
             combiCharges = pickle.load(cchFile)
 
         for lin in lines :

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -841,7 +841,7 @@ class TestCase(unittest.TestCase):
     self.assertTrue(m)
     self.assertTrue(m.GetNumAtoms()==30)
 
-    with open(fileN,'r') as dFile:
+    with open(fileN,'rb') as dFile:
       d = dFile.read()
     sdSup.SetData(d)
     m = six.next(sdSup)
@@ -1524,11 +1524,25 @@ CAS<~>
   def test41SetStreamIndices(self) :
     fileN = os.path.join(RDConfig.RDBaseDir,'Code','GraphMol','FileParsers',
                                             'test_data','NCI_aids_few.sdf')
+    allIndices = []
+    ifs = open(fileN, 'rb')
+    addIndex = True;
+    line = True;
+    pos = 0;
+    while (line):
+      if (addIndex):
+        pos = ifs.tell();
+      line = ifs.readline().decode('utf-8')
+      if (line):
+        if (addIndex):
+          allIndices.append(pos);
+        addIndex = (line[:4] == '$$$$')
+    ifs.close()
+    indices = allIndices
     sdSup = Chem.SDMolSupplier(fileN)
     molNames = ["48", "78", "128", "163", "164", "170", "180", "186",
             "192", "203", "210", "211", "213", "220", "229", "256"]
-    indices=[0, 2136, 6198, 8520, 11070, 12292, 14025, 15313, 17313, 20125, 22231,
-	     23729, 26147, 28331, 32541, 33991]
+    
     sdSup._SetStreamIndices(indices)
     self.assertTrue(len(sdSup) == 16)
     mol = sdSup[5]
@@ -1544,14 +1558,14 @@ CAS<~>
     self.assertTrue(ns == molNames)
 
     # this can also be used to skip molecules in the file:
-    indices=[0, 6198, 12292]
+    indices = [allIndices[0], allIndices[2], allIndices[5]]
     sdSup._SetStreamIndices(indices)
     self.assertTrue(len(sdSup) == 3)
     mol = sdSup[2]
     self.assertTrue(mol.GetProp("_Name") == "170")
 
     # or to reorder them:
-    indices=[0, 12292, 6198]
+    indices = [allIndices[0], allIndices[5], allIndices[2]]
     sdSup._SetStreamIndices(indices)
     self.assertTrue(len(sdSup) == 3)
     mol = sdSup[1]

--- a/Code/ML/InfoTheory/Wrap/testRanker.py
+++ b/Code/ML/InfoTheory/Wrap/testRanker.py
@@ -1,6 +1,7 @@
 import unittest
 import numpy
 import os
+import io
 
 from rdkit.six.moves import cPickle
 
@@ -151,7 +152,10 @@ class TestCase(unittest.TestCase):
         self.assertTrue(res is not None)    
 
     def test4Issue237(self) :
-        with open(os.path.join(RDConfig.RDBaseDir,'Code','ML','InfoTheory','Wrap','testData','Issue237.pkl'),'rb') as inF:
+        with open(os.path.join(RDConfig.RDBaseDir,'Code','ML','InfoTheory','Wrap','testData','Issue237.pkl'),'r') as inTF:
+            buf = inTF.read().replace('\r\n', '\n').encode('utf-8')
+            inTF.close()
+        with io.BytesIO(buf) as inF:
             examples,avail,bias,nB,nPoss = cPickle.load(inF, encoding='bytes')
         ranker = rdit.InfoBitRanker(nB,nPoss,rdit.InfoType.BIASENTROPY)
         ranker.SetMaskBits(avail)

--- a/Code/RDBoost/import_array.h
+++ b/Code/RDBoost/import_array.h
@@ -13,6 +13,9 @@
     // directly from within the BOOST_PYTHON_MODULE init function (that
     // returns void)
     import_array();
+#if defined(_MSC_VER) && (PY_MAJOR_VERSION >= 3)
+    return NULL;
+#endif
   }
 
 #endif

--- a/Projects/DbCLI/CreateDb.py
+++ b/Projects/DbCLI/CreateDb.py
@@ -63,6 +63,7 @@ from rdkit.Chem.MolDb import Loader
 
 logger = logger()
 import sys,os
+import io
 from rdkit.six.moves import cPickle
 from rdkit.Chem.MolDb.FingerprintUtils import BuildSigFactory,LayeredOptions
 from rdkit.Chem.MolDb import FingerprintUtils
@@ -276,7 +277,10 @@ def CreateDb(options,dataFilename='',supplier=None):
 
   if options.doDescriptors:
     descrConn=DbConnect(os.path.join(options.outDir,options.descrDbName))
-    calc = cPickle.load(open(options.descriptorCalcFilename,'rb'))
+    with open(options.descriptorCalcFilename,'r') as inTF:
+      buf = inTF.read().replace('\r\n', '\n').encode('utf-8')
+      inTF.close()
+    calc = cPickle.load(io.BytesIO(buf))
     nms = [x for x in calc.GetDescriptorNames()]
     descrCurs = descrConn.GetCursor()
     descrs = ['guid integer not null primary key','%s varchar not null unique'%options.molIdName]

--- a/rdkit/Chem/Pharm3D/UnitTestEmbed.py
+++ b/rdkit/Chem/Pharm3D/UnitTestEmbed.py
@@ -11,6 +11,7 @@
 from __future__ import print_function
 from rdkit import RDConfig
 import unittest,sys,os
+import io
 from rdkit.six import PY3
 from rdkit.six.moves import cPickle
 from rdkit import Chem
@@ -227,7 +228,10 @@ class TestCase(unittest.TestCase):
     m2 = Chem.MolFromMolFile(os.path.join(self.dataDir,
                                           'Issue268_Mol2.mol'))
     with open(os.path.join(self.dataDir,
-                           'Issue268_Pcop.pkl'),'rb') as inF:
+                           'Issue268_Pcop.pkl'),'r') as inTF:
+      buf = inTF.read().replace('\r\n', '\n').encode('utf-8')
+      inTF.close()
+    with io.BytesIO(buf) as inF:
       pcop = cPickle.load(inF, encoding='latin1')
     #pcop._boundsMat=numpy.array(pcop._boundsMat)
     #pcop._boundsMat2D=numpy.array(pcop._boundsMat2D)

--- a/rdkit/Chem/UnitTestCatalog.py
+++ b/rdkit/Chem/UnitTestCatalog.py
@@ -9,6 +9,7 @@
 #  of the RDKit source tree.
 #
 import os
+import io
 import unittest
 from rdkit import RDConfig
 from rdkit import Chem
@@ -87,7 +88,10 @@ class TestCase(unittest.TestCase):
   def test3CatFilePickle(self):
     with open(os.path.join(RDConfig.RDCodeDir,'Chem',
                            'test_data','simple_catalog.pkl'),
-              'rb') as pklFile:
+              'r') as pklTFile:
+      buf = pklTFile.read().replace('\r\n', '\n').encode('utf-8')
+      pklTFile.close()
+    with io.BytesIO(buf) as pklFile:
       cat = cPickle.load(pklFile, encoding='bytes')
     assert cat.GetNumEntries()==21
     assert cat.GetFPLength()==21

--- a/rdkit/Chem/UnitTestCrippen.py
+++ b/rdkit/Chem/UnitTestCrippen.py
@@ -13,6 +13,7 @@
 """
 from __future__ import print_function
 import unittest,sys,os
+import io
 
 import numpy
 
@@ -154,7 +155,10 @@ class TestCase(unittest.TestCase):
     self.assertTrue(nFails<nFailsAllowed)
   def testDetails(self):
     Crippen._Init()
-    with open(self.detailName,'rb') as inF:
+    with open(self.detailName,'r') as inTF:
+      buf = inTF.read().replace('\r\n', '\n').encode('utf-8')
+      inTF.close()
+    with io.BytesIO(buf) as inF:
       if 0:
         outF = open('tmp.pkl','wb+')
         self._writeDetailFile(inF,outF)
@@ -162,7 +166,10 @@ class TestCase(unittest.TestCase):
 
   def testDetails2(self):
     Crippen._Init()
-    with open(self.detailName2,'rb') as inF:
+    with open(self.detailName2,'r') as inTF:
+      buf = inTF.read().replace('\r\n', '\n').encode('utf-8')
+      inTF.close()
+    with io.BytesIO(buf) as inF:
       if 0:
         outF = open('tmp.pkl','wb+')
         self._writeDetailFile(inF,outF)

--- a/rdkit/Chem/UnitTestDescriptors.py
+++ b/rdkit/Chem/UnitTestDescriptors.py
@@ -14,6 +14,7 @@
 from __future__ import print_function
 from rdkit import RDConfig
 import unittest,os.path
+import io
 from rdkit.six.moves import cPickle
 from rdkit import Chem
 from rdkit.Chem import Descriptors
@@ -59,7 +60,10 @@ class TestCase(unittest.TestCase):
       self.assertEqual(actual,expected)
   def testMQNDetails(self):
     refFile = os.path.join(RDConfig.RDCodeDir,'Chem','test_data','MQNs_regress.pkl')
-    with open(refFile,'rb') as inf:
+    with open(refFile,'r') as intf:
+      buf = intf.read().replace('\r\n', '\n').encode('utf-8')
+      intf.close()
+    with io.BytesIO(buf) as inf:
       pkl = inf.read()
     refData  = cPickle.loads(pkl,encoding='bytes')
     fn = os.path.join(RDConfig.RDCodeDir,'Chem','test_data','aromat_regress.txt')

--- a/rdkit/ML/Composite/UnitTestComposite.py
+++ b/rdkit/ML/Composite/UnitTestComposite.py
@@ -8,6 +8,7 @@
 
 """
 import unittest
+import io
 from rdkit.six.moves import cPickle, xrange
 from rdkit.ML.Composite import Composite
 from rdkit.ML.DecTree.DecTree import DecTreeNode as Node
@@ -17,7 +18,10 @@ from rdkit import RDConfig
 class TestCase(unittest.TestCase):
   def setUp(self):
     #print '\n%s: '%self.shortDescription(),
-    with open(RDConfig.RDCodeDir+'/ML/Composite/test_data/ferro.pkl','rb') as pklF:
+    with open(RDConfig.RDCodeDir+'/ML/Composite/test_data/ferro.pkl','r') as pklTF:
+      buf = pklTF.read().replace('\r\n', '\n').encode('utf-8')
+      pklTF.close()
+    with io.BytesIO(buf) as pklF:
       self.examples = cPickle.load(pklF)
     self.varNames = ['composition','max_atomic','has3d','has4d','has5d','elconc','atvol','isferro']
     self.qBounds = [[],[1.89,3.53],[],[],[],[0.55,0.73],[11.81,14.52],[]]
@@ -41,7 +45,10 @@ class TestCase(unittest.TestCase):
       
   def testTreeGrow(self):
     " testing tree-based composite "
-    with open(RDConfig.RDCodeDir+'/ML/Composite/test_data/composite_base.pkl','rb') as pklF:
+    with open(RDConfig.RDCodeDir+'/ML/Composite/test_data/composite_base.pkl','r') as pklTF:
+      buf = pklTF.read().replace('\r\n', '\n').encode('utf-8')
+      pklTF.close()
+    with io.BytesIO(buf) as pklF:
       self.refCompos = cPickle.load(pklF)
 
     composite = Composite.Composite()

--- a/rdkit/ML/DecTree/UnitTestID3.py
+++ b/rdkit/ML/DecTree/UnitTestID3.py
@@ -5,6 +5,7 @@
 """ unit tests for the ID3 implementation """
 from __future__ import print_function
 import unittest
+import io
 from rdkit.six.moves import cPickle
 from rdkit import RDConfig
 from rdkit.ML.DecTree import ID3,DecTree
@@ -41,7 +42,10 @@ class ID3TestCase(unittest.TestCase):
   def testBasicTree(self):
     " testing basic tree growth "
     self._setupBasicTree()
-    with open(self.basicTreeName,'rb') as inFile:
+    with open(self.basicTreeName,'r') as inTFile:
+      buf = inTFile.read().replace('\r\n', '\n').encode('utf-8')
+      inTFile.close()
+    with io.BytesIO(buf) as inFile:
       t2 = cPickle.load(inFile)
     assert self.t1 == t2, 'Incorrect tree generated.'
 
@@ -65,7 +69,10 @@ class ID3TestCase(unittest.TestCase):
   def testMultiTree(self):
     " testing multivalued tree growth "
     self._setupMultiTree()
-    with open(self.multiTreeName,'rb') as inFile:
+    with open(self.multiTreeName,'r') as inTFile:
+      buf = inTFile.read().replace('\r\n', '\n').encode('utf-8')
+      inTFile.close()
+    with io.BytesIO(buf) as inFile:
       t2 = cPickle.load(inFile)
     assert self.t1 == t2, 'Incorrect tree generated.'
     
@@ -117,7 +124,10 @@ class ID3TestCase(unittest.TestCase):
   def testPyBasicTree(self):
     " testing basic tree growth (python entropy code) "
     self._setupPyBasicTree()
-    with open(self.basicTreeName,'rb') as inFile:
+    with open(self.basicTreeName,'r') as inTFile:
+      buf = inTFile.read().replace('\r\n', '\n').encode('utf-8')
+      inTFile.close()
+    with io.BytesIO(buf) as inFile:
       t2 = cPickle.load(inFile)
     assert self.t1 == t2, 'Incorrect tree generated.'
 
@@ -145,7 +155,10 @@ class ID3TestCase(unittest.TestCase):
   def testPyMultiTree(self):
     " testing multivalued tree growth (python entropy code) "
     self._setupPyMultiTree()
-    with open(self.multiTreeName,'rb') as inFile:
+    with open(self.multiTreeName,'r') as inTFile:
+      buf = inTFile.read().replace('\r\n', '\n').encode('utf-8')
+      inTFile.close()
+    with io.BytesIO(buf) as inFile:
       t2 = cPickle.load(inFile)
     assert self.t1 == t2, 'Incorrect tree generated.'
     

--- a/rdkit/ML/DecTree/UnitTestQuantTree.py
+++ b/rdkit/ML/DecTree/UnitTestQuantTree.py
@@ -7,6 +7,7 @@
 """ unit tests for the QuantTree implementation """
 from __future__ import print_function
 import unittest
+import io
 from rdkit import RDConfig
 from rdkit.ML.DecTree import BuildQuantTree
 from rdkit.ML.DecTree.QuantTree import QuantTreeNode
@@ -83,14 +84,20 @@ class TestCase(unittest.TestCase):
   def test1Tree(self):
     " testing tree1 "
     self._setupTree1()
-    with open(self.qTree1Name,'rb') as inFile:
+    with open(self.qTree1Name,'r') as inTFile:
+      buf = inTFile.read().replace('\r\n', '\n').encode('utf-8')
+      inTFile.close()
+    with io.BytesIO(buf) as inFile:
       t2 = cPickle.load(inFile)
     assert self.t1 == t2, 'Incorrect tree generated.'
 
   def test2Tree(self):
     " testing tree2 "
     self._setupTree2()
-    with open(self.qTree2Name,'rb') as inFile:
+    with open(self.qTree2Name,'r') as inTFile:
+      buf = inTFile.read().replace('\r\n', '\n').encode('utf-8')
+      inTFile.close()
+    with io.BytesIO(buf) as inFile:
       t2 = cPickle.load(inFile)
     assert self.t2 == t2, 'Incorrect tree generated.'
 
@@ -108,7 +115,10 @@ class TestCase(unittest.TestCase):
   def test4UnusedVars(self):
     " testing unused variables "
     self._setupTree1a()
-    with open(self.qTree1Name,'rb') as inFile:
+    with open(self.qTree1Name,'r') as inTFile:
+      buf = inTFile.read().replace('\r\n', '\n').encode('utf-8')
+      inTFile.close()
+    with io.BytesIO(buf) as inFile:
       t2 = cPickle.load(inFile)
     assert self.t1 == t2, 'Incorrect tree generated.'
     for i in xrange(len(self.examples1)):
@@ -155,9 +165,15 @@ class TestCase(unittest.TestCase):
   def test6Bug29_2(self):
     """ a more extensive test of the cmp stuff using pickled trees"""
     import os
-    with open(os.path.join(RDConfig.RDCodeDir,'ML','DecTree','test_data','CmpTree1.pkl'),'rb') as t1File:
+    with open(os.path.join(RDConfig.RDCodeDir,'ML','DecTree','test_data','CmpTree1.pkl'),'r') as t1TFile:
+      buf = t1TFile.read().replace('\r\n', '\n').encode('utf-8')
+      t1TFile.close()
+    with io.BytesIO(buf) as t1File:
       t1 = cPickle.load(t1File)
-    with open(os.path.join(RDConfig.RDCodeDir,'ML','DecTree','test_data','CmpTree2.pkl'),'rb') as t2File:
+    with open(os.path.join(RDConfig.RDCodeDir,'ML','DecTree','test_data','CmpTree2.pkl'),'r') as t2TFile:
+      buf = t2TFile.read().replace('\r\n', '\n').encode('utf-8')
+      t2TFile.close()
+    with io.BytesIO(buf) as t2File:
       t2 = cPickle.load(t2File)
     assert cmp(t1,t2),'equality failed'
 

--- a/rdkit/ML/DecTree/UnitTestXVal.py
+++ b/rdkit/ML/DecTree/UnitTestXVal.py
@@ -5,6 +5,7 @@
 """ unit testing code for cross validation """
 from __future__ import print_function
 import unittest, random
+import io
 from rdkit import RDConfig
 from rdkit.ML.DecTree import CrossValidate
 
@@ -40,7 +41,10 @@ class XValTestCase(unittest.TestCase):
 
     from rdkit.six.moves import cPickle
     #cPickle.dump(tree,open(self.origTreeName,'w+'))
-    with open(self.origTreeName,'rb') as inFile:
+    with open(self.origTreeName,'r') as inTFile:
+      buf = inTFile.read().replace('\r\n', '\n').encode('utf-8')
+      inTFile.close()
+    with io.BytesIO(buf) as inFile:
       oTree = cPickle.load(inFile)
 
     assert oTree==tree,'Random CrossValidation test failed'

--- a/rdkit/ML/Descriptors/UnitTestMolDescriptors.py
+++ b/rdkit/ML/Descriptors/UnitTestMolDescriptors.py
@@ -6,6 +6,7 @@
 
 """
 import unittest,os.path
+import io
 from rdkit.six.moves import cPickle
 from rdkit import RDConfig
 from rdkit.ML.Descriptors import MoleculeDescriptors
@@ -37,7 +38,10 @@ class TestCase(unittest.TestCase):
 
   def testSaveState(self):
     fName = os.path.join(RDConfig.RDCodeDir,'ML/Descriptors/test_data','molcalc.dsc')
-    with open(fName,'rb') as inF:
+    with open(fName,'r') as inTF:
+      buf = inTF.read().replace('\r\n', '\n').encode('utf-8')
+      inTF.close()
+    with io.BytesIO(buf) as inF:
       calc = cPickle.load(inF)
     self.assertEqual(calc.GetDescriptorNames(),tuple(self.descs))
     self.assertEqual(calc.GetDescriptorVersions(),tuple(self.vers))

--- a/rdkit/ML/ModelPackage/UnitTestPackage.py
+++ b/rdkit/ML/ModelPackage/UnitTestPackage.py
@@ -8,6 +8,7 @@
 from rdkit import RDConfig
 from rdkit.ML.Data import DataUtils
 import unittest,os,sys
+import io
 from rdkit.six.moves import cPickle
 from rdkit.ML.ModelPackage import Packager
 from rdkit import Chem
@@ -53,7 +54,10 @@ class TestCase(unittest.TestCase):
       
   def testBuild(self):
     """ tests building and screening a packager """
-    with open(os.path.join(self.dataDir,'Jan9_build3_calc.dsc'),'rb') as calcF:
+    with open(os.path.join(self.dataDir,'Jan9_build3_calc.dsc'),'r') as calcTF:
+      buf = calcTF.read().replace('\r\n', '\n').encode('utf-8')
+      calcTF.close()
+    with io.BytesIO(buf) as calcF:
       calc = cPickle.load(calcF)
     with open(os.path.join(self.dataDir,'Jan9_build3_model.pkl'),'rb') as modelF:
       model = cPickle.load(modelF)
@@ -62,20 +66,29 @@ class TestCase(unittest.TestCase):
   
   def testLoad(self):
     """ tests loading and screening a packager """
-    with open(os.path.join(self.dataDir,'Jan9_build3_pkg.pkl'),'rb') as pkgF:
+    with open(os.path.join(self.dataDir,'Jan9_build3_pkg.pkl'),'r') as pkgTF:
+      buf = pkgTF.read().replace('\r\n', '\n').encode('utf-8')
+      pkgTF.close()
+    with io.BytesIO(buf) as pkgF:
       pkg = cPickle.load(pkgF)
     self._verify(pkg,self.testD)
   
   def testLoad2(self):
     """ tests loading and screening a packager 2 """
-    with open(os.path.join(self.dataDir,'Jan9_build3_pkg.pkl'),'rb') as pkgF:
+    with open(os.path.join(self.dataDir,'Jan9_build3_pkg.pkl'),'r') as pkgTF:
+      buf = pkgTF.read().replace('\r\n', '\n').encode('utf-8')
+      pkgTF.close()
+    with io.BytesIO(buf) as pkgF:
       pkg = cPickle.load(pkgF)
     self._verify2(pkg,self.testD)
   
   def testPerm1(self):
     """ tests the descriptor remapping stuff in a packager """
     from rdkit.Chem import Descriptors
-    with open(os.path.join(self.dataDir,'Jan9_build3_pkg.pkl'),'rb') as pkgF:
+    with open(os.path.join(self.dataDir,'Jan9_build3_pkg.pkl'),'r') as pkgTF:
+      buf = pkgTF.read().replace('\r\n', '\n').encode('utf-8')
+      pkgTF.close()
+    with io.BytesIO(buf) as pkgF:
       pkg = cPickle.load(pkgF)
     calc = pkg.GetCalculator()
     names = calc.GetDescriptorNames()
@@ -103,7 +116,10 @@ class TestCase(unittest.TestCase):
 
   def testPerm2(self):
     """ tests the descriptor remapping stuff in a packager """
-    with open(os.path.join(self.dataDir,'Jan9_build3_pkg.pkl'),'rb') as pkgF:
+    with open(os.path.join(self.dataDir,'Jan9_build3_pkg.pkl'),'r') as pkgTF:
+      buf = pkgTF.read().replace('\r\n', '\n').encode('utf-8')
+      pkgTF.close()
+    with io.BytesIO(buf) as pkgF:
       pkg = cPickle.load(pkgF)
     calc = pkg.GetCalculator()
     names = calc.GetDescriptorNames()

--- a/rdkit/ML/UnitTestBuildComposite.py
+++ b/rdkit/ML/UnitTestBuildComposite.py
@@ -12,6 +12,7 @@
 
 """
 import unittest,os
+import io
 from rdkit.six.moves import cPickle as pickle
 from rdkit.six import cmp
 from rdkit import RDConfig
@@ -78,7 +79,10 @@ class TestCase(unittest.TestCase):
     self.details.tableName = 'ferro_quant'
     refComposName = 'ferromag_quant_10.pkl'
 
-    with open(os.path.join(self.baseDir,refComposName), 'rb') as pklF:
+    with open(os.path.join(self.baseDir,refComposName), 'r') as pklTF:
+      buf = pklTF.read().replace('\r\n', '\n').encode('utf-8')
+      pklTF.close()
+    with io.BytesIO(buf) as pklF:
       refCompos = pickle.load(pklF)
 
     # first make sure the data are intact
@@ -96,7 +100,10 @@ class TestCase(unittest.TestCase):
     self.details.tableName = 'ferro_quant'
     refComposName = 'ferromag_quant_10_3.pkl'
 
-    with open(os.path.join(self.baseDir,refComposName), 'rb') as pklF:
+    with open(os.path.join(self.baseDir,refComposName), 'r') as pklTF:
+      buf = pklTF.read().replace('\r\n', '\n').encode('utf-8')
+      pklTF.close()
+    with io.BytesIO(buf) as pklF:
       refCompos = pickle.load(pklF)
 
     # first make sure the data are intact
@@ -111,7 +118,10 @@ class TestCase(unittest.TestCase):
     self.details.tableName = 'ferro_quant'
     refComposName = 'ferromag_quant_10_3_lessgreedy.pkl'
 
-    with open(os.path.join(self.baseDir,refComposName), 'rb') as pklF:
+    with open(os.path.join(self.baseDir,refComposName), 'r') as pklTF:
+      buf = pklTF.read().replace('\r\n', '\n').encode('utf-8')
+      pklTF.close()
+    with io.BytesIO(buf) as pklF:
       refCompos = pickle.load(pklF)
 
     # first make sure the data are intact
@@ -127,7 +137,10 @@ class TestCase(unittest.TestCase):
     self.details.tableName = 'ferro_quant'
     refComposName = 'ferromag_quant_50_3.pkl'
 
-    with open(os.path.join(self.baseDir,refComposName), 'rb') as pklF:
+    with open(os.path.join(self.baseDir,refComposName), 'r') as pklTF:
+      buf = pklTF.read().replace('\r\n', '\n').encode('utf-8')
+      pklTF.close()
+    with io.BytesIO(buf) as pklF:
       refCompos = pickle.load(pklF)
 
     # first make sure the data are intact
@@ -143,7 +156,10 @@ class TestCase(unittest.TestCase):
     self.details.tableName = 'ferro_noquant'
     refComposName = 'ferromag_auto_10_3.pkl'
 
-    with open(os.path.join(self.baseDir,refComposName), 'rb') as pklF:
+    with open(os.path.join(self.baseDir,refComposName), 'r') as pklTF:
+      buf = pklTF.read().replace('\r\n', '\n').encode('utf-8')
+      pklTF.close()
+    with io.BytesIO(buf) as pklF:
       refCompos = pickle.load(pklF)
 
     # first make sure the data are intact
@@ -159,7 +175,10 @@ class TestCase(unittest.TestCase):
     self.details.tableName = 'ferro_noquant_realact'
     refComposName = 'ferromag_auto_10_3.pkl'
 
-    with open(os.path.join(self.baseDir,refComposName), 'rb') as pklF:
+    with open(os.path.join(self.baseDir,refComposName), 'r') as pklTF:
+      buf = pklTF.read().replace('\r\n', '\n').encode('utf-8')
+      pklTF.close()
+    with io.BytesIO(buf) as pklF:
       refCompos = pickle.load(pklF)
 
     # first make sure the data are intact
@@ -175,7 +194,10 @@ class TestCase(unittest.TestCase):
     """ Test composite of naive bayes"""
     self.details.tableName = 'ferro_noquant'
     refComposName = 'ferromag_NaiveBayes.pkl'
-    with open(os.path.join(self.baseDir,refComposName), 'rb') as pklFile:
+    with open(os.path.join(self.baseDir,refComposName), 'r') as pklTFile:
+      buf = pklTFile.read().replace('\r\n', '\n').encode('utf-8')
+      pklTFile.close()
+    with io.BytesIO(buf) as pklFile:
       refCompos = pickle.load(pklFile)
     self._init(refCompos,copyBounds=1)
     self.details.useTrees = 0

--- a/rdkit/ML/UnitTestScreenComposite.py
+++ b/rdkit/ML/UnitTestScreenComposite.py
@@ -13,6 +13,7 @@
 """
 from rdkit import RDConfig
 import unittest,os
+import io
 from rdkit.ML import BuildComposite
 from rdkit.ML import ScreenComposite
 from rdkit.six.moves import cPickle as pickle
@@ -34,7 +35,10 @@ class TestCase(unittest.TestCase):
   def test1(self):
     """ basics """
     self.details.tableName = 'ferro_quant'
-    with open(os.path.join(self.baseDir,'ferromag_quant_10.pkl'),'rb') as pklF:
+    with open(os.path.join(self.baseDir,'ferromag_quant_10.pkl'),'r') as pklTF:
+      buf = pklTF.read().replace('\r\n', '\n').encode('utf-8')
+      pklTF.close()
+    with io.BytesIO(buf) as pklF:
       compos = pickle.load(pklF)
     tgt = 5
     self.assertEqual(len(compos),tgt)
@@ -56,7 +60,10 @@ class TestCase(unittest.TestCase):
     self.details.doHoldout=1
     self.details.doTraining=0
     
-    with open(os.path.join(self.baseDir,'ferromag_quant_10.pkl'),'rb') as pklF:
+    with open(os.path.join(self.baseDir,'ferromag_quant_10.pkl'),'r') as pklTF:
+      buf = pklTF.read().replace('\r\n', '\n').encode('utf-8')
+      pklTF.close()
+    with io.BytesIO(buf) as pklF:
       compos = pickle.load(pklF)
     tgt = 5
     self.assertEqual(len(compos),tgt)
@@ -78,7 +85,10 @@ class TestCase(unittest.TestCase):
     self.details.doHoldout=0
     self.details.doTraining=1
 
-    with open(os.path.join(self.baseDir,'ferromag_quant_10.pkl'),'rb') as pklF:
+    with open(os.path.join(self.baseDir,'ferromag_quant_10.pkl'),'r') as pklTF:
+      buf = pklTF.read().replace('\r\n', '\n').encode('utf-8')
+      pklTF.close()
+    with io.BytesIO(buf) as pklF:
       compos = pickle.load(pklF)
     tgt = 5
     self.assertEqual(len(compos),tgt,'bad composite loaded: %d != %d'%(len(compos),tgt))
@@ -101,7 +111,10 @@ class TestCase(unittest.TestCase):
     self.details.doHoldout=0
     self.details.doTraining=0
 
-    with open(os.path.join(self.baseDir,'ferromag_quant_10.pkl'),'rb') as pklF:
+    with open(os.path.join(self.baseDir,'ferromag_quant_10.pkl'),'r') as pklTF:
+      buf = pklTF.read().replace('\r\n', '\n').encode('utf-8')
+      pklTF.close()
+    with io.BytesIO(buf) as pklF:
       compos = pickle.load(pklF)
     tgt = 5
     self.assertEqual(len(compos),tgt)
@@ -122,7 +135,10 @@ class TestCase(unittest.TestCase):
     """ basics """
     self.details.tableName = 'ferro_noquant'
 
-    with open(os.path.join(self.baseDir,'ferromag_auto_10_3.pkl'),'rb') as pklF:
+    with open(os.path.join(self.baseDir,'ferromag_auto_10_3.pkl'),'r') as pklTF:
+      buf = pklTF.read().replace('\r\n', '\n').encode('utf-8')
+      pklTF.close()
+    with io.BytesIO(buf) as pklF:
       compos = pickle.load(pklF)
     tgt = 10
     self.assertEqual(len(compos),tgt)
@@ -143,7 +159,10 @@ class TestCase(unittest.TestCase):
   def test6(self):
     """ multiple models """
     self.details.tableName = 'ferro_noquant'
-    with open(os.path.join(self.baseDir,'ferromag_auto_10_3.pkl'),'rb') as pklF:
+    with open(os.path.join(self.baseDir,'ferromag_auto_10_3.pkl'),'r') as pklTF:
+      buf = pklTF.read().replace('\r\n', '\n').encode('utf-8')
+      pklTF.close()
+    with io.BytesIO(buf) as pklF:
       compos = pickle.load(pklF)
     tgt = 10
     self.assertEqual(len(compos),tgt)
@@ -168,7 +187,10 @@ class TestCase(unittest.TestCase):
   def test7(self):
     """ shuffle """
     self.details.tableName = 'ferro_noquant'
-    with open(os.path.join(self.baseDir,'ferromag_shuffle_10_3.pkl'),'rb') as pklF:
+    with open(os.path.join(self.baseDir,'ferromag_shuffle_10_3.pkl'),'r') as pklTF:
+      buf = pklTF.read().replace('\r\n', '\n').encode('utf-8')
+      pklTF.close()
+    with io.BytesIO(buf) as pklF:
       compos = pickle.load(pklF)
     tgt = 10
     self.assertEqual(len(compos),tgt)
@@ -188,7 +210,10 @@ class TestCase(unittest.TestCase):
     """ shuffle with segmentation """
     self.details.tableName = 'ferro_noquant'
     with open(os.path.join(self.baseDir,'ferromag_shuffle_10_3.pkl'),
-              'rb') as pklF:
+              'r') as pklTF:
+      buf = pklTF.read().replace('\r\n', '\n').encode('utf-8')
+      pklTF.close()
+    with io.BytesIO(buf) as pklF:
       compos = pickle.load(pklF)
     tgt = 10
     self.assertEqual(len(compos),tgt)
@@ -209,7 +234,10 @@ class TestCase(unittest.TestCase):
     """ shuffle with segmentation2 """
     self.details.tableName = 'ferro_noquant'
     with open(os.path.join(self.baseDir,'ferromag_shuffle_10_3.pkl'),
-              'rb') as pklF:
+              'r') as pklTF:
+      buf = pklTF.read().replace('\r\n', '\n').encode('utf-8')
+      pklTF.close()
+    with io.BytesIO(buf) as pklF:
       compos = pickle.load(pklF)
     tgt = 10
     self.assertEqual(len(compos),tgt)
@@ -230,7 +258,10 @@ class TestCase(unittest.TestCase):
     """ filtering """
     self.details.tableName = 'ferro_noquant'
     with open(os.path.join(self.baseDir,'ferromag_filt_10_3.pkl'),
-              'rb') as pklF:
+              'r') as pklTF:
+      buf = pklTF.read().replace('\r\n', '\n').encode('utf-8')
+      pklTF.close()
+    with io.BytesIO(buf) as pklF:
       compos = pickle.load(pklF)
     tgt = 10
     self.assertEqual(len(compos),tgt)
@@ -252,7 +283,10 @@ class TestCase(unittest.TestCase):
     """ filtering with segmentation """
     self.details.tableName = 'ferro_noquant'
     with open(os.path.join(self.baseDir,'ferromag_filt_10_3.pkl'),
-              'rb') as pklF:
+              'r') as pklTF:
+      buf = pklTF.read().replace('\r\n', '\n').encode('utf-8')
+      pklTF.close()
+    with io.BytesIO(buf) as pklF:
       compos = pickle.load(pklF)
     tgt = 10
     self.assertEqual(len(compos),tgt)
@@ -276,7 +310,10 @@ class TestCase(unittest.TestCase):
     """ test the naive bayes composite"""
     self.details.tableName = 'ferro_noquant'
     with open(os.path.join(self.baseDir,'ferromag_NaiveBayes.pkl'),
-              'rb') as pklF:
+              'r') as pklTF:
+      buf = pklTF.read().replace('\r\n', '\n').encode('utf-8')
+      pklTF.close()
+    with io.BytesIO(buf) as pklF:
       compos = pickle.load(pklF)
     tgt = 10
     self.assertEqual(len(compos),tgt)


### PR DESCRIPTION
- Fixed tests failing on Windows when retrieving sources through the  Windows git client, which converts line terminators to CR+LF
- Added a conditional compilation clause to Code/RDBoost/import_array.h
  to avoid a compilation error on Windows with Python3