### PR TITLE
RDKit learns how to query properties on Atoms

### DIFF
--- a/Code/GraphMol/QueryOps.cpp
+++ b/Code/GraphMol/QueryOps.cpp
@@ -323,9 +323,4 @@ ATOM_NULL_QUERY *makeAtomNullQuery(){
   return res;
 }
 
-ATOM_PROP_QUERY *makeAtomHasPropQuery(const std::string &property)
-{
-  return new AtomHasPropQuery(property);
-}
-  
 };

--- a/Code/GraphMol/QueryOps.cpp
+++ b/Code/GraphMol/QueryOps.cpp
@@ -322,5 +322,10 @@ ATOM_NULL_QUERY *makeAtomNullQuery(){
   res->setDescription("AtomNull");
   return res;
 }
+
+ATOM_PROP_QUERY *makeAtomHasPropQuery(const std::string &property)
+{
+  return new AtomHasPropQuery(property);
+}
   
 };

--- a/Code/GraphMol/QueryOps.h
+++ b/Code/GraphMol/QueryOps.h
@@ -483,28 +483,31 @@ namespace RDKit{
   template <typename T>
   bool nullQueryFun(T arg) { return true; } 
 
+  typedef Bond const *ConstBondPtr;
+
   // ! Query whether an atom has a property
-  class AtomHasPropQuery : public Queries::EqualityQuery<
-    int, ConstAtomPtr, true> {
+  template<class TargetPtr>
+  class HasPropQuery : public Queries::EqualityQuery<
+    int, TargetPtr, true> {
 
     std::string propname;
   public:
-    AtomHasPropQuery():
-    Queries::EqualityQuery<int,ConstAtomPtr,true>(),
+    HasPropQuery():
+    Queries::EqualityQuery<int,TargetPtr,true>(),
       propname() {
       // default is to just do a number of rings query:
       this->setDescription("AtomHasProp");
       this->setDataFunc(0);
     };
-  explicit AtomHasPropQuery(const std::string & v) :
-    Queries::EqualityQuery<int,ConstAtomPtr,true>(),
+  explicit HasPropQuery(const std::string & v) :
+    Queries::EqualityQuery<int,TargetPtr,true>(),
       propname(v) {
       // default is to just do a number of rings query:
       this->setDescription("AtomHasProp");
       this->setDataFunc(0);
     };
 
-    virtual bool Match(const ConstAtomPtr what) const {
+    virtual bool Match(const TargetPtr what) const {
       bool res = what->hasProp(propname);
       if(this->getNegation()){
         res=!res;
@@ -513,10 +516,10 @@ namespace RDKit{
     }
 
     //! returns a copy of this query
-    Queries::Query<int,ConstAtomPtr,true> *
+    Queries::Query<int,TargetPtr,true> *
     copy() const {
-      AtomHasPropQuery *res = new AtomHasPropQuery(this->propname);
-      res->setNegation(getNegation());
+      HasPropQuery *res = new HasPropQuery(this->propname);
+      res->setNegation(this->getNegation());
       res->d_description = this->d_description;
       return res;
     }
@@ -528,40 +531,45 @@ namespace RDKit{
     int,Bond const *,true> BOND_PROP_QUERY;
 
   //! returns a Query for matching atoms that have a particular property
-  ATOM_PROP_QUERY *makeAtomHasPropQuery(const std::string &property);
+  template<class Target>
+  Queries::EqualityQuery<int,const Target *,true> *makeHasPropQuery(
+        const std::string &property)
+  {
+      return new HasPropQuery<const Target *>(property);
+  }
 
   // ! Query whether an atom has a property with a value
-  template<class T>
-  class AtomHasPropWithValueQuery : public Queries::EqualityQuery<
-    int, ConstAtomPtr, true> {
+  template<class TargetPtr, class T>
+  class HasPropWithValueQuery : public Queries::EqualityQuery<
+    int, TargetPtr, true> {
     std::string propname;
     T val;
     T tolerance;
   public:
-    AtomHasPropWithValueQuery():
-    Queries::EqualityQuery<int,ConstAtomPtr,true>(),
+    HasPropWithValueQuery():
+    Queries::EqualityQuery<int,TargetPtr,true>(),
       propname(), val() {
       // default is to just do a number of rings query:
-      this->setDescription("AtomHasPropWithValue");
+      this->setDescription("HasPropWithValue");
       this->setDataFunc(0);
     };
-    explicit AtomHasPropWithValueQuery(const std::string & prop, const T&v,
+    explicit HasPropWithValueQuery(const std::string & prop, const T&v,
                                        const T&tol=0.0) :
-    Queries::EqualityQuery<int,ConstAtomPtr,true>(),
+    Queries::EqualityQuery<int,TargetPtr,true>(),
       propname(prop),
       val(v),
       tolerance(tol) {
       // default is to just do a number of rings query:
-      this->setDescription("AtomHasPropWithValue");
+      this->setDescription("HasPropWithValue");
       this->setDataFunc(0);
     };
 
-    virtual bool Match(const ConstAtomPtr what) const {
+    virtual bool Match(const TargetPtr what) const {
       bool res = what->hasProp(propname);
       if (res)
       {
         try {
-          T atom_val = what->getProp<T>(propname);
+          T atom_val = what->template getProp<T>(propname);
           res = Queries::queryCmp(atom_val, this->val, this->tolerance) == 0;
         }
         catch (KeyErrorException e) {
@@ -580,9 +588,9 @@ namespace RDKit{
     }
 
     //! returns a copy of this query
-    Queries::Query<int,ConstAtomPtr,true> *
+    Queries::Query<int,TargetPtr,true> *
     copy() const {
-      AtomHasPropWithValueQuery *res = new AtomHasPropWithValueQuery(
+      HasPropWithValueQuery *res = new HasPropWithValueQuery(
          this->propname, this->val, this->tolerance);
       res->setNegation(this->getNegation());
       res->d_description = this->d_description;
@@ -590,36 +598,36 @@ namespace RDKit{
     }
   };
 
-  template<>
-  class AtomHasPropWithValueQuery<std::string> : public Queries::EqualityQuery<
-    int, ConstAtomPtr, true> {
+  template<class TargetPtr>
+    class HasPropWithValueQuery<TargetPtr, std::string> :
+        public Queries::EqualityQuery<int, TargetPtr, true> {
     std::string propname;
     std::string val;
   public:
-    AtomHasPropWithValueQuery():
-    Queries::EqualityQuery<int,ConstAtomPtr,true>(),
+    HasPropWithValueQuery():
+    Queries::EqualityQuery<int,TargetPtr,true>(),
       propname(), val() {
       // default is to just do a number of rings query:
-      this->setDescription("AtomHasPropWithValue");
+      this->setDescription("HasPropWithValue");
       this->setDataFunc(0);
     };
-    explicit AtomHasPropWithValueQuery(const std::string & prop,
+    explicit HasPropWithValueQuery(const std::string & prop,
                                        const std::string &v,
                                        const std::string &tol="") :
-    Queries::EqualityQuery<int,ConstAtomPtr,true>(),
+    Queries::EqualityQuery<int,TargetPtr,true>(),
       propname(prop),
       val(v) {
       // default is to just do a number of rings query:
-      this->setDescription("AtomHasPropWithValue");
+      this->setDescription("HasPropWithValue");
       this->setDataFunc(0);
     };
 
-    virtual bool Match(const ConstAtomPtr what) const {
+    virtual bool Match(const TargetPtr what) const {
       bool res = what->hasProp(propname);
       if (res)
       {
         try {
-          std::string atom_val = what->getProp<std::string>(propname);
+          std::string atom_val = what->template getProp<std::string>(propname);
           res = atom_val == this->val;
         }
         catch (KeyErrorException) {
@@ -637,10 +645,10 @@ namespace RDKit{
     }
 
     //! returns a copy of this query
-    Queries::Query<int,ConstAtomPtr,true> *
+    Queries::Query<int,TargetPtr,true> *
     copy() const {
-      AtomHasPropWithValueQuery<std::string> *res =
-        new AtomHasPropWithValueQuery<std::string>(
+      HasPropWithValueQuery<TargetPtr,std::string> *res =
+        new HasPropWithValueQuery<TargetPtr, std::string>(
           this->propname, this->val);
       res->setNegation(this->getNegation());
       res->d_description = this->d_description;
@@ -649,13 +657,14 @@ namespace RDKit{
   };
   
   
-  template<class T>
-    Queries::EqualityQuery<int, ConstAtomPtr, true> *makeAtomPropQuery(
+  template<class Target, class T>
+    Queries::EqualityQuery<int, const Target *, true> *makePropQuery(
         const std::string &propname,
         const T&val,
         const T&tolerance=T())
     {
-      return new AtomHasPropWithValueQuery<T>(propname, val, tolerance);
+      return new HasPropWithValueQuery<const Target *, T>(
+         propname, val, tolerance);
     }
 };
 

--- a/Code/GraphMol/querytest.cpp
+++ b/Code/GraphMol/querytest.cpp
@@ -615,7 +615,7 @@ void testGithub165(){
 void testHasPropMatch()
 {
   QueryAtom qA;
-  qA.setQuery(makeAtomHasPropQuery("foo"));
+  qA.setQuery(makeHasPropQuery<Atom>("foo"));
   Atom a1(6);
   TEST_ASSERT(!qA.Match(&a1));
   a1.setProp<int>("foo", 1);
@@ -626,7 +626,7 @@ void testHasPropWithValueMatch()
 {
   {
     QueryAtom qA;
-    qA.setQuery(makeAtomPropQuery<int>("foo", 2));
+    qA.setQuery(makePropQuery<Atom,int>("foo", 2));
     Atom a1(6);
     TEST_ASSERT(!qA.Match(&a1));
     a1.setProp<int>("foo", 1);
@@ -641,25 +641,61 @@ void testHasPropWithValueMatch()
 
   {
     QueryAtom qA;
-    qA.setQuery(makeAtomPropQuery<std::string>("foo", "bar"));
+    qA.setQuery(makePropQuery<Atom,std::string>("foo", "bar"));
     Atom a1(6);
     TEST_ASSERT(!qA.Match(&a1));
     a1.setProp<std::string>("foo", "bar");
     TEST_ASSERT(qA.Match(&a1));    
   }
+
+  {
+    QueryBond qA;
+    qA.setQuery(makePropQuery<Bond,int>("foo", 2));
+    Bond a1;
+    TEST_ASSERT(!qA.Match(&a1));
+    a1.setProp<int>("foo", 1);
+    TEST_ASSERT(!qA.Match(&a1));
+    a1.setProp<int>("foo", 2);
+    TEST_ASSERT(qA.Match(&a1));
     
+    a1.clearProp("foo");
+    a1.setProp<double>("foo", 2);
+    TEST_ASSERT(!qA.Match(&a1));
+  }
+
+  {
+    QueryBond qA;
+    qA.setQuery(makePropQuery<Bond,std::string>("foo", "bar"));
+    Bond a1;
+    TEST_ASSERT(!qA.Match(&a1));
+    a1.setProp<std::string>("foo", "bar");
+    TEST_ASSERT(qA.Match(&a1));    
+  }
+  
 }
 
 void testHasPropWithDoubleValueMatch()
 {
-  QueryAtom qA;
-  qA.setQuery(makeAtomPropQuery<double>("foo", 2));
-  Atom a1(6);
-  TEST_ASSERT(!qA.Match(&a1));
-  a1.setProp<double>("foo", 1);
-  TEST_ASSERT(!qA.Match(&a1));
-  a1.setProp<double>("foo", 2);
-  TEST_ASSERT(qA.Match(&a1));
+  {
+    QueryAtom qA;
+    qA.setQuery(makePropQuery<Atom, double>("foo", 2));
+    Atom a1(6);
+    TEST_ASSERT(!qA.Match(&a1));
+    a1.setProp<double>("foo", 1);
+    TEST_ASSERT(!qA.Match(&a1));
+    a1.setProp<double>("foo", 2);
+    TEST_ASSERT(qA.Match(&a1));
+  }
+  {
+    QueryBond qA;
+    qA.setQuery(makePropQuery<Bond, double>("foo", 2));
+    Bond a1;
+    TEST_ASSERT(!qA.Match(&a1));
+    a1.setProp<double>("foo", 1);
+    TEST_ASSERT(!qA.Match(&a1));
+    a1.setProp<double>("foo", 2);
+    TEST_ASSERT(qA.Match(&a1));
+  }
 }
 
 int main(){

--- a/Code/GraphMol/querytest.cpp
+++ b/Code/GraphMol/querytest.cpp
@@ -612,8 +612,55 @@ void testGithub165(){
 }
 
 
+void testHasPropMatch()
+{
+  QueryAtom qA;
+  qA.setQuery(makeAtomHasPropQuery("foo"));
+  Atom a1(6);
+  TEST_ASSERT(!qA.Match(&a1));
+  a1.setProp<int>("foo", 1);
+  TEST_ASSERT(qA.Match(&a1));
+}
 
+void testHasPropWithValueMatch()
+{
+  {
+    QueryAtom qA;
+    qA.setQuery(makeAtomPropQuery<int>("foo", 2));
+    Atom a1(6);
+    TEST_ASSERT(!qA.Match(&a1));
+    a1.setProp<int>("foo", 1);
+    TEST_ASSERT(!qA.Match(&a1));
+    a1.setProp<int>("foo", 2);
+    TEST_ASSERT(qA.Match(&a1));
+    
+    a1.clearProp("foo");
+    a1.setProp<double>("foo", 2);
+    TEST_ASSERT(!qA.Match(&a1));
+  }
 
+  {
+    QueryAtom qA;
+    qA.setQuery(makeAtomPropQuery<std::string>("foo", "bar"));
+    Atom a1(6);
+    TEST_ASSERT(!qA.Match(&a1));
+    a1.setProp<std::string>("foo", "bar");
+    TEST_ASSERT(qA.Match(&a1));    
+  }
+    
+}
+
+void testHasPropWithDoubleValueMatch()
+{
+  QueryAtom qA;
+  qA.setQuery(makeAtomPropQuery<double>("foo", 2));
+  Atom a1(6);
+  TEST_ASSERT(!qA.Match(&a1));
+  a1.setProp<double>("foo", 1);
+  TEST_ASSERT(!qA.Match(&a1));
+  a1.setProp<double>("foo", 2);
+  TEST_ASSERT(qA.Match(&a1));
+}
 
 int main(){
   RDLog::InitLogs();
@@ -629,6 +676,9 @@ int main(){
   testGithub153();
   testQualifiedQueries();
   testGithub165();
+  testHasPropMatch();
+  testHasPropWithValueMatch();
+  testHasPropWithDoubleValueMatch();
 #endif
   return 0;
 }


### PR DESCRIPTION
I'm not entirely sure I did this correctly, but the regression tests pass :)  If you think it's a good idea I'll add python wrappers which will probably be a bit harder!

 Examples:

    QueryAtom qA;
    qA.setQuery(makeAtomHasPropQuery("foo"));

    QueryAtom qA;
    qA.setQuery(makeAtomPropQuery<double>("foo", 2));

    QueryAtom qA;
    qA.setQuery(makeAtomPropQuery<std::string>("foo", "bar"));