### PR TITLE
RDKit learns how to release the GIL in python

### DIFF
--- a/Code/GraphMol/ChemReactions/Wrap/rdChemReactions.cpp
+++ b/Code/GraphMol/ChemReactions/Wrap/rdChemReactions.cpp
@@ -79,6 +79,7 @@ namespace RDKit {
   template <typename T>
   PyObject* RunReactants(ChemicalReaction *self,T reactants){
     if(!self->isInitialized()){
+      NOGIL gil;    
       self->initReactantMatchers();
     }
     MOL_SPTR_VECT reacts;
@@ -89,7 +90,10 @@ namespace RDKit {
       if(!reacts[i]) throw_value_error("reaction called with None reactants");
     }
     std::vector<MOL_SPTR_VECT> mols;
-    mols = self->runReactants(reacts);
+    {
+      NOGIL gil;
+      mols = self->runReactants(reacts);
+    }
     PyObject *res=PyTuple_New(mols.size());
     
     for(unsigned int i=0;i<mols.size();++i){

--- a/Code/GraphMol/Wrap/Mol.cpp
+++ b/Code/GraphMol/Wrap/Mol.cpp
@@ -16,6 +16,7 @@
 #include "seqs.hpp"
 // ours
 #include <RDBoost/pyint_api.h>
+#include <RDBoost/Wrap.h>
 #include <GraphMol/RDKitBase.h>
 #include <GraphMol/QueryOps.h>
 #include <GraphMol/MolPickler.h>
@@ -30,7 +31,10 @@ namespace RDKit {
 
   python::object MolToBinary(const ROMol &self){
     std::string res;
-    MolPickler::pickleMol(self,res);
+    {
+      NOGIL gil;
+      MolPickler::pickleMol(self,res);
+    }
     python::object retval = python::object(python::handle<>(PyBytes_FromStringAndSize(res.c_str(),res.length())));
     return retval;
   }
@@ -51,6 +55,7 @@ namespace RDKit {
   bool HasSubstructMatchStr(std::string pkl, const ROMol &query,
 			    bool recursionPossible=true,bool useChirality=false,
                             bool useQueryQueryMatches=false){
+    NOGIL gil;
     ROMol *mol;
     try {
       mol = new ROMol(pkl);
@@ -69,6 +74,7 @@ namespace RDKit {
   bool HasSubstructMatch(const ROMol &mol, const ROMol &query,
 			 bool recursionPossible=true,bool useChirality=false,
                             bool useQueryQueryMatches=false){
+    NOGIL gil;
     MatchVectType res;
     return SubstructMatch(mol,query,res,recursionPossible,useChirality,useQueryQueryMatches);
   }
@@ -83,6 +89,7 @@ namespace RDKit {
   }
   PyObject *GetSubstructMatch(const ROMol &mol, const ROMol &query,bool useChirality=false,
                             bool useQueryQueryMatches=false){
+    NOGIL gil;
     MatchVectType matches;
     SubstructMatch(mol,query,matches,true,useChirality,useQueryQueryMatches);
     return convertMatches(matches);

--- a/Code/RDBoost/Wrap.h
+++ b/Code/RDBoost/Wrap.h
@@ -130,4 +130,22 @@ std::vector<T> *pythonObjectToVect(const python::object &obj){
   return res;
 }
 
+class NOGIL
+{
+public:
+    inline NOGIL()
+    {
+        m_thread_state = PyEval_SaveThread();
+    }
+
+    inline ~NOGIL()
+    {
+        PyEval_RestoreThread(m_thread_state);
+        m_thread_state = NULL;
+    }
+
+private:
+    PyThreadState * m_thread_state;
+};
+
 #endif


### PR DESCRIPTION
Adds basic support for removing the GIL.

Only a few functions were modified that have been tested in a multi-threaded web-service.  

Note: The GIL can only be turned off where code does not call the PYTHON API, in many cases this is the whole function but in a few cases below it isn't.  Fortunately, Python appears to crash when the GIL is not re-acquired before a python api call, so they are fairly easy to find.
