### PR TITLE
Dev/property queries

### DIFF
--- a/Code/GraphMol/Wrap/Atom.cpp
+++ b/Code/GraphMol/Wrap/Atom.cpp
@@ -58,24 +58,26 @@ namespace RDKit{
     }
   }
 
-  void AtomSetProp(const Atom *atom, const char *key,std::string val) {
+  template<class T>
+  void AtomSetProp(const Atom *atom, const char *key, const T& val) {
     //std::cerr<<"asp: "<<atom<<" " << key<<" - " << val << std::endl;
-    atom->setProp(key, val);
+    atom->setProp<T>(key, val);
   }
-  
+
   int AtomHasProp(const Atom *atom, const char *key) {
     //std::cerr<<"ahp: "<<atom<<" " << key<< std::endl;
     int res = atom->hasProp(key);
     return res;
   }
 
-  std::string AtomGetProp(const Atom *atom, const char *key) {
+  template<class T>
+  T AtomGetProp(const Atom *atom, const char *key) {
     if (!atom->hasProp(key)) {
       PyErr_SetString(PyExc_KeyError,key);
       throw python::error_already_set();
     }
-    std::string res;
-    atom->getProp(key, res);
+    T res;
+    atom->getProp<T>(key, res);
     return res;
   }
 
@@ -275,7 +277,7 @@ struct atom_wrapper {
               "returns the SMARTS (or SMILES) string for an Atom\n\n")
 
       // properties
-      .def("SetProp",AtomSetProp,
+      .def("SetProp",AtomSetProp<std::string>,
 	   (python::arg("self"), python::arg("key"),
 	    python::arg("val")),
 	   "Sets an atomic property\n\n"
@@ -283,8 +285,8 @@ struct atom_wrapper {
 	   "    - key: the name of the property to be set (a string).\n"
 	   "    - value: the property value (a string).\n\n"
            )
-
-      .def("GetProp", AtomGetProp,
+      
+      .def("GetProp", AtomGetProp<std::string>,
            "Returns the value of the property.\n\n"
 	   "  ARGUMENTS:\n"
 	   "    - key: the name of the property to return (a string).\n\n"
@@ -292,6 +294,57 @@ struct atom_wrapper {
 	   "  NOTE:\n"
 	   "    - If the property has not been set, a KeyError exception will be raised.\n")
 
+      .def("SetIntProp",AtomSetProp<int>,
+	   (python::arg("self"), python::arg("key"),
+	    python::arg("val")),
+	   "Sets an atomic property\n\n"
+	   "  ARGUMENTS:\n"
+	   "    - key: the name of the property to be set (a int).\n"
+	   "    - value: the property value (a int).\n\n"
+           )
+      
+      .def("GetIntProp", AtomGetProp<int>,
+           "Returns the value of the property.\n\n"
+	   "  ARGUMENTS:\n"
+	   "    - key: the name of the property to return (an int).\n\n"
+	   "  RETURNS: an int\n\n"
+	   "  NOTE:\n"
+	   "    - If the property has not been set, a KeyError exception will be raised.\n")
+
+      .def("SetDoubleProp",AtomSetProp<double>,
+	   (python::arg("self"), python::arg("key"),
+	    python::arg("val")),
+	   "Sets an atomic property\n\n"
+	   "  ARGUMENTS:\n"
+	   "    - key: the name of the property to be set (a double).\n"
+	   "    - value: the property value (a double).\n\n"
+           )
+      
+      .def("GetDoubleProp", AtomGetProp<double>,
+           "Returns the value of the property.\n\n"
+	   "  ARGUMENTS:\n"
+	   "    - key: the name of the property to return (a double).\n\n"
+	   "  RETURNS: a double\n\n"
+	   "  NOTE:\n"
+	   "    - If the property has not been set, a KeyError exception will be raised.\n")
+      
+      .def("SetBoolProp",AtomSetProp<bool>,
+	   (python::arg("self"), python::arg("key"),
+	    python::arg("val")),
+	   "Sets an atomic property\n\n"
+	   "  ARGUMENTS:\n"
+	   "    - key: the name of the property to be set (a bool).\n"
+	   "    - value: the property value (a bool).\n\n"
+           )
+      
+      .def("GetBoolProp", AtomGetProp<bool>,
+           "Returns the value of the property.\n\n"
+	   "  ARGUMENTS:\n"
+	   "    - key: the name of the property to return (a bool).\n\n"
+	   "  RETURNS: a bool\n\n"
+	   "  NOTE:\n"
+	   "    - If the property has not been set, a KeyError exception will be raised.\n")
+      
       .def("HasProp", AtomHasProp,
            "Queries a Atom to see if a particular property has been assigned.\n\n"
 	   "  ARGUMENTS:\n"

--- a/Code/GraphMol/Wrap/Bond.cpp
+++ b/Code/GraphMol/Wrap/Bond.cpp
@@ -48,6 +48,14 @@ namespace RDKit{
     return res;
   }
 
+  void expandQuery(QueryBond *self,const QueryBond *other,
+                          Queries::CompositeQueryType how,
+                          bool maintainOrder){
+    if(other->hasQuery()){
+      const QueryBond::QUERYBOND_QUERY *qry=other->getQuery();
+      self->expandQuery(qry->copy(),how,maintainOrder);
+    }
+  }
 
 
   int BondHasProp(const Bond *bond, const char *key) {
@@ -55,8 +63,9 @@ namespace RDKit{
     return res;
   }
 
-  void BondSetProp(const Bond *bond, const char *key,std::string val) {
-    bond->setProp(key, val);
+  template<class T>
+  void BondSetProp(const Bond *bond, const char *key, const T&val) {
+    bond->setProp<T>(key, val);
   }
   void BondClearProp(const Bond *bond, const char *key){
     if (!bond->hasProp(key)) {
@@ -65,14 +74,14 @@ namespace RDKit{
     bond->clearProp(key);
   }
 
-
-  std::string BondGetProp(const Bond *bond, const char *key) {
+  template<class T>
+  T BondGetProp(const Bond *bond, const char *key) {
     if (!bond->hasProp(key)) {
       PyErr_SetString(PyExc_KeyError,key);
       throw python::error_already_set();
     }
-    std::string res;
-    bond->getProp(key, res);
+    T res;
+    bond->getProp<T>(key, res);
     return res;
   }
 
@@ -199,7 +208,7 @@ struct bond_wrapper {
               "returns the SMARTS (or SMILES) string for a Bond")
 
       // properties
-      .def("SetProp",BondSetProp,
+      .def("SetProp",BondSetProp<std::string>,
 	   (python::arg("self"), python::arg("key"),
 	    python::arg("val")),
 	   "Sets a bond property\n\n"
@@ -208,7 +217,7 @@ struct bond_wrapper {
 	   "    - value: the property value (a string).\n\n"
            )
 
-      .def("GetProp", BondGetProp,
+      .def("GetProp", BondGetProp<std::string>,
            "Returns the value of the property.\n\n"
 	   "  ARGUMENTS:\n"
 	   "    - key: the name of the property to return (a string).\n\n"
@@ -216,11 +225,63 @@ struct bond_wrapper {
 	   "  NOTE:\n"
 	   "    - If the property has not been set, a KeyError exception will be raised.\n")
 
+      .def("SetIntProp",BondSetProp<int>,
+	   (python::arg("self"), python::arg("key"),
+	    python::arg("val")),
+	   "Sets a bond property\n\n"
+	   "  ARGUMENTS:\n"
+	   "    - key: the name of the property to be set (a string).\n"
+	   "    - value: the property value (an int).\n\n"
+           )
+
+      .def("GetIntProp", BondGetProp<int>,
+           "Returns the value of the property.\n\n"
+	   "  ARGUMENTS:\n"
+	   "    - key: the name of the property to return (an int).\n\n"
+	   "  RETURNS: an int\n\n"
+	   "  NOTE:\n"
+	   "    - If the property has not been set, a KeyError exception will be raised.\n")
+
+      .def("SetDoubleProp",BondSetProp<double>,
+	   (python::arg("self"), python::arg("key"),
+	    python::arg("val")),
+	   "Sets a bond property\n\n"
+	   "  ARGUMENTS:\n"
+	   "    - key: the name of the property to be set (a string).\n"
+	   "    - value: the property value (a double).\n\n"
+           )
+
+      .def("GetDoubleProp", BondGetProp<double>,
+           "Returns the value of the property.\n\n"
+	   "  ARGUMENTS:\n"
+	   "    - key: the name of the property to return (a double).\n\n"
+	   "  RETURNS: a double\n\n"
+	   "  NOTE:\n"
+	   "    - If the property has not been set, a KeyError exception will be raised.\n")
+
+      .def("SetBoolProp",BondSetProp<bool>,
+	   (python::arg("self"), python::arg("key"),
+	    python::arg("val")),
+	   "Sets a bond property\n\n"
+	   "  ARGUMENTS:\n"
+	   "    - key: the name of the property to be set (a string).\n"
+	   "    - value: the property value (a boolean).\n\n"
+           )
+
+      .def("GetBoolProp", BondGetProp<bool>,
+           "Returns the value of the property.\n\n"
+	   "  ARGUMENTS:\n"
+	   "    - key: the name of the property to return (a boolean).\n\n"
+	   "  RETURNS: a boolean\n\n"
+	   "  NOTE:\n"
+	   "    - If the property has not been set, a KeyError exception will be raised.\n")
+
+      
       .def("HasProp", BondHasProp,
            "Queries a Bond to see if a particular property has been assigned.\n\n"
 	   "  ARGUMENTS:\n"
 	   "    - key: the name of the property to check for (a string).\n")
-
+      
       .def("ClearProp", BondClearProp,
            "Removes a particular property from an Bond (does nothing if not already set).\n\n"
 	   "  ARGUMENTS:\n"
@@ -271,6 +332,12 @@ struct bond_wrapper {
       .value("STEREOZ",Bond::STEREOZ)
       .value("STEREOE",Bond::STEREOE)
       ;
+
+    bondClassDoc="The class to store QueryBonds.\n\
+These cannot currently be constructed directly from Python\n";
+    python::class_<QueryBond,python::bases<Bond> >("QueryBond",bondClassDoc.c_str(),python::no_init)
+      ;
+    
   };
   
 };

--- a/Code/GraphMol/Wrap/Queries.cpp
+++ b/Code/GraphMol/Wrap/Queries.cpp
@@ -74,9 +74,28 @@ namespace RDKit{
   QAFUNC2(IsAliphaticQueryAtom,makeAtomAliphaticQuery,int);
   QAFUNC2(IsInRingQueryAtom,makeAtomInRingQuery,int);
 
+ QueryAtom *HasPropQueryAtom(const std::string &propname, bool negate) {       \
+    QueryAtom *res=new QueryAtom();\
+    res->setQuery(makeHasPropQuery<Atom>(propname));    \
+    if(negate) res->getQuery()->setNegation(true);\
+    return res;\
+  }
 
+ QueryBond *HasPropQueryBond(const std::string &propname, bool negate) {       \
+    QueryBond *res=new QueryBond();\
+    res->setQuery(makeHasPropQuery<Bond>(propname));    \
+    if(negate) res->getQuery()->setNegation(true);\
+    return res;\
+  }
 
-
+template<class Ret, class T>
+Ret *PropQuery(const std::string &propname, const T &v, bool negate) { \
+    QueryAtom *res=new QueryAtom();\
+    res->setQuery(makePropQuery<Atom,T>(propname,v));   \
+    if(negate) res->getQuery()->setNegation(true);\
+    return res;\
+  }
+      
 struct queries_wrapper {
   static void wrap(){
 #define QADEF1(_funcname_)     python::def(# _funcname_ "EqualsQueryAtom",_funcname_##EqualsQueryAtom,\
@@ -117,6 +136,15 @@ struct queries_wrapper {
     QADEF2(IsAliphatic);
     QADEF2(IsInRing);
 
+    python::def("HasPropQueryAtom",HasPropQueryAtom,
+                (python::arg("propname"),python::arg("negate")=false),
+                "Returns a QueryAtom that matches when the propery 'propname' exists in the atom.",
+                python::return_value_policy<python::manage_new_object>());
+
+    python::def("HasPropQueryBond",HasPropQueryBond,
+                (python::arg("propname"),python::arg("negate")=false),
+                "Returns a QueryBond that matches when the propery 'propname' exists in the bond.",
+                python::return_value_policy<python::manage_new_object>());
     
   };
 };

--- a/Code/GraphMol/Wrap/Queries.cpp
+++ b/Code/GraphMol/Wrap/Queries.cpp
@@ -88,14 +88,22 @@ namespace RDKit{
     return res;\
   }
 
-template<class Ret, class T>
+template<class Ob, class Ret, class T>
 Ret *PropQuery(const std::string &propname, const T &v, bool negate) { \
-    QueryAtom *res=new QueryAtom();\
-    res->setQuery(makePropQuery<Atom,T>(propname,v));   \
+    Ret *res=new Ret();\
+    res->setQuery(makePropQuery<Ob,T>(propname,v));  \
     if(negate) res->getQuery()->setNegation(true);\
     return res;\
   }
-      
+
+template<class Ob, class Ret, class T>
+Ret *PropQueryWithTol(const std::string &propname, const T &v, bool negate, const T &tol=T() ) { \
+    Ret *res=new Ret();\
+    res->setQuery(makePropQuery<Ob,T>(propname,v, tol));  \
+    if(negate) res->getQuery()->setNegation(true);\
+    return res;\
+  }
+  
 struct queries_wrapper {
   static void wrap(){
 #define QADEF1(_funcname_)     python::def(# _funcname_ "EqualsQueryAtom",_funcname_##EqualsQueryAtom,\
@@ -144,6 +152,68 @@ struct queries_wrapper {
     python::def("HasPropQueryBond",HasPropQueryBond,
                 (python::arg("propname"),python::arg("negate")=false),
                 "Returns a QueryBond that matches when the propery 'propname' exists in the bond.",
+                python::return_value_policy<python::manage_new_object>());
+
+    python::def("HasIntPropWithValueQueryAtom",PropQueryWithTol<Atom, QueryAtom, int>,
+                (python::arg("propname"),python::arg("val"),python::arg("negate")=false,
+                 python::arg("tolerance")=0),
+                "Returns a QueryAtom that matches when the propery 'propname' has the specified int value.",
+                python::return_value_policy<python::manage_new_object>());
+
+    python::def("HasBoolPropWithValueQueryAtom",PropQuery<Atom, QueryAtom, bool>,
+                (python::arg("propname"),python::arg("val"),python::arg("negate")=false),
+                "Returns a QueryAtom that matches when the propery 'propname' has the specified boolean"
+                " value.",
+                python::return_value_policy<python::manage_new_object>());
+
+    python::def("HasStringPropWithValueQueryAtom",PropQuery<Atom, QueryAtom, std::string>,
+                (python::arg("propname"),python::arg("val"),python::arg("negate")=false),
+                "Returns a QueryAtom that matches when the propery 'propname' has the specified string "
+                "value.",
+                python::return_value_policy<python::manage_new_object>());
+
+    python::def("HasDoublePropWithValueQueryAtom",PropQueryWithTol<Atom, QueryAtom, double>,
+                (python::arg("propname"),python::arg("val"),python::arg("negate")=false,
+                 python::arg("tolerance")=0.0),
+                "Returns a QueryAtom that matches when the propery 'propname' has the specified "
+                "value +- tolerance",
+                python::return_value_policy<python::manage_new_object>());
+
+    /////////////////////////////////////////////////////////////////////////////////////
+    //  Bond Queries
+    python::def("HasPropQueryBond",HasPropQueryBond,
+                (python::arg("propname"),python::arg("negate")=false),
+                "Returns a QueryBond that matches when the propery 'propname' exists in the bond.",
+                python::return_value_policy<python::manage_new_object>());
+
+    python::def("HasPropQueryBond",HasPropQueryBond,
+                (python::arg("propname"),python::arg("negate")=false),
+                "Returns a QueryBond that matches when the propery 'propname' exists in the bond.",
+                python::return_value_policy<python::manage_new_object>());
+
+    python::def("HasIntPropWithValueQueryBond",PropQueryWithTol<Bond, QueryBond, int>,
+                (python::arg("propname"),python::arg("val"),python::arg("negate")=false,
+                 python::arg("tolerance")=0),
+                "Returns a QueryBond that matches when the propery 'propname' has the specified int value.",
+                python::return_value_policy<python::manage_new_object>());
+
+    python::def("HasBoolPropWithValueQueryBond",PropQuery<Bond, QueryBond, bool>,
+                (python::arg("propname"),python::arg("val"),python::arg("negate")=false),
+                "Returns a QueryBond that matches when the propery 'propname' has the specified boolean"
+                " value.",
+                python::return_value_policy<python::manage_new_object>());
+
+    python::def("HasStringPropWithValueQueryBond",PropQuery<Bond, QueryBond, std::string>,
+                (python::arg("propname"),python::arg("val"),python::arg("negate")=false),
+                "Returns a QueryBond that matches when the propery 'propname' has the specified string "
+                "value.",
+                python::return_value_policy<python::manage_new_object>());
+
+    python::def("HasDoublePropWithValueQueryBond",PropQueryWithTol<Bond, QueryBond, double>,
+                (python::arg("propname"),python::arg("val"),python::arg("negate")=false,
+                 python::arg("tolerance")=0.0),
+                "Returns a QueryBond that matches when the propery 'propname' has the specified "
+                "value +- tolerance",
                 python::return_value_policy<python::manage_new_object>());
     
   };


### PR DESCRIPTION
String/Int/Bool and Double properties can now be set on Atoms/Bonds ( this was mostly to actually test the Python API!)

rdqueries now has

 HasIntPropWithValueQueryAtom/Bond
 HasDoublePropWithValueQueryAtom/Bond
 HasStringPropWithValueQueryAtom/Bond
 HasBoolPropWithValueQueryAtom/Bond

Int and Double values also except tolerances (+/-)

It would be nice to have >,>-,<,<= and ranges but this was beyond me this evening :)