### PR TITLE
RDKit exposes Atom/Bond bookmarks to python

### DIFF
--- a/Code/GraphMol/ROMol.h
+++ b/Code/GraphMol/ROMol.h
@@ -226,16 +226,27 @@ namespace RDKit{
     //@{
 
     //! associates an Atom pointer with a bookmark
-    void setAtomBookmark(ATOM_SPTR at,int mark) {d_atomBookmarks[mark].push_back(at.get());};
+    void setAtomBookmark(ATOM_SPTR at,int mark) {
+      setAtomBookmark(at.get(), mark);
+    }
     //! \overload
-    void setAtomBookmark(Atom *at,int mark) {d_atomBookmarks[mark].push_back(at);};
+    void setAtomBookmark(Atom *at,int mark) {
+      PRECONDITION(at, "NULL atom provided");
+      PRECONDITION(&at->getOwningMol()==this,
+                   "Can only bookmark atoms owned by this molecule");
+
+      d_atomBookmarks[mark].push_back(at);};
+
     //! associates an Atom pointer with a bookmark
     void replaceAtomBookmark(ATOM_SPTR at,int mark) {
-      d_atomBookmarks[mark].clear();
-      d_atomBookmarks[mark].push_back(at.get());
+      replaceAtomBookmark(at.get(), mark);
     };
     //! \overload
     void replaceAtomBookmark(Atom *at,int mark) {
+      PRECONDITION(at, "NULL atom provided");
+      PRECONDITION(&at->getOwningMol()==this,
+                   "Can only bookmark atoms owned by this molecule");
+      
       d_atomBookmarks[mark].clear();
       d_atomBookmarks[mark].push_back(at);
     };
@@ -257,9 +268,16 @@ namespace RDKit{
     ATOM_BOOKMARK_MAP *getAtomBookmarks() { return &d_atomBookmarks; };
 
     //! associates a Bond pointer with a bookmark
-    void setBondBookmark(BOND_SPTR bond,int mark) {d_bondBookmarks[mark].push_back(bond.get());};
+    void setBondBookmark(BOND_SPTR bond,int mark) {
+      setBondBookmark(bond.get(), mark);
+    }
     //! \overload
-    void setBondBookmark(Bond *bond,int mark) {d_bondBookmarks[mark].push_back(bond);};
+    void setBondBookmark(Bond *bond,int mark) {
+      //      PRECONDITION(bond, "NULL atom provided");
+      //PRECONDITION(&bond->getOwningMol()==this,
+      //             "Can only bookmark bonds owned by this molecule");
+
+      d_bondBookmarks[mark].push_back(bond);};
     //! returns the first Bond associated with the \c bookmark provided
     Bond *getBondWithBookmark(int mark);
     //! returns all bonds associated with the \c bookmark provided

--- a/Code/GraphMol/Wrap/Atom.cpp
+++ b/Code/GraphMol/Wrap/Atom.cpp
@@ -160,7 +160,7 @@ Note that, though it is possible to create one, having an Atom on its own\n\
 (i.e not associated with a molecule) is not particularly useful.\n";
 struct atom_wrapper {
   static void wrap(){
-    python::class_<Atom>("Atom",atomClassDoc.c_str(),python::init<std::string>())
+    python::class_<Atom,Atom*>("Atom",atomClassDoc.c_str(),python::init<std::string>())
 
       .def(python::init<unsigned int>("Constructor, takes either an int (atomic number) or a string (atomic symbol).\n"))
 

--- a/Code/GraphMol/Wrap/Bond.cpp
+++ b/Code/GraphMol/Wrap/Bond.cpp
@@ -121,7 +121,7 @@ Note: unlike Atoms, is it currently impossible to construct Bonds from\n\
 Python.\n";
 struct bond_wrapper {
   static void wrap(){
-    python::class_<Bond>("Bond",bondClassDoc.c_str(),python::no_init)
+    python::class_<Bond,Bond*>("Bond",bondClassDoc.c_str(),python::no_init)
 
       .def("GetOwningMol",&Bond::getOwningMol,
 	   "Returns the Mol that owns this bond.\n",

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -2780,6 +2780,14 @@ CAS<~>
                       [a.GetIdx() for a in m.GetAllAtomsWithBookmark(-1)])
     m.ClearAllAtomBookmarks()
     self.assertFalse(m.HasAtomBookmark(-1))
+
+    m2 = Chem.MolFromSmiles("C")
+    other_atom = list(m2.GetAtoms())[0]
+    try:
+      m.SetAtomBookmark(other_atom, 1000)
+      self.assertFalse("Should have been a runtime error!")
+    except RuntimeError, m:
+      self.assertEquals(str(m), "Pre-condition Violation")
     
   def testBondBookmarks(self):
     m = Chem.MolFromSmiles("C" * 14)
@@ -2806,6 +2814,14 @@ CAS<~>
                       [a.GetIdx() for a in m.GetAllBondsWithBookmark(-1)])
     m.ClearAllBondBookmarks()
     self.assertFalse(m.HasBondBookmark(-1))
+
+    m2 = Chem.MolFromSmiles("CC")
+    other_bond = list(m2.GetBonds())[0]
+    try:
+      m.SetBondBookmark(other_bond, 1000)
+      self.assertFalse("Should have been a runtime error!")
+    except RuntimeError, m:
+      self.assertEquals(str(m), "Pre-condition Violation")
 
     
           

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -2786,8 +2786,8 @@ CAS<~>
     try:
       m.SetAtomBookmark(other_atom, 1000)
       self.assertFalse("Should have been a runtime error!")
-    except RuntimeError, m:
-      self.assertEquals(str(m), "Pre-condition Violation")
+    except RuntimeError:
+      pass
     
   def testBondBookmarks(self):
     m = Chem.MolFromSmiles("C" * 14)
@@ -2820,8 +2820,8 @@ CAS<~>
     try:
       m.SetBondBookmark(other_bond, 1000)
       self.assertFalse("Should have been a runtime error!")
-    except RuntimeError, m:
-      self.assertEquals(str(m), "Pre-condition Violation")
+    except RuntimeError:
+      pass
 
     
           

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -2755,7 +2755,60 @@ CAS<~>
     self.assertEqual([x.GetIdx() for x in m.GetBonds() if q.Match(x)],
                      [10])
     
+  def testAtomBookmarks(self):
+    m = Chem.MolFromSmiles("C" * 14)
+    self.assertEquals(m.HasAtomBookmark(0), False)
     
+    atoms = list(m.GetAtoms())
+    for i in range(10):
+      self.assertFalse(m.HasAtomBookmark(i))
+
+    for atom in m.GetAtoms():
+      idx = atom.GetIdx()
+      m.SetAtomBookmark(atom, idx)
+
+    for i in range(len(m.GetAtoms())):
+      at = m.GetAtomWithBookmark(i)
+      self.assertEquals(at.GetIdx(),  i)
+      self.assertEquals([i], [a.GetIdx() for a in m.GetAllAtomsWithBookmark(i)])
+      m.ClearAtomBookmark(i,at)
+      self.assertFalse(m.HasAtomBookmark(i))
+
+    for atom in m.GetAtoms():
+      m.SetAtomBookmark(atom, -1)
+    self.assertEquals([a.GetIdx() for a in m.GetAtoms()],
+                      [a.GetIdx() for a in m.GetAllAtomsWithBookmark(-1)])
+    m.ClearAllAtomBookmarks()
+    self.assertFalse(m.HasAtomBookmark(-1))
+    
+  def testBondBookmarks(self):
+    m = Chem.MolFromSmiles("C" * 14)
+    self.assertEquals(m.HasBondBookmark(0), False)
+    
+    bonds = list(m.GetBonds())
+    for i in range(10):
+      self.assertFalse(m.HasBondBookmark(i))
+
+    for bond in m.GetBonds():
+      idx = bond.GetIdx()
+      m.SetBondBookmark(bond, idx)
+
+    for i in range(len(m.GetBonds())):
+      at = m.GetBondWithBookmark(i)
+      self.assertEquals(at.GetIdx(),  i)
+      self.assertEquals([i], [a.GetIdx() for a in m.GetAllBondsWithBookmark(i)])
+      m.ClearBondBookmark(i,at)
+      self.assertFalse(m.HasBondBookmark(i))
+
+    for bond in m.GetBonds():
+      m.SetBondBookmark(bond, -1)
+    self.assertEquals([a.GetIdx() for a in m.GetBonds()],
+                      [a.GetIdx() for a in m.GetAllBondsWithBookmark(-1)])
+    m.ClearAllBondBookmarks()
+    self.assertFalse(m.HasBondBookmark(-1))
+
+    
+          
 if __name__ == '__main__':
   unittest.main()
 

--- a/Code/RDBoost/WrapList.h
+++ b/Code/RDBoost/WrapList.h
@@ -1,0 +1,99 @@
+#include <list>
+#include <algorithm>
+#include <boost/python.hpp>
+
+// from
+// http://stackoverflow.com/questions/6776888/wrapping-a-list-of-structs-with-boost-python
+//  * modified to allow ptr classes and actually compile as intended
+template<class T>
+struct listwrap
+{
+    typedef typename std::list<T> L;
+    typedef typename L::value_type value_type;
+    typedef typename L::iterator iter_type;
+
+    static void add(L & x, value_type const& v)
+    {
+        x.push_back(v);
+    }
+
+    static bool in(L const& x, value_type const& v)
+    {
+        return std::find(x.begin(), x.end(), v) != x.end();
+    }
+
+    static int index(L const& x, value_type const& v)
+    {
+        int i = 0;
+        for(typename L::const_iterator it=x.begin(); it!=x.end(); ++it,++i)
+            if( *it == v ) return i;
+
+        PyErr_SetString(PyExc_ValueError, "Value not in the list");
+        throw boost::python::error_already_set();
+    }
+
+    static void del(L& x, int i)
+    {
+        if( i<0 ) 
+            i += x.size();
+
+        iter_type it = x.begin();
+        for (int pos = 0; pos < i; ++pos)
+            ++it;
+
+        if( i >= 0 && i < (int)x.size() ) {
+            x.erase(it);
+        } else {
+            PyErr_SetString(PyExc_IndexError, "Index out of range");
+            boost::python::throw_error_already_set();
+        }
+    }
+
+    static value_type& get(L& x, int i)
+    {
+        if( i < 0 ) 
+            i += x.size();
+
+        if( i >= 0 && i < (int)x.size() ) {
+            iter_type it = x.begin(); 
+            for(int pos = 0; pos < i; ++pos)
+                ++it;
+            return *it;                             
+        } else {
+            PyErr_SetString(PyExc_IndexError, "Index out of range");
+            throw boost::python::error_already_set();
+        }
+    }
+
+    static void set(L& x, int i, value_type const& v)
+    {
+        if( i < 0 ) 
+            i += x.size();
+
+        if( i >= 0 && i < (int)x.size() ) {
+            iter_type it = x.begin(); 
+            for(int pos = 0; pos < i; ++pos)
+                ++it;
+            *it = v;
+        } else {
+            PyErr_SetString(PyExc_IndexError, "Index out of range");
+            boost::python::throw_error_already_set();
+        }
+    }
+};
+
+
+template<class T>
+void export_ConstSTLListOfPtrs(const char* typeName)
+{
+    using namespace boost::python;
+
+    class_<std::list<T> >(typeName)
+        .def("__len__", &std::list<T>::size)
+        .def("__getitem__", &listwrap<T>::get,
+             python::return_internal_reference<1,
+             python::with_custodian_and_ward_postcall<0,1> >())
+        .def("__contains__", &listwrap<T>::in)
+        .def("__iter__", iterator<std::list<T> >())
+        .def("index", &listwrap<T>::index);
+}


### PR DESCRIPTION
Just trying to match the python help(Chem.Mol) documentation :)

You will note that I changed the definition of the wrapped atom and bond:

    python::class_<Atom, Atom *>("Atom",

adding the Atom* says we want to wrap atom pointers as well as atom references (so we can say, wrap a vector<Atom*>).

Practically, these are required to get the results of a reaction mapping as they are stored as bookmarks on the products.  There is a slight hiccup as there really is no identity on rdkit atoms/bonds/molecules:

    from rdkit import Chem
    >>> m = Chem.MolFromSmiles("C")
    >>> a1 = list(m.GetAtoms())[0]
    >>> a2 = list(m.GetAtoms())[0]
    >>> a1 == a2
    False

In the C++ land these are really the same atom.

This also propagates to molecules:

    >>> a1.GetOwningMol() == a1.GetOwningMol()
    False

I think this is easy to fix with an identity function ( I think SWIG does this).  For now I can use property tags to disambiguate my reactions, but this perhaps should be filed as a bug.