### PR TITLE
Save the atom bookmarks so we can deconvolute reaction products.

### DIFF
--- a/Code/GraphMol/ChemReactions/ReactionRunner.cpp
+++ b/Code/GraphMol/ChemReactions/ReactionRunner.cpp
@@ -754,7 +754,7 @@ namespace RDKit {
                                                   reactantsMatch.at(reactantId),
                                                   *iter, conf);
         }
-        product->clearAllAtomBookmarks();
+
         if(doConfs){
           product->addConformer(conf,true);
         }
@@ -774,6 +774,7 @@ namespace RDKit {
     }
     BOOST_FOREACH(ROMOL_SPTR msptr,reactants){
       CHECK_INVARIANT(msptr,"bad molecule in reactants");
+      msptr->clearAllAtomBookmarks(); // we use this as scratch space
     }
 
     std::vector<MOL_SPTR_VECT> productMols;


### PR DESCRIPTION
This also ensures the atom bookmarks in the reactants
are cleared (allows a product to be a reactant since we
no longer clear the product bookmarks)

n.b. -We might have to think about this a bit, since the bookmarked atoms being returned in the products are from the product itself, this is a safe operation.

However, we could have the same feature by having an alternate atom property along the lines of "reaction-mapped_atom_number" which would satisfy my needs (i.e. getting to the template atoms that were mapped to a product )