### PR TITLE
RDKit learns how to expose ChemicalReaction copy constructor to python

### DIFF
--- a/Code/GraphMol/ChemReactions/Wrap/rdChemReactions.cpp
+++ b/Code/GraphMol/ChemReactions/Wrap/rdChemReactions.cpp
@@ -313,6 +313,7 @@ Sample Usage:\n\
   python::class_<RDKit::ChemicalReaction>("ChemicalReaction",docString.c_str(),
                                           python::init<>("Constructor, takes no arguments"))
     .def(python::init<const std::string &>())
+    .def(python::init<const RDKit::ChemicalReaction&>())
     .def("GetNumReactantTemplates",&RDKit::ChemicalReaction::getNumReactantTemplates,
          "returns the number of reactants this reaction expects")
     .def("GetNumProductTemplates",&RDKit::ChemicalReaction::getNumProductTemplates,

--- a/Code/GraphMol/ChemReactions/Wrap/testReactionWrapper.py
+++ b/Code/GraphMol/ChemReactions/Wrap/testReactionWrapper.py
@@ -54,80 +54,84 @@ class TestCase(unittest.TestCase) :
 
 
   def test1Basics(self):
-    rxn = rdChemReactions.ChemicalReaction()
-    self.assertTrue(rxn.GetNumReactantTemplates()==0)
-    self.assertTrue(rxn.GetNumProductTemplates()==0)
+    rxna = rdChemReactions.ChemicalReaction()
+    # also tests empty copy constructor
+    for rxn in [rxna, rdChemReactions.ChemicalReaction(rxna)]:
+      self.assertTrue(rxn.GetNumReactantTemplates()==0)
+      self.assertTrue(rxn.GetNumProductTemplates()==0)
 
-    r1= Chem.MolFromSmarts('[C:1](=[O:2])O')
-    rxn.AddReactantTemplate(r1)
-    self.assertTrue(rxn.GetNumReactantTemplates()==1)
+      r1= Chem.MolFromSmarts('[C:1](=[O:2])O')
+      rxn.AddReactantTemplate(r1)
+      self.assertTrue(rxn.GetNumReactantTemplates()==1)
 
-    r1= Chem.MolFromSmarts('[N:3]')
-    rxn.AddReactantTemplate(r1)
-    self.assertTrue(rxn.GetNumReactantTemplates()==2)
+      r1= Chem.MolFromSmarts('[N:3]')
+      rxn.AddReactantTemplate(r1)
+      self.assertTrue(rxn.GetNumReactantTemplates()==2)
 
-    r1= Chem.MolFromSmarts('[C:1](=[O:2])[N:3]')
-    rxn.AddProductTemplate(r1)
-    self.assertTrue(rxn.GetNumProductTemplates()==1)
+      r1= Chem.MolFromSmarts('[C:1](=[O:2])[N:3]')
+      rxn.AddProductTemplate(r1)
+      self.assertTrue(rxn.GetNumProductTemplates()==1)
 
-    reacts = (Chem.MolFromSmiles('C(=O)O'),Chem.MolFromSmiles('N'))
-    ps = rxn.RunReactants(reacts)
-    self.assertTrue(len(ps)==1)
-    self.assertTrue(len(ps[0])==1)
-    self.assertTrue(ps[0][0].GetNumAtoms()==3)
-        
-    ps = rxn.RunReactants(list(reacts))
-    self.assertTrue(len(ps)==1)
-    self.assertTrue(len(ps[0])==1)
-    self.assertTrue(ps[0][0].GetNumAtoms()==3)    
+      reacts = (Chem.MolFromSmiles('C(=O)O'),Chem.MolFromSmiles('N'))
+      ps = rxn.RunReactants(reacts)
+      self.assertTrue(len(ps)==1)
+      self.assertTrue(len(ps[0])==1)
+      self.assertTrue(ps[0][0].GetNumAtoms()==3)
+
+      ps = rxn.RunReactants(list(reacts))
+      self.assertTrue(len(ps)==1)
+      self.assertTrue(len(ps[0])==1)
+      self.assertTrue(ps[0][0].GetNumAtoms()==3)    
 
   def test2DaylightParser(self):
-    rxn = rdChemReactions.ReactionFromSmarts('[C:1](=[O:2])O.[N:3]>>[C:1](=[O:2])[N:3]')
-    self.assertTrue(rxn)
-    self.assertTrue(rxn.GetNumReactantTemplates()==2)
-    self.assertTrue(rxn.GetNumProductTemplates()==1)
-    self.assertTrue(rxn._getImplicitPropertiesFlag())
-    
-    reacts = (Chem.MolFromSmiles('C(=O)O'),Chem.MolFromSmiles('N'))
-    ps = rxn.RunReactants(reacts)
-    self.assertTrue(len(ps)==1)
-    self.assertTrue(len(ps[0])==1)
-    self.assertTrue(ps[0][0].GetNumAtoms()==3)  
-    
-    reacts = (Chem.MolFromSmiles('CC(=O)OC'),Chem.MolFromSmiles('CN'))
-    ps = rxn.RunReactants(reacts)
-    self.assertTrue(len(ps)==1)
-    self.assertTrue(len(ps[0])==1)
-    self.assertTrue(ps[0][0].GetNumAtoms()==5)  
-    
+    rxna = rdChemReactions.ReactionFromSmarts('[C:1](=[O:2])O.[N:3]>>[C:1](=[O:2])[N:3]')
+    for rxn in [rxna, rdChemReactions.ChemicalReaction(rxna)]:
+      self.assertTrue(rxn)
+      self.assertTrue(rxn.GetNumReactantTemplates()==2)
+      self.assertTrue(rxn.GetNumProductTemplates()==1)
+      self.assertTrue(rxn._getImplicitPropertiesFlag())
+
+      reacts = (Chem.MolFromSmiles('C(=O)O'),Chem.MolFromSmiles('N'))
+      ps = rxn.RunReactants(reacts)
+      self.assertTrue(len(ps)==1)
+      self.assertTrue(len(ps[0])==1)
+      self.assertTrue(ps[0][0].GetNumAtoms()==3)  
+
+      reacts = (Chem.MolFromSmiles('CC(=O)OC'),Chem.MolFromSmiles('CN'))
+      ps = rxn.RunReactants(reacts)
+      self.assertTrue(len(ps)==1)
+      self.assertTrue(len(ps[0])==1)
+      self.assertTrue(ps[0][0].GetNumAtoms()==5)  
+
   def test3MDLParsers(self):
     fileN = os.path.join(self.dataDir,'AmideBond.rxn')
-    rxn = rdChemReactions.ReactionFromRxnFile(fileN) 
-    self.assertTrue(rxn)
-    self.assertFalse(rxn._getImplicitPropertiesFlag())
+    rxna = rdChemReactions.ReactionFromRxnFile(fileN)
+    for rxn in [rxna, rdChemReactions.ChemicalReaction(rxna)]:
+      self.assertTrue(rxn)
+      self.assertFalse(rxn._getImplicitPropertiesFlag())
 
-    self.assertTrue(rxn.GetNumReactantTemplates()==2)
-    self.assertTrue(rxn.GetNumProductTemplates()==1)
-    
-    reacts = (Chem.MolFromSmiles('C(=O)O'),Chem.MolFromSmiles('N'))
-    ps = rxn.RunReactants(reacts)
-    self.assertTrue(len(ps)==1)
-    self.assertTrue(len(ps[0])==1)
-    self.assertTrue(ps[0][0].GetNumAtoms()==3)  
-    
-    with open(fileN, 'r') as rxnF:
-      rxnBlock = rxnF.read()
-    rxn = rdChemReactions.ReactionFromRxnBlock(rxnBlock) 
-    self.assertTrue(rxn)
+      self.assertTrue(rxn.GetNumReactantTemplates()==2)
+      self.assertTrue(rxn.GetNumProductTemplates()==1)
 
-    self.assertTrue(rxn.GetNumReactantTemplates()==2)
-    self.assertTrue(rxn.GetNumProductTemplates()==1)
-    
-    reacts = (Chem.MolFromSmiles('C(=O)O'),Chem.MolFromSmiles('N'))
-    ps = rxn.RunReactants(reacts)
-    self.assertTrue(len(ps)==1)
-    self.assertTrue(len(ps[0])==1)
-    self.assertTrue(ps[0][0].GetNumAtoms()==3)  
+      reacts = (Chem.MolFromSmiles('C(=O)O'),Chem.MolFromSmiles('N'))
+      ps = rxn.RunReactants(reacts)
+      self.assertTrue(len(ps)==1)
+      self.assertTrue(len(ps[0])==1)
+      self.assertTrue(ps[0][0].GetNumAtoms()==3)  
+
+      with open(fileN, 'r') as rxnF:
+        rxnBlock = rxnF.read()
+      rxn = rdChemReactions.ReactionFromRxnBlock(rxnBlock) 
+      self.assertTrue(rxn)
+
+      self.assertTrue(rxn.GetNumReactantTemplates()==2)
+      self.assertTrue(rxn.GetNumProductTemplates()==1)
+
+      reacts = (Chem.MolFromSmiles('C(=O)O'),Chem.MolFromSmiles('N'))
+      ps = rxn.RunReactants(reacts)
+      self.assertTrue(len(ps)==1)
+      self.assertTrue(len(ps[0])==1)
+      self.assertTrue(ps[0][0].GetNumAtoms()==3)  
 
   def test4ErrorHandling(self):
     self.assertRaises(ValueError,lambda x='[C:1](=[O:2])Q.[N:3]>>[C:1](=[O:2])[N:3]':rdChemReactions.ReactionFromSmarts(x))
@@ -479,6 +483,31 @@ M  END
     self.failUnless(rxn.GetNumProductTemplates()==1)
     self.failUnless(rxn.GetNumAgentTemplates()==1)
     self.failUnless(len(agentList)==2)
+
+  def test20CheckCopyConstructedReactionAtomProps(self):
+    RLABEL     = "_MolFileRLabel"
+    amine_rxn =  '$RXN\n\n      ISIS     090220091541\n\n  2  1\n$MOL\n\n  -ISIS-  09020915412D\n\n  3  2  0  0  0  0  0  0  0  0999 V2000\n   -2.9083   -0.4708    0.0000 R#  0  0  0  0  0  0  0  0  0  1  0  0\n   -2.3995   -0.1771    0.0000 C   0  0  0  0  0  0  0  0  0  2  0  0\n   -2.4042    0.4125    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0\n  1  2  1  0  0  0  0\n  2  3  2  0  0  0  0\nV    2 aldehyde\nM  RGP  1   1   1\nM  END\n$MOL\n\n  -ISIS-  09020915412D\n\n  2  1  0  0  0  0  0  0  0  0999 V2000\n    2.8375   -0.2500    0.0000 R#  0  0  0  0  0  0  0  0  0  3  0  0\n    3.3463    0.0438    0.0000 N   0  0  0  0  0  0  0  0  0  4  0  0\n  1  2  1  0  0  0  0\nV    2 amine\nM  RGP  1   1   2\nM  END\n$MOL\n\n  -ISIS-  09020915412D\n\n  4  3  0  0  0  0  0  0  0  0999 V2000\n   13.3088    0.9436    0.0000 C   0  0  0  0  0  0  0  0  0  2  0  0\n   13.8206    1.2321    0.0000 R#  0  0  0  0  0  0  0  0  0  1  0  0\n   13.3028    0.3561    0.0000 N   0  0  0  0  0  0  0  0  0  4  0  0\n   12.7911    0.0676    0.0000 R#  0  0  0  0  0  0  0  0  0  3  0  0\n  1  3  1  0  0  0  0\n  1  2  1  0  0  0  0\n  3  4  1  0  0  0  0\nM  RGP  2   2   1   4   2\nM  END\n'
+    rxn = rdChemReactions.ReactionFromRxnBlock(amine_rxn)
+    res = []
+    for atom in rxn.GetReactantTemplate(0).GetAtoms():
+      if atom.HasProp(RLABEL):
+        res.append(( atom.GetIdx(), atom.GetProp(RLABEL)))
+    rxn2 = rdChemReactions.ChemicalReaction(rxn)
+    res2 = []
+
+    for atom in rxn2.GetReactantTemplate(0).GetAtoms():
+      if atom.HasProp(RLABEL):
+        res2.append(( atom.GetIdx(), atom.GetProp(RLABEL)))
+    self.assertEquals(res,res2)
+
+
+    # currently ToBinary does not save atom props
+    # rxn2 = rdChemReactions.ChemicalReaction(rxn.ToBinary())
+
+
+
+
+    
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
Going through ChemicalReaction(rxn.ToBinary()) was lossy when it came to atom properties.