### PR TITLE
Add code to accept blank SMILES input.

### DIFF
--- a/Code/PgSQL/rdkit/adapter.cpp
+++ b/Code/PgSQL/rdkit/adapter.cpp
@@ -148,7 +148,13 @@ parseMolText(char *data,bool asSmarts,bool warnOnFail) {
   try {
     StringData.assign(data);
     if(!asSmarts){
-      mol = SmilesToMol(StringData);
+      // Allow No-Structure construction.
+      if (StringData.empty()) {
+        mol = new ROMol();
+      }
+      else {
+        mol = SmilesToMol(StringData);
+      }
     } else {
       mol = SmartsToMol(StringData,0,false);
     }
@@ -223,6 +229,10 @@ isValidSmiles(char *data) {
   bool res;
   try {
     StringData.assign(data);
+    if (StringData.empty()) {
+      // Pass the test - No-Structure input is allowed. No cleanup necessary.
+      return true;
+    }
     mol = SmilesToMol(StringData,0,0);
     if(mol){
       MolOps::cleanUp(*mol);

--- a/Code/PgSQL/rdkit/expected/inchi.out
+++ b/Code/PgSQL/rdkit/expected/inchi.out
@@ -31,3 +31,15 @@ Chr(10) ||
  InChI=1S//
 (1 row)
 
+select mol_inchi('');
+ mol_inchi  
+------------
+ InChI=1S//
+(1 row)
+
+select mol_inchikey('');
+        mol_inchikey         
+-----------------------------
+ MOSFIJXAXDLOML-UHFFFAOYSA-N
+(1 row)
+

--- a/Code/PgSQL/rdkit/expected/rdkit-91.out
+++ b/Code/PgSQL/rdkit/expected/rdkit-91.out
@@ -92,6 +92,24 @@ SELECT mol_to_smiles('c1cccc[n,c]1'::qmol);
  c1ccncc1
 (1 row)
 
+SELECT is_valid_smiles('');
+ is_valid_smiles 
+-----------------
+ t
+(1 row)
+
+SELECT mol_from_smiles('');
+ mol_from_smiles 
+-----------------
+ 
+(1 row)
+
+SELECT mol_to_smiles(mol_from_smiles(''));
+ mol_to_smiles 
+---------------
+ 
+(1 row)
+
 CREATE TABLE pgmol (id int, m mol);
 \copy pgmol from 'data/data'
 CREATE UNIQUE INDEX mol_ididx ON pgmol (id);

--- a/Code/PgSQL/rdkit/sql/inchi.sql
+++ b/Code/PgSQL/rdkit/sql/inchi.sql
@@ -6,4 +6,6 @@ select mol_inchi(mol_from_ctab((Chr(10) || Chr(10) || Chr(10) ||
 '  0  0  0  0  0  0  0  0  0  0999 V2000' ||
 Chr(10) ||
 'M  END')::cstring));
+select mol_inchi('');
+select mol_inchikey('');
 

--- a/Code/PgSQL/rdkit/sql/rdkit-91.sql
+++ b/Code/PgSQL/rdkit/sql/rdkit-91.sql
@@ -23,6 +23,10 @@ SELECT mol_to_smarts(mol_from_smiles('c1ccccc1'));
 SELECT mol_to_smarts('c1cccc[n,c]1'::qmol);
 SELECT mol_to_smiles('c1cccc[n,c]1'::qmol);
 
+SELECT is_valid_smiles('');
+SELECT mol_from_smiles('');
+SELECT mol_to_smiles(mol_from_smiles(''));
+
 
 CREATE TABLE pgmol (id int, m mol);
 \copy pgmol from 'data/data'


### PR DESCRIPTION
No-Structures are saved to database dumps as blank strings ''.
This patch allows dumps with No-Structures to be read back in.