### PR TITLE
install missing FMCS/Graph.h header file

### DIFF
--- a/Code/GraphMol/FMCS/CMakeLists.txt
+++ b/Code/GraphMol/FMCS/CMakeLists.txt
@@ -3,11 +3,12 @@ rdkit_library(FMCS
               LINK_LIBRARIES Depictor FileParsers ChemTransforms SubstructMatch)
 
 rdkit_headers(FMCS.h
+              Graph.h
               Seed.h
               SeedSet.h
-			  MatchTable.h
-			  RingMatchTableSet.h
-			  SubstructureCache.h
+              MatchTable.h
+              RingMatchTableSet.h
+              SubstructureCache.h
               SubstructMatchCustom.h
               MaximumCommonSubgraph.h
               DEST GraphMol/FMCS)


### PR DESCRIPTION
Graph.h is included by FMCS.h, so it should be installed as well.