### PR TITLE
Expose raw MOL_SPTR_VECTORS to C++/Python for Reactions Reactants/Agents/Templates

### DIFF
--- a/Code/GraphMol/ChemReactions/Reaction.h
+++ b/Code/GraphMol/ChemReactions/Reaction.h
@@ -189,6 +189,10 @@ namespace RDKit{
     */
     std::vector<MOL_SPTR_VECT> runReactants(const MOL_SPTR_VECT reactants) const;
 
+    const MOL_SPTR_VECT & getReactants() const { return this->m_reactantTemplates; }
+    const MOL_SPTR_VECT & getAgents()    const { return this->m_agentTemplates; }
+    const MOL_SPTR_VECT & getProducts()  const { return this->m_productTemplates; }
+
     MOL_SPTR_VECT::const_iterator beginReactantTemplates() const {
         return this->m_reactantTemplates.begin();    
     }

--- a/Code/GraphMol/ChemReactions/Wrap/rdChemReactions.cpp
+++ b/Code/GraphMol/ChemReactions/Wrap/rdChemReactions.cpp
@@ -41,6 +41,7 @@
 #include <RDGeneral/FileParseException.h>
 #include <GraphMol/ChemReactions/ReactionFingerprints.h>
 #include <GraphMol/ChemReactions/ReactionUtils.h>
+#include <boost/python/suite/indexing/vector_indexing_suite.hpp>
 
 namespace python = boost::python;
 
@@ -310,6 +311,10 @@ Sample Usage:\n\
 'CN(C)C=O'\n\
 \n\
 ";
+  
+  python::class_<RDKit::MOL_SPTR_VECT>("ROMolList")
+    .def(python::vector_indexing_suite<RDKit::MOL_SPTR_VECT, true>() );
+
   python::class_<RDKit::ChemicalReaction>("ChemicalReaction",docString.c_str(),
                                           python::init<>("Constructor, takes no arguments"))
     .def(python::init<const std::string &>())
@@ -378,6 +383,17 @@ Sample Usage:\n\
          (python::arg("reaction"), python::arg("queries")=python::dict(),
           python::arg("propName")="molFileValue", python::arg("getLabels")=false),
          "adds recursive queries and returns reactant labels")
+    
+    .def("GetReactants", &RDKit::ChemicalReaction::getReactants,
+         python::return_value_policy<python::reference_existing_object>(),
+         "get the reactant templates")
+    .def("GetProducts", &RDKit::ChemicalReaction::getProducts,
+         python::return_value_policy<python::reference_existing_object>(),
+         "get the product templates")
+    .def("GetAgents", &RDKit::ChemicalReaction::getAgents,
+         python::return_value_policy<python::reference_existing_object>(),
+         "get the agent templates")
+    
     // enable pickle support
     .def_pickle(RDKit::reaction_pickle_suite())
   ;

--- a/Code/GraphMol/ChemReactions/Wrap/testReactionWrapper.py
+++ b/Code/GraphMol/ChemReactions/Wrap/testReactionWrapper.py
@@ -504,10 +504,22 @@ M  END
     # currently ToBinary does not save atom props
     # rxn2 = rdChemReactions.ChemicalReaction(rxn.ToBinary())
 
+  def test21CheckRawIters(self):
+    RLABEL     = "_MolFileRLabel"
+    amine_rxn =  '$RXN\n\n      ISIS     090220091541\n\n  2  1\n$MOL\n\n  -ISIS-  09020915412D\n\n  3  2  0  0  0  0  0  0  0  0999 V2000\n   -2.9083   -0.4708    0.0000 R#  0  0  0  0  0  0  0  0  0  1  0  0\n   -2.3995   -0.1771    0.0000 C   0  0  0  0  0  0  0  0  0  2  0  0\n   -2.4042    0.4125    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0\n  1  2  1  0  0  0  0\n  2  3  2  0  0  0  0\nV    2 aldehyde\nM  RGP  1   1   1\nM  END\n$MOL\n\n  -ISIS-  09020915412D\n\n  2  1  0  0  0  0  0  0  0  0999 V2000\n    2.8375   -0.2500    0.0000 R#  0  0  0  0  0  0  0  0  0  3  0  0\n    3.3463    0.0438    0.0000 N   0  0  0  0  0  0  0  0  0  4  0  0\n  1  2  1  0  0  0  0\nV    2 amine\nM  RGP  1   1   2\nM  END\n$MOL\n\n  -ISIS-  09020915412D\n\n  4  3  0  0  0  0  0  0  0  0999 V2000\n   13.3088    0.9436    0.0000 C   0  0  0  0  0  0  0  0  0  2  0  0\n   13.8206    1.2321    0.0000 R#  0  0  0  0  0  0  0  0  0  1  0  0\n   13.3028    0.3561    0.0000 N   0  0  0  0  0  0  0  0  0  4  0  0\n   12.7911    0.0676    0.0000 R#  0  0  0  0  0  0  0  0  0  3  0  0\n  1  3  1  0  0  0  0\n  1  2  1  0  0  0  0\n  3  4  1  0  0  0  0\nM  RGP  2   2   1   4   2\nM  END\n'
+    rxn = rdChemReactions.ReactionFromRxnBlock(amine_rxn)
+    reactants = rxn.GetReactants()
+    self.assertEquals( len(reactants), rxn.GetNumReactantTemplates() )
+    products = rxn.GetProducts()
+    self.assertEquals( len(products), rxn.GetNumProductTemplates() )
+    agents = rxn.GetAgents()
+    self.assertEquals( len(agents), rxn.GetNumAgentTemplates() )
 
-
-
-    
+    for i in range(rxn.GetNumReactantTemplates()):
+      p = rxn.GetReactantTemplate(i)
+      mb1 = Chem.MolToMolBlock(p)
+      mb2 = Chem.MolToMolBlock(reactants[i])
+      self.assertEquals(mb1, mb2)
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
If the std::vector<shared<ROMol> > are directly exposed in C++ land, they can trivially be wrapped in python.

This also allows C++11 ranges to work which is a nice side-effect.

    reactants = rxn.GetReactants()
    products = rxn.GetProducts()
    agents = rxn.GetAgents()
