### PR TITLE
Fix StringType access, remove unused imports

### DIFF
--- a/rdkit/sping/SVG/pidSVG.py
+++ b/rdkit/sping/SVG/pidSVG.py
@@ -48,8 +48,8 @@ Greg Landrum (greglandrum@earthlink.net) 3/10/2000
 
 from rdkit.sping.pid import *
 from rdkit.sping.PDF import pdfmetrics # for font info
-import string, os, types
-
+import string
+from types import StringType
 from math import *
 
 #SVG_HEADER = """<?xml version="1.0" encoding="iso-8859-1"?>


### PR DESCRIPTION
Fix for IPythonNote book using SVG rendering.

from rdkit import Chem
from rdkit.Chem.Draw import IPythonConsole
IPythonConsole.ipython_useSVG=True

This isn't tested anywhere outside the pidtest.py which I assume is tested with nose.