### PR TITLE
Fix mol drawing on Python3 (issue #460)

### DIFF
--- a/Docs/Book/Install.rst
+++ b/Docs/Book/Install.rst
@@ -169,6 +169,12 @@ You can completely disable building of the python wrappers by setting the config
 
     cmake -D RDK_BUILD_PYTHON_WRAPPERS= ..
 
+Recommended extras
+------------------
+
+  * for structure depiction cairo (for use with Python2) or cairocffi (for use with Python3) and their respective Python bindings are recommended.
+
+    
 Building the Java wrappers
 ==========================
 

--- a/rdkit/Chem/Draw/cairoCanvas.py
+++ b/rdkit/Chem/Draw/cairoCanvas.py
@@ -11,14 +11,18 @@
 #
 #pylint: disable=F0401,C0324,C0322,W0142
 import sys
-try:
-  import cairo
-except ImportError:
-  import cairocffi as cairo
+
+# for Python3, import cairocffi preferably
+if sys.version_info[0] > 2:
+  try:
+    import cairocffi as cairo
+
+  except ImportError:
+    import cairo
+
 if not hasattr(cairo.ImageSurface,'get_data') and \
    not hasattr(cairo.ImageSurface,'get_data_as_rgba'):
   raise ImportError('cairo version too old')
-
 
 import math
 import rdkit.RDConfig
@@ -78,12 +82,12 @@ class Canvas(CanvasBase):
       size=image.size[0], image.size[1]
       self.image=image
     elif ctx is None and size is not None:
-      if cairo.HAS_PDF_SURFACE and imageType == "pdf":
-        surface = cairo.PDFSurface (fileName, size[0], size[1])
-      elif cairo.HAS_SVG_SURFACE and imageType == "svg":
-        surface = cairo.SVGSurface (fileName, size[0], size[1])
-      elif cairo.HAS_PS_SURFACE and imageType == "ps":
-        surface = cairo.PSSurface (fileName, size[0], size[1])
+      if hasattr(cairo, "PDFSurface") and imageType == "pdf":
+        surface = cairo.PDFSurface(fileName, size[0], size[1])
+      elif hasattr(cairo, "SVGSurface") and imageType == "svg":
+        surface = cairo.SVGSurface(fileName, size[0], size[1])
+      elif hasattr(cairo, "PSSurface") and imageType == "ps":
+        surface = cairo.PSSurface(fileName, size[0], size[1])
       elif imageType == "png":
         surface = cairo.ImageSurface (cairo.FORMAT_ARGB32, size[0], size[1])
       else:
@@ -92,16 +96,16 @@ class Canvas(CanvasBase):
       ctx.set_source_rgb(1,1,1)
       ctx.paint()
     else:
-      surface=ctx.get_target()
+      surface = ctx.get_target()
       if size is None:
         try:
-          size=surface.get_width(),surface.get_height() 
+          size = surface.get_width(),surface.get_height() 
         except AttributeError:
-          size=None
-    self.ctx=ctx
-    self.size=size
-    self.surface=surface
-    self.fileName=fileName
+          size = None
+    self.ctx = ctx
+    self.size = size
+    self.surface = surface
+    self.fileName = fileName
 
   def flush(self):
     """temporary interface, must be splitted to different methods,


### PR DESCRIPTION
* cairocffi aims at being a drop-in replacement for cairo but does not seem to be quite there, yet
* this hack fixes issue #460 by trying to use cairocffi when running on Python3 and cairo when running on Python2
* tested for both Python versions
* I have now completely switched to Python3 with RDKit