### PR TITLE
FMCS Atom Distance Cutoff

### DIFF
--- a/Code/GraphMol/FMCS/CMakeLists.txt
+++ b/Code/GraphMol/FMCS/CMakeLists.txt
@@ -14,7 +14,7 @@ rdkit_headers(FMCS.h
               DEST GraphMol/FMCS)
 
 rdkit_test(testFMCS testFMCS_Unit.cpp LINK_LIBRARIES
-FMCS ChemTransforms Depictor FileParsers SmilesParse 
+FMCS ChemTransforms Depictor DistGeomHelpers FileParsers SmilesParse 
 GraphMol RDGeneral RDGeometryLib SubstructMatch  ${RDKit_THREAD_LIBS})
 
 add_subdirectory(Wrap)

--- a/Code/GraphMol/FMCS/FMCS.cpp
+++ b/Code/GraphMol/FMCS/FMCS.cpp
@@ -162,8 +162,9 @@ namespace RDKit {
     bool checkChiralityAndDistance(const MCSAtomCompareParameters& p, const ROMol& mol1, unsigned int atom1, const ROMol& mol2, unsigned int atom2) {
         if(p.MatchChiralTag && !checkAtomChirality(mol1, atom1, mol2, atom2))
             return false;
-        if(p.DistanceCutoff <= 0 && !checkAtomDistance(p.DistanceCutoff, mol1, atom1, mol2, atom2))
+        if(p.DistanceCutoff > 0 && !checkAtomDistance(p.DistanceCutoff, mol1, atom1, mol2, atom2)) {
             return false;
+        }
         return true;
     } 
 

--- a/Code/GraphMol/FMCS/FMCS.cpp
+++ b/Code/GraphMol/FMCS/FMCS.cpp
@@ -148,13 +148,13 @@ namespace RDKit {
     bool checkAtomDistance    (float cutoff, const ROMol& mol1, unsigned int atom1, const ROMol& mol2, unsigned int atom2) {
         const Atom& a1 = *mol1.getAtomWithIdx(atom1);
         const Atom& a2 = *mol2.getAtomWithIdx(atom2);
-        RDGeom::Point3D p1 = a1.getOwningMol().getConformer().getAtomPos(a1.getIdx());
-        RDGeom::Point3D p2 = a2.getOwningMol().getConformer().getAtomPos(a2.getIdx());
+        RDGeom::Point3D p1 = mol1.getConformer().getAtomPos(atom1);
+        RDGeom::Point3D p2 = mol2.getConformer().getAtomPos(atom2);
         float dx = p1.x-p2.x;
         float dy = p1.y-p2.y;
         float dz = p1.z-p2.z;
-        float distance = sqrt(dx*dx+dy*dy+dz*dz);
-        if(distance < cutoff)
+        float distancesq = (p1-p2).lengthSq();
+        if(distancesq < cutoff*cutoff)
             return true;
         return false;
     }

--- a/Code/GraphMol/FMCS/FMCS.h
+++ b/Code/GraphMol/FMCS/FMCS.h
@@ -11,6 +11,7 @@
 #include <vector>
 #include <string>
 #include <stdexcept>
+#include <limits>
 #include "../RDKitBase.h"
 #include "Graph.h"
 
@@ -20,8 +21,12 @@ namespace RDKit {
     struct MCSAtomCompareParameters {
         bool    MatchValences;
         bool    MatchChiralTag;
+        float   DistanceCutoff; // if DistanceCutoff <= 0, then ignored.
     public:
-        MCSAtomCompareParameters() : MatchValences(false), MatchChiralTag(false) {}
+        MCSAtomCompareParameters() : 
+            MatchValences(false),
+            MatchChiralTag(false),
+            DistanceCutoff(0) {}
     };
 
     struct MCSBondCompareParameters {
@@ -121,6 +126,7 @@ namespace RDKit {
                        bool ringMatchesRingOnly=false,
                        bool completeRingsOnly=false,
                        bool matchChiralTag=false,
+                       float distanceCutoff=0,
                        AtomComparator atomComp=AtomCompareElements,
                        BondComparator bondComp=BondCompareOrder);
 

--- a/Code/GraphMol/FMCS/Wrap/rdFMCS.cpp
+++ b/Code/GraphMol/FMCS/Wrap/rdFMCS.cpp
@@ -21,7 +21,7 @@ namespace RDKit {
                               unsigned timeout,bool verbose,
                               bool matchValences,
                               bool ringMatchesRingOnly,bool completeRingsOnly,
-                              bool matchChiralTag,
+                              bool matchChiralTag, float distanceCutoff,
                               AtomComparator atomComp, BondComparator bondComp) {
         std::vector<ROMOL_SPTR> ms;
         unsigned int nElems=python::extract<unsigned int>(mols.attr("__len__")());
@@ -32,7 +32,7 @@ namespace RDKit {
         }
 
         MCSResult *res= new MCSResult(findMCS(ms,maximizeBonds,threshold,timeout,verbose,
-                                               matchValences,ringMatchesRingOnly,completeRingsOnly,matchChiralTag,
+                                               matchValences,ringMatchesRingOnly,completeRingsOnly,matchChiralTag,distanceCutoff,
                                                atomComp,bondComp));
         return res;
     }
@@ -78,6 +78,7 @@ BOOST_PYTHON_MODULE(rdFMCS) {
                  python::arg("ringMatchesRingOnly")=false,
                  python::arg("completeRingsOnly")=false,
                  python::arg("matchChiralTag")=false,
+                 python::arg("distanceCutoff")=0,
                  python::arg("atomCompare")=RDKit::AtomCompareElements,
                  python::arg("bondCompare")=RDKit::BondCompareOrder
                 ),

--- a/Code/GraphMol/FMCS/testFMCS_Unit.cpp
+++ b/Code/GraphMol/FMCS/testFMCS_Unit.cpp
@@ -717,12 +717,9 @@ void testAtomCompareDistance() {
     ROMOL_SPTR mol2(SmilesToMol(s1));
 
     DGeomHelpers::EmbedMolecule(*mol1);
-    Conformer &conf1 = mol1->getConformer();
-
-    Conformer second(conf1);
-    Conformer &conf2 = second;
-    conf2.setAtomPos(0, RDGeom::Point3D(0,0,0));
-    mol2->addConformer(&conf2);
+    Conformer *conf2 = new Conformer(mol1->getConformer());
+    conf2->setAtomPos(0, RDGeom::Point3D(0,0,0));
+    mol2->addConformer(conf2);
 
     std::vector<ROMOL_SPTR> mols;
     mols.push_back(mol1);

--- a/Code/GraphMol/FMCS/testFMCS_Unit.cpp
+++ b/Code/GraphMol/FMCS/testFMCS_Unit.cpp
@@ -737,7 +737,6 @@ void testAtomCompareDistance() {
         TEST_ASSERT(mcs_res.NumBonds==4);
     }
 
-
     {
         MCSParameters p;
         p.AtomCompareParameters.MatchChiralTag = false;
@@ -749,6 +748,7 @@ void testAtomCompareDistance() {
     }
 
     mols.clear();
+    BOOST_LOG(rdInfoLog) << "\tdone" << std::endl;
 }
 
 void testGithubIssue481() {

--- a/Code/GraphMol/MolHash/HashToString.cpp
+++ b/Code/GraphMol/MolHash/HashToString.cpp
@@ -8,12 +8,12 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
+#include <algorithm>
 #include <boost/archive/iterators/base64_from_binary.hpp>
 #include <boost/archive/iterators/transform_width.hpp>
 #include <boost/archive/iterators/ostream_iterator.hpp>
 #include <string>
 #include <sstream>
-#include <algorithm>
 
 #include "MolHash.h"
 

--- a/Code/JavaWrappers/gmwrapper/src-test/org/RDKit/FMCSTests.java
+++ b/Code/JavaWrappers/gmwrapper/src-test/org/RDKit/FMCSTests.java
@@ -63,7 +63,7 @@ public class FMCSTests extends GraphMolTest {
 		mols.add(RWMol.MolFromSmiles("c1c(C)cccc1OC"));
 		mols.add(RWMol.MolFromSmiles("C1CCCCC1C"));
                 
-                MCSResult mcs=RDKFuncs.findMCS(mols,true,1,60,false,false,false,false,false,
+                MCSResult mcs=RDKFuncs.findMCS(mols,true,1,60,false,false,false,false,false,0,
                                                AtomComparator.AtomCompareElements,
                                                BondComparator.BondCompareAny);
                 assertEquals(6,mcs.getNumAtoms());


### PR DESCRIPTION
This pull request provides support for Atom matching to take into account of distances between atoms. This is useful when geometric matching is desired, and has the probable side-effect of greatly limiting the depth of the search when the coordinates of the individual atoms are known a priori.

findMCS now takes in an optional floating point argument distanceCutoff, such that if distanceCutoff <= 0, then it is ignored. Otherwise, two atoms are matchable only if their Euclidean distance less than distanceCutoff. 

This deals with #508 
