### PR TITLE
Improvements to LoadSDF and WriteSDF

### DIFF
--- a/rdkit/Chem/PandasTools.py
+++ b/rdkit/Chem/PandasTools.py
@@ -231,8 +231,8 @@ def ChangeMoleculeRendering(frame=None, renderer='PNG'):
   if frame is not None:
     frame.to_html = types.MethodType(patchPandasHTMLrepr,frame)
     
-def LoadSDF(filename, idName='ID',molColName = 'ROMol',includeFingerprints=False, isomericSmiles=False, smilesName=None):
-  """ Read file in SDF format and return as Pandas data frame """
+def LoadSDF(filename, idName='ID',molColName = 'ROMol',includeFingerprints=False, isomericSmiles=False, smilesName=None, embedProps=False):
+  """ Read file in SDF format and return as Pandas data frame. If embedProps=True all properties also get embedded in Mol objects in the molecule column. """
   df = None
   if type(filename) is str:
     f = open(filename, 'rb') #'rU')
@@ -241,6 +241,10 @@ def LoadSDF(filename, idName='ID',molColName = 'ROMol',includeFingerprints=False
   for i, mol in enumerate(Chem.ForwardSDMolSupplier(f)):
     if mol is None: continue
     row = dict((k, mol.GetProp(k)) for k in mol.GetPropNames())
+    if embedProps == False:
+      embeded_props = [x for x in mol.GetPropNames()]
+      for prop in embeded_props:
+            mol.ClearProp(prop)
     if mol.HasProp('_Name'): row[idName] = mol.GetProp('_Name')
     if smilesName is not None:
       row[smilesName] = Chem.MolToSmiles(mol, isomericSmiles=isomericSmiles)

--- a/rdkit/Chem/PandasTools.py
+++ b/rdkit/Chem/PandasTools.py
@@ -243,7 +243,7 @@ def LoadSDF(filename, idName='ID',molColName = 'ROMol',includeFingerprints=False
     row = dict((k, mol.GetProp(k)) for k in mol.GetPropNames())
     if not embedProps:
       for prop in mol.GetPropNames():
-            mol.ClearProp(prop)
+        mol.ClearProp(prop)
     if mol.HasProp('_Name'): row[idName] = mol.GetProp('_Name')
     if smilesName is not None:
       row[smilesName] = Chem.MolToSmiles(mol, isomericSmiles=isomericSmiles)

--- a/rdkit/Chem/PandasTools.py
+++ b/rdkit/Chem/PandasTools.py
@@ -264,42 +264,42 @@ def LoadSDF(filename, idName='ID',molColName = 'ROMol',includeFingerprints=False
 from rdkit.Chem import SDWriter
 
 def WriteSDF(df, out, molColName='ROMol', idName=None, properties=None, allNumeric=False):
-    '''Write an SD file for the molecules in the dataframe. Dataframe columns can be exported as SDF tags if specified in the "properties" list. "properties=list(df.columns)" would exort all columns. 
-    The "allNumeric" flag allows to automatically include all numeric columns in the output. User has to make sure that corect data type is assigned to column.
-    "idName" can be used to select a column to serve as molecule title. It can be set to "RowID" to use the dataframe row key as title.
-    '''
-    writer = SDWriter(out)
-    if properties is None:
-        properties=[]
-    if allNumeric:   
-        properties.extend([dt for dt in df.dtypes.keys() if (np.issubdtype(df.dtypes[dt],float) or np.issubdtype(df.dtypes[dt],int))])
+  '''Write an SD file for the molecules in the dataframe. Dataframe columns can be exported as SDF tags if specified in the "properties" list. "properties=list(df.columns)" would exort all columns. 
+  The "allNumeric" flag allows to automatically include all numeric columns in the output. User has to make sure that corect data type is assigned to column.
+  "idName" can be used to select a column to serve as molecule title. It can be set to "RowID" to use the dataframe row key as title.
+  '''
+  writer = SDWriter(out)
+  if properties is None:
+    properties=[]
+  if allNumeric:   
+    properties.extend([dt for dt in df.dtypes.keys() if (np.issubdtype(df.dtypes[dt],float) or np.issubdtype(df.dtypes[dt],int))])
+  
+  if molColName in properties:
+    properties.remove(molColName)
+  if idName in properties:
+    properties.remove(idName)
+  writer.SetProps(properties)
+  for row in df.iterrows():
+    mol = copy.deepcopy(row[1][molColName])
+    # Remove embeded props
+    embeded_props = [x for x in mol.GetPropNames()]
+    for prop in embeded_props:
+      mol.ClearProp(prop)
     
-    if molColName in properties:
-        properties.remove(molColName)
-    if idName in properties:
-        properties.remove(idName)
-    writer.SetProps(properties)
-    for row in df.iterrows():
-        mol = copy.deepcopy(row[1][molColName])
-        # Remove embeded props
-        embeded_props = [x for x in mol.GetPropNames()]
-        for prop in embeded_props:
-            mol.ClearProp(prop)
-        
-        if idName is not None:
-            if idName == 'RowID':
-                mol.SetProp('_Name',str(row[0]))
-            else:
-                mol.SetProp('_Name',str(row[1][idName]))
-        for p in properties:
-            cell_value = row[1][p]
-            # Make sure float does not get formatted in E notation
-            if np.issubdtype(type(cell_value),float):
-                mol.SetProp(p,'{:f}'.format(cell_value).rstrip('0'))
-            else:
-                mol.SetProp(p,str(cell_value))
-        writer.write(mol)
-    writer.close()
+    if idName is not None:
+      if idName == 'RowID':
+        mol.SetProp('_Name',str(row[0]))
+      else:
+        mol.SetProp('_Name',str(row[1][idName]))
+    for p in properties:
+      cell_value = row[1][p]
+      # Make sure float does not get formatted in E notation
+      if np.issubdtype(type(cell_value),float):
+        mol.SetProp(p,'{:f}'.format(cell_value).rstrip('0'))
+      else:
+        mol.SetProp(p,str(cell_value))
+    writer.write(mol)
+  writer.close()
     
 
 

--- a/rdkit/Chem/PandasTools.py
+++ b/rdkit/Chem/PandasTools.py
@@ -241,9 +241,8 @@ def LoadSDF(filename, idName='ID',molColName = 'ROMol',includeFingerprints=False
   for i, mol in enumerate(Chem.ForwardSDMolSupplier(f)):
     if mol is None: continue
     row = dict((k, mol.GetProp(k)) for k in mol.GetPropNames())
-    if embedProps == False:
-      embeded_props = [x for x in mol.GetPropNames()]
-      for prop in embeded_props:
+    if not embedProps:
+      for prop in mol.GetPropNames():
             mol.ClearProp(prop)
     if mol.HasProp('_Name'): row[idName] = mol.GetProp('_Name')
     if smilesName is not None:
@@ -264,8 +263,8 @@ def LoadSDF(filename, idName='ID',molColName = 'ROMol',includeFingerprints=False
 from rdkit.Chem import SDWriter
 
 def WriteSDF(df, out, molColName='ROMol', idName=None, properties=None, allNumeric=False):
-  '''Write an SD file for the molecules in the dataframe. Dataframe columns can be exported as SDF tags if specified in the "properties" list. "properties=list(df.columns)" would exort all columns. 
-  The "allNumeric" flag allows to automatically include all numeric columns in the output. User has to make sure that corect data type is assigned to column.
+  '''Write an SD file for the molecules in the dataframe. Dataframe columns can be exported as SDF tags if specified in the "properties" list. "properties=list(df.columns)" would export all columns. 
+  The "allNumeric" flag allows to automatically include all numeric columns in the output. User has to make sure that correct data type is assigned to column.
   "idName" can be used to select a column to serve as molecule title. It can be set to "RowID" to use the dataframe row key as title.
   '''
   writer = SDWriter(out)
@@ -282,8 +281,7 @@ def WriteSDF(df, out, molColName='ROMol', idName=None, properties=None, allNumer
   for row in df.iterrows():
     mol = copy.deepcopy(row[1][molColName])
     # Remove embeded props
-    embeded_props = [x for x in mol.GetPropNames()]
-    for prop in embeded_props:
+    for prop in mol.GetPropNames():
       mol.ClearProp(prop)
     
     if idName is not None:


### PR DESCRIPTION
*  I used WriteSDF a bit and noticed that it saves floats with E notation which confused some programs. I fixed it so that now it formats the floats "correctly" with decimal notation.  
*  When I tried to fix the code I also noticed that if no properties are given it just pulls the properties from mol objects in "ROMol" and writes those. I modified the code so that embedded properties are removed before molecule is written. 
*  I added few lines to remove embedded properties when loading sdf with LoadSDF. embedProps=False is the default now. I think this reasonable default since all the data is already in columns and as a bonus it will save some memory..
*  And finally I also renamed parameters to be consistent with LoadSDF. Will only break code where "titleColumn" was used.