### PR TITLE
Fixed crash upon closing a gzip/bzip2 stream opened in binary mode for use with SDWriter under Python3

### DIFF
--- a/Code/GraphMol/FileParsers/MolWriters.h
+++ b/Code/GraphMol/FileParsers/MolWriters.h
@@ -88,11 +88,12 @@ namespace RDKit {
         dp_ostream->flush();
       } catch(...){
       }
+      std::ostream *tmp_ostream = dp_ostream;
+      dp_ostream = NULL;
       if(df_owner) {
-        delete dp_ostream;
+        delete tmp_ostream;
         df_owner=false;
       }
-      dp_ostream=NULL;
     };
 
     //! \brief get the number of molecules written so far
@@ -160,11 +161,12 @@ namespace RDKit {
         dp_ostream->flush();
       } catch(...){
       }
+      std::ostream *tmp_ostream = dp_ostream;
+      dp_ostream = NULL;
       if(df_owner) {
-        delete dp_ostream;
+        delete tmp_ostream;
         df_owner=false;
       }
-      dp_ostream=NULL;
     };
 
     //! \brief get the number of molecules written so far
@@ -225,11 +227,12 @@ namespace RDKit {
         dp_ostream->flush();
       } catch(...){
       }
+      std::ostream *tmp_ostream = dp_ostream;
+      dp_ostream = NULL;
       if(df_owner) {
-        delete dp_ostream;
+        delete tmp_ostream;
         df_owner=false;
       }
-      dp_ostream=NULL;
     };
 
     //! \brief get the number of molecules written so far
@@ -283,11 +286,12 @@ namespace RDKit {
         dp_ostream->flush();
       } catch(...){
       }
+      std::ostream *tmp_ostream = dp_ostream;
+      dp_ostream = NULL;
       if(df_owner) {
-        delete dp_ostream;
+        delete tmp_ostream;
         df_owner=false;
       }
-      dp_ostream=NULL;
     };
 
     //! \brief get the number of molecules written so far

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -2993,14 +2993,38 @@ CAS<~>
     path = Chem.GetShortestPath(m, 1, 20)
     self.assertEqual(path, (1, 2, 3, 16, 17, 18, 20))
 
+  def testGithub497(self):
+    import gzip,tempfile,sys
+    outf = gzip.open(tempfile.mktemp(),'wb+')
+    m = Chem.MolFromSmiles('C')
+    w = Chem.SDWriter(outf)
+    e = False
+    try:
+      w.write(m)
+    except:
+      e = True
+    else:
+      e = (sys.version_info < (3, 0))
+    try:
+      w.close()
+    except:
+      e = True
+    else:
+      if (not e):
+        e = (sys.version_info < (3, 0))
+    w=None
+    outf.close()
+    self.assertTrue(e)
+    
   def testGithub498(self):
     import gzip,tempfile
-    outf = gzip.open(tempfile.mktemp(),'w+')
+    outf = gzip.open(tempfile.mktemp(),'wt+')
     m = Chem.MolFromSmiles('C')
     w = Chem.SDWriter(outf)
     w.write(m)
     w.close()
     w=None
+    outf.close()
     
 if __name__ == '__main__':
   unittest.main()

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -3002,18 +3002,30 @@ CAS<~>
     try:
       w.write(m)
     except:
+      sys.stderr.write('Opening gzip as binary fails on Python3 ' \
+        'upon writing to SDWriter without crashing the RDKit\n')
       e = True
     else:
       e = (sys.version_info < (3, 0))
     try:
       w.close()
     except:
+      sys.stderr.write('Opening gzip as binary fails on Python3 ' \
+        'upon closing SDWriter without crashing the RDKit\n')
       e = True
     else:
       if (not e):
         e = (sys.version_info < (3, 0))
     w=None
-    outf.close()
+    try:
+      outf.close()
+    except:
+      sys.stderr.write('Opening gzip as binary fails on Python3 ' \
+        'upon closing the stream without crashing the RDKit\n')
+      e = True
+    else:
+      if (not e):
+        e = (sys.version_info < (3, 0))
     self.assertTrue(e)
     
   def testGithub498(self):


### PR DESCRIPTION
- modified Code/GraphMol/FileParsers/MolWriters.h to avoid memory corruption
  due to double free (close() was being called twice when an exception
  occurred in the Python layer, leading to duplicate deletion of dp_ostream)
- modified testGithub498() in Code/GraphMol/Wrap/rough_test.py
  to comply with Python 3
- added testGithub497() to test the fix in Code/GraphMol/FileParsers/MolWriters.h