### PR TITLE
RDKit learns how to filter PAINS/BRENK/ZINC/NIH via FilterCatalog

### DIFF
--- a/Code/Catalogs/Catalog.h
+++ b/Code/Catalogs/Catalog.h
@@ -37,6 +37,9 @@ namespace RDCatalog {
   template <class entryType, class paramType>
   class Catalog {
   public:
+    typedef entryType entryType_t;
+    typedef paramType paramType_t;
+    
     //------------------------------------
     Catalog() : d_fpLength(0), dp_cParams(0) {};
 

--- a/Code/GraphMol/CMakeLists.txt
+++ b/Code/GraphMol/CMakeLists.txt
@@ -46,6 +46,7 @@ add_subdirectory(ChemReactions)
 add_subdirectory(ChemTransforms)
 
 add_subdirectory(Subgraphs)
+add_subdirectory(FilterCatalog)
 add_subdirectory(FragCatalog)
 add_subdirectory(Descriptors)
 

--- a/Code/GraphMol/FilterCatalog/CMakeLists.txt
+++ b/Code/GraphMol/FilterCatalog/CMakeLists.txt
@@ -1,0 +1,27 @@
+set(T_LIBS ${Boost_LIBRARIES})
+find_package(Boost 1.39.0 COMPONENTS serialization)
+if (Boost_SERIALIZATION_LIBRARY)
+  set(Boost_LIBRARIES ${T_LIBS} ${Boost_LIBRARIES})
+  message("== Using boost serialization library ${Boost_SERIALIZATION_LIBRARY}")
+  ADD_DEFINITIONS("-DRDK_USE_BOOST_SERIALIZATION")
+else()
+  message("== Making FilterCatalog without boost Serialization support")
+endif()
+
+rdkit_library(FilterCatalog
+              Filters.cpp
+              FilterCatalog.cpp
+              FilterCatalogEntry.cpp
+              FilterMatchers.cpp
+              LINK_LIBRARIES ${Boost_SERIALIZATION_LIBRARY} Subgraphs SubstructMatch SmilesParse GraphMol RDGeometryLib Catalogs RDGeneral )
+
+rdkit_headers(FilterCatalogEntry.h
+              FilterCatalog.h
+              FilterMatcherBase.h
+              FilterMatchers.h
+              DEST GraphMol/FilterCatalog)
+
+add_subdirectory(Wrap)
+
+rdkit_test(filterCatalogTest filtercatalogtest.cpp
+           LINK_LIBRARIES ${Boost_SERIALIZATION_LIBRARY} FilterCatalog SubstructMatch FileParsers SmilesParse GraphMol RDGeometryLib RDGeneral)

--- a/Code/GraphMol/FilterCatalog/FilterCatalog.cpp
+++ b/Code/GraphMol/FilterCatalog/FilterCatalog.cpp
@@ -1,0 +1,232 @@
+//  Copyright (c) 2015, Novartis Institutes for BioMedical Research Inc.
+//  All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+//       copyright notice, this list of conditions and the following
+//       disclaimer in the documentation and/or other materials provided
+//       with the distribution.
+//     * Neither the name of Novartis Institutes for BioMedical Research Inc.
+//       nor the names of its contributors may be used to endorse or promote
+//       products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+#include "FilterCatalog.h"
+#include "Filters.h"
+#include "FilterMatchers.h"
+
+#ifdef RDK_USE_BOOST_SERIALIZATION    
+#include <boost/archive/text_oarchive.hpp>
+#include <boost/archive/text_iarchive.hpp>
+#include <boost/serialization/shared_ptr.hpp>
+#endif
+
+#include <climits> // to get CHAR_BIT # bits in a char
+
+namespace RDKit
+{
+  bool FilterCatalogParams::addCatalog(FilterCatalogs catalog) {
+    bool addedCatalog = false;
+    // meh, not the best here... perhaps make num_catalogs?
+    for (unsigned int i=0; i<sizeof(catalog)*CHAR_BIT; ++i) {
+      if ((catalog & (1u<<i)) & FilterCatalogParams::ALL) {
+        FilterCatalogs cat = static_cast<FilterCatalogs>(catalog & (1u<<i));
+        if (GetNumEntries(cat)) {
+          d_catalogs.push_back(cat);
+          addedCatalog = true;
+        }
+      }
+    }
+    
+    return addedCatalog;
+  }
+
+  void FilterCatalogParams::fillCatalog(FilterCatalog &catalog) {
+    for ( size_t i=0; i<getCatalogs().size(); ++i) {
+      const FilterCatalogs catalogToAdd = getCatalogs()[i];
+      
+      const unsigned int entries = GetNumEntries(catalogToAdd);
+      const unsigned int propEntries = GetNumPropertyEntries(catalogToAdd);
+      // XXX Fix Me -> these should probably be shared to save memory
+      const FilterProperty_t *props = GetFilterProperties(catalogToAdd);
+    
+      for( unsigned int i=0; i<entries; ++i) {
+        const FilterData_t &data = GetFilterData(catalogToAdd)[i];
+        FilterCatalogEntry *entry = MakeFilterCatalogEntry(data, propEntries, props);
+        PRECONDITION(entry, "Bad Entry data");
+        if (entry)
+          catalog.addEntry(entry); // catalog owns entry
+      }
+    }
+  }
+
+  void FilterCatalogParams::toStream(std::ostream &ss) const {
+#ifndef RDK_USE_BOOST_SERIALIZATION    
+    PRECONDITION(0, "Boost SERIALIZATION is not enabled")
+#else
+    boost::archive::text_oarchive ar(ss);
+    ar << *this;
+#endif    
+  }
+
+  std::string FilterCatalogParams::Serialize() const {
+    std::stringstream ss;
+    toStream(ss);
+    return ss.str();
+  }
+
+  void FilterCatalogParams::initFromStream(std::istream &ss) {
+#ifndef RDK_USE_BOOST_SERIALIZATION    
+    PRECONDITION(0, "Boost SERIALIZATION is not enabled")
+#else
+    boost::archive::text_iarchive ar(ss);
+    ar >> *this;
+#endif
+  }
+
+  void FilterCatalogParams::initFromString(const std::string &text) {
+    std::stringstream ss(text);
+    initFromStream(ss);
+  }
+  
+  FilterCatalog::~FilterCatalog() {
+  }
+
+  void FilterCatalog::Clear() {
+    d_entries.clear();
+  }
+
+  FilterCatalog::FilterCatalog(const std::string &binStr) :
+    FCatalog(), d_entries() {
+#ifndef RDK_USE_BOOST_SERIALIZATION    
+    PRECONDITION(0, "Boost SERIALIZATION is not enabled")
+#else    
+    std::stringstream ss(binStr);
+    boost::archive::text_iarchive ar(ss);
+    ar & d_entries;
+#endif    
+  }
+  
+  std::string FilterCatalog::Serialize() const
+  {
+#ifndef RDK_USE_BOOST_SERIALIZATION    
+    PRECONDITION(0, "Boost SERIALIZATION is not enabled")
+#else
+
+    std::stringstream ss;
+    boost::archive::text_oarchive ar(ss);
+    ar & d_entries;
+    return ss.str();
+#endif    
+  }
+  
+  unsigned int FilterCatalog::addEntry(entryType_t *entry, bool updateFPLength) {
+    d_entries.push_back(boost::shared_ptr<entryType_t>(entry));
+    return static_cast<unsigned int>(d_entries.size() - 1);
+  }
+  
+  const FilterCatalog::entryType_t* FilterCatalog::getEntryWithIdx(unsigned int idx) const {
+    if(idx  < d_entries.size())
+      return d_entries[idx].get();
+    return 0;
+  }
+
+  FilterCatalog::CONST_SENTRY FilterCatalog::getEntry(unsigned int idx) const {
+    PRECONDITION(idx < d_entries.size(), "Index out of bounds");
+    if(idx  < d_entries.size())
+      return d_entries[idx];
+    return CONST_SENTRY();
+  }
+  
+  bool FilterCatalog::removeEntry(unsigned int idx) {
+    if (idx < d_entries.size()) {
+      d_entries.erase(d_entries.begin() + (idx));
+      return true;
+    }
+    return false;
+  }
+
+  bool FilterCatalog::removeEntry(const FilterCatalog::CONST_SENTRY &entry) {
+    std::vector<SENTRY>::iterator it = std::find(d_entries.begin(), d_entries.end(), entry);
+    if (it != d_entries.end()) {
+      d_entries.erase(it);
+      return true;
+    }
+    return false;
+  }
+
+  unsigned int FilterCatalog::getIdxForEntry(const entryType_t*entry) const {
+    for(size_t i=0;i<d_entries.size();++i) {
+      if (d_entries[i].get() == entry)
+        return i;
+    }
+    return UINT_MAX;
+  }
+  
+  unsigned int FilterCatalog::getIdxForEntry(const CONST_SENTRY &entry) const {
+    for(size_t i=0;i<d_entries.size();++i) {
+      if (d_entries[i] == entry)
+        return i;
+    }
+    return UINT_MAX;
+  }
+  
+  void FilterCatalog::setCatalogParams(paramType_t *params) {
+    Clear();
+    FCatalog::setCatalogParams(params);
+    params->fillCatalog(*this);
+    
+  }
+
+  bool FilterCatalog::hasMatch(const ROMol &mol) const {
+    return getFirstMatch(mol) != 0;
+  }
+
+  boost::shared_ptr<const FilterCatalog::entryType_t>
+    FilterCatalog::getFirstMatch(const ROMol &mol) const {
+    for( size_t i=0; i<d_entries.size(); ++i) {
+        if (d_entries[i]->hasFilterMatch(mol))
+          return d_entries[i];
+    }
+    return boost::shared_ptr<const FilterCatalog::entryType_t>();
+  }
+
+  const std::vector<boost::shared_ptr<const FilterCatalog::entryType_t> >
+    FilterCatalog::getMatches(const ROMol &mol) const {
+    
+    std::vector<boost::shared_ptr<const FilterCatalog::entryType_t> > result;
+    for( size_t i=0; i<d_entries.size(); ++i)
+      {
+        if (d_entries[i]->hasFilterMatch(mol))
+          result.push_back(d_entries[i]);
+      }
+    return result;
+  }
+
+
+bool FilterCatalogCanSerialize() {
+#ifdef RDK_USE_BOOST_SERIALIZATION
+  return true;
+#else
+  return false;
+#endif
+}
+   
+}

--- a/Code/GraphMol/FilterCatalog/FilterCatalog.h
+++ b/Code/GraphMol/FilterCatalog/FilterCatalog.h
@@ -1,0 +1,217 @@
+//  Copyright (c) 2015, Novartis Institutes for BioMedical Research Inc.
+//  All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+//       copyright notice, this list of conditions and the following
+//       disclaimer in the documentation and/or other materials provided
+//       with the distribution.
+//     * Neither the name of Novartis Institutes for BioMedical Research Inc.
+//       nor the names of its contributors may be used to endorse or promote
+//       products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+#ifndef _RD_FILTER_CATALOG_PARAMS_
+#define _RD_FILTER_CATALOG_PARAMS_
+
+#include <Catalogs/Catalog.h>
+#include <Catalogs/CatalogParams.h>
+#include "FilterCatalogEntry.h"
+
+namespace RDKit {
+  class FilterCatalog;
+  class FilterCatalogParams : public RDCatalog::CatalogParams
+  {
+  public:
+    enum FilterCatalogs
+    {
+      PAINS_A = (1u << 1),
+      PAINS_B = (1u << 2),
+      PAINS_C = (1u << 3),
+      PAINS   = PAINS_A | PAINS_B | PAINS_C,
+      
+      BRENK = (1u << 4),
+      NIH   = (1u << 5),
+      ZINC  = (1u << 6),
+
+      ALL = PAINS | BRENK | NIH | ZINC
+    };
+
+
+  FilterCatalogParams() : RDCatalog::CatalogParams() {
+    setTypeStr("Filter Catalog Parameters");
+  }
+
+  FilterCatalogParams(FilterCatalogs catalogs) : RDCatalog::CatalogParams() {
+    setTypeStr("Filter Catalog Parameters");
+    addCatalog(catalogs);
+  }
+
+  FilterCatalogParams(const FilterCatalogParams &other) :
+    RDCatalog::CatalogParams(other), d_catalogs(other.d_catalogs) {
+  }
+
+  virtual ~FilterCatalogParams() {}
+
+  //------------------------------------
+  //! Adds an existing FilterCatalog specification to be used in the FilterCatalog
+  //
+  /*!
+    Specifies an existing filter catalog to be used.
+      
+      \param catalogs One of the enumerated known FilterCatalogs 
+    */
+  virtual bool addCatalog(FilterCatalogs catalogs);
+
+  //------------------------------------
+  //! Returns the existing list of FilterCatalogs to be used.
+  const std::vector<FilterCatalogs> & getCatalogs() const { return d_catalogs; }
+  //! Fill a catalog with the appropriate entries
+  virtual void fillCatalog(FilterCatalog &catalog);
+  
+  //! serializes (pickles) to a stream
+  virtual void toStream(std::ostream &ss) const;
+  //! returns a string with a serialized (pickled) representation
+  virtual std::string Serialize() const;
+  //! initializes from a stream pickle
+  virtual void initFromStream(std::istream &ss);
+  //! initializes from a string pickle
+  virtual void initFromString(const std::string &text);
+  
+  private:
+
+    std::vector<FilterCatalogs> d_catalogs;
+
+#ifdef RDK_USE_BOOST_SERIALIZATION
+    friend class boost::serialization::access;
+    template<class Archive> 
+      void serialize(Archive & ar, const unsigned int version) {
+        ar & d_catalogs;
+      }
+#endif    
+  };
+
+  typedef RDCatalog::Catalog<FilterCatalogEntry, FilterCatalogParams> FCatalog;
+  class FilterCatalog : public FCatalog
+  {
+  public:
+    // syntactic sugar for getMatch(es) return values.
+    typedef boost::shared_ptr<entryType_t> SENTRY;
+    typedef boost::shared_ptr<const entryType_t> CONST_SENTRY;
+    
+
+    FilterCatalog() : FCatalog(), d_entries() {
+    }
+
+    FilterCatalog(const paramType_t &params) : FCatalog(), d_entries() {
+      setCatalogParams(new paramType_t(params));
+    }
+
+    FilterCatalog(const FilterCatalog &rhs) : FCatalog(rhs), d_entries(rhs.d_entries ) {
+    }
+
+    FilterCatalog(const std::string &binStr);
+    
+   ~FilterCatalog();
+
+    virtual std::string Serialize() const;
+
+    // Adds a new FilterCatalogEntry to the catalog
+    /*!
+      Adds a new FilterCatalogEntry to the catalog  The catalog
+      owns the entry
+      
+      \param entry          The FilterCatalogEntry to add.
+      \param updateFPLength unused in the FilterCatalog object.
+    */
+
+    virtual unsigned int addEntry(entryType_t *entry, bool updateFPLength = true);
+
+    // Removes a FilterCatalogEntry to the catalog by description
+    /*!
+      Removes a FilterCatalogEntry from the catalog.
+      
+      \param idx          The FilterCatalogEntry index for the entry to remove.
+       n.b. removing an entry may change the indicies of other entries.
+            To safely remove entries, remove entries with the highest idx
+             first.
+    */
+    bool removeEntry(unsigned int idx);
+    bool removeEntry(const CONST_SENTRY &entry);
+
+    //------------------------------------
+    //! returns a particular FilterCatalogEntry in the Catalog
+    //!  required by Catalog.h API
+    virtual const entryType_t* getEntryWithIdx(unsigned int idx) const;
+
+    //------------------------------------
+    //! returns a particular FilterCatalogEntry in the Catalog
+    //!  memory safe version of getEntryWithIdx
+    CONST_SENTRY getEntry(unsigned int idx) const;
+    
+    //------------------------------------
+    //! returns the idx of the given entry, UINT_MAX if not found.
+                     
+    unsigned int getIdxForEntry(const entryType_t*entry) const; 
+    unsigned int getIdxForEntry(const CONST_SENTRY &entry) const;
+
+    //------------------------------------
+    //! returns the number of entries in the catalog
+    virtual unsigned int getNumEntries() const { return d_entries.size(); }
+
+    //------------------------------------
+    //! Reset the current catalog to match the specified FilterCatalogParameters
+    /*
+      \param params  The new FilterCatalogParams specifying the new state of the catalog
+    */
+    virtual void setCatalogParams(paramType_t *params);
+
+    //------------------------------------
+    //! Returns true if the molecule matches any entry in the catalog
+    /*
+      \param mol  ROMol to match against the catalog
+    */
+    bool hasMatch(const ROMol &mol) const;
+
+    //------------------------------------
+    //! Returns the first match against the catalog
+    /*
+      \param mol  ROMol to match against the catalog
+    */
+    CONST_SENTRY getFirstMatch(const ROMol &mol) const;
+
+    //------------------------------------
+    //! Returns all matches to the molecule
+    /*
+      \param mol  ROMol to match against the catalog
+    */
+    const std::vector<CONST_SENTRY > getMatches(const ROMol &mol) const;
+
+  private:
+    void Clear();
+    std::vector<boost::shared_ptr<FilterCatalogEntry> > d_entries;
+  };
+
+  bool FilterCatalogCanSerialize();
+  
+}
+
+
+#endif

--- a/Code/GraphMol/FilterCatalog/FilterCatalogEntry.cpp
+++ b/Code/GraphMol/FilterCatalog/FilterCatalogEntry.cpp
@@ -1,0 +1,116 @@
+//  Copyright (c) 2015, Novartis Institutes for BioMedical Research Inc.
+//  All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+//       copyright notice, this list of conditions and the following
+//       disclaimer in the documentation and/or other materials provided
+//       with the distribution.
+//     * Neither the name of Novartis Institutes for BioMedical Research Inc.
+//       nor the names of its contributors may be used to endorse or promote
+//       products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+#include "Filters.h"
+#include "FilterCatalogEntry.h"
+#include <GraphMol/SmilesParse/SmilesParse.h>
+
+
+namespace RDKit
+{
+
+const std::string DESCRIPTION = "description";
+std::string FilterCatalogEntry::getDescription() const {
+  std::string desc;
+  d_props.getValIfPresent(DESCRIPTION, desc);
+  return desc;
+}
+
+void FilterCatalogEntry::setDescription(const std::string &desc) {
+  d_props.setVal(DESCRIPTION, desc);
+}
+
+
+  void FilterCatalogEntry::toStream(std::ostream &ss) const {
+#ifndef RDK_USE_BOOST_SERIALIZATION
+    PRECONDITION(0, "Boost SERIALIZATION is not enabled")
+#else
+    boost::archive::text_oarchive ar(ss);
+    ar << *this;
+#endif
+  }
+
+  std::string FilterCatalogEntry::Serialize() const {
+    std::stringstream ss;
+    toStream(ss);
+    return ss.str();
+  }
+
+  void FilterCatalogEntry::initFromStream(std::istream &ss) {
+#ifndef RDK_USE_BOOST_SERIALIZATION
+    PRECONDITION(0, "Boost SERIALIZATION is not enabled")
+#else
+    boost::archive::text_iarchive ar(ss);
+    ar >> *this;
+#endif
+  }
+
+  void FilterCatalogEntry::initFromString(const std::string &text) {
+    std::stringstream ss(text);
+    initFromStream(ss);
+  }
+    
+
+  FilterCatalogEntry *MakeFilterCatalogEntry(const FilterData_t &data,
+                                             unsigned int num_props,
+                                             const FilterProperty_t *props) {
+  ROMOL_SPTR pattern(SmartsToMol(data.smarts, 0, false));
+  if (!pattern.get())
+    return 0;
+
+  // The filter has the concept of the maximum number of times the pattern is allowed
+  //   without triggering
+  // The matcher has the concept of the minimum pattern count before the pattern
+  //  is triggered.
+  // Hence pattern.minCount == filter.maxCount + 1
+  const unsigned int minCount = data.max ? data.max + 1 : 1;
+  FilterCatalogEntry *entry =  new FilterCatalogEntry(
+              data.name,
+              boost::shared_ptr<FilterMatcherBase>(
+                new SmartsMatcher(data.name, pattern, minCount)));
+
+  if (!entry->isValid()) {
+    delete entry;
+      return 0;
+  }
+
+  // add the props
+  for(unsigned int i=0; i<num_props; i++) {
+    std::string val(props[i].value);
+    entry->getProps().setVal<std::string>(std::string(props[i].key),
+                                          val);
+  }
+      
+  return entry;
+}
+} // end namespace RDKit
+  
+
+

--- a/Code/GraphMol/FilterCatalog/FilterCatalogEntry.h
+++ b/Code/GraphMol/FilterCatalog/FilterCatalogEntry.h
@@ -1,0 +1,275 @@
+//  Copyright (c) 2015, Novartis Institutes for BioMedical Research Inc.
+//  All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+//       copyright notice, this list of conditions and the following
+//       disclaimer in the documentation and/or other materials provided
+//       with the distribution.
+//     * Neither the name of Novartis Institutes for BioMedical Research Inc.
+//       nor the names of its contributors may be used to endorse or promote
+//       products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+#ifndef __RD_FILTER_CATALOG_H__
+#define __RD_FILTER_CATALOG_H__
+
+#include <RDGeneral/types.h> // For Dict
+#include <GraphMol/RDKitBase.h>
+#include <GraphMol/Substruct/SubstructMatch.h>
+#include <Catalogs/CatalogEntry.h>
+
+#ifdef RDK_USE_BOOST_SERIALIZATION
+#include <boost/archive/text_oarchive.hpp>
+#include <boost/archive/text_iarchive.hpp>
+#include <boost/serialization/vector.hpp>
+#include <boost/serialization/shared_ptr.hpp>
+#endif
+
+#include "FilterMatchers.h"
+
+namespace RDKit
+{
+  typedef std::map<std::string,std::string> STRING_PROPS;
+  
+  class FilterCatalogEntry : public RDCatalog::CatalogEntry
+  {
+  private:
+    boost::shared_ptr<FilterMatcherBase> d_matcher;
+    Dict d_props;
+    
+  public:
+    FilterCatalogEntry() : d_matcher(), d_props() {
+    }
+    
+    FilterCatalogEntry(const std::string &name,
+                       const FilterMatcherBase &matcher) :
+      RDCatalog::CatalogEntry(), d_matcher(matcher.Clone()) {
+      setDescription(name);
+    }
+
+    FilterCatalogEntry(const std::string &name,
+                       boost::shared_ptr<FilterMatcherBase> matcher) :
+      RDCatalog::CatalogEntry(), d_matcher(matcher) {
+      setDescription(name);
+    }
+    
+    FilterCatalogEntry(const FilterCatalogEntry &rhs) :
+      RDCatalog::CatalogEntry(rhs), d_matcher(rhs.d_matcher), d_props(rhs.d_props) {
+    }
+    
+    virtual ~FilterCatalogEntry() {}
+
+    //------------------------------------
+    //! Returns true if the Filters stored in this catalog entry are valid
+    
+    bool isValid() const { return d_matcher.get() && d_matcher->isValid(); }
+
+    //------------------------------------
+    //! Returns the description of the catalog entry
+    std::string getDescription() const;
+    
+    //------------------------------------
+    //! Sets the description of the catalog entry
+    /*
+      \param const std::string & description
+     */
+    void  setDescription(const std::string &description);
+
+        //! \name Properties
+    //@{
+
+    //! returns a list with the names of our \c properties
+    STR_VECT getPropList() const {
+      return d_props.keys();
+    }
+      
+
+    //! sets a \c property value
+    /*!
+       \param key the name under which the \c property should be stored.
+           If a \c property is already stored under this name, it will be
+           replaced.
+       \param val the value to be stored
+     */
+    template <typename T>
+    void setProp(const char *key, T val) {
+      std::string what(key);
+    }
+    //! \overload
+    template <typename T>
+    void setProp(const std::string &key, T val) {
+      d_props.setVal(key, val);
+    }
+
+    //! allows retrieval of a particular property value
+    /*!
+
+       \param key the name under which the \c property should be stored.
+           If a \c property is already stored under this name, it will be
+           replaced.
+       \param res a reference to the storage location for the value.
+
+       <b>Notes:</b>
+         - if no \c property with name \c key exists, a KeyErrorException will be thrown.
+         - the \c boost::lexical_cast machinery is used to attempt type conversions.
+           If this fails, a \c boost::bad_lexical_cast exception will be thrown.
+
+    */
+    template <typename T> 
+    void getProp(const char *key, T &res) const {
+      d_props.getVal(key, res);
+    }
+    //! \overload
+    template <typename T>
+    void getProp(const std::string &key, T &res) const {
+      d_props.getVal(key, res);
+    }
+    //! \overload
+    template <typename T> 
+    T getProp(const char *key) const {
+      return d_props.getVal<T>(key);
+    }
+    //! \overload
+    template <typename T>
+    T getProp(const std::string &key) const {
+      return d_props.getVal<T>(key);
+    }
+
+    //! returns whether or not we have a \c property with name \c key
+    //!  and assigns the value if we do
+    template <typename T>
+    bool getPropIfPresent(const char *key,T &res) const {
+        return d_props.getValIfPresent(key,res);
+    }
+    //! \overload
+    template <typename T>
+    bool getPropIfPresent(const std::string &key,T &res) const {
+        return d_props.getValIfPresent(key,res);
+    }
+
+    //! returns whether or not we have a \c property with name \c key
+    bool hasProp(const char *key) const {
+      return d_props.hasVal(key);
+    }
+    //! \overload
+    bool hasProp(const std::string &key) const {
+      return d_props.hasVal(key);
+      //return hasProp(key.c_str());
+    }
+
+    //! clears the value of a \c property
+    void clearProp(const char *key)  {
+      std::string what(key);
+      clearProp(what);
+    };
+    //! \overload
+    void clearProp(const std::string &key)  {
+      d_props.clearVal(key);
+    };
+
+    // -------------------------------------------
+    //!  Properties usually contain the reference and source
+    //!  for the catalog entry.
+    
+          Dict &getProps()       { return d_props; }
+    const Dict &getProps() const { return d_props; }
+          void  setProps(const Dict &props) { d_props = props; }
+
+    //------------------------------------
+    //! Returns the matching filters for this catalog entry
+    /*
+      \param mol The molecule to match against
+      \param std::vector<FilterMatch> the resulting FilterMatches
+     */
+    bool getFilterMatches(const ROMol &mol, std::vector<FilterMatch> &matchVect) const {
+      return this->isValid() && d_matcher->getMatches(mol, matchVect);
+    }
+
+    //------------------------------------
+    //! Returns true if the filters in this catalog entry match the molecule
+    /*
+      \param mol The molecule to match against
+     */
+
+    bool hasFilterMatch(const ROMol &mol) const {
+      return this->isValid() && d_matcher->hasMatch(mol);
+    }
+
+
+    //! serializes (pickles) to a stream
+    virtual void toStream(std::ostream &ss) const;
+    //! returns a string with a serialized (pickled) representation
+    virtual std::string Serialize() const;
+    //! initializes from a stream pickle
+    virtual void initFromStream(std::istream &ss);
+    //! initializes from a string pickle
+    virtual void initFromString(const std::string &text);
+  private:
+
+#ifdef RDK_USE_BOOST_SERIALIZATION    
+    friend class boost::serialization::access;
+    template<class Archive>
+    void save(Archive &ar, const unsigned int version) const {
+      registerFilterMatcherTypes(ar);
+
+      ar & d_matcher;
+      // we only save string based props here...
+      STR_VECT keys = d_props.keys();
+      std::vector<std::string> string_props;
+      for(size_t i=0; i<keys.size(); ++i) {
+        std::string val;
+        try {
+          if (d_props.getValIfPresent<std::string>(keys[i], val)) {
+            string_props.push_back(keys[i]);
+            string_props.push_back(val);
+          }
+        } catch (const boost::bad_any_cast &) {
+          // pass, can't serialize
+          // warning, this changes properties types, see Dict.cpp
+        }
+      }
+      ar & string_props;
+    }
+
+    template<class Archive>
+    void load(Archive &ar, const unsigned int version) {
+      registerFilterMatcherTypes(ar);
+      
+      ar & d_matcher;
+      std::vector<std::string> string_props;
+      ar & string_props;
+      d_props.reset();
+      
+      for(size_t i=0; i<string_props.size()/2; ++i) {
+        d_props.setVal(string_props[i*2],
+                       string_props[i*2+1]);
+      }
+    }
+    
+    BOOST_SERIALIZATION_SPLIT_MEMBER();
+#endif
+  };
+}
+BOOST_CLASS_VERSION(RDKit::FilterCatalogEntry, 1)
+
+#endif //__RD_FILTER_CATALOG_H__
+
+

--- a/Code/GraphMol/FilterCatalog/FilterMatcherBase.h
+++ b/Code/GraphMol/FilterCatalog/FilterMatcherBase.h
@@ -1,0 +1,131 @@
+//  Copyright (c) 2015, Novartis Institutes for BioMedical Research Inc.
+//  All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+//       copyright notice, this list of conditions and the following
+//       disclaimer in the documentation and/or other materials provided
+//       with the distribution.
+//     * Neither the name of Novartis Institutes for BioMedical Research Inc.
+//       nor the names of its contributors may be used to endorse or promote
+//       products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+#ifndef __RD_FILTER_MATCHER_BASE_H__
+#define __RD_FILTER_MATCHER_BASE_H__
+#include <GraphMol/RDKitBase.h>
+#include "FilterMatcherBase.h"
+#include <boost/archive/text_oarchive.hpp>
+#include <boost/archive/text_iarchive.hpp>
+#include <boost/serialization/assume_abstract.hpp>
+#include <boost/enable_shared_from_this.hpp>
+
+namespace RDKit
+{
+
+  class FilterMatcherBase; // Forward declaration
+  
+  //! Holds the atomPairs matched by the underlying matcher
+  struct FilterMatch
+  {
+    boost::shared_ptr<FilterMatcherBase> filterMatch;
+    MatchVectType                        atomPairs;
+    
+  FilterMatch(boost::shared_ptr<FilterMatcherBase> filter,
+              MatchVectType atomPairs) :
+    filterMatch(filter), atomPairs(atomPairs) {
+    }
+    
+  FilterMatch(const FilterMatch &rhs) :
+    filterMatch(rhs.filterMatch),
+      atomPairs(rhs.atomPairs) {
+    }
+
+    bool operator==(const FilterMatch&rhs) {
+      return (filterMatch.get() == rhs.filterMatch.get() &&
+              atomPairs == rhs.atomPairs);
+    }
+  };
+  
+  extern const char * DEFAULT_FILTERMATCHERBASE_NAME;
+  class FilterMatcherBase :
+    public boost::enable_shared_from_this<FilterMatcherBase>
+  {
+    //------------------------------------
+    //! Virtual API for filter matching
+    std::string d_filterName;
+    
+  public:
+  FilterMatcherBase(const std::string &name=DEFAULT_FILTERMATCHERBASE_NAME) :
+    d_filterName(name) {
+    }
+
+  FilterMatcherBase(const FilterMatcherBase &rhs) :
+    d_filterName(rhs.d_filterName) {
+    }
+    
+    virtual ~FilterMatcherBase() {}
+    
+    virtual bool isValid() const = 0;
+    
+    virtual std::string getName() const { return d_filterName; }
+    //------------------------------------
+    //! getMatches
+    /*!
+      Match the filter against a molecule
+      
+      \param mol readonly const molecule being searched
+      \param matches  output vector of atom index matches found in the molecule
+    */
+    
+    virtual bool getMatches(const ROMol &mol,
+                            std::vector<FilterMatch> &matchVect) const = 0;
+    
+    //------------------------------------
+    //! hasMatches
+    /*!
+      Does the given molecule contain this filter pattern
+      
+      \param mol readonly const molecule being searched
+    */
+    
+    virtual bool hasMatch(const ROMol &mol) const = 0;
+    
+    //------------------------------------
+    //! Clone
+    //  Clones the current FilterMatcherBase into one that
+    //   can be passed around safely.
+    virtual boost::shared_ptr<FilterMatcherBase> Clone() const = 0;
+    
+  private:
+#ifdef RDK_USE_BOOST_SERIALIZATION        
+    friend class boost::serialization::access;
+    template<class Archive> 
+      void serialize(Archive & ar, const unsigned int version) {
+      ar & d_filterName;
+    }
+#endif    
+  };
+  
+#ifdef RDK_USE_BOOST_SERIALIZATION        
+  BOOST_SERIALIZATION_ASSUME_ABSTRACT(FilterMatcherBase)
+#endif
+}
+#endif

--- a/Code/GraphMol/FilterCatalog/FilterMatchers.cpp
+++ b/Code/GraphMol/FilterCatalog/FilterMatchers.cpp
@@ -1,0 +1,141 @@
+//  Copyright (c) 2015, Novartis Institutes for BioMedical Research Inc.
+//  All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+//       copyright notice, this list of conditions and the following
+//       disclaimer in the documentation and/or other materials provided
+//       with the distribution.
+//     * Neither the name of Novartis Institutes for BioMedical Research Inc.
+//       nor the names of its contributors may be used to endorse or promote
+//       products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+#include "FilterMatchers.h"
+#include <GraphMol/SmilesParse/SmilesParse.h>
+
+namespace RDKit
+{
+  const char * DEFAULT_FILTERMATCHERBASE_NAME = "Unnamed FilterMatcherBase";
+  const char * SMARTS_MATCH_NAME_DEFAULT = "Unnamed SmartsMatcher";
+
+  SmartsMatcher::SmartsMatcher(const ROMol &pattern,
+                               unsigned int minCount,
+                               unsigned int maxCount) :
+    FilterMatcherBase(SMARTS_MATCH_NAME_DEFAULT),
+    d_pattern(new ROMol(pattern)),
+    d_min_count(minCount),
+    d_max_count(maxCount) {
+  }
+  
+  SmartsMatcher::SmartsMatcher(const std::string &name,
+                               const ROMol &pattern,
+                               unsigned int minCount,
+                               unsigned int maxCount) :
+    FilterMatcherBase(name),
+    d_pattern(new ROMol(pattern)),
+    d_min_count(minCount),
+    d_max_count(maxCount) {
+  }
+
+  SmartsMatcher::SmartsMatcher(const std::string &name,
+                               const std::string &smarts,
+                               unsigned int minCount,
+                               unsigned int maxCount) :
+    FilterMatcherBase(name),
+    d_pattern(SmartsToMol(smarts)),
+    d_min_count(minCount),
+    d_max_count(maxCount) {
+  }
+  
+  SmartsMatcher::SmartsMatcher(const std::string &name,
+                               ROMOL_SPTR pattern,
+                               unsigned int minCount,
+                               unsigned int maxCount) :
+    FilterMatcherBase(name), d_pattern(pattern),
+    d_min_count(minCount), d_max_count(maxCount) {
+  }
+
+
+  void SmartsMatcher::setPattern(const std::string &smarts) {
+    d_pattern.reset( SmartsToMol(smarts) );
+  }
+  
+  void SmartsMatcher::setPattern(const ROMol&mol) {
+    d_pattern.reset( new ROMol(mol) );
+  }
+
+  SmartsMatcher::SmartsMatcher(const SmartsMatcher &rhs) :
+    FilterMatcherBase(rhs),
+    d_pattern(rhs.d_pattern),
+    d_min_count(rhs.d_min_count),
+    d_max_count(rhs.d_max_count) {
+  }
+    
+  bool SmartsMatcher::getMatches(const ROMol &mol,
+                               std::vector<FilterMatch> &matchVect) const {
+    PRECONDITION(d_pattern.get(),"bad on pattern");
+    
+    bool onPatExists = false;
+    std::vector<RDKit::MatchVectType> matches;
+
+    if (d_min_count == 1 && d_max_count == UINT_MAX) {
+      RDKit::MatchVectType match;
+      onPatExists = RDKit::SubstructMatch(mol, *d_pattern.get(),
+                                          match);
+      if(onPatExists)
+        matchVect.push_back(FilterMatch(Clone(), match));
+    }
+    else { // need to count
+      const bool uniquify = true;
+      unsigned int count = RDKit::SubstructMatch(mol,
+                                                 *d_pattern.get(),
+                                                 matches, uniquify);
+      onPatExists = ( count >= d_min_count &&
+                      (d_max_count == UINT_MAX || count <= d_max_count) );
+      if (onPatExists) {
+        boost::shared_ptr<FilterMatcherBase> clone = Clone();
+        for(size_t i=0;i<matches.size();++i) {
+          matchVect.push_back(FilterMatch(clone, matches[i]));
+        }
+      }
+    }
+    return onPatExists;
+  }
+  
+  bool SmartsMatcher::hasMatch(const ROMol &mol) const
+  {
+    PRECONDITION(d_pattern.get(),"bad on pattern");
+
+    if (d_min_count == 1 && d_max_count == UINT_MAX) {
+      RDKit::MatchVectType matches;
+      return SubstructMatch(mol, *d_pattern.get(), matches);
+    }
+    else { // need to count
+      const bool uniquify = true;
+      std::vector<RDKit::MatchVectType> matches;
+      unsigned int count = RDKit::SubstructMatch(mol,
+                                                 *d_pattern.get(),
+                                                 matches, uniquify);
+      return ( count >= d_min_count &&
+               (d_max_count == UINT_MAX || count <= d_max_count) );
+    }
+  }
+}

--- a/Code/GraphMol/FilterCatalog/FilterMatchers.h
+++ b/Code/GraphMol/FilterCatalog/FilterMatchers.h
@@ -1,0 +1,485 @@
+//  Copyright (c) 2015, Novartis Institutes for BioMedical Research Inc.
+//  All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+//       copyright notice, this list of conditions and the following
+//       disclaimer in the documentation and/or other materials provided
+//       with the distribution.
+//     * Neither the name of Novartis Institutes for BioMedical Research Inc.
+//       nor the names of its contributors may be used to endorse or promote
+//       products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+#ifndef __RD_FILTER_MATCHER_H__
+#define __RD_FILTER_MATCHER_H__
+#include <GraphMol/RDKitBase.h>
+#include <GraphMol/Substruct/SubstructMatch.h>
+#include "FilterMatcherBase.h"
+#include <GraphMol/MolPickler.h>
+
+namespace RDKit
+{
+
+namespace
+{
+  std::string getArgName(const boost::shared_ptr<FilterMatcherBase> &arg) {
+    if (arg.get())
+      return arg->getName();
+    return "<nullmatcher>";
+  }
+    
+}
+  
+namespace FilterMatchOps
+{
+  class And : public FilterMatcherBase
+  {
+    boost::shared_ptr<FilterMatcherBase> arg1;
+    boost::shared_ptr<FilterMatcherBase> arg2;
+  public:
+    // !Default Constructor for serialization
+    And() :FilterMatcherBase("And"), arg1(), arg2() {}
+
+    //! Constructs an Ander
+    //! True if arg1 and arg2 FilterMatchers are true
+    
+    And(const FilterMatcherBase &arg1,
+        const FilterMatcherBase &arg2) :
+    FilterMatcherBase("And"), arg1(arg1.Clone()), arg2(arg2.Clone()) {
+    }
+
+    And(const boost::shared_ptr<FilterMatcherBase> &arg1,
+      const boost::shared_ptr<FilterMatcherBase> &arg2) :
+    FilterMatcherBase("And"), arg1(arg1), arg2(arg2) {
+    }
+
+    And(const And&rhs) :
+      FilterMatcherBase(rhs),
+      arg1(rhs.arg1),
+      arg2(rhs.arg2) {
+    }
+
+    virtual std::string getName() const {
+      return "(" + getArgName(arg1) + " " + FilterMatcherBase::getName()
+        + " " + getArgName(arg2) + ")"; }
+
+    bool isValid() const {
+      return arg1.get() && arg2.get() &&
+        arg1->isValid() && arg2->isValid(); }
+    
+    bool hasMatch(const ROMol &mol) const {
+      PRECONDITION(isValid(), "FilterMatchOps::And is not valid, null arg1 or arg2");
+      return arg1->hasMatch(mol) && arg2->hasMatch(mol);
+    }
+
+    bool getMatches(const ROMol &mol, std::vector<FilterMatch> &matchVect) const {
+      PRECONDITION(isValid(), "FilterMatchOps::And is not valid, null arg1 or arg2");
+      std::vector<FilterMatch> matches;
+      if (arg1->getMatches(mol,matches) && arg2->getMatches(mol,matches))
+        {
+          matchVect = matches;
+          return true;
+        }
+      return false;
+    }
+
+    boost::shared_ptr<FilterMatcherBase> Clone() const {
+      return boost::shared_ptr<FilterMatcherBase>(new And(*this));
+    }
+  private:
+#ifdef RDK_USE_BOOST_SERIALIZATION    
+    friend class boost::serialization::access;
+    template<class Archive>
+    void serialize(Archive &ar, const unsigned int version) {
+      ar & boost::serialization::base_object<FilterMatcherBase>(*this);
+
+      ar & arg1;
+      ar & arg2;
+    }
+#endif    
+  };
+
+  class Or : public FilterMatcherBase {
+    boost::shared_ptr<FilterMatcherBase> arg1;
+    boost::shared_ptr<FilterMatcherBase> arg2;
+  public:
+    // !Default Constructor for serialization
+    Or() :FilterMatcherBase("Or"), arg1(), arg2() {}
+    
+    //! Constructs or Ander
+    //! true if arg1 or arg2 are true
+    Or(const FilterMatcherBase &arg1,
+       const FilterMatcherBase &arg2) :
+      FilterMatcherBase("Or"), arg1(arg1.Clone()), arg2(arg2.Clone()) {
+    }
+
+    Or(const boost::shared_ptr<FilterMatcherBase> &arg1,
+       const boost::shared_ptr<FilterMatcherBase> &arg2) :
+      FilterMatcherBase("Or"), arg1(arg1), arg2(arg2) {
+    }
+
+    Or(const Or&rhs) :
+      FilterMatcherBase(rhs),
+      arg1(rhs.arg1),
+      arg2(rhs.arg2) {
+    }
+
+    virtual std::string getName() const {
+      return "(" + getArgName(arg1) + " " + FilterMatcherBase::getName()
+        + " " + getArgName(arg2) + ")"; }
+
+    bool isValid() const {
+      return arg1.get() && arg2.get() &&
+        arg1->isValid() && arg2->isValid(); }
+
+    bool hasMatch(const ROMol &mol) const {
+      PRECONDITION(isValid(), "Or is not valid, null arg1 or arg2");
+      return arg1->hasMatch(mol) || arg2->hasMatch(mol);
+    }
+
+    bool getMatches(const ROMol &mol, std::vector<FilterMatch> &matchVect) const {
+      PRECONDITION(isValid(), "FilterMatchOps::Or is not valid, null arg1 or arg2");
+      // we want both matches to run in order to accumulate all matches
+      //  into matchVect, otherwise the or can be arbitrary...
+      bool res1 = arg1->getMatches(mol,matchVect);
+      bool res2 = arg2->getMatches(mol,matchVect);
+      return res1 || res2;
+    }
+
+    boost::shared_ptr<FilterMatcherBase> Clone() const {
+      return boost::shared_ptr<FilterMatcherBase>(new Or(*this));
+    }
+
+#ifdef RDK_USE_BOOST_SERIALIZATION    
+    friend class boost::serialization::access;
+    template<class Archive>
+    void serialize(Archive &ar, const unsigned int version) {
+      ar & boost::serialization::base_object<FilterMatcherBase>(*this);
+      ar & arg1;
+      ar & arg2;
+    }
+#endif
+  };
+
+  class Not : public FilterMatcherBase
+  {
+    boost::shared_ptr<FilterMatcherBase> arg1;
+  public:
+    // !Default Constructor for serialization
+    Not() :FilterMatcherBase("Not"), arg1() {}
+    
+    //! Constructs a Noter
+    //! true if arg1 is false (note, never returns matches
+    //  from getMatches since a false internal match matches
+    //  nothing!
+    Not(const FilterMatcherBase &arg1) :
+      FilterMatcherBase("Not"), arg1(arg1.Clone()) {
+    }
+
+    Not(const boost::shared_ptr<FilterMatcherBase> &arg1) :
+      FilterMatcherBase("Not"), arg1(arg1) {
+    }
+
+    Not(const Not &rhs) :
+      FilterMatcherBase(rhs),
+      arg1(rhs.arg1) {
+    }
+    
+    virtual std::string getName() const {
+      return "(" + FilterMatcherBase::getName() + " " + getArgName(arg1) + ")";
+    }
+      
+    bool isValid() const {
+      return arg1.get() && arg1->isValid();
+    }
+
+    bool hasMatch(const ROMol &mol) const {
+      PRECONDITION(isValid(), "FilterMatchOps::Not: arg1 is null");
+      return !arg1->hasMatch(mol);
+    }
+
+    bool getMatches(const ROMol &mol, std::vector<FilterMatch> &) const {
+      PRECONDITION(isValid(), "FilterMatchOps::Not: arg1 is null");
+      // If we are a not, we really can't hold the match for
+      //  this query since by definition it won't exist!
+      std::vector<FilterMatch> matchVect;
+      return !arg1->getMatches(mol,matchVect);
+    }
+
+    boost::shared_ptr<FilterMatcherBase> Clone() const {
+      return boost::shared_ptr<FilterMatcherBase>(new Not(*this));
+    }
+    
+  private:
+#ifdef RDK_USE_BOOST_SERIALIZATION    
+    friend class boost::serialization::access;
+    template<class Archive>
+    void serialize(Archive &ar, const unsigned int version) {
+      ar & boost::serialization::base_object<FilterMatcherBase>(*this);
+      ar & arg1;
+    }
+#endif
+  };
+}
+ 
+ extern const char * SMARTS_MATCH_NAME_DEFAULT;
+ class SmartsMatcher : public FilterMatcherBase
+ {
+    ROMOL_SPTR      d_pattern;
+    unsigned int    d_min_count;
+    unsigned int    d_max_count;
+    
+  public:
+    //! Construct a SmartsMatcher
+    SmartsMatcher(const std::string &name=SMARTS_MATCH_NAME_DEFAULT) :
+      FilterMatcherBase(name), d_pattern(), d_min_count(0), d_max_count(UINT_MAX) {
+      }
+
+    //! Construct a SmartsMatcher from a query molecule
+    /*
+      \param pattern  query molecule used as the substructure search
+      \param unsigned int minCount  minimum number of times the pattern needs to appear
+      \param maxCount the maximum number of times the pattern should appear
+      a value of UINT_MAX indicates the pattern can exist any number of times.
+      [default UINT_MAX]
+      
+    */
+    SmartsMatcher(const ROMol &pattern,
+                  unsigned int minCount=1, unsigned int maxCount=UINT_MAX);
+
+    //! Construct a SmartsMatcher
+    /*
+      \param name     name for the smarts pattern
+      \param pattern  query molecule used as the substructure search
+      \param unsigned int minCount  minimum number of times the pattern needs to appear
+      \param maxCount the maximum number of times the pattern should appear
+      a value of UINT_MAX indicates the pattern can exist any number of times.
+      [default UINT_MAX]
+      
+    */
+
+    SmartsMatcher(const std::string &name, const ROMol &pattern,
+                unsigned int minCount=1, unsigned int maxCount=UINT_MAX);
+
+    //! Construct a SmartsMatcher from a smarts pattern
+    /*
+      \param name     name for the smarts pattern
+      \param smarts   smarts pattern to use for the filter
+      \param unsigned int minCount  minimum number of times the pattern needs to appear
+      \param maxCount the maximum number of times the pattern should appear
+      a value of UINT_MAX indicates the pattern can exist any number of times.
+      [default UINT_MAX]
+    */
+
+    SmartsMatcher(const std::string &name,
+                  const std::string &smarts,
+                  unsigned int minCount=1, unsigned int maxCount=UINT_MAX);
+    
+    //! Construct a SmartsMatcher from a shared_ptr 
+    /*
+      \param name     name for the smarts pattern
+      \param pattern  shared_ptr query molecule used as the substructure search
+      \param unsigned int minCount  minimum number of times the pattern needs to appear
+      \param maxCount the maximum number of times the pattern should appear
+      a value of UINT_MAX indicates the pattern can exist any number of times.
+      [default UINT_MAX]
+    */    
+
+    SmartsMatcher(const std::string &name, ROMOL_SPTR onPattern,
+                  unsigned int minCount=1, unsigned int maxCount=UINT_MAX);
+
+    SmartsMatcher(const SmartsMatcher &rhs);
+
+    //! Returns True if the Smarts pattern is valid
+    bool isValid() const {
+      return d_pattern.get();
+    }
+
+    //! Return the shared_ptr to the underlying query molecule
+    const ROMOL_SPTR &getPattern()   const              { return d_pattern; }
+    //! Set the smarts pattern for the matcher
+    void              setPattern(const std::string &smarts);
+    //! Set the query molecule for the matcher
+    void              setPattern(const ROMol&mol);
+    //! Set the shared query molecule for the matcher
+    void              setPattern(const ROMOL_SPTR &pat) { d_pattern = pat; }
+
+    //! Get the minimum match count for the pattern to be true
+    unsigned int      getMinCount() const               { return d_min_count; }
+    //! Set the minimum match count for the pattern to be true
+    void              setMinCount(unsigned int val)     { d_min_count = val; }
+    //! Get the maximum match count for the pattern to be true
+    unsigned int      getMaxCount() const               { return d_max_count; }
+    //! Set the maximum match count for the pattern to be true
+    void              setMaxCount(unsigned int val)     { d_max_count = val; }
+
+    virtual bool getMatches(const ROMol &mol, std::vector<FilterMatch> &matchVect) const;
+    virtual bool hasMatch(const ROMol &mol) const;
+    virtual boost::shared_ptr<FilterMatcherBase> Clone() const {
+      return boost::shared_ptr<FilterMatcherBase>( new SmartsMatcher(*this) );
+    }
+
+  private:
+#ifdef RDK_USE_BOOST_SERIALIZATION    
+    friend class boost::serialization::access;
+    template<class Archive>
+    void save(Archive &ar, const unsigned int version) const {
+      ar & boost::serialization::base_object<FilterMatcherBase>(*this);
+      std::string res;
+      MolPickler::pickleMol(*d_pattern.get(),res);
+      ar & res;
+      ar & d_min_count;
+      ar & d_max_count;
+    }
+    template<class Archive>
+    void load(Archive &ar, const unsigned int version)  {
+      ar & boost::serialization::base_object<FilterMatcherBase>(*this);
+      {
+        std::string res;
+        ar & res;
+        d_pattern = boost::shared_ptr<ROMol>( new ROMol(res) );
+      }
+      ar & d_min_count;
+      ar & d_max_count;
+    }
+    BOOST_SERIALIZATION_SPLIT_MEMBER();    
+#endif
+ };
+
+  // ------------------------------------------------------------------
+  // Syntactic sugar for the following style patterns
+  // Add exclusion patterns
+  //   using FilterMatchOps;
+  //   And(new SmartsMatcher(pat1),
+  //                  new Not(SmartsMatcher(pat2)))
+  // The exclusion match never adds any FilterMatches when getMatches
+  //  is called, the main intent is for it to be used with an
+  //  And construct, such as:
+  //    And(SmartsMatcher(..), ExclusionList(...))
+  //
+  //  which will return the SmartsMatcher FilterMatch only if no patterns
+  //    in the exclusion list are found.
+  class ExclusionList : public FilterMatcherBase
+  {
+    std::vector<boost::shared_ptr<FilterMatcherBase> > d_offPatterns;
+    
+  public:
+    ExclusionList() : FilterMatcherBase("Not any of"), d_offPatterns() {
+    }
+    
+    //! Constructs an ExclusionList
+    //! true if non of the FilterMatcherBases are true
+    //! Syntactic sugar for
+    //!  using FilterMatchOps;
+    //!  And(Not(SmartsMatcher(pat1),
+    //!                 And(Not(SmartsMatcher(pat2)),
+    //!                                And(Not(Single...
+
+    ExclusionList(
+          const std::vector<boost::shared_ptr<FilterMatcherBase> > &offPatterns) :
+      FilterMatcherBase("Not any of"),
+      d_offPatterns(offPatterns) {
+      }
+
+    virtual std::string getName() const {
+      std::string res;
+      res = "(" + FilterMatcherBase::getName();
+      for(size_t i=0; i<d_offPatterns.size(); ++i) {
+        res += " " + d_offPatterns[i]->getName();
+      }
+      res += ")";
+      return res;
+    }
+    
+    bool isValid() const {
+      for(size_t i=0; i<d_offPatterns.size(); ++i)
+        if (!d_offPatterns[i]->isValid())
+          return false;
+      return true;
+    }
+
+    void addPattern(const FilterMatcherBase &base) {
+      PRECONDITION(base.isValid(), "Invalid FilterMatcherBase");
+      d_offPatterns.push_back(base.Clone());
+    }
+    
+    void setExclusionPatterns(
+      const std::vector<boost::shared_ptr<FilterMatcherBase> > &offPatterns) {
+      d_offPatterns = offPatterns;
+    }
+    
+    virtual bool getMatches(const ROMol &mol, std::vector<FilterMatch> &) const {
+      PRECONDITION(isValid(),
+                   "ExclusionList: one of the exclusion pattens is invalid");
+      bool result = true;
+      for(size_t i=0; i<d_offPatterns.size() && result; ++i) {
+        result &= !d_offPatterns[i]->hasMatch(mol);
+      }
+
+      return result;
+    }
+    
+    virtual bool hasMatch(const ROMol &mol) const {
+      PRECONDITION(isValid(),
+                   "ExclusionList: one of the exclusion pattens is invalid");
+      bool result = true;
+      for(size_t i=0; i<d_offPatterns.size() && result; ++i) {
+        result &= !d_offPatterns[i]->hasMatch(mol);
+      }
+
+      return result;
+    }
+
+    virtual boost::shared_ptr<FilterMatcherBase> Clone() const {
+      return boost::shared_ptr<FilterMatcherBase>( new ExclusionList(*this) );
+    }
+
+  private:
+#ifdef RDK_USE_BOOST_SERIALIZATION    
+    friend class boost::serialization::access;
+    template<class Archive>
+    void serialize(Archive &ar, const unsigned int version) {
+      ar & boost::serialization::base_object<FilterMatcherBase>(*this);
+      ar & d_offPatterns;
+    }
+#endif
+  };
+
+#ifdef RDK_USE_BOOST_SERIALIZATION      
+  // Register all known filter matcher types for serialization
+  template<class Archive>
+    void registerFilterMatcherTypes(Archive &ar) {
+    ar.register_type(static_cast<FilterMatchOps::And *>(NULL));
+    ar.register_type(static_cast<FilterMatchOps::Or *>(NULL));
+    ar.register_type(static_cast<FilterMatchOps::Not *>(NULL));
+    ar.register_type(static_cast<SmartsMatcher *>(NULL));
+    ar.register_type(static_cast<ExclusionList *>(NULL));
+  }
+#endif  
+}
+
+#ifdef RDK_USE_BOOST_SERIALIZATION    
+BOOST_CLASS_VERSION(RDKit::SmartsMatcher, 1)
+BOOST_CLASS_VERSION(RDKit::ExclusionList, 1)
+#endif
+
+
+#endif

--- a/Code/GraphMol/FilterCatalog/Filters.cpp
+++ b/Code/GraphMol/FilterCatalog/Filters.cpp
@@ -1,0 +1,1034 @@
+//  Copyright (c) 2015, Novartis Institutes for BioMedical Research Inc.
+//  All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+//       copyright notice, this list of conditions and the following
+//       disclaimer in the documentation and/or other materials provided
+//       with the distribution.
+//     * Neither the name of Novartis Institutes for BioMedical Research Inc.
+//       nor the names of its contributors may be used to endorse or promote
+//       products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+#include "Filters.h"
+#include "FilterCatalog.h"
+
+namespace RDKit
+{
+
+
+/////////////////////////////////////////////////////////////////////////////////////////
+// BRENK data
+// # Reference: Brenk R et al. Lessons Learnt from Assembling Screening Libraries for Drug Discovery for Neglected Diseases. ChemMedChem 3 (2008) 435-444. doi:10.1002/cmdc.200700139.
+// # Scope: unwanted functionality due to potential tox reasons or unfavourable pharmacokinetic properties
+// 
+
+const FilterData_t BRENK[] = {
+{">_2_ester_groups","C(=O)O[C,H1].C(=O)O[C,H1].C(=O)O[C,H1]",0,""},
+{"2-halo_pyridine","n1c([F,Cl,Br,I])cccc1",0,""},
+{"acid_halide","C(=O)[Cl,Br,I,F]",0,""},
+{"acyclic_C=C-O","C=[C!r]O",0,""},
+{"acyl_cyanide","N#CC(=O)",0,""},
+{"acyl_hydrazine","C(=O)N[NH2]",0,""},
+{"aldehyde","[CH1](=O)",0,""},
+{"Aliphatic_long_chain","[R0;D2][R0;D2][R0;D2][R0;D2]",0,""},
+{"alkyl_halide","[CX4][Cl,Br,I]",0,""},
+{"amidotetrazole","c1nnnn1C=O",0,""},
+{"aniline","c1cc([NH2])ccc1",0,""},
+{"azepane","[CH2R2]1N[CH2R2][CH2R2][CH2R2][CH2R2][CH2R2]1",0,""},
+{"Azido_group","N=[N+]=[N-]",0,""},
+{"Azo_group","N#N",0,""},
+{"azocane","[CH2R2]1N[CH2R2][CH2R2][CH2R2][CH2R2][CH2R2][CH2R2]1",0,""},
+{"benzidine","[cR2]1[cR2][cR2]([Nv3X3,Nv4X4])[cR2][cR2][cR2]1[cR2]2[cR2][cR2][cR2]([Nv3X3,Nv4X4])[cR2][cR2]2",0,""},
+{"beta-keto/anhydride","[C,c](=O)[CX4,CR0X3,O][C,c](=O)",0,""},
+{"biotin_analogue","C12C(NC(N1)=O)CSC2",0,""},
+{"Carbo_cation/anion","[C+,c+,C-,c-]",0,""},
+{"catechol","c1c([OH])c([OH,NH2,NH])ccc1",0,""},
+{"charged_oxygen_or_sulfur_atoms","[O+,o+,S+,s+]",0,""},
+{"chinone_1","C1(=[O,N])C=CC(=[O,N])C=C1",0,""},
+{"chinone_2","C1(=[O,N])C(=[O,N])C=CC=C1",0,""},
+{"conjugated_nitrile_group","C=[C!r]C#N",0,""},
+{"crown_ether","[OR2,NR2]@[CR2]@[CR2]@[OR2,NR2]@[CR2]@[CR2]@[OR2,NR2]",0,""},
+{"cumarine","c1ccc2c(c1)ccc(=O)o2",0,""},
+{"cyanamide","N[CH2]C#N",0,""},
+{"cyanate_/aminonitrile_/thiocyanate","[N,O,S]C#N",0,""},
+{"cyanohydrins","N#CC[OH]",0,""},
+{"cycloheptane_1","[CR2]1[CR2][CR2][CR2][CR2][CR2][CR2]1",0,""},
+{"cycloheptane_2","[CR2]1[CR2][CR2]cc[CR2][CR2]1",0,""},
+{"cyclooctane_1","[CR2]1[CR2][CR2][CR2][CR2][CR2][CR2][CR2]1",0,""},
+{"cyclooctane_2","[CR2]1[CR2][CR2]cc[CR2][CR2][CR2]1",0,""},
+{"diaminobenzene_1","[cR2]1[cR2]c([N+0X3R0,nX3R0])c([N+0X3R0,nX3R0])[cR2][cR2]1",0,""},
+{"diaminobenzene_2","[cR2]1[cR2]c([N+0X3R0,nX3R0])[cR2]c([N+0X3R0,nX3R0])[cR2]1",0,""},
+{"diaminobenzene_3","[cR2]1[cR2]c([N+0X3R0,nX3R0])[cR2][cR2]c1([N+0X3R0,nX3R0])",0,""},
+{"diazo_group","[N!R]=[N!R]",0,""},
+{"diketo_group","[C,c](=O)[C,c](=O)",0,""},
+{"disulphide","SS",0,""},
+{"enamine","[CX2R0][NX3R0]",0,""},
+{"ester_of_HOBT","C(=O)Onnn",0,""},
+{"four_member_lactones","C1(=O)OCC1",0,""},
+{"halogenated_ring_1","c1cc([Cl,Br,I,F])cc([Cl,Br,I,F])c1[Cl,Br,I,F]",0,""},
+{"halogenated_ring_2","c1ccc([Cl,Br,I,F])c([Cl,Br,I,F])c1[Cl,Br,I,F]",0,""},
+{"heavy_metal","[Hg,Fe,As,Sb,Zn,Se,se,Te,B,Si]",0,""},
+{"het-C-het_not_in_ring","[NX3R0,NX4R0,OR0,SX2R0][CX4][NX3R0,NX4R0,OR0,SX2R0]",0,""},
+{"hydantoin","C1NC(=O)NC(=O)1",0,""},
+{"hydrazine","N[NH2]",0,""},
+{"hydroquinone","[OH]c1ccc([OH,NH2,NH])cc1",0,""},
+{"hydroxamic_acid","C(=O)N[OH]",0,""},
+{"imine_1","C=[N!R]",0,""},
+{"imine_2","N=[CR0][N,n,O,S]",0,""},
+{"iodine","I",0,""},
+{"isocyanate","N=C=O",0,""},
+{"isolated_alkene","[$([CH2]),$([CH][CX4]),$(C([CX4])[CX4])]=[$([CH2]),$([CH][CX4]),$(C([CX4])[CX4])]",0,""},
+{"ketene","C=C=O",0,""},
+{"methylidene-1,3-dithiole","S1C=CSC1=S",0,""},
+{"Michael_acceptor_1","C=!@CC=[O,S]",0,""},
+{"Michael_acceptor_2","[$([CH]),$(CC)]#CC(=O)[C,c]",0,""},
+{"Michael_acceptor_3","[$([CH]),$(CC)]#CS(=O)(=O)[C,c]",0,""},
+{"Michael_acceptor_4","C=C(C=O)C=O",0,""},
+{"Michael_acceptor_5","[$([CH]),$(CC)]#CC(=O)O[C,c]",0,""},
+{"N_oxide","[NX2,nX3][OX1]",0,""},
+{"N-acyl-2-amino-5-mercapto-1,3,4-_thiadiazole","s1c(S)nnc1NC=O",0,""},
+{"N-C-halo","NC[F,Cl,Br,I]",0,""},
+{"N-halo","[NX3,NX4][F,Cl,Br,I]",0,""},
+{"N-hydroxyl_pyridine","n[OH]",0,""},
+{"nitro_group","[N+](=O)[O-]",0,""},
+{"N-nitroso","[#7]-N=O",0,""},
+{"oxime_1","[C,c]=N[OH]",0,""},
+{"oxime_2","[C,c]=NOC=O",0,""},
+{"Oxygen-nitrogen_single_bond","[OR0,NR0][OR0,NR0]",0,""},
+{"Perfluorinated_chain","[CX4](F)(F)[CX4](F)F",0,""},
+{"peroxide","OO",0,""},
+{"phenol_ester","c1ccccc1OC(=O)[#6]",0,""},
+{"phenyl_carbonate","c1ccccc1OC(=O)O",0,""},
+{"phosphor","P",0,""},
+{"phthalimide","[cR,CR]~C(=O)NC(=O)~[cR,CR]",0,""},
+{"Polycyclic_aromatic_hydrocarbon_1","a1aa2a3a(a1)A=AA=A3=AA=A2",0,""},
+{"Polycyclic_aromatic_hydrocarbon_2","a21aa3a(aa1aaaa2)aaaa3",0,""},
+{"Polycyclic_aromatic_hydrocarbon_3","a31a(a2a(aa1)aaaa2)aaaa3",0,""},
+{"polyene","[CR0]=[CR0][CR0]=[CR0]",0,""},
+{"quaternary_nitrogen_1","[s,S,c,C,n,N,o,O]~[nX3+,NX3+](~[s,S,c,C,n,N])~[s,S,c,C,n,N]",0,""},
+{"quaternary_nitrogen_2","[s,S,c,C,n,N,o,O]~[n+,N+](~[s,S,c,C,n,N,o,O])(~[s,S,c,C,n,N,o,O])~[s,S,c,C,n,N,o,O]",0,""},
+{"quaternary_nitrogen_3","[*]=[N+]=[*]",0,""},
+{"saponine_derivative","O1CCCCC1OC2CCC3CCCCC3C2",0,""},
+{"silicon_halogen","[Si][F,Cl,Br,I]",0,""},
+{"stilbene","c1ccccc1C=Cc2ccccc2",0,""},
+{"sulfinic_acid","[SX3](=O)[O-,OH]",0,""},
+{"Sulfonic_acid_1","[C,c]S(=O)(=O)O[C,c]",0,""},
+{"Sulfonic_acid_2","S(=O)(=O)[O-,OH]",0,""},
+{"sulfonyl_cyanide","S(=O)(=O)C#N",0,""},
+{"sulfur_oxygen_single_bond","[SX2]O",0,""},
+{"sulphate","OS(=O)(=O)[O-]",0,""},
+{"sulphur_nitrogen_single_bond","[SX2H0][N]",0,""},
+{"Thiobenzothiazole_1","c12ccccc1(SC(S)=N2)",0,""},
+{"thiobenzothiazole_2","c12ccccc1(SC(=S)N2)",0,""},
+{"Thiocarbonyl_group","[C,c]=S",0,""},
+{"thioester","SC=O",0,""},
+{"thiol_1","[S-]",0,""},
+{"thiol_2","[SH]",0,""},
+{"Three-membered_heterocycle","*1[O,S,N]*1",0,""},
+{"triflate","OS(=O)(=O)C(F)(F)F",0,""},
+{"triphenyl_methyl-silyl","[SiR0,CR0](c1ccccc1)(c2ccccc2)(c3ccccc3)",0,""},
+{"triple_bond","C#C",0,""}
+};
+const unsigned int NUM_BRENK = static_cast<unsigned int>(sizeof(BRENK)/sizeof(FilterData_t));
+
+const FilterProperty_t BRENK_PROPS[] = {
+{"Reference", "Brenk R et al. Lessons Learnt from Assembling Screening Libraries for Drug Discovery for Neglected Diseases. ChemMedChem 3 (2008) 435-444. doi:10.1002/cmdc.200700139."},
+{"Scope", "unwanted functionality due to potential tox reasons or unfavourable pharmacokinetic properties"}
+};
+const unsigned int NUM_BRENK_PROPS = static_cast<unsigned int>(sizeof(BRENK_PROPS)/
+                                                               sizeof(FilterProperty_t));
+
+
+
+/////////////////////////////////////////////////////////////////////////////////////////
+// NIH data
+// # Scope: annotate compounds with problematic functional groups 
+// # Reference: Doveston R, et al. A Unified Lead-oriented Synthesis of over Fifty Molecular Scaffolds. Org Biomol Chem 13 (2014) 859D65. doi:10.1039/C4OB02287D.
+// # Reference: Jadhav A, et al. Quantitative Analyses of Aggregation, Autofluorescence, and Reactivity Artifacts in a Screen for Inhibitors of a Thiol Protease. J Med Chem 53 (2009) 37D51. doi:10.1021/jm901070c.
+// 
+
+const FilterData_t NIH[] = {
+{"2halo_pyrazine_3EWG","[#7;R1]1[#6]([F,Cl,Br,I])[#6]([$(S(=O)(=O)),$(C(F)(F)(F)),$(C#N),$(N(=O)(=O)),$([N+](=O)[O-]),$(C=O)])[#7][#6][#6]1",0,""},
+{"2halo_pyrazine_5EWG","[#7;R1]1[#6]([F,Cl,Br,I])[#6;!$(c-N)][#7][#6]([$(S(=O)(=O)),$(C(F)(F)(F)),$(C#N),$(N(=O)(=O)),$([N+](=O)[O-]),$(C=O)])[#6;!$(c-N)]1",0,""},
+{"2halo_pyridazine_3EWG","[#7;R1]1[#6]([F,Cl,Br,I])[#6]([$(S(=O)(=O)),$(C(F)(F)(F)),$(C#N),$(N(=O)(=O)),$([N+](=O)[O-]),$(C=O)])[#6][#6][#7]1",0,""},
+{"2halo_pyridazine_5EWG","[#7;R1]1[#6]([F,Cl,Br,I])[#6][#6][#6]([$(S(=O)(=O)),$(C(F)(F)(F)),$(C#N),$(N(=O)(=O)),$([N+](=O)[O-]),$(C=O)])[#7]1",0,""},
+{"2halo_pyridine_3EWG","[#7;R1]1[#6;!$(c=O)]([F,Cl,Br,I])[#6]([$(S(=O)(=O)),$(C(F)(F)(F)),$(C#N),$(N(=O)(=O)),$([N+](=O)[O-]),$(C=O)])[#6;!$(c-N)][#6][#6;!$(c-N)]1",0,""},
+{"2halo_pyridine_5EWG","[#7;R1]1[#6;!$(c=O)]([F,Cl,Br,I])[#6][#6;!$(c-N)][#6]([$(S(=O)(=O)),$(C(F)(F)(F)),$(C#N),$(N(=O)(=O)),$([N+](=O)[O-]),$(C=O)])[#6;!$(c=O);!$(c-N)]1",0,""},
+{"2halo_pyrimidine_5EWG","[#7;R1]1[#6]([F,Cl,Br,I])[#7][#6][#6]([$(S(=O)(=O)),$(C(F)(F)(F)),$(C#N),$(N(=O)(=O)),$([N+](=O)[O-]),$(C=O)])[#6]1",0,""},
+{"3halo_pyridazine_2EWG","[#7;R1]1[#6]([$(S(=O)(=O)),$(C(F)(F)(F)),$(C#N),$(N(=O)(=O)),$([N+](=O)[O-]),$(C=O)])[#6]([F,Cl,Br,I])[#6][#6][#7]1",0,""},
+{"3halo_pyridazine_4EWG","[#7;R1]1[#6][#6]([F,Cl,Br,I])[#6]([$(S(=O)(=O)),$(C(F)(F)(F)),$(C#N),$(N(=O)(=O)),$([N+](=O)[O-]),$(C=O)])[#6][#7]1",0,""},
+{"4_pyridone_3_5_EWG","[#7,#8,#16]1~[#6;H]~[#6]([$(S(=O)(=O)),$(C(F)(F)(F)),$(C#N),$(N(=O)(=O)),$([N+](=O)[O-]),$(C=O)])~[#6](=O)~[#6]([$(S(=O)(=O)),$(C(F)(F)(F)),$(C#N),$(N(=O)(=O)),$([N+](=O)[O-]),$(C=O)])~[#6;H]1",0,""},
+{"4halo_pyridine_3EWG","[#7;R1]1[#6;!$(c=O);!$(c-N)][#6]([$(S(=O)(=O)),$(C(F)(F)(F)),$(C#N),$(N(=O)(=O)),$([N+](=O)[O-]),$(C=O)])[#6]([F,Cl,Br,I])[#6][#6;!$(c=O);!$(c-N)]1",0,""},
+{"4halo_pyrimidine_2_6EWG","[#7]1[#6]([$(S(=O)(=O)),$(C(F)(F)(F)),$(C#N),$(N(=O)(=O)),$([N+](=O)[O-]),$(C=O)])[#7;R1][#6]([F,Cl,Br,I])[#6][#6]1([$(S(=O)(=O)),$(C(F)(F)(F)),$(C#N),$(N(=O)(=O)),$([N+](=O)[O-]),$(C=O)])",0,""},
+{"4halo_pyrimidine_5EWG","[#7]1[#6][#7;R1][#6]([F,Cl,Br,I])[#6]([$(S(=O)(=O)),$(C(F)(F)(F)),$(C#N),$(N(=O)(=O)),$([N+](=O)[O-]),$(C=O)])[#6]1",0,""},
+{"CH2_S#O_3_ring","[CH2]1[O,S]C1",0,""},
+{"HOBT_ester","O=C(-[!N])O[$(nnn),$([#7]-[#7]=[#7])]",0,""},
+{"NO_phosphonate","P(=O)ON",0,""},
+{"acrylate","[CH2]=[C;!$(C-N);!$(C-O)]C(=O)",0,""},
+{"activated_4mem_ring","[#6]1~[$(C(=O)),$(S(=O))]~[O,S,N]~[$(C(=O)),$(S(=O))]1",0,""},
+{"activated_S#O_3_ring","C1~[O,S]~[C,N,O,S]1[a,N,O,S]",0,""},
+{"activated_acetylene","[$(S(=O)(=O)),$(C(F)(F)(F)),$(C#N),$(N(=O)(=O)),$([N+](=O)[O-]),$(C(=O))]C#[C;!$(C-N);!$(C-n)]",0,""},
+{"activated_diazo","[N;!R]([$(S(=O)(=O)),$(C(F)(F)(F)),$(C#N),$(N(=O)(=O)),$([N+](=O)[O-]),$(C(=O))])=[N;!R]([$(S(=O)(=O)),$(C(F)(F)(F)),$(C#N),$(N(=O)(=O)),$([N+](=O)[O-]),$(C(=O))])",0,""},
+{"activated_vinyl_ester","O=COC=[$(C(S(=O)(=O))),$(C(C(F)(F)(F))),$(C(C#N)),$(C(N(=O)(=O))),$(C([N+](=O)[O-])),$(C(C(=O)));!$(C(N))]",0,""},
+{"activated_vinyl_sulfonate","O(-S(=O)(=O))C=[$(C(S(=O)(=O))),$(C(C(F)(F)(F))),$(C(C#N)),$(C(N(=O)(=O))),$(C([N+](=O)[O-])),$(C(C(=O)));!$(C(N))]",0,""},
+{"acyclic_imide","[C,c][C;!R](=O)[N;!R][C;!R](=O)[C,c]",0,""},
+{"acyl_123_triazole","[#7;R1]1~[#7;R1]~[#7;R1](-C(=O))~[#6]~[#6]1",0,""},
+{"acyl_134_triazole","[#7]1~[#7]~[#6]~[#7](-C(=O)[!N])~[#6]1",0,""},
+{"acyl_activated_NO","O=C(-[!N])O[$([#7;+]),$(N(C=[O,S,N])(C=[O,S,N]))]",0,""},
+{"acyl_cyanide","C(=O)-C#N",0,""},
+{"acyl_imidazole","[C;!$(C-N)](=O)[#7]1[#6;H1,$([#6]([*;!R]))][#7][#6;H1,$([#6]([*;!R]))][#6;H1,$([#6]([*;!R]))]1",0,""},
+{"acyl_pyrazole","[C;!$(C-N)](=O)[#7]1[#7][#6;H1,$([#6]([*;!R]))][#6;H1,$([#6]([*;!R]))][#6;H1,$([#6]([*;!R]))]1",0,""},
+{"aldehyde","[C,c][C;H1](=O)",0,""},
+{"alpha_dicarbonyl","C(=O)!@C(=O)",0,""},
+{"alpha_halo_EWG","[$(C(F)(F)(F)),$(C#N),$(N(=O)(=O)),$([N+](=O)[O-])]-[CH,CH2]-[Cl,Br,I,$(O(S(=O)(=O)))]",0,""},
+{"alpha_halo_amine","[F,Cl,Br,I,$(O(S(=O)(=O)))]-[CH,CH2;!$(C(F)(F))]-[N,n]",0,"Edited"},
+{"alpha_halo_carbonyl","C(=O)([CH,CH2][Cl,Br,I,$(O(S(=O)(=O)))])",0,""},
+{"alpha_halo_heteroatom","[N,n,O,S;!$(S(=O)(=O))]-[CH,CH2;!$(C(F)(F))][F,Cl,Br,I,$(O(S(=O)(=O)))]",0,""},
+{"alpha_halo_heteroatom_tert","[N,n,O,S;!$(S(=O)(=O))]-C([Cl,Br,I,$(O(S(=O)(=O)))])(C)(C)",0,""},
+{"anhydride","[$(C(=O)),$(C(=S))]-[O,S]-[$(C(=O)),$(C(=S)),$(C(=[N;!R])),$(C(=N(-[C;X4])))]",0,""},
+{"aryl_phosphonate","P(=O)-[O;!R]-a",0,""},
+{"aryl_thiocarbonyl","a-[S;X2;!R]-[C;!R](=O)",0,""},
+{"azide","[$(N#[N+]-[N-]),$([N-]=[N+]=N)]",0,""},
+{"aziridine_diazirine","[C,N]1~[C,N]~N~1",0,""},
+{"azo_amino","[N]=[N;!R]-[N]",0,""},
+{"azo_aryl","c[N;!R;!+]=[N;!R;!+]-c",0,""},
+{"azo_filter1","[N;!R]=[N;!R]-[N]=[*]",0,""},
+{"azo_filter2","[N;!$(N-S(=O)(=O));!$(N-C=O)]-[N;!r3;!$(N-S(=O)(=O));!$(N-C=O)]-[N;!$(N-S(=O)(=O));!$(N-C=O)]",0,""},
+{"azo_filter3","[N;!R]-[N;!R]-[N;!R]",0,""},
+{"azo_filter4","a-N=N-[N;H2]",0,""},
+{"bad_boron","[B-,BH2,BH3,$(B(F)(F))]",0,""},
+{"bad_cations","[C+,F+,Cl+,Br+,I+,Se+]",0,""},
+{"benzidine_like","c([N;!+])1ccc(c2ccc([N;!+])cc2)cc1",0,""},
+{"beta_lactone","[#6,#15,#16]1(=O)~[#6]~[#6]~[#8,#16]1",0,""},
+{"betalactam","C1(=O)~[#6]~[#6]N1",0,""},
+{"betalactam_EWG","C1(=O)~[#6]~[#6]N1([$(S(=O)(=O)[C,c,O&D2]),$(C(F)(F)(F)),$(C#N),$(N(=O)(=O)),$([N+](=O)[O-]),$(C(=O)[C,c,O&D2])])",0,""},
+{"bis_activated_aryl_ester","O=[C,S]Oc1aaa([$(S(=O)(=O)),$(C(F)(F)(F)),$(C#N),$(N(=O)(=O)),$([N+](=O)[O-]),$(C(=O)O),$(C(=O)N)])aa([$(S(=O)(=O)),$(C(F)(F)(F)),$(C#N),$(N(=O)(=O)),$([N+](=O)[O-]),$(C(=O)O),$(C(=O)N)])1",0,""},
+{"bis_keto_olefin","CC(=O)[$([C&H1]),$(C-F),$(C-Cl),$(C-Br),$(C-I)]=[$([C&H1]),$(C-F),$(C-Cl),$(C-Br),$(C-I)]C(=O)C",0,""},
+{"boron_warhead","[C,c]~[#5]",0,""},
+{"branched_polycyclic_aromatic","a1(a2aa(a3aaaaa3)aa(a4aaaaa4)a2)aaaaa1",0,""},
+{"carbodiimide_iso#thio#cyanate","N=C=[N,O,S]",0,""},
+{"carbonyl_halide","O=C[F,Cl,Br,I]",0,""},
+{"contains_metal","[$([Ru]),$([#45]),$([Se]),$([se]),$([Pd]),$([#21]),$([Bi]),$([Sb]),$([Ag]),$([Ti]),$([Al]),$([Cd]),$([V]),$([In]),$([#24]),$([#50]),$([Mn]),$([La]),$([Fe]),$([Er]),$([Tm]),$([Yb]),$([Lu]),$([Hf]),$([Ta]),$([W]),$([Re]),$([#27]),$([#76]),$([Ni]),$([Ir]),$([Cu]),$([Zn]),$([Ga]),$([Ge]),$([As]),$([Y]),$([Zr]),$([Nb]),$([Ce]),$([#59]),$([Nd]),$([Sm]),$([Eu]),$([Gd]),$([Tb]),$([Dy]),$([#67]),$([Pt]),$([Au]),$([Hg]),$([Tl]),$([Pb]),$([Ac]),$([Th]),$([Pa]),$([Mo]),$([U]),$([Tc]),$([Te]),$([#84]),$([At])]",0,"Edited"},
+{"crown_ether","[$([O,S,#7;R1;r9,r10,r11,r12,r13,r14,r15,r16,r17,r18][CH,CH2;r9,r10,r11,r12,r13,r14,r15,r16,r17,r18][CH,CH2;r9,r10,r11,r12,r13,r14,r15,r16,r17,r18][O,S,#7;R1;r9,r10,r11,r12,r13,r14,r15,r16,r17,r18][CH,CH2;r9,r10,r11,r12,r13,r14,r15,r16,r17,r18][CH,CH2;r9,r10,r11,r12,r13,r14,r15,r16,r17,r18][O,S,#7;R1;r9,r10,r11,r12,r13,r14,r15,r16,r17,r18]),$([O,S,#7;R1;r9,r10,r11,r12,r13,r14,r15,r16,r17,r18][CH,CH2;r9,r10,r11,r12,r13,r14,r15,r16,r17,r18][CH,CH2;r9,r10,r11,r12,r13,r14,r15,r16,r17,r18][CH,CH2;r9,r10,r11,r12,r13,r14,r15,r16,r17,r18][O,S,#7;R1;r9,r10,r11,r12,r13,r14,r15,r16,r17,r18][CH,CH2;r9,r10,r11,r12,r13,r14,r15,r16,r17,r18][CH,CH2;r9,r10,r11,r12,r13,r14,r15,r16,r17,r18][CH,CH2;r9,r10,r11,r12,r13,r14,r15,r16,r17,r18][O,S,#7;R1;r9,r10,r11,r12,r13,r14,r15,r16,r17,r18]),$([O,S,#7;R1;r9,r10,r11,r12,r13,r14,r15,r16,r17,r18][CH,CH2;r9,r10,r11,r12,r13,r14,r15,r16,r17,r18][CH,CH2;r9,r10,r11,r12,r13,r14,r15,r16,r17,r18][O,S,#7;R1;r9,r10,r11,r12,r13,r14,r15,r16,r17,r18][CH,CH2;r9,r10,r11,r12,r13,r14,r15,r16,r17,r18][CH,CH2;r9,r10,r11,r12,r13,r14,r15,r16,r17,r18][CH,CH2;r9,r10,r11,r12,r13,r14,r15,r16,r17,r18][O,S,#7;R1;r9,r10,r11,r12,r13,r14,r15,r16,r17,r18])]",0,""},
+{"cyano_phosphonate","P(O[A,a])(O[A,a])(=O)C#N",0,""},
+{"cyanohydrin","[C;X4](-[OH,NH1,NH2,SH])(-C#N)",0,""},
+{"diamino_sulfide","[N,n]~[S;!R;D2]~[N,n]",0,""},
+{"diazo_carbonyl","[$(N=N=C~C=O),$(N#N-C~C=O)]",0,""},
+{"diazonium","a[N+]#N",0,""},
+{"dicarbonyl_sulfonamide","[$(N(-C(=O))(-C(=O))(-S(=O))),$(n([#6](=O))([#6](=O))([#16](=O)))]",0,""},
+{"disulfide_acyclic","[S;!R;X2]-[S;!R;X2]",0,""},
+{"disulfonyliminoquinone","S(=O)(=O)N=C1C=CC(=NS(=O)(=O))C=C1",0,""},
+{"double_trouble_warhead","NC(C[S;D1])C([N;H1]([O;D1]))=O",0,""},
+{"flavanoid","O=C2CC(a3aaaaa3)Oa1aaaaa12",0,""},
+{"four_nitriles","C#N.C#N.C#N.C#N",0,""},
+{"gte_10_carbon_sb_chain","[C;!R]-[C;!R]-[C;!R]-[C;!R]-[C;!R]-[C;!R]-[C;!R]-[C;!R]-[C;!R]-[C;!R]",0,""},
+{"gte_2_N_quats","[N,n;H0;+;!$(N~O);!$(n~O)].[N,n;H0;+;!$(N~O);!$(n~O)]",0,""},
+{"gte_2_free_phos","P([O;D1])=O.P([O;D1])=O",0,""},
+{"gte_2_sulfonic_acid","[C,c]S(=O)(=O)[O;D1].[C,c]S(=O)(=O)[O;D1]",0,""},
+{"gte_3_COOH","C(=O)[O;D1].C(=O)[O;D1].C(=O)[O;D1]",0,""},
+{"gte_3_iodine","[#53].[#53].[#53]",0,""},
+{"gte_4_basic_N","[N;!$(N(=[N,O,S,C]));!$(N(S(=O)(=O)));!$(N(C(F)(F)(F)));!$(N(C#N));!$(N(C(=O)));!$(N(C(=S)));!$(N(C(=N)));!$(N(#C));!$(N-c)].[N;!$(N(=[N,O,S,C]));!$(N(S(=O)(=O)));!$(N(C(F)(F)(F)));!$(N(C#N));!$(N(C(=O)));!$(N(C(=S)));!$(N(C(=N)));!$(N(#C));!$(N-c)].[N;!$(N(=[N,O,S,C]));!$(N(S(=O)(=O)));!$(N(C(F)(F)(F)));!$(N(C#N));!$(N(C(=O)));!$(N(C(=S)));!$(N(C(=N)));!$(N(#C));!$(N-c)].[N;!$(N(=[N,O,S,C]));!$(N(S(=O)(=O)));!$(N(C(F)(F)(F)));!$(N(C#N));!$(N(C(=O)));!$(N(C(=S)));!$(N(C(=N)));!$(N(#C));!$(N-c)]",0,""},
+{"gte_4_nitro","[$([N+](=O)[O-]),$(N(=O)=O)].[$([N+](=O)[O-]),$(N(=O)=O)].[$([N+](=O)[O-]),$(N(=O)=O)].[$([N+](=O)[O-]),$(N(=O)=O)]",0,""},
+{"gte_5_phenolic_OH","a[O;D1].a[O;D1].a[O;D1].a[O;D1].a[O;D1]",0,""},
+{"gte_7_aliphatic_OH","C[O;D1].C[O;D1].C[O;D1].C[O;D1].C[O;D1].C[O;D1].C[O;D1]",0,""},
+{"gte_7_total_hal","[Cl,Br,I].[Cl,Br,I].[Cl,Br,I].[Cl,Br,I].[Cl,Br,I].[Cl,Br,I].[Cl,Br,I]",0,""},
+{"gte_8_CF2_or_CH2","[CH2,$(C(F)(F));R0][CH2,$(C(F)(F));R0][CH2,$(C(F)(F));R0][CH2,$(C(F)(F));R0][CH2,$(C(F)(F));R0][CH2,$(C(F)(F));R0][CH2,$(C(F)(F));R0][CH2,$(C(F)(F));R0]",0,"Edited"},
+{"halo_5heterocycle_bis_EWG","[#7,#8,#16]1[#6]([$(S(=O)(=O)),$([F,Cl]),$(C(F)(F)(F)),$(C#N),$(N(=O)(=O)),$([N+](=O)[O-]),$(C(=O))])[#6]([$(S(=O)(=O)),$([F,Cl]),$(C(F)(F)(F)),$(C#N),$(N(=O)(=O)),$([N+](=O)[O-]),$(C(=O))])[#7][#6]1([Cl,Br,I])",0,""},
+{"halo_acrylate","[$([C;H2]),$([C&H1;$(C-F)]),$([C&H1;$(C-Cl)]),$([C&H1;$(C-Br)]),$([C&H1;$(C-I)]),$(C(F)F),$(C(Cl)Cl),$(C(Br)Br),$(C(I)I),$(C(F)Cl),$(C(F)Br),$(C(F)I),$(C(Cl)Br),$(C(Br)I)](=[$([C&H1;$(C(-C(=O)))]),$(C(F)(C(=O))),$(C(Cl)(C(=O))),$(C(Br)(C(=O))),$(C(I)(C(=O))),$(C(C)(C(=O))),$(C(c)(C(=O)))])",0,""},
+{"halo_imino","C(=[#7])([Cl,Br,I,$(O(S(=O)(=O)))])",0,""},
+{"halo_olefin_bis_EWG","C([Cl,Br,I,$(O(S(=O)(=O)))])=C([$(S(=O)(=O)),$(C(F)(F)(F)),$(C#N),$(N(=O)(=O)),$([N+](=O)[O-]),$(C=O)])([$(S(=O)(=O)),$(C(F)(F)(F)),$(C#N),$(N(=O)(=O)),$([N+](=O)[O-]),$(C=O)])",0,""},
+{"halo_phenolic_carbonyl","C(=O)Oc1c([Cl,F])[cH1,$(c[F,Cl])]c([F,Cl])[cH1,$(c[F,Cl])]c1([F,Cl])",0,""},
+{"halo_phenolic_sulfonyl","S(=O)Oc1c([Cl,F])[cH1,$(c[F,Cl])]c([F,Cl])[cH1,$(c[F,Cl])]c1([F,Cl])",0,""},
+{"halogen_heteroatom","[!C;!c;!H][F,Cl,Br,I]",0,""},
+{"hetero_silyl","[Si]~[!#6]",0,""},
+{"hydrazine","[N;X3;!$(N-S(=O)(=O));!$(N-C(F)(F)(F));!$(N-C#N);!$(N-C(=O));!$(N-C(=S));!$(N-C(=N))]-[N;X3;!$(N-S(=O)(=O));!$(N-C(F)(F)(F));!$(N-C#N);!$(N-C(=O));!$(N-C(=S));!$(N-C(=N))]",0,""},
+{"hydrazothiourea","[N;!R]=NC(=S)N",0,""},
+{"hydroxamate_warhead","C([N;H1]([O;D1]))=O",0,""},
+{"hyperval_sulfur","[$([#16&D3]),$([#16&D4])]=,:[#6]",0,""},
+{"isonitrile","[N+]#[C-]",0,""},
+{"keto_def_heterocycle","[$(c([C;!R;!$(C-[N,O,S]);!$(C-[H])](=O))1naaaa1),$(c([C;!R;!$(C-[N,O,S]);!$(C-[H])](=O))1naa[n,s,o]1)]",0,""},
+{"linear_polycyclic_aromatic_I","[$(a12aaaaa1aa3a(aa(aaaa4)a4a3)a2),$(a12aaaaa1aa3a(aaa4a3aaaa4)a2),$(a12aaaaa1a(aa5)a3a(aaa4a3a5aaa4)a2)]",0,""},
+{"linear_polycyclic_aromatic_II","[$(a12aaaa4a1a3a(aaaa3aa4)aa2),$(a12aaaaa1a3a(aaa4a3aaaa4)aa2),$(a1(a(aaaa4)a4a3a2aaaa3)a2aaaa1)]",0,""},
+{"maleimide_etc","[$([C;H1]),$(C(-[F,Cl,Br,I]))]1=[$([C;H1]),$(C(-[F,Cl,Br,I]))]C(=O)[N,O,S]C(=O)1",0,""},
+{"meldrums_acid_deriv","O=C1OC(C)(C)OC(C1)=O",0,""},
+{"monofluoroacetate","[C;H2](F)C(=O)[O,N,S]",0,""},
+{"nitrone","[C;!R]=[N+][O;D1]",0,""},
+{"nitrosamine","N-[N;X2](=O)",0,""},
+{"non_ring_CH2O_acetal","[O,N,S;!$(S~O)]!@[CH2]!@[O,S,N;!$(S~O)]",0,""},
+{"non_ring_acetal","[O,N,S;!$(S~O)]!@[C;H1;X4]!@[O,N,S;!$(S~O)]",0,""},
+{"non_ring_ketal","[O,N,S;!$(S~O)]!@[C;H0;X4](!@[O,N,S;!$(S~O)])(C)",0,""},
+{"ortho_hydroiminoquinone","c1c([N;D1])c([N;D1])c[cH1][cH1]1",0,""},
+{"ortho_hydroquinone","a1c([O,S;D1])c([O,S;D1])a[cH1][cH1]1",0,""},
+{"ortho_nitrophenyl_carbonyl","[#6]1(-O-[C;!R](=[O,N;!R]))[#6]([$(N(=O)(=O)),$([N+](=O)[O-])])[#6][#6][#6][#6]1",0,""},
+{"ortho_quinone","[CH1,$(C(-[Cl,Br,I]))]1=CC(=[O,N,S;!R])C(=[O,N,S])C=[CH1,$(C(-[Cl,Br,I]))]1",0,""},
+{"oxaziridine","C1~[O,S]~N1",0,""},
+{"oxime","[$(C=N[O;D1]);!$(C=[N+])][#6][#6]",0,""},
+{"oxonium","[o+,O+]",0,""},
+{"para_hydroiminoquinone","a1[cH1]c([N;D1])[cH1]ac([N;D1])1",0,""},
+{"para_hydroquinone","a1[cH1]c([O,S;D1])[cH1]ac([O,S;D1])1",0,""},
+{"para_nitrophenyl_ester","[#6]1(-O(-[C;!R](-[!N])(=[O,N;!R])))[#6][#6][#6]([$(N(=O)(=O)),$([N+](=O)[O-])])[#6][#6]1",0,""},
+{"para_quinone","[CH1,$(C(-[Cl,Br,I]))]1=[CH1,$(C(-[Cl,Br,I]))]C(=[O,N,S])[CH1,$(C(-[Cl,Br,I]))]=[CH1,$(C(-[Cl,Br,I]))]C1(=[O,N,S])",0,""},
+{"paraquat_like","[#6]1[#6][#6]([#6]2[#6][#6][#7;+][#6][#6]2)[#6][#6][#7;+]1",0,""},
+{"pentafluorophenylester","C(=O)Oc1c(F)c(F)c(F)c(F)c1(F)",0,""},
+{"perchloro_cp","C1(Cl)(Cl)C(Cl)C(Cl)=C(Cl)C1(Cl)",0,""},
+{"perhalo_dicarbonyl_phenyl","c1(C=O)c([Br,Cl,I])c([Br,Cl,I])c([Br,Cl,I])c([Br,Cl,I])c1(C=O)",0,""},
+{"perhalo_phenyl","c1c([Br,Cl,I])c([Br,Cl,I])c([Br,Cl,I])c([Br,Cl,I])c1([Br,Cl,I])",0,""},
+{"peroxide","[#8]~[#8]",0,""},
+{"phenolate_bis_EWG","O=[C,S]Oc1aaa([$(S(=O)(=O)),$(C(F)(F)(F)),$(C#N),$(N(=O)(=O)),$([N+](=O)[O-]),$(C(=O)O),$(C(=O)N)])aa([$(S(=O)(=O)),$(C(F)(F)(F)),$(C#N),$(N(=O)(=O)),$([N+](=O)[O-]),$(C(=O)O),$(C(=O)N)])1",0,""},
+{"phos_serine_warhead","NC(COP(O)(O)=O)C(O)=O",0,""},
+{"phos_threonine_warhead","NC(C(C)OP(O)(O)=O)C(O)=O",0,""},
+{"phos_tyrosine_warhead","NC(Cc1ccc(OP(O)(O)=O)cc1)C(O)=O",0,""},
+{"phosphite","[c,C]-[P;v3]",0,""},
+{"phosphonium","[#15;+]~[!O]",0,""},
+{"phosphorane","C=P",0,""},
+{"phosphorous_nitrogen_bond","[#15]~[N,n]",0,""},
+{"phosphorus_phosphorus_bond","P~P",0,""},
+{"phosphorus_sulfur_bond","P~S",0,""},
+{"polyene","C=[C;!R][C;!R]=[C;!R][C;!R]=[C;!R]",0,""},
+{"polyhalo_phenol_a","c1c([O;D1])c(-[Cl,Br,I])c(-[Cl,Br,I])cc1.c1c([O;D1])c(-[Cl,Br,I])c(-[Cl,Br,I])cc1",0,""},
+{"polyhalo_phenol_b","c1c([O;D1])c(-[Cl,Br,I])cc(-[Cl,Br,I])c1.c1c([O;D1])c(-[Cl,Br,I])cc(-[Cl,Br,I])c1",0,""},
+{"polyhalo_phenol_c","c1c([O;D1])ccc(-[Cl,Br,I])c(-[Cl,Br,I])1.c1c([O;D1])ccc(-[Cl,Br,I])c(-[Cl,Br,I])1",0,""},
+{"polyhalo_phenol_d","c(-[Cl,Br,I])1c([O;D1])c(-[Cl,Br,I])ccc1.c(-[Cl,Br,I])1c([O;D1])c(-[Cl,Br,I])ccc1",0,""},
+{"polyhalo_phenol_e","c1c([O;D1])ccc(-[Cl,Br,I])c(-[Cl,Br,I])1.c1c([O;D1])ccc(-[Cl,Br,I])c(-[Cl,Br,I])1",0,""},
+{"polysulfide","[S;D2]-[S;D2]-[S;D2]",0,""},
+{"porphyrin","[#6;r16,r17,r18]~[#6]1~[#6]~[#6]~[#6](~[#6])~[#7]1",0,""},
+{"primary_halide_sulfate","[CH2][Cl,Br,I,$(O(S(=O)(=O)[!$(N);!$([O&D1])]))]",0,""},
+{"quat_N_N","[N,n;R;+]!@[N,n]",0,""},
+{"quat_N_acyl","[N,n;+]!@C(=O)",0,""},
+{"quinone_methide","[#6;!$([#6](-[N,O,S]))]1=[#6;!$([#6](-[N,O,S]))][#6](=[#6])[#6;!$([#6](-[N,O,S]))]=[#6;!$([#6](-[N,O,S]))][#6]1(=[O,N,S])",0,""},
+{"rhodanine","C(=C)1SC(=S)NC(=O)1",0,""},
+{"secondary_halide_sulfate","[CH;!$(C=C)][Cl,Br,I,$(O(S(=O)(=O)[!$(N);!$([O&D1])]))]",0,""},
+{"sulf_D2_nitrogen","[S;D2](-[N;!$(N(=C));!$(N(-S(=O)(=O)));!$(N(-C(=O)))])",0,""},
+{"sulf_D2_oxygen_D2","[S;D2][O;D2]",0,""},
+{"sulf_D3_nitrogen","[S;D3](-N)(-[c,C])(-[c,C])",0,""},
+{"sulfite_sulfate_ester","[C,c]OS(=O)O[C,c]",0,""},
+{"sulfonium","[S+;X3;$(S-C);!$(S-[O;D1])]",0,""},
+{"sulfonyl_anhydride","[$(C(=O)),$(S(=O)(=O))][O,S](S(=O)(=O))",0,""},
+{"sulfonyl_halide","S(=O)(=O)[F,Cl,Br,I]",0,""},
+{"sulfonyl_heteroatom","[!#6;!#1;!#11;!#19]O(S(=O)(=O)(-[C,c]))",0,""},
+{"sulphonyl_cyanide","S(=O)(=O)C#N",0,""},
+{"tertiary_halide_sulfate","[C;X4](-[Cl,Br,I,$(O(S(=O)(=O)[!$(N);!$([O&D1])]))])(-[c,C])(-[c,C])(-[c,C])",0,""},
+{"thio_hydroxamate","[S;D2]([$(N(=C)),$(N(-S(=O)(=O))),$(N(-C(=O)))])",0,""},
+{"thio_xanthate","[S;!R]-[C;!R](=[S;!R])(-[S;!R])",0,""},
+{"thiocarbonate","SC(=O)[O,S]",0,""},
+{"thioester","[S;!R;H0]C(=[S,O;!R])([!O;!S;!N])",0,""},
+{"thiol_warhead","NC(C[S;D1])C(O)=O",0,""},
+{"thiopyrylium","c1[S,s;+]cccc1",0,""},
+{"thiosulfoxide","[C,c][S;X3](~O)-S",0,""},
+{"triamide","[$(N(-C(=O))(-C(=O))(-C(=O))),$(n([#6](=O))([#6](=O))([#6](=O)))]",0,""},
+{"triaryl_phosphine_oxide","P(=O)(a)(a)(a)",0,""},
+{"trichloromethyl_ketone","[$(C(=O));!$(C-N);!$(C-O);!$(C-S)]C(Cl)(Cl)(Cl)",0,""},
+{"triflate","OS(=O)(=O)(C(F)(F)(F))",0,""},
+{"trifluoroacetate_ester","C(F)(F)(F)C(=O)O",0,""},
+{"trifluoroacetate_thioester","C(F)(F)(F)C(=O)S",0,""},
+{"trifluoromethyl_ketone","[$(C(=O));!$(C-N);!$(C-O);!$(C-S)]C(F)(F)(F)",0,""},
+{"trihalovinyl_heteroatom","C(-[Cl,Br,I])(-[Cl,Br,I])=C(-[Cl,Br,I])(-[N,O,S])",0,""},
+{"trinitro_aromatic","[$(a1aaa([$(N(=O)(=O)),$([N+](=O)[O-])])a([$(N(=O)(=O)),$([N+](=O)[O-])])a1([$(N(=O)(=O)),$([N+](=O)[O-])])),$(a1aa([$(N(=O)(=O)),$([N+](=O)[O-])])a([$(N(=O)(=O)),$([N+](=O)[O-])])aa1([$(N(=O)(=O)),$([N+](=O)[O-])])),$(a1a([$(N(=O)(=O)),$([N+](=O)[O-])])aa([$(N(=O)(=O)),$([N+](=O)[O-])])aa1([$(N(=O)(=O)),$([N+](=O)[O-])]))]",0,""},
+{"trinitromethane_derivative","C([$([N+](=O)[O-]),$(N(=O)=O)])([$([N+](=O)[O-]),$(N(=O)=O)])([$([N+](=O)[O-]),$(N(=O)=O)])",0,""},
+{"tris_activated_aryl_ester","[$(O=[C,S]Oc1a([$(S(=O)(=O)),F,$(C(F)(F)(F)),$(C#N),$(N(=O)(=O)),$([N+](=O)[O-]),$(C(=O)O),$(C(=O)N)])a([$(S(=O)(=O)),F,$(C(F)(F)(F)),$(C#N),$(N(=O)(=O)),$([N+](=O)[O-]),$(C(=O)O),$(C(=O)N)])a([$(S(=O)(=O)),F,$(C(F)(F)(F)),$(C#N),$(N(=O)(=O)),$([N+](=O)[O-]),$(C(=O)O),$(C(=O)N)])aa1),$(O=[C,S]Oc1a([$(S(=O)(=O)),F,$(C(F)(F)(F)),$(C#N),$(N(=O)(=O)),$([N+](=O)[O-]),$(C(=O)O),$(C(=O)N)])a([$(S(=O)(=O)),F,$(C(F)(F)(F)),$(C#N),$(N(=O)(=O)),$([N+](=O)[O-]),$(C(=O)O),$(C(=O)N)])aaa([$(S(=O)(=O)),F,$(C(F)(F)(F)),$(C#N),$(N(=O)(=O)),$([N+](=O)[O-]),$(C(=O)O),$(C(=O)N)])1),$(O=[C,S]Oc1a([$(S(=O)(=O)),F,$(C(F)(F)(F)),$(C#N),$(N(=O)(=O)),$([N+](=O)[O-]),$(C(=O)O),$(C(=O)N)])aa([$(S(=O)(=O)),F,$(C(F)(F)(F)),$(C#N),$(N(=O)(=O)),$([N+](=O)[O-]),$(C(=O)O),$(C(=O)N)])a([$(S(=O)(=O)),F,$(C(F)(F)(F)),$(C#N),$(N(=O)(=O)),$([N+](=O)[O-]),$(C(=O)O),$(C(=O)N)])a1),$(O=[C,S]Oc1a([$(S(=O)(=O)),F,$(C(F)(F)(F)),$(C#N),$(N(=O)(=O)),$([N+](=O)[O-]),$(C(=O)O),$(C(=O)N)])aa([$(S(=O)(=O)),F,$(C(F)(F)(F)),$(C#N),$(N(=O)(=O)),$([N+](=O)[O-]),$(C(=O)O),$(C(=O)N)])aa([$(S(=O)(=O)),F,$(C(F)(F)(F)),$(C#N),$(N(=O)(=O)),$([N+](=O)[O-]),$(C(=O)O),$(C(=O)N)])1)]",0,""},
+{"trisub_bis_act_olefin","[CH;!R;!$(C-N)]=C([$(S(=O)(=O)),$(C(F)(F)(F)),$(C#N),$(N(=O)(=O)),$([N+](=O)[O-]),$(C(=O))])([$(S(=O)(=O)),$(C(F)(F)(F)),$(C#N),$(N(=O)(=O)),$([N+](=O)[O-]),$(C(=O))])",0,"Edited"},
+{"vinyl_carbonyl_EWG","[C;!R]([$(S(=O)(=O)),$(C(F)(F)(F)),$(C#N),$(N(=O)(=O)),$([N+](=O)[O-]),$(C=O)])([$(S(=O)(=O)),$(C(F)(F)(F)),$(C#N),$(N(=O)(=O)),$([N+](=O)[O-]),$(C=O)])=[C;!R]([C;!R](=O))([!$([#8]);!$([#7])])",0,""}
+};
+const unsigned int NUM_NIH = static_cast<unsigned int>(sizeof(NIH)/sizeof(FilterData_t));
+
+const FilterProperty_t NIH_PROPS[] = {
+{"Scope", "annotate compounds with problematic functional groups"},
+{"Reference", "Doveston R, et al. A Unified Lead-oriented Synthesis of over Fifty Molecular Scaffolds. Org Biomol Chem 13 (2014) 859D65. doi:10.1039/C4OB02287D."},
+{"Reference", "Jadhav A, et al. Quantitative Analyses of Aggregation, Autofluorescence, and Reactivity Artifacts in a Screen for Inhibitors of a Thiol Protease. J Med Chem 53 (2009) 37D51. doi:10.1021/jm901070c."}
+};
+const unsigned int NUM_NIH_PROPS = static_cast<unsigned int>(sizeof(NIH_PROPS)/
+                                                             sizeof(FilterProperty_t));
+
+
+
+/////////////////////////////////////////////////////////////////////////////////////////
+// PAINS_A data
+// # Reference: Baell JB, Holloway GA. New Substructure Filters for Removal of Pan Assay Interference Compounds (PAINS) from Screening Libraries and for Their Exclusion in Bioassays. J Med Chem 53 (2010) 2719D40. doi:10.1021/jm901137j.
+// # Scope: PAINS filters (family A)
+// 
+
+const FilterData_t PAINS_A[] = {
+{"ene_six_het_A(483)","[#6]-1(-[#6](~[!#6&!#1]~[#6]-[!#6&!#1]-[#6]-1=[!#6&!#1])~[!#6&!#1])=[#6;!R]",0,""},
+{"hzone_phenol_A(479)","c:1:c:c(:c(:c:c:1)-[#6]=[#7]-[#7])-[O;H1]",0,""},
+{"anil_di_alk_A(478)","[C;H2]N([C;H2])c1c[c;H1]c(N)[c;H1]c1",0,""},
+{"anil_di_alk_A(478)","[C;H2]N([C;H2])c1c([$([C;H2]),$([O][C;H2][C;H2])])c(N)[c;H1]c1",0,""},
+{"indol_3yl_alk(461)","c12ccccc1c([C;H1])c([$([C;H2]),$([C]=,:[!C]),$([C;H1][N]),$([C;H1]([C;H2])[N;H1][C;H2]),$([C;H1]([C;H2])[C;H2][N;H1][C;H2])])[nH]2",0,""},
+{"indol_3yl_alk(461)","c12ccccc1c([C;H1])c([$([C;H2]),$([C]=,:[!C]),$([C;H1][N]),$([C;H1]([C;H2])[N;H1][C;H2]),$([C;H1]([C;H2])[C;H2][N;H1][C;H2])])[n]2[C;H2]",0,""},
+{"quinone_A(370)","[!#6&!#1]=[#6]-1-[#6]=,:[#6]-[#6](=[!#6&!#1])-[#6]=,:[#6]-1",0,""},
+{"azo_A(324)","[#7;!R]=[#7]",0,""},
+{"imine_one_A(321)","[#6]-[#6](=[!#6&!#1;!R])-[#6](=[!#6&!#1;!R])-[$([#6]),$([#16](=[#8])=[#8])]",0,""},
+{"mannich_A(296)","[#7]-[C;X4]-c1ccccc1-[O;H1]",0,""},
+{"anil_di_alk_B(251)","c:1:c:c(:c:c:c:1-[#7](-[#6;X4])-[#6;X4])-[#6]=[#6]",0,""},
+{"anil_di_alk_C(246)","c:1:c:c(:c:c:c:1-[#8]-[#6;X4])-[#7](-[#6;X4])-[$([#1]),$([#6;X4])]",0,""},
+{"ene_rhod_A(235)","[#7]-1-[#6](=[#16])-[#16]-[#6](=[#6])-[#6]-1=[#8]",0,""},
+{"hzone_phenol_B(215)","c:1(:c:c:c(:c:c:1)-[#6]=[#7]-[#7])-[#8]-[#1]",0,""},
+{"ene_five_hetA1(201A)","[#6]-1(=[#6])-[#6]=[#7]-[#7,#8,#16]-[#6]-1=[#8]",0,""},
+{"ene_five_het_A(201)","[#6]-1(=[#6])-[#6]=[#7]-[!#6&!#1]-[#6]-1=[#8]",0,""},
+{"anil_di_alk_D(198)","c:1:c:c(:c:c:c:1-[#7](-[#6;X4])-[#6;X4])-[#6;X4]-[$([#8]-[#1]),$([#6]=[#6]-[#1]),$([#7]-[#6;X4])]",0,""},
+{"imine_one_isatin(189)","[#8]=[#6]-2-[#6](=!@[#7]-[#7])-c:1:c:c:c:c:c:1-[#7]-2",0,""},
+{"anil_di_alk_E(186)","[#6](-[#1])-[#7](-[#6](-[#1])-[#1])-c:1:c(:c(:c(:c(:c:1-[#1])-[$([#1]),$([#6](-[#1])-[#1])])-[#6](-[#1])-[$([#1]),$([#6]-[#1])])-[#1])-[#1]",0,""}
+};
+const unsigned int NUM_PAINS_A = static_cast<unsigned int>(sizeof(PAINS_A)/sizeof(FilterData_t));
+
+const FilterProperty_t PAINS_A_PROPS[] = {
+{"Reference", "Baell JB, Holloway GA. New Substructure Filters for Removal of Pan Assay Interference Compounds (PAINS) from Screening Libraries and for Their Exclusion in Bioassays. J Med Chem 53 (2010) 2719D40. doi:10.1021/jm901137j."},
+{"Scope", "PAINS filters (family A)"}
+};
+const unsigned int NUM_PAINS_A_PROPS = static_cast<unsigned int>(sizeof(PAINS_A_PROPS)/
+                                                                 sizeof(FilterProperty_t));
+
+
+
+/////////////////////////////////////////////////////////////////////////////////////////
+// PAINS_B data
+// # Reference: Baell JB, Holloway GA. New Substructure Filters for Removal of Pan Assay Interference Compounds (PAINS) from Screening Libraries and for Their Exclusion in Bioassays. J Med Chem 53 (2010) 2719D40. doi:10.1021/jm901137j.
+// # Scope: PAINS filters (family B)
+// # sulfonamide_B(41) c:1:c:c(:c:c:c:1-[#8]-[#1])-[#7](-[#1])-[#16](=[#8])=[#8] 0
+// # sulfonamide_B(41) [N;H1](c1ccc([O;H1])cc1)S(=O)=O 0 
+// # imidazole_A(19) n:1:c(:n(:c(:c:1-c:2:c:c:c:c:c:2)-c:3:c:c:c:c:c:3)-[#1])-[#6]:,=[!#1] 0 
+// 
+
+const FilterData_t PAINS_B[] = {
+{"thiaz_ene_A(128)","[#6]-1(=[#6](-[$([#1]),$([#6](-[#1])-[#1]),$([#6]=[#8])])-[#16]-[#6](-[#7]-1-[$([#1]),$([#6]-[#1]),$([#6]:[#6])])=[#7;!R])-[$([#6](-[#1])-[#1]),$([#6]:[#6])]",0,""},
+{"pyrrole_A(118)","n2(-[#6]:1:[!#1]:[#6]:[#6]:[#6]:[#6]:1)c(cc(c2-[#6;X4])-[#1])-[#6;X4]",0,""},
+{"catechol_A(92)","c:1:c:c(:c(:c:c:1)-[#8;H1])-[#8;H1]",0,""},
+{"ene_five_het_B(90)","[#6]-1(=[#6])-[#6](-[#7]=[#6]-[#16]-1)=[#8]",0,""},
+{"imine_one_fives(89)","[#6]-1=[!#1]-[!#6&!#1]-[#6](-[#6]-1=[!#6&!#1;!R])=[#8]",0,""},
+{"ene_five_het_C(85)","[#6]-1(-[#6](-[#6]=[#6]-[!#6&!#1]-1)=[#6])=[!#6&!#1]",0,""},
+{"hzone_pipzn(79)","CN1[C;H2][C;H2]N(N=[C;H1][#6]=,:[#6])[C;H2][C;H2]1",0,""},
+{"keto_keto_beta_A(68)","c:1-2:c(:c:c:c:c:1)-[#6](=[#8])-[#6;X4]-[#6]-2=[#8]",0,""},
+{"hzone_pyrrol(64)","Cn1cccc1C=NN",0,""},
+{"ene_one_ene_A(57)","[#6]=!@[#6](-[!#1])-@[#6](=!@[!#6&!#1])-@[#6](=!@[#6])-[!#1]",0,""},
+{"cyano_ene_amine_A(56)","N#CC=C(N)C(C#N)C#N",0,""},
+{"ene_five_one_A(55)","c:1-2:c(:c:c:c:c:1)-[#6](=[#8])-[#6](=[#6])-[#6]-2=[#8]",0,""},
+{"cyano_pyridone_A(54)","N#Cc1ccc[#7;H1]c1=S",0,""},
+{"anil_alk_ene(51)","c:1:c:c-2:c(:c:c:1)-[#6]-3-[#6](-[#6]-[#7]-2)-[#6]-[#6]=[#6]-3",0,""},
+{"amino_acridine_A(46)","c:1:c:2:c(:c:c:c:1):n:c:3:c(:c:2-[#7]):c:c:c:c:3",0,""},
+{"ene_five_het_D(46)","[#6]-1(=[#6])-[#6](=[#8])-[#7]-[#7]-[#6]-1=[#8]",0,""},
+{"thiophene_amino_Aa(45)","[N;H2]c1sc([!#1])c([!#1])c1C=O",0,""},
+{"ene_five_het_E(44)","[#7]-[#6]=!@[#6]-2-[#6](=[#8])-c:1:c:c:c:c:c:1-[!#6&!#1]-2",0,""},
+{"sulfonamide_A(43)","NS(=O)(=O)c1cc([F,Cl,Br,I])cc([F,Cl,Br,I])c1O",0,""},
+{"thio_ketone(43)","[#6]-[#6](=[#16])-[#6]",0,""},
+{"sulfonamide_B(41)","[H]N(c1ccc([O;H1])cc1)S(=O)=O",0,""},
+{"anil_no_alk(40)","c:1(:c(:c(:c(:c(:c:1-[#1])-[#1])-[$([#8]),$([#7]),$([#6](-[#1])-[#1])])-[#1])-[#1])-[#7](-[#1])-[#1]",0,""},
+{"thiophene_amino_Ab(40)","[$([#1]),$([#6](-[#1])-[#1]),$([#6]:[#6])]-c:1:c(:c(:c(:s:1)-[#7](-[#1])-[#6](=[#8])-[#6])-[#6](=[#8])-[#8])-[$([#6]:1:[#6]:[#6]:[#6]:[#6]:[#6]:1),$([#6]:1:[#16]:[#6]:[#6]:[#6]:1)]",0,""},
+{"het_pyridiniums_A(39)","[c;H1]1c[!#1]cc2ccc[n+]([$([O;X1]),$([C;H3]),$([#6][#6]:[#6]),$([#6][#6][#8]),$([#6][#6](C)=[#8]),$([#6][#6](N)=[#8]),$([#6][#6][#6])])c12",0,""},
+{"anthranil_one_A(38)","CC(=O)c1ccccc1[#7;H1][!$([#6]=[#8])]",0,""},
+{"cyano_imine_A(37)","[#7;H1][#7]=[#6](-[#6]#[#7])-[#6]=[!#6&!#1;!R]",0,""},
+{"diazox_sulfon_A(36)","[#7](-c:1:c:c:c:c:c:1)-[#16](=[#8])(=[#8])-[#6]:2:[#6]:[#6]:[#6]:[#6]:3:[#7]:[$([#8]),$([#16])]:[#7]:[#6]:2:3",0,""},
+{"hzone_anil_di_alk(35)","[#6](-[#1])(-[#1])-[#7](-[#6](-[#1])-[#1])-c:1:c(:c(:c(:c(:c:1-[#1])-[#1])-[#6](-[#1])=[#7]-[#7]-[$([#6](=[#8])-[#6](-[#1])(-[#1])-[#16]-[#6]:[#7]),$([#6](=[#8])-[#6](-[#1])(-[#1])-[!#1]:[!#1]:[#7]),$([#6](=[#8])-[#6]:[#6]-[#8]-[#1]),$([#6]:[#7]),$([#6](-[#1])(-[#1])-[#6](-[#1])-[#8]-[#1])])-[#1])-[#1]",0,""},
+{"rhod_sat_A(33)","[#7]-1-[#6](=[#16])-[#16]-[#6;X4]-[#6]-1=[#8]",0,""},
+{"hzone_enamin(30)","[#7][#7]=[#6][#6](-[$([#1]),$([#6])])=[#6]([#6])-!@[$([#7]),$([#8])]",0,""},
+{"pyrrole_B(29)","[#6;X4]c1ccc([#6]:[#6])n1c2ccccc2",0,""},
+{"thiophene_hydroxy(28)","s1ccc(c1)-[#8;H1]",0,""},
+{"cyano_pyridone_B(27)","[!#6][#6]1=,:[#7][#6]([#6])=,:[#6](C#N)[#6](=O)[#7]1",0,""},
+{"imine_one_sixes(27)","[#6]-1(-[#6](=[#8])-[#7]-[#6](=[#8])-[#7]-[#6]-1=[#8])=[#7]",0,""},
+{"dyes5A(27)","[#6]=,:[#6]:[#7]([#6])~[#6]:[#6]=,:[#6][#6]~[#6]:[#7]",0,""},
+{"naphth_amino_A(25)","c1cc2cccc3[#7][#6]=,:[#7]c(c1)c23",0,""},
+{"naphth_amino_B(25)","[C;X4]1[N;H1]c3cccc2cccc([N;H1]1)c23",0,""},
+{"ene_one_ester(24)","[#6]-[#8]-[#6](=[#8])-[#6](-[#7][#6])=[#6]-[#6](-[#6])=[#8]",0,""},
+{"thio_dibenzo(23)","S=[#6]1[#6]=,:[#6][!#6,!#6][#6]=,:[#6]1",0,""},
+{"cyano_cyano_A(23)","[#6](-[#6]#[#7])(-[#6]#[#7])-[#6](-[$([#6]#[#7]),$([#6]=[#7])])-[#6]#[#7]",0,""},
+{"hzone_acyl_naphthol(22)","[c;H1]2[c;H1][c;H1]c1[c;H1]c(C(=O)NN=C)c(O)[c;H1]c1[c;H1]2",0,""},
+{"het_65_A(21)","O=Cc1cnn2c([#8;H1])ccnc12",0,""},
+{"imidazole_A(19)","c1ccccc1c1c(c2ccccc2)nc([nH]1)[#6]:,=[#6,#7]",0,""},
+{"ene_cyano_A(19)","[#6](-[#6]#[#7])(-[#6]#[#7])=[#6]-c:1:c:c:c:c:c:1",0,""},
+{"anthranil_acid_A(19)","C=NNc1ccccc1C(=O)[#8;H1]",0,""},
+{"dyes3A(19)","[#6]-,:[#6]:[#7+]=,:[#6][#6]=[#6][#7][#6;X4]",0,""},
+{"dhp_bis_amino_CN(19)","[#6]=,:[#6]C1C(C#N)=C(N)SC(N)=C1C#N",0,""},
+{"het_6_tetrazine(18)","[#7]~[#6]:1:[#7]:[#7]:[#6](:[$([#7]),$([#6]-[#1]),$([#6]-[#7]-[#1])]:[$([#7]),$([#6]-[#7])]:1)-[$([#7]-[#1]),$([#8]-[#6](-[#1])-[#1])]",0,""},
+{"ene_one_hal(17)","[#6]-[#6]=[#6](-[F,Cl,Br,I])-[#6](=[#8])-[#6]",0,""},
+{"cyano_imine_B(17)","N#CC(C#N)=NNc1ccccc1",0,""},
+{"thiaz_ene_B(17)","[#6]NC(=O)-!@[#6]1=,:[#6]([$([N]),$(NC(=O)[#6]:[#6])])[#7]([$([#6;H2]-[#6;H1]=[#6;H2]),$([#6]=,:[#6])])[#6](=S)[#16]1",0,""},
+{"ene_rhod_B(16)","[C;H1]([$([#6]-[#35]),$([#6]:[#6](-[#1]):[#6](-[F,Cl,Br,I]):[#6]:[#6]-[F,Cl,Br,I]),$([#6]:[#6](-[#1]):[#6](-[#1]):[#6]-[#16]-[#6](-[#1])-[#1]),$([#6]:[#6]:[#6]:[#6]:[#6]:[#6]:[#6]:[#6]:[#6]:[#6]-[#8]-[#6;H2]),$([#6]:1:[#6](-[#6;H2]):[#7](-[#6;H2]):[#6](-[#6;H2]):[#6]:1)])=C1SC(=O)NC1=O",0,""},
+{"thio_carbonate_A(15)","[#7,#8]c2ccc1oc(=[#8,#16])sc1c2",0,""},
+{"anil_di_alk_furan_A(15)","[#7](-[#6](-[#1])-[#1])(-[#6](-[#1])-[#1])-c:1:c(:c(:c(:o:1)-[#6]=[#7]-[#7](-[#1])-[#6]=[!#6&!#1])-[#1])-[#1]",0,""},
+{"ene_five_het_F(15)","O=[#6]2[#6](=!@[#6]c1ccccc1)Sc3ccccc23",0,""}
+};
+const unsigned int NUM_PAINS_B = static_cast<unsigned int>(sizeof(PAINS_B)/sizeof(FilterData_t));
+
+const FilterProperty_t PAINS_B_PROPS[] = {
+{"Reference", "Baell JB, Holloway GA. New Substructure Filters for Removal of Pan Assay Interference Compounds (PAINS) from Screening Libraries and for Their Exclusion in Bioassays. J Med Chem 53 (2010) 2719D40. doi:10.1021/jm901137j."},
+{"Scope", "PAINS filters (family B)"},
+{"sulfonamide_B(41) c", "1:c:c(:c:c:c:1-[#8]-[#1])-[#7](-[#1])-[#16](=[#8])=[#8] 0"},
+{"imidazole_A(19) n", "1:c(:n(:c(:c:1-c:2:c:c:c:c:c:2)-c:3:c:c:c:c:c:3)-[#1])-[#6]:,=[!#1] 0"}
+};
+const unsigned int NUM_PAINS_B_PROPS = static_cast<unsigned int>(sizeof(PAINS_B_PROPS)/
+                                                                 sizeof(FilterProperty_t));
+
+
+
+/////////////////////////////////////////////////////////////////////////////////////////
+// PAINS_C data
+// # Reference: Baell JB, Holloway GA. New Substructure Filters for Removal of Pan Assay Interference Compounds (PAINS) from Screening Libraries and for Their Exclusion in Bioassays. J Med Chem 53 (2010) 2719D40. doi:10.1021/jm901137j.
+// # Scope: PAINS filters (family C)
+// 
+
+const FilterData_t PAINS_C[] = {
+{"anil_di_alk_F(14)","c:1:c:c(:c:c:c:1-[#6;X4]-c:2:c:c:c(:c:c:2)-[#7](-[$([#1]),$([#6;X4])])-[$([#1]),$([#6;X4])])-[#7](-[$([#1]),$([#6;X4])])-[$([#1]),$([#6;X4])]",0,""},
+{"hzone_anil(14)","c:1(:c(:c(:c(:c(:c:1-[#1])-[#1])-[#7](-[#1])-[#1])-[#1])-[#1])-[#6]=[#7]-[#7]-[#1]",0,""},
+{"het_5_pyrazole_OH(14)","c1(nn(c(c1-[$([#1]),$([#6]-[#1])])-[#8]-[#1])-c:2:c(:c(:c(:c(:c:2-[#1])-[#1])-[#1])-[#1])-[#1])-[#6;X4]",0,""},
+{"het_thio_666_A(13)","c:2(:c:1-[#16]-c:3:c(-[#7](-c:1:c(:c(:c:2-[#1])-[#1])-[#1])-[$([#1]),$([#6](-[#1])(-[#1])-[#1]),$([#6](-[#1])(-[#1])-[#6]-[#1])]):c(:c(~[$([#1]),$([#6]:[#6])]):c(:c:3-[#1])-[$([#1]),$([#7](-[#1])-[#1]),$([#8]-[#6;X4])])~[$([#1]),$([#7](-[#1])-[#6;X4]),$([#6]:[#6])])-[#1]",0,""},
+{"styrene_A(13)","[#6]-2-[#6]-c:1:c(:c:c:c:c:1)-[#6](-c:3:c:c:c:c:c-2:3)=[#6]-[#6]",0,""},
+{"ene_rhod_C(13)","[#16]-1-[#6](=[#7]-[#6]:[#6])-[#7](-[$([#1]),$([#6](-[#1])(-[#1])-[#6](-[#1])(-[#1])-[#8]),$([#6]:[#6])])-[#6](=[#8])-[#6]-1=[#6](-[#1])-[$([#6]:[#6]:[#6]-[#17]),$([#6]:[!#6&!#1])]",0,""},
+{"dhp_amino_CN_A(13)","[#7](-[#1])(-[#1])-[#6]-1=[#6](-[#6]#[#7])-[#6](-[#1])(-[#6]:[#6])-[#6](=[#6](-[#6]=[#6])-[#8]-1)-[#6](-[#1])-[#1]",0,""},
+{"cyano_imine_C(12)","[#8]=[#16](=[#8])-[#6](-[#6]#[#7])=[#7]-[#7]-[#1]",0,""},
+{"thio_urea_A(12)","c:1:c:c:c:c:c:1-[#7](-[#1])-[#6](=[#16])-[#7](-[#1])-[#6](-[#1])(-[#1])-[#6](-[#1])(-[#1])-[#6](-[#1])(-[#1])-[#7](-[#6](-[#1])-[#1])-c:2:c:c:c:c:c:2",0,""},
+{"thiophene_amino_B(12)","c:1:c(:c:c:c:c:1)-[#7](-[#1])-c:2:c(:c(:c(:s:2)-[$([#6]=[#8]),$([#6]#[#7]),$([#6](-[#8]-[#1])=[#6])])-[#7])-[$([#6]#[#7]),$([#6](:[#7]):[#7])]",0,""},
+{"keto_keto_beta_B(12)","[#6;X4]-1-[#6](=[#8])-[#7]-[#7]-[#6]-1=[#8]",0,""},
+{"keto_phenone_A(11)","c:1:c-3:c(:c:c:c:1)-[#6]:2:[#7]:[!#1]:[#6]:[#6]:[#6]:2-[#6]-3=[#8]",0,""},
+{"cyano_pyridone_C(11)","[#6]-1(-[#6](=[#6](-[#6]#[#7])-[#6](~[#8])~[#7]~[#6]-1~[#8])-[#6](-[#1])-[#1])=[#6](-[#1])-[#6]:[#6]",0,""},
+{"thiaz_ene_C(11)","[#6]-1(=[#6](-!@[#6]=[#7])-[#16]-[#6](-[#7]-1)=[#8])-[$([F,Cl,Br,I]),$([#7+](:[#6]):[#6])]",0,""},
+{"hzone_thiophene_A(11)","c:1:2:c(:c(:c(:c(:c:1-[#1])-[#1])-[#1])-[#1]):[!#6&!#1]:[#6](:[#6]:2-[#6](-[#1])=[#7]-[#7](-[#1])-[$([#6]:1:[#7]:[#6]:[#6](-[#1]):[#16]:1),$([#6]:[#6](-[#1]):[#6]-[#1]),$([#6]:[#7]:[#6]:[#7]:[#6]:[#7]),$([#6]:[#7]:[#7]:[#7]:[#7])])-[$([#1]),$([#8]-[#1]),$([#6](-[#1])-[#1])]",0,""},
+{"ene_quin_methide(10)","[!#1]:[!#1]-[#6](-[$([#1]),$([#6]#[#7])])=[#6]-1-[#6]=:[#6]-[#6](=[$([#8]),$([#7;!R])])-[#6]=:[#6]-1",0,""},
+{"het_thio_676_A(10)","c:1:c:c-2:c(:c:c:1)-[#6]-[#6](-c:3:c(-[#16]-2):c(:c(-[#1]):c(:c:3-[#1])-[$([#1]),$([#8]),$([#16;X2]),$([#6;X4]),$([#7](-[$([#1]),$([#6;X4])])-[$([#1]),$([#6;X4])])])-[#1])-[#7](-[$([#1]),$([#6;X4])])-[$([#1]),$([#6;X4])]",0,""},
+{"ene_five_het_G(10)","[#6]-1(=[#6])-[#6](-[#7,#16,#8][#6](-[!#1])=[#7]-1)=[#8]",0,""},
+{"acyl_het_A(9)","[#7+](:[!#1]:[!#1]:[!#1])-[!#1]=[#8]",0,""},
+{"anil_di_alk_G(9)","[#6;X4]-[#7](-[#6;X4])-c:1:c(:c(:c(:c(:c:1-[#1])-[#1])-[#6]2=:[#7][#6]:[#6]:[!#1]2)-[#1])-[#1]",0,""},
+{"dhp_keto_A(9)","[#7]-1(-[$([#6;X4]),$([#1])])-[#6]=:[#6](-[#6](=[#8])-[#6]:[#6]:[#6])-[#6](-[#6])-[#6](=[#6]-1-[#6](-[#1])(-[#1])-[#1])-[$([#6]=[#8]),$([#6]#[#7])]",0,""},
+{"thio_urea_B(9)","c:1:c:c:c:c:c:1-[#7](-[#1])-[#6](=[#16])-[#7](-[#1])-[#6](-[#1])(-[#1])-[#6](-[#1])(-[#1])-[#7](-[#6](-[#1])-[#1])-c:2:c:c:c:c:c:2",0,""},
+{"anil_alk_bim(9)","c:1:3:c(:c(:c(:c(:c:1-[#1])-[#1])-[#7](-[#1])-[#6](-[#1])(-[#1])-c:2:c:c:c:c:c:2)-[#1]):n:c(-[#1]):n:3-[#6]",0,""},
+{"imine_imine_A(9)","c:1:c:c-2:c(:c:c:1)-[#7]=[#6]-[#6]-2=[#7;!R]",0,""},
+{"thio_urea_C(9)","c:1(:c:c:c:c:c:1)-[#7](-[#1])-[#6](=[#16])-[#7]-[#7](-[#1])-[#6](=[#8])-[#6]-2:[!#1]:[!#6&!#1]:[#6]:[#6]-2",0,""},
+{"imine_one_fives_B(9)","[#7;!R]=[#6]-2-[#6](=[#8])-c:1:c:c:c:c:c:1-[#16]-2",0,""},
+{"dhp_amino_CN_B(9)","[$([#7](-[#1])-[#1]),$([#8]-[#1])]-[#6]-2=[#6](-[#6]#[#7])-[#6](-[#1])(-[#6]:[#6])-c:1:c(:n(-[#6]):n:c:1)-[#8]-2",0,""},
+{"anil_OC_no_alk_A(8)","[#7](-[#1])(-[#1])-c:1:c(:c(:c(:n:c:1-[#1])-[#8]-c:2:c:c:c:c:c:2)-[#1])-[#1]",0,""},
+{"het_thio_66_one(8)","[#6](=[#8])-[#6]-1=[#6]-[#7]-c:2:c(-[#16]-1):c:c:c:c:2",0,""},
+{"styrene_B(8)","c:1:c:c-2:c(:c:c:1)-[#6](-c:3:c(-[$([#16;X2]),$([#6;X4])]-2):c:c:c(:c:3)-[$([#1]),$([#17]),$([#6;X4])])=[#6]-[#6]",0,""},
+{"het_thio_5_A(8)","[#6](-[#1])(-[#1])-[#16;X2]-c:1:n:c(:c(:n:1-!@[#6](-[#1])-[#1])-c:2:c:c:c:c:c:2)-[#1]",0,""},
+{"anil_di_alk_ene_A(8)","[#6](-[#1])(-[#1])-[#7](-[#6](-[#1])-[#1])-[#6]-2=[#6](-[#1])-c:1:c(:c:c:c:c:1)-[#16;X2]-c:3:c-2:c:c:c:c:3",0,""},
+{"ene_rhod_D(8)","[#16]-1-[#6](=!@[#7]-[$([#1]),$([#7](-[#1])-[#6]:[#6])])-[#7](-[$([#1]),$([#6]:[#7]:[#6]:[#6]:[#16])])-[#6](=[#8])-[#6]-1=[#6](-[#1])-[#6]:[#6]-[$([#17]),$([#8]-[#6]-[#1])]",0,""},
+{"ene_rhod_E(8)","[#16]-1-[#6](=[#8])-[#7]-[#6](=[#16])-[#6]-1=[#6](-[#1])-[#6]:[#6]",0,""},
+{"anil_OH_alk_A(8)","c:1:c(:c:c:c:c:1)-[#6](-[#1])(-[#1])-[#7](-[#1])-c:2:c(:c(:c(:c(:c:2-[#1])-[#1])-[#8]-[#1])-[#1])-[#1]",0,""},
+{"pyrrole_C(8)","n1(-[#6;X4])c(c(-[#1])c(c1-[#6]:[#6])-[#1])-[#6](-[#1])-[#1]",0,""},
+{"thio_urea_D(8)","c:1(:c:c:c:c:c:1)-[#7](-[#1])-[#6](=[#16])-[#7]-[#7](-[#1])-c:2:c:c:c:c:c:2",0,""},
+{"thiaz_ene_D(8)","[#7](-c:1:c:c:c:c:c:1)-c2[n+]c(cs2)-c:3:c:c:c:c:c:3",0,""},
+{"ene_rhod_F(8)","n:1:c:c:c(:c:1-[#6](-[#1])-[#1])-[#6](-[#1])=[#6]-2-[#6](=[#8])-[#7]-[#6](=[!#6&!#1])-[#7]-2",0,""},
+{"thiaz_ene_E(8)","[#6]-1(=[#6](-[#6](-[#1])(-[#6])-[#6])-[#16]-[#6](-[#7]-1-[$([#1]),$([#6](-[#1])-[#1])])=[#8])-[#16]-[#6;R]",0,""},
+{"het_65_B(7)","[!#1]:1:[!#1]-2:[!#1](:[!#1]:[!#1]:[!#1]:1)-[#7](-[#1])-[#7](-[#6]-2=[#8])-[#6]",0,""},
+{"keto_keto_beta_C(7)","c:1:c:c-2:c(:c:c:1)-[#6](=[#6](-[#6]-2=[#8])-[#6])-[#8]-[#1]",0,""},
+{"het_66_A(7)","c:2:c:c:1:n:n:c(:n:c:1:c:c:2)-[#6](-[#1])(-[#1])-[#6]=[#8]",0,""},
+{"thio_urea_E(7)","c:1:c:c:c:c:c:1-[#7](-[#1])-[#6](=[#16])-[#7](-[#1])-[#6](-[#1])(-[#1])-c:2:n:c:c:c:c:2",0,""},
+{"thiophene_amino_C(7)","[#6](-[#1])-[#6](-[#1])(-[#1])-c:1:c(:c(:c(:s:1)-[#7](-[#1])-[#6](=[#8])-[#6]-[#6]-[#6]=[#8])-[$([#6](=[#8])-[#8]),$([#6]#[#7])])-[#6](-[#1])-[#1]",0,""},
+{"hzone_phenone(7)","[#6](-c:1:c(:c(:c(:c:c:1-[#1])-[$([#6;X4]),$([#1])])-[#1])-[#1])(-c:2:c(:c(:c(:c(:c:2-[#1])-[#1])-[$([#1]),$([#17])])-[#1])-[#1])=[$([#7]-[#8]-[#6](-[#1])(-[#1])-[#6](-[#1])(-[#1])-[#6](-[#1])(-[#1])-[#7](-[#6](-[#1])-[#1])-[#6](-[#1])-[#1]),$([#7]-[#8]-[#6](-[#1])(-[#1])-[#6](-[#1])(-[#1])-[#7](-[#6](-[#1])-[#1])-[#6](-[#1])-[#1]),$([#7]-[#7](-[#1])-[#6](=[#7]-[#1])-[#7](-[#1])-[#1]),$([#6](-[#1])-[#7])]",0,""},
+{"ene_rhod_G(7)","[#8](-[#1])-[#6](=[#8])-c:1:c:c(:c:c:c:1)-[#6]:[!#1]:[#6]-[#6](-[#1])=[#6]-2-[#6](=[!#6&!#1])-[#7]-[#6](=[!#6&!#1])-[!#6&!#1]-2",0,""},
+{"ene_cyano_B(7)","[#6]-1(=[#6]-[#6](-c:2:c:c(:c(:n:c-1:2)-[#7](-[#1])-[#1])-[#6]#[#7])=[#6])-[#6]#[#7]",0,""},
+{"dhp_amino_CN_C(7)","[#7](-[#1])(-[#1])-[#6]-1=[#6](-[#6]#[#7])-[#6](-[#1])(-[#6]:[#6])-[#6](=[#6](-[#6]:[#6])-[#8]-1)-[#6]#[#7]",0,""},
+{"het_5_A(7)","[#7]-2(-c:1:c:c:c:c:c:1)-[#7]=[#6](-[#6]=[#8])-[#6;X4]-[#6]-2=[#8]",0,""},
+{"ene_five_het_H(6)","[#7]-1=[#6]-[#6](-[#6](-[#7]-1)=[#16])=[#6]",0,""},
+{"thio_amide_A(6)","c1(coc(c1-[#1])-[#6](=[#16])-[#7]-2-[#6](-[#1])(-[#1])-[#6](-[#1])(-[#1])-[!#1]-[#6](-[#1])(-[#1])-[#6]-2(-[#1])-[#1])-[#1]",0,""},
+{"ene_cyano_C(6)","[#6]=[#6](-[#6]#[#7])-[#6](=[#7]-[#1])-[#7]-[#7]",0,""},
+{"hzone_furan_A(6)","c:1(:c(:c(:c(:o:1)-[$([#1]),$([#6](-[#1])-[#1])])-[#1])-[#1])-[#6](-[$([#1]),$([#6](-[#1])-[#1])])=[#7]-[#7](-[#1])-c:2:n:c:c:s:2",0,""},
+{"anil_di_alk_H(6)","c:1(:c(:c(:c(:c(:c:1-[#7](-[#1])-[#16](=[#8])(=[#8])-[#6]:2:[#6]:[!#1]:[#6]:[#6]:[#6]:2)-[#1])-[#7](-[#6](-[#1])-[#1])-[#6](-[#1])-[#1])-[#1])-[#1])-[#1]",0,""},
+{"het_65_C(6)","n2c1ccccn1c(c2-[$([#6](-[!#1])=[#6](-[#1])-[#6]:[#6]),$([#6]:[#8]:[#6])])-[#7]-[#6]:[#6]",0,""},
+{"thio_urea_F(6)","[#6]-1-[#7](-[#1])-[#7](-[#1])-[#6](=[#16])-[#7]-[#7]-1-[#1]",0,""},
+{"ene_five_het_I(6)","c:1(:c:c:c:o:1)-[#6](-[#1])=!@[#6]-3-[#6](=[#8])-c:2:c:c:c:c:c:2-[!#6&!#1]-3",0,""},
+{"keto_keto_gamma(5)","[#8]=[#6]-1-[#6;X4]-[#6]-[#6](=[#8])-c:2:c:c:c:c:c-1:2",0,""},
+{"quinone_B(5)","c:1:c:c-2:c(:c:c:1)-[#6](-c3cccc4noc-2c34)=[#8]",0,""},
+{"het_6_pyridone_OH(5)","[#8](-[#1])-c:1:n:c(:c:c:c:1)-[#8]-[#1]",0,""},
+{"hzone_naphth_A(5)","c:1:2:c(:c(:c(:c(:c:1:c(:c(:c(:c:2-[#1])-[#1])-[#6]=[#7]-[#7](-[#1])-[$([#6]:[#6]),$([#6]=[#16])])-[#1])-[#1])-[#1])-[#1])-[#1]",0,""},
+{"thio_ester_A(5)","[#6]-1=[#6](-[#16]-[#6](-[#6]=[#6]-1)=[#16])-[#7]",0,""},
+{"ene_misc_A(5)","[#6]-1=[#6]-[#6](-[#8]-[#6]-1-[#8])(-[#8])-[#6]",0,""},
+{"cyano_pyridone_D(5)","[#8]=[#6]-1-[#6](=[#6]-[#6](=[#7]-[#7]-1)-[#6]=[#8])-[#6]#[#7]",0,""},
+{"het_65_Db(5)","C3=CN1C(=NC(=C1-[#7]-[#6])-c:2:c:c:c:c:n:2)C=C3",0,""},
+{"het_666_A(5)","[#7]N-2-c:1:c:c:c:c:c:1-[#6](=[#7])-c:3:c-2:c:c:c:c:3",0,""},
+{"diazox_sulfon_B(5)","c:1:c(:c:c:c:c:1)-[#7]-2-[#6](-[#1])-[#6](-[#1])-[#7](-[#6](-[#1])-[#6]-2-[#1])-[#16](=[#8])(=[#8])-c:3:c:c:c:c:4:n:s:n:c:3:4",0,""},
+{"anil_NH_alk_A(5)","c:1(:c(:c-2:c(:c(:c:1-[#1])-[#1])-[#7](-[#6](-[#7]-2-[#1])=[#8])-[#1])-[#1])-[#7](-[#1])-[#6](-[#1])-[#1]",0,""},
+{"sulfonamide_C(5)","c:1(:c(:c-3:c(:c(:c:1-[#7](-[#1])-[#16](=[#8])(=[#8])-c:2:c:c:c(:c:c:2)-[!#6&!#1])-[#1])-[#8]-[#6](-[#8]-3)(-[#1])-[#1])-[#1])-[#1]",0,""},
+{"het_thio_N_55(5)","[#6](-[#1])-[#6]:2:[#7]:[#7](-c:1:c:c:c:c:c:1):[#16]:3:[!#6&!#1]:[!#1]:[#6]:[#6]:2:3",0,""},
+{"keto_keto_beta_D(5)","[#8]=[#6]-[#6]=[#6](-[#1])-[#8]-[#1]",0,""},
+{"ene_rhod_H(5)","[#7]-1-2-[#6](=[#7]-[#6](=[#8])-[#6](=[#7]-1)-[#6](-[#1])-[#1])-[#16]-[#6](=[#6](-[#1])-[#6]:[#6])-[#6]-2=[#8]",0,""},
+{"imine_ene_A(5)","[#6]:[#6]-[#6](-[#1])=[#6](-[#1])-[#6](-[#1])=[#7]-[#7](-[#6;X4])-[#6;X4]",0,""},
+{"het_thio_656a(5)","c:1:3:c(:c:c:c:c:1):c:2:n:n:c(-[#16]-[#6](-[#1])(-[#1])-[#6]=[#8]):n:c:2:n:3-[#6](-[#1])(-[#1])-[#6](-[#1])=[#6](-[#1])-[#1]",0,""},
+{"pyrrole_D(5)","n1(-[#6])c(c(-[#1])c(c1-[#6](-[#1])(-[#1])-[#7](-[#1])-[#6](=[#16])-[#7]-[#1])-[#1])-[#1]",0,""},
+{"pyrrole_E(5)","n2(-[#6]:1:[!#1]:[!#6&!#1]:[!#1]:[#6]:1-[#1])c(c(-[#1])c(c2-[#6;X4])-[#1])-[#6;X4]",0,""},
+{"thio_urea_G(5)","c:1(:c:c:c:c:c:1)-[#7](-[#1])-[#6](=[#16])-[#7]-[#7](-[#1])-[#6]([#7;R])[#7;R]",0,""},
+{"anisol_A(5)","c:1(:c(:c(:c(:c(:c:1-[$([#1]),$([#6](-[#1])-[#1])])-[#1])-[#8]-[#6](-[#1])-[#1])-[#6](-[#1])(-[#1])-[$([#7](-[#1])-[#6](=[#8])-[#6](-[#1])(-[#1])-[#6](-[#1])(-[#1])-[#6](-[#1])-[#1]),$([#6](-[#1])(-[#6](-[#1])-[#1])-[#7](-[#1])-[#6](=[#16])-[#7]-[#1])])-[#1])-[#8]-[#6](-[#1])-[#1]",0,""},
+{"pyrrole_F(5)","n2(-[#6]:1:[#6](-[#6]#[#7]):[#6]:[#6]:[!#6&!#1]:1)c(c(-[#1])c(c2)-[#1])-[#1]",0,""},
+{"dhp_amino_CN_D(5)","[#7](-[#1])(-[#1])-[#6]-2=[#6](-[#6]#[#7])-[#6](-[#1])(-[#6]:[#6])-c:1:c(:c:c:s:1)-[#8]-2",0,""},
+{"thiazole_amine_A(4)","[#7](-[#1])-c:1:n:c(:c:s:1)-c:2:c:n:c(-[#7](-[#1])-[#1]):s:2",0,""},
+{"het_6_imidate_A(4)","[#7]=[#6]-1-[#7](-[#1])-[#6](=[#6](-[#7]-[#1])-[#7]=[#7]-1)-[#7]-[#1]",0,""},
+{"anil_OC_no_alk_B(4)","c:1:c(:c:2:c(:c:c:1):c:c:c:c:2)-[#8]-c:3:c(:c(:c(:c(:c:3-[#1])-[#1])-[#7]-[#1])-[#1])-[#1]",0,""},
+{"styrene_C(4)","c:1:c:c-2:c(:c:c:1)-[#6]-[#16]-c3c(-[#6]-2=[#6])ccs3",0,""},
+{"azulene(4)","c:2:c:c:c:1:c(:c:c:c:1):c:c:2",0,""},
+{"furan_acid_A(4)","c:1(:c(:c(:c(:o:1)-[#6](-[#1])-[#1])-[#6](-[#1])(-[#1])-[#8]-[#6]:[#6])-[#1])-[#6](=[#8])-[#8]-[#1]",0,""},
+{"cyano_pyridone_E(4)","[!#1]:[#6]-[#6]-1=[#6](-[#1])-[#6](=[#6](-[#6]#[#7])-[#6](=[#8])-[#7]-1-[#1])-[#6]:[#8]",0,""},
+{"anil_alk_thio(4)","[#6]-1-3=[#6](-[#6](-[#7]-c:2:c:c:c:c:c-1:2)(-[#6])-[#6])-[#16]-[#16]-[#6]-3=[!#1]",0,""},
+{"anil_di_alk_I(4)","c:1(:c(:c(:c(:c(:c:1-[#7](-[#1])-[#6](=[#8])-c:2:c:c:c:c:c:2)-[#1])-[#7](-[#6](-[#1])-[#1])-[#6](-[#1])-[#1])-[#1])-[#1])-[#1]",0,""},
+{"het_thio_6_furan(4)","[#6](-[#1])(-[#1])-[#16;X2]-c:1:n:n:c(:c(:n:1)-c:2:c(:c(:c(:o:2)-[#1])-[#1])-[#1])-c:3:c(:c(:c(:o:3)-[#1])-[#1])-[#1]",0,""},
+{"anil_di_alk_ene_B(4)","[#6](-[#1])(-[#1])-[#7](-[#6](-[#1])-[#1])-[#6]-2=[#6]-c:1:c(:c:c:c:c:1)-[#6]-2(-[#1])-[#1]",0,""},
+{"imine_one_B(4)","[#7](-[#1])(-c:1:c:c:c:c:c:1)-[#7]=[#6](-[#6](=[#8])-[#6](-[#1])-[#1])-[#7](-[#1])-[$([#7]-[#1]),$([#6]:[#6])]",0,""},
+{"anil_OC_alk_A(4)","c:1:2:c(:c(:c(:c(:c:1-[#1])-[#1])-[#1])-[#1]):o:c:3:c(-[#1]):c(:c(-[#8]-[#6](-[#1])-[#1]):c(:c:2:3)-[#1])-[#7](-[#1])-[#6](-[#1])-[#1]",0,""},
+{"ene_five_het_J(4)","[#16]=[#6]-1-[#7](-[#1])-[#6]=[#6]-[#6]-2=[#6]-1-[#6](=[#8])-[#8]-[#6]-2=[#6]-[#1]",0,""},
+{"pyrrole_G(4)","n2(-c:1:c(:c:c(:c(:c:1)-[#1])-[$([#7](-[#1])-[#1]),$([#6]:[#7])])-[#1])c(c(-[#1])c(c2-[#1])-[#1])-[#1]",0,""},
+{"ene_five_het_K(4)","n1(-[#6])c(c(-[#1])c(c1-[#6](-[#1])=[#6]-2-[#6](=[#8])-[!#6&!#1]-[#6]=:[!#1]-2)-[#1])-[#1]",0,""},
+{"cyano_ene_amine_B(4)","[#6]=[#6]-[#6](-[#6]#[#7])(-[#6]#[#7])-[#6](-[#6]#[#7])=[#6]-[#7](-[#1])-[#1]",0,""},
+{"thio_ester_B(4)","[#6]:[#6]-[#6](=[#16;X1])-[#16;X2]-[#6](-[#1])-[$([#6](-[#1])-[#1]),$([#6]:[#6])]",0,""},
+{"ene_five_het_L(4)","[#8]=[#6]-3-[#6](=!@[#6](-[#1])-c:1:c:n:c:c:1)-c:2:c:c:c:c:c:2-[#7]-3",0,""},
+{"hzone_thiophene_B(4)","c:1(:c(:c(:c(:s:1)-[#1])-[#1])-[$([#1]),$([#6](-[#1])-[#1])])-[#6](-[#1])=[#7]-[#7](-[#1])-c:2:c:c:c:c:c:2",0,""},
+{"dhp_amino_CN_E(4)","[#6](-[#1])(-[#1])-[#16;X2]-[#6]-1=[#6](-[#6]#[#7])-[#6](-[#1])(-[#6]:[#6])-[#6](-[#6]#[#7])-[#6](=[#8])-[#7]-1",0,""},
+{"het_5_B(4)","[#7]-2(-c:1:c:c:c:c:c:1)-[#7]=[#6](-[#7](-[#1])-[#6]=[#8])-[#6](-[#1])(-[#1])-[#6]-2=[#8]",0,""},
+{"imine_imine_B(3)","[#6]:[#6]-[#6](-[#1])=[#6](-[#1])-[#6](-[#1])=[#7]-[#7]=[#6]",0,""},
+{"thiazole_amine_B(3)","c:1(:c:c:c(:c:c:1)-[#6](-[#1])-[#1])-c:2:c(:s:c(:n:2)-[#7](-[#1])-[#1])-[#6](-[#1])(-[#1])-[#1]",0,""},
+{"imine_ene_one_A(3)","[#6]-2(-[#6]=[#7]-c:1:c:c:c:c:c:1-[#7]-2)=[#6](-[#1])-[#6]=[#8]",0,""},
+{"diazox_A(3)","[#8](-c:1:c:c:c:c:c:1)-c:3:c:c:2:n:o:n:c:2:c:c:3",0,""},
+{"ene_one_A(3)","[!#1]:1:[!#1]:[!#1]:[!#1](:[!#1]:[!#1]:1)-[#6](-[#1])=[#6](-[#1])-[#6](-[#7]-c:2:c:c:c:3:c(:c:2):c:c:c(:n:3)-[#7](-[#6])-[#6])=[#8]",0,""},
+{"anil_OC_no_alk_C(3)","[#7](-[#1])(-[#1])-c:1:c(:c:c:c:n:1)-[#8]-[#6](-[#1])(-[#1])-[#6]:[#6]",0,""},
+{"thiazol_SC_A(3)","[#6]-[#16;X2]-c:1:n:c(:c:s:1)-[#1]",0,""},
+{"het_666_B(3)","c:1:c-3:c(:c:c:c:1)-[#7](-c:2:c:c:c:c:c:2-[#8]-3)-[#6](-[#1])(-[#1])-[#6](-[#1])-[#1]",0,""},
+{"furan_A(3)","c:1(:c(:c(:c(:o:1)-[#6](-[#1])-[#1])-[#1])-[#1])-[#6](-[#1])(-[#8]-[#1])-[#6]#[#6]-[#6;X4]",0,""},
+{"colchicine_A(3)","[#6]-1(-[#6](=[#6]-[#6]=[#6]-[#6]=[#6]-1)-[#7]-[#1])=[#7]-[#6]",0,""},
+{"thiophene_C(3)","[#6](-[#1])(-[#1])-[#7](-[#6](-[#1])-[#1])-[#6](-[#1])=[#6]-[#6](=[#8])-c:1:c(-[#16;X2]):s:c(:c:1)-[$([#6]#[#7]),$([#6]=[#8])]",0,""},
+{"anil_OC_alk_B(3)","c:1:3:c(:c:c:c:c:1)-[#7]-2-[#6](=[#8])-[#6](=[#6](-[F,Cl,Br,I])-[#6]-2=[#8])-[#7](-[#1])-[#6]:[#6]:[#6]:[#6](-[#8]-[#6](-[#1])-[#1]):[#6]:[#6]:3",0,""},
+{"het_thio_66_A(3)","c:1-2:c(:c:c:c:c:1)-[#6](-[#1])(-[#1])-[#6](-[#1])(-[#1])-[#7]=[#6]-2-[#16;X2]-[#6](-[#1])(-[#1])-[#6](=[#8])-c:3:c:c:c:c:c:3",0,""},
+{"rhod_sat_B(3)","[#7]-2(-c:1:c:c:c:c:c:1-[#6](-[#1])-[#1])-[#6](=[#16])-[#7](-[#6](-[#1])(-[#1])-[!#1]:[!#1]:[!#1]:[!#1]:[!#1])-[#6](-[#1])(-[#1])-[#6]-2=[#8]",0,""},
+{"ene_rhod_I(3)","[#7]-2(-[#6](-[#1])-[#1])-[#6](=[#16])-[#7](-[#1])-[#6](=[#6](-[#1])-c:1:c:c:c:c(:c:1)-[Br])-[#6]-2=[#8]",0,""},
+{"keto_thiophene(3)","c:1(:c(:c:2:c(:s:1):c:c:c:c:2)-[#6](-[#1])-[#1])-[#6](=[#8])-[#6](-[#1])(-[#1])-[#6](-[#1])-[#1]",0,""},
+{"imine_imine_C(3)","[#7](-[#6](-[#1])-[#1])(-[#6](-[#1])-[#1])-[#6](-[#1])=[#7]-[#6](-[#6](-[#1])-[#1])=[#7]-[#7](-[#6](-[#1])-[#1])-[#6]:[#6]",0,""},
+{"het_65_pyridone_A(3)","[#6]:2(:[#6](-[#6](-[#1])-[#1]):[#6]-1:[#6](-[#7]=[#6](-[#7](-[#6]-1=[!#6&!#1;X1])-[#6](-[#1])-[$([#6](=[#8])-[#8]),$([#6]:[#6])])-[$([#1]),$([#16]-[#6](-[#1])-[#1])]):[!#6&!#1;X2]:2)-[#6](-[#1])(-[#1])-[#6](-[#1])-[#1]",0,""},
+{"thiazole_amine_C(3)","c:1(:n:c(:c(-[#1]):s:1)-[!#1]:[!#1]:[!#1](-[$([#8]-[#6](-[#1])-[#1]),$([#6](-[#1])-[#1])]):[!#1]:[!#1])-[#7](-[#1])-[#6](-[#1])(-[#1])-c:2:c(-[#1]):c(:c(-[#1]):o:2)-[#1]",0,""},
+{"het_thio_pyr_A(3)","n:1:c(:c(:c(:c(:c:1-[#16]-[#6]-[#1])-[#6]#[#7])-c:2:c:c:c(:c:c:2)-[#8]-[#6](-[#1])-[#1])-[#1])-[#6]:[#6]",0,""},
+{"melamine_A(3)","c:1:4:c(:n:c(:n:c:1-[#7](-[#1])-[#6](-[#1])(-[#1])-c:2:c(:c(:c(:o:2)-[#1])-[#1])-[#1])-[#7](-[#1])-c:3:c:c(:c(:c:c:3-[$([#1]),$([#6](-[#1])-[#1]),$([#16;X2]),$([#8]-[#6]-[#1]),$([#7;X3])])-[$([#1]),$([#6](-[#1])-[#1]),$([#16;X2]),$([#8]-[#6]-[#1]),$([#7;X3])])-[$([#1]),$([#6](-[#1])-[#1]),$([#16;X2]),$([#8]-[#6]-[#1]),$([#7;X3])]):c:c:c:c:4",0,""},
+{"anil_NH_alk_B(3)","[#7](-[#1])(-[#6]:1:[#6]:[#6]:[!#1]:[#6]:[#6]:1)-c:2:c:c:c(:c:c:2)-[#7](-[#1])-[#6]-[#1]",0,""},
+{"rhod_sat_C(3)","[#7]-2(-c:1:c:c:c:c:c:1)-[#6](=[#7]-[#6]=[#8])-[#16]-[#6](-[#1])(-[#1])-[#6]-2=[#8]",0,""},
+{"thiophene_amino_D(3)","[#6]=[#6]-[#6](=[#8])-[#7]-c:1:c(:c(:c(:s:1)-[#6](=[#8])-[#8])-[#6]-[#1])-[#6]#[#7]",0,""},
+{"anil_OC_alk_C(3)","[$([#1]),$([#6](-[#1])-[#1])]-[#8]-c:1:c(:c(:c(:c(:c:1-[#1])-[#1])-[#1])-[#1])-[#7](-[#1])-[#6](-[#1])(-[#1])-c:2:n:c:c:n:2",0,""},
+{"het_thio_65_A(3)","[#6](-[#1])(-[#1])-[#16;X2]-c3nc1c(n(nc1-[#6](-[#1])-[#1])-c:2:c:c:c:c:c:2)nn3",0,""},
+{"het_thio_656b(3)","[#6]-[#6](=[#8])-[#6](-[#1])(-[#1])-[#16;X2]-c:3:n:n:c:2:c:1:c(:c(:c(:c(:c:1:n(:c:2:n:3)-[#1])-[#1])-[#1])-[#1])-[#1]",0,""},
+{"thiazole_amine_D(3)","s:1:c(:[n+](-[#6](-[#1])-[#1]):c(:c:1-[#1])-[#6])-[#7](-[#1])-c:2:c:c:c:c:c:2[$([#6](-[#1])-[#1]),$([#6]:[#6])]",0,""},
+{"thio_urea_H(3)","[#6]-2(=[#16])-[#7](-[#6](-[#1])(-[#1])-c:1:c:c:c:o:1)-[#6](=[#7]-[#7]-2-[#1])-[#6]:[#6]",0,""},
+{"cyano_pyridone_F(3)","[#7]-2(-c:1:c:c:c:c:c:1)-[#6](=[#8])-[#6](=[#6]-[#6](=[#7]-2)-[#6]#[#7])-[#6]#[#7]",0,""},
+{"rhod_sat_D(3)","[#7]-2(-c:1:c:c:c:c:c:1)-[#6](=[#8])-[#16]-[#6](-[#1])(-[#6](-[#1])(-[#1])-[#6](=[#8])-[#7](-[#1])-[#6]:[#6])-[#6]-2=[#8]",0,""},
+{"ene_rhod_J(3)","[#6](-[#1])(-[#1])-[#7]-2-[#6](=[$([#16]),$([#7])])-[!#6&!#1]-[#6](=[#6]-1-[#6](=[#6](-[#1])-[#6]:[#6]-[#7]-1-[#6](-[#1])-[#1])-[#1])-[#6]-2=[#8]",0,""},
+{"imine_phenol_A(3)","[#6]=[#7;!R]-c:1:c:c:c:c:c:1-[#8]-[#1]",0,""},
+{"thio_carbonate_B(3)","[#8]=[#6]-2-[#16]-c:1:c(:c(:c:c:c:1)-[#8]-[#6](-[#1])-[#1])-[#8]-2",0,""},
+{"het_thio_N_5A(3)","[#7]=[#6]-1-[#7]=[#6]-[#7]-[#16]-1",0,""},
+{"het_thio_N_65A(3)","[#7]-2-[#16]-[#6]-1=[#6](-[#6]:[#6]-[#7]-[#6]-1)-[#6]-2=[#16]",0,""},
+{"anil_di_alk_J(3)","[#6](-[#1])(-[#1])-[#7](-[#6](-[#1])-[#1])-c:1:c(:c(:c(:c(:c:1-[#1])-[#1])-[#6](-[#1])=[#7]-[#7]=[#6](-[#6])-[#6]:[#6])-[#1])-[#1]",0,""},
+{"pyrrole_H(3)","n1-2cccc1-[#6]=[#7](-[#6])-[#6]-[#6]-2",0,""},
+{"ene_cyano_D(3)","[#6](-[#6]#[#7])(-[#6]#[#7])=[#6](-[#16])-[#16]",0,""},
+{"cyano_cyano_B(3)","[#6]-1(-[#6]#[#7])(-[#6]#[#7])-[#6](-[#1])(-[#6](=[#8])-[#6])-[#6]-1-[#1]",0,""},
+{"ene_five_het_M(3)","[#6]-1=:[#6]-[#6](-[#6](-[$([#8]),$([#16])]-1)=[#6]-[#6]=[#8])=[#8]",0,""},
+{"cyano_ene_amine_C(3)","[#6]:[#6]-[#6](=[#8])-[#7](-[#1])-[#6](=[#8])-[#6](-[#6]#[#7])=[#6](-[#1])-[#7](-[#1])-[#6]:[#6]",0,""},
+{"thio_urea_I(3)","c:1(:c:c:c:c:c:1)-[#7](-[#1])-[#6](=[#16])-[#7](-[#1])-[#7]=[#6]-c:2:c:n:c:c:2",0,""},
+{"dhp_amino_CN_F(3)","[#7](-[#1])(-[#1])-[#6]-2=[#6](-[#6]#[#7])-[#6](-[#1])(-c:1:c:c:c:s:1)-[#6](=[#6](-[#6](-[#1])-[#1])-[#8]-2)-[#6](=[#8])-[#8]-[#6]",0,""},
+{"anthranil_acid_B(3)","c:1:c-3:c(:c:c(:c:1)-[#6](=[#8])-[#7](-[#1])-c:2:c(:c:c:c:c:2)-[#6](=[#8])-[#8]-[#1])-[#6](-[#7](-[#6]-3=[#8])-[#6](-[#1])-[#1])=[#8]",0,""},
+{"diazox_B(3)","[Cl]-c:2:c:c:1:n:o:n:c:1:c:c:2",0,""},
+{"thio_aldehyd_A(3)","[#6]-[#6](=[#16])-[#1]",0,""},
+{"thio_amide_B(2)","[#6;X4]-[#7](-[#1])-[#6](-[#6]:[#6])=[#6](-[#1])-[#6](=[#16])-[#7](-[#1])-c:1:c:c:c:c:c:1",0,""},
+{"imidazole_B(2)","[#6](-[#1])(-[#1])-[#6](-[#1])(-[#1])-[#16]-[#6](-[#1])(-[#1])-c1cn(cn1)-[#1]",0,""},
+{"thiazole_amine_E(2)","[#8]=[#6]-[#7](-[#1])-c:1:c(-[#6]:[#6]):n:c(-[#6](-[#1])(-[#1])-[#6]#[#7]):s:1",0,""},
+{"thiazole_amine_F(2)","[#6](-[#1])-[#7](-[#1])-c:1:n:c(:c:s:1)-c2cnc3n2ccs3",0,""},
+{"thio_ester_C(2)","[#7]-1-[#6](=[#8])-[#6](=[#6](-[#6])-[#16]-[#6]-1=[#16])-[#1]",0,""},
+{"ene_one_B(2)","[#6](-[#16])(-[#7])=[#6](-[#1])-[#6]=[#6](-[#1])-[#6]=[#8]",0,""},
+{"quinone_C(2)","[#8]=[#6]-3-c:1:c(:c:c:c:c:1)-[#6]-2=[#6](-[#8]-[#1])-[#6](=[#8])-[#7]-c:4:c-2:c-3:c:c:c:4",0,""},
+{"keto_naphthol_A(2)","c:1:2:c:c:c:c(:c:1:c(:c:c:c:2)-[$([#8]-[#1]),$([#7](-[#1])-[#1])])-[#6](-[#6])=[#8]",0,""},
+{"thio_amide_C(2)","[#6](-[#1])(-c:1:c:c:c:c:c:1)(-c:2:c:c:c:c:c:2)-[#6](=[#16])-[#7]-[#1]",0,""},
+{"phthalimide_misc(2)","[#7]-2(-[#6](=[#8])-c:1:c(:c(:c(:c(:c:1-[#1])-[#6](=[#8])-[#8]-[#1])-[#1])-[#1])-[#6]-2=[#8])-c:3:c(:c:c(:c(:c:3)-[#1])-[#8])-[#1]",0,""},
+{"sulfonamide_D(2)","c:1:c:c(:c:c:c:1-[#7](-[#1])-[#16](=[#8])=[#8])-[#7](-[#1])-[#16](=[#8])=[#8]",0,""},
+{"anil_NH_alk_C(2)","[#6](-[#1])-[#7](-[#1])-c:1:c(:c(:c(:c(:c:1-[#1])-[#1])-[#1])-[#1])-[#7](-[#1])-[#6]-[#1]",0,""},
+{"het_65_E(2)","s1c(c(c-2c1-[#7](-[#1])-[#6](-[#6](=[#6]-2-[#1])-[#6](=[#8])-[#8]-[#1])=[#8])-[#7](-[#1])-[#1])-[#6](=[#8])-[#7]-[#1]",0,""},
+{"hzide_naphth(2)","c:2(:c:1:c(:c(:c(:c(:c:1:c(:c(:c:2-[#1])-[#1])-[#1])-[#1])-[#7](-[#1])-[#7](-[#1])-[#6]=[#8])-[#1])-[#1])-[#1]",0,""},
+{"anisol_B(2)","[#6](-[#1])(-[#1])-c:1:c(:c(:c(:c(:c:1-[#8]-[#6](-[#1])-[#1])-[#1])-[#1])-[#6](-[#1])(-[#1])-[#7](-[#1])-[#6;X4])-[#1]",0,""},
+{"thio_carbam_ene(2)","[#6]-1=[#6]-[#7]-[#6](-[#16]-[#6;X4]-1)=[#16]",0,""},
+{"thio_amide_D(2)","[#6](-[#7](-[#6]-[#1])-[#6]-[#1]):[#6]-[#7](-[#1])-[#6](=[#16])-[#6]-[#1]",0,""},
+{"het_65_Da(2)","n2nc(c1cccc1c2-[#6])-[#6]",0,""},
+{"thiophene_D(2)","s:1:c(:c(-[#1]):c(:c:1-[#6](=[#8])-[#7](-[#1])-[#7]-[#1])-[#8]-[#6](-[#1])-[#1])-[#1]",0,""},
+{"het_thio_6_ene(2)","[#6]-1:[#6]-[#7]=[#6]-[#6](=[#6]-[#7]-[#6])-[#16]-1",0,""},
+{"cyano_keto_A(2)","[#6](-[#1])(-[#1])-[#6](-[#1])(-[#6]#[#7])-[#6](=[#8])-[#6]",0,""},
+{"anthranil_acid_C(2)","c2(c(-[#7](-[#1])-[#1])n(-c:1:c:c:c:c:c:1-[#6](=[#8])-[#8]-[#1])nc2-[#6]=[#8])-[$([#6]#[#7]),$([#6]=[#16])]",0,""},
+{"naphth_amino_C(2)","c:2:c:1:c:c:c:c-3:c:1:c(:c:c:2)-[#7](-[#7]=[#6]-3)-[#1]",0,""},
+{"naphth_amino_D(2)","c:2:c:1:c:c:c:c-3:c:1:c(:c:c:2)-[#7]-[#7]=[#7]-3",0,""},
+{"thiazole_amine_G(2)","c1csc(n1)-[#7]-[#7]-[#16](=[#8])=[#8]",0,""},
+{"het_66_B(2)","c:1:c:c:c:2:c(:c:1):n:c(:n:c:2)-[#7](-[#1])-[#6]-3=[#7]-[#6](-[#6]=[#6]-[#7]-3-[#1])(-[#6](-[#1])-[#1])-[#6](-[#1])-[#1]",0,""},
+{"coumarin_A(2)","c:1-3:c(:c(:c(:c(:c:1)-[#8]-[#6]-[#1])-[#1])-[#1])-c:2:c(:c(:c(:c(:c:2-[#1])-[#1])-[#8]-[#6](-[#1])-[#1])-[#1])-[#6](=[#8])-[#8]-3",0,""},
+{"anthranil_acid_D(2)","c:12:c(:c:c:c:n:1)c(c(-[#6](=[#8])~[#8;X1])s2)-[#7](-[#1])-[#1]",0,""},
+{"het_66_C(2)","c:1:2:n:c(:c(:n:c:1:[#6]:[#6]:[#6]:[!#1]:2)-[#6](-[#1])=[#6](-[#8]-[#1])-[#6])-[#6](-[#1])=[#6](-[#8]-[#1])-[#6]",0,""},
+{"thiophene_amino_E(2)","c1csc(c1-[#7](-[#1])-[#1])-[#6](-[#1])=[#6](-[#1])-c2cccs2",0,""},
+{"het_6666_A(2)","c:2:c:c:1:n:c:3:c(:n:c:1:c:c:2):c:c:c:4:c:3:c:c:c:c:4",0,""},
+{"sulfonamide_E(2)","[#6]:[#6]-[#7](-[#1])-[#16](=[#8])(=[#8])-[#7](-[#1])-[#6]:[#6]",0,""},
+{"anil_di_alk_K(2)","c:1:c:c(:c:c:c:1-[#7](-[#1])-[#1])-[#7](-[#6;X3])-[#6;X3]",0,""},
+{"het_5_C(2)","[#7]-2=[#6](-c:1:c:c:c:c:c:1)-[#6](-[#1])(-[#1])-[#6](-[#8]-[#1])(-[#6](-[#9])(-[#9])-[#9])-[#7]-2-[$([#6]:[#6]:[#6]:[#6]:[#6]:[#6]),$([#6](=[#16])-[#6]:[#6]:[#6]:[#6]:[#6]:[#6])]",0,""},
+{"ene_six_het_B(2)","c:1:c(:c:c:c:c:1)-[#6](=[#8])-[#6](-[#1])=[#6]-3-[#6](=[#8])-[#7](-[#1])-[#6](=[#8])-[#6](=[#6](-[#1])-c:2:c:c:c:c:c:2)-[#7]-3-[#1]",0,""},
+{"steroid_A(2)","[#8]=[#6]-4-[#6]-[#6]-[#6]-3-[#6]-2-[#6](=[#8])-[#6]-[#6]-1-[#6]-[#6]-[#6]-[#6]-1-[#6]-2-[#6]-[#6]-[#6]-3=[#6]-4",0,""},
+{"het_565_A(2)","c:1:2:c:3:c(:c(-[#8]-[#1]):c(:c:1:c(:c:n:2-[#6])-[#6]=[#8])-[#1]):n:c:n:3",0,""},
+{"thio_imine_ium(2)","[#6;X4]-[#7+](-[#6;X4]-[#8]-[#1])=[#6]-[#16]-[#6]-[#1]",0,""},
+{"anthranil_acid_E(2)","[#6]-3(=[#8])-[#6](=[#6](-[#1])-[#7](-[#1])-c:1:c:c:c:c:c:1-[#6](=[#8])-[#8]-[#1])-[#7]=[#6](-c:2:c:c:c:c:c:2)-[#8]-3",0,""},
+{"hzone_furan_B(2)","c:1(:c(:c(:c(:o:1)-[$([#1]),$([#6](-[#1])-[#1])])-[#1])-[#1])-[#6](-[$([#1]),$([#6](-[#1])-[#1])])=[#7]-[#7](-[#1])-c:2:c:c:n:c:c:2",0,""},
+{"thiophene_E(2)","c:1(:c(:c(:c(:s:1)-[$([#1]),$([#6](-[#1])-[#1])])-[#1])-[#1])-[#6](-[$([#1]),$([#6](-[#1])-[#1])])-[#6](=[#8])-[#7](-[#1])-c:2:n:c:c:s:2",0,""},
+{"ene_misc_B(2)","[#6]:[#6]-[#6](-[#1])(-[#1])-[#6](-[#1])(-[#6]=[#8])-[#7]-2-[#6](=[#8])-[#6]-1(-[#1])-[#6](-[#1])(-[#1])-[#6]=[#6]-[#6](-[#1])(-[#1])-[#6]-1(-[#1])-[#6]-2=[#8]",0,""},
+{"het_thio_5_B(2)","[#6]-1(-[#6]=[#8])(-[#6]:[#6])-[#16;X2]-[#6]=[#7]-[#7]-1-[#1]",0,""},
+{"thiophene_amino_F(2)","[#7](-[#1])(-[#1])-c:1:c(:c(:c(:s:1)-[#7](-[#1])-[#6](=[#8])-c:2:c:c:c:c:c:2)-[#6]#[#7])-[#6]:3:[!#1]:[!#1]:[!#1]:[!#1]:[!#1]:3",0,""},
+{"anil_OC_alk_D(2)","[#6](-[#1])(-[#1])-[#8]-c:1:c(:c(:c(:c(:c:1-[#1])-[#1])-[#6](-[#1])-[#1])-[#1])-[#7](-[#1])-[#6](-[#1])(-[#1])-c:2:c:c:c:c:c:2-[$([#6](-[#1])-[#1]),$([#8]-[#6](-[#1])-[#1])]",0,""},
+{"tert_butyl_A(2)","[#6](-[#1])(-[#1])(-[#1])-[#6](-[#6](-[#1])(-[#1])-[#1])(-[#6](-[#1])(-[#1])-[#1])-c:1:c(:c:c(:c(:c:1-[#1])-[#6](-[#6](-[#1])(-[#1])-[#1])(-[#6](-[#1])(-[#1])-[#1])-[#6](-[#1])(-[#1])-[#1])-[#8]-[#6](-[#1])-[#7])-[#1]",0,""},
+{"thio_urea_J(2)","c:1(:c(:o:c:c:1)-[#6]-[#1])-[#6]=[#7]-[#7](-[#1])-[#6](=[#16])-[#7]-[#1]",0,""},
+{"het_thio_65_B(2)","[#7](-[#1])-c1nc(nc2nnc(n12)-[#16]-[#6])-[#7](-[#1])-[#6]",0,""},
+{"coumarin_B(2)","c:1-2:c(:c:c:c:c:1-[#6](-[#1])(-[#1])-[#6](-[#1])=[#6](-[#1])-[#1])-[#6](=[#6](-[#6](=[#8])-[#7](-[#1])-[#6]:[#6])-[#6](=[#8])-[#8]-2)-[#1]",0,""},
+{"thio_urea_K(2)","[#6]-2(=[#16])-[#7]-1-[#6]:[#6]-[#7]=[#7]-[#6]-1=[#7]-[#7]-2-[#1]",0,""},
+{"thiophene_amino_G(2)","[#6]:[#6]:[#6]:[#6]:[#6]:[#6]-c:1:c:c(:c(:s:1)-[#7](-[#1])-[#6](=[#8])-[#6])-[#6](=[#8])-[#8]-[#1]",0,""},
+{"anil_NH_alk_D(2)","[#7](-[#1])(-[#1])-c:1:c(:c(:c(:c:c:1-[#7](-[#1])-[#6](-[#1])(-[#6])-[#6](-[#1])-[#6](-[#1])-[#1])-[#1])-[#1])-[#1]",0,""},
+{"het_thio_5_C(2)","[#16]=[#6]-2-[#7](-[#1])-[#7]=[#6](-c:1:c(:c(:c(:c(:c:1-[#1])-[#1])-[#8]-[#6](-[#1])-[#1])-[#1])-[#1])-[#8]-2",0,""},
+{"thio_keto_het(2)","[#16]=[#6]-c:1:c:c:c:2:c:c:c:c:n:1:2",0,""},
+{"het_thio_N_5B(2)","[#6]~1~[#6](~[#7]~[#7]~[#6](~[#6](-[#1])-[#1])~[#6](-[#1])-[#1])~[#7]~[#16]~[#6]~1",0,""},
+{"quinone_D(2)","[#6]-1(-[#6]=:[#6]-[#6]=:[#6]-[#6]-1=[!#6&!#1])=[!#6&!#1]",0,""},
+{"anil_di_alk_furan_B(2)","[#6](-[#1])(-[#1])-[#7](-[#6](-[#1])-[#1])-c:1:c(-[#1]):c(:c(:o:1)-[#6](-[#1])=[#6]-[#6]#[#7])-[#1]",0,""},
+{"ene_six_het_C(2)","[#8]=[#6]-1-[#6]:[#6]-[#6](-[#1])(-[#1])-[#7]-[#6]-1=[#6]-[#1]",0,""},
+{"het_55_A(2)","[#6]:[#6]-[#7]:2:[#7]:[#6]:1-[#6](-[#1])(-[#1])-[#16;X2]-[#6](-[#1])(-[#1])-[#6]:1-[#6]:2-[#7](-[#1])-[#6](=[#8])-[#6](-[#1])=[#6]-[#1]",0,""},
+{"het_thio_65_C(2)","n:1:c(:n(:c:2:c:1:c:c:c:c:2)-[#6](-[#1])-[#1])-[#16]-[#6](-[#1])(-[#1])-[#6](=[#8])-[#7](-[#1])-[#7]=[#6](-[#1])-[#6](-[#1])=[#6]-[#1]",0,""},
+{"hydroquin_A(2)","c:1(:c:c(:c(:c:c:1)-[#8]-[#1])-[#6](=!@[#6]-[#7])-[#6]=[#8])-[#8]-[#1]",0,""},
+{"anthranil_acid_F(2)","c:1(:c:c(:c(:c:c:1)-[#7](-[#1])-[#6](=[#8])-[#6]:[#6])-[#6](=[#8])-[#8]-[#1])-[#8]-[#1]",0,""},
+{"pyrrole_I(2)","n2(-[#6](-[#1])-[#1])c-1c(-[#6]:[#6]-[#6]-1=[#8])cc2-[#6](-[#1])-[#1]",0,""},
+{"thiophene_amino_H(2)","[#6](-[#1])-[#7](-[#1])-c:1:c(:c(:c(:s:1)-[#6]-[#1])-[#6]-[#1])-[#6](=[#8])-[#7](-[#1])-[#6]:[#6]",0,""},
+{"imine_one_fives_C(2)","[#6]:[#6]-[#7;!R]=[#6]-2-[#6](=[!#6&!#1])-c:1:c:c:c:c:c:1-[#7]-2",0,""},
+{"keto_phenone_zone_A(2)","c:1:c:c:c:c:c:1-[#6](=[#8])-[#7](-[#1])-[#7]=[#6]-3-c:2:c:c:c:c:c:2-c:4:c:c:c:c:c-3:4",0,""},
+{"dyes7A(2)","c:1:c(:c:c:c:c:1)-[#7](-[#6](-[#1])-[#1])-[#6](-[#1])=[#6](-[#1])-[#6]=!@[#6](-[#1])-[#6](-[#1])=[#6]-[#6]=@[#7]-c:2:c:c:c:c:c:2",0,""},
+{"het_pyridiniums_B(2)","[#6]:1:2:[!#1]:[#7+](:[!#1]:[#6](:[!#1]:1:[#6]:[#6]:[#6]:[#6]:2)-[*])~[#6]:[#6]",0,""},
+{"het_5_D(2)","[#7]-2(-c:1:c:c:c:c:c:1)-[#7]=[#6](-[#6](-[#1])-[#1])-[#6](-[#1])(-[#16]-[#6])-[#6]-2=[#8]",0,""},
+{"thiazole_amine_H(1)","c:1:c:c:c(:c:c:1-[#7](-[#1])-c2nc(c(-[#1])s2)-c:3:c:c:c(:c:c:3)-[#6](-[#1])(-[#6]-[#1])-[#6]-[#1])-[#6](=[#8])-[#8]-[#1]",0,""},
+{"thiazole_amine_I(1)","[#6](-[#1])(-[#1])-[#7](-[#1])-[#6]=[#7]-[#7](-[#1])-c1nc(c(-[#1])s1)-[#6]:[#6]",0,""},
+{"het_thio_N_5C(1)","[#6]:[#6]-[#7](-[#1])-[#6](=[#8])-c1c(snn1)-[#7](-[#1])-[#6]:[#6]",0,""},
+{"sulfonamide_F(1)","[#8]=[#16](=[#8])(-[#6]:[#6])-[#7](-[#1])-c1nc(cs1)-[#6]:[#6]",0,""},
+{"thiazole_amine_J(1)","[#8]=[#16](=[#8])(-[#6]:[#6])-[#7](-[#1])-[#7](-[#1])-c1nc(cs1)-[#6]:[#6]",0,""},
+{"het_65_F(1)","s2c:1:n:c:n:c(:c:1c(c2-[#6](-[#1])-[#1])-[#6](-[#1])-[#1])-[#7]-[#7]=[#6]-c3ccco3",0,""},
+{"keto_keto_beta_E(1)","[#6](=[#8])-[#6](-[#1])=[#6](-[#8]-[#1])-[#6](-[#8]-[#1])=[#6](-[#1])-[#6](=[#8])-[#6]",0,""},
+{"ene_five_one_B(1)","c:2(:c:1-[#6](-[#6](-[#6](-c:1:c(:c(:c:2-[#1])-[#1])-[#1])(-[#1])-[#1])=[#8])=[#6](-[#6](-[#1])-[#1])-[#6](-[#1])-[#1])-[#1]",0,""},
+{"keto_keto_beta_zone(1)","[#6]:[#6]-[#7](-[#1])-[#7]=[#6](-[#6](-[#1])-[#1])-[#6](-[#1])(-[#1])-[#6](-[#6](-[#1])-[#1])=[#7]-[#7](-[#1])-[#6]:[#6]",0,""},
+{"thio_urea_L(1)","[#6;X4]-[#16;X2]-[#6](=[#7]-[!#1]:[!#1]:[!#1]:[!#1])-[#7](-[#1])-[#7]=[#6]",0,""},
+{"het_thio_urea_ene(1)","[#6]-1(=[#7]-[#7](-[#6](-[#16]-1)=[#6](-[#1])-[#6]:[#6])-[#6]:[#6])-[#6]=[#8]",0,""},
+{"cyano_amino_het_A(1)","c:1(:c(:c:2:c(:n:c:1-[#7](-[#1])-[#1]):c:c:c(:c:2-[#7](-[#1])-[#1])-[#6]#[#7])-[#6]#[#7])-[#6]#[#7]",0,""},
+{"tetrazole_hzide(1)","[!#1]:1:[!#1]:[!#1]:[!#1](:[!#1]:[!#1]:1)-[#6](-[#1])=[#6](-[#1])-[#6](-[#7](-[#1])-[#7](-[#1])-c2nnnn2-[#6])=[#8]",0,""},
+{"imine_naphthol_A(1)","c:1:2:c(:c(:c(:c(:c:1:c(:c(:c(:c:2-[#1])-[#1])-[#6](=[#7]-[#6]:[#6])-[#6](-[#1])-[#1])-[#8]-[#1])-[#1])-[#1])-[#1])-[#1]",0,""},
+{"misc_anisole_A(1)","c:1(:c(:c:2:c(:c(:c:1-[#8]-[#6](-[#1])-[#1])-[#1]):c(:c(:c(:c:2-[#7](-[#1])-[#6](-[#1])(-[#1])-[#1])-[#1])-c:3:c(:c(:c(:c(:c:3-[#1])-[#1])-[#8]-[#6](-[#1])-[#1])-[#8]-[#6](-[#1])-[#1])-[#1])-[#1])-[#1])-[#8]-[#6](-[#1])-[#1]",0,""},
+{"het_thio_665(1)","c:1:c:c-2:c(:c:c:1)-[#16]-c3c(-[#7]-2)cc(s3)-[#6](-[#1])-[#1]",0,""},
+{"anil_di_alk_L(1)","c:1:c:c:c-2:c(:c:1)-[#6](-[#6](-[#7]-2-[#6](-[#1])(-[#1])-[#6](-[#1])(-[#1])-[#7]-4-[#6](-c:3:c:c:c:c:c:3-[#6]-4=[#8])=[#8])(-[#1])-[#1])(-[#1])-[#1]",0,""},
+{"colchicine_B(1)","c:1(:c:c:c(:c:c:1)-[#6]-3=[#6]-[#6](-c2cocc2-[#6](=[#6]-3)-[#8]-[#1])=[#8])-[#16]-[#6](-[#1])-[#1]",0,""},
+{"misc_aminoacid_A(1)","[#6;X4]-c:1:c(:c(:c(:c(:c:1-[#1])-[#1])-[#6](=[#8])-[#7](-[#1])-[#6](-[#1])(-[#6](-[#1])(-[#1])-[#6](-[#1])(-[#1])-[#16]-[#6](-[#1])(-[#1])-[#1])-[#6](=[#8])-[#8]-[#1])-[#1])-[#1]",0,""},
+{"imidazole_amino_A(1)","n:1:c(:n(:c(:c:1-c:2:c:c:c:c:c:2)-c:3:c:c:c:c:c:3)-[#7]=!@[#6])-[#7](-[#1])-[#1]",0,""},
+{"phenol_sulfite_A(1)","[#6](-c:1:c:c:c(:c:c:1)-[#8]-[#1])(-c:2:c:c:c(:c:c:2)-[#8]-[#1])-[#8]-[#16](=[#8])=[#8]",0,""},
+{"het_66_D(1)","c:2:c:c:1:n:c(:c(:n:c:1:c:c:2)-[#6](-[#1])(-[#1])-[#6](=[#8])-[#6]:[#6])-[#6](-[#1])(-[#1])-[#6](=[#8])-[#6]:[#6]",0,""},
+{"misc_anisole_B(1)","c:1(:c(:c(:c(:c(:c:1-[#1])-[#8]-[#6](-[#1])-[#1])-[#8]-[#6](-[#1])-[#1])-[#1])-[#1])-[#6](=[#8])-[#6](-[#1])(-[#1])-[#7](-[#6](-[#1])-[#1])-c:2:c:c:c(-[#6](-[#1])-[#1])c:c:2",0,""},
+{"tetrazole_A(1)","[#6](-[#1])(-[#1])-c1nnnn1-c:2:c(:c(:c(:c(:c:2-[#1])-[#1])-[#8]-[#6](-[#1])(-[#1])-[#1])-[#1])-[#1]",0,""},
+{"het_65_G(1)","[#6]-2(=[#7]-c1c(c(nn1-[#6](-[#6]-2(-[#1])-[#1])=[#8])-[#7](-[#1])-[#1])-[#7](-[#1])-[#1])-[#6]",0,""},
+{"misc_trityl_A(1)","[#6](-[#6]:[#6])(-[#6]:[#6])(-[#6]:[#6])-[#16]-[#6]:[#6]-[#6](=[#8])-[#8]-[#1]",0,""},
+{"misc_pyridine_OC(1)","[#8]=[#6](-c:1:c(:c(:n:c(:c:1-[#1])-[#8]-[#6](-[#1])(-[#1])-[#1])-[#8]-[#6](-[#1])(-[#1])-[#1])-[#1])-[#7](-[#1])-[#6](-[#1])(-[#6](-[#1])-[#1])-[#6](-[#1])-[#1]",0,""},
+{"het_6_hydropyridone(1)","[#7]-1=[#6](-[#7](-[#6](-[#6](-[#6]-1(-[#1])-[#6]:[#6])(-[#1])-[#1])=[#8])-[#1])-[#7]-[#1]",0,""},
+{"misc_stilbene(1)","[#6]-1(=[#6](-[#6](-[#6](-[#6](-[#6]-1(-[#1])-[#1])(-[#1])-[#6](=[#8])-[#6])(-[#1])-[#6](=[#8])-[#8]-[#1])(-[#1])-[#1])-[#6]:[#6])-[#6]:[#6]",0,""},
+{"misc_imidazole(1)","[#6](-[#1])(-c:1:c(:c(:c(:c(:c:1-[#1])-[#1])-[Cl])-[#1])-[#1])(-c:2:c(:c(:c(:c(:c:2-[#1])-[#1])-[Cl])-[#1])-[#1])-[#8]-[#6](-[#1])(-[#1])-[#6](-[#1])(-[#1])-[#6](-[#1])(-[#1])-c3nc(c(n3-[#6](-[#1])(-[#1])-[#1])-[#1])-[#1]",0,""},
+{"anil_NH_no_alk_A(1)","n:1:c(:c(:c(:c(:c:1-[#1])-[#7](-[#1])-[#1])-[#1])-[#1])-[#7](-[#1])-[#6]:[#6]",0,""},
+{"het_6_imidate_B(1)","[#7](-[#1])(-c:1:c(:c(:c(:c(:c:1-[#1])-[#1])-[#1])-[#1])-[#8]-[#1])-[#6]-2=[#6](-[#8]-[#6](-[#7]=[#7]-2)=[#7])-[#7](-[#1])-[#1]",0,""},
+{"anil_alk_B(1)","[#7](-[#1])(-c:1:c(:c(:c(:c(:c:1-[#1])-[#1])-[#6](-[#1])-[#1])-[#1])-[#1])-[#6](-[#1])(-[#1])-[#6](-[#1])(-[#1])-c:2:c(:c(:c(:c(:c:2-[#1])-[#1])-[#8]-[#6](-[#1])-[#1])-[#1])-[#1]",0,""},
+{"styrene_anil_A(1)","c:1:c:c-3:c(:c:c:1)-c:2:c:c:c(:c:c:2-[#6]-3=[#6](-[#1])-[#6])-[#7](-[#1])-[#1]",0,""},
+{"misc_aminal_acid(1)","c:1:c:c-2:c(:c:c:1)-[#7](-[#6](-[#8]-[#6]-2)(-[#6](=[#8])-[#8]-[#1])-[#6](-[#1])-[#1])-[#6](=[#8])-[#6](-[#1])-[#1]",0,""},
+{"anil_no_alk_D(1)","n:1:c(:c(:c(:c(:c:1-[#7](-[#1])-[#1])-[#6](-[#1])-[#1])-[#1])-[#6](-[#1])-[#1])-[#7](-[#1])-[#1]",0,""},
+{"anil_alk_C(1)","[#7](-[#1])(-c:1:c:c:c:c:c:1)-[#6](-[#6])(-[#6])-c:2:c(:c(:c(:c(:c:2-[#1])-[#1])-[#8]-[#6](-[#1])-[#1])-[#1])-[#1]",0,""},
+{"misc_anisole_C(1)","[#7](-[#1])(-c:1:c(:c(:c(:c(:c:1-[#1])-[#1])-[#8]-[#6](-[#1])(-[#1])-[#1])-[#8]-[#6]-[#1])-[#1])-[#6](=[#8])-[#7](-[#1])-[#6](-[#1])(-[#1])-[#6](-[#1])(-[#1])-[#6](-[#1])(-[#1])-[#7](-[#6](-[#1])(-[#1])-[#1])-[#6]:[#6]",0,""},
+{"het_465_misc(1)","c:1-2:c:c-3:c(:c:c:1-[#8]-[#6]-[#8]-2)-[#6]-[#6]-3",0,""},
+{"anthranil_acid_G(1)","c:1(:c(:c(:c(:c(:c:1-[#1])-[#1])-[#8]-[#6](-[#1])-[#1])-[#1])-[#6](=[#8])-[#8]-[#1])-[#7](-[#1])-[#6]:[#6]",0,""},
+{"anil_di_alk_M(1)","c:1(:c:4:c(:n:c(:c:1-[#6](-[#1])(-[#1])-[#7]-3-c:2:c(:c(:c(:c(:c:2-[#6](-[#1])(-[#1])-[#6]-3(-[#1])-[#1])-[#1])-[#1])-[#1])-[#1])-[#1]):c(:c(:c(:c:4-[#1])-[#1])-[#1])-[#1])-[#1]",0,""},
+{"anthranil_acid_H(1)","c:1:c(:c2:c(:c:c:1)c(c(n2-[#1])-[#6]:[#6])-[#6]:[#6])-[#6](=[#8])-[#8]-[#1]",0,""},
+{"thio_urea_M(1)","[#6]:[#6]-[#7](-[#6](-[#1])-[#1])-[#6](-[#1])(-[#1])-[#6](-[#1])(-[#1])-[#6](-[#1])(-[#1])-[#7](-[#1])-[#6](=[#16])-[#7](-[#1])-c:1:c(:c(:c(:c(:c:1-[F,Cl,Br,I])-[#1])-[#6](-[#1])-[#1])-[#1])-[#1]",0,""},
+{"thiazole_amine_K(1)","n:1:c3:c(:c:c2:c:1nc(s2)-[#7])sc(n3)-[#7]",0,""},
+{"het_thio_5_imine_A(1)","[#7]=[#6]-1-[#16]-[#6](=[#7])-[#7]=[#6]-1",0,""},
+{"thio_amide_E(1)","c:1:c(:n:c:c:c:1)-[#6](=[#16])-[#7](-[#1])-c:2:c(:c:c:c:c:2)-[#8]-[#6](-[#1])-[#1]",0,""},
+{"het_thio_676_B(1)","c:1-2:c(:c(:c(:c(:c:1-[#6](-c:3:c(-[#16]-[#6]-2(-[#1])-[#1]):c(:c(-[#1]):c(:c:3-[#1])-[#1])-[#1])-[#8]-[#6]:[#6])-[#1])-[#1])-[#1])-[#1]",0,""},
+{"sulfonamide_G(1)","[#6](-[#1])(-[#1])(-[#1])-c:1:c(:c(:c(:c(:n:1)-[#7](-[#1])-[#16](-c:2:c(:c(:c(:c(:c:2-[#1])-[#1])-[#8]-[#6](-[#1])(-[#1])-[#6](-[#1])(-[#1])-[#6](-[#1])-[#1])-[#1])-[#1])(=[#8])=[#8])-[#1])-[#1])-[#1]",0,""},
+{"thio_thiomorph_Z(1)","[#6](=[#8])(-[#7]-1-[#6]-[#6]-[#16]-[#6]-[#6]-1)-c:2:c(:c(:c(:c(:c:2-[#16]-[#6](-[#1])-[#1])-[#1])-[#1])-[#1])-[#1]",0,""},
+{"naphth_ene_one_A(1)","c:1:c:c:3:c:2:c(:c:1)-[#6](-[#6]=[#6](-c:2:c:c:c:3)-[#8]-[#6](-[#1])-[#1])=[#8]",0,""},
+{"naphth_ene_one_B(1)","c:1-3:c:2:c(:c(:c:c:1)-[#7]):c:c:c:c:2-[#6](-[#6]=[#6]-3-[#6](-[F])(-[F])-[F])=[#8]",0,""},
+{"amino_acridine_A(1)","c:1:c:c:c:c:2:c:1:c:c:3:c(:n:2):n:c:4:c(:c:3-[#7]):c:c:c:c:4",0,""},
+{"keto_phenone_B(1)","c:1:c-3:c(:c:c:c:1)-[#6]-2=[#7]-[!#1]=[#6]-[#6]-[#6]-2-[#6]-3=[#8]",0,""},
+{"hzone_acid_A(1)","c:1-3:c(:c(:c(:c(:c:1-[#1])-[#1])-[#8]-[#6](-[#1])-[#1])-[#1])-[#6](=[#7]-[#7](-[#1])-c:2:c(:c(:c(:c(:c:2-[#1])-[#1])-[#6](=[#8])-[#8]-[#1])-[#1])-[#1])-c:4:c-3:c(:c(:c(:c:4-[#1])-[#8]-[#6](-[#1])-[#1])-[#1])-[#1]",0,""},
+{"sulfonamide_H(1)","c:1(:c(:c(:c(:c(:c:1-[#1])-[#1])-[#7](-[#1])-[#1])-[#1])-[#1])-[#16](=[#8])(=[#8])-[#7](-[#1])-c:2:n:n:c(:c(:c:2-[#1])-[#1])-[#1]",0,""},
+{"het_565_indole(1)","c2(c(-[#1])n(-[#6](-[#1])-[#1])c:3:c(:c(:c:1n(c(c(c:1:c2:3)-[#1])-[#1])-[#6](-[#1])-[#1])-[#8]-[#6](-[#1])-[#1])-[#8]-[#6](-[#1])-[#1])-[#1]",0,""},
+{"pyrrole_J(1)","c1(c-2c(c(n1-[#6](-[#8])=[#8])-[#6](-[#1])-[#1])-[#16]-[#6](-[#1])(-[#1])-[#16]-2)-[#6](-[#1])-[#1]",0,""},
+{"pyrazole_amino_B(1)","s1ccnc1-c2c(n(nc2-[#1])-[#1])-[#7](-[#1])-[#1]",0,""},
+{"pyrrole_K(1)","c1(c(c(c(n1-[#1])-c:2:c(:c(:c(:c(:c:2-[#1])-[#1])-[#1])-[#1])-[#1])-[#6](-[#1])-[#1])-[#1])-[#6](=[#8])-[#8]-[#1]",0,""},
+{"anthranil_acid_I(1)","c:1:2(:c(:c(:c(:o:1)-[#6])-[#1])-[#1])-[#6](=[#8])-[#7](-[#1])-[#6]:[#6](-[#1]):[#6](-[#1]):[#6](-[#1]):[#6](-[#1]):[#6]:2-[#6](=[#8])-[#8]-[#1]",0,""},
+{"thio_amide_F(1)","[!#1]:[#6]-[#6](=[#16])-[#7](-[#1])-[#7](-[#1])-[#6]:[!#1]",0,""},
+{"ene_one_C(1)","[#6]-1(=[#8])-[#6](-[#6](-[#6]#[#7])=[#6](-[#1])-[#7])-[#6](-[#7])-[#6]=[#6]-1",0,""},
+{"het_65_H(1)","c2(c-1n(-[#6](-[#6]=[#6]-[#7]-1)=[#8])nc2-c3cccn3)-[#6]#[#7]",0,""},
+{"cyano_imine_D(1)","[#8]=[#6]-1-[#6](=[#7]-[#7]-[#6]-[#6]-1)-[#6]#[#7]",0,""},
+{"cyano_misc_A(1)","c:2(:c:1:c:c:c:c:c:1:n:n:c:2)-[#6](-[#6]:[#6])-[#6]#[#7]",0,""},
+{"ene_misc_C(1)","c:1:c:c-2:c(:c:c:1)-[#6]=[#6]-[#6](-[#7]-2-[#6](=[#8])-[#7](-[#1])-c:3:c:c(:c(:c:c:3)-[#8]-[#6](-[#1])-[#1])-[#8]-[#6](-[#1])-[#1])(-[#6](-[#1])-[#1])-[#6](-[#1])-[#1]",0,""},
+{"het_66_E(1)","c:2:c:c:1:n:c(:c(:n:c:1:c:c:2)-c:3:c:c:c:c:c:3)-c:4:c:c:c:c:c:4-[#8]-[#1]",0,""},
+{"keto_keto_beta_F(1)","[#6](-[#1])(-[#1])-[#6](-[#8]-[#1])=[#6](-[#6](=[#8])-[#6](-[#1])-[#1])-[#6](-[#1])-[#6]#[#6]",0,""},
+{"misc_naphthimidazole(1)","c:1:c:4:c(:c:c2:c:1nc(n2-[#1])-[#6]-[#8]-[#6](=[#8])-c:3:c:c(:c:c(:c:3)-[#7](-[#1])-[#1])-[#7](-[#1])-[#1]):c:c:c:c:4",0,""},
+{"naphth_ene_one_C(1)","c:2(:c:1:c:c:c:c-3:c:1:c(:c:c:2)-[#6]=[#6]-[#6]-3=[#7])-[#7]",0,""},
+{"keto_phenone_C(1)","c:2(:c:1:c:c:c:c:c:1:c-3:c(:c:2)-[#6](-c:4:c:c:c:c:c-3:4)=[#8])-[#8]-[#1]",0,""},
+{"coumarin_C(1)","[#6]-2(-[#6]=[#7]-c:1:c:c(:c:c:c:1-[#8]-2)-[Cl])=[#8]",0,""},
+{"thio_est_cyano_A(1)","[#6]-1=[#6]-[#7](-[#6](-c:2:c-1:c:c:c:c:2)(-[#6]#[#7])-[#6](=[#16])-[#16])-[#6]=[#8]",0,""},
+{"het_65_imidazole(1)","c2(nc:1:c(:c(:c(:c(:c:1-[#1])-[#1])-[#1])-[#1])n2-[#6])-[#7](-[#1])-[#6](-[#7](-[#1])-c:3:c(:c:c:c:c:3-[#1])-[#1])=[#8]",0,""},
+{"anthranil_acid_J(1)","[#7](-[#1])(-[#6]:[#6])-c:1:c(-[#6](=[#8])-[#8]-[#1]):c:c:c(:n:1)-[#6]:[#6]",0,""},
+{"colchicine_het(1)","c:1-3:c(:c:c:c:c:1)-[#16]-[#6](=[#7]-[#7]=[#6]-2-[#6]=[#6]-[#6]=[#6]-[#6]=[#6]-2)-[#7]-3-[#6](-[#1])-[#1]",0,""},
+{"ene_misc_D(1)","c:1-2:c(:c(:c(:c(:c:1-[#1])-[#8]-[#6](-[#1])-[#1])-[#8]-[#6](-[#1])-[#1])-[#1])-[#6](=[#6](-[#6])-[#16]-[#6]-2(-[#1])-[#1])-[#6]",0,""},
+{"indole_3yl_alk_B(1)","c:12:c(:c(:c(:c(:c:1-[#1])-[#1])-[#1])-[#1])c(c(-[#6]:[#6])n2-!@[#6]:[#6])-[#6](-[#1])-[#1]",0,""},
+{"anil_OH_no_alk_A(1)","[#7](-[#1])(-[#1])-c:1:c:c:c(:c:c:1-[#8]-[#1])-[#16](=[#8])(=[#8])-[#8]-[#1]",0,""},
+{"thiazole_amine_L(1)","s:1:c:c:c(:c:1-[#1])-c:2:c:s:c(:n:2)-[#7](-[#1])-[#1]",0,""},
+{"pyrazole_amino_A(1)","c1c(-[#7](-[#1])-[#1])nnc1-c2c(-[#6](-[#1])-[#1])oc(c2-[#1])-[#1]",0,""},
+{"het_thio_N_5D(1)","n1nscc1-c2nc(no2)-[#6]:[#6]",0,""},
+{"anil_alk_indane(1)","c:1(:c:c-3:c(:c:c:1)-[#7]-[#6]-4-c:2:c:c:c:c:c:2-[#6]-[#6]-3-4)-[#6;X4]",0,""},
+{"anil_di_alk_N(1)","c:1-2:c(:c(:c(:c(:c:1-[#1])-[#1])-[#1])-[#1])-[#6](=[#6](-[#1])-[#6]-3-[#6](-[#6]#[#7])-[#6](-[#1])(-[#1])-[#6](-[#1])-[#7]-2-3)-[#1]",0,""},
+{"het_666_C(1)","c:2-3:c(:c:c:1:c:c:c:c:c:1:c:2)-[#7](-[#6](-[#1])-[#1])-[#6](=[#8])-[#6](=[#7]-3)-[#6]:[#6]-[#7](-[#1])-[#6](-[#1])-[#1]",0,""},
+{"ene_one_D(1)","[#6](-[#8]-[#1]):[#6]-[#6](=[#8])-[#6](-[#1])=[#6](-[#6])-[#6]",0,""},
+{"anil_di_alk_indol(1)","c:1:2:c(:c(:c(:c(:c:1-[#1])-[#1])-[#7](-[#6](-[#1])-[#1])-[#6](-[#1])-[#1])-[#1]):c(:c(-[#1]):n:2-[#1])-[#16](=[#8])=[#8]",0,""},
+{"anil_no_alk_indol_A(1)","c:1:2:c(:c(:c(:c(:c:1-[#1])-[#1])-[#7](-[#1])-[#1])-[#1]):c(:c(-[#1]):n:2-[#6](-[#1])-[#1])-[#1]",0,""},
+{"dhp_amino_CN_G(1)","[#16;X2]-1-[#6]=[#6](-[#6]#[#7])-[#6](-[#6])(-[#6]=[#8])-[#6](=[#6]-1-[#7](-[#1])-[#1])-[$([#6]=[#8]),$([#6]#[#7])]",0,""},
+{"anil_di_alk_dhp(1)","[#7]-2-[#6]=[#6](-[#6]=[#8])-[#6](-c:1:c:c:c(:c:c:1)-[#7](-[#6](-[#1])-[#1])-[#6](-[#1])-[#1])-[#6]~3=[#6]-2~[#7]~[#6](~[#16])~[#7]~[#6]~3~[#7]",0,""},
+{"anthranil_amide_A(1)","c:1:c(:c:c:c:c:1)-[#6](=[#8])-[#7](-[#1])-c:2:c(:c:c:c:c:2)-[#6](=[#8])-[#7](-[#1])-[#7](-[#1])-c:3:n:c:c:s:3",0,""},
+{"hzone_anthran_Z(1)","c:1:c:2:c(:c:c:c:1):c(:c:3:c(:c:2):c:c:c:c:3)-[#6]=[#7]-[#7](-[#1])-c:4:c:c:c:c:c:4",0,""},
+{"ene_one_amide_A(1)","c:1:c(:c:c:c:c:1)-[#6](-[#1])-[#7]-[#6](=[#8])-[#6](-[#7](-[#1])-[#6](-[#1])-[#1])=[#6](-[#1])-[#6](=[#8])-c:2:c:c:c(:c:c:2)-[#8]-[#6](-[#1])-[#1]",0,""},
+{"het_76_A(1)","s:1:c(:c(-[#1]):c(:c:1-[#6]-3=[#7]-c:2:c:c:c:c:c:2-[#6](=[#7]-[#7]-3-[#1])-c:4:c:c:n:c:c:4)-[#1])-[#1]",0,""},
+{"thio_urea_N(1)","o:1:c(:c(-[#1]):c(:c:1-[#6](-[#1])(-[#1])-[#7](-[#1])-[#6](=[#16])-[#7](-[#6]-[#1])-[#6](-[#1])(-[#1])-c:2:c:c:c:c:c:2)-[#1])-[#1]",0,""},
+{"anil_di_alk_coum(1)","c:1:c(:c:c:c:c:1)-[#7](-[#6]-[#1])-[#6](-[#1])-[#6](-[#1])-[#6](-[#1])-[#7](-[#1])-[#6](=[#8])-[#6]-2=[#6](-[#8]-[#6](-[#6](=[#6]-2-[#6](-[#1])-[#1])-[#1])=[#8])-[#6](-[#1])-[#1]",0,""},
+{"ene_one_amide_B(1)","c2-3:c:c:c:1:c:c:c:c:c:1:c2-[#6](-[#1])-[#6;X4]-[#7]-[#6]-3=[#6](-[#1])-[#6](=[#8])-[#7](-[#6](-[#1])-[#1])-[#6](-[#1])-[#1]",0,""},
+{"het_thio_656c(1)","c:1:c(:c:c:c:c:1)-[#6]-4=[#7]-[#7]:2:[#6](:[#7+]:c:3:c:2:c:c:c:c:3)-[#16]-[#6;X4]-4",0,""},
+{"het_5_ene(1)","[#6]-2(=[#8])-[#6](=[#6](-[#6](-[#1])-[#1])-[#7](-[#1])-[#6](-[#1])(-[#1])-[#6](-[#1])(-[#1])-[#6](-[#1])-[#1])-[#7]=[#6](-c:1:c:c:c:c:c:1)-[#8]-2",0,""},
+{"thio_imide_A(1)","c:1:c(:c:c:c:c:1)-[#7]-2-[#6](=[#8])-[#6](=[#6](-[#1])-[#6]-2=[#8])-[#16]-c:3:c:c:c:c:c:3",0,""},
+{"dhp_amidine_A(1)","[#7]-1(-[#1])-[#7]=[#6](-[#7]-[#1])-[#16]-[#6](=[#6]-1-[#6]:[#6])-[#6]:[#6]",0,""},
+{"thio_urea_O(1)","c:1(:c(:c-3:c(:c(:c:1-[#7](-[#1])-[#6](=[#16])-[#7](-[#1])-[#6](-[#1])-c:2:c(:c(:c(:o:2)-[#6]-[#1])-[#1])-[#1])-[#1])-[#8]-[#6](-[#8]-3)(-[#1])-[#1])-[#1])-[#1]",0,""},
+{"anil_di_alk_O(1)","c:1(:c(:c(:c(:c(:c:1-[#7](-[#1])-[#6](=[#16])-[#7](-[#1])-c:2:c:c:c:c:c:2)-[#1])-[#7](-[#6](-[#1])-[#1])-[#6](-[#1])-[#1])-[#1])-[#1])-[#1]",0,""},
+{"thio_urea_P(1)","[#8]=[#6]-!@n:1:c:c:c-2:c:1-[#7](-[#1])-[#6](=[#16])-[#7]-2-[#1]",0,""},
+{"het_pyraz_misc(1)","[#6](-[F])(-[F])-[#6](=[#8])-[#7](-[#1])-c:1:c(-[#1]):n(-[#6](-[#1])(-[#1])-[#6](-[#1])(-[#1])-[#8]-[#6](-[#1])(-[#1])-[#6]:[#6]):n:c:1-[#1]",0,""},
+{"diazox_C(1)","[#7]-2=[#7]-[#6]:1:[#7]:[!#6&!#1]:[#7]:[#6]:1-[#7]=[#7]-[#6]:[#6]-2",0,""},
+{"diazox_D(1)","[#6]-2(-[#1])(-[#8]-[#1])-[#6]:1:[#7]:[!#6&!#1]:[#7]:[#6]:1-[#6](-[#1])(-[#8]-[#1])-[#6]=[#6]-2",0,""},
+{"misc_cyclopropane(1)","[#6]-1(-[#6](-[#1])(-[#1])-[#6]-1(-[#1])-[#1])(-[#6](=[#8])-[#7](-[#1])-c:2:c:c:c(:c:c:2)-[#8]-[#6](-[#1])(-[#1])-[#8])-[#16](=[#8])(=[#8])-[#6]:[#6]",0,""},
+{"imine_ene_one_B(1)","[#6]-1:[#6]-[#6](=[#8])-[#6]=[#6]-1-[#7]=[#6](-[#1])-[#7](-[#6;X4])-[#6;X4]",0,""},
+{"coumarin_D(1)","c:1:c:c(:c:c-2:c:1-[#6](=[#6](-[#1])-[#6](=[#8])-[#8]-2)-c:3:c:c:c:c:c:3)-[#8]-[#6](-[#1])(-[#1])-[#6]:[#8]:[#6]",0,""},
+{"misc_furan_A(1)","c:1:c(:o:c(:c:1-[#6](-[#1])-[#1])-[#6](-[#1])-[#1])-[#6](-[#1])(-[#1])-[#7]-[#6](-[#1])(-[#1])-[#6](-[#1])(-[#8]-[#6](-[#1])-[#1])-[#6](-[#1])(-[#1])-[#8]-c:2:c:c-3:c(:c:c:2)-[#8]-[#6](-[#8]-3)(-[#1])-[#1]",0,""},
+{"rhod_sat_E(1)","[#7]-4(-c:1:c:c:c:c:c:1)-[#6](=[#8])-[#16]-[#6](-[#1])(-[#7](-[#1])-c:2:c:c:c:c:3:c:c:c:c:c:2:3)-[#6]-4=[#8]",0,""},
+{"rhod_sat_imine_A(1)","[#7]-3(-[#6](=[#8])-c:1:c:c:c:c:c:1)-[#6](=[#7]-c:2:c:c:c:c:c:2)-[#16]-[#6](-[#1])(-[#1])-[#6]-3=[#8]",0,""},
+{"rhod_sat_F(1)","[#7]-2(-c:1:c:c:c:c:c:1)-[#6](=[#8])-[#16]-[#6](-[#1])(-[#1])-[#6]-2=[#16]",0,""},
+{"het_thio_5_imine_B(1)","[#7]-1(-[#6](-[#1])-[#1])-[#6](=[#16])-[#7](-[#6]:[#6])-[#6](=[#7]-[#6]:[#6])-[#6]-1=[#7]-[#6]:[#6]",0,""},
+{"het_thio_5_imine_C(1)","[#16]-1-[#6](=[#7]-[#7]-[#1])-[#16]-[#6](=[#7]-[#6]:[#6])-[#6]-1=[#7]-[#6]:[#6]",0,""},
+{"ene_five_het_N(1)","[#6]-2(=[#8])-[#6](=[#6](-[#1])-c:1:c(:c:c:c(:c:1)-[F,Cl,Br,I])-[#8]-[#6](-[#1])-[#1])-[#7]=[#6](-[#16]-[#6](-[#1])-[#1])-[#16]-2",0,""},
+{"thio_carbam_A(1)","[#6](-[#1])(-[#1])-[#16]-[#6](=[#16])-[#7](-[#1])-[#6](-[#1])(-[#1])-[#6]:[#6]",0,""},
+{"misc_anilide_A(1)","c:1(:c(:c(:c(:c(:c:1-[#1])-[#1])-[#6](-[#1])-[#1])-[#7](-[#1])-[#6](=[#8])-[#6](-[#1])(-[#1])-[#6](-[#1])(-[#1])-[#6]:[#6])-[#1])-[#7](-[#1])-[#6](=[#8])-[#6](-[#1])(-[#1])-[#6](-[#1])(-[#1])-[#6]:[#6]",0,""},
+{"misc_anilide_B(1)","c:1(:c(:c:c(:c:c:1-[#6])-[Br])-[#6])-[#7](-[#1])-[#6](=[#8])-[#7](-[#1])-[#6]-[#6]-[#6]",0,""},
+{"mannich_B(1)","c:1-2:c(:c:c:c(:c:1-[#8]-[#6](-[#1])(-[#1])-[#7](-[#6]:[#6]-[#8]-[#6](-[#1])-[#1])-[#6]-2(-[#1])-[#1])-[#1])-[#1]",0,""},
+{"mannich_catechol_A(1)","c:1-2:c(:c(:c(:c(:c:1-[#8]-[#6](-[#1])(-[#1])-[#7](-[#6](-[#1])-[#1])-[#6]-2(-[#1])-[#1])-[#1])-[#8])-[#8])-[#1]",0,""},
+{"anil_alk_D(1)","[#7](-[#1])(-c:1:c(:c(:c(:c(:c:1-[#1])-[#1])-[#6](-[#1])(-[#6](-[#1])-[#1])-[#6](-[#1])-[#1])-[#1])-[#1])-[#6](-[#1])(-[#1])-[#6](-[#1])(-[#1])-[#7](-[#6](-[#1])-[#1])-[#6](-[#1])-[#1]",0,""},
+{"het_65_I(1)","n:1:2:c:c:c(:c:c:1:c:c(:c:2-[#6](=[#8])-[#6]:[#6])-[#6]:[#6])-[#6](~[#8])~[#8]",0,""},
+{"misc_urea_A(1)","c:1(:c(:c(:c(:c(:c:1-[#1])-[#1])-[#1])-[#6](=[#6](-[#1])-[#1])-[#6](-[#1])-[#1])-[#1])-[#6](-[#6;X4])(-[#6;X4])-[#7](-[#1])-[#6](=[#8])-[#7](-[#6](-[#1])(-[#1])-[#6](-[#1])-[#1])-[#6](-[#1])(-[#1])-[#6](-[#1])(-[#1])-[#6](-[#1])-[#6](-[#1])(-[#1])-[#6]:[#6]",0,""},
+{"imidazole_C(1)","[#6]-3(-[#1])(-n:1:c(:n:c(:c:1-[#1])-[#1])-[#1])-c:2:c(:c(:c(:c(:c:2-[#1])-[Br])-[#1])-[#1])-[#6](-[#1])(-[#1])-[#6](-[#1])(-[#1])-c:4:c-3:c(:c(:c(:c:4-[#1])-[#1])-[#1])-[#1]",0,""},
+{"styrene_imidazole_A(1)","[#6](=[#6](-[#1])-[#6](-[#1])(-[#1])-n:1:c(:n:c(:c:1-[#1])-[#1])-[#1])(-[#6]:[#6])-[#6]:[#6]",0,""},
+{"thiazole_amine_M(1)","c:1(:n:c(:c(-[#1]):s:1)-c:2:c:c:n:c:c:2)-[#7](-[#1])-[#6]:[#6]-[#6](-[#1])-[#1]",0,""},
+{"misc_pyrrole_thiaz(1)","c:1(:n:c(:c(-[#1]):s:1)-c:2:c:c:c:c:c:2)-[#6](-[#1])(-[#6](-[#1])-[#1])-[#6](-[#1])(-[#1])-[#6](-[#1])(-[#1])-[#7]-[#6](-[#1])(-[#1])-c:3:c:c:c:n:3-[#1]",0,""},
+{"pyrrole_L(1)","n:1(-[#1]):c(:c(-[#6](-[#1])-[#1]):c(:c:1-[#6](-[#1])(-[#1])-[#6](-[#1])-[#1])-[#6](-[#1])(-[#1])-[#6](-[#1])-[#1])-[#6](=[#8])-[#8]-[#6](-[#1])-[#1]",0,""},
+{"het_thio_65_D(1)","c:2(:n:c:1:c(:c(:c:c(:c:1-[#1])-[F,Cl,Br,I])-[#1]):n:2-[#1])-[#16]-[#6](-[#1])(-[#1])-[#6](=[#8])-[#7](-[#1])-[#6]:[#6]",0,""},
+{"ene_misc_E(1)","c:1(:c(:c-2:c(:c(:c:1-[#8]-[#6](-[#1])-[#1])-[#1])-[#6]=[#6]-[#6](-[#1])-[#16]-2)-[#1])-[#8]-[#6](-[#1])-[#1]",0,""},
+{"thio_cyano_A(1)","[#7]-1(-[#1])-[#6](=[#16])-[#6](-[#1])(-[#6]#[#7])-[#6](-[#1])(-[#6]:[#6])-[#6](=[#6]-1-[#6]:[#6])-[#1]",0,""},
+{"cyano_amino_het_B(1)","n:1:c(:c(:c(:c(:c:1-[#16;X2]-c:2:c:c:c:c:c:2-[#7](-[#1])-[#1])-[#6]#[#7])-c:3:c:c:c:c:c:3)-[#6]#[#7])-[#7](-[#1])-[#1]",0,""},
+{"cyano_pyridone_G(1)","[#7]-2(-c:1:c:c:c(:c:c:1)-[#8]-[#6](-[#1])-[#1])-[#6](=[#8])-[#6](=[#6]-[#6](=[#7]-2)-n:3:c:n:c:c:3)-[#6]#[#7]",0,""},
+{"het_65_J(1)","o:1:c(:c:c:2:c:1:c(:c(:c(:c:2-[#1])-[#8]-[#6](-[#1])-[#1])-[#8]-[#6](-[#1])-[#1])-[#1])-[#6](~[#8])~[#8]",0,""},
+{"ene_one_yne_A(1)","[#6]#[#6]-[#6](=[#8])-[#6]#[#6]",0,""},
+{"anil_OH_no_alk_B(1)","c:2(:c:1:c(:c(:c(:c(:c:1:c(:c(:c:2-[#8]-[#1])-[#6]=[#8])-[#1])-[#1])-[#1])-[#1])-[#1])-[#7](-[#1])-[#1]",0,""},
+{"hzone_acyl_misc_A(1)","c:1(:c(:c(:c(:o:1)-[$([#1]),$([#6](-[#1])-[#1])])-[#1])-[#1])-[#6](=[#8])-[#7](-[#1])-[#7]=[#6](-[$([#1]),$([#6](-[#1])-[#1])])-c:2:c:c:c:c(:c:2)-[*]-[*]-[*]-c:3:c:c:c:o:3",0,""},
+{"thiophene_F(1)","[#16](=[#8])(=[#8])-[#7](-[#1])-c:1:c(:c(:c(:s:1)-[#6]-[#1])-[#6]-[#1])-[#6](=[#8])-[#7]-[#1]",0,""},
+{"anil_OC_alk_E(1)","[#6](-[#1])(-[#1])-[#8]-c:1:c(:c(:c(:c(:c:1-[#1])-[#1])-[#1])-[#1])-[#7](-[#1])-[#6](-[#1])(-[#1])-[#6](-[#1])(-[#8]-[#1])-[#6](-[#1])-[#1]",0,""},
+{"anil_OC_alk_F(1)","[#6](-[#1])(-[#1])-[#8]-c:1:c(:c(:c(:c(:c:1-[#1])-[#1])-[#1])-[#1])-[#7](-[#1])-[#6](-[#1])(-[#6]=[#8])-[#16]",0,""},
+{"het_65_K(1)","n1nnnc2cccc12",0,""},
+{"het_65_L(1)","c:1-2:c(-[#1]):s:c(:c:1-[#6](=[#8])-[#7]-[#7]=[#6]-2-[#7](-[#1])-[#1])-[#6]=[#8]",0,""},
+{"coumarin_E(1)","c:1-3:c(:c:2:c(:c:c:1-[Br]):o:c:c:2)-[#6](=[#6]-[#6](=[#8])-[#8]-3)-[#1]",0,""},
+{"coumarin_F(1)","c:1-3:c(:c:c:c:c:1)-[#6](=[#6](-[#6](=[#8])-[#7](-[#1])-c:2:n:o:c:c:2-[Br])-[#6](=[#8])-[#8]-3)-[#1]",0,""},
+{"coumarin_G(1)","c:1-2:c(:c:c(:c:c:1-[F,Cl,Br,I])-[F,Cl,Br,I])-[#6](=[#6](-[#6](=[#8])-[#7](-[#1])-[#1])-[#6](=[#7]-[#1])-[#8]-2)-[#1]",0,""},
+{"coumarin_H(1)","c:1-3:c(:c:c:c:c:1)-[#6](=[#6](-[#6](=[#8])-[#7](-[#1])-c:2:n:c(:c:s:2)-[#6]:[#16]:[#6]-[#1])-[#6](=[#8])-[#8]-3)-[#1]",0,""},
+{"het_thio_67_A(1)","[#6](-[#1])(-[#1])-[#16;X2]-c:2:n:n:c:1-[#6]:[#6]-[#7]=[#6]-[#8]-c:1:n:2",0,""},
+{"sulfonamide_I(1)","[#16](=[#8])(=[#8])(-c:1:c:n(-[#6](-[#1])-[#1]):c:n:1)-[#7](-[#1])-c:2:c:n(:n:c:2)-[#6](-[#1])(-[#1])-[#6]:[#6]-[#8]-[#6](-[#1])-[#1]",0,""},
+{"het_65_mannich(1)","c:1-2:c(:c(:c(:c(:c:1-[#8]-[#6](-[#1])(-[#1])-[#8]-2)-[#6](-[#1])(-[#1])-[#7]-3-[#6](-[#1])(-[#1])-[#6](-[#1])(-[#1])-[#6]:[#6]-3)-[#1])-[#1])-[#1]",0,""},
+{"anil_alk_A(1)","[#6](-[#1])(-[#1])-[#8]-[#6]:[#6]-[#6](-[#1])(-[#1])-[#7](-[#1])-c:2:c(:c(:c:1:n(:c(:n:c:1:c:2-[#1])-[#1])-[#6]-[#1])-[#1])-[#1]",0,""},
+{"het_5_inium(1)","[#7]-4(-c:1:c:c:c:c:c:1)-[#6](=[#7+](-c:2:c:c:c:c:c:2)-[#6](=[#7]-c:3:c:c:c:c:c:3)-[#7]-4)-[#1]",0,""},
+{"anil_di_alk_P(1)","[#6](-[#1])(-[#1])-[#7](-[#6](-[#1])-[#1])-c:2:c:c:c:1:s:c(:n:c:1:c:2)-[#16]-[#6](-[#1])-[#1]",0,""},
+{"thio_urea_Q(1)","c:1:2:c(:c(:c(:c(:c:1:c(:c(-[#1]):c(:c:2-[#1])-[#1])-[#6](-[#6](-[#1])-[#1])=[#7]-[#7](-[#1])-[#6](=[#16])-[#7](-[#1])-[#6]:[#6]:[#6])-[#1])-[#1])-[#1])-[#1]",0,""},
+{"thio_pyridine_A(1)","[#6]:1(:[#7]:[#6](:[#7]:[!#1]:[#7]:1)-c:2:c(:c(:c(:o:2)-[#1])-[#1])-[#1])-[#16]-[#6;X4]",0,""},
+{"melamine_B(1)","n:1:c(:n:c(:n:c:1-[#7](-[#6](-[#1])-[#1])-[#6](-[#1])-[#1])-[#7](-[#6](-[#1])-[#1])-[#6](-[#1])-[#1])-[#7](-[#6]-[#1])-[#6]=[#8]",0,""},
+{"misc_phthal_thio_N(1)","c:1(:n:s:c(:n:1)-[#7](-[#6](-[#1])-[#1])-[#6](-[#1])(-[#1])-[#6](-[#1])(-[#1])-[#7]-[#6](=[#8])-c:2:c:c:c:c:c:2-[#6](=[#8])-[#8]-[#1])-c:3:c:c:c:c:c:3",0,""},
+{"hzone_acyl_misc_B(1)","n:1:c(:c(:c(:c(:c:1-[#1])-[#1])-[#1])-[#1])-[#6](=[#8])-[#7](-[#1])-[#7]=[#6](-[#1])-c:2:c:c:c:c:c:2-[#8]-[#6](-[#1])(-[#1])-[#6](=[#8])-[#8]-[#1]",0,""},
+{"tert_butyl_B(1)","[#6](-[#1])(-[#1])(-[#1])-[#6](-[#6](-[#1])(-[#1])-[#1])(-[#6](-[#1])(-[#1])-[#1])-c:1:c(:c(:c(:c(:c:1-[#8]-[#1])-[#6](-[#6](-[#1])(-[#1])-[#1])(-[#6](-[#1])(-[#1])-[#1])-[#6](-[#1])(-[#1])-[#1])-[#1])-[#6](-[#1])(-[#1])-c:2:c:c:c(:c(:c:2-[#1])-[#1])-[#8]-[#1])-[#1]",0,""},
+{"diazox_E(1)","[#7](-[#1])(-[#1])-c:1:c(-[#7](-[#1])-[#1]):c(:c(-[#1]):c:2:n:o:n:c:1:2)-[#1]",0,""},
+{"anil_NH_no_alk_B(1)","[#7](-[#1])(-[#1])-c:1:c(:c(:c(:c(:c:1-[#7](-[#1])-[#16](=[#8])=[#8])-[#1])-[#7](-[#1])-[#6](-[#1])-[#1])-[F,Cl,Br,I])-[#1]",0,""},
+{"anil_no_alk_A(1)","[#7](-[#1])(-[#1])-c:1:c(:c(:c(:c(:c:1-[#7]=[#6]-2-[#6](=[#6]~[#6]~[#6]=[#6]-2)-[#1])-[#1])-[#1])-[#1])-[#1]",0,""},
+{"anil_no_alk_B(1)","[#7](-[#1])(-[#1])-c:1:c(:c(:c(:c(:c:1-n:2:c:c:c:c:2)-[#1])-[#6](-[#1])-[#1])-[#6](-[#1])-[#1])-[#1]",0,""},
+{"thio_ene_amine_A(1)","[#16]=[#6]-[#6](-[#6](-[#1])-[#1])=[#6](-[#6](-[#1])-[#1])-[#7](-[#6](-[#1])-[#1])-[#6](-[#1])-[#1]",0,""},
+{"het_55_B(1)","[#6]-1:[#6]-[#8]-[#6]-2-[#6](-[#1])(-[#1])-[#6](=[#8])-[#8]-[#6]-1-2",0,""},
+{"cyanamide_A(1)","[#8]-[#6](=[#8])-[#6](-[#1])(-[#1])-[#16;X2]-[#6](=[#7]-[#6]#[#7])-[#7](-[#1])-c:1:c:c:c:c:c:1",0,""},
+{"ene_one_one_A(1)","[#8]=[#6]-[#6]-1=[#6](-[#16]-[#6](=[#6](-[#1])-[#6])-[#16]-1)-[#6]=[#8]",0,""},
+{"ene_six_het_D(1)","[#8]=[#6]-1-[#7]-[#7]-[#6](=[#7]-[#6]-1=[#6]-[#1])-[!#1]:[!#1]",0,""},
+{"ene_cyano_E(1)","[#8]=[#6]-[#6](-[#1])=[#6](-[#6]#[#7])-[#6]",0,""},
+{"ene_cyano_F(1)","[#8](-[#1])-[#6](=[#8])-c:1:c(:c(:c(:c(:c:1-[#8]-[#1])-[#1])-c:2:c(-[#1]):c(:c(:o:2)-[#6](-[#1])=[#6](-[#6]#[#7])-c:3:n:c:c:n:3)-[#1])-[#1])-[#1]",0,""},
+{"hzone_furan_C(1)","c:1:c(:c:c:c:c:1)-[#7](-c:2:c:c:c:c:c:2)-[#7]=[#6](-[#1])-[#6]:3:[#6](:[#6](:[#6](:[!#1]:3)-c:4:c:c:c:c(:c:4)-[#6](=[#8])-[#8]-[#1])-[#1])-[#1]",0,""},
+{"anil_no_alk_C(1)","[#7](-[#1])(-[#1])-c:1:c(:c(:c(:c(:c:1-[#1])-[#1])-c:2:c(-[#1]):c(:c(-[#6](-[#1])-[#1]):o:2)-[#6]=[#8])-[#1])-[#1]",0,""},
+{"hzone_acid_D(1)","[#8](-[#1])-[#6](=[#8])-c:1:c:c:c(:c:c:1)-[#7]-[#7]=[#6](-[#1])-[#6]:2:[#6](:[#6](:[#6](:[!#1]:2)-c:3:c:c:c:c:c:3)-[#1])-[#1]",0,""},
+{"hzone_furan_E(1)","[#8](-[#1])-[#6](=[#8])-c:1:c:c:c:c(:c:1)-[#6]:[!#1]:[#6]-[#6]=[#7]-[#7](-[#1])-[#6](=[#8])-[#6](-[#1])(-[#1])-[#8]",0,""},
+{"het_6_pyridone_NH2(1)","[#8](-[#1])-[#6]:1:[#6](:[#6]:[!#1]:[#6](:[#7]:1)-[#7](-[#1])-[#1])-[#6](-[#1])(-[#1])-[#6](=[#8])-[#8]",0,""},
+{"imine_one_fives_D(1)","[#6]-1(=[!#6&!#1])-[#6](-[#7]=[#6]-[#16]-1)=[#8]",0,""},
+{"pyrrole_M(1)","n2(-c:1:c:c:c:c:c:1)c(c(-[#1])c(c2-[#6]=[#7]-[#8]-[#1])-[#1])-[#1]",0,""},
+{"pyrrole_N(1)","n2(-[#6](-[#1])-c:1:c(:c(:c:c(:c:1-[#1])-[#1])-[#1])-[#1])c(c(-[#1])c(c2-[#6]-[#1])-[#1])-[#6]-[#1]",0,""},
+{"pyrrole_O(1)","n1(-[#6](-[#1])-[#1])c(c(-[#6](=[#8])-[#6])c(c1-[#6]:[#6])-[#6])-[#6](-[#1])-[#1]",0,""},
+{"ene_cyano_G(1)","n1(-[#6])c(c(-[#1])c(c1-[#6](-[#1])=[#6](-[#6]#[#7])-c:2:n:c:c:s:2)-[#1])-[#1]",0,""},
+{"sulfonamide_J(1)","n3(-c:1:c:c:c:c:c:1-[#7](-[#1])-[#16](=[#8])(=[#8])-c:2:c:c:c:s:2)c(c(-[#1])c(c3-[#1])-[#1])-[#1]",0,""},
+{"misc_pyrrole_benz(1)","n2(-c:1:c(:c(:c(:c(:c:1-[#1])-[#1])-[#1])-[#1])-[#6](=[#8])-[#7](-[#1])-[#6](-[#1])(-[#6](-[#1])-[#1])-[#6](-[#1])(-[#1])-[#8]-[#6]:[#6])c(c(-[#1])c(c2-[#1])-[#1])-[#1]",0,""},
+{"thio_urea_R(1)","c:1(:c:c:c:c:c:1)-[#7](-[#1])-[#6](=[#16])-[#7]-[#7](-[#1])-[#6](-[#1])=[#6](-[#1])-[#6]=[#8]",0,""},
+{"ene_one_one_B(1)","[#6]-1(-[#6](=[#8])-[#6](-[#1])(-[#1])-[#6]-[#6](-[#1])(-[#1])-[#6]-1=[#8])=[#6](-[#7]-[#1])-[#6]=[#8]",0,""},
+{"dhp_amino_CN_H(1)","[#7](-[#1])(-[#1])-[#6]-1=[#6](-[#6]#[#7])-[#6](-[#1])(-[#6]:[#6])-[#16]-[#6;X4]-[#16]-1",0,""},
+{"het_66_anisole(1)","[#6](-[#1])(-[#1])-[#8]-c:1:c(:c(:c(:c(:c:1-[#1])-[#1])-[#1])-[#1])-[#7](-[#1])-c:2:c:c:n:c:3:c(:c:c:c(:c:2:3)-[#8]-[#6](-[#1])-[#1])-[#8]-[#6](-[#1])-[#1]",0,""},
+{"thiazole_amine_N(1)","[#6](-[#1])(-[#1])-[#8]-c:1:c(:c(:c(:c(:c:1-[#1])-[#1])-[#8]-[#6](-[#1])-[#1])-[#1])-[#7](-[#1])-c:2:n:c(:c:s:2)-c:3:c:c:c(:c:c:3)-[#8]-[#6](-[#1])-[#1]",0,""},
+{"het_pyridiniums_C(1)","[#6]~1~3~[#7](-[#6]:[#6])~[#6]~[#6]~[#6]~[#6]~1~[#6]~2~[#7]~[#6]~[#6]~[#6]~[#7+]~2~[#7]~3",0,""},
+{"het_5_E(1)","[#7]-3(-c:2:c:1:c:c:c:c:c:1:c:c:c:2)-[#7]=[#6](-[#6](-[#1])-[#1])-[#6](-[#1])(-[#1])-[#6]-3=[#8]",0,""}
+};
+const unsigned int NUM_PAINS_C = static_cast<unsigned int>(sizeof(PAINS_C)/sizeof(FilterData_t));
+
+const FilterProperty_t PAINS_C_PROPS[] = {
+{"Reference", "Baell JB, Holloway GA. New Substructure Filters for Removal of Pan Assay Interference Compounds (PAINS) from Screening Libraries and for Their Exclusion in Bioassays. J Med Chem 53 (2010) 2719D40. doi:10.1021/jm901137j."},
+{"Scope", "PAINS filters (family C)"}
+};
+const unsigned int NUM_PAINS_C_PROPS = static_cast<unsigned int>(sizeof(PAINS_C_PROPS)/
+                                                                 sizeof(FilterProperty_t));
+
+
+
+/////////////////////////////////////////////////////////////////////////////////////////
+// ZINC data
+// # Reference: http://blaster.docking.org/filtering/
+// # Scope: drug-likeness and unwanted functional group filters
+// 
+
+const FilterData_t ZINC[] = {
+{"Non-Hydrogen_atoms","[a,A]",40,""},
+{"carbons","[#6]",40,""},
+{"N,O,S","[#7,#8,#16]",20,""},
+{"Sulfonyl_halides","S(=O)(=O)[Cl,Br]",1,""},
+{"Acid_halides","[S,C](=[O,S])[F,Br,Cl,I]",1,""},
+{"Alkyl_halides","[Br,Cl,I][CX4;CH,CH2]",1,""},
+{"Phosphenes","cPc",0,""},
+{"Heptanes","[CD1][CD2][CD2][CD2][CD2][CD2][CD2]",0,""},
+{"Perchlorates","OCl(O)(O)(O)",0,""},
+{"Fluorines","F",7,""},
+{"Cl,Br,I","[Cl,Br,I]",6,""},
+{"Carbazides","O=CN=[N+]=[N-]",0,""},
+{"Acid_anhydrides","C(=O)OC(=O)",0,""},
+{"Peroxides","OO",0,""},
+{"Iso(thio)cyanates","N=C=[S,O]",1,""},
+{"Thiocyanates","SC#N",1,""},
+{"Phosphoranes","C=P",0,""},
+{"P/S_halides","[P,S][Cl,Br,F,I]",0,""},
+{"Cyanohydrines","N#CC[OH]",0,""},
+{"Carbazides","O=CN=[N+]=[N-]",0,""},
+{"Sulfate_esters","COS(=O)O[C,c]",1,""},
+{"Sulfonates","COS(=O)(=O)[C,c]",1,""},
+{"Pentafluorophenyl_esters","C(=O)Oc1c(F)c(F)c(F)c(F)c1(F)",0,""},
+{"Paranitrophenyl_esters","C(=O)Oc1ccc(N(=O)=O)cc1",0,""},
+{"HOBt_esters","C(=O)Onnn",0,""},
+{"Triflates","OS(=O)(=O)C(F)(F)F",0,""},
+{"Lawesson's_reagents","P(=S)(S)S",0,""},
+{"Phosphoramides","NP(=O)(N)N",0,""},
+{"Aromatic_azides","cN=[N+]=[N-]",0,""},
+{"Quaternary_C,Cl,I,P,S","[C+,Cl+,I+,P+,S+]",2,""},
+{"Beta_carbonyl_quaternary_N","C(=O)C[N+,n+]",2,""},
+{"Acylhydrazides","[N;R0][N;R0]C(=O)",2,""},
+{"Chloramidines","[Cl]C([C&R0])=N",0,""},
+{"Isonitriles","[N+]#[C-]",0,""},
+{"Triacyloximes","C(=O)N(C(=O))OC(=O)",0,""},
+{"Acyl_cyanides","N#CC(=O)",0,""},
+{"Sulfonyl_cyanides","S(=O)(=O)C#N",0,""},
+{"Cyanophosphonates","P(OCC)(OCC)(=O)C#N",0,""},
+{"Azocyanamides","[N;R0]=[N;R0]C#N",0,""},
+{"Azoalkanals","[N;R0]=[N;R0]CC=O",0,""},
+{"(Thio)epoxides,aziridines","C1[O,S,N]C1",2,""},
+{"Benzylic_quaternary_N","cC[N+]",2,""},
+{"Thioesters","C[O,S;R0][C;R0](=S)",2,""},
+{"Diand_Triphosphates","P(=O)([OH])OP(=O)[OH]",3,""},
+{"Aminooxy(oxo)","[#7]O[#6,#16]=O",2,""},
+{"nitros","N(~[OD1])~[OD1]",2,""},
+{"Imines","C=[N;R0]*",2,""},
+{"Acrylonitriles","N#CC=C",2,""},
+{"Propenals","C=CC(=O)[!#7;!#8]",2,""},
+{"Quaternary_N","[ND4+]",1,""}
+};
+const unsigned int NUM_ZINC = static_cast<unsigned int>(sizeof(ZINC)/sizeof(FilterData_t));
+
+const FilterProperty_t ZINC_PROPS[] = {
+{"Reference", "http://blaster.docking.org/filtering/"},
+{"Scope", "drug-likeness and unwanted functional group filters"}
+};
+const unsigned int NUM_ZINC_PROPS = static_cast<unsigned int>(sizeof(ZINC_PROPS)/
+                                                              sizeof(FilterProperty_t));
+
+
+////////////////////////////////////////////////////////////////////////
+// API
+unsigned int      GetNumEntries( FilterCatalogParams::FilterCatalogs catalog )
+{
+  switch(catalog) {
+  case FilterCatalogParams::BRENK:  return NUM_BRENK;
+  case FilterCatalogParams::NIH:    return NUM_NIH;
+  case FilterCatalogParams::PAINS_A:return NUM_PAINS_A;
+  case FilterCatalogParams::PAINS_B:return NUM_PAINS_B;
+  case FilterCatalogParams::PAINS_C:return NUM_PAINS_C;
+  case FilterCatalogParams::ZINC:   return NUM_ZINC;
+  default:
+    return 0;
+  }
+}
+
+const FilterData_t *GetFilterData(FilterCatalogParams::FilterCatalogs catalog)
+{
+  switch(catalog) {
+  case FilterCatalogParams::BRENK:  return BRENK;
+  case FilterCatalogParams::NIH:    return NIH;
+  case FilterCatalogParams::PAINS_A:return PAINS_A;
+  case FilterCatalogParams::PAINS_B:return PAINS_B;
+  case FilterCatalogParams::PAINS_C:return PAINS_C;
+  case FilterCatalogParams::ZINC:   return ZINC;
+  default:
+    return 0;
+  }
+}
+
+unsigned GetNumPropertyEntries(FilterCatalogParams::FilterCatalogs catalog)
+{
+  switch(catalog) {
+  case FilterCatalogParams::BRENK:  return NUM_BRENK_PROPS;
+  case FilterCatalogParams::NIH:    return NUM_NIH_PROPS;
+  case FilterCatalogParams::PAINS_A:return NUM_PAINS_A_PROPS;
+  case FilterCatalogParams::PAINS_B:return NUM_PAINS_B_PROPS;
+  case FilterCatalogParams::PAINS_C:return NUM_PAINS_C_PROPS;
+  case FilterCatalogParams::ZINC:   return NUM_ZINC_PROPS;
+  default:
+    return 0;
+  }
+}
+
+const FilterProperty_t* GetFilterProperties(FilterCatalogParams::FilterCatalogs catalog)
+{
+  switch(catalog) {
+  case FilterCatalogParams::BRENK:  return BRENK_PROPS;
+  case FilterCatalogParams::NIH:    return NIH_PROPS;
+  case FilterCatalogParams::PAINS_A:return PAINS_A_PROPS;
+  case FilterCatalogParams::PAINS_B:return PAINS_B_PROPS;
+  case FilterCatalogParams::PAINS_C:return PAINS_C_PROPS;
+  case FilterCatalogParams::ZINC:   return ZINC_PROPS;
+  default:
+    return 0;
+  }
+}
+
+}

--- a/Code/GraphMol/FilterCatalog/Filters.h
+++ b/Code/GraphMol/FilterCatalog/Filters.h
@@ -1,0 +1,64 @@
+//  Copyright (c) 2015, Novartis Institutes for BioMedical Research Inc.
+//  All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+//       copyright notice, this list of conditions and the following
+//       disclaimer in the documentation and/or other materials provided
+//       with the distribution.
+//     * Neither the name of Novartis Institutes for BioMedical Research Inc.
+//       nor the names of its contributors may be used to endorse or promote
+//       products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+#ifndef __RDKIT_FILTERDATA__
+#define __RDKIT_FILTERDATA__
+
+#include "FilterCatalogEntry.h"
+#include "FilterCatalog.h"
+
+namespace RDKit
+{
+  struct FilterData_t
+  {
+    const char * name;
+    const char * smarts;
+    unsigned int  max;
+    const char * comment;
+  };
+
+  struct FilterProperty_t
+  {
+    const char * key;
+    const char * value;
+  };
+
+  unsigned int            GetNumEntries( FilterCatalogParams::FilterCatalogs catalog );
+  const FilterData_t     *GetFilterData( FilterCatalogParams::FilterCatalogs catalog);
+  unsigned int            GetNumPropertyEntries( FilterCatalogParams::FilterCatalogs catalog);
+  const FilterProperty_t *GetFilterProperties(FilterCatalogParams::FilterCatalogs catalog);
+
+  FilterCatalogEntry *MakeFilterCatalogEntry(const FilterData_t &,
+                                             unsigned int num_props=0,
+                                             const FilterProperty_t *props=0);
+   
+}
+
+#endif

--- a/Code/GraphMol/FilterCatalog/README
+++ b/Code/GraphMol/FilterCatalog/README
@@ -1,0 +1,179 @@
+FilterCatalogs give RDKit the ability to screen out or reject undesireable molecules
+based on various criteria.  Supplied with RDKIt are the following filter sets:
+
+  * PAINS - Pan assay interference patterns.  These are seperated into three
+    sets PAINS_A, PAINS_B and PAINS_C.
+    Reference: Baell JB, Holloway GA. New Substructure Filters for Removal of Pan Assay
+               Interference Compounds (PAINS) from Screening Libraries and for Their
+               Exclusion in Bioassays.
+               J Med Chem 53 (2010) 2719Ð40. doi:10.1021/jm901137j.
+
+  * BRENK - filters unwanted functionality due to potential tox reasons or unfavorable
+     pharmacokinetics.
+    Reference: Brenk R et al. Lessons Learnt from Assembling Screening Libraries for
+               Drug Discovery for Neglected Diseases.
+               ChemMedChem 3 (2008) 435-444. doi:10.1002/cmdc.200700139.
+
+  * NIH - annotated compounds with problematic functional groups
+     Reference: Doveston R, et al. A Unified Lead-oriented Synthesis of over Fifty
+                Molecular Scaffolds. Org Biomol Chem 13 (2014) 859Ð65.
+                doi:10.1039/C4OB02287D.
+     Reference: Jadhav A, et al. Quantitative Analyses of Aggregation, Autofluorescence,
+                and Reactivity Artifacts in a Screen for Inhibitors of a Thiol Protease.
+                J Med Chem 53 (2009) 37Ð51. doi:10.1021/jm901070c.
+
+  * ZINC - Filtering based on drug-likeness and unwanted functional groups
+    Reference: http://blaster.docking.org/filtering/
+
+The following is C++ and Python examples of how to filter molecules.
+
+[C++]
+
+#include <GraphMol/FilterCatalog.h>
+using namespace RDKit;
+
+    SmilesMolSupplier suppl(…);
+
+    // setup the desired catalogs
+    FilterCatalogParams params;
+    params.addCatalog(FilterCatalogParams::PAINS_A);
+    params.addCatalog(FilterCatalogParams::PAINS_B);
+    params.addCatalog(FilterCatalogParams::PAINS_C);
+    
+    // create the catalog
+    FilterCatalog catalog(params);
+
+    unique_ptr<ROMol> mol; // automatically cleans up after us    
+    int count = 0;
+    while(!suppl.atEnd()){
+      mol.reset(suppl.next());
+      TEST_ASSERT(mol.get());
+
+      // Does a PAINS filter hit?
+      if (catalog.hasMatch(*mol)) {
+        std::cerr << "Warning: molecule failed filter " << std::endl;
+      }
+      
+      // More detailed data by retrieving the catalog entry
+      const FilterCatalogEntry *entry = catalog.getFirstMatch(*mol);
+      if (entry) {
+        std::cerr << "Warning: molecule failed filter: reason " <<
+          entry->getDescription() << std::endl;
+        
+        // get the matched substructure atoms for visualization
+        std::vector<FilterMatch> matches;
+        if (entry->getFilterMatches(*mol, matches)) {
+          for(std::vector<FilterMatch>::const_iterator it = matches.begin();
+              it != matches.end(); ++it) {
+            // Get the SmartsMatcherBase that matched
+            const FilterMatch & fm = (*it);
+            boost::shared_ptr<SmartsMatcherBase> matchingFilter = \
+              fm.filterMatch;
+            
+            // Get the matching atom indices
+            const MatchVectType &vect = fm.atomPairs;
+            for (MatchVectType::const_iterator it=vect.begin();
+                 it != vect.end(); ++it) {
+                 int atomIdx = it->second;
+            }
+
+          }
+        }
+      }
+      count ++;
+    } // end while
+
+Python API
+
+  import sys
+  from rdkit.Chem import FilterCatalog
+
+  params = FilterCatalog.FilterCatalogParams()
+  params.AddCatalog(FilterCatalogParams.FilterCatalogs.PAINS_A)
+  params.AddCatalog(FilterCatalogParams.FilterCatalogs.PAINS_B)
+  params.AddCatalog(FilterCatalogParams.FilterCatalogs.PAINS_C)
+  catalog = FilterCatalog.FilterCatalog(params)
+  
+  ...
+  for mol in mols:
+      if catalog.HasMatch(mol):
+         print("Warning: molecule failed filter", file=sys.stderr)
+      # more detailed
+      entry = catalog.GetFirstMatch(mol)
+      if entry:
+         print("Warning: molecule failed filter: reason %s"%(
+           entry.GetDescription()), file=sys.stderr)
+           
+         # get to the atoms involved in the substructure
+         #  there ma be many matching filters here...
+         for filterMatch in entry.getFilterMatches(mol):
+             filter = filterMatch.filterMatch
+             # get a description of the matching filter
+             print(filter)
+             for queryAtomIdx, atomIdx in filterMatch.atomPairs:
+                 # do something with the substructure matches
+
+Advanced
+
+ FilterCatalogs are fully serializable and can be stored for later use.
+
+  To serialize a catalog, use the catalog.Serialize() method.
+     std::string pickle = catalog.Serialize();
+     
+  To unserialize, send the resulting string into the constructor
+     FilterCatalog catalog(pickle);
+
+
+ The underlying matchers can be arbitrarily complicated and new
+  ones with more complicated semantics can be created.  The default
+  matching objects are:
+
+  SmartsMatcher - match a smarts pattern or query molecule with a minimum and maximum count
+  ExclusionList - returns false if any of the supplied matches exist
+
+  And - combine two matchers
+  Or  - true if any of two matchers are true
+  Not - invert the match (note that this can have confusing semantics
+          when dealing with substructure matches)
+
+  Entries can be added at any time to a catalog:
+  
+   ExclusionList excludedList;   
+
+    excludedList.addPattern(SmartsMatcher("Pattern 1", smarts)); 
+    excludedList.addPattern(SmartsMatcher("Pattern 2", smarts2)); 
+   
+
+  A FilterCatalog supports a few different types of matching.  One is
+  a traditional rejection filter where if a substructure exists in
+  the target molecule, the molecule is rejected.
+
+  These types of queries can indicate the substructure that triggered
+  the rejection through the FilterCatalogEntry::GetMatch(mol)
+  function.
+
+  The FilterCatalog also supports acceptance filters, that are
+  designed to indicate which molecules are ok.  These have
+  to be transformed into rejection filters or simply wrapped in a Not( acceptanceFilter )
+  when entered into the catalog.  For example, from Zinc:
+
+    carbons [#6] 40
+
+  means that we have a maximum of 40 carbon atoms.  We can write this by
+  converting the max count to a min count (i.e. the pattern is triggered
+  when the molecule has mincount atoms);
+
+    const unsigned int minCount = 40+1;
+    SmartsMatcher( "Too many carbons", "[#6"], minCount );
+
+  This can be properly substructure searched.
+
+  Or we can wrap this in a not:
+  
+    const unsigned int minCount = 0;
+    const unsigned int maxCount = 40;
+    Not( SmartsMatcher( "ok number of carbons", "[#6]", minCount, maxCount) );
+
+  Note: Wrapping in a Not loses the ability to highlight the rejecting
+    pattern when visualizing the molecule.
+  

--- a/Code/GraphMol/FilterCatalog/Wrap/CMakeLists.txt
+++ b/Code/GraphMol/FilterCatalog/Wrap/CMakeLists.txt
@@ -1,0 +1,20 @@
+set(T_LIBS ${Boost_LIBRARIES})
+find_package(Boost 1.39.0 COMPONENTS serialization)
+if (Boost_SERIALIZATION_LIBRARY)
+  set(Boost_LIBRARIES ${T_LIBS} ${Boost_LIBRARIES})
+  message("== Using boost serialization library ${Boost_SERIALIZATION_LIBRARY}")
+else()
+  message("== Making python FilterCatalog without boost Serialization support")
+endif()
+
+rdkit_python_extension(rdfiltercatalog
+                       rdfiltercatalog.cpp
+                       FilterCatalog.cpp
+                       DEST Chem 
+                       LINK_LIBRARIES
+                       ${Boost_SERIALIZATION_LIBRARY} 
+                       FilterCatalog 
+Subgraphs SubstructMatch SmilesParse Catalogs FileParsers GraphMol DataStructs RDGeometryLib RDGeneral 
+ RDBoost) 
+
+add_pytest(pyFilterCatalog ${CMAKE_CURRENT_SOURCE_DIR}/rough_test.py)

--- a/Code/GraphMol/FilterCatalog/Wrap/FilterCatalog.cpp
+++ b/Code/GraphMol/FilterCatalog/Wrap/FilterCatalog.cpp
@@ -168,7 +168,7 @@ namespace RDKit{
   };
 
   bool FilterCatalogRemoveEntry(FilterCatalog &fc, const boost::python::object &obj) {
-    if(PyInt_Check(obj.ptr())) {
+    if(PyLong_Check(obj.ptr())) {
       return fc.removeEntry(python::extract<unsigned int>(obj));
     }
     unsigned int idx = fc.getIdxForEntry(python::extract<FilterCatalogEntry*>(obj));

--- a/Code/GraphMol/FilterCatalog/Wrap/FilterCatalog.cpp
+++ b/Code/GraphMol/FilterCatalog/Wrap/FilterCatalog.cpp
@@ -1,0 +1,479 @@
+//  Copyright (c) 2015, Novartis Institutes for BioMedical Research Inc.
+//  All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+//       copyright notice, this list of conditions and the following
+//       disclaimer in the documentation and/or other materials provided
+//       with the distribution.
+//     * Neither the name of Novartis Institutes for BioMedical Research Inc.
+//       nor the names of its contributors may be used to endorse or promote
+//       products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+#include <RDBoost/Wrap.h>
+
+#include <boost/python.hpp>
+#include <boost/python/scope.hpp>
+
+#include <GraphMol/FilterCatalog/FilterCatalogEntry.h>
+#include <GraphMol/FilterCatalog/FilterCatalog.h>
+#include <GraphMol/FilterCatalog/FilterMatcherBase.h>
+#include <GraphMol/FilterCatalog/FilterMatchers.h>
+#include <boost/python/suite/indexing/vector_indexing_suite.hpp>
+#include <boost/python/stl_iterator.hpp>
+#include <boost/python/register_ptr_to_python.hpp>
+#include <GraphMol/RDKitBase.h>
+
+namespace python = boost::python;
+
+namespace RDKit{
+  template<typename T>
+  void python_to_vector(boost::python::object o, std::vector<T>& v) {
+    python::stl_input_iterator<T> begin(o);
+    python::stl_input_iterator<T> end;
+    v.clear();
+    v.insert(v.end(), begin, end);
+  }
+  
+  void SetOffPatterns(ExclusionList &fc, boost::python::object list) {
+    std::vector<FilterMatcherBase*> vect;
+    //python_to_vector<FilterMatcherBase*>(list, vect);
+    python::stl_input_iterator<FilterMatcherBase*> begin(list);
+    python::stl_input_iterator<FilterMatcherBase*> end;
+    
+    std::vector<boost::shared_ptr<FilterMatcherBase> >  temp;
+
+    int i=0;
+    for (; begin!=end; ++begin) {
+      temp.push_back( (*begin)->Clone() );
+    }
+    fc.setExclusionPatterns(temp);
+  }
+  /*
+  std::vector<const FilterCatalogEntry*> *GetMatches(FilterCatalog &fc, const ROMol &mol) {
+    std::vector<boost::shared_ptr<FilterCatalogEntry> > *result =        \
+      new std::vector<const FilterCatalogEntry*>(fc.getMatches(mol));
+    return result;
+  }
+  */
+  std::vector<FilterMatch> FilterMatcherBaseGetMatches(FilterMatcherBase &fm,
+                                        const ROMol &mol) {
+    std::vector<FilterMatch> matches;
+    if (fm.getMatches(mol, matches))
+    {
+      return matches;
+    }
+    return std::vector<FilterMatch>();
+  }
+
+  std::vector<FilterMatch> FilterCatalogEntryGetMatches(FilterCatalogEntry &fm,
+                                                        const ROMol &mol) {
+    std::vector<FilterMatch> matches;
+    if (fm.getFilterMatches(mol, matches))
+    {
+      return matches;
+    }
+    return std::vector<FilterMatch>();
+  }
+  /*
+  std::vector<MatchVectType> GetFilterMatchAtomPairs(FilterMatch &fm) {
+    return fm.atomPairs;
+  }
+  */
+
+  int GetMatchVectItem(std::pair<int,int> &pair, size_t idx) {
+    static const int def = 0xDEADBEEF;
+    if (idx == 0)
+      return pair.first;
+    else if (idx == 1)
+      return pair.second;
+    PyErr_SetString(PyExc_IndexError, "Index out of bounds");
+    python::throw_error_already_set();
+    return def;
+  }
+
+  void filter_catalog_add_entry(FilterCatalog &catalog,
+                                FilterCatalogEntry *entry) {
+    // these are cheap to copy, so we do this to avoid memory management
+    //  issues from python as the catalog will own the ptr
+    catalog.addEntry(new FilterCatalogEntry(*entry));
+  }
+
+  class PythonFilterMatch : public FilterMatcherBase {
+    PyObject *functor;
+    bool incref;
+    
+  public:
+    PythonFilterMatch(PyObject *self) :
+      FilterMatcherBase("Python Filter Matcher"),
+      functor(self),
+      incref(false)
+    {
+    };
+
+    // ONLY CALLED FROM C++ from the Clone operation
+    PythonFilterMatch(const PythonFilterMatch &rhs) :
+      FilterMatcherBase(rhs),
+      functor(rhs.functor),
+      incref(true)
+    {
+      python::incref(functor);
+    }
+
+    ~PythonFilterMatch() {
+      if(incref)
+        python::decref(functor);
+    }
+    virtual bool isValid() const {
+      return python::call_method<bool>(functor, "IsValid");
+    }
+    
+    virtual std::string getName() const {
+      return python::call_method<std::string>(functor, "GetName");
+    }
+    
+    virtual bool getMatches(const ROMol &mol,
+                            std::vector<FilterMatch> &matchVect) const {
+      return python::call_method<bool>(functor, "GetMatches",
+                                       boost::ref(mol),
+                                       boost::ref(matchVect));
+    }
+    
+    virtual bool hasMatch(const ROMol &mol) const {
+      return python::call_method<bool>(functor, "HasMatch",
+                                       boost::ref(mol));
+    }
+    
+    virtual boost::shared_ptr<FilterMatcherBase> Clone() const {
+      return boost::shared_ptr<FilterMatcherBase>(new PythonFilterMatch(*this));
+    }
+  };
+
+  bool FilterCatalogRemoveEntry(FilterCatalog &fc, const boost::python::object &obj) {
+    if(PyInt_Check(obj.ptr())) {
+      return fc.removeEntry(python::extract<unsigned int>(obj));
+    }
+    unsigned int idx = fc.getIdxForEntry(python::extract<FilterCatalogEntry*>(obj));
+    return fc.removeEntry(idx);
+  }
+  
+  const char* FilterMatchDoc = "Object that holds the result of running FilterMatcherBase::GetMatches\n\n"
+    " - filterMatch holds the FilterMatchBase that triggered the match\n"
+    " - atomParis holds the [ (query_atom_idx, target_atom_idx) ] pairs for the matches.\n"
+    "\n\n"
+    "Note that some matches may not have atom pairs (especially matches that use FilterMatchOps.Not";
+
+  const char *FilterMatcherBaseDoc = "Base class for matching molecules to filters.\n\n"
+    " A FilterMatcherBase supplies the following API \n"
+    " - IsValid() returns True if the matcher is valid for use, False otherwise\n"
+    " - HasMatch(mol) returns True if the molecule matches the filter\n"
+    " - GetMatches(mol) -> [FilterMatch, FilterMatch] returns all the FilterMatch data\n"
+    "       that matches the molecule\n"
+    "\n\nprint( FilterMatcherBase ) will print user-friendly information about the filter"
+    "\nNote that a FilterMatcherBase can be combined from may FilterMatcherBases"
+    "\nThis is why GetMatches can return multiple FilterMatcherBases.\n"
+    ">>> from rdkit.Chem.FilterCatalog import *\n"
+    ">>> carbon_matcher = SmartsMatcher('Carbon', '[#6]', 0, 1)\n"
+    ">>> oxygen_matcher = SmartsMatcher('Oxygen', '[#8]', 0, 1)\n"
+    ">>> co_matcher = FilterMatchOps.Or(carbon_matcher, oxygen_matcher)\n"
+    ">>> mol = Chem.MolFromSmiles('C')\n"
+    ">>> matches = co_matcher.GetMatches(mol)\n"
+    ">>> len(matches)\n"
+    "1\n"
+    ">>> print(matches[0].filterMatch)\n"
+    "Carbon\n\n";
+
+  const char *SmartsMatcherDoc = "Smarts Matcher Filter\n"
+    " basic constructors: \n"
+    "   SmartsMatcher( name, smarts_pattern, minCount=1, maxCount=UINT_MAX )\n"
+    "   SmartsMatcher( name, molecule, minCount=1, maxCount=UINT_MAX )\n\n"
+    "  note: If the supplied smarts pattern is not valid, the IsValid() function will\n"
+    "   return False\n"
+    ">>> from rdkit.Chem.FilterCatalog import *\n"
+    ">>> minCount, maxCount = 1,2\n"
+    ">>> carbon_matcher = SmartsMatcher('Carbon', '[#6]', minCount, maxCount)\n"
+    ">>> print (carbon_matcher.HasMatch(Chem.MolFromSmiles('CC')))\n"
+    "True\n"
+    ">>> print (carbon_matcher.HasMatch(Chem.MolFromSmiles('CCC')))\n"
+    "False\n"
+    ">>> carbon_matcher.SetMinCount(2)\n"
+    ">>> print (carbon_matcher.HasMatch(Chem.MolFromSmiles('C')))\n"
+    "False\n"
+    ">>> carbon_matcher.SetMaxCount(3)\n"
+    ">>> print (carbon_matcher.HasMatch(Chem.MolFromSmiles('CCC')))\n"
+    "True\n"
+    "\n";
+
+  const char * FilterCatalogEntryDoc = "FilterCatalogEntry\n"
+    "A filter catalog entry is an entry in a filter catalog.\n"
+    "Each filter is named and is used to flag a molecule usually for some\n"
+    "undesireable property.\n\n"
+    "For example, a PAINS (Pan Assay INterference) catalog entry be appear as\n"
+    "follows:\n\n"
+    ">>> from rdkit.Chem.FilterCatalog import *\n"
+    ">>> params = FilterCatalogParams()\n"
+    ">>> params.AddCatalog(FilterCatalogParams.FilterCatalogs.PAINS_A)\n"
+    "True\n"
+    ">>> catalog = FilterCatalog(params)\n"
+    ">>> mol = Chem.MolFromSmiles('O=C(Cn1cnc2c1c(=O)n(C)c(=O)n2C)N/N=C/c1c(O)ccc2c1cccc2')\n"
+    ">>> entry = catalog.GetFirstMatch(mol)\n"
+    ">>> print (entry.GetProp('Scope'))\n"
+    "PAINS filters (family A)\n"
+    ">>> print (entry.GetDescription())\n"
+    "hzone_phenol_A(479)\n"
+    "\n\n";
+  
+  struct filtercat_wrapper {
+    static void wrap() {
+
+      python::class_<std::pair<int, int> >("IntPair")
+        .def(python::init<const int&, const int&>())
+        .def_readwrite("query", &std::pair<int, int>::first)
+        .def_readwrite("target", &std::pair<int, int>::second)
+        .def( "__getitem__", &GetMatchVectItem)
+        ;
+      
+      python::class_<MatchVectType >("MatchTypeVect")
+        .def(python::vector_indexing_suite<MatchVectType >() );
+            
+      python::class_<FilterMatch, FilterMatch*, boost::shared_ptr<FilterMatch> >(
+         "FilterMatch", FilterMatchDoc,
+         python::init<boost::shared_ptr<FilterMatcherBase>, MatchVectType>())
+        .def_readonly("filterMatch", &FilterMatch::filterMatch)
+        .def_readonly("atomPairs", &FilterMatch::atomPairs)
+        ;
+
+      python::class_<std::vector<FilterMatch> >("VectFilterMatch")
+        .def(python::vector_indexing_suite<std::vector<FilterMatch> >() );
+      
+
+      python::class_<FilterMatcherBase,FilterMatcherBase*,
+                     boost::shared_ptr<FilterMatcherBase>,
+                     boost::noncopyable>(
+          "FilterMatcherBase",FilterMatcherBaseDoc,python::no_init)
+        .def("IsValid", &FilterMatcherBase::isValid,
+             "Return True if the filter matcher is valid, False otherwise")
+        .def("HasMatch", &FilterMatcherBase::hasMatch,
+             (python::arg("mol")),
+             "Returns True if mol matches the filter")
+        .def("GetMatches", &FilterMatcherBaseGetMatches,
+             (python::arg("mol")),
+             "Returns the list of matching subfilters mol matches any filter")
+
+        .def("GetName", &FilterMatcherBase::getName)
+        .def("__str__", &FilterMatcherBase::getName)
+        ;
+
+      python::register_ptr_to_python< boost::shared_ptr<FilterMatcherBase> >();
+      
+      python::class_<SmartsMatcher, SmartsMatcher *,
+                     python::bases<FilterMatcherBase> >("SmartsMatcher",
+                                                        python::init<const std::string&>())
+        .def(python::init<const ROMol &>(
+            "Construct from a molecule"))
+        .def(python::init<const std::string &, const ROMol &>(
+            "Construct from a name and a molecule"))
+        .def(python::init<const std::string &, const ROMol &, unsigned int>(
+            "Construct from a name, molecule and minimum count"))
+        .def(python::init<const std::string &, const ROMol &, unsigned int, unsigned int>(
+            "Construct from a name, molecule, minimum and maximum count"))
+
+        .def(python::init<const std::string &, const std::string &>(
+            "Construct from a name and smarts pattern (minimum count defaults to 1"))
+        .def(python::init<const std::string &, const std::string &, unsigned int>(
+            "Construct from a name,smarts pattern and minimum count"))
+        
+        .def(python::init<const std::string &, const std::string &,
+             unsigned int, unsigned int>(
+            "Construct from a name,smarts pattern, minimum and maximum count"))
+
+        .def("IsValid", &SmartsMatcher::isValid, "Returns True if the SmartsMatcher is valid")
+        .def("SetPattern", (void (SmartsMatcher::*)(const ROMol&))&SmartsMatcher::setPattern,
+             "Set the pattern molecule for the SmartsMatcher")
+        .def("SetPattern", (void (SmartsMatcher::*)(const std::string&))&SmartsMatcher::setPattern,
+             "Set the smarts pattern for the Smarts Matcher (warning: MinimumCount is not reset)")
+        .def("GetPattern", &SmartsMatcher::getPattern,
+             python::return_value_policy<python::return_by_value>())
+        .def("GetMinCount", &SmartsMatcher::getMinCount,
+             "Get the minimum times pattern must appear for the filter to match")
+        .def("SetMinCount", &SmartsMatcher::setMinCount,
+             (python::arg("count")),
+             "Set the minimum times pattern must appear to match")
+
+        .def("GetMaxCount", &SmartsMatcher::getMaxCount,
+             "Get the maximum times pattern can appear for the filter to match")
+        .def("SetMaxCount", &SmartsMatcher::setMaxCount,
+             (python::arg("count")),
+             "Set the maximum times pattern can appear for the filter to match")
+        ;
+
+      python::class_<ExclusionList, ExclusionList *,
+                     python::bases<FilterMatcherBase> >("ExclusionList",
+                                                        python::init<>())
+        .def("SetExclusionPatterns", &SetOffPatterns,
+             "Set a list of FilterMatcherBases that should not appear in a molecule")
+        .def("AddPattern", &ExclusionList::addPattern,
+             "Add a FilterMatcherBase that should not appear in a molecule")
+        ;
+
+      python::class_<std::vector<RDKit::ROMol*> >("MolList")
+        .def(python::vector_indexing_suite<std::vector<ROMol*>, true>() );
+
+      python::class_<FilterCatalogEntry,
+                     FilterCatalogEntry*,
+                     const FilterCatalogEntry *>
+           ("FilterCatalogEntry", python::init<>())
+        .def(python::init<const std::string &, FilterMatcherBase &>())
+        .def("IsValid", &FilterCatalogEntry::isValid)
+
+        .def("GetDescription", &FilterCatalogEntry::getDescription,
+             "Get the description of the catalog entry")
+        .def("SetDescription", &FilterCatalogEntry::setDescription,
+             (python::arg("description")),
+             "Set the description of the catalog entry")
+        .def("GetFilterMatches", &FilterCatalogEntryGetMatches,
+             (python::args("mol")),
+             "Retrieve the list of filters that match the molecule")
+        .def("HasFilterMatch", &FilterCatalogEntry::hasFilterMatch,
+             (python::args("mol")),
+             "Returns True if the catalog entry contains filters that match the molecule")
+
+        .def("Serialize", &FilterCatalogEntry::Serialize)
+        .def("GetPropList", &FilterCatalogEntry::getPropList)
+        .def("SetProp", (void (FilterCatalogEntry::*)
+                          (const std::string &, std::string) )
+             &FilterCatalogEntry::setProp<std::string>)
+        .def("GetProp", (std::string (FilterCatalogEntry::*)
+                         (const std::string &) const)
+             &FilterCatalogEntry::getProp<std::string>)
+        .def("ClearProp", (void (FilterCatalogEntry::*)
+                           (const std::string &))
+             &FilterCatalogEntry::clearProp)        
+        ;
+      
+      python::register_ptr_to_python< boost::shared_ptr<FilterCatalogEntry> >();
+      python::register_ptr_to_python< boost::shared_ptr<const FilterCatalogEntry> >();
+      
+      python::class_<std::vector<boost::shared_ptr<const FilterCatalogEntry> > >(
+        "FilterCatalogEntryList")
+        .def(python::vector_indexing_suite<
+             std::vector<boost::shared_ptr<const FilterCatalogEntry> >,
+             true>() );
+      
+      {
+        python::scope in_FilterCatalogParams =                          \
+          python::class_<FilterCatalogParams, FilterCatalogParams*>
+          ("FilterCatalogParams", python::init<>())
+          .def(python::init<FilterCatalogParams::FilterCatalogs>(
+            "Construct from a FilterCatalogs identifier (i.e. FilterCatalogParams.PAINS)"))
+          .def("AddCatalog", &FilterCatalogParams::addCatalog)
+          ;
+        
+          python::enum_<FilterCatalogParams::FilterCatalogs>("FilterCatalogs")
+          .value("PAINS_A", FilterCatalogParams::PAINS_A)
+          .value("PAINS_B", FilterCatalogParams::PAINS_B)
+          .value("PAINS_C", FilterCatalogParams::PAINS_C)
+          .value("PAINS", FilterCatalogParams::PAINS)
+          .value("BRENK", FilterCatalogParams::BRENK)
+          .value("NIH", FilterCatalogParams::NIH)
+          .value("ZINC", FilterCatalogParams::ZINC)
+          .value("ALL", FilterCatalogParams::ALL)
+            ;
+      
+      }
+
+      python::class_<FilterCatalog>("FilterCatalog",
+                                    python::init<>())
+        .def(python::init<const std::string&>())        
+        .def(python::init<const FilterCatalogParams&>())
+        .def("Serialize", &FilterCatalog::Serialize)
+        .def("AddEntry", &filter_catalog_add_entry,
+             (python::args("entry"), python::args("updateFPLength")=false),
+             "Add a FilterCatalogEntry to the catalog")
+        .def("RemoveEntry", &FilterCatalogRemoveEntry,
+                             "Remove the given entry from the catalog")
+        .def("GetNumEntries", &FilterCatalog::getNumEntries,
+             "Returns the number of entries in the catalog")
+        .def("GetEntryWithIdx", &FilterCatalog::getEntry,
+             (python::arg("idx")),
+             "Return the FilterCatalogEntry at the specified index")
+        .def("GetEntry", &FilterCatalog::getEntry,
+             (python::arg("idx")),
+             "Return the FilterCatalogEntry at the specified index")
+        .def("HasMatch", &FilterCatalog::hasMatch,
+             (python::arg("mol")),
+             "Returns True if the catalog has an entry that matches mol")
+        .def("GetFirstMatch", &FilterCatalog::getFirstMatch,
+             (python::arg("mol")),
+             "Return the first catalog entry that matches mol")
+        .def("GetMatches", &FilterCatalog::getMatches,
+             (python::arg("mol")),
+             "Return all catalog entries that match mol")
+        ;
+
+
+      python::class_<PythonFilterMatch,
+                     python::bases<FilterMatcherBase> >("PythonFilterMatcher",
+                                                        python::init<PyObject*>())
+        ;
+
+      python::def("FilterCatalogCanSerialize", FilterCatalogCanSerialize,
+                  "Returns True if the FilterCatalog is serializable "
+                  "(requires boost serialization");
+      
+      std::string nested_name = python::extract<std::string>(
+                      python::scope().attr("__name__") + ".FilterMatchOps");
+      python::object nested_module(python::handle<>(
+             python::borrowed(PyImport_AddModule(nested_name.c_str()))));
+      python::scope().attr("FilterMatchOps") = nested_module;
+      python::scope parent = nested_module;
+      
+      python::class_<FilterMatchOps::And, FilterMatchOps::And*,
+                     python::bases<FilterMatcherBase> >("And",
+                      python::init<FilterMatcherBase &,
+                                   FilterMatcherBase &>())
+        ;
+     
+      python::class_<FilterMatchOps::Or, FilterMatchOps::Or*,
+                     python::bases<FilterMatcherBase> >("Or",
+                           python::init<FilterMatcherBase&,
+                                        FilterMatcherBase&>() )
+        ;
+
+      python::class_<FilterMatchOps::Not, FilterMatchOps::Not*,
+                     python::bases<FilterMatcherBase> >("Not",
+                           python::init<FilterMatcherBase&>())
+        ;
+
+    
+        
+
+    };
+  };
+
+} //end of namespace
+
+void wrap_filtercat() {
+  RDKit::filtercat_wrapper::wrap();
+}
+
+
+

--- a/Code/GraphMol/FilterCatalog/Wrap/rdfiltercatalog.cpp
+++ b/Code/GraphMol/FilterCatalog/Wrap/rdfiltercatalog.cpp
@@ -1,0 +1,42 @@
+//  Copyright (c) 2015, Novartis Institutes for BioMedical Research Inc.
+//  All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+//       copyright notice, this list of conditions and the following
+//       disclaimer in the documentation and/or other materials provided
+//       with the distribution.
+//     * Neither the name of Novartis Institutes for BioMedical Research Inc.
+//       nor the names of its contributors may be used to endorse or promote
+//       products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+#include "rdfiltercatalog.h"
+#include <boost/python.hpp>
+
+namespace python = boost::python;
+
+void wrap_filtercat();
+
+BOOST_PYTHON_MODULE(rdfiltercatalog) {
+  python::register_exception_translator<IndexErrorException>(&translate_index_error);
+  python::register_exception_translator<ValueErrorException>(&translate_value_error);
+  wrap_filtercat();
+}

--- a/Code/GraphMol/FilterCatalog/Wrap/rdfiltercatalog.h
+++ b/Code/GraphMol/FilterCatalog/Wrap/rdfiltercatalog.h
@@ -1,0 +1,38 @@
+//  Copyright (c) 2015, Novartis Institutes for BioMedical Research Inc.
+//  All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+//       copyright notice, this list of conditions and the following
+//       disclaimer in the documentation and/or other materials provided
+//       with the distribution.
+//     * Neither the name of Novartis Institutes for BioMedical Research Inc.
+//       nor the names of its contributors may be used to endorse or promote
+//       products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+#ifndef _RDFILTERCAT_INCL_
+#define _RDFILTERCAT_INCL_
+
+#define PY_ARRAY_UNIQUE_SYMBOL rdfiltercat_array_API
+#include <RDBoost/Wrap.h>
+
+
+
+#endif

--- a/Code/GraphMol/FilterCatalog/Wrap/rough_test.py
+++ b/Code/GraphMol/FilterCatalog/Wrap/rough_test.py
@@ -1,0 +1,361 @@
+# $Id$
+#
+#  Copyright (C) 2015  Novartis Institute of BioMedical Research
+#         All Rights Reserved
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above
+#       copyright notice, this list of conditions and the following
+#       disclaimer in the documentation and/or other materials provided
+#       with the distribution.
+#     * Neither the name of Novartis Institutes for BioMedical Research Inc.
+#       nor the names of its contributors may be used to endorse or promote
+#       products derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+""" This is a rough coverage test of the python wrapper for FilterCatalogs
+
+it is intended to be shallow but broad.
+"""
+
+from __future__ import print_function
+import unittest,os
+from rdkit.six.moves import cPickle
+from rdkit import RDConfig
+from rdkit.RDLogger import logger
+logger=logger()
+from rdkit import Chem
+from rdkit.Chem import FilterCatalog, rdMolDescriptors
+from rdkit.Chem.FilterCatalog import FilterCatalogParams
+from rdkit.Chem.FilterCatalog import FilterMatchOps
+from rdkit import DataStructs
+
+class TestCase(unittest.TestCase):
+    def setUp(self):
+        pass
+
+    def test0FilterCatalogEntry(self):
+        matcher = FilterCatalog.SmartsMatcher("Aromatic carbon chain")
+        self.assertTrue(not matcher.IsValid())
+
+        pat = Chem.MolFromSmarts("c:c:c:c:c")
+        matcher.SetPattern(pat)
+        matcher.SetMinCount(1)
+        
+        entry = FilterCatalog.FilterCatalogEntry("Bar", matcher)
+        if FilterCatalog.FilterCatalogCanSerialize():
+            pickle = entry.Serialize()
+        else:
+            pickle = None
+
+
+        self.assertTrue(entry.GetDescription() == "Bar")
+        self.assertTrue(matcher.GetMinCount() == 1)
+        self.assertTrue(matcher.GetMaxCount() == 2**32-1)
+        self.assertTrue(matcher.IsValid())
+
+        entry.SetDescription("Foo")
+        self.assertTrue(entry.GetDescription() == "Foo")
+
+        mol = Chem.MolFromSmiles("c1ccccc1")
+        self.assertTrue(matcher.HasMatch(mol))
+
+
+        matcher = FilterCatalog.SmartsMatcher(pat)
+        self.assertEqual(str(matcher), "Unnamed SmartsMatcher")
+        self.assertTrue(matcher.GetMinCount() == 1)
+        self.assertTrue(matcher.HasMatch(mol))
+        matches = matcher.GetMatches(mol)
+
+        matcher = FilterCatalog.ExclusionList()
+        matcher.SetExclusionPatterns([matcher])
+        self.assertTrue(not matcher.HasMatch(mol))
+        
+        #pat = Chem.MolFromSmarts("c:c:c:c:c")
+        #entry.SetOnPattern(pat)
+        #entry.SetOffPatterns([pat,pat,pat])
+        #self.assertTrue(not entry.HasMatch(pat))
+
+    def test1FilterMatchOps(self):
+        mol = Chem.MolFromSmiles("c1ccccc1")
+
+        pat = Chem.MolFromSmarts("c:c:c:c:c")
+        matcher = FilterCatalog.SmartsMatcher("Five aromatic carbons", pat)
+        self.assertTrue(matcher.GetMinCount() == 1)
+        self.assertTrue(matcher.HasMatch(mol))
+        matches = matcher.GetMatches(mol)
+
+        matcher2 = FilterCatalog.ExclusionList()
+        matcher2.SetExclusionPatterns([matcher])
+        self.assertTrue(not matcher2.HasMatch(mol))
+
+
+        and_match = FilterMatchOps.And(matcher, matcher2)
+        self.assertTrue(not and_match.HasMatch(mol))
+        not_match = FilterMatchOps.Not(and_match)
+        self.assertTrue(not_match.HasMatch(mol))
+        or_match = FilterMatchOps.Or(matcher, matcher2)
+        self.assertTrue(or_match.HasMatch(mol))
+
+        print(and_match)
+        print(or_match)
+        print(not_match)
+        
+
+    def test2FilterCatalogTest(self):
+        tests = ((FilterCatalogParams.FilterCatalogs.PAINS_A, 19),
+                 (FilterCatalogParams.FilterCatalogs.PAINS_B, 55),
+                 (FilterCatalogParams.FilterCatalogs.PAINS_C, 409),
+                 (FilterCatalogParams.FilterCatalogs.PAINS, 409+19+55))
+
+        
+        for catalog_idx, num in tests:
+            params = FilterCatalog.FilterCatalogParams()
+            print ("*"*44)
+            print ("Testing:", catalog_idx, int(catalog_idx))
+            self.assertTrue(params.AddCatalog(catalog_idx))
+            catalog1 = FilterCatalog.FilterCatalog(params)
+
+            if FilterCatalog.FilterCatalogCanSerialize():
+                pickle = catalog1.Serialize();
+                catalog2 = FilterCatalog.FilterCatalog(pickle)
+                catalogs = [catalog1, catalog2]
+            else:
+                catalogs = [catalog1]
+                
+            for index,catalog in enumerate(catalogs):
+                self.assertEqual(catalog.GetNumEntries(),num)
+
+                if catalog_idx in [FilterCatalogParams.FilterCatalogs.PAINS_A,
+                                   FilterCatalogParams.FilterCatalogs.PAINS]:
+                    # http://chemistrycompass.com/chemsearch/58909/
+                    mol = Chem.MolFromSmiles("O=C(Cn1cnc2c1c(=O)n(C)c(=O)n2C)N/N=C/c1c(O)ccc2c1cccc2")
+                    entry = catalog.GetFirstMatch(mol)
+                    for key in entry.GetPropList():
+                        if key == "Reference":
+                            self.assertEquals(entry.GetProp(key),
+                                              "Baell JB, Holloway GA. New Substructure Filters for "
+                                              "Removal of Pan Assay Interference Compounds (PAINS) "
+                                              "from Screening Libraries and for Their Exclusion in "
+                                              "Bioassays. J Med Chem 53 (2010) 2719D40. "
+                                              "doi:10.1021/jm901137j.")
+                        elif key == "Scope":
+                            self.assertEquals(entry.GetProp(key), "PAINS filters (family A)")
+                            
+                    self.assertEqual(entry.GetDescription(),"hzone_phenol_A(479)")
+                    result = catalog.GetMatches(mol)
+                    self.assertEquals(len(result), 1)
+                    
+                    for entry in result:
+                        for filtermatch in entry.GetFilterMatches(mol):
+                            self.assertEquals(str(filtermatch.filterMatch), "hzone_phenol_A(479)")
+                            atomPairs = [tuple(x) for x in filtermatch.atomPairs]
+                            self.assertEquals(atomPairs,
+                                              [(0, 23), (1, 22),
+                                               (2, 20), (3, 19),
+                                               (4, 25), (5, 24),
+                                               (6, 18), (7, 17),
+                                               (8, 16), (9, 21)])
+                            
+                elif catalog_idx == FilterCatalogParams.FilterCatalogs.PAINS_B:
+                    mol = Chem.MolFromSmiles("FC(F)(F)Oc1ccc(NN=C(C#N)C#N)cc1") # CHEMBL457504
+                    entry = catalog.GetFirstMatch(mol)
+                    self.assertTrue(entry)
+                    self.assertEquals(entry.GetDescription(), "cyano_imine_B(17)")
+
+                elif catalog_idx == FilterCatalogParams.FilterCatalogs.PAINS_C:
+                    mol = Chem.MolFromSmiles("O=C1C2OC2C(=O)c3cc4CCCCc4cc13") # CHEMBL476649
+                    entry = catalog.GetFirstMatch(mol)
+                    self.assertTrue(entry)
+                    self.assertEquals(entry.GetDescription(), "keto_keto_gamma(5)")
+
+
+    def test3ExclusionFilter(self):
+        mol = Chem.MolFromSmiles("c1ccccc1")
+
+        pat = Chem.MolFromSmarts("c:c:c:c:c")
+        matcher = FilterCatalog.SmartsMatcher("Five aromatic carbons", pat)
+        self.assertTrue(matcher.GetMinCount() == 1)
+        self.assertTrue(matcher.HasMatch(mol))
+        matches = matcher.GetMatches(mol)
+
+        exclusionFilter = FilterCatalog.ExclusionList()
+        exclusionFilter.AddPattern(matcher)
+        self.assertFalse(exclusionFilter.HasMatch(mol))
+        
+        matches2 = exclusionFilter.GetMatches(mol)
+
+        self.assertTrue(matches)
+        self.assertFalse(matches2)
+
+    def test4CountTests(self):
+        matcher = FilterCatalog.SmartsMatcher("Carbon", "[#6]", 0, 2)
+        m = Chem.MolFromSmiles("N")
+        self.assertTrue(matcher.HasMatch(m))
+        m = Chem.MolFromSmiles("C")
+        self.assertTrue(matcher.HasMatch(m))
+        m = Chem.MolFromSmiles("CC")
+        self.assertTrue(matcher.HasMatch(m))
+        m = Chem.MolFromSmiles("CCC")
+        self.assertFalse(matcher.HasMatch(m))
+
+        matcher = FilterCatalog.SmartsMatcher("Carbon", "[#6]", 1, 2)
+        m = Chem.MolFromSmiles("N")
+        self.assertFalse(matcher.HasMatch(m))
+
+        
+    def testZinc(self):
+        params = FilterCatalog.FilterCatalogParams(FilterCatalogParams.FilterCatalogs.ZINC)
+        catalog = FilterCatalog.FilterCatalog(params)
+        self.assertTrue(catalog.GetNumEntries())
+
+        m = Chem.MolFromSmiles("C"*41)
+        entry = catalog.GetFirstMatch(m)
+        self.assertTrue(entry.GetDescription(), "Non-Hydrogen_atoms")
+
+        m = Chem.MolFromSmiles("CN"*20)
+        entry = catalog.GetFirstMatch(m)
+        self.assertEquals(catalog.GetFirstMatch(m), None)
+        
+    def testSmartsMatcherAPI(self):
+        sm = FilterCatalog.SmartsMatcher("Too many carbons", "[#6]", 40+1)
+        sm2 = FilterCatalog.SmartsMatcher("ok # carbons", "[#6]", 0, 40)
+        sm3 = FilterCatalog.FilterMatchOps.Not(sm2)
+        
+        m = Chem.MolFromSmiles("C"*40)
+        self.assertFalse(sm.HasMatch(m))
+        self.assertTrue(sm2.HasMatch(m))
+        self.assertFalse(sm3.HasMatch(m))
+        
+        m = Chem.MolFromSmiles("C"*41)
+        self.assertTrue(sm.HasMatch(m))
+        self.assertFalse(sm2.HasMatch(m))
+        self.assertTrue(sm3.HasMatch(m))
+
+    def testAddEntry(self):
+        sm = FilterCatalog.SmartsMatcher("Too many carbons", "[#6]", 40+1)
+        entry = FilterCatalog.FilterCatalogEntry("Bar", sm)
+        fc = FilterCatalog.FilterCatalog()
+        fc.AddEntry(entry)
+        del entry
+        del fc
+
+    def testRemoveEntry(self):
+        params = FilterCatalog.FilterCatalogParams(FilterCatalogParams.FilterCatalogs.ZINC)
+        catalog = FilterCatalog.FilterCatalog(params)
+        entry = catalog.GetEntryWithIdx(10)
+        desc = entry.GetDescription()
+        count = 0
+        descs = set( [ catalog.GetEntryWithIdx(i).GetDescription()
+                       for i in range (catalog.GetNumEntries())])
+        for i in range(catalog.GetNumEntries()):
+            if catalog.GetEntryWithIdx(i).GetDescription() == desc:
+                count += 1
+        print ("Count", count)
+        sz = catalog.GetNumEntries()
+        print ("*"*44)
+        print (dir(catalog))
+        self.assertTrue(catalog.RemoveEntry(entry))
+        del entry
+        self.assertTrue(catalog.GetNumEntries() == sz-1)
+
+        descs2 = set( [ catalog.GetEntryWithIdx(i).GetDescription()
+                        for i in range(catalog.GetNumEntries())])
+        print (descs - descs2)
+
+        newcount = 0
+        for i in range(catalog.GetNumEntries()):
+            if catalog.GetEntryWithIdx(i).GetDescription() == desc:
+                newcount += 1
+        self.assertEquals(count, newcount+1)
+        
+
+    def testPyFilter(self):
+        class MyFilterMatcher(FilterCatalog.FilterMatcher):
+            def IsValid(self):
+                return True
+
+            def HasMatch(self, mol):
+                return True
+            
+            def GetMatches(self, mol, vect):
+                v = FilterCatalog.MatchTypeVect()
+                v.append(FilterCatalog.IntPair(1,1))
+                match = FilterCatalog.FilterMatch(self,v)
+                vect.append(match)
+                return True
+
+        func = MyFilterMatcher("FilterMatcher")
+        self.assertEquals(func.GetName(), "FilterMatcher")
+        mol = Chem.MolFromSmiles("c1ccccc1")
+        self.assertEquals(func.HasMatch(mol), True)
+
+        or_match = FilterMatchOps.Or(func, func)
+        self.assertEquals( [[tuple(x) for x in filtermatch.atomPairs]
+                          for filtermatch in or_match.GetMatches(mol)],
+                           [[(1,1)],[(1,1)]])
+
+
+        not_match = FilterMatchOps.Not(func)
+        print(not_match)
+        self.assertEquals(not_match.HasMatch(mol), False)
+        # test memory
+        del func
+        
+        self.assertEquals(not_match.HasMatch(mol), False)
+        self.assertEquals( [[tuple(x) for x in filtermatch.atomPairs]
+                          for filtermatch in not_match.GetMatches(mol)],
+                           [])
+
+
+        entry = FilterCatalog.FilterCatalogEntry("Bar", MyFilterMatcher("FilterMatcher"))
+        fc = FilterCatalog.FilterCatalog()
+        fc.AddEntry(entry)
+
+        catalogEntry = fc.GetFirstMatch(mol)
+        print (catalogEntry.GetDescription())
+
+    def testMWFilter(self):
+        class MWFilter(FilterCatalog.FilterMatcher):
+            def __init__(self, minMw, maxMw):
+                FilterCatalog.FilterMatcher.__init__(self, "MW violation")
+                self.minMw = minMw
+                self.maxMw = maxMw
+
+            def IsValid(self):
+                return True
+
+            def HasMatch(self, mol):
+                mw = rdMolDescriptors.CalcExactMolWt(mol)
+                return not self.minMw <= mw <= self.maxMw
+
+        entry = FilterCatalog.FilterCatalogEntry("MW Violation", MWFilter(100,500))
+        fc = FilterCatalog.FilterCatalog()
+        fc.AddEntry(entry)
+        self.assertTrue(entry.GetDescription() == "MW Violation")
+
+        mol = Chem.MolFromSmiles("c1ccccc1")
+        catalogEntry = fc.GetFirstMatch(mol)
+
+
+
+        
+if __name__ == '__main__':
+    unittest.main()

--- a/Code/GraphMol/FilterCatalog/Wrap/test_list.py
+++ b/Code/GraphMol/FilterCatalog/Wrap/test_list.py
@@ -1,0 +1,14 @@
+
+tests=[
+  ("python","rough_test.py",{})
+  ]
+
+
+
+longTests=[]
+
+if __name__=='__main__':
+  import sys
+  from rdkit import TestRunner
+  failed,tests = TestRunner.RunScript('test_list.py',0,1)
+  sys.exit(len(failed))

--- a/Code/GraphMol/FilterCatalog/filtercatalogtest.cpp
+++ b/Code/GraphMol/FilterCatalog/filtercatalogtest.cpp
@@ -1,0 +1,138 @@
+//  Copyright (c) 2015, Novartis Institutes for BioMedical Research Inc.
+//  All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+//       copyright notice, this list of conditions and the following
+//       disclaimer in the documentation and/or other materials provided
+//       with the distribution.
+//     * Neither the name of Novartis Institutes for BioMedical Research Inc.
+//       nor the names of its contributors may be used to endorse or promote
+//       products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+#include <RDGeneral/RDLog.h>
+#include <GraphMol/RDKitBase.h>
+#include <GraphMol/FileParsers/MolSupplier.h>
+#include <GraphMol/FilterCatalog/FilterCatalog.h>
+
+#include <iostream>
+#include <map>
+#include <algorithm>
+#include <boost/foreach.hpp>
+
+
+using namespace RDKit;
+using namespace std;
+
+struct IntPair {
+  int first;
+  int second;
+};
+
+bool check(MatchVectType v, const IntPair *match) {
+  for (size_t i=0; i<v.size(); ++i) {
+    if (v[i].first != match[i].first) return false;
+    if (v[i].second != match[i].second) return false;
+  }
+  return true;
+}
+  
+
+void testFilterCatalog() {
+  BOOST_LOG(rdInfoLog) << "-----------------------\n Testing sf.net issue 2313979: aromaticity assignment hangs " << std::endl;
+  {
+    std::string pathName=getenv("RDBASE");
+    pathName += "/Code/GraphMol/test_data/";
+    SmilesMolSupplier suppl(pathName+"pains.smi");
+
+    FilterCatalogParams params;
+    params.addCatalog(FilterCatalogParams::PAINS_A);
+    params.addCatalog(FilterCatalogParams::PAINS_B);
+    params.addCatalog(FilterCatalogParams::PAINS_C);
+    
+    FilterCatalog catalog(params);
+    boost::scoped_ptr<ROMol> mol;
+    const IntPair match1[] = {{0,23},{1,22},{2,20},{3,19},{4,25},{5,24},
+                              {6,18},{7,17},{8,16},{9,21}};
+    const IntPair match2[] = {{0,13},{1,12},{2,11},{3,14},{4,15},{5,10},
+                              {6,9},{7,8},{8,7},{9,6},{10,5},{11,17},{12,16}};
+    const IntPair match3[] = {{0,0},{1,1},{2,2},{3,4},{4,5},{5,6},{6,7},
+                              {7,8},{8,9},{9,14},{10,15},{11,16}};
+    int count = 0;
+    while(!suppl.atEnd()){
+      mol.reset(suppl.next());
+      std::string name = mol->getProp<std::string>(common_properties::_Name);
+
+      TEST_ASSERT(mol.get());
+      if (catalog.hasMatch(*mol)) {
+        std::cerr << "Warning: molecule failed filter " << std::endl;
+      }
+      // More detailed
+      FilterCatalog::CONST_SENTRY entry = catalog.getFirstMatch(*mol);
+      if (entry) {
+        std::cerr << "Warning: molecule failed filter: reason " <<
+          entry->getDescription() << std::endl;
+        switch(count) {
+        case 0: TEST_ASSERT(entry->getDescription() == "hzone_phenol_A(479)"); break;
+        case 1: TEST_ASSERT(entry->getDescription() == "cyano_imine_B(17)"); break;
+        case 2: TEST_ASSERT(entry->getDescription() == "keto_keto_gamma(5)"); break;
+        }
+        TEST_ASSERT(entry->getDescription() == name);
+        
+        // get the substructure atoms for visualization
+        std::vector<FilterMatch> matches;
+        if (entry->getFilterMatches(*mol, matches)) {
+          for(std::vector<FilterMatch>::const_iterator it = matches.begin();
+              it != matches.end(); ++it) {
+            // Get the FilterMatcherBase that matched
+            const FilterMatch & fm = (*it);
+            boost::shared_ptr<FilterMatcherBase> matchingFilter =       \
+              fm.filterMatch;
+            
+            // Get the matching atom indices
+            const MatchVectType &vect = fm.atomPairs;
+            switch(count) {
+            case 0: TEST_ASSERT(check(vect, &match1[0])); break;
+            case 1: TEST_ASSERT(check(vect, &match2[0])); break;
+            case 2: TEST_ASSERT(check(vect, &match3[0])); break;
+            }
+              
+            // do something with these...
+          }
+        }
+      }
+      count ++;
+    } // end while
+  }
+  BOOST_LOG(rdInfoLog) << "Finished" << std::endl;
+}
+  
+
+int main(){
+  RDLog::InitLogs();
+  //boost::logging::enable_logs("rdApp.debug");
+
+
+  testFilterCatalog();
+
+  return 0;
+}
+
+

--- a/Code/GraphMol/FilterCatalog/filtercatlogtest.cpp
+++ b/Code/GraphMol/FilterCatalog/filtercatlogtest.cpp
@@ -1,0 +1,106 @@
+//  $Id$
+// 
+//   Copyright (C) 2002-2013 Greg Landrum and Rational Discovery LLC
+//
+//   @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
+//
+#include <RDGeneral/RDLog.h>
+#include <GraphMol/RDKitBase.h>
+#include <GraphMol/FileParsers/MolSupplier.h>
+#include <GraphMol/FilterCatalog/FilterCatalog.h>
+
+#include <iostream>
+#include <map>
+#include <algorithm>
+#include <boost/foreach.hpp>
+
+
+#ifndef M_PI
+#define M_PI           3.14159265358979323846
+#endif
+
+using namespace RDKit;
+using namespace std;
+RWMol _t;
+typedef class ROMol Mol;
+
+void testFilterCatalog() {
+  BOOST_LOG(rdInfoLog) << "-----------------------\n Testing sf.net issue 2313979: aromaticity assignment hangs " << std::endl;
+  {
+    std::string pathName=getenv("RDBASE");
+    pathName += "/Code/GraphMol/test_data/";
+    SmilesMolSupplier suppl(pathName+"pains.smi");
+
+    FilterCatalogParams params;
+    params.addCatalog(FilterCatalogParams::PAINS_A);
+    params.addCatalog(FilterCatalogParams::PAINS_B);
+    params.addCatalog(FilterCatalogParams::PAINS_C);
+    
+    FilterCatalog catalog(params);
+    boost::scoped_ptr<ROMol> mol;
+    const IntPair match1[] = {{0,23},{1,22},{2,20},{3,19},{4,25},{5,24},
+                              {6,18},{7,17},{8,16},{9,21}};
+    const IntPair match2[] = {{0,13},{1,12},{2,11},{3,14},{4,15},{5,10},
+                              {6,9},{7,8},{8,7},{9,6},{10,5},{11,17},{12,16}};
+    const IntPair match3[] = {{0,0},{1,1},{2,2},{3,4},{4,5},{5,6},{6,7},
+                              {7,8},{8,9},{9,14},{10,15},{11,16}};
+    int count = 0;
+    while(!suppl.atEnd()){
+      mol.reset(suppl.next());
+      std::string name = mol->getProp<std::string>(common_properties::_Name);
+
+      TEST_ASSERT(mol.get());
+      if (catalog.hasMatch(*mol)) {
+        std::cerr << "Warning: molecule failed filter " << std::endl;
+      }
+      // More detailed
+      FilterCatalog::CONST_SENTRY entry = catalog.getFirstMatch(*mol);
+      if (entry) {
+        std::cerr << "Warning: molecule failed filter: reason " <<
+          entry->getDescription() << std::endl;
+        TEST_ASSERT(entry->getDescription() == name);
+        
+        // get the substructure atoms for visualization
+        std::vector<FilterMatch> matches;
+        if (entry->getFilterMatches(*mol, matches)) {
+          for(std::vector<FilterMatch>::const_iterator it = matches.begin();
+              it != matches.end(); ++it) {
+            // Get the FilterMatcherBase that matched
+            const FilterMatch & fm = (*it);
+            boost::shared_ptr<FilterMatcherBase> matchingFilter =       \
+              fm.filterMatch;
+            
+            // Get the matching atom indices
+            const MatchVectType &vect = fm.atomPairs;
+            switch(count) {
+            case 0: TEST_ASSERT(check(vect, &match1[0])); break;
+            case 1: TEST_ASSERT(check(vect, &match2[0])); break;
+            case 2: TEST_ASSERT(check(vect, &match3[0])); break;
+            }
+              
+            // do something with these...
+          }
+        }
+      }
+      count ++;
+    } // end while
+  }
+  BOOST_LOG(rdInfoLog) << "Finished" << std::endl;
+}
+  
+
+int main(){
+  RDLog::InitLogs();
+  //boost::logging::enable_logs("rdApp.debug");
+
+
+  testFilterCatalog();
+
+  return 0;
+}
+
+

--- a/Code/GraphMol/test_data/pains.smi
+++ b/Code/GraphMol/test_data/pains.smi
@@ -1,0 +1,4 @@
+Smiles PainsMatch Source
+O=C(Cn1cnc2c1c(=O)n(C)c(=O)n2C)N/N=C/c1c(O)ccc2c1cccc2 hzone_phenol_A(479)  http://chemistrycompass.com/chemsearch/58909/ 
+FC(F)(F)Oc1ccc(NN=C(C#N)C#N)cc1 cyano_imine_B(17) CHEMBL457504 
+O=C1C2OC2C(=O)c3cc4CCCCc4cc13 keto_keto_gamma(5) CHEMBL476649 

--- a/rdkit/Chem/FilterCatalog.py
+++ b/rdkit/Chem/FilterCatalog.py
@@ -1,0 +1,66 @@
+#  Copyright (C) 2015 Novartis Institute for BioMedical Research
+#
+#   @@ All Rights Reserved @@
+#  This file is part of the RDKit.
+#  The contents are covered by the terms of the BSD license
+#  which is included in the file license.txt, found at the root
+#  of the RDKit source tree.
+#
+import sys
+
+from rdkit import Chem
+from rdkit.Chem.rdfiltercatalog import *
+
+class FilterMatcher(PythonFilterMatcher):
+    """FilterMatcher - This class allows creation of Python based
+    filters.  Subclass this class to create a Filter useable
+    in a FilterCatalogEntry
+
+    Simple Example:
+
+    from rdkit.Chem import rdMolDescriptors
+    class MWFilter(FilterMatcher):
+      def __init__(self, minMw, maxMw):
+          FilterMatcher.__init__(self, "MW violation")
+          self.minMw = minMw
+          self.maxMw = maxMw
+
+      def IsValid(self):
+         return True
+
+      def HasMatch(self, mol):
+         mw = rdMolDescriptors.CalcExactMolWt(mol)
+         return not self.minMw <= mw <= self.maxMw
+    """
+    def __init__(self, name="Unamed FilterMatcher"):
+        self.name = name
+        PythonFilterMatcher.__init__(self, self)
+
+    def HasMatch(self, mol):
+        """Return True if the filter matches the molecule"""
+        raise NotImplementedError("Need to implement HasMatch(mol) in a subclass of %s",
+                                  self.__class__.__name__)
+
+    def GetMatches(self, mol, matchVect):
+        """GetMatches(mol, matchVect) -> returns True if the filter matches
+        (By default, this calls HasMatch and does not modify matchVect)
+        
+        matchVect is a vector of FilterMatch's which hold the matching
+        filter and the matched query_atom, mol_atom pairs if applicable.
+        To append to this vector:
+        v = MatchTypeVect()
+        v.append(IntPair( query_atom_idx, mol_atom_idx ) )
+        match = FilterMatch(self, v)
+        matchVect.append( match )
+        """
+        return self.HasMatch(mol)
+
+    def IsValid(self, mol):
+        """Must override this function"""
+        raise NotImplementedError("IsValid must be implemented in a subclass of %s",
+                                  self.__class__.__name__)
+
+    def GetName(self):
+        return self.name
+
+    


### PR DESCRIPTION
FilterCatalogs give RDKit the ability to screen out or reject 
undesirable molecules based on various criteria.  Supplied 
with RDKIt are the following filter sets:

  * PAINS - Pan assay interference patterns.  
    These are separated into three sets PAINS_A, PAINS_B and PAINS_C.
    Reference: Baell JB, Holloway GA. New Substructure Filters for 
               Removal of Pan Assay Interference Compounds (PAINS) 
               from Screening Libraries and for Their Exclusion in 
               Bioassays.
               J Med Chem 53 (2010) 2719Ð40. doi:10.1021/jm901137j.

  * BRENK - filters unwanted functionality due to potential tox reasons 
            or unfavorable pharmacokinetics.
    Reference: Brenk R et al. Lessons Learnt from Assembling Screening 
               Libraries for Drug Discovery for Neglected Diseases.
               ChemMedChem 3 (2008) 435-444. doi:10.1002/cmdc.200700139.

  * NIH - annotated compounds with problematic functional groups
     Reference: Doveston R, et al. A Unified Lead-oriented Synthesis of 
                over Fifty Molecular Scaffolds. Org Biomol Chem 13 
                (2014) 859Ð65.
                doi:10.1039/C4OB02287D.
     Reference: Jadhav A, et al. Quantitative Analyses of Aggregation, 
                Autofluorescence, and Reactivity Artifacts in a Screen 
                for Inhibitors of a Thiol Protease.
                J Med Chem 53 (2009) 37Ð51. doi:10.1021/jm901070c.

  * ZINC - Filtering based on drug-likeness and unwanted functional 
           groups
    Reference: http://blaster.docking.org/filtering/

The following is C++ and Python examples of how to filter molecules.

[C++]

#include <GraphMol/FilterCatalog.h>
using namespace RDKit;

    SmilesMolSupplier suppl(…);

    // setup the desired catalogs
    FilterCatalogParams params;
    params.addCatalog(FilterCatalogParams::PAINS_A);
    params.addCatalog(FilterCatalogParams::PAINS_B);
    params.addCatalog(FilterCatalogParams::PAINS_C);
    
    // create the catalog
    FilterCatalog catalog(params);

    unique_ptr<ROMol> mol; // automatically cleans up after us    
    int count = 0;
    while(!suppl.atEnd()){
      mol.reset(suppl.next());
      TEST_ASSERT(mol.get());

      // Does a PAINS filter hit?
      if (catalog.hasMatch(*mol)) {
        std::cerr << "Warning: molecule failed filter " << std::endl;
      }
      
      // More detailed data by retrieving the catalog entry
      const FilterCatalogEntry *entry = catalog.getFirstMatch(*mol);
      if (entry) {
        std::cerr << "Warning: molecule failed filter: reason " <<
          entry->getDescription() << std::endl;
        
        // get the matched substructure atoms for visualization
        std::vector<FilterMatch> matches;
        if (entry->getFilterMatches(*mol, matches)) {
          for(std::vector<FilterMatch>::const_iterator it = matches.begin();
              it != matches.end(); ++it) {
            // Get the SmartsMatcherBase that matched
            const FilterMatch & fm = (*it);
            boost::shared_ptr<SmartsMatcherBase> matchingFilter = \
              fm.filterMatch;
            
            // Get the matching atom indices
            const MatchVectType &vect = fm.atomPairs;
            for (MatchVectType::const_iterator it=vect.begin();
                 it != vect.end(); ++it) {
                 int atomIdx = it->second;
            }

          }
        }
      }
      count ++;
    } // end while

Python API

  import sys
  from rdkit.Chem import FilterCatalog

  params = FilterCatalog.FilterCatalogParams()
  params.AddCatalog(FilterCatalogParams.FilterCatalogs.PAINS_A)
  params.AddCatalog(FilterCatalogParams.FilterCatalogs.PAINS_B)
  params.AddCatalog(FilterCatalogParams.FilterCatalogs.PAINS_C)
  catalog = FilterCatalog.FilterCatalog(params)
  
  ...
  for mol in mols:
      if catalog.HasMatch(mol):
         print("Warning: molecule failed filter", file=sys.stderr)
      # more detailed
      entry = catalog.GetFirstMatch(mol)
      if entry:
         print("Warning: molecule failed filter: reason %s"%(
           entry.GetDescription()), file=sys.stderr)
           
         # get to the atoms involved in the substructure
         #  there ma be many matching filters here...
         for filterMatch in entry.getFilterMatches(mol):
             filter = filterMatch.filterMatch
             # get a description of the matching filter
             print(filter)
             for queryAtomIdx, atomIdx in filterMatch.atomPairs:
                 # do something with the substructure matches

Advanced

 FilterCatalogs are fully serializable and can be stored for later use.

  To serialize a catalog, use the catalog.Serialize() method.
     std::string pickle = catalog.Serialize();
     
  To unserialize, send the resulting string into the constructor
     FilterCatalog catalog(pickle);


 The underlying matchers can be arbitrarily complicated and new
  ones with more complicated semantics can be created.  The default
  matching objects are:

  SmartsMatcher - match a smarts pattern or query molecule with a minimum 
                  and maximum count
  ExclusionList - returns false if any of the supplied matches exist

  And - combine two matchers
  Or  - true if any of two matchers are true
  Not - invert the match (note that this can have confusing semantics
          when dealing with substructure matches)

  Entries can be added at any time to a catalog:
  
   ExclusionList excludedList;   

    excludedList.addPattern(SmartsMatcher("Pattern 1", smarts)); 
    excludedList.addPattern(SmartsMatcher("Pattern 2", smarts2)); 
   

  A FilterCatalog supports a few different types of matching.  One is
  a traditional rejection filter where if a substructure exists in
  the target molecule, the molecule is rejected.

  These types of queries can indicate the substructure that triggered
  the rejection through the FilterCatalogEntry::GetMatch(mol)
  function.

  The FilterCatalog also supports acceptance filters, that are
  designed to indicate which molecules are ok.  These have
  to be transformed into rejection filters or simply wrapped in a 
  Not( acceptanceFilter ) when entered into the catalog.  For example, 
   from Zinc:

    carbons [#6] 40

  means that we have a maximum of 40 carbon atoms.  We can write this by
  converting the max count to a min count (i.e. the pattern is triggered
  when the molecule has mincount atoms);

    const unsigned int minCount = 40+1;
    SmartsMatcher( "Too many carbons", "[#6"], minCount );

  This can be properly substructure searched.

  Or we can wrap this in a not:
  
    const unsigned int minCount = 0;
    const unsigned int maxCount = 40;
    Not( SmartsMatcher( "ok number of carbons", "[#6]", minCount, maxCount) );

  Note: Wrapping in a Not loses the ability to highlight the rejecting
    pattern when visualizing the molecule.