### PR TITLE
Catalog::setCatalogParams needs to be virtual now

### DIFF
--- a/Code/Catalogs/Catalog.h
+++ b/Code/Catalogs/Catalog.h
@@ -81,7 +81,7 @@ namespace RDCatalog {
     
     //------------------------------------
     //! sets our parameters by copying the \c params argument
-    void setCatalogParams(paramType *params) {
+    virtual void setCatalogParams(paramType *params) {
       PRECONDITION(params,"bad parameter object");
       //if we already have a paramter object throw an exception
       PRECONDITION(!dp_cParams,"A parameter object already exists on the catalog" );


### PR DESCRIPTION
Because setCatalogParams is overloaded in the derived classes, it needs to be virtual to have the same effect as before (i.e. resetting the parameters properly)