### PR TITLE
changed sascorer.py to enable import from different location

### DIFF
--- a/Contrib/SA_Score/sascorer.py
+++ b/Contrib/SA_Score/sascorer.py
@@ -25,10 +25,15 @@ from rdkit.six import iteritems
 import math
 from collections import defaultdict
 
+import os.path as op
+
 _fscores = None
 def readFragmentScores(name='fpscores'):
     import gzip
     global _fscores
+    # generate the full path filename:
+    if name == "fpscores":
+        name = op.join(op.dirname(__file__), name)
     _fscores = cPickle.load(gzip.open('%s.pkl.gz'%name))
     outDict = {}
     for i in _fscores:
@@ -49,7 +54,6 @@ def numBridgeheadsAndSpiro(mol,ri=None):
   nSpiro=len(spiros)
 
   # find bonds that are shared between rings that share at least 2 bonds:
-  nBridge=0
   brings = [set(x) for x in ri.BondRings()]
   bridges=set()
   for i,bri in enumerate(brings):
@@ -130,7 +134,6 @@ def calculateScore(m):
 def processMols(mols,outf):
   
   print('smiles\tName\tsa_score')
-  count = {}
   for i,m in enumerate(mols):
     if m is None:
       continue


### PR DESCRIPTION
Wow, just discovered the awesome Synthetic Accessibility Scorer.
It seems that one can discover an awesome new feature in RDKit every day.
I changed the file path for fpscores.pkl.gz in sascorer.py so that sascorer can be imported from different locations (assuming that you have Contrib somewhere in your Python import path). Also removed some unused vars.
One question: in sascorer.processMols(mols,outf), the outf parameter is not used in the function.
Should I fix this?
Kind regards,
Axel