### PR TITLE
Automatic atom reordering in TorsionFingerprints

### DIFF
--- a/Contrib/NP_Score/npscorer.py
+++ b/Contrib/NP_Score/npscorer.py
@@ -23,7 +23,7 @@ def readNPModel(filename='publicnp.model.gz'):
   sys.stderr.write("model in\n")
   return fscore
 
-def scoreMol(mol):
+def scoreMol(mol,fscore):
   if mol is None:
       raise ValueError('invalid molecule')
   fp = rdMolDescriptors.GetMorganFingerprint(mol,2)
@@ -51,7 +51,7 @@ def processMols(fscore,suppl,outf):
       continue
     
     n += 1
-    score = "%.3f" % scoreMol(m)
+    score = "%.3f" % scoreMol(m,fscore)
 
     smiles = Chem.MolToSmiles(m,True)
     name = m.GetProp('_Name')

--- a/rdkit/Chem/TorsionFingerprints.py
+++ b/rdkit/Chem/TorsionFingerprints.py
@@ -566,7 +566,7 @@ def GetTFDBetweenMolecules(mol1, mol2, confId1=-1, confId2=-1, useWeights=True, 
                              if False, alternative not-covalently bound
                              atoms are used to define the torsion
 
-      Return: list of TFD values
+      Return: TFD value
   """
   if (Chem.MolToSmiles(mol1) != Chem.MolToSmiles(mol2)):
     raise ValueError("The two molecules must be instances of the same molecule!")

--- a/rdkit/Chem/TorsionFingerprints.py
+++ b/rdkit/Chem/TorsionFingerprints.py
@@ -505,7 +505,7 @@ def _getSameAtomOrder(mol1, mol2):
       cid = mol3.AddConformer(conf)
     return mol3
   else:
-    return mol2
+    return Chem.Mol(mol2)
 
 # some wrapper functions
 def GetTFDBetweenConformers(mol, confIds1, confIds2, useWeights=True, maxDev='equal', symmRadius=2, ignoreColinearBonds=True):

--- a/rdkit/Chem/TorsionFingerprints.py
+++ b/rdkit/Chem/TorsionFingerprints.py
@@ -570,9 +570,7 @@ def GetTFDBetweenMolecules(mol1, mol2, confId1=-1, confId2=-1, useWeights=True, 
   """
   if (Chem.MolToSmiles(mol1) != Chem.MolToSmiles(mol2)):
     raise ValueError("The two molecules must be instances of the same molecule!")
-  print mol2.GetNumConformers()
   mol2 = _getSameAtomOrder(mol1, mol2)
-  print mol2.GetNumConformers()
   tl, tlr = CalculateTorsionLists(mol1, maxDev=maxDev, symmRadius=symmRadius, ignoreColinearBonds=ignoreColinearBonds)
   # first molecule
   torsion1 = CalculateTorsionAngles(mol1, tl, tlr, confId=confId1)

--- a/rdkit/Chem/TorsionFingerprints.py
+++ b/rdkit/Chem/TorsionFingerprints.py
@@ -13,6 +13,7 @@ from rdkit import rdBase
 from rdkit import RDConfig
 from rdkit import Geometry
 from rdkit import Chem
+from rdkit.Chem import rdchem, Draw
 from rdkit.Chem import rdMolDescriptors
 import math, os
 
@@ -450,7 +451,7 @@ def CalculateTFD(torsions1, torsions2, weights=None):
   """ Calculate the torsion deviation fingerprint (TFD) given two lists of
       torsion angles.
 
-      Arguments;
+      Arguments:
       - torsions1:  torsion angles of conformation 1
       - torsions2:  torsion angles of conformation 2
       - weights:    list of torsion weights (default: None)
@@ -478,6 +479,33 @@ def CalculateTFD(torsions1, torsions2, weights=None):
   if sum_weights != 0: # avoid division by zero
     tfd /= sum_weights
   return tfd
+
+def _getSameAtomOrder(mol1, mol2):
+  """ Generate a new molecule with the atom order of mol1 and coordinates
+      from mol2.
+      
+      Arguments:
+      - mol1:     first instance of the molecule of interest
+      - mol2:     second instance the molecule of interest
+
+      Return: RDKit molecule
+  """
+  match = mol2.GetSubstructMatch(mol1)
+  atomNums = tuple(range(mol1.GetNumAtoms()))
+  if match != atomNums: # atom orders are not the same!
+    #print "Atoms of second molecule reordered."
+    mol3 = Chem.Mol(mol1)
+    mol3.RemoveAllConformers()
+    for conf2 in mol2.GetConformers():
+      confId = conf2.GetId()
+      conf = rdchem.Conformer(mol1.GetNumAtoms())
+      conf.SetId(confId)
+      for i in range(mol1.GetNumAtoms()):
+        conf.SetAtomPosition(i, mol2.GetConformer(confId).GetAtomPosition(match[i]))
+      cid = mol3.AddConformer(conf)
+    return mol3
+  else:
+    return mol2
 
 # some wrapper functions
 def GetTFDBetweenConformers(mol, confIds1, confIds2, useWeights=True, maxDev='equal', symmRadius=2, ignoreColinearBonds=True):
@@ -517,16 +545,15 @@ def GetTFDBetweenConformers(mol, confIds1, confIds2, useWeights=True, maxDev='eq
         tfd.append(CalculateTFD(t1, t2))
   return tfd
 
-def GetTFDBetweenMolecules(mol1, mol2, confIds1=-1, confIds2=-1, useWeights=True, maxDev='equal', symmRadius=2, ignoreColinearBonds=True):
-  """ Wrapper to calculate the TFD between two list of conformers 
-      of two molecules.
+def GetTFDBetweenMolecules(mol1, mol2, confId1=-1, confId2=-1, useWeights=True, maxDev='equal', symmRadius=2, ignoreColinearBonds=True):
+  """ Wrapper to calculate the TFD between two molecules.
       Important: The two molecules must be instances of the same molecule
 
       Arguments:
       - mol1:     first instance of the molecule of interest
       - mol2:     second instance the molecule of interest
-      - confIds1:  list of conformer indices from mol1 (default: first conformer)
-      - confIds2:  list of conformer indices from mol2 (default: first conformer)
+      - confId1:  conformer index for mol1 (default: first conformer)
+      - confId2:  conformer index for mol2 (default: first conformer)
       - useWeights: flag for using torsion weights in the TFD calculation
       - maxDev:   maximal deviation used for normalization
                   'equal': all torsions are normalized using 180.0 (default)
@@ -543,27 +570,19 @@ def GetTFDBetweenMolecules(mol1, mol2, confIds1=-1, confIds2=-1, useWeights=True
   """
   if (Chem.MolToSmiles(mol1) != Chem.MolToSmiles(mol2)):
     raise ValueError("The two molecules must be instances of the same molecule!")
+  print mol2.GetNumConformers()
+  mol2 = _getSameAtomOrder(mol1, mol2)
+  print mol2.GetNumConformers()
   tl, tlr = CalculateTorsionLists(mol1, maxDev=maxDev, symmRadius=symmRadius, ignoreColinearBonds=ignoreColinearBonds)
   # first molecule
-  if confIds1 < 0:
-    torsions1 = [CalculateTorsionAngles(mol1, tl, tlr)]
-  else:
-    torsions1 = [CalculateTorsionAngles(mol1, tl, tlr, confId=cid) for cid in confIds1]
+  torsion1 = CalculateTorsionAngles(mol1, tl, tlr, confId=confId1)
   # second molecule
-  if confIds2 < 0:
-    torsions2 = [CalculateTorsionAngles(mol2, tl, tlr)]
-  else:
-    torsions2 = [CalculateTorsionAngles(mol2, tl, tlr, confId=cid) for cid in confIds2]
-  tfd = []
+  torsion2 = CalculateTorsionAngles(mol2, tl, tlr, confId=confId2)
   if useWeights:
     weights = CalculateTorsionWeights(mol1, ignoreColinearBonds=ignoreColinearBonds)
-    for t1 in torsions1:
-      for t2 in torsions2:
-        tfd.append(CalculateTFD(t1, t2, weights=weights))
+    tfd = CalculateTFD(torsion1, torsion2, weights=weights)
   else:
-    for t1 in torsions1:
-      for t2 in torsions2:
-        tfd.append(CalculateTFD(t1, t2))
+    tfd = CalculateTFD(torsion1, torsion2)
   return tfd
 
 def GetTFDMatrix(mol, useWeights=True, maxDev='equal', symmRadius=2, ignoreColinearBonds=True):

--- a/rdkit/Chem/TorsionFingerprints.py
+++ b/rdkit/Chem/TorsionFingerprints.py
@@ -13,7 +13,7 @@ from rdkit import rdBase
 from rdkit import RDConfig
 from rdkit import Geometry
 from rdkit import Chem
-from rdkit.Chem import rdchem, Draw
+from rdkit.Chem import rdchem
 from rdkit.Chem import rdMolDescriptors
 import math, os
 

--- a/rdkit/Chem/UnitTestMol3D.py
+++ b/rdkit/Chem/UnitTestMol3D.py
@@ -91,9 +91,36 @@ class TestCase(unittest.TestCase):
     torsions2 = TorsionFingerprints.CalculateTorsionAngles(mol2, tors_list, tors_list_rings)
     weights = TorsionFingerprints.CalculateTorsionWeights(mol)
     tfd = TorsionFingerprints.CalculateTFD(torsions, torsions2, weights=weights)
-    self.assertAlmostEqual(tfd, 0.0645,4)
+    self.assertAlmostEqual(tfd, 0.0645, 4)
     tfd = TorsionFingerprints.CalculateTFD(torsions, torsions2)
-    self.assertAlmostEqual(tfd, 0.1680,4)
+    self.assertAlmostEqual(tfd, 0.1680, 4)
+
+    # the wrapper functions
+    tfd = TorsionFingerprints.GetTFDBetweenMolecules(mol, mol2)
+    self.assertAlmostEqual(tfd, 0.0645, 4)
+
+    mol.AddConformer(mol2.GetConformer(), assignId=True)
+    mol.AddConformer(mol2.GetConformer(), assignId=True)
+    tfd = TorsionFingerprints.GetTFDBetweenConformers(mol, confIds1=[0], confIds2=[1, 2])
+    self.assertEqual(len(tfd), 2)
+    self.assertAlmostEqual(tfd[0], 0.0645, 4)
+
+    tfdmat = TorsionFingerprints.GetTFDMatrix(mol)
+    self.assertEqual(len(tfdmat), 3)
+    
+  def testTorsionFingerprintsAtomReordering(self):
+    # we use the xray structure from the paper (JCIM, 52, 1499, 2012): 1DWD
+    refFile = os.path.join(RDConfig.RDCodeDir,'Chem','test_data','1DWD_ligand.pdb')
+    ref = Chem.MolFromSmiles('NC(=[NH2+])c1ccc(C[C@@H](NC(=O)CNS(=O)(=O)c2ccc3ccccc3c2)C(=O)N2CCCCC2)cc1')
+    mol1 = Chem.MolFromPDBFile(refFile)
+    mol1 = AllChem.AssignBondOrdersFromTemplate(ref, mol1)
+
+    refFile = os.path.join(RDConfig.RDCodeDir,'Chem','test_data','1DWD_ligand_reordered.pdb')
+    mol2 = Chem.MolFromPDBFile(refFile)
+    mol2 = AllChem.AssignBondOrdersFromTemplate(ref, mol2)
+
+    tfd = TorsionFingerprints.GetTFDBetweenMolecules(mol1, mol2)
+    self.assertEqual(tfd, 0.0)
 
   def testTorsionFingerprintsColinearBonds(self):
     # test that single bonds adjacent to triple bonds are ignored

--- a/rdkit/Chem/test_data/1DWD_ligand_reordered.pdb
+++ b/rdkit/Chem/test_data/1DWD_ligand_reordered.pdb
@@ -1,0 +1,68 @@
+HETATM    1  N1  UNL     1      31.296  20.429  26.237  1.00  0.00           N  
+HETATM    2  C1  UNL     1      32.475  19.965  25.786  1.00  0.00           C  
+HETATM    3  N2  UNL     1      33.531  20.749  26.044  1.00  0.00           N1+
+HETATM    4  C2  UNL     1      32.545  18.928  24.748  1.00  0.00           C  
+HETATM    5  C3  UNL     1      33.780  18.485  24.280  1.00  0.00           C  
+HETATM    6  C4  UNL     1      33.838  17.468  23.309  1.00  0.00           C  
+HETATM    7  C5  UNL     1      32.676  16.947  22.807  1.00  0.00           C  
+HETATM    8  C6  UNL     1      32.722  15.891  21.790  1.00  0.00           C  
+HETATM    9  C7  UNL     1      32.793  14.539  22.486  1.00  0.00           C  
+HETATM   10  N3  UNL     1      31.506  14.248  23.138  1.00  0.00           N  
+HETATM   11  C8  UNL     1      31.408  14.033  24.473  1.00  0.00           C  
+HETATM   12  O1  UNL     1      32.378  14.117  25.235  1.00  0.00           O  
+HETATM   13  C9  UNL     1      30.046  13.740  24.883  1.00  0.00           C  
+HETATM   14  N4  UNL     1      29.985  13.739  26.306  1.00  0.00           N  
+HETATM   15  S1  UNL     1      29.341  12.438  27.058  1.00  0.00           S  
+HETATM   16  O2  UNL     1      28.363  11.839  26.182  1.00  0.00           O  
+HETATM   17  O3  UNL     1      29.062  12.809  28.435  1.00  0.00           O  
+HETATM   18  C10 UNL     1      30.640  11.263  27.135  1.00  0.00           C  
+HETATM   19  C11 UNL     1      30.507  10.148  26.315  1.00  0.00           C  
+HETATM   20  C12 UNL     1      31.464   9.171  26.300  1.00  0.00           C  
+HETATM   21  C13 UNL     1      32.582   9.285  27.133  1.00  0.00           C  
+HETATM   22  C14 UNL     1      33.568   8.267  27.118  1.00  0.00           C  
+HETATM   23  C15 UNL     1      34.690   8.415  27.878  1.00  0.00           C  
+HETATM   24  C16 UNL     1      34.852   9.585  28.681  1.00  0.00           C  
+HETATM   25  C17 UNL     1      33.893  10.593  28.702  1.00  0.00           C  
+HETATM   26  C18 UNL     1      32.741  10.453  27.920  1.00  0.00           C  
+HETATM   27  C19 UNL     1      31.727  11.439  27.937  1.00  0.00           C  
+HETATM   28  C20 UNL     1      32.978  13.472  21.462  1.00  0.00           C  
+HETATM   29  O4  UNL     1      32.744  13.595  20.255  1.00  0.00           O  
+HETATM   30  N5  UNL     1      33.473  12.286  22.011  1.00  0.00           N  
+HETATM   31  C21 UNL     1      33.756  12.198  23.456  1.00  0.00           C  
+HETATM   32  C22 UNL     1      33.051  10.991  24.086  1.00  0.00           C  
+HETATM   33  C23 UNL     1      33.331   9.715  23.265  1.00  0.00           C  
+HETATM   34  C24 UNL     1      32.940   9.920  21.771  1.00  0.00           C  
+HETATM   35  C25 UNL     1      33.690  11.116  21.167  1.00  0.00           C  
+HETATM   36  C26 UNL     1      31.463  17.355  23.295  1.00  0.00           C  
+HETATM   37  C27 UNL     1      31.382  18.362  24.260  1.00  0.00           C  
+CONECT    1    2
+CONECT    2    3    3    4
+CONECT    4    5    5   37
+CONECT    5    6
+CONECT    6    7    7
+CONECT    7    8   36
+CONECT    8    9
+CONECT    9   10   28
+CONECT   10   11
+CONECT   11   12   12   13
+CONECT   13   14
+CONECT   14   15
+CONECT   15   16   16   17   17
+CONECT   15   18
+CONECT   18   19   19   27
+CONECT   19   20
+CONECT   20   21   21
+CONECT   21   22   26
+CONECT   22   23   23
+CONECT   23   24
+CONECT   24   25   25
+CONECT   25   26
+CONECT   26   27   27
+CONECT   28   29   29   30
+CONECT   30   31   35
+CONECT   31   32
+CONECT   32   33
+CONECT   33   34
+CONECT   34   35
+CONECT   36   37   37
+END


### PR DESCRIPTION
If two instances of the same molecule have different atom ordering, the second molecule is reordered to match the atom order of the first one.

The function GetTFDBetweenMolecules() takes now two confIds instead of two lists of confIds and returns a float instead of a list of floats. This has previously led to confusion.

Tests for the changes as well as for the wrapper functions have been added/adapted.

Entry in cookbook has been adapted. 
