### PR TITLE
Migrate std::string APIs to const std::string &

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,6 +101,7 @@ install(FILES
 # extra boost versions
 if(MSVC)
   SET(Boost_ADDITIONAL_VERSIONS "1.48" "1.48.0" "1.45" "1.45.0" "1.44" "1.44.0" "1.43" "1.43.0" "1.42" "1.42.0" "1.41" "1.41.0" "1.40" "1.40.0")
+  ADD_DEFINITIONS("-DBOOST_ALL_NO_LIB")
 endif(MSVC)
 
 if(RDK_BUILD_PYTHON_WRAPPERS)

--- a/Code/ChemicalFeatures/FreeChemicalFeature.h
+++ b/Code/ChemicalFeatures/FreeChemicalFeature.h
@@ -21,13 +21,13 @@ namespace ChemicalFeatures {
   class FreeChemicalFeature : public ChemicalFeature {
     public:
     //! start with everything specified
-    FreeChemicalFeature(std::string family, std::string type,
+    FreeChemicalFeature(const std::string &family, std::string type,
                         const RDGeom::Point3D &loc,int id=-1) :
       d_id(id), d_family(family), d_type(type), d_position(loc) {
     }
 
     //! start with family and location specified, leave the type blank
-    FreeChemicalFeature(std::string family, const RDGeom::Point3D &loc) :
+    FreeChemicalFeature(const std::string &family, const RDGeom::Point3D &loc) :
       d_id(-1), d_family(family), d_type(""), d_position(loc) {
     }
 

--- a/Code/DataStructs/BitVectUtils.h
+++ b/Code/DataStructs/BitVectUtils.h
@@ -16,7 +16,7 @@
 //! \brief Construct a BitVect from the ASCII representation of a
 //! Daylight fingerprint string
 template <typename T>
-void FromDaylightString(T &sbv,std::string s);
+void FromDaylightString(T &sbv,const std::string &s);
 
 //! \brief Construct a BitVect from the ASCII representation of a
 //! bit string (i.e. a bunch of zeros and ones)

--- a/Code/DataStructs/DatastructsException.h
+++ b/Code/DataStructs/DatastructsException.h
@@ -16,7 +16,7 @@ class DatastructsException : public std::exception {
   //! construct with an error message
   DatastructsException(const char *msg) : _msg(msg) {};
   //! construct with an error message
-  DatastructsException(const std::string msg) : _msg(msg) {};
+  DatastructsException(const std::string &msg) : _msg(msg) {};
   //! get the error message
   const char *message () const { return _msg.c_str(); };
   ~DatastructsException () throw () {};

--- a/Code/DataStructs/DiscreteValueVect.h
+++ b/Code/DataStructs/DiscreteValueVect.h
@@ -48,7 +48,7 @@ namespace RDKit{
     DiscreteValueVect(const DiscreteValueVect& other);
 
     //! constructor from a pickle
-    DiscreteValueVect(const std::string pkl){
+    DiscreteValueVect(const std::string &pkl){
       initFromText(pkl.c_str(),pkl.size());
     };
     //! constructor from a pickle

--- a/Code/DataStructs/SparseIntVect.h
+++ b/Code/DataStructs/SparseIntVect.h
@@ -40,7 +40,7 @@ namespace RDKit{
     }
 
     //! constructor from a pickle
-    SparseIntVect(const std::string pkl){
+    SparseIntVect(const std::string &pkl){
       initFromText(pkl.c_str(),pkl.size());
     };
     //! constructor from a pickle

--- a/Code/DataStructs/Utils.cpp
+++ b/Code/DataStructs/Utils.cpp
@@ -29,7 +29,7 @@ void a2b(const char *,char *);
 //! \brief Construct a BitVect from the ASCII representation of a
 //! Daylight fingerprint string
 template <typename T>
-void FromDaylightString(T &sbv,std::string s)
+void FromDaylightString(T &sbv,const std::string &s)
 {
   sbv.clearBits();
   int length = s.length();
@@ -66,8 +66,8 @@ void FromDaylightString(T &sbv,std::string s)
   }
 }
 
-template void FromDaylightString(SparseBitVect &sbv,std::string s);
-template void FromDaylightString(ExplicitBitVect &sbv,std::string s);
+template void FromDaylightString(SparseBitVect &sbv,const std::string &s);
+template void FromDaylightString(ExplicitBitVect &sbv,const std::string &s);
 
 //! \brief Construct a BitVect from the ASCII representation of a
 //! BitString

--- a/Code/DataStructs/Wrap/wrap_Utils.cpp
+++ b/Code/DataStructs/Wrap/wrap_Utils.cpp
@@ -52,9 +52,9 @@ struct Utils_wrapper {
                 "Creates an ExplicitBitVect from a binary string (byte array).");  
 
     python::def("InitFromDaylightString",
-                (void (*)(SparseBitVect &,std::string))FromDaylightString);
+                (void (*)(SparseBitVect &,const std::string&))FromDaylightString);
     python::def("InitFromDaylightString",
-                (void (*)(ExplicitBitVect &,std::string))FromDaylightString,
+                (void (*)(ExplicitBitVect &,const std::string&))FromDaylightString,
                 "Fill a BitVect using an ASCII (Daylight) encoding of a fingerprint.\n\
 \n\
    **Arguments**\n\

--- a/Code/Demos/boost/EBV_err/classA.h
+++ b/Code/Demos/boost/EBV_err/classA.h
@@ -27,11 +27,11 @@ class classA {
     }
   }
 
-  bool hasProp(std::string key) const {
+  bool hasProp(const std::string &key) const {
     return (dp_props.find(key) != dp_props.end());
   }
 
-  void setProp(std::string key, int val) {
+  void setProp(const std::string &key, int val) {
     dp_props[key] = val;
   }
 

--- a/Code/Demos/boost/EBV_err/classC.h
+++ b/Code/Demos/boost/EBV_err/classC.h
@@ -31,7 +31,7 @@ class classC {
     }
   }
 
-  bool hasProp(std::string key) const {
+  bool hasProp(const std::string &key) const {
     PAIR_VECT::const_iterator pvi;
     for (pvi = dp_props.begin(); pvi != dp_props.end(); pvi++) {
       if (pvi->first == key) {
@@ -41,7 +41,7 @@ class classC {
     return false; 
   }
 
-  void setProp(std::string key, int val) {
+  void setProp(const std::string &key, int val) {
     std::pair<std::string, int> newp(key, val);
     dp_props.push_back(newp);
   }

--- a/Code/Demos/boost/cross_mod_err/classA.h
+++ b/Code/Demos/boost/cross_mod_err/classA.h
@@ -27,11 +27,11 @@ class classA {
     }
   }
 
-  bool hasProp(std::string key) const {
+  bool hasProp(const std::string &key) const {
     return (dp_props.find(key) != dp_props.end());
   }
 
-  void setProp(std::string key, int val) {
+  void setProp(const std::string &key, int val) {
     dp_props[key] = val;
   }
 

--- a/Code/Demos/boost/cross_mod_err/classC.h
+++ b/Code/Demos/boost/cross_mod_err/classC.h
@@ -31,7 +31,7 @@ class classC {
     }
   }
 
-  bool hasProp(std::string key) const {
+  bool hasProp(const std::string &key) const {
     PAIR_VECT::const_iterator pvi;
     for (pvi = dp_props.begin(); pvi != dp_props.end(); pvi++) {
       if (pvi->first == key) {
@@ -41,7 +41,7 @@ class classC {
     return false; 
   }
 
-  void setProp(std::string key, int val) {
+  void setProp(const std::string &key, int val) {
     std::pair<std::string, int> newp(key, val);
     dp_props.push_back(newp);
   }

--- a/Code/ForceField/Wrap/PyForceField.h
+++ b/Code/ForceField/Wrap/PyForceField.h
@@ -129,7 +129,7 @@ namespace ForceFields {
     {
       mmffMolProperties->setMMFFEleTerm(state);
     };
-    void setMMFFVariant(std::string mmffVariant)
+    void setMMFFVariant(const std::string &mmffVariant)
     {
       mmffMolProperties->setMMFFVariant(mmffVariant);
     };

--- a/Code/Geometry/Grid3D.h
+++ b/Code/Geometry/Grid3D.h
@@ -23,7 +23,7 @@ namespace RDGeom {
     //! construct with an error message
     GridException(const char *msg) : _msg(msg) {};
     //! construct with an error message
-    GridException(const std::string msg) : _msg(msg) {};
+    GridException(const std::string &msg) : _msg(msg) {};
     //! get the error message
     const char *message () const { return _msg.c_str(); };
     ~GridException () throw () {};

--- a/Code/Geometry/UniformGrid3D.cpp
+++ b/Code/Geometry/UniformGrid3D.cpp
@@ -58,7 +58,7 @@ namespace RDGeom {
     }
   }
 
-  UniformGrid3D::UniformGrid3D(const std::string pkl) {
+  UniformGrid3D::UniformGrid3D(const std::string &pkl) {
     dp_storage=0;
     this->initFromText(pkl.c_str(),pkl.size());
   }
@@ -396,7 +396,7 @@ namespace RDGeom {
     }
   }
 
-  void writeGridToFile(const UniformGrid3D &grid, std::string filename) {
+  void writeGridToFile(const UniformGrid3D &grid, const std::string &filename) {
     //std::ofstream ofStrm(filename.c_str());
     std::ofstream *ofStrm = new std::ofstream(filename.c_str());
     std::ostream *oStrm =  static_cast<std::ostream *>(ofStrm);

--- a/Code/Geometry/UniformGrid3D.h
+++ b/Code/Geometry/UniformGrid3D.h
@@ -48,7 +48,7 @@ namespace RDGeom {
     //! copy ctor
     UniformGrid3D(const UniformGrid3D &other);
     //! construct from a string pickle
-    UniformGrid3D(const std::string pkl);
+    UniformGrid3D(const std::string &pkl);
     //! construct from a text pickle
     UniformGrid3D(const char *pkl,unsigned int);
 
@@ -198,7 +198,8 @@ namespace RDGeom {
   /*
     The grid is written in GRD format
   */
-  void writeGridToFile(const UniformGrid3D &grid, std::string filename);
+  void writeGridToFile(const UniformGrid3D &grid,
+                       const std::string &filename);
 
 }
 

--- a/Code/GraphMol/Atom.cpp
+++ b/Code/GraphMol/Atom.cpp
@@ -39,7 +39,7 @@ Atom::Atom(unsigned int num) {
   initAtom();
 };
 
-Atom::Atom(std::string what) {
+Atom::Atom(const std::string &what) {
   d_atomicNum = PeriodicTable::getTable()->getAtomicNumber(what);
   initAtom();
 };

--- a/Code/GraphMol/Atom.h
+++ b/Code/GraphMol/Atom.h
@@ -99,7 +99,7 @@ namespace RDKit{
     //! construct an Atom with a particular atomic number
     explicit Atom(unsigned int num);
     //! construct an Atom with a particular symbol (looked up in the PeriodicTable)
-    explicit Atom(std::string what);
+    explicit Atom(const std::string &what);
     Atom(const Atom & other);
     virtual ~Atom();
 

--- a/Code/GraphMol/ChemReactions/Reaction.cpp
+++ b/Code/GraphMol/ChemReactions/Reaction.cpp
@@ -349,7 +349,7 @@ namespace RDKit {
 
   void addRecursiveQueriesToReaction(ChemicalReaction &rxn,
                   const std::map<std::string,ROMOL_SPTR> &queries,
-                  std::string propName,
+                  const std::string &propName,
                   std::vector<std::vector<std::pair<unsigned int,std::string> > > *reactantLabels) {
     if(!rxn.isInitialized()){
       throw ChemicalReactionException("initMatchers() must be called first");

--- a/Code/GraphMol/ChemReactions/Reaction.h
+++ b/Code/GraphMol/ChemReactions/Reaction.h
@@ -376,7 +376,7 @@ namespace RDKit{
    */  
   void addRecursiveQueriesToReaction(ChemicalReaction &rxn,
                                      const std::map<std::string,ROMOL_SPTR> &queries,
-		  std::string propName,
+		  const std::string &propName,
 		  std::vector<std::vector<std::pair<unsigned int,std::string> > > *reactantLabels=NULL);
 
 } // end of RDKit namespace

--- a/Code/GraphMol/ChemReactions/ReactionParser.h
+++ b/Code/GraphMol/ChemReactions/ReactionParser.h
@@ -44,7 +44,7 @@ namespace RDKit{
     //! construct with an error message
     explicit ChemicalReactionParserException(const char *msg) : _msg(msg) {};
     //! construct with an error message
-    explicit ChemicalReactionParserException(const std::string msg) : _msg(msg) {};
+    explicit ChemicalReactionParserException(const std::string &msg) : _msg(msg) {};
     //! get the error message
     const char *message () const { return _msg.c_str(); };
     ~ChemicalReactionParserException () throw () {};

--- a/Code/GraphMol/ChemTransforms/ChemTransforms.cpp
+++ b/Code/GraphMol/ChemTransforms/ChemTransforms.cpp
@@ -29,7 +29,6 @@
 #include <RDGeneral/FileParseException.h>
 #include <RDGeneral/BadFileException.h>
 #include <GraphMol/ChemTransforms/ChemTransforms.h>
-
 namespace RDKit{
   namespace {
     void updateSubMolConfs(const ROMol &mol,RWMol &res,
@@ -557,8 +556,9 @@ namespace RDKit{
     return (ROMol *)res;
   }    
 
-  void addRecursiveQueries(ROMol &mol,const std::map<std::string,ROMOL_SPTR> &queries,std::string propName,
-                             std::vector<std::pair<unsigned int, std::string> > *reactantLabels){
+  void addRecursiveQueries(ROMol &mol,const std::map<std::string,ROMOL_SPTR> &queries,
+                           const std::string &propName,
+                           std::vector<std::pair<unsigned int, std::string> > *reactantLabels){
     std::string delim=",";
     boost::char_separator<char> sep(delim.c_str());
     if (reactantLabels!=NULL) {
@@ -609,8 +609,10 @@ namespace RDKit{
     }
   }
 
-  void parseQueryDefFile(std::istream *inStream,std::map<std::string,ROMOL_SPTR> &queryDefs,
-                         bool standardize,std::string delimiter,std::string comment,
+  void parseQueryDefFile(std::istream *inStream,
+                         std::map<std::string,ROMOL_SPTR> &queryDefs,
+                         bool standardize,
+                         const std::string &delimiter, const std::string &comment,
                          unsigned int nameColumn,unsigned int smartsColumn){
     PRECONDITION(inStream,"no stream");
     queryDefs.clear();
@@ -656,8 +658,10 @@ namespace RDKit{
       queryDefs[qname]=msptr;
     }
   }
-  void parseQueryDefFile(std::string filename,std::map<std::string,ROMOL_SPTR> &queryDefs,
-                         bool standardize,std::string delimiter,std::string comment,
+  void parseQueryDefFile(const std::string &filename,
+                         std::map<std::string,ROMOL_SPTR> &queryDefs,
+                         bool standardize,
+                         const std::string &delimiter, const std::string &comment,
                          unsigned int nameColumn,unsigned int smartsColumn){
     std::ifstream inStream(filename.c_str());
     if (!inStream || (inStream.bad()) ) {
@@ -669,7 +673,8 @@ namespace RDKit{
   }
   void parseQueryDefText(const std::string &queryDefText,
                          std::map<std::string,ROMOL_SPTR> &queryDefs,
-                         bool standardize,std::string delimiter,std::string comment,
+                         bool standardize,
+                         const std::string &delimiter, const std::string &comment,
                          unsigned int nameColumn,unsigned int smartsColumn){
     std::stringstream inStream(queryDefText);
     parseQueryDefFile(&inStream,queryDefs,standardize,delimiter,comment,nameColumn,smartsColumn);

--- a/Code/GraphMol/ChemTransforms/ChemTransforms.h
+++ b/Code/GraphMol/ChemTransforms/ChemTransforms.h
@@ -162,7 +162,9 @@ namespace RDKit{
           in \c queries
       
   */
-  void addRecursiveQueries(ROMol &mol,const std::map<std::string,ROMOL_SPTR> &queries,std::string propName,
+  void addRecursiveQueries(ROMol &mol,
+                           const std::map<std::string,ROMOL_SPTR> &queries,
+                           const std::string &propName,
                            std::vector<std::pair<unsigned int, std::string> > *reactantLabels=NULL);
 
 
@@ -180,16 +182,22 @@ namespace RDKit{
       \param smartsColumn     - column with the SMARTS definitions of the queries
 
   */
-  void parseQueryDefFile(std::string filename,std::map<std::string,ROMOL_SPTR> &queryDefs,
-                         bool standardize=true,std::string delimiter="\t",std::string comment="//",
+  void parseQueryDefFile(const std::string &filename,
+                         std::map<std::string,ROMOL_SPTR> &queryDefs,
+                         bool standardize=true,
+                         const std::string &delimiter="\t",const std::string &comment="//",
                          unsigned int nameColumn=0,unsigned int smartsColumn=1);
   //! \overload
-  void parseQueryDefFile(std::istream *inStream,std::map<std::string,ROMOL_SPTR> &queryDefs,
-                         bool standardize=true,std::string delimiter="\t",std::string comment="//",
+  void parseQueryDefFile(std::istream *inStream,
+                         std::map<std::string,ROMOL_SPTR> &queryDefs,
+                         bool standardize=true,
+                         const std::string &delimiter="\t",const std::string &comment="//",
                          unsigned int nameColumn=0,unsigned int smartsColumn=1);
   //! \brief equivalent to parseQueryDefFile() but the query definitions are explicitly passed in
-  void parseQueryDefText(const std::string &queryDefText,std::map<std::string,ROMOL_SPTR> &queryDefs,
-                         bool standardize=true,std::string delimiter="\t",std::string comment="//",
+  void parseQueryDefText(const std::string &queryDefText,
+                         std::map<std::string,ROMOL_SPTR> &queryDefs,
+                         bool standardize=true,
+                         const std::string &delimiter="\t",const std::string &comment="//",
                          unsigned int nameColumn=0,unsigned int smartsColumn=1);
   
 }

--- a/Code/GraphMol/ChemTransforms/MolFragmenter.cpp
+++ b/Code/GraphMol/ChemTransforms/MolFragmenter.cpp
@@ -43,8 +43,9 @@ namespace RDKit{
         (v1.atom2Label==v2.atom2Label)&&
         (v1.bondType==v2.bondType);
     }
-    void constructFragmenterAtomTypes(std::istream *inStream,std::map<unsigned int,std::string> &defs,
-                                      std::string comment,bool validate,
+    void constructFragmenterAtomTypes(std::istream *inStream,
+                                      std::map<unsigned int,std::string> &defs,
+                                      const std::string &comment,bool validate,
                                       std::map<unsigned int,ROMOL_SPTR> *environs){
       PRECONDITION(inStream,"no stream");
       defs.clear();
@@ -79,8 +80,9 @@ namespace RDKit{
         defs[idx]=tokens[1];
       }
     }
-    void constructFragmenterAtomTypes(const std::string &str,std::map<unsigned int,std::string> &defs,
-                                      std::string comment,bool validate,
+    void constructFragmenterAtomTypes(const std::string &str,
+                                      std::map<unsigned int,std::string> &defs,
+                                      const std::string &comment,bool validate,
                                       std::map<unsigned int,ROMOL_SPTR> *environs){
       std::stringstream istr(str);
       constructFragmenterAtomTypes(&istr,defs,comment,validate,environs);
@@ -124,7 +126,8 @@ namespace RDKit{
     void constructFragmenterBondTypes(std::istream *inStream,
                                       const std::map<unsigned int,std::string> &atomTypes,
                                       std::vector<FragmenterBondType> &defs,
-                                      std::string comment,bool validate,bool labelByConnector){
+                                      const std::string &comment,
+                                      bool validate,bool labelByConnector){
       PRECONDITION(inStream,"no stream");
       defs.clear();
       defs.resize(0);
@@ -197,7 +200,7 @@ namespace RDKit{
     void constructFragmenterBondTypes(const std::string &str,
                                       const std::map<unsigned int,std::string> &atomTypes,
                                       std::vector<FragmenterBondType> &defs,
-                                      std::string comment,bool validate,
+                                      const std::string &comment,bool validate,
                                       bool labelByConnector){
       std::stringstream istr(str);
       constructFragmenterBondTypes(&istr,atomTypes,defs,comment,validate,labelByConnector);

--- a/Code/GraphMol/ChemTransforms/MolFragmenter.h
+++ b/Code/GraphMol/ChemTransforms/MolFragmenter.h
@@ -74,22 +74,22 @@ namespace RDKit {
     ROMol *fragmentOnBRICSBonds(const ROMol &mol);
 
     void constructFragmenterAtomTypes(std::istream *inStream,std::map<unsigned int,std::string> &defs,
-                                      std::string comment="//",bool validate=true,
+                                      const std::string &comment="//",bool validate=true,
                                       std::map<unsigned int,ROMOL_SPTR> *environs=0);
     void constructFragmenterAtomTypes(const std::string &str,std::map<unsigned int,std::string> &defs,
-                                      std::string comment="//",bool validate=true,
+                                      const std::string &comment="//",bool validate=true,
                                       std::map<unsigned int,ROMOL_SPTR> *environs=0);
     void constructBRICSAtomTypes(std::map<unsigned int,std::string> &defs,
                                  std::map<unsigned int,ROMOL_SPTR> *environs=0);
     void constructFragmenterBondTypes(std::istream *inStream,
                                       const std::map<unsigned int,std::string> &atomTypes,
                                       std::vector<FragmenterBondType> &defs,
-                                      std::string comment="//",bool validate=true,
+                                      const std::string &comment="//",bool validate=true,
                                       bool labelByConnector=true);
     void constructFragmenterBondTypes(const std::string &str,
                                       const std::map<unsigned int,std::string> &atomTypes,
                                       std::vector<FragmenterBondType> &defs,
-                                      std::string comment="//",bool validate=true,
+                                      const std::string &comment="//",bool validate=true,
                                       bool labelByConnector=true);
     void constructBRICSBondTypes(std::vector<FragmenterBondType> &defs);
   }

--- a/Code/GraphMol/Chirality.cpp
+++ b/Code/GraphMol/Chirality.cpp
@@ -118,13 +118,16 @@ namespace RDKit{
       }
     }
 
-    void iterateCIPRanks(const ROMol &mol, DOUBLE_VECT &invars,
-                         UINT_VECT &ranks,bool seedWithInvars){
+    void iterateCIPRanks(const ROMol &mol, DOUBLE_VECT &invars, UINT_VECT &ranks,bool seedWithInvars){
       PRECONDITION(invars.size()==mol.getNumAtoms(),"bad invars size");
       PRECONDITION(ranks.size()>=mol.getNumAtoms(),"bad ranks size");
 
       unsigned int numAtoms = mol.getNumAtoms();
       CIP_ENTRY_VECT cipEntries(numAtoms);
+      INT_LIST allIndices;
+      for(unsigned int i=0;i<numAtoms;++i){
+        allIndices.push_back(i);
+      }
 #ifdef VERBOSE_CANON
       BOOST_LOG(rdDebugLog) << "invariants:" << std::endl;
       for(unsigned int i=0;i<numAtoms;i++){
@@ -173,17 +176,19 @@ namespace RDKit{
         //
         // for each atom, get a sorted list of its neighbors' ranks:
         //
-        for(int it=0;it<numAtoms;++it) {
+        for(INT_LIST_I it=allIndices.begin();
+            it!=allIndices.end();
+            ++it){
           CIP_ENTRY localEntry;
           localEntry.reserve(16);
 
           // start by pushing on our neighbors' ranks:
           ROMol::OEDGE_ITER beg,end;
-          boost::tie(beg,end) = mol.getAtomBonds(mol[it].get());
+          boost::tie(beg,end) = mol.getAtomBonds(mol[*it].get());
           while(beg!=end){
             const Bond *bond=mol[*beg].get();
             ++beg;
-            unsigned int nbrIdx=bond->getOtherAtomIdx(it);
+            unsigned int nbrIdx=bond->getOtherAtomIdx(*it);
             const Atom *nbr=mol[nbrIdx].get();
             
             int rank=ranks[nbrIdx]+1;
@@ -218,29 +223,30 @@ namespace RDKit{
           }
           // add a zero for each coordinated H:
           // (as long as we're not a query atom)
-          if(!mol[it]->hasQuery()){
+          if(!mol[*it]->hasQuery()){
             localEntry.insert(localEntry.begin(),
-                              mol[it]->getTotalNumHs(),
+                              mol[*it]->getTotalNumHs(),
                               0);
           }
 
           // we now have a sorted list of our neighbors' ranks,
           // copy it on in reversed order:
-          cipEntries[it].insert(cipEntries[it].end(),
+          cipEntries[*it].insert(cipEntries[*it].end(),
                                  localEntry.rbegin(),
                                  localEntry.rend());
-          if(cipEntries[it].size() > longestEntry){
-            longestEntry = cipEntries[it].size();
+          if(cipEntries[*it].size() > longestEntry){
+            longestEntry = cipEntries[*it].size();
           }
         }
         // ----------------------------------------------------
         //
         // pad the entries so that we compare rounds to themselves:
         // 
-        for(int it=0;it<numAtoms;++it) {
-          unsigned int sz=cipEntries[it].size();
+        for(INT_LIST_I it=allIndices.begin();it!=allIndices.end();
+            ++it){
+          unsigned int sz=cipEntries[*it].size();
           if(sz<longestEntry){
-            cipEntries[it].insert(cipEntries[it].end(),
+            cipEntries[*it].insert(cipEntries[*it].end(),
                                    longestEntry-sz,
                                    -1);
           }

--- a/Code/GraphMol/Conformer.h
+++ b/Code/GraphMol/Conformer.h
@@ -23,7 +23,7 @@ namespace RDKit {
     //! construct with an error message
     ConformerException(const char *msg) : _msg(msg) {};
     //! construct with an error message
-    ConformerException(const std::string msg) : _msg(msg) {};
+    ConformerException(const std::string &msg) : _msg(msg) {};
     //! get the error message
     const char *message () const { return _msg.c_str(); };
     ~ConformerException () throw () {};

--- a/Code/GraphMol/FileParsers/FileParsers.h
+++ b/Code/GraphMol/FileParsers/FileParsers.h
@@ -163,7 +163,7 @@ namespace RDKit{
    *                     is only done if the molecule is sanitized
    *   \param variant  - the atom type definitions to use
    */
-  RWMol *Mol2FileToMol(std::string fName,bool sanitize=true,bool removeHs=true,
+  RWMol *Mol2FileToMol(const std::string &fName,bool sanitize=true,bool removeHs=true,
                        Mol2Type variant=CORINA);
 
   // \brief construct a molecule from Tripos mol2 data in a stream

--- a/Code/GraphMol/FileParsers/FileParsers.h
+++ b/Code/GraphMol/FileParsers/FileParsers.h
@@ -71,7 +71,7 @@ namespace RDKit{
    *   \param strictParsing - if set, the parser is more lax about correctness
    *                          of the contents.
    */
-  RWMol *MolFileToMol(std::string fName, bool sanitize=true,
+  RWMol *MolFileToMol(const std::string &fName, bool sanitize=true,
                       bool removeHs=true,bool strictParsing=true);
 
   // \brief generates an MDL mol block for a molecule
@@ -95,7 +95,7 @@ namespace RDKit{
    *   \param forceV3000    - force generation a V3000 mol block (happens automatically with
    *                          more than 999 atoms or bonds)
    */
-  void MolToMolFile(const ROMol &mol,std::string fName,bool includeStereo=true,
+  void MolToMolFile(const ROMol &mol,const std::string &fName,bool includeStereo=true,
                     int confId=-1,bool kekulize=true,bool forceV3000=false);
 
 
@@ -136,14 +136,14 @@ namespace RDKit{
 			  read CombiCode-style tpls, so we'll allow this mis-feature
 			  to be parsed when this flag is set.
   */
-  RWMol *TPLFileToMol(std::string fName,bool sanitize=true,
+  RWMol *TPLFileToMol(const std::string &fName,bool sanitize=true,
                       bool skipFirstConf=false);
 
   std::string MolToTPLText(const ROMol &mol,
-			   std::string partialChargeProp="_GasteigerCharge",
+			   const std::string &partialChargeProp="_GasteigerCharge",
 			   bool writeFirstConfTwice=false);
-  void MolToTPLFile(const ROMol &mol,std::string fName,
-		    std::string partialChargeProp="_GasteigerCharge",
+  void MolToTPLFile(const ROMol &mol,const std::string &fName,
+		    const std::string &partialChargeProp="_GasteigerCharge",
 		    bool writeFirstConfTwice=false);
 
   //-----

--- a/Code/GraphMol/FileParsers/Mol2FileParser.cpp
+++ b/Code/GraphMol/FileParsers/Mol2FileParser.cpp
@@ -928,7 +928,7 @@ namespace RDKit{
   //  Read a molecule from a file
   //
   //------------------------------------------------
-  RWMol *Mol2FileToMol(std::string fName, bool sanitize, bool removeHs,
+  RWMol *Mol2FileToMol(const std::string &fName, bool sanitize, bool removeHs,
                        Mol2Type variant){
     // FIX: this binary mode of opening file is here because of a bug in VC++ 6.0
     // the function "tellg" does not work correctly if we do not open it this way

--- a/Code/GraphMol/FileParsers/MolFileParser.cpp
+++ b/Code/GraphMol/FileParsers/MolFileParser.cpp
@@ -2441,7 +2441,7 @@ namespace RDKit{
   //  Read a molecule from a file
   //
   //------------------------------------------------
-  RWMol *MolFileToMol(std::string fName, bool sanitize, bool removeHs,bool strictParsing){
+  RWMol *MolFileToMol(const std::string &fName, bool sanitize, bool removeHs,bool strictParsing){
     std::ifstream inStream(fName.c_str());
     if (!inStream || (inStream.bad()) ) {
       std::ostringstream errout;

--- a/Code/GraphMol/FileParsers/MolFileWriter.cpp
+++ b/Code/GraphMol/FileParsers/MolFileWriter.cpp
@@ -1053,7 +1053,7 @@ namespace RDKit{
   //  Dump a molecule to a file
   //
   //------------------------------------------------
-  void MolToMolFile(const ROMol &mol,std::string fName,bool includeStereo, int confId, bool kekulize,
+  void MolToMolFile(const ROMol &mol,const std::string &fName,bool includeStereo, int confId, bool kekulize,
                     bool forceV3000){
     std::ofstream *outStream = new std::ofstream(fName.c_str());
     if (!outStream || !(*outStream) || outStream->bad() ) {

--- a/Code/GraphMol/FileParsers/MolWriters.h
+++ b/Code/GraphMol/FileParsers/MolWriters.h
@@ -51,9 +51,9 @@ namespace RDKit {
       \param kekuleSmiles   : toggles the generation of kekule SMILES
 
      */
-    SmilesWriter(std::string fileName, 
-		 std::string delimiter=" ",
-		 std::string nameHeader="Name",
+    SmilesWriter(const std::string &fileName, 
+		 const std::string &delimiter=" ",
+		 const std::string &nameHeader="Name",
 		 bool includeHeader=true,
                  bool isomericSmiles=false,
                  bool kekuleSmiles=false);
@@ -101,7 +101,8 @@ namespace RDKit {
 
   private:
     // local initialization
-    void init(std::string delimiter,std::string nameHeader,
+    void init(const std::string &delimiter,
+              const std::string &nameHeader,
               bool includeHeader,
               bool isomericSmiles,
               bool kekuleSmiles);
@@ -136,7 +137,7 @@ namespace RDKit {
     /*!
       \param fileName       : filename to write to ("-" to write to stdout)
      */
-    SDWriter(std::string fileName);
+    SDWriter(const std::string &fileName);
     SDWriter(std::ostream *outStream,bool takeOwnership=false);
 
     ~SDWriter();
@@ -179,7 +180,7 @@ namespace RDKit {
     bool getKekulize() const { return df_kekulize; };    
     
   private:
-    void writeProperty(const ROMol &mol, std::string name);
+    void writeProperty(const ROMol &mol, const std::string &name);
 
     std::ostream *dp_ostream;
     bool df_owner;
@@ -202,7 +203,7 @@ namespace RDKit {
     /*!
       \param fileName       : filename to write to ("-" to write to stdout)
      */
-    TDTWriter(std::string fileName);
+    TDTWriter(const std::string &fileName);
     TDTWriter(std::ostream *outStream,bool takeOwnership=false);
 
     ~TDTWriter();
@@ -248,7 +249,7 @@ namespace RDKit {
     unsigned int getNumDigits() const { return d_numDigits;};
     
   private:
-    void writeProperty(const ROMol &mol, std::string name);
+    void writeProperty(const ROMol &mol, const std::string &name);
 
     std::ostream *dp_ostream;
     bool df_owner;
@@ -263,7 +264,7 @@ namespace RDKit {
   //! DataBank format files.
   class PDBWriter : public MolWriter {
   public:
-    PDBWriter(std::string fileName, unsigned int flavor = 0);
+    PDBWriter(const std::string &fileName, unsigned int flavor = 0);
     PDBWriter(std::ostream *outStream, bool takeOwnership=false,
               unsigned int flavor = 0);
     ~PDBWriter();

--- a/Code/GraphMol/FileParsers/PDBWriter.cpp
+++ b/Code/GraphMol/FileParsers/PDBWriter.cpp
@@ -283,7 +283,7 @@ namespace RDKit {
     return res;
   }
 
-  PDBWriter::PDBWriter(std::string fileName, unsigned int flavor) {
+  PDBWriter::PDBWriter(const std::string &fileName, unsigned int flavor) {
     if(fileName!= "-"){
       std::ofstream *tmpStream = new std::ofstream(fileName.c_str());
       df_owner=true;

--- a/Code/GraphMol/FileParsers/SDWriter.cpp
+++ b/Code/GraphMol/FileParsers/SDWriter.cpp
@@ -22,7 +22,7 @@
 #include <boost/any.hpp>
 
 namespace RDKit {
-  SDWriter::SDWriter(std::string fileName) {
+  SDWriter::SDWriter(const std::string &fileName) {
     if(fileName!= "-"){
       std::ofstream *tmpStream = new std::ofstream(fileName.c_str());
       df_owner=true;
@@ -114,7 +114,7 @@ namespace RDKit {
     ++d_molid;
   }
 
-  void SDWriter::writeProperty(const ROMol &mol, std::string name) {
+  void SDWriter::writeProperty(const ROMol &mol, const std::string &name) {
     PRECONDITION(dp_ostream,"no output stream");
 
     // write the property value

--- a/Code/GraphMol/FileParsers/SmilesWriter.cpp
+++ b/Code/GraphMol/FileParsers/SmilesWriter.cpp
@@ -22,9 +22,9 @@
 
 namespace RDKit {
   
-  SmilesWriter::SmilesWriter(std::string fileName, 
-			     std::string delimiter,
-			     std::string nameHeader,
+  SmilesWriter::SmilesWriter(const std::string &fileName, 
+			     const std::string &delimiter,
+			     const std::string &nameHeader,
 			     bool includeHeader,
                              bool isomericSmiles,
                              bool kekuleSmiles) {
@@ -60,8 +60,8 @@ namespace RDKit {
     df_owner = takeOwnership;
     this->init(delimiter,nameHeader,includeHeader,isomericSmiles,kekuleSmiles);
   }
-  void SmilesWriter::init(std::string delimiter,
-			  std::string nameHeader,
+  void SmilesWriter::init(const std::string &delimiter,
+			  const std::string &nameHeader,
 			  bool includeHeader,
                           bool isomericSmiles,
                           bool kekuleSmiles){

--- a/Code/GraphMol/FileParsers/TDTWriter.cpp
+++ b/Code/GraphMol/FileParsers/TDTWriter.cpp
@@ -24,7 +24,7 @@
 #include <boost/algorithm/string.hpp>
 
 namespace RDKit {
-  TDTWriter::TDTWriter(std::string fileName) {
+  TDTWriter::TDTWriter(const std::string &fileName) {
     if(fileName!="-"){
       std::ofstream *tmpStream = new std::ofstream(fileName.c_str());
       if (!tmpStream || !(*tmpStream) || (tmpStream->bad()) ) {
@@ -157,7 +157,7 @@ namespace RDKit {
     d_molid++;
   }
 
-  void TDTWriter::writeProperty(const ROMol &mol, std::string name) {
+  void TDTWriter::writeProperty(const ROMol &mol, const std::string &name) {
     PRECONDITION(dp_ostream,"no output stream");
     (*dp_ostream) << name << "<";
     

--- a/Code/GraphMol/FileParsers/TplFileParser.cpp
+++ b/Code/GraphMol/FileParsers/TplFileParser.cpp
@@ -264,7 +264,7 @@ namespace RDKit{
   //  Read a molecule from a file
   //
   //------------------------------------------------
-  RWMol *TPLFileToMol(std::string fName, bool sanitize,bool skipFirstConf){
+  RWMol *TPLFileToMol(const std::string &fName, bool sanitize,bool skipFirstConf){
     std::ifstream inStream(fName.c_str());
     if (!inStream || (inStream.bad()) ) {
       std::ostringstream errout;

--- a/Code/GraphMol/FileParsers/TplFileWriter.cpp
+++ b/Code/GraphMol/FileParsers/TplFileWriter.cpp
@@ -95,7 +95,9 @@ namespace RDKit{
   }
 
   
-  std::string MolToTPLText(const ROMol &mol,std::string partialChargeProp,bool writeFirstConfTwice){
+  std::string MolToTPLText(const ROMol &mol,
+                           const std::string &partialChargeProp,
+                           bool writeFirstConfTwice){
     if(!mol.getNumConformers()){
       BOOST_LOG(rdErrorLog)<<"Cannot write molecules with no conformers to TPL files\n";
       return "";
@@ -151,8 +153,8 @@ namespace RDKit{
   }
 
 
-  void MolToTPLFile(const ROMol &mol,std::string fName,
-                    std::string partialChargeProp,
+  void MolToTPLFile(const ROMol &mol,const std::string &fName,
+                    const std::string &partialChargeProp,
                     bool writeFirstConfTwice){
     std::ofstream *outStream = new std::ofstream(fName.c_str());
     if(!outStream||!(*outStream)||outStream->bad()){

--- a/Code/GraphMol/ForceFieldHelpers/MMFF/AtomTyper.cpp
+++ b/Code/GraphMol/ForceFieldHelpers/MMFF/AtomTyper.cpp
@@ -2262,7 +2262,7 @@ namespace RDKit {
     // in case atom types are missing, d_valid is set to false,
     // charges are set to 0.0 and the force-field is unusable
     MMFFMolProperties::MMFFMolProperties(ROMol &mol, 
-      std::string mmffVariant, boost::uint8_t verbosity,
+      const std::string &mmffVariant, boost::uint8_t verbosity,
       std::ostream &oStream) :
       d_valid(true),
       d_mmffs(mmffVariant == "MMFF94s" ? true : false),

--- a/Code/GraphMol/ForceFieldHelpers/MMFF/AtomTyper.h
+++ b/Code/GraphMol/ForceFieldHelpers/MMFF/AtomTyper.h
@@ -51,7 +51,7 @@ namespace RDKit {
     };
     class MMFFMolProperties {
     public:
-      MMFFMolProperties(ROMol &mol, std::string mmffVariant = "MMFF94", 
+      MMFFMolProperties(ROMol &mol, const std::string &mmffVariant = "MMFF94", 
         boost::uint8_t verbosity = MMFF_VERBOSITY_NONE,
         std::ostream &oStream = std::cout);
       ~MMFFMolProperties() {};
@@ -141,7 +141,7 @@ namespace RDKit {
       {
         return this->d_eleTerm;
       };
-      void setMMFFVariant(const std::string mmffVariant)
+      void setMMFFVariant(const std::string &mmffVariant)
       {
         PRECONDITION((mmffVariant == "MMFF94")
           || (mmffVariant == "MMFF94s"), "bad MMFF variant");

--- a/Code/GraphMol/FragCatalog/FragCatParams.cpp
+++ b/Code/GraphMol/FragCatalog/FragCatParams.cpp
@@ -19,7 +19,7 @@ namespace RDKit{
   using boost::uint32_t;
 
   FragCatParams::FragCatParams(unsigned int lLen, unsigned int uLen,
-			       std::string fgroupFile, double tol) {
+			       const std::string &fgroupFile, double tol) {
     d_funcGroups.clear();
     d_typeStr = "Fragment Catalog Parameters";
     CHECK_INVARIANT(lLen<=uLen,"The upper length for fragments must be >= lower length");

--- a/Code/GraphMol/FragCatalog/FragCatParams.h
+++ b/Code/GraphMol/FragCatalog/FragCatParams.h
@@ -39,7 +39,8 @@ namespace RDKit {
       \param tol        (optional) the eigenvalue tolerance to be used
                         when comparing fragments
     */
-    FragCatParams(unsigned int lLen, unsigned int uLen, std::string fgroupFile, double tol=1e-08);
+    FragCatParams(unsigned int lLen, unsigned int uLen,
+                  const std::string &fgroupFile, double tol=1e-08);
     //! copy constructor
     FragCatParams(const FragCatParams &other);
     //! construct from a pickle string (serialized representation)

--- a/Code/GraphMol/FragCatalog/FragCatalogEntry.h
+++ b/Code/GraphMol/FragCatalog/FragCatalogEntry.h
@@ -45,7 +45,7 @@ namespace RDKit {
     
     std::string getDescription() const {return d_descrip;}
     
-    void setDescription(std::string val) {d_descrip = val;}
+    void setDescription(const std::string &val) {d_descrip = val;}
 
     void setDescription(const FragCatParams *params);
     
@@ -101,7 +101,7 @@ namespace RDKit {
       dp_props->getVal(key, res);
     }
     template <typename T>
-      void getProp(const std::string key, T &res) const {
+      void getProp(const std::string &key, T &res) const {
       getProp(key.c_str(), res);
     }
     

--- a/Code/GraphMol/MonomerInfo.h
+++ b/Code/GraphMol/MonomerInfo.h
@@ -65,13 +65,13 @@ namespace RDKit{
                                                           d_secondaryStructure(other.d_secondaryStructure),
                                                           d_segmentNumber(other.d_segmentNumber){};
 
-    AtomPDBResidueInfo(std::string atomName,
+    AtomPDBResidueInfo(const std::string &atomName,
                        int serialNumber=0,
-                       std::string altLoc="",
-                       std::string residueName="",
+                       const std::string &altLoc="",
+                       const std::string &residueName="",
                        int residueNumber=0,
-                       std::string chainId="",
-                       std::string insertionCode="",
+                       const std::string &chainId="",
+                       const std::string &insertionCode="",
                        double occupancy=1.0,
                        double tempFactor=0.0,
                        bool isHeteroAtom=false,

--- a/Code/GraphMol/SLNParse/SLNAttribs.cpp
+++ b/Code/GraphMol/SLNParse/SLNAttribs.cpp
@@ -67,7 +67,7 @@ namespace RDKit{
       } 
     } // end of anonymous namespace
 
-    QueryAtom::QUERYATOM_QUERY *makeQueryFromOp(std::string op,int val,int (*func)(Atom const * at),
+    QueryAtom::QUERYATOM_QUERY *makeQueryFromOp(const std::string &op,int val,int (*func)(Atom const * at),
                                                 std::string description){
       PRECONDITION(func,"bad query function");
       QueryAtom::QUERYATOM_QUERY *res=0;  

--- a/Code/GraphMol/SLNParse/SLNParse.cpp
+++ b/Code/GraphMol/SLNParse/SLNParse.cpp
@@ -135,6 +135,7 @@ namespace RDKit {
     
     RWMol *toMol(std::string inp,bool doQueries,int debugParse){
       RWMol *res;
+      boost::trim_if(inp, boost::is_any_of(" \t\r\n"));
       inp = replaceSLNMacroAtoms(inp,debugParse);
       if(debugParse){
         std::cerr<<"****** PARSING SLN: ->"<<inp<<"<-"<<std::endl;

--- a/Code/GraphMol/SLNParse/SLNParse.cpp
+++ b/Code/GraphMol/SLNParse/SLNParse.cpp
@@ -178,11 +178,11 @@ namespace RDKit {
     };
   } // end of SLNParse namespace
   
-  RWMol *SLNToMol(std::string sln,bool sanitize,int debugParse){
+  RWMol *SLNToMol(const std::string &sln,bool sanitize,int debugParse){
     // FIX: figure out how to reset lexer state
     yysln_debug = debugParse;
     // strip any leading/trailing whitespace:
-    boost::trim_if(sln,boost::is_any_of(" \t\r\n"));
+    //boost::trim_if(sln,boost::is_any_of(" \t\r\n"));
 
     RWMol *res = SLNParse::toMol(sln,false,debugParse);
     if(res){
@@ -205,10 +205,10 @@ namespace RDKit {
     return res;
   };
 
-  RWMol *SLNQueryToMol(std::string sln,bool mergeHs,int debugParse){
+  RWMol *SLNQueryToMol(const std::string &sln,bool mergeHs,int debugParse){
     yysln_debug = debugParse;
     // strip any leading/trailing whitespace:
-    boost::trim_if(sln,boost::is_any_of(" \t\r\n"));
+    //boost::trim_if(sln,boost::is_any_of(" \t\r\n"));
     RWMol *res = SLNParse::toMol(sln,true,debugParse);
     if(res){
       SLNParse::finalizeQueryMol(res,mergeHs);

--- a/Code/GraphMol/SLNParse/SLNParse.h
+++ b/Code/GraphMol/SLNParse/SLNParse.h
@@ -45,14 +45,14 @@ namespace RDKit{
     void finalizeQueryMol(ROMol *mol,bool mergeHs);
   }
 
-  RWMol *SLNToMol(std::string smi,bool sanitize=true,int debugParse=0);
+  RWMol *SLNToMol(const std::string &smi,bool sanitize=true,int debugParse=0);
 
-  RWMol *SLNQueryToMol(std::string smi,bool mergeHs=true,int debugParse=0);
+  RWMol *SLNQueryToMol(const std::string &smi,bool mergeHs=true,int debugParse=0);
 
   class SLNParseException : public std::exception {
   public:
     SLNParseException(const char *msg) : _msg(msg) {};
-    SLNParseException(const std::string msg) : _msg(msg) {};
+    SLNParseException(const std::string &msg) : _msg(msg) {};
     const char *message () const { return _msg.c_str(); };
     ~SLNParseException () throw () {};
   private:

--- a/Code/GraphMol/SLNParse/test.cpp
+++ b/Code/GraphMol/SLNParse/test.cpp
@@ -1863,6 +1863,38 @@ void testIssue277(){
   BOOST_LOG(rdInfoLog) << "\tdone" << std::endl;
 }
 
+void test17() {
+  RDKit::RWMol *mol;
+  std::string sln;
+
+  BOOST_LOG(rdInfoLog) << "-------------------------------------" << std::endl;
+  BOOST_LOG(rdInfoLog) << "Test1 " << std::endl;
+
+  // test whitespace at end
+  sln = "CH4 \t";
+  mol=RDKit::SLNToMol(sln);
+  TEST_ASSERT(mol);
+  TEST_ASSERT(mol->getNumAtoms()==1);
+
+  sln = "CH4\t";
+  mol=RDKit::SLNToMol(sln);
+  TEST_ASSERT(mol);
+  TEST_ASSERT(mol->getNumAtoms()==1);
+  delete mol;
+
+  sln = "CH4\tfff";
+  mol=RDKit::SLNToMol(sln);
+  TEST_ASSERT(!mol);
+  delete mol;
+
+  sln = "C[charge=+1] \t";
+  mol=RDKit::SLNQueryToMol(sln);
+  TEST_ASSERT(mol);
+
+  sln = "C[charge=+1] \tfoo";
+  mol=RDKit::SLNQueryToMol(sln);
+  TEST_ASSERT(!mol);
+}
 
 int
 main(int argc, char *argv[])
@@ -1889,6 +1921,7 @@ main(int argc, char *argv[])
   test14();
   test15();
   test16();
+  test17();
 #endif
   testIssue277();
   testIssue278();

--- a/Code/GraphMol/SanitException.h
+++ b/Code/GraphMol/SanitException.h
@@ -26,7 +26,7 @@ namespace RDKit {
   class MolSanitizeException : public std::exception {
     public :
       MolSanitizeException(const char *msg) : _msg(msg) {};
-      MolSanitizeException(const std::string msg) : _msg(msg) {};
+      MolSanitizeException(const std::string &msg) : _msg(msg) {};
       const char *message () const { return _msg.c_str(); };
       ~MolSanitizeException () throw () {};
     

--- a/Code/GraphMol/SmilesParse/SmilesParse.h
+++ b/Code/GraphMol/SmilesParse/SmilesParse.h
@@ -40,7 +40,7 @@ namespace RDKit{
    \endcode
 
    */
-  RWMol *SmilesToMol(std::string smi,int debugParse=0,bool sanitize=1,
+  RWMol *SmilesToMol(const std::string &smi,int debugParse=0,bool sanitize=1,
                      std::map<std::string,std::string> *replacements=0);
   //! Construct a molecule from a SMARTS string
   /*!
@@ -52,7 +52,7 @@ namespace RDKit{
 
    \return a pointer to the new molecule; the caller is responsible for free'ing this.
    */
-  RWMol *SmartsToMol(std::string sma,int debugParse=0,bool mergeHs=false,
+  RWMol *SmartsToMol(const std::string &sma,int debugParse=0,bool mergeHs=false,
                      std::map<std::string,std::string> *replacements=0);
 
   class SmilesParseException : public std::exception {

--- a/Code/GraphMol/SmilesParse/lex.yysmarts.cpp.cmake
+++ b/Code/GraphMol/SmilesParse/lex.yysmarts.cpp.cmake
@@ -632,7 +632,7 @@ size_t setup_smarts_string(const std::string &text,yyscan_t yyscanner){
   for(start = 0 ; start < _yybytes_len; ++start) {
     if (yybytes[start] > 32) break;
   }
-  for(end = _yybytes_len ; end >= 0; --end) {
+  for(end = _yybytes_len ; end > start; --end) {
     if (yybytes[end] > 32) break;
   }
 

--- a/Code/GraphMol/SmilesParse/lex.yysmarts.cpp.cmake
+++ b/Code/GraphMol/SmilesParse/lex.yysmarts.cpp.cmake
@@ -607,11 +607,6 @@ using namespace RDKit;
 
 //static PeriodicTable * gl_ptab = PeriodicTable::getTable();
 
-void setup_smarts_string(const std::string &text,yyscan_t yyscanner){
-  YY_BUFFER_STATE buff=yysmarts__scan_string(text.c_str(),yyscanner);
-  POSTCONDITION(buff,"invalid buffer");
-}
-
 #define YY_FATAL_ERROR(msg) smarts_lexer_error(msg)
 
 void smarts_lexer_error(const char *msg) {
@@ -619,6 +614,49 @@ void smarts_lexer_error(const char *msg) {
      throw ValueErrorException(msg);
 }
 
+size_t setup_smarts_string(const std::string &text,yyscan_t yyscanner){
+//  YY_BUFFER_STATE buff=yysmarts__scan_string(text.c_str()+pos,yyscanner);
+  // Faster implementation of yysmarts__scan_string that handles trimming
+  YY_BUFFER_STATE b;      
+  char *buf;
+  yyconst char * yybytes = text.c_str();  
+  yy_size_t _yybytes_len=text.size(), n, start, end; 
+  /* Get memory for full buffer, including space for trailing EOB's. */
+  n = _yybytes_len + 2;
+  buf = (char *) yysmarts_alloc(n ,yyscanner );
+  if ( ! buf )
+    smarts_lexer_error( "out of dynamic memory in yysmarts__scan_bytes()" );
+
+  // ltrim
+
+  for(start = 0 ; start < _yybytes_len; ++start) {
+    if (yybytes[start] > 32) break;
+  }
+  for(end = _yybytes_len ; end >= 0; --end) {
+    if (yybytes[end] > 32) break;
+  }
+
+  _yybytes_len = end-start+1;
+  n = _yybytes_len + 2;
+  memcpy(buf, yybytes+start, _yybytes_len);
+  
+  
+  buf[_yybytes_len] = buf[_yybytes_len+1] = YY_END_OF_BUFFER_CHAR;
+  
+  b = yysmarts__scan_buffer(buf,n ,yyscanner);
+  if ( ! b )
+    smarts_lexer_error( "bad buffer in yysmarts__scan_bytes()" );
+  
+  /* It's okay to grow etc. this buffer, and we should throw it
+   * away when we're done.
+   */
+  b->yy_is_our_buffer = 1;
+  
+  
+  POSTCONDITION(b,"invalid buffer");
+  return start;
+  
+}
 
 
 #line 625 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/lex.yysmarts.cpp"

--- a/Code/GraphMol/SmilesParse/lex.yysmiles.cpp.cmake
+++ b/Code/GraphMol/SmilesParse/lex.yysmiles.cpp.cmake
@@ -582,10 +582,6 @@ static yyconst flex_int16_t yy_chk[303] =
 
 using namespace RDKit;
 
-void setup_smiles_string(const std::string &text,yyscan_t yyscanner){
-  YY_BUFFER_STATE buff=yysmiles__scan_string(text.c_str(),yyscanner);
-  POSTCONDITION(buff,"invalid buffer");
-}
 #define YY_FATAL_ERROR(msg) smiles_lexer_error(msg)
 
 void smiles_lexer_error(const char *msg) {
@@ -593,6 +589,49 @@ void smiles_lexer_error(const char *msg) {
      throw ValueErrorException(msg);
 }
 
+size_t setup_smiles_string(const std::string &text,yyscan_t yyscanner){
+//  YY_BUFFER_STATE buff=yysmiles__scan_string(text.c_str()+pos,yyscanner);
+  // Faster implementation of yysmiles__scan_string that handles trimming
+  YY_BUFFER_STATE b;      
+  char *buf;
+  yyconst char * yybytes = text.c_str();  
+  yy_size_t _yybytes_len=text.size(), n, start, end; 
+  /* Get memory for full buffer, including space for trailing EOB's. */
+  n = _yybytes_len + 2;
+  buf = (char *) yysmiles_alloc(n ,yyscanner );
+  if ( ! buf )
+    smiles_lexer_error( "out of dynamic memory in yysmiles__scan_bytes()" );
+
+  // ltrim
+
+  for(start = 0 ; start < _yybytes_len; ++start) {
+    if (yybytes[start] > 32) break;
+  }
+  for(end = _yybytes_len ; end >= 0; --end) {
+    if (yybytes[end] > 32) break;
+  }
+
+  _yybytes_len = end-start+1;
+  n = _yybytes_len + 2;
+  memcpy(buf, yybytes+start, _yybytes_len);
+  
+  
+  buf[_yybytes_len] = buf[_yybytes_len+1] = YY_END_OF_BUFFER_CHAR;
+  
+  b = yysmiles__scan_buffer(buf,n ,yyscanner);
+  if ( ! b )
+    smiles_lexer_error( "bad buffer in yysmiles__scan_bytes()" );
+  
+  /* It's okay to grow etc. this buffer, and we should throw it
+   * away when we're done.
+   */
+  b->yy_is_our_buffer = 1;
+  
+  
+  POSTCONDITION(b,"invalid buffer");
+  return start;
+  
+}
 
 #line 598 "/Users/landrgr1/RDKit_git/Code/GraphMol/SmilesParse/lex.yysmiles.cpp"
 

--- a/Code/GraphMol/SmilesParse/lex.yysmiles.cpp.cmake
+++ b/Code/GraphMol/SmilesParse/lex.yysmiles.cpp.cmake
@@ -607,7 +607,7 @@ size_t setup_smiles_string(const std::string &text,yyscan_t yyscanner){
   for(start = 0 ; start < _yybytes_len; ++start) {
     if (yybytes[start] > 32) break;
   }
-  for(end = _yybytes_len ; end >= 0; --end) {
+  for(end = _yybytes_len ; end > start; --end) {
     if (yybytes[end] > 32) break;
   }
 

--- a/Code/GraphMol/SmilesParse/smarts.ll
+++ b/Code/GraphMol/SmilesParse/smarts.ll
@@ -53,7 +53,7 @@ size_t setup_smarts_string(const std::string &text,yyscan_t yyscanner){
   for(start = 0 ; start < _yybytes_len; ++start) {
     if (yybytes[start] > 32) break;
   }
-  for(end = _yybytes_len ; end >= 0; --end) {
+  for(end = _yybytes_len ; end > start; --end) {
     if (yybytes[end] > 32) break;
   }
 

--- a/Code/GraphMol/SmilesParse/smarts.ll
+++ b/Code/GraphMol/SmilesParse/smarts.ll
@@ -28,17 +28,57 @@ using namespace RDKit;
 
 //static PeriodicTable * gl_ptab = PeriodicTable::getTable();
 
-void setup_smarts_string(const std::string &text,yyscan_t yyscanner){
-  YY_BUFFER_STATE buff=yysmarts__scan_string(text.c_str(),yyscanner);
-  POSTCONDITION(buff,"invalid buffer");
-}
-
 #define YY_FATAL_ERROR(msg) smarts_lexer_error(msg)
 
 void smarts_lexer_error(const char *msg) {
      BOOST_LOG(rdErrorLog) << msg<<std::endl;
      throw ValueErrorException(msg);
 }
+
+size_t setup_smarts_string(const std::string &text,yyscan_t yyscanner){
+//  YY_BUFFER_STATE buff=yysmarts__scan_string(text.c_str()+pos,yyscanner);
+  // Faster implementation of yysmarts__scan_string that handles trimming
+  YY_BUFFER_STATE b;      
+  char *buf;
+  yyconst char * yybytes = text.c_str();  
+  yy_size_t _yybytes_len=text.size(), n, start, end; 
+  /* Get memory for full buffer, including space for trailing EOB's. */
+  n = _yybytes_len + 2;
+  buf = (char *) yysmarts_alloc(n ,yyscanner );
+  if ( ! buf )
+    smarts_lexer_error( "out of dynamic memory in yysmarts__scan_bytes()" );
+
+  // ltrim
+
+  for(start = 0 ; start < _yybytes_len; ++start) {
+    if (yybytes[start] > 32) break;
+  }
+  for(end = _yybytes_len ; end >= 0; --end) {
+    if (yybytes[end] > 32) break;
+  }
+
+  _yybytes_len = end-start+1;
+  n = _yybytes_len + 2;
+  memcpy(buf, yybytes+start, _yybytes_len);
+  
+  
+  buf[_yybytes_len] = buf[_yybytes_len+1] = YY_END_OF_BUFFER_CHAR;
+  
+  b = yysmarts__scan_buffer(buf,n ,yyscanner);
+  if ( ! b )
+    smarts_lexer_error( "bad buffer in yysmarts__scan_bytes()" );
+  
+  /* It's okay to grow etc. this buffer, and we should throw it
+   * away when we're done.
+   */
+  b->yy_is_our_buffer = 1;
+  
+  
+  POSTCONDITION(b,"invalid buffer");
+  return start;
+  
+}
+
 %}
 %option stack
 %s IN_ATOM_STATE

--- a/Code/GraphMol/SmilesParse/smiles.ll
+++ b/Code/GraphMol/SmilesParse/smiles.ll
@@ -54,7 +54,7 @@ size_t setup_smiles_string(const std::string &text,yyscan_t yyscanner){
   for(start = 0 ; start < _yybytes_len; ++start) {
     if (yybytes[start] > 32) break;
   }
-  for(end = _yybytes_len ; end >= 0; --end) {
+  for(end = _yybytes_len ; end > start; --end) {
     if (yybytes[end] > 32) break;
   }
 

--- a/Code/GraphMol/SmilesParse/smiles.ll
+++ b/Code/GraphMol/SmilesParse/smiles.ll
@@ -29,10 +29,6 @@
 
 using namespace RDKit;
 
-void setup_smiles_string(const std::string &text,yyscan_t yyscanner){
-  YY_BUFFER_STATE buff=yysmiles__scan_string(text.c_str(),yyscanner);
-  POSTCONDITION(buff,"invalid buffer");
-}
 #define YY_FATAL_ERROR(msg) smiles_lexer_error(msg)
 
 void smiles_lexer_error(const char *msg) {
@@ -40,6 +36,49 @@ void smiles_lexer_error(const char *msg) {
      throw ValueErrorException(msg);
 }
 
+size_t setup_smiles_string(const std::string &text,yyscan_t yyscanner){
+//  YY_BUFFER_STATE buff=yysmiles__scan_string(text.c_str()+pos,yyscanner);
+  // Faster implementation of yysmiles__scan_string that handles trimming
+  YY_BUFFER_STATE b;      
+  char *buf;
+  yyconst char * yybytes = text.c_str();  
+  yy_size_t _yybytes_len=text.size(), n, start, end; 
+  /* Get memory for full buffer, including space for trailing EOB's. */
+  n = _yybytes_len + 2;
+  buf = (char *) yysmiles_alloc(n ,yyscanner );
+  if ( ! buf )
+    smiles_lexer_error( "out of dynamic memory in yysmiles__scan_bytes()" );
+
+  // ltrim
+
+  for(start = 0 ; start < _yybytes_len; ++start) {
+    if (yybytes[start] > 32) break;
+  }
+  for(end = _yybytes_len ; end >= 0; --end) {
+    if (yybytes[end] > 32) break;
+  }
+
+  _yybytes_len = end-start+1;
+  n = _yybytes_len + 2;
+  memcpy(buf, yybytes+start, _yybytes_len);
+  
+  
+  buf[_yybytes_len] = buf[_yybytes_len+1] = YY_END_OF_BUFFER_CHAR;
+  
+  b = yysmiles__scan_buffer(buf,n ,yyscanner);
+  if ( ! b )
+    smiles_lexer_error( "bad buffer in yysmiles__scan_bytes()" );
+  
+  /* It's okay to grow etc. this buffer, and we should throw it
+   * away when we're done.
+   */
+  b->yy_is_our_buffer = 1;
+  
+  
+  POSTCONDITION(b,"invalid buffer");
+  return start;
+  
+}
 %}
 
 %s IN_ATOM_STATE

--- a/Code/JavaWrappers/GenericRDKitException.h
+++ b/Code/JavaWrappers/GenericRDKitException.h
@@ -16,7 +16,7 @@ namespace RDKit {
 class GenericRDKitException : public std::exception
 {
 public:
-  GenericRDKitException(const std::string i) : _value(i) {};
+  GenericRDKitException(const std::string &i) : _value(i) {};
   GenericRDKitException(const char *msg) : _value(msg) {};
   std::string message () const { return _value; };
   ~GenericRDKitException () throw () {};

--- a/Code/ML/InfoTheory/InfoBitRanker.cpp
+++ b/Code/ML/InfoTheory/InfoBitRanker.cpp
@@ -276,7 +276,7 @@ namespace RDInfoTheory {
     }
   }
   
-  void InfoBitRanker::writeTopBitsToFile(std::string fileName) const {
+  void InfoBitRanker::writeTopBitsToFile(const std::string &fileName) const {
     std::ofstream tmpStream(fileName.c_str());
     if ((!tmpStream) || (tmpStream.bad()) ) {
       std::ostringstream errout;

--- a/Code/ML/InfoTheory/InfoBitRanker.h
+++ b/Code/ML/InfoTheory/InfoBitRanker.h
@@ -191,7 +191,7 @@ namespace RDInfoTheory {
     /*! \brief Write the top bits to a file
      *
      */
-    void writeTopBitsToFile(std::string fileName) const;
+    void writeTopBitsToFile(const std::string &fileName) const;
 
   private:
     /*! \brief check if we want to compute the info content for a bit based on the bias list

--- a/Code/RDGeneral/BadFileException.h
+++ b/Code/RDGeneral/BadFileException.h
@@ -22,7 +22,7 @@ namespace RDKit {
     //! construct with an error message
     explicit BadFileException(const char *msg) : std::runtime_error("BadFileException"), _msg(msg) {};
     //! construct with an error message
-    explicit BadFileException(const std::string msg) : std::runtime_error("BadFileException"), _msg(msg) {};
+    explicit BadFileException(const std::string &msg) : std::runtime_error("BadFileException"), _msg(msg) {};
     //! get the error message
     const char *message () const { return _msg.c_str(); };
     ~BadFileException () throw () {};

--- a/Code/RDGeneral/Exceptions.h
+++ b/Code/RDGeneral/Exceptions.h
@@ -31,7 +31,7 @@ private:
 class ValueErrorException : public std::runtime_error
 {
 public:
-  ValueErrorException(const std::string i) : std::runtime_error("ValueErrorException"), _value(i) {};
+  ValueErrorException(const std::string &i) : std::runtime_error("ValueErrorException"), _value(i) {};
   ValueErrorException(const char *msg) : std::runtime_error("ValueErrorException"), _value(msg) {};
   std::string message () const { return _value; };
   ~ValueErrorException () throw () {};

--- a/Code/RDGeneral/Invariant.h
+++ b/Code/RDGeneral/Invariant.h
@@ -52,7 +52,7 @@ namespace Invar {
 	line_d( line )
     {
     }
-    Invariant( const char * prefix, std::string mess, const char * expr, const char * const file, int line )
+    Invariant( const char * prefix, const std::string &mess, const char * expr, const char * const file, int line )
       : std::runtime_error( prefix ),
 	mess_d( mess.c_str() ),
         expr_d( expr ),

--- a/Contrib/ConformerParser/ConformerParser.h
+++ b/Contrib/ConformerParser/ConformerParser.h
@@ -64,7 +64,7 @@ namespace RDKit{
       \param coords       list with coordinates
 
     */
-    void readAmberTrajectory(std::string fName, std::vector<std::vector<double> > &coords,
+    void readAmberTrajectory(const std::string &fName, std::vector<std::vector<double> > &coords,
                              unsigned int numAtoms);
 
   } // end namespace ConformerParser


### PR DESCRIPTION
Large ABI breaking migration of std::string API points to const std::string.

This removes a lot of string copies ( in the case of smiles/smarts it removes at least two ).

Special care should be taken to reviewing the smiles/smarts parsers, especially with FLEX/BISON on/off
            -DRDK_USE_FLEXBISON=ON 
 there are a lot of moving parts.