### PR TITLE
Fixes sprintf not found on some gcc compiles

### DIFF
--- a/Code/GraphMol/FileParsers/SequenceWriters.cpp
+++ b/Code/GraphMol/FileParsers/SequenceWriters.cpp
@@ -8,7 +8,7 @@
 //  of the RDKit source tree.
 //
 #include <string.h>
-
+#include <stdio.h>
 #include <string>
 
 #include <GraphMol/RDKitBase.h>


### PR DESCRIPTION
fixes the following on gcc 4.6.3 Ubuntu 12

Code/GraphMol/FileParsers/SequenceWriters.cpp: In function 'bool RDKit::FindHELMAtom(std::vector<RDKit::AtomPDBResidueInfo*>*, RDKit::AtomPDBResidueInfo*, std::string&, std::string&)':
/home/vagrant/devel/rdkit/Code/GraphMol/FileParsers/SequenceWriters.cpp:362:39: error: 'sprintf' was not declared in this scope
make[2]: *** [Code/GraphMol/FileParsers/CMakeFiles/FileParsers.dir/SequenceWriters.cpp.o] Error 1
make[1]: *** [Code/GraphMol/FileParsers/CMakeFiles/FileParsers.dir/all] Error 2
make: *** [all] Error 2
