### PR TITLE
Fix AppVeyor and Travis UnitTests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,6 +101,7 @@ install(FILES
 # extra boost versions
 if(MSVC)
   SET(Boost_ADDITIONAL_VERSIONS "1.48" "1.48.0" "1.45" "1.45.0" "1.44" "1.44.0" "1.43" "1.43.0" "1.42" "1.42.0" "1.41" "1.41.0" "1.40" "1.40.0")
+  ADD_DEFINITIONS("-DBOOST_ALL_NO_LIB")
 endif(MSVC)
 
 if(RDK_BUILD_PYTHON_WRAPPERS)

--- a/rdkit/Chem/Draw/UnitTestSimilarityMaps.py
+++ b/rdkit/Chem/Draw/UnitTestSimilarityMaps.py
@@ -34,10 +34,25 @@
 
 """ unit testing code for molecule drawing
 """
+from __future__ import print_function
 from rdkit import RDConfig
 import unittest,os,tempfile
 from rdkit import Chem
 from rdkit.Chem import Draw
+
+import platform
+if platform.system() == "Linux":
+  import os, sys
+  if not os.environ.get("DISPLAY", None):
+    try:
+      # Force matplotlib to not use any Xwindows backend.
+      import matplotlib
+      print("Forcing use of Agg renderer", file=sys.stderr)
+      matplotlib.use('Agg')
+    except ImportError:
+      pass
+
+
 try:
   from rdkit.Chem.Draw import SimilarityMaps as sm
 except ImportError:

--- a/rdkit/Chem/PandasTools.py
+++ b/rdkit/Chem/PandasTools.py
@@ -87,7 +87,13 @@ from rdkit.Chem import Draw
 
 try:
   import pandas as pd
-  v = pd.version.version.split('.')
+  try:
+    v = pd.__version__.split('.')
+  except AttributeError:
+    # support for older versions of pandas
+    v = pd.version.version.split('.')
+
+    
   if v[0]=='0' and int(v[1])<10:
     print("Pandas version %s not compatible with tests"%v, file=sys.stderr)
     pd = None

--- a/rdkit/Chem/PandasTools.py
+++ b/rdkit/Chem/PandasTools.py
@@ -101,7 +101,16 @@ try:
       pd.set_option('display.max_colwidth',1000000000)
     #saves the default pandas rendering to allow restauration
     defPandasRendering = pd.core.frame.DataFrame.to_html
+except ImportError:
+  import traceback
+  traceback.print_exc()
+  pd = None
+  
 except Exception as e:
+  import sys
+  print("Pandas version %s not compatible with tests"%v, file=sys.stderr)
+  import traceback
+  traceback.print_exc()
   pd = None
 
 highlightSubstructures=True

--- a/rdkit/Chem/PandasTools.py
+++ b/rdkit/Chem/PandasTools.py
@@ -89,6 +89,7 @@ try:
   import pandas as pd
   v = pd.version.version.split('.')
   if v[0]=='0' and int(v[1])<10:
+    print("Pandas version %s not compatible with tests"%v, file=sys.stderr)
     pd = None
   else:
     if 'display.width' in  pd.core.config._registered_options:
@@ -108,7 +109,6 @@ except ImportError:
   
 except Exception as e:
   import sys
-  print("Pandas version %s not compatible with tests"%v, file=sys.stderr)
   import traceback
   traceback.print_exc()
   pd = None

--- a/rdkit/Chem/PandasTools.py
+++ b/rdkit/Chem/PandasTools.py
@@ -488,7 +488,13 @@ if __name__ == "__main__":
   if pd is None:
     print("pandas installation not found, skipping tests", file=sys.stderr)
   else:
-    v = pd.version.version.split('.')
+    # version check
+    try:
+      v = pd.__version__.split('.')
+    except AttributeError:
+      # support for older versions of pandas
+      v = pd.version.version.split('.')
+    
     if v[0]=='0' and int(v[1])<10:
       print("pandas installation >=0.10 not found, skipping tests",
             file=sys.stderr)


### PR DESCRIPTION
UnitTestSimilarityMaps was failing on travis because no XWindow display was set.  This forces matplotlib to use the Agg renderer when the DISPLAY variable isn't set which allows the test to pass but perhaps has side-effects.