### PR TITLE
Fixes #629 - python GetSubstructureMatch thread safety

### DIFF
--- a/Code/GraphMol/Wrap/Mol.cpp
+++ b/Code/GraphMol/Wrap/Mol.cpp
@@ -89,9 +89,11 @@ namespace RDKit {
   }
   PyObject *GetSubstructMatch(const ROMol &mol, const ROMol &query,bool useChirality=false,
                             bool useQueryQueryMatches=false){
-    NOGIL gil;
     MatchVectType matches;
-    SubstructMatch(mol,query,matches,true,useChirality,useQueryQueryMatches);
+    {
+      NOGIL gil;
+      SubstructMatch(mol,query,matches,true,useChirality,useQueryQueryMatches);
+    }
     return convertMatches(matches);
   }
 
@@ -100,7 +102,11 @@ namespace RDKit {
                                 bool useQueryQueryMatches=false,
                                 unsigned int maxMatches = 1000){
     std::vector< MatchVectType >  matches;
-    int matched = SubstructMatch(mol,query,matches,uniquify,true,useChirality,useQueryQueryMatches,maxMatches);
+    int matched;
+    {
+      NOGIL gil;
+      matched = SubstructMatch(mol,query,matches,uniquify,true,useChirality,useQueryQueryMatches,maxMatches);
+    }
     PyObject *res = PyTuple_New(matched);
     for(int idx=0;idx<matched;idx++){
       PyTuple_SetItem(res,idx,convertMatches(matches[idx]));


### PR DESCRIPTION
Never/ever call the Python API when the GIL is released.

Also releases the GIL during GetSubstructMatches.

Any ideas how to add a test case for this?  Do we know when to test threading?