### PR TITLE
Fix regressions occurring when building with msvc9

### DIFF
--- a/Code/GraphMol/FileParsers/MolFileWriter.cpp
+++ b/Code/GraphMol/FileParsers/MolFileWriter.cpp
@@ -633,7 +633,7 @@ namespace RDKit{
       // the mol file
       if ((dirCode == 1) || (dirCode == 6)) {
         INT_MAP_INT_CI wbi = wedgeBonds.find(bond->getIdx());
-        if (static_cast<unsigned int>(wbi->second) != bond->getBeginAtomIdx()) {
+        if (wbi != wedgeBonds.end() && static_cast<unsigned int>(wbi->second) != bond->getBeginAtomIdx()) {
           reverse = true;
         }
       }

--- a/Code/GraphMol/FileParsers/testMolWriter.cpp
+++ b/Code/GraphMol/FileParsers/testMolWriter.cpp
@@ -1350,7 +1350,7 @@ void testGithub611(){
     m->getBondWithIdx(2)->setBondDir(Bond::BEGINWEDGE);
     mb = MolToMolBlock(*m);
     TEST_ASSERT(mb.find("3  2  1  6")==std::string::npos);
-    TEST_ASSERT(mb.find("4  3  1  1")!=std::string::npos);
+    TEST_ASSERT(mb.find("3  4  1  1")!=std::string::npos);
   }
 }
 

--- a/Code/GraphMol/MolOps.cpp
+++ b/Code/GraphMol/MolOps.cpp
@@ -486,8 +486,9 @@ namespace RDKit{
     }
 
     unsigned int getMolFrags(const ROMol &mol, INT_VECT &mapping) {
-      mapping.resize(mol.getNumAtoms());
-      return boost::connected_components(mol.getTopology(),&mapping[0]);
+      unsigned int natms = mol.getNumAtoms();
+      mapping.resize(natms);
+      return natms ? boost::connected_components(mol.getTopology(),&mapping[0]) : 0;
     };
 
     unsigned int getMolFrags(const ROMol &mol, VECT_INT_VECT &frags) {


### PR DESCRIPTION
this PR fixes a few errors I observed in running tests after building RDKit with the "Microsoft Visual C++ Compiler for Python 2.7".

the changes make sense to me, but especially those related to the management of wedge bonds (probably a side effect of #611) could require a review.

thanks,
riccardo
  