### PR TITLE
Image tostring/fromstring methods replaced by tobytes/frombytes

### DIFF
--- a/rdkit/Chem/Draw/cairoCanvas.py
+++ b/rdkit/Chem/Draw/cairoCanvas.py
@@ -50,10 +50,7 @@ else:
   pangocairo=None
 
 from rdkit.Chem.Draw.canvasbase import CanvasBase
-try:
-  import Image
-except ImportError:
-  from PIL import Image
+from PIL import Image
 
 scriptPattern=re.compile(r'\<.+?\>')
   
@@ -76,10 +73,10 @@ class Canvas(CanvasBase):
     self.imageType=imageType
     if image is not None:
       try:
-      	imgd = image.tostring("raw","BGRA")
+      	imgd = image.tobytes("raw","BGRA")
       except SystemError:
         r,g,b,a = image.split()
-        imgd = Image.merge("RGBA",(b,g,r,a)).tostring("raw","RGBA")
+        imgd = Image.merge("RGBA",(b,g,r,a)).tobytes("raw","RGBA")
    
       a = array.array('B',imgd)
       stride=image.size[0]*4
@@ -123,11 +120,11 @@ class Canvas(CanvasBase):
     elif self.image is not None:
       # on linux at least it seems like the PIL images are BGRA, not RGBA:
       if hasattr(self.surface,'get_data'):
-        self.image.fromstring(bytes(self.surface.get_data()),
-                              "raw","BGRA",0,1)
+        self.image.frombytes(bytes(self.surface.get_data()),
+                             "raw","BGRA",0,1)
       else:
-        self.image.fromstring(bytes(surface.get_data_as_rgba()),
-                              "raw","RGBA",0,1)
+        self.image.frombytes(bytes(surface.get_data_as_rgba()),
+                             "raw","RGBA",0,1)
       self.surface.finish()
     elif self.imageType == "png":
       if hasattr(self.surface,'get_data'):

--- a/rdkit/Chem/Draw/cairoCanvas.py
+++ b/rdkit/Chem/Draw/cairoCanvas.py
@@ -73,10 +73,11 @@ class Canvas(CanvasBase):
     self.imageType=imageType
     if image is not None:
       try:
-      	imgd = image.tobytes("raw","BGRA")
+        imgd = getattr(image,'tobytes',image.tostring)("raw","BGRA")
       except SystemError:
         r,g,b,a = image.split()
-        imgd = Image.merge("RGBA",(b,g,r,a)).tobytes("raw","RGBA")
+        mrg = Image.merge("RGBA",(b,g,r,a))
+        imgd = getattr(mrg,'tobytes',mrg.tostring)("raw","RGBA")
    
       a = array.array('B',imgd)
       stride=image.size[0]*4
@@ -120,11 +121,11 @@ class Canvas(CanvasBase):
     elif self.image is not None:
       # on linux at least it seems like the PIL images are BGRA, not RGBA:
       if hasattr(self.surface,'get_data'):
-        self.image.frombytes(bytes(self.surface.get_data()),
-                             "raw","BGRA",0,1)
+        getattr(self.image,'frombytes',self.image.fromstring)(bytes(self.surface.get_data()),
+                                                              "raw","BGRA",0,1)
       else:
-        self.image.frombytes(bytes(surface.get_data_as_rgba()),
-                             "raw","RGBA",0,1)
+        getattr(self.image,'frombytes',self.image.fromstring)(bytes(surface.get_data_as_rgba()),
+                                                              "raw","RGBA",0,1)
       self.surface.finish()
     elif self.imageType == "png":
       if hasattr(self.surface,'get_data'):

--- a/rdkit/ML/MLUtils/VoteImg.py
+++ b/rdkit/ML/MLUtils/VoteImg.py
@@ -103,7 +103,7 @@ def BuildVoteImage(nModels,data,values,trueValues=[],
   data = [data[x] for x in order]
   maxVal = max(numpy.ravel(data))
   data = data * 255 / maxVal
-  img = Image.fromstring('L',(nModels,nData),data.astype('B').tostring())
+  img = Image.frombytes('L',(nModels,nData),data.astype('B').tobytes())
 
   if addLine:
     img = img.convert('RGB')

--- a/rdkit/ML/MLUtils/VoteImg.py
+++ b/rdkit/ML/MLUtils/VoteImg.py
@@ -103,8 +103,9 @@ def BuildVoteImage(nModels,data,values,trueValues=[],
   data = [data[x] for x in order]
   maxVal = max(numpy.ravel(data))
   data = data * 255 / maxVal
-  img = Image.frombytes('L',(nModels,nData),data.astype('B').tobytes())
-
+  datab = data.astype('B')
+  img = getattr(Image,'frombytes',Image.fromstring)('L',(nModels,nData),getattr(datab,'tobytes',datab.tostring)())
+  
   if addLine:
     img = img.convert('RGB')
     canvas = ImageDraw.Draw(img)

--- a/rdkit/sping/PDF/pdfgen.py
+++ b/rdkit/sping/PDF/pdfgen.py
@@ -645,7 +645,7 @@ class Canvas:
             imagedata.append('ID')   
 
             #use a flate filter and Ascii Base 85 to compress
-            raw = myimage.tostring()
+            raw = myimage.tobytes()
             assert len(raw) == imgwidth * imgheight, "Wrong amount of data for image"
             compressed = zlib.compress(raw)   #this bit is very fast...
             encoded = pdfutils._AsciiBase85Encode(compressed) #...sadly this isn't

--- a/rdkit/sping/PDF/pdfgen.py
+++ b/rdkit/sping/PDF/pdfgen.py
@@ -645,7 +645,7 @@ class Canvas:
             imagedata.append('ID')   
 
             #use a flate filter and Ascii Base 85 to compress
-            raw = myimage.tobytes()
+            raw = getattr(myimage, 'tobytes', myimage.tostring)()
             assert len(raw) == imgwidth * imgheight, "Wrong amount of data for image"
             compressed = zlib.compress(raw)   #this bit is very fast...
             encoded = pdfutils._AsciiBase85Encode(compressed) #...sadly this isn't

--- a/rdkit/sping/PDF/pdfutils.py
+++ b/rdkit/sping/PDF/pdfutils.py
@@ -28,7 +28,7 @@ def cacheImageFile(filename):
     code.append('/W %s /H %s /BPC 8 /CS /RGB /F [/A85 /Fl]' % (imgwidth, imgheight))
     code.append('ID')
     #use a flate filter and Ascii Base 85
-    raw = img.tostring()
+    raw = img.tobytes()
     assert(len(raw) == imgwidth * imgheight, "Wrong amount of data for image")
     compressed = zlib.compress(raw)   #this bit is very fast...
     encoded = _AsciiBase85Encode(compressed) #...sadly this isn't

--- a/rdkit/sping/PDF/pdfutils.py
+++ b/rdkit/sping/PDF/pdfutils.py
@@ -28,7 +28,7 @@ def cacheImageFile(filename):
     code.append('/W %s /H %s /BPC 8 /CS /RGB /F [/A85 /Fl]' % (imgwidth, imgheight))
     code.append('ID')
     #use a flate filter and Ascii Base 85
-    raw = img.tobytes()
+    raw = getattr(img, 'tobytes', img.tostring)()
     assert(len(raw) == imgwidth * imgheight, "Wrong amount of data for image")
     compressed = zlib.compress(raw)   #this bit is very fast...
     encoded = _AsciiBase85Encode(compressed) #...sadly this isn't

--- a/rdkit/sping/PS/pidPS.py
+++ b/rdkit/sping/PS/pidPS.py
@@ -923,7 +923,7 @@ translate
        # series of lines of the right overall size can follow
        # piddlePDF again
 
-       rawimage = myimage.tostring()
+       rawimage = myimage.tobytes()
        assert len(rawimage) == imgwidth*imgheight, 'Wrong amount of data for image' 
        #compressed = zlib.compress(rawimage) # no zlib at moment
        hex_encoded = self._AsciiHexEncode(rawimage)
@@ -1014,7 +1014,7 @@ translate
                           '>> % End image dictionary',
                           'image'])
         # after image operator just need to dump image dat to file as hexstring
-        rawimage = myimage.tostring()
+        rawimage = myimage.tobytes()
         assert len(rawimage) == imwidth*imheight, 'Wrong amount of data for image' 
         #compressed = zlib.compress(rawimage) # no zlib at moment
         hex_encoded = self._AsciiHexEncode(rawimage)

--- a/rdkit/sping/PS/pidPS.py
+++ b/rdkit/sping/PS/pidPS.py
@@ -923,7 +923,7 @@ translate
        # series of lines of the right overall size can follow
        # piddlePDF again
 
-       rawimage = myimage.tobytes()
+       rawimage = getattr(myimage, 'tobytes', myimage.tostring)()
        assert len(rawimage) == imgwidth*imgheight, 'Wrong amount of data for image' 
        #compressed = zlib.compress(rawimage) # no zlib at moment
        hex_encoded = self._AsciiHexEncode(rawimage)
@@ -1014,7 +1014,7 @@ translate
                           '>> % End image dictionary',
                           'image'])
         # after image operator just need to dump image dat to file as hexstring
-        rawimage = myimage.tobytes()
+        rawimage = getattr(myimage, 'tobytes', myimage.tostring)()
         assert len(rawimage) == imwidth*imheight, 'Wrong amount of data for image' 
         #compressed = zlib.compress(rawimage) # no zlib at moment
         hex_encoded = self._AsciiHexEncode(rawimage)

--- a/rdkit/sping/WX/pidWxDc.py
+++ b/rdkit/sping/WX/pidWxDc.py
@@ -274,7 +274,7 @@ class PiddleWxDc(sping_pid.Canvas):
             imgPil = image
         if (imgPil.mode!='RGB'):
             imgPil = imgPil.convert('RGB')
-        imgData = imgPil.tostring('raw','RGB')
+        imgData = imgPil.tobytes('raw','RGB')
         imgWx = wxEmptyImage(imgPil.size[0],imgPil.size[1])
         imgWx.SetData(imgData)
         self.dc.DrawBitmap(imgWx.ConvertToBitmap(), x1, y1)

--- a/rdkit/sping/WX/pidWxDc.py
+++ b/rdkit/sping/WX/pidWxDc.py
@@ -274,7 +274,7 @@ class PiddleWxDc(sping_pid.Canvas):
             imgPil = image
         if (imgPil.mode!='RGB'):
             imgPil = imgPil.convert('RGB')
-        imgData = imgPil.tobytes('raw','RGB')
+        imgData = getattr(imgPil, 'tobytes', imgPil.tostring)('raw','RGB')
         imgWx = wxEmptyImage(imgPil.size[0],imgPil.size[1])
         imgWx.SetData(imgData)
         self.dc.DrawBitmap(imgWx.ConvertToBitmap(), x1, y1)


### PR DESCRIPTION
In Pillow 3.0.0 some deprecated parts of the API have been removed (http://pillow.readthedocs.org/en/3.0.x/releasenotes/3.0.0.html#deprecated-methods). This pr replaces calls to tostring/fromstring with tobytes/frombytes. 

this changeset might be not backward compatible with the older PIL implementation (I didn't verify) and it's been only verified to the extent of the tests coverage.
