### PR TITLE
Minimal SWIG Java wrappers for ResonanceMolSupplier

### DIFF
--- a/Code/JavaWrappers/MolSupplier.i
+++ b/Code/JavaWrappers/MolSupplier.i
@@ -38,14 +38,17 @@
 
 %{
 #include <GraphMol/FileParsers/MolSupplier.h>
+#include <GraphMol/Resonance.h>
 %}
 
 
 %newobject RDKit::ForwardSDMolSupplier::next;
+%newobject RDKit::ResonanceMolSupplier::next;
 %newobject RDKit::SDMolSupplier::next;
 %newobject RDKit::SmilesMolSupplier::next;
 %newobject RDKit::TDTMolSupplier::next;
 %newobject RDKit::PDBMolSupplier::next;
 
 %include <GraphMol/FileParsers/MolSupplier.h>
+%include <GraphMol/Resonance.h>
 

--- a/Code/JavaWrappers/ROMol.i
+++ b/Code/JavaWrappers/ROMol.i
@@ -38,6 +38,7 @@
 #include <GraphMol/ROMol.h>
 #include <GraphMol/Conformer.h>
 #include <GraphMol/Substruct/SubstructMatch.h>
+#include <GraphMol/Resonance.h>
 #include <GraphMol/ChemTransforms/ChemTransforms.h>
 #include <GraphMol/Chirality.h>
 #include <GraphMol/SmilesParse/SmilesParse.h>
@@ -175,6 +176,12 @@
   std::vector< std::vector<std::pair<int, int> > > getSubstructMatches(RDKit::ROMol &query,bool uniquify=true, bool useChirality=false){
     std::vector<RDKit::MatchVectType> mv;
     SubstructMatch(*($self),query,mv,uniquify,true,useChirality);
+    return mv;
+  };
+
+  std::vector< std::vector<std::pair<int, int> > > getResonanceSubstructMatches(RDKit::ROMol &query,bool uniquify=false, bool useChirality=false, int numThreads=1){
+    std::vector<RDKit::MatchVectType> mv;
+    SubstructMatch(*($self),query,mv,uniquify,true,useChirality,false,1000,numThreads);
     return mv;
   };
 

--- a/Code/JavaWrappers/gmwrapper/src-test/org/RDKit/BasicMolecule2Tests.java
+++ b/Code/JavaWrappers/gmwrapper/src-test/org/RDKit/BasicMolecule2Tests.java
@@ -155,6 +155,26 @@ public class BasicMolecule2Tests extends GraphMolTest {
 		assertEquals(3,mvv.get(1).get(1).getSecond());
 	}
 
+	@Test public void testSubstruct6() {
+		ROMol p;
+		Match_Vect_Vect mvv;
+		ROMol m2;
+		m2 = RWMol.MolFromSmiles("CC(=O)[O-]");
+    ResonanceMolSupplier rs = new ResonanceMolSupplier(m2);
+		assertEquals(2,rs.length());
+		p = RWMol.MolFromSmarts("C(=O)[O-]");
+		mvv=m2.getSubstructMatches(p);
+		assertEquals(1,mvv.size());
+		assertEquals(3,mvv.get(0).size());
+		mvv=m2.getResonanceSubstructMatches(p);
+		assertEquals(2,mvv.size());
+		assertEquals(3,mvv.get(0).size());
+		assertEquals(3,mvv.get(1).size());
+		mvv=m2.getResonanceSubstructMatches(p, true);
+		assertEquals(1,mvv.size());
+		assertEquals(3,mvv.get(0).size());
+	}
+
 	public static void main(String args[]) {
 		org.junit.runner.JUnitCore.main("org.RDKit.BasicMolecule2Tests");
 	}

--- a/Code/JavaWrappers/gmwrapper/src-test/org/RDKit/WrapperTests.java
+++ b/Code/JavaWrappers/gmwrapper/src-test/org/RDKit/WrapperTests.java
@@ -183,6 +183,13 @@ public class WrapperTests extends GraphMolTest {
     }
 
     @Test
+    public void testBasicInstantiation_ResonanceMolSupplier() {
+       	ROMol m = RWMol.MolFromSmiles("CC(=O)[O-]");
+        ResonanceMolSupplier sup = new ResonanceMolSupplier(m);
+        assertNotNull(sup);
+    }
+
+    @Test
     public void testBasicInstantiation_SDMWriter() {
         SDWriter mw = new SDWriter("tmp.sdf");
         mw.close();


### PR DESCRIPTION
- added SWIG Java wrappers for ResonanceMolSupplier and
  getResonanceSubstructMatches()
- added a few tests