### PR TITLE
Fix unordered_map header

### DIFF
--- a/Code/GraphMol/Resonance.h
+++ b/Code/GraphMol/Resonance.h
@@ -13,7 +13,7 @@
 #include <vector>
 #include <stack>
 #include <map>
-#include <boost/unordered_set.hpp>
+#include <boost/unordered_map.hpp>
 
 namespace RDKit {
   class ROMol;


### PR DESCRIPTION
Changed unorderd_set to unordered_map (later versions of boost work ok, some versions don't define unordered_map in unordered_set)