### PR TITLE
fixed FutureWarning in PeriodicTable.py

### DIFF
--- a/rdkit/Chem/PeriodicTable.py
+++ b/rdkit/Chem/PeriodicTable.py
@@ -14,8 +14,6 @@
   this data is mostly obsolete
 
 """
-import re
-blankExpr = re.compile(r'\ *\t*\ *')
 # Num	Symb	RCov	RBO	RVdW	Max Bnd	Mass   nval
 periodicData=\
 """
@@ -128,7 +126,7 @@ periodicData=\
 nameTable = {}
 numTable = {}
 for line in periodicData.split('\n'):
-  splitLine = blankExpr.split(line)
+  splitLine = line.split()
   if len(splitLine)>1:
     nameTable[splitLine[1]] = (int(splitLine[0]),float(splitLine[6]),int(splitLine[7]),\
                                int(splitLine[5]),float(splitLine[2]),float(splitLine[3]),


### PR DESCRIPTION
In Python 3.5, there is an annoying FutureWarning about the use of a regular expression in PeriodicTable.py on import of the Chem module:

```
In [1]: from rdkit import Chem
/Users/rich/anaconda/lib/python3.5/site-packages/rdkit/Chem/PeriodicTable.py:131: FutureWarning: split() requires a non-empty pattern match.
  splitLine = blankExpr.split(line)
```

This pull request replaces the regular expression with the string method, `split`, that should fulfil the same function.  I don't think this module is used anymore, so could be removed to prevent the warning message, but this fixes the warning message in case we want to keep it.