### PR TITLE
Fixes a memory leak in fragmentMol

### DIFF
--- a/Code/GraphMol/MMPA/MMPA.cpp
+++ b/Code/GraphMol/MMPA/MMPA.cpp
@@ -136,10 +136,10 @@ std::cout<<res.size()+1<<": ";
 #ifdef _DEBUG
 std::cout<<"\n";            
 #endif
-        RWMol *core=NULL, *side_chains=NULL;   // core & side_chains output molecules
+        RWMOL_SPTR core, side_chains;   // core & side_chains output molecules
 
         if(isotope == 1){
-            side_chains = new RWMol(em); // output = '%s,%s,,%s.%s'
+	  side_chains = RWMOL_SPTR(new RWMol(em)); // output = '%s,%s,,%s.%s'
 // DEBUG PRINT
 #ifdef _DEBUG
 //OK: std::cout<<res.size()+1<<" isotope="<< isotope <<","<< MolToSmiles(*side_chains, true) <<"\n";
@@ -175,7 +175,7 @@ std::cout<<"isotope>=3: invalid fragments. fragment with maxCut connection point
             }
 
             size_t iCore = -1;
-            side_chains = new RWMol;
+            side_chains = RWMOL_SPTR(new RWMol);
             std::map<unsigned, unsigned> visitedBonds;// key is bond index in source molecule
             unsigned maxAttachments = 0;
             for(size_t i=0; i < frags.size(); i++) {
@@ -203,8 +203,8 @@ std::cout<<"isotope>=3: invalid fragments. fragment with maxCut connection point
                             || newAtomMap.end() == newAtomMap.find(bond->getEndAtomIdx())
                             || visitedBonds.end() != visitedBonds.find(bond->getIdx()) )
                                 continue;
-                            unsigned ai1 = newAtomMap[bond->getBeginAtomIdx()];
-                            unsigned ai2 = newAtomMap[bond->getEndAtomIdx()];
+                            unsigned ai1 = newAtomMap.at(bond->getBeginAtomIdx());
+                            unsigned ai2 = newAtomMap.at(bond->getEndAtomIdx());
                             unsigned bi  = side_chains->addBond(ai1, ai2, bond->getBondType());
                             visitedBonds[bond->getIdx()] = bi;
                         }
@@ -222,7 +222,7 @@ if(iCore != -1)
             }
             // build core molecule from selected fragment
             if(iCore != -1) {
-                core = new RWMol;
+         	core = RWMOL_SPTR(new RWMol);
                 visitedBonds.clear();
                 std::map<unsigned, unsigned> newAtomMap;  // key is atom index in source molecule
                 for(size_t i=0; i < frags[iCore].size(); i++) {
@@ -240,8 +240,8 @@ if(iCore != -1)
                         || newAtomMap.end() == newAtomMap.find(bond->getEndAtomIdx())
                         || visitedBonds.end() != visitedBonds.find(bond->getIdx()) )
                             continue;
-                        unsigned ai1 = newAtomMap[bond->getBeginAtomIdx()];
-                        unsigned ai2 = newAtomMap[bond->getEndAtomIdx()];
+                        unsigned ai1 = newAtomMap.at(bond->getBeginAtomIdx());
+                        unsigned ai2 = newAtomMap.at(bond->getEndAtomIdx());
                         unsigned bi  = core->addBond(ai1, ai2, bond->getBondType());
                         visitedBonds[bond->getIdx()] = bi;
                     }
@@ -259,10 +259,10 @@ if(iCore != -1)
             const std::pair<ROMOL_SPTR,ROMOL_SPTR>& r = res[ri];
             if(  side_chains->getNumAtoms() == r.second->getNumAtoms()
               && side_chains->getNumBonds() == r.second->getNumBonds()
-              &&((NULL==core && NULL==r.first.get()) 
-               ||(NULL!=core && NULL!=r.first.get()
-                && core->getNumAtoms() == r.first->getNumAtoms() 
-                && core->getNumBonds() == r.first->getNumBonds()) )   ) {
+		 &&((NULL==core.get() && NULL==r.first.get()) 
+		    ||(NULL!=core.get() && NULL!=r.first.get()
+		       && core->getNumAtoms() == r.first->getNumAtoms() 
+		       && core->getNumBonds() == r.first->getNumBonds()) )   ) {
                 // ToDo accurate check:
                 // 1. compare hash code
                 if(computeMorganCodeHash(*side_chains) == computeMorganCodeHash(*r.second)
@@ -276,7 +276,7 @@ if(iCore != -1)
             }
         }
         if(!resFound)
-            res.push_back(std::pair<ROMOL_SPTR,ROMOL_SPTR>(ROMOL_SPTR(core), ROMOL_SPTR(side_chains)));
+	  res.push_back(std::pair<ROMOL_SPTR,ROMOL_SPTR>(core, side_chains));//
 #ifdef _DEBUG
         else
 std::cout<<res.size()+1<<" --- DUPLICATE Result FOUND --- ri="<<ri<<"\n";

--- a/Code/GraphMol/MMPA/MMPA.cpp
+++ b/Code/GraphMol/MMPA/MMPA.cpp
@@ -311,6 +311,7 @@ std::cout<<res.size()+1<<" --- DUPLICATE Result FOUND --- ri="<<ri<<"\n";
     bool fragmentMol(const ROMol& mol,
                      std::vector< std::pair<ROMOL_SPTR,ROMOL_SPTR> >& res,
                      unsigned int maxCuts,
+                     unsigned int maxCutBonds,
                      const std::string& pattern) {
 #ifdef _DEBUG
 for(size_t i=0; i < mol.getNumAtoms(); i++)
@@ -360,6 +361,8 @@ for(size_t i=0; i < matching_atoms.size(); i++)
 
         std::vector<BondVector_t> matching_bonds; // List of matched query's bonds
         convertMatchingToBondVect(matching_bonds, matching_atoms, mol);
+        if (matching_bonds.size() > maxCutBonds)
+          return false;
 #ifdef _DEBUG
 std::cout<<"total matching_bonds = "<<matching_bonds.size()<<"\n";
 #endif

--- a/Code/GraphMol/MMPA/MMPA.h
+++ b/Code/GraphMol/MMPA/MMPA.h
@@ -16,10 +16,25 @@
 namespace RDKit {
 
   namespace MMPA {
-  
+    //! fragments a Molecule for processing with the Matched Molecular Pairs
+    //!  MMPA algorithm (Hussain et al)
+    /*!
+      \param mol           Molecule to fragment
+      \param result        Vector of Core and Sidechain results from the various cuts
+      \param maxCuts        Maximum number of times to cut the molecule to generate
+                            fragments.  A max cut of 3 will fragment with 1,2 and 3
+                            cuts.
+      \param maxCutBonds  Set the bond limit for determining which molecules
+                            to analyze.  If a molecule has more than
+                            this number of cutabble bonds, ignore.
+
+     \return true if the molecule was fragmented, false otherwise.
+    */
+
     bool fragmentMol(const ROMol &mol,
                      std::vector< std::pair<ROMOL_SPTR,ROMOL_SPTR> >& result,
                      unsigned int maxCuts=3,
+                     unsigned int maxCutBonds=20,
                      const std::string& pattern="[#6+0;!$(*=,#[!#6])]!@!=!#[*]");
   }
 } // namespace RDKit

--- a/Code/GraphMol/MMPA/Wrap/rdMMPA.cpp
+++ b/Code/GraphMol/MMPA/Wrap/rdMMPA.cpp
@@ -20,10 +20,11 @@ namespace python = boost::python;
 namespace {
   python::tuple fragmentMolHelper(const RDKit::ROMol &mol,
                                   unsigned int maxCuts,
+                                  unsigned int maxCutBonds,
                                   const std::string& pattern,
                                   bool resultsAsMols){
     std::vector< std::pair<RDKit::ROMOL_SPTR,RDKit::ROMOL_SPTR> > tres;
-    bool ok=RDKit::MMPA::fragmentMol(mol,tres,maxCuts,pattern);
+    bool ok=RDKit::MMPA::fragmentMol(mol,tres,maxCuts,maxCutBonds,pattern);
     python::list pyres;
     if(ok){
       for(std::vector< std::pair<RDKit::ROMOL_SPTR,RDKit::ROMOL_SPTR> >::const_iterator pr=tres.begin();
@@ -56,6 +57,7 @@ BOOST_PYTHON_MODULE(rdMMPA) {
   python::def("FragmentMol", fragmentMolHelper,
               (python::arg("mol"),
                python::arg("maxCuts")=3,
+               python::arg("maxCutBonds")=20,
                python::arg("pattern")="[#6+0;!$(*=,#[!#6])]!@!=!#[*]",
                python::arg("resultsAsMols")=true),
               docString.c_str());

--- a/Code/GraphMol/MMPA/Wrap/testMMPA.py
+++ b/Code/GraphMol/MMPA/Wrap/testMMPA.py
@@ -90,6 +90,13 @@ class TestCase(unittest.TestCase):
         for frag in frags:
             self.assertEqual(len(frag),2)        
 
+    def test5(self):
+        m = Chem.MolFromSmiles("CC[C@H](C)[C@@H](C(=O)N[C@H]1CSSC[C@H]2C(=O)NCC(=O)N3CCC[C@H]3C(=O)N[C@H](C(=O)N[C@H](C(=O)N[C@H](C(=O)N[C@@H](CSSC[C@@H](C(=O)N[C@H](C(=O)N4CCC[C@H]4C(=O)N[C@H](C(=O)N2)C)CC(=O)N)NC1=O)C(=O)N)CO)Cc5ccc(cc5)O)CCCC[NH3+])N") # ALPHA-CONOTOXIN SI
+        frags = rdMMPA.FragmentMol(m,resultsAsMols=False)
+        self.assertFalse(len(frags))
+        frags = rdMMPA.FragmentMol(m,maxCuts=2,maxCutBonds=21,resultsAsMols=False)
+        self.assertEqual(len(frags), 231)
+                
 
 
 if __name__=="__main__":


### PR DESCRIPTION
addResult was leaking the core and side_chains (verified with valgrind)

The raw core and side_chain pointers were converted to RWMOL_SPTR so if they are not pushed onto the result vector, they will be cleaned up regardless of code path.
