### PR TITLE
Updates CMAKE_SOURCE_DIR to CMAKE_CURRENT_SOURCE_DIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,8 +57,8 @@ set(RDKit_Month "03")
 set(RDKit_Revision "1.dev1")
 set(RDKit_ABI "1")
 
-set(RDKit_CodeDir "${CMAKE_SOURCE_DIR}/Code")
-set(RDKit_ExternalDir "${CMAKE_SOURCE_DIR}/External")
+set(RDKit_CodeDir "${CMAKE_CURRENT_SOURCE_DIR}/Code")
+set(RDKit_ExternalDir "${CMAKE_CURRENT_SOURCE_DIR}/External")
 
 if(RDK_INSTALL_INTREE)
   set(RDKit_BinDir "${CMAKE_SOURCE_DIR}/bin")


### PR DESCRIPTION
to allow for easier inclusion in other repos

This allows RDKit to be used as a subtree or submodule in other projects.