### PR TITLE
Fixes #717

### DIFF
--- a/Code/GraphMol/AddHs.cpp
+++ b/Code/GraphMol/AddHs.cpp
@@ -218,15 +218,17 @@ void setHydrogenCoords(ROMol *mol, unsigned int hydIdx, unsigned int heavyIdx) {
       // Three other neighbors:
       // --------------------------------------------------------------------------
       boost::tie(nbrIdx, endNbrs) = mol->getAtomNeighbors(heavyAtom);
+
       if (heavyAtom->hasProp(common_properties::_CIPCode)) {
         // if the central atom is chiral, we'll order the neighbors
         // by CIP rank:
-        std::vector<std::pair<int, int> > nbrs;
+        std::vector<std::pair<unsigned int, int> > nbrs;
         while (nbrIdx != endNbrs) {
           if (*nbrIdx != hydIdx) {
             const Atom *tAtom = mol->getAtomWithIdx(*nbrIdx);
-            int cip = 0;
-            tAtom->getPropIfPresent<int>(common_properties::_CIPRank, cip);
+            unsigned int cip = 0;
+            tAtom->getPropIfPresent<unsigned int>(common_properties::_CIPRank,
+                                                  cip);
             nbrs.push_back(std::make_pair(cip, rdcast<int>(*nbrIdx)));
           }
           ++nbrIdx;

--- a/Code/GraphMol/Chirality.cpp
+++ b/Code/GraphMol/Chirality.cpp
@@ -92,10 +92,10 @@ void buildCIPInvariants(const ROMol &mol, DOUBLE_VECT &res) {
 #if 0
         // NOTE: the inclusion of hybridization in the invariant (as
         // suggested in the original paper), leads to the situation
-        // that 
-        //   C[C@@](O)(C=C)C(C)CC 
+        // that
+        //   C[C@@](O)(C=C)C(C)CC
         // and
-        //   C[C@@](O)(C=C)C(C)CO 
+        //   C[C@@](O)(C=C)C(C)CO
         // are assigned S chirality even though the rest of the world
         // seems to agree that they ought to be R (atom 3, sp2, is ranked
         // higher than atom 5, sp3, no matter what their environments)
@@ -651,7 +651,7 @@ std::pair<bool, bool> assignAtomChiralCodes(ROMol &mol, UINT_VECT &ranks,
           cipCode = "S";
         else
           cipCode = "R";
-        atom->setProp(common_properties::_CIPCode, cipCode, true);
+        atom->setProp(common_properties::_CIPCode, cipCode, false);
       }
     }
   }
@@ -808,7 +808,8 @@ void rerankAtoms(const ROMol &mol, UINT_VECT &ranks) {
   iterateCIPRanks(mol, invars, ranks, true);
   // copy the ranks onto the atoms:
   for (unsigned int i = 0; i < mol.getNumAtoms(); i++) {
-    mol.getAtomWithIdx(i)->setProp(common_properties::_CIPRank, ranks[i], 1);
+    mol.getAtomWithIdx(i)
+        ->setProp(common_properties::_CIPRank, ranks[i], false);
   }
 
 #ifdef VERBOSE_CANON

--- a/Code/GraphMol/Chirality.cpp
+++ b/Code/GraphMol/Chirality.cpp
@@ -651,7 +651,7 @@ std::pair<bool, bool> assignAtomChiralCodes(ROMol &mol, UINT_VECT &ranks,
           cipCode = "S";
         else
           cipCode = "R";
-        atom->setProp(common_properties::_CIPCode, cipCode, false);
+        atom->setProp(common_properties::_CIPCode, cipCode);
       }
     }
   }
@@ -808,8 +808,7 @@ void rerankAtoms(const ROMol &mol, UINT_VECT &ranks) {
   iterateCIPRanks(mol, invars, ranks, true);
   // copy the ranks onto the atoms:
   for (unsigned int i = 0; i < mol.getNumAtoms(); i++) {
-    mol.getAtomWithIdx(i)
-        ->setProp(common_properties::_CIPRank, ranks[i], false);
+    mol.getAtomWithIdx(i)->setProp(common_properties::_CIPRank, ranks[i]);
   }
 
 #ifdef VERBOSE_CANON

--- a/Code/GraphMol/molopstest.cpp
+++ b/Code/GraphMol/molopstest.cpp
@@ -466,7 +466,7 @@ void test7() {
   CHECK_INVARIANT(std::find(tree.begin(),tree.end(),1)==tree.end(),"bogus idx in mst");
   delete m;
 #endif
-  
+
   smi = "C1C=CC=CC=1";
   m = SmilesToMol(smi);
   MolOps::findSpanningTree(*m,tree);
@@ -5449,6 +5449,41 @@ void testGithubIssue678() {
   BOOST_LOG(rdInfoLog) << "Finished" << std::endl;
 }
 
+void testGithubIssue717() {
+  BOOST_LOG(rdInfoLog)
+      << "-----------------------\n Testing github issue 717: "
+         "AddHs cip rank is declared <int> should be unsigned int"
+      << std::endl;
+
+  {  // single connected atom with degenerate coords
+    std::string mb =
+        "mol\n"
+        "  Mrv1561 01051606293D\n"
+        "\n"
+        "  4  3  0  0  0  0            999 V2000\n"
+        "   -0.0080   -0.0000   -0.0004 C   0  0  0  0  0  0  0  0  0  0  0  "
+        "0\n"
+        "    1.5343   -0.0050    0.0032 C   0  0  1  0  0  0  0  0  0  0  0  "
+        "0\n"
+        "    2.1517   -0.8276    1.4332 Cl  0  0  0  0  0  0  0  0  0  0  0  "
+        "0\n"
+        "    2.0123   -0.6447   -1.1142 F   0  0  0  0  0  0  0  0  0  0  0  "
+        "0\n"
+        "  2  3  1  0  0  0  0\n"
+        "  2  4  1  0  0  0  0\n"
+        "  2  1  1  0  0  0  0\n"
+        "M  END\n";
+    RWMol *m = MolBlockToMol(mb);
+    TEST_ASSERT(m);
+    MolOps::assignChiralTypesFrom3D(*m);
+    MolOps::assignStereochemistry(*m, true, true);
+    MolOps::addHs(*m, false, true);
+    TEST_ASSERT(m->getNumAtoms() == 8);
+    delete m;
+  }
+  BOOST_LOG(rdInfoLog) << "Finished" << std::endl;
+}
+
 int main() {
   RDLog::InitLogs();
 // boost::logging::enable_logs("rdApp.debug");
@@ -5531,5 +5566,7 @@ int main() {
   testAdjustQueryProperties();
 #endif
   testGithubIssue678();
+  testGithubIssue717();
+
   return 0;
 }


### PR DESCRIPTION
This changes the CIPCode and CIPRank atom properties to no longer be computed properties.
Note: under linux I was unable to actually get the bug to manifest (converting the uint property to an int didn't cause problems), but that doesn't mean it shouldn't still be fixed.