### PR TITLE
Fix/thread safe localeswitcher

### DIFF
--- a/Code/GraphMol/FileParsers/MolFileWriter.cpp
+++ b/Code/GraphMol/FileParsers/MolFileWriter.cpp
@@ -16,6 +16,7 @@
 #include <RDGeneral/Invariant.h>
 #include <GraphMol/RDKitQueries.h>
 #include <RDGeneral/Ranking.h>
+#include <RDGeneral/LocaleSwitcher.h>
 #include <vector>
 #include <algorithm>
 #include <fstream>
@@ -985,6 +986,7 @@ const std::string GetV3000MolFileBondLine(const Bond *bond,
 std::string MolToMolBlock(const ROMol &mol, bool includeStereo, int confId,
                           bool kekulize, bool forceV3000) {
   RDUNUSED_PARAM(includeStereo);
+  RDKit::Utils::LocaleSwitcher switcher;
   ROMol tromol(mol);
   RWMol &trwmol = static_cast<RWMol &>(tromol);
   // NOTE: kekulize the molecule before writing it out

--- a/Code/GraphMol/FileParsers/PDBWriter.cpp
+++ b/Code/GraphMol/FileParsers/PDBWriter.cpp
@@ -19,6 +19,7 @@
 
 #include <RDGeneral/BadFileException.h>
 #include <RDGeneral/FileParseException.h>
+#include <RDGeneral/LocaleSwitcher.h>
 #include <GraphMol/RDKitBase.h>
 #include <GraphMol/FileParsers/MolWriters.h>
 
@@ -229,6 +230,7 @@ std::string MolToPDBBlock(const ROMol &imol, int confId, unsigned int flavor) {
   ROMol mol(imol);
   RWMol &trwmol = static_cast<RWMol &>(mol);
   MolOps::Kekulize(trwmol);
+  Utils::LocaleSwitcher ls;
 
   std::string res;
   std::string name;

--- a/Code/GraphMol/FileParsers/test1.cpp
+++ b/Code/GraphMol/FileParsers/test1.cpp
@@ -21,6 +21,7 @@
 #include <GraphMol/Substruct/SubstructMatch.h>
 #include <RDGeneral/FileParseException.h>
 #include <RDGeneral/BadFileException.h>
+#include <clocale>
 
 #include <string>
 #include <fstream>
@@ -4123,11 +4124,8 @@ void testGithub360() {
   BOOST_LOG(rdInfoLog) << "Finished" << std::endl;
 }
 
-int main(int argc, char *argv[]) {
-  (void)argc;
-  (void)argv;
-  RDLog::InitLogs();
-#if 1
+void RunTests() {
+  #if 1
   test1();
   test2();
   test4();
@@ -4202,5 +4200,20 @@ int main(int argc, char *argv[]) {
   testPDBResidues();
   testGithub337();
   testGithub360();
+}
+
+int main(int argc, char *argv[]) {
+  (void)argc;
+  (void)argv;
+  //  std::locale::global(std::locale("de_DE.UTF-8"));
+
+  RDLog::InitLogs();
+  BOOST_LOG(rdInfoLog) << " ---- Running with POSIX locale ----- " << std::endl;
+  
+  RunTests(); // run with C locale
+  BOOST_LOG(rdInfoLog) << " ---- Running with German locale ----- " << std::endl;
+  setlocale(LC_ALL, "de_DE.UTF-8");
+
+  RunTests(); // run with German locale
   return 0;
 }

--- a/Code/RDGeneral/CMakeLists.txt
+++ b/Code/RDGeneral/CMakeLists.txt
@@ -2,7 +2,10 @@ CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/versions.h.cmake
                ${CMAKE_CURRENT_SOURCE_DIR}/versions.h )
 
 rdkit_library(RDGeneral
-              Invariant.cpp types.cpp utils.cpp RDLog.cpp Dict.cpp SHARED)
+              Invariant.cpp types.cpp utils.cpp RDLog.cpp Dict.cpp SHARED
+              LINK_LIBRARIES ${RDKit_THREAD_LIBS})
+
+target_link_libraries(RDGeneral ${RDKit_THREAD_LIBS})
 
 rdkit_headers(Exceptions.h
               BadFileException.h

--- a/Code/RDGeneral/CMakeLists.txt
+++ b/Code/RDGeneral/CMakeLists.txt
@@ -2,7 +2,8 @@ CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/versions.h.cmake
                ${CMAKE_CURRENT_SOURCE_DIR}/versions.h )
 
 rdkit_library(RDGeneral
-              Invariant.cpp types.cpp utils.cpp RDLog.cpp Dict.cpp SHARED
+              Invariant.cpp types.cpp utils.cpp RDLog.cpp Dict.cpp
+              LocaleSwitcher.cpp SHARED
               LINK_LIBRARIES ${RDKit_THREAD_LIBS})
 
 target_link_libraries(RDGeneral ${RDKit_THREAD_LIBS})

--- a/Code/RDGeneral/LocaleSwitcher.cpp
+++ b/Code/RDGeneral/LocaleSwitcher.cpp
@@ -1,0 +1,153 @@
+//  Copyright (c) 2016, Novartis Institutes for BioMedical Research Inc.
+//  All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+//       copyright notice, this list of conditions and the following
+//       disclaimer in the documentation and/or other materials provided
+//       with the distribution.
+//     * Neither the name of Novartis Institutes for BioMedical Research Inc.
+//       nor the names of its contributors may be used to endorse or promote
+//       products derived from this software without specific prior written
+//       permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+#include "LocaleSwitcher.h"
+
+// LocaleSwitcher Dependencies
+#include <clocale>
+#ifndef _MSC_VER
+#include <xlocale.h>
+#include <string>
+#else
+#include <locale.h>
+#endif
+
+#ifdef RDK_THREADSAFE_SSS
+#include <boost/thread/tss.hpp>
+#endif
+
+namespace RDKit {
+namespace Utils {
+namespace detail {
+// Implementation of LocaleSwitcher
+//  The locale switcher has state to indicate how many times
+//   it has been used (in a thread if thread safe RDKIT)
+
+const static int CurrentState  = 0; // return current state
+const static int SwitchLocale  = 1; // indicate we are now switched to "C"
+const static int ResetLocale   = -1;// return to previous locale (not "C")
+
+// Returns how many LocaleSwitches we have gone down.
+//  Such as
+//    void foo() { LocaleSwitcher switch; }
+//    void bar() { LocaleSwitcher switch; foo(); }
+//
+//  Implementations are free to not switch the locale if the locale
+//   is already in "C", but this is implementation defined.
+//  When Recurse(CurrentState) == 0 we are in the "global" locale,
+//   or at least at the top locale that isn't "C".
+//
+static int recurseLocale(int state) {
+#ifndef RDK_THREADSAFE_SSS
+  static int recursion = 0;  
+  if      (state==SwitchLocale) recursion++;
+  else if (state==ResetLocale)  recursion--;
+  return recursion;
+#else
+  static boost::thread_specific_ptr<int> recursion;
+  if( ! recursion.get() ) {
+    recursion.reset( new int(0));
+  }
+  if      (state==SwitchLocale) (*recursion)++;
+  else if (state==ResetLocale)  (*recursion)--;
+  return (*recursion);
+#endif
+}
+
+
+// allows an RAII-like approach to ensuring the locale is temporarily "C"
+// instead of whatever we started in.
+class LocaleSwitcherImpl {
+ public:
+#ifdef _MSC_VER
+
+  LocaleSwitcherImpl() {
+    if (!recurseLocale(CurrentState)) {
+#ifdef RDK_THREADSAFE_SSS
+      _configthreadlocale(_ENABLE_PER_THREAD_LOCALE);
+      ::setlocale(LC_ALL, "C"); // thread safe on windows
+#else
+      std::setlocale(LC_ALL, "C");
+#endif // RDK_THREADSAFE_SSS
+      recurseLocale(SwitchLocale);
+      switched = true;
+    }
+  }
+  ~LocaleSwitcherImpl() {
+    if (switched) {
+#ifdef RDK_THREADSAFE_SSS
+      ::setlocale(LC_ALL, "C");
+#else
+      std::setlocale(LC_ALL, ""); // back to last (global?) locale
+#endif // RDK_THREADSAFE_SSS
+      recurseLocale(ResetLocale);
+    }
+  }
+
+ public:
+  bool switched;
+#else // _MSC_VER
+  locale_t loc;     // current "C" locale
+  locale_t old_loc; // locale we came frome
+
+  LocaleSwitcherImpl() : old_locale(setlocale(LC_ALL, NULL)) {
+    // set locale for this thread
+
+    if (!recurseLocale(CurrentState) && old_locale != "C") {
+      recurseLocale(SwitchLocale);
+      old_loc = uselocale(0);
+      loc = newlocale(LC_ALL_MASK, "C", (locale_t)0);
+      uselocale(loc);
+      // Don't free "C" or "GLOBAL" Locales
+    } else
+      old_locale = "C"; // prevents recursion
+  }
+  ~LocaleSwitcherImpl() {
+    if (old_locale != "C") {
+      uselocale(old_loc);
+      freelocale(loc);
+      recurseLocale(ResetLocale);
+    }
+  }
+
+ public:
+  std::string old_locale;
+
+#endif // _MSC_VER
+};
+}
+
+// allows an RAII-like approach to ensuring the locale is temporarily "C"
+// instead of whatever we started in.
+
+LocaleSwitcher::LocaleSwitcher() : impl(new detail::LocaleSwitcherImpl) {}
+LocaleSwitcher::~LocaleSwitcher() { delete impl; }
+}
+}

--- a/Code/RDGeneral/LocaleSwitcher.h
+++ b/Code/RDGeneral/LocaleSwitcher.h
@@ -51,13 +51,14 @@ class LocaleSwitcher {
 public:
   bool switched;
 #else
+  locale_t loc;
 
 LocaleSwitcher() : old_locale(setlocale(LC_ALL, NULL)) {
     // set locale for this thread
 
     if (!Recurse() && old_locale != "C") {
       Recurse(1);
-      locale_t loc = newlocale(LC_ALL_MASK, "C", (locale_t)0);
+      loc = newlocale(LC_ALL_MASK, "C", (locale_t)0);
       uselocale(loc);
       // Don't free "C" or "GLOBAL" Locales
     } else
@@ -65,9 +66,7 @@ LocaleSwitcher() : old_locale(setlocale(LC_ALL, NULL)) {
   }
   ~LocaleSwitcher() {
     if (old_locale != "C") {
-      locale_t loc = newlocale(LC_ALL_MASK, old_locale.c_str(), (locale_t)0);
-      uselocale(loc);
-      // Don't free "C" or "GLOBAL" Locales
+      freelocale(loc);
       Recurse(-1);
     }
   }

--- a/Code/RDGeneral/LocaleSwitcher.h
+++ b/Code/RDGeneral/LocaleSwitcher.h
@@ -22,9 +22,10 @@ namespace RDKit {
 namespace Utils {
 // allows an RAII-like approach to ensuring the locale is temporarily "C"
 // instead of whatever we started in.
+
+#ifdef _MSC_VER  
 class LocaleSwitcher {
  public:
-#ifdef _MSC_VER  
 
   LocaleSwitcher() {
 #ifdef RDK_THREADSAFE_SSS
@@ -50,7 +51,7 @@ LocaleSwitcher() : old_locale(setlocale(LC_ALL, NULL)) {
       Recurse(1);
       locale_t loc = newlocale(LC_ALL_MASK, "C", (locale_t)0);
       uselocale(loc);
-      freelocale(loc);
+      // n.b. Don't free "C" or GLOBAL LOCALE
     } else
       old_locale = "C";
   }
@@ -58,7 +59,7 @@ LocaleSwitcher() : old_locale(setlocale(LC_ALL, NULL)) {
     if (old_locale != "C") {
       locale_t loc = newlocale(LC_ALL_MASK, old_locale.c_str(), (locale_t)0);
       uselocale(loc);
-      freelocale(loc);
+      // n.b.  Don't free "C" or GLOBAL LOCALE
       Recurse(-1);
     }
   }

--- a/Code/RDGeneral/LocaleSwitcher.h
+++ b/Code/RDGeneral/LocaleSwitcher.h
@@ -52,15 +52,14 @@ public:
   bool switched;
 #else
   locale_t loc;
-#ifdef __APPLE__
   locale_t old_loc;
-#endif      
+
 LocaleSwitcher() : old_locale(setlocale(LC_ALL, NULL)) {
     // set locale for this thread
 
     if (!Recurse() && old_locale != "C") {
       Recurse(1);
-      old_loc = uselocale(NULL);
+      old_loc = uselocale(0);
       loc = newlocale(LC_ALL_MASK, "C", (locale_t)0);
       uselocale(loc);
       // Don't free "C" or "GLOBAL" Locales
@@ -69,9 +68,7 @@ LocaleSwitcher() : old_locale(setlocale(LC_ALL, NULL)) {
   }
   ~LocaleSwitcher() {
     if (old_locale != "C") {
-#ifdef __APPLE__
       uselocale(old_loc);
-#endif
       freelocale(loc);
       Recurse(-1);
     }

--- a/Code/RDGeneral/LocaleSwitcher.h
+++ b/Code/RDGeneral/LocaleSwitcher.h
@@ -1,90 +1,50 @@
+//  Copyright (c) 2016, Novartis Institutes for BioMedical Research Inc.
+//  All rights reserved.
 //
-//  Copyright (C) 2012 Greg Landrum
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
 //
-//  @@ All Rights Reserved @@
-//  This file is part of the RDKit.
-//  The contents are covered by the terms of the BSD license
-//  which is included in the file license.txt, found at the root
-//  of the RDKit source tree.
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+//       copyright notice, this list of conditions and the following
+//       disclaimer in the documentation and/or other materials provided
+//       with the distribution.
+//     * Neither the name of Novartis Institutes for BioMedical Research Inc.
+//       nor the names of its contributors may be used to endorse or promote
+//       products derived from this software without specific prior written
+//       permission.
 //
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
 #ifndef _RD_LOCALESWITCHER_H
 #define _RD_LOCALESWITCHER_H
-
-#include <clocale>
-#ifndef _MSC_VER
-# include <xlocale.h>
-#else
-# include <locale.h>
-#endif
 
 namespace RDKit {
 namespace Utils {
 // allows an RAII-like approach to ensuring the locale is temporarily "C"
 // instead of whatever we started in.
+
+namespace detail {
+class LocaleSwitcherImpl; // concrete OS dependent implementation
+}
+
 class LocaleSwitcher {
- public:
-#ifdef _MSC_VER  
-
-  LocaleSwitcher() {
-    if (!Recurse()) {
-#ifdef RDK_THREADSAFE_SSS
-    _configthreadlocale(_ENABLE_PER_THREAD_LOCALE);
-    ::setlocale(LC_ALL, "C");
-#else    
-    std::setlocale(LC_ALL, "C");
-#endif
-    Recurse(1);
-    switched = true;
-    }
-  }
-  ~LocaleSwitcher() {
-    if (switched) {
-#ifdef RDK_THREADSAFE_SSS
-    ::setlocale(LC_ALL, "C");
-#else    
-    std::setlocale(LC_ALL, "");
-#endif
-    Recurse(-1);
-    }
-  }
+  detail::LocaleSwitcherImpl *impl;
 public:
-  bool switched;
-#else
-  locale_t loc;
-  locale_t old_loc;
-
-LocaleSwitcher() : old_locale(setlocale(LC_ALL, NULL)) {
-    // set locale for this thread
-
-    if (!Recurse() && old_locale != "C") {
-      Recurse(1);
-      old_loc = uselocale(0);
-      loc = newlocale(LC_ALL_MASK, "C", (locale_t)0);
-      uselocale(loc);
-      // Don't free "C" or "GLOBAL" Locales
-    } else
-      old_locale = "C";
-  }
-  ~LocaleSwitcher() {
-    if (old_locale != "C") {
-      uselocale(old_loc);
-      freelocale(loc);
-      Recurse(-1);
-    }
-  }
-  
-public:
-  std::string old_locale;
-
-#endif
-
-  // Recurse(1) recurse into switcher
-  // Recurse(-1) end recursion
-  //  Always turns current state (note: thread safe
-  //   when RDK_THREAFSAFE_SSS defined)
-  static int Recurse(int state=0);
-  
+  LocaleSwitcher();
+  ~LocaleSwitcher();
 };
 }
 }

--- a/Code/RDGeneral/LocaleSwitcher.h
+++ b/Code/RDGeneral/LocaleSwitcher.h
@@ -42,20 +42,35 @@ class LocaleSwitcher {
 #endif
   }
 #else
-  LocaleSwitcher() {
-    std::locale loc;
-    if (loc.name() != std::locale::classic().name()) {
-      // set locale for this thread
-      uselocale(newlocale(LC_ALL, "C", (locale_t)0));
-      switched = true;
-    }
+
+LocaleSwitcher() : old_locale(setlocale(LC_ALL, NULL)) {
+    // set locale for this thread
+
+    if (!Recurse() && old_locale != "C") {
+      Recurse(1);
+      locale_t loc = newlocale(LC_ALL_MASK, "C", (locale_t)0);
+      uselocale(loc);
+      freelocale(loc);
+    } else
+      old_locale = "C";
   }
   ~LocaleSwitcher() {
-    if (switched) {
-      uselocale(newlocale(LC_ALL, "", (locale_t)0));
+    if (old_locale != "C") {
+      locale_t loc = newlocale(LC_ALL_MASK, old_locale.c_str(), (locale_t)0);
+      uselocale(loc);
+      freelocale(loc);
+      Recurse(-1);
     }
   }
-  bool switched;
+  // Recurse(1) recurse into switcher
+  // Recurse(-1) end recursion
+  //  Always turns current state (note: thread safe
+  //   when RDK_THREAFSAFE_SSS defined)
+  static int Recurse(int state=0);
+  
+public:
+  std::string old_locale;
+
 #endif
   
 };

--- a/Code/RDGeneral/LocaleSwitcher.h
+++ b/Code/RDGeneral/LocaleSwitcher.h
@@ -27,20 +27,29 @@ class LocaleSwitcher {
 #ifdef _MSC_VER  
 
   LocaleSwitcher() {
+    if (!Recurse()) {
 #ifdef RDK_THREADSAFE_SSS
     _configthreadlocale(_ENABLE_PER_THREAD_LOCALE);
     ::setlocale(LC_ALL, "C");
 #else    
     std::setlocale(LC_ALL, "C");
 #endif
+    Recurse(1);
+    switched = true;
+    }
   }
   ~LocaleSwitcher() {
+    if (switched) {
 #ifdef RDK_THREADSAFE_SSS
     ::setlocale(LC_ALL, "C");
 #else    
     std::setlocale(LC_ALL, "");
 #endif
+    Recurse(-1);
+    }
   }
+public:
+  bool switched;
 #else
 
 LocaleSwitcher() : old_locale(setlocale(LC_ALL, NULL)) {
@@ -62,16 +71,17 @@ LocaleSwitcher() : old_locale(setlocale(LC_ALL, NULL)) {
       Recurse(-1);
     }
   }
-  // Recurse(1) recurse into switcher
-  // Recurse(-1) end recursion
-  //  Always turns current state (note: thread safe
-  //   when RDK_THREAFSAFE_SSS defined)
-  static int Recurse(int state=0);
   
 public:
   std::string old_locale;
 
 #endif
+
+  // Recurse(1) recurse into switcher
+  // Recurse(-1) end recursion
+  //  Always turns current state (note: thread safe
+  //   when RDK_THREAFSAFE_SSS defined)
+  static int Recurse(int state=0);
   
 };
 }

--- a/Code/RDGeneral/LocaleSwitcher.h
+++ b/Code/RDGeneral/LocaleSwitcher.h
@@ -22,10 +22,9 @@ namespace RDKit {
 namespace Utils {
 // allows an RAII-like approach to ensuring the locale is temporarily "C"
 // instead of whatever we started in.
-
-#ifdef _MSC_VER  
 class LocaleSwitcher {
  public:
+#ifdef _MSC_VER  
 
   LocaleSwitcher() {
 #ifdef RDK_THREADSAFE_SSS
@@ -51,7 +50,7 @@ LocaleSwitcher() : old_locale(setlocale(LC_ALL, NULL)) {
       Recurse(1);
       locale_t loc = newlocale(LC_ALL_MASK, "C", (locale_t)0);
       uselocale(loc);
-      // n.b. Don't free "C" or GLOBAL LOCALE
+      // Don't free "C" or "GLOBAL" Locales
     } else
       old_locale = "C";
   }
@@ -59,7 +58,7 @@ LocaleSwitcher() : old_locale(setlocale(LC_ALL, NULL)) {
     if (old_locale != "C") {
       locale_t loc = newlocale(LC_ALL_MASK, old_locale.c_str(), (locale_t)0);
       uselocale(loc);
-      // n.b.  Don't free "C" or GLOBAL LOCALE
+      // Don't free "C" or "GLOBAL" Locales
       Recurse(-1);
     }
   }

--- a/Code/RDGeneral/LocaleSwitcher.h
+++ b/Code/RDGeneral/LocaleSwitcher.h
@@ -52,12 +52,15 @@ public:
   bool switched;
 #else
   locale_t loc;
-
+#ifdef __APPLE__
+  locale_t old_loc;
+#endif      
 LocaleSwitcher() : old_locale(setlocale(LC_ALL, NULL)) {
     // set locale for this thread
 
     if (!Recurse() && old_locale != "C") {
       Recurse(1);
+      old_loc = uselocale(NULL);
       loc = newlocale(LC_ALL_MASK, "C", (locale_t)0);
       uselocale(loc);
       // Don't free "C" or "GLOBAL" Locales
@@ -66,6 +69,9 @@ LocaleSwitcher() : old_locale(setlocale(LC_ALL, NULL)) {
   }
   ~LocaleSwitcher() {
     if (old_locale != "C") {
+#ifdef __APPLE__
+      uselocale(old_loc);
+#endif
       freelocale(loc);
       Recurse(-1);
     }

--- a/Code/RDGeneral/types.cpp
+++ b/Code/RDGeneral/types.cpp
@@ -12,10 +12,6 @@
 //
 
 #include "types.h"
-#include "LocaleSwitcher.h"
-#ifdef RDK_THREADSAFE_SSS
-#include <boost/thread/tss.hpp>
-#endif
 
 namespace RDKit {
 namespace common_properties {
@@ -171,25 +167,6 @@ int nextCombination(INT_VECT &comb, int tot) {
   return celem;
 }
 
-namespace Utils {
-int LocaleSwitcher::Recurse(int state) {
-#ifndef RDK_THREADSAFE_SSS
-  static int recursion = 0;  
-  if      (state>0) recursion++;
-  else if(state<0) recursion--;
-  return recursion;
-#else
-  static boost::thread_specific_ptr<int> recursion;
-  if( ! recursion.get() ) {
-    // first time called by this thread
-    // construct test element to be used in all subsequent calls from this thread
-    recursion.reset( new int(0));
-  }
-  if      (state>0) (*recursion)++;
-  else if(state<0) (*recursion)--;
-  return (*recursion);
-#endif
-}
 
 }
-}
+

--- a/Code/RDGeneral/types.cpp
+++ b/Code/RDGeneral/types.cpp
@@ -12,6 +12,10 @@
 //
 
 #include "types.h"
+#include "LocaleSwitcher.h"
+#ifdef RDK_THREADSAFE_SSS
+#include <boost/thread/tss.hpp>
+#endif
 
 namespace RDKit {
 namespace common_properties {
@@ -165,5 +169,27 @@ int nextCombination(INT_VECT &comb, int tot) {
     comb[i] = comb[i - 1] + 1;
   }
   return celem;
+}
+
+namespace Utils {
+int LocaleSwitcher::Recurse(int state) {
+#ifndef RDK_THREADSAFE_SSS
+  static int recursion = 0;  
+  if      (state>0) recursion++;
+  else if(state<0) recursion--;
+  return recursion;
+#else
+  static boost::thread_specific_ptr<int> recursion;
+  if( ! recursion.get() ) {
+    // first time called by this thread
+    // construct test element to be used in all subsequent calls from this thread
+    recursion.reset( new int(0));
+  }
+  if      (state>0) (*recursion)++;
+  else if(state<0) (*recursion)--;
+  return (*recursion);
+#endif
+}
+
 }
 }


### PR DESCRIPTION
Only switch the locale if necessary on unix/linux.

On windows, enable per thread locale switching.

Add test that actually checks (not multithreaded yet though?)

Tests might fail if german locale is not included...