### PR TITLE
Fixes return type of operator[] (fails on later clangs)

### DIFF
--- a/Code/RDBoost/PySequenceHolder.h
+++ b/Code/RDBoost/PySequenceHolder.h
@@ -71,7 +71,7 @@ class PySequenceHolder {
     }
 
     POSTCONDITION(0, "cannot reach this point");
-    return static_cast<T>((unsigned int)0);
+    return static_cast<T>(T());
   };
 
  private:


### PR DESCRIPTION
Caused failures on OSX under some configurations (namely c++11 builds)