### PR TITLE
Fix/get double prop get props asdict

### DIFF
--- a/Code/GraphMol/Wrap/Atom.cpp
+++ b/Code/GraphMol/Wrap/Atom.cpp
@@ -69,17 +69,6 @@ int AtomHasProp(const Atom *atom, const char *key) {
   return res;
 }
 
-template <class T>
-T AtomGetProp(const Atom *atom, const char *key) {
-  if (!atom->hasProp(key)) {
-    PyErr_SetString(PyExc_KeyError, key);
-    throw python::error_already_set();
-  }
-  T res;
-  atom->getProp<T>(key, res);
-  return res;
-}
-
 void AtomClearProp(const Atom *atom, const char *key) {
   if (!atom->hasProp(key)) {
     return;
@@ -283,7 +272,7 @@ struct atom_wrapper {
              "    - key: the name of the property to be set (a string).\n"
              "    - value: the property value (a string).\n\n")
 
-        .def("GetProp", AtomGetProp<std::string>,
+        .def("GetProp", GetProp<Atom, std::string>,
              "Returns the value of the property.\n\n"
              "  ARGUMENTS:\n"
              "    - key: the name of the property to return (a string).\n\n"
@@ -306,7 +295,7 @@ struct atom_wrapper {
              "    - key: the name of the property to be set (an unsigned integer).\n"
              "    - value: the property value (a int >= 0).\n\n")
         
-        .def("GetIntProp", AtomGetProp<int>,
+        .def("GetIntProp", GetProp<Atom, int>,
              "Returns the value of the property.\n\n"
              "  ARGUMENTS:\n"
              "    - key: the name of the property to return (an int).\n\n"
@@ -315,7 +304,7 @@ struct atom_wrapper {
              "    - If the property has not been set, a KeyError exception "
              "will be raised.\n")
 
-        .def("GetUnsignedProp", AtomGetProp<unsigned>,
+        .def("GetUnsignedProp", GetProp<Atom, unsigned>,
              "Returns the value of the property.\n\n"
              "  ARGUMENTS:\n"
              "    - key: the name of the property to return (an unsigned integer).\n\n"
@@ -331,7 +320,7 @@ struct atom_wrapper {
              "    - key: the name of the property to be set (a double).\n"
              "    - value: the property value (a double).\n\n")
 
-        .def("GetDoubleProp", AtomGetProp<double>,
+        .def("GetDoubleProp", GetProp<Atom, double>,
              "Returns the value of the property.\n\n"
              "  ARGUMENTS:\n"
              "    - key: the name of the property to return (a double).\n\n"
@@ -347,7 +336,7 @@ struct atom_wrapper {
              "    - key: the name of the property to be set (a bool).\n"
              "    - value: the property value (a bool).\n\n")
 
-        .def("GetBoolProp", AtomGetProp<bool>,
+        .def("GetBoolProp", GetProp<Atom, bool>,
              "Returns the value of the property.\n\n"
              "  ARGUMENTS:\n"
              "    - key: the name of the property to return (a bool).\n\n"

--- a/Code/GraphMol/Wrap/Bond.cpp
+++ b/Code/GraphMol/Wrap/Bond.cpp
@@ -73,17 +73,6 @@ void BondClearProp(const Bond *bond, const char *key) {
   bond->clearProp(key);
 }
 
-template <class T>
-T BondGetProp(const Bond *bond, const char *key) {
-  if (!bond->hasProp(key)) {
-    PyErr_SetString(PyExc_KeyError, key);
-    throw python::error_already_set();
-  }
-  T res;
-  bond->getProp<T>(key, res);
-  return res;
-}
-
 bool BondIsInRing(const Bond *bond) {
   if (!bond->getOwningMol().getRingInfo()->isInitialized()) {
     MolOps::findSSSR(bond->getOwningMol());
@@ -216,7 +205,7 @@ struct bond_wrapper {
              "    - key: the name of the property to be set (a string).\n"
              "    - value: the property value (a string).\n\n")
 
-        .def("GetProp", BondGetProp<std::string>,
+        .def("GetProp", GetProp<Bond, std::string>,
              "Returns the value of the property.\n\n"
              "  ARGUMENTS:\n"
              "    - key: the name of the property to return (a string).\n\n"
@@ -239,7 +228,7 @@ struct bond_wrapper {
              "    - key: the name of the property to be set (a string).\n"
              "    - value: the property value (an int >= 0).\n\n")
         
-        .def("GetIntProp", BondGetProp<int>,
+        .def("GetIntProp", GetProp<Bond, int>,
              "Returns the value of the property.\n\n"
              "  ARGUMENTS:\n"
              "    - key: the name of the property to return (an int).\n\n"
@@ -248,7 +237,7 @@ struct bond_wrapper {
              "    - If the property has not been set, a KeyError exception "
              "will be raised.\n")
 
-        .def("GetUnsignedProp", BondGetProp<unsigned int>,
+        .def("GetUnsignedProp", GetProp<Bond, unsigned int>,
              "Returns the value of the property.\n\n"
              "  ARGUMENTS:\n"
              "    - key: the name of the property to return (an unsigned integer).\n\n"
@@ -264,7 +253,7 @@ struct bond_wrapper {
              "    - key: the name of the property to be set (a string).\n"
              "    - value: the property value (a double).\n\n")
 
-        .def("GetDoubleProp", BondGetProp<double>,
+        .def("GetDoubleProp", GetProp<Bond, double>,
              "Returns the value of the property.\n\n"
              "  ARGUMENTS:\n"
              "    - key: the name of the property to return (a double).\n\n"
@@ -280,7 +269,7 @@ struct bond_wrapper {
              "    - key: the name of the property to be set (a string).\n"
              "    - value: the property value (a boolean).\n\n")
 
-        .def("GetBoolProp", BondGetProp<bool>,
+        .def("GetBoolProp", GetProp<Bond, bool>,
              "Returns the value of the property.\n\n"
              "  ARGUMENTS:\n"
              "    - key: the name of the property to return (a boolean).\n\n"

--- a/Code/GraphMol/Wrap/Mol.cpp
+++ b/Code/GraphMol/Wrap/Mol.cpp
@@ -451,7 +451,7 @@ struct mol_wrapper {
              "    - value: the property value (a string).\n"
              "    - computed: (optional) marks the property as being "
              "computed.\n"
-             "                Defaults to 0.\n\n")
+             "                Defaults to False.\n\n")
         .def("SetDoubleProp", MolSetProp<double>,
              (python::arg("self"), python::arg("key"), python::arg("val"),
               python::arg("computed") = false),
@@ -471,7 +471,7 @@ struct mol_wrapper {
              "    - value: the property value as an integer.\n"
              "    - computed: (optional) marks the property as being "
              "computed.\n"
-             "                Defaults to 0.\n\n")
+             "                Defaults to False.\n\n")
         .def("SetUnsignedProp", MolSetProp<unsigned int>,
              (python::arg("self"), python::arg("key"), python::arg("val"),
               python::arg("computed") = false),
@@ -481,7 +481,7 @@ struct mol_wrapper {
              "    - value: the property value as an unsigned integer.\n"
              "    - computed: (optional) marks the property as being "
              "computed.\n"
-             "                Defaults to 0.\n\n")                
+             "                Defaults to False.\n\n")                
         .def("SetBoolProp", MolSetProp<bool>,
              (python::arg("self"), python::arg("key"), python::arg("val"),
               python::arg("computed") = false),
@@ -491,7 +491,7 @@ struct mol_wrapper {
              "    - value: the property value as a bool.\n"
              "    - computed: (optional) marks the property as being "
              "computed.\n"
-             "                Defaults to 0.\n\n")                
+             "                Defaults to False.\n\n")                
         .def("HasProp", MolHasProp,
              "Queries a molecule to see if a particular property has been "
              "assigned.\n\n"

--- a/Code/GraphMol/Wrap/Mol.cpp
+++ b/Code/GraphMol/Wrap/Mol.cpp
@@ -142,9 +142,15 @@ PyObject *GetMolConformers(ROMol &mol) {
 template <class T>
 T MolGetProp(const ROMol &mol, const char *key) {
   T res;
-  if (!mol.getPropIfPresent(key, res)) {
-    PyErr_SetString(PyExc_KeyError, key);
-    throw python::error_already_set();
+  try {
+    if (!mol.getPropIfPresent(key, res)) {
+      PyErr_SetString(PyExc_KeyError, key);
+      throw python::error_already_set();
+    }
+    return res;
+  } catch ( const boost::bad_any_cast &e ) {
+    throw ValueErrorException(std::string("key `") + key + "` exists but does not result in a " +
+                              GetTypeName<T>());
   }
   return res;
 }

--- a/Code/GraphMol/Wrap/Mol.cpp
+++ b/Code/GraphMol/Wrap/Mol.cpp
@@ -139,22 +139,6 @@ PyObject *GetMolConformers(ROMol &mol) {
   return res;
 }
 
-template <class T>
-T MolGetProp(const ROMol &mol, const char *key) {
-  T res;
-  try {
-    if (!mol.getPropIfPresent(key, res)) {
-      PyErr_SetString(PyExc_KeyError, key);
-      throw python::error_already_set();
-    }
-    return res;
-  } catch ( const boost::bad_any_cast &e ) {
-    throw ValueErrorException(std::string("key `") + key + "` exists but does not result in a " +
-                              GetTypeName<T>());
-  }
-  return res;
-}
-
 int MolHasProp(const ROMol &mol, const char *key) {
   int res = mol.hasProp(key);
   // std::cout << "key: "  << key << ": " << res << std::endl;
@@ -503,7 +487,7 @@ struct mol_wrapper {
              "assigned.\n\n"
              "  ARGUMENTS:\n"
              "    - key: the name of the property to check for (a string).\n")
-        .def("GetProp", MolGetProp<std::string>,
+        .def("GetProp", GetProp<ROMol, std::string>,
              "Returns the value of the property.\n\n"
              "  ARGUMENTS:\n"
              "    - key: the name of the property to return (a string).\n\n"
@@ -511,7 +495,7 @@ struct mol_wrapper {
              "  NOTE:\n"
              "    - If the property has not been set, a KeyError exception "
              "will be raised.\n")
-        .def("GetDoubleProp", MolGetProp<double>,
+        .def("GetDoubleProp", GetProp<ROMol, double>,
              "Returns the double value of the property if possible.\n\n"
              "  ARGUMENTS:\n"
              "    - key: the name of the property to return (a string).\n\n"
@@ -519,7 +503,7 @@ struct mol_wrapper {
              "  NOTE:\n"
              "    - If the property has not been set, a KeyError exception "
              "will be raised.\n")
-        .def("GetIntProp", MolGetProp<int>,
+        .def("GetIntProp", GetProp<ROMol, int>,
              "Returns the integer value of the property if possible.\n\n"
              "  ARGUMENTS:\n"
              "    - key: the name of the property to return (a string).\n\n"
@@ -527,7 +511,7 @@ struct mol_wrapper {
              "  NOTE:\n"
              "    - If the property has not been set, a KeyError exception "
              "will be raised.\n")
-        .def("GetUnsignedProp", MolGetProp<unsigned int>,
+        .def("GetUnsignedProp", GetProp<ROMol, unsigned int>,
              "Returns the unsigned int value of the property if possible.\n\n"
              "  ARGUMENTS:\n"
              "    - key: the name of the property to return (a string).\n\n"
@@ -535,7 +519,7 @@ struct mol_wrapper {
              "  NOTE:\n"
              "    - If the property has not been set, a KeyError exception "
              "will be raised.\n")
-        .def("GetBoolProp", MolGetProp<bool>,
+        .def("GetBoolProp", GetProp<ROMol, bool>,
              "Returns the double value of the property if possible.\n\n"
              "  ARGUMENTS:\n"
              "    - key: the name of the property to return (a string).\n\n"

--- a/Code/GraphMol/Wrap/props.hpp
+++ b/Code/GraphMol/Wrap/props.hpp
@@ -39,6 +39,22 @@
 namespace RDKit
 {
 
+template<class T>
+inline const char * GetTypeName() {
+  //PRECONDITION(0, "Unregistered c++ type");
+  return "unregistered C++ type";
+}
+
+template<>
+inline const char * GetTypeName<double>() { return "64 bit floating point value"; }
+template<>
+inline const char * GetTypeName<int>() { return "32 bit integer value";}
+template<>
+inline const char * GetTypeName<unsigned int>() { return "32 bit unsigned integer value";}
+template<>
+inline const char * GetTypeName<bool>() { return "True or False value";}
+
+
 template<class T, class U>
 bool AddToDict(const U& ob, boost::python::dict &dict, const std::string &key) {
   T res;
@@ -70,6 +86,23 @@ boost::python::dict GetPropsAsDict(const T &obj) {
   }
   return dict;
 }
+
+template <class RDOb, class T>
+T GetProp(RDOb *ob, const char *key) {
+  T res;
+  try {
+    if (!ob->getPropIfPresent(key, res)) {
+      PyErr_SetString(PyExc_KeyError, key);
+      throw python::error_already_set();
+    }
+    return res;
+  } catch ( const boost::bad_any_cast &e ) {
+    throw ValueErrorException(std::string("key `") + key + "` exists but does not result in a " +
+                              GetTypeName<T>());
+  }
+  return res;
+}
+
 
 }
 

--- a/Code/GraphMol/Wrap/props.hpp
+++ b/Code/GraphMol/Wrap/props.hpp
@@ -49,7 +49,7 @@ bool AddToDict(const U& ob, boost::python::dict &dict, const std::string &key) {
   } catch (boost::bad_any_cast &) {
     return false;
   }
-  return false;
+  return true;
 }
 
 template<class T>

--- a/Code/GraphMol/Wrap/props.hpp
+++ b/Code/GraphMol/Wrap/props.hpp
@@ -46,13 +46,13 @@ inline const char * GetTypeName() {
 }
 
 template<>
-inline const char * GetTypeName<double>() { return "64 bit floating point value"; }
+inline const char * GetTypeName<double>() { return "a double value"; }
 template<>
-inline const char * GetTypeName<int>() { return "32 bit integer value";}
+inline const char * GetTypeName<int>() { return "an integer value";}
 template<>
-inline const char * GetTypeName<unsigned int>() { return "32 bit unsigned integer value";}
+inline const char * GetTypeName<unsigned int>() { return "an unsigned integer value";}
 template<>
-inline const char * GetTypeName<bool>() { return "True or False value";}
+inline const char * GetTypeName<bool>() { return "a True or False value";}
 
 
 template<class T, class U>
@@ -97,7 +97,7 @@ T GetProp(RDOb *ob, const char *key) {
     }
     return res;
   } catch ( const boost::bad_any_cast &e ) {
-    throw ValueErrorException(std::string("key `") + key + "` exists but does not result in a " +
+    throw ValueErrorException(std::string("key `") + key + "` exists but does not result in " +
                               GetTypeName<T>());
   }
   return res;

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -453,13 +453,13 @@ class TestCase(unittest.TestCase):
     try:
       self.assertTrue(m.GetIntProp("a") == 2.0)
       raise Exception("Expected runtime exception")
-    except RuntimeError:
+    except ValueError:
       pass
     
     try:
       self.assertTrue(m.GetUnsignedProp("a") == 2.0)
       raise Exception("Expected runtime exception")
-    except RuntimeError:
+    except ValueError:
       pass
 
     
@@ -3415,6 +3415,36 @@ CAS<~>
     sdSup = Chem.SDMolSupplier(fileN)
     for i,mol in enumerate(sdSup):
       self.assertEquals(mol.GetPropsAsDict(includePrivate=True), sddata[i])
+
+  def testGetSetProps(self):
+    m = Chem.MolFromSmiles("CC")
+    errors = {"int": "key `foo` exists but does not result in a 32 bit integer value",
+              "double": "key `foo` exists but does not result in a 64 bit floating point value",
+              "bool": "key `foo` exists but does not result in a True or False value"}
+
+    for ob in [m, list(m.GetAtoms())[0], list(m.GetBonds())[0]]:
+      ob.SetDoubleProp("foo", 2.0)
+      try:
+        ob.GetBoolProp("foo")
+      except ValueError as e:
+        self.assertEquals(str(e), errors["bool"])
+
+      try:
+        ob.GetIntProp("foo")
+      except ValueError as e:
+        self.assertEquals(str(e), errors["int"])
+
+      ob.SetBoolProp("foo", True)
+      try:
+        ob.GetDoubleProp("foo")
+      except ValueError as e:
+        self.assertEquals(str(e), errors["double"])
+
+      try:
+        ob.GetIntProp("foo")
+      except ValueError as e:
+        self.assertEquals(str(e), errors["int"])
+      
       
 if __name__ == '__main__':
   unittest.main()

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -3424,27 +3424,22 @@ CAS<~>
 
     for ob in [m, list(m.GetAtoms())[0], list(m.GetBonds())[0]]:
       ob.SetDoubleProp("foo", 2.0)
-      try:
+      with self.assertRaises(ValueError) as e:
         ob.GetBoolProp("foo")
-      except ValueError as e:
-        self.assertEquals(str(e), errors["bool"])
-
-      try:
+      self.assertEquals(str(e.exception), errors["bool"])
+             
+      with self.assertRaises(ValueError) as e:
         ob.GetIntProp("foo")
-      except ValueError as e:
-        self.assertEquals(str(e), errors["int"])
-
-      ob.SetBoolProp("foo", True)
-      try:
-        ob.GetDoubleProp("foo")
-      except ValueError as e:
-        self.assertEquals(str(e), errors["double"])
-
-      try:
-        ob.GetIntProp("foo")
-      except ValueError as e:
-        self.assertEquals(str(e), errors["int"])
+      self.assertEquals(str(e.exception), errors["int"])
       
+      ob.SetBoolProp("foo", True)
+      with self.assertRaises(ValueError) as e:      
+        ob.GetDoubleProp("foo")
+      self.assertEquals(str(e.exception), errors["double"])
+      
+      with self.assertRaises(ValueError) as e:              
+        ob.GetIntProp("foo")
+      self.assertEquals(str(e.exception), errors["int"])
       
 if __name__ == '__main__':
   unittest.main()

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -3418,8 +3418,8 @@ CAS<~>
 
   def testGetSetProps(self):
     m = Chem.MolFromSmiles("CC")
-    errors = {"int": "key `foo` exists but does not result in a 32 bit integer value",
-              "double": "key `foo` exists but does not result in a 64 bit floating point value",
+    errors = {"int": "key `foo` exists but does not result in an integer value",
+              "double": "key `foo` exists but does not result in a double value",
               "bool": "key `foo` exists but does not result in a True or False value"}
 
     for ob in [m, list(m.GetAtoms())[0], list(m.GetBonds())[0]]:

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -482,13 +482,14 @@ class TestCase(unittest.TestCase):
     m.SetDoubleProp("b", 1000.0)
     m.SetUnsignedProp("c", 2000)
     m.SetIntProp("d", -2)
-    m.SetUnsignedProp("e", 2)
+    m.SetUnsignedProp("e", 2, True)
     self.assertEquals(m.GetPropsAsDict(),
-                      {'a': False, 'c': '2000', 'b': '1000', 'e': '2',
-                       'd': '-2', 'prop1': 'foob'})
+                      {'a': False, 'c': 2000, 'b': 1000.0,
+                       'd': -2, 'prop1': 'foob'})
+    self.assertEquals(m.GetPropsAsDict(False, True),
+                      {'a': False, 'c': 2000, 'b': 1000.0, 'e': 2,
+                       'd': -2, 'prop1': 'foob'})
 
-    self.assertEquals(list(m.GetPropsAsDict(True,True)['__computedProps']), [])
-    
   def test17Kekulize(self):
     m = Chem.MolFromSmiles('c1ccccc1')
     smi = Chem.MolToSmiles(m)
@@ -3306,7 +3307,7 @@ CAS<~>
   def testAtomBondProps(self):
     m = Chem.MolFromSmiles('c1ccccc1')
     for atom in m.GetAtoms():
-      self.assertEquals(atom.GetPropsAsDict(), {'_CIPRank': '0'})
+      self.assertEquals(atom.GetPropsAsDict(), {'_CIPRank': 0})
     for bond in m.GetBonds():
       self.assertEquals(bond.GetPropsAsDict(), {})
 
@@ -3315,79 +3316,100 @@ CAS<~>
                          'test_data','NCI_aids_few.sdf')
     #fileN = "../FileParsers/test_data/NCI_aids_few.sdf"
     sddata = [{'_MolFileInfo': 'BBtclserve11129916382D 0   0.00000     0.00000    48',
-               'NSC': '48', 'NCI_AIDS_Antiviral_Screen_IC50': '2.00E-04\tM\t=\t2.46E-05\t3',
-               '_Name': '48', 'CAS_RN': '15716-70-8', '_MolFileComments': '15716-70-8',
-               'NCI_AIDS_Antiviral_Screen_EC50': '2.00E-04\tM\t>\t2.00E-04\t3', 'NCI_AIDS_Antiviral_Screen_Conclusion': 'CI'},
-              {'_MolFileInfo': 'BBtclserve11129916382D 0   0.00000     0.00000    78', 'NSC': '78',
+               'NSC': 48, 'NCI_AIDS_Antiviral_Screen_IC50':
+               '2.00E-04\tM\t=\t2.46E-05\t3',
+               '_Name': 48, 'CAS_RN': '15716-70-8', '_MolFileComments': '15716-70-8',
+               'NCI_AIDS_Antiviral_Screen_EC50': '2.00E-04\tM\t>\t2.00E-04\t3',
+               'NCI_AIDS_Antiviral_Screen_Conclusion': 'CI'},
+              {'_MolFileInfo': 'BBtclserve11129916382D 0   0.00000     0.00000    78',
+               'NSC': 78,
                'NCI_AIDS_Antiviral_Screen_IC50': '2.00E-04\tM\t=\t9.80E-05\t3', 
-               '_Name': '78', 'CAS_RN': '6290-84-2', '_MolFileComments': '6290-84-2', 
+               '_Name': 78, 'CAS_RN': '6290-84-2', '_MolFileComments': '6290-84-2', 
                'NCI_AIDS_Antiviral_Screen_EC50': '2.00E-04\tM\t>\t2.00E-04\t3', 
                'NCI_AIDS_Antiviral_Screen_Conclusion': 'CI'},
-              {'_MolFileInfo': 'BBtclserve11129916382D 0   0.00000     0.00000   128', 'NSC': '128', 
+              {'_MolFileInfo': 'BBtclserve11129916382D 0   0.00000     0.00000   128',
+               'NSC': 128, 
                'NCI_AIDS_Antiviral_Screen_IC50': '2.00E-04\tM\t=\t4.60E-05\t4', 
-               '_Name': '128', 'CAS_RN': '5395-10-8', '_MolFileComments': '5395-10-8', 
+               '_Name': 128, 'CAS_RN': '5395-10-8', '_MolFileComments': '5395-10-8', 
                'NCI_AIDS_Antiviral_Screen_EC50': '2.00E-04\tM\t>\t2.00E-04\t4', 
                'NCI_AIDS_Antiviral_Screen_Conclusion': 'CI'},
-              {'_MolFileInfo': 'BBtclserve11129916382D 0   0.00000     0.00000   163', 'NSC': '163', 
+              {'_MolFileInfo': 'BBtclserve11129916382D 0   0.00000     0.00000   163',
+               'NSC': 163, 
                'NCI_AIDS_Antiviral_Screen_IC50': '6.75E-04\tM\t>\t6.75E-04\t2', 
-               '_Name': '163', 'CAS_RN': '81-11-8', '_MolFileComments': '81-11-8', 
+               '_Name': 163, 'CAS_RN': '81-11-8', '_MolFileComments': '81-11-8', 
                'NCI_AIDS_Antiviral_Screen_EC50': '6.75E-04\tM\t>\t6.75E-04\t2', 
                'NCI_AIDS_Antiviral_Screen_Conclusion': 'CI'},
-              {'_MolFileInfo': 'BBtclserve11129916382D 0   0.00000     0.00000   164', 'NSC': '164', 
+              {'_MolFileInfo': 'BBtclserve11129916382D 0   0.00000     0.00000   164',
+               'NSC': 164, 
                'NCI_AIDS_Antiviral_Screen_IC50': '2.00E-04\tM\t>\t2.00E-04\t2', 
-               '_Name': '164', 'CAS_RN': '5325-43-9', '_MolFileComments': '5325-43-9', 
+               '_Name': 164, 'CAS_RN': '5325-43-9', '_MolFileComments': '5325-43-9', 
                'NCI_AIDS_Antiviral_Screen_EC50': '2.00E-04\tM\t>\t2.00E-04\t2', 
                'NCI_AIDS_Antiviral_Screen_Conclusion': 'CI'},
-              {'_MolFileInfo': 'BBtclserve11129916382D 0   0.00000     0.00000   170', 'NSC': '170', 
-               '_Name': '170', 'CAS_RN': '999-99-9', '_MolFileComments': '999-99-9', 
+              {'_MolFileInfo': 'BBtclserve11129916382D 0   0.00000     0.00000   170',
+               'NSC': 170, 
+               '_Name': 170, 'CAS_RN': '999-99-9', '_MolFileComments': '999-99-9', 
                'NCI_AIDS_Antiviral_Screen_EC50': '9.47E-04\tM\t>\t9.47E-04\t1', 
                'NCI_AIDS_Antiviral_Screen_Conclusion': 'CI'},
-              {'_MolFileInfo': 'BBtclserve11129916382D 0   0.00000     0.00000   180', 'NSC': '180', 
-               'NCI_AIDS_Antiviral_Screen_IC50': '6.46E-04\tM\t=\t5.80E-04\t2\n1.81E-03\tM\t=\t6.90E-04\t2', 
-               '_Name': '180', 'CAS_RN': '69-72-7', '_MolFileComments': '69-72-7', 
-               'NCI_AIDS_Antiviral_Screen_EC50': '6.46E-04\tM\t>\t6.46E-04\t2\n1.81E-03\tM\t>\t1.81E-03\t2', 
+              {'_MolFileInfo': 'BBtclserve11129916382D 0   0.00000     0.00000   180',
+               'NSC': 180, 
+               'NCI_AIDS_Antiviral_Screen_IC50':
+               '6.46E-04\tM\t=\t5.80E-04\t2\n1.81E-03\tM\t=\t6.90E-04\t2', 
+               '_Name': 180, 'CAS_RN': '69-72-7', '_MolFileComments': '69-72-7', 
+               'NCI_AIDS_Antiviral_Screen_EC50':
+               '6.46E-04\tM\t>\t6.46E-04\t2\n1.81E-03\tM\t>\t1.81E-03\t2', 
                'NCI_AIDS_Antiviral_Screen_Conclusion': 'CI'},
-              {'_MolFileInfo': 'BBtclserve11129916382D 0   0.00000     0.00000   186', 'NSC': '186', 
+              {'_MolFileInfo': 'BBtclserve11129916382D 0   0.00000     0.00000   186',
+               'NSC': 186, 
                'NCI_AIDS_Antiviral_Screen_IC50': '1.44E-04\tM\t=\t2.49E-05\t2', 
-               '_Name': '186', 'CAS_RN': '518-75-2', '_MolFileComments': '518-75-2', 
+               '_Name': 186, 'CAS_RN': '518-75-2', '_MolFileComments': '518-75-2', 
                'NCI_AIDS_Antiviral_Screen_EC50': '1.44E-04\tM\t>\t1.44E-04\t2', 
                'NCI_AIDS_Antiviral_Screen_Conclusion': 'CI'},
-              {'_MolFileInfo': 'BBtclserve11129916382D 0   0.00000     0.00000   192', 'NSC': '192', 
+              {'_MolFileInfo': 'BBtclserve11129916382D 0   0.00000     0.00000   192',
+               'NSC': 192, 
                'NCI_AIDS_Antiviral_Screen_IC50': '2.00E-04\tM\t=\t3.38E-06\t2', 
-               '_Name': '192', 'CAS_RN': '2217-55-2', '_MolFileComments': '2217-55-2', 
+               '_Name': 192, 'CAS_RN': '2217-55-2', '_MolFileComments': '2217-55-2', 
                'NCI_AIDS_Antiviral_Screen_EC50': '2.00E-04\tM\t>\t2.00E-04\t2', 
                'NCI_AIDS_Antiviral_Screen_Conclusion': 'CI'},
-              {'_MolFileInfo': 'BBtclserve11129916382D 0   0.00000     0.00000   203', 'NSC': '203', 
-               '_Name': '203', 'CAS_RN': '1155-00-6', '_MolFileComments': '1155-00-6', 
+              {'_MolFileInfo': 'BBtclserve11129916382D 0   0.00000     0.00000   203',
+               'NSC': 203, 
+               '_Name': 203, 'CAS_RN': '1155-00-6', '_MolFileComments': '1155-00-6', 
                'NCI_AIDS_Antiviral_Screen_Conclusion': 'CI'},
-              {'_MolFileInfo': 'BBtclserve11129916382D 0   0.00000     0.00000   210', 'NSC': '210', 
+              {'_MolFileInfo': 'BBtclserve11129916382D 0   0.00000     0.00000   210',
+               'NSC': 210, 
                'NCI_AIDS_Antiviral_Screen_IC50': '1.33E-03\tM\t>\t1.33E-03\t2', 
-               '_Name': '210', 'CAS_RN': '5325-75-7', '_MolFileComments': '5325-75-7', 
+               '_Name': 210, 'CAS_RN': '5325-75-7', '_MolFileComments': '5325-75-7', 
                'NCI_AIDS_Antiviral_Screen_EC50': '1.33E-03\tM\t>\t1.33E-03\t2', 
                'NCI_AIDS_Antiviral_Screen_Conclusion': 'CI'},
-              {'_MolFileInfo': 'BBtclserve11129916382D 0   0.00000     0.00000   211', 'NSC': '211', 
-               'NCI_AIDS_Antiviral_Screen_IC50': '2.00E-04\tM\t>\t2.00E-04\t8\n2.00E-03\tM\t=\t1.12E-03\t2', 
-               '_Name': '211', 'CAS_RN': '5325-76-8', '_MolFileComments': '5325-76-8', 
-               'NCI_AIDS_Antiviral_Screen_EC50': '2.00E-04\tM\t>\t7.42E-05\t8\n2.00E-03\tM\t=\t6.35E-05\t2', 
+              {'_MolFileInfo': 'BBtclserve11129916382D 0   0.00000     0.00000   211',
+               'NSC': 211, 
+               'NCI_AIDS_Antiviral_Screen_IC50':
+               '2.00E-04\tM\t>\t2.00E-04\t8\n2.00E-03\tM\t=\t1.12E-03\t2', 
+               '_Name': 211, 'CAS_RN': '5325-76-8', '_MolFileComments': '5325-76-8', 
+               'NCI_AIDS_Antiviral_Screen_EC50':
+               '2.00E-04\tM\t>\t7.42E-05\t8\n2.00E-03\tM\t=\t6.35E-05\t2', 
                'NCI_AIDS_Antiviral_Screen_Conclusion': 'CM'},
-              {'_MolFileInfo': 'BBtclserve11129916382D 0   0.00000     0.00000   213', 'NSC': '213', 
+              {'_MolFileInfo': 'BBtclserve11129916382D 0   0.00000     0.00000   213',
+               'NSC': 213, 
                'NCI_AIDS_Antiviral_Screen_IC50': '2.00E-04\tM\t>\t2.00E-04\t4', 
-               '_Name': '213', 'CAS_RN': '119-80-2', '_MolFileComments': '119-80-2', 
+               '_Name': 213, 'CAS_RN': '119-80-2', '_MolFileComments': '119-80-2', 
                'NCI_AIDS_Antiviral_Screen_EC50': '2.00E-04\tM\t>\t2.00E-04\t4', 
                'NCI_AIDS_Antiviral_Screen_Conclusion': 'CI'},
-              {'_MolFileInfo': 'BBtclserve11129916382D 0   0.00000     0.00000   220', 'NSC': '220', 
+              {'_MolFileInfo': 'BBtclserve11129916382D 0   0.00000     0.00000   220',
+               'NSC': 220, 
                'NCI_AIDS_Antiviral_Screen_IC50': '2.00E-04\tM\t>\t2.00E-04\t4', 
-               '_Name': '220', 'CAS_RN': '5325-83-7', '_MolFileComments': '5325-83-7', 
+               '_Name': 220, 'CAS_RN': '5325-83-7', '_MolFileComments': '5325-83-7', 
                'NCI_AIDS_Antiviral_Screen_EC50': '2.00E-04\tM\t>\t2.00E-04\t4', 
                'NCI_AIDS_Antiviral_Screen_Conclusion': 'CI'},
-              {'_MolFileInfo': 'BBtclserve11129916382D 0   0.00000     0.00000   229', 'NSC': '229', 
+              {'_MolFileInfo': 'BBtclserve11129916382D 0   0.00000     0.00000   229',
+               'NSC': 229, 
                'NCI_AIDS_Antiviral_Screen_IC50': '2.00E-04\tM\t>\t2.00E-04\t2', 
-               '_Name': '229', 'CAS_RN': '5325-88-2', '_MolFileComments': '5325-88-2', 
+               '_Name': 229, 'CAS_RN': '5325-88-2', '_MolFileComments': '5325-88-2', 
                'NCI_AIDS_Antiviral_Screen_EC50': '2.00E-04\tM\t>\t2.00E-04\t2', 
                'NCI_AIDS_Antiviral_Screen_Conclusion': 'CI'},
-              {'_MolFileInfo': 'BBtclserve11129916382D 0   0.00000     0.00000   256', 'NSC': '256', 
+              {'_MolFileInfo': 'BBtclserve11129916382D 0   0.00000     0.00000   256',
+               'NSC': 256, 
                'NCI_AIDS_Antiviral_Screen_IC50': '2.00E-04\tM\t>\t2.00E-04\t4', 
-               '_Name': '256', 'CAS_RN': '5326-06-7', '_MolFileComments': '5326-06-7', 
+               '_Name': 256, 'CAS_RN': '5326-06-7', '_MolFileComments': '5326-06-7', 
                'NCI_AIDS_Antiviral_Screen_EC50': '2.00E-04\tM\t>\t2.00E-04\t4', 
                'NCI_AIDS_Antiviral_Screen_Conclusion': 'CI'},]
     sdSup = Chem.SDMolSupplier(fileN)


### PR DESCRIPTION
Fixes GetPropsAsDict - always fell back to GetStringProp

Retrieving a Property that exists but is not the requested value, now returns a ValueError not a RuntimeError.

Here are the type names, I might have gone too far, should I just use "Double", "Int"...??
```
template<>
inline const char * GetTypeName<double>() { return "64 bit floating point value"; }
template<>
inline const char * GetTypeName<int>() { return "32 bit integer value";}
template<>
inline const char * GetTypeName<unsigned int>() { return "32 bit unsigned integer value";}
template<>
inline const char * GetTypeName<bool>() { return "True or False value";}
```