### PR TITLE
Fix/translate invariant exception + Sending warnings/errors to IPython Console

### DIFF
--- a/Code/GraphMol/Wrap/rdchem.cpp
+++ b/Code/GraphMol/Wrap/rdchem.cpp
@@ -59,7 +59,10 @@ BOOST_PYTHON_MODULE(rdchem) {
       &translate_value_error);
   python::register_exception_translator<RDKit::MolSanitizeException>(
       &rdSanitExceptionTranslator);
-
+#if INVARIANT_EXCEPTION_METHOD  
+  python::register_exception_translator<Invar::Invariant>(
+      &translate_invariant_error);
+#endif
   //*********************************************
   //
   //  Utility Classes

--- a/Code/GraphMol/Wrap/rdchem.cpp
+++ b/Code/GraphMol/Wrap/rdchem.cpp
@@ -47,6 +47,43 @@ void wrap_EditableMol();
 void wrap_monomerinfo();
 void wrap_resmolsupplier();
 
+struct PySysErrWrite : std::ostream, std::streambuf
+{
+  std::string prefix;
+   std::string buffer; // unlimited! flushes in endl
+  
+  PySysErrWrite(const std::string &prefix) :
+      std::ostream(this), prefix(prefix) {}
+
+    int overflow(int c)
+    {
+        foo(c);
+        return 0;
+    }
+
+
+    void foo(char c)
+    {
+      buffer += c;
+      if (c == '\n') {
+        PySys_WriteStderr("%s", (prefix + buffer).c_str());
+        buffer.clear();
+      }
+    }
+};
+
+void WrapErrorStreams() {
+  static PySysErrWrite debug  ("C++ DEBUG: ");
+  static PySysErrWrite error  ("C++ ERROR: ");
+  static PySysErrWrite info   ("C++ INFO: ");
+  static PySysErrWrite warning("C++ WARNING: ");
+  
+  rdDebugLog->AddTee(debug);
+  rdInfoLog->AddTee(info);
+  rdErrorLog->AddTee(error);
+  rdWarningLog->AddTee(error);
+}
+
 BOOST_PYTHON_MODULE(rdchem) {
   python::scope().attr("__doc__") =
       "Module containing the core chemistry functionality of the RDKit";
@@ -63,6 +100,11 @@ BOOST_PYTHON_MODULE(rdchem) {
   python::register_exception_translator<Invar::Invariant>(
       &translate_invariant_error);
 #endif
+  python::def("WrapRDKitStreams", WrapErrorStreams,
+              "Wrap the internal RDKit streams so they go to python's "
+              "SysStdErr");
+
+  
   //*********************************************
   //
   //  Utility Classes

--- a/Code/RDBoost/CMakeLists.txt
+++ b/Code/RDBoost/CMakeLists.txt
@@ -1,5 +1,5 @@
 rdkit_library(RDBoost Wrap.cpp
-              LINK_LIBRARIES ${PYTHON_LIBRARIES} ${Boost_LIBRARIES})
+              LINK_LIBRARIES RDGeneral ${PYTHON_LIBRARIES} ${Boost_LIBRARIES})
 
 rdkit_headers(Wrap.h PySequenceHolder.h
               list_indexing_suite.hpp

--- a/Code/RDBoost/Wrap.cpp
+++ b/Code/RDBoost/Wrap.cpp
@@ -37,3 +37,17 @@ RDKIT_WRAP_DECL void translate_index_error(IndexErrorException const& e) {
 RDKIT_WRAP_DECL void translate_value_error(ValueErrorException const& e) {
   throw_value_error(e.message());
 }
+
+#ifdef INVARIANT_EXCEPTION_METHOD
+// A helper function for dealing with errors. Throw a Python RuntimeError
+RDKIT_WRAP_DECL void throw_runtime_error(const std::string err) {
+  PyErr_SetString(PyExc_RuntimeError, err.c_str());
+  python::throw_error_already_set();
+}
+
+
+RDKIT_WRAP_DECL void translate_invariant_error(Invar::Invariant const &e) {
+  throw_runtime_error(e.toString());
+}
+#endif                                               
+

--- a/Code/RDBoost/Wrap.h
+++ b/Code/RDBoost/Wrap.h
@@ -10,6 +10,8 @@
 #ifndef _RD_WRAP_H_
 #define _RD_WRAP_H_
 
+#include <RDGeneral/Invariant.h>
+
 #include <RDGeneral/BoostStartInclude.h>
 //
 // Generic Wrapper utility functionality
@@ -60,6 +62,11 @@ RDKIT_WRAP_DECL void throw_value_error(
 RDKIT_WRAP_DECL void translate_index_error(IndexErrorException const &e);
 RDKIT_WRAP_DECL void translate_value_error(ValueErrorException const &e);
 
+#ifdef INVARIANT_EXCEPTION_METHOD
+RDKIT_WRAP_DECL void throw_runtime_error(
+    const std::string err);  //!< construct and throw a \c ValueError
+RDKIT_WRAP_DECL void translate_invariant_error(Invar::Invariant const &e);
+#endif                                               
 //! \brief Registers a templated converter for returning \c vectors of a
 //!        particular type.
 //! This should be used instead of calling \c vector_to_python<T>()

--- a/Code/RDGeneral/RDLog.h
+++ b/Code/RDGeneral/RDLog.h
@@ -12,15 +12,36 @@
 #define _RDLOG_H_29JUNE2005_
 
 #if 1
+#include <boost/iostreams/tee.hpp>
+#include <boost/iostreams/stream.hpp>
 #include <iostream>
 namespace boost {
 namespace logging {
+struct rdLoggerFunctor {
+  virtual void Write(std::ostream &);
+};
+
+typedef boost::iostreams::tee_device<std::ostream, std::ostream> RDTee;
+typedef boost::iostreams::stream<RDTee> RDTeeStream;
+ 
 class rdLogger {
  public:
-  rdLogger(std::ostream *dest, bool owner = false)
-      : dp_dest(dest), df_owner(owner), df_enabled(true){};
   std::ostream *dp_dest;
   bool df_owner, df_enabled;
+
+  RDTee *tee;
+  RDTeeStream *teestream;
+  
+  rdLogger(std::ostream *dest, bool owner = false)
+      : dp_dest(dest), df_owner(owner), df_enabled(true),
+      tee(0), teestream(0){};
+
+  void AddTee(std::ostream &stream) {
+    if (dp_dest) {
+      tee = new RDTee(*dp_dest, stream);
+      teestream = new RDTeeStream(*tee);
+    }
+  }
   ~rdLogger() {
     if (dp_dest) {
       dp_dest->flush();
@@ -28,6 +49,8 @@ class rdLogger {
         delete dp_dest;
       }
     }
+    if (teestream) delete teestream;
+    if (tee) delete tee;
   }
 };
 void enable_logs(const char *arg);
@@ -43,7 +66,7 @@ std::ostream &toStream(std::ostream &);
   if ((!__arg__) || (!__arg__->dp_dest) || !(__arg__->df_enabled)) \
     ;                                                              \
   else                                                             \
-  RDLog::toStream(*(__arg__->dp_dest))
+    RDLog::toStream((__arg__->teestream) ? *(__arg__->teestream) : *(__arg__->dp_dest))
 
 extern boost::logging::rdLogger *rdAppLog;
 extern boost::logging::rdLogger *rdDebugLog;

--- a/rdkit/Chem/Draw/IPythonConsole.py
+++ b/rdkit/Chem/Draw/IPythonConsole.py
@@ -22,6 +22,9 @@ try:
 except ImportError:
     from PIL import Image
 
+# Expose the C++ Error streams to the IPythonConsole
+Chem.WrapRDKitErrorStreams()
+
 molSize = (450, 150)
 highlightSubstructs = True
 kekulizeStructures = True

--- a/rdkit/Chem/Draw/IPythonConsole.py
+++ b/rdkit/Chem/Draw/IPythonConsole.py
@@ -23,7 +23,7 @@ except ImportError:
     from PIL import Image
 
 # Expose the C++ Error streams to the IPythonConsole
-Chem.WrapRDKitErrorStreams()
+Chem.WrapRDKitStreams()
 
 molSize = (450, 150)
 highlightSubstructs = True


### PR DESCRIPTION
This adds a few useful features.

The first is that Invar::Invariant is now wrapped, so more meaningful messages are now sent to the console.

```
> m = Chem.Mol()
> m.GetAtomWithIdx(3)
---------------------------------------------------------------------------
RuntimeError                              Traceback (most recent call last)
<ipython-input-9-29869c86cafb> in <module>()
----> 1 m.GetAtomWithIdx(3)

RuntimeError: Pre-condition Violation
no atoms
Violation occurred on line 154 in file /Users/kellebr5/anaconda/conda-bld/work/Code/GraphMol/ROMol.cpp
Failed Expression: getNumAtoms() > 0
```

We may think about chopping off the source file at ..Code or removing it completely.

After watching my struggling coop load up ipython notebook AND have to have the console open to find errors, I added Chem.WrapRDKitStreams() which wraps the BOOST_LOGs and also sends them to the IPython Console.  For example:

```
In [1] Chem.MolFromSmiles("C[HO]")
C++ ERROR: [15:01:53] SMILES Parse Error: syntax error for input: 'C[HO]'
```

This is enabled from
```
from rdkit.Chem.Draw import IPythonConsole
```

We may need to put a mutex + a thread local buffer in the python ostream, I have not tried this with threaded C++ writing log errors.