### PR TITLE
Fix ConformerParser to use const std::string &

### DIFF
--- a/Contrib/ConformerParser/ConformerParser.cpp
+++ b/Contrib/ConformerParser/ConformerParser.cpp
@@ -69,7 +69,7 @@ namespace RDKit{
       return confIds;
     }
 
-    void readAmberTrajectory(std::string fName, std::vector<std::vector<double> > &coords,
+    void readAmberTrajectory(const std::string &fName, std::vector<std::vector<double> > &coords,
                              unsigned int numAtoms) {
       std::ifstream inStream(fName.c_str());
       if (!inStream || (inStream.bad()) ) {


### PR DESCRIPTION
In #627, `readAmberTrajectory` in ConformerParser.h is updated to use `const std::string &`. This updates the corresponding method in ConformerParser.cpp to match. I needed to do this to compile RDKit with contrib and successfully run the tests.