### PR TITLE
Adds support for capturing RDLogs in Python StdErr streams

### DIFF
--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -3393,7 +3393,30 @@ CAS<~>
     sdSup = Chem.SDMolSupplier(fileN)
     for i,mol in enumerate(sdSup):
       self.assertEquals(mol.GetPropsAsDict(includePrivate=True), sddata[i])
-      
+
+  # this test should probably always be last since it wraps
+  #  the logging stream
+  def testLogging(self):
+    err = sys.stderr
+    try:
+      loggers = [("RDKit ERROR",   "1", Chem.LogErrorMsg),
+                 ("RDKit INFO",    "2", Chem.LogInfoMsg),
+                 ("RDKit DEBUG",   "3", Chem.LogDebugMsg),
+                 ("RDKit WARNING", "4", Chem.LogWarningMsg)]
+      for msg, v, log in loggers:
+        sys.stderr = six.StringIO()
+        log(v)
+        self.assertEquals(sys.stderr.getvalue(), "")
+
+      Chem.WrapLogs()
+      for msg, v, log in loggers:
+        sys.stderr = six.StringIO()
+        log(v)
+        s = sys.stderr.getvalue()
+        self.assertTrue(msg in s)
+    finally:
+      sys.stderr = err
+    
 if __name__ == '__main__':
   unittest.main()
 

--- a/Code/GraphMol/Wrap/testThreads.py
+++ b/Code/GraphMol/Wrap/testThreads.py
@@ -34,12 +34,48 @@ for func in funcs:
     
 
 nthreads = int(multiprocessing.cpu_count() * 100 / 4) # 100 threads per cpu
+threads = []
 for i in range(0, nthreads):
     for func in funcs:
         t = threading.Thread(target=runner, args=(func,core_mol))
         t.start()
+        threads.append(t)
     t = threading.Thread(target=runner, args=("ToBinary",None))        
     t.start()
+    threads.append(t)
+for t in threads:
+    t.join()
 
+# this spews a ton of logging info...
+#  that is all intermingled...
+nthreads = int(multiprocessing.cpu_count())
+threads = []
+for i in range(0, nthreads):
+    for func in funcs:
+        t = threading.Thread(target=Chem.LogThreadTest)
+        t.start()
+        threads.append(t)
+    t = threading.Thread(target=Chem.LogThreadTest)
+    t.start()
+    threads.append(t)
+    
+for t in threads:
+    t.join()
 
+Chem.WrapLogs()
+# now the errors should be synchronized...
+nthreads = int(multiprocessing.cpu_count())
+threads = []
+for i in range(0, nthreads):
+    for func in funcs:
+        t = threading.Thread(target=Chem.LogThreadTest)
+        t.start()
+        threads.append(t)
+    t = threading.Thread(target=Chem.LogThreadTest)
+    t.start()
+    threads.append(t)
+    
+for t in threads:
+    t.join()
 
+    

--- a/Code/RDGeneral/RDLog.h
+++ b/Code/RDGeneral/RDLog.h
@@ -12,15 +12,36 @@
 #define _RDLOG_H_29JUNE2005_
 
 #if 1
+#include <boost/iostreams/tee.hpp>
+#include <boost/iostreams/stream.hpp>
 #include <iostream>
 namespace boost {
 namespace logging {
+struct rdLoggerFunctor {
+  virtual void Write(std::ostream &);
+};
+
+typedef boost::iostreams::tee_device<std::ostream, std::ostream> RDTee;
+typedef boost::iostreams::stream<RDTee> RDTeeStream;
+ 
 class rdLogger {
  public:
-  rdLogger(std::ostream *dest, bool owner = false)
-      : dp_dest(dest), df_owner(owner), df_enabled(true){};
   std::ostream *dp_dest;
   bool df_owner, df_enabled;
+
+  RDTee *tee;
+  RDTeeStream *teestream;
+  
+  rdLogger(std::ostream *dest, bool owner = false)
+      : dp_dest(dest), df_owner(owner), df_enabled(true),
+      tee(0), teestream(0){};
+
+  void AddTee(std::ostream &stream) {
+    if (dp_dest) {
+      tee = new RDTee(*dp_dest, stream);
+      teestream = new RDTeeStream(*tee);
+    }
+  }
   ~rdLogger() {
     if (dp_dest) {
       dp_dest->flush();
@@ -28,6 +49,8 @@ class rdLogger {
         delete dp_dest;
       }
     }
+    delete teestream;
+    delete tee;
   }
 };
 void enable_logs(const char *arg);
@@ -43,7 +66,7 @@ std::ostream &toStream(std::ostream &);
   if ((!__arg__) || (!__arg__->dp_dest) || !(__arg__->df_enabled)) \
     ;                                                              \
   else                                                             \
-  RDLog::toStream(*(__arg__->dp_dest))
+    RDLog::toStream((__arg__->teestream) ? *(__arg__->teestream) : *(__arg__->dp_dest))
 
 extern boost::logging::rdLogger *rdAppLog;
 extern boost::logging::rdLogger *rdDebugLog;

--- a/rdkit/Chem/Draw/IPythonConsole.py
+++ b/rdkit/Chem/Draw/IPythonConsole.py
@@ -33,6 +33,9 @@ drawing_type_3d = "ball and stick"
 camera_type_3d = "perspective"
 shader_3d = "lambert"
 
+# expose RDLogs to Python StdErr so they are shown
+#  in the IPythonConsole not the server logs.
+Chem.WrapLogs()
 
 def _toJSON(mol):
     """For IPython notebook, renders 3D webGL objects."""


### PR DESCRIPTION
Adds four basic logging functions to Chem that log through the C++ 
logging mechanism:

 Chem.LogWarningMsg(msg)
 Chem.LogInfoMsg(msg)
 Chem.LogErrorMsg(msg)
 Chem.LogDebugMsg(msg)

And a Wrapper to enable logs to be mirrored in Python SysStderr.  One of 
the nicer features of this logging system, is that Threaded logging is
synchronized to Python where it is interleaved in raw C++ logging.

  Chem.WrapLogs()

This allows:
```
 Chem.WrapLogs()
 sys.stderr = StringIO()
 ... rdkit stuff ...
 # sys.stderr has now captured all the RDKit Logs so we can do stuff with them
 errors = sys.stderr.getvalue()
```