### PR TITLE
Fixes Boost 1.46 issues with type traits

### DIFF
--- a/Code/RDGeneral/Dict.cpp
+++ b/Code/RDGeneral/Dict.cpp
@@ -14,6 +14,7 @@
 #include <boost/cstdint.hpp>
 #include <boost/tuple/tuple.hpp>
 #include <boost/utility.hpp>
+#include <boost/type_traits.hpp>
 #include <vector>
 #include <list>
 #include <iostream>


### PR DESCRIPTION
Small header file addition to Dict.cpp to help build with boost 1.46