### PR TITLE
Adds support for capturing RDLogs in Python StdErr streams

### DIFF
--- a/Code/GraphMol/Wrap/rdchem.cpp
+++ b/Code/GraphMol/Wrap/rdchem.cpp
@@ -93,24 +93,14 @@ struct PySysErrWrite : std::ostream, std::streambuf
 };
 
 void RDLogError(const std::string &msg) {
+  NOGIL gil;
   BOOST_LOG(rdErrorLog) << msg.c_str() << std::endl;
 }
 
 void RDLogWarning(const std::string &msg) {
+  NOGIL gil;
   BOOST_LOG(rdWarningLog) << msg.c_str() << std::endl;
 }
-
-#ifdef RDK_TEST_MULTITHREADED
-// As much as I hate adding test code to the python module
-//  we need to expose this to python somehow with the GIL
-//   turned off.
-void LogThreadTest() {
-  NOGIL gil;
-  for(int i=0;i<5;++i)
-    BOOST_LOG(rdWarningLog) <<
-        "Test [" << i << "]: the quick brown fox jumps over the lazy dog\n";
-}
-#endif
 
 void WrapLogs() {
   static PySysErrWrite debug  ("RDKit DEBUG: ");
@@ -145,10 +135,6 @@ BOOST_PYTHON_MODULE(rdchem) {
   python::def("LogErrorMsg", RDLogError,
               "Log a warning message to the RDKit error logs");
 
-
-#ifdef RDK_TEST_MULTITHREADED
-  python::def("LogThreadTest", LogThreadTest);
-#endif  
 
   //*********************************************
   //

--- a/Code/GraphMol/Wrap/rdchem.cpp
+++ b/Code/GraphMol/Wrap/rdchem.cpp
@@ -96,14 +96,6 @@ void RDLogError(const std::string &msg) {
   BOOST_LOG(rdErrorLog) << msg.c_str() << std::endl;
 }
 
-void RDLogInfo(const std::string &msg) {
-  BOOST_LOG(rdInfoLog) << msg.c_str() << std::endl;
-}
-
-void RDLogDebug(const std::string &msg) {
-  BOOST_LOG(rdDebugLog) << msg.c_str() << std::endl;
-}
-
 void RDLogWarning(const std::string &msg) {
   BOOST_LOG(rdWarningLog) << msg.c_str() << std::endl;
 }
@@ -150,12 +142,9 @@ BOOST_PYTHON_MODULE(rdchem) {
               "SysStdErr");
   python::def("LogWarningMsg", RDLogWarning,
               "Log a warning message to the RDKit warning logs");
-  python::def("LogInfoMsg", RDLogInfo,
-              "Log a warning message to the RDKit info logs");
   python::def("LogErrorMsg", RDLogError,
               "Log a warning message to the RDKit error logs");
-  python::def("LogDebugMsg", RDLogDebug,
-              "Log a warning message to the RDKit debug logs");
+
 
 #ifdef RDK_TEST_MULTITHREADED
   python::def("LogThreadTest", LogThreadTest);

--- a/Code/GraphMol/Wrap/rdchem.cpp
+++ b/Code/GraphMol/Wrap/rdchem.cpp
@@ -16,6 +16,11 @@
 #include <RDBoost/import_array.h>
 #include <RDBoost/iterator_next.h>
 
+#ifdef RDK_THREADSAFE_SSS
+// Thread local storage for output buffer for RDKit Logging
+#include <boost/thread/tss.hpp>
+#endif
+
 #include <sstream>
 
 #include "seqs.hpp"
@@ -47,6 +52,86 @@ void wrap_EditableMol();
 void wrap_monomerinfo();
 void wrap_resmolsupplier();
 
+struct PySysErrWrite : std::ostream, std::streambuf
+{
+  std::string prefix;
+  
+  PySysErrWrite(const std::string &prefix) :
+      std::ostream(this), prefix(prefix) {}
+
+  int overflow(int c) { write(c); return 0;}
+  
+#ifdef RDK_THREADSAFE_SSS
+  void write(char c) { // enable thread safe logging
+    static boost::thread_specific_ptr< std::string > buffer;
+    if( !buffer.get() ) {
+      buffer.reset( new std::string );
+    }
+    (*buffer.get()) += c;
+    if (c == '\n') {
+      // Python IO is not thread safe, so grab the GIL
+      PyGILState_STATE gstate;
+      gstate = PyGILState_Ensure();
+      PySys_WriteStderr("%s", (prefix + (*buffer.get())).c_str());
+      PyGILState_Release(gstate);
+      buffer->clear();
+    }
+  }
+  
+#else
+  std::string buffer; // unlimited! flushes in endl
+  void write(char c) {
+    buffer += c;
+    if (c == '\n') {
+      PySys_WriteStderr("%s", (prefix + buffer).c_str());
+      buffer.clear();
+    }
+  }
+#endif
+
+  
+};
+
+void RDLogError(const std::string &msg) {
+  BOOST_LOG(rdErrorLog) << msg.c_str() << std::endl;
+}
+
+void RDLogInfo(const std::string &msg) {
+  BOOST_LOG(rdInfoLog) << msg.c_str() << std::endl;
+}
+
+void RDLogDebug(const std::string &msg) {
+  BOOST_LOG(rdDebugLog) << msg.c_str() << std::endl;
+}
+
+void RDLogWarning(const std::string &msg) {
+  BOOST_LOG(rdWarningLog) << msg.c_str() << std::endl;
+}
+
+#ifdef RDK_TEST_MULTITHREADED
+// As much as I hate adding test code to the python module
+//  we need to expose this to python somehow with the GIL
+//   turned off.
+void LogThreadTest() {
+  NOGIL gil;
+  for(int i=0;i<5;++i)
+    BOOST_LOG(rdWarningLog) <<
+        "Test [" << i << "]: the quick brown fox jumps over the lazy dog\n";
+}
+#endif
+
+void WrapLogs() {
+  static PySysErrWrite debug  ("RDKit DEBUG: ");
+  static PySysErrWrite error  ("RDKit ERROR: ");
+  static PySysErrWrite info   ("RDKit INFO: ");
+  static PySysErrWrite warning("RDKit WARNING: ");
+  
+  rdDebugLog->AddTee(debug);
+  rdInfoLog->AddTee(info);
+  rdErrorLog->AddTee(error);
+  rdWarningLog->AddTee(warning);
+}
+
 BOOST_PYTHON_MODULE(rdchem) {
   python::scope().attr("__doc__") =
       "Module containing the core chemistry functionality of the RDKit";
@@ -59,6 +144,23 @@ BOOST_PYTHON_MODULE(rdchem) {
       &translate_value_error);
   python::register_exception_translator<RDKit::MolSanitizeException>(
       &rdSanitExceptionTranslator);
+
+  python::def("WrapLogs", WrapLogs,
+              "Wrap the internal RDKit streams so they go to python's "
+              "SysStdErr");
+  python::def("LogWarningMsg", RDLogWarning,
+              "Log a warning message to the RDKit warning logs");
+  python::def("LogInfoMsg", RDLogInfo,
+              "Log a warning message to the RDKit info logs");
+  python::def("LogErrorMsg", RDLogError,
+              "Log a warning message to the RDKit error logs");
+  python::def("LogDebugMsg", RDLogDebug,
+              "Log a warning message to the RDKit debug logs");
+
+#ifdef RDK_TEST_MULTITHREADED
+  python::def("LogThreadTest", LogThreadTest);
+#endif  
+
   //*********************************************
   //
   //  Utility Classes

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -3459,9 +3459,7 @@ CAS<~>
     err = sys.stderr
     try:
       loggers = [("RDKit ERROR",   "1", Chem.LogErrorMsg),
-                 ("RDKit INFO",    "2", Chem.LogInfoMsg),
-                 ("RDKit DEBUG",   "3", Chem.LogDebugMsg),
-                 ("RDKit WARNING", "4", Chem.LogWarningMsg)]
+                 ("RDKit WARNING", "2", Chem.LogWarningMsg)]
       for msg, v, log in loggers:
         sys.stderr = six.StringIO()
         log(v)

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -3452,6 +3452,29 @@ CAS<~>
       self.assertTrue("Failed Expression: 3 <= 0" in details)
       self.assertTrue("RDKIT:" in details)
       self.assertTrue(__version__ in details)
+
+  # this test should probably always be last since it wraps
+  #  the logging stream
+  def testLogging(self):
+    err = sys.stderr
+    try:
+      loggers = [("RDKit ERROR",   "1", Chem.LogErrorMsg),
+                 ("RDKit INFO",    "2", Chem.LogInfoMsg),
+                 ("RDKit DEBUG",   "3", Chem.LogDebugMsg),
+                 ("RDKit WARNING", "4", Chem.LogWarningMsg)]
+      for msg, v, log in loggers:
+        sys.stderr = six.StringIO()
+        log(v)
+        self.assertEquals(sys.stderr.getvalue(), "")
+
+      Chem.WrapLogs()
+      for msg, v, log in loggers:
+        sys.stderr = six.StringIO()
+        log(v)
+        s = sys.stderr.getvalue()
+        self.assertTrue(msg in s)
+    finally:
+      sys.stderr = err
     
 if __name__ == '__main__':
   unittest.main()

--- a/Code/GraphMol/Wrap/testThreads.py
+++ b/Code/GraphMol/Wrap/testThreads.py
@@ -34,12 +34,48 @@ for func in funcs:
     
 
 nthreads = int(multiprocessing.cpu_count() * 100 / 4) # 100 threads per cpu
+threads = []
 for i in range(0, nthreads):
     for func in funcs:
         t = threading.Thread(target=runner, args=(func,core_mol))
         t.start()
+        threads.append(t)
     t = threading.Thread(target=runner, args=("ToBinary",None))        
     t.start()
+    threads.append(t)
+for t in threads:
+    t.join()
 
+# this spews a ton of logging info...
+#  that is all intermingled...
+nthreads = int(multiprocessing.cpu_count())
+threads = []
+for i in range(0, nthreads):
+    for func in funcs:
+        t = threading.Thread(target=Chem.LogThreadTest)
+        t.start()
+        threads.append(t)
+    t = threading.Thread(target=Chem.LogThreadTest)
+    t.start()
+    threads.append(t)
+    
+for t in threads:
+    t.join()
 
+Chem.WrapLogs()
+# now the errors should be synchronized...
+nthreads = int(multiprocessing.cpu_count())
+threads = []
+for i in range(0, nthreads):
+    for func in funcs:
+        t = threading.Thread(target=Chem.LogThreadTest)
+        t.start()
+        threads.append(t)
+    t = threading.Thread(target=Chem.LogThreadTest)
+    t.start()
+    threads.append(t)
+    
+for t in threads:
+    t.join()
 
+    

--- a/Code/GraphMol/Wrap/testThreads.py
+++ b/Code/GraphMol/Wrap/testThreads.py
@@ -53,14 +53,14 @@ def LogError():
     while 1:
         if i==10: break
         i+=1
-        Chem.LogErrorMsg("My dog has fleas")
+        Chem.LogErrorMsg(str(i) + ":: My dog has fleas")
 
 def LogWarning():
     i=0
     while 1:
         if i==10: break
         i+=1
-        Chem.LogWarningMsg("All good boys to fine")
+        Chem.LogWarningMsg(str(i) + ":: All good boys to fine")
     
 # this spews a ton of logging info...
 #  that is all intermingled...
@@ -85,7 +85,7 @@ if 0:
 Chem.WrapLogs()
 
 err = sys.stderr
-sys.stderr = six.StringIO()
+stringio = sys.stderr = six.StringIO()
 
 # now the errors should be synchronized...
 nthreads = int(multiprocessing.cpu_count())
@@ -104,5 +104,13 @@ for i in range(0, nthreads):
     
 for t in threads:
     t.join()
-print (sys.stderr.getvalue())
-    
+sys.stderr = err
+
+stringio = sys.stderr = six.StringIO()
+LogWarning()
+LogError()
+sys.stderr = err
+assert "WARNING" in stringio.getvalue()
+assert "ERROR" in stringio.getvalue()
+assert stringio.getvalue().count("WARNING") == 10
+assert stringio.getvalue().count("ERROR") == 10

--- a/Code/GraphMol/Wrap/testThreads.py
+++ b/Code/GraphMol/Wrap/testThreads.py
@@ -1,4 +1,6 @@
+import sys
 from rdkit import Chem
+from rdkit import six
 import threading
 import multiprocessing
 
@@ -46,36 +48,61 @@ for i in range(0, nthreads):
 for t in threads:
     t.join()
 
+def LogError():
+    i=0
+    while 1:
+        if i==10: break
+        i+=1
+        Chem.LogErrorMsg("My dog has fleas")
+
+def LogWarning():
+    i=0
+    while 1:
+        if i==10: break
+        i+=1
+        Chem.LogWarningMsg("All good boys to fine")
+    
 # this spews a ton of logging info...
 #  that is all intermingled...
-nthreads = int(multiprocessing.cpu_count())
-threads = []
-for i in range(0, nthreads):
-    for func in funcs:
-        t = threading.Thread(target=Chem.LogThreadTest)
+if 0:
+    nthreads = int(multiprocessing.cpu_count())
+    threads = []
+    for i in range(0, nthreads):
+        for func in funcs:
+            if i%2 == 0:
+                t = threading.Thread(target=LogError)
+            else:
+                t = threading.Thread(target=LogWarning)
+            t.start()
+            threads.append(t)
+        t = threading.Thread(target=LogWarning)
         t.start()
         threads.append(t)
-    t = threading.Thread(target=Chem.LogThreadTest)
-    t.start()
-    threads.append(t)
-    
-for t in threads:
-    t.join()
+
+    for t in threads:
+        t.join()
 
 Chem.WrapLogs()
+
+err = sys.stderr
+sys.stderr = six.StringIO()
+
 # now the errors should be synchronized...
 nthreads = int(multiprocessing.cpu_count())
 threads = []
 for i in range(0, nthreads):
     for func in funcs:
-        t = threading.Thread(target=Chem.LogThreadTest)
+        if i%2 == 0:
+            t = threading.Thread(target=LogError)
+        else:
+            t = threading.Thread(target=LogWarning)
         t.start()
         threads.append(t)
-    t = threading.Thread(target=Chem.LogThreadTest)
+    t = threading.Thread(target=LogWarning)
     t.start()
     threads.append(t)
     
 for t in threads:
     t.join()
-
+print (sys.stderr.getvalue())
     

--- a/Code/RDGeneral/RDLog.h
+++ b/Code/RDGeneral/RDLog.h
@@ -17,9 +17,6 @@
 #include <iostream>
 namespace boost {
 namespace logging {
-struct rdLoggerFunctor {
-  virtual void Write(std::ostream &);
-};
 
 typedef boost::iostreams::tee_device<std::ostream, std::ostream> RDTee;
 typedef boost::iostreams::stream<RDTee> RDTeeStream;

--- a/Code/RDGeneral/RDLog.h
+++ b/Code/RDGeneral/RDLog.h
@@ -12,15 +12,36 @@
 #define _RDLOG_H_29JUNE2005_
 
 #if 1
+#include <boost/iostreams/tee.hpp>
+#include <boost/iostreams/stream.hpp>
 #include <iostream>
 namespace boost {
 namespace logging {
+struct rdLoggerFunctor {
+  virtual void Write(std::ostream &);
+};
+
+typedef boost::iostreams::tee_device<std::ostream, std::ostream> RDTee;
+typedef boost::iostreams::stream<RDTee> RDTeeStream;
+ 
 class rdLogger {
  public:
-  rdLogger(std::ostream *dest, bool owner = false)
-      : dp_dest(dest), df_owner(owner), df_enabled(true){};
   std::ostream *dp_dest;
   bool df_owner, df_enabled;
+
+  RDTee *tee;
+  RDTeeStream *teestream;
+  
+  rdLogger(std::ostream *dest, bool owner = false)
+      : dp_dest(dest), df_owner(owner), df_enabled(true),
+      tee(0), teestream(0){};
+
+  void AddTee(std::ostream &stream) {
+    if (dp_dest) {
+      tee = new RDTee(*dp_dest, stream);
+      teestream = new RDTeeStream(*tee);
+    }
+  }
   ~rdLogger() {
     if (dp_dest) {
       dp_dest->flush();
@@ -28,6 +49,8 @@ class rdLogger {
         delete dp_dest;
       }
     }
+    delete teestream;
+    delete tee;
   }
 };
 void enable_logs(const char *arg);
@@ -43,7 +66,7 @@ std::ostream &toStream(std::ostream &);
   if ((!__arg__) || (!__arg__->dp_dest) || !(__arg__->df_enabled)) \
     ;                                                              \
   else                                                             \
-  RDLog::toStream(*(__arg__->dp_dest))
+    RDLog::toStream((__arg__->teestream) ? *(__arg__->teestream) : *(__arg__->dp_dest))
 
 extern boost::logging::rdLogger *rdAppLog;
 extern boost::logging::rdLogger *rdDebugLog;

--- a/rdkit/Chem/Draw/IPythonConsole.py
+++ b/rdkit/Chem/Draw/IPythonConsole.py
@@ -33,6 +33,9 @@ drawing_type_3d = "ball and stick"
 camera_type_3d = "perspective"
 shader_3d = "lambert"
 
+# expose RDLogs to Python StdErr so they are shown
+#  in the IPythonConsole not the server logs.
+Chem.WrapLogs()
 
 def _toJSON(mol):
     """For IPython notebook, renders 3D webGL objects."""


### PR DESCRIPTION
Adds four basic logging functions to Chem that log through the C++
logging mechanism:

 Chem.LogWarningMsg(msg)
 Chem.LogInfoMsg(msg)
 Chem.LogErrorMsg(msg)
 Chem.LogDebugMsg(msg)

And a Wrapper to enable logs to be mirrored in Python SysStderr.  One of
the nicer features of this logging system, is that Threaded logging is
synchronized to Python where it is interleaved in raw C++ logging.

  Chem.WrapLogs()

This is automatically turned on when using the IPython Console.  Mistyped smiles strings now indicate that something was wrong ;)