### PR TITLE
Removed -Xdoclint:none flag when packing org.RDKitDoc.jar

### DIFF
--- a/Code/JavaWrappers/gmwrapper/CMakeLists.txt
+++ b/Code/JavaWrappers/gmwrapper/CMakeLists.txt
@@ -116,7 +116,7 @@ ADD_CUSTOM_COMMAND(
   COMMAND ${JAVADOC_EXE}  ${DOCLINT_FLAGS} -tag notes -tag example -d ${CMAKE_CURRENT_SOURCE_DIR}/doc -sourcepath ${CMAKE_CURRENT_SOURCE_DIR}/src org.RDKit
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
   ## Put the doc files into their own separate archive.
-  COMMAND ${JAVA_ARCHIVE} cf ${DOCLINT_FLAGS}
+  COMMAND ${JAVA_ARCHIVE} cf
     ${CMAKE_CURRENT_SOURCE_DIR}/org.RDKitDoc.jar
     doc
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}


### PR DESCRIPTION
I wasn't able to compile RDKit (HEAD) in Ubuntu 14.04 with Oracle Java 8 because it added the -Xdoclint:none flag to the `jar cf org.RDKitDoc.jar -d doc` command. Removing it solved the problem.

Hope that it helps! :)