### PR TITLE
Stop possible core leaks in pythonObjectToVect()

### DIFF
--- a/Code/GraphMol/Descriptors/Wrap/rdMolDescriptors.cpp
+++ b/Code/GraphMol/Descriptors/Wrap/rdMolDescriptors.cpp
@@ -110,11 +110,11 @@ RDKit::SparseIntVect<boost::int32_t> *GetAtomPairFingerprint(
     python::object fromAtoms, python::object ignoreAtoms,
     python::object atomInvariants, bool includeChirality, bool use2D,
     int confId) {
-  rdk_unique_ptr<std::vector<boost::uint32_t> > fvect =
+  rdk_auto_ptr<std::vector<boost::uint32_t> > fvect =
       pythonObjectToVect(fromAtoms, mol.getNumAtoms());
-  rdk_unique_ptr<std::vector<boost::uint32_t> > ivect =
+  rdk_auto_ptr<std::vector<boost::uint32_t> > ivect =
       pythonObjectToVect(ignoreAtoms, mol.getNumAtoms());
-  rdk_unique_ptr<std::vector<boost::uint32_t> > invvect = pythonObjectToVect(
+  rdk_auto_ptr<std::vector<boost::uint32_t> > invvect = pythonObjectToVect(
       atomInvariants,
       static_cast<unsigned int>(1 << RDKit::AtomPairs::codeSize));
   RDKit::SparseIntVect<boost::int32_t> *res;
@@ -128,11 +128,11 @@ RDKit::SparseIntVect<boost::int32_t> *GetHashedAtomPairFingerprint(
     unsigned int maxLength, python::object fromAtoms,
     python::object ignoreAtoms, python::object atomInvariants,
     bool includeChirality, bool use2D, int confId) {
-  rdk_unique_ptr<std::vector<boost::uint32_t> > fvect =
+  rdk_auto_ptr<std::vector<boost::uint32_t> > fvect =
       pythonObjectToVect(fromAtoms, mol.getNumAtoms());
-  rdk_unique_ptr<std::vector<boost::uint32_t> > ivect =
+  rdk_auto_ptr<std::vector<boost::uint32_t> > ivect =
       pythonObjectToVect(ignoreAtoms, mol.getNumAtoms());
-  rdk_unique_ptr<std::vector<boost::uint32_t> > invvect = pythonObjectToVect(
+  rdk_auto_ptr<std::vector<boost::uint32_t> > invvect = pythonObjectToVect(
       atomInvariants,
       static_cast<unsigned int>(1 << RDKit::AtomPairs::codeSize));
   RDKit::SparseIntVect<boost::int32_t> *res;
@@ -146,11 +146,11 @@ RDKit::SparseIntVect<boost::int64_t> *GetTopologicalTorsionFingerprint(
     const RDKit::ROMol &mol, unsigned int targetSize, python::object fromAtoms,
     python::object ignoreAtoms, python::object atomInvariants,
     bool includeChirality) {
-  rdk_unique_ptr<std::vector<boost::uint32_t> > fvect =
+  rdk_auto_ptr<std::vector<boost::uint32_t> > fvect =
       pythonObjectToVect(fromAtoms, mol.getNumAtoms());
-  rdk_unique_ptr<std::vector<boost::uint32_t> > ivect =
+  rdk_auto_ptr<std::vector<boost::uint32_t> > ivect =
       pythonObjectToVect(ignoreAtoms, mol.getNumAtoms());
-  rdk_unique_ptr<std::vector<boost::uint32_t> > invvect = pythonObjectToVect(
+  rdk_auto_ptr<std::vector<boost::uint32_t> > invvect = pythonObjectToVect(
       atomInvariants,
       static_cast<unsigned int>(1 << RDKit::AtomPairs::codeSize));
   if (targetSize * RDKit::AtomPairs::codeSize > 64) {
@@ -171,11 +171,11 @@ RDKit::SparseIntVect<boost::int64_t> *GetHashedTopologicalTorsionFingerprint(
     const RDKit::ROMol &mol, unsigned int nBits, unsigned int targetSize,
     python::object fromAtoms, python::object ignoreAtoms,
     python::object atomInvariants, bool includeChirality) {
-  rdk_unique_ptr<std::vector<boost::uint32_t> > fvect =
+  rdk_auto_ptr<std::vector<boost::uint32_t> > fvect =
       pythonObjectToVect(fromAtoms, mol.getNumAtoms());
-  rdk_unique_ptr<std::vector<boost::uint32_t> > ivect =
+  rdk_auto_ptr<std::vector<boost::uint32_t> > ivect =
       pythonObjectToVect(ignoreAtoms, mol.getNumAtoms());
-  rdk_unique_ptr<std::vector<boost::uint32_t> > invvect = pythonObjectToVect(
+  rdk_auto_ptr<std::vector<boost::uint32_t> > invvect = pythonObjectToVect(
       atomInvariants,
       static_cast<unsigned int>(1 << RDKit::AtomPairs::codeSize));
   RDKit::SparseIntVect<boost::int64_t> *res;
@@ -190,11 +190,11 @@ ExplicitBitVect *GetHashedTopologicalTorsionFingerprintAsBitVect(
     python::object fromAtoms, python::object ignoreAtoms,
     python::object atomInvariants, unsigned int nBitsPerEntry,
     bool includeChirality) {
-  rdk_unique_ptr<std::vector<boost::uint32_t> > fvect =
+  rdk_auto_ptr<std::vector<boost::uint32_t> > fvect =
       pythonObjectToVect(fromAtoms, mol.getNumAtoms());
-  rdk_unique_ptr<std::vector<boost::uint32_t> > ivect =
+  rdk_auto_ptr<std::vector<boost::uint32_t> > ivect =
       pythonObjectToVect(ignoreAtoms, mol.getNumAtoms());
-  rdk_unique_ptr<std::vector<boost::uint32_t> > invvect = pythonObjectToVect(
+  rdk_auto_ptr<std::vector<boost::uint32_t> > invvect = pythonObjectToVect(
       atomInvariants,
       static_cast<unsigned int>(1 << RDKit::AtomPairs::codeSize));
   ExplicitBitVect *res;
@@ -209,11 +209,11 @@ ExplicitBitVect *GetHashedAtomPairFingerprintAsBitVect(
     unsigned int maxLength, python::object fromAtoms,
     python::object ignoreAtoms, python::object atomInvariants,
     unsigned int nBitsPerEntry, bool includeChirality, bool use2D, int confId) {
-  rdk_unique_ptr<std::vector<boost::uint32_t> > fvect =
+  rdk_auto_ptr<std::vector<boost::uint32_t> > fvect =
       pythonObjectToVect(fromAtoms, mol.getNumAtoms());
-  rdk_unique_ptr<std::vector<boost::uint32_t> > ivect =
+  rdk_auto_ptr<std::vector<boost::uint32_t> > ivect =
       pythonObjectToVect(ignoreAtoms, mol.getNumAtoms());
-  rdk_unique_ptr<std::vector<boost::uint32_t> > invvect = pythonObjectToVect(
+  rdk_auto_ptr<std::vector<boost::uint32_t> > invvect = pythonObjectToVect(
       atomInvariants,
       static_cast<unsigned int>(1 << RDKit::AtomPairs::codeSize));
   ExplicitBitVect *res;

--- a/Code/GraphMol/Descriptors/Wrap/rdMolDescriptors.cpp
+++ b/Code/GraphMol/Descriptors/Wrap/rdMolDescriptors.cpp
@@ -110,20 +110,17 @@ RDKit::SparseIntVect<boost::int32_t> *GetAtomPairFingerprint(
     python::object fromAtoms, python::object ignoreAtoms,
     python::object atomInvariants, bool includeChirality, bool use2D,
     int confId) {
-  std::vector<boost::uint32_t> *fvect =
+  rdk_unique_ptr<std::vector<boost::uint32_t> > fvect =
       pythonObjectToVect(fromAtoms, mol.getNumAtoms());
-  std::vector<boost::uint32_t> *ivect =
+  rdk_unique_ptr<std::vector<boost::uint32_t> > ivect =
       pythonObjectToVect(ignoreAtoms, mol.getNumAtoms());
-  std::vector<boost::uint32_t> *invvect = pythonObjectToVect(
+  rdk_unique_ptr<std::vector<boost::uint32_t> > invvect = pythonObjectToVect(
       atomInvariants,
       static_cast<unsigned int>(1 << RDKit::AtomPairs::codeSize));
   RDKit::SparseIntVect<boost::int32_t> *res;
   res = RDKit::AtomPairs::getAtomPairFingerprint(
-      mol, minLength, maxLength, fvect, ivect, invvect, includeChirality, use2D,
-      confId);
-  if (fvect) delete fvect;
-  if (ivect) delete ivect;
-  if (invvect) delete invvect;
+      mol, minLength, maxLength, fvect.get(), ivect.get(), invvect.get(),
+      includeChirality, use2D, confId);
   return res;
 }
 RDKit::SparseIntVect<boost::int32_t> *GetHashedAtomPairFingerprint(
@@ -131,20 +128,17 @@ RDKit::SparseIntVect<boost::int32_t> *GetHashedAtomPairFingerprint(
     unsigned int maxLength, python::object fromAtoms,
     python::object ignoreAtoms, python::object atomInvariants,
     bool includeChirality, bool use2D, int confId) {
-  std::vector<boost::uint32_t> *fvect =
+  rdk_unique_ptr<std::vector<boost::uint32_t> > fvect =
       pythonObjectToVect(fromAtoms, mol.getNumAtoms());
-  std::vector<boost::uint32_t> *ivect =
+  rdk_unique_ptr<std::vector<boost::uint32_t> > ivect =
       pythonObjectToVect(ignoreAtoms, mol.getNumAtoms());
-  std::vector<boost::uint32_t> *invvect = pythonObjectToVect(
+  rdk_unique_ptr<std::vector<boost::uint32_t> > invvect = pythonObjectToVect(
       atomInvariants,
       static_cast<unsigned int>(1 << RDKit::AtomPairs::codeSize));
   RDKit::SparseIntVect<boost::int32_t> *res;
   res = RDKit::AtomPairs::getHashedAtomPairFingerprint(
-      mol, nBits, minLength, maxLength, fvect, ivect, invvect, includeChirality,
-      use2D, confId);
-  if (fvect) delete fvect;
-  if (ivect) delete ivect;
-  if (invvect) delete invvect;
+      mol, nBits, minLength, maxLength, fvect.get(), ivect.get(), invvect.get(),
+      includeChirality, use2D, confId);
   return res;
 }
 
@@ -152,11 +146,11 @@ RDKit::SparseIntVect<boost::int64_t> *GetTopologicalTorsionFingerprint(
     const RDKit::ROMol &mol, unsigned int targetSize, python::object fromAtoms,
     python::object ignoreAtoms, python::object atomInvariants,
     bool includeChirality) {
-  std::vector<boost::uint32_t> *fvect =
+  rdk_unique_ptr<std::vector<boost::uint32_t> > fvect =
       pythonObjectToVect(fromAtoms, mol.getNumAtoms());
-  std::vector<boost::uint32_t> *ivect =
+  rdk_unique_ptr<std::vector<boost::uint32_t> > ivect =
       pythonObjectToVect(ignoreAtoms, mol.getNumAtoms());
-  std::vector<boost::uint32_t> *invvect = pythonObjectToVect(
+  rdk_unique_ptr<std::vector<boost::uint32_t> > invvect = pythonObjectToVect(
       atomInvariants,
       static_cast<unsigned int>(1 << RDKit::AtomPairs::codeSize));
   if (targetSize * RDKit::AtomPairs::codeSize > 64) {
@@ -168,10 +162,8 @@ RDKit::SparseIntVect<boost::int64_t> *GetTopologicalTorsionFingerprint(
 
   RDKit::SparseIntVect<boost::int64_t> *res;
   res = RDKit::AtomPairs::getTopologicalTorsionFingerprint(
-      mol, targetSize, fvect, ivect, invvect, includeChirality);
-  if (fvect) delete fvect;
-  if (ivect) delete ivect;
-  if (invvect) delete invvect;
+      mol, targetSize, fvect.get(), ivect.get(), invvect.get(),
+      includeChirality);
   return res;
 }
 
@@ -179,19 +171,17 @@ RDKit::SparseIntVect<boost::int64_t> *GetHashedTopologicalTorsionFingerprint(
     const RDKit::ROMol &mol, unsigned int nBits, unsigned int targetSize,
     python::object fromAtoms, python::object ignoreAtoms,
     python::object atomInvariants, bool includeChirality) {
-  std::vector<boost::uint32_t> *fvect =
+  rdk_unique_ptr<std::vector<boost::uint32_t> > fvect =
       pythonObjectToVect(fromAtoms, mol.getNumAtoms());
-  std::vector<boost::uint32_t> *ivect =
+  rdk_unique_ptr<std::vector<boost::uint32_t> > ivect =
       pythonObjectToVect(ignoreAtoms, mol.getNumAtoms());
-  std::vector<boost::uint32_t> *invvect = pythonObjectToVect(
+  rdk_unique_ptr<std::vector<boost::uint32_t> > invvect = pythonObjectToVect(
       atomInvariants,
       static_cast<unsigned int>(1 << RDKit::AtomPairs::codeSize));
   RDKit::SparseIntVect<boost::int64_t> *res;
   res = RDKit::AtomPairs::getHashedTopologicalTorsionFingerprint(
-      mol, nBits, targetSize, fvect, ivect, invvect, includeChirality);
-  if (fvect) delete fvect;
-  if (ivect) delete ivect;
-  if (invvect) delete invvect;
+      mol, nBits, targetSize, fvect.get(), ivect.get(), invvect.get(),
+      includeChirality);
   return res;
 }
 
@@ -200,20 +190,17 @@ ExplicitBitVect *GetHashedTopologicalTorsionFingerprintAsBitVect(
     python::object fromAtoms, python::object ignoreAtoms,
     python::object atomInvariants, unsigned int nBitsPerEntry,
     bool includeChirality) {
-  std::vector<boost::uint32_t> *fvect =
+  rdk_unique_ptr<std::vector<boost::uint32_t> > fvect =
       pythonObjectToVect(fromAtoms, mol.getNumAtoms());
-  std::vector<boost::uint32_t> *ivect =
+  rdk_unique_ptr<std::vector<boost::uint32_t> > ivect =
       pythonObjectToVect(ignoreAtoms, mol.getNumAtoms());
-  std::vector<boost::uint32_t> *invvect = pythonObjectToVect(
+  rdk_unique_ptr<std::vector<boost::uint32_t> > invvect = pythonObjectToVect(
       atomInvariants,
       static_cast<unsigned int>(1 << RDKit::AtomPairs::codeSize));
   ExplicitBitVect *res;
   res = RDKit::AtomPairs::getHashedTopologicalTorsionFingerprintAsBitVect(
-      mol, nBits, targetSize, fvect, ivect, invvect, nBitsPerEntry,
-      includeChirality);
-  if (fvect) delete fvect;
-  if (ivect) delete ivect;
-  if (invvect) delete invvect;
+      mol, nBits, targetSize, fvect.get(), ivect.get(), invvect.get(),
+      nBitsPerEntry, includeChirality);
   return res;
 }
 
@@ -222,20 +209,17 @@ ExplicitBitVect *GetHashedAtomPairFingerprintAsBitVect(
     unsigned int maxLength, python::object fromAtoms,
     python::object ignoreAtoms, python::object atomInvariants,
     unsigned int nBitsPerEntry, bool includeChirality, bool use2D, int confId) {
-  std::vector<boost::uint32_t> *fvect =
+  rdk_unique_ptr<std::vector<boost::uint32_t> > fvect =
       pythonObjectToVect(fromAtoms, mol.getNumAtoms());
-  std::vector<boost::uint32_t> *ivect =
+  rdk_unique_ptr<std::vector<boost::uint32_t> > ivect =
       pythonObjectToVect(ignoreAtoms, mol.getNumAtoms());
-  std::vector<boost::uint32_t> *invvect = pythonObjectToVect(
+  rdk_unique_ptr<std::vector<boost::uint32_t> > invvect = pythonObjectToVect(
       atomInvariants,
       static_cast<unsigned int>(1 << RDKit::AtomPairs::codeSize));
   ExplicitBitVect *res;
   res = RDKit::AtomPairs::getHashedAtomPairFingerprintAsBitVect(
-      mol, nBits, minLength, maxLength, fvect, ivect, invvect, nBitsPerEntry,
-      includeChirality, use2D, confId);
-  if (fvect) delete fvect;
-  if (ivect) delete ivect;
-  if (invvect) delete invvect;
+      mol, nBits, minLength, maxLength, fvect.get(), ivect.get(), invvect.get(),
+      nBitsPerEntry, includeChirality, use2D, confId);
   return res;
 }
 

--- a/Code/GraphMol/MolDraw2D/Wrap/rdMolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/Wrap/rdMolDraw2D.cpp
@@ -61,14 +61,13 @@ void drawMoleculeHelper1(MolDraw2D &self, const ROMol &mol,
                          python::object highlight_atoms,
                          python::object highlight_atom_map,
                          python::object highlight_atom_radii, int confId = -1) {
-  std::vector<int> *highlightAtoms =
+  rdk_unique_ptr<std::vector<int> > highlightAtoms =
       pythonObjectToVect(highlight_atoms, static_cast<int>(mol.getNumAtoms()));
   std::map<int, DrawColour> *ham = pyDictToColourMap(highlight_atom_map);
   std::map<int, double> *har = pyDictToDoubleMap(highlight_atom_radii);
 
-  self.drawMolecule(mol, highlightAtoms, ham, har, confId);
+  self.drawMolecule(mol, highlightAtoms.get(), ham, har, confId);
 
-  delete highlightAtoms;
   delete ham;
   delete har;
 }
@@ -78,19 +77,18 @@ void drawMoleculeHelper2(MolDraw2D &self, const ROMol &mol,
                          python::object highlight_atom_map,
                          python::object highlight_bond_map,
                          python::object highlight_atom_radii, int confId = -1) {
-  std::vector<int> *highlightAtoms =
+  rdk_unique_ptr<std::vector<int> > highlightAtoms =
       pythonObjectToVect(highlight_atoms, static_cast<int>(mol.getNumAtoms()));
-  std::vector<int> *highlightBonds =
+  rdk_unique_ptr<std::vector<int> > highlightBonds =
       pythonObjectToVect(highlight_bonds, static_cast<int>(mol.getNumBonds()));
   // FIX: support these
   std::map<int, DrawColour> *ham = pyDictToColourMap(highlight_atom_map);
   std::map<int, DrawColour> *hbm = pyDictToColourMap(highlight_bond_map);
   std::map<int, double> *har = pyDictToDoubleMap(highlight_atom_radii);
 
-  self.drawMolecule(mol, highlightAtoms, highlightBonds, ham, hbm, har, confId);
+  self.drawMolecule(mol, highlightAtoms.get(), highlightBonds.get(), ham, hbm,
+                    har, confId);
 
-  delete highlightAtoms;
-  delete highlightBonds;
   delete ham;
   delete hbm;
   delete har;

--- a/Code/GraphMol/MolDraw2D/Wrap/rdMolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/Wrap/rdMolDraw2D.cpp
@@ -61,7 +61,7 @@ void drawMoleculeHelper1(MolDraw2D &self, const ROMol &mol,
                          python::object highlight_atoms,
                          python::object highlight_atom_map,
                          python::object highlight_atom_radii, int confId = -1) {
-  rdk_unique_ptr<std::vector<int> > highlightAtoms =
+  rdk_auto_ptr<std::vector<int> > highlightAtoms =
       pythonObjectToVect(highlight_atoms, static_cast<int>(mol.getNumAtoms()));
   std::map<int, DrawColour> *ham = pyDictToColourMap(highlight_atom_map);
   std::map<int, double> *har = pyDictToDoubleMap(highlight_atom_radii);
@@ -77,9 +77,9 @@ void drawMoleculeHelper2(MolDraw2D &self, const ROMol &mol,
                          python::object highlight_atom_map,
                          python::object highlight_bond_map,
                          python::object highlight_atom_radii, int confId = -1) {
-  rdk_unique_ptr<std::vector<int> > highlightAtoms =
+  rdk_auto_ptr<std::vector<int> > highlightAtoms =
       pythonObjectToVect(highlight_atoms, static_cast<int>(mol.getNumAtoms()));
-  rdk_unique_ptr<std::vector<int> > highlightBonds =
+  rdk_auto_ptr<std::vector<int> > highlightBonds =
       pythonObjectToVect(highlight_bonds, static_cast<int>(mol.getNumBonds()));
   // FIX: support these
   std::map<int, DrawColour> *ham = pyDictToColourMap(highlight_atom_map);

--- a/Code/GraphMol/MolHash/Wrap/rdMolHash.cpp
+++ b/Code/GraphMol/MolHash/Wrap/rdMolHash.cpp
@@ -18,19 +18,18 @@ using namespace RDKit;
 namespace {
 std::string GenMolHashString(const ROMol &mol, python::object atomsToUse,
                              python::object bondsToUse) {
-  std::vector<unsigned> *avect = NULL;
+  rdk_unique_ptr<std::vector<unsigned> > avect;
   if (atomsToUse) {
     avect = pythonObjectToVect(atomsToUse,
                                static_cast<unsigned>(mol.getNumAtoms()));
   }
-  std::vector<unsigned> *bvect = NULL;
+  rdk_unique_ptr<std::vector<unsigned> > bvect;
   if (bondsToUse) {
     bvect = pythonObjectToVect(bondsToUse,
                                static_cast<unsigned>(mol.getNumBonds()));
   }
-  std::string res = MolHash::generateMoleculeHashSet(mol, avect, bvect);
-  delete avect;
-  delete bvect;
+  std::string res =
+      MolHash::generateMoleculeHashSet(mol, avect.get(), bvect.get());
   return res;
 }
 }

--- a/Code/GraphMol/MolHash/Wrap/rdMolHash.cpp
+++ b/Code/GraphMol/MolHash/Wrap/rdMolHash.cpp
@@ -18,12 +18,12 @@ using namespace RDKit;
 namespace {
 std::string GenMolHashString(const ROMol &mol, python::object atomsToUse,
                              python::object bondsToUse) {
-  rdk_unique_ptr<std::vector<unsigned> > avect;
+  rdk_auto_ptr<std::vector<unsigned> > avect;
   if (atomsToUse) {
     avect = pythonObjectToVect(atomsToUse,
                                static_cast<unsigned>(mol.getNumAtoms()));
   }
-  rdk_unique_ptr<std::vector<unsigned> > bvect;
+  rdk_auto_ptr<std::vector<unsigned> > bvect;
   if (bondsToUse) {
     bvect = pythonObjectToVect(bondsToUse,
                                static_cast<unsigned>(mol.getNumBonds()));

--- a/Code/GraphMol/Wrap/MolOps.cpp
+++ b/Code/GraphMol/Wrap/MolOps.cpp
@@ -41,7 +41,7 @@ std::string molToSVG(const ROMol &mol, unsigned int width, unsigned int height,
                      unsigned int lineWidthMult, unsigned int fontSize,
                      bool includeAtomCircles, int confId) {
   RDUNUSED_PARAM(kekulize);
-  rdk_unique_ptr<std::vector<int> > highlightAtoms =
+  rdk_auto_ptr<std::vector<int> > highlightAtoms =
       pythonObjectToVect(pyHighlightAtoms, static_cast<int>(mol.getNumAtoms()));
   std::stringstream outs;
   MolDraw2DSVG drawer(width, height, outs);
@@ -58,7 +58,7 @@ python::tuple fragmentOnSomeBondsHelper(const ROMol &mol,
                                         python::object pyDummyLabels,
                                         python::object pyBondTypes,
                                         bool returnCutsPerAtom) {
-  rdk_unique_ptr<std::vector<unsigned int> > bondIndices =
+  rdk_auto_ptr<std::vector<unsigned int> > bondIndices =
       pythonObjectToVect(pyBondIndices, mol.getNumBonds());
   if (!bondIndices.get()) throw_value_error("empty bond indices");
 
@@ -131,7 +131,7 @@ ROMol *fragmentOnBondsHelper(const ROMol &mol, python::object pyBondIndices,
                              bool addDummies, python::object pyDummyLabels,
                              python::object pyBondTypes,
                              python::list pyCutsPerAtom) {
-  rdk_unique_ptr<std::vector<unsigned int> > bondIndices =
+  rdk_auto_ptr<std::vector<unsigned int> > bondIndices =
       pythonObjectToVect(pyBondIndices, mol.getNumBonds());
   if (!bondIndices.get()) throw_value_error("empty bond indices");
   std::vector<std::pair<unsigned int, unsigned int> > *dummyLabels = 0;
@@ -187,7 +187,7 @@ ROMol *renumberAtomsHelper(const ROMol &mol, python::object &pyNewOrder) {
       mol.getNumAtoms()) {
     throw_value_error("atomCounts shorter than the number of atoms");
   }
-  rdk_unique_ptr<std::vector<unsigned int> > newOrder =
+  rdk_auto_ptr<std::vector<unsigned int> > newOrder =
       pythonObjectToVect(pyNewOrder, mol.getNumAtoms());
   ROMol *res = MolOps::renumberAtoms(mol, *newOrder);
   return res;
@@ -303,7 +303,7 @@ void addRecursiveQueriesHelper(ROMol &mol, python::dict replDict,
 
 ROMol *addHs(const ROMol &orig, bool explicitOnly, bool addCoords,
              python::object onlyOnAtoms) {
-  rdk_unique_ptr<std::vector<unsigned int> > onlyOn;
+  rdk_auto_ptr<std::vector<unsigned int> > onlyOn;
   if (onlyOnAtoms) {
     onlyOn = pythonObjectToVect(onlyOnAtoms, orig.getNumAtoms());
   }
@@ -509,7 +509,7 @@ ExplicitBitVect *wrapLayeredFingerprint(
     unsigned int maxPath, unsigned int fpSize, python::list atomCounts,
     ExplicitBitVect *includeOnlyBits, bool branchedPaths,
     python::object fromAtoms) {
-  rdk_unique_ptr<std::vector<unsigned int> > lFromAtoms =
+  rdk_auto_ptr<std::vector<unsigned int> > lFromAtoms =
       pythonObjectToVect(fromAtoms, mol.getNumAtoms());
   std::vector<unsigned int> *atomCountsV = 0;
   if (atomCounts) {
@@ -575,9 +575,9 @@ ExplicitBitVect *wrapRDKFingerprintMol(
     double tgtDensity, unsigned int minSize, bool branchedPaths,
     bool useBondOrder, python::object atomInvariants, python::object fromAtoms,
     python::object atomBits) {
-  rdk_unique_ptr<std::vector<unsigned int> > lAtomInvariants =
+  rdk_auto_ptr<std::vector<unsigned int> > lAtomInvariants =
       pythonObjectToVect<unsigned int>(atomInvariants);
-  rdk_unique_ptr<std::vector<unsigned int> > lFromAtoms =
+  rdk_auto_ptr<std::vector<unsigned int> > lFromAtoms =
       pythonObjectToVect(fromAtoms, mol.getNumAtoms());
   std::vector<std::vector<boost::uint32_t> > *lAtomBits = 0;
   // if(!(atomBits.is_none())){

--- a/Code/GraphMol/Wrap/MolOps.cpp
+++ b/Code/GraphMol/Wrap/MolOps.cpp
@@ -41,15 +41,14 @@ std::string molToSVG(const ROMol &mol, unsigned int width, unsigned int height,
                      unsigned int lineWidthMult, unsigned int fontSize,
                      bool includeAtomCircles, int confId) {
   RDUNUSED_PARAM(kekulize);
-  std::vector<int> *highlightAtoms =
+  rdk_unique_ptr<std::vector<int> > highlightAtoms =
       pythonObjectToVect(pyHighlightAtoms, static_cast<int>(mol.getNumAtoms()));
   std::stringstream outs;
   MolDraw2DSVG drawer(width, height, outs);
   drawer.setFontSize(fontSize / 24.);
   drawer.setLineWidth(drawer.lineWidth() * lineWidthMult);
   drawer.drawOptions().circleAtoms = includeAtomCircles;
-  drawer.drawMolecule(mol, highlightAtoms, NULL, NULL, confId);
-  delete highlightAtoms;
+  drawer.drawMolecule(mol, highlightAtoms.get(), NULL, NULL, confId);
   drawer.finishDrawing();
   return outs.str();
 }
@@ -59,9 +58,9 @@ python::tuple fragmentOnSomeBondsHelper(const ROMol &mol,
                                         python::object pyDummyLabels,
                                         python::object pyBondTypes,
                                         bool returnCutsPerAtom) {
-  std::vector<unsigned int> *bondIndices =
+  rdk_unique_ptr<std::vector<unsigned int> > bondIndices =
       pythonObjectToVect(pyBondIndices, mol.getNumBonds());
-  if (!bondIndices) throw_value_error("empty bond indices");
+  if (!bondIndices.get()) throw_value_error("empty bond indices");
 
   std::vector<std::pair<unsigned int, unsigned int> > *dummyLabels = 0;
   if (pyDummyLabels) {
@@ -99,7 +98,6 @@ python::tuple fragmentOnSomeBondsHelper(const ROMol &mol,
   for (unsigned int i = 0; i < frags.size(); ++i) {
     res.append(frags[i]);
   }
-  delete bondIndices;
   delete dummyLabels;
   delete bondTypes;
   if (cutsPerAtom) {
@@ -133,9 +131,9 @@ ROMol *fragmentOnBondsHelper(const ROMol &mol, python::object pyBondIndices,
                              bool addDummies, python::object pyDummyLabels,
                              python::object pyBondTypes,
                              python::list pyCutsPerAtom) {
-  std::vector<unsigned int> *bondIndices =
+  rdk_unique_ptr<std::vector<unsigned int> > bondIndices =
       pythonObjectToVect(pyBondIndices, mol.getNumBonds());
-  if (!bondIndices) throw_value_error("empty bond indices");
+  if (!bondIndices.get()) throw_value_error("empty bond indices");
   std::vector<std::pair<unsigned int, unsigned int> > *dummyLabels = 0;
   if (pyDummyLabels) {
     unsigned int nVs =
@@ -179,7 +177,6 @@ ROMol *fragmentOnBondsHelper(const ROMol &mol, python::object pyBondIndices,
     delete cutsPerAtom;
   }
 
-  delete bondIndices;
   delete dummyLabels;
   delete bondTypes;
   return res;
@@ -190,10 +187,9 @@ ROMol *renumberAtomsHelper(const ROMol &mol, python::object &pyNewOrder) {
       mol.getNumAtoms()) {
     throw_value_error("atomCounts shorter than the number of atoms");
   }
-  std::vector<unsigned int> *newOrder =
+  rdk_unique_ptr<std::vector<unsigned int> > newOrder =
       pythonObjectToVect(pyNewOrder, mol.getNumAtoms());
   ROMol *res = MolOps::renumberAtoms(mol, *newOrder);
-  delete newOrder;
   return res;
 }
 
@@ -307,12 +303,11 @@ void addRecursiveQueriesHelper(ROMol &mol, python::dict replDict,
 
 ROMol *addHs(const ROMol &orig, bool explicitOnly, bool addCoords,
              python::object onlyOnAtoms) {
-  std::vector<unsigned int> *onlyOn = NULL;
+  rdk_unique_ptr<std::vector<unsigned int> > onlyOn;
   if (onlyOnAtoms) {
     onlyOn = pythonObjectToVect(onlyOnAtoms, orig.getNumAtoms());
   }
-  ROMol *res = MolOps::addHs(orig, explicitOnly, addCoords, onlyOn);
-  delete onlyOn;
+  ROMol *res = MolOps::addHs(orig, explicitOnly, addCoords, onlyOn.get());
   return res;
 }
 int getSSSR(ROMol &mol) {
@@ -514,7 +509,7 @@ ExplicitBitVect *wrapLayeredFingerprint(
     unsigned int maxPath, unsigned int fpSize, python::list atomCounts,
     ExplicitBitVect *includeOnlyBits, bool branchedPaths,
     python::object fromAtoms) {
-  std::vector<unsigned int> *lFromAtoms =
+  rdk_unique_ptr<std::vector<unsigned int> > lFromAtoms =
       pythonObjectToVect(fromAtoms, mol.getNumAtoms());
   std::vector<unsigned int> *atomCountsV = 0;
   if (atomCounts) {
@@ -533,7 +528,7 @@ ExplicitBitVect *wrapLayeredFingerprint(
   ExplicitBitVect *res;
   res = RDKit::LayeredFingerprintMol(mol, layerFlags, minPath, maxPath, fpSize,
                                      atomCountsV, includeOnlyBits,
-                                     branchedPaths, lFromAtoms);
+                                     branchedPaths, lFromAtoms.get());
 
   if (atomCountsV) {
     for (unsigned int i = 0; i < atomCountsV->size(); ++i) {
@@ -541,7 +536,6 @@ ExplicitBitVect *wrapLayeredFingerprint(
     }
     delete atomCountsV;
   }
-  delete lFromAtoms;
 
   return res;
 }
@@ -581,9 +575,9 @@ ExplicitBitVect *wrapRDKFingerprintMol(
     double tgtDensity, unsigned int minSize, bool branchedPaths,
     bool useBondOrder, python::object atomInvariants, python::object fromAtoms,
     python::object atomBits) {
-  std::vector<unsigned int> *lAtomInvariants =
+  rdk_unique_ptr<std::vector<unsigned int> > lAtomInvariants =
       pythonObjectToVect<unsigned int>(atomInvariants);
-  std::vector<unsigned int> *lFromAtoms =
+  rdk_unique_ptr<std::vector<unsigned int> > lFromAtoms =
       pythonObjectToVect(fromAtoms, mol.getNumAtoms());
   std::vector<std::vector<boost::uint32_t> > *lAtomBits = 0;
   // if(!(atomBits.is_none())){
@@ -592,12 +586,10 @@ ExplicitBitVect *wrapRDKFingerprintMol(
         new std::vector<std::vector<boost::uint32_t> >(mol.getNumAtoms());
   }
   ExplicitBitVect *res;
-  res = RDKit::RDKFingerprintMol(
-      mol, minPath, maxPath, fpSize, nBitsPerHash, useHs, tgtDensity, minSize,
-      branchedPaths, useBondOrder, lAtomInvariants, lFromAtoms, lAtomBits);
-
-  delete lAtomInvariants;
-  delete lFromAtoms;
+  res = RDKit::RDKFingerprintMol(mol, minPath, maxPath, fpSize, nBitsPerHash,
+                                 useHs, tgtDensity, minSize, branchedPaths,
+                                 useBondOrder, lAtomInvariants.get(),
+                                 lFromAtoms.get(), lAtomBits);
 
   if (lAtomBits) {
     python::list &pyl = static_cast<python::list &>(atomBits);

--- a/Code/GraphMol/Wrap/rdmolfiles.cpp
+++ b/Code/GraphMol/Wrap/rdmolfiles.cpp
@@ -240,31 +240,28 @@ std::string MolFragmentToSmilesHelper(
     python::object atomSymbols, python::object bondSymbols,
     bool doIsomericSmiles, bool doKekule, int rootedAtAtom, bool canonical,
     bool allBondsExplicit, bool allHsExplicit) {
-  std::vector<int> *avect =
+  rdk_unique_ptr<std::vector<int> > avect =
       pythonObjectToVect(atomsToUse, static_cast<int>(mol.getNumAtoms()));
-  if (!avect || !(avect->size())) {
+  if (!avect.get() || !(avect->size())) {
     throw_value_error("atomsToUse must not be empty");
   }
-  std::vector<int> *bvect =
+  rdk_unique_ptr<std::vector<int> > bvect =
       pythonObjectToVect(bondsToUse, static_cast<int>(mol.getNumBonds()));
-  std::vector<std::string> *asymbols =
+  rdk_unique_ptr<std::vector<std::string> > asymbols =
       pythonObjectToVect<std::string>(atomSymbols);
-  std::vector<std::string> *bsymbols =
+  rdk_unique_ptr<std::vector<std::string> > bsymbols =
       pythonObjectToVect<std::string>(bondSymbols);
-  if (asymbols && asymbols->size() != mol.getNumAtoms()) {
+  if (asymbols.get() && asymbols->size() != mol.getNumAtoms()) {
     throw_value_error("length of atom symbol list != number of atoms");
   }
-  if (bsymbols && bsymbols->size() != mol.getNumBonds()) {
+  if (bsymbols.get() && bsymbols->size() != mol.getNumBonds()) {
     throw_value_error("length of bond symbol list != number of bonds");
   }
 
   std::string res = MolFragmentToSmiles(
-      mol, *avect, bvect, asymbols, bsymbols, doIsomericSmiles, doKekule,
-      rootedAtAtom, canonical, allBondsExplicit, allHsExplicit);
-  delete avect;
-  delete bvect;
-  delete asymbols;
-  delete bsymbols;
+      mol, *avect.get(), bvect.get(), asymbols.get(), bsymbols.get(),
+      doIsomericSmiles, doKekule, rootedAtAtom, canonical, allBondsExplicit,
+      allHsExplicit);
   return res;
 }
 
@@ -285,21 +282,21 @@ std::vector<int> CanonicalRankAtomsInFragment(const ROMol &mol,
                                               bool breakTies = true)
 
 {
-  std::vector<int> *avect =
+  rdk_unique_ptr<std::vector<int> > avect =
       pythonObjectToVect(atomsToUse, static_cast<int>(mol.getNumAtoms()));
-  if (!avect || !(avect->size())) {
+  if (!avect.get() || !(avect->size())) {
     throw_value_error("atomsToUse must not be empty");
   }
-  std::vector<int> *bvect =
+  rdk_unique_ptr<std::vector<int> > bvect =
       pythonObjectToVect(bondsToUse, static_cast<int>(mol.getNumBonds()));
-  std::vector<std::string> *asymbols =
+  rdk_unique_ptr<std::vector<std::string> > asymbols =
       pythonObjectToVect<std::string>(atomSymbols);
-  std::vector<std::string> *bsymbols =
+  rdk_unique_ptr<std::vector<std::string> > bsymbols =
       pythonObjectToVect<std::string>(bondSymbols);
-  if (asymbols && asymbols->size() != mol.getNumAtoms()) {
+  if (asymbols.get() && asymbols->size() != mol.getNumAtoms()) {
     throw_value_error("length of atom symbol list != number of atoms");
   }
-  if (bsymbols && bsymbols->size() != mol.getNumBonds()) {
+  if (bsymbols.get() && bsymbols->size() != mol.getNumBonds()) {
     throw_value_error("length of bond symbol list != number of bonds");
   }
 
@@ -307,11 +304,12 @@ std::vector<int> CanonicalRankAtomsInFragment(const ROMol &mol,
   for (size_t i = 0; i < avect->size(); ++i) atoms[(*avect)[i]] = true;
 
   boost::dynamic_bitset<> bonds(mol.getNumBonds());
-  for (size_t i = 0; bvect && i < bvect->size(); ++i) bonds[(*bvect)[i]] = true;
+  for (size_t i = 0; bvect.get() && i < bvect->size(); ++i)
+    bonds[(*bvect)[i]] = true;
 
   std::vector<unsigned int> ranks(mol.getNumAtoms());
-  Canon::rankFragmentAtoms(mol, ranks, atoms, bonds, asymbols, bsymbols,
-                           breakTies);
+  Canon::rankFragmentAtoms(mol, ranks, atoms, bonds, asymbols.get(),
+                           bsymbols.get(), breakTies);
 
   std::vector<int> resRanks(mol.getNumAtoms());
   // set unused ranks to -1 for the Python interface

--- a/Code/GraphMol/Wrap/rdmolfiles.cpp
+++ b/Code/GraphMol/Wrap/rdmolfiles.cpp
@@ -240,16 +240,16 @@ std::string MolFragmentToSmilesHelper(
     python::object atomSymbols, python::object bondSymbols,
     bool doIsomericSmiles, bool doKekule, int rootedAtAtom, bool canonical,
     bool allBondsExplicit, bool allHsExplicit) {
-  rdk_unique_ptr<std::vector<int> > avect =
+  rdk_auto_ptr<std::vector<int> > avect =
       pythonObjectToVect(atomsToUse, static_cast<int>(mol.getNumAtoms()));
   if (!avect.get() || !(avect->size())) {
     throw_value_error("atomsToUse must not be empty");
   }
-  rdk_unique_ptr<std::vector<int> > bvect =
+  rdk_auto_ptr<std::vector<int> > bvect =
       pythonObjectToVect(bondsToUse, static_cast<int>(mol.getNumBonds()));
-  rdk_unique_ptr<std::vector<std::string> > asymbols =
+  rdk_auto_ptr<std::vector<std::string> > asymbols =
       pythonObjectToVect<std::string>(atomSymbols);
-  rdk_unique_ptr<std::vector<std::string> > bsymbols =
+  rdk_auto_ptr<std::vector<std::string> > bsymbols =
       pythonObjectToVect<std::string>(bondSymbols);
   if (asymbols.get() && asymbols->size() != mol.getNumAtoms()) {
     throw_value_error("length of atom symbol list != number of atoms");
@@ -282,16 +282,16 @@ std::vector<int> CanonicalRankAtomsInFragment(const ROMol &mol,
                                               bool breakTies = true)
 
 {
-  rdk_unique_ptr<std::vector<int> > avect =
+  rdk_auto_ptr<std::vector<int> > avect =
       pythonObjectToVect(atomsToUse, static_cast<int>(mol.getNumAtoms()));
   if (!avect.get() || !(avect->size())) {
     throw_value_error("atomsToUse must not be empty");
   }
-  rdk_unique_ptr<std::vector<int> > bvect =
+  rdk_auto_ptr<std::vector<int> > bvect =
       pythonObjectToVect(bondsToUse, static_cast<int>(mol.getNumBonds()));
-  rdk_unique_ptr<std::vector<std::string> > asymbols =
+  rdk_auto_ptr<std::vector<std::string> > asymbols =
       pythonObjectToVect<std::string>(atomSymbols);
-  rdk_unique_ptr<std::vector<std::string> > bsymbols =
+  rdk_auto_ptr<std::vector<std::string> > bsymbols =
       pythonObjectToVect<std::string>(bondSymbols);
   if (asymbols.get() && asymbols->size() != mol.getNumAtoms()) {
     throw_value_error("length of atom symbol list != number of atoms");

--- a/Code/RDBoost/Wrap.h
+++ b/Code/RDBoost/Wrap.h
@@ -21,7 +21,12 @@
 #include <memory>
 // ha ha... we don't actually want to use this, but we need to keep support old
 // C++ versions:
-#define rdk_unique_ptr std::auto_ptr
+#if __cplusplus < 201103L
+#define rdk_auto_ptr std::auto_ptr
+#else
+template <typename T>
+using rdk_auto_ptr = std::unique_ptr<T>;
+#endif
 
 // code for windows DLL handling taken from
 // http://www.boost.org/more/separate_compilation.html
@@ -110,9 +115,9 @@ void RegisterListConverter(bool noproxy = false) {
 }
 
 template <typename T>
-rdk_unique_ptr<std::vector<T> > pythonObjectToVect(const python::object &obj,
-                                                   T maxV) {
-  rdk_unique_ptr<std::vector<T> > res;
+rdk_auto_ptr<std::vector<T> > pythonObjectToVect(const python::object &obj,
+                                                 T maxV) {
+  rdk_auto_ptr<std::vector<T> > res;
   if (obj) {
     res.reset(new std::vector<T>);
     python::stl_input_iterator<T> beg(obj), end;
@@ -128,8 +133,8 @@ rdk_unique_ptr<std::vector<T> > pythonObjectToVect(const python::object &obj,
   return res;
 }
 template <typename T>
-rdk_unique_ptr<std::vector<T> > pythonObjectToVect(const python::object &obj) {
-  rdk_unique_ptr<std::vector<T> > res;
+rdk_auto_ptr<std::vector<T> > pythonObjectToVect(const python::object &obj) {
+  rdk_auto_ptr<std::vector<T> > res;
   if (obj) {
     res.reset(new std::vector<T>);
     unsigned int nFrom = python::extract<unsigned int>(obj.attr("__len__")());

--- a/Code/RDBoost/Wrap.h
+++ b/Code/RDBoost/Wrap.h
@@ -18,6 +18,10 @@
 //
 #include <boost/python.hpp>
 #include <boost/python/stl_iterator.hpp>
+#include <memory>
+// ha ha... we don't actually want to use this, but we need to keep support old
+// C++ versions:
+#define rdk_unique_ptr std::auto_ptr
 
 // code for windows DLL handling taken from
 // http://www.boost.org/more/separate_compilation.html
@@ -106,10 +110,11 @@ void RegisterListConverter(bool noproxy = false) {
 }
 
 template <typename T>
-std::vector<T> *pythonObjectToVect(const python::object &obj, T maxV) {
-  std::vector<T> *res = 0;
+rdk_unique_ptr<std::vector<T> > pythonObjectToVect(const python::object &obj,
+                                                   T maxV) {
+  rdk_unique_ptr<std::vector<T> > res;
   if (obj) {
-    res = new std::vector<T>;
+    res.reset(new std::vector<T>);
     python::stl_input_iterator<T> beg(obj), end;
     while (beg != end) {
       T v = *beg;
@@ -123,10 +128,10 @@ std::vector<T> *pythonObjectToVect(const python::object &obj, T maxV) {
   return res;
 }
 template <typename T>
-std::vector<T> *pythonObjectToVect(const python::object &obj) {
-  std::vector<T> *res = 0;
+rdk_unique_ptr<std::vector<T> > pythonObjectToVect(const python::object &obj) {
+  rdk_unique_ptr<std::vector<T> > res;
   if (obj) {
-    res = new std::vector<T>;
+    res.reset(new std::vector<T>);
     unsigned int nFrom = python::extract<unsigned int>(obj.attr("__len__")());
     for (unsigned int i = 0; i < nFrom; ++i) {
       T v = python::extract<T>(obj[i]);


### PR DESCRIPTION
@bp-kelley @DoliathGavid 
I'd love your feedback on this attempt to resolve the problem.
It would be easier in C++11, where I could just use a unique_ptr, but this seems like a reasonable workaround until we reach that point.