### PR TITLE
Add prepareMolForDrawing() function to C++

### DIFF
--- a/Code/GraphMol/FileParsers/MolFileStereochem.cpp
+++ b/Code/GraphMol/FileParsers/MolFileStereochem.cpp
@@ -384,7 +384,7 @@ INT_MAP_INT pickBondsToWedge(const ROMol &mol) {
     }
   }
 
-  // now rank atoms by the number of chiral neighbors they have:
+  // now rank atoms by the number of chiral neighbors or Hs they have:
   bool chiNbrs = false;
   for (ROMol::ConstAtomIterator cai = mol.beginAtoms(); cai != mol.endAtoms();
        ++cai) {
@@ -403,6 +403,11 @@ INT_MAP_INT pickBondsToWedge(const ROMol &mol) {
     while (nbrIdx != endNbrs) {
       const ATOM_SPTR nat = mol[*nbrIdx];
       ++nbrIdx;
+      if (nat->getAtomicNum() == 1) {
+        // special case: it's an H... we weight these especially high:
+        nChiralNbrs[at->getIdx()] -= 10;
+        continue;
+      }
       type = nat->getChiralTag();
       if (type != Atom::CHI_TETRAHEDRAL_CW && type != Atom::CHI_TETRAHEDRAL_CCW)
         continue;
@@ -426,7 +431,8 @@ INT_MAP_INT pickBondsToWedge(const ROMol &mol) {
   // picks a bond for each atom that we will wedge when we write the mol file
   // here is what we are going to do
   // - at each chiral center look for a bond that is begins at the atom and
-  //   is not yet picked to be wedged for a different chiral center
+  //   is not yet picked to be wedged for a different chiral center, preferring
+  //   bonds to Hs
   // - if we do not find a bond that begins at the chiral center - we will take
   //   the first bond that is not yet picked by any other chiral centers
   // we use the orders calculated above to determine which order to do the
@@ -447,13 +453,18 @@ INT_MAP_INT pickBondsToWedge(const ROMol &mol) {
     std::vector<std::pair<int, int> > nbrScores;
     while (atomBonds.first != atomBonds.second) {
       const Bond *bond = mol[*atomBonds.first].get();
-      atomBonds.first++;
+      ++atomBonds.first;
 
       // can only wedge single bonds:
       if (bond->getBondType() != Bond::SINGLE) continue;
 
       int bid = bond->getIdx();
       if (res.find(bid) == res.end()) {
+        // very strong preference for Hs:
+        if (bond->getOtherAtom(atom)->getAtomicNum() == 1) {
+          nbrScores.push_back(std::make_pair(-1000, bid));
+          continue;
+        }
         int nbrScore = 0;
         // prefer neighbors that are nonchiral or have as few chiral neighbors
         // as possible:

--- a/Code/GraphMol/FileParsers/MolFileStereochem.cpp
+++ b/Code/GraphMol/FileParsers/MolFileStereochem.cpp
@@ -462,7 +462,8 @@ INT_MAP_INT pickBondsToWedge(const ROMol &mol) {
       if (res.find(bid) == res.end()) {
         // very strong preference for Hs:
         if (bond->getOtherAtom(atom)->getAtomicNum() == 1) {
-          nbrScores.push_back(std::make_pair(-1000, bid));
+          nbrScores.push_back(
+              std::make_pair(-1000, bid));  // lower than anything else can be
           continue;
         }
         int nbrScore = 0;

--- a/Code/GraphMol/FileParsers/test1.cpp
+++ b/Code/GraphMol/FileParsers/test1.cpp
@@ -856,6 +856,19 @@ void testIssue399() {
 
   delete m1;
 
+  // make sure we prefer wedging bonds to Hs:
+  m1 = MolFileToMol(fName);
+  TEST_ASSERT(m1);
+  MolOps::addHs(*m1, false, true);
+  TEST_ASSERT(m1->getAtomWithIdx(7)->getAtomicNum() == 1);
+  TEST_ASSERT(m1->getBondBetweenAtoms(1, 7));
+  TEST_ASSERT(m1->getBondBetweenAtoms(1, 7)->getBondType() == Bond::SINGLE);
+  TEST_ASSERT(m1->getBondBetweenAtoms(1, 7)->getBondDir() == Bond::NONE);
+
+  WedgeMolBonds(*m1, &m1->getConformer());
+  TEST_ASSERT(m1->getBondBetweenAtoms(1, 7)->getBondDir() == Bond::BEGINWEDGE);
+
+  delete m1;
   BOOST_LOG(rdInfoLog) << "done" << std::endl;
 }
 

--- a/Code/GraphMol/MolDraw2D/CMakeLists.txt
+++ b/Code/GraphMol/MolDraw2D/CMakeLists.txt
@@ -7,6 +7,7 @@ option(RDK_BUILD_CAIRO_SUPPORT "build support for Cairo drawing" OFF )
 rdkit_headers(MolDraw2D.h
   MolDraw2DSVG.h
   MolDraw2Dwx.h
+  MolDraw2DUtils.h
 )
 
 if(RDK_BUILD_QT_SUPPORT)
@@ -23,7 +24,7 @@ if(RDK_BUILD_QT_SUPPORT)
   set(EXTRA_LOCAL_LIBS ${EXTRA_LOCAL_LIBS} ${Qt5Widgets_LIBRARIES}  ${Qt5OpenGL_LIBRARIES} )
   rdkit_headers(MolDraw2DQt.h)
 endif(RDK_BUILD_QT_SUPPORT)
-  
+
 if(RDK_BUILD_CAIRO_SUPPORT)
   find_package(Cairo REQUIRED)
   include_directories( ${CAIRO_INCLUDE_DIRS} )
@@ -35,13 +36,13 @@ endif(RDK_BUILD_CAIRO_SUPPORT)
 
 rdkit_library(MolDraw2D MolDraw2D.cpp MolDraw2DSVG.cpp
   ${CAIRODRAW2D_SRC} ${QTDRAW2D_SRC}
-  MolDraw2DDetails.cpp
+  MolDraw2DDetails.cpp MolDraw2DUtils.cpp
   LINK_LIBRARIES
   FileParsers SmilesParse Depictor RDGeometryLib
   RDGeneral SubstructMatch Subgraphs GraphMol RDGeometryLib
   ${RDKit_THREAD_LIBS} ${EXTRA_LOCAL_LIBS} )
 
-rdkit_test(moldraw2DTest1 test1.cpp LINK_LIBRARIES 
+rdkit_test(moldraw2DTest1 test1.cpp LINK_LIBRARIES
   FileParsers SmilesParse Depictor RDGeometryLib
   RDGeneral SubstructMatch Subgraphs GraphMol RDGeometryLib
   MolDraw2D ${RDKit_THREAD_LIBS} ${EXTRA_LOCAL_LIBS} )

--- a/Code/GraphMol/MolDraw2D/MolDraw2DUtils.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DUtils.cpp
@@ -1,0 +1,46 @@
+//
+//  Copyright (C) 2016 Greg Landrum
+//
+//   @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
+//
+#include <GraphMol/MolDraw2D/MolDraw2DUtils.h>
+#include <GraphMol/RWMol.h>
+#include <GraphMol/MolOps.h>
+#include <GraphMol/Depictor/RDDepictor.h>
+#include <GraphMol/FileParsers/MolFileStereochem.h>
+
+namespace RDKit {
+namespace MolDraw2DUtils {
+void prepareMolForDrawing(RWMol &mol, bool kekulize, bool addChiralHs,
+                          bool wedgeBonds, bool forceCoords) {
+  if (kekulize) {
+    MolOps::Kekulize(mol, false);  // kekulize, but keep the aromatic flags!
+  }
+  if (addChiralHs) {
+    std::vector<unsigned int> chiralAts;
+    for (RWMol::AtomIterator atIt = mol.beginAtoms(); atIt != mol.endAtoms();
+         ++atIt) {
+      if ((*atIt)->getChiralTag() == Atom::CHI_TETRAHEDRAL_CCW ||
+          (*atIt)->getChiralTag() == Atom::CHI_TETRAHEDRAL_CW) {
+        chiralAts.push_back((*atIt)->getIdx());
+      }
+    }
+    if (chiralAts.size()) {
+      bool addCoords = false;
+      if (!forceCoords && mol.getNumConformers()) addCoords = true;
+      MolOps::addHs(mol, false, addCoords, &chiralAts);
+    }
+  }
+  if (forceCoords || !mol.getNumConformers()) {
+    RDDepict::compute2DCoords(mol);
+  }
+  if (wedgeBonds) {
+    WedgeMolBonds(mol, &mol.getConformer());
+  }
+}
+}
+}

--- a/Code/GraphMol/MolDraw2D/MolDraw2DUtils.h
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DUtils.h
@@ -18,9 +18,9 @@ namespace RDKit {
 namespace MolDraw2DUtils {
 //! Does some cleanup operations on the molecule to prepare it to draw nicely
 /*
-The operations include: kekulization, addition of chiral Hs, wedging of bonds at
-chiral centers, and generation of a 2D conformation if the molecule does not
-already have a conformation
+The operations include: kekulization, addition of chiral Hs (so that we can draw
+wedges to them), wedging of bonds at chiral centers, and generation of a 2D
+conformation if the molecule does not already have a conformation
 
 \param mol: the molecule to be modified
 \param kekulize: toggles kekulization (this can fail, see below)

--- a/Code/GraphMol/MolDraw2D/MolDraw2DUtils.h
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DUtils.h
@@ -1,0 +1,24 @@
+//
+//  Copyright (C) 2016 Greg Landrum
+//
+//   @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
+//
+
+#ifndef MOLDRAW2DUTILS_H
+#define MOLDRAW2DUTILS_H
+#include <GraphMol/RWMol.h>
+
+// ****************************************************************************
+
+namespace RDKit {
+namespace MolDraw2DUtils {
+void prepareMolForDrawing(RWMol &mol, bool kekulize = true,
+                          bool addChiralHs = true, bool wedgeBonds = true,
+                          bool forceCoords = false);
+}
+}
+#endif  // MOLDRAW2DUTILS_H

--- a/Code/GraphMol/MolDraw2D/MolDraw2DUtils.h
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DUtils.h
@@ -16,6 +16,23 @@
 
 namespace RDKit {
 namespace MolDraw2DUtils {
+//! Does some cleanup operations on the molecule to prepare it to draw nicely
+/*
+The operations include: kekulization, addition of chiral Hs, wedging of bonds at
+chiral centers, and generation of a 2D conformation if the molecule does not
+already have a conformation
+
+\param mol: the molecule to be modified
+\param kekulize: toggles kekulization (this can fail, see below)
+\param addChiralHs: adds Hs to the graph on chiral atoms
+\param wedgeBonds: calls WedgeMolBonds()
+\param forceCoords: generates a 2D conformation even if one is present already
+
+NOTE: the kekulization step can fail, throwing a MolSanitizeExecption. If this
+happens the molecule will be in an inconsistent, partially kekulized, state.
+This isn't normally a problem for molecules that have been sanitized, but can be
+problematic if the molecules have been modified post santitization.
+*/
 void prepareMolForDrawing(RWMol &mol, bool kekulize = true,
                           bool addChiralHs = true, bool wedgeBonds = true,
                           bool forceCoords = false);

--- a/Code/GraphMol/MolDraw2D/Wrap/rdMolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/Wrap/rdMolDraw2D.cpp
@@ -12,6 +12,8 @@
 #include <GraphMol/ROMol.h>
 #include <RDBoost/Wrap.h>
 #include <GraphMol/MolDraw2D/MolDraw2D.h>
+#include <GraphMol/MolDraw2D/MolDraw2DUtils.h>
+
 #include <GraphMol/MolDraw2D/MolDraw2DSVG.h>
 #include <Geometry/point.h>
 #include <boost/python/suite/indexing/map_indexing_suite.hpp>
@@ -102,6 +104,14 @@ python::object getCairoDrawingText(const RDKit::MolDraw2DCairo &self) {
   return retval;
 }
 #endif
+ROMol *prepMolForDrawing(const ROMol *m, bool kekulize = true,
+                         bool addChiralHs = true, bool wedgeBonds = true,
+                         bool forceCoords = false) {
+  RWMol *res = new RWMol(*m);
+  MolDraw2DUtils::prepareMolForDrawing(*res, kekulize, addChiralHs, wedgeBonds,
+                                       forceCoords);
+  return static_cast<ROMol *>(res);
+}
 }
 
 BOOST_PYTHON_MODULE(rdMolDraw2D) {
@@ -181,4 +191,11 @@ BOOST_PYTHON_MODULE(rdMolDraw2D) {
       .def("WriteDrawingText", &RDKit::MolDraw2DCairo::writeDrawingText,
            "write the PNG data to the named file");
 #endif
+  python::def(
+      "PrepareMolForDrawing", &RDKit::prepMolForDrawing,
+      (python::arg("mol"), python::arg("kekulize") = true,
+       python::arg("addChiralHs") = true, python::arg("wedgeBonds") = true,
+       python::arg("forceCoords") = true),
+      "get ready to draw",
+      python::return_value_policy<python::manage_new_object>());
 }

--- a/Code/GraphMol/MolDraw2D/Wrap/rdMolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/Wrap/rdMolDraw2D.cpp
@@ -199,11 +199,12 @@ BOOST_PYTHON_MODULE(rdMolDraw2D) {
       "wedges to them), wedging of bonds at chiral centers, and generation of "
       "a 2D\n"
       "conformation if the molecule does not already have a conformation\n"
-      "\nReturns a modified copy of the molecule.\n" python::def(
-          "PrepareMolForDrawing", &RDKit::prepMolForDrawing,
-          (python::arg("mol"), python::arg("kekulize") = true,
-           python::arg("addChiralHs") = true, python::arg("wedgeBonds") = true,
-           python::arg("forceCoords") = true),
-          docString.c_str(),
-          python::return_value_policy<python::manage_new_object>());
+      "\nReturns a modified copy of the molecule.\n";
+  python::def(
+      "PrepareMolForDrawing", &RDKit::prepMolForDrawing,
+      (python::arg("mol"), python::arg("kekulize") = true,
+       python::arg("addChiralHs") = true, python::arg("wedgeBonds") = true,
+       python::arg("forceCoords") = true),
+      docString.c_str(),
+      python::return_value_policy<python::manage_new_object>());
 }

--- a/Code/GraphMol/MolDraw2D/Wrap/rdMolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/Wrap/rdMolDraw2D.cpp
@@ -191,11 +191,19 @@ BOOST_PYTHON_MODULE(rdMolDraw2D) {
       .def("WriteDrawingText", &RDKit::MolDraw2DCairo::writeDrawingText,
            "write the PNG data to the named file");
 #endif
-  python::def(
-      "PrepareMolForDrawing", &RDKit::prepMolForDrawing,
-      (python::arg("mol"), python::arg("kekulize") = true,
-       python::arg("addChiralHs") = true, python::arg("wedgeBonds") = true,
-       python::arg("forceCoords") = true),
-      "get ready to draw",
-      python::return_value_policy<python::manage_new_object>());
+  docString =
+      "Does some cleanup operations on the molecule to prepare it to draw "
+      "nicely.\n"
+      "The operations include: kekulization, addition of chiral Hs (so that we "
+      "can draw\n"
+      "wedges to them), wedging of bonds at chiral centers, and generation of "
+      "a 2D\n"
+      "conformation if the molecule does not already have a conformation\n"
+      "\nReturns a modified copy of the molecule.\n" python::def(
+          "PrepareMolForDrawing", &RDKit::prepMolForDrawing,
+          (python::arg("mol"), python::arg("kekulize") = true,
+           python::arg("addChiralHs") = true, python::arg("wedgeBonds") = true,
+           python::arg("forceCoords") = true),
+          docString.c_str(),
+          python::return_value_policy<python::manage_new_object>());
 }

--- a/Code/GraphMol/MolDraw2D/Wrap/testMolDraw2D.py
+++ b/Code/GraphMol/MolDraw2D/Wrap/testMolDraw2D.py
@@ -2,6 +2,7 @@ from rdkit import RDConfig
 import unittest
 from rdkit import Chem
 from rdkit.Chem import Draw,AllChem
+from rdkit.Chem.Draw import rdMolDraw2D
 
 class TestCase(unittest.TestCase):
     def setUp(self) :
@@ -16,7 +17,7 @@ class TestCase(unittest.TestCase):
         txt = d.GetDrawingText()
         self.assertTrue(txt.find("<svg:svg")!=-1)
         self.assertTrue(txt.find("</svg:svg>")!=-1)
-            
+
     def test2(self) :
         m = Chem.MolFromSmiles('c1ccc(C)c(C)c1C')
         AllChem.Compute2DCoords(m)
@@ -38,6 +39,11 @@ class TestCase(unittest.TestCase):
         d.FinishDrawing()
         txt = d.GetDrawingText()
 
-            
+    def testPrepareForDrawing(self):
+        m = Chem.MolFromSmiles('c1ccccc1[C@H](F)Cl')
+        nm = rdMolDraw2D.PrepareMolForDrawing(m)
+        self.assertEqual(nm.GetNumAtoms(),10)
+        self.assertEqual(nm.GetNumConformers(),1)
+
 if __name__=="__main__":
     unittest.main()

--- a/Code/GraphMol/MolDraw2D/test1.cpp
+++ b/Code/GraphMol/MolDraw2D/test1.cpp
@@ -20,6 +20,8 @@
 
 #include <GraphMol/MolDraw2D/MolDraw2D.h>
 #include <GraphMol/MolDraw2D/MolDraw2DSVG.h>
+#include <GraphMol/MolDraw2D/MolDraw2DUtils.h>
+
 #include <iostream>
 #include <fstream>
 #include <sstream>
@@ -614,8 +616,95 @@ void test7() {
   std::cerr << " Done" << std::endl;
 }
 
+void test8PrepareMolForDrawing() {
+  std::cout << " ----------------- Test8: PrepareMolDrawing" << std::endl;
+  std::string smiles = "c1ccccc1[C@H](F)Cl";
+  ROMol *m = SmilesToMol(smiles);
+  TEST_ASSERT(m);
+  {
+    RWMol nm(*m);
+    TEST_ASSERT(nm.getNumAtoms() == 9)
+    MolDraw2DUtils::prepareMolForDrawing(nm);
+    TEST_ASSERT(nm.getNumAtoms() == 10);
+    TEST_ASSERT(nm.getNumConformers() == 1);
+    TEST_ASSERT(!nm.getConformer().is3D());
+    TEST_ASSERT(nm.getBondBetweenAtoms(0, 1)->getBondType() != Bond::AROMATIC);
+    TEST_ASSERT(nm.getBondBetweenAtoms(0, 1)->getIsAromatic());
+    TEST_ASSERT(nm.getAtomWithIdx(9)->getAtomicNum() == 1);
+    TEST_ASSERT(nm.getBondBetweenAtoms(6, 9)->getBondType() == Bond::SINGLE);
+    TEST_ASSERT(nm.getBondBetweenAtoms(6, 9)->getBondDir() == Bond::BEGINWEDGE);
+
+    // make sure we can do it again:
+    MolDraw2DUtils::prepareMolForDrawing(nm);
+    TEST_ASSERT(nm.getNumAtoms() == 10);
+    TEST_ASSERT(nm.getNumConformers() == 1);
+    TEST_ASSERT(nm.getBondBetweenAtoms(0, 1)->getBondType() != Bond::AROMATIC);
+    TEST_ASSERT(nm.getBondBetweenAtoms(0, 1)->getIsAromatic());
+  }
+  {
+    RWMol nm(*m);
+    TEST_ASSERT(nm.getNumAtoms() == 9)
+    MolDraw2DUtils::prepareMolForDrawing(nm, false);
+    TEST_ASSERT(nm.getNumAtoms() == 10);
+    TEST_ASSERT(nm.getNumConformers() == 1);
+    TEST_ASSERT(nm.getBondBetweenAtoms(0, 1)->getBondType() == Bond::AROMATIC);
+    TEST_ASSERT(nm.getBondBetweenAtoms(0, 1)->getIsAromatic());
+  }
+  {
+    RWMol nm(*m);
+    TEST_ASSERT(nm.getNumAtoms() == 9)
+    MolDraw2DUtils::prepareMolForDrawing(nm, false, false);
+    TEST_ASSERT(nm.getNumAtoms() == 9);
+    TEST_ASSERT(nm.getNumConformers() == 1);
+    TEST_ASSERT(nm.getBondBetweenAtoms(0, 1)->getBondType() == Bond::AROMATIC);
+    TEST_ASSERT(nm.getBondBetweenAtoms(0, 1)->getIsAromatic());
+  }
+  {
+    RWMol nm(*m);
+    TEST_ASSERT(nm.getNumAtoms() == 9)
+    MolDraw2DUtils::prepareMolForDrawing(nm, false, true);
+    TEST_ASSERT(nm.getNumAtoms() == 10);
+    TEST_ASSERT(nm.getNumConformers() == 1);
+    TEST_ASSERT(nm.getBondBetweenAtoms(0, 1)->getBondType() == Bond::AROMATIC);
+    TEST_ASSERT(nm.getBondBetweenAtoms(0, 1)->getIsAromatic());
+  }
+
+  {
+    RWMol nm(*m);
+    TEST_ASSERT(nm.getNumAtoms() == 9)
+    MolDraw2DUtils::prepareMolForDrawing(nm, true, true, false);
+    TEST_ASSERT(nm.getNumAtoms() == 10);
+    TEST_ASSERT(nm.getNumConformers() == 1);
+    TEST_ASSERT(nm.getBondBetweenAtoms(0, 1)->getBondType() != Bond::AROMATIC);
+    TEST_ASSERT(nm.getBondBetweenAtoms(0, 1)->getIsAromatic());
+    TEST_ASSERT(nm.getAtomWithIdx(9)->getAtomicNum() == 1);
+    TEST_ASSERT(nm.getBondBetweenAtoms(6, 9)->getBondType() == Bond::SINGLE);
+    TEST_ASSERT(nm.getBondBetweenAtoms(6, 9)->getBondDir() == Bond::NONE);
+  }
+
+  {
+    // by default we don't force conformer generation
+    RWMol nm(*m);
+    RDDepict::compute2DCoords(nm);
+    nm.getConformer().set3D(true);  // it's not really, we're cheating
+    TEST_ASSERT(nm.getNumAtoms() == 9)
+    MolDraw2DUtils::prepareMolForDrawing(nm);
+    TEST_ASSERT(nm.getNumAtoms() == 10);
+    TEST_ASSERT(nm.getNumConformers() == 1);  // we have a conformer anyway
+    TEST_ASSERT(nm.getConformer().is3D());
+
+    // but if we do force, it blows out that conformer:
+    MolDraw2DUtils::prepareMolForDrawing(nm, true, true, true, true);
+    TEST_ASSERT(!nm.getConformer().is3D());
+  }
+
+  delete m;
+  std::cerr << " Done" << std::endl;
+}
+
 int main() {
   RDLog::InitLogs();
+#if 1
   test1();
   test2();
   test3();
@@ -624,4 +713,6 @@ int main() {
   testMultiThreaded();
   test6();
   test7();
+#endif
+  test8PrepareMolForDrawing();
 }


### PR DESCRIPTION
Captures the standard operations to get ready for doing a molecular rendering:
- kekulization
- generation of coordinates
- wedging bonds
- adding Hs to chiral atoms

Also fixes #772 (so that `wedgeMolBonds()` prefers wedging bonds to Hs)
