### PR TITLE
standardize the orientation when generating coords

### DIFF
--- a/Code/GraphMol/MolDraw2D/MolDraw2DUtils.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DUtils.cpp
@@ -37,7 +37,8 @@ void prepareMolForDrawing(RWMol &mol, bool kekulize, bool addChiralHs,
   }
   if (forceCoords || !mol.getNumConformers()) {
     // compute 2D coordinates in a standard orientation:
-    RDDepict::compute2DCoords(mol, NULL, true);
+    const bool canonOrient = true;
+    RDDepict::compute2DCoords(mol, NULL, canonOrient);
   }
   if (wedgeBonds) {
     WedgeMolBonds(mol, &mol.getConformer());

--- a/Code/GraphMol/MolDraw2D/MolDraw2DUtils.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DUtils.cpp
@@ -36,7 +36,8 @@ void prepareMolForDrawing(RWMol &mol, bool kekulize, bool addChiralHs,
     }
   }
   if (forceCoords || !mol.getNumConformers()) {
-    RDDepict::compute2DCoords(mol);
+    // compute 2D coordinates in a standard orientation:
+    RDDepict::compute2DCoords(mol, NULL, true);
   }
   if (wedgeBonds) {
     WedgeMolBonds(mol, &mol.getConformer());


### PR DESCRIPTION
This is a small one to modify `prepareMolForDrawing()` to generate the 2D coordinates in a standard orientation.