### PR TITLE
npscorer.py: Py3 compat and importable from other locations

### DIFF
--- a/Contrib/NP_Score/npscorer.py
+++ b/Contrib/NP_Score/npscorer.py
@@ -17,9 +17,9 @@ from __future__ import print_function
 from rdkit import Chem
 from rdkit.Chem import rdMolDescriptors
 import sys,math,gzip,pickle
-import os.path as op
+import os.path
 
-def readNPModel(filename=op.join(op.dirname(__file__), 'publicnp.model.gz')):
+def readNPModel(filename=os.path.join(os.path.dirname(__file__), 'publicnp.model.gz')):
   sys.stderr.write("reading NP model ...\n")
   fscore = pickle.load(gzip.open(filename))
   sys.stderr.write("model in\n")

--- a/Contrib/NP_Score/npscorer.py
+++ b/Contrib/NP_Score/npscorer.py
@@ -1,7 +1,7 @@
 #
 # calculation of natural product-likeness as described in:
 #
-# Natural Product-likeness Score and Its Application for Prioritization of Compound Libraries 
+# Natural Product-likeness Score and Its Application for Prioritization of Compound Libraries
 # Peter Ertl, Silvio Roggo, and Ansgar Schuffenhauer
 # Journal of Chemical Information and Modeling, 48, 68-74 (2008)
 # http://pubs.acs.org/doi/abs/10.1021/ci700286x
@@ -13,11 +13,13 @@
 # peter ertl, august 2015
 #
 
+from __future__ import print_function
 from rdkit import Chem
 from rdkit.Chem import rdMolDescriptors
 import sys,math,gzip,pickle
+import os.path as op
 
-def readNPModel(filename='publicnp.model.gz'):
+def readNPModel(filename=op.join(op.dirname(__file__), 'publicnp.model.gz')):
   sys.stderr.write("reading NP model ...\n")
   fscore = pickle.load(gzip.open(filename))
   sys.stderr.write("model in\n")
@@ -36,20 +38,20 @@ def scoreMol(mol,fscore):
   score /= float(mol.GetNumAtoms())
 
   # preventing score explosion for exotic molecules
-  if score > 4: 
+  if score > 4:
     score = 4. + math.log10(score - 4. + 1.)
   if score < -4:
     score = -4. - math.log10(-4. -score + 1.)
   return score
-  
-def processMols(fscore,suppl,outf):
+
+def processMols(fscore,suppl):
   sys.stderr.write("calculating ...\n")
   count = {}
   n = 0
   for i,m in enumerate(suppl):
     if m is None:
       continue
-    
+
     n += 1
     score = "%.3f" % scoreMol(m,fscore)
 
@@ -61,29 +63,27 @@ def processMols(fscore,suppl,outf):
 
 if __name__=='__main__':
 
-  outf = None
-
   fscore=readNPModel() # fills fscore
 
   suppl = Chem.SmilesMolSupplier(sys.argv[1],smilesColumn=0,nameColumn=1,titleLine=False)
-  processMols(fscore,suppl,outf)
-  
+  processMols(fscore,suppl)
+
 #
 # Copyright (c) 2015, Novartis Institutes for BioMedical Research Inc.
 # All rights reserved.
-# 
+#
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are
-# met: 
+# met:
 #
-#     * Redistributions of source code must retain the above copyright 
+#     * Redistributions of source code must retain the above copyright
 #       notice, this list of conditions and the following disclaimer.
 #     * Redistributions in binary form must reproduce the above
-#       copyright notice, this list of conditions and the following 
-#       disclaimer in the documentation and/or other materials provided 
+#       copyright notice, this list of conditions and the following
+#       disclaimer in the documentation and/or other materials provided
 #       with the distribution.
-#     * Neither the name of Novartis Institutes for BioMedical Research Inc. 
-#       nor the names of its contributors may be used to endorse or promote 
+#     * Neither the name of Novartis Institutes for BioMedical Research Inc.
+#       nor the names of its contributors may be used to endorse or promote
 #       products derived from this software without specific prior written permission.
 #
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS


### PR DESCRIPTION
* made Python3 compatible
* modified load path for the publicnp.model file to enable import of the module from other locations
* my editor removed some trailing whitespace