### PR TITLE
Fix/github805

### DIFF
--- a/Code/GraphMol/Chirality.cpp
+++ b/Code/GraphMol/Chirality.cpp
@@ -689,6 +689,31 @@ std::pair<bool, bool> assignBondStereoCodes(ROMol &mol, UINT_VECT &ranks) {
         // we're only going to handle 2 or three coordinate atoms:
         if ((begAtom->getDegree() == 2 || begAtom->getDegree() == 3) &&
             (endAtom->getDegree() == 2 || endAtom->getDegree() == 3)) {
+          // check to see if we have another double bond at either end,
+          // that disqualifies this as a stereobond (was github #805)
+          bool foundDoubleAtEnd=false;
+          ROMol::OEDGE_ITER begN,endN;
+          boost::tie(begN,endN) = mol.getAtomBonds(begAtom);
+          while(!foundDoubleAtEnd && begN!=endN){
+            BOND_SPTR bond=mol[*begN];
+            ++begN;
+            if(bond.get()!=dblBond && bond->getBondType()==Bond::DOUBLE){
+              foundDoubleAtEnd=true;
+              continue;
+            }
+          }
+          if(foundDoubleAtEnd) continue;
+          boost::tie(begN,endN) = mol.getAtomBonds(endAtom);
+          while(!foundDoubleAtEnd && begN!=endN){
+            BOND_SPTR bond=mol[*begN];
+            ++begN;
+            if(bond.get()!=dblBond && bond->getBondType()==Bond::DOUBLE){
+              foundDoubleAtEnd=true;
+              continue;
+            }
+          }
+          if(foundDoubleAtEnd) continue;
+
           ++unassignedBonds;
 
           // look around each atom and see if it has at least one bond with

--- a/Code/GraphMol/molopstest.cpp
+++ b/Code/GraphMol/molopstest.cpp
@@ -5627,6 +5627,27 @@ void testGithubIssue754() {
 
   BOOST_LOG(rdInfoLog) << "Finished" << std::endl;
 }
+void testGithubIssue805() {
+  BOOST_LOG(rdInfoLog) << "-----------------------\n Testing github #805 : "
+                          "Pre-condition Violation: bad bond type"
+                       << std::endl;
+  {
+    std::string pathName = getenv("RDBASE");
+    pathName += "/Code/GraphMol/test_data/";
+    ROMol *m = MolFileToMol(pathName + "pubchem_87396055.sdf");
+
+    TEST_ASSERT(m);
+    TEST_ASSERT(m->getNumAtoms() == 20);
+    TEST_ASSERT(m->getBondBetweenAtoms(2, 9)->getBondType() == Bond::DOUBLE);
+    TEST_ASSERT(m->getBondBetweenAtoms(2, 9)->getStereo() == Bond::STEREONONE);
+    TEST_ASSERT(m->getBondBetweenAtoms(3, 10)->getBondType() == Bond::DOUBLE);
+    TEST_ASSERT(m->getBondBetweenAtoms(3, 10)->getStereo() == Bond::STEREONONE);
+    std::string smi = MolToSmiles(*m, true);
+    std::cerr << "smi: " << smi << std::endl;
+    delete m;
+  }
+  BOOST_LOG(rdInfoLog) << "Finished" << std::endl;
+}
 
 int main() {
   RDLog::InitLogs();
@@ -5713,6 +5734,7 @@ int main() {
 #endif
   testPotentialStereoBonds();
   testGithubIssue754();
+  testGithubIssue805();
 
   return 0;
 }

--- a/Code/GraphMol/molopstest.cpp
+++ b/Code/GraphMol/molopstest.cpp
@@ -5643,7 +5643,18 @@ void testGithubIssue805() {
     TEST_ASSERT(m->getBondBetweenAtoms(3, 10)->getBondType() == Bond::DOUBLE);
     TEST_ASSERT(m->getBondBetweenAtoms(3, 10)->getStereo() == Bond::STEREONONE);
     std::string smi = MolToSmiles(*m, true);
-    std::cerr << "smi: " << smi << std::endl;
+    TEST_ASSERT(smi=="CCOP(=O)=C1CSC(c2cccs2)C1=P(=O)OCC");
+    delete m;
+  }
+  {
+    std::string smi="O=P(/O)=C/C";
+    ROMol *m = SmilesToMol(smi);
+    TEST_ASSERT(m);
+    TEST_ASSERT(m->getNumAtoms()==5);
+    TEST_ASSERT(m->getBondBetweenAtoms(1,3)->getBondType()==Bond::DOUBLE);
+    TEST_ASSERT(m->getBondBetweenAtoms(1,3)->getStereo() == Bond::STEREONONE);
+    smi = MolToSmiles(*m,true);
+    TEST_ASSERT(smi=="CC=P(=O)O");
     delete m;
   }
   BOOST_LOG(rdInfoLog) << "Finished" << std::endl;

--- a/Code/GraphMol/test_data/pubchem_87396055.sdf
+++ b/Code/GraphMol/test_data/pubchem_87396055.sdf
@@ -1,0 +1,170 @@
+87396055
+  -OEChem-03091600252D
+
+ 36 37  0     1  0  0  0  0  0999 V2000
+    4.8781   -2.2694    0.0000 S   0  0  0  0  0  0  0  0  0  0  0  0
+    3.3090   -0.0583    0.0000 S   0  0  0  0  0  0  0  0  0  0  0  0
+    5.3781    0.2694    0.0000 P   0  0  0  0  0  0  0  0  0  0  0  0
+    7.1382   -1.0094    0.0000 P   0  0  0  0  0  0  0  0  0  0  0  0
+    4.5121    0.7694    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
+    7.8813   -1.6785    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
+    6.2441    0.7694    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
+    7.3461   -0.0312    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
+    4.5691   -1.3184    0.0000 C   0  0  3  0  0  0  0  0  0  0  0  0
+    5.3781   -0.7306    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    6.1871   -1.3184    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    5.8781   -2.2694    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    3.6180   -1.0094    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    2.8090   -1.5971    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    2.0000   -1.0094    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    2.3090   -0.0583    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    4.5121    1.7694    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    8.8324   -1.3695    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    3.6461    2.2694    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    9.5755   -2.0386    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    4.1307   -1.7568    0.0000 H   0  0  0  0  0  0  0  0  0  0  0  0
+    5.8133   -2.8860    0.0000 H   0  0  0  0  0  0  0  0  0  0  0  0
+    6.4846   -2.3983    0.0000 H   0  0  0  0  0  0  0  0  0  0  0  0
+    2.8090   -2.2171    0.0000 H   0  0  0  0  0  0  0  0  0  0  0  0
+    1.4103   -1.2009    0.0000 H   0  0  0  0  0  0  0  0  0  0  0  0
+    1.9446    0.4433    0.0000 H   0  0  0  0  0  0  0  0  0  0  0  0
+    5.1227    1.6618    0.0000 H   0  0  0  0  0  0  0  0  0  0  0  0
+    4.7241    2.3520    0.0000 H   0  0  0  0  0  0  0  0  0  0  0  0
+    9.3210   -0.9878    0.0000 H   0  0  0  0  0  0  0  0  0  0  0  0
+    8.5413   -0.8220    0.0000 H   0  0  0  0  0  0  0  0  0  0  0  0
+    3.9561    2.8064    0.0000 H   0  0  0  0  0  0  0  0  0  0  0  0
+    3.1091    2.5794    0.0000 H   0  0  0  0  0  0  0  0  0  0  0  0
+    3.3361    1.7325    0.0000 H   0  0  0  0  0  0  0  0  0  0  0  0
+    9.1607   -2.4993    0.0000 H   0  0  0  0  0  0  0  0  0  0  0  0
+   10.0363   -2.4534    0.0000 H   0  0  0  0  0  0  0  0  0  0  0  0
+    9.9904   -1.5778    0.0000 H   0  0  0  0  0  0  0  0  0  0  0  0
+  1  9  1  0  0  0  0
+  1 12  1  0  0  0  0
+  2 13  1  0  0  0  0
+  2 16  1  0  0  0  0
+  3  5  1  0  0  0  0
+  3  7  2  0  0  0  0
+  3 10  2  0  0  0  0
+  4  6  1  0  0  0  0
+  4  8  2  0  0  0  0
+  4 11  2  0  0  0  0
+  5 17  1  0  0  0  0
+  6 18  1  0  0  0  0
+  9 10  1  0  0  0  0
+  9 13  1  0  0  0  0
+  9 21  1  0  0  0  0
+ 10 11  1  0  0  0  0
+ 11 12  1  0  0  0  0
+ 12 22  1  0  0  0  0
+ 12 23  1  0  0  0  0
+ 13 14  2  0  0  0  0
+ 14 15  1  0  0  0  0
+ 14 24  1  0  0  0  0
+ 15 16  2  0  0  0  0
+ 15 25  1  0  0  0  0
+ 16 26  1  0  0  0  0
+ 17 19  1  0  0  0  0
+ 17 27  1  0  0  0  0
+ 17 28  1  0  0  0  0
+ 18 20  1  0  0  0  0
+ 18 29  1  0  0  0  0
+ 18 30  1  0  0  0  0
+ 19 31  1  0  0  0  0
+ 19 32  1  0  0  0  0
+ 19 33  1  0  0  0  0
+ 20 34  1  0  0  0  0
+ 20 35  1  0  0  0  0
+ 20 36  1  0  0  0  0
+M  END
+> <PUBCHEM_COMPOUND_CID>
+87396055
+
+> <PUBCHEM_COMPOUND_CANONICALIZED>
+0
+
+> <PUBCHEM_CACTVS_COMPLEXITY>
+508
+
+> <PUBCHEM_CACTVS_HBOND_ACCEPTOR>
+6
+
+> <PUBCHEM_CACTVS_HBOND_DONOR>
+0
+
+> <PUBCHEM_CACTVS_ROTATABLE_BOND>
+5
+
+> <PUBCHEM_CACTVS_SUBSKEYS>
+AAADceBwOANgAAAAAAAAAAAAAAAAASJAAAAAAAAAAAAAAAABgAAAGgwAACAACACk0AKyAYAAARiEQCBCAIADAIAgCBBIiBgAAIgIICKgERCAAAAggAAoiAcAgIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+
+> <PUBCHEM_IUPAC_INCHI>
+InChI=1S/C12H16O4P2S2/c1-3-15-17(13)9-8-20-12(10-6-5-7-19-10)11(9)18(14)16-4-2/h5-7,12H,3-4,8H2,1-2H3
+
+> <PUBCHEM_IUPAC_INCHIKEY>
+IZJGZJFBVJCAGD-UHFFFAOYSA-N
+
+> <PUBCHEM_XLOGP3_AA>
+0.2
+
+> <PUBCHEM_EXACT_MASS>
+349.996524
+
+> <PUBCHEM_MOLECULAR_FORMULA>
+C12H16O4P2S2
+
+> <PUBCHEM_MOLECULAR_WEIGHT>
+350.330564
+
+> <PUBCHEM_OPENEYE_CAN_SMILES>
+CCOP(=C1CSC(C1=P(=O)OCC)C2=CC=CS2)=O
+
+> <PUBCHEM_OPENEYE_ISO_SMILES>
+CCO/P(=C/1\CSC(\C1=P(=O)/OCC)C2=CC=CS2)=O
+
+> <PUBCHEM_CACTVS_TPSA>
+106
+
+> <PUBCHEM_MONOISOTOPIC_WEIGHT>
+349.996524
+
+> <PUBCHEM_TOTAL_CHARGE>
+0
+
+> <PUBCHEM_HEAVY_ATOM_COUNT>
+20
+
+> <PUBCHEM_ATOM_DEF_STEREO_COUNT>
+0
+
+> <PUBCHEM_ATOM_UDEF_STEREO_COUNT>
+1
+
+> <PUBCHEM_BOND_DEF_STEREO_COUNT>
+2
+
+> <PUBCHEM_BOND_UDEF_STEREO_COUNT>
+0
+
+> <PUBCHEM_ISOTOPIC_ATOM_COUNT>
+0
+
+> <PUBCHEM_COMPONENT_COUNT>
+1
+
+> <PUBCHEM_CACTVS_TAUTO_COUNT>
+1
+
+> <PUBCHEM_COORDINATE_TYPE>
+1
+5
+255
+
+> <PUBCHEM_BONDANNOTATIONS>
+13  14  8
+14  15  8
+15  16  8
+2  13  8
+2  16  8
+9  13  3
+
+$$$$


### PR DESCRIPTION
Fixes the problem by removing stereo information from double bonds that have terminal atoms involved in other double bonds. So, for example, there is no longer double bond stereochemistry possible in `O=P(/O)=C/C`. I believe that this is chemically sensible and it certainly matches Marvin's behavior.

I will ask on the mailing list to see if anyone thinks those double bonds really can have stereochemistry (which would require a more complex fix), but I don't think that needs to delay this PR being merged.

