### PR TITLE
add Draw.MolsToSVGGrid()

### DIFF
--- a/rdkit/Chem/Draw/UnitTestDraw.py
+++ b/rdkit/Chem/Draw/UnitTestDraw.py
@@ -1,6 +1,6 @@
 # $Id$
 #
-#  Copyright (C) 2011  greg Landrum 
+#  Copyright (C) 2011  greg Landrum
 #
 #   @@ All Rights Reserved @@
 #  This file is part of the RDKit.
@@ -40,7 +40,7 @@ class TestCase(unittest.TestCase):
       os.unlink(fn)
     except Exception:
       pass
-    
+
   def testAggFile(self):
     try:
       from rdkit.Chem.Draw.aggCanvas import Canvas
@@ -92,7 +92,7 @@ class TestCase(unittest.TestCase):
     self.assertTrue(img)
     self.assertEqual(img.size[0],300)
     self.assertEqual(img.size[1],300)
-    
+
   def testAggImage(self):
     try:
       from rdkit.Chem.Draw.aggCanvas import Canvas
@@ -139,7 +139,7 @@ class TestCase(unittest.TestCase):
     self.assertTrue(img)
     self.assertEqual(img.size[0],300)
     self.assertEqual(img.size[1],300)
-    
+
   def testAggImageDash(self):
     try:
       from rdkit.Chem.Draw.aggCanvas import Canvas
@@ -171,7 +171,7 @@ class TestCase(unittest.TestCase):
     mol = Chem.MolFromSmiles('c1([O])ccc(O)cc1')
     img = Draw.MolToImage(mol)
     self.assertTrue(img)
-    
+
   def testGithubIssue86(self):
     mol = Chem.MolFromSmiles('F[C@H](Cl)Br')
     for b in mol.GetBonds():
@@ -189,10 +189,20 @@ class TestCase(unittest.TestCase):
     nbds = [x.GetBondDir() for x in mol.GetBonds()]
     self.assertEqual(obds,nbds)
 
-    
+  def testGridSVG(self):
+    mols = [Chem.MolFromSmiles('NC(C)C(=O)'*x) for x in range(10)]
+    legends = ['mol-%d'%x for x in range(len(mols))]
+    svg = Draw.MolsToGridSVG(mols,legends=legends,molsPerLine=3,subImgSize=(200,200))
+    self.assertTrue(svg.find("width='600px' height='800px'"))
+    svg = Draw.MolsToGridSVG(mols,legends=legends,molsPerLine=4,subImgSize=(200,200))
+    self.assertTrue(svg.find("width='800px' height='600px'"))
+    svg = Draw.MolsToGridSVG(mols,legends=legends,molsPerLine=3,subImgSize=(300,300))
+    self.assertTrue(svg.find("width='900px' height='1200px'"))
 
 
-    
+
+
+
+
 if __name__ == '__main__':
   unittest.main()
-

--- a/rdkit/Chem/Draw/UnitTestDraw.py
+++ b/rdkit/Chem/Draw/UnitTestDraw.py
@@ -192,11 +192,11 @@ class TestCase(unittest.TestCase):
   def testGridSVG(self):
     mols = [Chem.MolFromSmiles('NC(C)C(=O)'*x) for x in range(10)]
     legends = ['mol-%d'%x for x in range(len(mols))]
-    svg = Draw.MolsToGridSVG(mols,legends=legends,molsPerLine=3,subImgSize=(200,200))
+    svg = Draw.MolsToGridImage(mols,legends=legends,molsPerLine=3,subImgSize=(200,200),useSVG=True)
     self.assertTrue(svg.find("width='600px' height='800px'"))
-    svg = Draw.MolsToGridSVG(mols,legends=legends,molsPerLine=4,subImgSize=(200,200))
+    svg = Draw.MolsToGridImage(mols,legends=legends,molsPerLine=4,subImgSize=(200,200),useSVG=True)
     self.assertTrue(svg.find("width='800px' height='600px'"))
-    svg = Draw.MolsToGridSVG(mols,legends=legends,molsPerLine=3,subImgSize=(300,300))
+    svg = Draw.MolsToGridImage(mols,legends=legends,molsPerLine=3,subImgSize=(300,300),useSVG=True)
     self.assertTrue(svg.find("width='900px' height='1200px'"))
 
 

--- a/rdkit/Chem/Draw/__init__.py
+++ b/rdkit/Chem/Draw/__init__.py
@@ -1,9 +1,8 @@
-# $Id$
 #
-# Copyright (C) 2006-2011 Greg Landrum
+# Copyright (C) 2006-2016 Greg Landrum
 #  All Rights Reserved
 #
-import os
+import os,re
 from rdkit.six import iteritems
 from rdkit.Chem.Draw.MolDrawing import MolDrawing,DrawingOptions
 from rdkit.Chem.Draw.rdMolDraw2D import *
@@ -337,6 +336,47 @@ def MolsToGridImage(mols,molsPerRow=3,subImgSize=(200,200),legends=None,
       img = _moltoimg(mol,subImgSize,highlights,legends[i],**kwargs)
       res.paste(img,(col*subImgSize[0],row*subImgSize[1]))
   return res
+
+def MolsToGridSVG(mols,molsPerRow=3,subImgSize=(200,200),legends=None,
+                    highlightAtomLists=None,**kwargs):
+  """
+  """
+  matcher = re.compile(r'^(<.*>\n)(<svg:rect .*</svg\:rect>\n)(.*)</svg\:svg>',re.DOTALL)
+  if legends is None: legends = ['']*len(mols)
+  hdr=''
+  ftr='</svg:svg>'
+  rect=''
+
+  nRows = len(mols)//molsPerRow
+  if len(mols)%molsPerRow : nRows+=1
+
+  blocks = ['']*(nRows*molsPerRow)
+
+  fullSize=(molsPerRow*subImgSize[0],nRows*subImgSize[1])
+  for i,mol in enumerate(mols):
+    highlights=None
+    if highlightAtomLists and highlightAtomLists[i]:
+      highlights=highlightAtomLists[i]
+    if mol is not None:
+        nmol = rdMolDraw2D.PrepareMolForDrawing(mol,kekulize=kwargs.get('kekulize',True))
+        d2d = rdMolDraw2D.MolDraw2DSVG(subImgSize[0],subImgSize[1])
+        d2d.DrawMolecule(nmol,legend=legends[i],highlightAtoms=highlights)
+        d2d.FinishDrawing()
+        txt = d2d.GetDrawingText()
+        h,r,b = matcher.match(txt).groups()
+        if not hdr:
+            hdr = h.replace("width='200px' height='200px' >","width='%dpx' height='%dpx' >"%fullSize)
+        if not rect:
+            rect = r
+        blocks[i] = b
+  for i,elem in enumerate(blocks):
+    row = i//molsPerRow
+    col = i%molsPerRow
+    elem = rect+elem
+    blocks[i] = '<g transform="translate(%d,%d)" >%s</g>'%(col*subImgSize[0],row*subImgSize[1],elem)
+  res = hdr + '\n'.join(blocks)+ftr
+  return res
+
 
 def ReactionToImage(rxn, subImgSize=(200,200),**kwargs):
   """

--- a/rdkit/Chem/Draw/__init__.py
+++ b/rdkit/Chem/Draw/__init__.py
@@ -338,7 +338,7 @@ def MolsToGridImage(mols,molsPerRow=3,subImgSize=(200,200),legends=None,
   return res
 
 def MolsToGridSVG(mols,molsPerRow=3,subImgSize=(200,200),legends=None,
-                    highlightAtomLists=None,**kwargs):
+                    highlightAtomLists=None,stripSVGNamespace=True,**kwargs):
   """
   """
   matcher = re.compile(r'^(<.*>\n)(<svg:rect .*</svg\:rect>\n)(.*)</svg\:svg>',re.DOTALL)
@@ -375,6 +375,8 @@ def MolsToGridSVG(mols,molsPerRow=3,subImgSize=(200,200),legends=None,
     elem = rect+elem
     blocks[i] = '<g transform="translate(%d,%d)" >%s</g>'%(col*subImgSize[0],row*subImgSize[1],elem)
   res = hdr + '\n'.join(blocks)+ftr
+  if stripSVGNamespace:
+    res = res.replace('svg:','')
   return res
 
 

--- a/rdkit/Chem/Draw/__init__.py
+++ b/rdkit/Chem/Draw/__init__.py
@@ -312,9 +312,9 @@ def _moltoimg(mol,sz,highlights,legend,**kwargs):
         img = Image.open(sio)
     return img
 
-def MolsToGridImage(mols,molsPerRow=3,subImgSize=(200,200),legends=None,
+def _MolsToGridImage(mols,molsPerRow=3,subImgSize=(200,200),legends=None,
                     highlightAtomLists=None,**kwargs):
-  """
+  """ returns a PIL Image of the grid
   """
   try:
     import Image
@@ -337,9 +337,9 @@ def MolsToGridImage(mols,molsPerRow=3,subImgSize=(200,200),legends=None,
       res.paste(img,(col*subImgSize[0],row*subImgSize[1]))
   return res
 
-def MolsToGridSVG(mols,molsPerRow=3,subImgSize=(200,200),legends=None,
+def _MolsToGridSVG(mols,molsPerRow=3,subImgSize=(200,200),legends=None,
                     highlightAtomLists=None,stripSVGNamespace=True,**kwargs):
-  """
+  """ returns an SVG of the grid
   """
   matcher = re.compile(r'^(<.*>\n)(<svg:rect .*</svg\:rect>\n)(.*)</svg\:svg>',re.DOTALL)
   if legends is None: legends = ['']*len(mols)
@@ -379,6 +379,14 @@ def MolsToGridSVG(mols,molsPerRow=3,subImgSize=(200,200),legends=None,
     res = res.replace('svg:','')
   return res
 
+def MolsToGridImage(mols,molsPerRow=3,subImgSize=(200,200),legends=None,
+                    highlightAtomLists=None,useSVG=False,**kwargs):
+  if useSVG:
+      return _MolsToGridSVG(mols,molsPerRow=molsPerRow,subImgSize=subImgSize,
+                legends=legends, highlightAtomLists=highlightAtomLists, **kwargs)
+  else:
+      return _MolsToGridImage(mols,molsPerRow=molsPerRow,subImgSize=subImgSize,
+                legends=legends, highlightAtomLists=highlightAtomLists, **kwargs)
 
 def ReactionToImage(rxn, subImgSize=(200,200),**kwargs):
   """


### PR DESCRIPTION
This assembles the final svg using regexp operations instead of parsing the xml and working directly with the tree.

I think it's ok to do things this way, and suspect that it ends up being faster, but it's probably possible to do things differently if someone else thinks this is horrible.