### PR TITLE
Add some utils functions to ChemReactions and RDKFingerprints

### DIFF
--- a/Code/GraphMol/Fingerprints/Fingerprints.h
+++ b/Code/GraphMol/Fingerprints/Fingerprints.h
@@ -12,6 +12,7 @@
 
 #include <vector>
 #include <boost/cstdint.hpp>
+#include <DataStructs/SparseIntVect.h>
 
 class ExplicitBitVect;
 namespace RDKit {
@@ -55,7 +56,8 @@ ExplicitBitVect *RDKFingerprintMol(
     bool branchedPaths = true, bool useBondOrder = true,
     std::vector<boost::uint32_t> *atomInvariants = 0,
     const std::vector<boost::uint32_t> *fromAtoms = 0,
-    std::vector<std::vector<boost::uint32_t> > *atomBits = 0);
+    std::vector<std::vector<boost::uint32_t> > *atomBits = 0,
+    std::map<boost::uint32_t,std::vector<std::vector<int> > > *bitInfo=0);
 const std::string RDKFingerprintMolVersion = "2.0.0";
 
 //! \brief Generates a topological (Daylight like) fingerprint for a molecule
@@ -142,6 +144,18 @@ ExplicitBitVect *PatternFingerprintMol(
     const ROMol &mol, unsigned int fpSize = 2048,
     std::vector<unsigned int> *atomCounts = 0,
     ExplicitBitVect *setOnlyBits = 0);
+
+SparseIntVect<boost::uint64_t> *getUnfoldedRDKFingerprintMol(const ROMol &mol,unsigned int minPath=1,
+      unsigned int maxPath=7,
+      bool useHs=true,
+      bool branchedPaths=true,
+      bool useBondOrder=true,
+      std::vector<boost::uint32_t> *atomInvariants=0,
+      const std::vector<boost::uint32_t> *fromAtoms=0,
+      std::vector<std::vector<boost::uint64_t> > *atomBits=0,
+      std::map<boost::uint64_t,std::vector<std::vector<int> > > *bitInfo=0);
+
 }
+
 
 #endif

--- a/Code/GraphMol/Fingerprints/test1.cpp
+++ b/Code/GraphMol/Fingerprints/test1.cpp
@@ -3001,6 +3001,7 @@ void testGitHubIssue334() {
   BOOST_LOG(rdErrorLog) << "  done" << std::endl;
 }
 
+
 void testGitHubIssue695() {
   BOOST_LOG(rdErrorLog) << "-------------------------------------" << std::endl;
   BOOST_LOG(rdErrorLog) << "    Test GitHub Issue 695: Include cis/trans "
@@ -3178,6 +3179,165 @@ void testGitHubIssue811() {
   BOOST_LOG(rdErrorLog) << "  done" << std::endl;
 }
 
+void testRDKFPUnfolded(){
+  BOOST_LOG(rdErrorLog) << "-------------------------------------" << std::endl;
+  BOOST_LOG(rdErrorLog) << "    Test unfolded version of RDKFP   " << std::endl;
+  {
+    ROMol *m1 = SmilesToMol("c1ccccc1N");
+    TEST_ASSERT(m1);
+    SparseIntVect<boost::uint64_t> *fp1;
+    SparseIntVect<boost::uint64_t>::StorageType::const_iterator iter;
+
+    fp1 = getUnfoldedRDKFingerprintMol(*m1);
+    TEST_ASSERT(fp1);
+
+#if 0
+    for (iter = fp1->getNonzeroElements().begin();
+         iter != fp1->getNonzeroElements().end(); ++iter) {
+      std::cerr << "   " << iter->first << ": " << iter->second << std::endl;
+    }
+    std::cerr << "  ------------ " << std::endl;
+#endif
+    TEST_ASSERT(fp1->getNonzeroElements().size() == 19);
+    iter = fp1->getNonzeroElements().find(374073638);
+    TEST_ASSERT(iter != fp1->getNonzeroElements().end() && iter->second == 6);
+    iter = fp1->getNonzeroElements().find(464351883);
+    TEST_ASSERT(iter != fp1->getNonzeroElements().end() && iter->second == 2);
+    iter = fp1->getNonzeroElements().find(1949583554);
+    TEST_ASSERT(iter != fp1->getNonzeroElements().end() && iter->second == 6);
+    iter = fp1->getNonzeroElements().find(4105342207);
+    TEST_ASSERT(iter != fp1->getNonzeroElements().end() && iter->second == 1);
+    iter = fp1->getNonzeroElements().find(794080973);
+    TEST_ASSERT(iter != fp1->getNonzeroElements().end() && iter->second == 1);
+    iter = fp1->getNonzeroElements().find(3826517238);
+    TEST_ASSERT(iter != fp1->getNonzeroElements().end() && iter->second == 2);
+
+    delete m1;
+  }
+  {
+    ROMol *m1 = SmilesToMol("Cl");
+    TEST_ASSERT(m1);
+    SparseIntVect<boost::uint64_t> *fp1;
+    SparseIntVect<boost::uint64_t>::StorageType::const_iterator iter;
+
+    fp1 = getUnfoldedRDKFingerprintMol(*m1);
+    TEST_ASSERT(fp1);
+    TEST_ASSERT(fp1->getNonzeroElements().size() == 0);
+
+    delete m1;
+  }
+  {
+    ROMol *m1 = SmilesToMol("CCCO");
+    TEST_ASSERT(m1);
+    SparseIntVect<boost::uint64_t> *fp1;
+    SparseIntVect<boost::uint64_t>::StorageType::const_iterator iter;
+    std::map<boost::uint64_t,std::vector<std::vector<int> > > bitInfo;
+    std::map<boost::uint64_t,std::vector<std::vector<int> > >::const_iterator iter2;
+
+    fp1 = getUnfoldedRDKFingerprintMol(*m1,1,7,true,true,true,NULL,NULL,NULL,&bitInfo);
+    TEST_ASSERT(fp1);
+
+#if 0
+    for (iter = fp1->getNonzeroElements().begin();
+         iter != fp1->getNonzeroElements().end(); ++iter) {
+      std::cerr << "   " << iter->first << ": " << iter->second << std::endl;
+    }
+    std::cerr << "  ------------ " << std::endl;
+#endif
+#if 0
+    for (iter2 = bitInfo.begin();
+         iter2 != bitInfo.end(); ++iter2) {
+      std::cerr << "   " << iter2->first << ": ";
+      for (unsigned i=0; i<iter2->second.size(); i++){
+        std::cerr << " [ ";
+        for (unsigned j=0; j<iter2->second.at(i).size(); j++){
+          std::cerr << iter2->second.at(i).at(j) << " ";
+        }
+        std::cerr << "], ";
+      }
+      std::cerr << std::endl;
+    }
+    std::cerr << "  ------------ " << std::endl;
+#endif
+
+    TEST_ASSERT(fp1->getNonzeroElements().size() == 5);
+    iter = fp1->getNonzeroElements().find(1524090560);
+    TEST_ASSERT(iter != fp1->getNonzeroElements().end() && iter->second == 1);
+    iter = fp1->getNonzeroElements().find(1940446997);
+    TEST_ASSERT(iter != fp1->getNonzeroElements().end() && iter->second == 1);
+    iter = fp1->getNonzeroElements().find(3977409745);
+    TEST_ASSERT(iter != fp1->getNonzeroElements().end() && iter->second == 1);
+    iter = fp1->getNonzeroElements().find(4274652475);
+    TEST_ASSERT(iter != fp1->getNonzeroElements().end() && iter->second == 1);
+    iter = fp1->getNonzeroElements().find(4275705116);
+    TEST_ASSERT(iter != fp1->getNonzeroElements().end() && iter->second == 2);
+
+    iter2 = bitInfo.find(4275705116);
+    TEST_ASSERT(iter2 != bitInfo.end() && iter2->second[0][0] == 0);
+    TEST_ASSERT(iter2 != bitInfo.end() && iter2->second.size() == 2 && iter2->second[1][0] == 1);
+    iter2 = bitInfo.find(4274652475);
+    TEST_ASSERT(iter2 != bitInfo.end() && iter2->second[0][0] == 2);
+    iter2 = bitInfo.find(3977409745);
+    TEST_ASSERT(iter2 != bitInfo.end() && iter2->second[0].size() == 3 && iter2->second[0][0] == 0);
+    TEST_ASSERT(iter2 != bitInfo.end() && iter2->second[0].size() == 3 && iter2->second[0][1] == 1);
+    TEST_ASSERT(iter2 != bitInfo.end() && iter2->second[0].size() == 3 && iter2->second[0][2] == 2);
+    iter2 = bitInfo.find(1524090560);
+    TEST_ASSERT(iter2 != bitInfo.end() && iter2->second[0].size() == 2 && iter2->second[0][0] == 1);
+    TEST_ASSERT(iter2 != bitInfo.end() && iter2->second[0].size() == 2 && iter2->second[0][1] == 2);
+
+    delete m1;
+  }
+}
+
+void testRDKFPBitInfo(){
+  BOOST_LOG(rdErrorLog) << "-------------------------------------" << std::endl;
+  BOOST_LOG(rdErrorLog) << "    Test bitinfo of RDKFP   " << std::endl;
+
+  {
+    ROMol *m1 = SmilesToMol("CCCO");
+    TEST_ASSERT(m1);
+    ExplicitBitVect *fp1;
+    std::map<boost::uint32_t,std::vector<std::vector<int> > > bitInfo;
+    std::map<boost::uint32_t,std::vector<std::vector<int> > >::const_iterator iter2;
+
+    fp1 = RDKFingerprintMol(*m1,1,7,2048,2,true,0.0,128,true,true,NULL,NULL,NULL,&bitInfo);
+    TEST_ASSERT(fp1);
+
+#if 0
+    for (iter2 = bitInfo.begin();
+         iter2 != bitInfo.end(); ++iter2) {
+      std::cerr << "   " << iter2->first << ": ";
+      for (unsigned i=0; i<iter2->second.size(); i++){
+        std::cerr << " [ ";
+        for (unsigned j=0; j<iter2->second.at(i).size(); j++){
+          std::cerr << iter2->second.at(i).at(j) << " ";
+        }
+        std::cerr << "], ";
+      }
+      std::cerr << std::endl;
+    }
+    std::cerr << "  ------------ " << std::endl;
+#endif
+
+    iter2 = bitInfo.find(1772);
+    TEST_ASSERT(iter2 != bitInfo.end() && iter2->second[0][0] == 0);
+    TEST_ASSERT(iter2 != bitInfo.end() && iter2->second.size() == 2 && iter2->second[1][0] == 1);
+    iter2 = bitInfo.find(562);
+    TEST_ASSERT(iter2 != bitInfo.end() && iter2->second[0][0] == 2);
+    iter2 = bitInfo.find(1118);
+    TEST_ASSERT(iter2 != bitInfo.end() && iter2->second[0].size() == 3 && iter2->second[0][0] == 0);
+    TEST_ASSERT(iter2 != bitInfo.end() && iter2->second[0].size() == 3 && iter2->second[0][1] == 1);
+    TEST_ASSERT(iter2 != bitInfo.end() && iter2->second[0].size() == 3 && iter2->second[0][2] == 2);
+    iter2 = bitInfo.find(1183);
+    TEST_ASSERT(iter2 != bitInfo.end() && iter2->second[0].size() == 2 && iter2->second[0][0] == 1);
+    TEST_ASSERT(iter2 != bitInfo.end() && iter2->second[0].size() == 2 && iter2->second[0][1] == 2);
+
+    delete m1;
+  }
+}
+
+
+
 int main(int argc, char *argv[]) {
   (void)argc;
   (void)argv;
@@ -3226,8 +3386,10 @@ int main(int argc, char *argv[]) {
   testGitHubIssue258();
   testGitHubIssue334();
   testGitHubIssue695();
-#endif
   testGitHubIssue811();
+  testRDKFPUnfolded();
+  testRDKFPBitInfo();
+#endif
 
   return 0;
 }

--- a/Code/GraphMol/Wrap/MolOps.cpp
+++ b/Code/GraphMol/Wrap/MolOps.cpp
@@ -574,22 +574,26 @@ ExplicitBitVect *wrapRDKFingerprintMol(
     unsigned int fpSize, unsigned int nBitsPerHash, bool useHs,
     double tgtDensity, unsigned int minSize, bool branchedPaths,
     bool useBondOrder, python::object atomInvariants, python::object fromAtoms,
-    python::object atomBits) {
+    python::object atomBits, python::object bitInfo) {
   rdk_auto_ptr<std::vector<unsigned int> > lAtomInvariants =
       pythonObjectToVect<unsigned int>(atomInvariants);
   rdk_auto_ptr<std::vector<unsigned int> > lFromAtoms =
       pythonObjectToVect(fromAtoms, mol.getNumAtoms());
   std::vector<std::vector<boost::uint32_t> > *lAtomBits = 0;
+  std::map<boost::uint32_t,std::vector<std::vector<int> > > *lBitInfo=0;
   // if(!(atomBits.is_none())){
   if (atomBits != python::object()) {
     lAtomBits =
         new std::vector<std::vector<boost::uint32_t> >(mol.getNumAtoms());
   }
+  if(bitInfo!=python::object()){
+    lBitInfo = new std::map<boost::uint32_t,std::vector<std::vector<int> > >;
+  }
   ExplicitBitVect *res;
   res = RDKit::RDKFingerprintMol(mol, minPath, maxPath, fpSize, nBitsPerHash,
                                  useHs, tgtDensity, minSize, branchedPaths,
                                  useBondOrder, lAtomInvariants.get(),
-                                 lFromAtoms.get(), lAtomBits);
+                                 lFromAtoms.get(), lAtomBits, lBitInfo);
 
   if (lAtomBits) {
     python::list &pyl = static_cast<python::list &>(atomBits);
@@ -600,9 +604,92 @@ ExplicitBitVect *wrapRDKFingerprintMol(
     }
     delete lAtomBits;
   }
+  if(lBitInfo){
+    python::dict &pyd=static_cast<python::dict &>(bitInfo);
+    typedef std::map<boost::uint32_t,std::vector<std::vector<int> > >::iterator it_type;
+    for(it_type it = (*lBitInfo).begin(); it != (*lBitInfo).end(); ++it) {
+      python::list temp;
+      std::vector<std::vector<int> >::iterator itset;
+      for (itset = it->second.begin(); itset != it->second.end(); ++itset){
+        python::list temp2;
+        for(unsigned int i=0; i<itset->size(); ++i){
+          temp2.append(itset->at(i));
+        }
+        temp.append(temp2);
+      }
+      if(!pyd.has_key(it->first)){
+        pyd[it->first]=temp;
+      }
+    }
+    delete lBitInfo;
+  }
 
   return res;
 }
+
+
+SparseIntVect<boost::uint64_t> *wrapUnfoldedRDKFingerprintMol(const ROMol &mol,
+                                       unsigned int minPath,
+                                       unsigned int maxPath,
+                                       bool useHs,
+                                       bool branchedPaths,
+                                       bool useBondOrder,
+                                       python::object atomInvariants,
+                                       python::object fromAtoms,
+                                       python::object atomBits,
+                                       python::object bitInfo
+                                       ){
+  rdk_auto_ptr<std::vector<unsigned int> > lAtomInvariants=pythonObjectToVect<unsigned int>(atomInvariants);
+  rdk_auto_ptr<std::vector<unsigned int> > lFromAtoms=pythonObjectToVect(fromAtoms,mol.getNumAtoms());
+  std::vector<std::vector<boost::uint64_t> > *lAtomBits=0;
+  std::map<boost::uint64_t,std::vector<std::vector<int> > > *lBitInfo=0;
+
+  //if(!(atomBits.is_none())){
+  if(atomBits!=python::object()){
+    lAtomBits = new std::vector<std::vector<boost::uint64_t> >(mol.getNumAtoms());
+  }
+  if(bitInfo!=python::object()){
+    lBitInfo = new std::map<boost::uint64_t,std::vector<std::vector<int> > >;
+  }
+
+  SparseIntVect<boost::uint64_t> *res;
+  res = getUnfoldedRDKFingerprintMol(mol,minPath,maxPath,useHs,branchedPaths,
+      useBondOrder,lAtomInvariants.get(),lFromAtoms.get(),lAtomBits,lBitInfo);
+
+  if(lAtomBits){
+    python::list &pyl=static_cast<python::list &>(atomBits);
+    for(unsigned int i=0;i<mol.getNumAtoms();++i){
+      python::list tmp;
+      BOOST_FOREACH(boost::uint64_t v,(*lAtomBits)[i]){
+        tmp.append(v);
+      }
+      pyl.append(tmp);
+    }
+    delete lAtomBits;
+  }
+  if(lBitInfo){
+    python::dict &pyd=static_cast<python::dict &>(bitInfo);
+    typedef std::map<boost::uint64_t,std::vector<std::vector<int> > >::iterator it_type;
+    for(it_type it = (*lBitInfo).begin(); it != (*lBitInfo).end(); ++it) {
+      python::list temp;
+      std::vector<std::vector<int> >::iterator itset;
+      for (itset = it->second.begin(); itset != it->second.end(); ++itset){
+        python::list temp2;
+        for(unsigned int i=0; i<itset->size(); ++i){
+          temp2.append(itset->at(i));
+        }
+        temp.append(temp2);
+      }
+      if(!pyd.has_key(it->first)){
+        pyd[it->first]=temp;
+      }
+    }
+    delete lBitInfo;
+  }
+
+  return res;
+}
+
 
 python::object findAllSubgraphsOfLengthsMtoNHelper(const ROMol &mol,
                                                    unsigned int lowerLen,
@@ -1453,7 +1540,22 @@ struct molops_wrapper {
          python::arg("branchedPaths") = true,
          python::arg("useBondOrder") = true, python::arg("atomInvariants") = 0,
          python::arg("fromAtoms") = 0,
-         python::arg("atomBits") = python::object()),
+         python::arg("atomBits") = python::object(),
+         python::arg("bitInfo")=python::object()),
+         docString.c_str(),
+         python::return_value_policy<python::manage_new_object>());
+    python::scope().attr("_RDKFingerprint_version")=RDKit::RDKFingerprintMolVersion;
+
+
+         python::def("UnfoldedRDKFingerprintCountBased", wrapUnfoldedRDKFingerprintMol,
+                     (python::arg("mol"),python::arg("minPath")=1,
+                      python::arg("maxPath")=7,python::arg("useHs")=true,
+                      python::arg("branchedPaths")=true,
+                      python::arg("useBondOrder")=true,
+                      python::arg("atomInvariants")=0,
+                      python::arg("fromAtoms")=0,
+                      python::arg("atomBits")=python::object(),
+                      python::arg("bitInfo")=python::object()),
         docString.c_str(),
         python::return_value_policy<python::manage_new_object>());
     python::scope().attr("_RDKFingerprint_version") =

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -3500,7 +3500,77 @@ CAS<~>
         for pn in m.GetPropNames():
             self.assertTrue(nm.HasProp(pn))
             self.assertEqual(m.GetProp(pn),nm.GetProp(pn))
+            
+  
+  def testUnfoldedRDKFingerprint(self):
+    from rdkit.Chem import AllChem
+    
+    m = Chem.MolFromSmiles('c1ccccc1N')
+    fp = AllChem.UnfoldedRDKFingerprintCountBased(m)
+    fpDict = fp.GetNonzeroElements()
+    self.assertEquals(len(fpDict.items()),19)
+    self.assertTrue(fpDict.has_key(374073638))
+    self.assertEquals(fpDict[374073638],6)
+    self.assertTrue(fpDict.has_key(464351883))
+    self.assertEquals(fpDict[464351883],2)
+    self.assertTrue(fpDict.has_key(1949583554))
+    self.assertEquals(fpDict[1949583554],6)    
+    self.assertTrue(fpDict.has_key(4105342207))
+    self.assertEquals(fpDict[4105342207],1)
+    self.assertTrue(fpDict.has_key(794080973))
+    self.assertEquals(fpDict[794080973],1)
+    self.assertTrue(fpDict.has_key(3826517238))
+    self.assertEquals(fpDict[3826517238],2)
+    
+    m = Chem.MolFromSmiles('Cl')
+    fp = AllChem.UnfoldedRDKFingerprintCountBased(m)
+    fpDict = fp.GetNonzeroElements()
+    self.assertEquals(len(fpDict.items()),0)
+    
+    m = Chem.MolFromSmiles('CCCO')
+    aBits = {} 
+    fp = AllChem.UnfoldedRDKFingerprintCountBased(m, bitInfo=aBits)
+    fpDict = fp.GetNonzeroElements()
+    self.assertEquals(len(fpDict.items()),5)
+    self.assertTrue(fpDict.has_key(1524090560))
+    self.assertEquals(fpDict[1524090560],1)
+    self.assertTrue(fpDict.has_key(1940446997))
+    self.assertEquals(fpDict[1940446997],1)
+    self.assertTrue(fpDict.has_key(3977409745))
+    self.assertEquals(fpDict[3977409745],1)    
+    self.assertTrue(fpDict.has_key(4274652475))
+    self.assertEquals(fpDict[4274652475],1)
+    self.assertTrue(fpDict.has_key(4275705116))
+    self.assertEquals(fpDict[4275705116],2)
+    
+    self.assertTrue(aBits.has_key(1524090560))
+    self.assertEquals(aBits[1524090560],[[1,2]])
+    self.assertTrue(aBits.has_key(1940446997))
+    self.assertEquals(aBits[1940446997],[[0,1]])
+    self.assertTrue(aBits.has_key(3977409745))
+    self.assertEquals(aBits[3977409745],[[0,1,2]])    
+    self.assertTrue(aBits.has_key(4274652475))
+    self.assertEquals(aBits[4274652475],[[2]])
+    self.assertTrue(aBits.has_key(4275705116))
+    self.assertEquals(aBits[4275705116],[[0],[1]])
 
+
+  def testRDKFingerprintBitInfo(self):
+
+    m = Chem.MolFromSmiles('CCCO')
+    aBits = {}
+    fp1 = Chem.RDKFingerprint(m, bitInfo=aBits)
+    self.assertTrue(aBits.has_key(1183))
+    self.assertEquals(aBits[1183],[[1,2]])
+    self.assertTrue(aBits.has_key(709))
+    self.assertEquals(aBits[709],[[0,1]])
+    self.assertTrue(aBits.has_key(1118))
+    self.assertEquals(aBits[1118],[[0,1,2]])    
+    self.assertTrue(aBits.has_key(562))
+    self.assertEquals(aBits[562],[[2]])
+    self.assertTrue(aBits.has_key(1772))
+    self.assertEquals(aBits[1772],[[0],[1]])
+    
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Chem Reactions
- provide function to re/move agents
- add utils function to remove atom-mapping numbers
- allow sanitization of reactions, necessary for improving drawing

RDKFingerprints
- add an unfolded count-based version of this FP
- add a bitinfo map to allow mapping bits back to atoms like the one used in MorganFPs
- refactor some code to largely avoid code duplicates