### PR TITLE
Additional "hypervalent" halogen cleanups

### DIFF
--- a/Code/GraphMol/MolOps.h
+++ b/Code/GraphMol/MolOps.h
@@ -398,8 +398,10 @@ int setAromaticity(RWMol &mol);
            oxygen is changed to a single bond
        The net result is that nitro groups can be counted on to be:
          \c "[N+](=O)[O-]"
-     - modifies perchlorates from Cl(=O)(=O)(=O)[O-] to
-       [Cl+3]([O-])([O-])([O-])[O-]
+     - modifies halogen-oxygen containing species as follows:
+        \c [Cl,Br,I](=O)(=O)(=O)O -> [X+3]([O-])([O-])([O-])O
+        \c [Cl,Br,I](=O)(=O)O -> [X+3]([O-])([O-])O
+        \c [Cl,Br,I](=O)O -> [X+]([O-])O
      - converts the substructure [N,C]=P(=O)-* to [N,C]=[P+](-[O-])-*
 
    \param mol    the molecule of interest

--- a/Code/GraphMol/molopstest.cpp
+++ b/Code/GraphMol/molopstest.cpp
@@ -1988,6 +1988,41 @@ void testSanitOps() {
   TEST_ASSERT(m->getAtomWithIdx(0)->getFormalCharge() == 3);
   delete m;
 
+  smi = "Cl(=O)(=O)(=O)O";
+  m = SmilesToMol(smi);
+  TEST_ASSERT(m);
+  TEST_ASSERT(m->getNumAtoms() == 5);
+  TEST_ASSERT(m->getAtomWithIdx(0)->getFormalCharge() == 3);
+  delete m;
+
+  smi = "Br(=O)(=O)(=O)[O-]";
+  m = SmilesToMol(smi);
+  TEST_ASSERT(m);
+  TEST_ASSERT(m->getNumAtoms() == 5);
+  TEST_ASSERT(m->getAtomWithIdx(0)->getFormalCharge() == 3);
+  delete m;
+
+  smi = "Br(=O)(=O)(=O)O";
+  m = SmilesToMol(smi);
+  TEST_ASSERT(m);
+  TEST_ASSERT(m->getNumAtoms() == 5);
+  TEST_ASSERT(m->getAtomWithIdx(0)->getFormalCharge() == 3);
+  delete m;
+
+  smi = "I(=O)(=O)(=O)[O-]";
+  m = SmilesToMol(smi);
+  TEST_ASSERT(m);
+  TEST_ASSERT(m->getNumAtoms() == 5);
+  TEST_ASSERT(m->getAtomWithIdx(0)->getFormalCharge() == 3);
+  delete m;
+
+  smi = "I(=O)(=O)(=O)O";
+  m = SmilesToMol(smi);
+  TEST_ASSERT(m);
+  TEST_ASSERT(m->getNumAtoms() == 5);
+  TEST_ASSERT(m->getAtomWithIdx(0)->getFormalCharge() == 3);
+  delete m;
+
   pathName = getenv("RDBASE");
   pathName += "/Code/GraphMol/test_data/";
   m = MolFileToMol(pathName + "perchlorate1.mol");
@@ -2023,6 +2058,90 @@ void testSanitOps() {
   TEST_ASSERT(m->getAtomWithIdx(1)->getFormalCharge() == 0);
   TEST_ASSERT(m->getAtomWithIdx(0)->getFormalCharge() == 0);
   TEST_ASSERT(m->getBondBetweenAtoms(0, 1)->getBondType() == Bond::TRIPLE);
+  delete m;
+
+  smi = "Cl(=O)(=O)O";
+  m = SmilesToMol(smi);
+  TEST_ASSERT(m);
+  TEST_ASSERT(m->getNumAtoms() == 4);
+  TEST_ASSERT(m->getAtomWithIdx(0)->getFormalCharge() == 2);
+  delete m;
+
+  smi = "Cl(=O)(=O)[O-]";
+  m = SmilesToMol(smi);
+  TEST_ASSERT(m);
+  TEST_ASSERT(m->getNumAtoms() == 4);
+  TEST_ASSERT(m->getAtomWithIdx(0)->getFormalCharge() == 2);
+  delete m;
+
+  smi = "Br(=O)(=O)O";
+  m = SmilesToMol(smi);
+  TEST_ASSERT(m);
+  TEST_ASSERT(m->getNumAtoms() == 4);
+  TEST_ASSERT(m->getAtomWithIdx(0)->getFormalCharge() == 2);
+  delete m;
+
+  smi = "Br(=O)(=O)[O-]";
+  m = SmilesToMol(smi);
+  TEST_ASSERT(m);
+  TEST_ASSERT(m->getNumAtoms() == 4);
+  TEST_ASSERT(m->getAtomWithIdx(0)->getFormalCharge() == 2);
+  delete m;
+
+  smi = "I(=O)(=O)O";
+  m = SmilesToMol(smi);
+  TEST_ASSERT(m);
+  TEST_ASSERT(m->getNumAtoms() == 4);
+  TEST_ASSERT(m->getAtomWithIdx(0)->getFormalCharge() == 2);
+  delete m;
+
+  smi = "I(=O)(=O)[O-]";
+  m = SmilesToMol(smi);
+  TEST_ASSERT(m);
+  TEST_ASSERT(m->getNumAtoms() == 4);
+  TEST_ASSERT(m->getAtomWithIdx(0)->getFormalCharge() == 2);
+  delete m;
+
+  smi = "Cl(=O)O";
+  m = SmilesToMol(smi);
+  TEST_ASSERT(m);
+  TEST_ASSERT(m->getNumAtoms() == 3);
+  TEST_ASSERT(m->getAtomWithIdx(0)->getFormalCharge() == 1);
+  delete m;
+
+  smi = "Cl(=O)[O-]";
+  m = SmilesToMol(smi);
+  TEST_ASSERT(m);
+  TEST_ASSERT(m->getNumAtoms() == 3);
+  TEST_ASSERT(m->getAtomWithIdx(0)->getFormalCharge() == 1);
+  delete m;
+
+  smi = "Br(=O)O";
+  m = SmilesToMol(smi);
+  TEST_ASSERT(m);
+  TEST_ASSERT(m->getNumAtoms() == 3);
+  TEST_ASSERT(m->getAtomWithIdx(0)->getFormalCharge() == 1);
+  delete m;
+
+  smi = "Br(=O)[O-]";
+  m = SmilesToMol(smi);
+  TEST_ASSERT(m);
+  TEST_ASSERT(m->getNumAtoms() == 3);
+  TEST_ASSERT(m->getAtomWithIdx(0)->getFormalCharge() == 1);
+  delete m;
+
+  smi = "I(=O)O";
+  m = SmilesToMol(smi);
+  TEST_ASSERT(m);
+  TEST_ASSERT(m->getNumAtoms() == 3);
+  TEST_ASSERT(m->getAtomWithIdx(0)->getFormalCharge() == 1);
+  delete m;
+
+  smi = "I(=O)[O-]";
+  m = SmilesToMol(smi);
+  TEST_ASSERT(m);
+  TEST_ASSERT(m->getNumAtoms() == 3);
+  TEST_ASSERT(m->getAtomWithIdx(0)->getFormalCharge() == 1);
   delete m;
 
   BOOST_LOG(rdInfoLog) << "Finished" << std::endl;

--- a/Docs/Book/RDKit_Book.rst
+++ b/Docs/Book/RDKit_Book.rst
@@ -68,11 +68,11 @@ Notice that exocyclic bonds to electronegative atoms “steal” the valence ele
 The use of fused rings for aromaticity can lead to situations where individual rings are not aromatic, but the fused system is.
 An example of this is azulene:
 
-.. image:: images/picture_8.png 
+.. image:: images/picture_8.png
 
 An extreme example, demonstrating both fused rings and the influence of exocyclic double bonds:
 
-.. image:: images/picture_7.png 
+.. image:: images/picture_7.png
 
 >>> m=Chem.MolFromSmiles('O=C1C=CC(=O)C2=C1OC=CO2')
 >>> m.GetAtomWithIdx(6).GetIsAromatic()
@@ -84,7 +84,7 @@ False
 
 A special case, heteroatoms with radicals are not considered candidates for aromaticity:
 
-.. image:: images/picture_10.png 
+.. image:: images/picture_10.png
 
 >>> m = Chem.MolFromSmiles('C1=C[N]C=C1')
 >>> m.GetAtomWithIdx(0).GetIsAromatic()
@@ -96,7 +96,7 @@ False
 
 Carbons with radicals, however, are still considered:
 
-.. image:: images/picture_11.png 
+.. image:: images/picture_11.png
 
 >>> m = Chem.MolFromSmiles('C1=[C]NC=C1')
 >>> m.GetAtomWithIdx(0).GetIsAromatic()
@@ -314,7 +314,7 @@ Rules and caveats
    So do [C,N,O:1] or [C;R:1].
 
 2. Don't forget that unspecified bonds in SMARTS are either single or aromatic.
-   Bond orders in product templates are assigned when the product template itself is constructed and it's not always possible to tell if the bond should be single or aromatic: 
+   Bond orders in product templates are assigned when the product template itself is constructed and it's not always possible to tell if the bond should be single or aromatic:
 
 >>> rxn = AllChem.ReactionFromSmarts('[#6:1][#7,#8:2]>>[#6:1][#6:2]')
 >>> [Chem.MolToSmiles(x,1) for x in rxn.RunReactants((Chem.MolFromSmiles('C1NCCCC1'),))[0]]
@@ -342,11 +342,11 @@ Chemical Features
 
 Chemical features are defined by a Feature Type and a Feature Family.
 The Feature Family is a general classification of the feature (such as "Hydrogen-bond Donor" or "Aromatic") while the Feature Type provides additional, higher-resolution, information about features.
-Pharmacophore matching is done using Feature Family's. Each feature type contains the following pieces of information: 
+Pharmacophore matching is done using Feature Family's. Each feature type contains the following pieces of information:
 
 - A SMARTS pattern that describes atoms (one or more) matching the feature type.
 - Weights used to determine the feature's position based on the positions of its defining atoms.
-  
+
 
 
 Syntax of the FDef file
@@ -358,13 +358,13 @@ AtomType definitions
 
 An AtomType definition allows you to assign a shorthand name to be used in place of a SMARTS string defining an atom query.
 This allows FDef files to be made much more readable.
-For example, defining a non-polar carbon atom like this:: 
+For example, defining a non-polar carbon atom like this::
 
   AtomType Carbon_NonPolar [C&!$(C=[O,N,P,S])&!$(C#N)]
 
 creates a new name that can be used anywhere else in the FDef file that it would be useful to use this SMARTS.
 To reference an AtomType, just include its name in curly brackets.
-For example, this excerpt from an FDef file defines another atom type - Hphobe - which references the Carbon_NonPolar definition:: 
+For example, this excerpt from an FDef file defines another atom type - Hphobe - which references the Carbon_NonPolar definition::
 
   AtomType Carbon_NonPolar [C&!$(C=[O,N,P,S])&!$(C#N)]
   AtomType Hphobe [{Carbon_NonPolar},c,s,S&H0&v2,F,Cl,Br,I]
@@ -373,7 +373,7 @@ Note that ``{Carbon_NonPolar}`` is used in the new AtomType definition without a
 
 
 Repeating an AtomType results in the two definitions being combined using the SMARTS "," (or) operator.
-Here's an example:: 
+Here's an example::
 
   AtomType d1 [N&!H0]
   AtomType d1 [O&!H0]
@@ -396,7 +396,7 @@ It is also possible to define negative AtomType queries::
   AtomType d1 [N,O,S]
   AtomType !d1 [H0]
 
-The negative query gets combined with the first to produce a definition identical to this:: 
+The negative query gets combined with the first to produce a definition identical to this::
 
   AtomType d1 [!H0;N,O,S]
 
@@ -407,7 +407,7 @@ Note that the negative AtomType is added to the beginning of the query.
 Feature definitions
 -------------------
 
-A feature definition is more complex than an AtomType definition and stretches across multiple lines:: 
+A feature definition is more complex than an AtomType definition and stretches across multiple lines::
 
   DefineFeature HDonor1 [N,O;!H0]
   Family HBondDonor
@@ -428,16 +428,16 @@ Additional syntax notes:
 ------------------------
 
 - Any line that begins with a # symbol is considered a comment and will be ignored.
-- A backslash character, \, at the end of a line is a continuation character, it indicates that the data from that line is continued on the next line of the file.  Blank space at the beginning of these additional lines is ignored. For example, this AtomType definition:: 
+- A backslash character, \, at the end of a line is a continuation character, it indicates that the data from that line is continued on the next line of the file.  Blank space at the beginning of these additional lines is ignored. For example, this AtomType definition::
 
     AtomType tButylAtom [$([C;!R](-[CH3])(-[CH3])(-[CH3])),\
     $([CH3](-[C;!R](-[CH3])(-[CH3])))]
 
-  is exactly equivalent to this one:: 
+  is exactly equivalent to this one::
 
     AtomType tButylAtom [$([C;!R](-[CH3])(-[CH3])(-[CH3])),$([CH3](-[C;!R](-[CH3])(-[CH3])))]
 
-  (though the first form is much easier to read!) 
+  (though the first form is much easier to read!)
 
 
 Atom weights and feature locations
@@ -447,7 +447,7 @@ Atom weights and feature locations
 Frequently Asked Question(s)
 ============================
 
-- What happens if a Feature Type is repeated in the file? Here's an example:: 
+- What happens if a Feature Type is repeated in the file? Here's an example::
 
     DefineFeature HDonor1 [O&!H0]
     Family HBondDonor
@@ -460,7 +460,7 @@ Frequently Asked Question(s)
     EndFeature
 
   In this case both definitions of the HDonor1 feature type will be active.
-  This is functionally identical to:: 
+  This is functionally identical to::
 
     DefineFeature HDonor1 [O,N;!H0]
     Family HBondDonor
@@ -468,7 +468,7 @@ Frequently Asked Question(s)
     EndFeature
 
   **However** the formulation of this feature definition with a duplicated feature type is considerably less efficient and more confusing than the simpler combined definition.
-  
+
 
 
 Representation of Pharmacophore Fingerprints
@@ -495,7 +495,7 @@ case when the query molecule is derived from a mol block or SMILES.
 
 The general rule used in the RDKit is that if you
 don't specify a property in the query, then it's not used as part of
-the matching criteria and that Hs are ignored. 
+the matching criteria and that Hs are ignored.
 This leads to the following behavior:
 
 +----------+---------+-------+
@@ -578,7 +578,74 @@ True
 False
 
 
+Molecular Sanitization
+**********************
 
+The molecule parsing functions all, by default, perform a "sanitization"
+operation on the molecules read. The idea is to generate useful computed
+properties (like hybridization, ring membership, etc.) for the rest of the code
+and to ensure that the molecules are "reasonable": that they can be represented
+with octet-complete Lewis dot structures.
+
+Here are the steps involved, in order.
+
+  1. ``clearComputedProps``: removes any computed properties that already exist
+      on the molecule and its atoms and bonds. This step is always performed.
+
+  2. ``cleanUp``: standardizes a small number of non-standard valence states.
+     The clean up operations are:
+
+      - Neutral 5 valent Ns with double bonds to Os are converted
+        to the zwitterionic form.
+        Example: ``N(=O)=O -> [N+](=O)O-]``
+
+      - Neutral 5 valent Ns with triple bonds to another N are converted
+        to the zwitterionic form.
+        Example: ``C-N=N#N -> C-N=[N+]=[N-]``
+
+      - Neutral 5 valent phosphorus with one double bond to an O and another to
+        either a C or a P are converted to the zwitterionic form.
+        Example: ``C=P(=O)O -> C=[P+]([O-])O``
+
+      - Neutral Cl, Br, or I with exclusively O neighbors, and a valence of 3,
+        5, or 7, are converted to the zwitterionic form. This covers things
+        like chlorous acid, chloric acid, and perchloric acid.
+        Example: ``O=Cl(=O)O -> [O-][Cl+2][O-]O``
+
+     This step should not generate execptions.
+
+  3. ``updatePropertyCache``: calculates the explicit and implicit valences on
+     all atoms. This generates exceptions for atoms in higher-than-allowed
+     valence states. This step is always performed, but if it is "skipped"
+     the test for non-standard valences will not be carried out.
+
+  4. ``symmetrizeSSSR``: calls the symmetrized smallest set of smallest rings
+     algorithm (discussed in the Getting Started document).
+
+  5. ``Kekulize``: converts aromatic rings to their Kekule form. Will raise an
+     exception if a ring cannot be kekulized or if aromatic bonds are found
+     outside of rings.
+
+  6. ``assignRadicals``: determines the number of radical electrons (if any) on
+     each atom.
+
+  7. ``setAromaticity``: identifies the aromatic rings and ring systems
+     (see above), sets the aromatic flag on atoms and bonds, sets bond orders
+     to aromatic.
+
+  8. ``setConjugation``: identifies which bonds are conjugated
+
+  9. ``setHybridization``: calculates the hybridization state of each atom
+
+  10. ``cleanupChirality``: removes chiral tags from atoms that are not sp3
+      hybridized.
+
+  11. ``adjustHs``: adds explicit Hs where necessary to preserve the chemistry.
+      This is typically needed for heteroatoms in aromatic rings. The classic
+      example is the nitrogen atom in pyrrole.
+
+The individual steps can be toggled on or off when calling
+``MolOps::sanitizeMol`` or ``Chem.SanitizeMol``.
 
 Implementation Details
 **********************
@@ -592,7 +659,7 @@ ROMol  (Mol in Python)
 ------------------------
 
 +------------------------+---------------------------------------------------+
-| Property Name          | Use                                               | 
+| Property Name          | Use                                               |
 +========================+===================================================+
 | MolFileComments        |   Read from/written to the comment line of CTABs. |
 +------------------------+---------------------------------------------------+
@@ -609,7 +676,7 @@ Atom
 ----
 
 +------------------------+-------------------------------------------------------------------------------------------------+
-| Property Name          | Use                                                                                             | 
+| Property Name          | Use                                                                                             |
 +========================+=================================================================================================+
 | _CIPCode               | the CIP code (R or S) of the atom                                                               |
 +------------------------+-------------------------------------------------------------------------------------------------+
@@ -631,7 +698,7 @@ Atom
 +------------------------+-------------------------------------------------------------------------------------------------+
 | molFileValue           | the mol file value for an atom (follows V tags), read from/written to CTABs                     |
 +------------------------+-------------------------------------------------------------------------------------------------+
-| molFileInversionFlag   | used to flag whether stereochemistry at an atom changes in a reaction,                          | 
+| molFileInversionFlag   | used to flag whether stereochemistry at an atom changes in a reaction,                          |
 |                        | read from/written to CTABs, determined automatically from SMILES                                |
 +------------------------+-------------------------------------------------------------------------------------------------+
 | molRxnComponent        | which component of a reaction an atom belongs to, read from/written to CTABs                    |
@@ -711,7 +778,7 @@ License
 
 .. image:: images/picture_5.png
 
-This document is copyright (C) 2007-2015 by Greg Landrum
+This document is copyright (C) 2007-2016 by Greg Landrum
 
 This work is licensed under the Creative Commons Attribution-ShareAlike 3.0 License.
 To view a copy of this license, visit http://creativecommons.org/licenses/by-sa/3.0/ or send a letter to Creative Commons, 543 Howard Street, 5th Floor, San Francisco, California, 94105, USA.
@@ -719,4 +786,3 @@ To view a copy of this license, visit http://creativecommons.org/licenses/by-sa/
 
 The intent of this license is similar to that of the RDKit itself.
 In simple words: “Do whatever you want with it, but please give us some credit.”
-


### PR DESCRIPTION
The `cleanUp` function previously just handled perchloric acid. This generalizes it to handle chloric and chlorous acids as well, along with the corresponding Br and I equivalents.
The idea is to be able to handle these species, which have perfectly reasonable octet-satisfied Lewis dot structures, without requiring the addition of new valence states to the halogens.