### PR TITLE
Attempt to fix crash while running testGithub497() on Windows with Python 3.x

### DIFF
--- a/Code/GraphMol/FileParsers/MolWriters.h
+++ b/Code/GraphMol/FileParsers/MolWriters.h
@@ -76,21 +76,23 @@ class SmilesWriter : public MolWriter {
   //! \brief flush the ostream
   void flush() {
     PRECONDITION(dp_ostream, "no output stream");
-    dp_ostream->flush();
-  };
-
-  //! \brief close our stream (the writer cannot be used again)
-  void close() {
-    PRECONDITION(dp_ostream, "no output stream");
     try {
       dp_ostream->flush();
     } catch (...) {
     }
+  };
+
+  //! \brief close our stream (the writer cannot be used again)
+  void close() {
+    flush();
     std::ostream *tmp_ostream = dp_ostream;
     dp_ostream = NULL;
     if (df_owner) {
-      delete tmp_ostream;
       df_owner = false;
+      try {
+        delete tmp_ostream;
+      } catch (...) {
+      }
     }
   };
 
@@ -150,21 +152,23 @@ class SDWriter : public MolWriter {
   //! \brief flush the ostream
   void flush() {
     PRECONDITION(dp_ostream, "no output stream");
-    dp_ostream->flush();
-  };
-
-  //! \brief close our stream (the writer cannot be used again)
-  void close() {
-    PRECONDITION(dp_ostream, "no output stream");
     try {
       dp_ostream->flush();
     } catch (...) {
     }
+  };
+
+  //! \brief close our stream (the writer cannot be used again)
+  void close() {
+    flush();
     std::ostream *tmp_ostream = dp_ostream;
     dp_ostream = NULL;
     if (df_owner) {
-      delete tmp_ostream;
       df_owner = false;
+      try {
+        delete tmp_ostream;
+      } catch (...) {
+      }
     }
   };
 

--- a/Code/GraphMol/FileParsers/MolWriters.h
+++ b/Code/GraphMol/FileParsers/MolWriters.h
@@ -79,6 +79,10 @@ class SmilesWriter : public MolWriter {
     try {
       dp_ostream->flush();
     } catch (...) {
+      try {
+        dp_ostream->setstate(std::ios::badbit);
+      } catch (const std::runtime_error& e) {
+      }
     }
   };
 
@@ -89,10 +93,7 @@ class SmilesWriter : public MolWriter {
     dp_ostream = NULL;
     if (df_owner) {
       df_owner = false;
-      try {
-        delete tmp_ostream;
-      } catch (...) {
-      }
+      delete tmp_ostream;
     }
   };
 
@@ -155,6 +156,10 @@ class SDWriter : public MolWriter {
     try {
       dp_ostream->flush();
     } catch (...) {
+      try {
+        dp_ostream->setstate(std::ios::badbit);
+      } catch (const std::runtime_error& e) {
+      }
     }
   };
 
@@ -165,10 +170,7 @@ class SDWriter : public MolWriter {
     dp_ostream = NULL;
     if (df_owner) {
       df_owner = false;
-      try {
-        delete tmp_ostream;
-      } catch (...) {
-      }
+      delete tmp_ostream;
     }
   };
 

--- a/Code/GraphMol/FileParsers/MolWriters.h
+++ b/Code/GraphMol/FileParsers/MolWriters.h
@@ -80,7 +80,8 @@ class SmilesWriter : public MolWriter {
       dp_ostream->flush();
     } catch (...) {
       try {
-        dp_ostream->setstate(std::ios::badbit);
+        if (dp_ostream->good())
+          dp_ostream->setstate(std::ios::badbit);
       } catch (const std::runtime_error& e) {
       }
     }
@@ -157,7 +158,8 @@ class SDWriter : public MolWriter {
       dp_ostream->flush();
     } catch (...) {
       try {
-        dp_ostream->setstate(std::ios::badbit);
+        if (dp_ostream->good())
+          dp_ostream->setstate(std::ios::badbit);
       } catch (const std::runtime_error& e) {
       }
     }
@@ -223,21 +225,25 @@ class TDTWriter : public MolWriter {
   //! \brief flush the ostream
   void flush() {
     PRECONDITION(dp_ostream, "no output stream");
-    dp_ostream->flush();
+    try {
+      dp_ostream->flush();
+    } catch (...) {
+      try {
+        if (dp_ostream->good())
+          dp_ostream->setstate(std::ios::badbit);
+      } catch (const std::runtime_error& e) {
+      }
+    }
   };
 
   //! \brief close our stream (the writer cannot be used again)
   void close() {
-    PRECONDITION(dp_ostream, "no output stream");
-    try {
-      dp_ostream->flush();
-    } catch (...) {
-    }
+    flush();
     std::ostream *tmp_ostream = dp_ostream;
     dp_ostream = NULL;
     if (df_owner) {
-      delete tmp_ostream;
       df_owner = false;
+      delete tmp_ostream;
     }
   };
 
@@ -283,21 +289,25 @@ class PDBWriter : public MolWriter {
   //! \brief flush the ostream
   void flush() {
     PRECONDITION(dp_ostream, "no output stream");
-    dp_ostream->flush();
+    try {
+      dp_ostream->flush();
+    } catch (...) {
+      try {
+        if (dp_ostream->good())
+          dp_ostream->setstate(std::ios::badbit);
+      } catch (const std::runtime_error& e) {
+      }
+    }
   };
 
   //! \brief close our stream (the writer cannot be used again)
   void close() {
-    PRECONDITION(dp_ostream, "no output stream");
-    try {
-      dp_ostream->flush();
-    } catch (...) {
-    }
+    flush();
     std::ostream *tmp_ostream = dp_ostream;
     dp_ostream = NULL;
     if (df_owner) {
-      delete tmp_ostream;
       df_owner = false;
+      delete tmp_ostream;
     }
   };
 


### PR DESCRIPTION
I could reproduce the crash on my system when I invoked flush() on the SDWriter(); the crash happened when I quit the Python interpreter because ~SDWriter() was invoked and the boost_adaptbx::python::streambuf destructor throws an exception upon flushing the stream itself.
Wrapping the destruction of the streambuf in a try...catch block should fix the issue for you too, hopefully.
