### PR TITLE
Autodetect boost c++ library and compile with matching one

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -182,6 +182,29 @@ else(RDK_BUILD_PYTHON_WRAPPERS)
   find_package(Boost 1.39.0 REQUIRED)
 endif(RDK_BUILD_PYTHON_WRAPPERS)
 
+if(APPLE)
+  # always required
+  set(T_LIBS ${Boost_LIBRARIES})
+  find_package(Boost 1.39.0 COMPONENTS regex REQUIRED)
+  
+  # reset boost libraries so python is still there
+  #  if it had been found before
+  set(Boost_LIBRARIES ${T_LIBS})
+
+  MESSAGE("== OSX: CHECKING for libc++")
+  execute_process( COMMAND /usr/bin/otool "-L" "${Boost_REGEX_LIBRARY_RELEASE}"
+                   OUTPUT_VARIABLE LIBCPP
+                   ERROR_VARIABLE ERR)
+
+  if(LIBCPP MATCHES ".*libc[+][+].*")
+     MESSAGE("== BOOST USES LIBC++")
+     SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -stdlib=libc++")
+   else()
+     MESSAGE("== BOOST USES STDLIBC++")
+     # FOR CXX11 support SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+  endif()
+endif(APPLE)
+
 include_directories(${Boost_INCLUDE_DIRS})
 link_directories(${Boost_LIBRARY_DIRS})
 


### PR DESCRIPTION
This was buried in the extended travis-builds patch.  It automatically configures libc++ on APPLE when boost has been linked to it.