### PR TITLE
Fixed a bug in getUFFAngleBendParams()

### DIFF
--- a/Code/GraphMol/ForceFieldHelpers/UFF/AtomTyper.cpp
+++ b/Code/GraphMol/ForceFieldHelpers/UFF/AtomTyper.cpp
@@ -433,7 +433,7 @@ bool getUFFAngleBendParams(const ROMol &mol, unsigned int idx1,
     double bondOrder23 = bond[1]->getBondTypeAsDouble();
     uffAngleBendParams.theta0 = RAD2DEG * paramVect[1]->theta0;
     uffAngleBendParams.ka = Utils::calcAngleForceConstant(
-        uffAngleBendParams.theta0, bondOrder12, bondOrder23, paramVect[0],
+        paramVect[1]->theta0, bondOrder12, bondOrder23, paramVect[0],
         paramVect[1], paramVect[2]);
   }
   return res;

--- a/Code/GraphMol/ForceFieldHelpers/UFF/testUFFHelpers.cpp
+++ b/Code/GraphMol/ForceFieldHelpers/UFF/testUFFHelpers.cpp
@@ -996,7 +996,7 @@ void testUFFParamGetters() {
     ForceFields::UFF::UFFAngle uffAngleBendParams;
     TEST_ASSERT(UFF::getUFFAngleBendParams(*molH, 6, 7, 8, uffAngleBendParams));
     TEST_ASSERT(
-        ((int)boost::math::round(uffAngleBendParams.ka * 1000) == 143325) &&
+        ((int)boost::math::round(uffAngleBendParams.ka * 1000) == 303297) &&
         ((int)boost::math::round(uffAngleBendParams.theta0 * 1000) == 109470));
     TEST_ASSERT(
         !UFF::getUFFAngleBendParams(*molH, 0, 7, 8, uffAngleBendParams));

--- a/Code/GraphMol/ForceFieldHelpers/Wrap/testHelpers.py
+++ b/Code/GraphMol/ForceFieldHelpers/Wrap/testHelpers.py
@@ -211,7 +211,7 @@ M  END"""
     self.failIf(uffBondStretchParams)
     uffAngleBendParams = ChemicalForceFields.GetUFFAngleBendParams(m, 6, 7, 8)
     self.failUnless(uffAngleBendParams)
-    self.failUnless((int(round(uffAngleBendParams[0] * 1000) == 143325))
+    self.failUnless((int(round(uffAngleBendParams[0] * 1000) == 303297))
       and (int(round(uffAngleBendParams[1] * 1000) == 109470)));
     uffAngleBendParams = ChemicalForceFields.GetUFFAngleBendParams(m, 0, 7, 8)
     self.failIf(uffAngleBendParams)


### PR DESCRIPTION
There was a bug in getUFFAngleBendParams(), where the theta0 value (in radians) was multiplied by the RAD2DEG conversion factor before being returned to the user (which is correct, since theta0 values in the UFF parameters are given in radians), but then, instead of the original theta0 value in radians, the value in degrees was passed to Utils::calcAngleForceConstant(), which is obviously wrong.
I also fixed the relevant tests.