### PR TITLE
stop including isotope labels in reduceProductToSideChains()

### DIFF
--- a/Code/GraphMol/ChemReactions/ReactionRunner.cpp
+++ b/Code/GraphMol/ChemReactions/ReactionRunner.cpp
@@ -1037,7 +1037,6 @@ ROMol *reduceProductToSideChains(const ROMOL_SPTR &product,
               PRECONDITION(at,
                            "Internal error in reduceProductToSideChains, bad "
                            "atom retrieval");
-              at->setIsotope(atommapno);
               at->setProp(common_properties::molAtomMapNumber, atommapno);
             }
           }

--- a/Code/GraphMol/ChemReactions/Wrap/rdChemReactions.cpp
+++ b/Code/GraphMol/ChemReactions/Wrap/rdChemReactions.cpp
@@ -211,16 +211,15 @@ void RemoveUnmappedProductTemplates(ChemicalReaction *self,
   }
 }
 
-void RemoveAgentTemplates(ChemicalReaction &self, python::object targetList){
-  if(targetList==python::object()){
-      self.removeAgentTemplates();
-  }
-  else{
+void RemoveAgentTemplates(ChemicalReaction &self, python::object targetList) {
+  if (targetList == python::object()) {
+    self.removeAgentTemplates();
+  } else {
     MOL_SPTR_VECT tmp;
     self.removeAgentTemplates(&tmp);
     python::list molList = python::extract<python::list>(targetList);
-    if(tmp.size() > 0){
-      for(unsigned int i = 0; i < tmp.size(); i++){
+    if (tmp.size() > 0) {
+      for (unsigned int i = 0; i < tmp.size(); i++) {
         molList.append(tmp[i]);
       }
     }
@@ -416,9 +415,10 @@ Sample Usage:\n\
            "Removes molecules with an atom mapping ratio below "
            "thresholdUnmappedAtoms from product templates to the agent "
            "templates or to a given targetList")
-      .def("RemoveAgentTemplates",RDKit::RemoveAgentTemplates,
-           (python::arg("self"), python::arg("targetList")=python::object()),
-           "Removes agents from reaction. If targetList is provide the agents will be transfered to that list.")
+      .def("RemoveAgentTemplates", RDKit::RemoveAgentTemplates,
+           (python::arg("self"), python::arg("targetList") = python::object()),
+           "Removes agents from reaction. If targetList is provide the agents "
+           "will be transfered to that list.")
       .def("RunReactants", (PyObject * (*)(RDKit::ChemicalReaction *,
                                            python::tuple))RDKit::RunReactants,
            "apply the reaction to a sequence of reactant molecules and return "
@@ -612,10 +612,11 @@ of the replacements argument.",
       "ReduceProductToSideChains", RDKit::reduceProductToSideChains,
       (python::arg("product"), python::arg("addDummyAtoms") = true),
       "reduce the product of a reaction to the side chains added by the reaction.\
-              The output is a molecule with attached wildcards indicating where the product was attached.  The isotope of the dummy atom\
-              is the reaction map number of the product's atom (if avialable).",
+              The output is a molecule with attached wildcards indicating where the product was attached.\
+              The dummy atom has the same reaction-map number as the product atom (if available).",
       python::return_value_policy<python::manage_new_object>());
-  python::def("RemoveMappingNumbersFromReactions",RDKit::removeMappingNumbersFromReactions,
-          (python::arg("reaction")),
-          "Removes the mapping numbers from the molecules of a reaction");
+  python::def("RemoveMappingNumbersFromReactions",
+              RDKit::removeMappingNumbersFromReactions,
+              (python::arg("reaction")),
+              "Removes the mapping numbers from the molecules of a reaction");
 }

--- a/Code/GraphMol/ChemReactions/Wrap/testReactionWrapper.py
+++ b/Code/GraphMol/ChemReactions/Wrap/testReactionWrapper.py
@@ -2,19 +2,19 @@
 #
 #  Copyright (c) 2007-2014, Novartis Institutes for BioMedical Research Inc.
 #  All rights reserved.
-# 
+#
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are
-# met: 
+# met:
 #
-#     * Redistributions of source code must retain the above copyright 
+#     * Redistributions of source code must retain the above copyright
 #       notice, this list of conditions and the following disclaimer.
 #     * Redistributions in binary form must reproduce the above
-#       copyright notice, this list of conditions and the following 
-#       disclaimer in the documentation and/or other materials provided 
+#       copyright notice, this list of conditions and the following
+#       disclaimer in the documentation and/or other materials provided
 #       with the distribution.
-#     * Neither the name of Novartis Institutes for BioMedical Research Inc. 
-#       nor the names of its contributors may be used to endorse or promote 
+#     * Neither the name of Novartis Institutes for BioMedical Research Inc.
+#       nor the names of its contributors may be used to endorse or promote
 #       products derived from this software without specific prior written permission.
 #
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
@@ -81,7 +81,7 @@ class TestCase(unittest.TestCase) :
       ps = rxn.RunReactants(list(reacts))
       self.assertTrue(len(ps)==1)
       self.assertTrue(len(ps[0])==1)
-      self.assertTrue(ps[0][0].GetNumAtoms()==3)    
+      self.assertTrue(ps[0][0].GetNumAtoms()==3)
 
   def test2DaylightParser(self):
     rxna = rdChemReactions.ReactionFromSmarts('[C:1](=[O:2])O.[N:3]>>[C:1](=[O:2])[N:3]')
@@ -95,13 +95,13 @@ class TestCase(unittest.TestCase) :
       ps = rxn.RunReactants(reacts)
       self.assertTrue(len(ps)==1)
       self.assertTrue(len(ps[0])==1)
-      self.assertTrue(ps[0][0].GetNumAtoms()==3)  
+      self.assertTrue(ps[0][0].GetNumAtoms()==3)
 
       reacts = (Chem.MolFromSmiles('CC(=O)OC'),Chem.MolFromSmiles('CN'))
       ps = rxn.RunReactants(reacts)
       self.assertTrue(len(ps)==1)
       self.assertTrue(len(ps[0])==1)
-      self.assertTrue(ps[0][0].GetNumAtoms()==5)  
+      self.assertTrue(ps[0][0].GetNumAtoms()==5)
 
   def test3MDLParsers(self):
     fileN = os.path.join(self.dataDir,'AmideBond.rxn')
@@ -117,11 +117,11 @@ class TestCase(unittest.TestCase) :
       ps = rxn.RunReactants(reacts)
       self.assertTrue(len(ps)==1)
       self.assertTrue(len(ps[0])==1)
-      self.assertTrue(ps[0][0].GetNumAtoms()==3)  
+      self.assertTrue(ps[0][0].GetNumAtoms()==3)
 
       with open(fileN, 'r') as rxnF:
         rxnBlock = rxnF.read()
-      rxn = rdChemReactions.ReactionFromRxnBlock(rxnBlock) 
+      rxn = rdChemReactions.ReactionFromRxnBlock(rxnBlock)
       self.assertTrue(rxn)
 
       self.assertTrue(rxn.GetNumReactantTemplates()==2)
@@ -131,7 +131,7 @@ class TestCase(unittest.TestCase) :
       ps = rxn.RunReactants(reacts)
       self.assertTrue(len(ps)==1)
       self.assertTrue(len(ps[0])==1)
-      self.assertTrue(ps[0][0].GetNumAtoms()==3)  
+      self.assertTrue(ps[0][0].GetNumAtoms()==3)
 
   def test4ErrorHandling(self):
     self.assertRaises(ValueError,lambda x='[C:1](=[O:2])Q.[N:3]>>[C:1](=[O:2])[N:3]':rdChemReactions.ReactionFromSmarts(x))
@@ -174,7 +174,7 @@ $MOL
 M  END
     """
     self.assertRaises(ValueError,lambda x=block:rdChemReactions.ReactionFromRxnBlock(x))
-        
+
     block="""$RXN
 
       ISIS     082120061354
@@ -378,7 +378,7 @@ M  END
     p1 = rxn.GetProductTemplate(0)
     sma=Chem.MolToSmarts(p1)
     self.assertEqual(sma,'[C:1]-,:[O:2]')
-    
+
     p2 = rxn.GetProductTemplate(1)
     sma=Chem.MolToSmarts(p2)
     self.assertEqual(sma,'[N:3]')
@@ -397,7 +397,7 @@ M  END
     self.assertTrue(rxn.IsMoleculeProduct(Chem.MolFromSmiles('NC(=O)C')))
     self.assertTrue(rxn.IsMoleculeProduct(Chem.MolFromSmiles('CNC(=O)C')))
     self.assertFalse(rxn.IsMoleculeProduct(Chem.MolFromSmiles('COC(=O)C')))
-    
+
   def test15Replacements(self):
     rxn = rdChemReactions.ReactionFromSmarts('[{amine}:1]>>[*:1]-C',
                                              replacements={'{amine}':'$([N;!H0;$(N-[#6]);!$(N-[!#6;!#1]);!$(N-C=[O,N,S])])'})
@@ -408,25 +408,25 @@ M  END
     self.assertEqual(len(ps),1)
     self.assertEqual(len(ps[0]),1)
     self.assertEqual(ps[0][0].GetNumAtoms(),4)
-    
+
   def test16GetReactingAtoms(self):
     rxn = rdChemReactions.ReactionFromSmarts("[O:1][C:2].[N:3]>>[N:1][C:2].[N:3]")
     self.assertTrue(rxn)
     rxn.Initialize()
     rAs = rxn.GetReactingAtoms()
     self.assertEqual(len(rAs),2)
-    self.assertEqual(len(rAs[0]),1)    
-    self.assertEqual(len(rAs[1]),0)    
+    self.assertEqual(len(rAs[0]),1)
+    self.assertEqual(len(rAs[1]),0)
 
     rxn = rdChemReactions.ReactionFromSmarts("[O:1]C>>[O:1]C")
     self.assertTrue(rxn)
     rxn.Initialize()
     rAs = rxn.GetReactingAtoms()
     self.assertEqual(len(rAs),1)
-    self.assertEqual(len(rAs[0]),2)    
+    self.assertEqual(len(rAs[0]),2)
     rAs = rxn.GetReactingAtoms(True)
     self.assertEqual(len(rAs),1)
-    self.assertEqual(len(rAs[0]),1)   
+    self.assertEqual(len(rAs[0]),1)
 
   def test17AddRecursiveQueriesToReaction(self):
     rxn = rdChemReactions.ReactionFromSmarts("[C:1][O:2].[N:3]>>[C:1][N:2]")
@@ -474,7 +474,7 @@ M  END
     self.failUnless(rxn.GetNumReactantTemplates()==3)
     self.failUnless(rxn.GetNumProductTemplates()==2)
     self.failUnless(rxn.GetNumAgentTemplates()==0)
-    
+
     agentList=[]
     rxn.RemoveUnmappedReactantTemplates(moveToAgentTemplates=False, targetList=agentList)
     rxn.RemoveUnmappedProductTemplates(targetList=agentList)
@@ -536,10 +536,10 @@ M  END
     self.assertTrue(res)
     expected_result = [Chem.MolToSmiles(Chem.MolFromSmiles("C=CCNC(N)=S"))]
     expected_result.sort()
-    sidechains_expected_result = [Chem.MolToSmiles(Chem.MolFromSmiles("[1*:1]=S.[3*:3]CC=C"), isomericSmiles=True)]
+    sidechains_expected_result = [Chem.MolToSmiles(Chem.MolFromSmiles("[*:1]=S.[*:3]CC=C"), isomericSmiles=True)]
     sidechains_nodummy_expected_result = [ [0,[3,],[1,]], [3,[1,],[2,]] ]
     sidechains_nodummy = []
-    
+
     sidechains_expected_result.sort()
 
     for addDummy in [True, False]:
@@ -568,11 +568,11 @@ M  END
         self.assertEquals(sidechains, sidechains_expected_result)
       else:
         self.assertEquals(sidechains_nodummy, sidechains_nodummy_expected_result)
-        
+
 
     expected_result = [Chem.MolToSmiles(Chem.MolFromSmiles("NCNCc1ncc(Cl)cc1Br"))]
     expected_result.sort()
-    sidechains_expected_result = [Chem.MolToSmiles(Chem.MolFromSmiles("[2*:2]Cc1ncc(Cl)cc1Br"), isomericSmiles=True)]
+    sidechains_expected_result = [Chem.MolToSmiles(Chem.MolFromSmiles("[*:2]Cc1ncc(Cl)cc1Br"), isomericSmiles=True)]
     sidechains_expected_result.sort()
 
     res = rxn.RunReactant(reagents[1], 1)
@@ -593,7 +593,7 @@ M  END
     self.assertFalse(rxn.RunReactant(reagents[1], 0))
 
     # try a broken ring based side-chain
-    sidechains_expected_result = ['c1ccc2c(c1)nc1n2CC[2*:2]1']
+    sidechains_expected_result = ['c1ccc2c(c1)nc1n2CC[*:2]1']
     reactant = Chem.MolFromSmiles('c1ccc2c(c1)nc1n2CCN1')
     res = rxn.RunReactant(reactant, 1)
     result = []
@@ -617,7 +617,7 @@ M  END
     mol = Chem.AddHs(mol)
     m = rdChemReactions.ReduceProductToSideChains(mol)
     self.assertTrue(m.GetNumAtoms() == 0)
-    
-      
+
+
 if __name__ == '__main__':
   unittest.main()

--- a/Code/GraphMol/ChemReactions/testReaction.cpp
+++ b/Code/GraphMol/ChemReactions/testReaction.cpp
@@ -5715,7 +5715,7 @@ void test60RunSingleReactant() {
 
   {
     ROMOL_SPTR expected_result(SmilesToMol("C=CCNC(N)=S"));
-    ROMOL_SPTR expected_sidechain_result(SmilesToMol("[1*:1]=S.[3*:3]CC=C"));
+    ROMOL_SPTR expected_sidechain_result(SmilesToMol("[*:1]=S.[*:3]CC=C"));
     const bool isomericSmiles = true;
     std::string expected = MolToSmiles(*expected_result, isomericSmiles);
     std::string expected_sidechain =
@@ -5740,7 +5740,7 @@ void test60RunSingleReactant() {
 
   {
     ROMOL_SPTR expected_result(SmilesToMol("NCNCc1ncc(Cl)cc1Br"));
-    ROMOL_SPTR expected_sidechain_result(SmilesToMol("[2*:2]Cc1ncc(Cl)cc1Br"));
+    ROMOL_SPTR expected_sidechain_result(SmilesToMol("[*:2]Cc1ncc(Cl)cc1Br"));
     const bool isomericSmiles = true;
     std::string expected = MolToSmiles(*expected_result, isomericSmiles);
     std::string expected_sidechain =


### PR DESCRIPTION
The atom-map info is there and is sufficient, adding the redundant isotope info is just confusing