### PR TITLE
Fix building with system InChI

### DIFF
--- a/External/INCHI-API/CMakeLists.txt
+++ b/External/INCHI-API/CMakeLists.txt
@@ -54,6 +54,9 @@ if(RDK_BUILD_INCHI_SUPPORT)
                        src/ichi_io.c  
                        src/sha2.c           src/strutil.c  
                        src/util.c SHARED)
+      install(TARGETS Inchi DESTINATION ${RDKit_LibDir})
+      set(INCHI_LIBRARIES Inchi)
+      include_directories(${CMAKE_CURRENT_SOURCE_DIR}/src)
     else()
       if(NOT INCHI_FOUND)
         message(WARNING  "** NO INCHI SOFTWARE FOUND\n"
@@ -61,9 +64,6 @@ if(RDK_BUILD_INCHI_SUPPORT)
         set(RDK_BUILD_INCHI_SUPPORT OFF)
       endif()
     endif()
-    install(TARGETS Inchi DESTINATION ${RDKit_LibDir})
-    set(INCHI_LIBRARIES Inchi)
-    include_directories(${CMAKE_CURRENT_SOURCE_DIR}/src)
 
 endif(RDK_BUILD_INCHI_SUPPORT)
 


### PR DESCRIPTION
Recent changes to the InChI cmake process moved these lines so it attempts to add an inchi target even if compiling using the system InChI. This resulted in the following error:

    CMake Error at External/INCHI-API/CMakeLists.txt:64 (install):
    install TARGETS given target "Inchi" which does not exist in this directory.

This commit simply moves the lines back such that the inchi target is only added when downloading and compiling local inchi.