### PR TITLE
Fix out of range dereference in MCS code.

### DIFF
--- a/Code/GraphMol/FMCS/MaximumCommonSubgraph.cpp
+++ b/Code/GraphMol/FMCS/MaximumCommonSubgraph.cpp
@@ -1057,8 +1057,7 @@ bool MaximumCommonSubgraph::matchIncrementalFast(Seed& seed, unsigned itarget) {
                                          // Another atoms
       if (tb) {  // bond exists, check match with query molecule
         unsigned tbi = tb->getIdx();
-        unsigned qbi =
-            seed.MoleculeFragment.BondsIdx[newBondAnotherAtomSeedIdx];
+        unsigned qbi = seed.MoleculeFragment.BondsIdx[newBondSeedIdx];
         if (!match.VisitedTargetBonds[tbi])  // false if target bond is already
                                              // matched
           matched = target.BondMatchTable.at(qbi, tbi);


### PR DESCRIPTION
I was getting horrible segfaults where qbi was being set to 2359832 (or some large number), and BondTable.at(qbi, tbi) was subsequently crapping out.

I'm actually baffled by how this ever worked. Maybe it was because we were always growing contiguously (but it seems that even then, you'd have the number of seed bonds possibly be number of seed atoms - 1 for totally aliphatic chains). 