### PR TITLE
Adds the default index to the building block templates

### DIFF
--- a/rdkit/Chem/ChemUtils/TemplateExpand.py
+++ b/rdkit/Chem/ChemUtils/TemplateExpand.py
@@ -144,6 +144,7 @@ def _exploder(mol,depth,sidechains,core,chainIndices,autoNames=True,templateName
           else:
             bbNm = str(bb[1])
           r.SetProp('building_block_%d'%(bbI+1),bbNm)
+          r.SetProp('_idx_building_block_%d'%(bbI+1),str(bb[1]))
           for propN in bbMol.GetPropNames():
             r.SetProp('building_block_%d_%s'%(bbI+1,propN),bbMol.GetProp(propN))
         nDumped += 1

--- a/rdkit/Chem/ChemUtils/TemplateExpand.py
+++ b/rdkit/Chem/ChemUtils/TemplateExpand.py
@@ -144,7 +144,7 @@ def _exploder(mol,depth,sidechains,core,chainIndices,autoNames=True,templateName
           else:
             bbNm = str(bb[1])
           r.SetProp('building_block_%d'%(bbI+1),bbNm)
-          r.SetProp('_idx_building_block_%d'%(bbI+1),str(bb[1]))
+          r.SetIntProp('_idx_building_block_%d'%(bbI+1),bb[1])
           for propN in bbMol.GetPropNames():
             r.SetProp('building_block_%d_%s'%(bbI+1,propN),bbMol.GetProp(propN))
         nDumped += 1


### PR DESCRIPTION
The building_block_%d needed to be parsed to find the actual index, this just saves the the raw index.

This is used in some external regression tests that may be folded into at a later date.