### PR TITLE
Dev/filtercatalog functional groups

### DIFF
--- a/Code/GraphMol/ChemReactions/Wrap/testReactionWrapper.py
+++ b/Code/GraphMol/ChemReactions/Wrap/testReactionWrapper.py
@@ -447,6 +447,24 @@ M  END
     labels = rxn.AddRecursiveQueriesToReaction(qs,'query', getLabels=True)
     self.assertTrue(len(labels), 1)
 
+  def test17bAddRecursiveQueriesToReaction(self):
+    from rdkit.Chem import FilterCatalog
+    rxn = rdChemReactions.ReactionFromSmarts("[C:1][O:2].[N:3]>>[C:1][N:2]")
+    self.assertTrue(rxn)
+    rxn.Initialize()
+    rxn.GetReactantTemplate(0).GetAtomWithIdx(0).SetProp('query', 'carboxylicacid')
+    querydefs = {k.lower():v
+                 for k,v in FilterCatalog.GetFlattenedFunctionalGroupHierarchy().items()}
+    
+    self.assertTrue('CarboxylicAcid' in FilterCatalog.GetFlattenedFunctionalGroupHierarchy())
+    rxn.AddRecursiveQueriesToReaction(querydefs,
+                                      'query')
+    q = rxn.GetReactantTemplate(0)
+    m = Chem.MolFromSmiles('C(=O)[O-].N')
+    self.assertTrue(m.HasSubstructMatch(q))
+    m = Chem.MolFromSmiles('C.N')
+    self.assertFalse(m.HasSubstructMatch(q))
+    
   def test18GithubIssue16(self):
     rxn = rdChemReactions.ReactionFromSmarts("[F:1]>>[Cl:1]")
     self.assertTrue(rxn)

--- a/Code/GraphMol/FilterCatalog/CMakeLists.txt
+++ b/Code/GraphMol/FilterCatalog/CMakeLists.txt
@@ -22,6 +22,7 @@ rdkit_library(FilterCatalog
               FilterCatalog.cpp
               FilterCatalogEntry.cpp
               FilterMatchers.cpp
+              FunctionalGroupHierarchy.cpp
               LINK_LIBRARIES Subgraphs SubstructMatch SmilesParse
               GraphMol RDGeometryLib Catalogs RDGeneral ${Boost_SERIALIZATION_LIBRARY} )
 
@@ -29,6 +30,7 @@ rdkit_headers(FilterCatalogEntry.h
               FilterCatalog.h
               FilterMatcherBase.h
               FilterMatchers.h
+              FunctionalGroupHierarchy.h
               DEST GraphMol/FilterCatalog)
 
 add_subdirectory(Wrap)

--- a/Code/GraphMol/FilterCatalog/FilterCatalog.cpp
+++ b/Code/GraphMol/FilterCatalog/FilterCatalog.cpp
@@ -215,6 +215,15 @@ const std::vector<FilterCatalog::CONST_SENTRY> FilterCatalog::getMatches(
   return result;
 }
 
+const std::vector<FilterMatch> FilterCatalog::getFilterMatches(
+    const ROMol &mol) const {
+  std::vector<FilterMatch> result;
+  for (size_t i = 0; i < d_entries.size(); ++i) {
+    d_entries[i]->getFilterMatches(mol, result);
+  }
+  return result;
+}
+
 bool FilterCatalogCanSerialize() {
 #ifdef RDK_USE_BOOST_SERIALIZATION
   return true;

--- a/Code/GraphMol/FilterCatalog/FilterCatalog.h
+++ b/Code/GraphMol/FilterCatalog/FilterCatalog.h
@@ -221,12 +221,19 @@ class FilterCatalog : public FCatalog {
   */
   CONST_SENTRY getFirstMatch(const ROMol &mol) const;
 
-  //------------------------------------
-  //! Returns all matches to the molecule
+  //-------------------------------------------
+  //! Returns all entry matches to the molecule
   /*
     \param mol  ROMol to match against the catalog
   */
   const std::vector<CONST_SENTRY> getMatches(const ROMol &mol) const;
+
+  //--------------------------------------------
+  //! Returns all FilterMatches for the molecule
+  /*
+    \param mol  ROMol to match against the catalog
+  */
+  const std::vector<FilterMatch> getFilterMatches(const ROMol &mol) const;
 
  private:
   void Clear();

--- a/Code/GraphMol/FilterCatalog/FilterMatchers.cpp
+++ b/Code/GraphMol/FilterCatalog/FilterMatchers.cpp
@@ -134,8 +134,8 @@ bool FilterHierarchyMatcher::getMatches(const ROMol &mol,
   if (result) {
     std::vector<FilterMatch> children;
 
-    for (size_t i = 0; i < d_children.size() && result; ++i) {
-      d_children[i]->getMatches(mol, children);
+    BOOST_FOREACH(boost::shared_ptr<FilterHierarchyMatcher> matcher, d_children) {
+      matcher->getMatches(mol, children);
     }
 
     if (children.size()) {

--- a/Code/GraphMol/FilterCatalog/FilterMatchers.cpp
+++ b/Code/GraphMol/FilterCatalog/FilterMatchers.cpp
@@ -123,4 +123,29 @@ bool SmartsMatcher::hasMatch(const ROMol &mol) const {
             (d_max_count == UINT_MAX || count <= d_max_count));
   }
 }
+
+bool FilterHierarchyMatcher::getMatches(const ROMol &mol,
+                                        std::vector<FilterMatch> &m) const {
+  // a null matcher is root, just goes to the children
+
+  std::vector<FilterMatch> temp;
+  bool result = d_matcher->getMatches(mol, temp);
+
+  if (result) {
+    std::vector<FilterMatch> children;
+
+    for (size_t i = 0; i < d_children.size() && result; ++i) {
+      d_children[i]->getMatches(mol, children);
+    }
+
+    if (children.size()) {
+        m.insert(m.end(), children.begin(), children.end());      
+    } else {
+      m.insert(m.end(), temp.begin(), temp.end());
+    }
+  }
+
+  return result;
+}
+
 }

--- a/Code/GraphMol/FilterCatalog/FilterMatchers.h
+++ b/Code/GraphMol/FilterCatalog/FilterMatchers.h
@@ -449,6 +449,75 @@ class ExclusionList : public FilterMatcherBase {
 #endif
 };
 
+class FilterHierarchyMatcher : public FilterMatcherBase {
+  std::vector<boost::shared_ptr<FilterHierarchyMatcher> > d_children;
+  boost::shared_ptr<FilterMatcherBase> d_matcher;
+  
+public:
+  FilterHierarchyMatcher() : 
+    FilterMatcherBase(), 
+    d_matcher() {
+  }
+    
+  FilterHierarchyMatcher(const FilterMatcherBase &matcher) :
+    FilterMatcherBase(), 
+    d_matcher(matcher.Clone()) {
+  }
+  
+  virtual std::string getName() const {
+    if (d_matcher.get()) {
+      return d_matcher->getName();
+    }
+    return "FilterMatcherHierarchy root";
+  }
+
+  bool isValid() const {
+    return true;
+  }
+
+  void setPattern(const FilterMatcherBase & matcher) {
+    PRECONDITION(matcher.isValid(), "Adding invalid patterns is not allowed.");
+    d_matcher = matcher.Clone();
+    PRECONDITION(getName() == d_matcher->getName(), "Opps");
+  }
+
+  //! add a FilterHierarchy as a child.
+  //!  returns the FilterHierarchy pointer used in the tree (this is a
+  //!   shallow copy of the original)
+  boost::shared_ptr<FilterHierarchyMatcher> addChild(
+      const FilterHierarchyMatcher &hierarchy) {
+    PRECONDITION(hierarchy.d_matcher.get() && hierarchy.d_matcher->isValid(),
+                 "Only one root node is allowed in a FilterHierarchyMatcher");
+    
+    d_children.push_back( boost::shared_ptr<FilterHierarchyMatcher>(
+        new FilterHierarchyMatcher(hierarchy) ));
+    return d_children.back();
+  }
+
+  virtual bool getMatches(const ROMol &mol, std::vector<FilterMatch> &m) const;
+
+  virtual bool hasMatch(const ROMol &mol) const {
+    std::vector<FilterMatch> temp;
+    return getMatches(mol, temp);
+  }
+
+  virtual boost::shared_ptr<FilterMatcherBase> Clone() const {
+    return boost::shared_ptr<FilterMatcherBase>(new FilterHierarchyMatcher(*this));
+  }
+ private:
+#ifdef RDK_USE_BOOST_SERIALIZATION
+  friend class boost::serialization::access;
+  template <class Archive>
+  void serialize(Archive &ar, const unsigned int version) {
+    RDUNUSED_PARAM(version);
+    ar &boost::serialization::base_object<FilterMatcherBase>(*this);
+    ar &d_children;
+    ar &d_matcher;
+  }
+#endif
+  
+};
+
 #ifdef RDK_USE_BOOST_SERIALIZATION
 // Register all known filter matcher types for serialization
 template <class Archive>
@@ -458,6 +527,7 @@ void registerFilterMatcherTypes(Archive &ar) {
   ar.register_type(static_cast<FilterMatchOps::Not *>(NULL));
   ar.register_type(static_cast<SmartsMatcher *>(NULL));
   ar.register_type(static_cast<ExclusionList *>(NULL));
+  ar.register_type(static_cast<FilterMatcherHierarchy *>(NULL));
 }
 #endif
 }
@@ -465,6 +535,7 @@ void registerFilterMatcherTypes(Archive &ar) {
 #ifdef RDK_USE_BOOST_SERIALIZATION
 BOOST_CLASS_VERSION(RDKit::SmartsMatcher, 1)
 BOOST_CLASS_VERSION(RDKit::ExclusionList, 1)
+BOOST_CLASS_VERSION(RDKit::FilterMatcherHierarchy, 1)
 #endif
 
 #endif

--- a/Code/GraphMol/FilterCatalog/FilterMatchers.h
+++ b/Code/GraphMol/FilterCatalog/FilterMatchers.h
@@ -527,7 +527,7 @@ void registerFilterMatcherTypes(Archive &ar) {
   ar.register_type(static_cast<FilterMatchOps::Not *>(NULL));
   ar.register_type(static_cast<SmartsMatcher *>(NULL));
   ar.register_type(static_cast<ExclusionList *>(NULL));
-  ar.register_type(static_cast<FilterMatcherHierarchy *>(NULL));
+  ar.register_type(static_cast<FilterHierarchyMatcher *>(NULL));
 }
 #endif
 }
@@ -535,7 +535,7 @@ void registerFilterMatcherTypes(Archive &ar) {
 #ifdef RDK_USE_BOOST_SERIALIZATION
 BOOST_CLASS_VERSION(RDKit::SmartsMatcher, 1)
 BOOST_CLASS_VERSION(RDKit::ExclusionList, 1)
-BOOST_CLASS_VERSION(RDKit::FilterMatcherHierarchy, 1)
+BOOST_CLASS_VERSION(RDKit::FilterHierarchyMatcher, 1)
 #endif
 
 #endif

--- a/Code/GraphMol/FilterCatalog/FilterMatchers.h
+++ b/Code/GraphMol/FilterCatalog/FilterMatchers.h
@@ -454,16 +454,25 @@ class FilterHierarchyMatcher : public FilterMatcherBase {
   boost::shared_ptr<FilterMatcherBase> d_matcher;
   
 public:
+  // !Default Constructor for serialization
   FilterHierarchyMatcher() : 
     FilterMatcherBase(), 
     d_matcher() {
   }
-    
+  //! Constructs a FilterHierarchyMatcher from a FilterMatchBase
+  //!  A FilterHierarchyMatcher is a tree hierarchy where to
+  //!  match a child node, one needs to match the parent first.
+  //!  For each branch, the lowest nodes are returned when
+  //!   getting the filter matches.
+  /*
+      \param matcher FilterMatcherBase to match this node against
+  */
   FilterHierarchyMatcher(const FilterMatcherBase &matcher) :
     FilterMatcherBase(), 
     d_matcher(matcher.Clone()) {
   }
   
+  //! Return the name for this node (from the underlying FilterMatcherBase)
   virtual std::string getName() const {
     if (d_matcher.get()) {
       return d_matcher->getName();
@@ -471,10 +480,15 @@ public:
     return "FilterMatcherHierarchy root";
   }
 
+  //! returns true if this node has a valid matcher
   bool isValid() const {
-    return true;
+    return d_matcher->isValid();
   }
 
+  //! Set a new FilterMatcherBase for this node
+  /*
+    \param matcher The new FilterMatcherBase
+  */
   void setPattern(const FilterMatcherBase & matcher) {
     PRECONDITION(matcher.isValid(), "Adding invalid patterns is not allowed.");
     d_matcher = matcher.Clone();
@@ -484,6 +498,9 @@ public:
   //! add a FilterHierarchy as a child.
   //!  returns the FilterHierarchy pointer used in the tree (this is a
   //!   shallow copy of the original)
+  /*
+    \param hierarchy The new FilterHierarchyMatcher child for this node
+  */
   boost::shared_ptr<FilterHierarchyMatcher> addChild(
       const FilterHierarchyMatcher &hierarchy) {
     PRECONDITION(hierarchy.d_matcher.get() && hierarchy.d_matcher->isValid(),
@@ -494,13 +511,23 @@ public:
     return d_children.back();
   }
 
-  virtual bool getMatches(const ROMol &mol, std::vector<FilterMatch> &m) const;
+  //! returns the FilterMatches against the given molecule
+  /*
+    \param mol The molecule to match against
+    \param matches The vector of FilterMatch objects that match
+  */
+  virtual bool getMatches(const ROMol &mol, std::vector<FilterMatch> &matches) const;
 
+  //! Does this node match the molecule
+  /*
+    \param mol The molecule to match against
+  */
   virtual bool hasMatch(const ROMol &mol) const {
     std::vector<FilterMatch> temp;
     return getMatches(mol, temp);
   }
 
+  //! Clones the FilterHierarchyMatcher into a FilterMatcherBase
   virtual boost::shared_ptr<FilterMatcherBase> Clone() const {
     return boost::shared_ptr<FilterMatcherBase>(new FilterHierarchyMatcher(*this));
   }

--- a/Code/GraphMol/FilterCatalog/FunctionalGroupHierarchy.cpp
+++ b/Code/GraphMol/FilterCatalog/FunctionalGroupHierarchy.cpp
@@ -1,0 +1,195 @@
+//
+//  Copyright (c) 2016, Novartis Institutes for BioMedical Research Inc.
+//  All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+//       copyright notice, this list of conditions and the following
+//       disclaimer in the documentation and/or other materials provided
+//       with the distribution.
+//     * Neither the name of Novartis Institutes for BioMedical Research Inc.
+//       nor the names of its contributors may be used to endorse or promote
+//       products derived from this software without specific prior written
+//       permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+#include "FilterMatchers.h"
+#include "FilterCatalog.h"
+#include <GraphMol/SmilesParse/SmilesParse.h>
+#include <RDGeneral/BoostStartInclude.h>
+#include <boost/shared_ptr.hpp>
+#ifdef RDK_THREADSAFE_SSS
+#include <boost/thread/once.hpp>
+#endif
+#include <RDGeneral/BoostEndInclude.h>
+
+namespace RDKit {
+
+namespace {
+struct FuncData_t {
+  int level;
+  const char * name;
+  const char * smarts;
+  const char * label;
+  const char * removalReaction;
+};
+
+// Exploit the fact that the current hierarchy is a two level tree
+//  0 -> gets added to root node
+//  1 -> gets added to last 0 node
+const FuncData_t FuncDataArray[] = {
+  {0,"AcidChloride","C(=O)Cl","Acid Chloride",0},
+  {1,"AcidChloride.Aromatic","[$(C-!@[a])](=O)(Cl)","Aromatic",0},
+  {1,"AcidChloride.Aliphatic","[$(C-!@[A;!Cl])](=O)(Cl)","Aliphatic",0},
+  
+  {0,"CarboxylicAcid","C(=O)[O;H,-]","Carboxylic acid",0},
+  {1,"CarboxylicAcid.Aromatic","[$(C-!@[a])](=O)([O;H,-])","Aromatic",0},
+  {1,"CarboxylicAcid.Aliphatic","[$(C-!@[A;!O])](=O)([O;H,-])","Aliphatic",0},
+  {1,"CarboxylicAcid.AlphaAmino","[$(C-[C;!$(C=[!#6])]-[N;!H0;!$(N-[!#6;!#1]);!$(N-C=[O,N,S])])](=O)([O;H,-])","alpha Amino Acid",0},
+  
+  {0,"SulfonylChloride","[$(S-!@[#6])](=O)(=O)(Cl)","Sulfonyl Chloride",0},
+  {1,"SulfonylChloride.Aromatic","[$(S-!@c)](=O)(=O)(Cl)","Aromatic",0},
+  {1,"SulfonylChloride.Aliphatic","[$(S-!@C)](=O)(=O)(Cl)","Aliphatic",0},
+  
+  {0,"Amine","[N;$(N-[#6]);!$(N-[!#6;!#1]);!$(N-C=[O,N,S])]","Amine",0},
+  {1,"Amine.Primary","[N;H2;D1;$(N-!@[#6]);!$(N-C=[O,N,S])]","Primary",0},
+  {1,"Amine.Primary.Aromatic","[N;H2;D1;$(N-!@c);!$(N-C=[O,N,S])]","Primary aromatic",0},
+  {1,"Amine.Primary.Aliphatic","[N;H2;D1;$(N-!@C);!$(N-C=[O,N,S])]","Primary aliphatic",0},
+  {1,"Amine.Secondary","[N;H1;D2;$(N(-[#6])-[#6]);!$(N-C=[O,N,S])]","Secondary",0},
+  {1,"Amine.Secondary.Aromatic","[N;H1;D2;$(N(-[c])-[#6]);!$(N-C=[O,N,S])]","Secondary aromatic",0},
+  {1,"Amine.Secondary.Aliphatic","[N;H1;D2;$(N(-C)-C);!$(N-C=[O,N,S])]","Secondary aliphatic",0},
+  {1,"Amine.Tertiary","[N;H0;D3;$(N(-[#6])(-[#6])-[#6]);!$(N-C=[O,N,S])]","Tertiary",0},
+  {1,"Amine.Tertiary.Aromatic","[N;H0;D3;$(N(-[c])(-[#6])-[#6]);$(N-C=[O,N,S])]","Tertiary aromatic",0},
+  {1,"Amine.Tertiary.Aliphatic","[N;H0;D3;$(N(-C)(-C)-C);!$(N-C=[O,N,S])]","Tertiary aliphatic",0},
+  {1,"Amine.Aromatic","[N;$(N-c);!$(N-[!#6;!#1]);!$(N-C=[O,N,S])]","Aromatic",0},
+  {1,"Amine.Aliphatic","[N;!$(N-c);$(N-C);!$(N-[!#6;!#1]);!$(N-C=[O,N,S])]","Aliphatic",0},
+  {1,"Amine.Cyclic","[N;R;$(N-[#6]);!$(N-[!#6;!#1]);!$(N-C=[O,N,S])]","Cyclic",0},
+  
+  {0,"BoronicAcid","[$(B-!@[#6])](O)(O)","Boronic Acid","[#6:1]-!@[B:2]([O:3])[O:4]>>[#6:1][X].[B:2]([O:3])[O:4]"},
+  {1,"BoronicAcid.Aromatic","[$(B-!@c)](O)(O)","Aromatic","[c:1]-!@[B:2]([O:3])[O:4]>>[c:1][X].[B:2]([O:3])[O:4]"},
+  {1,"BoronicAcid.Aliphatic","[$(B-!@C)](O)(O)","Aliphatic","[C:1]-!@[B:2]([O:3])[O:4]>>[C:1][X].[B:2]([O:3])[O:4]"},
+  
+  {0,"Isocyanate","[$(N-!@[#6])](=!@C=!@O)","Isocyanate",0},
+  {1,"Isocyanate.Aromatic","[$(N-!@c)](=!@C=!@O)","Aromatic",0},
+  {1,"Isocyanate.Aliphatic","[$(N-!@C)](=!@C=!@O)","Aliphatic",0},
+  
+  {0,"Alcohol","[O;H1;$(O-!@[#6;!$(C=!@[O,N,S])])]","Alcohol",0},
+  {1,"Alcohol.Aromatic","[O;H1;$(O-!@c)]","Aromatic",0},
+  {1,"Alcohol.Aliphatic","[O;H1;$(O-!@[C;!$(C=!@[O,N,S])])]","Aliphatic",0},
+  
+  {0,"Aldehyde","[CH;D2;!$(C-[!#6;!#1])]=O","Aldehyde",0},
+  {1,"Aldehyde.Aromatic","[CH;D2;$(C-!@[a])](=O)","Aromatic",0},
+  {1,"Aldehyde.Aliphatic","[CH;D2;$(C-!@C)](=O)","Aliphatic",0},
+  
+  {0,"Halogen","[$([F,Cl,Br,I]-!@[#6]);!$([F,Cl,Br,I]-!@C-!@[F,Cl,Br,I]);!$([F,Cl,Br,I]-[C,S](=[O,S,N]))]","Halogen",0},
+  {1,"Halogen.Aromatic","[F,Cl,Br,I;$(*-!@c)]","Aromatic",0},
+  {1,"Halogen.Aliphatic","[$([F,Cl,Br,I]-!@C);!$([F,Cl,Br,I]-!@C-!@[F,Cl,Br,I])]","Aliphatic",0},
+  {1,"Halogen.NotFluorine","[$([Cl,Br,I]-!@[#6]);!$([Cl,Br,I]-!@C-!@[F,Cl,Br,I]);!$([Cl,Br,I]-[C,S](=[O,S,N]))]","Not Fluorine",0},
+  {2,"Halogen.NotFluorine.Aliphatic","[$([Cl,Br,I]-!@C);!$([Cl,Br,I]-!@C-!@[F,Cl,Br,I]);!$([Cl,Br,I]-[C,S](=[O,S,N]))]","Aliphatic Not Fluorine",0},
+  {2,"Halogen.NotFluorine.Aromatic","[$([Cl,Br,I]-!@c)]","Aromatic Not Fluorine",0},
+  {1,"Halogen.Bromine","[Br;$([Br]-!@[#6]);!$([Br]-!@C-!@[F,Cl,Br,I]);!$([Br]-[C,S](=[O,S,N]))]","Bromine",0},
+  {2,"Halogen.Bromine.Aliphatic","[Br;$(Br-!@C);!$(Br-!@C-!@[F,Cl,Br,I]);!$(Br-[C,S](=[O,S,N]))]","Aliphatic Bromine",0},
+  {2,"Halogen.Bromine.Aromatic","[Br;$(Br-!@c)]","Aromatic Bromine",0},
+  {2,"Halogen.Bromine.BromoKetone","[Br;$(Br-[CH2]-C(=O)-[#6])]","Bromoketone",0},
+
+  {0,"Azide","[N;H0;$(N-[#6]);D2]=[N;D2]=[N;D1]","Azide",0},
+  {1,"Azide.Aromatic","[N;H0;$(N-c);D2]=[N;D2]=[N;D1]","Aromatic Azide",0},
+  {1,"Azide.Aliphatic","[N;H0;$(N-C);D2]=[N;D2]=[N;D1]","Aliphatic Azide",0},
+  
+  {0,"Nitro","[N;H0;$(N-[#6]);D3](=[O;D1])~[O;D1]","Nitro",0},
+  {1,"Nitro.Aromatic","[N;H0;$(N-c);D3](=[O;D1])~[O;D1]","Aromatic Nitro",0},
+  {1,"Nitro.Aliphatic","[N;H0;$(N-C);D3](=[O;D1])~[O;D1]","Aliphatic Nitro",0},
+  
+  {0,"TerminalAlkyne","[C;$(C#[CH])]","Terminal Alkyne",0}
+};
+
+const unsigned int NUM_FUNCS =
+    static_cast<unsigned int>(sizeof(FuncDataArray) / sizeof(FuncData_t));
+
+FilterCatalog &hierarchy_get() {
+  static FilterCatalog fgroup;
+  return fgroup;
+}
+
+std::map<std::string, ROMOL_SPTR> &flatten_get() {
+  static std::map<std::string, ROMOL_SPTR> flattenedHierarchy;
+  return flattenedHierarchy;
+}
+
+void hierarchy_create() {
+  FilterCatalog & fgroupHierarchy = hierarchy_get();
+  std::map<std::string, ROMOL_SPTR> &flattenedHierarchy = flatten_get();
+  
+  std::vector<FilterHierarchyMatcher*>  toplevel;
+  std::vector<FilterHierarchyMatcher*>  stack(4); // max tree depth currently 4
+  
+  for (size_t i=0; i<NUM_FUNCS; ++i) {
+    // Make a new node
+    ROMOL_SPTR pattern(SmartsToMol(FuncDataArray[i].smarts,0, true));
+    pattern->setProp("Label", FuncDataArray[i].label);
+    if (FuncDataArray[i].removalReaction) {
+      pattern->setProp("RemovalReaction", FuncDataArray[i].removalReaction);
+    }
+    flattenedHierarchy[FuncDataArray[i].name] = pattern;
+    FilterHierarchyMatcher node(SmartsMatcher(FuncDataArray[i].name,
+                                              pattern));
+
+    if (FuncDataArray[i].level == 0) {
+      toplevel.push_back(new FilterHierarchyMatcher(node));
+      stack[0] = toplevel.back();
+      
+    } else {
+      boost::shared_ptr<FilterHierarchyMatcher> real_node = \
+          stack[FuncDataArray[i].level-1]->addChild(node);
+
+      stack[FuncDataArray[i].level] = real_node.get();
+    }
+  }
+
+  // add the top levels to the filter catalog and give them ownership
+  //  to the filter catalog
+  for(size_t i=0; i<toplevel.size(); ++i) {
+    fgroupHierarchy.addEntry(
+        new FilterCatalogEntry(toplevel[i]->getName(),
+                               boost::shared_ptr<FilterMatcherBase>(toplevel[i]) ));
+  }
+}
+}
+
+const FilterCatalog &GetFunctionalGroupHierarchy() {
+#ifdef RDK_THREADSAFE_SSS  
+  static boost::once_flag flag;
+  boost::call_once( &hierarchy_create, flag );
+#else
+  static bool loaded=false;
+  if(!loaded) {
+    hierarchy_create();
+    loaded=true;
+  }
+#endif  
+  return hierarchy_get();
+}
+
+const std::map<std::string, ROMOL_SPTR> &GetFlattenedFunctionalGroupHierarchy() {
+  GetFunctionalGroupHierarchy();
+  return flatten_get();
+}
+
+}

--- a/Code/GraphMol/FilterCatalog/FunctionalGroupHierarchy.cpp
+++ b/Code/GraphMol/FilterCatalog/FunctionalGroupHierarchy.cpp
@@ -159,6 +159,9 @@ void hierarchy_create() {
       stack[0] = toplevel.back();
       
     } else {
+      PRECONDITION(FuncDataArray[i].level < MAX_DEPTH,
+                   std::string("Invalid Depth in Built in Functional Group Hierarchy: ") +
+                   FuncDataArray[i].name);
       boost::shared_ptr<FilterHierarchyMatcher> real_node = \
           stack[FuncDataArray[i].level-1]->addChild(node);
 

--- a/Code/GraphMol/FilterCatalog/FunctionalGroupHierarchy.cpp
+++ b/Code/GraphMol/FilterCatalog/FunctionalGroupHierarchy.cpp
@@ -51,9 +51,12 @@ struct FuncData_t {
   const char * removalReaction;
 };
 
-// Exploit the fact that the current hierarchy is a two level tree
+// Exploit the fact that the current hierarchy is a three level tree
 //  0 -> gets added to root node
 //  1 -> gets added to last 0 node
+//  2 -> gets added to last 1 node
+const int MAX_DEPTH = 3;
+
 const FuncData_t FuncDataArray[] = {
   {0,"AcidChloride","C(=O)Cl","Acid Chloride",0},
   {1,"AcidChloride.Aromatic","[$(C-!@[a])](=O)(Cl)","Aromatic",0},
@@ -70,14 +73,14 @@ const FuncData_t FuncDataArray[] = {
   
   {0,"Amine","[N;$(N-[#6]);!$(N-[!#6;!#1]);!$(N-C=[O,N,S])]","Amine",0},
   {1,"Amine.Primary","[N;H2;D1;$(N-!@[#6]);!$(N-C=[O,N,S])]","Primary",0},
-  {1,"Amine.Primary.Aromatic","[N;H2;D1;$(N-!@c);!$(N-C=[O,N,S])]","Primary aromatic",0},
-  {1,"Amine.Primary.Aliphatic","[N;H2;D1;$(N-!@C);!$(N-C=[O,N,S])]","Primary aliphatic",0},
+  {2,"Amine.Primary.Aromatic","[N;H2;D1;$(N-!@c);!$(N-C=[O,N,S])]","Primary aromatic",0},
+  {2,"Amine.Primary.Aliphatic","[N;H2;D1;$(N-!@C);!$(N-C=[O,N,S])]","Primary aliphatic",0},
   {1,"Amine.Secondary","[N;H1;D2;$(N(-[#6])-[#6]);!$(N-C=[O,N,S])]","Secondary",0},
-  {1,"Amine.Secondary.Aromatic","[N;H1;D2;$(N(-[c])-[#6]);!$(N-C=[O,N,S])]","Secondary aromatic",0},
-  {1,"Amine.Secondary.Aliphatic","[N;H1;D2;$(N(-C)-C);!$(N-C=[O,N,S])]","Secondary aliphatic",0},
+  {2,"Amine.Secondary.Aromatic","[N;H1;D2;$(N(-[c])-[#6]);!$(N-C=[O,N,S])]","Secondary aromatic",0},
+  {2,"Amine.Secondary.Aliphatic","[N;H1;D2;$(N(-C)-C);!$(N-C=[O,N,S])]","Secondary aliphatic",0},
   {1,"Amine.Tertiary","[N;H0;D3;$(N(-[#6])(-[#6])-[#6]);!$(N-C=[O,N,S])]","Tertiary",0},
-  {1,"Amine.Tertiary.Aromatic","[N;H0;D3;$(N(-[c])(-[#6])-[#6]);$(N-C=[O,N,S])]","Tertiary aromatic",0},
-  {1,"Amine.Tertiary.Aliphatic","[N;H0;D3;$(N(-C)(-C)-C);!$(N-C=[O,N,S])]","Tertiary aliphatic",0},
+  {2,"Amine.Tertiary.Aromatic","[N;H0;D3;$(N(-[c])(-[#6])-[#6]);$(N-C=[O,N,S])]","Tertiary aromatic",0},
+  {2,"Amine.Tertiary.Aliphatic","[N;H0;D3;$(N(-C)(-C)-C);!$(N-C=[O,N,S])]","Tertiary aliphatic",0},
   {1,"Amine.Aromatic","[N;$(N-c);!$(N-[!#6;!#1]);!$(N-C=[O,N,S])]","Aromatic",0},
   {1,"Amine.Aliphatic","[N;!$(N-c);$(N-C);!$(N-[!#6;!#1]);!$(N-C=[O,N,S])]","Aliphatic",0},
   {1,"Amine.Cyclic","[N;R;$(N-[#6]);!$(N-[!#6;!#1]);!$(N-C=[O,N,S])]","Cyclic",0},
@@ -138,7 +141,7 @@ void hierarchy_create() {
   std::map<std::string, ROMOL_SPTR> &flattenedHierarchy = flatten_get();
   
   std::vector<FilterHierarchyMatcher*>  toplevel;
-  std::vector<FilterHierarchyMatcher*>  stack(4); // max tree depth currently 4
+  FilterHierarchyMatcher* stack[MAX_DEPTH];
   
   for (size_t i=0; i<NUM_FUNCS; ++i) {
     // Make a new node

--- a/Code/GraphMol/FilterCatalog/FunctionalGroupHierarchy.h
+++ b/Code/GraphMol/FilterCatalog/FunctionalGroupHierarchy.h
@@ -1,0 +1,43 @@
+//
+//  Copyright (c) 2016, Novartis Institutes for BioMedical Research Inc.
+//  All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+//       copyright notice, this list of conditions and the following
+//       disclaimer in the documentation and/or other materials provided
+//       with the distribution.
+//     * Neither the name of Novartis Institutes for BioMedical Research Inc.
+//       nor the names of its contributors may be used to endorse or promote
+//       products derived from this software without specific prior written
+//       permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+#ifndef RDKIT_FUNCTIONAL_GROUP_HIERARCHY_H
+#define RDKIT_FUNCTIONAL_GROUP_HIERARCHY_H
+#include "FilterCatalog.h"
+
+
+namespace RDKit {
+const FilterCatalog &GetFunctionalGroupHierarchy();
+const std::map<std::string, ROMOL_SPTR> &GetFlattenedFunctionalGroupHierarchy();
+}
+
+#endif

--- a/Code/GraphMol/FilterCatalog/Wrap/FilterCatalog.cpp
+++ b/Code/GraphMol/FilterCatalog/Wrap/FilterCatalog.cpp
@@ -35,6 +35,7 @@
 #include <GraphMol/FilterCatalog/FilterCatalog.h>
 #include <GraphMol/FilterCatalog/FilterMatcherBase.h>
 #include <GraphMol/FilterCatalog/FilterMatchers.h>
+#include <GraphMol/FilterCatalog/FunctionalGroupHierarchy.h>
 #include <GraphMol/RDKitBase.h>
 
 namespace python = boost::python;
@@ -254,6 +255,18 @@ const char *FilterCatalogEntryDoc =
     "hzone_phenol_A(479)\n"
     "\n\n";
 
+
+python::dict GetFlattenedFunctionalGroupHierarchyHelper() {
+  const std::map<std::string, ROMOL_SPTR> &flattened = \
+      GetFlattenedFunctionalGroupHierarchy();
+  python::dict dict;
+  for(std::map<std::string, ROMOL_SPTR>::const_iterator it=flattened.begin();
+      it!=flattened.end();
+      ++it) {
+    dict[it->first] = it->second;
+  }
+  return dict;
+}
 struct filtercat_wrapper {
   static void wrap() {
     python::class_<std::pair<int, int> >("IntPair")
@@ -344,6 +357,18 @@ struct filtercat_wrapper {
         .def("AddPattern", &ExclusionList::addPattern,
              "Add a FilterMatcherBase that should not appear in a molecule");
 
+    python::class_<FilterHierarchyMatcher, FilterHierarchyMatcher *,
+                   python::bases<FilterMatcherBase> >("FilterHierarchyMatcher",
+                                                      python::init<>())
+        .def(python::init<const FilterMatcherBase &>("Construct from a filtermatcher"))
+        .def("SetPattern", &FilterHierarchyMatcher::setPattern,
+             "Set the filtermatcher pattern for this node.  An empty node is considered "
+             "a root node and passes along the matches to the children.")
+        .def("AddChild", &FilterHierarchyMatcher::addChild,
+             "Add a child node to this hierarchy.");
+
+    python::register_ptr_to_python<boost::shared_ptr<FilterHierarchyMatcher> >();
+    
     python::class_<std::vector<RDKit::ROMol *> >("MolList")
         .def(python::vector_indexing_suite<std::vector<ROMol *>, true>());
 
@@ -378,6 +403,13 @@ struct filtercat_wrapper {
                               FilterCatalogEntry::clearProp);
 
     python::register_ptr_to_python<boost::shared_ptr<FilterCatalogEntry> >();
+    python::def("GetFunctionalGroupHierarchy", GetFunctionalGroupHierarchy,
+                "Returns the functional group hierarchy filter catalog",
+                python::return_value_policy<python::reference_existing_object>());
+    python::def("GetFlattenedFunctionalGroupHierarchy",
+                GetFlattenedFunctionalGroupHierarchyHelper,
+                "Returns the flattened functional group hierarchy as a dictionary "
+                " of name:ROMOL_SPTR substructure items");
 
 #ifdef BOOST_PYTHON_SUPPORT_SHARED_CONST
     python::register_ptr_to_python<
@@ -437,7 +469,9 @@ struct filtercat_wrapper {
              (python::arg("mol")),
              "Return the first catalog entry that matches mol")
         .def("GetMatches", &FilterCatalog::getMatches, (python::arg("mol")),
-             "Return all catalog entries that match mol");
+             "Return all catalog entries that match mol")
+        .def("GetFilterMatches", &FilterCatalog::getFilterMatches, (python::arg("mol")),
+             "Return every matching filter from all catalog entries that match mol");
 
     python::class_<PythonFilterMatch, python::bases<FilterMatcherBase> >(
         "PythonFilterMatcher", python::init<PyObject *>());
@@ -464,6 +498,8 @@ struct filtercat_wrapper {
     python::class_<FilterMatchOps::Not, FilterMatchOps::Not *,
                    python::bases<FilterMatcherBase> >(
         "Not", python::init<FilterMatcherBase &>());
+
+
   };
 };
 

--- a/Code/GraphMol/FilterCatalog/Wrap/FilterCatalog.cpp
+++ b/Code/GraphMol/FilterCatalog/Wrap/FilterCatalog.cpp
@@ -233,6 +233,25 @@ const char *SmartsMatcherDoc =
     "True\n"
     "\n";
 
+const char *FilterHierarchyMatcherDoc =
+    "Hierarchical Filter\n"
+    " basic constructors: \n"
+    "   FilterHierarchyMatcher( matcher )\n"
+    "   where can be any FilterMatcherBase (SmartsMatcher, etc)\n"
+    " FilterHierarchyMatcher's have children and can form matching\n"
+    "  trees.  then GetFilterMatches is called, the most specific (\n"
+    "  i.e. lowest node in a branch) is returned.\n\n"
+    " n.b. A FilterHierarchicalMatcher of functional groups is returned\n"
+    "  by calling GetFunctionalGroupHierarchy()\n\n"
+    ">>> from rdkit.Chem import MolFromSmiles\n"
+    ">>> from rdkit.Chem.FilterCatalog import *\n"
+    ">>> functionalGroups = GetFunctionalGroupHierarchy()\n"
+    ">>> [match.filterMatch.GetName() \n"
+    "...     for match in functionalGroups.GetFilterMatches(\n"
+    "...         MolFromSmiles('c1ccccc1Cl'))]\n"
+    "['Halogen.Aromatic', 'Halogen.NotFluorine.Aromatic']\n"
+    "\n";
+
 const char *FilterCatalogEntryDoc =
     "FilterCatalogEntry\n"
     "A filter catalog entry is an entry in a filter catalog.\n"
@@ -304,7 +323,8 @@ struct filtercat_wrapper {
 
     python::class_<SmartsMatcher, SmartsMatcher *,
                    python::bases<FilterMatcherBase> >(
-        "SmartsMatcher", python::init<const std::string &>())
+                       "SmartsMatcher", SmartsMatcherDoc,
+                       python::init<const std::string &>())
         .def(python::init<const ROMol &>("Construct from a molecule"))
         .def(python::init<const std::string &, const ROMol &>(
             "Construct from a name and a molecule"))
@@ -359,6 +379,7 @@ struct filtercat_wrapper {
 
     python::class_<FilterHierarchyMatcher, FilterHierarchyMatcher *,
                    python::bases<FilterMatcherBase> >("FilterHierarchyMatcher",
+                                                      FilterHierarchyMatcherDoc,
                                                       python::init<>())
         .def(python::init<const FilterMatcherBase &>("Construct from a filtermatcher"))
         .def("SetPattern", &FilterHierarchyMatcher::setPattern,
@@ -374,6 +395,7 @@ struct filtercat_wrapper {
 
     python::class_<FilterCatalogEntry, FilterCatalogEntry *,
                    const FilterCatalogEntry *>("FilterCatalogEntry",
+                                               FilterCatalogEntryDoc,
                                                python::init<>())
         .def(python::init<const std::string &, FilterMatcherBase &>())
         .def("IsValid", &FilterCatalogEntry::isValid)

--- a/Code/GraphMol/FilterCatalog/Wrap/rough_test.py
+++ b/Code/GraphMol/FilterCatalog/Wrap/rough_test.py
@@ -456,17 +456,24 @@ class TestCase(unittest.TestCase):
                      ['Halogen.Aliphatic', 'Halogen.NotFluorine.Aliphatic',
                       'Halogen.Bromine.Aliphatic']) ]
 
-        # test GetMatches API
-        for mol, res in matches:
-            entries = list(fc.GetMatches(mol))
-            for entry in entries:
-                hits = [match.filterMatch.GetName() for match in entry.GetFilterMatches(mol)]
-                self.assertEquals(res, hits)
+        catalogs = [fc]
+        if FilterCatalog.FilterCatalogCanSerialize():
+            pickle = fc.Serialize()
+            fc2 = FilterCatalog.FilterCatalog(pickle)
+            catalogs.append(fc2)
 
-        # test GetFilterMatches API
-        for mol, res in matches:
-            self.assertEquals(res, [match.filterMatch.GetName()
-                                    for match in fc.GetFilterMatches(mol)])
+        for fc in catalogs:
+            # test GetMatches API
+            for mol, res in matches:
+                entries = list(fc.GetMatches(mol))
+                for entry in entries:
+                    hits = [match.filterMatch.GetName() for match in entry.GetFilterMatches(mol)]
+                    self.assertEquals(res, hits)
+
+            # test GetFilterMatches API
+            for mol, res in matches:
+                self.assertEquals(res, [match.filterMatch.GetName()
+                                        for match in fc.GetFilterMatches(mol)])
                     
 
     def testFlattenedFunctionalGroupHierarchy(self):

--- a/Code/GraphMol/FilterCatalog/Wrap/rough_test.py
+++ b/Code/GraphMol/FilterCatalog/Wrap/rough_test.py
@@ -36,16 +36,23 @@ it is intended to be shallow but broad.
 """
 
 from __future__ import print_function
-import unittest,os
+import doctest,unittest,os
 from rdkit.six.moves import cPickle
 from rdkit import RDConfig
 from rdkit.RDLogger import logger
 logger=logger()
 from rdkit import Chem
+from rdkit.Chem import rdfiltercatalog
 from rdkit.Chem import FilterCatalog, rdMolDescriptors
 from rdkit.Chem.FilterCatalog import FilterCatalogParams
 from rdkit.Chem.FilterCatalog import FilterMatchOps
 from rdkit import DataStructs
+
+def load_tests(loader, tests, ignore):
+    tests.addTests(doctest.DocTestSuite(rdfiltercatalog))
+    print("*"*44)
+    print (dir(tests))
+    return tests
 
 class TestCase(unittest.TestCase):
     def setUp(self):

--- a/Code/GraphMol/FilterCatalog/Wrap/rough_test.py
+++ b/Code/GraphMol/FilterCatalog/Wrap/rough_test.py
@@ -272,7 +272,6 @@ class TestCase(unittest.TestCase):
         print ("Count", count)
         sz = catalog.GetNumEntries()
         print ("*"*44)
-        print (dir(catalog))
         self.assertTrue(catalog.RemoveEntry(entry))
         del entry
         self.assertTrue(catalog.GetNumEntries() == sz-1)
@@ -355,7 +354,143 @@ class TestCase(unittest.TestCase):
         mol = Chem.MolFromSmiles("c1ccccc1")
         catalogEntry = fc.GetFirstMatch(mol)
 
+    def testFilterHierarchyMatcher(self):
+        # test 
+        root = FilterCatalog.FilterHierarchyMatcher()
+        sm = h = FilterCatalog.SmartsMatcher("Halogen",
+                                         "[$([F,Cl,Br,I]-!@[#6]);!$([F,Cl,Br,I]"
+                                         "-!@C-!@[F,Cl,Br,I]);!$([F,Cl,Br,I]-[C,S]"
+                                         "(=[O,S,N]))]", 1)
+        root.SetPattern(sm)
+        def hierarchy(matcher):
+            node = FilterCatalog.FilterHierarchyMatcher(matcher)
+            self.assertEquals(matcher.GetName(), node.GetName())
+            return node
+        
+        sm = FilterCatalog.SmartsMatcher("Halogen.Aromatic",
+                                         "[F,Cl,Br,I;$(*-!@c)]")
+        root.AddChild(hierarchy(sm))
+        
+        sm = FilterCatalog.SmartsMatcher("Halogen.NotFluorine",
+                                         "[$([Cl,Br,I]-!@[#6]);!$([Cl,Br,I]"
+                                         "-!@C-!@[F,Cl,Br,I]);!$([Cl,Br,I]-[C,S]"
+                                         "(=[O,S,N]))]")
+        node = hierarchy(sm)
+        halogen_notf_children = [ hierarchy(x) for x in [
+            FilterCatalog.SmartsMatcher("Halogen.NotFluorine.Aliphatic",
+                                        "[$([Cl,Br,I]-!@C);!$([Cl,Br,I]"
+                                        "-!@C-!@[F,Cl,Br,I]);!$([Cl,Br,I]-[C,S](=[O,S,N]))]"),
+            
+            FilterCatalog.SmartsMatcher("Halogen.NotFluorine.Aromatic",
+                                        "[$([Cl,Br,I]-!@c)]")
+            ]]
+        for child in halogen_notf_children:
+            node.AddChild(child)
+        root.AddChild(node)
+        
+        sm = FilterCatalog.SmartsMatcher("Halogen.Bromine",
+                                         "[Br;$([Br]-!@[#6]);!$([Br]-!@C-!@[F,Cl,Br,I])"
+                                         ";!$([Br]-[C,S](=[O,S,N]))]", 1)
+        node = hierarchy(sm)
+        halogen_bromine_children = [ hierarchy(x) for x in [
+            FilterCatalog.SmartsMatcher("Halogen.Bromine.Aliphatic",
+                                        "[Br;$(Br-!@C);!$(Br-!@C-!@[F,Cl,Br,I]);"
+                                        "!$(Br-[C,S](=[O,S,N]))]"),
+            FilterCatalog.SmartsMatcher("Halogen.Bromine.Aromatic",
+                                        "[Br;$(Br-!@c)]"),
+            FilterCatalog.SmartsMatcher("Halogen.Bromine.BromoKetone",
+                                        "[Br;$(Br-[CH2]-C(=O)-[#6])]")
+            ]]
+        for child in halogen_bromine_children:
+            node.AddChild(child)
+        
+        root.AddChild(node)
+        
 
+        m = Chem.MolFromSmiles("CCl")
+        assert h.HasMatch(m)
+        res = root.GetMatches(m)
+        self.assertEquals(len(res), 1)
+        self.assertEquals([ match.filterMatch.GetName() for match in res ],
+                          ['Halogen.NotFluorine.Aliphatic'])
+        
+        m = Chem.MolFromSmiles("c1ccccc1Cl")
+        assert h.HasMatch(m)
+        res = root.GetMatches(m)
+        self.assertEquals(len(res), 2)
+
+        m = Chem.MolFromSmiles("c1ccccc1Br")
+        assert h.HasMatch(m)
+        res = root.GetMatches(m)
+        self.assertEquals(len(res), 3)
+        
+        self.assertEquals([ match.filterMatch.GetName() for match in res ],
+                          ['Halogen.Aromatic', 'Halogen.NotFluorine.Aromatic',
+                           'Halogen.Bromine.Aromatic'])
+
+        m = Chem.MolFromSmiles("c1ccccc1F")
+        assert h.HasMatch(m)
+        res = root.GetMatches(m)
+        self.assertEquals(len(res), 1)
+        
+        self.assertEquals([ match.filterMatch.GetName() for match in res ],
+                          ['Halogen.Aromatic'])
+
+        m = Chem.MolFromSmiles("CBr")
+        assert h.HasMatch(m)
+        res = root.GetMatches(m)
+
+        self.assertEquals([ match.filterMatch.GetName() for match in res ],
+                          ['Halogen.NotFluorine.Aliphatic', 'Halogen.Bromine.Aliphatic'])
+        
+    def testFunctionalGroupHierarchy(self):
+        fc = FilterCatalog.GetFunctionalGroupHierarchy()
+        
+        matches = [ (Chem.MolFromSmiles("CCl"),
+                     ['Halogen.Aliphatic', 'Halogen.NotFluorine.Aliphatic']),
+                    (Chem.MolFromSmiles("c1ccccc1Cl"),
+                     ['Halogen.Aromatic', 'Halogen.NotFluorine.Aromatic']),
+                    (Chem.MolFromSmiles("c1ccccc1F"),
+                     ['Halogen.Aromatic']),
+                    (Chem.MolFromSmiles("CBr"),
+                     ['Halogen.Aliphatic', 'Halogen.NotFluorine.Aliphatic',
+                      'Halogen.Bromine.Aliphatic']) ]
+
+        # test GetMatches API
+        for mol, res in matches:
+            entries = list(fc.GetMatches(mol))
+            for entry in entries:
+                hits = [match.filterMatch.GetName() for match in entry.GetFilterMatches(mol)]
+                self.assertEquals(res, hits)
+
+        # test GetFilterMatches API
+        for mol, res in matches:
+            self.assertEquals(res, [match.filterMatch.GetName()
+                                    for match in fc.GetFilterMatches(mol)])
+                    
+
+    def testFlattenedFunctionalGroupHierarchy(self):
+        queryDefs = FilterCatalog.GetFlattenedFunctionalGroupHierarchy()
+        items = sorted(queryDefs.items())
+        
+        matches = [ (Chem.MolFromSmiles("CCl"),
+                     ['Halogen', 'Halogen.Aliphatic', 'Halogen.NotFluorine',
+                      'Halogen.NotFluorine.Aliphatic']),
+                    (Chem.MolFromSmiles("c1ccccc1Cl"),
+                     ['Halogen', 'Halogen.Aromatic', 'Halogen.NotFluorine',
+                      'Halogen.NotFluorine.Aromatic']),
+                    (Chem.MolFromSmiles("c1ccccc1F"),
+                     ['Halogen', 'Halogen.Aromatic']),
+                    (Chem.MolFromSmiles("CBr"),
+                     ['Halogen', 'Halogen.Aliphatic',
+                      'Halogen.Bromine', 'Halogen.Bromine.Aliphatic',
+                      'Halogen.NotFluorine', 'Halogen.NotFluorine.Aliphatic',
+                  ]) ]
+
+        for mol, res in matches:
+            hits = [name for  name, pat in items if mol.HasSubstructMatch(pat)]
+            self.assertEquals(hits, res)
+            
 
         
 if __name__ == '__main__':


### PR DESCRIPTION
Implements #732 

FilterHierarchyMatcher has beed added as a new FilterCatalog matcher.  It stores a hierarchy of smarts patterns that (in principle) should get more specific from the root to the leaves.  Fore each matching branch in the tree, it returns the most specific FilterMatch.  I.e.  Halogen->Halogen.Aromatic would return Halogen.Aromatic

A new FilterCatalog has been added that holds all the hierarchies stored in Functional_Group_Hierarchy.txt.

It also supplies the flattened form of the recursive queries that can be used in addRecursiveQueries.

Example:

        fc = FilterCatalog.GetFunctionalGroupHierarchy()
        
        for mol, res in matches:
           func_groups =  [match.filterMatch.GetName()
                             for match in fc.GetFilterMatches(mol)]

Example of getting queryDefs for addRecursive:

      # keys need to be lower case for recursiveQueries, probably should make this
      #  the default?
      querydefs = {k.lower():v
                 for k,v in FilterCatalog.GetFlattenedFunctionalGroupHierarchy().items()}
    
      rxn.AddRecursiveQueriesToReaction(querydefs, 'query')