### PR TITLE
Adds RDAny (smaller generic holder) Updates all used dictionaries

### DIFF
--- a/Code/GraphMol/Atom.cpp
+++ b/Code/GraphMol/Atom.cpp
@@ -29,22 +29,22 @@ bool isEarlyAtom(int atomicNum) {
   return (4 - PeriodicTable::getTable()->getNouterElecs(atomicNum)) > 0;
 }
 }
-Atom::Atom() {
+Atom::Atom() : RDProps() {
   d_atomicNum = 0;
   initAtom();
 }
 
-Atom::Atom(unsigned int num) {
+Atom::Atom(unsigned int num) : RDProps() {
   d_atomicNum = num;
   initAtom();
 };
 
-Atom::Atom(const std::string &what) {
+Atom::Atom(const std::string &what) : RDProps() {
   d_atomicNum = PeriodicTable::getTable()->getAtomicNumber(what);
   initAtom();
 };
 
-Atom::Atom(const Atom &other) {
+Atom::Atom(const Atom &other) : RDProps(other) {
   // NOTE: we do *not* copy ownership!
   d_atomicNum = other.d_atomicNum;
   dp_mol = 0;
@@ -60,13 +60,6 @@ Atom::Atom(const Atom &other) {
   d_hybrid = other.d_hybrid;
   d_implicitValence = other.d_implicitValence;
   d_explicitValence = other.d_explicitValence;
-  if (other.dp_props) {
-    dp_props = new Dict(*other.dp_props);
-  } else {
-    dp_props = new Dict();
-    STR_VECT computed;
-    dp_props->setVal(detail::computedPropName, computed);
-  }
   if (other.dp_monomerInfo) {
     dp_monomerInfo = other.dp_monomerInfo->copy();
   } else {
@@ -84,7 +77,6 @@ void Atom::initAtom() {
   d_chiralTag = CHI_UNSPECIFIED;
   d_hybrid = UNSPECIFIED;
   dp_mol = 0;
-  dp_props = new Dict();
   dp_monomerInfo = 0;
 
   d_implicitValence = -1;
@@ -92,10 +84,6 @@ void Atom::initAtom() {
 }
 
 Atom::~Atom() {
-  if (dp_props) {
-    delete dp_props;
-    dp_props = 0;
-  }
   if (dp_monomerInfo) {
     delete dp_monomerInfo;
   }

--- a/Code/GraphMol/Bond.cpp
+++ b/Code/GraphMol/Bond.cpp
@@ -15,18 +15,16 @@
 
 namespace RDKit {
 
-Bond::Bond() {
+Bond::Bond() : RDProps() {
   initBond();
-  dp_props = new Dict();
 };
 
-Bond::Bond(BondType bT) {
+Bond::Bond(BondType bT) : RDProps() {
   initBond();
   d_bondType = bT;
-  dp_props = new Dict();
 };
 
-Bond::Bond(const Bond &other) {
+Bond::Bond(const Bond &other) : RDProps(other) {
   // NOTE: we do *not* copy ownership!
   dp_mol = 0;
   d_bondType = other.d_bondType;
@@ -42,15 +40,9 @@ Bond::Bond(const Bond &other) {
   df_isAromatic = other.df_isAromatic;
   df_isConjugated = other.df_isConjugated;
   d_index = other.d_index;
-  if (other.dp_props) {
-    dp_props = new Dict(*other.dp_props);
-  } else {
-    dp_props = new Dict();
-  }
 }
 
 Bond::~Bond() {
-  delete dp_props;
   delete dp_stereoAtoms;
 }
 
@@ -68,11 +60,7 @@ Bond &Bond::operator=(const Bond &other) {
   df_isAromatic = other.df_isAromatic;
   df_isConjugated = other.df_isConjugated;
   d_index = other.d_index;
-  if (other.dp_props) {
-    dp_props = new Dict(*other.dp_props);
-  } else {
-    dp_props = new Dict();
-  }
+  dp_props = other.dp_props;
 
   return *this;
 }

--- a/Code/GraphMol/Canon.cpp
+++ b/Code/GraphMol/Canon.cpp
@@ -923,7 +923,8 @@ void canonicalizeFragment(ROMol &mol, int atomIdx,
   if (!mol.getRingInfo()->isInitialized()) {
     MolOps::findSSSR(mol);
   }
-  mol.getAtomWithIdx(atomIdx)->setProp("_TraversalStartPoint", true);
+  mol.getAtomWithIdx(atomIdx)->setProp(
+      common_properties::_TraversalStartPoint, true);
 
   VECT_INT_VECT atomRingClosures(nAtoms);
   std::vector<INT_LIST> atomTraversalBondOrder(nAtoms);

--- a/Code/GraphMol/ForceFieldHelpers/MMFF/AtomTyper.cpp
+++ b/Code/GraphMol/ForceFieldHelpers/MMFF/AtomTyper.cpp
@@ -3651,14 +3651,14 @@ bool MMFFMolProperties::getMMFFVdWParams(const unsigned int idx1,
     const MMFFVdW *mmffVdWParamsIAtom = (*mmffVdW)(iAtomType);
     const MMFFVdW *mmffVdWParamsJAtom = (*mmffVdW)(jAtomType);
     if (mmffVdWParamsIAtom && mmffVdWParamsJAtom) {
-      mmffVdWParams.R_ij_starUnscaled = Utils::calcUnscaledVdWMinimum(
+      mmffVdWParams.R_ij_starUnscaled = MMFF::Utils::calcUnscaledVdWMinimum(
           mmffVdW, mmffVdWParamsIAtom, mmffVdWParamsJAtom);
-      mmffVdWParams.epsilonUnscaled = Utils::calcUnscaledVdWWellDepth(
+      mmffVdWParams.epsilonUnscaled = MMFF::Utils::calcUnscaledVdWWellDepth(
           mmffVdWParams.R_ij_starUnscaled, mmffVdWParamsIAtom,
           mmffVdWParamsJAtom);
       mmffVdWParams.R_ij_star = mmffVdWParams.R_ij_starUnscaled;
       mmffVdWParams.epsilon = mmffVdWParams.epsilonUnscaled;
-      Utils::scaleVdWParams(mmffVdWParams.R_ij_star, mmffVdWParams.epsilon,
+      MMFF::Utils::scaleVdWParams(mmffVdWParams.R_ij_star, mmffVdWParams.epsilon,
                             mmffVdW, mmffVdWParamsIAtom, mmffVdWParamsJAtom);
       res = true;
     }

--- a/Code/GraphMol/ForceFieldHelpers/MMFF/Builder.cpp
+++ b/Code/GraphMol/ForceFieldHelpers/MMFF/Builder.cpp
@@ -73,7 +73,7 @@ void addBonds(const ROMol &mol, MMFFMolProperties *mmffMolProperties,
         const Atom *iAtom = (*bi)->getBeginAtom();
         const Atom *jAtom = (*bi)->getEndAtom();
         const double dist = field->distance(idx1, idx2);
-        const double bondStretchEnergy = Utils::calcBondStretchEnergy(
+        const double bondStretchEnergy = MMFF::Utils::calcBondStretchEnergy(
             mmffBondParams.r0, mmffBondParams.kb, dist);
         if (mmffMolProperties->getMMFFVerbosity() == MMFF_VERBOSITY_HIGH) {
           oStream << std::left << std::setw(2) << iAtom->getSymbol() << " #"
@@ -303,10 +303,10 @@ void addAngles(const ROMol &mol, MMFFMolProperties *mmffMolProperties,
                                      (*(points[idx[2]]))[1],
                                      (*(points[idx[2]]))[2]);
             const double cosTheta =
-                Utils::calcCosTheta(p1, p2, p3, field->distance(idx[0], idx[1]),
-                                    field->distance(idx[1], idx[2]));
+                MMFF::Utils::calcCosTheta(p1, p2, p3, field->distance(idx[0], idx[1]),
+                                          field->distance(idx[1], idx[2]));
             const double theta = RAD2DEG * acos(cosTheta);
-            const double angleBendEnergy = Utils::calcAngleBendEnergy(
+            const double angleBendEnergy = MMFF::Utils::calcAngleBendEnergy(
                 mmffAngleParams.theta0, mmffAngleParams.ka,
                 mmffPropParamsCentralAtom->linh, cosTheta);
             if (mmffMolProperties->getMMFFVerbosity() == MMFF_VERBOSITY_HIGH) {
@@ -431,12 +431,12 @@ void addStretchBend(const ROMol &mol, MMFFMolProperties *mmffMolProperties,
                                      (*(points[idx[2]]))[1],
                                      (*(points[idx[2]]))[2]);
             const double cosTheta =
-                Utils::calcCosTheta(p1, p2, p3, dist1, dist2);
+                MMFF::Utils::calcCosTheta(p1, p2, p3, dist1, dist2);
             const double theta = RAD2DEG * acos(cosTheta);
             const std::pair<double, double> forceConstants =
-                Utils::calcStbnForceConstants(&mmffStbnParams);
+                MMFF::Utils::calcStbnForceConstants(&mmffStbnParams);
             const std::pair<double, double> stretchBendEnergies =
-                Utils::calcStretchBendEnergy(
+                MMFF::Utils::calcStretchBendEnergy(
                     dist1 - mmffBondParams[0].r0, dist2 - mmffBondParams[1].r0,
                     theta - mmffAngleParams.theta0, forceConstants);
             if (mmffMolProperties->getMMFFVerbosity() == MMFF_VERBOSITY_HIGH) {
@@ -584,9 +584,9 @@ void addOop(const ROMol &mol, MMFFMolProperties *mmffMolProperties,
         const RDGeom::Point3D p4((*(points[idx[n[3]]]))[0],
                                  (*(points[idx[n[3]]]))[1],
                                  (*(points[idx[n[3]]]))[2]);
-        const double chi = Utils::calcOopChi(p1, p2, p3, p4);
+        const double chi = MMFF::Utils::calcOopChi(p1, p2, p3, p4);
         const double oopBendEnergy =
-            Utils::calcOopBendEnergy(chi, mmffOopParams.koop);
+            MMFF::Utils::calcOopBendEnergy(chi, mmffOopParams.koop);
         if (mmffMolProperties->getMMFFVerbosity() == MMFF_VERBOSITY_HIGH) {
           oStream << std::left << std::setw(2) << atom[0]->getSymbol() << " #"
                   << std::setw(5) << idx[n[0]] + 1 << std::setw(2)
@@ -716,8 +716,8 @@ void addTorsions(const ROMol &mol, MMFFMolProperties *mmffMolProperties,
                                              (*(points[idx4]))[1],
                                              (*(points[idx4]))[2]);
                     const double cosPhi =
-                        Utils::calcTorsionCosPhi(p1, p2, p3, p4);
-                    const double torsionEnergy = Utils::calcTorsionEnergy(
+                        MMFF::Utils::calcTorsionCosPhi(p1, p2, p3, p4);
+                    const double torsionEnergy = MMFF::Utils::calcTorsionEnergy(
                         mmffTorParams.V1, mmffTorParams.V2, mmffTorParams.V3,
                         cosPhi);
                     if (mmffMolProperties->getMMFFVerbosity() ==
@@ -814,7 +814,7 @@ void addVdW(const ROMol &mol, int confId, MMFFMolProperties *mmffMolProperties,
           if (mmffMolProperties->getMMFFVerbosity()) {
             const Atom *iAtom = mol.getAtomWithIdx(i);
             const Atom *jAtom = mol.getAtomWithIdx(j);
-            const double vdWEnergy = Utils::calcVdWEnergy(
+            const double vdWEnergy = MMFF::Utils::calcVdWEnergy(
                 dist, mmffVdWParams.R_ij_star, mmffVdWParams.epsilon);
             if (mmffMolProperties->getMMFFVerbosity() == MMFF_VERBOSITY_HIGH) {
               unsigned int iAtomType = mmffMolProperties->getMMFFAtomType(i);
@@ -904,7 +904,7 @@ void addEle(const ROMol &mol, int confId, MMFFMolProperties *mmffMolProperties,
           const unsigned int jAtomType = mmffMolProperties->getMMFFAtomType(j);
           const Atom *iAtom = mol.getAtomWithIdx(i);
           const Atom *jAtom = mol.getAtomWithIdx(j);
-          const double eleEnergy = Utils::calcEleEnergy(
+          const double eleEnergy = MMFF::Utils::calcEleEnergy(
               i, j, dist, chargeTerm, dielModel,
               getTwoBitCell(neighborMatrix, i * nAtoms + j) == RELATION_1_4);
           if (mmffMolProperties->getMMFFVerbosity() == MMFF_VERBOSITY_HIGH) {

--- a/Code/GraphMol/ForceFieldHelpers/UFF/AtomTyper.cpp
+++ b/Code/GraphMol/ForceFieldHelpers/UFF/AtomTyper.cpp
@@ -400,8 +400,8 @@ bool getUFFBondStretchParams(const ROMol &mol, unsigned int idx1,
   if (res) {
     double bondOrder = bond->getBondTypeAsDouble();
     uffBondStretchParams.r0 =
-        Utils::calcBondRestLength(bondOrder, paramVect[0], paramVect[1]);
-    uffBondStretchParams.kb = Utils::calcBondForceConstant(
+        UFF::Utils::calcBondRestLength(bondOrder, paramVect[0], paramVect[1]);
+    uffBondStretchParams.kb = UFF::Utils::calcBondForceConstant(
         uffBondStretchParams.r0, paramVect[0], paramVect[1]);
   }
   return res;
@@ -432,7 +432,7 @@ bool getUFFAngleBendParams(const ROMol &mol, unsigned int idx1,
     double bondOrder12 = bond[0]->getBondTypeAsDouble();
     double bondOrder23 = bond[1]->getBondTypeAsDouble();
     uffAngleBendParams.theta0 = RAD2DEG * paramVect[1]->theta0;
-    uffAngleBendParams.ka = Utils::calcAngleForceConstant(
+    uffAngleBendParams.ka = UFF::Utils::calcAngleForceConstant(
         paramVect[1]->theta0, bondOrder12, bondOrder23, paramVect[0],
         paramVect[1], paramVect[2]);
   }
@@ -477,8 +477,8 @@ bool getUFFTorsionParams(const ROMol &mol, unsigned int idx1, unsigned int idx2,
       // general case:
       uffTorsionParams.V = sqrt(paramVect[0]->V1 * paramVect[1]->V1);
       // special case for single bonds between group 6 elements:
-      if (((int)(bondOrder * 10) == 10) && Utils::isInGroup6(atNum[0]) &&
-          Utils::isInGroup6(atNum[1])) {
+      if (((int)(bondOrder * 10) == 10) && UFF::Utils::isInGroup6(atNum[0]) &&
+          UFF::Utils::isInGroup6(atNum[1])) {
         double V2 = 6.8;
         double V3 = 6.8;
         if (atNum[0] == 8) V2 = 2.0;
@@ -487,18 +487,18 @@ bool getUFFTorsionParams(const ROMol &mol, unsigned int idx1, unsigned int idx2,
       }
     } else if ((hyb[0] == RDKit::Atom::SP2) && (hyb[1] == RDKit::Atom::SP2)) {
       uffTorsionParams.V =
-          Utils::equation17(bondOrder, paramVect[0], paramVect[1]);
+          UFF::Utils::equation17(bondOrder, paramVect[0], paramVect[1]);
     } else {
       // SP2 - SP3,  this is, by default, independent of atom type in UFF:
       uffTorsionParams.V = 1.0;
       if ((int)(bondOrder * 10) == 10) {
         // special case between group 6 sp3 and non-group 6 sp2:
-        if (((hyb[0] == RDKit::Atom::SP3) && Utils::isInGroup6(atNum[0]) &&
-             (!Utils::isInGroup6(atNum[1]))) ||
-            ((hyb[1] == RDKit::Atom::SP3) && Utils::isInGroup6(atNum[1]) &&
-             (!Utils::isInGroup6(atNum[0])))) {
+        if (((hyb[0] == RDKit::Atom::SP3) && UFF::Utils::isInGroup6(atNum[0]) &&
+             (!UFF::Utils::isInGroup6(atNum[1]))) ||
+            ((hyb[1] == RDKit::Atom::SP3) && UFF::Utils::isInGroup6(atNum[1]) &&
+             (!UFF::Utils::isInGroup6(atNum[0])))) {
           uffTorsionParams.V =
-              Utils::equation17(bondOrder, paramVect[0], paramVect[1]);
+              UFF::Utils::equation17(bondOrder, paramVect[0], paramVect[1]);
         }
         // special case for sp3 - sp2 - sp2
         // (i.e. the sp2 has another sp2 neighbor, like propene)
@@ -550,7 +550,7 @@ bool getUFFInversionParams(const ROMol &mol, unsigned int idx1,
   if (res) {
     isBoundToSP2O = (isBoundToSP2O && (at2AtomicNum == 6));
     boost::tuple<double, double, double, double> invCoeffForceCon =
-        Utils::calcInversionCoefficientsAndForceConstant(at2AtomicNum,
+        UFF::Utils::calcInversionCoefficientsAndForceConstant(at2AtomicNum,
                                                          isBoundToSP2O);
     uffInversionParams.K = boost::tuples::get<0>(invCoeffForceCon);
   }
@@ -571,8 +571,8 @@ bool getUFFVdWParams(const ROMol &mol, unsigned int idx1, unsigned int idx2,
     res = (paramVect[i] ? true : false);
   }
   if (res) {
-    uffVdWParams.x_ij = Utils::calcNonbondedMinimum(paramVect[0], paramVect[1]);
-    uffVdWParams.D_ij = Utils::calcNonbondedDepth(paramVect[0], paramVect[1]);
+    uffVdWParams.x_ij = UFF::Utils::calcNonbondedMinimum(paramVect[0], paramVect[1]);
+    uffVdWParams.D_ij = UFF::Utils::calcNonbondedDepth(paramVect[0], paramVect[1]);
   }
   return res;
 }

--- a/Code/GraphMol/ForceFieldHelpers/UFF/Builder.cpp
+++ b/Code/GraphMol/ForceFieldHelpers/UFF/Builder.cpp
@@ -450,7 +450,7 @@ void addNonbonded(const ROMol &mol, int confId, const AtomicParamVect &params,
       if (getTwoBitCell(neighborMatrix, i * nAtoms + j) >= RELATION_1_4) {
         double dist = (conf.getAtomPos(i) - conf.getAtomPos(j)).length();
         if (dist <
-            vdwThresh * Utils::calcNonbondedMinimum(params[i], params[j])) {
+            vdwThresh * UFF::Utils::calcNonbondedMinimum(params[i], params[j])) {
           vdWContrib *contrib;
           contrib = new vdWContrib(field, i, j, params[i], params[j]);
           field->contribs().push_back(ForceFields::ContribPtr(contrib));

--- a/Code/GraphMol/MolDiscriminators.cpp
+++ b/Code/GraphMol/MolDiscriminators.cpp
@@ -57,7 +57,7 @@ double computeBalabanJ(const ROMol &mol, bool useBO, bool force,
                        const std::vector<int> *bondPath, bool cacheIt) {
   RDUNUSED_PARAM(useBO);
   double res = 0.0;
-  if (!force && mol.hasProp(common_properties::BalanbanJ)) {
+  if (!force && mol.hasProp(common_properties::BalabanJ)) {
     mol.getProp(common_properties::BalabanJ, res);
   } else {
     double *dMat;

--- a/Code/GraphMol/QueryBond.cpp
+++ b/Code/GraphMol/QueryBond.cpp
@@ -30,8 +30,7 @@ QueryBond &QueryBond::operator=(const QueryBond &other) {
   dp_mol = 0;
   d_bondType = other.d_bondType;
   dp_query = other.dp_query->copy();
-  delete dp_props;
-  if (other.dp_props) dp_props = new Dict(*other.dp_props);
+  dp_props = other.dp_props;
   return *this;
 }
 

--- a/Code/GraphMol/ROMol.cpp
+++ b/Code/GraphMol/ROMol.cpp
@@ -34,17 +34,14 @@ void ROMol::destroy() {
   d_atomBookmarks.clear();
   d_bondBookmarks.clear();
   d_graph.clear();
-  if (dp_props) {
-    delete dp_props;
-    dp_props = 0;
-  }
+
   if (dp_ringInfo) {
     delete dp_ringInfo;
     dp_ringInfo = 0;
   }
 };
 
-ROMol::ROMol(const std::string &pickle) {
+ROMol::ROMol(const std::string &pickle) : RDProps() {
   initMol();
   MolPickler::molFromPickle(pickle, *this);
 }
@@ -75,8 +72,6 @@ void ROMol::initFromOther(const ROMol &other, bool quickCopy, int confId) {
     dp_ringInfo = new RingInfo();
   }
 
-  if (dp_props) delete dp_props;
-  dp_props = 0;
   if (!quickCopy) {
     // copy conformations
     for (ConstConformerIterator ci = other.beginConformers();
@@ -86,10 +81,8 @@ void ROMol::initFromOther(const ROMol &other, bool quickCopy, int confId) {
         this->addConformer(conf);
       }
     }
-
-    if (other.dp_props) {
-      dp_props = new Dict(*other.dp_props);
-    }
+    
+    dp_props = other.dp_props;
 
     // Bookmarks should be copied as well:
     BOOST_FOREACH (ATOM_BOOKMARK_MAP::value_type abmI, other.d_atomBookmarks) {
@@ -102,18 +95,17 @@ void ROMol::initFromOther(const ROMol &other, bool quickCopy, int confId) {
         setBondBookmark(getBondWithIdx(bptr->getIdx()), bbmI.first);
       }
     }
-  }
-  if (!dp_props) {
-    dp_props = new Dict();
+  } else {
+    dp_props.reset();
     STR_VECT computed;
-    dp_props->setVal(detail::computedPropName, computed);
+    dp_props.setVal(detail::computedPropName, computed);
   }
   // std::cerr<<"---------    done init from other: "<<this<<"
   // "<<&other<<std::endl;
 }
 
 void ROMol::initMol() {
-  dp_props = new Dict();
+  dp_props.reset();
   dp_ringInfo = new RingInfo();
   // ok every molecule contains a property entry called detail::computedPropName
   // which provides
@@ -122,7 +114,7 @@ void ROMol::initMol() {
   // along
   // initialize this list to an empty vector of strings
   STR_VECT computed;
-  dp_props->setVal(detail::computedPropName, computed);
+  dp_props.setVal(detail::computedPropName, computed);
 }
 
 unsigned int ROMol::getAtomDegree(const Atom *at) const {
@@ -477,12 +469,8 @@ void ROMol::clearComputedProps(bool includeRings) const {
   // the SSSR information:
   if (includeRings) this->dp_ringInfo->reset();
 
-  STR_VECT compLst;
-  if (getPropIfPresent(detail::computedPropName, compLst)) {
-    BOOST_FOREACH (std::string &sv, compLst) { dp_props->clearVal(sv); }
-    compLst.clear();
-  }
-  dp_props->setVal(detail::computedPropName, compLst);
+  RDProps::clearComputedProps();
+  
   for (ConstAtomIterator atomIt = this->beginAtoms();
        atomIt != this->endAtoms(); ++atomIt) {
     (*atomIt)->clearComputedProps();

--- a/Code/GraphMol/RWMol.h
+++ b/Code/GraphMol/RWMol.h
@@ -214,11 +214,10 @@ class RWMol : public ROMol {
     d_bondBookmarks.clear();
     d_graph.clear();
     d_confs.clear();
-    if (dp_props) {
-      dp_props->reset();
-      STR_VECT computed;
-      dp_props->setVal(detail::computedPropName, computed);
-    }
+    dp_props.reset();
+    STR_VECT computed;
+    dp_props.setVal(detail::computedPropName, computed);
+
     if (dp_ringInfo) dp_ringInfo->reset();
   };
 

--- a/Code/GraphMol/Wrap/Atom.cpp
+++ b/Code/GraphMol/Wrap/Atom.cpp
@@ -360,7 +360,10 @@ struct atom_wrapper {
         .def("GetPropNames", &Atom::getPropList, (python::arg("self")),
              "Returns a list of the properties set on the Atom.\n\n")
 
-        .def("GetPropsAsDict", GetPropsAsDict<Atom>, (python::arg("self")),
+        .def("GetPropsAsDict", GetPropsAsDict<Atom>, (python::arg("self"),
+                                                      python::arg("includePrivate") = true,
+                                                      python::arg("includeComputed") = true
+                                                      ),
              "Returns a dictionary of the properties set on the Atom.\n"
              " n.b. some properties cannot be converted to python types.\n")
         

--- a/Code/GraphMol/Wrap/Bond.cpp
+++ b/Code/GraphMol/Wrap/Bond.cpp
@@ -293,7 +293,10 @@ struct bond_wrapper {
         .def("GetPropNames", &Bond::getPropList, (python::arg("self")),
              "Returns a list of the properties set on the Bond.\n\n")
 
-        .def("GetPropsAsDict", GetPropsAsDict<Bond>, (python::arg("self")),
+        .def("GetPropsAsDict", GetPropsAsDict<Bond>, (python::arg("self"),
+                                                      python::arg("includePrivate") = true,
+                                                      python::arg("includeComputed") = true
+                                                      ),
              "Returns a dictionary of the properties set on the Bond.\n"
              " n.b. some properties cannot be converted to python types.\n")
         

--- a/Code/GraphMol/Wrap/Mol.cpp
+++ b/Code/GraphMol/Wrap/Mol.cpp
@@ -158,29 +158,6 @@ void MolClearProp(const ROMol &mol, const char *key) {
   mol.clearProp(key);
 }
 
-// specialized for include private/computed...
-boost::python::dict MolGetPropsAsDict(const ROMol &mol,
-                                      bool includePrivate=false,
-                                      bool includeComputed=false) {
-  boost::python::dict dict;
-  // precedence double, int, unsigned, std::vector<double>,
-  // std::vector<int>, std::vector<unsigned>, string
-  STR_VECT keys = mol.getPropList(includePrivate, includeComputed);
-  for(size_t i=0;i<keys.size();++i) {
-    if (AddToDict<double>(mol, dict, keys[i])) continue;
-    if (AddToDict<int>(mol, dict, keys[i])) continue;
-    if (AddToDict<unsigned int>(mol, dict, keys[i])) continue;
-    if (AddToDict<bool>(mol, dict, keys[i])) continue;
-    if (AddToDict<std::vector<double> >(mol, dict, keys[i])) continue;
-    if (AddToDict<std::vector<int> >(mol, dict, keys[i])) continue;
-    if (AddToDict<std::vector<unsigned int> >(mol, dict, keys[i])) continue;
-    //    if (AddToDict<std::vector<bool> >(mol, dict, keys[i])) continue;
-    if (AddToDict<std::string>(mol, dict, keys[i])) continue;
-    if (AddToDict<std::vector<std::string> >(mol, dict, keys[i])) continue;
-  }
-  return dict;
-}
-
 void MolClearComputedProps(const ROMol &mol) { mol.clearComputedProps(); }
 
 void MolDebug(const ROMol &mol) { mol.debugMol(std::cout); }
@@ -558,7 +535,7 @@ struct mol_wrapper {
              "                      Defaults to 0.\n\n"
              "  RETURNS: a tuple of strings\n")
 
-        .def("GetPropsAsDict", MolGetPropsAsDict,
+        .def("GetPropsAsDict", GetPropsAsDict<ROMol>,
              (python::arg("self"), python::arg("includePrivate") = false,
               python::arg("includeComputed") = false),
              "Returns a dictionary populated with the molecules properties.\n"

--- a/Code/GraphMol/Wrap/props.hpp
+++ b/Code/GraphMol/Wrap/props.hpp
@@ -69,11 +69,13 @@ bool AddToDict(const U& ob, boost::python::dict &dict, const std::string &key) {
 }
 
 template<class T>
-boost::python::dict GetPropsAsDict(const T &obj) {
+boost::python::dict GetPropsAsDict(const T &obj,
+                                   bool includePrivate,
+                                   bool includeComputed) {
   boost::python::dict dict;
   // precedence double, int, unsigned, std::vector<double>,
   // std::vector<int>, std::vector<unsigned>, string
-  STR_VECT keys = obj.getPropList();
+  STR_VECT keys = obj.getPropList(includePrivate, includeComputed);
   for(size_t i=0;i<keys.size();++i) {
     if (AddToDict<double>(obj, dict, keys[i])) continue;
     if (AddToDict<int>(obj, dict, keys[i])) continue;
@@ -82,6 +84,7 @@ boost::python::dict GetPropsAsDict(const T &obj) {
     if (AddToDict<std::vector<double> >(obj, dict, keys[i])) continue;
     if (AddToDict<std::vector<int> >(obj, dict, keys[i])) continue;
     if (AddToDict<std::vector<unsigned int> >(obj, dict, keys[i])) continue;
+    if (AddToDict<std::vector<std::string> >(obj, dict, keys[i])) continue;    
     if (AddToDict<std::string>(obj, dict, keys[i])) continue;
   }
   return dict;

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -1,4 +1,3 @@
-# $Id$
 #
 #  Copyright (C) 2003-2013  Greg Landrum and Rational Discovery LLC
 #         All Rights Reserved
@@ -493,9 +492,6 @@ class TestCase(unittest.TestCase):
     m.SetUnsignedProp("c", 2000)
     m.SetIntProp("d", -2)
     m.SetUnsignedProp("e", 2, True)
-    self.assertEquals(m.GetPropsAsDict(),
-                      {'a': False, 'c': 2000, 'b': 1000.0,
-                       'd': -2, 'prop1': 'foob'})
     self.assertEquals(m.GetPropsAsDict(False, True),
                       {'a': False, 'c': 2000, 'b': 1000.0, 'e': 2,
                        'd': -2, 'prop1': 'foob'})
@@ -3317,7 +3313,12 @@ CAS<~>
   def testAtomBondProps(self):
     m = Chem.MolFromSmiles('c1ccccc1')
     for atom in m.GetAtoms():
-      self.assertEquals(atom.GetPropsAsDict(), {'_CIPRank': 0})
+      d = atom.GetPropsAsDict()
+      self.assertEquals(set(d.keys()), set(['_CIPRank', '__computedProps']))
+      self.assertEquals(d['_CIPRank'], 0)
+      self.assertEquals(list(d['__computedProps']), ['_CIPRank'])
+
+
     for bond in m.GetBonds():
       self.assertEquals(bond.GetPropsAsDict(), {})
 

--- a/Code/GraphMol/new_canon.cpp
+++ b/Code/GraphMol/new_canon.cpp
@@ -415,7 +415,7 @@ void advancedInitCanonAtom(const ROMol &mol, Canon::canon_atom &atom,
   atom.isRingStereoAtom =
       (atom.atom->getChiralTag() == Atom::CHI_TETRAHEDRAL_CW ||
        atom.atom->getChiralTag() == Atom::CHI_TETRAHEDRAL_CCW) &&
-      atom.atom->hasProp("_ringStereoAtoms");
+      atom.atom->hasProp(common_properties::_ringStereoAtoms);
   atom.hasRingNbr = hasRingNbr(mol, atom.atom);
 }
 }  // end anonymous namespace

--- a/Code/JavaWrappers/Atom.i
+++ b/Code/JavaWrappers/Atom.i
@@ -58,9 +58,6 @@
 #endif
 %include <GraphMol/Atom.h>
 
-/* For the time being, assume all properties will be strings */
-%template(setProp)  RDKit::Atom::setProp<std::string>;
-
 %newobject RDKit::Atom::getProp;
 %extend RDKit::Atom {
   std::string getProp(const std::string key){

--- a/Code/JavaWrappers/RDProps.i
+++ b/Code/JavaWrappers/RDProps.i
@@ -1,7 +1,6 @@
 /* 
-* $Id: Bond.i 2519 2013-05-17 03:01:18Z glandrum $
 *
-*  Copyright (c) 2010, Novartis Institutes for BioMedical Research Inc.
+*  Copyright (c) 2015, Novartis Institutes for BioMedical Research Inc.
 *  All rights reserved.
 * 
 * Redistribution and use in source and binary forms, with or without
@@ -31,35 +30,13 @@
 * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-%include "std_string.i"
-%include "std_vector.i"
-%include "std_map.i"
-%include "std_pair.i"
-
 %{
 #include <RDGeneral/types.h>
-#include <GraphMol/Bond.h>
-#include <GraphMol/FileParsers/MolFileStereochem.h>
+#include <RDGeneral/RDProps.h>
 %}
 
-%ignore RDKit::Bond::getValenceContrib(const Atom *) const;
-%ignore RDKit::Bond::Match(const Bond *) const;
-%ignore RDKit::Bond::setBeginAtom(Atom *at);
-%ignore RDKit::Bond::setEndAtom(Atom *at);
 
-%include <GraphMol/Bond.h>
+%include <RDGeneral/RDProps.h>
 
-%extend RDKit::Bond {
-  std::string getProp(const std::string key){
-    std::string res;
-    ($self)->getProp(key, res);
-    return res;
-  }
-
-  /* Methods from MolFileStereoChem.h */
-  Bond::BondDir DetermineBondWedgeState(const RDKit::INT_MAP_INT &wedgeBonds,
-                                        const RDKit::Conformer *conf) {
-    RDKit::DetermineBondWedgeState(($self), wedgeBonds, conf);
-  }
-}
-
+/* For the time being, assume all properties will be strings */
+%template(setProp)  RDKit::RDProps::setProp<std::string>;

--- a/Code/JavaWrappers/ROMol.i
+++ b/Code/JavaWrappers/ROMol.i
@@ -109,9 +109,6 @@
 %}
 %include <GraphMol/ROMol.h>
 
-/* For the time being, assume all properties will be strings */
-%template(setProp)  RDKit::ROMol::setProp<std::string>;
-
 
 %newobject removeHs;
 %newobject addHs;

--- a/Code/JavaWrappers/gmwrapper/GraphMolJava.i
+++ b/Code/JavaWrappers/gmwrapper/GraphMolJava.i
@@ -93,6 +93,7 @@ typedef unsigned long long int	uintmax_t;
 #endif
 
 %shared_ptr(std::exception)
+%shared_ptr(RDKit::RDProps)
 %shared_ptr(RDKit::ROMol)
 %shared_ptr(RDKit::RWMol)
 %shared_ptr(RDKit::Atom)
@@ -154,6 +155,7 @@ typedef unsigned long long int	uintmax_t;
 %include "../types.i"
 // Conformer seems to need to come before ROMol
 %include "../Conformer.i"
+%include "../RDProps.i"
 %include "../ROMol.i"
 %include "../RWMol.i"
 %include "../Bond.i"

--- a/Code/RDGeneral/CMakeLists.txt
+++ b/Code/RDGeneral/CMakeLists.txt
@@ -15,7 +15,12 @@ rdkit_headers(Exceptions.h
               Dict.h
               FileParseException.h
               Invariant.h
+              RDAny.h
+              RDValue.h
+              RDValue-doublemagic.h
+              RDValue-taggedunion.h
               RDLog.h
+              RDProps.h
               StreamOps.h
               types.h
               utils.h
@@ -29,4 +34,5 @@ if (NOT RDK_INSTALL_INTREE)
         PATTERN ".svn" EXCLUDE)
 endif (NOT RDK_INSTALL_INTREE)
 rdkit_test(testDict testDict.cpp LINK_LIBRARIES RDGeneral)
+rdkit_test(testRDValue testRDValue.cpp LINK_LIBRARIES RDGeneral)
 

--- a/Code/RDGeneral/Dict.cpp
+++ b/Code/RDGeneral/Dict.cpp
@@ -10,42 +10,7 @@
 //
 #include "Dict.h"
 
-#include <boost/shared_array.hpp>
-#include <boost/cstdint.hpp>
-#include <boost/tuple/tuple.hpp>
-#include <boost/utility.hpp>
-#include <boost/type_traits.hpp>
-#include <vector>
-#include <list>
-#include <iostream>
-#include <sstream>
-#include <RDGeneral/LocaleSwitcher.h>
-
 namespace RDKit {
-namespace {
-template <class T>
-std::string vectToString(const boost::any &val) {
-  const std::vector<T> &tv = boost::any_cast<std::vector<T> >(val);
-  std::ostringstream sstr;
-  sstr << "[";
-  std::copy(tv.begin(), tv.end(), std::ostream_iterator<T>(sstr, ","));
-  sstr << "]";
-  return sstr.str();
-}
-std::string intVectToString(const boost::any &val) {
-  return vectToString<int>(val);
-}
-std::string uintVectToString(const boost::any &val) {
-  return vectToString<unsigned int>(val);
-}
-std::string doubleVectToString(const boost::any &val) {
-  // there is a performance cost associated with the
-  // LocaleSwitcher, so make sure we only instantiate it when
-  // it's really necessary (this was github #703)
-  Utils::LocaleSwitcher ls;
-  return vectToString<double>(val);
-}
-}
 
 void Dict::getVal(const std::string &what, std::string &res) const {
   //
@@ -58,38 +23,15 @@ void Dict::getVal(const std::string &what, std::string &res) const {
   //  little bit by trying that and, if the cast fails, attempting a couple of
   //  other casts, which will then be lexically cast to type T.
   //
-  if (!hasVal(what)) throw KeyErrorException(what);
-  const boost::any &val = _data.find(what)->second;
-  try {
-    res = boost::any_cast<std::string>(val);
-  } catch (const boost::bad_any_cast &) {
-    if (val.type() == typeid(int)) {
-      res = boost::lexical_cast<std::string>(boost::any_cast<int>(val));
-    } else if (val.type() == typeid(unsigned int)) {
-      res =
-          boost::lexical_cast<std::string>(boost::any_cast<unsigned int>(val));
-    } else if (val.type() == typeid(long)) {
-      res = boost::lexical_cast<std::string>(boost::any_cast<long>(val));
-    } else if (val.type() == typeid(unsigned long)) {
-      res =
-          boost::lexical_cast<std::string>(boost::any_cast<unsigned long>(val));
-    } else if (val.type() == typeid(float)) {
-      Utils::LocaleSwitcher ls;  // late instantiation of LocaleSwitcher
-      res = boost::lexical_cast<std::string>(boost::any_cast<float>(val));
-    } else if (val.type() == typeid(double)) {
-      Utils::LocaleSwitcher ls;  // late instantiation of LocaleSwitcher
-      res = boost::lexical_cast<std::string>(boost::any_cast<double>(val));
-    } else if (val.type() == typeid(const char *)) {
-      res = std::string(boost::any_cast<const char *>(val));
-    } else if (val.type() == typeid(std::vector<unsigned int>)) {
-      res = uintVectToString(val);
-    } else if (val.type() == typeid(std::vector<int>)) {
-      res = intVectToString(val);
-    } else {
-      throw;
+  for(size_t i=0; i< _data.size(); ++i) {
+    if (_data[i].key == what) {
+      rdvalue_tostring(_data[i].val, res);
+      return;
     }
+
   }
-};
+  throw KeyErrorException(what);    
+}
 
 bool Dict::getValIfPresent(const std::string &what, std::string &res) const {
   //
@@ -102,129 +44,13 @@ bool Dict::getValIfPresent(const std::string &what, std::string &res) const {
   //  little bit by trying that and, if the cast fails, attempting a couple of
   //  other casts, which will then be lexically cast to type T.
   //
-  DataType::const_iterator pos = _data.find(what);
-  if (pos == _data.end()) return false;
-  const boost::any &val = pos->second;
-  try {
-    res = boost::any_cast<std::string>(val);
-  } catch (const boost::bad_any_cast &) {
-    if (val.type() == typeid(int)) {
-      res = boost::lexical_cast<std::string>(boost::any_cast<int>(val));
-    } else if (val.type() == typeid(unsigned int)) {
-      res =
-          boost::lexical_cast<std::string>(boost::any_cast<unsigned int>(val));
-    } else if (val.type() == typeid(long)) {
-      res = boost::lexical_cast<std::string>(boost::any_cast<long>(val));
-    } else if (val.type() == typeid(unsigned long)) {
-      res =
-          boost::lexical_cast<std::string>(boost::any_cast<unsigned long>(val));
-    } else if (val.type() == typeid(float)) {
-      Utils::LocaleSwitcher ls;  // late instantiation of LocaleSwitcher
-      res = boost::lexical_cast<std::string>(boost::any_cast<float>(val));
-    } else if (val.type() == typeid(double)) {
-      Utils::LocaleSwitcher ls;  // late instantiation of LocaleSwitcher
-      res = boost::lexical_cast<std::string>(boost::any_cast<double>(val));
-    } else if (val.type() == typeid(const char *)) {
-      res = std::string(boost::any_cast<const char *>(val));
-    } else if (val.type() == typeid(std::vector<unsigned int>)) {
-      res = uintVectToString(val);
-    } else if (val.type() == typeid(std::vector<int>)) {
-      res = intVectToString(val);
-    } else {
-      return false;
+  for(size_t i=0; i< _data.size(); ++i) {
+    if (_data[i].key == what) {
+      rdvalue_tostring(_data[i].val, res);
+      return true;
     }
   }
-  return true;
-};
-
-namespace {
-template <class T>
-typename boost::enable_if<boost::is_floating_point<T>, T>::type _fromany(
-    const boost::any &arg) {
-  T res;
-  if (arg.type() == typeid(std::string) || arg.type() == typeid(const char *)) {
-    Utils::LocaleSwitcher ls;  // late instantiation of LocaleSwitcher
-    try {
-      res = boost::any_cast<T>(arg);
-    } catch (const boost::bad_any_cast &exc) {
-      try {
-        res = boost::lexical_cast<T>(boost::any_cast<std::string>(arg));
-      } catch (...) {
-        throw exc;
-      }
-    }
-  } else {
-    res = boost::any_cast<T>(arg);
-  }
-  return res;
+  return false;
 }
-template <class T>
-typename boost::enable_if<boost::is_integral<T>, T>::type _fromany(
-    const boost::any &arg) {
-  T res;
-  if (arg.type() == typeid(std::string) || arg.type() == typeid(const char *)) {
-    try {
-      res = boost::any_cast<T>(arg);
-    } catch (const boost::bad_any_cast &exc) {
-      try {
-        res = boost::lexical_cast<T>(boost::any_cast<std::string>(arg));
-      } catch (...) {
-        throw exc;
-      }
-    }
-  } else {
-    res = boost::any_cast<T>(arg);
-  }
-  return res;
-}
-template <class T>
-typename boost::disable_if<boost::is_arithmetic<T>, T>::type _fromany(
-    const boost::any &arg) {
-  return boost::any_cast<T>(arg);
-}
-}
-template <typename T>
-T Dict::fromany(const boost::any &arg) const {
-  return _fromany<T>(arg);
-};
-template <typename T>
-boost::any Dict::toany(T arg) const {
-  return boost::any(arg);
-};
 
-#define ANY_FORCE(T)                                        \
-  template T Dict::fromany<T>(const boost::any &arg) const; \
-  template boost::any Dict::toany<T>(T arg) const;
-
-ANY_FORCE(bool);
-ANY_FORCE(boost::shared_array<double>);
-ANY_FORCE(boost::shared_array<int>);
-ANY_FORCE(double);
-ANY_FORCE(int);
-ANY_FORCE(std::list<int>);
-ANY_FORCE(std::string);
-ANY_FORCE(std::vector<boost::shared_array<double> >);
-ANY_FORCE(std::vector<boost::shared_array<int> >);
-ANY_FORCE(std::vector<double>);
-ANY_FORCE(std::vector<int>);
-ANY_FORCE(std::vector<std::list<int> >);
-ANY_FORCE(std::vector<std::string>);
-ANY_FORCE(std::vector<std::vector<double> >);
-ANY_FORCE(std::vector<std::vector<int> >);
-ANY_FORCE(std::vector<unsigned int>);
-ANY_FORCE(std::vector<unsigned long long>);
-ANY_FORCE(unsigned int);
-
-template const std::string &Dict::fromany<const std::string &>(
-    const boost::any &arg) const;
-
-typedef boost::tuples::tuple<boost::uint32_t, boost::uint32_t, boost::uint32_t>
-    uint32_t_tuple;
-typedef boost::tuples::tuple<double, double, double> double_tuple;
-
-template uint32_t_tuple Dict::fromany<uint32_t_tuple>(
-    const boost::any &arg) const;
-template boost::any Dict::toany<uint32_t_tuple>(uint32_t_tuple arg) const;
-template double_tuple Dict::fromany<double_tuple>(const boost::any &arg) const;
-template boost::any Dict::toany<double_tuple>(double_tuple arg) const;
 }

--- a/Code/RDGeneral/Dict.h
+++ b/Code/RDGeneral/Dict.h
@@ -18,8 +18,8 @@
 #include <map>
 #include <string>
 #include <vector>
-#include <boost/any.hpp>
-#include <RDGeneral/Exceptions.h>
+#include "RDValue.h"
+#include "Exceptions.h"
 #include <boost/lexical_cast.hpp>
 
 namespace RDKit {
@@ -28,29 +28,61 @@ typedef std::vector<std::string> STR_VECT;
 //! \brief The \c Dict class can be used to store objects of arbitrary
 //!        type keyed by \c strings.
 //!
-//!  The actual storage is done using \c boost::any objects.
+//!  The actual storage is done using \c RDAny objects.
 //!
 class Dict {
- public:
-  typedef std::map<std::string, boost::any> DataType;
-  Dict() { _data.clear(); };
+  struct Pair {
+    std::string key;
+    RDValue val;
 
-  Dict(const Dict &other) : _data(other._data){};
+   Pair() : key(), val() {}
+   Pair(const std::string &s, const RDValue &v) : key(s), val(v) {
+   }
+  };
+  
+  typedef std::vector<Pair> DataType;
+public:
+  Dict() : _data(), _hasNonPodData(false) {  };
 
+  Dict(const Dict &other) : _data(other._data) {
+    _hasNonPodData = other._hasNonPodData;
+    if (_hasNonPodData) {
+      std::vector<Pair> data(other._data.size());
+      _data.swap(data);
+      for (size_t i=0; i< _data.size(); ++i) {
+        _data[i].key = other._data[i].key;
+        copy_rdvalue(_data[i].val, other._data[i].val);
+      }
+    }   
+  }
+  
+  ~Dict() {
+    reset(); // to clear pointers if necessary
+  }
+  
   Dict &operator=(const Dict &other) {
-    _data = other._data;
+    _hasNonPodData = other._hasNonPodData;
+    if (_hasNonPodData) {
+      std::vector<Pair> data(other._data.size());
+      _data.swap(data);
+      for (size_t i=0; i< _data.size(); ++i) {
+        _data[i].key = other._data[i].key;
+        copy_rdvalue(_data[i].val, other._data[i].val);
+      }
+    } else {
+      _data = other._data;      
+    }    
     return *this;
   };
 
   //----------------------------------------------------------
   //! \brief Returns whether or not the dictionary contains a particular
   //!        key.
-  bool hasVal(const char *what) const {
-    std::string key(what);
-    return hasVal(key);
-  };
   bool hasVal(const std::string &what) const {
-    return _data.find(what) != _data.end();
+    for(size_t i=0 ; i< _data.size(); ++i) {
+      if (_data[i].key == what ) return true;
+    }
+    return false;
   };
 
   //----------------------------------------------------------
@@ -62,7 +94,7 @@ class Dict {
     STR_VECT res;
     DataType::const_iterator item;
     for (item = _data.begin(); item != _data.end(); item++) {
-      res.push_back(item->first);
+      res.push_back(item->key);
     }
     return res;
   }
@@ -87,33 +119,16 @@ class Dict {
   //! \overload
   template <typename T>
   T getVal(const std::string &what) const {
-    DataType::const_iterator pos = _data.find(what);
-    if (pos == _data.end()) throw KeyErrorException(what);
-    const boost::any &val = pos->second;
-    return fromany<T>(val);
+    for(size_t i=0; i< _data.size(); ++i) {
+      if (_data[i].key == what) {
+        return from_rdvalue<T>(_data[i].val);
+      }
+    }
+    throw KeyErrorException(what);
   }
 
   //! \overload
-  template <typename T>
-  T getVal(const char *what,
-           T &res) const {  // FIX: it doesn't really fit that this returns T
-    std::string key(what);
-    res = getVal<T>(key);
-    return res;
-  };
-  //! \overload
-  template <typename T>
-  T getVal(const char *what) const {
-    std::string key(what);
-    return getVal<T>(key);
-  };
-
-  //! \overload
   void getVal(const std::string &what, std::string &res) const;
-  //! \overload
-  void getVal(const char *what, std::string &res) const {
-    getVal(std::string(what), res);
-  };
 
   //----------------------------------------------------------
   //! \brief Potentially gets the value associated with a particular key
@@ -132,25 +147,18 @@ class Dict {
 
   template <typename T>
   bool getValIfPresent(const std::string &what, T &res) const {
-    DataType::const_iterator pos = _data.find(what);
-    if (pos == _data.end()) return false;
-    const boost::any &val = pos->second;
-    res = fromany<T>(val);
-    return true;
+    for(size_t i=0; i< _data.size(); ++i) {
+      if (_data[i].key == what) {
+        res = from_rdvalue<T>(_data[i].val);
+        return true;
+      }
+    }
+    return false;
   };
 
-  template <typename T>
-  bool getValIfPresent(const char *what, T &res) const {
-    std::string key(what);
-    return getValIfPresent<T>(key, res);
-  };
 
   //! \overload
   bool getValIfPresent(const std::string &what, std::string &res) const;
-  //! \overload
-  bool getValIfPresent(const char *what, std::string &res) const {
-    return getValIfPresent(std::string(what), res);
-  };
 
   //----------------------------------------------------------
   //! \brief Sets the value associated with a key
@@ -167,14 +175,66 @@ class Dict {
   */
   template <typename T>
   void setVal(const std::string &what, T &val) {
-    _data[what] = toany(val);
+    _hasNonPodData = true;
+    for(size_t i=0; i< _data.size(); ++i) {
+      if (_data[i].key == what) {
+        _data[i].val = val;
+        return;
+      }
+    }
+    _data.push_back(Pair(what, val));
   };
-  //! \overload
-  template <typename T>
-  void setVal(const char *what, T &val) {
-    std::string key = what;
-    setVal(key, val);
-  };
+
+  void setVal(const std::string &what, bool val) {
+    for(size_t i=0; i< _data.size(); ++i) {
+      if (_data[i].key == what) {
+        _data[i].val = val;
+        return;
+      }
+    }
+    _data.push_back(Pair(what, val));
+  }
+
+  void setVal(const std::string &what, double val) {
+    for(size_t i=0; i< _data.size(); ++i) {
+      if (_data[i].key == what) {
+        _data[i].val = val;
+        return;
+      }
+    }
+    _data.push_back(Pair(what, val));
+  }
+  
+  void setVal(const std::string &what, float val) {
+    for(size_t i=0; i< _data.size(); ++i) {
+      if (_data[i].key == what) {
+        _data[i].val = val;
+        return;
+      }
+    }
+    _data.push_back(Pair(what, val));
+  }
+  
+  void setVal(const std::string &what, int val) {
+    for(size_t i=0; i< _data.size(); ++i) {
+      if (_data[i].key == what) {
+        _data[i].val = val;
+        return;
+      }
+    }
+    _data.push_back(Pair(what, val));    
+  }
+  
+  void setVal(const std::string &what, unsigned int val) {
+    for(size_t i=0; i< _data.size(); ++i) {
+      if (_data[i].key == what) {
+        _data[i].val = val;
+        return;
+      }
+    }
+    _data.push_back(Pair(what, val));
+  }
+  
   //! \overload
   void setVal(const std::string &what, const char *val) {
     std::string h(val);
@@ -193,43 +253,58 @@ class Dict {
         a KeyErrorException will be thrown.
   */
   void clearVal(const std::string &what) {
-    if (!this->hasVal(what)) throw KeyErrorException(what);
-    _data.erase(what);
-  };
-
-  //! \overload
-  void clearVal(const char *what) {
-    std::string key = what;
-    clearVal(key);
+    for(DataType::iterator it = _data.begin(); it < _data.end() ; ++it) {
+      if (it->key == what) {
+        _data.erase(it);
+        return;
+      }
+    }
+    throw KeyErrorException(what);
   };
 
   //----------------------------------------------------------
   //! \brief Clears all keys (and values) from the dictionary.
   //!
-  void reset() { _data.clear(); };
+  void reset() {
+    if (_hasNonPodData) {
+      for (size_t i=0; i< _data.size(); ++i) {
+        RDValue::cleanup_rdvalue(_data[i].val);
+      }
+    }
+    DataType data;
+    _data.swap(data);
+  };
 
   //----------------------------------------------------------
-  //! Converts a \c boost::any to type \c T
+  //! Converts a \c RDAny to type \c T
   /*!
-     \param arg a \c boost::any reference
+     \param arg a \c RDAny reference
 
      \returns the converted object of type \c T
   */
+  /*
   template <typename T>
-  T fromany(const boost::any &arg) const;
-
+      T fromany(const RDAny &arg) const {
+    return from_rdany<T>(arg);
+  }
+  */
   //----------------------------------------------------------
-  //! Converts an instance of type \c T to \c boost::any
+  //! Converts an instance of type \c T to \c RDAny
   /*!
      \param arg the object to be converted
 
-     \returns a \c boost::any instance
+     \returns a \c RDAny instance
   */
+  /*
   template <typename T>
-  boost::any toany(T arg) const;
-
+      RDAny toany(T arg) const {
+    return RDAny(arg);
+  };
+  */
  private:
   DataType _data;  //!< the actual dictionary
+  bool     _hasNonPodData; // if true, need a deep copy
+                           //  (copy_rdvalue)
 };
 }
 #endif

--- a/Code/RDGeneral/Dict.h
+++ b/Code/RDGeneral/Dict.h
@@ -28,7 +28,7 @@ typedef std::vector<std::string> STR_VECT;
 //! \brief The \c Dict class can be used to store objects of arbitrary
 //!        type keyed by \c strings.
 //!
-//!  The actual storage is done using \c RDAny objects.
+//!  The actual storage is done using \c RDValue objects.
 //!
 class Dict {
   struct Pair {
@@ -185,7 +185,9 @@ public:
     _data.push_back(Pair(what, val));
   };
 
-  void setVal(const std::string &what, bool val) {
+  template <typename T>
+  void setPODVal(const std::string &what, T val) {
+    _hasNonPodData = true;
     for(size_t i=0; i< _data.size(); ++i) {
       if (_data[i].key == what) {
         _data[i].val = val;
@@ -193,46 +195,26 @@ public:
       }
     }
     _data.push_back(Pair(what, val));
+  };
+  
+  void setVal(const std::string &what, bool val) {
+    setPODVal(what, val);
   }
 
   void setVal(const std::string &what, double val) {
-    for(size_t i=0; i< _data.size(); ++i) {
-      if (_data[i].key == what) {
-        _data[i].val = val;
-        return;
-      }
-    }
-    _data.push_back(Pair(what, val));
+    setPODVal(what, val);
   }
   
   void setVal(const std::string &what, float val) {
-    for(size_t i=0; i< _data.size(); ++i) {
-      if (_data[i].key == what) {
-        _data[i].val = val;
-        return;
-      }
-    }
-    _data.push_back(Pair(what, val));
+    setPODVal(what, val);
   }
   
   void setVal(const std::string &what, int val) {
-    for(size_t i=0; i< _data.size(); ++i) {
-      if (_data[i].key == what) {
-        _data[i].val = val;
-        return;
-      }
-    }
-    _data.push_back(Pair(what, val));    
+    setPODVal(what, val);
   }
   
   void setVal(const std::string &what, unsigned int val) {
-    for(size_t i=0; i< _data.size(); ++i) {
-      if (_data[i].key == what) {
-        _data[i].val = val;
-        return;
-      }
-    }
-    _data.push_back(Pair(what, val));
+    setPODVal(what, val);
   }
   
   //! \overload

--- a/Code/RDGeneral/Invariant.h
+++ b/Code/RDGeneral/Invariant.h
@@ -17,7 +17,7 @@
 #include <iostream>
 #include <stdexcept>
 
-#include <RDGeneral/RDLog.h>
+#include "RDLog.h"
 
 #ifdef RDDEBUG
 // Enable RDDEBUG for testing whether rdcast

--- a/Code/RDGeneral/RDAny.h
+++ b/Code/RDGeneral/RDAny.h
@@ -1,0 +1,216 @@
+//  Copyright (c) 2015, Novartis Institutes for BioMedical Research Inc.
+//  All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+//       copyright notice, this list of conditions and the following
+//       disclaimer in the documentation and/or other materials provided
+//       with the distribution.
+//     * Neither the name of Novartis Institutes for BioMedical Research Inc.
+//       nor the names of its contributors may be used to endorse or promote
+//       products derived from this software without specific prior written
+//       permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+#ifndef RDKIT_RDANY_H
+#define RDKIT_RDANY_H
+#include <boost/any.hpp>
+#include <boost/utility.hpp>
+#include <boost/lexical_cast.hpp>
+#include "LocaleSwitcher.h"
+#include "RDValue.h"
+#include <string>
+#include <vector>
+#include <iostream>
+#include <sstream>
+namespace RDKit {
+
+// RDValue does not dynamically create POD types (kind of like
+//  cdiggins::any)  However, it doesn't use RTTI type info
+//  directly, it uses a companion short valued type
+//  to determine what to do.
+// For unregistered types, it falls back to boost::any.
+//  The Size of an RDAny is (sizeof(double) + sizeof(short) == 10 bytes)
+//
+//   For the sake of compatibility, errors throw boost::bad_any_cast
+//
+// Examples:
+//
+//   RDAny v(2.);
+//   v = 1;
+//   std::vector<double> d;
+//   v == d;
+//   v.asDoubleVect().push_back(4.)
+//   rdany_cast<std::vector<double>(v).push_back(4.)
+//
+//   Falls back to boost::any for non registered types
+//   v = boost::shared_ptr<ROMol>(new ROMol(m));
+//
+
+// Safe container for RDValue -- cleans up memory and copy constructs
+struct RDAny {
+  RDValue m_value;
+
+  RDAny() : m_value() {}
+  template <class T> RDAny(const T &d) : m_value(d) {}
+  /*
+  explicit RDAny(bool v) : m_value(v) {}
+  template <class T>
+  explicit RDAny(std::vector<T> *v) : m_value(v) {}
+  template <class T>
+  explicit RDAny(const boost::shared_ptr<T> &v) : m_value(v) {}
+  */
+  RDAny(const RDAny &rhs) {
+    copy_rdvalue(m_value, rhs.m_value);
+  }
+
+  ~RDAny() { RDValue::cleanup_rdvalue(m_value); }
+
+  // For easy of use:
+  //   RDAny v;
+  //   v = 2.0;
+  //   v = std::string("foo...");
+
+  RDAny &operator=(const RDAny &rhs) {
+    copy_rdvalue(m_value, rhs.m_value);
+    return *this;
+  }
+
+  RDAny &operator=(float d) {
+    RDValue::cleanup_rdvalue(m_value);
+    m_value = RDValue(d);
+    return *this;
+  }
+
+  RDAny &operator=(int d) {
+    RDValue::cleanup_rdvalue(m_value);
+    m_value = RDValue(d);
+    return *this;
+  }
+
+  RDAny &operator=(unsigned int d) {
+    RDValue::cleanup_rdvalue(m_value);
+    m_value = RDValue(d);
+    return *this;
+  }
+
+  RDAny &operator=(bool d) {
+    RDValue::cleanup_rdvalue(m_value);
+    m_value = RDValue(d);
+    return *this;
+  }
+
+  RDAny &operator=(const std::string &d) {
+    RDValue::cleanup_rdvalue(m_value);
+    m_value = RDValue(d);
+    return *this;
+  }
+
+  RDAny &operator=(const std::vector<double> &d) {
+    RDValue::cleanup_rdvalue(m_value);
+    m_value = RDValue(d);
+    return *this;
+  }
+
+  RDAny &operator=(const std::vector<float> &d) {
+    RDValue::cleanup_rdvalue(m_value);
+    m_value = RDValue(d);
+    return *this;
+  }
+
+  RDAny &operator=(const std::vector<int> &d) {
+    RDValue::cleanup_rdvalue(m_value);
+    m_value = RDValue(d);
+    return *this;
+  }
+
+  RDAny &operator=(const std::vector<unsigned int> &d) {
+    RDValue::cleanup_rdvalue(m_value);
+    m_value = d;
+    return *this;
+  }
+
+  RDAny &operator=(const std::vector<std::string> &d) {
+    RDValue::cleanup_rdvalue(m_value);
+    m_value = RDValue(d);
+    return *this;
+  }
+
+  RDAny &operator=(const boost::any &d) {
+    RDValue::cleanup_rdvalue(m_value);
+    m_value = RDValue(d);//new boost::any(d);
+    return *this;
+  }
+
+  template<class T>
+  RDAny &operator=(const T &d) {
+    RDValue::cleanup_rdvalue(m_value);
+    boost::any *v = new boost::any(d);
+    m_value = RDValue(v);
+    return *this;
+  }
+    
+};
+
+////////////////////////////////////////////////////////////////
+// rdany_cast
+////////////////////////////////////////////////////////////////
+
+
+// Const Access
+template <class T>
+const T rdany_cast(const RDAny &d) {
+  return rdvalue_cast<T>(d.m_value);
+}
+
+// Direct access
+template <class T>
+T rdany_cast(RDAny &d) {
+  return rdvalue_cast<T>(d.m_value);
+}
+
+template <class T>
+typename boost::enable_if<boost::is_arithmetic<T>, T>::type from_rdany(
+    const RDAny &arg) {
+  T res;
+  if (arg.m_value.getTag() == RDTypeTag::StringTag) {
+    Utils::LocaleSwitcher ls;
+    try {
+      res = rdany_cast<T>(arg);
+    } catch (const boost::bad_any_cast &exc) {
+      try {
+        res = boost::lexical_cast<T>(rdany_cast<std::string>(arg));
+      } catch (...) {
+        throw exc;
+      }
+    }
+  } else {
+    res = rdany_cast<T>(arg);
+  }
+  return res;
+}
+
+template <class T>
+typename boost::disable_if<boost::is_arithmetic<T>, T>::type from_rdany(
+    const RDAny &arg) {
+  return rdany_cast<T>(arg);
+}
+
+}
+#endif

--- a/Code/RDGeneral/RDProps.h
+++ b/Code/RDGeneral/RDProps.h
@@ -1,0 +1,150 @@
+#ifndef RDKIT_RDPROPS_H
+#define RDKIT_RDPROPS_H
+#include "Dict.h"
+#include "types.h"
+#include <boost/foreach.hpp>
+
+namespace RDKit {
+
+class RDProps {
+protected:
+  mutable Dict dp_props;
+  // It is a quirk of history that this is mutable
+  //  as the RDKit allows properties to be set
+  //  on const obects.
+
+ public:
+  RDProps() : dp_props() {}
+  RDProps(const RDProps &rhs) : dp_props(rhs.dp_props) {}
+  RDProps& operator=(const RDProps &rhs) {
+    dp_props = rhs.dp_props;
+    return *this;
+  }
+  void clear() {
+    dp_props.reset();
+  }
+  // ------------------------------------
+  //  Local Property Dict functionality
+  //  all setProp functions are const because they
+  //     are not meant to change the atom chemically
+  // ------------------------------------
+  //! returns a list with the names of our \c properties
+  STR_VECT getPropList(bool includePrivate = true,
+                       bool includeComputed = true) const {
+    const STR_VECT &tmp = dp_props.keys();
+    STR_VECT res, computed;
+    if (!includeComputed &&
+        getPropIfPresent(detail::computedPropName, computed)) {
+      computed.push_back(detail::computedPropName);
+    }
+
+    STR_VECT::const_iterator pos = tmp.begin();
+    while (pos != tmp.end()) {
+      if ((includePrivate || (*pos)[0] != '_') &&
+          std::find(computed.begin(), computed.end(), *pos) == computed.end()) {
+        res.push_back(*pos);
+      }
+      pos++;
+    }
+    return res;
+  }
+  
+  //! sets a \c property value
+  /*!
+    \param key the name under which the \c property should be stored.
+    If a \c property is already stored under this name, it will be
+    replaced.
+    \param val the value to be stored
+    \param computed (optional) allows the \c property to be flagged
+    \c computed.
+  */
+
+  //! \overload
+  template <typename T>
+  void setProp(const std::string &key, T val, bool computed = false) const {
+    if (computed) {
+      STR_VECT compLst;
+      getPropIfPresent(detail::computedPropName, compLst);
+      if (std::find(compLst.begin(), compLst.end(), key) == compLst.end()) {
+        compLst.push_back(key);
+        dp_props.setVal(detail::computedPropName, compLst);
+      }
+    }
+    // setProp(key.c_str(),val);
+    dp_props.setVal(key, val);
+  }
+
+  //! allows retrieval of a particular property value
+  /*!
+
+    \param key the name under which the \c property should be stored.
+    If a \c property is already stored under this name, it will be
+    replaced.
+    \param res a reference to the storage location for the value.
+
+    <b>Notes:</b>
+    - if no \c property with name \c key exists, a KeyErrorException will be
+    thrown.
+    - the \c boost::lexical_cast machinery is used to attempt type
+    conversions.
+    If this fails, a \c boost::bad_lexical_cast exception will be thrown.
+
+  */
+  //! \overload
+  template <typename T>
+  void getProp(const std::string &key, T &res) const {
+    dp_props.getVal(key, res);
+  }
+
+  //! \overload
+  template <typename T>
+  T getProp(const std::string &key) const {
+    return dp_props.getVal<T>(key);
+  }
+
+  //! returns whether or not we have a \c property with name \c key
+  //!  and assigns the value if we do
+  //! \overload
+  template <typename T>
+  bool getPropIfPresent(const std::string &key, T &res) const {
+    return dp_props.getValIfPresent(key, res);
+  }
+
+  //! \overload
+  bool hasProp(const std::string &key) const {
+    return dp_props.hasVal(key);
+  };
+
+  //! clears the value of a \c property
+  /*!
+    <b>Notes:</b>
+    - if no \c property with name \c key exists, a KeyErrorException
+    will be thrown.
+    - if the \c property is marked as \c computed, it will also be removed
+    from our list of \c computedProperties
+  */
+  //! \overload
+  void clearProp(const std::string &key) const {
+    STR_VECT compLst;
+    if (getPropIfPresent(detail::computedPropName, compLst)) {
+      STR_VECT_I svi = std::find(compLst.begin(), compLst.end(), key);
+      if (svi != compLst.end()) {
+        compLst.erase(svi);
+        dp_props.setVal(detail::computedPropName, compLst);
+      }
+    }
+    dp_props.clearVal(key);
+  };
+
+  //! clears all of our \c computed \c properties
+  void clearComputedProps() const {
+    STR_VECT compLst;
+    if (getPropIfPresent(detail::computedPropName, compLst)) {
+      BOOST_FOREACH (const std::string &sv, compLst) { dp_props.clearVal(sv); }
+      compLst.clear();
+      dp_props.setVal(detail::computedPropName, compLst);
+    }
+  }
+};
+}
+#endif

--- a/Code/RDGeneral/RDValue-doublemagic.h
+++ b/Code/RDGeneral/RDValue-doublemagic.h
@@ -224,6 +224,11 @@ struct RDValue {
   }
   
   uint64_t getTag() const {
+    if (otherBits < RDTypeTag::MaxDouble ||
+        (otherBits & RDTypeTag::NaN) == RDTypeTag::NaN) {
+      return RDTypeTag::DoubleTag;
+    }
+    
     uint64_t tag = otherBits & TagMask;
     if (tag == RDTypeTag::PtrTag)
       return otherBits & PointerTagMask;

--- a/Code/RDGeneral/RDValue-doublemagic.h
+++ b/Code/RDGeneral/RDValue-doublemagic.h
@@ -1,0 +1,410 @@
+//  Copyright (c) 2015, Novartis Institutes for BioMedical Research Inc.
+//  All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+//       copyright notice, this list of conditions and the following
+//       disclaimer in the documentation and/or other materials provided
+//       with the distribution.
+//     * Neither the name of Novartis Institutes for BioMedical Research Inc.
+//       nor the names of its contributors may be used to endorse or promote
+//       products derived from this software without specific prior written
+//       permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+#ifndef RDKIT_RDVALUE_PTRMAGIC_H
+#define RDKIT_RDVALUE_PTRMAGIC_H
+
+#include <stdint.h>
+#include <cassert>
+#include <boost/any.hpp>
+#include "Invariant.h"
+#include <iostream>
+#include <iomanip>
+#include <sstream>
+#include <vector>
+#include <string>
+#include <boost/utility.hpp>
+#include <boost/lexical_cast.hpp>
+#include <cmath>
+#include <boost/type_traits.hpp>
+#include <boost/static_assert.hpp>
+#include "LocaleSwitcher.h"
+#include <boost/detail/endian.hpp>
+
+#if defined(BOOST_BIG_ENDIAN) 
+BOOST_STATIC_ASSERT(false && "RDValue only has been tested under little endian cpus");
+#endif
+
+namespace RDKit {
+
+  // Inspired by
+  // https://nikic.github.io/2012/02/02/Pointer-magic-for-efficient-dynamic-value-representations.html
+// 16 bit storage for value types using Quiet NaN spaces in
+//  doubles
+// Won't work on Solaris and some other os's as mmaping maps from
+// top memory down
+// Example check:
+//     std::string *pointer = new std::string(v);
+//      assert((reinterpret_cast<uint64_t>(pointer) & StringTag) == 0);
+
+//  implementations, need a typedef at compile time to figure this out.
+//  current implementation is probably little endian, need to check.
+  
+/*
+  Encoding for storing other things as a double.  Use
+  Quiet NaN
+  Quiet NaN: // used to encode types
+   F   F    F   1XXX < - X = type bits (first bit is set to one)
+
+  seeeeeee|eeeemmmm|mmmmmmmm|mmmmmmmm|mmmmmmmm|mmmmmmmm|mmmmmmmm|mmmmmmmm
+  s1111111|11111ppp|pppppppp|pppppppp|pppppppp|pppppppp|pppppppp|pppppppp
+               ^- first mantissa bit 1    everything else is "payload" -^
+   ^- exponent bits all 1                 and mustn't be all-zero (as it
+  ^- any sign bit                         would be INF then)
+
+  Available 
+  8 = 1000 MaxDouble // Not really a tag, is a sentinel
+  9 = 1001 Float
+  b = 1010 Int32
+  a = 1011 Uint32
+  C = 1100 <none>
+  D = 1101 <none>
+  E = 1110 <none>
+  F = 1111 PtrTag (look at lower 3 bits for type)
+*/ 
+
+namespace RDTypeTag {
+  static const uint64_t NaN       = 0xfff7FFFFFFFFFFFF; // signalling NaN
+  static const uint64_t MaxDouble = 0xfff8000000000000; //
+  static const uint64_t DoubleTag = 0xfff8000000000000; // 
+  static const uint64_t FloatTag  = 0xfff9000000000000; // 
+  static const uint64_t IntTag  = 0xfffa000000000000; // 
+  static const uint64_t UnsignedIntTag = 0xfffb000000000000;
+  
+  // PTR Tags use the last 3 bits for typing info
+  static const uint64_t PtrTag            = 0xffff000000000000;
+  static const uint64_t StringTag         = 0xffff000000000001; //001
+  static const uint64_t VecDoubleTag      = 0xffff000000000002; //010
+  static const uint64_t VecFloatTag       = 0xffff000000000003; //011
+  static const uint64_t VecIntTag         = 0xffff000000000004; //100
+  static const uint64_t VecUnsignedIntTag = 0xffff000000000005; //101
+  static const uint64_t VecStringTag      = 0xffff000000000006; //110
+  static const uint64_t AnyTag            = 0xffff000000000007; //111
+
+  // Retrieves the tag (and PtrMask) from the type
+  template<class T> inline uint64_t GetTag() { return AnyTag; }
+  template<> inline uint64_t GetTag<double>() { return MaxDouble; }
+  template<> inline uint64_t GetTag<float>() { return FloatTag; }
+  template<> inline uint64_t GetTag<int>() { return IntTag; }
+  template<> inline uint64_t GetTag<unsigned int>() { return UnsignedIntTag; }
+  template<> inline uint64_t GetTag<std::string>() { return StringTag; }
+  template<> inline uint64_t GetTag<std::vector<double> >() { return VecDoubleTag; }
+  template<> inline uint64_t GetTag<std::vector<float> >() { return VecFloatTag; }
+  template<> inline uint64_t GetTag<std::vector<int> >() { return VecIntTag; }
+  template<> inline uint64_t GetTag<std::vector<unsigned int> >() { return VecUnsignedIntTag; }
+  template<> inline uint64_t GetTag<std::vector<std::string> >() { return VecStringTag; }
+  template<> inline uint64_t GetTag<boost::any>() { return AnyTag; }
+}
+
+
+struct RDValue {
+  // Bit Twidling for conversion from the Tag to a Pointer
+  static const uint64_t TagMask         = 0xFFFF000000000000;
+  static const uint64_t PointerTagMask  = 0xFFFF000000000007;
+  static const uint64_t ApplyMask       = 0x0000FFFFFFFFFFFF;
+  static const uint64_t ApplyPtrMask    = 0x0000FFFFFFFFFFF8;
+  
+  union {
+    double  doubleBits;
+    uint64_t otherBits;
+  };
+
+  inline RDValue() : doubleBits(0.0) {}
+  
+  inline RDValue(double number) {
+    if (boost::math::isnan(number)) {
+      // Store a signalling NaN for NaN's.
+      //  quiet NaNs are used for other types.
+      otherBits = RDTypeTag::NaN;
+      assert(boost::math::isnan(doubleBits));
+    }
+    else
+      doubleBits = number;
+  }
+
+  inline RDValue(float number) {
+    otherBits = 0 | RDTypeTag::FloatTag;
+    memcpy(((char*)&otherBits), &number, sizeof(float));
+  }
+    
+  inline RDValue(int32_t number) {
+    otherBits = (((uint64_t)number) & ApplyMask ) | RDTypeTag::IntTag;
+  }
+
+  inline RDValue(unsigned int number) {
+    otherBits = (((uint64_t)number) & ApplyMask ) | RDTypeTag::UnsignedIntTag;
+  }
+  
+  inline RDValue(bool number) {
+    otherBits = (static_cast<uint64_t>(number) & ApplyMask) | RDTypeTag::IntTag;
+  }
+
+  inline RDValue(boost::any *pointer) {
+    // ensure that the pointer really is only 48 bit
+    assert((reinterpret_cast<uint64_t>(pointer) & RDTypeTag::AnyTag) == 0);
+    otherBits = reinterpret_cast<uint64_t>(pointer) | RDTypeTag::AnyTag;
+  }
+  
+  inline RDValue(const boost::any &any) {
+    // ensure that the pointer really is only 48 bit
+    boost::any *pointer = new boost::any(any);
+    assert((reinterpret_cast<uint64_t>(pointer) & RDTypeTag::AnyTag) == 0);
+    otherBits = reinterpret_cast<uint64_t>(pointer) | RDTypeTag::AnyTag;
+  }
+
+  // Unknown types are stored as boost::any
+  template <class T>
+  inline RDValue(const T&v) {
+    boost::any *pointer = new boost::any(v);
+    assert((reinterpret_cast<uint64_t>(pointer) & RDTypeTag::AnyTag) == 0);
+    otherBits = reinterpret_cast<uint64_t>(pointer) | RDTypeTag::AnyTag;
+  }
+  
+  inline RDValue(const std::string &v) {
+    std::string *pointer = new std::string(v);
+    assert((reinterpret_cast<uint64_t>(pointer) & RDTypeTag::StringTag) == 0);
+    otherBits = reinterpret_cast<uint64_t>(pointer) | RDTypeTag::StringTag;
+  }
+
+  inline RDValue(const std::vector<double> &v) {
+    std::vector<double> *pointer = new std::vector<double>(v);
+    assert((reinterpret_cast<uint64_t>(pointer) & RDTypeTag::VecDoubleTag) == 0);
+    otherBits = reinterpret_cast<uint64_t>(pointer) | RDTypeTag::VecDoubleTag;
+  }
+
+  inline RDValue(const std::vector<float> &v) {
+    std::vector<float> *pointer = new std::vector<float>(v);
+    assert((reinterpret_cast<uint64_t>(pointer) & RDTypeTag::VecFloatTag) == 0);
+    otherBits = reinterpret_cast<uint64_t>(pointer) | RDTypeTag::VecFloatTag;
+  }
+  
+  inline RDValue(const std::vector<int> &v) {
+    std::vector<int> *pointer = new std::vector<int>(v);
+    assert((reinterpret_cast<uint64_t>(pointer) & RDTypeTag::VecIntTag) == 0);
+    otherBits = reinterpret_cast<uint64_t>(pointer) | RDTypeTag::VecIntTag;    
+  }
+
+  inline RDValue(const std::vector<unsigned int> &v) {
+    std::vector<unsigned int> *pointer = new std::vector<unsigned int>(v);
+    assert((reinterpret_cast<uint64_t>(pointer) & RDTypeTag::VecIntTag) == 0);
+    otherBits = reinterpret_cast<uint64_t>(pointer) | RDTypeTag::VecUnsignedIntTag;    
+  }
+  
+  inline RDValue(const std::vector<std::string> &v) {
+    std::vector<std::string> *pointer = new std::vector<std::string>(v);
+    assert((reinterpret_cast<uint64_t>(pointer) & RDTypeTag::VecStringTag) == 0);
+    otherBits = reinterpret_cast<uint64_t>(pointer) | RDTypeTag::VecStringTag;        
+  }
+  
+  uint64_t getTag() const {
+    uint64_t tag = otherBits & TagMask;
+    if (tag == RDTypeTag::PtrTag)
+      return otherBits & PointerTagMask;
+    return tag;
+  }
+
+  // ptrCast - unsafe, use rdvalue_cast instead.
+  template<class T>
+  inline T* ptrCast() const {
+    return reinterpret_cast<T*>(otherBits & ~RDTypeTag::GetTag<T>());
+  }
+
+  // RDValue doesn't have an explicit destructor, it must
+  //  be wrapped in a container.
+  // The idea is that POD types don't need to be destroyed
+  //  and this allows the container optimization possibilities.
+  inline void destroy() {
+    switch(getTag()) {
+      case RDTypeTag::StringTag:
+        delete ptrCast<std::string>();
+        break;
+      case RDTypeTag::VecDoubleTag:
+        delete ptrCast<std::vector<double> >();
+        break;
+      case RDTypeTag::VecFloatTag:
+        delete ptrCast<std::vector<float> >();
+        break;
+      case RDTypeTag::VecIntTag:
+        delete ptrCast<std::vector<int> >();
+        break;
+      case RDTypeTag::VecUnsignedIntTag:
+        delete ptrCast<std::vector<unsigned int> >();
+        break;
+      case RDTypeTag::VecStringTag:
+        delete ptrCast<std::vector<std::string> >();
+        break;
+      case RDTypeTag::AnyTag:
+        delete ptrCast<boost::any>();
+        break;
+      default:
+        break;
+    }
+  }
+  
+  static
+  inline void cleanup_rdvalue(RDValue v) { v.destroy(); }
+
+};
+
+/////////////////////////////////////////////////////////////////////////////////////
+// Given two RDValue::Values - copy the appropriate structure
+//   RDValue doesn't have a copy constructor, the default
+//   copy act's like a move for better value semantics.
+//  Containers may need to copy though.
+inline void copy_rdvalue(RDValue &dest,
+                         const RDValue &src) {
+  dest.destroy();
+  switch(src.getTag()) {
+    case RDTypeTag::StringTag:
+      dest = RDValue(*src.ptrCast<std::string>());
+      break;
+    case RDTypeTag::VecDoubleTag:
+      dest = RDValue(*src.ptrCast<std::vector<double> >());
+      break;
+    case RDTypeTag::VecFloatTag:
+      dest = RDValue(*src.ptrCast<std::vector<float> >());
+      break;
+    case RDTypeTag::VecIntTag:
+      dest = RDValue(*src.ptrCast<std::vector<int> >());
+      break;
+    case RDTypeTag::VecUnsignedIntTag:
+      dest = RDValue(*src.ptrCast<std::vector<unsigned int> >());
+      break;
+    case RDTypeTag::VecStringTag:
+      dest = RDValue(*src.ptrCast<std::vector<std::string> >());
+      break;
+    case RDTypeTag::AnyTag:
+      dest = RDValue(*src.ptrCast<boost::any>());
+      break;
+    default:
+      dest = src;
+  }
+}
+
+/////////////////////////////////////////////////////////////////////////////////////
+// rdvalue_is<T>
+
+template<class T>
+inline bool rdvalue_is(RDValue v) {
+  return v.getTag() == RDTypeTag::GetTag<typename boost::remove_reference<T>::type>();
+}
+
+template<>
+inline bool rdvalue_is<double>(RDValue v) {
+  return v.otherBits < RDTypeTag::MaxDouble ||
+      (v.otherBits & RDTypeTag::NaN) == RDTypeTag::NaN;
+}
+
+template<>
+inline bool rdvalue_is<const double &>(RDValue v) {
+  return rdvalue_is<double>(v);
+}
+
+template<>
+inline bool rdvalue_is<bool>(RDValue v) {
+  return (v.getTag() == RDTypeTag::IntTag &&
+          (static_cast<int32_t>(v.otherBits & ~RDTypeTag::IntTag) == 1 ||
+           static_cast<int32_t>(v.otherBits & ~RDTypeTag::IntTag) == 0 ));
+}
+
+template<>
+inline bool rdvalue_is<const bool&>(RDValue v) {
+  return rdvalue_is<bool>(v);
+}
+
+/////////////////////////////////////////////////////////////////////////////////////
+// rdvalue_cast<T>
+//
+//  POD types do not support reference semantics.  Other types do.
+// rdvalue_cast<const std::vector<double> &>(RDValue);  // ok
+// rdvalue_cast<const float &>(RDValue); // bad_any_cast
+
+ typedef RDValue RDValue_cast_t;
+// Get stuff stored in boost any
+template<class T>
+inline T rdvalue_cast(RDValue v) {
+  // Disable reference and pointer casts to POD data.
+  BOOST_STATIC_ASSERT( !(
+      (boost::is_pointer<T>::value && (
+          boost::is_integral<typename boost::remove_pointer<T>::type>::value ||
+          boost::is_floating_point<typename boost::remove_pointer<T>::type>::value)) ||
+      (boost::is_reference<T>::value && (
+          boost::is_integral<typename boost::remove_reference<T>::type>::value ||
+          boost::is_floating_point<typename boost::remove_reference<T>::type>::value))
+                         ));
+
+  if (rdvalue_is<boost::any>(v)) {
+    return boost::any_cast<T>(*v.ptrCast<boost::any>());
+  }
+  throw boost::bad_any_cast();
+}
+
+// POD casts
+template<>
+inline double rdvalue_cast<double>(RDValue v) {
+  if (rdvalue_is<double>(v)) return v.doubleBits;
+  throw boost::bad_any_cast();
+}
+
+template<>
+inline float rdvalue_cast<float>(RDValue v) {
+  if (rdvalue_is<float>(v)) {
+    float f;
+    memcpy(&f, ((char*)&v.otherBits), sizeof(float));
+    return f;
+  }
+  throw boost::bad_any_cast();
+}
+
+// n.b. with const expressions, could use ~RDTagTypes::GetTag<T>()
+//  and enable_if
+template<>
+inline int rdvalue_cast<int>(RDValue v) {
+  if (rdvalue_is<int>(v)) return static_cast<int32_t>(v.otherBits &
+                                                      ~RDTypeTag::IntTag);
+  throw boost::bad_any_cast();
+}
+template<>
+inline unsigned int rdvalue_cast<unsigned int>(RDValue v) {
+  if (rdvalue_is<unsigned int>(v)) return static_cast<uint32_t>(
+          v.otherBits & ~RDTypeTag::UnsignedIntTag);
+  throw boost::bad_any_cast();
+}
+
+template<>
+inline bool rdvalue_cast<bool>(RDValue v) {
+  if (rdvalue_is<bool>(v)) return static_cast<int32_t>(
+          v.otherBits & ~RDTypeTag::IntTag);
+  throw boost::bad_any_cast();
+}
+
+} // namespace rdkit
+#endif
+

--- a/Code/RDGeneral/RDValue-doublemagic.h
+++ b/Code/RDGeneral/RDValue-doublemagic.h
@@ -46,11 +46,8 @@
 #include <boost/type_traits.hpp>
 #include <boost/static_assert.hpp>
 #include "LocaleSwitcher.h"
-#include <boost/detail/endian.hpp>
 
-#if defined(BOOST_BIG_ENDIAN) 
-BOOST_STATIC_ASSERT(false && "RDValue only has been tested under little endian cpus");
-#endif
+#define RDVALUE_HASBOOL
 
 namespace RDKit {
 
@@ -96,7 +93,8 @@ namespace RDTypeTag {
   static const uint64_t DoubleTag = 0xfff8000000000000; // 
   static const uint64_t FloatTag  = 0xfff9000000000000; // 
   static const uint64_t IntTag  = 0xfffa000000000000; // 
-  static const uint64_t UnsignedIntTag = 0xfffb000000000000;
+  static const uint64_t UnsignedIntTag = 0xfffb000000000000; //
+  static const uint64_t BoolTag        = 0xfffc000000000000; //  
   
   // PTR Tags use the last 3 bits for typing info
   static const uint64_t PtrTag            = 0xffff000000000000;
@@ -114,6 +112,7 @@ namespace RDTypeTag {
   template<> inline uint64_t GetTag<float>() { return FloatTag; }
   template<> inline uint64_t GetTag<int>() { return IntTag; }
   template<> inline uint64_t GetTag<unsigned int>() { return UnsignedIntTag; }
+  template<> inline uint64_t GetTag<bool>() { return BoolTag; }
   template<> inline uint64_t GetTag<std::string>() { return StringTag; }
   template<> inline uint64_t GetTag<std::vector<double> >() { return VecDoubleTag; }
   template<> inline uint64_t GetTag<std::vector<float> >() { return VecFloatTag; }
@@ -163,7 +162,7 @@ struct RDValue {
   }
   
   inline RDValue(bool number) {
-    otherBits = (static_cast<uint64_t>(number) & ApplyMask) | RDTypeTag::IntTag;
+    otherBits = (static_cast<uint64_t>(number) & ApplyMask) | RDTypeTag::BoolTag;
   }
 
   inline RDValue(boost::any *pointer) {
@@ -332,6 +331,7 @@ inline bool rdvalue_is<const double &>(RDValue v) {
   return rdvalue_is<double>(v);
 }
 
+/*
 template<>
 inline bool rdvalue_is<bool>(RDValue v) {
   return (v.getTag() == RDTypeTag::IntTag &&
@@ -343,6 +343,7 @@ template<>
 inline bool rdvalue_is<const bool&>(RDValue v) {
   return rdvalue_is<bool>(v);
 }
+*/
 
 /////////////////////////////////////////////////////////////////////////////////////
 // rdvalue_cast<T>
@@ -405,8 +406,8 @@ inline unsigned int rdvalue_cast<unsigned int>(RDValue v) {
 
 template<>
 inline bool rdvalue_cast<bool>(RDValue v) {
-  if (rdvalue_is<bool>(v)) return static_cast<int32_t>(
-          v.otherBits & ~RDTypeTag::IntTag);
+  if (rdvalue_is<bool>(v)) return static_cast<bool>(
+          v.otherBits & ~RDTypeTag::BoolTag);
   throw boost::bad_any_cast();
 }
 

--- a/Code/RDGeneral/RDValue-taggedunion.h
+++ b/Code/RDGeneral/RDValue-taggedunion.h
@@ -1,0 +1,355 @@
+//  Copyright (c) 2015, Novartis Institutes for BioMedical Research Inc.
+//  All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+//       copyright notice, this list of conditions and the following
+//       disclaimer in the documentation and/or other materials provided
+//       with the distribution.
+//     * Neither the name of Novartis Institutes for BioMedical Research Inc.
+//       nor the names of its contributors may be used to endorse or promote
+//       products derived from this software without specific prior written
+//       permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+#ifndef RDKIT_RDVALUE_TAGGED_UNION_H
+#define RDKIT_RDVALUE_TAGGED_UNION_H
+
+#include <stdint.h>
+#include <cassert>
+#include <boost/any.hpp>
+#include "Invariant.h"
+#include <iostream>
+#include <iomanip>
+#include <sstream>
+#include <vector>
+#include <boost/utility.hpp>
+#include <boost/lexical_cast.hpp>
+#include "LocaleSwitcher.h"
+
+#define RDVALUE_HASBOOL
+
+namespace RDKit {
+
+// RDValue does not dynamically create POD types (kind of like
+//  cdiggins::any)  However, it doesn't use RTTI type info
+//  directly, it uses a companion short valued type
+//  to determine what to do.
+// For unregistered types, it falls back to boost::any.
+//  The Size of an RDAny is (sizeof(double) + sizeof(short) == 10 bytes
+//   (aligned to actually 16 so hard to pass as value type)
+//
+//   For the sake of compatibility, errors throw boost::bad_any_cast
+//
+// Examples:
+//
+//   RDAny v(2.);
+//   v = 1;
+//   std::vector<double> d;
+//   v == d;
+//   v.asDoubleVect().push_back(4.)
+//   rdany_cast<std::vector<double>(v).push_back(4.)
+//
+//   Falls back to boost::any for non registered types
+//   v = boost::shared_ptr<ROMol>(new ROMol(m));
+//
+
+// RDValue does not manange memory of non-pod data
+//  this must be done externally (string, Any, vector...)
+// Tagged union
+
+namespace RDTypeTag {
+  const short EmptyTag           = 0;
+  const short IntTag             = 1;
+  const short DoubleTag          = 2;
+  const short StringTag          = 3;
+  const short FloatTag           = 4;
+  const short BoolTag            = 5;
+  const short UnsignedIntTag     = 6;
+  const short AnyTag             = 7;
+  const short VecDoubleTag       = 8;
+  const short VecFloatTag        = 9;
+  const short VecIntTag          = 10;
+  const short VecUnsignedIntTag  = 11;
+  const short VecStringTag       = 12;
+  template<class T> inline short GetTag() { return AnyTag; }
+  template<> inline short GetTag<double>() { return DoubleTag; }
+  template<> inline short GetTag<float>() { return FloatTag; }
+  template<> inline short GetTag<int>() { return IntTag; }
+  template<> inline short GetTag<unsigned int>() { return UnsignedIntTag; }
+  template<> inline short GetTag<bool>() { return BoolTag; }
+  template<> inline short GetTag<std::string>() { return StringTag; }
+  template<> inline short GetTag<std::vector<double> >() { return VecDoubleTag; }
+  template<> inline short GetTag<std::vector<float> >() { return VecFloatTag; }
+  template<> inline short GetTag<std::vector<int> >() { return VecIntTag; }
+  template<> inline short GetTag<std::vector<unsigned int> >() { return VecUnsignedIntTag; }
+  template<> inline short GetTag<std::vector<std::string> >() { return VecStringTag; }
+  template<> inline short GetTag<boost::any>() { return AnyTag; }
+
+  namespace detail {
+    union Value {
+      double d;
+      float f;
+      int i;
+      unsigned u;
+      bool b;
+      std::string *s;
+      boost::any *a;
+      std::vector<double> *vd;
+      std::vector<float> *vf;
+      std::vector<int> *vi;
+      std::vector<unsigned int> *vu;
+      std::vector<std::string> *vs;
+      
+      inline Value() {}
+      inline Value(double v) : d(v) {}
+      inline Value(float v) : f(v) {}
+      inline Value(int v) : i(v) {}
+      inline Value(unsigned int v) : u(v) {}
+      inline Value(bool  v) : b(v) {}
+      inline Value(std::string *v) : s(v) {}
+      inline Value(boost::any *v) : a(v) {}
+      inline Value(std::vector<double> *v) : vd(v) {}
+      inline Value(std::vector<float> *v) : vf(v) {}
+      inline Value(std::vector<int> *v) : vi(v) {}
+      inline Value(std::vector<unsigned int> *v) : vu(v) {}
+      inline Value(std::vector<std::string> *v) : vs(v) {}
+    };
+  
+    template<class T>
+        inline T* valuePtrCast(Value value) {
+      return boost::any_cast<T*>(*value.a);
+    }
+    template<>
+    inline boost::any *valuePtrCast<boost::any>(Value value) { return value.a; }
+
+    template<>
+    inline std::string *valuePtrCast<std::string>(Value value) { return value.s; }
+    template<>
+    inline std::vector<double> *valuePtrCast<std::vector<double> >(Value value) {
+      return value.vd; }
+    template<>
+    inline std::vector<float> *valuePtrCast<std::vector<float> >(Value value) {
+      return value.vf; }
+    template<>
+    inline std::vector<int> *valuePtrCast<std::vector<int> >(Value value) {
+      return value.vi; }
+    template<>
+    inline std::vector<unsigned int> *valuePtrCast<std::vector<unsigned int> >(
+        Value value) {
+      return value.vu; }
+    template<>
+    inline std::vector<std::string> *valuePtrCast<std::vector<std::string> >(
+        Value value) {
+      return value.vs; }
+  }
+}
+
+struct RDValue {
+  RDTypeTag::detail::Value value;
+  short type;
+  short reserved_tag; // 16 bit alignment
+
+ inline RDValue(): value(0.0), type(RDTypeTag::EmptyTag) {}
+  // Pod Style (Direct storage)
+ inline RDValue(double v)   : value(v), type(RDTypeTag::DoubleTag) {}
+ inline RDValue(float v)    : value(v), type(RDTypeTag::FloatTag) {}
+ inline RDValue(int v)      : value(v), type(RDTypeTag::IntTag) {}
+ inline RDValue(unsigned v) : value(v), type(RDTypeTag::UnsignedIntTag) {}
+ inline RDValue(bool v)     : value(v), type(RDTypeTag::BoolTag) {}
+
+ inline RDValue(boost::any *v)  : value(v),type(RDTypeTag::AnyTag) {}
+
+  // Copies passed in pointers
+ inline RDValue(const boost::any &v)  : value(new boost::any(v)),type(RDTypeTag::AnyTag) {}
+ inline RDValue(const std::string &v) : value(new std::string(v)),type(RDTypeTag::StringTag){};
+ template <class T>
+ inline RDValue(const T &v) : value(new boost::any(v)),type(RDTypeTag::AnyTag) {}
+
+ inline RDValue(const std::vector<double> &v) : value(new std::vector<double>(v)),
+    type(RDTypeTag::VecDoubleTag) {}
+ inline RDValue(const std::vector<float> &v)  : value(new std::vector<float>(v)),
+    type(RDTypeTag::VecFloatTag) {}
+ inline RDValue(const std::vector<int> &v)    : value(new std::vector<int>(v)),
+    type(RDTypeTag::VecIntTag) {}
+ inline RDValue(const std::vector<unsigned int> &v) :
+  value(new std::vector<unsigned int>(v)),
+    type(RDTypeTag::VecUnsignedIntTag) {}
+ inline RDValue(const std::vector<std::string> &v) :
+  value(new std::vector<std::string>(v)),
+    type(RDTypeTag::VecStringTag) {}
+
+  short getTag() const { return type; }
+  
+  // ptrCast - unsafe, use rdvalue_cast instead.
+  template<class T>
+  inline T* ptrCast() const {
+    return RDTypeTag::detail::valuePtrCast<T>(value);
+  }
+
+  // RDValue doesn't have an explicit destructor, it must
+  //  be wrapped in a container.
+  // The idea is that POD types don't need to be destroyed
+  //  and this allows the container optimization possibilities.  
+  void destroy() {
+    switch (type) {
+      case RDTypeTag::StringTag:
+        delete value.s;
+        break;
+      case RDTypeTag::AnyTag:
+        delete value.a;
+        break;
+      case RDTypeTag::VecDoubleTag:
+        delete value.vd;
+        break;
+      case RDTypeTag::VecFloatTag:
+        delete value.vf;
+        break;
+      case RDTypeTag::VecIntTag:
+        delete value.vi;
+        break;
+      case RDTypeTag::VecUnsignedIntTag:
+        delete value.vu;
+        break;
+      case RDTypeTag::VecStringTag:
+        delete value.vs;
+        break;
+      default:
+        break;
+    }
+    type = RDTypeTag::EmptyTag;
+  }
+
+  static // Given a type and an RDAnyValue - delete the appropriate structure
+  inline void cleanup_rdvalue(RDValue &rdvalue) {
+    rdvalue.destroy();
+  }
+};
+
+/////////////////////////////////////////////////////////////////////////////////////
+// Given two RDValue::Values - copy the appropriate structure
+//   RDValue doesn't have a copy constructor, the default
+//   copy act's like a move for better value semantics.
+//  Containers may need to copy though.
+inline void copy_rdvalue(RDValue &dest,
+                         const RDValue &src) {
+  dest.destroy();
+  dest.type = src.type;
+  switch (src.type) {
+    case RDTypeTag::StringTag:
+      dest.value.s = new std::string(*src.value.s);
+      break;
+    case RDTypeTag::AnyTag:
+      dest.value.a = new boost::any(*src.value.a);
+      break;
+    case RDTypeTag::VecDoubleTag:
+      dest.value.vd = new std::vector<double>(*src.value.vd);
+      break;
+    case RDTypeTag::VecFloatTag:
+      dest.value.vf = new std::vector<float>(*src.value.vf);
+      break;
+    case RDTypeTag::VecIntTag:
+      dest.value.vi = new std::vector<int>(*src.value.vi);
+      break;
+    case RDTypeTag::VecUnsignedIntTag:
+      dest.value.vu = new std::vector<unsigned int>(*src.value.vu);
+      break;
+    case RDTypeTag::VecStringTag:
+      dest.value.vs = new std::vector<std::string>(*src.value.vs);
+      break;
+    default:
+      dest = src;
+  }
+}
+
+/////////////////////////////////////////////////////////////////////////////////////
+// rdvalue_is<T>
+
+template<class T>
+inline bool rdvalue_is(RDValue v) {
+  return v.getTag() == RDTypeTag::GetTag<typename boost::remove_reference<T>::type>();
+}
+
+/////////////////////////////////////////////////////////////////////////////////////
+// rdvalue_cast<T>
+//
+//  POD types do not support reference semantics.  Other types do.
+// rdvalue_cast<const std::vector<double> &>(RDValue);  // ok
+// rdvalue_cast<const float &>(RDValue); // bad_any_cast
+
+#ifdef RDK_32BIT_BUILD
+ // avoid register pressure and spilling on 32 bit systems
+ typedef const RDValue& RDValue_cast_t;
+#else
+ typedef RDValue RDValue_cast_t;
+#endif
+
+// Get stuff stored in boost any
+template<class T>
+inline T rdvalue_cast(RDValue_cast_t v) {
+  // Disable reference and pointer casts to POD data.
+  BOOST_STATIC_ASSERT( !(
+      (boost::is_pointer<T>::value && (
+          boost::is_integral<typename boost::remove_pointer<T>::type>::value ||
+          boost::is_floating_point<typename boost::remove_pointer<T>::type>::value)) ||
+      (boost::is_reference<T>::value && (
+          boost::is_integral<typename boost::remove_reference<T>::type>::value ||
+          boost::is_floating_point<typename boost::remove_reference<T>::type>::value))
+                         ));
+
+  if (rdvalue_is<boost::any>(v)) {
+    return boost::any_cast<T>(*v.ptrCast<boost::any>());
+  }
+  throw boost::bad_any_cast();
+}
+
+// POD casts
+template<>
+inline double rdvalue_cast<double>(RDValue_cast_t v) {
+  if (rdvalue_is<double>(v)) return v.value.d;
+  throw boost::bad_any_cast();
+}
+
+template<>
+inline float rdvalue_cast<float>(RDValue_cast_t v) {
+  if (rdvalue_is<float>(v)) return v.value.f;
+  throw boost::bad_any_cast();
+}
+
+template<>
+inline int rdvalue_cast<int>(RDValue_cast_t v) {
+  if (rdvalue_is<int>(v)) return v.value.i;
+  throw boost::bad_any_cast();
+}
+template<>
+inline unsigned int rdvalue_cast<unsigned int>(RDValue_cast_t v) {
+  if (rdvalue_is<unsigned int>(v)) return v.value.u;
+  throw boost::bad_any_cast();
+}
+
+template<>
+inline bool rdvalue_cast<bool>(RDValue_cast_t v) {
+  if (rdvalue_is<bool>(v)) return v.value.b;
+  throw boost::bad_any_cast();
+}
+
+
+} // namespace rdkit
+#endif
+

--- a/Code/RDGeneral/RDValue.h
+++ b/Code/RDGeneral/RDValue.h
@@ -1,0 +1,257 @@
+//  Copyright (c) 2015, Novartis Institutes for BioMedical Research Inc.
+//  All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+//       copyright notice, this list of conditions and the following
+//       disclaimer in the documentation and/or other materials provided
+//       with the distribution.
+//     * Neither the name of Novartis Institutes for BioMedical Research Inc.
+//       nor the names of its contributors may be used to endorse or promote
+//       products derived from this software without specific prior written
+//       permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+#ifndef RDKIT_RDVALUE_H
+#define RDKIT_RDVALUE_H
+
+//#define UNSAFE_RDVALUE
+#ifdef UNSAFE_RDVALUE
+#include "RDValue-doublemagic.h"
+#else
+#include "RDValue-taggedunion.h"
+#endif
+
+namespace RDKit {
+//  Common Casts (POD Casts are implementation dependent)
+// string casts
+template<>
+inline std::string rdvalue_cast<std::string>(RDValue_cast_t v) {
+  if (rdvalue_is<std::string>(v)) return *v.ptrCast<std::string>();
+  throw boost::bad_any_cast();
+}
+
+template<>
+inline std::string & rdvalue_cast<std::string&>(RDValue_cast_t v) {
+  if (rdvalue_is<std::string>(v)) return *v.ptrCast<std::string>();
+  throw boost::bad_any_cast();
+}
+
+// Special Vecor Casts
+template<>
+inline std::vector<double> rdvalue_cast<std::vector<double> >(RDValue_cast_t v) {
+  if(rdvalue_is<std::vector<double> >(v))
+    return *v.ptrCast<std::vector<double> >();
+  throw boost::bad_any_cast();
+}
+
+template<>
+inline std::vector<double> &rdvalue_cast<std::vector<double> &>(RDValue_cast_t v) {
+  if(rdvalue_is<std::vector<double> >(v))
+    return *v.ptrCast<std::vector<double> >();
+  throw boost::bad_any_cast();
+}
+
+template<>
+inline std::vector<float> rdvalue_cast<std::vector<float> >(RDValue_cast_t v) {
+  if(rdvalue_is<std::vector<float> >(v))
+    return *v.ptrCast<std::vector<float> >();
+  throw boost::bad_any_cast();
+}
+
+template<>
+inline std::vector<float> &rdvalue_cast<std::vector<float> &>(RDValue_cast_t v) {
+  if(rdvalue_is<std::vector<float> >(v))
+    return *v.ptrCast<std::vector<float> >();
+  throw boost::bad_any_cast();
+}
+
+template<>
+inline std::vector<std::string> rdvalue_cast<std::vector<std::string> >(RDValue_cast_t v) {
+  if(rdvalue_is<std::vector<std::string> >(v))
+    return *v.ptrCast<std::vector<std::string> >();
+  throw boost::bad_any_cast();
+}
+
+template<>
+inline std::vector<std::string> &rdvalue_cast<std::vector<std::string> &>(RDValue_cast_t v) {
+  if(rdvalue_is<std::vector<std::string> >(v))
+    return *v.ptrCast<std::vector<std::string> >();
+  throw boost::bad_any_cast();
+}
+
+template<>
+inline std::vector<int> rdvalue_cast<std::vector<int> >(RDValue_cast_t v) {
+  if(rdvalue_is<std::vector<int> >(v))
+    return *v.ptrCast<std::vector<int> >();
+  throw boost::bad_any_cast();
+}
+
+template<>
+inline std::vector<int> &rdvalue_cast<std::vector<int> &>(RDValue_cast_t v) {
+  if(rdvalue_is<std::vector<int> >(v))
+    return *v.ptrCast<std::vector<int> >();
+  throw boost::bad_any_cast();
+}
+
+template<>
+inline std::vector<unsigned int> rdvalue_cast<std::vector<unsigned int> >(RDValue_cast_t v) {
+  if(rdvalue_is<std::vector<unsigned int> >(v))
+    return *v.ptrCast<std::vector<unsigned int> >();
+  throw boost::bad_any_cast();
+}
+
+template<>
+inline std::vector<unsigned int> &rdvalue_cast<std::vector<unsigned int> &>(RDValue_cast_t v) {
+  if(rdvalue_is<std::vector<unsigned int> >(v))
+    return *v.ptrCast<std::vector<unsigned int> >();
+  throw boost::bad_any_cast();
+}
+
+// Get boost any
+template<>
+inline boost::any rdvalue_cast<boost::any>(RDValue_cast_t v) {
+  if (rdvalue_is<boost::any>(v)) {
+    return *v.ptrCast<boost::any>();
+  }
+  throw boost::bad_any_cast();
+}
+
+template<>
+inline boost::any &rdvalue_cast<boost::any&>(RDValue_cast_t v) {
+  if (rdvalue_is<boost::any>(v)) {
+    return *v.ptrCast<boost::any>();
+  }
+  throw boost::bad_any_cast();
+}
+
+template<>
+inline const boost::any &rdvalue_cast<const boost::any&>(RDValue_cast_t v) {
+  if (rdvalue_is<boost::any>(v)) {
+    return *v.ptrCast<boost::any>();
+  }
+  throw boost::bad_any_cast();
+}
+
+/////////////////////////////////////////////////////////////////////////////////////
+// lexical casts...
+template <class T>
+    std::string vectToString(RDValue val) {
+  const std::vector<T> &tv = rdvalue_cast<std::vector<T>&>(val);
+  std::ostringstream sstr;
+  sstr.imbue(std::locale("C"));
+  sstr << std::setprecision(17);
+  sstr << "[";
+  std::copy(tv.begin(), tv.end(), std::ostream_iterator<T>(sstr, ","));
+  sstr << "]";
+  return sstr.str();
+}
+
+inline bool rdvalue_tostring(RDValue_cast_t val, std::string &res) {
+  Utils::LocaleSwitcher ls; // for lexical cast...
+  switch (val.getTag()) {
+    case RDTypeTag::StringTag:
+      res = rdvalue_cast<std::string>(val);
+      break;
+    case RDTypeTag::IntTag:
+      res = boost::lexical_cast<std::string>(rdvalue_cast<int>(val));
+      break;
+    case RDTypeTag::DoubleTag:
+      res = boost::lexical_cast<std::string>(rdvalue_cast<double>(val));
+      break;
+    case RDTypeTag::UnsignedIntTag:
+      res = boost::lexical_cast<std::string>(rdvalue_cast<unsigned int>(val));
+      break;
+#ifdef RDVALUE_HASBOOL      
+    case RDTypeTag::BoolTag:
+      res = boost::lexical_cast<std::string>(rdvalue_cast<bool>(val));
+      break;
+#endif
+    case RDTypeTag::FloatTag:
+      res = boost::lexical_cast<std::string>(rdvalue_cast<float>(val));
+      break;
+    case RDTypeTag::VecDoubleTag:
+      res = vectToString<double>(val);
+      break;
+    case RDTypeTag::VecFloatTag:
+      res = vectToString<float>(val);
+      break;
+    case RDTypeTag::VecIntTag:
+      res = vectToString<int>(val);
+      break;
+    case RDTypeTag::VecUnsignedIntTag:
+      res = vectToString<unsigned int>(val);
+      break;
+    case RDTypeTag::VecStringTag:
+      res = vectToString<std::string>(val);
+      break;
+    case RDTypeTag::AnyTag:
+      try {
+        res = boost::any_cast<std::string>(rdvalue_cast<boost::any&>(val));
+      } catch (const boost::bad_any_cast &) {
+        if (rdvalue_cast<boost::any&>(val).type() == typeid(long)) {
+          res = boost::lexical_cast<std::string>(boost::any_cast<long>(
+              rdvalue_cast<boost::any&>(val)));
+        } else if (rdvalue_cast<boost::any&>(val).type() == typeid(unsigned long)) {
+          res =
+              boost::lexical_cast<std::string>(
+                  boost::any_cast<unsigned long>(rdvalue_cast<boost::any&>(val)));
+        } else {
+          throw;
+          return false;
+        }
+      }
+      break;
+    default:
+      res = "";
+  }
+  return true;
+}
+
+// from_rdvalue -> converts string values to appropriate types
+template <class T>
+typename boost::enable_if<boost::is_arithmetic<T>, T>::type from_rdvalue(
+    RDValue_cast_t arg) {
+  T res;
+  if (arg.getTag() == RDTypeTag::StringTag) {
+    Utils::LocaleSwitcher ls;
+    try {
+      res = rdvalue_cast<T>(arg);
+    } catch (const boost::bad_any_cast &exc) {
+      try {
+        res = boost::lexical_cast<T>(rdvalue_cast<std::string>(arg));
+      } catch (...) {
+        throw exc;
+      }
+    }
+  } else {
+    res = rdvalue_cast<T>(arg);
+  }
+  return res;
+}
+
+template <class T>
+typename boost::disable_if<boost::is_arithmetic<T>, T>::type from_rdvalue(
+    RDValue_cast_t arg) {
+  return rdvalue_cast<T>(arg);
+}
+}
+#endif
+
+

--- a/Code/RDGeneral/testDict.cpp
+++ b/Code/RDGeneral/testDict.cpp
@@ -41,7 +41,7 @@ void testRDAny() {
     for (int i=0; i<100; ++i) {
         vi += i;
         v = rdvalue_cast<int>(v) + i;
-        CHECK_INVARIANT(vi == rdvalue_cast<int>(v), "Opps, bad variant");
+        TEST_ASSERT(vi == rdvalue_cast<int>(v));
       }
                
   }
@@ -49,30 +49,30 @@ void testRDAny() {
   {
     RDAny a(1);
     RDAny b = a;
-    CHECK_INVARIANT(rdany_cast<int>(a) == 1, "Should be 1");
-    CHECK_INVARIANT(rdany_cast<int>(b) == 1, "Should be 1");
+    TEST_ASSERT(rdany_cast<int>(a) == 1);
+    TEST_ASSERT(rdany_cast<int>(b) == 1);
   }
   
   
   {
     RDAny a(1);
     RDAny b = a;
-    CHECK_INVARIANT(rdany_cast<int>(a) == 1, "should be one");
-    CHECK_INVARIANT(rdany_cast<int>(b) == rdany_cast<int>(a), "Bad Any");
+    TEST_ASSERT(rdany_cast<int>(a) == 1);
+    TEST_ASSERT(rdany_cast<int>(b) == rdany_cast<int>(a));
     std::map<std::string, RDAny> foo;
     foo["foo"] = a;
     foo["bar"] = std::string("This is a test");
-    CHECK_INVARIANT(rdany_cast<int>(foo["foo"]) == 1, "should be one");
-    CHECK_INVARIANT(rdany_cast<int>(foo["foo"]) == rdany_cast<int>(a), "Bad Any");
-    CHECK_INVARIANT(rdany_cast<std::string>(foo["bar"]) == "This is a test", "Bad Any");
+    TEST_ASSERT(rdany_cast<int>(foo["foo"]) == 1);
+    TEST_ASSERT(rdany_cast<int>(foo["foo"]) == rdany_cast<int>(a));
+    TEST_ASSERT(rdany_cast<std::string>(foo["bar"]) == "This is a test");
   }
 
   {
     bool a = true;
     RDValue v(a);
-    CHECK_INVARIANT(rdvalue_cast<bool>(v) == true, "bad value cast");
+    TEST_ASSERT(rdvalue_cast<bool>(v) == true);
     v = (int) 10;
-    CHECK_INVARIANT(rdvalue_cast<int>(v) == 10, "bad value cast");
+    TEST_ASSERT(rdvalue_cast<int>(v) == 10);
   }
   
   {
@@ -89,17 +89,17 @@ void testRDAny() {
     computed.push_back("foo");
     d.setVal(detail::computedPropName, computed);
     STR_VECT computed2 = d.getVal<STR_VECT>(detail::computedPropName);
-    CHECK_INVARIANT(computed2[0] == "foo", "bad STR_VECT");
+    TEST_ASSERT(computed2[0] == "foo");
     Dict d2(d);
     computed2 = d2.getVal<STR_VECT>(detail::computedPropName);
-    CHECK_INVARIANT(computed2[0] == "foo", "bad STR_VECT");
+    TEST_ASSERT(computed2[0] == "foo");
   }
   
   {
     Dict d;
     //int v=1;
     //d.setVal("foo", v);
-    //CHECK_INVARIANT(d.getVal<int>("foo") == 1, "bad getval");
+    //TEST_ASSERT(d.getVal<int>("foo") == 1, "bad getval");
     
     std::vector<int> fooV;
     fooV.resize(3);
@@ -112,7 +112,7 @@ void testRDAny() {
       RDAny a(fooV);
       std::cerr << "retrieve int vect" << std::endl;
       fooV2 = rdany_cast<std::vector<int> >(a);
-      CHECK_INVARIANT(fooV == fooV2, "bad getVal");
+      TEST_ASSERT(fooV == fooV2);
     }
     
     {
@@ -121,7 +121,7 @@ void testRDAny() {
       d.setVal("bar", fooV);
       std::cerr << "dict get int vect" << std::endl;
       d.getVal("bar", fooV2);
-      CHECK_INVARIANT(fooV == fooV2, "bad getVal");
+      TEST_ASSERT(fooV == fooV2);
     }
   }
   
@@ -135,9 +135,9 @@ void testRDAny() {
     RDAny baz(foo);
     
     for(int i=0;i<4;++i) { 
-      CHECK_INVARIANT(rdany_cast<std::vector<int> >(foo)[i] == i, "Failed check");
-      CHECK_INVARIANT(rdany_cast<std::vector<int> >(bar)[i] == i, "Failed check");
-      CHECK_INVARIANT(rdany_cast<std::vector<int> >(baz)[i] == i, "Failed check");
+      TEST_ASSERT(rdany_cast<std::vector<int> >(foo)[i] == i);
+      TEST_ASSERT(rdany_cast<std::vector<int> >(bar)[i] == i);
+      TEST_ASSERT(rdany_cast<std::vector<int> >(baz)[i] == i);
     }
     
   }
@@ -150,13 +150,13 @@ void testRDAny() {
     RDAny foo(v);
 
     for(int i=0;i<4;++i) { 
-      CHECK_INVARIANT(rdany_cast<std::vector<double> >(foo)[i] == i, "Failed check");
+      TEST_ASSERT(rdany_cast<std::vector<double> >(foo)[i] == i);
     }
     
     RDAny b = foo;
 
     for(int i=0;i<4;++i) { 
-      CHECK_INVARIANT(rdany_cast<std::vector<double> >(b)[i] == i, "Failed check");
+      TEST_ASSERT(rdany_cast<std::vector<double> >(b)[i] == i);
     }
   }
   const int loops = 10000000;
@@ -234,18 +234,18 @@ void testRDAny() {
   
   { // checks replacement with vector
     RDAny vv(2.0);
-    CHECK_INVARIANT(rdany_cast<double>(vv) == 2.0, "Bad double");
+    TEST_ASSERT(rdany_cast<double>(vv) == 2.0);
     
     
     std::vector<int> vect;
     vect.push_back(1);
     vv = vect;
-    CHECK_INVARIANT(rdany_cast<std::vector<int> >(vv)[0] == 1, "Bad cast");
+    TEST_ASSERT(rdany_cast<std::vector<int> >(vv)[0] == 1);
     
     // tests copy
     RDAny vvv(vv);
     
-    CHECK_INVARIANT(rdany_cast<std::vector<int> >(vvv)[0] == 1, "Bad cast");    
+    TEST_ASSERT(rdany_cast<std::vector<int> >(vvv)[0] == 1);    
   }
 
   {
@@ -264,11 +264,10 @@ void testRDAny() {
     boost::any_cast<const std::vector<std::pair<int,int> > &>(any);
     
     const std::vector<std::pair<int,int> > &pv = rdany_cast<std::vector<std::pair<int, int> > >(vv);
-    CHECK_INVARIANT(pv[0].first == 2,
-                    "Bad cast");
+    TEST_ASSERT(pv[0].first == 2);
     RDAny vvv(vv);
-    CHECK_INVARIANT((rdany_cast<std::vector<std::pair<int, int> > >(vvv)[0].first == 2),
-                    "Bad cast");
+    TEST_ASSERT((rdany_cast<std::vector<std::pair<int, int> > >(vvv)[0].first ==
+                 2));
     
   }
 
@@ -286,8 +285,8 @@ void testRDAny() {
     } catch (boost::bad_any_cast &e) {
     }
     
-    CHECK_INVARIANT((*rdany_cast<std::vector<int> *>(vv))[0] == 100, "Bad cast");
-    CHECK_INVARIANT((*rdany_cast<std::vector<int> *>((const RDAny&)vv))[0] == 100, "Bad cast");
+    TEST_ASSERT((*rdany_cast<std::vector<int> *>(vv))[0] == 100);
+    TEST_ASSERT((*rdany_cast<std::vector<int> *>((const RDAny&)vv))[0] == 100);
     delete p;
 
     std::map<int,int> *m = new std::map<int,int>();
@@ -295,8 +294,7 @@ void testRDAny() {
     RDAny mv(m);
     // leaks
     std::map<int,int> *anym = rdany_cast<std::map<int,int> *>(mv);
-    CHECK_INVARIANT(anym->find(0) != anym->end(),
-                    "Bad cast");    
+    TEST_ASSERT(anym->find(0) != anym->end());
     delete anym;
   }
 
@@ -307,9 +305,9 @@ void testRDAny() {
     p->push_back(100);
     RDAny v(p);
     RDAny vv(v);
-    CHECK_INVARIANT((*rdany_cast<vptr>(v))[0] == 100, "Bad cast");    
-    CHECK_INVARIANT((*rdany_cast<vptr>(vv))[0] == 100, "Bad cast");
-    CHECK_INVARIANT((*rdany_cast<vptr>((const RDAny&)vv))[0] == 100, "Bad cast");
+    TEST_ASSERT((*rdany_cast<vptr>(v))[0] == 100);    
+    TEST_ASSERT((*rdany_cast<vptr>(vv))[0] == 100);
+    TEST_ASSERT((*rdany_cast<vptr>((const RDAny&)vv))[0] == 100);
 
     typedef boost::shared_ptr<std::map<int,int> > mptr;
     mptr m(new std::map<int,int>());
@@ -317,11 +315,10 @@ void testRDAny() {
     RDAny mv(m);
     // leaks
     mptr anym = rdany_cast<mptr>(mv);
-    CHECK_INVARIANT(anym->find(0) != anym->end(),
-                    "Bad cast");
+    TEST_ASSERT(anym->find(0) != anym->end());
 
     RDAny any3(boost::shared_ptr<Foo>( new Foo ));
-    CHECK_INVARIANT(any3.m_value.getTag() == RDTypeTag::AnyTag, "Wrong type");
+    TEST_ASSERT(any3.m_value.getTag() == RDTypeTag::AnyTag);
   }
 }
 
@@ -556,83 +553,83 @@ int main() {
   INT_VECT fooV;
   fooV.resize(3);
   BOOST_LOG(rdInfoLog) << "dict test" << std::endl;
-  CHECK_INVARIANT(!d.hasVal("foo"), "bad init");
+  TEST_ASSERT(!d.hasVal("foo"));
   int x = 1;
   d.setVal("foo", x);
-  CHECK_INVARIANT(d.hasVal("foo"), "should be there");
-  CHECK_INVARIANT(!d.hasVal("bar"), "bad other key");
+  TEST_ASSERT(d.hasVal("foo"));
+  TEST_ASSERT(!d.hasVal("bar"));
   int v, v2;
   d.getVal("foo", v);
-  CHECK_INVARIANT(v == 1, "bad val");
+  TEST_ASSERT(v == 1);
   v2 = d.getVal<int>("foo");
-  CHECK_INVARIANT(v2 == v, "bad val");
+  TEST_ASSERT(v2 == v);
   d.setVal("bar", fooV);
   d.getVal("foo", v);
-  CHECK_INVARIANT(v == 1, "bad val");
+  TEST_ASSERT(v == 1);
   v2 = d.getVal<int>("foo");
-  CHECK_INVARIANT(v2 == v, "bad val");
+  TEST_ASSERT(v2 == v);
   INT_VECT fooV2, fooV3;
   d.getVal("bar", fooV2);
   fooV3 = d.getVal<INT_VECT>("bar");
-  CHECK_INVARIANT(fooV == fooV2, "bad getVal");
-  CHECK_INVARIANT(fooV2 == fooV3, "bad getVal");
+  TEST_ASSERT(fooV == fooV2);
+  TEST_ASSERT(fooV2 == fooV3);
 
   VECT_INT_VECT fooV4;
   fooV4.resize(3);
-  CHECK_INVARIANT(!d.hasVal("baz"), "bad get");
+  TEST_ASSERT(!d.hasVal("baz"));
   d.setVal("baz", fooV4);
-  CHECK_INVARIANT(d.hasVal("baz"), "bad get");
+  TEST_ASSERT(d.hasVal("baz"));
 
   DictCon dc1;
-  CHECK_INVARIANT(!dc1.getDict()->hasVal("foo"), "bad init");
+  TEST_ASSERT(!dc1.getDict()->hasVal("foo"));
   int y = 1;
   dc1.getDict()->setVal("foo", y);
-  CHECK_INVARIANT(dc1.getDict()->hasVal("foo"), "should be there");
-  CHECK_INVARIANT(!dc1.getDict()->hasVal("bar"), "bad other key");
+  TEST_ASSERT(dc1.getDict()->hasVal("foo"));
+  TEST_ASSERT(!dc1.getDict()->hasVal("bar"));
   dc1.getDict()->setVal("bar", fooV);
   dc1.getDict()->getVal("foo", v);
-  CHECK_INVARIANT(v == 1, "bad val");
+  TEST_ASSERT(v == 1);
   dc1.getDict()->getVal("bar", fooV2);
-  CHECK_INVARIANT(fooV == fooV2, "bad getVal");
+  TEST_ASSERT(fooV == fooV2);
   fooV4.resize(3);
-  CHECK_INVARIANT(!dc1.getDict()->hasVal("baz"), "bad get");
+  TEST_ASSERT(!dc1.getDict()->hasVal("baz"));
   dc1.getDict()->setVal("baz", fooV4);
-  CHECK_INVARIANT(dc1.getDict()->hasVal("baz"), "bad get");
+  TEST_ASSERT(dc1.getDict()->hasVal("baz"));
 
   dc1.getDict()->reset();
 
   DictCon dc2 = dc1;
-  CHECK_INVARIANT(!dc2.getDict()->hasVal("foo"), "bad init");
+  TEST_ASSERT(!dc2.getDict()->hasVal("foo"));
   int z = 1;
   dc2.getDict()->setVal("foo", z);
-  CHECK_INVARIANT(dc2.getDict()->hasVal("foo"), "should be there");
-  CHECK_INVARIANT(!dc2.getDict()->hasVal("bar"), "bad other key");
+  TEST_ASSERT(dc2.getDict()->hasVal("foo"));
+  TEST_ASSERT(!dc2.getDict()->hasVal("bar"));
   dc2.getDict()->setVal("bar", fooV);
   dc2.getDict()->getVal("foo", v);
-  CHECK_INVARIANT(v == 1, "bad val");
+  TEST_ASSERT(v == 1);
   dc2.getDict()->getVal("bar", fooV2);
-  CHECK_INVARIANT(fooV == fooV2, "bad getVal");
+  TEST_ASSERT(fooV == fooV2);
   fooV4.resize(3);
-  CHECK_INVARIANT(!dc2.getDict()->hasVal("baz"), "bad get");
+  TEST_ASSERT(!dc2.getDict()->hasVal("baz"));
   dc2.getDict()->setVal("baz", fooV4);
-  CHECK_INVARIANT(dc2.getDict()->hasVal("baz"), "bad get");
+  TEST_ASSERT(dc2.getDict()->hasVal("baz"));
 
   DictCon dc3(dc2);
-  CHECK_INVARIANT(dc3.getDict()->hasVal("foo"), "should be there");
+  TEST_ASSERT(dc3.getDict()->hasVal("foo"));
   dc3.getDict()->getVal("foo", v);
-  CHECK_INVARIANT(v == 1, "bad val");
+  TEST_ASSERT(v == 1);
   dc3.getDict()->getVal("bar", fooV2);
-  CHECK_INVARIANT(fooV == fooV2, "bad getVal");
+  TEST_ASSERT(fooV == fooV2);
   fooV4.resize(3);
-  CHECK_INVARIANT(dc3.getDict()->hasVal("baz"), "bad get");
+  TEST_ASSERT(dc3.getDict()->hasVal("baz"));
 
-  CHECK_INVARIANT(dc3.getDict()->hasVal("foo"), "should be there");
+  TEST_ASSERT(dc3.getDict()->hasVal("foo"));
   dc3.getDict()->getVal("foo", v);
-  CHECK_INVARIANT(v == 1, "bad val");
+  TEST_ASSERT(v == 1);
   dc3.getDict()->getVal("bar", fooV2);
-  CHECK_INVARIANT(fooV == fooV2, "bad getVal");
+  TEST_ASSERT(fooV == fooV2);
   fooV4.resize(3);
-  CHECK_INVARIANT(dc3.getDict()->hasVal("baz"), "bad get");
+  TEST_ASSERT(dc3.getDict()->hasVal("baz"));
 
   testStringVals();
   testVectToString();

--- a/Code/RDGeneral/testRDValue.cpp
+++ b/Code/RDGeneral/testRDValue.cpp
@@ -1,7 +1,6 @@
 #include "RDValue.h"
 #include "RDProps.h"
 #include "Invariant.h"
-#include "PropertyPickler.h"
 #include <limits>
 #include <vector>
 #include <list>
@@ -140,62 +139,10 @@ std::vector<T> makeVec() {
   return vec;
 }
 
-template<class T>
-void testProp(T val) {
-  std::string pklName = getenv("RDBASE");
-  pklName += "/Code/GraphMol/test_data/prop.pkl";
-  
-  {
-    std::ofstream ss(pklName.c_str(), std::ios_base::binary);
-    RDProps p;
-    p.setProp<T>("foo", val);
-    TEST_ASSERT(pickleProps(ss, p));
-  }
-  
-  {
-    std::ifstream ss(pklName.c_str(), std::ios_base::binary);
-    RDProps p2;
-    addPropsFromPickle(ss, p2);
-    TEST_ASSERT(p2.getProp<T>("foo") == val);
-  }
-};
-
-void testPropertyPickler() {
-  testProp<int>(1234);
-  testProp<double>(1234.);
-  testProp<float>(1234.0f);
-  testProp<unsigned int>(1234u);
-  testProp<bool>(true);
-  testProp<std::string>(std::string("the quick brown fox jumps over the lazy dog"));
-  
-  testProp(0);
-  testProp(0.);
-  testProp(0.0f);
-  testProp(0u);
-  testProp(false);
-
-  testProp(makeVec<int>());
-  testProp(makeVec<int>());
-  testProp(makeVec<int>());
-  testProp(makeVec<unsigned int>());
-
-  {
-    std::vector<std::string> v;
-    v.push_back("a");
-    v.push_back("b");
-    v.push_back("c");
-    v.push_back("d");
-    v.push_back("e");
-    testProp(v);
-  }
-}
-
-
 int main() {
   std::cerr << "-- running tests -- " << std::endl;
   testPOD();
   testPODVectors();
   testStringVect();
   testNaN();
-  testPropertyPickler();
 }

--- a/Code/RDGeneral/testRDValue.cpp
+++ b/Code/RDGeneral/testRDValue.cpp
@@ -1,0 +1,128 @@
+#include "RDValue.h"
+#include "Invariant.h"
+#include <limits>
+#include <vector>
+#include <list>
+#include <map>
+#include <string>
+
+using namespace RDKit;
+
+template<class T>
+void testLimits() {
+  // check numeric limits
+  {
+    RDValue v(std::numeric_limits<T>::min());
+    std::cerr << "min: " << std::numeric_limits<T>::min() << " " << rdvalue_cast<T>(v) <<
+        std::endl;
+    CHECK_INVARIANT(rdvalue_cast<T>(v) == std::numeric_limits<T>::min(), "bad min");
+    CHECK_INVARIANT(rdvalue_cast<T>(RDValue(v)) == std::numeric_limits<T>::min(), "bad min");
+    v = std::numeric_limits<T>::max();
+    CHECK_INVARIANT(rdvalue_cast<T>(v) == std::numeric_limits<T>::max(), "bad max");
+    CHECK_INVARIANT(rdvalue_cast<T>(RDValue(v)) == std::numeric_limits<T>::max(), "bad max");
+    
+  }
+  {
+    RDValue v(std::numeric_limits<T>::max());
+    CHECK_INVARIANT(rdvalue_cast<T>(v) == std::numeric_limits<T>::max(), "bad max");
+    RDValue vv(v);
+    CHECK_INVARIANT(rdvalue_cast<T>(vv) == std::numeric_limits<T>::max(), "bad max");
+
+    v = std::numeric_limits<T>::min();
+    RDValue vvv(v);
+    CHECK_INVARIANT(rdvalue_cast<T>(v) == std::numeric_limits<T>::min(), "bad min");
+    CHECK_INVARIANT(rdvalue_cast<T>(vvv) == std::numeric_limits<T>::min(), "bad min");
+  }
+}
+
+void testPOD() {
+  testLimits<int>();
+  testLimits<unsigned int>();
+  testLimits<double>();
+  testLimits<float>();
+  testLimits<bool>();
+}
+
+
+
+template<class T>
+void testVector() {
+  T minv = std::numeric_limits<T>::min();
+  T maxv = std::numeric_limits<T>::max();
+  std::vector<T> data;
+  data.push_back(minv);
+  data.push_back(maxv);
+  data.push_back(T());
+
+  RDValue v(data);
+  CHECK_INVARIANT(rdvalue_cast<std::vector<T> >(v) == data, "bad vec");
+  RDValue vv; copy_rdvalue(vv,v);
+  CHECK_INVARIANT(rdvalue_cast<std::vector<T> >(vv) == data, "bad copy constructor");
+  RDValue::cleanup_rdvalue(v); // desctructor...
+  RDValue::cleanup_rdvalue(vv);
+}
+
+void testPODVectors() {
+  testVector<int>();
+  testVector<unsigned int>();
+  testVector<double>();
+  testVector<float>();
+  testVector<long double>(); // stored in anys
+}
+
+void testStringVect() {
+  std::vector<std::string> vecs;
+  vecs.push_back("my");
+  vecs.push_back("dog");
+  vecs.push_back("has");
+  vecs.push_back("fleas");
+  RDValue v(vecs);
+  CHECK_INVARIANT(rdvalue_cast<std::vector<std::string> >(v) == vecs, "bad vect");
+  RDValue vc; copy_rdvalue(vc, v);
+  CHECK_INVARIANT(rdvalue_cast<std::vector<std::string> >(vc) == vecs, "bad vect");
+  RDValue vv = vecs;
+  RDValue vvc; copy_rdvalue(vvc, vv);
+  CHECK_INVARIANT(rdvalue_cast<std::vector<std::string> >(vv) == vecs, "bad vect");          
+  CHECK_INVARIANT(rdvalue_cast<std::vector<std::string> >(vvc) == vecs, "bad vect");
+
+  RDValue::cleanup_rdvalue(v); // desctructor...
+  RDValue::cleanup_rdvalue(vc); // desctructor...
+  RDValue::cleanup_rdvalue(vv); // desctructor...
+  RDValue::cleanup_rdvalue(vvc); // desctructor...
+}
+
+void testMapsAndLists() {
+  {
+    typedef std::map<std::string, int> listtype;
+    listtype m;
+    m["foo"] = 1;
+    m["bar"] = 2;
+    RDValue v(m);
+    CHECK_INVARIANT(rdvalue_cast<listtype>(v) == m, "bad map cast");
+    RDValue::cleanup_rdvalue(v);
+  }
+  {
+    std::list<std::string> m;
+    m.push_back("foo");
+    m.push_back("bar");
+    RDValue v(m);
+    CHECK_INVARIANT(rdvalue_cast<std::list<std::string> >(v) == m, "bad map cast");
+    RDValue::cleanup_rdvalue(v);
+  }
+}
+
+void testNaN() {
+  // make a NaN
+  double nan=sqrt(-1.0);
+  RDValue v(nan);
+
+  CHECK_INVARIANT(boost::math::isnan(rdvalue_cast<double>(v)), "Oops, can't store NaNs!");
+}
+
+int main() {
+  std::cerr << "-- running tests -- " << std::endl;
+  testPOD();
+  testPODVectors();
+  testStringVect();
+  testNaN();
+}

--- a/Code/RDGeneral/testRDValue.cpp
+++ b/Code/RDGeneral/testRDValue.cpp
@@ -1,10 +1,14 @@
 #include "RDValue.h"
+#include "RDProps.h"
 #include "Invariant.h"
+#include "PropertyPickler.h"
 #include <limits>
 #include <vector>
 #include <list>
 #include <map>
 #include <string>
+#include <iostream>
+#include <fstream>
 
 using namespace RDKit;
 
@@ -115,9 +119,77 @@ void testNaN() {
   // make a NaN
   double nan=sqrt(-1.0);
   RDValue v(nan);
+  TEST_ASSERT(v.getTag() == RDTypeTag::DoubleTag);
 
   CHECK_INVARIANT(boost::math::isnan(rdvalue_cast<double>(v)), "Oops, can't store NaNs!");
+
+  RDValue vv(2.0);
+  TEST_ASSERT(rdvalue_is<double>(vv));
+  TEST_ASSERT(vv.getTag() == RDTypeTag::DoubleTag);
 }
+
+template<class T>
+std::vector<T> makeVec() {
+  std::vector<T> vec;
+  vec.push_back((T)0);
+  vec.push_back((T)1);
+  vec.push_back((T)2);
+  vec.push_back((T)3);
+  vec.push_back((T)4);
+  vec.push_back((T)5);
+  return vec;
+}
+
+template<class T>
+void testProp(T val) {
+  std::string pklName = getenv("RDBASE");
+  pklName += "/Code/GraphMol/test_data/prop.pkl";
+  
+  {
+    std::ofstream ss(pklName.c_str(), std::ios_base::binary);
+    RDProps p;
+    p.setProp<T>("foo", val);
+    TEST_ASSERT(pickleProps(ss, p));
+  }
+  
+  {
+    std::ifstream ss(pklName.c_str(), std::ios_base::binary);
+    RDProps p2;
+    addPropsFromPickle(ss, p2);
+    TEST_ASSERT(p2.getProp<T>("foo") == val);
+  }
+};
+
+void testPropertyPickler() {
+  testProp<int>(1234);
+  testProp<double>(1234.);
+  testProp<float>(1234.0f);
+  testProp<unsigned int>(1234u);
+  testProp<bool>(true);
+  testProp<std::string>(std::string("the quick brown fox jumps over the lazy dog"));
+  
+  testProp(0);
+  testProp(0.);
+  testProp(0.0f);
+  testProp(0u);
+  testProp(false);
+
+  testProp(makeVec<int>());
+  testProp(makeVec<int>());
+  testProp(makeVec<int>());
+  testProp(makeVec<unsigned int>());
+
+  {
+    std::vector<std::string> v;
+    v.push_back("a");
+    v.push_back("b");
+    v.push_back("c");
+    v.push_back("d");
+    v.push_back("e");
+    testProp(v);
+  }
+}
+
 
 int main() {
   std::cerr << "-- running tests -- " << std::endl;
@@ -125,4 +197,5 @@ int main() {
   testPODVectors();
   testStringVect();
   testNaN();
+  testPropertyPickler();
 }

--- a/Code/RDGeneral/types.cpp
+++ b/Code/RDGeneral/types.cpp
@@ -48,6 +48,7 @@ const std::string _SmilesStart = "_SmilesStart";
 const std::string _StereochemDone = "_StereochemDone";
 const std::string _TraversalBondIndexOrder = "_TraversalBondIndexOrder";
 const std::string _TraversalRingClosureBond = "_TraversalRingClosureBond";
+const std::string _TraversalStartPoint = "_TraversalStartPoint";
 const std::string _TriposAtomType = "_TriposAtomType";
 const std::string _Unfinished_SLN_ = "_Unfinished_SLN_";
 const std::string _UnknownStereo = "_UnknownStereo";

--- a/Code/RDGeneral/types.h
+++ b/Code/RDGeneral/types.h
@@ -17,7 +17,7 @@
 
 #include <cmath>
 
-#include <RDGeneral/Invariant.h>
+#include "Invariant.h"
 #include "Dict.h"
 
 namespace detail {
@@ -42,84 +42,125 @@ const std::string computedPropName = "__computedProps";
 
 namespace RDKit {
 namespace common_properties {
-extern const std::string TWOD;
-extern const std::string BalabanJ;
-extern const std::string BalanbanJ;
-extern const std::string Discrims;
-extern const std::string DistanceMatrix_Paths;
-extern const std::string MolFileComments;
-extern const std::string MolFileInfo;
-extern const std::string NullBond;
-extern const std::string _2DConf;
-extern const std::string _3DConf;
-extern const std::string _AtomID;
-extern const std::string _BondsPotentialStereo;
-extern const std::string _CIPCode;
-extern const std::string _CIPRank;
-extern const std::string _ChiralityPossible;
-extern const std::string _CrippenLogP;
-extern const std::string _CrippenMR;
-extern const std::string _MMFFSanitized;
-extern const std::string _MolFileChiralFlag;
-extern const std::string _MolFileRLabel;
-extern const std::string _Name;
-extern const std::string _NeedsQueryScan;
-extern const std::string _QueryFormalCharge;
-extern const std::string _QueryHCount;
-extern const std::string _QueryIsotope;
-extern const std::string _QueryMass;
-extern const std::string _ReactionDegreeChanged;
-extern const std::string _RingClosures;
-extern const std::string _SLN_s;
-extern const std::string _SmilesStart;
-extern const std::string _StereochemDone;
-extern const std::string _TraversalBondIndexOrder;
-extern const std::string _TraversalRingClosureBond;
-extern const std::string _TriposAtomType;
-extern const std::string _Unfinished_SLN_;
-extern const std::string _UnknownStereo;
-extern const std::string _connectivityHKDeltas;
-extern const std::string _connectivityNVals;
-extern const std::string _crippenLogP;
-extern const std::string _crippenLogPContribs;
-extern const std::string _crippenMR;
-extern const std::string _crippenMRContribs;
-extern const std::string _doIsoSmiles;
-extern const std::string _fragSMARTS;
-extern const std::string _hasMassQuery;
-extern const std::string _labuteASA;
-extern const std::string _labuteAtomContribs;
-extern const std::string _labuteAtomHContrib;
-extern const std::string _protected;
-extern const std::string _queryRootAtom;
-extern const std::string _ringStereoAtoms;
-extern const std::string _ringStereoWarning;
-extern const std::string _ringStereochemCand;
-extern const std::string _smilesAtomOutputOrder;
-extern const std::string _starred;
-extern const std::string _supplementalSmilesLabel;
-extern const std::string _tpsa;
-extern const std::string _tpsaAtomContribs;
-extern const std::string _unspecifiedOrder;
-extern const std::string _brokenChirality;
+///////////////////////////////////////////////////////////////
+// Molecule Props
+extern const std::string _Name;           // string
+extern const std::string MolFileInfo;     // string
+extern const std::string MolFileComments; // string
+extern const std::string _2DConf;         // int (combine into dimension?)
+extern const std::string _3DConf;         // int
+extern const std::string _doIsoSmiles;    // int (should probably be removed)
+extern const std::string extraRings;      // vec<vec<int> > 
+extern const std::string _smilesAtomOutputOrder; // vec<int> computed
+extern const std::string _StereochemDone; // int 
+extern const std::string _NeedsQueryScan; // int (bool)
+extern const std::string _fragSMARTS;     // std::string
+extern const std::string maxAttachIdx;    // int TemplEnumTools.cpp
+extern const std::string origNoImplicit;  // int (bool) 
+extern const std::string ringMembership;  //? unused (molopstest.cpp)
+
+// Computed Values
+// ConnectivityDescriptors
+extern const std::string _connectivityHKDeltas;// std::vector<double> computed 
+extern const std::string _connectivityNVals;   // std::vector<double> computed 
+
+extern const std::string _crippenLogP;         // double computed
+extern const std::string _crippenLogPContribs; // std::vector<double> computed
+
+extern const std::string _crippenMR;           // double computed
+extern const std::string _crippenMRContribs;   // std::vector<double> computed
+
+extern const std::string _labuteASA;           // double computed
+extern const std::string _labuteAtomContribs;  // vec<double> computed
+extern const std::string _labuteAtomHContrib;  // double computed
+
+extern const std::string _tpsa;                // double computed
+extern const std::string _tpsaAtomContribs;    // vec<double> computed
+
+extern const std::string numArom;              // int computed (only uses in tests?)
+extern const std::string _MMFFSanitized;       // int (bool) computed
+
+extern const std::string _CrippenLogP; // Unused (in the basement)
+extern const std::string _CrippenMR;   // Unused (in the basement)
+
+///////////////////////////////////////////////////////////////
+// Atom Props
+
+// Chirality stuff
+extern const std::string _BondsPotentialStereo; // int (or bool) COMPUTED 
+extern const std::string _CIPCode; // std::string COMPUTED
+extern const std::string _CIPRank; // int COMPUTED
+extern const std::string _ChiralityPossible; // int
+extern const std::string _UnknownStereo; // int (bool) AddHs/Chirality
+extern const std::string _ringStereoAtoms; // int vect Canon/Chiral/MolHash/MolOps//Renumber//RWmol
+extern const std::string _ringStereochemCand; // chirality bool COMPUTED
+extern const std::string _ringStereoWarning; // obsolete ?
+
+// Smiles parsing
+extern const std::string _SmilesStart; // int
+extern const std::string _TraversalBondIndexOrder; // ? unused
+extern const std::string _TraversalRingClosureBond; // unsigned int 
+extern const std::string _TraversalStartPoint; // bool
+extern const std::string _queryRootAtom; // int SLNParse/SubstructMatch
+extern const std::string _hasMassQuery; // atom bool
+extern const std::string _protected; // atom int (bool)
+extern const std::string _supplementalSmilesLabel; // atom string (SmilesWrite)
+extern const std::string _unspecifiedOrder;// atom int (bool) smarts/smiles
+extern const std::string _RingClosures; // INT_VECT smarts/smiles/canon
+
+// MDL Style Properties (MolFileParser)
+extern const std::string molAtomMapNumber; // int 
+extern const std::string molFileAlias;  // string 
+extern const std::string molFileValue;  // string 
+extern const std::string molInversionFlag; // int 
+extern const std::string molParity;     // int 
+extern const std::string molRxnComponent; // int 
+extern const std::string molRxnRole;    // int 
+extern const std::string molTotValence; // int 
+extern const std::string _MolFileRLabel; // int
+extern const std::string _MolFileChiralFlag; // int
+
+extern const std::string dummyLabel; // atom string
+
+// Reaction Information (Reactions.cpp)
+extern const std::string _QueryFormalCharge; //  int 
+extern const std::string _QueryHCount; // int 
+extern const std::string _QueryIsotope; // int
+extern const std::string _QueryMass; // int = round(float * 1000) 
+extern const std::string _ReactionDegreeChanged; // int (bool) 
+extern const std::string NullBond; // int (bool)
 extern const std::string _rgroupAtomMaps;
 extern const std::string _rgroupBonds;
-extern const std::string dummyLabel;
-extern const std::string extraRings;
-extern const std::string isImplicit;
-extern const std::string maxAttachIdx;
-extern const std::string molAtomMapNumber;
-extern const std::string molFileAlias;
-extern const std::string molFileValue;
-extern const std::string molInversionFlag;
-extern const std::string molParity;
-extern const std::string molRxnComponent;
-extern const std::string molRxnRole;
-extern const std::string molTotValence;
-extern const std::string numArom;
-extern const std::string origNoImplicit;
-extern const std::string ringMembership;
-extern const std::string smilesSymbol;
+
+// SLN
+extern const std::string _AtomID; // unsigned int SLNParser
+extern const std::string _starred; // atom int COMPUTED (SLN)
+extern const std::string _SLN_s; // string SLNAttribs (chiral info)
+extern const std::string _Unfinished_SLN_; // int (bool)
+
+// Smarts Smiles
+extern const std::string _brokenChirality; // atom bool
+extern const std::string isImplicit;  // atom int (bool) 
+extern const std::string smilesSymbol; // atom string (only used in test?)
+
+// Tripos
+extern const std::string _TriposAtomType; // string Mol2FileParser
+// missing defs for _TriposAtomName//_TriposPartialCharge...
+
+
+///////////////////////////////////////////////////////////////
+// misc props
+extern const std::string TWOD; // need THREED -> confusing using in TDTMol supplier
+                               //  converge with _2DConf?
+extern const std::string BalabanJ; // mol double
+extern const std::string BalanbanJ; // typo!! fix...
+
+extern const std::string Discrims; // FragCatalog Entry
+                                   // Subgraphs::DiscrimTuple (uint32,uint32,uint32)
+extern const std::string DistanceMatrix_Paths; // boost::shared_array<double>
+                                               //  - note, confusing creation of names in
+                                               //  - getDistanceMat
+
 }  // end common_properties
 #ifndef WIN32
 typedef long long int LONGINT;


### PR DESCRIPTION
This is an API compliant version of the current rdany system, but uses a lot less memory in practice.

There are two versions of RDAny for evaluation, one is a simple tagged union (64 + 16 bits in size) and the other is a NaN tagged value (64 bits).

The NaN tagged value is neat, and surprisingly works well, it, however, exploits both the NaN bit structure in IEEE floating point AND the fact that current OSes don't use more that 48 bits to access memory.  This technique is used in some Javascript engines, but still makes me feel dirty inside.

The default is the tagged union, and this may indeed win out in the end especially if we use integer keys instead of strings (this is another PR for  later).

Both systems fall back to boost::any storage, so no functionality is lost.  Instead of using boost::any_cast, a new cast is added rdany_cast, however end users should not have to use this.

Additionally, a new class has been created RDProps, which, when subclassed, enabled property support for any class.  Atoms/Bonds and Molecules now use RDProps cleaning up a lot of redundant code.

Finally the types.h namespace has been documented and cleaned up a bit.