### PR TITLE
Dev/rdkit rdany int keys

### DIFF
--- a/Code/GraphMol/ChemReactions/PreprocessRxn.h
+++ b/Code/GraphMol/ChemReactions/PreprocessRxn.h
@@ -39,18 +39,21 @@
 namespace RDKit {
 
 bool preprocessReaction(ChemicalReaction &rxn,
-                        const std::string &propName=common_properties::molFileValue);
+                        const std::string &propName=common_properties::getPropName(
+                            common_properties::molFileValue));
 
 bool preprocessReaction(ChemicalReaction &rxn,
                         unsigned int &numWarnings,
                         unsigned int &numErrors,
                         std::vector<
                           std::vector<std::pair<unsigned int,std::string> > >&reactantLabels,
-                        const std::string &propName=common_properties::molFileValue);
+                        const std::string &propName=common_properties::getPropName(
+                            common_properties::molFileValue));
 
 bool preprocessReaction(ChemicalReaction &rxn,
                         const std::map<std::string, ROMOL_SPTR> &queries,
-                        const std::string &propName=common_properties::molFileValue);
+                        const std::string &propName=common_properties::getPropName(
+                            common_properties::molFileValue));
   
 bool preprocessReaction(ChemicalReaction &rxn,
                         unsigned int &numWarnings,
@@ -58,7 +61,8 @@ bool preprocessReaction(ChemicalReaction &rxn,
                         std::vector<
                           std::vector<std::pair<unsigned int,std::string> > >&reactantLabels,
                         const std::map<std::string, ROMOL_SPTR> &queries,
-                        const std::string &propName=common_properties::molFileValue);
+                        const std::string &propName=common_properties::getPropName(
+                            common_properties::molFileValue));
 }
 
 #endif

--- a/Code/GraphMol/ChemReactions/Wrap/rdChemReactions.cpp
+++ b/Code/GraphMol/ChemReactions/Wrap/rdChemReactions.cpp
@@ -777,7 +777,8 @@ Sample Usage:\n\
   python::def("PreprocessReaction", PreprocessReaction,
               (python::arg("reaction"),
                python::arg("queries")=python::dict(),
-               python::arg("propName")=common_properties::molFileValue),
+               python::arg("propName")=common_properties::getPropName(
+                   common_properties::molFileValue)),
               docString.c_str());
 }
 }

--- a/Code/GraphMol/FileParsers/MolFileParser.cpp
+++ b/Code/GraphMol/FileParsers/MolFileParser.cpp
@@ -2330,7 +2330,7 @@ RWMol *MolDataStreamToMol(std::istream *inStream, unsigned int &line,
   res->setProp("_MolFileInfo", tempStr);
   if (tempStr.length() >= 22) {
     std::string dimLabel = tempStr.substr(20, 2);
-    if (dimLabel == "2d" || dimLabel == common_properties::TWOD) {
+    if (dimLabel == "2d" || dimLabel == "2D") {
       res->setProp(common_properties::_2DConf, 1);
     } else if (dimLabel == "3d" || dimLabel == "3D") {
       res->setProp(common_properties::_3DConf, 1);

--- a/Code/GraphMol/FileParsers/SDWriter.cpp
+++ b/Code/GraphMol/FileParsers/SDWriter.cpp
@@ -114,16 +114,16 @@ void _MolToSDStream(std::ostream *dp_ostream, const ROMol &mol, int confId,
     // if use did not specify any properties, write all non computed properties
     // out to the file
     STR_VECT properties = mol.getPropList();
-    STR_VECT compLst;
-    mol.getPropIfPresent(detail::computedPropName, compLst);
-
+    STR_VECT compLst = mol.getComputedPropList();
+    
     STR_VECT_CI pi;
     for (pi = properties.begin(); pi != properties.end(); pi++) {
       // ignore any of the following properties
       if (((*pi) == detail::computedPropName) ||
-          ((*pi) == common_properties::_Name) || ((*pi) == "_MolFileInfo") ||
-          ((*pi) == "_MolFileComments") ||
-          ((*pi) == common_properties::_MolFileChiralFlag)) {
+          ((*pi) == common_properties::getPropName(common_properties::_Name)) ||
+          ((*pi) == common_properties::getPropName(common_properties::MolFileInfo)) ||
+          ((*pi) == common_properties::getPropName(common_properties::MolFileComments)) ||
+          ((*pi) == common_properties::getPropName(common_properties::_MolFileChiralFlag))) {
         continue;
       }
 

--- a/Code/GraphMol/FileParsers/TDTMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/TDTMolSupplier.cpp
@@ -209,7 +209,8 @@ ROMol *TDTMolSupplier::parseMol(std::string inLine) {
   std::size_t endP = inLine.find_last_of(">");
   std::string smiles = inLine.substr(startP + 1, endP - startP - 1);
   ROMol *res = SmilesToMol(smiles, 0, df_sanitize);
-
+  
+  const std::string TWOD = common_properties::getPropName(common_properties::TWOD);
   if (res && res->getNumAtoms() > 0) {
     // -----------
     //   Process the properties:
@@ -221,7 +222,7 @@ ROMol *TDTMolSupplier::parseMol(std::string inLine) {
       boost::trim_if(propName, boost::is_any_of(" \t"));
       startP = endP + 1;
 
-      if (propName == common_properties::TWOD && d_confId2D >= 0) {
+      if (propName == TWOD && d_confId2D >= 0) {
         std::string rest = inLine.substr(startP, inLine.size() - startP);
         std::vector<double> coords;
         TDTParseUtils::ParseNumberList(rest, coords, dp_inStream);

--- a/Code/GraphMol/FileParsers/TDTWriter.cpp
+++ b/Code/GraphMol/FileParsers/TDTWriter.cpp
@@ -136,16 +136,16 @@ void TDTWriter::write(const ROMol &mol, int confId) {
     // if use did not specify any properties, write all non computed properties
     // out to the file
     STR_VECT properties = mol.getPropList();
-    STR_VECT compLst;
-    mol.getPropIfPresent(detail::computedPropName, compLst);
+    STR_VECT compLst = mol.getComputedPropList();
 
     STR_VECT_CI pi;
     for (pi = properties.begin(); pi != properties.end(); pi++) {
       // ignore any of the following properties
       if (((*pi) == detail::computedPropName) ||
-          ((*pi) == common_properties::_Name) || ((*pi) == "_MolFileInfo") ||
-          ((*pi) == "_MolFileComments") ||
-          ((*pi) == common_properties::_MolFileChiralFlag)) {
+          ((*pi) == common_properties::getPropName(common_properties::_Name)) ||
+          ((*pi) == common_properties::getPropName(common_properties::MolFileInfo)) ||
+          ((*pi) == common_properties::getPropName(common_properties::MolFileComments)) ||
+          ((*pi) == common_properties::getPropName(common_properties::_MolFileChiralFlag))) {
         continue;
       }
 

--- a/Code/GraphMol/FileParsers/TplFileParser.cpp
+++ b/Code/GraphMol/FileParsers/TplFileParser.cpp
@@ -127,7 +127,8 @@ Conformer *ParseConfData(std::istream *inStream, unsigned int &line, RWMol *mol,
     throw FileParseException(errout.str());
   }
   std::ostringstream propName;
-  propName << "Conf_" << mol->getNumConformers() << common_properties::_Name;
+  propName << "Conf_" << mol->getNumConformers() << common_properties::getPropName(
+      common_properties::_Name);
   mol->setProp(propName.str(),
                boost::trim_copy(tempStr.substr(4, tempStr.size() - 4)));
 

--- a/Code/GraphMol/FileParsers/testMolWriter.cpp
+++ b/Code/GraphMol/FileParsers/testMolWriter.cpp
@@ -662,6 +662,7 @@ void testIssue265() {
     writer.write(*m1);
     writer.flush();
     std::string otext = sstream.str();
+    std::cerr << "otext: " << otext << std::endl;
     TEST_ASSERT(otext == "$SMI<C1NO1>\n3D<0,0,0,0,1,0,1,0,0;>\n");
   }
 }

--- a/Code/GraphMol/FragCatalog/FragCatalogEntry.cpp
+++ b/Code/GraphMol/FragCatalog/FragCatalogEntry.cpp
@@ -54,14 +54,11 @@ FragCatalogEntry::FragCatalogEntry(const ROMol *omol, const PATH_TYPE &path,
       }
     }
   }
-  dp_props = new Dict();
-
   d_descrip = "";
 }
 
 FragCatalogEntry::FragCatalogEntry(const std::string &pickle) {
   d_aToFmap.clear();
-  dp_props = new Dict();
   this->initFromString(pickle);
 }
 

--- a/Code/GraphMol/FragCatalog/FragCatalogEntry.h
+++ b/Code/GraphMol/FragCatalog/FragCatalogEntry.h
@@ -23,10 +23,9 @@
 
 namespace RDKit {
 
-class FragCatalogEntry : public RDCatalog::CatalogEntry {
+class FragCatalogEntry : public RDCatalog::CatalogEntry, public RDKit::RDProps {
  public:
   FragCatalogEntry() : dp_mol(0), d_descrip(""), d_order(0) {
-    dp_props = new Dict();
     setBitId(-1);
   }
 
@@ -37,10 +36,6 @@ class FragCatalogEntry : public RDCatalog::CatalogEntry {
   ~FragCatalogEntry() {
     delete dp_mol;
     dp_mol = 0;
-    if (dp_props) {
-      delete dp_props;
-      dp_props = 0;
-    }
   }
 
   std::string getDescription() const { return d_descrip; }
@@ -63,52 +58,6 @@ class FragCatalogEntry : public RDCatalog::CatalogEntry {
   // REVIEW: this should be removed?
   std::string getSmarts() { return ""; }
 
-  // FUnctions on the property dictionary
-  template <typename T>
-  void setProp(const char *key, T &val) const {
-    dp_props->setVal(key, val);
-  }
-
-  template <typename T>
-  void setProp(const std::string &key, T &val) const {
-    setProp(key.c_str(), val);
-  }
-
-  void setProp(const char *key, int val) const { dp_props->setVal(key, val); }
-
-  void setProp(const std::string &key, int val) const {
-    setProp(key.c_str(), val);
-  }
-
-  void setProp(const char *key, float val) const { dp_props->setVal(key, val); }
-
-  void setProp(const std::string &key, float val) const {
-    setProp(key.c_str(), val);
-  }
-
-  void setProp(const std::string &key, std::string &val) const {
-    setProp(key.c_str(), val);
-  }
-
-  template <typename T>
-  void getProp(const char *key, T &res) const {
-    dp_props->getVal(key, res);
-  }
-  template <typename T>
-  void getProp(const std::string &key, T &res) const {
-    getProp(key.c_str(), res);
-  }
-
-  bool hasProp(const char *key) const {
-    if (!dp_props) return false;
-    return dp_props->hasVal(key);
-  }
-  bool hasProp(const std::string &key) const { return hasProp(key.c_str()); }
-
-  void clearProp(const char *key) const { dp_props->clearVal(key); }
-
-  void clearProp(const std::string &key) const { clearProp(key.c_str()); }
-
   void toStream(std::ostream &ss) const;
   std::string Serialize() const;
   void initFromStream(std::istream &ss);
@@ -116,8 +65,6 @@ class FragCatalogEntry : public RDCatalog::CatalogEntry {
 
  private:
   ROMol *dp_mol;
-  Dict *dp_props;
-
   std::string d_descrip;
 
   unsigned int d_order;

--- a/Code/GraphMol/MolOps.cpp
+++ b/Code/GraphMol/MolOps.cpp
@@ -733,8 +733,9 @@ int getFormalCharge(const ROMol &mol) {
   return accum;
 };
 
-unsigned getNumAtomsWithDistinctProperty(const ROMol &mol, std::string prop) {
-  return getNumAtomsWithDistinctProperty(mol, Dict::tagmap.get(prop));
+unsigned getNumAtomsWithDistinctProperty(const ROMol &mol,
+                                         const std::string &prop) {
+  return getNumAtomsWithDistinctProperty(mol, GetKey(prop));
 }
 
 unsigned getNumAtomsWithDistinctProperty(const ROMol &mol, int prop) {

--- a/Code/GraphMol/MolOps.cpp
+++ b/Code/GraphMol/MolOps.cpp
@@ -734,6 +734,10 @@ int getFormalCharge(const ROMol &mol) {
 };
 
 unsigned getNumAtomsWithDistinctProperty(const ROMol &mol, std::string prop) {
+  return getNumAtomsWithDistinctProperty(mol, Dict::tagmap.get(prop));
+}
+
+unsigned getNumAtomsWithDistinctProperty(const ROMol &mol, int prop) {
   unsigned numPropAtoms = 0;
   for (ROMol::ConstAtomIterator ai = mol.beginAtoms(); ai != mol.endAtoms();
        ++ai) {
@@ -743,5 +747,7 @@ unsigned getNumAtomsWithDistinctProperty(const ROMol &mol, std::string prop) {
   }
   return numPropAtoms;
 }
+
+
 };  // end of namespace MolOps
 };  // end of namespace RDKit

--- a/Code/GraphMol/MolOps.h
+++ b/Code/GraphMol/MolOps.h
@@ -802,7 +802,8 @@ void findPotentialStereoBonds(ROMol &mol, bool cleanIt = false);
 //@}
 
 //! returns the number of atoms which have a particular property set
-unsigned getNumAtomsWithDistinctProperty(const ROMol &mol, const std::string &prop);
+unsigned getNumAtomsWithDistinctProperty(const ROMol &mol,
+                                         const std::string &prop);
 unsigned getNumAtomsWithDistinctProperty(const ROMol &mol, int prop);
 
 };  // end of namespace MolOps

--- a/Code/GraphMol/MolOps.h
+++ b/Code/GraphMol/MolOps.h
@@ -802,7 +802,8 @@ void findPotentialStereoBonds(ROMol &mol, bool cleanIt = false);
 //@}
 
 //! returns the number of atoms which have a particular property set
-unsigned getNumAtomsWithDistinctProperty(const ROMol &mol, std::string prop);
+unsigned getNumAtomsWithDistinctProperty(const ROMol &mol, const std::string &prop);
+unsigned getNumAtomsWithDistinctProperty(const ROMol &mol, int prop);
 
 };  // end of namespace MolOps
 };  // end of namespace RDKit

--- a/Code/GraphMol/ROMol.cpp
+++ b/Code/GraphMol/ROMol.cpp
@@ -82,7 +82,7 @@ void ROMol::initFromOther(const ROMol &other, bool quickCopy, int confId) {
       }
     }
     
-    dp_props = other.dp_props;
+    RDProps::operator=((const RDProps&)other);
 
     // Bookmarks should be copied as well:
     BOOST_FOREACH (ATOM_BOOKMARK_MAP::value_type abmI, other.d_atomBookmarks) {
@@ -96,25 +96,15 @@ void ROMol::initFromOther(const ROMol &other, bool quickCopy, int confId) {
       }
     }
   } else {
-    dp_props.reset();
-    STR_VECT computed;
-    dp_props.setVal(detail::computedPropName, computed);
+    RDProps::clear();
   }
   // std::cerr<<"---------    done init from other: "<<this<<"
   // "<<&other<<std::endl;
 }
 
 void ROMol::initMol() {
-  dp_props.reset();
+  RDProps::clear();
   dp_ringInfo = new RingInfo();
-  // ok every molecule contains a property entry called detail::computedPropName
-  // which provides
-  //  list of property keys that correspond to value that have been computed
-  // this can used to blow out all computed properties while leaving the rest
-  // along
-  // initialize this list to an empty vector of strings
-  STR_VECT computed;
-  dp_props.setVal(detail::computedPropName, computed);
 }
 
 unsigned int ROMol::getAtomDegree(const Atom *at) const {
@@ -572,5 +562,4 @@ unsigned int ROMol::addConformer(Conformer *conf, bool assignId) {
   d_confs.push_back(nConf);
   return conf->getId();
 }
-
 }  // end o' namespace

--- a/Code/GraphMol/RWMol.h
+++ b/Code/GraphMol/RWMol.h
@@ -214,10 +214,7 @@ class RWMol : public ROMol {
     d_bondBookmarks.clear();
     d_graph.clear();
     d_confs.clear();
-    dp_props.reset();
-    STR_VECT computed;
-    dp_props.setVal(detail::computedPropName, computed);
-
+    RDProps::clear();
     if (dp_ringInfo) dp_ringInfo->reset();
   };
 

--- a/Code/GraphMol/Wrap/Atom.cpp
+++ b/Code/GraphMol/Wrap/Atom.cpp
@@ -360,6 +360,9 @@ struct atom_wrapper {
         .def("GetPropNames", &Atom::getPropList, (python::arg("self")),
              "Returns a list of the properties set on the Atom.\n\n")
 
+        .def("GetComputedPropNames", &Atom::getComputedPropList, (python::arg("self")),
+             "Returns a list of the computed properties set on the Atom.\n\n")
+        
         .def("GetPropsAsDict", GetPropsAsDict<Atom>, (python::arg("self"),
                                                       python::arg("includePrivate") = true,
                                                       python::arg("includeComputed") = true

--- a/Code/GraphMol/Wrap/Bond.cpp
+++ b/Code/GraphMol/Wrap/Bond.cpp
@@ -293,6 +293,9 @@ struct bond_wrapper {
         .def("GetPropNames", &Bond::getPropList, (python::arg("self")),
              "Returns a list of the properties set on the Bond.\n\n")
 
+        .def("GetPropNames", &Bond::getComputedPropList, (python::arg("self")),
+             "Returns a list of the computed properties set on the Bond.\n\n")
+        
         .def("GetPropsAsDict", GetPropsAsDict<Bond>, (python::arg("self"),
                                                       python::arg("includePrivate") = true,
                                                       python::arg("includeComputed") = true

--- a/Code/GraphMol/Wrap/Mol.cpp
+++ b/Code/GraphMol/Wrap/Mol.cpp
@@ -543,6 +543,9 @@ struct mol_wrapper {
              "                      Defaults to 0.\n\n"
              "  RETURNS: a tuple of strings\n")
 
+        .def("GetComputedPropNames", &ROMol::getComputedPropList,
+             "Returns a tuple with all comptued property names for this molecule.\n")
+        
         .def("GetPropsAsDict", GetPropsAsDict<ROMol>,
              (python::arg("self"), python::arg("includePrivate") = false,
               python::arg("includeComputed") = false),

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -3314,9 +3314,9 @@ CAS<~>
     m = Chem.MolFromSmiles('c1ccccc1')
     for atom in m.GetAtoms():
       d = atom.GetPropsAsDict()
-      self.assertEquals(set(d.keys()), set(['_CIPRank', '__computedProps']))
+      self.assertEquals(set(d.keys()), set(['_CIPRank']))
       self.assertEquals(d['_CIPRank'], 0)
-      self.assertEquals(list(d['__computedProps']), ['_CIPRank'])
+      self.assertEquals(list(atom.GetComputedPropNames()), ['_CIPRank'])
 
 
     for bond in m.GetBonds():

--- a/Code/JavaWrappers/RDProps.i
+++ b/Code/JavaWrappers/RDProps.i
@@ -33,9 +33,15 @@
 %{
 #include <RDGeneral/types.h>
 #include <RDGeneral/RDProps.h>
+#include <RDGeneral/Dict.h>
 %}
 
+%ignore RDKit::KeyIntPair;
+%ignore RDKit::Dict::begin;
+%ignore RDKit::Dict::end;
+%ignore RDKit::Dict::DataType;
 
+%include <RDGeneral/Dict.h>
 %include <RDGeneral/RDProps.h>
 
 /* For the time being, assume all properties will be strings */

--- a/Code/JavaWrappers/RDTags.i
+++ b/Code/JavaWrappers/RDTags.i
@@ -1,0 +1,40 @@
+/* 
+*
+*  Copyright (c) 2016, Novartis Institutes for BioMedical Research Inc.
+*  All rights reserved.
+* 
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are
+* met: 
+*
+*     * Redistributions of source code must retain the above copyright 
+*       notice, this list of conditions and the following disclaimer.
+*     * Redistributions in binary form must reproduce the above
+*       copyright notice, this list of conditions and the following 
+*       disclaimer in the documentation and/or other materials provided 
+*       with the distribution.
+*     * Neither the name of Novartis Institutes for BioMedical Research Inc. 
+*       nor the names of its contributors may be used to endorse or promote 
+*       products derived from this software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+* "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+* LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+* A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+* OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+* SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+* DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+* THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+* OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+%{
+#include <RDGeneral/types.h>
+#include <RDGeneral/tags.h>
+%}
+
+%ignore RDKit::RDTags::operator=(const RDKit::RDTags &);
+%include <RDGeneral/tags.h>
+

--- a/Code/JavaWrappers/gmwrapper/GraphMolJava.i
+++ b/Code/JavaWrappers/gmwrapper/GraphMolJava.i
@@ -155,6 +155,7 @@ typedef unsigned long long int	uintmax_t;
 %include "../types.i"
 // Conformer seems to need to come before ROMol
 %include "../Conformer.i"
+%include "../RDTags.i"
 %include "../RDProps.i"
 %include "../ROMol.i"
 %include "../RWMol.i"

--- a/Code/RDGeneral/CMakeLists.txt
+++ b/Code/RDGeneral/CMakeLists.txt
@@ -1,5 +1,16 @@
 CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/versions.cpp.cmake
                ${CMAKE_CURRENT_SOURCE_DIR}/versions.cpp )
+               
+CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/rdkit.h.in
+               ${CMAKE_CURRENT_SOURCE_DIR}/rdkit.h @ONLY)
+
+if(UNSAFE_RDVALUE)
+CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/RDValue-doublemagic.h
+               ${CMAKE_CURRENT_SOURCE_DIR}/RDValue-implementation.h COPYONLY)
+else(UNSAFE_RDVALUE)
+CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/RDValue-taggedunion.h
+               ${CMAKE_CURRENT_SOURCE_DIR}/RDValue-implementation.h COPYONLY)
+endif(UNSAFE_RDVALUE)
 
 rdkit_library(RDGeneral
               Invariant.cpp types.cpp utils.cpp RDLog.cpp Dict.cpp
@@ -8,7 +19,8 @@ rdkit_library(RDGeneral
 
 target_link_libraries(RDGeneral ${RDKit_THREAD_LIBS})
 
-rdkit_headers(Exceptions.h
+rdkit_headers(rdkit.h
+              Exceptions.h
               BadFileException.h
               BoostStartInclude.h
               BoostEndInclude.h
@@ -17,8 +29,7 @@ rdkit_headers(Exceptions.h
               Invariant.h
               RDAny.h
               RDValue.h
-              RDValue-doublemagic.h
-              RDValue-taggedunion.h
+              RDValue-implementation.h
               RDLog.h
               RDProps.h
               StreamOps.h

--- a/Code/RDGeneral/CMakeLists.txt
+++ b/Code/RDGeneral/CMakeLists.txt
@@ -23,6 +23,8 @@ rdkit_headers(Exceptions.h
               RDProps.h
               StreamOps.h
               tags.h
+              tags-nonthreadsafe.h
+              tags-threadsafe.h
               types.h
               utils.h
               versions.h

--- a/Code/RDGeneral/CMakeLists.txt
+++ b/Code/RDGeneral/CMakeLists.txt
@@ -22,6 +22,7 @@ rdkit_headers(Exceptions.h
               RDLog.h
               RDProps.h
               StreamOps.h
+              tags.h
               types.h
               utils.h
               versions.h
@@ -35,4 +36,5 @@ if (NOT RDK_INSTALL_INTREE)
 endif (NOT RDK_INSTALL_INTREE)
 rdkit_test(testDict testDict.cpp LINK_LIBRARIES RDGeneral)
 rdkit_test(testRDValue testRDValue.cpp LINK_LIBRARIES RDGeneral)
+rdkit_test(testRDTags testRDTags.cpp LINK_LIBRARIES RDGeneral)
 

--- a/Code/RDGeneral/Dict.cpp
+++ b/Code/RDGeneral/Dict.cpp
@@ -11,10 +11,12 @@
 //
 #include "Dict.h"
 #include "Exceptions.h"
+#include "tags.h"
 
 namespace RDKit {
 
-RDTags RDKit::Dict::tagmap;
+RDTags RDKit::KeyIntPair::tagmap;
+
 
 void Dict::getVal(int tag, std::string &res) const {
   //
@@ -64,8 +66,8 @@ const char *getPropName(int v) {
   if (v>=0 && v<=MAX) {
     return common_properties::propnames[v];
   }
-  if ((size_t)v < RDKit::Dict::tagmap.keys.size())
-    return RDKit::Dict::tagmap.keys[v].c_str();
+  if ((size_t)v < RDKit::KeyIntPair::tagmap.keys.size())
+    return RDKit::KeyIntPair::tagmap.keys[v].c_str();
 
   throw KeyErrorException("Unknown tag");
 }

--- a/Code/RDGeneral/Dict.cpp
+++ b/Code/RDGeneral/Dict.cpp
@@ -1,5 +1,6 @@
 // $Id$
 //
+// Copyright (C) 2015 Novartis Institute of BioMedical Research
 // Copyright (C) 2003-2008 Greg Landrum and Rational Discovery LLC
 //
 //  @@ All Rights Reserved @@
@@ -9,10 +10,13 @@
 //  of the RDKit source tree.
 //
 #include "Dict.h"
+#include "Exceptions.h"
 
 namespace RDKit {
 
-void Dict::getVal(const std::string &what, std::string &res) const {
+RDTags RDKit::Dict::tagmap;
+
+void Dict::getVal(int tag, std::string &res) const {
   //
   //  We're going to try and be somewhat crafty about this getVal stuff to make
   //  these
@@ -24,16 +28,16 @@ void Dict::getVal(const std::string &what, std::string &res) const {
   //  other casts, which will then be lexically cast to type T.
   //
   for(size_t i=0; i< _data.size(); ++i) {
-    if (_data[i].key == what) {
+    if (_data[i].getKey() == tag) {
       rdvalue_tostring(_data[i].val, res);
       return;
     }
 
   }
-  throw KeyErrorException(what);    
+  throw KeyErrorException(common_properties::getPropName(tag));    
 }
 
-bool Dict::getValIfPresent(const std::string &what, std::string &res) const {
+bool Dict::getValIfPresent(int tag, std::string &res) const {
   //
   //  We're going to try and be somewhat crafty about this getVal stuff to make
   //  these
@@ -45,12 +49,27 @@ bool Dict::getValIfPresent(const std::string &what, std::string &res) const {
   //  other casts, which will then be lexically cast to type T.
   //
   for(size_t i=0; i< _data.size(); ++i) {
-    if (_data[i].key == what) {
+    if (_data[i].getKey() == tag) {
       rdvalue_tostring(_data[i].val, res);
       return true;
     }
   }
   return false;
+}
+
+
+namespace common_properties {
+
+const char *getPropName(int v) {
+  if (v>=0 && v<=MAX) {
+    return common_properties::propnames[v];
+  }
+  if ((size_t)v < RDKit::Dict::tagmap.keys.size())
+    return RDKit::Dict::tagmap.keys[v].c_str();
+
+  throw KeyErrorException("Unknown tag");
+}
+
 }
 
 }

--- a/Code/RDGeneral/Dict.h
+++ b/Code/RDGeneral/Dict.h
@@ -187,7 +187,7 @@ public:
 
   template <typename T>
   void setPODVal(const std::string &what, T val) {
-    _hasNonPodData = true;
+    // don't change the hasNonPodData status
     for(size_t i=0; i< _data.size(); ++i) {
       if (_data[i].key == what) {
         _data[i].val = val;

--- a/Code/RDGeneral/RDProps.h
+++ b/Code/RDGeneral/RDProps.h
@@ -70,7 +70,7 @@ protected:
   }
   
   bool isComputedProp(const std::string &prop) const {
-    return isComputedProp(Dict::tagmap.get(prop));
+    return isComputedProp(GetKey(prop));
   }
   //! sets a \c property value
   /*!
@@ -94,7 +94,7 @@ protected:
 
   template <typename T>
   void setProp(const std::string &key, T val, bool computed = false) const {
-    setProp(Dict::tagmap.get(key), val, computed);
+    setProp(GetKey(key), val, computed);
   }
   //! allows retrieval of a particular property value
   /*!
@@ -119,7 +119,7 @@ protected:
   }
   template <typename T>
   void getProp(const std::string &key, T &res) const {
-    return getProp(Dict::tagmap.get(key), res);
+    return getProp(GetKey(key), res);
   }
 
   //! \overload
@@ -129,7 +129,7 @@ protected:
   }
   template <typename T>
   T getProp(const std::string &key) const {
-    return getProp<T>(Dict::tagmap.get(key));
+    return getProp<T>(GetKey(key));
   }
   //! returns whether or not we have a \c property with name \c key
   //!  and assigns the value if we do
@@ -141,7 +141,7 @@ protected:
 
   template <typename T>
   bool getPropIfPresent(const std::string &key, T &res) const {
-    return getPropIfPresent(Dict::tagmap.get(key), res);
+    return getPropIfPresent(GetKey(key), res);
   }
   //! \overload
   bool hasProp(int tag) const {
@@ -171,7 +171,7 @@ protected:
   };
 
   void clearProp(const std::string &key) const {
-    clearProp(Dict::tagmap.get(key));
+    clearProp(GetKey(key));
   };
 
   //! clears all of our \c computed \c properties

--- a/Code/RDGeneral/RDValue-doublemagic.h
+++ b/Code/RDGeneral/RDValue-doublemagic.h
@@ -46,6 +46,7 @@
 #include <boost/type_traits.hpp>
 #include <boost/static_assert.hpp>
 #include "LocaleSwitcher.h"
+#include "tags.h"
 
 namespace RDKit {
 
@@ -408,6 +409,22 @@ inline bool rdvalue_cast<bool>(RDValue v) {
           v.otherBits & ~RDTypeTag::BoolTag);
   throw boost::bad_any_cast();
 }
+
+// The RDValue has no getKey implementation
+//  so implement our own
+struct KeyIntPair {
+  int key;
+  RDValue val;
+  KeyIntPair() : key(), val() {}
+  KeyIntPair(int k, const RDValue &v) : key(k), val(v) {}
+  KeyIntPair(const std::string &s, RDValue_cast_t v) :
+  key(tagmap.get(s)), val(v) {}
+  
+  inline void setKey(int k) { key = k; }
+  inline int  getKey() const { return key; }
+
+  static RDTags tagmap;
+};
 
 } // namespace rdkit
 #endif

--- a/Code/RDGeneral/RDValue-doublemagic.h
+++ b/Code/RDGeneral/RDValue-doublemagic.h
@@ -47,8 +47,6 @@
 #include <boost/static_assert.hpp>
 #include "LocaleSwitcher.h"
 
-#define RDVALUE_HASBOOL
-
 namespace RDKit {
 
   // Inspired by

--- a/Code/RDGeneral/RDValue-taggedunion.h
+++ b/Code/RDGeneral/RDValue-taggedunion.h
@@ -43,7 +43,7 @@
 #include <boost/lexical_cast.hpp>
 #include "LocaleSwitcher.h"
 
-#define RDVALUE_HASBOOL
+#define RDVALUE_HAS_KEY
 
 namespace RDKit {
 
@@ -75,32 +75,32 @@ namespace RDKit {
 // Tagged union
 
 namespace RDTypeTag {
-  const short EmptyTag           = 0;
-  const short IntTag             = 1;
-  const short DoubleTag          = 2;
-  const short StringTag          = 3;
-  const short FloatTag           = 4;
-  const short BoolTag            = 5;
-  const short UnsignedIntTag     = 6;
-  const short AnyTag             = 7;
-  const short VecDoubleTag       = 8;
-  const short VecFloatTag        = 9;
-  const short VecIntTag          = 10;
-  const short VecUnsignedIntTag  = 11;
-  const short VecStringTag       = 12;
-  template<class T> inline short GetTag() { return AnyTag; }
-  template<> inline short GetTag<double>() { return DoubleTag; }
-  template<> inline short GetTag<float>() { return FloatTag; }
-  template<> inline short GetTag<int>() { return IntTag; }
-  template<> inline short GetTag<unsigned int>() { return UnsignedIntTag; }
-  template<> inline short GetTag<bool>() { return BoolTag; }
-  template<> inline short GetTag<std::string>() { return StringTag; }
-  template<> inline short GetTag<std::vector<double> >() { return VecDoubleTag; }
-  template<> inline short GetTag<std::vector<float> >() { return VecFloatTag; }
-  template<> inline short GetTag<std::vector<int> >() { return VecIntTag; }
-  template<> inline short GetTag<std::vector<unsigned int> >() { return VecUnsignedIntTag; }
-  template<> inline short GetTag<std::vector<std::string> >() { return VecStringTag; }
-  template<> inline short GetTag<boost::any>() { return AnyTag; }
+  const unsigned char EmptyTag           = 0;
+  const unsigned char IntTag             = 1;
+  const unsigned char DoubleTag          = 2;
+  const unsigned char StringTag          = 3;
+  const unsigned char FloatTag           = 4;
+  const unsigned char BoolTag            = 5;
+  const unsigned char UnsignedIntTag     = 6;
+  const unsigned char AnyTag             = 7;
+  const unsigned char VecDoubleTag       = 8;
+  const unsigned char VecFloatTag        = 9;
+  const unsigned char VecIntTag          = 10;
+  const unsigned char VecUnsignedIntTag  = 11;
+  const unsigned char VecStringTag       = 12;
+  template<class T> inline unsigned char GetTag() { return AnyTag; }
+  template<> inline unsigned char GetTag<double>() { return DoubleTag; }
+  template<> inline unsigned char GetTag<float>() { return FloatTag; }
+  template<> inline unsigned char GetTag<int>() { return IntTag; }
+  template<> inline unsigned char GetTag<unsigned int>() { return UnsignedIntTag; }
+  template<> inline unsigned char GetTag<bool>() { return BoolTag; }
+  template<> inline unsigned char GetTag<std::string>() { return StringTag; }
+  template<> inline unsigned char GetTag<std::vector<double> >() { return VecDoubleTag; }
+  template<> inline unsigned char GetTag<std::vector<float> >() { return VecFloatTag; }
+  template<> inline unsigned char GetTag<std::vector<int> >() { return VecIntTag; }
+  template<> inline unsigned char GetTag<std::vector<unsigned int> >() { return VecUnsignedIntTag; }
+  template<> inline unsigned char GetTag<std::vector<std::string> >() { return VecStringTag; }
+  template<> inline unsigned char GetTag<boost::any>() { return AnyTag; }
 
   namespace detail {
     union Value {
@@ -161,42 +161,52 @@ namespace RDTypeTag {
   }
 }
 
+const unsigned int KEYMAX = 0x00FFFFFF;
+
 struct RDValue {
   RDTypeTag::detail::Value value;
-  short type;
-  short reserved_tag; // 16 bit alignment
+  unsigned int type:8;
+  unsigned int key:24;
 
- inline RDValue(): value(0.0), type(RDTypeTag::EmptyTag) {}
+  inline RDValue(): value(0.0), type(RDTypeTag::EmptyTag), key(KEYMAX) {}
   // Pod Style (Direct storage)
- inline RDValue(double v)   : value(v), type(RDTypeTag::DoubleTag) {}
- inline RDValue(float v)    : value(v), type(RDTypeTag::FloatTag) {}
- inline RDValue(int v)      : value(v), type(RDTypeTag::IntTag) {}
- inline RDValue(unsigned v) : value(v), type(RDTypeTag::UnsignedIntTag) {}
- inline RDValue(bool v)     : value(v), type(RDTypeTag::BoolTag) {}
+ inline RDValue(double v)   : value(v), type(RDTypeTag::DoubleTag), key(KEYMAX) {}
+ inline RDValue(float v)    : value(v), type(RDTypeTag::FloatTag), key(KEYMAX) {}
+ inline RDValue(int v)      : value(v), type(RDTypeTag::IntTag), key(KEYMAX) {}
+ inline RDValue(unsigned v) : value(v), type(RDTypeTag::UnsignedIntTag), key(KEYMAX) {}
+ inline RDValue(bool v)     : value(v), type(RDTypeTag::BoolTag), key(KEYMAX) {}
 
- inline RDValue(boost::any *v)  : value(v),type(RDTypeTag::AnyTag) {}
+ inline RDValue(boost::any *v)  : value(v),type(RDTypeTag::AnyTag), key(KEYMAX) {}
 
   // Copies passed in pointers
- inline RDValue(const boost::any &v)  : value(new boost::any(v)),type(RDTypeTag::AnyTag) {}
- inline RDValue(const std::string &v) : value(new std::string(v)),type(RDTypeTag::StringTag){};
+ inline RDValue(const boost::any &v)  : value(new boost::any(v)),type(RDTypeTag::AnyTag), key(KEYMAX) {}
+ inline RDValue(const std::string &v) : value(new std::string(v)),type(RDTypeTag::StringTag), key(KEYMAX){};
  template <class T>
- inline RDValue(const T &v) : value(new boost::any(v)),type(RDTypeTag::AnyTag) {}
+ inline RDValue(const T &v) : value(new boost::any(v)),type(RDTypeTag::AnyTag), key(KEYMAX) {}
 
  inline RDValue(const std::vector<double> &v) : value(new std::vector<double>(v)),
-    type(RDTypeTag::VecDoubleTag) {}
+    type(RDTypeTag::VecDoubleTag), key(KEYMAX) {}
  inline RDValue(const std::vector<float> &v)  : value(new std::vector<float>(v)),
-    type(RDTypeTag::VecFloatTag) {}
+    type(RDTypeTag::VecFloatTag), key(KEYMAX) {}
  inline RDValue(const std::vector<int> &v)    : value(new std::vector<int>(v)),
-    type(RDTypeTag::VecIntTag) {}
+    type(RDTypeTag::VecIntTag), key(KEYMAX) {}
  inline RDValue(const std::vector<unsigned int> &v) :
   value(new std::vector<unsigned int>(v)),
-    type(RDTypeTag::VecUnsignedIntTag) {}
+    type(RDTypeTag::VecUnsignedIntTag), key(KEYMAX) {}
  inline RDValue(const std::vector<std::string> &v) :
   value(new std::vector<std::string>(v)),
-    type(RDTypeTag::VecStringTag) {}
+    type(RDTypeTag::VecStringTag), key(KEYMAX) {}
 
-  short getTag() const { return type; }
+  inline unsigned char getTag() const { return type; }
   
+  // we have enough space left over for a 24 bit key, might as well use it
+  inline int           getKey() const { return static_cast<int>(key); }
+  inline void          setKey(int k) {
+    CHECK_INVARIANT(k>=0 && k < static_cast<int>((1u<<24)-1),
+                    "Key index negative or too large to save");
+    key=k;
+  }
+
   // ptrCast - unsafe, use rdvalue_cast instead.
   template<class T>
   inline T* ptrCast() const {
@@ -251,6 +261,7 @@ inline void copy_rdvalue(RDValue &dest,
                          const RDValue &src) {
   dest.destroy();
   dest.type = src.type;
+  dest.key = src.key;
   switch (src.type) {
     case RDTypeTag::StringTag:
       dest.value.s = new std::string(*src.value.s);

--- a/Code/RDGeneral/RDValue-taggedunion.h
+++ b/Code/RDGeneral/RDValue-taggedunion.h
@@ -42,6 +42,7 @@
 #include <boost/utility.hpp>
 #include <boost/lexical_cast.hpp>
 #include "LocaleSwitcher.h"
+#include "tags.h"
 
 #define RDVALUE_HAS_KEY
 
@@ -360,6 +361,21 @@ inline bool rdvalue_cast<bool>(RDValue_cast_t v) {
   throw boost::bad_any_cast();
 }
 
+struct KeyIntPair {
+   RDValue val;
+  
+  KeyIntPair() : val() {}
+  KeyIntPair(int k, const RDValue &v) : val(v) {
+   val.setKey(k);
+   TEST_ASSERT(val.getKey() == k);
+  }
+  KeyIntPair(const std::string &s, RDValue_cast_t v) :
+   val(v) { val.setKey(tagmap.get(s));}
+  
+  inline void setKey(int k) { val.setKey(k); }
+  inline int  getKey() const { return val.getKey(); }
+  static RDTags tagmap;
+};  
 
 } // namespace rdkit
 #endif

--- a/Code/RDGeneral/RDValue-taggedunion.h
+++ b/Code/RDGeneral/RDValue-taggedunion.h
@@ -165,8 +165,8 @@ const unsigned int KEYMAX = 0x00FFFFFF;
 
 struct RDValue {
   RDTypeTag::detail::Value value;
-  unsigned int type:8;
-  unsigned int key:24;
+  short type;
+  int key;
 
   inline RDValue(): value(0.0), type(RDTypeTag::EmptyTag), key(KEYMAX) {}
   // Pod Style (Direct storage)

--- a/Code/RDGeneral/RDValue.h
+++ b/Code/RDGeneral/RDValue.h
@@ -178,11 +178,9 @@ inline bool rdvalue_tostring(RDValue_cast_t val, std::string &res) {
     case RDTypeTag::UnsignedIntTag:
       res = boost::lexical_cast<std::string>(rdvalue_cast<unsigned int>(val));
       break;
-#ifdef RDVALUE_HASBOOL      
     case RDTypeTag::BoolTag:
       res = boost::lexical_cast<std::string>(rdvalue_cast<bool>(val));
       break;
-#endif
     case RDTypeTag::FloatTag:
       res = boost::lexical_cast<std::string>(rdvalue_cast<float>(val));
       break;

--- a/Code/RDGeneral/RDValue.h
+++ b/Code/RDGeneral/RDValue.h
@@ -31,12 +31,7 @@
 #ifndef RDKIT_RDVALUE_H
 #define RDKIT_RDVALUE_H
 
-//#define UNSAFE_RDVALUE
-#ifdef UNSAFE_RDVALUE
-#include "RDValue-doublemagic.h"
-#else
-#include "RDValue-taggedunion.h"
-#endif
+#include "RDValue-implementation.h"
 
 namespace RDKit {
 //  Common Casts (POD Casts are implementation dependent)

--- a/Code/RDGeneral/rdkit.h.in
+++ b/Code/RDGeneral/rdkit.h.in
@@ -1,6 +1,6 @@
 /* 
 *
-*  Copyright (c) 2015, Novartis Institutes for BioMedical Research Inc.
+*  Copyright (c) 2016, Novartis Institutes for BioMedical Research Inc.
 *  All rights reserved.
 * 
 * Redistribution and use in source and binary forms, with or without
@@ -29,18 +29,13 @@
 * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
-#ifndef RDKIT_TAGS_H
-#define RDKIT_TAGS_H
 
+// Build Time Definitions
 
-#include "rdkit.h"
-
-#ifdef  RDK_THREADSAFE_SSS
-#include "tags-threadsafe.h"
-#else
-#include "tags-nonthreadsafe.h"
+#ifndef RDK_THREADSAFE_SSS
+#cmakedefine RDK_THREADSAFE_SSS
 #endif
 
+#ifndef RDK_TEST_MULTITHREADED
+#cmakedefine RDK_TEST_MULTITHREADED
 #endif
-
-

--- a/Code/RDGeneral/tags-nonthreadsafe.h
+++ b/Code/RDGeneral/tags-nonthreadsafe.h
@@ -1,6 +1,6 @@
 /* 
 *
-*  Copyright (c) 2015, Novartis Institutes for BioMedical Research Inc.
+*  Copyright (c) 2016, Novartis Institutes for BioMedical Research Inc.
 *  All rights reserved.
 * 
 * Redistribution and use in source and binary forms, with or without
@@ -29,17 +29,63 @@
 * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
-#ifndef RDKIT_TAGS_H
-#define RDKIT_TAGS_H
+#ifndef RDKIT_TAGS_NONTHREADSAFE_H
+#define RDKIT_TAGS_NONTHREADSAFE_H
+
+#include "types.h"
+
+#include "BoostStartInclude.h"
+#include <boost/unordered_map.hpp>
+#include "BoostEndInclude.h"
 
 
+namespace RDKit
+{
 
-#ifdef  RDK_THREADSAFE_SSS
-#include "tags-threadsafe.h"
-#else
-#include "tags-nonthreadsafe.h"
+// RDTags is designed to be used as a static singleton
+class RDTags
+{
+  RDTags(const RDTags&);
+  RDTags& operator=(const RDTags&);
+public:
+  // Load the known keys
+  RDTags() {
+    for(int i=0;i<=common_properties::MAX;++i) {
+      keyIntMap[common_properties::getPropName(i)] = i;
+      keys.push_back(common_properties::getPropName(i));
+    }
+  };
+
+  //! \brief Get the current string key for the integer key.
+  //!  throws std::out_of_range when key is out
+  //!  of range.  
+  const std::string &get(int tag) const {
+    return keys[tag]; // raises exception
+  }
+
+  //! \brief Return the int key for the specified string key
+  //! If the string key has never been used before, it is
+  //!  added to the global map and a new integer key is created.
+  int get(const std::string &key) const
+  {
+    boost::unordered_map<std::string, int>::const_iterator it=keyIntMap.find(key);
+    
+    if (it != keyIntMap.end()) {
+      return it->second;
+    }
+
+    int res = static_cast<int>(keyIntMap.size());
+    std::pair<std::string, int> p(key,res);
+    keyIntMap.insert(p);
+    keys.push_back(key);
+    return res;
+  }
+  
+public:
+  mutable boost::unordered_map<std::string, int> keyIntMap;
+  mutable std::vector<std::string > keys;
+};
+
+}
+
 #endif
-
-#endif
-
-

--- a/Code/RDGeneral/tags-threadsafe.h
+++ b/Code/RDGeneral/tags-threadsafe.h
@@ -1,0 +1,121 @@
+/* 
+*
+*  Copyright (c) 2016, Novartis Institutes for BioMedical Research Inc.
+*  All rights reserved.
+* 
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are
+* met: 
+*
+*     * Redistributions of source code must retain the above copyright 
+*       notice, this list of conditions and the following disclaimer.
+*     * Redistributions in binary form must reproduce the above
+*       copyright notice, this list of conditions and the following 
+*       disclaimer in the documentation and/or other materials provided 
+*       with the distribution.
+*     * Neither the name of Novartis Institutes for BioMedical Research Inc. 
+*       nor the names of its contributors may be used to endorse or promote 
+*       products derived from this software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+* "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+* LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+* A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+* OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+* SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+* DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+* THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+* OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+#ifndef RDKIT_TAGS_THREADSAFE_H
+#define RDKIT_TAGS_THREADSAFE_H
+
+#include "BoostStartInclude.h"
+#include <boost/unordered_map.hpp>
+#include <boost/thread/mutex.hpp>
+#include <boost/thread/tss.hpp>
+#include "BoostEndInclude.h"
+
+#include "types.h"
+
+namespace RDKit
+{
+
+class RDTags
+{
+  RDTags(const RDTags&);
+  RDTags& operator=(const RDTags&);
+public:
+  RDTags() {
+    // Load the known keys
+    for(int i=0;i<=common_properties::MAX;++i) {
+      keyIntMap[common_properties::getPropName(i)] = i;
+      keys.push_back(common_properties::getPropName(i));
+    }
+  };
+
+  //! \brief Get the current string key for the integer key.
+  //!  throws std::out_of_range when key is out
+  //!  of range.
+  inline const std::string &get(int tag) const {
+    return keys[tag]; // raises exception
+  }
+
+  //! \brief Return the int key for the specified string key
+  //! If the string key has never been used before, it is
+  //!  added to the global map and a new integer key is created.
+  inline int get(const std::string &key) const
+  {
+    // local threadsafe map used for quick non-contested lookups in threads
+    static boost::thread_specific_ptr<boost::unordered_map<std::string, int> >
+        tls_keyIntMap;
+
+    if ( !tls_keyIntMap.get() ) {
+      // enable TLS loaded with current map
+      boost::unique_lock<boost::mutex> lock(_globalMapMutex);
+      tls_keyIntMap.reset(new boost::unordered_map<std::string, int>(keyIntMap));
+    }
+    
+    boost::unordered_map<std::string, int> &local_keyIntMap= *tls_keyIntMap;
+    // check the thread local cache
+    {
+      boost::unordered_map<std::string, int>::const_iterator it=local_keyIntMap.find(key);
+      if (it != local_keyIntMap.end())
+        return it->second;
+    }
+    
+    {
+      boost::unique_lock<boost::mutex> lock(_globalMapMutex);
+
+      // Check to see if the key has been added to the global map
+      boost::unordered_map<std::string, int>::const_iterator it=keyIntMap.find(key);
+        
+      if (it != keyIntMap.end()) {
+        // if so, insert into local map and return
+        local_keyIntMap.insert(*it);
+        return it->second;
+      }
+
+      // otherwise make a new map and add it to the local and global maps
+      int res = static_cast<int>(keyIntMap.size());
+      std::pair<std::string, int> p(key,res);
+      local_keyIntMap.insert(p);
+      keyIntMap.insert(p);
+      keys.push_back(key);
+      return res;
+      // lock is released
+    }
+  }
+  
+private:
+    mutable boost::mutex _globalMapMutex;
+public:
+    mutable boost::unordered_map<std::string, int> keyIntMap;
+    mutable std::vector<std::string > keys;
+};
+
+}
+
+#endif

--- a/Code/RDGeneral/tags.h
+++ b/Code/RDGeneral/tags.h
@@ -1,0 +1,122 @@
+/* 
+*
+*  Copyright (c) 2015, Novartis Institutes for BioMedical Research Inc.
+*  All rights reserved.
+* 
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are
+* met: 
+*
+*     * Redistributions of source code must retain the above copyright 
+*       notice, this list of conditions and the following disclaimer.
+*     * Redistributions in binary form must reproduce the above
+*       copyright notice, this list of conditions and the following 
+*       disclaimer in the documentation and/or other materials provided 
+*       with the distribution.
+*     * Neither the name of Novartis Institutes for BioMedical Research Inc. 
+*       nor the names of its contributors may be used to endorse or promote 
+*       products derived from this software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+* "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+* LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+* A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+* OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+* SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+* DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+* THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+* OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+#ifndef RDKIT_TAGS_H
+#define RDKIT_TAGS_H
+
+#include "BoostStartInclude.h"
+
+#ifdef RDK_TEST_MULTITHREADED
+#include <boost/thread/mutex.hpp>
+#include <boost/thread/tss.hpp>
+#endif
+
+#include <boost/unordered_map.hpp>
+#include "BoostEndInclude.h"
+#include "types.h"
+
+namespace RDKit
+{
+
+class RDTags
+{
+  RDTags(const RDTags&);
+  RDTags& operator=(const RDTags&);
+public:
+  RDTags() {
+    for(int i=0;i<=common_properties::MAX;++i) {
+      m[common_properties::getPropName(i)] = i;
+      keys.push_back(common_properties::getPropName(i));
+    }
+  };
+
+  const std::string &get(int tag) const {
+    return keys[tag]; // raises exception
+  }
+  
+  int get(const std::string &k) const
+  {
+#ifdef RDK_TEST_MULTITHREADED
+    static boost::thread_specific_ptr<boost::unordered_map<std::string, int> >
+        instance;
+
+    if ( !instance.get() ) {
+      boost::unique_lock<boost::mutex> lock(_m);
+      // enable TLS loaded with current map
+      instance.reset(new boost::unordered_map<std::string, int>(m));
+    }
+    
+    boost::unordered_map<std::string, int> &ptr = *instance;
+    // check tls map
+    {
+      boost::unordered_map<std::string, int>::const_iterator it=ptr.find(k);
+      if (it != ptr.end())
+        return it->second;
+    }
+#endif
+    
+    {
+      boost::unique_lock<boost::mutex> lock(_m);
+      
+      {
+        boost::unordered_map<std::string, int>::const_iterator it=m.find(k);
+        
+        if (it != m.end()) {
+#ifdef RDK_TEST_MULTITHREADED          
+          // insert into local map        
+          instance->insert(*it);
+#endif
+          return it->second;
+        }
+      }
+      {
+        int res = m.size();
+        std::pair<std::string, int> p(k,res);
+#ifdef RDK_TEST_MULTITHREADED        
+        instance->insert(p);
+#endif        
+        m.insert(p);
+        keys.push_back(k);
+        return res;
+      }
+    }
+  }
+  
+private:
+    mutable boost::mutex _m;
+public:
+    mutable boost::unordered_map<std::string, int> m;
+    mutable std::vector<std::string > keys;
+};
+
+}
+
+#endif

--- a/Code/RDGeneral/testRDTags.cpp
+++ b/Code/RDGeneral/testRDTags.cpp
@@ -1,0 +1,149 @@
+#include "tags.h"
+#include "Invariant.h"
+
+using namespace RDKit;
+
+template < typename T > std::string to_string( const T& n )
+{
+  std::ostringstream stm ;
+  stm << n ;
+  return stm.str() ;
+}
+
+const int MOD=10000;
+const int COUNT=5000000;
+static std::vector<std::string> nums;
+
+void testTags() {
+  for( int idx=0; idx<MOD; ++idx) {
+    nums.push_back( to_string(idx) );
+  }
+
+
+  RDTags tags;
+  {
+    std::clock_t clock1 = std::clock();
+
+    for( int idx=0; idx<COUNT; ++idx) {
+      int i = idx % MOD;
+      CHECK_INVARIANT(tags.get(nums[i]) == common_properties::MAX+i+1,
+                      "Bad map");
+    }
+    std::clock_t clock2 = std::clock();
+    
+    std::cout << "tag gets: " << (double)(clock2-clock1)/CLOCKS_PER_SEC << " s" << std::endl;
+
+  }
+  {
+    std::clock_t clock1 = std::clock();
+
+    for( int idx=0; idx<COUNT; ++idx) {
+      int i = idx % MOD;
+      CHECK_INVARIANT(tags.get(nums[i]) == common_properties::MAX+i+1,
+                      "Bad map");
+    }
+    std::clock_t clock2 = std::clock();
+    
+    std::cout << "tag gets: " << (double)(clock2-clock1)/CLOCKS_PER_SEC << " s" << std::endl;
+
+  }
+  
+  for( int idx=0; idx<COUNT; ++idx) {
+    int i = idx % MOD;
+    CHECK_INVARIANT(nums[i] == tags.get(common_properties::MAX+i+1),
+                    "Bad lookup");
+  }
+  
+  }
+
+#ifdef RDK_TEST_MULTITHREADED
+namespace {
+void runblock_test(RDTags *tag, std::map<std::string, int> *m) {
+  for( int idx=0; idx<COUNT; ++idx) {
+    int i = idx % MOD;
+    int value = tag->get(nums[i]);
+    (*m)[nums[i]] = value;
+  }
+}
+
+void runblock_time(RDTags *tag) {
+  for( int idx=0; idx<COUNT; ++idx) {
+    int i = idx % MOD;
+    tag->get(nums[i]);
+  }
+}
+}
+
+#include <RDGeneral/BoostStartInclude.h>
+#include <boost/thread.hpp>
+#include <RDGeneral/BoostEndInclude.h>
+void testMultiThread() {
+  RDTags tagmap;
+  boost::thread_group tg;
+  int count = 8;
+
+  std::vector<std::map<std::string, int> > maps(count);
+  for (int i=0; i<count; ++i) {
+    tg.add_thread(new boost::thread(runblock_test, &tagmap, &maps[i]));
+  }
+  tg.join_all();
+
+  for( int idx=0; idx<MOD; ++idx) {
+    std::string k = to_string(idx);
+    int i = maps[0][k];
+    int i2 = maps[1][k];
+    int i3 = maps[2][k];
+    int i4 = maps[3][k];
+    if (!(i == i2 == i3 == i4)) {
+      //std::cout << k << ":" << i << " " << i2 << " " << i3 << " " << i4 << std::endl;
+      CHECK_INVARIANT(i, "Bad insertion");
+      CHECK_INVARIANT(i == maps[1][k], "Bad insertion 1");
+      CHECK_INVARIANT(i == maps[2][k], "Bad insertion 1");
+      CHECK_INVARIANT(i == maps[3][k], "Bad insertion 1");
+    }
+  }
+}
+
+void testMultiThreadTime() {
+  RDTags tagmap;
+  {
+    boost::thread_group tg;
+    int count = 4;
+    std::clock_t clock1 = std::clock();
+    
+    for (int i=0; i<count; ++i) {
+      tg.add_thread(new boost::thread(runblock_time, &tagmap));
+    }
+    tg.join_all();
+    std::clock_t clock2 = std::clock();
+    
+    std::cout << "4 tagmaps colliding a lot: " << (double)(clock2-clock1)/CLOCKS_PER_SEC << " s" << std::endl;
+  }
+  {
+    boost::thread_group tg;
+    int count = 4;
+    std::clock_t clock1 = std::clock();
+    
+    for (int i=0; i<count; ++i) {
+      tg.add_thread(new boost::thread(runblock_time, &tagmap));
+    }
+    tg.join_all();
+    std::clock_t clock2 = std::clock();
+    
+    std::cout << "4 tagmaps colliding a lot (start with tls loaded): " << (double)(clock2-clock1)/CLOCKS_PER_SEC << " s" << std::endl;
+  }
+  
+
+}
+#endif
+
+int main() {
+  std::cerr << "-- running tests -- " << std::endl;
+  testTags();
+#ifdef RDK_TEST_MULTITHREADED
+  std::cerr << "-- running multithreaded -- " << std::endl;
+  //testMultiThread();
+  testMultiThreadTime();
+#endif  
+  return 0;
+}

--- a/Code/RDGeneral/types.cpp
+++ b/Code/RDGeneral/types.cpp
@@ -15,85 +15,90 @@
 
 namespace RDKit {
 namespace common_properties {
-const std::string TWOD = "2D";
-const std::string BalabanJ = "BalabanJ";
-const std::string BalanbanJ = "BalanbanJ";
-const std::string Discrims = "Discrims";
-const std::string DistanceMatrix_Paths = "DistanceMatrix_Paths";
-const std::string MolFileComments = "MolFileComments";
-const std::string MolFileInfo = "MolFileInfo";
-const std::string NullBond = "NullBond";
-const std::string _2DConf = "_2DConf";
-const std::string _3DConf = "_3DConf";
-const std::string _AtomID = "_AtomID";
-const std::string _BondsPotentialStereo = "_BondsPotentialStereo";
-const std::string _CIPCode = "_CIPCode";
-const std::string _CIPRank = "_CIPRank";
-const std::string _ChiralityPossible = "_ChiralityPossible";
-const std::string _CrippenLogP = "_CrippenLogP";
-const std::string _CrippenMR = "_CrippenMR";
-const std::string _MMFFSanitized = "_MMFFSanitized";
-const std::string _MolFileChiralFlag = "_MolFileChiralFlag";
-const std::string _MolFileRLabel = "_MolFileRLabel";
-const std::string _Name = "_Name";
-const std::string _NeedsQueryScan = "_NeedsQueryScan";
-const std::string _QueryFormalCharge = "_QueryFormalCharge";
-const std::string _QueryHCount = "_QueryHCount";
-const std::string _QueryIsotope = "_QueryIsotope";
-const std::string _QueryMass = "_QueryMass";
-const std::string _ReactionDegreeChanged = "_ReactionDegreeChanged";
-const std::string _RingClosures = "_RingClosures";
-const std::string _SLN_s = "_SLN_s";
-const std::string _SmilesStart = "_SmilesStart";
-const std::string _StereochemDone = "_StereochemDone";
-const std::string _TraversalBondIndexOrder = "_TraversalBondIndexOrder";
-const std::string _TraversalRingClosureBond = "_TraversalRingClosureBond";
-const std::string _TraversalStartPoint = "_TraversalStartPoint";
-const std::string _TriposAtomType = "_TriposAtomType";
-const std::string _Unfinished_SLN_ = "_Unfinished_SLN_";
-const std::string _UnknownStereo = "_UnknownStereo";
-const std::string _connectivityHKDeltas = "_connectivityHKDeltas";
-const std::string _connectivityNVals = "_connectivityNVals";
-const std::string _crippenLogP = "_crippenLogP";
-const std::string _crippenLogPContribs = "_crippenLogPContribs";
-const std::string _crippenMR = "_crippenMR";
-const std::string _crippenMRContribs = "_crippenMRContribs";
-const std::string _doIsoSmiles = "_doIsoSmiles";
-const std::string _fragSMARTS = "_fragSMARTS";
-const std::string _hasMassQuery = "_hasMassQuery";
-const std::string _labuteASA = "_labuteASA";
-const std::string _labuteAtomContribs = "_labuteAtomContribs";
-const std::string _labuteAtomHContrib = "_labuteAtomHContrib";
-const std::string _protected = "_protected";
-const std::string _queryRootAtom = "_queryRootAtom";
-const std::string _ringStereoAtoms = "_ringStereoAtoms";
-const std::string _ringStereoWarning = "_ringStereoWarning";
-const std::string _ringStereochemCand = "_ringStereochemCand";
-const std::string _smilesAtomOutputOrder = "_smilesAtomOutputOrder";
-const std::string _starred = "_starred";
-const std::string _supplementalSmilesLabel = "_supplementalSmilesLabel";
-const std::string _tpsa = "_tpsa";
-const std::string _tpsaAtomContribs = "_tpsaAtomContribs";
-const std::string _unspecifiedOrder = "_unspecifiedOrder";
-const std::string _brokenChirality = "_brokenChirality";
-const std::string _rgroupAtomMaps = "_rgroupAtomMaps";
-const std::string _rgroupBonds = "_rgroupBonds";
-const std::string dummyLabel = "dummyLabel";
-const std::string extraRings = "extraRings";
-const std::string isImplicit = "isImplicit";
-const std::string maxAttachIdx = "maxAttachIdx";
-const std::string molAtomMapNumber = "molAtomMapNumber";
-const std::string molFileAlias = "molFileAlias";
-const std::string molFileValue = "molFileValue";
-const std::string molInversionFlag = "molInversionFlag";
-const std::string molParity = "molParity";
-const std::string molRxnComponent = "molRxnComponent";
-const std::string molRxnRole = "molRxnRole";
-const std::string molTotValence = "molTotValence";
-const std::string numArom = "numArom";
-const std::string origNoImplicit = "origNoImplicit";
-const std::string ringMembership = "ringMembership";
-const std::string smilesSymbol = "smilesSymbol";
+const char * propnames[] = {
+  "_Name",
+  "_MolFileInfo",
+  "_MolFileComments",
+  "_2DConf",
+  "_3DConf",
+  "_doIsoSmiles",
+  "extraRings",
+  "_smilesAtomOutputOrder",
+  "_StereochemDone",
+  "_NeedsQueryScan",
+  "_fragSMARTS",
+  "maxAttachIdx",
+  "origNoImplicit",
+  "ringMembership",
+  "_connectivityHKDeltas",
+  "_connectivityNVals",
+  "_crippenLogP",
+  "_crippenLogPContribs",
+  "_crippenMR",
+  "_crippenMRContribs",
+  "_labuteASA",
+  "_labuteAtomContribs",
+  "_labuteAtomHContrib",
+  "_tpsa",
+  "_tpsaAtomContribs",
+  "numArom",
+  "_MMFFSanitized",
+  "_CrippenLogP",
+  "_CrippenMR",
+  "_BondsPotentialStereo",
+  "_CIPCode",
+  "_CIPRank",
+  "_ChiralityPossible",
+  "_UnknownStereo",
+  "_ringStereoAtoms",
+  "_ringStereochemCand",
+  "_ringStereoWarning",
+  "_SmilesStart",
+  "_TraversalBondIndexOrder",
+  "_TraversalRingClosureBond",
+  "_TraversalStartPoint",
+  "_queryRootAtom",
+  "_hasMassQuery",
+  "_protected",
+  "_supplementalSmilesLabel",
+  "_unspecifiedOrder",
+  "_RingClosures",
+  "molAtomMapNumber",
+  "molFileAlias",
+  "molFileValue",
+  "molInversionFlag",
+  "molParity",
+  "molRxnComponent",
+  "molRxnRole",
+  "molTotValence",
+  "_MolFileRLabel",
+  "_MolFileChiralFlag",
+  "dummyLabel",
+  "_QueryFormalCharge",
+  "_QueryHCount",
+  "_QueryIsotope",
+  "_QueryMass",
+  "_ReactionDegreeChanged",
+  "NullBond",
+  "_rgroupAtomMaps",
+  "_rgroupBonds",
+  "_AtomID",
+  "_starred",
+  "_SLN_s",
+  "_Unfinished_SLN_",
+  "_brokenChirality",
+  "isImplicit",
+  "smilesSymbol",
+  "_TriposAtomType",
+  "2D",
+  "BalabanJ",
+  "BalanbanJ",
+  "Discrims",
+  "DistanceMatrix_Paths",
+  //"__computedProps"
+};
+
+
 }  // end common_properties
 
 const double MAX_DOUBLE = std::numeric_limits<double>::max();

--- a/Code/RDGeneral/types.h
+++ b/Code/RDGeneral/types.h
@@ -18,7 +18,7 @@
 #include <cmath>
 
 #include "Invariant.h"
-#include "Dict.h"
+#include "Exceptions.h"
 
 namespace detail {
 // used in various places for computed properties
@@ -44,124 +44,123 @@ namespace RDKit {
 namespace common_properties {
 ///////////////////////////////////////////////////////////////
 // Molecule Props
-extern const std::string _Name;           // string
-extern const std::string MolFileInfo;     // string
-extern const std::string MolFileComments; // string
-extern const std::string _2DConf;         // int (combine into dimension?)
-extern const std::string _3DConf;         // int
-extern const std::string _doIsoSmiles;    // int (should probably be removed)
-extern const std::string extraRings;      // vec<vec<int> > 
-extern const std::string _smilesAtomOutputOrder; // vec<int> computed
-extern const std::string _StereochemDone; // int 
-extern const std::string _NeedsQueryScan; // int (bool)
-extern const std::string _fragSMARTS;     // std::string
-extern const std::string maxAttachIdx;    // int TemplEnumTools.cpp
-extern const std::string origNoImplicit;  // int (bool) 
-extern const std::string ringMembership;  //? unused (molopstest.cpp)
+const int _Name                  = 0;   // string
+const int MolFileInfo            = 1;   // string
+const int MolFileComments        = 2;   // string
+const int _2DConf                = 3;   // int (combine into dimension?)
+const int _3DConf                = 4;   // int
+const int _doIsoSmiles           = 5;   // int (should probably be removed)
+const int extraRings             = 6;   // vec<vec<int> >
+const int _smilesAtomOutputOrder = 7;   // vec<int> computed
+const int _StereochemDone        = 8;   // int
+const int _NeedsQueryScan        = 9;   // int (bool)
+const int _fragSMARTS            = 10;  // std::string
+const int maxAttachIdx           = 11;  // int TemplEnumTools.cpp
+const int origNoImplicit         = 12;  // int (bool)
+const int ringMembership         = 13;  //? unused (molopstest.cpp)
 
 // Computed Values
 // ConnectivityDescriptors
-extern const std::string _connectivityHKDeltas;// std::vector<double> computed 
-extern const std::string _connectivityNVals;   // std::vector<double> computed 
-
-extern const std::string _crippenLogP;         // double computed
-extern const std::string _crippenLogPContribs; // std::vector<double> computed
-
-extern const std::string _crippenMR;           // double computed
-extern const std::string _crippenMRContribs;   // std::vector<double> computed
-
-extern const std::string _labuteASA;           // double computed
-extern const std::string _labuteAtomContribs;  // vec<double> computed
-extern const std::string _labuteAtomHContrib;  // double computed
-
-extern const std::string _tpsa;                // double computed
-extern const std::string _tpsaAtomContribs;    // vec<double> computed
-
-extern const std::string numArom;              // int computed (only uses in tests?)
-extern const std::string _MMFFSanitized;       // int (bool) computed
-
-extern const std::string _CrippenLogP; // Unused (in the basement)
-extern const std::string _CrippenMR;   // Unused (in the basement)
+const int _connectivityHKDeltas = 14;   // std::vector<double> computed
+const int _connectivityNVals    = 15;   // std::vector<double> computed
+const int _crippenLogP          = 16;   // double computed
+const int _crippenLogPContribs  = 17;   // std::vector<double> computed
+const int _crippenMR            = 18;   // double computed
+const int _crippenMRContribs    = 19;   // std::vector<double> computed
+const int _labuteASA            = 20;   // double computed
+const int _labuteAtomContribs   = 21;   // vec<double> computed
+const int _labuteAtomHContrib   = 22;   // double computed
+const int _tpsa                 = 23;   // double computed
+const int _tpsaAtomContribs     = 24;   // vec<double> computed
+const int numArom               = 25;   // int computed (only uses in tests?)
+const int _MMFFSanitized        = 26;   // int (bool) computed
+const int _CrippenLogP          = 27;   // Unused (in the basement)
+const int _CrippenMR            = 28;   // Unused (in the basement)
 
 ///////////////////////////////////////////////////////////////
 // Atom Props
 
 // Chirality stuff
-extern const std::string _BondsPotentialStereo; // int (or bool) COMPUTED 
-extern const std::string _CIPCode; // std::string COMPUTED
-extern const std::string _CIPRank; // int COMPUTED
-extern const std::string _ChiralityPossible; // int
-extern const std::string _UnknownStereo; // int (bool) AddHs/Chirality
-extern const std::string _ringStereoAtoms; // int vect Canon/Chiral/MolHash/MolOps//Renumber//RWmol
-extern const std::string _ringStereochemCand; // chirality bool COMPUTED
-extern const std::string _ringStereoWarning; // obsolete ?
+const int _BondsPotentialStereo = 29;   // int (or bool) COMPUTED
+const int _CIPCode              = 30;   // std::string COMPUTED
+const int _CIPRank              = 31;   // int COMPUTED
+const int _ChiralityPossible    = 32;   // int
+const int _UnknownStereo        = 33;   // int (bool) AddHs/Chirality
+const int _ringStereoAtoms      = 34;   // int vect Canon/Chiral/MolHash/MolOps//Renumber
+                                        //RWmol
+const int _ringStereochemCand   = 35;   // chirality bool COMPUTED
+const int _ringStereoWarning    = 36;   // obsolete ?
 
 // Smiles parsing
-extern const std::string _SmilesStart; // int
-extern const std::string _TraversalBondIndexOrder; // ? unused
-extern const std::string _TraversalRingClosureBond; // unsigned int 
-extern const std::string _TraversalStartPoint; // bool
-extern const std::string _queryRootAtom; // int SLNParse/SubstructMatch
-extern const std::string _hasMassQuery; // atom bool
-extern const std::string _protected; // atom int (bool)
-extern const std::string _supplementalSmilesLabel; // atom string (SmilesWrite)
-extern const std::string _unspecifiedOrder;// atom int (bool) smarts/smiles
-extern const std::string _RingClosures; // INT_VECT smarts/smiles/canon
+const int _SmilesStart              = 37; // int
+const int _TraversalBondIndexOrder  = 38; // ? unused
+const int _TraversalRingClosureBond = 39; // unsigned int
+const int _TraversalStartPoint      = 40; // bool
+const int _queryRootAtom            = 41; // int SLNParse/SubstructMatch
+const int _hasMassQuery             = 42; // atom bool
+const int _protected                = 43; // atom int (bool)
+const int _supplementalSmilesLabel  = 44; // atom string (SmilesWrite)
+const int _unspecifiedOrder         = 45; // atom int (bool) smarts/smiles
+const int _RingClosures             = 46; // INT_VECT smarts/smiles/canon
 
 // MDL Style Properties (MolFileParser)
-extern const std::string molAtomMapNumber; // int 
-extern const std::string molFileAlias;  // string 
-extern const std::string molFileValue;  // string 
-extern const std::string molInversionFlag; // int 
-extern const std::string molParity;     // int 
-extern const std::string molRxnComponent; // int 
-extern const std::string molRxnRole;    // int 
-extern const std::string molTotValence; // int 
-extern const std::string _MolFileRLabel; // int
-extern const std::string _MolFileChiralFlag; // int
-
-extern const std::string dummyLabel; // atom string
-
+const int molAtomMapNumber   = 47;      // int
+const int molFileAlias       = 48;      // string
+const int molFileValue       = 49;      // string
+const int molInversionFlag   = 50;      // int
+const int molParity          = 51;      // int
+const int molRxnComponent    = 52;      // int
+const int molRxnRole         = 53;      // int
+const int molTotValence      = 54;      // int
+const int _MolFileRLabel     = 55;      // int
+const int _MolFileChiralFlag = 56;      // int
+const int dummyLabel         = 57;       // atom string
+    
 // Reaction Information (Reactions.cpp)
-extern const std::string _QueryFormalCharge; //  int 
-extern const std::string _QueryHCount; // int 
-extern const std::string _QueryIsotope; // int
-extern const std::string _QueryMass; // int = round(float * 1000) 
-extern const std::string _ReactionDegreeChanged; // int (bool) 
-extern const std::string NullBond; // int (bool)
-extern const std::string _rgroupAtomMaps;
-extern const std::string _rgroupBonds;
+const int _QueryFormalCharge     = 58;  //  int
+const int _QueryHCount           = 59;  // int
+const int _QueryIsotope          = 60;  // int
+const int _QueryMass             = 61;  // int = round(float * 1000)
+const int _ReactionDegreeChanged = 62;  // int (bool)
+const int NullBond               = 63;  // int (bool)
+const int _rgroupAtomMaps        = 64;  // int
+const int _rgroupBonds           = 65;  // int
 
 // SLN
-extern const std::string _AtomID; // unsigned int SLNParser
-extern const std::string _starred; // atom int COMPUTED (SLN)
-extern const std::string _SLN_s; // string SLNAttribs (chiral info)
-extern const std::string _Unfinished_SLN_; // int (bool)
+const int _AtomID          = 66;        // unsigned int SLNParser
+const int _starred         = 67;        // atom int COMPUTED (SLN)
+const int _SLN_s           = 68;        // string SLNAttribs (chiral info)
+const int _Unfinished_SLN_ = 69;        // int (bool)
 
 // Smarts Smiles
-extern const std::string _brokenChirality; // atom bool
-extern const std::string isImplicit;  // atom int (bool) 
-extern const std::string smilesSymbol; // atom string (only used in test?)
+const int _brokenChirality = 70;        // atom bool
+const int isImplicit       = 71;        // atom int (bool)
+const int smilesSymbol     = 72;        // atom string (only used in test?)
 
 // Tripos
-extern const std::string _TriposAtomType; // string Mol2FileParser
+const int _TriposAtomType = 73; // string Mol2FileParser
 // missing defs for _TriposAtomName//_TriposPartialCharge...
 
 
 ///////////////////////////////////////////////////////////////
 // misc props
-extern const std::string TWOD; // need THREED -> confusing using in TDTMol supplier
-                               //  converge with _2DConf?
-extern const std::string BalabanJ; // mol double
-extern const std::string BalanbanJ; // typo!! fix...
-
-extern const std::string Discrims; // FragCatalog Entry
-                                   // Subgraphs::DiscrimTuple (uint32,uint32,uint32)
-extern const std::string DistanceMatrix_Paths; // boost::shared_array<double>
-                                               //  - note, confusing creation of names in
-                                               //  - getDistanceMat
+const int TWOD                 = 74;    // need THREED -> confusing using in TDTMol supplier                                           //  converge with _2DConf?
+const int BalabanJ             = 75;    // mol double
+const int BalanbanJ            = 76;    // typo!! fix...
+const int Discrims             = 77;    // FragCatalog Entry
+                                        // Subgraphs::DiscrimTuple (uint32,uint32,uint32)
+const int DistanceMatrix_Paths = 78;    // boost::shared_array<double>
+                                        //  - note, confusing creation of names in
+                                        //  - getDistanceMat
+const int MAX                  = 78;   // reserved spaces
+const int RESERVED             = 256;
+///////////////////////////////////////////////////////////////
+// Name Lookup (see Dict.cpp)
+extern const char * propnames[];
+const char *getPropName(int);
 
 }  // end common_properties
+
 #ifndef WIN32
 typedef long long int LONGINT;
 #else


### PR DESCRIPTION
Major optimization to RDKit Dictionaries.
- Dictionaries no longer use string->value lookups, they use int->value lookups.
- Most internal operations have predefined names (now integer values) so these are largely unchanged in the source code when using the common_properties namespace.
- names are mapped to integers using a new tagging system;  

```
  common_properties::getPropName(int) //returns the name for an integer tag
  Dict::tagmap.get("name") //returns the tag for the string, making a new tag if necessary in a thread-safe manner
```
- the list of computedProperties no longer exists in the dictionary as it was always used.  It now exists outside of the dictionary and is a list of integers.  This adds Dict::isComputedProp(what) and Dict::getComputedPropList() which are faster to compute and search as well.

Benefits:
  Smaller and quite a bit faster than the original implementation, especially for "built in" types.

Risks:
  The default implementation can only handle 16,777,216 (2^24) tags.  An exception will occur when this number is reached with essentially no recurse to recover tags.  This may be an issue for long running servers.  At the cost of some space per value (32bits) or by using the double-magic implementation, this can be 2^32 or 4,294,967,296.  

See the RDVALUE_HAS_KEY define in RDValue.h.

Both have the same issue that the tag space cannot be recovered unless we know that no molecules are present.
