### PR TITLE
Bug when removing stereo info?

### DIFF
--- a/Code/GraphMol/RWMol.cpp
+++ b/Code/GraphMol/RWMol.cpp
@@ -329,7 +329,7 @@ void RWMol::removeBond(unsigned int aid1, unsigned int aid2) {
     if (!obnd) continue;
     obnd->getStereoAtoms().clear();
   }
-  boost::tie(a1, a2) = boost::adjacent_vertices(aid1, d_graph);
+  boost::tie(a1, a2) = boost::adjacent_vertices(aid2, d_graph);
   while (a1 != a2) {
     unsigned int oIdx = rdcast<unsigned int>(*a1);
     ++a1;


### PR DESCRIPTION
It's very possible, that I don't understand something (apologies) but shouldn't the second loop iterate over vertices adjacent to the second end of the bond being removed?