### PR TITLE
Made DistGeomHelpers test robust against small 3D coordinate variations

### DIFF
--- a/Code/GraphMol/DistGeomHelpers/Wrap/testDistGeom.py
+++ b/Code/GraphMol/DistGeomHelpers/Wrap/testDistGeom.py
@@ -375,16 +375,24 @@ class TestCase(unittest.TestCase) :
             ee = ff.CalcEnergy()
             energies.append(ee)
 
-        mol = Chem.AddHs(Chem.MolFromSmiles("CC(C)(C)c(cc12)n[n]2C(=O)/C=C(N1)/COC"))
-        cids = rdDistGeom.EmbedMultipleConfs(mol,200,maxAttempts=30,randomSeed=100,numThreads=4)
+        mol2 = Chem.AddHs(Chem.MolFromSmiles("CC(C)(C)c(cc12)n[n]2C(=O)/C=C(N1)/COC"))
+        cids2 = rdDistGeom.EmbedMultipleConfs(mol2,200,maxAttempts=30,randomSeed=100,numThreads=4)
+        self.assertTrue(lstEq(cids, cids2))
         nenergies = []
-        for cid in cids:
-            ff = ChemicalForceFields.UFFGetMoleculeForceField(mol, 10.0, cid)
+        for cid in cids2:
+            ff = ChemicalForceFields.UFFGetMoleculeForceField(mol2, 10.0, cid)
             ee = ff.CalcEnergy()
             nenergies.append(ee)
 
-        self.assertTrue(lstEq(energies, nenergies,tol=1e-6))
+        self.assertTrue(lstEq(energies, nenergies, tol=5.0))
             
+        for cid in cids:
+            msd = 0.0
+            for i in range(mol.GetNumAtoms()):
+                msd += (mol.GetConformer().GetAtomPosition(i) \
+                    - mol2.GetConformer().GetAtomPosition(i)).LengthSq()
+            msd /= mol.GetNumAtoms()
+            self.assertTrue(msd < 1.0e-5)
 
             
 if __name__ == '__main__':

--- a/Code/GraphMol/DistGeomHelpers/testDgeomHelpers.cpp
+++ b/Code/GraphMol/DistGeomHelpers/testDgeomHelpers.cpp
@@ -1407,13 +1407,26 @@ void testMultiThreadMultiConf() {
     ForceFields::ForceField *ff = UFF::constructForceField(*m, 100, *ci);
     ff->initialize();
     double e1 = ff->calcEnergy();
+    const RDGeom::PointPtrVect &pVect = ff->positions();
     TEST_ASSERT(e1 > 100.0);
     TEST_ASSERT(e1 < 300.0);
+    ForceFields::ForceField *ff2 = UFF::constructForceField(m2, 100, *ci);
+    ff2->initialize();
+    double e2 = ff2->calcEnergy();
+    const RDGeom::PointPtrVect &p2Vect = ff2->positions();
+    TEST_ASSERT(fabs(e1 - e2) < 5.0);
+    TEST_ASSERT(pVect.size() == p2Vect.size());
+    double msd = 0.0;
+    for (unsigned int i = 0; i < pVect.size(); ++i) {
+      const RDGeom::Point3D *p = dynamic_cast<const RDGeom::Point3D *>(pVect[i]);
+      const RDGeom::Point3D *p2 = dynamic_cast<const RDGeom::Point3D *>(p2Vect[i]);
+      TEST_ASSERT(p && p2);
+      msd += (*p - *p2).lengthSq();
+    }
+    msd /= static_cast<double>(pVect.size());
+    TEST_ASSERT(msd < 1.0e-5);
     delete ff;
-    ff = UFF::constructForceField(m2, 100, *ci);
-    ff->initialize();
-    double e2 = ff->calcEnergy();
-    TEST_ASSERT(feq(e1, e2));
+    delete ff2;
   }
 }
 #endif


### PR DESCRIPTION
- made Code/GraphMol/DistGeomHelpers/testDgeomHelpers.cpp and Code/GraphMol/DistGeomHelpers/Wrap/testDistGeom.py
  more robust against very small coordinate variations which may induce UFF energy variations in the 1-kcal/mol range.
  This was observed in a single case using the MinGW 32-bit g++ compiler. The check for identity of conformations
  between single- and multi-threaded runs is now complemented by a 3D coordinate MSD check