### PR TITLE
Adds aromatization and reaction options to AdjustQuery

### DIFF
--- a/Code/GraphMol/AdjustQuery.cpp
+++ b/Code/GraphMol/AdjustQuery.cpp
@@ -22,22 +22,6 @@ namespace {
 bool isMapped(const Atom* atom) {
   return atom->hasProp(common_properties::molAtomMapNumber);
 }
-
-bool isRGroup(const Atom* atom) {
-  return atom->hasProp(common_properties::_MolFileRLabel) || atom->getAtomicNum() == 0;
-}
-
-bool attachedToRGroup(const ROMol &mol, Atom*atom) {
-  ROMol::ADJ_ITER nbrIdx, endNbrs;
-  boost::tie(nbrIdx, endNbrs) = mol.getAtomNeighbors(atom);
-  while (nbrIdx != endNbrs) {
-    if (isRGroup(mol.getAtomWithIdx(*nbrIdx)))
-      return true;
-    ++nbrIdx;
-  }
-  return false;
-}
-
 }
 
 namespace MolOps {
@@ -74,14 +58,12 @@ void adjustQueryProperties(RWMol &mol, const AdjustQueryParameters *inParams) {
     // create a query atom they may no longer be valid.
     unsigned int nRings = ringInfo->numAtomRings(i);
     int atomicNum = at->getAtomicNum();
-    bool attachedR = attachedToRGroup(mol,at);
     if (params.adjustDegree &&
         !((params.adjustDegreeFlags & ADJUST_IGNORECHAINATOMS) && !nRings) &&
         !((params.adjustDegreeFlags & ADJUST_IGNORERINGATOMS) && nRings) &&
         !((params.adjustDegreeFlags & ADJUST_IGNOREDUMMIES) && !atomicNum) &&
         !((params.adjustDegreeFlags & ADJUST_IGNORENONDUMMIES) && atomicNum) &&
-        !((params.adjustDegreeFlags & ADJUST_IGNOREMAPPED) && isMapped(at)) &&
-        !((params.adjustDegreeFlags & ADJUST_IGNOREATTACHEDRGROUPS) && attachedR)
+        !((params.adjustDegreeFlags & ADJUST_IGNOREMAPPED) && isMapped(at))
         ) {
       QueryAtom *qa;
       if (!at->hasQuery()) {
@@ -101,7 +83,6 @@ void adjustQueryProperties(RWMol &mol, const AdjustQueryParameters *inParams) {
         !((params.adjustRingCountFlags & ADJUST_IGNOREDUMMIES) && !atomicNum) &&
         !((params.adjustRingCountFlags & ADJUST_IGNORENONDUMMIES) &&
         !((params.adjustRingCountFlags & ADJUST_IGNOREMAPPED) && isMapped(at)) &&
-        !((params.adjustRingCountFlags & ADJUST_IGNOREATTACHEDRGROUPS) && attachedR) &&
           atomicNum)) {
       QueryAtom *qa;
       if (!at->hasQuery()) {

--- a/Code/GraphMol/AdjustQuery.cpp
+++ b/Code/GraphMol/AdjustQuery.cpp
@@ -35,6 +35,7 @@ bool attachedToRGroup(const ROMol &mol, Atom*atom) {
       return true;
     ++nbrIdx;
   }
+  return false;
 }
 
 }

--- a/Code/GraphMol/MolOps.h
+++ b/Code/GraphMol/MolOps.h
@@ -247,6 +247,8 @@ typedef enum {
   ADJUST_IGNORERINGATOMS = 0x4,
   ADJUST_IGNOREDUMMIES = 0x2,
   ADJUST_IGNORENONDUMMIES = 0x8,
+  ADJUST_IGNOREMAPPED = 0x10,
+  ADJUST_IGNOREATTACHEDRGROUPS = 0x20, // Ignore if atom is attached to rgroup
   ADJUST_IGNOREALL = 0xFFFFFFF
 } AdjustQueryWhichFlags;
 struct AdjustQueryParameters {
@@ -257,13 +259,15 @@ struct AdjustQueryParameters {
 
   bool makeDummiesQueries; /**< convert dummy atoms without isotope labels to
                               any-atom queries */
-
+  bool aromatizeIfPossible;
+  
   AdjustQueryParameters()
       : adjustDegree(true),
         adjustDegreeFlags(ADJUST_IGNOREDUMMIES | ADJUST_IGNORECHAINATOMS),
         adjustRingCount(false),
         adjustRingCountFlags(ADJUST_IGNOREDUMMIES | ADJUST_IGNORECHAINATOMS),
-        makeDummiesQueries(true) {}
+        makeDummiesQueries(true),
+        aromatizeIfPossible(true) {}
 };
 //! returns a copy of a molecule with query properties adjusted
 /*!

--- a/Code/GraphMol/MolOps.h
+++ b/Code/GraphMol/MolOps.h
@@ -248,7 +248,6 @@ typedef enum {
   ADJUST_IGNOREDUMMIES = 0x2,
   ADJUST_IGNORENONDUMMIES = 0x8,
   ADJUST_IGNOREMAPPED = 0x10,
-  ADJUST_IGNOREATTACHEDRGROUPS = 0x20, // Ignore if atom is attached to rgroup
   ADJUST_IGNOREALL = 0xFFFFFFF
 } AdjustQueryWhichFlags;
 struct AdjustQueryParameters {

--- a/Code/GraphMol/molopstest.cpp
+++ b/Code/GraphMol/molopstest.cpp
@@ -5510,7 +5510,7 @@ void testAdjustQueryProperties() {
     params.aromatizeIfPossible = true;
     params.makeDummiesQueries = true;
     params.adjustDegreeFlags = ( MolOps::ADJUST_IGNOREDUMMIES | MolOps::ADJUST_IGNORECHAINATOMS |
-                                 MolOps::ADJUST_IGNOREMAPPED | MolOps::ADJUST_IGNOREATTACHEDRGROUPS );
+                                 MolOps::ADJUST_IGNOREMAPPED );
     
     RWMol *m = MolBlockToMol(mb);
     MolOps::adjustQueryProperties(*m, &params);
@@ -5549,7 +5549,7 @@ void testAdjustQueryProperties() {
     params.aromatizeIfPossible = true;
     params.makeDummiesQueries = true;
     params.adjustDegreeFlags = ( MolOps::ADJUST_IGNOREDUMMIES | MolOps::ADJUST_IGNORECHAINATOMS |
-                                 MolOps::ADJUST_IGNOREMAPPED | MolOps::ADJUST_IGNOREATTACHEDRGROUPS );
+                                 MolOps::ADJUST_IGNOREMAPPED );
     
     RWMol *m = MolBlockToMol(mb);
     MolOps::adjustQueryProperties(*m, &params);

--- a/Code/GraphMol/molopstest.cpp
+++ b/Code/GraphMol/molopstest.cpp
@@ -5485,7 +5485,83 @@ void testAdjustQueryProperties() {
     delete qm;
     delete aqm;
   }
+  { // CTAB
+    //  -- only match rgroups
+    std::string mb = "adjust.mol\n"
+        "  ChemDraw06271617272D\n"
+        "\n"
+        "  7  7  0  0  0  0  0  0  0  0999 V2000\n"
+        "   -1.0717    0.4125    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n"
+        "   -1.0717   -0.4125    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n"
+        "   -0.3572   -0.8250    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n"
+        "    0.3572   -0.4125    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n"
+        "    0.3572    0.4125    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n"
+        "   -0.3572    0.8250    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n"
+        "    1.0717    0.8250    0.0000 R   0  0  0  0  0  0  0  0  0  1  0  0\n"
+        "  1  2  1  0      \n"
+        "  2  3  2  0      \n"
+        "  3  4  1  0      \n"
+        "  4  5  2  0      \n"
+        "  5  6  1  0      \n"
+        "  6  1  2  0      \n"
+        "  5  7  1  0      \n"
+        "M  END\n";
+    MolOps::AdjustQueryParameters params;
+    params.aromatizeIfPossible = true;
+    params.makeDummiesQueries = true;
+    params.adjustDegreeFlags = ( MolOps::ADJUST_IGNOREDUMMIES | MolOps::ADJUST_IGNORECHAINATOMS |
+                                 MolOps::ADJUST_IGNOREMAPPED | MolOps::ADJUST_IGNOREATTACHEDRGROUPS );
+    
+    RWMol *m = MolBlockToMol(mb);
+    MolOps::adjustQueryProperties(*m, &params);
+    MatchVectType match;
+    ROMol *t = SmilesToMol("c1ccccc1Cl");
+    TEST_ASSERT(SubstructMatch(*t,*m,match));
+    delete t;
+    // shouldn't match (explicit degree)
+    t = SmilesToMol("c1ccc(Cl)cc1Cl");
+    TEST_ASSERT(!SubstructMatch(*t,*m,match));
+    delete m;
+  }
 
+  { // CTAB
+    //  -- match non rgroups if mapped
+    std::string mb = "adjust.mol\n"
+        "  ChemDraw06271617272D\n"
+        "\n"
+        "  7  7  0  0  0  0  0  0  0  0999 V2000\n"
+        "   -1.0717    0.4125    0.0000 C   0  0  0  0  0  0  0  0  0  2  0  0\n"
+        "   -1.0717   -0.4125    0.0000 C   0  0  0  0  0  0  0  0  0  3  0  0\n"
+        "   -0.3572   -0.8250    0.0000 C   0  0  0  0  0  0  0  0  0  4  0  0\n"
+        "    0.3572   -0.4125    0.0000 C   0  0  0  0  0  0  0  0  0  5  0  0\n"
+        "    0.3572    0.4125    0.0000 C   0  0  0  0  0  0  0  0  0  6  0  0\n"
+        "   -0.3572    0.8250    0.0000 C   0  0  0  0  0  0  0  0  0  7  0  0\n"
+        "    1.0717    0.8250    0.0000 R   0  0  0  0  0  0  0  0  0  1  0  0\n"
+        "  1  2  1  0      \n"
+        "  2  3  2  0      \n"
+        "  3  4  1  0      \n"
+        "  4  5  2  0      \n"
+        "  5  6  1  0      \n"
+        "  6  1  2  0      \n"
+        "  5  7  1  0      \n"
+        "M  END\n";
+    MolOps::AdjustQueryParameters params;
+    params.aromatizeIfPossible = true;
+    params.makeDummiesQueries = true;
+    params.adjustDegreeFlags = ( MolOps::ADJUST_IGNOREDUMMIES | MolOps::ADJUST_IGNORECHAINATOMS |
+                                 MolOps::ADJUST_IGNOREMAPPED | MolOps::ADJUST_IGNOREATTACHEDRGROUPS );
+    
+    RWMol *m = MolBlockToMol(mb);
+    MolOps::adjustQueryProperties(*m, &params);
+    MatchVectType match;
+    ROMol *t = SmilesToMol("c1ccccc1Cl");
+    TEST_ASSERT(SubstructMatch(*t,*m,match));
+    delete t;
+    // should match (mapped!)
+    t = SmilesToMol("c1c(Cl)cc(Cl)cc1Cl");
+    TEST_ASSERT(SubstructMatch(*t,*m,match));
+    delete m;
+  }
   BOOST_LOG(rdInfoLog) << "Finished" << std::endl;
 }
 


### PR DESCRIPTION
 aromatizeIfPossible - checks kekulized queries for aromatic compatibility
 adds IGNORE_MAPPED and IGNORE_ATTACHEDRGROUPS options to adjustDegree

Adds the appropriate options to AdjustQueries that will work for the proposed prepareQueries and sanitizeReactions.

This is basically a review for whether this is a suitable API or whether we want to move these into a prepareQueries function.