### PR TITLE
Does takeOwnership flag has any effect now?

### DIFF
--- a/Code/GraphMol/ROMol.cpp
+++ b/Code/GraphMol/ROMol.cpp
@@ -353,6 +353,7 @@ unsigned int ROMol::addBond(Bond *bond_pin, bool takeOwnership) {
   else
     bond_p = bond_pin;
 
+  /* after the line below is executed, the takeOwnership flag has no effect */
   bond_p->setOwningMol(this);
   bool ok;
   MolGraph::edge_descriptor which;


### PR DESCRIPTION
In the code below (`addBond` method):

      if (!takeOwnership)
        bond_p = bond_pin->copy();
      else
        bond_p = bond_pin;

      bond_p->setOwningMol(this);

If the `takeOwnership` flag is set to false, the `copy` method is called which does not change bond's ownership.
But then, regardless of the flag, the ownership is transferred to the current molecule anyway. So what's the sense of having this flag?

Maybe there are some side effects that I can't see now, but if not I'd say:

1. `addBond` method signature should be changed to remove `takeOwnership` parameter or:
2. `bond_p->setOwningMol(this);` line should be removed