### PR TITLE
Fix format-security GCC warning

### DIFF
--- a/Code/PgSQL/rdkit/mol_op.c
+++ b/Code/PgSQL/rdkit/mol_op.c
@@ -351,10 +351,8 @@ Datum fmcs_mol2s_transition(PG_FUNCTION_ARGS) {
     /// elog(WARNING, "fmcs_mol2s_transition() called first time");
     CROMol mol = PG_GETARG_DATUM(1);
     int len;
-    char t[256];
-    sprintf(t, "mol=%p, fcinfo: %p, %p", mol, fcinfo->flinfo->fn_extra,
+    elog(WARNING, "mol=%p, fcinfo: %p, %p", mol, fcinfo->flinfo->fn_extra,
             fcinfo->flinfo->fn_mcxt);
-    elog(WARNING, t);
     fcinfo->flinfo->fn_extra =
         SearchMolCache(fcinfo->flinfo->fn_extra, fcinfo->flinfo->fn_mcxt,
                        PG_GETARG_DATUM(1), NULL, &mol, NULL);
@@ -380,10 +378,8 @@ Datum fmcs_mol2s_transition(PG_FUNCTION_ARGS) {
     // mol_to_smiles():
     CROMol mol = PG_GETARG_DATUM(1);
     int len;
-    char t[256];
-    sprintf(t, "mol=%p, fcinfo: %p, %p", mol, fcinfo->flinfo->fn_extra,
-            fcinfo->flinfo->fn_mcxt);
-    elog(WARNING, t);
+    elog(WARNING, "mol=%p, fcinfo: %p, %p", mol, fcinfo->flinfo->fn_extra,
+            fcinfo->flinfo->fn_mcxt));
     fcinfo->flinfo->fn_extra =
         SearchMolCache(fcinfo->flinfo->fn_extra, fcinfo->flinfo->fn_mcxt,
                        PG_GETARG_DATUM(1), NULL, &mol, NULL);


### PR DESCRIPTION
In Fedora land, format-security GCC warnings are treated as errors
so the build would fail like this:
```
In file included from /usr/include/pgsql/server/postgres.h:48:0,
                 from rdkit.h:40,
                 from mol_op.c:33:
mol_op.c:339:19: error: format not a string literal and no format arguments [-Werror=format-security]
     elog(WARNING, t);
                   ^
```