### PR TITLE
Adds Atom atom map and rlabel apis

### DIFF
--- a/Code/GraphMol/Atom.cpp
+++ b/Code/GraphMol/Atom.cpp
@@ -518,9 +518,7 @@ void Atom::invertChirality() {
   }
 }
 
-namespace MDL {
-
-void setRLabel(Atom *atm, int rlabel) {
+void setAtomRLabel(Atom *atm, int rlabel) {
   PRECONDITION(atm, "bad atom");
   // rlabel ==> n2 => 0..99
   PRECONDITION(rlabel >= 0 && rlabel < 100, "rlabel out of range for MDL files");
@@ -532,14 +530,14 @@ void setRLabel(Atom *atm, int rlabel) {
   }
 }
 //! Gets the atom's RLabel
-int getRLabel(const Atom *atom) {
+int getAtomRLabel(const Atom *atom) {
   PRECONDITION(atom, "bad atom");
   unsigned int rlabel=0;
   atom->getPropIfPresent(common_properties::_MolFileRLabel, rlabel);
   return static_cast<int>(rlabel);
 }
 
-void setAlias(Atom *atom, const std::string &alias) {
+void setAtomAlias(Atom *atom, const std::string &alias) {
   PRECONDITION(atom, "bad atom");
   if(alias != "") {
     atom->setProp(common_properties::molFileAlias, alias);
@@ -548,14 +546,14 @@ void setAlias(Atom *atom, const std::string &alias) {
   }
 }
 
-std::string getAlias(const Atom *atom) {
+std::string getAtomAlias(const Atom *atom) {
   PRECONDITION(atom, "bad atom");
   std::string alias;
   atom->getPropIfPresent(common_properties::molFileAlias, alias);
   return alias;
 }
 
-void setValue(Atom *atom, const std::string &value) {
+void setAtomValue(Atom *atom, const std::string &value) {
   PRECONDITION(atom, "bad atom");
   if(value != "") {
     atom->setProp(common_properties::molFileValue, value);
@@ -564,17 +562,14 @@ void setValue(Atom *atom, const std::string &value) {
   }
 }
 
-std::string getValue(const Atom *atom) {
+std::string getAtomValue(const Atom *atom) {
   PRECONDITION(atom, "bad atom");
   std::string value;
   atom->getPropIfPresent(common_properties::molFileValue, value);
   return value;
 }
 
-}
-
-namespace Daylight {
-void setSupplementalLabel(Atom *atom, const std::string &label) {
+void setSupplementalSmilesLabel(Atom *atom, const std::string &label) {
   PRECONDITION(atom, "bad atom");
   if(label != "") {
     atom->setProp(common_properties::_supplementalSmilesLabel, label);
@@ -583,12 +578,11 @@ void setSupplementalLabel(Atom *atom, const std::string &label) {
   }
 }
 
-std::string getSupplementalLabel(const Atom *atom) {
+std::string getSupplementalSmilesLabel(const Atom *atom) {
   PRECONDITION(atom, "bad atom");
   std::string label;
   atom->getPropIfPresent(common_properties::_supplementalSmilesLabel, label);
   return label;
-}
 }
 
 }  // end o' namespace RDKit

--- a/Code/GraphMol/Atom.cpp
+++ b/Code/GraphMol/Atom.cpp
@@ -517,6 +517,80 @@ void Atom::invertChirality() {
       break;
   }
 }
+
+namespace MDL {
+
+void setRLabel(Atom *atm, int rlabel) {
+  PRECONDITION(atm, "bad atom");
+  // rlabel ==> n2 => 0..99
+  PRECONDITION(rlabel >= 0 && rlabel < 100, "rlabel out of range for MDL files");
+  if (rlabel) {
+    atm->setProp(common_properties::_MolFileRLabel, static_cast<unsigned int>(rlabel));
+  }
+  else if (atm->hasProp(common_properties::_MolFileRLabel)) {
+    atm->clearProp(common_properties::_MolFileRLabel);
+  }
+}
+//! Gets the atom's RLabel
+int getRLabel(const Atom *atom) {
+  PRECONDITION(atom, "bad atom");
+  unsigned int rlabel=0;
+  atom->getPropIfPresent(common_properties::_MolFileRLabel, rlabel);
+  return static_cast<int>(rlabel);
+}
+
+void setAlias(Atom *atom, const std::string &alias) {
+  PRECONDITION(atom, "bad atom");
+  if(alias != "") {
+    atom->setProp(common_properties::molFileAlias, alias);
+  } else if ( atom->hasProp(common_properties::molFileAlias) ) {
+    atom->clearProp(common_properties::molFileAlias);
+  }
+}
+
+std::string getAlias(const Atom *atom) {
+  PRECONDITION(atom, "bad atom");
+  std::string alias;
+  atom->getPropIfPresent(common_properties::molFileAlias, alias);
+  return alias;
+}
+
+void setValue(Atom *atom, const std::string &value) {
+  PRECONDITION(atom, "bad atom");
+  if(value != "") {
+    atom->setProp(common_properties::molFileValue, value);
+  } else if ( atom->hasProp(common_properties::molFileValue) ) {
+    atom->clearProp(common_properties::molFileValue);
+  }
+}
+
+std::string getValue(const Atom *atom) {
+  PRECONDITION(atom, "bad atom");
+  std::string value;
+  atom->getPropIfPresent(common_properties::molFileValue, value);
+  return value;
+}
+
+}
+
+namespace Daylight {
+void setSupplementalLabel(Atom *atom, const std::string &label) {
+  PRECONDITION(atom, "bad atom");
+  if(label != "") {
+    atom->setProp(common_properties::_supplementalSmilesLabel, label);
+  } else if ( atom->hasProp(common_properties::_supplementalSmilesLabel) ) {
+    atom->clearProp(common_properties::_supplementalSmilesLabel);
+  }
+}
+
+std::string getSupplementalLabel(const Atom *atom) {
+  PRECONDITION(atom, "bad atom");
+  std::string label;
+  atom->getPropIfPresent(common_properties::_supplementalSmilesLabel, label);
+  return label;
+}
+}
+
 }  // end o' namespace RDKit
 
 std::ostream &operator<<(std::ostream &target, const RDKit::Atom &at) {

--- a/Code/GraphMol/Atom.h
+++ b/Code/GraphMol/Atom.h
@@ -405,29 +405,27 @@ class Atom : public RDProps {
   void initAtom();
 };
 
-namespace MDL {
 //! Set the atom's MDL integer RLabel
 //   Setting to 0 clears the rlabel.  Rlabel must be in the range [0..99]
-void setRLabel(Atom *atm, int rlabel);
-int getRLabel(const Atom *atm);
+void setAtomRLabel(Atom *atm, int rlabel);
+int getAtomRLabel(const Atom *atm);
 
 //! Set the atom's MDL atom alias
 //   Setting to an empty string clears the alias
-void setAlias(Atom *atom, const std::string &alias);
-std::string getAlias(const Atom *atom);
+void setAtomAlias(Atom *atom, const std::string &alias);
+std::string getAtomAlias(const Atom *atom);
 
 //! Set the atom's MDL atom value
 //   Setting to an empty string clears the value
-void setValue(Atom *atom, const std::string &value);
-std::string getValue(const Atom *atom);
-}
+//   This is where recursive smarts get stored in MolBlock Queries
+void setAtomValue(Atom *atom, const std::string &value);
+std::string getAtomValue(const Atom *atom);
 
-namespace Daylight {
 //! Sets the supplemental label that will follow the atom when writing
 //   smiles strings.
-void setSupplementalLabel(Atom *atom, const std::string &label);
-std::string getSupplementalLabel(const Atom *atom);  
-}
+void setSupplementalSmilesLabel(Atom *atom, const std::string &label);
+std::string getSupplementalSmilesLabel(const Atom *atom);  
+
 };
 //! allows Atom objects to be dumped to streams
 std::ostream &operator<<(std::ostream &target, const RDKit::Atom &at);

--- a/Code/GraphMol/Atom.h
+++ b/Code/GraphMol/Atom.h
@@ -360,6 +360,38 @@ class Atom : public RDProps {
   //! takes ownership of the pointer
   void setMonomerInfo(AtomMonomerInfo *info) { dp_monomerInfo = info; };
 
+  //! Set the atom map Number of the atom
+  void setAtomMapNum(int mapno) {
+    if (mapno) {
+      setProp(common_properties::molAtomMapNumber, mapno);
+    }
+    else if (hasProp(common_properties::molAtomMapNumber)) {
+      clearProp(common_properties::molAtomMapNumber);
+    }
+  }
+  //! Gets the atom map Number of the atom, if no atom map exists, 0 is returned.
+  int getAtomMapNum() const {
+    int mapno=0;
+    getPropIfPresent(common_properties::molAtomMapNumber, mapno);
+    return mapno;
+  }
+
+  //! Set the atom's RLabel
+  void setRlabel(int rlabel) {
+    if (rlabel) {
+      setProp(common_properties::_MolFileRLabel, static_cast<unsigned int>(rlabel));
+    }
+    else if (hasProp(common_properties::_MolFileRLabel)) {
+      clearProp(common_properties::_MolFileRLabel);
+    }
+  }
+  //! Gets the atom's RLabel
+  int getRlabel() const {
+    unsigned int rlabel=0;
+    getPropIfPresent(common_properties::_MolFileRLabel, rlabel);
+    return static_cast<int>(rlabel);
+  }
+  
  protected:
   //! sets our owning molecule
   void setOwningMol(ROMol *other);

--- a/Code/GraphMol/Atom.h
+++ b/Code/GraphMol/Atom.h
@@ -361,7 +361,9 @@ class Atom : public RDProps {
   void setMonomerInfo(AtomMonomerInfo *info) { dp_monomerInfo = info; };
 
   //! Set the atom map Number of the atom
-  void setAtomMapNum(int mapno) {
+  void setAtomMapNum(int mapno, bool strict=true) {
+    PRECONDITION(!strict || mapno>=0 && mapno<1000,
+                 "atom map number out of range [0..1000], use strict=false to override");
     if (mapno) {
       setProp(common_properties::molAtomMapNumber, mapno);
     }
@@ -376,22 +378,6 @@ class Atom : public RDProps {
     return mapno;
   }
 
-  //! Set the atom's RLabel
-  void setRlabel(int rlabel) {
-    if (rlabel) {
-      setProp(common_properties::_MolFileRLabel, static_cast<unsigned int>(rlabel));
-    }
-    else if (hasProp(common_properties::_MolFileRLabel)) {
-      clearProp(common_properties::_MolFileRLabel);
-    }
-  }
-  //! Gets the atom's RLabel
-  int getRlabel() const {
-    unsigned int rlabel=0;
-    getPropIfPresent(common_properties::_MolFileRLabel, rlabel);
-    return static_cast<int>(rlabel);
-  }
-  
  protected:
   //! sets our owning molecule
   void setOwningMol(ROMol *other);
@@ -418,6 +404,30 @@ class Atom : public RDProps {
   AtomMonomerInfo *dp_monomerInfo;
   void initAtom();
 };
+
+namespace MDL {
+//! Set the atom's MDL integer RLabel
+//   Setting to 0 clears the rlabel.  Rlabel must be in the range [0..99]
+void setRLabel(Atom *atm, int rlabel);
+int getRLabel(const Atom *atm);
+
+//! Set the atom's MDL atom alias
+//   Setting to an empty string clears the alias
+void setAlias(Atom *atom, const std::string &alias);
+std::string getAlias(const Atom *atom);
+
+//! Set the atom's MDL atom value
+//   Setting to an empty string clears the value
+void setValue(Atom *atom, const std::string &value);
+std::string getValue(const Atom *atom);
+}
+
+namespace Daylight {
+//! Sets the supplemental label that will follow the atom when writing
+//   smiles strings.
+void setSupplementalLabel(Atom *atom, const std::string &label);
+std::string getSupplementalLabel(const Atom *atom);  
+}
 };
 //! allows Atom objects to be dumped to streams
 std::ostream &operator<<(std::ostream &target, const RDKit::Atom &at);

--- a/Code/GraphMol/FileParsers/SDWriter.cpp
+++ b/Code/GraphMol/FileParsers/SDWriter.cpp
@@ -115,12 +115,12 @@ void _MolToSDStream(std::ostream *dp_ostream, const ROMol &mol, int confId,
     // out to the file
     STR_VECT properties = mol.getPropList();
     STR_VECT compLst;
-    mol.getPropIfPresent(detail::computedPropName, compLst);
+    mol.getPropIfPresent(RDKit::detail::computedPropName, compLst);
 
     STR_VECT_CI pi;
     for (pi = properties.begin(); pi != properties.end(); pi++) {
       // ignore any of the following properties
-      if (((*pi) == detail::computedPropName) ||
+      if (((*pi) == RDKit::detail::computedPropName) ||
           ((*pi) == common_properties::_Name) || ((*pi) == "_MolFileInfo") ||
           ((*pi) == "_MolFileComments") ||
           ((*pi) == common_properties::_MolFileChiralFlag)) {

--- a/Code/GraphMol/FileParsers/TDTWriter.cpp
+++ b/Code/GraphMol/FileParsers/TDTWriter.cpp
@@ -137,12 +137,12 @@ void TDTWriter::write(const ROMol &mol, int confId) {
     // out to the file
     STR_VECT properties = mol.getPropList();
     STR_VECT compLst;
-    mol.getPropIfPresent(detail::computedPropName, compLst);
+    mol.getPropIfPresent(RDKit::detail::computedPropName, compLst);
 
     STR_VECT_CI pi;
     for (pi = properties.begin(); pi != properties.end(); pi++) {
       // ignore any of the following properties
-      if (((*pi) == detail::computedPropName) ||
+      if (((*pi) == RDKit::detail::computedPropName) ||
           ((*pi) == common_properties::_Name) || ((*pi) == "_MolFileInfo") ||
           ((*pi) == "_MolFileComments") ||
           ((*pi) == common_properties::_MolFileChiralFlag)) {

--- a/Code/GraphMol/FileParsers/test1.cpp
+++ b/Code/GraphMol/FileParsers/test1.cpp
@@ -1953,7 +1953,29 @@ void testMolFileAtomValues() {
     m->getAtomWithIdx(1)->getProp(common_properties::molFileValue, val);
     TEST_ASSERT(val == "acidchloride");
 
+    TEST_ASSERT(m->getAtomWithIdx(0)->hasProp(common_properties::molAtomMapNumber));
+    TEST_ASSERT(m->getAtomWithIdx(1)->hasProp(common_properties::molAtomMapNumber));
+    TEST_ASSERT(m->getAtomWithIdx(2)->hasProp(common_properties::molAtomMapNumber));
+    TEST_ASSERT(!m->getAtomWithIdx(3)->hasProp(common_properties::molAtomMapNumber));
+
+    TEST_ASSERT(m->getAtomWithIdx(0)->getAtomMapNum() == 1);
+    TEST_ASSERT(m->getAtomWithIdx(1)->getAtomMapNum() == 2);
+    TEST_ASSERT(m->getAtomWithIdx(2)->getAtomMapNum() == 3);
+    TEST_ASSERT(m->getAtomWithIdx(3)->getAtomMapNum() == 0);
+
+    // round trip
+    m->getAtomWithIdx(0)->setAtomMapNum(4);
+    m->getAtomWithIdx(3)->setRlabel(1);
+    RWMol *m2 = MolBlockToMol(MolToMolBlock(*m));
+    TEST_ASSERT(m2);
+    TEST_ASSERT(m->getAtomWithIdx(0)->getAtomMapNum() == 4);
+    TEST_ASSERT(m->getAtomWithIdx(1)->getAtomMapNum() == 2);
+    TEST_ASSERT(m->getAtomWithIdx(2)->getAtomMapNum() == 3);
+    TEST_ASSERT(m->getAtomWithIdx(3)->getAtomMapNum() == 0);
+    TEST_ASSERT(m->getAtomWithIdx(3)->getRlabel() == 1);
+    
     delete m;
+    delete m2;
   }
 
   {
@@ -4366,6 +4388,9 @@ void testParseCHG() {
   TEST_ASSERT(positions.size() == 3); // 24/3 == 8
   
   delete m;
+}
+
+void testMolAtomMapNumber() {
 }
 
 void RunTests() {

--- a/Code/GraphMol/FileParsers/test1.cpp
+++ b/Code/GraphMol/FileParsers/test1.cpp
@@ -1952,7 +1952,7 @@ void testMolFileAtomValues() {
     TEST_ASSERT(m->getAtomWithIdx(1)->hasProp(common_properties::molFileValue));
     m->getAtomWithIdx(1)->getProp(common_properties::molFileValue, val);
     TEST_ASSERT(val == "acidchloride");
-    TEST_ASSERT(MDL::getValue(m->getAtomWithIdx(1)) == "acidchloride")
+    TEST_ASSERT(getAtomValue(m->getAtomWithIdx(1)) == "acidchloride")
                  
     TEST_ASSERT(m->getAtomWithIdx(0)->hasProp(common_properties::molAtomMapNumber));
     TEST_ASSERT(m->getAtomWithIdx(1)->hasProp(common_properties::molAtomMapNumber));
@@ -1966,18 +1966,18 @@ void testMolFileAtomValues() {
 
     // round trip
     m->getAtomWithIdx(0)->setAtomMapNum(4);
-    MDL::setRLabel(m->getAtomWithIdx(3), 1);
-    MDL::setAlias(m->getAtomWithIdx(0), "acidchloride");
-    MDL::setValue(m->getAtomWithIdx(0), "foobar");
+    setAtomRLabel(m->getAtomWithIdx(3), 1);
+    setAtomAlias(m->getAtomWithIdx(0), "acidchloride");
+    setAtomValue(m->getAtomWithIdx(0), "foobar");
     RWMol *m2 = MolBlockToMol(MolToMolBlock(*m));
     TEST_ASSERT(m2);
     TEST_ASSERT(m->getAtomWithIdx(0)->getAtomMapNum() == 4);
     TEST_ASSERT(m->getAtomWithIdx(1)->getAtomMapNum() == 2);
     TEST_ASSERT(m->getAtomWithIdx(2)->getAtomMapNum() == 3);
     TEST_ASSERT(m->getAtomWithIdx(3)->getAtomMapNum() == 0);
-    TEST_ASSERT(MDL::getRLabel(m->getAtomWithIdx(3)) == 1);
-    TEST_ASSERT(MDL::getAlias(m->getAtomWithIdx(0)) == "acidchloride");
-    TEST_ASSERT(MDL::getValue(m->getAtomWithIdx(0)) == "foobar");
+    TEST_ASSERT(getAtomRLabel(m->getAtomWithIdx(3)) == 1);
+    TEST_ASSERT(getAtomAlias(m->getAtomWithIdx(0)) == "acidchloride");
+    TEST_ASSERT(getAtomValue(m->getAtomWithIdx(0)) == "foobar");
                 
     delete m;
     delete m2;
@@ -4398,15 +4398,15 @@ void testParseCHG() {
 void testMDLAtomProps() {
   std::string smi="CC";
   ROMOL_SPTR mol(SmilesToMol(smi, false, false));
-  MDL::setAlias(mol->getAtomWithIdx(0), "foo");
-  MDL::setValue(mol->getAtomWithIdx(0), "bar");
-  MDL::setRLabel(mol->getAtomWithIdx(0), 1);
+  setAtomAlias(mol->getAtomWithIdx(0), "foo");
+  setAtomValue(mol->getAtomWithIdx(0), "bar");
+  setAtomRLabel(mol->getAtomWithIdx(0), 1);
   mol.reset( MolBlockToMol(MolToMolBlock(*mol.get())) );
-  TEST_ASSERT(MDL::getAlias(mol->getAtomWithIdx(0))=="foo");
-  TEST_ASSERT(MDL::getValue(mol->getAtomWithIdx(0))=="bar");
-  TEST_ASSERT(MDL::getRLabel(mol->getAtomWithIdx(0))==1);
+  TEST_ASSERT(getAtomAlias(mol->getAtomWithIdx(0))=="foo");
+  TEST_ASSERT(getAtomValue(mol->getAtomWithIdx(0))=="bar");
+  TEST_ASSERT(getAtomRLabel(mol->getAtomWithIdx(0))==1);
   try {
-    MDL::setRLabel(mol->getAtomWithIdx(0), 100);
+    setAtomRLabel(mol->getAtomWithIdx(0), 100);
     TEST_ASSERT(0);
   } catch (...) {
   }
@@ -4415,11 +4415,11 @@ void testMDLAtomProps() {
 void testSupplementalSmilesLabel() {
   std::string smi="C";
   ROMOL_SPTR mol(SmilesToMol(smi, false, false));
-  Daylight::setSupplementalLabel(mol->getAtomWithIdx(0),
-                                 "xxx");
+  setSupplementalSmilesLabel(mol->getAtomWithIdx(0),
+                             "xxx");
   smi = MolToSmiles(*mol.get());
   TEST_ASSERT(smi == "Cxxx");
-  TEST_ASSERT(Daylight::getSupplementalLabel(mol->getAtomWithIdx(0)) ==
+  TEST_ASSERT(getSupplementalSmilesLabel(mol->getAtomWithIdx(0)) ==
               "xxx");
   
 }

--- a/Code/GraphMol/ROMol.cpp
+++ b/Code/GraphMol/ROMol.cpp
@@ -98,7 +98,7 @@ void ROMol::initFromOther(const ROMol &other, bool quickCopy, int confId) {
   } else {
     dp_props.reset();
     STR_VECT computed;
-    dp_props.setVal(detail::computedPropName, computed);
+    dp_props.setVal(RDKit::detail::computedPropName, computed);
   }
   // std::cerr<<"---------    done init from other: "<<this<<"
   // "<<&other<<std::endl;
@@ -107,14 +107,14 @@ void ROMol::initFromOther(const ROMol &other, bool quickCopy, int confId) {
 void ROMol::initMol() {
   dp_props.reset();
   dp_ringInfo = new RingInfo();
-  // ok every molecule contains a property entry called detail::computedPropName
+  // ok every molecule contains a property entry called RDKit::detail::computedPropName
   // which provides
   //  list of property keys that correspond to value that have been computed
   // this can used to blow out all computed properties while leaving the rest
   // along
   // initialize this list to an empty vector of strings
   STR_VECT computed;
-  dp_props.setVal(detail::computedPropName, computed);
+  dp_props.setVal(RDKit::detail::computedPropName, computed);
 }
 
 unsigned int ROMol::getAtomDegree(const Atom *at) const {

--- a/Code/GraphMol/RWMol.h
+++ b/Code/GraphMol/RWMol.h
@@ -216,7 +216,7 @@ class RWMol : public ROMol {
     d_confs.clear();
     dp_props.reset();
     STR_VECT computed;
-    dp_props.setVal(detail::computedPropName, computed);
+    dp_props.setVal(RDKit::detail::computedPropName, computed);
 
     if (dp_ringInfo) dp_ringInfo->reset();
   };

--- a/Code/GraphMol/Wrap/Atom.cpp
+++ b/Code/GraphMol/Wrap/Atom.cpp
@@ -433,45 +433,36 @@ These cannot currently be constructed directly from Python\n";
               python::arg("maintainOrder") = true),
              "combines the query from other with ours");
 
-    {
-      python::scope MDL = python::class_<MDLDummy>("MDL",
-                                                   "Manipulating MDL Properties on Atoms").
-          def("GetRLabel", MDL::getRLabel,
-              (python::arg("atom")),
-              "Returns the atom's MDL RLabel (this is an integer from 0 to 99)").staticmethod("GetRLabel").
-          def("SetRLabel", MDL::setRLabel,
-              (python::arg("atom"), python::arg("rlabel")),
-              "Sets the atom's MDL RLabel (this is an integer from 0 to 99).\nSetting to 0 clears the rlabel.").staticmethod("SetRLabel").
-          
-          def("GetAlias", MDL::getAlias,
-              (python::arg("atom")),
-              "Returns the atom's MDL alias text").staticmethod("GetAlias").
-          def("SetAlias", MDL::setAlias,
-              (python::arg("atom"), python::arg("rlabel")),
-              "Sets the atom's MDL alias text.\nSetting to an empty string clears the alias.").staticmethod("SetAlias").        
-          def("GetValue", MDL::getValue,
-              (python::arg("atom")),
-              "Returns the atom's MDL alias text").staticmethod("GetValue").
-          def("SetValue", MDL::setValue,
-              (python::arg("atom"), python::arg("rlabel")),
-              "Sets the atom's MDL alias text.\nSetting to an empty string clears the alias.").staticmethod("SetValue");
-    }
+    python::def("GetAtomRLabel", getAtomRLabel,
+        (python::arg("atom")),
+        "Returns the atom's MDL AtomRLabel (this is an integer from 0 to 99)");
+    python::def("SetAtomRLabel", setAtomRLabel,
+        (python::arg("atom"), python::arg("rlabel")),
+        "Sets the atom's MDL RLabel (this is an integer from 0 to 99).\nSetting to 0 clears the rlabel.");
+    
+    python::def("GetAtomAlias", getAtomAlias,
+        (python::arg("atom")),
+        "Returns the atom's MDL alias text");
+    python::def("SetAtomAlias", setAtomAlias,
+        (python::arg("atom"), python::arg("rlabel")),
+        "Sets the atom's MDL alias text.\nSetting to an empty string clears the alias.");
+    python::def("GetAtomValue", getAtomValue,
+        (python::arg("atom")),
+        "Returns the atom's MDL alias text");
+    python::def("SetAtomValue", setAtomValue,
+        (python::arg("atom"), python::arg("rlabel")),
+        "Sets the atom's MDL alias text.\nSetting to an empty string clears the alias.");
 
-    {
-      python::scope Daylight = python::class_<MDLDummy>("Daylight",
-                                                        "Manipulating Daylight Properties on Atoms")
-          .def("GetSupplementalLabel", Daylight::getSupplementalLabel,
-               (python::arg("atom")),
-               "Gets the supplemental smiles label on an atom, returns an empty string if not present.").staticmethod("GetSupplementalLabel")
-          .def("SetSupplementalLabel", Daylight::setSupplementalLabel,
-               (python::arg("atom"), python::arg("label")),
-               "Sets a supplemental label on an atom that is written to the smiles string.\n" \
-               ">>> m = Chem.MolFromSmiles(\"C\")\n"                    \
-               ">>> Chem.Daylight.SetSupplementalLabel(m.GetAtomWithIdx(0), '???')\n" \
-               ">>> Chem.MolToSmiles(m)\n"                              \
-               "'C???'\n").staticmethod("SetSupplementalLabel");
-      
-    };
+    python::def("GetSupplementalSmilesLabel", getSupplementalSmilesLabel,
+        (python::arg("atom")),
+        "Gets the supplemental smiles label on an atom, returns an empty string if not present.");
+    python::def("SetSupplementalSmilesLabel", setSupplementalSmilesLabel,
+        (python::arg("atom"), python::arg("label")),
+        "Sets a supplemental label on an atom that is written to the smiles string.\n" \
+        ">>> m = Chem.MolFromSmiles(\"C\")\n"                           \
+        ">>> Chem.SetSupplementalSmilesLabel(m.GetAtomWithIdx(0), '<xxx>')\n" \
+        ">>> Chem.MolToSmiles(m)\n"                                     \
+        "'C<xxx>'\n");
   }
   
 };

--- a/Code/GraphMol/Wrap/Atom.cpp
+++ b/Code/GraphMol/Wrap/Atom.cpp
@@ -389,8 +389,18 @@ struct atom_wrapper {
                  1, python::with_custodian_and_ward_postcall<0, 1> >(),
              "Returns the atom's MonomerInfo object, if there is one.\n\n")
         .def("SetMonomerInfo", SetAtomMonomerInfo,
-             "Sets the atom's MonomerInfo object.\n\n");
-
+             "Sets the atom's MonomerInfo object.\n\n")
+        .def("GetAtomMapNum", &Atom::getAtomMapNum,
+             "Gets the atoms map number, returns 0 if not set")
+        .def("SetAtomMapNum", &Atom::setAtomMapNum,
+             (python::arg("self"), python::arg("mapno")),
+             "Sets the atoms map number, a value of 0 clears the atom map")
+        .def("GetRlabel", &Atom::getRlabel,
+             "Gets the atom's rlabel, returns 0 if not set")
+        .def("SetRlabel", &Atom::setRlabel,
+             (python::arg("self"), python::arg("rlabel")),
+             "Sets the atom's rlabel, a value of 0 clears the rlabel");
+    
     python::enum_<Atom::HybridizationType>("HybridizationType")
         .value("UNSPECIFIED", Atom::UNSPECIFIED)
         .value("SP", Atom::SP)

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -2231,14 +2231,14 @@ CAS<~>
     self.assertTrue(at.HasProp('_MolFileRLabel'))
     p = at.GetProp('_MolFileRLabel')
     self.assertEqual(p,'2')
-    self.assertEqual(at.GetRlabel(), 2)
+    self.assertEqual(Chem.MDL.GetRLabel(at),  2)
 
     at = m.GetAtomWithIdx(4)
     self.assertTrue(at is not None)
     self.assertTrue(at.HasProp('_MolFileRLabel'))
     p = at.GetProp('_MolFileRLabel')
     self.assertEqual(p,'1')
-    self.assertEqual(at.GetRlabel(), 1)
+    self.assertEqual(Chem.MDL.GetRLabel(at), 1)
 
   def test64MoleculeCleanup(self):
     m = Chem.MolFromSmiles('CN(=O)=O',False)
@@ -2579,6 +2579,7 @@ CAS<~>
   def test82Issue288(self):
     m = Chem.MolFromSmiles('CC*')
     m.GetAtomWithIdx(2).SetProp('molAtomMapNumber','30')
+    
     smi=Chem.MolToSmiles(m)
     self.assertEqual(smi,'CC[*:30]')
     # try newer api
@@ -3647,8 +3648,21 @@ CAS<~>
     m.GetBondWithIdx(0).SetProp("foo","1")
     self.assertEqual(list(m.GetBondWithIdx(0).GetPropNames()),["foo"])
 
+  def testMDLProps(self):
+    m = Chem.MolFromSmiles("CCC")
+    m.GetAtomWithIdx(0).SetAtomMapNum(1)
+    Chem.MDL.SetAlias(m.GetAtomWithIdx(1), "foo")
+    Chem.MDL.SetValue(m.GetAtomWithIdx(1), "bar")
 
+    m = Chem.MolFromMolBlock(Chem.MolToMolBlock(m))
+    self.assertEquals(m.GetAtomWithIdx(0).GetAtomMapNum(), 1)
+    self.assertEquals(Chem.MDL.GetAlias(m.GetAtomWithIdx(1)), "foo")
+    self.assertEquals(Chem.MDL.GetValue(m.GetAtomWithIdx(1)), "bar")
 
-
+  def testSmilesProps(self):
+    m = Chem.MolFromSmiles("C")
+    Chem.Daylight.SetSupplementalLabel(m.GetAtomWithIdx(0), 'xxx')
+    self.assertEquals(Chem.MolToSmiles(m), "Cxxx")
+    
 if __name__ == '__main__':
   unittest.main()

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -2231,12 +2231,14 @@ CAS<~>
     self.assertTrue(at.HasProp('_MolFileRLabel'))
     p = at.GetProp('_MolFileRLabel')
     self.assertEqual(p,'2')
+    self.assertEqual(at.GetRlabel(), 2)
 
     at = m.GetAtomWithIdx(4)
     self.assertTrue(at is not None)
     self.assertTrue(at.HasProp('_MolFileRLabel'))
     p = at.GetProp('_MolFileRLabel')
     self.assertEqual(p,'1')
+    self.assertEqual(at.GetRlabel(), 1)
 
   def test64MoleculeCleanup(self):
     m = Chem.MolFromSmiles('CN(=O)=O',False)
@@ -2579,6 +2581,12 @@ CAS<~>
     m.GetAtomWithIdx(2).SetProp('molAtomMapNumber','30')
     smi=Chem.MolToSmiles(m)
     self.assertEqual(smi,'CC[*:30]')
+    # try newer api
+    m = Chem.MolFromSmiles('CC*')
+    m.GetAtomWithIdx(2).SetAtomMapNum(30)
+    smi=Chem.MolToSmiles(m)
+    self.assertEqual(smi,'CC[*:30]')
+    
 
   def test83GitHubIssue19(self):
     fileN = os.path.join(RDConfig.RDBaseDir,'Code','GraphMol','FileParsers',

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -2231,14 +2231,14 @@ CAS<~>
     self.assertTrue(at.HasProp('_MolFileRLabel'))
     p = at.GetProp('_MolFileRLabel')
     self.assertEqual(p,'2')
-    self.assertEqual(Chem.MDL.GetRLabel(at),  2)
+    self.assertEqual(Chem.GetAtomRLabel(at),  2)
 
     at = m.GetAtomWithIdx(4)
     self.assertTrue(at is not None)
     self.assertTrue(at.HasProp('_MolFileRLabel'))
     p = at.GetProp('_MolFileRLabel')
     self.assertEqual(p,'1')
-    self.assertEqual(Chem.MDL.GetRLabel(at), 1)
+    self.assertEqual(Chem.GetAtomRLabel(at), 1)
 
   def test64MoleculeCleanup(self):
     m = Chem.MolFromSmiles('CN(=O)=O',False)
@@ -3651,17 +3651,17 @@ CAS<~>
   def testMDLProps(self):
     m = Chem.MolFromSmiles("CCC")
     m.GetAtomWithIdx(0).SetAtomMapNum(1)
-    Chem.MDL.SetAlias(m.GetAtomWithIdx(1), "foo")
-    Chem.MDL.SetValue(m.GetAtomWithIdx(1), "bar")
+    Chem.SetAtomAlias(m.GetAtomWithIdx(1), "foo")
+    Chem.SetAtomValue(m.GetAtomWithIdx(1), "bar")
 
     m = Chem.MolFromMolBlock(Chem.MolToMolBlock(m))
     self.assertEquals(m.GetAtomWithIdx(0).GetAtomMapNum(), 1)
-    self.assertEquals(Chem.MDL.GetAlias(m.GetAtomWithIdx(1)), "foo")
-    self.assertEquals(Chem.MDL.GetValue(m.GetAtomWithIdx(1)), "bar")
+    self.assertEquals(Chem.GetAtomAlias(m.GetAtomWithIdx(1)), "foo")
+    self.assertEquals(Chem.GetAtomValue(m.GetAtomWithIdx(1)), "bar")
 
   def testSmilesProps(self):
     m = Chem.MolFromSmiles("C")
-    Chem.Daylight.SetSupplementalLabel(m.GetAtomWithIdx(0), 'xxx')
+    Chem.SetSupplementalSmilesLabel(m.GetAtomWithIdx(0), 'xxx')
     self.assertEquals(Chem.MolToSmiles(m), "Cxxx")
     
 if __name__ == '__main__':

--- a/Code/GraphMol/test1.cpp
+++ b/Code/GraphMol/test1.cpp
@@ -161,7 +161,7 @@ void testMolProps() {
   m2.setProp("cprop1", 1, true);
   m2.setProp("cprop2", 2, true);
   STR_VECT cplst;
-  m2.getProp(detail::computedPropName, cplst);
+  m2.getProp(RDKit::detail::computedPropName, cplst);
   CHECK_INVARIANT(cplst.size() == 2, "");
   CHECK_INVARIANT(cplst[0] == "cprop1", "");
   CHECK_INVARIANT(cplst[1] == "cprop2", "");
@@ -179,12 +179,12 @@ void testMolProps() {
 
   m2.clearProp("cprop1");
   CHECK_INVARIANT(!m2.hasProp("cprop1"), "");
-  m2.getProp(detail::computedPropName, cplst);
+  m2.getProp(RDKit::detail::computedPropName, cplst);
   CHECK_INVARIANT(cplst.size() == 1, "");
 
   m2.clearComputedProps();
   CHECK_INVARIANT(!m2.hasProp("cprop2"), "");
-  m2.getProp(detail::computedPropName, cplst);
+  m2.getProp(RDKit::detail::computedPropName, cplst);
   CHECK_INVARIANT(cplst.size() == 0, "");
 
   BOOST_LOG(rdInfoLog) << "Finished" << std::endl;
@@ -206,7 +206,7 @@ void testClearMol() {
   m2.getProp("prop1", tmpI);
   TEST_ASSERT(tmpI == 2);
 
-  TEST_ASSERT(m2.hasProp(detail::computedPropName));
+  TEST_ASSERT(m2.hasProp(RDKit::detail::computedPropName));
 
   m2.clear();
   TEST_ASSERT(!m2.hasProp("prop1"));
@@ -215,7 +215,7 @@ void testClearMol() {
   TEST_ASSERT(m2.getAtomBookmarks()->empty());
   TEST_ASSERT(m2.getBondBookmarks()->empty());
 
-  TEST_ASSERT(m2.hasProp(detail::computedPropName));  // <- github issue 176
+  TEST_ASSERT(m2.hasProp(RDKit::detail::computedPropName));  // <- github issue 176
   TEST_ASSERT(m2.getPropList().size() == 1);
 
   BOOST_LOG(rdInfoLog) << "Finished" << std::endl;
@@ -287,19 +287,19 @@ void testAtomProps() {
   a1->setProp("cprop1", 1, true);
   a1->setProp("cprop2", 2, true);
   STR_VECT cplst;
-  a1->getProp(detail::computedPropName, cplst);
+  a1->getProp(RDKit::detail::computedPropName, cplst);
   CHECK_INVARIANT(cplst.size() == 2, "");
   CHECK_INVARIANT(cplst[0] == "cprop1", "");
   CHECK_INVARIANT(cplst[1] == "cprop2", "");
 
   a1->clearProp("cprop1");
   CHECK_INVARIANT(!a1->hasProp("cprop1"), "");
-  a1->getProp(detail::computedPropName, cplst);
+  a1->getProp(RDKit::detail::computedPropName, cplst);
   CHECK_INVARIANT(cplst.size() == 1, "");
 
   a1->clearComputedProps();
   CHECK_INVARIANT(!a1->hasProp("cprop2"), "");
-  a1->getProp(detail::computedPropName, cplst);
+  a1->getProp(RDKit::detail::computedPropName, cplst);
   CHECK_INVARIANT(cplst.size() == 0, "");
 
   BOOST_LOG(rdInfoLog) << "Finished" << std::endl;
@@ -342,19 +342,19 @@ void testBondProps() {
   b1->setProp("cprop1", 1, true);
   b1->setProp("cprop2", 2, true);
   STR_VECT cplst;
-  b1->getProp(detail::computedPropName, cplst);
+  b1->getProp(RDKit::detail::computedPropName, cplst);
   CHECK_INVARIANT(cplst.size() == 2, "");
   CHECK_INVARIANT(cplst[0] == "cprop1", "");
   CHECK_INVARIANT(cplst[1] == "cprop2", "");
 
   b1->clearProp("cprop1");
   CHECK_INVARIANT(!b1->hasProp("cprop1"), "");
-  b1->getProp(detail::computedPropName, cplst);
+  b1->getProp(RDKit::detail::computedPropName, cplst);
   CHECK_INVARIANT(cplst.size() == 1, "");
 
   b1->clearComputedProps();
   CHECK_INVARIANT(!b1->hasProp("cprop2"), "");
-  b1->getProp(detail::computedPropName, cplst);
+  b1->getProp(RDKit::detail::computedPropName, cplst);
   CHECK_INVARIANT(cplst.size() == 0, "");
 
   BOOST_LOG(rdInfoLog) << "Finished" << std::endl;

--- a/Code/RDGeneral/RDProps.h
+++ b/Code/RDGeneral/RDProps.h
@@ -34,8 +34,8 @@ protected:
     const STR_VECT &tmp = dp_props.keys();
     STR_VECT res, computed;
     if (!includeComputed &&
-        getPropIfPresent(detail::computedPropName, computed)) {
-      computed.push_back(detail::computedPropName);
+        getPropIfPresent(RDKit::detail::computedPropName, computed)) {
+      computed.push_back(RDKit::detail::computedPropName);
     }
 
     STR_VECT::const_iterator pos = tmp.begin();
@@ -48,7 +48,7 @@ protected:
     }
     return res;
   }
-  
+
   //! sets a \c property value
   /*!
     \param key the name under which the \c property should be stored.
@@ -64,10 +64,10 @@ protected:
   void setProp(const std::string &key, T val, bool computed = false) const {
     if (computed) {
       STR_VECT compLst;
-      getPropIfPresent(detail::computedPropName, compLst);
+      getPropIfPresent(RDKit::detail::computedPropName, compLst);
       if (std::find(compLst.begin(), compLst.end(), key) == compLst.end()) {
         compLst.push_back(key);
-        dp_props.setVal(detail::computedPropName, compLst);
+        dp_props.setVal(RDKit::detail::computedPropName, compLst);
       }
     }
     // setProp(key.c_str(),val);
@@ -126,11 +126,11 @@ protected:
   //! \overload
   void clearProp(const std::string &key) const {
     STR_VECT compLst;
-    if (getPropIfPresent(detail::computedPropName, compLst)) {
+    if (getPropIfPresent(RDKit::detail::computedPropName, compLst)) {
       STR_VECT_I svi = std::find(compLst.begin(), compLst.end(), key);
       if (svi != compLst.end()) {
         compLst.erase(svi);
-        dp_props.setVal(detail::computedPropName, compLst);
+        dp_props.setVal(RDKit::detail::computedPropName, compLst);
       }
     }
     dp_props.clearVal(key);
@@ -139,10 +139,10 @@ protected:
   //! clears all of our \c computed \c properties
   void clearComputedProps() const {
     STR_VECT compLst;
-    if (getPropIfPresent(detail::computedPropName, compLst)) {
+    if (getPropIfPresent(RDKit::detail::computedPropName, compLst)) {
       BOOST_FOREACH (const std::string &sv, compLst) { dp_props.clearVal(sv); }
       compLst.clear();
-      dp_props.setVal(detail::computedPropName, compLst);
+      dp_props.setVal(RDKit::detail::computedPropName, compLst);
     }
   }
 };

--- a/Code/RDGeneral/testDict.cpp
+++ b/Code/RDGeneral/testDict.cpp
@@ -37,18 +37,18 @@ void testGithub940() {
   {  // tests computed props
     STR_VECT computed;
     Dict *d = new Dict();
-    d->setVal(detail::computedPropName, computed);
+    d->setVal(RDKit::detail::computedPropName, computed);
     computed.push_back("foo");
-    d->setVal(detail::computedPropName, computed);
+    d->setVal(RDKit::detail::computedPropName, computed);
     delete d;
   }
   {  // tests computed props
     STR_VECT computed;
     Dict *d = new Dict();
-    d->setVal(detail::computedPropName, computed);
+    d->setVal(RDKit::detail::computedPropName, computed);
     computed.push_back("foo");
-    d->setVal(detail::computedPropName, computed);
-    d->clearVal(detail::computedPropName);
+    d->setVal(RDKit::detail::computedPropName, computed);
+    d->clearVal(RDKit::detail::computedPropName);
     delete d;
   }
   BOOST_LOG(rdErrorLog) << "\tdone" << std::endl;
@@ -110,13 +110,13 @@ void testRDAny() {
   { // tests computed props
     STR_VECT computed;
     Dict d;
-    d.setVal(detail::computedPropName, computed);
+    d.setVal(RDKit::detail::computedPropName, computed);
     computed.push_back("foo");
-    d.setVal(detail::computedPropName, computed);
-    STR_VECT computed2 = d.getVal<STR_VECT>(detail::computedPropName);
+    d.setVal(RDKit::detail::computedPropName, computed);
+    STR_VECT computed2 = d.getVal<STR_VECT>(RDKit::detail::computedPropName);
     TEST_ASSERT(computed2[0] == "foo");
     Dict d2(d);
-    computed2 = d2.getVal<STR_VECT>(detail::computedPropName);
+    computed2 = d2.getVal<STR_VECT>(RDKit::detail::computedPropName);
     TEST_ASSERT(computed2[0] == "foo");
   }
   

--- a/Code/RDGeneral/types.cpp
+++ b/Code/RDGeneral/types.cpp
@@ -14,6 +14,10 @@
 #include "types.h"
 
 namespace RDKit {
+  namespace detail {
+  const std::string computedPropName = "__computedProps";
+  }
+
 namespace common_properties {
 const std::string TWOD = "2D";
 const std::string BalabanJ = "BalabanJ";

--- a/Code/RDGeneral/types.h
+++ b/Code/RDGeneral/types.h
@@ -20,11 +20,6 @@
 #include "Invariant.h"
 #include "Dict.h"
 
-namespace detail {
-// used in various places for computed properties
-const std::string computedPropName = "__computedProps";
-}
-
 #include <vector>
 #include <deque>
 #include <map>
@@ -41,6 +36,12 @@ const std::string computedPropName = "__computedProps";
 #include <boost/lexical_cast.hpp>
 
 namespace RDKit {
+
+  namespace detail {
+  // used in various places for computed properties
+  extern const std::string computedPropName;
+  }
+
 namespace common_properties {
 ///////////////////////////////////////////////////////////////
 // Molecule Props
@@ -50,19 +51,19 @@ extern const std::string MolFileComments; // string
 extern const std::string _2DConf;         // int (combine into dimension?)
 extern const std::string _3DConf;         // int
 extern const std::string _doIsoSmiles;    // int (should probably be removed)
-extern const std::string extraRings;      // vec<vec<int> > 
+extern const std::string extraRings;      // vec<vec<int> >
 extern const std::string _smilesAtomOutputOrder; // vec<int> computed
-extern const std::string _StereochemDone; // int 
+extern const std::string _StereochemDone; // int
 extern const std::string _NeedsQueryScan; // int (bool)
 extern const std::string _fragSMARTS;     // std::string
 extern const std::string maxAttachIdx;    // int TemplEnumTools.cpp
-extern const std::string origNoImplicit;  // int (bool) 
+extern const std::string origNoImplicit;  // int (bool)
 extern const std::string ringMembership;  //? unused (molopstest.cpp)
 
 // Computed Values
 // ConnectivityDescriptors
-extern const std::string _connectivityHKDeltas;// std::vector<double> computed 
-extern const std::string _connectivityNVals;   // std::vector<double> computed 
+extern const std::string _connectivityHKDeltas;// std::vector<double> computed
+extern const std::string _connectivityNVals;   // std::vector<double> computed
 
 extern const std::string _crippenLogP;         // double computed
 extern const std::string _crippenLogPContribs; // std::vector<double> computed
@@ -87,7 +88,7 @@ extern const std::string _CrippenMR;   // Unused (in the basement)
 // Atom Props
 
 // Chirality stuff
-extern const std::string _BondsPotentialStereo; // int (or bool) COMPUTED 
+extern const std::string _BondsPotentialStereo; // int (or bool) COMPUTED
 extern const std::string _CIPCode; // std::string COMPUTED
 extern const std::string _CIPRank; // int COMPUTED
 extern const std::string _ChiralityPossible; // int
@@ -99,7 +100,7 @@ extern const std::string _ringStereoWarning; // obsolete ?
 // Smiles parsing
 extern const std::string _SmilesStart; // int
 extern const std::string _TraversalBondIndexOrder; // ? unused
-extern const std::string _TraversalRingClosureBond; // unsigned int 
+extern const std::string _TraversalRingClosureBond; // unsigned int
 extern const std::string _TraversalStartPoint; // bool
 extern const std::string _queryRootAtom; // int SLNParse/SubstructMatch
 extern const std::string _hasMassQuery; // atom bool
@@ -109,25 +110,25 @@ extern const std::string _unspecifiedOrder;// atom int (bool) smarts/smiles
 extern const std::string _RingClosures; // INT_VECT smarts/smiles/canon
 
 // MDL Style Properties (MolFileParser)
-extern const std::string molAtomMapNumber; // int 
-extern const std::string molFileAlias;  // string 
-extern const std::string molFileValue;  // string 
-extern const std::string molInversionFlag; // int 
-extern const std::string molParity;     // int 
-extern const std::string molRxnComponent; // int 
-extern const std::string molRxnRole;    // int 
-extern const std::string molTotValence; // int 
+extern const std::string molAtomMapNumber; // int
+extern const std::string molFileAlias;  // string
+extern const std::string molFileValue;  // string
+extern const std::string molInversionFlag; // int
+extern const std::string molParity;     // int
+extern const std::string molRxnComponent; // int
+extern const std::string molRxnRole;    // int
+extern const std::string molTotValence; // int
 extern const std::string _MolFileRLabel; // int
 extern const std::string _MolFileChiralFlag; // int
 
 extern const std::string dummyLabel; // atom string
 
 // Reaction Information (Reactions.cpp)
-extern const std::string _QueryFormalCharge; //  int 
-extern const std::string _QueryHCount; // int 
+extern const std::string _QueryFormalCharge; //  int
+extern const std::string _QueryHCount; // int
 extern const std::string _QueryIsotope; // int
-extern const std::string _QueryMass; // int = round(float * 1000) 
-extern const std::string _ReactionDegreeChanged; // int (bool) 
+extern const std::string _QueryMass; // int = round(float * 1000)
+extern const std::string _ReactionDegreeChanged; // int (bool)
 extern const std::string NullBond; // int (bool)
 extern const std::string _rgroupAtomMaps;
 extern const std::string _rgroupBonds;
@@ -140,7 +141,7 @@ extern const std::string _Unfinished_SLN_; // int (bool)
 
 // Smarts Smiles
 extern const std::string _brokenChirality; // atom bool
-extern const std::string isImplicit;  // atom int (bool) 
+extern const std::string isImplicit;  // atom int (bool)
 extern const std::string smilesSymbol; // atom string (only used in test?)
 
 // Tripos


### PR DESCRIPTION
Adds atom map and Rlabel apis to the Atom.  Atom maps probably should be on the Atom, rlabels could be free functions and not on the Atom.  We could do the same for molfile values and aliases.

C++
```
atom->setAtomMapNum(mapno);
atom->setRlabel(rlabel);
atom->getAtomMapNum();
atom->getRlabel();
```

python
```
atom.SetAtomMapNum(mapno)
atom.SetRlabel(rlabel)
atom.GetAtomMapNum()
atom.GetRlabel()
```

Values of 0 unset atom maps and rlabels.