### PR TITLE
Dev/chemtransforms chirality

### DIFF
--- a/Code/GraphMol/ChemTransforms/ChemTransforms.cpp
+++ b/Code/GraphMol/ChemTransforms/ChemTransforms.cpp
@@ -145,7 +145,6 @@ std::vector<ROMOL_SPTR> replaceSubstructs(
   std::vector<MatchVectType> fgpMatches;
 
   boost::dynamic_bitset<> removedAtoms(mol.getNumAtoms());
-  std::cerr << "useChirality " << (int) useChirality << std::endl;
   // do the substructure matching and get the atoms that match the query
   const bool uniquify = true;
   const bool recursionPossible=true;
@@ -154,7 +153,6 @@ std::vector<ROMOL_SPTR> replaceSubstructs(
   // if we didn't find any matches, there's nothing to be done here
   // simply return a list with a copy of the starting molecule
   if (fgpMatches.size() == 0) {
-    std::cerr << "No match" << std::endl;
     res.push_back(ROMOL_SPTR(new ROMol(mol, false)));
     res[0]->clearComputedProps(false);
     return res;

--- a/Code/GraphMol/ChemTransforms/ChemTransforms.h
+++ b/Code/GraphMol/ChemTransforms/ChemTransforms.h
@@ -28,12 +28,13 @@ typedef boost::shared_ptr<ROMol> ROMOL_SPTR;
     \param onlyFrags  if this is set, atoms will only be removed if
                       the entire fragment in which they are found is
                       matched by the query.
+    \param useChirality - if set, match the coreQuery using chirality
 
     \return a copy of \c mol with the matching atoms and bonds (if any)
             removed.
 */
 ROMol *deleteSubstructs(const ROMol &mol, const ROMol &query,
-                        bool onlyFrags = false);
+                        bool onlyFrags = false, bool useChirality = false);
 
 //! \brief Returns a list of copies of an ROMol with the atoms and bonds that
 //!      match a pattern replaced with the atoms contained in another molecule.
@@ -61,6 +62,8 @@ ROMol *deleteSubstructs(const ROMol &mol, const ROMol &query,
     \param query       the query ROMol
     \param replacement the ROMol to be inserted
     \param replaceAll  if this is true, only a single result, with all
+    \param useChirality - if set, match the coreQuery using chirality
+
    occurances
                        of the substructure replaced, will be returned.
     \param replacementConnectionPoint   index of the atom in the replacement
@@ -73,7 +76,8 @@ ROMol *deleteSubstructs(const ROMol &mol, const ROMol &query,
 */
 std::vector<ROMOL_SPTR> replaceSubstructs(
     const ROMol &mol, const ROMol &query, const ROMol &replacement,
-    bool replaceAll = false, unsigned int replacementConnectionPoint = 0);
+    bool replaceAll = false, unsigned int replacementConnectionPoint = 0,
+    bool useChirality = false);
 
 //! \brief Returns a copy of an ROMol with the atoms and bonds that
 //!      don't fall within a substructure match removed.
@@ -83,11 +87,13 @@ std::vector<ROMOL_SPTR> replaceSubstructs(
 /*!
     \param mol       the ROMol of interest
     \param coreQuery a query ROMol to be used to match the core
+    \param useChirality - if set, match the coreQuery using chirality
 
     \return a copy of \c mol with the non-matching atoms and bonds (if any)
             removed and dummies at the connection points.
 */
-ROMol *replaceSidechains(const ROMol &mol, const ROMol &coreQuery);
+ROMol *replaceSidechains(const ROMol &mol, const ROMol &coreQuery,
+                         bool useChirality = false);
 
 //! \brief Returns a copy of an ROMol with the atoms and bonds that
 //!      do fall within a substructure match removed.
@@ -112,6 +118,7 @@ ROMol *replaceSidechains(const ROMol &mol, const ROMol &coreQuery);
    considered.
                                Molecules that have sidechains that are attached
                                at other points will be rejected (NULL returned).
+    \param useChirality - if set, match the coreQuery using chirality
 
     \return a copy of \c mol with the non-matching atoms and bonds (if any)
             removed and dummies at the connection points. The client is

--- a/Code/GraphMol/ChemTransforms/ChemTransforms.h
+++ b/Code/GraphMol/ChemTransforms/ChemTransforms.h
@@ -121,7 +121,7 @@ ROMol *replaceSidechains(const ROMol &mol, const ROMol &coreQuery);
 */
 ROMol *replaceCore(const ROMol &mol, const ROMol &coreQuery,
                    bool replaceDummies = true, bool labelByIndex = false,
-                   bool requireDummyMatch = false);
+                   bool requireDummyMatch = false, bool useChirality = false);
 
 //! \brief Carries out a Murcko decomposition on the molecule provided
 //!

--- a/Code/GraphMol/ChemTransforms/testChemTransforms.cpp
+++ b/Code/GraphMol/ChemTransforms/testChemTransforms.cpp
@@ -787,11 +787,18 @@ void testReplaceCoreRequireDummies() {
     ROMol *mol1 = SmilesToMol(smi);
     TEST_ASSERT(mol1);
 
-    ROMol *mol2 = replaceCore(*mol1, *matcher, false, true, false);
+    bool replaceDummies = false;
+    bool labelByIndex = true;
+    bool requireDummyMatch = false;
+    ROMol *mol2 = replaceCore(*mol1, *matcher,
+                              replaceDummies, labelByIndex,
+                              requireDummyMatch);
     TEST_ASSERT(mol2);
     TEST_ASSERT(mol2->getNumAtoms() == 5);
     smi = MolToSmiles(*mol2, true);
-    TEST_ASSERT(smi == "[1*]CC.[4*]C");
+    // If dummies existed and were replaced
+    //  use THEIR atom indices
+    TEST_ASSERT(smi == "[2*]CC.[5*]C");
 
     delete mol1;
     delete mol2;
@@ -800,7 +807,13 @@ void testReplaceCoreRequireDummies() {
     mol1 = SmilesToMol(smi);
     TEST_ASSERT(mol1);
 
-    mol2 = replaceCore(*mol1, *matcher, false, true, true);
+    replaceDummies = false;
+    labelByIndex = true;
+    requireDummyMatch = true;
+    mol2 = replaceCore(*mol1, *matcher,
+                       replaceDummies, labelByIndex,
+                       requireDummyMatch);
+
     TEST_ASSERT(!mol2);
     delete mol1;
 
@@ -808,7 +821,13 @@ void testReplaceCoreRequireDummies() {
     mol1 = SmilesToMol(smi);
     TEST_ASSERT(mol1);
 
-    mol2 = replaceCore(*mol1, *matcher, false, true, true);
+    replaceDummies = false;
+    labelByIndex = true;
+    requireDummyMatch = true;
+    mol2 = replaceCore(*mol1, *matcher,
+                       replaceDummies, labelByIndex,
+                       requireDummyMatch);
+
     TEST_ASSERT(!mol2);
     delete mol1;
 

--- a/Code/GraphMol/ChemTransforms/testChemTransforms.cpp
+++ b/Code/GraphMol/ChemTransforms/testChemTransforms.cpp
@@ -91,6 +91,27 @@ void testDeleteSubstruct() {
   TEST_ASSERT(mol2);
   TEST_ASSERT(mol2->getNumAtoms() == 4);
 
+  // test chiralty
+  smi = "CCO[C@H](N)(P)";
+  mol1 = SmilesToMol(smi);
+  matcher1 = SmartsToMol("O[C@H](N)(P)");
+  mol2 = deleteSubstructs(*mol1, *matcher1, false, true);
+  std::string smi1 = MolToSmiles(*mol2, true);
+  std::cerr << "1 smi: " << smi1 << std::endl;  
+  TEST_ASSERT(smi1 == "CC");
+  delete matcher1;
+  delete mol2;
+  
+  matcher1 = SmartsToMol("O[C@@H](N)(P)");
+  mol2 = deleteSubstructs(*mol1, *matcher1, false, true);
+  smi1 = MolToSmiles(*mol2, true);
+  std::cerr << "2 smi: " << smi1 << std::endl;
+  TEST_ASSERT(smi1 == "CCO[C@H](N)P");
+  
+  delete mol1;
+  delete matcher1;
+  delete mol2;
+
   BOOST_LOG(rdInfoLog) << "\tdone" << std::endl;
 }
 
@@ -173,6 +194,30 @@ void testReplaceSubstructs() {
   TEST_ASSERT(vect[0]->getNumAtoms() == 3);
   TEST_ASSERT(vect[0]->getNumBonds() == 3);
 
+  // test chirality
+  delete mol1;
+  delete matcher1;
+  sma = "P([C@H](N)O)";
+  matcher1 = SmartsToMol(sma);
+  TEST_ASSERT(matcher1);
+
+  // test stereo matching
+  smi = "CCP([C@H](N)O)CC";
+  mol1 = SmilesToMol(smi);
+  vect = replaceSubstructs(*mol1, *matcher1, *frag, false, 0, true);
+  TEST_ASSERT(vect.size() == 1);
+  std::string smi1 = MolToSmiles(*vect[0], true);
+  TEST_ASSERT(smi1 == "CCNCC");
+
+  smi = "CCP([C@@H](N)O)CC";
+  mol1 = SmilesToMol(smi);
+  vect = replaceSubstructs(*mol1, *matcher1, *frag, false, 0, true);
+  TEST_ASSERT(vect.size() == 1);
+  smi1 = MolToSmiles(*vect[0], true);
+  std::cerr << "smi1" << smi1;
+  // no change
+  TEST_ASSERT(smi1 == "CCP(CC)[C@@H](N)O");
+  
   BOOST_LOG(rdInfoLog) << "\tdone" << std::endl;
 }
 
@@ -196,6 +241,7 @@ void testReplaceSubstructs2() {
     std::vector<ROMOL_SPTR> vect = replaceSubstructs(*mol1, *matcher1, *frag);
     TEST_ASSERT(vect.size() == 1);
     TEST_ASSERT(mol1->getNumAtoms() == 5);
+
     TEST_ASSERT(vect[0]->getNumAtoms() == 6);
     std::string csmi1 = MolToSmiles(*vect[0], true);
 
@@ -276,6 +322,19 @@ void testReplaceSidechains() {
   delete mol2;
   delete matcher1;
 
+  sma = "P([C@H](N)O)";
+  matcher1 = SmartsToMol(sma);
+  TEST_ASSERT(matcher1);
+  smi = "CCP([C@H](N)O)CC";
+  mol1 = SmilesToMol(smi);
+  mol2 = replaceSidechains(*mol1, *matcher1, true);
+  TEST_ASSERT(mol2);
+  smi = MolToSmiles(*mol2, true);
+  std::cerr << "smi1;;; " << smi << std::endl;
+  delete mol1;
+  delete mol2;
+  delete matcher1;
+  
   BOOST_LOG(rdInfoLog) << "\tdone" << std::endl;
 }
 

--- a/Code/GraphMol/ChemTransforms/testChemTransforms.cpp
+++ b/Code/GraphMol/ChemTransforms/testChemTransforms.cpp
@@ -683,14 +683,23 @@ void testReplaceCore2() {
     {"C1O[C@]1(OC)NC",  "C1O[C@]1(*)*", true,  true,  false, true,  "[3*]C.[4*]C"},
 
     {"C1O[C@@]1(OC)NCC", "C1O[C@]1(*)*", true,  false, false, false, "[1*]C.[2*]CC"},
-    {"C1O[C@@]1(OC)NCC", "C1O[C@]1(*)*", true,  false, false, true,  "[1*]C.[2*]CC"},  // seems broken?
+    {"C1O[C@@]1(OC)NCC", "C1O[C@]1(*)*", true,  false, false, true,  "[1*]CC.[2*]C"},
+    
     {"C1O[C@@]1(OC)NCC", "C1O[C@]1(*)*", true,  true,  false, false, "[3*]C.[4*]CC"},
     {"C1O[C@@]1(OC)NCC", "C1O[C@]1(*)*", true,  true,  false, true,  "[3*]CC.[4*]C"},
 
     {"C1O[C@]1(OC)NCC",  "C1O[C@]1(*)*", true,  false, false, false, "[1*]C.[2*]CC"},
     {"C1O[C@]1(OC)NCC",  "C1O[C@]1(*)*", true,  false, false, true,  "[1*]C.[2*]CC"},
     {"C1O[C@]1(OC)NCC",  "C1O[C@]1(*)*", true,  true,  false, false, "[3*]C.[4*]CC"},
-    {"C1O[C@]1(OC)NCC",  "C1O[C@]1(*)*", true,  true,  false, true,  "[3*]C.[4*]CC"}    
+    {"C1O[C@]1(OC)NCC",  "C1O[C@]1(*)*", true,  true,  false, true,  "[3*]C.[4*]CC"},
+
+    {"CNOC", "CONC", false, true, false, false, ""},
+    {"PCNOCS", "CONC", false, true, false, false, "[*]S.[3*]P"},
+    {"PCNOCS", "CONC", false, false, false, false, "[1*]S.[2*]P"},
+
+    {"PCONCS", "CONC", false, true, false, false, "[*]P.[3*]S"},
+    {"PCONCS", "CONC", false, false, false, false, "[1*]P.[2*]S"}
+
   };
   size_t num_tests = sizeof(tests)/sizeof(CoreTest);
   for(size_t i=0; i<num_tests; ++i) {
@@ -714,7 +723,7 @@ void testReplaceCore2() {
             tests[i].expected << " got => " <<
             smi << std::endl;
       }
-      //TEST_ASSERT(smi == tests[i].expected);
+      TEST_ASSERT(smi == tests[i].expected);
     } else {
       TEST_ASSERT(!res.get());
     }

--- a/Code/GraphMol/Wrap/MolOps.cpp
+++ b/Code/GraphMol/Wrap/MolOps.cpp
@@ -319,9 +319,11 @@ int getSSSR(ROMol &mol) {
 PyObject *replaceSubstructures(const ROMol &orig, const ROMol &query,
                                const ROMol &replacement,
                                bool replaceAll = false,
-                               unsigned int replacementConnectionPoint = 0) {
+                               unsigned int replacementConnectionPoint = 0,
+                               bool useChirality=false) {
   std::vector<ROMOL_SPTR> v = replaceSubstructs(
-      orig, query, replacement, replaceAll, replacementConnectionPoint);
+      orig, query, replacement, replaceAll, replacementConnectionPoint,
+      useChirality);
   PyObject *res = PyTuple_New(v.size());
   for (unsigned int i = 0; i < v.size(); ++i) {
     PyTuple_SetItem(res, i, python::converter::shared_ptr_to_python(v[i]));
@@ -910,6 +912,8 @@ struct molops_wrapper {
       See below for examples.\n\
       Default value is 0 (remove the atoms whether or not the entire fragment matches)\n\
 \n\
+    - useChirality: (optional) match the substructure query using chirality\n\
+\n\
   RETURNS: a new molecule with the substructure removed\n\
 \n\
   NOTES:\n\
@@ -931,7 +935,8 @@ struct molops_wrapper {
 \n";
     python::def("DeleteSubstructs", deleteSubstructs,
                 (python::arg("mol"), python::arg("query"),
-                 python::arg("onlyFrags") = false),
+                 python::arg("onlyFrags") = false,
+                 python::arg("useChirality") = false),
                 docString.c_str(),
                 python::return_value_policy<python::manage_new_object>());
     docString = "Do a Murcko decomposition and return the scaffold";
@@ -963,6 +968,7 @@ struct molops_wrapper {
       Default value is False (return multiple replacements)\n\
     - replacementConnectionPoint: (optional) index of the atom in the replacement that\n\
       the bond should be made to.\n\
+    - useChirality: (optional) match the substructure query using chirality\n\
 \n\
   RETURNS: a tuple of new molecules with the substructures replaced removed\n\
 \n\
@@ -986,7 +992,8 @@ struct molops_wrapper {
     python::def("ReplaceSubstructs", replaceSubstructures,
                 (python::arg("mol"), python::arg("query"),
                  python::arg("replacement"), python::arg("replaceAll") = false,
-                 python::arg("replacementConnectionPoint") = 0),
+                 python::arg("replacementConnectionPoint") = 0,
+                 python::arg("useChirality") = false),
                 docString.c_str());
 
     // ------------------------------------------------------------------------
@@ -1715,6 +1722,8 @@ ARGUMENTS:\n\
 \n\
     - coreQuery: the molecule to be used as a substructure query for recognizing the core\n\
 \n\
+    - useChirality: (optional) match the substructure query using chirality\n\
+\n\
   RETURNS: a new molecule with the sidechains removed\n\
 \n\
   NOTES:\n\
@@ -1733,7 +1742,8 @@ ARGUMENTS:\n\
     - ReplaceSidechains('C1CC2C1CCC2','C1CCC1') -> '[Xa]C1CCC1[Xb]'\n\
 \n";
     python::def("ReplaceSidechains", replaceSidechains,
-                (python::arg("mol"), python::arg("coreQuery")),
+                (python::arg("mol"), python::arg("coreQuery"),
+                 python::arg("useChirality") = false),
                 docString.c_str(),
                 python::return_value_policy<python::manage_new_object>());
 
@@ -1754,6 +1764,8 @@ ARGUMENTS:\n\
 \n\
     - requireDummyMatch: if the molecule has side chains that attach at points not\n\
                          flagged with a dummy, it will be rejected (None is returned)\n\
+\n\
+    - useChirality: use chirality matching in the coreQuery\n\
 \n\
   RETURNS: a new molecule with the core removed\n\
 \n\
@@ -1780,7 +1792,8 @@ ARGUMENTS:\n\
                 (python::arg("mol"), python::arg("coreQuery"),
                  python::arg("replaceDummies") = true,
                  python::arg("labelByIndex") = false,
-                 python::arg("requireDummyMatch") = false),
+                 python::arg("requireDummyMatch") = false,
+                 python::arg("useChirality") = false),
                 docString.c_str(),
                 python::return_value_policy<python::manage_new_object>());
 

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -1812,6 +1812,40 @@ CAS<~>
     r = Chem.ReplaceCore(m,core)
     self.assertFalse(r)
 
+    # smiles, smarts, replaceDummies, labelByIndex, useChirality
+    expected = {
+      ('C1O[C@@]1(OC)NC', 'C1O[C@]1(*)*', False, False, False) : '[1*]OC.[2*]NC' ,
+      ('C1O[C@@]1(OC)NC', 'C1O[C@]1(*)*', False, False, True) : '[1*]NC.[2*]OC' ,
+      ('C1O[C@@]1(OC)NC', 'C1O[C@]1(*)*', False, True, False) : '[3*]OC.[4*]NC' ,
+      ('C1O[C@@]1(OC)NC', 'C1O[C@]1(*)*', False, True, True) : '[3*]NC.[4*]OC' ,
+      ('C1O[C@@]1(OC)NC', 'C1O[C@]1(*)*', True, False, False) : '[1*]C.[2*]C' ,
+      ('C1O[C@@]1(OC)NC', 'C1O[C@]1(*)*', True, False, True) : '[1*]C.[2*]C' ,
+      ('C1O[C@@]1(OC)NC', 'C1O[C@]1(*)*', True, True, False) : '[3*]C.[4*]C' ,
+      ('C1O[C@@]1(OC)NC', 'C1O[C@]1(*)*', True, True, True) : '[3*]C.[4*]C' ,
+      ('C1O[C@]1(OC)NC', 'C1O[C@]1(*)*', False, False, False) : '[1*]OC.[2*]NC' ,
+      ('C1O[C@]1(OC)NC', 'C1O[C@]1(*)*', False, False, True) : '[1*]OC.[2*]NC' ,
+      ('C1O[C@]1(OC)NC', 'C1O[C@]1(*)*', False, True, False) : '[3*]OC.[4*]NC' ,
+      ('C1O[C@]1(OC)NC', 'C1O[C@]1(*)*', False, True, True) : '[3*]OC.[4*]NC' ,
+      ('C1O[C@]1(OC)NC', 'C1O[C@]1(*)*', True, False, False) : '[1*]C.[2*]C' ,
+      ('C1O[C@]1(OC)NC', 'C1O[C@]1(*)*', True, False, True) : '[1*]C.[2*]C' ,
+      ('C1O[C@]1(OC)NC', 'C1O[C@]1(*)*', True, True, False) : '[3*]C.[4*]C' ,
+      ('C1O[C@]1(OC)NC', 'C1O[C@]1(*)*', True, True, True) : '[3*]C.[4*]C' ,
+    }
+
+    for (smiles, smarts, replaceDummies, labelByIndex, useChirality), expected_smiles in expected.items():
+      nm = Chem.ReplaceCore(
+        Chem.MolFromSmiles(smiles),
+        Chem.MolFromSmarts(smarts),
+        replaceDummies=replaceDummies,
+        labelByIndex=labelByIndex,
+        useChirality=useChirality)
+      if Chem.MolToSmiles(nm, True) != expected_smiles:
+        print("ReplaceCore(%r, %r, replaceDummies=%r, labelByIndex=%r, useChirality=%r"%(
+          smiles, smarts, replaceDummies, labelByIndex, useChirality), file=sys.stderr)
+        print("expected: %s\ngot: %s"%(expected, Chem.MolToSmiles(nm, True)), file=sys.stderr)
+        self.assertEquals(expected_smiles, Chem.MolToSmiles(nm, True))
+
+
   def test47RWMols(self):
     """ test the RWMol class
 


### PR DESCRIPTION
Adds chirality to ChemTransforms

Fixes output ordering of replaceCore.  Now uses core ordering not molecule ordering.

Breaking change when replaceDummies=False and labelByIndex=True, the dummies in the output are labelled with the dummy index in the core.  Previously they were labeled by the atom they were attached to.