### PR TITLE
Fixes MMFF94 aromaticity perception and ChemicalForceFields.MMFFHasAllMoleculeParams()

### DIFF
--- a/Code/GraphMol/ForceFieldHelpers/MMFF/AtomTyper.cpp
+++ b/Code/GraphMol/ForceFieldHelpers/MMFF/AtomTyper.cpp
@@ -402,17 +402,6 @@ void setMMFFAromaticity(RWMol &mol) {
         for (j = 0; j < atomRings[i].size(); ++j) {
           atom = mol.getAtomWithIdx(atomRings[i][j]);
           atom->setIsAromatic(true);
-          if (atom->getAtomicNum() != 6) {
-//                std::cerr<<"   orig: "<<atom->getNumExplicitHs()<<std::endl;
-#if 1
-            atom->calcImplicitValence(false);
-            int iv = atom->getImplicitValence();
-            if (iv) {
-              atom->setNumExplicitHs(iv);
-              atom->calcImplicitValence(false);
-            }
-#endif
-          }
         }
       }
     }
@@ -444,6 +433,26 @@ void setMMFFAromaticity(RWMol &mol) {
       bond = mol.getBondBetweenAtoms(atomRings[i][j], nextInRing);
       bond->setBondType(Bond::AROMATIC);
       bond->setIsAromatic(true);
+    }
+  }
+  for (i = 0; i < atomRings.size(); ++i) {
+    // if the ring is not aromatic, move to the next one
+    if (!aromRingBitVect[i]) {
+      continue;
+    }
+    for (j = 0; j < atomRings[i].size(); ++j) {
+      atom = mol.getAtomWithIdx(atomRings[i][j]);
+      if (atom->getAtomicNum() != 6) {
+//                std::cerr<<"   orig: "<<atom->getNumExplicitHs()<<std::endl;
+#if 1
+        atom->calcImplicitValence(false);
+        int iv = atom->getImplicitValence();
+        if (iv) {
+          atom->setNumExplicitHs(iv);
+          atom->calcImplicitValence(false);
+        }
+#endif
+      }
     }
   }
 }

--- a/Code/GraphMol/ForceFieldHelpers/MMFF/AtomTyper.cpp
+++ b/Code/GraphMol/ForceFieldHelpers/MMFF/AtomTyper.cpp
@@ -445,11 +445,20 @@ void setMMFFAromaticity(RWMol &mol) {
       if (atom->getAtomicNum() != 6) {
 //                std::cerr<<"   orig: "<<atom->getNumExplicitHs()<<std::endl;
 #if 1
-        atom->calcImplicitValence(false);
-        int iv = atom->getImplicitValence();
+        int iv = atom->getNumImplicitHs();
+        int ev = atom->getNumExplicitHs();
+        int d = atom->getDegree();
+        int td = atom->getTotalDegree();
+        std::cerr << "1) iv = " << iv << ", ev = " << ev
+          << ", d = " << d << ", td = " << td << std::endl;
         if (iv) {
           atom->setNumExplicitHs(iv);
-          atom->calcImplicitValence(false);
+          iv = atom->calcImplicitValence(false);
+          ev = atom->calcExplicitValence(false);
+          d = atom->getDegree();
+          td = atom->getTotalDegree();
+          std::cerr << "2) iv = " << iv << ", ev = " << ev
+            << ", d = " << d << ", td = " << td << std::endl;
         }
 #endif
       }

--- a/Code/GraphMol/ForceFieldHelpers/MMFF/AtomTyper.cpp
+++ b/Code/GraphMol/ForceFieldHelpers/MMFF/AtomTyper.cpp
@@ -443,24 +443,12 @@ void setMMFFAromaticity(RWMol &mol) {
     for (j = 0; j < atomRings[i].size(); ++j) {
       atom = mol.getAtomWithIdx(atomRings[i][j]);
       if (atom->getAtomicNum() != 6) {
-//                std::cerr<<"   orig: "<<atom->getNumExplicitHs()<<std::endl;
-#if 1
-        int iv = atom->getNumImplicitHs();
-        int ev = atom->getNumExplicitHs();
-        int d = atom->getDegree();
-        int td = atom->getTotalDegree();
-        std::cerr << "1) iv = " << iv << ", ev = " << ev
-          << ", d = " << d << ", td = " << td << std::endl;
+        int iv = atom->calcImplicitValence(false);
+        atom->calcExplicitValence(false);
         if (iv) {
           atom->setNumExplicitHs(iv);
-          iv = atom->calcImplicitValence(false);
-          ev = atom->calcExplicitValence(false);
-          d = atom->getDegree();
-          td = atom->getTotalDegree();
-          std::cerr << "2) iv = " << iv << ", ev = " << ev
-            << ", d = " << d << ", td = " << td << std::endl;
+          atom->calcImplicitValence(false);
         }
-#endif
       }
     }
   }

--- a/Code/GraphMol/ForceFieldHelpers/Wrap/rdForceFields.cpp
+++ b/Code/GraphMol/ForceFieldHelpers/Wrap/rdForceFields.cpp
@@ -143,7 +143,7 @@ ForceFields::PyForceField *MMFFGetMoleculeForceField(
   return pyFF;
 }
 
-bool MMFFHasAllMoleculeParams(ROMol &mol) {
+bool MMFFHasAllMoleculeParams(ROMol mol) {
   MMFF::MMFFMolProperties mmffMolProperties(mol);
 
   return mmffMolProperties.isValid();

--- a/Code/GraphMol/ForceFieldHelpers/Wrap/rdForceFields.cpp
+++ b/Code/GraphMol/ForceFieldHelpers/Wrap/rdForceFields.cpp
@@ -143,8 +143,9 @@ ForceFields::PyForceField *MMFFGetMoleculeForceField(
   return pyFF;
 }
 
-bool MMFFHasAllMoleculeParams(ROMol mol) {
-  MMFF::MMFFMolProperties mmffMolProperties(mol);
+bool MMFFHasAllMoleculeParams(const ROMol &mol) {
+  ROMol molCopy(mol);
+  MMFF::MMFFMolProperties mmffMolProperties(molCopy);
 
   return mmffMolProperties.isValid();
 }

--- a/Code/GraphMol/ForceFieldHelpers/Wrap/testHelpers.py
+++ b/Code/GraphMol/ForceFieldHelpers/Wrap/testHelpers.py
@@ -1,5 +1,5 @@
 from rdkit import Chem
-from rdkit.Chem import ChemicalForceFields
+from rdkit.Chem import ChemicalForceFields, rdmolops, rdDistGeom
 from rdkit import RDConfig
 import unittest
 import os
@@ -230,6 +230,25 @@ M  END"""
     self.failUnless((int(round(uffVdWParams[0] * 1000)) == 3754)
       and (int(round(uffVdWParams[1] * 1000)) == 85))
 
+  def test11(self) :
+    for i in range(2):
+      m = Chem.MolFromSmiles('Cc1nc(=O)c(C[NH3+])c(-c2c[nH]c3ccccc23)[nH]1')
+      m = rdmolops.AddHs(m)
+      aromaticFlagsBefore = []
+      for a in m.GetAtoms():
+        aromaticFlagsBefore.append(a.GetIsAromatic())
+      if (i):
+        self.failUnless(ChemicalForceFields.MMFFGetMoleculeProperties(m))
+      else:
+        self.failUnless(ChemicalForceFields.MMFFHasAllMoleculeParams(m))
+      aromaticFlagsAfter = []
+      for a in m.GetAtoms():
+        aromaticFlagsAfter.append(a.GetIsAromatic())
+      res = (aromaticFlagsBefore == aromaticFlagsAfter)
+      if (i):
+        res = not res
+      self.failUnless(res)
+      self.failUnless(rdDistGeom.EmbedMolecule(m) == 0)
 
 
 if __name__== '__main__':

--- a/Code/GraphMol/ForceFieldHelpers/Wrap/testHelpers.py
+++ b/Code/GraphMol/ForceFieldHelpers/Wrap/testHelpers.py
@@ -1,5 +1,5 @@
 from rdkit import Chem
-from rdkit.Chem import ChemicalForceFields, rdmolops, rdDistGeom
+from rdkit.Chem import ChemicalForceFields
 from rdkit import RDConfig
 import unittest
 import os
@@ -231,9 +231,10 @@ M  END"""
       and (int(round(uffVdWParams[1] * 1000)) == 85))
 
   def test11(self) :
-    for i in range(2):
+    query = Chem.MolFromSmarts('c1cccn1')
+    for i in [0, 1]:
       m = Chem.MolFromSmiles('Cc1nc(=O)c(C[NH3+])c(-c2c[nH]c3ccccc23)[nH]1')
-      m = rdmolops.AddHs(m)
+      m = Chem.AddHs(m)
       aromaticFlagsBefore = []
       for a in m.GetAtoms():
         aromaticFlagsBefore.append(a.GetIsAromatic())
@@ -248,7 +249,10 @@ M  END"""
       if (i):
         res = not res
       self.failUnless(res)
-      self.failUnless(rdDistGeom.EmbedMolecule(m) == 0)
+      lastNIdx = m.GetSubstructMatch(query)[-1]
+      atom = m.GetAtomWithIdx(lastNIdx)
+      self.failUnless((atom.GetImplicitValence() \
+        + atom.GetExplicitValence()) == 3)
 
 
 if __name__== '__main__':

--- a/Code/GraphMol/ForceFieldHelpers/Wrap/testHelpers.py
+++ b/Code/GraphMol/ForceFieldHelpers/Wrap/testHelpers.py
@@ -249,9 +249,6 @@ M  END"""
         res = not res
       self.failUnless(res)
       pyrroleNIdx = m.GetSubstructMatch(query)[-1]
-      print ('i = ' + str(i) + ', pyrroleNIdx = ' + str(pyrroleNIdx) \
-        + ', GetTotalDegree() = ' \
-        + str(m.GetAtomWithIdx(pyrroleNIdx).GetTotalDegree()) + '\n')
       self.failUnless(m.GetAtomWithIdx(pyrroleNIdx).GetTotalDegree() == 3)
 
 

--- a/Code/GraphMol/ForceFieldHelpers/Wrap/testHelpers.py
+++ b/Code/GraphMol/ForceFieldHelpers/Wrap/testHelpers.py
@@ -234,7 +234,6 @@ M  END"""
     query = Chem.MolFromSmarts('c1cccn1')
     for i in [0, 1]:
       m = Chem.MolFromSmiles('Cc1nc(=O)c(C[NH3+])c(-c2c[nH]c3ccccc23)[nH]1')
-      m = Chem.AddHs(m)
       aromaticFlagsBefore = []
       for a in m.GetAtoms():
         aromaticFlagsBefore.append(a.GetIsAromatic())
@@ -249,10 +248,11 @@ M  END"""
       if (i):
         res = not res
       self.failUnless(res)
-      lastNIdx = m.GetSubstructMatch(query)[-1]
-      atom = m.GetAtomWithIdx(lastNIdx)
-      self.failUnless((atom.GetImplicitValence() \
-        + atom.GetExplicitValence()) == 3)
+      pyrroleNIdx = m.GetSubstructMatch(query)[-1]
+      print ('i = ' + str(i) + ', pyrroleNIdx = ' + str(pyrroleNIdx) \
+        + ', GetTotalDegree() = ' \
+        + str(m.GetAtomWithIdx(pyrroleNIdx).GetTotalDegree()) + '\n')
+      self.failUnless(m.GetAtomWithIdx(pyrroleNIdx).GetTotalDegree() == 3)
 
 
 if __name__== '__main__':


### PR DESCRIPTION
- calcImplicitValence() and setNumExplicitHs() are now called after all aromaticity flags have been set
- ChemicalForceFields.MMFFHasAllMoleculeParams() now operates on a copy of the molecule such that atom and bond aromaticity are not altered by the check
- test11 was added to GraphMol/ForceFieldHelpers/Wrap/testHelpers.py to check for the two bugs fixed by this PR
