### PR TITLE
Add an initial version of wavy bonds

### DIFF
--- a/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
@@ -1159,6 +1159,8 @@ void MolDraw2D::drawRect(const Point2D &cds1, const Point2D &cds2) {
 void MolDraw2D::drawWavyLine(const Point2D &cds1, const Point2D &cds2,
                              const DrawColour &col1, const DrawColour &col2,
                              unsigned int nSegments, double vertOffset) {
+  RDUNUSED_PARAM(nSegments);
+  RDUNUSED_PARAM(vertOffset);
   drawLine(cds1, cds2, col1, col2);
 }
 // ****************************************************************************

--- a/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
@@ -771,6 +771,9 @@ void MolDraw2D::drawBond(const ROMol &mol, const BOND_SPTR &bond, int at1_idx,
       } else {
         drawWedgedBond(at1_cds, at2_cds, true, col1, col2);
       }
+    } else if (Bond::SINGLE == bt && Bond::UNKNOWN == bond->getBondDir()) {
+      // unspecified stereo
+      drawWavyLine(at1_cds, at2_cds, col1, col2);
     } else {
       // in all other cases, we will definitely want to draw a line between the
       // two atoms
@@ -1153,18 +1156,20 @@ void MolDraw2D::drawRect(const Point2D &cds1, const Point2D &cds2) {
   drawPolygon(pts);
 }
 
+void MolDraw2D::drawWavyLine(const Point2D &cds1, const Point2D &cds2,
+                             const DrawColour &col1, const DrawColour &col2,
+                             unsigned int nSegments, double vertOffset) {
+  drawLine(cds1, cds2, col1, col2);
+}
 // ****************************************************************************
 //  we draw the line at cds2, perpendicular to the line cds1-cds2
 void MolDraw2D::drawAttachmentLine(const Point2D &cds1, const Point2D &cds2,
                                    const DrawColour &col, double len,
                                    unsigned int nSegments) {
-  if (nSegments % 2)
-    ++nSegments;  // we're going to assume an even number of segments
   Point2D perp = calcPerpendicular(cds1, cds2);
   Point2D p1 = Point2D(cds2.x - perp.x * len / 2, cds2.y - perp.y * len / 2);
   Point2D p2 = Point2D(cds2.x + perp.x * len / 2, cds2.y + perp.y * len / 2);
-  setColour(col);
-  drawLine(p1, p2);
+  drawWavyLine(p1, p2, col, col, nSegments);
 }
 
 }  // EO namespace RDKit

--- a/Code/GraphMol/MolDraw2D/MolDraw2D.h
+++ b/Code/GraphMol/MolDraw2D/MolDraw2D.h
@@ -175,8 +175,11 @@ class MolDraw2D {
   virtual void drawRect(const Point2D &cds1, const Point2D &cds2);
   virtual void drawAttachmentLine(const Point2D &cds1, const Point2D &cds2,
                                   const DrawColour &col, double len = 1.0,
-                                  unsigned int nSegments = 8);
-
+                                  unsigned int nSegments = 16);
+  virtual void drawWavyLine(const Point2D &cds1, const Point2D &cds2,
+                            const DrawColour &col1, const DrawColour &col2,
+                            unsigned int nSegments = 16,
+                            double vertOffset = 0.05);
   virtual void tagAtoms(const ROMol &mol) { RDUNUSED_PARAM(mol); };
 
   virtual bool fillPolys() const { return fill_polys_; }
@@ -235,9 +238,6 @@ class MolDraw2D {
   void drawAtomLabel(int atom_num,
                      const std::vector<int> *highlight_atoms = NULL,
                      const std::map<int, DrawColour> *highlight_map = NULL);
-
-  // calculate normalised perpendicular to vector between two coords
-  Point2D calcPerpendicular(const Point2D &cds1, const Point2D &cds2);
   // cds1 and cds2 are 2 atoms in a ring.  Returns the perpendicular pointing
   // into
   // the ring.
@@ -247,7 +247,8 @@ class MolDraw2D {
   // perpendicular
   // pointing into the inside of the bond
   Point2D bondInsideDoubleBond(const ROMol &mol, const BOND_SPTR &bond);
-  // calculate normalised perpendicular to vector between two coords, such that
+  // calculate normalised perpendicular to vector between two coords, such
+  // that
   // it's inside the angle made between (1 and 2) and (2 and 3).
   Point2D calcInnerPerpendicular(const Point2D &cds1, const Point2D &cds2,
                                  const Point2D &cds3);
@@ -262,6 +263,7 @@ class MolDraw2D {
   std::pair<std::string, OrientType> getAtomSymbolAndOrientation(
       const Atom &atom, const Point2D &nbr_sum);
 
+ protected:
   virtual void doContinuousHighlighting(
       const ROMol &mol, const std::vector<int> *highlight_atoms,
       const std::vector<int> *highlight_bonds,
@@ -270,6 +272,9 @@ class MolDraw2D {
       const std::map<int, double> *highlight_radii);
 
   virtual void highlightCloseContacts();
+
+  // calculate normalised perpendicular to vector between two coords
+  Point2D calcPerpendicular(const Point2D &cds1, const Point2D &cds2);
 };
 }
 

--- a/Code/GraphMol/MolDraw2D/MolDraw2DCairo.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DCairo.cpp
@@ -56,6 +56,40 @@ void MolDraw2DCairo::drawLine(const Point2D &cds1, const Point2D &cds2) {
   cairo_stroke(dp_cr);
 }
 
+void MolDraw2DCairo::drawWavyLine(const Point2D &cds1, const Point2D &cds2,
+                                  const DrawColour &col1,
+                                  const DrawColour &col2,
+                                  unsigned int nSegments, double vertOffset) {
+  PRECONDITION(dp_cr, "no draw context");
+
+  if (nSegments % 2)
+    ++nSegments;  // we're going to assume an even number of segments
+
+  Point2D perp = calcPerpendicular(cds1, cds2);
+  Point2D delta = (cds2 - cds1);
+  perp *= vertOffset;
+  delta /= nSegments;
+
+  Point2D c1 = getDrawCoords(cds1);
+
+  unsigned int width = lineWidth();
+  cairo_set_line_width(dp_cr, width);
+  cairo_set_dash(dp_cr, 0, 0, 0);
+  setColour(col1);
+  cairo_move_to(dp_cr, c1.x, c1.y);
+  for (unsigned int i = 0; i < nSegments; ++i) {
+    Point2D startpt = cds1 + delta * i;
+    Point2D segpt = getDrawCoords(startpt + delta);
+    Point2D cpt1 =
+        getDrawCoords(startpt + delta / 3. + perp * (i % 2 ? -1 : 1));
+    Point2D cpt2 =
+        getDrawCoords(startpt + delta * 2. / 3. + perp * (i % 2 ? -1 : 1));
+    // if (i == nSegments / 2 && col2 != col1) setColour(col2);
+    cairo_curve_to(dp_cr, cpt1.x, cpt1.y, cpt2.x, cpt2.y, segpt.x, segpt.y);
+  }
+  cairo_stroke(dp_cr);
+}
+
 // ****************************************************************************
 // draw the char, with the bottom left hand corner at cds
 void MolDraw2DCairo::drawChar(char c, const Point2D &cds) {

--- a/Code/GraphMol/MolDraw2D/MolDraw2DCairo.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DCairo.cpp
@@ -61,6 +61,7 @@ void MolDraw2DCairo::drawWavyLine(const Point2D &cds1, const Point2D &cds2,
                                   const DrawColour &col2,
                                   unsigned int nSegments, double vertOffset) {
   PRECONDITION(dp_cr, "no draw context");
+  PRECONDITION(nSegments > 1, "too few segments");
 
   if (nSegments % 2)
     ++nSegments;  // we're going to assume an even number of segments

--- a/Code/GraphMol/MolDraw2D/MolDraw2DCairo.h
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DCairo.h
@@ -63,6 +63,10 @@ class MolDraw2DCairo : public MolDraw2D {
   void drawPolygon(const std::vector<Point2D> &cds);
   void clearDrawing();
 
+  void drawWavyLine(const Point2D &cds1, const Point2D &cds2,
+                    const DrawColour &col1, const DrawColour &col2,
+                    unsigned int nSegments = 16, double vertOffset = 0.05);
+
   // using the current scale, work out the size of the label in molecule
   // coordinates
   void getStringSize(const std::string &label, double &label_width,

--- a/Code/GraphMol/MolDraw2D/MolDraw2DSVG.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DSVG.cpp
@@ -61,6 +61,8 @@ void MolDraw2DSVG::setColour(const DrawColour &col) {
 void MolDraw2DSVG::drawWavyLine(const Point2D &cds1, const Point2D &cds2,
                                 const DrawColour &col1, const DrawColour &col2,
                                 unsigned int nSegments, double vertOffset) {
+  PRECONDITION(nSegments > 1, "too few segments");
+
   if (nSegments % 2)
     ++nSegments;  // we're going to assume an even number of segments
   setColour(col1);

--- a/Code/GraphMol/MolDraw2D/MolDraw2DSVG.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DSVG.cpp
@@ -58,6 +58,42 @@ void MolDraw2DSVG::setColour(const DrawColour &col) {
   MolDraw2D::setColour(col);
 }
 
+void MolDraw2DSVG::drawWavyLine(const Point2D &cds1, const Point2D &cds2,
+                                const DrawColour &col1, const DrawColour &col2,
+                                unsigned int nSegments, double vertOffset) {
+  if (nSegments % 2)
+    ++nSegments;  // we're going to assume an even number of segments
+  setColour(col1);
+
+  Point2D perp = calcPerpendicular(cds1, cds2);
+  Point2D delta = (cds2 - cds1);
+  perp *= vertOffset;
+  delta /= nSegments;
+
+  Point2D c1 = getDrawCoords(cds1);
+
+  std::string col = DrawColourToSVG(colour());
+  unsigned int width = lineWidth();
+  d_os << "<svg:path ";
+  d_os << "d='M" << c1.x << "," << c1.y;
+  for (unsigned int i = 0; i < nSegments; ++i) {
+    Point2D startpt = cds1 + delta * i;
+    Point2D segpt = getDrawCoords(startpt + delta);
+    Point2D cpt1 =
+        getDrawCoords(startpt + delta / 3. + perp * (i % 2 ? -1 : 1));
+    Point2D cpt2 =
+        getDrawCoords(startpt + delta * 2. / 3. + perp * (i % 2 ? -1 : 1));
+    d_os << " C" << cpt1.x << "," << cpt1.y << " " << cpt2.x << "," << cpt2.y
+         << " " << segpt.x << "," << segpt.y;
+  }
+  d_os << "' ";
+
+  d_os << "style='fill:none;stroke:" << col << ";stroke-width:" << width
+       << "px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       << "'";
+  d_os << " />\n";
+}
+
 // ****************************************************************************
 void MolDraw2DSVG::drawLine(const Point2D &cds1, const Point2D &cds2) {
   Point2D c1 = getDrawCoords(cds1);

--- a/Code/GraphMol/MolDraw2D/MolDraw2DSVG.h
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DSVG.h
@@ -52,6 +52,10 @@ class MolDraw2DSVG : public MolDraw2D {
   void drawEllipse(const Point2D &cds1, const Point2D &cds2);
   void clearDrawing();
 
+  void drawWavyLine(const Point2D &cds1, const Point2D &cds2,
+                    const DrawColour &col1, const DrawColour &col2,
+                    unsigned int nSegments = 16, double vertOffset = 0.05);
+
   // using the current scale, work out the size of the label in molecule
   // coordinates
   void getStringSize(const std::string &label, double &label_width,

--- a/Code/GraphMol/MolDraw2D/test1.cpp
+++ b/Code/GraphMol/MolDraw2D/test1.cpp
@@ -473,6 +473,63 @@ void test5() {
     }
     delete m;
   }
+  {
+    std::string smiles = "*C";
+    std::string nameBase = "test5_2";
+    ROMol *m = SmilesToMol(smiles);
+    TEST_ASSERT(m);
+    RDDepict::compute2DCoords(*m, 0, true);
+    WedgeMolBonds(*m, &(m->getConformer()));
+    MolDrawOptions options;
+    options.dummiesAreAttachments = true;
+#ifdef RDK_CAIRO_BUILD
+    {
+      MolDraw2DCairo drawer(300, 300);
+      drawer.drawOptions() = options;
+      drawer.drawMolecule(*m);
+      drawer.finishDrawing();
+      drawer.writeDrawingText(nameBase + ".png");
+    }
+#endif
+    {
+      std::ofstream outs((nameBase + ".svg").c_str());
+      MolDraw2DSVG drawer(300, 300, outs);
+      drawer.drawOptions() = options;
+      drawer.drawMolecule(*m);
+      drawer.finishDrawing();
+      outs.flush();
+    }
+    delete m;
+  }
+  {
+    std::string smiles = "CC(F)(Cl)Br";
+    std::string nameBase = "test5_3";
+    ROMol *m = SmilesToMol(smiles);
+    TEST_ASSERT(m);
+    m->getBondBetweenAtoms(1, 2)->setBondDir(Bond::UNKNOWN);
+    RDDepict::compute2DCoords(*m, 0, true);
+    WedgeMolBonds(*m, &(m->getConformer()));
+    MolDrawOptions options;
+    options.dummiesAreAttachments = true;
+#ifdef RDK_CAIRO_BUILD
+    {
+      MolDraw2DCairo drawer(300, 300);
+      drawer.drawOptions() = options;
+      drawer.drawMolecule(*m);
+      drawer.finishDrawing();
+      drawer.writeDrawingText(nameBase + ".png");
+    }
+#endif
+    {
+      std::ofstream outs((nameBase + ".svg").c_str());
+      MolDraw2DSVG drawer(300, 300, outs);
+      drawer.drawOptions() = options;
+      drawer.drawMolecule(*m);
+      drawer.finishDrawing();
+      outs.flush();
+    }
+    delete m;
+  }
   std::cout << " Done" << std::endl;
 }
 
@@ -745,9 +802,9 @@ void test8PrepareMolForDrawing() {
 }
 
 void testGithub781() {
-  std::cout
-      << " ----------------- Test Github #781: Rendering single-atom molecules"
-      << std::endl;
+  std::cout << " ----------------- Test Github #781: Rendering single-atom "
+               "molecules"
+            << std::endl;
 
   {
     std::string smiles = "C";
@@ -1036,7 +1093,8 @@ void testGithub910() {
   {
     // this is a ChEMBL molecule
     std::string smiles =
-        "CSCC[C@H](NC(=O)[C@@H](CCC(N)=O)NC(=O)[C@@H](N)Cc1c[nH]c2ccccc12)C(=O)"
+        "CSCC[C@H](NC(=O)[C@@H](CCC(N)=O)NC(=O)[C@@H](N)Cc1c[nH]c2ccccc12)C(="
+        "O)"
         "NCC(=O)N[C@@H](Cc1c[nH]cn1)C(=O)N[C@@H](CO)C(=O)O";
     ROMol *m = SmilesToMol(smiles);
     TEST_ASSERT(m);
@@ -1052,7 +1110,8 @@ void testGithub910() {
   {  // now with Hs
     // this is a ChEMBL molecule
     std::string smiles =
-        "CSCC[C@H](NC(=O)[C@@H](CCC(N)=O)NC(=O)[C@@H](N)Cc1c[nH]c2ccccc12)C(=O)"
+        "CSCC[C@H](NC(=O)[C@@H](CCC(N)=O)NC(=O)[C@@H](N)Cc1c[nH]c2ccccc12)C(="
+        "O)"
         "NCC(=O)N[C@@H](Cc1c[nH]cn1)C(=O)N[C@@H](CO)C(=O)O";
     RWMol *m = SmilesToMol(smiles);
     TEST_ASSERT(m);
@@ -1068,9 +1127,9 @@ void testGithub910() {
 }
 
 void testGithub932() {
-  std::cout
-      << " ----------------- Test Github #932: mistake in SVG for wedged bonds"
-      << std::endl;
+  std::cout << " ----------------- Test Github #932: mistake in SVG for "
+               "wedged bonds"
+            << std::endl;
   {
     std::string smiles = "CC[C@](F)(Cl)Br";
     RWMol *m = SmilesToMol(smiles);
@@ -1088,9 +1147,9 @@ void testGithub932() {
 }
 
 void testGithub953() {
-  std::cout
-      << " ----------------- Test Github #953: default color should not be cyan"
-      << std::endl;
+  std::cout << " ----------------- Test Github #953: default color should "
+               "not be cyan"
+            << std::endl;
   {
     std::string smiles = "[Nb]";
     RWMol *m = SmilesToMol(smiles);


### PR DESCRIPTION
Used for attachment points and unknown stereochem
This is not a perfect implementation, but is a decent place to start
Currently only supports SVG and Cairo canvases.

Example images:
![image](https://cloud.githubusercontent.com/assets/540511/17541802/7a22d358-5ec3-11e6-85c7-c6c95900d2d3.png)

![image](https://cloud.githubusercontent.com/assets/540511/17541805/819ddf1a-5ec3-11e6-8df8-6e279c242837.png)

