### PR TITLE
Fixes issue #1021

### DIFF
--- a/Code/GraphMol/Chirality.cpp
+++ b/Code/GraphMol/Chirality.cpp
@@ -470,15 +470,12 @@ void findChiralAtomSpecialCases(ROMol &mol,
        ++ait) {
     const Atom *atom = *ait;
     if (atomsSeen[atom->getIdx()]) continue;
-    // atomsUsed.set(atom->getIdx());
     if (atom->getChiralTag() == Atom::CHI_UNSPECIFIED ||
         atom->hasProp(common_properties::_CIPCode) ||
         !mol.getRingInfo()->numAtomRings(atom->getIdx()) ||
         !atomIsCandidateForRingStereochem(mol, atom)) {
       continue;
     }
-    // std::cerr << " bfs from " << atom->getIdx() << std::endl;
-    // ----------
     // do a BFS from this ring atom along ring bonds and find other candidates.
     std::list<const Atom *> nextAtoms;
     // start with finding viable neighbors
@@ -486,18 +483,11 @@ void findChiralAtomSpecialCases(ROMol &mol,
     boost::tie(beg, end) = mol.getAtomBonds(atom);
     while (beg != end) {
       unsigned int bidx = mol[*beg]->getIdx();
-      // std::cerr << "         bond: " << bidx << " "
-      //           << mol.getRingInfo()->numBondRings(bidx) << " ? "
-      //           << bondsSeen[bidx] << std::endl;
       if (!bondsSeen[bidx]) {
         bondsSeen.set(bidx);
         if (mol.getRingInfo()->numBondRings(bidx)) {
           const Atom *oatom = mol[*beg]->getOtherAtom(atom);
-          // std::cerr << "                   oa: " << oatom->getIdx() << " "
-          //           << atomsSeen[oatom->getIdx()] << std::endl;
           if (!atomsSeen[oatom->getIdx()]) {
-            // std::cerr << "                push " << oatom->getIdx()
-            //           << std::endl;
             nextAtoms.push_back(oatom);
             atomsUsed.set(oatom->getIdx());
           }
@@ -515,15 +505,10 @@ void findChiralAtomSpecialCases(ROMol &mol,
       const Atom *ratom = nextAtoms.front();
       nextAtoms.pop_front();
       atomsSeen.set(ratom->getIdx());
-      // std::cerr << "   look at: " << ratom->getIdx() << std::endl;
       if (ratom->getChiralTag() != Atom::CHI_UNSPECIFIED &&
           !ratom->hasProp(common_properties::_CIPCode) &&
           atomIsCandidateForRingStereochem(mol, ratom)) {
-        // std::cerr << "  special case!" << std::endl;
         int same = (ratom->getChiralTag() == atom->getChiralTag()) ? 1 : -1;
-        // std::cerr << " atoms " << atom->getIdx() << " and " <<
-        // ratom->getIdx()
-        //           << " same? " << same << std::endl;
         ringStereoAtoms.push_back(same * (ratom->getIdx() + 1));
         INT_VECT oringatoms(0);
         ratom->getPropIfPresent(common_properties::_ringStereoAtoms,
@@ -630,9 +615,6 @@ std::pair<bool, bool> isAtomPotentialChiralCenter(
       }
       codesSeen[ranks[otherIdx]] = 1;
       nbrs.push_back(std::make_pair(ranks[otherIdx], mol[*beg]->getIdx()));
-      // std::cerr<<"      "<< atom->getIdx() << " " << mol[*beg]->getIdx() <<
-      // "
-      // " << otherIdx << "(" << ranks[otherIdx] <<")"<<std::endl;
       ++beg;
     }
 
@@ -726,11 +708,6 @@ std::pair<bool, bool> assignAtomChiralCodes(ROMol &mol, UINT_VECT &ranks,
         if (nbrIndices.size() == 3 && atom->getTotalNumHs() == 1) {
           ++nSwaps;
         }
-
-        // std::cerr<<"nbrs from "<<atom->getIdx()<<" ";
-        // std::copy(nbrIndices.begin(),nbrIndices.end(),std::ostream_iterator<unsigned
-        // int>(std::cerr," "));
-        // std::cerr<<"nSwaps: "<<nSwaps<<" tag: "<<tag<<std::endl;
 
         // if that number is odd, we'll change our chirality:
         if (nSwaps % 2) {
@@ -1044,23 +1021,10 @@ void assignStereochemistry(ROMol &mol, bool cleanIt, bool force,
     for (ROMol::AtomIterator atIt = mol.beginAtoms(); atIt != mol.endAtoms();
          ++atIt) {
       Atom *atom = *atIt;
-      // std::cerr << " at: " << atom->getIdx() << " " << atom->getChiralTag()
-      //           << " " << atom->hasProp(common_properties::_CIPCode) << " "
-      //           << possibleSpecialCases[atom->getIdx()] << " "
-      //           << atom->hasProp(common_properties::_ringStereoAtoms)
-      //           << std::endl;
       if (atom->getChiralTag() != Atom::CHI_UNSPECIFIED &&
           !atom->hasProp(common_properties::_CIPCode) &&
           (possibleSpecialCases[atom->getIdx()] ||
            atom->hasProp(common_properties::_ringStereoAtoms))) {
-        // std::cerr << " possible chiral center: " << atom->getIdx() << ": "
-        //           << atom->getChiralTag() << " "
-        //           << possibleSpecialCases[atom->getIdx()] << " "
-        //           << possibleSpecialCases[atom->getIdx()] << " "
-        //           << atom->getProp<std::vector<int> >(
-        //                      common_properties::_ringStereoAtoms)
-        //                  .size()
-        //           << std::endl;
       }
 
       if (atom->getChiralTag() != Atom::CHI_UNSPECIFIED &&

--- a/Code/GraphMol/Chirality.cpp
+++ b/Code/GraphMol/Chirality.cpp
@@ -451,70 +451,6 @@ bool atomIsCandidateForRingStereochem(const ROMol &mol, const Atom *atom) {
   return res;
 }
 
-#if 0
-// returns true if the atom is allowed to have stereochemistry specified
-bool checkChiralAtomSpecialCases(ROMol &mol, const Atom *atom) {
-  PRECONDITION(atom, "bad atom");
-
-  if (!mol.getRingInfo()->isInitialized()) {
-    VECT_INT_VECT sssrs;
-    MolOps::symmetrizeSSSR(mol, sssrs);
-  }
-
-  const RingInfo *ringInfo = mol.getRingInfo();
-  if (ringInfo->numAtomRings(atom->getIdx()) &&
-      atomIsCandidateForRingStereochem(mol, atom)) {
-    // the atom is in a ring, so the "chirality" specification may actually
-    // be handling ring stereochemistry.
-
-    // check for another chiral tagged
-    // atom without stereochem in this atom's rings:
-    INT_VECT ringStereoAtoms(0);
-    atom->getPropIfPresent(common_properties::_ringStereoAtoms,
-                           ringStereoAtoms);
-
-    const VECT_INT_VECT atomRings = ringInfo->atomRings();
-    for (VECT_INT_VECT::const_iterator ringIt = atomRings.begin();
-         ringIt != atomRings.end(); ++ringIt) {
-      if (std::find(ringIt->begin(), ringIt->end(),
-                    static_cast<int>(atom->getIdx())) != ringIt->end()) {
-        for (INT_VECT::const_iterator idxIt = ringIt->begin();
-             idxIt != ringIt->end(); ++idxIt) {
-          int same = 1;
-          if (*idxIt != static_cast<int>(atom->getIdx()) &&
-              mol.getAtomWithIdx(*idxIt)->getChiralTag() !=
-                  Atom::CHI_UNSPECIFIED &&
-              !mol.getAtomWithIdx(*idxIt)->hasProp(
-                  common_properties::_CIPCode) &&
-              atomIsCandidateForRingStereochem(mol,
-                                               mol.getAtomWithIdx(*idxIt))) {
-            // we get to keep the stereochem specification on this atom:
-            if (mol.getAtomWithIdx(*idxIt)->getChiralTag() !=
-                atom->getChiralTag()) {
-              same = -1;
-            }
-            ringStereoAtoms.push_back(same * (*idxIt + 1));
-            INT_VECT oAtoms(0);
-            mol.getAtomWithIdx(*idxIt)->getPropIfPresent(
-                common_properties::_ringStereoAtoms, oAtoms);
-
-            oAtoms.push_back(same * (atom->getIdx() + 1));
-            mol.getAtomWithIdx(*idxIt)->setProp(
-                common_properties::_ringStereoAtoms, oAtoms, true);
-          }
-        }
-      }
-    }
-    if (ringStereoAtoms.size()) {
-      atom->setProp(common_properties::_ringStereoAtoms, ringStereoAtoms, true);
-      return true;
-    }
-  }
-  return false;
-}
-
-#endif
-
 // finds all possible chiral special cases.
 // at the moment this is just candidates for ring stereochemistry
 void findChiralAtomSpecialCases(ROMol &mol,
@@ -585,8 +521,9 @@ void findChiralAtomSpecialCases(ROMol &mol,
           atomIsCandidateForRingStereochem(mol, ratom)) {
         // std::cerr << "  special case!" << std::endl;
         int same = (ratom->getChiralTag() == atom->getChiralTag()) ? 1 : -1;
-          // std::cerr << " atoms " << atom->getIdx() << " and " << ratom->getIdx()
-          //           << " same? " << same << std::endl;
+        // std::cerr << " atoms " << atom->getIdx() << " and " <<
+        // ratom->getIdx()
+        //           << " same? " << same << std::endl;
         ringStereoAtoms.push_back(same * (ratom->getIdx() + 1));
         INT_VECT oringatoms(0);
         ratom->getPropIfPresent(common_properties::_ringStereoAtoms,

--- a/Code/GraphMol/Chirality.cpp
+++ b/Code/GraphMol/Chirality.cpp
@@ -534,11 +534,13 @@ void findChiralAtomSpecialCases(ROMol &mol,
        ++ait) {
     const Atom *atom = *ait;
     if (atomsSeen[atom->getIdx()]) continue;
-    atomsSeen.set(atom->getIdx());
-    if (!mol.getRingInfo()->numAtomRings(atom->getIdx()) ||
+    // atomsUsed.set(atom->getIdx());
+    if (atom->getChiralTag() == Atom::CHI_UNSPECIFIED ||
+        !mol.getRingInfo()->numAtomRings(atom->getIdx()) ||
         !atomIsCandidateForRingStereochem(mol, atom)) {
       continue;
     }
+    // std::cerr << " bfs from " << atom->getIdx() << std::endl;
     // ----------
     // do a BFS from this ring atom along ring bonds and find other candidates.
     std::list<const Atom *> nextAtoms;
@@ -547,11 +549,18 @@ void findChiralAtomSpecialCases(ROMol &mol,
     boost::tie(beg, end) = mol.getAtomBonds(atom);
     while (beg != end) {
       unsigned int bidx = mol[*beg]->getIdx();
+      // std::cerr << "         bond: " << bidx << " "
+      //           << mol.getRingInfo()->numBondRings(bidx) << " ? "
+      //           << bondsSeen[bidx] << std::endl;
       if (!bondsSeen[bidx]) {
         bondsSeen.set(bidx);
         if (mol.getRingInfo()->numBondRings(bidx)) {
           const Atom *oatom = mol[*beg]->getOtherAtom(atom);
+          // std::cerr << "                   oa: " << oatom->getIdx() << " "
+          //           << atomsSeen[oatom->getIdx()] << std::endl;
           if (!atomsSeen[oatom->getIdx()]) {
+            // std::cerr << "                push " << oatom->getIdx()
+            //           << std::endl;
             nextAtoms.push_back(oatom);
             atomsUsed.set(oatom->getIdx());
           }
@@ -569,9 +578,11 @@ void findChiralAtomSpecialCases(ROMol &mol,
       const Atom *ratom = nextAtoms.front();
       nextAtoms.pop_front();
       atomsSeen.set(ratom->getIdx());
+      // std::cerr << "   look at: " << ratom->getIdx() << std::endl;
       if (ratom->getChiralTag() != Atom::CHI_UNSPECIFIED &&
           !ratom->hasProp(common_properties::_CIPCode) &&
           atomIsCandidateForRingStereochem(mol, ratom)) {
+        // std::cerr << "  special case!" << std::endl;
         int same = (ratom->getChiralTag() == atom->getChiralTag()) ? 1 : -1;
         ringStereoAtoms.push_back(same * (ratom->getIdx() + 1));
         INT_VECT oringatoms(0);
@@ -599,7 +610,12 @@ void findChiralAtomSpecialCases(ROMol &mol,
         ++beg;
       }
     }  // end of BFS
-    atom->setProp(common_properties::_ringStereoAtoms, ringStereoAtoms, true);
+    if (ringStereoAtoms.size() != 0) {
+      atom->setProp(common_properties::_ringStereoAtoms, ringStereoAtoms, true);
+    } else {
+      possibleSpecialCases.reset(atom->getIdx());
+    }
+    atomsSeen.set(atom->getIdx());
   }
 }
 
@@ -938,9 +954,9 @@ void assignStereochemistry(ROMol &mol, bool cleanIt, bool force,
   }
 
 #if 0
-      std::cerr<<">>>>>>>>>>>>>\n";
-      std::cerr<<"assign stereochem\n";
-      mol.debugMol(std::cerr);
+  std::cerr << ">>>>>>>>>>>>>\n";
+  std::cerr << "assign stereochem\n";
+  mol.debugMol(std::cerr);
 #endif
 
   // as part of the preparation, we'll loop over the atoms and
@@ -1023,9 +1039,11 @@ void assignStereochemistry(ROMol &mol, bool cleanIt, bool force,
       Chirality::rerankAtoms(mol, atomRanks);
     }
 #if 0
-        std::cout<<"*************** done iteration "<<keepGoing<<" ***********"<<std::endl;
-        mol.debugMol(std::cout);
-        std::cout<<"*************** done iteration "<<keepGoing<<" ***********"<<std::endl;
+    std::cout << "*************** done iteration " << keepGoing
+              << " ***********" << std::endl;
+    mol.debugMol(std::cout);
+    std::cout << "*************** done iteration " << keepGoing
+              << " ***********" << std::endl;
 #endif
   }
 
@@ -1043,9 +1061,15 @@ void assignStereochemistry(ROMol &mol, bool cleanIt, bool force,
     for (ROMol::AtomIterator atIt = mol.beginAtoms(); atIt != mol.endAtoms();
          ++atIt) {
       Atom *atom = *atIt;
+      // std::cerr << " at: " << atom->getIdx() << " " << atom->getChiralTag()
+      //           << " " << atom->hasProp(common_properties::_CIPCode) << " "
+      //           << possibleSpecialCases[atom->getIdx()] << " "
+      //           << atom->hasProp(common_properties::_ringStereoAtoms)
+      //           << std::endl;
       if (atom->getChiralTag() != Atom::CHI_UNSPECIFIED &&
           !atom->hasProp(common_properties::_CIPCode) &&
-          !possibleSpecialCases[atom->getIdx()]) {
+          (!possibleSpecialCases[atom->getIdx()] ||
+           !atom->hasProp(common_properties::_ringStereoAtoms))) {
         atom->setChiralTag(Atom::CHI_UNSPECIFIED);
 
         // If the atom has an explicit hydrogen and no charge, that H

--- a/Code/GraphMol/Chirality.cpp
+++ b/Code/GraphMol/Chirality.cpp
@@ -476,7 +476,8 @@ void findChiralAtomSpecialCases(ROMol &mol,
         !atomIsCandidateForRingStereochem(mol, atom)) {
       continue;
     }
-    // do a BFS from this ring atom along ring bonds and find other candidates.
+    // do a BFS from this ring atom along ring bonds and find other
+    // stereochemistry candidates.
     std::list<const Atom *> nextAtoms;
     // start with finding viable neighbors
     ROMol::OEDGE_ITER beg, end;

--- a/Code/GraphMol/molopstest.cpp
+++ b/Code/GraphMol/molopstest.cpp
@@ -6243,6 +6243,37 @@ void testGithubIssue962() {
   BOOST_LOG(rdInfoLog) << "\tdone" << std::endl;
 }
 
+void testGithubIssue1021() {
+  BOOST_LOG(rdInfoLog)
+      << "-----------------------\n Testing github issue 1021: "
+         "AssignStereochemistry() giving incorrect results after "
+         "FastFindRings()"
+      << std::endl;
+  {
+    std::string smi = "C[C@H]1CC2CCCC(C1)[C@H]2N";
+    RWMol *m = SmilesToMol(smi);
+    TEST_ASSERT(m);
+    TEST_ASSERT(m->getNumAtoms() == 11);
+    TEST_ASSERT(m->getAtomWithIdx(1)->getChiralTag() != Atom::CHI_UNSPECIFIED);
+    TEST_ASSERT(m->getAtomWithIdx(9)->getChiralTag() != Atom::CHI_UNSPECIFIED);
+
+    m->clearComputedProps();
+    bool cleanit = true, force = true;
+    MolOps::assignStereochemistry(*m, cleanit, force);
+    TEST_ASSERT(m->getAtomWithIdx(1)->getChiralTag() != Atom::CHI_UNSPECIFIED);
+    TEST_ASSERT(m->getAtomWithIdx(9)->getChiralTag() != Atom::CHI_UNSPECIFIED);
+
+    m->clearComputedProps();
+    MolOps::fastFindRings(*m);
+    MolOps::assignStereochemistry(*m, cleanit, force);
+    TEST_ASSERT(m->getAtomWithIdx(1)->getChiralTag() != Atom::CHI_UNSPECIFIED);
+    TEST_ASSERT(m->getAtomWithIdx(9)->getChiralTag() != Atom::CHI_UNSPECIFIED);
+
+    delete m;
+  }
+  BOOST_LOG(rdInfoLog) << "\tdone" << std::endl;
+}
+
 int main() {
   RDLog::InitLogs();
 // boost::logging::enable_logs("rdApp.debug");
@@ -6334,8 +6365,10 @@ int main() {
   testSimpleAromaticity();
   testCustomAromaticity();
   testGithubIssue908();
-#endif
   testGithubIssue962();
+
+#endif
+  testGithubIssue1021();
 
   return 0;
 }

--- a/Code/GraphMol/molopstest.cpp
+++ b/Code/GraphMol/molopstest.cpp
@@ -4643,6 +4643,7 @@ void _renumberTest(const ROMol *m) {
     }
 
     std::string nSmi = MolToSmiles(*nm, true);
+    if (nSmi != refSmi) std::cerr << refSmi << std::endl << nSmi << std::endl;
     TEST_ASSERT(nSmi == refSmi);
     delete nm;
   }


### PR DESCRIPTION
This changes the way ring stereochemistry is identified and renders it insensitive to the details of the ring-finding algorithm.

The new implementation is about the same speed as the old one (maybe a bit quicker). It could almost certainly be optimized, but I want to get the fix in first and deal with that later when time arises.

It's been through valgrind and is clean.
