### PR TITLE
Cause ImportError from failed dlopen of the rdBase.so shared library to propagate.

### DIFF
--- a/rdkit/__init__.py
+++ b/rdkit/__init__.py
@@ -2,4 +2,5 @@ try:
     from .rdBase import rdkitVersion as __version__
 except ImportError:
     __version__='Unknown'
+    raise
 


### PR DESCRIPTION
Without this, it's very easy to get a SegFault when importing RDKit
binaries into a python interpreter with a UCS2 vs UCS4 symbol
mismatch. For example:

$ python -c "import rdkit.rdBase"
Segmentation fault

A UCS2 vs UCS4 mismatch should throw the more intelligible stack trace:

$ python -c "import rdkit.rdBase"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "rdkit/__init__.py", line 2, in <module>
    from .rdBase import rdkitVersion as __version__
ImportError: /path/to/lib/libboost_python.so.1.59.0: undefined symbol: PyUnicodeUCS2_FromEncodedObject

Was there a good reason to not propagate ImportError? This doesn't seem to detract from the goal of #380 that originally put the code in there. 