### PR TITLE
Preserve bond direction in fragmentOnBonds

### DIFF
--- a/Code/GraphMol/ChemTransforms/MolFragmenter.cpp
+++ b/Code/GraphMol/ChemTransforms/MolFragmenter.cpp
@@ -401,6 +401,8 @@ ROMol *fragmentOnBonds(
     unsigned int bidx = bond->getBeginAtomIdx();
     unsigned int eidx = bond->getEndAtomIdx();
     Bond::BondType bT = bond->getBondType();
+    Bond::BondDir bD = bond->getBondDir();
+    unsigned int bondidx;
     res->removeBond(bidx, eidx);
     if (nCutsPerAtom) {
       (*nCutsPerAtom)[bidx] += 1;
@@ -419,9 +421,12 @@ ROMol *fragmentOnBonds(
       }
       unsigned int idx1 = res->addAtom(at1, false, true);
       if (bondTypes) bT = (*bondTypes)[i];
-      res->addBond(eidx, at1->getIdx(), bT);
+      bondidx = res->addBond(eidx, at1->getIdx(), bT) - 1;
+      res->getBondWithIdx(bondidx)->setBondDir(bD);
+      
       unsigned int idx2 = res->addAtom(at2, false, true);
-      res->addBond(bidx, at2->getIdx(), bT);
+      bondidx = res->addBond(at2->getIdx(), bidx, bT) - 1;
+      res->getBondWithIdx(bondidx)->setBondDir(bD);
 
       // figure out if we need to change the stereo tags on the atoms:
       if (mol.getAtomWithIdx(bidx)->getChiralTag() ==


### PR DESCRIPTION
When I use FragmentOnBonds() to fragment on a directional bond involved in double bond stereochemistry, the resulting structure no longer contains the direction.

```
>>> from rdkit import Chem
>>> mol = Chem.MolFromSmiles("F/C=C/F")
>>> frag_mol = Chem.FragmentOnBonds(mol, [0], dummyLabels=[(0,0)])
>>> Chem.MolToSmiles(frag_mol, isomericSmiles=True)
'[*]C=CF.[*]F'
```

I would like to preserve that information, so I can re-connect the fragments and get the original structure. I would like resulting SMILES to be equivalent to:

```
>>> expected_mol = Chem.MolFromSmiles("F*.*/C=C/F")
>>> Chem.MolToSmiles(expected_mol, isomericSmiles=True)
'[*]/C=C/F.[*]F'
```

The patch is a sketch of a solution meant for discussion. It is not complete, for several reasons:

1)  I changed the atom order for the second bonds If the bond to cut connected a1-a2 then the old implementation made a1-\* , a2-\* . I changed it to a1-*, *-a2 so I could use the same BondDir value for both newly created bonds. The documentation does not specify which atom is which, but downstream code may depend on it.  If they should not change, then there needs to be mapping from BEGINWEDGE<->BEGINDASH and ENDDOWNRIGHT<->ENDUPRIGHT.

2) There may need to be a flag to enable/disable the option because existing code may expect the bond direction to disappear. If so, this would also need to be in the Python and Java APIs and the documentation.

3) The existing function lets you specify a alternate bond type. It probably makes no sense to have a bond direction on a triple bond. Should BondDir only be preserved for single bonds, or caveat emptor?

4) I did not add a test case as I couldn't figure out the test system. (Eg, "make test" gives many failures, including in testChemTransforms, where manual testing reports "Testing a former crash in replaceCore / terminate called throwing an exceptionAbort".) I probably don't have my test environment set up correctly.
