### PR TITLE
Fixes #1041

### DIFF
--- a/Code/GraphMol/Atom.h
+++ b/Code/GraphMol/Atom.h
@@ -20,6 +20,7 @@
 #include <boost/foreach.hpp>
 
 // ours
+#include <RDGeneral/Invariant.h>
 #include <Query/QueryObjects.h>
 #include <RDGeneral/types.h>
 #include <RDGeneral/RDProps.h>
@@ -120,7 +121,10 @@ class Atom : public RDProps {
   std::string getSymbol() const;
 
   //! returns a reference to the ROMol that owns this Atom
-  ROMol &getOwningMol() const { return *dp_mol; };
+  ROMol &getOwningMol() const {
+    PRECONDITION(dp_mol, "no owner");
+    return *dp_mol;
+  };
 
   //! returns our index within the ROMol
   unsigned int getIdx() const { return d_index; };

--- a/Code/GraphMol/Bond.h
+++ b/Code/GraphMol/Bond.h
@@ -14,7 +14,7 @@
 #include <iostream>
 
 // Ours
-// FIX: grn...
+#include <RDGeneral/Invariant.h>
 #include <Query/QueryObjects.h>
 #include <RDGeneral/types.h>
 #include <RDGeneral/RDProps.h>
@@ -44,7 +44,7 @@ typedef boost::shared_ptr<Atom> ATOM_SPTR;
           clients who need to store extra data on Bond objects.
 
 */
-class Bond : public RDProps{
+class Bond : public RDProps {
   friend class RWMol;
   friend class ROMol;
 
@@ -144,7 +144,10 @@ class Bond : public RDProps{
   bool getIsConjugated() const { return df_isConjugated; };
 
   //! returns a reference to the ROMol that owns this Bond
-  ROMol &getOwningMol() const { return *dp_mol; };
+  ROMol &getOwningMol() const {
+    PRECONDITION(dp_mol, "no owner");
+    return *dp_mol;
+  };
   //! sets our owning molecule
   void setOwningMol(ROMol *other);
   //! sets our owning molecule

--- a/Code/GraphMol/Wrap/Atom.cpp
+++ b/Code/GraphMol/Wrap/Atom.cpp
@@ -233,7 +233,7 @@ struct atom_wrapper {
 
         .def("GetOwningMol", &Atom::getOwningMol,
              "Returns the Mol that owns this atom.\n",
-             python::return_value_policy<python::reference_existing_object>())
+             python::return_internal_reference<>())
 
         .def("GetNeighbors", AtomGetNeighbors,
              "Returns a read-only sequence of the atom's neighbors\n")
@@ -396,9 +396,10 @@ struct atom_wrapper {
         .def("GetAtomMapNum", &Atom::getAtomMapNum,
              "Gets the atoms map number, returns 0 if not set")
         .def("SetAtomMapNum", &Atom::setAtomMapNum,
-             (python::arg("self"), python::arg("mapno"), python::arg("strict") = false),
+             (python::arg("self"), python::arg("mapno"),
+              python::arg("strict") = false),
              "Sets the atoms map number, a value of 0 clears the atom map");
-    
+
     python::enum_<Atom::HybridizationType>("HybridizationType")
         .value("UNSPECIFIED", Atom::UNSPECIFIED)
         .value("SP", Atom::SP)
@@ -433,38 +434,41 @@ These cannot currently be constructed directly from Python\n";
               python::arg("maintainOrder") = true),
              "combines the query from other with ours");
 
-    python::def("GetAtomRLabel", getAtomRLabel,
-        (python::arg("atom")),
+    python::def(
+        "GetAtomRLabel", getAtomRLabel, (python::arg("atom")),
         "Returns the atom's MDL AtomRLabel (this is an integer from 0 to 99)");
     python::def("SetAtomRLabel", setAtomRLabel,
-        (python::arg("atom"), python::arg("rlabel")),
-        "Sets the atom's MDL RLabel (this is an integer from 0 to 99).\nSetting to 0 clears the rlabel.");
-    
-    python::def("GetAtomAlias", getAtomAlias,
-        (python::arg("atom")),
-        "Returns the atom's MDL alias text");
+                (python::arg("atom"), python::arg("rlabel")),
+                "Sets the atom's MDL RLabel (this is an integer from 0 to "
+                "99).\nSetting to 0 clears the rlabel.");
+
+    python::def("GetAtomAlias", getAtomAlias, (python::arg("atom")),
+                "Returns the atom's MDL alias text");
     python::def("SetAtomAlias", setAtomAlias,
-        (python::arg("atom"), python::arg("rlabel")),
-        "Sets the atom's MDL alias text.\nSetting to an empty string clears the alias.");
-    python::def("GetAtomValue", getAtomValue,
-        (python::arg("atom")),
-        "Returns the atom's MDL alias text");
+                (python::arg("atom"), python::arg("rlabel")),
+                "Sets the atom's MDL alias text.\nSetting to an empty string "
+                "clears the alias.");
+    python::def("GetAtomValue", getAtomValue, (python::arg("atom")),
+                "Returns the atom's MDL alias text");
     python::def("SetAtomValue", setAtomValue,
-        (python::arg("atom"), python::arg("rlabel")),
-        "Sets the atom's MDL alias text.\nSetting to an empty string clears the alias.");
+                (python::arg("atom"), python::arg("rlabel")),
+                "Sets the atom's MDL alias text.\nSetting to an empty string "
+                "clears the alias.");
 
     python::def("GetSupplementalSmilesLabel", getSupplementalSmilesLabel,
-        (python::arg("atom")),
-        "Gets the supplemental smiles label on an atom, returns an empty string if not present.");
-    python::def("SetSupplementalSmilesLabel", setSupplementalSmilesLabel,
+                (python::arg("atom")),
+                "Gets the supplemental smiles label on an atom, returns an "
+                "empty string if not present.");
+    python::def(
+        "SetSupplementalSmilesLabel", setSupplementalSmilesLabel,
         (python::arg("atom"), python::arg("label")),
-        "Sets a supplemental label on an atom that is written to the smiles string.\n" \
-        ">>> m = Chem.MolFromSmiles(\"C\")\n"                           \
-        ">>> Chem.SetSupplementalSmilesLabel(m.GetAtomWithIdx(0), '<xxx>')\n" \
-        ">>> Chem.MolToSmiles(m)\n"                                     \
+        "Sets a supplemental label on an atom that is written to the smiles "
+        "string.\n"
+        ">>> m = Chem.MolFromSmiles(\"C\")\n"
+        ">>> Chem.SetSupplementalSmilesLabel(m.GetAtomWithIdx(0), '<xxx>')\n"
+        ">>> Chem.MolToSmiles(m)\n"
         "'C<xxx>'\n");
   }
-  
 };
 }  // end of namespace
 void wrap_atom() { RDKit::atom_wrapper::wrap(); }

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -3775,5 +3775,15 @@ CAS<~>
     # just need to test that this exists:
     self.assertTrue(Chem.BondDir.EITHERDOUBLE)
 
+  def testGithub1041(self):
+    a = Chem.Atom(6)
+    self.assertRaises(RuntimeError,lambda : a.GetOwningMol())
+    self.assertRaises(RuntimeError,lambda : a.GetNeighbors())
+    self.assertRaises(RuntimeError,lambda : a.GetBonds())
+    self.assertRaises(RuntimeError,lambda : a.IsInRing())
+    self.assertRaises(RuntimeError,lambda : a.IsInRingSize(4))
+
+
+
 if __name__ == '__main__':
   unittest.main()

--- a/Code/GraphMol/test1.cpp
+++ b/Code/GraphMol/test1.cpp
@@ -215,7 +215,8 @@ void testClearMol() {
   TEST_ASSERT(m2.getAtomBookmarks()->empty());
   TEST_ASSERT(m2.getBondBookmarks()->empty());
 
-  TEST_ASSERT(m2.hasProp(RDKit::detail::computedPropName));  // <- github issue 176
+  TEST_ASSERT(
+      m2.hasProp(RDKit::detail::computedPropName));  // <- github issue 176
   TEST_ASSERT(m2.getPropList().size() == 1);
 
   BOOST_LOG(rdInfoLog) << "Finished" << std::endl;
@@ -1299,6 +1300,34 @@ void testGithub381() {
 void testGithub381() {}
 #endif
 
+void testGithub1041() {
+  BOOST_LOG(rdErrorLog) << "-------------------------------------" << std::endl;
+  BOOST_LOG(rdErrorLog) << "    Test github1041: Segfault for atom with no "
+                           "owner (expect some warnings)"
+                        << std::endl;
+  {
+    Atom at(6);
+    bool ok = false;
+    try {
+      at.getOwningMol();
+    } catch (const Invar::Invariant &err) {
+      ok = true;
+    }
+    TEST_ASSERT(ok);
+  }
+  {
+    Bond b;
+    bool ok = false;
+    try {
+      b.getOwningMol();
+    } catch (const Invar::Invariant &err) {
+      ok = true;
+    }
+    TEST_ASSERT(ok);
+  }
+  BOOST_LOG(rdErrorLog) << "  done" << std::endl;
+}
+
 // -------------------------------------------------------------------
 int main() {
   RDLog::InitLogs();
@@ -1325,6 +1354,7 @@ int main() {
   testAtomListLineRoundTrip();
   testGithub608();
   testGithub381();
+  testGithub1041();
 
   return 0;
 }


### PR DESCRIPTION
The "side effect" of this is that calling `{Atom,Bond}::getOwningMol()` now has a PRECONDITION that the owning molecule is actually set.
Given that those methods both dereference the pointer before returning it, I am *amazed* that this hasn't been a problem previously. Still, good to fix it now.
