### PR TITLE
Conformer GetPos returns a numpy array rather than a tuple of tuples

### DIFF
--- a/Code/GraphMol/Wrap/Conformer.cpp
+++ b/Code/GraphMol/Wrap/Conformer.cpp
@@ -30,7 +30,7 @@ RDGeom::Point3D GetAtomPos(const Conformer *conf, unsigned int aid) {
 }
 
 PyObject* GetPos(const Conformer *conf) {
-    RDGeom::POINT3D_VECT pos = conf->getPositions();
+    const RDGeom::POINT3D_VECT &pos = conf->getPositions();
 
     // define a 2D array with the following size
     npy_intp dims[2];

--- a/Code/GraphMol/Wrap/Conformer.cpp
+++ b/Code/GraphMol/Wrap/Conformer.cpp
@@ -83,7 +83,7 @@ struct conformer_wrapper {
         .def("SetId", &Conformer::setId, "Set the ID of the conformer\n")
 
         .def("GetAtomPosition", GetAtomPos, "Get the posistion of an atom\n")
-
+	.def("GetPositions", GetPos, "Get positions of all the atoms\n")
         .def("SetAtomPosition", SetAtomPos,
              "Set the position of the specified atom\n")
         .def("SetAtomPosition", (void (Conformer::*)(unsigned int, const RDGeom::Point3D&)) &

--- a/Code/GraphMol/Wrap/Conformer.cpp
+++ b/Code/GraphMol/Wrap/Conformer.cpp
@@ -19,13 +19,37 @@
 #include <GraphMol/Conformer.h>
 #include <RDBoost/PySequenceHolder.h>
 //#include "seqs.hpp"
-
+#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+#include <numpy/arrayobject.h>
 namespace python = boost::python;
 
 namespace RDKit {
 RDGeom::Point3D GetAtomPos(const Conformer *conf, unsigned int aid) {
   RDGeom::Point3D res = conf->getAtomPos(aid);
   return res;
+}
+
+PyObject* GetPos(const Conformer *conf) {
+    RDGeom::POINT3D_VECT pos = conf->getPositions();
+
+    // define a 2D array with the following size
+    npy_intp dims[2];
+    dims[0] = pos.size();
+    dims[1] = 3;
+
+    // initialize the array
+    PyArrayObject *res = (PyArrayObject *)PyArray_SimpleNew(2, dims, NPY_DOUBLE);
+
+    // represent the array as a 1D/flat array of doubles
+    double *resData = reinterpret_cast<double *>(PyArray_DATA(res));
+
+    // manually insert the data, 3 corresponsd to the x, y and z dimensions
+    for (unsigned int i = 0; i < pos.size(); ++i) {
+        resData[3*i+0] = pos[i].x;
+        resData[3*i+1] = pos[i].y;
+        resData[3*i+2] = pos[i].z;
+    }
+    return PyArray_Return(res);
 }
 
 void SetAtomPos(Conformer *conf, unsigned int aid, python::object loc) {

--- a/Code/GraphMol/Wrap/rdchem.h
+++ b/Code/GraphMol/Wrap/rdchem.h
@@ -10,6 +10,8 @@
 #ifndef _RDCHEM_INCL_
 #define _RDCHEM_INCL_
 
+#define PY_ARRAY_UNIQUE_SYMBOL rdchem_array_API
+
 namespace RDKit {
 class ConformerException;
 }

--- a/Code/GraphMol/Wrap/testConformer.py
+++ b/Code/GraphMol/Wrap/testConformer.py
@@ -123,5 +123,23 @@ class TestCase(unittest.TestCase):
     self.assertTrue(confs == ())
 
 
+  def test5PositionsArray(self):
+    smi = 'c1ccccc1'
+    m = Chem.MolFromSmiles(smi)
+    addConf(m)
+
+    confs = m.GetConformers()
+    self.assertTrue(len(confs) == 1)
+
+    for conf in confs:
+      pos = conf.GetPositions()
+      self.assertTrue(pos.shape, (6,3))
+
+    m.RemoveAllConformers()
+    self.assertTrue(m.GetNumConformers() == 0)
+    confs = m.GetConformers()
+    self.assertTrue(confs == ())
+
+
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
hi Greg, 

The conformer GetPositions now  returns a numpy array rather than a tuple of tuples - I think this will be nice to most users, since probably people convert it into numpy manually anyway. 

But it's very minor and was mainly an exercise so feel free to drop it 