### PR TITLE
Provide SVG output from the cartridge

### DIFF
--- a/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
@@ -328,7 +328,6 @@ void MolDraw2D::drawMolecule(const ROMol &mol, const std::string &legend,
     // the 0.94 is completely empirical and was brought over from Python
     Point2D loc =
         getAtomCoords(std::make_pair(panel_width_ / 2., 0.94 * panel_height_));
-
     double o_font_size = fontSize();
     setFontSize(options_.legendFontSize /
                 scale_);  // set the font size to about 12 pixels high

--- a/Code/GraphMol/MolDraw2D/MolDraw2DUtils.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DUtils.cpp
@@ -8,10 +8,17 @@
 //  of the RDKit source tree.
 //
 #include <GraphMol/MolDraw2D/MolDraw2DUtils.h>
+#include <GraphMol/MolDraw2D/MolDraw2D.h>
+
 #include <GraphMol/RWMol.h>
 #include <GraphMol/MolOps.h>
 #include <GraphMol/Depictor/RDDepictor.h>
 #include <GraphMol/FileParsers/MolFileStereochem.h>
+
+#include <RDGeneral/BoostStartInclude.h>
+#include <boost/property_tree/ptree.hpp>
+#include <boost/property_tree/json_parser.hpp>
+#include <RDGeneral/BoostEndInclude.h>
 
 namespace RDKit {
 namespace MolDraw2DUtils {
@@ -59,5 +66,27 @@ void prepareMolForDrawing(RWMol &mol, bool kekulize, bool addChiralHs,
     WedgeMolBonds(mol, &mol.getConformer());
   }
 }
+
+void updateDrawerParamsFromJSON(MolDraw2D &drawer, const char *json) {
+  PRECONDITION(json, "no parameter string");
+  updateDrawerParamsFromJSON(drawer, std::string(json));
+};
+#define PT_OPT_GET(opt) opts.opt = pt.get(#opt, opts.opt)
+
+void updateDrawerParamsFromJSON(MolDraw2D &drawer, const std::string &json) {
+  if (json == "") return;
+  std::istringstream ss;
+  ss.str(json);
+  MolDrawOptions &opts = drawer.drawOptions();
+  boost::property_tree::ptree pt;
+  boost::property_tree::read_json(ss, pt);
+  PT_OPT_GET(atomLabelDeuteriumTritium);
+  PT_OPT_GET(dummiesAreAttachments);
+  //
+  //
+  // opts.atomLabelDeuteriumTritium =
+  //     pt.get("atomLabelDeuteriumTritium", opts.atomLabelDeuteriumTritium);
 }
-}
+
+}  // end of MolDraw2DUtils namespace
+}  // end of RDKit namespace

--- a/Code/GraphMol/MolDraw2D/MolDraw2DUtils.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DUtils.cpp
@@ -16,6 +16,8 @@
 #include <GraphMol/FileParsers/MolFileStereochem.h>
 
 #include <RDGeneral/BoostStartInclude.h>
+#include <boost/foreach.hpp>
+#include <boost/lexical_cast.hpp>
 #include <boost/property_tree/ptree.hpp>
 #include <boost/property_tree/json_parser.hpp>
 #include <RDGeneral/BoostEndInclude.h>
@@ -73,6 +75,20 @@ void updateDrawerParamsFromJSON(MolDraw2D &drawer, const char *json) {
 };
 #define PT_OPT_GET(opt) opts.opt = pt.get(#opt, opts.opt)
 
+void get_colour_option(boost::property_tree::ptree *pt, const char *pnm,
+                       DrawColour &colour) {
+  PRECONDITION(pnm && strlen(pnm), "bad property name");
+  if (pt->find(pnm) == pt->not_found()) return;
+
+  boost::property_tree::ptree::const_iterator itm = pt->get_child(pnm).begin();
+  colour.get<0>() = itm->second.get_value<float>();
+  ++itm;
+  colour.get<1>() = itm->second.get_value<float>();
+  ++itm;
+  colour.get<2>() = itm->second.get_value<float>();
+  ++itm;
+}
+
 void updateDrawerParamsFromJSON(MolDraw2D &drawer, const std::string &json) {
   if (json == "") return;
   std::istringstream ss;
@@ -82,10 +98,25 @@ void updateDrawerParamsFromJSON(MolDraw2D &drawer, const std::string &json) {
   boost::property_tree::read_json(ss, pt);
   PT_OPT_GET(atomLabelDeuteriumTritium);
   PT_OPT_GET(dummiesAreAttachments);
-  //
-  //
-  // opts.atomLabelDeuteriumTritium =
-  //     pt.get("atomLabelDeuteriumTritium", opts.atomLabelDeuteriumTritium);
+  PT_OPT_GET(circleAtoms);
+  PT_OPT_GET(continuousHighlight);
+  PT_OPT_GET(flagCloseContactsDist);
+  PT_OPT_GET(includeAtomTags);
+  PT_OPT_GET(clearBackground);
+  PT_OPT_GET(legendFontSize);
+  PT_OPT_GET(multipleBondOffset);
+  PT_OPT_GET(padding);
+  PT_OPT_GET(additionalAtomLabelPadding);
+  get_colour_option(&pt, "highlightColour", opts.highlightColour);
+  get_colour_option(&pt, "backgroundColour", opts.backgroundColour);
+  get_colour_option(&pt, "legendColour", opts.legendColour);
+  if (pt.find("atomLabels") != pt.not_found()) {
+    BOOST_FOREACH (boost::property_tree::ptree::value_type const &item,
+                   pt.get_child("atomLabels")) {
+      opts.atomLabels[boost::lexical_cast<int>(item.first)] =
+          item.second.get_value<std::string>();
+    }
+  }
 }
 
 }  // end of MolDraw2DUtils namespace

--- a/Code/GraphMol/MolDraw2D/MolDraw2DUtils.h
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DUtils.h
@@ -15,6 +15,7 @@
 // ****************************************************************************
 
 namespace RDKit {
+class MolDraw2D;
 namespace MolDraw2DUtils {
 //! Does some cleanup operations on the molecule to prepare it to draw nicely
 /*
@@ -36,6 +37,9 @@ problematic if the molecules have been modified post santitization.
 void prepareMolForDrawing(RWMol &mol, bool kekulize = true,
                           bool addChiralHs = true, bool wedgeBonds = true,
                           bool forceCoords = false);
+
+void updateDrawerParamsFromJSON(MolDraw2D &drawer, const char *json);
+void updateDrawerParamsFromJSON(MolDraw2D &drawer, const std::string &json);
 }
 }
 #endif  // MOLDRAW2DUTILS_H

--- a/Code/GraphMol/MolDraw2D/test1.cpp
+++ b/Code/GraphMol/MolDraw2D/test1.cpp
@@ -1422,7 +1422,7 @@ void testCrossedBonds() {
     drawer.finishDrawing();
     outs.close();
   }
-  std::cerr << "Done" << std::endl;
+  std::cerr << " Done" << std::endl;
 }
 void test10DrawSecondMol() {
   std::cout << " ----------------- Testing drawing a second molecule"
@@ -1668,6 +1668,28 @@ void test12DrawMols() {
   std::cerr << " Done" << std::endl;
 }
 
+void test13JSONConfig() {
+  std::cerr << " ----------------- Test JSON Configuration" << std::endl;
+  {
+    std::string smiles = "CCO";
+    RWMol *m = SmilesToMol(smiles);
+    TEST_ASSERT(m);
+    MolDraw2DUtils::prepareMolForDrawing(*m);
+    MolDraw2DSVG drawer(250, 200);
+    const char *json = "{\"legendColour\":[1.0,0.5,1.0]}";
+    MolDraw2DUtils::updateDrawerParamsFromJSON(drawer, json);
+    drawer.drawMolecule(*m, "foo");
+    drawer.finishDrawing();
+    std::string text = drawer.getDrawingText();
+    std::ofstream outs("test13_1.svg");
+    outs << text;
+    TEST_ASSERT(text.find("text-anchor:start;fill:#FF7FFF") !=
+                std::string::npos);
+    outs.close();
+  }
+  std::cerr << " Done" << std::endl;
+}
+
 int main() {
   RDLog::InitLogs();
 #if 1
@@ -1693,6 +1715,7 @@ int main() {
   testCrossedBonds();
   test10DrawSecondMol();
   test11DrawMolGrid();
-#endif
   test12DrawMols();
+#endif
+  test13JSONConfig();
 }

--- a/Code/GraphMol/MolDraw2D/test1.cpp
+++ b/Code/GraphMol/MolDraw2D/test1.cpp
@@ -1746,9 +1746,7 @@ int main() {
   test10DrawSecondMol();
   test11DrawMolGrid();
   test12DrawMols();
-<<<<<<< HEAD
-  #endif test13JSONConfig();
-=======
+#endif
+  test13JSONConfig();
   testGithub1090();
->>>>>>> origin/master
 }

--- a/Code/PgSQL/rdkit/CMakeLists.txt
+++ b/Code/PgSQL/rdkit/CMakeLists.txt
@@ -93,9 +93,9 @@ if(RDK_BUILD_INCHI_SUPPORT)
   set(pgRDKitLibList "${pgRDKitLibList}RDInchiLib;${INCHI_LIBRARIES};")
 endif(RDK_BUILD_INCHI_SUPPORT)
 set(pgRDKitLibList "${pgRDKitLibList}"
-    "MolHash;FMCS;ChemReactions;ChemTransforms;"
+    "MolDraw2D;MolTransforms;MolHash;FMCS;ChemReactions;ChemTransforms;"
     "FileParsers;SmilesParse;Fingerprints;Subgraphs;Descriptors;"
-    "PartialCharges;SubstructMatch;GraphMol;DataStructs;Depictor;"
+    "PartialCharges;SubstructMatch;GraphMol;EigenSolvers;DataStructs;Depictor;"
     "RDGeometryLib;RDGeneral")
 foreach(pgRDKitLib ${pgRDKitLibList})
   set(pgRDKitLibs "${pgRDKitLibs}${pgRDKitLib}${pgRDKitLibSuffix};")

--- a/Code/PgSQL/rdkit/adapter.cpp
+++ b/Code/PgSQL/rdkit/adapter.cpp
@@ -662,16 +662,12 @@ extern "C" CROMol MolAdjustQueryProperties(CROMol i, const char *params) {
   MolOps::AdjustQueryParameters p;
 
   if (params && strlen(params)) {
-    // try {
-    parseAdjustQueryParameters(p, params);
-    // } catch (...) {
-    //   ereport(
-    //       WARNING,
-    //       (errcode(ERRCODE_WARNING),
-    //        errmsg(
-    //            "adjustQueryProperties: Invalid argument \'params\'
-    //            ignored")));
-    // }
+    try {
+      parseAdjustQueryParameters(p, params);
+    } catch (...) {
+      elog(WARNING,
+           "adjustQueryProperties: Invalid argument \'params\' ignored");
+    }
   }
   ROMol *mol = MolOps::adjustQueryProperties(*im, &p);
   return (CROMol)mol;
@@ -684,11 +680,14 @@ extern "C" char *MolGetSVG(CROMol i, unsigned int w, unsigned int h,
   MolDraw2DUtils::prepareMolForDrawing(*im);
   std::string slegend(legend ? legend : "");
   MolDraw2DSVG drawer(w, h);
-
-#if 0
   if (params && strlen(params)) {
+    try {
+      MolDraw2DUtils::updateDrawerParamsFromJSON(drawer, params);
+    } catch (...) {
+      elog(WARNING,
+           "adjustQueryProperties: Invalid argument \'params\' ignored");
+    }
   }
-#endif
   drawer.drawMolecule(*im, legend);
   drawer.finishDrawing();
   std::string txt = drawer.getDrawingText();

--- a/Code/PgSQL/rdkit/adapter.cpp
+++ b/Code/PgSQL/rdkit/adapter.cpp
@@ -391,12 +391,12 @@ extern "C" bytea *makeMolSignature(CROMol data) {
 
     if (res) {
       std::string sres = BitVectToBinaryText(*res);
-      
+
       unsigned int varsize = VARHDRSZ + sres.size();
-      ret = (bytea *) palloc0(varsize);
+      ret = (bytea *)palloc0(varsize);
       memcpy(VARDATA(ret), sres.data(), sres.size());
       SET_VARSIZE(ret, varsize);
-      
+
       delete res;
       res = 0;
     }
@@ -710,14 +710,14 @@ extern "C" Bfp *deconstructCBfp(CBfp data) {
 extern "C" BfpSignature *makeBfpSignature(CBfp data) {
   std::string *ebv = (std::string *)data;
   int siglen = ebv->size();
-  
+
   unsigned int varsize = sizeof(BfpSignature) + siglen;
-  BfpSignature * res = (BfpSignature *)palloc0(varsize);
+  BfpSignature *res = (BfpSignature *)palloc0(varsize);
   SET_VARSIZE(res, varsize);
 
   res->weight = bitstringWeight(siglen, (uint8 *)ebv->data());
   memcpy(res->fp, ebv->data(), siglen);
-  
+
   return res;
 }
 
@@ -843,9 +843,8 @@ extern "C" bytea *makeLowSparseFingerPrint(CSfp data, int numInts) {
   return res;
 }
 
-extern "C" void countOverlapValues(bytea *sign, CSfp data,
-                                   int numBits, int *sum, int *overlapSum,
-                                   int *overlapN) {
+extern "C" void countOverlapValues(bytea *sign, CSfp data, int numBits,
+                                   int *sum, int *overlapSum, int *overlapN) {
   SparseFP *v = (SparseFP *)data;
   SparseFP::StorageType::const_iterator iter;
 
@@ -875,8 +874,8 @@ extern "C" void countOverlapValues(bytea *sign, CSfp data,
   }
 }
 
-extern "C" void countLowOverlapValues(bytea *sign, CSfp data,
-                                      int numInts, int *querySum, int *keySum,
+extern "C" void countLowOverlapValues(bytea *sign, CSfp data, int numInts,
+                                      int *querySum, int *keySum,
                                       int *overlapUp, int *overlapDown) {
   SparseFP *v = (SparseFP *)data;
   SparseFP::StorageType::const_iterator iter;
@@ -1401,7 +1400,7 @@ extern "C" CBfp makeMACCSBFP(CROMol data) {
 }
 
 extern "C" CBfp makeAvalonBFP(CROMol data, bool isQuery,
-			      unsigned int bitFlags) {
+                              unsigned int bitFlags) {
 #ifdef BUILD_AVALON_SUPPORT
   ROMol *mol = (ROMol *)data;
   ExplicitBitVect *res = NULL;
@@ -1525,7 +1524,7 @@ extern "C" CChemicalReaction parseChemReactBlob(char *data, int len) {
 }
 
 extern "C" char *makeChemReactText(CChemicalReaction data, int *len,
-				   bool asSmarts) {
+                                   bool asSmarts) {
   ChemicalReaction *rxn = (ChemicalReaction *)data;
 
   try {
@@ -1635,12 +1634,12 @@ extern "C" bytea *makeReactionSign(CChemicalReaction data) {
 
     if (res) {
       std::string sres = BitVectToBinaryText(*res);
-      
+
       unsigned int varsize = VARHDRSZ + sres.size();
-      ret = (bytea *) palloc0(varsize);
+      ret = (bytea *)palloc0(varsize);
       memcpy(VARDATA(ret), sres.data(), sres.size());
       SET_VARSIZE(ret, varsize);
-      
+
       delete res;
       res = 0;
     }
@@ -1831,8 +1830,8 @@ extern "C" int reactioncmp(CChemicalReaction rxn, CChemicalReaction rxn2) {
   return -1;
 }
 
-extern "C" CSfp makeReactionDifferenceSFP(
-    CChemicalReaction data, int size, int fpType) {
+extern "C" CSfp makeReactionDifferenceSFP(CChemicalReaction data, int size,
+                                          int fpType) {
   ChemicalReaction *rxn = (ChemicalReaction *)data;
   SparseFP *res = NULL;
 
@@ -1898,22 +1897,7 @@ extern "C" char *computeMolHash(CROMol data, int *len) {
     text.clear();
   }
   *len = text.length();
-  return (char *)text.c_str();
-}
-
-extern "C" char *  // TEMP
-    Mol2Smiles(CROMol data) {
-  const ROMol &mol = *(ROMol *)data;
-  static string text;
-  text.clear();
-  try {
-    text = RDKit::MolToSmiles(mol);
-  } catch (...) {
-    ereport(WARNING,
-            (errcode(ERRCODE_WARNING), errmsg("Mol2Smiles(): failed")));
-    text.clear();
-  }
-  return (char *)text.c_str();
+  return strdup(text.c_str());
 }
 
 extern "C" char *findMCSsmiles(char *smiles, char *params) {
@@ -1944,7 +1928,7 @@ extern "C" char *findMCSsmiles(char *smiles, char *params) {
     } catch (...) {
       ereport(WARNING, (errcode(ERRCODE_WARNING),
                         errmsg("findMCS: Invalid argument \'params\'")));
-      return (char *)mcs.c_str();
+      return strdup("");
     }
   }
 
@@ -1958,7 +1942,7 @@ extern "C" char *findMCSsmiles(char *smiles, char *params) {
     ereport(WARNING, (errcode(ERRCODE_WARNING), errmsg("findMCS: failed")));
     mcs.clear();
   }
-  return mcs.empty() ? (char *)"" : (char *)mcs.c_str();
+  return mcs.empty() ? strdup("") : strdup(mcs.c_str());
 }
 
 extern "C" void *addMol2list(void *lst, Mol *mol) {
@@ -2000,7 +1984,7 @@ extern "C" char *findMCS(void *vmols, char *params) {
       // mcs = params; //DEBUG
       ereport(WARNING, (errcode(ERRCODE_WARNING),
                         errmsg("findMCS: Invalid argument \'params\'")));
-      return (char *)mcs.c_str();
+      return strdup(mcs.c_str());
     }
   }
 
@@ -2018,5 +2002,5 @@ extern "C" char *findMCS(void *vmols, char *params) {
   // elog(WARNING, t);
   delete molecules;
   // elog(WARNING, "findMCS(): molecules deleted. FINISHED.");
-  return (char *)mcs.c_str();
+  return strdup(mcs.c_str());
 }

--- a/Code/PgSQL/rdkit/adapter.cpp
+++ b/Code/PgSQL/rdkit/adapter.cpp
@@ -50,6 +50,10 @@
 #include <GraphMol/FMCS/FMCS.h>
 #include <DataStructs/BitOps.h>
 #include <DataStructs/SparseIntVect.h>
+#include <GraphMol/MolDraw2D/MolDraw2D.h>
+#include <GraphMol/MolDraw2D/MolDraw2DSVG.h>
+#include <GraphMol/MolDraw2D/MolDraw2DUtils.h>
+
 #include <RDGeneral/BoostStartInclude.h>
 #include <boost/integer_traits.hpp>
 #include <boost/property_tree/ptree.hpp>
@@ -673,6 +677,24 @@ extern "C" CROMol MolAdjustQueryProperties(CROMol i, const char *params) {
   return (CROMol)mol;
 }
 
+extern "C" char *MolGetSVG(CROMol i, unsigned int w, unsigned int h,
+                           const char *legend, const char *params) {
+  RWMol *im = (RWMol *)i;
+
+  MolDraw2DUtils::prepareMolForDrawing(*im);
+  std::string slegend(legend ? legend : "");
+  MolDraw2DSVG drawer(w, h);
+
+#if 0
+  if (params && strlen(params)) {
+  }
+#endif
+  drawer.drawMolecule(*im, legend);
+  drawer.finishDrawing();
+  std::string txt = drawer.getDrawingText();
+  return strdup(txt.c_str());
+}
+
 /*******************************************
  *     CBfp transformation                 *
  *******************************************/
@@ -902,8 +924,8 @@ extern "C" void countLowOverlapValues(bytea *sign, CSfp data, int numInts,
   for (n = 0; n < numInts; n++) {
     *keySum += s[n].low;
     if (s[n].low != s[n].high)
-      *keySum +=
-          s[n].high; /* there is at least two key mapped into current backet */
+      *keySum += s[n].high; /* there is at least two key mapped into current
+                               backet */
   }
 
   Assert(*overlapUp <= *keySum);
@@ -1073,7 +1095,8 @@ extern "C" bool calcSparseStringAllValsGT(const char *a, unsigned int sza,
   t1 += sizeof(boost::uint32_t);
   if (tmp != sizeof(boost::uint32_t)) {
     elog(ERROR,
-         "calcSparseStringAllValsGT: could not convert argument 1 -> uint32_t");
+         "calcSparseStringAllValsGT: could not convert argument 1 -> "
+         "uint32_t");
   }
 
   // boost::uint32_t len1;
@@ -1110,7 +1133,8 @@ extern "C" bool calcSparseStringAllValsLT(const char *a, unsigned int sza,
   t1 += sizeof(boost::uint32_t);
   if (tmp != sizeof(boost::uint32_t)) {
     elog(ERROR,
-         "calcSparseStringAllValsGT: could not convert argument 1 -> uint32_t");
+         "calcSparseStringAllValsGT: could not convert argument 1 -> "
+         "uint32_t");
   }
 
   // boost::uint32_t len1;

--- a/Code/PgSQL/rdkit/expected/props.out
+++ b/Code/PgSQL/rdkit/expected/props.out
@@ -273,3 +273,64 @@ SELECT mol_murckoscaffold('CSC(C)=O'::mol) is NULL;
  t
 (1 row)
 
+SELECT mol_to_svg('CCO'::mol) svg;
+                                                                                                         svg                                                                                                         
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ <?xml version='1.0' encoding='iso-8859-1'?>                                                                                                                                                                        +
+ <svg:svg version='1.1' baseProfile='full'                                                                                                                                                                          +
+               xmlns:svg='http://www.w3.org/2000/svg'                                                                                                                                                               +
+                       xmlns:rdkit='http://www.rdkit.org/xml'                                                                                                                                                       +
+                       xmlns:xlink='http://www.w3.org/1999/xlink'                                                                                                                                                   +
+                   xml:space='preserve'                                                                                                                                                                             +
+ width='250px' height='200px' >                                                                                                                                                                                     +
+ <svg:rect style='opacity:1.0;fill:#FFFFFF;stroke:none' width='250' height='200' x='0' y='0'> </svg:rect>                                                                                                           +
+ <svg:path d='M 11.3636,124.362 95.7545,75.6385' style='fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />                                  +
+ <svg:path d='M 95.7545,75.6385 131.455,96.25' style='fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />                                    +
+ <svg:path d='M 131.455,96.25 167.155,116.862' style='fill:none;fill-rule:evenodd;stroke:#FF0000;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />                                    +
+ <svg:text x='166.64' y='131.862' style='font-size:15px;font-style:normal;font-weight:normal;fill-opacity:1;stroke:none;font-family:sans-serif;text-anchor:start;fill:#FF0000' ><svg:tspan>OH</svg:tspan></svg:text>+
+ </svg:svg>                                                                                                                                                                                                         +
+ 
+(1 row)
+
+SELECT mol_to_svg('CCO'::mol,'legend') svg;
+                                                                                                         svg                                                                                                          
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ <?xml version='1.0' encoding='iso-8859-1'?>                                                                                                                                                                         +
+ <svg:svg version='1.1' baseProfile='full'                                                                                                                                                                           +
+               xmlns:svg='http://www.w3.org/2000/svg'                                                                                                                                                                +
+                       xmlns:rdkit='http://www.rdkit.org/xml'                                                                                                                                                        +
+                       xmlns:xlink='http://www.w3.org/1999/xlink'                                                                                                                                                    +
+                   xml:space='preserve'                                                                                                                                                                              +
+ width='250px' height='200px' >                                                                                                                                                                                      +
+ <svg:rect style='opacity:1.0;fill:#FFFFFF;stroke:none' width='250' height='200' x='0' y='0'> </svg:rect>                                                                                                            +
+ <svg:path d='M 11.3636,124.362 95.7545,75.6385' style='fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />                                   +
+ <svg:path d='M 95.7545,75.6385 131.455,96.25' style='fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />                                     +
+ <svg:path d='M 131.455,96.25 167.155,116.862' style='fill:none;fill-rule:evenodd;stroke:#FF0000;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />                                     +
+ <svg:text x='166.64' y='131.862' style='font-size:15px;font-style:normal;font-weight:normal;fill-opacity:1;stroke:none;font-family:sans-serif;text-anchor:start;fill:#FF0000' ><svg:tspan>OH</svg:tspan></svg:text> +
+ <svg:text x='103.377' y='194' style='font-size:12px;font-style:normal;font-weight:normal;fill-opacity:1;stroke:none;font-family:sans-serif;text-anchor:start;fill:#000000' ><svg:tspan>legend</svg:tspan></svg:text>+
+ </svg:svg>                                                                                                                                                                                                          +
+ 
+(1 row)
+
+SELECT mol_to_svg('CCO'::mol,'legend',250,200,
+  '{"atomLabels":{"1":"foo"},"legendColour":[0.5,0.5,0.5]}') svg;
+                                                                                                          svg                                                                                                          
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ <?xml version='1.0' encoding='iso-8859-1'?>                                                                                                                                                                          +
+ <svg:svg version='1.1' baseProfile='full'                                                                                                                                                                            +
+               xmlns:svg='http://www.w3.org/2000/svg'                                                                                                                                                                 +
+                       xmlns:rdkit='http://www.rdkit.org/xml'                                                                                                                                                         +
+                       xmlns:xlink='http://www.w3.org/1999/xlink'                                                                                                                                                     +
+                   xml:space='preserve'                                                                                                                                                                               +
+ width='250px' height='200px' >                                                                                                                                                                                       +
+ <svg:rect style='opacity:1.0;fill:#FFFFFF;stroke:none' width='250' height='200' x='0' y='0'> </svg:rect>                                                                                                             +
+ <svg:path d='M 11.3636,124.362 83.2395,82.864' style='fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />                                     +
+ <svg:path d='M 108.269,82.864 137.712,99.8628' style='fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />                                     +
+ <svg:path d='M 137.712,99.8628 167.155,116.862' style='fill:none;fill-rule:evenodd;stroke:#FF0000;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />                                    +
+ <svg:text x='83.2395' y='83.1385' style='font-size:15px;font-style:normal;font-weight:normal;fill-opacity:1;stroke:none;font-family:sans-serif;text-anchor:start;fill:#000000' ><svg:tspan>foo</svg:tspan></svg:text>+
+ <svg:text x='166.64' y='131.862' style='font-size:15px;font-style:normal;font-weight:normal;fill-opacity:1;stroke:none;font-family:sans-serif;text-anchor:start;fill:#FF0000' ><svg:tspan>OH</svg:tspan></svg:text>  +
+ <svg:text x='103.377' y='194' style='font-size:12px;font-style:normal;font-weight:normal;fill-opacity:1;stroke:none;font-family:sans-serif;text-anchor:start;fill:#7F7F7F' ><svg:tspan>legend</svg:tspan></svg:text> +
+ </svg:svg>                                                                                                                                                                                                           +
+ 
+(1 row)
+

--- a/Code/PgSQL/rdkit/mol_op.c
+++ b/Code/PgSQL/rdkit/mol_op.c
@@ -270,7 +270,9 @@ Datum mol_hash(PG_FUNCTION_ARGS) {
   Assert(mol != 0);
   str = computeMolHash(mol, &len);
   Assert(str != 0 && strlen(str) != 0);
-  PG_RETURN_CSTRING(pnstrdup(str, len));
+  char *res = pnstrdup(str, len);
+  free((void *)str);
+  PG_RETURN_CSTRING(res);
 }
 
 PGDLLEXPORT Datum mol_adjust_query_properties(PG_FUNCTION_ARGS);
@@ -303,7 +305,10 @@ Datum fmcs_smiles(PG_FUNCTION_ARGS) {
   str = findMCSsmiles(str, params);
   // elog(WARNING, str);
   Assert(str != 0);
-  PG_RETURN_CSTRING(pnstrdup(str, strlen(str)));
+
+  char *res = pnstrdup(str, strlen(str));
+  free((void *)str);
+  PG_RETURN_CSTRING(res);
 }
 
 PGDLLEXPORT Datum fmcs_smiles_transition(PG_FUNCTION_ARGS);
@@ -431,6 +436,7 @@ Datum fmcs_mols(PG_FUNCTION_ARGS) {
   text *ts = (text *)palloc(ts_size);
   SET_VARSIZE(ts, ts_size);
   memcpy(VARDATA(ts), str, strlen(str));
+  free((void *)str);
   PG_RETURN_TEXT_P(ts);
 }
 

--- a/Code/PgSQL/rdkit/mol_op.c
+++ b/Code/PgSQL/rdkit/mol_op.c
@@ -293,6 +293,26 @@ Datum mol_adjust_query_properties(PG_FUNCTION_ARGS) {
   PG_RETURN_MOL_P(res);
 }
 
+PGDLLEXPORT Datum mol_to_svg(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(mol_to_svg);
+Datum mol_to_svg(PG_FUNCTION_ARGS) {
+  CROMol mol;
+  fcinfo->flinfo->fn_extra =
+      searchMolCache(fcinfo->flinfo->fn_extra, fcinfo->flinfo->fn_mcxt,
+                     PG_GETARG_DATUM(0), NULL, &mol, NULL);
+  Assert(mol != 0);
+
+  char *legend = PG_GETARG_CSTRING(1);
+  unsigned int w = PG_GETARG_UINT32(2);
+  unsigned int h = PG_GETARG_UINT32(3);
+  char *params = PG_GETARG_CSTRING(4);
+
+  char *str = MolGetSVG(mol, w, h, legend, params);
+  char *res = pnstrdup(str, strlen(str));
+  free((void *)str);
+  PG_RETURN_CSTRING(res);
+}
+
 /*** fmcs ***/
 
 PGDLLEXPORT Datum fmcs_smiles(PG_FUNCTION_ARGS);
@@ -362,7 +382,7 @@ Datum fmcs_mol2s_transition(PG_FUNCTION_ARGS) {
     int len, ts_size;
     char *smiles;
     elog(WARNING, "mol=%p, fcinfo: %p, %p", mol, fcinfo->flinfo->fn_extra,
-	 fcinfo->flinfo->fn_mcxt);
+         fcinfo->flinfo->fn_mcxt);
     fcinfo->flinfo->fn_extra =
         searchMolCache(fcinfo->flinfo->fn_extra, fcinfo->flinfo->fn_mcxt,
                        PG_GETARG_DATUM(1), NULL, &mol, NULL);
@@ -389,7 +409,7 @@ Datum fmcs_mol2s_transition(PG_FUNCTION_ARGS) {
     CROMol mol = PG_GETARG_DATUM(1);
     int len;
     elog(WARNING, "mol=%p, fcinfo: %p, %p", mol, fcinfo->flinfo->fn_extra,
-            fcinfo->flinfo->fn_mcxt);
+         fcinfo->flinfo->fn_mcxt);
     fcinfo->flinfo->fn_extra =
         searchMolCache(fcinfo->flinfo->fn_extra, fcinfo->flinfo->fn_mcxt,
                        PG_GETARG_DATUM(1), NULL, &mol, NULL);

--- a/Code/PgSQL/rdkit/rdkit.h
+++ b/Code/PgSQL/rdkit/rdkit.h
@@ -163,6 +163,8 @@ const char *MolInchiKey(CROMol i, const char *opts);
 CROMol MolMurckoScaffold(CROMol i);
 
 CROMol MolAdjustQueryProperties(CROMol m, const char *params);
+char *MolGetSVG(CROMol i, unsigned int w, unsigned int h, const char *legend,
+                const char *params);
 
 /* ExplicitBitVect */
 typedef void *CBfp;

--- a/Code/PgSQL/rdkit/rdkit.h
+++ b/Code/PgSQL/rdkit/rdkit.h
@@ -1,4 +1,3 @@
-// $Id$
 //
 //  Copyright (c) 2010-2015, Novartis Institutes for BioMedical Research Inc.
 //  All rights reserved.
@@ -30,8 +29,8 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
-#ifndef _RDKIT_H_
-#define _RDKIT_H_
+#ifndef RDKIT_H_PSQL
+#define RDKIT_H_PSQL
 
 #ifdef __cplusplus
 extern "C" {
@@ -66,7 +65,7 @@ typedef struct {
 #define PG_RETURN_BFP_P(x) PG_RETURN_DATUM(BfpPGetDatum(x))
 
 #define BFP_SIGLEN(x) (VARSIZE(x) - VARHDRSZ)
-  
+
 typedef bytea Sfp;
 
 #define DatumGetSfpP(x) ((Sfp *)PG_DETOAST_DATUM(x))
@@ -197,11 +196,10 @@ bool calcSparseStringAllValsLT(const char *a, unsigned int sza, int tgt);
 CSfp addSFP(CSfp a, CSfp b);
 CSfp subtractSFP(CSfp a, CSfp b);
 
-void countOverlapValues(bytea *sign, CSfp data, int numBits,
-                        int *sum, int *overlapSum, int *overlapN);
-void countLowOverlapValues(bytea *sign, CSfp data, int numInts,
-                           int *querySum, int *keySum, int *overlapUp,
-                           int *overlapDown);
+void countOverlapValues(bytea *sign, CSfp data, int numBits, int *sum,
+                        int *overlapSum, int *overlapN);
+void countLowOverlapValues(bytea *sign, CSfp data, int numInts, int *querySum,
+                           int *keySum, int *overlapUp, int *overlapDown);
 /*
  * Various mol -> fp transformation
  */

--- a/Code/PgSQL/rdkit/rdkit.sql.in
+++ b/Code/PgSQL/rdkit/rdkit.sql.in
@@ -177,6 +177,11 @@ RETURNS mol
 AS 'MODULE_PATHNAME'
 LANGUAGE C STRICT IMMUTABLE;
 
+CREATE OR REPLACE FUNCTION mol_to_svg(mol, cstring default '', integer default 250, integer default 200, cstring default '')
+RETURNS cstring
+AS 'MODULE_PATHNAME'
+LANGUAGE C STRICT IMMUTABLE;
+
 
 -- mol conversion functions
 

--- a/Code/PgSQL/rdkit/sql/props.sql
+++ b/Code/PgSQL/rdkit/sql/props.sql
@@ -50,3 +50,8 @@ SELECT mol_numrings('CCC'::mol) val;
 SELECT mol_numrings('C1CC1'::mol) val;
 SELECT mol_murckoscaffold('c1ccccc1CCC'::mol) val;
 SELECT mol_murckoscaffold('CSC(C)=O'::mol) is NULL;
+
+SELECT mol_to_svg('CCO'::mol) svg;
+SELECT mol_to_svg('CCO'::mol,'legend') svg;
+SELECT mol_to_svg('CCO'::mol,'legend',250,200,
+  '{"atomLabels":{"1":"foo"},"legendColour":[0.5,0.5,0.5]}') svg;

--- a/Docs/Book/Cartridge.md
+++ b/Docs/Book/Cartridge.md
@@ -524,6 +524,8 @@ There are additional operators defined in the cartridge, but these are used for 
 -   mol\_to\_smarts(mol) : returns SMARTS string for a molecule.
 -   mol\_to\_pkl(mol) : returns binary string (bytea) for a molecule. (*available from Q3 2012 (2012\_09) release*)
 -   mol\_to\_ctab(mol,bool default true) : returns a CTAB (mol block) string for a molecule. The optional second argument controls whether or not 2D coordinates will be generated for molecules that don't have coordinates. (*available from the 2014\_03 release*)
+-   mol\_to\_svg(mol,string default '',int default 250, int default 200, string default '') : returns an SVG with a drawing of the molecule. The optional parameters are a string to use as the legend, the width of the image, the height of the image, and a JSON with additional rendering parameters. (*available from the 2016\_09 release*)
+
 
 ##### Substructure operations
 


### PR DESCRIPTION
This also adds JSON configuration options for the `MolDraw2D` class.

Here are a couple examples of how you invoke this from SQL:
```
glandrum=# select mol_to_svg('CO[2H]'::mol);
glandrum=# select mol_to_svg('CO[2H]'::mol,'legend');
glandrum=# select mol_to_svg('CO[2H]'::mol,'legend',250,200,'{"atomLabelDeuteriumTritium":true}');
```

It might be worth thinking about having a version where the full configuration is pulled from JSON instead of allowing the legend, width, and height to be provided without using JSON. 