### PR TITLE
Allow the output of ROMol::debugMol() to show up in jupyter

### DIFF
--- a/Code/GraphMol/Wrap/Mol.cpp
+++ b/Code/GraphMol/Wrap/Mol.cpp
@@ -165,7 +165,7 @@ void MolDebug(const ROMol &mol, bool useStdout) {
     mol.debugMol(std::cout);
   } else {
     std::ostream *dest = &std::cerr;
-    if (rdWarningLog != NULL) {
+    if (rdInfoLog != NULL) {
       if (rdInfoLog->teestream) {
         dest = rdInfoLog->teestream;
       } else if (rdInfoLog->dp_dest) {

--- a/Code/GraphMol/Wrap/Mol.cpp
+++ b/Code/GraphMol/Wrap/Mol.cpp
@@ -166,10 +166,10 @@ void MolDebug(const ROMol &mol, bool useStdout) {
   } else {
     std::ostream *dest = &std::cerr;
     if (rdWarningLog != NULL) {
-      if (rdWarningLog->teestream) {
-        dest = rdWarningLog->teestream;
-      } else if (rdWarningLog->dp_dest) {
-        dest = rdWarningLog->dp_dest;
+      if (rdInfoLog->teestream) {
+        dest = rdInfoLog->teestream;
+      } else if (rdInfoLog->dp_dest) {
+        dest = rdInfoLog->dp_dest;
       }
       mol.debugMol(*dest);
     }

--- a/Code/GraphMol/Wrap/Mol.cpp
+++ b/Code/GraphMol/Wrap/Mol.cpp
@@ -145,7 +145,7 @@ int MolHasProp(const ROMol &mol, const char *key) {
   return res;
 }
 
-template<class T>
+template <class T>
 void MolSetProp(const ROMol &mol, const char *key, const T &val,
                 bool computed = false) {
   mol.setProp<T>(key, val, computed);
@@ -160,7 +160,21 @@ void MolClearProp(const ROMol &mol, const char *key) {
 
 void MolClearComputedProps(const ROMol &mol) { mol.clearComputedProps(); }
 
-void MolDebug(const ROMol &mol) { mol.debugMol(std::cout); }
+void MolDebug(const ROMol &mol, bool useStdout) {
+  if (useStdout) {
+    mol.debugMol(std::cout);
+  } else {
+    std::ostream *dest = &std::cerr;
+    if (rdWarningLog != NULL) {
+      if (rdWarningLog->teestream) {
+        dest = rdWarningLog->teestream;
+      } else if (rdWarningLog->dp_dest) {
+        dest = rdWarningLog->dp_dest;
+      }
+      mol.debugMol(*dest);
+    }
+  }
+}
 
 // FIX: we should eventually figure out how to do iterators properly
 AtomIterSeq *MolGetAtoms(ROMol *mol) {
@@ -262,17 +276,17 @@ struct mol_wrapper {
         .def(python::init<const ROMol &, bool, int>())
         .def("__copy__", &generic__copy__<ROMol>)
         .def("__deepcopy__", &generic__deepcopy__<ROMol>)
-        .def("GetNumAtoms", getMolNumAtoms,
-             (python::arg("onlyHeavy") = -1,
-              python::arg("onlyExplicit") = true),
-             "Returns the number of atoms in the molecule.\n\n"
-             "  ARGUMENTS:\n"
-             "    - onlyExplicit: (optional) include only explicit atoms "
-             "(atoms in the molecular graph)\n"
-             "                    defaults to 1.\n"
-             "  NOTE: the onlyHeavy argument is deprecated\n"
+        .def(
+            "GetNumAtoms", getMolNumAtoms,
+            (python::arg("onlyHeavy") = -1, python::arg("onlyExplicit") = true),
+            "Returns the number of atoms in the molecule.\n\n"
+            "  ARGUMENTS:\n"
+            "    - onlyExplicit: (optional) include only explicit atoms "
+            "(atoms in the molecular graph)\n"
+            "                    defaults to 1.\n"
+            "  NOTE: the onlyHeavy argument is deprecated\n"
 
-             )
+            )
         .def("GetNumHeavyAtoms", &ROMol::getNumHeavyAtoms,
              "Returns the number of heavy atoms (atomic number >1) in the "
              "molecule.\n\n")
@@ -388,11 +402,13 @@ struct mol_wrapper {
               python::arg("useChirality") = false,
               python::arg("useQueryQueryMatches") = false,
               python::arg("maxMatches") = 1000),
-             "Returns tuples of the indices of the molecule's atoms that match "
+             "Returns tuples of the indices of the molecule's atoms that "
+             "match "
              "a substructure query.\n\n"
              "  ARGUMENTS:\n"
              "    - query: a Molecule.\n"
-             "    - uniquify: (optional) determines whether or not the matches "
+             "    - uniquify: (optional) determines whether or not the "
+             "matches "
              "are uniquified.\n"
              "                Defaults to 1.\n\n"
              "    - useChirality: enables the use of stereochemistry in the "
@@ -442,7 +458,8 @@ struct mol_wrapper {
               python::arg("computed") = false),
              "Sets an integer valued molecular property\n\n"
              "  ARGUMENTS:\n"
-             "    - key: the name of the property to be set (an unsigned number).\n"
+             "    - key: the name of the property to be set (an unsigned "
+             "number).\n"
              "    - value: the property value as an integer.\n"
              "    - computed: (optional) marks the property as being "
              "computed.\n"
@@ -456,7 +473,7 @@ struct mol_wrapper {
              "    - value: the property value as an unsigned integer.\n"
              "    - computed: (optional) marks the property as being "
              "computed.\n"
-             "                Defaults to False.\n\n")                
+             "                Defaults to False.\n\n")
         .def("SetBoolProp", MolSetProp<bool>,
              (python::arg("self"), python::arg("key"), python::arg("val"),
               python::arg("computed") = false),
@@ -466,7 +483,7 @@ struct mol_wrapper {
              "    - value: the property value as a bool.\n"
              "    - computed: (optional) marks the property as being "
              "computed.\n"
-             "                Defaults to False.\n\n")                
+             "                Defaults to False.\n\n")
         .def("HasProp", MolHasProp,
              "Queries a molecule to see if a particular property has been "
              "assigned.\n\n"
@@ -527,7 +544,8 @@ struct mol_wrapper {
 
         .def("NeedsUpdatePropertyCache", &ROMol::needsUpdatePropertyCache,
              (python::arg("self")),
-             "Returns true or false depending on whether implicit and explicit "
+             "Returns true or false depending on whether implicit and "
+             "explicit "
              "valence of the molecule have already been calculated.\n\n")
 
         .def("GetPropNames", &ROMol::getPropList,
@@ -547,7 +565,8 @@ struct mol_wrapper {
              (python::arg("self"), python::arg("includePrivate") = false,
               python::arg("includeComputed") = false),
              "Returns a dictionary populated with the molecules properties.\n"
-             " n.b. Some properties are not able to be converted to python types.\n\n"
+             " n.b. Some properties are not able to be converted to python "
+             "types.\n\n"
              "  ARGUMENTS:\n"
              "    - includePrivate: (optional) toggles inclusion of private "
              "properties in the result set.\n"
@@ -556,7 +575,6 @@ struct mol_wrapper {
              "properties in the result set.\n"
              "                      Defaults to False.\n\n"
              "  RETURNS: a dictionary\n")
-             
 
         .def("GetAtoms", MolGetAtoms,
              python::return_value_policy<
@@ -588,6 +606,7 @@ struct mol_wrapper {
         .def_pickle(mol_pickle_suite())
 
         .def("Debug", MolDebug,
+             (python::arg("mol"), python::arg("useStdout") = true),
              "Prints debugging information about the molecule.\n")
 
         .def("ToBinary", MolToBinary,

--- a/rdkit/Chem/Draw/IPythonConsole.py
+++ b/rdkit/Chem/Draw/IPythonConsole.py
@@ -60,7 +60,6 @@ shader_3d = "lambert"
 #  in the IPythonConsole not the server logs.
 Chem.WrapLogs()
 
-
 def _toJSON(mol):
   """For IPython notebook, renders 3D webGL objects."""
 
@@ -220,6 +219,9 @@ def InstallIPythonRenderer():
   Image.Image._repr_png_ = display_pil_image
   _MolsToGridImageSaved = Draw.MolsToGridImage
   Draw.MolsToGridImage = ShowMols
+  rdchem.Mol.__DebugMol = rdchem.Mol.Debug
+  rdchem.Mol.Debug = lambda self,useStdout=False:self.__DebugMol(useStdout=useStdout)
+
 
 
 InstallIPythonRenderer()
@@ -241,3 +243,6 @@ def UninstallIPythonRenderer():
   del Image.Image._repr_png_
   if _MolsToGridImageSaved is not None:
     Draw.MolsToGridImage = _MolsToGridImageSaved
+  if hasattr(rdchem.Mol, '__DebugMol'):
+    rdchem.Mol.Debug = rdchem.Mol.__DebugMol
+    del rdchem.Mol.__DebugMol


### PR DESCRIPTION
A small one that builds on top of @bp-kelley's work to make the output of the rdkit logs visible in the jupyter notebook