### PR TITLE
Check for doubles after other integer types when reporting properties

### DIFF
--- a/Code/GraphMol/Wrap/props.hpp
+++ b/Code/GraphMol/Wrap/props.hpp
@@ -77,13 +77,13 @@ boost::python::dict GetPropsAsDict(const T &obj,
   // std::vector<int>, std::vector<unsigned>, string
   STR_VECT keys = obj.getPropList(includePrivate, includeComputed);
   for(size_t i=0;i<keys.size();++i) {
-    if (AddToDict<double>(obj, dict, keys[i])) continue;
     if (AddToDict<int>(obj, dict, keys[i])) continue;
     if (AddToDict<unsigned int>(obj, dict, keys[i])) continue;
     if (AddToDict<bool>(obj, dict, keys[i])) continue;
-    if (AddToDict<std::vector<double> >(obj, dict, keys[i])) continue;
+    if (AddToDict<double>(obj, dict, keys[i])) continue;
     if (AddToDict<std::vector<int> >(obj, dict, keys[i])) continue;
     if (AddToDict<std::vector<unsigned int> >(obj, dict, keys[i])) continue;
+    if (AddToDict<std::vector<double> >(obj, dict, keys[i])) continue;
     if (AddToDict<std::vector<std::string> >(obj, dict, keys[i])) continue;    
     if (AddToDict<std::string>(obj, dict, keys[i])) continue;
   }

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -510,7 +510,18 @@ class TestCase(unittest.TestCase):
                                       'e': 2,
                                       'd': -2,
                                       'prop1': 'foob'})
-
+    m = Chem.MolFromSmiles('C1=CN=CC=C1')
+    m.SetProp("int", "1000")
+    m.SetProp("double", "10000.123")
+    print(m.GetPropsAsDict())
+    self.assertEquals(m.GetPropsAsDict(),
+                      {"int":1000,
+                       "double":10000.123})
+    
+    self.assertEquals(type(m.GetPropsAsDict()['int']), int)
+    self.assertEquals(type(m.GetPropsAsDict()['double']), float)
+    
+    
   def test17Kekulize(self):
     m = Chem.MolFromSmiles('c1ccccc1')
     smi = Chem.MolToSmiles(m)


### PR DESCRIPTION
Fixes #1113 

Reverse the order of property lookups, doubles should come last.