### PR TITLE
add more detailed error reporting when python tests fail in TestRunner.py

### DIFF
--- a/rdkit/TestRunner.py
+++ b/rdkit/TestRunner.py
@@ -106,6 +106,9 @@ def RunScript(script, doLongTests, verbose):
 
   nTests = len(tests) + len(longTests)
   del sys.modules[script]
+  if verbose and failed:
+    for exeName,args,extras in failed:
+        print("!!! TEST FAILURE: ",exeName,args,extras,file=sys.stderr)
   return failed, nTests
 
 


### PR DESCRIPTION
shows the name and additional arguments of the failing subtest