### PR TITLE
This makes Chem.SanitizeMol significantly faster when dealing with mo…

### DIFF
--- a/Code/GraphMol/FindRings.cpp
+++ b/Code/GraphMol/FindRings.cpp
@@ -880,6 +880,8 @@ int findSSSR(const ROMol &mol, VECT_INT_VECT &res) {
        fi++) {  // loop over the fragments in a molecule
     VECT_INT_VECT fragRes;
     curFrag = frags[fi];
+    if (curFrag.size() <= 3)
+      continue;
 
     // the following is the list of atoms that are useful in the next round of
     // trimming


### PR DESCRIPTION
…lecules with lots of disconnected fragments (like a box of water).

The following is the runtime of Chem.SanitizeMol while adding 10,000
waters with explicit hydrogens when running Chem.SanitizeMol on every
1,000th water added.

Before:
0 add_water = 0.00007s
0 Chem.SanitizeMol = 0.01991s
1000 add_water = 0.00009s
1000 Chem.SanitizeMol = 0.99659s
2000 add_water = 0.00013s
2000 Chem.SanitizeMol = 3.94565s
3000 add_water = 0.00018s
3000 Chem.SanitizeMol = 8.94760s
4000 add_water = 0.00023s
4000 Chem.SanitizeMol = 15.75187s
5000 add_water = 0.00035s
5000 Chem.SanitizeMol = 24.59318s
6000 add_water = 0.00048s
6000 Chem.SanitizeMol = 37.23530s
7000 add_water = 0.00042s
7000 Chem.SanitizeMol = 47.70860s
8000 add_water = 0.00105s
8000 Chem.SanitizeMol = 62.21912s
9000 add_water = 0.00056s
9000 Chem.SanitizeMol = 80.08511s

After:
0 add_water = 0.00008s
0 Chem.SanitizeMol = 0.02371s
1000 add_water = 0.00006s
1000 Chem.SanitizeMol = 0.02986s
2000 add_water = 0.00013s
2000 Chem.SanitizeMol = 0.06513s
3000 add_water = 0.00018s
3000 Chem.SanitizeMol = 0.09535s
4000 add_water = 0.00025s
4000 Chem.SanitizeMol = 0.12644s
5000 add_water = 0.00044s
5000 Chem.SanitizeMol = 0.15263s
6000 add_water = 0.00050s
6000 Chem.SanitizeMol = 0.19130s
7000 add_water = 0.00040s
7000 Chem.SanitizeMol = 0.21398s
8000 add_water = 0.00046s
8000 Chem.SanitizeMol = 0.24383s
9000 add_water = 0.00054s
9000 Chem.SanitizeMol = 0.28527s

[time_sssr_on_water.txt](https://github.com/rdkit/rdkit/files/557784/time_sssr_on_water.txt)