### PR TITLE
SSSR performance improvements to support larger systems

### DIFF
--- a/Code/GraphMol/FindRings.cpp
+++ b/Code/GraphMol/FindRings.cpp
@@ -860,9 +860,12 @@ int findSSSR(const ROMol &mol, VECT_INT_VECT &res) {
   boost::dynamic_bitset<> ringAtoms(nats);
 
   INT_VECT atomDegrees(nats);
+  INT_VECT atomDegreesWithZeroOrderBonds(nats);
   for (unsigned int i = 0; i < nats; ++i) {
     const Atom *atom = mol.getAtomWithIdx(i);
-    atomDegrees[i] = atom->getDegree();
+    int deg = atom->getDegree();
+    atomDegrees[i] = deg;
+    atomDegreesWithZeroOrderBonds[i] = deg;
     ROMol::OEDGE_ITER beg, end;
     boost::tie(beg, end) = mol.getAtomBonds(atom);
     while (beg != end) {
@@ -881,17 +884,31 @@ int findSSSR(const ROMol &mol, VECT_INT_VECT &res) {
     VECT_INT_VECT fragRes;
     curFrag = frags[fi];
 
+    if (curFrag.size() < 3)
+      continue;
+
     // the following is the list of atoms that are useful in the next round of
     // trimming
     // basically atoms that become degree 0 or 1 because of bond removals
     // initialized with atoms of degrees 0 and 1
     INT_SET changed;
+    int bndcnt_from_deg = 0;
     for (INT_VECT_CI aidi = curFrag.begin(); aidi != curFrag.end(); aidi++) {
-      unsigned int deg = atomDegrees[*aidi];
+      int atom_idx = *aidi;
+      bndcnt_from_deg += atomDegreesWithZeroOrderBonds[atom_idx];
+
+      int deg = atomDegrees[atom_idx];
       if (deg < 2) {
         changed.insert((*aidi));
       }
     }
+
+    // check to see if this fragment can even have a possible ring
+    CHECK_INVARIANT(bndcnt_from_deg % 2 == 0, "fragment graph has a dangling degree");
+    bndcnt_from_deg = bndcnt_from_deg / 2;
+    int num_possible_rings = bndcnt_from_deg - curFrag.size() + 1;
+    if (num_possible_rings < 1)
+      continue;
 
     boost::dynamic_bitset<> doneAts(nats);
     unsigned int nAtomsDone = 0;

--- a/Regress/Scripts/new_timings.py
+++ b/Regress/Scripts/new_timings.py
@@ -3,34 +3,40 @@ import time, gzip, random, os, sys
 from rdkit import Chem
 from rdkit.Chem import AllChem
 from rdkit.RDLogger import logger
+
+dname = os.path.dirname(__file__)
+def data(fname):
+  return os.path.join(dname, '..', 'Data', fname)
+
 logger = logger()
 
 tests = [1] * 1001
 if len(sys.argv) > 1:
   tests = [0] * 1001
-  tests[1] = 1
   for x in sys.argv[1:]:
     x = int(x)
     tests[x] = 1
 ts = []
 mols = []
-lines = gzip.open('../Data/znp.50k.smi.gz', 'rt').readlines()
-logger.info('mols from smiles')
-nMols = 0
-nBad = 0
-t1 = time.time()
-for line in lines:
-  line = line.strip().split(' ')
-  m = Chem.MolFromSmiles(line[0])
-  if m:
-    nMols += 1
-    mols.append(m)
-  else:
-    nBad += 1
 
-t2 = time.time()
-logger.info('Results1: %.2f seconds, %d passed, %d failed' % (t2 - t1, nMols, nBad))
-ts.append(t2 - t1)
+if tests[0]:
+  lines = gzip.open(data('znp.50k.smi.gz'), 'rt').readlines()
+  logger.info('mols from smiles')
+  nMols = 0
+  nBad = 0
+  t1 = time.time()
+  for line in lines:
+    line = line.strip().split(' ')
+    m = Chem.MolFromSmiles(line[0])
+    if m:
+      nMols += 1
+      mols.append(m)
+    else:
+      nBad += 1
+
+  t2 = time.time()
+  logger.info('Results1: %.2f seconds, %d passed, %d failed' % (t2 - t1, nMols, nBad))
+  ts.append(t2 - t1)
 
 if tests[1]:
   logger.info('Writing: Canonical SMILES')
@@ -42,7 +48,7 @@ if tests[1]:
   ts.append(t2 - t1)
 
 if tests[2]:
-  sdData = gzip.open('../Data/mols.1000.sdf.gz', 'rb').read()
+  sdData = gzip.open(data('mols.1000.sdf.gz'), 'rb').read()
   logger.info('mols from sdf')
   suppl = Chem.SDMolSupplier()
   suppl.SetData(sdData)
@@ -61,7 +67,7 @@ if tests[2]:
   ts.append(t2 - t1)
 
 if tests[3] or tests[4] or tests[5]:
-  pattData = gzip.open('../Data/queries.txt.gz', 'rt').readlines()
+  pattData = gzip.open(data('queries.txt.gz'), 'rt').readlines()
   pattData = [x.strip().replace('[H]', '').replace('()', '') for x in pattData]
   logger.info('patterns from smiles')
   patts = []
@@ -104,7 +110,7 @@ if tests[6] or tests[7] or tests[8]:
   logger.info('reading SMARTS')
   patts = []
   t1 = time.time()
-  for line in open('../Data/RLewis_smarts.txt'):
+  for line in open(data('RLewis_smarts.txt')):
     line = line.strip()
     if line == '' or line[0] == '#':
       continue


### PR DESCRIPTION
This has the following two performance improvements to findSSSR that leads to speeding up Chem.SanitizeMol substantially on large systems  (thousands of atoms):

- When the fragment does not contain any rings as determined by Euler's formula (E-V+1 = #rings) such as a water box, skip the SSSR detection entirely. ~1800x faster on 9,000 waters with explicit hydrogens. 
- Avoid an O(N^2) loop to determine the number of bonds in the fragment. Use a cheaper method of summing the atom degrees and dividing by two. (There was already a loop over atom degrees, so easy to highjack that loop to do this operation). ~10x on 60,000 carbon atom chain with a cyclic-propane attached. 

The result is no real measurable effect on the new_timings.py smiles parsing unfortunately, but didn't make it worse :-) 
before: new_timings.py 0

[11:51:50] INFO: mols from smiles
[11:52:11] INFO: Results1: 21.40 seconds, 50000 passed, 0 failed
times:  21.4
[11:52:14] INFO: mols from smiles
[11:52:36] INFO: Results1: 21.62 seconds, 50000 passed, 0 failed
times:  21.6
[11:52:39] INFO: mols from smiles
[11:53:00] INFO: Results1: 21.48 seconds, 50000 passed, 0 failed
times:  21.5

after: new_timings.py 0

[11:58:27] INFO: mols from smiles
[11:58:49] INFO: Results1: 21.60 seconds, 50000 passed, 0 failed
times:  21.6
[11:58:52] INFO: mols from smiles
[11:59:13] INFO: Results1: 21.25 seconds, 50000 passed, 0 failed
times:  21.3
[11:59:16] INFO: mols from smiles
[11:59:37] INFO: Results1: 21.36 seconds, 50000 passed, 0 failed
times:  21.4

Attaching the timings and scripts used for them to the pull request. Doesn't appear to be a need to check them into the code since they are engineered corner cases for the extreme (though I don't think a water box as extreme :-). 

[time_sssr_on_water.txt](https://github.com/rdkit/rdkit/files/558400/time_sssr_on_water.txt)
[time_sssr_on_long_chain_with_some_rings.txt](https://github.com/rdkit/rdkit/files/558402/time_sssr_on_long_chain_with_some_rings.txt)
[time_sssr_on_long_chain_with_one_ring.txt](https://github.com/rdkit/rdkit/files/558404/time_sssr_on_long_chain_with_one_ring.txt)
[sssr_opt_tweak.txt](https://github.com/rdkit/rdkit/files/558407/sssr_opt_tweak.txt)
