### PR TITLE
Replace has_key use in Python (#issue1042)

### DIFF
--- a/Contrib/M_Kossner/Frames.py
+++ b/Contrib/M_Kossner/Frames.py
@@ -162,7 +162,7 @@ if __name__ == '__main__':
   for mol in suppl:
     m = GetFrame(mol)
     cansmiles = Chem.MolToSmiles(m, isomericSmiles=True)
-    if FrameDict.has_key(cansmiles):
+    if cansmiles in FrameDict:
       FrameDict[cansmiles].append(mol)
     else:
       FrameDict[cansmiles] = [mol, ]

--- a/External/pymol/modules/pymol/rpc.py
+++ b/External/pymol/modules/pymol/rpc.py
@@ -123,7 +123,7 @@ def rpcResetCGO(id):
   if id == "*":
     cgoDict = {}
     res = 1
-  elif cgoDict.has_key(id):
+  elif id in cgoDict:
     del (cgoDict[id])
     res = 1
   else:
@@ -549,7 +549,7 @@ def rpcHelp(what=''):
     res = serv.funcs.keys()
   else:
     funcs = serv.funcs
-    if funcs.has_key(what):
+    if what in funcs:
       fn = funcs[what]
       res = "Function: %s(" % what
       defs = fn.func_defaults

--- a/Scripts/AddIssue.py
+++ b/Scripts/AddIssue.py
@@ -9,7 +9,7 @@ def create(db, **issue):
   # first we need to create a 'msg' node containing the message
   msg = {}
   # check if the message was passed on the command line
-  if issue.has_key('messages'):
+  if 'messages' in issue:
     # from command line
     msg['content'] = issue['messages']
   else:
@@ -23,7 +23,7 @@ def create(db, **issue):
   # resolve linked and multilinked properties
   properties = db.issue.getprops()
   for key in issue.keys():
-    if properties.has_key(key):
+    if key in properties:
       if isinstance(properties[key], hyperdb.Link):
         if not issue[key].isdigit():
           # resolve linked property names into node ids

--- a/rdkit/Chem/DSViewer.py
+++ b/rdkit/Chem/DSViewer.py
@@ -167,7 +167,7 @@ class MolViewer(object):
     return obj
 
   def GetSelectedAtoms(self, whichSelection=''):
-    #print 'WHICH',repr(whichSelection),self.displayables.has_key(whichSelection.lower())
+    #print 'WHICH',repr(whichSelection), whichSelection.lower() in self.displayables
     if not whichSelection:
       d = str(self.doc.DoCommand('GetPropertyValue atom select=true: id=?'))
       d2 = str(self.doc.DoCommand('GetPropertyValue atom select=true: molecule=?'))
@@ -176,7 +176,7 @@ class MolViewer(object):
         tmpD = {}
         for id in d2.split(','):
           id = int(id.split('/')[1]) + 1
-          if tmpD.has_key(id):
+          if id in tmpD:
             molIds.append(tmpD[id])
           else:
             for k, v in self.displayables.iteritems():
@@ -185,7 +185,7 @@ class MolViewer(object):
                 molIds.append(k)
       else:
         molIds = [''] * (d.count(',') + 1)
-    elif self.displayables.has_key(whichSelection.lower()):
+    elif whichSelection.lower() in self.displayables:
       whichSelection = whichSelection.lower()
       whichSelection = self.displayables[whichSelection].id
       d = str(

--- a/rdkit/Chem/Pharm2D/LazyGenerator.py
+++ b/rdkit/Chem/Pharm2D/LazyGenerator.py
@@ -89,7 +89,7 @@ class Generator(object):
     """
     if idx < 0 or idx >= self.sig.GetSize():
       raise IndexError('Index %d invalid' % (idx))
-    if self.bits is not None and self.bits.has_key(idx):
+    if self.bits is not None and idx in self.bits:
       return self.bits[idx]
 
     tmp = Matcher.GetAtomsMatchingBit(self.sig, idx, self.mol, dMat=self.dMat, justOne=1,

--- a/rdkit/DataStructs/HierarchyVis.py
+++ b/rdkit/DataStructs/HierarchyVis.py
@@ -103,7 +103,7 @@ def DrawHierarchy(adjList, levelList, canvas, entryColors=None, bitIds=None, min
           # first do lines down to the next level:
           if levelLen != maxLevel:
             for neighbor in adjList[id]:
-              if drawLocs.has_key(neighbor):
+              if neighbor in drawLocs:
                 p2 = drawLocs[neighbor][0]
                 canvas.drawLine(pos[0], pos[1], p2[0], p2[1], visOpts.lineColor, visOpts.lineWidth)
           drawLocs[id] = tuple(pos), nodeRad

--- a/rdkit/Dbase/DbReport.py
+++ b/rdkit/Dbase/DbReport.py
@@ -205,7 +205,7 @@ else:
 
     styles = getSampleStyleSheet()
     title = 'Db Report'
-    if kwargs.has_key('title'):
+    if 'title' in kwargs:
       title = kwargs['title']
       del kwargs['title']
 

--- a/rdkit/sping/PDF/pdfdoc.py
+++ b/rdkit/sping/PDF/pdfdoc.py
@@ -226,7 +226,7 @@ class PDFDocument:
     #self.objects.append(page.stream)
 
   def hasFont(self, psfontname):
-    return self.fontMapping.has_key(psfontname)
+    return psfontname in self.fontMapping
 
   def getInternalFontName(self, psfontname):
     try:

--- a/rdkit/sping/PDF/pidPDF.py
+++ b/rdkit/sping/PDF/pidPDF.py
@@ -222,7 +222,7 @@ class PDFCanvas(Canvas):
       face = 'serif'
     else:
       face = string.lower(font.face)
-    while font_face_map.has_key(face):
+    while face in font_face_map:
       face = font_face_map[face]
     #step 2, - resolve bold/italic to get the right PS font name
     psname = ps_font_map[(face, font.bold, font.italic)]

--- a/rdkit/sping/Pyart/Fontmapping.py
+++ b/rdkit/sping/Pyart/Fontmapping.py
@@ -75,7 +75,7 @@ def getPyartName(pidfont):
   # print "pidfont.face = %s" % pidfont.face
 
   face = string.lower(face)
-  if PidLegalFonts.has_key(face):
+  if face in PidLegalFonts:
     return MapPid2PyartFontName[(PidLegalFonts[face], shape)]
   else:
     raise ValueError("Illegal Font")
@@ -94,7 +94,7 @@ getPdfName = getPyartName
 #      # print "pidfont.face = %s" % pidfont.face
 
 #      face = string.lower(face)
-#      if PidLegalFonts.has_key(face):
+#      if face in PidLegalFonts:
 #          return PDFFontMapping[ ( PidLegalFonts[face], shape) ]
 #      else:
 #          raise "Illegal Font"

--- a/rdkit/sping/ReportLab/pidReportLab.py
+++ b/rdkit/sping/ReportLab/pidReportLab.py
@@ -89,7 +89,7 @@ class RLCanvas(Canvas):
       face = 'serif'
     else:
       face = font.face.lower()
-    while pidPDF.font_face_map.has_key(face):
+    while face in pidPDF.font_face_map:
       face = pidPDF.font_face_map[face]
     #step 2, - resolve bold/italic to get the right PS font name
     psname = pidPDF.ps_font_map[(face, font.bold, font.italic)]

--- a/rdkit/sping/SVG/pidSVG.py
+++ b/rdkit/sping/SVG/pidSVG.py
@@ -302,7 +302,7 @@ class SVGCanvas(Canvas):
       styleStr += ' '.join([str(x) for x in dash])
       styleStr += '"'
     outStr = '<svg:line x1="%.2f" y1="%.2f" x2="%.2f" y2="%.2f" %s>' % (x1, y1, x2, y2, styleStr)
-    if kwargs.has_key('bodyText'):
+    if 'bodyText' in kwargs:
       outStr += kwargs['bodyText']
     outStr += '</svg:line>\n'
     self._txt = self._txt + outStr
@@ -344,7 +344,7 @@ class SVGCanvas(Canvas):
 
     # draw it
     outStr = '<svg:polygon %s %s points="%s">' % (fillStr, edgeStr, pointStr)
-    if kwargs.has_key('bodyText'):
+    if 'bodyText' in kwargs:
       outStr += kwargs['bodyText']
     outStr += '</svg:polygon>\n'
     self._txt = self._txt + outStr
@@ -386,10 +386,10 @@ class SVGCanvas(Canvas):
 
     # draw it
     mods = [fillStr, edgeStr, ellipseStr]
-    if kwargs.has_key('extraAttribs'):
+    if 'extraAttribs' in kwargs:
       mods.append(kwargs['extraAttribs'])
     outStr = '<svg:ellipse %s>' % (' '.join(mods))
-    if kwargs.has_key('bodyText'):
+    if 'bodyText' in kwargs:
       outStr += kwargs['bodyText']
     outStr += '</svg:ellipse>\n'
     self._txt = self._txt + outStr
@@ -440,14 +440,14 @@ class SVGCanvas(Canvas):
     # draw it
     if not filling:
       outStr = '<svg:path %s %s d="%s">' % (fillStr, edgeStr, pathStr)
-      if kwargs.has_key('bodyText'):
+      if 'bodyText' in kwargs:
         outStr += kwargs['bodyText']
       outStr += '</svg:path>\n'
     else:
       outStr = '<svg:path %s d="%s">' % (fillStr, fillPathStr)
       outStr += '</svg:path>\n'
       outStr = outStr + '<svg:path fill="none" %s d="%s">' % (edgeStr, strokePathStr)
-      if kwargs.has_key('bodyText'):
+      if 'bodyText' in kwargs:
         outStr += kwargs['bodyText']
       outStr += '</svg:path>\n'
     self._txt = self._txt + outStr
@@ -489,7 +489,7 @@ class SVGCanvas(Canvas):
 
     # draw it
     outStr = '<svg:path %s %s d="%s">' % (fillStr, edgeStr, curveStr)
-    if kwargs.has_key('bodyText'):
+    if 'bodyText' in kwargs:
       outStr += kwargs['bodyText']
     outStr += '</svg:path>\n'
     self._txt = self._txt + outStr
@@ -533,7 +533,7 @@ class SVGCanvas(Canvas):
       outStr += self._drawStringOneLine(line, xLoc, yP, fontStr, svgColor, **kwargs)
       yP = yP + lineHeight
 
-    if kwargs.has_key('bodyText'):
+    if 'bodyText' in kwargs:
       outStr += kwargs['bodyText']
     outStr += '</svg:g>'
 
@@ -598,7 +598,7 @@ class SVGCanvas(Canvas):
     if closed == 1:
       pathStr = pathStr + 'Z'
     outStr = '<svg:path %s %s d="%s">' % (edgeStr, fillStr, pathStr)
-    if kwargs.has_key('bodyText'):
+    if 'bodyText' in kwargs:
       outStr += kwargs['bodyText']
     outStr += '</svg:path>\n'
     self._txt = self._txt + outStr
@@ -620,7 +620,7 @@ class SVGCanvas(Canvas):
       im_height = abs(y2 - y1)
     outStr = '<svg:image x="%.2f" y="%.2f" width="%.2f" height="%.2f" xlink:href="%s">'%\
              (x1,y1,im_width,im_height,imageFileName)
-    if kwargs.has_key('bodyText'):
+    if 'bodyText' in kwargs:
       outStr += kwargs['bodyText']
     outStr += '</svg:image>\n'
     self._txt = self._txt + outStr

--- a/rdkit/sping/TK/pidTK.py
+++ b/rdkit/sping/TK/pidTK.py
@@ -136,7 +136,7 @@ class FontManager:
       # check if the user specified a generic face type
       # like serif or monospaced. check is case-insenstive.
       f = string.lower(font.face)
-      if self.__alt_faces.has_key(f):
+      if f in self.__alt_faces:
         family = self.__alt_faces[f]
       else:
         family = font.face
@@ -154,7 +154,7 @@ class FontManager:
     key = (family, size, weight, slant, underline)
 
     # check if we've already seen this font.
-    if self.font_cache.has_key(key):
+    if key in self.font_cache:
       # yep, don't bother creating a new one. just fetch it.
       font = self.font_cache[key]
     else:

--- a/rdkit/sping/tests/pidtest.py
+++ b/rdkit/sping/tests/pidtest.py
@@ -318,7 +318,7 @@ def wxTest(testfunc):
     return
 
   global wx_app
-  if not globals().has_key("wx_app"):
+  if not 'wx_app' in globals():
 
     class CanvasApp(wxApp):
       "The wxApp that runs canvas.  Initializes windows, and handles redrawing"


### PR DESCRIPTION
This replaces all remaining has_key uses in the Python code.

Tests run fine, however I don't think there is a test for the SVG generation and I couldn't get cairo working on my laptop. Still, the changes are syntactic only, so modifications should be fine.