### PR TITLE
Remove iPythonConsole configuration for normal Draw tests

### DIFF
--- a/rdkit/Chem/Draw/UnitTestDraw.py
+++ b/rdkit/Chem/Draw/UnitTestDraw.py
@@ -15,12 +15,19 @@ import unittest, os, tempfile
 from rdkit import Chem
 from rdkit.Chem import Draw
 from rdkit.RDLogger import logger
+try:
+  from rdkit.Chem.Draw import IPythonConsole
+except ImportError:
+  IPythonConsole = None
+
 logger = logger()
 
 
 class TestCase(unittest.TestCase):
 
   def setUp(self):
+    if IPythonConsole is not None and Draw.MolsToGridImage == IPythonConsole.ShowMols:
+      IPythonConsole.UninstallIPythonRenderer()
     self.mol = Chem.MolFromSmiles('c1c(C[15NH3+])ccnc1[C@](Cl)(Br)[C@](Cl)(Br)F')
 
   def testCairoFile(self):

--- a/rdkit/Chem/Draw/UnitTestIPython.py
+++ b/rdkit/Chem/Draw/UnitTestIPython.py
@@ -21,9 +21,17 @@ except ImportError:
 
 class TestCase(unittest.TestCase):
 
+  def setUp(self):
+    if IPythonConsole is not None:
+      IPythonConsole.InstallIPythonRenderer()
+    self.mol = Chem.MolFromSmiles('c1c(C[15NH3+])ccnc1[C@](Cl)(Br)[C@](Cl)(Br)F')
+
+  def tearDown(self):
+    if IPythonConsole is not None:
+      IPythonConsole.UninstallIPythonRenderer()
+
+  @unittest.skipIf(IPythonConsole is None, 'IPython not available')
   def testGithub1089(self):
-    if IPythonConsole is None:
-      return
     m = Chem.MolFromSmiles('CCCC')
 
     IPythonConsole.ipython_useSVG = False

--- a/rdkit/Chem/Draw/UnitTestIPython.py
+++ b/rdkit/Chem/Draw/UnitTestIPython.py
@@ -22,7 +22,7 @@ except ImportError:
 class TestCase(unittest.TestCase):
 
   def setUp(self):
-    if IPythonConsole is not None:
+    if IPythonConsole is not None and Draw.MolsToGridImage != IPythonConsole.ShowMols:
       IPythonConsole.InstallIPythonRenderer()
     self.mol = Chem.MolFromSmiles('c1c(C[15NH3+])ccnc1[C@](Cl)(Br)[C@](Cl)(Br)F')
 


### PR DESCRIPTION
Importing IPythonConsole automatically executes `InstallIPythonRenderer()`. This causes problems with the UnitTestDraw.TestGridSVG test if automatic detection of unit tests is used. The test runner in RDkit avoids this problem by running individual processes for each unit test file. This PR implements setUp and tearDown methods that isolate the iPython tests within the same process.