### PR TITLE
Workaround to compile with Visual Studio 2015

### DIFF
--- a/Code/DataStructs/Wrap/wrap_BitOps.cpp
+++ b/Code/DataStructs/Wrap/wrap_BitOps.cpp
@@ -15,6 +15,12 @@
 
 namespace python = boost::python;
 
+// Workaround for bug in Visual Studio 2015 Update 3
+namespace boost {
+  template<> const volatile ExplicitBitVect* get_pointer(const volatile ExplicitBitVect* p) { return p; }
+  template<> const volatile SparseBitVect* get_pointer(const volatile SparseBitVect* p) { return p; }
+}
+
 SBV *ff1(const SBV &bv1, int factor = 2) {
   return FoldFingerprint(bv1, factor);
 }

--- a/Code/DataStructs/Wrap/wrap_BitOps.cpp
+++ b/Code/DataStructs/Wrap/wrap_BitOps.cpp
@@ -15,12 +15,6 @@
 
 namespace python = boost::python;
 
-// Workaround for bug in Visual Studio 2015 Update 3
-namespace boost {
-  template<> const volatile ExplicitBitVect* get_pointer(const volatile ExplicitBitVect* p) { return p; }
-  template<> const volatile SparseBitVect* get_pointer(const volatile SparseBitVect* p) { return p; }
-}
-
 SBV *ff1(const SBV &bv1, int factor = 2) {
   return FoldFingerprint(bv1, factor);
 }

--- a/Code/DataStructs/Wrap/wrap_ExplicitBV.cpp
+++ b/Code/DataStructs/Wrap/wrap_ExplicitBV.cpp
@@ -15,6 +15,13 @@
 
 namespace python = boost::python;
 
+// Workaround for bug in Visual Studio 2015 Update 3
+#if defined(_MSC_VER) && (_MSC_VER == 1900) && (_MSC_FULL_VER >= 190024210)
+namespace boost {
+  template<> const volatile ExplicitBitVect* get_pointer(const volatile ExplicitBitVect* p) { return p; }
+}
+#endif
+
 // allows BitVects to be pickled
 struct ebv_pickle_suite : python::pickle_suite {
   static python::tuple getinitargs(const ExplicitBitVect &self) {

--- a/Code/DataStructs/Wrap/wrap_SparseBV.cpp
+++ b/Code/DataStructs/Wrap/wrap_SparseBV.cpp
@@ -16,6 +16,13 @@
 
 namespace python = boost::python;
 
+// Workaround for bug in Visual Studio 2015 Update 3
+#if defined(_MSC_VER) && (_MSC_VER == 1900) && (_MSC_FULL_VER >= 190024210)
+namespace boost {
+  template<> const volatile SparseBitVect* get_pointer(const volatile SparseBitVect* p) { return p; }
+}
+#endif
+
 // allows BitVects to be pickled
 struct sbv_pickle_suite : python::pickle_suite {
   static python::tuple getinitargs(const SparseBitVect &self) {

--- a/Code/Geometry/Wrap/UniformGrid3D.cpp
+++ b/Code/Geometry/Wrap/UniformGrid3D.cpp
@@ -20,6 +20,11 @@
 #include <Geometry/GridUtils.h>
 namespace python = boost::python;
 
+// Workaround for bug in Visual Studio 2015 Update 3
+namespace boost {
+  template<> const volatile RDGeom::UniformGrid3D* get_pointer(const volatile RDGeom::UniformGrid3D* p) { return p; }
+}
+
 using namespace RDKit;
 
 namespace RDGeom {

--- a/Code/Geometry/Wrap/UniformGrid3D.cpp
+++ b/Code/Geometry/Wrap/UniformGrid3D.cpp
@@ -21,9 +21,11 @@
 namespace python = boost::python;
 
 // Workaround for bug in Visual Studio 2015 Update 3
+#if defined(_MSC_VER) && (_MSC_VER == 1900) && (_MSC_FULL_VER >= 190024210)
 namespace boost {
   template<> const volatile RDGeom::UniformGrid3D* get_pointer(const volatile RDGeom::UniformGrid3D* p) { return p; }
 }
+#endif
 
 using namespace RDKit;
 

--- a/Code/GraphMol/ChemReactions/Wrap/Enumerate.cpp
+++ b/Code/GraphMol/ChemReactions/Wrap/Enumerate.cpp
@@ -38,6 +38,15 @@
 
 namespace python = boost::python;
 
+// Workaround for bug in Visual Studio 2015 Update 3
+namespace boost {
+  template<> const volatile RDKit::EnumerateLibraryBase* get_pointer(const volatile RDKit::EnumerateLibraryBase* p) { return p; }
+  template<> const volatile RDKit::EnumerationStrategyBase* get_pointer(const volatile RDKit::EnumerationStrategyBase* p) { return p; }
+  template<> const volatile RDKit::CartesianProductStrategy* get_pointer(const volatile RDKit::CartesianProductStrategy* p) { return p; }
+  template<> const volatile RDKit::RandomSampleStrategy* get_pointer(const volatile RDKit::RandomSampleStrategy* p) { return p; }
+  template<> const volatile RDKit::RandomSampleAllBBsStrategy* get_pointer(const volatile RDKit::RandomSampleAllBBsStrategy* p) { return p; }
+  template<> const volatile RDKit::EvenSamplePairsStrategy* get_pointer(const volatile RDKit::EvenSamplePairsStrategy* p) { return p; }
+}
 
 namespace RDKit {
   
@@ -428,6 +437,11 @@ for result in itertools.islice(libary2, 1000):\n\
 };
 
 }// end of namespace
+
+// Workaround for bug in Visual Studio 2015 Update 3
+namespace boost {
+  template<> const volatile RDKit::EnumerateLibraryWrap* get_pointer(const volatile RDKit::EnumerateLibraryWrap* p) { return p; }
+}
 
 void wrap_enumeration() {
   RDKit::enumeration_wrapper::wrap();

--- a/Code/GraphMol/ChemReactions/Wrap/Enumerate.cpp
+++ b/Code/GraphMol/ChemReactions/Wrap/Enumerate.cpp
@@ -39,6 +39,7 @@
 namespace python = boost::python;
 
 // Workaround for bug in Visual Studio 2015 Update 3
+#if defined(_MSC_VER) && (_MSC_VER == 1900) && (_MSC_FULL_VER >= 190024210)
 namespace boost {
   template<> const volatile RDKit::EnumerateLibraryBase* get_pointer(const volatile RDKit::EnumerateLibraryBase* p) { return p; }
   template<> const volatile RDKit::EnumerationStrategyBase* get_pointer(const volatile RDKit::EnumerationStrategyBase* p) { return p; }
@@ -47,6 +48,7 @@ namespace boost {
   template<> const volatile RDKit::RandomSampleAllBBsStrategy* get_pointer(const volatile RDKit::RandomSampleAllBBsStrategy* p) { return p; }
   template<> const volatile RDKit::EvenSamplePairsStrategy* get_pointer(const volatile RDKit::EvenSamplePairsStrategy* p) { return p; }
 }
+#endif
 
 namespace RDKit {
   
@@ -439,9 +441,11 @@ for result in itertools.islice(libary2, 1000):\n\
 }// end of namespace
 
 // Workaround for bug in Visual Studio 2015 Update 3
+#if defined(_MSC_VER) && (_MSC_VER == 1900) && (_MSC_FULL_VER >= 190024210)
 namespace boost {
   template<> const volatile RDKit::EnumerateLibraryWrap* get_pointer(const volatile RDKit::EnumerateLibraryWrap* p) { return p; }
 }
+#endif
 
 void wrap_enumeration() {
   RDKit::enumeration_wrapper::wrap();

--- a/Code/GraphMol/ChemReactions/Wrap/rdChemReactions.cpp
+++ b/Code/GraphMol/ChemReactions/Wrap/rdChemReactions.cpp
@@ -50,6 +50,12 @@
 
 namespace python = boost::python;
 
+// Workaround for bug in Visual Studio 2015 Update 3
+namespace boost {
+  template<> const volatile RDKit::ROMol* get_pointer(const volatile RDKit::ROMol* p) { return p; }
+  template<> const volatile ExplicitBitVect* get_pointer(const volatile ExplicitBitVect* p) { return p; }
+}
+
 void rdChemicalReactionParserExceptionTranslator(
     RDKit::ChemicalReactionParserException const &x) {
   std::ostringstream ss;

--- a/Code/GraphMol/ChemReactions/Wrap/rdChemReactions.cpp
+++ b/Code/GraphMol/ChemReactions/Wrap/rdChemReactions.cpp
@@ -51,10 +51,12 @@
 namespace python = boost::python;
 
 // Workaround for bug in Visual Studio 2015 Update 3
+#if defined(_MSC_VER) && (_MSC_VER == 1900) && (_MSC_FULL_VER >= 190024210)
 namespace boost {
   template<> const volatile RDKit::ROMol* get_pointer(const volatile RDKit::ROMol* p) { return p; }
   template<> const volatile ExplicitBitVect* get_pointer(const volatile ExplicitBitVect* p) { return p; }
 }
+#endif
 
 void rdChemicalReactionParserExceptionTranslator(
     RDKit::ChemicalReactionParserException const &x) {

--- a/Code/GraphMol/Descriptors/Wrap/rdMolDescriptors.cpp
+++ b/Code/GraphMol/Descriptors/Wrap/rdMolDescriptors.cpp
@@ -30,6 +30,14 @@
 
 namespace python = boost::python;
 
+// Workaround for bug in Visual Studio 2015 Update 3
+namespace boost {
+  template<> const volatile ExplicitBitVect* get_pointer(const volatile ExplicitBitVect* p) { return p; }
+  template<> const volatile RDKit::Descriptors::PropertyFunctor* get_pointer(const volatile RDKit::Descriptors::PropertyFunctor* p) { return p; }
+  template<> const volatile RDKit::ROMol* get_pointer(const volatile RDKit::ROMol* p) { return p; }
+  template<> const volatile Queries::RangeQuery<double, RDKit::ROMol const &, 1>* get_pointer(const volatile Queries::RangeQuery<double, RDKit::ROMol const &, 1>* p) { return p; }
+}
+
 namespace {
 std::vector<unsigned int> atomPairTypes(
     RDKit::AtomPairs::atomNumberTypes,

--- a/Code/GraphMol/Descriptors/Wrap/rdMolDescriptors.cpp
+++ b/Code/GraphMol/Descriptors/Wrap/rdMolDescriptors.cpp
@@ -31,12 +31,14 @@
 namespace python = boost::python;
 
 // Workaround for bug in Visual Studio 2015 Update 3
+#if defined(_MSC_VER) && (_MSC_VER == 1900) && (_MSC_FULL_VER >= 190024210)
 namespace boost {
   template<> const volatile ExplicitBitVect* get_pointer(const volatile ExplicitBitVect* p) { return p; }
   template<> const volatile RDKit::Descriptors::PropertyFunctor* get_pointer(const volatile RDKit::Descriptors::PropertyFunctor* p) { return p; }
   template<> const volatile RDKit::ROMol* get_pointer(const volatile RDKit::ROMol* p) { return p; }
   template<> const volatile Queries::RangeQuery<double, RDKit::ROMol const &, 1>* get_pointer(const volatile Queries::RangeQuery<double, RDKit::ROMol const &, 1>* p) { return p; }
 }
+#endif
 
 namespace {
 std::vector<unsigned int> atomPairTypes(

--- a/Code/GraphMol/FilterCatalog/Wrap/FilterCatalog.cpp
+++ b/Code/GraphMol/FilterCatalog/Wrap/FilterCatalog.cpp
@@ -40,6 +40,21 @@
 
 namespace python = boost::python;
 
+// Workaround for bug in Visual Studio 2015 Update 3
+namespace boost {
+  template<> const volatile RDKit::FilterCatalogEntry* get_pointer(const volatile RDKit::FilterCatalogEntry* p) { return p; }
+  template<> const volatile RDKit::FilterMatcherBase* get_pointer(const volatile RDKit::FilterMatcherBase* p) { return p; }
+  template<> const volatile RDKit::SmartsMatcher* get_pointer(const volatile RDKit::SmartsMatcher* p) { return p; }
+  template<> const volatile RDKit::ExclusionList* get_pointer(const volatile RDKit::ExclusionList* p) { return p; }
+  template<> const volatile RDKit::FilterCatalogParams* get_pointer(const volatile RDKit::FilterCatalogParams* p) { return p; }
+  template<> const volatile RDKit::FilterMatchOps::And* get_pointer(const volatile RDKit::FilterMatchOps::And* p) { return p; }
+  template<> const volatile RDKit::FilterMatchOps::Or* get_pointer(const volatile RDKit::FilterMatchOps::Or* p) { return p; }
+  template<> const volatile RDKit::FilterMatchOps::Not* get_pointer(const volatile RDKit::FilterMatchOps::Not* p) { return p; }
+  template<> const volatile RDKit::FilterHierarchyMatcher* get_pointer(const volatile RDKit::FilterHierarchyMatcher* p) { return p; }
+  template<> const volatile RDKit::FilterCatalog* get_pointer(const volatile RDKit::FilterCatalog* p) { return p; }
+  template<> const volatile RDKit::ROMol* get_pointer(const volatile RDKit::ROMol* p) { return p; }
+}
+
 namespace RDKit {
 
 struct filtercatalog_pickle_suite : python::pickle_suite {

--- a/Code/GraphMol/FilterCatalog/Wrap/FilterCatalog.cpp
+++ b/Code/GraphMol/FilterCatalog/Wrap/FilterCatalog.cpp
@@ -41,6 +41,7 @@
 namespace python = boost::python;
 
 // Workaround for bug in Visual Studio 2015 Update 3
+#if defined(_MSC_VER) && (_MSC_VER == 1900) && (_MSC_FULL_VER >= 190024210)
 namespace boost {
   template<> const volatile RDKit::FilterCatalogEntry* get_pointer(const volatile RDKit::FilterCatalogEntry* p) { return p; }
   template<> const volatile RDKit::FilterMatcherBase* get_pointer(const volatile RDKit::FilterMatcherBase* p) { return p; }
@@ -54,6 +55,7 @@ namespace boost {
   template<> const volatile RDKit::FilterCatalog* get_pointer(const volatile RDKit::FilterCatalog* p) { return p; }
   template<> const volatile RDKit::ROMol* get_pointer(const volatile RDKit::ROMol* p) { return p; }
 }
+#endif
 
 namespace RDKit {
 

--- a/Code/GraphMol/FragCatalog/Wrap/FragCatParams.cpp
+++ b/Code/GraphMol/FragCatalog/Wrap/FragCatParams.cpp
@@ -20,6 +20,14 @@
 #include <Catalogs/CatalogParams.h>
 
 namespace python = boost::python;
+
+// Workaround for bug in Visual Studio 2015 Update 3
+namespace boost {
+  template<> const volatile RDKit::FragCatParams* get_pointer(const volatile RDKit::FragCatParams* p) { return p; }
+  template<> const volatile RDKit::ROMol* get_pointer(const volatile RDKit::ROMol* p) { return p; }
+  template<> const volatile ExplicitBitVect* get_pointer(const volatile ExplicitBitVect* p) { return p; }
+}
+
 namespace RDKit {
 struct fragparams_wrapper {
   static void wrap() {

--- a/Code/GraphMol/FragCatalog/Wrap/FragCatParams.cpp
+++ b/Code/GraphMol/FragCatalog/Wrap/FragCatParams.cpp
@@ -22,11 +22,13 @@
 namespace python = boost::python;
 
 // Workaround for bug in Visual Studio 2015 Update 3
+#if defined(_MSC_VER) && (_MSC_VER == 1900) && (_MSC_FULL_VER >= 190024210)
 namespace boost {
   template<> const volatile RDKit::FragCatParams* get_pointer(const volatile RDKit::FragCatParams* p) { return p; }
   template<> const volatile RDKit::ROMol* get_pointer(const volatile RDKit::ROMol* p) { return p; }
   template<> const volatile ExplicitBitVect* get_pointer(const volatile ExplicitBitVect* p) { return p; }
 }
+#endif
 
 namespace RDKit {
 struct fragparams_wrapper {

--- a/Code/GraphMol/MolCatalog/Wrap/rdMolCatalog.cpp
+++ b/Code/GraphMol/MolCatalog/Wrap/rdMolCatalog.cpp
@@ -12,10 +12,12 @@
 namespace python = boost::python;
 
 // Workaround for bug in Visual Studio 2015 Update 3
+#if defined(_MSC_VER) && (_MSC_VER == 1900) && (_MSC_FULL_VER >= 190024210)
 namespace boost {
   template<> const volatile RDKit::ROMol* get_pointer(const volatile RDKit::ROMol* p) { return p; }
   template<> const volatile RDCatalog::HierarchCatalog<RDKit::MolCatalogEntry, RDKit::MolCatalogParams, int>* get_pointer(const volatile RDCatalog::HierarchCatalog<RDKit::MolCatalogEntry, RDKit::MolCatalogParams, int>* p) { return p; }
 }
+#endif
 
 using namespace RDKit;
 namespace {

--- a/Code/GraphMol/MolCatalog/Wrap/rdMolCatalog.cpp
+++ b/Code/GraphMol/MolCatalog/Wrap/rdMolCatalog.cpp
@@ -10,6 +10,13 @@
 #include <GraphMol/MolCatalog/MolCatalogParams.h>
 
 namespace python = boost::python;
+
+// Workaround for bug in Visual Studio 2015 Update 3
+namespace boost {
+  template<> const volatile RDKit::ROMol* get_pointer(const volatile RDKit::ROMol* p) { return p; }
+  template<> const volatile RDCatalog::HierarchCatalog<RDKit::MolCatalogEntry, RDKit::MolCatalogParams, int>* get_pointer(const volatile RDCatalog::HierarchCatalog<RDKit::MolCatalogEntry, RDKit::MolCatalogParams, int>* p) { return p; }
+}
+
 using namespace RDKit;
 namespace {
 struct molcatalog_pickle_suite : python::pickle_suite {

--- a/Code/GraphMol/MolChemicalFeatures/Wrap/MolChemicalFeature.cpp
+++ b/Code/GraphMol/MolChemicalFeatures/Wrap/MolChemicalFeature.cpp
@@ -19,6 +19,12 @@
 
 namespace python = boost::python;
 
+// Workaround for bug in Visual Studio 2015 Update 3
+namespace boost {
+  template<> const volatile RDKit::MolChemicalFeature* get_pointer(const volatile RDKit::MolChemicalFeature* p) { return p; }
+  template<> const volatile RDKit::ROMol* get_pointer(const volatile RDKit::ROMol* p) { return p; }
+}
+
 namespace RDKit {
 PyObject *getFeatAtomIds(const MolChemicalFeature &feat) {
   const MolChemicalFeature::AtomPtrContainer &atoms = feat.getAtoms();

--- a/Code/GraphMol/MolChemicalFeatures/Wrap/MolChemicalFeature.cpp
+++ b/Code/GraphMol/MolChemicalFeatures/Wrap/MolChemicalFeature.cpp
@@ -20,10 +20,12 @@
 namespace python = boost::python;
 
 // Workaround for bug in Visual Studio 2015 Update 3
+#if defined(_MSC_VER) && (_MSC_VER == 1900) && (_MSC_FULL_VER >= 190024210)
 namespace boost {
   template<> const volatile RDKit::MolChemicalFeature* get_pointer(const volatile RDKit::MolChemicalFeature* p) { return p; }
   template<> const volatile RDKit::ROMol* get_pointer(const volatile RDKit::ROMol* p) { return p; }
 }
+#endif
 
 namespace RDKit {
 PyObject *getFeatAtomIds(const MolChemicalFeature &feat) {

--- a/Code/GraphMol/MolDraw2D/Wrap/rdMolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/Wrap/rdMolDraw2D.cpp
@@ -25,9 +25,11 @@
 namespace python = boost::python;
 
 // Workaround for bug in Visual Studio 2015 Update 3
+#if defined(_MSC_VER) && (_MSC_VER == 1900) && (_MSC_FULL_VER >= 190024210)
 namespace boost {
   template<> const volatile RDKit::ROMol* get_pointer(const volatile RDKit::ROMol* p) { return p; }
 }
+#endif
 
 namespace RDKit {
 namespace {

--- a/Code/GraphMol/MolDraw2D/Wrap/rdMolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/Wrap/rdMolDraw2D.cpp
@@ -24,6 +24,11 @@
 
 namespace python = boost::python;
 
+// Workaround for bug in Visual Studio 2015 Update 3
+namespace boost {
+  template<> const volatile RDKit::ROMol* get_pointer(const volatile RDKit::ROMol* p) { return p; }
+}
+
 namespace RDKit {
 namespace {
 std::map<int, DrawColour> *pyDictToColourMap(python::object pyo) {

--- a/Code/GraphMol/ReducedGraphs/Wrap/rdReducedGraphs.cpp
+++ b/Code/GraphMol/ReducedGraphs/Wrap/rdReducedGraphs.cpp
@@ -25,6 +25,11 @@
 
 namespace python = boost::python;
 
+// Workaround for bug in Visual Studio 2015 Update 3
+namespace boost {
+  template<> const volatile RDKit::ROMol* get_pointer(const volatile RDKit::ROMol* p) { return p; }
+}
+
 namespace {
 RDKit::ROMol *GenerateMolExtendedReducedGraphHelper(const RDKit::ROMol &mol,
                                                     python::object atomTypes) {

--- a/Code/GraphMol/ReducedGraphs/Wrap/rdReducedGraphs.cpp
+++ b/Code/GraphMol/ReducedGraphs/Wrap/rdReducedGraphs.cpp
@@ -26,9 +26,11 @@
 namespace python = boost::python;
 
 // Workaround for bug in Visual Studio 2015 Update 3
+#if defined(_MSC_VER) && (_MSC_VER == 1900) && (_MSC_FULL_VER >= 190024210)
 namespace boost {
   template<> const volatile RDKit::ROMol* get_pointer(const volatile RDKit::ROMol* p) { return p; }
 }
+#endif
 
 namespace {
 RDKit::ROMol *GenerateMolExtendedReducedGraphHelper(const RDKit::ROMol &mol,

--- a/Code/GraphMol/SLNParse/Wrap/rdSLNParse.cpp
+++ b/Code/GraphMol/SLNParse/Wrap/rdSLNParse.cpp
@@ -43,9 +43,11 @@
 namespace python = boost::python;
 
 // Workaround for bug in Visual Studio 2015 Update 3
+#if defined(_MSC_VER) && (_MSC_VER == 1900) && (_MSC_FULL_VER >= 190024210)
 namespace boost {
   template<> const volatile RDKit::ROMol* get_pointer(const volatile RDKit::ROMol* p) { return p; }
 }
+#endif
 
 void rdSLNParseExceptionTranslator(RDKit::SLNParseException const &x) {
   std::ostringstream ss;

--- a/Code/GraphMol/SLNParse/Wrap/rdSLNParse.cpp
+++ b/Code/GraphMol/SLNParse/Wrap/rdSLNParse.cpp
@@ -42,6 +42,11 @@
 
 namespace python = boost::python;
 
+// Workaround for bug in Visual Studio 2015 Update 3
+namespace boost {
+  template<> const volatile RDKit::ROMol* get_pointer(const volatile RDKit::ROMol* p) { return p; }
+}
+
 void rdSLNParseExceptionTranslator(RDKit::SLNParseException const &x) {
   std::ostringstream ss;
   ss << "SLNParseException: " << x.message();

--- a/Code/GraphMol/Wrap/Atom.cpp
+++ b/Code/GraphMol/Wrap/Atom.cpp
@@ -27,6 +27,13 @@
 #include <algorithm>
 
 namespace python = boost::python;
+
+// Workaround for bug in Visual Studio 2015 Update 3
+namespace boost {
+  template<> const volatile RDKit::AtomPDBResidueInfo* get_pointer(const volatile RDKit::AtomPDBResidueInfo* p) { return p; }
+  template<> const volatile RDKit::AtomMonomerInfo* get_pointer(const volatile RDKit::AtomMonomerInfo* p) { return p; }
+}
+
 namespace RDKit {
 namespace {
 std::string qhelper(Atom::QUERYATOM_QUERY *q, unsigned int depth) {

--- a/Code/GraphMol/Wrap/Atom.cpp
+++ b/Code/GraphMol/Wrap/Atom.cpp
@@ -29,10 +29,12 @@
 namespace python = boost::python;
 
 // Workaround for bug in Visual Studio 2015 Update 3
+#if defined(_MSC_VER) && (_MSC_VER == 1900) && (_MSC_FULL_VER >= 190024210)
 namespace boost {
   template<> const volatile RDKit::AtomPDBResidueInfo* get_pointer(const volatile RDKit::AtomPDBResidueInfo* p) { return p; }
   template<> const volatile RDKit::AtomMonomerInfo* get_pointer(const volatile RDKit::AtomMonomerInfo* p) { return p; }
 }
+#endif
 
 namespace RDKit {
 namespace {

--- a/Code/GraphMol/Wrap/ForwardSDMolSupplier.cpp
+++ b/Code/GraphMol/Wrap/ForwardSDMolSupplier.cpp
@@ -129,8 +129,10 @@ struct forwardsdmolsup_wrap {
 }
 
 // Workaround for bug in Visual Studio 2015 Update 3
+#if defined(_MSC_VER) && (_MSC_VER == 1900) && (_MSC_FULL_VER >= 190024210)
 namespace boost {
   template<> const volatile LocalForwardSDMolSupplier* get_pointer(const volatile LocalForwardSDMolSupplier* p) { return p; };
 }
+#endif
 
 void wrap_forwardsdsupplier() { RDKit::forwardsdmolsup_wrap::wrap(); }

--- a/Code/GraphMol/Wrap/ForwardSDMolSupplier.cpp
+++ b/Code/GraphMol/Wrap/ForwardSDMolSupplier.cpp
@@ -128,4 +128,9 @@ struct forwardsdmolsup_wrap {
 };
 }
 
+// Workaround for bug in Visual Studio 2015 Update 3
+namespace boost {
+  template<> const volatile LocalForwardSDMolSupplier* get_pointer(const volatile LocalForwardSDMolSupplier* p) { return p; };
+}
+
 void wrap_forwardsdsupplier() { RDKit::forwardsdmolsup_wrap::wrap(); }

--- a/Code/GraphMol/Wrap/Mol.cpp
+++ b/Code/GraphMol/Wrap/Mol.cpp
@@ -666,4 +666,10 @@ struct mol_wrapper {
   };
 };
 }  // end of namespace
+
+// Workaround for bug in Visual Studio 2015 Update 3
+namespace boost {
+  template<> const volatile RDKit::ReadWriteMol* get_pointer(const volatile RDKit::ReadWriteMol* p) { return p; }
+}
+
 void wrap_mol() { RDKit::mol_wrapper::wrap(); }

--- a/Code/GraphMol/Wrap/Mol.cpp
+++ b/Code/GraphMol/Wrap/Mol.cpp
@@ -668,8 +668,10 @@ struct mol_wrapper {
 }  // end of namespace
 
 // Workaround for bug in Visual Studio 2015 Update 3
+#if defined(_MSC_VER) && (_MSC_VER == 1900) && (_MSC_FULL_VER >= 190024210)
 namespace boost {
   template<> const volatile RDKit::ReadWriteMol* get_pointer(const volatile RDKit::ReadWriteMol* p) { return p; }
 }
+#endif
 
 void wrap_mol() { RDKit::mol_wrapper::wrap(); }

--- a/Code/GraphMol/Wrap/MolOps.cpp
+++ b/Code/GraphMol/Wrap/MolOps.cpp
@@ -32,6 +32,13 @@
 #include <sstream>
 #include <GraphMol/MolDraw2D/MolDraw2DSVG.h>
 namespace python = boost::python;
+
+// Workaround for bug in Visual Studio 2015 Update 3
+namespace boost {
+  template<> const volatile RDKit::ROMol* get_pointer(const volatile RDKit::ROMol* p) { return p; }
+  template<> const volatile ExplicitBitVect* get_pointer(const volatile ExplicitBitVect* p) { return p; }
+}
+
 using boost_adaptbx::python::streambuf;
 
 namespace RDKit {

--- a/Code/GraphMol/Wrap/MolOps.cpp
+++ b/Code/GraphMol/Wrap/MolOps.cpp
@@ -34,10 +34,12 @@
 namespace python = boost::python;
 
 // Workaround for bug in Visual Studio 2015 Update 3
+#if defined(_MSC_VER) && (_MSC_VER == 1900) && (_MSC_FULL_VER >= 190024210)
 namespace boost {
   template<> const volatile RDKit::ROMol* get_pointer(const volatile RDKit::ROMol* p) { return p; }
   template<> const volatile ExplicitBitVect* get_pointer(const volatile ExplicitBitVect* p) { return p; }
 }
+#endif
 
 using boost_adaptbx::python::streambuf;
 

--- a/Code/GraphMol/Wrap/Queries.cpp
+++ b/Code/GraphMol/Wrap/Queries.cpp
@@ -18,10 +18,13 @@
 
 namespace python = boost::python;
 
+// Workaround for bug in Visual Studio 2015 Update 3
+#if defined(_MSC_VER) && (_MSC_VER == 1900) && (_MSC_FULL_VER >= 190024210)
 namespace boost {
   template<> const volatile RDKit::QueryBond* get_pointer(const volatile RDKit::QueryBond* p) { return p; }
   template<> const volatile RDKit::QueryAtom* get_pointer(const volatile RDKit::QueryAtom* p) { return p; }
 }
+#endif
 
 namespace RDKit {
 

--- a/Code/GraphMol/Wrap/Queries.cpp
+++ b/Code/GraphMol/Wrap/Queries.cpp
@@ -17,6 +17,12 @@
 #include <RDGeneral/types.h>
 
 namespace python = boost::python;
+
+namespace boost {
+  template<> const volatile RDKit::QueryBond* get_pointer(const volatile RDKit::QueryBond* p) { return p; }
+  template<> const volatile RDKit::QueryAtom* get_pointer(const volatile RDKit::QueryAtom* p) { return p; }
+}
+
 namespace RDKit {
 
 /*

--- a/Code/GraphMol/Wrap/SDMolSupplier.cpp
+++ b/Code/GraphMol/Wrap/SDMolSupplier.cpp
@@ -23,6 +23,11 @@
 
 namespace python = boost::python;
 
+// Workaround for bug in Visual Studio 2015 Update 3
+namespace boost {
+  template<> const volatile RDKit::SDMolSupplier* get_pointer(const volatile RDKit::SDMolSupplier* p) { return p; }
+}
+
 namespace RDKit {
 void setDataHelper(SDMolSupplier &self, const std::string &text, bool sanitize,
                    bool removeHs, bool strictParsing) {

--- a/Code/GraphMol/Wrap/SDMolSupplier.cpp
+++ b/Code/GraphMol/Wrap/SDMolSupplier.cpp
@@ -24,9 +24,11 @@
 namespace python = boost::python;
 
 // Workaround for bug in Visual Studio 2015 Update 3
+#if defined(_MSC_VER) && (_MSC_VER == 1900) && (_MSC_FULL_VER >= 190024210)
 namespace boost {
   template<> const volatile RDKit::SDMolSupplier* get_pointer(const volatile RDKit::SDMolSupplier* p) { return p; }
 }
+#endif
 
 namespace RDKit {
 void setDataHelper(SDMolSupplier &self, const std::string &text, bool sanitize,

--- a/Code/GraphMol/Wrap/SmilesMolSupplier.cpp
+++ b/Code/GraphMol/Wrap/SmilesMolSupplier.cpp
@@ -22,6 +22,11 @@
 
 namespace python = boost::python;
 
+// Workaround for bug in Visual Studio 2015 Update 3
+namespace boost {
+  template<> const volatile RDKit::SmilesMolSupplier* get_pointer(const volatile RDKit::SmilesMolSupplier* p) { return p; }
+}
+
 namespace RDKit {
 
 SmilesMolSupplier *SmilesSupplierFromText(

--- a/Code/GraphMol/Wrap/SmilesMolSupplier.cpp
+++ b/Code/GraphMol/Wrap/SmilesMolSupplier.cpp
@@ -23,9 +23,11 @@
 namespace python = boost::python;
 
 // Workaround for bug in Visual Studio 2015 Update 3
+#if defined(_MSC_VER) && (_MSC_VER == 1900) && (_MSC_FULL_VER >= 190024210)
 namespace boost {
   template<> const volatile RDKit::SmilesMolSupplier* get_pointer(const volatile RDKit::SmilesMolSupplier* p) { return p; }
 }
+#endif
 
 namespace RDKit {
 

--- a/Code/GraphMol/Wrap/TDTMolSupplier.cpp
+++ b/Code/GraphMol/Wrap/TDTMolSupplier.cpp
@@ -21,9 +21,11 @@
 namespace python = boost::python;
 
 // Workaround for bug in Visual Studio 2015 Update 3
+#if defined(_MSC_VER) && (_MSC_VER == 1900) && (_MSC_FULL_VER >= 190024210)
 namespace boost {
   template<> const volatile RDKit::TDTMolSupplier* get_pointer(const volatile RDKit::TDTMolSupplier* p) { return p; }
 }
+#endif
 
 namespace RDKit {
 

--- a/Code/GraphMol/Wrap/TDTMolSupplier.cpp
+++ b/Code/GraphMol/Wrap/TDTMolSupplier.cpp
@@ -20,6 +20,11 @@
 
 namespace python = boost::python;
 
+// Workaround for bug in Visual Studio 2015 Update 3
+namespace boost {
+  template<> const volatile RDKit::TDTMolSupplier* get_pointer(const volatile RDKit::TDTMolSupplier* p) { return p; }
+}
+
 namespace RDKit {
 
 std::string tdtMolSupplierClassDoc =

--- a/Code/GraphMol/Wrap/rdchem.cpp
+++ b/Code/GraphMol/Wrap/rdchem.cpp
@@ -27,11 +27,13 @@
 namespace python = boost::python;
 
 // Workaround for bug in Visual Studio 2015 Update 3
+#if defined(_MSC_VER) && (_MSC_VER == 1900) && (_MSC_FULL_VER >= 190024210)
 namespace boost {
   template<> const volatile RDKit::Bond* get_pointer(const volatile RDKit::Bond* p) { return p; }
   template<> const volatile RDKit::Atom* get_pointer(const volatile RDKit::Atom* p) { return p; }
   template<> const volatile RDKit::ROMol* get_pointer(const volatile RDKit::ROMol* p) { return p; }
 }
+#endif
 
 using namespace RDKit;
 

--- a/Code/GraphMol/Wrap/rdchem.cpp
+++ b/Code/GraphMol/Wrap/rdchem.cpp
@@ -25,6 +25,14 @@
 
 #include "seqs.hpp"
 namespace python = boost::python;
+
+// Workaround for bug in Visual Studio 2015 Update 3
+namespace boost {
+  template<> const volatile RDKit::Bond* get_pointer(const volatile RDKit::Bond* p) { return p; }
+  template<> const volatile RDKit::Atom* get_pointer(const volatile RDKit::Atom* p) { return p; }
+  template<> const volatile RDKit::ROMol* get_pointer(const volatile RDKit::ROMol* p) { return p; }
+}
+
 using namespace RDKit;
 
 namespace RDKit {

--- a/Code/GraphMol/Wrap/rdmolfiles.cpp
+++ b/Code/GraphMol/Wrap/rdmolfiles.cpp
@@ -34,6 +34,12 @@
 #include <GraphMol/SanitException.h>
 
 namespace python = boost::python;
+
+// Workaround for bug in Visual Studio 2015 Update 3
+namespace boost {
+  template<> const volatile RDKit::ROMol* get_pointer(const volatile RDKit::ROMol* p) { return p; }
+}
+
 using namespace RDKit;
 
 void rdSanitExceptionTranslator(RDKit::MolSanitizeException const &x) {

--- a/Code/GraphMol/Wrap/rdmolfiles.cpp
+++ b/Code/GraphMol/Wrap/rdmolfiles.cpp
@@ -36,9 +36,11 @@
 namespace python = boost::python;
 
 // Workaround for bug in Visual Studio 2015 Update 3
+#if defined(_MSC_VER) && (_MSC_VER == 1900) && (_MSC_FULL_VER >= 190024210)
 namespace boost {
   template<> const volatile RDKit::ROMol* get_pointer(const volatile RDKit::ROMol* p) { return p; }
 }
+#endif
 
 using namespace RDKit;
 

--- a/External/AvalonTools/Wrap/pyAvalonTools.cpp
+++ b/External/AvalonTools/Wrap/pyAvalonTools.cpp
@@ -16,9 +16,11 @@ extern "C" {
 }
 
 // Workaround for bug in Visual Studio 2015 Update 3
+#if defined(_MSC_VER) && (_MSC_VER == 1900) && (_MSC_FULL_VER >= 190024210)
 namespace boost {
   template<> const volatile ExplicitBitVect* get_pointer(const volatile ExplicitBitVect* p) { return p; }
 }
+#endif
 
 namespace python = boost::python;
 

--- a/External/AvalonTools/Wrap/pyAvalonTools.cpp
+++ b/External/AvalonTools/Wrap/pyAvalonTools.cpp
@@ -15,6 +15,11 @@ extern "C" {
 #include "struchk.h"
 }
 
+// Workaround for bug in Visual Studio 2015 Update 3
+namespace boost {
+  template<> const volatile ExplicitBitVect* get_pointer(const volatile ExplicitBitVect* p) { return p; }
+}
+
 namespace python = boost::python;
 
 namespace {


### PR DESCRIPTION
There is a bug in the current version of Microsoft Visual Studio 2015 that causes linker errors with boost python. For example:

    rdMolCatalog.cpp.obj : error LNK2019: unresolved external symbol "class RDKit::ROMol const volatile * __cdecl boost::get_pointer<class RDKit::ROMol const volatile >(class RDKit::ROMol const volatile *)" (??$get_pointer@$$CDVROMol@RDKit@@@boost@@YAPEDVROMol@RDKit@@PEDV12@@Z)

It appears that this is a known issue that will supposedly be fixed in a future version of Visual Studio. For more details see:

- https://connect.microsoft.com/VisualStudio/Feedback/Details/2852624
- http://stackoverflow.com/questions/38261530/unresolved-external-symbols-since-visual-studio-2015-update-3-boost-python-link

This pull request contains the changes I had to make to successfully compile with Visual Studio 2015. I basically just naively implemented the suggested workaround from the Microsoft bug tracker.