### PR TITLE
Removes exponetial numBonds behavior

### DIFF
--- a/Code/GraphMol/ROMol.cpp
+++ b/Code/GraphMol/ROMol.cpp
@@ -48,16 +48,6 @@ ROMol::ROMol(const std::string &pickle) : RDProps() {
   numBonds = rdcast<unsigned int>(boost::num_edges(d_graph));
 }
 
-std::string ROMol::GetName() const {
-  std::string result;
-  getPropIfPresent(common_properties::_Name, result);
-  return result;
-}
-
-void ROMol::SetName(const std::string &name) {
-  setProp<std::string>(common_properties::_Name, name);
-}
-
 void ROMol::initFromOther(const ROMol &other, bool quickCopy, int confId) {
   if (this == &other) return;
   numBonds = 0;

--- a/Code/GraphMol/ROMol.cpp
+++ b/Code/GraphMol/ROMol.cpp
@@ -43,12 +43,24 @@ void ROMol::destroy() {
 
 ROMol::ROMol(const std::string &pickle) : RDProps() {
   initMol();
+  numBonds = 0;
   MolPickler::molFromPickle(pickle, *this);
+  numBonds = rdcast<unsigned int>(boost::num_edges(d_graph));
+}
+
+std::string ROMol::GetName() const {
+  std::string result;
+  getPropIfPresent(common_properties::_Name, result);
+  return result;
+}
+
+void ROMol::SetName(const std::string &name) {
+  setProp<std::string>(common_properties::_Name, name);
 }
 
 void ROMol::initFromOther(const ROMol &other, bool quickCopy, int confId) {
   if (this == &other) return;
-
+  numBonds = 0;
   // std::cerr<<"    init from other: "<<this<<" "<<&other<<std::endl;
   // copy over the atoms
   const MolGraph &oGraph = other.d_graph;
@@ -360,9 +372,10 @@ unsigned int ROMol::addBond(Bond *bond_pin, bool takeOwnership) {
                                           bond_p->getEndAtomIdx(), d_graph);
   CHECK_INVARIANT(ok, "bond could not be added");
   d_graph[which].reset(bond_p);
-  int res = rdcast<int>(boost::num_edges(d_graph));
-  bond_p->setIdx(res - 1);
-  return res;
+  numBonds++;
+  //  int res = rdcast<int>(boost::num_edges(d_graph));
+  bond_p->setIdx(numBonds - 1);
+  return numBonds;//res;
 }
 unsigned int ROMol::addBond(Bond::BOND_SPTR bsp) { return addBond(bsp.get()); }
 

--- a/Code/GraphMol/ROMol.h
+++ b/Code/GraphMol/ROMol.h
@@ -42,8 +42,11 @@ typedef boost::shared_ptr<Atom> ATOM_SPTR;
 typedef boost::shared_ptr<Bond> BOND_SPTR;
 
 //! This is the BGL type used to store the topology:
-typedef boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS,
-                              ATOM_SPTR, BOND_SPTR>
+typedef boost::adjacency_list<
+    boost::vecS,
+    boost::vecS,
+    boost::undirectedS,
+    ATOM_SPTR, BOND_SPTR>
     MolGraph;
 class MolPickler;
 class RWMol;
@@ -175,7 +178,7 @@ class ROMol : public RDProps {
   //@}
   //! \endcond
 
-  ROMol() : RDProps() { initMol(); }
+  ROMol() : RDProps(), numBonds(0) { initMol(); }
 
   //! copy constructor with a twist
   /*!
@@ -191,12 +194,18 @@ class ROMol : public RDProps {
   ROMol(const ROMol &other, bool quickCopy = false, int confId = -1) : RDProps() {
     dp_ringInfo = 0;
     initFromOther(other, quickCopy, confId);
+    numBonds = rdcast<unsigned int>(boost::num_edges(d_graph));
   };
   //! construct a molecule from a pickle string
   ROMol(const std::string &binStr);
 
   virtual ~ROMol() { destroy(); };
 
+  //! \name Molecule Name or Title
+  //@{
+  std::string GetName() const;
+  void        SetName(const std::string &);
+  //@}
   //! \name Atoms
   //@{
 
@@ -591,8 +600,12 @@ class ROMol : public RDProps {
   ROMol &operator=(
       const ROMol &);  // disable assignment, RWMol's support assignment
 
-#ifdef WIN32
- protected:
+protected:
+  unsigned int numBonds;  
+#ifndef WIN32
+private:
+
+
 #endif
   void initMol();
   virtual void destroy();

--- a/Code/GraphMol/ROMol.h
+++ b/Code/GraphMol/ROMol.h
@@ -201,10 +201,6 @@ class ROMol : public RDProps {
 
   virtual ~ROMol() { destroy(); };
 
-  //! \name Molecule Name or Title
-  //@{
-  std::string GetName() const;
-  void        SetName(const std::string &);
   //@}
   //! \name Atoms
   //@{

--- a/Code/GraphMol/RWMol.cpp
+++ b/Code/GraphMol/RWMol.cpp
@@ -31,6 +31,7 @@ RWMol &RWMol::operator=(const RWMol &other) {
   if (this != &other) {
     this->clear();
     d_partialBonds.clear();
+    numBonds = 0;
     initFromOther(other, false, -1);
   }
   return *this;
@@ -269,8 +270,9 @@ unsigned int RWMol::addBond(unsigned int atomIdx1, unsigned int atomIdx2,
   MolGraph::edge_descriptor which;
   boost::tie(which, ok) = boost::add_edge(atomIdx1, atomIdx2, d_graph);
   d_graph[which].reset(b);
-  unsigned int res = rdcast<unsigned int>(boost::num_edges(d_graph));
-  b->setIdx(res - 1);
+  //unsigned int res = rdcast<unsigned int>(boost::num_edges(d_graph));
+  ++numBonds;
+  b->setIdx(numBonds - 1);
   b->setBeginAtomIdx(atomIdx1);
   b->setEndAtomIdx(atomIdx2);
 
@@ -282,7 +284,7 @@ unsigned int RWMol::addBond(unsigned int atomIdx1, unsigned int atomIdx2,
     dp_ringInfo->reset();
   }
 
-  return res;
+  return numBonds;//res;
 }
 
 unsigned int RWMol::addBond(Atom *atom1, Atom *atom2, Bond::BondType bondType) {
@@ -353,6 +355,7 @@ void RWMol::removeBond(unsigned int aid1, unsigned int aid2) {
   MolGraph::vertex_descriptor vd1 = boost::vertex(aid1, d_graph);
   MolGraph::vertex_descriptor vd2 = boost::vertex(aid2, d_graph);
   boost::remove_edge(vd1, vd2, d_graph);
+  --numBonds;
 }
 
 Bond *RWMol::createPartialBond(unsigned int atomIdx1, Bond::BondType bondType) {


### PR DESCRIPTION
As it turns out, boost::graph's use of a list has a non-constant behavior for getting the number of bonds (edges).  This is a patch to prevent this behavior for large systems.

It is somewhat informational, @coleb - please check to see if this helps your run-times.