### PR TITLE
Added getAlignmentTransform to ROMol.i to expose in Java SWIG wrapper

### DIFF
--- a/Code/JavaWrappers/ROMol.i
+++ b/Code/JavaWrappers/ROMol.i
@@ -370,12 +370,21 @@
                   bool reflect=false, unsigned int maxIters=50) {
     return RDKit::MolAlign::alignMol(*($self), refMol, prbCid, refCid, atomMap, weights, reflect, maxIters);
   }
-
+  
   void alignMolConformers(ROMol &mol, const std::vector<unsigned int> *atomIds=0,
                           const std::vector<unsigned int> *confIds=0,
                           const RDNumeric::DoubleVector  *weights=0, 
                           bool reflect=false, unsigned int maxIters=50) {
     RDKit::MolAlign::alignMolConformers(*($self), atomIds, confIds, weights, reflect, maxIters);
+  }
+  
+  /* From GraphMol/MolAlign/AlignMolecules */
+  double getAlignmentTransform(const RDKit::ROMol &refMol,
+                             RDGeom::Transform3D &trans, int prbCid = -1,
+                             int refCid = -1, const std::vector<std::pair<int,int> > *atomMap = 0,
+                             const RDNumeric::DoubleVector *weights = 0,
+                             bool reflect = false, unsigned int maxIters = 50){
+     return RDKit::MolAlign::getAlignmentTransform(*($self),refMol,trans,refCid,atomMap,weights,reflect,maxIters);
   }
 
   /* From GraphMol/MolAlign/AlignMolecules */

--- a/Code/JavaWrappers/ROMol.i
+++ b/Code/JavaWrappers/ROMol.i
@@ -384,7 +384,7 @@
                              int refCid = -1, const std::vector<std::pair<int,int> > *atomMap = 0,
                              const RDNumeric::DoubleVector *weights = 0,
                              bool reflect = false, unsigned int maxIters = 50){
-     return RDKit::MolAlign::getAlignmentTransform(*($self),refMol,trans,refCid,atomMap,weights,reflect,maxIters);
+     return RDKit::MolAlign::getAlignmentTransform(*($self), refMol, trans, prbCid, refCid, atomMap, weights, reflect, maxIters);
   }
 
   /* From GraphMol/MolAlign/AlignMolecules */

--- a/Code/JavaWrappers/gmwrapper/src-test/org/RDKit/AlignTests.java
+++ b/Code/JavaWrappers/gmwrapper/src-test/org/RDKit/AlignTests.java
@@ -54,6 +54,22 @@ public class AlignTests extends GraphMolTest {
             
 	}
     
+	@Test
+	public void testgetAlignmentTransform(){
+		//Test alignment with Transform base on GraphMol/MolAlign/testMolAlign.cpp#test1MolAlign()
+		String fname0 = new File(getRDBase(),
+					 "Code/GraphMol/MolAlign/test_data/1oir.mol").getPath();
+		String fname1 = new File(getRDBase(),
+					 "Code/GraphMol/MolAlign/test_data/1oir_conf.mol").getPath();
+		ROMol m0 = RWMol.MolFromMolFile(fname0);
+		ROMol m1 = RWMol.MolFromMolFile(fname1);
+		Transform3D trans = new Transform3D();
+		double res = m0.getAlignmentTransform(m1);
+		assetEquals(res, 0.6578);
+		m0.delete();
+		m1.delete();
+	}
+	
 	public static void main(String args[]) {
 		org.junit.runner.JUnitCore.main("org.RDKit.AlignTests");
 	}

--- a/Code/JavaWrappers/gmwrapper/src-test/org/RDKit/AlignTests.java
+++ b/Code/JavaWrappers/gmwrapper/src-test/org/RDKit/AlignTests.java
@@ -64,7 +64,7 @@ public class AlignTests extends GraphMolTest {
 		ROMol m0 = RWMol.MolFromMolFile(fname0);
 		ROMol m1 = RWMol.MolFromMolFile(fname1);
 		Transform3D trans = new Transform3D();
-		double res = m0.getAlignmentTransform(m1);
+		double res = m0.getAlignmentTransform(m1, trans);
 		assetEquals(res, 0.6578);
 		m0.delete();
 		m1.delete();

--- a/Code/JavaWrappers/gmwrapper/src-test/org/RDKit/AlignTests.java
+++ b/Code/JavaWrappers/gmwrapper/src-test/org/RDKit/AlignTests.java
@@ -65,7 +65,7 @@ public class AlignTests extends GraphMolTest {
 		ROMol m1 = RWMol.MolFromMolFile(fname1);
 		Transform3D trans = new Transform3D();
 		double res = m0.getAlignmentTransform(m1, trans);
-		assertEquals(res, 0.6578);
+		assertEquals(res, 0.6578, 0.001);
 		m0.delete();
 		m1.delete();
 	}

--- a/Code/JavaWrappers/gmwrapper/src-test/org/RDKit/AlignTests.java
+++ b/Code/JavaWrappers/gmwrapper/src-test/org/RDKit/AlignTests.java
@@ -57,15 +57,15 @@ public class AlignTests extends GraphMolTest {
 	@Test
 	public void testgetAlignmentTransform(){
 		//Test alignment with Transform base on GraphMol/MolAlign/testMolAlign.cpp#test1MolAlign()
-		String fname0 = new File(getRDBase(),
+		String fname0 = new File(getRdBase(),
 					 "Code/GraphMol/MolAlign/test_data/1oir.mol").getPath();
-		String fname1 = new File(getRDBase(),
+		String fname1 = new File(getRdBase(),
 					 "Code/GraphMol/MolAlign/test_data/1oir_conf.mol").getPath();
 		ROMol m0 = RWMol.MolFromMolFile(fname0);
 		ROMol m1 = RWMol.MolFromMolFile(fname1);
 		Transform3D trans = new Transform3D();
 		double res = m0.getAlignmentTransform(m1, trans);
-		assetEquals(res, 0.6578);
+		assertEquals(res, 0.6578);
 		m0.delete();
 		m1.delete();
 	}


### PR DESCRIPTION
Adding this method to the Java wrappers will allow RMSD calculations without the need to actually align the probe conformation to the reference