### PR TITLE
only use boost::multiprecision when it is installed

### DIFF
--- a/Code/GraphMol/ChemReactions/Enumerate/EnumerationStrategyBase.h
+++ b/Code/GraphMol/ChemReactions/Enumerate/EnumerationStrategyBase.h
@@ -37,7 +37,6 @@
 #include <vector>
 #include <RDGeneral/BoostStartInclude.h>
 #include <boost/cstdint.hpp>
-#include <boost/multiprecision/cpp_int.hpp>
 #include <boost/serialization/assume_abstract.hpp>
 #include <boost/serialization/vector.hpp>
 // the next two includes need to be there for boost 1.56


### PR DESCRIPTION
With this change the code can now be built on systems with older versions of boost (multiprecision first showed up in 1.53).