### PR TITLE
Fix resMolSupplierTest for boost 1.62

### DIFF
--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -3248,13 +3248,11 @@ CAS<~>
 
     resMolSuppl = Chem.ResonanceMolSupplier(mol, Chem.KEKULE_ALL)
     self.assertEqual(len(resMolSuppl), 8)
-    bondTypeDict = {}
     # check that we actually have two alternate Kekule structures
-    bondTypeDict[resMolSuppl[0].GetBondBetweenAtoms(3, 4).GetBondType()] = True
-    bondTypeDict[resMolSuppl[1].GetBondBetweenAtoms(3, 4).GetBondType()] = True
-    self.assertEqual(len(bondTypeDict), 2)
+    bondTypes = set(r.GetBondBetweenAtoms(3, 4).GetBondType() for r in resMolSuppl)
+    self.assertEqual(len(bondTypes), 2)
 
-    bondTypeDict = {}
+    bondTypes = set()
     resMolSuppl = Chem.ResonanceMolSupplier(mol,
       Chem.ALLOW_INCOMPLETE_OCTETS \
       | Chem.UNCONSTRAINED_CATIONS \

--- a/Code/GraphMol/resMolSupplierTest.cpp
+++ b/Code/GraphMol/resMolSupplierTest.cpp
@@ -83,14 +83,13 @@ void testBaseFunctionality() {
   resMolSuppl =
       new ResonanceMolSupplier((ROMol &)*mol, ResonanceMolSupplier::KEKULE_ALL);
   TEST_ASSERT(resMolSuppl->length() == 8);
-  std::map<Bond::BondType, bool> bondTypeMap;
+  std::set<Bond::BondType> bondTypes;
   // check that we actually have two alternate Kekule structures
-  bondTypeMap[(*resMolSuppl)[0]->getBondBetweenAtoms(3, 4)->getBondType()] =
-      true;
-  bondTypeMap[(*resMolSuppl)[1]->getBondBetweenAtoms(3, 4)->getBondType()] =
-      true;
-  TEST_ASSERT(bondTypeMap.size() == 2);
-  bondTypeMap.clear();
+  for (unsigned int i = 0; i < resMolSuppl->length(); ++i) {
+    bondTypes.insert((*resMolSuppl)[i]->getBondBetweenAtoms(3, 4)->getBondType());
+  }
+  TEST_ASSERT(bondTypes.size() == 2);
+  bondTypes.clear();
   delete resMolSuppl;
 
   resMolSuppl = new ResonanceMolSupplier(


### PR DESCRIPTION
I've found that molecules seem to be produced in a different order from the ResonanceMolSupplier when using boost 1.62 (on Windows), causing one of the tests to fail.

The test in question looked at the first two molecules supplied for a given SMILES with the `KEKULE_ALL` option on, and checked to see if a specific bond type changed. Unfortunately it seems with boost 1.62 the first two resonance forms both have the same bond type in that position.

I've modified the test to look at all 8 supplied molecules, and check whether there are at least two different bond types amongst the whole set.

cc @ptosco 
