### PR TITLE
Include <boost/cstdint.hpp> for uint64_t

### DIFF
--- a/Code/GraphMol/ChemReactions/Wrap/Enumerate.cpp
+++ b/Code/GraphMol/ChemReactions/Wrap/Enumerate.cpp
@@ -35,6 +35,7 @@
 #include <GraphMol/ChemReactions/Enumerate/EvenSamplePairs.h>
 #include <GraphMol/ChemReactions/Enumerate/Enumerate.h>
 #include <boost/python/stl_iterator.hpp>
+#include <boost/cstdint.hpp>
 
 namespace python = boost::python;
 
@@ -146,7 +147,7 @@ void ToBBS(EnumerationStrategyBase &rgroup, ChemicalReaction &rxn, python::list 
   rgroup.initialize(rxn, ConvertToVect(ob));
 }
 
-typedef std::vector<uint64_t> VectSizeT;
+typedef std::vector<boost::uint64_t> VectSizeT;
 typedef std::vector<std::vector<std::string> > VectStringVect;
 typedef std::vector<MOL_SPTR_VECT > VectMolVect;
 


### PR DESCRIPTION
One more occurrence of `uint64_t` that requires `<boost/cstdint.hpp>` due to the lack of `<stdint.h>` in Visual Studio 2008.