### PR TITLE
replace std::map::at with std::map::find

### DIFF
--- a/Code/GraphMol/StructChecker/AtomSymbolMatch.cpp
+++ b/Code/GraphMol/StructChecker/AtomSymbolMatch.cpp
@@ -63,7 +63,7 @@ class AtomSymbolMapper {
     for (unsigned n = 0; n < 110; n++) SymbolMap[AtomSymbol[n]] = n;
   }
   inline unsigned getAtomicNumber(const std::string symbol) const {
-    return SymbolMap.at(symbol);
+    return SymbolMap.find(symbol)->second;
   }
 };
 static const AtomSymbolMapper smap;


### PR DESCRIPTION
The 'at' method of std::map is a C++11 feature not supported by Visual Studio 2008.