### PR TITLE
Fix Trajectory GetSnapshot behaviour after Clear

### DIFF
--- a/Code/GraphMol/Trajectory/Trajectory.cpp
+++ b/Code/GraphMol/Trajectory/Trajectory.cpp
@@ -65,7 +65,7 @@ unsigned int Trajectory::addSnapshot(const Snapshot &s) {
 }
 
 const Snapshot &Trajectory::getSnapshot(unsigned int snapshotNum) const {
-  URANGE_CHECK(snapshotNum, d_snapshotVect->size() - 1);
+  URANGE_CHECK(snapshotNum + 1, d_snapshotVect->size());
   return (*d_snapshotVect)[snapshotNum];
 }
 
@@ -77,7 +77,7 @@ unsigned int Trajectory::insertSnapshot(unsigned int snapshotNum, Snapshot s) {
 }
 
 unsigned int Trajectory::removeSnapshot(unsigned int snapshotNum) {
-  URANGE_CHECK(snapshotNum, d_snapshotVect->size() - 1);
+  URANGE_CHECK(snapshotNum + 1, d_snapshotVect->size());
   return (d_snapshotVect->erase(d_snapshotVect->begin() + snapshotNum) - d_snapshotVect->begin());
 }
 

--- a/Code/GraphMol/Trajectory/trajectoryTest.cpp
+++ b/Code/GraphMol/Trajectory/trajectoryTest.cpp
@@ -469,11 +469,6 @@ void testAddConformersFromTrajectory() {
   Trajectory traj(3, mol->getNumAtoms(), sv);
   mol->removeConformer(0);
   traj.addConformersToMol(*mol);
-  traj.clear();
-  unsigned int n1 = mol->getNumConformers();
-  traj.addConformersToMol(*mol);
-  unsigned int n2 = mol->getNumConformers();
-  TEST_ASSERT(n1 == n2);
   for (unsigned int nConf = 0;
     nConf < mol->getNumConformers(); ++nConf) {
     std::stringstream ss;
@@ -483,6 +478,21 @@ void testAddConformersFromTrajectory() {
     w.write(*mol, nConf);
   }
   w.close();
+  traj.clear();
+  unsigned int n1 = mol->getNumConformers();
+  traj.addConformersToMol(*mol);
+  unsigned int n2 = mol->getNumConformers();
+  TEST_ASSERT(n1 == n2);
+  // getSnapshot should raise exception after Clear()
+  bool ok = false;
+  try {
+    traj.getSnapshot(0);
+  }
+  catch (Invar::Invariant &e) {
+    BOOST_LOG(rdErrorLog) << e.getMessage() << std::endl;
+    ok = true;
+  }
+  TEST_ASSERT(ok);
   delete field;
   delete mol;
 }

--- a/Code/GraphMol/Wrap/testTrajectory.py
+++ b/Code/GraphMol/Wrap/testTrajectory.py
@@ -422,15 +422,22 @@ class TestCase(unittest.TestCase):
     traj = Trajectory(3, mol.GetNumAtoms(), sv)
     mol.RemoveConformer(0)
     traj.AddConformersToMol(mol)
+    for nConf in range(mol.GetNumConformers()):
+      mol.SetProp('ENERGY', '{0:.4f}'.format(traj.GetSnapshot(nConf).GetEnergy()))
+      w.write(mol, nConf)
+    w.close()
     traj.Clear()
     n1 = mol.GetNumConformers()
     traj.AddConformersToMol(mol)
     n2 = mol.GetNumConformers()
     self.assertEqual(n1, n2)
-    for nConf in range(mol.GetNumConformers()):
-      mol.SetProp('ENERGY', '{0:.4f}'.format(traj.GetSnapshot(nConf).GetEnergy()))
-      w.write(mol, nConf)
-    w.close()
+    # GetSnapshot should raise exception after Clear()
+    e = False
+    try:
+      traj.GetSnapshot(0)
+    except:
+      e = True
+    self.assertTrue(e)
 
   def testAddConformersFromAmberTrajectory(self):
     mol = Chem.MolFromSmiles('CCC')

--- a/Code/JavaWrappers/gmwrapper/src-test/org/RDKit/TrajectoryTests.java
+++ b/Code/JavaWrappers/gmwrapper/src-test/org/RDKit/TrajectoryTests.java
@@ -1,6 +1,6 @@
 /*
 *  Copyright (C) 2016 Sereina Riniker, Paolo Tosco
-* 
+*
 *    @@ All Rights Reserved @@
 *   This file is part of the RDKit.
 *   The contents are covered by the terms of the BSD license
@@ -539,17 +539,26 @@ public class TrajectoryTests extends GraphMolTest {
         Trajectory traj = new Trajectory(3, mol.getNumAtoms(), sv);
         mol.removeConformer(0);
         traj.addConformersToMol(mol);
-        traj.clear();
-        long n1 = mol.getNumConformers();
-        traj.addConformersToMol(mol);
-        long n2 = mol.getNumConformers();
-        assertEquals(n2, n1);
         for (int nConf = 0; nConf < mol.getNumConformers(); ++nConf) {
             String ss = String.format("%.4f", traj.getSnapshot(nConf).getEnergy());
             mol.setProp("ENERGY", ss, false);
             w.write(mol, nConf);
         }
         w.close();
+        traj.clear();
+        long n1 = mol.getNumConformers();
+        traj.addConformersToMol(mol);
+        long n2 = mol.getNumConformers();
+        assertEquals(n2, n1);
+        // getSnapshot should raise exception after Clear()
+        boolean e = false;
+        try {
+            traj.getSnapshot(0);
+        }
+        catch (GenericRDKitException ex) {
+            e = true;
+        }
+        assertEquals(true, e);
     }
 
     @Test


### PR DESCRIPTION
This fixes an issue with the `URANGE_CHECK` in the `getSnapshot` and `removeSnapshot` methods on `Trajectory`.

I came across the issue due to trajectory test failures when compiling with VS2008: any `GetSnapshot(n)` call on a `Trajectory` after calling `Clear()` results in a crash, rather than the expected Range Error Runtime error. For other compilers, the underlying vector elements may happen to still be accessible after calling clear on the vector, so the tests pass, but a similar crash can occur if an index larger than the original size of the vector is passed to `GetSnapshot(n)`.

The problem occurs specifically when the snapshot vector is empty - the size is zero as an unsigned int, which I think rolls over to INT_MAX when 1 is subtracted. As a result, `URANGE_CHECK` fails to catch any out of range access.

The tests shouldn't be trying to access the snapshots after clearing the trajectory anyway, so they have also been updated to get the snapshot energies before testing the `Clear()` behaviour.