### PR TITLE
Expose RWMol.ReplaceBond to Python

### DIFF
--- a/Code/GraphMol/Wrap/Mol.cpp
+++ b/Code/GraphMol/Wrap/Mol.cpp
@@ -235,6 +235,7 @@ class ReadWriteMol : public RWMol {
     return addAtom(atom, true, false);
   };
   void ReplaceAtom(unsigned int idx, Atom *atom) { replaceAtom(idx, atom); };
+  void ReplaceBond(unsigned int idx, Bond *bond) { replaceBond(idx, bond); };
   ROMol *GetMol() const {
     ROMol *res = new ROMol(*this);
     return res;
@@ -660,6 +661,9 @@ struct mol_wrapper {
         .def("ReplaceAtom", &ReadWriteMol::ReplaceAtom,
              (python::arg("mol"), python::arg("index"), python::arg("newAtom")),
              "replaces the specified atom with the provided one")
+        .def("ReplaceBond", &ReadWriteMol::ReplaceBond,
+             (python::arg("mol"), python::arg("index"), python::arg("newBond")),
+             "replaces the specified bond with the provided one")
         .def("GetMol", &ReadWriteMol::GetMol,
              "Returns a Mol (a normal molecule)",
              python::return_value_policy<python::manage_new_object>());

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -3140,6 +3140,25 @@ CAS<~>
     w = None
     outf.close()
 
+  def testReplaceBond(self):
+    origmol = Chem.RWMol(Chem.MolFromSmiles("CC"))
+    bonds = list(origmol.GetBonds())
+    self.assertEqual(len(bonds), 1)
+    singlebond = bonds[0]
+    self.assertEqual(singlebond.GetBondType(), Chem.BondType.SINGLE)
+
+    # this is the only way we create a bond, is take it from another molecule
+    doublebonded = Chem.MolFromSmiles("C=C")
+    doublebond = list(doublebonded.GetBonds())[0]
+
+    # make sure replacing the bond changes the smiles
+    self.assertEquals(Chem.MolToSmiles(origmol), "CC")
+    origmol.ReplaceBond(singlebond.GetIdx(), doublebond)
+    Chem.SanitizeMol(origmol)
+
+    self.assertEquals(Chem.MolToSmiles(origmol), "C=C")
+
+
   def testAdjustQueryProperties(self):
     m = Chem.MolFromSmarts('C1CCC1*')
     am = Chem.AdjustQueryProperties(m)


### PR DESCRIPTION
This will be more useful in a later pull request I'm working on that
exposes QueryBonds to Python. Though it is usable without QueryBonds
as well, so submitting this for now.