### PR TITLE
Add Contrib dir to RDPaths

### DIFF
--- a/rdkit/CMakeLists.txt
+++ b/rdkit/CMakeLists.txt
@@ -7,6 +7,7 @@ _share = os.path.join(r'${CMAKE_INSTALL_PREFIX}', r'${RDKit_ShareDir}')
 RDDataDir=os.path.join(_share,'Data')
 RDDocsDir=os.path.join(_share,'Docs')
 RDProjDir=os.path.join(_share,'Projects')
+RDContribDir=os.path.join(_share,'Contrib')
 ")
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/RDPaths.py 
         DESTINATION ${RDKit_PythonDir})


### PR DESCRIPTION
Ensure `RDContribDir` is still available if `RDConfig` falls back to `RDPaths.py`

#1024 originally added `RDContribDir`, but not if neither `RDBASE` or `CONDA_DEFAULT_ENV` are set.