### PR TITLE
Find potential stereo bonds should return any

### DIFF
--- a/Code/GraphMol/Chirality.cpp
+++ b/Code/GraphMol/Chirality.cpp
@@ -1071,26 +1071,7 @@ void assignStereochemistry(ROMol &mol, bool cleanIt, bool force,
 #endif
 }
 
-// Find bonds than can be cis/trans in a molecule and mark them as "any"
-// - this function finds any double bonds that can potentially be part
-//   of a cis/trans system. No attempt is made here to mark them cis or trans
-//
-// This function is useful in two situations
-//  1) when parsing a mol file; for the bonds marked here, coordinate
-//  informations
-//     on the neighbors can be used to indentify cis or trans states
-//  2) when writing a mol file; bonds that can be cis/trans but not marked as
-//  either
-//     need to be specially marked in the mol file
-//
-//  The CIPranks on the neighboring atoms are check in this function. The
-//  _CIPCode property
-//  if set to any on the double bond.
-//
-// ARGUMENTS:
-//   mol - the molecule of interest
-//   cleanIt - if this option is set to true, any previous marking of _CIPCode
-//               on the bond is cleared - otherwise it is left untouched
+// Find bonds than can be cis/trans in a molecule and mark them as Bond::STEREOANY.
 void findPotentialStereoBonds(ROMol &mol, bool cleanIt) {
   // FIX: The earlier thought was to provide an optional argument to ignore or
   // consider
@@ -1191,6 +1172,11 @@ void findPotentialStereoBonds(ROMol &mol, bool cleanIt) {
                 dblBond->getStereoAtoms().push_back(begAtomNeighbors[0]);
                 dblBond->getStereoAtoms().push_back(endAtomNeighbors[0]);
               }  // end of different number of neighbors on beg and end atoms
+
+              // mark this double bond as a potential stereo bond
+              if (!dblBond->getStereoAtoms().empty()) {
+                dblBond->setStereo(Bond::STEREOANY);
+              }
             }    // end of check that beg and end atoms have at least 1
                  // neighbor:
           }      // end of 2 and 3 coordinated atoms only

--- a/Code/GraphMol/MolOps.h
+++ b/Code/GraphMol/MolOps.h
@@ -816,19 +816,26 @@ void assignStereochemistry(ROMol &mol, bool cleanIt = false, bool force = false,
 void removeStereochemistry(ROMol &mol);
 
 //! \brief finds bonds that could be cis/trans in a molecule and mark them as
-//!  Bond::STEREONONE
+//!  Bond::STEREOANY.
 /*!
   \param mol     the molecule of interest
   \param cleanIt toggles removal of stereo flags from double bonds that can
                  not have stereochemistry
 
-  This function is usefuly in two situations
+  This function finds any double bonds that can potentially be part of
+  a cis/trans system. No attempt is made here to mark them cis or
+  trans. No attempt is made to detect double bond stereo in ring systems.
+
+  This function is useful in the following situations:
     - when parsing a mol file; for the bonds marked here, coordinate
-  informations
-      on the neighbors can be used to indentify cis or trans states
+      information on the neighbors can be used to indentify cis or trans states
     - when writing a mol file; bonds that can be cis/trans but not marked as
-  either
-      need to be specially marked in the mol file
+      either need to be specially marked in the mol file
+    - finding double bonds with unspecified stereochemistry so they
+      can be enumerated for downstream 3D tools
+
+  The CIPranks on the neighboring atoms are checked in this function. The
+  _CIPCode property if set to any on the double bond.
 */
 void findPotentialStereoBonds(ROMol &mol, bool cleanIt = false);
 //@}

--- a/Code/GraphMol/Wrap/MolOps.cpp
+++ b/Code/GraphMol/Wrap/MolOps.cpp
@@ -1507,6 +1507,23 @@ struct molops_wrapper {
 
     // ------------------------------------------------------------------------
     docString =
+        "Find bonds than can be cis/trans in a molecule and mark them as 'any'.\n\
+         This function finds any double bonds that can potentially be part\n\
+         of a cis/trans system. No attempt is made here to mark them cis or trans\n\
+\n\
+  ARGUMENTS:\n\
+\n\
+    - mol: the molecule to use\n\
+    - cleanIt: (optional) if this option is set to true, any previous marking of _CIPCode\n\
+               on the bond is cleared - otherwise it is left untouched\n\
+\n";
+    python::def("FindPotentialStereoBonds", MolOps::findPotentialStereoBonds,
+                (python::arg("mol"), python::arg("cleanIt") = false),
+                docString.c_str());
+
+
+    // ------------------------------------------------------------------------
+    docString =
         "Removes all stereochemistry info from the molecule.\n\
 \n";
     python::def("RemoveStereochemistry", MolOps::removeStereochemistry,

--- a/Code/JavaWrappers/RDKFuncs_doc.i
+++ b/Code/JavaWrappers/RDKFuncs_doc.i
@@ -1,21 +1,21 @@
-/* 
+/*
 * $Id$
 *
 *  Copyright (c) 2010, Novartis Institutes for BioMedical Research Inc.
 *  All rights reserved.
-* 
+*
 * Redistribution and use in source and binary forms, with or without
 * modification, are permitted provided that the following conditions are
-* met: 
+* met:
 *
-*     * Redistributions of source code must retain the above copyright 
+*     * Redistributions of source code must retain the above copyright
 *       notice, this list of conditions and the following disclaimer.
 *     * Redistributions in binary form must reproduce the above
-*       copyright notice, this list of conditions and the following 
-*       disclaimer in the documentation and/or other materials provided 
+*       copyright notice, this list of conditions and the following
+*       disclaimer in the documentation and/or other materials provided
 *       with the distribution.
-*     * Neither the name of Novartis Institutes for BioMedical Research Inc. 
-*       nor the names of its contributors may be used to endorse or promote 
+*     * Neither the name of Novartis Institutes for BioMedical Research Inc.
+*       nor the names of its contributors may be used to endorse or promote
 *       products derived from this software without specific prior written permission.
 *
 * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
@@ -32,7 +32,7 @@
 */
 
 %typemap(javaimports) RDKit::MolOps "
-/** 
+/**
 Groups a variety of molecular query and transformation operations. */"
 
 %javamethodmodifiers RDKit::MolOps::addHs 	( 	const ROMol &  	mol, 		bool  	explicitOnly = false, 		bool  	addCoords = false	  	) 			"
@@ -170,17 +170,13 @@ public";
 %javamethodmodifiers RDKit::MolOps::findPotentialStereoBonds 	( 	ROMol &  	mol, 		bool  	cleanIt = false	  	) 			"
 /**
 <p>
-finds bonds that could be cis/trans in a molecule and mark them as Bond::STEREONONE
+finds bonds that could be cis/trans in a molecule and mark them as Bond::STEREOANY
 <p>
 <p>
 @param
 mol 	the molecule of interest
 cleanIt 	toggles removal of stereo flags from double bonds that can not have stereochemistry
-This function is usefuly in two situations
 <p>
-    * when parsing a mol file; for the bonds marked here, coordinate informations on the neighbors can be used to indentify cis or trans states
-    * when writing a mol file; bonds that can be cis/trans but not marked as either need to be specially marked in the mol file
-
 */
 public";
 


### PR DESCRIPTION
This is a change in behavior of findPotentialStereoBonds to make it match _some_ of its doc strings. This makes findPotentialStereoBonds mark double bonds as Bond::STEREOANY if it could potentially be cis/trans. Previously, it would be marked Bond::STEREONONE, which isn't very helpful for locating the bond for further enumeration processing. 

Also wrapped findPotentialStereoBonds into Python and cleaned up and consolidated the doc strings for it into the header file. Test cases in Python to make sure it finds double bond stereo when it should, and doesn't when it shouldn't.  

The next pull request I want to submit after this is to submit a bond stereo enumerator. However, this comment in the code about how Bond::setStereo should not be wrapped has given me pause: 
https://github.com/rdkit/rdkit/blob/master/Code/GraphMol/Wrap/Bond.cpp#L131

Ultimately, would like to be able to do this: 

```python
Chem.FindPotentialStereoBonds(mol)
for bond in mol.GetBonds():
  if bond.GetBondType() == Chem.BondType.DOUBLE and bond.GetStereo() == Chem.BondStereo.STEREOANY:
    bond.SetStereo(Chem.BondStereo.STEREOZ)
    Chem.MolToSmiles(mol)
    bond.SetStereo(Chem.BondStereo.STEREOE)
    Chem.MolToSmiles(mol)
```

And have Chem.MolToSmiles 'do the right thing' with giving me the enumerated bond stereo SMILES. If I'm going down a dark alley, please let me know. :-)