### PR TITLE
Turns on -fpermissive for gcc >= 6 and boost < 1.62

### DIFF
--- a/Code/GraphMol/ChemReactions/CMakeLists.txt
+++ b/Code/GraphMol/ChemReactions/CMakeLists.txt
@@ -4,6 +4,12 @@ else()
       message("== Making EnumerateLibrary without boost Serialization support")
 endif()
 
+if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 5)
+  if(Boost_VERSION LESS  106200)
+    set_property(SOURCE Enumerate/Enumerate.cpp APPEND_STRING PROPERTY COMPILE_FLAGS " -fpermissive ")
+  endif()
+endif()
+
 rdkit_library(ChemReactions
               Reaction.cpp MDLParser.cpp DaylightParser.cpp ReactionPickler.cpp
 	            ReactionWriter.cpp ReactionDepict.cpp ReactionFingerprints.cpp ReactionUtils.cpp MoleculeParser.cpp ReactionRunner.cpp PreprocessRxn.cpp SanitizeRxn.cpp


### PR DESCRIPTION
Second time's the charm.  This has been tested to compile, but I haven't had a compile failure so I don't know if it fixes those.