### PR TITLE
Fixes #1230

### DIFF
--- a/Code/GraphMol/Chirality.cpp
+++ b/Code/GraphMol/Chirality.cpp
@@ -1071,7 +1071,8 @@ void assignStereochemistry(ROMol &mol, bool cleanIt, bool force,
 #endif
 }
 
-// Find bonds than can be cis/trans in a molecule and mark them as Bond::STEREOANY.
+// Find bonds than can be cis/trans in a molecule and mark them as
+// Bond::STEREOANY.
 void findPotentialStereoBonds(ROMol &mol, bool cleanIt) {
   // FIX: The earlier thought was to provide an optional argument to ignore or
   // consider
@@ -1112,7 +1113,15 @@ void findPotentialStereoBonds(ROMol &mol, bool cleanIt) {
             // ------------------
             // get the CIP ranking of each atom if we need it:
             if (!cipDone) {
-              Chirality::assignAtomCIPRanks(mol, ranks);
+              if (!begAtom->hasProp(common_properties::_CIPRank)) {
+                Chirality::assignAtomCIPRanks(mol, ranks);
+              } else {
+                // no need to recompute if we don't need to recompute. :-)
+                for (unsigned int ai = 0; ai < mol.getNumAtoms(); ++ai) {
+                  ranks[ai] = mol.getAtomWithIdx(ai)->getProp<unsigned int>(
+                      common_properties::_CIPRank);
+                }
+              }
               cipDone = true;
             }
             // find the neighbors for the begin atom and the endAtom
@@ -1124,9 +1133,22 @@ void findPotentialStereoBonds(ROMol &mol, bool cleanIt) {
             if (begAtomNeighbors.size() > 0 && endAtomNeighbors.size() > 0) {
               if ((begAtomNeighbors.size() == 2) &&
                   (endAtomNeighbors.size() == 2)) {
-                // if both of the atoms have 2 neighbors (other than the one
-                // connected
-                // by the double bond) and ....
+// if both of the atoms have 2 neighbors (other than the one
+// connected
+// by the double bond) and ....
+#if 0
+                std::cerr << "Bond: " << dblBond->getIdx() << " "
+                          << begAtom->getIdx() << "=" << endAtom->getIdx()
+                          << std::endl;
+                std::cerr << "   " << begAtomNeighbors[0] << "="
+                          << ranks[begAtomNeighbors[0]] << ":";
+                std::cerr << "   " << begAtomNeighbors[1] << "="
+                          << ranks[begAtomNeighbors[1]] << std::endl;
+                std::cerr << "   " << endAtomNeighbors[0] << "="
+                          << ranks[endAtomNeighbors[0]] << ":";
+                std::cerr << "   " << endAtomNeighbors[1] << "="
+                          << ranks[endAtomNeighbors[1]] << std::endl;
+#endif
                 if ((ranks[begAtomNeighbors[0]] !=
                      ranks[begAtomNeighbors[1]]) &&
                     (ranks[endAtomNeighbors[0]] !=
@@ -1177,12 +1199,12 @@ void findPotentialStereoBonds(ROMol &mol, bool cleanIt) {
               if (!dblBond->getStereoAtoms().empty()) {
                 dblBond->setStereo(Bond::STEREOANY);
               }
-            }    // end of check that beg and end atoms have at least 1
-                 // neighbor:
-          }      // end of 2 and 3 coordinated atoms only
-        }        // end of we want it or CIP code is not set
-      }          // end of double bond
-    }            // end of for loop over all bonds
+            }  // end of check that beg and end atoms have at least 1
+               // neighbor:
+          }    // end of 2 and 3 coordinated atoms only
+        }      // end of we want it or CIP code is not set
+      }        // end of double bond
+    }          // end of for loop over all bonds
     mol.setProp(common_properties::_BondsPotentialStereo, 1, true);
   }
 }

--- a/Code/GraphMol/molopstest.cpp
+++ b/Code/GraphMol/molopstest.cpp
@@ -6004,6 +6004,27 @@ void testPotentialStereoBonds() {
 
     delete m;
   }
+  {  // repeat the real problem, but set the cleanIt argument to false
+    std::string smiles = "CC/C=C/C(\\C=C/CC)=C(CC)CO";
+    ROMol *m = SmilesToMol(smiles);
+    TEST_ASSERT(m);
+    TEST_ASSERT(m->getNumAtoms() == 14);
+    TEST_ASSERT(m->getBondWithIdx(2)->getBondType() == Bond::DOUBLE);
+    TEST_ASSERT(m->getBondWithIdx(2)->getStereo() == Bond::STEREOE);
+    TEST_ASSERT(m->getBondWithIdx(5)->getBondType() == Bond::DOUBLE);
+    TEST_ASSERT(m->getBondWithIdx(5)->getStereo() == Bond::STEREOZ);
+    TEST_ASSERT(m->getBondWithIdx(8)->getBondType() == Bond::DOUBLE);
+    TEST_ASSERT(m->getBondWithIdx(8)->getStereo() == Bond::STEREONONE);
+    MolOps::findPotentialStereoBonds(*m, false);
+    TEST_ASSERT(m->getBondWithIdx(2)->getBondType() == Bond::DOUBLE);
+    TEST_ASSERT(m->getBondWithIdx(2)->getStereo() == Bond::STEREOE);
+    TEST_ASSERT(m->getBondWithIdx(5)->getBondType() == Bond::DOUBLE);
+    TEST_ASSERT(m->getBondWithIdx(5)->getStereo() == Bond::STEREOZ);
+    TEST_ASSERT(m->getBondWithIdx(8)->getBondType() == Bond::DOUBLE);
+    TEST_ASSERT(m->getBondWithIdx(8)->getStereo() == Bond::STEREOANY);
+
+    delete m;
+  }
 
   {  // just do document that we still don't do this one, which is much harder
     std::string smiles = "CC/C=C/C(/C=C/CC)=C(CC)CO";

--- a/Code/GraphMol/molopstest.cpp
+++ b/Code/GraphMol/molopstest.cpp
@@ -5928,6 +5928,7 @@ void testPotentialStereoBonds() {
   BOOST_LOG(rdInfoLog)
       << "-----------------------\n Testing findPotentialStereoBonds"
       << std::endl;
+
   {  // starting point: full sanitization
     std::string smiles =
         "Br/C(=N\\N=c1/nn[nH][nH]1)c1ccncc1";  // possible problem reported by
@@ -5954,6 +5955,78 @@ void testPotentialStereoBonds() {
     TEST_ASSERT(m->getBondWithIdx(3)->getStereoAtoms().size() == 2);
     delete m;
   }
+
+  // this next block is for github1230: FindPotentialStereoBonds() failure
+  {  // simple
+    std::string smiles = "CC=CC";
+    ROMol *m = SmilesToMol(smiles);
+    TEST_ASSERT(m);
+    TEST_ASSERT(m->getNumAtoms() == 4);
+    TEST_ASSERT(m->getBondWithIdx(1)->getBondType() == Bond::DOUBLE);
+    TEST_ASSERT(m->getBondWithIdx(1)->getStereo() == Bond::STEREONONE);
+
+    MolOps::findPotentialStereoBonds(*m, true);
+    TEST_ASSERT(m->getBondWithIdx(1)->getStereo() == Bond::STEREOANY);
+
+    delete m;
+  }
+  {  // simple2
+    std::string smiles = "CC=C(C)C";
+    ROMol *m = SmilesToMol(smiles);
+    TEST_ASSERT(m);
+    TEST_ASSERT(m->getNumAtoms() == 5);
+    TEST_ASSERT(m->getBondWithIdx(1)->getBondType() == Bond::DOUBLE);
+    TEST_ASSERT(m->getBondWithIdx(1)->getStereo() == Bond::STEREONONE);
+
+    MolOps::findPotentialStereoBonds(*m, true);
+    TEST_ASSERT(m->getBondWithIdx(1)->getStereo() == Bond::STEREONONE);
+
+    delete m;
+  }
+  {  // the real problem
+    std::string smiles = "CC/C=C/C(\\C=C/CC)=C(CC)CO";
+    ROMol *m = SmilesToMol(smiles);
+    TEST_ASSERT(m);
+    TEST_ASSERT(m->getNumAtoms() == 14);
+    TEST_ASSERT(m->getBondWithIdx(2)->getBondType() == Bond::DOUBLE);
+    TEST_ASSERT(m->getBondWithIdx(2)->getStereo() == Bond::STEREOE);
+    TEST_ASSERT(m->getBondWithIdx(5)->getBondType() == Bond::DOUBLE);
+    TEST_ASSERT(m->getBondWithIdx(5)->getStereo() == Bond::STEREOZ);
+    TEST_ASSERT(m->getBondWithIdx(8)->getBondType() == Bond::DOUBLE);
+    TEST_ASSERT(m->getBondWithIdx(8)->getStereo() == Bond::STEREONONE);
+    MolOps::findPotentialStereoBonds(*m, true);
+    TEST_ASSERT(m->getBondWithIdx(2)->getBondType() == Bond::DOUBLE);
+    TEST_ASSERT(m->getBondWithIdx(2)->getStereo() == Bond::STEREOANY);
+    TEST_ASSERT(m->getBondWithIdx(5)->getBondType() == Bond::DOUBLE);
+    TEST_ASSERT(m->getBondWithIdx(5)->getStereo() == Bond::STEREOANY);
+    TEST_ASSERT(m->getBondWithIdx(8)->getBondType() == Bond::DOUBLE);
+    TEST_ASSERT(m->getBondWithIdx(8)->getStereo() == Bond::STEREOANY);
+
+    delete m;
+  }
+
+  {  // just do document that we still don't do this one, which is much harder
+    std::string smiles = "CC/C=C/C(/C=C/CC)=C(CC)CO";
+    ROMol *m = SmilesToMol(smiles);
+    TEST_ASSERT(m);
+    TEST_ASSERT(m->getNumAtoms() == 14);
+    TEST_ASSERT(m->getBondWithIdx(2)->getBondType() == Bond::DOUBLE);
+    TEST_ASSERT(m->getBondWithIdx(2)->getStereo() == Bond::STEREOE);
+    TEST_ASSERT(m->getBondWithIdx(5)->getBondType() == Bond::DOUBLE);
+    TEST_ASSERT(m->getBondWithIdx(5)->getStereo() == Bond::STEREOE);
+    TEST_ASSERT(m->getBondWithIdx(8)->getBondType() == Bond::DOUBLE);
+    TEST_ASSERT(m->getBondWithIdx(8)->getStereo() == Bond::STEREONONE);
+    MolOps::findPotentialStereoBonds(*m, true);
+    TEST_ASSERT(m->getBondWithIdx(2)->getBondType() == Bond::DOUBLE);
+    TEST_ASSERT(m->getBondWithIdx(2)->getStereo() == Bond::STEREOANY);
+    TEST_ASSERT(m->getBondWithIdx(5)->getBondType() == Bond::DOUBLE);
+    TEST_ASSERT(m->getBondWithIdx(5)->getStereo() == Bond::STEREOANY);
+    TEST_ASSERT(m->getBondWithIdx(8)->getBondType() == Bond::DOUBLE);
+    TEST_ASSERT(m->getBondWithIdx(8)->getStereo() == Bond::STEREONONE);
+
+    delete m;
+  }
+
   BOOST_LOG(rdInfoLog) << "Finished" << std::endl;
 }
 
@@ -6602,7 +6675,6 @@ int main() {
   testGithubIssue539();
   testGithubIssue678();
   testGithubIssue717();
-  testPotentialStereoBonds();
   testGithubIssue754();
   testGithubIssue805();
   testGithubIssue518();
@@ -6615,9 +6687,10 @@ int main() {
 
   testGithubIssue1021();
   testGithubIssue607();
-#endif
   testAdjustQueryProperties();
   testGithubIssue1204();
+#endif
+  testPotentialStereoBonds();
 
   return 0;
 }


### PR DESCRIPTION
This not only makes things correct, it also makes them faster.

The problem arose because `assignAtomCIPRanks()` does not do the recursion to deal with dependent stereochemistry that `assignStereochemistry()` does. This patch just uses whatever information on CIP ranks is there already, which usually comes from assignStereochemistry().