### PR TITLE
Partial support for reading CXSMILES

### DIFF
--- a/Code/DataStructs/DiscreteValueVect.h
+++ b/Code/DataStructs/DiscreteValueVect.h
@@ -50,7 +50,7 @@ class DiscreteValueVect {
 
   //! constructor from a pickle
   DiscreteValueVect(const std::string &pkl) {
-    initFromText(pkl.c_str(), pkl.size());
+    initFromText(pkl.c_str(), static_cast<unsigned int>(pkl.size()));
   };
   //! constructor from a pickle
   DiscreteValueVect(const char *pkl, const unsigned int len) {

--- a/Code/DataStructs/ExplicitBitVect.h
+++ b/Code/DataStructs/ExplicitBitVect.h
@@ -11,7 +11,9 @@
 #ifndef __RD_EXPLICITBITVECTS_H__
 #define __RD_EXPLICITBITVECTS_H__
 
+#include <RDGeneral/BoostStartInclude.h>
 #include <boost/dynamic_bitset.hpp>
+#include <RDGeneral/BoostEndInclude.h>
 #include "BitVect.h"
 
 //! a class for bit vectors that are densely occupied

--- a/Code/GraphMol/Aromaticity.cpp
+++ b/Code/GraphMol/Aromaticity.cpp
@@ -656,7 +656,7 @@ int aromaticityHelper(RWMol &mol, unsigned int minRingSize,
 
   VECT_INT_VECT cRings;  // holder for rings that are candidates for aromaticity
   for (VECT_INT_VECT_I vivi = srings.begin(); vivi != srings.end(); ++vivi) {
-    unsigned int ringSz = (*vivi).size();
+    size_t ringSz = (*vivi).size();
     // test ring size:
     if ((minRingSize && ringSz < minRingSize) ||
         (maxRingSize && ringSz > maxRingSize))

--- a/Code/GraphMol/Canon.h
+++ b/Code/GraphMol/Canon.h
@@ -10,8 +10,10 @@
 #ifndef _RD_CANON_H_
 #define _RD_CANON_H_
 
+#include <RDGeneral/BoostStartInclude.h>
 #include <boost/tuple/tuple.hpp>
 #include <boost/dynamic_bitset.hpp>
+#include <RDGeneral/BoostEndInclude.h>
 
 namespace RDKit {
 class ROMol;

--- a/Code/GraphMol/ChemReactions/MDLParser.cpp
+++ b/Code/GraphMol/ChemReactions/MDLParser.cpp
@@ -40,9 +40,12 @@
 #include <RDGeneral/FileParseException.h>
 
 #include <fstream>
+#include <RDGeneral/BoostStartInclude.h>
 #include <boost/lexical_cast.hpp>
 #include <boost/algorithm/string/trim.hpp>
 #include <boost/tokenizer.hpp>
+#include <RDGeneral/BoostEndInclude.h>
+
 #include "ReactionUtils.h"
 
 namespace RDKit {

--- a/Code/GraphMol/ChemReactions/Reaction.h
+++ b/Code/GraphMol/ChemReactions/Reaction.h
@@ -148,7 +148,7 @@ class ChemicalReaction {
   unsigned int addReactantTemplate(ROMOL_SPTR mol) {
     this->df_needsInit = true;
     this->m_reactantTemplates.push_back(mol);
-    return this->m_reactantTemplates.size();
+    return rdcast<unsigned int>(this->m_reactantTemplates.size());
   }
 
   //! Adds a new agent template
@@ -158,7 +158,7 @@ class ChemicalReaction {
   */
   unsigned int addAgentTemplate(ROMOL_SPTR mol) {
     this->m_agentTemplates.push_back(mol);
-    return this->m_agentTemplates.size();
+    return rdcast<unsigned int>(this->m_agentTemplates.size());
   }
 
   //! Adds a new product template
@@ -168,7 +168,7 @@ class ChemicalReaction {
   */
   unsigned int addProductTemplate(ROMOL_SPTR mol) {
     this->m_productTemplates.push_back(mol);
-    return this->m_productTemplates.size();
+    return rdcast<unsigned int>(this->m_productTemplates.size());
   }
 
   //! Removes the reactant templates from a reaction if atom mapping ratio is
@@ -271,13 +271,13 @@ class ChemicalReaction {
     return this->m_agentTemplates.end();
   }
   unsigned int getNumReactantTemplates() const {
-    return this->m_reactantTemplates.size();
+    return rdcast<unsigned int>(this->m_reactantTemplates.size());
   };
   unsigned int getNumProductTemplates() const {
-    return this->m_productTemplates.size();
+    return rdcast<unsigned int>(this->m_productTemplates.size());
   };
   unsigned int getNumAgentTemplates() const {
-    return this->m_agentTemplates.size();
+    return rdcast<unsigned int>(this->m_agentTemplates.size());
   };
 
   //! initializes our internal reactant-matching datastructures.

--- a/Code/GraphMol/ChemTransforms/ChemTransforms.cpp
+++ b/Code/GraphMol/ChemTransforms/ChemTransforms.cpp
@@ -15,10 +15,12 @@
 #include <RDGeneral/Exceptions.h>
 #include <GraphMol/RDKitBase.h>
 #include <GraphMol/Substruct/SubstructMatch.h>
+#include <RDGeneral/BoostStartInclude.h>
 #include <boost/dynamic_bitset.hpp>
 #include <boost/tokenizer.hpp>
 #include <boost/algorithm/string/trim.hpp>
 #include <boost/algorithm/string.hpp>
+#include <RDGeneral/BoostEndInclude.h>
 #include <vector>
 #include <algorithm>
 #include <iostream>

--- a/Code/GraphMol/FileParsers/FileParserUtils.h
+++ b/Code/GraphMol/FileParsers/FileParserUtils.h
@@ -12,8 +12,10 @@
 
 #include <string>
 #include <iostream>
+#include <RDGeneral/BoostStartInclude.h>
 #include <boost/lexical_cast.hpp>
 #include <boost/algorithm/string.hpp>
+#include <RDGeneral/BoostEndInclude.h>
 
 namespace RDKit {
 class RWMol;

--- a/Code/GraphMol/FileParsers/ForwardSDMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/ForwardSDMolSupplier.cpp
@@ -13,8 +13,10 @@
 #include <RDGeneral/StreamOps.h>
 #include <RDGeneral/RDLog.h>
 #include <GraphMol/SanitException.h>
-
+#include <RDGeneral/BoostStartInclude.h>
 #include <boost/algorithm/string.hpp>
+#include <RDGeneral/BoostEndInclude.h>
+
 #include "MolSupplier.h"
 #include "FileParsers.h"
 

--- a/Code/GraphMol/FileParsers/MolFileParser.cpp
+++ b/Code/GraphMol/FileParsers/MolFileParser.cpp
@@ -1064,17 +1064,9 @@ Atom *ParseMolFileAtomLine(const std::string text, RDGeom::Point3D &pos,
         // according to the MDL spec, these match anything
         query->setQuery(makeAtomNullQuery());
       } else if (symb == "Q") {
-        ATOM_OR_QUERY *q = new ATOM_OR_QUERY;
-        q->setDescription("AtomOr");
-        q->setNegation(true);
-        q->addChild(
-            QueryAtom::QUERYATOM_QUERY::CHILD_TYPE(makeAtomNumQuery(6)));
-        q->addChild(
-            QueryAtom::QUERYATOM_QUERY::CHILD_TYPE(makeAtomNumQuery(1)));
-        query->setQuery(q);
+        query->setQuery(makeQAtomQuery());
       } else if (symb == "A") {
-        query->setQuery(makeAtomNumQuery(1));
-        query->getQuery()->setNegation(true);
+        query->setQuery(makeAAtomQuery());
       }
       delete res;
       res = query;

--- a/Code/GraphMol/FileParsers/MolFileParser.cpp
+++ b/Code/GraphMol/FileParsers/MolFileParser.cpp
@@ -852,7 +852,7 @@ void ParseV3000RGroups(RWMol *mol, Atom *&atom, const std::string &text,
   }
   std::vector<std::string> splitToken;
   std::string resid = text.substr(1, text.size() - 2);
-  boost::split(splitToken, resid, boost::is_any_of(" "));
+  boost::split(splitToken, resid, boost::is_any_of(std::string(" ")));
   if (splitToken.size() < 1) {
     std::ostringstream errout;
     errout << "Bad RGROUPS specification " << text << " on line " << line

--- a/Code/GraphMol/FileParsers/MolFileParser.cpp
+++ b/Code/GraphMol/FileParsers/MolFileParser.cpp
@@ -7,6 +7,12 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
+#include <RDGeneral/BoostStartInclude.h>
+#include <boost/lexical_cast.hpp>
+#include <boost/algorithm/string.hpp>
+#include <boost/tokenizer.hpp>
+#include <boost/algorithm/string/trim.hpp>
+#include <RDGeneral/BoostEndInclude.h>
 
 #include "FileParsers.h"
 #include "FileParserUtils.h"
@@ -16,12 +22,6 @@
 #include <RDGeneral/RDLog.h>
 
 #include <fstream>
-#include <RDGeneral/BoostStartInclude.h>
-#include <boost/lexical_cast.hpp>
-#include <boost/algorithm/string.hpp>
-#include <boost/tokenizer.hpp>
-#include <boost/algorithm/string/trim.hpp>
-#include <RDGeneral/BoostEndInclude.h>
 #include <RDGeneral/FileParseException.h>
 #include <RDGeneral/BadFileException.h>
 #include <RDGeneral/LocaleSwitcher.h>

--- a/Code/GraphMol/FileParsers/MolFileStereochem.cpp
+++ b/Code/GraphMol/FileParsers/MolFileStereochem.cpp
@@ -103,7 +103,7 @@ Atom::ChiralType FindAtomStereochemistry(const RWMol &mol, const Bond *bond,
     }
     ++beg;
   }
-  int nNbrs = neighborBondIndices.size();
+  size_t nNbrs = neighborBondIndices.size();
 
   //----------------------------------------------------------
   //

--- a/Code/GraphMol/FileParsers/MolWriters.h
+++ b/Code/GraphMol/FileParsers/MolWriters.h
@@ -82,7 +82,7 @@ class SmilesWriter : public MolWriter {
       try {
         if (dp_ostream->good())
           dp_ostream->setstate(std::ios::badbit);
-      } catch (const std::runtime_error& e) {
+      } catch (const std::runtime_error& ) {
       }
     }
   };
@@ -160,7 +160,7 @@ class SDWriter : public MolWriter {
       try {
         if (dp_ostream->good())
           dp_ostream->setstate(std::ios::badbit);
-      } catch (const std::runtime_error& e) {
+      } catch (const std::runtime_error& ) {
       }
     }
   };
@@ -231,7 +231,7 @@ class TDTWriter : public MolWriter {
       try {
         if (dp_ostream->good())
           dp_ostream->setstate(std::ios::badbit);
-      } catch (const std::runtime_error& e) {
+      } catch (const std::runtime_error& ) {
       }
     }
   };
@@ -295,7 +295,7 @@ class PDBWriter : public MolWriter {
       try {
         if (dp_ostream->good())
           dp_ostream->setstate(std::ios::badbit);
-      } catch (const std::runtime_error& e) {
+      } catch (const std::runtime_error& ) {
       }
     }
   };

--- a/Code/GraphMol/FileParsers/PDBWriter.cpp
+++ b/Code/GraphMol/FileParsers/PDBWriter.cpp
@@ -169,7 +169,7 @@ std::string GetPDBBondLines(const Atom *atom, bool all, bool both, bool mult,
     }
   }
 
-  unsigned int count = v.size();
+  unsigned int count = rdcast<unsigned int>(v.size());
   if (count == 0) return "";
 
   std::sort(v.begin(), v.end());

--- a/Code/GraphMol/FileParsers/SDMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/SDMolSupplier.cpp
@@ -120,7 +120,7 @@ void SDMolSupplier::checkForEnd() {
   // or we reach end of file in the meantime
   if (dp_inStream->eof()) {
     df_end = true;
-    d_len = d_molpos.size();
+    d_len = rdcast<int>(d_molpos.size());
     return;
   }
   // we are not at the end of file, check for blank lines
@@ -130,7 +130,7 @@ void SDMolSupplier::checkForEnd() {
     tempStr = getLine(dp_inStream);
     if (dp_inStream->eof()) {
       df_end = true;
-      d_len = d_molpos.size();
+      d_len = rdcast<int>(d_molpos.size());
       return;
     }
     if (tempStr.find_first_not_of(" \t\r\n") == std::string::npos) {
@@ -139,7 +139,7 @@ void SDMolSupplier::checkForEnd() {
   }
   if (nempty == 4) {
     df_end = true;
-    d_len = d_molpos.size();
+    d_len = rdcast<int>(d_molpos.size());
   }
 }
 
@@ -167,7 +167,7 @@ ROMol *SDMolSupplier::next() {
   if (dp_inStream->eof()) {
     // FIX: we should probably be throwing an exception here
     df_end = true;
-    d_len = d_molpos.size();
+    d_len = rdcast<int>(d_molpos.size());
     return res;
   }
 
@@ -220,7 +220,7 @@ void SDMolSupplier::moveTo(unsigned int idx) {
   } else {
     std::string tempStr;
     dp_inStream->seekg(d_molpos.back());
-    d_last = d_molpos.size() - 1;
+    d_last = rdcast<int>(d_molpos.size()) - 1;
     while ((d_last < static_cast<int>(idx)) && (!dp_inStream->eof())) {
       d_line++;
       tempStr = getLine(dp_inStream);
@@ -236,7 +236,7 @@ void SDMolSupplier::moveTo(unsigned int idx) {
     }
     // if we reached end of file without reaching "idx" we have an index error
     if (dp_inStream->eof()) {
-      d_len = d_molpos.size();
+      d_len = rdcast<int>(d_molpos.size());
       std::ostringstream errout;
       errout << "ERROR: Index error (idx = " << idx << ") : "
              << " we do no have enough mol blocks";
@@ -259,7 +259,7 @@ unsigned int SDMolSupplier::length() {
     return d_len;
   } else {
     std::string tempStr;
-    d_len = d_molpos.size();
+    d_len = rdcast<int>(d_molpos.size());
     dp_inStream->seekg(d_molpos.back());
     while (!dp_inStream->eof()) {
       std::getline(*dp_inStream, tempStr);
@@ -291,6 +291,6 @@ void SDMolSupplier::setStreamIndices(const std::vector<std::streampos> &locs) {
   d_molpos.resize(locs.size());
   std::copy(locs.begin(), locs.end(), d_molpos.begin());
   this->reset();
-  d_len = d_molpos.size();
+  d_len = rdcast<int>(d_molpos.size());
 }
 }

--- a/Code/GraphMol/FileParsers/TDTMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/TDTMolSupplier.cpp
@@ -8,6 +8,12 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
+#include <RDGeneral/BoostStartInclude.h>
+#include <boost/tokenizer.hpp>
+#include <boost/algorithm/string.hpp>
+#include <boost/lexical_cast.hpp>
+#include <RDGeneral/BoostEndInclude.h>
+
 #include <RDGeneral/BadFileException.h>
 #include <RDGeneral/FileParseException.h>
 #include <RDGeneral/RDLog.h>
@@ -16,9 +22,6 @@
 #include <GraphMol/SmilesParse/SmilesParse.h>
 #include <RDGeneral/LocaleSwitcher.h>
 
-#include <boost/tokenizer.hpp>
-#include <boost/algorithm/string.hpp>
-#include <boost/lexical_cast.hpp>
 
 #include <fstream>
 #include <iostream>
@@ -181,7 +184,9 @@ void TDTMolSupplier::checkForEnd() {
   // we are not at the end of file, but check for blank lines:
   std::string tempStr;
   std::getline(*dp_inStream, tempStr);
-  boost::trim_left_if(tempStr, boost::is_any_of(" \t\r\n"));
+
+  boost::trim_left_if(tempStr, boost::is_any_of(std::string(" \t\r\n")));
+
   if (tempStr.length() == 0) {
     df_end = true;
     // the -1 here is because by the time we get here we've already pushed on

--- a/Code/GraphMol/FileParsers/TplFileParser.cpp
+++ b/Code/GraphMol/FileParsers/TplFileParser.cpp
@@ -8,6 +8,11 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
+#include <RDGeneral/BoostStartInclude.h>
+#include <boost/lexical_cast.hpp>
+#include <boost/algorithm/string.hpp>
+#include <boost/algorithm/string/trim.hpp>
+#include <RDGeneral/BoostEndInclude.h>
 
 #include "FileParsers.h"
 #include "FileParserUtils.h"
@@ -15,9 +20,7 @@
 #include <RDGeneral/StreamOps.h>
 
 #include <fstream>
-#include <boost/lexical_cast.hpp>
-#include <boost/algorithm/string.hpp>
-#include <boost/algorithm/string/trim.hpp>
+
 #include <RDGeneral/FileParseException.h>
 #include <RDGeneral/BadFileException.h>
 #include <typeinfo>

--- a/Code/GraphMol/MolDrawing/MolDrawing.h
+++ b/Code/GraphMol/MolDrawing/MolDrawing.h
@@ -14,8 +14,11 @@
 #define _RD_MOLDRAWING_H_
 
 #include <vector>
+#include <RDGeneral/BoostStartInclude.h>
 #include <boost/foreach.hpp>
 #include <boost/lexical_cast.hpp>
+#include <RDGeneral/BoostEndInclude.h>
+
 #include <GraphMol/RDKitBase.h>
 #include <GraphMol/Depictor/RDDepictor.h>
 #include <Geometry/point.h>

--- a/Code/GraphMol/MolOps.h
+++ b/Code/GraphMol/MolOps.h
@@ -14,8 +14,10 @@
 #include <vector>
 #include <map>
 #include <list>
+#include <RDGeneral/BoostStartInclude.h>
 #include <boost/smart_ptr.hpp>
 #include <boost/dynamic_bitset.hpp>
+#include <RDGeneral/BoostEndInclude.h>
 #include <RDGeneral/types.h>
 
 extern const int ci_LOCAL_INF;

--- a/Code/GraphMol/QueryOps.cpp
+++ b/Code/GraphMol/QueryOps.cpp
@@ -340,12 +340,42 @@ ATOM_OR_QUERY *makeQAtomQuery() {
     Queries::Query<int, Atom const *, true>::CHILD_TYPE(makeAtomNumQuery(1)));
   return res;
 }
+ATOM_EQUALS_QUERY *makeQHAtomQuery() {
+  ATOM_EQUALS_QUERY *res = makeAtomNumQuery(6);
+  res->setNegation(true);
+  return res;
+}
 ATOM_EQUALS_QUERY *makeAAtomQuery() {
   ATOM_EQUALS_QUERY *res = makeAtomNumQuery(1);
   res->setNegation(true);
   return res;
 }
+ATOM_EQUALS_QUERY *makeAHAtomQuery() {
+  ATOM_EQUALS_QUERY *res = rdcast<ATOM_EQUALS_QUERY *>(makeAtomNullQuery());
+  return res;
+}
 
+ATOM_OR_QUERY *makeXAtomQuery() {
+  ATOM_OR_QUERY *res = new ATOM_OR_QUERY;
+  res->setDescription("AtomOr");
+  res->addChild(
+    Queries::Query<int, Atom const *, true>::CHILD_TYPE(makeAtomNumQuery(9)));
+  res->addChild(
+    Queries::Query<int, Atom const *, true>::CHILD_TYPE(makeAtomNumQuery(17)));
+  res->addChild(
+    Queries::Query<int, Atom const *, true>::CHILD_TYPE(makeAtomNumQuery(35)));
+  res->addChild(
+    Queries::Query<int, Atom const *, true>::CHILD_TYPE(makeAtomNumQuery(53)));
+  res->addChild(
+    Queries::Query<int, Atom const *, true>::CHILD_TYPE(makeAtomNumQuery(85)));
+  return res;
+}
+ATOM_OR_QUERY *makeXHAtomQuery() {
+  ATOM_OR_QUERY *res = makeXAtomQuery();
+  res->addChild(
+    Queries::Query<int, Atom const *, true>::CHILD_TYPE(makeAtomNumQuery(1)));
+  return res;
+}
 ATOM_EQUALS_QUERY *makeAtomInNRingsQuery(int what) {
   ATOM_EQUALS_QUERY *res;
   res = makeAtomSimpleQuery<ATOM_EQUALS_QUERY>(what, queryIsAtomInNRings);

--- a/Code/GraphMol/QueryOps.cpp
+++ b/Code/GraphMol/QueryOps.cpp
@@ -376,6 +376,69 @@ ATOM_OR_QUERY *makeXHAtomQuery() {
     Queries::Query<int, Atom const *, true>::CHILD_TYPE(makeAtomNumQuery(1)));
   return res;
 }
+
+ATOM_OR_QUERY *makeMAtomQuery() {
+  // using the definition from Marvin Sketch, which produces the following SMARTS:
+  // !#1!#2!#5!#6!#7!#8!#9!#10!#14!#15!#16!#17!#18!#33!#34!#35!#36!#52!#53!#54!#85!#86
+  // it's easier to define what isn't a metal than what is. :-)
+  ATOM_OR_QUERY *res = makeMHAtomQuery();
+  res->addChild(
+    Queries::Query<int, Atom const *, true>::CHILD_TYPE(makeAtomNumQuery(1)));
+  return res;
+}
+ATOM_OR_QUERY *makeMHAtomQuery() {
+  // using the definition from Marvin Sketch, which produces the following SMARTS:
+  // !#2!#5!#6!#7!#8!#9!#10!#14!#15!#16!#17!#18!#33!#34!#35!#36!#52!#53!#54!#85!#86
+  // it's easier to define what isn't a metal than what is. :-)
+  ATOM_OR_QUERY *res = new ATOM_OR_QUERY;
+  res->setDescription("AtomOr");
+  res->setNegation(true);
+  res->addChild(
+    Queries::Query<int, Atom const *, true>::CHILD_TYPE(makeAtomNumQuery(2)));
+  res->addChild(
+    Queries::Query<int, Atom const *, true>::CHILD_TYPE(makeAtomNumQuery(5)));
+  res->addChild(
+    Queries::Query<int, Atom const *, true>::CHILD_TYPE(makeAtomNumQuery(6)));
+  res->addChild(
+    Queries::Query<int, Atom const *, true>::CHILD_TYPE(makeAtomNumQuery(7)));
+  res->addChild(
+    Queries::Query<int, Atom const *, true>::CHILD_TYPE(makeAtomNumQuery(8)));
+  res->addChild(
+    Queries::Query<int, Atom const *, true>::CHILD_TYPE(makeAtomNumQuery(9)));
+  res->addChild(
+    Queries::Query<int, Atom const *, true>::CHILD_TYPE(makeAtomNumQuery(10)));
+  res->addChild(
+    Queries::Query<int, Atom const *, true>::CHILD_TYPE(makeAtomNumQuery(14)));
+  res->addChild(
+    Queries::Query<int, Atom const *, true>::CHILD_TYPE(makeAtomNumQuery(15)));
+  res->addChild(
+    Queries::Query<int, Atom const *, true>::CHILD_TYPE(makeAtomNumQuery(16)));
+  res->addChild(
+    Queries::Query<int, Atom const *, true>::CHILD_TYPE(makeAtomNumQuery(17)));
+  res->addChild(
+    Queries::Query<int, Atom const *, true>::CHILD_TYPE(makeAtomNumQuery(18)));
+  res->addChild(
+    Queries::Query<int, Atom const *, true>::CHILD_TYPE(makeAtomNumQuery(33)));
+  res->addChild(
+    Queries::Query<int, Atom const *, true>::CHILD_TYPE(makeAtomNumQuery(34)));
+  res->addChild(
+    Queries::Query<int, Atom const *, true>::CHILD_TYPE(makeAtomNumQuery(35)));
+  res->addChild(
+    Queries::Query<int, Atom const *, true>::CHILD_TYPE(makeAtomNumQuery(36)));
+  res->addChild(
+    Queries::Query<int, Atom const *, true>::CHILD_TYPE(makeAtomNumQuery(52)));
+  res->addChild(
+    Queries::Query<int, Atom const *, true>::CHILD_TYPE(makeAtomNumQuery(53)));
+  res->addChild(
+    Queries::Query<int, Atom const *, true>::CHILD_TYPE(makeAtomNumQuery(54)));
+  res->addChild(
+    Queries::Query<int, Atom const *, true>::CHILD_TYPE(makeAtomNumQuery(85)));
+  res->addChild(
+    Queries::Query<int, Atom const *, true>::CHILD_TYPE(makeAtomNumQuery(86)));
+  return res;
+}
+
+
 ATOM_EQUALS_QUERY *makeAtomInNRingsQuery(int what) {
   ATOM_EQUALS_QUERY *res;
   res = makeAtomSimpleQuery<ATOM_EQUALS_QUERY>(what, queryIsAtomInNRings);

--- a/Code/GraphMol/QueryOps.cpp
+++ b/Code/GraphMol/QueryOps.cpp
@@ -1,6 +1,5 @@
-// $Id$
 //
-// Copyright (C) 2003-2008 Greg Landrum and Rational Discovery LLC
+// Copyright (C) 2003-2017 Greg Landrum and Rational Discovery LLC
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -331,10 +330,19 @@ ATOM_EQUALS_QUERY *makeAtomInRingQuery() {
   return res;
 }
 
-ATOM_EQUALS_QUERY *makeAtomHasRingBondQuery() {
-  ATOM_EQUALS_QUERY *res =
-      makeAtomSimpleQuery<ATOM_EQUALS_QUERY>(true, queryAtomHasRingBond);
-  res->setDescription("AtomHasRingBond");
+ATOM_OR_QUERY *makeQAtomQuery() {
+  ATOM_OR_QUERY *res = new ATOM_OR_QUERY;
+  res->setDescription("AtomOr"); // FIX: we really should label this more descriptively so that it can be output more cleanly
+  res->setNegation(true);
+  res->addChild(
+    Queries::Query<int, Atom const *, true>::CHILD_TYPE(makeAtomNumQuery(6)));
+  res->addChild(
+    Queries::Query<int, Atom const *, true>::CHILD_TYPE(makeAtomNumQuery(1)));
+  return res;
+}
+ATOM_EQUALS_QUERY *makeAAtomQuery() {
+  ATOM_EQUALS_QUERY *res = makeAtomNumQuery(1);
+  res->setNegation(true);
   return res;
 }
 
@@ -344,6 +352,14 @@ ATOM_EQUALS_QUERY *makeAtomInNRingsQuery(int what) {
   res->setDescription("AtomInNRings");
   return res;
 }
+
+ATOM_EQUALS_QUERY *makeAtomHasRingBondQuery() {
+  ATOM_EQUALS_QUERY *res =
+    makeAtomSimpleQuery<ATOM_EQUALS_QUERY>(true, queryAtomHasRingBond);
+  res->setDescription("AtomHasRingBond");
+  return res;
+}
+
 
 BOND_EQUALS_QUERY *makeBondOrderEqualsQuery(Bond::BondType what) {
   BOND_EQUALS_QUERY *res = new BOND_EQUALS_QUERY;

--- a/Code/GraphMol/QueryOps.h
+++ b/Code/GraphMol/QueryOps.h
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2003-2010 Greg Landrum and Rational Discovery LLC
+//  Copyright (C) 2003-2017 Greg Landrum and Rational Discovery LLC
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -411,7 +411,12 @@ T *makeAtomRingBondCountQuery(int what, const std::string &descr) {
 //! \overload
 ATOM_EQUALS_QUERY *makeAtomRingBondCountQuery(int what);
 
-//! returns a Query for matching atoms with a particular number of ring bonds
+//! returns a Query for matching generic A atoms (heavy atoms)
+ATOM_EQUALS_QUERY *makeAAtomQuery();
+//! returns a Query for matching generic Q atoms (heteroatoms)
+ATOM_OR_QUERY *makeQAtomQuery();
+
+//! returns a Query for matching atoms that have ring bonds
 template <class T>
 T *makeAtomHasRingBondQuery(const std::string &descr) {
   return makeAtomSimpleQuery<T>(1, queryAtomHasRingBond, descr);

--- a/Code/GraphMol/QueryOps.h
+++ b/Code/GraphMol/QueryOps.h
@@ -419,10 +419,14 @@ ATOM_EQUALS_QUERY *makeAHAtomQuery();
 ATOM_OR_QUERY *makeQAtomQuery();
 //! returns a Query for matching generic QH atoms (heteroatom or H)
 ATOM_EQUALS_QUERY *makeQHAtomQuery();
-//! returns a Query for matching generic X atoms (halogen)
+//! returns a Query for matching generic X atoms (halogens)
 ATOM_OR_QUERY *makeXAtomQuery();
 //! returns a Query for matching generic XH atoms (halogen or H)
 ATOM_OR_QUERY *makeXHAtomQuery();
+//! returns a Query for matching generic M atoms (metals)
+ATOM_OR_QUERY *makeMAtomQuery();
+//! returns a Query for matching generic MH atoms (metals or H)
+ATOM_OR_QUERY *makeMHAtomQuery();
 
 //! returns a Query for matching atoms that have ring bonds
 template <class T>

--- a/Code/GraphMol/QueryOps.h
+++ b/Code/GraphMol/QueryOps.h
@@ -413,8 +413,16 @@ ATOM_EQUALS_QUERY *makeAtomRingBondCountQuery(int what);
 
 //! returns a Query for matching generic A atoms (heavy atoms)
 ATOM_EQUALS_QUERY *makeAAtomQuery();
+//! returns a Query for matching generic AH atoms (any atom)
+ATOM_EQUALS_QUERY *makeAHAtomQuery();
 //! returns a Query for matching generic Q atoms (heteroatoms)
 ATOM_OR_QUERY *makeQAtomQuery();
+//! returns a Query for matching generic QH atoms (heteroatom or H)
+ATOM_EQUALS_QUERY *makeQHAtomQuery();
+//! returns a Query for matching generic X atoms (halogen)
+ATOM_OR_QUERY *makeXAtomQuery();
+//! returns a Query for matching generic XH atoms (halogen or H)
+ATOM_OR_QUERY *makeXHAtomQuery();
 
 //! returns a Query for matching atoms that have ring bonds
 template <class T>

--- a/Code/GraphMol/SLNParse/SLNParseOps.h
+++ b/Code/GraphMol/SLNParse/SLNParseOps.h
@@ -39,7 +39,9 @@
 #include <GraphMol/SLNParse/SLNAttribs.h>
 #include <GraphMol/RDKitBase.h>
 #include <GraphMol/RDKitQueries.h>
+#include <RDGeneral/BoostStartInclude.h>
 #include <boost/lexical_cast.hpp>
+#include <RDGeneral/BoostEndInclude.h>
 
 namespace RDKit {
 namespace SLNParse {

--- a/Code/GraphMol/SmilesParse/CMakeLists.txt
+++ b/Code/GraphMol/SmilesParse/CMakeLists.txt
@@ -11,27 +11,27 @@ ADD_DEFINITIONS("/D YY_NO_UNISTD_H")
 endif()
 
 if(FLEX_EXECUTABLE)
-  FLEX_TARGET(SmilesL smiles.ll 
-              ${CMAKE_CURRENT_SOURCE_DIR}/lex.yysmiles.cpp 
+  FLEX_TARGET(SmilesL smiles.ll
+              ${CMAKE_CURRENT_SOURCE_DIR}/lex.yysmiles.cpp
              COMPILE_FLAGS "-Pyysmiles_" )
-  FLEX_TARGET(SmartsL smarts.ll 
-              ${CMAKE_CURRENT_SOURCE_DIR}/lex.yysmarts.cpp 
+  FLEX_TARGET(SmartsL smarts.ll
+              ${CMAKE_CURRENT_SOURCE_DIR}/lex.yysmarts.cpp
               COMPILE_FLAGS "-Pyysmarts_" )
   SET(FLEX_OUTPUT_FILES ${FLEX_SmilesL_OUTPUTS} ${FLEX_SmartsL_OUTPUTS})
 else(FLEX_EXECUTABLE)
-  CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/lex.yysmiles.cpp.cmake 
+  CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/lex.yysmiles.cpp.cmake
                  ${CMAKE_CURRENT_SOURCE_DIR}/lex.yysmiles.cpp COPYONLY)
-  CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/lex.yysmarts.cpp.cmake 
+  CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/lex.yysmarts.cpp.cmake
                  ${CMAKE_CURRENT_SOURCE_DIR}/lex.yysmarts.cpp COPYONLY)
-  FILE(GLOB FLEX_OUTPUT_FILES "${CMAKE_CURRENT_SOURCE_DIR}/lex.*.cpp")	
+  FILE(GLOB FLEX_OUTPUT_FILES "${CMAKE_CURRENT_SOURCE_DIR}/lex.*.cpp")
 endif(FLEX_EXECUTABLE)
 
 if(BISON_EXECUTABLE)
-  BISON_TARGET(SmilesY smiles.yy 
-               ${CMAKE_CURRENT_SOURCE_DIR}/smiles.tab.cpp 
+  BISON_TARGET(SmilesY smiles.yy
+               ${CMAKE_CURRENT_SOURCE_DIR}/smiles.tab.cpp
                COMPILE_FLAGS "-pyysmiles_" )
-  BISON_TARGET(SmartsY smarts.yy 
-               ${CMAKE_CURRENT_SOURCE_DIR}/smarts.tab.cpp 
+  BISON_TARGET(SmartsY smarts.yy
+               ${CMAKE_CURRENT_SOURCE_DIR}/smarts.tab.cpp
                COMPILE_FLAGS "-pyysmarts_" )
   SET(BISON_OUTPUT_FILES ${BISON_SmilesY_OUTPUTS} ${BISON_SmartsY_OUTPUTS})
   if(FLEX_EXECUTABLE)
@@ -39,20 +39,20 @@ if(BISON_EXECUTABLE)
     ADD_FLEX_BISON_DEPENDENCY(SmartsL SmartsY)
   endif(FLEX_EXECUTABLE)
 else(BISON_EXECUTABLE)
-  CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/smiles.tab.hpp.cmake 
+  CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/smiles.tab.hpp.cmake
                  ${CMAKE_CURRENT_SOURCE_DIR}/smiles.tab.hpp COPYONLY)
-  CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/smiles.tab.cpp.cmake 
+  CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/smiles.tab.cpp.cmake
                  ${CMAKE_CURRENT_SOURCE_DIR}/smiles.tab.cpp COPYONLY)
-  CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/smarts.tab.hpp.cmake 
+  CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/smarts.tab.hpp.cmake
                  ${CMAKE_CURRENT_SOURCE_DIR}/smarts.tab.hpp COPYONLY)
-  CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/smarts.tab.cpp.cmake 
+  CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/smarts.tab.cpp.cmake
                  ${CMAKE_CURRENT_SOURCE_DIR}/smarts.tab.cpp COPYONLY)
   FILE(GLOB BISON_OUTPUT_FILES "${CMAKE_CURRENT_SOURCE_DIR}/*.tab.?pp")
 endif(BISON_EXECUTABLE)
 
 rdkit_library(SmilesParse
-              SmilesParse.cpp SmilesParseOps.cpp 
-              SmilesWrite.cpp SmartsWrite.cpp
+              SmilesParse.cpp SmilesParseOps.cpp
+              SmilesWrite.cpp SmartsWrite.cpp CXSmilesOps.cpp
               ${BISON_OUTPUT_FILES}
               ${FLEX_OUTPUT_FILES}
               LINK_LIBRARIES GraphMol)
@@ -64,6 +64,6 @@ rdkit_headers(primes.h
               SmilesWrite.h DEST GraphMol/SmilesParse)
 
 rdkit_test(smiTest1 test.cpp LINK_LIBRARIES FileParsers SmilesParse GraphMol RDGeneral RDGeometryLib )
+rdkit_test(cxsmilesTest cxsmiles_test.cpp LINK_LIBRARIES FileParsers SmilesParse GraphMol RDGeneral RDGeometryLib )
 
 rdkit_test(smaTest1 smatest.cpp LINK_LIBRARIES SmilesParse SubstructMatch GraphMol RDGeneral RDGeometryLib )
-

--- a/Code/GraphMol/SmilesParse/CXSmilesOps.cpp
+++ b/Code/GraphMol/SmilesParse/CXSmilesOps.cpp
@@ -7,15 +7,15 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-#include <GraphMol/RDKitBase.h>
-#include <GraphMol/RDKitQueries.h>
-#include <iostream>
-#include "SmilesParseOps.h"
 #include <RDGeneral/BoostStartInclude.h>
 #include <boost/algorithm/string.hpp>
 #include <boost/foreach.hpp>
 #include <boost/lexical_cast.hpp>
 #include <RDGeneral/BoostEndInclude.h>
+#include <GraphMol/RDKitBase.h>
+#include <GraphMol/RDKitQueries.h>
+#include <iostream>
+#include "SmilesParseOps.h"
 
 namespace SmilesParseOps {
   using namespace RDKit;

--- a/Code/GraphMol/SmilesParse/CXSmilesOps.cpp
+++ b/Code/GraphMol/SmilesParse/CXSmilesOps.cpp
@@ -41,7 +41,7 @@ namespace SmilesParseOps {
       while (first != last && *first != '$') {
         std::string tkn = read_text_to(first, last, ';', '$');
         if (tkn != "") {
-          mol.getAtomWithIdx(atIdx)->setProp("_atomLabel", tkn);
+          mol.getAtomWithIdx(atIdx)->setProp(RDKit::common_properties::atomLabel, tkn);
         }
         ++atIdx;
         if(first != last && *first!='$') ++first;
@@ -211,7 +211,7 @@ namespace SmilesParseOps {
     void processCXSmilesLabels(RDKit::RWMol &mol) {
       for (RDKit::ROMol::AtomIterator atIt = mol.beginAtoms(); atIt != mol.endAtoms(); ++atIt) {
         std::string symb = "";
-        if((*atIt)->getPropIfPresent("_atomLabel",symb)) {
+        if((*atIt)->getPropIfPresent(RDKit::common_properties::atomLabel,symb)) {
           if (symb.size() > 3 && symb[0] == '_' && symb[1] == 'A' && symb[2] == 'P') {
             unsigned int mapNum = boost::lexical_cast<unsigned int>(symb.substr(3, symb.size() - 3));
             (*atIt)->setAtomMapNum(mapNum);
@@ -265,7 +265,7 @@ namespace SmilesParseOps {
             // queries have no implicit Hs:
             query->setNoImplicit(true);
             mol.replaceAtom((*atIt)->getIdx(), query);
-            mol.getAtomWithIdx((*atIt)->getIdx())->setProp("_atomLabel", symb);
+            mol.getAtomWithIdx((*atIt)->getIdx())->setProp(RDKit::common_properties::atomLabel, symb);
           }
         }
       }

--- a/Code/GraphMol/SmilesParse/CXSmilesOps.cpp
+++ b/Code/GraphMol/SmilesParse/CXSmilesOps.cpp
@@ -212,7 +212,10 @@ namespace SmilesParseOps {
       for (RDKit::ROMol::AtomIterator atIt = mol.beginAtoms(); atIt != mol.endAtoms(); ++atIt) {
         std::string symb = "";
         if((*atIt)->getPropIfPresent("_atomLabel",symb)) {
-          if (symb == "AH_p" || symb == "QH_p" || symb == "XH_p" || symb == "X_p" ||
+          if (symb.size() > 3 && symb[0] == '_' && symb[1] == 'A' && symb[2] == 'P') {
+            unsigned int mapNum = boost::lexical_cast<unsigned int>(symb.substr(3, symb.size() - 3));
+            (*atIt)->setAtomMapNum(mapNum);
+          } else if (symb == "AH_p" || symb == "QH_p" || symb == "XH_p" || symb == "X_p" ||
             symb == "Q_e" || symb == "star_e") {
             QueryAtom *query = new QueryAtom(0);
             if (symb == "star_e") {

--- a/Code/GraphMol/SmilesParse/CXSmilesOps.cpp
+++ b/Code/GraphMol/SmilesParse/CXSmilesOps.cpp
@@ -11,8 +11,11 @@
 #include <GraphMol/RDKitQueries.h>
 #include <iostream>
 #include "SmilesParseOps.h"
-//#include <boost/config/warning_disable.hpp>
-//#include <boost/spirit/include/qi.hpp>
+#include <RDGeneral/BoostStartInclude.h>
+#include <boost/algorithm/string.hpp>
+#include <boost/foreach.hpp>
+#include <boost/lexical_cast.hpp>
+#include <RDGeneral/BoostEndInclude.h>
 
 
 
@@ -22,13 +25,12 @@ namespace SmilesParseOps {
   namespace parser {
     template <typename Iterator>
     std::string read_text_to(Iterator &first, Iterator last, const char sep, const char blockend) {
+      Iterator start = first; 
       // EFF: there are certainly faster ways to do this
-      std::string res = "";
       while (first != last && *first != sep && *first != blockend) {
-        res += *first;
         ++first;
       }
-      std::cerr << "   tkn: " << res << std::endl;
+      std::string res(start, first);
       return res;
     }
 
@@ -36,7 +38,6 @@ namespace SmilesParseOps {
     bool parse_atom_labels(Iterator &first, Iterator last, RDKit::RWMol &mol) {
       if (first >= last || *first != '$') return false;
       ++first;
-      std::cerr << "atom labels" << std::endl;
       unsigned int atIdx = 0;
       while (first != last && *first != '$') {
         std::string tkn = read_text_to(first, last, ';', '$');
@@ -53,17 +54,35 @@ namespace SmilesParseOps {
     template <typename Iterator>
     bool parse_coords(Iterator &first, Iterator last, RDKit::RWMol &mol) {
       if (first >= last || *first != '(') return false;
+
+      RDKit::Conformer *conf = new Conformer(mol.getNumAtoms());
+      mol.addConformer(conf);
       ++first;
-      std::cerr << "atom coords" << std::endl;
+      unsigned int atIdx = 0;
       while (first != last && *first != ')') {
-        ++first;
+        RDGeom::Point3D pt;
+        std::string tkn = read_text_to(first, last, ';', ')');
+        if (tkn != "") {
+          std::vector<std::string> tokens;
+          boost::split(tokens, tkn, boost::is_any_of(","));
+          if(tokens.size()>=1 && tokens[0].size())
+             pt.x = boost::lexical_cast<double>(tokens[0]);
+          if (tokens.size() >= 2 && tokens[1].size())
+            pt.y = boost::lexical_cast<double>(tokens[1]);
+          if (tokens.size() >= 3 && tokens[2].size())
+            pt.z = boost::lexical_cast<double>(tokens[2]);
+        }
+
+        conf->setAtomPos(atIdx, pt);
+        ++atIdx;
+        if (first != last && *first != ')') ++first;
       }
       if (first == last || *first != ')') return false;
       return true;
 
     }
     template <typename Iterator>
-    bool parse_it(Iterator first, Iterator last,RDKit::RWMol &mol) {
+    bool parse_it(Iterator &first, Iterator last,RDKit::RWMol &mol) {
       if (first >= last || *first != '|') return false;
       ++first;
       while (first < last && *first != '|') {
@@ -76,20 +95,16 @@ namespace SmilesParseOps {
         ++first;
       }
       if (first >= last || *first != '|') return false;
+      ++first; // step past the last '|'
       return true;
     }
   } // end of namespace parser
 
-  
-
-
-  void parseCXNExtensions(RDKit::RWMol & mol, const std::string & extText) {
-    std::cerr << "parseCXNExtensions: " << extText << std::endl;
+  void parseCXExtensions(RDKit::RWMol & mol, const std::string & extText, std::string::const_iterator &first) {
+    //std::cerr << "parseCXNExtensions: " << extText << std::endl;
     if (!extText.size() || extText[0] != '|') return;
-    bool ok = parser::parse_it(extText.begin(), extText.end(),mol);
+    first = extText.begin();
+    bool ok = parser::parse_it(first, extText.end(),mol);
     POSTCONDITION(ok,"parse failed");
-
-
-
   }
 } // end of namespace SmilesParseOps

--- a/Code/GraphMol/SmilesParse/CXSmilesOps.cpp
+++ b/Code/GraphMol/SmilesParse/CXSmilesOps.cpp
@@ -47,6 +47,7 @@ namespace SmilesParseOps {
         if(first != last && *first!='$') ++first;
       }
       if (first == last || *first != '$') return false;
+      ++first;
       return true;
     }
 
@@ -77,6 +78,7 @@ namespace SmilesParseOps {
         if (first != last && *first != ')') ++first;
       }
       if (first == last || *first != ')') return false;
+      ++first;
       return true;
 
     }
@@ -132,8 +134,54 @@ namespace SmilesParseOps {
     return true;
   }
 
+  template <typename Iterator>
+  bool processRadicalSection(Iterator &first, Iterator last, RDKit::RWMol &mol,
+    unsigned int numRadicalElectrons) {
+    if (first >= last ) return false;
+    ++first;
+    if (first >= last || *first != ':') return false;
+    ++first;
+    unsigned int atIdx;
+    if (!read_int(first, last, atIdx)) return false;
+    mol.getAtomWithIdx(atIdx)->setNumRadicalElectrons(numRadicalElectrons);
+    while (first < last && *first == ',') {
+      ++first;
+      if (first < last && (*first < '0' || *first>'9')) return true;
+      if (!read_int(first, last, atIdx)) return false;
+      mol.getAtomWithIdx(atIdx)->setNumRadicalElectrons(numRadicalElectrons);
+    }
+    if (first >= last) return false;
+    return true;
+  }
 
-    
+  template <typename Iterator>
+  bool parse_radicals(Iterator &first, Iterator last, RDKit::RWMol &mol) {
+    if (first >= last || *first != '^') return false;
+    while (*first == '^') {
+      ++first;
+      if (first >= last ) return false;
+      if (*first<'1' || *first>'7') return false; // these are the values that are allowed to be there
+      switch (*first) {
+      case '1':
+        if(!processRadicalSection(first, last, mol, 1)) return false;
+        break;
+      case '2':
+      case '3':
+      case '4':
+        if (!processRadicalSection(first, last, mol, 2)) return false;
+        break;
+      case '5':
+      case '6':
+      case '7':
+        if (!processRadicalSection(first, last, mol, 3)) return false;
+        break;
+      default:
+        BOOST_LOG(rdWarningLog) << "Radical specification " << *first << " ignored.";
+      }
+    }
+    return true;
+  }
+
     template <typename Iterator>
     bool parse_it(Iterator &first, Iterator last,RDKit::RWMol &mol) {
       if (first >= last || *first != '|') return false;
@@ -148,7 +196,10 @@ namespace SmilesParseOps {
         else if (*first == 'C') {
           if (!parse_coordinate_bonds(first, last, mol)) return false;
         }
-        if(first < last && *first != '|') ++first;
+        else if (*first == '^') {
+          if (!parse_radicals(first, last, mol)) return false;
+        }
+        //if(first < last && *first != '|') ++first;
       }
       if (first >= last || *first != '|') return false;
       ++first; // step past the last '|'
@@ -165,7 +216,8 @@ namespace SmilesParseOps {
             symb == "Q_e" || symb == "star_e") {
             QueryAtom *query = new QueryAtom(0);
             if (symb == "star_e") {
-              // according to the MDL spec, these match anything
+              /* according to the MDL spec, these match anything, but in MARVIN they are
+              "unspecified end groups" for polymers */
               query->setQuery(makeAtomNullQuery());
             } else if (symb == "Q_e") {
               ATOM_OR_QUERY *q = new ATOM_OR_QUERY;
@@ -176,11 +228,15 @@ namespace SmilesParseOps {
               q->addChild(
                 QueryAtom::QUERYATOM_QUERY::CHILD_TYPE(makeAtomNumQuery(1)));
               query->setQuery(q);
-            } else if (symb == "QH_P") {
+            } else if (symb == "QH_p") {
               ATOM_EQUALS_QUERY *q = makeAtomNumQuery(6);
               q->setNegation(true);
               query->setQuery(q);
-            } else if (symb == "AH_P") { // this seems wrong...
+            } else if (symb == "AH_p") { // this seems wrong...
+              /* According to the MARVIN Sketch, AH is "any atom, including H" - this would be 
+              "*" in SMILES - and "A" is "any atom except H".
+              The CXSMILES docs say that "A" can be represented normally in SMILES and that "AH" 
+              needs to be written out as AH_p. I'm not sure what to make of this.*/
               ATOM_EQUALS_QUERY *q = makeAtomNumQuery(1);
               q->setNegation(true);
               query->setQuery(q);

--- a/Code/GraphMol/SmilesParse/CXSmilesOps.cpp
+++ b/Code/GraphMol/SmilesParse/CXSmilesOps.cpp
@@ -223,14 +223,7 @@ namespace SmilesParseOps {
               "unspecified end groups" for polymers */
               query->setQuery(makeAtomNullQuery());
             } else if (symb == "Q_e") {
-              ATOM_OR_QUERY *q = new ATOM_OR_QUERY;
-              q->setDescription("AtomOr");
-              q->setNegation(true);
-              q->addChild(
-                QueryAtom::QUERYATOM_QUERY::CHILD_TYPE(makeAtomNumQuery(6)));
-              q->addChild(
-                QueryAtom::QUERYATOM_QUERY::CHILD_TYPE(makeAtomNumQuery(1)));
-              query->setQuery(q);
+              query->setQuery(makeQAtomQuery());
             } else if (symb == "QH_p") {
               ATOM_EQUALS_QUERY *q = makeAtomNumQuery(6);
               q->setNegation(true);
@@ -269,9 +262,7 @@ namespace SmilesParseOps {
           }
         } else if ((*atIt)->getAtomicNum() == 0 && (*atIt)->getSymbol() == "*") {
           QueryAtom *query = new QueryAtom(0);
-          ATOM_EQUALS_QUERY *q = makeAtomNumQuery(1);
-          q->setNegation(true);
-          query->setQuery(q);
+          query->setQuery(makeAAtomQuery());
           query->setNoImplicit(true);
           mol.replaceAtom((*atIt)->getIdx(), query);          
         }

--- a/Code/GraphMol/SmilesParse/CXSmilesOps.cpp
+++ b/Code/GraphMol/SmilesParse/CXSmilesOps.cpp
@@ -1,0 +1,63 @@
+//
+//  Copyright (C) 2016 Greg Landrum
+//
+//   @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
+//
+#include <GraphMol/RDKitBase.h>
+#include <GraphMol/RDKitQueries.h>
+#include <iostream>
+#include "SmilesParseOps.h"
+#include <boost/config/warning_disable.hpp>
+#include <boost/spirit/include/qi.hpp>
+
+
+
+namespace SmilesParseOps {
+  using namespace RDKit;
+
+  namespace parser {
+    namespace qi = boost::spirit::qi;
+    namespace ascii = boost::spirit::ascii;
+
+    template <typename Iterator>
+    bool parse_it(Iterator first, Iterator last)
+    {
+      using qi::double_;
+      using qi::phrase_parse;
+      using ascii::space;
+      std::cerr << "PARSE: " << last-first << std::endl;
+      bool r = phrase_parse(
+        first,                          /*< start iterator >*/
+        last,                           /*< end iterator >*/
+        ('|' >>
+          *('(' >>
+            -(double_) >> ',' >> -(double_) >> ',' >> -(double_) >>
+            *( ';' >> -(double_) >> ',' >> -(double_) >> ',' >> -(double_) ) >>
+          ')') >> 
+          '|'
+          ),   /*< the parser >*/
+        space                           /*< the skip-parser >*/
+      );
+      std::cerr << "DONE: " << (last - first) << "? " << r << std::endl;
+      if (first != last) // fail if we did not get a full match
+        return false;
+      return r;
+    }
+
+  } // end of namespace parser
+
+
+  void parseCXNExtensions(RDKit::RWMol & mol, const std::string & extText) {
+    std::cerr << "parseCXNExtensions: " << extText << std::endl;
+    if (!extText.size() || extText[0] != '|') return;
+    bool ok = parser::parse_it(extText.begin(), extText.end());
+    POSTCONDITION(ok,"parse failed");
+
+
+
+  }
+} // end of namespace SmilesParseOps

--- a/Code/GraphMol/SmilesParse/CXSmilesOps.cpp
+++ b/Code/GraphMol/SmilesParse/CXSmilesOps.cpp
@@ -239,10 +239,10 @@ namespace SmilesParseOps {
               /* According to the MARVIN Sketch, AH is "any atom, including H" - this would be 
               "*" in SMILES - and "A" is "any atom except H".
               The CXSMILES docs say that "A" can be represented normally in SMILES and that "AH" 
-              needs to be written out as AH_p. I'm not sure what to make of this.*/
-              ATOM_EQUALS_QUERY *q = makeAtomNumQuery(1);
-              q->setNegation(true);
-              query->setQuery(q);
+              needs to be written out as AH_p. I'm going to assume that this is a Marvin internal thing and
+              just parse it as they describe it. This means that "*" in the SMILES itself needs to be treated
+              differently, which we do below. */
+              query->setQuery(makeAtomNullQuery());
             } else if (symb == "X_p" || symb == "XH_p") { 
               ATOM_OR_QUERY *q = new ATOM_OR_QUERY;
               q->setDescription("AtomOr");
@@ -267,6 +267,13 @@ namespace SmilesParseOps {
             mol.replaceAtom((*atIt)->getIdx(), query);
             mol.getAtomWithIdx((*atIt)->getIdx())->setProp(RDKit::common_properties::atomLabel, symb);
           }
+        } else if ((*atIt)->getAtomicNum() == 0 && (*atIt)->getSymbol() == "*") {
+          QueryAtom *query = new QueryAtom(0);
+          ATOM_EQUALS_QUERY *q = makeAtomNumQuery(1);
+          q->setNegation(true);
+          query->setQuery(q);
+          query->setNoImplicit(true);
+          mol.replaceAtom((*atIt)->getIdx(), query);          
         }
       }
     }

--- a/Code/GraphMol/SmilesParse/CXSmilesOps.cpp
+++ b/Code/GraphMol/SmilesParse/CXSmilesOps.cpp
@@ -19,151 +19,154 @@
 #include "SmilesParseOps.h"
 
 namespace SmilesParseOps {
-  using namespace RDKit;
+using namespace RDKit;
 
-  namespace parser {
-    template <typename Iterator>
-    std::string read_text_to(Iterator &first, Iterator last, const char sep, const char blockend) {
-      Iterator start = first;
-      // EFF: there are certainly faster ways to do this
-      while (first != last && *first != sep && *first != blockend) {
-        ++first;
-      }
-      std::string res(start, first);
-      return res;
+namespace parser {
+template <typename Iterator>
+std::string read_text_to(Iterator &first, Iterator last, const char sep,
+                         const char blockend) {
+  Iterator start = first;
+  // EFF: there are certainly faster ways to do this
+  while (first != last && *first != sep && *first != blockend) {
+    ++first;
+  }
+  std::string res(start, first);
+  return res;
+}
+
+template <typename Iterator>
+bool parse_atom_labels(Iterator &first, Iterator last, RDKit::RWMol &mol) {
+  if (first >= last || *first != '$') return false;
+  ++first;
+  unsigned int atIdx = 0;
+  while (first != last && *first != '$') {
+    std::string tkn = read_text_to(first, last, ';', '$');
+    if (tkn != "") {
+      mol.getAtomWithIdx(atIdx)->setProp(RDKit::common_properties::atomLabel,
+                                         tkn);
+    }
+    ++atIdx;
+    if (first != last && *first != '$') ++first;
+  }
+  if (first == last || *first != '$') return false;
+  ++first;
+  return true;
+}
+
+template <typename Iterator>
+bool parse_coords(Iterator &first, Iterator last, RDKit::RWMol &mol) {
+  if (first >= last || *first != '(') return false;
+
+  RDKit::Conformer *conf = new Conformer(mol.getNumAtoms());
+  mol.addConformer(conf);
+  ++first;
+  unsigned int atIdx = 0;
+  while (first != last && *first != ')') {
+    RDGeom::Point3D pt;
+    std::string tkn = read_text_to(first, last, ';', ')');
+    if (tkn != "") {
+      std::vector<std::string> tokens;
+      boost::split(tokens, tkn, boost::is_any_of(std::string(",")));
+      if (tokens.size() >= 1 && tokens[0].size())
+        pt.x = boost::lexical_cast<double>(tokens[0]);
+      if (tokens.size() >= 2 && tokens[1].size())
+        pt.y = boost::lexical_cast<double>(tokens[1]);
+      if (tokens.size() >= 3 && tokens[2].size())
+        pt.z = boost::lexical_cast<double>(tokens[2]);
     }
 
-    template <typename Iterator>
-    bool parse_atom_labels(Iterator &first, Iterator last, RDKit::RWMol &mol) {
-      if (first >= last || *first != '$') return false;
-      ++first;
-      unsigned int atIdx = 0;
-      while (first != last && *first != '$') {
-        std::string tkn = read_text_to(first, last, ';', '$');
-        if (tkn != "") {
-          mol.getAtomWithIdx(atIdx)->setProp(RDKit::common_properties::atomLabel, tkn);
-        }
-        ++atIdx;
-        if(first != last && *first!='$') ++first;
-      }
-      if (first == last || *first != '$') return false;
-      ++first;
-      return true;
-    }
+    conf->setAtomPos(atIdx, pt);
+    ++atIdx;
+    if (first != last && *first != ')') ++first;
+  }
+  if (first == last || *first != ')') return false;
+  ++first;
+  return true;
+}
 
-    template <typename Iterator>
-    bool parse_coords(Iterator &first, Iterator last, RDKit::RWMol &mol) {
-      if (first >= last || *first != '(') return false;
+template <typename Iterator>
+bool read_int(Iterator &first, Iterator last, unsigned int &res) {
+  std::string num = "";
+  while (first != last && *first >= '0' && *first <= '9') {
+    num += *first;
+    ++first;
+  }
+  if (num == "") {
+    return false;
+  }
+  res = boost::lexical_cast<unsigned int>(num);
+  return true;
+}
+template <typename Iterator>
+bool read_int_pair(Iterator &first, Iterator last, unsigned int &n1,
+                   unsigned int &n2, char sep = '.') {
+  if (!read_int(first, last, n1)) return false;
+  if (first >= last || *first != sep) return false;
+  ++first;
+  return read_int(first, last, n2);
+}
 
-      RDKit::Conformer *conf = new Conformer(mol.getNumAtoms());
-      mol.addConformer(conf);
-      ++first;
-      unsigned int atIdx = 0;
-      while (first != last && *first != ')') {
-        RDGeom::Point3D pt;
-        std::string tkn = read_text_to(first, last, ';', ')');
-        if (tkn != "") {
-          std::vector<std::string> tokens;
-          boost::split(tokens, tkn, boost::is_any_of(std::string(",")));
-          if(tokens.size()>=1 && tokens[0].size())
-             pt.x = boost::lexical_cast<double>(tokens[0]);
-          if (tokens.size() >= 2 && tokens[1].size())
-            pt.y = boost::lexical_cast<double>(tokens[1]);
-          if (tokens.size() >= 3 && tokens[2].size())
-            pt.z = boost::lexical_cast<double>(tokens[2]);
-        }
-
-        conf->setAtomPos(atIdx, pt);
-        ++atIdx;
-        if (first != last && *first != ')') ++first;
-      }
-      if (first == last || *first != ')') return false;
-      ++first;
-      return true;
-
-    }
-
-    template <typename Iterator>
-    bool read_int(Iterator &first, Iterator last, unsigned int &res) {
-      std::string num = "";
-      while (first != last && *first >= '0' && *first <= '9') {
-        num += *first;
-        ++first;
-      }
-      if (num=="") {
+template <typename Iterator>
+bool parse_coordinate_bonds(Iterator &first, Iterator last, RDKit::RWMol &mol) {
+  if (first >= last || *first != 'C') return false;
+  ++first;
+  if (first >= last || *first != ':') return false;
+  ++first;
+  while (first != last && *first >= '0' && *first <= '9') {
+    unsigned int aidx;
+    unsigned int bidx;
+    if (read_int_pair(first, last, aidx, bidx)) {
+      Bond *bnd = mol.getBondWithIdx(bidx);
+      if (bnd->getBeginAtomIdx() != aidx && bnd->getEndAtomIdx() != aidx) {
+        std::cerr << "BOND NOT FOUND! " << bidx << " involving atom " << aidx
+                  << std::endl;
         return false;
       }
-      res = boost::lexical_cast<unsigned int>(num);
-      return true;
-  }
-    template <typename Iterator>
-    bool read_int_pair(Iterator &first, Iterator last, unsigned int &n1, unsigned int &n2, char sep='.') {
-      if (!read_int(first, last, n1)) return false;
-      if (first >= last || *first != sep) return false;
-      ++first;
-      return read_int(first, last, n2);
-    }
-
-    template <typename Iterator>
-  bool parse_coordinate_bonds(Iterator &first, Iterator last, RDKit::RWMol &mol) {
-    if (first >= last || *first != 'C') return false;
-    ++first;
-    if (first >= last || *first != ':') return false;
-    ++first;
-    while (first != last && *first >= '0' && *first<='9') {
-      unsigned int aidx;
-      unsigned int bidx;
-      if (read_int_pair(first, last, aidx,bidx)) {
-        Bond *bnd = mol.getBondWithIdx(bidx);
-        if (bnd->getBeginAtomIdx() != aidx && bnd->getEndAtomIdx() != aidx) {
-          std::cerr << "BOND NOT FOUND! " << bidx << " involving atom " << aidx <<  std::endl;
-          return false;
-        }
-        bnd->setBondType(Bond::DATIVE);
-        if (bnd->getBeginAtomIdx() != aidx) {
-          unsigned int tmp = bnd->getBeginAtomIdx();
-          bnd->setBeginAtomIdx(aidx);
-          bnd->setEndAtomIdx(tmp);
-        }
+      bnd->setBondType(Bond::DATIVE);
+      if (bnd->getBeginAtomIdx() != aidx) {
+        unsigned int tmp = bnd->getBeginAtomIdx();
+        bnd->setBeginAtomIdx(aidx);
+        bnd->setEndAtomIdx(tmp);
       }
-      else {
-        return false;
-      }
-      if (first < last && *first == ',') ++first;
+    } else {
+      return false;
     }
-    return true;
+    if (first < last && *first == ',') ++first;
   }
+  return true;
+}
 
-  template <typename Iterator>
-  bool processRadicalSection(Iterator &first, Iterator last, RDKit::RWMol &mol,
-    unsigned int numRadicalElectrons) {
-    if (first >= last ) return false;
+template <typename Iterator>
+bool processRadicalSection(Iterator &first, Iterator last, RDKit::RWMol &mol,
+                           unsigned int numRadicalElectrons) {
+  if (first >= last) return false;
+  ++first;
+  if (first >= last || *first != ':') return false;
+  ++first;
+  unsigned int atIdx;
+  if (!read_int(first, last, atIdx)) return false;
+  mol.getAtomWithIdx(atIdx)->setNumRadicalElectrons(numRadicalElectrons);
+  while (first < last && *first == ',') {
     ++first;
-    if (first >= last || *first != ':') return false;
-    ++first;
-    unsigned int atIdx;
+    if (first < last && (*first < '0' || *first > '9')) return true;
     if (!read_int(first, last, atIdx)) return false;
     mol.getAtomWithIdx(atIdx)->setNumRadicalElectrons(numRadicalElectrons);
-    while (first < last && *first == ',') {
-      ++first;
-      if (first < last && (*first < '0' || *first>'9')) return true;
-      if (!read_int(first, last, atIdx)) return false;
-      mol.getAtomWithIdx(atIdx)->setNumRadicalElectrons(numRadicalElectrons);
-    }
-    if (first >= last) return false;
-    return true;
   }
+  if (first >= last) return false;
+  return true;
+}
 
-  template <typename Iterator>
-  bool parse_radicals(Iterator &first, Iterator last, RDKit::RWMol &mol) {
-    if (first >= last || *first != '^') return false;
-    while (*first == '^') {
-      ++first;
-      if (first >= last ) return false;
-      if (*first<'1' || *first>'7') return false; // these are the values that are allowed to be there
-      switch (*first) {
+template <typename Iterator>
+bool parse_radicals(Iterator &first, Iterator last, RDKit::RWMol &mol) {
+  if (first >= last || *first != '^') return false;
+  while (*first == '^') {
+    ++first;
+    if (first >= last) return false;
+    if (*first < '1' || *first > '7')
+      return false;  // these are the values that are allowed to be there
+    switch (*first) {
       case '1':
-        if(!processRadicalSection(first, last, mol, 1)) return false;
+        if (!processRadicalSection(first, last, mol, 1)) return false;
         break;
       case '2':
       case '3':
@@ -176,94 +179,102 @@ namespace SmilesParseOps {
         if (!processRadicalSection(first, last, mol, 3)) return false;
         break;
       default:
-        BOOST_LOG(rdWarningLog) << "Radical specification " << *first << " ignored.";
-      }
-    }
-    return true;
-  }
-
-    template <typename Iterator>
-    bool parse_it(Iterator &first, Iterator last,RDKit::RWMol &mol) {
-      if (first >= last || *first != '|') return false;
-      ++first;
-      while (first < last && *first != '|') {
-        if (*first == '(') {
-          if (!parse_coords(first, last, mol)) return false;
-        }
-        else if (*first == '$') {
-          if (!parse_atom_labels(first, last, mol)) return false;
-        }
-        else if (*first == 'C') {
-          if (!parse_coordinate_bonds(first, last, mol)) return false;
-        }
-        else if (*first == '^') {
-          if (!parse_radicals(first, last, mol)) return false;
-        }
-        //if(first < last && *first != '|') ++first;
-      }
-      if (first >= last || *first != '|') return false;
-      ++first; // step past the last '|'
-      return true;
-    }
-  } // end of namespace parser
-
-  namespace {
-    void processCXSmilesLabels(RDKit::RWMol &mol) {
-      for (RDKit::ROMol::AtomIterator atIt = mol.beginAtoms(); atIt != mol.endAtoms(); ++atIt) {
-        std::string symb = "";
-        if((*atIt)->getPropIfPresent(RDKit::common_properties::atomLabel,symb)) {
-          if (symb.size() > 3 && symb[0] == '_' && symb[1] == 'A' && symb[2] == 'P') {
-            unsigned int mapNum = boost::lexical_cast<unsigned int>(symb.substr(3, symb.size() - 3));
-            (*atIt)->setAtomMapNum(mapNum);
-          } else if (symb == "AH_p" || symb == "QH_p" || symb == "XH_p" || symb == "X_p" ||
-            symb == "Q_e" || symb == "star_e") {
-            QueryAtom *query = new QueryAtom(0);
-            if (symb == "star_e") {
-              /* according to the MDL spec, these match anything, but in MARVIN they are
-              "unspecified end groups" for polymers */
-              query->setQuery(makeAtomNullQuery());
-            } else if (symb == "Q_e") {
-              query->setQuery(makeQAtomQuery());
-            } else if (symb == "QH_p") {
-              query->setQuery(makeQHAtomQuery());
-            } else if (symb == "AH_p") { // this seems wrong...
-              /* According to the MARVIN Sketch, AH is "any atom, including H" - this would be
-              "*" in SMILES - and "A" is "any atom except H".
-              The CXSMILES docs say that "A" can be represented normally in SMILES and that "AH"
-              needs to be written out as AH_p. I'm going to assume that this is a Marvin internal thing and
-              just parse it as they describe it. This means that "*" in the SMILES itself needs to be treated
-              differently, which we do below. */
-              query->setQuery(makeAHAtomQuery());
-            } else if (symb == "X_p" ) {
-              query->setQuery(makeXAtomQuery());
-            }  else if (symb == "XH_p") {
-              query->setQuery(makeXHAtomQuery());
-            }
-            // queries have no implicit Hs:
-            query->setNoImplicit(true);
-            mol.replaceAtom((*atIt)->getIdx(), query);
-            mol.getAtomWithIdx((*atIt)->getIdx())->setProp(RDKit::common_properties::atomLabel, symb);
-          }
-        } else if ((*atIt)->getAtomicNum() == 0 && (*atIt)->getSymbol() == "*") {
-          QueryAtom *query = new QueryAtom(0);
-          query->setQuery(makeAAtomQuery());
-          query->setNoImplicit(true);
-          mol.replaceAtom((*atIt)->getIdx(), query);
-        }
-      }
-    }
-
-  } // end of anonymous namespace
-
-
-  void parseCXExtensions(RDKit::RWMol & mol, const std::string & extText, std::string::const_iterator &first) {
-    //std::cerr << "parseCXNExtensions: " << extText << std::endl;
-    if (!extText.size() || extText[0] != '|') return;
-    first = extText.begin();
-    bool ok = parser::parse_it(first, extText.end(),mol);
-    if (!ok) throw RDKit::SmilesParseException("failure parsing CXSMILES extensions");
-    if (ok) {
-      processCXSmilesLabels(mol);
+        BOOST_LOG(rdWarningLog) << "Radical specification " << *first
+                                << " ignored.";
     }
   }
-} // end of namespace SmilesParseOps
+  return true;
+}
+
+template <typename Iterator>
+bool parse_it(Iterator &first, Iterator last, RDKit::RWMol &mol) {
+  if (first >= last || *first != '|') return false;
+  ++first;
+  while (first < last && *first != '|') {
+    if (*first == '(') {
+      if (!parse_coords(first, last, mol)) return false;
+    } else if (*first == '$') {
+      if (!parse_atom_labels(first, last, mol)) return false;
+    } else if (*first == 'C') {
+      if (!parse_coordinate_bonds(first, last, mol)) return false;
+    } else if (*first == '^') {
+      if (!parse_radicals(first, last, mol)) return false;
+    }
+    // if(first < last && *first != '|') ++first;
+  }
+  if (first >= last || *first != '|') return false;
+  ++first;  // step past the last '|'
+  return true;
+}
+}  // end of namespace parser
+
+namespace {
+template <typename Q>
+void addquery(Q *qry, std::string symbol, RDKit::RWMol &mol, unsigned int idx) {
+  PRECONDITION(qry, "bad query");
+  QueryAtom *qa = new QueryAtom(0);
+  qa->setQuery(qry);
+  qa->setNoImplicit(true);
+  mol.replaceAtom(idx, qa);
+  if (symbol != "")
+    mol.getAtomWithIdx(idx)->setProp(RDKit::common_properties::atomLabel,
+                                     symbol);
+  delete qa;
+}
+void processCXSmilesLabels(RDKit::RWMol &mol) {
+  for (RDKit::ROMol::AtomIterator atIt = mol.beginAtoms();
+       atIt != mol.endAtoms(); ++atIt) {
+    std::string symb = "";
+    if ((*atIt)->getPropIfPresent(RDKit::common_properties::atomLabel, symb)) {
+      if (symb.size() > 3 && symb[0] == '_' && symb[1] == 'A' &&
+          symb[2] == 'P') {
+        unsigned int mapNum =
+            boost::lexical_cast<unsigned int>(symb.substr(3, symb.size() - 3));
+        (*atIt)->setAtomMapNum(mapNum);
+      } else if (symb == "star_e") {
+        /* according to the MDL spec, these match anything, but in MARVIN they
+        are "unspecified end groups" for polymers */
+        addquery(makeAtomNullQuery(), symb, mol, (*atIt)->getIdx());
+      } else if (symb == "Q_e") {
+        addquery(makeQAtomQuery(), symb, mol, (*atIt)->getIdx());
+      } else if (symb == "QH_p") {
+        addquery(makeQHAtomQuery(), symb, mol, (*atIt)->getIdx());
+      } else if (symb == "AH_p") {  // this seems wrong...
+        /* According to the MARVIN Sketch, AH is "any atom, including H" -
+        this would be "*" in SMILES - and "A" is "any atom except H".
+        The CXSMILES docs say that "A" can be represented normally in SMILES
+        and that "AH" needs to be written out as AH_p. I'm going to assume that
+        this is a Marvin internal thing and just parse it as they describe it.
+        This means that "*" in the SMILES itself needs to be treated
+        differently, which we do below. */
+        addquery(makeAHAtomQuery(), symb, mol, (*atIt)->getIdx());
+      } else if (symb == "X_p") {
+        addquery(makeXAtomQuery(), symb, mol, (*atIt)->getIdx());
+      } else if (symb == "XH_p") {
+        addquery(makeXHAtomQuery(), symb, mol, (*atIt)->getIdx());
+      } else if (symb == "M_p") {
+        addquery(makeMAtomQuery(), symb, mol, (*atIt)->getIdx());
+      } else if (symb == "MH_p") {
+        addquery(makeMHAtomQuery(), symb, mol, (*atIt)->getIdx());
+      }
+    } else if ((*atIt)->getAtomicNum() == 0 && (*atIt)->getSymbol() == "*") {
+      addquery(makeAAtomQuery(), "", mol, (*atIt)->getIdx());
+    }
+  }
+}
+
+}  // end of anonymous namespace
+
+void parseCXExtensions(RDKit::RWMol &mol, const std::string &extText,
+                       std::string::const_iterator &first) {
+  // std::cerr << "parseCXNExtensions: " << extText << std::endl;
+  if (!extText.size() || extText[0] != '|') return;
+  first = extText.begin();
+  bool ok = parser::parse_it(first, extText.end(), mol);
+  if (!ok)
+    throw RDKit::SmilesParseException("failure parsing CXSMILES extensions");
+  if (ok) {
+    processCXSmilesLabels(mol);
+  }
+}
+}  // end of namespace SmilesParseOps

--- a/Code/GraphMol/SmilesParse/CXSmilesOps.cpp
+++ b/Code/GraphMol/SmilesParse/CXSmilesOps.cpp
@@ -11,8 +11,8 @@
 #include <GraphMol/RDKitQueries.h>
 #include <iostream>
 #include "SmilesParseOps.h"
-#include <boost/config/warning_disable.hpp>
-#include <boost/spirit/include/qi.hpp>
+//#include <boost/config/warning_disable.hpp>
+//#include <boost/spirit/include/qi.hpp>
 
 
 
@@ -20,41 +20,73 @@ namespace SmilesParseOps {
   using namespace RDKit;
 
   namespace parser {
-    namespace qi = boost::spirit::qi;
-    namespace ascii = boost::spirit::ascii;
-
     template <typename Iterator>
-    bool parse_it(Iterator first, Iterator last)
-    {
-      using qi::double_;
-      using qi::phrase_parse;
-      using ascii::space;
-      std::cerr << "PARSE: " << last-first << std::endl;
-      bool r = phrase_parse(
-        first,                          /*< start iterator >*/
-        last,                           /*< end iterator >*/
-        ('|' >>
-          *('(' >>
-            -(double_) >> ',' >> -(double_) >> ',' >> -(double_) >>
-            *( ';' >> -(double_) >> ',' >> -(double_) >> ',' >> -(double_) ) >>
-          ')') >> 
-          '|'
-          ),   /*< the parser >*/
-        space                           /*< the skip-parser >*/
-      );
-      std::cerr << "DONE: " << (last - first) << "? " << r << std::endl;
-      if (first != last) // fail if we did not get a full match
-        return false;
-      return r;
+    std::string read_text_to(Iterator &first, Iterator last, const char sep, const char blockend) {
+      // EFF: there are certainly faster ways to do this
+      std::string res = "";
+      while (first != last && *first != sep && *first != blockend) {
+        res += *first;
+        ++first;
+      }
+      std::cerr << "   tkn: " << res << std::endl;
+      return res;
     }
 
+    template <typename Iterator>
+    bool parse_atom_labels(Iterator &first, Iterator last, RDKit::RWMol &mol) {
+      if (first >= last || *first != '$') return false;
+      ++first;
+      std::cerr << "atom labels" << std::endl;
+      unsigned int atIdx = 0;
+      while (first != last && *first != '$') {
+        std::string tkn = read_text_to(first, last, ';', '$');
+        if (tkn != "") {
+          mol.getAtomWithIdx(atIdx)->setProp("_atomLabel", tkn);
+        }
+        ++atIdx;
+        if(first != last && *first!='$') ++first;
+      }
+      if (first == last || *first != '$') return false;
+      return true;
+    }
+
+    template <typename Iterator>
+    bool parse_coords(Iterator &first, Iterator last, RDKit::RWMol &mol) {
+      if (first >= last || *first != '(') return false;
+      ++first;
+      std::cerr << "atom coords" << std::endl;
+      while (first != last && *first != ')') {
+        ++first;
+      }
+      if (first == last || *first != ')') return false;
+      return true;
+
+    }
+    template <typename Iterator>
+    bool parse_it(Iterator first, Iterator last,RDKit::RWMol &mol) {
+      if (first >= last || *first != '|') return false;
+      ++first;
+      while (first < last && *first != '|') {
+        if (*first == '(') {
+          if (!parse_coords(first, last, mol)) return false;
+        }
+        else if (*first == '$') {
+          if (!parse_atom_labels(first, last, mol)) return false;
+        }
+        ++first;
+      }
+      if (first >= last || *first != '|') return false;
+      return true;
+    }
   } // end of namespace parser
+
+  
 
 
   void parseCXNExtensions(RDKit::RWMol & mol, const std::string & extText) {
     std::cerr << "parseCXNExtensions: " << extText << std::endl;
     if (!extText.size() || extText[0] != '|') return;
-    bool ok = parser::parse_it(extText.begin(), extText.end());
+    bool ok = parser::parse_it(extText.begin(), extText.end(),mol);
     POSTCONDITION(ok,"parse failed");
 
 

--- a/Code/GraphMol/SmilesParse/CXSmilesOps.cpp
+++ b/Code/GraphMol/SmilesParse/CXSmilesOps.cpp
@@ -24,7 +24,7 @@ namespace SmilesParseOps {
   namespace parser {
     template <typename Iterator>
     std::string read_text_to(Iterator &first, Iterator last, const char sep, const char blockend) {
-      Iterator start = first; 
+      Iterator start = first;
       // EFF: there are certainly faster ways to do this
       while (first != last && *first != sep && *first != blockend) {
         ++first;
@@ -103,7 +103,7 @@ namespace SmilesParseOps {
       ++first;
       return read_int(first, last, n2);
     }
-    
+
     template <typename Iterator>
   bool parse_coordinate_bonds(Iterator &first, Iterator last, RDKit::RWMol &mol) {
     if (first >= last || *first != 'C') return false;
@@ -225,35 +225,19 @@ namespace SmilesParseOps {
             } else if (symb == "Q_e") {
               query->setQuery(makeQAtomQuery());
             } else if (symb == "QH_p") {
-              ATOM_EQUALS_QUERY *q = makeAtomNumQuery(6);
-              q->setNegation(true);
-              query->setQuery(q);
+              query->setQuery(makeQHAtomQuery());
             } else if (symb == "AH_p") { // this seems wrong...
-              /* According to the MARVIN Sketch, AH is "any atom, including H" - this would be 
+              /* According to the MARVIN Sketch, AH is "any atom, including H" - this would be
               "*" in SMILES - and "A" is "any atom except H".
-              The CXSMILES docs say that "A" can be represented normally in SMILES and that "AH" 
+              The CXSMILES docs say that "A" can be represented normally in SMILES and that "AH"
               needs to be written out as AH_p. I'm going to assume that this is a Marvin internal thing and
               just parse it as they describe it. This means that "*" in the SMILES itself needs to be treated
               differently, which we do below. */
-              query->setQuery(makeAtomNullQuery());
-            } else if (symb == "X_p" || symb == "XH_p") { 
-              ATOM_OR_QUERY *q = new ATOM_OR_QUERY;
-              q->setDescription("AtomOr");
-              q->addChild(
-                QueryAtom::QUERYATOM_QUERY::CHILD_TYPE(makeAtomNumQuery(9)));
-              q->addChild(
-                QueryAtom::QUERYATOM_QUERY::CHILD_TYPE(makeAtomNumQuery(17)));
-              q->addChild(
-                QueryAtom::QUERYATOM_QUERY::CHILD_TYPE(makeAtomNumQuery(35)));
-              q->addChild(
-                QueryAtom::QUERYATOM_QUERY::CHILD_TYPE(makeAtomNumQuery(53)));
-              q->addChild(
-                QueryAtom::QUERYATOM_QUERY::CHILD_TYPE(makeAtomNumQuery(85)));
-              if (symb == "XH_p") {
-                q->addChild(
-                  QueryAtom::QUERYATOM_QUERY::CHILD_TYPE(makeAtomNumQuery(1)));
-              }
-              query->setQuery(q);
+              query->setQuery(makeAHAtomQuery());
+            } else if (symb == "X_p" ) {
+              query->setQuery(makeXAtomQuery());
+            }  else if (symb == "XH_p") {
+              query->setQuery(makeXHAtomQuery());
             }
             // queries have no implicit Hs:
             query->setNoImplicit(true);
@@ -264,7 +248,7 @@ namespace SmilesParseOps {
           QueryAtom *query = new QueryAtom(0);
           query->setQuery(makeAAtomQuery());
           query->setNoImplicit(true);
-          mol.replaceAtom((*atIt)->getIdx(), query);          
+          mol.replaceAtom((*atIt)->getIdx(), query);
         }
       }
     }

--- a/Code/GraphMol/SmilesParse/SmartsWrite.cpp
+++ b/Code/GraphMol/SmilesParse/SmartsWrite.cpp
@@ -30,7 +30,7 @@ std::string _recurseBondSmarts(const Bond *bond,
                                bool negate, int atomToLeftIdx);
 
 bool _checkForOrAndLowAnd(std::string smarts) {
-  int orLoc, andLoc;
+  size_t orLoc, andLoc;
   // if we're a pure recursive smarts, we don't need to worry about this
   if (smarts[0] == '$' && smarts[smarts.size() - 1] == ')') return false;
   orLoc = smarts.find(",");
@@ -56,7 +56,7 @@ std::string _combineChildSmarts(std::string cs1, std::string cs2,
     res += cs2;
   } else if ((descrip.find("And") > 0) &&
              (descrip.find("And") < descrip.length())) {
-    int orLoc1, orLoc2;
+    size_t orLoc1, orLoc2;
     std::string symb;
     orLoc1 = cs1.find(',');
     orLoc2 = cs2.find(',');

--- a/Code/GraphMol/SmilesParse/SmartsWrite.cpp
+++ b/Code/GraphMol/SmilesParse/SmartsWrite.cpp
@@ -35,7 +35,7 @@ bool _checkForOrAndLowAnd(std::string smarts) {
   if (smarts[0] == '$' && smarts[smarts.size() - 1] == ')') return false;
   orLoc = smarts.find(",");
   andLoc = smarts.find(";");
-  if ((orLoc > 0) && (andLoc > 0)) {
+  if ((orLoc != std::string::npos) && (andLoc != std::string::npos)) {
     return true;
   } else {
     return false;
@@ -60,7 +60,7 @@ std::string _combineChildSmarts(std::string cs1, std::string cs2,
     std::string symb;
     orLoc1 = cs1.find(',');
     orLoc2 = cs2.find(',');
-    if ((orLoc1 > 0) || (orLoc2 > 0)) {
+    if ((orLoc1 != std::string::npos) || (orLoc2 != std::string::npos)) {
       symb = ";";
     } else {
       symb = "&";

--- a/Code/GraphMol/SmilesParse/SmilesParse.cpp
+++ b/Code/GraphMol/SmilesParse/SmilesParse.cpp
@@ -194,7 +194,6 @@ RWMol *SmilesToMol(const std::string &smiles, const SmilesParserParams &params) 
       cxPart = boost::trim_copy(smiles.substr(sidx, smiles.size() - sidx)); 
     }
   }
-  std::cerr << "   lsmiles " << lsmiles << std::endl;
 
   if(lsmiles=="") {
     lsmiles = smiles;
@@ -237,10 +236,15 @@ RWMol *SmilesToMol(const std::string &smiles, const SmilesParserParams &params) 
     bool cleanIt = true, force = true, flagPossible = true;
     MolOps::assignStereochemistry(*res, cleanIt, force, flagPossible);
   }
-  if(res && name!="") res->setProp(common_properties::_Name,name);
   if (res && params.allowCXSMILES && cxPart != "") {
-    SmilesParseOps::parseCXNExtensions(*res, cxPart);
+    std::string::iterator pos;
+    SmilesParseOps::parseCXExtensions(*res, cxPart, pos);
+    if (params.parseName && pos != cxPart.end()) {
+      std::string nmpart(pos, cxPart.end());
+      name = boost::trim_copy(nmpart);
+    }
   }
+  if (res && name != "") res->setProp(common_properties::_Name, name);
   return res;
 };
 RWMol *SmartsToMol(const std::string &smarts, int debugParse, bool mergeHs,

--- a/Code/GraphMol/SmilesParse/SmilesParse.cpp
+++ b/Code/GraphMol/SmilesParse/SmilesParse.cpp
@@ -191,7 +191,7 @@ RWMol *SmilesToMol(const std::string &smiles, const SmilesParserParams &params) 
     size_t sidx = smiles.find_first_of(" \t");
     if (sidx != std::string::npos && sidx != 0)  {
       lsmiles = smiles.substr(0, sidx);
-      cxPart = boost::trim_copy(smiles.substr(sidx, smiles.size() - sidx)); 
+      cxPart = boost::trim_copy(smiles.substr(sidx, smiles.size() - sidx));
     }
   }
 
@@ -237,10 +237,14 @@ RWMol *SmilesToMol(const std::string &smiles, const SmilesParserParams &params) 
     MolOps::assignStereochemistry(*res, cleanIt, force, flagPossible);
   }
   if (res && params.allowCXSMILES && cxPart != "") {
-    std::string::iterator pos;
-    SmilesParseOps::parseCXExtensions(*res, cxPart, pos);
-    if (params.parseName && pos != cxPart.end()) {
-      std::string nmpart(pos, cxPart.end());
+    // it's goofy that we have to do this, but c++0x doesn't seem to have
+    // a way to get a const_iterator from a non-const std::string. In C++11
+    // we could just use .cend()
+    const std::string &cxcopy = cxPart;
+    std::string::const_iterator pos;
+    SmilesParseOps::parseCXExtensions(*res, cxcopy, pos);
+    if (params.parseName && pos != cxcopy.end()) {
+      std::string nmpart(pos, cxcopy.end());
       name = boost::trim_copy(nmpart);
     }
   }

--- a/Code/GraphMol/SmilesParse/SmilesParse.cpp
+++ b/Code/GraphMol/SmilesParse/SmilesParse.cpp
@@ -23,16 +23,16 @@
 //
 //
 //
-#include <GraphMol/RDKitBase.h>
-#include "SmilesParse.h"
-#include "SmilesParseOps.h"
-#include <RDGeneral/RDLog.h>
-#include <RDGeneral/Invariant.h>
 #include <RDGeneral/BoostStartInclude.h>
 #include <boost/algorithm/string.hpp>
 #include <boost/foreach.hpp>
 #include <boost/lexical_cast.hpp>
 #include <RDGeneral/BoostEndInclude.h>
+#include <GraphMol/RDKitBase.h>
+#include "SmilesParse.h"
+#include "SmilesParseOps.h"
+#include <RDGeneral/RDLog.h>
+#include <RDGeneral/Invariant.h>
 #include <list>
 
 int yysmiles_parse(const char *, std::vector<RDKit::RWMol *> *,

--- a/Code/GraphMol/SmilesParse/SmilesParse.cpp
+++ b/Code/GraphMol/SmilesParse/SmilesParse.cpp
@@ -1,6 +1,5 @@
-// $Id$
 //
-//  Copyright (C) 2001-2014 Greg Landrum and Rational Discovery LLC
+//  Copyright (C) 2001-2016 Greg Landrum and Rational Discovery LLC
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -180,11 +179,20 @@ RWMol *toMol(const std::string &inp,
 
 RWMol *SmilesToMol(const std::string &smiles, const SmilesParserParams &params) {
   yysmiles_debug = params.debugParse;
+
+  std::string lsmiles = smiles, name="";
+  if(params.parseName){
+    std::vector<std::string> tokens;
+    boost::split(tokens, lsmiles, boost::is_any_of(" \t"),
+                 boost::token_compress_on);
+    lsmiles = tokens[0];
+    if(tokens.size()>1) name = tokens[1];
+  };
   // strip any leading/trailing whitespace:
   // boost::trim_if(smi,boost::is_any_of(" \t\r\n"));
   RWMol *res=NULL;
   if (params.replacements) {
-    std::string smi = smiles;
+    std::string smi = lsmiles;
     bool loopAgain = true;
     while (loopAgain) {
       loopAgain = false;
@@ -199,7 +207,7 @@ RWMol *SmilesToMol(const std::string &smiles, const SmilesParserParams &params) 
     }
     res = toMol(smi, smiles_parse, smi);
   } else {
-    res = toMol(smiles, smiles_parse, smiles);
+    res = toMol(lsmiles, smiles_parse, lsmiles);
   }
   if ( res && (params.sanitize || params.removeHs)) {
     try {
@@ -218,6 +226,7 @@ RWMol *SmilesToMol(const std::string &smiles, const SmilesParserParams &params) 
     bool cleanIt = true, force = true, flagPossible = true;
     MolOps::assignStereochemistry(*res, cleanIt, force, flagPossible);
   }
+  if(res && name!="") res->setProp(common_properties::_Name,name);
   return res;
 };
 RWMol *SmartsToMol(const std::string &smarts, int debugParse, bool mergeHs,

--- a/Code/GraphMol/SmilesParse/SmilesParse.h
+++ b/Code/GraphMol/SmilesParse/SmilesParse.h
@@ -28,7 +28,7 @@ struct SmilesParserParams {
 		debugParse(0),
 		sanitize(true),
 		replacements(NULL),
-		allowCXSMILES(true),
+		allowCXSMILES(false),
 		parseName(false),
 		removeHs(true)
 	{};

--- a/Code/GraphMol/SmilesParse/SmilesParse.h
+++ b/Code/GraphMol/SmilesParse/SmilesParse.h
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2001-2011 Greg Landrum and Rational Discovery LLC
+//  Copyright (C) 2001-2016 Greg Landrum and Rational Discovery LLC
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -16,6 +16,25 @@
 
 namespace RDKit {
 class RWMol;
+
+struct SmilesParserParams {
+	int debugParse;
+	bool sanitize;
+	std::map<std::string, std::string> *replacements;
+	bool allowCXSMILES;
+	bool parseName;
+	bool removeHs;
+	SmilesParserParams() :
+		debugParse(0),
+		sanitize(true),
+		replacements(NULL),
+		allowCXSMILES(true),
+		parseName(false),
+		removeHs(true)
+	{};
+};
+RWMol *SmilesToMol(const std::string &smi, const SmilesParserParams &params);
+
 
 //! Construct a molecule from a SMILES string
 /*!
@@ -44,9 +63,23 @@ class RWMol;
  \endcode
 
  */
-RWMol *SmilesToMol(const std::string &smi, int debugParse = 0,
-                   bool sanitize = 1,
-                   std::map<std::string, std::string> *replacements = 0);
+inline RWMol *SmilesToMol(const std::string &smi, int debugParse = 0,
+                   bool sanitize = true,
+                   std::map<std::string, std::string> *replacements = 0){
+  SmilesParserParams params;
+  params.debugParse = debugParse;
+  params.replacements = replacements;
+  if(sanitize) {
+    params.sanitize=true;
+    params.removeHs=true;
+  } else {
+    params.sanitize=false;
+    params.removeHs=false;
+  }
+  return SmilesToMol(smi,params);
+};
+
+
 //! Construct a molecule from a SMARTS string
 /*!
  \param sma           the SMARTS to convert

--- a/Code/GraphMol/SmilesParse/SmilesParseOps.cpp
+++ b/Code/GraphMol/SmilesParse/SmilesParseOps.cpp
@@ -216,8 +216,10 @@ void _invChiralRingAtomWithHs(Atom *atom) {
     atom->invertChirality();
   }
 }
+typedef std::pair<size_t, size_t> SIZET_PAIR;
 typedef std::pair<int, int> INT_PAIR;
-bool operator<(const INT_PAIR &p1, const INT_PAIR &p2) {
+template <typename T>
+bool operator<(const std::pair<T,T> &p1, const std::pair<T,T> &p2) {
   return p1.first < p2.first;
 }
 namespace {
@@ -256,11 +258,11 @@ void AdjustAtomChiralityFlags(RWMol *mol) {
             std::ostream_iterator<int>(std::cout," "));
         std::cout << std::endl;
 #endif
-      std::list<INT_PAIR> neighbors;
+      std::list<SIZET_PAIR> neighbors;
       // push this atom onto the list of neighbors (we'll use this
       // to find our place later):
       neighbors.push_back(std::make_pair((*atomIt)->getIdx(), -1));
-      std::list<int> bondOrder;
+      std::list<size_t> bondOrder;
       RWMol::ADJ_ITER nbrIdx, endNbrs;
       boost::tie(nbrIdx, endNbrs) = mol->getAtomNeighbors(*atomIt);
       while (nbrIdx != endNbrs) {
@@ -278,7 +280,7 @@ void AdjustAtomChiralityFlags(RWMol *mol) {
       // find the location of this atom.  it pretty much has to be
       // first in the list, e.g for smiles like [C@](F)(Cl)(Br)I, or
       // second (everything else).
-      std::list<INT_PAIR>::iterator selfPos = neighbors.begin();
+      std::list<SIZET_PAIR>::iterator selfPos = neighbors.begin();
       if (selfPos->first != static_cast<int>((*atomIt)->getIdx())) {
         ++selfPos;
       }
@@ -287,10 +289,10 @@ void AdjustAtomChiralityFlags(RWMol *mol) {
 
       // copy over the bond ids:
       INT_LIST bondOrdering;
-      for (std::list<INT_PAIR>::iterator neighborIt = neighbors.begin();
+      for (std::list<SIZET_PAIR>::iterator neighborIt = neighbors.begin();
            neighborIt != neighbors.end(); ++neighborIt) {
         if (neighborIt != selfPos) {
-          bondOrdering.push_back(neighborIt->second);
+          bondOrdering.push_back(rdcast<int>(neighborIt->second));
         } else {
           // we are not going to add the atom itself, but we will push on
           // ring closure bonds at this point (if required):

--- a/Code/GraphMol/SmilesParse/SmilesParseOps.cpp
+++ b/Code/GraphMol/SmilesParse/SmilesParseOps.cpp
@@ -1,6 +1,5 @@
-// $Id$
 //
-//  Copyright (C) 2001-2010 Greg Landrum and Rational Discovery LLC
+//  Copyright (C) 2001-2016 Greg Landrum and Rational Discovery LLC
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.

--- a/Code/GraphMol/SmilesParse/SmilesParseOps.h
+++ b/Code/GraphMol/SmilesParse/SmilesParseOps.h
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2001-2008 Greg Landrum and Rational Discovery LLC
+//  Copyright (C) 2001-2016 Greg Landrum and Rational Discovery LLC
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -29,6 +29,7 @@ RDKit::Bond::BondType GetUnspecifiedBondType(const RDKit::RWMol *mol,
 void CloseMolRings(RDKit::RWMol *mol, bool toleratePartials);
 void AdjustAtomChiralityFlags(RDKit::RWMol *mol);
 void CleanupAfterParsing(RDKit::RWMol *mol);
+void parseCXNExtensions(RDKit::RWMol &mol, const std::string &extText);
 };
 
 #endif

--- a/Code/GraphMol/SmilesParse/SmilesParseOps.h
+++ b/Code/GraphMol/SmilesParse/SmilesParseOps.h
@@ -29,7 +29,7 @@ RDKit::Bond::BondType GetUnspecifiedBondType(const RDKit::RWMol *mol,
 void CloseMolRings(RDKit::RWMol *mol, bool toleratePartials);
 void AdjustAtomChiralityFlags(RDKit::RWMol *mol);
 void CleanupAfterParsing(RDKit::RWMol *mol);
-void parseCXNExtensions(RDKit::RWMol &mol, const std::string &extText);
+void parseCXExtensions(RDKit::RWMol &mol, const std::string &extText, std::string::const_iterator &pos);
 };
 
 #endif

--- a/Code/GraphMol/SmilesParse/SmilesWrite.cpp
+++ b/Code/GraphMol/SmilesParse/SmilesWrite.cpp
@@ -12,9 +12,12 @@
 #include <RDGeneral/types.h>
 #include <GraphMol/Canon.h>
 #include <GraphMol/new_canon.h>
+#include <RDGeneral/BoostStartInclude.h>
 #include <boost/lexical_cast.hpp>
 #include <boost/foreach.hpp>
 #include <boost/dynamic_bitset.hpp>
+#include <RDGeneral/BoostEndInclude.h>
+
 #include <sstream>
 #include <map>
 #include <list>

--- a/Code/GraphMol/SmilesParse/cxsmiles_test.cpp
+++ b/Code/GraphMol/SmilesParse/cxsmiles_test.cpp
@@ -83,17 +83,20 @@ void testAtomLabels() {
     TEST_ASSERT(!m->getAtomWithIdx(1)->hasProp("_atomLabel"));
     delete m;
   }
-  { // example from the docs:
+  { // attachment points, example from the docs
     std::string smiles = "C[C@H](N*)C(*)=O |$;;;_AP1;;_AP2;$|";
     SmilesParserParams params;
     params.allowCXSMILES = true;
     ROMol *m = SmilesToMol(smiles, params);
     TEST_ASSERT(m);
     TEST_ASSERT(m->getNumAtoms() == 7);
+    TEST_ASSERT(m->getAtomWithIdx(3)->getAtomicNum() == 0);
     TEST_ASSERT(m->getAtomWithIdx(3)->getProp<std::string>("_atomLabel") == "_AP1");
+    TEST_ASSERT(m->getAtomWithIdx(3)->getAtomMapNum() == 1);
+
+    TEST_ASSERT(m->getAtomWithIdx(5)->getAtomicNum() == 0);
     TEST_ASSERT(m->getAtomWithIdx(5)->getProp<std::string>("_atomLabel") == "_AP2");
-    TEST_ASSERT(!m->getAtomWithIdx(1)->hasProp("_atomLabel"));
-    delete m;
+    TEST_ASSERT(m->getAtomWithIdx(5)->getAtomMapNum() == 2);
   }
   { // query properties
     std::string smiles = "**C |$Q_e;QH_p;;$|";
@@ -148,7 +151,7 @@ void testCXSmilesAndName() {
 
 
 void testCoordinateBonds() {
-  BOOST_LOG(rdInfoLog) << "testing coordinate" << std::endl;
+  BOOST_LOG(rdInfoLog) << "testing coordinate bonds" << std::endl;
   {
     std::string smiles = "[Fe]1C=C1 |C:1.0,2.2|";
     SmilesParserParams params;
@@ -188,7 +191,7 @@ void testCoordinateBonds() {
 
 
 void testRadicals() {
-  BOOST_LOG(rdInfoLog) << "testing coordinate" << std::endl;
+  BOOST_LOG(rdInfoLog) << "testing radicals" << std::endl;
   {
     std::string smiles = "[O]C[O] |^1:0,2|";      ;
     SmilesParserParams params;

--- a/Code/GraphMol/SmilesParse/cxsmiles_test.cpp
+++ b/Code/GraphMol/SmilesParse/cxsmiles_test.cpp
@@ -1,0 +1,54 @@
+//
+//  Copyright (C) 2016 Greg Landrum
+//
+//   @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
+//
+#include <string>
+#include <GraphMol/RDKitBase.h>
+#include "SmilesParse.h"
+#include "SmilesWrite.h"
+#include <RDGeneral/RDLog.h>
+using namespace RDKit;
+
+void testBase() {
+  BOOST_LOG(rdInfoLog) << "testing base functionality"
+    << std::endl;
+  { // it works when nothing is provided
+    std::string smiles = "CC";
+    SmilesParserParams params;
+    params.allowCXSMILES = true;
+    ROMol *m = SmilesToMol(smiles, params);
+    TEST_ASSERT(m);
+    TEST_ASSERT(m->getNumAtoms() == 2);
+    delete m;
+  }
+  BOOST_LOG(rdInfoLog) << "done" << std::endl;
+}
+void testCoords2D() {
+  BOOST_LOG(rdInfoLog) << "testing reading 2D coordinates"
+                       << std::endl;
+  {
+    std::string smiles = "CC |(0,.75,;0,-.75,)|";
+    SmilesParserParams params;
+    params.allowCXSMILES = true; 
+    ROMol *m = SmilesToMol(smiles,params);
+    TEST_ASSERT(m);
+    TEST_ASSERT(m->getNumAtoms()==2);
+    TEST_ASSERT(m->getNumConformers()==1);
+
+    delete m;
+  }
+  BOOST_LOG(rdInfoLog) << "done" << std::endl;
+}
+
+int main(int argc, char *argv[]) {
+  (void)argc;
+  (void)argv;
+  RDLog::InitLogs();
+  testBase();
+  testCoords2D();
+}

--- a/Code/GraphMol/SmilesParse/cxsmiles_test.cpp
+++ b/Code/GraphMol/SmilesParse/cxsmiles_test.cpp
@@ -131,6 +131,46 @@ void testCXSmilesAndName() {
 }
 
 
+void testCoordinateBonds() {
+  BOOST_LOG(rdInfoLog) << "testing coordinate" << std::endl;
+  {
+    std::string smiles = "[Fe]1C=C1 |C:1.0,2.2|";
+    SmilesParserParams params;
+    params.allowCXSMILES = true;
+    ROMol *m = SmilesToMol(smiles, params);
+    TEST_ASSERT(m);
+    TEST_ASSERT(m->getNumAtoms() == 3);
+    TEST_ASSERT(m->getBondBetweenAtoms(1,2));
+    TEST_ASSERT(m->getBondBetweenAtoms(1,2)->getBondType() == Bond::DOUBLE);
+    TEST_ASSERT(m->getBondBetweenAtoms(0,1));
+    TEST_ASSERT(m->getBondBetweenAtoms(0, 1)->getBondType()==Bond::DATIVE);
+    TEST_ASSERT(m->getBondBetweenAtoms(0, 1)->getBeginAtomIdx() == 1);
+    TEST_ASSERT(m->getBondBetweenAtoms(0, 2));
+    TEST_ASSERT(m->getBondBetweenAtoms(0, 2)->getBondType() == Bond::DATIVE);
+    TEST_ASSERT(m->getBondBetweenAtoms(0, 2)->getBeginAtomIdx() == 2);
+    delete m;
+  }
+  {
+    std::string smiles = "C1[Fe]C=1 |C:0.0,2.1|";
+    SmilesParserParams params;
+    params.allowCXSMILES = true;
+    ROMol *m = SmilesToMol(smiles, params);
+    TEST_ASSERT(m);
+    TEST_ASSERT(m->getNumAtoms() == 3);
+    TEST_ASSERT(m->getBondBetweenAtoms(0, 2));
+    TEST_ASSERT(m->getBondBetweenAtoms(0, 2)->getBondType() == Bond::DOUBLE);
+    TEST_ASSERT(m->getBondBetweenAtoms(0, 1));
+    TEST_ASSERT(m->getBondBetweenAtoms(0, 1)->getBondType() == Bond::DATIVE);
+    TEST_ASSERT(m->getBondBetweenAtoms(0, 1)->getBeginAtomIdx() == 0);
+    TEST_ASSERT(m->getBondBetweenAtoms(1, 2));
+    TEST_ASSERT(m->getBondBetweenAtoms(1, 2)->getBondType() == Bond::DATIVE);
+    TEST_ASSERT(m->getBondBetweenAtoms(1, 2)->getBeginAtomIdx() == 2);
+    delete m;
+  }
+  BOOST_LOG(rdInfoLog) << "done" << std::endl;
+}
+
+
 int main(int argc, char *argv[]) {
   (void)argc;
   (void)argv;
@@ -139,4 +179,5 @@ int main(int argc, char *argv[]) {
   testCoords2D();
   testAtomLabels();
   testCXSmilesAndName();
+  testCoordinateBonds();
 }

--- a/Code/GraphMol/SmilesParse/cxsmiles_test.cpp
+++ b/Code/GraphMol/SmilesParse/cxsmiles_test.cpp
@@ -78,9 +78,9 @@ void testAtomLabels() {
     ROMol *m = SmilesToMol(smiles, params);
     TEST_ASSERT(m);
     TEST_ASSERT(m->getNumAtoms() == 3);
-    TEST_ASSERT(m->getAtomWithIdx(0)->getProp<std::string>("_atomLabel") == "foo");
-    TEST_ASSERT(m->getAtomWithIdx(2)->getProp<std::string>("_atomLabel") == "bar");
-    TEST_ASSERT(!m->getAtomWithIdx(1)->hasProp("_atomLabel"));
+    TEST_ASSERT(m->getAtomWithIdx(0)->getProp<std::string>(common_properties::atomLabel) == "foo");
+    TEST_ASSERT(m->getAtomWithIdx(2)->getProp<std::string>(common_properties::atomLabel) == "bar");
+    TEST_ASSERT(!m->getAtomWithIdx(1)->hasProp(common_properties::atomLabel));
     delete m;
   }
   { // attachment points, example from the docs
@@ -91,11 +91,11 @@ void testAtomLabels() {
     TEST_ASSERT(m);
     TEST_ASSERT(m->getNumAtoms() == 7);
     TEST_ASSERT(m->getAtomWithIdx(3)->getAtomicNum() == 0);
-    TEST_ASSERT(m->getAtomWithIdx(3)->getProp<std::string>("_atomLabel") == "_AP1");
+    TEST_ASSERT(m->getAtomWithIdx(3)->getProp<std::string>(common_properties::atomLabel) == "_AP1");
     TEST_ASSERT(m->getAtomWithIdx(3)->getAtomMapNum() == 1);
 
     TEST_ASSERT(m->getAtomWithIdx(5)->getAtomicNum() == 0);
-    TEST_ASSERT(m->getAtomWithIdx(5)->getProp<std::string>("_atomLabel") == "_AP2");
+    TEST_ASSERT(m->getAtomWithIdx(5)->getProp<std::string>(common_properties::atomLabel) == "_AP2");
     TEST_ASSERT(m->getAtomWithIdx(5)->getAtomMapNum() == 2);
   }
   { // query properties
@@ -105,9 +105,9 @@ void testAtomLabels() {
     ROMol *m = SmilesToMol(smiles, params);
     TEST_ASSERT(m);
     TEST_ASSERT(m->getNumAtoms() == 3);
-    TEST_ASSERT(m->getAtomWithIdx(0)->getProp<std::string>("_atomLabel") == "Q_e");
-    TEST_ASSERT(m->getAtomWithIdx(1)->getProp<std::string>("_atomLabel") == "QH_p");
-    TEST_ASSERT(!m->getAtomWithIdx(2)->hasProp("_atomLabel"));
+    TEST_ASSERT(m->getAtomWithIdx(0)->getProp<std::string>(common_properties::atomLabel) == "Q_e");
+    TEST_ASSERT(m->getAtomWithIdx(1)->getProp<std::string>(common_properties::atomLabel) == "QH_p");
+    TEST_ASSERT(!m->getAtomWithIdx(2)->hasProp(common_properties::atomLabel));
     TEST_ASSERT(m->getAtomWithIdx(0)->hasQuery());
     TEST_ASSERT(m->getAtomWithIdx(1)->hasQuery());
     TEST_ASSERT(!m->getAtomWithIdx(2)->hasQuery());
@@ -129,7 +129,7 @@ void testCXSmilesAndName() {
     ROMol *m = SmilesToMol(smiles, params);
     TEST_ASSERT(m);
     TEST_ASSERT(m->getNumAtoms() == 3);
-    TEST_ASSERT(m->getAtomWithIdx(0)->getProp<std::string>("_atomLabel") == "foo");
+    TEST_ASSERT(m->getAtomWithIdx(0)->getProp<std::string>(common_properties::atomLabel) == "foo");
     TEST_ASSERT(!m->hasProp("_Name"));
     delete m;
   }
@@ -142,7 +142,7 @@ void testCXSmilesAndName() {
     ROMol *m = SmilesToMol(smiles, params);
     TEST_ASSERT(m);
     TEST_ASSERT(m->getNumAtoms() == 3);
-    TEST_ASSERT(m->getAtomWithIdx(0)->getProp<std::string>("_atomLabel") == "foo");
+    TEST_ASSERT(m->getAtomWithIdx(0)->getProp<std::string>(common_properties::atomLabel) == "foo");
     TEST_ASSERT(m->getProp<std::string>("_Name")=="ourname");
     delete m;
   }

--- a/Code/GraphMol/SmilesParse/cxsmiles_test.cpp
+++ b/Code/GraphMol/SmilesParse/cxsmiles_test.cpp
@@ -15,9 +15,8 @@
 using namespace RDKit;
 
 void testBase() {
-  BOOST_LOG(rdInfoLog) << "testing base functionality"
-    << std::endl;
-  { // it works when nothing is provided
+  BOOST_LOG(rdInfoLog) << "testing base functionality" << std::endl;
+  {  // it works when nothing is provided
     std::string smiles = "CC";
     SmilesParserParams params;
     params.allowCXSMILES = true;
@@ -29,19 +28,18 @@ void testBase() {
   BOOST_LOG(rdInfoLog) << "done" << std::endl;
 }
 void testCoords2D() {
-  BOOST_LOG(rdInfoLog) << "testing reading 2D coordinates"
-                       << std::endl;
+  BOOST_LOG(rdInfoLog) << "testing reading 2D coordinates" << std::endl;
   {
     std::string smiles = "CC |(0,.75,;0,-.75,)|";
     SmilesParserParams params;
     params.allowCXSMILES = true;
-    ROMol *m = SmilesToMol(smiles,params);
+    ROMol *m = SmilesToMol(smiles, params);
     TEST_ASSERT(m);
-    TEST_ASSERT(m->getNumAtoms()==2);
-    TEST_ASSERT(m->getNumConformers()==1);
-    TEST_ASSERT(fabs(m->getConformer().getAtomPos(0).x ) < 1e-4);
+    TEST_ASSERT(m->getNumAtoms() == 2);
+    TEST_ASSERT(m->getNumConformers() == 1);
+    TEST_ASSERT(fabs(m->getConformer().getAtomPos(0).x) < 1e-4);
     TEST_ASSERT(fabs(m->getConformer().getAtomPos(0).y - 0.75) < 1e-4);
-    TEST_ASSERT(fabs(m->getConformer().getAtomPos(0).z ) < 1e-4);
+    TEST_ASSERT(fabs(m->getConformer().getAtomPos(0).z) < 1e-4);
     TEST_ASSERT(fabs(m->getConformer().getAtomPos(1).x) < 1e-4);
     TEST_ASSERT(fabs(m->getConformer().getAtomPos(1).y + 0.75) < 1e-4);
     TEST_ASSERT(fabs(m->getConformer().getAtomPos(1).z) < 1e-4);
@@ -69,8 +67,7 @@ void testCoords2D() {
 }
 
 void testAtomLabels() {
-  BOOST_LOG(rdInfoLog) << "testing reading Atom Labels"
-    << std::endl;
+  BOOST_LOG(rdInfoLog) << "testing reading Atom Labels" << std::endl;
   {
     std::string smiles = "CCC |$foo;;bar$|";
     SmilesParserParams params;
@@ -78,12 +75,14 @@ void testAtomLabels() {
     ROMol *m = SmilesToMol(smiles, params);
     TEST_ASSERT(m);
     TEST_ASSERT(m->getNumAtoms() == 3);
-    TEST_ASSERT(m->getAtomWithIdx(0)->getProp<std::string>(common_properties::atomLabel) == "foo");
-    TEST_ASSERT(m->getAtomWithIdx(2)->getProp<std::string>(common_properties::atomLabel) == "bar");
+    TEST_ASSERT(m->getAtomWithIdx(0)->getProp<std::string>(
+                    common_properties::atomLabel) == "foo");
+    TEST_ASSERT(m->getAtomWithIdx(2)->getProp<std::string>(
+                    common_properties::atomLabel) == "bar");
     TEST_ASSERT(!m->getAtomWithIdx(1)->hasProp(common_properties::atomLabel));
     delete m;
   }
-  { // attachment points, example from the docs
+  {  // attachment points, example from the docs
     std::string smiles = "C[C@H](N*)C(*)=O |$;;;_AP1;;_AP2;$|";
     SmilesParserParams params;
     params.allowCXSMILES = true;
@@ -91,22 +90,26 @@ void testAtomLabels() {
     TEST_ASSERT(m);
     TEST_ASSERT(m->getNumAtoms() == 7);
     TEST_ASSERT(m->getAtomWithIdx(3)->getAtomicNum() == 0);
-    TEST_ASSERT(m->getAtomWithIdx(3)->getProp<std::string>(common_properties::atomLabel) == "_AP1");
+    TEST_ASSERT(m->getAtomWithIdx(3)->getProp<std::string>(
+                    common_properties::atomLabel) == "_AP1");
     TEST_ASSERT(m->getAtomWithIdx(3)->getAtomMapNum() == 1);
 
     TEST_ASSERT(m->getAtomWithIdx(5)->getAtomicNum() == 0);
-    TEST_ASSERT(m->getAtomWithIdx(5)->getProp<std::string>(common_properties::atomLabel) == "_AP2");
+    TEST_ASSERT(m->getAtomWithIdx(5)->getProp<std::string>(
+                    common_properties::atomLabel) == "_AP2");
     TEST_ASSERT(m->getAtomWithIdx(5)->getAtomMapNum() == 2);
   }
-  { // query properties
+  {  // query properties
     std::string smiles = "**C |$Q_e;QH_p;;$|";
     SmilesParserParams params;
     params.allowCXSMILES = true;
     ROMol *m = SmilesToMol(smiles, params);
     TEST_ASSERT(m);
     TEST_ASSERT(m->getNumAtoms() == 3);
-    TEST_ASSERT(m->getAtomWithIdx(0)->getProp<std::string>(common_properties::atomLabel) == "Q_e");
-    TEST_ASSERT(m->getAtomWithIdx(1)->getProp<std::string>(common_properties::atomLabel) == "QH_p");
+    TEST_ASSERT(m->getAtomWithIdx(0)->getProp<std::string>(
+                    common_properties::atomLabel) == "Q_e");
+    TEST_ASSERT(m->getAtomWithIdx(1)->getProp<std::string>(
+                    common_properties::atomLabel) == "QH_p");
     TEST_ASSERT(!m->getAtomWithIdx(2)->hasProp(common_properties::atomLabel));
     TEST_ASSERT(m->getAtomWithIdx(0)->hasQuery());
     TEST_ASSERT(m->getAtomWithIdx(1)->hasQuery());
@@ -114,34 +117,57 @@ void testAtomLabels() {
 
     delete m;
   }
-  { // query properties2
+  {  // query properties2
     std::string smiles = "** |$;AH_p;$|";
     SmilesParserParams params;
     params.allowCXSMILES = true;
     ROMol *m = SmilesToMol(smiles, params);
     TEST_ASSERT(m);
     TEST_ASSERT(m->getNumAtoms() == 2);
-    TEST_ASSERT(m->getAtomWithIdx(1)->getProp<std::string>(common_properties::atomLabel) == "AH_p");
+    TEST_ASSERT(m->getAtomWithIdx(1)->getProp<std::string>(
+                    common_properties::atomLabel) == "AH_p");
     TEST_ASSERT(!m->getAtomWithIdx(0)->hasProp(common_properties::atomLabel));
     TEST_ASSERT(m->getAtomWithIdx(0)->hasQuery());
-    TEST_ASSERT(m->getAtomWithIdx(0)->getQuery()->getDescription() == "AtomAtomicNum");
+    TEST_ASSERT(m->getAtomWithIdx(0)->getQuery()->getDescription() ==
+                "AtomAtomicNum");
     TEST_ASSERT(m->getAtomWithIdx(1)->hasQuery());
-    TEST_ASSERT(m->getAtomWithIdx(1)->getQuery()->getDescription() == "AtomNull");
+    TEST_ASSERT(m->getAtomWithIdx(1)->getQuery()->getDescription() ==
+                "AtomNull");
 
     delete m;
   }
 
-  { // query properties3
+  {  // query properties3
     std::string smiles = "** |$;XH_p;$|";
     SmilesParserParams params;
     params.allowCXSMILES = true;
     ROMol *m = SmilesToMol(smiles, params);
     TEST_ASSERT(m);
     TEST_ASSERT(m->getNumAtoms() == 2);
-    TEST_ASSERT(m->getAtomWithIdx(1)->getProp<std::string>(common_properties::atomLabel) == "XH_p");
+    TEST_ASSERT(m->getAtomWithIdx(1)->getProp<std::string>(
+                    common_properties::atomLabel) == "XH_p");
     TEST_ASSERT(!m->getAtomWithIdx(0)->hasProp(common_properties::atomLabel));
     TEST_ASSERT(m->getAtomWithIdx(0)->hasQuery());
-    TEST_ASSERT(m->getAtomWithIdx(0)->getQuery()->getDescription()=="AtomAtomicNum");
+    TEST_ASSERT(m->getAtomWithIdx(0)->getQuery()->getDescription() ==
+                "AtomAtomicNum");
+    TEST_ASSERT(m->getAtomWithIdx(1)->hasQuery());
+    TEST_ASSERT(m->getAtomWithIdx(1)->getQuery()->getDescription() == "AtomOr");
+
+    delete m;
+  }
+  {  // query properties3
+    std::string smiles = "** |$MH_p;M_p;$|";
+    SmilesParserParams params;
+    params.allowCXSMILES = true;
+    ROMol *m = SmilesToMol(smiles, params);
+    TEST_ASSERT(m);
+    TEST_ASSERT(m->getNumAtoms() == 2);
+    TEST_ASSERT(m->getAtomWithIdx(0)->getProp<std::string>(
+                    common_properties::atomLabel) == "MH_p");
+    TEST_ASSERT(m->getAtomWithIdx(1)->getProp<std::string>(
+                    common_properties::atomLabel) == "M_p");
+    TEST_ASSERT(m->getAtomWithIdx(0)->hasQuery());
+    TEST_ASSERT(m->getAtomWithIdx(0)->getQuery()->getDescription() == "AtomOr");
     TEST_ASSERT(m->getAtomWithIdx(1)->hasQuery());
     TEST_ASSERT(m->getAtomWithIdx(1)->getQuery()->getDescription() == "AtomOr");
 
@@ -151,8 +177,7 @@ void testAtomLabels() {
 }
 
 void testCXSmilesAndName() {
-  BOOST_LOG(rdInfoLog) << "testing CSXMILES and mol name"
-    << std::endl;
+  BOOST_LOG(rdInfoLog) << "testing CSXMILES and mol name" << std::endl;
   {
     std::string smiles = "CCC |$foo;;bar$|";
     SmilesParserParams params;
@@ -161,7 +186,8 @@ void testCXSmilesAndName() {
     ROMol *m = SmilesToMol(smiles, params);
     TEST_ASSERT(m);
     TEST_ASSERT(m->getNumAtoms() == 3);
-    TEST_ASSERT(m->getAtomWithIdx(0)->getProp<std::string>(common_properties::atomLabel) == "foo");
+    TEST_ASSERT(m->getAtomWithIdx(0)->getProp<std::string>(
+                    common_properties::atomLabel) == "foo");
     TEST_ASSERT(!m->hasProp("_Name"));
     delete m;
   }
@@ -174,13 +200,13 @@ void testCXSmilesAndName() {
     ROMol *m = SmilesToMol(smiles, params);
     TEST_ASSERT(m);
     TEST_ASSERT(m->getNumAtoms() == 3);
-    TEST_ASSERT(m->getAtomWithIdx(0)->getProp<std::string>(common_properties::atomLabel) == "foo");
-    TEST_ASSERT(m->getProp<std::string>(common_properties::_Name)=="ourname");
+    TEST_ASSERT(m->getAtomWithIdx(0)->getProp<std::string>(
+                    common_properties::atomLabel) == "foo");
+    TEST_ASSERT(m->getProp<std::string>(common_properties::_Name) == "ourname");
     delete m;
   }
   BOOST_LOG(rdInfoLog) << "done" << std::endl;
 }
-
 
 void testCoordinateBonds() {
   BOOST_LOG(rdInfoLog) << "testing coordinate bonds" << std::endl;
@@ -191,10 +217,10 @@ void testCoordinateBonds() {
     ROMol *m = SmilesToMol(smiles, params);
     TEST_ASSERT(m);
     TEST_ASSERT(m->getNumAtoms() == 3);
-    TEST_ASSERT(m->getBondBetweenAtoms(1,2));
-    TEST_ASSERT(m->getBondBetweenAtoms(1,2)->getBondType() == Bond::DOUBLE);
-    TEST_ASSERT(m->getBondBetweenAtoms(0,1));
-    TEST_ASSERT(m->getBondBetweenAtoms(0, 1)->getBondType()==Bond::DATIVE);
+    TEST_ASSERT(m->getBondBetweenAtoms(1, 2));
+    TEST_ASSERT(m->getBondBetweenAtoms(1, 2)->getBondType() == Bond::DOUBLE);
+    TEST_ASSERT(m->getBondBetweenAtoms(0, 1));
+    TEST_ASSERT(m->getBondBetweenAtoms(0, 1)->getBondType() == Bond::DATIVE);
     TEST_ASSERT(m->getBondBetweenAtoms(0, 1)->getBeginAtomIdx() == 1);
     TEST_ASSERT(m->getBondBetweenAtoms(0, 2));
     TEST_ASSERT(m->getBondBetweenAtoms(0, 2)->getBondType() == Bond::DATIVE);
@@ -221,11 +247,11 @@ void testCoordinateBonds() {
   BOOST_LOG(rdInfoLog) << "done" << std::endl;
 }
 
-
 void testRadicals() {
   BOOST_LOG(rdInfoLog) << "testing radicals" << std::endl;
   {
-    std::string smiles = "[O]C[O] |^1:0,2|";      ;
+    std::string smiles = "[O]C[O] |^1:0,2|";
+    ;
     SmilesParserParams params;
     params.allowCXSMILES = true;
     ROMol *m = SmilesToMol(smiles, params);
@@ -250,7 +276,7 @@ void testRadicals() {
 
     delete m;
   }
-  { // radicals and coordinate bonds
+  {  // radicals and coordinate bonds
     std::string smiles = "[Fe]N([O])[O] |^1:2,3,C:1.0|";
     SmilesParserParams params;
     params.allowCXSMILES = true;
@@ -267,8 +293,7 @@ void testRadicals() {
     delete m;
   }
 
-
-    BOOST_LOG(rdInfoLog) << "done" << std::endl;
+  BOOST_LOG(rdInfoLog) << "done" << std::endl;
 }
 
 int main(int argc, char *argv[]) {
@@ -281,5 +306,4 @@ int main(int argc, char *argv[]) {
   testCXSmilesAndName();
   testCoordinateBonds();
   testRadicals();
-
 }

--- a/Code/GraphMol/SmilesParse/cxsmiles_test.cpp
+++ b/Code/GraphMol/SmilesParse/cxsmiles_test.cpp
@@ -124,11 +124,29 @@ void testAtomLabels() {
     TEST_ASSERT(m->getAtomWithIdx(1)->getProp<std::string>(common_properties::atomLabel) == "AH_p");
     TEST_ASSERT(!m->getAtomWithIdx(0)->hasProp(common_properties::atomLabel));
     TEST_ASSERT(m->getAtomWithIdx(0)->hasQuery());
+    TEST_ASSERT(m->getAtomWithIdx(0)->getQuery()->getDescription() == "AtomAtomicNum");
     TEST_ASSERT(m->getAtomWithIdx(1)->hasQuery());
+    TEST_ASSERT(m->getAtomWithIdx(1)->getQuery()->getDescription() == "AtomNull");
 
     delete m;
   }
 
+  { // query properties3
+    std::string smiles = "** |$;XH_p;$|";
+    SmilesParserParams params;
+    params.allowCXSMILES = true;
+    ROMol *m = SmilesToMol(smiles, params);
+    TEST_ASSERT(m);
+    TEST_ASSERT(m->getNumAtoms() == 2);
+    TEST_ASSERT(m->getAtomWithIdx(1)->getProp<std::string>(common_properties::atomLabel) == "XH_p");
+    TEST_ASSERT(!m->getAtomWithIdx(0)->hasProp(common_properties::atomLabel));
+    TEST_ASSERT(m->getAtomWithIdx(0)->hasQuery());
+    TEST_ASSERT(m->getAtomWithIdx(0)->getQuery()->getDescription()=="AtomAtomicNum");
+    TEST_ASSERT(m->getAtomWithIdx(1)->hasQuery());
+    TEST_ASSERT(m->getAtomWithIdx(1)->getQuery()->getDescription() == "AtomOr");
+
+    delete m;
+  }
   BOOST_LOG(rdInfoLog) << "done" << std::endl;
 }
 

--- a/Code/GraphMol/SmilesParse/cxsmiles_test.cpp
+++ b/Code/GraphMol/SmilesParse/cxsmiles_test.cpp
@@ -34,7 +34,7 @@ void testCoords2D() {
   {
     std::string smiles = "CC |(0,.75,;0,-.75,)|";
     SmilesParserParams params;
-    params.allowCXSMILES = true; 
+    params.allowCXSMILES = true;
     ROMol *m = SmilesToMol(smiles,params);
     TEST_ASSERT(m);
     TEST_ASSERT(m->getNumAtoms()==2);
@@ -175,7 +175,7 @@ void testCXSmilesAndName() {
     TEST_ASSERT(m);
     TEST_ASSERT(m->getNumAtoms() == 3);
     TEST_ASSERT(m->getAtomWithIdx(0)->getProp<std::string>(common_properties::atomLabel) == "foo");
-    TEST_ASSERT(m->getProp<std::string>("_Name")=="ourname");
+    TEST_ASSERT(m->getProp<std::string>(common_properties::_Name)=="ourname");
     delete m;
   }
   BOOST_LOG(rdInfoLog) << "done" << std::endl;
@@ -267,7 +267,7 @@ void testRadicals() {
     delete m;
   }
 
-  
+
     BOOST_LOG(rdInfoLog) << "done" << std::endl;
 }
 

--- a/Code/GraphMol/SmilesParse/cxsmiles_test.cpp
+++ b/Code/GraphMol/SmilesParse/cxsmiles_test.cpp
@@ -38,7 +38,27 @@ void testCoords2D() {
     ROMol *m = SmilesToMol(smiles,params);
     TEST_ASSERT(m);
     TEST_ASSERT(m->getNumAtoms()==2);
-    TEST_ASSERT(m->getNumConformers()==1);
+    //TEST_ASSERT(m->getNumConformers()==1);
+
+    delete m;
+  }
+  BOOST_LOG(rdInfoLog) << "done" << std::endl;
+}
+
+void testAtomLabels() {
+  BOOST_LOG(rdInfoLog) << "testing reading Atom Labels"
+    << std::endl;
+  {
+    std::string smiles = "CCC |$foo;;bar$|";
+    SmilesParserParams params;
+    params.allowCXSMILES = true;
+    ROMol *m = SmilesToMol(smiles, params);
+    TEST_ASSERT(m);
+    TEST_ASSERT(m->getNumAtoms() == 3);
+    TEST_ASSERT(m->getAtomWithIdx(0)->getProp<std::string>("_atomLabel") == "foo");
+    TEST_ASSERT(m->getAtomWithIdx(2)->getProp<std::string>("_atomLabel") == "bar");
+    TEST_ASSERT(!m->getAtomWithIdx(1)->hasProp("_atomLabel"));
+
 
     delete m;
   }
@@ -51,4 +71,5 @@ int main(int argc, char *argv[]) {
   RDLog::InitLogs();
   testBase();
   testCoords2D();
+  testAtomLabels();
 }

--- a/Code/GraphMol/SmilesParse/cxsmiles_test.cpp
+++ b/Code/GraphMol/SmilesParse/cxsmiles_test.cpp
@@ -38,7 +38,30 @@ void testCoords2D() {
     ROMol *m = SmilesToMol(smiles,params);
     TEST_ASSERT(m);
     TEST_ASSERT(m->getNumAtoms()==2);
-    //TEST_ASSERT(m->getNumConformers()==1);
+    TEST_ASSERT(m->getNumConformers()==1);
+    TEST_ASSERT(fabs(m->getConformer().getAtomPos(0).x ) < 1e-4);
+    TEST_ASSERT(fabs(m->getConformer().getAtomPos(0).y - 0.75) < 1e-4);
+    TEST_ASSERT(fabs(m->getConformer().getAtomPos(0).z ) < 1e-4);
+    TEST_ASSERT(fabs(m->getConformer().getAtomPos(1).x) < 1e-4);
+    TEST_ASSERT(fabs(m->getConformer().getAtomPos(1).y + 0.75) < 1e-4);
+    TEST_ASSERT(fabs(m->getConformer().getAtomPos(1).z) < 1e-4);
+
+    delete m;
+  }
+  {
+    std::string smiles = "CC |(,,;,,-.75)|";
+    SmilesParserParams params;
+    params.allowCXSMILES = true;
+    ROMol *m = SmilesToMol(smiles, params);
+    TEST_ASSERT(m);
+    TEST_ASSERT(m->getNumAtoms() == 2);
+    TEST_ASSERT(m->getNumConformers() == 1);
+    TEST_ASSERT(fabs(m->getConformer().getAtomPos(0).x) < 1e-4);
+    TEST_ASSERT(fabs(m->getConformer().getAtomPos(0).y) < 1e-4);
+    TEST_ASSERT(fabs(m->getConformer().getAtomPos(0).z) < 1e-4);
+    TEST_ASSERT(fabs(m->getConformer().getAtomPos(1).x) < 1e-4);
+    TEST_ASSERT(fabs(m->getConformer().getAtomPos(1).y) < 1e-4);
+    TEST_ASSERT(fabs(m->getConformer().getAtomPos(1).z + 0.75) < 1e-4);
 
     delete m;
   }
@@ -58,12 +81,55 @@ void testAtomLabels() {
     TEST_ASSERT(m->getAtomWithIdx(0)->getProp<std::string>("_atomLabel") == "foo");
     TEST_ASSERT(m->getAtomWithIdx(2)->getProp<std::string>("_atomLabel") == "bar");
     TEST_ASSERT(!m->getAtomWithIdx(1)->hasProp("_atomLabel"));
+    delete m;
+  }
+  { // example from the docs:
+    std::string smiles = "C[C@H](N*)C(*)=O |$;;;_AP1;;_AP2;$|";
+    SmilesParserParams params;
+    params.allowCXSMILES = true;
+    ROMol *m = SmilesToMol(smiles, params);
+    TEST_ASSERT(m);
+    TEST_ASSERT(m->getNumAtoms() == 7);
+    TEST_ASSERT(m->getAtomWithIdx(3)->getProp<std::string>("_atomLabel") == "_AP1");
+    TEST_ASSERT(m->getAtomWithIdx(5)->getProp<std::string>("_atomLabel") == "_AP2");
+    TEST_ASSERT(!m->getAtomWithIdx(1)->hasProp("_atomLabel"));
+    delete m;
+  }
 
+  BOOST_LOG(rdInfoLog) << "done" << std::endl;
+}
 
+void testCXSmilesAndName() {
+  BOOST_LOG(rdInfoLog) << "testing CSXMILES and mol name"
+    << std::endl;
+  {
+    std::string smiles = "CCC |$foo;;bar$|";
+    SmilesParserParams params;
+    params.allowCXSMILES = true;
+    params.parseName = true;
+    ROMol *m = SmilesToMol(smiles, params);
+    TEST_ASSERT(m);
+    TEST_ASSERT(m->getNumAtoms() == 3);
+    TEST_ASSERT(m->getAtomWithIdx(0)->getProp<std::string>("_atomLabel") == "foo");
+    TEST_ASSERT(!m->hasProp("_Name"));
+    delete m;
+  }
+  {
+    std::string smiles = "CCC |$foo;;bar$| ourname";
+    SmilesParserParams params;
+    params.allowCXSMILES = true;
+    params.parseName = true;
+
+    ROMol *m = SmilesToMol(smiles, params);
+    TEST_ASSERT(m);
+    TEST_ASSERT(m->getNumAtoms() == 3);
+    TEST_ASSERT(m->getAtomWithIdx(0)->getProp<std::string>("_atomLabel") == "foo");
+    TEST_ASSERT(m->getProp<std::string>("_Name")=="ourname");
     delete m;
   }
   BOOST_LOG(rdInfoLog) << "done" << std::endl;
 }
+
 
 int main(int argc, char *argv[]) {
   (void)argc;
@@ -72,4 +138,5 @@ int main(int argc, char *argv[]) {
   testBase();
   testCoords2D();
   testAtomLabels();
+  testCXSmilesAndName();
 }

--- a/Code/GraphMol/SmilesParse/cxsmiles_test.cpp
+++ b/Code/GraphMol/SmilesParse/cxsmiles_test.cpp
@@ -114,6 +114,20 @@ void testAtomLabels() {
 
     delete m;
   }
+  { // query properties2
+    std::string smiles = "** |$;AH_p;$|";
+    SmilesParserParams params;
+    params.allowCXSMILES = true;
+    ROMol *m = SmilesToMol(smiles, params);
+    TEST_ASSERT(m);
+    TEST_ASSERT(m->getNumAtoms() == 2);
+    TEST_ASSERT(m->getAtomWithIdx(1)->getProp<std::string>(common_properties::atomLabel) == "AH_p");
+    TEST_ASSERT(!m->getAtomWithIdx(0)->hasProp(common_properties::atomLabel));
+    TEST_ASSERT(m->getAtomWithIdx(0)->hasQuery());
+    TEST_ASSERT(m->getAtomWithIdx(1)->hasQuery());
+
+    delete m;
+  }
 
   BOOST_LOG(rdInfoLog) << "done" << std::endl;
 }

--- a/Code/GraphMol/SmilesParse/cxsmiles_test.cpp
+++ b/Code/GraphMol/SmilesParse/cxsmiles_test.cpp
@@ -95,6 +95,17 @@ void testAtomLabels() {
     TEST_ASSERT(!m->getAtomWithIdx(1)->hasProp("_atomLabel"));
     delete m;
   }
+  { // query properties
+    std::string smiles = "** |$Q_e;QH_p;$|";
+    SmilesParserParams params;
+    params.allowCXSMILES = true;
+    ROMol *m = SmilesToMol(smiles, params);
+    TEST_ASSERT(m);
+    TEST_ASSERT(m->getNumAtoms() == 2);
+    TEST_ASSERT(m->getAtomWithIdx(0)->getProp<std::string>("_atomLabel") == "Q_e");
+    TEST_ASSERT(m->getAtomWithIdx(1)->getProp<std::string>("_atomLabel") == "QH_p");
+    delete m;
+  }
 
   BOOST_LOG(rdInfoLog) << "done" << std::endl;
 }

--- a/Code/GraphMol/SmilesParse/test.cpp
+++ b/Code/GraphMol/SmilesParse/test.cpp
@@ -3893,7 +3893,54 @@ void testSmilesParseParams() {
       delete m;
     }
   }
-	BOOST_LOG(rdInfoLog) << "done" << std::endl;
+
+  { // basic name parsing
+    std::string smiles = "CCCC the_name";
+    ROMol *m = SmilesToMol(smiles);
+    TEST_ASSERT(!m);
+    { // no removeHs, no sanitization
+      SmilesParserParams params;
+      m = SmilesToMol(smiles, params);
+      TEST_ASSERT(!m);
+    }
+    { // no removeHs, no sanitization
+       SmilesParserParams params;
+       params.parseName = true;
+       m = SmilesToMol(smiles, params);
+       TEST_ASSERT(m);
+       TEST_ASSERT(m->getNumAtoms() == 4);
+       TEST_ASSERT(m->hasProp(common_properties::_Name));
+       TEST_ASSERT(m->getProp<std::string>(common_properties::_Name)=="the_name");
+       delete m;
+    }
+  }
+  { // name parsing2
+    std::string smiles = "CCCC\tthe_name";
+    { // no removeHs, no sanitization
+      SmilesParserParams params;
+      params.parseName = true;
+      RWMol *m = SmilesToMol(smiles, params);
+      TEST_ASSERT(m);
+      TEST_ASSERT(m->getNumAtoms() == 4);
+      TEST_ASSERT(m->hasProp(common_properties::_Name));
+      TEST_ASSERT(m->getProp<std::string>(common_properties::_Name) == "the_name");
+      delete m;
+    }
+  }
+  { // name parsing3
+    std::string smiles = "CCCC\t  the_name  ";
+    { // no removeHs, no sanitization
+      SmilesParserParams params;
+      params.parseName = true;
+      RWMol *m = SmilesToMol(smiles, params);
+      TEST_ASSERT(m);
+      TEST_ASSERT(m->getNumAtoms() == 4);
+      TEST_ASSERT(m->hasProp(common_properties::_Name));
+      TEST_ASSERT(m->getProp<std::string>(common_properties::_Name) == "the_name");
+      delete m;
+    }
+  }
+  BOOST_LOG(rdInfoLog) << "done" << std::endl;
 }
 
 int main(int argc, char *argv[]) {

--- a/Code/GraphMol/SmilesParse/test.cpp
+++ b/Code/GraphMol/SmilesParse/test.cpp
@@ -3844,6 +3844,58 @@ void testGithub1219() {
   BOOST_LOG(rdInfoLog) << "done" << std::endl;
 }
 
+void testSmilesParseParams() {
+	BOOST_LOG(rdInfoLog)
+		<< "Testing the SmilesParseParams class"
+		<< std::endl;
+	{
+		std::string smiles = "C1=CC=CC=C1[H]";
+		ROMol *m = SmilesToMol(smiles);
+		TEST_ASSERT(m);
+		TEST_ASSERT(m->getNumAtoms() == 6);
+		TEST_ASSERT(m->getBondWithIdx(0)->getIsAromatic());
+		delete m;
+
+		{
+			SmilesParserParams params;
+			m = SmilesToMol(smiles,params);
+			TEST_ASSERT(m);
+			TEST_ASSERT(m->getNumAtoms() == 6);
+			TEST_ASSERT(m->getBondWithIdx(0)->getIsAromatic());
+			delete m;
+		}
+		{ // no removeHs, with sanitization
+			SmilesParserParams params;
+      params.removeHs = false;
+			m = SmilesToMol(smiles,params);
+			TEST_ASSERT(m);
+			TEST_ASSERT(m->getNumAtoms() == 7);
+			TEST_ASSERT(m->getBondWithIdx(0)->getIsAromatic());
+			delete m;
+		}
+    { // removeHs, no sanitization
+      SmilesParserParams params;
+      params.sanitize = false;
+      m = SmilesToMol(smiles, params);
+      TEST_ASSERT(m);
+      TEST_ASSERT(m->getNumAtoms() == 6);
+      TEST_ASSERT(!m->getBondWithIdx(0)->getIsAromatic());
+      delete m;
+    }
+    { // no removeHs, no sanitization
+      SmilesParserParams params;
+      params.removeHs = false;
+      params.sanitize = false;
+      m = SmilesToMol(smiles, params);
+      TEST_ASSERT(m);
+      TEST_ASSERT(m->getNumAtoms() == 7);
+      TEST_ASSERT(!m->getBondWithIdx(0)->getIsAromatic());
+      delete m;
+    }
+  }
+	BOOST_LOG(rdInfoLog) << "done" << std::endl;
+}
+
 int main(int argc, char *argv[]) {
   (void)argc;
   (void)argv;
@@ -3911,4 +3963,5 @@ int main(int argc, char *argv[]) {
   testGithub760();
   testDativeBonds();
   testGithub1219();
+  testSmilesParseParams();
 }

--- a/Code/GraphMol/Wrap/rdmolfiles.cpp
+++ b/Code/GraphMol/Wrap/rdmolfiles.cpp
@@ -322,6 +322,13 @@ std::vector<int> CanonicalRankAtomsInFragment(const ROMol &mol,
 
   return resRanks;
 }
+
+ROMol *MolFromSmilesHelper(python::object ismiles,
+                           const SmilesParserParams &params) {
+  std::string smiles = pyObjectToString(ismiles);
+
+  return SmilesToMol(smiles,params);
+}
 }
 
 // MolSupplier stuff
@@ -640,7 +647,8 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
    \n\
        a Mol object, None on failure.\n\
    \n";
-   python::def("MolFromSmiles", RDKit::MolFromSmiles,
+   python::def("MolFromSmiles",
+               MolFromSmilesHelper,
                (python::arg("SMILES"), python::arg("params")),
                docString.c_str(),
                python::return_value_policy<python::manage_new_object>());

--- a/Code/GraphMol/Wrap/rdmolfiles.cpp
+++ b/Code/GraphMol/Wrap/rdmolfiles.cpp
@@ -1,6 +1,5 @@
-// $Id$
 //
-//  Copyright (C) 2003-2010 Greg Landrum and Rational Discovery LLC
+//  Copyright (C) 2003-2016 Greg Landrum and Rational Discovery LLC
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -611,6 +610,42 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
        python::arg("includeStereo") = false, python::arg("confId") = -1,
        python::arg("kekulize") = true, python::arg("forceV3000") = false),
       docString.c_str());
+
+  python::class_<RDKit::SmilesParserParams, boost::noncopyable>(
+      "SmilesParserParams", "Parameters controlling SMILES Parsing")
+      .def_readwrite("maxIterations",
+                     &RDKit::SmilesParserParams::debugParse,
+                     "controls the amount of debugging information produced")
+     .def_readwrite("parseName",
+                    &RDKit::SmilesParserParams::parseName,
+                    "controls whether or not the molecule name is also parsed")
+      .def_readwrite("allowCXSMILES",
+                     &RDKit::SmilesParserParams::allowCXSMILES,
+                     "controls whether or not the CXSMILES extensions are parsed")
+       .def_readwrite("sanitize",
+                      &RDKit::SmilesParserParams::sanitize,
+                      "controls whether or not the molecule is sanitized before being returned")
+      .def_readwrite("removeHs",
+                     &RDKit::SmilesParserParams::removeHs,
+                     "controls whether or not Hs are removed before the molecule is returned");
+     docString =
+         "Construct a molecule from a SMILES string.\n\n\
+     ARGUMENTS:\n\
+   \n\
+       - SMILES: the smiles string\n\
+   \n\
+       - params: used to provide optional parameters for the SMILES parsing\n\
+   \n\
+     RETURNS:\n\
+   \n\
+       a Mol object, None on failure.\n\
+   \n";
+   python::def("MolFromSmiles", RDKit::MolFromSmiles,
+               (python::arg("SMILES"), python::arg("params")),
+               docString.c_str(),
+               python::return_value_policy<python::manage_new_object>());
+
+
 
   docString =
       "Construct a molecule from a SMILES string.\n\n\

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2003-2013  Greg Landrum and Rational Discovery LLC
+#  Copyright (C) 2003-2017  Greg Landrum and Rational Discovery LLC
 #         All Rights Reserved
 #
 """ This is a rough coverage test of the python wrapper
@@ -3888,6 +3888,19 @@ CAS<~>
     self.assertRaises(RuntimeError, lambda: a.IsInRing())
     self.assertRaises(RuntimeError, lambda: a.IsInRingSize(4))
 
+  def testSmilesParseParams(self):
+    smi = "CCC |$foo;;bar$| ourname"
+    m = Chem.MolFromSmiles(smi)
+    self.assertTrue(m is None)
+    ps = Chem.SmilesParserParams()
+    ps.allowCXSMILES = True
+    ps.parseName = True
+    m = Chem.MolFromSmiles(smi,ps)
+    self.assertTrue(m is not None)
+    self.assertTrue(m.GetAtomWithIdx(0).HasProp('atomLabel'))
+    self.assertEquals(m.GetAtomWithIdx(0).GetProp('atomLabel'),"foo")
+    self.assertTrue(m.HasProp('_Name'))
+    self.assertEquals(m.GetProp('_Name'),"ourname")
 
 if __name__ == '__main__':
   if "RDTESTCASE" in os.environ:

--- a/Code/GraphMol/new_canon.h
+++ b/Code/GraphMol/new_canon.h
@@ -12,9 +12,11 @@
 #include <RDGeneral/hanoiSort.h>
 #include <GraphMol/ROMol.h>
 #include <GraphMol/RingInfo.h>
+#include <RDGeneral/BoostStartInclude.h>
 #include <boost/cstdint.hpp>
 #include <boost/foreach.hpp>
 #include <boost/dynamic_bitset.hpp>
+#include <RDGeneral/BoostEndInclude.h>
 #include <cstring>
 #include <iostream>
 #include <cassert>

--- a/Code/RDGeneral/BoostStartInclude.h
+++ b/Code/RDGeneral/BoostStartInclude.h
@@ -69,7 +69,9 @@
 
 #elif defined(_MSC_VER)
 /* Microsoft Visual Studio. --------------------------------- */
-#pragma warning(push, 0)
+#pragma warning(push)
+#pragma warning(disable:4996 4267)
+
 #elif defined(__PGI)
 /* Portland Group PGCC/PGCPP. ------------------------------- */
 

--- a/Code/RDGeneral/Dict.h
+++ b/Code/RDGeneral/Dict.h
@@ -20,7 +20,9 @@
 #include <vector>
 #include "RDValue.h"
 #include "Exceptions.h"
+#include <RDGeneral/BoostStartInclude.h>
 #include <boost/lexical_cast.hpp>
+#include <RDGeneral/BoostEndInclude.h>
 
 namespace RDKit {
 typedef std::vector<std::string> STR_VECT;
@@ -39,7 +41,7 @@ class Dict {
    Pair(const std::string &s, const RDValue &v) : key(s), val(v) {
    }
   };
-  
+
   typedef std::vector<Pair> DataType;
 public:
   Dict() : _data(), _hasNonPodData(false) {  };
@@ -53,13 +55,13 @@ public:
         _data[i].key = other._data[i].key;
         copy_rdvalue(_data[i].val, other._data[i].val);
       }
-    }   
+    }
   }
-  
+
   ~Dict() {
     reset(); // to clear pointers if necessary
   }
-  
+
   Dict &operator=(const Dict &other) {
     _hasNonPodData = other._hasNonPodData;
     if (_hasNonPodData) {
@@ -70,8 +72,8 @@ public:
         copy_rdvalue(_data[i].val, other._data[i].val);
       }
     } else {
-      _data = other._data;      
-    }    
+      _data = other._data;
+    }
     return *this;
   };
 
@@ -198,7 +200,7 @@ public:
     }
     _data.push_back(Pair(what, val));
   };
-  
+
   void setVal(const std::string &what, bool val) {
     setPODVal(what, val);
   }
@@ -206,19 +208,19 @@ public:
   void setVal(const std::string &what, double val) {
     setPODVal(what, val);
   }
-  
+
   void setVal(const std::string &what, float val) {
     setPODVal(what, val);
   }
-  
+
   void setVal(const std::string &what, int val) {
     setPODVal(what, val);
   }
-  
+
   void setVal(const std::string &what, unsigned int val) {
     setPODVal(what, val);
   }
-  
+
   //! \overload
   void setVal(const std::string &what, const char *val) {
     std::string h(val);

--- a/Code/RDGeneral/RDAny.h
+++ b/Code/RDGeneral/RDAny.h
@@ -30,9 +30,12 @@
 //
 #ifndef RDKIT_RDANY_H
 #define RDKIT_RDANY_H
+#include <RDGeneral/BoostStartInclude.h>
 #include <boost/any.hpp>
 #include <boost/utility.hpp>
 #include <boost/lexical_cast.hpp>
+#include <RDGeneral/BoostEndInclude.h>
+
 #include "LocaleSwitcher.h"
 #include "RDValue.h"
 #include <string>
@@ -165,7 +168,7 @@ struct RDAny {
     m_value = RDValue(v);
     return *this;
   }
-    
+
 };
 
 ////////////////////////////////////////////////////////////////

--- a/Code/RDGeneral/RDValue-doublemagic.h
+++ b/Code/RDGeneral/RDValue-doublemagic.h
@@ -40,11 +40,13 @@
 #include <sstream>
 #include <vector>
 #include <string>
+#include <RDGeneral/BoostStartInclude.h>
 #include <boost/utility.hpp>
 #include <boost/lexical_cast.hpp>
-#include <cmath>
 #include <boost/type_traits.hpp>
 #include <boost/static_assert.hpp>
+#include <RDGeneral/BoostEndInclude.h>
+#include <cmath>
 #include "LocaleSwitcher.h"
 
 #define RDVALUE_HASBOOL

--- a/Code/RDGeneral/RDValue-taggedunion.h
+++ b/Code/RDGeneral/RDValue-taggedunion.h
@@ -31,17 +31,20 @@
 #ifndef RDKIT_RDVALUE_TAGGED_UNION_H
 #define RDKIT_RDVALUE_TAGGED_UNION_H
 
-#include <boost/cstdint.hpp>
 #include <cassert>
-#include <boost/any.hpp>
 #include "Invariant.h"
 #include <iostream>
 #include <iomanip>
 #include <sstream>
 #include <vector>
+
+#include <RDGeneral/BoostStartInclude.h>
+#include <boost/cstdint.hpp>
+#include <boost/any.hpp>
 #include <boost/utility.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/type_traits/is_floating_point.hpp>
+#include <RDGeneral/BoostEndInclude.h>
 #include "LocaleSwitcher.h"
 
 #define RDVALUE_HASBOOL

--- a/Code/RDGeneral/types.cpp
+++ b/Code/RDGeneral/types.cpp
@@ -1,7 +1,5 @@
-// $Id$
 //
-//                 Copyright 2001-2006
-//                   Rational Discovery LLC
+//  Copyright 2001-2016 Greg Landrum and Rational Discovery LLC
 //
 //  @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -98,6 +96,8 @@ const std::string numArom = "numArom";
 const std::string origNoImplicit = "origNoImplicit";
 const std::string ringMembership = "ringMembership";
 const std::string smilesSymbol = "smilesSymbol";
+const std::string atomLabel = "atomSymbol";
+
 }  // end common_properties
 
 const double MAX_DOUBLE = std::numeric_limits<double>::max();

--- a/Code/RDGeneral/types.cpp
+++ b/Code/RDGeneral/types.cpp
@@ -96,7 +96,7 @@ const std::string numArom = "numArom";
 const std::string origNoImplicit = "origNoImplicit";
 const std::string ringMembership = "ringMembership";
 const std::string smilesSymbol = "smilesSymbol";
-const std::string atomLabel = "atomSymbol";
+const std::string atomLabel = "atomLabel";
 
 }  // end common_properties
 

--- a/Code/RDGeneral/types.h
+++ b/Code/RDGeneral/types.h
@@ -31,9 +31,10 @@
 #include <limits>
 
 #include <cstring>
-
+#include <RDGeneral/BoostStartInclude.h>
 #include <boost/any.hpp>
 #include <boost/lexical_cast.hpp>
+#include <RDGeneral/BoostEndInclude.h>
 
 namespace RDKit {
 

--- a/Code/RDGeneral/types.h
+++ b/Code/RDGeneral/types.h
@@ -109,6 +109,7 @@ extern const std::string _protected; // atom int (bool)
 extern const std::string _supplementalSmilesLabel; // atom string (SmilesWrite)
 extern const std::string _unspecifiedOrder;// atom int (bool) smarts/smiles
 extern const std::string _RingClosures; // INT_VECT smarts/smiles/canon
+extern const std::string atomLabel; // atom string from CXSMILES
 
 // MDL Style Properties (MolFileParser)
 extern const std::string molAtomMapNumber; // int


### PR DESCRIPTION
Beginning of the work for #1226. This isn't done, but it's probably already useful.

This PR includes:
 - molecule name
 - atom labels
 - coordinate bonds
 - query atoms
 - coordinates
 - radicals

Additional stuff in here:
 - a new version of SmilesToMol() that takes a parameters object.
 - removal of a bunch of compiler warnings on windows (I was doing the work there and couldn't help myself)
