### PR TITLE
make the Pandas version checking more robust

### DIFF
--- a/rdkit/Chem/PandasTools.py
+++ b/rdkit/Chem/PandasTools.py
@@ -114,10 +114,12 @@ try:
 
   def _getPandasVersion():
     """ Get the pandas version as a tuple """
+    import re
     try:
-      v = pd.__version__.split('.')
+      v = pd.__version__
     except AttributeError:
-      v = pd.version.version.split('.')
+      v = pd.version.version
+    v = re.split(r'[^0-9,.]',v)[0].split('.')
     return tuple(int(vi) for vi in v)
 
   if _getPandasVersion() < (0, 10):
@@ -132,7 +134,7 @@ try:
       pd.set_option('display.height', 1000000000)
     if 'display.max_colwidth' in pd.core.config._registered_options:
       pd.set_option('display.max_colwidth', 1000000000)
-    # saves the default pandas rendering to allow restauration
+    # saves the default pandas rendering to allow restoration
     defPandasRendering = pd.core.frame.DataFrame.to_html
 except ImportError:
   import traceback


### PR DESCRIPTION
This fixes a problem with versions of pandas that have "odd" version numbers like this (which is what's currently deployed via conda):
```
In [2]: pd.__version__
Out[2]: '0.19.2+0.g825876c.dirty'
```
This is what's causing the current travis failures.

Since this is minor and gets the tests working again, I'm going to go ahead and merge it soonish, but feedback from @gedeck and @bp-kelley would still be very welcome. :-)