### PR TITLE
Usethe directionality of dative bonds in substructure matching

### DIFF
--- a/Code/GraphMol/Substruct/SubstructUtils.cpp
+++ b/Code/GraphMol/Substruct/SubstructUtils.cpp
@@ -24,8 +24,8 @@ bool atomCompat(const ATOM_SPTR &a1, const ATOM_SPTR &a2,
   // " " << a2->getIdx() << std::endl;
   bool res;
   if (useQueryQueryMatches && a1->hasQuery() && a2->hasQuery()) {
-    res = static_cast<QueryAtom *>(a1.get())
-              ->QueryMatch(static_cast<QueryAtom *>(a2.get()));
+    res = static_cast<QueryAtom *>(a1.get())->QueryMatch(
+        static_cast<QueryAtom *>(a2.get()));
   } else {
     res = a1->Match(a2);
   }
@@ -55,10 +55,18 @@ bool bondCompat(const BOND_SPTR &b1, const BOND_SPTR &b2,
   PRECONDITION(b2, "bad bond");
   bool res;
   if (useQueryQueryMatches && b1->hasQuery() && b2->hasQuery()) {
-    res = static_cast<QueryBond *>(b1.get())
-              ->QueryMatch(static_cast<QueryBond *>(b2.get()));
+    res = static_cast<QueryBond *>(b1.get())->QueryMatch(
+        static_cast<QueryBond *>(b2.get()));
   } else {
     res = b1->Match(b2);
+  }
+  if (res && b1->getBondType() == Bond::DATIVE &&
+      b2->getBondType() == Bond::DATIVE) {
+    // for dative bonds we need to make sure that the direction also matches:
+    if (!b1->getBeginAtom()->Match(b1->getBeginAtom()) ||
+        !b1->getEndAtom()->Match(b2->getEndAtom())) {
+      res = false;
+    }
   }
   // std::cout << "\t\tbondCompat: "<< b1->getIdx() << "-" << b2->getIdx() << ":
   // " << res << std::endl;

--- a/Code/GraphMol/Substruct/test1.cpp
+++ b/Code/GraphMol/Substruct/test1.cpp
@@ -1,6 +1,5 @@
-// $Id$
 //
-//  Copyright (C) 2001-2015 Greg Landrum and Rational Discovery LLC
+//  Copyright (C) 2001-2017 Greg Landrum and Rational Discovery LLC
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -1163,6 +1162,42 @@ void testGitHubIssue688() {
   BOOST_LOG(rdErrorLog) << "  done" << std::endl;
 }
 
+void testDativeMatch() {
+  BOOST_LOG(rdErrorLog) << "-------------------------------------" << std::endl;
+  BOOST_LOG(rdErrorLog) << "    Test dative-bond matching" << std::endl;
+  {
+    std::string smi = "[Cu]->[Fe]";
+    ROMol *mol = SmilesToMol(smi);
+    TEST_ASSERT(mol);
+
+    // make sure a self-match works
+    MatchVectType match;
+    TEST_ASSERT(SubstructMatch(*mol, *mol, match));
+    TEST_ASSERT(match.size() == mol->getNumAtoms());
+
+    {  // reverse the order and make sure that works
+      std::string sma = "[Fe]<-[Cu]";
+      ROMol *qmol = SmilesToMol(sma);
+      TEST_ASSERT(qmol);
+      MatchVectType match;
+      TEST_ASSERT(SubstructMatch(*mol, *qmol, match));
+      TEST_ASSERT(match.size() == qmol->getNumAtoms());
+      delete qmol;
+    }
+    {  // reverse the direction and make sure that does not work.
+      std::string sma = "[Fe]->[Cu]";
+      ROMol *qmol = SmilesToMol(sma);
+      TEST_ASSERT(qmol);
+      MatchVectType match;
+      TEST_ASSERT(!SubstructMatch(*mol, *qmol, match));
+      delete qmol;
+    }
+
+    delete mol;
+  }
+  BOOST_LOG(rdErrorLog) << "  done" << std::endl;
+}
+
 int main(int argc, char *argv[]) {
 #if 1
   test1();
@@ -1182,5 +1217,6 @@ int main(int argc, char *argv[]) {
 #endif
   testChiralMatch();
   testGitHubIssue688();
+  testDativeMatch();
   return 0;
 }


### PR DESCRIPTION
This is a simple patch to change the behavior so that `[Fe]->[Cu]` no longer matches `[Fe]<-[Cu]`.
