### PR TITLE
Safer ranking-related performance computation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,6 @@ __pycache__/
 
 /rdkit/ML/Data/test_data/testgeneral.dat.pkl
 /rdkit/ML/Data/test_data/testquant.qdat.pkl
+
+# Tests caches
+.cache/

--- a/rdkit/ML/Scoring/Scoring.py
+++ b/rdkit/ML/Scoring/Scoring.py
@@ -36,17 +36,19 @@ def sortByColumns(scores, col, reverse=False):
     raise ValueError('scores cannot be empty')
   np.random.RandomState(0).shuffle(scores)  # Shuffle (deterministically)
 
+  # Allow to pass collections of columns to ignore
+  if isinstance(classCol, int):
+    classCol = (classCol,)
+
   # Sort without taking the class into account
   # This works for any of {list, tuple, numpy array, ...}
-  scores_dim = len(scores[0])
-  if col < 0:
-    col += scores_dim
-  all_but_class = itemgetter(*[i for i in range(scores_dim) if i != col])
-  return sorted(scores, key=all_but_class, reverse=reverse)
+  numCols = len(scores[0])
+  classCol = set(c if c >= 0 else c + numCols for c in classCol)
+  allButClass = itemgetter(*[i for i in range(numCols) if i not in classCol])
+  return sorted(scores, key=allButClass, reverse=reverse)
 
-  # I guess I should use camel case
-  # Could these safeguards be introduced in ROC/BEDROC etc. without changing
-  # the API but for adding keyword arguments?
+  # Could these safeguards be introduced in ROC/BEDROC etc.
+  # without changing the API but for adding keyword arguments?
 
 
 def CalcROC(scores, col):

--- a/rdkit/ML/Scoring/Scoring.py
+++ b/rdkit/ML/Scoring/Scoring.py
@@ -15,7 +15,6 @@ after a file from Peter Gedeck, Greg Landrum
 
 import math
 import numpy as np
-import copy
 from operator import itemgetter
 
 
@@ -32,7 +31,9 @@ def sortByColumns(scores, col, reverse=False):
   These problems are not uncommon. See the unit tests for some artificial examples.
   """
   # Shuffle
-  scores = copy.copy(scores)                # No side effects
+  scores = list(scores)                     # No side effects
+  if 0 == len(scores):
+    raise ValueError('scores cannot be empty')
   np.random.RandomState(0).shuffle(scores)  # Shuffle (deterministically)
 
   # Sort without taking the class into account

--- a/rdkit/ML/Scoring/Scoring.py
+++ b/rdkit/ML/Scoring/Scoring.py
@@ -19,7 +19,7 @@ import copy
 from operator import itemgetter
 
 
-def avoid_sorting_artifacts_on_ranking(scores, col, reverse=False):
+def sortByColumns(scores, col, reverse=False):
   """
   Safeguard against rotten ROCs (& AUCs & RIEs and whatnot) due to ordering artifacts.
 

--- a/rdkit/ML/Scoring/Scoring.py
+++ b/rdkit/ML/Scoring/Scoring.py
@@ -18,7 +18,7 @@ import numpy as np
 from operator import itemgetter
 
 
-def sortByColumns(scores, col, reverse=False):
+def SortByColumns(scores, classCol, reverse=False):
   """
   Safeguard against rotten ROCs (& AUCs & RIEs and whatnot) due to ordering artifacts.
 

--- a/rdkit/ML/Scoring/Scoring.py
+++ b/rdkit/ML/Scoring/Scoring.py
@@ -14,7 +14,7 @@ after a file from Peter Gedeck, Greg Landrum
 """
 
 import math
-import random  # Does rdkit depend on numpy? => Use np.random instead
+import numpy as np
 import copy
 from operator import itemgetter
 
@@ -26,16 +26,14 @@ def avoid_sorting_artifacts_on_ranking(scores, col, reverse=False):
   Avoids having artificially good/bad scores because:
     - `scores` are ordered by class (col) and python stable (tim)sort
       keeps the order on ties; this is specially bad if our model
-      returns garbage scores, let them be nans or any other constant.
+      returns garbage (nan) scores, or any other constant.
     - related, we leak the class in sorting
 
   These problems are not uncommon. See the unit tests for some artificial examples.
   """
   # Shuffle
-  scores = copy.copy(scores)        # No side effects
-  random.Random(0).shuffle(scores)  # Shuffle (deterministically)
-  # If numpy is a core dependency of rdkit,
-  # we could just use more efficient shuffling.
+  scores = copy.copy(scores)                # No side effects
+  np.random.RandomState(0).shuffle(scores)  # Shuffle (deterministically)
 
   # Sort without taking the class into account
   # This works for any of {list, tuple, numpy array, ...}

--- a/rdkit/ML/Scoring/UnitTestScoring.py
+++ b/rdkit/ML/Scoring/UnitTestScoring.py
@@ -149,7 +149,7 @@ class TestCase(unittest.TestCase):
 
   def test_safeguard_sort(self):
 
-    # Garbage scores with sorted classes show garbage performance
+    # NaN scores with sorted classes show uninformative performance
     nan = float('nan')
     scores = [(nan, 0)] * 10 + [(nan, 1)] * 10
     naively_sorted_scores = sorted(scores)

--- a/rdkit/ML/Scoring/UnitTestScoring.py
+++ b/rdkit/ML/Scoring/UnitTestScoring.py
@@ -153,7 +153,7 @@ class TestCase(unittest.TestCase):
     nan = float('nan')
     scores = [(nan, 0)] * 10 + [(nan, 1)] * 10
     naively_sorted_scores = sorted(scores)
-    safeguarded_scores = Scoring.sortByColumns(naively_sorted_scores, -1)
+    safeguarded_scores = Scoring.SortByColumns(naively_sorted_scores, -1)
     # This is the problem
     self.assertEqual(Scoring.CalcAUC(naively_sorted_scores, 1), 0)
     self.assertEqual(Scoring.CalcAUC(naively_sorted_scores[::-1], 1), 1)
@@ -175,7 +175,7 @@ class TestCase(unittest.TestCase):
     self.assertAlmostEqual(Scoring.CalcAUC(sorted(scores, reverse=True), -1),
                            0.6, delta=tol)
     # This is the solution
-    safeguarded_scores = Scoring.sortByColumns(scores, -1)
+    safeguarded_scores = Scoring.SortByColumns(scores, -1)
     self.assertAlmostEqual(Scoring.CalcAUC(safeguarded_scores, -1), 0.5, delta=tol)
 
     # N.B. the same tests would also apply to RIE, enrichment factor, BEDROC...

--- a/rdkit/ML/Scoring/UnitTestScoring.py
+++ b/rdkit/ML/Scoring/UnitTestScoring.py
@@ -153,7 +153,7 @@ class TestCase(unittest.TestCase):
     nan = float('nan')
     scores = [(nan, 0)] * 10 + [(nan, 1)] * 10
     naively_sorted_scores = sorted(scores)
-    safeguarded_scores = Scoring.avoid_sorting_artifacts_on_ranking(naively_sorted_scores, -1)
+    safeguarded_scores = Scoring.sortByColumns(naively_sorted_scores, -1)
     # This is the problem
     self.assertEqual(Scoring.CalcAUC(naively_sorted_scores, 1), 0)
     self.assertEqual(Scoring.CalcAUC(naively_sorted_scores[::-1], 1), 1)
@@ -175,7 +175,7 @@ class TestCase(unittest.TestCase):
     self.assertAlmostEqual(Scoring.CalcAUC(sorted(scores, reverse=True), -1),
                            0.6, delta=tol)
     # This is the solution
-    safeguarded_scores = Scoring.avoid_sorting_artifacts_on_ranking(scores, -1)
+    safeguarded_scores = Scoring.sortByColumns(scores, -1)
     self.assertAlmostEqual(Scoring.CalcAUC(safeguarded_scores, -1), 0.5, delta=tol)
 
     # N.B. the same tests would also apply to RIE, enrichment factor, BEDROC...


### PR DESCRIPTION
Here are some changes you could add to rdkit to avoid errors due to presorting of examples by class when computing AUCs and friends. In a nutshell: always randomly shuffle the scores and never use the class as a key for sorting when computing any ROC-like curve.

These errors, in my experience, are more frequent than what one would think, and giving the users the responsibility to sort the scores themselves makes them likely to happen. An example, the cell of your TDT notebook (@sriniker) where you sort the scores (fortunately, this changes nothing of your results). This is fixed in [this pull request on your TDT project](https://github.com/sriniker/TDT-tutorial-2014/pull/1).