### PR TITLE
Add the option to match formal charges to FMCS

### DIFF
--- a/Code/GraphMol/FMCS/FMCS.cpp
+++ b/Code/GraphMol/FMCS/FMCS.cpp
@@ -38,6 +38,8 @@ void parseMCSParametersJSON(const char* json, MCSParameters* params) {
         pt.get<bool>("MatchValences", p.AtomCompareParameters.MatchValences);
     p.AtomCompareParameters.MatchChiralTag =
         pt.get<bool>("MatchChiralTag", p.AtomCompareParameters.MatchChiralTag);
+    p.AtomCompareParameters.MatchFormalCharge = pt.get<bool>(
+        "MatchFormalCharge", p.AtomCompareParameters.MatchFormalCharge);
     p.BondCompareParameters.RingMatchesRingOnly = pt.get<bool>(
         "RingMatchesRingOnly", p.BondCompareParameters.RingMatchesRingOnly);
     p.BondCompareParameters.CompleteRingsOnly = pt.get<bool>(
@@ -134,6 +136,14 @@ bool MCSProgressCallbackTimeout(const MCSProgressData& stat,
 // PREDEFINED FUNCTORS:
 
 //=== ATOM COMPARE ========================================================
+static bool checkAtomCharge(const MCSAtomCompareParameters& p,
+                            const ROMol& mol1, unsigned int atom1,
+                            const ROMol& mol2, unsigned int atom2) {
+  RDUNUSED_PARAM(p);
+  const Atom& a1 = *mol1.getAtomWithIdx(atom1);
+  const Atom& a2 = *mol2.getAtomWithIdx(atom2);
+  return a1.getFormalCharge() == a2.getFormalCharge();
+}
 static bool checkAtomChirality(const MCSAtomCompareParameters& p,
                                const ROMol& mol1, unsigned int atom1,
                                const ROMol& mol2, unsigned int atom2) {
@@ -152,7 +162,11 @@ static bool checkAtomChirality(const MCSAtomCompareParameters& p,
 bool MCSAtomCompareAny(const MCSAtomCompareParameters& p, const ROMol& mol1,
                        unsigned int atom1, const ROMol& mol2,
                        unsigned int atom2, void*) {
-  if (p.MatchChiralTag) return checkAtomChirality(p, mol1, atom1, mol2, atom2);
+  if (p.MatchChiralTag && !checkAtomChirality(p, mol1, atom1, mol2, atom2))
+    return false;
+  if (p.MatchFormalCharge && !checkAtomCharge(p, mol1, atom1, mol2, atom2))
+    return false;
+
   return true;
 }
 
@@ -164,7 +178,10 @@ bool MCSAtomCompareElements(const MCSAtomCompareParameters& p,
   if (a1.getAtomicNum() != a2.getAtomicNum()) return false;
   if (p.MatchValences && a1.getTotalValence() != a2.getTotalValence())
     return false;
-  if (p.MatchChiralTag) return checkAtomChirality(p, mol1, atom1, mol2, atom2);
+  if (p.MatchChiralTag && !checkAtomChirality(p, mol1, atom1, mol2, atom2))
+    return false;
+  if (p.MatchFormalCharge && !checkAtomCharge(p, mol1, atom1, mol2, atom2))
+    return false;
   return true;
 }
 
@@ -178,7 +195,10 @@ bool MCSAtomCompareIsotopes(const MCSAtomCompareParameters& p,
   const Atom& a1 = *mol1.getAtomWithIdx(atom1);
   const Atom& a2 = *mol2.getAtomWithIdx(atom2);
   if (a1.getIsotope() != a2.getIsotope()) return false;
-  if (p.MatchChiralTag) return checkAtomChirality(p, mol1, atom1, mol2, atom2);
+  if (p.MatchChiralTag && !checkAtomChirality(p, mol1, atom1, mol2, atom2))
+    return false;
+  if (p.MatchFormalCharge && !checkAtomCharge(p, mol1, atom1, mol2, atom2))
+    return false;
   return true;
 }
 
@@ -340,7 +360,7 @@ bool FinalChiralityCheckFunction(const short unsigned c1[],
     ///*------------------ OLD Code :
     // ???: non chiral query atoms ARE ALLOWED TO MATCH to Chiral target atoms
     // (see test for issue 481)
-    if (a1.getDegree() < 3 ||//#688: doesn't deal with "explicit" Hs properly
+    if (a1.getDegree() < 3 ||  //#688: doesn't deal with "explicit" Hs properly
         !(ac1 == Atom::CHI_TETRAHEDRAL_CW || ac1 == Atom::CHI_TETRAHEDRAL_CCW))
       continue;  // skip non chiral center QUERY atoms
     if (!(ac2 == Atom::CHI_TETRAHEDRAL_CW || ac2 == Atom::CHI_TETRAHEDRAL_CCW))
@@ -363,7 +383,7 @@ bool FinalChiralityCheckFunction(const short unsigned c1[],
     */
     const unsigned a1Degree =
         boost::out_degree(c1[i], query);  // a1.getDegree();
-        //number of all connected atoms in a seed
+    // number of all connected atoms in a seed
     if (a1Degree > a2.getDegree()) {  //#688 was != . // FIX issue 631
       // printf("atoms Degree (%u, %u) %u [%u], %u\n", query[c1[i]],
       // target[c2[i]], a1Degree, a1.getDegree(), a2.getDegree());
@@ -382,17 +402,17 @@ bool FinalChiralityCheckFunction(const short unsigned c1[],
     //#688
     INT_LIST qmoOrder;
     {
-        ROMol::OEDGE_ITER dbeg, dend;
-        boost::tie(dbeg, dend) = mol1.getAtomBonds(&a1);
-        for (; dbeg != dend; dbeg++) {
-            int dbidx = mol1[*dbeg]->getIdx();
-            if (std::find(qOrder.begin(), qOrder.end(), dbidx) != qOrder.end())
-                qmoOrder.push_back(dbidx);
-//            else
-//                qmoOrder.push_back(-1);
-        }
+      ROMol::OEDGE_ITER dbeg, dend;
+      boost::tie(dbeg, dend) = mol1.getAtomBonds(&a1);
+      for (; dbeg != dend; dbeg++) {
+        int dbidx = mol1[*dbeg]->getIdx();
+        if (std::find(qOrder.begin(), qOrder.end(), dbidx) != qOrder.end())
+          qmoOrder.push_back(dbidx);
+        //            else
+        //                qmoOrder.push_back(-1);
+      }
     }
-    int qPermCount = //was: a1.getPerturbationOrder(qOrder);
+    int qPermCount =  // was: a1.getPerturbationOrder(qOrder);
         static_cast<int>(countSwapsToInterconvert(qmoOrder, qOrder));
 
     INT_LIST mOrder;
@@ -400,24 +420,24 @@ bool FinalChiralityCheckFunction(const short unsigned c1[],
       const Bond* mB = mol2.getBondBetweenAtoms(target[c2[i]], target[c2[j]]);
       if (mB) mOrder.push_back(mB->getIdx());
     }
-    
+
     //#688
     while (mOrder.size() < a2.getDegree()) {
-        mOrder.push_back(-1);
+      mOrder.push_back(-1);
     }
     INT_LIST moOrder;
     ROMol::OEDGE_ITER dbeg, dend;
     boost::tie(dbeg, dend) = mol2.getAtomBonds(&a2);
     for (; dbeg != dend; dbeg++) {
-        int dbidx = mol2[*dbeg]->getIdx();
-        if (std::find(mOrder.begin(), mOrder.end(), dbidx) != mOrder.end())
-            moOrder.push_back(dbidx);
-        else
-            moOrder.push_back(-1);
+      int dbidx = mol2[*dbeg]->getIdx();
+      if (std::find(mOrder.begin(), mOrder.end(), dbidx) != mOrder.end())
+        moOrder.push_back(dbidx);
+      else
+        moOrder.push_back(-1);
     }
 
-    int mPermCount = //was: a2.getPerturbationOrder(mOrder);
-            static_cast<int>(countSwapsToInterconvert(moOrder, mOrder));
+    int mPermCount =  // was: a2.getPerturbationOrder(mOrder);
+        static_cast<int>(countSwapsToInterconvert(moOrder, mOrder));
     //----
 
     if ((qPermCount % 2 == mPermCount % 2 &&

--- a/Code/GraphMol/FMCS/FMCS.h
+++ b/Code/GraphMol/FMCS/FMCS.h
@@ -23,9 +23,11 @@ struct MCSParameters;
 struct MCSAtomCompareParameters {
   bool MatchValences;
   bool MatchChiralTag;
+  bool MatchFormalCharge;
 
  public:
-  MCSAtomCompareParameters() : MatchValences(false), MatchChiralTag(false) {}
+  MCSAtomCompareParameters()
+      : MatchValences(false), MatchChiralTag(false), MatchFormalCharge(false) {}
 };
 
 struct MCSBondCompareParameters {
@@ -54,30 +56,33 @@ typedef bool (*MCSBondCompareFunction)(const MCSBondCompareParameters& p,
                                        void* userData);
 
 // Some predefined functors:
-RDKIT_WRAP_DECL bool MCSAtomCompareAny(const MCSAtomCompareParameters& p, const ROMol& mol1,
-                       unsigned int atom1, const ROMol& mol2,
-                       unsigned int atom2, void* userData);
+RDKIT_WRAP_DECL bool MCSAtomCompareAny(const MCSAtomCompareParameters& p,
+                                       const ROMol& mol1, unsigned int atom1,
+                                       const ROMol& mol2, unsigned int atom2,
+                                       void* userData);
 
 RDKIT_WRAP_DECL bool MCSAtomCompareElements(const MCSAtomCompareParameters& p,
-                            const ROMol& mol1, unsigned int atom1,
-                            const ROMol& mol2, unsigned int atom2,
-                            void* userData);
+                                            const ROMol& mol1,
+                                            unsigned int atom1,
+                                            const ROMol& mol2,
+                                            unsigned int atom2, void* userData);
 RDKIT_WRAP_DECL bool MCSAtomCompareIsotopes(const MCSAtomCompareParameters& p,
-                            const ROMol& mol1, unsigned int atom1,
-                            const ROMol& mol2, unsigned int atom2,
-                            void* userData);
+                                            const ROMol& mol1,
+                                            unsigned int atom1,
+                                            const ROMol& mol2,
+                                            unsigned int atom2, void* userData);
 
-RDKIT_WRAP_DECL bool MCSBondCompareAny(const MCSBondCompareParameters& p, const ROMol& mol1,
-                       unsigned int bond1, const ROMol& mol2,
-                       unsigned int bond2, void* userData);
-RDKIT_WRAP_DECL bool MCSBondCompareOrder(const MCSBondCompareParameters& p, const ROMol& mol1,
-                         unsigned int bond1, const ROMol& mol2,
-                         unsigned int bond2,
-                         void* userData);  // ignore Aromatization
-RDKIT_WRAP_DECL bool MCSBondCompareOrderExact(const MCSBondCompareParameters& p,
-                              const ROMol& mol1, unsigned int bond1,
-                              const ROMol& mol2, unsigned int bond2,
-                              void* userData);
+RDKIT_WRAP_DECL bool MCSBondCompareAny(const MCSBondCompareParameters& p,
+                                       const ROMol& mol1, unsigned int bond1,
+                                       const ROMol& mol2, unsigned int bond2,
+                                       void* userData);
+RDKIT_WRAP_DECL bool MCSBondCompareOrder(
+    const MCSBondCompareParameters& p, const ROMol& mol1, unsigned int bond1,
+    const ROMol& mol2, unsigned int bond2,
+    void* userData);  // ignore Aromatization
+RDKIT_WRAP_DECL bool MCSBondCompareOrderExact(
+    const MCSBondCompareParameters& p, const ROMol& mol1, unsigned int bond1,
+    const ROMol& mol2, unsigned int bond2, void* userData);
 
 struct MCSProgressData {
   unsigned NumAtoms;

--- a/Code/GraphMol/FMCS/Wrap/testFMCS.py
+++ b/Code/GraphMol/FMCS/Wrap/testFMCS.py
@@ -209,6 +209,21 @@ class TestCase(unittest.TestCase):
     mcs = rdFMCS.FindMCS(ms,ps)
     self.assertEqual(mcs.numAtoms, 2)
 
+  def test10MatchChargeAndParams(self):
+    smis = ("CCNC", "CCN(C)C", "CC[N+](C)C", "CC[C+](C)C")
+    ms = [Chem.MolFromSmiles(x) for x in smis]
+
+    mcs = rdFMCS.FindMCS(ms)
+    self.assertEqual(mcs.numAtoms, 2)
+
+    ps = rdFMCS.MCSParameters()
+    ps.SetAtomTyper(rdFMCS.AtomCompare.CompareAny)
+    mcs = rdFMCS.FindMCS(ms,ps)
+    self.assertEqual(mcs.numAtoms, 4)
+
+    ps.AtomCompareParameters.MatchFormalCharge = True
+    mcs = rdFMCS.FindMCS(ms,ps)
+    self.assertEqual(mcs.numAtoms, 2)
 
 
 if __name__ == "__main__":

--- a/Code/GraphMol/FMCS/Wrap/testFMCS.py
+++ b/Code/GraphMol/FMCS/Wrap/testFMCS.py
@@ -181,6 +181,35 @@ class TestCase(unittest.TestCase):
     r = rdFMCS.FindMCS(ms, seedSmarts='C1OC1')
     self.assertEqual(r.smartsString, "")
 
+  def test8MatchParams(self):
+    smis = ("CCC1NC1", "CCC1N(C)C1", "CCC1OC1")
+    ms = [Chem.MolFromSmiles(x) for x in smis]
+    mcs = rdFMCS.FindMCS(ms)
+    self.assertEqual(mcs.numAtoms, 4)
+
+    ps = rdFMCS.MCSParameters()
+    ps.BondCompareParameters.CompleteRingsOnly = True
+    mcs = rdFMCS.FindMCS(ms,ps)
+    self.assertEqual(mcs.numAtoms, 3)
+
+
+    ps = rdFMCS.MCSParameters()
+    ps.SetAtomTyper(rdFMCS.AtomCompare.CompareAny)
+    mcs = rdFMCS.FindMCS(ms,ps)
+    self.assertEqual(mcs.numAtoms, 5)
+
+  def test9MatchCharge(self):
+    smis = ("CCNC", "CCN(C)C", "CC[N+](C)C")
+    ms = [Chem.MolFromSmiles(x) for x in smis]
+    mcs = rdFMCS.FindMCS(ms)
+    self.assertEqual(mcs.numAtoms, 4)
+
+    ps = rdFMCS.MCSParameters()
+    ps.AtomCompareParameters.MatchFormalCharge = True
+    mcs = rdFMCS.FindMCS(ms,ps)
+    self.assertEqual(mcs.numAtoms, 2)
+
+
 
 if __name__ == "__main__":
   unittest.main()

--- a/Code/GraphMol/FMCS/Wrap/testFMCS.py
+++ b/Code/GraphMol/FMCS/Wrap/testFMCS.py
@@ -31,9 +31,9 @@ class TestCase(unittest.TestCase):
       mcs.smartsString,
       '[#6](:[#6]:[#6]):[#6]:[#7]:[#6]-[#6]-[#7](-[#6](-[#6])-[#6]1:[#6]:[#6]:[#6]:[#6]:[#7]:1)-[#6]-[#6]-[#6]-[#6]-[#7]')
     qm = Chem.MolFromSmarts(mcs.smartsString)
-    self.failUnless(qm is not None)
+    self.assertTrue(qm is not None)
     for m in ms:
-      self.failUnless(m.HasSubstructMatch(qm))
+      self.assertTrue(m.HasSubstructMatch(qm))
 
     mcs = rdFMCS.FindMCS(ms, threshold=0.8)
     self.assertEqual(mcs.numBonds, 21)
@@ -42,9 +42,9 @@ class TestCase(unittest.TestCase):
       mcs.smartsString,
       '[#6](:[#6]:[#6]):[#6]:[#7]:[#6]-[#6]-[#7](-[#6](-[#6])-[#6]1:[#6]:[#6]:[#6]:[#6]:[#7]:1)-[#6]-[#6]-[#6]-[#6]-[#7]')
     qm = Chem.MolFromSmarts(mcs.smartsString)
-    self.failUnless(qm is not None)
+    self.assertTrue(qm is not None)
     for m in ms:
-      self.failUnless(m.HasSubstructMatch(qm))
+      self.assertTrue(m.HasSubstructMatch(qm))
 
   def test2(self):
     smis = ("CHEMBL122452 CN(CCCN(C)CCc1ccccc1)CCOC(c1ccccc1)c1ccccc1",
@@ -67,9 +67,9 @@ class TestCase(unittest.TestCase):
     self.assertEqual(mcs.numBonds, 9)
     self.assertEqual(mcs.numAtoms, 10)
     qm = Chem.MolFromSmarts(mcs.smartsString)
-    self.failUnless(qm is not None)
+    self.assertTrue(qm is not None)
     for m in ms:
-      self.failUnless(m.HasSubstructMatch(qm))
+      self.assertTrue(m.HasSubstructMatch(qm))
     # smarts too hard to canonicalize this
     #self.assertEqual(mcs.smartsString,'[#6]-,:[#6]-,:[#6]-,:[#6]-,:[#6](-[#6]-[#8]-[#6]:,-[#6])-,:[#6]')
 
@@ -77,12 +77,12 @@ class TestCase(unittest.TestCase):
     self.assertEqual(mcs.numBonds, 20)
     self.assertEqual(mcs.numAtoms, 19)
     qm = Chem.MolFromSmarts(mcs.smartsString)
-    self.failUnless(qm is not None)
+    self.assertTrue(qm is not None)
     nHits = 0
     for m in ms:
       if m.HasSubstructMatch(qm):
         nHits += 1
-    self.failUnless(nHits >= int(0.8 * len(smis)))
+    self.assertTrue(nHits >= int(0.8 * len(smis)))
     # smarts too hard to canonicalize this
     #self.assertEqual(mcs.smartsString,'[#6]1:[#6]:[#6]:[#6](:[#6]:[#6]:1)-[#6](-[#8]-[#6]-[#6]-[#7]-[#6]-[#6])-[#6]2:[#6]:[#6]:[#6]:[#6]:[#6]:2')
 
@@ -101,10 +101,10 @@ class TestCase(unittest.TestCase):
     self.assertEqual(mcs.numAtoms, 3)
     qm = Chem.MolFromSmarts(mcs.smartsString)
 
-    self.failUnless(Chem.MolFromSmiles('CC[14CH3]').HasSubstructMatch(qm))
-    self.failIf(Chem.MolFromSmiles('CC[13CH3]').HasSubstructMatch(qm))
-    self.failUnless(Chem.MolFromSmiles('OO[14CH3]').HasSubstructMatch(qm))
-    self.failIf(Chem.MolFromSmiles('O[13CH2][14CH3]').HasSubstructMatch(qm))
+    self.assertTrue(Chem.MolFromSmiles('CC[14CH3]').HasSubstructMatch(qm))
+    self.assertFalse(Chem.MolFromSmiles('CC[13CH3]').HasSubstructMatch(qm))
+    self.assertTrue(Chem.MolFromSmiles('OO[14CH3]').HasSubstructMatch(qm))
+    self.assertFalse(Chem.MolFromSmiles('O[13CH2][14CH3]').HasSubstructMatch(qm))
 
   def test4RingMatches(self):
     smis = ['CCCCC', 'CCC1CCCCC1']
@@ -184,6 +184,7 @@ class TestCase(unittest.TestCase):
   def test8MatchParams(self):
     smis = ("CCC1NC1", "CCC1N(C)C1", "CCC1OC1")
     ms = [Chem.MolFromSmiles(x) for x in smis]
+
     mcs = rdFMCS.FindMCS(ms)
     self.assertEqual(mcs.numAtoms, 4)
 
@@ -191,7 +192,6 @@ class TestCase(unittest.TestCase):
     ps.BondCompareParameters.CompleteRingsOnly = True
     mcs = rdFMCS.FindMCS(ms,ps)
     self.assertEqual(mcs.numAtoms, 3)
-
 
     ps = rdFMCS.MCSParameters()
     ps.SetAtomTyper(rdFMCS.AtomCompare.CompareAny)
@@ -201,6 +201,7 @@ class TestCase(unittest.TestCase):
   def test9MatchCharge(self):
     smis = ("CCNC", "CCN(C)C", "CC[N+](C)C")
     ms = [Chem.MolFromSmiles(x) for x in smis]
+
     mcs = rdFMCS.FindMCS(ms)
     self.assertEqual(mcs.numAtoms, 4)
 

--- a/Code/GraphMol/FMCS/testFMCS_Unit.cpp
+++ b/Code/GraphMol/FMCS/testFMCS_Unit.cpp
@@ -1058,7 +1058,8 @@ void testGithub631() {
         MCSResult res = findMCS(mols, &p);
         BOOST_LOG(rdInfoLog) << "MCS: " << res.SmartsString << " "
                              << res.NumAtoms << " atoms, " << res.NumBonds
-                             << " bonds\n" << std::endl;
+                             << " bonds\n"
+                             << std::endl;
         ;
 
         TEST_ASSERT(res.NumAtoms == mols[0]->getNumAtoms());
@@ -1073,7 +1074,8 @@ void testGithub631() {
         MCSResult res = findMCS(mols, &p);
         BOOST_LOG(rdInfoLog) << "MCS: " << res.SmartsString << " "
                              << res.NumAtoms << " atoms, " << res.NumBonds
-                             << " bonds\n" << std::endl;
+                             << " bonds\n"
+                             << std::endl;
         ;
 
         TEST_ASSERT(res.NumAtoms == mols[0]->getNumAtoms());
@@ -1082,6 +1084,50 @@ void testGithub631() {
       BOOST_LOG(rdInfoLog) << "============================================"
                            << std::endl;
     }
+  BOOST_LOG(rdInfoLog) << "\tdone" << std::endl;
+}
+
+void testFormalChargeMatch() {
+  BOOST_LOG(rdInfoLog) << "-------------------------------------" << std::endl;
+  BOOST_LOG(rdInfoLog) << "Testing including formal charge in matches "
+                       << std::endl;
+  std::vector<ROMOL_SPTR> mols;
+  const char* smi[] = {"CCNC", "CCN(C)C", "CC[N+](C)C"};
+
+  for (size_t i = 0; i < sizeof(smi) / sizeof(smi[0]); i++) {
+    RWMol* m = SmilesToMol(getSmilesOnly(smi[i]));
+    TEST_ASSERT(m);
+
+    mols.push_back(ROMOL_SPTR(m));
+  }
+  {
+    // by default charge is not used.
+    MCSParameters p;
+    MCSResult res = findMCS(mols, &p);
+    BOOST_LOG(rdInfoLog) << "MCS: " << res.SmartsString << " " << res.NumAtoms
+                         << " atoms, " << res.NumBonds << " bonds\n"
+                         << std::endl;
+    ;
+
+    TEST_ASSERT(res.NumAtoms == 4);
+    TEST_ASSERT(res.NumBonds == 3);
+  }
+  {
+    // check charge
+    MCSParameters p;
+    p.AtomCompareParameters.MatchFormalCharge = true;
+    MCSResult res = findMCS(mols, &p);
+    BOOST_LOG(rdInfoLog) << "MCS: " << res.SmartsString << " " << res.NumAtoms
+                         << " atoms, " << res.NumBonds << " bonds\n"
+                         << std::endl;
+    ;
+
+    TEST_ASSERT(res.NumAtoms == 2);
+    TEST_ASSERT(res.NumBonds == 1);
+  }
+
+  BOOST_LOG(rdInfoLog) << "============================================"
+                       << std::endl;
   BOOST_LOG(rdInfoLog) << "\tdone" << std::endl;
 }
 
@@ -1141,6 +1187,8 @@ int main(int argc, const char* argv[]) {
   testChirality();
   testGithub631();
   //---
+
+  testFormalChargeMatch();
 
   unsigned long long t1 = nanoClock();
   double sec = double(t1 - T0) / 1000000.;


### PR DESCRIPTION
This is a C++-based alternative to #1157 
Also provides some additional control over the MCS parameters from Python by exposing the MCSParameters objects to the Python wrapper.