### PR TITLE
Refactoring BuildFragmentCatalog

### DIFF
--- a/rdkit/Chem/UnitTestCatalog.py
+++ b/rdkit/Chem/UnitTestCatalog.py
@@ -16,9 +16,7 @@ from rdkit import RDConfig
 from rdkit.Chem import FragmentCatalog, BuildFragmentCatalog
 from rdkit.six.moves import cPickle
 
-
-def feq(n1, n2, tol=1e-4):
-  return abs(n1 - n2) < tol
+doLong = False
 
 
 class TestCase(unittest.TestCase):
@@ -71,16 +69,16 @@ class TestCase(unittest.TestCase):
       fp = fpgen.GetFPForMol(mol, fragCat)
       if i < len(obits):
         smi = Chem.MolToSmiles(mol)
-        assert fp.GetNumOnBits() == obits[i], '%s: %s' % (smi, str(fp.GetOnBits()))
+        self.assertEqual(fp.GetNumOnBits(), obits[i], msg='%s: %s' % (smi, str(fp.GetOnBits())))
       obl = fp.GetOnBits()
       if i < len(obls):
-        assert tuple(obl) == obls[i], '%s: %s' % (smi, obl)
+        self.assertEqual(tuple(obl), obls[i], msg='%s: %s' % (smi, obl))
       i += 1
 
   def test1CatGen(self):
     self._fillCat(self.smiList2)
-    assert self.fragCat.GetNumEntries() == 21
-    assert self.fragCat.GetFPLength() == 21
+    self.assertEqual(self.fragCat.GetNumEntries(), 21)
+    self.assertEqual(self.fragCat.GetFPLength(), 21)
     self._testBits(self.fragCat)
 
   def test2CatStringPickle(self):
@@ -88,14 +86,14 @@ class TestCase(unittest.TestCase):
 
     # test non-binary pickle:
     cat2 = cPickle.loads(cPickle.dumps(self.fragCat))
-    assert cat2.GetNumEntries() == 21
-    assert cat2.GetFPLength() == 21
+    self.assertEqual(cat2.GetNumEntries(), 21)
+    self.assertEqual(cat2.GetFPLength(), 21)
     self._testBits(cat2)
 
     # test binary pickle:
     cat2 = cPickle.loads(cPickle.dumps(self.fragCat, 1))
-    assert cat2.GetNumEntries() == 21
-    assert cat2.GetFPLength() == 21
+    self.assertEqual(cat2.GetNumEntries(), 21)
+    self.assertEqual(cat2.GetFPLength(), 21)
     self._testBits(cat2)
 
   def test3CatFilePickle(self):
@@ -105,14 +103,14 @@ class TestCase(unittest.TestCase):
       pklTFile.close()
     with io.BytesIO(buf) as pklFile:
       cat = cPickle.load(pklFile, encoding='bytes')
-    assert cat.GetNumEntries() == 21
-    assert cat.GetFPLength() == 21
+    self.assertEqual(cat.GetNumEntries(), 21)
+    self.assertEqual(cat.GetFPLength(), 21)
     self._testBits(cat)
 
   def test4CatGuts(self):
     self._fillCat(self.smiList2)
-    assert self.fragCat.GetNumEntries() == 21
-    assert self.fragCat.GetFPLength() == 21
+    self.assertEqual(self.fragCat.GetNumEntries(), 21)
+    self.assertEqual(self.fragCat.GetFPLength(), 21)
     #
     # FIX: (Issue 162)
     # bits like 11 and 15 are questionable here because the underlying
@@ -140,12 +138,15 @@ class TestCase(unittest.TestCase):
     for i in range(len(descrs)):
       ID, d, order, ids = descrs[i]
       descr = self.fragCat.GetBitDescription(ID)
-      assert descr == d, '%d: %s != %s' % (ID, descr, d)
-      assert self.fragCat.GetBitOrder(ID) == order
-      assert tuple(self.fragCat.GetBitFuncGroupIds(ID)) == ids, '%d: %s != %s' % (
-        ID, str(self.fragCat.GetBitFuncGroupIds(ID)), str(ids))
+      self.assertEqual(descr, d, msg='%d: %s != %s' % (ID, descr, d))
+      self.assertEqual(self.fragCat.GetBitOrder(ID), order)
+      self.assertEqual(
+        tuple(self.fragCat.GetBitFuncGroupIds(ID)), ids,
+        msg='%d: %s != %s' % (ID, str(self.fragCat.GetBitFuncGroupIds(ID)), str(ids)))
 
-  def _test5MoreComplex(self):
+  def test5MoreComplex(self):
+    if not doLong:
+      raise unittest.SkipTest('Longer running test skipped')
     lastIdx = 0
     ranges = {}
     suppl = Chem.SmilesMolSupplierFromText('\n'.join(self.smiList), ',', 0, -1, 0)
@@ -158,86 +159,98 @@ class TestCase(unittest.TestCase):
     for i, mol in enumerate(suppl):
       fp = fpgen.GetFPForMol(mol, self.fragCat)
       for bit in ranges[i]:
-        assert fp[bit], '%s: %s' % (Chem.MolToSmiles(mol), str(bit))
+        self.assertEqual(fp[bit], 1, msg='%s: %s' % (Chem.MolToSmiles(mol), str(bit)))
 
   def test6Builder(self):
     suppl = Chem.SmilesMolSupplierFromText('\n'.join(self.smiList2), ',', 0, -1, 0)
     cat = BuildFragmentCatalog.BuildCatalog(suppl, minPath=1, reportFreq=20)
-    assert cat.GetNumEntries() == 21
-    assert cat.GetFPLength() == 21
+    self.assertEqual(cat.GetNumEntries(), 21)
+    self.assertEqual(cat.GetFPLength(), 21)
     self._testBits(cat)
 
   def test7ScoreMolecules(self):
     suppl = Chem.SmilesMolSupplierFromText('\n'.join(self.smiList2), ',', 0, -1, 0)
     cat = BuildFragmentCatalog.BuildCatalog(suppl, minPath=1, reportFreq=20)
-    assert cat.GetNumEntries() == 21
-    assert cat.GetFPLength() == 21
+    self.assertEqual(cat.GetNumEntries(), 21)
+    self.assertEqual(cat.GetFPLength(), 21)
 
     scores, obls = BuildFragmentCatalog.ScoreMolecules(suppl, cat, acts=self.list2Acts,
                                                        reportFreq=20)
     for i in range(len(self.list2Obls)):
-      assert tuple(obls[i]) == self.list2Obls[i], '%d: %s != %s' % (i, str(obls[i]),
-                                                                    str(self.list2Obls[i]))
+      self.assertEqual(
+        tuple(obls[i]), self.list2Obls[i], msg='%d: %s != %s' % (i, str(obls[i]),
+                                                                 str(self.list2Obls[i])))
 
     scores2 = BuildFragmentCatalog.ScoreFromLists(obls, suppl, cat, acts=self.list2Acts,
                                                   reportFreq=20)
     for i in range(len(scores)):
-      assert (scores[i] == scores2[i]).all(), '%d: %s != %s' % (i, str(scores[i]), str(scores2[i]))
+      self.assertTrue((scores[i] == scores2[i]).all(),
+                      msg='%d: %s != %s' % (i, str(scores[i]), str(scores2[i])))
 
   def test8MolRanks(self):
     suppl = Chem.SmilesMolSupplierFromText('\n'.join(self.smiList2), ',', 0, -1, 0)
     cat = BuildFragmentCatalog.BuildCatalog(suppl, minPath=1, reportFreq=20)
-    assert cat.GetNumEntries() == 21
-    assert cat.GetFPLength() == 21
+    self.assertEqual(cat.GetNumEntries(), 21)
+    self.assertEqual(cat.GetFPLength(), 21)
 
     # new InfoGain ranking:
     bitInfo, _ = BuildFragmentCatalog.CalcGains(suppl, cat, topN=10, acts=self.list2Acts,
                                                 reportFreq=20, biasList=(1, ))
     entry = bitInfo[0]
-    assert int(entry[0]) == 0
-    assert cat.GetBitDescription(int(entry[0])) == 'C<-O>C'
-    assert feq(entry[1], 0.4669)
+    self.assertEqual(int(entry[0]), 0)
+    self.assertEqual(cat.GetBitDescription(int(entry[0])), 'C<-O>C')
+    self.assertAlmostEqual(entry[1], 0.4669, delta=1e-4)
 
     entry = bitInfo[1]
-    assert int(entry[0]) in (2, 6)
+    self.assertIn(int(entry[0]), (2, 6))
     txt = cat.GetBitDescription(int(entry[0]))
-    self.assertTrue(txt in ('C<-O>CC', 'C<-O>=C'), txt)
-    assert feq(entry[1], 0.1611)
+    self.assertIn(txt, ('C<-O>CC', 'C<-O>=C'), msg=txt)
+    self.assertAlmostEqual(entry[1], 0.1611, delta=1e-4)
 
     entry = bitInfo[6]
-    assert int(entry[0]) == 16
-    assert cat.GetBitDescription(int(entry[0])) == 'C=CC<-O>'
-    assert feq(entry[1], 0.0560)
+    self.assertEqual(int(entry[0]), 16)
+    self.assertEqual(cat.GetBitDescription(int(entry[0])), 'C=CC<-O>')
+    self.assertAlmostEqual(entry[1], 0.0560, delta=1e-4)
 
     # standard InfoGain ranking:
     bitInfo, _ = BuildFragmentCatalog.CalcGains(suppl, cat, topN=10, acts=self.list2Acts,
                                                 reportFreq=20)
     entry = bitInfo[0]
-    assert int(entry[0]) == 0
-    assert cat.GetBitDescription(int(entry[0])) == 'C<-O>C'
-    assert feq(entry[1], 0.4669)
+    self.assertEqual(int(entry[0]), 0)
+    self.assertEqual(cat.GetBitDescription(int(entry[0])), 'C<-O>C')
+    self.assertAlmostEqual(entry[1], 0.4669, delta=1e-4)
 
     entry = bitInfo[1]
-    assert int(entry[0]) == 5
-    assert cat.GetBitDescription(int(entry[0])) == 'C=CC'
-    assert feq(entry[1], 0.2057)
+    self.assertEqual(int(entry[0]), 5)
+    self.assertEqual(cat.GetBitDescription(int(entry[0])), 'C=CC')
+    self.assertAlmostEqual(entry[1], 0.2057, delta=1e-4)
 
   def test9Issue116(self):
     smiList = ['Cc1ccccc1']
     suppl = Chem.SmilesMolSupplierFromText('\n'.join(smiList), ',', 0, -1, 0)
     cat = BuildFragmentCatalog.BuildCatalog(suppl, minPath=2, maxPath=2)
-    assert cat.GetFPLength() == 2
-    assert cat.GetBitDescription(0) == 'ccC'
+    self.assertEqual(cat.GetFPLength(), 2)
+    self.assertEqual(cat.GetBitDescription(0), 'ccC')
     fpgen = FragmentCatalog.FragFPGenerator()
     mol = Chem.MolFromSmiles('Cc1ccccc1')
     fp = fpgen.GetFPForMol(mol, cat)
-    assert fp[0]
-    assert fp[1]
+    self.assertEqual(fp[0], 1)
+    self.assertEqual(fp[1], 1)
     mol = Chem.MolFromSmiles('c1ccccc1-c1ccccc1')
     fp = fpgen.GetFPForMol(mol, cat)
-    assert not fp[0]
-    assert fp[1]
+    self.assertEqual(fp[0], 0)
+    self.assertEqual(fp[1], 1)
 
 
-if __name__ == '__main__':
+if __name__ == '__main__':  # pragma: nocover
+  import argparse
+  import sys
+  parser = argparse.ArgumentParser()
+  parser.add_argument('-l', default=False, action='store_true', dest='doLong')
+  args = parser.parse_args()
+  doLong = args.doLong
+
+  # Remove the -l flag if present so that it isn't interpreted by unittest.main()
+  if '-l' in sys.argv:
+    sys.argv.remove('-l')
   unittest.main()

--- a/rdkit/Chem/UnitTestGraphDescriptors_2.py
+++ b/rdkit/Chem/UnitTestGraphDescriptors_2.py
@@ -519,6 +519,6 @@ if __name__ == '__main__':
   doLong = args.doLong
 
   # Remove the -l flag if present so that it isn't interpreted by unittest.main()
-  if 'l' in sys.argv:
+  if '-l' in sys.argv:
     sys.argv.remove('-l')
   unittest.main()

--- a/rdkit/Chem/UnitTestSuppliers.py
+++ b/rdkit/Chem/UnitTestSuppliers.py
@@ -1,6 +1,5 @@
-# $Id$
 #
-#  Copyright (C) 2003-2006  Rational Discovery LLC
+#  Copyright (C) 2002-2006  greg Landrum and Rational Discovery LLC
 #
 #   @@ All Rights Reserved @@
 #  This file is part of the RDKit.
@@ -8,97 +7,248 @@
 #  which is included in the file license.txt, found at the root
 #  of the RDKit source tree.
 #
-""" unit testing code for molecule suppliers
-
 """
-import os
-import tempfile
+unit testing code for calculations in rdkit.Chem.MolSurf
+"""
+from __future__ import print_function
+
+from collections import namedtuple
+import os.path
 import unittest
 
-from rdkit import Chem, RDLogger
+from rdkit import Chem
 from rdkit import RDConfig
-from rdkit.six import next
+from rdkit.Chem import MolSurf
+
+doLong = False
+TestData = namedtuple('TestData', 'lineNo,smiles,mol,expected')
 
 
 class TestCase(unittest.TestCase):
+  dataNCI200 = os.path.join(RDConfig.RDDataDir, 'NCI', 'first_200.tpsa.csv')
+  dataNCI5000 = os.path.join(RDConfig.RDCodeDir, 'Chem', 'test_data', 'NCI_5K_TPSA.csv')
+  dataTPSAregr = os.path.join(RDConfig.RDCodeDir, 'Chem', 'test_data', 'tpsa_regr.csv')
 
-  def tearDown(self):
-    RDLogger.EnableLog('rdApp.error')
+  @classmethod
+  def readNCI_200(cls):
+    for data in readPSAtestData(cls.dataNCI200):
+      yield data
 
-  def test1SDSupplier(self):
-    fileN = os.path.join(RDConfig.RDCodeDir, 'VLib', 'NodeLib', 'test_data', 'NCI_aids.10.sdf')
+  @classmethod
+  def readNCI_5000(cls):
+    for data in readPSAtestData(cls.dataNCI5000):
+      yield data
 
-    suppl = Chem.SDMolSupplier(fileN)
-    ms = [x for x in suppl]
-    self.assertEqual(len(ms), 10)
+  @classmethod
+  def readTPSAregres(cls):
+    for data in readPSAtestData(cls.dataTPSAregr):
+      yield data
 
-    # test repeating:
-    ms = [x for x in suppl]
-    self.assertEqual(len(ms), 10)
+  def testTPSAShort(self):
+    for data in self.readNCI_200():
+      calc = MolSurf.TPSA(data.mol)
+      self.assertAlmostEqual(
+        calc, data.expected, delta=1e-4,
+        msg='bad TPSA for SMILES {0.smiles} ({1:.2f} != {0.expected:.2f})'.format(data, calc))
 
-    # test reset:
-    suppl.reset()
-    m = next(suppl)
-    self.assertEqual(m.GetProp('_Name'), '48')
-    self.assertEqual(m.GetProp('NSC'), '48')
-    self.assertEqual(m.GetProp('CAS_RN'), '15716-70-8')
-    m = next(suppl)
-    self.assertEqual(m.GetProp('_Name'), '78')
-    self.assertEqual(m.GetProp('NSC'), '78')
-    self.assertEqual(m.GetProp('CAS_RN'), '6290-84-2')
+  def testTPSALong(self):
+    if not doLong:
+      raise unittest.SkipTest('long test')
+    for data in self.readNCI_5000():
+      try:
+        calc = MolSurf.TPSA(data.mol)
+      except Exception:
+        raise AssertionError(
+          'Line {0.lineNo}: TPSA Calculation failed for SMILES {0.smiles}'.format(data))
+      self.assertAlmostEqual(
+        calc, data.expected, delta=1e-4,
+        msg='bad TPSA for SMILES {0.smiles} ({1:.2f} != {0.expected:.2f})'.format(data, calc))
 
-    suppl.reset()
-    for _ in range(10):
-      m = next(suppl)
+  def testTPSALongNCI(self):
+    if not doLong:
+      raise unittest.SkipTest('long test')
+    for data in self.readTPSAregres():
+      try:
+        calc = MolSurf.TPSA(data.mol)
+      except Exception:
+        raise AssertionError(
+          'Line {0.lineNo}: TPSA Calculation failed for SMILES {0.smiles}'.format(data))
+      self.assertAlmostEqual(
+        calc, data.expected, delta=1e-4,
+        msg='bad TPSA for SMILES {0.smiles} ({1:.2f} != {0.expected:.2f})'.format(data, calc))
 
-    with self.assertRaises(StopIteration):
-      m = next(suppl)
+  def testHsAndTPSA(self):
+    """
+     testing the impact of Hs in the graph on PSA calculations
+     This was sf.net issue 1969745
+    """
+    mol = Chem.MolFromSmiles('c1c[nH]cc1')
+    molH = Chem.AddHs(mol)
+    psa = MolSurf.TPSA(mol)
+    psaH = MolSurf.TPSA(molH)
 
-  def test2SmilesSupplier(self):
-    fileN = os.path.join(RDConfig.RDCodeDir, 'VLib', 'NodeLib', 'test_data', 'pgp_20.txt')
+    if psa != psaH:
+      psac = MolSurf.rdMolDescriptors._CalcTPSAContribs(mol)
+      psaHc = MolSurf.rdMolDescriptors._CalcTPSAContribs(molH)
+      for i, v in enumerate(psac):
+        print('\t', i, '\t', v, '\t', psaHc[i])
+      while i < len(psaHc):
+        print('\t\t\t', psaHc[i])
+        i += 1
+    self.assertEqual(psa, psaH)
 
-    suppl = Chem.SmilesMolSupplier(fileN, delimiter='\t', smilesColumn=2, nameColumn=1, titleLine=1)
-    ms = [x for x in suppl]
-    self.assertEqual(len(ms), 20)
+    for data in self.readNCI_200():
+      mol = Chem.AddHs(data.mol)
+      calc = MolSurf.TPSA(mol)
+      self.assertAlmostEqual(
+        calc, data.expected, delta=1e-4,
+        msg='bad TPSA for SMILES {0.smiles} ({1:.2f} != {0.expected:.2f})'.format(data, calc))
 
-    # test repeating:
-    ms = [x for x in suppl]
-    self.assertEqual(len(ms), 20)
-    # test reset:
-    suppl.reset()
-    m = next(suppl)
-    self.assertEqual(m.GetProp('_Name'), 'ALDOSTERONE')
-    self.assertEqual(m.GetProp('ID'), 'RD-PGP-0001')
-    m = next(suppl)
-    self.assertEqual(m.GetProp('_Name'), 'AMIODARONE')
-    self.assertEqual(m.GetProp('ID'), 'RD-PGP-0002')
-    suppl.reset()
-    for _ in range(20):
-      m = next(suppl)
-    with self.assertRaises(StopIteration):
-      m = next(suppl)
-
-  def test3SmilesSupplier(self):
-    txt = """C1CC1,1
-CC(=O)O,3
-fail,4
-CCOC,5
-"""
-    RDLogger.DisableLog('rdApp.error')
-
-    fileN = tempfile.mktemp('.csv')
-    try:
-      with open(fileN, 'w+') as f:
-        f.write(txt)
-      suppl = Chem.SmilesMolSupplier(fileN, delimiter=',', smilesColumn=0, nameColumn=1,
-                                     titleLine=0)
-      ms = [x for x in suppl]
-      while ms.count(None):
-        ms.remove(None)
-      self.assertEqual(len(ms), 3)
-    finally:
-      os.unlink(fileN)
+    if doLong:
+      for data in self.readNCI_5000():
+        mol = Chem.AddHs(data.mol)
+        calc = MolSurf.TPSA(mol)
+        self.assertAlmostEqual(
+          calc, data.expected, delta=1e-4,
+          msg='bad TPSA for SMILES {0.smiles} ({1:.2f} != {0.expected:.2f})'.format(data, calc))
 
 
-if __name__ == '__main__':
+class TestCase_descriptorRegression(unittest.TestCase):
+
+  def __testDesc(self, fileN, col, func):
+    for data in readRegressionData(fileN, col):
+      if abs(data.expected - 666.0) < 1e-4:
+        print(data)
+        raise AssertionError('check this data entry')
+      try:
+        val = func(data.mol)
+      except Exception:
+        val = 666
+      self.assertAlmostEqual(
+        val, data.expected, delta=1e-4,
+        msg='line {0.lineNo}, mol {0.smiles} (calc = {1}) should have val = {0.expected}'.format(
+          data, val))
+
+  def testLabuteASALong(self):
+    if not doLong:
+      raise unittest.SkipTest('long test')
+    col = 6
+    self.__testDesc('PP_descrs_regress.csv', col, lambda x: MolSurf.LabuteASA(x, includeHs=1))
+    self.__testDesc('PP_descrs_regress.2.csv', col, lambda x: MolSurf.LabuteASA(x, includeHs=1))
+
+  def testTPSALong(self):
+    col = 28
+    self.__testDesc('PP_descrs_regress.csv', col, MolSurf.TPSA)
+    if doLong:
+      self.__testDesc('PP_descrs_regress.2.csv', col, MolSurf.TPSA)
+
+  def testMOELong(self):
+    if not doLong:
+      raise unittest.SkipTest('long test')
+    fName = 'PP_descrs_regress.VSA.csv'
+    self.__testDesc(fName, 1, MolSurf.SMR_VSA1)
+    self.__testDesc(fName, 2, MolSurf.SMR_VSA10)
+    self.__testDesc(fName, 3, MolSurf.SMR_VSA2)
+    self.__testDesc(fName, 4, MolSurf.SMR_VSA3)
+    self.__testDesc(fName, 5, MolSurf.SMR_VSA4)
+    self.__testDesc(fName, 6, MolSurf.SMR_VSA5)
+    self.__testDesc(fName, 7, MolSurf.SMR_VSA6)
+    self.__testDesc(fName, 8, MolSurf.SMR_VSA7)
+    self.__testDesc(fName, 9, MolSurf.SMR_VSA8)
+    self.__testDesc(fName, 10, MolSurf.SMR_VSA9)
+    self.__testDesc(fName, 11, MolSurf.SlogP_VSA1)
+    self.__testDesc(fName, 12, MolSurf.SlogP_VSA10)
+    self.__testDesc(fName, 13, MolSurf.SlogP_VSA11)
+    self.__testDesc(fName, 14, MolSurf.SlogP_VSA12)
+
+    fName = 'PP_descrs_regress.VSA.2.csv'
+    self.__testDesc(fName, 1, MolSurf.SMR_VSA1)
+    self.__testDesc(fName, 2, MolSurf.SMR_VSA10)
+    self.__testDesc(fName, 11, MolSurf.SlogP_VSA1)
+    self.__testDesc(fName, 12, MolSurf.SlogP_VSA10)
+    self.__testDesc(fName, 13, MolSurf.SlogP_VSA11)
+    self.__testDesc(fName, 14, MolSurf.SlogP_VSA12)
+
+
+class TestCase_python(unittest.TestCase):
+  """ Test the Python implementation of the various descriptors """
+
+  def test_pyTPSA(self):
+    for data in TestCase.readNCI_200():
+      molPy = Chem.MolFromSmiles(data.smiles)
+      self.assertAlmostEqual(MolSurf.TPSA(data.mol), MolSurf._pyTPSA(molPy))
+
+  def test_pyLabuteASA(self):
+    for data in TestCase.readNCI_200():
+      molPy = Chem.MolFromSmiles(data.smiles)
+      self.assertAlmostEqual(MolSurf.LabuteASA(data.mol), MolSurf.pyLabuteASA(molPy))
+
+  def test_pyPEOE_VSA_(self):
+    for data in TestCase.readNCI_200():
+      molPy = Chem.MolFromSmiles(data.smiles)
+      for calcC, calcPy in zip(MolSurf.PEOE_VSA_(data.mol), MolSurf.pyPEOE_VSA_(molPy,
+                                                                                force=False)):
+        self.assertAlmostEqual(calcC, calcPy)
+
+  def test_pySlogP_VSA_(self):
+    for data in TestCase.readNCI_200():
+      molPy = Chem.MolFromSmiles(data.smiles)
+      for calcC, calcPy in zip(
+          MolSurf.SlogP_VSA_(data.mol), MolSurf.pySlogP_VSA_(molPy, force=False)):
+        self.assertAlmostEqual(calcC, calcPy)
+
+  def test_pySMR_VSA_(self):
+    for data in TestCase.readNCI_200():
+      molPy = Chem.MolFromSmiles(data.smiles)
+      for calcC, calcPy in zip(MolSurf.SMR_VSA_(data.mol), MolSurf.pySMR_VSA_(molPy, force=False)):
+        self.assertAlmostEqual(calcC, calcPy)
+
+  def test_pyLabuteHelper(self):
+    for data in TestCase.readNCI_200():
+      molPy = Chem.MolFromSmiles(data.smiles)
+      for calcC, calcPy in zip(MolSurf._LabuteHelper(data.mol), MolSurf._pyLabuteHelper(molPy)):
+        self.assertAlmostEqual(calcC, calcPy)
+
+
+def readPSAtestData(filename):
+  """ Read test data for PSA method from file """
+  with open(filename, 'r') as f:
+    for lineNo, line in enumerate(f, 1):
+      if line[0] == '#':
+        continue
+      smiles, expected = line.strip().split(',')
+      mol = Chem.MolFromSmiles(smiles)
+      if not mol:
+        raise AssertionError('molecule construction failed on line %d' % lineNo)
+      yield TestData(lineNo, smiles, mol, float(expected))
+
+
+def readRegressionData(filename, col):
+  """ Return entries form regression dataset.
+  Returns the line number, smiles, molecule, and the value found in column col
+  """
+  with open(os.path.join(RDConfig.RDCodeDir, 'Chem', 'test_data', filename), 'r') as inF:
+    for lineNum, line in enumerate(inF, 1):
+      if line[0] == '#':
+        continue
+      splitL = line.split(',')
+      smi = splitL[0]
+      mol = Chem.MolFromSmiles(smi)
+      if mol is None:
+        raise AssertionError('line %d, smiles: %s' % (lineNum, smi))
+      expected = float(splitL[col])
+      yield TestData(lineNum, smi, mol, expected)
+
+
+if __name__ == '__main__':  # pragma: nocover
+  import argparse
+  import sys
+  parser = argparse.ArgumentParser()
+  parser.add_argument('-l', default=False, action='store_true', dest='doLong')
+  args = parser.parse_args()
+  doLong = args.doLong
+
+  # Remove the -l flag if present so that it isn't interpreted by unittest.main()
+  if '-l' in sys.argv:
+    sys.argv.remove('-l')
   unittest.main()

--- a/rdkit/Chem/UnitTestSurf.py
+++ b/rdkit/Chem/UnitTestSurf.py
@@ -249,6 +249,6 @@ if __name__ == '__main__':  # pragma: nocover
   doLong = args.doLong
 
   # Remove the -l flag if present so that it isn't interpreted by unittest.main()
-  if 'l' in sys.argv:
+  if '-l' in sys.argv:
     sys.argv.remove('-l')
   unittest.main()


### PR DESCRIPTION
Reviewed the unit test code:

- replaced assert with unittest assert methods
- Enable manually excluded longer test to be included using a command line flag

Extracted the progress reporting into a separate class. The intention was to reduce the amount of boilerplate code dedicated to this to help focusing on the actual tasks.

Also fixed bugs in three more unit test files for the handling of long tests.