### PR TITLE
Add support for custom atom labels to C++ drawing code

### DIFF
--- a/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
@@ -282,8 +282,9 @@ void MolDraw2D::drawMolecule(const ROMol &mol,
     while (atom != end_atom) {
       const Atom *at1 = mol[*atom].get();
       ++atom;
-      if (drawOptions().atomLabels.find(at1->getIdx()) !=
-          drawOptions().atomLabels.end()) {
+      if (at1->hasProp(common_properties::atomLabel) ||
+          drawOptions().atomLabels.find(at1->getIdx()) !=
+              drawOptions().atomLabels.end()) {
         // skip dummies that explicitly have a label provided
         continue;
       }
@@ -1266,6 +1267,8 @@ pair<string, MolDraw2D::OrientType> MolDraw2D::getAtomSymbolAndOrientation(
     // specified labels are trump: no matter what else happens we will show
     // them.
     symbol = drawOptions().atomLabels.find(atom.getIdx())->second;
+  } else if (atom.hasProp(common_properties::atomLabel)) {
+    symbol = atom.getProp<std::string>(common_properties::atomLabel);
   } else if (drawOptions().dummiesAreAttachments && atom.getAtomicNum() == 0 &&
              atom.getDegree() == 1) {
     symbol = "";

--- a/Code/GraphMol/MolDraw2D/test1.cpp
+++ b/Code/GraphMol/MolDraw2D/test1.cpp
@@ -1893,6 +1893,40 @@ M  END";
   std::cerr << " Done" << std::endl;
 }
 
+void testGithub1322() {
+  std::cout << " ----------------- Testing github 1322: add custom atom labels"
+            << std::endl;
+  {
+    std::string smiles = "CCC[Se]";  // made up
+    RWMol *m1 = SmilesToMol(smiles);
+    TEST_ASSERT(m1);
+    MolDraw2DUtils::prepareMolForDrawing(*m1);
+
+    {
+      MolDraw2DSVG drawer(500, 200, 250, 200);
+      drawer.drawMolecule(*m1, "m1");
+      drawer.finishDrawing();
+      std::string text = drawer.getDrawingText();
+      TEST_ASSERT(text.find("Se") != std::string::npos);
+    }
+    {
+      m1->getAtomWithIdx(3)->setProp(common_properties::atomLabel,
+                                     "customlabel");
+      MolDraw2DSVG drawer(500, 200, 250, 200);
+      drawer.drawMolecule(*m1, "m1");
+      drawer.finishDrawing();
+      std::string text = drawer.getDrawingText();
+      std::ofstream outs("test1322_1.svg");
+      outs << text;
+      outs.flush();
+      TEST_ASSERT(text.find("Se") == std::string::npos);
+      TEST_ASSERT(text.find("customlabel") != std::string::npos);
+    }
+    delete m1;
+  }
+  std::cerr << " Done" << std::endl;
+}
+
 int main() {
   RDLog::InitLogs();
 #if 1
@@ -1924,4 +1958,5 @@ int main() {
   testGithub1035();
 #endif
   testGithub1271();
+  testGithub1322();
 }


### PR DESCRIPTION
Fixes #1322
Uses the `atomLabel` property