### PR TITLE
add "RDKit" to the beginning of all library names

### DIFF
--- a/Code/cmake/Modules/RDKitUtils.cmake
+++ b/Code/cmake/Modules/RDKitUtils.cmake
@@ -56,27 +56,30 @@ macro(rdkit_library)
         INSTALL(TARGETS ${RDKLIB_NAME}_static EXPORT ${RDKit_EXPORTED_TARGETS}
                 DESTINATION ${RDKit_LibDir}/${RDKLIB_DEST}
                 COMPONENT dev )
+        set_target_properties(${RDKLIB_NAME}_static PROPERTIES
+                              OUTPUT_NAME "RDKit${RDKLIB_NAME}_static")
+
       endif(RDK_INSTALL_STATIC_LIBS)
     IF(RDKLIB_LINK_LIBRARIES)
       target_link_libraries(${RDKLIB_NAME} ${RDKLIB_LINK_LIBRARIES})
     ENDIF(RDKLIB_LINK_LIBRARIES)
   endif(MSVC)
   if(WIN32)
-    set_target_properties(${RDKLIB_NAME} PROPERTIES 
-                          OUTPUT_NAME "${RDKLIB_NAME}" 
+    set_target_properties(${RDKLIB_NAME} PROPERTIES
+                          OUTPUT_NAME "RDKit${RDKLIB_NAME}"
                           VERSION "${RDKit_ABI}.${RDKit_Year}.${RDKit_Month}")
   else(WIN32)
-    set_target_properties(${RDKLIB_NAME} PROPERTIES 
-                          OUTPUT_NAME ${RDKLIB_NAME} 
-                          VERSION ${RDKit_VERSION} 
+    set_target_properties(${RDKLIB_NAME} PROPERTIES
+                          OUTPUT_NAME "RDKit${RDKLIB_NAME}"
+                          VERSION ${RDKit_VERSION}
                           SOVERSION ${RDKit_ABI} )
-  endif(WIN32)			  
-  set_target_properties(${RDKLIB_NAME} PROPERTIES 
+  endif(WIN32)
+  set_target_properties(${RDKLIB_NAME} PROPERTIES
                         ARCHIVE_OUTPUT_DIRECTORY ${RDK_ARCHIVE_OUTPUT_DIRECTORY}
                         RUNTIME_OUTPUT_DIRECTORY ${RDK_RUNTIME_OUTPUT_DIRECTORY}
                         LIBRARY_OUTPUT_DIRECTORY ${RDK_LIBRARY_OUTPUT_DIRECTORY})
 endmacro(rdkit_library)
-  
+
 macro(rdkit_headers)
   if (NOT RDK_INSTALL_INTREE)
     PARSE_ARGUMENTS(RDKHDR
@@ -105,14 +108,14 @@ if(WIN32)
                           LIBRARY_OUTPUT_DIRECTORY
                           ${RDK_PYTHON_OUTPUT_DIRECTORY}/${RDKPY_DEST})
 else(WIN32)
-    set_target_properties(${RDKPY_NAME} PROPERTIES 
+    set_target_properties(${RDKPY_NAME} PROPERTIES
                           LIBRARY_OUTPUT_DIRECTORY
                           ${RDK_PYTHON_OUTPUT_DIRECTORY}/${RDKPY_DEST})
-endif(WIN32)  
-    target_link_libraries(${RDKPY_NAME} ${RDKPY_LINK_LIBRARIES} 
+endif(WIN32)
+    target_link_libraries(${RDKPY_NAME} ${RDKPY_LINK_LIBRARIES}
                           ${PYTHON_LIBRARIES} ${Boost_LIBRARIES} )
 
-    INSTALL(TARGETS ${RDKPY_NAME} 
+    INSTALL(TARGETS ${RDKPY_NAME}
             LIBRARY DESTINATION ${RDKit_PythonDir}/${RDKPY_DEST})
   endif(RDK_BUILD_PYTHON_WRAPPERS)
 endmacro(rdkit_python_extension)


### PR DESCRIPTION
This is connected with #1036, there's a bunch of discussion there.
The change is simple and a good one to make, thought it will break other people's build scripts.
I've confirmed that builds and tests work on linux, the mac, and windows, but having others try would be good.
