### PR TITLE
Fixes error when randomizing charged molecules

### DIFF
--- a/rdkit/Chem/Randomize.py
+++ b/rdkit/Chem/Randomize.py
@@ -13,6 +13,9 @@ from rdkit.six.moves import range
 from rdkit import Chem
 
 
+def grouped(iterable, n):
+  return zip(*[iter(iterable)]*n)
+
 def RandomizeMolBlock(molB):
   splitB = molB.split('\n')
   res = []
@@ -49,11 +52,12 @@ def RandomizeMolBlock(molB):
       line = splitB[i]
       chargeline = line.split()
       col = line[0:9]
-      for i in range(3,len(chargeline),2):
-        col = col +"%4i%4i"%(order.index(int(chargeline[i])-1)+1,int(chargeline[i+1])+1)
-      #print col
+      for atom, charge in grouped(chargeline[3:], 2):
+        atom = order.index(int(atom) - 1) + 1
+        charge = int(charge)
+        col += "%4i%4i" % (atom, charge)
       res.append(col)
-    
+
   res.append('M  END')
   return '\n'.join(res)
 

--- a/rdkit/Chem/Randomize.py
+++ b/rdkit/Chem/Randomize.py
@@ -43,6 +43,17 @@ def RandomizeMolBlock(molB):
     inL = '% 3d% 3d' % (idx1 + 1, idx2 + 1) + inL[6:]
     res.append(inL)
     idx += 1
+  #Charges
+  for i in range(idx, len(splitB)):
+    if splitB[i][0:6] == "M  CHG":
+      line = splitB[i]
+      chargeline = line.split()
+      col = line[0:9]
+      for i in range(3,len(chargeline),2):
+        col = col +"%4i%4i"%(order.index(int(chargeline[i])-1)+1,int(chargeline[i+1])+1)
+      #print col
+      res.append(col)
+    
   res.append('M  END')
   return '\n'.join(res)
 

--- a/rdkit/Chem/UnitTestRandomize.py
+++ b/rdkit/Chem/UnitTestRandomize.py
@@ -13,6 +13,7 @@ import unittest
 
 from rdkit import Chem
 from rdkit.Chem import Randomize
+import random
 
 
 def MolBlockToSmiles(mb):
@@ -21,17 +22,20 @@ def MolBlockToSmiles(mb):
 class TestCase(unittest.TestCase):
 
   def test1(self):
-    smiles = ["C[N+](C)(C)C", "CC(=O)[O-]", "[NH3+]CC(=O)[O-]",'[Cl-].[Cl-].[Mg+2]']
+    random.seed(42)
+    smiles = ["C[N+](C)(C)C", "CC(=O)[O-]", "[NH3+]CC(=O)[O-]",'[Cl-].[Cl-].[Mg+2]','[O-][O-]','[O-]C[O-]','[Na+].[Na+].[O-2]']
     msg = "Could not randomize charged mol %s"
-    for smi in smiles:
-      mb = Chem.MolToMolBlock(Chem.MolFromSmiles(smi))
-      rmb = Randomize.RandomizeMolBlock(mb)
-      #Test if fails conversion
-      self.assertNotEqual(None,Chem.MolFromMolBlock(rmb), msg=msg % (smi))
-      #Test if canonical Smile is same
-      self.assertEqual(MolBlockToSmiles(mb),MolBlockToSmiles(mb),msg=msg % (smi))
+    for i in range(10):
+      for smi in smiles:
+        mb = Chem.MolToMolBlock(Chem.MolFromSmiles(smi))
+        rmb = Randomize.RandomizeMolBlock(mb)
+        #Test if fails conversion
+        self.assertNotEqual(None,Chem.MolFromMolBlock(rmb), msg=msg % (smi))
+        #Test if canonical Smile is same
+        self.assertEqual(MolBlockToSmiles(mb),MolBlockToSmiles(mb),msg=msg % (smi))
 
   def test2(self):
+    random.seed(42)
     smiles = ['CON', 'c1ccccn1', 'C/C=C/F']
     msg = "\nRef: %s\n   : %s"
     nReps = 10

--- a/rdkit/Chem/UnitTestRandomize.py
+++ b/rdkit/Chem/UnitTestRandomize.py
@@ -1,0 +1,47 @@
+#
+#  Copyright (C) 2017 Esben Jannik Bjerrum
+#
+#   @@ All Rights Reserved @@
+#  This file is part of the RDKit.
+#  The contents are covered by the terms of the BSD license
+#  which is included in the file license.txt, found at the root
+#  of the RDKit source tree.
+#
+from __future__ import print_function
+
+import unittest
+
+from rdkit import Chem
+from rdkit.Chem import Randomize
+
+
+def MolBlockToSmiles(mb):
+  return Chem.MolToSmiles(Chem.MolFromMolBlock(mb))
+
+class TestCase(unittest.TestCase):
+
+  def test1(self):
+    smiles = ["C[N+](C)(C)C", "CC(=O)[O-]", "[NH3+]CC(=O)[O-]",'[Cl-].[Cl-].[Mg+2]']
+    msg = "Could not randomize charged mol %s"
+    for smi in smiles:
+      mb = Chem.MolToMolBlock(Chem.MolFromSmiles(smi))
+      rmb = Randomize.RandomizeMolBlock(mb)
+      #Test if fails conversion
+      self.assertNotEqual(None,Chem.MolFromMolBlock(rmb), msg=msg % (smi))
+      #Test if canonical Smile is same
+      self.assertEqual(MolBlockToSmiles(mb),MolBlockToSmiles(mb),msg=msg % (smi))
+
+  def test2(self):
+    smiles = ['CON', 'c1ccccn1', 'C/C=C/F']
+    msg = "\nRef: %s\n   : %s"
+    nReps = 10
+    for smi in smiles:
+      mol = Chem.MolFromSmiles(smi)
+      refSmi = Chem.MolToSmiles(mol, False)
+      for i in range(nReps):
+        m2 = Randomize.RandomizeMol(mol)
+        randomizedsmi = Chem.MolToSmiles(m2, False)
+        self.assertEqual(refSmi, randomizedsmi, msg=msg % (refSmi, smi))
+
+if __name__ == '__main__':  # pragma: nocover
+  unittest.main()

--- a/rdkit/Chem/test_list.py
+++ b/rdkit/Chem/test_list.py
@@ -23,6 +23,7 @@ tests = [
   ("python", "UnitTestPeriodicTable.py", {}),
   ("python", "UnitTestDocTestsChem.py", {}),
   ("python", "UnitTestFeatFinderCLI.py", {}),
+  ("python", "UnitTestRandomize.py", {}),
   ("python", "test_list.py", {'dir': 'AtomPairs'}),
   ("python", "test_list.py", {'dir': 'ChemUtils'}),
   ("python", "test_list.py", {'dir': 'EState'}),


### PR DESCRIPTION
Fixes error when randomizing charged molecules as the one below:

from rdkit import Chem
from rdkit.Chem import Randomize

#Charged molecule
mol = Chem.MolFromSmiles('C[N+](C)(C)C')

#Get molblock and randomize atom order
mb = Chem.MolToMolBlock(mol)
rmb = Randomize.RandomizeMolBlock(mb)

#Randomized MolBlock does not contain charge information
#Conversion back to molecule fails
rmol = Chem.MolFromMolBlock(rmb)
[08:36:58] Explicit valence for atom # 0 N, 4, is greater than permitted