### PR TITLE
Fix/github1366

### DIFF
--- a/Code/GraphMol/AtomIterators.cpp
+++ b/Code/GraphMol/AtomIterators.cpp
@@ -81,8 +81,6 @@ int AtomIterator_<Atom_, Mol_>::operator-(
 template <class Atom_, class Mol_>
 Atom_ *AtomIterator_<Atom_, Mol_>::operator*() const {
   PRECONDITION(_mol != NULL, "no molecule");
-  if (_max > _mol->getNumAtoms())
-    throw std::runtime_error("invalid AtomIterator dereferenced");
   RANGE_CHECK(0, _pos, _max - 1);
   return (*_mol)[_pos].get();
 }
@@ -90,8 +88,6 @@ Atom_ *AtomIterator_<Atom_, Mol_>::operator*() const {
 template <class Atom_, class Mol_>
 Atom_ *AtomIterator_<Atom_, Mol_>::operator[](const int which) const {
   PRECONDITION(_mol != NULL, "no molecule");
-  if (_max > _mol->getNumAtoms())
-    throw std::runtime_error("invalid AtomIterator access");
   RANGE_CHECK(0, which, _max - 1);
   return (*_mol)[which].get();
 }

--- a/Code/GraphMol/AtomIterators.cpp
+++ b/Code/GraphMol/AtomIterators.cpp
@@ -82,6 +82,8 @@ int AtomIterator_<Atom_, Mol_>::operator-(
 template <class Atom_, class Mol_>
 Atom_ *AtomIterator_<Atom_, Mol_>::operator*() const {
   PRECONDITION(_mol != NULL, "no molecule");
+  if (_max > _mol->getNumAtoms())
+    throw ValueErrorException("invalid AtomIterator dereferenced");
   RANGE_CHECK(0, _pos, _max - 1);
   return (*_mol)[_pos].get();
 }
@@ -89,6 +91,8 @@ Atom_ *AtomIterator_<Atom_, Mol_>::operator*() const {
 template <class Atom_, class Mol_>
 Atom_ *AtomIterator_<Atom_, Mol_>::operator[](const int which) const {
   PRECONDITION(_mol != NULL, "no molecule");
+  if (_max > _mol->getNumAtoms())
+    throw ValueErrorException("invalid AtomIterator access");
   RANGE_CHECK(0, which, _max - 1);
   return (*_mol)[which].get();
 }
@@ -213,8 +217,8 @@ Atom_ *HeteroatomIterator_<Atom_, Mol_>::operator*() const {
 }
 // pre-increment
 template <class Atom_, class Mol_>
-HeteroatomIterator_<Atom_, Mol_> &HeteroatomIterator_<Atom_, Mol_>::
-operator++() {
+HeteroatomIterator_<Atom_, Mol_>
+    &HeteroatomIterator_<Atom_, Mol_>::operator++() {
   _pos = _findNext(_pos + 1);
   return *this;
 }
@@ -227,8 +231,8 @@ HeteroatomIterator_<Atom_, Mol_> HeteroatomIterator_<Atom_, Mol_>::operator++(
 }
 // pre-decrement
 template <class Atom_, class Mol_>
-HeteroatomIterator_<Atom_, Mol_> &HeteroatomIterator_<Atom_, Mol_>::
-operator--() {
+HeteroatomIterator_<Atom_, Mol_>
+    &HeteroatomIterator_<Atom_, Mol_>::operator--() {
   _pos = _findPrev(_pos - 1);
   return *this;
 }
@@ -292,8 +296,8 @@ AromaticAtomIterator_<Atom_, Mol_>::AromaticAtomIterator_(
 }
 
 template <class Atom_, class Mol_>
-AromaticAtomIterator_<Atom_, Mol_> &AromaticAtomIterator_<Atom_, Mol_>::
-operator=(const ThisType &other) {
+AromaticAtomIterator_<Atom_, Mol_>
+    &AromaticAtomIterator_<Atom_, Mol_>::operator=(const ThisType &other) {
   _mol = other._mol;
   _end = other._end;
   _pos = other._pos;
@@ -318,8 +322,8 @@ Atom_ *AromaticAtomIterator_<Atom_, Mol_>::operator*() const {
 }
 // pre-increment
 template <class Atom_, class Mol_>
-AromaticAtomIterator_<Atom_, Mol_> &AromaticAtomIterator_<Atom_, Mol_>::
-operator++() {
+AromaticAtomIterator_<Atom_, Mol_>
+    &AromaticAtomIterator_<Atom_, Mol_>::operator++() {
   _pos = _findNext(_pos + 1);
   return *this;
 }
@@ -332,8 +336,8 @@ operator++(int) {
 }
 // pre-decrement
 template <class Atom_, class Mol_>
-AromaticAtomIterator_<Atom_, Mol_> &AromaticAtomIterator_<Atom_, Mol_>::
-operator--() {
+AromaticAtomIterator_<Atom_, Mol_>
+    &AromaticAtomIterator_<Atom_, Mol_>::operator--() {
   _pos = _findPrev(_pos - 1);
   return *this;
 }
@@ -552,8 +556,8 @@ Atom_ *MatchingAtomIterator_<Atom_, Mol_>::operator*() const {
 }
 // pre-increment
 template <class Atom_, class Mol_>
-MatchingAtomIterator_<Atom_, Mol_> &MatchingAtomIterator_<Atom_, Mol_>::
-operator++() {
+MatchingAtomIterator_<Atom_, Mol_>
+    &MatchingAtomIterator_<Atom_, Mol_>::operator++() {
   _pos = _findNext(_pos + 1);
   return *this;
 }
@@ -566,8 +570,8 @@ operator++(int) {
 }
 // pre-decrement
 template <class Atom_, class Mol_>
-MatchingAtomIterator_<Atom_, Mol_> &MatchingAtomIterator_<Atom_, Mol_>::
-operator--() {
+MatchingAtomIterator_<Atom_, Mol_>
+    &MatchingAtomIterator_<Atom_, Mol_>::operator--() {
   _pos = _findPrev(_pos - 1);
   return *this;
 }

--- a/Code/GraphMol/AtomIterators.cpp
+++ b/Code/GraphMol/AtomIterators.cpp
@@ -1,6 +1,5 @@
-// $Id$
 //
-//  Copyright (C) 2002-2006 Greg Landrum and Rational Discovery LLC
+//  Copyright (C) 2002-2017 Greg Landrum and Rational Discovery LLC
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -83,7 +82,7 @@ template <class Atom_, class Mol_>
 Atom_ *AtomIterator_<Atom_, Mol_>::operator*() const {
   PRECONDITION(_mol != NULL, "no molecule");
   if (_max > _mol->getNumAtoms())
-    throw ValueErrorException("invalid AtomIterator dereferenced");
+    throw std::runtime_error("invalid AtomIterator dereferenced");
   RANGE_CHECK(0, _pos, _max - 1);
   return (*_mol)[_pos].get();
 }
@@ -92,7 +91,7 @@ template <class Atom_, class Mol_>
 Atom_ *AtomIterator_<Atom_, Mol_>::operator[](const int which) const {
   PRECONDITION(_mol != NULL, "no molecule");
   if (_max > _mol->getNumAtoms())
-    throw ValueErrorException("invalid AtomIterator access");
+    throw std::runtime_error("invalid AtomIterator access");
   RANGE_CHECK(0, which, _max - 1);
   return (*_mol)[which].get();
 }

--- a/Code/GraphMol/AtomIterators.cpp
+++ b/Code/GraphMol/AtomIterators.cpp
@@ -81,12 +81,14 @@ int AtomIterator_<Atom_, Mol_>::operator-(
 // dereference
 template <class Atom_, class Mol_>
 Atom_ *AtomIterator_<Atom_, Mol_>::operator*() const {
+  PRECONDITION(_mol != NULL, "no molecule");
   RANGE_CHECK(0, _pos, _max - 1);
   return (*_mol)[_pos].get();
 }
 // random access
 template <class Atom_, class Mol_>
 Atom_ *AtomIterator_<Atom_, Mol_>::operator[](const int which) const {
+  PRECONDITION(_mol != NULL, "no molecule");
   RANGE_CHECK(0, which, _max - 1);
   return (*_mol)[which].get();
 }
@@ -206,6 +208,7 @@ bool HeteroatomIterator_<Atom_, Mol_>::operator!=(const ThisType &other) const {
 
 template <class Atom_, class Mol_>
 Atom_ *HeteroatomIterator_<Atom_, Mol_>::operator*() const {
+  PRECONDITION(_mol != NULL, "no molecule");
   return (*_mol)[_pos].get();
 }
 // pre-increment
@@ -310,6 +313,7 @@ bool AromaticAtomIterator_<Atom_, Mol_>::operator!=(
 
 template <class Atom_, class Mol_>
 Atom_ *AromaticAtomIterator_<Atom_, Mol_>::operator*() const {
+  PRECONDITION(_mol != NULL, "no molecule");
   return (*_mol)[_pos].get();
 }
 // pre-increment

--- a/Code/GraphMol/AtomIterators.h
+++ b/Code/GraphMol/AtomIterators.h
@@ -62,7 +62,7 @@ class AtomIterator_ {
   ThisType &operator--();
   ThisType operator--(int);
 
-  // private:
+ private:
   int _pos, _max;
   Mol_ *_mol;
 };

--- a/Code/GraphMol/Wrap/Mol.cpp
+++ b/Code/GraphMol/Wrap/Mol.cpp
@@ -1,6 +1,5 @@
-// $Id$
-//
-//  Copyright (C) 2003-2009 Greg Landrum and Rational Discovery LLC
+
+//  Copyright (C) 2003-2017 Greg Landrum and Rational Discovery LLC
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -190,19 +189,20 @@ void MolDebug(const ROMol &mol, bool useStdout) {
 
 // FIX: we should eventually figure out how to do iterators properly
 AtomIterSeq *MolGetAtoms(ROMol *mol) {
-  AtomIterSeq *res = new AtomIterSeq(mol->beginAtoms(), mol->endAtoms());
+  AtomIterSeq *res = new AtomIterSeq(mol->beginAtoms(), mol->endAtoms(),
+                                     AtomCountFunctor(*mol));
   return res;
 }
 QueryAtomIterSeq *MolGetAromaticAtoms(ROMol *mol) {
   QueryAtom *qa = new QueryAtom();
   qa->setQuery(makeAtomAromaticQuery());
-  QueryAtomIterSeq *res =
-      new QueryAtomIterSeq(mol->beginQueryAtoms(qa), mol->endQueryAtoms());
+  QueryAtomIterSeq *res = new QueryAtomIterSeq(
+      mol->beginQueryAtoms(qa), mol->endQueryAtoms(), AtomCountFunctor(*mol));
   return res;
 }
 QueryAtomIterSeq *MolGetQueryAtoms(ROMol *mol, QueryAtom *qa) {
-  QueryAtomIterSeq *res =
-      new QueryAtomIterSeq(mol->beginQueryAtoms(qa), mol->endQueryAtoms());
+  QueryAtomIterSeq *res = new QueryAtomIterSeq(
+      mol->beginQueryAtoms(qa), mol->endQueryAtoms(), AtomCountFunctor(*mol));
   return res;
 }
 
@@ -212,7 +212,8 @@ QueryAtomIterSeq *MolGetQueryAtoms(ROMol *mol, QueryAtom *qa) {
 //  return res;
 //}
 BondIterSeq *MolGetBonds(ROMol *mol) {
-  BondIterSeq *res = new BondIterSeq(mol->beginBonds(), mol->endBonds());
+  BondIterSeq *res = new BondIterSeq(mol->beginBonds(), mol->endBonds(),
+                                     BondCountFunctor(*mol));
   return res;
 }
 
@@ -281,7 +282,8 @@ struct mol_wrapper {
     python::register_exception_translator<ConformerException>(
         &rdExceptionTranslator);
 
-    python::enum_<RDKit::PicklerOps::PropertyPickleOptions>("PropertyPickleOptions")
+    python::enum_<RDKit::PicklerOps::PropertyPickleOptions>(
+        "PropertyPickleOptions")
         .value("NoProps", RDKit::PicklerOps::NoProps)
         .value("MolProps", RDKit::PicklerOps::MolProps)
         .value("AtomProps", RDKit::PicklerOps::AtomProps)
@@ -293,11 +295,13 @@ struct mol_wrapper {
         .export_values();
     ;
 
-    python::def("GetDefaultPickleProperties", MolPickler::getDefaultPickleProperties,
+    python::def("GetDefaultPickleProperties",
+                MolPickler::getDefaultPickleProperties,
                 "Get the current global mol pickler options.");
-    python::def("SetDefaultPickleProperties", MolPickler::setDefaultPickleProperties,
+    python::def("SetDefaultPickleProperties",
+                MolPickler::setDefaultPickleProperties,
                 "Set the current global mol pickler options.");
-    
+
     python::class_<ROMol, ROMOL_SPTR, boost::noncopyable>(
         "Mol", molClassDoc.c_str(),
         python::init<>("Constructor, takes no arguments"))
@@ -644,8 +648,9 @@ struct mol_wrapper {
              "Returns a binary string representation of the molecule.\n")
         .def("ToBinary", MolToBinaryWithProps,
              (python::arg("mol"), python::arg("propertyFlags")),
-             "Returns a binary string representation of the molecule pickling the "
-              "specified properties.\n")
+             "Returns a binary string representation of the molecule pickling "
+             "the "
+             "specified properties.\n")
 
         .def("GetRingInfo", &ROMol::getRingInfo,
              python::return_value_policy<python::reference_existing_object>(),

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -4227,7 +4227,7 @@ CAS<~>
     ats = iter(mol.GetAtoms())
     atom = next(ats)
     mol.RemoveAtom(atom.GetIdx())
-    self.assertRaises(ValueError,next,ats)
+    self.assertRaises(RuntimeError,next,ats)
 
 
 if __name__ == '__main__':

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -4229,6 +4229,13 @@ CAS<~>
     mol.RemoveAtom(atom.GetIdx())
     self.assertRaises(RuntimeError,next,ats)
 
+    mol = Chem.MolFromSmiles('[*]C[*]')
+    mol = Chem.RWMol(mol)
+    bonds = iter(mol.GetBonds())
+    bond = next(bonds)
+    mol.RemoveBond(bond.GetBeginAtomIdx(),bond.GetEndAtomIdx())
+    self.assertRaises(RuntimeError,next,bonds)
+
 
 if __name__ == '__main__':
   if "RDTESTCASE" in os.environ:

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -4221,7 +4221,13 @@ CAS<~>
     self.assertEqual(m.GetAtomWithIdx(0).GetHybridization().name,'SP3')
     self.assertEqual(m.GetAtomWithIdx(4).GetHybridization().name,'S')
 
-
+  def testGithub1366(self):
+    mol = Chem.MolFromSmiles('[*]C[*]')
+    mol = Chem.RWMol(mol)
+    ats = iter(mol.GetAtoms())
+    atom = next(ats)
+    mol.RemoveAtom(atom.GetIdx())
+    self.assertRaises(ValueError,next,ats)
 
 
 if __name__ == '__main__':

--- a/Code/GraphMol/Wrap/seqs.hpp
+++ b/Code/GraphMol/Wrap/seqs.hpp
@@ -11,69 +11,108 @@
 #include <RDBoost/python.h>
 namespace python = boost::python;
 
-namespace RDKit{
-  // Note: T1 should be some iterator type,
-  //       T2 is the value when we dereference T
-  template<class T1, class T2> class ReadOnlySeq{
-  private:
-    T1 _start,_end,_pos;
-    int _size;
-  public:
-    //ReadOnlySeq() {};
-    ~ReadOnlySeq() {
-      //std::cerr<<" GC: "<<this<<std::endl;
-    }
-    ReadOnlySeq(T1 start,T1 end) : _start(start), _end(end), _pos(start), _size(-1) {};
-    ReadOnlySeq(const ReadOnlySeq<T1,T2> &other) :  _start(other._start), _end(other._end),
-                                                    _pos(other._pos), _size(other._size) {};
-    void reset() {
-      //std::cerr << "**** reset ****" << this<< std::endl;
-      _pos = _start;
-    }
-    ReadOnlySeq<T1,T2> *__iter__() {
-      //std::cerr << "**** ITER ****" << this << std::endl;
-      reset();
-      //std::cerr << "  finish ****" << this << std::endl;
-      return this;
-    };
-    T2 next() {
-      //std::cerr << "\tnext: " << _pos._pos << " " << _end._pos << std::endl;
-      if(_pos == _end){
-	PyErr_SetString(PyExc_StopIteration,"End of sequence hit");
-	throw python::error_already_set();
-      }      
-      T2 res = *_pos;
-      ++_pos;
-      return res;
-    }
-    T2 get_item(int which) {
-      //std::cerr << "get_item: " <<which<< std::endl;
-      if(which >= len() ){
-	PyErr_SetString(PyExc_IndexError,"End of sequence hit");
-	throw python::error_already_set();
-      }
-      T1 it=_start;
-      for(int i=0;i<which;i++){
-	++it;
-      }
-      return *it;
-    }
-    int len() {
-      //std::cerr << "len " << std::endl;
-      if(_size<0){
-	_size = 0;
-	for(T1 tmp=_start;tmp!=_end;tmp++){
-	  //std::cerr << "\tincr: "  <<  std::endl;
-	  _size++;
-	}
-      }
-      //std::cerr << "\tret" << std::endl;
-      return _size;
-    }
-  };
+namespace RDKit {
 
-  typedef ReadOnlySeq<ROMol::AtomIterator,Atom*> AtomIterSeq;
-  typedef ReadOnlySeq<ROMol::QueryAtomIterator,Atom*> QueryAtomIterSeq;
-  typedef ReadOnlySeq<ROMol::BondIterator,Bond*> BondIterSeq;
+class AtomCountFunctor {
+ private:
+  const ROMol &_mol;
+
+ public:
+  AtomCountFunctor(const ROMol &mol) : _mol(mol){};
+  unsigned int operator()() const { return _mol.getNumAtoms(); };
+};
+class BondCountFunctor {
+ private:
+  const ROMol &_mol;
+
+ public:
+  BondCountFunctor(const ROMol &mol) : _mol(mol){};
+  unsigned int operator()() const { return _mol.getNumBonds(); };
+};
+
+// Note: T1 should be some iterator type,
+//       T2 is the value when we dereference T
+template <class T1, class T2, class T3>
+class ReadOnlySeq {
+ private:
+  T1 _start, _end, _pos;
+  int _size;
+  T3 _lenFunc;
+  size_t _origLen;
+
+ public:
+  ~ReadOnlySeq() {}
+  ReadOnlySeq(T1 start, T1 end, T3 lenFunc)
+      : _start(start),
+        _end(end),
+        _pos(start),
+        _size(-1),
+        _lenFunc(lenFunc),
+        _origLen(lenFunc()){};
+  ReadOnlySeq(const ReadOnlySeq<T1, T2, T3> &other)
+      : _start(other._start),
+        _end(other._end),
+        _pos(other._pos),
+        _size(other._size),
+        _lenFunc(other._lenFunc),
+        _origLen(other._origLen){};
+  void reset() {
+    // std::cerr << "**** reset ****" << this<< std::endl;
+    _pos = _start;
+  }
+  ReadOnlySeq<T1, T2, T3> *__iter__() {
+    // std::cerr << "**** ITER ****" << this << std::endl;
+    reset();
+    // std::cerr << "  finish ****" << this << std::endl;
+    return this;
+  };
+  T2 next() {
+    // std::cerr << "\tnext: " << _pos._pos << " " << _end._pos << std::endl;
+    if (_pos == _end) {
+      PyErr_SetString(PyExc_StopIteration, "End of sequence hit");
+      throw python::error_already_set();
+    }
+    if (_lenFunc() != _origLen) {
+      PyErr_SetString(PyExc_RuntimeError, "Sequence modified during iteration");
+      throw python::error_already_set();
+    }
+    T2 res = *_pos;
+    ++_pos;
+    return res;
+  }
+  T2 get_item(int which) {
+    // std::cerr << "get_item: " <<which<< std::endl;
+    if (which >= len()) {
+      PyErr_SetString(PyExc_IndexError, "End of sequence hit");
+      throw python::error_already_set();
+    }
+    if (_lenFunc() != _origLen) {
+      PyErr_SetString(PyExc_RuntimeError, "Sequence modified during iteration");
+      throw python::error_already_set();
+    }
+    T1 it = _start;
+    for (int i = 0; i < which; i++) {
+      ++it;
+    }
+    return *it;
+  }
+  int len() {
+    // std::cerr << "len " << std::endl;
+    if (_size < 0) {
+      _size = 0;
+      for (T1 tmp = _start; tmp != _end; tmp++) {
+        // std::cerr << "\tincr: "  <<  std::endl;
+        _size++;
+      }
+    }
+    // std::cerr << "\tret" << std::endl;
+    return _size;
+  }
+};
+
+typedef ReadOnlySeq<ROMol::AtomIterator, Atom *, AtomCountFunctor> AtomIterSeq;
+typedef ReadOnlySeq<ROMol::QueryAtomIterator, Atom *, AtomCountFunctor>
+    QueryAtomIterSeq;
+typedef ReadOnlySeq<ROMol::BondIterator, Bond *, BondCountFunctor> BondIterSeq;
 }
 #endif

--- a/Code/GraphMol/itertest.cpp
+++ b/Code/GraphMol/itertest.cpp
@@ -381,42 +381,6 @@ void test8() {
   BOOST_LOG(rdInfoLog) << "test8 done" << endl;
 };
 
-void testGithub1366() {
-  {
-    string smi = "*C*";
-    RWMol *m = SmilesToMol(smi);
-    TEST_ASSERT(m);
-    TEST_ASSERT(m->getNumAtoms() == 3);
-    {
-      RWMol::AtomIterator iter = m->beginAtoms();
-      TEST_ASSERT((*iter)->getAtomicNum() == 0);
-      ++iter;
-      TEST_ASSERT((*iter)->getAtomicNum() == 6);
-      ++iter;
-      TEST_ASSERT((*iter)->getAtomicNum() == 0);
-      ++iter;
-      TEST_ASSERT(iter == m->endAtoms());
-    }
-
-    {
-      RWMol::AtomIterator iter = m->beginAtoms();
-      TEST_ASSERT((*iter)->getAtomicNum() == 0);
-      m->removeAtom((*iter)->getIdx());
-      // at this point the iterator is no longer valid.
-      bool ok = false;
-      try {
-        *iter;
-      } catch (const std::runtime_error &e) {
-        ok = true;
-      }
-      TEST_ASSERT(ok);
-    }
-    delete m;
-  }
-
-  BOOST_LOG(rdInfoLog) << "testGithub1366 done" << endl;
-};
-
 int main() {
   RDLog::InitLogs();
   test1();
@@ -428,7 +392,6 @@ int main() {
   test7();
   test8();
   testIssue263();
-  testGithub1366();
 
   return 0;
 }

--- a/Code/GraphMol/itertest.cpp
+++ b/Code/GraphMol/itertest.cpp
@@ -388,20 +388,34 @@ void testGithub1366() {
     RWMol *m = SmilesToMol(smi);
     TEST_ASSERT(m);
     TEST_ASSERT(m->getNumAtoms() == 3);
-    for (RWMol::AtomIterator iter = m->beginAtoms(); iter != m->endAtoms();
-         ++iter) {
-      if ((*iter)->getAtomicNum() == 0) {
-        std::cerr << "remove: " << (*iter)->getIdx() << std::endl;
-        m->removeAtom((*iter)->getIdx());
-      } else {
-        std::cerr << "keep: " << (*iter)->getIdx() << std::endl;
-      }
+    {
+      RWMol::AtomIterator iter = m->beginAtoms();
+      TEST_ASSERT((*iter)->getAtomicNum() == 0);
+      ++iter;
+      TEST_ASSERT((*iter)->getAtomicNum() == 6);
+      ++iter;
+      TEST_ASSERT((*iter)->getAtomicNum() == 0);
+      ++iter;
+      TEST_ASSERT(iter == m->endAtoms());
     }
-    TEST_ASSERT(m->getNumAtoms() == 1);
+
+    {
+      RWMol::AtomIterator iter = m->beginAtoms();
+      TEST_ASSERT((*iter)->getAtomicNum() == 0);
+      m->removeAtom((*iter)->getIdx());
+      // at this point the iterator is no longer valid.
+      bool ok = false;
+      try {
+        *iter;
+      } catch (const ValueErrorException &e) {
+        ok = true;
+      }
+      TEST_ASSERT(ok);
+    }
     delete m;
   }
 
-  BOOST_LOG(rdInfoLog) << "test8 done" << endl;
+  BOOST_LOG(rdInfoLog) << "testGithub1366 done" << endl;
 };
 
 int main() {

--- a/Code/GraphMol/itertest.cpp
+++ b/Code/GraphMol/itertest.cpp
@@ -1,6 +1,5 @@
-// $Id$
 //
-//  Copyright (C) 2002-2006 Greg Landrum and Rational Discovery LLC
+//  Copyright (C) 2002-2017 Greg Landrum and Rational Discovery LLC
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -407,7 +406,7 @@ void testGithub1366() {
       bool ok = false;
       try {
         *iter;
-      } catch (const ValueErrorException &e) {
+      } catch (const std::runtime_error &e) {
         ok = true;
       }
       TEST_ASSERT(ok);

--- a/Code/GraphMol/itertest.cpp
+++ b/Code/GraphMol/itertest.cpp
@@ -374,9 +374,31 @@ void test8() {
       TEST_ASSERT((*queryIt)->getIdx() == 1);
       nSeen++;
     }
-    TEST_ASSERT(nSeen = 1);
+    TEST_ASSERT(nSeen == 1);
     delete m;
     delete q;
+  }
+
+  BOOST_LOG(rdInfoLog) << "test8 done" << endl;
+};
+
+void testGithub1366() {
+  {
+    string smi = "*C*";
+    RWMol *m = SmilesToMol(smi);
+    TEST_ASSERT(m);
+    TEST_ASSERT(m->getNumAtoms() == 3);
+    for (RWMol::AtomIterator iter = m->beginAtoms(); iter != m->endAtoms();
+         ++iter) {
+      if ((*iter)->getAtomicNum() == 0) {
+        std::cerr << "remove: " << (*iter)->getIdx() << std::endl;
+        m->removeAtom((*iter)->getIdx());
+      } else {
+        std::cerr << "keep: " << (*iter)->getIdx() << std::endl;
+      }
+    }
+    TEST_ASSERT(m->getNumAtoms() == 1);
+    delete m;
   }
 
   BOOST_LOG(rdInfoLog) << "test8 done" << endl;
@@ -393,6 +415,7 @@ int main() {
   test7();
   test8();
   testIssue263();
+  testGithub1366();
 
   return 0;
 }


### PR DESCRIPTION
I think this is a better solution to the problem solved by #1374 

Instead of adding a check in the core C++ I switched it to the wrapper code. I think this makes more sense since testing C++ iterators for validity isn't idiomatic. It also allows testing of `BondIterator`s and use of a better error message. 