### PR TITLE
Fix #1227

### DIFF
--- a/Code/GraphMol/DistGeomHelpers/Embedder.cpp
+++ b/Code/GraphMol/DistGeomHelpers/Embedder.cpp
@@ -66,7 +66,8 @@ const EmbedParameters KDG(0,      // maxIterations
                           true,   // useBasicKnowledge
                           false,  // verbose
                           5.0,    // basinThresh
-                          -1.0    // pruneRmsThresh
+                          -1.0,   // pruneRmsThresh
+                          false   // onlyHeavyAtomsForRMS
                           );
 
 //! Parameters corresponding to Sereina Riniker's ETDG approach
@@ -86,7 +87,8 @@ const EmbedParameters ETDG(0,      // maxIterations
                            false,  // useBasicKnowledge
                            false,  // verbose
                            5.0,    // basinThresh
-                           -1.0    // pruneRmsThresh
+                           -1.0,   // pruneRmsThresh
+                           false   // onlyHeavyAtomsForRMS
                            );
 //! Parameters corresponding to Sereina Riniker's ETKDG approach
 const EmbedParameters ETKDG(0,      // maxIterations
@@ -105,7 +107,8 @@ const EmbedParameters ETKDG(0,      // maxIterations
                             true,   // useBasicKnowledge
                             false,  // verbose
                             5.0,    // basinThresh
-                            -1.0    // pruneRmsThresh
+                            -1.0,   // pruneRmsThresh
+                            false   // onlyHeavyAtomsForRMS
                             );
 
 bool _volumeTest(const DistGeom::ChiralSetPtr &chiralSet,
@@ -600,19 +603,23 @@ void _findChiralSets(const ROMol &mol, DistGeom::VECT_CHIRALSET &chiralCenters,
   }      // for loop over atoms
 }  // end of _findChiralSets
 
-void _fillAtomPositions(RDGeom::Point3DConstPtrVect &pts,
-                        const Conformer &conf) {
+void _fillAtomPositions(RDGeom::Point3DConstPtrVect &pts, const Conformer &conf,
+                        const ROMol &mol, bool onlyHeavyAtomsForRMS) {
   unsigned int na = conf.getNumAtoms();
   pts.clear();
   unsigned int ai;
   pts.reserve(na);
   for (ai = 0; ai < na; ++ai) {
+    // FIX: should we include D and T here?
+    if (onlyHeavyAtomsForRMS && mol.getAtomWithIdx(ai)->getAtomicNum() == 1) {
+      continue;
+    }
     pts.push_back(&conf.getAtomPos(ai));
   }
 }
 
 bool _isConfFarFromRest(const ROMol &mol, const Conformer &conf,
-                        double threshold) {
+                        double threshold, bool onlyHeavyAtomsForRMS) {
   // NOTE: it is tempting to use some triangle inequality to prune
   // conformations here but some basic testing has shown very
   // little advantage and given that the time for pruning fades in
@@ -621,7 +628,7 @@ bool _isConfFarFromRest(const ROMol &mol, const Conformer &conf,
   ROMol::ConstConformerIterator confi;
 
   RDGeom::Point3DConstPtrVect refPoints, prbPoints;
-  _fillAtomPositions(refPoints, conf);
+  _fillAtomPositions(refPoints, conf, mol, onlyHeavyAtomsForRMS);
 
   bool res = true;
   unsigned int na = conf.getNumAtoms();
@@ -630,7 +637,7 @@ bool _isConfFarFromRest(const ROMol &mol, const Conformer &conf,
   RDGeom::Transform3D trans;
   double ssr;
   for (confi = mol.beginConformers(); confi != mol.endConformers(); confi++) {
-    _fillAtomPositions(prbPoints, *(*confi));
+    _fillAtomPositions(prbPoints, *(*confi), mol, onlyHeavyAtomsForRMS);
     ssr = RDNumeric::Alignments::AlignPoints(refPoints, prbPoints, trans);
     if (ssr < ssrThres) {
       res = false;
@@ -646,13 +653,14 @@ int EmbedMolecule(ROMol &mol, unsigned int maxIterations, int seed,
                   const std::map<int, RDGeom::Point3D> *coordMap,
                   double optimizerForceTol, bool ignoreSmoothingFailures,
                   bool enforceChirality, bool useExpTorsionAnglePrefs,
-                  bool useBasicKnowledge, bool verbose, double basinThresh) {
+                  bool useBasicKnowledge, bool verbose, double basinThresh,
+                  bool onlyHeavyAtomsForRMS) {
   INT_VECT confIds;
-  EmbedMultipleConfs(mol, confIds, 1, 1, maxIterations, seed, clearConfs,
-                     useRandomCoords, boxSizeMult, randNegEig, numZeroFail,
-                     -1.0, coordMap, optimizerForceTol, ignoreSmoothingFailures,
-                     enforceChirality, useExpTorsionAnglePrefs,
-                     useBasicKnowledge, verbose, basinThresh);
+  EmbedMultipleConfs(
+      mol, confIds, 1, 1, maxIterations, seed, clearConfs, useRandomCoords,
+      boxSizeMult, randNegEig, numZeroFail, -1.0, coordMap, optimizerForceTol,
+      ignoreSmoothingFailures, enforceChirality, useExpTorsionAnglePrefs,
+      useBasicKnowledge, verbose, basinThresh, onlyHeavyAtomsForRMS);
 
   int res;
   if (confIds.size()) {
@@ -785,7 +793,7 @@ void EmbedMultipleConfs(ROMol &mol, INT_VECT &res, unsigned int numConfs,
                         double optimizerForceTol, bool ignoreSmoothingFailures,
                         bool enforceChirality, bool useExpTorsionAnglePrefs,
                         bool useBasicKnowledge, bool verbose,
-                        double basinThresh) {
+                        double basinThresh, bool onlyHeavyAtomsForRMS) {
   if (!mol.getNumAtoms()) {
     throw ValueErrorException("molecule has no atoms");
   }
@@ -941,7 +949,8 @@ void EmbedMultipleConfs(ROMol &mol, INT_VECT &res, unsigned int numConfs,
       // check if we are pruning away conformations and
       // a closeby conformation has already been chosen :
       if (pruneRmsThresh > 0.0 &&
-          !_isConfFarFromRest(mol, *conf, pruneRmsThresh)) {
+          !_isConfFarFromRest(mol, *conf, pruneRmsThresh,
+                              onlyHeavyAtomsForRMS)) {
         delete conf;
       } else {
         int confId = (int)mol.addConformer(conf, true);
@@ -960,13 +969,14 @@ INT_VECT EmbedMultipleConfs(
     const std::map<int, RDGeom::Point3D> *coordMap, double optimizerForceTol,
     bool ignoreSmoothingFailures, bool enforceChirality,
     bool useExpTorsionAnglePrefs, bool useBasicKnowledge, bool verbose,
-    double basinThresh) {
+    double basinThresh, bool onlyHeavyAtomsForRMS) {
   INT_VECT res;
-  EmbedMultipleConfs(
-      mol, res, numConfs, 1, maxIterations, seed, clearConfs, useRandomCoords,
-      boxSizeMult, randNegEig, numZeroFail, pruneRmsThresh, coordMap,
-      optimizerForceTol, ignoreSmoothingFailures, enforceChirality,
-      useExpTorsionAnglePrefs, useBasicKnowledge, verbose, basinThresh);
+  EmbedMultipleConfs(mol, res, numConfs, 1, maxIterations, seed, clearConfs,
+                     useRandomCoords, boxSizeMult, randNegEig, numZeroFail,
+                     pruneRmsThresh, coordMap, optimizerForceTol,
+                     ignoreSmoothingFailures, enforceChirality,
+                     useExpTorsionAnglePrefs, useBasicKnowledge, verbose,
+                     basinThresh, onlyHeavyAtomsForRMS);
   return res;
 }
 }  // end of namespace DGeomHelpers

--- a/Code/GraphMol/DistGeomHelpers/Embedder.cpp
+++ b/Code/GraphMol/DistGeomHelpers/Embedder.cpp
@@ -67,7 +67,7 @@ const EmbedParameters KDG(0,      // maxIterations
                           false,  // verbose
                           5.0,    // basinThresh
                           -1.0,   // pruneRmsThresh
-                          false   // onlyHeavyAtomsForRMS
+                          true    // onlyHeavyAtomsForRMS
                           );
 
 //! Parameters corresponding to Sereina Riniker's ETDG approach
@@ -88,7 +88,7 @@ const EmbedParameters ETDG(0,      // maxIterations
                            false,  // verbose
                            5.0,    // basinThresh
                            -1.0,   // pruneRmsThresh
-                           false   // onlyHeavyAtomsForRMS
+                           true    // onlyHeavyAtomsForRMS
                            );
 //! Parameters corresponding to Sereina Riniker's ETKDG approach
 const EmbedParameters ETKDG(0,      // maxIterations
@@ -108,7 +108,7 @@ const EmbedParameters ETKDG(0,      // maxIterations
                             false,  // verbose
                             5.0,    // basinThresh
                             -1.0,   // pruneRmsThresh
-                            false   // onlyHeavyAtomsForRMS
+                            true    // onlyHeavyAtomsForRMS
                             );
 
 bool _volumeTest(const DistGeom::ChiralSetPtr &chiralSet,

--- a/Code/GraphMol/DistGeomHelpers/Embedder.h
+++ b/Code/GraphMol/DistGeomHelpers/Embedder.h
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2004-2012 Greg Landrum and Rational Discovery LLC
+//  Copyright (C) 2004-2017 Greg Landrum and Rational Discovery LLC
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -8,8 +8,8 @@
 //  of the RDKit source tree.
 //
 
-#ifndef _RD_EMBEDDER_H_
-#define _RD_EMBEDDER_H_
+#ifndef RD_EMBEDDER_H_GUARD
+#define RD_EMBEDDER_H_GUARD
 
 #include <map>
 #include <Geometry/point.h>
@@ -94,6 +94,8 @@ namespace DGeomHelpers {
   \param basinThresh    set the basin threshold for the DGeom force field,
                         (this shouldn't normally be altered in client code).
 
+  \param onlyHeavyAtomsForRMS  only use the heavy atoms when doing RMS filtering
+
   \return ID of the conformations added to the molecule, -1 if the emdedding
   failed
 */
@@ -107,7 +109,7 @@ int EmbedMolecule(ROMol &mol, unsigned int maxIterations = 0, int seed = -1,
                   bool enforceChirality = true,
                   bool useExpTorsionAnglePrefs = false,
                   bool useBasicKnowledge = false, bool verbose = false,
-                  double basinThresh = 5.0);
+                  double basinThresh = 5.0, bool onlyHeavyAtomsForRMS = false);
 
 //*! Embed multiple conformations for a molecule
 /*!
@@ -196,20 +198,20 @@ int EmbedMolecule(ROMol &mol, unsigned int maxIterations = 0, int seed = -1,
   \param basinThresh    set the basin threshold for the DGeom force field,
                         (this shouldn't normally be altered in client code).
 
+  \param onlyHeavyAtomsForRMS  only use the heavy atoms when doing RMS filtering
+
 */
-void EmbedMultipleConfs(ROMol &mol, INT_VECT &res, unsigned int numConfs = 10,
-                        int numThreads = 1, unsigned int maxIterations = 30,
-                        int seed = -1, bool clearConfs = true,
-                        bool useRandomCoords = false, double boxSizeMult = 2.0,
-                        bool randNegEig = true, unsigned int numZeroFail = 1,
-                        double pruneRmsThresh = -1.0,
-                        const std::map<int, RDGeom::Point3D> *coordMap = 0,
-                        double optimizerForceTol = 1e-3,
-                        bool ignoreSmoothingFailures = false,
-                        bool enforceChirality = true,
-                        bool useExpTorsionAnglePrefs = false,
-                        bool useBasicKnowledge = false, bool verbose = false,
-                        double basinThresh = 5.0);
+void EmbedMultipleConfs(
+    ROMol &mol, INT_VECT &res, unsigned int numConfs = 10, int numThreads = 1,
+    unsigned int maxIterations = 30, int seed = -1, bool clearConfs = true,
+    bool useRandomCoords = false, double boxSizeMult = 2.0,
+    bool randNegEig = true, unsigned int numZeroFail = 1,
+    double pruneRmsThresh = -1.0,
+    const std::map<int, RDGeom::Point3D> *coordMap = 0,
+    double optimizerForceTol = 1e-3, bool ignoreSmoothingFailures = false,
+    bool enforceChirality = true, bool useExpTorsionAnglePrefs = false,
+    bool useBasicKnowledge = false, bool verbose = false,
+    double basinThresh = 5.0, bool onlyHeavyAtomsForRMS = false);
 //! \overload
 INT_VECT EmbedMultipleConfs(
     ROMol &mol, unsigned int numConfs = 10, unsigned int maxIterations = 30,
@@ -220,7 +222,7 @@ INT_VECT EmbedMultipleConfs(
     double optimizerForceTol = 1e-3, bool ignoreSmoothingFailures = false,
     bool enforceChirality = true, bool useExpTorsionAnglePrefs = false,
     bool useBasicKnowledge = false, bool verbose = false,
-    double basinThresh = 5.0);
+    double basinThresh = 5.0, bool onlyHeavyAtomsForRMS = false);
 
 //! Parameter object for controlling embedding
 /*!
@@ -294,6 +296,8 @@ INT_VECT EmbedMultipleConfs(
 
   basinThresh    set the basin threshold for the DGeom force field,
                  (this shouldn't normally be altered in client code).
+
+  onlyHeavyAtomsForRMS  only use the heavy atoms when doing RMS filtering
 */
 struct EmbedParameters {
   unsigned int maxIterations;
@@ -313,6 +317,7 @@ struct EmbedParameters {
   bool verbose;
   double basinThresh;
   double pruneRmsThresh;
+  bool onlyHeavyAtomsForRMS;
   EmbedParameters()
       : maxIterations(0),
         numThreads(1),
@@ -330,7 +335,8 @@ struct EmbedParameters {
         useBasicKnowledge(false),
         verbose(false),
         basinThresh(5.0),
-        pruneRmsThresh(-1.0){};
+        pruneRmsThresh(-1.0),
+        onlyHeavyAtomsForRMS(false){};
   EmbedParameters(unsigned int maxIterations, int numThreads, int randomSeed,
                   bool clearConfs, bool useRandomCoords, double boxSizeMult,
                   bool randNegEig, unsigned int numZeroFail,
@@ -338,7 +344,7 @@ struct EmbedParameters {
                   double optimizerForceTol, bool ignoreSmoothingFailures,
                   bool enforceChirality, bool useExpTorsionAnglePrefs,
                   bool useBasicKnowledge, bool verbose, double basinThresh,
-                  double pruneRmsThresh)
+                  double pruneRmsThresh, bool onlyHeavyAtomsForRMS)
       : maxIterations(maxIterations),
         numThreads(numThreads),
         randomSeed(randomSeed),
@@ -355,7 +361,8 @@ struct EmbedParameters {
         useBasicKnowledge(useBasicKnowledge),
         verbose(verbose),
         basinThresh(basinThresh),
-        pruneRmsThresh(pruneRmsThresh){};
+        pruneRmsThresh(pruneRmsThresh),
+        onlyHeavyAtomsForRMS(onlyHeavyAtomsForRMS){};
 };
 
 //! Parameters corresponding to Sereina Riniker's KDG approach
@@ -372,7 +379,7 @@ inline int EmbedMolecule(ROMol &mol, const EmbedParameters &params) {
       params.numZeroFail, params.coordMap, params.optimizerForceTol,
       params.ignoreSmoothingFailures, params.enforceChirality,
       params.useExpTorsionAnglePrefs, params.useBasicKnowledge, params.verbose,
-      params.basinThresh);
+      params.basinThresh, params.onlyHeavyAtomsForRMS);
 }
 inline void EmbedMultipleConfs(ROMol &mol, INT_VECT &res, unsigned int numConfs,
                                const EmbedParameters &params) {
@@ -383,7 +390,7 @@ inline void EmbedMultipleConfs(ROMol &mol, INT_VECT &res, unsigned int numConfs,
       params.pruneRmsThresh, params.coordMap, params.optimizerForceTol,
       params.ignoreSmoothingFailures, params.enforceChirality,
       params.useExpTorsionAnglePrefs, params.useBasicKnowledge, params.verbose,
-      params.basinThresh);
+      params.basinThresh, params.onlyHeavyAtomsForRMS);
 }
 inline INT_VECT EmbedMultipleConfs(ROMol &mol, unsigned int numConfs,
                                    const EmbedParameters &params) {

--- a/Code/GraphMol/DistGeomHelpers/Wrap/rdDistGeom.cpp
+++ b/Code/GraphMol/DistGeomHelpers/Wrap/rdDistGeom.cpp
@@ -1,6 +1,5 @@
-// $Id$
 //
-//  Copyright (C) 2004-2012 Greg Landrum and Rational Discovery LLC
+//  Copyright (C) 2004-2017 Greg Landrum and Rational Discovery LLC
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -313,7 +312,11 @@ BOOST_PYTHON_MODULE(rdDistGeom) {
                      &RDKit::DGeomHelpers::EmbedParameters::pruneRmsThresh,
                      "used to filter multiple conformations: keep only "
                      "conformations that are at least this far apart from each "
-                     "other");
+                     "other")
+      .def_readwrite(
+          "onlyHeavyAtomsForRMS",
+          &RDKit::DGeomHelpers::EmbedParameters::onlyHeavyAtomsForRMS,
+          "Only consider heavy atoms when doing RMS filtering");
   docString =
       "Use distance geometry to obtain multiple sets of \n\
  coordinates for a molecule\n\

--- a/Code/GraphMol/DistGeomHelpers/testDgeomHelpers.cpp
+++ b/Code/GraphMol/DistGeomHelpers/testDgeomHelpers.cpp
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2004-2008 Greg Landrum and Rational Discovery LLC
+//  Copyright (C) 2004-2017 Greg Landrum and Rational Discovery LLC
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -1803,6 +1803,32 @@ void testEmbedParameters() {
   }
 }
 
+void testGithub1227() {
+  {
+    RWMol *m = SmilesToMol("CC");
+    TEST_ASSERT(m);
+    MolOps::addHs(*m);
+    TEST_ASSERT(m->getNumAtoms() == 8);
+
+    DGeomHelpers::EmbedParameters params(DGeomHelpers::ETKDG);
+    params.randomSeed = 0xf00d;
+
+    INT_VECT cids = DGeomHelpers::EmbedMultipleConfs(*m, 10, params);
+    DGeomHelpers::EmbedMolecule(*m, params);
+    TEST_ASSERT(cids.size() == 10);
+    params.pruneRmsThresh = 0.5;
+
+    cids = DGeomHelpers::EmbedMultipleConfs(*m, 10, params);
+    TEST_ASSERT(cids.size() == 6);
+
+    params.onlyHeavyAtomsForRMS = true;
+    cids = DGeomHelpers::EmbedMultipleConfs(*m, 10, params);
+    TEST_ASSERT(cids.size() == 1);
+
+    delete m;
+  }
+}
+
 int main() {
   RDLog::InitLogs();
   BOOST_LOG(rdInfoLog)
@@ -1962,11 +1988,16 @@ int main() {
   BOOST_LOG(rdInfoLog) << "\t ugly conformations can be generated for highly "
                           "constrained ring systems.\n";
   testGithub971();
-#endif
 
   BOOST_LOG(rdInfoLog) << "\t---------------------------------\n";
   BOOST_LOG(rdInfoLog) << "\t test embed parameters structure.\n";
   testEmbedParameters();
+#endif
+
+  BOOST_LOG(rdInfoLog) << "\t---------------------------------\n";
+  BOOST_LOG(rdInfoLog)
+      << "\t test github 1227: Hs being used in RMSD filtering.\n";
+  testGithub1227();
 
   BOOST_LOG(rdInfoLog)
       << "*******************************************************\n";

--- a/Code/GraphMol/DistGeomHelpers/testDgeomHelpers.cpp
+++ b/Code/GraphMol/DistGeomHelpers/testDgeomHelpers.cpp
@@ -1809,21 +1809,20 @@ void testGithub1227() {
     TEST_ASSERT(m);
     MolOps::addHs(*m);
     TEST_ASSERT(m->getNumAtoms() == 8);
-
+    INT_VECT cids;
     DGeomHelpers::EmbedParameters params(DGeomHelpers::ETKDG);
     params.randomSeed = 0xf00d;
 
-    INT_VECT cids = DGeomHelpers::EmbedMultipleConfs(*m, 10, params);
-    DGeomHelpers::EmbedMolecule(*m, params);
-    TEST_ASSERT(cids.size() == 10);
-    params.pruneRmsThresh = 0.5;
-
     cids = DGeomHelpers::EmbedMultipleConfs(*m, 10, params);
-    TEST_ASSERT(cids.size() == 6);
+    TEST_ASSERT(cids.size() == 10);
 
-    params.onlyHeavyAtomsForRMS = true;
+    params.pruneRmsThresh = 0.5;
     cids = DGeomHelpers::EmbedMultipleConfs(*m, 10, params);
     TEST_ASSERT(cids.size() == 1);
+
+    params.onlyHeavyAtomsForRMS = false;  // the old default behavior
+    cids = DGeomHelpers::EmbedMultipleConfs(*m, 10, params);
+    TEST_ASSERT(cids.size() == 6);
 
     delete m;
   }


### PR DESCRIPTION
The remaining question around this one is whether or not ignoring H atoms during the RMS filtering of conformations should be made the default for KDG, ETDG, and ETKDG. I have opted for "yes" in this PR. This does create different default results for those three parameter sets. I'm normally reluctant to do that, but given that these sets, particularly ETKDG, are somehow capturing "best practices", I think it's ok here.