### PR TITLE
modify pattern fp order; update expected psql results

### DIFF
--- a/Code/GraphMol/Fingerprints/PatternFingerprints.cpp
+++ b/Code/GraphMol/Fingerprints/PatternFingerprints.cpp
@@ -55,7 +55,6 @@ class ss_matcher {
 
 namespace RDKit {
 const char *pqs[] = {
-    "[D0]",  // special case: single atom fragment
     "[*]~[*]", "[*]~[*]~[*]", "[R]~1~[R]~[R]~1",
     //"[*]~[*]~[*]~[*]",
     "[*]~[*](~[*])~[*]",
@@ -74,6 +73,7 @@ const char *pqs[] = {
     //"[*]!@[R]~[R]!@[*]",  Github #151: can't have !@ in an SSS pattern
     //"[*]!@[R]~[R]~[R]!@[*]", Github #151: can't have !@ in an SSS pattern
     "[*]~[R](@[R])@[R](@[R])~[*]", "[*]~[R](@[R])@[R]@[R](@[R])~[*]",
+    "[D0]",  // special case: single atom fragment
 #if 0
                       "[*]~[*](~[*])(~[*])~[*]",
                       "[*]~[*]~[*]~[*]~[*]~[*]",

--- a/Code/PgSQL/rdkit/expected/reaction.out
+++ b/Code/PgSQL/rdkit/expected/reaction.out
@@ -672,7 +672,7 @@ SELECT tanimoto_sml(reaction_structural_bfp('c1ccccc1>CC(=O)O.[Na+]>c1ccncc1',5)
 SELECT tanimoto_sml(reaction_structural_bfp('c1ccccc1>CC(=O)O.[Na+]>c1ccncc1',5), reaction_structural_bfp('c1ncccc1>[Na+]>c1ncncc1',5));
    tanimoto_sml    
 -------------------
- 0.578571428571429
+ 0.588652482269504
 (1 row)
 
 SET rdkit.agent_FP_bit_ratio=0.5;
@@ -865,9 +865,9 @@ SELECT tanimoto_sml(reaction_structural_bfp('c1ccccc1>CC(=O)O.[Na+]>c1ccncc1',5)
 (1 row)
 
 SELECT tanimoto_sml(reaction_structural_bfp('c1ccccc1>CC(=O)O.[Na+]>c1ccncc1',5), reaction_structural_bfp('c1ncccc1>[Na+]>c1ncncc1',5));
-   tanimoto_sml   
-------------------
- 0.58695652173913
+   tanimoto_sml    
+-------------------
+ 0.592857142857143
 (1 row)
 
 SET rdkit.ignore_reaction_agents=true;


### PR DESCRIPTION
This tweak moves the new pattern added as part of #1354 to the end of the list of patterns so that the bit ids generated by the other patterns remains constant.
It also updates the expected results for the cartridge tests to reflect the new bits.
