### PR TITLE
Fix cxsmiles parse on VS2008

### DIFF
--- a/Code/GraphMol/SmilesParse/CXSmilesOps.cpp
+++ b/Code/GraphMol/SmilesParse/CXSmilesOps.cpp
@@ -266,7 +266,7 @@ bool parse_it(Iterator &first, Iterator last, RDKit::RWMol &mol) {
       } else {
         if (!parse_atom_labels(first, last, mol)) return false;
       }
-    } else if ((first + 9) < last &&
+    } else if (std::distance(first, last) > 9 &&
                std::string(first, first + 9) == "atomProp:") {
       first += 9;
       if (!parse_atom_props(first, last, mol)) return false;

--- a/Code/GraphMol/SmilesParse/CXSmilesOps.cpp
+++ b/Code/GraphMol/SmilesParse/CXSmilesOps.cpp
@@ -50,7 +50,7 @@ std::string read_text_to(Iterator &first, Iterator last, std::string delims) {
   Iterator start = first;
   // EFF: there are certainly faster ways to do this
   while (first != last && delims.find_first_of(*first) == std::string::npos) {
-    if (*first == '&' && first + 2 < last && *(first + 1) == '#') {
+    if (*first == '&' && std::distance(first, last) > 2 && *(first + 1) == '#') {
       // escaped char
       if (start != first) {
         res += std::string(start, first);
@@ -256,17 +256,18 @@ bool parse_it(Iterator &first, Iterator last, RDKit::RWMol &mol) {
   if (first >= last || *first != '|') return false;
   ++first;
   while (first < last && *first != '|') {
+    Iterator::difference_type length = std::distance(first, last);
     if (*first == '(') {
       if (!parse_coords(first, last, mol)) return false;
     } else if (*first == '$') {
-      if ((first + 4) < last && *(first + 1) == '_' && *(first + 2) == 'A' &&
+      if (length > 4 && *(first + 1) == '_' && *(first + 2) == 'A' &&
           *(first + 3) == 'V' && *(first + 4) == ':') {
         first += 4;
         if (!parse_atom_values(first, last, mol)) return false;
       } else {
         if (!parse_atom_labels(first, last, mol)) return false;
       }
-    } else if (std::distance(first, last) > 9 &&
+    } else if (length > 9 &&
                std::string(first, first + 9) == "atomProp:") {
       first += 9;
       if (!parse_atom_props(first, last, mol)) return false;

--- a/Code/GraphMol/SmilesParse/CXSmilesOps.cpp
+++ b/Code/GraphMol/SmilesParse/CXSmilesOps.cpp
@@ -256,7 +256,7 @@ bool parse_it(Iterator &first, Iterator last, RDKit::RWMol &mol) {
   if (first >= last || *first != '|') return false;
   ++first;
   while (first < last && *first != '|') {
-    Iterator::difference_type length = std::distance(first, last);
+    typename Iterator::difference_type length = std::distance(first, last);
     if (*first == '(') {
       if (!parse_coords(first, last, mol)) return false;
     } else if (*first == '$') {

--- a/Code/GraphMol/SmilesParse/cxsmiles_test.cpp
+++ b/Code/GraphMol/SmilesParse/cxsmiles_test.cpp
@@ -251,7 +251,6 @@ void testRadicals() {
   BOOST_LOG(rdInfoLog) << "testing radicals" << std::endl;
   {
     std::string smiles = "[O]C[O] |^1:0,2|";
-    ;
     SmilesParserParams params;
     params.allowCXSMILES = true;
     ROMol *m = SmilesToMol(smiles, params);


### PR DESCRIPTION
Parsing SMILES with short (<9 character) chemaxon extensions is failing for me when compiling with VS2008.

I think this is because incrementing an iterator beyond its end leads to undefined behaviour, so `(first + 9) < last` is not actually guaranteed to return false for strings with less than 9 characters. Seems not to be an issue with most compilers but caused a crash in VS2008.

Changing to `std::distance(first, last) > 9` seems to fix the problem for me.