### PR TITLE
Fixes #1423

### DIFF
--- a/Code/GraphMol/Chirality.cpp
+++ b/Code/GraphMol/Chirality.cpp
@@ -829,19 +829,17 @@ std::pair<bool, bool> assignBondStereoCodes(ROMol &mol, UINT_VECT &ranks) {
               endNbrAid = endAtomNeighbors[1].first;
             }
 
-            bool conflictingBegin = false;
-            bool conflictingEnd = false;
-            if (begAtomNeighbors.size() == 2 &&
-                begAtomNeighbors[0].second == begAtomNeighbors[1].second)
-              conflictingBegin = true;
-            if (endAtomNeighbors.size() == 2 &&
-                endAtomNeighbors[0].second == endAtomNeighbors[1].second)
-              conflictingEnd = true;
+            bool conflictingBegin =
+                (begAtomNeighbors.size() == 2 &&
+                 begAtomNeighbors[0].second == begAtomNeighbors[1].second);
+            bool conflictingEnd =
+                (endAtomNeighbors.size() == 2 &&
+                 endAtomNeighbors[0].second == endAtomNeighbors[1].second);
             if (conflictingBegin || conflictingEnd) {
               dblBond->setStereo(Bond::STEREONONE);
-              BOOST_LOG(rdWarningLog)
-                  << "Conflicting single bond directions around double bond "
-                  << dblBond->getIdx() << "." << std::endl;
+              BOOST_LOG(rdWarningLog) << "Conflicting single bond directions "
+                                         "around double bond at index"
+                                      << dblBond->getIdx() << "." << std::endl;
               BOOST_LOG(rdWarningLog) << "  BondStereo set to STEREONONE and "
                                          "single bond directions set to NONE."
                                       << std::endl;

--- a/Code/GraphMol/Chirality.cpp
+++ b/Code/GraphMol/Chirality.cpp
@@ -838,7 +838,7 @@ std::pair<bool, bool> assignBondStereoCodes(ROMol &mol, UINT_VECT &ranks) {
             if (conflictingBegin || conflictingEnd) {
               dblBond->setStereo(Bond::STEREONONE);
               BOOST_LOG(rdWarningLog) << "Conflicting single bond directions "
-                                         "around double bond at index"
+                                         "around double bond at index "
                                       << dblBond->getIdx() << "." << std::endl;
               BOOST_LOG(rdWarningLog) << "  BondStereo set to STEREONONE and "
                                          "single bond directions set to NONE."

--- a/Code/GraphMol/hanoitest.cpp
+++ b/Code/GraphMol/hanoitest.cpp
@@ -98,7 +98,8 @@ void test1() {
 
   typedef boost::random::mersenne_twister<boost::uint32_t, 32, 4, 2, 31,
                                           0x9908b0df, 11, 7, 0x9d2c5680, 15,
-                                          0xefc60000, 18, 3346425566U> rng_type;
+                                          0xefc60000, 18, 3346425566U>
+      rng_type;
   typedef boost::uniform_int<> distrib_type;
   typedef boost::variate_generator<rng_type &, distrib_type> source_type;
   rng_type generator(42u);
@@ -995,7 +996,7 @@ std::string smis[] = {
     // doubled house
     "C12C3C45C67C8C9C66C14C21C35C78C961", "C12C3C45C6C7C11C27C41C356",
     // Problematic round-tripping
-    "COC(=O)/C=C/C(C)=C/C=C/C(C)=C/C=C/C=C(/C)/C=C/C=C(\\C)/C=C/C(=O)[O-]",
+    "COC(=O)/C=C/C(C)=C/C=C/C(C)=C/C=C/C=C(C)/C=C/C=C(\\C)/C=C/C(=O)[O-]",
     "COC(=O)/C=C/C(C)=C/C=C/C(C)=C/C=C/C=C(\\C)/C=C/C=C(\\C)/C=C/C(=O)[O-]",
     "c1cc2ccc(ccc3ccc1cc3)cc2", "C13C6C1C2C4C2C3C5C4C56",
     "C45C1C6C3C6C5C4C2C3C12", "C45C2C6C3C6C5C4C1C3C12",

--- a/Code/GraphMol/hanoitest.cpp
+++ b/Code/GraphMol/hanoitest.cpp
@@ -996,7 +996,7 @@ std::string smis[] = {
     // doubled house
     "C12C3C45C67C8C9C66C14C21C35C78C961", "C12C3C45C6C7C11C27C41C356",
     // Problematic round-tripping
-    "COC(=O)/C=C/C(C)=C/C=C/C(C)=C/C=C/C=C(C)/C=C/C=C(\\C)/C=C/C(=O)[O-]",
+    "COC(=O)/C=C/C(C)=C/C=C/C(C)=C/C=C/C=C(/C)/C=C/C=C(\\C)/C=C/C(=O)[O-]",
     "COC(=O)/C=C/C(C)=C/C=C/C(C)=C/C=C/C=C(\\C)/C=C/C=C(\\C)/C=C/C(=O)[O-]",
     "c1cc2ccc(ccc3ccc1cc3)cc2", "C13C6C1C2C4C2C3C5C4C56",
     "C45C1C6C3C6C5C4C2C3C12", "C45C2C6C3C6C5C4C1C3C12",

--- a/Code/GraphMol/hanoitest.cpp
+++ b/Code/GraphMol/hanoitest.cpp
@@ -996,7 +996,7 @@ std::string smis[] = {
     // doubled house
     "C12C3C45C67C8C9C66C14C21C35C78C961", "C12C3C45C6C7C11C27C41C356",
     // Problematic round-tripping
-    "COC(=O)/C=C/C(C)=C/C=C/C(C)=C/C=C/C=C(/C)/C=C/C=C(\\C)/C=C/C(=O)[O-]",
+    "COC(=O)/C=C/C(C)=C/C=C/C(C)=C/C=C/C=C(C)/C=C/C=C(\\C)/C=C/C(=O)[O-]",
     "COC(=O)/C=C/C(C)=C/C=C/C(C)=C/C=C/C=C(\\C)/C=C/C=C(\\C)/C=C/C(=O)[O-]",
     "c1cc2ccc(ccc3ccc1cc3)cc2", "C13C6C1C2C4C2C3C5C4C56",
     "C45C1C6C3C6C5C4C2C3C12", "C45C2C6C3C6C5C4C1C3C12",

--- a/Code/GraphMol/testChirality.cpp
+++ b/Code/GraphMol/testChirality.cpp
@@ -2315,8 +2315,13 @@ void testGithub1423() {
     TEST_ASSERT(m->getNumAtoms() == 5);
     TEST_ASSERT(m->getBondWithIdx(2)->getBondType() == Bond::DOUBLE);
     TEST_ASSERT(m->getBondWithIdx(2)->getStereo() == Bond::STEREONONE);
+    TEST_ASSERT(m->getBondWithIdx(0)->getBondType() == Bond::SINGLE);
+    TEST_ASSERT(m->getBondWithIdx(0)->getBondDir() == Bond::NONE);
+    TEST_ASSERT(m->getBondWithIdx(1)->getBondType() == Bond::SINGLE);
+    TEST_ASSERT(m->getBondWithIdx(1)->getBondDir() == Bond::NONE);
+
     TEST_ASSERT(warns.str() != "");
-    TEST_ASSERT(warns.str().find("stereo set to STEREONONE") !=
+    TEST_ASSERT(warns.str().find("BondStereo set to STEREONONE") !=
                 std::string::npos);
     delete m;
     rdWarningLog->ClearTee();
@@ -2332,12 +2337,40 @@ void testGithub1423() {
     TEST_ASSERT(m->getBondWithIdx(15)->getBondType() == Bond::DOUBLE);
     TEST_ASSERT(m->getBondWithIdx(15)->getStereo() == Bond::STEREONONE);
     TEST_ASSERT(warns.str() != "");
-    TEST_ASSERT(warns.str().find("stereo set to STEREONONE") !=
+    TEST_ASSERT(warns.str().find("BondStereo set to STEREONONE") !=
                 std::string::npos);
     delete m;
     rdWarningLog->ClearTee();
   }
 
+  {  // a problem that came up during testing
+    std::stringstream warns;
+    rdWarningLog->SetTee(warns);
+    std::string smi = "C/C(\\F)=C/[C@H](F)C=C(F)C";
+    ROMol *m = SmilesToMol(smi);
+    TEST_ASSERT(m);
+    TEST_ASSERT(m->getBondWithIdx(2)->getBondType() == Bond::DOUBLE);
+    TEST_ASSERT(m->getBondWithIdx(2)->getStereo() == Bond::STEREONONE);
+    TEST_ASSERT(m->getAtomWithIdx(4)->getChiralTag() == Atom::CHI_UNSPECIFIED);
+    TEST_ASSERT(warns.str() != "");
+    TEST_ASSERT(warns.str().find("BondStereo set to STEREONONE") !=
+                std::string::npos);
+    delete m;
+    rdWarningLog->ClearTee();
+  }
+
+  {  // a problem that came up during testing
+    std::stringstream warns;
+    rdWarningLog->SetTee(warns);
+    std::string smi = "C/C1=C/C=C=C=C2C(=C([Si](C)(C)C)\\C=C/1)C(=O)c1ccccc12";
+    ROMol *m = SmilesToMol(smi);
+    TEST_ASSERT(m);
+    TEST_ASSERT(warns.str() != "");
+    TEST_ASSERT(warns.str().find("BondStereo set to STEREONONE") !=
+                std::string::npos);
+    delete m;
+    rdWarningLog->ClearTee();
+  }
   BOOST_LOG(rdInfoLog) << "done" << std::endl;
 }
 int main() {
@@ -2364,8 +2397,8 @@ int main() {
   testIssue2705543();
   testGithub553();
   testGithub803();
-#endif
   testGithub1294();
+#endif
   testGithub1423();
   return 0;
 }


### PR DESCRIPTION
When conflicting stereo directions are found on an atom:
- A warning is raised
- the double bond stereochemistry is set to STEREONONE
- the directionalities on the offending stereobonds are set to NONE:

```
In [2]: m = Chem.MolFromSmiles(r'C/C(\F)=C/C')
[05:10:05] Conflicting single bond directions around double bond 2.
[05:10:05]   BondStereo set to STEREONONE and single bond directions set to NONE.

In [3]: m.Debug()
Atoms:
	0 6 C chg: 0  deg: 1 exp: 1 imp: 3 hyb: 4 arom?: 0 chi: 0
	1 6 C chg: 0  deg: 3 exp: 4 imp: 0 hyb: 3 arom?: 0 chi: 0
	2 9 F chg: 0  deg: 1 exp: 1 imp: 0 hyb: 4 arom?: 0 chi: 0
	3 6 C chg: 0  deg: 2 exp: 3 imp: 1 hyb: 3 arom?: 0 chi: 0
	4 6 C chg: 0  deg: 1 exp: 1 imp: 3 hyb: 4 arom?: 0 chi: 0
Bonds:
	0 0->1 order: 1 conj?: 0 aromatic?: 0
	1 1->2 order: 1 conj?: 0 aromatic?: 0
	2 1->3 order: 2 conj?: 0 aromatic?: 0
	3 3->4 order: 1 dir: 4 conj?: 0 aromatic?: 0
```