### PR TITLE
RWMol.clear() should reset the numBonds count.

### DIFF
--- a/Code/GraphMol/ROMol.cpp
+++ b/Code/GraphMol/ROMol.cpp
@@ -83,7 +83,7 @@ void ROMol::initFromOther(const ROMol &other, bool quickCopy, int confId) {
         this->addConformer(conf);
       }
     }
-    
+
     dp_props = other.dp_props;
 
     // Bookmarks should be copied as well:
@@ -109,7 +109,8 @@ void ROMol::initFromOther(const ROMol &other, bool quickCopy, int confId) {
 void ROMol::initMol() {
   dp_props.reset();
   dp_ringInfo = new RingInfo();
-  // ok every molecule contains a property entry called RDKit::detail::computedPropName
+  // ok every molecule contains a property entry called
+  // RDKit::detail::computedPropName
   // which provides
   //  list of property keys that correspond to value that have been computed
   // this can used to blow out all computed properties while leaving the rest
@@ -232,7 +233,7 @@ void ROMol::clearBondBookmark(const int mark, const Bond *bond) {
 unsigned int ROMol::getNumBonds(bool onlyHeavy) const {
   // By default resturn the bonds that connect only the heavy atoms
   // hydrogen connecting bonds are ignores
-  int res = rdcast<int>(boost::num_edges(d_graph));
+  int res = numBonds;
   if (!onlyHeavy) {
     // If we need hydrogen connecting bonds add them up
     for (ConstAtomIterator ai = beginAtoms(); ai != endAtoms(); ++ai) {
@@ -346,7 +347,8 @@ unsigned int ROMol::addBond(Bond *bond_pin, bool takeOwnership) {
   PRECONDITION(bond_pin->getBeginAtomIdx() != bond_pin->getEndAtomIdx(),
                "attempt to add self-bond");
   PRECONDITION(!(boost::edge(bond_pin->getBeginAtomIdx(),
-                             bond_pin->getEndAtomIdx(), d_graph).second),
+                             bond_pin->getEndAtomIdx(), d_graph)
+                     .second),
                "bond already exists");
 
   Bond *bond_p;
@@ -365,7 +367,7 @@ unsigned int ROMol::addBond(Bond *bond_pin, bool takeOwnership) {
   numBonds++;
   //  int res = rdcast<int>(boost::num_edges(d_graph));
   bond_p->setIdx(numBonds - 1);
-  return numBonds;//res;
+  return numBonds;  // res;
 }
 unsigned int ROMol::addBond(Bond::BOND_SPTR bsp) { return addBond(bsp.get()); }
 
@@ -473,7 +475,7 @@ void ROMol::clearComputedProps(bool includeRings) const {
   if (includeRings) this->dp_ringInfo->reset();
 
   RDProps::clearComputedProps();
-  
+
   for (ConstAtomIterator atomIt = this->beginAtoms();
        atomIt != this->endAtoms(); ++atomIt) {
     (*atomIt)->clearComputedProps();

--- a/Code/GraphMol/RWMol.h
+++ b/Code/GraphMol/RWMol.h
@@ -226,7 +226,7 @@ class RWMol : public ROMol {
     dp_props.reset();
     STR_VECT computed;
     dp_props.setVal(RDKit::detail::computedPropName, computed);
-
+    numBonds = 0;
     if (dp_ringInfo) dp_ringInfo->reset();
   };
 

--- a/Code/GraphMol/test1.cpp
+++ b/Code/GraphMol/test1.cpp
@@ -1338,6 +1338,26 @@ void testGithub1041() {
   BOOST_LOG(rdErrorLog) << "  done" << std::endl;
 }
 
+void testGithub1453() {
+  BOOST_LOG(rdErrorLog) << "-------------------------------------" << std::endl;
+  BOOST_LOG(rdErrorLog)
+      << "    Test github1453: RWMol.clear() should reset the numBonds count."
+      << std::endl;
+
+  RWMol m2;
+
+  m2.addAtom(new Atom(6));
+  m2.addAtom(new Atom(6));
+  m2.addBond(0, 1, Bond::TRIPLE);
+  TEST_ASSERT(m2.getNumAtoms() == 2);
+  TEST_ASSERT(m2.getNumBonds() == 1);
+  m2.clear();
+  TEST_ASSERT(m2.getNumAtoms() == 0);
+  TEST_ASSERT(m2.getNumBonds() == 0);
+
+  BOOST_LOG(rdErrorLog) << "  done" << std::endl;
+}
+
 // -------------------------------------------------------------------
 int main() {
   RDLog::InitLogs();
@@ -1365,6 +1385,8 @@ int main() {
   testGithub608();
   testGithub381();
   testGithub1041();
+  testGithub1041();
+  testGithub1453();
 
   return 0;
 }


### PR DESCRIPTION
NumBonds needs to be reset in clear(). This has been around for a while (Nov 16?) and took Noel a couple of days to track down.