### PR TITLE
Dev/add update props api

### DIFF
--- a/Code/GraphMol/AdjustQuery.cpp
+++ b/Code/GraphMol/AdjustQuery.cpp
@@ -63,7 +63,9 @@ void adjustQueryProperties(RWMol &mol, const AdjustQueryParameters *inParams) {
             isMapped(mol.getAtomWithIdx(i)))) {
         QueryAtom *qa = new QueryAtom();
         qa->setQuery(makeAtomNullQuery());
-        mol.replaceAtom(i, qa);
+        const bool updateLabel = false;
+        const bool preserveProps = true;
+        mol.replaceAtom(i, qa, updateLabel, preserveProps);
         delete qa;
       }
     }
@@ -76,7 +78,8 @@ void adjustQueryProperties(RWMol &mol, const AdjustQueryParameters *inParams) {
             ringInfo->numBondRings(i))) {
         QueryBond *qb = new QueryBond();
         qb->setQuery(makeBondNullQuery());
-        mol.replaceBond(i, qb);
+        const bool preserveProps = true;        
+        mol.replaceBond(i, qb, preserveProps);
         delete qb;
       }
     }
@@ -91,7 +94,9 @@ void adjustQueryProperties(RWMol &mol, const AdjustQueryParameters *inParams) {
         !at->getIsotope()) {
       QueryAtom *qa = new QueryAtom();
       qa->setQuery(makeAtomNullQuery());
-      mol.replaceAtom(i, qa);
+      const bool updateLabel = false;
+      const bool preserveProps = true;
+      mol.replaceAtom(i, qa, updateLabel, preserveProps);
       delete qa;
       at = mol.getAtomWithIdx(i);
     }  // end of makeDummiesQueries
@@ -104,7 +109,9 @@ void adjustQueryProperties(RWMol &mol, const AdjustQueryParameters *inParams) {
       QueryAtom *qa;
       if (!at->hasQuery()) {
         qa = new QueryAtom(*at);
-        mol.replaceAtom(i, qa);
+        const bool updateLabel = false;        
+        const bool preserveProps = true;
+        mol.replaceAtom(i, qa, updateLabel, preserveProps);
         delete qa;
         qa = static_cast<QueryAtom *>(mol.getAtomWithIdx(i));
         at = static_cast<Atom *>(qa);
@@ -124,7 +131,9 @@ void adjustQueryProperties(RWMol &mol, const AdjustQueryParameters *inParams) {
       QueryAtom *qa;
       if (!at->hasQuery()) {
         qa = new QueryAtom(*at);
-        mol.replaceAtom(i, qa);
+        const bool updateLabel = false;
+        const bool preserveProps = true;
+        mol.replaceAtom(i, qa, updateLabel, preserveProps);
         delete qa;
         qa = static_cast<QueryAtom *>(mol.getAtomWithIdx(i));
         at = static_cast<Atom *>(qa);

--- a/Code/GraphMol/RWMol.cpp
+++ b/Code/GraphMol/RWMol.cpp
@@ -138,7 +138,7 @@ void RWMol::replaceAtom(unsigned int idx, Atom *atom_pin, bool updateLabel,
   MolGraph::vertex_descriptor vd = boost::vertex(idx, d_graph);
   if (preserveProps) {
     const bool replaceExistingData = false;
-    atom_p->updateProps(*d_graph[vd].get());
+    atom_p->updateProps(*d_graph[vd].get(), replaceExistingData);
   }
   d_graph[vd].reset(atom_p);
   // FIX: do something about bookmarks

--- a/Code/GraphMol/RWMol.cpp
+++ b/Code/GraphMol/RWMol.cpp
@@ -127,7 +127,8 @@ unsigned int RWMol::addAtom(bool updateLabel) {
   return rdcast<unsigned int>(which);
 }
 
-void RWMol::replaceAtom(unsigned int idx, Atom *atom_pin, bool updateLabel) {
+void RWMol::replaceAtom(unsigned int idx, Atom *atom_pin, bool updateLabel,
+                        bool preserveProps) {
   RDUNUSED_PARAM(updateLabel);
   PRECONDITION(atom_pin, "bad atom passed to replaceAtom");
   URANGE_CHECK(idx, getNumAtoms() - 1);
@@ -135,11 +136,15 @@ void RWMol::replaceAtom(unsigned int idx, Atom *atom_pin, bool updateLabel) {
   atom_p->setOwningMol(this);
   atom_p->setIdx(idx);
   MolGraph::vertex_descriptor vd = boost::vertex(idx, d_graph);
+  if (preserveProps) {
+    const bool replaceExistingData = false;
+    atom_p->updateProps(*d_graph[vd].get());
+  }
   d_graph[vd].reset(atom_p);
   // FIX: do something about bookmarks
 };
 
-void RWMol::replaceBond(unsigned int idx, Bond *bond_pin) {
+void RWMol::replaceBond(unsigned int idx, Bond *bond_pin, bool preserveProps) {
   PRECONDITION(bond_pin, "bad bond passed to replaceBond");
   URANGE_CHECK(idx, getNumBonds() - 1);
   BOND_ITER_PAIR bIter = getEdges();
@@ -150,6 +155,11 @@ void RWMol::replaceBond(unsigned int idx, Bond *bond_pin) {
   bond_p->setIdx(idx);
   bond_p->setBeginAtomIdx(obond->getBeginAtomIdx());
   bond_p->setEndAtomIdx(obond->getEndAtomIdx());
+  if (preserveProps) {
+    const bool replaceExistingData = false;
+    bond_p->updateProps( *d_graph[*(bIter.first)].get(), replaceExistingData );
+  }
+
   d_graph[*(bIter.first)].reset(bond_p);
   // FIX: do something about bookmarks
 };

--- a/Code/GraphMol/RWMol.h
+++ b/Code/GraphMol/RWMol.h
@@ -103,9 +103,11 @@ class RWMol : public ROMol {
     \param atom         the new atom, which will be copied.
     \param updateLabel   (optional) if this is true, the new Atom will be
                          our \c activeAtom
+    \param preserveProps if true preserve the original atom property data
 
   */
-  void replaceAtom(unsigned int idx, Atom *atom, bool updateLabel = false);
+  void replaceAtom(unsigned int idx, Atom *atom, bool updateLabel = false,
+                   bool preserveProps = false);
   //! returns a pointer to the highest-numbered Atom
   Atom *getLastAtom() { return getAtomWithIdx(getNumAtoms() - 1); };
   //! returns a pointer to the "active" Atom
@@ -211,9 +213,10 @@ class RWMol : public ROMol {
   /*!
     \param idx          the index of the Bond to replace
     \param bond         the new bond, which will be copied.
+    \param preserveProps if true preserve the original bond property data    
 
   */
-  void replaceBond(unsigned int idx, Bond *bond);
+  void replaceBond(unsigned int idx, Bond *bond, bool preserveProps=false);
 
   //@}
 

--- a/Code/GraphMol/Wrap/EditableMol.cpp
+++ b/Code/GraphMol/Wrap/EditableMol.cpp
@@ -52,11 +52,18 @@ class EditableMol : boost::noncopyable {
     PRECONDITION(atom, "bad atom");
     return dp_mol->addAtom(atom, true, false);
   };
-  void ReplaceAtom(unsigned int idx, Atom *atom) {
+  void ReplaceAtom(unsigned int idx, Atom *atom,
+                   bool updateLabels, bool preserveProps) {
     PRECONDITION(dp_mol, "no molecule");
     PRECONDITION(atom, "bad atom");
-    dp_mol->replaceAtom(idx, atom);
+    dp_mol->replaceAtom(idx, atom, updateLabels, preserveProps);
   };
+  void ReplaceBond(unsigned int idx, Bond *bond, bool preserveProps) {
+    PRECONDITION(dp_mol, "no molecule");
+    PRECONDITION(bond, "bad bond");
+    dp_mol->replaceBond(idx, bond, preserveProps);
+  };
+  
   ROMol *GetMol() const {
     PRECONDITION(dp_mol, "no molecule");
     ROMol *res = new ROMol(*dp_mol);
@@ -97,17 +104,27 @@ struct EditableMol_wrapper {
              "Remove the specified bond from the molecule")
 
         .def("AddBond", &EditableMol::AddBond,
-             (python::arg("mol"), python::arg("beginAtomIdx"),
+             (python::arg("beginAtomIdx"),
               python::arg("endAtomIdx"),
               python::arg("order") = Bond::UNSPECIFIED),
              "add a bond, returns the index of the newly added bond")
 
         .def("AddAtom", &EditableMol::AddAtom,
-             (python::arg("mol"), python::arg("atom")),
+             (python::arg("atom")),
              "add an atom, returns the index of the newly added atom")
+        
         .def("ReplaceAtom", &EditableMol::ReplaceAtom,
-             (python::arg("mol"), python::arg("index"), python::arg("newAtom")),
-             "replaces the specified atom with the provided one")
+             (python::arg("index"), python::arg("newAtom"),
+              python::arg("updateLabel")=false, python::arg("preserveProps")=false),
+             "replaces the specified atom with the provided one\n"
+             "If updateLabel is True, the new atom becomes the active atom\n"
+             "If preserveProps is True preserve keep the existing props unless explicit set on the new atom")
+        .def("ReplaceBond", &EditableMol::ReplaceBond,
+             (python::arg("index"), python::arg("newBond"),
+              python::arg("preserveProps")=false),
+             "replaces the specified bond with the provided one.\n"
+             "If preserveProps is True preserve keep the existing props unless explicit set on the new bond")
+        
         .def("GetMol", &EditableMol::GetMol,
              "Returns a Mol (a normal molecule)",
              python::return_value_policy<python::manage_new_object>());

--- a/Code/GraphMol/Wrap/Mol.cpp
+++ b/Code/GraphMol/Wrap/Mol.cpp
@@ -247,8 +247,14 @@ class ReadWriteMol : public RWMol {
     PRECONDITION(atom, "bad atom");
     return addAtom(atom, true, false);
   };
-  void ReplaceAtom(unsigned int idx, Atom *atom) { replaceAtom(idx, atom); };
-  void ReplaceBond(unsigned int idx, Bond *bond) { replaceBond(idx, bond); };
+  void ReplaceAtom(unsigned int idx, Atom *atom, bool updateLabel, bool preserveProps) {
+    PRECONDITION(atom, "bad atom");
+    replaceAtom(idx, atom, updateLabel, preserveProps);
+  };
+  void ReplaceBond(unsigned int idx, Bond *bond, bool preserveProps) {
+    PRECONDITION(bond, "bad bond");
+    replaceBond(idx, bond, preserveProps);
+  };
   ROMol *GetMol() const {
     ROMol *res = new ROMol(*this);
     return res;
@@ -688,20 +694,25 @@ struct mol_wrapper {
              "Remove the specified bond from the molecule")
 
         .def("AddBond", &ReadWriteMol::AddBond,
-             (python::arg("mol"), python::arg("beginAtomIdx"),
+             (python::arg("beginAtomIdx"),
               python::arg("endAtomIdx"),
               python::arg("order") = Bond::UNSPECIFIED),
              "add a bond, returns the new number of bonds")
 
         .def("AddAtom", &ReadWriteMol::AddAtom,
-             (python::arg("mol"), python::arg("atom")),
+             (python::arg("atom")),
              "add an atom, returns the index of the newly added atom")
         .def("ReplaceAtom", &ReadWriteMol::ReplaceAtom,
-             (python::arg("mol"), python::arg("index"), python::arg("newAtom")),
-             "replaces the specified atom with the provided one")
+             (python::arg("index"), python::arg("newAtom"),
+              python::arg("updateLabel")=false, python::arg("preserveProps")=false),
+             "replaces the specified atom with the provided one\n"
+             "If updateLabel is True, the new atom becomes the active atom\n"
+             "If preserveProps is True preserve keep the existing props unless explicit set on the new atom")
         .def("ReplaceBond", &ReadWriteMol::ReplaceBond,
-             (python::arg("mol"), python::arg("index"), python::arg("newBond")),
-             "replaces the specified bond with the provided one")
+             (python::arg("index"), python::arg("newBond"),
+              python::arg("preserveProps")=false),
+             "replaces the specified bond with the provided one.\n"
+             "If preserveProps is True preserve keep the existing props unless explicit set on the new bond")
         .def("GetMol", &ReadWriteMol::GetMol,
              "Returns a Mol (a normal molecule)",
              python::return_value_policy<python::manage_new_object>());

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -3502,6 +3502,15 @@ CAS<~>
     am = Chem.AdjustQueryProperties(m, qps)
     self.assertEqual(Chem.MolToSmarts(am),'[#6&D2]1-[#6&D2]-[#6&D2]-[#6&D3]-1~[#8]~[#6]')
 
+  def testAdjustQueryPropertiesgithubIssue1474(self):
+    core = Chem.MolFromSmiles('[*:1]C1N([*:2])C([*:3])O1')
+    core.GetAtomWithIdx(0).SetProp('foo','bar')
+    core.GetAtomWithIdx(1).SetProp('foo','bar')
+
+    ap = Chem.AdjustQueryProperties(core)
+    self.assertEqual(ap.GetAtomWithIdx(0).GetPropsAsDict()["foo"], "bar")
+    self.assertEqual(ap.GetAtomWithIdx(1).GetPropsAsDict()["foo"], "bar")
+    
   def testGithubIssue579(self):
     fileN = os.path.join(RDConfig.RDBaseDir, 'Code', 'GraphMol', 'FileParsers', 'test_data',
                          'NCI_aids_few.sdf.gz')

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -2235,6 +2235,39 @@ CAS<~>
       # confirm that an RWMol can be constructed without arguments
       m = Chem.RWMol()
 
+    # test replaceAtom/Bond preserving properties
+    mol = Chem.MolFromSmiles('C1CCC1')
+    mol2 = Chem.MolFromSmiles('C1CCC1')
+    mol.GetAtomWithIdx(0).SetProp("foo", "bar")
+    mol.GetBondWithIdx(0).SetProp("foo", "bar")
+    newBond = mol2.GetBondWithIdx(0)
+    self.assertTrue(type(mol) == Chem.Mol)
+
+    for rwmol in [Chem.EditableMol(mol), Chem.RWMol(mol)]:
+      newAt = Chem.Atom(8)
+      rwmol.ReplaceAtom(0, newAt)
+      self.assertTrue(Chem.MolToSmiles(rwmol.GetMol()) == 'C1COC1')
+      self.assertFalse(rwmol.GetMol().GetAtomWithIdx(0).HasProp("foo"))
+
+    for rwmol in [Chem.EditableMol(mol), Chem.RWMol(mol)]:
+      newAt = Chem.Atom(8)
+      rwmol.ReplaceAtom(0, newAt, preserveProps=True)
+      self.assertTrue(Chem.MolToSmiles(rwmol.GetMol()) == 'C1COC1')
+      self.assertTrue(rwmol.GetMol().GetAtomWithIdx(0).HasProp("foo"))
+      self.assertEqual(rwmol.GetMol().GetAtomWithIdx(0).GetProp("foo"), "bar")
+
+    for rwmol in [Chem.EditableMol(mol), Chem.RWMol(mol)]:
+      rwmol.ReplaceBond(0, newBond)
+      self.assertTrue(Chem.MolToSmiles(rwmol.GetMol()) == 'C1CCC1')      
+      self.assertFalse(rwmol.GetMol().GetBondWithIdx(0).HasProp("foo"))
+
+    for rwmol in [Chem.EditableMol(mol), Chem.RWMol(mol)]:
+      rwmol.ReplaceBond(0, newBond, preserveProps=True)
+      self.assertTrue(Chem.MolToSmiles(rwmol.GetMol()) == 'C1CCC1')      
+      self.assertTrue(rwmol.GetMol().GetBondWithIdx(0).HasProp("foo"))
+      self.assertEqual(rwmol.GetMol().GetBondWithIdx(0).GetProp("foo"), "bar")
+      
+
   def test47SmartsPieces(self):
     """ test the GetAtomSmarts and GetBondSmarts functions
 

--- a/Code/GraphMol/molopstest.cpp
+++ b/Code/GraphMol/molopstest.cpp
@@ -5492,6 +5492,30 @@ void testAdjustQueryProperties() {
     delete qm;
     delete aqm;
   }
+  {  // dummies from SMILES 2
+    std::string smiles = "C1CCC1[*:1]";
+    ROMol *qm = SmilesToMol(smiles);
+    qm->getAtomWithIdx(4)->setProp<int>("foo", 2);
+    
+    TEST_ASSERT(qm);
+    TEST_ASSERT(qm->getNumAtoms() == 5);
+    ROMol *aqm = MolOps::adjustQueryProperties(*qm);
+    TEST_ASSERT(aqm);
+    TEST_ASSERT(aqm->getNumAtoms() == 5);
+    TEST_ASSERT(aqm->getAtomWithIdx(4)->getProp<int>("foo") == 2);
+    TEST_ASSERT(aqm->getAtomWithIdx(4)->getAtomMapNum() == 1);
+    {
+      smiles = "C1CCC1CC";
+      ROMol *m = SmilesToMol(smiles);
+      TEST_ASSERT(m);
+      MatchVectType match;
+      TEST_ASSERT(!SubstructMatch(*m, *qm, match));
+      TEST_ASSERT(SubstructMatch(*m, *aqm, match));
+      delete m;
+    }
+    delete qm;
+    delete aqm;
+  }
   {  // CTAB
     //  -- only match rgroups
     std::string mb =

--- a/Code/RDGeneral/Dict.h
+++ b/Code/RDGeneral/Dict.h
@@ -63,6 +63,21 @@ public:
     reset(); // to clear pointers if necessary
   }
 
+  void update(const Dict &other, bool preserveExisting=false) {
+    if(!preserveExisting) {
+      *this = other;
+    }
+    else {
+      for (size_t i=0; i< other._data.size(); ++i) {
+        const Pair & pair = other._data[i];
+        if(!hasVal(pair.key)) {
+          _data.push_back(pair);
+          copy_rdvalue(_data.back().val, pair.val);
+        }
+      }
+    }
+  }
+  
   Dict &operator=(const Dict &other) {
     _hasNonPodData = other._hasNonPodData;
     if (_hasNonPodData) {

--- a/Code/RDGeneral/RDProps.h
+++ b/Code/RDGeneral/RDProps.h
@@ -145,6 +145,19 @@ class RDProps {
       dp_props.setVal(RDKit::detail::computedPropName, compLst);
     }
   }
+
+  //! update the properties from another
+  /*
+    \param source    Source to update the properties from
+    \param preserve  Existing If true keep existing data, else override from the source
+  */
+  void updateProps(const RDProps &source, bool preserveExisting=false) {
+    dp_props.update(source.getDict(), preserveExisting); 
+  }
+  
 };
+
+
+
 }
 #endif

--- a/Code/RDGeneral/testDict.cpp
+++ b/Code/RDGeneral/testDict.cpp
@@ -569,6 +569,72 @@ void testConstReturns() {
   BOOST_LOG(rdErrorLog) << "\tdone" << std::endl;
 }
 
+void testUpdate() {
+  BOOST_LOG(rdErrorLog) << "-------------------------------------" << std::endl;
+  BOOST_LOG(rdErrorLog) << "Testing dict update." << std::endl;
+
+  {
+    Dict d;
+    std::string sv;
+    sv = "1.3";
+    d.setVal("foo", sv);
+    double dv = 3.0;
+    d.setVal("foo2", dv);
+    std::vector<int> f;
+    f.push_back(1);
+    f.push_back(2);
+    d.setVal("foo3", f);
+    
+    Dict d2;
+    d2.update(d);
+    TEST_ASSERT(d.getVal<std::string>("foo") == d2.getVal<std::string>("foo"));
+    TEST_ASSERT(d.getVal<double>("foo2") == d2.getVal<double>("foo2"));
+    TEST_ASSERT(d.getVal<std::vector<int> >("foo3") == d2.getVal<std::vector<int> >("foo3"));
+  }
+  
+  {
+    Dict d;
+    std::string sv;
+    sv = "1.3";
+    d.setVal("foo", sv);
+    double dv = 3.0;
+    d.setVal("foo2", dv);
+    std::vector<int> f;
+    f.push_back(1);
+    f.push_back(2);
+    d.setVal("foo3", f);
+    
+    Dict d2;
+    d2.update(d, false);
+    TEST_ASSERT(d.getVal<std::string>("foo") == d2.getVal<std::string>("foo"));
+    TEST_ASSERT(d.getVal<double>("foo2") == d2.getVal<double>("foo2"));
+    TEST_ASSERT(d.getVal<std::vector<int> >("foo3") == d2.getVal<std::vector<int> >("foo3"));
+  }
+
+  {
+    Dict d;
+    std::string sv;
+    sv = "1.3";
+    d.setVal("foo", sv);
+    double dv = 3.0;
+    d.setVal("foo2", dv);
+    std::vector<int> f;
+    f.push_back(1);
+    f.push_back(2);
+    d.setVal("foo3", f);
+    
+    Dict d2;
+    d2.setVal("foo", 1);
+    d2.update(d, true);
+    TEST_ASSERT(1 == d2.getVal<int>("foo"));
+    TEST_ASSERT(d.getVal<double>("foo2") == d2.getVal<double>("foo2"));
+    TEST_ASSERT(d.getVal<std::vector<int> >("foo3") == d2.getVal<std::vector<int> >("foo3"));
+  }
+  
+  BOOST_LOG(rdErrorLog) << "\tdone" << std::endl;
+  
+}
+
 int main() {
   RDLog::InitLogs();
   testGithub940();
@@ -662,6 +728,6 @@ int main() {
   testVectToString();
 #endif
   testConstReturns();
-  
+  testUpdate();
   return 0;
 }


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! 
-->
#### Reference Issue

Fixes #1474

#### What does this implement/fix? Explain your changes.

Adds Dict.update and RDProps::updateProperties to update properties from another source.

This is now used in RWMol::replaceAtom and RWMol::replaceBond

#### Any other comments?

