### PR TITLE
Directly specify rotor model used in QED.

### DIFF
--- a/rdkit/Chem/QED.py
+++ b/rdkit/Chem/QED.py
@@ -253,7 +253,7 @@ def properties(mol):
             if mol.HasSubstructMatch(pattern)),
     HBD=rdmd.CalcNumHBD(mol),
     PSA=MolSurf.TPSA(mol),
-    ROTB=rdmd.CalcNumRotatableBonds(mol),
+    ROTB=rdmd.CalcNumRotatableBonds(mol, rdmd.NumRotatableBondsOptions.Strict),
     AROM=Chem.GetSSSR(Chem.DeleteSubstructs(Chem.Mol(mol), AliphaticRings)),
     ALERTS=sum(1 for alert in StructuralAlerts if mol.HasSubstructMatch(alert)),
   )


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! 
-->

#### What does this implement/fix? Explain your changes.

Explicitly calls the Strict Rotor calculation in QED since the default can change based on the CMAKE file.

#### Any other comments?
