### PR TITLE
Don't build AUTOCORR2D if 3D is turned off

### DIFF
--- a/Code/GraphMol/Descriptors/Wrap/rdMolDescriptors.cpp
+++ b/Code/GraphMol/Descriptors/Wrap/rdMolDescriptors.cpp
@@ -152,7 +152,6 @@ python::list calcAUTOCORR3Ds(const RDKit::ROMol &mol, int confId) {
   BOOST_FOREACH (double iv, res) { pyres.append(iv); }
   return pyres;
 }
-#endif
 
 python::list calcAUTOCORR2Ds(const RDKit::ROMol &mol) {
   std::vector<double> res;
@@ -161,6 +160,8 @@ python::list calcAUTOCORR2Ds(const RDKit::ROMol &mol) {
   BOOST_FOREACH (double iv, res) { pyres.append(iv); }
   return pyres;
 }
+
+#endif
 
 RDKit::SparseIntVect<boost::int32_t> *GetAtomPairFingerprint(
     const RDKit::ROMol &mol, unsigned int minLength, unsigned int maxLength,
@@ -1605,11 +1606,11 @@ BOOST_PYTHON_MODULE(rdMolDescriptors) {
               (python::arg("mol"), python::arg("confId") = -1),
               docString.c_str());
 
-#endif
-
   python::scope().attr("_CalcAUTOCORR2D_version") =
       RDKit::Descriptors::AUTOCORR2DVersion;
   docString = "Returns 2D Autocorrelation descriptors vector";
   python::def("CalcAUTOCORR2D", calcAUTOCORR2Ds, (python::arg("mol")),
               docString.c_str());
+
+#endif  
 }

--- a/Code/GraphMol/Descriptors/Wrap/test3D.py
+++ b/Code/GraphMol/Descriptors/Wrap/test3D.py
@@ -26,6 +26,7 @@ class TestCase(unittest.TestCase):
     'Descriptors','test_data')
     self.suppl = Chem.SDMolSupplier(os.path.join(self.dataDir,'PBF_egfr.sdf'),removeHs=False)
 
+  @unittest.skipIf(not haveDescrs3D,"3d descriptors not present")    
   def test1AUTOCORR2D(self):
       # not really a 3D descriptor, but this was added at the same time
       with open(os.path.join(self.dataDir,'auto2D.out')) as refFile:


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! 
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.

If we disable 3D descriptors, RDKit fails to build.

#### Any other comments?

Is there any reason *not* to always build 3D?  This would make the logic simpler.