### PR TITLE
do not include xlocale.h, as it was removed in glibc 2.26

### DIFF
--- a/Code/RDGeneral/LocaleSwitcher.cpp
+++ b/Code/RDGeneral/LocaleSwitcher.cpp
@@ -32,10 +32,8 @@
 
 // LocaleSwitcher Dependencies
 #include <clocale>
-#ifndef _WIN32
-#include <string>
-#else
-#include <locale.h>
+#ifdef __clang__
+#include <xlocale.h>
 #endif
 
 #ifdef RDK_THREADSAFE_SSS

--- a/Code/RDGeneral/LocaleSwitcher.cpp
+++ b/Code/RDGeneral/LocaleSwitcher.cpp
@@ -33,7 +33,6 @@
 // LocaleSwitcher Dependencies
 #include <clocale>
 #ifndef _WIN32
-#include <xlocale.h>
 #include <string>
 #else
 #include <locale.h>


### PR DESCRIPTION
According to
https://sourceware.org/glibc/wiki/Release/2.26#Removal_of_.27xlocale.h.27
the defines were a subset of locale.h, that we include anyway

<!--
Thanks for contributing a pull request! 
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.


#### Any other comments?

