### PR TITLE
- assorted fixes to get the current master branch to build on Windows

### DIFF
--- a/Code/GraphMol/Descriptors/CMakeLists.txt
+++ b/Code/GraphMol/Descriptors/CMakeLists.txt
@@ -29,21 +29,21 @@ LINK_LIBRARIES PartialCharges Descriptors FileParsers SmilesParse Subgraphs Subs
 
 if(RDK_BUILD_DESCRIPTORS3D)
   rdkit_test(testPBF testPBF.cpp
-LINK_LIBRARIES  Descriptors FileParsers SmilesParse MolTransforms GraphMol DataStructs EigenSolvers RDGeneral RDGeometryLib ${RDKit_THREAD_LIBS} )
+LINK_LIBRARIES  Descriptors FileParsers SmilesParse MolTransforms PartialCharges GraphMol DataStructs EigenSolvers RDGeneral RDGeometryLib ${RDKit_THREAD_LIBS} )
  rdkit_test(testRDF testRDF.cpp
-LINK_LIBRARIES  Descriptors FileParsers SmilesParse MolTransforms GraphMol DataStructs EigenSolvers RDGeneral RDGeometryLib ${RDKit_THREAD_LIBS} )
+LINK_LIBRARIES  Descriptors FileParsers SmilesParse MolTransforms PartialCharges GraphMol DataStructs EigenSolvers RDGeneral RDGeometryLib ${RDKit_THREAD_LIBS} )
  rdkit_test(testMORSE testMORSE.cpp
-LINK_LIBRARIES  Descriptors FileParsers SmilesParse MolTransforms GraphMol DataStructs EigenSolvers RDGeneral RDGeometryLib ${RDKit_THREAD_LIBS} )
+LINK_LIBRARIES  Descriptors FileParsers SmilesParse MolTransforms PartialCharges GraphMol DataStructs EigenSolvers RDGeneral RDGeometryLib ${RDKit_THREAD_LIBS} )
 rdkit_test(test3D test3D.cpp
-LINK_LIBRARIES  Descriptors FileParsers SmilesParse MolTransforms GraphMol DataStructs EigenSolvers RDGeneral RDGeometryLib ${RDKit_THREAD_LIBS} )
+LINK_LIBRARIES  Descriptors FileParsers SmilesParse MolTransforms PartialCharges GraphMol DataStructs EigenSolvers RDGeneral RDGeometryLib ${RDKit_THREAD_LIBS} )
   rdkit_test(testWHIM testWHIM.cpp
-LINK_LIBRARIES  Descriptors FileParsers SmilesParse MolTransforms GraphMol DataStructs EigenSolvers RDGeneral RDGeometryLib ${RDKit_THREAD_LIBS} )
+LINK_LIBRARIES  Descriptors FileParsers SmilesParse MolTransforms PartialCharges GraphMol DataStructs EigenSolvers RDGeneral RDGeometryLib ${RDKit_THREAD_LIBS} )
   rdkit_test(testGETAWAY testGETAWAY.cpp
-LINK_LIBRARIES  Descriptors FileParsers SmilesParse MolTransforms GraphMol DataStructs EigenSolvers RDGeneral RDGeometryLib ${RDKit_THREAD_LIBS} )
+LINK_LIBRARIES  Descriptors FileParsers SmilesParse MolTransforms PartialCharges GraphMol DataStructs EigenSolvers RDGeneral RDGeometryLib ${RDKit_THREAD_LIBS} )
   rdkit_test(testAUTOCORR3D testAUTOCORR3D.cpp
-LINK_LIBRARIES  Descriptors FileParsers SmilesParse MolTransforms GraphMol DataStructs EigenSolvers RDGeneral RDGeometryLib ${RDKit_THREAD_LIBS} )
+LINK_LIBRARIES  Descriptors FileParsers SmilesParse MolTransforms PartialCharges GraphMol DataStructs EigenSolvers RDGeneral RDGeometryLib ${RDKit_THREAD_LIBS} )
   rdkit_test(testAUTOCORR2D testAUTOCORR2D.cpp
-LINK_LIBRARIES  Descriptors FileParsers SmilesParse MolTransforms GraphMol DataStructs EigenSolvers RDGeneral RDGeometryLib ${RDKit_THREAD_LIBS} )
+LINK_LIBRARIES  Descriptors FileParsers SmilesParse MolTransforms PartialCharges GraphMol DataStructs EigenSolvers RDGeneral RDGeometryLib ${RDKit_THREAD_LIBS} )
 
 endif(RDK_BUILD_DESCRIPTORS3D)
 

--- a/Code/GraphMol/Descriptors/GETAWAY.cpp
+++ b/Code/GraphMol/Descriptors/GETAWAY.cpp
@@ -571,7 +571,7 @@ void getGETAWAYDesc(MatrixXd H, MatrixXd R, MatrixXd Adj, int numAtoms,
     }
     double* Bimat = GetGeodesicMatrix(dist, i, numAtoms);
     Map<MatrixXd> Bj(Bimat, numAtoms, numAtoms);
-    if (i > 0 and i < 9) {  // use Bj
+    if (i > 0 && i < 9) {  // use Bj
       for (int j = 0; j < numAtoms - 1; j++) {
         for (int k = j + 1; k < numAtoms; k++) {
           if (Bj(j, k) == 1) {
@@ -672,7 +672,7 @@ void getGETAWAYDesc(MatrixXd H, MatrixXd R, MatrixXd Adj, int numAtoms,
     Rkmaxs = 0;
 
     // from 1 to 8
-    if (i > 0 and i < 9) {
+    if (i > 0 && i < 9) {
       for (int j = 0; j < numAtoms - 1; j++) {
         for (int k = j + 1; k < numAtoms; k++) {
           if (Bj(j, k) == 1) {

--- a/Code/GraphMol/Descriptors/MolData3Ddescriptors.cpp
+++ b/Code/GraphMol/Descriptors/MolData3Ddescriptors.cpp
@@ -120,7 +120,7 @@ std::vector<double> MolData3Ddescriptors::GetIState(const RDKit::ROMol& mol) {
     const RDKit::Atom* atom = mol.getAtomWithIdx(i);
     int atNum = atom->getAtomicNum();
     int degree = atom->getDegree();  // number of substituants (heavy of not?)
-    if (degree > 0 and atNum > 1) {
+    if (degree > 0 && atNum > 1) {
       int h = atom->getTotalNumHs(
           true);  // caution getTotalNumHs(true) to count h !!!!
       int dv = RDKit::PeriodicTable::getTable()->getNouterElecs(atNum) -
@@ -145,7 +145,7 @@ std::vector<double> MolData3Ddescriptors::GetIStateDrag(
     const RDKit::Atom* atom = mol.getAtomWithIdx(i);
     int atNum = atom->getAtomicNum();
     int degree = atom->getDegree();  // number of substituants
-    if (degree > 0 and atNum > 1) {
+    if (degree > 0 && atNum > 1) {
       int h = atom->getTotalNumHs(true);
       int Zv = RDKit::PeriodicTable::getTable()->getNouterElecs(
           atNum);                  // number of valence (explicit with Hs)
@@ -170,11 +170,7 @@ std::vector<double> MolData3Ddescriptors::GetEState(const RDKit::ROMol& mol) {
 
   double tmp, p;
   double* dist = RDKit::MolOps::getDistanceMat(mol, false, false);
-  double accum[numAtoms];
-
-  for (int i = 0; i < numAtoms; i++) {
-    accum[i] = 0.0;
-  }
+  std::vector<double> accum(numAtoms, 0.0);
 
   for (int i = 0; i < numAtoms; i++) {
     for (int j = i + 1; j < numAtoms; j++) {
@@ -203,11 +199,7 @@ std::vector<double> MolData3Ddescriptors::GetEState2(const RDKit::ROMol& mol) {
   // in WHIM definition it's write:
   double tmp, p, d;
   double* dist = RDKit::MolOps::getDistanceMat(mol, false, false);
-  double accum[numAtoms];
-
-  for (int i = 0; i < numAtoms; i++) {
-    accum[i] = 0.0;
-  }
+  std::vector<double> accum(numAtoms, 0.0);
 
   for (int i = 0; i < numAtoms; i++) {
     for (int j = i + 1; j < numAtoms; j++) {

--- a/Code/GraphMol/Descriptors/WHIM.cpp
+++ b/Code/GraphMol/Descriptors/WHIM.cpp
@@ -154,42 +154,40 @@ std::vector<double> getWhimD(std::vector<double> weigthvector,
 	  
 // we should take into account atoms that are in the axis too!!! which is not trivial
   for (int i = 0; i < 3; i++) {
-    double Symetric[2*numAtoms];
+    std::vector<double> Symetric(2*numAtoms, 0.0);
     double ns = 0.0;
     double na = 0.0;
     for (int j = 0; j < numAtoms; j++) {
-       bool amatch = false;
-       for (int k = 0; k < numAtoms; k++) {
-	   if (j==k) {
-             continue;
-           }
-	   if (std::abs(Scores(j, i) + Scores(k, i)) <= th) {
-		  // those that are close opposite & not close to the axis!
-	          ns += 1;  // check only once the symetric none null we need to add +2!
-		            // (reduce the loop duration)
-		  amatch = true;
-		  Symetric[j]=1.0;
-		  Symetric[j+numAtoms]=2.0;
-		  Symetric[k]=1.0;
-		  Symetric[k+numAtoms]=2.0;
-		  break;
-            }
+      bool amatch = false;
+      for (int k = 0; k < numAtoms; k++) {
+	      if (j==k) {
+          continue;
         }
-        if (!amatch) {
-	 na +=1;
-         Symetric[j]=0.0;
-         Symetric[j+numAtoms]=std::abs(Scores(j, i));
+	      if (std::abs(Scores(j, i) + Scores(k, i)) <= th) {
+		      // those that are close opposite & not close to the axis!
+	        ns += 1;  // check only once the symetric none null we need to add +2!
+		      // (reduce the loop duration)
+		      amatch = true;
+		      Symetric[j]=1.0;
+		      Symetric[j+numAtoms]=2.0;
+		      Symetric[k]=1.0;
+		      Symetric[k+numAtoms]=2.0;
+		      break;
         }
+      }
+      if (!amatch) {
+        na +=1;
+        Symetric[j]=0.0;
+        Symetric[j+numAtoms]=std::abs(Scores(j, i));
+      }
     }
     // take into account the atoms close to the axis
     for (int aj = 0; aj < numAtoms; aj++) {
-	if (Symetric[aj+numAtoms]<th and Symetric[aj]<1.0) {
-		ns +=1;
-		na -=1;	
-	}
+	    if (Symetric[aj+numAtoms]<th && Symetric[aj]<1.0) {
+		    ns +=1;
+        na -=1;	
+      }
     }
-
-	  
     gamma[i] = 0.0;
     double gammainv=1.0;
     if (ns == 0) {
@@ -199,9 +197,8 @@ std::vector<double> getWhimD(std::vector<double> weigthvector,
       gammainv = 1.0 - ((ns / nAT) * log(ns / nAT) / log(2) +
                        (na / nAT) * log(1.0 / nAT) / log(2));   
     }
-  gamma[i]=1.0/gammainv;
+    gamma[i]=1.0/gammainv;
   }
-  
   w[14] = gamma[0];  // G1
   w[15] = gamma[1];  // G2
   w[16] = gamma[2];  // G3
@@ -212,7 +209,7 @@ std::vector<double> getWhimD(std::vector<double> weigthvector,
 }
 
 void GetWHIMs(const Conformer &conf, std::vector<double> &result,
-              double Vpoints[], double th) {
+              double *Vpoints, double th) {
   std::vector<double> wu(18);
   std::vector<double> wm(18);
   std::vector<double> wv(18);
@@ -274,7 +271,7 @@ void getWHIM(const ROMol &mol, std::vector<double> &res, int confId,
              double th) {
   int numAtoms = mol.getNumAtoms();
   const Conformer &conf = mol.getConformer(confId);
-  double Vpoints[3 * numAtoms];
+  double *Vpoints = new double[3 * numAtoms];
 
   for (int i = 0; i < numAtoms; ++i) {
     Vpoints[3 * i] = conf.getAtomPos(i).x;
@@ -284,6 +281,7 @@ void getWHIM(const ROMol &mol, std::vector<double> &res, int confId,
 
   std::vector<double> w(126);
   GetWHIMs(conf, w, Vpoints, th);
+  delete [] Vpoints;
 
   // Dragon extract only this list in this order : L1 L2 L3 P1 P2 G1 G2 G3 E1 E2
   // E3

--- a/Code/GraphMol/MolDraw2D/Wrap/CMakeLists.txt
+++ b/Code/GraphMol/MolDraw2D/Wrap/CMakeLists.txt
@@ -1,8 +1,8 @@
 rdkit_python_extension(rdMolDraw2D
                        rdMolDraw2D.cpp
                        DEST Chem/Draw
-                       LINK_LIBRARIES MolDraw2D
-Depictor FileParsers SubstructMatch MolTransforms GraphMol
+                       LINK_LIBRARIES ChemReactions MolDraw2D
+Depictor FileParsers SmilesParse SubstructMatch MolTransforms GraphMol
 DataStructs EigenSolvers RDGeometryLib RDGeneral RDBoost)
 
 add_pytest(pyMolDraw2D ${CMAKE_CURRENT_SOURCE_DIR}/testMolDraw2D.py)

--- a/Code/GraphMol/Wrap/CMakeLists.txt
+++ b/Code/GraphMol/Wrap/CMakeLists.txt
@@ -10,7 +10,7 @@ rdkit_python_extension(rdmolops
                        rdmolops.cpp MolOps.cpp
                        DEST Chem
                        LINK_LIBRARIES
-                       MolDraw2D Depictor FileParsers SubstructMatch Fingerprints ChemTransforms
+                       ChemReactions MolDraw2D Depictor FileParsers SubstructMatch Fingerprints ChemTransforms
                        Catalogs Subgraphs SmilesParse MolTransforms GraphMol EigenSolvers
 RDGeometryLib DataStructs RDGeneral RDBoost  )
 


### PR DESCRIPTION
- linked a few missing libraries that caused undefined references with MSVC
- changed a few `and` (that MSVC does not understand) into `&&`
- allocated a `double[]` as a `double *` on heap as MSVC does not accept non-const static arrays, and a couple others as `std::vector<double>`
- adjusted some indentation (purely cosmetic)