### PR TITLE
Fix #1496

### DIFF
--- a/Code/GraphMol/Fingerprints/PatternFingerprints.cpp
+++ b/Code/GraphMol/Fingerprints/PatternFingerprints.cpp
@@ -1,6 +1,5 @@
-// $Id$
 //
-//  Copyright (C) 2013 Greg Landrum and Rational Discovery LLC
+//  Copyright (C) 2013-2017 Greg Landrum and Rational Discovery LLC
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -33,7 +32,7 @@
 #include <boost/flyweight/no_tracking.hpp>
 #include <RDGeneral/BoostEndInclude.h>
 
-//#define VERBOSE_FINGERPRINTING 1
+// #define VERBOSE_FINGERPRINTING 1
 
 namespace {
 class ss_matcher {
@@ -73,7 +72,7 @@ const char *pqs[] = {
     //"[*]!@[R]~[R]!@[*]",  Github #151: can't have !@ in an SSS pattern
     //"[*]!@[R]~[R]~[R]!@[*]", Github #151: can't have !@ in an SSS pattern
     "[*]~[R](@[R])@[R](@[R])~[*]", "[*]~[R](@[R])@[R]@[R](@[R])~[*]",
-    "[D0]",  // special case: single atom fragment
+    "[*]",  // single atom fragment
 #if 0
                       "[*]~[*](~[*])(~[*])~[*]",
                       "[*]~[*]~[*]~[*]~[*]~[*]",

--- a/Code/GraphMol/Fingerprints/test1.cpp
+++ b/Code/GraphMol/Fingerprints/test1.cpp
@@ -3406,6 +3406,58 @@ void testGitHubIssue879() {
   BOOST_LOG(rdErrorLog) << "  done" << std::endl;
 }
 
+void testGitHubIssue1496() {
+  BOOST_LOG(rdErrorLog) << "-------------------------------------" << std::endl;
+  BOOST_LOG(rdErrorLog) << "Github #1496: Pattern fingerprint setting bad bits "
+                           "for degree zero atoms"
+                        << std::endl;
+  {
+    std::string smiles = "C";
+    ROMol *m1 = SmilesToMol(smiles);
+    TEST_ASSERT(m1);
+    TEST_ASSERT(m1->getNumAtoms() == 1);
+    ExplicitBitVect *bv1 = PatternFingerprintMol(*m1, 2048);
+    TEST_ASSERT(bv1);
+
+    std::string smarts = "[#6]";
+    ROMol *m2 = SmartsToMol(smarts);
+    TEST_ASSERT(m2);
+    TEST_ASSERT(m2->getNumAtoms() == 1);
+    ExplicitBitVect *bv2 = PatternFingerprintMol(*m2, 2048);
+    TEST_ASSERT(bv2);
+    TEST_ASSERT(bv1->getNumOnBits() >= bv2->getNumOnBits())
+    TEST_ASSERT(AllProbeBitsMatch(*bv2, *bv1));
+
+    delete m1;
+    delete bv1;
+    delete m2;
+    delete bv2;
+  }
+  {
+    std::string smiles = "CC";
+    ROMol *m1 = SmilesToMol(smiles);
+    TEST_ASSERT(m1);
+    TEST_ASSERT(m1->getNumAtoms() == 2);
+    ExplicitBitVect *bv1 = PatternFingerprintMol(*m1, 2048);
+    TEST_ASSERT(bv1);
+
+    std::string smarts = "[#6]";
+    ROMol *m2 = SmartsToMol(smarts);
+    TEST_ASSERT(m2);
+    TEST_ASSERT(m2->getNumAtoms() == 1);
+    ExplicitBitVect *bv2 = PatternFingerprintMol(*m2, 2048);
+    TEST_ASSERT(bv2);
+    TEST_ASSERT(bv1->getNumOnBits() > bv2->getNumOnBits())
+    TEST_ASSERT(AllProbeBitsMatch(*bv2, *bv1));
+
+    delete m1;
+    delete bv1;
+    delete m2;
+    delete bv2;
+  }
+  BOOST_LOG(rdErrorLog) << "  done" << std::endl;
+}
+
 int main(int argc, char *argv[]) {
   (void)argc;
   (void)argv;
@@ -3457,9 +3509,10 @@ int main(int argc, char *argv[]) {
   testGitHubIssue811();
   testRDKFPUnfolded();
   testRDKFPBitInfo();
-#endif
   testGitHubIssue874();
   testGitHubIssue879();
+#endif
+  testGitHubIssue1496();
 
   return 0;
 }

--- a/Code/PgSQL/rdkit/expected/reaction.out
+++ b/Code/PgSQL/rdkit/expected/reaction.out
@@ -660,7 +660,7 @@ SELECT tanimoto_sml(reaction_structural_bfp('c1ccccc1>>c1ccncc1',5), reaction_st
 SELECT tanimoto_sml(reaction_structural_bfp('c1ccccc1>>c1ccncc1',5), reaction_structural_bfp('c1ncccc1>>c1ncncc1',5));
    tanimoto_sml    
 -------------------
- 0.771428571428571
+ 0.793388429752066
 (1 row)
 
 SELECT tanimoto_sml(reaction_structural_bfp('c1ccccc1>CC(=O)O.[Na+]>c1ccncc1',5), reaction_structural_bfp('c1ccccc1>CC(=O)O.[Na+]>c1ccncc1',5));
@@ -672,7 +672,7 @@ SELECT tanimoto_sml(reaction_structural_bfp('c1ccccc1>CC(=O)O.[Na+]>c1ccncc1',5)
 SELECT tanimoto_sml(reaction_structural_bfp('c1ccccc1>CC(=O)O.[Na+]>c1ccncc1',5), reaction_structural_bfp('c1ncccc1>[Na+]>c1ncncc1',5));
    tanimoto_sml    
 -------------------
- 0.588652482269504
+ 0.604938271604938
 (1 row)
 
 SET rdkit.agent_FP_bit_ratio=0.5;
@@ -853,9 +853,9 @@ SELECT tanimoto_sml(reaction_structural_bfp('c1ccccc1>>c1ccncc1',5), reaction_st
 (1 row)
 
 SELECT tanimoto_sml(reaction_structural_bfp('c1ccccc1>>c1ccncc1',5), reaction_structural_bfp('c1ncccc1>>c1ncncc1',5));
-   tanimoto_sml    
--------------------
- 0.778846153846154
+ tanimoto_sml 
+--------------
+          0.8
 (1 row)
 
 SELECT tanimoto_sml(reaction_structural_bfp('c1ccccc1>CC(=O)O.[Na+]>c1ccncc1',5), reaction_structural_bfp('c1ccccc1>CC(=O)O.[Na+]>c1ccncc1',5));
@@ -867,7 +867,7 @@ SELECT tanimoto_sml(reaction_structural_bfp('c1ccccc1>CC(=O)O.[Na+]>c1ccncc1',5)
 SELECT tanimoto_sml(reaction_structural_bfp('c1ccccc1>CC(=O)O.[Na+]>c1ccncc1',5), reaction_structural_bfp('c1ncccc1>[Na+]>c1ncncc1',5));
    tanimoto_sml    
 -------------------
- 0.592857142857143
+ 0.608695652173913
 (1 row)
 
 SET rdkit.ignore_reaction_agents=true;
@@ -902,9 +902,9 @@ SELECT tanimoto_sml(reaction_structural_bfp('c1ccccc1>>c1ccncc1',5), reaction_st
 (1 row)
 
 SELECT tanimoto_sml(reaction_structural_bfp('c1ccccc1>>c1ccncc1',5), reaction_structural_bfp('c1ncccc1>>c1ncncc1',5));
-   tanimoto_sml    
--------------------
- 0.778846153846154
+ tanimoto_sml 
+--------------
+          0.8
 (1 row)
 
 SELECT tanimoto_sml(reaction_structural_bfp('c1ccccc1>CC(=O)O.[Na+]>c1ccncc1',5), reaction_structural_bfp('c1ccccc1>CC(=O)O.[Na+]>c1ccncc1',5));
@@ -914,9 +914,9 @@ SELECT tanimoto_sml(reaction_structural_bfp('c1ccccc1>CC(=O)O.[Na+]>c1ccncc1',5)
 (1 row)
 
 SELECT tanimoto_sml(reaction_structural_bfp('c1ccccc1>CC(=O)O.[Na+]>c1ccncc1',5), reaction_structural_bfp('c1ncccc1>[Na+]>c1ncncc1',5));
-   tanimoto_sml    
--------------------
- 0.778846153846154
+ tanimoto_sml 
+--------------
+          0.8
 (1 row)
 
 SET enable_indexscan=on;


### PR DESCRIPTION
This fixes the problem caused by the fix for #879 in a reasonable way: instead of adding a bit for degree zero atoms (which then breaks for single atom queries), we add a pattern that just recognizes individual atoms.

The side affect here is, unfortunately, that it breaks backwards compatibility with previous pattern fingerprints. This raises the question as to whether or not we should assign #1496 to the `2017_09_1` release instead of `2017_03_4`. At the moment I would lean towards not making such an obvious compatibility breaking change in a patch release, but I see arguments both ways. @bp-kelley : what's  your thought here? 

Note that decision about which milestone we assign #1496 to doesn't have any impact on this correctness of this particular PR, it's just a question we need to consider at the same time.