### PR TITLE
Adds canonicalization of atom maps

### DIFF
--- a/Code/GraphMol/MMPA/MMPA.cpp
+++ b/Code/GraphMol/MMPA/MMPA.cpp
@@ -295,7 +295,7 @@ static void addResult(std::vector<std::pair<ROMOL_SPTR, ROMOL_SPTR> >&
     }
   }
   if (!resFound) {
-    std::cerr << "**********************" << std::endl;
+    //std::cerr << "**********************" << std::endl;
     // From rfrag.py
     // now change the labels on sidechains and core
     // to get the new labels, cansmi the dot-disconnected side chains
@@ -320,7 +320,7 @@ static void addResult(std::vector<std::pair<ROMOL_SPTR, ROMOL_SPTR> >&
       MolOps::sanitizeMol(_side_chain);
       const bool doIsomericSmiles = true; // should this be false???
       std::string smiles = MolToSmiles(_side_chain, true);
-      std::cerr << "smiles: " << smiles << std::endl;
+      //std::cerr << "smiles: " << smiles << std::endl;
       const std::vector<unsigned int> &ranks = _side_chain.getProp<
         std::vector<unsigned int> >(
           common_properties::_smilesAtomOutputOrder);
@@ -331,41 +331,17 @@ static void addResult(std::vector<std::pair<ROMOL_SPTR, ROMOL_SPTR> >&
         unsigned int atom_idx = ranks[idx];
         if(oldMaps[atom_idx] >0) {
           const int label = oldMaps[atom_idx];
-          std::cerr << "atom_idx: " << atom_idx << " rank: " << ranks[atom_idx] <<
-              " molAtomMapNumber: " << label << std::endl;
+          //std::cerr << "atom_idx: " << atom_idx << " rank: " << ranks[atom_idx] <<
+          //    " molAtomMapNumber: " << label << std::endl;
           rankedAtoms.push_back(std::make_pair(idx, label));
         }
       }
       std::sort(rankedAtoms.begin(), rankedAtoms.end());
       for(size_t i=0;i<rankedAtoms.size();++i) {
-        std::cerr << "Remapping: " << rankedAtoms[i].second << " " << " to " << (i+1) <<
-            std::endl;
+        //std::cerr << "Remapping: " << rankedAtoms[i].second << " " << " to " << (i+1) <<
+        //    std::endl;
         canonicalAtomMaps[rankedAtoms[i].second] = (int)(i+1);
       }
-
-      /*
-      std::vector<unsigned int> ranks(mol.getNumAtoms());
-      const bool breakTies = true;
-      const bool includeChirality = true;
-      const bool includeIsotopes = true;
-      Canon::rankMolAtoms(_side_chain, ranks, breakTies, includeChirality, includeIsotopes);
-      std::vector<std::pair<unsigned int, int> > rankedAtoms;
-      
-      for(size_t atom_idx=0;atom_idx<ranks.size();++atom_idx) {
-        if(oldMaps[atom_idx] >0) {
-          const int label = oldMaps[atom_idx];
-          std::cerr << "atom_idx: " << atom_idx << " rank: " << ranks[atom_idx] <<
-              " molAtomMapNumber: " << label << std::endl;
-          rankedAtoms.push_back(std::make_pair(ranks[atom_idx], label));
-        }
-      }
-      std::sort(rankedAtoms.begin(), rankedAtoms.end());
-      for(size_t i=0;i<rankedAtoms.size();++i) {
-        std::cerr << "Remapping: " << rankedAtoms[i].second << " " << " to " << (i+1) <<
-            std::endl;
-        canonicalAtomMaps[rankedAtoms[i].second] = (int)(i+1);
-      }
-      */
     }
 
     if( core.get() ) { // remap core if it exists
@@ -373,8 +349,8 @@ static void addResult(std::vector<std::pair<ROMOL_SPTR, ROMOL_SPTR> >&
            ++at) {
         int label = 0;
         if ((*at)->getPropIfPresent(common_properties::molAtomMapNumber, label) ) {
-          std::cerr << "reammping core: " << label << " :" << canonicalAtomMaps[label] <<
-              std::endl;
+          //std::cerr << "remapping core: " << label << " :" << canonicalAtomMaps[label] <<
+          //    std::endl;
           (*at)->setProp(common_properties::molAtomMapNumber, canonicalAtomMaps[label]);
         }
       }
@@ -384,8 +360,8 @@ static void addResult(std::vector<std::pair<ROMOL_SPTR, ROMOL_SPTR> >&
          ++at) {
       int label = 0;
       if ((*at)->getPropIfPresent(common_properties::molAtomMapNumber, label) ) {
-        std::cerr << "reammping side chain: " << label << " :" << 
-         canonicalAtomMaps[label] << std::endl;
+        //std::cerr << "remapping side chain: " << label << " :" << 
+        // canonicalAtomMaps[label] << std::endl;
         (*at)->setProp(common_properties::molAtomMapNumber, canonicalAtomMaps[label]);
       }
     }

--- a/Code/GraphMol/MMPA/Wrap/testMMPA.py
+++ b/Code/GraphMol/MMPA/Wrap/testMMPA.py
@@ -33,13 +33,13 @@ class TestCase(unittest.TestCase):
 
     fs = Chem.GetMolFrags(frags[0][1], asMols=True)
     self.assertEqual(len(fs), 2)
-    self.assertEqual(Chem.MolToSmiles(fs[0], True), 'c1ccc([*:2])cc1')
-    self.assertEqual(Chem.MolToSmiles(fs[1], True), 'CO[*:2]')
+    self.assertEqual(Chem.MolToSmiles(fs[0], True), 'c1ccc([*:1])cc1')
+    self.assertEqual(Chem.MolToSmiles(fs[1], True), 'CO[*:1]')
 
     fs = Chem.GetMolFrags(frags[1][1], asMols=True)
     self.assertEqual(len(fs), 2)
-    self.assertEqual(Chem.MolToSmiles(fs[0], True), 'c1ccc(O[*:2])cc1')
-    self.assertEqual(Chem.MolToSmiles(fs[1], True), 'C[*:2]')
+    self.assertEqual(Chem.MolToSmiles(fs[0], True), 'c1ccc(O[*:1])cc1')
+    self.assertEqual(Chem.MolToSmiles(fs[1], True), 'C[*:1]')
 
     fs = Chem.GetMolFrags(frags[2][0], asMols=True)
     self.assertEqual(len(fs), 1)
@@ -63,8 +63,8 @@ class TestCase(unittest.TestCase):
     self.assertNotEqual(frags[1][1], '')
     self.assertNotEqual(frags[2][1], '')
 
-    self.assertEqual(frags[0][1], 'CO[*:2].c1ccc(cc1)[*:2]')
-    self.assertEqual(frags[1][1], 'C[*:2].c1ccc(cc1)O[*:2]')
+    self.assertEqual(frags[0][1], 'CO[*:1].c1ccc(cc1)[*:1]')
+    self.assertEqual(frags[1][1], 'C[*:1].c1ccc(cc1)O[*:1]')
     self.assertEqual(frags[2][0], 'O([*:1])[*:2]')
     self.assertEqual(frags[2][1], 'C[*:1].c1ccc([*:2])cc1')
 
@@ -78,7 +78,7 @@ class TestCase(unittest.TestCase):
     self.assertEqual(frags[0][0], '')
     self.assertNotEqual(frags[0][1], '')
 
-    self.assertEqual(frags[0][1], 'CO[*:2].c1ccc(cc1)[*:2]')
+    self.assertEqual(frags[0][1], 'CO[*:1].c1ccc(cc1)[*:1]')
 
   def test4(self):
     m = Chem.MolFromSmiles('Cc1ccccc1NC(=O)C(C)[NH+]1CCCC1')  # ZINC00000051

--- a/Code/GraphMol/MMPA/Wrap/testMMPA.py
+++ b/Code/GraphMol/MMPA/Wrap/testMMPA.py
@@ -33,21 +33,21 @@ class TestCase(unittest.TestCase):
 
     fs = Chem.GetMolFrags(frags[0][1], asMols=True)
     self.assertEqual(len(fs), 2)
-    self.assertEqual(Chem.MolToSmiles(fs[0], True), 'c1ccc([*:1])cc1')
-    self.assertEqual(Chem.MolToSmiles(fs[1], True), 'CO[*:1]')
+    self.assertEqual(Chem.MolToSmiles(fs[0], True), 'c1ccc([*:2])cc1')
+    self.assertEqual(Chem.MolToSmiles(fs[1], True), 'CO[*:2]')
 
     fs = Chem.GetMolFrags(frags[1][1], asMols=True)
     self.assertEqual(len(fs), 2)
-    self.assertEqual(Chem.MolToSmiles(fs[0], True), 'c1ccc(O[*:1])cc1')
-    self.assertEqual(Chem.MolToSmiles(fs[1], True), 'C[*:1]')
+    self.assertEqual(Chem.MolToSmiles(fs[0], True), 'c1ccc(O[*:2])cc1')
+    self.assertEqual(Chem.MolToSmiles(fs[1], True), 'C[*:2]')
 
     fs = Chem.GetMolFrags(frags[2][0], asMols=True)
     self.assertEqual(len(fs), 1)
     self.assertEqual(Chem.MolToSmiles(fs[0], True), 'O([*:1])[*:2]')
     fs = Chem.GetMolFrags(frags[2][1], asMols=True)
     self.assertEqual(len(fs), 2)
-    self.assertEqual(Chem.MolToSmiles(fs[0], True), 'c1ccc([*:1])cc1')
-    self.assertEqual(Chem.MolToSmiles(fs[1], True), 'C[*:2]')
+    self.assertEqual(Chem.MolToSmiles(fs[0], True), 'c1ccc([*:2])cc1')
+    self.assertEqual(Chem.MolToSmiles(fs[1], True), 'C[*:1]')
 
   def test2(self):
     m = Chem.MolFromSmiles('c1ccccc1OC')
@@ -63,10 +63,10 @@ class TestCase(unittest.TestCase):
     self.assertNotEqual(frags[1][1], '')
     self.assertNotEqual(frags[2][1], '')
 
-    self.assertEqual(frags[0][1], 'CO[*:1].c1ccc(cc1)[*:1]')
-    self.assertEqual(frags[1][1], 'C[*:1].c1ccc(cc1)O[*:1]')
+    self.assertEqual(frags[0][1], 'CO[*:2].c1ccc(cc1)[*:2]')
+    self.assertEqual(frags[1][1], 'C[*:2].c1ccc(cc1)O[*:2]')
     self.assertEqual(frags[2][0], 'O([*:1])[*:2]')
-    self.assertEqual(frags[2][1], 'C[*:2].c1ccc([*:1])cc1')
+    self.assertEqual(frags[2][1], 'C[*:1].c1ccc([*:2])cc1')
 
   def test3(self):
     m = Chem.MolFromSmiles('c1ccccc1OC')
@@ -78,7 +78,7 @@ class TestCase(unittest.TestCase):
     self.assertEqual(frags[0][0], '')
     self.assertNotEqual(frags[0][1], '')
 
-    self.assertEqual(frags[0][1], 'CO[*:1].c1ccc(cc1)[*:1]')
+    self.assertEqual(frags[0][1], 'CO[*:2].c1ccc(cc1)[*:2]')
 
   def test4(self):
     m = Chem.MolFromSmiles('Cc1ccccc1NC(=O)C(C)[NH+]1CCCC1')  # ZINC00000051


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! 
-->
#### Reference Issue
Fixes #1407


#### What does this implement/fix? Explain your changes.
Properly maps atom maps to the side chains.

#### Any other comments?

Current output

```
Contrib/mmpa/rfrag.py <cs_c.smi | grep ':3'
Nc1cc(O)cc(Cl)c1,a,c1c([*:1])cc([*:3])cc1[*:2],Cl[*:1].N[*:2].O[*:3]
Nc1occ(Cl)c1O,b,c1oc([*:2])c([*:3])c1[*:1],Cl[*:1].N[*:2].O[*:3]
```

This seems like a bit of overkill, perhaps there is a better way.