### PR TITLE
fixes #1447

### DIFF
--- a/Code/DataStructs/Wrap/DataStructs.cpp
+++ b/Code/DataStructs/Wrap/DataStructs.cpp
@@ -14,6 +14,8 @@
 #include <RDBoost/Wrap.h>
 #include <DataStructs/BitVects.h>
 #include <DataStructs/DiscreteValueVect.h>
+#include <DataStructs/SparseIntVect.h>
+
 #include "DataStructs.h"
 #include <boost/python/numeric.hpp>
 #include <numpy/npy_common.h>
@@ -80,6 +82,22 @@ BOOST_PYTHON_MODULE(cDataStructs) {
       (python::arg("bv"), python::arg("destArray")));
   python::def("ConvertToNumpyArray",
               (void (*)(const RDKit::DiscreteValueVect &,
+                        python::object))convertToNumpyArray,
+              (python::arg("bv"), python::arg("destArray")));
+  python::def("ConvertToNumpyArray",
+              (void (*)(const RDKit::SparseIntVect<boost::int32_t> &,
+                        python::object))convertToNumpyArray,
+              (python::arg("bv"), python::arg("destArray")));
+  python::def("ConvertToNumpyArray",
+              (void (*)(const RDKit::SparseIntVect<boost::int64_t> &,
+                        python::object))convertToNumpyArray,
+              (python::arg("bv"), python::arg("destArray")));
+  python::def("ConvertToNumpyArray",
+              (void (*)(const RDKit::SparseIntVect<boost::uint32_t> &,
+                        python::object))convertToNumpyArray,
+              (python::arg("bv"), python::arg("destArray")));
+  python::def("ConvertToNumpyArray",
+              (void (*)(const RDKit::SparseIntVect<boost::uint64_t> &,
                         python::object))convertToNumpyArray,
               (python::arg("bv"), python::arg("destArray")));
 }

--- a/Code/DataStructs/Wrap/testBV.py
+++ b/Code/DataStructs/Wrap/testBV.py
@@ -87,7 +87,7 @@ class TestCase(unittest.TestCase):
     nbits = 10
     bv1 = DataStructs.ExplicitBitVect(nbits)
     bv1[0]
-    with self.assertRaisesRegexp(IndexError, ""):
+    with self.assertRaisesRegex(IndexError, ""):
       bv1[11]
 
   def test4OnBitsInCommon(self):
@@ -190,16 +190,31 @@ class TestCase(unittest.TestCase):
 
   def test9ToNumpy(self):
     import numpy
-    bv = DataStructs.ExplicitBitVect(32)
-    bv.SetBit(0)
-    bv.SetBit(1)
-    bv.SetBit(17)
-    bv.SetBit(23)
-    bv.SetBit(31)
-    arr = numpy.zeros((3, ), 'i')
-    DataStructs.ConvertToNumpyArray(bv, arr)
-    for i in range(bv.GetNumBits()):
-      self.assertEqual(bv[i], arr[i])
+    for typ in (DataStructs.ExplicitBitVect,):
+        bv = typ(32)
+        bv.SetBit(0)
+        bv.SetBit(1)
+        bv.SetBit(17)
+        bv.SetBit(23)
+        bv.SetBit(31)
+        arr = numpy.zeros((32, ), 'i')
+        DataStructs.ConvertToNumpyArray(bv, arr)
+        for i in range(bv.GetNumBits()):
+          self.assertEqual(bv[i], arr[i])
+
+    for typ in (DataStructs.IntSparseIntVect,
+        DataStructs.LongSparseIntVect, DataStructs.UIntSparseIntVect,
+        DataStructs.ULongSparseIntVect):
+        iv = typ(32)
+        iv[0] = 1
+        iv[1] = 1
+        iv[17] = 1
+        iv[23] = 1
+        iv[31] = 1
+        arr = numpy.zeros((32, ), 'i')
+        DataStructs.ConvertToNumpyArray(iv, arr)
+        for i in range(iv.GetLength()):
+          self.assertEqual(iv[i], arr[i])
 
   def test10BulkOps2(self):
     nbits = 10000

--- a/Code/DataStructs/Wrap/testBV.py
+++ b/Code/DataStructs/Wrap/testBV.py
@@ -87,7 +87,7 @@ class TestCase(unittest.TestCase):
     nbits = 10
     bv1 = DataStructs.ExplicitBitVect(nbits)
     bv1[0]
-    with self.assertRaisesRegex(IndexError, ""):
+    with self.assertRaisesRegexp(IndexError, ""):
       bv1[11]
 
   def test4OnBitsInCommon(self):


### PR DESCRIPTION
adds `ConvertToNumPyArray()` versions for the various `SparseIntVect` types