### PR TITLE
Add a MolBundle class

### DIFF
--- a/Code/GraphMol/CMakeLists.txt
+++ b/Code/GraphMol/CMakeLists.txt
@@ -39,6 +39,7 @@ rdkit_headers(Atom.h
               SanitException.h
               MonomerInfo.h
               new_canon.h
+              MolBundle.h
               DEST GraphMol)
 
 add_subdirectory(Depictor)
@@ -118,3 +119,6 @@ rdkit_test(graphmolMemTest1 memtest1.cpp LINK_LIBRARIES SmilesParse GraphMol RDG
 
 rdkit_test(resMolSupplierTest resMolSupplierTest.cpp
            LINK_LIBRARIES SmilesParse GraphMol RDGeometryLib RDGeneral SubstructMatch FileParsers)
+
+rdkit_test(molBundleTest testMolBundle.cpp
+          LINK_LIBRARIES SmilesParse GraphMol RDGeometryLib RDGeneral SubstructMatch FileParsers)

--- a/Code/GraphMol/MolBundle.h
+++ b/Code/GraphMol/MolBundle.h
@@ -33,29 +33,27 @@ class ROMol;
 //! MolBundle contains (conceptually) a collection of ROMols with the same
 //! topology
 /*!
-  This is designed for allowing handling of things like enhanced stereochemistr.
-
-
- */
-
+  This is designed to allow handling things like enhanced stereochemistry,
+  but can no doubt be (ab)used in other ways.
+*/
 class MolBundle : public RDProps {
  public:
   MolBundle() : RDProps(){};
 
-  //! copy constructor with a twist
-  /*!
-    \param other     the molecule to be copied
-  */
+  //! copy constructor
   MolBundle(const MolBundle &other) : RDProps(other) { d_mols = other.d_mols; };
-  //! construct from a pickle string
-  // MolBundle(const std::string &binStr);
+  // FIX: need serialization/deserialization
 
   virtual ~MolBundle(){};
 
+  //! returns our molecules
   virtual const std::vector<boost::shared_ptr<ROMol> > &getMols() const {
     return d_mols;
   };
 
+  //! adds a new molecule and returns the total number of molecules
+  //!  enforces that the new molecule has the same number of atoms and bonds
+  //!  as the molecules that are already there.
   unsigned int addMol(boost::shared_ptr<ROMol> nmol) {
     PRECONDITION(nmol.get(), "bad mol pointer");
     if (d_mols.size()) {
@@ -70,11 +68,14 @@ class MolBundle : public RDProps {
     d_mols.push_back(nmol);
     return (d_mols.size());
   }
+  //! returns the number of molecules from the bundle
   unsigned int size() const { return d_mols.size(); };
+  //! returns a particular molecule in the bundle
   const boost::shared_ptr<ROMol> getMol(size_t idx) const {
     if (idx >= d_mols.size()) throw IndexErrorException(idx);
     return d_mols[idx];
   };
+  //! returns a particular molecule from the bundle
   const boost::shared_ptr<ROMol> operator[](size_t idx) const {
     return getMol(idx);
   };

--- a/Code/GraphMol/MolBundle.h
+++ b/Code/GraphMol/MolBundle.h
@@ -1,0 +1,77 @@
+//
+//  Copyright (C) 2017 Greg Landrum
+//
+//   @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
+//
+/*! \file MolBundle.h
+
+  \brief Defines a class for managing bundles of molecules
+
+*/
+
+#ifndef RD_MOLBUNDLE_AUG2017
+#define RD_MOLBUNDLE_AUG2017
+
+/// Std stuff
+#include <vector>
+
+// boost stuff
+#include <RDGeneral/BoostStartInclude.h>
+#include <boost/smart_ptr.hpp>
+#include <RDGeneral/BoostEndInclude.h>
+
+namespace RDKit {
+class ROMol;
+
+//! MolBundle contains (conceptually) a collection of ROMols with the same
+//! topology
+/*!
+  This is designed for allowing handling of things like enhanced stereochemistr.
+
+
+ */
+
+class MolBundle : public RDProps {
+ public:
+  MolBundle() : RDProps(){};
+
+  //! copy constructor with a twist
+  /*!
+    \param other     the molecule to be copied
+  */
+  MolBundle(const MolBundle &other) : RDProps(other) { d_mols = other.d_mols; };
+  //! construct from a pickle string
+  // MolBundle(const std::string &binStr);
+
+  virtual ~MolBundle(){};
+
+  virtual const std::vector<boost::shared_ptr<ROMol> > &getMols() const {
+    return d_mols;
+  };
+
+  unsigned int addMol(boost::shared_ptr<ROMol> nmol) {
+    if (d_mols.size()) {
+      // FIX: verify size
+    }
+    d_mols.push_back(nmol);
+    return (d_mols.size());
+  }
+  unsigned int size() const { return d_mols.size(); };
+  const boost::shared_ptr<ROMol> getMol(size_t idx) const {
+    PRECONDITION(idx < d_mols.size(), "bad index");
+    return d_mols[idx];
+  };
+  const boost::shared_ptr<ROMol> operator[](size_t idx) const {
+    return getMol(idx);
+  };
+
+ private:
+  std::vector<boost::shared_ptr<ROMol> > d_mols;
+};
+
+};  // end of RDKit namespace
+#endif

--- a/Code/GraphMol/MolBundle.h
+++ b/Code/GraphMol/MolBundle.h
@@ -24,6 +24,9 @@
 #include <boost/smart_ptr.hpp>
 #include <RDGeneral/BoostEndInclude.h>
 
+// our stuff
+#include <RDGeneral/Exceptions.h>
+
 namespace RDKit {
 class ROMol;
 
@@ -54,15 +57,22 @@ class MolBundle : public RDProps {
   };
 
   unsigned int addMol(boost::shared_ptr<ROMol> nmol) {
+    PRECONDITION(nmol.get(), "bad mol pointer");
     if (d_mols.size()) {
-      // FIX: verify size
+      if (nmol->getNumAtoms() != d_mols[0]->getNumAtoms())
+        throw ValueErrorException(
+            "all molecules in a bundle must have the same number of atoms");
+      // REVIEW: should we allow different numbers of bonds?
+      if (nmol->getNumBonds() != d_mols[0]->getNumBonds())
+        throw ValueErrorException(
+            "all molecules in a bundle must have the same number of atoms");
     }
     d_mols.push_back(nmol);
     return (d_mols.size());
   }
   unsigned int size() const { return d_mols.size(); };
   const boost::shared_ptr<ROMol> getMol(size_t idx) const {
-    PRECONDITION(idx < d_mols.size(), "bad index");
+    if (idx >= d_mols.size()) throw IndexErrorException(idx);
     return d_mols[idx];
   };
   const boost::shared_ptr<ROMol> operator[](size_t idx) const {

--- a/Code/GraphMol/MolBundle.h
+++ b/Code/GraphMol/MolBundle.h
@@ -54,7 +54,7 @@ class MolBundle : public RDProps {
   //! adds a new molecule and returns the total number of molecules
   //!  enforces that the new molecule has the same number of atoms and bonds
   //!  as the molecules that are already there.
-  unsigned int addMol(boost::shared_ptr<ROMol> nmol) {
+  virtual size_t addMol(boost::shared_ptr<ROMol> nmol) {
     PRECONDITION(nmol.get(), "bad mol pointer");
     if (d_mols.size()) {
       if (nmol->getNumAtoms() != d_mols[0]->getNumAtoms())
@@ -63,20 +63,20 @@ class MolBundle : public RDProps {
       // REVIEW: should we allow different numbers of bonds?
       if (nmol->getNumBonds() != d_mols[0]->getNumBonds())
         throw ValueErrorException(
-            "all molecules in a bundle must have the same number of atoms");
+            "all molecules in a bundle must have the same number of bonds");
     }
     d_mols.push_back(nmol);
     return (d_mols.size());
   }
   //! returns the number of molecules from the bundle
-  unsigned int size() const { return d_mols.size(); };
+  virtual size_t size() const { return d_mols.size(); };
   //! returns a particular molecule in the bundle
-  const boost::shared_ptr<ROMol> getMol(size_t idx) const {
+  virtual const boost::shared_ptr<ROMol> getMol(size_t idx) const {
     if (idx >= d_mols.size()) throw IndexErrorException(idx);
     return d_mols[idx];
   };
   //! returns a particular molecule from the bundle
-  const boost::shared_ptr<ROMol> operator[](size_t idx) const {
+  virtual const boost::shared_ptr<ROMol> operator[](size_t idx) const {
     return getMol(idx);
   };
 

--- a/Code/GraphMol/ROMol.h
+++ b/Code/GraphMol/ROMol.h
@@ -42,11 +42,8 @@ typedef boost::shared_ptr<Atom> ATOM_SPTR;
 typedef boost::shared_ptr<Bond> BOND_SPTR;
 
 //! This is the BGL type used to store the topology:
-typedef boost::adjacency_list<
-    boost::vecS,
-    boost::vecS,
-    boost::undirectedS,
-    ATOM_SPTR, BOND_SPTR>
+typedef boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS,
+                              ATOM_SPTR, BOND_SPTR>
     MolGraph;
 class MolPickler;
 class RWMol;
@@ -191,7 +188,8 @@ class ROMol : public RDProps {
     only
          the specified conformer from \c other.
   */
-  ROMol(const ROMol &other, bool quickCopy = false, int confId = -1) : RDProps() {
+  ROMol(const ROMol &other, bool quickCopy = false, int confId = -1)
+      : RDProps() {
     dp_ringInfo = 0;
     initFromOther(other, quickCopy, confId);
     numBonds = rdcast<unsigned int>(boost::num_edges(d_graph));
@@ -596,12 +594,10 @@ class ROMol : public RDProps {
   ROMol &operator=(
       const ROMol &);  // disable assignment, RWMol's support assignment
 
-protected:
-  unsigned int numBonds;  
+ protected:
+  unsigned int numBonds;
 #ifndef WIN32
-private:
-
-
+ private:
 #endif
   void initMol();
   virtual void destroy();

--- a/Code/GraphMol/Substruct/SubstructMatch.cpp
+++ b/Code/GraphMol/Substruct/SubstructMatch.cpp
@@ -367,6 +367,19 @@ bool SubstructMatch(const ROMol &mol, const MolBundle &bundle,
   return res;
 }
 
+bool SubstructMatch(const MolBundle &bundle, const MolBundle &qbundle,
+                    MatchVectType &matchVect, bool recursionPossible,
+                    bool useChirality, bool useQueryQueryMatches) {
+  bool res = false;
+  for (unsigned int i = 0; i < bundle.size() && !res; ++i) {
+    for (unsigned int j = 0; j < bundle.size() && !res; ++j) {
+      res =
+          SubstructMatch(*bundle[i], *qbundle[j], matchVect, recursionPossible,
+                         useChirality, useQueryQueryMatches);
+    }
+  }
+  return res;
+}
 // ----------------------------------------------
 //
 // find one match in ResonanceMolSupplier object
@@ -456,6 +469,48 @@ unsigned int SubstructMatch(const ROMol &mol, const ROMol &query,
       v->d_mutex.unlock();
   }
 #endif
+  return res;
+}
+
+unsigned int SubstructMatch(const MolBundle &mol, const ROMol &query,
+                            std::vector<MatchVectType> &matches, bool uniquify,
+                            bool recursionPossible, bool useChirality,
+                            bool useQueryQueryMatches,
+                            unsigned int maxMatches) {
+  unsigned int res = 0;
+  for (unsigned int i = 0; i < mol.size() && !res; ++i) {
+    res = SubstructMatch(*mol[i], query, matches, uniquify, recursionPossible,
+                         useChirality, useQueryQueryMatches, maxMatches);
+  }
+  return res;
+}
+
+unsigned int SubstructMatch(const ROMol &mol, const MolBundle &query,
+                            std::vector<MatchVectType> &matches, bool uniquify,
+                            bool recursionPossible, bool useChirality,
+                            bool useQueryQueryMatches,
+                            unsigned int maxMatches) {
+  unsigned int res = 0;
+  for (unsigned int i = 0; i < query.size() && !res; ++i) {
+    res = SubstructMatch(mol, *query[i], matches, uniquify, recursionPossible,
+                         useChirality, useQueryQueryMatches, maxMatches);
+  }
+  return res;
+}
+
+unsigned int SubstructMatch(const MolBundle &mol, const MolBundle &query,
+                            std::vector<MatchVectType> &matches, bool uniquify,
+                            bool recursionPossible, bool useChirality,
+                            bool useQueryQueryMatches,
+                            unsigned int maxMatches) {
+  unsigned int res = 0;
+  for (unsigned int i = 0; i < mol.size() && !res; ++i) {
+    for (unsigned int j = 0; j < query.size() && !res; ++j) {
+      res = SubstructMatch(*mol[i], *query[j], matches, uniquify,
+                           recursionPossible, useChirality,
+                           useQueryQueryMatches, maxMatches);
+    }
+  }
   return res;
 }
 

--- a/Code/GraphMol/Substruct/SubstructMatch.cpp
+++ b/Code/GraphMol/Substruct/SubstructMatch.cpp
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2001-2015 Greg Landrum and Rational Discovery LLC
+//  Copyright (C) 2001-2017 Greg Landrum and Rational Discovery LLC
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -13,6 +13,8 @@
 #include <GraphMol/RDKitBase.h>
 #include <GraphMol/RDKitQueries.h>
 #include <GraphMol/Resonance.h>
+#include <GraphMol/MolBundle.h>
+
 #include "SubstructMatch.h"
 #include "SubstructUtils.h"
 #include <boost/smart_ptr.hpp>
@@ -343,6 +345,28 @@ bool SubstructMatch(const ROMol &mol, const ROMol &query,
   return res;
 }
 
+bool SubstructMatch(const MolBundle &bundle, const ROMol &query,
+                    MatchVectType &matchVect, bool recursionPossible,
+                    bool useChirality, bool useQueryQueryMatches) {
+  bool res = false;
+  for (unsigned int i = 0; i < bundle.size() && !res; ++i) {
+    res = SubstructMatch(*bundle[i], query, matchVect, recursionPossible,
+                         useChirality, useQueryQueryMatches);
+  }
+  return res;
+}
+
+bool SubstructMatch(const ROMol &mol, const MolBundle &bundle,
+                    MatchVectType &matchVect, bool recursionPossible,
+                    bool useChirality, bool useQueryQueryMatches) {
+  bool res = false;
+  for (unsigned int i = 0; i < bundle.size() && !res; ++i) {
+    res = SubstructMatch(mol, *bundle[i], matchVect, recursionPossible,
+                         useChirality, useQueryQueryMatches);
+  }
+  return res;
+}
+
 // ----------------------------------------------
 //
 // find one match in ResonanceMolSupplier object
@@ -538,8 +562,8 @@ unsigned int RecursiveMatcher(const ROMol &mol, const ROMol &query,
           }
         }
         if (!found) {
-          BOOST_LOG(rdErrorLog) << "no match found for queryRootAtom"
-                                << std::endl;
+          BOOST_LOG(rdErrorLog)
+              << "no match found for queryRootAtom" << std::endl;
         }
       }
     }

--- a/Code/GraphMol/Substruct/SubstructMatch.h
+++ b/Code/GraphMol/Substruct/SubstructMatch.h
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2001-2015 Greg Landrum and Rational Discovery LLC
+//  Copyright (C) 2001-2017 Greg Landrum and Rational Discovery LLC
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -7,8 +7,8 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-#ifndef _RD_SUBSTRUCTMATCH_H__
-#define _RD_SUBSTRUCTMATCH_H__
+#ifndef RD_SUBSTRUCTMATCH_H
+#define RD_SUBSTRUCTMATCH_H
 
 // std bits
 #include <vector>
@@ -18,6 +18,7 @@ class ROMol;
 class Atom;
 class Bond;
 class ResonanceMolSupplier;
+class MolBundle;
 
 //! \brief used to return matches from substructure searching,
 //!   The format is (queryAtomIdx, molAtomIdx)
@@ -126,6 +127,25 @@ unsigned int SubstructMatch(ResonanceMolSupplier &resMolSuppl,
                             bool useChirality = false,
                             bool useQueryQueryMatches = false,
                             unsigned int maxMatches = 1000, int numThreads = 1);
+
+bool SubstructMatch(const MolBundle &bundle, const ROMol &query,
+                    MatchVectType &matchVect, bool recursionPossible = true,
+                    bool useChirality = false,
+                    bool useQueryQueryMatches = false);
+bool SubstructMatch(const MolBundle &bundle, const MolBundle &query,
+                    MatchVectType &matchVect, bool recursionPossible = true,
+                    bool useChirality = false,
+                    bool useQueryQueryMatches = false);
+bool SubstructMatch(const ROMol &bundle, const MolBundle &query,
+                    MatchVectType &matchVect, bool recursionPossible = true,
+                    bool useChirality = false,
+                    bool useQueryQueryMatches = false);
+unsigned int SubstructMatch(const MolBundle &mol, const ROMol &query,
+                            std::vector<MatchVectType> &matchVect,
+                            bool uniquify = true, bool recursionPossible = true,
+                            bool useChirality = false,
+                            bool useQueryQueryMatches = false,
+                            unsigned int maxMatches = 1000);
 }
 
 #endif

--- a/Code/GraphMol/Substruct/SubstructMatch.h
+++ b/Code/GraphMol/Substruct/SubstructMatch.h
@@ -147,7 +147,7 @@ bool SubstructMatch(const MolBundle &bundle, const MolBundle &query,
                     bool useChirality = false,
                     bool useQueryQueryMatches = false);
 //! \overload
-//! finds all matches in the first element of the bundle that has any matches
+//! finds all matches in the first molecule of the bundle that matches the query
 unsigned int SubstructMatch(const MolBundle &mol, const ROMol &query,
                             std::vector<MatchVectType> &matchVect,
                             bool uniquify = true, bool recursionPossible = true,
@@ -156,7 +156,7 @@ unsigned int SubstructMatch(const MolBundle &mol, const ROMol &query,
                             unsigned int maxMatches = 1000);
 
 //! \overload
-//! finds all matches in the first element of the bundle that has any matches
+//! finds all matches in the first molecule of the bundle that matches
 unsigned int SubstructMatch(const MolBundle &mol, const MolBundle &query,
                             std::vector<MatchVectType> &matchVect,
                             bool uniquify = true, bool recursionPossible = true,
@@ -164,7 +164,8 @@ unsigned int SubstructMatch(const MolBundle &mol, const MolBundle &query,
                             bool useQueryQueryMatches = false,
                             unsigned int maxMatches = 1000);
 //! \overload
-//! finds all matches in the first element of the bundle that has any matches
+//! finds all matches against the first molecule of the query bundle that
+//! matches
 unsigned int SubstructMatch(const ROMol &mol, const MolBundle &query,
                             std::vector<MatchVectType> &matchVect,
                             bool uniquify = true, bool recursionPossible = true,

--- a/Code/GraphMol/Substruct/SubstructMatch.h
+++ b/Code/GraphMol/Substruct/SubstructMatch.h
@@ -132,15 +132,28 @@ bool SubstructMatch(const MolBundle &bundle, const ROMol &query,
                     MatchVectType &matchVect, bool recursionPossible = true,
                     bool useChirality = false,
                     bool useQueryQueryMatches = false);
-bool SubstructMatch(const MolBundle &bundle, const MolBundle &query,
-                    MatchVectType &matchVect, bool recursionPossible = true,
-                    bool useChirality = false,
-                    bool useQueryQueryMatches = false);
 bool SubstructMatch(const ROMol &bundle, const MolBundle &query,
                     MatchVectType &matchVect, bool recursionPossible = true,
                     bool useChirality = false,
                     bool useQueryQueryMatches = false);
+bool SubstructMatch(const MolBundle &bundle, const MolBundle &query,
+                    MatchVectType &matchVect, bool recursionPossible = true,
+                    bool useChirality = false,
+                    bool useQueryQueryMatches = false);
+// finds all matches in the first element of the bundle that has any matches
 unsigned int SubstructMatch(const MolBundle &mol, const ROMol &query,
+                            std::vector<MatchVectType> &matchVect,
+                            bool uniquify = true, bool recursionPossible = true,
+                            bool useChirality = false,
+                            bool useQueryQueryMatches = false,
+                            unsigned int maxMatches = 1000);
+unsigned int SubstructMatch(const MolBundle &mol, const MolBundle &query,
+                            std::vector<MatchVectType> &matchVect,
+                            bool uniquify = true, bool recursionPossible = true,
+                            bool useChirality = false,
+                            bool useQueryQueryMatches = false,
+                            unsigned int maxMatches = 1000);
+unsigned int SubstructMatch(const ROMol &mol, const MolBundle &query,
                             std::vector<MatchVectType> &matchVect,
                             bool uniquify = true, bool recursionPossible = true,
                             bool useChirality = false,

--- a/Code/GraphMol/Substruct/SubstructMatch.h
+++ b/Code/GraphMol/Substruct/SubstructMatch.h
@@ -128,31 +128,43 @@ unsigned int SubstructMatch(ResonanceMolSupplier &resMolSuppl,
                             bool useQueryQueryMatches = false,
                             unsigned int maxMatches = 1000, int numThreads = 1);
 
+//! \overload
+//! finds the first match in the bundle
 bool SubstructMatch(const MolBundle &bundle, const ROMol &query,
                     MatchVectType &matchVect, bool recursionPossible = true,
                     bool useChirality = false,
                     bool useQueryQueryMatches = false);
+//! \overload
+//! finds the first match in the bundle
 bool SubstructMatch(const ROMol &bundle, const MolBundle &query,
                     MatchVectType &matchVect, bool recursionPossible = true,
                     bool useChirality = false,
                     bool useQueryQueryMatches = false);
+//! \overload
+//! finds the first match in the bundle
 bool SubstructMatch(const MolBundle &bundle, const MolBundle &query,
                     MatchVectType &matchVect, bool recursionPossible = true,
                     bool useChirality = false,
                     bool useQueryQueryMatches = false);
-// finds all matches in the first element of the bundle that has any matches
+//! \overload
+//! finds all matches in the first element of the bundle that has any matches
 unsigned int SubstructMatch(const MolBundle &mol, const ROMol &query,
                             std::vector<MatchVectType> &matchVect,
                             bool uniquify = true, bool recursionPossible = true,
                             bool useChirality = false,
                             bool useQueryQueryMatches = false,
                             unsigned int maxMatches = 1000);
+
+//! \overload
+//! finds all matches in the first element of the bundle that has any matches
 unsigned int SubstructMatch(const MolBundle &mol, const MolBundle &query,
                             std::vector<MatchVectType> &matchVect,
                             bool uniquify = true, bool recursionPossible = true,
                             bool useChirality = false,
                             bool useQueryQueryMatches = false,
                             unsigned int maxMatches = 1000);
+//! \overload
+//! finds all matches in the first element of the bundle that has any matches
 unsigned int SubstructMatch(const ROMol &mol, const MolBundle &query,
                             std::vector<MatchVectType> &matchVect,
                             bool uniquify = true, bool recursionPossible = true,

--- a/Code/GraphMol/testMolBundle.cpp
+++ b/Code/GraphMol/testMolBundle.cpp
@@ -1,0 +1,163 @@
+//
+//  Copyright (C) 2017 Greg Landrum
+//
+//   @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
+//
+#include <iostream>
+#include <string>
+#include <map>
+#include <GraphMol/RDKitBase.h>
+#include <GraphMol/MolBundle.h>
+#include <GraphMol/Substruct/SubstructMatch.h>
+#include <GraphMol/SmilesParse/SmilesParse.h>
+#include <GraphMol/FileParsers/FileParsers.h>
+#include <GraphMol/FileParsers/MolWriters.h>
+#include <GraphMol/MolOps.h>
+#include <GraphMol/Resonance.h>
+
+using namespace RDKit;
+
+void testBaseFunctionality() {
+  BOOST_LOG(rdInfoLog) << "-----------------------\n"
+                       << "    testBaseFunctionality" << std::endl;
+  ROMOL_SPTR mol(SmilesToMol("CC[C@H](C)F"));
+
+  MolBundle bundle;
+  TEST_ASSERT(bundle.size() == 0);
+  TEST_ASSERT(bundle.addMol(mol) == 1);
+  TEST_ASSERT(bundle.size() == 1);
+  TEST_ASSERT(bundle.addMol(ROMOL_SPTR(SmilesToMol("CC[C@@H](C)F"))) == 2);
+  TEST_ASSERT(bundle.size() == 2);
+
+  MolBundle bundle2(bundle);
+  TEST_ASSERT(bundle2.size() == 2);
+
+  TEST_ASSERT(bundle.getMol(0)->getNumAtoms() == 5);
+  TEST_ASSERT(bundle[0]->getNumAtoms() == 5);
+
+  BOOST_LOG(rdInfoLog) << "  Done." << std::endl;
+}
+
+void testSubstructFunctionality() {
+  BOOST_LOG(rdInfoLog) << "-----------------------\n"
+                       << "    testSubstructFunctionality" << std::endl;
+  {
+    MolBundle bundle;
+    TEST_ASSERT(bundle.addMol(ROMOL_SPTR(SmilesToMol("CC[C@H](Cl)F"))) == 1);
+    TEST_ASSERT(bundle.addMol(ROMOL_SPTR(SmilesToMol("CC[C@@H](Cl)F"))) == 2);
+
+    ROMOL_SPTR qry(SmilesToMol("C[C@@H](Cl)F"));
+    MatchVectType match;
+    TEST_ASSERT(SubstructMatch(bundle, *qry, match));
+    TEST_ASSERT(SubstructMatch(bundle, *qry, match, true, true));
+    ROMOL_SPTR qry2(SmilesToMol("C[C@@H](Br)F"));
+    TEST_ASSERT(!SubstructMatch(bundle, *qry2, match));
+    TEST_ASSERT(!SubstructMatch(bundle, *qry2, match, true, true));
+
+    std::vector<MatchVectType> matches;
+    TEST_ASSERT(SubstructMatch(bundle, *qry, matches) == 1);
+    TEST_ASSERT(SubstructMatch(bundle, *qry, matches, false, true, true) == 1);
+    TEST_ASSERT(SubstructMatch(bundle, *qry2, matches) == 0);
+    TEST_ASSERT(SubstructMatch(bundle, *qry2, matches, false, true, true) == 0);
+  }
+  {
+    MolBundle bundle;
+    TEST_ASSERT(bundle.addMol(ROMOL_SPTR(SmilesToMol("C[C@H](Cl)F"))) == 1);
+    TEST_ASSERT(bundle.addMol(ROMOL_SPTR(SmilesToMol("C[C@@H](Cl)F"))) == 2);
+
+    ROMOL_SPTR mol(SmilesToMol("CC[C@@H](Cl)F"));
+    MatchVectType match;
+    TEST_ASSERT(SubstructMatch(*mol, bundle, match));
+    TEST_ASSERT(SubstructMatch(*mol, bundle, match, true, true));
+    ROMOL_SPTR mol2(SmilesToMol("CC[C@@H](Br)F"));
+    TEST_ASSERT(!SubstructMatch(*mol2, bundle, match));
+    TEST_ASSERT(!SubstructMatch(*mol2, bundle, match, true, true));
+
+    std::vector<MatchVectType> matches;
+    TEST_ASSERT(SubstructMatch(*mol, bundle, matches) == 1);
+    TEST_ASSERT(SubstructMatch(*mol, bundle, matches, false, true, true) == 1);
+    TEST_ASSERT(SubstructMatch(*mol2, bundle, matches) == 0);
+    TEST_ASSERT(SubstructMatch(*mol2, bundle, matches, false, true, true) == 0);
+  }
+  {
+    MolBundle bundle;
+    TEST_ASSERT(bundle.addMol(ROMOL_SPTR(SmilesToMol("CC[C@H](Cl)F"))) == 1);
+    TEST_ASSERT(bundle.addMol(ROMOL_SPTR(SmilesToMol("CC[C@@H](Cl)F"))) == 2);
+
+    MolBundle qbundle;
+    TEST_ASSERT(qbundle.addMol(ROMOL_SPTR(SmilesToMol("C[13C@H](Cl)F"))) == 1);
+    TEST_ASSERT(qbundle.addMol(ROMOL_SPTR(SmilesToMol("C[C@@H](Cl)F"))) == 2);
+
+    MatchVectType match;
+    TEST_ASSERT(SubstructMatch(bundle, qbundle, match));
+    TEST_ASSERT(SubstructMatch(bundle, qbundle, match, true, true));
+
+    std::vector<MatchVectType> matches;
+    TEST_ASSERT(SubstructMatch(bundle, qbundle, matches) == 1);
+    TEST_ASSERT(SubstructMatch(bundle, qbundle, matches, false, true, true) ==
+                1);
+  }
+  BOOST_LOG(rdInfoLog) << "  Done." << std::endl;
+}
+
+void testExceptions() {
+  BOOST_LOG(rdInfoLog) << "-----------------------\n"
+                       << "    testExceptions" << std::endl;
+  ROMOL_SPTR mol(SmilesToMol("C1CCC1"));
+
+  MolBundle bundle;
+  TEST_ASSERT(bundle.size() == 0);
+  TEST_ASSERT(bundle.addMol(mol) == 1);
+  TEST_ASSERT(bundle.size() == 1);
+  {
+    bool ok = false;
+    try {
+      bundle.addMol(ROMOL_SPTR(SmilesToMol("C1CC1")));
+    } catch (const ValueErrorException &) {
+      ok = true;
+    }
+    TEST_ASSERT(ok);
+  }
+  {
+    bool ok = false;
+    try {
+      bundle.addMol(ROMOL_SPTR(SmilesToMol("CCCC")));
+    } catch (const ValueErrorException &) {
+      ok = true;
+    }
+    TEST_ASSERT(ok);
+  }
+  {
+    bool ok = false;
+    try {
+      bundle.getMol(1);
+    } catch (const IndexErrorException &) {
+      ok = true;
+    }
+    TEST_ASSERT(ok);
+  }
+  {
+    bool ok = false;
+    try {
+      bundle[1];
+    } catch (const IndexErrorException &) {
+      ok = true;
+    }
+    TEST_ASSERT(ok);
+  }
+  BOOST_LOG(rdInfoLog) << "  Done." << std::endl;
+}
+
+int main() {
+  RDLog::InitLogs();
+#if 1
+  testBaseFunctionality();
+  testSubstructFunctionality();
+  testExceptions();
+#endif
+  return 0;
+}


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
This adds a `MolBundle`: a class to hold groups of molecules that have the topology (currently enforced as the same number of atoms and bonds).
It also adds integration of that class with the substructure searching code.

At the moment this isn't particular interesting, but it lays the groundwork for support of things like enhanced stereochemistry in the not-too-distant future.

#### Any other comments?
The current implementation is certainly not the most memory efficient way of solving the problem, but the API should allow us to move to something better if that becomes important. The once concern there is the `getMols()` method, which we may want to consider removing from the API.
