### PR TITLE
Added rankAtoms to ROMol wrapper and added Java test case

### DIFF
--- a/Code/JavaWrappers/ROMol.i
+++ b/Code/JavaWrappers/ROMol.i
@@ -426,7 +426,7 @@
   void rankMolAtoms(UINT_VECT &ranks,
                   bool breakTies = true, bool includeChirality = true,
                   bool includeIsotopes = true){
-	Canon::rankMolAtoms(*($self), ranks, breakTies, includeChirality, includeIsotopes);
+	RDKit::Canon::rankMolAtoms(*($self), ranks, breakTies, includeChirality, includeIsotopes);
   }
 }
 

--- a/Code/JavaWrappers/ROMol.i
+++ b/Code/JavaWrappers/ROMol.i
@@ -60,7 +60,6 @@
 #include <GraphMol/MolAlign/O3AAlignMolecules.h>
 #include <GraphMol/MolDraw2D/MolDraw2DSVG.h>
 #include <GraphMol/PartialCharges/GasteigerCharges.h>
-#include <GraphMol/new_canon.h>
 #include <sstream>
 %}
 

--- a/Code/JavaWrappers/ROMol.i
+++ b/Code/JavaWrappers/ROMol.i
@@ -427,7 +427,7 @@
   void rankMolAtoms(UINT_VECT &ranks,
                   bool breakTies = true, bool includeChirality = true,
                   bool includeIsotopes = true){
-	Canon::rankMolAtoms(*($self),breakTies,includeChirality,includeIsotopes);
+	Canon::rankMolAtoms(*($self), ranks, breakTies, includeChirality, includeIsotopes);
 }
 
 

--- a/Code/JavaWrappers/ROMol.i
+++ b/Code/JavaWrappers/ROMol.i
@@ -60,6 +60,7 @@
 #include <GraphMol/MolAlign/O3AAlignMolecules.h>
 #include <GraphMol/MolDraw2D/MolDraw2DSVG.h>
 #include <GraphMol/PartialCharges/GasteigerCharges.h>
+#include <GraphMol/new_canon.h>
 #include <sstream>
 %}
 

--- a/Code/JavaWrappers/ROMol.i
+++ b/Code/JavaWrappers/ROMol.i
@@ -428,6 +428,7 @@
                   bool breakTies = true, bool includeChirality = true,
                   bool includeIsotopes = true){
 	Canon::rankMolAtoms(*($self), ranks, breakTies, includeChirality, includeIsotopes);
+  }
 }
 
 

--- a/Code/JavaWrappers/ROMol.i
+++ b/Code/JavaWrappers/ROMol.i
@@ -60,6 +60,7 @@
 #include <GraphMol/MolAlign/O3AAlignMolecules.h>
 #include <GraphMol/MolDraw2D/MolDraw2DSVG.h>
 #include <GraphMol/PartialCharges/GasteigerCharges.h>
+#include <GraphMol/new_canon.h>
 #include <sstream>
 %}
 
@@ -421,6 +422,12 @@
                                int nIter=12,bool throwOnParamFailure=false){
     RDKit::computeGasteigerCharges(*mol,charges,nIter,throwOnParamFailure);
   }
+
+  /* From new_canon.h*/
+  void rankMolAtoms(UINT_VECT &ranks,
+                  bool breakTies = true, bool includeChirality = true,
+                  bool includeIsotopes = true){
+	Canon::rankMolAtoms(*($self),breakTies,includeChirality,includeIsotopes);
 }
 
 

--- a/Code/JavaWrappers/gmwrapper/src-test/org/RDKit/SmilesTests.java
+++ b/Code/JavaWrappers/gmwrapper/src-test/org/RDKit/SmilesTests.java
@@ -151,7 +151,7 @@ public class SmilesTests extends GraphMolTest {
 				mTest.GetNumAtoms(), ranks.size(), mTest.GetNumAtoms());
 
 		//Anf now compare..
-		for(int i=0; i<mRef.GetNumAtoms()){
+		for(int i=0; i<mRef.GetNumAtoms(); i++){
 			int refRank=Integer.parseInt(mRef.getAtomWithIdx(i).getProp("_canonicalRankingNumber"));
 			assertEquals("Error in ranking - got " + ranks.get(i) + 
 					" expected " + refRank, refRank,ranks.get(i));

--- a/Code/JavaWrappers/gmwrapper/src-test/org/RDKit/SmilesTests.java
+++ b/Code/JavaWrappers/gmwrapper/src-test/org/RDKit/SmilesTests.java
@@ -136,7 +136,31 @@ public class SmilesTests extends GraphMolTest {
             assertEquals("bad smiles: "+nsmi+"!="+expected,nsmi,expected);
 	}
 
-    
+    @Test
+	public void testRankAtoms(){
+	//Need a molecule to canonicalise
+		ROMol mRef = RDKFuncs.MolFromSmiles("C(CO)(C=C)CCC(CC)C#N");
+		ROMol mTest = RDKFuncs.MolFromSmiles("C(CO)(C=C)CCC(CC)C#N");
+		//assign the ranks in the reference
+		mRef.MolToSmiles(true);
+
+		//And now using the new method
+		UInt_Vect ranks = new UInt_Vect();
+		mTest.rankMolAtoms(ranks);
+		assertEquals("Wrong size ranks - " + ranks.size() + " != " + 
+				mTest.GetNumAtoms(), ranks.size(), mTest.GetNumAtoms());
+
+		//Anf now compare..
+		for(int i=0; i<mRef.GetNumAtoms()){
+			int refRank=Integer.parseInt(mRef.getAtomWithIdx(i).getProp("_canonicalRankingNumber"));
+			assertEquals("Error in ranking - got " + ranks.get(i) + 
+					" expected " + refRank, refRank,ranks.get(i));
+		}
+		mRef.delete();
+		mTest.delete();
+		ranks.delete();
+	}
+
 	public static void main(String args[]) {
 		org.junit.runner.JUnitCore.main("org.RDKit.SmilesTests");
 	}

--- a/Code/JavaWrappers/gmwrapper/src-test/org/RDKit/SmilesTests.java
+++ b/Code/JavaWrappers/gmwrapper/src-test/org/RDKit/SmilesTests.java
@@ -1,5 +1,4 @@
 /* 
- * $Id: SmilesTests.java 131 2011-01-20 22:01:29Z ebakke $
  *
  *  Copyright (c) 2010, Novartis Institutes for BioMedical Research Inc.
  *  All rights reserved.
@@ -136,29 +135,29 @@ public class SmilesTests extends GraphMolTest {
             assertEquals("bad smiles: "+nsmi+"!="+expected,nsmi,expected);
 	}
 
-    @Test
+    	@Test
 	public void testRankAtoms(){
-	//Need a molecule to canonicalise
-		ROMol mRef = RDKFuncs.MolFromSmiles("C(CO)(C=C)CCC(CC)C#N");
-		ROMol mTest = RDKFuncs.MolFromSmiles("C(CO)(C=C)CCC(CC)C#N");
-		//assign the ranks in the reference
-		mRef.MolToSmiles(true);
+	    //Need a molecule to canonicalise
+	    ROMol mRef = RDKFuncs.MolFromSmiles("C(CO)(C=C)CCC(CC)C#N");
+	    ROMol mTest = RDKFuncs.MolFromSmiles("C(CO)(C=C)CCC(CC)C#N");
+	    //assign the ranks in the reference
+	    mRef.MolToSmiles(true);
 
-		//And now using the new method
-		UInt_Vect ranks = new UInt_Vect();
-		mTest.rankMolAtoms(ranks);
-		assertEquals("Wrong size ranks - " + ranks.size() + " != " + 
-				mTest.GetNumAtoms(), ranks.size(), mTest.GetNumAtoms());
+	    // And now using the new method
+	    UInt_Vect ranks = new UInt_Vect();
+	    mTest.rankMolAtoms(ranks);
+	    assertEquals("Wrong size ranks - " + ranks.size() + " != " + 
+	  		mTest.GetNumAtoms(), ranks.size(), mTest.GetNumAtoms());
 
-		//Anf now compare..
-		for(int i=0; i<mRef.GetNumAtoms(); i++){
-			int refRank=Integer.parseInt(mRef.getAtomWithIdx(i).getProp("_canonicalRankingNumber"));
-			assertEquals("Error in ranking - got " + ranks.get(i) + 
-					" expected " + refRank, refRank,ranks.get(i));
-		}
-		mRef.delete();
-		mTest.delete();
-		ranks.delete();
+	    // And now compare..
+	    for(int i=0; i<mRef.GetNumAtoms(); i++){
+		int refRank=Integer.parseInt(mRef.getAtomWithIdx(i).getProp("_canonicalRankingNumber"));
+		assertEquals("Error in ranking - got " + ranks.get(i) + 
+				" expected " + refRank, refRank,ranks.get(i));
+	    }
+	    mRef.delete();
+	    mTest.delete();
+	    ranks.delete();
 	}
 
 	public static void main(String args[]) {


### PR DESCRIPTION
This enhancement adds the `rankMolAtoms()` from `new_canon.h` to the Java wrapper of the ROMol object. Currently, the canonical ranks are only available via a call to `ROMol#MolToSmiles()` followed by parsing atom or molecule properties

