### PR TITLE
Provide support for color palettes in MolDraw2D

### DIFF
--- a/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
@@ -1069,10 +1069,18 @@ DrawColour MolDraw2D::getColour(
 
 // ****************************************************************************
 DrawColour MolDraw2D::getColourByAtomicNum(int atomic_num) {
-  DrawColour res = drawOptions().atomColourPalette[-1];
+  DrawColour res;
   if (drawOptions().atomColourPalette.find(atomic_num) !=
       drawOptions().atomColourPalette.end()) {
     res = drawOptions().atomColourPalette[atomic_num];
+  } else if (atomic_num != -1 &&
+             drawOptions().atomColourPalette.find(-1) !=
+                 drawOptions().atomColourPalette.end()) {
+    // if -1 is in the palette, we use that for undefined colors
+    res = drawOptions().atomColourPalette[-1];
+  } else {
+    // if all else fails, default to black:
+    res = DrawColour(0, 0, 0);
   }
   return res;
 }

--- a/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
@@ -1069,46 +1069,11 @@ DrawColour MolDraw2D::getColour(
 
 // ****************************************************************************
 DrawColour MolDraw2D::getColourByAtomicNum(int atomic_num) {
-  // RGB values taken from Qt's QColor. The seem to work pretty well on my
-  // machine. Using them as fractions of 255, as that's the way Cairo does it.
-  DrawColour res(0., 0., 0.);  // default to black
-
-  switch (atomic_num) {
-    case 0:
-      res = DrawColour(0.5, 0.5, 0.5);
-      break;
-    case 1:  // Hs and Carbons are the same colour
-    case 6:
-      res = DrawColour(0.0, 0.0, 0.0);
-      break;
-    case 7:
-      res = DrawColour(0.0, 0.0, 1.0);
-      break;
-    case 8:
-      res = DrawColour(1.0, 0.0, 0.0);
-      break;
-    case 9:
-      res = DrawColour(0.2, 0.8, 0.8);
-      break;
-    case 15:
-      res = DrawColour(1.0, 0.5, 0.0);
-      break;
-    case 16:
-      res = DrawColour(0.8, 0.8, 0.0);
-      break;
-    case 17:
-      res = DrawColour(0.0, 0.802, 0.0);
-      break;
-    case 35:
-      res = DrawColour(0.5, 0.3, 0.1);
-      break;
-    case 53:
-      res = DrawColour(0.63, 0.12, 0.94);
-      break;
-    default:
-      break;
+  DrawColour res = drawOptions().atomColourPalette[-1];
+  if (drawOptions().atomColourPalette.find(atomic_num) !=
+      drawOptions().atomColourPalette.end()) {
+    res = drawOptions().atomColourPalette[atomic_num];
   }
-
   return res;
 }
 

--- a/Code/GraphMol/MolDraw2D/MolDraw2D.h
+++ b/Code/GraphMol/MolDraw2D/MolDraw2D.h
@@ -36,7 +36,23 @@ using RDGeom::Point2D;
 namespace RDKit {
 
 typedef boost::tuple<float, float, float> DrawColour;
+typedef std::map<int, DrawColour> ColourPalette;
 typedef std::vector<unsigned int> DashPattern;
+
+inline void assignDefaultPalette(ColourPalette &palette) {
+  palette.clear();
+  palette[-1] = DrawColour(0, 0, 0);
+  palette[0] = DrawColour(0.5, 0.5, 0.5);
+  palette[1] = palette[6] = DrawColour(0.0, 0.0, 0.0);
+  palette[7] = DrawColour(0.0, 0.0, 1.0);
+  palette[8] = DrawColour(1.0, 0.0, 0.0);
+  palette[9] = DrawColour(0.2, 0.8, 0.8);
+  palette[15] = DrawColour(1.0, 0.5, 0.0);
+  palette[16] = DrawColour(0.8, 0.8, 0.0);
+  palette[17] = DrawColour(0.0, 0.802, 0.0);
+  palette[35] = DrawColour(0.5, 0.3, 0.1);
+  palette[53] = DrawColour(0.63, 0.12, 0.94);
+};
 
 struct MolDrawOptions {
   bool atomLabelDeuteriumTritium;  // toggles replacing 2H with D and 3H with T
@@ -66,9 +82,12 @@ struct MolDrawOptions {
   std::vector<std::vector<int> > atomRegions;  // regions
   DrawColour
       symbolColour;  // color to be used for the symbols and arrows in reactions
-  std::vector<DrawColour> highlightColourPalette; // defining 10 default colors
-                                                 // for highlighting atoms and bonds
-                                                 //or reactants in a reactions
+  std::vector<DrawColour> highlightColourPalette;  // defining 10 default colors
+  // for highlighting atoms and bonds
+  // or reactants in a reactions
+  ColourPalette atomColourPalette;  // the palette used to assign
+                                    // colors to atoms based on
+                                    // atomic number. -1 is the default value
 
   MolDrawOptions()
       : atomLabelDeuteriumTritium(false),
@@ -85,19 +104,20 @@ struct MolDrawOptions {
         multipleBondOffset(0.15),
         padding(0.05),
         additionalAtomLabelPadding(0.0),
-        symbolColour(0, 0, 0){
-    highlightColourPalette.push_back(DrawColour(1., 1., .67)); // popcorn yellow
-    highlightColourPalette.push_back(DrawColour(1., .8, .6)); // sand
-    highlightColourPalette.push_back(DrawColour(1., .71, .76)); // light pink
-    highlightColourPalette.push_back(DrawColour(.8, 1., .8)); // offwhitegreen
-    highlightColourPalette.push_back(DrawColour(.87, .63, .87)); // plum
-    highlightColourPalette.push_back(DrawColour(.76, .94, .96)); // pastel blue
-    highlightColourPalette.push_back(DrawColour(.67, .67, 1.)); // periwinkle
-    highlightColourPalette.push_back(DrawColour(.64, .76, .34)); // avocado
-    highlightColourPalette.push_back(DrawColour(.56, .93, .56)); // light green
-    highlightColourPalette.push_back(DrawColour(.20, .63, .79)); // peacock
+        symbolColour(0, 0, 0) {
+    highlightColourPalette.push_back(
+        DrawColour(1., 1., .67));                              // popcorn yellow
+    highlightColourPalette.push_back(DrawColour(1., .8, .6));  // sand
+    highlightColourPalette.push_back(DrawColour(1., .71, .76));  // light pink
+    highlightColourPalette.push_back(DrawColour(.8, 1., .8));  // offwhitegreen
+    highlightColourPalette.push_back(DrawColour(.87, .63, .87));  // plum
+    highlightColourPalette.push_back(DrawColour(.76, .94, .96));  // pastel blue
+    highlightColourPalette.push_back(DrawColour(.67, .67, 1.));   // periwinkle
+    highlightColourPalette.push_back(DrawColour(.64, .76, .34));  // avocado
+    highlightColourPalette.push_back(DrawColour(.56, .93, .56));  // light green
+    highlightColourPalette.push_back(DrawColour(.20, .63, .79));  // peacock
+    assignDefaultPalette(atomColourPalette);
   };
-
 };
 
 //! MolDraw2D is the base class for doing 2D renderings of molecules
@@ -215,15 +235,16 @@ class MolDraw2D {
     \param highlightByReactant : (optional) if this is set, atoms and bonds will
     be highlighted based on which reactant they come from. Atom map numbers
     will not be shown.
-    \param highlightColorsReactants : (optional) provide a vector of colors for the
+    \param highlightColorsReactants : (optional) provide a vector of colors for
+    the
     reactant highlighting.
     \param confIds   : (optional) vector of confIds to use for rendering. These
     are numbered by reactants, then agents, then products.
   */
-  virtual void drawReaction(const ChemicalReaction &rxn,
-                            bool highlightByReactant = false,
-                            const std::vector<DrawColour>* highlightColorsReactants = NULL,
-                            const std::vector<int> *confIds = NULL);
+  virtual void drawReaction(
+      const ChemicalReaction &rxn, bool highlightByReactant = false,
+      const std::vector<DrawColour> *highlightColorsReactants = NULL,
+      const std::vector<int> *confIds = NULL);
 
   //! \name Transformations
   //@{

--- a/Code/GraphMol/MolDraw2D/MolDraw2D.h
+++ b/Code/GraphMol/MolDraw2D/MolDraw2D.h
@@ -54,6 +54,11 @@ inline void assignDefaultPalette(ColourPalette &palette) {
   palette[53] = DrawColour(0.63, 0.12, 0.94);
 };
 
+inline void assignBWPalette(ColourPalette &palette) {
+  palette.clear();
+  palette[-1] = DrawColour(0, 0, 0);
+};
+
 struct MolDrawOptions {
   bool atomLabelDeuteriumTritium;  // toggles replacing 2H with D and 3H with T
   bool dummiesAreAttachments;      // draws "breaks" at dummy atoms

--- a/Code/GraphMol/MolDraw2D/Wrap/rdMolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/Wrap/rdMolDraw2D.cpp
@@ -27,7 +27,7 @@ namespace python = boost::python;
 
 namespace RDKit {
 namespace {
-void pyDictToColourMap(python::object pyo, std::map<int, DrawColour> &res) {
+void pyDictToColourMap(python::object pyo, ColourPalette &res) {
   python::dict tDict = python::extract<python::dict>(pyo);
   for (unsigned int i = 0;
        i < python::extract<unsigned int>(tDict.keys().attr("__len__")()); ++i) {
@@ -39,10 +39,10 @@ void pyDictToColourMap(python::object pyo, std::map<int, DrawColour> &res) {
     res[python::extract<int>(tDict.keys()[i])] = clr;
   }
 }
-std::map<int, DrawColour> *pyDictToColourMap(python::object pyo) {
-  std::map<int, DrawColour> *res = NULL;
+ColourPalette *pyDictToColourMap(python::object pyo) {
+  ColourPalette *res = NULL;
   if (pyo) {
-    res = new std::map<int, DrawColour>;
+    res = new ColourPalette;
     pyDictToColourMap(pyo, *res);
   }
   return res;
@@ -98,7 +98,7 @@ void drawMoleculeHelper1(MolDraw2D &self, const ROMol &mol,
                          std::string legend) {
   rdk_auto_ptr<std::vector<int> > highlightAtoms =
       pythonObjectToVect(highlight_atoms, static_cast<int>(mol.getNumAtoms()));
-  std::map<int, DrawColour> *ham = pyDictToColourMap(highlight_atom_map);
+  ColourPalette *ham = pyDictToColourMap(highlight_atom_map);
   std::map<int, double> *har = pyDictToDoubleMap(highlight_atom_radii);
 
   self.drawMolecule(mol, legend, highlightAtoms.get(), ham, har, confId);
@@ -118,8 +118,8 @@ void drawMoleculeHelper2(MolDraw2D &self, const ROMol &mol,
   rdk_auto_ptr<std::vector<int> > highlightBonds =
       pythonObjectToVect(highlight_bonds, static_cast<int>(mol.getNumBonds()));
   // FIX: support these
-  std::map<int, DrawColour> *ham = pyDictToColourMap(highlight_atom_map);
-  std::map<int, DrawColour> *hbm = pyDictToColourMap(highlight_bond_map);
+  ColourPalette *ham = pyDictToColourMap(highlight_atom_map);
+  ColourPalette *hbm = pyDictToColourMap(highlight_bond_map);
   std::map<int, double> *har = pyDictToDoubleMap(highlight_atom_radii);
 
   self.drawMolecule(mol, legend, highlightAtoms.get(), highlightBonds.get(),
@@ -165,7 +165,7 @@ void drawMoleculesHelper2(MolDraw2D &self, python::object pmols,
     }
   }
 
-  rdk_auto_ptr<std::vector<std::map<int, DrawColour> > > highlightAtomMap;
+  rdk_auto_ptr<std::vector<ColourPalette> > highlightAtomMap;
   if (highlight_atom_map) {
     if (python::extract<unsigned int>(highlight_atom_map.attr("__len__")()) !=
         nThere) {
@@ -173,12 +173,12 @@ void drawMoleculesHelper2(MolDraw2D &self, python::object pmols,
           "If highlightAtomMap is provided it must be the same length as the "
           "molecule list.");
     }
-    highlightAtomMap.reset(new std::vector<std::map<int, DrawColour> >(nThere));
+    highlightAtomMap.reset(new std::vector<ColourPalette>(nThere));
     for (unsigned int i = 0; i < nThere; ++i) {
       pyDictToColourMap(highlight_atom_map[i], (*highlightAtomMap)[i]);
     }
   }
-  rdk_auto_ptr<std::vector<std::map<int, DrawColour> > > highlightBondMap;
+  rdk_auto_ptr<std::vector<ColourPalette> > highlightBondMap;
   if (highlight_bond_map) {
     if (python::extract<unsigned int>(highlight_bond_map.attr("__len__")()) !=
         nThere) {
@@ -186,7 +186,7 @@ void drawMoleculesHelper2(MolDraw2D &self, python::object pmols,
           "If highlightBondMap is provided it must be the same length as the "
           "molecule list.");
     }
-    highlightBondMap.reset(new std::vector<std::map<int, DrawColour> >(nThere));
+    highlightBondMap.reset(new std::vector<ColourPalette>(nThere));
     for (unsigned int i = 0; i < nThere; ++i) {
       pyDictToColourMap(highlight_bond_map[i], (*highlightBondMap)[i]);
     }
@@ -284,6 +284,13 @@ void useDefaultAtomPalette(RDKit::MolDrawOptions &self) {
 void useBWAtomPalette(RDKit::MolDrawOptions &self) {
   assignBWPalette(self.atomColourPalette);
 }
+void updateAtomPalette(RDKit::MolDrawOptions &self, python::object cmap) {
+  pyDictToColourMap(cmap, self.atomColourPalette);
+}
+void setAtomPalette(RDKit::MolDrawOptions &self, python::object cmap) {
+  self.atomColourPalette.clear();
+  updateAtomPalette(self, cmap);
+}
 }
 
 BOOST_PYTHON_MODULE(rdMolDraw2D) {
@@ -315,6 +322,13 @@ BOOST_PYTHON_MODULE(rdMolDraw2D) {
            "use the default colour palette for atoms and bonds")
       .def("useBWAtomPalette", &RDKit::useBWAtomPalette,
            "use the black & white palette for atoms and bonds")
+      .def("updateAtomPalette", &RDKit::updateAtomPalette,
+           "updates the palette for atoms and bonds from a dictionary mapping "
+           "ints to 3-tuples")
+      .def(
+          "setAtomPalette", &RDKit::setAtomPalette,
+          "sets the palette for atoms and bonds from a dictionary mapping ints "
+          "to 3-tuples")
       .def_readwrite("atomLabels", &RDKit::MolDrawOptions::atomLabels,
                      "maps indices to atom labels")
       .def_readwrite("atomLabelDeuteriumTritium",

--- a/Code/GraphMol/MolDraw2D/Wrap/rdMolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/Wrap/rdMolDraw2D.cpp
@@ -278,6 +278,12 @@ void setBgColour(RDKit::MolDrawOptions &self, python::tuple tpl) {
 void setHighlightColour(RDKit::MolDrawOptions &self, python::tuple tpl) {
   self.highlightColour = pyTupleToDrawColour(tpl);
 }
+void useDefaultAtomPalette(RDKit::MolDrawOptions &self) {
+  assignDefaultPalette(self.atomColourPalette);
+}
+void useBWAtomPalette(RDKit::MolDrawOptions &self) {
+  assignBWPalette(self.atomColourPalette);
+}
 }
 
 BOOST_PYTHON_MODULE(rdMolDraw2D) {
@@ -305,6 +311,10 @@ BOOST_PYTHON_MODULE(rdMolDraw2D) {
            "method for setting the background colour")
       .def("setHighlightColour", &RDKit::setHighlightColour,
            "method for setting the highlight colour")
+      .def("useDefaultAtomPalette", &RDKit::useDefaultAtomPalette,
+           "use the default colour palette for atoms and bonds")
+      .def("useBWAtomPalette", &RDKit::useBWAtomPalette,
+           "use the black & white palette for atoms and bonds")
       .def_readwrite("atomLabels", &RDKit::MolDrawOptions::atomLabels,
                      "maps indices to atom labels")
       .def_readwrite("atomLabelDeuteriumTritium",

--- a/Code/GraphMol/MolDraw2D/Wrap/testMolDraw2D.py
+++ b/Code/GraphMol/MolDraw2D/Wrap/testMolDraw2D.py
@@ -278,6 +278,16 @@ M  END""")
     self.assertTrue(txt.find("stroke:#00CC00")==-1)
     self.assertTrue(txt.find("stroke:#FFFF00")>=0)
 
+    # try a palette that doesn't have a default:
+    d = Draw.MolDraw2DSVG(300, 300)
+    d.drawOptions().setAtomPalette({0:(1,1,0)})
+    d.DrawMolecule(dm)
+    d.FinishDrawing()
+    txt = d.GetDrawingText()
+    self.assertTrue(txt.find("stroke:#000000")>=0)
+    self.assertTrue(txt.find("stroke:#00CC00")==-1)
+    self.assertTrue(txt.find("stroke:#FFFF00")==-1)
+
 
 if __name__ == "__main__":
   unittest.main()

--- a/Code/GraphMol/MolDraw2D/Wrap/testMolDraw2D.py
+++ b/Code/GraphMol/MolDraw2D/Wrap/testMolDraw2D.py
@@ -239,5 +239,45 @@ M  END""")
     self.assertTrue(txt.find("stroke:#000000")>=0)
     self.assertTrue(txt.find("stroke:#00CC00")==-1)
 
+  def testUpdatePalette(self):
+    m = Chem.MolFromSmiles('CCOCNCCl')
+    dm = Draw.PrepareMolForDrawing(m)
+    d = Draw.MolDraw2DSVG(300, 300)
+    d.DrawMolecule(dm)
+    d.FinishDrawing()
+    txt = d.GetDrawingText()
+    self.assertTrue(txt.find("stroke:#000000")>=0)
+    self.assertTrue(txt.find("stroke:#00CC00")>=0)
+
+    d = Draw.MolDraw2DSVG(300, 300)
+    d.drawOptions().updateAtomPalette({6:(1,1,0)})
+    d.DrawMolecule(dm)
+    d.FinishDrawing()
+    txt = d.GetDrawingText()
+    self.assertTrue(txt.find("stroke:#000000")==-1)
+    self.assertTrue(txt.find("stroke:#00CC00")>=0)
+    self.assertTrue(txt.find("stroke:#FFFF00")>=0)
+
+
+  def testSetPalette(self):
+    m = Chem.MolFromSmiles('CCOCNCCl')
+    dm = Draw.PrepareMolForDrawing(m)
+    d = Draw.MolDraw2DSVG(300, 300)
+    d.DrawMolecule(dm)
+    d.FinishDrawing()
+    txt = d.GetDrawingText()
+    self.assertTrue(txt.find("stroke:#000000")>=0)
+    self.assertTrue(txt.find("stroke:#00CC00")>=0)
+
+    d = Draw.MolDraw2DSVG(300, 300)
+    d.drawOptions().setAtomPalette({-1:(1,1,0)})
+    d.DrawMolecule(dm)
+    d.FinishDrawing()
+    txt = d.GetDrawingText()
+    self.assertTrue(txt.find("stroke:#000000")==-1)
+    self.assertTrue(txt.find("stroke:#00CC00")==-1)
+    self.assertTrue(txt.find("stroke:#FFFF00")>=0)
+
+
 if __name__ == "__main__":
   unittest.main()

--- a/Code/GraphMol/MolDraw2D/Wrap/testMolDraw2D.py
+++ b/Code/GraphMol/MolDraw2D/Wrap/testMolDraw2D.py
@@ -221,5 +221,23 @@ M  END""")
     d = Draw.MolDraw2DSVG(900, 300)
     self.assertRaises(ValueError, d.DrawReaction, rxn, True, colors)
 
+  def testBWDrawing(self):
+    m = Chem.MolFromSmiles('CCOCNCCl')
+    dm = Draw.PrepareMolForDrawing(m)
+    d = Draw.MolDraw2DSVG(300, 300)
+    d.DrawMolecule(dm)
+    d.FinishDrawing()
+    txt = d.GetDrawingText()
+    self.assertTrue(txt.find("stroke:#000000")>=0)
+    self.assertTrue(txt.find("stroke:#00CC00")>=0)
+
+    d = Draw.MolDraw2DSVG(300, 300)
+    d.drawOptions().useBWAtomPalette()
+    d.DrawMolecule(dm)
+    d.FinishDrawing()
+    txt = d.GetDrawingText()
+    self.assertTrue(txt.find("stroke:#000000")>=0)
+    self.assertTrue(txt.find("stroke:#00CC00")==-1)
+
 if __name__ == "__main__":
   unittest.main()

--- a/Code/GraphMol/MolDraw2D/test1.cpp
+++ b/Code/GraphMol/MolDraw2D/test1.cpp
@@ -2013,6 +2013,44 @@ void testGithub565() {
   std::cerr << " Done" << std::endl;
 }
 
+void test14BWPalette() {
+  std::cout << " ----------------- Testing use of a black & white palette"
+            << std::endl;
+  {
+    std::string smiles = "CNC(Cl)C(=O)O";
+    RWMol *m1 = SmilesToMol(smiles);
+    TEST_ASSERT(m1);
+    MolDraw2DUtils::prepareMolForDrawing(*m1);
+
+    {  // start with color
+      MolDraw2DSVG drawer(200, 200);
+      drawer.drawMolecule(*m1, "m1");
+      drawer.finishDrawing();
+      std::string text = drawer.getDrawingText();
+
+      TEST_ASSERT(text.find("stroke:#00CC00") != std::string::npos);
+
+      std::ofstream outs("test14_1.svg");
+      outs << text;
+      outs.flush();
+    }
+    {  // now B&W
+      MolDraw2DSVG drawer(200, 200);
+      assignBWPalette(drawer.drawOptions().atomColourPalette);
+      drawer.drawMolecule(*m1, "m1");
+      drawer.finishDrawing();
+      std::string text = drawer.getDrawingText();
+
+      TEST_ASSERT(text.find("stroke:#00CC00") == std::string::npos);
+
+      std::ofstream outs("test14_2.svg");
+      outs << text;
+      outs.flush();
+    }
+  }
+  std::cerr << " Done" << std::endl;
+}
+
 int main() {
   RDLog::InitLogs();
 #if 1
@@ -2046,4 +2084,5 @@ int main() {
   testGithub1271();
   testGithub1322();
   testGithub565();
+  test14BWPalette();
 }

--- a/Code/JavaWrappers/MolDraw2D.i
+++ b/Code/JavaWrappers/MolDraw2D.i
@@ -42,9 +42,9 @@
 #include <utility>
 %}
 
-%template(INT_STRING_MAP) std::map< int, std::string >;
-%template(INT_DRAWCOLOUR_MAP) std::map< int, RDKit::DrawColour >;
-%template(INT_DOUBLE_MAP) std::map< int, double >;
+%template(Int_String_Map) std::map< int, std::string >;
+%template(Int_DrawColour_Map) std::map< int, RDKit::DrawColour >;
+%template(Int_Double_Map) std::map< int, double >;
 %template(DrawColour) boost::tuple<float,float,float>;
 %template(Float_Pair) std::pair<float,float>;
 %template(Float_Pair_Vect) std::vector< std::pair<float,float> >;


### PR DESCRIPTION
#### Reference Issue
Fixes #1510, among other things.

#### What does this implement/fix? Explain your changes.
Instead of just supporting B&W rendering, I also added support for more general palettes (in the sense that code can now provide an `atomic_num->DrawColour` map).
 