### PR TITLE
A sort of fix for #1281 

### DIFF
--- a/Code/GraphMol/FindRings.cpp
+++ b/Code/GraphMol/FindRings.cpp
@@ -26,6 +26,8 @@ typedef RINGINVAR_SET::const_iterator RINGINVAR_SET_CI;
 typedef std::vector<boost::uint32_t> RINGINVAR_VECT;
 
 namespace RingUtils {
+const size_t MAX_BFSQ_SIZE = 200000;  // arbitrary huge value
+
 using namespace RDKit;
 
 boost::uint32_t computeRingInvariant(INT_VECT ring, unsigned int nAtoms) {
@@ -645,6 +647,14 @@ int smallestRingsBfs(const ROMol &mol, int root, VECT_INT_VECT &rings,
   int curr = -1;
   unsigned int curSize = UINT_MAX;
   while (bfsq.size() > 0) {
+    if (bfsq.size() >= RingUtils::MAX_BFSQ_SIZE) {
+      std::string msg =
+          "Maximum BFS search size exceeded.\nThis is likely due to a highly "
+          "symmetric fused ring system.";
+      BOOST_LOG(rdErrorLog) << msg << std::endl;
+      throw ValueErrorException(msg);
+    }
+
     curr = bfsq.front();
     bfsq.pop_front();
 
@@ -737,6 +747,13 @@ bool _atomSearchBFS(const ROMol &tMol, unsigned int startAtomIdx,
   tv.push_back(startAtomIdx);
   bfsq.push_back(tv);
   while (!bfsq.empty()) {
+    if (bfsq.size() >= RingUtils::MAX_BFSQ_SIZE) {
+      std::string msg =
+          "Maximum BFS search size exceeded.\nThis is likely due to a highly "
+          "symmetric fused ring system.";
+      BOOST_LOG(rdErrorLog) << msg << std::endl;
+      throw ValueErrorException(msg);
+    }
     tv = bfsq.front();
     bfsq.pop_front();
 
@@ -884,8 +901,7 @@ int findSSSR(const ROMol &mol, VECT_INT_VECT &res) {
     VECT_INT_VECT fragRes;
     curFrag = frags[fi];
 
-    if (curFrag.size() < 3)
-      continue;
+    if (curFrag.size() < 3) continue;
 
     // the following is the list of atoms that are useful in the next round of
     // trimming
@@ -907,13 +923,14 @@ int findSSSR(const ROMol &mol, VECT_INT_VECT &res) {
     }
 
     // check to see if this fragment can even have a possible ring
-    CHECK_INVARIANT(bndcnt_with_zero_order_bonds % 2 == 0, "fragment graph has a dangling degree");
+    CHECK_INVARIANT(bndcnt_with_zero_order_bonds % 2 == 0,
+                    "fragment graph has a dangling degree");
     bndcnt_with_zero_order_bonds = bndcnt_with_zero_order_bonds / 2;
     int num_possible_rings = bndcnt_with_zero_order_bonds - curFrag.size() + 1;
-    if (num_possible_rings < 1)
-      continue;
+    if (num_possible_rings < 1) continue;
 
-    CHECK_INVARIANT(nbnds % 2 == 0, "fragment graph problem when including zero-order bonds");
+    CHECK_INVARIANT(nbnds % 2 == 0,
+                    "fragment graph problem when including zero-order bonds");
     nbnds = nbnds / 2;
 
     boost::dynamic_bitset<> doneAts(nats);

--- a/Code/GraphMol/molopstest.cpp
+++ b/Code/GraphMol/molopstest.cpp
@@ -6830,6 +6830,46 @@ void testGithub1439() {
   BOOST_LOG(rdInfoLog) << "Finished" << std::endl;
 }
 
+void testGithub1281() {
+  BOOST_LOG(rdInfoLog)
+      << "-----------------------\n Testing github issue 1281: " << std::endl
+      << "RDKit gets stuck on PubChem CID 102128817" << std::endl;
+  {  // basics
+    std::string smiles =
+        "COC1=CC=C(C=C1)C2C3=C(C=CC4=CC=CC=C43)OC5=CC6=C(C=C5)C7=NC8=C9C=CC1="
+        "CC9=C(N8)N=C3C4=C5C=CC(=C4)OC4=C(C(C8=C(C=CC9=CC=CC=C98)OC8=CC9=C(C="
+        "C8)C8=NC9=NC9=C%10C=C(C=CC%10=C(N9)N=C9C%10=C(C=C(C=C%10)OC%10=C2C2="
+        "CC=CC=C2C=C%10)C(=N9)NC2=NC(=N8)C8=C2C=C(C=C8)OC2=C(C(C8=C(C=CC9=CC="
+        "CC=C98)OC8=CC9=C(C=C8)C(=NC5=N3)N=C9NC6=N7)C3=CC=C(C=C3)OC)C3=CC=CC="
+        "C3C=C2)OC2=C(C(C3=C(O1)C=CC1=CC=CC=C13)C1=CC=C(C=C1)OC)C1=CC=CC=C1C="
+        "C2)C1=CC=C(C=C1)OC)C1=CC=CC=C1C=C4";
+    {
+      RWMol *m = SmilesToMol(smiles, 0, false);
+      TEST_ASSERT(m);
+      TEST_ASSERT(m->getNumAtoms() == 204);
+      TEST_ASSERT(m->getNumBonds() == 244);
+      bool ok = false;
+      try {
+        MolOps::findSSSR(*m);
+      } catch (const ValueErrorException &) {
+        ok = true;
+      }
+      TEST_ASSERT(ok);
+      delete m;
+    }
+    {
+      bool ok = false;
+      try {
+        RWMol *m = SmilesToMol(smiles);
+      } catch (const ValueErrorException &) {
+        ok = true;
+      }
+      TEST_ASSERT(ok);
+    }
+  }
+  BOOST_LOG(rdInfoLog) << "Finished" << std::endl;
+}
+
 int main() {
   RDLog::InitLogs();
 // boost::logging::enable_logs("rdApp.debug");
@@ -6927,11 +6967,11 @@ int main() {
   testGithubIssue1204();
   testPotentialStereoBonds();
   testSetBondStereo();
-#endif
 
   testBondSetStereoAtoms();
   testGithub1478();
   testGithub1439();
-
+#endif
+  testGithub1281();
   return 0;
 }


### PR DESCRIPTION
This just causes the molecule processing to fail in a reasonable amount of time; it is not an actual fix to the underlying ring-finding problem

The real solution here would be to finish integrating the new ring-finding code from Florian (which I will eventually do). However, since that has turned out to be harder than expected, I'm adding this workaround so that the ring-finding algorithm throws an exception when things get too hairy instead of consuming all system memory.

I verified that this fix did not lead to any additional molecule parsing failures when processing the 1.7 million structures in ChEMBL 23