### PR TITLE
Fixes #1489

### DIFF
--- a/Code/GraphMol/QueryAtom.h
+++ b/Code/GraphMol/QueryAtom.h
@@ -78,6 +78,29 @@ class QueryAtom : public Atom {
 
 };  // end o' class
 
+namespace detail {
+inline std::string qhelper(Atom::QUERYATOM_QUERY *q, unsigned int depth) {
+  std::string res = "";
+  if (q) {
+    for (unsigned int i = 0; i < depth; ++i) res += "  ";
+    res += q->getFullDescription() + "\n";
+    for (Atom::QUERYATOM_QUERY::CHILD_VECT_CI ci = q->beginChildren();
+         ci != q->endChildren(); ++ci) {
+      res += qhelper((*ci).get(), depth + 1);
+    }
+  }
+  return res;
+}
+}  // end of detail namespace
+inline std::string describeQuery(const Atom *atom) {
+  PRECONDITION(atom, "bad atom");
+  std::string res = "";
+  if (atom->hasQuery()) {
+    res = detail::qhelper(atom->getQuery(), 0);
+  }
+  return res;
+}
+
 };  // end o' namespace
 
 #endif

--- a/Code/GraphMol/QueryBond.h
+++ b/Code/GraphMol/QueryBond.h
@@ -91,6 +91,29 @@ class QueryBond : public Bond {
  protected:
   QUERYBOND_QUERY *dp_query;
 };
+
+namespace detail {
+inline std::string qhelper(Bond::QUERYBOND_QUERY *q, unsigned int depth) {
+  std::string res;
+  if (q) {
+    for (unsigned int i = 0; i < depth; ++i) res += "  ";
+    res += q->getFullDescription() + "\n";
+    for (Bond::QUERYBOND_QUERY::CHILD_VECT_CI ci = q->beginChildren();
+         ci != q->endChildren(); ++ci) {
+      res += qhelper((*ci).get(), depth + 1);
+    }
+  }
+  return res;
+}
+}  // end of detail namespace
+inline std::string describeQuery(const Bond *bond) {
+  PRECONDITION(bond, "bad bond");
+  std::string res = "";
+  if (bond->hasQuery()) {
+    res = detail::qhelper(bond->getQuery(), 0);
+  }
+  return res;
+}
 };
 
 #endif

--- a/Code/GraphMol/SmilesParse/SmilesParseOps.cpp
+++ b/Code/GraphMol/SmilesParse/SmilesParseOps.cpp
@@ -28,7 +28,7 @@ void CheckRingClosureBranchStatus(RDKit::Atom *atom, RDKit::RWMol *mp) {
   // and is currently degree two (protects against C1CN[C@](O)(N)1)
   if (atom->getIdx() != mp->getNumAtoms(true) - 1 && atom->getDegree() == 2 &&
       (atom->getChiralTag() == Atom::CHI_TETRAHEDRAL_CW ||
-       atom->getChiralTag() == Atom::CHI_TETRAHEDRAL_CCW) ) {
+       atom->getChiralTag() == Atom::CHI_TETRAHEDRAL_CCW)) {
     atom->invertChirality();
   }
 }
@@ -219,7 +219,7 @@ void _invChiralRingAtomWithHs(Atom *atom) {
 typedef std::pair<size_t, size_t> SIZET_PAIR;
 typedef std::pair<int, int> INT_PAIR;
 template <typename T>
-bool operator<(const std::pair<T,T> &p1, const std::pair<T,T> &p2) {
+bool operator<(const std::pair<T, T> &p1, const std::pair<T, T> &p2) {
   return p1.first < p2.first;
 }
 namespace {
@@ -233,7 +233,43 @@ bool isUnsaturated(const Atom *atom, const RWMol *mol) {
   }
   return false;
 }
+
+bool hasSingleHQuery(const Atom::QUERYATOM_QUERY *q) {
+  // list queries are series of nested ors of AtomAtomicNum queries
+  PRECONDITION(q, "bad query");
+  bool res = false;
+  std::string descr = q->getDescription();
+  if (descr == "AtomAnd") {
+    for (Atom::QUERYATOM_QUERY::CHILD_VECT_CI cIt = q->beginChildren();
+         cIt != q->endChildren(); ++cIt) {
+      std::string descr = (*cIt)->getDescription();
+      if (descr == "AtomHCount") {
+        if (!(*cIt)->getNegation() &&
+            ((ATOM_EQUALS_QUERY *)(*cIt).get())->getVal() == 1) {
+          return true;
+        }
+        return false;
+      } else if (descr == "AtomAnd") {
+        res = hasSingleHQuery((*cIt).get());
+        if (res) return true;
+      }
+    }
+  }
+  return res;
 }
+
+bool atomHasExplicitHs(const Atom *atom) {
+  if (atom->getNumExplicitHs()) return true;
+  if (atom->hasQuery()) {
+    // the SMARTS [C@@H] produces an atom with a H query, but we also
+    // need to treat this like an explicit H for chirality purposes
+    // This was Github #1489
+    bool res = hasSingleHQuery(atom->getQuery());
+    return res;
+  }
+  return false;
+}
+}  // end of anonymous namespace
 void AdjustAtomChiralityFlags(RWMol *mol) {
   PRECONDITION(mol, "no molecule");
   for (RWMol::AtomIterator atomIt = mol->beginAtoms();
@@ -253,10 +289,10 @@ void AdjustAtomChiralityFlags(RWMol *mol) {
                                   ringClosures);
 
 #if 0
-        std::cout << "CLOSURES: ";
-        std::copy(ringClosures.begin(),ringClosures.end(),
-            std::ostream_iterator<int>(std::cout," "));
-        std::cout << std::endl;
+      std::cout << "CLOSURES: ";
+      std::copy(ringClosures.begin(), ringClosures.end(),
+                std::ostream_iterator<int>(std::cout, " "));
+      std::cout << std::endl;
 #endif
       std::list<SIZET_PAIR> neighbors;
       // push this atom onto the list of neighbors (we'll use this
@@ -333,7 +369,7 @@ void AdjustAtomChiralityFlags(RWMol *mol) {
       if ((*atomIt)->getDegree() == 3 &&
           (((*atomIt)->getNumExplicitHs() &&
             (*atomIt)->hasProp(common_properties::_SmilesStart)) ||
-           (!(*atomIt)->getNumExplicitHs() && ringClosures.size() == 1 &&
+           (!atomHasExplicitHs(*atomIt) && ringClosures.size() == 1 &&
             !isUnsaturated(*atomIt, mol)))) {
         ++nSwaps;
       }

--- a/Code/GraphMol/Substruct/SubstructMatch.h
+++ b/Code/GraphMol/Substruct/SubstructMatch.h
@@ -7,8 +7,8 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-#ifndef _RD_SUBSTRUCTMATCH_H__
-#define _RD_SUBSTRUCTMATCH_H__
+#ifndef RD_SUBSTRUCTMATCH_H
+#define RD_SUBSTRUCTMATCH_H
 
 // std bits
 #include <vector>

--- a/Code/GraphMol/Substruct/SubstructUtils.cpp
+++ b/Code/GraphMol/Substruct/SubstructUtils.cpp
@@ -30,13 +30,15 @@ bool atomCompat(const ATOM_SPTR &a1, const ATOM_SPTR &a2,
     res = a1->Match(a2);
   }
   return res;
+  std::cerr << "\t\tatomCompat: " << a1 << " " << a1->getIdx() << "-" << a2
+            << " " << a2->getIdx() << std::endl;
+  std::cerr << "\t\t    " << res << std::endl;
+  return res;
 }
 
 bool chiralAtomCompat(const ATOM_SPTR &a1, const ATOM_SPTR &a2) {
   PRECONDITION(a1, "bad atom");
   PRECONDITION(a2, "bad atom");
-  // std::cerr << "\t\tatomCompat: "<< a1 << " " << a1->getIdx() << "-" << a2 <<
-  // " " << a2->getIdx() << std::endl;
   bool res = a1->Match(a2);
   if (res) {
     std::string s1, s2;
@@ -46,6 +48,9 @@ bool chiralAtomCompat(const ATOM_SPTR &a1, const ATOM_SPTR &a2) {
       res = hascode1 && hascode2 && s1 == s2;
     }
   }
+  std::cerr << "\t\tchiralAtomCompat: " << a1 << " " << a1->getIdx() << "-"
+            << a2 << " " << a2->getIdx() << std::endl;
+  std::cerr << "\t\t    " << res << std::endl;
   return res;
 }
 

--- a/Code/GraphMol/Substruct/test1.cpp
+++ b/Code/GraphMol/Substruct/test1.cpp
@@ -1361,6 +1361,96 @@ void testDativeMatch() {
   BOOST_LOG(rdErrorLog) << "  done" << std::endl;
 }
 
+void testGithubIssue1489() {
+  BOOST_LOG(rdErrorLog) << "-------------------------------------" << std::endl;
+  BOOST_LOG(rdErrorLog) << "    Testing Github #1389: Substructure matching "
+                           "with chirality failure when query is built from "
+                           "SMARTS"
+                        << std::endl;
+#if 1
+  {
+    std::string smi1 = "CCC[C@@H]1CN(CCC)CCN1";
+    std::string smi2 = "CCC[C@H]1CN(CCC)CCN1";
+    ROMol *mol1 = SmilesToMol(smi1);
+    TEST_ASSERT(mol1);
+    ROMol *mol2 = SmilesToMol(smi2);
+    TEST_ASSERT(mol2);
+
+    bool recursionPossible = true;
+    bool useChirality = true;
+
+    MatchVectType match;
+    // make sure self-matches work
+    TEST_ASSERT(
+        SubstructMatch(*mol1, *mol1, match, recursionPossible, useChirality));
+    TEST_ASSERT(
+        SubstructMatch(*mol2, *mol2, match, recursionPossible, useChirality));
+
+    // check matches using the molecules from smiles:
+    TEST_ASSERT(
+        !SubstructMatch(*mol1, *mol2, match, recursionPossible, useChirality));
+    TEST_ASSERT(SubstructMatch(*mol1, *mol2, match, recursionPossible, false));
+
+    {
+      ROMol *qmol1 = SmartsToMol(smi1);
+
+      qmol1->updatePropertyCache();
+      TEST_ASSERT(qmol1);
+      TEST_ASSERT(
+          SubstructMatch(*mol1, *qmol1, match, recursionPossible, false));
+      TEST_ASSERT(SubstructMatch(*mol1, *qmol1, match, recursionPossible,
+                                 useChirality));
+      TEST_ASSERT(
+          SubstructMatch(*mol2, *qmol1, match, recursionPossible, false));
+      TEST_ASSERT(!SubstructMatch(*mol2, *qmol1, match, recursionPossible,
+                                  useChirality));
+      delete qmol1;
+    }
+    delete mol1;
+    delete mol2;
+  }
+#endif
+  {
+    std::string smi1 = "F([C@@H](Cl)Br)";
+    ROMol *mol1 = SmilesToMol(smi1);
+    TEST_ASSERT(mol1);
+
+    bool recursionPossible = true;
+    bool useChirality = true;
+
+    MatchVectType match;
+    // make sure self-matches work
+    TEST_ASSERT(
+        SubstructMatch(*mol1, *mol1, match, recursionPossible, useChirality));
+    {
+      ROMol *qmol1 = SmartsToMol(smi1);
+
+      qmol1->updatePropertyCache();
+      TEST_ASSERT(qmol1);
+      TEST_ASSERT(
+          SubstructMatch(*mol1, *qmol1, match, recursionPossible, false));
+      TEST_ASSERT(SubstructMatch(*mol1, *qmol1, match, recursionPossible,
+                                 useChirality));
+      delete qmol1;
+    }
+    {
+      std::string smi2 = "F([C@H](Br)Cl)";
+      ROMol *qmol1 = SmartsToMol(smi2);
+
+      qmol1->updatePropertyCache();
+      TEST_ASSERT(qmol1);
+      TEST_ASSERT(
+          SubstructMatch(*mol1, *qmol1, match, recursionPossible, false));
+      TEST_ASSERT(SubstructMatch(*mol1, *qmol1, match, recursionPossible,
+                                 useChirality));
+      delete qmol1;
+    }
+    delete mol1;
+  }
+
+  BOOST_LOG(rdErrorLog) << "  done" << std::endl;
+}
+
 int main(int argc, char *argv[]) {
 #if 1
   test1();
@@ -1380,8 +1470,8 @@ int main(int argc, char *argv[]) {
   testGitHubIssue688();
   testDativeMatch();
   testCisTransMatch();
-
-#endif
   testCisTransMatch2();
+#endif
+  testGithubIssue1489();
   return 0;
 }

--- a/Code/GraphMol/Wrap/Atom.cpp
+++ b/Code/GraphMol/Wrap/Atom.cpp
@@ -29,26 +29,7 @@
 namespace python = boost::python;
 namespace RDKit {
 namespace {
-std::string qhelper(Atom::QUERYATOM_QUERY *q, unsigned int depth) {
-  std::string res = "";
-  if (q) {
-    for (unsigned int i = 0; i < depth; ++i) res += "  ";
-    res += q->getFullDescription() + "\n";
-    for (Atom::QUERYATOM_QUERY::CHILD_VECT_CI ci = q->beginChildren();
-         ci != q->endChildren(); ++ci) {
-      res += qhelper((*ci).get(), depth + 1);
-    }
-  }
-  return res;
-}
-}  // end of local namespace
-std::string describeQuery(const Atom *atom) {
-  std::string res = "";
-  if (atom->hasQuery()) {
-    res = qhelper(atom->getQuery(), 0);
-  }
-  return res;
-}
+
 void expandQuery(QueryAtom *self, const QueryAtom *other,
                  Queries::CompositeQueryType how, bool maintainOrder) {
   if (other->hasQuery()) {

--- a/Code/GraphMol/Wrap/Atom.cpp
+++ b/Code/GraphMol/Wrap/Atom.cpp
@@ -1,6 +1,5 @@
-// $Id$
 //
-//  Copyright (C) 2003-2013 Greg Landrum and Rational Discovery LLC
+//  Copyright (C) 2003-2017 Greg Landrum and Rational Discovery LLC
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -28,7 +27,6 @@
 
 namespace python = boost::python;
 namespace RDKit {
-namespace {
 
 void expandQuery(QueryAtom *self, const QueryAtom *other,
                  Queries::CompositeQueryType how, bool maintainOrder) {

--- a/Code/GraphMol/Wrap/Bond.cpp
+++ b/Code/GraphMol/Wrap/Bond.cpp
@@ -23,32 +23,6 @@
 namespace python = boost::python;
 namespace RDKit {
 
-namespace {
-std::string qhelper(Bond::QUERYBOND_QUERY *q, unsigned int depth) {
-  std::ostringstream res;
-
-  if (q) {
-    for (unsigned int i = 0; i < depth; ++i) res << "  ";
-    res << q->getFullDescription();
-    if (q->getNegation()) res << " ! ";
-
-    res << "\n";
-    for (Bond::QUERYBOND_QUERY::CHILD_VECT_CI ci = q->beginChildren();
-         ci != q->endChildren(); ++ci) {
-      res << qhelper((*ci).get(), depth + 1);
-    }
-  }
-  return res.str();
-}
-}  // end of local namespace
-std::string describeQuery(const Bond *bond) {
-  std::string res = "";
-  if (bond->hasQuery()) {
-    res = qhelper(bond->getQuery(), 0);
-  }
-  return res;
-}
-
 void expandQuery(QueryBond *self, const QueryBond *other,
                  Queries::CompositeQueryType how, bool maintainOrder) {
   if (other->hasQuery()) {

--- a/Code/GraphMol/Wrap/Bond.cpp
+++ b/Code/GraphMol/Wrap/Bond.cpp
@@ -1,6 +1,5 @@
-// $Id$
 //
-//  Copyright (C) 2003-2014 Rational Discovery LLC
+//  Copyright (C) 2003-2017 Rational Discovery LLC
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.


### PR DESCRIPTION
This also moves the C++ versions of the `describeQuery()` functions for atoms and bonds from the code for the Python wrapper into the main C++ API. The functions are generally useful.