### PR TITLE
Dev/rgroup decomp freefunction

### DIFF
--- a/Code/GraphMol/RGroupDecomposition/RGroupDecomp.cpp
+++ b/Code/GraphMol/RGroupDecomposition/RGroupDecomp.cpp
@@ -222,7 +222,6 @@ struct RGroupData {
       delete m;
     }
     smiles = getSmiles();
-    PRECONDITION(combinedMol->hasProp("idx"), "NO IDX");
     combinedMol->setProp(common_properties::internalRgroupSmiles, smiles);
   }
 
@@ -274,30 +273,6 @@ struct RGroupMatch {
   RGroupMatch(size_t core_index, const R_DECOMP &input_rgroups)
       : core_idx(core_index), rgroups(input_rgroups) {}
 
-  /*
-  bool check() const {
-    for(R_DECOMP::const_iterator rgroup = rgroups.begin();
-        rgroup != rgroups.end();
-        ++rgroup) {
-      std::cerr << "== Checking rgroupmatch:" << rgroup->first << " " <<
-          "idx: " << rgroup->second->combinedMol->getProp<int>("idx") <<
-          " numatoms:" << rgroup->second->combinedMol->getNumAtoms() <<
-          " has smiles " << (int)rgroup->second->combinedMol->hasProp(common_properties::rgroupSmiles) <<
-          " labelled: " << rgroup->second->labelled <<
-          " count:" << rgroup->second->count <<
-          std::endl;
-      if(!rgroup->second->combinedMol->hasProp(common_properties::rgroupSmiles)) {
-        std::cerr << "Check failed: No smiles:" << rgroup->second->count << std::endl;
-        return false;
-      }
-      if(!rgroup->second->labelled) {
-        std::cerr << "Check failed: Unlabelled rgroup: " << rgroup->second->count << std::endl;
-        return false;
-      }
-    }
-    return true;
-  }
-  */
 };
 
 void ADD_MATCH(R_DECOMP &match, int rlabel) {
@@ -650,8 +625,6 @@ struct RGroupDecompData {
       mol.addBond(atomsToAdd[i].first, atomsToAdd[i].second, Bond::SINGLE);
     }
     mol.updatePropertyCache(false);  // this was github #1550
-    mol.setProp<std::string>(common_properties::rgroupSmiles,
-                             MolToSmiles(mol,true));
   }
 
   void relabelRGroup(RGroupData &rgroup, const std::map<int, int> &mappings) {
@@ -659,7 +632,6 @@ struct RGroupDecompData {
 
     RWMol &mol = *rgroup.combinedMol.get();
     if (rgroup.combinedMol->hasProp(done)) {
-      PRECONDITION(mol.hasProp(common_properties::rgroupSmiles), "Must have smiles");
       rgroup.labelled = true;
       return;
     }
@@ -707,8 +679,6 @@ struct RGroupDecompData {
     }
     
     mol.updatePropertyCache(false);  // this was github #1550
-    mol.setProp<std::string>(common_properties::rgroupSmiles,
-                             MolToSmiles(mol, true));
     rgroup.labelled = true;
   }
 
@@ -1089,10 +1059,6 @@ RGroupColumns RGroupDecomposition::getRGroupsAsColumns() const {
     for(size_t idx=0;idx<it->second.size();++idx) {
       if(!it->second[idx].get()) {
         it->second[idx] = boost::make_shared<RWMol>();
-        it->second[idx]->setProp(common_properties::rgroupSmiles, "");
-      }
-      else if (!it->second[idx]->hasProp(common_properties::rgroupSmiles)) {
-        it->second[idx]->setProp(common_properties::rgroupSmiles, "");
       }
     }
   }

--- a/Code/GraphMol/RGroupDecomposition/RGroupDecomp.cpp
+++ b/Code/GraphMol/RGroupDecomposition/RGroupDecomp.cpp
@@ -1078,9 +1078,9 @@ std::vector<unsigned int> Decomp(RGroupDecomposition &decomp,
   return unmatched;
 }
 }
-unsigned int RGroupDecompose(RGroupRows &rows,
-                             const std::vector<ROMOL_SPTR> &cores,
+unsigned int RGroupDecompose(const std::vector<ROMOL_SPTR> &cores,
                              const std::vector<ROMOL_SPTR> &mols,
+                             RGroupRows &rows,
                              std::vector<unsigned int> *unmatchedIndices,
                              const RGroupDecompositionParameters &options) {
   RGroupDecomposition decomp(cores, options);
@@ -1091,9 +1091,9 @@ unsigned int RGroupDecompose(RGroupRows &rows,
   return mols.size() - unmatched.size();
 }
 
-unsigned int RGroupDecompose(RGroupColumns &columns,
-                             const std::vector<ROMOL_SPTR> &cores,
+unsigned int RGroupDecompose(const std::vector<ROMOL_SPTR> &cores,
                              const std::vector<ROMOL_SPTR> &mols,
+                             RGroupColumns &columns,
                              std::vector<unsigned int> *unmatchedIndices,
                              const RGroupDecompositionParameters &options)
 {

--- a/Code/GraphMol/RGroupDecomposition/RGroupDecomp.cpp
+++ b/Code/GraphMol/RGroupDecomposition/RGroupDecomp.cpp
@@ -1087,7 +1087,11 @@ RGroupColumns RGroupDecomposition::getRGroupsAsColumns() const {
     }
     
     for(size_t idx=0;idx<it->second.size();++idx) {
-      if (!it->second[idx]->hasProp(common_properties::rgroupSmiles)) {
+      if(!it->second[idx].get()) {
+        it->second[idx] = boost::make_shared<RWMol>();
+        it->second[idx]->setProp(common_properties::rgroupSmiles, "");
+      }
+      else if (!it->second[idx]->hasProp(common_properties::rgroupSmiles)) {
         it->second[idx]->setProp(common_properties::rgroupSmiles, "");
       }
     }

--- a/Code/GraphMol/RGroupDecomposition/RGroupDecomp.cpp
+++ b/Code/GraphMol/RGroupDecomposition/RGroupDecomp.cpp
@@ -52,6 +52,7 @@ namespace RDKit {
 namespace {
 const std::string RLABEL = "tempRlabel";
 const std::string SIDECHAIN_RLABELS = "sideChainRlabels";
+const std::string done = "RLABEL_PROCESSED";
 
 bool setLabel(Atom *atom, int label, std::set<int> &labels, int &maxLabel,
               bool relabel, const std::string &type) {
@@ -181,6 +182,7 @@ bool RGroupDecompositionParameters::prepareCore(RWMol &core,
 
 namespace {
 // RGroup Class to hold the attached bits
+
 struct RGroupData {
   boost::shared_ptr<RWMol> combinedMol;
   std::vector<boost::shared_ptr<ROMol> > mols;  // All the mols in the rgroup
@@ -188,7 +190,15 @@ struct RGroupData {
   std::string
       smiles;  // smiles for all the mols in the rgroup (with attachments)
   std::set<int> attachments;  // attachment points
+  bool labelled;
 
+ private:
+  RGroupData(const RGroupData &rhs);
+  
+ public:
+  RGroupData() : combinedMol(), mols(), smilesSet(), smiles(), attachments(), labelled(false) {
+  }
+  
   void add(boost::shared_ptr<ROMol> newMol,
            const std::vector<int> &rlabel_attachments) {
     // some fragments can be add multiple times if they are cyclic
@@ -196,6 +206,7 @@ struct RGroupData {
       if (newMol.get() == mols[i].get()) return;
     }
 
+    labelled = false;
     std::copy(rlabel_attachments.begin(), rlabel_attachments.end(),
               std::inserter(attachments, attachments.end()));
 
@@ -206,10 +217,12 @@ struct RGroupData {
       combinedMol = boost::shared_ptr<RWMol>(new RWMol(*mols[0].get()));
     } else {
       ROMol *m = combineMols(*combinedMol.get(), *newMol.get());
+      m->updateProps(*combinedMol.get());
       combinedMol.reset(new RWMol(*m));
       delete m;
     }
     smiles = getSmiles();
+    PRECONDITION(combinedMol->hasProp("idx"), "NO IDX");
     combinedMol->setProp(common_properties::internalRgroupSmiles, smiles);
   }
 
@@ -250,12 +263,47 @@ struct RGroupData {
 }
 
 namespace {
+typedef boost::shared_ptr<RGroupData> RData;
+
+typedef std::map<int, RData> R_DECOMP;
 struct RGroupMatch {
-  size_t core_idx;
-  std::map<int, RGroupData> rgroups;
-  RGroupMatch(size_t core_index, const std::map<int, RGroupData> &input_rgroups)
+  // RGroupMatch is the decomposition for a single molecule
+  size_t core_idx; // index of the matching core
+  R_DECOMP rgroups; // rlabel->RGroupData mapping
+  
+  RGroupMatch(size_t core_index, const R_DECOMP &input_rgroups)
       : core_idx(core_index), rgroups(input_rgroups) {}
+
+  /*
+  bool check() const {
+    for(R_DECOMP::const_iterator rgroup = rgroups.begin();
+        rgroup != rgroups.end();
+        ++rgroup) {
+      std::cerr << "== Checking rgroupmatch:" << rgroup->first << " " <<
+          "idx: " << rgroup->second->combinedMol->getProp<int>("idx") <<
+          " numatoms:" << rgroup->second->combinedMol->getNumAtoms() <<
+          " has smiles " << (int)rgroup->second->combinedMol->hasProp(common_properties::rgroupSmiles) <<
+          " labelled: " << rgroup->second->labelled <<
+          " count:" << rgroup->second->count <<
+          std::endl;
+      if(!rgroup->second->combinedMol->hasProp(common_properties::rgroupSmiles)) {
+        std::cerr << "Check failed: No smiles:" << rgroup->second->count << std::endl;
+        return false;
+      }
+      if(!rgroup->second->labelled) {
+        std::cerr << "Check failed: Unlabelled rgroup: " << rgroup->second->count << std::endl;
+        return false;
+      }
+    }
+    return true;
+  }
+  */
 };
+
+void ADD_MATCH(R_DECOMP &match, int rlabel) {
+  if(match.find(rlabel) == match.end())
+    match[rlabel] = boost::make_shared<RGroupData>();
+}
 
 struct CartesianProduct {
   std::vector<size_t> permutation;
@@ -315,23 +363,23 @@ double score(const std::vector<size_t> &permutation,
     std::map<std::set<int>, int> linkerMatchSet;
     // std::map<std::vector<int>, int > attachMatch;
     for (size_t m = 0; m < permutation.size(); ++m) {  // for each molecule
-      std::map<int, RGroupData>::const_iterator rg =
+      R_DECOMP::const_iterator rg =
           matches[m][permutation[m]].rgroups.find(l);
       if (rg != matches[m][permutation[m]].rgroups.end()) {
 #ifdef DEBUG
-        std::cerr << " RGroup: " << rg->second.smiles;
+        std::cerr << " RGroup: " << rg->second->smiles;
 #endif
-        matchSet[rg->second.smiles]++;
+        matchSet[rg->second->smiles]++;
 #ifdef DEBUG
-        std::cerr << " score: " << matchSet[rg->second.smiles] << std::endl;
+        std::cerr << " score: " << matchSet[rg->second->smiles] << std::endl;
 #endif
         // XXX Use fragment counts to see if we are linking cycles?
-        if (rg->second.smiles.find(".") == std::string::npos &&
-            rg->second.attachments.size() > 1) {
-          linkerMatchSet[rg->second.attachments]++;
+        if (rg->second->smiles.find(".") == std::string::npos &&
+            rg->second->attachments.size() > 1) {
+          linkerMatchSet[rg->second->attachments]++;
 #ifdef DEBUG
           std::cerr << " Linker Score: "
-                    << linkerMatchSet[rg->second.attachments]++ << std::endl;
+                    << linkerMatchSet[rg->second->attachments]++ << std::endl;
 #endif
         }
       }
@@ -487,10 +535,10 @@ struct RGroupDecompData {
            lit != labels.end(); ++lit) {
         bool allH = true;
         for (size_t i = 0; i < result.size(); ++i) {
-          std::map<int, RGroupData>::const_iterator rgroup =
+          R_DECOMP::const_iterator rgroup =
               result[i].rgroups.find(*lit);
           if (rgroup == result[i].rgroups.end() ||
-              !rgroup->second.isHydrogen()) {
+              !rgroup->second->isHydrogen()) {
             allH = false;
             break;
           }
@@ -602,16 +650,22 @@ struct RGroupDecompData {
       mol.addBond(atomsToAdd[i].first, atomsToAdd[i].second, Bond::SINGLE);
     }
     mol.updatePropertyCache(false);  // this was github #1550
+    mol.setProp<std::string>(common_properties::rgroupSmiles,
+                             MolToSmiles(mol,true));
   }
 
   void relabelRGroup(RGroupData &rgroup, const std::map<int, int> &mappings) {
     PRECONDITION(rgroup.combinedMol.get(), "Unprocessed rgroup");
-    const std::string done = "RLABEL_PROCESSED";
-    if (rgroup.combinedMol->hasProp(done)) return;
-
-    rgroup.combinedMol->setProp(done, true);
 
     RWMol &mol = *rgroup.combinedMol.get();
+    if (rgroup.combinedMol->hasProp(done)) {
+      PRECONDITION(mol.hasProp(common_properties::rgroupSmiles), "Must have smiles");
+      rgroup.labelled = true;
+      return;
+    }
+
+    mol.setProp(done, true);
+    //std::cerr << "==> relabelling: " << mol.getProp<int>("idx") << " <++idx" << std::endl;
 
     std::vector<std::pair<Atom *, Atom *> > atomsToAdd;  // adds -R if necessary
 
@@ -644,16 +698,18 @@ struct RGroupDecompData {
       mol.addAtom(atomsToAdd[i].second, false, true);
       mol.addBond(atomsToAdd[i].first, atomsToAdd[i].second, Bond::SINGLE);
     }
+    
     if (params.removeHydrogensPostMatch) {
       bool implicitOnly = false;
       bool updateExplicitCount = false;
       bool sanitize = false;
       MolOps::removeHs(mol, implicitOnly, updateExplicitCount, sanitize);
     }
+    
     mol.updatePropertyCache(false);  // this was github #1550
     mol.setProp<std::string>(common_properties::rgroupSmiles,
                              MolToSmiles(mol, true));
-
+    rgroup.labelled = true;
   }
 
   // relabel the core and sidechains using the specified user labels
@@ -676,15 +732,13 @@ struct RGroupDecompData {
 
     for (std::vector<RGroupMatch>::iterator it = best.begin(); it != best.end();
          ++it) {
-      for (std::map<int, RGroupData>::iterator rit = it->rgroups.begin();
+      for (R_DECOMP::iterator rit = it->rgroups.begin();
            rit != it->rgroups.end(); ++rit) {
         if (rit->first >= 0) userLabels.insert(rit->first);
         if (rit->first < 0) indexLabels.insert(rit->first);
 
-        std::map<int, int> rlabelsUsedInRGroup =
-            rit->second.getNumBondsToRlabels();
-        for (std::map<int, int>::iterator numBondsUsed =
-                 rlabelsUsedInRGroup.begin();
+        std::map<int, int> rlabelsUsedInRGroup = rit->second->getNumBondsToRlabels();
+        for (std::map<int, int>::iterator numBondsUsed = rlabelsUsedInRGroup.begin();
              numBondsUsed != rlabelsUsedInRGroup.end(); ++numBondsUsed) {
           // Make space for the extra labels
           if (numBondsUsed->second > 1) {  // multiple
@@ -705,12 +759,11 @@ struct RGroupDecompData {
                   indexLabels, extraAtomRLabels);
     }
 
-    const std::string done = "RLABEL_PROCESSED";
     for (std::vector<RGroupMatch>::iterator it = best.begin(); it != best.end();
          ++it) {
-      for (std::map<int, RGroupData>::iterator rit = it->rgroups.begin();
+      for (R_DECOMP::iterator rit = it->rgroups.begin();
            rit != it->rgroups.end(); ++rit) {
-        relabelRGroup(rit->second, finalRlabelMapping);
+        relabelRGroup(*rit->second, finalRlabelMapping);
       }
     }
   }
@@ -829,6 +882,8 @@ int RGroupDecomposition::add(const ROMol &inmol) {
 
   //  Should probably scan all mols first to find match with
   //  smallest number of matches...
+  size_t size = data->matches.size();
+
 
   std::vector<RGroupMatch> potentialMatches;
 
@@ -843,12 +898,16 @@ int RGroupDecomposition::add(const ROMol &inmol) {
     }
 
     if (tMol) {
-      std::map<int, RGroupData> match;
+      R_DECOMP match;
       // rlabel rgroups
       MOL_SPTR_VECT fragments = MolOps::getMolFrags(*tMol, false);
       for (size_t i = 0; i < fragments.size(); ++i) {
         std::vector<int> attachments;
         boost::shared_ptr<ROMol> &newMol = fragments[i];
+        newMol->setProp<int>("core", core_idx);
+        newMol->setProp<int>("idx", size);
+        newMol->setProp<int>("frag_idx", i);
+        
         for (ROMol::AtomIterator atIt = newMol->beginAtoms();
              atIt != newMol->endAtoms(); ++atIt) {
           Atom *tmp = *atIt;
@@ -878,7 +937,8 @@ int RGroupDecomposition::add(const ROMol &inmol) {
           for (size_t attach_idx = 0; attach_idx < attachments.size();
                ++attach_idx) {
             int rlabel = attachments[attach_idx];
-            match[rlabel].add(newMol, attachments);
+            ADD_MATCH(match, rlabel);
+            match[rlabel]->add(newMol, attachments);
           }
         } else {
           // special case, only one fragment
@@ -944,8 +1004,6 @@ int RGroupDecomposition::add(const ROMol &inmol) {
   data->matches.push_back(potentialMatches);
   data->permutation = std::vector<size_t>(data->matches.size(), 0);
 
-  size_t size = data->matches.size();
-
   if (size) {
     if (data->params.matchingStrategy & Greedy ||
         (data->params.matchingStrategy & GreedyChunks && size > 1 &&
@@ -978,9 +1036,9 @@ RGroupRows RGroupDecomposition::getRGroupsAsRows() const {
     RGroupRow &out_rgroups = groups.back();
     out_rgroups["Core"] = data->labelledCores[it->core_idx];
 
-    std::map<int, RGroupData> &in_rgroups = it->rgroups;
+    R_DECOMP &in_rgroups = it->rgroups;
 
-    for (std::map<int, RGroupData>::const_iterator rgroup = in_rgroups.begin();
+    for (R_DECOMP::const_iterator rgroup = in_rgroups.begin();
          rgroup != in_rgroups.end(); ++rgroup) {
       std::map<int, int>::const_iterator realLabel =
           data->finalRlabelMapping.find(rgroup->first);
@@ -988,7 +1046,7 @@ RGroupRows RGroupDecomposition::getRGroupsAsRows() const {
                    "unprocessed rlabel, please call process() first.");
       out_rgroups[std::string("R") +
                   boost::lexical_cast<std::string>(realLabel->second)] =
-          rgroup->second.combinedMol;
+          rgroup->second->combinedMol;
     }
   }
   return groups;
@@ -1002,26 +1060,37 @@ RGroupColumns RGroupDecomposition::getRGroupsAsColumns() const {
   unsigned int molidx = 0;
   for (std::vector<RGroupMatch>::iterator it = permutation.begin();
        it != permutation.end(); ++it, ++molidx) {
-    std::map<int, RGroupData> &in_rgroups = it->rgroups;
+    R_DECOMP &in_rgroups = it->rgroups;
     groups["Core"].push_back(data->labelledCores[it->core_idx]);
 
-    for (std::map<int, RGroupData>::const_iterator rgroup = in_rgroups.begin();
+    for (R_DECOMP::const_iterator rgroup = in_rgroups.begin();
          rgroup != in_rgroups.end(); ++rgroup) {
       std::map<int, int>::const_iterator realLabel =
           data->finalRlabelMapping.find(rgroup->first);
       PRECONDITION(realLabel != data->finalRlabelMapping.end(),
                    "unprocessed rlabel, please call process() first.");
+      PRECONDITION(rgroup->second->combinedMol->hasProp(done),
+                   "Not done! Call process()");
+
       std::string r = std::string("R") +
                       boost::lexical_cast<std::string>(realLabel->second);
       RGroupColumn &col = groups[r];
       if (molidx && col.size() < (size_t)(molidx - 1)) col.resize(molidx - 1);
-      col.push_back(rgroup->second.combinedMol);
+      col.push_back(rgroup->second->combinedMol);
     }
   }
-  // Now make all columns equal
+  // Now make all columns equal - this adds empty mols...
   for (std::map<std::string, RGroupColumn>::iterator it = groups.begin();
        it != groups.end(); ++it) {
-    if (it->second.size() != molidx) it->second.resize(molidx);
+    if (it->second.size() != molidx) {
+      it->second.resize(molidx);
+    }
+    
+    for(size_t idx=0;idx<it->second.size();++idx) {
+      if (!it->second[idx]->hasProp(common_properties::rgroupSmiles)) {
+        it->second[idx]->setProp(common_properties::rgroupSmiles, "");
+      }
+    }
   }
   return groups;
 }

--- a/Code/GraphMol/RGroupDecomposition/RGroupDecomp.h
+++ b/Code/GraphMol/RGroupDecomposition/RGroupDecomp.h
@@ -143,6 +143,19 @@ class RGroupDecomposition {
   //! return rgroups in column order group[attachment_point][row] = ROMol
   RGroupColumns getRGroupsAsColumns() const;
 };
+
+unsigned int RGroupDecompose(RGroupRows &rows,
+                             const std::vector<ROMOL_SPTR> &cores,
+                             const std::vector<ROMOL_SPTR> &mols,
+                             std::vector<unsigned int> *unmatched = 0,
+                             const RGroupDecompositionParameters &options = RGroupDecompositionParameters());
+
+unsigned int RGroupDecompose(RGroupColumns &rows,
+                             const std::vector<ROMOL_SPTR> &cores,
+                             const std::vector<ROMOL_SPTR> &mols,
+                             std::vector<unsigned int> *unmatched = 0,
+                             const RGroupDecompositionParameters &options = RGroupDecompositionParameters());
+                        
 }
 
 #endif

--- a/Code/GraphMol/RGroupDecomposition/RGroupDecomp.h
+++ b/Code/GraphMol/RGroupDecomposition/RGroupDecomp.h
@@ -144,15 +144,15 @@ class RGroupDecomposition {
   RGroupColumns getRGroupsAsColumns() const;
 };
 
-unsigned int RGroupDecompose(RGroupRows &rows,
-                             const std::vector<ROMOL_SPTR> &cores,
+unsigned int RGroupDecompose(const std::vector<ROMOL_SPTR> &cores,
                              const std::vector<ROMOL_SPTR> &mols,
+                             RGroupRows &rows,
                              std::vector<unsigned int> *unmatched = 0,
                              const RGroupDecompositionParameters &options = RGroupDecompositionParameters());
 
-unsigned int RGroupDecompose(RGroupColumns &rows,
-                             const std::vector<ROMOL_SPTR> &cores,
+unsigned int RGroupDecompose(const std::vector<ROMOL_SPTR> &cores,
                              const std::vector<ROMOL_SPTR> &mols,
+                             RGroupColumns &columns,
                              std::vector<unsigned int> *unmatched = 0,
                              const RGroupDecompositionParameters &options = RGroupDecompositionParameters());
                         

--- a/Code/GraphMol/RGroupDecomposition/Wrap/rdRGroupComposition.cpp
+++ b/Code/GraphMol/RGroupDecomposition/Wrap/rdRGroupComposition.cpp
@@ -39,7 +39,7 @@
 #include <math.h>
 
 #include <RDGeneral/Exceptions.h>
-#include <DataStructs/ExplicitBitVect.h>
+#include <GraphMol/SmilesParse/SmilesWrite.h>
 #include <GraphMol/RDKitBase.h>
 #include <GraphMol/RGroupDecomposition/RGroupDecomp.h>
 #include <RDBoost/Wrap.h>
@@ -88,8 +88,7 @@ class RGroupDecompositionHelper {
       for (RGroupRow::const_iterator sit = side_chains.begin();
            sit != side_chains.end(); ++sit) {
         if (asSmiles) {
-          PRECONDITION(sit->second->hasProp(common_properties::rgroupSmiles), "rows: no cached rgroup smiles");
-          dict[sit->first] = sit->second->getProp<std::string>(common_properties::rgroupSmiles);
+          dict[sit->first] = MolToSmiles(*sit->second, true);
         } else {
           dict[sit->first] = sit->second;
         }
@@ -111,10 +110,7 @@ class RGroupDecompositionHelper {
       for (RGroupColumn::const_iterator cit = it->second.begin();
            cit != it->second.end(); ++cit) {
         if (asSmiles) {
-          //std::cerr << "--> checking " << (*cit)->getProp<int>("idx") << std::endl;
-          //PRECONDITION((*cit)->hasProp(common_properties::rgroupSmiles),
-          //             "columns: No cached rgroup smiles!")
-          col.append((*cit)->getProp<std::string>(common_properties::rgroupSmiles));
+          col.append(MolToSmiles(**cit,true));
         } else {
           col.append(*cit);
         }

--- a/Code/GraphMol/RGroupDecomposition/Wrap/rdRGroupComposition.cpp
+++ b/Code/GraphMol/RGroupDecomposition/Wrap/rdRGroupComposition.cpp
@@ -88,6 +88,7 @@ class RGroupDecompositionHelper {
       for (RGroupRow::const_iterator sit = side_chains.begin();
            sit != side_chains.end(); ++sit) {
         if (asSmiles) {
+          PRECONDITION(sit->second->hasProp(common_properties::rgroupSmiles), "rows: no cached rgroup smiles");
           dict[sit->first] = sit->second->getProp<std::string>(common_properties::rgroupSmiles);
         } else {
           dict[sit->first] = sit->second;
@@ -110,6 +111,9 @@ class RGroupDecompositionHelper {
       for (RGroupColumn::const_iterator cit = it->second.begin();
            cit != it->second.end(); ++cit) {
         if (asSmiles) {
+          //std::cerr << "--> checking " << (*cit)->getProp<int>("idx") << std::endl;
+          //PRECONDITION((*cit)->hasProp(common_properties::rgroupSmiles),
+          //             "columns: No cached rgroup smiles!")
           col.append((*cit)->getProp<std::string>(common_properties::rgroupSmiles));
         } else {
           col.append(*cit);
@@ -131,7 +135,6 @@ python::object RGroupDecomp(python::object cores,
                             ) {
   RGroupDecompositionHelper decomp(cores, options);
   python::list unmatched;
-  unsigned int count = 0;
 
   python::stl_input_iterator<ROMOL_SPTR> iter(mols), end;
   while (iter != end) {
@@ -235,10 +238,20 @@ struct rgroupdecomp_wrapper {
         .def("Process", &RGroupDecompositionHelper::Process,
              "Process the rgroups (must be done prior to "
              "GetRGroupsAsRows/Columns)")
-        .def("GetRGroupsAsRows", &RGroupDecompositionHelper::GetRGroupsAsRows)
+        .def("GetRGroupsAsRows", &RGroupDecompositionHelper::GetRGroupsAsRows,
+             python::arg("asSmiles")=false)
         .def("GetRGroupsAsColumns",
-             &RGroupDecompositionHelper::GetRGroupsAsColumn);
-  };
+             &RGroupDecompositionHelper::GetRGroupsAsColumn,
+             python::arg("asSmiles")=false);
+    docString = "...";
+    python::def(
+        "RGroupDecomp", RDKit::RGroupDecomp,
+        (python::arg("cores"), python::arg("mols"),
+         python::arg("asSmiles") = false,
+         python::arg("asRows") = true,
+         python::arg("options") = RGroupDecompositionParameters()),
+        docString.c_str());
+  };  
 };
 }
 

--- a/Code/GraphMol/RGroupDecomposition/Wrap/test_rgroups.py
+++ b/Code/GraphMol/RGroupDecomposition/Wrap/test_rgroups.py
@@ -37,7 +37,7 @@ from rdkit.six.moves import cPickle
 
 from rdkit import rdBase
 from rdkit import Chem
-from rdkit.Chem.rdRGroupDecomposition import RGroupDecomposition, RGroupDecompositionParameters
+from rdkit.Chem.rdRGroupDecomposition import RGroupDecomp, RGroupDecomposition, RGroupDecompositionParameters
 from collections import OrderedDict
 
 class TestCase(unittest.TestCase) :
@@ -112,12 +112,23 @@ C1CCO[C@@](S)(P)1
         core = Chem.MolFromSmarts("C1CCOC1")
         rgroups = RGroupDecomposition(core)
         for m in mols:
-            print (m, Chem.MolToSmiles(m))
             rgroups.Add(m)
         rgroups.Process()
         columns = rgroups.GetRGroupsAsColumns()
+        data = {}
         for k,v in columns.items():
-            print("%s:%s"%(k, " ".join([Chem.MolToSmiles(m,True) for m in v])))
+            data[k] = [Chem.MolToSmiles(m,True) for m in v]
+
+        rgroups2,unmatched = RGroupDecomp([core], mols)
+        columns2,unmatched = RGroupDecomp([core], mols, asRows=False)
+        data2 = {}
+        for k,v in columns2.items():
+            data2[k] = [Chem.MolToSmiles(m,True) for m in v]
+
+        self.assertEqual(data, data2)
+        columns3, unmatched = RGroupDecomp([core], mols, asRows=False, asSmiles=True)
+        self.assertEqual(data, columns3)
+        
 
     def test_h_options(self):
         core = Chem.MolFromSmiles("O=c1oc2ccccc2cc1")

--- a/Code/GraphMol/RGroupDecomposition/Wrap/test_rgroups.py
+++ b/Code/GraphMol/RGroupDecomposition/Wrap/test_rgroups.py
@@ -37,7 +37,7 @@ from rdkit.six.moves import cPickle
 
 from rdkit import rdBase
 from rdkit import Chem
-from rdkit.Chem.rdRGroupDecomposition import RGroupDecomp, RGroupDecomposition, RGroupDecompositionParameters
+from rdkit.Chem.rdRGroupDecomposition import RGroupDecompose, RGroupDecomposition, RGroupDecompositionParameters
 from collections import OrderedDict
 
 class TestCase(unittest.TestCase) :
@@ -119,14 +119,14 @@ C1CCO[C@@](S)(P)1
         for k,v in columns.items():
             data[k] = [Chem.MolToSmiles(m,True) for m in v]
 
-        rgroups2,unmatched = RGroupDecomp([core], mols)
-        columns2,unmatched = RGroupDecomp([core], mols, asRows=False)
+        rgroups2,unmatched = RGroupDecompose([core], mols)
+        columns2,unmatched = RGroupDecompose([core], mols, asRows=False)
         data2 = {}
         for k,v in columns2.items():
             data2[k] = [Chem.MolToSmiles(m,True) for m in v]
 
         self.assertEqual(data, data2)
-        columns3, unmatched = RGroupDecomp([core], mols, asRows=False, asSmiles=True)
+        columns3, unmatched = RGroupDecompose([core], mols, asRows=False, asSmiles=True)
         self.assertEqual(data, columns3)
         
 
@@ -153,6 +153,18 @@ C1CCO[C@@](S)(P)1
         columns = rgd.GetRGroupsAsColumns()
         self.assertEqual(columns['R2'][0].GetNumAtoms(),7)
 
+    def test_unmatched(self):
+        cores = [Chem.MolFromSmiles("N")]
+        mols = [Chem.MolFromSmiles("CC"),
+                Chem.MolFromSmiles("CC"),
+                Chem.MolFromSmiles("CC"),
+                Chem.MolFromSmiles("N"),
+                Chem.MolFromSmiles("CC")]
+
+        res, unmatched = RGroupDecompose(cores, mols)
+        self.assertEquals(len(res), 1)
+        self.assertEquals(unmatched, [0,1,2,4])
+        
 
 if __name__ == '__main__':
   unittest.main()

--- a/Code/GraphMol/RGroupDecomposition/testRGroupDecomp.cpp
+++ b/Code/GraphMol/RGroupDecomposition/testRGroupDecomp.cpp
@@ -269,10 +269,10 @@ const char *coreSmi[] = {
     "C1CCOC(Cl)CC1", "C1CC(Cl)OCCC1", "C1CCOC(I)CC1", "C1CC(I)OCCC1"};
 
 const char *coreSmiRes[] = {
-    "Core:C1CCC([*:1])N([*:2])CC1 R1:Cl[*:1].[H][*:1] R2:[H][*:2]",
-    "Core:C1CCC([*:1])N([*:2])CC1 R1:Cl[*:1].[H][*:1] R2:[H][*:2]",
-    "Core:C1CCC([*:1])N([*:2])CC1 R1:I[*:1].[H][*:1] R2:[H][*:2]",
-    "Core:C1CCC([*:1])N([*:2])CC1 R1:I[*:1].[H][*:1] R2:[H][*:2]",
+    "Core:C1CCC([*:2])N([*:1])CC1 R1:Cl[*:1].[H][*:1]",
+    "Core:C1CCC([*:2])N([*:1])CC1 R1:Cl[*:1].[H][*:1]",
+    "Core:C1CCC([*:2])N([*:1])CC1 R1:I[*:1].[H][*:1]",
+    "Core:C1CCC([*:2])N([*:1])CC1 R1:I[*:1].[H][*:1]",
     "Core:C1CCSC([*:1])CC1 R1:Cl[*:1].[H][*:1]",
     "Core:C1CCSC([*:1])CC1 R1:Cl[*:1].[H][*:1]",
     "Core:C1CCSC([*:1])CC1 R1:I[*:1].[H][*:1]",

--- a/Code/RDGeneral/types.cpp
+++ b/Code/RDGeneral/types.cpp
@@ -97,7 +97,8 @@ const std::string origNoImplicit = "origNoImplicit";
 const std::string ringMembership = "ringMembership";
 const std::string smilesSymbol = "smilesSymbol";
 const std::string atomLabel = "atomLabel";
-
+const std::string internalRgroupSmiles = "internalRgroupSmiles";
+const std::string rgroupSmiles = "rgroupSmiles";
 }  // end common_properties
 
 const double MAX_DOUBLE = std::numeric_limits<double>::max();

--- a/Code/RDGeneral/types.cpp
+++ b/Code/RDGeneral/types.cpp
@@ -98,7 +98,6 @@ const std::string ringMembership = "ringMembership";
 const std::string smilesSymbol = "smilesSymbol";
 const std::string atomLabel = "atomLabel";
 const std::string internalRgroupSmiles = "internalRgroupSmiles";
-const std::string rgroupSmiles = "rgroupSmiles";
 }  // end common_properties
 
 const double MAX_DOUBLE = std::numeric_limits<double>::max();

--- a/Code/RDGeneral/types.h
+++ b/Code/RDGeneral/types.h
@@ -164,7 +164,6 @@ extern const std::string DistanceMatrix_Paths; // boost::shared_array<double>
                                                //  - note, confusing creation of names in
                                                //  - getDistanceMat
 extern const std::string internalRgroupSmiles;
-extern const std::string rgroupSmiles;
 
 }  // end common_properties
 #ifndef WIN32

--- a/Code/RDGeneral/types.h
+++ b/Code/RDGeneral/types.h
@@ -163,6 +163,8 @@ extern const std::string Discrims; // FragCatalog Entry
 extern const std::string DistanceMatrix_Paths; // boost::shared_array<double>
                                                //  - note, confusing creation of names in
                                                //  - getDistanceMat
+extern const std::string internalRgroupSmiles;
+extern const std::string rgroupSmiles;
 
 }  // end common_properties
 #ifndef WIN32


### PR DESCRIPTION
Adds free function API and python interface.

This also fixes a subtle but serious bug in the RGroupDecomp.  The RGroupMatch data should have been stored as a shared pointer as early copies were not maintained properly between iterations.  The multicore results from the cpp tests were returning hydrogens that should have been stripped out.  This fixes that issue and assigns the rgroups indices properly (previously, the first four had incorrect assignments).

If this is acceptable, the docstrings are the last item necessary.