### PR TITLE
handle the heavy-atom degree queries differently

### DIFF
--- a/Code/GraphMol/AdjustQuery.cpp
+++ b/Code/GraphMol/AdjustQuery.cpp
@@ -78,7 +78,7 @@ void adjustQueryProperties(RWMol &mol, const AdjustQueryParameters *inParams) {
             ringInfo->numBondRings(i))) {
         QueryBond *qb = new QueryBond();
         qb->setQuery(makeBondNullQuery());
-        const bool preserveProps = true;        
+        const bool preserveProps = true;
         mol.replaceBond(i, qb, preserveProps);
         delete qb;
       }
@@ -109,7 +109,7 @@ void adjustQueryProperties(RWMol &mol, const AdjustQueryParameters *inParams) {
       QueryAtom *qa;
       if (!at->hasQuery()) {
         qa = new QueryAtom(*at);
-        const bool updateLabel = false;        
+        const bool updateLabel = false;
         const bool preserveProps = true;
         mol.replaceAtom(i, qa, updateLabel, preserveProps);
         delete qa;
@@ -118,24 +118,43 @@ void adjustQueryProperties(RWMol &mol, const AdjustQueryParameters *inParams) {
       } else {
         qa = static_cast<QueryAtom *>(at);
       }
-      if (params.adjustDegree == 2) {
-        ATOM_EQUALS_QUERY *tmp = new ATOM_EQUALS_QUERY;
-        tmp->setVal(qa->getTotalDegree() - qa->getTotalNumHs(true));
-        tmp->setDataFunc(queryAtomHeavyAtomDegree);
-        tmp->setDescription("queryAtomHeavyDegree");
-        qa->expandQuery(tmp);
-      } else {
-        qa->expandQuery(makeAtomExplicitDegreeQuery(qa->getDegree()));
-      }
+      qa->expandQuery(makeAtomExplicitDegreeQuery(qa->getDegree()));
     }  // end of adjust degree
+    if (params.adjustHeavyDegree &&
+        !((params.adjustHeavyDegreeFlags & ADJUST_IGNORECHAINS) && !nRings) &&
+        !((params.adjustHeavyDegreeFlags & ADJUST_IGNORERINGS) && nRings) &&
+        !((params.adjustHeavyDegreeFlags & ADJUST_IGNOREDUMMIES) &&
+          !atomicNum) &&
+        !((params.adjustHeavyDegreeFlags & ADJUST_IGNORENONDUMMIES) &&
+          atomicNum) &&
+        !((params.adjustHeavyDegreeFlags & ADJUST_IGNOREMAPPED) &&
+          isMapped(at))) {
+      QueryAtom *qa;
+      if (!at->hasQuery()) {
+        qa = new QueryAtom(*at);
+        const bool updateLabel = false;
+        const bool preserveProps = true;
+        mol.replaceAtom(i, qa, updateLabel, preserveProps);
+        delete qa;
+        qa = static_cast<QueryAtom *>(mol.getAtomWithIdx(i));
+        at = static_cast<Atom *>(qa);
+      } else {
+        qa = static_cast<QueryAtom *>(at);
+      }
+      ATOM_EQUALS_QUERY *tmp = new ATOM_EQUALS_QUERY;
+      tmp->setVal(qa->getTotalDegree() - qa->getTotalNumHs(true));
+      tmp->setDataFunc(queryAtomHeavyAtomDegree);
+      tmp->setDescription("queryAtomHeavyDegree");
+      qa->expandQuery(tmp);
+    }  // end of adjust heavy degree
     if (params.adjustRingCount &&
         !((params.adjustRingCountFlags & ADJUST_IGNORECHAINS) && !nRings) &&
         !((params.adjustRingCountFlags & ADJUST_IGNORERINGS) && nRings) &&
         !((params.adjustRingCountFlags & ADJUST_IGNOREDUMMIES) && !atomicNum) &&
         !((params.adjustRingCountFlags & ADJUST_IGNORENONDUMMIES) &&
-          !((params.adjustRingCountFlags & ADJUST_IGNOREMAPPED) &&
-            isMapped(at)) &&
-          atomicNum)) {
+          atomicNum) &&
+        !((params.adjustRingCountFlags & ADJUST_IGNOREMAPPED) &&
+          isMapped(at))) {
       QueryAtom *qa;
       if (!at->hasQuery()) {
         qa = new QueryAtom(*at);

--- a/Code/GraphMol/AdjustQuery.cpp
+++ b/Code/GraphMol/AdjustQuery.cpp
@@ -1,5 +1,5 @@
 //
-//  Copyright (c) 2015 Greg Landrum
+//  Copyright (c) 2015-2017 Greg Landrum
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -141,11 +141,8 @@ void adjustQueryProperties(RWMol &mol, const AdjustQueryParameters *inParams) {
       } else {
         qa = static_cast<QueryAtom *>(at);
       }
-      ATOM_EQUALS_QUERY *tmp = new ATOM_EQUALS_QUERY;
-      tmp->setVal(qa->getTotalDegree() - qa->getTotalNumHs(true));
-      tmp->setDataFunc(queryAtomHeavyAtomDegree);
-      tmp->setDescription("queryAtomHeavyDegree");
-      qa->expandQuery(tmp);
+      qa->expandQuery(makeAtomHeavyAtomDegreeQuery(qa->getTotalDegree() -
+                                                   qa->getTotalNumHs(true)));
     }  // end of adjust heavy degree
     if (params.adjustRingCount &&
         !((params.adjustRingCountFlags & ADJUST_IGNORECHAINS) && !nRings) &&

--- a/Code/GraphMol/MolOps.h
+++ b/Code/GraphMol/MolOps.h
@@ -253,14 +253,8 @@ typedef enum {
   ADJUST_IGNOREALL = 0xFFFFFFF
 } AdjustQueryWhichFlags;
 
-namespace AdjustDegree {
-const unsigned int NoAdjust = 0;
-const unsigned int TotalDegree = 1;
-const unsigned int HeavyDegree = 2;
-}
-
 struct AdjustQueryParameters {
-  int adjustDegree; /**< add degree queries 1/true == all 2 == heavy*/
+  bool adjustDegree; /**< add degree queries */
   boost::uint32_t adjustDegreeFlags;
   bool adjustRingCount; /**< add ring-count queries */
   boost::uint32_t adjustRingCountFlags;
@@ -272,9 +266,12 @@ struct AdjustQueryParameters {
   boost::uint32_t makeBondsGenericFlags;
   bool makeAtomsGeneric; /**< convert atoms to generic queries (any atoms) */
   boost::uint32_t makeAtomsGenericFlags;
+  bool adjustHeavyDegree; /**< adjust the heavy-atom degree instead of overall
+                             degree */
+  boost::uint32_t adjustHeavyDegreeFlags;
 
   AdjustQueryParameters()
-      : adjustDegree(AdjustDegree::TotalDegree),
+      : adjustDegree(true),
         adjustDegreeFlags(ADJUST_IGNOREDUMMIES | ADJUST_IGNORECHAINS),
         adjustRingCount(false),
         adjustRingCountFlags(ADJUST_IGNOREDUMMIES | ADJUST_IGNORECHAINS),
@@ -283,7 +280,9 @@ struct AdjustQueryParameters {
         makeBondsGeneric(false),
         makeBondsGenericFlags(ADJUST_IGNORENONE),
         makeAtomsGeneric(false),
-        makeAtomsGenericFlags(ADJUST_IGNORENONE) {}
+        makeAtomsGenericFlags(ADJUST_IGNORENONE),
+        adjustHeavyDegree(false),
+        adjustHeavyDegreeFlags(ADJUST_IGNOREDUMMIES | ADJUST_IGNORECHAINS) {}
 };
 //! returns a copy of a molecule with query properties adjusted
 /*!

--- a/Code/GraphMol/MolPickler.cpp
+++ b/Code/GraphMol/MolPickler.cpp
@@ -1,6 +1,5 @@
-// $Id$
 //
-//  Copyright (C) 2001-2013 Greg Landrum and Rational Discovery LLC
+//  Copyright (C) 2001-2017 Greg Landrum and Rational Discovery LLC
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -70,7 +69,7 @@ void propmutex_create() {
   boost::mutex::scoped_lock test_lock(mutex);
 }
 
-boost::mutex& GetPropMutex() {
+boost::mutex &GetPropMutex() {
 #ifdef BOOST_THREAD_PROVIDES_ONCE_CXX11
   static boost::once_flag flag;
 #else
@@ -91,12 +90,11 @@ unsigned int MolPickler::getDefaultPickleProperties() {
 }
 
 void MolPickler::setDefaultPickleProperties(unsigned int props) {
-#ifdef RDK_THREADSAFE_SSS  
+#ifdef RDK_THREADSAFE_SSS
   boost::mutex::scoped_lock lock(GetPropMutex());
 #endif
   defaultProperties = props;
 }
-
 
 namespace {
 using namespace Queries;
@@ -246,6 +244,8 @@ void finalizeQueryFromDescription(Query<int, Atom const *, true> *query,
     query->setDataFunc(queryAtomExplicitDegree);
   } else if (descr == "AtomTotalDegree") {
     query->setDataFunc(queryAtomTotalDegree);
+  } else if (descr == "AtomHeavyAtomDegree") {
+    query->setDataFunc(queryAtomHeavyAtomDegree);
   } else if (descr == "AtomHCount") {
     query->setDataFunc(queryAtomHCount);
   } else if (descr == "AtomImplicitHCount") {
@@ -753,11 +753,11 @@ void MolPickler::molFromPickle(std::istream &ss, ROMol *mol) {
   streamRead(ss, patchVersion);
   if (majorVersion > versionMajor ||
       (majorVersion == versionMajor && minorVersion > versionMinor)) {
-    BOOST_LOG(rdWarningLog) << "Depickling from a version number ("
-                            << majorVersion << "." << minorVersion << ")"
-                            << "that is higher than our version ("
-                            << versionMajor << "." << versionMinor
-                            << ").\nThis probably won't work." << std::endl;
+    BOOST_LOG(rdWarningLog)
+        << "Depickling from a version number (" << majorVersion << "."
+        << minorVersion << ")"
+        << "that is higher than our version (" << versionMajor << "."
+        << versionMinor << ").\nThis probably won't work." << std::endl;
   }
   majorVersion = 1000 * majorVersion + minorVersion * 10 + patchVersion;
   if (majorVersion == 1) {

--- a/Code/GraphMol/QueryOps.cpp
+++ b/Code/GraphMol/QueryOps.cpp
@@ -234,6 +234,13 @@ ATOM_EQUALS_QUERY *makeAtomTotalDegreeQuery(int what) {
   return res;
 }
 
+ATOM_EQUALS_QUERY *makeAtomHeavyAtomDegreeQuery(int what) {
+  ATOM_EQUALS_QUERY *res =
+      makeAtomSimpleQuery<ATOM_EQUALS_QUERY>(what, queryAtomHeavyAtomDegree);
+  res->setDescription("AtomHeavyAtomDegree");
+  return res;
+}
+
 ATOM_EQUALS_QUERY *makeAtomHCountQuery(int what) {
   ATOM_EQUALS_QUERY *res =
       makeAtomSimpleQuery<ATOM_EQUALS_QUERY>(what, queryAtomHCount);
@@ -332,12 +339,14 @@ ATOM_EQUALS_QUERY *makeAtomInRingQuery() {
 
 ATOM_OR_QUERY *makeQAtomQuery() {
   ATOM_OR_QUERY *res = new ATOM_OR_QUERY;
-  res->setDescription("AtomOr"); // FIX: we really should label this more descriptively so that it can be output more cleanly
+  res->setDescription("AtomOr");  // FIX: we really should label this more
+                                  // descriptively so that it can be output more
+                                  // cleanly
   res->setNegation(true);
   res->addChild(
-    Queries::Query<int, Atom const *, true>::CHILD_TYPE(makeAtomNumQuery(6)));
+      Queries::Query<int, Atom const *, true>::CHILD_TYPE(makeAtomNumQuery(6)));
   res->addChild(
-    Queries::Query<int, Atom const *, true>::CHILD_TYPE(makeAtomNumQuery(1)));
+      Queries::Query<int, Atom const *, true>::CHILD_TYPE(makeAtomNumQuery(1)));
   return res;
 }
 ATOM_EQUALS_QUERY *makeQHAtomQuery() {
@@ -359,85 +368,86 @@ ATOM_OR_QUERY *makeXAtomQuery() {
   ATOM_OR_QUERY *res = new ATOM_OR_QUERY;
   res->setDescription("AtomOr");
   res->addChild(
-    Queries::Query<int, Atom const *, true>::CHILD_TYPE(makeAtomNumQuery(9)));
-  res->addChild(
-    Queries::Query<int, Atom const *, true>::CHILD_TYPE(makeAtomNumQuery(17)));
-  res->addChild(
-    Queries::Query<int, Atom const *, true>::CHILD_TYPE(makeAtomNumQuery(35)));
-  res->addChild(
-    Queries::Query<int, Atom const *, true>::CHILD_TYPE(makeAtomNumQuery(53)));
-  res->addChild(
-    Queries::Query<int, Atom const *, true>::CHILD_TYPE(makeAtomNumQuery(85)));
+      Queries::Query<int, Atom const *, true>::CHILD_TYPE(makeAtomNumQuery(9)));
+  res->addChild(Queries::Query<int, Atom const *, true>::CHILD_TYPE(
+      makeAtomNumQuery(17)));
+  res->addChild(Queries::Query<int, Atom const *, true>::CHILD_TYPE(
+      makeAtomNumQuery(35)));
+  res->addChild(Queries::Query<int, Atom const *, true>::CHILD_TYPE(
+      makeAtomNumQuery(53)));
+  res->addChild(Queries::Query<int, Atom const *, true>::CHILD_TYPE(
+      makeAtomNumQuery(85)));
   return res;
 }
 ATOM_OR_QUERY *makeXHAtomQuery() {
   ATOM_OR_QUERY *res = makeXAtomQuery();
   res->addChild(
-    Queries::Query<int, Atom const *, true>::CHILD_TYPE(makeAtomNumQuery(1)));
+      Queries::Query<int, Atom const *, true>::CHILD_TYPE(makeAtomNumQuery(1)));
   return res;
 }
 
 ATOM_OR_QUERY *makeMAtomQuery() {
-  // using the definition from Marvin Sketch, which produces the following SMARTS:
+  // using the definition from Marvin Sketch, which produces the following
+  // SMARTS:
   // !#1!#2!#5!#6!#7!#8!#9!#10!#14!#15!#16!#17!#18!#33!#34!#35!#36!#52!#53!#54!#85!#86
   // it's easier to define what isn't a metal than what is. :-)
   ATOM_OR_QUERY *res = makeMHAtomQuery();
   res->addChild(
-    Queries::Query<int, Atom const *, true>::CHILD_TYPE(makeAtomNumQuery(1)));
+      Queries::Query<int, Atom const *, true>::CHILD_TYPE(makeAtomNumQuery(1)));
   return res;
 }
 ATOM_OR_QUERY *makeMHAtomQuery() {
-  // using the definition from Marvin Sketch, which produces the following SMARTS:
+  // using the definition from Marvin Sketch, which produces the following
+  // SMARTS:
   // !#2!#5!#6!#7!#8!#9!#10!#14!#15!#16!#17!#18!#33!#34!#35!#36!#52!#53!#54!#85!#86
   // it's easier to define what isn't a metal than what is. :-)
   ATOM_OR_QUERY *res = new ATOM_OR_QUERY;
   res->setDescription("AtomOr");
   res->setNegation(true);
   res->addChild(
-    Queries::Query<int, Atom const *, true>::CHILD_TYPE(makeAtomNumQuery(2)));
+      Queries::Query<int, Atom const *, true>::CHILD_TYPE(makeAtomNumQuery(2)));
   res->addChild(
-    Queries::Query<int, Atom const *, true>::CHILD_TYPE(makeAtomNumQuery(5)));
+      Queries::Query<int, Atom const *, true>::CHILD_TYPE(makeAtomNumQuery(5)));
   res->addChild(
-    Queries::Query<int, Atom const *, true>::CHILD_TYPE(makeAtomNumQuery(6)));
+      Queries::Query<int, Atom const *, true>::CHILD_TYPE(makeAtomNumQuery(6)));
   res->addChild(
-    Queries::Query<int, Atom const *, true>::CHILD_TYPE(makeAtomNumQuery(7)));
+      Queries::Query<int, Atom const *, true>::CHILD_TYPE(makeAtomNumQuery(7)));
   res->addChild(
-    Queries::Query<int, Atom const *, true>::CHILD_TYPE(makeAtomNumQuery(8)));
+      Queries::Query<int, Atom const *, true>::CHILD_TYPE(makeAtomNumQuery(8)));
   res->addChild(
-    Queries::Query<int, Atom const *, true>::CHILD_TYPE(makeAtomNumQuery(9)));
-  res->addChild(
-    Queries::Query<int, Atom const *, true>::CHILD_TYPE(makeAtomNumQuery(10)));
-  res->addChild(
-    Queries::Query<int, Atom const *, true>::CHILD_TYPE(makeAtomNumQuery(14)));
-  res->addChild(
-    Queries::Query<int, Atom const *, true>::CHILD_TYPE(makeAtomNumQuery(15)));
-  res->addChild(
-    Queries::Query<int, Atom const *, true>::CHILD_TYPE(makeAtomNumQuery(16)));
-  res->addChild(
-    Queries::Query<int, Atom const *, true>::CHILD_TYPE(makeAtomNumQuery(17)));
-  res->addChild(
-    Queries::Query<int, Atom const *, true>::CHILD_TYPE(makeAtomNumQuery(18)));
-  res->addChild(
-    Queries::Query<int, Atom const *, true>::CHILD_TYPE(makeAtomNumQuery(33)));
-  res->addChild(
-    Queries::Query<int, Atom const *, true>::CHILD_TYPE(makeAtomNumQuery(34)));
-  res->addChild(
-    Queries::Query<int, Atom const *, true>::CHILD_TYPE(makeAtomNumQuery(35)));
-  res->addChild(
-    Queries::Query<int, Atom const *, true>::CHILD_TYPE(makeAtomNumQuery(36)));
-  res->addChild(
-    Queries::Query<int, Atom const *, true>::CHILD_TYPE(makeAtomNumQuery(52)));
-  res->addChild(
-    Queries::Query<int, Atom const *, true>::CHILD_TYPE(makeAtomNumQuery(53)));
-  res->addChild(
-    Queries::Query<int, Atom const *, true>::CHILD_TYPE(makeAtomNumQuery(54)));
-  res->addChild(
-    Queries::Query<int, Atom const *, true>::CHILD_TYPE(makeAtomNumQuery(85)));
-  res->addChild(
-    Queries::Query<int, Atom const *, true>::CHILD_TYPE(makeAtomNumQuery(86)));
+      Queries::Query<int, Atom const *, true>::CHILD_TYPE(makeAtomNumQuery(9)));
+  res->addChild(Queries::Query<int, Atom const *, true>::CHILD_TYPE(
+      makeAtomNumQuery(10)));
+  res->addChild(Queries::Query<int, Atom const *, true>::CHILD_TYPE(
+      makeAtomNumQuery(14)));
+  res->addChild(Queries::Query<int, Atom const *, true>::CHILD_TYPE(
+      makeAtomNumQuery(15)));
+  res->addChild(Queries::Query<int, Atom const *, true>::CHILD_TYPE(
+      makeAtomNumQuery(16)));
+  res->addChild(Queries::Query<int, Atom const *, true>::CHILD_TYPE(
+      makeAtomNumQuery(17)));
+  res->addChild(Queries::Query<int, Atom const *, true>::CHILD_TYPE(
+      makeAtomNumQuery(18)));
+  res->addChild(Queries::Query<int, Atom const *, true>::CHILD_TYPE(
+      makeAtomNumQuery(33)));
+  res->addChild(Queries::Query<int, Atom const *, true>::CHILD_TYPE(
+      makeAtomNumQuery(34)));
+  res->addChild(Queries::Query<int, Atom const *, true>::CHILD_TYPE(
+      makeAtomNumQuery(35)));
+  res->addChild(Queries::Query<int, Atom const *, true>::CHILD_TYPE(
+      makeAtomNumQuery(36)));
+  res->addChild(Queries::Query<int, Atom const *, true>::CHILD_TYPE(
+      makeAtomNumQuery(52)));
+  res->addChild(Queries::Query<int, Atom const *, true>::CHILD_TYPE(
+      makeAtomNumQuery(53)));
+  res->addChild(Queries::Query<int, Atom const *, true>::CHILD_TYPE(
+      makeAtomNumQuery(54)));
+  res->addChild(Queries::Query<int, Atom const *, true>::CHILD_TYPE(
+      makeAtomNumQuery(85)));
+  res->addChild(Queries::Query<int, Atom const *, true>::CHILD_TYPE(
+      makeAtomNumQuery(86)));
   return res;
 }
-
 
 ATOM_EQUALS_QUERY *makeAtomInNRingsQuery(int what) {
   ATOM_EQUALS_QUERY *res;
@@ -448,11 +458,10 @@ ATOM_EQUALS_QUERY *makeAtomInNRingsQuery(int what) {
 
 ATOM_EQUALS_QUERY *makeAtomHasRingBondQuery() {
   ATOM_EQUALS_QUERY *res =
-    makeAtomSimpleQuery<ATOM_EQUALS_QUERY>(true, queryAtomHasRingBond);
+      makeAtomSimpleQuery<ATOM_EQUALS_QUERY>(true, queryAtomHasRingBond);
   res->setDescription("AtomHasRingBond");
   return res;
 }
-
 
 BOND_EQUALS_QUERY *makeBondOrderEqualsQuery(Bond::BondType what) {
   BOND_EQUALS_QUERY *res = new BOND_EQUALS_QUERY;

--- a/Code/GraphMol/QueryOps.h
+++ b/Code/GraphMol/QueryOps.h
@@ -269,6 +269,14 @@ T *makeAtomTotalDegreeQuery(int what, const std::string &descr) {
 //! \overload
 ATOM_EQUALS_QUERY *makeAtomTotalDegreeQuery(int what);
 
+//! returns a Query for matching heavy atom degree
+template <class T>
+T *makeAtomHeavyAtomDegreeQuery(int what, const std::string &descr) {
+  return makeAtomSimpleQuery<T>(what, queryAtomHeavyAtomDegree, descr);
+}
+//! \overload
+ATOM_EQUALS_QUERY *makeAtomHeavyAtomDegreeQuery(int what);
+
 //! returns a Query for matching hydrogen count
 template <class T>
 T *makeAtomHCountQuery(int what, const std::string &descr) {

--- a/Code/GraphMol/RGroupDecomposition/RGroupDecomp.cpp
+++ b/Code/GraphMol/RGroupDecomposition/RGroupDecomp.cpp
@@ -167,15 +167,15 @@ bool RGroupDecompositionParameters::prepareCore(RWMol &core,
 
   MolOps::AdjustQueryParameters adjustParams;
   adjustParams.makeDummiesQueries = true;
-  adjustParams.adjustDegree = onlyMatchAtRGroups
-                                  ? MolOps::AdjustDegree::HeavyDegree
-                                  : MolOps::AdjustDegree::NoAdjust;
+  adjustParams.adjustDegree = false;
+  adjustParams.adjustHeavyDegree = onlyMatchAtRGroups;
+  // if (onlyMatchAtRGroups)
+  //   adjustParams.adjustDegreeFlags |= MolOps::ADJUST_IGNOREHS;
   adjustQueryProperties(core, &adjustParams);
 
   for (std::map<int, int>::iterator it = atomToLabel.begin();
        it != atomToLabel.end(); ++it)
     core.getAtomWithIdx(it->first)->setProp(RLABEL, it->second);
-
   return true;
 }
 
@@ -920,8 +920,8 @@ int RGroupDecomposition::add(const ROMol &inmol) {
     }
   }
   if (potentialMatches.size() == 0) {
-    BOOST_LOG(rdWarningLog) << "No attachment points in side chains"
-                            << std::endl;
+    BOOST_LOG(rdWarningLog)
+        << "No attachment points in side chains" << std::endl;
 
     return -1;
   }

--- a/Code/GraphMol/RGroupDecomposition/testRGroupDecomp.cpp
+++ b/Code/GraphMol/RGroupDecomposition/testRGroupDecomp.cpp
@@ -128,6 +128,7 @@ void testRGroupOnlyMatching() {
     ROMol *mol = SmilesToMol(matchRGroupOnlyData[i]);
     int res = decomp.add(*mol);
     if (i < 4) {
+      std::cerr << i << " " << res << std::endl;
       TEST_ASSERT(res == i);
     } else {
       TEST_ASSERT(res == -1);

--- a/Code/GraphMol/Wrap/MolOps.cpp
+++ b/Code/GraphMol/Wrap/MolOps.cpp
@@ -950,7 +950,7 @@ struct molops_wrapper {
     - The original molecule is *not* modified.\n\
 \n";
     python::def("RemoveHs",
-                (ROMol * (*)(const ROMol &, bool, bool, bool))MolOps::removeHs,
+                (ROMol * (*)(const ROMol &, bool, bool, bool)) MolOps::removeHs,
                 (python::arg("mol"), python::arg("implicitOnly") = false,
                  python::arg("updateExplicitCount") = false,
                  python::arg("sanitize") = true),
@@ -1962,7 +1962,7 @@ EXAMPLES:\n\
 \n\
 \n";
     python::def("ReplaceCore", (ROMol * (*)(const ROMol &, const ROMol &, bool,
-                                            bool, bool, bool))replaceCore,
+                                            bool, bool, bool)) replaceCore,
                 (python::arg("mol"), python::arg("coreQuery"),
                  python::arg("replaceDummies") = true,
                  python::arg("labelByIndex") = false,
@@ -2081,6 +2081,8 @@ EXAMPLES:\n\
 Attributes:\n\
   - adjustDegree: \n\
       modified atoms have an explicit-degree query added based on their degree in the query \n\
+  - adjustHeavyDegree: \n\
+      modified atoms have a heavy-atom-degree query added based on their degree in the query \n\
   - adjustDegreeFlags: \n\
       controls which atoms have a degree query added \n\
   - adjustRingCount: \n\
@@ -2113,6 +2115,10 @@ A note on the flags controlling which atoms/bonds are modified: \n\
                        &MolOps::AdjustQueryParameters::adjustDegree)
         .def_readwrite("adjustDegreeFlags",
                        &MolOps::AdjustQueryParameters::adjustDegreeFlags)
+        .def_readwrite("adjustHeavyDegree",
+                       &MolOps::AdjustQueryParameters::adjustHeavyDegree)
+        .def_readwrite("adjustHeavyDegreeFlags",
+                       &MolOps::AdjustQueryParameters::adjustHeavyDegreeFlags)
         .def_readwrite("adjustRingCount",
                        &MolOps::AdjustQueryParameters::adjustRingCount)
         .def_readwrite("adjustRingCountFlags",

--- a/Code/GraphMol/molopstest.cpp
+++ b/Code/GraphMol/molopstest.cpp
@@ -5785,6 +5785,38 @@ void testAdjustQueryProperties() {
     delete qm;
   }
 
+  {  // heavy atom degree
+    std::string smiles = "C1CC(*)C1*";
+    ROMol *qm = SmartsToMol(smiles);
+    TEST_ASSERT(qm);
+    TEST_ASSERT(qm->getNumAtoms() == 6);
+    MolOps::AdjustQueryParameters params;
+    params.adjustDegree = false;
+    params.adjustHeavyDegree = true;
+    ROMol *aqm = MolOps::adjustQueryProperties(*qm, &params);
+    TEST_ASSERT(aqm);
+    TEST_ASSERT(aqm->getNumAtoms() == 6);
+    {
+      smiles = "C1CC(C)C1(C)";
+      ROMol *m = SmilesToMol(smiles);
+      TEST_ASSERT(m);
+      MatchVectType match;
+      TEST_ASSERT(SubstructMatch(*m, *qm, match));
+      TEST_ASSERT(SubstructMatch(*m, *aqm, match));
+      delete m;
+    }
+    {
+      smiles = "C1CC([2H])C1(C)";
+      ROMol *m = SmilesToMol(smiles);
+      TEST_ASSERT(m);
+      MatchVectType match;
+      TEST_ASSERT(SubstructMatch(*m, *qm, match));
+      TEST_ASSERT(!SubstructMatch(*m, *aqm, match));
+      delete m;
+    }
+    delete qm;
+    delete aqm;
+  }
   BOOST_LOG(rdInfoLog) << "Finished" << std::endl;
 }
 
@@ -6618,11 +6650,15 @@ void testGithubIssue908() {
                        << std::endl;
   {
     std::string mb =
-        "\n     RDKit          2D\n\n  4  3  0  0  0  0  0  0  0  0999 V2000\n "
+        "\n     RDKit          2D\n\n  4  3  0  0  0  0  0  0  0  0999 "
+        "V2000\n "
         "  -0.0000   -1.5000    0.0000 Br  0  0  0  0  0  0  0  0  0  0  0  "
-        "0\n   -0.0000   -0.0000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0 "
-        " 0\n    1.2990    0.7500    0.0000 F   0  0  0  0  0  0  0  0  0  0  "
-        "0  0\n   -1.2990    0.7500    0.0000 Cl  0  0  0  0  0  0  0  0  0  0 "
+        "0\n   -0.0000   -0.0000    0.0000 C   0  0  0  0  0  0  0  0  0  0  "
+        "0 "
+        " 0\n    1.2990    0.7500    0.0000 F   0  0  0  0  0  0  0  0  0  0 "
+        " "
+        "0  0\n   -1.2990    0.7500    0.0000 Cl  0  0  0  0  0  0  0  0  0  "
+        "0 "
         " 0  0\n  2  1  1  1\n  2  3  1  0\n  2  4  1  0\nM  END\n";
     RWMol *m = MolBlockToMol(mb);
     TEST_ASSERT(m);

--- a/Code/GraphMol/testPickler.cpp
+++ b/Code/GraphMol/testPickler.cpp
@@ -1,6 +1,5 @@
-// $Id$
 //
-//  Copyright (C) 2004-2011 Greg Landrum and Rational Discovery LLC
+//  Copyright (C) 2004-2017 Greg Landrum and Rational Discovery LLC
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -833,7 +832,7 @@ void testIssue3496759() {
       if (inl[0] == '#' || inl.size() < 2) continue;
       std::vector<std::string> tokens;
       boost::split(tokens, inl, boost::is_any_of(" \t"));
-      // std::cerr<<"smarts: "<<tokens[0]<<std::endl;
+      // std::cerr << "smarts: " << tokens[0] << std::endl;
       ROMol *m1 = SmartsToMol(tokens[0]);
       TEST_ASSERT(m1);
       std::string smi1 = MolToSmiles(*m1, 1);
@@ -947,8 +946,8 @@ void testAtomResidues() {
     m->addAtom(new Atom(6));
     m->addBond(2, 3, Bond::SINGLE);
 
-    m->getAtomWithIdx(0)
-        ->setMonomerInfo(new AtomMonomerInfo(AtomMonomerInfo::OTHER, "m1"));
+    m->getAtomWithIdx(0)->setMonomerInfo(
+        new AtomMonomerInfo(AtomMonomerInfo::OTHER, "m1"));
     m->getAtomWithIdx(1)->setMonomerInfo(new AtomPDBResidueInfo("Ca", 3));
     MolOps::sanitizeMol(*m);
 
@@ -1017,14 +1016,13 @@ void testGithub713() {
 
 void testPickleProps() {
   BOOST_LOG(rdInfoLog) << "-----------------------\n";
-  BOOST_LOG(rdInfoLog) << "Testing pickling of properties"
-                       << std::endl;
+  BOOST_LOG(rdInfoLog) << "Testing pickling of properties" << std::endl;
 
   std::vector<double> v;
   v.push_back(1234.);
   v.push_back(444.);
   v.push_back(1123.);
-  
+
   ROMol *m = SmilesToMol("CC");
   m->setProp("double", 1.0);
   m->setProp("int", 100);
@@ -1039,7 +1037,7 @@ void testPickleProps() {
   a->setProp("boolfalse", false);
   a->setProp("dvec", v);
   a->setProp("_private", true);
-  
+
   Bond *b = m->getBondWithIdx(0);
   b->setProp("double", 1.0);
   b->setProp("int", 100);
@@ -1047,7 +1045,7 @@ void testPickleProps() {
   b->setProp("boolfalse", false);
   b->setProp("dvec", v);
   b->setProp("_private", true);
-  
+
   std::string pkl;
   {
     MolPickler::pickleMol(*m, pkl, PicklerOps::AllProps);
@@ -1126,7 +1124,8 @@ void testPickleProps() {
   }
 
   {
-    MolPickler::pickleMol(*m, pkl, PicklerOps::AtomProps | PicklerOps::PrivateProps);
+    MolPickler::pickleMol(*m, pkl,
+                          PicklerOps::AtomProps | PicklerOps::PrivateProps);
     RWMol *m2 = new RWMol(pkl);
     TEST_ASSERT(m2);
     TEST_ASSERT(!m2->hasProp("double"));
@@ -1150,7 +1149,7 @@ void testPickleProps() {
 
     delete m2;
   }
-  
+
   {
     MolPickler::pickleMol(*m, pkl, PicklerOps::BondProps);
     RWMol *m2 = new RWMol(pkl);
@@ -1166,7 +1165,7 @@ void testPickleProps() {
     TEST_ASSERT(!a->hasProp("bool"));
     TEST_ASSERT(!a->hasProp("boolfalse"));
     TEST_ASSERT(!a->hasProp("_private"));
-    
+
     b = m2->getBondWithIdx(0);
     TEST_ASSERT(b->getProp<double>("double") == 1.0);
     TEST_ASSERT(b->getProp<int>("int") == 100);
@@ -1177,7 +1176,8 @@ void testPickleProps() {
   }
 
   {
-    MolPickler::pickleMol(*m, pkl, PicklerOps::BondProps | PicklerOps::PrivateProps);
+    MolPickler::pickleMol(*m, pkl,
+                          PicklerOps::BondProps | PicklerOps::PrivateProps);
     RWMol *m2 = new RWMol(pkl);
     TEST_ASSERT(m2);
     TEST_ASSERT(!m2->hasProp("double"));
@@ -1200,12 +1200,32 @@ void testPickleProps() {
     TEST_ASSERT(b->getProp<bool>("_private") == true);
     delete m2;
   }
-  
+
   delete m;
-  
+
   BOOST_LOG(rdErrorLog) << "\tdone" << std::endl;
 }
 
+void testGithub1563() {
+  BOOST_LOG(rdInfoLog) << "-----------------------\n";
+  BOOST_LOG(rdInfoLog)
+      << "Testing Github 1563: Add a canned Atom query for heavy atom degree"
+      << std::endl;
+
+  RWMol m;
+  QueryAtom *qa = new QueryAtom();
+  qa->setQuery(makeAtomHeavyAtomDegreeQuery(3));
+  m.addAtom(qa);
+  TEST_ASSERT(m.getAtomWithIdx(0)->hasQuery());
+  TEST_ASSERT(m.getAtomWithIdx(0)->getQuery()->getDescription() ==
+              "AtomHeavyAtomDegree");
+  RWMol nm(m);
+  TEST_ASSERT(nm.getAtomWithIdx(0)->hasQuery());
+  TEST_ASSERT(nm.getAtomWithIdx(0)->getQuery()->getDescription() ==
+              "AtomHeavyAtomDegree");
+
+  BOOST_LOG(rdErrorLog) << "\tdone" << std::endl;
+}
 
 int main(int argc, char *argv[]) {
   RDLog::InitLogs();
@@ -1239,5 +1259,5 @@ int main(int argc, char *argv[]) {
   testAtomResidues();
   testGithub149();
   testGithub713();
-
+  testGithub1563();
 }

--- a/Code/PgSQL/rdkit/adapter.cpp
+++ b/Code/PgSQL/rdkit/adapter.cpp
@@ -646,6 +646,7 @@ void parseAdjustQueryParameters(MolOps::AdjustQueryParameters &p,
   boost::property_tree::ptree pt;
   boost::property_tree::read_json(ss, pt);
   p.adjustDegree = pt.get("adjustDegree", p.adjustDegree);
+  p.adjustHeavyDegree = pt.get("adjustHeavyDegree", p.adjustHeavyDegree);
   p.adjustRingCount = pt.get("adjustRingCount", p.adjustRingCount);
   p.makeDummiesQueries = pt.get("makeDummiesQueries", p.makeDummiesQueries);
   p.aromatizeIfPossible = pt.get("aromatizeIfPossible", p.aromatizeIfPossible);
@@ -654,6 +655,9 @@ void parseAdjustQueryParameters(MolOps::AdjustQueryParameters &p,
   std::string which;
   which = boost::to_upper_copy<std::string>(pt.get("adjustDegreeFlags", ""));
   if (which != "") p.adjustDegreeFlags = parseWhichString(which);
+  which =
+      boost::to_upper_copy<std::string>(pt.get("adjustHeavyDegreeFlags", ""));
+  if (which != "") p.adjustHeavyDegreeFlags = parseWhichString(which);
   which = boost::to_upper_copy<std::string>(pt.get("adjustRingCountFlags", ""));
   if (which != "") p.adjustRingCountFlags = parseWhichString(which);
   which =

--- a/Code/PgSQL/rdkit/expected/rdkit-91.out
+++ b/Code/PgSQL/rdkit/expected/rdkit-91.out
@@ -845,3 +845,21 @@ select 'C1C(C)C1CCCC'::mol @> mol_adjust_query_properties('C1CC1CC'::mol,'{"adju
 
 select 'C1C(C)C1CCCC'::mol @> mol_adjust_query_properties('C1CC1CC'::mol,'{"adjustDegreeFlags":"bogus"}');
 ERROR:  bad which string provided 'BOGUS'
+select 'C1C([2H])C1CCCC'::mol @> mol_adjust_query_properties('C1CC1CC'::mol);
+ ?column? 
+----------
+ f
+(1 row)
+
+select 'C1C([2H])C1CCCC'::mol @> mol_adjust_query_properties('C1CC1CC'::mol,'{"adjustDegree":false}');
+ ?column? 
+----------
+ t
+(1 row)
+
+select 'C1C([2H])C1CCCC'::mol @> mol_adjust_query_properties('C1CC1CC'::mol,'{"adjustDegree":false,"adjustHeavyDegree":true}');
+ ?column? 
+----------
+ t
+(1 row)
+

--- a/Code/PgSQL/rdkit/sql/rdkit-91.sql
+++ b/Code/PgSQL/rdkit/sql/rdkit-91.sql
@@ -322,3 +322,6 @@ select 'C1C(C)C1CCCC'::mol @> mol_adjust_query_properties('C1CC1CC'::mol,'{"adju
 select 'C1C(C)C1CCCC'::mol @> mol_adjust_query_properties('C1CC1CC'::mol,'{"adjustDegreeFlags":"IGNORERINGS"}');
 select 'C1C(C)C1CCCC'::mol @> mol_adjust_query_properties('C1CC1CC'::mol,'{"adjustDegreeFlags":"IGNORERINGS|IGNORECHAINS"}');
 select 'C1C(C)C1CCCC'::mol @> mol_adjust_query_properties('C1CC1CC'::mol,'{"adjustDegreeFlags":"bogus"}');
+select 'C1C([2H])C1CCCC'::mol @> mol_adjust_query_properties('C1CC1CC'::mol);
+select 'C1C([2H])C1CCCC'::mol @> mol_adjust_query_properties('C1CC1CC'::mol,'{"adjustDegree":false}');
+select 'C1C([2H])C1CCCC'::mol @> mol_adjust_query_properties('C1CC1CC'::mol,'{"adjustDegree":false,"adjustHeavyDegree":true}');


### PR DESCRIPTION
The R-group decomposition PR changed `AdjustQueryParameters::adjustDegree` from bool to int and used the value of the int to determine which type of degree query was added - normal or heavy-atom degree. This was awkward and not backwards compatible.

This PR switches `AdjustQueryParameters::adjustDegree` back to being a bool and adds the new parameter `AdjustQueryParameters::adjustHeavyDegree` to allow heavy-atom degree queries to be added.
