### PR TITLE
Added C++ version of getBestRMS()

### DIFF
--- a/Code/GraphMol/MolAlign/AlignMolecules.h
+++ b/Code/GraphMol/MolAlign/AlignMolecules.h
@@ -100,6 +100,36 @@ double alignMol(ROMol &prbMol, const ROMol &refMol, int prbCid = -1,
                 const RDNumeric::DoubleVector *weights = 0,
                 bool reflect = false, unsigned int maxIters = 50);
 
+//! Returns the optimal RMS for aligning two molecules, taking
+//  symmetry into account. As a side-effect, the probe molecule is
+//  left in the aligned state.
+/*!
+  This function will attempt to align all permutations of matching atom
+  orders in both molecules, for some molecules it will lead to 'combinatorial
+  explosion' especially if hydrogens are present.
+  Use 'RDKit::MolAlign::alignMol' to align molecules without changing the
+  atom order.
+
+  \param probeMol   the molecule to be aligned to the reference
+  \param refMol     the reference molecule
+  \param probeId    (optional) probe conformation to use
+  \param refId      (optional) reference conformation to use
+  \param map        (optional) a vector of vectors of pairs of atom IDs
+                    (probe AtomId, ref AtomId) used to compute the alignments.
+                    If not provided, these will be generated using a
+                    substructure search.
+  \param maxMatches (optional) if map is empty, this will be the max number of
+                    matches found in a SubstructMatch().
+
+  <b>Returns</b>
+  Best RMSD value found
+*/
+double getBestRMS(ROMol& probeMol, ROMol& refMol,
+                  int probeId = -1, int refId = -1,
+                  const std::vector<MatchVectType>& map =
+                    std::vector<MatchVectType>(),
+                  int maxMatches = 1e6);
+
 //! Align the conformations of a molecule using a common set of atoms. If
 // the molecules contains queries, then the queries must also match exactly.
 

--- a/Code/GraphMol/MolAlign/Wrap/testMolAlign.py
+++ b/Code/GraphMol/MolAlign/Wrap/testMolAlign.py
@@ -466,6 +466,18 @@ class TestCase(unittest.TestCase):
                                             )
       self.failUnlessEqual(len(algs), nConfs)
 
+  def test17GetBestRMS(self):
+    sdf = os.path.join(RDConfig.RDBaseDir, 'Code', 'GraphMol', 'MolAlign',
+                       'test_data', 'probe_mol.sdf')
+    molS = Chem.SDMolSupplier(sdf, True, False)
+    mol1 = molS[1]
+    mol2 = molS[2]
+
+    # AlignMol() would return this for the rms: 2.50561
+    # But the best rms is: 2.43449
+    rmsd = rdMolAlign.GetBestRMS(mol1, mol2);
+
+    self.failUnlessAlmostEqual(rmsd, 2.43449209)
 
 if __name__ == '__main__':
   print("Testing MolAlign Wrappers")

--- a/Code/GraphMol/MolAlign/testMolAlign.cpp
+++ b/Code/GraphMol/MolAlign/testMolAlign.cpp
@@ -66,6 +66,23 @@ void test1MolAlign() {
   delete m3;
 }
 
+void test1GetBestRMS() {
+  std::string rdbase = getenv("RDBASE");
+  std::string fname =
+    rdbase + "/Code/GraphMol/MolAlign/test_data/probe_mol.sdf";
+  SDMolSupplier supplier(fname, true, false);
+  ROMol *m1 = supplier[1];
+  ROMol *m2 = supplier[2];
+
+  // alignMol() would return this for the rms: 2.50561
+  // But the best rms is: 2.43449
+  double rmsd = MolAlign::getBestRMS(*m1, *m2);
+
+  TEST_ASSERT(RDKit::feq(rmsd, 2.43449));
+  delete m1;
+  delete m2;
+}
+
 void test1MolWithQueryAlign() {
   // identical to test1MolAlign except we replace one atom with a QueryAtom instead
 
@@ -88,7 +105,7 @@ void test1MolWithQueryAlign() {
 
   std::string fname3 =
       rdbase + "/Code/GraphMol/MolAlign/test_data/1oir_trans.mol";
-  
+
   RWMol *m3 = new RWMol(*MolFileToMol(fname3));
   m3->replaceAtom(0, new QueryAtom(5));
 
@@ -114,7 +131,7 @@ void test1MolWithQueryAlign() {
   // provide an atom mapping
   delete m1;
   delete m2;
-  delete m3;  
+  delete m3;
 
 }
 
@@ -883,6 +900,10 @@ int main() {
   std::cout << "\t---------------------------------\n";
   std::cout << "\t test1MolAlign \n\n";
   test1MolAlign();
+
+  std::cout << "\t---------------------------------\n";
+  std::cout << "\t test1GetBestRMS \n\n";
+  test1GetBestRMS();
 
   std::cout << "\t---------------------------------\n";
   std::cout << "\t test1MolWithQueryAlign \n\n";

--- a/rdkit/Chem/AllChem.py
+++ b/rdkit/Chem/AllChem.py
@@ -89,52 +89,6 @@ def ComputeMolVolume(mol, confId=-1, gridSpacing=0.2, boxMargin=2.0):
   vol = voxelVol * len(voxels)
   return vol
 
-
-def GetBestRMS(ref, probe, refConfId=-1, probeConfId=-1, maps=None):
-  """ Returns the optimal RMS for aligning two molecules, taking
-  symmetry into account. As a side-effect, the probe molecule is
-  left in the aligned state.
-
-  Arguments:
-    - ref: the reference molecule
-    - probe: the molecule to be aligned to the reference
-    - refConfId: (optional) reference conformation to use
-    - probeConfId: (optional) probe conformation to use
-    - maps: (optional) a list of lists of (probeAtomId,refAtomId)
-      tuples with the atom-atom mappings of the two molecules.
-      If not provided, these will be generated using a substructure
-      search.
-
-  Note:
-  This function will attempt to align all permutations of matching atom
-  orders in both molecules, for some molecules it will lead to 'combinatorial
-  explosion' especially if hydrogens are present.
-  Use 'rdkit.Chem.AllChem.AlignMol' to align molecules without changing the
-  atom order.
-
-  """
-  if not maps:
-    matches = ref.GetSubstructMatches(probe, uniquify=False)
-    if not matches:
-      raise ValueError('mol %s does not match mol %s' % (ref.GetProp('_Name'),
-                                                         probe.GetProp('_Name')))
-    if len(matches) > 1e6:
-      warnings.warn("{} matches detected for molecule {}, this may lead to a performance slowdown.".
-                    format(len(matches), probe.GetProp('_Name')))
-    maps = [list(enumerate(match)) for match in matches]
-  bestRMS = 1000.
-  for amap in maps:
-    rms = AlignMol(probe, ref, probeConfId, refConfId, atomMap=amap)
-    if rms < bestRMS:
-      bestRMS = rms
-      bestMap = amap
-
-  # finally repeate the best alignment :
-  if bestMap != amap:
-    AlignMol(probe, ref, probeConfId, refConfId, atomMap=bestMap)
-  return bestRMS
-
-
 def GetConformerRMS(mol, confId1, confId2, atomIds=None, prealigned=False):
   """ Returns the RMS between two conformations.
   By default, the conformers will be aligned to the first conformer


### PR DESCRIPTION
getBestRMS() was previously a Python-only function. This
adds a C++ version of the function.

<!--
Thanks for contributing a pull request! 
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.


#### Any other comments?

