### PR TITLE
Fixes github1567

### DIFF
--- a/Code/GraphMol/SmilesParse/SmilesWrite.cpp
+++ b/Code/GraphMol/SmilesParse/SmilesWrite.cpp
@@ -437,7 +437,7 @@ std::string MolToSmiles(const ROMol &mol, bool doIsomericSmiles, bool doKekule,
 #ifdef VERBOSE_CANON
     for (unsigned int tmpI = 0; tmpI < ranks.size(); tmpI++) {
       std::cout << tmpI << " " << ranks[tmpI] << " "
-                << *(tmol.getAtomWithIdx(tmpI)) << std::endl;
+                << *(tmol->getAtomWithIdx(tmpI)) << std::endl;
     }
 #endif
 
@@ -627,6 +627,10 @@ std::string MolFragmentToSmiles(const ROMol &mol,
   if (canonical) {
     Canon::rankFragmentAtoms(tmol, ranks, atomsInPlay, bondsInPlay, atomSymbols,
                              true, doIsomericSmiles, doIsomericSmiles);
+    // std::cerr << "RANKS: ";
+    // std::copy(ranks.begin(), ranks.end(),
+    //           std::ostream_iterator<int>(std::cerr, " "));
+    // std::cerr << std::endl;
     // MolOps::rankAtomsInFragment(tmol,ranks,atomsInPlay,bondsInPlay,atomSymbols,bondSymbols);
   } else {
     for (unsigned int i = 0; i < tmol.getNumAtoms(); ++i) ranks[i] = i;

--- a/Code/GraphMol/SmilesParse/test.cpp
+++ b/Code/GraphMol/SmilesParse/test.cpp
@@ -3109,7 +3109,7 @@ void testFragmentSmiles() {
     int as[] = {0, 1, 2, 3};
     std::vector<int> atomsToUse(as, as + sizeof(as) / sizeof(int));
     std::string csmiles = MolFragmentToSmiles(*m, atomsToUse, 0, 0, 0);
-    TEST_ASSERT(csmiles == "CC(O)=O");
+    TEST_ASSERT(csmiles == "CC(=O)O");
     delete m;
   }
   {
@@ -3123,7 +3123,7 @@ void testFragmentSmiles() {
     std::vector<std::string> bondLabels(labels, labels + 5);
     std::string csmiles =
         MolFragmentToSmiles(*m, atomsToUse, 0, 0, &bondLabels);
-    TEST_ASSERT(csmiles == "C-C(-O)=O");
+    TEST_ASSERT(csmiles == "C-C(=O)-O");
     delete m;
   }
   {
@@ -3137,7 +3137,7 @@ void testFragmentSmiles() {
     std::vector<std::string> bondLabels(labels, labels + 5);
     std::string csmiles =
         MolFragmentToSmiles(*m, atomsToUse, 0, 0, &bondLabels);
-    TEST_ASSERT(csmiles == "CaC(aO)bO");
+    TEST_ASSERT(csmiles == "CaC(bO)aO");
     delete m;
   }
   {
@@ -3178,7 +3178,7 @@ void testFragmentSmiles() {
     std::string csmiles =
         MolFragmentToSmiles(*m, atomsToUse, 0, 0, &bondLabels);
     std::cerr << csmiles << std::endl;
-    TEST_ASSERT(csmiles == "CaC(aC)bC");
+    TEST_ASSERT(csmiles == "CaC(bC)aC" || csmiles == "CbC(ac)ac");
     delete m;
   }
   {
@@ -3193,7 +3193,7 @@ void testFragmentSmiles() {
     std::string csmiles =
         MolFragmentToSmiles(*m, atomsToUse, 0, 0, &bondLabels);
     std::cerr << csmiles << std::endl;
-    TEST_ASSERT(csmiles == "CaC(bC)bC" || csmiles == "CbC(aC)bC");
+    TEST_ASSERT(csmiles == "CaC(bC)bC" || csmiles == "CbC(bC)aC");
     delete m;
   }
   {
@@ -3845,35 +3845,33 @@ void testGithub1219() {
 }
 
 void testSmilesParseParams() {
-	BOOST_LOG(rdInfoLog)
-		<< "Testing the SmilesParseParams class"
-		<< std::endl;
-	{
-		std::string smiles = "C1=CC=CC=C1[H]";
-		ROMol *m = SmilesToMol(smiles);
-		TEST_ASSERT(m);
-		TEST_ASSERT(m->getNumAtoms() == 6);
-		TEST_ASSERT(m->getBondWithIdx(0)->getIsAromatic());
-		delete m;
+  BOOST_LOG(rdInfoLog) << "Testing the SmilesParseParams class" << std::endl;
+  {
+    std::string smiles = "C1=CC=CC=C1[H]";
+    ROMol *m = SmilesToMol(smiles);
+    TEST_ASSERT(m);
+    TEST_ASSERT(m->getNumAtoms() == 6);
+    TEST_ASSERT(m->getBondWithIdx(0)->getIsAromatic());
+    delete m;
 
-		{
-			SmilesParserParams params;
-			m = SmilesToMol(smiles,params);
-			TEST_ASSERT(m);
-			TEST_ASSERT(m->getNumAtoms() == 6);
-			TEST_ASSERT(m->getBondWithIdx(0)->getIsAromatic());
-			delete m;
-		}
-		{ // no removeHs, with sanitization
-			SmilesParserParams params;
+    {
+      SmilesParserParams params;
+      m = SmilesToMol(smiles, params);
+      TEST_ASSERT(m);
+      TEST_ASSERT(m->getNumAtoms() == 6);
+      TEST_ASSERT(m->getBondWithIdx(0)->getIsAromatic());
+      delete m;
+    }
+    {  // no removeHs, with sanitization
+      SmilesParserParams params;
       params.removeHs = false;
-			m = SmilesToMol(smiles,params);
-			TEST_ASSERT(m);
-			TEST_ASSERT(m->getNumAtoms() == 7);
-			TEST_ASSERT(m->getBondWithIdx(0)->getIsAromatic());
-			delete m;
-		}
-    { // removeHs, no sanitization
+      m = SmilesToMol(smiles, params);
+      TEST_ASSERT(m);
+      TEST_ASSERT(m->getNumAtoms() == 7);
+      TEST_ASSERT(m->getBondWithIdx(0)->getIsAromatic());
+      delete m;
+    }
+    {  // removeHs, no sanitization
       SmilesParserParams params;
       params.sanitize = false;
       m = SmilesToMol(smiles, params);
@@ -3882,7 +3880,7 @@ void testSmilesParseParams() {
       TEST_ASSERT(!m->getBondWithIdx(0)->getIsAromatic());
       delete m;
     }
-    { // no removeHs, no sanitization
+    {  // no removeHs, no sanitization
       SmilesParserParams params;
       params.removeHs = false;
       params.sanitize = false;
@@ -3894,49 +3892,52 @@ void testSmilesParseParams() {
     }
   }
 
-  { // basic name parsing
+  {  // basic name parsing
     std::string smiles = "CCCC the_name";
     ROMol *m = SmilesToMol(smiles);
     TEST_ASSERT(!m);
-    { // no removeHs, no sanitization
+    {  // no removeHs, no sanitization
       SmilesParserParams params;
       m = SmilesToMol(smiles, params);
       TEST_ASSERT(!m);
     }
-    { // no removeHs, no sanitization
-       SmilesParserParams params;
-       params.parseName = true;
-       m = SmilesToMol(smiles, params);
-       TEST_ASSERT(m);
-       TEST_ASSERT(m->getNumAtoms() == 4);
-       TEST_ASSERT(m->hasProp(common_properties::_Name));
-       TEST_ASSERT(m->getProp<std::string>(common_properties::_Name)=="the_name");
-       delete m;
-    }
-  }
-  { // name parsing2
-    std::string smiles = "CCCC\tthe_name";
-    { // no removeHs, no sanitization
+    {  // no removeHs, no sanitization
       SmilesParserParams params;
       params.parseName = true;
-      RWMol *m = SmilesToMol(smiles, params);
+      m = SmilesToMol(smiles, params);
       TEST_ASSERT(m);
       TEST_ASSERT(m->getNumAtoms() == 4);
       TEST_ASSERT(m->hasProp(common_properties::_Name));
-      TEST_ASSERT(m->getProp<std::string>(common_properties::_Name) == "the_name");
+      TEST_ASSERT(m->getProp<std::string>(common_properties::_Name) ==
+                  "the_name");
       delete m;
     }
   }
-  { // name parsing3
-    std::string smiles = "CCCC\t  the_name  ";
-    { // no removeHs, no sanitization
+  {  // name parsing2
+    std::string smiles = "CCCC\tthe_name";
+    {  // no removeHs, no sanitization
       SmilesParserParams params;
       params.parseName = true;
       RWMol *m = SmilesToMol(smiles, params);
       TEST_ASSERT(m);
       TEST_ASSERT(m->getNumAtoms() == 4);
       TEST_ASSERT(m->hasProp(common_properties::_Name));
-      TEST_ASSERT(m->getProp<std::string>(common_properties::_Name) == "the_name");
+      TEST_ASSERT(m->getProp<std::string>(common_properties::_Name) ==
+                  "the_name");
+      delete m;
+    }
+  }
+  {  // name parsing3
+    std::string smiles = "CCCC\t  the_name  ";
+    {  // no removeHs, no sanitization
+      SmilesParserParams params;
+      params.parseName = true;
+      RWMol *m = SmilesToMol(smiles, params);
+      TEST_ASSERT(m);
+      TEST_ASSERT(m->getNumAtoms() == 4);
+      TEST_ASSERT(m->hasProp(common_properties::_Name));
+      TEST_ASSERT(m->getProp<std::string>(common_properties::_Name) ==
+                  "the_name");
       delete m;
     }
   }

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -2258,15 +2258,15 @@ CAS<~>
 
     for rwmol in [Chem.EditableMol(mol), Chem.RWMol(mol)]:
       rwmol.ReplaceBond(0, newBond)
-      self.assertTrue(Chem.MolToSmiles(rwmol.GetMol()) == 'C1CCC1')      
+      self.assertTrue(Chem.MolToSmiles(rwmol.GetMol()) == 'C1CCC1')
       self.assertFalse(rwmol.GetMol().GetBondWithIdx(0).HasProp("foo"))
 
     for rwmol in [Chem.EditableMol(mol), Chem.RWMol(mol)]:
       rwmol.ReplaceBond(0, newBond, preserveProps=True)
-      self.assertTrue(Chem.MolToSmiles(rwmol.GetMol()) == 'C1CCC1')      
+      self.assertTrue(Chem.MolToSmiles(rwmol.GetMol()) == 'C1CCC1')
       self.assertTrue(rwmol.GetMol().GetBondWithIdx(0).HasProp("foo"))
       self.assertEqual(rwmol.GetMol().GetBondWithIdx(0).GetProp("foo"), "bar")
-      
+
 
   def test47SmartsPieces(self):
     """ test the GetAtomSmarts and GetBondSmarts functions
@@ -3258,10 +3258,10 @@ CAS<~>
     mol = Chem.MolFromSmiles('C1NCN1.C1NCN1')
     self.assertEquals(
       list(Chem.CanonicalRankAtomsInFragment(mol, atomsToUse=range(0, 4), breakTies=False)),
-      [0, 6, 0, 6, -1, -1, -1, -1])
+      [4, 6, 4, 6, -1, -1, -1, -1])
     self.assertEquals(
       list(Chem.CanonicalRankAtomsInFragment(mol, atomsToUse=range(4, 8), breakTies=False)),
-      [-1, -1, -1, -1, 0, 6, 0, 6])
+      [-1, -1, -1, -1, 4, 6, 4, 6])
 
   def test93RWMolsAsROMol(self):
     """ test the RWMol class as a proper ROMol
@@ -3543,7 +3543,7 @@ CAS<~>
     ap = Chem.AdjustQueryProperties(core)
     self.assertEqual(ap.GetAtomWithIdx(0).GetPropsAsDict()["foo"], "bar")
     self.assertEqual(ap.GetAtomWithIdx(1).GetPropsAsDict()["foo"], "bar")
-    
+
   def testGithubIssue579(self):
     fileN = os.path.join(RDConfig.RDBaseDir, 'Code', 'GraphMol', 'FileParsers', 'test_data',
                          'NCI_aids_few.sdf.gz')
@@ -4341,7 +4341,7 @@ M  END
         self.assertEqual( c1, c2 )
 
       assert d1 == d2
-      
+
     self.assertEqual(Chem.MolToSmiles(mol, isomericSmiles=True),
                      Chem.MolToSmiles(mol3,isomericSmiles=True))
 
@@ -4354,7 +4354,7 @@ M  END
     self.assertEqual(m2.GetProp("foo"),"bar")
     for atom in m2.GetAtoms():
       self.assertEqual(atom.GetProp("myidx"), str(atom.GetIdx()))
-    
+
     self.assertEqual(Chem.MolToSmiles(m2, True),
                      Chem.MolToSmiles(Chem.MolFromSmiles(
                        "CN[C@@H](C)C(=O)N[C@H](C(=O)N1C[C@@H](Oc2ccccc2)C[C@H]1C(=O)N[C@@H]1CCCc2ccccc21)C1CCCCC1"),
@@ -4368,7 +4368,7 @@ M  END
       self.assertFalse(True) # shouldn't get here
     except RuntimeError:
       pass
-    
+
 if __name__ == '__main__':
   if "RDTESTCASE" in os.environ:
     suite = unittest.TestSuite()

--- a/Code/GraphMol/hanoitest.cpp
+++ b/Code/GraphMol/hanoitest.cpp
@@ -1087,8 +1087,8 @@ std::string smis[] = {
     "C12C3C4C5C6C7C8C1C1C9C5C5C%10C2C2C%11C%12C%13C3C3C7C%10C7C4C%11C1C3C(C5C8%"
     "12)C(C62)C7C9%13",  // does not initially work
     // drawn examples first reviewer
-    "C12C3C4C1CC5C46C7C5C1C57C6C53C1C2",
-    "C1C2C3C4CC5C6C1C17C8C61C5C48C3C27", "EOS"};
+    "C12C3C4C1CC5C46C7C5C1C57C6C53C1C2", "C1C2C3C4CC5C6C1C17C8C61C5C48C3C27",
+    "EOS"};
 
 void test7() {
   BOOST_LOG(rdInfoLog) << "testing stability w.r.t. renumbering." << std::endl;
@@ -1459,6 +1459,35 @@ void test12() {
   BOOST_LOG(rdInfoLog) << "Finished" << std::endl;
 }
 
+void testGithub1567() {
+  BOOST_LOG(rdInfoLog)
+      << "testing github #1567: Non-canonical result from MolFragmentToSmiles()"
+      << std::endl;
+  {
+    ROMol *m1 = SmilesToMol("CC1CN(Cc2cccc(C)c2)C1");
+    TEST_ASSERT(m1);
+    int m1Ats_a[6] = {1, 12, 3, 4, 5, 11};
+    std::vector<int> m1Ats(m1Ats_a, m1Ats_a + 6);
+    int m1Bnds_a[5] = {12, 11, 3, 4, 13};
+    std::vector<int> m1Bnds(m1Bnds_a, m1Bnds_a + 5);
+    std::string smi1 = MolFragmentToSmiles(*m1, m1Ats, &m1Bnds);
+
+    ROMol *m2 = SmilesToMol("CN(CCC)Cc1cccc(C)c1");
+    TEST_ASSERT(m2);
+    int m2Ats_a[6] = {3, 2, 1, 5, 6, 12};
+    std::vector<int> m2Ats(m2Ats_a, m2Ats_a + 6);
+    int m2Bnds_a[5] = {2, 1, 4, 5, 12};
+    std::vector<int> m2Bnds(m2Bnds_a, m2Bnds_a + 5);
+    std::string smi2 = MolFragmentToSmiles(*m2, m2Ats, &m2Bnds);
+
+    TEST_ASSERT(smi1 == smi2);
+
+    delete m1;
+    delete m2;
+  }
+  BOOST_LOG(rdInfoLog) << "Finished" << std::endl;
+}
+
 int main() {
   RDLog::InitLogs();
 #if 1
@@ -1476,6 +1505,7 @@ int main() {
   test7();
   test8();
 #endif
+  testGithub1567();
 
   return 0;
 }

--- a/Code/GraphMol/new_canon.cpp
+++ b/Code/GraphMol/new_canon.cpp
@@ -317,6 +317,19 @@ void getNbrs(const ROMol &mol, const Atom *at, int *ids) {
   }
 }
 
+bondholder makeBondHolder(const Bond *bond, unsigned int otherIdx,
+                          bool includeChirality) {
+  Bond::BondStereo stereo = Bond::STEREONONE;
+  if (includeChirality) {
+    stereo = bond->getStereo();
+    if (stereo == Bond::STEREOANY) {
+      stereo = Bond::STEREONONE;
+    }
+  }
+  Bond::BondType bt =
+      bond->getIsAromatic() ? Bond::AROMATIC : bond->getBondType();
+  return bondholder(bt, stereo, otherIdx, 0);
+}
 void getBonds(const ROMol &mol, const Atom *at, std::vector<bondholder> &nbrs,
               bool includeChirality) {
   ROMol::OEDGE_ITER beg, end;
@@ -324,18 +337,8 @@ void getBonds(const ROMol &mol, const Atom *at, std::vector<bondholder> &nbrs,
   while (beg != end) {
     const BOND_SPTR bond = (mol)[*beg];
     ++beg;
-    Bond::BondStereo stereo = Bond::STEREONONE;
-    if (includeChirality) {
-      stereo = bond->getStereo();
-      if (stereo == Bond::STEREOANY) {
-        stereo = Bond::STEREONONE;
-      }
-    }
-    unsigned int idx = bond->getOtherAtomIdx(at->getIdx());
-    Bond::BondType bt =
-        bond->getIsAromatic() ? Bond::AROMATIC : bond->getBondType();
-    bondholder bh(bondholder(bt, stereo, idx, 0));
-    nbrs.push_back(bh);
+    nbrs.push_back(makeBondHolder(
+        bond.get(), bond->getOtherAtomIdx(at->getIdx()), includeChirality));
   }
   std::sort(nbrs.begin(), nbrs.end(), bondholder::greater);
 }
@@ -439,21 +442,59 @@ void initCanonAtoms(const ROMol &mol, std::vector<Canon::canon_atom> &atoms,
 void initFragmentCanonAtoms(const ROMol &mol,
                             std::vector<Canon::canon_atom> &atoms,
                             bool includeChirality,
-                            const std::vector<std::string> *atomSymbols) {
+                            const std::vector<std::string> *atomSymbols,
+                            const boost::dynamic_bitset<> &atomsInPlay,
+                            const boost::dynamic_bitset<> &bondsInPlay) {
+  // start by initializing the atoms
   for (unsigned int i = 0; i < mol.getNumAtoms(); ++i) {
     atoms[i].atom = mol.getAtomWithIdx(i);
     atoms[i].index = i;
-    atoms[i].degree = atoms[i].atom->getDegree();
-    atoms[i].nbrIds = (int *)calloc(atoms[i].degree, sizeof(int));
-    if (atomSymbols) {
-      atoms[i].p_symbol = &(*atomSymbols)[i];
-    } else {
-      atoms[i].p_symbol = 0;
-    }
-    advancedInitCanonAtom(mol, atoms[i], i);
-    atoms[i].bonds.reserve(atoms[i].degree);
-    getBonds(mol, atoms[i].atom, atoms[i].bonds, includeChirality);
+    // we don't care about overall degree, so we start that at zero, and
+    // then count the degree in the fragment itself below.
     atoms[i].degree = 0;
+    if (atomsInPlay[i]) {
+      atoms[i].nbrIds = (int *)calloc(atoms[i].atom->getDegree(), sizeof(int));
+      if (atomSymbols) {
+        atoms[i].p_symbol = &(*atomSymbols)[i];
+      } else {
+        atoms[i].p_symbol = 0;
+      }
+      advancedInitCanonAtom(mol, atoms[i], i);
+      atoms[i].bonds.reserve(atoms[i].atom->getDegree());
+    }
+  }
+
+  // now deal with the bonds in the fragment.
+  // these set the atomic degrees and update the neighbor lists
+  for (ROMol::ConstBondIterator bI = mol.beginBonds(); bI != mol.endBonds();
+       ++bI) {
+    if (!bondsInPlay[(*bI)->getIdx()] ||
+        !atomsInPlay[(*bI)->getBeginAtomIdx()] ||
+        !atomsInPlay[(*bI)->getEndAtomIdx()])
+      continue;
+    Canon::canon_atom &begAt = atoms[(*bI)->getBeginAtomIdx()];
+    Canon::canon_atom &endAt = atoms[(*bI)->getEndAtomIdx()];
+    begAt.nbrIds[begAt.degree] = (*bI)->getEndAtomIdx();
+    endAt.nbrIds[endAt.degree] = (*bI)->getBeginAtomIdx();
+    begAt.degree++;
+    endAt.degree++;
+    begAt.bonds.push_back(
+        makeBondHolder(*bI, (*bI)->getEndAtomIdx(), includeChirality));
+    endAt.bonds.push_back(
+        makeBondHolder(*bI, (*bI)->getBeginAtomIdx(), includeChirality));
+  }
+
+  // and now we can do the last bit for each atom
+  for (size_t i = 0; i < mol.getNumAtoms(); ++i) {
+    if (!atomsInPlay[i]) continue;
+    // this is the fix for github #1567: we let the atom's degree
+    // in the original molecule influence its degree in the fragment
+    atoms[i].totalNumHs +=
+        (mol.getAtomWithIdx(i)->getDegree() - atoms[i].degree);
+
+    // and sort our list of neighboring bonds
+    std::sort(atoms[i].bonds.begin(), atoms[i].bonds.end(),
+              bondholder::greater);
   }
 }
 
@@ -556,22 +597,8 @@ void rankFragmentAtoms(const ROMol &mol, std::vector<unsigned int> &res,
                "bad atomSymbols size");
 
   std::vector<Canon::canon_atom> atoms(mol.getNumAtoms());
-  initFragmentCanonAtoms(mol, atoms, includeChirality, atomSymbols);
-  for (ROMol::ConstBondIterator bI = mol.beginBonds(); bI != mol.endBonds();
-       ++bI) {
-    if (!bondsInPlay[(*bI)->getIdx()]) continue;
-    Canon::canon_atom &begAt = atoms[(*bI)->getBeginAtomIdx()];
-    Canon::canon_atom &endAt = atoms[(*bI)->getEndAtomIdx()];
-    begAt.nbrIds[begAt.degree] = (*bI)->getEndAtomIdx();
-    endAt.nbrIds[endAt.degree] = (*bI)->getBeginAtomIdx();
-    begAt.degree++;
-    endAt.degree++;
-  }
-  for (size_t i = 0; i < mol.getNumAtoms(); ++i) {
-    if (!atomsInPlay[i]) continue;
-    atoms[i].totalNumHs +=
-        (mol.getAtomWithIdx(i)->getDegree() - atoms[i].degree);
-  }
+  initFragmentCanonAtoms(mol, atoms, includeChirality, atomSymbols, atomsInPlay,
+                         bondsInPlay);
 
   AtomCompareFunctor ftor(&atoms.front(), mol, &atomsInPlay, &bondsInPlay);
   ftor.df_useIsotopes = includeIsotopes;

--- a/Code/GraphMol/new_canon.h
+++ b/Code/GraphMol/new_canon.h
@@ -289,6 +289,7 @@ class AtomCompareFunctor {
       else
         return 0;
     }
+
     // move onto atomic number
     ivi = dp_atoms[i].atom->getAtomicNum();
     ivj = dp_atoms[j].atom->getAtomicNum();
@@ -350,6 +351,7 @@ class AtomCompareFunctor {
       else if (ivi > ivj)
         return 1;
     }
+
     if (df_useChiralityRings) {
       // ring stereochemistry
       ivi = getAtomRingNbrCode(i);


### PR DESCRIPTION
This fixes a bug in the way atom degree was treated when canonicalizing fragments of molecules. It only affects `MolFragmentToSmiles()` and `canonicalizeFragment()`.

The key point is to not lose all information about the degree of the atom in the full molecule

@NadineSchneider has looked at it and "signed off". :-)