### PR TITLE
Support continuous highlighting in drawMolecules().

### DIFF
--- a/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
@@ -244,7 +244,7 @@ void MolDraw2D::drawMolecule(const ROMol &mol,
   } else if (drawOptions().circleAtoms && highlight_atoms) {
     ROMol::VERTEX_ITER this_at, end_at;
     boost::tie(this_at, end_at) = mol.getVertices();
-    setFillPolys(false);
+    setFillPolys(drawOptions().fillHighlights);
     while (this_at != end_at) {
       int this_idx = mol[*this_at]->getIdx();
       if (std::find(highlight_atoms->begin(), highlight_atoms->end(),
@@ -714,13 +714,24 @@ void MolDraw2D::drawMolecules(
     int col = 0;
     if (nCols > 1) col = i % nCols;
     setOffset(col * panelWidth(), row * panelHeight());
+
+    vector<int> *lhighlight_bonds = NULL;
+    if (highlight_bonds) {
+      lhighlight_bonds = new std::vector<int>((*highlight_bonds)[i]);
+    } else if (drawOptions().continuousHighlight && highlight_atoms) {
+      lhighlight_bonds = new vector<int>();
+      getBondHighlightsForAtoms(tmols[i], (*highlight_atoms)[i],
+                                *lhighlight_bonds);
+    };
+
     drawMolecule(tmols[i], legends ? (*legends)[i] : "",
                  highlight_atoms ? &(*highlight_atoms)[i] : NULL,
-                 highlight_bonds ? &(*highlight_bonds)[i] : NULL,
+                 lhighlight_bonds,
                  highlight_atom_maps ? &(*highlight_atom_maps)[i] : NULL,
                  highlight_bond_maps ? &(*highlight_bond_maps)[i] : NULL,
                  highlight_radii ? &(*highlight_radii)[i] : NULL,
                  confIds ? (*confIds)[i] : -1);
+    delete lhighlight_bonds;
   }
 };
 

--- a/Code/GraphMol/MolDraw2D/MolDraw2D.h
+++ b/Code/GraphMol/MolDraw2D/MolDraw2D.h
@@ -66,6 +66,8 @@ struct MolDrawOptions {
   DrawColour highlightColour;      // default highlight color
   bool continuousHighlight;  // highlight by drawing an outline *underneath* the
                              // molecule
+  bool fillHighlights;       // fill the areas used to highlight atoms and atom
+                             // regions
   int flagCloseContactsDist;  // if positive, this will be used as a cutoff (in
                               // pixels) for highlighting close contacts
   bool includeAtomTags;  // toggles inclusion of atom tags in the output. does
@@ -100,6 +102,7 @@ struct MolDrawOptions {
         circleAtoms(true),
         highlightColour(1, .5, .5),
         continuousHighlight(true),
+        fillHighlights(true),
         flagCloseContactsDist(3),
         includeAtomTags(false),
         clearBackground(true),

--- a/Code/GraphMol/MolDraw2D/Wrap/rdMolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/Wrap/rdMolDraw2D.cpp
@@ -336,6 +336,7 @@ BOOST_PYTHON_MODULE(rdMolDraw2D) {
                      "labels deuterium as D and tritium as T")
       .def_readwrite("continuousHighlight",
                      &RDKit::MolDrawOptions::continuousHighlight)
+      .def_readwrite("fillHighlights", &RDKit::MolDrawOptions::fillHighlights)
       .def_readwrite("flagCloseContactsDist",
                      &RDKit::MolDrawOptions::flagCloseContactsDist)
       .def_readwrite("atomRegions", &RDKit::MolDrawOptions::atomRegions,

--- a/Code/GraphMol/MolDraw2D/test1.cpp
+++ b/Code/GraphMol/MolDraw2D/test1.cpp
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2015 Greg Landrum
+//  Copyright (C) 2015-2017 Greg Landrum
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -2051,6 +2051,63 @@ void test14BWPalette() {
   std::cerr << " Done" << std::endl;
 }
 
+void test15ContinuousHighlightingWithGrid() {
+  std::cerr << " ----------------- Testing use of continuous highlighting with "
+               "drawMolecules"
+            << std::endl;
+
+  {
+    std::string smiles =
+        "COc1cccc(NC(=O)[C@H](Cl)Sc2nc(ns2)c3ccccc3Cl)c1";  // made up
+    RWMol *m1 = SmilesToMol(smiles);
+    TEST_ASSERT(m1);
+    smiles = "NC(=O)[C@H](Cl)Sc1ncns1";  // made up
+    RWMol *m2 = SmilesToMol(smiles);
+    TEST_ASSERT(m2);
+    std::vector<ROMol *> mols;
+    mols.push_back(m1);
+    mols.push_back(m2);
+    std::vector<std::vector<int> > atHighlights(2);
+    atHighlights[0].push_back(0);
+    atHighlights[0].push_back(1);
+    atHighlights[0].push_back(2);
+    atHighlights[0].push_back(6);
+
+    atHighlights[1].push_back(0);
+    atHighlights[1].push_back(1);
+    atHighlights[1].push_back(2);
+    atHighlights[1].push_back(6);
+
+    {
+      MolDraw2DSVG drawer(500, 200, 250, 200);
+      drawer.drawOptions().continuousHighlight = false;
+      drawer.drawMolecules(mols, NULL, &atHighlights);
+      drawer.finishDrawing();
+      std::string text = drawer.getDrawingText();
+      std::ofstream outs("test15_1.svg");
+      outs << text;
+      outs.flush();
+      TEST_ASSERT(text.find("stroke:#FF7F7F;stroke-width:8px;") ==
+                  std::string::npos);
+    }
+
+    {
+      MolDraw2DSVG drawer(500, 200, 250, 200);
+      drawer.drawOptions().continuousHighlight = true;
+      drawer.drawMolecules(mols, NULL, &atHighlights);
+      drawer.finishDrawing();
+      std::string text = drawer.getDrawingText();
+      std::ofstream outs("test15_2.svg");
+      outs << text;
+      outs.flush();
+      TEST_ASSERT(text.find("stroke:#FF7F7F;stroke-width:8px;") !=
+                  std::string::npos);
+    }
+  }
+
+  std::cerr << " Done" << std::endl;
+}
+
 int main() {
   RDLog::InitLogs();
 #if 1
@@ -2085,4 +2142,5 @@ int main() {
   testGithub1322();
   testGithub565();
   test14BWPalette();
+  test15ContinuousHighlightingWithGrid();
 }


### PR DESCRIPTION
There's a workaround to get roughly the same effect from client code, but it's a pain. This is an easier (and more intuitive) solution to the problem: if `continuousHighlighting` is on and you call `drawMolecules()` and just provide the atoms to be highlighted, then the behavior is the same as `drawMolecule()` in the same situation - bonds connecting the highlighted atoms will also be highlighted.

Also adds a `fillHighlights` option to `DrawOptions`

