### PR TITLE
[WIP] add threshold argument to maxmin picker

### DIFF
--- a/Code/SimDivPickers/MaxMinPicker.h
+++ b/Code/SimDivPickers/MaxMinPicker.h
@@ -80,8 +80,7 @@ class MaxMinPicker : public DistPicker {
   template <typename T>
   RDKit::INT_VECT lazyPick(T &func, unsigned int poolSize,
                            unsigned int pickSize,
-                           const RDKit::INT_VECT &firstPicks,
-                           int seed,
+                           const RDKit::INT_VECT &firstPicks, int seed,
                            double &threshold) const;
 
   /*! \brief Contains the implementation for the MaxMin diversity picker
@@ -149,8 +148,7 @@ template <typename T>
 RDKit::INT_VECT MaxMinPicker::lazyPick(T &func, unsigned int poolSize,
                                        unsigned int pickSize,
                                        const RDKit::INT_VECT &firstPicks,
-                                       int seed,
-                                       double &threshold) const {
+                                       int seed, double &threshold) const {
   if (!poolSize) throw ValueErrorException("empty pool to pick from");
 
   if (poolSize < pickSize)
@@ -233,6 +231,7 @@ RDKit::INT_VECT MaxMinPicker::lazyPick(T &func, unsigned int poolSize,
 
   // now pick 1 compound at a time
   double maxOFmin = -1.0;
+  double tmpThreshold = -1.0;
   while (picked < pickSize) {
     unsigned int *pick_prev = 0;
     maxOFmin = -1.0;
@@ -264,16 +263,15 @@ RDKit::INT_VECT MaxMinPicker::lazyPick(T &func, unsigned int poolSize,
     } while (*prev != 0);
 
     // if the current distance is closer then threshold, we're done
-    if (threshold >= 0.0 && maxOFmin < threshold)
-      break;
-
+    if (threshold >= 0.0 && maxOFmin < threshold) break;
+    tmpThreshold = maxOFmin;
     // now add the new pick to picks and remove it from the pool
     *pick_prev = pinfo[pick].next;
     picks.push_back(pick);
     picked++;
   }
 
-  threshold = maxOFmin;
+  threshold = tmpThreshold;
   delete[] pinfo;
   return picks;
 }
@@ -284,20 +282,18 @@ RDKit::INT_VECT MaxMinPicker::lazyPick(T &func, unsigned int poolSize,
                                        const RDKit::INT_VECT &firstPicks,
                                        int seed) const {
   double threshold = -1.0;
-  return MaxMinPicker::lazyPick(func, poolSize, pickSize,
-                                firstPicks, seed, threshold);
+  return MaxMinPicker::lazyPick(func, poolSize, pickSize, firstPicks, seed,
+                                threshold);
 }
 
 template <typename T>
 RDKit::INT_VECT MaxMinPicker::lazyPick(T &func, unsigned int poolSize,
-                                       unsigned int pickSize) const
-{
+                                       unsigned int pickSize) const {
   RDKit::INT_LIST firstPicks;
   double threshold = -1.0;
-  return MaxMinPicker::lazyPick(func, poolSize, pickSize,
-                                firstPicks, -1,  threshold);
+  return MaxMinPicker::lazyPick(func, poolSize, pickSize, firstPicks, -1,
+                                threshold);
 }
-
 };
 
 #endif

--- a/Code/SimDivPickers/MaxMinPicker.h
+++ b/Code/SimDivPickers/MaxMinPicker.h
@@ -69,9 +69,20 @@ class MaxMinPicker : public DistPicker {
    */
   template <typename T>
   RDKit::INT_VECT lazyPick(T &func, unsigned int poolSize,
+                           unsigned int pickSize) const;
+
+  template <typename T>
+  RDKit::INT_VECT lazyPick(T &func, unsigned int poolSize,
                            unsigned int pickSize,
-                           RDKit::INT_VECT firstPicks = RDKit::INT_VECT(),
+                           const RDKit::INT_VECT &firstPicks,
                            int seed = -1) const;
+
+  template <typename T>
+  RDKit::INT_VECT lazyPick(T &func, unsigned int poolSize,
+                           unsigned int pickSize,
+                           const RDKit::INT_VECT &firstPicks,
+                           int seed,
+                           double &threshold) const;
 
   /*! \brief Contains the implementation for the MaxMin diversity picker
    *
@@ -137,8 +148,9 @@ struct MaxMinPickInfo {
 template <typename T>
 RDKit::INT_VECT MaxMinPicker::lazyPick(T &func, unsigned int poolSize,
                                        unsigned int pickSize,
-                                       RDKit::INT_VECT firstPicks,
-                                       int seed) const {
+                                       const RDKit::INT_VECT &firstPicks,
+                                       int seed,
+                                       double &threshold) const {
   if (!poolSize) throw ValueErrorException("empty pool to pick from");
 
   if (poolSize < pickSize)
@@ -148,7 +160,10 @@ RDKit::INT_VECT MaxMinPicker::lazyPick(T &func, unsigned int poolSize,
 
   unsigned int memsize = (unsigned int)(poolSize * sizeof(MaxMinPickInfo));
   MaxMinPickInfo *pinfo = new MaxMinPickInfo[memsize];
-  if (!pinfo) return picks;
+  if (!pinfo) {
+    threshold = -1.0;
+    return picks;
+  }
   memset(pinfo, 0, memsize);
 
   picks.reserve(pickSize);
@@ -188,6 +203,7 @@ RDKit::INT_VECT MaxMinPicker::lazyPick(T &func, unsigned int poolSize,
   }
 
   if (picked >= pickSize) {
+    threshold = -1.0;
     delete[] pinfo;
     return picks;
   }
@@ -216,9 +232,10 @@ RDKit::INT_VECT MaxMinPicker::lazyPick(T &func, unsigned int poolSize,
   } while (*prev != 0);
 
   // now pick 1 compound at a time
+  double maxOFmin = -1.0;
   while (picked < pickSize) {
     unsigned int *pick_prev = 0;
-    double maxOFmin = -1.0;
+    maxOFmin = -1.0;
     prev = &pool_list;
     do {
       poolIdx = *prev;
@@ -246,15 +263,41 @@ RDKit::INT_VECT MaxMinPicker::lazyPick(T &func, unsigned int poolSize,
       prev = &pinfo[poolIdx].next;
     } while (*prev != 0);
 
+    // if the current distance is closer then threshold, we're done
+    if (threshold >= 0.0 && maxOFmin < threshold)
+      break;
+
     // now add the new pick to picks and remove it from the pool
     *pick_prev = pinfo[pick].next;
     picks.push_back(pick);
     picked++;
   }
 
+  threshold = maxOFmin;
   delete[] pinfo;
   return picks;
 }
+
+template <typename T>
+RDKit::INT_VECT MaxMinPicker::lazyPick(T &func, unsigned int poolSize,
+                                       unsigned int pickSize,
+                                       const RDKit::INT_VECT &firstPicks,
+                                       int seed) const {
+  double threshold = -1.0;
+  return MaxMinPicker::lazyPick(func, poolSize, pickSize,
+                                firstPicks, seed, threshold);
+}
+
+template <typename T>
+RDKit::INT_VECT MaxMinPicker::lazyPick(T &func, unsigned int poolSize,
+                                       unsigned int pickSize) const
+{
+  RDKit::INT_LIST firstPicks;
+  double threshold = -1.0;
+  return MaxMinPicker::lazyPick(func, poolSize, pickSize,
+                                firstPicks, -1,  threshold);
+}
+
 };
 
 #endif

--- a/Code/SimDivPickers/Wrap/MaxMinPicker.cpp
+++ b/Code/SimDivPickers/Wrap/MaxMinPicker.cpp
@@ -86,8 +86,8 @@ RDKit::INT_VECT LazyMaxMinPicks(MaxMinPicker *picker, python::object distFunc,
                                 python::object firstPicks, int seed,
                                 python::object useCache) {
   if (useCache != python::object()) {
-    BOOST_LOG(rdWarningLog) << "the useCache argument is deprecated and ignored"
-                            << std::endl;
+    BOOST_LOG(rdWarningLog)
+        << "the useCache argument is deprecated and ignored" << std::endl;
   }
   pyobjFunctor functor(distFunc);
   RDKit::INT_VECT res;
@@ -142,8 +142,8 @@ RDKit::INT_VECT LazyVectorMaxMinPicks(MaxMinPicker *picker, python::object objs,
                                       python::object firstPicks, int seed,
                                       python::object useCache) {
   if (useCache != python::object()) {
-    BOOST_LOG(rdWarningLog) << "the useCache argument is deprecated and ignored"
-                            << std::endl;
+    BOOST_LOG(rdWarningLog)
+        << "the useCache argument is deprecated and ignored" << std::endl;
   }
   std::vector<const ExplicitBitVect *> bvs(poolSize);
   for (int i = 0; i < poolSize; ++i) {
@@ -262,6 +262,8 @@ struct MaxMin_wrap {
              "should not.\n"
              "  - poolSize: number of items in the pool\n"
              "  - pickSize: number of items to pick from the pool\n"
+             "  - threshold: stop picking when the distance goes below this "
+             "value\n"
              "  - firstPicks: (optional) the first items to be picked (seeds "
              "the list)\n"
              "  - seed: (optional) seed for the random number generator\n")
@@ -281,6 +283,8 @@ struct MaxMin_wrap {
              "from.\n"
              "  - poolSize: number of items in the pool\n"
              "  - pickSize: number of items to pick from the pool\n"
+             "  - threshold: stop picking when the distance goes below this "
+             "value\n"
              "  - firstPicks: (optional) the first items to be picked (seeds "
              "the list)\n"
              "  - seed: (optional) seed for the random number generator\n");

--- a/Code/SimDivPickers/Wrap/MaxMinPicker.cpp
+++ b/Code/SimDivPickers/Wrap/MaxMinPicker.cpp
@@ -66,6 +66,21 @@ class pyobjFunctor {
   python::object dp_obj;
 };
 
+namespace {
+template <typename T>
+void LazyMaxMinHelper(MaxMinPicker *picker, T functor, unsigned int poolSize,
+                      unsigned int pickSize, python::object firstPicks,
+                      int seed, RDKit::INT_VECT &res, double &threshold) {
+  RDKit::INT_VECT firstPickVect;
+  for (unsigned int i = 0;
+       i < python::extract<unsigned int>(firstPicks.attr("__len__")()); ++i) {
+    firstPickVect.push_back(python::extract<int>(firstPicks[i]));
+  }
+  res = picker->lazyPick(functor, poolSize, pickSize, firstPickVect, seed,
+                         threshold);
+}
+}  // end of anonymous namespace
+
 RDKit::INT_VECT LazyMaxMinPicks(MaxMinPicker *picker, python::object distFunc,
                                 int poolSize, int pickSize,
                                 python::object firstPicks, int seed,
@@ -74,15 +89,21 @@ RDKit::INT_VECT LazyMaxMinPicks(MaxMinPicker *picker, python::object distFunc,
     BOOST_LOG(rdWarningLog) << "the useCache argument is deprecated and ignored"
                             << std::endl;
   }
-  RDKit::INT_VECT firstPickVect;
-  for (unsigned int i = 0;
-       i < python::extract<unsigned int>(firstPicks.attr("__len__")()); ++i) {
-    firstPickVect.push_back(python::extract<int>(firstPicks[i]));
-  }
-  RDKit::INT_VECT res;
   pyobjFunctor functor(distFunc);
-  res = picker->lazyPick(functor, poolSize, pickSize, firstPickVect, seed);
+  RDKit::INT_VECT res;
+  double threshold = -1.;
+  LazyMaxMinHelper(picker, functor, poolSize, pickSize, firstPicks, seed, res,
+                   threshold);
   return res;
+}
+python::tuple LazyMaxMinPicksWithThreshold(
+    MaxMinPicker *picker, python::object distFunc, int poolSize, int pickSize,
+    double threshold, python::object firstPicks, int seed) {
+  pyobjFunctor functor(distFunc);
+  RDKit::INT_VECT res;
+  LazyMaxMinHelper(picker, functor, poolSize, pickSize, firstPicks, seed, res,
+                   threshold);
+  return python::make_tuple(res, threshold);
 }
 
 // NOTE: TANIMOTO and DICE provably return the same results for the diversity
@@ -129,15 +150,29 @@ RDKit::INT_VECT LazyVectorMaxMinPicks(MaxMinPicker *picker, python::object objs,
     bvs[i] = python::extract<const ExplicitBitVect *>(objs[i]);
   }
   pyBVFunctor<ExplicitBitVect> functor(bvs, TANIMOTO);
-  RDKit::INT_VECT firstPickVect;
-  for (unsigned int i = 0;
-       i < python::extract<unsigned int>(firstPicks.attr("__len__")()); ++i) {
-    firstPickVect.push_back(python::extract<int>(firstPicks[i]));
-  }
-  RDKit::INT_VECT res =
-      picker->lazyPick(functor, poolSize, pickSize, firstPickVect, seed);
+
+  RDKit::INT_VECT res;
+  double threshold = -1.;
+  LazyMaxMinHelper(picker, functor, poolSize, pickSize, firstPicks, seed, res,
+                   threshold);
   return res;
 }
+
+python::tuple LazyVectorMaxMinPicksWithThreshold(
+    MaxMinPicker *picker, python::object objs, int poolSize, int pickSize,
+    double threshold, python::object firstPicks, int seed) {
+  std::vector<const ExplicitBitVect *> bvs(poolSize);
+  for (int i = 0; i < poolSize; ++i) {
+    bvs[i] = python::extract<const ExplicitBitVect *>(objs[i]);
+  }
+  pyBVFunctor<ExplicitBitVect> functor(bvs, TANIMOTO);
+
+  RDKit::INT_VECT res;
+  LazyMaxMinHelper(picker, functor, poolSize, pickSize, firstPicks, seed, res,
+                   threshold);
+  return python::make_tuple(res, threshold);
+}
+
 }  // end of namespace RDPickers
 
 struct MaxMin_wrap {
@@ -205,7 +240,50 @@ struct MaxMin_wrap {
              "  - firstPicks: (optional) the first items to be picked (seeds "
              "the list)\n"
              "  - seed: (optional) seed for the random number generator\n"
-             "  - useCache: IGNORED.\n");
+             "  - useCache: IGNORED.\n")
+
+        .def("LazyPickWithThreshold", RDPickers::LazyMaxMinPicksWithThreshold,
+             (python::arg("self"), python::arg("distFunc"),
+              python::arg("poolSize"), python::arg("pickSize"),
+              python::arg("threshold"),
+              python::arg("firstPicks") = python::tuple(),
+              python::arg("seed") = -1),
+             "Pick a subset of items from a pool of items using the MaxMin "
+             "Algorithm\n"
+             "Ashton, M. et. al., Quant. Struct.-Act. Relat., 21 (2002), "
+             "598-604 \n"
+             "ARGUMENTS:\n\n"
+             "  - distFunc: a function that should take two indices and return "
+             "the\n"
+             "              distance between those two points.\n"
+             "              NOTE: the implementation caches distance values, "
+             "so the\n"
+             "              client code does not need to do so; indeed, it "
+             "should not.\n"
+             "  - poolSize: number of items in the pool\n"
+             "  - pickSize: number of items to pick from the pool\n"
+             "  - firstPicks: (optional) the first items to be picked (seeds "
+             "the list)\n"
+             "  - seed: (optional) seed for the random number generator\n")
+        .def("LazyBitVectorPickWithThreshold",
+             RDPickers::LazyVectorMaxMinPicksWithThreshold,
+             (python::arg("self"), python::arg("objects"),
+              python::arg("poolSize"), python::arg("pickSize"),
+              python::arg("threshold"),
+              python::arg("firstPicks") = python::tuple(),
+              python::arg("seed") = -1),
+             "Pick a subset of items from a pool of bit vectors using the "
+             "MaxMin Algorithm\n"
+             "Ashton, M. et. al., Quant. Struct.-Act. Relat., 21 (2002), "
+             "598-604 \n"
+             "ARGUMENTS:\n\n"
+             "  - vectors: a sequence of the bit vectors that should be picked "
+             "from.\n"
+             "  - poolSize: number of items in the pool\n"
+             "  - pickSize: number of items to pick from the pool\n"
+             "  - firstPicks: (optional) the first items to be picked (seeds "
+             "the list)\n"
+             "  - seed: (optional) seed for the random number generator\n");
   };
 };
 

--- a/Code/SimDivPickers/Wrap/testPickers.py
+++ b/Code/SimDivPickers/Wrap/testPickers.py
@@ -239,7 +239,25 @@ class TestCase(unittest.TestCase):
     self.assertEqual(ids,[374,720,690,339,875,842,404,725,120,385,115,868,630,\
                           881,516,497,412,718,869,407])
 
+  def testBitVectorMaxMin4(self):
+    # threshold tests
+    fname = os.path.join(RDConfig.RDBaseDir, 'Code', 'SimDivPickers', 'Wrap', 'test_data',
+                         'chembl_cyps.head.fps')
+    fps = []
+    with open(fname) as infil:
+      for line in infil:
+          fp = DataStructs.CreateFromFPSText(line.strip())
+          fps.append(fp)
+    mmp =rdSimDivPickers.MaxMinPicker()
+    ids,threshold=mmp.LazyBitVectorPickWithThreshold(fps,len(fps),20,-1.0)
+    self.assertEqual(list(ids),[374,720,690,339,875,842,404,725,120,385,115,868,630,\
+                          881,516,497,412,718,869,407])
 
+    self.assertAlmostEqual(threshold,0.8977,4)
+
+    ids,threshold=mmp.LazyBitVectorPickWithThreshold(fps,len(fps),20,0.91)
+    self.assertEqual(list(ids),[374,720,690,339,875,842,404,725,120,385,115,868,630])
+    self.assertTrue(threshold>=0.91)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This is used to either set or return a threshold for the picks.
It allows retrieval of the distance of the last item picked from its nearest neighbor as well as specification of a minimum value this should be.

@bp-kelley : I'm struggling a bit with how to expose this extra arg that's used to return a value on the Python side without breaking the existing python API. Any thoughts?