### PR TITLE
Fixes Java wrapper build error with Boost 1.64

### DIFF
--- a/Code/JavaWrappers/gmwrapper/GraphMolJava.i
+++ b/Code/JavaWrappers/gmwrapper/GraphMolJava.i
@@ -62,6 +62,7 @@
 // The actual definition isn't in the top level hpp file!
 // The next two lines are to work around a problem caused by the fact that older versions of
 // SWIG don't work with newer versions of boost.
+#define BOOST_SP_NOEXCEPT
 #define BOOST_NOEXCEPT
 #define BOOST_NO_CXX11_RVALUE_REFERENCES
 #define BOOST_NO_CXX11_NULLPTR


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! 
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.
I was getting the following error while trying to build Java wrappers on Windows with VS2017 and Boost 1.64:
`C:/boost/boost_1_64_0/boost/smart_ptr/shared_array.hpp:57: Error: Syntax error in input(3).`
The reason is that the `BOOST_SP_NOEXCEPT` macro is not defined when `shared_array.hpp` is included by SWIG. The fix is to add a definition for `BOOST_SP_NOEXCEPT` in `GraphMolJava.i` to those already present.

#### Any other comments?

