### PR TITLE
Remove history in comment

### DIFF
--- a/rdkit/Chem/QED.py
+++ b/rdkit/Chem/QED.py
@@ -49,9 +49,6 @@ are very small and are not compromising the usefulness of using Qed in your dail
     'Quantifying the chemical beauty of drugs',
     Nature Chemistry, 4, 90-98 [http://dx.doi.org/10.1038/nchem.1243]
 
-History:
-  2012-04 Adapted to internal RDkit implementation
-  2013-05 moved to rdkit.Chem.QED
 """
 from collections import namedtuple
 import math


### PR DESCRIPTION
#### Reference Issue
User reported that he's not able to import QED. Had the impression that due to the history information, the code should have been in earlier versions of RDkit #1611 

#### What does this implement/fix? Explain your changes.
RDKit doesn't document change history in comment. Removing this, will reduce confusion. In addition, the history is so not up to date, that it is useless anyway.

#### Any other comments?

