### PR TITLE
This makes assignStereochemistry cleanIt=True not remove CIS/TRANS

### DIFF
--- a/Code/GraphMol/Chirality.cpp
+++ b/Code/GraphMol/Chirality.cpp
@@ -1006,6 +1006,9 @@ void assignStereochemistry(ROMol &mol, bool cleanIt, bool force,
       if ((*bondIt)->getBondType() == Bond::DOUBLE) {
         if ((*bondIt)->getBondDir() == Bond::EITHERDOUBLE) {
           (*bondIt)->setStereo(Bond::STEREOANY);
+        } else if ((*bondIt)->getStereo() == Bond::STEREOCIS ||
+                   (*bondIt)->getStereo() == Bond::STEREOTRANS) {
+          hasStereoBonds = true;
         } else if ((*bondIt)->getStereo() != Bond::STEREOANY) {
           (*bondIt)->setStereo(Bond::STEREONONE);
           (*bondIt)->getStereoAtoms().clear();
@@ -1032,6 +1035,10 @@ void assignStereochemistry(ROMol &mol, bool cleanIt, bool force,
           hasStereoBonds = true;
         }
       }
+    }
+    if (!cleanIt && hasStereoBonds) {
+      break; // no reason to keep iterating if we've already
+             // determined there are stereo bonds to consider
     }
   }
   UINT_VECT atomRanks;
@@ -1068,6 +1075,10 @@ void assignStereochemistry(ROMol &mol, bool cleanIt, bool force,
   }
 
   if (cleanIt) {
+    // if the ranks are needed again, this will force them to be
+    // re-calculated based on the stereo calculated above.
+    atomRanks.clear();
+
     for (ROMol::AtomIterator atIt = mol.beginAtoms(); atIt != mol.endAtoms();
          ++atIt) {
       if ((*atIt)->hasProp(common_properties::_ringStereochemCand))
@@ -1083,14 +1094,9 @@ void assignStereochemistry(ROMol &mol, bool cleanIt, bool force,
       Atom *atom = *atIt;
       if (atom->getChiralTag() != Atom::CHI_UNSPECIFIED &&
           !atom->hasProp(common_properties::_CIPCode) &&
-          (possibleSpecialCases[atom->getIdx()] ||
-           atom->hasProp(common_properties::_ringStereoAtoms))) {
-      }
-
-      if (atom->getChiralTag() != Atom::CHI_UNSPECIFIED &&
-          !atom->hasProp(common_properties::_CIPCode) &&
           (!possibleSpecialCases[atom->getIdx()] ||
            !atom->hasProp(common_properties::_ringStereoAtoms))) {
+
         atom->setChiralTag(Atom::CHI_UNSPECIFIED);
 
         // If the atom has an explicit hydrogen and no charge, that H
@@ -1115,6 +1121,36 @@ void assignStereochemistry(ROMol &mol, bool cleanIt, bool force,
           (*bondIt)->getBeginAtom()->getChiralTag() == Atom::CHI_UNSPECIFIED &&
           (*bondIt)->getEndAtom()->getChiralTag() == Atom::CHI_UNSPECIFIED) {
         (*bondIt)->setBondDir(Bond::NONE);
+      }
+
+      // make sure CIS/TRANS assignments are actually stereo bonds
+      if ((*bondIt)->getBondType() == Bond::DOUBLE) {
+        if ((*bondIt)->getStereo() == Bond::STEREOCIS ||
+            (*bondIt)->getStereo() == Bond::STEREOTRANS) {
+
+          if (!atomRanks.size()) {
+            Chirality::assignAtomCIPRanks(mol, atomRanks);
+          }
+
+          const Atom *begAtom = (*bondIt)->getBeginAtom(),
+                     *endAtom = (*bondIt)->getEndAtom();
+          UINT_VECT begAtomNeighbors, endAtomNeighbors;
+          Chirality::findAtomNeighborsHelper(mol, begAtom, *bondIt,
+                                             begAtomNeighbors);
+          Chirality::findAtomNeighborsHelper(mol, endAtom, *bondIt,
+                                             endAtomNeighbors);
+
+          // Note, this relies on this being a hydrogen-suppressed
+          // graph as the 'Note' in the doc string of this function
+          // indicates is a pre-condition.
+          if ((begAtomNeighbors.size() == 2 &&
+               atomRanks[begAtomNeighbors[0]] == atomRanks[begAtomNeighbors[1]]) ||
+              (endAtomNeighbors.size() == 2 &&
+               atomRanks[endAtomNeighbors[0]] == atomRanks[endAtomNeighbors[1]])) {
+            (*bondIt)->setStereo(Bond::STEREONONE);
+            (*bondIt)->getStereoAtoms().clear();
+          }
+        }
       }
     }
   }

--- a/Code/GraphMol/MolOps.h
+++ b/Code/GraphMol/MolOps.h
@@ -820,11 +820,19 @@ void detectBondStereochemistry(ROMol &mol, int confId = -1);
 
 //! Assign stereochemistry tags to atoms (i.e. R/S) and bonds (i.e. Z/E)
 /*!
+  Does the CIP stereochemistry assignment for the molecule's atoms
+  (R/S) and double bond (Z/E). Chiral atoms will have a property
+  '_CIPCode' indicating their chiral code.
 
-  \param mol     the molecule of interest
-  \param cleanIt toggles removal of stereo flags from double bonds that can
-                 not have stereochemistry
-  \param force   forces the calculation to be repeated even if it has
+  \param mol     the molecule to use
+  \param cleanIt whether atoms with a chiral specifier that aren't
+                 actually chiral (e.g. atoms with duplicate
+                 substituents or only 2 substituents, etc.) will have
+                 their chiral code set to CHI_UNSPECIFIED. Bonds with
+                 STEREOCIS/STEREOTRANS specified that have duplicate
+                 substituents based upon the CIP atom ranks will be
+                 marked STEREONONE.
+  \param force   causes the calculation to be repeated even if it has
                  already been done
   \param flagPossibleStereoCenters   set the _ChiralityPossible property on
                                      atoms that are possible stereocenters

--- a/Code/GraphMol/Wrap/MolOps.cpp
+++ b/Code/GraphMol/Wrap/MolOps.cpp
@@ -1505,7 +1505,9 @@ struct molops_wrapper {
     - mol: the molecule to use\n\
     - cleanIt: (optional) if provided, atoms with a chiral specifier that aren't\n\
       actually chiral (e.g. atoms with duplicate substituents or only 2 substituents,\n\
-      etc.) will have their chiral code set to CHI_UNSPECIFIED\n\
+      etc.) will have their chiral code set to CHI_UNSPECIFIED. Bonds with \n\
+      STEREOCIS/STEREOTRANS specified that have duplicate substituents based upon the CIP \n\
+      atom ranks will be marked STEREONONE. \n\
     - force: (optional) causes the calculation to be repeated, even if it has already\n\
       been done\n\
     - flagPossibleStereoCenters (optional)   set the _ChiralityPossible property on\n\

--- a/Code/JavaWrappers/RDKFuncs_doc.i
+++ b/Code/JavaWrappers/RDKFuncs_doc.i
@@ -94,11 +94,21 @@ public";
 <p>
 Assign stereochemistry tags to atoms (i.e. R/S) and bonds (i.e. Z/E).
 <p>
+Does the CIP stereochemistry assignment for the molecule's atoms
+(R/S) and double bond (Z/E). Chiral atoms will have a property
+'_CIPCode' indicating their chiral code.
 <p>
 @param
-mol 	the molecule of interest
-cleanIt 	toggles removal of stereo flags from double bonds that can not have stereochemistry
-force 	forces the calculation to be repeated even if it has already been done
+mol     the molecule to use
+cleanIt whether atoms with a chiral specifier that aren't
+        actually chiral (e.g. atoms with duplicate
+        substituents or only 2 substituents, etc.) will have
+        their chiral code set to CHI_UNSPECIFIED. Bonds with
+        STEREOCIS/STEREOTRANS specified that have duplicate
+        substituents based upon the CIP atom ranks will be
+        marked STEREONONE.
+force   causes the calculation to be repeated even if it has
+        already been done
 <p>
 @notes
 <li>Throughout we assume that we're working with a hydrogen-suppressed graph.


### PR DESCRIPTION
#### Reference Issue

issue #1614

#### What does this implement/fix? Explain your changes.

This makes assignStereochemistry cleanIt=True not remove CIS/TRANS
bond stereo chemistry that was manually added as described in .

Incorrect CIS/TRANS stereochemistry will still be removed by
'cleanIt=true' if symmetry is detected. However, this symmetry
detection doesn't work in more complex pseudo-stereo chemistry cases:
bond stereo that depends on other bond stereo to break symmetry; and
bond stereo that depends on other atom stereo centers to break
symmetry. Test cases for these cases have been added ifdef'd in based
on USE_NEW_STEREOCHEMISTRY.

However, getting USE_NEW_STEREOCHEMISTRY to work in a copacetic way is
not trivial, I tried a little bit here to no avail. I'm leaving the
test cases checked in as they should be useful when we decide to make
the plunge into using Canon::chiralRankMolAtoms for symmetry detection
instead of the CIP ranks.

So this fixes at least the glaring issue of STEREOCIS and STEREOTRANS
being incorrectly removed by 'cleanIt=true' when it is indeed valid
stereo. The checks made for symmetry are rudimentary, but don't feel
complete.

#### Any other comments?

Unsure about this one a bit. On one hand, blowing away STEREOCIS and STEREOTRANS that the user has explicitly set feels really bad. On the other hand, perhaps this function should be renamed assignCIPStereochemistry, and make it only deal with STEREOE and STEREOZ. Then perhaps we should have a new API that traffics in STEREOCIS and STEREOTRANS using the new canonicalization?