### PR TITLE
Enable windows build that uses cairo

### DIFF
--- a/Code/GraphMol/MolDraw2D/Wrap/CMakeLists.txt
+++ b/Code/GraphMol/MolDraw2D/Wrap/CMakeLists.txt
@@ -2,7 +2,7 @@ rdkit_python_extension(rdMolDraw2D
                        rdMolDraw2D.cpp
                        DEST Chem/Draw
                        LINK_LIBRARIES MolDraw2D
-Depictor FileParsers SubstructMatch MolTransforms GraphMol
+Depictor ChemReactions FileParsers SubstructMatch MolTransforms GraphMol
 DataStructs EigenSolvers RDGeometryLib RDGeneral RDBoost ${EXTRA_LOCAL_LIBS})
 
 add_pytest(pyMolDraw2D ${CMAKE_CURRENT_SOURCE_DIR}/testMolDraw2D.py)

--- a/Code/GraphMol/MolDraw2D/Wrap/CMakeLists.txt
+++ b/Code/GraphMol/MolDraw2D/Wrap/CMakeLists.txt
@@ -2,7 +2,7 @@ rdkit_python_extension(rdMolDraw2D
                        rdMolDraw2D.cpp
                        DEST Chem/Draw
                        LINK_LIBRARIES MolDraw2D
-Depictor ChemReactions FileParsers SubstructMatch MolTransforms GraphMol
+Depictor ChemReactions SmilesParse FileParsers SubstructMatch MolTransforms GraphMol
 DataStructs EigenSolvers RDGeometryLib RDGeneral RDBoost ${EXTRA_LOCAL_LIBS})
 
 add_pytest(pyMolDraw2D ${CMAKE_CURRENT_SOURCE_DIR}/testMolDraw2D.py)

--- a/Code/GraphMol/MolDraw2D/Wrap/CMakeLists.txt
+++ b/Code/GraphMol/MolDraw2D/Wrap/CMakeLists.txt
@@ -1,8 +1,8 @@
 rdkit_python_extension(rdMolDraw2D
                        rdMolDraw2D.cpp
                        DEST Chem/Draw
-                       LINK_LIBRARIES ChemReactions MolDraw2D
-Depictor FileParsers SmilesParse SubstructMatch MolTransforms GraphMol
-DataStructs EigenSolvers RDGeometryLib RDGeneral RDBoost)
+                       LINK_LIBRARIES MolDraw2D
+Depictor FileParsers SubstructMatch MolTransforms GraphMol
+DataStructs EigenSolvers RDGeometryLib RDGeneral RDBoost ${EXTRA_LOCAL_LIBS})
 
 add_pytest(pyMolDraw2D ${CMAKE_CURRENT_SOURCE_DIR}/testMolDraw2D.py)


### PR DESCRIPTION
This links in additional libraries to make things work

With the code at this state I can do a conda build that includes cairo support, which is a big win on the Windows side.

