### PR TITLE
Fixing bug in IPythonConsole SVG rendering introduced in 1027d4469545653180fff9a38dc8224bd50e8b0d

### DIFF
--- a/rdkit/Chem/Draw/IPythonConsole.py
+++ b/rdkit/Chem/Draw/IPythonConsole.py
@@ -112,6 +112,7 @@ def _toSVG(mol):
     highlightAtoms = mol.__sssAtoms
   else:
     highlightAtoms = []
+  kekulize=kekulizeStructures
   return Draw._moltoSVG(mol,molSize,highlightAtoms,"",kekulize)
 
 


### PR DESCRIPTION
#### Reference Issue
SVG rendering in IPythonConsole is broken. 

#### What does this implement/fix? Explain your changes.
Quick hot fix to get it working again.

#### Any other comments?
Not sure the best way to unit test this internal API. 
