### PR TITLE
Improve AddHs for molecules read from PDB

### DIFF
--- a/Code/GraphMol/AddHs.cpp
+++ b/Code/GraphMol/AddHs.cpp
@@ -399,7 +399,7 @@ void AssignHsResidueInfo(RWMol &mol) {
 namespace MolOps {
 
 void addHs(RWMol &mol, bool explicitOnly, bool addCoords,
-           const UINT_VECT *onlyOnAtoms, bool residueInfo) {
+           const UINT_VECT *onlyOnAtoms, bool addResidueInfo) {
   // when we hit each atom, clear its computed properties
   // NOTE: it is essential that we not clear the ring info in the
   // molecule's computed properties.  We don't want to have to
@@ -473,13 +473,13 @@ void addHs(RWMol &mol, bool explicitOnly, bool addCoords,
     newAt->updatePropertyCache();
   }
   // take care of AtomPDBResidueInfo for Hs if root atom has it
-  if (residueInfo) AssignHsResidueInfo(mol);
+  if (addResidueInfo) AssignHsResidueInfo(mol);
 }
 
 ROMol *addHs(const ROMol &mol, bool explicitOnly, bool addCoords,
-             const UINT_VECT *onlyOnAtoms, bool residueInfo) {
+             const UINT_VECT *onlyOnAtoms, bool addResidueInfo) {
   RWMol *res = new RWMol(mol);
-  addHs(*res, explicitOnly, addCoords, onlyOnAtoms, residueInfo);
+  addHs(*res, explicitOnly, addCoords, onlyOnAtoms, addResidueInfo);
   return static_cast<ROMol *>(res);
 };
 

--- a/Code/GraphMol/AddHs.cpp
+++ b/Code/GraphMol/AddHs.cpp
@@ -438,7 +438,7 @@ void addHs(RWMol &mol, bool explicitOnly, bool addCoords,
             current_info = info;
           }
 
-          AtomPDBResidueInfo *newInfo = new AtomPDBResidueInfo(" H  ", newIdx, "", info->getResidueName(),
+          AtomPDBResidueInfo *newInfo = new AtomPDBResidueInfo(" H  ", max_serial, "", info->getResidueName(),
                                                                info->getResidueNumber(), info->getChainId(), "",
                                                                info->getIsHeteroAtom());
           mol.getAtomWithIdx(*begin)->setMonomerInfo(newInfo);

--- a/Code/GraphMol/AddHs.cpp
+++ b/Code/GraphMol/AddHs.cpp
@@ -336,7 +336,7 @@ void setHydrogenCoords(ROMol *mol, unsigned int hydIdx, unsigned int heavyIdx) {
   }
 }
 
-void AssignHsPDBInfo(RWMol &mol) {
+void AssignHsResidueInfo(RWMol &mol) {
 
   int max_serial = 0;
   unsigned int stopIdx = mol.getNumAtoms();
@@ -399,7 +399,7 @@ void AssignHsPDBInfo(RWMol &mol) {
 namespace MolOps {
 
 void addHs(RWMol &mol, bool explicitOnly, bool addCoords,
-           const UINT_VECT *onlyOnAtoms) {
+           const UINT_VECT *onlyOnAtoms, bool residueInfo) {
   // when we hit each atom, clear its computed properties
   // NOTE: it is essential that we not clear the ring info in the
   // molecule's computed properties.  We don't want to have to
@@ -473,13 +473,13 @@ void addHs(RWMol &mol, bool explicitOnly, bool addCoords,
     newAt->updatePropertyCache();
   }
   // take care of AtomPDBResidueInfo for Hs if root atom has it
-  AssignHsPDBInfo(mol);
+  if (residueInfo) AssignHsResidueInfo(mol);
 }
 
 ROMol *addHs(const ROMol &mol, bool explicitOnly, bool addCoords,
-             const UINT_VECT *onlyOnAtoms) {
+             const UINT_VECT *onlyOnAtoms, bool residueInfo) {
   RWMol *res = new RWMol(mol);
-  addHs(*res, explicitOnly, addCoords, onlyOnAtoms);
+  addHs(*res, explicitOnly, addCoords, onlyOnAtoms, residueInfo);
   return static_cast<ROMol *>(res);
 };
 

--- a/Code/GraphMol/AddHs.cpp
+++ b/Code/GraphMol/AddHs.cpp
@@ -11,6 +11,7 @@
 #include <list>
 #include "QueryAtom.h"
 #include "QueryOps.h"
+#include "MonomerInfo.h"
 #include <Geometry/Transform3D.h>
 #include <Geometry/point.h>
 #include <boost/foreach.hpp>
@@ -386,6 +387,13 @@ void addHs(RWMol &mol, bool explicitOnly, bool addCoords,
       mol.addBond(aidx, newIdx, Bond::SINGLE);
       mol.getAtomWithIdx(newIdx)->updatePropertyCache();
       if (addCoords) setHydrogenCoords(&mol, newIdx, aidx);
+      AtomPDBResidueInfo *info = (AtomPDBResidueInfo *)(newAt->getMonomerInfo());
+      if (info && info->getMonomerType() == AtomMonomerInfo::PDBRESIDUE) {
+        AtomPDBResidueInfo *newInfo = new AtomPDBResidueInfo(" H  ", newIdx, "", info->getResidueName(),
+                                                             info->getResidueNumber(), info->getChainId(), "",
+                                                             info->getIsHeteroAtom());
+        mol.getAtomWithIdx(newIdx)->setMonomerInfo(newInfo);
+      }
     }
     // clear the local property
     newAt->setNumExplicitHs(0);
@@ -401,6 +409,14 @@ void addHs(RWMol &mol, bool explicitOnly, bool addCoords,
         mol.getAtomWithIdx(newIdx)->setProp(common_properties::isImplicit, 1);
         mol.getAtomWithIdx(newIdx)->updatePropertyCache();
         if (addCoords) setHydrogenCoords(&mol, newIdx, aidx);
+        // add PDBResidueInfo if root atom has it
+        AtomPDBResidueInfo *info = (AtomPDBResidueInfo *)(newAt->getMonomerInfo());
+        if (info && info->getMonomerType() == AtomMonomerInfo::PDBRESIDUE) {
+            AtomPDBResidueInfo *newInfo = new AtomPDBResidueInfo(" H  ", newIdx, "", info->getResidueName(),
+                                                                 info->getResidueNumber(), info->getChainId(), "",
+                                                                 info->getIsHeteroAtom());
+            mol.getAtomWithIdx(newIdx)->setMonomerInfo(newInfo);
+        }
       }
       // be very clear about implicits not being allowed in this representation
       newAt->setProp(common_properties::origNoImplicit, newAt->getNoImplicit(),

--- a/Code/GraphMol/FileParsers/test1.cpp
+++ b/Code/GraphMol/FileParsers/test1.cpp
@@ -3750,7 +3750,7 @@ void testPDBFile() {
     ROMol *nm = MolOps::addHs(*m);
     AtomPDBResidueInfo *info = (AtomPDBResidueInfo *)(nm->getAtomWithIdx(nm->getNumAtoms()-1)->getMonomerInfo());
     TEST_ASSERT(info->getMonomerType() == AtomMonomerInfo::PDBRESIDUE);
-    TEST_ASSERT(info->getName() == " H  ");
+    TEST_ASSERT(info->getName() == " H1 ");
     TEST_ASSERT(info->getResidueName() == "ASN");
   }
 

--- a/Code/GraphMol/FileParsers/test1.cpp
+++ b/Code/GraphMol/FileParsers/test1.cpp
@@ -3745,6 +3745,13 @@ void testPDBFile() {
     TEST_ASSERT(feq(m->getConformer().getAtomPos(0).x, 17.047));
     TEST_ASSERT(feq(m->getConformer().getAtomPos(0).y, 14.099));
     TEST_ASSERT(feq(m->getConformer().getAtomPos(0).z, 3.625));
+
+    // test adding hydrogens
+    ROMol *nm = MolOps::addHs(*m);
+    AtomPDBResidueInfo *info = (AtomPDBResidueInfo *)(nm->getAtomWithIdx(nm->getNumAtoms()-1)->getMonomerInfo());
+    TEST_ASSERT(info->getMonomerType() == AtomMonomerInfo::PDBRESIDUE);
+    TEST_ASSERT(info->getName() == " H  ");
+    TEST_ASSERT(info->getResidueName() == "ASN");
   }
 
   {

--- a/Code/GraphMol/FileParsers/test1.cpp
+++ b/Code/GraphMol/FileParsers/test1.cpp
@@ -3750,7 +3750,7 @@ void testPDBFile() {
     ROMol *nm = MolOps::addHs(*m);
     AtomPDBResidueInfo *info = (AtomPDBResidueInfo *)(nm->getAtomWithIdx(nm->getNumAtoms()-1)->getMonomerInfo());
     TEST_ASSERT(info->getMonomerType() == AtomMonomerInfo::PDBRESIDUE);
-    TEST_ASSERT(info->getName() == " H1 ");
+    TEST_ASSERT(info->getName() == " H7 ");
     TEST_ASSERT(info->getResidueName() == "ASN");
   }
 

--- a/Code/GraphMol/FileParsers/test1.cpp
+++ b/Code/GraphMol/FileParsers/test1.cpp
@@ -3747,7 +3747,7 @@ void testPDBFile() {
     TEST_ASSERT(feq(m->getConformer().getAtomPos(0).z, 3.625));
 
     // test adding hydrogens
-    ROMol *nm = MolOps::addHs(*m);
+    ROMol *nm = MolOps::addHs(*m, false, false, NULL, true);
     AtomPDBResidueInfo *info = (AtomPDBResidueInfo *)(nm->getAtomWithIdx(nm->getNumAtoms()-1)->getMonomerInfo());
     TEST_ASSERT(info->getMonomerType() == AtomMonomerInfo::PDBRESIDUE);
     TEST_ASSERT(info->getName() == " H7 ");

--- a/Code/GraphMol/MolOps.h
+++ b/Code/GraphMol/MolOps.h
@@ -163,7 +163,7 @@ double computeBalabanJ(double *distMat, int nb, int nAts);
                 of the added Hs will be used.
     \param onlyOnAtoms   (optional) if provided, this should be a vector of
                 IDs of the atoms that will be considered for H addition.
-    \param residueInfo   (optional) if this is true, add residue info to
+    \param addResidueInfo   (optional) if this is true, add residue info to
                 hydrogen atoms (useful for PDB files).
 
     \return the new molecule
@@ -177,11 +177,11 @@ double computeBalabanJ(double *distMat, int nb, int nAts);
  */
 ROMol *addHs(const ROMol &mol, bool explicitOnly = false,
              bool addCoords = false, const UINT_VECT *onlyOnAtoms = NULL,
-             bool residueInfo = false);
+             bool addResidueInfo = false);
 //! \overload
 // modifies the molecule in place
 void addHs(RWMol &mol, bool explicitOnly = false, bool addCoords = false,
-           const UINT_VECT *onlyOnAtoms = NULL, bool residueInfo = false);
+           const UINT_VECT *onlyOnAtoms = NULL, bool addResidueInfo = false);
 
 //! returns a copy of a molecule with hydrogens removed
 /*!

--- a/Code/GraphMol/MolOps.h
+++ b/Code/GraphMol/MolOps.h
@@ -163,6 +163,8 @@ double computeBalabanJ(double *distMat, int nb, int nAts);
                 of the added Hs will be used.
     \param onlyOnAtoms   (optional) if provided, this should be a vector of
                 IDs of the atoms that will be considered for H addition.
+    \param residueInfo   (optional) if this is true, add residue info to
+                hydrogen atoms (useful for PDB files).
 
     \return the new molecule
 
@@ -174,11 +176,12 @@ double computeBalabanJ(double *distMat, int nb, int nAts);
    returns.
  */
 ROMol *addHs(const ROMol &mol, bool explicitOnly = false,
-             bool addCoords = false, const UINT_VECT *onlyOnAtoms = NULL);
+             bool addCoords = false, const UINT_VECT *onlyOnAtoms = NULL,
+             bool residueInfo = false);
 //! \overload
 // modifies the molecule in place
 void addHs(RWMol &mol, bool explicitOnly = false, bool addCoords = false,
-           const UINT_VECT *onlyOnAtoms = NULL);
+           const UINT_VECT *onlyOnAtoms = NULL, bool residueInfo = false);
 
 //! returns a copy of a molecule with hydrogens removed
 /*!

--- a/Code/GraphMol/Wrap/MolOps.cpp
+++ b/Code/GraphMol/Wrap/MolOps.cpp
@@ -301,12 +301,12 @@ void addRecursiveQueriesHelper(ROMol &mol, python::dict replDict,
 }
 
 ROMol *addHs(const ROMol &orig, bool explicitOnly, bool addCoords,
-             python::object onlyOnAtoms, bool residueInfo) {
+             python::object onlyOnAtoms, bool addResidueInfo) {
   rdk_auto_ptr<std::vector<unsigned int> > onlyOn;
   if (onlyOnAtoms) {
     onlyOn = pythonObjectToVect(onlyOnAtoms, orig.getNumAtoms());
   }
-  ROMol *res = MolOps::addHs(orig, explicitOnly, addCoords, onlyOn.get(), residueInfo);
+  ROMol *res = MolOps::addHs(orig, explicitOnly, addCoords, onlyOn.get(), addResidueInfo);
   return res;
 }
 int getSSSR(ROMol &mol) {
@@ -934,7 +934,7 @@ struct molops_wrapper {
     - onlyOnAtoms: (optional) if this sequence is provided, only these atoms will be\n\
       considered to have Hs added to them\n\
 \n\
-    - residueInfo: (optional) if this is true, add residue info to\n\
+    - addResidueInfo: (optional) if this is true, add residue info to\n\
       hydrogen atoms (useful for PDB files).\n\
 \n\
   RETURNS: a new molecule with added Hs\n\
@@ -951,7 +951,7 @@ struct molops_wrapper {
                 (python::arg("mol"), python::arg("explicitOnly") = false,
                  python::arg("addCoords") = false,
                  python::arg("onlyOnAtoms") = python::object(),
-                 python::arg("residueInfo") = false),
+                 python::arg("addResidueInfo") = false),
                 docString.c_str(),
                 python::return_value_policy<python::manage_new_object>());
 

--- a/Code/GraphMol/Wrap/MolOps.cpp
+++ b/Code/GraphMol/Wrap/MolOps.cpp
@@ -301,12 +301,12 @@ void addRecursiveQueriesHelper(ROMol &mol, python::dict replDict,
 }
 
 ROMol *addHs(const ROMol &orig, bool explicitOnly, bool addCoords,
-             python::object onlyOnAtoms) {
+             python::object onlyOnAtoms, bool residueInfo) {
   rdk_auto_ptr<std::vector<unsigned int> > onlyOn;
   if (onlyOnAtoms) {
     onlyOn = pythonObjectToVect(onlyOnAtoms, orig.getNumAtoms());
   }
-  ROMol *res = MolOps::addHs(orig, explicitOnly, addCoords, onlyOn.get());
+  ROMol *res = MolOps::addHs(orig, explicitOnly, addCoords, onlyOn.get(), residueInfo);
   return res;
 }
 int getSSSR(ROMol &mol) {
@@ -931,8 +931,11 @@ struct molops_wrapper {
     - addCoords: (optional) if this toggle is set, The Hs will have 3D coordinates\n\
       set.  Default value is 0 (no 3D coords).\n\
 \n\
-    - onlyOnHs: (optional) if this sequence is provided, only these atoms will be\n\
+    - onlyOnAtoms: (optional) if this sequence is provided, only these atoms will be\n\
       considered to have Hs added to them\n\
+\n\
+    - residueInfo: (optional) if this is true, add residue info to\n\
+      hydrogen atoms (useful for PDB files).\n\
 \n\
   RETURNS: a new molecule with added Hs\n\
 \n\
@@ -947,7 +950,8 @@ struct molops_wrapper {
     python::def("AddHs", addHs,
                 (python::arg("mol"), python::arg("explicitOnly") = false,
                  python::arg("addCoords") = false,
-                 python::arg("onlyOnAtoms") = python::object()),
+                 python::arg("onlyOnAtoms") = python::object(),
+                 python::arg("residueInfo") = false),
                 docString.c_str(),
                 python::return_value_policy<python::manage_new_object>());
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! 
-->
#### What does this implement/fix? Explain your changes.
This PR fixes behavior of AddHs for molecules read from PDB file. Current behavior is to ignore residue information. What's more, the Hs written to PDB file are always HETATM and of UNL residue.

Proposed changes add AtomPDBResidueInfo based on the information collected from the root atom.
I decided against adding a flag, since it doesn't break default behavior and is kind of expected when working with proteins. 
