### PR TITLE
added Scripts/create_deb_packages.sh

### DIFF
--- a/Scripts/create_deb_packages.sh
+++ b/Scripts/create_deb_packages.sh
@@ -6,10 +6,29 @@
 
 mkdir -p build
 cd build
-cmake -DRDK_INSTALL_INTREE=OFF -DCMAKE_INSTALL_PREFIX=/usr ../
+cmake -Wno-dev \
+    -DRDK_INSTALL_INTREE=OFF \
+    -DRDK_BUILD_INCHI_SUPPORT=ON \
+    -DRDK_BUILD_AVALON_SUPPORT=ON \
+    -DRDK_BUILD_PYTHON_WRAPPERS=ON \
+    -DCMAKE_INSTALL_PREFIX=/usr \
+    -DRDKit_VERSION=`date +%Y.%m` \
+    ../
 nprocs=`getconf _NPROCESSORS_ONLN`
 make -j $nprocs
 cpack -G DEB
 
-# # to install them
+# # to install all the necessary dependencies
+# sudo apt-get install \
+#      fonts-freefont-ttf \
+#      libboost-python1.58.0 \
+#      libboost-regex1.58.0 \
+#      libboost-system1.58.0 \
+#      libboost-thread1.58.0 \
+#      libc6 \
+#      libgcc1 \
+#      libpython2.7 \
+#      libstdc++6 \
+#      python
+# # to install the freshly built rdkit packages
 # sudo dpkg -i *.deb

--- a/Scripts/create_deb_packages.sh
+++ b/Scripts/create_deb_packages.sh
@@ -18,16 +18,21 @@ make -j $nprocs
 cpack -G DEB
 
 # # to install all necessary dependencies on Ubuntu
-# sudo apt-get install \
-#      fonts-freefont-ttf \
-#      libboost-python1.58.0 \
-#      libboost-regex1.58.0 \
-#      libboost-system1.58.0 \
-#      libboost-thread1.58.0 \
-#      libc6 \
-#      libgcc1 \
-#      libpython2.7 \
-#      libstdc++6 \
-#      python
+#sudo apt install -y \
+#  curl \
+#  wget \
+#  libboost-all-dev \
+#  cmake \
+#  git \
+#  g++ \
+#  libeigen3-dev \
+#  python3 \
+#  libpython3-all-dev \
+#  python3-numpy \
+#  python3-pip \
+#  python3-pil \
+#  python3-six \
+#  python3-pandas
+
 # # to install the freshly built rdkit packages
 # sudo dpkg -i *.deb

--- a/Scripts/create_deb_packages.sh
+++ b/Scripts/create_deb_packages.sh
@@ -12,7 +12,6 @@ cmake -Wno-dev \
     -DRDK_BUILD_AVALON_SUPPORT=ON \
     -DRDK_BUILD_PYTHON_WRAPPERS=ON \
     -DCMAKE_INSTALL_PREFIX=/usr \
-    -DRDKit_VERSION=`date +%Y.%m` \
     ../
 nprocs=`getconf _NPROCESSORS_ONLN`
 make -j $nprocs

--- a/Scripts/create_deb_packages.sh
+++ b/Scripts/create_deb_packages.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# create *.deb packages for Ubuntu
+
+#set -x # DEBUG
+
+mkdir -p build
+cd build
+cmake -DRDK_INSTALL_INTREE=OFF -DCMAKE_INSTALL_PREFIX=/usr ../
+nprocs=`getconf _NPROCESSORS_ONLN`
+make -j $nprocs
+cpack -G DEB
+
+# # to install them
+# sudo dpkg -i *.deb

--- a/Scripts/create_deb_packages.sh
+++ b/Scripts/create_deb_packages.sh
@@ -6,7 +6,7 @@
 
 mkdir -p build
 cd build
-cmake -Wno-dev \
+cmake \
     -DRDK_INSTALL_INTREE=OFF \
     -DRDK_BUILD_INCHI_SUPPORT=ON \
     -DRDK_BUILD_AVALON_SUPPORT=ON \

--- a/Scripts/create_deb_packages.sh
+++ b/Scripts/create_deb_packages.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# create *.deb packages for Ubuntu
+# create binary *.deb packages
 
 #set -x # DEBUG
 

--- a/Scripts/create_deb_packages.sh
+++ b/Scripts/create_deb_packages.sh
@@ -17,7 +17,7 @@ nprocs=`getconf _NPROCESSORS_ONLN`
 make -j $nprocs
 cpack -G DEB
 
-# # to install all the necessary dependencies
+# # to install all necessary dependencies on Ubuntu
 # sudo apt-get install \
 #      fonts-freefont-ttf \
 #      libboost-python1.58.0 \


### PR DESCRIPTION
#### Reference Issue
related to https://github.com/rdkit/rdkit/issues/911 and https://github.com/rdkit/rdkit/pull/1580

#### What does this implement/fix? Explain your changes.
A ready to use script so that people can easily generate binary deb packages
from the source tree.

#### Any other comments?
This will ease the Ubuntu PPA maintainance and make sure that people can easily
check the working condition and relevance of the cpack rules related to deb packages.
