### PR TITLE
Treat bonds in PDB CONECT records explicitly, but make blacklisted ones zero-order.

### DIFF
--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -3062,12 +3062,19 @@ CAS<~>
     mol = Chem.MolFromPDBFile(fileN, sanitize=False, removeHs=False)
     atom = mol.GetAtomWithIdx(40)
     self.assertEqual(atom.GetAtomicNum(), 30)  # is it Zn
-    self.assertEqual(atom.GetDegree(), 0)  # Zn should have no bonds
+    self.assertEqual(atom.GetDegree(), 4)  # Zn should have 4 zero-order bonds
+    self.assertEqual(atom.GetExplicitValence(), 0)
+    bonds_order = [bond.GetBondType() for bond in atom.GetBonds()]
+    self.assertEqual(bonds_order, [Chem.BondType.ZERO] * atom.GetDegree())
+
     # test metal bonds without proximity bonding
     mol = Chem.MolFromPDBFile(fileN, sanitize=False, removeHs=False, proximityBonding=False)
     atom = mol.GetAtomWithIdx(40)
     self.assertEqual(atom.GetAtomicNum(), 30)  # is it Zn
-    self.assertEqual(atom.GetDegree(), 0)  # Zn should have no bonds
+    self.assertEqual(atom.GetDegree(), 4)  # Zn should have 4 zero-order bonds
+    self.assertEqual(atom.GetExplicitValence(), 0)
+    bonds_order = [bond.GetBondType() for bond in atom.GetBonds()]
+    self.assertEqual(bonds_order, [Chem.BondType.ZERO] * atom.GetDegree())
     # test unbinding HOHs
     fileN = os.path.join(RDConfig.RDBaseDir, 'Code', 'GraphMol', 'FileParsers', 'test_data',
                          '2vnf_bindedHOH.pdb')


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
This is small addition to #1629, which treats the bonds in PDB file as explicit. If they are made between blacklisted pair of atoms (waters, anions, noble gases, metaloids or metals) they are made zero-order. This is very in line with the [original publication by Alex Clark](http://pubs.acs.org/doi/abs/10.1021/ci200488k), which introduced the zero-order bonds. If someone wanted these bonds removed, then appropriate `flavor` flag will ignore PDB CONECT records and will get the bonding from atoms proximity, which will not add those. 

This will also make recent changes to PDB reader less intrusive and more backward compatible, as all bonds from file will be in place, as one could suspect.
