### PR TITLE
Use numpy not numeric for boost 1.65+ - fixes #1581

### DIFF
--- a/Code/DataManip/MetricMatrixCalc/Wrap/rdMetricMatrixCalc.cpp
+++ b/Code/DataManip/MetricMatrixCalc/Wrap/rdMetricMatrixCalc.cpp
@@ -10,7 +10,7 @@
 //
 #define PY_ARRAY_UNIQUE_SYMBOL rdmetric_array_API
 #include <RDBoost/python.h>
-#include <boost/python/numeric.hpp>
+#include <RDBoost/boost_numpy.h>
 
 #include <RDBoost/PySequenceHolder.h>
 #include <RDBoost/Wrap.h>

--- a/Code/DataStructs/Wrap/DataStructs.cpp
+++ b/Code/DataStructs/Wrap/DataStructs.cpp
@@ -17,7 +17,7 @@
 #include <DataStructs/SparseIntVect.h>
 
 #include "DataStructs.h"
-#include <boost/python/numeric.hpp>
+#include <RDBoost/boost_numpy.h>
 #include <numpy/npy_common.h>
 #include <RDBoost/import_array.h>
 #include <RDBoost/pyint_api.h>

--- a/Code/Demos/boost/numpy/linalg.cpp
+++ b/Code/Demos/boost/numpy/linalg.cpp
@@ -3,13 +3,13 @@
 //
 
 #include <boost/python.hpp>
-#include <boost/python/numeric.hpp>
+#include <RDBoost/boost_numpy.h>
 #define PY_ARRAY_UNIQUE_SYMBOL RD_array_API
 #include <numpy/arrayobject.h>
 
 namespace python = boost::python;
 
-double GetFirstElement(python::numeric::array &x) {
+double GetFirstElement(NumpyArrayType &x) {
   PyArrayObject *ptr = (PyArrayObject *)x.ptr();
   void *data = PyArray_DATA(ptr);
   double res = 0.0;

--- a/Code/GraphMol/MolAlign/Wrap/rdMolAlign.cpp
+++ b/Code/GraphMol/MolAlign/Wrap/rdMolAlign.cpp
@@ -13,7 +13,7 @@
 #define PY_ARRAY_UNIQUE_SYMBOL rdmolalign_array_API
 #include <RDBoost/python.h>
 #include <RDBoost/import_array.h>
-#include <boost/python/numeric.hpp>
+#include <RDBoost/boost_numpy.h>
 #include "numpy/arrayobject.h"
 #include <GraphMol/MolAlign/AlignMolecules.h>
 #include <GraphMol/MolAlign/O3AAlignMolecules.h>

--- a/Code/GraphMol/ReducedGraphs/Wrap/rdReducedGraphs.cpp
+++ b/Code/GraphMol/ReducedGraphs/Wrap/rdReducedGraphs.cpp
@@ -11,7 +11,7 @@
 
 #define PY_ARRAY_UNIQUE_SYMBOL rdreducedgraphs_array_API
 #include <RDBoost/python.h>
-#include <boost/python/numeric.hpp>
+#include <RDBoost/boost_numpy.h>
 
 #include <RDBoost/Wrap.h>
 #include <GraphMol/GraphMol.h>

--- a/Code/Numerics/Alignment/Wrap/rdAlignment.cpp
+++ b/Code/Numerics/Alignment/Wrap/rdAlignment.cpp
@@ -10,7 +10,7 @@
 //
 #define PY_ARRAY_UNIQUE_SYMBOL rdalignment_array_API
 #include <RDBoost/python.h>
-#include <boost/python/numeric.hpp>
+#include <RDBoost/boost_numpy.h>
 #include <RDBoost/import_array.h>
 
 #include <RDBoost/PySequenceHolder.h>

--- a/Code/RDBoost/CMakeLists.txt
+++ b/Code/RDBoost/CMakeLists.txt
@@ -4,6 +4,7 @@ rdkit_library(RDBoost Wrap.cpp
 rdkit_headers(Wrap.h PySequenceHolder.h
               list_indexing_suite.hpp
               python.h
+              boost_numpy.h
               python_streambuf.h
               DEST RDBoost)
 

--- a/Code/RDBoost/boost_numpy.h
+++ b/Code/RDBoost/boost_numpy.h
@@ -1,0 +1,9 @@
+// Boost python numpy available in Boost 1.63+
+// Boost python numeric removed in Boost 1.65+
+#if BOOST_VERSION < 106500
+#include <boost/python/numeric.hpp>
+typedef typename boost::python::numeric::array NumpyArrayType;
+#else
+#include <boost/python/numpy.hpp>
+typedef typename boost::python::numpy::ndarray NumpyArrayType;
+#endif

--- a/Code/SimDivPickers/Wrap/HierarchicalClusterPicker.cpp
+++ b/Code/SimDivPickers/Wrap/HierarchicalClusterPicker.cpp
@@ -12,7 +12,7 @@
 #define PY_ARRAY_UNIQUE_SYMBOL rdpicker_array_API
 #include <RDBoost/python.h>
 
-#include <boost/python/numeric.hpp>
+#include <RDBoost/boost_numpy.h>
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 #include <numpy/arrayobject.h>
 #include <RDBoost/Wrap.h>

--- a/Code/SimDivPickers/Wrap/MaxMinPicker.cpp
+++ b/Code/SimDivPickers/Wrap/MaxMinPicker.cpp
@@ -11,7 +11,7 @@
 #define PY_ARRAY_UNIQUE_SYMBOL rdpicker_array_API
 #include <RDBoost/python.h>
 #include <RDBoost/Wrap.h>
-#include <boost/python/numeric.hpp>
+#include <RDBoost/boost_numpy.h>
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 #include <numpy/arrayobject.h>
 #include <map>


### PR DESCRIPTION
boost python numeric no longer exists in boost 1.65, so check boost version and conditionally use boost python numpy.

Fixes #1581
Fixes https://github.com/rdkit/homebrew-rdkit/issues/43