### PR TITLE
There is no need to enforce that (i, j) and (k, l) be bonded when setting a i, j, k, l dihedral

### DIFF
--- a/Code/GraphMol/MolTransforms/MolTransforms.cpp
+++ b/Code/GraphMol/MolTransforms/MolTransforms.cpp
@@ -536,12 +536,8 @@ void setDihedralRad(Conformer &conf, unsigned int iAtomId, unsigned int jAtomId,
   URANGE_CHECK(kAtomId, pos.size());
   URANGE_CHECK(lAtomId, pos.size());
   ROMol &mol = conf.getOwningMol();
-  Bond *bondIJ = mol.getBondBetweenAtoms(iAtomId, jAtomId);
-  if (!bondIJ) throw ValueErrorException("atoms i and j must be bonded");
   Bond *bondJK = mol.getBondBetweenAtoms(jAtomId, kAtomId);
   if (!bondJK) throw ValueErrorException("atoms j and k must be bonded");
-  Bond *bondKL = mol.getBondBetweenAtoms(kAtomId, lAtomId);
-  if (!bondKL) throw ValueErrorException("atoms k and l must be bonded");
 
   if (queryIsBondInRing(bondJK))
     throw ValueErrorException("bond (j,k) must not belong to a ring");

--- a/Code/GraphMol/MolTransforms/Wrap/testMolTransforms.py
+++ b/Code/GraphMol/MolTransforms/Wrap/testMolTransforms.py
@@ -116,6 +116,33 @@ class TestCase(unittest.TestCase):
     dihedral = rdmt.GetDihedralDeg(conf, 8, 0, 19, 21)
     self.failUnlessAlmostEqual(dihedral, -120.0, 1)
 
+  def testGetSetDihedralThroughTripleBond(self):
+    file = os.path.join(RDConfig.RDBaseDir, 'Code', 'GraphMol', 'MolTransforms', 'test_data',
+                        'github1262_2.mol')
+
+    m = Chem.MolFromMolFile(file, True, False)
+    conf = m.GetConformer()
+    rdmt.SetDihedralDeg(conf, 6, 1, 2, 9, 0.0)
+    dihedral = rdmt.GetDihedralDeg(conf, 6, 1, 2, 9)
+    self.failUnlessAlmostEqual(dihedral, 0.0, 1)
+    dist = rdmt.GetBondLength(conf, 6, 9)
+    rdmt.SetDihedralDeg(conf, 6, 1, 2, 9, 120.0)
+    dihedral = rdmt.GetDihedralDeg(conf, 6, 1, 2, 9)
+    self.failUnlessAlmostEqual(dihedral, 120.0, 1)
+    dist2 = rdmt.GetBondLength(conf, 6, 7)
+    self.failUnlessAlmostEqual(dist, dist2, 1)
+    rdmt.SetDihedralDeg(conf, 6, 1, 2, 9, 180.0)
+    dihedral = rdmt.GetDihedralDeg(conf, 6, 1, 2, 9)
+    self.failUnlessAlmostEqual(dihedral, 180.0, 1)
+    dist3 = rdmt.GetBondLength(conf, 6, 9)
+    self.failIfAlmostEqual(dist, dist3, 1)
+    exceptionRaised = False
+    try:
+      rdmt.SetDihedralDeg(conf, 6, 0, 3, 9, 0.0)
+    except ValueError:
+      exceptionRaised = True
+    self.failUnless(exceptionRaised)
+
 
 if __name__ == "__main__":
   unittest.main()

--- a/Code/GraphMol/MolTransforms/test1.cpp
+++ b/Code/GraphMol/MolTransforms/test1.cpp
@@ -167,7 +167,7 @@ void testGetSetAngle() {
   TEST_ASSERT(m);
   Conformer &conf = m->getConformer();
   double angle = getAngleDeg(conf, 0, 19, 21);
-  TEST_ASSERT(RDKit::feq(RDKit::round(angle * 10) / 10, 109.7));
+  TEST_ASSERT(RDKit::feq(angle, 109.7, 0.05));
   setAngleDeg(conf, 0, 19, 21, 125.0);
   angle = getAngleDeg(conf, 0, 19, 21);
   TEST_ASSERT(RDKit::feq(angle, 125.0));
@@ -187,7 +187,7 @@ void testGetSetDihedral() {
   TEST_ASSERT(m);
   Conformer &conf = m->getConformer();
   double dihedral = getDihedralDeg(conf, 0, 19, 21, 24);
-  TEST_ASSERT(RDKit::feq(RDKit::round(dihedral * 100) / 100, 176.05));
+  TEST_ASSERT(RDKit::feq(dihedral, 176.05, 0.05));
   setDihedralDeg(conf, 8, 0, 19, 21, 65.0);
   dihedral = getDihedralDeg(conf, 8, 0, 19, 21);
   TEST_ASSERT(RDKit::feq(dihedral, 65.0));
@@ -199,6 +199,38 @@ void testGetSetDihedral() {
   TEST_ASSERT(RDKit::feq(dihedral, -2. / 3. * M_PI));
   dihedral = getDihedralDeg(conf, 8, 0, 19, 21);
   TEST_ASSERT(RDKit::feq(dihedral, -120.0));
+}
+
+void testGetSetDihedralThroughTripleBond() {
+  std::string rdbase = getenv("RDBASE");
+  std::string fName =
+      rdbase +
+      "/Code/GraphMol/MolTransforms/test_data/github1262_2.mol";
+  RWMol *m = MolFileToMol(fName, true, false);
+  TEST_ASSERT(m);
+  Conformer &conf = m->getConformer();
+  setDihedralDeg(conf, 6, 1, 2, 9, 0.0);
+  double dihedral = getDihedralDeg(conf, 6, 1, 2, 9);
+  TEST_ASSERT(RDKit::feq(dihedral, 0.0));
+  double dist = getBondLength(conf, 6, 9);
+  setDihedralDeg(conf, 6, 1, 2, 9, 120.0);
+  dihedral = getDihedralDeg(conf, 6, 1, 2, 9);
+  TEST_ASSERT(RDKit::feq(dihedral, 120.0));
+  double dist2 = getBondLength(conf, 6, 7);
+  TEST_ASSERT(RDKit::feq(dist, dist2, 0.05));
+  setDihedralDeg(conf, 6, 1, 2, 9, 180.0);
+  dihedral = getDihedralDeg(conf, 6, 1, 2, 9);
+  TEST_ASSERT(RDKit::feq(dihedral, 180.0));
+  double dist3 = getBondLength(conf, 6, 9);
+  TEST_ASSERT(!RDKit::feq(dist, dist3, 0.3));
+  bool exceptionRaised = false;
+  try {
+    setDihedralDeg(conf, 6, 0, 3, 9, 0.0);
+  }
+  catch (ValueErrorException &e) {
+    exceptionRaised = true;
+  }
+  TEST_ASSERT(exceptionRaised);
 }
 
 #ifndef RDK_HAS_EIGEN3
@@ -283,6 +315,9 @@ int main() {
   std::cout << "\t---------------------------------\n";
   std::cout << "\t testGetSetDihedral \n\n";
   testGetSetDihedral();
+  std::cout << "\t---------------------------------\n";
+  std::cout << "\t testGetSetDihedralThroughTripleBond \n\n";
+  testGetSetDihedralThroughTripleBond();
   std::cout << "\t---------------------------------\n";
   std::cout << "\t testGithub1262: PMI descriptors incorrect  \n\n";
   testGithub1262();


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! 
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.
There is no need to enforce that (i, j) and (k, l) be bonded when setting a i, j, k, l dihedral.
For example, in OCC#CCN one might want to rotate clockwise by 60 degrees the hydroxymethyl and aminomethyl groups around the C#C axis by doing a perfectly legitimate

`MolTransforms::setDihedral(conf, 0, 2, 3, 5, MolTransforms::getDihedral(conf, 0, 2, 3, 5) + 60.0)`

but the current code does not allow this as (i, j) and (k, l) are not bonded. However, the only requirement here is that (j, k) be bonded.
So I am removing the checks for (i, j) and (k, l) to be bonded that I originally put in, as they are not required.

#### Any other comments?

