### PR TITLE
Fix: GetDonor2FeatVects heavy atoms confusion

### DIFF
--- a/rdkit/Chem/Features/FeatDirUtilsRD.py
+++ b/rdkit/Chem/Features/FeatDirUtilsRD.py
@@ -297,7 +297,7 @@ def GetDonor2FeatVects(conf, featAtoms, scale=1.5):
     bvec.Normalize()
     bvec *= scale
     bvec += cpt
-    if _checkPlanarity(conf, cpt, nbrs):
+    if _checkPlanarity(conf, cpt, nbrs, tol=1.0e-2):
       # only the hydrogen atom direction needs to be used
       return ((cpt, bvec), ), 'linear'
     else:

--- a/rdkit/Chem/Features/FeatDirUtilsRD.py
+++ b/rdkit/Chem/Features/FeatDirUtilsRD.py
@@ -270,7 +270,7 @@ def GetDonor2FeatVects(conf, featAtoms, scale=1.5):
   assert len(nbrs) >= 2
   
   hydrogens = []
-  heavy=[]
+  heavy = []
   for nbr in nbrs:
     if nbr.GetAtomicNum() == 1:
       hydrogens.append(nbr)

--- a/rdkit/Chem/Features/FeatDirUtilsRD.py
+++ b/rdkit/Chem/Features/FeatDirUtilsRD.py
@@ -268,22 +268,20 @@ def GetDonor2FeatVects(conf, featAtoms, scale=1.5):
   # find the two atoms that are neighbors of this atoms
   nbrs = list(mol.GetAtomWithIdx(aid).GetNeighbors())
   assert len(nbrs) >= 2
-
+  
   hydrogens = []
-  tmp = []
-  while len(nbrs):
-    nbr = nbrs.pop()
+  heavy=[]
+  for nbr in nbrs:
     if nbr.GetAtomicNum() == 1:
       hydrogens.append(nbr)
     else:
-      tmp.append(nbr)
-  nbrs = tmp
+      heavy.append(nbr) 
 
   if len(nbrs) == 2:
     # there should be no hydrogens in this case
     assert len(hydrogens) == 0
     # in this case the direction is the opposite of the average vector of the two neighbors
-    bvec = _findAvgVec(conf, cpt, nbrs)
+    bvec = _findAvgVec(conf, cpt, heavy)
     bvec *= (-1.0 * scale)
     bvec += cpt
     return ((cpt, bvec), ), 'linear'
@@ -304,7 +302,7 @@ def GetDonor2FeatVects(conf, featAtoms, scale=1.5):
       return ((cpt, bvec), ), 'linear'
     else:
       # we have a non-planar configuration - we will assume sp3 and compute a second direction vector
-      ovec = _findAvgVec(conf, cpt, nbrs)
+      ovec = _findAvgVec(conf, cpt, heavy)
       ovec *= (-1.0 * scale)
       ovec += cpt
       return ((cpt, bvec),

--- a/rdkit/Chem/Features/FeatDirUtilsRD.py
+++ b/rdkit/Chem/Features/FeatDirUtilsRD.py
@@ -312,6 +312,7 @@ def GetDonor2FeatVects(conf, featAtoms, scale=1.5):
     # in this case we should have two or more hydrogens we will simple use there directions
     res = []
     for hid in hydrogens:
+      hid = hid.GetIdx()
       bvec = conf.GetAtomPosition(hid)
       bvec -= cpt
       bvec.Normalize()

--- a/rdkit/Chem/Features/UnitTestFeatDirUtilsRD.py
+++ b/rdkit/Chem/Features/UnitTestFeatDirUtilsRD.py
@@ -1,0 +1,172 @@
+import unittest
+
+from rdkit import Chem
+from rdkit.Geometry.rdGeometry import Point3D
+from rdkit.Chem.Features.FeatDirUtilsRD import GetDonor2FeatVects
+
+class TestCase(unittest.TestCase):
+	def assertListAlmostEqual(self, list1, list2, msg, tol=7):
+		self.assertEqual(len(list1), len(list2), msg)
+		for a, b in zip(list1, list2):
+			 self.assertAlmostEqual(a, b, tol, msg)
+
+	def setUp(self):
+		#Define molecule for using in tests of GetDonor2FeatVects
+		self.mol = Chem.MolFromSmiles('C=CCONC')
+		emol = Chem.RWMol(self.mol)
+		emol = Chem.AddHs(emol)
+		emol.AddConformer(Chem.Conformer(15))
+		emol.GetConformer().SetAtomPosition(0, [-2.8272, -0.2716, 0.4130])  #C
+		emol.GetConformer().SetAtomPosition(1, [-1.7908, -0.1146, -0.4177]) #C
+		emol.GetConformer().SetAtomPosition(2, [-0.5452, 0.6287, -0.0653])  #C
+		emol.GetConformer().SetAtomPosition(3, [0.5603, -0.2584, -0.1671])  #O
+		emol.GetConformer().SetAtomPosition(4, [1.7601, 0.4902, 0.1811])    #N
+		emol.GetConformer().SetAtomPosition(5, [2.8427, -0.4743, 0.0559])   #C
+		emol.GetConformer().SetAtomPosition(6, [-3.7065, -0.8216, 0.0959])  #H
+		emol.GetConformer().SetAtomPosition(7, [-2.8190, 0.1408, 1.4159])   #H
+		emol.GetConformer().SetAtomPosition(8, [-1.8508, -0.5462, -1.4133]) #H
+		emol.GetConformer().SetAtomPosition(9, [-0.6006, 1.0355, 0.9521])   #H
+		emol.GetConformer().SetAtomPosition(10, [-0.4226, 1.4609, -0.7693]) #H
+		emol.GetConformer().SetAtomPosition(11, [1.8283, 1.1371, -0.6054])  #H
+		emol.GetConformer().SetAtomPosition(12, [2.8648, -0.9271, -0.9408]) #H
+		emol.GetConformer().SetAtomPosition(13, [2.7437, -1.2668, 0.8044])  #H
+		emol.GetConformer().SetAtomPosition(14, [3.8013, 0.0259, 0.2227])   #H
+		self.mol = Chem.Mol(emol)
+
+	def test1_GetDonor2FeatVects(self):
+		'''Case 1: two hydrogens'''
+		conf = self.mol.GetConformer(-1)
+		case1 = GetDonor2FeatVects(conf, [2], scale=1.5)
+		pos_heavy_atom = conf.GetAtomPosition(2)
+		
+		#Check if there are two vectors
+		self.assertEqual(len(case1[0]), 2, 'Incorrect number of vectors')
+
+		#Check initial points of the vectors
+		self.assertListAlmostEqual(case1[0][0][0], pos_heavy_atom, 
+							'Incorrect starting point of vector 1')
+		self.assertListAlmostEqual(case1[0][1][0], pos_heavy_atom, 
+							'Incorrect starting point of vector 2')
+		
+		#Check directions of the vectors
+		vec_h1 = conf.GetAtomPosition(9) - pos_heavy_atom
+		vec_h2 = conf.GetAtomPosition(10) - pos_heavy_atom
+		vec_1 = case1[0][0][1] - case1[0][0][0]
+		vec_2 = case1[0][1][1] - case1[0][1][0]
+	
+		self.assertListAlmostEqual(vec_1.CrossProduct(vec_h1), Point3D(0,0,0),
+								'Incorrect direction of vector 1')
+		self.assertTrue(vec_1.DotProduct(vec_h1) > 0, 
+						'Incorrect direction of vector 1')
+		self.assertListAlmostEqual(vec_2.CrossProduct(vec_h2), Point3D(0,0,0),
+								'Incorrect direction of vector 2')
+		self.assertTrue(vec_2.DotProduct(vec_h2) > 0, 
+						'Incorrect direction of vector 2')
+
+		#Check length of the vectors
+		self.assertAlmostEqual(vec_1.Length(), 1.5, 
+								msg='Incorrect length of vector 1')
+		
+		self.assertAlmostEqual(vec_2.Length(), 1.5, 
+								msg='Incorrect length of vector 2')
+
+	def test2_1_GetDonor2FeatVects(self):
+		'''Case 2.1: one hydrogen with sp2 arrangement'''
+		conf = self.mol.GetConformer(-1)
+
+		case21 = GetDonor2FeatVects(conf, [1], scale=1.5)
+		pos_heavy_atom = conf.GetAtomPosition(1)
+		
+		#Check if there is one vector
+		self.assertEqual(len(case21[0]), 1, 'Incorrect number of vectors')
+
+		#Check initial point of the vector
+		self.assertListAlmostEqual(case21[0][0][0], pos_heavy_atom, 
+									'Incorrect starting point of vector')
+		
+		#Check direction of the vector
+		vec_h = conf.GetAtomPosition(8) - (pos_heavy_atom)
+		vec = case21[0][0][1] - case21[0][0][0]
+		self.assertListAlmostEqual(vec.CrossProduct(vec_h), Point3D(0,0,0),
+								'Incorrect direction of vector')
+		self.assertTrue(vec.DotProduct(vec_h) > 0, 
+						'Incorrect direction of vector')
+
+		#Check length of the vector
+		self.assertAlmostEqual(vec.Length(), 1.5, 
+								msg='Incorrect length of vector')
+
+	def test2_2_GetDonor2FeatVects(self):
+		#Case 2.2: one hydrogen with sp3 arrangement
+		conf = self.mol.GetConformer(-1)
+		case22 = GetDonor2FeatVects(conf, [4], scale=1.5)
+		pos_heavy_atom = conf.GetAtomPosition(4)
+		
+		#Check if there are two vectors
+		self.assertEqual(len(case22[0]), 2, 'Incorrect number of vectors')
+
+		#Check initial points of the vectors
+		self.assertListAlmostEqual(case22[0][0][0], pos_heavy_atom, 
+							'Incorrect starting point of vector 1')
+		self.assertListAlmostEqual(case22[0][1][0], pos_heavy_atom, 
+							'Incorrect starting point of vector 2')
+
+		#Check directions of the vectors
+		vec_h = conf.GetAtomPosition(11) - pos_heavy_atom
+
+		vec_nbr1 = conf.GetAtomPosition(3) - pos_heavy_atom
+		vec_nbr1.Normalize()
+		vec_nbr2 = conf.GetAtomPosition(5) - pos_heavy_atom
+		vec_nbr2.Normalize()
+		avg_vec = (vec_nbr1 + vec_nbr2)
+
+		vec_1 = case22[0][0][1] - case22[0][0][0]
+		vec_2 = case22[0][1][1] - case22[0][1][0]
+
+		self.assertListAlmostEqual(vec_1.CrossProduct(vec_h), Point3D(0,0,0),
+								'Incorrect direction of vector 1')
+		self.assertTrue(vec_1.DotProduct(vec_h) > 0, 
+						'Incorrect direction of vector 1')
+		self.assertListAlmostEqual(vec_2.CrossProduct(avg_vec), Point3D(0,0,0),
+								'Incorrect direction of vector 2')
+		self.assertTrue(vec_2.DotProduct(avg_vec) < 0, 
+						'Incorrect direction of vector 2')
+
+		#Check length of the vectors
+		self.assertAlmostEqual(vec_1.Length(), 1.5, 
+								msg='Incorrect length of vector 1')
+		
+		self.assertAlmostEqual(vec_2.Length(), 1.5, 
+								msg='Incorrect length of vector 2')
+
+	def test3_GetDonor2FeatVects(self):
+		'''Case 3: no hydrogens'''
+		conf = self.mol.GetConformer(-1)
+		case3 = GetDonor2FeatVects(conf, [3], scale=1.5)
+		pos_heavy_atom = conf.GetAtomPosition(3)
+		
+		#Check if there is one vector
+		self.assertEqual(len(case3[0]), 1, 'Incorrect number of vectors')
+		
+		#Check initial point of the vector
+		self.assertListAlmostEqual(case3[0][0][0], pos_heavy_atom, 
+									'Incorrect starting point of vector')
+		
+		#Check direction of the vector
+		vec_nbr1 = conf.GetAtomPosition(2) - pos_heavy_atom
+		vec_nbr1.Normalize()
+		vec_nbr2 = conf.GetAtomPosition(4) - pos_heavy_atom
+		vec_nbr2.Normalize()
+		avg_vec = (vec_nbr1 + vec_nbr2)
+		vec = case3[0][0][1] - case3[0][0][0]
+		self.assertListAlmostEqual(vec.CrossProduct(avg_vec), Point3D(0,0,0),
+								'Incorrect direction of vector')
+		self.assertTrue(vec.DotProduct(avg_vec) < 0, 
+						'Incorrect direction of vector')
+
+		#Check length of the vector
+		self.assertAlmostEqual(vec.Length(), 1.5, 
+								msg='Incorrect length of vector')
+
+if __name__ == '__main__':
+	unittest.main()

--- a/rdkit/Chem/Features/test_list.py
+++ b/rdkit/Chem/Features/test_list.py
@@ -1,0 +1,10 @@
+tests = [
+	("python", "UnitTestFeatDirUtilsRD.py", {})
+]
+
+longTests = []
+if __name__ == '__main__':
+	import sys
+	from rdkit import TestRunner
+	failed, tests = TestRunner.RunScript('test_list.py', 0, 1)
+	sys.exit(len(failed))


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! 
-->
#### Reference Issue
<!-- Fixes GetDonor2FeatVects heavy atoms confusion -->

#### What does this implement/fix? Explain your changes.
Dear Greg,

First of all, as is the first time I write you, I want to present me. I am starting my PhD of bioinformatics in Barcelona, and I am using the RDKit library in some aspects of my work.

ConcreteIy, I am using the FeatDirUtilsRD to calculate the feature vectors of a feature and I have found some apparent mistakes in the function GetDonor2FeatVects.

I think that there is a confusion with the "nbrs" list. The first thing that the function does is to create a "hydrogens" list to use it after. But after the while loop, the list "nbrs" doesn't contain anymore the all neighbours (including hydrogens) of the donor, but only the heavy neighbour atoms. The "nbrs" list is used after the while with two meanings: as if it contained all the neighbours or only the heavy ones (I think here is the confusion).

I propose to change the "while" loop by a "for" one, creating a "heavy" list with the heavy neighbours atoms and keeping the meaning of "nbrs" list as all the neighbours (including hydrogens). After the loop, I have changed the "nbrs" list by the "heavy" one where I find that is correct.

I would be grateful if you could review my proposed changes and say me if I am right with these.

Many thanks,

José Emilio Sánchez

#### Any other comments?

I have created another pull request in rdkit-orig repository a few moments ago, but I realized that the good place was here. Sorry for the inconvenience.
