### PR TITLE
Fixes #1695

### DIFF
--- a/Code/GraphMol/RGroupDecomposition/Wrap/rdRGroupComposition.cpp
+++ b/Code/GraphMol/RGroupDecomposition/Wrap/rdRGroupComposition.cpp
@@ -145,8 +145,15 @@ python::object RGroupDecomp(python::object cores, python::object mols,
 
 struct rgroupdecomp_wrapper {
   static void wrap() {
-    python::class_<RDKit::MOL_SPTR_VECT>("MOL_SPTR_VECT")
-        .def(python::vector_indexing_suite<RDKit::MOL_SPTR_VECT, true>());
+    // logic from https://stackoverflow.com/a/13017303
+    boost::python::type_info info =
+        boost::python::type_id<RDKit::MOL_SPTR_VECT>();
+    const boost::python::converter::registration *reg =
+        boost::python::converter::registry::query(info);
+    if (reg == NULL || (*reg).m_to_python == NULL) {
+      python::class_<RDKit::MOL_SPTR_VECT>("MOL_SPTR_VECT")
+          .def(python::vector_indexing_suite<RDKit::MOL_SPTR_VECT, true>());
+    }
 
     std::string docString = "";
     python::enum_<RDKit::RGroupLabels>("RGroupLabels")


### PR DESCRIPTION
Apologies for the amount of code reformatting that got mixed in here.
The actual changes are the two uses of this code snippet to register the `MOL_SPTR_VECT` class:
```
  // logic from https://stackoverflow.com/a/13017303
  boost::python::type_info info =
      boost::python::type_id<RDKit::MOL_SPTR_VECT>();
  const boost::python::converter::registration *reg =
      boost::python::converter::registry::query(info);
  if (reg == NULL || (*reg).m_to_python == NULL) {
    python::class_<RDKit::MOL_SPTR_VECT>("MOL_SPTR_VECT")
        .def(python::vector_indexing_suite<RDKit::MOL_SPTR_VECT, true>());
  }
```

No specific test is included for this since the fix just prevents a warning from Boost. If the rest of the tests pass then we haven't broken anything.