### PR TITLE
Fixes github #1702

### DIFF
--- a/Code/GraphMol/Descriptors/AUTOCORR2D.h
+++ b/Code/GraphMol/Descriptors/AUTOCORR2D.h
@@ -33,17 +33,14 @@
 //
 // Created by Guillaume GODIN, 2016
 
-
 #ifndef AUTOCORR2DRDKIT_H_SEPT2016
 #define AUTOCORR2DRDKIT_H_SEPT2016
 
-#ifdef RDK_BUILD_DESCRIPTORS3D
 namespace RDKit {
 class ROMol;
 namespace Descriptors {
 const std::string AUTOCORR2DVersion = "1.0.0";
-	void AUTOCORR2D(const ROMol &, std::vector<double> &res);
+void AUTOCORR2D(const ROMol &, std::vector<double> &res);
 }
 }
-#endif
 #endif

--- a/Code/GraphMol/Descriptors/CMakeLists.txt
+++ b/Code/GraphMol/Descriptors/CMakeLists.txt
@@ -1,7 +1,7 @@
 if(RDK_BUILD_DESCRIPTORS3D)
 
-  set(DESC3D_HDRS MolDescriptors3D.h PBF.h PMI.h Data3Ddescriptors.h MolData3Ddescriptors.h AUTOCORR3D.h AUTOCORR2D.h RDF.h MORSE.h GETAWAY.h WHIM.h)
-  set(DESC3D_SOURCES PBF.cpp PMI.cpp Data3Ddescriptors.cpp MolData3Ddescriptors.cpp AUTOCORR3D.cpp AUTOCORR2D.cpp RDF.cpp MORSE.cpp GETAWAY.cpp WHIM.cpp)
+  set(DESC3D_HDRS MolDescriptors3D.h PBF.h PMI.h AUTOCORR3D.h RDF.h MORSE.h GETAWAY.h WHIM.h)
+  set(DESC3D_SOURCES PBF.cpp PMI.cpp AUTOCORR3D.cpp RDF.cpp MORSE.cpp GETAWAY.cpp WHIM.cpp)
 
 endif(RDK_BUILD_DESCRIPTORS3D)
 
@@ -9,6 +9,7 @@ rdkit_library(Descriptors
               Crippen.cpp MolDescriptors.cpp MolSurf.cpp Lipinski.cpp ConnectivityDescriptors.cpp
               MQN.cpp
               Property.cpp
+              AUTOCORR2D.cpp Data3Ddescriptors.cpp MolData3Ddescriptors.cpp
               USRDescriptor.cpp
               ${DESC3D_SOURCES}
               LINK_LIBRARIES PartialCharges SmilesParse FileParsers Subgraphs SubstructMatch MolTransforms GraphMol
@@ -20,12 +21,17 @@ rdkit_headers(Crippen.h Lipinski.h
               ConnectivityDescriptors.h MQN.h
               RegisterDescriptor.h
               Property.h
+              AUTOCORR2D.h Data3Ddescriptors.h MolData3Ddescriptors.h
               USRDescriptor.h
               ${DESC3D_HDRS}
               DEST GraphMol/Descriptors)
 
 rdkit_test(testDescriptors test.cpp
 LINK_LIBRARIES PartialCharges Descriptors FileParsers SmilesParse Subgraphs SubstructMatch MolTransforms GraphMol EigenSolvers DataStructs RDGeneral RDGeometryLib ${RDKit_THREAD_LIBS} )
+
+rdkit_test(testAUTOCORR2D testAUTOCORR2D.cpp
+LINK_LIBRARIES  Descriptors FileParsers SmilesParse MolTransforms PartialCharges GraphMol DataStructs EigenSolvers RDGeneral RDGeometryLib ${RDKit_THREAD_LIBS} )
+
 
 if(RDK_BUILD_DESCRIPTORS3D)
   rdkit_test(testPBF testPBF.cpp
@@ -42,9 +48,6 @@ LINK_LIBRARIES  Descriptors FileParsers SmilesParse MolTransforms PartialCharges
 LINK_LIBRARIES  Descriptors FileParsers SmilesParse MolTransforms PartialCharges GraphMol DataStructs EigenSolvers RDGeneral RDGeometryLib ${RDKit_THREAD_LIBS} )
   rdkit_test(testAUTOCORR3D testAUTOCORR3D.cpp
 LINK_LIBRARIES  Descriptors FileParsers SmilesParse MolTransforms PartialCharges GraphMol DataStructs EigenSolvers RDGeneral RDGeometryLib ${RDKit_THREAD_LIBS} )
-  rdkit_test(testAUTOCORR2D testAUTOCORR2D.cpp
-LINK_LIBRARIES  Descriptors FileParsers SmilesParse MolTransforms PartialCharges GraphMol DataStructs EigenSolvers RDGeneral RDGeometryLib ${RDKit_THREAD_LIBS} )
-
 endif(RDK_BUILD_DESCRIPTORS3D)
 
 

--- a/Code/GraphMol/Descriptors/test.cpp
+++ b/Code/GraphMol/Descriptors/test.cpp
@@ -2093,6 +2093,21 @@ void testUSRCATDescriptor() {
   BOOST_LOG(rdErrorLog) << "  done" << std::endl;
 }
 
+void testGithub1702() {
+  BOOST_LOG(rdErrorLog) << "-------------------------------------" << std::endl;
+  BOOST_LOG(rdErrorLog) << "    Test Github #1702: AUTOCORR2D.h not installed "
+                           "unless RDK_BUILD_DESCRIPTORS3D but is required"
+                        << std::endl;
+  std::vector<double> descriptor(12);
+
+  ROMol *mol = SmilesToMol("C1CCCCC1");
+  std::vector<double> dvals;
+  AUTOCORR2D(*mol, dvals);
+  TEST_ASSERT(dvals.size() == 192);
+  delete mol;
+  BOOST_LOG(rdErrorLog) << "  done" << std::endl;
+}
+
 //-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
 //
 //-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
@@ -2133,4 +2148,5 @@ int main() {
   testPropertyQueries();
   testStereoCounting();
   testUSRDescriptor();
+  testGithub1702();
 }


### PR DESCRIPTION
Nothing particularly complicated here: make sure that the Autocorr2d descriptor is always enabled.