### PR TITLE
Fix/rgroup prefer matching nonhs over hs

### DIFF
--- a/Code/GraphMol/RGroupDecomposition/RGroupDecomp.cpp
+++ b/Code/GraphMol/RGroupDecomposition/RGroupDecomp.cpp
@@ -372,7 +372,7 @@ double score(const std::vector<size_t> &permutation,
         if(static_cast<size_t>(it->second) == permutation.size())
           equivalentRGroupCount.push_back(static_cast<float>(it->second));
         else
-          equivalentRGroupCount.push_back(it->second * 0.05f); // small boosts for hydrogens
+          equivalentRGroupCount.push_back(it->second * 1.0/permutation.size()); // massively downweight hydrogens
       } else {
         equivalentRGroupCount.push_back(static_cast<float>(it->second));
       }

--- a/Code/GraphMol/RGroupDecomposition/RGroupDecomp.cpp
+++ b/Code/GraphMol/RGroupDecomposition/RGroupDecomp.cpp
@@ -337,14 +337,14 @@ double score(const std::vector<size_t> &permutation,
 #endif
     std::map<std::string, int> matchSet;
     std::map<std::set<int>, int> linkerMatchSet;
-    // std::map<std::vector<int>, int > attachMatch;
+
     for (size_t m = 0; m < permutation.size(); ++m) {  // for each molecule
       auto rg = matches[m][permutation[m]].rgroups.find(l);
       if (rg != matches[m][permutation[m]].rgroups.end()) {
 #ifdef DEBUG
         std::cerr << " RGroup: " << rg->second->smiles;
 #endif
-        matchSet[rg->second->smiles]++;
+        matchSet[rg->second->smiles]+=1;
 #ifdef DEBUG
         std::cerr << " score: " << matchSet[rg->second->smiles] << std::endl;
 #endif
@@ -361,14 +361,24 @@ double score(const std::vector<size_t> &permutation,
     }
 
     // get the counts for each rgroup found and sort in reverse order
-    std::vector<int> equivalentRGroupCount;
+    std::vector<float> equivalentRGroupCount;
 
     for (std::map<std::string, int>::const_iterator it = matchSet.begin();
          it != matchSet.end(); ++it) {
-      equivalentRGroupCount.push_back(it->second);
+      
+      // if the rgroup is a hydrogens, only consider if the group is all
+      //  hydrogen, otherwise score based on the non hydrogens
+      if(it->first.find("[H]") != std::string::npos) {
+        if(static_cast<size_t>(it->second) == permutation.size())
+          equivalentRGroupCount.push_back(static_cast<float>(it->second));
+        else
+          equivalentRGroupCount.push_back(it->second * 0.05f); // small boosts for hydrogens
+      } else {
+        equivalentRGroupCount.push_back(static_cast<float>(it->second));
+      }
     }
     std::sort(equivalentRGroupCount.begin(), equivalentRGroupCount.end(),
-              std::greater<int>());
+              std::greater<float>());
 
     double tempScore = 1.;
     // score the sets from the largest to the smallest


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! 
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->
Fixes #1659 

#### What does this implement/fix? Explain your changes.
Massively penalizes paired Hs unless they fill the entire RGroup.

This might be an issue with SH versus S so we may need to special case some atoms types occasionally.

#### Any other comments?

