### PR TITLE
Get queries from the new cactvs SMARTS extensions to pickle correctly

### DIFF
--- a/Code/GraphMol/MolPickler.cpp
+++ b/Code/GraphMol/MolPickler.cpp
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2001-2017 Greg Landrum and Rational Discovery LLC
+//  Copyright (C) 2001-2018 Greg Landrum and Rational Discovery LLC
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -18,6 +18,8 @@
 #include <Query/QueryObjects.h>
 #include <map>
 #include <boost/cstdint.hpp>
+#include <boost/algorithm/string.hpp>
+
 #ifdef RDK_THREADSAFE_SSS
 #include <boost/thread/once.hpp>
 #include <boost/thread/mutex.hpp>
@@ -218,8 +220,17 @@ void pickleQuery(std::ostream &ss, const Query<int, T const *, true> *query) {
 
 void finalizeQueryFromDescription(Query<int, Atom const *, true> *query,
                                   Atom const *owner) {
-  RDUNUSED_PARAM(owner);
   std::string descr = query->getDescription();
+  RDUNUSED_PARAM(owner);
+
+  if (boost::starts_with(descr, "range_")) {
+    descr = descr.substr(6);
+  } else if (boost::starts_with(descr, "less_")) {
+    descr = descr.substr(5);
+  } else if (boost::starts_with(descr, "greater_")) {
+    descr = descr.substr(8);
+  }
+
   Query<int, Atom const *, true> *tmpQuery;
   if (descr == "AtomRingBondCount") {
     query->setDataFunc(queryAtomRingBondCount);
@@ -270,6 +281,14 @@ void finalizeQueryFromDescription(Query<int, Atom const *, true> *query,
     query->setDataFunc(queryIsAtomInRing);
   } else if (descr == "AtomInNRings") {
     query->setDataFunc(queryIsAtomInNRings);
+  } else if (descr == "AtomHasHeteroatomNeighbors") {
+    query->setDataFunc(queryAtomHasHeteroatomNbrs);
+  } else if (descr == "AtomNumHeteroatomNeighbors") {
+    query->setDataFunc(queryAtomNumHeteroatomNbrs);
+  } else if (descr == "AtomHasAliphaticHeteroatomNeighbors") {
+    query->setDataFunc(queryAtomHasAliphaticHeteroatomNbrs);
+  } else if (descr == "AtomNumAliphaticHeteroatomNeighbors") {
+    query->setDataFunc(queryAtomNumAliphaticHeteroatomNbrs);
   } else if (descr == "AtomNull") {
     query->setDataFunc(nullDataFun);
     query->setMatchFunc(nullQueryFun);

--- a/Code/GraphMol/MolPickler.cpp
+++ b/Code/GraphMol/MolPickler.cpp
@@ -345,6 +345,8 @@ Query<int, T const *, true> *buildBaseQuery(std::istream &ss, T const *owner,
   int32_t val;
   int32_t nMembers;
   char cval;
+  const unsigned int lowerOpen = 1 << 1;
+  const unsigned int upperOpen = 1;
   switch (tag) {
     case MolPickler::QUERY_AND:
       res = new AndQuery<int, T const *, true>();
@@ -430,7 +432,7 @@ Query<int, T const *, true> *buildBaseQuery(std::istream &ss, T const *owner,
       static_cast<RangeQuery<int, T const *, true> *>(res)->setTol(val);
       streamRead(ss, cval, version);
       static_cast<RangeQuery<int, T const *, true> *>(res)->setEndsOpen(
-          cval & (1 << 1), cval & 1);
+          cval & lowerOpen, cval & upperOpen);
       break;
     case MolPickler::QUERY_SET:
       res = new SetQuery<int, T const *, true>();

--- a/Code/GraphMol/MolPickler.cpp
+++ b/Code/GraphMol/MolPickler.cpp
@@ -344,6 +344,7 @@ Query<int, T const *, true> *buildBaseQuery(std::istream &ss, T const *owner,
   Query<int, T const *, true> *res = nullptr;
   int32_t val;
   int32_t nMembers;
+  char cval;
   switch (tag) {
     case MolPickler::QUERY_AND:
       res = new AndQuery<int, T const *, true>();
@@ -427,6 +428,9 @@ Query<int, T const *, true> *buildBaseQuery(std::istream &ss, T const *owner,
       static_cast<RangeQuery<int, T const *, true> *>(res)->setUpper(val);
       streamRead(ss, val, version);
       static_cast<RangeQuery<int, T const *, true> *>(res)->setTol(val);
+      streamRead(ss, cval, version);
+      static_cast<RangeQuery<int, T const *, true> *>(res)->setEndsOpen(
+          cval & (1 << 1), cval & 1);
       break;
     case MolPickler::QUERY_SET:
       res = new SetQuery<int, T const *, true>();

--- a/Code/GraphMol/SmilesParse/smatest.cpp
+++ b/Code/GraphMol/SmilesParse/smatest.cpp
@@ -36,7 +36,6 @@ void testPass() {
     "C-C",
     "C=C",
     "[CH2+]C[CH+2]",
-#endif
     "C1CC=1",
     "C=1CC1",
     "Ccc",
@@ -95,6 +94,7 @@ void testPass() {
     "[z1]",
     "[Z]",
     "[Z1]",
+#endif
     "[D{1-3}]",  // cactvs range queries
     "[D{-3}]",
     "[D{1-}]",
@@ -108,11 +108,11 @@ void testPass() {
     CHECK_INVARIANT(mol, smi);
     int nAts = mol->getNumAtoms();
     CHECK_INVARIANT(nAts != 0, smi.c_str());
-    // make sure that we can pickle and de-pickle it (this is the test for github #1710):
+    // make sure that we can pickle and de-pickle it (this is the test for
+    // github #1710):
     std::string pkl;
-    MolPickler::pickleMol(*mol,pkl);
+    MolPickler::pickleMol(*mol, pkl);
     delete mol;
-    std::cerr<<smi<<std::endl;
     mol = new Mol(pkl);
     TEST_ASSERT(mol);
     delete mol;

--- a/Code/GraphMol/SmilesParse/smatest.cpp
+++ b/Code/GraphMol/SmilesParse/smatest.cpp
@@ -93,24 +93,29 @@ void testPass() {
     "C%(10000)CC%(10000)",  // high ring closures (Github #1624)
     "[z]",                  // cactvs heteroatom neighbor queries
     "[z1]",
-    "[z{1-3}]",
     "[Z]",
     "[Z1]",
-    "[Z{1-3}]",
     "[D{1-3}]",  // cactvs range queries
     "[D{-3}]",
     "[D{1-}]",
+    "[z{1-3}]",
+    "[Z{1-3}]",
     "EOS"
   };
   while (smis[i] != "EOS") {
     string smi = smis[i];
     mol = SmartsToMol(smi);
     CHECK_INVARIANT(mol, smi);
-    if (mol) {
-      int nAts = mol->getNumAtoms();
-      CHECK_INVARIANT(nAts != 0, smi.c_str());
-      delete mol;
-    }
+    int nAts = mol->getNumAtoms();
+    CHECK_INVARIANT(nAts != 0, smi.c_str());
+    // make sure that we can pickle and de-pickle it (this is the test for github #1710):
+    std::string pkl;
+    MolPickler::pickleMol(*mol,pkl);
+    delete mol;
+    std::cerr<<smi<<std::endl;
+    mol = new Mol(pkl);
+    TEST_ASSERT(mol);
+    delete mol;
     i++;
   }
   BOOST_LOG(rdInfoLog) << "\tdone" << std::endl;

--- a/Code/GraphMol/SmilesParse/smatest.cpp
+++ b/Code/GraphMol/SmilesParse/smatest.cpp
@@ -2315,7 +2315,6 @@ void testCactvsExtensions() {
     }
     delete m;
   }  // end of NCOc1ncccc1 examples
-
   BOOST_LOG(rdInfoLog) << "done" << std::endl;
 }
 


### PR DESCRIPTION
Fixes a problem pickling/unpickling range queries.
Fixes the unpickling of the new cactvs extensions added in #1704 