### PR TITLE
fix illegal use of typename in the new python_numpy code

### DIFF
--- a/Code/RDBoost/boost_numpy.h
+++ b/Code/RDBoost/boost_numpy.h
@@ -2,8 +2,8 @@
 // Boost python numeric removed in Boost 1.65+
 #if BOOST_VERSION < 106500
 #include <boost/python/numeric.hpp>
-typedef typename boost::python::numeric::array NumpyArrayType;
+typedef boost::python::numeric::array NumpyArrayType;
 #else
 #include <boost/python/numpy.hpp>
-typedef typename boost::python::numpy::ndarray NumpyArrayType;
+typedef boost::python::numpy::ndarray NumpyArrayType;
 #endif


### PR DESCRIPTION
report from Roger S. easy fix.