### PR TITLE
Allow installation of Python tests to facilitate testing installations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -357,11 +357,22 @@ if(NOT RDK_INSTALL_INTREE)
         PATTERN "test_list*" EXCLUDE
         PATTERN "CMake*" EXCLUDE
         )
-    install(DIRECTORY Scripts DESTINATION
+    if(RDK_INSTALL_PYTHON_TESTS)
+      install(DIRECTORY Scripts DESTINATION
         ${RDKit_ShareDir}
         COMPONENT data
         PATTERN ".svn" EXCLUDE
         )
+    else(RDK_INSTALL_PYTHON_TESTS)
+      install(DIRECTORY Scripts DESTINATION
+        ${RDKit_ShareDir}
+        COMPONENT data
+        PATTERN ".svn" EXCLUDE
+        PATTERN "run_python_tests.py" EXCLUDE
+        )
+    endif(RDK_INSTALL_PYTHON_TESTS)
+
+
   endif(RDK_BUILD_PYTHON_WRAPPERS)
   install(FILES README license.txt
           DESTINATION ${RDKit_ShareDir}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ option(RDK_PGSQL_STATIC "statically link rdkit libraries into the PostgreSQL car
 option(RDK_BUILD_CONTRIB "build the Contrib directory" OFF )
 option(RDK_INSTALL_INTREE "install the rdkit in the source tree (former behavior)" ON )
 option(RDK_INSTALL_STATIC_LIBS "install the rdkit static libraries" ON )
+option(RDK_INSTALL_PYTHON_TESTS "install the rdkit Python tests with the wrappers" OFF )
 option(RDK_BUILD_THREADSAFE_SSS "enable thread-safe substructure searching (requires boost.thread)" ON )
 option(RDK_BUILD_SLN_SUPPORT "include support for the SLN format" ON )
 option(RDK_TEST_MULTITHREADED "run some tests of multithreading" ON )
@@ -200,17 +201,27 @@ if(RDK_BUILD_PYTHON_WRAPPERS)
       )
     endif (NOT PYTHON_INSTDIR)
     message("Python Install directory ${PYTHON_INSTDIR}")
-    install(DIRECTORY rdkit DESTINATION ${PYTHON_INSTDIR}
-      COMPONENT python
-      PATTERN ".svn" EXCLUDE
-      PATTERN "test_data" EXCLUDE
-      PATTERN "testData" EXCLUDE
-      PATTERN "test_list*" EXCLUDE
-      PATTERN "CMake*" EXCLUDE
-      PATTERN "Basement" EXCLUDE
-      PATTERN "UnitTest*" EXCLUDE
-      )
     set(RDKit_PythonDir "${PYTHON_INSTDIR}/rdkit")
+    if(RDK_INSTALL_PYTHON_TESTS)
+      install(DIRECTORY rdkit DESTINATION ${PYTHON_INSTDIR}
+        COMPONENT python
+        PATTERN ".svn" EXCLUDE
+        PATTERN "CMake*" EXCLUDE
+        PATTERN "Basement" EXCLUDE
+        )
+    else(RDK_INSTALL_PYTHON_TESTS)
+      install(DIRECTORY rdkit DESTINATION ${PYTHON_INSTDIR}
+        COMPONENT python
+        PATTERN ".svn" EXCLUDE
+        PATTERN "test_data" EXCLUDE
+        PATTERN "testData" EXCLUDE
+        PATTERN "test_list*" EXCLUDE
+        PATTERN "CMake*" EXCLUDE
+        PATTERN "Basement" EXCLUDE
+        PATTERN "UnitTest*" EXCLUDE
+        )
+    endif(RDK_INSTALL_PYTHON_TESTS)
+
   endif(RDK_INSTALL_INTREE)
 
 else(RDK_BUILD_PYTHON_WRAPPERS)
@@ -345,6 +356,11 @@ if(NOT RDK_INSTALL_INTREE)
         PATTERN ".svn" EXCLUDE
         PATTERN "test_list*" EXCLUDE
         PATTERN "CMake*" EXCLUDE
+        )
+    install(DIRECTORY Scripts DESTINATION
+        ${RDKit_ShareDir}
+        COMPONENT data
+        PATTERN ".svn" EXCLUDE
         )
   endif(RDK_BUILD_PYTHON_WRAPPERS)
   install(FILES README license.txt

--- a/Scripts/run_python_tests.py
+++ b/Scripts/run_python_tests.py
@@ -1,0 +1,22 @@
+#
+#  Copyright (C) 2018 Greg Landrum
+#   All Rights Reserved
+#
+#  This file is part of the RDKit.
+#  The contents are covered by the terms of the BSD license
+#  which is included in the file license.txt, found at the root
+#  of the RDKit source tree.
+#
+from rdkit import RDConfig
+from rdkit import TestRunner
+import os,time,sys
+
+if __name__ == '__main__':
+    script = 'test_list.py'
+    os.chdir(RDConfig.RDCodeDir)
+    t1 = time.time()
+    failed,nTests = TestRunner.RunScript(script,doLongTests=False,\
+        verbose=True)
+    t2 = time.time()
+    TestRunner.ReportResults(script,failed,nTests,t2-t1,verbose=True,dest=sys.stderr)
+    sys.exit(len(failed))

--- a/rdkit/TestRunner.py
+++ b/rdkit/TestRunner.py
@@ -1,4 +1,3 @@
-#  $Id$
 #
 #  Copyright (c) 2003-2010 Greg Landrum and Rational Discovery LLC
 #


### PR DESCRIPTION
This provides a new cmake option `RDK_INSTALL_PYTHON_TESTS`, which defaults to off.
When this is set, the cmake-based installation will include the tests and test data that are found in the `rdkit` directory (the current behavior is to not include these in the installation). 

Another change is to start installing the `Scripts` directory in `${RDKit_ShareDir}`. This makes the helper scripts like `FeatFinderCLI.py` part of the installation. When test installation is enabled this directory will also include the script `run_python_tests.py`d, which launches the test framework to run all tests in the `rdkit` module.