### PR TITLE
Fixes #1689

### DIFF
--- a/Code/GraphMol/FileParsers/MolFileParser.cpp
+++ b/Code/GraphMol/FileParsers/MolFileParser.cpp
@@ -1443,15 +1443,31 @@ void ParseMolBlockBonds(std::istream *inStream, unsigned int &line,
 }
 
 bool ParseMolBlockProperties(std::istream *inStream, unsigned int &line,
-                             RWMol *mol) {
+                             RWMol *mol, bool strictParsing) {
   PRECONDITION(inStream, "bad stream");
   PRECONDITION(mol, "bad molecule");
   // older mol files can have an atom list block here
   std::string tempStr = getLine(inStream);
   ++line;
-  if (tempStr[0] != 'M' && tempStr[0] != 'A' && tempStr[0] != 'V' &&
-      tempStr[0] != 'G' && tempStr[0] != 'S') {
-    ParseOldAtomList(mol, tempStr, line);
+  // there is apparently some software out there that puts a
+  // blank line in mol blocks before the "M  END". If we aren't
+  // doing strict parsing, deal with that here.
+  if (!tempStr.size()) {
+    if (!strictParsing) {
+      tempStr = getLine(inStream);
+      ++line;
+    } else {
+      std::ostringstream errout;
+      errout << "Problems encountered parsing Mol data, unexpected blank line "
+                "found at line "
+             << line;
+      throw FileParseException(errout.str());
+    }
+  } else {
+    if (tempStr[0] != 'M' && tempStr[0] != 'A' && tempStr[0] != 'V' &&
+        tempStr[0] != 'G' && tempStr[0] != 'S') {
+      ParseOldAtomList(mol, tempStr, line);
+    }
   }
 
   bool fileComplete = false;
@@ -2293,7 +2309,8 @@ bool ParseV2000CTAB(std::istream *inStream, unsigned int &line, RWMol *mol,
 
   ParseMolBlockBonds(inStream, line, nBonds, mol, chiralityPossible);
 
-  bool fileComplete = ParseMolBlockProperties(inStream, line, mol);
+  bool fileComplete =
+      ParseMolBlockProperties(inStream, line, mol, strictParsing);
   return fileComplete;
 }
 

--- a/Code/GraphMol/FileParsers/test1.cpp
+++ b/Code/GraphMol/FileParsers/test1.cpp
@@ -3748,7 +3748,9 @@ void testPDBFile() {
 
     // test adding hydrogens
     ROMol *nm = MolOps::addHs(*m, false, false, NULL, true);
-    AtomPDBResidueInfo *info = (AtomPDBResidueInfo *)(nm->getAtomWithIdx(nm->getNumAtoms()-1)->getMonomerInfo());
+    AtomPDBResidueInfo *info =
+        (AtomPDBResidueInfo *)(nm->getAtomWithIdx(nm->getNumAtoms() - 1)
+                                   ->getMonomerInfo());
     TEST_ASSERT(info->getMonomerType() == AtomMonomerInfo::PDBRESIDUE);
     TEST_ASSERT(info->getName() == " H7 ");
     TEST_ASSERT(info->getResidueName() == "ASN");
@@ -4883,6 +4885,41 @@ void testGithub1340() {
   BOOST_LOG(rdInfoLog) << "done" << std::endl;
 }
 
+void testGithub1689() {
+  BOOST_LOG(rdInfoLog) << "Test github 1689: Play nice with naughty MOL blocks"
+                       << std::endl;
+
+  std::string molb =
+      "rdkit_blank_line_before_M_END_test.sdf\n"
+      "  ChemDraw12181709392D\n"
+      "\n"
+      "  2  1  0  0  0  0  0  0  0  0999 V2000\n"
+      "   -0.3572   -0.2062    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n"
+      "    0.3572    0.2062    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n"
+      "  1  2  1  0      \n"
+      "\n"
+      "M  END\n";
+  {
+    bool sanitize = true, removeHs = true, strictParsing = false;
+    ROMol *m = MolBlockToMol(molb, sanitize, removeHs, strictParsing);
+    TEST_ASSERT(m);
+    TEST_ASSERT(m->getNumAtoms() == 2);
+    TEST_ASSERT(m->getNumBonds() == 1);
+    delete m;
+  }
+  {
+    bool sanitize = true, removeHs = true, strictParsing = true;
+    bool ok = false;
+    try {
+      MolBlockToMol(molb, sanitize, removeHs, strictParsing);
+    } catch (FileParseException &e) {
+      ok = true;
+    }
+    TEST_ASSERT(ok);
+  }
+  BOOST_LOG(rdInfoLog) << "done" << std::endl;
+}
+
 void RunTests() {
 #if 1
   test1();
@@ -4973,9 +5010,10 @@ void RunTests() {
 
   testMolFileDativeBonds();
   testGithub1251();
-#endif
   testGithub1029();
   testGithub1340();
+#endif
+  testGithub1689();
 }
 
 // must be in German Locale for test...


### PR DESCRIPTION
Allows blank lines in place of old-style atoms lists when `strictParsing` is false