### PR TITLE
switch to using std::regex in the SLN parser

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -228,11 +228,6 @@ else(RDK_BUILD_PYTHON_WRAPPERS)
   find_package(Boost 1.56.0 REQUIRED)
 endif(RDK_BUILD_PYTHON_WRAPPERS)
 
-if(APPLE)
-  find_package(Boost 1.56.0 COMPONENTS regex REQUIRED)
-  list(APPEND Boost_IMPORTED_LIBRARIES "Boost::regex")
-endif(APPLE)
-
 # set the boost include directories
 target_link_libraries(rdkit_base INTERFACE Boost::boost)
 

--- a/Code/GraphMol/SLNParse/CMakeLists.txt
+++ b/Code/GraphMol/SLNParse/CMakeLists.txt
@@ -6,15 +6,8 @@ else(RDK_USE_FLEXBISON)
   set(BISON_EXECUTABLE "")
 endif(RDK_USE_FLEXBISON)
 
-find_package(Boost 1.56.0 COMPONENTS regex REQUIRED)
-list(APPEND Boost_IMPORTED_LIBRARIES "Boost::regex")
-
 if(MSVC)
   ADD_DEFINITIONS("/D YY_NO_UNISTD_H")
-  # as of cmake 2.8.0 and boost 1.43 we need to do this to avoid
-  # forcing the user to build both static and dynamic versions
-  # of the regex library:
-  ADD_DEFINITIONS("/D BOOST_ALL_DYN_LINK")
 endif(MSVC)
 
 if(FLEX_EXECUTABLE)
@@ -48,7 +41,7 @@ endif(BISON_EXECUTABLE)
 rdkit_library(SLNParse
               SLNParse.cpp SLNAttribs.cpp
               ${BISON_OUTPUT_FILES} ${FLEX_OUTPUT_FILES}
-              LINK_LIBRARIES GraphMol Boost::regex )
+              LINK_LIBRARIES GraphMol )
 
 rdkit_headers(SLNAttribs.h
               SLNParse.h
@@ -56,7 +49,7 @@ rdkit_headers(SLNAttribs.h
 
 rdkit_test(testSLNParse test.cpp
            LINK_LIBRARIES SLNParse SmilesParse SubstructMatch
-GraphMol RDGeometryLib RDGeneral Boost::regex
+GraphMol RDGeometryLib RDGeneral
 )
 
 add_subdirectory(Wrap)

--- a/Code/GraphMol/SLNParse/SLNParse.cpp
+++ b/Code/GraphMol/SLNParse/SLNParse.cpp
@@ -1,4 +1,3 @@
-// $Id$
 //
 //  Copyright (c) 2008, Novartis Institutes for BioMedical Research Inc.
 //  All rights reserved.
@@ -40,7 +39,7 @@
 #include <RDGeneral/RDLog.h>
 #include <RDGeneral/Invariant.h>
 #include <boost/algorithm/string.hpp>
-#include <boost/regex.hpp>
+#include <regex>
 
 int yysln_parse(const char *, std::vector<RDKit::RWMol *> *, bool, void *);
 int yysln_lex_init(void **);
@@ -73,8 +72,8 @@ void finalizeQueryMol(ROMol *mol, bool mergeHs) {
          atomIt != mol->endAtoms(); ++atomIt) {
       // set a query for the H count:
       if ((*atomIt)->getNumExplicitHs()) {
-        (*atomIt)
-            ->expandQuery(makeAtomHCountQuery((*atomIt)->getNumExplicitHs()));
+        (*atomIt)->expandQuery(
+            makeAtomHCountQuery((*atomIt)->getNumExplicitHs()));
       }
     }
   }
@@ -104,13 +103,14 @@ void finalizeQueryMol(ROMol *mol, bool mergeHs) {
 
 std::string replaceSLNMacroAtoms(std::string inp, int debugParse) {
   RDUNUSED_PARAM(debugParse);
-  const boost::regex defn("\\{(.+?):(.+?)\\}");
+  const std::regex defn("\\{(.+?):(.+?)\\}");
   const char *empty = "";
 
   std::string res;
   // remove any macro definitions:
-  res = boost::regex_replace(inp, defn, empty,
-                             boost::match_default | boost::format_all);
+  res = std::regex_replace(
+      inp, defn, empty,
+      std::regex_constants::match_default | std::regex_constants::format_sed);
 
   if (res != inp) {
     // there are macro definitions, we're going to replace
@@ -118,18 +118,20 @@ std::string replaceSLNMacroAtoms(std::string inp, int debugParse) {
     std::string::const_iterator start, end;
     start = inp.begin();
     end = inp.end();
-    boost::match_results<std::string::const_iterator> what;
-    boost::match_flag_type flags = boost::match_default;
-    while (regex_search(start, end, what, defn, flags)) {
+    std::match_results<std::string::const_iterator> what;
+    std::regex_constants::match_flag_type flags =
+        std::regex_constants::match_default;
+    while (std::regex_search(start, end, what, defn, flags)) {
       std::string macroNm(what[1].first, what[1].second);
       std::string macroVal(what[2].first, what[2].second);
-      res = boost::regex_replace(res, boost::regex(macroNm), macroVal.c_str(),
-                                 boost::match_default | boost::format_all);
+      res = std::regex_replace(res, std::regex(macroNm), macroVal.c_str(),
+                               std::regex_constants::match_default |
+                                   std::regex_constants::format_sed);
       // update search position:
       start = what[0].second;
       // update flags:
-      flags |= boost::match_prev_avail;
-      flags |= boost::match_not_bob;
+      flags |= std::regex_constants::match_prev_avail;
+      // flags |= std::regex_constants::match_not_bob;
     }
   }
   return res;

--- a/Code/GraphMol/SLNParse/SLNParse.cpp
+++ b/Code/GraphMol/SLNParse/SLNParse.cpp
@@ -131,7 +131,6 @@ std::string replaceSLNMacroAtoms(std::string inp, int debugParse) {
       start = what[0].second;
       // update flags:
       flags |= std::regex_constants::match_prev_avail;
-      // flags |= std::regex_constants::match_not_bob;
     }
   }
   return res;

--- a/Code/GraphMol/SLNParse/Wrap/CMakeLists.txt
+++ b/Code/GraphMol/SLNParse/Wrap/CMakeLists.txt
@@ -2,6 +2,6 @@ rdkit_python_extension(rdSLNParse rdSLNParse.cpp
                        DEST Chem
                        LINK_LIBRARIES
                        SLNParse SmilesParse SubstructMatch GraphMol
-                       RDGeometryLib RDGeneral DataStructs RDBoost Boost::regex)
+                       RDGeometryLib RDGeneral DataStructs RDBoost )
 
 add_pytest(pySLNParse ${CMAKE_CURRENT_SOURCE_DIR}/testSLN.py)


### PR DESCRIPTION
This is another "take advantage of built-in C++11 features" ticket and removes the boost regex dependency.

Since regex is only used in the SLN parser, this isn't a big change.

I've tested on linux, the Mac, and Windows (VS2015).