### PR TITLE
Stop dereferencing end() iterators

### DIFF
--- a/Code/GraphMol/CMakeLists.txt
+++ b/Code/GraphMol/CMakeLists.txt
@@ -123,4 +123,4 @@ rdkit_test(resMolSupplierTest resMolSupplierTest.cpp
 rdkit_test(molBundleTest testMolBundle.cpp
           LINK_LIBRARIES SmilesParse GraphMol RDGeometryLib RDGeneral SubstructMatch FileParsers)
 
-rdkit_test(test-valgrind test-valgrind.cpp LINK_LIBRARIES FileParsers SmilesParse GraphMol RDGeometryLib RDGeneral SubstructMatch ForceFieldHelpers ForceField)
+rdkit_test(test-valgrind test-valgrind.cpp LINK_LIBRARIES SmilesParse GraphMol RDGeneral)

--- a/Code/GraphMol/ROMol.h
+++ b/Code/GraphMol/ROMol.h
@@ -110,13 +110,14 @@ struct CXXAtomIterator {
     Atom *current;
 
     CXXAtomIter(Graph *graph, typename Graph::vertex_iterator pos)
-        : graph(graph),
-          pos(pos),
-          current(boost::num_vertices(*graph) ? (*graph)[*pos] : 0) {}
+        : graph(graph), pos(pos), current(nullptr) {}
 
-    Vertex &operator*() { return current; }
+    Vertex &operator*() {
+      current = (*graph)[*pos];
+      return current;
+    }
     CXXAtomIter &operator++() {
-      current = (*graph)[*(++pos)];
+      ++pos;
       return *this;
     }
     bool operator!=(const CXXAtomIter &it) const { return pos != it.pos; }
@@ -142,13 +143,14 @@ struct CXXBondIterator {
     Bond *current;
 
     CXXBondIter(Graph *graph, typename Graph::edge_iterator pos)
-        : graph(graph),
-          pos(pos),
-          current(boost::num_vertices(*graph) ? (*graph)[*pos] : 0) {}
+        : graph(graph), pos(pos), current(nullptr) {}
 
-    Edge &operator*() { return current; }
+    Edge &operator*() {
+      current = (*graph)[*pos];
+      return current;
+    }
     CXXBondIter &operator++() {
-      current = (*graph)[*(++pos)];
+      ++pos;
       return *this;
     }
     bool operator!=(const CXXBondIter &it) const { return pos != it.pos; }

--- a/Code/GraphMol/test-valgrind.cpp
+++ b/Code/GraphMol/test-valgrind.cpp
@@ -24,24 +24,23 @@ using namespace std;
 using namespace RDKit;
 
 // memory tests for valgrind
-void testRemoveAtomBond(RWMol &m, int atomidx, int bondidx)
-{
+void testRemoveAtomBond(RWMol &m, int atomidx, int bondidx) {
   const Bond *b = m.getBondWithIdx(bondidx);
-  if (bondidx>=0) m.removeBond(b->getBeginAtomIdx(), b->getEndAtomIdx());
-  if (atomidx>=0) m.removeAtom(atomidx);
+  if (bondidx >= 0) m.removeBond(b->getBeginAtomIdx(), b->getEndAtomIdx());
+  if (atomidx >= 0) m.removeAtom(atomidx);
 }
 
 void testRemovals(RWMol m) {
-  for(unsigned int i=0;i<m.getNumAtoms()/2;i++) {
-    int atomidx = (i%2==0) ? m.getNumAtoms()-1 : 0;
-    int bondidx = (i%2==0) ? m.getNumBonds()-1 : 0;
+  for (unsigned int i = 0; i < m.getNumAtoms() / 2; i++) {
+    int atomidx = (i % 2 == 0) ? m.getNumAtoms() - 1 : 0;
+    int bondidx = (i % 2 == 0) ? m.getNumBonds() - 1 : 0;
     testRemoveAtomBond(m, atomidx, bondidx);
   }
 }
 
 void test1() {
   std::string smi = "CCC";
-  for(int i=4; i<20; ++i) {
+  for (int i = 4; i < 20; ++i) {
     smi += "C";
     RWMol *m = SmilesToMol(smi.c_str());
     testRemovals(*m);
@@ -49,10 +48,21 @@ void test1() {
   }
 }
 
+void test2() {
+  std::string smi = "CCC";
+  auto m = std::unique_ptr<ROMol>(SmilesToMol(smi));
+  for (const auto at : m->atoms()) {
+    TEST_ASSERT(at->getAtomicNum() == 6);
+  }
+  for (const auto bnd : m->bonds()) {
+    TEST_ASSERT(bnd->getBondType() == Bond::SINGLE);
+  }
+}
+
 // -------------------------------------------------------------------
 int main() {
   RDLog::InitLogs();
-// boost::logging::enable_logs("rdApp.info");
+  // boost::logging::enable_logs("rdApp.info");
   test1();
 
   return 0;

--- a/Code/GraphMol/test1.cpp
+++ b/Code/GraphMol/test1.cpp
@@ -1452,14 +1452,14 @@ void testRanges() {
 void testGithub1642() {
   BOOST_LOG(rdErrorLog) << "-------------------------------------" << std::endl;
   BOOST_LOG(rdErrorLog)
-      << "    Test github1642: Atom index type is to low for big molecules."
+      << "    Test github1642: Atom index type is too low for big molecules."
       << std::endl;
   RWMol m2;
 
   unsigned int big_num_atoms = 70000;
-
+  Atom *carbon = new Atom(6);
   for (unsigned int i = 0; i < big_num_atoms; ++i) {
-    m2.addAtom(new Atom(6));
+    m2.addAtom(carbon);
   }
 
   TEST_ASSERT(m2.getNumAtoms() == big_num_atoms);
@@ -1469,7 +1469,7 @@ void testGithub1642() {
   }
   TEST_ASSERT(m2.getNumAtoms() == 0);
 
-  BOOST_LOG(rdInfoLog) << "Finished" << std::endl;
+  BOOST_LOG(rdErrorLog) << "Finished" << std::endl;
 }
 
 // -------------------------------------------------------------------


### PR DESCRIPTION
The new code for doing range-based loops over atoms and bonds illegally dereferences the `end()` vertex/edge iterators when `CXX{Atom,Bond}Iterator::end()` is called. This fixes that.

There's also a memory leak fix for one of the recently added tests.