### PR TITLE
Stop putting brackets around * atoms in SMILES

### DIFF
--- a/Code/GraphMol/ChemReactions/testReaction.cpp
+++ b/Code/GraphMol/ChemReactions/testReaction.cpp
@@ -1474,7 +1474,7 @@ void test15Issue1882749() {
       << "Testing sf.net Issue 1882749: property handling in products."
       << std::endl;
 
-  smi = "[N:1]-!@[*]>>[N;+1,+0:1][#0]";
+  smi = "[N:1]-!@*>>[N;+1,+0:1][#0]";
   rxn = RxnSmartsToChemicalReaction(smi);
   TEST_ASSERT(rxn);
   TEST_ASSERT(rxn->getNumReactantTemplates() == 1);
@@ -1484,7 +1484,7 @@ void test15Issue1882749() {
   TEST_ASSERT(nError == 0);
 
   delete rxn;
-  smi = "[N:1]-!@[*]>>[N;-1:1]";
+  smi = "[N:1]-!@*>>[N;-1:1]";
   rxn = RxnSmartsToChemicalReaction(smi);
   TEST_ASSERT(rxn);
   TEST_ASSERT(rxn->getNumReactantTemplates() == 1);
@@ -1507,7 +1507,7 @@ void test15Issue1882749() {
   TEST_ASSERT(prods[0][0]->getAtomWithIdx(0)->getFormalCharge() == -1);
 
   delete rxn;
-  smi = "[N;D3:1]-!@[*]>>[N;H1:1]";
+  smi = "[N;D3:1]-!@*>>[N;H1:1]";
   rxn = RxnSmartsToChemicalReaction(smi);
   TEST_ASSERT(rxn);
   TEST_ASSERT(rxn->getNumReactantTemplates() == 1);
@@ -1523,7 +1523,7 @@ void test15Issue1882749() {
   TEST_ASSERT(prods[0][0]->getAtomWithIdx(0)->getNumExplicitHs() == 1);
 
   delete rxn;
-  smi = "[N;D3:1]-!@[*]>>[15N:1]";
+  smi = "[N;D3:1]-!@*>>[15N:1]";
   rxn = RxnSmartsToChemicalReaction(smi);
   TEST_ASSERT(rxn);
   TEST_ASSERT(rxn->getNumReactantTemplates() == 1);
@@ -1543,7 +1543,7 @@ void test15Issue1882749() {
   TEST_ASSERT(feq(prods[0][0]->getAtomWithIdx(0)->getMass(), 15.0001));
 
   delete rxn;
-  smi = "[N;D3:1]-!@[*]>>[15N;-1:1]";
+  smi = "[N;D3:1]-!@*>>[15N;-1:1]";
   rxn = RxnSmartsToChemicalReaction(smi);
   TEST_ASSERT(rxn);
   TEST_ASSERT(rxn->getNumReactantTemplates() == 1);
@@ -2105,7 +2105,7 @@ void test19Issue2050085() {
       << "Testing sf.net Issue 2050085: recap failing on chiral molecules."
       << std::endl;
 
-  smi = "[N;!D1;+0](-!@[*:1])-!@[*:2]>>[*][*:1].[*:2][*]";
+  smi = "[N;!D1;+0](-!@[*:1])-!@[*:2]>>*[*:1].[*:2]*";
   rxn = RxnSmartsToChemicalReaction(smi);
   TEST_ASSERT(rxn);
   TEST_ASSERT(rxn->getNumReactantTemplates() == 1);

--- a/Code/GraphMol/ChemTransforms/testChemTransforms.cpp
+++ b/Code/GraphMol/ChemTransforms/testChemTransforms.cpp
@@ -630,7 +630,7 @@ void testReplaceCore() {
   TEST_ASSERT(mol1);
 
   delete matcher1;
-  sma = "[*]C1CC([*])C1";
+  sma = "*C1CC(*)C1";
   matcher1 = SmartsToMol(sma);
   TEST_ASSERT(matcher1);
 
@@ -716,10 +716,10 @@ void testReplaceCore2() {
        "[3*]C.[4*]CC"},
 
       {"CNOC", "CONC", false, true, false, false, ""},
-      {"PCNOCS", "CONC", false, true, false, false, "[*]S.[3*]P"},
+      {"PCNOCS", "CONC", false, true, false, false, "*S.[3*]P"},
       {"PCNOCS", "CONC", false, false, false, false, "[1*]S.[2*]P"},
 
-      {"PCONCS", "CONC", false, true, false, false, "[*]P.[3*]S"},
+      {"PCONCS", "CONC", false, true, false, false, "*P.[3*]S"},
       {"PCONCS", "CONC", false, false, false, false, "[1*]P.[2*]S"}
 
   };

--- a/Code/GraphMol/RGroupDecomposition/testRGroupDecomp.cpp
+++ b/Code/GraphMol/RGroupDecomposition/testRGroupDecomp.cpp
@@ -181,10 +181,10 @@ void testRingMatching() {
 const char *ringData2[3] = {"c1cocc1CCl", "c1c[nH]cc1CI", "c1cscc1CF"};
 
 const char *ringDataRes2[3] = {
-    "Core:[*]1[*][*][*:1](C[*:2])[*]1 R1:[H]c1oc([H])c([*:1])c1[H] R2:Cl[*:2]",
-    "Core:[*]1[*][*][*:1](C[*:2])[*]1 R1:[H]c1c([*:1])c([H])n([H])c1[H] "
+    "Core:*1**[*:1](C[*:2])*1 R1:[H]c1oc([H])c([*:1])c1[H] R2:Cl[*:2]",
+    "Core:*1**[*:1](C[*:2])*1 R1:[H]c1c([*:1])c([H])n([H])c1[H] "
     "R2:I[*:2]",
-    "Core:[*]1[*][*][*:1](C[*:2])[*]1 R1:[H]c1sc([H])c([*:1])c1[H] R2:F[*:2]"};
+    "Core:*1**[*:1](C[*:2])*1 R1:[H]c1sc([H])c([*:1])c1[H] R2:F[*:2]"};
 
 void testRingMatching2() {
   BOOST_LOG(rdInfoLog)
@@ -325,7 +325,7 @@ void testGithub1550() {
 
   decomp.process();
   RGroupColumns groups = decomp.getRGroupsAsColumns();
-  
+
   RWMol *coreRes = (RWMol *)groups["Core"][0].get();
   TEST_ASSERT(coreRes->getNumAtoms() == 14);
   MolOps::Kekulize(*coreRes);
@@ -409,7 +409,7 @@ void testGitHubIssue1705() {
 
   TEST_ASSERT(ss.str() == "Rgroup===Core\nOc1ccc([*:2])cc1[*:1]\nOc1ccc([*:2])cc1[*:1]\nOc1ccc([*:2])cc1[*:1]\nOc1ccc([*:2])cc1[*:1]\nOc1ccc([*:2])cc1[*:1]\nRgroup===R1\n[H][*:1]\nF[*:1]\nF[*:1]\nF[*:1]\nCl[*:1]\nRgroup===R2\n[H][*:2]\n[H][*:2]\n[H][*:2]\n[H]N([H])[*:2]\n[H][*:2]\n");
 
-  
+
 }
 
 
@@ -432,7 +432,7 @@ int main() {
   testRemoveHs();
 
   testGitHubIssue1705();
-  
+
   BOOST_LOG(rdInfoLog)
       << "********************************************************\n";
   return 0;

--- a/Code/GraphMol/ReducedGraphs/Wrap/testReducedGraphs.py
+++ b/Code/GraphMol/ReducedGraphs/Wrap/testReducedGraphs.py
@@ -16,18 +16,18 @@ class TestCase(unittest.TestCase):
     m = Chem.MolFromSmiles('OCCc1ccccc1')
     mrg = rdRG.GenerateMolExtendedReducedGraph(m)
     mrg.UpdatePropertyCache(False)
-    self.failUnlessEqual('[*]cCCO', Chem.MolToSmiles(mrg))
+    self.failUnlessEqual('*cCCO', Chem.MolToSmiles(mrg))
 
     m = Chem.MolFromSmiles('OCCC1CCCCC1')
     mrg = rdRG.GenerateMolExtendedReducedGraph(m)
     mrg.UpdatePropertyCache(False)
-    self.failUnlessEqual('[*]CCCO', Chem.MolToSmiles(mrg))
+    self.failUnlessEqual('*CCCO', Chem.MolToSmiles(mrg))
 
   def test2(self):
     m = Chem.MolFromSmiles('OCCc1ccccc1')
     mrg = rdRG.GenerateMolExtendedReducedGraph(m)
     mrg.UpdatePropertyCache(False)
-    self.failUnlessEqual('[*]cCCO', Chem.MolToSmiles(mrg))
+    self.failUnlessEqual('*cCCO', Chem.MolToSmiles(mrg))
 
     fp1 = rdRG.GenerateErGFingerprintForReducedGraph(mrg)
     fp2 = rdRG.GetErGFingerprint(m)

--- a/Code/GraphMol/SmilesParse/SmilesWrite.cpp
+++ b/Code/GraphMol/SmilesParse/SmilesWrite.cpp
@@ -27,7 +27,7 @@
 namespace RDKit {
 
 namespace SmilesWrite {
-const int atomicSmiles[] = {5, 6, 7, 8, 9, 15, 16, 17, 35, 53, -1};
+const int atomicSmiles[] = {0, 5, 6, 7, 8, 9, 15, 16, 17, 35, 53, -1};
 bool inOrganicSubset(int atomicNumber) {
   unsigned int idx = 0;
   while (atomicSmiles[idx] < atomicNumber && atomicSmiles[idx] != -1) {
@@ -53,7 +53,8 @@ std::string GetAtomSmiles(const Atom *atom, bool doKekule, const Bond *bondIn,
 
   bool needsBracket = false;
   std::string symb;
-  if (!atom->getPropIfPresent(common_properties::smilesSymbol, symb)) {
+  bool hasCustomSymbol = atom->getPropIfPresent(common_properties::smilesSymbol, symb);
+  if (!hasCustomSymbol) {
     symb = PeriodicTable::getTable()->getElementSymbol(num);
   }
 
@@ -90,7 +91,7 @@ std::string GetAtomSmiles(const Atom *atom, bool doKekule, const Bond *bondIn,
     int totalValence = atom->getTotalValence();
     bool nonStandard = false;
 
-    if (atom->getNumRadicalElectrons()) {
+    if (hasCustomSymbol || atom->getNumRadicalElectrons()) {
       nonStandard = true;
     } else if ((num == 7 || num == 15) && atom->getIsAromatic() &&
                atom->getNumExplicitHs()) {

--- a/Code/GraphMol/SmilesParse/test.cpp
+++ b/Code/GraphMol/SmilesParse/test.cpp
@@ -2807,10 +2807,10 @@ void testBug3525799() {
     m = SmilesToMol(smiles);
     TEST_ASSERT(m);
     smiles = MolToSmiles(*m, true);
-    TEST_ASSERT(smiles == "[*]CC");
+    TEST_ASSERT(smiles == "*CC");
     m->getAtomWithIdx(2)->setProp(common_properties::dummyLabel, "foo");
     smiles = MolToSmiles(*m, true);
-    TEST_ASSERT(smiles == "[*]CC");
+    TEST_ASSERT(smiles == "*CC");
     delete m;
   }
 
@@ -2820,7 +2820,7 @@ void testBug3525799() {
     m = SmilesToMol(smiles);
     TEST_ASSERT(m);
     smiles = MolToSmiles(*m, true);
-    TEST_ASSERT(smiles == "[*]CC");
+    TEST_ASSERT(smiles == "*CC");
     m->getAtomWithIdx(2)->setProp(common_properties::smilesSymbol, "Xa");
     smiles = MolToSmiles(*m, true);
     TEST_ASSERT(smiles == "[Xa]CC");

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -3171,7 +3171,7 @@ CAS<~>
     self.assertEqual(frags, ((0, 12), (1, 2, 3, 5, 11, 14, 16), (4, 13), (6, 7, 15, 18),
                              (8, 9, 10, 17)))
     smi = Chem.MolToSmiles(nm, True)
-    self.assertEqual(smi, '[*]C1CC([4*])C1[6*].[1*]C.[3*]O.[5*]CC[8*].[7*]C1CC1')
+    self.assertEqual(smi, '*C1CC([4*])C1[6*].[1*]C.[3*]O.[5*]CC[8*].[7*]C1CC1')
 
     nm = Chem.FragmentOnBonds(m, bs, dummyLabels=labels)
     frags = Chem.GetMolFrags(nm)
@@ -4343,14 +4343,14 @@ CAS<~>
     self.assertEqual(m.GetAtomWithIdx(4).GetHybridization().name,'S')
 
   def testGithub1366(self):
-    mol = Chem.MolFromSmiles('[*]C[*]')
+    mol = Chem.MolFromSmiles('*C*')
     mol = Chem.RWMol(mol)
     ats = iter(mol.GetAtoms())
     atom = next(ats)
     mol.RemoveAtom(atom.GetIdx())
     self.assertRaises(RuntimeError,next,ats)
 
-    mol = Chem.MolFromSmiles('[*]C[*]')
+    mol = Chem.MolFromSmiles('*C*')
     mol = Chem.RWMol(mol)
     bonds = iter(mol.GetBonds())
     bond = next(bonds)

--- a/Code/GraphMol/molopstest.cpp
+++ b/Code/GraphMol/molopstest.cpp
@@ -3136,19 +3136,19 @@ void testSFNetIssue2196817() {
     RWMol *m = SmilesToMol(smi);
     TEST_ASSERT(m);
     smi = MolToSmiles(*m);
-    TEST_ASSERT(smi == "[*]1cc[*][nH]1");
+    TEST_ASSERT(smi == "*1cc*[nH]1");
     delete m;
     smi = "c1***c1";
     m = SmilesToMol(smi);
     TEST_ASSERT(m);
     smi = MolToSmiles(*m);
-    TEST_ASSERT(smi == "[*]1:[*]cc[*]:1");
+    TEST_ASSERT(smi == "*1:*cc*:1");
     delete m;
     smi = "c:1:*:*:*:*1";
     m = SmilesToMol(smi);
     TEST_ASSERT(m);
     smi = MolToSmiles(*m);
-    TEST_ASSERT(smi == "[*]1:[*]:[*]c[*]:1");
+    TEST_ASSERT(smi == "*1:*:*c*:1");
 
     delete m;
     // we don't kekulize rings that are all dummies, this was github #1478
@@ -3156,7 +3156,7 @@ void testSFNetIssue2196817() {
     m = SmilesToMol(smi);
     TEST_ASSERT(m);
     smi = MolToSmiles(*m);
-    TEST_ASSERT(smi == "[*]1:[*]:[*]:[*]:[*]:1");
+    TEST_ASSERT(smi == "*1:*:*:*:*:1");
     delete m;
   }
 
@@ -3183,7 +3183,7 @@ void testSFNetIssue2196817() {
   }
 
   {
-    std::string smi = "c1ccc(C2CC(n4cc[*]c4=C2))cc1";
+    std::string smi = "c1ccc(C2CC(n4cc*c4=C2))cc1";
     RWMol *m = SmilesToMol(smi);
     TEST_ASSERT(m);
     TEST_ASSERT(m->getBondBetweenAtoms(0, 1)->getIsAromatic());
@@ -4693,7 +4693,7 @@ void testRenumberAtoms() {
     ROMol *nm = MolOps::renumberAtoms(*m, nVect);
     delete m;
   }
-  
+
   BOOST_LOG(rdInfoLog) << "Finished" << std::endl;
 }
 void testGithubIssue141() {

--- a/Code/GraphMol/testChirality.cpp
+++ b/Code/GraphMol/testChirality.cpp
@@ -2137,7 +2137,7 @@ void testGithub553() {
   }
 
   {
-    std::string smi = "[*][C@H]([*:2])[*:3]";
+    std::string smi = "*[C@H]([*:2])[*:3]";
     ROMol *m = SmilesToMol(smi);
     TEST_ASSERT(m);
     TEST_ASSERT(m->getNumAtoms() == 4);
@@ -2178,7 +2178,7 @@ void testGithub803() {
                        << std::endl;
 
   {
-    std::string smi = "[*][C@H]([9*])[8*]";
+    std::string smi = "*[C@H]([9*])[8*]";
     ROMol *m = SmilesToMol(smi);
     TEST_ASSERT(m);
     TEST_ASSERT(m->getNumAtoms() == 4);
@@ -2192,12 +2192,12 @@ void testGithub803() {
     TEST_ASSERT(cip == "S");
 
     smi = MolToSmiles(*m, true);
-    TEST_ASSERT(smi == "[*][C@@H]([8*])[9*]");
+    TEST_ASSERT(smi == "*[C@@H]([8*])[9*]");
 
     delete m;
   }
   {
-    std::string smi = "[*][C@H]([15*])[9*]";
+    std::string smi = "*[C@H]([15*])[9*]";
     ROMol *m = SmilesToMol(smi);
     TEST_ASSERT(m);
     TEST_ASSERT(m->getNumAtoms() == 4);
@@ -2211,7 +2211,7 @@ void testGithub803() {
     TEST_ASSERT(cip == "S");
 
     smi = MolToSmiles(*m, true);
-    TEST_ASSERT(smi == "[*][C@@H]([9*])[15*]");
+    TEST_ASSERT(smi == "*[C@@H]([9*])[15*]");
 
     delete m;
   }
@@ -2487,7 +2487,7 @@ void testIssue1735() {
   BOOST_LOG(rdInfoLog) << "done" << std::endl;
 }
 
-  
+
 int main() {
   RDLog::InitLogs();
 // boost::logging::enable_logs("rdApp.debug");

--- a/rdkit/Chem/Fraggle/FraggleSim.py
+++ b/rdkit/Chem/Fraggle/FraggleSim.py
@@ -69,7 +69,7 @@ FTYPE_CYCLIC_ACYCLIC = 'cyclic_and_acyclic'
 # Global SMARTS used by the program
 
 # acyclic bond smarts
-ACYC_SMARTS = Chem.MolFromSmarts("[*]!@!=!#[*]")
+ACYC_SMARTS = Chem.MolFromSmarts("*!@!=!#*")
 # exocyclic/fused exocyclic bond smarts
 CYC_SMARTS = Chem.MolFromSmarts("[R1,R2]@[r;!R1]")
 
@@ -86,7 +86,7 @@ def delete_bonds(mol, bonds, ftype, hac):
   """ Fragment molecule on bonds and reduce to fraggle fragmentation SMILES.
   If none exists, returns None """
 
-  # Replace the given bonds with attachment points (B1-B2 -> B1-[*].[*]-B2)
+  # Replace the given bonds with attachment points (B1-B2 -> B1-*.*-B2)
   bondIdx = [mol.GetBondBetweenAtoms(*bond).GetIdx() for bond in bonds]
   modifiedMol = Chem.FragmentOnBonds(mol, bondIdx, dummyLabels=[(0, 0)] * len(bondIdx))
 
@@ -188,22 +188,22 @@ def generate_fraggle_fragmentation(mol, verbose=False):
     >>> fragments = generate_fraggle_fragmentation(q)
     >>> fragments = sorted(['.'.join(sorted(s.split('.'))) for s in fragments])
     >>> fragments
-     ['[*]C(=O)NC1CCN(Cc2cc(OC)c3ccccc3c2OC)CC1',
-      '[*]C(=O)c1cncc(C)c1.[*]C1CCN(Cc2cc(OC)c3ccccc3c2OC)CC1',
-      '[*]C(=O)c1cncc(C)c1.[*]Cc1cc(OC)c2ccccc2c1OC',
-      '[*]C(=O)c1cncc(C)c1.[*]c1cc(OC)c2ccccc2c1OC',
-      '[*]C1CCN(Cc2cc(OC)c3ccccc3c2OC)CC1',
-      '[*]C1CCN(Cc2cc(OC)c3ccccc3c2OC)CC1.[*]c1cncc(C)c1',
-      '[*]Cc1cc(OC)c2ccccc2c1OC.[*]NC(=O)c1cncc(C)c1',
-      '[*]Cc1cc(OC)c2ccccc2c1OC.[*]c1cncc(C)c1',
-      '[*]N1CCC(NC(=O)c2cncc(C)c2)CC1.[*]c1cc(OC)c2ccccc2c1OC',
-      '[*]NC(=O)c1cncc(C)c1.[*]c1cc(OC)c2ccccc2c1OC',
-      '[*]NC1CCN(Cc2cc(OC)c3ccccc3c2OC)CC1',
-      '[*]NC1CCN(Cc2cc(OC)c3ccccc3c2OC)CC1.[*]c1cncc(C)c1',
-      '[*]c1c(CN2CCC(NC(=O)c3cncc(C)c3)CC2)cc(OC)c2ccccc12',
-      '[*]c1c(OC)cc(CN2CCC(NC(=O)c3cncc(C)c3)CC2)c(OC)c1[*]',
-      '[*]c1cc(CN2CCC(NC(=O)c3cncc(C)c3)CC2)c(OC)c2ccccc12',
-      '[*]c1cc(OC)c2ccccc2c1OC.[*]c1cncc(C)c1']
+     ['*C(=O)NC1CCN(Cc2cc(OC)c3ccccc3c2OC)CC1',
+      '*C(=O)c1cncc(C)c1.*C1CCN(Cc2cc(OC)c3ccccc3c2OC)CC1',
+      '*C(=O)c1cncc(C)c1.*Cc1cc(OC)c2ccccc2c1OC',
+      '*C(=O)c1cncc(C)c1.*c1cc(OC)c2ccccc2c1OC',
+      '*C1CCN(Cc2cc(OC)c3ccccc3c2OC)CC1',
+      '*C1CCN(Cc2cc(OC)c3ccccc3c2OC)CC1.*c1cncc(C)c1',
+      '*Cc1cc(OC)c2ccccc2c1OC.*NC(=O)c1cncc(C)c1',
+      '*Cc1cc(OC)c2ccccc2c1OC.*c1cncc(C)c1',
+      '*N1CCC(NC(=O)c2cncc(C)c2)CC1.*c1cc(OC)c2ccccc2c1OC',
+      '*NC(=O)c1cncc(C)c1.*c1cc(OC)c2ccccc2c1OC',
+      '*NC1CCN(Cc2cc(OC)c3ccccc3c2OC)CC1',
+      '*NC1CCN(Cc2cc(OC)c3ccccc3c2OC)CC1.*c1cncc(C)c1',
+      '*c1c(CN2CCC(NC(=O)c3cncc(C)c3)CC2)cc(OC)c2ccccc12',
+      '*c1c(OC)cc(CN2CCC(NC(=O)c3cncc(C)c3)CC2)c(OC)c1*',
+      '*c1cc(CN2CCC(NC(=O)c3cncc(C)c3)CC2)c(OC)c2ccccc12',
+      '*c1cc(OC)c2ccccc2c1OC.*c1cncc(C)c1']
   """
   # query mol heavy atom count
   hac = mol.GetNumAtoms()
@@ -359,21 +359,21 @@ def GetFraggleSimilarity(queryMol, refMol, tverskyThresh=0.8):
     >>> sim
     0.980...
     >>> match
-    '[*]C1CCN(Cc2cc(OC)c3ccccc3c2OC)CC1'
+    '*C1CCN(Cc2cc(OC)c3ccccc3c2OC)CC1'
 
     >>> m = Chem.MolFromSmiles('COc1cc(CN2CCC(Nc3nc4ccccc4s3)CC2)c(OC)c2ccccc12')
     >>> sim,match = GetFraggleSimilarity(q,m)
     >>> sim
     0.794...
     >>> match
-    '[*]C1CCN(Cc2cc(OC)c3ccccc3c2OC)CC1'
+    '*C1CCN(Cc2cc(OC)c3ccccc3c2OC)CC1'
 
     >>> q = Chem.MolFromSmiles('COc1ccccc1')
     >>> sim,match = GetFraggleSimilarity(q,m)
     >>> sim
     0.347...
     >>> match
-    '[*]c1ccccc1'
+    '*c1ccccc1'
 
     """
   if hasattr(queryMol, '_fraggleDecomp'):

--- a/rdkit/Chem/Fraggle/UnitTestFraggle.py
+++ b/rdkit/Chem/Fraggle/UnitTestFraggle.py
@@ -37,18 +37,18 @@ class TestCase(unittest.TestCase):
     frags = FraggleSim.generate_fraggle_fragmentation(mol)
     self.assertEqual(len(frags), 16)
     expected = (
-      '[*]C(=O)NC1CCN(Cc2cc(OC)c3ccccc3c2OC)CC1',
-      '[*]C(=O)c1cncc(C)c1.[*]C1CCN(Cc2cc(OC)c3ccccc3c2OC)CC1',
-      '[*]C(=O)c1cncc(C)c1.[*]c1cc(OC)c2ccccc2c1OC', '[*]C1CCN(Cc2cc(OC)c3ccccc3c2OC)CC1',
-      '[*]C(=O)c1cncc(C)c1.[*]Cc1cc(OC)c2ccccc2c1OC',
-      '[*]Cc1cc(OC)c2ccccc2c1OC.[*]NC(=O)c1cncc(C)c1', '[*]Cc1cc(OC)c2ccccc2c1OC.[*]c1cncc(C)c1',
-      '[*]NC(=O)c1cncc(C)c1.[*]c1cc(OC)c2ccccc2c1OC', '[*]NC1CCN(Cc2cc(OC)c3ccccc3c2OC)CC1',
-      '[*]NC1CCN(Cc2cc(OC)c3ccccc3c2OC)CC1.[*]c1cncc(C)c1',
-      '[*]c1c(CN2CCC(NC(=O)c3cncc(C)c3)CC2)cc(OC)c2ccccc12',
-      '[*]c1c(OC)cc(CN2CCC(NC(=O)c3cncc(C)c3)CC2)c(OC)c1[*]',
-      '[*]c1cc(CN2CCC(NC(=O)c3cncc(C)c3)CC2)c(OC)c2ccccc12',
-      '[*]N1CCC(NC(=O)c2cncc(C)c2)CC1.[*]c1cc(OC)c2ccccc2c1OC',
-      '[*]C1CCN(Cc2cc(OC)c3ccccc3c2OC)CC1.[*]c1cncc(C)c1', '[*]c1cc(OC)c2ccccc2c1OC.[*]c1cncc(C)c1')
+      '*C(=O)NC1CCN(Cc2cc(OC)c3ccccc3c2OC)CC1',
+      '*C(=O)c1cncc(C)c1.*C1CCN(Cc2cc(OC)c3ccccc3c2OC)CC1',
+      '*C(=O)c1cncc(C)c1.*c1cc(OC)c2ccccc2c1OC', '*C1CCN(Cc2cc(OC)c3ccccc3c2OC)CC1',
+      '*C(=O)c1cncc(C)c1.*Cc1cc(OC)c2ccccc2c1OC',
+      '*Cc1cc(OC)c2ccccc2c1OC.*NC(=O)c1cncc(C)c1', '*Cc1cc(OC)c2ccccc2c1OC.*c1cncc(C)c1',
+      '*NC(=O)c1cncc(C)c1.*c1cc(OC)c2ccccc2c1OC', '*NC1CCN(Cc2cc(OC)c3ccccc3c2OC)CC1',
+      '*NC1CCN(Cc2cc(OC)c3ccccc3c2OC)CC1.*c1cncc(C)c1',
+      '*c1c(CN2CCC(NC(=O)c3cncc(C)c3)CC2)cc(OC)c2ccccc12',
+      '*c1c(OC)cc(CN2CCC(NC(=O)c3cncc(C)c3)CC2)c(OC)c1*',
+      '*c1cc(CN2CCC(NC(=O)c3cncc(C)c3)CC2)c(OC)c2ccccc12',
+      '*N1CCC(NC(=O)c2cncc(C)c2)CC1.*c1cc(OC)c2ccccc2c1OC',
+      '*C1CCN(Cc2cc(OC)c3ccccc3c2OC)CC1.*c1cncc(C)c1', '*c1cc(OC)c2ccccc2c1OC.*c1cncc(C)c1')
     expected = [_of(s) for s in expected]
     for smi in frags:
       self.assertTrue(_of(smi) in expected)
@@ -56,8 +56,8 @@ class TestCase(unittest.TestCase):
     # Test case for fragments that contain a cyclic and acyclic component
     mol = Chem.MolFromSmiles('c12c(CCC)cccc2cccc1')
     frags = FraggleSim.generate_fraggle_fragmentation(mol)
-    expected = ['[*]CCC.[*]c1ccccc1[*]', '[*]Cc1cccc2ccccc12', '[*]c1cccc(CCC)c1[*]',
-                '[*]c1cccc2ccccc12', '[*]c1ccccc1[*]']
+    expected = ['*CCC.*c1ccccc1*', '*Cc1cccc2ccccc12', '*c1cccc(CCC)c1*',
+                '*c1cccc2ccccc12', '*c1ccccc1*']
     expected = [_of(s) for s in expected]
     for smi in frags:
       self.assertTrue(_of(smi) in expected)
@@ -69,16 +69,16 @@ class TestCase(unittest.TestCase):
     self.assertEqual(len(frags), 13)
 
     expected = (
-      '[*]C(=O)c1ccccc1.[*]C1CCN(Cc2cc(OC)c3ccccc3c2OC)CC1',
-      '[*]C(=O)c1ccccc1.[*]Cc1cc(OC)c2ccccc2c1OC', '[*]C(=O)c1ccccc1.[*]c1cc(OC)c2ccccc2c1OC',
-      '[*]C1CCN(Cc2cc(OC)c3ccccc3c2OC)CC1.[*]c1ccccc1',
-      '[*]Cc1cc(OC)c2ccccc2c1OC.[*]NC(=O)c1ccccc1', '[*]Cc1cc(OC)c2ccccc2c1OC.[*]c1ccccc1',
-      '[*]N1CCC(NC(=O)c2ccccc2)CC1.[*]c1cc(OC)c2ccccc2c1OC',
-      '[*]NC(=O)c1ccccc1.[*]c1cc(OC)c2ccccc2c1OC',
-      '[*]NC1CCN(Cc2cc(OC)c3ccccc3c2OC)CC1.[*]c1ccccc1',
-      '[*]c1c(CN2CCC(NC(=O)c3ccccc3)CC2)cc(OC)c2ccccc12',
-      '[*]c1c(OC)cc(CN2CCC(NC(=O)c3ccccc3)CC2)c(OC)c1[*]',
-      '[*]c1cc(CN2CCC(NC(=O)c3ccccc3)CC2)c(OC)c2ccccc12', '[*]c1cc(OC)c2ccccc2c1OC.[*]c1ccccc1')
+      '*C(=O)c1ccccc1.*C1CCN(Cc2cc(OC)c3ccccc3c2OC)CC1',
+      '*C(=O)c1ccccc1.*Cc1cc(OC)c2ccccc2c1OC', '*C(=O)c1ccccc1.*c1cc(OC)c2ccccc2c1OC',
+      '*C1CCN(Cc2cc(OC)c3ccccc3c2OC)CC1.*c1ccccc1',
+      '*Cc1cc(OC)c2ccccc2c1OC.*NC(=O)c1ccccc1', '*Cc1cc(OC)c2ccccc2c1OC.*c1ccccc1',
+      '*N1CCC(NC(=O)c2ccccc2)CC1.*c1cc(OC)c2ccccc2c1OC',
+      '*NC(=O)c1ccccc1.*c1cc(OC)c2ccccc2c1OC',
+      '*NC1CCN(Cc2cc(OC)c3ccccc3c2OC)CC1.*c1ccccc1',
+      '*c1c(CN2CCC(NC(=O)c3ccccc3)CC2)cc(OC)c2ccccc12',
+      '*c1c(OC)cc(CN2CCC(NC(=O)c3ccccc3)CC2)c(OC)c1*',
+      '*c1cc(CN2CCC(NC(=O)c3ccccc3)CC2)c(OC)c2ccccc12', '*c1cc(OC)c2ccccc2c1OC.*c1ccccc1')
     expected = [_of(s) for s in expected]
     for smi in frags:
       self.assertIn(_of(smi), expected)
@@ -88,39 +88,39 @@ class TestCase(unittest.TestCase):
 
   def test_select_fragments_acyclic(self):
     # acyclic fragments: returns fragments with more than two heavy atoms
-    self._testSelectFragment('[*]C.[*]O[*].[*]c1cccc2ccccc12', FraggleSim.FTYPE_ACYCLIC, 12,
-                             '[*]c1cccc2ccccc12')
+    self._testSelectFragment('*C.*O*.*c1cccc2ccccc12', FraggleSim.FTYPE_ACYCLIC, 12,
+                             '*c1cccc2ccccc12')
     # ignore the fragments if less than 60% of original molecule
-    self._testSelectFragment('[*]CC.[*]O[*].[*]c1ccccc1', FraggleSim.FTYPE_ACYCLIC, 9,
-                             '[*]c1ccccc1')
-    self._testSelectFragment('[*]CC.[*]OCC[*].[*]c1ccccc1', FraggleSim.FTYPE_ACYCLIC, 11,
-                             '[*]c1ccccc1')
-    self._testSelectFragment('[*]CC.[*]OCCC[*].[*]c1ccccc1', FraggleSim.FTYPE_ACYCLIC, 12, None)
+    self._testSelectFragment('*CC.*O*.*c1ccccc1', FraggleSim.FTYPE_ACYCLIC, 9,
+                             '*c1ccccc1')
+    self._testSelectFragment('*CC.*OCC*.*c1ccccc1', FraggleSim.FTYPE_ACYCLIC, 11,
+                             '*c1ccccc1')
+    self._testSelectFragment('*CC.*OCCC*.*c1ccccc1', FraggleSim.FTYPE_ACYCLIC, 12, None)
     # ignore fragments that are smaller than 2 atoms
-    self._testSelectFragment('[*]C.[*]O[*].[*]c1ccccc1', FraggleSim.FTYPE_ACYCLIC, 8, '[*]c1ccccc1')
-    self._testSelectFragment('[*]CC.[*]O[*].[*]c1ccccc1', FraggleSim.FTYPE_ACYCLIC, 9,
-                             '[*]c1ccccc1')
-    self._testSelectFragment('[*]CCC.[*]O[*].[*]c1ccccc1', FraggleSim.FTYPE_ACYCLIC, 10,
-                             '[*]CCC.[*]c1ccccc1')
+    self._testSelectFragment('*C.*O*.*c1ccccc1', FraggleSim.FTYPE_ACYCLIC, 8, '*c1ccccc1')
+    self._testSelectFragment('*CC.*O*.*c1ccccc1', FraggleSim.FTYPE_ACYCLIC, 9,
+                             '*c1ccccc1')
+    self._testSelectFragment('*CCC.*O*.*c1ccccc1', FraggleSim.FTYPE_ACYCLIC, 10,
+                             '*CCC.*c1ccccc1')
     # Only small fragments
-    self._testSelectFragment('[*]CC.[*]CC.[*]CC', FraggleSim.FTYPE_ACYCLIC, 6, None)
-    self._testSelectFragment('[*]CCC.[*]CCC.[*]CCC', FraggleSim.FTYPE_ACYCLIC, 6,
-                             '[*]CCC.[*]CCC.[*]CCC')
+    self._testSelectFragment('*CC.*CC.*CC', FraggleSim.FTYPE_ACYCLIC, 6, None)
+    self._testSelectFragment('*CCC.*CCC.*CCC', FraggleSim.FTYPE_ACYCLIC, 6,
+                             '*CCC.*CCC.*CCC')
 
   def test_select_fragments_cyclic(self):
-    self._testSelectFragment('[*]c1ccccc1[*].[*]cccc[*]', FraggleSim.FTYPE_CYCLIC, 10,
-                             '[*]c1ccccc1[*]')
-    self._testSelectFragment('[*]c1ccccc1[*].[*]C.[*]C', FraggleSim.FTYPE_CYCLIC, 8, None)
+    self._testSelectFragment('*c1ccccc1*.*cccc*', FraggleSim.FTYPE_CYCLIC, 10,
+                             '*c1ccccc1*')
+    self._testSelectFragment('*c1ccccc1*.*C.*C', FraggleSim.FTYPE_CYCLIC, 8, None)
     # Fragment too small
-    self._testSelectFragment('[*]c1ccccc1[*].[*]c(CCCCCCCCCC)ccc[*]', FraggleSim.FTYPE_CYCLIC, 20,
+    self._testSelectFragment('*c1ccccc1*.*c(CCCCCCCCCC)ccc*', FraggleSim.FTYPE_CYCLIC, 20,
                              None)
 
   def test_select_fragments_cyclic_acyclic(self):
-    self._testSelectFragment('[*]c1ccccc1[*].[*]CCC.[*]C', FraggleSim.FTYPE_CYCLIC_ACYCLIC, 10,
-                             '[*]c1ccccc1[*].[*]CCC')
-    self._testSelectFragment('[*]CCC.[*]C.[*]c1ccccc1[*]', FraggleSim.FTYPE_CYCLIC_ACYCLIC, 10,
-                             '[*]CCC.[*]c1ccccc1[*]')
-    self._testSelectFragment('[*]CCC.[*]CCCCCCCCCCC[*].[*]c1ccccc1[*]',
+    self._testSelectFragment('*c1ccccc1*.*CCC.*C', FraggleSim.FTYPE_CYCLIC_ACYCLIC, 10,
+                             '*c1ccccc1*.*CCC')
+    self._testSelectFragment('*CCC.*C.*c1ccccc1*', FraggleSim.FTYPE_CYCLIC_ACYCLIC, 10,
+                             '*CCC.*c1ccccc1*')
+    self._testSelectFragment('*CCC.*CCCCCCCCCCC*.*c1ccccc1*',
                              FraggleSim.FTYPE_CYCLIC_ACYCLIC, 25, None)
 
   def _testSelectFragment(self, smiles, fragmentType, numAtoms, expected):
@@ -130,11 +130,11 @@ class TestCase(unittest.TestCase):
 
   def test_isValidRingCut(self):
     rdBase.DisableLog('rdApp.error')
-    self.assertEqual(FraggleSim.isValidRingCut(Chem.MolFromSmiles('[*]CCC[*]')), False)
-    self.assertEqual(FraggleSim.isValidRingCut(Chem.MolFromSmiles('[*]C1CC1[*]')), True)
-    self.assertEqual(FraggleSim.isValidRingCut(Chem.MolFromSmiles('[*]c1ccccc1[*]')), True)
+    self.assertEqual(FraggleSim.isValidRingCut(Chem.MolFromSmiles('*CCC*')), False)
+    self.assertEqual(FraggleSim.isValidRingCut(Chem.MolFromSmiles('*C1CC1*')), True)
+    self.assertEqual(FraggleSim.isValidRingCut(Chem.MolFromSmiles('*c1ccccc1*')), True)
     self.assertEqual(
-      FraggleSim.isValidRingCut(Chem.MolFromSmiles('[*]cccc[*]', sanitize=False)), False)
+      FraggleSim.isValidRingCut(Chem.MolFromSmiles('*cccc*', sanitize=False)), False)
     rdBase.EnableLog('rdApp.error')
 
   def test_GetFraggleSimilarity(self):
@@ -142,22 +142,22 @@ class TestCase(unittest.TestCase):
     m = Chem.MolFromSmiles('COc1cc(CN2CCC(NC(=O)c3ccccc3)CC2)c(OC)c2ccccc12')
     sim, match = FraggleSim.GetFraggleSimilarity(q, m)
     self.assertAlmostEqual(sim, 0.980, places=2)
-    self.assertEqual(match, '[*]C1CCN(Cc2cc(OC)c3ccccc3c2OC)CC1')
+    self.assertEqual(match, '*C1CCN(Cc2cc(OC)c3ccccc3c2OC)CC1')
 
     m = Chem.MolFromSmiles('COc1cc(CN2CCC(Nc3nc4ccccc4s3)CC2)c(OC)c2ccccc12')
     sim, match = FraggleSim.GetFraggleSimilarity(q, m)
     self.assertAlmostEqual(sim, 0.794, places=2)
-    self.assertEqual(match, '[*]C1CCN(Cc2cc(OC)c3ccccc3c2OC)CC1')
+    self.assertEqual(match, '*C1CCN(Cc2cc(OC)c3ccccc3c2OC)CC1')
 
     q = Chem.MolFromSmiles('COc1ccccc1')
     sim, match = FraggleSim.GetFraggleSimilarity(q, m)
     self.assertAlmostEqual(sim, 0.347, places=2)
-    self.assertEqual(match, '[*]c1ccccc1')
+    self.assertEqual(match, '*c1ccccc1')
 
     m = Chem.MolFromSmiles('COc1cc(CN2CCC(NC(=O)c3ccccc3)CC2)c(OC)c2ccccc12')
     sim, match = FraggleSim.GetFraggleSimilarity(q, m)
     self.assertAlmostEqual(sim, 0.266, places=2)
-    self.assertEqual(match, '[*]c1ccccc1')
+    self.assertEqual(match, '*c1ccccc1')
 
 
 if __name__ == '__main__':  # pragma: nocover

--- a/rdkit/Chem/Recap.py
+++ b/rdkit/Chem/Recap.py
@@ -1,19 +1,19 @@
 #
 #  Copyright (c) 2007, Novartis Institutes for BioMedical Research Inc.
 #  All rights reserved.
-# 
+#
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are
-# met: 
+# met:
 #
-#     * Redistributions of source code must retain the above copyright 
+#     * Redistributions of source code must retain the above copyright
 #       notice, this list of conditions and the following disclaimer.
 #     * Redistributions in binary form must reproduce the above
-#       copyright notice, this list of conditions and the following 
-#       disclaimer in the documentation and/or other materials provided 
+#       copyright notice, this list of conditions and the following
+#       disclaimer in the documentation and/or other materials provided
 #       with the distribution.
-#     * Neither the name of Novartis Institutes for BioMedical Research Inc. 
-#       nor the names of its contributors may be used to endorse or promote 
+#     * Neither the name of Novartis Institutes for BioMedical Research Inc.
+#       nor the names of its contributors may be used to endorse or promote
 #       products derived from this software without specific prior written permission.
 #
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
@@ -43,16 +43,15 @@ For example:
 >>> res
 <...Chem.Recap.RecapHierarchyNode object at ...>
 >>> sorted(res.children.keys())
-['[*]C1CC1', '[*]c1ccc(OC)cn1', '[*]c1ccccc1-c1...cc(OC)c...1', '[*]c1ccccc1OC1CC1']
+['*C1CC1', '*c1ccc(OC)cn1', '*c1ccccc1-c1ccc(OC)cn1', '*c1ccccc1OC1CC1']
 >>> sorted(res.GetAllChildren().keys())
-['[*]C1CC1', '[*]c1ccc(OC)cn1', '[*]c1ccccc1-c1...cc(OC)c...1', '[*]c1ccccc1OC1CC1', '[*]c1ccccc1[*]']
-
+['*C1CC1', '*c1ccc(OC)cn1', '*c1ccccc1*', '*c1ccccc1-c1ccc(OC)cn1', '*c1ccccc1OC1CC1']
 
 To get the standard set of RECAP results, use GetLeaves():
 >>> leaves=res.GetLeaves()
 >>> sorted(leaves.keys())
-['[*]C1CC1', '[*]c1ccc(OC)cn1', '[*]c1ccccc1[*]']
->>> leaf = leaves['[*]C1CC1']
+['*C1CC1', '*c1ccc(OC)cn1', '*c1ccccc1*']
+>>> leaf = leaves['*C1CC1']
 >>> leaf.mol
 <...Chem.rdchem.Mol object at ...>
 
@@ -66,21 +65,21 @@ from rdkit.six import iterkeys, iteritems, next
 
 # These are the definitions that will be applied to fragment molecules:
 reactionDefs = (
-  "[#7;+0;D2,D3:1]!@C(!@=O)!@[#7;+0;D2,D3:2]>>[*][#7:1].[#7:2][*]",  # urea
-  "[C;!$(C([#7])[#7]):1](=!@[O:2])!@[#7;+0;!D1:3]>>[*][C:1]=[O:2].[*][#7:3]",  # amide
-  "[C:1](=!@[O:2])!@[O;+0:3]>>[*][C:1]=[O:2].[O:3][*]",  # ester
-  "[N;!D1;+0;!$(N-C=[#7,#8,#15,#16])](-!@[*:1])-!@[*:2]>>[*][*:1].[*:2][*]",  # amines
-  #"[N;!D1](!@[*:1])!@[*:2]>>[*][*:1].[*:2][*]", # amines
+  "[#7;+0;D2,D3:1]!@C(!@=O)!@[#7;+0;D2,D3:2]>>*[#7:1].[#7:2]*",  # urea
+  "[C;!$(C([#7])[#7]):1](=!@[O:2])!@[#7;+0;!D1:3]>>*[C:1]=[O:2].*[#7:3]",  # amide
+  "[C:1](=!@[O:2])!@[O;+0:3]>>*[C:1]=[O:2].[O:3]*",  # ester
+  "[N;!D1;+0;!$(N-C=[#7,#8,#15,#16])](-!@[*:1])-!@[*:2]>>*[*:1].[*:2]*",  # amines
+  #"[N;!D1](!@[*:1])!@[*:2]>>*[*:1].[*:2]*", # amines
 
   # again: what about aromatics?
-  "[#7;R;D3;+0:1]-!@[*:2]>>[*][#7:1].[*:2][*]",  # cyclic amines
-  "[#6:1]-!@[O;+0]-!@[#6:2]>>[#6:1][*].[*][#6:2]",  # ether
-  "[C:1]=!@[C:2]>>[C:1][*].[*][C:2]",  # olefin
-  "[n;+0:1]-!@[C:2]>>[n:1][*].[C:2][*]",  # aromatic nitrogen - aliphatic carbon
-  "[O:3]=[C:4]-@[N;+0:1]-!@[C:2]>>[O:3]=[C:4]-[N:1][*].[C:2][*]",  # lactam nitrogen - aliphatic carbon
-  "[c:1]-!@[c:2]>>[c:1][*].[*][c:2]",  # aromatic carbon - aromatic carbon
-  "[n;+0:1]-!@[c:2]>>[n:1][*].[*][c:2]",  # aromatic nitrogen - aromatic carbon *NOTE* this is not part of the standard recap set.
-  "[#7;+0;D2,D3:1]-!@[S:2](=[O:3])=[O:4]>>[#7:1][*].[*][S:2](=[O:3])=[O:4]",  # sulphonamide
+  "[#7;R;D3;+0:1]-!@[*:2]>>*[#7:1].[*:2]*",  # cyclic amines
+  "[#6:1]-!@[O;+0]-!@[#6:2]>>[#6:1]*.*[#6:2]",  # ether
+  "[C:1]=!@[C:2]>>[C:1]*.*[C:2]",  # olefin
+  "[n;+0:1]-!@[C:2]>>[n:1]*.[C:2]*",  # aromatic nitrogen - aliphatic carbon
+  "[O:3]=[C:4]-@[N;+0:1]-!@[C:2]>>[O:3]=[C:4]-[N:1]*.[C:2]*",  # lactam nitrogen - aliphatic carbon
+  "[c:1]-!@[c:2]>>[c:1]*.*[c:2]",  # aromatic carbon - aromatic carbon
+  "[n;+0:1]-!@[c:2]>>[n:1]*.*[c:2]",  # aromatic nitrogen - aromatic carbon *NOTE* this is not part of the standard recap set.
+  "[#7;+0;D2,D3:1]-!@[S:2](=[O:3])=[O:4]>>[#7:1]*.*[S:2](=[O:3])=[O:4]",  # sulphonamide
 )
 
 reactions = tuple([Reactions.ReactionFromSmarts(x) for x in reactionDefs])
@@ -190,7 +189,7 @@ def RecapDecompose(mol, allNodes=None, minFragmentSize=0, onlyUseReactions=None)
                 break
             # don't forget after replacing dummy atoms to remove any empty
             # branches:
-            elif pSmi.replace('[*]', '').replace('()', '') in ('', 'C', 'CC', 'CCC'):
+            elif pSmi.replace('*', '').replace('()', '') in ('', 'C', 'CC', 'CCC'):
               seqOk = False
               break
             prod.pSmi = pSmi
@@ -248,8 +247,8 @@ if __name__ == '__main__':
       self.assertTrue(len(res.children.keys()) == 2)
       # we get two more nodes from that:
       self.assertTrue(len(allNodes.keys()) == 5)
-      self.assertTrue('[*]c1ccccc1OC' in allNodes)
-      self.assertTrue('[*]c1ccccc1' in allNodes)
+      self.assertTrue('*c1ccccc1OC' in allNodes)
+      self.assertTrue('*c1ccccc1' in allNodes)
 
       m = Chem.MolFromSmiles('C1CC1Oc1ccccc1-c1ncccc1')
       res = RecapDecompose(m, allNodes=allNodes)
@@ -263,9 +262,9 @@ if __name__ == '__main__':
       self.assertTrue(res)
       self.assertTrue(len(res.GetLeaves()) == 2)
       ks = res.GetLeaves().keys()
-      self.assertFalse('[*]C([*])[*]' in ks)
-      self.assertTrue('[*]c1ccccc1' in ks)
-      self.assertTrue('[*]C([*])Oc1ccccc1' in ks)
+      self.assertFalse('*C(*)*' in ks)
+      self.assertTrue('*c1ccccc1' in ks)
+      self.assertTrue('*C(*)Oc1ccccc1' in ks)
 
     def testSFNetIssue1804418(self):
       m = Chem.MolFromSmiles('C1CCCCN1CCCC')
@@ -273,8 +272,8 @@ if __name__ == '__main__':
       self.assertTrue(res)
       self.assertTrue(len(res.GetLeaves()) == 2)
       ks = res.GetLeaves().keys()
-      self.assertTrue('[*]N1CCCCC1' in ks)
-      self.assertTrue('[*]CCCC' in ks)
+      self.assertTrue('*N1CCCCC1' in ks)
+      self.assertTrue('*CCCC' in ks)
 
     def testMinFragmentSize(self):
       m = Chem.MolFromSmiles('CCCOCCC')
@@ -285,7 +284,7 @@ if __name__ == '__main__':
       self.assertTrue(res)
       self.assertTrue(len(res.GetLeaves()) == 1)
       ks = res.GetLeaves().keys()
-      self.assertTrue('[*]CCC' in ks)
+      self.assertTrue('*CCC' in ks)
 
       m = Chem.MolFromSmiles('CCCOCC')
       res = RecapDecompose(m, minFragmentSize=3)
@@ -297,9 +296,9 @@ if __name__ == '__main__':
       self.assertTrue(res)
       self.assertTrue(len(res.GetLeaves()) == 2)
       ks = res.GetLeaves().keys()
-      self.assertTrue('[*]CCC' in ks)
+      self.assertTrue('*CCC' in ks)
       ks = res.GetLeaves().keys()
-      self.assertTrue('[*]CCOC' in ks)
+      self.assertTrue('*CCOC' in ks)
 
     def testAmideRxn(self):
       m = Chem.MolFromSmiles('C1CC1C(=O)NC1OC1')
@@ -307,24 +306,24 @@ if __name__ == '__main__':
       self.assertTrue(res)
       self.assertTrue(len(res.GetLeaves()) == 2)
       ks = res.GetLeaves().keys()
-      self.assertTrue('[*]C(=O)C1CC1' in ks)
-      self.assertTrue('[*]NC1CO1' in ks)
+      self.assertTrue('*C(=O)C1CC1' in ks)
+      self.assertTrue('*NC1CO1' in ks)
 
       m = Chem.MolFromSmiles('C1CC1C(=O)N(C)C1OC1')
       res = RecapDecompose(m, onlyUseReactions=[1])
       self.assertTrue(res)
       self.assertTrue(len(res.GetLeaves()) == 2)
       ks = res.GetLeaves().keys()
-      self.assertTrue('[*]C(=O)C1CC1' in ks)
-      self.assertTrue('[*]N(C)C1CO1' in ks)
+      self.assertTrue('*C(=O)C1CC1' in ks)
+      self.assertTrue('*N(C)C1CO1' in ks)
 
       m = Chem.MolFromSmiles('C1CC1C(=O)n1cccc1')
       res = RecapDecompose(m, onlyUseReactions=[1])
       self.assertTrue(res)
       self.assertTrue(len(res.GetLeaves()) == 2)
       ks = res.GetLeaves().keys()
-      self.assertTrue('[*]C(=O)C1CC1' in ks)
-      self.assertTrue('[*]n1cccc1' in ks)
+      self.assertTrue('*C(=O)C1CC1' in ks)
+      self.assertTrue('*n1cccc1' in ks)
 
       m = Chem.MolFromSmiles('C1CC1C(=O)CC1OC1')
       res = RecapDecompose(m, onlyUseReactions=[1])
@@ -359,8 +358,8 @@ if __name__ == '__main__':
       self.assertTrue(res)
       self.assertTrue(len(res.GetLeaves()) == 2)
       ks = res.GetLeaves().keys()
-      self.assertTrue('[*]C(=O)C1CC1' in ks)
-      self.assertTrue('[*]OC1CO1' in ks)
+      self.assertTrue('*C(=O)C1CC1' in ks)
+      self.assertTrue('*OC1CO1' in ks)
 
       m = Chem.MolFromSmiles('C1CC1C(=O)CC1OC1')
       res = RecapDecompose(m, onlyUseReactions=[2])
@@ -378,16 +377,16 @@ if __name__ == '__main__':
       self.assertTrue(res)
       self.assertTrue(len(res.GetLeaves()) == 2)
       ks = res.GetLeaves().keys()
-      self.assertTrue('[*]NC1CC1' in ks)
-      self.assertTrue('[*]NC1CO1' in ks)
+      self.assertTrue('*NC1CC1' in ks)
+      self.assertTrue('*NC1CO1' in ks)
 
       m = Chem.MolFromSmiles('C1CC1NC(=O)N(C)C1OC1')
       res = RecapDecompose(m, onlyUseReactions=[0])
       self.assertTrue(res)
       self.assertTrue(len(res.GetLeaves()) == 2)
       ks = res.GetLeaves().keys()
-      self.assertTrue('[*]NC1CC1' in ks)
-      self.assertTrue('[*]N(C)C1CO1' in ks)
+      self.assertTrue('*NC1CC1' in ks)
+      self.assertTrue('*N(C)C1CO1' in ks)
 
       m = Chem.MolFromSmiles('C1CCNC(=O)NC1C')
       res = RecapDecompose(m, onlyUseReactions=[0])
@@ -399,15 +398,15 @@ if __name__ == '__main__':
       self.assertTrue(res)
       self.assertTrue(len(res.GetLeaves()) == 2)
       ks = res.GetLeaves().keys()
-      self.assertTrue('[*]n1cccc1' in ks)
-      self.assertTrue('[*]NC1CO1' in ks)
+      self.assertTrue('*n1cccc1' in ks)
+      self.assertTrue('*NC1CO1' in ks)
 
       m = Chem.MolFromSmiles('c1cccn1C(=O)n1c(C)ccc1')
       res = RecapDecompose(m, onlyUseReactions=[0])
       self.assertTrue(res)
       self.assertTrue(len(res.GetLeaves()) == 2)
       ks = res.GetLeaves().keys()
-      self.assertTrue('[*]n1cccc1C' in ks)
+      self.assertTrue('*n1cccc1C' in ks)
 
     def testAmineRxn(self):
       m = Chem.MolFromSmiles('C1CC1N(C1NC1)C1OC1')
@@ -415,44 +414,44 @@ if __name__ == '__main__':
       self.assertTrue(res)
       self.assertTrue(len(res.GetLeaves()) == 3)
       ks = res.GetLeaves().keys()
-      self.assertTrue('[*]C1CC1' in ks)
-      self.assertTrue('[*]C1CO1' in ks)
-      self.assertTrue('[*]C1CN1' in ks)
+      self.assertTrue('*C1CC1' in ks)
+      self.assertTrue('*C1CO1' in ks)
+      self.assertTrue('*C1CN1' in ks)
 
       m = Chem.MolFromSmiles('c1ccccc1N(C1NC1)C1OC1')
       res = RecapDecompose(m)
       self.assertTrue(res)
       self.assertTrue(len(res.GetLeaves()) == 3)
       ks = res.GetLeaves().keys()
-      self.assertTrue('[*]c1ccccc1' in ks)
-      self.assertTrue('[*]C1CO1' in ks)
-      self.assertTrue('[*]C1CN1' in ks)
+      self.assertTrue('*c1ccccc1' in ks)
+      self.assertTrue('*C1CO1' in ks)
+      self.assertTrue('*C1CN1' in ks)
 
       m = Chem.MolFromSmiles('c1ccccc1N(c1ncccc1)C1OC1')
       res = RecapDecompose(m)
       self.assertTrue(res)
       self.assertTrue(len(res.GetLeaves()) == 3)
       ks = res.GetLeaves().keys()
-      self.assertTrue('[*]c1ccccc1' in ks)
-      self.assertTrue('[*]c1ccccn1' in ks)
-      self.assertTrue('[*]C1CO1' in ks)
+      self.assertTrue('*c1ccccc1' in ks)
+      self.assertTrue('*c1ccccn1' in ks)
+      self.assertTrue('*C1CO1' in ks)
 
       m = Chem.MolFromSmiles('c1ccccc1N(c1ncccc1)c1ccco1')
       res = RecapDecompose(m)
       self.assertTrue(res)
       self.assertTrue(len(res.GetLeaves()) == 3)
       ks = res.GetLeaves().keys()
-      self.assertTrue('[*]c1ccccc1' in ks)
-      self.assertTrue('[*]c1ccccn1' in ks)
-      self.assertTrue('[*]c1ccco1' in ks)
+      self.assertTrue('*c1ccccc1' in ks)
+      self.assertTrue('*c1ccccn1' in ks)
+      self.assertTrue('*c1ccco1' in ks)
 
       m = Chem.MolFromSmiles('C1CCCCN1C1CC1')
       res = RecapDecompose(m)
       self.assertTrue(res)
       self.assertTrue(len(res.GetLeaves()) == 2)
       ks = res.GetLeaves().keys()
-      self.assertTrue('[*]N1CCCCC1' in ks)
-      self.assertTrue('[*]C1CC1' in ks)
+      self.assertTrue('*N1CCCCC1' in ks)
+      self.assertTrue('*C1CC1' in ks)
 
       m = Chem.MolFromSmiles('C1CCC2N1CC2')
       res = RecapDecompose(m)
@@ -465,8 +464,8 @@ if __name__ == '__main__':
       self.assertTrue(res)
       self.assertTrue(len(res.GetLeaves()) == 2)
       ks = res.GetLeaves().keys()
-      self.assertTrue('[*]C1CC1' in ks)
-      self.assertTrue('[*]C1CO1' in ks)
+      self.assertTrue('*C1CC1' in ks)
+      self.assertTrue('*C1CO1' in ks)
 
       m = Chem.MolFromSmiles('C1CCCCO1')
       res = RecapDecompose(m)
@@ -478,16 +477,16 @@ if __name__ == '__main__':
       self.assertTrue(res)
       self.assertTrue(len(res.GetLeaves()) == 2)
       ks = res.GetLeaves().keys()
-      self.assertTrue('[*]c1ccccc1' in ks)
-      self.assertTrue('[*]C1CO1' in ks)
+      self.assertTrue('*c1ccccc1' in ks)
+      self.assertTrue('*C1CO1' in ks)
 
       m = Chem.MolFromSmiles('c1ccccc1Oc1ncccc1')
       res = RecapDecompose(m)
       self.assertTrue(res)
       self.assertTrue(len(res.GetLeaves()) == 2)
       ks = res.GetLeaves().keys()
-      self.assertTrue('[*]c1ccccc1' in ks)
-      self.assertTrue('[*]c1ccccn1' in ks)
+      self.assertTrue('*c1ccccc1' in ks)
+      self.assertTrue('*c1ccccn1' in ks)
 
     def testOlefinRxn(self):
       m = Chem.MolFromSmiles('ClC=CBr')
@@ -495,8 +494,8 @@ if __name__ == '__main__':
       self.assertTrue(res)
       self.assertTrue(len(res.GetLeaves()) == 2)
       ks = res.GetLeaves().keys()
-      self.assertTrue('[*]CCl' in ks)
-      self.assertTrue('[*]CBr' in ks)
+      self.assertTrue('*CCl' in ks)
+      self.assertTrue('*CBr' in ks)
 
       m = Chem.MolFromSmiles('C1CC=CC1')
       res = RecapDecompose(m)
@@ -509,8 +508,8 @@ if __name__ == '__main__':
       self.assertTrue(res)
       self.assertTrue(len(res.GetLeaves()) == 2)
       ks = res.GetLeaves().keys()
-      self.assertTrue('[*]n1cccc1' in ks)
-      self.assertTrue('[*]CCCC' in ks)
+      self.assertTrue('*n1cccc1' in ks)
+      self.assertTrue('*CCCC' in ks)
 
       m = Chem.MolFromSmiles('c1ccc2n1CCCC2')
       res = RecapDecompose(m)
@@ -523,8 +522,8 @@ if __name__ == '__main__':
       self.assertTrue(res)
       self.assertTrue(len(res.GetLeaves()) == 2)
       ks = res.GetLeaves().keys()
-      self.assertTrue('[*]N1CCC1=O' in ks)
-      self.assertTrue('[*]CCCC' in ks)
+      self.assertTrue('*N1CCC1=O' in ks)
+      self.assertTrue('*CCCC' in ks)
 
       m = Chem.MolFromSmiles('O=C1CC2N1CCCC2')
       res = RecapDecompose(m)
@@ -537,8 +536,8 @@ if __name__ == '__main__':
       self.assertTrue(res)
       self.assertTrue(len(res.GetLeaves()) == 2)
       ks = res.GetLeaves().keys()
-      self.assertTrue('[*]c1ccccc1' in ks)
-      self.assertTrue('[*]c1ccccn1' in ks)
+      self.assertTrue('*c1ccccc1' in ks)
+      self.assertTrue('*c1ccccn1' in ks)
 
       m = Chem.MolFromSmiles('c1ccccc1C1CC1')
       res = RecapDecompose(m)
@@ -551,8 +550,8 @@ if __name__ == '__main__':
       self.assertTrue(res)
       self.assertTrue(len(res.GetLeaves()) == 2)
       ks = res.GetLeaves().keys()
-      self.assertTrue('[*]n1cccc1' in ks)
-      self.assertTrue('[*]c1ccccc1' in ks)
+      self.assertTrue('*n1cccc1' in ks)
+      self.assertTrue('*c1ccccc1' in ks)
 
     def testSulfonamideRxn(self):
       m = Chem.MolFromSmiles('CCCNS(=O)(=O)CC')
@@ -560,16 +559,16 @@ if __name__ == '__main__':
       self.assertTrue(res)
       self.assertTrue(len(res.GetLeaves()) == 2)
       ks = res.GetLeaves().keys()
-      self.assertTrue('[*]NCCC' in ks)
-      self.assertTrue('[*]S(=O)(=O)CC' in ks)
+      self.assertTrue('*NCCC' in ks)
+      self.assertTrue('*S(=O)(=O)CC' in ks)
 
       m = Chem.MolFromSmiles('c1cccn1S(=O)(=O)CC')
       res = RecapDecompose(m)
       self.assertTrue(res)
       self.assertTrue(len(res.GetLeaves()) == 2)
       ks = res.GetLeaves().keys()
-      self.assertTrue('[*]n1cccc1' in ks)
-      self.assertTrue('[*]S(=O)(=O)CC' in ks)
+      self.assertTrue('*n1cccc1' in ks)
+      self.assertTrue('*S(=O)(=O)CC' in ks)
 
       m = Chem.MolFromSmiles('C1CNS(=O)(=O)CC1')
       res = RecapDecompose(m)

--- a/rdkit/Chem/UnitTestEnumerateHeterocycles.py
+++ b/rdkit/Chem/UnitTestEnumerateHeterocycles.py
@@ -193,8 +193,8 @@ class TestCase(unittest.TestCase):
             ('n1ncccc1', 4),
             ('n1cnccc1', 4),
             ('n1ccncc1', 4),
-            ('c1c([*])[nH]c(=O)[nH]c1=O', 1),
-            ('[*]c1c[nH]c(=O)[nH]c1=O', 1),
+            ('c1c(*)[nH]c(=O)[nH]c1=O', 1),
+            ('*c1c[nH]c(=O)[nH]c1=O', 1),
             ]
 
         smarts_mol = Chem.MolFromSmarts(rxn.SMARTS)

--- a/rdkit/Chem/UnitTestSmiles.py
+++ b/rdkit/Chem/UnitTestSmiles.py
@@ -123,12 +123,12 @@ class TestCase(unittest.TestCase):
       ('Br[C@](N)(C)O',    'O[C@](Br)(C)N'),
 
       # examples with attachment points every toolkit agrees on
-      ('[*][C@@H](C)N',    '[C@H]([*])(C)N'),
-      ('[*][C@@](F)(C)N',  '[C@@]([*])(F)(C)N'),
+      ('*[C@@H](C)N',    '[C@H](*)(C)N'),
+      ('*[C@@](F)(C)N',  '[C@@](*)(F)(C)N'),
 
       # examples from Dalke 2017 UGM talk
-      ('[*][C@](N)(O)S', '[C@]([*])(N)(O)S'),
-      ('[*][C@H](O)S',   '[C@@H]([*])(O)S'),
+      ('*[C@](N)(O)S', '[C@](*)(N)(O)S'),
+      ('*[C@H](O)S',   '[C@@H](*)(O)S'),
       ('[*:1][C@]1([*:2])CC1(Cl)Cl', '[C@]([*:1])1([*:2])CC1(Cl)Cl'), # RDKit used to parse these as different isomers, and ChemAxon removes this stereochemistry entirely
 
       # example from Dalke report here: https://www.mail-archive.com/rdkit-discuss@lists.sourceforge.net/msg05296.html
@@ -146,12 +146,12 @@ class TestCase(unittest.TestCase):
       ('Cl[C@]1(c2ccccc2)NCCCS1',    '[C@](Cl)1(c2ccccc2)NCCCS1'),
       ('Cl3.[C@]31(c2ccccc2)NCCCS1', '[C@](Cl)1(c2ccccc2)NCCCS1'),
       ('Cl[C@](F)1C2C(C1)CNC2',      '[C@](Cl)(F)1C2C(C1)CNC2'),
-      ('[*][C@@H]1CO1',              '[C@H]([*])1CO1'),     # with hydrogen property
-      ('[*][C@@]1(C)CCO1',           '[C@@]([*])1(C)CCO1'), # without hydrogen property
+      ('*[C@@H]1CO1',              '[C@H](*)1CO1'),     # with hydrogen property
+      ('*[C@@]1(C)CCO1',           '[C@@](*)1(C)CCO1'), # without hydrogen property
       ('F[C@@]1(C)CCO1',             '[C@@](F)1(C)CCO1'),   # with a real atom to be sure
 
       # bridge-head ring case, RDKit already agreed with all the other toolkits on this case
-      ('[*][C@@]12CNC[C@H]1C2',   '[C@@]([*])12CNC[C@H]1C2'),
+      ('*[C@@]12CNC[C@H]1C2',   '[C@@](*)12CNC[C@H]1C2'),
 
       # ring cases from https://github.com/rdkit/rdkit/commit/a2fe13f85a89cd66903ca63edeec0f99b61e8185#diff-6c7d3f98ef92f3b9cfd041f772c442f9R29
       ('C1CN[C@](O)(N)1',  'C1CN[C@]1(O)(N)'), # all toolkits agree


### PR DESCRIPTION
outputting dummy atoms as `[*]` instead of `*` is unnecessary and ugly, so stop doing it.