### PR TITLE
Replace link to incorrect thread

### DIFF
--- a/Docs/Book/Cookbook.md
+++ b/Docs/Book/Cookbook.md
@@ -115,7 +115,7 @@ The code:
 
 ### Neutralizing Charged Molecules
 
-Mailing list discussion: <http://www.mail-archive.com/rdkit-discuss@lists.sourceforge.net/msg02648.html>
+Mailing list discussion: <http://www.mail-archive.com/rdkit-discuss@lists.sourceforge.net/msg02669.html>
 
 The code:
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! 
-->
#### Reference Issue


#### What does this implement/fix? Explain your changes.
Under the **Neutralizing Charged Molecules** heading, there was a reference to the mailing list archive, however, this link pointed to an unrelated topic which related to the **Parallel conformation generation** heading. I have replaced it with the only thread from the mailing list archive which I could find which relates to the appropriate topic. Unfortunately, there does not appear to be the original code available from this thread as it point to a dead Google Code Wiki link. 

I apologize if I have included the incorrect thread, but I just wanted to try and fix this issue.

#### Any other comments?

