### PR TITLE
Fix for issue #1730

### DIFF
--- a/Code/GraphMol/Aromaticity.cpp
+++ b/Code/GraphMol/Aromaticity.cpp
@@ -621,18 +621,10 @@ namespace {
 // use minRingSize=0 or maxRingSize=0 to ignore these constraints
 int aromaticityHelper(RWMol &mol, unsigned int minRingSize,
                       unsigned int maxRingSize, bool includeFused) {
-  // FIX: we will assume for now that if the input molecule came
-  // with aromaticity information it is correct and we will not
-  // touch it. Loop through the atoms and check if any atom has
-  // arom stuff set.  We may want check this more carefully later
-  // and start from scratch if necessary
-  ROMol::AtomIterator ai;
-  for (ai = mol.beginAtoms(); ai != mol.endAtoms(); ai++) {
-    if ((*ai)->getIsAromatic()) {
-      // found aromatic info
-      return -1;
-    }
-  }
+  // This function used to check if the input molecule came
+  // with aromaticity information, assumed it is correct and
+  // did not touch it. Now it ignores that information entirely.
+
 
   // first find the all the simple rings in the molecule
   VECT_INT_VECT srings;

--- a/Code/GraphMol/Resonance.cpp
+++ b/Code/GraphMol/Resonance.cpp
@@ -237,7 +237,7 @@ void updateV(unsigned int &v) {
 void sanitizeMol(RWMol &mol) {
   unsigned int opFailed;
   MolOps::sanitizeMol(mol, opFailed, MolOps::SANITIZE_FINDRADICALS |
-                                         MolOps::SANITIZE_SETAROMATICITY |
+                                         //MolOps::SANITIZE_SETAROMATICITY |
                                          MolOps::SANITIZE_ADJUSTHS);
 }
 

--- a/Code/GraphMol/molopstest.cpp
+++ b/Code/GraphMol/molopstest.cpp
@@ -6553,6 +6553,29 @@ void testCustomAromaticity() {
   BOOST_LOG(rdInfoLog) << "Finished" << std::endl;
 }
 
+void testGithubIssue1730() {
+  BOOST_LOG(rdInfoLog) << "-----------------------\n Testing github issue "
+                          "#1730: setAromaticity() should work even if "
+                          "there are aromatic atoms present"
+                       << std::endl;
+  {
+    std::string smiles = "C1=CC=CC=C1-c2ccccc2";
+    RWMol *m = SmilesToMol(smiles, 0, false);
+    m->updatePropertyCache();
+    TEST_ASSERT(m);
+    TEST_ASSERT(m->getBondWithIdx(0)->getIsAromatic() == false);
+    TEST_ASSERT(m->getAtomWithIdx(0)->getIsAromatic() == false);
+    TEST_ASSERT(m->getBondWithIdx(6)->getIsAromatic() == true);
+    TEST_ASSERT(m->getAtomWithIdx(6)->getIsAromatic() == true);
+    MolOps::setAromaticity(*m);
+    TEST_ASSERT(m->getBondWithIdx(0)->getIsAromatic() == true);
+    TEST_ASSERT(m->getAtomWithIdx(0)->getIsAromatic() == true);
+    delete m;
+  }
+
+  BOOST_LOG(rdInfoLog) << "Finished" << std::endl;
+}
+
 void testKekulizeErrorReporting() {
   BOOST_LOG(rdInfoLog)
       << "-----------------------\n Testing error reporting for kekulization"
@@ -7065,6 +7088,7 @@ int main() {
   testKekulizeErrorReporting();
   testGithubIssue868();
   testSimpleAromaticity();
+  testGithubIssue1730();
   testCustomAromaticity();
   testGithubIssue908();
   testGithubIssue962();


### PR DESCRIPTION
setAromaticity() now works even if there are aromatic atoms present and the relevant test case is added

#### Reference Issue

Fixes #1730

#### What does this implement/fix? Explain your changes.

Removed the existing aromaticity info check from aromaticityHelper() used by setAromaticity() that made it not touch the molecule if there are any atoms set as aromatic already.

#### Any other comments?

