### PR TITLE
Fix linking of python bindings on Mac

### DIFF
--- a/Code/RDBoost/CMakeLists.txt
+++ b/Code/RDBoost/CMakeLists.txt
@@ -1,5 +1,12 @@
-rdkit_library(RDBoost Wrap.cpp
-              LINK_LIBRARIES RDGeneral ${PYTHON_LIBRARIES} ${Boost_LIBRARIES})
+if(APPLE)
+  # Don't link against Python library on Mac
+  rdkit_library(RDBoost Wrap.cpp
+                LINK_LIBRARIES RDGeneral ${Boost_LIBRARIES})
+  set_target_properties(RDBoost PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")
+else()
+  rdkit_library(RDBoost Wrap.cpp
+                LINK_LIBRARIES RDGeneral ${PYTHON_LIBRARIES} ${Boost_LIBRARIES})
+endif()
 
 rdkit_headers(Wrap.h PySequenceHolder.h
               list_indexing_suite.hpp

--- a/Code/cmake/Modules/RDKitUtils.cmake
+++ b/Code/cmake/Modules/RDKitUtils.cmake
@@ -112,8 +112,15 @@ else(WIN32)
                           LIBRARY_OUTPUT_DIRECTORY
                           ${RDK_PYTHON_OUTPUT_DIRECTORY}/${RDKPY_DEST})
 endif(WIN32)
+if(APPLE)
+    # Don't link against Python library on Mac
+    target_link_libraries(${RDKPY_NAME} ${RDKPY_LINK_LIBRARIES}
+                          ${Boost_LIBRARIES} )
+    set_target_properties(${RDKPY_NAME} PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")
+else()
     target_link_libraries(${RDKPY_NAME} ${RDKPY_LINK_LIBRARIES}
                           ${PYTHON_LIBRARIES} ${Boost_LIBRARIES} )
+endif()
 
     INSTALL(TARGETS ${RDKPY_NAME}
             LIBRARY DESTINATION ${RDKit_PythonDir}/${RDKPY_DEST} COMPONENT python)


### PR DESCRIPTION
Don’t link against python on Mac, and use `-undefined dynamic_lookup` to allow this.

I believe this fixes #1617, so RDKit works with recent versions of python in the conda `defaults` channel.

Note: For this to work, boost_python also has to be linked in this way. I think this may be the case since around boost 1.59?