### PR TITLE
Add detection of statically linked python executable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,8 @@ endif()
 
 project (RDKit)
 
+add_library(rdkit_base INTERFACE)
+
 IF(NOT CMAKE_BUILD_TYPE)
   SET(CMAKE_BUILD_TYPE Release CACHE STRING
       "Choose the type of build, options are: None Debug Release RelWithDebInfo MinSizeRel."
@@ -149,6 +151,8 @@ if(RDK_BUILD_PYTHON_WRAPPERS)
     set(Python_ADDITIONAL_VERSIONS "${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}")
   endif (PYTHONINTERP_FOUND AND NOT Python_ADDITIONAL_VERSIONS)
   find_package(PythonLibs)
+  target_include_directories(rdkit_base INTERFACE ${PYTHON_INCLUDE_DIR})
+
   if(CMAKE_MAJOR_VERSION EQUAL 2 AND CMAKE_MINOR_VERSION EQUAL 6)
     include_directories(${PYTHON_INCLUDE_PATH})
   else(CMAKE_MAJOR_VERSION EQUAL 2 AND CMAKE_MINOR_VERSION EQUAL 6)
@@ -188,6 +192,28 @@ if(RDK_BUILD_PYTHON_WRAPPERS)
         OUTPUT_STRIP_TRAILING_WHITESPACE
       )
     endif (NOT PYTHON_INSTDIR)
+
+   
+   execute_process(
+      COMMAND
+      ${PYTHON_EXECUTABLE} -c "from distutils import sysconfig; print(sysconfig.get_config_var('Py_ENABLE_SHARED'))"
+      OUTPUT_VARIABLE Py_ENABLE_SHARED
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+   )
+
+   # See https://bugs.python.org/msg277944
+   # The "command to create shared modules". Used as variable in the "Makefile (and similar) templates to build python modules"
+   # for both in-python and third party modules. Initialized to hold the value which works for third party modules to link
+   # against the _installed_ python.
+   # We strip off the first word though (which will be the compiler name).
+   execute_process(
+      COMMAND
+      ${PYTHON_EXECUTABLE} -c "from distutils import sysconfig; print(sysconfig.get_config_var('LDSHARED').split(' ', 1)[1])"
+      OUTPUT_VARIABLE PYTHON_LDSHARED
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+   )
+   message("PYTHON USING LINK LINE: ${PYTHON_LDSHARED}")
+   
     message("Python Install directory ${PYTHON_INSTDIR}")
     install(DIRECTORY rdkit DESTINATION ${PYTHON_INSTDIR}
       COMPONENT python

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -194,26 +194,6 @@ if(RDK_BUILD_PYTHON_WRAPPERS)
     endif (NOT PYTHON_INSTDIR)
 
    
-   execute_process(
-      COMMAND
-      ${PYTHON_EXECUTABLE} -c "from distutils import sysconfig; print(sysconfig.get_config_var('Py_ENABLE_SHARED'))"
-      OUTPUT_VARIABLE Py_ENABLE_SHARED
-      OUTPUT_STRIP_TRAILING_WHITESPACE
-   )
-
-   # See https://bugs.python.org/msg277944
-   # The "command to create shared modules". Used as variable in the "Makefile (and similar) templates to build python modules"
-   # for both in-python and third party modules. Initialized to hold the value which works for third party modules to link
-   # against the _installed_ python.
-   # We strip off the first word though (which will be the compiler name).
-   execute_process(
-      COMMAND
-      ${PYTHON_EXECUTABLE} -c "from distutils import sysconfig; print(sysconfig.get_config_var('LDSHARED').split(' ', 1)[1])"
-      OUTPUT_VARIABLE PYTHON_LDSHARED
-      OUTPUT_STRIP_TRAILING_WHITESPACE
-   )
-   message("PYTHON USING LINK LINE: ${PYTHON_LDSHARED}")
-   
     message("Python Install directory ${PYTHON_INSTDIR}")
     install(DIRECTORY rdkit DESTINATION ${PYTHON_INSTDIR}
       COMPONENT python
@@ -228,6 +208,28 @@ if(RDK_BUILD_PYTHON_WRAPPERS)
     set(RDKit_PythonDir "${PYTHON_INSTDIR}/rdkit")
   endif(RDK_INSTALL_INTREE)
 
+  # determine linkage of python
+  execute_process(
+      COMMAND
+      ${PYTHON_EXECUTABLE} -c "from distutils import sysconfig; print(sysconfig.get_config_var('Py_ENABLE_SHARED'))"
+      OUTPUT_VARIABLE Py_ENABLE_SHARED
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+
+  # See https://bugs.python.org/msg277944
+  # The "command to create shared modules". Used as variable in the "Makefile (and similar) templates to build python modules"
+  # for both in-python and third party modules. Initialized to hold the value which works for third party modules to link
+  # against the _installed_ python.
+  # We strip off the first word though (which will be the compiler name).
+  execute_process(
+      COMMAND
+      ${PYTHON_EXECUTABLE} -c "from distutils import sysconfig; print(sysconfig.get_config_var('LDSHARED').split(' ', 1)[1])"
+      OUTPUT_VARIABLE PYTHON_LDSHARED
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+   )
+   message("PYTHON Py_ENABLE_SHARED: ${Py_ENABLE_SHARED}")
+   message("PYTHON USING LINK LINE: ${PYTHON_LDSHARED}")
+   
 else(RDK_BUILD_PYTHON_WRAPPERS)
   find_package(Boost 1.39.0 REQUIRED)
 endif(RDK_BUILD_PYTHON_WRAPPERS)

--- a/Code/RDBoost/CMakeLists.txt
+++ b/Code/RDBoost/CMakeLists.txt
@@ -1,6 +1,17 @@
-rdkit_library(RDBoost Wrap.cpp
-              LINK_LIBRARIES RDGeneral ${PYTHON_LIBRARIES} ${Boost_LIBRARIES})
-
+if("${Py_ENABLE_SHARED}" STREQUAL "1")
+  rdkit_library(RDBoost Wrap.cpp
+                LINK_LIBRARIES RDGeneral ${PYTHON_LIBRARIES} ${Boost_LIBRARIES})
+else()
+    rdkit_library(RDBoost Wrap.cpp
+                LINK_LIBRARIES RDGeneral ${Boost_LIBRARIES})
+    if("${PYTHON_LDSHARED}" STREQUAL "")
+    else()
+       # fixes an apple issue
+       STRING(REGEX REPLACE "-bundle" "" LDSHARED ${PYTHON_LDSHARED})
+       set_target_properties(RDBoost PROPERTIES LINK_FLAGS ${LDSHARED})
+    endif()
+    
+endif()
 rdkit_headers(Wrap.h PySequenceHolder.h
               list_indexing_suite.hpp
               python.h

--- a/Code/cmake/Modules/RDKitUtils.cmake
+++ b/Code/cmake/Modules/RDKitUtils.cmake
@@ -103,17 +103,25 @@ macro(rdkit_python_extension)
   if(RDK_BUILD_PYTHON_WRAPPERS)
     PYTHON_ADD_MODULE(${RDKPY_NAME} ${RDKPY_SOURCES})
     set_target_properties(${RDKPY_NAME} PROPERTIES PREFIX "")
-if(WIN32)
-    set_target_properties(${RDKPY_NAME} PROPERTIES SUFFIX ".pyd"
-                          LIBRARY_OUTPUT_DIRECTORY
-                          ${RDK_PYTHON_OUTPUT_DIRECTORY}/${RDKPY_DEST})
-else(WIN32)
-    set_target_properties(${RDKPY_NAME} PROPERTIES
-                          LIBRARY_OUTPUT_DIRECTORY
-                          ${RDK_PYTHON_OUTPUT_DIRECTORY}/${RDKPY_DEST})
-endif(WIN32)
-    target_link_libraries(${RDKPY_NAME} ${RDKPY_LINK_LIBRARIES}
-                          ${PYTHON_LIBRARIES} ${Boost_LIBRARIES} )
+    if(WIN32)
+      set_target_properties(${RDKPY_NAME} PROPERTIES SUFFIX ".pyd"
+                           LIBRARY_OUTPUT_DIRECTORY
+                           ${RDK_PYTHON_OUTPUT_DIRECTORY}/${RDKPY_DEST})
+    else(WIN32)
+        set_target_properties(${RDKPY_NAME} PROPERTIES
+                              LIBRARY_OUTPUT_DIRECTORY
+                              ${RDK_PYTHON_OUTPUT_DIRECTORY}/${RDKPY_DEST})
+    endif(WIN32)
+    
+    if("${Py_ENABLE_SHARED}" STREQUAL "1")
+      target_link_libraries(${RDKPY_NAME} ${RDKPY_LINK_LIBRARIES}
+                            ${PYTHON_LIBRARIES} ${Boost_LIBRARIES} )
+    else()
+      target_link_libraries(${RDKPY_NAME} ${RDKPY_LINK_LIBRARIES}
+                            ${Boost_LIBRARIES} )
+      message("set_target_properties ${RDKPY_NAME} PROPERTIES LINK_FLAGS ${PYTHON_LDSHARED}")                            
+      set_target_properties(${RDKPY_NAME} PROPERTIES LINK_FLAGS ${PYTHON_LDSHARED})
+    endif()
 
     INSTALL(TARGETS ${RDKPY_NAME}
             LIBRARY DESTINATION ${RDKit_PythonDir}/${RDKPY_DEST} COMPONENT python)

--- a/Code/cmake/Modules/RDKitUtils.cmake
+++ b/Code/cmake/Modules/RDKitUtils.cmake
@@ -119,8 +119,11 @@ macro(rdkit_python_extension)
     else()
       target_link_libraries(${RDKPY_NAME} ${RDKPY_LINK_LIBRARIES}
                             ${Boost_LIBRARIES} )
-      message("set_target_properties ${RDKPY_NAME} PROPERTIES LINK_FLAGS ${PYTHON_LDSHARED}")                            
-      set_target_properties(${RDKPY_NAME} PROPERTIES LINK_FLAGS ${PYTHON_LDSHARED})
+      if("${PYTHON_LDSHARED}" STREQUAL "")
+      else()
+        message("set_target_properties ${RDKPY_NAME} PROPERTIES LINK_FLAGS ${PYTHON_LDSHARED}")                            
+        set_target_properties(${RDKPY_NAME} PROPERTIES LINK_FLAGS ${PYTHON_LDSHARED})
+      endif()
     endif()
 
     INSTALL(TARGETS ${RDKPY_NAME}


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! 
-->
#### Reference Issue
This is a major change to #1800 

<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.

Detects python linkage and sets up the rdkit linkage appropriately

#### Any other comments?

cmake should really do this...

Boost dependencies used during testing on osx

```
requirements:
  build:
    - cmake
    - requests
    - boost 1.65.*
    - py-boost 1.65.*
    - libcxx
    - python
    - numpy {{ '%s.*' % (environ.get('NPY_VER') or '1.11') }}
    - pillow
    - freetype
    - cairo [linux]
    - cairocffi [linux]
    - pandas
  run:
    - boost 1.65.*
    - py-boost 1.65.*
    - libcxx
    - python
    - numpy {{ '%s.*' % (environ.get('NPY_VER') or '1.11') }}
    - cairo [linux]
    - cairocffi [linux]
```