### PR TITLE
change how the EmbedParameter objects are exposed to Java

### DIFF
--- a/Code/JavaWrappers/DistGeom.i
+++ b/Code/JavaWrappers/DistGeom.i
@@ -57,7 +57,41 @@
 
 %ignore RDKit::DGeomHelpers::EmbedMolecule;
 %ignore RDKit::DGeomHelpers::EmbedMultipleConfs;
+// make sure the struct has a copy constructor:
+%copyctor RDKit::DGeomHelpers::EmbedParameters;
+
+// we want to ignore the const global parameter objects because SWIG does a
+// poor job of making them read-only when they are exposed to Java.
+%ignore RDKit::DGeomHelpers::KDG;
+%ignore RDKit::DGeomHelpers::ETDG;
+%ignore RDKit::DGeomHelpers::ETKDG;
+%ignore RDKit::DGeomHelpers::ETKDGv2;
+
 %include <GraphMol/DistGeomHelpers/Embedder.h>
+
+// create functions to return copies of the global parameter objects
+%newobject RDKit::DGeomHelpers::getKDG;
+%newobject RDKit::DGeomHelpers::getETDG;
+%newobject RDKit::DGeomHelpers::getETKDG;
+%newobject RDKit::DGeomHelpers::getETKDGv2;
+%inline {
+  namespace RDKit{
+    namespace DGeomHelpers {
+      EmbedParameters *getKDG() {
+        return new EmbedParameters(KDG);
+      }
+      EmbedParameters *getETDG() {
+        return new EmbedParameters(ETDG);
+      }
+      EmbedParameters *getETKDG() {
+        return new EmbedParameters(ETKDG);
+      }
+      EmbedParameters *getETKDGv2() {
+        return new EmbedParameters(ETKDGv2);
+      }
+    }
+  }
+}
 
 // A class to hang special distance geometry methods on.
 %inline {

--- a/Code/JavaWrappers/gmwrapper/src-test/org/RDKit/DistanceGeometryTests.java
+++ b/Code/JavaWrappers/gmwrapper/src-test/org/RDKit/DistanceGeometryTests.java
@@ -481,13 +481,21 @@ public class DistanceGeometryTests extends GraphMolTest {
 		ROMol ref=RWMol.MolFromMolFile(molFile.getPath(), true, false);;
 		ROMol test = RWMol.MolFromSmiles("OCCC").addHs(false,false);
     assertTrue(test.getNumAtoms()==ref.getNumAtoms());
-    EmbedParameters eps = RDKFuncs.getETKDG();
+    EmbedParameters eps = new EmbedParameters(RDKFuncs.getETKDG());
     eps.setRandomSeed(42);
 		int cid = DistanceGeom.EmbedMolecule(test,eps);
 		assertTrue(cid>-1);
     double ssd;
 		ssd = test.alignMol(ref);
 		assertTrue(ssd < 0.1);
+
+    // make sure we didn't change the global params
+    EmbedParameters eps2 = RDKFuncs.getETKDG();
+		cid = DistanceGeom.EmbedMolecule(test,eps2);
+		assertTrue(cid>-1);
+		ssd = test.alignMol(ref);
+		assertTrue(ssd > 0.1);
+
 	}
   @Test
 	public void test9ETDGParams2() {
@@ -520,10 +528,10 @@ public class DistanceGeometryTests extends GraphMolTest {
 		assertTrue(ssd < 0.1);
 	}
 
-
-
 	public static void main(String args[]) {
+    System.out.print("STARTING\n");
 		org.junit.runner.JUnitCore.main("org.RDKit.DistanceGeometryTests");
+    System.out.print("FINISHED\n");
 	}
 
 }


### PR DESCRIPTION
- They should not be writeable (this was a problem everywhere)
- On the Mac there were seg faults caused by globals being deleted (at least I think that was what was going on).
- The EmbedParameters struct also did not have a copy ctor in Java.

This fix manually creates functions to expose copies of the relevant objects to Java and adds the copy ctor.
