### PR TITLE
Allow types.h to be included in applications that use /D_USE_MATH_DEFINES

### DIFF
--- a/Code/GraphMol/FMCS/FMCS.cpp
+++ b/Code/GraphMol/FMCS/FMCS.cpp
@@ -259,9 +259,9 @@ static bool checkRingMatch(const MCSBondCompareParameters& p, const ROMol& mol1,
       static_cast<FMCS::RingMatchTableSet*>(v_ringMatchMatrixSet);
 
   const std::vector<size_t>& ringsIdx1 =
-      ringMatchMatrixSet->getQueryBondRings(bond1);  // indeces of rings
+      ringMatchMatrixSet->getQueryBondRings(bond1);  // indices of rings
   const std::vector<size_t>& ringsIdx2 =
-      ringMatchMatrixSet->getTargetBondRings(&mol2, bond2);  // indeces of rings
+      ringMatchMatrixSet->getTargetBondRings(&mol2, bond2);  // indices of rings
   bool bond1inRing = !ringsIdx1.empty();
   bool bond2inRing = !ringsIdx2.empty();
 

--- a/Code/RDGeneral/types.h
+++ b/Code/RDGeneral/types.h
@@ -12,10 +12,16 @@
 #define RD_TYPES_H
 
 #ifdef WIN32
+#ifndef _USE_MATH_DEFINES
 #define _USE_MATH_DEFINES
+#define _DEFINED_USE_MATH_DEFINES
 #endif
-
+#endif
 #include <cmath>
+#ifdef _DEFINED_USE_MATH_DEFINES
+#undef _DEFINED_USE_MATH_DEFINES
+#undef _USE_MATH_DEFINES
+#endif
 
 #include "Invariant.h"
 #include "Dict.h"


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
I had compilation issues on Windows because I set /D_USE_MATH_DEFINES globally. This caused a compilation failure when including types.h.

#### Any other comments?
Maybe the `_DEFINED_USE_MATH_DEFINES` setting is excessive.
