### PR TITLE
Expose minAtomRingSize() and minBondRingSize() to Python wrappers

### DIFF
--- a/Code/GraphMol/Wrap/RingInfo.cpp
+++ b/Code/GraphMol/Wrap/RingInfo.cpp
@@ -57,8 +57,9 @@ struct ringinfo_wrapper {
   static void wrap() {
     python::class_<RingInfo>("RingInfo", classDoc.c_str(), python::no_init)
         .def("IsAtomInRingOfSize", &RingInfo::isAtomInRingOfSize)
+        .def("MinAtomRingSize", &RingInfo::minAtomRingSize)
         .def("IsBondInRingOfSize", &RingInfo::isBondInRingOfSize)
-        .def("IsBondInRingOfSize", &RingInfo::isBondInRingOfSize)
+        .def("MinBondRingSize", &RingInfo::minBondRingSize)
         .def("NumAtomRings", &RingInfo::numAtomRings)
         .def("NumBondRings", &RingInfo::numBondRings)
         .def("NumRings", &RingInfo::numRings)


### PR DESCRIPTION
This PR exposes in Python the smallest ring size for bonds and atoms from `RingInfo` and directly from `Bond` and `Atom` objects. There are no efficient ways to do it now from Python other than iterating over a range of sizes with `IsInRingSize`...

`RingInfo` has those methods already exposed in Java. Is there an automatic way we could make sure that the exposed API match?