### PR TITLE
Don't manually set RDConfig paths in conda env

### DIFF
--- a/rdkit/RDConfig.py
+++ b/rdkit/RDConfig.py
@@ -22,19 +22,6 @@ if 'RDBASE' in os.environ:
   RDBinDir = os.path.join(RDBaseDir, 'bin')
   RDProjDir = os.path.join(RDBaseDir, 'Projects')
   RDContribDir = os.path.join(RDBaseDir, 'Contrib')
-elif 'CONDA_DEFAULT_ENV' in os.environ:
-  # we are running in a conda environ.
-  RDCodeDir = os.path.dirname(__file__)
-  splitdir = RDCodeDir.split(os.path.sep)
-  condaDir = splitdir[:-4]
-  if condaDir[0] == '':
-    condaDir[0] = os.path.sep
-  condaDir += ['share', 'RDKit']
-  _share = os.path.join(*condaDir)
-  RDDataDir = os.path.join(_share, 'Data')
-  RDDocsDir = os.path.join(_share, 'Docs')
-  RDProjDir = os.path.join(_share, 'Projects')
-  RDContribDir = os.path.join(_share, 'Contrib')
 else:
   from rdkit.RDPaths import *
 


### PR DESCRIPTION
These manually set paths are incorrect on Windows. In fact, they don't need to be manually set anyway. Instead, just fall back to using RDPaths, which hardcodes a (placeholder) path at build time. When installing a conda package, conda dynamically replaces all occurrences of hardcoded absolute paths with the correct path to the environment.

This should mean that the [rdconfig.patch](https://github.com/rdkit/conda-rdkit/blob/dev/anaconda5_moderncxx/rdkit/rdconfig.patch) used in the conda recipe is no longer needed.