### PR TITLE
Make svg xmlns prefix use more consistent

### DIFF
--- a/Code/GraphMol/MolDraw2D/MolDraw2DSVG.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DSVG.cpp
@@ -47,20 +47,20 @@ std::string DrawColourToSVG(const DrawColour &col) {
 
 void MolDraw2DSVG::initDrawing() {
   d_os << "<?xml version='1.0' encoding='iso-8859-1'?>\n";
-  d_os << "<svg:svg version='1.1' baseProfile='full'\n      \
-        xmlns:svg='http://www.w3.org/2000/svg'\n              \
+  d_os << "<svg version='1.1' baseProfile='full'\n      \
+        xmlns='http://www.w3.org/2000/svg'\n              \
         xmlns:rdkit='http://www.rdkit.org/xml'\n              \
         xmlns:xlink='http://www.w3.org/1999/xlink'\n          \
         xml:space='preserve'\n";
   d_os << "width='" << width() << "px' height='" << height() << "px' >\n";
-  // d_os<<"<svg:g transform='translate("<<width()*.05<<","<<height()*.05<<")
+  // d_os<<"<g transform='translate("<<width()*.05<<","<<height()*.05<<")
   // scale(.85,.85)'>";
 }
 
 // ****************************************************************************
 void MolDraw2DSVG::finishDrawing() {
-  // d_os << "</svg:g>";
-  d_os << "</svg:svg>\n";
+  // d_os << "</g>";
+  d_os << "</svg>\n";
 }
 
 // ****************************************************************************
@@ -87,7 +87,7 @@ void MolDraw2DSVG::drawWavyLine(const Point2D &cds1, const Point2D &cds2,
 
   std::string col = DrawColourToSVG(colour());
   unsigned int width = lineWidth();
-  d_os << "<svg:path ";
+  d_os << "<path ";
   d_os << "d='M" << c1.x << "," << c1.y;
   for (unsigned int i = 0; i < nSegments; ++i) {
     Point2D startpt = cds1 + delta * i;
@@ -123,7 +123,7 @@ void MolDraw2DSVG::drawLine(const Point2D &cds1, const Point2D &cds2) {
     dss << dashes.back();
     dashString = dss.str();
   }
-  d_os << "<svg:path ";
+  d_os << "<path ";
   d_os << "d='M " << c1.x << "," << c1.y << " " << c2.x << "," << c2.y << "' ";
   d_os << "style='fill:none;fill-rule:evenodd;stroke:" << col
        << ";stroke-width:" << width
@@ -138,7 +138,7 @@ void MolDraw2DSVG::drawChar(char c, const Point2D &cds) {
   unsigned int fontSz = scale() * fontSize();
   std::string col = DrawColourToSVG(colour());
 
-  d_os << "<svg:text";
+  d_os << "<text";
   d_os << " x='" << cds.x;
   d_os << "' y='" << cds.y << "'";
   d_os << " style='font-size:" << fontSz
@@ -147,7 +147,7 @@ void MolDraw2DSVG::drawChar(char c, const Point2D &cds) {
        << "fill:" << col << "'";
   d_os << " >";
   d_os << c;
-  d_os << "</svg:text>";
+  d_os << "</text>";
 }
 
 // ****************************************************************************
@@ -157,7 +157,7 @@ void MolDraw2DSVG::drawPolygon(const std::vector<Point2D> &cds) {
   std::string col = DrawColourToSVG(colour());
   unsigned int width = lineWidth();
   std::string dashString = "";
-  d_os << "<svg:path ";
+  d_os << "<path ";
   d_os << "d='M";
   Point2D c0 = getDrawCoords(cds[0]);
   d_os << " " << c0.x << "," << c0.y;
@@ -191,7 +191,7 @@ void MolDraw2DSVG::drawEllipse(const Point2D &cds1, const Point2D &cds2) {
   std::string col = DrawColourToSVG(colour());
   unsigned int width = lineWidth();
   std::string dashString = "";
-  d_os << "<svg:ellipse"
+  d_os << "<ellipse"
        << " cx='" << cx << "'"
        << " cy='" << cy << "'"
        << " rx='" << w / 2 << "'"
@@ -212,11 +212,11 @@ void MolDraw2DSVG::drawEllipse(const Point2D &cds1, const Point2D &cds2) {
 // ****************************************************************************
 void MolDraw2DSVG::clearDrawing() {
   std::string col = DrawColourToSVG(drawOptions().backgroundColour);
-  d_os << "<svg:rect";
+  d_os << "<rect";
   d_os << " style='opacity:1.0;fill:" << col << ";stroke:none'";
   d_os << " width='" << width() << "' height='" << height() << "'";
   d_os << " x='0' y='0'";
-  d_os << "> </svg:rect>\n";
+  d_os << "> </rect>\n";
 }
 
 // ****************************************************************************
@@ -307,7 +307,7 @@ void MolDraw2DSVG::drawString(const std::string &str, const Point2D &cds) {
 
   Point2D draw_coords = getDrawCoords(Point2D(draw_x, draw_y));
 
-  d_os << "<svg:text";
+  d_os << "<text";
   d_os << " x='" << draw_coords.x;
 
   d_os << "' y='" << draw_coords.y << "'";
@@ -328,11 +328,11 @@ void MolDraw2DSVG::drawString(const std::string &str, const Point2D &cds) {
     if ('<' == str[i] && setStringDrawMode(str, draw_mode, i)) {
       if (!first_span) {
         escape_xhtml(span);
-        d_os << span << "</svg:tspan>";
+        d_os << span << "</tspan>";
         span = "";
       }
       first_span = false;
-      d_os << "<svg:tspan";
+      d_os << "<tspan";
       switch (draw_mode) {
         case TextDrawSuperscript:
           d_os << " style='baseline-shift:super;font-size:" << fontSz * 0.75
@@ -352,14 +352,14 @@ void MolDraw2DSVG::drawString(const std::string &str, const Point2D &cds) {
     }
     if (first_span) {
       first_span = false;
-      d_os << "<svg:tspan>";
+      d_os << "<tspan>";
       span = "";
     }
     span += str[i];
   }
   escape_xhtml(span);
-  d_os << span << "</svg:tspan>";
-  d_os << "</svg:text>\n";
+  d_os << span << "</tspan>";
+  d_os << "</text>\n";
 }
 
 void MolDraw2DSVG::tagAtoms(const ROMol &mol) {

--- a/Code/GraphMol/MolDraw2D/Wrap/testMolDraw2D.py
+++ b/Code/GraphMol/MolDraw2D/Wrap/testMolDraw2D.py
@@ -19,8 +19,8 @@ class TestCase(unittest.TestCase):
     d.DrawMolecule(m)
     d.FinishDrawing()
     txt = d.GetDrawingText()
-    self.assertTrue(txt.find("<svg:svg") != -1)
-    self.assertTrue(txt.find("</svg:svg>") != -1)
+    self.assertTrue(txt.find("<svg") != -1)
+    self.assertTrue(txt.find("</svg>") != -1)
 
   def test2(self):
     m = Chem.MolFromSmiles('c1ccc(C)c(C)c1C')
@@ -165,7 +165,7 @@ M  END""")
         bnds.append(tmp)
     drawer.DrawMolecules(tms,highlightAtoms=matches,highlightBonds=bnds,highlightAtomColors=acolors)
     drawer.FinishDrawing()
-    svg = drawer.GetDrawingText().replace('svg:','')
+    svg = drawer.GetDrawingText()
     # 4 molecules, 6 bonds each:
     self.assertEqual(svg.count('fill:none;fill-rule:evenodd;stroke:#FF7F7F'),24)
     # 4 molecules, one atom each:
@@ -191,8 +191,8 @@ M  END""")
     d.DrawReaction(rxn)
     d.FinishDrawing()
     txt = d.GetDrawingText()
-    self.assertTrue(txt.find("<svg:svg") != -1)
-    self.assertTrue(txt.find("</svg:svg>") != -1)
+    self.assertTrue(txt.find("<svg") != -1)
+    self.assertTrue(txt.find("</svg>") != -1)
     #print(txt,file=open('blah1.svg','w+'))
 
   def testReaction2(self):
@@ -201,8 +201,8 @@ M  END""")
     d.DrawReaction(rxn,highlightByReactant=True)
     d.FinishDrawing()
     txt = d.GetDrawingText()
-    self.assertTrue(txt.find("<svg:svg") != -1)
-    self.assertTrue(txt.find("</svg:svg>") != -1)
+    self.assertTrue(txt.find("<svg") != -1)
+    self.assertTrue(txt.find("</svg>") != -1)
     #print(txt,file=open('blah2.svg','w+'))
 
   def testReaction3(self):
@@ -212,8 +212,8 @@ M  END""")
     d.DrawReaction(rxn,highlightByReactant=True,highlightColorsReactants=colors)
     d.FinishDrawing()
     txt = d.GetDrawingText()
-    self.assertTrue(txt.find("<svg:svg") != -1)
-    self.assertTrue(txt.find("</svg:svg>") != -1)
+    self.assertTrue(txt.find("<svg") != -1)
+    self.assertTrue(txt.find("</svg>") != -1)
 
   def testReaction4(self):
     rxn = AllChem.ReactionFromSmarts('[CH3:1][C:2](=[O:3])[OH:4].[CH3:5][NH2:6]>CC(O)C.[Pt]>[CH3:1][C:2](=[O:3])[NH:6][CH3:5].[OH2:4]',useSmiles=True)

--- a/Code/GraphMol/MolDraw2D/test1.cpp
+++ b/Code/GraphMol/MolDraw2D/test1.cpp
@@ -55,8 +55,8 @@ void test1() {
     drawer.drawMolecule(*m);
     drawer.finishDrawing();
     std::string text = drawer.getDrawingText();
-    TEST_ASSERT(text.find("<svg:svg") != std::string::npos);
-    TEST_ASSERT(text.find("</svg:svg>") != std::string::npos);
+    TEST_ASSERT(text.find("<svg") != std::string::npos);
+    TEST_ASSERT(text.find("</svg>") != std::string::npos);
     delete m;
   }
   {
@@ -597,8 +597,8 @@ void testMultiThreaded() {
     drawer.drawMolecule(*(mols[i]));
     drawer.finishDrawing();
     refData[i] = drawer.getDrawingText();
-    TEST_ASSERT(refData[i].find("<svg:svg") != std::string::npos);
-    TEST_ASSERT(refData[i].find("</svg:svg>") != std::string::npos);
+    TEST_ASSERT(refData[i].find("<svg") != std::string::npos);
+    TEST_ASSERT(refData[i].find("</svg>") != std::string::npos);
   }
 
   std::vector<std::future<void>> tg;
@@ -634,7 +634,7 @@ void test6() {
     std::string txt = drawer.getDrawingText();
     std::ofstream outs("test6_1.svg");
     outs << txt;
-    // TEST_ASSERT(txt.find("<svg:svg")!=std::string::npos);
+    // TEST_ASSERT(txt.find("<svg")!=std::string::npos);
   }
   std::cerr << " Done" << std::endl;
 }
@@ -654,8 +654,8 @@ void test7() {
     std::string txt = drawer.getDrawingText();
     std::ofstream outs((nameBase + ".svg").c_str());
     outs << txt;
-    TEST_ASSERT(txt.find("<svg:svg") != std::string::npos);
-    TEST_ASSERT(txt.find("<svg:rect") == std::string::npos);
+    TEST_ASSERT(txt.find("<svg") != std::string::npos);
+    TEST_ASSERT(txt.find("<rect") == std::string::npos);
   }
 #ifdef RDK_CAIRO_BUILD
   {
@@ -676,8 +676,8 @@ void test7() {
     std::string txt = drawer.getDrawingText();
     std::ofstream outs((nameBase + ".svg").c_str());
     outs << txt;
-    TEST_ASSERT(txt.find("<svg:svg") != std::string::npos);
-    TEST_ASSERT(txt.find("<svg:rect") != std::string::npos);
+    TEST_ASSERT(txt.find("<svg") != std::string::npos);
+    TEST_ASSERT(txt.find("<rect") != std::string::npos);
     TEST_ASSERT(txt.find("fill:#CCCCCC") != std::string::npos);
   }
 #ifdef RDK_CAIRO_BUILD
@@ -835,8 +835,8 @@ void testGithub781() {
     drawer.drawMolecule(*m);
     drawer.finishDrawing();
     std::string txt = drawer.getDrawingText();
-    TEST_ASSERT(txt.find("<svg:svg") != std::string::npos);
-    TEST_ASSERT(txt.find("<svg:tspan>CH</svg:tspan>") != std::string::npos);
+    TEST_ASSERT(txt.find("<svg") != std::string::npos);
+    TEST_ASSERT(txt.find("<tspan>CH</tspan>") != std::string::npos);
     delete m;
   }
   {
@@ -848,8 +848,8 @@ void testGithub781() {
     drawer.drawMolecule(*m);
     drawer.finishDrawing();
     std::string txt = drawer.getDrawingText();
-    TEST_ASSERT(txt.find("<svg:svg") != std::string::npos);
-    TEST_ASSERT(txt.find("<svg:tspan>OH</svg:tspan>") == std::string::npos);
+    TEST_ASSERT(txt.find("<svg") != std::string::npos);
+    TEST_ASSERT(txt.find("<tspan>OH</tspan>") == std::string::npos);
     delete m;
   }
   {
@@ -861,8 +861,8 @@ void testGithub781() {
     drawer.drawMolecule(*m);
     drawer.finishDrawing();
     std::string txt = drawer.getDrawingText();
-    TEST_ASSERT(txt.find("<svg:svg") != std::string::npos);
-    TEST_ASSERT(txt.find("<svg:tspan>C</svg:tspan>") != std::string::npos);
+    TEST_ASSERT(txt.find("<svg") != std::string::npos);
+    TEST_ASSERT(txt.find("<tspan>C</tspan>") != std::string::npos);
     delete m;
   }
   {
@@ -874,9 +874,9 @@ void testGithub781() {
     drawer.drawMolecule(*m);
     drawer.finishDrawing();
     std::string txt = drawer.getDrawingText();
-    TEST_ASSERT(txt.find("<svg:svg") != std::string::npos);
-    TEST_ASSERT(txt.find("<svg:tspan>CH</svg:tspan>") != std::string::npos);
-    TEST_ASSERT(txt.find("<svg:tspan>Cl</svg:tspan>") != std::string::npos);
+    TEST_ASSERT(txt.find("<svg") != std::string::npos);
+    TEST_ASSERT(txt.find("<tspan>CH</tspan>") != std::string::npos);
+    TEST_ASSERT(txt.find("<tspan>Cl</tspan>") != std::string::npos);
     delete m;
   }
   {  // empty molecule
@@ -887,8 +887,8 @@ void testGithub781() {
     drawer.drawMolecule(*m);
     drawer.finishDrawing();
     std::string txt = drawer.getDrawingText();
-    TEST_ASSERT(txt.find("<svg:svg") != std::string::npos);
-    TEST_ASSERT(txt.find("<svg:tspan>") == std::string::npos);
+    TEST_ASSERT(txt.find("<svg") != std::string::npos);
+    TEST_ASSERT(txt.find("<tspan>") == std::string::npos);
     delete m;
   }
   std::cerr << " Done" << std::endl;
@@ -978,7 +978,7 @@ void test9MolLegends() {
     std::string txt = drawer.getDrawingText();
     std::ofstream outs("test9_1.svg");
     outs << txt;
-    // TEST_ASSERT(txt.find("<svg:svg")!=std::string::npos);
+    // TEST_ASSERT(txt.find("<svg")!=std::string::npos);
   }
   std::cerr << " Done" << std::endl;
 }
@@ -1235,7 +1235,7 @@ M  END";
     std::ofstream outs("test983_1.svg");
     outs << text;
     outs.flush();
-    TEST_ASSERT(text.find("<svg:path d='M 130.309,117.496 194.727,89.1159 "
+    TEST_ASSERT(text.find("<path d='M 130.309,117.496 194.727,89.1159 "
                           "187.092,75.893 130.309,117.496' "
                           "style='fill:#000000") != std::string::npos);
     delete m;
@@ -1286,7 +1286,7 @@ M  END";
     std::ofstream outs("test983_2.svg");
     outs << text;
     outs.flush();
-    TEST_ASSERT(text.find("<svg:path d='M 107.911,115.963 80.5887,91.4454 "
+    TEST_ASSERT(text.find("<path d='M 107.911,115.963 80.5887,91.4454 "
                           "75.9452,97.9126 107.911,115.963' "
                           "style='fill:#000000;") != std::string::npos);
 

--- a/Code/GraphMol/MolDraw2D/test1.cpp.hold
+++ b/Code/GraphMol/MolDraw2D/test1.cpp.hold
@@ -52,8 +52,8 @@ void test1() {
     drawer.drawMolecule(*m);
     drawer.finishDrawing();
     std::string text = drawer.getDrawingText();
-    TEST_ASSERT(text.find("<svg:svg") != std::string::npos);
-    TEST_ASSERT(text.find("</svg:svg>") != std::string::npos);
+    TEST_ASSERT(text.find("<svg") != std::string::npos);
+    TEST_ASSERT(text.find("</svg>") != std::string::npos);
     delete m;
   }
   {
@@ -521,8 +521,8 @@ void testMultiThreaded() {
     drawer.drawMolecule(*(mols[i]));
     drawer.finishDrawing();
     refData[i] = drawer.getDrawingText();
-    TEST_ASSERT(refData[i].find("<svg:svg") != std::string::npos);
-    TEST_ASSERT(refData[i].find("</svg:svg>") != std::string::npos);
+    TEST_ASSERT(refData[i].find("<svg") != std::string::npos);
+    TEST_ASSERT(refData[i].find("</svg>") != std::string::npos);
   }
 
   boost::thread_group tg;
@@ -555,7 +555,7 @@ void test6() {
     std::string txt = drawer.getDrawingText();
     std::ofstream outs("test6_1.svg");
     outs << txt;
-    // TEST_ASSERT(txt.find("<svg:svg")!=std::string::npos);
+    // TEST_ASSERT(txt.find("<svg")!=std::string::npos);
   }
   std::cerr << " Done" << std::endl;
 }
@@ -575,8 +575,8 @@ void test7() {
     std::string txt = drawer.getDrawingText();
     std::ofstream outs((nameBase + ".svg").c_str());
     outs << txt;
-    TEST_ASSERT(txt.find("<svg:svg") != std::string::npos);
-    TEST_ASSERT(txt.find("<svg:rect") == std::string::npos);
+    TEST_ASSERT(txt.find("<svg") != std::string::npos);
+    TEST_ASSERT(txt.find("<rect") == std::string::npos);
   }
 #ifdef RDK_CAIRO_BUILD
   {
@@ -597,8 +597,8 @@ void test7() {
     std::string txt = drawer.getDrawingText();
     std::ofstream outs((nameBase + ".svg").c_str());
     outs << txt;
-    TEST_ASSERT(txt.find("<svg:svg") != std::string::npos);
-    TEST_ASSERT(txt.find("<svg:rect") != std::string::npos);
+    TEST_ASSERT(txt.find("<svg") != std::string::npos);
+    TEST_ASSERT(txt.find("<rect") != std::string::npos);
     TEST_ASSERT(txt.find("fill:#CCCCCC") != std::string::npos);
   }
 #ifdef RDK_CAIRO_BUILD
@@ -628,8 +628,8 @@ void testGithub781() {
     drawer.drawMolecule(*m);
     drawer.finishDrawing();
     std::string txt = drawer.getDrawingText();
-    TEST_ASSERT(txt.find("<svg:svg") != std::string::npos);
-    TEST_ASSERT(txt.find("<svg:tspan>CH</svg:tspan>") != std::string::npos);
+    TEST_ASSERT(txt.find("<svg") != std::string::npos);
+    TEST_ASSERT(txt.find("<tspan>CH</tspan>") != std::string::npos);
     delete m;
   }
   {
@@ -641,8 +641,8 @@ void testGithub781() {
     drawer.drawMolecule(*m);
     drawer.finishDrawing();
     std::string txt = drawer.getDrawingText();
-    TEST_ASSERT(txt.find("<svg:svg") != std::string::npos);
-    TEST_ASSERT(txt.find("<svg:tspan>C</svg:tspan>") != std::string::npos);
+    TEST_ASSERT(txt.find("<svg") != std::string::npos);
+    TEST_ASSERT(txt.find("<tspan>C</tspan>") != std::string::npos);
     delete m;
   }
   {
@@ -654,9 +654,9 @@ void testGithub781() {
     drawer.drawMolecule(*m);
     drawer.finishDrawing();
     std::string txt = drawer.getDrawingText();
-    TEST_ASSERT(txt.find("<svg:svg") != std::string::npos);
-    TEST_ASSERT(txt.find("<svg:tspan>CH</svg:tspan>") != std::string::npos);
-    TEST_ASSERT(txt.find("<svg:tspan>Cl</svg:tspan>") != std::string::npos);
+    TEST_ASSERT(txt.find("<svg") != std::string::npos);
+    TEST_ASSERT(txt.find("<tspan>CH</tspan>") != std::string::npos);
+    TEST_ASSERT(txt.find("<tspan>Cl</tspan>") != std::string::npos);
     delete m;
   }
   {  // empty molecule
@@ -667,8 +667,8 @@ void testGithub781() {
     drawer.drawMolecule(*m);
     drawer.finishDrawing();
     std::string txt = drawer.getDrawingText();
-    TEST_ASSERT(txt.find("<svg:svg") != std::string::npos);
-    TEST_ASSERT(txt.find("<svg:tspan>") == std::string::npos);
+    TEST_ASSERT(txt.find("<svg") != std::string::npos);
+    TEST_ASSERT(txt.find("<tspan>") == std::string::npos);
     delete m;
   }
   std::cerr << " Done" << std::endl;

--- a/Code/GraphMol/MolDrawing/DrawingToSVG.h
+++ b/Code/GraphMol/MolDrawing/DrawingToSVG.h
@@ -93,7 +93,7 @@ void drawLine(std::vector<int>::const_iterator &pos, std::ostringstream &sstr,
   std::string c1 = getColor(an1);
   std::string c2 = getColor(an2);
   if (c1 == c2) {
-    sstr << "<svg:path ";
+    sstr << "<path ";
     sstr << "d='M " << *pos << "," << *(pos + 1) << " " << *(pos + 2) << ","
          << *(pos + 3) << "' ";
     pos += 4;
@@ -109,14 +109,14 @@ void drawLine(std::vector<int>::const_iterator &pos, std::ostringstream &sstr,
     int yp2 = *pos++;
     int mx = xp1 + (xp2 - xp1) / 2;
     int my = yp1 + (yp2 - yp1) / 2;
-    sstr << "<svg:path ";
+    sstr << "<path ";
     sstr << "d='M " << xp1 << "," << yp1 << " " << mx << "," << my << "' ";
     sstr << "style='fill:none;fill-rule:evenodd;stroke:" << c1
          << ";stroke-width:" << width
          << "px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          << dashString << "'";
     sstr << " />\n";
-    sstr << "<svg:path ";
+    sstr << "<path ";
     sstr << "d='M " << mx << "," << my << " " << xp2 << "," << yp2 << "' ";
     sstr << "style='fill:none;fill-rule:evenodd;stroke:" << c2
          << ";stroke-width:" << width
@@ -140,29 +140,29 @@ void drawAtom(std::vector<int>::const_iterator &pos, std::ostringstream &sstr,
   if (label.length()) {
     int width = fontSz * label.length();
     int height = fontSz;
-    sstr << "<svg:g transform='translate(" << xp << "," << yp
-         << ")'><svg:rect ";
+    sstr << "<g transform='translate(" << xp << "," << yp
+         << ")'><rect ";
     sstr << "style='opacity:1.0;fill:#FFFFFF;stroke:none'";
     sstr << " width='" << width << "' height='" << height << "'";
     sstr << " x='-" << width / 2 << "' y='-" << height / 2 << "'";
-    sstr << "> </svg:rect>\n";
-    sstr << "<svg:text";
+    sstr << "> </rect>\n";
+    sstr << "<text";
     sstr << " style='font-size:" << fontSz
          << "px;font-style:normal;font-weight:normal;line-height:125%;letter-"
             "spacing:0px;word-spacing:0px;fill-opacity:1;stroke:none;font-"
             "family:sans-serif;text-anchor:middle"
          << ";fill:" << getColor(atNum) << "'";
     sstr << " y='" << .75 * fontSz / 2 << "'>";
-    sstr << "<svg:tspan>";
-    sstr << label << "</svg:tspan>";
-    sstr << "</svg:text>";
-    sstr << "</svg:g>\n";
+    sstr << "<tspan>";
+    sstr << label << "</tspan>";
+    sstr << "</text>";
+    sstr << "</g>\n";
   }
   if (includeAtomCircles) {
 #if 0          
-          sstr<<"<svg:circle cx='"<<xp<<"' cy='"<<yp<<"' r='5' />\n";
+          sstr<<"<circle cx='"<<xp<<"' cy='"<<yp<<"' r='5' />\n";
 #else
-    sstr << "<svg:circle cx='" << xp << "' cy='" << yp
+    sstr << "<circle cx='" << xp << "' cy='" << yp
          << "' r='0' style='fill:none;stroke:none' />\n";
 #endif
   }
@@ -184,17 +184,17 @@ std::string DrawingToSVG(const std::vector<int> &drawing,
   height = *pos++;
   std::ostringstream sstr;
   sstr << "<?xml version='1.0' encoding='iso-8859-1'?>\n";
-  sstr << "<svg:svg version='1.1' baseProfile='full'\n      \
-        xmlns:svg='http://www.w3.org/2000/svg'\n                \
+  sstr << "<svg version='1.1' baseProfile='full'\n      \
+        xmlns='http://www.w3.org/2000/svg'\n                \
         xmlns:xlink='http://www.w3.org/1999/xlink'\n          \
         xml:space='preserve'\n";
   sstr << "width='" << width << "px' height='" << height << "px' >\n";
-  sstr << "<svg:rect ";
+  sstr << "<rect ";
   sstr << "style='opacity:1.0;fill:#FFFFFF;stroke:none'";
   sstr << " width='" << width << "' height='" << height << "'";
   sstr << " x='0' y='0'";
-  sstr << "> </svg:rect>\n";
-  sstr << "<svg:g transform='translate(" << width * .05 << "," << height * .05
+  sstr << "> </rect>\n";
+  sstr << "<g transform='translate(" << width * .05 << "," << height * .05
        << ") scale(.85,.85)'>";
   while (pos != drawing.end()) {
     int token = *pos++;
@@ -209,7 +209,7 @@ std::string DrawingToSVG(const std::vector<int> &drawing,
         std::cerr << "unrecognized token: " << token << std::endl;
     }
   }
-  sstr << "</svg:g></svg:svg>";
+  sstr << "</g></svg>";
   return sstr.str();
 }
 }  // end of namespace Drawing

--- a/Code/JavaWrappers/gmwrapper/src-test/org/RDKit/Chemv2Tests.java
+++ b/Code/JavaWrappers/gmwrapper/src-test/org/RDKit/Chemv2Tests.java
@@ -139,8 +139,8 @@ public class Chemv2Tests extends GraphMolTest {
 		Conformer c = m.getConformer();
 		m.WedgeMolBonds(c);
                 String svg=m.ToSVG(8,50);
-                assertTrue(svg.indexOf("<svg:svg")>-1);
-                assertTrue(svg.indexOf("</svg:svg>")>-1);
+                assertTrue(svg.indexOf("<svg")>-1);
+                assertTrue(svg.indexOf("</svg>")>-1);
 	}
 
 	@Test
@@ -153,8 +153,8 @@ public class Chemv2Tests extends GraphMolTest {
           drawer.drawMolecule(m);
           drawer.finishDrawing();
           String svg = drawer.getDrawingText();
-          assertTrue(svg.indexOf("<svg:svg") > -1);
-          assertTrue(svg.indexOf("</svg:svg>") > -1);
+          assertTrue(svg.indexOf("<svg") > -1);
+          assertTrue(svg.indexOf("</svg>") > -1);
         }
         @Test
         public void testMolDraw2DSVGSingleAtomMol() {
@@ -166,8 +166,8 @@ public class Chemv2Tests extends GraphMolTest {
           drawer.drawMolecule(m);
           drawer.finishDrawing();
           String svg = drawer.getDrawingText();
-          assertTrue(svg.indexOf("<svg:svg") > -1);
-          assertTrue(svg.indexOf("</svg:svg>") > -1);
+          assertTrue(svg.indexOf("<svg") > -1);
+          assertTrue(svg.indexOf("</svg>") > -1);
         }
         @Test
         public void testPrepareMolForDrawing() {
@@ -182,8 +182,8 @@ public class Chemv2Tests extends GraphMolTest {
           drawer.drawMolecule(m);
           drawer.finishDrawing();
           String svg = drawer.getDrawingText();
-          assertTrue(svg.indexOf("<svg:svg") > -1);
-          assertTrue(svg.indexOf("</svg:svg>") > -1);
+          assertTrue(svg.indexOf("<svg") > -1);
+          assertTrue(svg.indexOf("</svg>") > -1);
         }
         @Test
         public void testMolDraw2DHighlight() {
@@ -210,8 +210,8 @@ public class Chemv2Tests extends GraphMolTest {
           drawer.finishDrawing();
           String svg = drawer.getDrawingText();
           // System.out.print(svg);
-          assertTrue(svg.indexOf("<svg:svg") > -1);
-          assertTrue(svg.indexOf("</svg:svg>") > -1);
+          assertTrue(svg.indexOf("<svg") > -1);
+          assertTrue(svg.indexOf("</svg>") > -1);
           assertTrue(svg.indexOf("THE_LEGEND") > -1);
           assertTrue(svg.indexOf("fill:#FFFF00;") > -1);
           assertTrue(svg.indexOf("fill:#FF00FF;") > -1);

--- a/Code/PgSQL/rdkit/expected/props.out
+++ b/Code/PgSQL/rdkit/expected/props.out
@@ -277,18 +277,18 @@ SELECT mol_to_svg('CCO'::mol) svg;
                                                                                                          svg                                                                                                         
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  <?xml version='1.0' encoding='iso-8859-1'?>                                                                                                                                                                        +
- <svg:svg version='1.1' baseProfile='full'                                                                                                                                                                          +
+ <svg version='1.1' baseProfile='full'                                                                                                                                                                          +
                xmlns:svg='http://www.w3.org/2000/svg'                                                                                                                                                               +
                        xmlns:rdkit='http://www.rdkit.org/xml'                                                                                                                                                       +
                        xmlns:xlink='http://www.w3.org/1999/xlink'                                                                                                                                                   +
                    xml:space='preserve'                                                                                                                                                                             +
  width='250px' height='200px' >                                                                                                                                                                                     +
- <svg:rect style='opacity:1.0;fill:#FFFFFF;stroke:none' width='250' height='200' x='0' y='0'> </svg:rect>                                                                                                           +
- <svg:path d='M 11.3636,124.362 95.7545,75.6385' style='fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />                                  +
- <svg:path d='M 95.7545,75.6385 131.455,96.25' style='fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />                                    +
- <svg:path d='M 131.455,96.25 167.155,116.862' style='fill:none;fill-rule:evenodd;stroke:#FF0000;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />                                    +
- <svg:text x='166.64' y='131.862' style='font-size:15px;font-style:normal;font-weight:normal;fill-opacity:1;stroke:none;font-family:sans-serif;text-anchor:start;fill:#FF0000' ><svg:tspan>OH</svg:tspan></svg:text>+
- </svg:svg>                                                                                                                                                                                                         +
+ <rect style='opacity:1.0;fill:#FFFFFF;stroke:none' width='250' height='200' x='0' y='0'> </rect>                                                                                                           +
+ <path d='M 11.3636,124.362 95.7545,75.6385' style='fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />                                  +
+ <path d='M 95.7545,75.6385 131.455,96.25' style='fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />                                    +
+ <path d='M 131.455,96.25 167.155,116.862' style='fill:none;fill-rule:evenodd;stroke:#FF0000;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />                                    +
+ <text x='166.64' y='131.862' style='font-size:15px;font-style:normal;font-weight:normal;fill-opacity:1;stroke:none;font-family:sans-serif;text-anchor:start;fill:#FF0000' ><tspan>OH</tspan></text>+
+ </svg>                                                                                                                                                                                                         +
  
 (1 row)
 
@@ -296,19 +296,19 @@ SELECT mol_to_svg('CCO'::mol,'legend') svg;
                                                                                                          svg                                                                                                          
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  <?xml version='1.0' encoding='iso-8859-1'?>                                                                                                                                                                         +
- <svg:svg version='1.1' baseProfile='full'                                                                                                                                                                           +
+ <svg version='1.1' baseProfile='full'                                                                                                                                                                           +
                xmlns:svg='http://www.w3.org/2000/svg'                                                                                                                                                                +
                        xmlns:rdkit='http://www.rdkit.org/xml'                                                                                                                                                        +
                        xmlns:xlink='http://www.w3.org/1999/xlink'                                                                                                                                                    +
                    xml:space='preserve'                                                                                                                                                                              +
  width='250px' height='200px' >                                                                                                                                                                                      +
- <svg:rect style='opacity:1.0;fill:#FFFFFF;stroke:none' width='250' height='200' x='0' y='0'> </svg:rect>                                                                                                            +
- <svg:path d='M 11.3636,124.362 95.7545,75.6385' style='fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />                                   +
- <svg:path d='M 95.7545,75.6385 131.455,96.25' style='fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />                                     +
- <svg:path d='M 131.455,96.25 167.155,116.862' style='fill:none;fill-rule:evenodd;stroke:#FF0000;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />                                     +
- <svg:text x='166.64' y='131.862' style='font-size:15px;font-style:normal;font-weight:normal;fill-opacity:1;stroke:none;font-family:sans-serif;text-anchor:start;fill:#FF0000' ><svg:tspan>OH</svg:tspan></svg:text> +
- <svg:text x='103.377' y='194' style='font-size:12px;font-style:normal;font-weight:normal;fill-opacity:1;stroke:none;font-family:sans-serif;text-anchor:start;fill:#000000' ><svg:tspan>legend</svg:tspan></svg:text>+
- </svg:svg>                                                                                                                                                                                                          +
+ <rect style='opacity:1.0;fill:#FFFFFF;stroke:none' width='250' height='200' x='0' y='0'> </rect>                                                                                                            +
+ <path d='M 11.3636,124.362 95.7545,75.6385' style='fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />                                   +
+ <path d='M 95.7545,75.6385 131.455,96.25' style='fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />                                     +
+ <path d='M 131.455,96.25 167.155,116.862' style='fill:none;fill-rule:evenodd;stroke:#FF0000;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />                                     +
+ <text x='166.64' y='131.862' style='font-size:15px;font-style:normal;font-weight:normal;fill-opacity:1;stroke:none;font-family:sans-serif;text-anchor:start;fill:#FF0000' ><tspan>OH</tspan></text> +
+ <text x='103.377' y='194' style='font-size:12px;font-style:normal;font-weight:normal;fill-opacity:1;stroke:none;font-family:sans-serif;text-anchor:start;fill:#000000' ><tspan>legend</tspan></text>+
+ </svg>                                                                                                                                                                                                          +
  
 (1 row)
 
@@ -317,20 +317,20 @@ SELECT mol_to_svg('CCO'::mol,'legend',250,200,
                                                                                                           svg                                                                                                          
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  <?xml version='1.0' encoding='iso-8859-1'?>                                                                                                                                                                          +
- <svg:svg version='1.1' baseProfile='full'                                                                                                                                                                            +
+ <svg version='1.1' baseProfile='full'                                                                                                                                                                            +
                xmlns:svg='http://www.w3.org/2000/svg'                                                                                                                                                                 +
                        xmlns:rdkit='http://www.rdkit.org/xml'                                                                                                                                                         +
                        xmlns:xlink='http://www.w3.org/1999/xlink'                                                                                                                                                     +
                    xml:space='preserve'                                                                                                                                                                               +
  width='250px' height='200px' >                                                                                                                                                                                       +
- <svg:rect style='opacity:1.0;fill:#FFFFFF;stroke:none' width='250' height='200' x='0' y='0'> </svg:rect>                                                                                                             +
- <svg:path d='M 11.3636,124.362 83.2395,82.864' style='fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />                                     +
- <svg:path d='M 108.269,82.864 137.712,99.8628' style='fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />                                     +
- <svg:path d='M 137.712,99.8628 167.155,116.862' style='fill:none;fill-rule:evenodd;stroke:#FF0000;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />                                    +
- <svg:text x='83.2395' y='83.1385' style='font-size:15px;font-style:normal;font-weight:normal;fill-opacity:1;stroke:none;font-family:sans-serif;text-anchor:start;fill:#000000' ><svg:tspan>foo</svg:tspan></svg:text>+
- <svg:text x='166.64' y='131.862' style='font-size:15px;font-style:normal;font-weight:normal;fill-opacity:1;stroke:none;font-family:sans-serif;text-anchor:start;fill:#FF0000' ><svg:tspan>OH</svg:tspan></svg:text>  +
- <svg:text x='103.377' y='194' style='font-size:12px;font-style:normal;font-weight:normal;fill-opacity:1;stroke:none;font-family:sans-serif;text-anchor:start;fill:#7F7F7F' ><svg:tspan>legend</svg:tspan></svg:text> +
- </svg:svg>                                                                                                                                                                                                           +
+ <rect style='opacity:1.0;fill:#FFFFFF;stroke:none' width='250' height='200' x='0' y='0'> </rect>                                                                                                             +
+ <path d='M 11.3636,124.362 83.2395,82.864' style='fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />                                     +
+ <path d='M 108.269,82.864 137.712,99.8628' style='fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />                                     +
+ <path d='M 137.712,99.8628 167.155,116.862' style='fill:none;fill-rule:evenodd;stroke:#FF0000;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />                                    +
+ <text x='83.2395' y='83.1385' style='font-size:15px;font-style:normal;font-weight:normal;fill-opacity:1;stroke:none;font-family:sans-serif;text-anchor:start;fill:#000000' ><tspan>foo</tspan></text>+
+ <text x='166.64' y='131.862' style='font-size:15px;font-style:normal;font-weight:normal;fill-opacity:1;stroke:none;font-family:sans-serif;text-anchor:start;fill:#FF0000' ><tspan>OH</tspan></text>  +
+ <text x='103.377' y='194' style='font-size:12px;font-style:normal;font-weight:normal;fill-opacity:1;stroke:none;font-family:sans-serif;text-anchor:start;fill:#7F7F7F' ><tspan>legend</tspan></text> +
+ </svg>                                                                                                                                                                                                           +
  
 (1 row)
 

--- a/rdkit/Chem/Draw/__init__.py
+++ b/rdkit/Chem/Draw/__init__.py
@@ -364,7 +364,7 @@ def _moltoSVG(mol, sz, highlights, legend, kekulize, **kwargs):
   d2d.DrawMolecule(mc, legend=legend, highlightAtoms=highlights)
   d2d.FinishDrawing()
   svg = d2d.GetDrawingText()
-  return svg.replace("svg:", "")
+  return svg
 
 
 
@@ -406,8 +406,7 @@ def _MolsToGridImage(mols, molsPerRow=3, subImgSize=(200, 200), legends=None,
 
 
 def _MolsToGridSVG(mols, molsPerRow=3, subImgSize=(200, 200), legends=None,
-                   highlightAtomLists=None, highlightBondLists=None,
-                   stripSVGNamespace=True, **kwargs):
+                   highlightAtomLists=None, highlightBondLists=None, **kwargs):
   """ returns an SVG of the grid
   """
   if legends is None:
@@ -426,8 +425,6 @@ def _MolsToGridSVG(mols, molsPerRow=3, subImgSize=(200, 200), legends=None,
                     highlightBonds=highlightBondLists,**kwargs)
   d2d.FinishDrawing()
   res = d2d.GetDrawingText()
-  if stripSVGNamespace:
-    res = res.replace('svg:', '')
   return res
 
 
@@ -503,7 +500,7 @@ def ReactionToImage(rxn, subImgSize=(200, 200), useSVG=False, **kwargs):
       d.DrawReaction(rxn,**kwargs)
       d.FinishDrawing()
       if useSVG:
-          return d.GetDrawingText().replace('svg:', '')
+          return d.GetDrawingText()
       else:
           return _drawerToImage(d)
 

--- a/rdkit/Chem/PandasTools.py
+++ b/rdkit/Chem/PandasTools.py
@@ -208,7 +208,7 @@ def _get_svg_image(mol, size=(200, 200), highlightAtoms=[]):
   drawer = rdMolDraw2D.MolDraw2DSVG(*size)
   drawer.DrawMolecule(mol, highlightAtoms=highlightAtoms)
   drawer.FinishDrawing()
-  svg = drawer.GetDrawingText().replace('svg:', '')
+  svg = drawer.GetDrawingText()
   return SVG(svg).data  # IPython's SVG clears the svg text
 
 


### PR DESCRIPTION
As I understand it, there are two ways to handle the svg namespace in svg output: Either use `xmlns:svg='http://www.w3.org/2000/svg'` and prefix every svg element with `svg:`, or use `xmlns='http://www.w3.org/2000/svg'` to indicate a default namespace so no prefixes are needed.

I think they are equally valid. RDKit uses the former, however there are a whole bunch of places in the python wrappers where the `svg:` prefix is manually stripped off every element before the output is returned. The `xmlns` definition is not modified, so I think the output is invalid.

I presume there may be some issue with using the prefixed version that caused the stripping code to be added in the first place. So instead, this PR makes svg the default namepace, so no prefixes or stripping are needed.