### PR TITLE
R-group Decomposition: allow H replacements when matchOnlyAtRgroups is set

### DIFF
--- a/Code/GraphMol/QueryOps.h
+++ b/Code/GraphMol/QueryOps.h
@@ -78,10 +78,10 @@ static inline int queryAtomExplicitDegree(Atom const *at) {
 static inline int queryAtomTotalDegree(Atom const *at) {
   return at->getTotalDegree();
 };
-static inline int queryAtomHeavyAtomDegree(Atom const *at) {
+static inline int queryAtomNonHydrogenDegree(Atom const *at) {
   return at->getTotalDegree() - at->getTotalNumHs(true);
 }
-static inline int queryAtomNonHydrogenDegree(Atom const *at) {
+static inline int queryAtomHeavyAtomDegree(Atom const *at) {
   int heavyDegree = 0;
   ROMol::ADJ_ITER nbrIdx, endNbrs;
   boost::tie(nbrIdx, endNbrs) = at->getOwningMol().getAtomNeighbors(at);

--- a/Code/GraphMol/QueryOps.h
+++ b/Code/GraphMol/QueryOps.h
@@ -79,6 +79,9 @@ static inline int queryAtomTotalDegree(Atom const *at) {
   return at->getTotalDegree();
 };
 static inline int queryAtomHeavyAtomDegree(Atom const *at) {
+  return at->getTotalDegree() - at->getTotalNumHs(true);
+}
+static inline int queryAtomNonHydrogenDegree(Atom const *at) {
   int heavyDegree = 0;
   ROMol::ADJ_ITER nbrIdx, endNbrs;
   boost::tie(nbrIdx, endNbrs) = at->getOwningMol().getAtomNeighbors(at);

--- a/Code/GraphMol/QueryOps.h
+++ b/Code/GraphMol/QueryOps.h
@@ -79,7 +79,18 @@ static inline int queryAtomTotalDegree(Atom const *at) {
   return at->getTotalDegree();
 };
 static inline int queryAtomHeavyAtomDegree(Atom const *at) {
-  return at->getTotalDegree() - at->getTotalNumHs(true);
+  int heavyDegree = 0;
+  ROMol::ADJ_ITER nbrIdx, endNbrs;
+  boost::tie(nbrIdx, endNbrs) = at->getOwningMol().getAtomNeighbors(at);
+  while (nbrIdx != endNbrs) {
+    const Atom *nbr = at->getOwningMol()[*nbrIdx];
+    if (nbr->getAtomicNum() > 1) {
+      heavyDegree++;
+    }
+    ++nbrIdx;
+  }
+
+  return heavyDegree;
 };
 static inline int queryAtomHCount(Atom const *at) {
   return at->getTotalNumHs(true);

--- a/Code/GraphMol/RGroupDecomposition/testRGroupDecomp.cpp
+++ b/Code/GraphMol/RGroupDecomposition/testRGroupDecomp.cpp
@@ -413,6 +413,33 @@ void testGitHubIssue1705() {
 
 }
 
+void testMatchOnlyAtRgroupHs() {
+  BOOST_LOG(rdInfoLog)
+      << "********************************************************\n";
+  BOOST_LOG(rdInfoLog) << "test matching only rgroups but allows Hs" << std::endl;
+
+  RWMol *core = SmilesToMol("*OCC");
+  RGroupDecompositionParameters params;
+  params.onlyMatchAtRGroups = true;
+  RGroupDecomposition decomp(*core, params);
+  const char *smilesData[2] = {"OCC","COCC"};
+  for (int i = 0; i < 2; ++i) {
+    ROMol *mol = SmilesToMol(smilesData[i]);
+    int res = decomp.add(*mol);
+  }
+  decomp.process();
+
+  std::stringstream ss;
+  RGroupColumns groups = decomp.getRGroupsAsColumns();
+  for (auto &column : groups) {
+    ss << "Rgroup===" << column.first << std::endl;
+    for (auto &rgroup : column.second ) {
+      ss << MolToSmiles(*rgroup) << std::endl;
+    }
+  }
+  std::cerr << ss.str() << std::endl;
+  TEST_ASSERT(ss.str() == "Rgroup===Core\nCCO[*:1]\nCCO[*:1]\nRgroup===R1\n[H][*:1]\n[H]C([H])([H])[*:1]\n");
+}
 
 int main() {
   RDLog::InitLogs();
@@ -433,7 +460,8 @@ int main() {
   testRemoveHs();
 
   testGitHubIssue1705();
-
+  testMatchOnlyAtRgroupHs();
+  
   BOOST_LOG(rdInfoLog)
       << "********************************************************\n";
   return 0;

--- a/Code/GraphMol/SLNParse/SLNAttribs.cpp
+++ b/Code/GraphMol/SLNParse/SLNAttribs.cpp
@@ -241,7 +241,7 @@ void parseAtomAttribs(Atom *atom, AttribListType attribs, bool doingQuery) {
                                 fTag + "AtomHCount");
       } else if (attribName == "hac") {
         if (fTag == "") val = parseIntAttribVal(attribName, attribVal);
-        query = makeQueryFromOp(attribPtr->op, val, queryAtomHeavyAtomDegree,
+        query = makeQueryFromOp(attribPtr->op, val, queryAtomNonHydrogenDegree,
                                 fTag + "AtomHeavyAtomDegree");
       } else if (attribName == "f") {
         if (fTag == "") val = parseIntAttribVal(attribName, attribVal);


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! 
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.
Fixes QueryOps.h to not consider dummy atoms as "heavy" as they can be either.  This allows the RGroupDecomp to allow rgroups to match both heavy and H atoms.

#### Any other comments?
