### PR TITLE
Fixes a link error on Windows

### DIFF
--- a/Code/GraphMol/FileParsers/CMakeLists.txt
+++ b/Code/GraphMol/FileParsers/CMakeLists.txt
@@ -33,7 +33,7 @@ rdkit_headers(FileParsers.h
 
 rdkit_test(fileParsersTest1 test1.cpp
            LINK_LIBRARIES FileParsers SmilesParse
-	   SubstructMatch GraphMol RDGeneral RDGeometryLib )
+	   SubstructMatch GraphMol RDGeneral RDGeometryLib ${maeparser_var})
 
 if(RDK_BUILD_TEST_GZIP)
     find_package(Boost 1.56.0 COMPONENTS system iostreams REQUIRED)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! 
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.
Fixes a link error of `fileParsersTest1` when building with `maeparser`

#### Any other comments?

