### PR TITLE
Fixes locale handling on Windows

### DIFF
--- a/Code/GraphMol/FileParsers/test1.cpp
+++ b/Code/GraphMol/FileParsers/test1.cpp
@@ -5365,7 +5365,7 @@ int main(int argc, char *argv[]) {
                        << std::endl;
   std::setlocale(LC_ALL, "de_DE.UTF-8");
   std::cout << std::setlocale(LC_ALL, nullptr) << std::endl;
-  testLocaleSwitcher();  // must be the last test
+  testLocaleSwitcher();
   testMultiThreadedSwitcher();
   RunTests();
 

--- a/Code/GraphMol/FileParsers/test1.cpp
+++ b/Code/GraphMol/FileParsers/test1.cpp
@@ -5322,7 +5322,9 @@ void testLocaleSwitcher() {
 #include <future>
 
 namespace {
-void runblock() { testLocaleSwitcher(); }
+void runblock() {
+  std::setlocale(LC_ALL, "de_DE.UTF-8");
+  testLocaleSwitcher(); }
 }
 void testMultiThreadedSwitcher() {
   BOOST_LOG(rdErrorLog) << "-------------------------------------" << std::endl;
@@ -5361,8 +5363,8 @@ int main(int argc, char *argv[]) {
 
   BOOST_LOG(rdInfoLog) << " ---- Running with German locale ----- "
                        << std::endl;
-  setlocale(LC_ALL, "de_DE.UTF-8");
-  std::cout << setlocale(LC_ALL, nullptr) << std::endl;
+  std::setlocale(LC_ALL, "de_DE.UTF-8");
+  std::cout << std::setlocale(LC_ALL, nullptr) << std::endl;
   testLocaleSwitcher();  // must be the last test
   testMultiThreadedSwitcher();
   RunTests();

--- a/Code/RDGeneral/LocaleSwitcher.cpp
+++ b/Code/RDGeneral/LocaleSwitcher.cpp
@@ -97,6 +97,7 @@ class LocaleSwitcherImpl {
     if (!recurseLocale(CurrentState)) {
 #ifdef RDK_THREADSAFE_SSS
       _configthreadlocale(_ENABLE_PER_THREAD_LOCALE);
+      old_locale = ::setlocale(LC_ALL, nullptr);
       ::setlocale(LC_ALL, "C");  // thread safe on windows
 #else
       std::setlocale(LC_ALL, "C");
@@ -108,16 +109,17 @@ class LocaleSwitcherImpl {
   ~LocaleSwitcherImpl() {
     if (switched) {
 #ifdef RDK_THREADSAFE_SSS
-      ::setlocale(LC_ALL, "C");
+      ::setlocale(LC_ALL, old_locale.c_str());
 #else
-      std::setlocale(LC_ALL, "");  // back to last (global?) locale
+      std::setlocale(LC_ALL, old_locale.c_str());  // back to last (global?) locale
 #endif  // RDK_THREADSAFE_SSS
       recurseLocale(ResetLocale);
     }
   }
 
  public:
-  bool switched;
+  bool switched = false;
+  std::string old_locale;
 #else  // _WIN32
   locale_t loc;      // current "C" locale
   locale_t old_loc;  // locale we came frome


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! 
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->
Locale handling was broken under Windows.

#### What does this implement/fix? Explain your changes.
- avoids that the recursion counter becomes negative
- resets the switched boolean
- restores the pre-existing locale rather than the user-defined one as it may have changed compared to the user's default locale (I implemented the same behaviour as on other platforms)

#### Any other comments?

