### PR TITLE
Fixes failing Pandas doctest

### DIFF
--- a/Code/GraphMol/FileParsers/test1.cpp
+++ b/Code/GraphMol/FileParsers/test1.cpp
@@ -5322,7 +5322,9 @@ void testLocaleSwitcher() {
 #include <future>
 
 namespace {
-void runblock() { testLocaleSwitcher(); }
+void runblock() {
+  std::setlocale(LC_ALL, "de_DE.UTF-8");
+  testLocaleSwitcher(); }
 }
 void testMultiThreadedSwitcher() {
   BOOST_LOG(rdErrorLog) << "-------------------------------------" << std::endl;
@@ -5361,8 +5363,8 @@ int main(int argc, char *argv[]) {
 
   BOOST_LOG(rdInfoLog) << " ---- Running with German locale ----- "
                        << std::endl;
-  setlocale(LC_ALL, "de_DE.UTF-8");
-  std::cout << setlocale(LC_ALL, nullptr) << std::endl;
+  std::setlocale(LC_ALL, "de_DE.UTF-8");
+  std::cout << std::setlocale(LC_ALL, nullptr) << std::endl;
   testLocaleSwitcher();  // must be the last test
   testMultiThreadedSwitcher();
   RunTests();

--- a/Code/RDGeneral/LocaleSwitcher.cpp
+++ b/Code/RDGeneral/LocaleSwitcher.cpp
@@ -81,7 +81,7 @@ static int recurseLocale(int state) {
   static thread_local int recursion = 0;
   if (state == SwitchLocale)
     recursion++;
-  else if (state == ResetLocale)
+  else if (state == ResetLocale && recursion)
     recursion--;
   return recursion;
 #endif
@@ -97,6 +97,7 @@ class LocaleSwitcherImpl {
     if (!recurseLocale(CurrentState)) {
 #ifdef RDK_THREADSAFE_SSS
       _configthreadlocale(_ENABLE_PER_THREAD_LOCALE);
+      old_locale = ::setlocale(LC_ALL, nullptr);
       ::setlocale(LC_ALL, "C");  // thread safe on windows
 #else
       std::setlocale(LC_ALL, "C");
@@ -108,16 +109,18 @@ class LocaleSwitcherImpl {
   ~LocaleSwitcherImpl() {
     if (switched) {
 #ifdef RDK_THREADSAFE_SSS
-      ::setlocale(LC_ALL, "C");
+      ::setlocale(LC_ALL, old_locale.c_str());
 #else
-      std::setlocale(LC_ALL, "");  // back to last (global?) locale
+      std::setlocale(LC_ALL, old_locale.c_str());  // back to last (global?) locale
 #endif  // RDK_THREADSAFE_SSS
       recurseLocale(ResetLocale);
+      switched = false;
     }
   }
 
  public:
-  bool switched;
+  bool switched = false;
+  std::string old_locale;
 #else  // _WIN32
   locale_t loc;      // current "C" locale
   locale_t old_loc;  // locale we came frome

--- a/rdkit/Chem/PandasTools.py
+++ b/rdkit/Chem/PandasTools.py
@@ -17,11 +17,11 @@ If the dataframe is containing a molecule format in a column (e.g. smiles), like
 ...   'Name':'Ampicilline'}, ignore_index=True)#Ampicilline
 >>> print([str(x) for x in  antibiotics.columns])
 ['Name', 'Smiles']
->>> print(antibiotics)
+>>> print(antibiotics) # doctest: +ELLIPSIS
             Name                                             Smiles
 0  Penicilline G    CC1(C(N2C(S1)C(C2=O)NC(=O)CC3=CC=CC=C3)C(=O)O)C
-1   Tetracycline  CC1(C2CC3C(C(=O)C(=C(C3(C(=O)C2=C(C4=C1C=CC=C4...
-2  Ampicilline  CC1(C(N2C(S1)C(C2=O)NC(=O)C(C3=CC=CC=C3)N)C(=O...
+1   Tetracycline  CC1(C2CC3C(C(=O)C(=C(C3(C(=O)C2=C(C4=C1C=CC=C4*...*
+2  Ampicilline  CC1(C(N2C(S1)C(C2=O)NC(=O)C(C3=CC=CC=C3)N)C(=O*...*
 
 a new column can be created holding the respective RDKit molecule objects. The fingerprint can be
 included to accelerate substructure searches on the dataframe.
@@ -36,10 +36,10 @@ Such the antibiotics containing the beta-lactam ring "C1C(=O)NC1" can be obtaine
 
 >>> beta_lactam = Chem.MolFromSmiles('C1C(=O)NC1')
 >>> beta_lactam_antibiotics = antibiotics[antibiotics['Molecule'] >= beta_lactam]
->>> print(beta_lactam_antibiotics[['Name','Smiles']])
+>>> print(beta_lactam_antibiotics[['Name','Smiles']]) # doctest: +ELLIPSIS
             Name                                             Smiles
 0  Penicilline G    CC1(C(N2C(S1)C(C2=O)NC(=O)CC3=CC=CC=C3)C(=O)O)C
-2  Ampicilline  CC1(C(N2C(S1)C(C2=O)NC(=O)C(C3=CC=CC=C3)N)C(=O...
+2  Ampicilline  CC1(C(N2C(S1)C(C2=O)NC(=O)C(C3=CC=CC=C3)N)C(=O*...*
 
 
 It is also possible to load an SDF file can be load into a dataframe.
@@ -74,7 +74,8 @@ Molecule                  200  non-null values
 dtypes: object(20)>
 
 Conversion to html is quite easy:
->>> htm = frame.to_html()
+>>> htm = frame.to_html() # doctest: +ELLIPSIS
+*...*
 >>> str(htm[:36])
 '<table border="1" class="dataframe">'
 

--- a/rdkit/Chem/UnitTestPandasTools.py
+++ b/rdkit/Chem/UnitTestPandasTools.py
@@ -1,6 +1,8 @@
 from __future__ import print_function
 
 import doctest
+if (getattr(doctest, 'ELLIPSIS_MARKER')):
+  doctest.ELLIPSIS_MARKER = '*...*'
 import gzip
 import os
 import shutil


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! 
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.
The Pandas doctest was failing as on Windows you may get a spurious warning about missing fonts, e.g.:
```
Warning: unable to load font metrics from dir c:\build\rdkit\rdkit\sping\PIL\pilfonts
```
This can be solved using `doctest.ELLIPSIS`, however I redefined the `ELLIPSIS` marker to be `*...*` rather than the default `...` as the latter can be confused by `doctest` with the Python continuation prompt and therefore not work as expected when used at the beginning of a lline, as required to match a line which may have any content (as well as no content at all). See https://stackoverflow.com/questions/1024411/can-python-doctest-ignore-some-output-lines for a discussion.

#### Any other comments?

