### PR TITLE
Fixes pandas doctest on Windows

### DIFF
--- a/rdkit/Chem/PandasTools.py
+++ b/rdkit/Chem/PandasTools.py
@@ -17,11 +17,11 @@ If the dataframe is containing a molecule format in a column (e.g. smiles), like
 ...   'Name':'Ampicilline'}, ignore_index=True)#Ampicilline
 >>> print([str(x) for x in  antibiotics.columns])
 ['Name', 'Smiles']
->>> print(antibiotics)
+>>> print(antibiotics) # doctest: +ELLIPSIS
             Name                                             Smiles
 0  Penicilline G    CC1(C(N2C(S1)C(C2=O)NC(=O)CC3=CC=CC=C3)C(=O)O)C
-1   Tetracycline  CC1(C2CC3C(C(=O)C(=C(C3(C(=O)C2=C(C4=C1C=CC=C4...
-2  Ampicilline  CC1(C(N2C(S1)C(C2=O)NC(=O)C(C3=CC=CC=C3)N)C(=O...
+1   Tetracycline  CC1(C2CC3C(C(=O)C(=C(C3(C(=O)C2=C(C4=C1C=CC=C4*...*
+2  Ampicilline  CC1(C(N2C(S1)C(C2=O)NC(=O)C(C3=CC=CC=C3)N)C(=O*...*
 
 a new column can be created holding the respective RDKit molecule objects. The fingerprint can be
 included to accelerate substructure searches on the dataframe.
@@ -36,10 +36,10 @@ Such the antibiotics containing the beta-lactam ring "C1C(=O)NC1" can be obtaine
 
 >>> beta_lactam = Chem.MolFromSmiles('C1C(=O)NC1')
 >>> beta_lactam_antibiotics = antibiotics[antibiotics['Molecule'] >= beta_lactam]
->>> print(beta_lactam_antibiotics[['Name','Smiles']])
+>>> print(beta_lactam_antibiotics[['Name','Smiles']]) # doctest: +ELLIPSIS
             Name                                             Smiles
 0  Penicilline G    CC1(C(N2C(S1)C(C2=O)NC(=O)CC3=CC=CC=C3)C(=O)O)C
-2  Ampicilline  CC1(C(N2C(S1)C(C2=O)NC(=O)C(C3=CC=CC=C3)N)C(=O...
+2  Ampicilline  CC1(C(N2C(S1)C(C2=O)NC(=O)C(C3=CC=CC=C3)N)C(=O*...*
 
 
 It is also possible to load an SDF file can be load into a dataframe.
@@ -74,7 +74,8 @@ Molecule                  200  non-null values
 dtypes: object(20)>
 
 Conversion to html is quite easy:
->>> htm = frame.to_html()
+>>> htm = frame.to_html() # doctest: +ELLIPSIS
+*...*
 >>> str(htm[:36])
 '<table border="1" class="dataframe">'
 

--- a/rdkit/Chem/UnitTestPandasTools.py
+++ b/rdkit/Chem/UnitTestPandasTools.py
@@ -1,6 +1,8 @@
 from __future__ import print_function
 
 import doctest
+if (getattr(doctest, 'ELLIPSIS_MARKER')):
+  doctest.ELLIPSIS_MARKER = '*...*'
 import gzip
 import os
 import shutil


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! 
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.
The Pandas doctest was failing as on Windows you may get a spurious warning about missing fonts, e.g.:
```
Warning: unable to load font metrics from dir c:\build\rdkit\rdkit\sping\PIL\pilfonts
```
This can be solved using `doctest.ELLIPSIS`, however I redefined the `ELLIPSIS` marker to be `*...*` rather than the default `...` as the latter can be confused by `doctest` with the Python continuation prompt and therefore not work as expected when used at the beginning of a lline, as required to match a line which may have any content (as well as no content at all). See https://stackoverflow.com/questions/1024411/can-python-doctest-ignore-some-output-lines for a discussion.

#### Any other comments?

