### PR TITLE
Allow Atom.GetAtomSmarts() to return isomeric SMILES

### DIFF
--- a/Code/GraphMol/SmilesParse/SmilesWrite.cpp
+++ b/Code/GraphMol/SmilesParse/SmilesWrite.cpp
@@ -300,7 +300,8 @@ std::string FragmentSmilesConstruct(
         }
         // std::cout<<"\t\tAtom: "<<mSE.obj.atom->getIdx()<<std::endl;
         if (!atomSymbols) {
-          res << GetAtomSmiles(mSE.obj.atom, doKekule, bond, allHsExplicit);
+          res << GetAtomSmiles(mSE.obj.atom, doKekule, bond, allHsExplicit,
+                               doIsomericSmiles);
         } else {
           res << (*atomSymbols)[mSE.obj.atom->getIdx()];
         }

--- a/Code/GraphMol/SmilesParse/SmilesWrite.h
+++ b/Code/GraphMol/SmilesParse/SmilesWrite.h
@@ -31,9 +31,13 @@ RDKIT_SMILESPARSE_EXPORT bool inOrganicSubset(int atomicNumber);
     chirality calculation
   \param allHsExplicit : if true, hydrogen counts will be provided for every
   atom.
+  \param isomericSmiles : if true, isomeric SMILES will be generated
 */
-RDKIT_SMILESPARSE_EXPORT std::string GetAtomSmiles(const Atom *atom, bool doKekule = false,
-                          const Bond *bondIn = 0, bool allHsExplicit = false);
+RDKIT_SMILESPARSE_EXPORT std::string GetAtomSmiles(const Atom *atom,
+                                                   bool doKekule = false,
+                                                   const Bond *bondIn = 0,
+                                                   bool allHsExplicit = false,
+                                                   bool isomericSmiles = true);
 
 //! \brief returns the SMILES for a bond
 /*!
@@ -44,9 +48,10 @@ RDKIT_SMILESPARSE_EXPORT std::string GetAtomSmiles(const Atom *atom, bool doKeku
     bond orders for aromatic bonds)
   \param allBondsExplicit : if true, symbols will be included for all bonds.
 */
-RDKIT_SMILESPARSE_EXPORT std::string GetBondSmiles(const Bond *bond, int atomToLeftIdx = -1,
-                          bool doKekule = false, bool allBondsExplicit = false);
-}
+RDKIT_SMILESPARSE_EXPORT std::string GetBondSmiles(
+    const Bond *bond, int atomToLeftIdx = -1, bool doKekule = false,
+    bool allBondsExplicit = false);
+}  // namespace SmilesWrite
 
 //! \brief returns canonical SMILES for a molecule
 /*!
@@ -62,10 +67,10 @@ RDKIT_SMILESPARSE_EXPORT std::string GetBondSmiles(const Bond *bond, int atomToL
   \param allHsExplicit : if true, hydrogen counts will be provided for every
   atom.
  */
-RDKIT_SMILESPARSE_EXPORT std::string MolToSmiles(const ROMol &mol, bool doIsomericSmiles = true,
-                        bool doKekule = false, int rootedAtAtom = -1,
-                        bool canonical = true, bool allBondsExplicit = false,
-                        bool allHsExplicit = false);
+RDKIT_SMILESPARSE_EXPORT std::string MolToSmiles(
+    const ROMol &mol, bool doIsomericSmiles = true, bool doKekule = false,
+    int rootedAtAtom = -1, bool canonical = true, bool allBondsExplicit = false,
+    bool allHsExplicit = false);
 
 //! \brief returns canonical SMILES for part of a molecule
 /*!
@@ -90,15 +95,13 @@ RDKIT_SMILESPARSE_EXPORT std::string MolToSmiles(const ROMol &mol, bool doIsomer
   \b NOTE: the bondSymbols are *not* currently used in the canonicalization.
 
  */
-RDKIT_SMILESPARSE_EXPORT std::string MolFragmentToSmiles(const ROMol &mol,
-                                const std::vector<int> &atomsToUse,
-                                const std::vector<int> *bondsToUse = 0,
-                                const std::vector<std::string> *atomSymbols = 0,
-                                const std::vector<std::string> *bondSymbols = 0,
-                                bool doIsomericSmiles = true,
-                                bool doKekule = false, int rootedAtAtom = -1,
-                                bool canonical = true,
-                                bool allBondsExplicit = false,
-                                bool allHsExplicit = false);
-}
+RDKIT_SMILESPARSE_EXPORT std::string MolFragmentToSmiles(
+    const ROMol &mol, const std::vector<int> &atomsToUse,
+    const std::vector<int> *bondsToUse = 0,
+    const std::vector<std::string> *atomSymbols = 0,
+    const std::vector<std::string> *bondSymbols = 0,
+    bool doIsomericSmiles = true, bool doKekule = false, int rootedAtAtom = -1,
+    bool canonical = true, bool allBondsExplicit = false,
+    bool allHsExplicit = false);
+}  // namespace RDKit
 #endif

--- a/Code/GraphMol/Wrap/Atom.cpp
+++ b/Code/GraphMol/Wrap/Atom.cpp
@@ -93,12 +93,15 @@ bool AtomIsInRingSize(const Atom *atom, int size) {
                                                                 size);
 }
 
-std::string AtomGetSmarts(const Atom *atom) {
+std::string AtomGetSmarts(const Atom *atom, bool doKekule, bool allHsExplicit,
+                          bool isomericSmiles) {
   std::string res;
   if (atom->hasQuery()) {
     res = SmartsWrite::GetAtomSmarts(static_cast<const QueryAtom *>(atom));
   } else {
-    res = SmilesWrite::GetAtomSmiles(atom);
+    // FIX: this should not be necessary
+    res = SmilesWrite::GetAtomSmiles(atom, doKekule, nullptr, allHsExplicit,
+                                     isomericSmiles);
   }
   return res;
 }
@@ -243,6 +246,9 @@ struct atom_wrapper {
              "debugging purposes.\n\n")
 
         .def("GetSmarts", AtomGetSmarts,
+             (python::arg("self"), python::arg("doKekule") = false,
+              python::arg("allHsExplicit") = false,
+              python::arg("isomericSmiles") = true),
              "returns the SMARTS (or SMILES) string for an Atom\n\n")
 
         // properties
@@ -449,5 +455,5 @@ These cannot currently be constructed directly from Python\n";
         "'C<xxx>'\n");
   }
 };
-}  // end of namespace
+}  // namespace RDKit
 void wrap_atom() { RDKit::atom_wrapper::wrap(); }

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -2306,6 +2306,11 @@ CAS<~>
     self.assertTrue(m.GetAtomWithIdx(1).GetSmarts() == 'O')
     self.assertTrue(m.GetBondBetweenAtoms(0, 1).GetSmarts() == '=')
 
+    m = Chem.MolFromSmiles('C[C@H](F)[15NH3+]')
+    self.assertEqual(m.GetAtomWithIdx(0).GetSmarts(), 'C')
+    self.assertEqual(m.GetAtomWithIdx(0).GetSmarts(allHsExplicit=True), '[CH3]')
+    self.assertEqual(m.GetAtomWithIdx(3).GetSmarts(), '[15NH3+]')
+    self.assertEqual(m.GetAtomWithIdx(3).GetSmarts(allHsExplicit=True), '[15NH3+]')
   def test48Issue1928819(self):
     """ test a crash involving looping directly over mol suppliers
     """

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -2311,6 +2311,7 @@ CAS<~>
     self.assertEqual(m.GetAtomWithIdx(0).GetSmarts(allHsExplicit=True), '[CH3]')
     self.assertEqual(m.GetAtomWithIdx(3).GetSmarts(), '[15NH3+]')
     self.assertEqual(m.GetAtomWithIdx(3).GetSmarts(allHsExplicit=True), '[15NH3+]')
+
   def test48Issue1928819(self):
     """ test a crash involving looping directly over mol suppliers
     """

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -13,12 +13,16 @@
     - `BUILD_SLN_SUPPORT` -> `RDK_BUILD_SLN_SUPPORT`
     - `RDK_CAIRO_BUILD` -> `RDK_BUILD_CAIRO_SUPPORT`
 
-
 ## Backwards incompatible changes
+This release includes a set of changes to make the default arguments to common
+functions less error prone (github #1679).
+- GetAtomSmiles() now generates isomeric SMILES by default.
 
 ## Acknowledgements:
 
 ## Highlights:
+
+## Contrib updates:
 
 ## New Features and Enhancements:
 


### PR DESCRIPTION
There was no straightforward way to have `GetAtomSmarts()` (which returns SMILES if the atom has no query) return isomeric SMILES for atoms. This clears that up by adding an optional argument to `RDKit::SmilesWrite::GetAtomSmiles()` that causes it to return isomeric SMILES. In the spirit of #1679, this defaults to `true`. This is different than the current behavior (thus the `changes results` tag), but is certainly more correct.