### PR TITLE
Addresses several minor warning messages during the build

### DIFF
--- a/Code/GraphMol/AddHs.cpp
+++ b/Code/GraphMol/AddHs.cpp
@@ -494,7 +494,6 @@ bool adjustStereoAtomsIfRequired(RWMol &mol, const Atom *atom,
   const auto &cbnd =
       mol.getBondBetweenAtoms(atom->getIdx(), heavyAtom->getIdx());
   if (!cbnd) return false;
-  Bond *dblBond = nullptr;
   for (const auto &nbri :
        boost::make_iterator_range(mol.getAtomBonds(heavyAtom))) {
     Bond *bnd = mol[nbri];

--- a/Code/GraphMol/ChemTransforms/MolFragmenter.cpp
+++ b/Code/GraphMol/ChemTransforms/MolFragmenter.cpp
@@ -358,13 +358,15 @@ void checkChiralityPostMove(const ROMol &mol, const Atom *oAt, Atom *nAt,
   static const std::string newBondOrder = "_newBondOrder";
   INT_LIST newOrder;
   INT_LIST incomingOrder;
+
+  const int check_bond_index = static_cast<int>(bond->getIdx());
   // since we may call this function more than once, we need to keep track of
   // whether or not we've already been called and what the new atom order is.
   // we do this with a property.
   // this was github #1734
   if (nAt->getPropIfPresent(newBondOrder, incomingOrder)) {
-    BOOST_FOREACH (int bidx, incomingOrder) {
-      if (bidx != bond->getIdx()) {
+    for (int bidx: incomingOrder) {
+      if (bidx != check_bond_index) {
         newOrder.push_back(bidx);
       }
     }

--- a/Code/GraphMol/Chirality.cpp
+++ b/Code/GraphMol/Chirality.cpp
@@ -1735,7 +1735,7 @@ void updateDoubleBondNeighbors(ROMol &mol, Bond *dblBond, const Conformer *conf,
   }
 }
 
-bool isBondCandidateForStereo(const Bond *bond, const ROMol &mol) {
+bool isBondCandidateForStereo(const Bond *bond) {
   PRECONDITION(bond, "no bond");
   if (bond->getBondType() == Bond::DOUBLE &&
       bond->getStereo() != Bond::STEREOANY &&
@@ -1774,7 +1774,7 @@ void setDoubleBondNeighborDirections(ROMol &mol, const Conformer *conf) {
 
   for (RWMol::BondIterator bondIt = mol.beginBonds(); bondIt != mol.endBonds();
        ++bondIt) {
-    if (isBondCandidateForStereo(*bondIt, mol)) {
+    if (isBondCandidateForStereo(*bondIt)) {
       const Atom *a1 = (*bondIt)->getBeginAtom();
       const Atom *a2 = (*bondIt)->getEndAtom();
 

--- a/Code/GraphMol/FilterCatalog/FunctionalGroupHierarchy.cpp
+++ b/Code/GraphMol/FilterCatalog/FunctionalGroupHierarchy.cpp
@@ -173,9 +173,6 @@ const FuncData_t FuncDataArray[] = {
 
     {0, "TerminalAlkyne", "[C;$(C#[CH])]", "Terminal Alkyne", nullptr}};
 
-const unsigned int NUM_FUNCS =
-    static_cast<unsigned int>(sizeof(FuncDataArray) / sizeof(FuncData_t));
-
 FilterCatalog &hierarchy_get() {
   static FilterCatalog fgroup;
   return fgroup;

--- a/Code/GraphMol/FilterCatalog/update_pains.py
+++ b/Code/GraphMol/FilterCatalog/update_pains.py
@@ -137,9 +137,10 @@ sc = set(pains_c)
 
 PAINS = {}
 
-for smiles, name in csv.reader(open(PAINS_CSV)):
-  name = name.replace("<regId=", "").replace(">", "")
-  PAINS[name] = smiles
+with open(PAINS_CSV) as fh:
+  for smiles, name in csv.reader(fh):
+    name = name.replace("<regId=", "").replace(">", "")
+    PAINS[name] = smiles
 
 PAINS_A = []
 for n in pains_a:
@@ -166,17 +167,18 @@ PAINS_C = "const FilterData_t PAINS_C[] = {\n%s\n};" % ",\n".join(PAINS_C)
 
 
 def write_pains(filename, data):
-  t = open(filename).read()
+  with open(filename) as fh:
+    t = fh.read()
   if t != data:
     if py3:
       import io
       # newline = don't convert to windows style
-      f = io.open(filename, 'w', newline='')
-      f.write(data)
+      with io.open(filename, 'w', newline='') as f:
+        f.write(data)
     else:
       # wb = means don't convert newline to windows style
-      open(filename, 'wb').write(data)
-
+      with open(filename, 'wb') as f:
+        f.write(data)
 
 write_pains(PAINS_A_FILENAME, PAINS_A)
 write_pains(PAINS_B_FILENAME, PAINS_B)

--- a/Code/GraphMol/RGroupDecomposition/testRGroupDecomp.cpp
+++ b/Code/GraphMol/RGroupDecomposition/testRGroupDecomp.cpp
@@ -425,7 +425,7 @@ void testMatchOnlyAtRgroupHs() {
   const char *smilesData[2] = {"OCC","COCC"};
   for (int i = 0; i < 2; ++i) {
     ROMol *mol = SmilesToMol(smilesData[i]);
-    int res = decomp.add(*mol);
+    decomp.add(*mol);
   }
   decomp.process();
 

--- a/Code/GraphMol/StructChecker/ReCharge.cpp
+++ b/Code/GraphMol/StructChecker/ReCharge.cpp
@@ -402,7 +402,6 @@ int ChargeFix::markMostAcidicAtoms(double &pKa_value, double &gap) {
   unsigned na = Mol.getNumAtoms();
 
   for (unsigned i = 0; i < na; i++) {
-    const Atom &atom = *Mol.getAtomWithIdx(i);
     if (AtomColor[i] != 0 && AtompKaValue[i] < min_pKa)
       min_pKa = AtompKaValue[i];
   }

--- a/Code/GraphMol/StructChecker/Tautomer.cpp
+++ b/Code/GraphMol/StructChecker/Tautomer.cpp
@@ -33,7 +33,6 @@ bool StructCheckTautomer::applyTautomer(unsigned it) {
     return false;
   }
   const unsigned nta = toTautomer.getNumAtoms();
-  const unsigned ntb = toTautomer.getNumBonds();
   MatchVectType match;  // The format is (queryAtomIdx, molAtomIdx)
   std::vector<unsigned> atomIdxMap(
       Mol.getNumAtoms());  // matched tau atom indeces

--- a/Code/GraphMol/molopstest.cpp
+++ b/Code/GraphMol/molopstest.cpp
@@ -4691,7 +4691,7 @@ void testRenumberAtoms() {
     ROMol *m = new ROMol;
     TEST_ASSERT(m);
     std::vector<unsigned int> nVect;
-    ROMol *nm = MolOps::renumberAtoms(*m, nVect);
+    MolOps::renumberAtoms(*m, nVect);
     delete m;
   }
 
@@ -6939,6 +6939,8 @@ void testGithub1281() {
       bool ok = false;
       try {
         RWMol *m = SmilesToMol(smiles);
+        // Can never get here:
+        delete m;
       } catch (const ValueErrorException &) {
         ok = true;
       }

--- a/Code/GraphMol/testPicklerGlobalSettings.cpp
+++ b/Code/GraphMol/testPicklerGlobalSettings.cpp
@@ -254,7 +254,7 @@ void testGlobalPickleProps() {
 }
 
 
-int main(int argc, char *argv[]) {
+int main(int, char**) {
   RDLog::InitLogs();
 
   testGlobalPickleProps();

--- a/Code/SimDivPickers/testPickers.cpp
+++ b/Code/SimDivPickers/testPickers.cpp
@@ -16,7 +16,7 @@
 
 namespace {
 double dist_on_line(unsigned int i, unsigned int j) {
-  return abs((double)i - (double)j);
+  return std::abs((double)i - (double)j);
 }
 }
 void testGithub1421() {


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
I compiled using clang and Python3. It's possible that neither are the default for other users, so I saw a couple of warning messages that looked easy to fix.

This includes three commits:

* Close open file handles during build set-up (a6e8fa9), which addresses several "ResourceWarning:
unclosed file" when building under Python3
* Address minor compiler warnings (af9a4fd), which addresses several trivial warning messages under clang.
* Address compiler warning: impossible comparison. (a593381) **This is a logical change**. Removes a comparison between unsigned int and -1, which can never be true.
