### PR TITLE
Allow coordgen and maeparser to be built as static libraries

### DIFF
--- a/Code/cmake/Modules/RDKitUtils.cmake
+++ b/Code/cmake/Modules/RDKitUtils.cmake
@@ -273,3 +273,20 @@ function(createExportTestHeaders)
   overwriteIfChanged("${CMAKE_BINARY_DIR}/${exportPath}" "${CMAKE_SOURCE_DIR}/${exportPath}")
   overwriteIfChanged("${CMAKE_BINARY_DIR}/${testPath}" "${CMAKE_SOURCE_DIR}/${testPath}")
 endfunction(createExportTestHeaders)
+
+function(patchCoordGenMaeExportHeaders keyword path)
+  file(APPEND "${path}"
+    "// appended by CMake patchCoordGenMaeExportHeaders\n"
+    "#if !defined(RDKIT_DYN_LINK) || defined(SWIG)\n"
+    "#ifdef EXPORT_${keyword}\n"
+    "#undef EXPORT_${keyword}\n"
+    "#endif\n"
+    "#define EXPORT_${keyword}\n"
+    "#endif\n"
+    "#ifndef SWIG\n"
+    "#ifdef _MSC_VER\n"
+    "#pragma warning(disable:4251)\n"
+    "#pragma warning(disable:4275)\n"
+    "#endif\n"
+    "#endif\n")
+endfunction(patchCoordGenMaeExportHeaders)

--- a/External/CoordGen/CMakeLists.txt
+++ b/External/CoordGen/CMakeLists.txt
@@ -1,6 +1,9 @@
 add_custom_target(coordgen_support ALL)
 
 if(RDK_BUILD_COORDGEN_SUPPORT)
+    add_definitions(-DIN_MAEPARSER)
+    add_definitions(-DIN_COORDGEN)
+    include(RDKitUtils)
     if(NOT DEFINED MAEPARSER_DIR)
       set(MAEPARSER_DIR "${CMAKE_CURRENT_SOURCE_DIR}/maeparser")
     endif()
@@ -13,15 +16,13 @@ if(RDK_BUILD_COORDGEN_SUPPORT)
           ${CMAKE_CURRENT_SOURCE_DIR}/master.tar.gz
           WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
         file(RENAME "maeparser-${RELEASE_NO}" "${MAEPARSER_DIR}")
+        patchCoordGenMaeExportHeaders("MAEPARSER" "${MAEPARSER_DIR}/MaeParserConfig.hpp")
     else()
       message("-- Found MAEParser source in ${MAEPARSER_DIR}")
     endif()
 
     file(GLOB MAESOURCES "${MAEPARSER_DIR}/*.cpp")
     rdkit_library(maeparser ${MAESOURCES} SHARED )
-    if((MSVC AND RDK_INSTALL_DLLS_MSVC) OR ((NOT MSVC) AND WIN32))
-      set_target_properties(maeparser PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
-    endif()
     install(TARGETS maeparser DESTINATION ${RDKit_LibDir})
 
     if(NOT DEFINED COORDGEN_DIR)
@@ -37,15 +38,13 @@ if(RDK_BUILD_COORDGEN_SUPPORT)
           ${CMAKE_CURRENT_SOURCE_DIR}/master.tar.gz
           WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
         file(RENAME "coordgenlibs-${RELEASE_NO}" "${COORDGEN_DIR}")
+        patchCoordGenMaeExportHeaders("COORDGEN" "${COORDGEN_DIR}/CoordgenConfig.hpp")
     else()
       message("-- Found coordgenlibs source in ${COORDGEN_DIR}")
     endif()
 
     file(GLOB CGSOURCES "${COORDGEN_DIR}/*.cpp")
     rdkit_library(coordgenlib ${CGSOURCES} SHARED LINK_LIBRARIES maeparser)
-    if((MSVC AND RDK_INSTALL_DLLS_MSVC) OR ((NOT MSVC) AND WIN32))
-      set_target_properties(coordgenlib PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
-    endif()
     install(TARGETS coordgenlib DESTINATION ${RDKit_LibDir})
 
     set(MAE_FILES ${COORDGEN_DIR}/templates.mae )


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! 
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->
The code in the `coordgen` and `maeparser` now incorporates explicit `dllimport`/`dllexport` decorators, however it does not seem to support building static libraries on Windows anymore, as `dllimport`/`dllexport` decorators are always added.

#### What does this implement/fix? Explain your changes.
As the RDKit needs to build static libraries too, I added a `patchCoordGenMaeExportHeaders()` function to `RDKitUtils.cmake` which adds a few pre-processor directives to `coordgen` and `maeparser` headers to allow that. Additionally, I removed the `CMAKE WINDOWS EXPORT_ALL_SYMBOLS` bit from the `coordgen` `CMakeLists.txt` as it is not needed anymore, since now explict decorators are present in the headers. I also added the `-DIN_COORDGEN` and `-DIN_MAEPARSER` definitions to the `coordgen` `CMakeLists.txt` as required by the new `coordgen`/`maeparser` headers.

#### Any other comments?

