### PR TITLE
Make IFG contrib license clearer

### DIFF
--- a/Contrib/IFG/ifg.py
+++ b/Contrib/IFG/ifg.py
@@ -1,3 +1,12 @@
+#
+#  Original authors: Richard Hall and Guillaume Godin
+#  This file is part of the RDKit.
+#  The contents are covered by the terms of the BSD license
+#  which is included in the file license.txt, found at the root
+#  of the RDKit source tree.
+
+#
+#
 # Richard hall 2017
 # IFG main code
 # Guillaume Godin 2017


### PR DESCRIPTION
@thegodone @Richard-Hall : The IFG contribution to the RDKit didn't include anything explicit about the license. This fixes that.
Are you ok with the changes?