### PR TITLE
Fixes #1929

### DIFF
--- a/External/CoordGen/CoordGen.h
+++ b/External/CoordGen/CoordGen.h
@@ -50,8 +50,11 @@ unsigned int addCoords(T& mol, const CoordGenParams* params = nullptr) {
   if (params->templateFileDir != "") {
     templateFileDir = params->templateFileDir;
   } else {
-    templateFileDir = std::getenv("RDBASE");
-    templateFileDir += "/Data/";
+    auto rdbase = std::getenv("RDBASE");
+    if (rdbase != nullptr) {
+      templateFileDir += rdbase;
+      templateFileDir += "/Data/";
+    }
   }
   double scaleFactor = params->coordgenScaling;
 
@@ -60,8 +63,9 @@ unsigned int addCoords(T& mol, const CoordGenParams* params = nullptr) {
 
   // FIX: only do this check once.
   std::cerr << "  TEMPLATES: " << templateFileDir << std::endl;
-  minimizer.setTemplateFileDir(templateFileDir);
-
+  if (templateFileDir != "") {
+    minimizer.setTemplateFileDir(templateFileDir);
+  }
   bool hasTemplateMatch = false;
   MatchVectType mv;
   if (params->templateMol && params->templateMol->getNumConformers() == 1) {

--- a/External/CoordGen/test.cpp
+++ b/External/CoordGen/test.cpp
@@ -138,7 +138,7 @@ bool compareConfs(const ROMol* m, const ROMol* templ, const MatchVectType& mv,
   }
   return true;
 }
-}
+}  // namespace
 
 void test2() {
   BOOST_LOG(rdInfoLog) << "-------------------------------------" << std::endl;
@@ -391,10 +391,31 @@ void test2() {
   BOOST_LOG(rdInfoLog) << "done" << std::endl;
 }
 
+void testGithub1929() {
+  BOOST_LOG(rdInfoLog) << "-------------------------------------" << std::endl;
+  BOOST_LOG(rdInfoLog)
+      << "testing github1929: make sure coordgen works with bogus file names"
+      << std::endl;
+  {
+    ROMol* m = SmilesToMol("c1cc(CC)cnc1CC(=O)O");
+    TEST_ASSERT(m);
+    m->setProp("_Name", "test1");
+    CoordGen::CoordGenParams params;
+    params.templateFileDir = "I_do_not_exist";
+
+    TEST_ASSERT(CoordGen::addCoords(*m, &params) == 0);
+    TEST_ASSERT(m->getNumConformers() == 1);
+    delete m;
+  }
+
+  BOOST_LOG(rdInfoLog) << "done" << std::endl;
+}
+
 int main(int argc, char* argv[]) {
   (void)argc;
   (void)argv;
   RDLog::InitLogs();
   test2();
   test1();
+  testGithub1929();
 }

--- a/rdkit/RDConfig.py
+++ b/rdkit/RDConfig.py
@@ -24,6 +24,8 @@ if 'RDBASE' in os.environ:
   RDContribDir = os.path.join(RDBaseDir, 'Contrib')
 else:
   from rdkit.RDPaths import *
+  import rdkit.RDPaths
+  os.environ['RDBASE'] = rdkit.RDPaths._share
 
 rpcTestPort = 8423
 pythonTestCommand = "python"
@@ -38,6 +40,7 @@ class ObsoleteCodeError(Exception):
 
 class UnimplementedCodeError(Exception):
   pass
+
 
 # ---------------------
 # the following block contains stuff used by the


### PR DESCRIPTION
This does two things:
1) Remove the cause of the segfault
2) start setting `$RDBASE` on the Python side when `RDPaths` is being used.