### PR TITLE
Fix embarassing bug, check the counter each iteration 

### DIFF
--- a/Code/GraphMol/SubstructLibrary/SubstructLibrary.cpp
+++ b/Code/GraphMol/SubstructLibrary/SubstructLibrary.cpp
@@ -86,9 +86,11 @@ void SubSearcher(const ROMol &in_query, const Bits &bits,
                  std::atomic<int> &counter, const int maxResults) {
   ROMol query(in_query);
   MatchVectType matchVect;
-  for (unsigned int idx = start; idx < end; idx += numThreads) {
+  for (unsigned int idx = start;
+       idx < end && (maxResults == -1 || counter < maxResults);
+       idx += numThreads) {
     if (!bits.check(idx)) continue;
-    // need shared_ptr as it (may) controls the lifespan of the
+    // need shared_ptr as it (may) control the lifespan of the
     //  returned molecule!
     const boost::shared_ptr<ROMol> &m = mols.getMol(idx);
     const ROMol *mol = m.get();


### PR DESCRIPTION
not just after searching

This was noted by Andrew Dalke.  It can be a large optimization or a minor one depending on the number of false positives in the bit vector.

<!--
Thanks for contributing a pull request! 
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.


#### Any other comments?
