### PR TITLE
Update Install.md for linux build in anaconda environment

### DIFF
--- a/Docs/Book/Install.md
+++ b/Docs/Book/Install.md
@@ -80,12 +80,8 @@ Start by downloading the latest anaconda installer from [Anaconda](https://www.a
 Numpy and matplotlib are already part of the base installation of anaconda. Due to the latest boost libraries being currently built with a GLIBC version higher than the default in anaconda, we need to update to a more recent version:
 
 	conda install -y gxx_linux-64
-
-After that, numpy's include path must be fixed to allow RDKit to find its headers in the proper location. For that, from your anaconda root directory (usually ~/anaconda3/), run:
-
-	ln -s ./lib/python3.6/site-packages/numpy/core/include/numpy ./include/
 	
-At this point, you should be able to clone the RDKit repository to the desired build location, and start the build:
+At this point, you should be able to clone the RDKit repository to the desired build location, and start the build. Please consider that it is necessary to indicate the path to the numpy headers for RDKit to find them, since anaconda hides them inside the numpy package:
 
 	git clone https://github.com/rdkit/rdkit.git
 	cd rdkit

--- a/Docs/Book/Install.md
+++ b/Docs/Book/Install.md
@@ -67,6 +67,38 @@ Once "make" and "make install" completed successfully, use the following command
 This is required due to the [System Integrity Protection SIP](https://en.wikipedia.org/wiki/System_Integrity_Protection)
 introduced in more recent macOS versions.
 
+#### Linux x86_64: Python 3 environment
+
+The following commands will create a development environment for Linux x86_64 and Python 3.
+
+Start by downloading the latest anaconda installer from [Anaconda](https://www.anaconda.com/download/#linux) and install it. Then, install the required packages:
+
+	bash Anaconda3-5.2.0-x86_64.sh
+    conda install -y cmake cairo pillow eigen pkg-config
+    conda install -y boost-cpp boost py-boost
+
+Numpy and matplotlib are already part of the base installation of anaconda. Due to the latest boost libraries being currently built with a GLIBC version higher than the default in anaconda, we need to update to a more recent version:
+
+	conda install -y gxx_linux-64
+
+After that, numpy's include path must be fixed to allow RDKit to find its headers in the proper location. For that, from your anaconda root directory (usually ~/anaconda3/), run:
+
+	ln -s ./lib/python3.6/site-packages/numpy/core/include/numpy ./include/
+	
+At this point, you should be able to clone the RDKit repository to the desired build location, and start the build:
+
+	git clone https://github.com/rdkit/rdkit.git
+	cd rdkit
+	mkdir build && cd build
+	cmake .. -DPy_ENABLE_SHARED=1 \
+		-DRDK_INSTALL_INTREE=ON \
+		-DRDK_INSTALL_STATIC_LIBS=OFF \
+		-DRDK_BUILD_CPP_TESTS=ON \
+		-DRDK_OPTIMIZE_NATIVE=OFF
+	  
+And finally, `make`, `make install` and `ctest`
+
+
 ### Installing and using PostgreSQL and the RDKit PostgreSQL cartridge from a conda environment
 
 Due to the conda python distribution being a different version to the system python, it is easiest to install PostgreSQL and the PostgreSQL python client via conda.

--- a/Docs/Book/Install.md
+++ b/Docs/Book/Install.md
@@ -93,8 +93,7 @@ At this point, you should be able to clone the RDKit repository to the desired b
 	cmake .. -DPy_ENABLE_SHARED=1 \
 		-DRDK_INSTALL_INTREE=ON \
 		-DRDK_INSTALL_STATIC_LIBS=OFF \
-		-DRDK_BUILD_CPP_TESTS=ON \
-		-DRDK_OPTIMIZE_NATIVE=OFF
+		-DRDK_BUILD_CPP_TESTS=ON
 	  
 And finally, `make`, `make install` and `ctest`
 

--- a/Docs/Book/Install.md
+++ b/Docs/Book/Install.md
@@ -93,7 +93,8 @@ At this point, you should be able to clone the RDKit repository to the desired b
 	cmake .. -DPy_ENABLE_SHARED=1 \
 		-DRDK_INSTALL_INTREE=ON \
 		-DRDK_INSTALL_STATIC_LIBS=OFF \
-		-DRDK_BUILD_CPP_TESTS=ON
+		-DRDK_BUILD_CPP_TESTS=ON \
+		-DPYTHON_NUMPY_INCLUDE_PATH="$CONDA_PREFIX/lib/python3.6/site-packages/numpy/core/include"
 	  
 And finally, `make`, `make install` and `ctest`
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! 
-->
#### Reference Issue
To build RDKit under anaconda environment in linux, a couple of fixes are required, since the GLIBC version with which 'boost' requires is higher than the one in the default compiler. Also, numpy headers must be linked into the main include directory for RDKit to be able to find them.

#### What does this implement/fix? Explain your changes.
It adds detailed instructions on how to build from source in Linux/andaconda3 environment.

#### Any other comments?
Thanks!
