### PR TITLE
Fixes #1925

### DIFF
--- a/Code/GraphMol/SmilesParse/SmilesParseOps.cpp
+++ b/Code/GraphMol/SmilesParse/SmilesParseOps.cpp
@@ -15,6 +15,7 @@
 #include <algorithm>
 #include <boost/dynamic_bitset.hpp>
 #include <boost/foreach.hpp>
+#include <boost/format.hpp>
 #include <RDGeneral/RDLog.h>
 
 namespace SmilesParseOps {
@@ -442,9 +443,14 @@ void CloseMolRings(RWMol *mol, bool toleratePartials) {
         if (!toleratePartials && atomIt == atomsEnd) {
           ReportParseError("unclosed ring");
         } else if (atomIt != atomsEnd && *atomIt == atom1) {
-          // make sure we don't try to connect an atom to itself,
-          // this was bug 3145697:
-          ++atomIt;
+          // make sure we don't try to connect an atom to itself
+          // this was github #1925
+          auto fmt =
+              boost::format{
+                  "duplicated ring closure %1% bonds atom %2% to itself"} %
+              bookmarkIt->first % atom1->getIdx();
+          std::string msg = fmt.str();
+          ReportParseError(msg.c_str(), true);
         } else if (atomIt != atomsEnd) {
           // we actually found an atom, so connect it to the first
           Atom *atom2 = *atomIt;

--- a/Code/GraphMol/SmilesParse/test.cpp
+++ b/Code/GraphMol/SmilesParse/test.cpp
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2003-2016 Greg Landrum and  Rational Discovery LLC
+//  Copyright (C) 2003-2018 Greg Landrum and  Rational Discovery LLC
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -4053,6 +4053,19 @@ void testHashAtomExtension() {
   BOOST_LOG(rdInfoLog) << "done" << std::endl;
 }
 
+void testGithub1925() {
+  BOOST_LOG(rdInfoLog) << "Testing Github #1925: Atom with bond to itself is "
+                          "accepted by the SMILES parser."
+                       << std::endl;
+  {
+    std::string smi = "C1CC111";
+    RWMol *m = nullptr;
+    m = SmilesToMol(smi);
+    TEST_ASSERT(!m);
+  }
+  BOOST_LOG(rdInfoLog) << "done" << std::endl;
+}
+
 int main(int argc, char *argv[]) {
   (void)argc;
   (void)argv;
@@ -4121,8 +4134,9 @@ int main(int argc, char *argv[]) {
   testGithub1219();
   testSmilesParseParams();
   testRingClosureNumberWithBrackets();
-#endif
   testGithub1652();
   testIsomericSmilesIsDefault();
   testHashAtomExtension();
+#endif
+  testGithub1925();
 }


### PR DESCRIPTION
This also introduces a dependency on boost::format since it seems much cleaner than using a stringstream

