### PR TITLE
Add conda-forge tip to Install.md

### DIFF
--- a/Docs/Book/Install.md
+++ b/Docs/Book/Install.md
@@ -16,20 +16,26 @@ The easiest way to get Conda is having it installed as part of the [Anaconda Pyt
 
 Creating a new conda environment with the RDKit installed requires one single command similar to the following::
 
-  $ conda create -c rdkit -n my-rdkit-env rdkit
+    $ conda create -c rdkit -n my-rdkit-env rdkit
 
 Finally, the new environment must be activated so that the corresponding python interpreter becomes available in the same shell:
 
-  $ source activate my-rdkit-env
+    $ source activate my-rdkit-env
 
 If for some reason this does not work, try:
 
-  $ cd [anaconda folder]/bin
-  $ source activate my-rdkit-env
+    $ cd [anaconda folder]/bin
+    $ source activate my-rdkit-env
 
 Windows users will use a slightly different command:
 
-  C:\> activate my-rdkit-env
+    C:\> activate my-rdkit-env
+  
+#### conda-forge package
+
+A [conda-forge](https://conda-forge.org/#about) RDKit package is also available, which may offer an easier installation for users already using other conda-forge packages. This package can be installed with:
+
+    $ conda install -c conda-forge rdkit
 
 ### How to build from source with Conda
 


### PR DESCRIPTION
Also fixes a couple other lines that didn't get parsed as code blocks.

Not sure whether or not you're OK pointing users to the unofficial conda-forge feedstock -- the installation is probably easier via the conda-forge package if you already are using other package supplied via conda-forge. But those users might already know about the rdkit package?