### PR TITLE
Fixes #1972

### DIFF
--- a/Code/GraphMol/SmilesParse/SmilesParseOps.cpp
+++ b/Code/GraphMol/SmilesParse/SmilesParseOps.cpp
@@ -43,11 +43,19 @@ void CheckRingClosureBranchStatus(RDKit::Atom *atom, RDKit::RWMol *mp) {
   // We recognize these situations using the index of the chiral atom
   // and the degree of that chiral atom at the time the ring closure
   // digit is encountered during parsing.
+  // ----------
+  // github #1972 adds these examples:
+  //   1) [C@@]1(Cl)(F)I.Br1    (ok)
+  //   2) [C@@](Cl)1(F)I.Br1    (reverse)
+  //   3) [C@@](Cl)(F)1I.Br1    (ok)
+  //   4) [C@@](Cl)(F)(I)1.Br1  (reverse)
   if (atom->getIdx() != mp->getNumAtoms(true) - 1 &&
       (atom->getDegree() == 1 ||
-       (atom->getDegree() == 2 && atom->getIdx() != 0)) &&
+       (atom->getDegree() == 2 && atom->getIdx() != 0) ||
+       (atom->getDegree() == 3 && atom->getIdx() == 0)) &&
       (atom->getChiralTag() == Atom::CHI_TETRAHEDRAL_CW ||
        atom->getChiralTag() == Atom::CHI_TETRAHEDRAL_CCW)) {
+    // std::cerr << "crcbs: " << atom->getIdx() << std::endl;
     atom->invertChirality();
   }
 }
@@ -307,10 +315,10 @@ void AdjustAtomChiralityFlags(RWMol *mol) {
                                   ringClosures);
 
 #if 0
-      std::cout << "CLOSURES: ";
+      std::cerr << "CLOSURES: ";
       std::copy(ringClosures.begin(), ringClosures.end(),
-                std::ostream_iterator<int>(std::cout, " "));
-      std::cout << std::endl;
+                std::ostream_iterator<int>(std::cerr, " "));
+      std::cerr << std::endl;
 #endif
       std::list<SIZET_PAIR> neighbors;
       // push this atom onto the list of neighbors (we'll use this

--- a/Code/GraphMol/SmilesParse/test.cpp
+++ b/Code/GraphMol/SmilesParse/test.cpp
@@ -4066,6 +4066,65 @@ void testGithub1925() {
   BOOST_LOG(rdInfoLog) << "done" << std::endl;
 }
 
+void testGithub1972() {
+  BOOST_LOG(rdInfoLog)
+      << "Testing Github #1972: Incorrect tetrahedral stereo when reading "
+         "SMILES with ring closure as last neighbor"
+      << std::endl;
+  {
+    std::vector<std::vector<std::string>> smiles = {
+        {"[C@@]1(Cl)(F)(I).Br1", "[C@@](Br)(Cl)(F)(I)"},
+        {"[C@@](Cl)(F)(I)1.Br1", "[C@@](Cl)(F)(I)Br"},
+        {"[C@@](Cl)1(F)(I).Br1", "[C@@](Cl)(Br)(F)(I)"},
+        {"[C@@](Cl)(F)1(I).Br1", "[C@@](Cl)(F)(Br)(I)"}};
+    for (const auto &pr : smiles) {
+      // std::cerr << "--------------------------" << std::endl;
+      // std::cerr << pr[0] << " " << pr[1] << std::endl;
+      std::unique_ptr<ROMol> m1(SmilesToMol(pr[0]));
+      // std::cerr << "------------" << std::endl;
+      std::unique_ptr<ROMol> m2(SmilesToMol(pr[1]));
+      TEST_ASSERT(m1);
+      TEST_ASSERT(m2);
+      // m1->debugMol(std::cerr);
+      // std::cerr << "------------" << std::endl;
+      // m2->debugMol(std::cerr);
+      auto csmi1 = MolToSmiles(*m1);
+      auto csmi2 = MolToSmiles(*m2);
+      // std::cerr << ">>> " << (csmi1 == csmi2) << " " << csmi1 << " " << csmi2
+      //           << std::endl;
+      TEST_ASSERT(csmi1 == csmi2);
+    }
+  }
+  {  // even stupider examples
+    std::vector<std::vector<std::string>> smiles = {
+        {"[C@@]1(Cl)2(I).Br1.F2", "[C@@](Br)(Cl)(F)(I)"},
+        {"[C@@](Cl)2(I)1.Br1.F2", "[C@@](Cl)(F)(I)Br"},
+        {"[C@@]12(Cl)(I).Br1.F2", "[C@@](Br)(F)(Cl)(I)"},
+        {"[C@@]21(Cl)(I).Br1.F2", "[C@@](F)(Br)(Cl)(I)"},
+        {"[C@@](Cl)12(I).Br1.F2", "[C@@](Cl)(Br)(F)(I)"},
+        {"[C@@](Cl)21(I).Br1.F2", "[C@@](Cl)(F)(Br)(I)"},
+        {"[C@@](Cl)(I)21.Br1.F2", "[C@@](Cl)(I)(F)(Br)"},
+        {"[C@@](Cl)(I)12.Br1.F2", "[C@@](Cl)(I)(Br)(F)"}};
+    for (const auto &pr : smiles) {
+      // std::cerr << "--------------------------" << std::endl;
+      // std::cerr << pr[0] << " " << pr[1] << std::endl;
+      std::unique_ptr<ROMol> m1(SmilesToMol(pr[0]));
+      // std::cerr << "------------" << std::endl;
+      std::unique_ptr<ROMol> m2(SmilesToMol(pr[1]));
+      TEST_ASSERT(m1);
+      TEST_ASSERT(m2);
+      // m1->debugMol(std::cerr);
+      // std::cerr << "------------" << std::endl;
+      // m2->debugMol(std::cerr);
+      auto csmi1 = MolToSmiles(*m1);
+      auto csmi2 = MolToSmiles(*m2);
+      // std::cerr << ">>> " << (csmi1 == csmi2) << " " << csmi1 << " " << csmi2
+      //           << std::endl;
+      TEST_ASSERT(csmi1 == csmi2);
+    }
+  }
+  BOOST_LOG(rdInfoLog) << "done" << std::endl;
+}
 int main(int argc, char *argv[]) {
   (void)argc;
   (void)argv;
@@ -4137,6 +4196,7 @@ int main(int argc, char *argv[]) {
   testGithub1652();
   testIsomericSmilesIsDefault();
   testHashAtomExtension();
-#endif
   testGithub1925();
+#endif
+  testGithub1972();
 }


### PR DESCRIPTION
adds another special case for these.
At some point it would be worthwhile to refactor the way that ring closures are handled by the SMILES/SMARTS parsers, but that's a larger undertaking.