### PR TITLE
Fixes #1985

### DIFF
--- a/Code/GraphMol/SmilesParse/SmartsWrite.cpp
+++ b/Code/GraphMol/SmilesParse/SmartsWrite.cpp
@@ -636,6 +636,9 @@ std::string FragmentSmartsConstruct(ROMol &mol, unsigned int atomIdx,
   VECT_INT_VECT rings;
   mol.getRingInfo()->reset();
   mol.getRingInfo()->initialize();
+  for (auto &atom : mol.atoms()) {
+    atom->updatePropertyCache(false);
+  }
   Canon::canonicalizeFragment(mol, atomIdx, colors, ranks, molStack);
 
   // now clear the "SSSR" property

--- a/Code/GraphMol/SmilesParse/smatest.cpp
+++ b/Code/GraphMol/SmilesParse/smatest.cpp
@@ -2583,6 +2583,28 @@ void testGithub1906() {
   BOOST_LOG(rdInfoLog) << "done" << std::endl;
 }
 
+void testGithub1985() {
+  BOOST_LOG(rdInfoLog) << "-------------------------------------" << std::endl;
+  BOOST_LOG(rdInfoLog) << "Testing Github #1985: MolFromSmarts/MolToSmarts "
+                          "fails to round trip on patterns with chirality"
+                       << std::endl;
+  {
+    std::vector<std::string> smarts = {
+        "[C@]",
+        "[C:1]([C@:3]1([OH:24])[CH2:8][CH2:7][C@H:6]2[C@H:9]3[C@H:19]([C@@H:20]"
+        "([F:22])[CH2:21][C@:4]12[CH3:5])[C@:17]1([CH3:18])[C:12](=[CH:13][C:"
+        "14](=[O:23])[CH2:15][CH2:16]1)[CH:11]=[CH:10]3)#[CH:2]"};
+    for (const auto &pr : smarts) {
+      std::unique_ptr<ROMol> m1(SmartsToMol(pr));
+      TEST_ASSERT(m1);
+      auto csma1 = MolToSmarts(*m1);
+      TEST_ASSERT(csma1.find("C@") != std::string::npos);
+    }
+  }
+
+  BOOST_LOG(rdInfoLog) << "done" << std::endl;
+}
+
 int main(int argc, char *argv[]) {
   (void)argc;
   (void)argv;
@@ -2631,7 +2653,9 @@ int main(int argc, char *argv[]) {
   testGithub1920();
   testGithub1719();
   testCombinedQueries();
-#endif
   testGithub1906();
+#endif
+  testGithub1985();
+
   return 0;
 }


### PR DESCRIPTION
The trick here is to call `updatePropertyCache()` before generating SMARTS.
