### PR TITLE
Resolve #1269

### DIFF
--- a/Code/GraphMol/ChemReactions/ReactionRunner.cpp
+++ b/Code/GraphMol/ChemReactions/ReactionRunner.cpp
@@ -438,10 +438,8 @@ void setReactantAtomPropertiesToProduct(Atom *productAtom,
   } else {
     // remove bookkeeping labels (if present)
     if (productAtom->hasProp(WAS_DUMMY)) productAtom->clearProp(WAS_DUMMY);
-    if (productAtom->hasProp(REACT_ATOM_IDX))
-      productAtom->clearProp(REACT_ATOM_IDX);
   }
-
+  productAtom->setProp<unsigned int>(REACT_ATOM_IDX,reactantAtom.getIdx());
   if (setImplicitProperties) {
     updateImplicitAtomProperties(productAtom, &reactantAtom);
   }

--- a/Code/GraphMol/ChemReactions/ReactionRunner.cpp
+++ b/Code/GraphMol/ChemReactions/ReactionRunner.cpp
@@ -439,7 +439,7 @@ void setReactantAtomPropertiesToProduct(Atom *productAtom,
     // remove bookkeeping labels (if present)
     if (productAtom->hasProp(WAS_DUMMY)) productAtom->clearProp(WAS_DUMMY);
   }
-  productAtom->setProp<unsigned int>(REACT_ATOM_IDX,reactantAtom.getIdx());
+  productAtom->setProp<unsigned int>(REACT_ATOM_IDX, reactantAtom.getIdx());
   if (setImplicitProperties) {
     updateImplicitAtomProperties(productAtom, &reactantAtom);
   }
@@ -1058,7 +1058,9 @@ ROMol *reduceProductToSideChains(const ROMOL_SPTR &product,
     Atom *scaffold_atom =
         mol->getAtomWithIdx(rdcast<unsigned int>(scaffold_atom_idx));
     // add map no's here from dummy atoms
-    if (!scaffold_atom->hasProp(REACT_ATOM_IDX)) {
+    // was this atom in one of the reactant templates?
+    if (scaffold_atom->hasProp(OLD_MAPNO) ||
+        !scaffold_atom->hasProp(REACT_ATOM_IDX)) {
       // are we attached to a reactant atom?
       ROMol::ADJ_ITER nbrIdx, endNbrs;
       boost::tie(nbrIdx, endNbrs) = mol->getAtomNeighbors(scaffold_atom);
@@ -1066,7 +1068,7 @@ ROMol *reduceProductToSideChains(const ROMOL_SPTR &product,
 
       while (nbrIdx != endNbrs) {
         Atom *nbr = mol->getAtomWithIdx(*nbrIdx);
-        if (nbr->hasProp(REACT_ATOM_IDX)) {
+        if (!nbr->hasProp(OLD_MAPNO) && nbr->hasProp(REACT_ATOM_IDX)) {
           if (nbr->hasProp(WAS_DUMMY)) {
             bonds_to_product.push_back(RGroup(
                 nbr,

--- a/Code/GraphMol/ChemReactions/ReactionRunner.cpp
+++ b/Code/GraphMol/ChemReactions/ReactionRunner.cpp
@@ -48,12 +48,8 @@ typedef std::vector<MatchVectType> VectMatchVectType;
 typedef std::vector<VectMatchVectType> VectVectMatchVectType;
 
 namespace {
-const std::string REACT_ATOM_IDX =
-    "react_atom_idx";  // reactant atom idx ( in output )
 const std::string WAS_DUMMY =
     "was_dummy";  // was the atom originally a dummy in product
-const std::string OLD_MAPNO =
-    "old_mapno";  // the original mapno (mapno gets cleared)
 }  // namespace
 
 namespace ReactionRunnerUtils {
@@ -202,7 +198,7 @@ RWMOL_SPTR convertTemplateToMol(const ROMOL_SPTR prodTemplateSptr) {
       // now clear the molAtomMapNumber property so that it doesn't
       // end up in the products (this was bug 3140490):
       newAtom->clearProp(common_properties::molAtomMapNumber);
-      newAtom->setProp<int>(OLD_MAPNO, mapNum);
+      newAtom->setProp<int>(common_properties::reactionMapNum, mapNum);
     }
 
     newAtom->setChiralTag(Atom::CHI_UNSPECIFIED);
@@ -433,13 +429,13 @@ void setReactantAtomPropertiesToProduct(Atom *productAtom,
     if (productAtom->hasProp(common_properties::_MolFileRLabel)) {
       productAtom->clearProp(common_properties::_MolFileRLabel);
     }
-    productAtom->setProp<unsigned int>(REACT_ATOM_IDX, reactantAtom.getIdx());
+    productAtom->setProp<unsigned int>(common_properties::reactantAtomIdx, reactantAtom.getIdx());
     productAtom->setProp(WAS_DUMMY, true);
   } else {
     // remove bookkeeping labels (if present)
     if (productAtom->hasProp(WAS_DUMMY)) productAtom->clearProp(WAS_DUMMY);
   }
-  productAtom->setProp<unsigned int>(REACT_ATOM_IDX, reactantAtom.getIdx());
+  productAtom->setProp<unsigned int>(common_properties::reactantAtomIdx, reactantAtom.getIdx());
   if (setImplicitProperties) {
     updateImplicitAtomProperties(productAtom, &reactantAtom);
   }
@@ -487,7 +483,7 @@ void addMissingProductAtom(const Atom &reactAtom, unsigned reactNeighborIdx,
                            ReactantProductAtomMapping *mapping) {
   auto *newAtom = new Atom(reactAtom);
   unsigned reactAtomIdx = reactAtom.getIdx();
-  newAtom->setProp<unsigned int>(REACT_ATOM_IDX, reactAtomIdx);
+  newAtom->setProp<unsigned int>(common_properties::reactantAtomIdx, reactAtomIdx);
   unsigned productIdx = product->addAtom(newAtom, false, true);
   mapping->reactProdAtomMap[reactAtomIdx].push_back(productIdx);
   mapping->prodReactAtomMap[productIdx] = reactAtomIdx;
@@ -580,13 +576,13 @@ void addReactantNeighborsToProduct(
             if (!product->getBondBetweenAtoms(prodBeginIdx, prodEndIdx)) {
               // They must be mapped
               CHECK_INVARIANT(
-                  product->getAtomWithIdx(prodBeginIdx)->hasProp(OLD_MAPNO) &&
-                      product->getAtomWithIdx(prodEndIdx)->hasProp(OLD_MAPNO),
+                  product->getAtomWithIdx(prodBeginIdx)->hasProp(common_properties::reactionMapNum) &&
+                      product->getAtomWithIdx(prodEndIdx)->hasProp(common_properties::reactionMapNum),
                   "atoms should be mapped in product");
               int a1mapidx = product->getAtomWithIdx(prodBeginIdx)
-                                 ->getProp<int>(OLD_MAPNO);
+                                 ->getProp<int>(common_properties::reactionMapNum);
               int a2mapidx =
-                  product->getAtomWithIdx(prodEndIdx)->getProp<int>(OLD_MAPNO);
+                  product->getAtomWithIdx(prodEndIdx)->getProp<int>(common_properties::reactionMapNum);
               if (a1mapidx > a2mapidx) std::swap(a1mapidx, a2mapidx);
               if (mapping->reactantTemplateAtomBonds.find(
                       std::make_pair(a1mapidx, a2mapidx)) ==
@@ -1059,8 +1055,8 @@ ROMol *reduceProductToSideChains(const ROMOL_SPTR &product,
         mol->getAtomWithIdx(rdcast<unsigned int>(scaffold_atom_idx));
     // add map no's here from dummy atoms
     // was this atom in one of the reactant templates?
-    if (scaffold_atom->hasProp(OLD_MAPNO) ||
-        !scaffold_atom->hasProp(REACT_ATOM_IDX)) {
+    if (scaffold_atom->hasProp(common_properties::reactionMapNum) ||
+        !scaffold_atom->hasProp(common_properties::reactantAtomIdx)) {
       // are we attached to a reactant atom?
       ROMol::ADJ_ITER nbrIdx, endNbrs;
       boost::tie(nbrIdx, endNbrs) = mol->getAtomNeighbors(scaffold_atom);
@@ -1068,13 +1064,13 @@ ROMol *reduceProductToSideChains(const ROMOL_SPTR &product,
 
       while (nbrIdx != endNbrs) {
         Atom *nbr = mol->getAtomWithIdx(*nbrIdx);
-        if (!nbr->hasProp(OLD_MAPNO) && nbr->hasProp(REACT_ATOM_IDX)) {
+        if (!nbr->hasProp(common_properties::reactionMapNum) && nbr->hasProp(common_properties::reactantAtomIdx)) {
           if (nbr->hasProp(WAS_DUMMY)) {
             bonds_to_product.push_back(RGroup(
                 nbr,
                 mol->getBondBetweenAtoms(scaffold_atom->getIdx(), *nbrIdx)
                     ->getBondType(),
-                nbr->getProp<int>(OLD_MAPNO)));
+                nbr->getProp<int>(common_properties::reactionMapNum)));
           } else {
             bonds_to_product.push_back(RGroup(
                 nbr, mol->getBondBetweenAtoms(scaffold_atom->getIdx(), *nbrIdx)

--- a/Code/GraphMol/ChemReactions/testReaction.cpp
+++ b/Code/GraphMol/ChemReactions/testReaction.cpp
@@ -6770,7 +6770,7 @@ void testGithub1269() {
       << std::endl;
   {
     // nonsense test case
-    std::string sma = "[C:1]>>[O:1]";
+    std::string sma = "[C:1]>>[O:1]Cl";
     ChemicalReaction *rxn = RxnSmartsToChemicalReaction(sma);
     TEST_ASSERT(rxn);
     TEST_ASSERT(rxn->getNumReactantTemplates() == 1);
@@ -6787,11 +6787,15 @@ void testGithub1269() {
     TEST_ASSERT(prods.size() == 1);
     TEST_ASSERT(prods[0].size() == 1);
     TEST_ASSERT(prods[0][0]->getAtomWithIdx(0)->getAtomicNum() == 8);
-    TEST_ASSERT(prods[0][0]->getAtomWithIdx(0)->hasProp("react_atom_idx"));
+    TEST_ASSERT(prods[0][0]->getAtomWithIdx(0)->hasProp(
+        common_properties::reactantAtomIdx));
     TEST_ASSERT(prods[0][0]->getAtomWithIdx(0)->getProp<unsigned int>(
                     "react_atom_idx") == 1);
-    TEST_ASSERT(prods[0][0]->getAtomWithIdx(1)->hasProp("react_atom_idx"));
-    TEST_ASSERT(prods[0][0]->getAtomWithIdx(1)->getProp<unsigned int>(
+    TEST_ASSERT(!prods[0][0]->getAtomWithIdx(1)->hasProp(
+        common_properties::reactantAtomIdx));
+    TEST_ASSERT(prods[0][0]->getAtomWithIdx(2)->hasProp(
+        common_properties::reactantAtomIdx));
+    TEST_ASSERT(prods[0][0]->getAtomWithIdx(2)->getProp<unsigned int>(
                     "react_atom_idx") == 0);
 
     delete rxn;

--- a/Code/GraphMol/ChemReactions/testReaction.cpp
+++ b/Code/GraphMol/ChemReactions/testReaction.cpp
@@ -5734,8 +5734,6 @@ void test60RunSingleReactant() {
         TEST_ASSERT(MolToSmiles(*prod[prodidx]) == expected);
         ROMol *sidechain = reduceProductToSideChains(prod[prodidx]);
         std::string smi = MolToSmiles(*sidechain, isomericSmiles);
-        std::cerr<<expected_sidechain<<std::endl;
-        std::cerr<<smi<<std::endl;
         TEST_ASSERT(smi == expected_sidechain);
       }
     }
@@ -6767,8 +6765,9 @@ void testGithub1869() {
 
 void testGithub1269() {
   BOOST_LOG(rdInfoLog) << "-------------------------------------" << std::endl;
-  BOOST_LOG(rdInfoLog) << "Testing github #1269: preserve reactant atom idx in products"
-                       << std::endl;
+  BOOST_LOG(rdInfoLog)
+      << "Testing github #1269: preserve reactant atom idx in products"
+      << std::endl;
   {
     // nonsense test case
     std::string sma = "[C:1]>>[O:1]";
@@ -6777,7 +6776,6 @@ void testGithub1269() {
     TEST_ASSERT(rxn->getNumReactantTemplates() == 1);
     TEST_ASSERT(rxn->getNumProductTemplates() == 1);
     rxn->initReactantMatchers();
-
 
     MOL_SPTR_VECT reacts;
     std::string smi = "NC";
@@ -6788,11 +6786,13 @@ void testGithub1269() {
     auto prods = rxn->runReactants(reacts);
     TEST_ASSERT(prods.size() == 1);
     TEST_ASSERT(prods[0].size() == 1);
-    TEST_ASSERT(prods[0][0]->getAtomWithIdx(0)->getAtomicNum()==8);
+    TEST_ASSERT(prods[0][0]->getAtomWithIdx(0)->getAtomicNum() == 8);
     TEST_ASSERT(prods[0][0]->getAtomWithIdx(0)->hasProp("react_atom_idx"));
-    TEST_ASSERT(prods[0][0]->getAtomWithIdx(0)->getProp<unsigned int>("react_atom_idx")==1);
+    TEST_ASSERT(prods[0][0]->getAtomWithIdx(0)->getProp<unsigned int>(
+                    "react_atom_idx") == 1);
     TEST_ASSERT(prods[0][0]->getAtomWithIdx(1)->hasProp("react_atom_idx"));
-    TEST_ASSERT(prods[0][0]->getAtomWithIdx(1)->getProp<unsigned int>("react_atom_idx")==0);
+    TEST_ASSERT(prods[0][0]->getAtomWithIdx(1)->getProp<unsigned int>(
+                    "react_atom_idx") == 0);
 
     delete rxn;
   }

--- a/Code/GraphMol/ChemReactions/testReaction.cpp
+++ b/Code/GraphMol/ChemReactions/testReaction.cpp
@@ -5734,6 +5734,8 @@ void test60RunSingleReactant() {
         TEST_ASSERT(MolToSmiles(*prod[prodidx]) == expected);
         ROMol *sidechain = reduceProductToSideChains(prod[prodidx]);
         std::string smi = MolToSmiles(*sidechain, isomericSmiles);
+        std::cerr<<expected_sidechain<<std::endl;
+        std::cerr<<smi<<std::endl;
         TEST_ASSERT(smi == expected_sidechain);
       }
     }
@@ -6763,6 +6765,39 @@ void testGithub1869() {
   BOOST_LOG(rdInfoLog) << "\tdone" << std::endl;
 }
 
+void testGithub1269() {
+  BOOST_LOG(rdInfoLog) << "-------------------------------------" << std::endl;
+  BOOST_LOG(rdInfoLog) << "Testing github #1269: preserve reactant atom idx in products"
+                       << std::endl;
+  {
+    // nonsense test case
+    std::string sma = "[C:1]>>[O:1]";
+    ChemicalReaction *rxn = RxnSmartsToChemicalReaction(sma);
+    TEST_ASSERT(rxn);
+    TEST_ASSERT(rxn->getNumReactantTemplates() == 1);
+    TEST_ASSERT(rxn->getNumProductTemplates() == 1);
+    rxn->initReactantMatchers();
+
+
+    MOL_SPTR_VECT reacts;
+    std::string smi = "NC";
+    auto mol = SmilesToMol(smi);
+    TEST_ASSERT(mol);
+    reacts.push_back(ROMOL_SPTR(mol));
+
+    auto prods = rxn->runReactants(reacts);
+    TEST_ASSERT(prods.size() == 1);
+    TEST_ASSERT(prods[0].size() == 1);
+    TEST_ASSERT(prods[0][0]->getAtomWithIdx(0)->getAtomicNum()==8);
+    TEST_ASSERT(prods[0][0]->getAtomWithIdx(0)->hasProp("react_atom_idx"));
+    TEST_ASSERT(prods[0][0]->getAtomWithIdx(0)->getProp<unsigned int>("react_atom_idx")==1);
+    TEST_ASSERT(prods[0][0]->getAtomWithIdx(1)->hasProp("react_atom_idx"));
+    TEST_ASSERT(prods[0][0]->getAtomWithIdx(1)->getProp<unsigned int>("react_atom_idx")==0);
+
+    delete rxn;
+  }
+}
+
 int main() {
   RDLog::InitLogs();
 
@@ -6846,9 +6881,10 @@ int main() {
   test70Github1544();
   testSanitizeException();
   testReactionProperties();
-#endif
   testGithub1950();
   testGithub1869();
+#endif
+  testGithub1269();
 
   BOOST_LOG(rdInfoLog)
       << "*******************************************************\n";

--- a/Code/RDGeneral/types.cpp
+++ b/Code/RDGeneral/types.cpp
@@ -47,6 +47,9 @@ const std::string _QueryHCount = "_QueryHCount";
 const std::string _QueryIsotope = "_QueryIsotope";
 const std::string _QueryMass = "_QueryMass";
 const std::string _ReactionDegreeChanged = "_ReactionDegreeChanged";
+const std::string reactantAtomIdx = "react_atom_idx";
+const std::string reactionMapNum = "old_mapno";
+
 const std::string _RingClosures = "_RingClosures";
 const std::string _SLN_s = "_SLN_s";
 const std::string _SmilesStart = "_SmilesStart";

--- a/Code/RDGeneral/types.h
+++ b/Code/RDGeneral/types.h
@@ -56,42 +56,60 @@ namespace common_properties {
 RDKIT_RDGENERAL_EXPORT extern const std::string _Name;            // string
 RDKIT_RDGENERAL_EXPORT extern const std::string MolFileInfo;      // string
 RDKIT_RDGENERAL_EXPORT extern const std::string MolFileComments;  // string
-RDKIT_RDGENERAL_EXPORT extern const std::string _2DConf;          // int (combine into dimension?)
-RDKIT_RDGENERAL_EXPORT extern const std::string _3DConf;          // int
-RDKIT_RDGENERAL_EXPORT extern const std::string _doIsoSmiles;     // int (should probably be removed)
-RDKIT_RDGENERAL_EXPORT extern const std::string extraRings;       // vec<vec<int> >
-RDKIT_RDGENERAL_EXPORT extern const std::string _smilesAtomOutputOrder;  // vec<int> computed
-RDKIT_RDGENERAL_EXPORT extern const std::string _StereochemDone;         // int
-RDKIT_RDGENERAL_EXPORT extern const std::string _NeedsQueryScan;         // int (bool)
-RDKIT_RDGENERAL_EXPORT extern const std::string _fragSMARTS;             // std::string
-RDKIT_RDGENERAL_EXPORT extern const std::string maxAttachIdx;            // int TemplEnumTools.cpp
-RDKIT_RDGENERAL_EXPORT extern const std::string origNoImplicit;          // int (bool)
-RDKIT_RDGENERAL_EXPORT extern const std::string ringMembership;          //? unused (molopstest.cpp)
+RDKIT_RDGENERAL_EXPORT extern const std::string
+    _2DConf;  // int (combine into dimension?)
+RDKIT_RDGENERAL_EXPORT extern const std::string _3DConf;  // int
+RDKIT_RDGENERAL_EXPORT extern const std::string
+    _doIsoSmiles;  // int (should probably be removed)
+RDKIT_RDGENERAL_EXPORT extern const std::string extraRings;  // vec<vec<int> >
+RDKIT_RDGENERAL_EXPORT extern const std::string
+    _smilesAtomOutputOrder;  // vec<int> computed
+RDKIT_RDGENERAL_EXPORT extern const std::string _StereochemDone;  // int
+RDKIT_RDGENERAL_EXPORT extern const std::string _NeedsQueryScan;  // int (bool)
+RDKIT_RDGENERAL_EXPORT extern const std::string _fragSMARTS;      // std::string
+RDKIT_RDGENERAL_EXPORT extern const std::string
+    maxAttachIdx;  // int TemplEnumTools.cpp
+RDKIT_RDGENERAL_EXPORT extern const std::string origNoImplicit;  // int (bool)
+RDKIT_RDGENERAL_EXPORT extern const std::string
+    ringMembership;  //? unused (molopstest.cpp)
 
 // Computed Values
 // ConnectivityDescriptors
-RDKIT_RDGENERAL_EXPORT extern const std::string _connectivityHKDeltas;  // std::vector<double> computed
-RDKIT_RDGENERAL_EXPORT extern const std::string _connectivityNVals;     // std::vector<double> computed
+RDKIT_RDGENERAL_EXPORT extern const std::string
+    _connectivityHKDeltas;  // std::vector<double> computed
+RDKIT_RDGENERAL_EXPORT extern const std::string
+    _connectivityNVals;  // std::vector<double> computed
 
-RDKIT_RDGENERAL_EXPORT extern const std::string _crippenLogP;          // double computed
-RDKIT_RDGENERAL_EXPORT extern const std::string _crippenLogPContribs;  // std::vector<double> computed
+RDKIT_RDGENERAL_EXPORT extern const std::string
+    _crippenLogP;  // double computed
+RDKIT_RDGENERAL_EXPORT extern const std::string
+    _crippenLogPContribs;  // std::vector<double> computed
 
-RDKIT_RDGENERAL_EXPORT extern const std::string _crippenMR;          // double computed
-RDKIT_RDGENERAL_EXPORT extern const std::string _crippenMRContribs;  // std::vector<double> computed
+RDKIT_RDGENERAL_EXPORT extern const std::string _crippenMR;  // double computed
+RDKIT_RDGENERAL_EXPORT extern const std::string
+    _crippenMRContribs;  // std::vector<double> computed
 
-RDKIT_RDGENERAL_EXPORT extern const std::string _labuteASA;           // double computed
-RDKIT_RDGENERAL_EXPORT extern const std::string _labuteAtomContribs;  // vec<double> computed
-RDKIT_RDGENERAL_EXPORT extern const std::string _labuteAtomHContrib;  // double computed
+RDKIT_RDGENERAL_EXPORT extern const std::string _labuteASA;  // double computed
+RDKIT_RDGENERAL_EXPORT extern const std::string
+    _labuteAtomContribs;  // vec<double> computed
+RDKIT_RDGENERAL_EXPORT extern const std::string
+    _labuteAtomHContrib;  // double computed
 
-RDKIT_RDGENERAL_EXPORT extern const std::string _tpsa;              // double computed
-RDKIT_RDGENERAL_EXPORT extern const std::string _tpsaAtomContribs;  // vec<double> computed
+RDKIT_RDGENERAL_EXPORT extern const std::string _tpsa;  // double computed
+RDKIT_RDGENERAL_EXPORT extern const std::string
+    _tpsaAtomContribs;  // vec<double> computed
 
-RDKIT_RDGENERAL_EXPORT extern const std::string numArom;         // int computed (only uses in tests?)
-RDKIT_RDGENERAL_EXPORT extern const std::string _MMFFSanitized;  // int (bool) computed
+RDKIT_RDGENERAL_EXPORT extern const std::string
+    numArom;  // int computed (only uses in tests?)
+RDKIT_RDGENERAL_EXPORT extern const std::string
+    _MMFFSanitized;  // int (bool) computed
 
-RDKIT_RDGENERAL_EXPORT extern const std::string _CrippenLogP;      // Unused (in the basement)
-RDKIT_RDGENERAL_EXPORT extern const std::string _CrippenMR;        // Unused (in the basement)
-RDKIT_RDGENERAL_EXPORT extern const std::string _GasteigerCharge;  // used to hold partial charges
+RDKIT_RDGENERAL_EXPORT extern const std::string
+    _CrippenLogP;  // Unused (in the basement)
+RDKIT_RDGENERAL_EXPORT extern const std::string
+    _CrippenMR;  // Unused (in the basement)
+RDKIT_RDGENERAL_EXPORT extern const std::string
+    _GasteigerCharge;  // used to hold partial charges
 RDKIT_RDGENERAL_EXPORT extern const std::string
     _GasteigerHCharge;  // used to hold partial charges from implicit Hs
 
@@ -99,28 +117,40 @@ RDKIT_RDGENERAL_EXPORT extern const std::string
 // Atom Props
 
 // Chirality stuff
-RDKIT_RDGENERAL_EXPORT extern const std::string _BondsPotentialStereo;  // int (or bool) COMPUTED
-RDKIT_RDGENERAL_EXPORT extern const std::string _CIPCode;               // std::string COMPUTED
-RDKIT_RDGENERAL_EXPORT extern const std::string _CIPRank;               // int COMPUTED
-RDKIT_RDGENERAL_EXPORT extern const std::string _ChiralityPossible;     // int
-RDKIT_RDGENERAL_EXPORT extern const std::string _UnknownStereo;         // int (bool) AddHs/Chirality
+RDKIT_RDGENERAL_EXPORT extern const std::string
+    _BondsPotentialStereo;  // int (or bool) COMPUTED
+RDKIT_RDGENERAL_EXPORT extern const std::string
+    _CIPCode;  // std::string COMPUTED
+RDKIT_RDGENERAL_EXPORT extern const std::string _CIPRank;  // int COMPUTED
+RDKIT_RDGENERAL_EXPORT extern const std::string _ChiralityPossible;  // int
+RDKIT_RDGENERAL_EXPORT extern const std::string
+    _UnknownStereo;  // int (bool) AddHs/Chirality
 RDKIT_RDGENERAL_EXPORT extern const std::string
     _ringStereoAtoms;  // int vect Canon/Chiral/MolHash/MolOps//Renumber//RWmol
-RDKIT_RDGENERAL_EXPORT extern const std::string _ringStereochemCand;  // chirality bool COMPUTED
-RDKIT_RDGENERAL_EXPORT extern const std::string _ringStereoWarning;   // obsolete ?
+RDKIT_RDGENERAL_EXPORT extern const std::string
+    _ringStereochemCand;  // chirality bool COMPUTED
+RDKIT_RDGENERAL_EXPORT extern const std::string
+    _ringStereoWarning;  // obsolete ?
 
 // Smiles parsing
-RDKIT_RDGENERAL_EXPORT extern const std::string _SmilesStart;               // int
-RDKIT_RDGENERAL_EXPORT extern const std::string _TraversalBondIndexOrder;   // ? unused
-RDKIT_RDGENERAL_EXPORT extern const std::string _TraversalRingClosureBond;  // unsigned int
-RDKIT_RDGENERAL_EXPORT extern const std::string _TraversalStartPoint;       // bool
-RDKIT_RDGENERAL_EXPORT extern const std::string _queryRootAtom;  // int SLNParse/SubstructMatch
-RDKIT_RDGENERAL_EXPORT extern const std::string _hasMassQuery;   // atom bool
-RDKIT_RDGENERAL_EXPORT extern const std::string _protected;      // atom int (bool)
-RDKIT_RDGENERAL_EXPORT extern const std::string _supplementalSmilesLabel;  // atom string (SmilesWrite)
-RDKIT_RDGENERAL_EXPORT extern const std::string _unspecifiedOrder;  // atom int (bool) smarts/smiles
-RDKIT_RDGENERAL_EXPORT extern const std::string _RingClosures;      // INT_VECT smarts/smiles/canon
-RDKIT_RDGENERAL_EXPORT extern const std::string atomLabel;          // atom string from CXSMILES
+RDKIT_RDGENERAL_EXPORT extern const std::string _SmilesStart;  // int
+RDKIT_RDGENERAL_EXPORT extern const std::string
+    _TraversalBondIndexOrder;  // ? unused
+RDKIT_RDGENERAL_EXPORT extern const std::string
+    _TraversalRingClosureBond;  // unsigned int
+RDKIT_RDGENERAL_EXPORT extern const std::string _TraversalStartPoint;  // bool
+RDKIT_RDGENERAL_EXPORT extern const std::string
+    _queryRootAtom;  // int SLNParse/SubstructMatch
+RDKIT_RDGENERAL_EXPORT extern const std::string _hasMassQuery;  // atom bool
+RDKIT_RDGENERAL_EXPORT extern const std::string _protected;  // atom int (bool)
+RDKIT_RDGENERAL_EXPORT extern const std::string
+    _supplementalSmilesLabel;  // atom string (SmilesWrite)
+RDKIT_RDGENERAL_EXPORT extern const std::string
+    _unspecifiedOrder;  // atom int (bool) smarts/smiles
+RDKIT_RDGENERAL_EXPORT extern const std::string
+    _RingClosures;  // INT_VECT smarts/smiles/canon
+RDKIT_RDGENERAL_EXPORT extern const std::string
+    atomLabel;  // atom string from CXSMILES
 
 // MDL Style Properties (MolFileParser)
 RDKIT_RDGENERAL_EXPORT extern const std::string molAtomMapNumber;    // int
@@ -135,32 +165,42 @@ RDKIT_RDGENERAL_EXPORT extern const std::string _MolFileRLabel;      // int
 RDKIT_RDGENERAL_EXPORT extern const std::string _MolFileChiralFlag;  // int
 RDKIT_RDGENERAL_EXPORT extern const std::string _MolFileAtomQuery;   // int
 RDKIT_RDGENERAL_EXPORT extern const std::string _MolFileBondQuery;   // int
-RDKIT_RDGENERAL_EXPORT extern const std::string MRV_SMA;             // smarts string from Marvin
-RDKIT_RDGENERAL_EXPORT extern const std::string dummyLabel;          // atom string
+RDKIT_RDGENERAL_EXPORT extern const std::string
+    MRV_SMA;  // smarts string from Marvin
+RDKIT_RDGENERAL_EXPORT extern const std::string dummyLabel;  // atom string
 
 // Reaction Information (Reactions.cpp)
-RDKIT_RDGENERAL_EXPORT extern const std::string _QueryFormalCharge;      //  int
-RDKIT_RDGENERAL_EXPORT extern const std::string _QueryHCount;            // int
-RDKIT_RDGENERAL_EXPORT extern const std::string _QueryIsotope;           // int
-RDKIT_RDGENERAL_EXPORT extern const std::string _QueryMass;              // int = round(float * 1000)
-RDKIT_RDGENERAL_EXPORT extern const std::string _ReactionDegreeChanged;  // int (bool)
-RDKIT_RDGENERAL_EXPORT extern const std::string NullBond;                // int (bool)
+RDKIT_RDGENERAL_EXPORT extern const std::string _QueryFormalCharge;  //  int
+RDKIT_RDGENERAL_EXPORT extern const std::string _QueryHCount;        // int
+RDKIT_RDGENERAL_EXPORT extern const std::string _QueryIsotope;       // int
+RDKIT_RDGENERAL_EXPORT extern const std::string
+    _QueryMass;  // int = round(float * 1000)
+RDKIT_RDGENERAL_EXPORT extern const std::string
+    _ReactionDegreeChanged;                                // int (bool)
+RDKIT_RDGENERAL_EXPORT extern const std::string NullBond;  // int (bool)
 RDKIT_RDGENERAL_EXPORT extern const std::string _rgroupAtomMaps;
 RDKIT_RDGENERAL_EXPORT extern const std::string _rgroupBonds;
+RDKIT_RDGENERAL_EXPORT extern const std::string reactantAtomIdx;
+RDKIT_RDGENERAL_EXPORT extern const std::string reactionMapNum;
 
 // SLN
-RDKIT_RDGENERAL_EXPORT extern const std::string _AtomID;           // unsigned int SLNParser
-RDKIT_RDGENERAL_EXPORT extern const std::string _starred;          // atom int COMPUTED (SLN)
-RDKIT_RDGENERAL_EXPORT extern const std::string _SLN_s;            // string SLNAttribs (chiral info)
+RDKIT_RDGENERAL_EXPORT extern const std::string
+    _AtomID;  // unsigned int SLNParser
+RDKIT_RDGENERAL_EXPORT extern const std::string
+    _starred;  // atom int COMPUTED (SLN)
+RDKIT_RDGENERAL_EXPORT extern const std::string
+    _SLN_s;  // string SLNAttribs (chiral info)
 RDKIT_RDGENERAL_EXPORT extern const std::string _Unfinished_SLN_;  // int (bool)
 
 // Smarts Smiles
 RDKIT_RDGENERAL_EXPORT extern const std::string _brokenChirality;  // atom bool
-RDKIT_RDGENERAL_EXPORT extern const std::string isImplicit;        // atom int (bool)
-RDKIT_RDGENERAL_EXPORT extern const std::string smilesSymbol;      // atom string (only used in test?)
+RDKIT_RDGENERAL_EXPORT extern const std::string isImplicit;  // atom int (bool)
+RDKIT_RDGENERAL_EXPORT extern const std::string
+    smilesSymbol;  // atom string (only used in test?)
 
 // Tripos
-RDKIT_RDGENERAL_EXPORT extern const std::string _TriposAtomType;  // string Mol2FileParser
+RDKIT_RDGENERAL_EXPORT extern const std::string
+    _TriposAtomType;  // string Mol2FileParser
 // missing defs for _TriposAtomName//_TriposPartialCharge...
 
 ///////////////////////////////////////////////////////////////
@@ -173,12 +213,13 @@ RDKIT_RDGENERAL_EXPORT extern const std::string BalanbanJ;  // typo!! fix...
 
 RDKIT_RDGENERAL_EXPORT extern const std::string Discrims;  // FragCatalog Entry
 // Subgraphs::DiscrimTuple (uint32,uint32,uint32)
-RDKIT_RDGENERAL_EXPORT extern const std::string DistanceMatrix_Paths;  // boost::shared_array<double>
+RDKIT_RDGENERAL_EXPORT extern const std::string
+    DistanceMatrix_Paths;  // boost::shared_array<double>
 //  - note, confusing creation of names in
 //  - getDistanceMat
 RDKIT_RDGENERAL_EXPORT extern const std::string internalRgroupSmiles;
 
-}  // end common_properties
+}  // namespace common_properties
 #ifndef WIN32
 typedef long long int LONGINT;
 #else
@@ -290,11 +331,13 @@ struct RDKIT_RDGENERAL_EXPORT charptr_functor {
 
 //! \brief calculate the union of two INT_VECTs and put the results in a
 //! third vector
-RDKIT_RDGENERAL_EXPORT void Union(const INT_VECT &r1, const INT_VECT &r2, INT_VECT &res);
+RDKIT_RDGENERAL_EXPORT void Union(const INT_VECT &r1, const INT_VECT &r2,
+                                  INT_VECT &res);
 
 //! \brief calculate the intersection of two INT_VECTs and put the results in a
 //! third vector
-RDKIT_RDGENERAL_EXPORT void Intersect(const INT_VECT &r1, const INT_VECT &r2, INT_VECT &res);
+RDKIT_RDGENERAL_EXPORT void Intersect(const INT_VECT &r1, const INT_VECT &r2,
+                                      INT_VECT &res);
 
 //! calculating the union of the INT_VECT's in a VECT_INT_VECT
 /*!
@@ -304,7 +347,7 @@ RDKIT_RDGENERAL_EXPORT void Intersect(const INT_VECT &r1, const INT_VECT &r2, IN
            from the union.
 */
 RDKIT_RDGENERAL_EXPORT void Union(const VECT_INT_VECT &rings, INT_VECT &res,
-           const INT_VECT *exclude = NULL);
+                                  const INT_VECT *exclude = NULL);
 
 //! given a current combination of numbers change it to the next possible
 // combination
@@ -324,6 +367,6 @@ RDKIT_RDGENERAL_EXPORT int nextCombination(INT_VECT &comb, int tot);
 //! rounds a value to the closest int
 RDKIT_RDGENERAL_EXPORT double round(double v);
 
-};  // end of namespace
+};  // namespace RDKit
 
 #endif


### PR DESCRIPTION
Reactant atom indices are now available in the products of reactions as atom properties.

@bp-kelley : I had to change the logic in `reduceProductToSidechains()` a bit as part of this change. I think I got it right, and the tests all pass, but it would be cool if you could pay particular attention to that.
