### PR TITLE
Fixes #1990

### DIFF
--- a/Code/GraphMol/DistGeomHelpers/testDgeomHelpers.cpp
+++ b/Code/GraphMol/DistGeomHelpers/testDgeomHelpers.cpp
@@ -1252,7 +1252,7 @@ void runblock(const std::vector<ROMol *> &mols,
     }
   }
 };
-}
+}  // namespace
 
 #include <thread>
 #include <future>
@@ -1623,7 +1623,7 @@ void compareConfs(const ROMol *m, const ROMol *expected, int molConfId = -1,
     TEST_ASSERT((pt1i - pt2i).length() < 10e-4);
   }
 }
-}
+}  // namespace
 
 void testGithub971() {
   {
@@ -2017,6 +2017,29 @@ void testGithubPullRequest1635() {
   }
 }
 
+void testGithub1990() {
+  {  // we saw the problem here (though it came from something in MolOps)
+    std::unique_ptr<RWMol> mol(SmilesToMol("F/C=C/F"));
+    TEST_ASSERT(mol);
+    MolOps::addHs(*mol);
+    MolOps::removeHs(*mol);
+    TEST_ASSERT(mol->getNumAtoms() == 4);
+    int cid = DGeomHelpers::EmbedMolecule(*mol);
+    TEST_ASSERT(cid >= 0);
+  }
+  {  // The original problem report
+    std::unique_ptr<RWMol> mol(SmilesToMol(
+        "CCCCCCCCCCCCCCCC(=O)O[C@@H]1CC(C)=C(/C=C/C(C)=C/C=C/C(C)=C/"
+        "C=C\\C=C(C)\\C=C\\C=C(C)\\C=C\\C2=C(C)C[C@@H](OC(=O)CCCCCCCCCCCCCCC)"
+        "CC2(C)C)C(C)(C)C1"));
+    TEST_ASSERT(mol);
+    MolOps::addHs(*mol);
+    MolOps::removeHs(*mol);
+    int cid = DGeomHelpers::EmbedMolecule(*mol);
+    TEST_ASSERT(cid >= 0);
+  }
+}
+
 int main() {
   RDLog::InitLogs();
   BOOST_LOG(rdInfoLog)
@@ -2180,7 +2203,6 @@ int main() {
   BOOST_LOG(rdInfoLog) << "\t---------------------------------\n";
   BOOST_LOG(rdInfoLog) << "\t test embed parameters structure.\n";
   testEmbedParameters();
-#endif
 
   BOOST_LOG(rdInfoLog) << "\t---------------------------------\n";
   BOOST_LOG(rdInfoLog)
@@ -2194,6 +2216,11 @@ int main() {
   BOOST_LOG(rdInfoLog) << "\t---------------------------------\n";
   BOOST_LOG(rdInfoLog) << "\t Deterministic with large random seeds\n";
   testGithubPullRequest1635();
+#endif
+
+  BOOST_LOG(rdInfoLog) << "\t---------------------------------\n";
+  BOOST_LOG(rdInfoLog) << "\t Github #1990: seg fault after RemoveHs\n";
+  testGithub1990();
 
   BOOST_LOG(rdInfoLog)
       << "*******************************************************\n";

--- a/Code/GraphMol/RWMol.cpp
+++ b/Code/GraphMol/RWMol.cpp
@@ -150,7 +150,7 @@ void RWMol::replaceBond(unsigned int idx, Bond *bond_pin, bool preserveProps) {
   URANGE_CHECK(idx, getNumBonds());
   BOND_ITER_PAIR bIter = getEdges();
   for (unsigned int i = 0; i < idx; i++) ++bIter.first;
-  Bond* obond = d_graph[*(bIter.first)];
+  Bond *obond = d_graph[*(bIter.first)];
   Bond *bond_p = bond_pin->copy();
   bond_p->setOwningMol(this);
   bond_p->setIdx(idx);
@@ -205,7 +205,7 @@ void RWMol::removeAtom(Atom *atom) {
   }
 
   // remove bonds attached to the atom
-  std::vector<std::pair<unsigned int, unsigned int> > nbrs;
+  std::vector<std::pair<unsigned int, unsigned int>> nbrs;
   ADJ_ITER b1, b2;
   boost::tie(b1, b2) = getAtomNeighbors(atom);
   while (b1 != b2) {
@@ -241,7 +241,7 @@ void RWMol::removeAtom(Atom *atom) {
   EDGE_ITER beg, end;
   boost::tie(beg, end) = getEdges();
   while (beg != end) {
-    Bond* bond = d_graph[*beg++];
+    Bond *bond = d_graph[*beg++];
     unsigned int tmpIdx = bond->getBeginAtomIdx();
     if (tmpIdx > idx) bond->setBeginAtomIdx(tmpIdx - 1);
     tmpIdx = bond->getEndAtomIdx();
@@ -351,7 +351,9 @@ void RWMol::removeBond(unsigned int aid1, unsigned int aid2) {
     if (oIdx == aid2) continue;
     Bond *obnd = getBondBetweenAtoms(aid1, oIdx);
     if (!obnd) continue;
-    obnd->getStereoAtoms().clear();
+    if (std::find(obnd->getStereoAtoms().begin(), obnd->getStereoAtoms().end(),
+                  aid2) != obnd->getStereoAtoms().end())
+      obnd->getStereoAtoms().clear();
   }
   boost::tie(a1, a2) = boost::adjacent_vertices(aid2, d_graph);
   while (a1 != a2) {
@@ -360,7 +362,9 @@ void RWMol::removeBond(unsigned int aid1, unsigned int aid2) {
     if (oIdx == aid1) continue;
     Bond *obnd = getBondBetweenAtoms(aid2, oIdx);
     if (!obnd) continue;
-    obnd->getStereoAtoms().clear();
+    if (std::find(obnd->getStereoAtoms().begin(), obnd->getStereoAtoms().end(),
+                  aid1) != obnd->getStereoAtoms().end())
+      obnd->getStereoAtoms().clear();
   }
 
   // reset our ring info structure, because it is pretty likely
@@ -371,7 +375,7 @@ void RWMol::removeBond(unsigned int aid1, unsigned int aid2) {
   ROMol::EDGE_ITER firstB, lastB;
   boost::tie(firstB, lastB) = this->getEdges();
   while (firstB != lastB) {
-    Bond* bond = (*this)[*firstB];
+    Bond *bond = (*this)[*firstB];
     if (bond->getIdx() > idx) {
       bond->setIdx(bond->getIdx() - 1);
     }
@@ -407,4 +411,4 @@ unsigned int RWMol::finishPartialBond(unsigned int atomIdx2, int bondBookmark,
   return addBond(bsp->getBeginAtomIdx(), atomIdx2, bondType);
 }
 
-}  // end o' namespace
+}  // namespace RDKit

--- a/Code/GraphMol/molopstest.cpp
+++ b/Code/GraphMol/molopstest.cpp
@@ -7466,6 +7466,41 @@ void testGithub1928() {
   BOOST_LOG(rdInfoLog) << "Finished" << std::endl;
 }
 
+void testGithub1990() {
+  BOOST_LOG(rdInfoLog) << "-----------------------\n Testing Github issue "
+                          "1990: removeHs screws up bond stereo"
+                       << std::endl;
+  {
+    std::unique_ptr<RWMol> mol(SmilesToMol("F/C=C/F"));
+    TEST_ASSERT(mol);
+    MolOps::addHs(*mol);
+    MolOps::removeHs(*mol);
+    TEST_ASSERT(mol->getNumAtoms() == 4);
+    TEST_ASSERT(mol->getBondWithIdx(1)->getStereoAtoms().size() == 2);
+  }
+  {  // make sure that stereo is removed when it comes from Hs:
+    std::unique_ptr<RWMol> mol(SmilesToMol("F/C=C/F"));
+    TEST_ASSERT(mol);
+    MolOps::addHs(*mol);
+    TEST_ASSERT(mol->getBondWithIdx(1)->getStereoAtoms().size() == 2);
+    mol->getBondWithIdx(1)->getStereoAtoms()[0] = 4;
+    MolOps::removeHs(*mol);
+    TEST_ASSERT(mol->getBondWithIdx(1)->getStereoAtoms().size() == 2);
+    mol->getBondWithIdx(1)->getStereoAtoms()[0] = 0;
+  }
+  {  // make sure that stereo is removed when it comes from Hs:
+    std::unique_ptr<RWMol> mol(SmilesToMol("F/C=C/F"));
+    TEST_ASSERT(mol);
+    MolOps::addHs(*mol);
+    TEST_ASSERT(mol->getBondWithIdx(1)->getStereoAtoms().size() == 2);
+    mol->getBondWithIdx(1)->getStereoAtoms()[1] = 5;
+    MolOps::removeHs(*mol);
+    TEST_ASSERT(mol->getBondWithIdx(1)->getStereoAtoms().size() == 2);
+    mol->getBondWithIdx(1)->getStereoAtoms()[1] = 3;
+  }
+  BOOST_LOG(rdInfoLog) << "Finished" << std::endl;
+}
+
 int main() {
   RDLog::InitLogs();
   // boost::logging::enable_logs("rdApp.debug");
@@ -7574,8 +7609,9 @@ int main() {
   testGithub1622();
   testGithub1703();
   testGithub1810();
-#endif
   testGithub1936();
   testGithub1928();
+#endif
+  testGithub1990();
   return 0;
 }

--- a/Code/GraphMol/molopstest.cpp
+++ b/Code/GraphMol/molopstest.cpp
@@ -7478,7 +7478,7 @@ void testGithub1990() {
     TEST_ASSERT(mol->getNumAtoms() == 4);
     TEST_ASSERT(mol->getBondWithIdx(1)->getStereoAtoms().size() == 2);
   }
-  {  // make sure that stereo is removed when it comes from Hs:
+  {  // make sure that stereo is not removed when it comes from Hs:
     std::unique_ptr<RWMol> mol(SmilesToMol("F/C=C/F"));
     TEST_ASSERT(mol);
     MolOps::addHs(*mol);
@@ -7488,7 +7488,7 @@ void testGithub1990() {
     TEST_ASSERT(mol->getBondWithIdx(1)->getStereoAtoms().size() == 2);
     mol->getBondWithIdx(1)->getStereoAtoms()[0] = 0;
   }
-  {  // make sure that stereo is removed when it comes from Hs:
+  {  // make sure that stereo is not removed when it comes from Hs:
     std::unique_ptr<RWMol> mol(SmilesToMol("F/C=C/F"));
     TEST_ASSERT(mol);
     MolOps::addHs(*mol);


### PR DESCRIPTION
makes sure we don't destroy a double bond's StereoAtoms just because a bond connected to one of its atoms is removed

