### PR TITLE
Add support for constructing atoms/bonds from SMILES/SMARTS

### DIFF
--- a/Code/GraphMol/SmilesParse/CMakeLists.txt
+++ b/Code/GraphMol/SmilesParse/CMakeLists.txt
@@ -67,6 +67,7 @@ rdkit_headers(primes.h
               SmilesWrite.h DEST GraphMol/SmilesParse)
 
 rdkit_test(smiTest1 test.cpp LINK_LIBRARIES FileParsers SmilesParse GraphMol RDGeneral RDGeometryLib )
+rdkit_test(smiTest2 test2.cpp LINK_LIBRARIES SmilesParse GraphMol RDGeneral RDGeometryLib )
 rdkit_test(cxsmilesTest cxsmiles_test.cpp LINK_LIBRARIES FileParsers SmilesParse GraphMol RDGeneral RDGeometryLib )
 
 rdkit_test(smaTest1 smatest.cpp LINK_LIBRARIES SmilesParse SubstructMatch GraphMol RDGeneral RDGeometryLib )

--- a/Code/GraphMol/SmilesParse/SmilesParse.cpp
+++ b/Code/GraphMol/SmilesParse/SmilesParse.cpp
@@ -34,6 +34,11 @@
 #include <RDGeneral/RDLog.h>
 #include <RDGeneral/Invariant.h>
 #include "smiles.tab.hpp"
+// NOTE: this is a bit fragile since a lot of the #defines in smiles.tab.hpp
+// could prevent the same #defines in smarts.tab.hpp from being read.
+// Fortunately if there are actually any problems here, they will inevitably
+// show up very quickly in the tests.
+#include "smarts.tab.hpp"
 #include <list>
 
 int yysmiles_lex_init(void **);
@@ -41,13 +46,51 @@ int yysmiles_lex_destroy(void *);
 size_t setup_smiles_string(const std::string &text, void *);
 extern int yysmiles_debug;
 
-int yysmarts_parse(const char *, std::vector<RDKit::RWMol *> *, void *);
 int yysmarts_lex_init(void **);
 int yysmarts_lex_destroy(void *);
 size_t setup_smarts_string(const std::string &text, void *);
 extern int yysmarts_debug;
 namespace RDKit {
 namespace {
+int smarts_bond_parse(const std::string &inp, Bond *&bond) {
+  void *scanner;
+  int res;
+
+  TEST_ASSERT(!yysmarts_lex_init(&scanner));
+  try {
+    size_t ltrim = setup_smarts_string(inp, scanner);
+    int start_tok = static_cast<int>(START_BOND);
+    std::vector<RWMol *> molVect;
+    Atom *lastAtom = nullptr;
+    res = yysmarts_parse(inp.c_str() + ltrim, &molVect, lastAtom, bond, scanner,
+                         start_tok);
+  } catch (...) {
+    yysmarts_lex_destroy(scanner);
+    throw;
+  }
+  yysmarts_lex_destroy(scanner);
+  return res;
+}
+int smarts_atom_parse(const std::string &inp, Atom *&atom) {
+  void *scanner;
+  int res;
+
+  TEST_ASSERT(!yysmarts_lex_init(&scanner));
+  try {
+    size_t ltrim = setup_smarts_string(inp, scanner);
+    int start_tok = static_cast<int>(START_ATOM);
+    std::vector<RWMol *> molVect;
+    Bond *lastBond = nullptr;
+    res = yysmarts_parse(inp.c_str() + ltrim, &molVect, atom, lastBond, scanner,
+                         start_tok);
+  } catch (...) {
+    yysmarts_lex_destroy(scanner);
+    throw;
+  }
+  yysmarts_lex_destroy(scanner);
+  return res;
+}
+
 int smiles_bond_parse(const std::string &inp, Bond *&bond) {
   std::list<unsigned int> branchPoints;
   void *scanner;
@@ -117,7 +160,11 @@ int smarts_parse(const std::string &inp, std::vector<RDKit::RWMol *> &molVect) {
   TEST_ASSERT(!yysmarts_lex_init(&scanner));
   try {
     size_t ltrim = setup_smarts_string(inp, scanner);
-    res = yysmarts_parse(inp.c_str() + ltrim, &molVect, scanner);
+    int start_tok = static_cast<int>(START_MOL);
+    Atom *lastAtom = nullptr;
+    Bond *lastBond = nullptr;
+    res = yysmarts_parse(inp.c_str() + ltrim, &molVect, lastAtom, lastBond,
+                         scanner, start_tok);
   } catch (...) {
     yysmarts_lex_destroy(scanner);
     throw;
@@ -352,6 +399,22 @@ RWMol *SmilesToMol(const std::string &smiles,
   if (res && name != "") res->setProp(common_properties::_Name, name);
   return res;
 };
+Atom *SmartsToAtom(const std::string &smiles) {
+  yysmarts_debug = false;
+
+  Atom *res = nullptr;
+  res = toAtom(smiles, smarts_atom_parse);
+  return res;
+};
+
+Bond *SmartsToBond(const std::string &smiles) {
+  yysmarts_debug = false;
+
+  Bond *res = nullptr;
+  res = toBond(smiles, smarts_bond_parse);
+  return res;
+};
+
 RWMol *SmartsToMol(const std::string &smarts, int debugParse, bool mergeHs,
                    std::map<std::string, std::string> *replacements) {
   yysmarts_debug = debugParse;

--- a/Code/GraphMol/SmilesParse/SmilesParse.cpp
+++ b/Code/GraphMol/SmilesParse/SmilesParse.cpp
@@ -33,16 +33,19 @@
 #include "SmilesParseOps.h"
 #include <RDGeneral/RDLog.h>
 #include <RDGeneral/Invariant.h>
+#include "smiles.tab.hpp"
 #include <list>
 
 #ifdef RDKIT_GRAPHMOL_BUILD
 pippo pippo pippo
 #endif
 
+    // int
+    // yysmiles_parse(const char *, std::vector<RDKit::RWMol *> *,
+    //                std::list<unsigned int> *, void *, int &);
+
     int
-    yysmiles_parse(const char *, std::vector<RDKit::RWMol *> *,
-                   std::list<unsigned int> *, void *);
-int yysmiles_lex_init(void **);
+    yysmiles_lex_init(void **);
 int yysmiles_lex_destroy(void *);
 size_t setup_smiles_string(const std::string &text, void *);
 extern int yysmiles_debug;
@@ -62,7 +65,9 @@ int smiles_parse(const std::string &inp, std::vector<RDKit::RWMol *> &molVect) {
   TEST_ASSERT(!yysmiles_lex_init(&scanner));
   try {
     size_t ltrim = setup_smiles_string(inp, scanner);
-    res = yysmiles_parse(inp.c_str() + ltrim, &molVect, &branchPoints, scanner);
+    int start_tok = static_cast<int>(START_MOL);
+    res = yysmiles_parse(inp.c_str() + ltrim, &molVect, &branchPoints, scanner,
+                         start_tok);
   } catch (...) {
     yysmiles_lex_destroy(scanner);
     throw;

--- a/Code/GraphMol/SmilesParse/SmilesParse.h
+++ b/Code/GraphMol/SmilesParse/SmilesParse.h
@@ -100,6 +100,9 @@ RDKIT_SMILESPARSE_EXPORT RWMol *SmartsToMol(
     const std::string &sma, int debugParse = 0, bool mergeHs = false,
     std::map<std::string, std::string> *replacements = 0);
 
+RDKIT_SMILESPARSE_EXPORT Atom *SmartsToAtom(const std::string &sma);
+RDKIT_SMILESPARSE_EXPORT Bond *SmartsToBond(const std::string &sma);
+
 class RDKIT_SMILESPARSE_EXPORT SmilesParseException : public std::exception {
  public:
   SmilesParseException(const char *msg) : _msg(msg){};

--- a/Code/GraphMol/SmilesParse/SmilesParse.h
+++ b/Code/GraphMol/SmilesParse/SmilesParse.h
@@ -17,6 +17,8 @@
 
 namespace RDKit {
 class RWMol;
+class Atom;
+class Bond;
 
 struct RDKIT_SMILESPARSE_EXPORT SmilesParserParams {
   int debugParse;
@@ -33,7 +35,11 @@ struct RDKIT_SMILESPARSE_EXPORT SmilesParserParams {
         parseName(false),
         removeHs(true){};
 };
-RDKIT_SMILESPARSE_EXPORT RWMol *SmilesToMol(const std::string &smi, const SmilesParserParams &params);
+RDKIT_SMILESPARSE_EXPORT RWMol *SmilesToMol(const std::string &smi,
+                                            const SmilesParserParams &params);
+
+RDKIT_SMILESPARSE_EXPORT Atom *SmilesToAtom(const std::string &smi);
+RDKIT_SMILESPARSE_EXPORT Bond *SmilesToBond(const std::string &smi);
 
 //! Construct a molecule from a SMILES string
 /*!
@@ -90,9 +96,9 @@ inline RWMol *SmilesToMol(
  \return a pointer to the new molecule; the caller is responsible for free'ing
  this.
  */
-RDKIT_SMILESPARSE_EXPORT RWMol *SmartsToMol(const std::string &sma, int debugParse = 0,
-                   bool mergeHs = false,
-                   std::map<std::string, std::string> *replacements = 0);
+RDKIT_SMILESPARSE_EXPORT RWMol *SmartsToMol(
+    const std::string &sma, int debugParse = 0, bool mergeHs = false,
+    std::map<std::string, std::string> *replacements = 0);
 
 class RDKIT_SMILESPARSE_EXPORT SmilesParseException : public std::exception {
  public:
@@ -104,6 +110,6 @@ class RDKIT_SMILESPARSE_EXPORT SmilesParseException : public std::exception {
  private:
   std::string _msg;
 };
-}
+}  // namespace RDKit
 
 #endif

--- a/Code/GraphMol/SmilesParse/lex.yysmarts.cpp.cmake
+++ b/Code/GraphMol/SmilesParse/lex.yysmarts.cpp.cmake
@@ -9,9 +9,231 @@
 #define FLEX_SCANNER
 #define YY_FLEX_MAJOR_VERSION 2
 #define YY_FLEX_MINOR_VERSION 6
-#define YY_FLEX_SUBMINOR_VERSION 0
+#define YY_FLEX_SUBMINOR_VERSION 4
 #if YY_FLEX_SUBMINOR_VERSION > 0
 #define FLEX_BETA
+#endif
+
+#ifdef yy_create_buffer
+#define yysmarts__create_buffer_ALREADY_DEFINED
+#else
+#define yy_create_buffer yysmarts__create_buffer
+#endif
+
+#ifdef yy_delete_buffer
+#define yysmarts__delete_buffer_ALREADY_DEFINED
+#else
+#define yy_delete_buffer yysmarts__delete_buffer
+#endif
+
+#ifdef yy_scan_buffer
+#define yysmarts__scan_buffer_ALREADY_DEFINED
+#else
+#define yy_scan_buffer yysmarts__scan_buffer
+#endif
+
+#ifdef yy_scan_string
+#define yysmarts__scan_string_ALREADY_DEFINED
+#else
+#define yy_scan_string yysmarts__scan_string
+#endif
+
+#ifdef yy_scan_bytes
+#define yysmarts__scan_bytes_ALREADY_DEFINED
+#else
+#define yy_scan_bytes yysmarts__scan_bytes
+#endif
+
+#ifdef yy_init_buffer
+#define yysmarts__init_buffer_ALREADY_DEFINED
+#else
+#define yy_init_buffer yysmarts__init_buffer
+#endif
+
+#ifdef yy_flush_buffer
+#define yysmarts__flush_buffer_ALREADY_DEFINED
+#else
+#define yy_flush_buffer yysmarts__flush_buffer
+#endif
+
+#ifdef yy_load_buffer_state
+#define yysmarts__load_buffer_state_ALREADY_DEFINED
+#else
+#define yy_load_buffer_state yysmarts__load_buffer_state
+#endif
+
+#ifdef yy_switch_to_buffer
+#define yysmarts__switch_to_buffer_ALREADY_DEFINED
+#else
+#define yy_switch_to_buffer yysmarts__switch_to_buffer
+#endif
+
+#ifdef yypush_buffer_state
+#define yysmarts_push_buffer_state_ALREADY_DEFINED
+#else
+#define yypush_buffer_state yysmarts_push_buffer_state
+#endif
+
+#ifdef yypop_buffer_state
+#define yysmarts_pop_buffer_state_ALREADY_DEFINED
+#else
+#define yypop_buffer_state yysmarts_pop_buffer_state
+#endif
+
+#ifdef yyensure_buffer_stack
+#define yysmarts_ensure_buffer_stack_ALREADY_DEFINED
+#else
+#define yyensure_buffer_stack yysmarts_ensure_buffer_stack
+#endif
+
+#ifdef yylex
+#define yysmarts_lex_ALREADY_DEFINED
+#else
+#define yylex yysmarts_lex
+#endif
+
+#ifdef yyrestart
+#define yysmarts_restart_ALREADY_DEFINED
+#else
+#define yyrestart yysmarts_restart
+#endif
+
+#ifdef yylex_init
+#define yysmarts_lex_init_ALREADY_DEFINED
+#else
+#define yylex_init yysmarts_lex_init
+#endif
+
+#ifdef yylex_init_extra
+#define yysmarts_lex_init_extra_ALREADY_DEFINED
+#else
+#define yylex_init_extra yysmarts_lex_init_extra
+#endif
+
+#ifdef yylex_destroy
+#define yysmarts_lex_destroy_ALREADY_DEFINED
+#else
+#define yylex_destroy yysmarts_lex_destroy
+#endif
+
+#ifdef yyget_debug
+#define yysmarts_get_debug_ALREADY_DEFINED
+#else
+#define yyget_debug yysmarts_get_debug
+#endif
+
+#ifdef yyset_debug
+#define yysmarts_set_debug_ALREADY_DEFINED
+#else
+#define yyset_debug yysmarts_set_debug
+#endif
+
+#ifdef yyget_extra
+#define yysmarts_get_extra_ALREADY_DEFINED
+#else
+#define yyget_extra yysmarts_get_extra
+#endif
+
+#ifdef yyset_extra
+#define yysmarts_set_extra_ALREADY_DEFINED
+#else
+#define yyset_extra yysmarts_set_extra
+#endif
+
+#ifdef yyget_in
+#define yysmarts_get_in_ALREADY_DEFINED
+#else
+#define yyget_in yysmarts_get_in
+#endif
+
+#ifdef yyset_in
+#define yysmarts_set_in_ALREADY_DEFINED
+#else
+#define yyset_in yysmarts_set_in
+#endif
+
+#ifdef yyget_out
+#define yysmarts_get_out_ALREADY_DEFINED
+#else
+#define yyget_out yysmarts_get_out
+#endif
+
+#ifdef yyset_out
+#define yysmarts_set_out_ALREADY_DEFINED
+#else
+#define yyset_out yysmarts_set_out
+#endif
+
+#ifdef yyget_leng
+#define yysmarts_get_leng_ALREADY_DEFINED
+#else
+#define yyget_leng yysmarts_get_leng
+#endif
+
+#ifdef yyget_text
+#define yysmarts_get_text_ALREADY_DEFINED
+#else
+#define yyget_text yysmarts_get_text
+#endif
+
+#ifdef yyget_lineno
+#define yysmarts_get_lineno_ALREADY_DEFINED
+#else
+#define yyget_lineno yysmarts_get_lineno
+#endif
+
+#ifdef yyset_lineno
+#define yysmarts_set_lineno_ALREADY_DEFINED
+#else
+#define yyset_lineno yysmarts_set_lineno
+#endif
+
+#ifdef yyget_column
+#define yysmarts_get_column_ALREADY_DEFINED
+#else
+#define yyget_column yysmarts_get_column
+#endif
+
+#ifdef yyset_column
+#define yysmarts_set_column_ALREADY_DEFINED
+#else
+#define yyset_column yysmarts_set_column
+#endif
+
+#ifdef yywrap
+#define yysmarts_wrap_ALREADY_DEFINED
+#else
+#define yywrap yysmarts_wrap
+#endif
+
+#ifdef yyget_lval
+#define yysmarts_get_lval_ALREADY_DEFINED
+#else
+#define yyget_lval yysmarts_get_lval
+#endif
+
+#ifdef yyset_lval
+#define yysmarts_set_lval_ALREADY_DEFINED
+#else
+#define yyset_lval yysmarts_set_lval
+#endif
+
+#ifdef yyalloc
+#define yysmarts_alloc_ALREADY_DEFINED
+#else
+#define yyalloc yysmarts_alloc
+#endif
+
+#ifdef yyrealloc
+#define yysmarts_realloc_ALREADY_DEFINED
+#else
+#define yyrealloc yysmarts_realloc
+#endif
+
+#ifdef yyfree
+#define yysmarts_free_ALREADY_DEFINED
+#else
+#define yyfree yysmarts_free
 #endif
 
 /* First, we deal with  platform-specific or compiler-specific issues. */
@@ -84,40 +306,32 @@ typedef unsigned int flex_uint32_t;
 #define UINT32_MAX             (4294967295U)
 #endif
 
+#ifndef SIZE_MAX
+#define SIZE_MAX               (~(size_t)0)
+#endif
+
 #endif /* ! C99 */
 
 #endif /* ! FLEXINT_H */
 
-#ifdef __cplusplus
+/* begin standard C++ headers. */
 
-/* The "const" storage-class-modifier is valid. */
-#define YY_USE_CONST
-
-#else	/* ! __cplusplus */
-
-/* C99 requires __STDC__ to be defined as 1. */
-#if defined (__STDC__)
-
-#define YY_USE_CONST
-
-#endif	/* defined (__STDC__) */
-#endif	/* ! __cplusplus */
-
-#ifdef YY_USE_CONST
+/* TODO: this is always defined, so inline it */
 #define yyconst const
+
+#if defined(__GNUC__) && __GNUC__ >= 3
+#define yynoreturn __attribute__((__noreturn__))
 #else
-#define yyconst
+#define yynoreturn
 #endif
 
 /* Returned upon end-of-file. */
 #define YY_NULL 0
 
-/* Promotes a possibly negative, possibly signed char to an unsigned
- * integer for use as an array index.  If the signed char is negative,
- * we want to instead treat it as an 8-bit unsigned char, hence the
- * double cast.
+/* Promotes a possibly negative, possibly signed char to an
+ *   integer in range [0..255] for use as an array index.
  */
-#define YY_SC_TO_UI(c) ((unsigned int) (unsigned char) c)
+#define YY_SC_TO_UI(c) ((YY_CHAR) (c))
 
 /* An opaque pointer. */
 #ifndef YY_TYPEDEF_YY_SCANNER_T
@@ -141,20 +355,16 @@ typedef void* yyscan_t;
  * definition of BEGIN.
  */
 #define BEGIN yyg->yy_start = 1 + 2 *
-
 /* Translate the current start state into a value that can be later handed
  * to BEGIN to return to the state.  The YYSTATE alias is for lex
  * compatibility.
  */
 #define YY_START ((yyg->yy_start - 1) / 2)
 #define YYSTATE YY_START
-
 /* Action number for EOF rule of a given start state. */
 #define YY_STATE_EOF(state) (YY_END_OF_BUFFER + state + 1)
-
 /* Special action meaning "start processing a new file". */
-#define YY_NEW_FILE yysmarts_restart(yyin ,yyscanner )
-
+#define YY_NEW_FILE yyrestart( yyin , yyscanner )
 #define YY_END_OF_BUFFER_CHAR 0
 
 /* Size of default input buffer. */
@@ -187,7 +397,7 @@ typedef size_t yy_size_t;
 #define EOB_ACT_CONTINUE_SCAN 0
 #define EOB_ACT_END_OF_FILE 1
 #define EOB_ACT_LAST_MATCH 2
-
+    
     #define YY_LESS_LINENO(n)
     #define YY_LINENO_REWIND_TO(ptr)
     
@@ -204,7 +414,6 @@ typedef size_t yy_size_t;
 		YY_DO_BEFORE_ACTION; /* set up yytext again */ \
 		} \
 	while ( 0 )
-
 #define unput(c) yyunput( c, yyg->yytext_ptr , yyscanner )
 
 #ifndef YY_STRUCT_YY_BUFFER_STATE
@@ -219,7 +428,7 @@ struct yy_buffer_state
 	/* Size of input buffer in bytes, not including room for EOB
 	 * characters.
 	 */
-	yy_size_t yy_buf_size;
+	int yy_buf_size;
 
 	/* Number of characters read into yy_ch_buf, not including EOB
 	 * characters.
@@ -247,7 +456,7 @@ struct yy_buffer_state
 
     int yy_bs_lineno; /**< The line count. */
     int yy_bs_column; /**< The column count. */
-    
+
 	/* Whether to try to fill the input buffer when we reach the
 	 * end of it.
 	 */
@@ -264,7 +473,7 @@ struct yy_buffer_state
 	 * possible backing-up.
 	 *
 	 * When we actually see the EOF, we change the status to "new"
-	 * (via yysmarts_restart()), so that the user can continue scanning by
+	 * (via yyrestart()), so that the user can continue scanning by
 	 * just pointing yyin at a new input file.
 	 */
 #define YY_BUFFER_EOF_PENDING 2
@@ -281,87 +490,77 @@ struct yy_buffer_state
 #define YY_CURRENT_BUFFER ( yyg->yy_buffer_stack \
                           ? yyg->yy_buffer_stack[yyg->yy_buffer_stack_top] \
                           : NULL)
-
 /* Same as previous macro, but useful when we know that the buffer stack is not
  * NULL or when we need an lvalue. For internal use only.
  */
 #define YY_CURRENT_BUFFER_LVALUE yyg->yy_buffer_stack[yyg->yy_buffer_stack_top]
 
-void yysmarts_restart (FILE *input_file ,yyscan_t yyscanner );
-void yysmarts__switch_to_buffer (YY_BUFFER_STATE new_buffer ,yyscan_t yyscanner );
-YY_BUFFER_STATE yysmarts__create_buffer (FILE *file,int size ,yyscan_t yyscanner );
-void yysmarts__delete_buffer (YY_BUFFER_STATE b ,yyscan_t yyscanner );
-void yysmarts__flush_buffer (YY_BUFFER_STATE b ,yyscan_t yyscanner );
-void yysmarts_push_buffer_state (YY_BUFFER_STATE new_buffer ,yyscan_t yyscanner );
-void yysmarts_pop_buffer_state (yyscan_t yyscanner );
+void yyrestart ( FILE *input_file , yyscan_t yyscanner );
+void yy_switch_to_buffer ( YY_BUFFER_STATE new_buffer , yyscan_t yyscanner );
+YY_BUFFER_STATE yy_create_buffer ( FILE *file, int size , yyscan_t yyscanner );
+void yy_delete_buffer ( YY_BUFFER_STATE b , yyscan_t yyscanner );
+void yy_flush_buffer ( YY_BUFFER_STATE b , yyscan_t yyscanner );
+void yypush_buffer_state ( YY_BUFFER_STATE new_buffer , yyscan_t yyscanner );
+void yypop_buffer_state ( yyscan_t yyscanner );
 
-static void yysmarts_ensure_buffer_stack (yyscan_t yyscanner );
-static void yysmarts__load_buffer_state (yyscan_t yyscanner );
-static void yysmarts__init_buffer (YY_BUFFER_STATE b,FILE *file ,yyscan_t yyscanner );
+static void yyensure_buffer_stack ( yyscan_t yyscanner );
+static void yy_load_buffer_state ( yyscan_t yyscanner );
+static void yy_init_buffer ( YY_BUFFER_STATE b, FILE *file , yyscan_t yyscanner );
+#define YY_FLUSH_BUFFER yy_flush_buffer( YY_CURRENT_BUFFER , yyscanner)
 
-#define YY_FLUSH_BUFFER yysmarts__flush_buffer(YY_CURRENT_BUFFER ,yyscanner)
+YY_BUFFER_STATE yy_scan_buffer ( char *base, yy_size_t size , yyscan_t yyscanner );
+YY_BUFFER_STATE yy_scan_string ( const char *yy_str , yyscan_t yyscanner );
+YY_BUFFER_STATE yy_scan_bytes ( const char *bytes, int len , yyscan_t yyscanner );
 
-YY_BUFFER_STATE yysmarts__scan_buffer (char *base,yy_size_t size ,yyscan_t yyscanner );
-YY_BUFFER_STATE yysmarts__scan_string (yyconst char *yy_str ,yyscan_t yyscanner );
-YY_BUFFER_STATE yysmarts__scan_bytes (yyconst char *bytes,yy_size_t len ,yyscan_t yyscanner );
+void *yyalloc ( yy_size_t , yyscan_t yyscanner );
+void *yyrealloc ( void *, yy_size_t , yyscan_t yyscanner );
+void yyfree ( void * , yyscan_t yyscanner );
 
-void *yysmarts_alloc (yy_size_t ,yyscan_t yyscanner );
-void *yysmarts_realloc (void *,yy_size_t ,yyscan_t yyscanner );
-void yysmarts_free (void * ,yyscan_t yyscanner );
-
-#define yy_new_buffer yysmarts__create_buffer
-
+#define yy_new_buffer yy_create_buffer
 #define yy_set_interactive(is_interactive) \
 	{ \
 	if ( ! YY_CURRENT_BUFFER ){ \
-        yysmarts_ensure_buffer_stack (yyscanner); \
+        yyensure_buffer_stack (yyscanner); \
 		YY_CURRENT_BUFFER_LVALUE =    \
-            yysmarts__create_buffer(yyin,YY_BUF_SIZE ,yyscanner); \
+            yy_create_buffer( yyin, YY_BUF_SIZE , yyscanner); \
 	} \
 	YY_CURRENT_BUFFER_LVALUE->yy_is_interactive = is_interactive; \
 	}
-
 #define yy_set_bol(at_bol) \
 	{ \
 	if ( ! YY_CURRENT_BUFFER ){\
-        yysmarts_ensure_buffer_stack (yyscanner); \
+        yyensure_buffer_stack (yyscanner); \
 		YY_CURRENT_BUFFER_LVALUE =    \
-            yysmarts__create_buffer(yyin,YY_BUF_SIZE ,yyscanner); \
+            yy_create_buffer( yyin, YY_BUF_SIZE , yyscanner); \
 	} \
 	YY_CURRENT_BUFFER_LVALUE->yy_at_bol = at_bol; \
 	}
-
 #define YY_AT_BOL() (YY_CURRENT_BUFFER_LVALUE->yy_at_bol)
 
 /* Begin user sect3 */
 
 #define yysmarts_wrap(yyscanner) (/*CONSTCOND*/1)
 #define YY_SKIP_YYWRAP
-
-typedef unsigned char YY_CHAR;
+typedef flex_uint8_t YY_CHAR;
 
 typedef int yy_state_type;
 
 #define yytext_ptr yytext_r
 
-static yy_state_type yy_get_previous_state (yyscan_t yyscanner );
-static yy_state_type yy_try_NUL_trans (yy_state_type current_state  ,yyscan_t yyscanner);
-static int yy_get_next_buffer (yyscan_t yyscanner );
-#if defined(__GNUC__) && __GNUC__ >= 3
-__attribute__((__noreturn__))
-#endif
-static void yy_fatal_error (yyconst char msg[] ,yyscan_t yyscanner );
+static yy_state_type yy_get_previous_state ( yyscan_t yyscanner );
+static yy_state_type yy_try_NUL_trans ( yy_state_type current_state  , yyscan_t yyscanner);
+static int yy_get_next_buffer ( yyscan_t yyscanner );
+static void yynoreturn yy_fatal_error ( const char* msg , yyscan_t yyscanner );
 
 /* Done after the current pattern has been matched and before the
  * corresponding action - sets up yytext.
  */
 #define YY_DO_BEFORE_ACTION \
 	yyg->yytext_ptr = yy_bp; \
-	yyleng = (size_t) (yy_cp - yy_bp); \
+	yyleng = (int) (yy_cp - yy_bp); \
 	yyg->yy_hold_char = *yy_cp; \
 	*yy_cp = '\0'; \
 	yyg->yy_c_buf_p = yy_cp;
-
 #define YY_NUM_RULES 179
 #define YY_END_OF_BUFFER 180
 /* This struct is not used in this scanner,
@@ -371,7 +570,7 @@ struct yy_trans_info
 	flex_int32_t yy_verify;
 	flex_int32_t yy_nxt;
 	};
-static yyconst flex_int16_t yy_accept[217] =
+static const flex_int16_t yy_accept[217] =
     {   0,
         0,    0,    0,    0,    0,    0,    0,    0,  180,  178,
       177,  167,  145,  164,  169,  155,  140,  153,  170,  152,
@@ -399,7 +598,7 @@ static yyconst flex_int16_t yy_accept[217] =
         5,    3,    1,  110,  108,    0
     } ;
 
-static yyconst YY_CHAR yy_ec[256] =
+static const YY_CHAR yy_ec[256] =
     {   0,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    2,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
@@ -431,7 +630,7 @@ static yyconst YY_CHAR yy_ec[256] =
         1,    1,    1,    1,    1
     } ;
 
-static yyconst YY_CHAR yy_meta[86] =
+static const YY_CHAR yy_meta[86] =
     {   0,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
@@ -444,7 +643,7 @@ static yyconst YY_CHAR yy_meta[86] =
         1,    1,    1,    1,    1
     } ;
 
-static yyconst flex_uint16_t yy_base[217] =
+static const flex_int16_t yy_base[217] =
     {   0,
         0,    0,   80,    0,  212,  209,  208,  207,  212,  281,
       281,  281,  281,  281,  281,  281,  281,  281,  281,  178,
@@ -472,7 +671,7 @@ static yyconst flex_uint16_t yy_base[217] =
       281,  281,  281,  281,  281,  281
     } ;
 
-static yyconst flex_int16_t yy_def[217] =
+static const flex_int16_t yy_def[217] =
     {   0,
       216,    1,    1,    3,    1,    1,    1,    1,  216,  216,
       216,  216,  216,  216,  216,  216,  216,  216,  216,  216,
@@ -500,7 +699,7 @@ static yyconst flex_int16_t yy_def[217] =
       216,  216,  216,  216,  216,    0
     } ;
 
-static yyconst flex_uint16_t yy_nxt[367] =
+static const flex_int16_t yy_nxt[367] =
     {   0,
        10,   11,   10,   12,   13,   10,   14,   15,   16,   10,
        17,   18,   19,   20,   21,   22,   23,   24,   24,   24,
@@ -544,7 +743,7 @@ static yyconst flex_uint16_t yy_nxt[367] =
       216,  216,  216,  216,  216,  216
     } ;
 
-static yyconst flex_int16_t yy_chk[367] =
+static const flex_int16_t yy_chk[367] =
     {   0,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
@@ -677,10 +876,9 @@ size_t setup_smarts_string(const std::string &text,yyscan_t yyscanner){
 
 }
 
+#line 880 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/lex.yysmarts.cpp"
 
-
-
-#line 679 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/lex.yysmarts.cpp"
+#line 882 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/lex.yysmarts.cpp"
 
 #define INITIAL 0
 #define IN_ATOM_STATE 1
@@ -713,7 +911,7 @@ struct yyguts_t
     YY_BUFFER_STATE * yy_buffer_stack; /**< Stack as an array. */
     char yy_hold_char;
     int yy_n_chars;
-    yy_size_t yyleng_r;
+    int yyleng_r;
     char *yy_c_buf_p;
     int yy_init;
     int yy_start;
@@ -735,52 +933,52 @@ struct yyguts_t
 
     }; /* end struct yyguts_t */
 
-static int yy_init_globals (yyscan_t yyscanner );
+static int yy_init_globals ( yyscan_t yyscanner );
 
     /* This must go here because YYSTYPE and YYLTYPE are included
      * from bison output in section 1.*/
     #    define yylval yyg->yylval_r
     
-int yysmarts_lex_init (yyscan_t* scanner);
+int yylex_init (yyscan_t* scanner);
 
-int yysmarts_lex_init_extra (YY_EXTRA_TYPE user_defined,yyscan_t* scanner);
+int yylex_init_extra ( YY_EXTRA_TYPE user_defined, yyscan_t* scanner);
 
 /* Accessor methods to globals.
    These are made visible to non-reentrant scanners for convenience. */
 
-int yysmarts_lex_destroy (yyscan_t yyscanner );
+int yylex_destroy ( yyscan_t yyscanner );
 
-int yysmarts_get_debug (yyscan_t yyscanner );
+int yyget_debug ( yyscan_t yyscanner );
 
-void yysmarts_set_debug (int debug_flag ,yyscan_t yyscanner );
+void yyset_debug ( int debug_flag , yyscan_t yyscanner );
 
-YY_EXTRA_TYPE yysmarts_get_extra (yyscan_t yyscanner );
+YY_EXTRA_TYPE yyget_extra ( yyscan_t yyscanner );
 
-void yysmarts_set_extra (YY_EXTRA_TYPE user_defined ,yyscan_t yyscanner );
+void yyset_extra ( YY_EXTRA_TYPE user_defined , yyscan_t yyscanner );
 
-FILE *yysmarts_get_in (yyscan_t yyscanner );
+FILE *yyget_in ( yyscan_t yyscanner );
 
-void yysmarts_set_in  (FILE * _in_str ,yyscan_t yyscanner );
+void yyset_in  ( FILE * _in_str , yyscan_t yyscanner );
 
-FILE *yysmarts_get_out (yyscan_t yyscanner );
+FILE *yyget_out ( yyscan_t yyscanner );
 
-void yysmarts_set_out  (FILE * _out_str ,yyscan_t yyscanner );
+void yyset_out  ( FILE * _out_str , yyscan_t yyscanner );
 
-yy_size_t yysmarts_get_leng (yyscan_t yyscanner );
+			int yyget_leng ( yyscan_t yyscanner );
 
-char *yysmarts_get_text (yyscan_t yyscanner );
+char *yyget_text ( yyscan_t yyscanner );
 
-int yysmarts_get_lineno (yyscan_t yyscanner );
+int yyget_lineno ( yyscan_t yyscanner );
 
-void yysmarts_set_lineno (int _line_number ,yyscan_t yyscanner );
+void yyset_lineno ( int _line_number , yyscan_t yyscanner );
 
-int yysmarts_get_column  (yyscan_t yyscanner );
+int yyget_column  ( yyscan_t yyscanner );
 
-void yysmarts_set_column (int _column_no ,yyscan_t yyscanner );
+void yyset_column ( int _column_no , yyscan_t yyscanner );
 
-YYSTYPE * yysmarts_get_lval (yyscan_t yyscanner );
+YYSTYPE * yyget_lval ( yyscan_t yyscanner );
 
-void yysmarts_set_lval (YYSTYPE * yylval_param ,yyscan_t yyscanner );
+void yyset_lval ( YYSTYPE * yylval_param , yyscan_t yyscanner );
 
 /* Macros after this point can all be overridden by user definitions in
  * section 1.
@@ -788,41 +986,40 @@ void yysmarts_set_lval (YYSTYPE * yylval_param ,yyscan_t yyscanner );
 
 #ifndef YY_SKIP_YYWRAP
 #ifdef __cplusplus
-extern "C" int yysmarts_wrap (yyscan_t yyscanner );
+extern "C" int yywrap ( yyscan_t yyscanner );
 #else
-extern int yysmarts_wrap (yyscan_t yyscanner );
+extern int yywrap ( yyscan_t yyscanner );
 #endif
 #endif
 
 #ifndef YY_NO_UNPUT
     
-    static void yyunput (int c,char *buf_ptr  ,yyscan_t yyscanner);
+    static void yyunput ( int c, char *buf_ptr  , yyscan_t yyscanner);
     
 #endif
 
 #ifndef yytext_ptr
-static void yy_flex_strncpy (char *,yyconst char *,int ,yyscan_t yyscanner);
+static void yy_flex_strncpy ( char *, const char *, int , yyscan_t yyscanner);
 #endif
 
 #ifdef YY_NEED_STRLEN
-static int yy_flex_strlen (yyconst char * ,yyscan_t yyscanner);
+static int yy_flex_strlen ( const char * , yyscan_t yyscanner);
 #endif
 
 #ifndef YY_NO_INPUT
-
 #ifdef __cplusplus
-static int yyinput (yyscan_t yyscanner );
+static int yyinput ( yyscan_t yyscanner );
 #else
-static int input (yyscan_t yyscanner );
+static int input ( yyscan_t yyscanner );
 #endif
 
 #endif
 
-    static void yy_push_state (int _new_state ,yyscan_t yyscanner);
+    static void yy_push_state ( int _new_state , yyscan_t yyscanner);
     
-    static void yy_pop_state (yyscan_t yyscanner );
+    static void yy_pop_state ( yyscan_t yyscanner );
     
-    static int yy_top_state (yyscan_t yyscanner );
+    static int yy_top_state ( yyscan_t yyscanner );
     
 /* Amount of stuff to slurp up with each read. */
 #ifndef YY_READ_BUF_SIZE
@@ -839,7 +1036,7 @@ static int input (yyscan_t yyscanner );
 /* This used to be an fputs(), but since the string might contain NUL's,
  * we now use fwrite().
  */
-#define ECHO do { if (fwrite( yytext, yyleng, 1, yyout )) {} } while (0)
+#define ECHO do { if (fwrite( yytext, (size_t) yyleng, 1, yyout )) {} } while (0)
 #endif
 
 /* Gets input and stuffs it into "buf".  number of characters read, or YY_NULL,
@@ -850,7 +1047,7 @@ static int input (yyscan_t yyscanner );
 	if ( YY_CURRENT_BUFFER_LVALUE->yy_is_interactive ) \
 		{ \
 		int c = '*'; \
-		size_t n; \
+		int n; \
 		for ( n = 0; n < max_size && \
 			     (c = getc( yyin )) != EOF && c != '\n'; ++n ) \
 			buf[n] = (char) c; \
@@ -863,7 +1060,7 @@ static int input (yyscan_t yyscanner );
 	else \
 		{ \
 		errno=0; \
-		while ( (result = fread(buf, 1, max_size, yyin))==0 && ferror(yyin)) \
+		while ( (result = (int) fread(buf, 1, (yy_size_t) max_size, yyin)) == 0 && ferror(yyin)) \
 			{ \
 			if( errno != EINTR) \
 				{ \
@@ -904,10 +1101,10 @@ static int input (yyscan_t yyscanner );
 #ifndef YY_DECL
 #define YY_DECL_IS_OURS 1
 
-extern int yysmarts_lex \
-               (YYSTYPE * yylval_param ,yyscan_t yyscanner);
+extern int yylex \
+               (YYSTYPE * yylval_param , yyscan_t yyscanner);
 
-#define YY_DECL int yysmarts_lex \
+#define YY_DECL int yylex \
                (YYSTYPE * yylval_param , yyscan_t yyscanner)
 #endif /* !YY_DECL */
 
@@ -955,19 +1152,29 @@ YY_DECL
 			yyout = stdout;
 
 		if ( ! YY_CURRENT_BUFFER ) {
-			yysmarts_ensure_buffer_stack (yyscanner);
+			yyensure_buffer_stack (yyscanner);
 			YY_CURRENT_BUFFER_LVALUE =
-				yysmarts__create_buffer(yyin,YY_BUF_SIZE ,yyscanner);
+				yy_create_buffer( yyin, YY_BUF_SIZE , yyscanner);
 		}
 
-		yysmarts__load_buffer_state(yyscanner );
+		yy_load_buffer_state( yyscanner );
 		}
 
 	{
-#line 86 "smarts.ll"
+#line 91 "smarts.ll"
 
 
-#line 966 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/lex.yysmarts.cpp"
+
+#line 95 "smarts.ll"
+  if (start_token)
+    {
+      int t = start_token;
+      start_token = 0;
+      return t;
+    }
+
+
+#line 1178 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/lex.yysmarts.cpp"
 
 	while ( /*CONSTCOND*/1 )		/* loops until end-of-file is reached */
 		{
@@ -995,9 +1202,9 @@ yy_match:
 				{
 				yy_current_state = (int) yy_def[yy_current_state];
 				if ( yy_current_state >= 217 )
-					yy_c = yy_meta[(unsigned int) yy_c];
+					yy_c = yy_meta[yy_c];
 				}
-			yy_current_state = yy_nxt[yy_base[yy_current_state] + (unsigned int) yy_c];
+			yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
 			++yy_cp;
 			}
 		while ( yy_base[yy_current_state] != 281 );
@@ -1025,241 +1232,241 @@ do_action:	/* This label is used only to access EOF actions. */
 			goto yy_find_action;
 
 case 1:
-#line 89 "smarts.ll"
+#line 104 "smarts.ll"
 case 2:
-#line 90 "smarts.ll"
+#line 105 "smarts.ll"
 case 3:
-#line 91 "smarts.ll"
+#line 106 "smarts.ll"
 case 4:
-#line 92 "smarts.ll"
+#line 107 "smarts.ll"
 case 5:
 YY_RULE_SETUP
-#line 92 "smarts.ll"
+#line 107 "smarts.ll"
 { return CHI_CLASS_TOKEN; }
 	YY_BREAK
 case 6:
 YY_RULE_SETUP
-#line 94 "smarts.ll"
+#line 109 "smarts.ll"
 { return AT_TOKEN; }
 	YY_BREAK
 case 7:
-#line 98 "smarts.ll"
-case 8:
-#line 99 "smarts.ll"
-case 9:
-#line 100 "smarts.ll"
-case 10:
-#line 101 "smarts.ll"
-case 11:
-#line 102 "smarts.ll"
-case 12:
-#line 103 "smarts.ll"
-case 13:
-#line 104 "smarts.ll"
-case 14:
-#line 105 "smarts.ll"
-case 15:
-#line 106 "smarts.ll"
-case 16:
-#line 107 "smarts.ll"
-case 17:
-#line 108 "smarts.ll"
-case 18:
-#line 109 "smarts.ll"
-case 19:
-#line 110 "smarts.ll"
-case 20:
-#line 111 "smarts.ll"
-case 21:
-#line 112 "smarts.ll"
-case 22:
 #line 113 "smarts.ll"
-case 23:
+case 8:
 #line 114 "smarts.ll"
-case 24:
+case 9:
 #line 115 "smarts.ll"
-case 25:
+case 10:
 #line 116 "smarts.ll"
-case 26:
+case 11:
 #line 117 "smarts.ll"
-case 27:
+case 12:
 #line 118 "smarts.ll"
-case 28:
+case 13:
 #line 119 "smarts.ll"
-case 29:
+case 14:
 #line 120 "smarts.ll"
-case 30:
+case 15:
 #line 121 "smarts.ll"
-case 31:
+case 16:
 #line 122 "smarts.ll"
-case 32:
+case 17:
 #line 123 "smarts.ll"
-case 33:
+case 18:
 #line 124 "smarts.ll"
-case 34:
+case 19:
 #line 125 "smarts.ll"
-case 35:
+case 20:
 #line 126 "smarts.ll"
-case 36:
+case 21:
 #line 127 "smarts.ll"
-case 37:
+case 22:
 #line 128 "smarts.ll"
-case 38:
+case 23:
 #line 129 "smarts.ll"
-case 39:
+case 24:
 #line 130 "smarts.ll"
-case 40:
+case 25:
 #line 131 "smarts.ll"
-case 41:
+case 26:
 #line 132 "smarts.ll"
-case 42:
+case 27:
 #line 133 "smarts.ll"
-case 43:
+case 28:
 #line 134 "smarts.ll"
-case 44:
+case 29:
 #line 135 "smarts.ll"
-case 45:
+case 30:
 #line 136 "smarts.ll"
-case 46:
+case 31:
 #line 137 "smarts.ll"
-case 47:
+case 32:
 #line 138 "smarts.ll"
-case 48:
+case 33:
 #line 139 "smarts.ll"
-case 49:
+case 34:
 #line 140 "smarts.ll"
-case 50:
+case 35:
 #line 141 "smarts.ll"
-case 51:
+case 36:
 #line 142 "smarts.ll"
-case 52:
+case 37:
 #line 143 "smarts.ll"
-case 53:
+case 38:
 #line 144 "smarts.ll"
-case 54:
+case 39:
 #line 145 "smarts.ll"
-case 55:
+case 40:
 #line 146 "smarts.ll"
-case 56:
+case 41:
 #line 147 "smarts.ll"
-case 57:
+case 42:
 #line 148 "smarts.ll"
-case 58:
+case 43:
 #line 149 "smarts.ll"
-case 59:
+case 44:
 #line 150 "smarts.ll"
-case 60:
+case 45:
 #line 151 "smarts.ll"
-case 61:
+case 46:
 #line 152 "smarts.ll"
-case 62:
+case 47:
 #line 153 "smarts.ll"
-case 63:
+case 48:
 #line 154 "smarts.ll"
-case 64:
+case 49:
 #line 155 "smarts.ll"
-case 65:
+case 50:
 #line 156 "smarts.ll"
-case 66:
+case 51:
 #line 157 "smarts.ll"
-case 67:
+case 52:
 #line 158 "smarts.ll"
-case 68:
+case 53:
 #line 159 "smarts.ll"
-case 69:
+case 54:
 #line 160 "smarts.ll"
-case 70:
+case 55:
 #line 161 "smarts.ll"
-case 71:
+case 56:
 #line 162 "smarts.ll"
-case 72:
+case 57:
 #line 163 "smarts.ll"
-case 73:
+case 58:
 #line 164 "smarts.ll"
-case 74:
+case 59:
 #line 165 "smarts.ll"
-case 75:
+case 60:
 #line 166 "smarts.ll"
-case 76:
+case 61:
 #line 167 "smarts.ll"
-case 77:
+case 62:
 #line 168 "smarts.ll"
-case 78:
+case 63:
 #line 169 "smarts.ll"
-case 79:
+case 64:
 #line 170 "smarts.ll"
-case 80:
+case 65:
 #line 171 "smarts.ll"
-case 81:
+case 66:
 #line 172 "smarts.ll"
-case 82:
+case 67:
 #line 173 "smarts.ll"
-case 83:
+case 68:
 #line 174 "smarts.ll"
-case 84:
+case 69:
 #line 175 "smarts.ll"
-case 85:
+case 70:
 #line 176 "smarts.ll"
-case 86:
+case 71:
 #line 177 "smarts.ll"
-case 87:
+case 72:
 #line 178 "smarts.ll"
-case 88:
+case 73:
 #line 179 "smarts.ll"
-case 89:
+case 74:
 #line 180 "smarts.ll"
-case 90:
+case 75:
 #line 181 "smarts.ll"
-case 91:
+case 76:
 #line 182 "smarts.ll"
-case 92:
+case 77:
 #line 183 "smarts.ll"
-case 93:
+case 78:
 #line 184 "smarts.ll"
-case 94:
+case 79:
 #line 185 "smarts.ll"
-case 95:
+case 80:
 #line 186 "smarts.ll"
-case 96:
+case 81:
 #line 187 "smarts.ll"
-case 97:
+case 82:
 #line 188 "smarts.ll"
-case 98:
+case 83:
 #line 189 "smarts.ll"
-case 99:
+case 84:
 #line 190 "smarts.ll"
-case 100:
+case 85:
 #line 191 "smarts.ll"
-case 101:
+case 86:
 #line 192 "smarts.ll"
-case 102:
+case 87:
 #line 193 "smarts.ll"
-case 103:
+case 88:
 #line 194 "smarts.ll"
-case 104:
+case 89:
 #line 195 "smarts.ll"
-case 105:
+case 90:
 #line 196 "smarts.ll"
-case 106:
+case 91:
 #line 197 "smarts.ll"
-case 107:
+case 92:
 #line 198 "smarts.ll"
-case 108:
+case 93:
 #line 199 "smarts.ll"
-case 109:
+case 94:
 #line 200 "smarts.ll"
-case 110:
+case 95:
 #line 201 "smarts.ll"
+case 96:
+#line 202 "smarts.ll"
+case 97:
+#line 203 "smarts.ll"
+case 98:
+#line 204 "smarts.ll"
+case 99:
+#line 205 "smarts.ll"
+case 100:
+#line 206 "smarts.ll"
+case 101:
+#line 207 "smarts.ll"
+case 102:
+#line 208 "smarts.ll"
+case 103:
+#line 209 "smarts.ll"
+case 104:
+#line 210 "smarts.ll"
+case 105:
+#line 211 "smarts.ll"
+case 106:
+#line 212 "smarts.ll"
+case 107:
+#line 213 "smarts.ll"
+case 108:
+#line 214 "smarts.ll"
+case 109:
+#line 215 "smarts.ll"
+case 110:
+#line 216 "smarts.ll"
 case 111:
 YY_RULE_SETUP
-#line 201 "smarts.ll"
+#line 216 "smarts.ll"
 {   yylval->atom = new QueryAtom( PeriodicTable::getTable()->getAtomicNumber( yytext ) );
 				return ATOM_TOKEN;
 			}
 	YY_BREAK
 case 112:
 YY_RULE_SETUP
-#line 204 "smarts.ll"
+#line 219 "smarts.ll"
 {
 	yylval->atom = new QueryAtom();
 	yylval->atom->setQuery(makeAtomExplicitDegreeQuery(1));
@@ -1268,7 +1475,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 113:
 YY_RULE_SETUP
-#line 210 "smarts.ll"
+#line 225 "smarts.ll"
 {
 	yylval->atom = new QueryAtom();
 	yylval->atom->setQuery(makeAtomTotalDegreeQuery(1));
@@ -1277,7 +1484,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 114:
 YY_RULE_SETUP
-#line 216 "smarts.ll"
+#line 231 "smarts.ll"
 {
 	yylval->atom = new QueryAtom();
 	yylval->atom->setQuery(makeAtomHasRingBondQuery());
@@ -1286,7 +1493,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 115:
 YY_RULE_SETUP
-#line 222 "smarts.ll"
+#line 237 "smarts.ll"
 {
 	yylval->atom = new QueryAtom();
 	yylval->atom->setQuery(makeAtomTotalValenceQuery(1));
@@ -1295,7 +1502,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 116:
 YY_RULE_SETUP
-#line 228 "smarts.ll"
+#line 243 "smarts.ll"
 {
 	yylval->atom = new QueryAtom();
 	yylval->atom->setQuery(makeAtomHasHeteroatomNbrsQuery());
@@ -1304,7 +1511,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 117:
 YY_RULE_SETUP
-#line 234 "smarts.ll"
+#line 249 "smarts.ll"
 {
 	yylval->atom = new QueryAtom();
 	yylval->atom->setQuery(makeAtomHasAliphaticHeteroatomNbrsQuery());
@@ -1313,7 +1520,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 118:
 YY_RULE_SETUP
-#line 240 "smarts.ll"
+#line 255 "smarts.ll"
 {
 	yylval->atom = new QueryAtom();
         yylval->atom->setQuery(makeAtomHasImplicitHQuery());
@@ -1322,7 +1529,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 119:
 YY_RULE_SETUP
-#line 246 "smarts.ll"
+#line 261 "smarts.ll"
 {
 	yylval->atom = new QueryAtom();
 	yylval->atom->setQuery(new AtomRingQuery(-1));
@@ -1331,7 +1538,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 120:
 YY_RULE_SETUP
-#line 252 "smarts.ll"
+#line 267 "smarts.ll"
 {
 	yylval->atom = new QueryAtom();
 	yylval->atom->setQuery(makeAtomInRingQuery());
@@ -1340,102 +1547,102 @@ YY_RULE_SETUP
 	YY_BREAK
 case 121:
 YY_RULE_SETUP
-#line 258 "smarts.ll"
+#line 273 "smarts.ll"
 {  return H_TOKEN;  }
 	YY_BREAK
 case 122:
 YY_RULE_SETUP
-#line 261 "smarts.ll"
+#line 276 "smarts.ll"
 {  yylval->ival = 5;  return ORGANIC_ATOM_TOKEN;  }
 	YY_BREAK
 case 123:
 YY_RULE_SETUP
-#line 263 "smarts.ll"
+#line 278 "smarts.ll"
 {  yylval->ival = 6;  return ORGANIC_ATOM_TOKEN;  }
 	YY_BREAK
 case 124:
 YY_RULE_SETUP
-#line 265 "smarts.ll"
+#line 280 "smarts.ll"
 {  yylval->ival = 7;  return ORGANIC_ATOM_TOKEN;  }
 	YY_BREAK
 case 125:
 YY_RULE_SETUP
-#line 267 "smarts.ll"
+#line 282 "smarts.ll"
 {  yylval->ival = 8;  return ORGANIC_ATOM_TOKEN;  }
 	YY_BREAK
 case 126:
 YY_RULE_SETUP
-#line 269 "smarts.ll"
+#line 284 "smarts.ll"
 {  yylval->ival = 9;  return ORGANIC_ATOM_TOKEN;  }
 	YY_BREAK
 case 127:
 YY_RULE_SETUP
-#line 271 "smarts.ll"
+#line 286 "smarts.ll"
 {  yylval->ival = 15;  return ORGANIC_ATOM_TOKEN;  }
 	YY_BREAK
 case 128:
 YY_RULE_SETUP
-#line 273 "smarts.ll"
+#line 288 "smarts.ll"
 {  yylval->ival = 16;  return ORGANIC_ATOM_TOKEN;  }
 	YY_BREAK
 case 129:
 YY_RULE_SETUP
-#line 275 "smarts.ll"
+#line 290 "smarts.ll"
 {  yylval->ival = 17;  return ORGANIC_ATOM_TOKEN;  }
 	YY_BREAK
 case 130:
 YY_RULE_SETUP
-#line 277 "smarts.ll"
+#line 292 "smarts.ll"
 {  yylval->ival = 35;  return ORGANIC_ATOM_TOKEN;  }
 	YY_BREAK
 case 131:
 YY_RULE_SETUP
-#line 279 "smarts.ll"
+#line 294 "smarts.ll"
 {  yylval->ival = 53;  return ORGANIC_ATOM_TOKEN;  }
 	YY_BREAK
 case 132:
 YY_RULE_SETUP
-#line 282 "smarts.ll"
+#line 297 "smarts.ll"
 {  yylval->ival = 5;  return AROMATIC_ATOM_TOKEN;  }
 	YY_BREAK
 case 133:
 YY_RULE_SETUP
-#line 284 "smarts.ll"
+#line 299 "smarts.ll"
 {  yylval->ival = 6;  return AROMATIC_ATOM_TOKEN;  }
 	YY_BREAK
 case 134:
 YY_RULE_SETUP
-#line 286 "smarts.ll"
+#line 301 "smarts.ll"
 {  yylval->ival = 7;  return AROMATIC_ATOM_TOKEN;  }
 	YY_BREAK
 case 135:
 YY_RULE_SETUP
-#line 288 "smarts.ll"
+#line 303 "smarts.ll"
 {  yylval->ival = 8;  return AROMATIC_ATOM_TOKEN;  }
 	YY_BREAK
 case 136:
 YY_RULE_SETUP
-#line 290 "smarts.ll"
+#line 305 "smarts.ll"
 {  yylval->ival = 15;  return AROMATIC_ATOM_TOKEN;  }
 	YY_BREAK
 case 137:
 YY_RULE_SETUP
-#line 292 "smarts.ll"
+#line 307 "smarts.ll"
 {  yylval->ival = 16;  return AROMATIC_ATOM_TOKEN;  }
 	YY_BREAK
 case 138:
 YY_RULE_SETUP
-#line 294 "smarts.ll"
+#line 309 "smarts.ll"
 {  yylval->ival = 34;  return AROMATIC_ATOM_TOKEN;  }
 	YY_BREAK
 case 139:
 YY_RULE_SETUP
-#line 296 "smarts.ll"
+#line 311 "smarts.ll"
 {  yylval->ival = 52;  return AROMATIC_ATOM_TOKEN;  }
 	YY_BREAK
 case 140:
 YY_RULE_SETUP
-#line 300 "smarts.ll"
+#line 315 "smarts.ll"
 {
 	yylval->atom = new QueryAtom();
 	yylval->atom->setQuery(makeAtomNullQuery());
@@ -1444,7 +1651,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 141:
 YY_RULE_SETUP
-#line 306 "smarts.ll"
+#line 321 "smarts.ll"
 {
 	yylval->atom = new QueryAtom();
 	yylval->atom->setQuery(makeAtomAromaticQuery());
@@ -1454,7 +1661,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 142:
 YY_RULE_SETUP
-#line 313 "smarts.ll"
+#line 328 "smarts.ll"
 {
 	yylval->atom = new QueryAtom();
 	yylval->atom->setQuery(makeAtomAliphaticQuery());
@@ -1463,50 +1670,50 @@ YY_RULE_SETUP
 	YY_BREAK
 case 143:
 YY_RULE_SETUP
-#line 320 "smarts.ll"
+#line 335 "smarts.ll"
 { return COLON_TOKEN; }
 	YY_BREAK
 case 144:
 YY_RULE_SETUP
-#line 322 "smarts.ll"
+#line 337 "smarts.ll"
 { return UNDERSCORE_TOKEN; }
 	YY_BREAK
 case 145:
 YY_RULE_SETUP
-#line 324 "smarts.ll"
+#line 339 "smarts.ll"
 { return HASH_TOKEN; }
 	YY_BREAK
 case 146:
 YY_RULE_SETUP
-#line 326 "smarts.ll"
+#line 341 "smarts.ll"
 { yylval->bond = new QueryBond(Bond::DOUBLE);
 	yylval->bond->setQuery(makeBondOrderEqualsQuery(Bond::DOUBLE));
 	return BOND_TOKEN;  }
 	YY_BREAK
 case 147:
 YY_RULE_SETUP
-#line 330 "smarts.ll"
+#line 345 "smarts.ll"
 { yylval->bond = new QueryBond();
 	yylval->bond->setQuery(makeBondNullQuery());
 	return BOND_TOKEN;  }
 	YY_BREAK
 case 148:
 YY_RULE_SETUP
-#line 334 "smarts.ll"
+#line 349 "smarts.ll"
 { yylval->bond = new QueryBond(Bond::SINGLE);
 	yylval->bond->setBondDir(Bond::ENDDOWNRIGHT);
 	return BOND_TOKEN;  }
 	YY_BREAK
 case 149:
 YY_RULE_SETUP
-#line 338 "smarts.ll"
+#line 353 "smarts.ll"
 { yylval->bond = new QueryBond(Bond::SINGLE);
 	yylval->bond->setBondDir(Bond::ENDUPRIGHT);
 	return BOND_TOKEN;  }
 	YY_BREAK
 case 150:
 YY_RULE_SETUP
-#line 342 "smarts.ll"
+#line 357 "smarts.ll"
 {
     yylval->bond = new QueryBond(Bond::DATIVER);
     return BOND_TOKEN;
@@ -1514,7 +1721,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 151:
 YY_RULE_SETUP
-#line 346 "smarts.ll"
+#line 361 "smarts.ll"
 {
     yylval->bond = new QueryBond(Bond::DATIVEL);
     return BOND_TOKEN;
@@ -1522,57 +1729,57 @@ YY_RULE_SETUP
 	YY_BREAK
 case 152:
 YY_RULE_SETUP
-#line 351 "smarts.ll"
+#line 366 "smarts.ll"
 { return MINUS_TOKEN; }
 	YY_BREAK
 case 153:
 YY_RULE_SETUP
-#line 353 "smarts.ll"
+#line 368 "smarts.ll"
 { return PLUS_TOKEN; }
 	YY_BREAK
 case 154:
 YY_RULE_SETUP
-#line 355 "smarts.ll"
+#line 370 "smarts.ll"
 { yy_push_state(IN_RECURSION_STATE,yyscanner); return BEGIN_RECURSE; }
 	YY_BREAK
 case 155:
 YY_RULE_SETUP
-#line 357 "smarts.ll"
+#line 372 "smarts.ll"
 { yy_push_state(IN_BRANCH_STATE,yyscanner); return GROUP_OPEN_TOKEN; }
 	YY_BREAK
 case 156:
 YY_RULE_SETUP
-#line 358 "smarts.ll"
+#line 373 "smarts.ll"
 { yy_pop_state(yyscanner); return GROUP_CLOSE_TOKEN; }
 	YY_BREAK
 case 157:
 YY_RULE_SETUP
-#line 359 "smarts.ll"
+#line 374 "smarts.ll"
 { yy_pop_state(yyscanner); return END_RECURSE; }
 	YY_BREAK
 case 158:
 YY_RULE_SETUP
-#line 361 "smarts.ll"
+#line 376 "smarts.ll"
 {  return RANGE_OPEN_TOKEN; }
 	YY_BREAK
 case 159:
 YY_RULE_SETUP
-#line 362 "smarts.ll"
+#line 377 "smarts.ll"
 { yy_pop_state(yyscanner); return RANGE_CLOSE_TOKEN; }
 	YY_BREAK
 case 160:
 YY_RULE_SETUP
-#line 366 "smarts.ll"
+#line 381 "smarts.ll"
 { yy_push_state(IN_ATOM_STATE,yyscanner); return ATOM_OPEN_TOKEN; }
 	YY_BREAK
 case 161:
 YY_RULE_SETUP
-#line 367 "smarts.ll"
+#line 382 "smarts.ll"
 { yy_pop_state(yyscanner); return ATOM_CLOSE_TOKEN; }
 	YY_BREAK
 case 162:
 YY_RULE_SETUP
-#line 368 "smarts.ll"
+#line 383 "smarts.ll"
 { /* FIX: ???
                            This rule is here because otherwise recursive SMARTS queries like:
 	                   [$(C(=O)[O,N])] lex improperly (no ATOM_CLOSE token is returned).
@@ -1584,47 +1791,47 @@ YY_RULE_SETUP
 	YY_BREAK
 case 163:
 YY_RULE_SETUP
-#line 377 "smarts.ll"
+#line 392 "smarts.ll"
 { return SEPARATOR_TOKEN; }
 	YY_BREAK
 case 164:
 YY_RULE_SETUP
-#line 379 "smarts.ll"
+#line 394 "smarts.ll"
 { return PERCENT_TOKEN; }
 	YY_BREAK
 case 165:
 YY_RULE_SETUP
-#line 381 "smarts.ll"
+#line 396 "smarts.ll"
 { yylval->ival = 0;  return ZERO_TOKEN; }
 	YY_BREAK
 case 166:
 YY_RULE_SETUP
-#line 382 "smarts.ll"
+#line 397 "smarts.ll"
 { yylval->ival = yytext[0]-'0';  return NONZERO_DIGIT_TOKEN; }
 	YY_BREAK
 case 167:
 YY_RULE_SETUP
-#line 384 "smarts.ll"
+#line 399 "smarts.ll"
 { return NOT_TOKEN; }
 	YY_BREAK
 case 168:
 YY_RULE_SETUP
-#line 386 "smarts.ll"
+#line 401 "smarts.ll"
 { return SEMI_TOKEN; }
 	YY_BREAK
 case 169:
 YY_RULE_SETUP
-#line 388 "smarts.ll"
+#line 403 "smarts.ll"
 { return AND_TOKEN; }
 	YY_BREAK
 case 170:
 YY_RULE_SETUP
-#line 390 "smarts.ll"
+#line 405 "smarts.ll"
 { return OR_TOKEN; }
 	YY_BREAK
 case 171:
 YY_RULE_SETUP
-#line 392 "smarts.ll"
+#line 407 "smarts.ll"
 {
 	yylval->atom = new QueryAtom();
 	yylval->atom->setQuery(makeAtomHybridizationQuery(Atom::S));
@@ -1633,7 +1840,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 172:
 YY_RULE_SETUP
-#line 398 "smarts.ll"
+#line 413 "smarts.ll"
 {
 	yylval->atom = new QueryAtom();
 	yylval->atom->setQuery(makeAtomHybridizationQuery(Atom::SP));
@@ -1642,7 +1849,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 173:
 YY_RULE_SETUP
-#line 404 "smarts.ll"
+#line 419 "smarts.ll"
 {
 	yylval->atom = new QueryAtom();
 	yylval->atom->setQuery(makeAtomHybridizationQuery(Atom::SP2));
@@ -1651,7 +1858,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 174:
 YY_RULE_SETUP
-#line 410 "smarts.ll"
+#line 425 "smarts.ll"
 {
 	yylval->atom = new QueryAtom();
 	yylval->atom->setQuery(makeAtomHybridizationQuery(Atom::SP3));
@@ -1660,7 +1867,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 175:
 YY_RULE_SETUP
-#line 415 "smarts.ll"
+#line 430 "smarts.ll"
 {
 	yylval->atom = new QueryAtom();
 	yylval->atom->setQuery(makeAtomHybridizationQuery(Atom::SP3D));
@@ -1669,7 +1876,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 176:
 YY_RULE_SETUP
-#line 420 "smarts.ll"
+#line 435 "smarts.ll"
 {
 	yylval->atom = new QueryAtom();
 	yylval->atom->setQuery(makeAtomHybridizationQuery(Atom::SP3D2));
@@ -1679,27 +1886,27 @@ YY_RULE_SETUP
 case 177:
 /* rule 177 can match eol */
 YY_RULE_SETUP
-#line 425 "smarts.ll"
+#line 440 "smarts.ll"
 return EOS_TOKEN;
 	YY_BREAK
 case YY_STATE_EOF(INITIAL):
 case YY_STATE_EOF(IN_ATOM_STATE):
 case YY_STATE_EOF(IN_BRANCH_STATE):
 case YY_STATE_EOF(IN_RECURSION_STATE):
-#line 427 "smarts.ll"
+#line 442 "smarts.ll"
 { return EOS_TOKEN; }
 	YY_BREAK
 case 178:
 YY_RULE_SETUP
-#line 428 "smarts.ll"
+#line 443 "smarts.ll"
 return yytext[0];
 	YY_BREAK
 case 179:
 YY_RULE_SETUP
-#line 430 "smarts.ll"
+#line 445 "smarts.ll"
 ECHO;
 	YY_BREAK
-#line 1698 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/lex.yysmarts.cpp"
+#line 1910 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/lex.yysmarts.cpp"
 
 	case YY_END_OF_BUFFER:
 		{
@@ -1715,7 +1922,7 @@ ECHO;
 			/* We're scanning a new file or input source.  It's
 			 * possible that this happened because the user
 			 * just pointed yyin at a new source and called
-			 * yysmarts_lex().  If so, then we have to assure
+			 * yylex().  If so, then we have to assure
 			 * consistency between YY_CURRENT_BUFFER and our
 			 * globals.  Here is the right place to do so, because
 			 * this is the first action (other than possibly a
@@ -1775,7 +1982,7 @@ ECHO;
 				{
 				yyg->yy_did_buffer_switch_on_eof = 0;
 
-				if ( yysmarts_wrap(yyscanner ) )
+				if ( yywrap( yyscanner ) )
 					{
 					/* Note: because we've taken care in
 					 * yy_get_next_buffer() to have set up
@@ -1829,7 +2036,7 @@ ECHO;
 	} /* end of action switch */
 		} /* end of scanning one token */
 	} /* end of user's declarations */
-} /* end of yysmarts_lex */
+} /* end of yylex */
 
 /* yy_get_next_buffer - try to read in a new buffer
  *
@@ -1843,7 +2050,7 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 	char *dest = YY_CURRENT_BUFFER_LVALUE->yy_ch_buf;
 	char *source = yyg->yytext_ptr;
-	yy_size_t number_to_move, i;
+	int number_to_move, i;
 	int ret_val;
 
 	if ( yyg->yy_c_buf_p > &YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[yyg->yy_n_chars + 1] )
@@ -1872,7 +2079,7 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 	/* Try to read more data. */
 
 	/* First move last chars to start of buffer. */
-	number_to_move = (yy_size_t) (yyg->yy_c_buf_p - yyg->yytext_ptr) - 1;
+	number_to_move = (int) (yyg->yy_c_buf_p - yyg->yytext_ptr - 1);
 
 	for ( i = 0; i < number_to_move; ++i )
 		*(dest++) = *(source++);
@@ -1885,7 +2092,7 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 
 	else
 		{
-			yy_size_t num_to_read =
+			int num_to_read =
 			YY_CURRENT_BUFFER_LVALUE->yy_buf_size - number_to_move - 1;
 
 		while ( num_to_read <= 0 )
@@ -1899,7 +2106,7 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 
 			if ( b->yy_is_our_buffer )
 				{
-				yy_size_t new_size = b->yy_buf_size * 2;
+				int new_size = b->yy_buf_size * 2;
 
 				if ( new_size <= 0 )
 					b->yy_buf_size += b->yy_buf_size / 8;
@@ -1908,11 +2115,12 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 
 				b->yy_ch_buf = (char *)
 					/* Include room in for 2 EOB chars. */
-					yysmarts_realloc((void *) b->yy_ch_buf,b->yy_buf_size + 2 ,yyscanner );
+					yyrealloc( (void *) b->yy_ch_buf,
+							 (yy_size_t) (b->yy_buf_size + 2) , yyscanner );
 				}
 			else
 				/* Can't grow it, we don't own it. */
-				b->yy_ch_buf = 0;
+				b->yy_ch_buf = NULL;
 
 			if ( ! b->yy_ch_buf )
 				YY_FATAL_ERROR(
@@ -1940,7 +2148,7 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 		if ( number_to_move == YY_MORE_ADJ )
 			{
 			ret_val = EOB_ACT_END_OF_FILE;
-			yysmarts_restart(yyin  ,yyscanner);
+			yyrestart( yyin  , yyscanner);
 			}
 
 		else
@@ -1954,12 +2162,15 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 	else
 		ret_val = EOB_ACT_CONTINUE_SCAN;
 
-	if ((int) (yyg->yy_n_chars + number_to_move) > YY_CURRENT_BUFFER_LVALUE->yy_buf_size) {
+	if ((yyg->yy_n_chars + number_to_move) > YY_CURRENT_BUFFER_LVALUE->yy_buf_size) {
 		/* Extend the array by 50%, plus the number we really need. */
 		int new_size = yyg->yy_n_chars + number_to_move + (yyg->yy_n_chars >> 1);
-		YY_CURRENT_BUFFER_LVALUE->yy_ch_buf = (char *) yysmarts_realloc((void *) YY_CURRENT_BUFFER_LVALUE->yy_ch_buf,new_size ,yyscanner );
+		YY_CURRENT_BUFFER_LVALUE->yy_ch_buf = (char *) yyrealloc(
+			(void *) YY_CURRENT_BUFFER_LVALUE->yy_ch_buf, (yy_size_t) new_size , yyscanner );
 		if ( ! YY_CURRENT_BUFFER_LVALUE->yy_ch_buf )
 			YY_FATAL_ERROR( "out of dynamic memory in yy_get_next_buffer()" );
+		/* "- 2" to take care of EOB's */
+		YY_CURRENT_BUFFER_LVALUE->yy_buf_size = (int) (new_size - 2);
 	}
 
 	yyg->yy_n_chars += number_to_move;
@@ -1993,9 +2204,9 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 			{
 			yy_current_state = (int) yy_def[yy_current_state];
 			if ( yy_current_state >= 217 )
-				yy_c = yy_meta[(unsigned int) yy_c];
+				yy_c = yy_meta[yy_c];
 			}
-		yy_current_state = yy_nxt[yy_base[yy_current_state] + (unsigned int) yy_c];
+		yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
 		}
 
 	return yy_current_state;
@@ -2022,9 +2233,9 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 		{
 		yy_current_state = (int) yy_def[yy_current_state];
 		if ( yy_current_state >= 217 )
-			yy_c = yy_meta[(unsigned int) yy_c];
+			yy_c = yy_meta[yy_c];
 		}
-	yy_current_state = yy_nxt[yy_base[yy_current_state] + (unsigned int) yy_c];
+	yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
 	yy_is_jam = (yy_current_state == 216);
 
 	(void)yyg;
@@ -2046,7 +2257,7 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 	if ( yy_cp < YY_CURRENT_BUFFER_LVALUE->yy_ch_buf + 2 )
 		{ /* need to shift things up to make room */
 		/* +2 for EOB chars. */
-		yy_size_t number_to_move = yyg->yy_n_chars + 2;
+		int number_to_move = yyg->yy_n_chars + 2;
 		char *dest = &YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[
 					YY_CURRENT_BUFFER_LVALUE->yy_buf_size + 2];
 		char *source =
@@ -2058,7 +2269,7 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 		yy_cp += (int) (dest - source);
 		yy_bp += (int) (dest - source);
 		YY_CURRENT_BUFFER_LVALUE->yy_n_chars =
-			yyg->yy_n_chars = YY_CURRENT_BUFFER_LVALUE->yy_buf_size;
+			yyg->yy_n_chars = (int) YY_CURRENT_BUFFER_LVALUE->yy_buf_size;
 
 		if ( yy_cp < YY_CURRENT_BUFFER_LVALUE->yy_ch_buf + 2 )
 			YY_FATAL_ERROR( "flex scanner push-back overflow" );
@@ -2098,7 +2309,7 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 
 		else
 			{ /* need more input */
-			yy_size_t offset = yyg->yy_c_buf_p - yyg->yytext_ptr;
+			int offset = (int) (yyg->yy_c_buf_p - yyg->yytext_ptr);
 			++yyg->yy_c_buf_p;
 
 			switch ( yy_get_next_buffer( yyscanner ) )
@@ -2115,14 +2326,14 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 					 */
 
 					/* Reset buffer status. */
-					yysmarts_restart(yyin ,yyscanner);
+					yyrestart( yyin , yyscanner);
 
 					/*FALLTHROUGH*/
 
 				case EOB_ACT_END_OF_FILE:
 					{
-					if ( yysmarts_wrap(yyscanner ) )
-						return EOF;
+					if ( yywrap( yyscanner ) )
+						return 0;
 
 					if ( ! yyg->yy_did_buffer_switch_on_eof )
 						YY_NEW_FILE;
@@ -2153,34 +2364,34 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
  * @param yyscanner The scanner object.
  * @note This function does not reset the start condition to @c INITIAL .
  */
-    void yysmarts_restart  (FILE * input_file , yyscan_t yyscanner)
+    void yyrestart  (FILE * input_file , yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 
 	if ( ! YY_CURRENT_BUFFER ){
-        yysmarts_ensure_buffer_stack (yyscanner);
+        yyensure_buffer_stack (yyscanner);
 		YY_CURRENT_BUFFER_LVALUE =
-            yysmarts__create_buffer(yyin,YY_BUF_SIZE ,yyscanner);
+            yy_create_buffer( yyin, YY_BUF_SIZE , yyscanner);
 	}
 
-	yysmarts__init_buffer(YY_CURRENT_BUFFER,input_file ,yyscanner);
-	yysmarts__load_buffer_state(yyscanner );
+	yy_init_buffer( YY_CURRENT_BUFFER, input_file , yyscanner);
+	yy_load_buffer_state( yyscanner );
 }
 
 /** Switch to a different input buffer.
  * @param new_buffer The new input buffer.
  * @param yyscanner The scanner object.
  */
-    void yysmarts__switch_to_buffer  (YY_BUFFER_STATE  new_buffer , yyscan_t yyscanner)
+    void yy_switch_to_buffer  (YY_BUFFER_STATE  new_buffer , yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 
 	/* TODO. We should be able to replace this entire function body
 	 * with
-	 *		yysmarts_pop_buffer_state();
-	 *		yysmarts_push_buffer_state(new_buffer);
+	 *		yypop_buffer_state();
+	 *		yypush_buffer_state(new_buffer);
      */
-	yysmarts_ensure_buffer_stack (yyscanner);
+	yyensure_buffer_stack (yyscanner);
 	if ( YY_CURRENT_BUFFER == new_buffer )
 		return;
 
@@ -2193,17 +2404,17 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 		}
 
 	YY_CURRENT_BUFFER_LVALUE = new_buffer;
-	yysmarts__load_buffer_state(yyscanner );
+	yy_load_buffer_state( yyscanner );
 
 	/* We don't actually know whether we did this switch during
-	 * EOF (yysmarts_wrap()) processing, but the only time this flag
-	 * is looked at is after yysmarts_wrap() is called, so it's safe
+	 * EOF (yywrap()) processing, but the only time this flag
+	 * is looked at is after yywrap() is called, so it's safe
 	 * to go ahead and always set it.
 	 */
 	yyg->yy_did_buffer_switch_on_eof = 1;
 }
 
-static void yysmarts__load_buffer_state  (yyscan_t yyscanner)
+static void yy_load_buffer_state  (yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 	yyg->yy_n_chars = YY_CURRENT_BUFFER_LVALUE->yy_n_chars;
@@ -2218,35 +2429,35 @@ static void yysmarts__load_buffer_state  (yyscan_t yyscanner)
  * @param yyscanner The scanner object.
  * @return the allocated buffer state.
  */
-    YY_BUFFER_STATE yysmarts__create_buffer  (FILE * file, int  size , yyscan_t yyscanner)
+    YY_BUFFER_STATE yy_create_buffer  (FILE * file, int  size , yyscan_t yyscanner)
 {
 	YY_BUFFER_STATE b;
     
-	b = (YY_BUFFER_STATE) yysmarts_alloc(sizeof( struct yy_buffer_state ) ,yyscanner );
+	b = (YY_BUFFER_STATE) yyalloc( sizeof( struct yy_buffer_state ) , yyscanner );
 	if ( ! b )
-		YY_FATAL_ERROR( "out of dynamic memory in yysmarts__create_buffer()" );
+		YY_FATAL_ERROR( "out of dynamic memory in yy_create_buffer()" );
 
-	b->yy_buf_size = (yy_size_t)size;
+	b->yy_buf_size = size;
 
 	/* yy_ch_buf has to be 2 characters longer than the size given because
 	 * we need to put in 2 end-of-buffer characters.
 	 */
-	b->yy_ch_buf = (char *) yysmarts_alloc(b->yy_buf_size + 2 ,yyscanner );
+	b->yy_ch_buf = (char *) yyalloc( (yy_size_t) (b->yy_buf_size + 2) , yyscanner );
 	if ( ! b->yy_ch_buf )
-		YY_FATAL_ERROR( "out of dynamic memory in yysmarts__create_buffer()" );
+		YY_FATAL_ERROR( "out of dynamic memory in yy_create_buffer()" );
 
 	b->yy_is_our_buffer = 1;
 
-	yysmarts__init_buffer(b,file ,yyscanner);
+	yy_init_buffer( b, file , yyscanner);
 
 	return b;
 }
 
 /** Destroy the buffer.
- * @param b a buffer created with yysmarts__create_buffer()
+ * @param b a buffer created with yy_create_buffer()
  * @param yyscanner The scanner object.
  */
-    void yysmarts__delete_buffer (YY_BUFFER_STATE  b , yyscan_t yyscanner)
+    void yy_delete_buffer (YY_BUFFER_STATE  b , yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 
@@ -2257,28 +2468,28 @@ static void yysmarts__load_buffer_state  (yyscan_t yyscanner)
 		YY_CURRENT_BUFFER_LVALUE = (YY_BUFFER_STATE) 0;
 
 	if ( b->yy_is_our_buffer )
-		yysmarts_free((void *) b->yy_ch_buf ,yyscanner );
+		yyfree( (void *) b->yy_ch_buf , yyscanner );
 
-	yysmarts_free((void *) b ,yyscanner );
+	yyfree( (void *) b , yyscanner );
 }
 
 /* Initializes or reinitializes a buffer.
  * This function is sometimes called more than once on the same buffer,
- * such as during a yysmarts_restart() or at EOF.
+ * such as during a yyrestart() or at EOF.
  */
-    static void yysmarts__init_buffer  (YY_BUFFER_STATE  b, FILE * file , yyscan_t yyscanner)
+    static void yy_init_buffer  (YY_BUFFER_STATE  b, FILE * file , yyscan_t yyscanner)
 
 {
 	int oerrno = errno;
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 
-	yysmarts__flush_buffer(b ,yyscanner);
+	yy_flush_buffer( b , yyscanner);
 
 	b->yy_input_file = file;
 	b->yy_fill_buffer = 1;
 
-    /* If b is the current buffer, then yysmarts__init_buffer was _probably_
-     * called from yysmarts_restart() or through yy_get_next_buffer.
+    /* If b is the current buffer, then yy_init_buffer was _probably_
+     * called from yyrestart() or through yy_get_next_buffer.
      * In that case, we don't want to reset the lineno or column.
      */
     if (b != YY_CURRENT_BUFFER){
@@ -2295,7 +2506,7 @@ static void yysmarts__load_buffer_state  (yyscan_t yyscanner)
  * @param b the buffer state to be flushed, usually @c YY_CURRENT_BUFFER.
  * @param yyscanner The scanner object.
  */
-    void yysmarts__flush_buffer (YY_BUFFER_STATE  b , yyscan_t yyscanner)
+    void yy_flush_buffer (YY_BUFFER_STATE  b , yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 	if ( ! b )
@@ -2316,7 +2527,7 @@ static void yysmarts__load_buffer_state  (yyscan_t yyscanner)
 	b->yy_buffer_status = YY_BUFFER_NEW;
 
 	if ( b == YY_CURRENT_BUFFER )
-		yysmarts__load_buffer_state(yyscanner );
+		yy_load_buffer_state( yyscanner );
 }
 
 /** Pushes the new state onto the stack. The new state becomes
@@ -2325,15 +2536,15 @@ static void yysmarts__load_buffer_state  (yyscan_t yyscanner)
  *  @param new_buffer The new state.
  *  @param yyscanner The scanner object.
  */
-void yysmarts_push_buffer_state (YY_BUFFER_STATE new_buffer , yyscan_t yyscanner)
+void yypush_buffer_state (YY_BUFFER_STATE new_buffer , yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 	if (new_buffer == NULL)
 		return;
 
-	yysmarts_ensure_buffer_stack(yyscanner);
+	yyensure_buffer_stack(yyscanner);
 
-	/* This block is copied from yysmarts__switch_to_buffer. */
+	/* This block is copied from yy_switch_to_buffer. */
 	if ( YY_CURRENT_BUFFER )
 		{
 		/* Flush out information for old buffer. */
@@ -2347,8 +2558,8 @@ void yysmarts_push_buffer_state (YY_BUFFER_STATE new_buffer , yyscan_t yyscanner
 		yyg->yy_buffer_stack_top++;
 	YY_CURRENT_BUFFER_LVALUE = new_buffer;
 
-	/* copied from yysmarts__switch_to_buffer. */
-	yysmarts__load_buffer_state(yyscanner );
+	/* copied from yy_switch_to_buffer. */
+	yy_load_buffer_state( yyscanner );
 	yyg->yy_did_buffer_switch_on_eof = 1;
 }
 
@@ -2356,19 +2567,19 @@ void yysmarts_push_buffer_state (YY_BUFFER_STATE new_buffer , yyscan_t yyscanner
  *  The next element becomes the new top.
  *  @param yyscanner The scanner object.
  */
-void yysmarts_pop_buffer_state (yyscan_t yyscanner)
+void yypop_buffer_state (yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 	if (!YY_CURRENT_BUFFER)
 		return;
 
-	yysmarts__delete_buffer(YY_CURRENT_BUFFER ,yyscanner);
+	yy_delete_buffer(YY_CURRENT_BUFFER , yyscanner);
 	YY_CURRENT_BUFFER_LVALUE = NULL;
 	if (yyg->yy_buffer_stack_top > 0)
 		--yyg->yy_buffer_stack_top;
 
 	if (YY_CURRENT_BUFFER) {
-		yysmarts__load_buffer_state(yyscanner );
+		yy_load_buffer_state( yyscanner );
 		yyg->yy_did_buffer_switch_on_eof = 1;
 	}
 }
@@ -2376,7 +2587,7 @@ void yysmarts_pop_buffer_state (yyscan_t yyscanner)
 /* Allocates the stack if it does not exist.
  *  Guarantees space for at least one push.
  */
-static void yysmarts_ensure_buffer_stack (yyscan_t yyscanner)
+static void yyensure_buffer_stack (yyscan_t yyscanner)
 {
 	yy_size_t num_to_alloc;
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
@@ -2387,15 +2598,15 @@ static void yysmarts_ensure_buffer_stack (yyscan_t yyscanner)
 		 * scanner will even need a stack. We use 2 instead of 1 to avoid an
 		 * immediate realloc on the next call.
          */
-		num_to_alloc = 1; /* After all that talk, this was set to 1 anyways... */
-		yyg->yy_buffer_stack = (struct yy_buffer_state**)yysmarts_alloc
+      num_to_alloc = 1; /* After all that talk, this was set to 1 anyways... */
+		yyg->yy_buffer_stack = (struct yy_buffer_state**)yyalloc
 								(num_to_alloc * sizeof(struct yy_buffer_state*)
 								, yyscanner);
 		if ( ! yyg->yy_buffer_stack )
-			YY_FATAL_ERROR( "out of dynamic memory in yysmarts_ensure_buffer_stack()" );
-								  
+			YY_FATAL_ERROR( "out of dynamic memory in yyensure_buffer_stack()" );
+
 		memset(yyg->yy_buffer_stack, 0, num_to_alloc * sizeof(struct yy_buffer_state*));
-				
+
 		yyg->yy_buffer_stack_max = num_to_alloc;
 		yyg->yy_buffer_stack_top = 0;
 		return;
@@ -2407,12 +2618,12 @@ static void yysmarts_ensure_buffer_stack (yyscan_t yyscanner)
 		yy_size_t grow_size = 8 /* arbitrary grow size */;
 
 		num_to_alloc = yyg->yy_buffer_stack_max + grow_size;
-		yyg->yy_buffer_stack = (struct yy_buffer_state**)yysmarts_realloc
+		yyg->yy_buffer_stack = (struct yy_buffer_state**)yyrealloc
 								(yyg->yy_buffer_stack,
 								num_to_alloc * sizeof(struct yy_buffer_state*)
 								, yyscanner);
 		if ( ! yyg->yy_buffer_stack )
-			YY_FATAL_ERROR( "out of dynamic memory in yysmarts_ensure_buffer_stack()" );
+			YY_FATAL_ERROR( "out of dynamic memory in yyensure_buffer_stack()" );
 
 		/* zero only the new slots.*/
 		memset(yyg->yy_buffer_stack + yyg->yy_buffer_stack_max, 0, grow_size * sizeof(struct yy_buffer_state*));
@@ -2424,9 +2635,9 @@ static void yysmarts_ensure_buffer_stack (yyscan_t yyscanner)
  * @param base the character buffer
  * @param size the size in bytes of the character buffer
  * @param yyscanner The scanner object.
- * @return the newly allocated buffer state object. 
+ * @return the newly allocated buffer state object.
  */
-YY_BUFFER_STATE yysmarts__scan_buffer  (char * base, yy_size_t  size , yyscan_t yyscanner)
+YY_BUFFER_STATE yy_scan_buffer  (char * base, yy_size_t  size , yyscan_t yyscanner)
 {
 	YY_BUFFER_STATE b;
     
@@ -2434,69 +2645,69 @@ YY_BUFFER_STATE yysmarts__scan_buffer  (char * base, yy_size_t  size , yyscan_t 
 	     base[size-2] != YY_END_OF_BUFFER_CHAR ||
 	     base[size-1] != YY_END_OF_BUFFER_CHAR )
 		/* They forgot to leave room for the EOB's. */
-		return 0;
+		return NULL;
 
-	b = (YY_BUFFER_STATE) yysmarts_alloc(sizeof( struct yy_buffer_state ) ,yyscanner );
+	b = (YY_BUFFER_STATE) yyalloc( sizeof( struct yy_buffer_state ) , yyscanner );
 	if ( ! b )
-		YY_FATAL_ERROR( "out of dynamic memory in yysmarts__scan_buffer()" );
+		YY_FATAL_ERROR( "out of dynamic memory in yy_scan_buffer()" );
 
-	b->yy_buf_size = size - 2;	/* "- 2" to take care of EOB's */
+	b->yy_buf_size = (int) (size - 2);	/* "- 2" to take care of EOB's */
 	b->yy_buf_pos = b->yy_ch_buf = base;
 	b->yy_is_our_buffer = 0;
-	b->yy_input_file = 0;
+	b->yy_input_file = NULL;
 	b->yy_n_chars = b->yy_buf_size;
 	b->yy_is_interactive = 0;
 	b->yy_at_bol = 1;
 	b->yy_fill_buffer = 0;
 	b->yy_buffer_status = YY_BUFFER_NEW;
 
-	yysmarts__switch_to_buffer(b ,yyscanner );
+	yy_switch_to_buffer( b , yyscanner );
 
 	return b;
 }
 
-/** Setup the input buffer state to scan a string. The next call to yysmarts_lex() will
+/** Setup the input buffer state to scan a string. The next call to yylex() will
  * scan from a @e copy of @a str.
  * @param yystr a NUL-terminated string to scan
  * @param yyscanner The scanner object.
  * @return the newly allocated buffer state object.
  * @note If you want to scan bytes that may contain NUL values, then use
- *       yysmarts__scan_bytes() instead.
+ *       yy_scan_bytes() instead.
  */
-YY_BUFFER_STATE yysmarts__scan_string (yyconst char * yystr , yyscan_t yyscanner)
+YY_BUFFER_STATE yy_scan_string (const char * yystr , yyscan_t yyscanner)
 {
     
-	return yysmarts__scan_bytes(yystr,strlen(yystr) ,yyscanner);
+	return yy_scan_bytes( yystr, (int) strlen(yystr) , yyscanner);
 }
 
-/** Setup the input buffer state to scan the given bytes. The next call to yysmarts_lex() will
+/** Setup the input buffer state to scan the given bytes. The next call to yylex() will
  * scan from a @e copy of @a bytes.
  * @param yybytes the byte buffer to scan
  * @param _yybytes_len the number of bytes in the buffer pointed to by @a bytes.
  * @param yyscanner The scanner object.
  * @return the newly allocated buffer state object.
  */
-YY_BUFFER_STATE yysmarts__scan_bytes  (yyconst char * yybytes, yy_size_t  _yybytes_len , yyscan_t yyscanner)
+YY_BUFFER_STATE yy_scan_bytes  (const char * yybytes, int  _yybytes_len , yyscan_t yyscanner)
 {
 	YY_BUFFER_STATE b;
 	char *buf;
 	yy_size_t n;
-	yy_size_t i;
+	int i;
     
 	/* Get memory for full buffer, including space for trailing EOB's. */
-	n = _yybytes_len + 2;
-	buf = (char *) yysmarts_alloc(n ,yyscanner );
+	n = (yy_size_t) (_yybytes_len + 2);
+	buf = (char *) yyalloc( n , yyscanner );
 	if ( ! buf )
-		YY_FATAL_ERROR( "out of dynamic memory in yysmarts__scan_bytes()" );
+		YY_FATAL_ERROR( "out of dynamic memory in yy_scan_bytes()" );
 
 	for ( i = 0; i < _yybytes_len; ++i )
 		buf[i] = yybytes[i];
 
 	buf[_yybytes_len] = buf[_yybytes_len+1] = YY_END_OF_BUFFER_CHAR;
 
-	b = yysmarts__scan_buffer(buf,n ,yyscanner);
+	b = yy_scan_buffer( buf, n , yyscanner);
 	if ( ! b )
-		YY_FATAL_ERROR( "bad buffer in yysmarts__scan_bytes()" );
+		YY_FATAL_ERROR( "bad buffer in yy_scan_bytes()" );
 
 	/* It's okay to grow etc. this buffer, and we should throw it
 	 * away when we're done.
@@ -2514,13 +2725,14 @@ YY_BUFFER_STATE yysmarts__scan_bytes  (yyconst char * yybytes, yy_size_t  _yybyt
 		yy_size_t new_size;
 
 		yyg->yy_start_stack_depth += YY_START_STACK_INCR;
-		new_size = yyg->yy_start_stack_depth * sizeof( int );
+		new_size = (yy_size_t) yyg->yy_start_stack_depth * sizeof( int );
 
 		if ( ! yyg->yy_start_stack )
-			yyg->yy_start_stack = (int *) yysmarts_alloc(new_size ,yyscanner );
+			yyg->yy_start_stack = (int *) yyalloc( new_size , yyscanner );
 
 		else
-			yyg->yy_start_stack = (int *) yysmarts_realloc((void *) yyg->yy_start_stack,new_size ,yyscanner );
+			yyg->yy_start_stack = (int *) yyrealloc(
+					(void *) yyg->yy_start_stack, new_size , yyscanner );
 
 		if ( ! yyg->yy_start_stack )
 			YY_FATAL_ERROR( "out of memory expanding start-condition stack" );
@@ -2550,11 +2762,11 @@ YY_BUFFER_STATE yysmarts__scan_bytes  (yyconst char * yybytes, yy_size_t  _yybyt
 #define YY_EXIT_FAILURE 2
 #endif
 
-static void yy_fatal_error (yyconst char* msg , yyscan_t yyscanner)
+static void yynoreturn yy_fatal_error (const char* msg , yyscan_t yyscanner)
 {
 	struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 	(void)yyg;
-	(void) fprintf( stderr, "%s\n", msg );
+	fprintf( stderr, "%s\n", msg );
 	exit( YY_EXIT_FAILURE );
 }
 
@@ -2580,7 +2792,7 @@ static void yy_fatal_error (yyconst char* msg , yyscan_t yyscanner)
 /** Get the user-defined data for this scanner.
  * @param yyscanner The scanner object.
  */
-YY_EXTRA_TYPE yysmarts_get_extra  (yyscan_t yyscanner)
+YY_EXTRA_TYPE yyget_extra  (yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
     return yyextra;
@@ -2589,10 +2801,10 @@ YY_EXTRA_TYPE yysmarts_get_extra  (yyscan_t yyscanner)
 /** Get the current line number.
  * @param yyscanner The scanner object.
  */
-int yysmarts_get_lineno  (yyscan_t yyscanner)
+int yyget_lineno  (yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
-    
+
         if (! YY_CURRENT_BUFFER)
             return 0;
     
@@ -2602,10 +2814,10 @@ int yysmarts_get_lineno  (yyscan_t yyscanner)
 /** Get the current column number.
  * @param yyscanner The scanner object.
  */
-int yysmarts_get_column  (yyscan_t yyscanner)
+int yyget_column  (yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
-    
+
         if (! YY_CURRENT_BUFFER)
             return 0;
     
@@ -2615,7 +2827,7 @@ int yysmarts_get_column  (yyscan_t yyscanner)
 /** Get the input stream.
  * @param yyscanner The scanner object.
  */
-FILE *yysmarts_get_in  (yyscan_t yyscanner)
+FILE *yyget_in  (yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
     return yyin;
@@ -2624,7 +2836,7 @@ FILE *yysmarts_get_in  (yyscan_t yyscanner)
 /** Get the output stream.
  * @param yyscanner The scanner object.
  */
-FILE *yysmarts_get_out  (yyscan_t yyscanner)
+FILE *yyget_out  (yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
     return yyout;
@@ -2633,7 +2845,7 @@ FILE *yysmarts_get_out  (yyscan_t yyscanner)
 /** Get the length of the current token.
  * @param yyscanner The scanner object.
  */
-yy_size_t yysmarts_get_leng  (yyscan_t yyscanner)
+int yyget_leng  (yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
     return yyleng;
@@ -2643,7 +2855,7 @@ yy_size_t yysmarts_get_leng  (yyscan_t yyscanner)
  * @param yyscanner The scanner object.
  */
 
-char *yysmarts_get_text  (yyscan_t yyscanner)
+char *yyget_text  (yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
     return yytext;
@@ -2653,7 +2865,7 @@ char *yysmarts_get_text  (yyscan_t yyscanner)
  * @param user_defined The data to be associated with this scanner.
  * @param yyscanner The scanner object.
  */
-void yysmarts_set_extra (YY_EXTRA_TYPE  user_defined , yyscan_t yyscanner)
+void yyset_extra (YY_EXTRA_TYPE  user_defined , yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
     yyextra = user_defined ;
@@ -2663,13 +2875,13 @@ void yysmarts_set_extra (YY_EXTRA_TYPE  user_defined , yyscan_t yyscanner)
  * @param _line_number line number
  * @param yyscanner The scanner object.
  */
-void yysmarts_set_lineno (int  _line_number , yyscan_t yyscanner)
+void yyset_lineno (int  _line_number , yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 
         /* lineno is only valid if an input buffer exists. */
         if (! YY_CURRENT_BUFFER )
-           YY_FATAL_ERROR( "yysmarts_set_lineno called with no buffer" );
+           YY_FATAL_ERROR( "yyset_lineno called with no buffer" );
     
     yylineno = _line_number;
 }
@@ -2678,13 +2890,13 @@ void yysmarts_set_lineno (int  _line_number , yyscan_t yyscanner)
  * @param _column_no column number
  * @param yyscanner The scanner object.
  */
-void yysmarts_set_column (int  _column_no , yyscan_t yyscanner)
+void yyset_column (int  _column_no , yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 
         /* column is only valid if an input buffer exists. */
         if (! YY_CURRENT_BUFFER )
-           YY_FATAL_ERROR( "yysmarts_set_column called with no buffer" );
+           YY_FATAL_ERROR( "yyset_column called with no buffer" );
     
     yycolumn = _column_no;
 }
@@ -2693,27 +2905,27 @@ void yysmarts_set_column (int  _column_no , yyscan_t yyscanner)
  * input buffer.
  * @param _in_str A readable stream.
  * @param yyscanner The scanner object.
- * @see yysmarts__switch_to_buffer
+ * @see yy_switch_to_buffer
  */
-void yysmarts_set_in (FILE *  _in_str , yyscan_t yyscanner)
+void yyset_in (FILE *  _in_str , yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
     yyin = _in_str ;
 }
 
-void yysmarts_set_out (FILE *  _out_str , yyscan_t yyscanner)
+void yyset_out (FILE *  _out_str , yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
     yyout = _out_str ;
 }
 
-int yysmarts_get_debug  (yyscan_t yyscanner)
+int yyget_debug  (yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
     return yy_flex_debug;
 }
 
-void yysmarts_set_debug (int  _bdebug , yyscan_t yyscanner)
+void yyset_debug (int  _bdebug , yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
     yy_flex_debug = _bdebug ;
@@ -2721,13 +2933,13 @@ void yysmarts_set_debug (int  _bdebug , yyscan_t yyscanner)
 
 /* Accessor methods for yylval and yylloc */
 
-YYSTYPE * yysmarts_get_lval  (yyscan_t yyscanner)
+YYSTYPE * yyget_lval  (yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
     return yylval;
 }
 
-void yysmarts_set_lval (YYSTYPE *  yylval_param , yyscan_t yyscanner)
+void yyset_lval (YYSTYPE *  yylval_param , yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
     yylval = yylval_param;
@@ -2735,20 +2947,18 @@ void yysmarts_set_lval (YYSTYPE *  yylval_param , yyscan_t yyscanner)
 
 /* User-visible API */
 
-/* yysmarts_lex_init is special because it creates the scanner itself, so it is
+/* yylex_init is special because it creates the scanner itself, so it is
  * the ONLY reentrant function that doesn't take the scanner as the last argument.
  * That's why we explicitly handle the declaration, instead of using our macros.
  */
-
-int yysmarts_lex_init(yyscan_t* ptr_yy_globals)
-
+int yylex_init(yyscan_t* ptr_yy_globals)
 {
     if (ptr_yy_globals == NULL){
         errno = EINVAL;
         return 1;
     }
 
-    *ptr_yy_globals = (yyscan_t) yysmarts_alloc ( sizeof( struct yyguts_t ), NULL );
+    *ptr_yy_globals = (yyscan_t) yyalloc ( sizeof( struct yyguts_t ), NULL );
 
     if (*ptr_yy_globals == NULL){
         errno = ENOMEM;
@@ -2761,39 +2971,37 @@ int yysmarts_lex_init(yyscan_t* ptr_yy_globals)
     return yy_init_globals ( *ptr_yy_globals );
 }
 
-/* yysmarts_lex_init_extra has the same functionality as yysmarts_lex_init, but follows the
+/* yylex_init_extra has the same functionality as yylex_init, but follows the
  * convention of taking the scanner as the last argument. Note however, that
  * this is a *pointer* to a scanner, as it will be allocated by this call (and
  * is the reason, too, why this function also must handle its own declaration).
- * The user defined value in the first argument will be available to yysmarts_alloc in
+ * The user defined value in the first argument will be available to yyalloc in
  * the yyextra field.
  */
-
-int yysmarts_lex_init_extra(YY_EXTRA_TYPE yy_user_defined,yyscan_t* ptr_yy_globals )
-
+int yylex_init_extra( YY_EXTRA_TYPE yy_user_defined, yyscan_t* ptr_yy_globals )
 {
     struct yyguts_t dummy_yyguts;
 
-    yysmarts_set_extra (yy_user_defined, &dummy_yyguts);
+    yyset_extra (yy_user_defined, &dummy_yyguts);
 
     if (ptr_yy_globals == NULL){
         errno = EINVAL;
         return 1;
     }
-	
-    *ptr_yy_globals = (yyscan_t) yysmarts_alloc ( sizeof( struct yyguts_t ), &dummy_yyguts );
-	
+
+    *ptr_yy_globals = (yyscan_t) yyalloc ( sizeof( struct yyguts_t ), &dummy_yyguts );
+
     if (*ptr_yy_globals == NULL){
         errno = ENOMEM;
         return 1;
     }
-    
+
     /* By setting to 0xAA, we expose bugs in
     yy_init_globals. Leave at 0x00 for releases. */
     memset(*ptr_yy_globals,0x00,sizeof(struct yyguts_t));
-    
-    yysmarts_set_extra (yy_user_defined, *ptr_yy_globals);
-    
+
+    yyset_extra (yy_user_defined, *ptr_yy_globals);
+
     return yy_init_globals ( *ptr_yy_globals );
 }
 
@@ -2801,13 +3009,13 @@ static int yy_init_globals (yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
     /* Initialization is the same as for the non-reentrant scanner.
-     * This function is called from yysmarts_lex_destroy(), so don't allocate here.
+     * This function is called from yylex_destroy(), so don't allocate here.
      */
 
-    yyg->yy_buffer_stack = 0;
+    yyg->yy_buffer_stack = NULL;
     yyg->yy_buffer_stack_top = 0;
     yyg->yy_buffer_stack_max = 0;
-    yyg->yy_c_buf_p = (char *) 0;
+    yyg->yy_c_buf_p = NULL;
     yyg->yy_init = 0;
     yyg->yy_start = 0;
 
@@ -2820,42 +3028,42 @@ static int yy_init_globals (yyscan_t yyscanner)
     yyin = stdin;
     yyout = stdout;
 #else
-    yyin = (FILE *) 0;
-    yyout = (FILE *) 0;
+    yyin = NULL;
+    yyout = NULL;
 #endif
 
     /* For future reference: Set errno on error, since we are called by
-     * yysmarts_lex_init()
+     * yylex_init()
      */
     return 0;
 }
 
-/* yysmarts_lex_destroy is for both reentrant and non-reentrant scanners. */
-int yysmarts_lex_destroy  (yyscan_t yyscanner)
+/* yylex_destroy is for both reentrant and non-reentrant scanners. */
+int yylex_destroy  (yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 
     /* Pop the buffer stack, destroying each element. */
 	while(YY_CURRENT_BUFFER){
-		yysmarts__delete_buffer(YY_CURRENT_BUFFER ,yyscanner );
+		yy_delete_buffer( YY_CURRENT_BUFFER , yyscanner );
 		YY_CURRENT_BUFFER_LVALUE = NULL;
-		yysmarts_pop_buffer_state(yyscanner);
+		yypop_buffer_state(yyscanner);
 	}
 
 	/* Destroy the stack itself. */
-	yysmarts_free(yyg->yy_buffer_stack ,yyscanner);
+	yyfree(yyg->yy_buffer_stack , yyscanner);
 	yyg->yy_buffer_stack = NULL;
 
     /* Destroy the start condition stack. */
-        yysmarts_free(yyg->yy_start_stack ,yyscanner );
+        yyfree( yyg->yy_start_stack , yyscanner );
         yyg->yy_start_stack = NULL;
 
     /* Reset the globals. This is important in a non-reentrant scanner so the next time
-     * yysmarts_lex() is called, initialization will occur. */
+     * yylex() is called, initialization will occur. */
     yy_init_globals( yyscanner);
 
     /* Destroy the main struct (reentrant only). */
-    yysmarts_free ( yyscanner , yyscanner );
+    yyfree ( yyscanner , yyscanner );
     yyscanner = NULL;
     return 0;
 }
@@ -2865,7 +3073,7 @@ int yysmarts_lex_destroy  (yyscan_t yyscanner)
  */
 
 #ifndef yytext_ptr
-static void yy_flex_strncpy (char* s1, yyconst char * s2, int n , yyscan_t yyscanner)
+static void yy_flex_strncpy (char* s1, const char * s2, int n , yyscan_t yyscanner)
 {
 	struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 	(void)yyg;
@@ -2877,7 +3085,7 @@ static void yy_flex_strncpy (char* s1, yyconst char * s2, int n , yyscan_t yysca
 #endif
 
 #ifdef YY_NEED_STRLEN
-static int yy_flex_strlen (yyconst char * s , yyscan_t yyscanner)
+static int yy_flex_strlen (const char * s , yyscan_t yyscanner)
 {
 	int n;
 	for ( n = 0; s[n]; ++n )
@@ -2887,14 +3095,14 @@ static int yy_flex_strlen (yyconst char * s , yyscan_t yyscanner)
 }
 #endif
 
-void *yysmarts_alloc (yy_size_t  size , yyscan_t yyscanner)
+void *yyalloc (yy_size_t  size , yyscan_t yyscanner)
 {
 	struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 	(void)yyg;
-	return (void *) malloc( size );
+	return malloc(size);
 }
 
-void *yysmarts_realloc  (void * ptr, yy_size_t  size , yyscan_t yyscanner)
+void *yyrealloc  (void * ptr, yy_size_t  size , yyscan_t yyscanner)
 {
 	struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 	(void)yyg;
@@ -2906,20 +3114,19 @@ void *yysmarts_realloc  (void * ptr, yy_size_t  size , yyscan_t yyscanner)
 	 * any pointer type to void*, and deal with argument conversions
 	 * as though doing an assignment.
 	 */
-	return (void *) realloc( (char *) ptr, size );
+	return realloc(ptr, size);
 }
 
-void yysmarts_free (void * ptr , yyscan_t yyscanner)
+void yyfree (void * ptr , yyscan_t yyscanner)
 {
 	struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 	(void)yyg;
-	free( (char *) ptr );	/* see yysmarts_realloc() for (char *) cast */
+	free( (char *) ptr );	/* see yyrealloc() for (char *) cast */
 }
 
 #define YYTABLES_NAME "yytables"
 
-#line 430 "smarts.ll"
-
+#line 445 "smarts.ll"
 
 
 #undef yysmarts_wrap

--- a/Code/GraphMol/SmilesParse/lex.yysmiles.cpp.cmake
+++ b/Code/GraphMol/SmilesParse/lex.yysmiles.cpp.cmake
@@ -9,9 +9,231 @@
 #define FLEX_SCANNER
 #define YY_FLEX_MAJOR_VERSION 2
 #define YY_FLEX_MINOR_VERSION 6
-#define YY_FLEX_SUBMINOR_VERSION 0
+#define YY_FLEX_SUBMINOR_VERSION 4
 #if YY_FLEX_SUBMINOR_VERSION > 0
 #define FLEX_BETA
+#endif
+
+#ifdef yy_create_buffer
+#define yysmiles__create_buffer_ALREADY_DEFINED
+#else
+#define yy_create_buffer yysmiles__create_buffer
+#endif
+
+#ifdef yy_delete_buffer
+#define yysmiles__delete_buffer_ALREADY_DEFINED
+#else
+#define yy_delete_buffer yysmiles__delete_buffer
+#endif
+
+#ifdef yy_scan_buffer
+#define yysmiles__scan_buffer_ALREADY_DEFINED
+#else
+#define yy_scan_buffer yysmiles__scan_buffer
+#endif
+
+#ifdef yy_scan_string
+#define yysmiles__scan_string_ALREADY_DEFINED
+#else
+#define yy_scan_string yysmiles__scan_string
+#endif
+
+#ifdef yy_scan_bytes
+#define yysmiles__scan_bytes_ALREADY_DEFINED
+#else
+#define yy_scan_bytes yysmiles__scan_bytes
+#endif
+
+#ifdef yy_init_buffer
+#define yysmiles__init_buffer_ALREADY_DEFINED
+#else
+#define yy_init_buffer yysmiles__init_buffer
+#endif
+
+#ifdef yy_flush_buffer
+#define yysmiles__flush_buffer_ALREADY_DEFINED
+#else
+#define yy_flush_buffer yysmiles__flush_buffer
+#endif
+
+#ifdef yy_load_buffer_state
+#define yysmiles__load_buffer_state_ALREADY_DEFINED
+#else
+#define yy_load_buffer_state yysmiles__load_buffer_state
+#endif
+
+#ifdef yy_switch_to_buffer
+#define yysmiles__switch_to_buffer_ALREADY_DEFINED
+#else
+#define yy_switch_to_buffer yysmiles__switch_to_buffer
+#endif
+
+#ifdef yypush_buffer_state
+#define yysmiles_push_buffer_state_ALREADY_DEFINED
+#else
+#define yypush_buffer_state yysmiles_push_buffer_state
+#endif
+
+#ifdef yypop_buffer_state
+#define yysmiles_pop_buffer_state_ALREADY_DEFINED
+#else
+#define yypop_buffer_state yysmiles_pop_buffer_state
+#endif
+
+#ifdef yyensure_buffer_stack
+#define yysmiles_ensure_buffer_stack_ALREADY_DEFINED
+#else
+#define yyensure_buffer_stack yysmiles_ensure_buffer_stack
+#endif
+
+#ifdef yylex
+#define yysmiles_lex_ALREADY_DEFINED
+#else
+#define yylex yysmiles_lex
+#endif
+
+#ifdef yyrestart
+#define yysmiles_restart_ALREADY_DEFINED
+#else
+#define yyrestart yysmiles_restart
+#endif
+
+#ifdef yylex_init
+#define yysmiles_lex_init_ALREADY_DEFINED
+#else
+#define yylex_init yysmiles_lex_init
+#endif
+
+#ifdef yylex_init_extra
+#define yysmiles_lex_init_extra_ALREADY_DEFINED
+#else
+#define yylex_init_extra yysmiles_lex_init_extra
+#endif
+
+#ifdef yylex_destroy
+#define yysmiles_lex_destroy_ALREADY_DEFINED
+#else
+#define yylex_destroy yysmiles_lex_destroy
+#endif
+
+#ifdef yyget_debug
+#define yysmiles_get_debug_ALREADY_DEFINED
+#else
+#define yyget_debug yysmiles_get_debug
+#endif
+
+#ifdef yyset_debug
+#define yysmiles_set_debug_ALREADY_DEFINED
+#else
+#define yyset_debug yysmiles_set_debug
+#endif
+
+#ifdef yyget_extra
+#define yysmiles_get_extra_ALREADY_DEFINED
+#else
+#define yyget_extra yysmiles_get_extra
+#endif
+
+#ifdef yyset_extra
+#define yysmiles_set_extra_ALREADY_DEFINED
+#else
+#define yyset_extra yysmiles_set_extra
+#endif
+
+#ifdef yyget_in
+#define yysmiles_get_in_ALREADY_DEFINED
+#else
+#define yyget_in yysmiles_get_in
+#endif
+
+#ifdef yyset_in
+#define yysmiles_set_in_ALREADY_DEFINED
+#else
+#define yyset_in yysmiles_set_in
+#endif
+
+#ifdef yyget_out
+#define yysmiles_get_out_ALREADY_DEFINED
+#else
+#define yyget_out yysmiles_get_out
+#endif
+
+#ifdef yyset_out
+#define yysmiles_set_out_ALREADY_DEFINED
+#else
+#define yyset_out yysmiles_set_out
+#endif
+
+#ifdef yyget_leng
+#define yysmiles_get_leng_ALREADY_DEFINED
+#else
+#define yyget_leng yysmiles_get_leng
+#endif
+
+#ifdef yyget_text
+#define yysmiles_get_text_ALREADY_DEFINED
+#else
+#define yyget_text yysmiles_get_text
+#endif
+
+#ifdef yyget_lineno
+#define yysmiles_get_lineno_ALREADY_DEFINED
+#else
+#define yyget_lineno yysmiles_get_lineno
+#endif
+
+#ifdef yyset_lineno
+#define yysmiles_set_lineno_ALREADY_DEFINED
+#else
+#define yyset_lineno yysmiles_set_lineno
+#endif
+
+#ifdef yyget_column
+#define yysmiles_get_column_ALREADY_DEFINED
+#else
+#define yyget_column yysmiles_get_column
+#endif
+
+#ifdef yyset_column
+#define yysmiles_set_column_ALREADY_DEFINED
+#else
+#define yyset_column yysmiles_set_column
+#endif
+
+#ifdef yywrap
+#define yysmiles_wrap_ALREADY_DEFINED
+#else
+#define yywrap yysmiles_wrap
+#endif
+
+#ifdef yyget_lval
+#define yysmiles_get_lval_ALREADY_DEFINED
+#else
+#define yyget_lval yysmiles_get_lval
+#endif
+
+#ifdef yyset_lval
+#define yysmiles_set_lval_ALREADY_DEFINED
+#else
+#define yyset_lval yysmiles_set_lval
+#endif
+
+#ifdef yyalloc
+#define yysmiles_alloc_ALREADY_DEFINED
+#else
+#define yyalloc yysmiles_alloc
+#endif
+
+#ifdef yyrealloc
+#define yysmiles_realloc_ALREADY_DEFINED
+#else
+#define yyrealloc yysmiles_realloc
+#endif
+
+#ifdef yyfree
+#define yysmiles_free_ALREADY_DEFINED
+#else
+#define yyfree yysmiles_free
 #endif
 
 /* First, we deal with  platform-specific or compiler-specific issues. */
@@ -84,40 +306,32 @@ typedef unsigned int flex_uint32_t;
 #define UINT32_MAX             (4294967295U)
 #endif
 
+#ifndef SIZE_MAX
+#define SIZE_MAX               (~(size_t)0)
+#endif
+
 #endif /* ! C99 */
 
 #endif /* ! FLEXINT_H */
 
-#ifdef __cplusplus
+/* begin standard C++ headers. */
 
-/* The "const" storage-class-modifier is valid. */
-#define YY_USE_CONST
-
-#else	/* ! __cplusplus */
-
-/* C99 requires __STDC__ to be defined as 1. */
-#if defined (__STDC__)
-
-#define YY_USE_CONST
-
-#endif	/* defined (__STDC__) */
-#endif	/* ! __cplusplus */
-
-#ifdef YY_USE_CONST
+/* TODO: this is always defined, so inline it */
 #define yyconst const
+
+#if defined(__GNUC__) && __GNUC__ >= 3
+#define yynoreturn __attribute__((__noreturn__))
 #else
-#define yyconst
+#define yynoreturn
 #endif
 
 /* Returned upon end-of-file. */
 #define YY_NULL 0
 
-/* Promotes a possibly negative, possibly signed char to an unsigned
- * integer for use as an array index.  If the signed char is negative,
- * we want to instead treat it as an 8-bit unsigned char, hence the
- * double cast.
+/* Promotes a possibly negative, possibly signed char to an
+ *   integer in range [0..255] for use as an array index.
  */
-#define YY_SC_TO_UI(c) ((unsigned int) (unsigned char) c)
+#define YY_SC_TO_UI(c) ((YY_CHAR) (c))
 
 /* An opaque pointer. */
 #ifndef YY_TYPEDEF_YY_SCANNER_T
@@ -141,20 +355,16 @@ typedef void* yyscan_t;
  * definition of BEGIN.
  */
 #define BEGIN yyg->yy_start = 1 + 2 *
-
 /* Translate the current start state into a value that can be later handed
  * to BEGIN to return to the state.  The YYSTATE alias is for lex
  * compatibility.
  */
 #define YY_START ((yyg->yy_start - 1) / 2)
 #define YYSTATE YY_START
-
 /* Action number for EOF rule of a given start state. */
 #define YY_STATE_EOF(state) (YY_END_OF_BUFFER + state + 1)
-
 /* Special action meaning "start processing a new file". */
-#define YY_NEW_FILE yysmiles_restart(yyin ,yyscanner )
-
+#define YY_NEW_FILE yyrestart( yyin , yyscanner )
 #define YY_END_OF_BUFFER_CHAR 0
 
 /* Size of default input buffer. */
@@ -187,7 +397,7 @@ typedef size_t yy_size_t;
 #define EOB_ACT_CONTINUE_SCAN 0
 #define EOB_ACT_END_OF_FILE 1
 #define EOB_ACT_LAST_MATCH 2
-
+    
     #define YY_LESS_LINENO(n)
     #define YY_LINENO_REWIND_TO(ptr)
     
@@ -204,7 +414,6 @@ typedef size_t yy_size_t;
 		YY_DO_BEFORE_ACTION; /* set up yytext again */ \
 		} \
 	while ( 0 )
-
 #define unput(c) yyunput( c, yyg->yytext_ptr , yyscanner )
 
 #ifndef YY_STRUCT_YY_BUFFER_STATE
@@ -219,7 +428,7 @@ struct yy_buffer_state
 	/* Size of input buffer in bytes, not including room for EOB
 	 * characters.
 	 */
-	yy_size_t yy_buf_size;
+	int yy_buf_size;
 
 	/* Number of characters read into yy_ch_buf, not including EOB
 	 * characters.
@@ -247,7 +456,7 @@ struct yy_buffer_state
 
     int yy_bs_lineno; /**< The line count. */
     int yy_bs_column; /**< The column count. */
-    
+
 	/* Whether to try to fill the input buffer when we reach the
 	 * end of it.
 	 */
@@ -264,7 +473,7 @@ struct yy_buffer_state
 	 * possible backing-up.
 	 *
 	 * When we actually see the EOF, we change the status to "new"
-	 * (via yysmiles_restart()), so that the user can continue scanning by
+	 * (via yyrestart()), so that the user can continue scanning by
 	 * just pointing yyin at a new input file.
 	 */
 #define YY_BUFFER_EOF_PENDING 2
@@ -281,87 +490,77 @@ struct yy_buffer_state
 #define YY_CURRENT_BUFFER ( yyg->yy_buffer_stack \
                           ? yyg->yy_buffer_stack[yyg->yy_buffer_stack_top] \
                           : NULL)
-
 /* Same as previous macro, but useful when we know that the buffer stack is not
  * NULL or when we need an lvalue. For internal use only.
  */
 #define YY_CURRENT_BUFFER_LVALUE yyg->yy_buffer_stack[yyg->yy_buffer_stack_top]
 
-void yysmiles_restart (FILE *input_file ,yyscan_t yyscanner );
-void yysmiles__switch_to_buffer (YY_BUFFER_STATE new_buffer ,yyscan_t yyscanner );
-YY_BUFFER_STATE yysmiles__create_buffer (FILE *file,int size ,yyscan_t yyscanner );
-void yysmiles__delete_buffer (YY_BUFFER_STATE b ,yyscan_t yyscanner );
-void yysmiles__flush_buffer (YY_BUFFER_STATE b ,yyscan_t yyscanner );
-void yysmiles_push_buffer_state (YY_BUFFER_STATE new_buffer ,yyscan_t yyscanner );
-void yysmiles_pop_buffer_state (yyscan_t yyscanner );
+void yyrestart ( FILE *input_file , yyscan_t yyscanner );
+void yy_switch_to_buffer ( YY_BUFFER_STATE new_buffer , yyscan_t yyscanner );
+YY_BUFFER_STATE yy_create_buffer ( FILE *file, int size , yyscan_t yyscanner );
+void yy_delete_buffer ( YY_BUFFER_STATE b , yyscan_t yyscanner );
+void yy_flush_buffer ( YY_BUFFER_STATE b , yyscan_t yyscanner );
+void yypush_buffer_state ( YY_BUFFER_STATE new_buffer , yyscan_t yyscanner );
+void yypop_buffer_state ( yyscan_t yyscanner );
 
-static void yysmiles_ensure_buffer_stack (yyscan_t yyscanner );
-static void yysmiles__load_buffer_state (yyscan_t yyscanner );
-static void yysmiles__init_buffer (YY_BUFFER_STATE b,FILE *file ,yyscan_t yyscanner );
+static void yyensure_buffer_stack ( yyscan_t yyscanner );
+static void yy_load_buffer_state ( yyscan_t yyscanner );
+static void yy_init_buffer ( YY_BUFFER_STATE b, FILE *file , yyscan_t yyscanner );
+#define YY_FLUSH_BUFFER yy_flush_buffer( YY_CURRENT_BUFFER , yyscanner)
 
-#define YY_FLUSH_BUFFER yysmiles__flush_buffer(YY_CURRENT_BUFFER ,yyscanner)
+YY_BUFFER_STATE yy_scan_buffer ( char *base, yy_size_t size , yyscan_t yyscanner );
+YY_BUFFER_STATE yy_scan_string ( const char *yy_str , yyscan_t yyscanner );
+YY_BUFFER_STATE yy_scan_bytes ( const char *bytes, int len , yyscan_t yyscanner );
 
-YY_BUFFER_STATE yysmiles__scan_buffer (char *base,yy_size_t size ,yyscan_t yyscanner );
-YY_BUFFER_STATE yysmiles__scan_string (yyconst char *yy_str ,yyscan_t yyscanner );
-YY_BUFFER_STATE yysmiles__scan_bytes (yyconst char *bytes,yy_size_t len ,yyscan_t yyscanner );
+void *yyalloc ( yy_size_t , yyscan_t yyscanner );
+void *yyrealloc ( void *, yy_size_t , yyscan_t yyscanner );
+void yyfree ( void * , yyscan_t yyscanner );
 
-void *yysmiles_alloc (yy_size_t ,yyscan_t yyscanner );
-void *yysmiles_realloc (void *,yy_size_t ,yyscan_t yyscanner );
-void yysmiles_free (void * ,yyscan_t yyscanner );
-
-#define yy_new_buffer yysmiles__create_buffer
-
+#define yy_new_buffer yy_create_buffer
 #define yy_set_interactive(is_interactive) \
 	{ \
 	if ( ! YY_CURRENT_BUFFER ){ \
-        yysmiles_ensure_buffer_stack (yyscanner); \
+        yyensure_buffer_stack (yyscanner); \
 		YY_CURRENT_BUFFER_LVALUE =    \
-            yysmiles__create_buffer(yyin,YY_BUF_SIZE ,yyscanner); \
+            yy_create_buffer( yyin, YY_BUF_SIZE , yyscanner); \
 	} \
 	YY_CURRENT_BUFFER_LVALUE->yy_is_interactive = is_interactive; \
 	}
-
 #define yy_set_bol(at_bol) \
 	{ \
 	if ( ! YY_CURRENT_BUFFER ){\
-        yysmiles_ensure_buffer_stack (yyscanner); \
+        yyensure_buffer_stack (yyscanner); \
 		YY_CURRENT_BUFFER_LVALUE =    \
-            yysmiles__create_buffer(yyin,YY_BUF_SIZE ,yyscanner); \
+            yy_create_buffer( yyin, YY_BUF_SIZE , yyscanner); \
 	} \
 	YY_CURRENT_BUFFER_LVALUE->yy_at_bol = at_bol; \
 	}
-
 #define YY_AT_BOL() (YY_CURRENT_BUFFER_LVALUE->yy_at_bol)
 
 /* Begin user sect3 */
 
 #define yysmiles_wrap(yyscanner) (/*CONSTCOND*/1)
 #define YY_SKIP_YYWRAP
-
-typedef unsigned char YY_CHAR;
+typedef flex_uint8_t YY_CHAR;
 
 typedef int yy_state_type;
 
 #define yytext_ptr yytext_r
 
-static yy_state_type yy_get_previous_state (yyscan_t yyscanner );
-static yy_state_type yy_try_NUL_trans (yy_state_type current_state  ,yyscan_t yyscanner);
-static int yy_get_next_buffer (yyscan_t yyscanner );
-#if defined(__GNUC__) && __GNUC__ >= 3
-__attribute__((__noreturn__))
-#endif
-static void yy_fatal_error (yyconst char msg[] ,yyscan_t yyscanner );
+static yy_state_type yy_get_previous_state ( yyscan_t yyscanner );
+static yy_state_type yy_try_NUL_trans ( yy_state_type current_state  , yyscan_t yyscanner);
+static int yy_get_next_buffer ( yyscan_t yyscanner );
+static void yynoreturn yy_fatal_error ( const char* msg , yyscan_t yyscanner );
 
 /* Done after the current pattern has been matched and before the
  * corresponding action - sets up yytext.
  */
 #define YY_DO_BEFORE_ACTION \
 	yyg->yytext_ptr = yy_bp; \
-	yyleng = (size_t) (yy_cp - yy_bp); \
+	yyleng = (int) (yy_cp - yy_bp); \
 	yyg->yy_hold_char = *yy_cp; \
 	*yy_cp = '\0'; \
 	yyg->yy_c_buf_p = yy_cp;
-
 #define YY_NUM_RULES 182
 #define YY_END_OF_BUFFER 183
 /* This struct is not used in this scanner,
@@ -371,7 +570,7 @@ struct yy_trans_info
 	flex_int32_t yy_verify;
 	flex_int32_t yy_nxt;
 	};
-static yyconst flex_int16_t yy_accept[247] =
+static const flex_int16_t yy_accept[247] =
     {   0,
         0,    0,    0,    0,  183,  181,  180,  163,  177,  172,
       173,  144,  171,  170,  176,  169,  178,  179,  164,  181,
@@ -402,7 +601,7 @@ static yyconst flex_int16_t yy_accept[247] =
       161,  147,  154,  149,  160,    0
     } ;
 
-static yyconst YY_CHAR yy_ec[256] =
+static const YY_CHAR yy_ec[256] =
     {   0,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    2,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
@@ -434,7 +633,7 @@ static yyconst YY_CHAR yy_ec[256] =
         1,    1,    1,    1,    1
     } ;
 
-static yyconst YY_CHAR yy_meta[72] =
+static const YY_CHAR yy_meta[72] =
     {   0,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
@@ -446,7 +645,7 @@ static yyconst YY_CHAR yy_meta[72] =
         1
     } ;
 
-static yyconst flex_uint16_t yy_base[247] =
+static const flex_int16_t yy_base[247] =
     {   0,
         0,    0,   68,    0,  272,  303,  303,  303,  303,  303,
       303,  303,  303,  246,  303,  303,  303,  303,  303,  245,
@@ -477,7 +676,7 @@ static yyconst flex_uint16_t yy_base[247] =
       303,  303,  303,  303,  303,  303
     } ;
 
-static yyconst flex_int16_t yy_def[247] =
+static const flex_int16_t yy_def[247] =
     {   0,
       246,    1,    1,    3,  246,  246,  246,  246,  246,  246,
       246,  246,  246,  246,  246,  246,  246,  246,  246,  246,
@@ -508,7 +707,7 @@ static yyconst flex_int16_t yy_def[247] =
       246,  246,  246,  246,  246,    0
     } ;
 
-static yyconst flex_uint16_t yy_nxt[375] =
+static const flex_int16_t yy_nxt[375] =
     {   0,
         6,    7,    6,    8,    9,    6,   10,   11,   12,   13,
        14,   15,   16,   17,   18,   19,   20,   21,    6,   22,
@@ -553,7 +752,7 @@ static yyconst flex_uint16_t yy_nxt[375] =
       246,  246,  246,  246
     } ;
 
-static yyconst flex_int16_t yy_chk[375] =
+static const flex_int16_t yy_chk[375] =
     {   0,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
@@ -689,8 +888,9 @@ size_t setup_smiles_string(const std::string &text,yyscan_t yyscanner){
   return start;
 
 }
+#line 892 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/lex.yysmiles.cpp"
 
-#line 689 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/lex.yysmiles.cpp"
+#line 894 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/lex.yysmiles.cpp"
 
 #define INITIAL 0
 #define IN_ATOM_STATE 1
@@ -721,7 +921,7 @@ struct yyguts_t
     YY_BUFFER_STATE * yy_buffer_stack; /**< Stack as an array. */
     char yy_hold_char;
     int yy_n_chars;
-    yy_size_t yyleng_r;
+    int yyleng_r;
     char *yy_c_buf_p;
     int yy_init;
     int yy_start;
@@ -743,52 +943,52 @@ struct yyguts_t
 
     }; /* end struct yyguts_t */
 
-static int yy_init_globals (yyscan_t yyscanner );
+static int yy_init_globals ( yyscan_t yyscanner );
 
     /* This must go here because YYSTYPE and YYLTYPE are included
      * from bison output in section 1.*/
     #    define yylval yyg->yylval_r
     
-int yysmiles_lex_init (yyscan_t* scanner);
+int yylex_init (yyscan_t* scanner);
 
-int yysmiles_lex_init_extra (YY_EXTRA_TYPE user_defined,yyscan_t* scanner);
+int yylex_init_extra ( YY_EXTRA_TYPE user_defined, yyscan_t* scanner);
 
 /* Accessor methods to globals.
    These are made visible to non-reentrant scanners for convenience. */
 
-int yysmiles_lex_destroy (yyscan_t yyscanner );
+int yylex_destroy ( yyscan_t yyscanner );
 
-int yysmiles_get_debug (yyscan_t yyscanner );
+int yyget_debug ( yyscan_t yyscanner );
 
-void yysmiles_set_debug (int debug_flag ,yyscan_t yyscanner );
+void yyset_debug ( int debug_flag , yyscan_t yyscanner );
 
-YY_EXTRA_TYPE yysmiles_get_extra (yyscan_t yyscanner );
+YY_EXTRA_TYPE yyget_extra ( yyscan_t yyscanner );
 
-void yysmiles_set_extra (YY_EXTRA_TYPE user_defined ,yyscan_t yyscanner );
+void yyset_extra ( YY_EXTRA_TYPE user_defined , yyscan_t yyscanner );
 
-FILE *yysmiles_get_in (yyscan_t yyscanner );
+FILE *yyget_in ( yyscan_t yyscanner );
 
-void yysmiles_set_in  (FILE * _in_str ,yyscan_t yyscanner );
+void yyset_in  ( FILE * _in_str , yyscan_t yyscanner );
 
-FILE *yysmiles_get_out (yyscan_t yyscanner );
+FILE *yyget_out ( yyscan_t yyscanner );
 
-void yysmiles_set_out  (FILE * _out_str ,yyscan_t yyscanner );
+void yyset_out  ( FILE * _out_str , yyscan_t yyscanner );
 
-yy_size_t yysmiles_get_leng (yyscan_t yyscanner );
+			int yyget_leng ( yyscan_t yyscanner );
 
-char *yysmiles_get_text (yyscan_t yyscanner );
+char *yyget_text ( yyscan_t yyscanner );
 
-int yysmiles_get_lineno (yyscan_t yyscanner );
+int yyget_lineno ( yyscan_t yyscanner );
 
-void yysmiles_set_lineno (int _line_number ,yyscan_t yyscanner );
+void yyset_lineno ( int _line_number , yyscan_t yyscanner );
 
-int yysmiles_get_column  (yyscan_t yyscanner );
+int yyget_column  ( yyscan_t yyscanner );
 
-void yysmiles_set_column (int _column_no ,yyscan_t yyscanner );
+void yyset_column ( int _column_no , yyscan_t yyscanner );
 
-YYSTYPE * yysmiles_get_lval (yyscan_t yyscanner );
+YYSTYPE * yyget_lval ( yyscan_t yyscanner );
 
-void yysmiles_set_lval (YYSTYPE * yylval_param ,yyscan_t yyscanner );
+void yyset_lval ( YYSTYPE * yylval_param , yyscan_t yyscanner );
 
 /* Macros after this point can all be overridden by user definitions in
  * section 1.
@@ -796,32 +996,31 @@ void yysmiles_set_lval (YYSTYPE * yylval_param ,yyscan_t yyscanner );
 
 #ifndef YY_SKIP_YYWRAP
 #ifdef __cplusplus
-extern "C" int yysmiles_wrap (yyscan_t yyscanner );
+extern "C" int yywrap ( yyscan_t yyscanner );
 #else
-extern int yysmiles_wrap (yyscan_t yyscanner );
+extern int yywrap ( yyscan_t yyscanner );
 #endif
 #endif
 
 #ifndef YY_NO_UNPUT
     
-    static void yyunput (int c,char *buf_ptr  ,yyscan_t yyscanner);
+    static void yyunput ( int c, char *buf_ptr  , yyscan_t yyscanner);
     
 #endif
 
 #ifndef yytext_ptr
-static void yy_flex_strncpy (char *,yyconst char *,int ,yyscan_t yyscanner);
+static void yy_flex_strncpy ( char *, const char *, int , yyscan_t yyscanner);
 #endif
 
 #ifdef YY_NEED_STRLEN
-static int yy_flex_strlen (yyconst char * ,yyscan_t yyscanner);
+static int yy_flex_strlen ( const char * , yyscan_t yyscanner);
 #endif
 
 #ifndef YY_NO_INPUT
-
 #ifdef __cplusplus
-static int yyinput (yyscan_t yyscanner );
+static int yyinput ( yyscan_t yyscanner );
 #else
-static int input (yyscan_t yyscanner );
+static int input ( yyscan_t yyscanner );
 #endif
 
 #endif
@@ -841,7 +1040,7 @@ static int input (yyscan_t yyscanner );
 /* This used to be an fputs(), but since the string might contain NUL's,
  * we now use fwrite().
  */
-#define ECHO do { if (fwrite( yytext, yyleng, 1, yyout )) {} } while (0)
+#define ECHO do { if (fwrite( yytext, (size_t) yyleng, 1, yyout )) {} } while (0)
 #endif
 
 /* Gets input and stuffs it into "buf".  number of characters read, or YY_NULL,
@@ -852,7 +1051,7 @@ static int input (yyscan_t yyscanner );
 	if ( YY_CURRENT_BUFFER_LVALUE->yy_is_interactive ) \
 		{ \
 		int c = '*'; \
-		size_t n; \
+		int n; \
 		for ( n = 0; n < max_size && \
 			     (c = getc( yyin )) != EOF && c != '\n'; ++n ) \
 			buf[n] = (char) c; \
@@ -865,7 +1064,7 @@ static int input (yyscan_t yyscanner );
 	else \
 		{ \
 		errno=0; \
-		while ( (result = fread(buf, 1, max_size, yyin))==0 && ferror(yyin)) \
+		while ( (result = (int) fread(buf, 1, (yy_size_t) max_size, yyin)) == 0 && ferror(yyin)) \
 			{ \
 			if( errno != EINTR) \
 				{ \
@@ -906,10 +1105,10 @@ static int input (yyscan_t yyscanner );
 #ifndef YY_DECL
 #define YY_DECL_IS_OURS 1
 
-extern int yysmiles_lex \
-               (YYSTYPE * yylval_param ,yyscan_t yyscanner);
+extern int yylex \
+               (YYSTYPE * yylval_param , yyscan_t yyscanner);
 
-#define YY_DECL int yysmiles_lex \
+#define YY_DECL int yylex \
                (YYSTYPE * yylval_param , yyscan_t yyscanner)
 #endif /* !YY_DECL */
 
@@ -957,19 +1156,29 @@ YY_DECL
 			yyout = stdout;
 
 		if ( ! YY_CURRENT_BUFFER ) {
-			yysmiles_ensure_buffer_stack (yyscanner);
+			yyensure_buffer_stack (yyscanner);
 			YY_CURRENT_BUFFER_LVALUE =
-				yysmiles__create_buffer(yyin,YY_BUF_SIZE ,yyscanner);
+				yy_create_buffer( yyin, YY_BUF_SIZE , yyscanner);
 		}
 
-		yysmiles__load_buffer_state(yyscanner );
+		yy_load_buffer_state( yyscanner );
 		}
 
 	{
-#line 86 "smiles.ll"
+#line 91 "smiles.ll"
 
 
-#line 968 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/lex.yysmiles.cpp"
+
+#line 95 "smiles.ll"
+  if (start_token)
+    {
+      int t = start_token;
+      start_token = 0;
+      return t;
+    }
+
+
+#line 1182 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/lex.yysmiles.cpp"
 
 	while ( /*CONSTCOND*/1 )		/* loops until end-of-file is reached */
 		{
@@ -997,9 +1206,9 @@ yy_match:
 				{
 				yy_current_state = (int) yy_def[yy_current_state];
 				if ( yy_current_state >= 247 )
-					yy_c = yy_meta[(unsigned int) yy_c];
+					yy_c = yy_meta[yy_c];
 				}
-			yy_current_state = yy_nxt[yy_base[yy_current_state] + (unsigned int) yy_c];
+			yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
 			++yy_cp;
 			}
 		while ( yy_base[yy_current_state] != 303 );
@@ -1027,663 +1236,663 @@ do_action:	/* This label is used only to access EOF actions. */
 			goto yy_find_action;
 
 case 1:
-#line 89 "smiles.ll"
+#line 104 "smiles.ll"
 case 2:
-#line 90 "smiles.ll"
+#line 105 "smiles.ll"
 case 3:
-#line 91 "smiles.ll"
+#line 106 "smiles.ll"
 case 4:
-#line 92 "smiles.ll"
+#line 107 "smiles.ll"
 case 5:
 YY_RULE_SETUP
-#line 92 "smiles.ll"
+#line 107 "smiles.ll"
 { return CHI_CLASS_TOKEN; }
 	YY_BREAK
 case 6:
 YY_RULE_SETUP
-#line 94 "smiles.ll"
+#line 109 "smiles.ll"
 { return AT_TOKEN; }
 	YY_BREAK
 case 7:
 YY_RULE_SETUP
-#line 97 "smiles.ll"
+#line 112 "smiles.ll"
 { yylval->atom = new Atom(2); return ATOM_TOKEN; }
 	YY_BREAK
 case 8:
 YY_RULE_SETUP
-#line 98 "smiles.ll"
+#line 113 "smiles.ll"
 { yylval->atom = new Atom(3); return ATOM_TOKEN; }
 	YY_BREAK
 case 9:
 YY_RULE_SETUP
-#line 99 "smiles.ll"
+#line 114 "smiles.ll"
 { yylval->atom = new Atom(4); return ATOM_TOKEN; }
 	YY_BREAK
 case 10:
 YY_RULE_SETUP
-#line 100 "smiles.ll"
+#line 115 "smiles.ll"
 { yylval->atom = new Atom(10); return ATOM_TOKEN; }
 	YY_BREAK
 case 11:
 YY_RULE_SETUP
-#line 101 "smiles.ll"
+#line 116 "smiles.ll"
 { yylval->atom = new Atom(11); return ATOM_TOKEN; }
 	YY_BREAK
 case 12:
 YY_RULE_SETUP
-#line 102 "smiles.ll"
+#line 117 "smiles.ll"
 { yylval->atom = new Atom(12); return ATOM_TOKEN; }
 	YY_BREAK
 case 13:
 YY_RULE_SETUP
-#line 103 "smiles.ll"
+#line 118 "smiles.ll"
 { yylval->atom = new Atom(13); return ATOM_TOKEN; }
 	YY_BREAK
 case 14:
 YY_RULE_SETUP
-#line 104 "smiles.ll"
+#line 119 "smiles.ll"
 { yylval->atom = new Atom(14); return ATOM_TOKEN; }
 	YY_BREAK
 case 15:
 YY_RULE_SETUP
-#line 105 "smiles.ll"
+#line 120 "smiles.ll"
 { yylval->atom = new Atom(18); return ATOM_TOKEN; }
 	YY_BREAK
 case 16:
 YY_RULE_SETUP
-#line 106 "smiles.ll"
+#line 121 "smiles.ll"
 { yylval->atom = new Atom(19); return ATOM_TOKEN; }
 	YY_BREAK
 case 17:
 YY_RULE_SETUP
-#line 107 "smiles.ll"
+#line 122 "smiles.ll"
 { yylval->atom = new Atom(20); return ATOM_TOKEN; }
 	YY_BREAK
 case 18:
 YY_RULE_SETUP
-#line 108 "smiles.ll"
+#line 123 "smiles.ll"
 { yylval->atom = new Atom(21); return ATOM_TOKEN; }
 	YY_BREAK
 case 19:
 YY_RULE_SETUP
-#line 109 "smiles.ll"
+#line 124 "smiles.ll"
 { yylval->atom = new Atom(22); return ATOM_TOKEN; }
 	YY_BREAK
 case 20:
 YY_RULE_SETUP
-#line 110 "smiles.ll"
+#line 125 "smiles.ll"
 { yylval->atom = new Atom(23); return ATOM_TOKEN; }
 	YY_BREAK
 case 21:
 YY_RULE_SETUP
-#line 111 "smiles.ll"
+#line 126 "smiles.ll"
 { yylval->atom = new Atom(24); return ATOM_TOKEN; }
 	YY_BREAK
 case 22:
 YY_RULE_SETUP
-#line 112 "smiles.ll"
+#line 127 "smiles.ll"
 { yylval->atom = new Atom(25); return ATOM_TOKEN; }
 	YY_BREAK
 case 23:
 YY_RULE_SETUP
-#line 113 "smiles.ll"
+#line 128 "smiles.ll"
 { yylval->atom = new Atom(26); return ATOM_TOKEN; }
 	YY_BREAK
 case 24:
 YY_RULE_SETUP
-#line 114 "smiles.ll"
+#line 129 "smiles.ll"
 { yylval->atom = new Atom(27); return ATOM_TOKEN; }
 	YY_BREAK
 case 25:
 YY_RULE_SETUP
-#line 115 "smiles.ll"
+#line 130 "smiles.ll"
 { yylval->atom = new Atom(28); return ATOM_TOKEN; }
 	YY_BREAK
 case 26:
 YY_RULE_SETUP
-#line 116 "smiles.ll"
+#line 131 "smiles.ll"
 { yylval->atom = new Atom(29); return ATOM_TOKEN; }
 	YY_BREAK
 case 27:
 YY_RULE_SETUP
-#line 117 "smiles.ll"
+#line 132 "smiles.ll"
 { yylval->atom = new Atom(30); return ATOM_TOKEN; }
 	YY_BREAK
 case 28:
 YY_RULE_SETUP
-#line 118 "smiles.ll"
+#line 133 "smiles.ll"
 { yylval->atom = new Atom(31); return ATOM_TOKEN; }
 	YY_BREAK
 case 29:
 YY_RULE_SETUP
-#line 119 "smiles.ll"
+#line 134 "smiles.ll"
 { yylval->atom = new Atom(32); return ATOM_TOKEN; }
 	YY_BREAK
 case 30:
 YY_RULE_SETUP
-#line 120 "smiles.ll"
+#line 135 "smiles.ll"
 { yylval->atom = new Atom(33); return ATOM_TOKEN; }
 	YY_BREAK
 case 31:
 YY_RULE_SETUP
-#line 121 "smiles.ll"
+#line 136 "smiles.ll"
 { yylval->atom = new Atom(34); return ATOM_TOKEN; }
 	YY_BREAK
 case 32:
 YY_RULE_SETUP
-#line 122 "smiles.ll"
+#line 137 "smiles.ll"
 { yylval->atom = new Atom(36); return ATOM_TOKEN; }
 	YY_BREAK
 case 33:
 YY_RULE_SETUP
-#line 123 "smiles.ll"
+#line 138 "smiles.ll"
 { yylval->atom = new Atom(37); return ATOM_TOKEN; }
 	YY_BREAK
 case 34:
 YY_RULE_SETUP
-#line 124 "smiles.ll"
+#line 139 "smiles.ll"
 { yylval->atom = new Atom(38); return ATOM_TOKEN; }
 	YY_BREAK
 case 35:
 YY_RULE_SETUP
-#line 125 "smiles.ll"
+#line 140 "smiles.ll"
 { yylval->atom = new Atom(39); return ATOM_TOKEN; }
 	YY_BREAK
 case 36:
 YY_RULE_SETUP
-#line 126 "smiles.ll"
+#line 141 "smiles.ll"
 { yylval->atom = new Atom(40); return ATOM_TOKEN; }
 	YY_BREAK
 case 37:
 YY_RULE_SETUP
-#line 127 "smiles.ll"
+#line 142 "smiles.ll"
 { yylval->atom = new Atom(41); return ATOM_TOKEN; }
 	YY_BREAK
 case 38:
 YY_RULE_SETUP
-#line 128 "smiles.ll"
+#line 143 "smiles.ll"
 { yylval->atom = new Atom(42); return ATOM_TOKEN; }
 	YY_BREAK
 case 39:
 YY_RULE_SETUP
-#line 129 "smiles.ll"
+#line 144 "smiles.ll"
 { yylval->atom = new Atom(43); return ATOM_TOKEN; }
 	YY_BREAK
 case 40:
 YY_RULE_SETUP
-#line 130 "smiles.ll"
+#line 145 "smiles.ll"
 { yylval->atom = new Atom(44); return ATOM_TOKEN; }
 	YY_BREAK
 case 41:
 YY_RULE_SETUP
-#line 131 "smiles.ll"
+#line 146 "smiles.ll"
 { yylval->atom = new Atom(45); return ATOM_TOKEN; }
 	YY_BREAK
 case 42:
 YY_RULE_SETUP
-#line 132 "smiles.ll"
+#line 147 "smiles.ll"
 { yylval->atom = new Atom(46); return ATOM_TOKEN; }
 	YY_BREAK
 case 43:
 YY_RULE_SETUP
-#line 133 "smiles.ll"
+#line 148 "smiles.ll"
 { yylval->atom = new Atom(47); return ATOM_TOKEN; }
 	YY_BREAK
 case 44:
 YY_RULE_SETUP
-#line 134 "smiles.ll"
+#line 149 "smiles.ll"
 { yylval->atom = new Atom(48); return ATOM_TOKEN; }
 	YY_BREAK
 case 45:
 YY_RULE_SETUP
-#line 135 "smiles.ll"
+#line 150 "smiles.ll"
 { yylval->atom = new Atom(49); return ATOM_TOKEN; }
 	YY_BREAK
 case 46:
 YY_RULE_SETUP
-#line 136 "smiles.ll"
+#line 151 "smiles.ll"
 { yylval->atom = new Atom(50); return ATOM_TOKEN; }
 	YY_BREAK
 case 47:
 YY_RULE_SETUP
-#line 137 "smiles.ll"
+#line 152 "smiles.ll"
 { yylval->atom = new Atom(51); return ATOM_TOKEN; }
 	YY_BREAK
 case 48:
 YY_RULE_SETUP
-#line 138 "smiles.ll"
+#line 153 "smiles.ll"
 { yylval->atom = new Atom(52); return ATOM_TOKEN; }
 	YY_BREAK
 case 49:
 YY_RULE_SETUP
-#line 139 "smiles.ll"
+#line 154 "smiles.ll"
 { yylval->atom = new Atom(54); return ATOM_TOKEN; }
 	YY_BREAK
 case 50:
 YY_RULE_SETUP
-#line 140 "smiles.ll"
+#line 155 "smiles.ll"
 { yylval->atom = new Atom(55); return ATOM_TOKEN; }
 	YY_BREAK
 case 51:
 YY_RULE_SETUP
-#line 141 "smiles.ll"
+#line 156 "smiles.ll"
 { yylval->atom = new Atom(56); return ATOM_TOKEN; }
 	YY_BREAK
 case 52:
 YY_RULE_SETUP
-#line 142 "smiles.ll"
+#line 157 "smiles.ll"
 { yylval->atom = new Atom(57); return ATOM_TOKEN; }
 	YY_BREAK
 case 53:
 YY_RULE_SETUP
-#line 143 "smiles.ll"
+#line 158 "smiles.ll"
 { yylval->atom = new Atom(58); return ATOM_TOKEN; }
 	YY_BREAK
 case 54:
 YY_RULE_SETUP
-#line 144 "smiles.ll"
+#line 159 "smiles.ll"
 { yylval->atom = new Atom(59); return ATOM_TOKEN; }
 	YY_BREAK
 case 55:
 YY_RULE_SETUP
-#line 145 "smiles.ll"
+#line 160 "smiles.ll"
 { yylval->atom = new Atom(60); return ATOM_TOKEN; }
 	YY_BREAK
 case 56:
 YY_RULE_SETUP
-#line 146 "smiles.ll"
+#line 161 "smiles.ll"
 { yylval->atom = new Atom(61); return ATOM_TOKEN; }
 	YY_BREAK
 case 57:
 YY_RULE_SETUP
-#line 147 "smiles.ll"
+#line 162 "smiles.ll"
 { yylval->atom = new Atom(62); return ATOM_TOKEN; }
 	YY_BREAK
 case 58:
 YY_RULE_SETUP
-#line 148 "smiles.ll"
+#line 163 "smiles.ll"
 { yylval->atom = new Atom(63); return ATOM_TOKEN; }
 	YY_BREAK
 case 59:
 YY_RULE_SETUP
-#line 149 "smiles.ll"
+#line 164 "smiles.ll"
 { yylval->atom = new Atom(64); return ATOM_TOKEN; }
 	YY_BREAK
 case 60:
 YY_RULE_SETUP
-#line 150 "smiles.ll"
+#line 165 "smiles.ll"
 { yylval->atom = new Atom(65); return ATOM_TOKEN; }
 	YY_BREAK
 case 61:
 YY_RULE_SETUP
-#line 151 "smiles.ll"
+#line 166 "smiles.ll"
 { yylval->atom = new Atom(66); return ATOM_TOKEN; }
 	YY_BREAK
 case 62:
 YY_RULE_SETUP
-#line 152 "smiles.ll"
+#line 167 "smiles.ll"
 { yylval->atom = new Atom(67); return ATOM_TOKEN; }
 	YY_BREAK
 case 63:
 YY_RULE_SETUP
-#line 153 "smiles.ll"
+#line 168 "smiles.ll"
 { yylval->atom = new Atom(68); return ATOM_TOKEN; }
 	YY_BREAK
 case 64:
 YY_RULE_SETUP
-#line 154 "smiles.ll"
+#line 169 "smiles.ll"
 { yylval->atom = new Atom(69); return ATOM_TOKEN; }
 	YY_BREAK
 case 65:
 YY_RULE_SETUP
-#line 155 "smiles.ll"
+#line 170 "smiles.ll"
 { yylval->atom = new Atom(70); return ATOM_TOKEN; }
 	YY_BREAK
 case 66:
 YY_RULE_SETUP
-#line 156 "smiles.ll"
+#line 171 "smiles.ll"
 { yylval->atom = new Atom(71); return ATOM_TOKEN; }
 	YY_BREAK
 case 67:
 YY_RULE_SETUP
-#line 157 "smiles.ll"
+#line 172 "smiles.ll"
 { yylval->atom = new Atom(72); return ATOM_TOKEN; }
 	YY_BREAK
 case 68:
 YY_RULE_SETUP
-#line 158 "smiles.ll"
+#line 173 "smiles.ll"
 { yylval->atom = new Atom(73); return ATOM_TOKEN; }
 	YY_BREAK
 case 69:
 YY_RULE_SETUP
-#line 159 "smiles.ll"
+#line 174 "smiles.ll"
 { yylval->atom = new Atom(74); return ATOM_TOKEN; }
 	YY_BREAK
 case 70:
 YY_RULE_SETUP
-#line 160 "smiles.ll"
+#line 175 "smiles.ll"
 { yylval->atom = new Atom(75); return ATOM_TOKEN; }
 	YY_BREAK
 case 71:
 YY_RULE_SETUP
-#line 161 "smiles.ll"
+#line 176 "smiles.ll"
 { yylval->atom = new Atom(76); return ATOM_TOKEN; }
 	YY_BREAK
 case 72:
 YY_RULE_SETUP
-#line 162 "smiles.ll"
+#line 177 "smiles.ll"
 { yylval->atom = new Atom(77); return ATOM_TOKEN; }
 	YY_BREAK
 case 73:
 YY_RULE_SETUP
-#line 163 "smiles.ll"
+#line 178 "smiles.ll"
 { yylval->atom = new Atom(78); return ATOM_TOKEN; }
 	YY_BREAK
 case 74:
 YY_RULE_SETUP
-#line 164 "smiles.ll"
+#line 179 "smiles.ll"
 { yylval->atom = new Atom(79); return ATOM_TOKEN; }
 	YY_BREAK
 case 75:
 YY_RULE_SETUP
-#line 165 "smiles.ll"
+#line 180 "smiles.ll"
 { yylval->atom = new Atom(80); return ATOM_TOKEN; }
 	YY_BREAK
 case 76:
 YY_RULE_SETUP
-#line 166 "smiles.ll"
+#line 181 "smiles.ll"
 { yylval->atom = new Atom(81); return ATOM_TOKEN; }
 	YY_BREAK
 case 77:
 YY_RULE_SETUP
-#line 167 "smiles.ll"
+#line 182 "smiles.ll"
 { yylval->atom = new Atom(82); return ATOM_TOKEN; }
 	YY_BREAK
 case 78:
 YY_RULE_SETUP
-#line 168 "smiles.ll"
+#line 183 "smiles.ll"
 { yylval->atom = new Atom(83); return ATOM_TOKEN; }
 	YY_BREAK
 case 79:
 YY_RULE_SETUP
-#line 169 "smiles.ll"
+#line 184 "smiles.ll"
 { yylval->atom = new Atom(84); return ATOM_TOKEN; }
 	YY_BREAK
 case 80:
 YY_RULE_SETUP
-#line 170 "smiles.ll"
+#line 185 "smiles.ll"
 { yylval->atom = new Atom(85); return ATOM_TOKEN; }
 	YY_BREAK
 case 81:
 YY_RULE_SETUP
-#line 171 "smiles.ll"
+#line 186 "smiles.ll"
 { yylval->atom = new Atom(86); return ATOM_TOKEN; }
 	YY_BREAK
 case 82:
 YY_RULE_SETUP
-#line 172 "smiles.ll"
+#line 187 "smiles.ll"
 { yylval->atom = new Atom(87); return ATOM_TOKEN; }
 	YY_BREAK
 case 83:
 YY_RULE_SETUP
-#line 173 "smiles.ll"
+#line 188 "smiles.ll"
 { yylval->atom = new Atom(88); return ATOM_TOKEN; }
 	YY_BREAK
 case 84:
 YY_RULE_SETUP
-#line 174 "smiles.ll"
+#line 189 "smiles.ll"
 { yylval->atom = new Atom(89); return ATOM_TOKEN; }
 	YY_BREAK
 case 85:
 YY_RULE_SETUP
-#line 175 "smiles.ll"
+#line 190 "smiles.ll"
 { yylval->atom = new Atom(90); return ATOM_TOKEN; }
 	YY_BREAK
 case 86:
 YY_RULE_SETUP
-#line 176 "smiles.ll"
+#line 191 "smiles.ll"
 { yylval->atom = new Atom(91); return ATOM_TOKEN; }
 	YY_BREAK
 case 87:
 YY_RULE_SETUP
-#line 177 "smiles.ll"
+#line 192 "smiles.ll"
 { yylval->atom = new Atom(92); return ATOM_TOKEN; }
 	YY_BREAK
 case 88:
 YY_RULE_SETUP
-#line 178 "smiles.ll"
+#line 193 "smiles.ll"
 { yylval->atom = new Atom(93); return ATOM_TOKEN; }
 	YY_BREAK
 case 89:
 YY_RULE_SETUP
-#line 179 "smiles.ll"
+#line 194 "smiles.ll"
 { yylval->atom = new Atom(94); return ATOM_TOKEN; }
 	YY_BREAK
 case 90:
 YY_RULE_SETUP
-#line 180 "smiles.ll"
+#line 195 "smiles.ll"
 { yylval->atom = new Atom(95); return ATOM_TOKEN; }
 	YY_BREAK
 case 91:
 YY_RULE_SETUP
-#line 181 "smiles.ll"
+#line 196 "smiles.ll"
 { yylval->atom = new Atom(96); return ATOM_TOKEN; }
 	YY_BREAK
 case 92:
 YY_RULE_SETUP
-#line 182 "smiles.ll"
+#line 197 "smiles.ll"
 { yylval->atom = new Atom(97); return ATOM_TOKEN; }
 	YY_BREAK
 case 93:
 YY_RULE_SETUP
-#line 183 "smiles.ll"
+#line 198 "smiles.ll"
 { yylval->atom = new Atom(98); return ATOM_TOKEN; }
 	YY_BREAK
 case 94:
 YY_RULE_SETUP
-#line 184 "smiles.ll"
+#line 199 "smiles.ll"
 { yylval->atom = new Atom(99); return ATOM_TOKEN; }
 	YY_BREAK
 case 95:
 YY_RULE_SETUP
-#line 185 "smiles.ll"
+#line 200 "smiles.ll"
 { yylval->atom = new Atom(100); return ATOM_TOKEN; }
 	YY_BREAK
 case 96:
 YY_RULE_SETUP
-#line 186 "smiles.ll"
+#line 201 "smiles.ll"
 { yylval->atom = new Atom(101); return ATOM_TOKEN; }
 	YY_BREAK
 case 97:
 YY_RULE_SETUP
-#line 187 "smiles.ll"
+#line 202 "smiles.ll"
 { yylval->atom = new Atom(102); return ATOM_TOKEN; }
 	YY_BREAK
 case 98:
 YY_RULE_SETUP
-#line 188 "smiles.ll"
+#line 203 "smiles.ll"
 { yylval->atom = new Atom(103); return ATOM_TOKEN; }
 	YY_BREAK
 case 99:
 YY_RULE_SETUP
-#line 189 "smiles.ll"
+#line 204 "smiles.ll"
 { yylval->atom = new Atom(104); return ATOM_TOKEN; }
 	YY_BREAK
 case 100:
 YY_RULE_SETUP
-#line 190 "smiles.ll"
+#line 205 "smiles.ll"
 { yylval->atom = new Atom(105); return ATOM_TOKEN; }
 	YY_BREAK
 case 101:
 YY_RULE_SETUP
-#line 191 "smiles.ll"
+#line 206 "smiles.ll"
 { yylval->atom = new Atom(106); return ATOM_TOKEN; }
 	YY_BREAK
 case 102:
 YY_RULE_SETUP
-#line 192 "smiles.ll"
+#line 207 "smiles.ll"
 { yylval->atom = new Atom(107); return ATOM_TOKEN; }
 	YY_BREAK
 case 103:
 YY_RULE_SETUP
-#line 193 "smiles.ll"
+#line 208 "smiles.ll"
 { yylval->atom = new Atom(108); return ATOM_TOKEN; }
 	YY_BREAK
 case 104:
 YY_RULE_SETUP
-#line 194 "smiles.ll"
+#line 209 "smiles.ll"
 { yylval->atom = new Atom(109); return ATOM_TOKEN; }
 	YY_BREAK
 case 105:
 YY_RULE_SETUP
-#line 195 "smiles.ll"
+#line 210 "smiles.ll"
 { yylval->atom = new Atom(110); return ATOM_TOKEN; }
 	YY_BREAK
 case 106:
 YY_RULE_SETUP
-#line 196 "smiles.ll"
+#line 211 "smiles.ll"
 { yylval->atom = new Atom(111); return ATOM_TOKEN; }
 	YY_BREAK
 case 107:
 YY_RULE_SETUP
-#line 197 "smiles.ll"
+#line 212 "smiles.ll"
 { yylval->atom = new Atom(112); return ATOM_TOKEN; }
 	YY_BREAK
 case 108:
 YY_RULE_SETUP
-#line 198 "smiles.ll"
+#line 213 "smiles.ll"
 { yylval->atom = new Atom(113); return ATOM_TOKEN; }
 	YY_BREAK
 case 109:
 YY_RULE_SETUP
-#line 199 "smiles.ll"
+#line 214 "smiles.ll"
 { yylval->atom = new Atom(114); return ATOM_TOKEN; }
 	YY_BREAK
 case 110:
 YY_RULE_SETUP
-#line 200 "smiles.ll"
+#line 215 "smiles.ll"
 { yylval->atom = new Atom(115); return ATOM_TOKEN; }
 	YY_BREAK
 case 111:
 YY_RULE_SETUP
-#line 201 "smiles.ll"
+#line 216 "smiles.ll"
 { yylval->atom = new Atom(116); return ATOM_TOKEN; }
 	YY_BREAK
 case 112:
 YY_RULE_SETUP
-#line 202 "smiles.ll"
+#line 217 "smiles.ll"
 { yylval->atom = new Atom(117); return ATOM_TOKEN; }
 	YY_BREAK
 case 113:
 YY_RULE_SETUP
-#line 203 "smiles.ll"
+#line 218 "smiles.ll"
 { yylval->atom = new Atom(118); return ATOM_TOKEN; }
 	YY_BREAK
 case 114:
 YY_RULE_SETUP
-#line 205 "smiles.ll"
+#line 220 "smiles.ll"
 { yylval->atom = new Atom(110); return ATOM_TOKEN; }
 	YY_BREAK
 case 115:
 YY_RULE_SETUP
-#line 206 "smiles.ll"
+#line 221 "smiles.ll"
 { yylval->atom = new Atom(111); return ATOM_TOKEN; }
 	YY_BREAK
 case 116:
 YY_RULE_SETUP
-#line 207 "smiles.ll"
+#line 222 "smiles.ll"
 { yylval->atom = new Atom(112); return ATOM_TOKEN; }
 	YY_BREAK
 case 117:
 YY_RULE_SETUP
-#line 208 "smiles.ll"
+#line 223 "smiles.ll"
 { yylval->atom = new Atom(113); return ATOM_TOKEN; }
 	YY_BREAK
 case 118:
 YY_RULE_SETUP
-#line 209 "smiles.ll"
+#line 224 "smiles.ll"
 { yylval->atom = new Atom(114); return ATOM_TOKEN; }
 	YY_BREAK
 case 119:
 YY_RULE_SETUP
-#line 210 "smiles.ll"
+#line 225 "smiles.ll"
 { yylval->atom = new Atom(115); return ATOM_TOKEN; }
 	YY_BREAK
 case 120:
 YY_RULE_SETUP
-#line 211 "smiles.ll"
+#line 226 "smiles.ll"
 { yylval->atom = new Atom(116); return ATOM_TOKEN; }
 	YY_BREAK
 case 121:
 YY_RULE_SETUP
-#line 212 "smiles.ll"
+#line 227 "smiles.ll"
 { yylval->atom = new Atom(117); return ATOM_TOKEN; }
 	YY_BREAK
 case 122:
 YY_RULE_SETUP
-#line 213 "smiles.ll"
+#line 228 "smiles.ll"
 { yylval->atom = new Atom(118); return ATOM_TOKEN; }
 	YY_BREAK
 case 123:
 YY_RULE_SETUP
-#line 215 "smiles.ll"
+#line 230 "smiles.ll"
 { yylval->atom = new Atom(5);return ORGANIC_ATOM_TOKEN; }
 	YY_BREAK
 case 124:
 YY_RULE_SETUP
-#line 216 "smiles.ll"
+#line 231 "smiles.ll"
 { yylval->atom = new Atom(6);return ORGANIC_ATOM_TOKEN; }
 	YY_BREAK
 case 125:
 YY_RULE_SETUP
-#line 217 "smiles.ll"
+#line 232 "smiles.ll"
 { yylval->atom = new Atom(7);return ORGANIC_ATOM_TOKEN; }
 	YY_BREAK
 case 126:
 YY_RULE_SETUP
-#line 218 "smiles.ll"
+#line 233 "smiles.ll"
 { yylval->atom = new Atom(8);return ORGANIC_ATOM_TOKEN; }
 	YY_BREAK
 case 127:
 YY_RULE_SETUP
-#line 219 "smiles.ll"
+#line 234 "smiles.ll"
 { yylval->atom = new Atom(15);return ORGANIC_ATOM_TOKEN; }
 	YY_BREAK
 case 128:
 YY_RULE_SETUP
-#line 220 "smiles.ll"
+#line 235 "smiles.ll"
 { yylval->atom = new Atom(16);return ORGANIC_ATOM_TOKEN; }
 	YY_BREAK
 case 129:
 YY_RULE_SETUP
-#line 221 "smiles.ll"
+#line 236 "smiles.ll"
 { yylval->atom = new Atom(9);return ORGANIC_ATOM_TOKEN; }
 	YY_BREAK
 case 130:
 YY_RULE_SETUP
-#line 222 "smiles.ll"
+#line 237 "smiles.ll"
 { yylval->atom = new Atom(17);return ORGANIC_ATOM_TOKEN; }
 	YY_BREAK
 case 131:
 YY_RULE_SETUP
-#line 223 "smiles.ll"
+#line 238 "smiles.ll"
 { yylval->atom = new Atom(35);return ORGANIC_ATOM_TOKEN; }
 	YY_BREAK
 case 132:
 YY_RULE_SETUP
-#line 224 "smiles.ll"
+#line 239 "smiles.ll"
 { yylval->atom = new Atom(53);return ORGANIC_ATOM_TOKEN; }
 	YY_BREAK
 case 133:
 YY_RULE_SETUP
-#line 226 "smiles.ll"
+#line 241 "smiles.ll"
 {
 				return H_TOKEN;
 			}
 	YY_BREAK
 case 134:
 YY_RULE_SETUP
-#line 230 "smiles.ll"
+#line 245 "smiles.ll"
 {	yylval->atom = new Atom ( 5 );
 			yylval->atom->setIsAromatic(true);
 				return AROMATIC_ATOM_TOKEN;
@@ -1691,7 +1900,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 135:
 YY_RULE_SETUP
-#line 234 "smiles.ll"
+#line 249 "smiles.ll"
 {	yylval->atom = new Atom ( 6 );
 			yylval->atom->setIsAromatic(true);
 				return AROMATIC_ATOM_TOKEN;
@@ -1699,7 +1908,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 136:
 YY_RULE_SETUP
-#line 238 "smiles.ll"
+#line 253 "smiles.ll"
 {	yylval->atom = new Atom( 7 );
 			yylval->atom->setIsAromatic(true);
 				return AROMATIC_ATOM_TOKEN;
@@ -1707,7 +1916,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 137:
 YY_RULE_SETUP
-#line 242 "smiles.ll"
+#line 257 "smiles.ll"
 {	yylval->atom = new Atom( 8 );
 			yylval->atom->setIsAromatic(true);
 				return AROMATIC_ATOM_TOKEN;
@@ -1715,7 +1924,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 138:
 YY_RULE_SETUP
-#line 246 "smiles.ll"
+#line 261 "smiles.ll"
 {	yylval->atom = new Atom( 15 );
 			yylval->atom->setIsAromatic(true);
 				return AROMATIC_ATOM_TOKEN;
@@ -1723,7 +1932,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 139:
 YY_RULE_SETUP
-#line 250 "smiles.ll"
+#line 265 "smiles.ll"
 {	yylval->atom = new Atom( 16 );
 			yylval->atom->setIsAromatic(true);
 				return AROMATIC_ATOM_TOKEN;
@@ -1731,7 +1940,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 140:
 YY_RULE_SETUP
-#line 255 "smiles.ll"
+#line 270 "smiles.ll"
 {	yylval->atom = new Atom( 14 );
 			yylval->atom->setIsAromatic(true);
 				return AROMATIC_ATOM_TOKEN;
@@ -1739,7 +1948,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 141:
 YY_RULE_SETUP
-#line 259 "smiles.ll"
+#line 274 "smiles.ll"
 {	yylval->atom = new Atom( 33 );
 			yylval->atom->setIsAromatic(true);
 				return AROMATIC_ATOM_TOKEN;
@@ -1747,7 +1956,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 142:
 YY_RULE_SETUP
-#line 263 "smiles.ll"
+#line 278 "smiles.ll"
 {	yylval->atom = new Atom( 34 );
 			yylval->atom->setIsAromatic(true);
 				return AROMATIC_ATOM_TOKEN;
@@ -1755,7 +1964,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 143:
 YY_RULE_SETUP
-#line 267 "smiles.ll"
+#line 282 "smiles.ll"
 {	yylval->atom = new Atom( 52 );
 			yylval->atom->setIsAromatic(true);
 				return AROMATIC_ATOM_TOKEN;
@@ -1763,7 +1972,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 144:
 YY_RULE_SETUP
-#line 272 "smiles.ll"
+#line 287 "smiles.ll"
 {   yylval->atom = new Atom( 0 );
 		            yylval->atom->setProp(common_properties::dummyLabel,
                                                         std::string("*"));
@@ -1774,12 +1983,12 @@ YY_RULE_SETUP
 	YY_BREAK
 case 145:
 YY_RULE_SETUP
-#line 280 "smiles.ll"
+#line 295 "smiles.ll"
 { return COLON_TOKEN; }
 	YY_BREAK
 case 146:
 YY_RULE_SETUP
-#line 282 "smiles.ll"
+#line 297 "smiles.ll"
 { return HASH_TOKEN; }
 	YY_BREAK
 
@@ -1788,203 +1997,203 @@ YY_RULE_SETUP
 
 case 147:
 YY_RULE_SETUP
-#line 289 "smiles.ll"
+#line 304 "smiles.ll"
 { yylval->atom = new Atom(104); return ATOM_TOKEN; }
 	YY_BREAK
 case 148:
 YY_RULE_SETUP
-#line 290 "smiles.ll"
+#line 305 "smiles.ll"
 { yylval->atom = new Atom(105); return ATOM_TOKEN; }
 	YY_BREAK
 case 149:
 YY_RULE_SETUP
-#line 291 "smiles.ll"
+#line 306 "smiles.ll"
 { yylval->atom = new Atom(106); return ATOM_TOKEN; }
 	YY_BREAK
 case 150:
 YY_RULE_SETUP
-#line 292 "smiles.ll"
+#line 307 "smiles.ll"
 { yylval->atom = new Atom(107); return ATOM_TOKEN; }
 	YY_BREAK
 case 151:
 YY_RULE_SETUP
-#line 293 "smiles.ll"
+#line 308 "smiles.ll"
 { yylval->atom = new Atom(108); return ATOM_TOKEN; }
 	YY_BREAK
 case 152:
 YY_RULE_SETUP
-#line 294 "smiles.ll"
+#line 309 "smiles.ll"
 { yylval->atom = new Atom(109); return ATOM_TOKEN; }
 	YY_BREAK
 case 153:
 YY_RULE_SETUP
-#line 295 "smiles.ll"
+#line 310 "smiles.ll"
 { yylval->atom = new Atom(110); return ATOM_TOKEN; }
 	YY_BREAK
 case 154:
 YY_RULE_SETUP
-#line 296 "smiles.ll"
+#line 311 "smiles.ll"
 { yylval->atom = new Atom(111); return ATOM_TOKEN; }
 	YY_BREAK
 case 155:
 YY_RULE_SETUP
-#line 297 "smiles.ll"
+#line 312 "smiles.ll"
 { yylval->atom = new Atom(112); return ATOM_TOKEN; }
 	YY_BREAK
 case 156:
 YY_RULE_SETUP
-#line 298 "smiles.ll"
+#line 313 "smiles.ll"
 { yylval->atom = new Atom(113); return ATOM_TOKEN; }
 	YY_BREAK
 case 157:
 YY_RULE_SETUP
-#line 299 "smiles.ll"
+#line 314 "smiles.ll"
 { yylval->atom = new Atom(114); return ATOM_TOKEN; }
 	YY_BREAK
 case 158:
 YY_RULE_SETUP
-#line 300 "smiles.ll"
+#line 315 "smiles.ll"
 { yylval->atom = new Atom(115); return ATOM_TOKEN; }
 	YY_BREAK
 case 159:
 YY_RULE_SETUP
-#line 301 "smiles.ll"
+#line 316 "smiles.ll"
 { yylval->atom = new Atom(116); return ATOM_TOKEN; }
 	YY_BREAK
 case 160:
 YY_RULE_SETUP
-#line 302 "smiles.ll"
+#line 317 "smiles.ll"
 { yylval->atom = new Atom(117); return ATOM_TOKEN; }
 	YY_BREAK
 case 161:
 YY_RULE_SETUP
-#line 303 "smiles.ll"
+#line 318 "smiles.ll"
 { yylval->atom = new Atom(118); return ATOM_TOKEN; }
 	YY_BREAK
 case 162:
 YY_RULE_SETUP
-#line 305 "smiles.ll"
+#line 320 "smiles.ll"
 { yylval->bond = new Bond(Bond::DOUBLE);
 	  return BOND_TOKEN; }
 	YY_BREAK
 case 163:
 YY_RULE_SETUP
-#line 307 "smiles.ll"
+#line 322 "smiles.ll"
 { yylval->bond = new Bond(Bond::TRIPLE);
 	  return BOND_TOKEN; }
 	YY_BREAK
 case 164:
 YY_RULE_SETUP
-#line 309 "smiles.ll"
+#line 324 "smiles.ll"
 { yylval->bond = new Bond(Bond::AROMATIC);
 	  yylval->bond->setIsAromatic(true);
 	  return BOND_TOKEN; }
 	YY_BREAK
 case 165:
 YY_RULE_SETUP
-#line 312 "smiles.ll"
+#line 327 "smiles.ll"
 { yylval->bond = new Bond(Bond::DATIVER);
 	  return BOND_TOKEN; }
 	YY_BREAK
 case 166:
 YY_RULE_SETUP
-#line 314 "smiles.ll"
+#line 329 "smiles.ll"
 { yylval->bond = new Bond(Bond::DATIVEL);
 	  return BOND_TOKEN; }
 	YY_BREAK
 case 167:
 YY_RULE_SETUP
-#line 316 "smiles.ll"
+#line 331 "smiles.ll"
 { yylval->bond = new QueryBond();
 	  yylval->bond->setQuery(makeBondNullQuery());
 	  return BOND_TOKEN;  }
 	YY_BREAK
 case 168:
 YY_RULE_SETUP
-#line 320 "smiles.ll"
+#line 335 "smiles.ll"
 { yylval->bond = new Bond(Bond::SINGLE);
 	yylval->bond->setBondDir(Bond::ENDDOWNRIGHT);
 	return BOND_TOKEN;  }
 	YY_BREAK
 case 169:
 YY_RULE_SETUP
-#line 324 "smiles.ll"
+#line 339 "smiles.ll"
 { yylval->bond = new Bond(Bond::SINGLE);
 	yylval->bond->setBondDir(Bond::ENDUPRIGHT);
 	return BOND_TOKEN;  }
 	YY_BREAK
 case 170:
 YY_RULE_SETUP
-#line 328 "smiles.ll"
+#line 343 "smiles.ll"
 { return MINUS_TOKEN; }
 	YY_BREAK
 case 171:
 YY_RULE_SETUP
-#line 330 "smiles.ll"
+#line 345 "smiles.ll"
 { return PLUS_TOKEN; }
 	YY_BREAK
 case 172:
 YY_RULE_SETUP
-#line 332 "smiles.ll"
+#line 347 "smiles.ll"
 { return GROUP_OPEN_TOKEN; }
 	YY_BREAK
 case 173:
 YY_RULE_SETUP
-#line 333 "smiles.ll"
+#line 348 "smiles.ll"
 { return GROUP_CLOSE_TOKEN; }
 	YY_BREAK
 case 174:
 YY_RULE_SETUP
-#line 336 "smiles.ll"
+#line 351 "smiles.ll"
 { BEGIN IN_ATOM_STATE; return ATOM_OPEN_TOKEN; }
 	YY_BREAK
 case 175:
 YY_RULE_SETUP
-#line 337 "smiles.ll"
+#line 352 "smiles.ll"
 { BEGIN INITIAL; return ATOM_CLOSE_TOKEN; }
 	YY_BREAK
 case 176:
 YY_RULE_SETUP
-#line 339 "smiles.ll"
+#line 354 "smiles.ll"
 { return SEPARATOR_TOKEN; }
 	YY_BREAK
 case 177:
 YY_RULE_SETUP
-#line 341 "smiles.ll"
+#line 356 "smiles.ll"
 { return PERCENT_TOKEN; }
 	YY_BREAK
 case 178:
 YY_RULE_SETUP
-#line 343 "smiles.ll"
+#line 358 "smiles.ll"
 { yylval->ival = 0; return ZERO_TOKEN; }
 	YY_BREAK
 case 179:
 YY_RULE_SETUP
-#line 344 "smiles.ll"
+#line 359 "smiles.ll"
 { yylval->ival = atoi( yytext ); return NONZERO_DIGIT_TOKEN; }
 	YY_BREAK
 case 180:
 /* rule 180 can match eol */
 YY_RULE_SETUP
-#line 348 "smiles.ll"
+#line 363 "smiles.ll"
 return 0;
 	YY_BREAK
 case YY_STATE_EOF(INITIAL):
 case YY_STATE_EOF(IN_ATOM_STATE):
-#line 350 "smiles.ll"
+#line 365 "smiles.ll"
 { return EOS_TOKEN; }
 	YY_BREAK
 case 181:
 YY_RULE_SETUP
-#line 351 "smiles.ll"
+#line 366 "smiles.ll"
 return yytext[0];
 	YY_BREAK
 case 182:
 YY_RULE_SETUP
-#line 353 "smiles.ll"
+#line 368 "smiles.ll"
 ECHO;
 	YY_BREAK
-#line 1983 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/lex.yysmiles.cpp"
+#line 2197 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/lex.yysmiles.cpp"
 
 	case YY_END_OF_BUFFER:
 		{
@@ -2000,7 +2209,7 @@ ECHO;
 			/* We're scanning a new file or input source.  It's
 			 * possible that this happened because the user
 			 * just pointed yyin at a new source and called
-			 * yysmiles_lex().  If so, then we have to assure
+			 * yylex().  If so, then we have to assure
 			 * consistency between YY_CURRENT_BUFFER and our
 			 * globals.  Here is the right place to do so, because
 			 * this is the first action (other than possibly a
@@ -2060,7 +2269,7 @@ ECHO;
 				{
 				yyg->yy_did_buffer_switch_on_eof = 0;
 
-				if ( yysmiles_wrap(yyscanner ) )
+				if ( yywrap( yyscanner ) )
 					{
 					/* Note: because we've taken care in
 					 * yy_get_next_buffer() to have set up
@@ -2114,7 +2323,7 @@ ECHO;
 	} /* end of action switch */
 		} /* end of scanning one token */
 	} /* end of user's declarations */
-} /* end of yysmiles_lex */
+} /* end of yylex */
 
 /* yy_get_next_buffer - try to read in a new buffer
  *
@@ -2128,7 +2337,7 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 	char *dest = YY_CURRENT_BUFFER_LVALUE->yy_ch_buf;
 	char *source = yyg->yytext_ptr;
-	yy_size_t number_to_move, i;
+	int number_to_move, i;
 	int ret_val;
 
 	if ( yyg->yy_c_buf_p > &YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[yyg->yy_n_chars + 1] )
@@ -2157,7 +2366,7 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 	/* Try to read more data. */
 
 	/* First move last chars to start of buffer. */
-	number_to_move = (yy_size_t) (yyg->yy_c_buf_p - yyg->yytext_ptr) - 1;
+	number_to_move = (int) (yyg->yy_c_buf_p - yyg->yytext_ptr - 1);
 
 	for ( i = 0; i < number_to_move; ++i )
 		*(dest++) = *(source++);
@@ -2170,7 +2379,7 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 
 	else
 		{
-			yy_size_t num_to_read =
+			int num_to_read =
 			YY_CURRENT_BUFFER_LVALUE->yy_buf_size - number_to_move - 1;
 
 		while ( num_to_read <= 0 )
@@ -2184,7 +2393,7 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 
 			if ( b->yy_is_our_buffer )
 				{
-				yy_size_t new_size = b->yy_buf_size * 2;
+				int new_size = b->yy_buf_size * 2;
 
 				if ( new_size <= 0 )
 					b->yy_buf_size += b->yy_buf_size / 8;
@@ -2193,11 +2402,12 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 
 				b->yy_ch_buf = (char *)
 					/* Include room in for 2 EOB chars. */
-					yysmiles_realloc((void *) b->yy_ch_buf,b->yy_buf_size + 2 ,yyscanner );
+					yyrealloc( (void *) b->yy_ch_buf,
+							 (yy_size_t) (b->yy_buf_size + 2) , yyscanner );
 				}
 			else
 				/* Can't grow it, we don't own it. */
-				b->yy_ch_buf = 0;
+				b->yy_ch_buf = NULL;
 
 			if ( ! b->yy_ch_buf )
 				YY_FATAL_ERROR(
@@ -2225,7 +2435,7 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 		if ( number_to_move == YY_MORE_ADJ )
 			{
 			ret_val = EOB_ACT_END_OF_FILE;
-			yysmiles_restart(yyin  ,yyscanner);
+			yyrestart( yyin  , yyscanner);
 			}
 
 		else
@@ -2239,12 +2449,15 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 	else
 		ret_val = EOB_ACT_CONTINUE_SCAN;
 
-	if ((int) (yyg->yy_n_chars + number_to_move) > YY_CURRENT_BUFFER_LVALUE->yy_buf_size) {
+	if ((yyg->yy_n_chars + number_to_move) > YY_CURRENT_BUFFER_LVALUE->yy_buf_size) {
 		/* Extend the array by 50%, plus the number we really need. */
 		int new_size = yyg->yy_n_chars + number_to_move + (yyg->yy_n_chars >> 1);
-		YY_CURRENT_BUFFER_LVALUE->yy_ch_buf = (char *) yysmiles_realloc((void *) YY_CURRENT_BUFFER_LVALUE->yy_ch_buf,new_size ,yyscanner );
+		YY_CURRENT_BUFFER_LVALUE->yy_ch_buf = (char *) yyrealloc(
+			(void *) YY_CURRENT_BUFFER_LVALUE->yy_ch_buf, (yy_size_t) new_size , yyscanner );
 		if ( ! YY_CURRENT_BUFFER_LVALUE->yy_ch_buf )
 			YY_FATAL_ERROR( "out of dynamic memory in yy_get_next_buffer()" );
+		/* "- 2" to take care of EOB's */
+		YY_CURRENT_BUFFER_LVALUE->yy_buf_size = (int) (new_size - 2);
 	}
 
 	yyg->yy_n_chars += number_to_move;
@@ -2278,9 +2491,9 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 			{
 			yy_current_state = (int) yy_def[yy_current_state];
 			if ( yy_current_state >= 247 )
-				yy_c = yy_meta[(unsigned int) yy_c];
+				yy_c = yy_meta[yy_c];
 			}
-		yy_current_state = yy_nxt[yy_base[yy_current_state] + (unsigned int) yy_c];
+		yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
 		}
 
 	return yy_current_state;
@@ -2307,9 +2520,9 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 		{
 		yy_current_state = (int) yy_def[yy_current_state];
 		if ( yy_current_state >= 247 )
-			yy_c = yy_meta[(unsigned int) yy_c];
+			yy_c = yy_meta[yy_c];
 		}
-	yy_current_state = yy_nxt[yy_base[yy_current_state] + (unsigned int) yy_c];
+	yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
 	yy_is_jam = (yy_current_state == 246);
 
 	(void)yyg;
@@ -2331,7 +2544,7 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 	if ( yy_cp < YY_CURRENT_BUFFER_LVALUE->yy_ch_buf + 2 )
 		{ /* need to shift things up to make room */
 		/* +2 for EOB chars. */
-		yy_size_t number_to_move = yyg->yy_n_chars + 2;
+		int number_to_move = yyg->yy_n_chars + 2;
 		char *dest = &YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[
 					YY_CURRENT_BUFFER_LVALUE->yy_buf_size + 2];
 		char *source =
@@ -2343,7 +2556,7 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 		yy_cp += (int) (dest - source);
 		yy_bp += (int) (dest - source);
 		YY_CURRENT_BUFFER_LVALUE->yy_n_chars =
-			yyg->yy_n_chars = YY_CURRENT_BUFFER_LVALUE->yy_buf_size;
+			yyg->yy_n_chars = (int) YY_CURRENT_BUFFER_LVALUE->yy_buf_size;
 
 		if ( yy_cp < YY_CURRENT_BUFFER_LVALUE->yy_ch_buf + 2 )
 			YY_FATAL_ERROR( "flex scanner push-back overflow" );
@@ -2383,7 +2596,7 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 
 		else
 			{ /* need more input */
-			yy_size_t offset = yyg->yy_c_buf_p - yyg->yytext_ptr;
+			int offset = (int) (yyg->yy_c_buf_p - yyg->yytext_ptr);
 			++yyg->yy_c_buf_p;
 
 			switch ( yy_get_next_buffer( yyscanner ) )
@@ -2400,14 +2613,14 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 					 */
 
 					/* Reset buffer status. */
-					yysmiles_restart(yyin ,yyscanner);
+					yyrestart( yyin , yyscanner);
 
 					/*FALLTHROUGH*/
 
 				case EOB_ACT_END_OF_FILE:
 					{
-					if ( yysmiles_wrap(yyscanner ) )
-						return EOF;
+					if ( yywrap( yyscanner ) )
+						return 0;
 
 					if ( ! yyg->yy_did_buffer_switch_on_eof )
 						YY_NEW_FILE;
@@ -2438,34 +2651,34 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
  * @param yyscanner The scanner object.
  * @note This function does not reset the start condition to @c INITIAL .
  */
-    void yysmiles_restart  (FILE * input_file , yyscan_t yyscanner)
+    void yyrestart  (FILE * input_file , yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 
 	if ( ! YY_CURRENT_BUFFER ){
-        yysmiles_ensure_buffer_stack (yyscanner);
+        yyensure_buffer_stack (yyscanner);
 		YY_CURRENT_BUFFER_LVALUE =
-            yysmiles__create_buffer(yyin,YY_BUF_SIZE ,yyscanner);
+            yy_create_buffer( yyin, YY_BUF_SIZE , yyscanner);
 	}
 
-	yysmiles__init_buffer(YY_CURRENT_BUFFER,input_file ,yyscanner);
-	yysmiles__load_buffer_state(yyscanner );
+	yy_init_buffer( YY_CURRENT_BUFFER, input_file , yyscanner);
+	yy_load_buffer_state( yyscanner );
 }
 
 /** Switch to a different input buffer.
  * @param new_buffer The new input buffer.
  * @param yyscanner The scanner object.
  */
-    void yysmiles__switch_to_buffer  (YY_BUFFER_STATE  new_buffer , yyscan_t yyscanner)
+    void yy_switch_to_buffer  (YY_BUFFER_STATE  new_buffer , yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 
 	/* TODO. We should be able to replace this entire function body
 	 * with
-	 *		yysmiles_pop_buffer_state();
-	 *		yysmiles_push_buffer_state(new_buffer);
+	 *		yypop_buffer_state();
+	 *		yypush_buffer_state(new_buffer);
      */
-	yysmiles_ensure_buffer_stack (yyscanner);
+	yyensure_buffer_stack (yyscanner);
 	if ( YY_CURRENT_BUFFER == new_buffer )
 		return;
 
@@ -2478,17 +2691,17 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 		}
 
 	YY_CURRENT_BUFFER_LVALUE = new_buffer;
-	yysmiles__load_buffer_state(yyscanner );
+	yy_load_buffer_state( yyscanner );
 
 	/* We don't actually know whether we did this switch during
-	 * EOF (yysmiles_wrap()) processing, but the only time this flag
-	 * is looked at is after yysmiles_wrap() is called, so it's safe
+	 * EOF (yywrap()) processing, but the only time this flag
+	 * is looked at is after yywrap() is called, so it's safe
 	 * to go ahead and always set it.
 	 */
 	yyg->yy_did_buffer_switch_on_eof = 1;
 }
 
-static void yysmiles__load_buffer_state  (yyscan_t yyscanner)
+static void yy_load_buffer_state  (yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 	yyg->yy_n_chars = YY_CURRENT_BUFFER_LVALUE->yy_n_chars;
@@ -2503,35 +2716,35 @@ static void yysmiles__load_buffer_state  (yyscan_t yyscanner)
  * @param yyscanner The scanner object.
  * @return the allocated buffer state.
  */
-    YY_BUFFER_STATE yysmiles__create_buffer  (FILE * file, int  size , yyscan_t yyscanner)
+    YY_BUFFER_STATE yy_create_buffer  (FILE * file, int  size , yyscan_t yyscanner)
 {
 	YY_BUFFER_STATE b;
     
-	b = (YY_BUFFER_STATE) yysmiles_alloc(sizeof( struct yy_buffer_state ) ,yyscanner );
+	b = (YY_BUFFER_STATE) yyalloc( sizeof( struct yy_buffer_state ) , yyscanner );
 	if ( ! b )
-		YY_FATAL_ERROR( "out of dynamic memory in yysmiles__create_buffer()" );
+		YY_FATAL_ERROR( "out of dynamic memory in yy_create_buffer()" );
 
-	b->yy_buf_size = (yy_size_t)size;
+	b->yy_buf_size = size;
 
 	/* yy_ch_buf has to be 2 characters longer than the size given because
 	 * we need to put in 2 end-of-buffer characters.
 	 */
-	b->yy_ch_buf = (char *) yysmiles_alloc(b->yy_buf_size + 2 ,yyscanner );
+	b->yy_ch_buf = (char *) yyalloc( (yy_size_t) (b->yy_buf_size + 2) , yyscanner );
 	if ( ! b->yy_ch_buf )
-		YY_FATAL_ERROR( "out of dynamic memory in yysmiles__create_buffer()" );
+		YY_FATAL_ERROR( "out of dynamic memory in yy_create_buffer()" );
 
 	b->yy_is_our_buffer = 1;
 
-	yysmiles__init_buffer(b,file ,yyscanner);
+	yy_init_buffer( b, file , yyscanner);
 
 	return b;
 }
 
 /** Destroy the buffer.
- * @param b a buffer created with yysmiles__create_buffer()
+ * @param b a buffer created with yy_create_buffer()
  * @param yyscanner The scanner object.
  */
-    void yysmiles__delete_buffer (YY_BUFFER_STATE  b , yyscan_t yyscanner)
+    void yy_delete_buffer (YY_BUFFER_STATE  b , yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 
@@ -2542,28 +2755,28 @@ static void yysmiles__load_buffer_state  (yyscan_t yyscanner)
 		YY_CURRENT_BUFFER_LVALUE = (YY_BUFFER_STATE) 0;
 
 	if ( b->yy_is_our_buffer )
-		yysmiles_free((void *) b->yy_ch_buf ,yyscanner );
+		yyfree( (void *) b->yy_ch_buf , yyscanner );
 
-	yysmiles_free((void *) b ,yyscanner );
+	yyfree( (void *) b , yyscanner );
 }
 
 /* Initializes or reinitializes a buffer.
  * This function is sometimes called more than once on the same buffer,
- * such as during a yysmiles_restart() or at EOF.
+ * such as during a yyrestart() or at EOF.
  */
-    static void yysmiles__init_buffer  (YY_BUFFER_STATE  b, FILE * file , yyscan_t yyscanner)
+    static void yy_init_buffer  (YY_BUFFER_STATE  b, FILE * file , yyscan_t yyscanner)
 
 {
 	int oerrno = errno;
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 
-	yysmiles__flush_buffer(b ,yyscanner);
+	yy_flush_buffer( b , yyscanner);
 
 	b->yy_input_file = file;
 	b->yy_fill_buffer = 1;
 
-    /* If b is the current buffer, then yysmiles__init_buffer was _probably_
-     * called from yysmiles_restart() or through yy_get_next_buffer.
+    /* If b is the current buffer, then yy_init_buffer was _probably_
+     * called from yyrestart() or through yy_get_next_buffer.
      * In that case, we don't want to reset the lineno or column.
      */
     if (b != YY_CURRENT_BUFFER){
@@ -2580,7 +2793,7 @@ static void yysmiles__load_buffer_state  (yyscan_t yyscanner)
  * @param b the buffer state to be flushed, usually @c YY_CURRENT_BUFFER.
  * @param yyscanner The scanner object.
  */
-    void yysmiles__flush_buffer (YY_BUFFER_STATE  b , yyscan_t yyscanner)
+    void yy_flush_buffer (YY_BUFFER_STATE  b , yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 	if ( ! b )
@@ -2601,7 +2814,7 @@ static void yysmiles__load_buffer_state  (yyscan_t yyscanner)
 	b->yy_buffer_status = YY_BUFFER_NEW;
 
 	if ( b == YY_CURRENT_BUFFER )
-		yysmiles__load_buffer_state(yyscanner );
+		yy_load_buffer_state( yyscanner );
 }
 
 /** Pushes the new state onto the stack. The new state becomes
@@ -2610,15 +2823,15 @@ static void yysmiles__load_buffer_state  (yyscan_t yyscanner)
  *  @param new_buffer The new state.
  *  @param yyscanner The scanner object.
  */
-void yysmiles_push_buffer_state (YY_BUFFER_STATE new_buffer , yyscan_t yyscanner)
+void yypush_buffer_state (YY_BUFFER_STATE new_buffer , yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 	if (new_buffer == NULL)
 		return;
 
-	yysmiles_ensure_buffer_stack(yyscanner);
+	yyensure_buffer_stack(yyscanner);
 
-	/* This block is copied from yysmiles__switch_to_buffer. */
+	/* This block is copied from yy_switch_to_buffer. */
 	if ( YY_CURRENT_BUFFER )
 		{
 		/* Flush out information for old buffer. */
@@ -2632,8 +2845,8 @@ void yysmiles_push_buffer_state (YY_BUFFER_STATE new_buffer , yyscan_t yyscanner
 		yyg->yy_buffer_stack_top++;
 	YY_CURRENT_BUFFER_LVALUE = new_buffer;
 
-	/* copied from yysmiles__switch_to_buffer. */
-	yysmiles__load_buffer_state(yyscanner );
+	/* copied from yy_switch_to_buffer. */
+	yy_load_buffer_state( yyscanner );
 	yyg->yy_did_buffer_switch_on_eof = 1;
 }
 
@@ -2641,19 +2854,19 @@ void yysmiles_push_buffer_state (YY_BUFFER_STATE new_buffer , yyscan_t yyscanner
  *  The next element becomes the new top.
  *  @param yyscanner The scanner object.
  */
-void yysmiles_pop_buffer_state (yyscan_t yyscanner)
+void yypop_buffer_state (yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 	if (!YY_CURRENT_BUFFER)
 		return;
 
-	yysmiles__delete_buffer(YY_CURRENT_BUFFER ,yyscanner);
+	yy_delete_buffer(YY_CURRENT_BUFFER , yyscanner);
 	YY_CURRENT_BUFFER_LVALUE = NULL;
 	if (yyg->yy_buffer_stack_top > 0)
 		--yyg->yy_buffer_stack_top;
 
 	if (YY_CURRENT_BUFFER) {
-		yysmiles__load_buffer_state(yyscanner );
+		yy_load_buffer_state( yyscanner );
 		yyg->yy_did_buffer_switch_on_eof = 1;
 	}
 }
@@ -2661,7 +2874,7 @@ void yysmiles_pop_buffer_state (yyscan_t yyscanner)
 /* Allocates the stack if it does not exist.
  *  Guarantees space for at least one push.
  */
-static void yysmiles_ensure_buffer_stack (yyscan_t yyscanner)
+static void yyensure_buffer_stack (yyscan_t yyscanner)
 {
 	yy_size_t num_to_alloc;
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
@@ -2672,15 +2885,15 @@ static void yysmiles_ensure_buffer_stack (yyscan_t yyscanner)
 		 * scanner will even need a stack. We use 2 instead of 1 to avoid an
 		 * immediate realloc on the next call.
          */
-		num_to_alloc = 1; /* After all that talk, this was set to 1 anyways... */
-		yyg->yy_buffer_stack = (struct yy_buffer_state**)yysmiles_alloc
+      num_to_alloc = 1; /* After all that talk, this was set to 1 anyways... */
+		yyg->yy_buffer_stack = (struct yy_buffer_state**)yyalloc
 								(num_to_alloc * sizeof(struct yy_buffer_state*)
 								, yyscanner);
 		if ( ! yyg->yy_buffer_stack )
-			YY_FATAL_ERROR( "out of dynamic memory in yysmiles_ensure_buffer_stack()" );
-								  
+			YY_FATAL_ERROR( "out of dynamic memory in yyensure_buffer_stack()" );
+
 		memset(yyg->yy_buffer_stack, 0, num_to_alloc * sizeof(struct yy_buffer_state*));
-				
+
 		yyg->yy_buffer_stack_max = num_to_alloc;
 		yyg->yy_buffer_stack_top = 0;
 		return;
@@ -2692,12 +2905,12 @@ static void yysmiles_ensure_buffer_stack (yyscan_t yyscanner)
 		yy_size_t grow_size = 8 /* arbitrary grow size */;
 
 		num_to_alloc = yyg->yy_buffer_stack_max + grow_size;
-		yyg->yy_buffer_stack = (struct yy_buffer_state**)yysmiles_realloc
+		yyg->yy_buffer_stack = (struct yy_buffer_state**)yyrealloc
 								(yyg->yy_buffer_stack,
 								num_to_alloc * sizeof(struct yy_buffer_state*)
 								, yyscanner);
 		if ( ! yyg->yy_buffer_stack )
-			YY_FATAL_ERROR( "out of dynamic memory in yysmiles_ensure_buffer_stack()" );
+			YY_FATAL_ERROR( "out of dynamic memory in yyensure_buffer_stack()" );
 
 		/* zero only the new slots.*/
 		memset(yyg->yy_buffer_stack + yyg->yy_buffer_stack_max, 0, grow_size * sizeof(struct yy_buffer_state*));
@@ -2709,9 +2922,9 @@ static void yysmiles_ensure_buffer_stack (yyscan_t yyscanner)
  * @param base the character buffer
  * @param size the size in bytes of the character buffer
  * @param yyscanner The scanner object.
- * @return the newly allocated buffer state object. 
+ * @return the newly allocated buffer state object.
  */
-YY_BUFFER_STATE yysmiles__scan_buffer  (char * base, yy_size_t  size , yyscan_t yyscanner)
+YY_BUFFER_STATE yy_scan_buffer  (char * base, yy_size_t  size , yyscan_t yyscanner)
 {
 	YY_BUFFER_STATE b;
     
@@ -2719,69 +2932,69 @@ YY_BUFFER_STATE yysmiles__scan_buffer  (char * base, yy_size_t  size , yyscan_t 
 	     base[size-2] != YY_END_OF_BUFFER_CHAR ||
 	     base[size-1] != YY_END_OF_BUFFER_CHAR )
 		/* They forgot to leave room for the EOB's. */
-		return 0;
+		return NULL;
 
-	b = (YY_BUFFER_STATE) yysmiles_alloc(sizeof( struct yy_buffer_state ) ,yyscanner );
+	b = (YY_BUFFER_STATE) yyalloc( sizeof( struct yy_buffer_state ) , yyscanner );
 	if ( ! b )
-		YY_FATAL_ERROR( "out of dynamic memory in yysmiles__scan_buffer()" );
+		YY_FATAL_ERROR( "out of dynamic memory in yy_scan_buffer()" );
 
-	b->yy_buf_size = size - 2;	/* "- 2" to take care of EOB's */
+	b->yy_buf_size = (int) (size - 2);	/* "- 2" to take care of EOB's */
 	b->yy_buf_pos = b->yy_ch_buf = base;
 	b->yy_is_our_buffer = 0;
-	b->yy_input_file = 0;
+	b->yy_input_file = NULL;
 	b->yy_n_chars = b->yy_buf_size;
 	b->yy_is_interactive = 0;
 	b->yy_at_bol = 1;
 	b->yy_fill_buffer = 0;
 	b->yy_buffer_status = YY_BUFFER_NEW;
 
-	yysmiles__switch_to_buffer(b ,yyscanner );
+	yy_switch_to_buffer( b , yyscanner );
 
 	return b;
 }
 
-/** Setup the input buffer state to scan a string. The next call to yysmiles_lex() will
+/** Setup the input buffer state to scan a string. The next call to yylex() will
  * scan from a @e copy of @a str.
  * @param yystr a NUL-terminated string to scan
  * @param yyscanner The scanner object.
  * @return the newly allocated buffer state object.
  * @note If you want to scan bytes that may contain NUL values, then use
- *       yysmiles__scan_bytes() instead.
+ *       yy_scan_bytes() instead.
  */
-YY_BUFFER_STATE yysmiles__scan_string (yyconst char * yystr , yyscan_t yyscanner)
+YY_BUFFER_STATE yy_scan_string (const char * yystr , yyscan_t yyscanner)
 {
     
-	return yysmiles__scan_bytes(yystr,strlen(yystr) ,yyscanner);
+	return yy_scan_bytes( yystr, (int) strlen(yystr) , yyscanner);
 }
 
-/** Setup the input buffer state to scan the given bytes. The next call to yysmiles_lex() will
+/** Setup the input buffer state to scan the given bytes. The next call to yylex() will
  * scan from a @e copy of @a bytes.
  * @param yybytes the byte buffer to scan
  * @param _yybytes_len the number of bytes in the buffer pointed to by @a bytes.
  * @param yyscanner The scanner object.
  * @return the newly allocated buffer state object.
  */
-YY_BUFFER_STATE yysmiles__scan_bytes  (yyconst char * yybytes, yy_size_t  _yybytes_len , yyscan_t yyscanner)
+YY_BUFFER_STATE yy_scan_bytes  (const char * yybytes, int  _yybytes_len , yyscan_t yyscanner)
 {
 	YY_BUFFER_STATE b;
 	char *buf;
 	yy_size_t n;
-	yy_size_t i;
+	int i;
     
 	/* Get memory for full buffer, including space for trailing EOB's. */
-	n = _yybytes_len + 2;
-	buf = (char *) yysmiles_alloc(n ,yyscanner );
+	n = (yy_size_t) (_yybytes_len + 2);
+	buf = (char *) yyalloc( n , yyscanner );
 	if ( ! buf )
-		YY_FATAL_ERROR( "out of dynamic memory in yysmiles__scan_bytes()" );
+		YY_FATAL_ERROR( "out of dynamic memory in yy_scan_bytes()" );
 
 	for ( i = 0; i < _yybytes_len; ++i )
 		buf[i] = yybytes[i];
 
 	buf[_yybytes_len] = buf[_yybytes_len+1] = YY_END_OF_BUFFER_CHAR;
 
-	b = yysmiles__scan_buffer(buf,n ,yyscanner);
+	b = yy_scan_buffer( buf, n , yyscanner);
 	if ( ! b )
-		YY_FATAL_ERROR( "bad buffer in yysmiles__scan_bytes()" );
+		YY_FATAL_ERROR( "bad buffer in yy_scan_bytes()" );
 
 	/* It's okay to grow etc. this buffer, and we should throw it
 	 * away when we're done.
@@ -2795,11 +3008,11 @@ YY_BUFFER_STATE yysmiles__scan_bytes  (yyconst char * yybytes, yy_size_t  _yybyt
 #define YY_EXIT_FAILURE 2
 #endif
 
-static void yy_fatal_error (yyconst char* msg , yyscan_t yyscanner)
+static void yynoreturn yy_fatal_error (const char* msg , yyscan_t yyscanner)
 {
 	struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 	(void)yyg;
-	(void) fprintf( stderr, "%s\n", msg );
+	fprintf( stderr, "%s\n", msg );
 	exit( YY_EXIT_FAILURE );
 }
 
@@ -2825,7 +3038,7 @@ static void yy_fatal_error (yyconst char* msg , yyscan_t yyscanner)
 /** Get the user-defined data for this scanner.
  * @param yyscanner The scanner object.
  */
-YY_EXTRA_TYPE yysmiles_get_extra  (yyscan_t yyscanner)
+YY_EXTRA_TYPE yyget_extra  (yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
     return yyextra;
@@ -2834,10 +3047,10 @@ YY_EXTRA_TYPE yysmiles_get_extra  (yyscan_t yyscanner)
 /** Get the current line number.
  * @param yyscanner The scanner object.
  */
-int yysmiles_get_lineno  (yyscan_t yyscanner)
+int yyget_lineno  (yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
-    
+
         if (! YY_CURRENT_BUFFER)
             return 0;
     
@@ -2847,10 +3060,10 @@ int yysmiles_get_lineno  (yyscan_t yyscanner)
 /** Get the current column number.
  * @param yyscanner The scanner object.
  */
-int yysmiles_get_column  (yyscan_t yyscanner)
+int yyget_column  (yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
-    
+
         if (! YY_CURRENT_BUFFER)
             return 0;
     
@@ -2860,7 +3073,7 @@ int yysmiles_get_column  (yyscan_t yyscanner)
 /** Get the input stream.
  * @param yyscanner The scanner object.
  */
-FILE *yysmiles_get_in  (yyscan_t yyscanner)
+FILE *yyget_in  (yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
     return yyin;
@@ -2869,7 +3082,7 @@ FILE *yysmiles_get_in  (yyscan_t yyscanner)
 /** Get the output stream.
  * @param yyscanner The scanner object.
  */
-FILE *yysmiles_get_out  (yyscan_t yyscanner)
+FILE *yyget_out  (yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
     return yyout;
@@ -2878,7 +3091,7 @@ FILE *yysmiles_get_out  (yyscan_t yyscanner)
 /** Get the length of the current token.
  * @param yyscanner The scanner object.
  */
-yy_size_t yysmiles_get_leng  (yyscan_t yyscanner)
+int yyget_leng  (yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
     return yyleng;
@@ -2888,7 +3101,7 @@ yy_size_t yysmiles_get_leng  (yyscan_t yyscanner)
  * @param yyscanner The scanner object.
  */
 
-char *yysmiles_get_text  (yyscan_t yyscanner)
+char *yyget_text  (yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
     return yytext;
@@ -2898,7 +3111,7 @@ char *yysmiles_get_text  (yyscan_t yyscanner)
  * @param user_defined The data to be associated with this scanner.
  * @param yyscanner The scanner object.
  */
-void yysmiles_set_extra (YY_EXTRA_TYPE  user_defined , yyscan_t yyscanner)
+void yyset_extra (YY_EXTRA_TYPE  user_defined , yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
     yyextra = user_defined ;
@@ -2908,13 +3121,13 @@ void yysmiles_set_extra (YY_EXTRA_TYPE  user_defined , yyscan_t yyscanner)
  * @param _line_number line number
  * @param yyscanner The scanner object.
  */
-void yysmiles_set_lineno (int  _line_number , yyscan_t yyscanner)
+void yyset_lineno (int  _line_number , yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 
         /* lineno is only valid if an input buffer exists. */
         if (! YY_CURRENT_BUFFER )
-           YY_FATAL_ERROR( "yysmiles_set_lineno called with no buffer" );
+           YY_FATAL_ERROR( "yyset_lineno called with no buffer" );
     
     yylineno = _line_number;
 }
@@ -2923,13 +3136,13 @@ void yysmiles_set_lineno (int  _line_number , yyscan_t yyscanner)
  * @param _column_no column number
  * @param yyscanner The scanner object.
  */
-void yysmiles_set_column (int  _column_no , yyscan_t yyscanner)
+void yyset_column (int  _column_no , yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 
         /* column is only valid if an input buffer exists. */
         if (! YY_CURRENT_BUFFER )
-           YY_FATAL_ERROR( "yysmiles_set_column called with no buffer" );
+           YY_FATAL_ERROR( "yyset_column called with no buffer" );
     
     yycolumn = _column_no;
 }
@@ -2938,27 +3151,27 @@ void yysmiles_set_column (int  _column_no , yyscan_t yyscanner)
  * input buffer.
  * @param _in_str A readable stream.
  * @param yyscanner The scanner object.
- * @see yysmiles__switch_to_buffer
+ * @see yy_switch_to_buffer
  */
-void yysmiles_set_in (FILE *  _in_str , yyscan_t yyscanner)
+void yyset_in (FILE *  _in_str , yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
     yyin = _in_str ;
 }
 
-void yysmiles_set_out (FILE *  _out_str , yyscan_t yyscanner)
+void yyset_out (FILE *  _out_str , yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
     yyout = _out_str ;
 }
 
-int yysmiles_get_debug  (yyscan_t yyscanner)
+int yyget_debug  (yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
     return yy_flex_debug;
 }
 
-void yysmiles_set_debug (int  _bdebug , yyscan_t yyscanner)
+void yyset_debug (int  _bdebug , yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
     yy_flex_debug = _bdebug ;
@@ -2966,13 +3179,13 @@ void yysmiles_set_debug (int  _bdebug , yyscan_t yyscanner)
 
 /* Accessor methods for yylval and yylloc */
 
-YYSTYPE * yysmiles_get_lval  (yyscan_t yyscanner)
+YYSTYPE * yyget_lval  (yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
     return yylval;
 }
 
-void yysmiles_set_lval (YYSTYPE *  yylval_param , yyscan_t yyscanner)
+void yyset_lval (YYSTYPE *  yylval_param , yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
     yylval = yylval_param;
@@ -2980,20 +3193,18 @@ void yysmiles_set_lval (YYSTYPE *  yylval_param , yyscan_t yyscanner)
 
 /* User-visible API */
 
-/* yysmiles_lex_init is special because it creates the scanner itself, so it is
+/* yylex_init is special because it creates the scanner itself, so it is
  * the ONLY reentrant function that doesn't take the scanner as the last argument.
  * That's why we explicitly handle the declaration, instead of using our macros.
  */
-
-int yysmiles_lex_init(yyscan_t* ptr_yy_globals)
-
+int yylex_init(yyscan_t* ptr_yy_globals)
 {
     if (ptr_yy_globals == NULL){
         errno = EINVAL;
         return 1;
     }
 
-    *ptr_yy_globals = (yyscan_t) yysmiles_alloc ( sizeof( struct yyguts_t ), NULL );
+    *ptr_yy_globals = (yyscan_t) yyalloc ( sizeof( struct yyguts_t ), NULL );
 
     if (*ptr_yy_globals == NULL){
         errno = ENOMEM;
@@ -3006,39 +3217,37 @@ int yysmiles_lex_init(yyscan_t* ptr_yy_globals)
     return yy_init_globals ( *ptr_yy_globals );
 }
 
-/* yysmiles_lex_init_extra has the same functionality as yysmiles_lex_init, but follows the
+/* yylex_init_extra has the same functionality as yylex_init, but follows the
  * convention of taking the scanner as the last argument. Note however, that
  * this is a *pointer* to a scanner, as it will be allocated by this call (and
  * is the reason, too, why this function also must handle its own declaration).
- * The user defined value in the first argument will be available to yysmiles_alloc in
+ * The user defined value in the first argument will be available to yyalloc in
  * the yyextra field.
  */
-
-int yysmiles_lex_init_extra(YY_EXTRA_TYPE yy_user_defined,yyscan_t* ptr_yy_globals )
-
+int yylex_init_extra( YY_EXTRA_TYPE yy_user_defined, yyscan_t* ptr_yy_globals )
 {
     struct yyguts_t dummy_yyguts;
 
-    yysmiles_set_extra (yy_user_defined, &dummy_yyguts);
+    yyset_extra (yy_user_defined, &dummy_yyguts);
 
     if (ptr_yy_globals == NULL){
         errno = EINVAL;
         return 1;
     }
-	
-    *ptr_yy_globals = (yyscan_t) yysmiles_alloc ( sizeof( struct yyguts_t ), &dummy_yyguts );
-	
+
+    *ptr_yy_globals = (yyscan_t) yyalloc ( sizeof( struct yyguts_t ), &dummy_yyguts );
+
     if (*ptr_yy_globals == NULL){
         errno = ENOMEM;
         return 1;
     }
-    
+
     /* By setting to 0xAA, we expose bugs in
     yy_init_globals. Leave at 0x00 for releases. */
     memset(*ptr_yy_globals,0x00,sizeof(struct yyguts_t));
-    
-    yysmiles_set_extra (yy_user_defined, *ptr_yy_globals);
-    
+
+    yyset_extra (yy_user_defined, *ptr_yy_globals);
+
     return yy_init_globals ( *ptr_yy_globals );
 }
 
@@ -3046,13 +3255,13 @@ static int yy_init_globals (yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
     /* Initialization is the same as for the non-reentrant scanner.
-     * This function is called from yysmiles_lex_destroy(), so don't allocate here.
+     * This function is called from yylex_destroy(), so don't allocate here.
      */
 
-    yyg->yy_buffer_stack = 0;
+    yyg->yy_buffer_stack = NULL;
     yyg->yy_buffer_stack_top = 0;
     yyg->yy_buffer_stack_max = 0;
-    yyg->yy_c_buf_p = (char *) 0;
+    yyg->yy_c_buf_p = NULL;
     yyg->yy_init = 0;
     yyg->yy_start = 0;
 
@@ -3065,42 +3274,42 @@ static int yy_init_globals (yyscan_t yyscanner)
     yyin = stdin;
     yyout = stdout;
 #else
-    yyin = (FILE *) 0;
-    yyout = (FILE *) 0;
+    yyin = NULL;
+    yyout = NULL;
 #endif
 
     /* For future reference: Set errno on error, since we are called by
-     * yysmiles_lex_init()
+     * yylex_init()
      */
     return 0;
 }
 
-/* yysmiles_lex_destroy is for both reentrant and non-reentrant scanners. */
-int yysmiles_lex_destroy  (yyscan_t yyscanner)
+/* yylex_destroy is for both reentrant and non-reentrant scanners. */
+int yylex_destroy  (yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 
     /* Pop the buffer stack, destroying each element. */
 	while(YY_CURRENT_BUFFER){
-		yysmiles__delete_buffer(YY_CURRENT_BUFFER ,yyscanner );
+		yy_delete_buffer( YY_CURRENT_BUFFER , yyscanner );
 		YY_CURRENT_BUFFER_LVALUE = NULL;
-		yysmiles_pop_buffer_state(yyscanner);
+		yypop_buffer_state(yyscanner);
 	}
 
 	/* Destroy the stack itself. */
-	yysmiles_free(yyg->yy_buffer_stack ,yyscanner);
+	yyfree(yyg->yy_buffer_stack , yyscanner);
 	yyg->yy_buffer_stack = NULL;
 
     /* Destroy the start condition stack. */
-        yysmiles_free(yyg->yy_start_stack ,yyscanner );
+        yyfree( yyg->yy_start_stack , yyscanner );
         yyg->yy_start_stack = NULL;
 
     /* Reset the globals. This is important in a non-reentrant scanner so the next time
-     * yysmiles_lex() is called, initialization will occur. */
+     * yylex() is called, initialization will occur. */
     yy_init_globals( yyscanner);
 
     /* Destroy the main struct (reentrant only). */
-    yysmiles_free ( yyscanner , yyscanner );
+    yyfree ( yyscanner , yyscanner );
     yyscanner = NULL;
     return 0;
 }
@@ -3110,7 +3319,7 @@ int yysmiles_lex_destroy  (yyscan_t yyscanner)
  */
 
 #ifndef yytext_ptr
-static void yy_flex_strncpy (char* s1, yyconst char * s2, int n , yyscan_t yyscanner)
+static void yy_flex_strncpy (char* s1, const char * s2, int n , yyscan_t yyscanner)
 {
 	struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 	(void)yyg;
@@ -3122,7 +3331,7 @@ static void yy_flex_strncpy (char* s1, yyconst char * s2, int n , yyscan_t yysca
 #endif
 
 #ifdef YY_NEED_STRLEN
-static int yy_flex_strlen (yyconst char * s , yyscan_t yyscanner)
+static int yy_flex_strlen (const char * s , yyscan_t yyscanner)
 {
 	int n;
 	for ( n = 0; s[n]; ++n )
@@ -3132,14 +3341,14 @@ static int yy_flex_strlen (yyconst char * s , yyscan_t yyscanner)
 }
 #endif
 
-void *yysmiles_alloc (yy_size_t  size , yyscan_t yyscanner)
+void *yyalloc (yy_size_t  size , yyscan_t yyscanner)
 {
 	struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 	(void)yyg;
-	return (void *) malloc( size );
+	return malloc(size);
 }
 
-void *yysmiles_realloc  (void * ptr, yy_size_t  size , yyscan_t yyscanner)
+void *yyrealloc  (void * ptr, yy_size_t  size , yyscan_t yyscanner)
 {
 	struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 	(void)yyg;
@@ -3151,20 +3360,19 @@ void *yysmiles_realloc  (void * ptr, yy_size_t  size , yyscan_t yyscanner)
 	 * any pointer type to void*, and deal with argument conversions
 	 * as though doing an assignment.
 	 */
-	return (void *) realloc( (char *) ptr, size );
+	return realloc(ptr, size);
 }
 
-void yysmiles_free (void * ptr , yyscan_t yyscanner)
+void yyfree (void * ptr , yyscan_t yyscanner)
 {
 	struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 	(void)yyg;
-	free( (char *) ptr );	/* see yysmiles_realloc() for (char *) cast */
+	free( (char *) ptr );	/* see yyrealloc() for (char *) cast */
 }
 
 #define YYTABLES_NAME "yytables"
 
-#line 353 "smiles.ll"
-
+#line 368 "smiles.ll"
 
 
 #undef yysmiles_wrap

--- a/Code/GraphMol/SmilesParse/smarts.ll
+++ b/Code/GraphMol/SmilesParse/smarts.ll
@@ -90,6 +90,15 @@ size_t setup_smarts_string(const std::string &text,yyscan_t yyscanner){
 %s IN_RECURSION_STATE
 %%
 
+%{
+  if (start_token)
+    {
+      int t = start_token;
+      start_token = 0;
+      return t;
+    }
+%}
+
 @[' ']*TH |
 @[' ']*AL |
 @[' ']*SQ |

--- a/Code/GraphMol/SmilesParse/smarts.tab.cpp.cmake
+++ b/Code/GraphMol/SmilesParse/smarts.tab.cpp.cmake
@@ -50,7 +50,7 @@
 #define YYSKELETON_NAME "yacc.c"
 
 /* Pure parsers.  */
-#define YYPURE 1
+#define YYPURE 2
 
 /* Push parsers.  */
 #define YYPUSH 0
@@ -89,12 +89,14 @@
 #define YYDEBUG 1
 #include "smarts.tab.hpp"
 
-extern int yysmarts_lex(YYSTYPE *,void *);
+extern int yysmarts_lex(YYSTYPE *,void *, int &);
 
 void
 yysmarts_error( const char *input,
                 std::vector<RDKit::RWMol *> *ms,
-		void *scanner,const char * msg )
+                RDKit::Atom* &lastAtom,
+                RDKit::Bond* &lastBond,
+		void *scanner,int start_token, const char * msg )
 {
   throw RDKit::SmilesParseException(msg);
 }
@@ -111,7 +113,7 @@ namespace {
  }
 }
 
-#line 115 "C:/Users/glandrum/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:339  */
+#line 117 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:339  */
 
 # ifndef YY_NULLPTR
 #  if defined __cplusplus && 201103L <= __cplusplus
@@ -131,8 +133,8 @@ namespace {
 
 /* In a future release of Bison, this section will be replaced
    by #include "smarts.tab.hpp".  */
-#ifndef YY_YYSMARTS_C_USERS_GLANDRUM_RDKIT_GIT_CODE_GRAPHMOL_SMILESPARSE_SMARTS_TAB_HPP_INCLUDED
-# define YY_YYSMARTS_C_USERS_GLANDRUM_RDKIT_GIT_CODE_GRAPHMOL_SMILESPARSE_SMARTS_TAB_HPP_INCLUDED
+#ifndef YY_YYSMARTS_SCRATCH_RDKIT_GIT_CODE_GRAPHMOL_SMILESPARSE_SMARTS_TAB_HPP_INCLUDED
+# define YY_YYSMARTS_SCRATCH_RDKIT_GIT_CODE_GRAPHMOL_SMILESPARSE_SMARTS_TAB_HPP_INCLUDED
 /* Debug traces.  */
 #ifndef YYDEBUG
 # define YYDEBUG 0
@@ -146,46 +148,49 @@ extern int yysmarts_debug;
 # define YYTOKENTYPE
   enum yytokentype
   {
-    AROMATIC_ATOM_TOKEN = 258,
-    ORGANIC_ATOM_TOKEN = 259,
-    ATOM_TOKEN = 260,
-    SIMPLE_ATOM_QUERY_TOKEN = 261,
-    COMPLEX_ATOM_QUERY_TOKEN = 262,
-    RINGSIZE_ATOM_QUERY_TOKEN = 263,
-    RINGBOND_ATOM_QUERY_TOKEN = 264,
-    IMPLICIT_H_ATOM_QUERY_TOKEN = 265,
-    HYB_TOKEN = 266,
-    HETERONEIGHBOR_ATOM_QUERY_TOKEN = 267,
-    ALIPHATIC = 268,
-    ALIPHATICHETERONEIGHBOR_ATOM_QUERY_TOKEN = 269,
-    ZERO_TOKEN = 270,
-    NONZERO_DIGIT_TOKEN = 271,
-    GROUP_OPEN_TOKEN = 272,
-    GROUP_CLOSE_TOKEN = 273,
-    SEPARATOR_TOKEN = 274,
-    RANGE_OPEN_TOKEN = 275,
-    RANGE_CLOSE_TOKEN = 276,
-    HASH_TOKEN = 277,
-    MINUS_TOKEN = 278,
-    PLUS_TOKEN = 279,
-    CHIRAL_MARKER_TOKEN = 280,
-    CHI_CLASS_TOKEN = 281,
-    CHI_CLASS_OH_TOKEN = 282,
-    H_TOKEN = 283,
-    AT_TOKEN = 284,
-    PERCENT_TOKEN = 285,
-    ATOM_OPEN_TOKEN = 286,
-    ATOM_CLOSE_TOKEN = 287,
-    NOT_TOKEN = 288,
-    AND_TOKEN = 289,
-    OR_TOKEN = 290,
-    SEMI_TOKEN = 291,
-    BEGIN_RECURSE = 292,
-    END_RECURSE = 293,
-    COLON_TOKEN = 294,
-    UNDERSCORE_TOKEN = 295,
-    BOND_TOKEN = 296,
-    EOS_TOKEN = 297
+    START_MOL = 258,
+    START_ATOM = 259,
+    START_BOND = 260,
+    AROMATIC_ATOM_TOKEN = 261,
+    ORGANIC_ATOM_TOKEN = 262,
+    ATOM_TOKEN = 263,
+    SIMPLE_ATOM_QUERY_TOKEN = 264,
+    COMPLEX_ATOM_QUERY_TOKEN = 265,
+    RINGSIZE_ATOM_QUERY_TOKEN = 266,
+    RINGBOND_ATOM_QUERY_TOKEN = 267,
+    IMPLICIT_H_ATOM_QUERY_TOKEN = 268,
+    HYB_TOKEN = 269,
+    HETERONEIGHBOR_ATOM_QUERY_TOKEN = 270,
+    ALIPHATIC = 271,
+    ALIPHATICHETERONEIGHBOR_ATOM_QUERY_TOKEN = 272,
+    ZERO_TOKEN = 273,
+    NONZERO_DIGIT_TOKEN = 274,
+    GROUP_OPEN_TOKEN = 275,
+    GROUP_CLOSE_TOKEN = 276,
+    SEPARATOR_TOKEN = 277,
+    RANGE_OPEN_TOKEN = 278,
+    RANGE_CLOSE_TOKEN = 279,
+    HASH_TOKEN = 280,
+    MINUS_TOKEN = 281,
+    PLUS_TOKEN = 282,
+    CHIRAL_MARKER_TOKEN = 283,
+    CHI_CLASS_TOKEN = 284,
+    CHI_CLASS_OH_TOKEN = 285,
+    H_TOKEN = 286,
+    AT_TOKEN = 287,
+    PERCENT_TOKEN = 288,
+    ATOM_OPEN_TOKEN = 289,
+    ATOM_CLOSE_TOKEN = 290,
+    NOT_TOKEN = 291,
+    AND_TOKEN = 292,
+    OR_TOKEN = 293,
+    SEMI_TOKEN = 294,
+    BEGIN_RECURSE = 295,
+    END_RECURSE = 296,
+    COLON_TOKEN = 297,
+    UNDERSCORE_TOKEN = 298,
+    BOND_TOKEN = 299,
+    EOS_TOKEN = 300
   };
 #endif
 
@@ -194,14 +199,14 @@ extern int yysmarts_debug;
 
 union YYSTYPE
 {
-#line 50 "smarts.yy" /* yacc.c:355  */
+#line 61 "smarts.yy" /* yacc.c:355  */
 
   int                      moli;
   RDKit::QueryAtom * atom;
   RDKit::QueryBond * bond;
   int                      ival;
 
-#line 205 "C:/Users/glandrum/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:355  */
+#line 210 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:355  */
 };
 
 typedef union YYSTYPE YYSTYPE;
@@ -211,13 +216,20 @@ typedef union YYSTYPE YYSTYPE;
 
 
 
-int yysmarts_parse (const char *input, std::vector<RDKit::RWMol *> *molList, void *scanner);
+int yysmarts_parse (const char *input, std::vector<RDKit::RWMol *> *molList, RDKit::Atom* &lastAtom, RDKit::Bond* &lastBond, void *scanner, int& start_token);
+/* "%code provides" blocks.  */
+#line 56 "smarts.yy" /* yacc.c:355  */
 
-#endif /* !YY_YYSMARTS_C_USERS_GLANDRUM_RDKIT_GIT_CODE_GRAPHMOL_SMILESPARSE_SMARTS_TAB_HPP_INCLUDED  */
+#define YY_DECL int yylex \
+               (YYSTYPE * yylval_param , yyscan_t yyscanner, int& start_token)
+
+#line 227 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:355  */
+
+#endif /* !YY_YYSMARTS_SCRATCH_RDKIT_GIT_CODE_GRAPHMOL_SMILESPARSE_SMARTS_TAB_HPP_INCLUDED  */
 
 /* Copy the second part of user declarations.  */
 
-#line 221 "C:/Users/glandrum/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:358  */
+#line 233 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:358  */
 
 #ifdef short
 # undef short
@@ -457,23 +469,23 @@ union yyalloc
 #endif /* !YYCOPY_NEEDED */
 
 /* YYFINAL -- State number of the termination state.  */
-#define YYFINAL  38
+#define YYFINAL  25
 /* YYLAST -- Last index in YYTABLE.  */
-#define YYLAST   470
+#define YYLAST   467
 
 /* YYNTOKENS -- Number of terminals.  */
-#define YYNTOKENS  43
+#define YYNTOKENS  46
 /* YYNNTS -- Number of nonterminals.  */
 #define YYNNTS  20
 /* YYNRULES -- Number of rules.  */
-#define YYNRULES  106
+#define YYNRULES  108
 /* YYNSTATES -- Number of states.  */
-#define YYNSTATES  155
+#define YYNSTATES  160
 
 /* YYTRANSLATE[YYX] -- Symbol number corresponding to YYX as returned
    by yylex, with out-of-bounds checking.  */
 #define YYUNDEFTOK  2
-#define YYMAXUTOK   297
+#define YYMAXUTOK   300
 
 #define YYTRANSLATE(YYX)                                                \
   ((unsigned int) (YYX) <= YYMAXUTOK ? yytranslate[YYX] : YYUNDEFTOK)
@@ -511,24 +523,25 @@ static const yytype_uint8 yytranslate[] =
        5,     6,     7,     8,     9,    10,    11,    12,    13,    14,
       15,    16,    17,    18,    19,    20,    21,    22,    23,    24,
       25,    26,    27,    28,    29,    30,    31,    32,    33,    34,
-      35,    36,    37,    38,    39,    40,    41,    42
+      35,    36,    37,    38,    39,    40,    41,    42,    43,    44,
+      45
 };
 
 #if YYDEBUG
   /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
 static const yytype_uint16 yyrline[] =
 {
-       0,    87,    87,    88,    94,    97,   108,   116,   141,   161,
-     166,   197,   217,   231,   232,   243,   244,   245,   249,   272,
-     276,   281,   287,   296,   302,   310,   318,   331,   337,   343,
-     349,   372,   375,   381,   382,   386,   403,   427,   428,   433,
-     434,   439,   440,   445,   446,   447,   448,   449,   450,   451,
-     454,   457,   460,   463,   466,   469,   475,   481,   488,   496,
-     504,   510,   516,   522,   528,   534,   535,   542,   543,   546,
-     549,   552,   555,   561,   573,   578,   583,   587,   591,   595,
-     598,   599,   606,   607,   613,   619,   625,   630,   637,   638,
-     639,   640,   641,   642,   646,   647,   648,   649,   650,   651,
-     652,   657,   658,   662,   663,   666,   667
+       0,   101,   101,   104,   107,   110,   116,   119,   129,   137,
+     162,   182,   187,   218,   238,   252,   253,   264,   265,   266,
+     270,   293,   297,   302,   308,   317,   323,   331,   339,   352,
+     358,   364,   370,   393,   396,   402,   403,   407,   424,   448,
+     449,   454,   455,   460,   461,   466,   467,   468,   469,   470,
+     471,   472,   475,   478,   481,   484,   487,   490,   496,   502,
+     509,   517,   525,   531,   537,   543,   549,   555,   556,   563,
+     564,   567,   570,   573,   576,   582,   594,   599,   604,   608,
+     612,   616,   619,   620,   627,   628,   634,   640,   646,   651,
+     658,   659,   660,   661,   662,   663,   667,   668,   669,   670,
+     671,   672,   673,   678,   679,   683,   684,   687,   688
 };
 #endif
 
@@ -537,10 +550,11 @@ static const yytype_uint16 yyrline[] =
    First, the terminals, then, starting at YYNTOKENS, nonterminals.  */
 static const char *const yytname[] =
 {
-  "$end", "error", "$undefined", "AROMATIC_ATOM_TOKEN",
-  "ORGANIC_ATOM_TOKEN", "ATOM_TOKEN", "SIMPLE_ATOM_QUERY_TOKEN",
-  "COMPLEX_ATOM_QUERY_TOKEN", "RINGSIZE_ATOM_QUERY_TOKEN",
-  "RINGBOND_ATOM_QUERY_TOKEN", "IMPLICIT_H_ATOM_QUERY_TOKEN", "HYB_TOKEN",
+  "$end", "error", "$undefined", "START_MOL", "START_ATOM", "START_BOND",
+  "AROMATIC_ATOM_TOKEN", "ORGANIC_ATOM_TOKEN", "ATOM_TOKEN",
+  "SIMPLE_ATOM_QUERY_TOKEN", "COMPLEX_ATOM_QUERY_TOKEN",
+  "RINGSIZE_ATOM_QUERY_TOKEN", "RINGBOND_ATOM_QUERY_TOKEN",
+  "IMPLICIT_H_ATOM_QUERY_TOKEN", "HYB_TOKEN",
   "HETERONEIGHBOR_ATOM_QUERY_TOKEN", "ALIPHATIC",
   "ALIPHATICHETERONEIGHBOR_ATOM_QUERY_TOKEN", "ZERO_TOKEN",
   "NONZERO_DIGIT_TOKEN", "GROUP_OPEN_TOKEN", "GROUP_CLOSE_TOKEN",
@@ -549,8 +563,8 @@ static const char *const yytname[] =
   "CHI_CLASS_OH_TOKEN", "H_TOKEN", "AT_TOKEN", "PERCENT_TOKEN",
   "ATOM_OPEN_TOKEN", "ATOM_CLOSE_TOKEN", "NOT_TOKEN", "AND_TOKEN",
   "OR_TOKEN", "SEMI_TOKEN", "BEGIN_RECURSE", "END_RECURSE", "COLON_TOKEN",
-  "UNDERSCORE_TOKEN", "BOND_TOKEN", "EOS_TOKEN", "$accept", "cmpd", "mol",
-  "branch", "atomd", "hydrogen_atom", "atom_expr", "point_query",
+  "UNDERSCORE_TOKEN", "BOND_TOKEN", "EOS_TOKEN", "$accept", "meta_start",
+  "mol", "branch", "atomd", "hydrogen_atom", "atom_expr", "point_query",
   "recursive_query", "atom_query", "possible_range_query", "simple_atom",
   "bond_expr", "bond_query", "bondd", "charge_spec", "ring_number",
   "number", "nonzero_number", "digit", YY_NULLPTR
@@ -566,16 +580,16 @@ static const yytype_uint16 yytoknum[] =
      265,   266,   267,   268,   269,   270,   271,   272,   273,   274,
      275,   276,   277,   278,   279,   280,   281,   282,   283,   284,
      285,   286,   287,   288,   289,   290,   291,   292,   293,   294,
-     295,   296,   297
+     295,   296,   297,   298,   299,   300
 };
 # endif
 
-#define YYPACT_NINF -57
+#define YYPACT_NINF -50
 
 #define yypact_value_is_default(Yystate) \
-  (!!((Yystate) == (-57)))
+  (!!((Yystate) == (-50)))
 
-#define YYTABLE_NINF -73
+#define YYTABLE_NINF -75
 
 #define yytable_value_is_error(Yytable_value) \
   0
@@ -584,22 +598,22 @@ static const yytype_uint16 yytoknum[] =
      STATE-NUM.  */
 static const yytype_int16 yypact[] =
 {
-      27,   -26,   -57,   -57,   -57,   369,    22,   202,   -57,   -57,
-     -57,   -57,   -57,   113,   162,   222,   224,   -57,   233,   235,
-     -57,   -57,    69,    80,    25,    20,     5,   404,     1,   262,
-     -57,   -57,   -57,    30,   -57,   -57,    51,   124,   -57,    52,
-     -57,   -57,   -57,   223,     1,   -57,   -57,   -57,   185,   429,
-     -57,   -57,   -57,   -57,   419,   429,   -57,   -57,   -57,   -57,
-     -57,   -57,   -57,   -57,   -57,   -57,   -57,   -57,   -57,   -57,
-     -57,    69,    21,   -57,   -57,    69,   -57,    71,   119,   -57,
-     404,   404,   404,    69,   -57,    82,   -57,    69,   424,   -57,
-     -57,   -57,   150,   140,   -57,   124,   124,   -57,   429,   429,
-     429,   -57,   -57,   -57,    15,   -57,    69,    69,     2,   404,
-     334,   299,    31,    69,    77,   -57,   -57,    69,    49,   -57,
-     -57,   181,   -57,   146,   -57,    73,   253,   -57,    84,    98,
-     -57,    97,   116,    92,   -57,    69,   -57,   -57,   177,   -57,
-     124,   -57,   -57,   105,   -57,   115,   -57,   242,   -57,   -57,
-     -57,   264,   -57,   127,   -57
+     176,   -29,    32,    32,   106,    13,   -50,   -50,   -50,   -50,
+     353,   186,   -50,   -50,   -50,   -50,   -50,   -50,   -50,   106,
+     -50,   -50,   237,   106,   -50,   -50,   -27,   -50,   -50,    62,
+      79,   101,   139,   -50,   146,   227,   -50,   -50,    30,    14,
+      18,     8,   -26,   388,    32,   246,   -50,   -50,   -50,    46,
+     -50,   -50,   217,    56,   -50,   -50,   207,    32,    80,   -50,
+     -50,   403,   -50,   -50,   -50,   106,   106,   106,   -50,   -50,
+     -50,   -50,   -50,   -50,   -50,   -50,   -50,   -50,   -50,   -50,
+     -50,   -50,    30,   -25,   -50,   -50,    30,   -50,   424,   103,
+     -50,   388,   388,   388,    30,   -50,    28,   -50,    30,   425,
+     -50,   -50,   134,   420,   -50,    56,    56,   -50,   -50,   -50,
+      34,    76,    20,   -50,    30,    30,    40,   388,   318,   283,
+      60,    30,    75,   -50,   -50,    30,    17,   -50,   -50,   165,
+     -50,   216,   -50,    73,   107,   -50,   110,    49,   111,   -50,
+      30,   -50,   -50,   248,   -50,    56,   -50,   -50,   125,   -50,
+     116,   -50,   285,   -50,   -50,   -50,   320,   -50,   140,   -50
 };
 
   /* YYDEFACT[STATE-NUM] -- Default reduction number in state STATE-NUM.
@@ -607,36 +621,36 @@ static const yytype_int16 yypact[] =
      means the default is an error.  */
 static const yytype_uint8 yydefact[] =
 {
-       0,     0,    74,    73,    75,     0,     0,     2,     6,    16,
-      15,     5,    39,    43,    46,    47,    48,    65,    44,    45,
-     101,   103,     0,    93,    90,    61,    64,     0,     0,     0,
-      31,    33,    34,     0,    37,    62,    66,   102,     1,     0,
-       4,   106,   105,     0,     0,    84,    83,    86,     0,     0,
-      85,    82,    12,     7,     0,    79,    80,    10,    94,    49,
-      52,    53,    54,    50,    51,    41,    91,    92,    88,    89,
-      19,     0,     0,    60,    63,    61,    32,    66,     0,    17,
-       0,     0,     0,     0,    30,     0,    40,     0,    58,    38,
-     104,     3,     0,     0,     9,     0,     0,    87,     0,     0,
-       0,     8,    11,    81,     0,    23,     0,    58,    35,    27,
-      28,    29,     0,     0,     0,    42,    21,     0,     0,    59,
-      13,     0,    95,     0,    76,    77,    78,    20,     0,     0,
-      18,     0,     0,     0,    25,     0,    14,    96,     0,    24,
-      36,    55,    56,     0,    22,     0,    97,     0,    57,    26,
-      98,     0,    99,     0,   100
+       0,     0,     0,     0,     0,     0,     7,    76,    75,    77,
+       0,     2,     8,    18,    17,     3,    86,    85,    88,     0,
+      87,    84,     4,    81,    82,     1,     0,     6,    41,    45,
+      48,    49,    50,    67,    46,    47,   103,   105,     0,    95,
+      92,    63,    66,     0,     0,     0,    33,    35,    36,     0,
+      39,    64,    68,   104,   108,   107,     0,     0,     0,    14,
+       9,     0,    12,    96,    89,     0,     0,     0,    83,     5,
+      51,    54,    55,    56,    52,    53,    43,    93,    94,    90,
+      91,    21,     0,     0,    62,    65,    63,    34,    68,     0,
+      19,     0,     0,     0,     0,    32,     0,    42,     0,    60,
+      40,   106,     0,     0,    11,     0,     0,    10,    13,    78,
+      79,    80,     0,    25,     0,    60,    37,    29,    30,    31,
+       0,     0,     0,    44,    23,     0,     0,    61,    15,     0,
+      97,     0,    22,     0,     0,    20,     0,     0,     0,    27,
+       0,    16,    98,     0,    26,    38,    57,    58,     0,    24,
+       0,    99,     0,    59,    28,   100,     0,   101,     0,   102
 };
 
   /* YYPGOTO[NTERM-NUM].  */
-static const yytype_int8 yypgoto[] =
+static const yytype_int16 yypgoto[] =
 {
-     -57,   -57,   -22,   -57,    -6,   -57,   -56,     0,   -57,   -57,
-     -57,    10,   -31,   -57,    -4,   -23,   101,    -5,    34,   -34
+     -50,   -50,   -33,   -50,     4,   -50,   220,   -40,   -50,   -50,
+     -50,    -1,    -3,   -50,   -11,   -39,   102,   -10,    39,   -49
 };
 
   /* YYDEFGOTO[NTERM-NUM].  */
 static const yytype_int8 yydefgoto[] =
 {
-      -1,     6,     7,    52,     8,     9,    29,    30,    31,    32,
-      33,    10,    54,    55,    56,    35,    57,    77,    37,    58
+      -1,     5,    11,    59,    12,    13,    45,    46,    47,    48,
+      49,    14,    61,    23,    24,    51,    62,    88,    53,    63
 };
 
   /* YYTABLE[YYPACT[STATE-NUM]] -- What to do in state STATE-NUM.  If
@@ -644,160 +658,158 @@ static const yytype_int8 yydefgoto[] =
      number is the opposite.  If YYTABLE_NINF, syntax error.  */
 static const yytype_int16 yytable[] =
 {
-      36,    53,    72,    90,     2,     3,    78,     4,    59,    60,
-      61,    62,    93,    63,    64,    34,    11,    65,    67,    69,
-      73,    92,    38,    39,   109,   110,   111,    76,     1,    84,
-       2,     3,     5,     4,    74,    20,    21,    34,    94,    34,
-      20,    21,   129,    23,    24,    97,    89,   127,   101,    68,
-      85,   103,    70,   105,     2,     3,    86,     4,     5,    71,
-     106,   122,   123,   130,    40,   118,   104,   124,   125,   126,
-      73,   121,    53,    87,     2,     3,    86,     4,   112,    88,
-     114,   134,   115,   119,    20,    21,    53,    89,   135,   138,
-      34,    34,    34,    87,    91,    20,    21,    20,    21,   107,
-     132,   128,   119,    66,   147,   113,    90,    98,   131,    84,
-      84,    84,   133,   151,    21,    53,   139,   153,   141,    34,
-      34,    34,     2,     3,   144,     4,   148,   143,    20,    21,
-     145,    20,    21,   -67,    41,    42,    43,   142,    44,    41,
-      42,    45,    46,     2,     3,   154,     4,   149,    47,    48,
-       5,     0,    49,     2,     3,   102,     4,   108,    50,     0,
-      51,    41,    42,   140,   137,    41,    42,    43,   120,    44,
-       0,     5,    45,    46,    98,    99,   100,    20,    21,    47,
-      48,     5,   -70,    49,     2,     3,     0,     4,     0,    50,
-       0,    51,    41,    42,     0,   146,    41,    42,    43,   136,
-      44,    95,    96,    45,    46,     2,     3,     0,     4,     0,
-      47,    48,     5,     0,    49,     0,     0,    41,    42,    43,
-      50,    44,    51,     0,    45,    46,     2,     3,     0,     4,
-       0,    47,    48,     5,     0,    49,     0,    20,    21,    20,
-      21,    50,   -71,    51,   -72,    45,    46,     0,    20,    21,
-      20,    21,    47,   -68,     5,   -69,    49,    41,    42,     0,
-     150,     0,    50,     0,    51,     2,     3,    12,     4,    13,
-      14,    15,    16,    17,    18,     0,    19,    20,    21,    41,
-      42,     0,   152,     0,    22,    23,    24,    98,    99,     0,
-      75,    26,     0,     0,    79,    27,    80,    81,    82,    28,
-       0,    83,     2,     3,    12,     4,    13,    14,    15,    16,
-      17,    18,     0,    19,    20,    21,     0,     0,     0,     0,
-       0,    22,    23,    24,     0,     0,     0,    75,    26,     0,
-       0,     0,    27,    80,    81,     0,    28,     2,     3,    12,
-       4,    13,    14,    15,    16,    17,    18,     0,    19,    20,
-      21,     0,     0,     0,     0,     0,    22,    23,    24,     0,
-       0,     0,    75,    26,     0,     0,     0,    27,    80,     0,
-       0,    28,     2,     3,    12,     4,    13,    14,    15,    16,
-      17,    18,     0,    19,    20,    21,     0,     0,     0,     0,
-       0,    22,    23,    24,     0,     0,     0,    25,    26,     0,
-       0,     0,    27,     0,     0,     0,    28,     2,     3,    12,
-       4,    13,    14,    15,    16,    17,    18,     0,    19,    20,
-      21,     0,     2,     3,     0,     4,    22,    23,    24,     0,
-       0,     0,    75,    26,    41,    42,     0,    27,     0,    20,
-      21,    28,     0,     0,     0,     0,     0,    23,    24,    48,
-       5,    45,    46,    98,    99,   100,   116,     0,    47,     0,
-       0,     0,    49,   117,     0,     0,     0,     0,    50,     0,
-      51
+      52,    22,    83,    87,   101,    95,    85,    15,    64,    50,
+     113,    89,    68,    25,    26,    60,     6,   114,    69,    70,
+      71,    72,    73,   102,    74,    75,    36,    37,    76,    78,
+      80,    84,    36,    37,    39,    40,    36,    37,     7,     8,
+      77,     9,    50,    81,    50,    79,    36,    37,    36,    37,
+      82,   100,   139,   103,   121,   132,   130,   131,    27,   140,
+     126,   104,   109,   110,   111,   107,    10,    36,    37,    96,
+     129,    65,   112,   147,    54,    55,    84,    95,    95,    95,
+      36,    37,   143,   134,   120,   -69,   122,   100,   123,   127,
+      50,    50,    50,    60,   152,   135,   101,    36,    37,   105,
+     106,   137,   -72,   156,   133,   127,    60,   158,   144,     7,
+       8,   136,     9,    65,    66,   138,    50,    50,    50,    36,
+      37,    54,    55,    56,   -73,    57,    37,   148,    16,    17,
+     150,    16,    17,    60,   146,    18,    58,    10,    18,    19,
+       7,     8,    19,     9,   116,    20,   149,    21,    20,   153,
+      21,   154,    54,    55,    56,   128,    57,    36,    37,    16,
+      17,   159,   -74,   108,    36,    37,    18,    58,    10,   -70,
+      19,     7,     8,   145,     9,     0,    20,     1,    21,     2,
+       3,     4,     0,    54,    55,    56,   141,    57,     0,     0,
+      16,    17,     7,     8,     0,     9,     0,    18,    58,    10,
+       0,    19,     0,     0,    54,    55,    56,    20,    57,    21,
+       0,    16,    17,     7,     8,     0,     9,     0,    18,    58,
+      10,     0,    19,     7,     8,    97,     9,     0,    20,     0,
+      21,     0,    16,    17,    54,    55,     0,   142,     0,    18,
+       0,    10,    98,    19,     0,    36,    37,     0,    99,    20,
+     -71,    21,     7,     8,    28,     9,    29,    30,    31,    32,
+      33,    34,     0,    35,    36,    37,    54,    55,     0,   151,
+       0,    38,    39,    40,    65,    66,    67,    86,    42,     0,
+       0,    90,    43,    91,    92,    93,    44,     0,    94,     7,
+       8,    28,     9,    29,    30,    31,    32,    33,    34,     0,
+      35,    36,    37,    54,    55,     0,   155,     0,    38,    39,
+      40,   117,   118,   119,    86,    42,     0,     0,     0,    43,
+      91,    92,     0,    44,     7,     8,    28,     9,    29,    30,
+      31,    32,    33,    34,     0,    35,    36,    37,    54,    55,
+       0,   157,     0,    38,    39,    40,     0,     0,     0,    86,
+      42,     0,     0,     0,    43,    91,     0,     0,    44,     7,
+       8,    28,     9,    29,    30,    31,    32,    33,    34,     0,
+      35,    36,    37,     0,     0,     0,     0,     0,    38,    39,
+      40,     0,     0,     0,    41,    42,     0,     0,     0,    43,
+       0,     0,     0,    44,     7,     8,    28,     9,    29,    30,
+      31,    32,    33,    34,     0,    35,    36,    37,     0,     7,
+       8,     0,     9,    38,    39,    40,     0,     0,     0,    86,
+      42,    54,    55,     0,    43,     0,     7,     8,    44,     9,
+       7,     8,    97,     9,     0,     0,    58,    10,     0,     0,
+      65,    66,    67,    36,    37,     0,     0,     0,     0,    98,
+       0,    39,    40,     0,    10,   115,     0,    65,    66,    67,
+     124,     0,     0,     0,     0,     0,     0,   125
 };
 
 static const yytype_int16 yycheck[] =
 {
-       5,     7,    25,    37,     3,     4,    28,     6,    13,    14,
-      15,    16,    43,    18,    19,     5,    42,    22,    23,    24,
-      25,    43,     0,     1,    80,    81,    82,    27,     1,    29,
-       3,     4,    31,     6,    29,    15,    16,    27,    44,    29,
-      15,    16,    40,    23,    24,    49,    36,    32,    54,    24,
-      20,    55,    32,    32,     3,     4,     5,     6,    31,    39,
-      39,    95,    96,    32,    42,    88,    71,    98,    99,   100,
-      75,    93,    78,    22,     3,     4,     5,     6,    83,    28,
-      85,    32,    87,    88,    15,    16,    92,    77,    39,   123,
-      80,    81,    82,    22,    42,    15,    16,    15,    16,    28,
-      23,   106,   107,    23,   138,    23,   140,    34,   113,   109,
-     110,   111,   117,   147,    16,   121,    32,   151,    21,   109,
-     110,   111,     3,     4,    32,     6,    21,   132,    15,    16,
-     135,    15,    16,    20,    15,    16,    17,    21,    19,    15,
-      16,    22,    23,     3,     4,    18,     6,    32,    29,    30,
-      31,    -1,    33,     3,     4,    54,     6,    38,    39,    -1,
-      41,    15,    16,   129,    18,    15,    16,    17,    18,    19,
-      -1,    31,    22,    23,    34,    35,    36,    15,    16,    29,
-      30,    31,    20,    33,     3,     4,    -1,     6,    -1,    39,
-      -1,    41,    15,    16,    -1,    18,    15,    16,    17,    18,
-      19,    16,    17,    22,    23,     3,     4,    -1,     6,    -1,
-      29,    30,    31,    -1,    33,    -1,    -1,    15,    16,    17,
-      39,    19,    41,    -1,    22,    23,     3,     4,    -1,     6,
-      -1,    29,    30,    31,    -1,    33,    -1,    15,    16,    15,
-      16,    39,    20,    41,    20,    22,    23,    -1,    15,    16,
-      15,    16,    29,    20,    31,    20,    33,    15,    16,    -1,
-      18,    -1,    39,    -1,    41,     3,     4,     5,     6,     7,
-       8,     9,    10,    11,    12,    -1,    14,    15,    16,    15,
-      16,    -1,    18,    -1,    22,    23,    24,    34,    35,    -1,
-      28,    29,    -1,    -1,    32,    33,    34,    35,    36,    37,
-      -1,    39,     3,     4,     5,     6,     7,     8,     9,    10,
-      11,    12,    -1,    14,    15,    16,    -1,    -1,    -1,    -1,
-      -1,    22,    23,    24,    -1,    -1,    -1,    28,    29,    -1,
-      -1,    -1,    33,    34,    35,    -1,    37,     3,     4,     5,
-       6,     7,     8,     9,    10,    11,    12,    -1,    14,    15,
-      16,    -1,    -1,    -1,    -1,    -1,    22,    23,    24,    -1,
-      -1,    -1,    28,    29,    -1,    -1,    -1,    33,    34,    -1,
-      -1,    37,     3,     4,     5,     6,     7,     8,     9,    10,
-      11,    12,    -1,    14,    15,    16,    -1,    -1,    -1,    -1,
-      -1,    22,    23,    24,    -1,    -1,    -1,    28,    29,    -1,
-      -1,    -1,    33,    -1,    -1,    -1,    37,     3,     4,     5,
-       6,     7,     8,     9,    10,    11,    12,    -1,    14,    15,
-      16,    -1,     3,     4,    -1,     6,    22,    23,    24,    -1,
-      -1,    -1,    28,    29,    15,    16,    -1,    33,    -1,    15,
-      16,    37,    -1,    -1,    -1,    -1,    -1,    23,    24,    30,
-      31,    22,    23,    34,    35,    36,    32,    -1,    29,    -1,
-      -1,    -1,    33,    39,    -1,    -1,    -1,    -1,    39,    -1,
-      41
+      10,     4,    41,    43,    53,    45,    32,     3,    19,    10,
+      35,    44,    23,     0,     1,    11,    45,    42,    45,    29,
+      30,    31,    32,    56,    34,    35,    18,    19,    38,    39,
+      40,    41,    18,    19,    26,    27,    18,    19,     6,     7,
+      26,     9,    43,    35,    45,    27,    18,    19,    18,    19,
+      42,    52,    35,    56,    26,    35,   105,   106,    45,    42,
+      99,    57,    65,    66,    67,    61,    34,    18,    19,    23,
+     103,    37,    82,    24,    18,    19,    86,   117,   118,   119,
+      18,    19,   131,    43,    94,    23,    96,    88,    98,    99,
+      91,    92,    93,    89,   143,    35,   145,    18,    19,    19,
+      20,    26,    23,   152,   114,   115,   102,   156,    35,     6,
+       7,   121,     9,    37,    38,   125,   117,   118,   119,    18,
+      19,    18,    19,    20,    23,    22,    19,   137,    25,    26,
+     140,    25,    26,   129,    24,    32,    33,    34,    32,    36,
+       6,     7,    36,     9,    41,    42,    35,    44,    42,    24,
+      44,    35,    18,    19,    20,    21,    22,    18,    19,    25,
+      26,    21,    23,    61,    18,    19,    32,    33,    34,    23,
+      36,     6,     7,   134,     9,    -1,    42,     1,    44,     3,
+       4,     5,    -1,    18,    19,    20,    21,    22,    -1,    -1,
+      25,    26,     6,     7,    -1,     9,    -1,    32,    33,    34,
+      -1,    36,    -1,    -1,    18,    19,    20,    42,    22,    44,
+      -1,    25,    26,     6,     7,    -1,     9,    -1,    32,    33,
+      34,    -1,    36,     6,     7,     8,     9,    -1,    42,    -1,
+      44,    -1,    25,    26,    18,    19,    -1,    21,    -1,    32,
+      -1,    34,    25,    36,    -1,    18,    19,    -1,    31,    42,
+      23,    44,     6,     7,     8,     9,    10,    11,    12,    13,
+      14,    15,    -1,    17,    18,    19,    18,    19,    -1,    21,
+      -1,    25,    26,    27,    37,    38,    39,    31,    32,    -1,
+      -1,    35,    36,    37,    38,    39,    40,    -1,    42,     6,
+       7,     8,     9,    10,    11,    12,    13,    14,    15,    -1,
+      17,    18,    19,    18,    19,    -1,    21,    -1,    25,    26,
+      27,    91,    92,    93,    31,    32,    -1,    -1,    -1,    36,
+      37,    38,    -1,    40,     6,     7,     8,     9,    10,    11,
+      12,    13,    14,    15,    -1,    17,    18,    19,    18,    19,
+      -1,    21,    -1,    25,    26,    27,    -1,    -1,    -1,    31,
+      32,    -1,    -1,    -1,    36,    37,    -1,    -1,    40,     6,
+       7,     8,     9,    10,    11,    12,    13,    14,    15,    -1,
+      17,    18,    19,    -1,    -1,    -1,    -1,    -1,    25,    26,
+      27,    -1,    -1,    -1,    31,    32,    -1,    -1,    -1,    36,
+      -1,    -1,    -1,    40,     6,     7,     8,     9,    10,    11,
+      12,    13,    14,    15,    -1,    17,    18,    19,    -1,     6,
+       7,    -1,     9,    25,    26,    27,    -1,    -1,    -1,    31,
+      32,    18,    19,    -1,    36,    -1,     6,     7,    40,     9,
+       6,     7,     8,     9,    -1,    -1,    33,    34,    -1,    -1,
+      37,    38,    39,    18,    19,    -1,    -1,    -1,    -1,    25,
+      -1,    26,    27,    -1,    34,    31,    -1,    37,    38,    39,
+      35,    -1,    -1,    -1,    -1,    -1,    -1,    42
 };
 
   /* YYSTOS[STATE-NUM] -- The (internal number of the) accessing
      symbol of state STATE-NUM.  */
 static const yytype_uint8 yystos[] =
 {
-       0,     1,     3,     4,     6,    31,    44,    45,    47,    48,
-      54,    42,     5,     7,     8,     9,    10,    11,    12,    14,
-      15,    16,    22,    23,    24,    28,    29,    33,    37,    49,
-      50,    51,    52,    53,    54,    58,    60,    61,     0,     1,
-      42,    15,    16,    17,    19,    22,    23,    29,    30,    33,
-      39,    41,    46,    47,    55,    56,    57,    59,    62,    60,
-      60,    60,    60,    60,    60,    60,    23,    60,    24,    60,
-      32,    39,    58,    60,    29,    28,    50,    60,    45,    32,
-      34,    35,    36,    39,    50,    20,     5,    22,    28,    54,
-      62,    42,    45,    55,    47,    16,    17,    57,    34,    35,
-      36,    47,    59,    57,    60,    32,    39,    28,    38,    49,
-      49,    49,    60,    23,    60,    60,    32,    39,    58,    60,
-      18,    45,    62,    62,    55,    55,    55,    32,    60,    40,
-      32,    60,    23,    60,    32,    39,    18,    18,    62,    32,
-      61,    21,    21,    60,    32,    60,    18,    62,    21,    32,
-      18,    62,    18,    62,    18
+       0,     1,     3,     4,     5,    47,    45,     6,     7,     9,
+      34,    48,    50,    51,    57,    50,    25,    26,    32,    36,
+      42,    44,    58,    59,    60,     0,     1,    45,     8,    10,
+      11,    12,    13,    14,    15,    17,    18,    19,    25,    26,
+      27,    31,    32,    36,    40,    52,    53,    54,    55,    56,
+      57,    61,    63,    64,    18,    19,    20,    22,    33,    49,
+      50,    58,    62,    65,    60,    37,    38,    39,    60,    45,
+      63,    63,    63,    63,    63,    63,    63,    26,    63,    27,
+      63,    35,    42,    61,    63,    32,    31,    53,    63,    48,
+      35,    37,    38,    39,    42,    53,    23,     8,    25,    31,
+      57,    65,    48,    58,    50,    19,    20,    50,    62,    58,
+      58,    58,    63,    35,    42,    31,    41,    52,    52,    52,
+      63,    26,    63,    63,    35,    42,    61,    63,    21,    48,
+      65,    65,    35,    63,    43,    35,    63,    26,    63,    35,
+      42,    21,    21,    65,    35,    64,    24,    24,    63,    35,
+      63,    21,    65,    24,    35,    21,    65,    21,    65,    21
 };
 
   /* YYR1[YYN] -- Symbol number of symbol that rule YYN derives.  */
 static const yytype_uint8 yyr1[] =
 {
-       0,    43,    44,    44,    44,    44,    45,    45,    45,    45,
-      45,    45,    45,    46,    46,    47,    47,    47,    47,    48,
-      48,    48,    48,    48,    48,    48,    48,    49,    49,    49,
-      49,    49,    50,    50,    50,    51,    51,    52,    52,    52,
-      52,    52,    52,    52,    52,    52,    52,    52,    52,    52,
-      52,    52,    52,    52,    52,    52,    52,    52,    52,    52,
-      52,    52,    52,    52,    52,    52,    52,    53,    53,    53,
-      53,    53,    53,    54,    54,    54,    55,    55,    55,    55,
-      56,    56,    57,    57,    57,    57,    57,    57,    58,    58,
-      58,    58,    58,    58,    59,    59,    59,    59,    59,    59,
-      59,    60,    60,    61,    61,    62,    62
+       0,    46,    47,    47,    47,    47,    47,    47,    48,    48,
+      48,    48,    48,    48,    48,    49,    49,    50,    50,    50,
+      50,    51,    51,    51,    51,    51,    51,    51,    51,    52,
+      52,    52,    52,    52,    53,    53,    53,    54,    54,    55,
+      55,    55,    55,    55,    55,    55,    55,    55,    55,    55,
+      55,    55,    55,    55,    55,    55,    55,    55,    55,    55,
+      55,    55,    55,    55,    55,    55,    55,    55,    55,    56,
+      56,    56,    56,    56,    56,    57,    57,    57,    58,    58,
+      58,    58,    59,    59,    60,    60,    60,    60,    60,    60,
+      61,    61,    61,    61,    61,    61,    62,    62,    62,    62,
+      62,    62,    62,    63,    63,    64,    64,    65,    65
 };
 
   /* YYR2[YYN] -- Number of symbols on the right hand side of rule YYN.  */
 static const yytype_uint8 yyr2[] =
 {
-       0,     2,     1,     3,     2,     2,     1,     2,     3,     3,
-       2,     3,     2,     3,     4,     1,     1,     3,     5,     3,
-       5,     4,     6,     4,     6,     5,     7,     3,     3,     3,
-       2,     1,     2,     1,     1,     3,     5,     1,     2,     1,
-       2,     2,     3,     1,     1,     1,     1,     1,     1,     2,
-       2,     2,     2,     2,     2,     5,     5,     6,     2,     3,
-       2,     1,     1,     2,     1,     1,     1,     1,     1,     1,
-       1,     1,     1,     1,     1,     1,     3,     3,     3,     1,
-       1,     2,     1,     1,     1,     1,     1,     2,     2,     2,
-       1,     2,     2,     1,     1,     3,     4,     5,     6,     7,
-       8,     1,     1,     1,     2,     1,     1
+       0,     2,     2,     2,     2,     3,     2,     2,     1,     2,
+       3,     3,     2,     3,     2,     3,     4,     1,     1,     3,
+       5,     3,     5,     4,     6,     4,     6,     5,     7,     3,
+       3,     3,     2,     1,     2,     1,     1,     3,     5,     1,
+       2,     1,     2,     2,     3,     1,     1,     1,     1,     1,
+       1,     2,     2,     2,     2,     2,     2,     5,     5,     6,
+       2,     3,     2,     1,     1,     2,     1,     1,     1,     1,
+       1,     1,     1,     1,     1,     1,     1,     1,     3,     3,
+       3,     1,     1,     2,     1,     1,     1,     1,     1,     2,
+       2,     2,     1,     2,     2,     1,     1,     3,     4,     5,
+       6,     7,     8,     1,     1,     1,     2,     1,     1
 };
 
 
@@ -825,7 +837,7 @@ do                                                              \
     }                                                           \
   else                                                          \
     {                                                           \
-      yyerror (input, molList, scanner, YY_("syntax error: cannot back up")); \
+      yyerror (input, molList, lastAtom, lastBond, scanner, start_token, YY_("syntax error: cannot back up")); \
       YYERROR;                                                  \
     }                                                           \
 while (0)
@@ -862,7 +874,7 @@ do {                                                                      \
     {                                                                     \
       YYFPRINTF (stderr, "%s ", Title);                                   \
       yy_symbol_print (stderr,                                            \
-                  Type, Value, input, molList, scanner); \
+                  Type, Value, input, molList, lastAtom, lastBond, scanner, start_token); \
       YYFPRINTF (stderr, "\n");                                           \
     }                                                                     \
 } while (0)
@@ -873,13 +885,16 @@ do {                                                                      \
 `----------------------------------------*/
 
 static void
-yy_symbol_value_print (FILE *yyoutput, int yytype, YYSTYPE const * const yyvaluep, const char *input, std::vector<RDKit::RWMol *> *molList, void *scanner)
+yy_symbol_value_print (FILE *yyoutput, int yytype, YYSTYPE const * const yyvaluep, const char *input, std::vector<RDKit::RWMol *> *molList, RDKit::Atom* &lastAtom, RDKit::Bond* &lastBond, void *scanner, int& start_token)
 {
   FILE *yyo = yyoutput;
   YYUSE (yyo);
   YYUSE (input);
   YYUSE (molList);
+  YYUSE (lastAtom);
+  YYUSE (lastBond);
   YYUSE (scanner);
+  YYUSE (start_token);
   if (!yyvaluep)
     return;
 # ifdef YYPRINT
@@ -895,12 +910,12 @@ yy_symbol_value_print (FILE *yyoutput, int yytype, YYSTYPE const * const yyvalue
 `--------------------------------*/
 
 static void
-yy_symbol_print (FILE *yyoutput, int yytype, YYSTYPE const * const yyvaluep, const char *input, std::vector<RDKit::RWMol *> *molList, void *scanner)
+yy_symbol_print (FILE *yyoutput, int yytype, YYSTYPE const * const yyvaluep, const char *input, std::vector<RDKit::RWMol *> *molList, RDKit::Atom* &lastAtom, RDKit::Bond* &lastBond, void *scanner, int& start_token)
 {
   YYFPRINTF (yyoutput, "%s %s (",
              yytype < YYNTOKENS ? "token" : "nterm", yytname[yytype]);
 
-  yy_symbol_value_print (yyoutput, yytype, yyvaluep, input, molList, scanner);
+  yy_symbol_value_print (yyoutput, yytype, yyvaluep, input, molList, lastAtom, lastBond, scanner, start_token);
   YYFPRINTF (yyoutput, ")");
 }
 
@@ -933,7 +948,7 @@ do {                                                            \
 `------------------------------------------------*/
 
 static void
-yy_reduce_print (yytype_int16 *yyssp, YYSTYPE *yyvsp, int yyrule, const char *input, std::vector<RDKit::RWMol *> *molList, void *scanner)
+yy_reduce_print (yytype_int16 *yyssp, YYSTYPE *yyvsp, int yyrule, const char *input, std::vector<RDKit::RWMol *> *molList, RDKit::Atom* &lastAtom, RDKit::Bond* &lastBond, void *scanner, int& start_token)
 {
   unsigned long int yylno = yyrline[yyrule];
   int yynrhs = yyr2[yyrule];
@@ -947,7 +962,7 @@ yy_reduce_print (yytype_int16 *yyssp, YYSTYPE *yyvsp, int yyrule, const char *in
       yy_symbol_print (stderr,
                        yystos[yyssp[yyi + 1 - yynrhs]],
                        &(yyvsp[(yyi + 1) - (yynrhs)])
-                                              , input, molList, scanner);
+                                              , input, molList, lastAtom, lastBond, scanner, start_token);
       YYFPRINTF (stderr, "\n");
     }
 }
@@ -955,7 +970,7 @@ yy_reduce_print (yytype_int16 *yyssp, YYSTYPE *yyvsp, int yyrule, const char *in
 # define YY_REDUCE_PRINT(Rule)          \
 do {                                    \
   if (yydebug)                          \
-    yy_reduce_print (yyssp, yyvsp, Rule, input, molList, scanner); \
+    yy_reduce_print (yyssp, yyvsp, Rule, input, molList, lastAtom, lastBond, scanner, start_token); \
 } while (0)
 
 /* Nonzero means print parse trace.  It is left uninitialized so that
@@ -1213,12 +1228,15 @@ yysyntax_error (YYSIZE_T *yymsg_alloc, char **yymsg,
 `-----------------------------------------------*/
 
 static void
-yydestruct (const char *yymsg, int yytype, YYSTYPE *yyvaluep, const char *input, std::vector<RDKit::RWMol *> *molList, void *scanner)
+yydestruct (const char *yymsg, int yytype, YYSTYPE *yyvaluep, const char *input, std::vector<RDKit::RWMol *> *molList, RDKit::Atom* &lastAtom, RDKit::Bond* &lastBond, void *scanner, int& start_token)
 {
   YYUSE (yyvaluep);
   YYUSE (input);
   YYUSE (molList);
+  YYUSE (lastAtom);
+  YYUSE (lastBond);
   YYUSE (scanner);
+  YYUSE (start_token);
   if (!yymsg)
     yymsg = "Deleting";
   YY_SYMBOL_PRINT (yymsg, yytype, yyvaluep, yylocationp);
@@ -1236,7 +1254,7 @@ yydestruct (const char *yymsg, int yytype, YYSTYPE *yyvaluep, const char *input,
 `----------*/
 
 int
-yyparse (const char *input, std::vector<RDKit::RWMol *> *molList, void *scanner)
+yyparse (const char *input, std::vector<RDKit::RWMol *> *molList, RDKit::Atom* &lastAtom, RDKit::Bond* &lastBond, void *scanner, int& start_token)
 {
 /* The lookahead symbol.  */
 int yychar;
@@ -1405,7 +1423,7 @@ yybackup:
   if (yychar == YYEMPTY)
     {
       YYDPRINTF ((stderr, "Reading a token: "));
-      yychar = yylex (&yylval, scanner);
+      yychar = yylex (&yylval, scanner, start_token);
     }
 
   if (yychar <= YYEOF)
@@ -1483,39 +1501,62 @@ yyreduce:
   YY_REDUCE_PRINT (yyn);
   switch (yyn)
     {
-        case 3:
-#line 88 "smarts.yy" /* yacc.c:1646  */
+        case 2:
+#line 101 "smarts.yy" /* yacc.c:1646  */
     {
-  yyclearin;
-  yyerrok;
-  yyErrorCleanup(molList);
-  YYABORT;
+// the molList has already been updated, no need to do anything
 }
-#line 1495 "C:/Users/glandrum/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
+#line 1510 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
+    break;
+
+  case 3:
+#line 104 "smarts.yy" /* yacc.c:1646  */
+    {
+  lastAtom = (yyvsp[0].atom);
+}
+#line 1518 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
     break;
 
   case 4:
-#line 94 "smarts.yy" /* yacc.c:1646  */
+#line 107 "smarts.yy" /* yacc.c:1646  */
     {
-  YYACCEPT;
+  lastBond = (yyvsp[0].bond);
 }
-#line 1503 "C:/Users/glandrum/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
+#line 1526 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
     break;
 
   case 5:
-#line 97 "smarts.yy" /* yacc.c:1646  */
+#line 110 "smarts.yy" /* yacc.c:1646  */
     {
   yyclearin;
   yyerrok;
-
   yyErrorCleanup(molList);
   YYABORT;
 }
-#line 1515 "C:/Users/glandrum/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
+#line 1537 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
     break;
 
   case 6:
-#line 108 "smarts.yy" /* yacc.c:1646  */
+#line 116 "smarts.yy" /* yacc.c:1646  */
+    {
+  YYACCEPT;
+}
+#line 1545 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
+    break;
+
+  case 7:
+#line 119 "smarts.yy" /* yacc.c:1646  */
+    {
+  yyclearin;
+  yyerrok;
+  yyErrorCleanup(molList);
+  YYABORT;
+}
+#line 1556 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
+    break;
+
+  case 8:
+#line 129 "smarts.yy" /* yacc.c:1646  */
     {
   int sz     = molList->size();
   molList->resize( sz + 1);
@@ -1524,11 +1565,11 @@ yyreduce:
   //delete $1;
   (yyval.moli) = sz;
 }
-#line 1528 "C:/Users/glandrum/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
+#line 1569 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
     break;
 
-  case 7:
-#line 116 "smarts.yy" /* yacc.c:1646  */
+  case 9:
+#line 137 "smarts.yy" /* yacc.c:1646  */
     {
   RWMol *mp = (*molList)[(yyval.moli)];
   Atom *a1 = mp->getActiveAtom();
@@ -1553,11 +1594,11 @@ yyreduce:
   delete newB;
   //delete $2;
 }
-#line 1557 "C:/Users/glandrum/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
+#line 1598 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
     break;
 
-  case 8:
-#line 141 "smarts.yy" /* yacc.c:1646  */
+  case 10:
+#line 162 "smarts.yy" /* yacc.c:1646  */
     {
   RWMol *mp = (*molList)[(yyval.moli)];
   int atomIdx1 = mp->getActiveAtom()->getIdx();
@@ -1577,20 +1618,20 @@ yyreduce:
   mp->addBond((yyvsp[-1].bond));
   delete (yyvsp[-1].bond);
 }
-#line 1581 "C:/Users/glandrum/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
+#line 1622 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
     break;
 
-  case 9:
-#line 161 "smarts.yy" /* yacc.c:1646  */
+  case 11:
+#line 182 "smarts.yy" /* yacc.c:1646  */
     {
   RWMol *mp = (*molList)[(yyval.moli)];
   mp->addAtom((yyvsp[0].atom),true,true);
 }
-#line 1590 "C:/Users/glandrum/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
+#line 1631 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
     break;
 
-  case 10:
-#line 166 "smarts.yy" /* yacc.c:1646  */
+  case 12:
+#line 187 "smarts.yy" /* yacc.c:1646  */
     {
   RWMol * mp = (*molList)[(yyval.moli)];
   Atom *atom=mp->getActiveAtom();
@@ -1621,11 +1662,11 @@ yyreduce:
   atom->setProp(RDKit::common_properties::_RingClosures,tmp);
 
 }
-#line 1625 "C:/Users/glandrum/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
+#line 1666 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
     break;
 
-  case 11:
-#line 197 "smarts.yy" /* yacc.c:1646  */
+  case 13:
+#line 218 "smarts.yy" /* yacc.c:1646  */
     {
   RWMol * mp = (*molList)[(yyval.moli)];
   Atom *atom=mp->getActiveAtom();
@@ -1645,11 +1686,11 @@ yyreduce:
   atom->setProp(RDKit::common_properties::_RingClosures,tmp);
 
 }
-#line 1649 "C:/Users/glandrum/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
+#line 1690 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
     break;
 
-  case 12:
-#line 217 "smarts.yy" /* yacc.c:1646  */
+  case 14:
+#line 238 "smarts.yy" /* yacc.c:1646  */
     {
   RWMol *m1_p = (*molList)[(yyval.moli)],*m2_p=(*molList)[(yyvsp[0].moli)];
   // FIX: handle generic bonds here
@@ -1660,17 +1701,17 @@ yyreduce:
     molList->resize( sz-1 );
   }
 }
-#line 1664 "C:/Users/glandrum/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
+#line 1705 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
     break;
 
-  case 13:
-#line 231 "smarts.yy" /* yacc.c:1646  */
+  case 15:
+#line 252 "smarts.yy" /* yacc.c:1646  */
     { (yyval.moli) = (yyvsp[-1].moli); }
-#line 1670 "C:/Users/glandrum/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
+#line 1711 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
     break;
 
-  case 14:
-#line 232 "smarts.yy" /* yacc.c:1646  */
+  case 16:
+#line 253 "smarts.yy" /* yacc.c:1646  */
     {
   // FIX: this needs to handle arbitrary bond_exprs
   (yyval.moli) = (yyvsp[-1].moli);
@@ -1679,56 +1720,56 @@ yyreduce:
   (yyvsp[-2].bond)->setBeginAtomIdx(0);
   (*molList)[ sz-1 ]->setBondBookmark((yyvsp[-2].bond),ci_LEADING_BOND);
 }
-#line 1683 "C:/Users/glandrum/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
+#line 1724 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
     break;
 
-  case 17:
-#line 246 "smarts.yy" /* yacc.c:1646  */
+  case 19:
+#line 267 "smarts.yy" /* yacc.c:1646  */
     {
   (yyval.atom) = (yyvsp[-1].atom);
 }
-#line 1691 "C:/Users/glandrum/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
+#line 1732 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
     break;
 
-  case 18:
-#line 250 "smarts.yy" /* yacc.c:1646  */
+  case 20:
+#line 271 "smarts.yy" /* yacc.c:1646  */
     {
   (yyval.atom) = (yyvsp[-3].atom);
   (yyval.atom)->setProp(RDKit::common_properties::molAtomMapNumber,(yyvsp[-1].ival));
 }
-#line 1700 "C:/Users/glandrum/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
+#line 1741 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
     break;
 
-  case 19:
-#line 273 "smarts.yy" /* yacc.c:1646  */
+  case 21:
+#line 294 "smarts.yy" /* yacc.c:1646  */
     {
   (yyval.atom) = new QueryAtom(1);
 }
-#line 1708 "C:/Users/glandrum/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
+#line 1749 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
     break;
 
-  case 20:
-#line 277 "smarts.yy" /* yacc.c:1646  */
+  case 22:
+#line 298 "smarts.yy" /* yacc.c:1646  */
     {
   (yyval.atom) = new QueryAtom(1);
   (yyval.atom)->setProp(RDKit::common_properties::molAtomMapNumber,(yyvsp[-1].ival));
 }
-#line 1717 "C:/Users/glandrum/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
+#line 1758 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
     break;
 
-  case 21:
-#line 281 "smarts.yy" /* yacc.c:1646  */
+  case 23:
+#line 302 "smarts.yy" /* yacc.c:1646  */
     {
   QueryAtom *newQ = new QueryAtom(1);
   newQ->setIsotope((yyvsp[-2].ival));
   newQ->expandQuery(makeAtomIsotopeQuery((yyvsp[-2].ival)),Queries::COMPOSITE_AND,true);
   (yyval.atom)=newQ;
 }
-#line 1728 "C:/Users/glandrum/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
+#line 1769 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
     break;
 
-  case 22:
-#line 287 "smarts.yy" /* yacc.c:1646  */
+  case 24:
+#line 308 "smarts.yy" /* yacc.c:1646  */
     {
   QueryAtom *newQ = new QueryAtom(1);
   newQ->setIsotope((yyvsp[-4].ival));
@@ -1737,22 +1778,22 @@ yyreduce:
 
   (yyval.atom)=newQ;
 }
-#line 1741 "C:/Users/glandrum/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
+#line 1782 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
     break;
 
-  case 23:
-#line 296 "smarts.yy" /* yacc.c:1646  */
+  case 25:
+#line 317 "smarts.yy" /* yacc.c:1646  */
     {
   QueryAtom *newQ = new QueryAtom(1);
   newQ->setFormalCharge((yyvsp[-1].ival));
   newQ->expandQuery(makeAtomFormalChargeQuery((yyvsp[-1].ival)),Queries::COMPOSITE_AND,true);
   (yyval.atom)=newQ;
 }
-#line 1752 "C:/Users/glandrum/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
+#line 1793 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
     break;
 
-  case 24:
-#line 302 "smarts.yy" /* yacc.c:1646  */
+  case 26:
+#line 323 "smarts.yy" /* yacc.c:1646  */
     {
   QueryAtom *newQ = new QueryAtom(1);
   newQ->setFormalCharge((yyvsp[-3].ival));
@@ -1761,11 +1802,11 @@ yyreduce:
 
   (yyval.atom)=newQ;
 }
-#line 1765 "C:/Users/glandrum/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
+#line 1806 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
     break;
 
-  case 25:
-#line 310 "smarts.yy" /* yacc.c:1646  */
+  case 27:
+#line 331 "smarts.yy" /* yacc.c:1646  */
     {
   QueryAtom *newQ = new QueryAtom(1);
   newQ->setIsotope((yyvsp[-3].ival));
@@ -1774,11 +1815,11 @@ yyreduce:
   newQ->expandQuery(makeAtomFormalChargeQuery((yyvsp[-1].ival)),Queries::COMPOSITE_AND,true);
   (yyval.atom)=newQ;
 }
-#line 1778 "C:/Users/glandrum/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
+#line 1819 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
     break;
 
-  case 26:
-#line 318 "smarts.yy" /* yacc.c:1646  */
+  case 28:
+#line 339 "smarts.yy" /* yacc.c:1646  */
     {
   QueryAtom *newQ = new QueryAtom(1);
   newQ->setIsotope((yyvsp[-5].ival));
@@ -1789,44 +1830,44 @@ yyreduce:
 
   (yyval.atom)=newQ;
 }
-#line 1793 "C:/Users/glandrum/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
+#line 1834 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
     break;
 
-  case 27:
-#line 331 "smarts.yy" /* yacc.c:1646  */
+  case 29:
+#line 352 "smarts.yy" /* yacc.c:1646  */
     {
   (yyvsp[-2].atom)->expandQuery((yyvsp[0].atom)->getQuery()->copy(),Queries::COMPOSITE_AND,true);
   if((yyvsp[-2].atom)->getChiralTag()==Atom::CHI_UNSPECIFIED) (yyvsp[-2].atom)->setChiralTag((yyvsp[0].atom)->getChiralTag());
   SmilesParseOps::ClearAtomChemicalProps((yyvsp[-2].atom));
   delete (yyvsp[0].atom);
 }
-#line 1804 "C:/Users/glandrum/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
+#line 1845 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
     break;
 
-  case 28:
-#line 337 "smarts.yy" /* yacc.c:1646  */
+  case 30:
+#line 358 "smarts.yy" /* yacc.c:1646  */
     {
   (yyvsp[-2].atom)->expandQuery((yyvsp[0].atom)->getQuery()->copy(),Queries::COMPOSITE_OR,true);
   if((yyvsp[-2].atom)->getChiralTag()==Atom::CHI_UNSPECIFIED) (yyvsp[-2].atom)->setChiralTag((yyvsp[0].atom)->getChiralTag());
   SmilesParseOps::ClearAtomChemicalProps((yyvsp[-2].atom));
   delete (yyvsp[0].atom);
 }
-#line 1815 "C:/Users/glandrum/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
+#line 1856 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
     break;
 
-  case 29:
-#line 343 "smarts.yy" /* yacc.c:1646  */
+  case 31:
+#line 364 "smarts.yy" /* yacc.c:1646  */
     {
   (yyvsp[-2].atom)->expandQuery((yyvsp[0].atom)->getQuery()->copy(),Queries::COMPOSITE_AND,true);
   if((yyvsp[-2].atom)->getChiralTag()==Atom::CHI_UNSPECIFIED) (yyvsp[-2].atom)->setChiralTag((yyvsp[0].atom)->getChiralTag());
   SmilesParseOps::ClearAtomChemicalProps((yyvsp[-2].atom));
   delete (yyvsp[0].atom);
 }
-#line 1826 "C:/Users/glandrum/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
+#line 1867 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
     break;
 
-  case 30:
-#line 349 "smarts.yy" /* yacc.c:1646  */
+  case 32:
+#line 370 "smarts.yy" /* yacc.c:1646  */
     {
   (yyvsp[-1].atom)->expandQuery((yyvsp[0].atom)->getQuery()->copy(),Queries::COMPOSITE_AND,true);
   if((yyvsp[-1].atom)->getChiralTag()==Atom::CHI_UNSPECIFIED) (yyvsp[-1].atom)->setChiralTag((yyvsp[0].atom)->getChiralTag());
@@ -1850,22 +1891,22 @@ yyreduce:
   }
   delete (yyvsp[0].atom);
 }
-#line 1854 "C:/Users/glandrum/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
+#line 1895 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
     break;
 
-  case 32:
-#line 375 "smarts.yy" /* yacc.c:1646  */
+  case 34:
+#line 396 "smarts.yy" /* yacc.c:1646  */
     {
   (yyvsp[0].atom)->getQuery()->setNegation(!((yyvsp[0].atom)->getQuery()->getNegation()));
   (yyvsp[0].atom)->setAtomicNum(0);
   SmilesParseOps::ClearAtomChemicalProps((yyvsp[0].atom));
   (yyval.atom) = (yyvsp[0].atom);
 }
-#line 1865 "C:/Users/glandrum/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
+#line 1906 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
     break;
 
-  case 35:
-#line 386 "smarts.yy" /* yacc.c:1646  */
+  case 37:
+#line 407 "smarts.yy" /* yacc.c:1646  */
     {
   // this is a recursive SMARTS expression
   QueryAtom *qA = new QueryAtom();
@@ -1883,11 +1924,11 @@ yyreduce:
   }
   (yyval.atom) = qA;
 }
-#line 1887 "C:/Users/glandrum/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
+#line 1928 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
     break;
 
-  case 36:
-#line 403 "smarts.yy" /* yacc.c:1646  */
+  case 38:
+#line 424 "smarts.yy" /* yacc.c:1646  */
     {
   // UNDOCUMENTED EXTENSION:
   // this is a recursive SMARTS expression with a serial number
@@ -1909,117 +1950,117 @@ yyreduce:
   }
   (yyval.atom) = qA;
 }
-#line 1913 "C:/Users/glandrum/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
-    break;
-
-  case 38:
-#line 428 "smarts.yy" /* yacc.c:1646  */
-    {
-  (yyvsp[0].atom)->setIsotope((yyvsp[-1].ival));
-  (yyvsp[0].atom)->expandQuery(makeAtomIsotopeQuery((yyvsp[-1].ival)),Queries::COMPOSITE_AND,true);
-  (yyval.atom)=(yyvsp[0].atom);
-}
-#line 1923 "C:/Users/glandrum/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
+#line 1954 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
     break;
 
   case 40:
-#line 434 "smarts.yy" /* yacc.c:1646  */
+#line 449 "smarts.yy" /* yacc.c:1646  */
     {
   (yyvsp[0].atom)->setIsotope((yyvsp[-1].ival));
   (yyvsp[0].atom)->expandQuery(makeAtomIsotopeQuery((yyvsp[-1].ival)),Queries::COMPOSITE_AND,true);
   (yyval.atom)=(yyvsp[0].atom);
 }
-#line 1933 "C:/Users/glandrum/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
-    break;
-
-  case 41:
-#line 439 "smarts.yy" /* yacc.c:1646  */
-    { (yyval.atom) = new QueryAtom((yyvsp[0].ival)); }
-#line 1939 "C:/Users/glandrum/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
+#line 1964 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
     break;
 
   case 42:
-#line 440 "smarts.yy" /* yacc.c:1646  */
+#line 455 "smarts.yy" /* yacc.c:1646  */
+    {
+  (yyvsp[0].atom)->setIsotope((yyvsp[-1].ival));
+  (yyvsp[0].atom)->expandQuery(makeAtomIsotopeQuery((yyvsp[-1].ival)),Queries::COMPOSITE_AND,true);
+  (yyval.atom)=(yyvsp[0].atom);
+}
+#line 1974 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
+    break;
+
+  case 43:
+#line 460 "smarts.yy" /* yacc.c:1646  */
+    { (yyval.atom) = new QueryAtom((yyvsp[0].ival)); }
+#line 1980 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
+    break;
+
+  case 44:
+#line 461 "smarts.yy" /* yacc.c:1646  */
     {
   (yyval.atom) = new QueryAtom((yyvsp[0].ival));
   (yyval.atom)->setIsotope((yyvsp[-2].ival));
   (yyval.atom)->expandQuery(makeAtomIsotopeQuery((yyvsp[-2].ival)),Queries::COMPOSITE_AND,true);
 }
-#line 1949 "C:/Users/glandrum/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
-    break;
-
-  case 49:
-#line 451 "smarts.yy" /* yacc.c:1646  */
-    {
-  static_cast<ATOM_EQUALS_QUERY *>((yyvsp[-1].atom)->getQuery())->setVal((yyvsp[0].ival));
-}
-#line 1957 "C:/Users/glandrum/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
-    break;
-
-  case 50:
-#line 454 "smarts.yy" /* yacc.c:1646  */
-    {
-  (yyvsp[-1].atom)->setQuery(makeAtomNumHeteroatomNbrsQuery((yyvsp[0].ival)));
-}
-#line 1965 "C:/Users/glandrum/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
+#line 1990 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
     break;
 
   case 51:
-#line 457 "smarts.yy" /* yacc.c:1646  */
+#line 472 "smarts.yy" /* yacc.c:1646  */
     {
-  (yyvsp[-1].atom)->setQuery(makeAtomNumAliphaticHeteroatomNbrsQuery((yyvsp[0].ival)));
+  static_cast<ATOM_EQUALS_QUERY *>((yyvsp[-1].atom)->getQuery())->setVal((yyvsp[0].ival));
 }
-#line 1973 "C:/Users/glandrum/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
+#line 1998 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
     break;
 
   case 52:
-#line 460 "smarts.yy" /* yacc.c:1646  */
+#line 475 "smarts.yy" /* yacc.c:1646  */
     {
-  (yyvsp[-1].atom)->setQuery(makeAtomMinRingSizeQuery((yyvsp[0].ival)));
+  (yyvsp[-1].atom)->setQuery(makeAtomNumHeteroatomNbrsQuery((yyvsp[0].ival)));
 }
-#line 1981 "C:/Users/glandrum/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
+#line 2006 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
     break;
 
   case 53:
-#line 463 "smarts.yy" /* yacc.c:1646  */
+#line 478 "smarts.yy" /* yacc.c:1646  */
     {
-  (yyvsp[-1].atom)->setQuery(makeAtomRingBondCountQuery((yyvsp[0].ival)));
+  (yyvsp[-1].atom)->setQuery(makeAtomNumAliphaticHeteroatomNbrsQuery((yyvsp[0].ival)));
 }
-#line 1989 "C:/Users/glandrum/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
+#line 2014 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
     break;
 
   case 54:
-#line 466 "smarts.yy" /* yacc.c:1646  */
+#line 481 "smarts.yy" /* yacc.c:1646  */
     {
-  (yyvsp[-1].atom)->setQuery(makeAtomImplicitHCountQuery((yyvsp[0].ival)));
+  (yyvsp[-1].atom)->setQuery(makeAtomMinRingSizeQuery((yyvsp[0].ival)));
 }
-#line 1997 "C:/Users/glandrum/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
+#line 2022 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
     break;
 
   case 55:
-#line 469 "smarts.yy" /* yacc.c:1646  */
+#line 484 "smarts.yy" /* yacc.c:1646  */
+    {
+  (yyvsp[-1].atom)->setQuery(makeAtomRingBondCountQuery((yyvsp[0].ival)));
+}
+#line 2030 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
+    break;
+
+  case 56:
+#line 487 "smarts.yy" /* yacc.c:1646  */
+    {
+  (yyvsp[-1].atom)->setQuery(makeAtomImplicitHCountQuery((yyvsp[0].ival)));
+}
+#line 2038 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
+    break;
+
+  case 57:
+#line 490 "smarts.yy" /* yacc.c:1646  */
     {
   ATOM_EQUALS_QUERY *oq = static_cast<ATOM_EQUALS_QUERY *>((yyvsp[-4].atom)->getQuery());
   ATOM_GREATEREQUAL_QUERY *nq = makeAtomSimpleQuery<ATOM_GREATEREQUAL_QUERY>((yyvsp[-1].ival),oq->getDataFunc(),
     std::string("greater_")+oq->getDescription());
   (yyvsp[-4].atom)->setQuery(nq);
 }
-#line 2008 "C:/Users/glandrum/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
+#line 2049 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
     break;
 
-  case 56:
-#line 475 "smarts.yy" /* yacc.c:1646  */
+  case 58:
+#line 496 "smarts.yy" /* yacc.c:1646  */
     {
   ATOM_EQUALS_QUERY *oq = static_cast<ATOM_EQUALS_QUERY *>((yyvsp[-4].atom)->getQuery());
   ATOM_LESSEQUAL_QUERY *nq = makeAtomSimpleQuery<ATOM_LESSEQUAL_QUERY>((yyvsp[-2].ival),oq->getDataFunc(),
     std::string("less_")+oq->getDescription());
   (yyvsp[-4].atom)->setQuery(nq);
 }
-#line 2019 "C:/Users/glandrum/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
+#line 2060 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
     break;
 
-  case 57:
-#line 481 "smarts.yy" /* yacc.c:1646  */
+  case 59:
+#line 502 "smarts.yy" /* yacc.c:1646  */
     {
   ATOM_EQUALS_QUERY *oq = static_cast<ATOM_EQUALS_QUERY *>((yyvsp[-5].atom)->getQuery());
   ATOM_RANGE_QUERY *nq = makeAtomRangeQuery((yyvsp[-3].ival),(yyvsp[-1].ival),false,false,
@@ -2027,11 +2068,11 @@ yyreduce:
     std::string("range_")+oq->getDescription());
   (yyvsp[-5].atom)->setQuery(nq);
 }
-#line 2031 "C:/Users/glandrum/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
+#line 2072 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
     break;
 
-  case 58:
-#line 488 "smarts.yy" /* yacc.c:1646  */
+  case 60:
+#line 509 "smarts.yy" /* yacc.c:1646  */
     {
   QueryAtom *newQ = new QueryAtom();
   newQ->setQuery(makeAtomIsotopeQuery((yyvsp[-1].ival)));
@@ -2040,11 +2081,11 @@ yyreduce:
   newQ->setNumExplicitHs(1);
   (yyval.atom)=newQ;
 }
-#line 2044 "C:/Users/glandrum/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
+#line 2085 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
     break;
 
-  case 59:
-#line 496 "smarts.yy" /* yacc.c:1646  */
+  case 61:
+#line 517 "smarts.yy" /* yacc.c:1646  */
     {
   QueryAtom *newQ = new QueryAtom();
   newQ->setQuery(makeAtomIsotopeQuery((yyvsp[-2].ival)));
@@ -2053,116 +2094,116 @@ yyreduce:
   newQ->setNumExplicitHs((yyvsp[0].ival));
   (yyval.atom)=newQ;
 }
-#line 2057 "C:/Users/glandrum/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
+#line 2098 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
     break;
 
-  case 60:
-#line 504 "smarts.yy" /* yacc.c:1646  */
+  case 62:
+#line 525 "smarts.yy" /* yacc.c:1646  */
     {
   QueryAtom *newQ = new QueryAtom();
   newQ->setQuery(makeAtomHCountQuery((yyvsp[0].ival)));
   newQ->setNumExplicitHs((yyvsp[0].ival));
   (yyval.atom)=newQ;
 }
-#line 2068 "C:/Users/glandrum/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
+#line 2109 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
     break;
 
-  case 61:
-#line 510 "smarts.yy" /* yacc.c:1646  */
+  case 63:
+#line 531 "smarts.yy" /* yacc.c:1646  */
     {
   QueryAtom *newQ = new QueryAtom();
   newQ->setQuery(makeAtomHCountQuery(1));
   newQ->setNumExplicitHs(1);
   (yyval.atom)=newQ;
 }
-#line 2079 "C:/Users/glandrum/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
+#line 2120 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
     break;
 
-  case 62:
-#line 516 "smarts.yy" /* yacc.c:1646  */
+  case 64:
+#line 537 "smarts.yy" /* yacc.c:1646  */
     {
   QueryAtom *newQ = new QueryAtom();
   newQ->setQuery(makeAtomFormalChargeQuery((yyvsp[0].ival)));
   newQ->setFormalCharge((yyvsp[0].ival));
   (yyval.atom)=newQ;
 }
-#line 2090 "C:/Users/glandrum/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
+#line 2131 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
     break;
 
-  case 63:
-#line 522 "smarts.yy" /* yacc.c:1646  */
+  case 65:
+#line 543 "smarts.yy" /* yacc.c:1646  */
     {
   QueryAtom *newQ = new QueryAtom();
   newQ->setQuery(makeAtomNullQuery());
   newQ->setChiralTag(Atom::CHI_TETRAHEDRAL_CW);
   (yyval.atom)=newQ;
 }
-#line 2101 "C:/Users/glandrum/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
+#line 2142 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
     break;
 
-  case 64:
-#line 528 "smarts.yy" /* yacc.c:1646  */
+  case 66:
+#line 549 "smarts.yy" /* yacc.c:1646  */
     {
   QueryAtom *newQ = new QueryAtom();
   newQ->setQuery(makeAtomNullQuery());
   newQ->setChiralTag(Atom::CHI_TETRAHEDRAL_CCW);
   (yyval.atom)=newQ;
 }
-#line 2112 "C:/Users/glandrum/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
+#line 2153 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
     break;
 
-  case 66:
-#line 535 "smarts.yy" /* yacc.c:1646  */
+  case 68:
+#line 556 "smarts.yy" /* yacc.c:1646  */
     {
   QueryAtom *newQ = new QueryAtom();
   newQ->setQuery(makeAtomIsotopeQuery((yyvsp[0].ival)));
   (yyval.atom)=newQ;
 }
-#line 2122 "C:/Users/glandrum/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
-    break;
-
-  case 68:
-#line 543 "smarts.yy" /* yacc.c:1646  */
-    {
-  (yyvsp[0].atom)->setQuery(makeAtomNumHeteroatomNbrsQuery(0));
-}
-#line 2130 "C:/Users/glandrum/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
-    break;
-
-  case 69:
-#line 546 "smarts.yy" /* yacc.c:1646  */
-    {
-  (yyvsp[0].atom)->setQuery(makeAtomNumAliphaticHeteroatomNbrsQuery(0));
-}
-#line 2138 "C:/Users/glandrum/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
+#line 2163 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
     break;
 
   case 70:
-#line 549 "smarts.yy" /* yacc.c:1646  */
+#line 564 "smarts.yy" /* yacc.c:1646  */
     {
-  (yyvsp[0].atom)->setQuery(makeAtomMinRingSizeQuery(5)); // this is going to be ignored anyway
+  (yyvsp[0].atom)->setQuery(makeAtomNumHeteroatomNbrsQuery(0));
 }
-#line 2146 "C:/Users/glandrum/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
+#line 2171 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
     break;
 
   case 71:
-#line 552 "smarts.yy" /* yacc.c:1646  */
+#line 567 "smarts.yy" /* yacc.c:1646  */
     {
-  (yyvsp[0].atom)->setQuery(makeAtomRingBondCountQuery(0));
+  (yyvsp[0].atom)->setQuery(makeAtomNumAliphaticHeteroatomNbrsQuery(0));
 }
-#line 2154 "C:/Users/glandrum/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
+#line 2179 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
     break;
 
   case 72:
-#line 555 "smarts.yy" /* yacc.c:1646  */
+#line 570 "smarts.yy" /* yacc.c:1646  */
     {
-  (yyvsp[0].atom)->setQuery(makeAtomImplicitHCountQuery(0));
+  (yyvsp[0].atom)->setQuery(makeAtomMinRingSizeQuery(5)); // this is going to be ignored anyway
 }
-#line 2162 "C:/Users/glandrum/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
+#line 2187 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
     break;
 
   case 73:
-#line 561 "smarts.yy" /* yacc.c:1646  */
+#line 573 "smarts.yy" /* yacc.c:1646  */
+    {
+  (yyvsp[0].atom)->setQuery(makeAtomRingBondCountQuery(0));
+}
+#line 2195 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
+    break;
+
+  case 74:
+#line 576 "smarts.yy" /* yacc.c:1646  */
+    {
+  (yyvsp[0].atom)->setQuery(makeAtomImplicitHCountQuery(0));
+}
+#line 2203 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
+    break;
+
+  case 75:
+#line 582 "smarts.yy" /* yacc.c:1646  */
     {
   //
   // This construction (and some others) may seem odd, but the
@@ -2175,187 +2216,187 @@ yyreduce:
   (yyval.atom) = new QueryAtom((yyvsp[0].ival));
   (yyval.atom)->setQuery(makeAtomTypeQuery((yyvsp[0].ival),false));
 }
-#line 2179 "C:/Users/glandrum/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
+#line 2220 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
     break;
 
-  case 74:
-#line 573 "smarts.yy" /* yacc.c:1646  */
+  case 76:
+#line 594 "smarts.yy" /* yacc.c:1646  */
     {
   (yyval.atom) = new QueryAtom((yyvsp[0].ival));
   (yyval.atom)->setIsAromatic(true);
   (yyval.atom)->setQuery(makeAtomTypeQuery((yyvsp[0].ival),true));
 }
-#line 2189 "C:/Users/glandrum/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
+#line 2230 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
     break;
 
-  case 76:
-#line 583 "smarts.yy" /* yacc.c:1646  */
+  case 78:
+#line 604 "smarts.yy" /* yacc.c:1646  */
     {
   (yyvsp[-2].bond)->expandQuery((yyvsp[0].bond)->getQuery()->copy(),Queries::COMPOSITE_AND,true);
   delete (yyvsp[0].bond);
 }
-#line 2198 "C:/Users/glandrum/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
+#line 2239 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
     break;
 
-  case 77:
-#line 587 "smarts.yy" /* yacc.c:1646  */
+  case 79:
+#line 608 "smarts.yy" /* yacc.c:1646  */
     {
   (yyvsp[-2].bond)->expandQuery((yyvsp[0].bond)->getQuery()->copy(),Queries::COMPOSITE_OR,true);
   delete (yyvsp[0].bond);
 }
-#line 2207 "C:/Users/glandrum/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
+#line 2248 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
     break;
 
-  case 78:
-#line 591 "smarts.yy" /* yacc.c:1646  */
+  case 80:
+#line 612 "smarts.yy" /* yacc.c:1646  */
     {
   (yyvsp[-2].bond)->expandQuery((yyvsp[0].bond)->getQuery()->copy(),Queries::COMPOSITE_AND,true);
   delete (yyvsp[0].bond);
 }
-#line 2216 "C:/Users/glandrum/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
+#line 2257 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
     break;
 
-  case 81:
-#line 599 "smarts.yy" /* yacc.c:1646  */
+  case 83:
+#line 620 "smarts.yy" /* yacc.c:1646  */
     {
   (yyvsp[-1].bond)->expandQuery((yyvsp[0].bond)->getQuery()->copy(),Queries::COMPOSITE_AND,true);
   delete (yyvsp[0].bond);
 }
-#line 2225 "C:/Users/glandrum/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
+#line 2266 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
     break;
 
-  case 83:
-#line 607 "smarts.yy" /* yacc.c:1646  */
+  case 85:
+#line 628 "smarts.yy" /* yacc.c:1646  */
     {
   QueryBond *newB= new QueryBond();
   newB->setBondType(Bond::SINGLE);
   newB->setQuery(makeBondOrderEqualsQuery(Bond::SINGLE));
   (yyval.bond) = newB;
 }
-#line 2236 "C:/Users/glandrum/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
+#line 2277 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
     break;
 
-  case 84:
-#line 613 "smarts.yy" /* yacc.c:1646  */
+  case 86:
+#line 634 "smarts.yy" /* yacc.c:1646  */
     {
   QueryBond *newB= new QueryBond();
   newB->setBondType(Bond::TRIPLE);
   newB->setQuery(makeBondOrderEqualsQuery(Bond::TRIPLE));
   (yyval.bond) = newB;
 }
-#line 2247 "C:/Users/glandrum/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
+#line 2288 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
     break;
 
-  case 85:
-#line 619 "smarts.yy" /* yacc.c:1646  */
+  case 87:
+#line 640 "smarts.yy" /* yacc.c:1646  */
     {
   QueryBond *newB= new QueryBond();
   newB->setBondType(Bond::AROMATIC);
   newB->setQuery(makeBondOrderEqualsQuery(Bond::AROMATIC));
   (yyval.bond) = newB;
 }
-#line 2258 "C:/Users/glandrum/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
+#line 2299 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
     break;
 
-  case 86:
-#line 625 "smarts.yy" /* yacc.c:1646  */
+  case 88:
+#line 646 "smarts.yy" /* yacc.c:1646  */
     {
   QueryBond *newB= new QueryBond();
   newB->setQuery(makeBondIsInRingQuery());
   (yyval.bond) = newB;
 }
-#line 2268 "C:/Users/glandrum/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
+#line 2309 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
     break;
 
-  case 87:
-#line 630 "smarts.yy" /* yacc.c:1646  */
+  case 89:
+#line 651 "smarts.yy" /* yacc.c:1646  */
     {
   (yyvsp[0].bond)->getQuery()->setNegation(!((yyvsp[0].bond)->getQuery()->getNegation()));
   (yyval.bond) = (yyvsp[0].bond);
 }
-#line 2277 "C:/Users/glandrum/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
-    break;
-
-  case 88:
-#line 637 "smarts.yy" /* yacc.c:1646  */
-    { (yyval.ival)=2; }
-#line 2283 "C:/Users/glandrum/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
-    break;
-
-  case 89:
-#line 638 "smarts.yy" /* yacc.c:1646  */
-    { (yyval.ival)=(yyvsp[0].ival); }
-#line 2289 "C:/Users/glandrum/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
+#line 2318 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
     break;
 
   case 90:
-#line 639 "smarts.yy" /* yacc.c:1646  */
-    { (yyval.ival)=1; }
-#line 2295 "C:/Users/glandrum/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
+#line 658 "smarts.yy" /* yacc.c:1646  */
+    { (yyval.ival)=2; }
+#line 2324 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
     break;
 
   case 91:
-#line 640 "smarts.yy" /* yacc.c:1646  */
-    { (yyval.ival)=-2; }
-#line 2301 "C:/Users/glandrum/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
+#line 659 "smarts.yy" /* yacc.c:1646  */
+    { (yyval.ival)=(yyvsp[0].ival); }
+#line 2330 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
     break;
 
   case 92:
-#line 641 "smarts.yy" /* yacc.c:1646  */
-    { (yyval.ival)=-(yyvsp[0].ival); }
-#line 2307 "C:/Users/glandrum/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
+#line 660 "smarts.yy" /* yacc.c:1646  */
+    { (yyval.ival)=1; }
+#line 2336 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
     break;
 
   case 93:
-#line 642 "smarts.yy" /* yacc.c:1646  */
-    { (yyval.ival)=-1; }
-#line 2313 "C:/Users/glandrum/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
+#line 661 "smarts.yy" /* yacc.c:1646  */
+    { (yyval.ival)=-2; }
+#line 2342 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
+    break;
+
+  case 94:
+#line 662 "smarts.yy" /* yacc.c:1646  */
+    { (yyval.ival)=-(yyvsp[0].ival); }
+#line 2348 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
     break;
 
   case 95:
-#line 647 "smarts.yy" /* yacc.c:1646  */
-    { (yyval.ival) = (yyvsp[-1].ival)*10+(yyvsp[0].ival); }
-#line 2319 "C:/Users/glandrum/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
-    break;
-
-  case 96:
-#line 648 "smarts.yy" /* yacc.c:1646  */
-    { (yyval.ival) = (yyvsp[-1].ival); }
-#line 2325 "C:/Users/glandrum/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
+#line 663 "smarts.yy" /* yacc.c:1646  */
+    { (yyval.ival)=-1; }
+#line 2354 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
     break;
 
   case 97:
-#line 649 "smarts.yy" /* yacc.c:1646  */
-    { (yyval.ival) = (yyvsp[-2].ival)*10+(yyvsp[-1].ival); }
-#line 2331 "C:/Users/glandrum/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
+#line 668 "smarts.yy" /* yacc.c:1646  */
+    { (yyval.ival) = (yyvsp[-1].ival)*10+(yyvsp[0].ival); }
+#line 2360 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
     break;
 
   case 98:
-#line 650 "smarts.yy" /* yacc.c:1646  */
-    { (yyval.ival) = (yyvsp[-3].ival)*100+(yyvsp[-2].ival)*10+(yyvsp[-1].ival); }
-#line 2337 "C:/Users/glandrum/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
+#line 669 "smarts.yy" /* yacc.c:1646  */
+    { (yyval.ival) = (yyvsp[-1].ival); }
+#line 2366 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
     break;
 
   case 99:
-#line 651 "smarts.yy" /* yacc.c:1646  */
-    { (yyval.ival) = (yyvsp[-4].ival)*1000+(yyvsp[-3].ival)*100+(yyvsp[-2].ival)*10+(yyvsp[-1].ival); }
-#line 2343 "C:/Users/glandrum/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
+#line 670 "smarts.yy" /* yacc.c:1646  */
+    { (yyval.ival) = (yyvsp[-2].ival)*10+(yyvsp[-1].ival); }
+#line 2372 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
     break;
 
   case 100:
-#line 652 "smarts.yy" /* yacc.c:1646  */
+#line 671 "smarts.yy" /* yacc.c:1646  */
+    { (yyval.ival) = (yyvsp[-3].ival)*100+(yyvsp[-2].ival)*10+(yyvsp[-1].ival); }
+#line 2378 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
+    break;
+
+  case 101:
+#line 672 "smarts.yy" /* yacc.c:1646  */
+    { (yyval.ival) = (yyvsp[-4].ival)*1000+(yyvsp[-3].ival)*100+(yyvsp[-2].ival)*10+(yyvsp[-1].ival); }
+#line 2384 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
+    break;
+
+  case 102:
+#line 673 "smarts.yy" /* yacc.c:1646  */
     { (yyval.ival) = (yyvsp[-5].ival)*10000+(yyvsp[-4].ival)*1000+(yyvsp[-3].ival)*100+(yyvsp[-2].ival)*10+(yyvsp[-1].ival); }
-#line 2349 "C:/Users/glandrum/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
+#line 2390 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
     break;
 
-  case 104:
-#line 663 "smarts.yy" /* yacc.c:1646  */
+  case 106:
+#line 684 "smarts.yy" /* yacc.c:1646  */
     { (yyval.ival) = (yyvsp[-1].ival)*10 + (yyvsp[0].ival); }
-#line 2355 "C:/Users/glandrum/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
+#line 2396 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
     break;
 
 
-#line 2359 "C:/Users/glandrum/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
+#line 2400 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.cpp" /* yacc.c:1646  */
       default: break;
     }
   /* User semantic actions sometimes alter yychar, and that requires
@@ -2405,7 +2446,7 @@ yyerrlab:
     {
       ++yynerrs;
 #if ! YYERROR_VERBOSE
-      yyerror (input, molList, scanner, YY_("syntax error"));
+      yyerror (input, molList, lastAtom, lastBond, scanner, start_token, YY_("syntax error"));
 #else
 # define YYSYNTAX_ERROR yysyntax_error (&yymsg_alloc, &yymsg, \
                                         yyssp, yytoken)
@@ -2432,7 +2473,7 @@ yyerrlab:
                 yymsgp = yymsg;
               }
           }
-        yyerror (input, molList, scanner, yymsgp);
+        yyerror (input, molList, lastAtom, lastBond, scanner, start_token, yymsgp);
         if (yysyntax_error_status == 2)
           goto yyexhaustedlab;
       }
@@ -2456,7 +2497,7 @@ yyerrlab:
       else
         {
           yydestruct ("Error: discarding",
-                      yytoken, &yylval, input, molList, scanner);
+                      yytoken, &yylval, input, molList, lastAtom, lastBond, scanner, start_token);
           yychar = YYEMPTY;
         }
     }
@@ -2512,7 +2553,7 @@ yyerrlab1:
 
 
       yydestruct ("Error: popping",
-                  yystos[yystate], yyvsp, input, molList, scanner);
+                  yystos[yystate], yyvsp, input, molList, lastAtom, lastBond, scanner, start_token);
       YYPOPSTACK (1);
       yystate = *yyssp;
       YY_STACK_PRINT (yyss, yyssp);
@@ -2549,7 +2590,7 @@ yyabortlab:
 | yyexhaustedlab -- memory exhaustion comes here.  |
 `-------------------------------------------------*/
 yyexhaustedlab:
-  yyerror (input, molList, scanner, YY_("memory exhausted"));
+  yyerror (input, molList, lastAtom, lastBond, scanner, start_token, YY_("memory exhausted"));
   yyresult = 2;
   /* Fall through.  */
 #endif
@@ -2561,7 +2602,7 @@ yyreturn:
          user semantic actions for why this is necessary.  */
       yytoken = YYTRANSLATE (yychar);
       yydestruct ("Cleanup: discarding lookahead",
-                  yytoken, &yylval, input, molList, scanner);
+                  yytoken, &yylval, input, molList, lastAtom, lastBond, scanner, start_token);
     }
   /* Do not reclaim the symbols of the rule whose action triggered
      this YYABORT or YYACCEPT.  */
@@ -2570,7 +2611,7 @@ yyreturn:
   while (yyssp != yyss)
     {
       yydestruct ("Cleanup: popping",
-                  yystos[*yyssp], yyvsp, input, molList, scanner);
+                  yystos[*yyssp], yyvsp, input, molList, lastAtom, lastBond, scanner, start_token);
       YYPOPSTACK (1);
     }
 #ifndef yyoverflow
@@ -2583,5 +2624,5 @@ yyreturn:
 #endif
   return yyresult;
 }
-#line 670 "smarts.yy" /* yacc.c:1906  */
+#line 691 "smarts.yy" /* yacc.c:1906  */
 

--- a/Code/GraphMol/SmilesParse/smarts.tab.hpp.cmake
+++ b/Code/GraphMol/SmilesParse/smarts.tab.hpp.cmake
@@ -30,8 +30,8 @@
    This special exception was added by the Free Software Foundation in
    version 2.2 of Bison.  */
 
-#ifndef YY_YYSMARTS_C_USERS_GLANDRUM_RDKIT_GIT_CODE_GRAPHMOL_SMILESPARSE_SMARTS_TAB_HPP_INCLUDED
-# define YY_YYSMARTS_C_USERS_GLANDRUM_RDKIT_GIT_CODE_GRAPHMOL_SMILESPARSE_SMARTS_TAB_HPP_INCLUDED
+#ifndef YY_YYSMARTS_SCRATCH_RDKIT_GIT_CODE_GRAPHMOL_SMILESPARSE_SMARTS_TAB_HPP_INCLUDED
+# define YY_YYSMARTS_SCRATCH_RDKIT_GIT_CODE_GRAPHMOL_SMILESPARSE_SMARTS_TAB_HPP_INCLUDED
 /* Debug traces.  */
 #ifndef YYDEBUG
 # define YYDEBUG 0
@@ -45,46 +45,49 @@ extern int yysmarts_debug;
 # define YYTOKENTYPE
   enum yytokentype
   {
-    AROMATIC_ATOM_TOKEN = 258,
-    ORGANIC_ATOM_TOKEN = 259,
-    ATOM_TOKEN = 260,
-    SIMPLE_ATOM_QUERY_TOKEN = 261,
-    COMPLEX_ATOM_QUERY_TOKEN = 262,
-    RINGSIZE_ATOM_QUERY_TOKEN = 263,
-    RINGBOND_ATOM_QUERY_TOKEN = 264,
-    IMPLICIT_H_ATOM_QUERY_TOKEN = 265,
-    HYB_TOKEN = 266,
-    HETERONEIGHBOR_ATOM_QUERY_TOKEN = 267,
-    ALIPHATIC = 268,
-    ALIPHATICHETERONEIGHBOR_ATOM_QUERY_TOKEN = 269,
-    ZERO_TOKEN = 270,
-    NONZERO_DIGIT_TOKEN = 271,
-    GROUP_OPEN_TOKEN = 272,
-    GROUP_CLOSE_TOKEN = 273,
-    SEPARATOR_TOKEN = 274,
-    RANGE_OPEN_TOKEN = 275,
-    RANGE_CLOSE_TOKEN = 276,
-    HASH_TOKEN = 277,
-    MINUS_TOKEN = 278,
-    PLUS_TOKEN = 279,
-    CHIRAL_MARKER_TOKEN = 280,
-    CHI_CLASS_TOKEN = 281,
-    CHI_CLASS_OH_TOKEN = 282,
-    H_TOKEN = 283,
-    AT_TOKEN = 284,
-    PERCENT_TOKEN = 285,
-    ATOM_OPEN_TOKEN = 286,
-    ATOM_CLOSE_TOKEN = 287,
-    NOT_TOKEN = 288,
-    AND_TOKEN = 289,
-    OR_TOKEN = 290,
-    SEMI_TOKEN = 291,
-    BEGIN_RECURSE = 292,
-    END_RECURSE = 293,
-    COLON_TOKEN = 294,
-    UNDERSCORE_TOKEN = 295,
-    BOND_TOKEN = 296,
-    EOS_TOKEN = 297
+    START_MOL = 258,
+    START_ATOM = 259,
+    START_BOND = 260,
+    AROMATIC_ATOM_TOKEN = 261,
+    ORGANIC_ATOM_TOKEN = 262,
+    ATOM_TOKEN = 263,
+    SIMPLE_ATOM_QUERY_TOKEN = 264,
+    COMPLEX_ATOM_QUERY_TOKEN = 265,
+    RINGSIZE_ATOM_QUERY_TOKEN = 266,
+    RINGBOND_ATOM_QUERY_TOKEN = 267,
+    IMPLICIT_H_ATOM_QUERY_TOKEN = 268,
+    HYB_TOKEN = 269,
+    HETERONEIGHBOR_ATOM_QUERY_TOKEN = 270,
+    ALIPHATIC = 271,
+    ALIPHATICHETERONEIGHBOR_ATOM_QUERY_TOKEN = 272,
+    ZERO_TOKEN = 273,
+    NONZERO_DIGIT_TOKEN = 274,
+    GROUP_OPEN_TOKEN = 275,
+    GROUP_CLOSE_TOKEN = 276,
+    SEPARATOR_TOKEN = 277,
+    RANGE_OPEN_TOKEN = 278,
+    RANGE_CLOSE_TOKEN = 279,
+    HASH_TOKEN = 280,
+    MINUS_TOKEN = 281,
+    PLUS_TOKEN = 282,
+    CHIRAL_MARKER_TOKEN = 283,
+    CHI_CLASS_TOKEN = 284,
+    CHI_CLASS_OH_TOKEN = 285,
+    H_TOKEN = 286,
+    AT_TOKEN = 287,
+    PERCENT_TOKEN = 288,
+    ATOM_OPEN_TOKEN = 289,
+    ATOM_CLOSE_TOKEN = 290,
+    NOT_TOKEN = 291,
+    AND_TOKEN = 292,
+    OR_TOKEN = 293,
+    SEMI_TOKEN = 294,
+    BEGIN_RECURSE = 295,
+    END_RECURSE = 296,
+    COLON_TOKEN = 297,
+    UNDERSCORE_TOKEN = 298,
+    BOND_TOKEN = 299,
+    EOS_TOKEN = 300
   };
 #endif
 
@@ -93,14 +96,14 @@ extern int yysmarts_debug;
 
 union YYSTYPE
 {
-#line 50 "smarts.yy" /* yacc.c:1909  */
+#line 61 "smarts.yy" /* yacc.c:1909  */
 
   int                      moli;
   RDKit::QueryAtom * atom;
   RDKit::QueryBond * bond;
   int                      ival;
 
-#line 104 "C:/Users/glandrum/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.hpp" /* yacc.c:1909  */
+#line 107 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.hpp" /* yacc.c:1909  */
 };
 
 typedef union YYSTYPE YYSTYPE;
@@ -110,6 +113,13 @@ typedef union YYSTYPE YYSTYPE;
 
 
 
-int yysmarts_parse (const char *input, std::vector<RDKit::RWMol *> *molList, void *scanner);
+int yysmarts_parse (const char *input, std::vector<RDKit::RWMol *> *molList, RDKit::Atom* &lastAtom, RDKit::Bond* &lastBond, void *scanner, int& start_token);
+/* "%code provides" blocks.  */
+#line 56 "smarts.yy" /* yacc.c:1909  */
 
-#endif /* !YY_YYSMARTS_C_USERS_GLANDRUM_RDKIT_GIT_CODE_GRAPHMOL_SMILESPARSE_SMARTS_TAB_HPP_INCLUDED  */
+#define YY_DECL int yylex \
+               (YYSTYPE * yylval_param , yyscan_t yyscanner, int& start_token)
+
+#line 124 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smarts.tab.hpp" /* yacc.c:1909  */
+
+#endif /* !YY_YYSMARTS_SCRATCH_RDKIT_GIT_CODE_GRAPHMOL_SMILESPARSE_SMARTS_TAB_HPP_INCLUDED  */

--- a/Code/GraphMol/SmilesParse/smarts.yy
+++ b/Code/GraphMol/SmilesParse/smarts.yy
@@ -18,12 +18,14 @@
 #define YYDEBUG 1
 #include "smarts.tab.hpp"
 
-extern int yysmarts_lex(YYSTYPE *,void *);
+extern int yysmarts_lex(YYSTYPE *,void *, int &);
 
 void
 yysmarts_error( const char *input,
                 std::vector<RDKit::RWMol *> *ms,
-		void *scanner,const char * msg )
+                RDKit::Atom* &lastAtom,
+                RDKit::Bond* &lastBond,
+		void *scanner,int start_token, const char * msg )
 {
   throw RDKit::SmilesParseException(msg);
 }
@@ -41,11 +43,20 @@ namespace {
 }
 %}
 
-%define api.pure
+%define api.pure full
 %lex-param   {yyscan_t *scanner}
+%lex-param   {int& start_token}
 %parse-param {const char *input}
 %parse-param {std::vector<RDKit::RWMol *> *molList}
+%parse-param {RDKit::Atom* &lastAtom}
+%parse-param {RDKit::Bond* &lastBond}
 %parse-param {void *scanner}
+%parse-param {int& start_token}
+
+%code provides {
+#define YY_DECL int yylex \
+               (YYSTYPE * yylval_param , yyscan_t yyscanner, int& start_token)
+}
 
 %union {
   int                      moli;
@@ -54,6 +65,7 @@ namespace {
   int                      ival;
 }
 
+%token START_MOL START_ATOM START_BOND;
 %token <ival> AROMATIC_ATOM_TOKEN ORGANIC_ATOM_TOKEN
 %token <atom> ATOM_TOKEN
 %token <atom> SIMPLE_ATOM_QUERY_TOKEN COMPLEX_ATOM_QUERY_TOKEN
@@ -69,7 +81,7 @@ namespace {
 %token NOT_TOKEN AND_TOKEN OR_TOKEN SEMI_TOKEN BEGIN_RECURSE END_RECURSE
 %token COLON_TOKEN UNDERSCORE_TOKEN
 %token <bond> BOND_TOKEN
-%type <moli> cmpd mol branch
+%type <moli>  mol branch
 %type <atom> atomd simple_atom hydrogen_atom
 %type <atom> atom_expr point_query atom_query recursive_query possible_range_query
 %type <ival> ring_number nonzero_number number charge_spec digit
@@ -81,23 +93,32 @@ namespace {
 %left AND_TOKEN
 %right NOT_TOKEN
 
+%start meta_start
+
 %%
 
 /* --------------------------------------------------------------- */
-cmpd: mol
-| cmpd error EOS_TOKEN{
+meta_start: START_MOL mol {
+// the molList has already been updated, no need to do anything
+}
+| START_ATOM atomd {
+  lastAtom = $2;
+}
+| START_BOND bond_expr {
+  lastBond = $2;
+}
+| meta_start error EOS_TOKEN{
   yyclearin;
   yyerrok;
   yyErrorCleanup(molList);
   YYABORT;
 }
-| cmpd EOS_TOKEN {
+| meta_start EOS_TOKEN {
   YYACCEPT;
 }
-| error EOS_TOKEN{
+| error EOS_TOKEN {
   yyclearin;
   yyerrok;
-
   yyErrorCleanup(molList);
   YYABORT;
 }

--- a/Code/GraphMol/SmilesParse/smiles.ll
+++ b/Code/GraphMol/SmilesParse/smiles.ll
@@ -95,7 +95,6 @@ size_t setup_smiles_string(const std::string &text,yyscan_t yyscanner){
     {
       int t = start_token;
       start_token = 0;
-      std::cerr<<"INIT: "<<t<<std::endl;
       return t;
     }
 %}

--- a/Code/GraphMol/SmilesParse/smiles.ll
+++ b/Code/GraphMol/SmilesParse/smiles.ll
@@ -90,6 +90,16 @@ size_t setup_smiles_string(const std::string &text,yyscan_t yyscanner){
 %s IN_ATOM_STATE
 %%
 
+%{
+  if (start_token)
+    {
+      int t = start_token;
+      start_token = 0;
+      std::cerr<<"INIT: "<<t<<std::endl;
+      return t;
+    }
+%}
+
 @[' ']*TH |
 @[' ']*AL |
 @[' ']*SQ |

--- a/Code/GraphMol/SmilesParse/smiles.tab.cpp.cmake
+++ b/Code/GraphMol/SmilesParse/smiles.tab.cpp.cmake
@@ -50,7 +50,7 @@
 #define YYSKELETON_NAME "yacc.c"
 
 /* Pure parsers.  */
-#define YYPURE 1
+#define YYPURE 2
 
 /* Push parsers.  */
 #define YYPUSH 0
@@ -91,7 +91,7 @@
 #define YYDEBUG 1
 #include "smiles.tab.hpp"
 
-extern int yysmiles_lex(YYSTYPE *,void *);
+extern int yysmiles_lex(YYSTYPE *,void *,int &);
 
 
 using namespace RDKit;
@@ -108,8 +108,20 @@ namespace {
 void
 yysmiles_error( const char *input,
                 std::vector<RDKit::RWMol *> *ms,
+                RDKit::Atom* &lastAtom,
+                RDKit::Bond* &lastBond,
                 std::list<unsigned int> *branchPoints,
-		void *scanner,const char * msg )
+		void *scanner,int start_token, const char * msg )
+{
+  yyErrorCleanup(ms);
+  throw RDKit::SmilesParseException(msg);
+}
+
+void
+yysmiles_error( const char *input,
+                std::vector<RDKit::RWMol *> *ms,
+                std::list<unsigned int> *branchPoints,
+		void *scanner,int start_token, const char * msg )
 {
   yyErrorCleanup(ms);
   throw RDKit::SmilesParseException(msg);
@@ -117,7 +129,7 @@ yysmiles_error( const char *input,
 
 
 
-#line 121 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:339  */
+#line 133 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:339  */
 
 # ifndef YY_NULLPTR
 #  if defined __cplusplus && 201103L <= __cplusplus
@@ -152,29 +164,32 @@ extern int yysmiles_debug;
 # define YYTOKENTYPE
   enum yytokentype
   {
-    AROMATIC_ATOM_TOKEN = 258,
-    ATOM_TOKEN = 259,
-    ORGANIC_ATOM_TOKEN = 260,
-    NONZERO_DIGIT_TOKEN = 261,
-    ZERO_TOKEN = 262,
-    GROUP_OPEN_TOKEN = 263,
-    GROUP_CLOSE_TOKEN = 264,
-    SEPARATOR_TOKEN = 265,
-    LOOP_CONNECTOR_TOKEN = 266,
-    MINUS_TOKEN = 267,
-    PLUS_TOKEN = 268,
-    CHIRAL_MARKER_TOKEN = 269,
-    CHI_CLASS_TOKEN = 270,
-    CHI_CLASS_OH_TOKEN = 271,
-    H_TOKEN = 272,
-    AT_TOKEN = 273,
-    PERCENT_TOKEN = 274,
-    COLON_TOKEN = 275,
-    HASH_TOKEN = 276,
-    BOND_TOKEN = 277,
-    ATOM_OPEN_TOKEN = 278,
-    ATOM_CLOSE_TOKEN = 279,
-    EOS_TOKEN = 280
+    START_MOL = 258,
+    START_ATOM = 259,
+    START_BOND = 260,
+    AROMATIC_ATOM_TOKEN = 261,
+    ATOM_TOKEN = 262,
+    ORGANIC_ATOM_TOKEN = 263,
+    NONZERO_DIGIT_TOKEN = 264,
+    ZERO_TOKEN = 265,
+    GROUP_OPEN_TOKEN = 266,
+    GROUP_CLOSE_TOKEN = 267,
+    SEPARATOR_TOKEN = 268,
+    LOOP_CONNECTOR_TOKEN = 269,
+    MINUS_TOKEN = 270,
+    PLUS_TOKEN = 271,
+    CHIRAL_MARKER_TOKEN = 272,
+    CHI_CLASS_TOKEN = 273,
+    CHI_CLASS_OH_TOKEN = 274,
+    H_TOKEN = 275,
+    AT_TOKEN = 276,
+    PERCENT_TOKEN = 277,
+    COLON_TOKEN = 278,
+    HASH_TOKEN = 279,
+    BOND_TOKEN = 280,
+    ATOM_OPEN_TOKEN = 281,
+    ATOM_CLOSE_TOKEN = 282,
+    EOS_TOKEN = 283
   };
 #endif
 
@@ -183,14 +198,14 @@ extern int yysmiles_debug;
 
 union YYSTYPE
 {
-#line 57 "smiles.yy" /* yacc.c:355  */
+#line 78 "smiles.yy" /* yacc.c:355  */
 
   int                      moli;
   RDKit::Atom * atom;
   RDKit::Bond * bond;
   int                      ival;
 
-#line 194 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:355  */
+#line 209 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:355  */
 };
 
 typedef union YYSTYPE YYSTYPE;
@@ -200,13 +215,20 @@ typedef union YYSTYPE YYSTYPE;
 
 
 
-int yysmiles_parse (const char *input, std::vector<RDKit::RWMol *> *molList, std::list<unsigned int> *branchPoints, void *scanner);
+int yysmiles_parse (const char *input, std::vector<RDKit::RWMol *> *molList, RDKit::Atom* &lastAtom, RDKit::Bond* &lastBond, std::list<unsigned int> *branchPoints, void *scanner, int& start_token);
+/* "%code provides" blocks.  */
+#line 73 "smiles.yy" /* yacc.c:355  */
+
+#define YY_DECL int yylex \
+               (YYSTYPE * yylval_param , yyscan_t yyscanner, int& start_token)
+
+#line 226 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:355  */
 
 #endif /* !YY_YYSMILES_SCRATCH_RDKIT_GIT_CODE_GRAPHMOL_SMILESPARSE_SMILES_TAB_HPP_INCLUDED  */
 
 /* Copy the second part of user declarations.  */
 
-#line 210 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:358  */
+#line 232 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:358  */
 
 #ifdef short
 # undef short
@@ -446,23 +468,23 @@ union yyalloc
 #endif /* !YYCOPY_NEEDED */
 
 /* YYFINAL -- State number of the termination state.  */
-#define YYFINAL  22
+#define YYFINAL  17
 /* YYLAST -- Last index in YYTABLE.  */
 #define YYLAST   115
 
 /* YYNTOKENS -- Number of terminals.  */
-#define YYNTOKENS  26
+#define YYNTOKENS  29
 /* YYNNTS -- Number of nonterminals.  */
-#define YYNNTS  13
+#define YYNNTS  14
 /* YYNRULES -- Number of rules.  */
-#define YYNRULES  60
+#define YYNRULES  64
 /* YYNSTATES -- Number of states.  */
-#define YYNSTATES  85
+#define YYNSTATES  92
 
 /* YYTRANSLATE[YYX] -- Symbol number corresponding to YYX as returned
    by yylex, with out-of-bounds checking.  */
 #define YYUNDEFTOK  2
-#define YYMAXUTOK   280
+#define YYMAXUTOK   283
 
 #define YYTRANSLATE(YYX)                                                \
   ((unsigned int) (YYX) <= YYMAXUTOK ? yytranslate[YYX] : YYUNDEFTOK)
@@ -499,20 +521,20 @@ static const yytype_uint8 yytranslate[] =
        2,     2,     2,     2,     2,     2,     1,     2,     3,     4,
        5,     6,     7,     8,     9,    10,    11,    12,    13,    14,
       15,    16,    17,    18,    19,    20,    21,    22,    23,    24,
-      25
+      25,    26,    27,    28
 };
 
 #if YYDEBUG
   /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
 static const yytype_uint16 yyrline[] =
 {
-       0,    79,    79,    80,    86,    89,    99,   110,   120,   140,
-     148,   154,   173,   191,   207,   217,   237,   245,   255,   256,
-     263,   271,   272,   273,   274,   275,   276,   277,   281,   282,
-     283,   284,   285,   286,   287,   288,   289,   293,   294,   295,
-     299,   300,   301,   302,   303,   304,   308,   309,   313,   314,
-     315,   316,   317,   318,   319,   323,   324,   328,   329,   332,
-     333
+       0,   103,   103,   106,   109,   112,   118,   121,   132,   143,
+     153,   173,   181,   187,   206,   224,   240,   250,   270,   278,
+     287,   288,   296,   297,   304,   312,   313,   314,   315,   316,
+     317,   318,   322,   323,   324,   325,   326,   327,   328,   329,
+     330,   334,   335,   336,   340,   341,   342,   343,   344,   345,
+     349,   350,   354,   355,   356,   357,   358,   359,   360,   364,
+     365,   369,   370,   373,   374
 };
 #endif
 
@@ -521,16 +543,16 @@ static const yytype_uint16 yyrline[] =
    First, the terminals, then, starting at YYNTOKENS, nonterminals.  */
 static const char *const yytname[] =
 {
-  "$end", "error", "$undefined", "AROMATIC_ATOM_TOKEN", "ATOM_TOKEN",
-  "ORGANIC_ATOM_TOKEN", "NONZERO_DIGIT_TOKEN", "ZERO_TOKEN",
-  "GROUP_OPEN_TOKEN", "GROUP_CLOSE_TOKEN", "SEPARATOR_TOKEN",
-  "LOOP_CONNECTOR_TOKEN", "MINUS_TOKEN", "PLUS_TOKEN",
-  "CHIRAL_MARKER_TOKEN", "CHI_CLASS_TOKEN", "CHI_CLASS_OH_TOKEN",
-  "H_TOKEN", "AT_TOKEN", "PERCENT_TOKEN", "COLON_TOKEN", "HASH_TOKEN",
-  "BOND_TOKEN", "ATOM_OPEN_TOKEN", "ATOM_CLOSE_TOKEN", "EOS_TOKEN",
-  "$accept", "cmpd", "mol", "atomd", "charge_element", "h_element",
-  "chiral_element", "element", "simple_atom", "ring_number", "number",
-  "nonzero_number", "digit", YY_NULLPTR
+  "$end", "error", "$undefined", "START_MOL", "START_ATOM", "START_BOND",
+  "AROMATIC_ATOM_TOKEN", "ATOM_TOKEN", "ORGANIC_ATOM_TOKEN",
+  "NONZERO_DIGIT_TOKEN", "ZERO_TOKEN", "GROUP_OPEN_TOKEN",
+  "GROUP_CLOSE_TOKEN", "SEPARATOR_TOKEN", "LOOP_CONNECTOR_TOKEN",
+  "MINUS_TOKEN", "PLUS_TOKEN", "CHIRAL_MARKER_TOKEN", "CHI_CLASS_TOKEN",
+  "CHI_CLASS_OH_TOKEN", "H_TOKEN", "AT_TOKEN", "PERCENT_TOKEN",
+  "COLON_TOKEN", "HASH_TOKEN", "BOND_TOKEN", "ATOM_OPEN_TOKEN",
+  "ATOM_CLOSE_TOKEN", "EOS_TOKEN", "$accept", "meta_start", "mol", "bondd",
+  "atomd", "charge_element", "h_element", "chiral_element", "element",
+  "simple_atom", "ring_number", "number", "nonzero_number", "digit", YY_NULLPTR
 };
 #endif
 
@@ -541,14 +563,14 @@ static const yytype_uint16 yytoknum[] =
 {
        0,   256,   257,   258,   259,   260,   261,   262,   263,   264,
      265,   266,   267,   268,   269,   270,   271,   272,   273,   274,
-     275,   276,   277,   278,   279,   280
+     275,   276,   277,   278,   279,   280,   281,   282,   283
 };
 # endif
 
-#define YYPACT_NINF -22
+#define YYPACT_NINF -32
 
 #define yypact_value_is_default(Yystate) \
-  (!!((Yystate) == (-22)))
+  (!!((Yystate) == (-32)))
 
 #define YYTABLE_NINF -1
 
@@ -559,15 +581,16 @@ static const yytype_uint16 yytoknum[] =
      STATE-NUM.  */
 static const yytype_int8 yypact[] =
 {
-       8,   -15,   -22,   -22,    94,     5,    60,   -22,   -22,   -22,
-     -22,   -22,   -22,     1,    47,   -17,    80,    20,    21,   -22,
-      85,    74,   -22,    17,   -22,   -22,   -22,    73,   -22,    -1,
-      68,     6,    68,   -22,   -22,   -22,    47,   -22,    47,   -22,
-       9,    13,    47,    28,   -22,    33,    47,   -22,   -22,   -22,
-      -1,    -1,   -22,   -22,   -22,   -22,    74,    74,   -22,   -22,
-     -22,    35,   -22,   -22,   -22,   -22,   -22,   -22,    47,   -22,
-     -22,   -22,   -22,    38,   -22,   -22,   -22,    42,   -22,    98,
-     -22,   103,   -22,    48,   -22
+       5,   -11,     8,     8,   -10,     2,   -32,   -32,   -32,    88,
+      54,   -32,   -32,   -32,   -32,   -32,   -32,   -32,    -8,   -32,
+     -32,   -32,   -32,     4,    68,    -5,    74,     9,    15,   -32,
+      79,   105,   -32,   -32,    67,   -32,     8,    62,    39,    62,
+     -32,   -32,   -32,   -32,    68,   -32,    68,   -32,    32,     3,
+      68,    18,   -32,    25,    68,   -32,   -32,     8,     8,   -32,
+     -32,   -32,   -32,   105,   105,   -32,   -32,   -32,    24,   -32,
+     -32,   -32,   -32,   -32,   -32,    68,   -32,   -32,   -32,   -32,
+      34,   -32,   -32,   -32,    92,   -32,    97,   -32,   101,   -32,
+      49,   -32
 };
 
   /* YYDEFACT[STATE-NUM] -- Default reduction number in state STATE-NUM.
@@ -575,29 +598,30 @@ static const yytype_int8 yypact[] =
      means the default is an error.  */
 static const yytype_uint8 yydefact[] =
 {
-       0,     0,    47,    46,     0,     0,     2,     6,    18,     5,
-      42,    57,    55,    28,     0,     0,    21,    34,    37,    40,
-       0,    56,     1,     0,     4,    59,    60,     0,    17,     0,
-       0,     0,     0,     7,    11,    48,    30,    44,     0,    20,
-      25,    22,    35,    38,    43,    29,     0,    41,    58,     3,
-       0,     0,    14,    10,     9,    13,     0,     0,     8,    12,
-      32,     0,    26,    27,    23,    24,    36,    39,    31,    45,
-      16,    15,    49,     0,    19,    33,    50,     0,    51,     0,
-      52,     0,    53,     0,    54
+       0,     0,     0,     0,     0,     0,     7,    51,    50,     0,
+       2,     8,    22,     3,    21,    20,     4,     1,     0,     6,
+      46,    61,    59,    32,     0,     0,    25,    38,    41,    44,
+       0,    60,    63,    64,     0,    19,     0,     0,     0,     0,
+       9,    13,    52,     5,    34,    48,     0,    24,    29,    26,
+      39,    42,    47,    33,     0,    45,    62,     0,     0,    16,
+      12,    11,    15,     0,     0,    10,    14,    36,     0,    30,
+      31,    27,    28,    40,    43,    35,    49,    18,    17,    53,
+       0,    23,    37,    54,     0,    55,     0,    56,     0,    57,
+       0,    58
 };
 
   /* YYPGOTO[NTERM-NUM].  */
 static const yytype_int8 yypgoto[] =
 {
-     -22,   -22,   -22,    11,   -22,   -22,   -22,   -22,     4,     2,
-     -13,   -22,   -21
+     -32,   -32,   -32,   -32,     1,   -32,   -32,   -32,   -32,    -2,
+      17,   -23,   -32,   -31
 };
 
   /* YYDEFGOTO[NTERM-NUM].  */
 static const yytype_int8 yydefgoto[] =
 {
-      -1,     5,     6,     7,    15,    16,    17,    18,     8,    34,
-      20,    21,    35
+      -1,     5,    10,    16,    11,    25,    26,    27,    28,    12,
+      41,    30,    31,    42
 };
 
   /* YYTABLE[YYPACT[STATE-NUM]] -- What to do in state STATE-NUM.  If
@@ -605,73 +629,74 @@ static const yytype_int8 yydefgoto[] =
      number is the opposite.  If YYTABLE_NINF, syntax error.  */
 static const yytype_uint8 yytable[] =
 {
-      48,    37,     2,    38,     3,    22,    23,    39,    19,     1,
-       9,     2,    56,     3,    57,    11,    12,    33,    36,    11,
-      12,    62,     4,    60,    47,    61,    64,    63,    65,    66,
-      24,     4,    55,    69,    59,    72,    73,    42,    52,    43,
-      53,    54,    49,    58,    25,    26,    67,    76,    25,    26,
-      68,    78,    77,    11,    12,    75,    79,    84,    81,    74,
-      83,    70,    71,     2,     0,     3,    25,    26,    27,    28,
-      29,     2,    30,     3,    25,    26,     2,     0,     3,    31,
-      25,    26,    32,     4,     0,    50,     0,    31,     2,    44,
-       3,     4,    40,    41,     0,    51,     4,     2,    10,     3,
-      11,    12,    45,     0,    25,    26,    46,    80,     0,    25,
-      26,    13,    82,     0,     0,    14
+      56,    45,    17,    18,    13,    14,     1,    29,     2,     3,
+       4,    40,    21,    22,     7,    15,     8,     6,    46,    71,
+      43,    67,    47,    68,    44,    70,    72,    73,    55,    50,
+      19,    76,    79,    80,     9,    59,    51,    60,    61,    74,
+      65,    21,    22,    32,    33,    75,    83,    69,    63,    84,
+      64,    81,    82,    86,    62,    88,    66,    90,    77,    78,
+       7,    91,     8,    32,    33,    34,    35,    36,     7,    37,
+       8,    32,    33,     7,     0,     8,    38,    21,    22,    39,
+       9,     0,    57,     0,    38,     7,    52,     8,     9,    48,
+      49,     0,    58,     9,     7,    20,     8,    21,    22,    53,
+       0,    32,    33,    54,    85,     0,    32,    33,    23,    87,
+      32,    33,    24,    89,    32,    33
 };
 
 static const yytype_int8 yycheck[] =
 {
-      21,    14,     3,    20,     5,     0,     1,    24,     4,     1,
-      25,     3,     6,     5,     8,     6,     7,     6,    17,     6,
-       7,    12,    23,    36,    20,    38,    13,    40,    41,    42,
-      25,    23,    30,    46,    32,    56,    57,    17,    27,    18,
-      29,    30,    25,    32,     6,     7,    18,     9,     6,     7,
-      17,     9,    73,     6,     7,    68,    77,     9,    79,    24,
-      81,    50,    51,     3,    -1,     5,     6,     7,     8,     9,
-      10,     3,    12,     5,     6,     7,     3,    -1,     5,    19,
-       6,     7,    22,    23,    -1,    12,    -1,    19,     3,     4,
-       5,    23,    12,    13,    -1,    22,    23,     3,     4,     5,
-       6,     7,    17,    -1,     6,     7,    21,     9,    -1,     6,
-       7,    17,     9,    -1,    -1,    21
+      31,    24,     0,     1,     3,    15,     1,     9,     3,     4,
+       5,    10,     9,    10,     6,    25,     8,    28,    23,    16,
+      28,    44,    27,    46,    20,    48,    49,    50,    30,    20,
+      28,    54,    63,    64,    26,    34,    21,    36,    37,    21,
+      39,     9,    10,     9,    10,    20,    12,    15,     9,    80,
+      11,    27,    75,    84,    37,    86,    39,    88,    57,    58,
+       6,    12,     8,     9,    10,    11,    12,    13,     6,    15,
+       8,     9,    10,     6,    -1,     8,    22,     9,    10,    25,
+      26,    -1,    15,    -1,    22,     6,     7,     8,    26,    15,
+      16,    -1,    25,    26,     6,     7,     8,     9,    10,    20,
+      -1,     9,    10,    24,    12,    -1,     9,    10,    20,    12,
+       9,    10,    24,    12,     9,    10
 };
 
   /* YYSTOS[STATE-NUM] -- The (internal number of the) accessing
      symbol of state STATE-NUM.  */
 static const yytype_uint8 yystos[] =
 {
-       0,     1,     3,     5,    23,    27,    28,    29,    34,    25,
-       4,     6,     7,    17,    21,    30,    31,    32,    33,    34,
-      36,    37,     0,     1,    25,     6,     7,     8,     9,    10,
-      12,    19,    22,    29,    35,    38,    17,    36,    20,    24,
-      12,    13,    17,    18,     4,    17,    21,    34,    38,    25,
-      12,    22,    29,    29,    29,    35,     6,     8,    29,    35,
-      36,    36,    12,    36,    13,    36,    36,    18,    17,    36,
-      29,    29,    38,    38,    24,    36,     9,    38,     9,    38,
-       9,    38,     9,    38,     9
+       0,     1,     3,     4,     5,    30,    28,     6,     8,    26,
+      31,    33,    38,    33,    15,    25,    32,     0,     1,    28,
+       7,     9,    10,    20,    24,    34,    35,    36,    37,    38,
+      40,    41,     9,    10,    11,    12,    13,    15,    22,    25,
+      33,    39,    42,    28,    20,    40,    23,    27,    15,    16,
+      20,    21,     7,    20,    24,    38,    42,    15,    25,    33,
+      33,    33,    39,     9,    11,    33,    39,    40,    40,    15,
+      40,    16,    40,    40,    21,    20,    40,    33,    33,    42,
+      42,    27,    40,    12,    42,    12,    42,    12,    42,    12,
+      42,    12
 };
 
   /* YYR1[YYN] -- Symbol number of symbol that rule YYN derives.  */
 static const yytype_uint8 yyr1[] =
 {
-       0,    26,    27,    27,    27,    27,    28,    28,    28,    28,
-      28,    28,    28,    28,    28,    28,    28,    28,    29,    29,
-      29,    30,    30,    30,    30,    30,    30,    30,    31,    31,
-      31,    31,    31,    31,    31,    31,    31,    32,    32,    32,
-      33,    33,    33,    33,    33,    33,    34,    34,    35,    35,
-      35,    35,    35,    35,    35,    36,    36,    37,    37,    38,
-      38
+       0,    29,    30,    30,    30,    30,    30,    30,    31,    31,
+      31,    31,    31,    31,    31,    31,    31,    31,    31,    31,
+      32,    32,    33,    33,    33,    34,    34,    34,    34,    34,
+      34,    34,    35,    35,    35,    35,    35,    35,    35,    35,
+      35,    36,    36,    36,    37,    37,    37,    37,    37,    37,
+      38,    38,    39,    39,    39,    39,    39,    39,    39,    40,
+      40,    41,    41,    42,    42
 };
 
   /* YYR2[YYN] -- Number of symbols on the right hand side of rule YYN.  */
 static const yytype_uint8 yyr2[] =
 {
-       0,     2,     1,     3,     2,     2,     1,     2,     3,     3,
-       3,     2,     3,     3,     3,     4,     4,     2,     1,     5,
-       3,     1,     2,     3,     3,     2,     3,     3,     1,     2,
-       2,     3,     3,     4,     1,     2,     3,     1,     2,     3,
-       1,     2,     1,     2,     2,     3,     1,     1,     1,     3,
-       4,     5,     6,     7,     8,     1,     1,     1,     2,     1,
-       1
+       0,     2,     2,     2,     2,     3,     2,     2,     1,     2,
+       3,     3,     3,     2,     3,     3,     3,     4,     4,     2,
+       1,     1,     1,     5,     3,     1,     2,     3,     3,     2,
+       3,     3,     1,     2,     2,     3,     3,     4,     1,     2,
+       3,     1,     2,     3,     1,     2,     1,     2,     2,     3,
+       1,     1,     1,     3,     4,     5,     6,     7,     8,     1,
+       1,     1,     2,     1,     1
 };
 
 
@@ -699,7 +724,7 @@ do                                                              \
     }                                                           \
   else                                                          \
     {                                                           \
-      yyerror (input, molList, branchPoints, scanner, YY_("syntax error: cannot back up")); \
+      yyerror (input, molList, lastAtom, lastBond, branchPoints, scanner, start_token, YY_("syntax error: cannot back up")); \
       YYERROR;                                                  \
     }                                                           \
 while (0)
@@ -736,7 +761,7 @@ do {                                                                      \
     {                                                                     \
       YYFPRINTF (stderr, "%s ", Title);                                   \
       yy_symbol_print (stderr,                                            \
-                  Type, Value, input, molList, branchPoints, scanner); \
+                  Type, Value, input, molList, lastAtom, lastBond, branchPoints, scanner, start_token); \
       YYFPRINTF (stderr, "\n");                                           \
     }                                                                     \
 } while (0)
@@ -747,14 +772,17 @@ do {                                                                      \
 `----------------------------------------*/
 
 static void
-yy_symbol_value_print (FILE *yyoutput, int yytype, YYSTYPE const * const yyvaluep, const char *input, std::vector<RDKit::RWMol *> *molList, std::list<unsigned int> *branchPoints, void *scanner)
+yy_symbol_value_print (FILE *yyoutput, int yytype, YYSTYPE const * const yyvaluep, const char *input, std::vector<RDKit::RWMol *> *molList, RDKit::Atom* &lastAtom, RDKit::Bond* &lastBond, std::list<unsigned int> *branchPoints, void *scanner, int& start_token)
 {
   FILE *yyo = yyoutput;
   YYUSE (yyo);
   YYUSE (input);
   YYUSE (molList);
+  YYUSE (lastAtom);
+  YYUSE (lastBond);
   YYUSE (branchPoints);
   YYUSE (scanner);
+  YYUSE (start_token);
   if (!yyvaluep)
     return;
 # ifdef YYPRINT
@@ -770,12 +798,12 @@ yy_symbol_value_print (FILE *yyoutput, int yytype, YYSTYPE const * const yyvalue
 `--------------------------------*/
 
 static void
-yy_symbol_print (FILE *yyoutput, int yytype, YYSTYPE const * const yyvaluep, const char *input, std::vector<RDKit::RWMol *> *molList, std::list<unsigned int> *branchPoints, void *scanner)
+yy_symbol_print (FILE *yyoutput, int yytype, YYSTYPE const * const yyvaluep, const char *input, std::vector<RDKit::RWMol *> *molList, RDKit::Atom* &lastAtom, RDKit::Bond* &lastBond, std::list<unsigned int> *branchPoints, void *scanner, int& start_token)
 {
   YYFPRINTF (yyoutput, "%s %s (",
              yytype < YYNTOKENS ? "token" : "nterm", yytname[yytype]);
 
-  yy_symbol_value_print (yyoutput, yytype, yyvaluep, input, molList, branchPoints, scanner);
+  yy_symbol_value_print (yyoutput, yytype, yyvaluep, input, molList, lastAtom, lastBond, branchPoints, scanner, start_token);
   YYFPRINTF (yyoutput, ")");
 }
 
@@ -808,7 +836,7 @@ do {                                                            \
 `------------------------------------------------*/
 
 static void
-yy_reduce_print (yytype_int16 *yyssp, YYSTYPE *yyvsp, int yyrule, const char *input, std::vector<RDKit::RWMol *> *molList, std::list<unsigned int> *branchPoints, void *scanner)
+yy_reduce_print (yytype_int16 *yyssp, YYSTYPE *yyvsp, int yyrule, const char *input, std::vector<RDKit::RWMol *> *molList, RDKit::Atom* &lastAtom, RDKit::Bond* &lastBond, std::list<unsigned int> *branchPoints, void *scanner, int& start_token)
 {
   unsigned long int yylno = yyrline[yyrule];
   int yynrhs = yyr2[yyrule];
@@ -822,7 +850,7 @@ yy_reduce_print (yytype_int16 *yyssp, YYSTYPE *yyvsp, int yyrule, const char *in
       yy_symbol_print (stderr,
                        yystos[yyssp[yyi + 1 - yynrhs]],
                        &(yyvsp[(yyi + 1) - (yynrhs)])
-                                              , input, molList, branchPoints, scanner);
+                                              , input, molList, lastAtom, lastBond, branchPoints, scanner, start_token);
       YYFPRINTF (stderr, "\n");
     }
 }
@@ -830,7 +858,7 @@ yy_reduce_print (yytype_int16 *yyssp, YYSTYPE *yyvsp, int yyrule, const char *in
 # define YY_REDUCE_PRINT(Rule)          \
 do {                                    \
   if (yydebug)                          \
-    yy_reduce_print (yyssp, yyvsp, Rule, input, molList, branchPoints, scanner); \
+    yy_reduce_print (yyssp, yyvsp, Rule, input, molList, lastAtom, lastBond, branchPoints, scanner, start_token); \
 } while (0)
 
 /* Nonzero means print parse trace.  It is left uninitialized so that
@@ -1088,13 +1116,16 @@ yysyntax_error (YYSIZE_T *yymsg_alloc, char **yymsg,
 `-----------------------------------------------*/
 
 static void
-yydestruct (const char *yymsg, int yytype, YYSTYPE *yyvaluep, const char *input, std::vector<RDKit::RWMol *> *molList, std::list<unsigned int> *branchPoints, void *scanner)
+yydestruct (const char *yymsg, int yytype, YYSTYPE *yyvaluep, const char *input, std::vector<RDKit::RWMol *> *molList, RDKit::Atom* &lastAtom, RDKit::Bond* &lastBond, std::list<unsigned int> *branchPoints, void *scanner, int& start_token)
 {
   YYUSE (yyvaluep);
   YYUSE (input);
   YYUSE (molList);
+  YYUSE (lastAtom);
+  YYUSE (lastBond);
   YYUSE (branchPoints);
   YYUSE (scanner);
+  YYUSE (start_token);
   if (!yymsg)
     yymsg = "Deleting";
   YY_SYMBOL_PRINT (yymsg, yytype, yyvaluep, yylocationp);
@@ -1112,7 +1143,7 @@ yydestruct (const char *yymsg, int yytype, YYSTYPE *yyvaluep, const char *input,
 `----------*/
 
 int
-yyparse (const char *input, std::vector<RDKit::RWMol *> *molList, std::list<unsigned int> *branchPoints, void *scanner)
+yyparse (const char *input, std::vector<RDKit::RWMol *> *molList, RDKit::Atom* &lastAtom, RDKit::Bond* &lastBond, std::list<unsigned int> *branchPoints, void *scanner, int& start_token)
 {
 /* The lookahead symbol.  */
 int yychar;
@@ -1281,7 +1312,7 @@ yybackup:
   if (yychar == YYEMPTY)
     {
       YYDPRINTF ((stderr, "Reading a token: "));
-      yychar = yylex (&yylval, scanner);
+      yychar = yylex (&yylval, scanner, start_token);
     }
 
   if (yychar <= YYEOF)
@@ -1359,38 +1390,62 @@ yyreduce:
   YY_REDUCE_PRINT (yyn);
   switch (yyn)
     {
-        case 3:
-#line 80 "smiles.yy" /* yacc.c:1646  */
+        case 2:
+#line 103 "smiles.yy" /* yacc.c:1646  */
     {
-  yyclearin;
-  yyerrok;
-  yyErrorCleanup(molList);
-  YYABORT;
+// the molList has already been updated, no need to do anything
 }
-#line 1371 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
+#line 1399 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
+    break;
+
+  case 3:
+#line 106 "smiles.yy" /* yacc.c:1646  */
+    {
+  lastAtom = (yyvsp[0].atom);
+}
+#line 1407 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
     break;
 
   case 4:
-#line 86 "smiles.yy" /* yacc.c:1646  */
+#line 109 "smiles.yy" /* yacc.c:1646  */
     {
-  YYACCEPT;
+  lastBond = (yyvsp[0].bond);
 }
-#line 1379 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
+#line 1415 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
     break;
 
   case 5:
-#line 89 "smiles.yy" /* yacc.c:1646  */
+#line 112 "smiles.yy" /* yacc.c:1646  */
     {
   yyclearin;
   yyerrok;
   yyErrorCleanup(molList);
   YYABORT;
 }
-#line 1390 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
+#line 1426 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
     break;
 
   case 6:
-#line 99 "smiles.yy" /* yacc.c:1646  */
+#line 118 "smiles.yy" /* yacc.c:1646  */
+    {
+  YYACCEPT;
+}
+#line 1434 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
+    break;
+
+  case 7:
+#line 121 "smiles.yy" /* yacc.c:1646  */
+    {
+  yyclearin;
+  yyerrok;
+  yyErrorCleanup(molList);
+  YYABORT;
+}
+#line 1445 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
+    break;
+
+  case 8:
+#line 132 "smiles.yy" /* yacc.c:1646  */
     {
   int sz     = molList->size();
   molList->resize( sz + 1);
@@ -1401,11 +1456,11 @@ yyreduce:
   delete (yyvsp[0].atom);
   (yyval.moli) = sz;
 }
-#line 1405 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
+#line 1460 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
     break;
 
-  case 7:
-#line 110 "smiles.yy" /* yacc.c:1646  */
+  case 9:
+#line 143 "smiles.yy" /* yacc.c:1646  */
     {
   RWMol *mp = (*molList)[(yyval.moli)];
   Atom *a1 = mp->getActiveAtom();
@@ -1415,11 +1470,11 @@ yyreduce:
 	      SmilesParseOps::GetUnspecifiedBondType(mp,a1,mp->getAtomWithIdx(atomIdx2)));
   //delete $2;
 }
-#line 1419 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
+#line 1474 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
     break;
 
-  case 8:
-#line 120 "smiles.yy" /* yacc.c:1646  */
+  case 10:
+#line 153 "smiles.yy" /* yacc.c:1646  */
     {
   RWMol *mp = (*molList)[(yyval.moli)];
   int atomIdx1 = mp->getActiveAtom()->getIdx();
@@ -1439,11 +1494,11 @@ yyreduce:
   mp->addBond((yyvsp[-1].bond),true);
   //delete $3;
 }
-#line 1443 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
+#line 1498 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
     break;
 
-  case 9:
-#line 140 "smiles.yy" /* yacc.c:1646  */
+  case 11:
+#line 173 "smiles.yy" /* yacc.c:1646  */
     {
   RWMol *mp = (*molList)[(yyval.moli)];
   int atomIdx1 = mp->getActiveAtom()->getIdx();
@@ -1451,21 +1506,21 @@ yyreduce:
   mp->addBond(atomIdx1,atomIdx2,Bond::SINGLE);
   //delete $3;
 }
-#line 1455 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
+#line 1510 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
     break;
 
-  case 10:
-#line 148 "smiles.yy" /* yacc.c:1646  */
+  case 12:
+#line 181 "smiles.yy" /* yacc.c:1646  */
     {
   RWMol *mp = (*molList)[(yyval.moli)];
   (yyvsp[0].atom)->setProp(RDKit::common_properties::_SmilesStart,1,true);
   mp->addAtom((yyvsp[0].atom),true,true);
 }
-#line 1465 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
+#line 1520 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
     break;
 
-  case 11:
-#line 154 "smiles.yy" /* yacc.c:1646  */
+  case 13:
+#line 187 "smiles.yy" /* yacc.c:1646  */
     {
   RWMol * mp = (*molList)[(yyval.moli)];
   Atom *atom=mp->getActiveAtom();
@@ -1484,11 +1539,11 @@ yyreduce:
   atom->setProp(RDKit::common_properties::_RingClosures,tmp);
 
 }
-#line 1488 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
+#line 1543 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
     break;
 
-  case 12:
-#line 173 "smiles.yy" /* yacc.c:1646  */
+  case 14:
+#line 206 "smiles.yy" /* yacc.c:1646  */
     {
   RWMol * mp = (*molList)[(yyval.moli)];
   Atom *atom=mp->getActiveAtom();
@@ -1506,11 +1561,11 @@ yyreduce:
   atom->setProp(RDKit::common_properties::_RingClosures,tmp);
   delete (yyvsp[-1].bond);
 }
-#line 1510 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
+#line 1565 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
     break;
 
-  case 13:
-#line 191 "smiles.yy" /* yacc.c:1646  */
+  case 15:
+#line 224 "smiles.yy" /* yacc.c:1646  */
     {
   RWMol * mp = (*molList)[(yyval.moli)];
   Atom *atom=mp->getActiveAtom();
@@ -1526,11 +1581,11 @@ yyreduce:
   tmp.push_back(-((yyvsp[0].ival)+1));
   atom->setProp(RDKit::common_properties::_RingClosures,tmp);
 }
-#line 1530 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
+#line 1585 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
     break;
 
-  case 14:
-#line 207 "smiles.yy" /* yacc.c:1646  */
+  case 16:
+#line 240 "smiles.yy" /* yacc.c:1646  */
     {
   RWMol *mp = (*molList)[(yyval.moli)];
   Atom *a1 = mp->getActiveAtom();
@@ -1541,11 +1596,11 @@ yyreduce:
   //delete $3;
   branchPoints->push_back(atomIdx1);
 }
-#line 1545 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
+#line 1600 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
     break;
 
-  case 15:
-#line 217 "smiles.yy" /* yacc.c:1646  */
+  case 17:
+#line 250 "smiles.yy" /* yacc.c:1646  */
     {
   RWMol *mp = (*molList)[(yyval.moli)];
   int atomIdx1 = mp->getActiveAtom()->getIdx();
@@ -1566,11 +1621,11 @@ yyreduce:
   //delete $4;
   branchPoints->push_back(atomIdx1);
 }
-#line 1570 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
+#line 1625 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
     break;
 
-  case 16:
-#line 237 "smiles.yy" /* yacc.c:1646  */
+  case 18:
+#line 270 "smiles.yy" /* yacc.c:1646  */
     {
   RWMol *mp = (*molList)[(yyval.moli)];
   int atomIdx1 = mp->getActiveAtom()->getIdx();
@@ -1579,203 +1634,211 @@ yyreduce:
   //delete $4;
   branchPoints->push_back(atomIdx1);
 }
-#line 1583 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
+#line 1638 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
     break;
 
-  case 17:
-#line 245 "smiles.yy" /* yacc.c:1646  */
+  case 19:
+#line 278 "smiles.yy" /* yacc.c:1646  */
     {
-  if(branchPoints->empty()) yyerror(input,molList,branchPoints,scanner,"extra close parentheses");
+  if(branchPoints->empty()) yyerror(input,molList,branchPoints,scanner,start_token,"extra close parentheses");
   RWMol *mp = (*molList)[(yyval.moli)];
   mp->setActiveAtom(branchPoints->back());
   branchPoints->pop_back();
 }
-#line 1594 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
+#line 1649 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
     break;
 
-  case 19:
-#line 257 "smiles.yy" /* yacc.c:1646  */
+  case 21:
+#line 288 "smiles.yy" /* yacc.c:1646  */
+    {
+          (yyval.bond) = new Bond(Bond::SINGLE);
+          }
+#line 1657 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
+    break;
+
+  case 23:
+#line 298 "smiles.yy" /* yacc.c:1646  */
     {
   (yyval.atom) = (yyvsp[-3].atom);
   (yyval.atom)->setNoImplicit(true);
   (yyval.atom)->setProp(RDKit::common_properties::molAtomMapNumber,(yyvsp[-1].ival));
 }
-#line 1604 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
+#line 1667 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
     break;
 
-  case 20:
-#line 264 "smiles.yy" /* yacc.c:1646  */
+  case 24:
+#line 305 "smiles.yy" /* yacc.c:1646  */
     {
   (yyval.atom) = (yyvsp[-1].atom);
   (yyvsp[-1].atom)->setNoImplicit(true);
 }
-#line 1613 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
-    break;
-
-  case 22:
-#line 272 "smiles.yy" /* yacc.c:1646  */
-    { (yyvsp[-1].atom)->setFormalCharge(1); }
-#line 1619 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
-    break;
-
-  case 23:
-#line 273 "smiles.yy" /* yacc.c:1646  */
-    { (yyvsp[-2].atom)->setFormalCharge(2); }
-#line 1625 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
-    break;
-
-  case 24:
-#line 274 "smiles.yy" /* yacc.c:1646  */
-    { (yyvsp[-2].atom)->setFormalCharge((yyvsp[0].ival)); }
-#line 1631 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
-    break;
-
-  case 25:
-#line 275 "smiles.yy" /* yacc.c:1646  */
-    { (yyvsp[-1].atom)->setFormalCharge(-1); }
-#line 1637 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
+#line 1676 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
     break;
 
   case 26:
-#line 276 "smiles.yy" /* yacc.c:1646  */
-    { (yyvsp[-2].atom)->setFormalCharge(-2); }
-#line 1643 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
+#line 313 "smiles.yy" /* yacc.c:1646  */
+    { (yyvsp[-1].atom)->setFormalCharge(1); }
+#line 1682 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
     break;
 
   case 27:
-#line 277 "smiles.yy" /* yacc.c:1646  */
-    { (yyvsp[-2].atom)->setFormalCharge(-(yyvsp[0].ival)); }
-#line 1649 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
+#line 314 "smiles.yy" /* yacc.c:1646  */
+    { (yyvsp[-2].atom)->setFormalCharge(2); }
+#line 1688 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
     break;
 
   case 28:
-#line 281 "smiles.yy" /* yacc.c:1646  */
-    { (yyval.atom) = new Atom(1); }
-#line 1655 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
+#line 315 "smiles.yy" /* yacc.c:1646  */
+    { (yyvsp[-2].atom)->setFormalCharge((yyvsp[0].ival)); }
+#line 1694 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
     break;
 
   case 29:
-#line 282 "smiles.yy" /* yacc.c:1646  */
-    { (yyval.atom) = new Atom(1); (yyval.atom)->setIsotope((yyvsp[-1].ival)); }
-#line 1661 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
+#line 316 "smiles.yy" /* yacc.c:1646  */
+    { (yyvsp[-1].atom)->setFormalCharge(-1); }
+#line 1700 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
     break;
 
   case 30:
-#line 283 "smiles.yy" /* yacc.c:1646  */
-    { (yyval.atom) = new Atom(1); (yyval.atom)->setNumExplicitHs(1); }
-#line 1667 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
+#line 317 "smiles.yy" /* yacc.c:1646  */
+    { (yyvsp[-2].atom)->setFormalCharge(-2); }
+#line 1706 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
     break;
 
   case 31:
-#line 284 "smiles.yy" /* yacc.c:1646  */
-    { (yyval.atom) = new Atom(1); (yyval.atom)->setIsotope((yyvsp[-2].ival)); (yyval.atom)->setNumExplicitHs(1);}
-#line 1673 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
+#line 318 "smiles.yy" /* yacc.c:1646  */
+    { (yyvsp[-2].atom)->setFormalCharge(-(yyvsp[0].ival)); }
+#line 1712 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
     break;
 
   case 32:
-#line 285 "smiles.yy" /* yacc.c:1646  */
-    { (yyval.atom) = new Atom(1); (yyval.atom)->setNumExplicitHs((yyvsp[0].ival)); }
-#line 1679 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
+#line 322 "smiles.yy" /* yacc.c:1646  */
+    { (yyval.atom) = new Atom(1); }
+#line 1718 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
     break;
 
   case 33:
-#line 286 "smiles.yy" /* yacc.c:1646  */
-    { (yyval.atom) = new Atom(1); (yyval.atom)->setIsotope((yyvsp[-3].ival)); (yyval.atom)->setNumExplicitHs((yyvsp[0].ival));}
-#line 1685 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
+#line 323 "smiles.yy" /* yacc.c:1646  */
+    { (yyval.atom) = new Atom(1); (yyval.atom)->setIsotope((yyvsp[-1].ival)); }
+#line 1724 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
+    break;
+
+  case 34:
+#line 324 "smiles.yy" /* yacc.c:1646  */
+    { (yyval.atom) = new Atom(1); (yyval.atom)->setNumExplicitHs(1); }
+#line 1730 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
     break;
 
   case 35:
-#line 288 "smiles.yy" /* yacc.c:1646  */
-    { (yyval.atom) = (yyvsp[-1].atom); (yyvsp[-1].atom)->setNumExplicitHs(1);}
-#line 1691 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
+#line 325 "smiles.yy" /* yacc.c:1646  */
+    { (yyval.atom) = new Atom(1); (yyval.atom)->setIsotope((yyvsp[-2].ival)); (yyval.atom)->setNumExplicitHs(1);}
+#line 1736 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
     break;
 
   case 36:
-#line 289 "smiles.yy" /* yacc.c:1646  */
-    { (yyval.atom) = (yyvsp[-2].atom); (yyvsp[-2].atom)->setNumExplicitHs((yyvsp[0].ival));}
-#line 1697 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
+#line 326 "smiles.yy" /* yacc.c:1646  */
+    { (yyval.atom) = new Atom(1); (yyval.atom)->setNumExplicitHs((yyvsp[0].ival)); }
+#line 1742 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
     break;
 
-  case 38:
-#line 294 "smiles.yy" /* yacc.c:1646  */
-    { (yyvsp[-1].atom)->setChiralTag(Atom::CHI_TETRAHEDRAL_CCW); }
-#line 1703 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
+  case 37:
+#line 327 "smiles.yy" /* yacc.c:1646  */
+    { (yyval.atom) = new Atom(1); (yyval.atom)->setIsotope((yyvsp[-3].ival)); (yyval.atom)->setNumExplicitHs((yyvsp[0].ival));}
+#line 1748 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
     break;
 
   case 39:
-#line 295 "smiles.yy" /* yacc.c:1646  */
-    { (yyvsp[-2].atom)->setChiralTag(Atom::CHI_TETRAHEDRAL_CW); }
-#line 1709 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
+#line 329 "smiles.yy" /* yacc.c:1646  */
+    { (yyval.atom) = (yyvsp[-1].atom); (yyvsp[-1].atom)->setNumExplicitHs(1);}
+#line 1754 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
     break;
 
-  case 41:
-#line 300 "smiles.yy" /* yacc.c:1646  */
-    { (yyvsp[0].atom)->setIsotope( (yyvsp[-1].ival) ); (yyval.atom) = (yyvsp[0].atom); }
-#line 1715 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
+  case 40:
+#line 330 "smiles.yy" /* yacc.c:1646  */
+    { (yyval.atom) = (yyvsp[-2].atom); (yyvsp[-2].atom)->setNumExplicitHs((yyvsp[0].ival));}
+#line 1760 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
+    break;
+
+  case 42:
+#line 335 "smiles.yy" /* yacc.c:1646  */
+    { (yyvsp[-1].atom)->setChiralTag(Atom::CHI_TETRAHEDRAL_CCW); }
+#line 1766 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
     break;
 
   case 43:
-#line 302 "smiles.yy" /* yacc.c:1646  */
-    { (yyvsp[0].atom)->setIsotope( (yyvsp[-1].ival) ); (yyval.atom) = (yyvsp[0].atom); }
-#line 1721 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
-    break;
-
-  case 44:
-#line 303 "smiles.yy" /* yacc.c:1646  */
-    { (yyval.atom) = new Atom((yyvsp[0].ival)); }
-#line 1727 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
+#line 336 "smiles.yy" /* yacc.c:1646  */
+    { (yyvsp[-2].atom)->setChiralTag(Atom::CHI_TETRAHEDRAL_CW); }
+#line 1772 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
     break;
 
   case 45:
-#line 304 "smiles.yy" /* yacc.c:1646  */
-    { (yyval.atom) = new Atom((yyvsp[0].ival)); (yyval.atom)->setIsotope((yyvsp[-2].ival)); }
-#line 1733 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
+#line 341 "smiles.yy" /* yacc.c:1646  */
+    { (yyvsp[0].atom)->setIsotope( (yyvsp[-1].ival) ); (yyval.atom) = (yyvsp[0].atom); }
+#line 1778 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
+    break;
+
+  case 47:
+#line 343 "smiles.yy" /* yacc.c:1646  */
+    { (yyvsp[0].atom)->setIsotope( (yyvsp[-1].ival) ); (yyval.atom) = (yyvsp[0].atom); }
+#line 1784 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
+    break;
+
+  case 48:
+#line 344 "smiles.yy" /* yacc.c:1646  */
+    { (yyval.atom) = new Atom((yyvsp[0].ival)); }
+#line 1790 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
     break;
 
   case 49:
-#line 314 "smiles.yy" /* yacc.c:1646  */
-    { (yyval.ival) = (yyvsp[-1].ival)*10+(yyvsp[0].ival); }
-#line 1739 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
-    break;
-
-  case 50:
-#line 315 "smiles.yy" /* yacc.c:1646  */
-    { (yyval.ival) = (yyvsp[-1].ival); }
-#line 1745 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
-    break;
-
-  case 51:
-#line 316 "smiles.yy" /* yacc.c:1646  */
-    { (yyval.ival) = (yyvsp[-2].ival)*10+(yyvsp[-1].ival); }
-#line 1751 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
-    break;
-
-  case 52:
-#line 317 "smiles.yy" /* yacc.c:1646  */
-    { (yyval.ival) = (yyvsp[-3].ival)*100+(yyvsp[-2].ival)*10+(yyvsp[-1].ival); }
-#line 1757 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
+#line 345 "smiles.yy" /* yacc.c:1646  */
+    { (yyval.atom) = new Atom((yyvsp[0].ival)); (yyval.atom)->setIsotope((yyvsp[-2].ival)); }
+#line 1796 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
     break;
 
   case 53:
-#line 318 "smiles.yy" /* yacc.c:1646  */
-    { (yyval.ival) = (yyvsp[-4].ival)*1000+(yyvsp[-3].ival)*100+(yyvsp[-2].ival)*10+(yyvsp[-1].ival); }
-#line 1763 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
+#line 355 "smiles.yy" /* yacc.c:1646  */
+    { (yyval.ival) = (yyvsp[-1].ival)*10+(yyvsp[0].ival); }
+#line 1802 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
     break;
 
   case 54:
-#line 319 "smiles.yy" /* yacc.c:1646  */
-    { (yyval.ival) = (yyvsp[-5].ival)*10000+(yyvsp[-4].ival)*1000+(yyvsp[-3].ival)*100+(yyvsp[-2].ival)*10+(yyvsp[-1].ival); }
-#line 1769 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
+#line 356 "smiles.yy" /* yacc.c:1646  */
+    { (yyval.ival) = (yyvsp[-1].ival); }
+#line 1808 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
+    break;
+
+  case 55:
+#line 357 "smiles.yy" /* yacc.c:1646  */
+    { (yyval.ival) = (yyvsp[-2].ival)*10+(yyvsp[-1].ival); }
+#line 1814 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
+    break;
+
+  case 56:
+#line 358 "smiles.yy" /* yacc.c:1646  */
+    { (yyval.ival) = (yyvsp[-3].ival)*100+(yyvsp[-2].ival)*10+(yyvsp[-1].ival); }
+#line 1820 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
+    break;
+
+  case 57:
+#line 359 "smiles.yy" /* yacc.c:1646  */
+    { (yyval.ival) = (yyvsp[-4].ival)*1000+(yyvsp[-3].ival)*100+(yyvsp[-2].ival)*10+(yyvsp[-1].ival); }
+#line 1826 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
     break;
 
   case 58:
-#line 329 "smiles.yy" /* yacc.c:1646  */
+#line 360 "smiles.yy" /* yacc.c:1646  */
+    { (yyval.ival) = (yyvsp[-5].ival)*10000+(yyvsp[-4].ival)*1000+(yyvsp[-3].ival)*100+(yyvsp[-2].ival)*10+(yyvsp[-1].ival); }
+#line 1832 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
+    break;
+
+  case 62:
+#line 370 "smiles.yy" /* yacc.c:1646  */
     { (yyval.ival) = (yyvsp[-1].ival)*10 + (yyvsp[0].ival); }
-#line 1775 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
+#line 1838 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
     break;
 
 
-#line 1779 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
+#line 1842 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
       default: break;
     }
   /* User semantic actions sometimes alter yychar, and that requires
@@ -1825,7 +1888,7 @@ yyerrlab:
     {
       ++yynerrs;
 #if ! YYERROR_VERBOSE
-      yyerror (input, molList, branchPoints, scanner, YY_("syntax error"));
+      yyerror (input, molList, lastAtom, lastBond, branchPoints, scanner, start_token, YY_("syntax error"));
 #else
 # define YYSYNTAX_ERROR yysyntax_error (&yymsg_alloc, &yymsg, \
                                         yyssp, yytoken)
@@ -1852,7 +1915,7 @@ yyerrlab:
                 yymsgp = yymsg;
               }
           }
-        yyerror (input, molList, branchPoints, scanner, yymsgp);
+        yyerror (input, molList, lastAtom, lastBond, branchPoints, scanner, start_token, yymsgp);
         if (yysyntax_error_status == 2)
           goto yyexhaustedlab;
       }
@@ -1876,7 +1939,7 @@ yyerrlab:
       else
         {
           yydestruct ("Error: discarding",
-                      yytoken, &yylval, input, molList, branchPoints, scanner);
+                      yytoken, &yylval, input, molList, lastAtom, lastBond, branchPoints, scanner, start_token);
           yychar = YYEMPTY;
         }
     }
@@ -1932,7 +1995,7 @@ yyerrlab1:
 
 
       yydestruct ("Error: popping",
-                  yystos[yystate], yyvsp, input, molList, branchPoints, scanner);
+                  yystos[yystate], yyvsp, input, molList, lastAtom, lastBond, branchPoints, scanner, start_token);
       YYPOPSTACK (1);
       yystate = *yyssp;
       YY_STACK_PRINT (yyss, yyssp);
@@ -1969,7 +2032,7 @@ yyabortlab:
 | yyexhaustedlab -- memory exhaustion comes here.  |
 `-------------------------------------------------*/
 yyexhaustedlab:
-  yyerror (input, molList, branchPoints, scanner, YY_("memory exhausted"));
+  yyerror (input, molList, lastAtom, lastBond, branchPoints, scanner, start_token, YY_("memory exhausted"));
   yyresult = 2;
   /* Fall through.  */
 #endif
@@ -1981,7 +2044,7 @@ yyreturn:
          user semantic actions for why this is necessary.  */
       yytoken = YYTRANSLATE (yychar);
       yydestruct ("Cleanup: discarding lookahead",
-                  yytoken, &yylval, input, molList, branchPoints, scanner);
+                  yytoken, &yylval, input, molList, lastAtom, lastBond, branchPoints, scanner, start_token);
     }
   /* Do not reclaim the symbols of the rule whose action triggered
      this YYABORT or YYACCEPT.  */
@@ -1990,7 +2053,7 @@ yyreturn:
   while (yyssp != yyss)
     {
       yydestruct ("Cleanup: popping",
-                  yystos[*yyssp], yyvsp, input, molList, branchPoints, scanner);
+                  yystos[*yyssp], yyvsp, input, molList, lastAtom, lastBond, branchPoints, scanner, start_token);
       YYPOPSTACK (1);
     }
 #ifndef yyoverflow
@@ -2003,5 +2066,5 @@ yyreturn:
 #endif
   return yyresult;
 }
-#line 343 "smiles.yy" /* yacc.c:1906  */
+#line 384 "smiles.yy" /* yacc.c:1906  */
 

--- a/Code/GraphMol/SmilesParse/smiles.tab.hpp.cmake
+++ b/Code/GraphMol/SmilesParse/smiles.tab.hpp.cmake
@@ -45,29 +45,32 @@ extern int yysmiles_debug;
 # define YYTOKENTYPE
   enum yytokentype
   {
-    AROMATIC_ATOM_TOKEN = 258,
-    ATOM_TOKEN = 259,
-    ORGANIC_ATOM_TOKEN = 260,
-    NONZERO_DIGIT_TOKEN = 261,
-    ZERO_TOKEN = 262,
-    GROUP_OPEN_TOKEN = 263,
-    GROUP_CLOSE_TOKEN = 264,
-    SEPARATOR_TOKEN = 265,
-    LOOP_CONNECTOR_TOKEN = 266,
-    MINUS_TOKEN = 267,
-    PLUS_TOKEN = 268,
-    CHIRAL_MARKER_TOKEN = 269,
-    CHI_CLASS_TOKEN = 270,
-    CHI_CLASS_OH_TOKEN = 271,
-    H_TOKEN = 272,
-    AT_TOKEN = 273,
-    PERCENT_TOKEN = 274,
-    COLON_TOKEN = 275,
-    HASH_TOKEN = 276,
-    BOND_TOKEN = 277,
-    ATOM_OPEN_TOKEN = 278,
-    ATOM_CLOSE_TOKEN = 279,
-    EOS_TOKEN = 280
+    START_MOL = 258,
+    START_ATOM = 259,
+    START_BOND = 260,
+    AROMATIC_ATOM_TOKEN = 261,
+    ATOM_TOKEN = 262,
+    ORGANIC_ATOM_TOKEN = 263,
+    NONZERO_DIGIT_TOKEN = 264,
+    ZERO_TOKEN = 265,
+    GROUP_OPEN_TOKEN = 266,
+    GROUP_CLOSE_TOKEN = 267,
+    SEPARATOR_TOKEN = 268,
+    LOOP_CONNECTOR_TOKEN = 269,
+    MINUS_TOKEN = 270,
+    PLUS_TOKEN = 271,
+    CHIRAL_MARKER_TOKEN = 272,
+    CHI_CLASS_TOKEN = 273,
+    CHI_CLASS_OH_TOKEN = 274,
+    H_TOKEN = 275,
+    AT_TOKEN = 276,
+    PERCENT_TOKEN = 277,
+    COLON_TOKEN = 278,
+    HASH_TOKEN = 279,
+    BOND_TOKEN = 280,
+    ATOM_OPEN_TOKEN = 281,
+    ATOM_CLOSE_TOKEN = 282,
+    EOS_TOKEN = 283
   };
 #endif
 
@@ -76,14 +79,14 @@ extern int yysmiles_debug;
 
 union YYSTYPE
 {
-#line 57 "smiles.yy" /* yacc.c:1909  */
+#line 78 "smiles.yy" /* yacc.c:1909  */
 
   int                      moli;
   RDKit::Atom * atom;
   RDKit::Bond * bond;
   int                      ival;
 
-#line 87 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.hpp" /* yacc.c:1909  */
+#line 90 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.hpp" /* yacc.c:1909  */
 };
 
 typedef union YYSTYPE YYSTYPE;
@@ -93,6 +96,13 @@ typedef union YYSTYPE YYSTYPE;
 
 
 
-int yysmiles_parse (const char *input, std::vector<RDKit::RWMol *> *molList, std::list<unsigned int> *branchPoints, void *scanner);
+int yysmiles_parse (const char *input, std::vector<RDKit::RWMol *> *molList, RDKit::Atom* &lastAtom, RDKit::Bond* &lastBond, std::list<unsigned int> *branchPoints, void *scanner, int& start_token);
+/* "%code provides" blocks.  */
+#line 73 "smiles.yy" /* yacc.c:1909  */
+
+#define YY_DECL int yylex \
+               (YYSTYPE * yylval_param , yyscan_t yyscanner, int& start_token)
+
+#line 107 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.hpp" /* yacc.c:1909  */
 
 #endif /* !YY_YYSMILES_SCRATCH_RDKIT_GIT_CODE_GRAPHMOL_SMILESPARSE_SMILES_TAB_HPP_INCLUDED  */

--- a/Code/GraphMol/SmilesParse/smiles.yy
+++ b/Code/GraphMol/SmilesParse/smiles.yy
@@ -89,7 +89,7 @@ yysmiles_error( const char *input,
 %token MINUS_TOKEN PLUS_TOKEN CHIRAL_MARKER_TOKEN CHI_CLASS_TOKEN CHI_CLASS_OH_TOKEN
 %token H_TOKEN AT_TOKEN PERCENT_TOKEN COLON_TOKEN HASH_TOKEN
 %token <bond> BOND_TOKEN
-%type <moli> cmpd mol
+%type <moli> mol
 %type <atom> atomd element chiral_element h_element charge_element simple_atom
 %type <bond> bondd
 %type <ival>  nonzero_number number ring_number digit

--- a/Code/GraphMol/SmilesParse/smiles.yy
+++ b/Code/GraphMol/SmilesParse/smiles.yy
@@ -20,7 +20,7 @@
 #define YYDEBUG 1
 #include "smiles.tab.hpp"
 
-extern int yysmiles_lex(YYSTYPE *,void *,int);
+extern int yysmiles_lex(YYSTYPE *,void *,int &);
 
 
 using namespace RDKit;
@@ -87,26 +87,19 @@ yysmiles_error( const char *input,
 %%
 
 meta_start: START_MOL mol {
-std::cerr<<" MOL! "<<std::endl;
 }
 | START_ATOM atomd
 | START_BOND bondd
 | meta_start error EOS_TOKEN{
-std::cerr<<" ERR! "<<std::endl;
-
   yyclearin;
   yyerrok;
   yyErrorCleanup(molList);
   YYABORT;
 }
 | meta_start EOS_TOKEN {
-std::cerr<<" EOS! "<<std::endl;
-
   YYACCEPT;
 }
 | error EOS_TOKEN {
-std::cerr<<" ERR_EOS! "<<std::endl;
-
   yyclearin;
   yyerrok;
   yyErrorCleanup(molList);

--- a/Code/GraphMol/SmilesParse/test.cpp
+++ b/Code/GraphMol/SmilesParse/test.cpp
@@ -116,7 +116,7 @@ void testPass() {
   while (smis[i] != "EOS") {
     string smi = smis[i];
     BOOST_LOG(rdInfoLog) << "***: " << smi << std::endl;
-    mol = SmilesToMol(smi, true);
+    mol = SmilesToMol(smi);
     CHECK_INVARIANT(mol, smi);
     if (mol) {
       unsigned int nAts = mol->getNumAtoms();

--- a/Code/GraphMol/SmilesParse/test.cpp
+++ b/Code/GraphMol/SmilesParse/test.cpp
@@ -116,7 +116,7 @@ void testPass() {
   while (smis[i] != "EOS") {
     string smi = smis[i];
     BOOST_LOG(rdInfoLog) << "***: " << smi << std::endl;
-    mol = SmilesToMol(smi);
+    mol = SmilesToMol(smi, true);
     CHECK_INVARIANT(mol, smi);
     if (mol) {
       unsigned int nAts = mol->getNumAtoms();

--- a/Code/GraphMol/SmilesParse/test2.cpp
+++ b/Code/GraphMol/SmilesParse/test2.cpp
@@ -1,0 +1,72 @@
+//
+//  Copyright (C) 2018 Greg Landrum
+//
+//   @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
+//
+#include <RDBoost/test.h>
+#include <iostream>
+#include <string>
+#include <GraphMol/RDKitBase.h>
+#include "SmilesParse.h"
+#include "SmilesWrite.h"
+#include "SmartsWrite.h"
+#include <RDGeneral/RDLog.h>
+//#include <boost/log/functions.hpp>
+using namespace RDKit;
+using namespace std;
+
+void testParseAtomSmiles() {
+  BOOST_LOG(rdInfoLog) << "Testing ParseAtomSmiles" << std::endl;
+  {  // these should pass
+    std::vector<std::string> smiles = {"C", "[NH4+]", "[13C@H]"};
+    for (const auto &pr : smiles) {
+      std::unique_ptr<Atom> a1(SmilesToAtom(pr));
+      TEST_ASSERT(a1);
+      TEST_ASSERT(a1->getAtomicNum() > 0);
+    }
+  }
+
+  {  // these should fail
+    std::vector<std::string> smiles = {"CO", "", "C-O", "-", "[Bg]"};
+    for (const auto &pr : smiles) {
+      std::unique_ptr<Atom> a1(SmilesToAtom(pr));
+      TEST_ASSERT(!a1);
+    }
+  }
+  BOOST_LOG(rdInfoLog) << "done" << std::endl;
+}
+
+void testParseBondSmiles() {
+  BOOST_LOG(rdInfoLog) << "Testing ParseBondSmiles" << std::endl;
+  {  // these should pass
+    std::vector<std::string> smiles = {":", "=", "#", "-", "/", "\\"};
+    for (const auto &pr : smiles) {
+      std::unique_ptr<Bond> a1(SmilesToBond(pr));
+      TEST_ASSERT(a1);
+    }
+  }
+
+  {  // these should fail
+    std::vector<std::string> smiles = {"C", "", "C-O", "*"};
+    for (const auto &pr : smiles) {
+      std::unique_ptr<Bond> a1(SmilesToBond(pr));
+      TEST_ASSERT(!a1);
+    }
+  }
+  BOOST_LOG(rdInfoLog) << "done" << std::endl;
+}
+
+int main(int argc, char *argv[]) {
+  (void)argc;
+  (void)argv;
+  RDLog::InitLogs();
+// boost::logging::enable_logs("rdApp.debug");
+#if 1
+  testParseAtomSmiles();
+  testParseBondSmiles();
+#endif
+}

--- a/Code/GraphMol/SmilesParse/test2.cpp
+++ b/Code/GraphMol/SmilesParse/test2.cpp
@@ -60,6 +60,49 @@ void testParseBondSmiles() {
   BOOST_LOG(rdInfoLog) << "done" << std::endl;
 }
 
+void testParseAtomSmarts() {
+  BOOST_LOG(rdInfoLog) << "Testing ParseAtomSmarts" << std::endl;
+  {  // these should pass
+    std::vector<std::string> smiles = {"C", "[NH4+]", "[13C@H]",
+                                       "[C,N,$(C=CC)]"};
+    for (const auto &pr : smiles) {
+      std::unique_ptr<Atom> a1(SmartsToAtom(pr));
+      TEST_ASSERT(a1);
+      TEST_ASSERT(a1->getAtomicNum() > 0);
+    }
+  }
+
+  {  // these should fail
+    std::vector<std::string> smiles = {"CO", "", "C-O", "-", "[Bg]"};
+    for (const auto &pr : smiles) {
+      std::unique_ptr<Atom> a1(SmartsToAtom(pr));
+      TEST_ASSERT(!a1);
+    }
+  }
+  BOOST_LOG(rdInfoLog) << "done" << std::endl;
+}
+
+void testParseBondSmarts() {
+  BOOST_LOG(rdInfoLog) << "Testing ParseBondSmarts" << std::endl;
+  {  // these should pass
+    std::vector<std::string> smiles = {":",  "=", "#",  "-",  "/",
+                                       "\\", "@", "!-", "=,#"};
+    for (const auto &pr : smiles) {
+      std::unique_ptr<Bond> a1(SmartsToBond(pr));
+      TEST_ASSERT(a1);
+    }
+  }
+
+  {  // these should fail
+    std::vector<std::string> smiles = {"C", "", "-O", "*"};
+    for (const auto &pr : smiles) {
+      std::unique_ptr<Bond> a1(SmartsToBond(pr));
+      TEST_ASSERT(!a1);
+    }
+  }
+  BOOST_LOG(rdInfoLog) << "done" << std::endl;
+}
+
 int main(int argc, char *argv[]) {
   (void)argc;
   (void)argv;
@@ -68,5 +111,7 @@ int main(int argc, char *argv[]) {
 #if 1
   testParseAtomSmiles();
   testParseBondSmiles();
+  testParseAtomSmarts();
+  testParseBondSmarts();
 #endif
 }

--- a/Code/GraphMol/Wrap/rdmolfiles.cpp
+++ b/Code/GraphMol/Wrap/rdmolfiles.cpp
@@ -698,6 +698,14 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
                python::arg("replacements") = python::dict()),
               docString.c_str(),
               python::return_value_policy<python::manage_new_object>());
+  docString = "Construct an atom from a SMILES string";
+  python::def("AtomFromSmiles", SmilesToAtom, python::arg("SMILES"),
+              docString.c_str(),
+              python::return_value_policy<python::manage_new_object>());
+  docString = "Construct a bond from a SMILES string";
+  python::def("BondFromSmiles", SmilesToBond, python::arg("SMILES"),
+              docString.c_str(),
+              python::return_value_policy<python::manage_new_object>());
 
   docString =
       "Construct a molecule from a SMARTS string.\n\n\
@@ -719,6 +727,14 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
   python::def("MolFromSmarts", RDKit::MolFromSmarts,
               (python::arg("SMARTS"), python::arg("mergeHs") = false,
                python::arg("replacements") = python::dict()),
+              docString.c_str(),
+              python::return_value_policy<python::manage_new_object>());
+  docString = "Construct an atom from a SMARTS string";
+  python::def("AtomFromSmarts", SmartsToAtom, python::arg("SMARTS"),
+              docString.c_str(),
+              python::return_value_policy<python::manage_new_object>());
+  docString = "Construct a bond from a SMARTS string";
+  python::def("BondFromSmarts", SmartsToBond, python::arg("SMILES"),
               docString.c_str(),
               python::return_value_policy<python::manage_new_object>());
 

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -2288,7 +2288,7 @@ CAS<~>
     m = Chem.MolFromSmarts("[C,N]C")
     self.assertTrue(m.GetAtomWithIdx(0).GetSmarts() == '[C,N]')
     self.assertTrue(m.GetAtomWithIdx(1).GetSmarts() == 'C')
-    self.assertEqual(m.GetBondBetweenAtoms(0, 1).GetSmarts(),'')
+    self.assertEqual(m.GetBondBetweenAtoms(0, 1).GetSmarts(), '')
 
     m = Chem.MolFromSmarts("[$(C=O)]-O")
     self.assertTrue(m.GetAtomWithIdx(0).GetSmarts() == '[$(C=O)]')
@@ -4788,6 +4788,25 @@ M  END"""
     self.assertEqual(m.GetBondWithIdx(0).GetBondDir(), Chem.BondDir.NONE)
     Chem.WedgeBond(m.GetBondWithIdx(0), 1, m.GetConformer())
     self.assertEqual(m.GetBondWithIdx(0).GetBondDir(), Chem.BondDir.BEGINWEDGE)
+
+  def testSmilesToAtom(self):
+    a = Chem.AtomFromSmiles("C")
+    self.assertEqual(a.GetAtomicNum(), 6)
+    b = Chem.BondFromSmiles("=")
+    self.assertEqual(b.GetBondType(), Chem.BondType.DOUBLE)
+    a = Chem.AtomFromSmiles("error")
+    self.assertIs(a, None)
+    b = Chem.BondFromSmiles("d")
+    self.assertIs(b, None)
+
+    a = Chem.AtomFromSmarts("C")
+    self.assertEqual(a.GetAtomicNum(), 6)
+    b = Chem.BondFromSmarts("=")
+    self.assertEqual(b.GetBondType(), Chem.BondType.DOUBLE)
+    a = Chem.AtomFromSmarts("error")
+    self.assertIs(a, None)
+    b = Chem.BondFromSmarts("d")
+    self.assertIs(b, None)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
It ended up being reasonably straightforward (though somewhat under-documented) to add mulitiple entry points to the parsers.

`SmilesWrite.cpp` is a good target for a future refactoring exercise: there's more duplicated code there than I would like.

Fixes #1919 