### PR TITLE
Add missing boost header for v1.64

### DIFF
--- a/Code/GraphMol/Substruct/SubstructMatch.cpp
+++ b/Code/GraphMol/Substruct/SubstructMatch.cpp
@@ -17,6 +17,7 @@
 
 #include "SubstructMatch.h"
 #include "SubstructUtils.h"
+#include <boost/serialization/array_wrapper.hpp>
 #include <boost/smart_ptr.hpp>
 #include <map>
 

--- a/Code/GraphMol/Substruct/SubstructMatch.cpp
+++ b/Code/GraphMol/Substruct/SubstructMatch.cpp
@@ -17,9 +17,12 @@
 
 #include "SubstructMatch.h"
 #include "SubstructUtils.h"
-#include <boost/serialization/array_wrapper.hpp>
 #include <boost/smart_ptr.hpp>
 #include <map>
+
+#if BOOST_VERSION == 106400
+#include <boost/serialization/array_wrapper.hpp>
+#endif
 
 #ifdef RDK_THREADSAFE_SSS
 #include <mutex>


### PR DESCRIPTION
Based on this SE post: https://stackoverflow.com/questions/44534516/error-make-array-is-not-a-member-of-boostserialization

<!--
Thanks for contributing a pull request! 
-->
#### Reference Issue
Fixes #2015

