### PR TITLE
correct mistake in halogen cleanup and add test cases, fix for #2020

### DIFF
--- a/Code/GraphMol/MolOps.cpp
+++ b/Code/GraphMol/MolOps.cpp
@@ -173,18 +173,20 @@ void halogenCleanup(RWMol &mol, Atom *atom) {
       ++nid1;
     }
     if (neighborsAllO) {
-      atom->setFormalCharge(ev / 2);
+      int formalCharge = 0;
       boost::tie(nid1, end1) = mol.getAtomNeighbors(atom);
       while (nid1 != end1) {
         Bond *b = mol.getBondBetweenAtoms(aid, *nid1);
         if (b->getBondType() == Bond::DOUBLE) {
           b->setBondType(Bond::SINGLE);
           Atom *otherAtom = mol.getAtomWithIdx(*nid1);
+          formalCharge++;
           otherAtom->setFormalCharge(-1);
           otherAtom->calcExplicitValence(false);
         }
         ++nid1;
       }
+      atom->setFormalCharge(formalCharge);
       atom->calcExplicitValence(false);
     }
   }

--- a/Code/GraphMol/molopstest.cpp
+++ b/Code/GraphMol/molopstest.cpp
@@ -2144,6 +2144,27 @@ void testSanitOps() {
   TEST_ASSERT(m->getAtomWithIdx(0)->getFormalCharge() == 1);
   delete m;
 
+  smi = "I(O)(O)(O)(O)O";
+  m = SmilesToMol(smi);
+  TEST_ASSERT(m);
+  TEST_ASSERT(m->getNumAtoms() == 6);
+  TEST_ASSERT(m->getAtomWithIdx(0)->getFormalCharge() == 0);
+  delete m;
+
+  smi = "I(O)(O)O";
+  m = SmilesToMol(smi);
+  TEST_ASSERT(m);
+  TEST_ASSERT(m->getNumAtoms() == 4);
+  TEST_ASSERT(m->getAtomWithIdx(0)->getFormalCharge() == 0);
+  delete m;
+
+  smi = "I(=O)(O)(O)(O)";
+  m = SmilesToMol(smi);
+  TEST_ASSERT(m);
+  TEST_ASSERT(m->getNumAtoms() == 5);
+  TEST_ASSERT(m->getAtomWithIdx(0)->getFormalCharge() == 1);
+  delete m;
+
   BOOST_LOG(rdInfoLog) << "Finished" << std::endl;
 }
 

--- a/Code/GraphMol/molopstest.cpp
+++ b/Code/GraphMol/molopstest.cpp
@@ -2164,7 +2164,14 @@ void testSanitOps() {
   TEST_ASSERT(m->getNumAtoms() == 5);
   TEST_ASSERT(m->getAtomWithIdx(0)->getFormalCharge() == 1);
   delete m;
-
+  
+  smi = "CC(=O)O[IH2](O)OC(C)=O";
+  m = SmilesToMol(smi);
+  TEST_ASSERT(m);
+  TEST_ASSERT(m->getNumAtoms() == 10);
+  TEST_ASSERT(m->getAtomWithIdx(4)->getFormalCharge() == 0);
+  delete m;
+  
   BOOST_LOG(rdInfoLog) << "Finished" << std::endl;
 }
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! 
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->
Fix for #2020 

#### What does this implement/fix? Explain your changes.
During halogen cleanup, only add a positive formal charge when there is a double bond and a negative charge is also set on the oxygen atom.

#### Any other comments?
Closes #2020 
