### PR TITLE
Fixes #2034

### DIFF
--- a/Code/GraphMol/FMCS/FMCS.h
+++ b/Code/GraphMol/FMCS/FMCS.h
@@ -22,10 +22,14 @@ struct RDKIT_FMCS_EXPORT MCSAtomCompareParameters {
   bool MatchValences;
   bool MatchChiralTag;
   bool MatchFormalCharge;
+  bool RingMatchesRingOnly;
 
  public:
   MCSAtomCompareParameters()
-      : MatchValences(false), MatchChiralTag(false), MatchFormalCharge(false) {}
+      : MatchValences(false),
+        MatchChiralTag(false),
+        MatchFormalCharge(false),
+        RingMatchesRingOnly(false) {}
 };
 
 struct RDKIT_FMCS_EXPORT MCSBondCompareParameters {
@@ -55,25 +59,21 @@ typedef bool (*MCSBondCompareFunction)(const MCSBondCompareParameters& p,
 
 // Some predefined functors:
 RDKIT_FMCS_EXPORT bool MCSAtomCompareAny(const MCSAtomCompareParameters& p,
-                                       const ROMol& mol1, unsigned int atom1,
-                                       const ROMol& mol2, unsigned int atom2,
-                                       void* userData);
+                                         const ROMol& mol1, unsigned int atom1,
+                                         const ROMol& mol2, unsigned int atom2,
+                                         void* userData);
 
-RDKIT_FMCS_EXPORT bool MCSAtomCompareElements(const MCSAtomCompareParameters& p,
-                                            const ROMol& mol1,
-                                            unsigned int atom1,
-                                            const ROMol& mol2,
-                                            unsigned int atom2, void* userData);
-RDKIT_FMCS_EXPORT bool MCSAtomCompareIsotopes(const MCSAtomCompareParameters& p,
-                                            const ROMol& mol1,
-                                            unsigned int atom1,
-                                            const ROMol& mol2,
-                                            unsigned int atom2, void* userData);
+RDKIT_FMCS_EXPORT bool MCSAtomCompareElements(
+    const MCSAtomCompareParameters& p, const ROMol& mol1, unsigned int atom1,
+    const ROMol& mol2, unsigned int atom2, void* userData);
+RDKIT_FMCS_EXPORT bool MCSAtomCompareIsotopes(
+    const MCSAtomCompareParameters& p, const ROMol& mol1, unsigned int atom1,
+    const ROMol& mol2, unsigned int atom2, void* userData);
 
 RDKIT_FMCS_EXPORT bool MCSBondCompareAny(const MCSBondCompareParameters& p,
-                                       const ROMol& mol1, unsigned int bond1,
-                                       const ROMol& mol2, unsigned int bond2,
-                                       void* userData);
+                                         const ROMol& mol1, unsigned int bond1,
+                                         const ROMol& mol2, unsigned int bond2,
+                                         void* userData);
 RDKIT_FMCS_EXPORT bool MCSBondCompareOrder(
     const MCSBondCompareParameters& p, const ROMol& mol1, unsigned int bond1,
     const ROMol& mol2, unsigned int bond2,
@@ -95,7 +95,8 @@ typedef bool (*MCSProgressCallback)(const MCSProgressData& stat,
                                     const MCSParameters& params,
                                     void* userData);
 RDKIT_FMCS_EXPORT bool MCSProgressCallbackTimeout(const MCSProgressData& stat,
-                                const MCSParameters& params, void* userData);
+                                                  const MCSParameters& params,
+                                                  void* userData);
 
 struct RDKIT_FMCS_EXPORT MCSParameters {
   bool MaximizeBonds;
@@ -139,12 +140,13 @@ struct RDKIT_FMCS_EXPORT MCSResult {
   bool isCompleted() const { return !Canceled; }
 };
 
-RDKIT_FMCS_EXPORT void parseMCSParametersJSON(const char* json, MCSParameters* params);
+RDKIT_FMCS_EXPORT void parseMCSParametersJSON(const char* json,
+                                              MCSParameters* params);
 
 RDKIT_FMCS_EXPORT MCSResult findMCS(const std::vector<ROMOL_SPTR>& mols,
-                  const MCSParameters* params = 0);
+                                    const MCSParameters* params = 0);
 RDKIT_FMCS_EXPORT MCSResult findMCS_P(const std::vector<ROMOL_SPTR>& mols,
-                    const char* params_json);
+                                      const char* params_json);
 
 typedef enum {
   AtomCompareAny,
@@ -156,12 +158,12 @@ typedef enum {
   BondCompareOrder,
   BondCompareOrderExact
 } BondComparator;
-RDKIT_FMCS_EXPORT MCSResult findMCS(const std::vector<ROMOL_SPTR>& mols, bool maximizeBonds,
-                  double threshold = 1.0, unsigned timeout = 3600,
-                  bool verbose = false, bool matchValences = false,
-                  bool ringMatchesRingOnly = false,
-                  bool completeRingsOnly = false, bool matchChiralTag = false,
-                  AtomComparator atomComp = AtomCompareElements,
-                  BondComparator bondComp = BondCompareOrder);
+RDKIT_FMCS_EXPORT MCSResult
+findMCS(const std::vector<ROMOL_SPTR>& mols, bool maximizeBonds,
+        double threshold = 1.0, unsigned timeout = 3600, bool verbose = false,
+        bool matchValences = false, bool ringMatchesRingOnly = false,
+        bool completeRingsOnly = false, bool matchChiralTag = false,
+        AtomComparator atomComp = AtomCompareElements,
+        BondComparator bondComp = BondCompareOrder);
 
 }  // namespace RDKit

--- a/Code/GraphMol/FMCS/Wrap/rdFMCS.cpp
+++ b/Code/GraphMol/FMCS/Wrap/rdFMCS.cpp
@@ -64,6 +64,7 @@ MCSResult *FindMCSWrapper(python::object mols, bool maximizeBonds,
   p.InitialSeed = seedSmarts;
   p.AtomCompareParameters.MatchValences = matchValences;
   p.AtomCompareParameters.MatchChiralTag = matchChiralTag;
+  p.AtomCompareParameters.RingMatchesRingOnly = ringMatchesRingOnly;
   SetMCSAtomTyper(p, atomComp);
   SetMCSBondTyper(p, bondComp);
   p.BondCompareParameters.RingMatchesRingOnly = ringMatchesRingOnly;
@@ -93,7 +94,7 @@ MCSResult *FindMCSWrapper2(python::object mols, const MCSParameters &params) {
   }
   return res;
 }
-}
+}  // namespace RDKit
 namespace {
 struct mcsresult_wrapper {
   static void wrap() {
@@ -109,7 +110,7 @@ struct mcsresult_wrapper {
                       "if True, the MCS calculation did not finish");
   }
 };
-}
+}  // namespace
 
 BOOST_PYTHON_MODULE(rdFMCS) {
   python::scope().attr("__doc__") =
@@ -185,7 +186,10 @@ BOOST_PYTHON_MODULE(rdFMCS) {
                      "include atom chirality in the match")
       .def_readwrite("MatchFormalCharge",
                      &RDKit::MCSAtomCompareParameters::MatchFormalCharge,
-                     "include formal charge in the match");
+                     "include formal charge in the match")
+      .def_readwrite("RingMatchesRingOnly",
+                     &RDKit::MCSAtomCompareParameters::RingMatchesRingOnly,
+                     "ring atoms are only allowed to match other ring atoms");
   python::class_<RDKit::MCSBondCompareParameters, boost::noncopyable>(
       "MCSBondCompareParameters",
       "Parameters controlling how bond-bond matching is done")

--- a/Code/GraphMol/FMCS/Wrap/testFMCS.py
+++ b/Code/GraphMol/FMCS/Wrap/testFMCS.py
@@ -11,16 +11,18 @@ class TestCase(unittest.TestCase):
     pass
 
   def test1(self):
-    smis = ("Cc1nc(CN(C(C)c2ncccc2)CCCCN)ccc1 CHEMBL1682991",  #-- QUERY
-            "Cc1ccc(CN(C(C)c2ccccn2)CCCCN)nc1 CHEMBL1682990",
-            "Cc1cccnc1CN(C(C)c1ccccn1)CCCCN CHEMBL1682998",
-            "CC(N(CCCCN)Cc1c(N)cccn1)c1ccccn1 CHEMBL1682987",
-            "Cc1cc(C)c(CN(C(C)c2ccccn2)CCCCN)nc1 CHEMBL1682992",
-            "Cc1cc(C(C)N(CCCCN)Cc2c(C)cccn2)ncc1 CHEMBL1682993",
-            "Cc1nc(C(C)N(CCCCN)Cc2nc3c([nH]2)cccc3)ccc1 CHEMBL1682878",
-            "CC(c1ncccc1)N(CCCCN)Cc1nc2c([nH]1)cccc2 CHEMBL1682867",
-            "CC(N(CCCCN)Cc1c(C(C)(C)C)cccn1)c1ccccn1 CHEMBL1682989",
-            "CC(N(CCCCN)Cc1c(C(F)(F)F)cccn1)c1ccccn1 CHEMBL1682988", )
+    smis = (
+      "Cc1nc(CN(C(C)c2ncccc2)CCCCN)ccc1 CHEMBL1682991",  #-- QUERY
+      "Cc1ccc(CN(C(C)c2ccccn2)CCCCN)nc1 CHEMBL1682990",
+      "Cc1cccnc1CN(C(C)c1ccccn1)CCCCN CHEMBL1682998",
+      "CC(N(CCCCN)Cc1c(N)cccn1)c1ccccn1 CHEMBL1682987",
+      "Cc1cc(C)c(CN(C(C)c2ccccn2)CCCCN)nc1 CHEMBL1682992",
+      "Cc1cc(C(C)N(CCCCN)Cc2c(C)cccn2)ncc1 CHEMBL1682993",
+      "Cc1nc(C(C)N(CCCCN)Cc2nc3c([nH]2)cccc3)ccc1 CHEMBL1682878",
+      "CC(c1ncccc1)N(CCCCN)Cc1nc2c([nH]1)cccc2 CHEMBL1682867",
+      "CC(N(CCCCN)Cc1c(C(C)(C)C)cccn1)c1ccccn1 CHEMBL1682989",
+      "CC(N(CCCCN)Cc1c(C(F)(F)F)cccn1)c1ccccn1 CHEMBL1682988",
+    )
     ms = [Chem.MolFromSmiles(x.split()[0]) for x in smis]
     qm = ms[0]
     ms = ms[1:]
@@ -29,7 +31,8 @@ class TestCase(unittest.TestCase):
     self.assertEqual(mcs.numAtoms, 21)
     self.assertEqual(
       mcs.smartsString,
-      '[#6](:[#6]:[#6]):[#6]:[#7]:[#6]-[#6]-[#7](-[#6](-[#6])-[#6]1:[#6]:[#6]:[#6]:[#6]:[#7]:1)-[#6]-[#6]-[#6]-[#6]-[#7]')
+      '[#6](:[#6]:[#6]):[#6]:[#7]:[#6]-[#6]-[#7](-[#6](-[#6])-[#6]1:[#6]:[#6]:[#6]:[#6]:[#7]:1)-[#6]-[#6]-[#6]-[#6]-[#7]'
+    )
     qm = Chem.MolFromSmarts(mcs.smartsString)
     self.assertTrue(qm is not None)
     for m in ms:
@@ -40,25 +43,28 @@ class TestCase(unittest.TestCase):
     self.assertEqual(mcs.numAtoms, 21)
     self.assertEqual(
       mcs.smartsString,
-      '[#6](:[#6]:[#6]):[#6]:[#7]:[#6]-[#6]-[#7](-[#6](-[#6])-[#6]1:[#6]:[#6]:[#6]:[#6]:[#7]:1)-[#6]-[#6]-[#6]-[#6]-[#7]')
+      '[#6](:[#6]:[#6]):[#6]:[#7]:[#6]-[#6]-[#7](-[#6](-[#6])-[#6]1:[#6]:[#6]:[#6]:[#6]:[#7]:1)-[#6]-[#6]-[#6]-[#6]-[#7]'
+    )
     qm = Chem.MolFromSmarts(mcs.smartsString)
     self.assertTrue(qm is not None)
     for m in ms:
       self.assertTrue(m.HasSubstructMatch(qm))
 
   def test2(self):
-    smis = ("CHEMBL122452 CN(CCCN(C)CCc1ccccc1)CCOC(c1ccccc1)c1ccccc1",
-            "CHEMBL123252 CN(CCCc1ccccc1)CCCN(C)CCOC(c1ccccc1)c1ccccc1",
-            "CHEMBL121611 Fc1ccc(C(OCCNCCCNCCc2ccccc2)c2ccc(F)cc2)cc1",
-            "CHEMBL121050 O=C(Cc1ccccc1)NCCCCNCCOC(c1ccc(F)cc1)c1ccc(F)cc1",
-            "CHEMBL333667 O=C(Cc1ccccc1)NCCNCCOC(c1ccc(F)cc1)c1ccc(F)cc1",
-            "CHEMBL121486 O=C(Cc1ccc(Br)cc1)NC=CNCCOC(c1ccc(F)cc1)c1ccc(F)cc1",
-            "CHEMBL123830 O=C(Cc1ccc(F)cc1)NCCNCCOC(c1ccc(F)cc1)c1ccc(F)cc1",
-            "CHEMBL420900 O=C(Cc1ccccc1)NCCCNCCOC(c1ccc(F)cc1)c1ccc(F)cc1",
-            "CHEMBL121460 CN(CCOC(c1ccc(F)cc1)c1ccc(F)cc1)CCN(C)CCOC(c1ccc(F)cc1)c1ccc(F)cc1",
-            "CHEMBL120901 COC(=O)C1C2CCC(CC1C(=O)Oc1ccccc1)N2C",
-            "CHEMBL122859 O=C1CN(CCc2ccccc2)CCN1CCOC(c1ccc(F)cc1)c1ccc(F)cc1",
-            "CHEMBL121027 CN(CCOC(c1ccccc1)c1ccccc1)CCN(C)CCc1ccc(F)cc1", )
+    smis = (
+      "CHEMBL122452 CN(CCCN(C)CCc1ccccc1)CCOC(c1ccccc1)c1ccccc1",
+      "CHEMBL123252 CN(CCCc1ccccc1)CCCN(C)CCOC(c1ccccc1)c1ccccc1",
+      "CHEMBL121611 Fc1ccc(C(OCCNCCCNCCc2ccccc2)c2ccc(F)cc2)cc1",
+      "CHEMBL121050 O=C(Cc1ccccc1)NCCCCNCCOC(c1ccc(F)cc1)c1ccc(F)cc1",
+      "CHEMBL333667 O=C(Cc1ccccc1)NCCNCCOC(c1ccc(F)cc1)c1ccc(F)cc1",
+      "CHEMBL121486 O=C(Cc1ccc(Br)cc1)NC=CNCCOC(c1ccc(F)cc1)c1ccc(F)cc1",
+      "CHEMBL123830 O=C(Cc1ccc(F)cc1)NCCNCCOC(c1ccc(F)cc1)c1ccc(F)cc1",
+      "CHEMBL420900 O=C(Cc1ccccc1)NCCCNCCOC(c1ccc(F)cc1)c1ccc(F)cc1",
+      "CHEMBL121460 CN(CCOC(c1ccc(F)cc1)c1ccc(F)cc1)CCN(C)CCOC(c1ccc(F)cc1)c1ccc(F)cc1",
+      "CHEMBL120901 COC(=O)C1C2CCC(CC1C(=O)Oc1ccccc1)N2C",
+      "CHEMBL122859 O=C1CN(CCc2ccccc2)CCN1CCOC(c1ccc(F)cc1)c1ccc(F)cc1",
+      "CHEMBL121027 CN(CCOC(c1ccccc1)c1ccccc1)CCN(C)CCc1ccc(F)cc1",
+    )
 
     ms = [Chem.MolFromSmiles(x.split()[1]) for x in smis]
     qm = ms[0]
@@ -87,8 +93,10 @@ class TestCase(unittest.TestCase):
     #self.assertEqual(mcs.smartsString,'[#6]1:[#6]:[#6]:[#6](:[#6]:[#6]:1)-[#6](-[#8]-[#6]-[#6]-[#7]-[#6]-[#6])-[#6]2:[#6]:[#6]:[#6]:[#6]:[#6]:2')
 
   def test3IsotopeMatch(self):
-    smis = ("CC[14NH2]",
-            "CC[14CH3]", )
+    smis = (
+      "CC[14NH2]",
+      "CC[14CH3]",
+    )
 
     ms = [Chem.MolFromSmiles(x) for x in smis]
     mcs = rdFMCS.FindMCS(ms)
@@ -120,9 +128,9 @@ class TestCase(unittest.TestCase):
     self.assertEqual(mcs.smartsString, '[#6]-[#6]-[#6]')
 
     mcs = rdFMCS.FindMCS(ms, ringMatchesRingOnly=True)
-    self.assertEqual(mcs.numBonds, 2)
-    self.assertEqual(mcs.numAtoms, 3)
-    self.assertEqual(mcs.smartsString, '[#6]-[#6]-[#6]')
+    self.assertEqual(mcs.numBonds, 1)
+    self.assertEqual(mcs.numAtoms, 2)
+    self.assertEqual(mcs.smartsString, '[#6]-[#6]')
 
     smis = ['CC1CCC1', 'CCC1CCCCC1']
     ms = [Chem.MolFromSmiles(x) for x in smis]
@@ -190,12 +198,12 @@ class TestCase(unittest.TestCase):
 
     ps = rdFMCS.MCSParameters()
     ps.BondCompareParameters.CompleteRingsOnly = True
-    mcs = rdFMCS.FindMCS(ms,ps)
+    mcs = rdFMCS.FindMCS(ms, ps)
     self.assertEqual(mcs.numAtoms, 3)
 
     ps = rdFMCS.MCSParameters()
     ps.SetAtomTyper(rdFMCS.AtomCompare.CompareAny)
-    mcs = rdFMCS.FindMCS(ms,ps)
+    mcs = rdFMCS.FindMCS(ms, ps)
     self.assertEqual(mcs.numAtoms, 5)
 
   def test9MatchCharge(self):
@@ -207,7 +215,7 @@ class TestCase(unittest.TestCase):
 
     ps = rdFMCS.MCSParameters()
     ps.AtomCompareParameters.MatchFormalCharge = True
-    mcs = rdFMCS.FindMCS(ms,ps)
+    mcs = rdFMCS.FindMCS(ms, ps)
     self.assertEqual(mcs.numAtoms, 2)
 
   def test10MatchChargeAndParams(self):
@@ -219,12 +227,30 @@ class TestCase(unittest.TestCase):
 
     ps = rdFMCS.MCSParameters()
     ps.SetAtomTyper(rdFMCS.AtomCompare.CompareAny)
-    mcs = rdFMCS.FindMCS(ms,ps)
+    mcs = rdFMCS.FindMCS(ms, ps)
     self.assertEqual(mcs.numAtoms, 4)
 
     ps.AtomCompareParameters.MatchFormalCharge = True
-    mcs = rdFMCS.FindMCS(ms,ps)
+    mcs = rdFMCS.FindMCS(ms, ps)
     self.assertEqual(mcs.numAtoms, 2)
+
+  def test11Github2034(self):
+    smis = ("C1CC1N2CC2", "C1CC1N")
+    ms = [Chem.MolFromSmiles(x) for x in smis]
+
+    mcs = rdFMCS.FindMCS(ms)
+    self.assertEqual(mcs.numAtoms, 4)
+    self.assertEqual(mcs.numBonds, 4)
+
+    mcs = rdFMCS.FindMCS(ms, ringMatchesRingOnly=True)
+    self.assertEqual(mcs.numAtoms, 3)
+    self.assertEqual(mcs.numBonds, 3)
+
+    ps = rdFMCS.MCSParameters()
+    ps.AtomCompareParameters.RingMatchesRingOnly = True
+    mcs = rdFMCS.FindMCS(ms, ps)
+    self.assertEqual(mcs.numAtoms, 3)
+    self.assertEqual(mcs.numBonds, 3)
 
 
 if __name__ == "__main__":

--- a/Code/GraphMol/FMCS/testFMCS_Unit.cpp
+++ b/Code/GraphMol/FMCS/testFMCS_Unit.cpp
@@ -1,4 +1,3 @@
-// $Id: testFMCS_Unit.cpp $
 //
 //  Copyright (c) 2014, Novartis Institutes for BioMedical Research Inc.
 //  All rights reserved.
@@ -525,7 +524,8 @@ void testAtomCompareIsotopes() {
   std::cout << "\ntestAtomCompareIsotopes()\n";
   std::vector<ROMOL_SPTR> mols;
   const char* smi[] = {
-      "CC[13NH2]", "CC[13CH3]",
+      "CC[13NH2]",
+      "CC[13CH3]",
   };
   for (auto& i : smi) mols.push_back(ROMOL_SPTR(SmilesToMol(getSmilesOnly(i))));
   MCSParameters p;
@@ -670,7 +670,7 @@ void compareChirality(const char* target, const char* query,
   ROMOL_SPTR target_ptr(SmilesToMol(target));
   ROMOL_SPTR query_ptr(SmartsToMol(query));
 
-  std::vector<std::pair<int, int> > vect;
+  std::vector<std::pair<int, int>> vect;
   bool sub_res = SubstructMatch(*target_ptr.get(), *query_ptr.get(), vect, true,
                                 useChirality);
 
@@ -812,7 +812,7 @@ void testGithubIssue481() {
 
     BOOST_LOG(rdInfoLog) << "**** mols:" << s1 << "   " << s2 << "\n";
     //#688:
-    std::vector<std::pair<int, int> > vect;
+    std::vector<std::pair<int, int>> vect;
     ROMOL_SPTR mcs_mol(SmilesToMol("OCCl"));
     bool sub_res = SubstructMatch(*ptr2, *mcs_mol, vect, true, false);
     std::cout << "query=OCCl "
@@ -899,7 +899,7 @@ void testGithubIssue481() {
       BOOST_LOG(rdInfoLog) << "MCS: " << mcs_res.SmartsString << " "
                            << mcs_res.NumAtoms << " atoms, " << mcs_res.NumBonds
                            << " bonds\n";
-      std::vector<std::pair<int, int> > vect;
+      std::vector<std::pair<int, int>> vect;
       bool sub_res =
           SubstructMatch(*mols[1].get(), *mols[0].get(), vect, true, true);
       if (sub_res == false) {  // actualy == true & 4, 3 !!!
@@ -930,7 +930,7 @@ void testGithubIssue481() {
       BOOST_LOG(rdInfoLog) << "MCS: " << mcs_res.SmartsString << " "
                            << mcs_res.NumAtoms << " atoms, " << mcs_res.NumBonds
                            << " bonds\n";
-      std::vector<std::pair<int, int> > vect;
+      std::vector<std::pair<int, int>> vect;
       bool sub_res =
           SubstructMatch(*mols[1].get(), *mols[0].get(), vect, true, true);
       if (sub_res == false) {
@@ -1024,7 +1024,8 @@ void testGithub631() {
   const char* smi[] = {
       // all examples derived from the bug report
       "CN(C)[C@@H]1CCCNC1",  // == MCS
-      "C1C=CCN1[C@@H]1CCCNC1", "Cc1cc2c(cc1C)C(=O)N([C@@H]1CCC(=O)NC1=O)C2=O",
+      "C1C=CCN1[C@@H]1CCCNC1",
+      "Cc1cc2c(cc1C)C(=O)N([C@@H]1CCC(=O)NC1=O)C2=O",
   };
 
   for (int pass = 0; pass < 2; ++pass, mols.clear())
@@ -1043,10 +1044,10 @@ void testGithub631() {
         p.AtomCompareParameters.MatchChiralTag = false;
         //          p.Verbose = true;
         MCSResult res = findMCS(mols, &p);
-        BOOST_LOG(rdInfoLog) << "MCS: " << res.SmartsString << " "
-                             << res.NumAtoms << " atoms, " << res.NumBonds
-                             << " bonds\n"
-                             << std::endl;
+        BOOST_LOG(rdInfoLog)
+            << "MCS: " << res.SmartsString << " " << res.NumAtoms << " atoms, "
+            << res.NumBonds << " bonds\n"
+            << std::endl;
         ;
 
         TEST_ASSERT(res.NumAtoms == mols[0]->getNumAtoms());
@@ -1059,10 +1060,10 @@ void testGithub631() {
         // p.BondCompareParameters.MatchStereo = useChirality;
         //        p.Verbose = true;
         MCSResult res = findMCS(mols, &p);
-        BOOST_LOG(rdInfoLog) << "MCS: " << res.SmartsString << " "
-                             << res.NumAtoms << " atoms, " << res.NumBonds
-                             << " bonds\n"
-                             << std::endl;
+        BOOST_LOG(rdInfoLog)
+            << "MCS: " << res.SmartsString << " " << res.NumAtoms << " atoms, "
+            << res.NumBonds << " bonds\n"
+            << std::endl;
         ;
 
         TEST_ASSERT(res.NumAtoms == mols[0]->getNumAtoms());
@@ -1111,6 +1112,64 @@ void testFormalChargeMatch() {
 
     TEST_ASSERT(res.NumAtoms == 2);
     TEST_ASSERT(res.NumBonds == 1);
+  }
+
+  BOOST_LOG(rdInfoLog) << "============================================"
+                       << std::endl;
+  BOOST_LOG(rdInfoLog) << "\tdone" << std::endl;
+}
+
+void testGithub2034() {
+  BOOST_LOG(rdInfoLog) << "-------------------------------------" << std::endl;
+  BOOST_LOG(rdInfoLog) << "Testing Github #2034: add test for ring--non-ring "
+                          "matches at the atom level"
+                       << std::endl;
+  std::vector<ROMOL_SPTR> mols;
+  const char* smi[] = {"C1CC1N2CC2", "C1CC1N"};
+
+  for (auto& i : smi) {
+    auto m = SmilesToMol(getSmilesOnly(i));
+    TEST_ASSERT(m);
+
+    mols.push_back(ROMOL_SPTR(m));
+  }
+  {
+    // by default we're not doing ringMatchesRingOnly.
+    MCSResult res = findMCS(mols);
+    BOOST_LOG(rdInfoLog) << "MCS: " << res.SmartsString << " " << res.NumAtoms
+                         << " atoms, " << res.NumBonds << " bonds\n"
+                         << std::endl;
+
+    TEST_ASSERT(res.NumAtoms == 4);
+    TEST_ASSERT(res.NumBonds == 4);
+  }
+
+  {
+    MCSParameters p;
+    p.AtomCompareParameters.RingMatchesRingOnly = true;
+    //          p.Verbose = true;
+    MCSResult res = findMCS(mols, &p);
+    BOOST_LOG(rdInfoLog) << "MCS: " << res.SmartsString << " " << res.NumAtoms
+                         << " atoms, " << res.NumBonds << " bonds\n"
+                         << std::endl;
+
+    TEST_ASSERT(res.NumAtoms == 3);
+    TEST_ASSERT(res.NumBonds == 3);
+  }
+  {
+    // set it:
+    bool maximizeBonds = true, verbose = false, matchValences = false,
+         ringMatchesRingOnly = true;
+    double threshold = 1.0;
+    unsigned timeout = 3000;
+    MCSResult res = findMCS(mols, maximizeBonds, threshold, timeout, verbose,
+                            matchValences, ringMatchesRingOnly);
+    BOOST_LOG(rdInfoLog) << "MCS: " << res.SmartsString << " " << res.NumAtoms
+                         << " atoms, " << res.NumBonds << " bonds\n"
+                         << std::endl;
+
+    TEST_ASSERT(res.NumAtoms == 3);
+    TEST_ASSERT(res.NumBonds == 3);
   }
 
   BOOST_LOG(rdInfoLog) << "============================================"
@@ -1176,6 +1235,7 @@ int main(int argc, const char* argv[]) {
   //---
 
   testFormalChargeMatch();
+  testGithub2034();
 
   unsigned long long t1 = nanoClock();
   double sec = double(t1 - T0) / 1000000.;

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -17,6 +17,8 @@
 This release includes a set of changes to make the default arguments to common
 functions less error prone (github #1679).
 - GetAtomSmiles() now generates isomeric SMILES by default.
+- The ringMatchesRingOnly option to the FindMCS() function now applies to
+  atom-atom matches as well as bond-bond matches. 
 
 ## Acknowledgements:
 


### PR DESCRIPTION
Adds atom ring membership to be taken into account when determining whether a ring-ring match is present.
We should also add something equivalent for completeRingsOnly, but that can be a separate issue.