### PR TITLE
Fix #2042 allowing python/c++ randomizer smiles generator

### DIFF
--- a/Code/GraphMol/Canon.cpp
+++ b/Code/GraphMol/Canon.cpp
@@ -13,7 +13,6 @@
 #include <RDGeneral/Exceptions.h>
 #include <RDGeneral/hash/hash.hpp>
 #include <algorithm>
-//#include "boost/random.hpp" 
 
 namespace RDKit {
 namespace Canon {
@@ -670,27 +669,22 @@ void dfsBuildStack(ROMol &mol, int atomIdx, int inBondIdx,
         continue;
       }
       unsigned long rank = ranks[otherIdx];
-
-      //std::cerr<<"before the rules rings:  p: "<<otherIdx<<" "<<colors[otherIdx]<<" "<<theBond->getBondType()<<" "<<rank<<std::endl;
-
-      if (theBond->getOwningMol().getRingInfo()->numBondRings(
+      if (!doRandom) {
+        if (theBond->getOwningMol().getRingInfo()->numBondRings(
               theBond->getIdx())) {
-        if (!bondSymbols) {
-          rank += static_cast<int>(MAX_BONDTYPE - theBond->getBondType()) *
+            if (!bondSymbols) {
+                rank += static_cast<int>(MAX_BONDTYPE - theBond->getBondType()) *
                   MAX_NATOMS * MAX_NATOMS;
-        } else {
-          const std::string &symb = (*bondSymbols)[theBond->getIdx()];
-          boost::uint32_t hsh = gboost::hash_range(symb.begin(), symb.end());
-          rank += (hsh % MAX_NATOMS) * MAX_NATOMS * MAX_NATOMS;
-        }
+            } else {
+            const std::string &symb = (*bondSymbols)[theBond->getIdx()];
+            boost::uint32_t hsh = gboost::hash_range(symb.begin(), symb.end());
+            rank += (hsh % MAX_NATOMS) * MAX_NATOMS * MAX_NATOMS;
+            }
+        }      
+      } else {
+         // randomize the rank      
+         rank = std::rand();
       }
-      // std::cerr<<"after the rules rings:  p: "<<otherIdx<<" "<<colors[otherIdx]<<" "<<theBond->getBondType()<<" "<<rank<<std::endl;
-      
-    if (doRandom) {
-      // set the seed for rand function (1 by default if not usinig srand call function)
-      // randomized the rank instead of using "rdkit rank rules"
-      rank = std::rand();
-    }
       //std::cerr << "\nmygenerator:" << numberGenerator() << std::endl; 
 
       possibles.push_back(PossibleType(rank, otherIdx, theBond));

--- a/Code/GraphMol/Canon.h
+++ b/Code/GraphMol/Canon.h
@@ -116,7 +116,8 @@ RDKIT_GRAPHMOL_EXPORT void canonicalizeFragment(ROMol &mol, int atomIdx,
                           MolStack &molStack,
                           const boost::dynamic_bitset<> *bondsInPlay = 0,
                           const std::vector<std::string> *bondSymbols = 0,
-                          bool doIsomericSmiles = false);
+                          bool doIsomericSmiles = false,
+                          bool doRandom = false);
 
 }  // end of namespace Canon
 }  // end of namespace RDKit

--- a/Code/GraphMol/SmilesParse/SmilesWrite.cpp
+++ b/Code/GraphMol/SmilesParse/SmilesWrite.cpp
@@ -425,6 +425,18 @@ std::string MolToSmiles(const ROMol &mol, bool doIsomericSmiles, bool doKekule,
       tmol->debugMol(std::cout);
       std::cout << "----------------------------" << std::endl;
 #endif
+    
+    // adding randomness without setting the rootedAtAtom
+    if (doRandom ) {
+      if (rootedAtAtom == -1) {
+        rootedAtAtom = std::rand() % mol.getNumAtoms(); 
+        // need to find an atom id between 0 and mol.getNumAtoms() exclusively
+        PRECONDITION(rootedAtAtom < 0 ||
+                   static_cast<unsigned int>(rootedAtAtom) < mol.getNumAtoms(),
+               "rootedAtomAtom must be less than the number of atoms");
+      }
+    }
+
 
     std::string res;
     unsigned int nAtoms = tmol->getNumAtoms();

--- a/Code/GraphMol/SmilesParse/SmilesWrite.cpp
+++ b/Code/GraphMol/SmilesParse/SmilesWrite.cpp
@@ -271,7 +271,7 @@ std::string FragmentSmilesConstruct(
     ROMol &mol, int atomIdx, std::vector<Canon::AtomColors> &colors,
     const UINT_VECT &ranks, bool doKekule, bool canonical,
     bool doIsomericSmiles, bool allBondsExplicit, bool allHsExplicit,
-    std::vector<unsigned int> &atomOrdering,
+    bool doRandom, std::vector<unsigned int> &atomOrdering,
     const boost::dynamic_bitset<> *bondsInPlay = nullptr,
     const std::vector<std::string> *atomSymbols = nullptr,
     const std::vector<std::string> *bondSymbols = nullptr) {
@@ -293,7 +293,7 @@ std::string FragmentSmilesConstruct(
   std::list<unsigned int> ringClosuresToErase;
 
   Canon::canonicalizeFragment(mol, atomIdx, colors, ranks, molStack,
-                              bondsInPlay, bondSymbols, doIsomericSmiles);
+                              bondsInPlay, bondSymbols, doIsomericSmiles, doRandom);
   Bond *bond = nullptr;
   BOOST_FOREACH (Canon::MolStackElem mSE, molStack) {
     switch (mSE.type) {
@@ -382,7 +382,7 @@ static bool SortBasedOnFirstElement(
 
 std::string MolToSmiles(const ROMol &mol, bool doIsomericSmiles, bool doKekule,
                         int rootedAtAtom, bool canonical, bool allBondsExplicit,
-                        bool allHsExplicit) {
+                        bool allHsExplicit, bool doRandom) {
   if (!mol.getNumAtoms()) return "";
   PRECONDITION(rootedAtAtom < 0 ||
                    static_cast<unsigned int>(rootedAtAtom) < mol.getNumAtoms(),
@@ -479,7 +479,7 @@ std::string MolToSmiles(const ROMol &mol, bool doIsomericSmiles, bool doKekule,
 
       subSmi = SmilesWrite::FragmentSmilesConstruct(
           *tmol, nextAtomIdx, colors, ranks, doKekule, canonical,
-          doIsomericSmiles, allBondsExplicit, allHsExplicit, atomOrdering);
+          doIsomericSmiles, allBondsExplicit, allHsExplicit, doRandom ,  atomOrdering);
 
       res += subSmi;
       colorIt = std::find(colors.begin(), colors.end(), Canon::WHITE_NODE);
@@ -679,7 +679,7 @@ std::string MolFragmentToSmiles(const ROMol &mol,
 
     subSmi = SmilesWrite::FragmentSmilesConstruct(
         tmol, nextAtomIdx, colors, ranks, doKekule, canonical, doIsomericSmiles,
-        allBondsExplicit, allHsExplicit, atomOrdering, &bondsInPlay,
+        allBondsExplicit, allHsExplicit, false, atomOrdering, &bondsInPlay,
         atomSymbols, bondSymbols);
 
     res += subSmi;

--- a/Code/GraphMol/SmilesParse/SmilesWrite.h
+++ b/Code/GraphMol/SmilesParse/SmilesWrite.h
@@ -70,7 +70,7 @@ RDKIT_SMILESPARSE_EXPORT std::string GetBondSmiles(
 RDKIT_SMILESPARSE_EXPORT std::string MolToSmiles(
     const ROMol &mol, bool doIsomericSmiles = true, bool doKekule = false,
     int rootedAtAtom = -1, bool canonical = true, bool allBondsExplicit = false,
-    bool allHsExplicit = false);
+    bool allHsExplicit = false, bool doRandom = false);
 
 //! \brief returns canonical SMILES for part of a molecule
 /*!

--- a/Code/GraphMol/SmilesParse/test.cpp
+++ b/Code/GraphMol/SmilesParse/test.cpp
@@ -4066,6 +4066,51 @@ void testGithub1925() {
   BOOST_LOG(rdInfoLog) << "done" << std::endl;
 }
 
+
+void testdoRandomSmileGeneration() {
+  BOOST_LOG(rdInfoLog) << "-------------------------------------\n";
+  BOOST_LOG(rdInfoLog)
+      << "Testing the random Generator for SMILES\n"
+      << std::endl;
+  {
+    std::srand(1); // be sure we use it for testcase!
+    const char *benzenes[1] = {
+        "c1ccncc1C"};
+
+    const char *rulesmiles[7] = {
+       "c1ccncc1C","c1cc(C)cnc1","c1ccc(C)cn1","n1cccc(C)c1",
+        "c1ncccc1C","c1(C)cccnc1","Cc1cccnc1"};
+    
+    const char *randomsmiles[7] = {
+      "c1ccncc1C","c1cc(cnc1)C","c1ccc(cn1)C","n1cccc(c1)C","c1ncccc1C",
+      "c1(cccnc1)C","Cc1cccnc1"};
+    
+    for (int i = 0; i < 1; ++i) {
+      ROMol *m = SmilesToMol(benzenes[i]);
+      TEST_ASSERT(m);
+      TEST_ASSERT(m->getNumAtoms() == 7);
+      std::string randombenzene = "";
+      std::string rulebenzene = "";
+      for (int j = 0; j < 7; ++j) {
+        randombenzene = MolToSmiles(*m, true, false, j, false,false,false,true);
+        BOOST_LOG(rdInfoLog) << "random :" <<  randombenzene << std::endl;
+        rulebenzene = MolToSmiles(*m, true, false, j, false,false,false,false);
+        BOOST_LOG(rdInfoLog) << "rule :" <<  rulebenzene << std::endl;
+        TEST_ASSERT(randombenzene == randomsmiles[j]);
+        TEST_ASSERT(rulebenzene == rulesmiles[j]);
+      }
+      
+      delete m;
+    }
+
+  }
+  BOOST_LOG(rdInfoLog) << "done" << std::endl;
+}
+
+
+
+
+
 void testGithub1972() {
   BOOST_LOG(rdInfoLog)
       << "Testing Github #1972: Incorrect tetrahedral stereo when reading "
@@ -4180,6 +4225,7 @@ int main(int argc, char *argv[]) {
   testGithub389();
   testBug1719046();
   testBug1844617();
+
 #if 1  // POSTPONED during canonicalization rewrite
   // testGithub298();
   testFragmentSmiles();
@@ -4199,4 +4245,6 @@ int main(int argc, char *argv[]) {
   testGithub1925();
 #endif
   testGithub1972();
+  testdoRandomSmileGeneration();
+
 }

--- a/Code/GraphMol/Wrap/rdmolfiles.cpp
+++ b/Code/GraphMol/Wrap/rdmolfiles.cpp
@@ -796,7 +796,7 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
       (python::arg("mol"), python::arg("isomericSmiles") = true,
        python::arg("kekuleSmiles") = false, python::arg("rootedAtAtom") = -1,
        python::arg("canonical") = true, python::arg("allBondsExplicit") = false,
-       python::arg("allHsExplicit") = false),
+       python::arg("allHsExplicit") = false, python::arg("doRandom") = false),
       docString.c_str());
 
   docString =
@@ -824,6 +824,8 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
       in the output SMILES. Defaults to false.\n\
     - allHsExplicit: (optional) if true, all H counts will be explicitly indicated\n\
       in the output SMILES. Defaults to false.\n\
+    - doRandom: (optional) if true, randomized the DFS transversal graph,\n\
+      so we can generate random smiles. Defaults to false.\n\
 \n\
   RETURNS:\n\
 \n\


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! 
-->
#### Reference Issue
Fix #2042 the code was developped during Cambridge RDKit UGM 2018 by Guillaume GODIN and Takayuki Serizawa.


#### What does this implement/fix? Explain your changes.
We implement a new option to generate pure random smiles from a given rootAtoms number. This parameters doRandom is set by default to false to have rule based rdkit smiles generator. Setting it to True allows user to generate more smiles.

#### Any other comments?
basically this is the command to run to produce more random smiles:
t= Chem.MolToSmiles(m, rootedAtAtom=n, canonical=False, doRandom=True)

complete example to show that the number of generated smiles increase:
from __future__ import print_function
import random
from rdkit import Chem
from rdkit import rdBase

def allsmiles(smil, doRandom):
     m = Chem.MolFromSmiles(smil) # Construct a molecule from a
     if m is None:
         return smil
     N = m.GetNumAtoms()
     if N==0:
         return smil
     try:
        n= random.randint(0,N-1)
        t= Chem.MolToSmiles(m, rootedAtAtom=n, canonical=False, doRandom=doRandom)
     except :
        return smil
     return t


Smi = set()
for i in range(1,100):
	Smi.add(allsmiles('CC(C)1CCCC1',True))

print(list(Smi))

Smi = set()
for i in range(1,100):
	Smi.add(allsmiles('CC(C)1CCCC1',False))

print(list(Smi))



