### PR TITLE
Fix memory leak in Dict operator=

### DIFF
--- a/Code/GraphMol/test-valgrind.cpp
+++ b/Code/GraphMol/test-valgrind.cpp
@@ -60,11 +60,18 @@ void test2() {
   }
 }
 
+void testCopyConstructor() {
+  RDKit::RWMol mol1;
+  RDKit::RWMol mol2(mol1);
+  RDKit::RWMol mol3;
+  mol3 = mol2;
+}
+
 // -------------------------------------------------------------------
 int main() {
-  RDLog::InitLogs();
+  //RDLog::InitLogs();
   // boost::logging::enable_logs("rdApp.info");
-  test1();
-
+  //test1();
+  testCopyConstructor();
   return 0;
 }

--- a/Code/GraphMol/test-valgrind.cpp
+++ b/Code/GraphMol/test-valgrind.cpp
@@ -69,9 +69,9 @@ void testCopyConstructor() {
 
 // -------------------------------------------------------------------
 int main() {
-  //RDLog::InitLogs();
+  RDLog::InitLogs();
   // boost::logging::enable_logs("rdApp.info");
-  //test1();
+  test1();
   testCopyConstructor();
   return 0;
 }

--- a/Code/RDGeneral/Dict.h
+++ b/Code/RDGeneral/Dict.h
@@ -94,6 +94,7 @@ class RDKIT_RDGENERAL_EXPORT Dict {
   Dict &operator=(const Dict &other) {
     _hasNonPodData = other._hasNonPodData;
     if (_hasNonPodData) {
+      reset();
       std::vector<Pair> data(other._data.size());
       _data.swap(data);
       for (size_t i = 0; i < _data.size(); ++i) {

--- a/Code/RDGeneral/Dict.h
+++ b/Code/RDGeneral/Dict.h
@@ -50,7 +50,7 @@ class RDKIT_RDGENERAL_EXPORT Dict {
 
   Dict(const Dict &other) : _data(other._data) {
     _hasNonPodData = other._hasNonPodData;
-    if (_hasNonPodData) {
+    if (other._hasNonPodData) { // other has non pod data, need to copy
       std::vector<Pair> data(other._data.size());
       _data.swap(data);
       for (size_t i = 0; i < _data.size(); ++i) {
@@ -92,8 +92,10 @@ class RDKIT_RDGENERAL_EXPORT Dict {
   }
 
   Dict &operator=(const Dict &other) {
-    if (_hasNonPodData) {
-      reset();
+    if (this == &other) return *this;
+    if (_hasNonPodData) reset();
+    
+    if (other._hasNonPodData) {
       std::vector<Pair> data(other._data.size());
       _data.swap(data);
       for (size_t i = 0; i < _data.size(); ++i) {
@@ -103,7 +105,7 @@ class RDKIT_RDGENERAL_EXPORT Dict {
     } else {
       _data = other._data;
     }
-    _hasNonPodData = other._hasNonPodData;
+    _hasNonPodData = other._hasNonPodData;    
     return *this;
   };
 

--- a/Code/RDGeneral/Dict.h
+++ b/Code/RDGeneral/Dict.h
@@ -92,7 +92,6 @@ class RDKIT_RDGENERAL_EXPORT Dict {
   }
 
   Dict &operator=(const Dict &other) {
-    _hasNonPodData = other._hasNonPodData;
     if (_hasNonPodData) {
       reset();
       std::vector<Pair> data(other._data.size());
@@ -104,6 +103,7 @@ class RDKIT_RDGENERAL_EXPORT Dict {
     } else {
       _data = other._data;
     }
+    _hasNonPodData = other._hasNonPodData;
     return *this;
   };
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! 
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.
Simple fix for Dict.h

Operator= was leaking non-pod properties from the underlying Dictionary.

#### Any other comments?
