### PR TITLE
Add a default for maximum products generated by a reaction (maxProduc…

### DIFF
--- a/Code/GraphMol/ChemReactions/Reaction.cpp
+++ b/Code/GraphMol/ChemReactions/Reaction.cpp
@@ -47,8 +47,8 @@
 namespace RDKit {
 
 std::vector<MOL_SPTR_VECT> ChemicalReaction::runReactants(
-    const MOL_SPTR_VECT reactants) const {
-  return run_Reactants(*this, reactants);
+    const MOL_SPTR_VECT reactants, unsigned int maxProducts) const {
+  return run_Reactants(*this, reactants, maxProducts);
 }
 
 std::vector<MOL_SPTR_VECT> ChemicalReaction::runReactant(

--- a/Code/GraphMol/ChemReactions/Reaction.h
+++ b/Code/GraphMol/ChemReactions/Reaction.h
@@ -207,6 +207,8 @@ class RDKIT_CHEMREACTIONS_EXPORT ChemicalReaction : public RDProps {
     \param reactants  the reactants to be used. The length of this must be equal
     to
                       this->getNumReactantTemplates()
+    \param maxProducts:  if non zero, the maximum number of products to generate
+                         before stopping.  If hit a warning will be generated.
 
     \return a vector of vectors of products. Each subvector will be
             this->getNumProductTemplates() long.
@@ -216,7 +218,8 @@ class RDKIT_CHEMREACTIONS_EXPORT ChemicalReaction : public RDProps {
     map multiple times onto its reactant. This leads to multiple possible result
     sets.
   */
-  std::vector<MOL_SPTR_VECT> runReactants(const MOL_SPTR_VECT reactants) const;
+  std::vector<MOL_SPTR_VECT> runReactants(const MOL_SPTR_VECT reactants,
+                                          unsigned int numProducts=1000) const;
 
   //! Runs a single reactant against a single reactant template
   /*!

--- a/Code/GraphMol/ChemReactions/ReactionRunner.cpp
+++ b/Code/GraphMol/ChemReactions/ReactionRunner.cpp
@@ -122,25 +122,41 @@ bool getReactantMatches(const MOL_SPTR_VECT &reactants,
   return res;
 }  // end of getReactantMatches()
 
-void recurseOverReactantCombinations(
+// Return false if maxProducts has been hit...
+//  Otherwise we can't tell if we were stopped exactly
+//  or were terminated.
+bool recurseOverReactantCombinations(
     const VectVectMatchVectType &matchesByReactant,
     VectVectMatchVectType &matchesPerProduct, unsigned int level,
-    VectMatchVectType combination) {
+    VectMatchVectType combination,
+    unsigned int maxProducts) {
   unsigned int nReactants = matchesByReactant.size();
   URANGE_CHECK(level, nReactants);
   PRECONDITION(combination.size() == nReactants, "bad combination size");
+
+  if(maxProducts && matchesPerProduct.size() >= maxProducts) {
+    return false;
+  }
+
+  bool keepGoing = true;
   for (auto reactIt = matchesByReactant[level].begin();
        reactIt != matchesByReactant[level].end(); ++reactIt) {
     VectMatchVectType prod = combination;
     prod[level] = *reactIt;
     if (level == nReactants - 1) {
       // this is the bottom of the recursion:
+      if(maxProducts && matchesPerProduct.size() >= maxProducts) {
+        keepGoing = false;
+        break;
+      }
       matchesPerProduct.push_back(prod);
+
     } else {
-      recurseOverReactantCombinations(matchesByReactant, matchesPerProduct,
-                                      level + 1, prod);
+      keepGoing = recurseOverReactantCombinations(matchesByReactant, matchesPerProduct,
+                                                  level + 1, prod, maxProducts);
     }
   }
+  return keepGoing;
 }  // end of recurseOverReactantCombinations
 
 void updateImplicitAtomProperties(Atom *prodAtom, const Atom *reactAtom) {
@@ -167,12 +183,17 @@ void updateImplicitAtomProperties(Atom *prodAtom, const Atom *reactAtom) {
 
 void generateReactantCombinations(
     const VectVectMatchVectType &matchesByReactant,
-    VectVectMatchVectType &matchesPerProduct) {
+    VectVectMatchVectType &matchesPerProduct,
+    unsigned int maxProducts) {
   matchesPerProduct.clear();
   VectMatchVectType tmp;
   tmp.clear();
   tmp.resize(matchesByReactant.size());
-  recurseOverReactantCombinations(matchesByReactant, matchesPerProduct, 0, tmp);
+  if (!recurseOverReactantCombinations(matchesByReactant, matchesPerProduct, 0, tmp, maxProducts)) {
+    BOOST_LOG(rdWarningLog)
+        << "Maximum product count hit " << maxProducts << ", stopping reaction early...\n";
+
+  }
 }  // end of generateReactantCombinations()
 
 RWMOL_SPTR convertTemplateToMol(const ROMOL_SPTR prodTemplateSptr) {
@@ -906,7 +927,8 @@ MOL_SPTR_VECT generateOneProductSet(
 }  // namespace ReactionRunnerUtils
 
 std::vector<MOL_SPTR_VECT> run_Reactants(const ChemicalReaction &rxn,
-                                         const MOL_SPTR_VECT &reactants) {
+                                         const MOL_SPTR_VECT &reactants,
+                                         unsigned int maxProducts) {
   if (!rxn.isInitialized()) {
     throw ChemicalReactionException(
         "initMatchers() must be called before runReactants()");
@@ -941,7 +963,8 @@ std::vector<MOL_SPTR_VECT> run_Reactants(const ChemicalReaction &rxn,
   // start by doing the combinatorics on the matches:
   VectVectMatchVectType reactantMatchesPerProduct;
   ReactionRunnerUtils::generateReactantCombinations(matchesByReactant,
-                                                    reactantMatchesPerProduct);
+                                                    reactantMatchesPerProduct,
+                                                    maxProducts);
   productMols.resize(reactantMatchesPerProduct.size());
 
   for (unsigned int productId = 0; productId != productMols.size();

--- a/Code/GraphMol/ChemReactions/ReactionRunner.h
+++ b/Code/GraphMol/ChemReactions/ReactionRunner.h
@@ -46,7 +46,8 @@ namespace RDKit {
                     rxn->getNumReactantTemplates()
                     Caution: The order of the reactant templates determines the
   order of the reactants!
-
+  \param maxProducts:  if non zero, the maximum number of products to generate
+                       before stopping.  If hit a warning will be generated.
   \return a vector of vectors of products. Each subvector will be
           rxn->getNumProductTemplates() long.
 
@@ -54,8 +55,9 @@ namespace RDKit {
   map multiple times onto its reactant. This leads to multiple possible result
   sets.
 */
-RDKIT_CHEMREACTIONS_EXPORT std::vector<MOL_SPTR_VECT> run_Reactants(const ChemicalReaction& rxn,
-                                         const MOL_SPTR_VECT& reactants);
+RDKIT_CHEMREACTIONS_EXPORT std::vector<MOL_SPTR_VECT> run_Reactants(
+    const ChemicalReaction& rxn, const MOL_SPTR_VECT& reactants,
+    unsigned int maxProducts=1000);
 
 //! Runs a single reactant against a single reactant template
 /*!

--- a/Code/GraphMol/ChemReactions/Wrap/rdChemReactions.cpp
+++ b/Code/GraphMol/ChemReactions/Wrap/rdChemReactions.cpp
@@ -88,7 +88,7 @@ struct reaction_pickle_suite : python::pickle_suite {
 };
 
 template <typename T>
-PyObject *RunReactants(ChemicalReaction *self, T reactants) {
+PyObject *RunReactants(ChemicalReaction *self, T reactants, unsigned int maxProducts) {
   if (!self->isInitialized()) {
     NOGIL gil;
     self->initReactantMatchers();
@@ -104,7 +104,7 @@ PyObject *RunReactants(ChemicalReaction *self, T reactants) {
   std::vector<MOL_SPTR_VECT> mols;
   {
     NOGIL gil;
-    mols = self->runReactants(reacts);
+    mols = self->runReactants(reacts, maxProducts);
   }
   PyObject *res = PyTuple_New(mols.size());
 
@@ -500,13 +500,18 @@ Sample Usage:\n\
            "Removes agents from reaction. If targetList is provide the agents "
            "will be transfered to that list.")
       .def("RunReactants", (PyObject * (*)(RDKit::ChemicalReaction *,
-                                           python::tuple))RDKit::RunReactants,
+                                           python::tuple,
+                                           unsigned int maxProducts))RDKit::RunReactants,
+           (python::arg("self"), python::arg("reactants"), python::arg("maxProducts")=1000),
            "apply the reaction to a sequence of reactant molecules and return "
-           "the products as a tuple of tuples")
+           "the products as a tuple of tuples.  If maxProducts is not zero,"
+           " stop the reaction when maxProducts have been generated [default=1000]")
       .def("RunReactants", (PyObject * (*)(RDKit::ChemicalReaction *,
-                                           python::list))RDKit::RunReactants,
+                                           python::list, unsigned int maxProducts))RDKit::RunReactants,
+           (python::arg("self"), python::arg("reactants"), python::arg("maxProducts")=1000),
            "apply the reaction to a sequence of reactant molecules and return "
-           "the products as a tuple of tuples")
+           "the products as a tuple of tuples.  If maxProducts is not zero,"
+           " stop the reaction when maxProducts have been generated [default=1000]")
       .def("RunReactant",
            (PyObject * (*)(RDKit::ChemicalReaction *, python::object,
                            unsigned))RDKit::RunReactant,

--- a/Code/GraphMol/ChemReactions/Wrap/testReactionWrapper.py
+++ b/Code/GraphMol/ChemReactions/Wrap/testReactionWrapper.py
@@ -694,5 +694,21 @@ M  END
     self.assertTrue(nrxn.HasProp("intprop"))
     self.assertEquals(nrxn.GetIntProp("intprop"),3)
 
+  def testRoundTripException(self):
+    smarts = '[C:1]([C@:3]1([OH:24])[CH2:8][CH2:7][C@H:6]2[C@H:9]3[C@H:19]([C@@H:20]([F:22])[CH2:21][C@:4]12[CH3:5])[C@:17]1([CH3:18])[C:12](=[CH:13][C:14](=[O:23])[CH2:15][CH2:16]1)[CH:11]=[CH:10]3)#[CH:2].C(Cl)CCl.ClC1C=CC=C(C(OO)=[O:37])C=1.C(O)(C)(C)C>C(OCC)(=O)C>[C:1]([C@:3]1([OH:24])[CH2:8][CH2:7][C@H:6]2[C@H:9]3[C@H:19]([C@@H:20]([F:22])[CH2:21][C@:4]12[CH3:5])[C@:17]1([CH3:18])[C:12](=[CH:13][C:14](=[O:23])[CH2:15][CH2:16]1)[C@H:11]1[O:37][C@@H:10]31)#[CH:2]'
+    rxn = rdChemReactions.ReactionFromSmarts(smarts)
+    # this shouldn't throw an exception
+    smarts = rdChemReactions.ReactionToSmarts(rxn)
+
+  def testMaxProducts(self):
+    smarts = "[c:1]1[c:2][c:3][c:4][c:5][c:6]1>>[c:1]1[c:2][c:3][c:4][c:5][c:6]1"
+    rxn = rdChemReactions.ReactionFromSmarts(smarts)
+    m = Chem.MolFromSmiles("c1ccccc1")
+    prods = rxn.RunReactants([m])
+    self.assertEqual(len(prods), 12)
+    
+    prods = rxn.RunReactants([m],1)
+    self.assertEqual(len(prods), 1)
+    
 if __name__ == '__main__':
   unittest.main(verbosity=True)


### PR DESCRIPTION
…ts=1000)

<!--
Thanks for contributing a pull request! 
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->
Reagents that have a ridiculous number of matches can play havoc with the reaction runner.  This limits the possible number of products to a sane amount.

#### What does this implement/fix? Explain your changes.


#### Any other comments?

