### PR TITLE
Add user-defined literals for parsing SMILES and SMARTS

### DIFF
--- a/Code/GraphMol/SmilesParse/SmilesParse.h
+++ b/Code/GraphMol/SmilesParse/SmilesParse.h
@@ -11,14 +11,13 @@
 #ifndef _RD_SMILESPARSE_H_
 #define _RD_SMILESPARSE_H_
 
+#include <GraphMol/RWMol.h>
+#include <GraphMol/SanitException.h>
 #include <string>
 #include <exception>
 #include <map>
 
 namespace RDKit {
-class RWMol;
-class Atom;
-class Bond;
 
 struct RDKIT_SMILESPARSE_EXPORT SmilesParserParams {
   int debugParse;
@@ -113,6 +112,30 @@ class RDKIT_SMILESPARSE_EXPORT SmilesParseException : public std::exception {
  private:
   std::string _msg;
 };
+
+inline std::unique_ptr<RDKit::RWMol> operator"" _smiles(const char *text,
+                                                        size_t len) {
+  std::string smi(text, len);
+  RWMol *ptr = nullptr;
+  try {
+    ptr = SmilesToMol(smi);
+  } catch (const RDKit::MolSanitizeException &e) {
+    ptr = nullptr;
+  }
+  return std::unique_ptr<RWMol>(ptr);
+}
+inline std::unique_ptr<RDKit::RWMol> operator"" _smarts(const char *text,
+                                                        size_t len) {
+  std::string smi(text, len);
+  RWMol *ptr = nullptr;
+  try {
+    ptr = SmartsToMol(smi);
+  } catch (const RDKit::MolSanitizeException &e) {
+    ptr = nullptr;
+  }
+  return std::unique_ptr<RWMol>(ptr);
+}
+
 }  // namespace RDKit
 
 #endif

--- a/Code/GraphMol/SmilesParse/SmilesWrite.h
+++ b/Code/GraphMol/SmilesParse/SmilesWrite.h
@@ -13,6 +13,7 @@
 
 #include <string>
 #include <vector>
+#include <memory>
 
 namespace RDKit {
 class Atom;

--- a/Code/GraphMol/SmilesParse/catch_tests.cpp
+++ b/Code/GraphMol/SmilesParse/catch_tests.cpp
@@ -90,3 +90,23 @@ TEST_CASE("Github #2029", "[SMILES,bug]") {
                                             allBondsExplicit));
   }
 }
+
+TEST_CASE("Smiles literals", "[SMILES]") {
+  auto mol = "c1ccccc1"_smiles;
+  REQUIRE(mol);
+  CHECK(6 == mol->getNumAtoms());
+  auto fail1 = "c1ccccc"_smiles;
+  REQUIRE(!fail1);
+  auto fail2 = "c1cccn1"_smiles;
+  REQUIRE(!fail2);
+}
+
+TEST_CASE("Smarts literals", "[Smarts]") {
+  auto mol = "c1ccc[c,n]c1"_smarts;
+  REQUIRE(mol);
+  CHECK(6 == mol->getNumAtoms());
+  auto fail1 = "c1ccccc"_smarts;
+  REQUIRE(!fail1);
+  auto mol2 = "c1cccn1"_smarts;
+  REQUIRE(mol2);
+}


### PR DESCRIPTION
This allows these constructs to be used:
```
auto m = "c1ccccc1"_smiles;
auto p = "c1ccc[c,n]c1"_smarts;
```
The types of both `m` and `p` above are `std::unique_ptr<RWMol>`, so the above is roughly a replacement for:
```
std::unique_ptr<RWMol> m(SmilesToMol("c1ccccc1"));
std::unique_ptr<RWMol> p(SmartsToMol("c1ccc[c,n]c1"));

```
This is a small bit of syntactic sugar, but I think it will make writing tests easier and less error prone (by "enforcing" the use of smart pointers).