### PR TITLE
Moved test.h from RDBoost to RDGeneral for consistency with export.h

### DIFF
--- a/Code/ChemicalFeatures/testChemicalFeatures.cpp
+++ b/Code/ChemicalFeatures/testChemicalFeatures.cpp
@@ -10,7 +10,7 @@
 //
 //
 
-#include <RDBoost/test.h>
+#include <RDGeneral/test.h>
 #include "FreeChemicalFeature.h"
 #include <Geometry/point.h>
 #include <iostream>

--- a/Code/DataManip/MetricMatrixCalc/testMatCalc.cpp
+++ b/Code/DataManip/MetricMatrixCalc/testMatCalc.cpp
@@ -8,7 +8,7 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-#include <RDBoost/test.h>
+#include <RDGeneral/test.h>
 #include "MetricFuncs.h"
 #include "MetricMatrixCalc.h"
 

--- a/Code/DataStructs/testDatastructs.cpp
+++ b/Code/DataStructs/testDatastructs.cpp
@@ -8,7 +8,7 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-#include <RDBoost/test.h>
+#include <RDGeneral/test.h>
 #include <cstdlib>
 #include <iostream>
 #include <sstream>

--- a/Code/DataStructs/testFPB.cpp
+++ b/Code/DataStructs/testFPB.cpp
@@ -7,7 +7,7 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-#include <RDBoost/test.h>
+#include <RDGeneral/test.h>
 #include <RDGeneral/Invariant.h>
 #include <RDGeneral/RDLog.h>
 #include <RDGeneral/Exceptions.h>

--- a/Code/DataStructs/testMultiFPB.cpp
+++ b/Code/DataStructs/testMultiFPB.cpp
@@ -7,7 +7,7 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-#include <RDBoost/test.h>
+#include <RDGeneral/test.h>
 #include <RDGeneral/Invariant.h>
 #include <RDGeneral/RDLog.h>
 #include <RDGeneral/Exceptions.h>

--- a/Code/Demos/RDKit/Basement/BinaryIO/iotest.cpp
+++ b/Code/Demos/RDKit/Basement/BinaryIO/iotest.cpp
@@ -8,7 +8,7 @@
 // of that library.
 //
 
-#include <RDBoost/test.h>
+#include <RDGeneral/test.h>
 #include <RDGeneral/RDLog.h>
 #include <GraphMol/RDKitBase.h>
 

--- a/Code/DistGeom/testDistGeom.cpp
+++ b/Code/DistGeom/testDistGeom.cpp
@@ -9,7 +9,7 @@
 //  of the RDKit source tree.
 //
 
-#include <RDBoost/test.h>
+#include <RDGeneral/test.h>
 #include "BoundsMatrix.h"
 #include "TriangleSmooth.h"
 #include <iostream>

--- a/Code/Features/testFeatures.cpp
+++ b/Code/Features/testFeatures.cpp
@@ -8,7 +8,7 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-#include <RDBoost/test.h>
+#include <RDGeneral/test.h>
 #include <iostream>
 #include <RDGeneral/Invariant.h>
 #include <RDGeneral/utils.h>

--- a/Code/ForceField/MMFF/testMMFFForceField.cpp
+++ b/Code/ForceField/MMFF/testMMFFForceField.cpp
@@ -9,7 +9,7 @@
 //  of the RDKit source tree.
 //
 
-#include <RDBoost/test.h>
+#include <RDGeneral/test.h>
 #include <GraphMol/RDKitBase.h>
 #include <GraphMol/FileParsers/MolSupplier.h>
 #include <GraphMol/FileParsers/MolWriters.h>

--- a/Code/ForceField/UFF/testUFFForceField.cpp
+++ b/Code/ForceField/UFF/testUFFForceField.cpp
@@ -8,7 +8,7 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-#include <RDBoost/test.h>
+#include <RDGeneral/test.h>
 #include <iostream>
 #include <iomanip>
 #include <math.h>

--- a/Code/Geometry/testGrid.cpp
+++ b/Code/Geometry/testGrid.cpp
@@ -8,7 +8,7 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-#include <RDBoost/test.h>
+#include <RDGeneral/test.h>
 #include "UniformGrid3D.h"
 #include <DataStructs/DiscreteValueVect.h>
 #include "point.h"

--- a/Code/Geometry/testTransforms.cpp
+++ b/Code/Geometry/testTransforms.cpp
@@ -9,7 +9,7 @@
 //  of the RDKit source tree.
 //
 
-#include <RDBoost/test.h>
+#include <RDGeneral/test.h>
 #include <RDGeneral/types.h>
 #include <RDGeneral/Invariant.h>
 #include <RDGeneral/utils.h>

--- a/Code/GraphMol/Basement/FeatTrees/testFeatTrees.cpp
+++ b/Code/GraphMol/Basement/FeatTrees/testFeatTrees.cpp
@@ -8,7 +8,7 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-#include <RDBoost/test.h>
+#include <RDGeneral/test.h>
 #include <RDGeneral/RDLog.h>
 #include <boost/log/functions.hpp>
 #include <GraphMol/RDKitBase.h>

--- a/Code/GraphMol/ChemReactions/Enumerate/testEnumerate.cpp
+++ b/Code/GraphMol/ChemReactions/Enumerate/testEnumerate.cpp
@@ -30,7 +30,7 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
 
-#include <RDBoost/test.h>
+#include <RDGeneral/test.h>
 #include <RDGeneral/utils.h>
 #include <RDGeneral/Exceptions.h>
 #include <GraphMol/RDKitBase.h>

--- a/Code/GraphMol/ChemReactions/testReaction.cpp
+++ b/Code/GraphMol/ChemReactions/testReaction.cpp
@@ -29,7 +29,7 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
-#include <RDBoost/test.h>
+#include <RDGeneral/test.h>
 #include <RDGeneral/RDLog.h>
 #include <RDGeneral/utils.h>
 #include <GraphMol/RDKitBase.h>

--- a/Code/GraphMol/ChemReactions/testReactionFingerprints.cpp
+++ b/Code/GraphMol/ChemReactions/testReactionFingerprints.cpp
@@ -30,7 +30,7 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
-#include <RDBoost/test.h>
+#include <RDGeneral/test.h>
 #include <RDGeneral/RDLog.h>
 #include <RDGeneral/utils.h>
 #include <GraphMol/RDKitBase.h>

--- a/Code/GraphMol/ChemTransforms/testChemTransforms.cpp
+++ b/Code/GraphMol/ChemTransforms/testChemTransforms.cpp
@@ -7,7 +7,7 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-#include <RDBoost/test.h>
+#include <RDGeneral/test.h>
 #include <RDGeneral/RDLog.h>
 #include <RDGeneral/utils.h>
 #include <GraphMol/RDKitBase.h>

--- a/Code/GraphMol/Depictor/Basement/depictTest.cpp
+++ b/Code/GraphMol/Depictor/Basement/depictTest.cpp
@@ -8,7 +8,7 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-#include <RDBoost/test.h>
+#include <RDGeneral/test.h>
 #include <RDGeneral/Invariant.h>
 #include <RDGeneral/RDLog.h>
 #include "Depictor.h"

--- a/Code/GraphMol/Depictor/testDepictor.cpp
+++ b/Code/GraphMol/Depictor/testDepictor.cpp
@@ -7,7 +7,7 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-#include <RDBoost/test.h>
+#include <RDGeneral/test.h>
 #include <RDGeneral/Invariant.h>
 #include <RDGeneral/RDLog.h>
 #include <GraphMol/RDKitBase.h>

--- a/Code/GraphMol/Descriptors/test.cpp
+++ b/Code/GraphMol/Descriptors/test.cpp
@@ -8,7 +8,7 @@
 //  of the RDKit source tree.
 //
 
-#include <RDBoost/test.h>
+#include <RDGeneral/test.h>
 #include <iostream>
 #include <fstream>
 

--- a/Code/GraphMol/Descriptors/test3D.cpp
+++ b/Code/GraphMol/Descriptors/test3D.cpp
@@ -13,7 +13,7 @@
 #define _CRT_SECURE_NO_WARNINGS
 #endif
 
-#include <RDBoost/test.h>
+#include <RDGeneral/test.h>
 #include <iostream>
 #include <fstream>
 

--- a/Code/GraphMol/Descriptors/testAUTOCORR2D.cpp
+++ b/Code/GraphMol/Descriptors/testAUTOCORR2D.cpp
@@ -7,7 +7,7 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-#include <RDBoost/test.h>
+#include <RDGeneral/test.h>
 #include <RDGeneral/Invariant.h>
 #include <GraphMol/RDKitBase.h>
 #include <GraphMol/FileParsers/MolSupplier.h>

--- a/Code/GraphMol/Descriptors/testAUTOCORR3D.cpp
+++ b/Code/GraphMol/Descriptors/testAUTOCORR3D.cpp
@@ -7,7 +7,7 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-#include <RDBoost/test.h>
+#include <RDGeneral/test.h>
 #include <RDGeneral/Invariant.h>
 #include <GraphMol/RDKitBase.h>
 #include <GraphMol/FileParsers/MolSupplier.h>

--- a/Code/GraphMol/Descriptors/testEEM.cpp
+++ b/Code/GraphMol/Descriptors/testEEM.cpp
@@ -7,7 +7,7 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-#include <RDBoost/test.h>
+#include <RDGeneral/test.h>
 #include <RDGeneral/Invariant.h>
 #include <GraphMol/RDKitBase.h>
 #include <GraphMol/FileParsers/MolSupplier.h>

--- a/Code/GraphMol/Descriptors/testGETAWAY.cpp
+++ b/Code/GraphMol/Descriptors/testGETAWAY.cpp
@@ -7,7 +7,7 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-#include <RDBoost/test.h>
+#include <RDGeneral/test.h>
 #include <RDGeneral/Invariant.h>
 #include <GraphMol/RDKitBase.h>
 #include <GraphMol/FileParsers/MolSupplier.h>

--- a/Code/GraphMol/Descriptors/testMORSE.cpp
+++ b/Code/GraphMol/Descriptors/testMORSE.cpp
@@ -8,7 +8,7 @@
 //  of the RDKit source tree.
 //
 
-#include <RDBoost/test.h>
+#include <RDGeneral/test.h>
 #include <RDGeneral/Invariant.h>
 #include <GraphMol/RDKitBase.h>
 #include <GraphMol/FileParsers/MolSupplier.h>

--- a/Code/GraphMol/Descriptors/testPBF.cpp
+++ b/Code/GraphMol/Descriptors/testPBF.cpp
@@ -8,7 +8,7 @@
 //  of the RDKit source tree.
 //
 
-#include <RDBoost/test.h>
+#include <RDGeneral/test.h>
 #include <RDGeneral/Invariant.h>
 #include <GraphMol/RDKitBase.h>
 #include <GraphMol/FileParsers/MolSupplier.h>

--- a/Code/GraphMol/Descriptors/testRDF.cpp
+++ b/Code/GraphMol/Descriptors/testRDF.cpp
@@ -7,7 +7,7 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-#include <RDBoost/test.h>
+#include <RDGeneral/test.h>
 #include <RDGeneral/Invariant.h>
 #include <GraphMol/RDKitBase.h>
 #include <GraphMol/FileParsers/MolSupplier.h>

--- a/Code/GraphMol/Descriptors/testWHIM.cpp
+++ b/Code/GraphMol/Descriptors/testWHIM.cpp
@@ -7,7 +7,7 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-#include <RDBoost/test.h>
+#include <RDGeneral/test.h>
 #include <RDGeneral/Invariant.h>
 #include <GraphMol/RDKitBase.h>
 #include <GraphMol/FileParsers/MolSupplier.h>

--- a/Code/GraphMol/DistGeomHelpers/testDgeomHelpers.cpp
+++ b/Code/GraphMol/DistGeomHelpers/testDgeomHelpers.cpp
@@ -7,7 +7,7 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-#include <RDBoost/test.h>
+#include <RDGeneral/test.h>
 #include <RDGeneral/RDLog.h>
 #include <RDGeneral/versions.h>
 #include <GraphMol/RDKitBase.h>

--- a/Code/GraphMol/FMCS/Test/testFMCS.cpp
+++ b/Code/GraphMol/FMCS/Test/testFMCS.cpp
@@ -31,7 +31,7 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
 #ifdef _WIN32
-#include <RDBoost/test.h>
+#include <RDGeneral/test.h>
 #include <Windows.h>
 #else
 #include <unistd.h>

--- a/Code/GraphMol/FMCS/testFMCS_Unit.cpp
+++ b/Code/GraphMol/FMCS/testFMCS_Unit.cpp
@@ -30,7 +30,7 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
 #ifdef _WIN32
-#include <RDBoost/test.h>
+#include <RDGeneral/test.h>
 #include <Windows.h>
 #else
 #include <unistd.h>

--- a/Code/GraphMol/FileParsers/catch_tests.cpp
+++ b/Code/GraphMol/FileParsers/catch_tests.cpp
@@ -1,6 +1,6 @@
 #define CATCH_CONFIG_MAIN  // This tells Catch to provide a main() - only do
                            // this in one cpp file
-#include "RDBoost/test.h"
+#include "RDGeneral/test.h"
 #include "catch.hpp"
 
 #include <GraphMol/RDKitBase.h>

--- a/Code/GraphMol/FileParsers/test1.cpp
+++ b/Code/GraphMol/FileParsers/test1.cpp
@@ -7,7 +7,7 @@
 //  of the RDKit source tree.
 //
 
-#include <RDBoost/test.h>
+#include <RDGeneral/test.h>
 #include <RDGeneral/RDLog.h>
 #include <GraphMol/RDKitBase.h>
 #include <GraphMol/Canon.h>

--- a/Code/GraphMol/FileParsers/testMol2ToMol.cpp
+++ b/Code/GraphMol/FileParsers/testMol2ToMol.cpp
@@ -32,7 +32,7 @@
 //  created by Nik Stiefl May 2008
 //
 
-#include <RDBoost/test.h>
+#include <RDGeneral/test.h>
 #include <RDGeneral/RDLog.h>
 #include <GraphMol/RDKitBase.h>
 #include "FileParsers.h"

--- a/Code/GraphMol/FileParsers/testMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/testMolSupplier.cpp
@@ -8,7 +8,7 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-#include <RDBoost/test.h>
+#include <RDGeneral/test.h>
 #include <GraphMol/RDKitBase.h>
 #include <string>
 #include <iostream>

--- a/Code/GraphMol/FileParsers/testMolWriter.cpp
+++ b/Code/GraphMol/FileParsers/testMolWriter.cpp
@@ -7,7 +7,7 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-#include <RDBoost/test.h>
+#include <RDGeneral/test.h>
 #include <GraphMol/RDKitBase.h>
 #include <string>
 #include <iostream>

--- a/Code/GraphMol/FileParsers/testSequence.cpp
+++ b/Code/GraphMol/FileParsers/testSequence.cpp
@@ -1,4 +1,4 @@
-#include <RDBoost/test.h>
+#include <RDGeneral/test.h>
 #include <stdlib.h>
 #include <stdio.h>
 

--- a/Code/GraphMol/FileParsers/testTpls.cpp
+++ b/Code/GraphMol/FileParsers/testTpls.cpp
@@ -8,7 +8,7 @@
 //  of the RDKit source tree.
 //
 
-#include <RDBoost/test.h>
+#include <RDGeneral/test.h>
 #include <RDGeneral/RDLog.h>
 #include <GraphMol/RDKitBase.h>
 #include "FileParsers.h"

--- a/Code/GraphMol/FilterCatalog/filtercatalogtest.cpp
+++ b/Code/GraphMol/FilterCatalog/filtercatalogtest.cpp
@@ -28,7 +28,7 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
-#include <RDBoost/test.h>
+#include <RDGeneral/test.h>
 #include <RDGeneral/RDLog.h>
 #include <GraphMol/RDKitBase.h>
 #include <GraphMol/FileParsers/MolSupplier.h>

--- a/Code/GraphMol/Fingerprints/test1.cpp
+++ b/Code/GraphMol/Fingerprints/test1.cpp
@@ -8,7 +8,7 @@
 //  of the RDKit source tree.
 //
 
-#include <RDBoost/test.h>
+#include <RDGeneral/test.h>
 #include <GraphMol/RDKitBase.h>
 #include <GraphMol/SmilesParse/SmilesParse.h>
 #include <GraphMol/SmilesParse/SmilesWrite.h>

--- a/Code/GraphMol/ForceFieldHelpers/CrystalFF/testCrystalFF.cpp
+++ b/Code/GraphMol/ForceFieldHelpers/CrystalFF/testCrystalFF.cpp
@@ -9,7 +9,7 @@
 //  of the RDKit source tree.
 //
 
-#include <RDBoost/test.h>
+#include <RDGeneral/test.h>
 #include <RDGeneral/utils.h>
 #include <Geometry/point.h>
 #include <GraphMol/RDKitBase.h>

--- a/Code/GraphMol/ForceFieldHelpers/MMFF/testMMFFHelpers.cpp
+++ b/Code/GraphMol/ForceFieldHelpers/MMFF/testMMFFHelpers.cpp
@@ -8,7 +8,7 @@
 //  of the RDKit source tree.
 //
 
-#include <RDBoost/test.h>
+#include <RDGeneral/test.h>
 #include <iostream>
 #include <RDGeneral/Invariant.h>
 #include <RDGeneral/RDLog.h>

--- a/Code/GraphMol/ForceFieldHelpers/UFF/testUFFHelpers.cpp
+++ b/Code/GraphMol/ForceFieldHelpers/UFF/testUFFHelpers.cpp
@@ -8,7 +8,7 @@
 //  of the RDKit source tree.
 //
 
-#include <RDBoost/test.h>
+#include <RDGeneral/test.h>
 #include <iostream>
 #include <RDGeneral/Invariant.h>
 #include <RDGeneral/RDLog.h>

--- a/Code/GraphMol/FragCatalog/test1.cpp
+++ b/Code/GraphMol/FragCatalog/test1.cpp
@@ -8,7 +8,7 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-#include <RDBoost/test.h>
+#include <RDGeneral/test.h>
 #include <GraphMol/RDKitBase.h>
 #include <GraphMol/RDKitQueries.h>
 #include <RDGeneral/RDLog.h>

--- a/Code/GraphMol/MMPA/MMPA_UnitTest.cpp
+++ b/Code/GraphMol/MMPA/MMPA_UnitTest.cpp
@@ -31,7 +31,7 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
 #ifndef _MSC_VER
-#include <RDBoost/test.h>
+#include <RDGeneral/test.h>
 #include <unistd.h>
 #include <fcntl.h>
 #include <sys/time.h>

--- a/Code/GraphMol/MolAlign/testMolAlign.cpp
+++ b/Code/GraphMol/MolAlign/testMolAlign.cpp
@@ -7,7 +7,7 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-#include <RDBoost/test.h>
+#include <RDGeneral/test.h>
 #include "AlignMolecules.h"
 #include "O3AAlignMolecules.h"
 #include <GraphMol/FileParsers/MolSupplier.h>

--- a/Code/GraphMol/MolCatalog/test1.cpp
+++ b/Code/GraphMol/MolCatalog/test1.cpp
@@ -2,7 +2,7 @@
 //
 //  Copyright (C) 2006 Greg Landrum
 //
-#include <RDBoost/test.h>
+#include <RDGeneral/test.h>
 #include <GraphMol/RDKitBase.h>
 #include <GraphMol/RDKitQueries.h>
 #include <RDGeneral/RDLog.h>

--- a/Code/GraphMol/MolChemicalFeatures/testFeatures.cpp
+++ b/Code/GraphMol/MolChemicalFeatures/testFeatures.cpp
@@ -8,7 +8,7 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-#include <RDBoost/test.h>
+#include <RDGeneral/test.h>
 #include <fstream>
 #include <iostream>
 #include <RDGeneral/Invariant.h>

--- a/Code/GraphMol/MolDraw2D/rxn_test1.cpp
+++ b/Code/GraphMol/MolDraw2D/rxn_test1.cpp
@@ -8,7 +8,7 @@
 //  of the RDKit source tree.
 //
 
-#include <RDBoost/test.h>
+#include <RDGeneral/test.h>
 #include <RDGeneral/utils.h>
 #include <RDGeneral/Invariant.h>
 #include <RDGeneral/RDLog.h>

--- a/Code/GraphMol/MolDraw2D/test1.cpp
+++ b/Code/GraphMol/MolDraw2D/test1.cpp
@@ -8,7 +8,7 @@
 //  of the RDKit source tree.
 //
 
-#include <RDBoost/test.h>
+#include <RDGeneral/test.h>
 #include <RDGeneral/utils.h>
 #include <RDGeneral/Invariant.h>
 #include <RDGeneral/RDLog.h>

--- a/Code/GraphMol/MolHash/testMolHash.cpp
+++ b/Code/GraphMol/MolHash/testMolHash.cpp
@@ -8,7 +8,7 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-#include <RDBoost/test.h>
+#include <RDGeneral/test.h>
 #include <list>
 #include <vector>
 #include <string>

--- a/Code/GraphMol/MolInterchange/test1.cpp
+++ b/Code/GraphMol/MolInterchange/test1.cpp
@@ -6,7 +6,7 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-#include <RDBoost/test.h>
+#include <RDGeneral/test.h>
 #include <RDGeneral/RDLog.h>
 #include <GraphMol/RDKitBase.h>
 #include <GraphMol/MolPickler.h>

--- a/Code/GraphMol/MolStandardize/testFragment.cpp
+++ b/Code/GraphMol/MolStandardize/testFragment.cpp
@@ -7,7 +7,7 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-#include <RDBoost/test.h>
+#include <RDGeneral/test.h>
 #include <GraphMol/MolStandardize/FragmentCatalog/FragmentCatalogParams.h>
 #include <GraphMol/MolStandardize/FragmentCatalog/FragmentCatalogUtils.h>
 #include <GraphMol/MolStandardize/Fragment.h>

--- a/Code/GraphMol/MolTransforms/test1.cpp
+++ b/Code/GraphMol/MolTransforms/test1.cpp
@@ -7,7 +7,7 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-#include <RDBoost/test.h>
+#include <RDGeneral/test.h>
 #include <RDGeneral/Invariant.h>
 #include <RDGeneral/utils.h>
 #include <Geometry/Transform3D.h>

--- a/Code/GraphMol/PartialCharges/test1.cpp
+++ b/Code/GraphMol/PartialCharges/test1.cpp
@@ -10,7 +10,7 @@
 //
 
 // std bits
-#include <RDBoost/test.h>
+#include <RDGeneral/test.h>
 #include <iostream>
 
 // RD bits

--- a/Code/GraphMol/RGroupDecomposition/testRGroupDecomp.cpp
+++ b/Code/GraphMol/RGroupDecomposition/testRGroupDecomp.cpp
@@ -28,7 +28,7 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
-#include <RDBoost/test.h>
+#include <RDGeneral/test.h>
 #include <RDGeneral/RDLog.h>
 #include <RDGeneral/utils.h>
 #include <GraphMol/RDKitBase.h>

--- a/Code/GraphMol/ReducedGraphs/test1.cpp
+++ b/Code/GraphMol/ReducedGraphs/test1.cpp
@@ -9,7 +9,7 @@
 //  of the RDKit source tree.
 //
 
-#include <RDBoost/test.h>
+#include <RDGeneral/test.h>
 #include <GraphMol/RDKitBase.h>
 #include <GraphMol/SmilesParse/SmilesParse.h>
 #include <GraphMol/SmilesParse/SmilesWrite.h>

--- a/Code/GraphMol/SLNParse/test.cpp
+++ b/Code/GraphMol/SLNParse/test.cpp
@@ -32,7 +32,7 @@
 //
 //  Created by Greg Landrum September, 2006
 //
-#include <RDBoost/test.h>
+#include <RDGeneral/test.h>
 #include <iostream>
 #include <GraphMol/RDKitBase.h>
 #include <GraphMol/SLNParse/SLNParse.h>

--- a/Code/GraphMol/ShapeHelpers/testShapeHelpers.cpp
+++ b/Code/GraphMol/ShapeHelpers/testShapeHelpers.cpp
@@ -9,7 +9,7 @@
 //  of the RDKit source tree.
 //
 
-#include <RDBoost/test.h>
+#include <RDGeneral/test.h>
 #include <Geometry/UniformGrid3D.h>
 #include "ShapeEncoder.h"
 #include "ShapeUtils.h"

--- a/Code/GraphMol/SmilesParse/cxsmiles_test.cpp
+++ b/Code/GraphMol/SmilesParse/cxsmiles_test.cpp
@@ -7,7 +7,7 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-#include <RDBoost/test.h>
+#include <RDGeneral/test.h>
 #include <string>
 #include <GraphMol/RDKitBase.h>
 #include "SmilesParse.h"

--- a/Code/GraphMol/SmilesParse/smatest.cpp
+++ b/Code/GraphMol/SmilesParse/smatest.cpp
@@ -7,7 +7,7 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-#include <RDBoost/test.h>
+#include <RDGeneral/test.h>
 #include <iostream>
 
 #include <fstream>

--- a/Code/GraphMol/SmilesParse/test.cpp
+++ b/Code/GraphMol/SmilesParse/test.cpp
@@ -7,7 +7,7 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-#include <RDBoost/test.h>
+#include <RDGeneral/test.h>
 #include <iostream>
 #include <string>
 #include <GraphMol/RDKitBase.h>

--- a/Code/GraphMol/SmilesParse/test2.cpp
+++ b/Code/GraphMol/SmilesParse/test2.cpp
@@ -7,7 +7,7 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-#include <RDBoost/test.h>
+#include <RDGeneral/test.h>
 #include <iostream>
 #include <string>
 #include <GraphMol/RDKitBase.h>

--- a/Code/GraphMol/StructChecker/testStructChecker.cpp
+++ b/Code/GraphMol/StructChecker/testStructChecker.cpp
@@ -7,7 +7,7 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-#include <RDBoost/test.h>
+#include <RDGeneral/test.h>
 #include "../RDKitBase.h"
 #include "../FileParsers/FileParsers.h"  //MOL single molecule !
 #include "../FileParsers/MolSupplier.h"  //SDF

--- a/Code/GraphMol/Subgraphs/test1.cpp
+++ b/Code/GraphMol/Subgraphs/test1.cpp
@@ -8,7 +8,7 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-#include <RDBoost/test.h>
+#include <RDGeneral/test.h>
 #include <GraphMol/RDKitBase.h>
 #include <GraphMol/Subgraphs/Subgraphs.h>
 #include <GraphMol/SmilesParse/SmilesParse.h>

--- a/Code/GraphMol/Subgraphs/test2.cpp
+++ b/Code/GraphMol/Subgraphs/test2.cpp
@@ -7,7 +7,7 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-#include <RDBoost/test.h>
+#include <RDGeneral/test.h>
 #include <GraphMol/RDKitBase.h>
 #include <GraphMol/SmilesParse/SmilesParse.h>
 #include <GraphMol/SmilesParse/SmilesWrite.h>

--- a/Code/GraphMol/Substruct/test1.cpp
+++ b/Code/GraphMol/Substruct/test1.cpp
@@ -10,7 +10,7 @@
 //
 
 // std bits
-#include <RDBoost/test.h>
+#include <RDGeneral/test.h>
 #include <iostream>
 
 // RD bits

--- a/Code/GraphMol/SubstructLibrary/substructLibraryTest.cpp
+++ b/Code/GraphMol/SubstructLibrary/substructLibraryTest.cpp
@@ -10,7 +10,7 @@
 //
 
 // std bits
-#include <RDBoost/test.h>
+#include <RDGeneral/test.h>
 #include <iostream>
 
 // RD bits

--- a/Code/GraphMol/Trajectory/trajectoryTest.cpp
+++ b/Code/GraphMol/Trajectory/trajectoryTest.cpp
@@ -9,7 +9,7 @@
 //  of the RDKit source tree.
 //
 
-#include <RDBoost/test.h>
+#include <RDGeneral/test.h>
 #include "Trajectory.h"
 #include <Geometry/point.h>
 #include <GraphMol/ROMol.h>

--- a/Code/GraphMol/bulktest.cpp
+++ b/Code/GraphMol/bulktest.cpp
@@ -8,7 +8,7 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-#include <RDBoost/test.h>
+#include <RDGeneral/test.h>
 #include <GraphMol/RDKitBase.h>
 #include <GraphMol/MolPickler.h>
 #include <GraphMol/SmilesParse/SmilesParse.h>

--- a/Code/GraphMol/cptest.cpp
+++ b/Code/GraphMol/cptest.cpp
@@ -7,7 +7,7 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-#include <RDBoost/test.h>
+#include <RDGeneral/test.h>
 #include <GraphMol/RDKitBase.h>
 #include <GraphMol/RDKitQueries.h>
 #include <GraphMol/SmilesParse/SmilesParse.h>

--- a/Code/GraphMol/hanoitest.cpp
+++ b/Code/GraphMol/hanoitest.cpp
@@ -7,7 +7,7 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-#include <RDBoost/test.h>
+#include <RDGeneral/test.h>
 #include <GraphMol/new_canon.h>
 #include <RDGeneral/RDLog.h>
 #include <RDGeneral/Invariant.h>

--- a/Code/GraphMol/itertest.cpp
+++ b/Code/GraphMol/itertest.cpp
@@ -7,7 +7,7 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-#include <RDBoost/test.h>
+#include <RDGeneral/test.h>
 #include <GraphMol/RDKitBase.h>
 #include <GraphMol/RDKitQueries.h>
 #include <GraphMol/SmilesParse/SmilesParse.h>

--- a/Code/GraphMol/memtest1.cpp
+++ b/Code/GraphMol/memtest1.cpp
@@ -9,7 +9,7 @@
 //  of the RDKit source tree.
 //
 
-#include <RDBoost/test.h>
+#include <RDGeneral/test.h>
 #include <GraphMol/RDKitBase.h>
 #include <GraphMol/MonomerInfo.h>
 #include <GraphMol/RDKitQueries.h>

--- a/Code/GraphMol/molopstest.cpp
+++ b/Code/GraphMol/molopstest.cpp
@@ -7,7 +7,7 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-#include <RDBoost/test.h>
+#include <RDGeneral/test.h>
 #include <RDGeneral/utils.h>
 #include <RDGeneral/Invariant.h>
 #include <RDGeneral/RDLog.h>

--- a/Code/GraphMol/querytest.cpp
+++ b/Code/GraphMol/querytest.cpp
@@ -7,7 +7,7 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-#include <RDBoost/test.h>
+#include <RDGeneral/test.h>
 #include <RDGeneral/Invariant.h>
 #include <RDGeneral/RDLog.h>
 #include <GraphMol/RDKitBase.h>

--- a/Code/GraphMol/resMolSupplierTest.cpp
+++ b/Code/GraphMol/resMolSupplierTest.cpp
@@ -1,4 +1,4 @@
-#include <RDBoost/test.h>
+#include <RDGeneral/test.h>
 #include <iostream>
 #include <string>
 #include <map>

--- a/Code/GraphMol/sanitTest.cpp
+++ b/Code/GraphMol/sanitTest.cpp
@@ -9,7 +9,7 @@
 //  of the RDKit source tree.
 //
 
-#include <RDBoost/test.h>
+#include <RDGeneral/test.h>
 #include <GraphMol/RDKitBase.h>
 #include <GraphMol/RDKitQueries.h>
 #include <GraphMol/SmilesParse/SmilesParse.h>

--- a/Code/GraphMol/test-valgrind.cpp
+++ b/Code/GraphMol/test-valgrind.cpp
@@ -8,7 +8,7 @@
 //  of the RDKit source tree.
 //
 
-#include <RDBoost/test.h>
+#include <RDGeneral/test.h>
 #include <GraphMol/RDKitBase.h>
 #include <GraphMol/MonomerInfo.h>
 #include <GraphMol/RDKitQueries.h>

--- a/Code/GraphMol/test1.cpp
+++ b/Code/GraphMol/test1.cpp
@@ -8,7 +8,7 @@
 //  of the RDKit source tree.
 //
 
-#include <RDBoost/test.h>
+#include <RDGeneral/test.h>
 #include <GraphMol/RDKitBase.h>
 #include <GraphMol/MonomerInfo.h>
 #include <GraphMol/RDKitQueries.h>

--- a/Code/GraphMol/testCanon.cpp
+++ b/Code/GraphMol/testCanon.cpp
@@ -8,7 +8,7 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-#include <RDBoost/test.h>
+#include <RDGeneral/test.h>
 #include <GraphMol/RDKitBase.h>
 #include <GraphMol/RDKitQueries.h>
 #include <GraphMol/SmilesParse/SmilesParse.h>

--- a/Code/GraphMol/testChirality.cpp
+++ b/Code/GraphMol/testChirality.cpp
@@ -10,7 +10,7 @@
 //
 // There are chirality test cases spread all over the place. Many of the
 // tests here are repeats, but it's good to have everything in one place.
-#include <RDBoost/test.h>
+#include <RDGeneral/test.h>
 #include <RDGeneral/utils.h>
 #include <RDGeneral/Invariant.h>
 #include <RDGeneral/RDLog.h>

--- a/Code/GraphMol/testMolBundle.cpp
+++ b/Code/GraphMol/testMolBundle.cpp
@@ -7,7 +7,7 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-#include <RDBoost/test.h>
+#include <RDGeneral/test.h>
 #include <iostream>
 #include <string>
 #include <map>

--- a/Code/GraphMol/testPickler.cpp
+++ b/Code/GraphMol/testPickler.cpp
@@ -7,7 +7,7 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-#include <RDBoost/test.h>
+#include <RDGeneral/test.h>
 #include <RDGeneral/utils.h>
 #include <GraphMol/RDKitBase.h>
 #include <GraphMol/RDKitQueries.h>

--- a/Code/GraphMol/testPicklerGlobalSettings.cpp
+++ b/Code/GraphMol/testPicklerGlobalSettings.cpp
@@ -29,7 +29,7 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
-#include <RDBoost/test.h>
+#include <RDGeneral/test.h>
 #include <RDGeneral/utils.h>
 #include <GraphMol/RDKitBase.h>
 #include <GraphMol/RDKitQueries.h>

--- a/Code/Numerics/Alignment/testAlignment.cpp
+++ b/Code/Numerics/Alignment/testAlignment.cpp
@@ -7,7 +7,7 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-#include <RDBoost/test.h>
+#include <RDGeneral/test.h>
 #include "AlignPoints.h"
 #include <Numerics/Vector.h>
 #include <RDGeneral/utils.h>

--- a/Code/Numerics/EigenSolvers/testEigenSolvers.cpp
+++ b/Code/Numerics/EigenSolvers/testEigenSolvers.cpp
@@ -8,7 +8,7 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-#include <RDBoost/test.h>
+#include <RDGeneral/test.h>
 #include "PowerEigenSolver.h"
 #include <Numerics/Matrix.h>
 #include <Numerics/SquareMatrix.h>

--- a/Code/Numerics/Optimizer/testOptimizer.cpp
+++ b/Code/Numerics/Optimizer/testOptimizer.cpp
@@ -8,7 +8,7 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-#include <RDBoost/test.h>
+#include <RDGeneral/test.h>
 #include <iostream>
 #include <math.h>
 #include <RDGeneral/Invariant.h>

--- a/Code/Numerics/testMatrices.cpp
+++ b/Code/Numerics/testMatrices.cpp
@@ -8,7 +8,7 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-#include <RDBoost/test.h>
+#include <RDGeneral/test.h>
 #include "Matrix.h"
 #include "SquareMatrix.h"
 #include "SymmMatrix.h"

--- a/Code/Query/test.cpp
+++ b/Code/Query/test.cpp
@@ -9,7 +9,7 @@
 //  of the RDKit source tree.
 //
 
-#include <RDBoost/test.h>
+#include <RDGeneral/test.h>
 #include "QueryObjects.h"
 #include <iostream>
 #include <math.h>

--- a/Code/RDBoost/CMakeLists.txt
+++ b/Code/RDBoost/CMakeLists.txt
@@ -21,7 +21,6 @@ rdkit_headers(Wrap.h PySequenceHolder.h
               python.h
               boost_numpy.h
               python_streambuf.h
-              test.h
               DEST RDBoost)
 
 add_subdirectory(Wrap)

--- a/Code/RDGeneral/CMakeLists.txt
+++ b/Code/RDGeneral/CMakeLists.txt
@@ -59,6 +59,7 @@ rdkit_headers(Exceptions.h
               Ranking.h
               hanoiSort.h
               export.h
+              test.h
               DEST RDGeneral)
 if (NOT RDK_INSTALL_INTREE)
   install(DIRECTORY hash DESTINATION ${RDKit_HdrDir}/RDGeneral/hash

--- a/Code/RDGeneral/testDict.cpp
+++ b/Code/RDGeneral/testDict.cpp
@@ -10,7 +10,7 @@
 //
 //
 
-#include <RDBoost/test.h>
+#include <RDGeneral/test.h>
 #include "types.h"
 #include <RDGeneral/Invariant.h>
 #include <RDGeneral/RDAny.h>

--- a/Code/RDGeneral/testRDValue.cpp
+++ b/Code/RDGeneral/testRDValue.cpp
@@ -1,4 +1,4 @@
-#include <RDBoost/test.h>
+#include <RDGeneral/test.h>
 #include "RDValue.h"
 #include "RDProps.h"
 #include "Invariant.h"

--- a/Code/SimDivPickers/testPickers.cpp
+++ b/Code/SimDivPickers/testPickers.cpp
@@ -7,7 +7,7 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-#include <RDBoost/test.h>
+#include <RDGeneral/test.h>
 #include "MaxMinPicker.h"
 #include <iostream>
 #include <RDGeneral/Invariant.h>

--- a/Code/cmake/Modules/RDKitUtils.cmake
+++ b/Code/cmake/Modules/RDKitUtils.cmake
@@ -259,7 +259,7 @@ function(createExportTestHeaders)
     "\n"
     "#include <boost/config.hpp>\n"
     "#endif\n")
-  set(testPath "Code/RDBoost/test.h")
+  set(testPath "Code/RDGeneral/test.h")
   file(WRITE "${CMAKE_BINARY_DIR}/${testPath}"
     "// auto-generated header to be imported in all cpp tests\n"
     "#pragma once\n")

--- a/External/AvalonTools/test1.cpp
+++ b/External/AvalonTools/test1.cpp
@@ -8,7 +8,7 @@
 //  avalontoolkit
 //
 
-#include <RDBoost/test.h>
+#include <RDGeneral/test.h>
 #include <RDGeneral/RDLog.h>
 #include <GraphMol/RDKitBase.h>
 #include <GraphMol/SmilesParse/SmilesParse.h>


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! 
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.
`test.h` is now generated in `RDGeneral` rather than in `RDBoost` for consistency with `export.h` (which was moved from `RDBoost` to `RDGeneral` some time ago).

#### Any other comments?

