### PR TITLE
Fixes #2062

### DIFF
--- a/Code/GraphMol/AddHs.cpp
+++ b/Code/GraphMol/AddHs.cpp
@@ -879,6 +879,7 @@ void mergeQueryHs(RWMol &mol, bool mergeUnmappedOnly) {
           ATOM_EQUALS_QUERY *tmp = makeAtomNumQuery(atom->getAtomicNum());
           auto *newAt = new QueryAtom;
           newAt->setQuery(tmp);
+          newAt->updateProps(*atom);
           mol.replaceAtom(atom->getIdx(), newAt);
           delete newAt;
           atom = mol.getAtomWithIdx(currIdx);

--- a/Code/GraphMol/catch_tests.cpp
+++ b/Code/GraphMol/catch_tests.cpp
@@ -43,3 +43,23 @@ TEST_CASE("Sanitization tests", "[molops]") {
     }
   }
 }
+
+TEST_CASE("Github #2062", "[bug, molops]") {
+  SmilesParserParams ps;
+  ps.removeHs = false;
+  ps.sanitize = true;
+  std::unique_ptr<RWMol> mol(SmilesToMol("[C:1][C:2]([H:3])([H])[O:4][H]",ps));
+  REQUIRE(mol);
+  CHECK(mol->getNumAtoms() == 6);
+  mol->getAtomWithIdx(1)->setProp("intProp",42);
+  MolOps::mergeQueryHs(*mol);
+  CHECK(mol->getNumAtoms() == 3);
+  SECTION("basics") {
+    CHECK(mol->getAtomWithIdx(1)->getAtomMapNum() == 2);
+  }
+  SECTION("other props") {
+  REQUIRE(mol->getAtomWithIdx(1)->hasProp("intProp"));
+  CHECK(mol->getAtomWithIdx(1)->getProp<int>("intProp") == 42);
+}
+
+}


### PR DESCRIPTION
Simple fix: copy properties from reactant atoms over to product atoms.
I don't think this should break anything, but you may want to have a look at it @bp-kelley 