### PR TITLE
Expose a CMake flag to build RDKit with -rpath

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ option(RDK_BUILD_COMPRESSED_SUPPLIERS "build in support for compressed MolSuppli
 option(RDK_BUILD_INCHI_SUPPORT "build the rdkit inchi wrapper" OFF )
 option(RDK_BUILD_AVALON_SUPPORT "install support for the avalon toolkit. Use the variable AVALONTOOLS_DIR to set the location of the source." OFF )
 option(RDK_BUILD_PGSQL "build the PostgreSQL cartridge" OFF )
+option(RDK_BUILD_RPATH_SUPPORT "build shared libraries using rpath" OFF)
 option(RDK_PGSQL_STATIC "statically link rdkit libraries into the PostgreSQL cartridge" ON )
 option(RDK_BUILD_CONTRIB "build the Contrib directory" OFF )
 option(RDK_INSTALL_INTREE "install the rdkit in the source tree (former behavior)" ON )
@@ -119,6 +120,32 @@ else(RDK_INSTALL_INTREE)
   set(RDKit_HdrDir "include/rdkit")
   set(RDKit_ShareDir "share/RDKit")
 endif(RDK_INSTALL_INTREE)
+
+if(RDK_BUILD_RPATH_SUPPORT)
+  # use, i.e. don't skip the full RPATH for the build tree
+  SET(CMAKE_SKIP_BUILD_RPATH  FALSE)
+
+  # when building, don't use the install RPATH already
+  # (but later on when installing)
+  SET(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
+
+  message("CMAKE_INSTALL_RPATH ${CMAKE_INSTALL_PREFIX}/lib")
+  SET(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
+
+  # add the automatically determined parts of the RPATH
+  # which point to directories outside the build tree to the install RPATH
+  SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+
+  # the RPATH to be used when installing, but only if it's not a system
+  # directory
+  LIST(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES
+  "${CMAKE_INSTALL_PREFIX}/lib" isSystemDir)
+  IF("${isSystemDir}" STREQUAL "-1")
+     SET(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
+  ENDIF("${isSystemDir}" STREQUAL "-1")
+endif()
+
+
 
 if(RDK_BUILD_SWIG_WRAPPERS)
   set(RDKit_JavaLibDir "${RDKit_ExternalDir}/java_lib")

--- a/External/catch/CMakeLists.txt
+++ b/External/catch/CMakeLists.txt
@@ -3,20 +3,25 @@ project(catch_builder CXX)
 # Includes Catch in the project:
 include(ExternalProject)
 
-ExternalProject_Add(
-    catch
-    SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/catch
-    GIT_REPOSITORY https://github.com/philsquared/Catch.git
-    GIT_TAG "v2.1.1"
-    TIMEOUT 10
-    UPDATE_COMMAND ""
-    CONFIGURE_COMMAND ""
-    BUILD_COMMAND ""
-    INSTALL_COMMAND ""
-    LOG_DOWNLOAD ON
-   )
+if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/catch")
+  ExternalProject_Add(
+      catch
+      SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/catch
+      GIT_REPOSITORY https://github.com/philsquared/Catch.git
+      GIT_TAG "v2.1.1"
+      TIMEOUT 10
+      UPDATE_COMMAND ""
+      CONFIGURE_COMMAND ""
+      BUILD_COMMAND ""
+      INSTALL_COMMAND ""
+      LOG_DOWNLOAD ON
+     )
 
-# Expose required variable (CATCH_INCLUDE_DIR) to parent scope
-ExternalProject_Get_Property(catch source_dir)
+  # Expose required variable (CATCH_INCLUDE_DIR) to parent scope
+  ExternalProject_Get_Property(catch source_dir)
+else()
+  set(source_dir "${CMAKE_CURRENT_SOURCE_DIR}/catch")
+endif()
+
 set(CATCH_MODULE_PATH ${source_dir} CACHE INTERNAL "location of Catch")
 set(CATCH_INCLUDE_DIR ${CATCH_MODULE_PATH}/single_include CACHE INTERNAL "Path to include folder for Catch")


### PR DESCRIPTION
This is the only changes we make to the RDKit in order to be able to build it internally for our infrastructure. Hopefully they are generally useful enough features that they could be included in the mainline RDKit. 

- Adding a RDK_BUILD_RPATH_SUPPORT CMake option to build the RDKit shared libraries with -rpath pointing to the location that the C++ shared will be installed into.
- Allow catch to be manually downloaded into the proper location (similar to the rest of the Extrernal dependencies). We have the requirement that our software deployments need to be self-contained (i.e. make no external internet connections), this gives us a guarantee that we have all the proper sources in place to re-create any binary package. 

Including these in the mainline would make it easier for us to keep up to date with RDKit's master branch and they seem to be generally useful build features. 