### PR TITLE
Address compile warnings & trivial improvements

### DIFF
--- a/Code/DataStructs/testDatastructs.cpp
+++ b/Code/DataStructs/testDatastructs.cpp
@@ -116,7 +116,7 @@ void Test(T arg) {
 
   try {
     t3.getBit(4000);
-  } catch (IndexErrorException) {
+  } catch (IndexErrorException &) {
     std::cout << " except " << endl;
   } catch (...) {
     std::cout << " ERROR EXCEPT " << endl;
@@ -1403,7 +1403,7 @@ int main() {
   RDLog::InitLogs();
   try {
     throw IndexErrorException(3);
-  } catch (IndexErrorException) {
+  } catch (IndexErrorException &) {
     BOOST_LOG(rdInfoLog) << "pass" << endl;
   }
 

--- a/Code/ForceField/MMFF/Params.cpp
+++ b/Code/ForceField/MMFF/Params.cpp
@@ -47,7 +47,7 @@ MMFFAromCollection::MMFFAromCollection(const boost::uint8_t *mmffArom) {
   if (!mmffArom) {
     mmffArom = defaultMMFFArom;
   }
-  for (unsigned int i = 0; i < sizeof(mmffArom) / sizeof(mmffArom[0]); ++i) {
+  for (unsigned int i = 0; i < sizeof(mmffArom) / sizeof(boost::uint8_t); ++i) {
     d_params.push_back(mmffArom[i]);
   }
 }
@@ -62,7 +62,7 @@ extern const std::string defaultMMFFDef;
 MMFFDefCollection *MMFFDefCollection::getMMFFDef(const std::string &mmffDef) {
   if (!ds_instance) {
     ds_instance = new MMFFDefCollection(mmffDef);
-  } else if (mmffDef != "") {
+  } else if (!mmffDef.empty()) {
     delete ds_instance;
     ds_instance = new MMFFDefCollection(mmffDef);
   }
@@ -70,7 +70,7 @@ MMFFDefCollection *MMFFDefCollection::getMMFFDef(const std::string &mmffDef) {
 }
 
 MMFFDefCollection::MMFFDefCollection(std::string mmffDef) {
-  if (mmffDef == "") {
+  if (mmffDef.empty()) {
     mmffDef = defaultMMFFDef;
   }
   std::istringstream inStream(mmffDef);
@@ -79,7 +79,7 @@ MMFFDefCollection::MMFFDefCollection(std::string mmffDef) {
   unsigned int atomType;
   while (!(inStream.eof())) {
     if (inLine[0] != '*') {
-      MMFFDef mmffDefObj;
+      MMFFDef mmffDefObj{};
       boost::char_separator<char> tabSep("\t");
       tokenizer tokens(inLine, tabSep);
       tokenizer::iterator token = tokens.begin();
@@ -457,7 +457,7 @@ MMFFPropCollection *MMFFPropCollection::getMMFFProp(
     const std::string &mmffProp) {
   if (!ds_instance) {
     ds_instance = new MMFFPropCollection(mmffProp);
-  } else if (mmffProp != "") {
+  } else if (!mmffProp.empty()) {
     delete ds_instance;
     ds_instance = new MMFFPropCollection(mmffProp);
   }
@@ -465,14 +465,14 @@ MMFFPropCollection *MMFFPropCollection::getMMFFProp(
 }
 
 MMFFPropCollection::MMFFPropCollection(std::string mmffProp) {
-  if (mmffProp == "") {
+  if (mmffProp.empty()) {
     mmffProp = defaultMMFFProp;
   }
   std::istringstream inStream(mmffProp);
   std::string inLine = RDKit::getLine(inStream);
   while (!(inStream.eof())) {
     if (inLine[0] != '*') {
-      MMFFProp mmffPropObj;
+      MMFFProp mmffPropObj{};
       boost::char_separator<char> tabSep("\t");
       tokenizer tokens(inLine, tabSep);
       tokenizer::iterator token = tokens.begin();
@@ -629,7 +629,7 @@ MMFFPBCICollection *MMFFPBCICollection::getMMFFPBCI(
     const std::string &mmffPBCI) {
   if (!ds_instance) {
     ds_instance = new MMFFPBCICollection(mmffPBCI);
-  } else if (mmffPBCI != "") {
+  } else if (!mmffPBCI.empty()) {
     delete ds_instance;
     ds_instance = new MMFFPBCICollection(mmffPBCI);
   }
@@ -637,14 +637,14 @@ MMFFPBCICollection *MMFFPBCICollection::getMMFFPBCI(
 }
 
 MMFFPBCICollection::MMFFPBCICollection(std::string mmffPBCI) {
-  if (mmffPBCI == "") {
+  if (mmffPBCI.empty()) {
     mmffPBCI = defaultMMFFPBCI;
   }
   std::istringstream inStream(mmffPBCI);
   std::string inLine = RDKit::getLine(inStream);
   while (!(inStream.eof())) {
     if (inLine[0] != '*') {
-      MMFFPBCI mmffPBCIObj;
+      MMFFPBCI mmffPBCIObj{};
       boost::char_separator<char> tabSep("\t");
       tokenizer tokens(inLine, tabSep);
       tokenizer::iterator token = tokens.begin();
@@ -787,7 +787,7 @@ extern const std::string defaultMMFFChg;
 MMFFChgCollection *MMFFChgCollection::getMMFFChg(const std::string &mmffChg) {
   if (!ds_instance) {
     ds_instance = new MMFFChgCollection(mmffChg);
-  } else if (mmffChg != "") {
+  } else if (!mmffChg.empty()) {
     delete ds_instance;
     ds_instance = new MMFFChgCollection(mmffChg);
   }
@@ -795,14 +795,14 @@ MMFFChgCollection *MMFFChgCollection::getMMFFChg(const std::string &mmffChg) {
 }
 
 MMFFChgCollection::MMFFChgCollection(std::string mmffChg) {
-  if (mmffChg == "") {
+  if (mmffChg.empty()) {
     mmffChg = defaultMMFFChg;
   }
   std::istringstream inStream(mmffChg);
   std::string inLine = RDKit::getLine(inStream);
   while (!(inStream.eof())) {
     if (inLine[0] != '*') {
-      MMFFChg mmffChgObj;
+      MMFFChg mmffChgObj{};
       boost::char_separator<char> tabSep("\t");
       tokenizer tokens(inLine, tabSep);
       tokenizer::iterator token = tokens.begin();
@@ -1360,7 +1360,7 @@ MMFFBondCollection *MMFFBondCollection::getMMFFBond(
     const std::string &mmffBond) {
   if (!ds_instance) {
     ds_instance = new MMFFBondCollection(mmffBond);
-  } else if (mmffBond != "") {
+  } else if (!mmffBond.empty()) {
     delete ds_instance;
     ds_instance = new MMFFBondCollection(mmffBond);
   }
@@ -1368,7 +1368,7 @@ MMFFBondCollection *MMFFBondCollection::getMMFFBond(
 }
 
 MMFFBondCollection::MMFFBondCollection(std::string mmffBond) {
-  if (mmffBond == "") {
+  if (mmffBond.empty()) {
     mmffBond = defaultMMFFBond;
   }
   std::istringstream inStream(mmffBond);
@@ -1931,7 +1931,7 @@ MMFFBndkCollection *MMFFBndkCollection::getMMFFBndk(
     const std::string &mmffBndk) {
   if (!ds_instance) {
     ds_instance = new MMFFBndkCollection(mmffBndk);
-  } else if (mmffBndk != "") {
+  } else if (!mmffBndk.empty()) {
     delete ds_instance;
     ds_instance = new MMFFBndkCollection(mmffBndk);
   }
@@ -1939,14 +1939,14 @@ MMFFBndkCollection *MMFFBndkCollection::getMMFFBndk(
 }
 
 MMFFBndkCollection::MMFFBndkCollection(std::string mmffBndk) {
-  if (mmffBndk == "") {
+  if (mmffBndk.empty()) {
     mmffBndk = defaultMMFFBndk;
   }
   std::istringstream inStream(mmffBndk);
   std::string inLine = RDKit::getLine(inStream);
   while (!(inStream.eof())) {
     if (inLine[0] != '*') {
-      MMFFBond mmffBondObj;
+      MMFFBond mmffBondObj{};
       boost::char_separator<char> tabSep("\t");
       tokenizer tokens(inLine, tabSep);
       tokenizer::iterator token = tokens.begin();
@@ -2058,7 +2058,7 @@ MMFFHerschbachLaurieCollection::getMMFFHerschbachLaurie(
     const std::string &mmffHerschbachLaurie) {
   if (!ds_instance) {
     ds_instance = new MMFFHerschbachLaurieCollection(mmffHerschbachLaurie);
-  } else if (mmffHerschbachLaurie != "") {
+  } else if (!mmffHerschbachLaurie.empty()) {
     delete ds_instance;
     ds_instance = new MMFFHerschbachLaurieCollection(mmffHerschbachLaurie);
   }
@@ -2067,14 +2067,14 @@ MMFFHerschbachLaurieCollection::getMMFFHerschbachLaurie(
 
 MMFFHerschbachLaurieCollection::MMFFHerschbachLaurieCollection(
     std::string mmffHerschbachLaurie) {
-  if (mmffHerschbachLaurie == "") {
+  if (mmffHerschbachLaurie.empty()) {
     mmffHerschbachLaurie = defaultMMFFHerschbachLaurie;
   }
   std::istringstream inStream(mmffHerschbachLaurie);
   std::string inLine = RDKit::getLine(inStream);
   while (!(inStream.eof())) {
     if (inLine[0] != '*') {
-      MMFFHerschbachLaurie mmffHerschbachLaurieObj;
+      MMFFHerschbachLaurie mmffHerschbachLaurieObj{};
       boost::char_separator<char> tabSep("\t");
       tokenizer tokens(inLine, tabSep);
       tokenizer::iterator token = tokens.begin();
@@ -2148,7 +2148,7 @@ MMFFCovRadPauEleCollection *MMFFCovRadPauEleCollection::getMMFFCovRadPauEle(
     const std::string &mmffCovRadPauEle) {
   if (!ds_instance) {
     ds_instance = new MMFFCovRadPauEleCollection(mmffCovRadPauEle);
-  } else if (mmffCovRadPauEle != "") {
+  } else if (!mmffCovRadPauEle.empty()) {
     delete ds_instance;
     ds_instance = new MMFFCovRadPauEleCollection(mmffCovRadPauEle);
   }
@@ -2157,14 +2157,14 @@ MMFFCovRadPauEleCollection *MMFFCovRadPauEleCollection::getMMFFCovRadPauEle(
 
 MMFFCovRadPauEleCollection::MMFFCovRadPauEleCollection(
     std::string mmffCovRadPauEle) {
-  if (mmffCovRadPauEle == "") {
+  if (mmffCovRadPauEle.empty()) {
     mmffCovRadPauEle = defaultMMFFCovRadPauEle;
   }
   std::istringstream inStream(mmffCovRadPauEle);
   std::string inLine = RDKit::getLine(inStream);
   while (!(inStream.eof())) {
     if (inLine[0] != '*') {
-      MMFFCovRadPauEle mmffCovRadPauEleObj;
+      MMFFCovRadPauEle mmffCovRadPauEleObj{};
       boost::char_separator<char> tabSep("\t");
       tokenizer tokens(inLine, tabSep);
       tokenizer::iterator token = tokens.begin();
@@ -2219,7 +2219,7 @@ MMFFAngleCollection *MMFFAngleCollection::getMMFFAngle(
     const std::string &mmffAngle) {
   if (!ds_instance) {
     ds_instance = new MMFFAngleCollection(mmffAngle);
-  } else if (mmffAngle != "") {
+  } else if (!mmffAngle.empty()) {
     delete ds_instance;
     ds_instance = new MMFFAngleCollection(mmffAngle);
   }
@@ -2227,7 +2227,7 @@ MMFFAngleCollection *MMFFAngleCollection::getMMFFAngle(
 }
 
 MMFFAngleCollection::MMFFAngleCollection(std::string mmffAngle) {
-  if (mmffAngle == "") {
+  if (mmffAngle.empty()) {
     unsigned int i = 0;
     while (defaultMMFFAngleData[i] != "EOS") {
       mmffAngle += defaultMMFFAngleData[i];
@@ -2239,7 +2239,7 @@ MMFFAngleCollection::MMFFAngleCollection(std::string mmffAngle) {
   std::string inLine = RDKit::getLine(inStream);
   while (!(inStream.eof())) {
     if (inLine[0] != '*') {
-      MMFFAngle mmffAngleObj;
+      MMFFAngle mmffAngleObj{};
       boost::char_separator<char> tabSep("\t");
       tokenizer tokens(inLine, tabSep);
       tokenizer::iterator token = tokens.begin();
@@ -4653,7 +4653,7 @@ MMFFStbnCollection *MMFFStbnCollection::getMMFFStbn(
     const std::string &mmffStbn) {
   if (!ds_instance) {
     ds_instance = new MMFFStbnCollection(mmffStbn);
-  } else if (mmffStbn != "") {
+  } else if (!mmffStbn.empty()) {
     delete ds_instance;
     ds_instance = new MMFFStbnCollection(mmffStbn);
   }
@@ -4661,7 +4661,7 @@ MMFFStbnCollection *MMFFStbnCollection::getMMFFStbn(
 }
 
 MMFFStbnCollection::MMFFStbnCollection(std::string mmffStbn) {
-  if (mmffStbn == "") {
+  if (mmffStbn.empty()) {
     mmffStbn = defaultMMFFStbn;
   }
   std::istringstream inStream(mmffStbn);
@@ -5016,7 +5016,7 @@ MMFFDfsbCollection *MMFFDfsbCollection::getMMFFDfsb(
     const std::string &mmffDfsb) {
   if (!ds_instance) {
     ds_instance = new MMFFDfsbCollection(mmffDfsb);
-  } else if (mmffDfsb != "") {
+  } else if (!mmffDfsb.empty()) {
     delete ds_instance;
     ds_instance = new MMFFDfsbCollection(mmffDfsb);
   }
@@ -5024,14 +5024,14 @@ MMFFDfsbCollection *MMFFDfsbCollection::getMMFFDfsb(
 }
 
 MMFFDfsbCollection::MMFFDfsbCollection(std::string mmffDfsb) {
-  if (mmffDfsb == "") {
+  if (mmffDfsb.empty()) {
     mmffDfsb = defaultMMFFDfsb;
   }
   std::istringstream inStream(mmffDfsb);
   std::string inLine = RDKit::getLine(inStream);
   while (!(inStream.eof())) {
     if (inLine[0] != '*') {
-      MMFFStbn mmffStbnObj;
+      MMFFStbn mmffStbnObj{};
       boost::char_separator<char> tabSep("\t");
       tokenizer tokens(inLine, tabSep);
       tokenizer::iterator token = tokens.begin();
@@ -5101,7 +5101,7 @@ MMFFOopCollection *MMFFOopCollection::getMMFFOop(const bool isMMFFs,
   unsigned int i = (isMMFFs ? 1 : 0);
   if (!ds_instance[i]) {
     ds_instance[i] = new MMFFOopCollection(isMMFFs, mmffOop);
-  } else if (mmffOop != "") {
+  } else if (!mmffOop.empty()) {
     delete ds_instance[i];
     ds_instance[i] = new MMFFOopCollection(isMMFFs, mmffOop);
   }
@@ -5109,14 +5109,14 @@ MMFFOopCollection *MMFFOopCollection::getMMFFOop(const bool isMMFFs,
 }
 
 MMFFOopCollection::MMFFOopCollection(const bool isMMFFs, std::string mmffOop) {
-  if (mmffOop == "") {
+  if (mmffOop.empty()) {
     mmffOop = (isMMFFs ? defaultMMFFsOop : defaultMMFFOop);
   }
   std::istringstream inStream(mmffOop);
   std::string inLine = RDKit::getLine(inStream);
   while (!(inStream.eof())) {
     if (inLine[0] != '*') {
-      MMFFOop mmffOopObj;
+      MMFFOop mmffOopObj{};
       boost::char_separator<char> tabSep("\t");
       tokenizer tokens(inLine, tabSep);
       tokenizer::iterator token = tokens.begin();
@@ -5427,7 +5427,7 @@ MMFFTorCollection *MMFFTorCollection::getMMFFTor(const bool isMMFFs,
   unsigned int i = (isMMFFs ? 1 : 0);
   if (!ds_instance[i]) {
     ds_instance[i] = new MMFFTorCollection(isMMFFs, mmffTor);
-  } else if (mmffTor != "") {
+  } else if (!mmffTor.empty()) {
     delete ds_instance[i];
     ds_instance[i] = new MMFFTorCollection(isMMFFs, mmffTor);
   }
@@ -5435,14 +5435,14 @@ MMFFTorCollection *MMFFTorCollection::getMMFFTor(const bool isMMFFs,
 }
 
 MMFFTorCollection::MMFFTorCollection(const bool isMMFFs, std::string mmffTor) {
-  if (mmffTor == "") {
+  if (mmffTor.empty()) {
     mmffTor = (isMMFFs ? defaultMMFFsTor : defaultMMFFTor);
   }
   std::istringstream inStream(mmffTor);
   std::string inLine = RDKit::getLine(inStream);
   while (!(inStream.eof())) {
     if (inLine[0] != '*') {
-      MMFFTor mmffTorObj;
+      MMFFTor mmffTorObj{};
       boost::char_separator<char> tabSep("\t");
       tokenizer tokens(inLine, tabSep);
       tokenizer::iterator token = tokens.begin();
@@ -8436,7 +8436,7 @@ extern const std::string defaultMMFFVdW;
 MMFFVdWCollection *MMFFVdWCollection::getMMFFVdW(const std::string &mmffVdW) {
   if (!ds_instance) {
     ds_instance = new MMFFVdWCollection(mmffVdW);
-  } else if (mmffVdW != "") {
+  } else if (!mmffVdW.empty()) {
     delete ds_instance;
     ds_instance = new MMFFVdWCollection(mmffVdW);
   }
@@ -8444,7 +8444,7 @@ MMFFVdWCollection *MMFFVdWCollection::getMMFFVdW(const std::string &mmffVdW) {
 }
 
 MMFFVdWCollection::MMFFVdWCollection(std::string mmffVdW) {
-  if (mmffVdW == "") {
+  if (mmffVdW.empty()) {
     mmffVdW = defaultMMFFVdW;
   }
   std::istringstream inStream(mmffVdW);
@@ -8468,7 +8468,7 @@ MMFFVdWCollection::MMFFVdWCollection(std::string mmffVdW) {
         this->DAEPS = boost::lexical_cast<double>(*token);
         ++token;
       } else {
-        MMFFVdW mmffVdWObj;
+        MMFFVdW mmffVdWObj{};
 #ifdef RDKIT_MMFF_PARAMS_USE_STD_MAP
         unsigned int atomType = boost::lexical_cast<unsigned int>(*token);
 #else

--- a/Code/ForceField/MMFF/Params.cpp
+++ b/Code/ForceField/MMFF/Params.cpp
@@ -79,7 +79,7 @@ MMFFDefCollection::MMFFDefCollection(std::string mmffDef) {
   unsigned int atomType;
   while (!(inStream.eof())) {
     if (inLine[0] != '*') {
-      MMFFDef mmffDefObj{};
+      MMFFDef mmffDefObj;
       boost::char_separator<char> tabSep("\t");
       tokenizer tokens(inLine, tabSep);
       tokenizer::iterator token = tokens.begin();
@@ -472,7 +472,7 @@ MMFFPropCollection::MMFFPropCollection(std::string mmffProp) {
   std::string inLine = RDKit::getLine(inStream);
   while (!(inStream.eof())) {
     if (inLine[0] != '*') {
-      MMFFProp mmffPropObj{};
+      MMFFProp mmffPropObj;
       boost::char_separator<char> tabSep("\t");
       tokenizer tokens(inLine, tabSep);
       tokenizer::iterator token = tokens.begin();
@@ -644,7 +644,7 @@ MMFFPBCICollection::MMFFPBCICollection(std::string mmffPBCI) {
   std::string inLine = RDKit::getLine(inStream);
   while (!(inStream.eof())) {
     if (inLine[0] != '*') {
-      MMFFPBCI mmffPBCIObj{};
+      MMFFPBCI mmffPBCIObj;
       boost::char_separator<char> tabSep("\t");
       tokenizer tokens(inLine, tabSep);
       tokenizer::iterator token = tokens.begin();
@@ -802,7 +802,7 @@ MMFFChgCollection::MMFFChgCollection(std::string mmffChg) {
   std::string inLine = RDKit::getLine(inStream);
   while (!(inStream.eof())) {
     if (inLine[0] != '*') {
-      MMFFChg mmffChgObj{};
+      MMFFChg mmffChgObj;
       boost::char_separator<char> tabSep("\t");
       tokenizer tokens(inLine, tabSep);
       tokenizer::iterator token = tokens.begin();
@@ -1946,7 +1946,7 @@ MMFFBndkCollection::MMFFBndkCollection(std::string mmffBndk) {
   std::string inLine = RDKit::getLine(inStream);
   while (!(inStream.eof())) {
     if (inLine[0] != '*') {
-      MMFFBond mmffBondObj{};
+      MMFFBond mmffBondObj;
       boost::char_separator<char> tabSep("\t");
       tokenizer tokens(inLine, tabSep);
       tokenizer::iterator token = tokens.begin();
@@ -2074,7 +2074,7 @@ MMFFHerschbachLaurieCollection::MMFFHerschbachLaurieCollection(
   std::string inLine = RDKit::getLine(inStream);
   while (!(inStream.eof())) {
     if (inLine[0] != '*') {
-      MMFFHerschbachLaurie mmffHerschbachLaurieObj{};
+      MMFFHerschbachLaurie mmffHerschbachLaurieObj;
       boost::char_separator<char> tabSep("\t");
       tokenizer tokens(inLine, tabSep);
       tokenizer::iterator token = tokens.begin();
@@ -2164,7 +2164,7 @@ MMFFCovRadPauEleCollection::MMFFCovRadPauEleCollection(
   std::string inLine = RDKit::getLine(inStream);
   while (!(inStream.eof())) {
     if (inLine[0] != '*') {
-      MMFFCovRadPauEle mmffCovRadPauEleObj{};
+      MMFFCovRadPauEle mmffCovRadPauEleObj;
       boost::char_separator<char> tabSep("\t");
       tokenizer tokens(inLine, tabSep);
       tokenizer::iterator token = tokens.begin();
@@ -2239,7 +2239,7 @@ MMFFAngleCollection::MMFFAngleCollection(std::string mmffAngle) {
   std::string inLine = RDKit::getLine(inStream);
   while (!(inStream.eof())) {
     if (inLine[0] != '*') {
-      MMFFAngle mmffAngleObj{};
+      MMFFAngle mmffAngleObj;
       boost::char_separator<char> tabSep("\t");
       tokenizer tokens(inLine, tabSep);
       tokenizer::iterator token = tokens.begin();
@@ -5031,7 +5031,7 @@ MMFFDfsbCollection::MMFFDfsbCollection(std::string mmffDfsb) {
   std::string inLine = RDKit::getLine(inStream);
   while (!(inStream.eof())) {
     if (inLine[0] != '*') {
-      MMFFStbn mmffStbnObj{};
+      MMFFStbn mmffStbnObj;
       boost::char_separator<char> tabSep("\t");
       tokenizer tokens(inLine, tabSep);
       tokenizer::iterator token = tokens.begin();
@@ -5116,7 +5116,7 @@ MMFFOopCollection::MMFFOopCollection(const bool isMMFFs, std::string mmffOop) {
   std::string inLine = RDKit::getLine(inStream);
   while (!(inStream.eof())) {
     if (inLine[0] != '*') {
-      MMFFOop mmffOopObj{};
+      MMFFOop mmffOopObj;
       boost::char_separator<char> tabSep("\t");
       tokenizer tokens(inLine, tabSep);
       tokenizer::iterator token = tokens.begin();
@@ -5442,7 +5442,7 @@ MMFFTorCollection::MMFFTorCollection(const bool isMMFFs, std::string mmffTor) {
   std::string inLine = RDKit::getLine(inStream);
   while (!(inStream.eof())) {
     if (inLine[0] != '*') {
-      MMFFTor mmffTorObj{};
+      MMFFTor mmffTorObj;
       boost::char_separator<char> tabSep("\t");
       tokenizer tokens(inLine, tabSep);
       tokenizer::iterator token = tokens.begin();
@@ -8468,7 +8468,7 @@ MMFFVdWCollection::MMFFVdWCollection(std::string mmffVdW) {
         this->DAEPS = boost::lexical_cast<double>(*token);
         ++token;
       } else {
-        MMFFVdW mmffVdWObj{};
+        MMFFVdW mmffVdWObj;
 #ifdef RDKIT_MMFF_PARAMS_USE_STD_MAP
         unsigned int atomType = boost::lexical_cast<unsigned int>(*token);
 #else

--- a/Code/Geometry/testTransforms.cpp
+++ b/Code/Geometry/testTransforms.cpp
@@ -22,13 +22,13 @@
 using namespace RDGeom;
 using namespace std;
 
-double ptEq(const Point3D pt1, const Point3D pt2, double val = 1.e-8) {
-  return ((abs(pt1.x - pt2.x) < val) && (abs(pt1.y - pt2.y) < val) &&
-          (abs(pt1.z - pt2.z) < val));
+bool ptEq(const Point3D pt1, const Point3D pt2, double val = 1.e-8) {
+  return ((fabs(pt1.x - pt2.x) < val) && (fabs(pt1.y - pt2.y) < val) &&
+          (fabs(pt1.z - pt2.z) < val));
 }
 
-double ptEq(const Point2D pt1, const Point2D pt2, double val = 1.e-8) {
-  return ((abs(pt1.x - pt2.x) < val) && (abs(pt1.y - pt2.y) < val));
+bool ptEq(const Point2D pt1, const Point2D pt2, double val = 1.e-8) {
+  return ((fabs(pt1.x - pt2.x) < val) && (fabs(pt1.y - pt2.y) < val));
 }
 
 double randNum(double x = 5) {
@@ -54,39 +54,39 @@ void testPointND() {
   ep[4] = 0.6742;
 
   for (i = 0; i < 5; ++i) {
-    TEST_ASSERT(abs(pt[i] - ep[i]) < 1.e-4);
+    TEST_ASSERT(fabs(pt[i] - ep[i]) < 1.e-4);
   }
 
   PointND pt2(pt);
   for (i = 0; i < 5; ++i) {
-    TEST_ASSERT(abs(pt2[i] - ep[i]) < 1.e-4);
+    TEST_ASSERT(fabs(pt2[i] - ep[i]) < 1.e-4);
   }
 
   pt2 += pt;
   for (i = 0; i < 5; ++i) {
-    TEST_ASSERT(abs(pt2[i] - 2 * ep[i]) < 1.e-4);
+    TEST_ASSERT(fabs(pt2[i] - 2 * ep[i]) < 1.e-4);
   }
 
   pt2 /= 2.0;
   for (i = 0; i < 5; ++i) {
-    TEST_ASSERT(abs(pt2[i] - ep[i]) < 1.e-4);
+    TEST_ASSERT(fabs(pt2[i] - ep[i]) < 1.e-4);
   }
 
   pt2 -= pt;
   for (i = 0; i < 5; ++i) {
-    TEST_ASSERT(abs(pt2[i] - 0.0) < 1.e-4);
+    TEST_ASSERT(fabs(pt2[i] - 0.0) < 1.e-4);
   }
   pt2 = pt;
   pt2 *= 2.;
   for (i = 0; i < 5; ++i) {
-    TEST_ASSERT(abs(pt2[i] - 2 * ep[i]) < 1.e-4);
+    TEST_ASSERT(fabs(pt2[i] - 2 * ep[i]) < 1.e-4);
   }
 
   double dp = pt.dotProduct(pt2);
-  TEST_ASSERT(abs(dp - 2.0) < 1.e-4);
+  TEST_ASSERT(fabs(dp - 2.0) < 1.e-4);
 
   double angle = pt.angleTo(pt2);
-  TEST_ASSERT(abs(angle - 0.0) < 1.e-4);
+  TEST_ASSERT(fabs(angle - 0.0) < 1.e-4);
 }
 
 void testPointOps3D() {
@@ -95,20 +95,20 @@ void testPointOps3D() {
   Point3D pt2(-1, 0, 0);
   Point3D pt3(0, -1, 0);
 
-  TEST_ASSERT(abs(pt0.angleTo(pt0)) < 1e-4);
-  TEST_ASSERT(abs(pt0.angleTo(pt1) - M_PI / 2.) < 1e-4);
-  TEST_ASSERT(abs(pt0.angleTo(pt2) - M_PI) < 1e-4);
-  TEST_ASSERT(abs(pt0.angleTo(pt3) - M_PI / 2.) < 1e-4);
+  TEST_ASSERT(fabs(pt0.angleTo(pt0)) < 1e-4);
+  TEST_ASSERT(fabs(pt0.angleTo(pt1) - M_PI / 2.) < 1e-4);
+  TEST_ASSERT(fabs(pt0.angleTo(pt2) - M_PI) < 1e-4);
+  TEST_ASSERT(fabs(pt0.angleTo(pt3) - M_PI / 2.) < 1e-4);
 
-  TEST_ASSERT(abs(pt1.angleTo(pt0) - M_PI / 2.) < 1e-4);
-  TEST_ASSERT(abs(pt1.angleTo(pt1)) < 1e-4);
-  TEST_ASSERT(abs(pt1.angleTo(pt2) - M_PI / 2.) < 1e-4);
-  TEST_ASSERT(abs(pt1.angleTo(pt3) - M_PI) < 1e-4);
+  TEST_ASSERT(fabs(pt1.angleTo(pt0) - M_PI / 2.) < 1e-4);
+  TEST_ASSERT(fabs(pt1.angleTo(pt1)) < 1e-4);
+  TEST_ASSERT(fabs(pt1.angleTo(pt2) - M_PI / 2.) < 1e-4);
+  TEST_ASSERT(fabs(pt1.angleTo(pt3) - M_PI) < 1e-4);
 
-  TEST_ASSERT(abs(pt0.signedAngleTo(pt0)) < 1e-4);
-  TEST_ASSERT(abs(pt0.signedAngleTo(pt1) - M_PI / 2.) < 1e-4);
-  TEST_ASSERT(abs(pt0.signedAngleTo(pt2) - M_PI) < 1e-4);
-  TEST_ASSERT(abs(pt0.signedAngleTo(pt3) - 3. * M_PI / 2.) < 1e-4);
+  TEST_ASSERT(fabs(pt0.signedAngleTo(pt0)) < 1e-4);
+  TEST_ASSERT(fabs(pt0.signedAngleTo(pt1) - M_PI / 2.) < 1e-4);
+  TEST_ASSERT(fabs(pt0.signedAngleTo(pt2) - M_PI) < 1e-4);
+  TEST_ASSERT(fabs(pt0.signedAngleTo(pt3) - 3. * M_PI / 2.) < 1e-4);
 
   Point3D diffPt = pt0.directionVector(pt1);
   Point3D ref(-sqrt(2.) / 2., sqrt(2.) / 2., 0);
@@ -120,20 +120,20 @@ void testPointOps2D() {
   Point2D pt2(-1, 0);
   Point2D pt3(0, -1);
 
-  TEST_ASSERT(abs(pt0.angleTo(pt0)) < 1e-4);
-  TEST_ASSERT(abs(pt0.angleTo(pt1) - M_PI / 2.) < 1e-4);
-  TEST_ASSERT(abs(pt0.angleTo(pt2) - M_PI) < 1e-4);
-  TEST_ASSERT(abs(pt0.angleTo(pt3) - M_PI / 2.) < 1e-4);
+  TEST_ASSERT(fabs(pt0.angleTo(pt0)) < 1e-4);
+  TEST_ASSERT(fabs(pt0.angleTo(pt1) - M_PI / 2.) < 1e-4);
+  TEST_ASSERT(fabs(pt0.angleTo(pt2) - M_PI) < 1e-4);
+  TEST_ASSERT(fabs(pt0.angleTo(pt3) - M_PI / 2.) < 1e-4);
 
-  TEST_ASSERT(abs(pt1.angleTo(pt0) - M_PI / 2.) < 1e-4);
-  TEST_ASSERT(abs(pt1.angleTo(pt1)) < 1e-4);
-  TEST_ASSERT(abs(pt1.angleTo(pt2) - M_PI / 2.) < 1e-4);
-  TEST_ASSERT(abs(pt1.angleTo(pt3) - M_PI) < 1e-4);
+  TEST_ASSERT(fabs(pt1.angleTo(pt0) - M_PI / 2.) < 1e-4);
+  TEST_ASSERT(fabs(pt1.angleTo(pt1)) < 1e-4);
+  TEST_ASSERT(fabs(pt1.angleTo(pt2) - M_PI / 2.) < 1e-4);
+  TEST_ASSERT(fabs(pt1.angleTo(pt3) - M_PI) < 1e-4);
 
-  TEST_ASSERT(abs(pt0.signedAngleTo(pt0)) < 1e-4);
-  TEST_ASSERT(abs(pt0.signedAngleTo(pt1) - M_PI / 2.) < 1e-4);
-  TEST_ASSERT(abs(pt0.signedAngleTo(pt2) - M_PI) < 1e-4);
-  TEST_ASSERT(abs(pt0.signedAngleTo(pt3) - 3. * M_PI / 2.) < 1e-4);
+  TEST_ASSERT(fabs(pt0.signedAngleTo(pt0)) < 1e-4);
+  TEST_ASSERT(fabs(pt0.signedAngleTo(pt1) - M_PI / 2.) < 1e-4);
+  TEST_ASSERT(fabs(pt0.signedAngleTo(pt2) - M_PI) < 1e-4);
+  TEST_ASSERT(fabs(pt0.signedAngleTo(pt3) - 3. * M_PI / 2.) < 1e-4);
 
   Point2D diffPt = pt0.directionVector(pt1);
   Point2D ref(-sqrt(2.) / 2., sqrt(2.) / 2.);
@@ -145,8 +145,8 @@ void test12D() {
   Transform2D trans;
   trans.TransformPoint(pt);
 
-  CHECK_INVARIANT(abs(pt.x - 1.0) < 1.e-8, "");
-  CHECK_INVARIANT(abs(pt.y - 2.0) < 1.e-8, "");
+  CHECK_INVARIANT(fabs(pt.x - 1.0) < 1.e-8, "");
+  CHECK_INVARIANT(fabs(pt.y - 2.0) < 1.e-8, "");
 
   Point2D ref1(randNum(), randNum());
   Point2D ref2(randNum(), randNum());
@@ -166,8 +166,8 @@ void test12D() {
 
   // make sure pt1 overlaps ref1
   Point2D dif1 = pt1 - ref1;
-  CHECK_INVARIANT(abs(dif1.x) < 1.e-8, "");
-  CHECK_INVARIANT(abs(dif1.y) < 1.e-8, "");
+  CHECK_INVARIANT(fabs(dif1.x) < 1.e-8, "");
+  CHECK_INVARIANT(fabs(dif1.y) < 1.e-8, "");
 
   // now check that the angle between the two vectors (ref2 - ref1) and
   // (pt2 - pt1) is zero
@@ -176,7 +176,7 @@ void test12D() {
   rvec.normalize();
   pvec.normalize();
   double pdot = rvec.dotProduct(pvec);
-  CHECK_INVARIANT(abs(pdot - 1.0) < 1.e-8, "");
+  CHECK_INVARIANT(fabs(pdot - 1.0) < 1.e-8, "");
 
   // compute the reverse transform and make sure we are basically getting the
   // identity

--- a/Code/GraphMol/ChemReactions/Enumerate/EvenSamplePairs.cpp
+++ b/Code/GraphMol/ChemReactions/Enumerate/EvenSamplePairs.cpp
@@ -144,7 +144,6 @@ bool EvenSamplePairsStrategy::try_add(size_t seed) {
       used_count[i] = 0;
       for (size_t j = 0; j < rgroups[i]; ++j) {
         var_used[i][j]--;
-        assert(var_used[i][j] >= 0);
         if (var_used[i][j] > 0) used_count[i]++;
       }
     }  // end scan
@@ -273,4 +272,4 @@ std::string EvenSamplePairsStrategy::stats() const {
      << std::endl;
   return ss.str();
 }
-}
+}  // namespace RDKit

--- a/Code/GraphMol/ChemReactions/Enumerate/testEnumerate.cpp
+++ b/Code/GraphMol/ChemReactions/Enumerate/testEnumerate.cpp
@@ -369,19 +369,11 @@ void testGithub1657() {
   BOOST_LOG(rdInfoLog) << "\tdone" << std::endl;
 }
 #else
-void testGithub1657() {
-}
+void testGithub1657() {}
 #endif
 
-
-int main(int argc, char *argv[]) {
+int main() {
   RDLog::InitLogs();
-  bool doLong = false;
-  if (argc > 1) {
-    if (!strncmp(argv[1], "-l", 2)) {
-      doLong = true;
-    }
-  }
 #if 1
   testSamplers();
   testEvenSamplers();

--- a/Code/GraphMol/Depictor/RDDepictor.cpp
+++ b/Code/GraphMol/Depictor/RDDepictor.cpp
@@ -418,7 +418,8 @@ unsigned int compute2DCoordsMimicDistMat(
     RDKit::ROMol &mol, const DOUBLE_SMART_PTR *dmat, bool canonOrient,
     bool clearConfs, double weightDistMat, unsigned int nFlipsPerSample,
     unsigned int nSamples, int sampleSeed, bool permuteDeg4Nodes,
-    bool /* forceRDKit */) {
+    bool forceRDKit) {
+  RDUNUSED_PARAM(forceRDKit);
   // storage for pieces of a molecule/s that are embedded in 2D
   std::list<EmbeddedFrag> efrags;
   computeInitialCoords(mol, nullptr, efrags);

--- a/Code/GraphMol/Depictor/RDDepictor.cpp
+++ b/Code/GraphMol/Depictor/RDDepictor.cpp
@@ -418,7 +418,7 @@ unsigned int compute2DCoordsMimicDistMat(
     RDKit::ROMol &mol, const DOUBLE_SMART_PTR *dmat, bool canonOrient,
     bool clearConfs, double weightDistMat, unsigned int nFlipsPerSample,
     unsigned int nSamples, int sampleSeed, bool permuteDeg4Nodes,
-    bool forceRDKit) {
+    bool /* forceRDKit */) {
   // storage for pieces of a molecule/s that are embedded in 2D
   std::list<EmbeddedFrag> efrags;
   computeInitialCoords(mol, nullptr, efrags);

--- a/Code/GraphMol/Descriptors/AUTOCORR2D.cpp
+++ b/Code/GraphMol/Descriptors/AUTOCORR2D.cpp
@@ -46,7 +46,7 @@ namespace {
 MolData3Ddescriptors moldata3D;
 
 // this is the Broto-Moreau 2D descriptors (centered or not)
-void get2DautocorrelationDesc(double* dist, int numAtoms, const ROMol& mol,
+void get2DautocorrelationDesc(const double* dist, unsigned int numAtoms, const ROMol& mol,
                               std::vector<double>& res) {
   std::vector<double> wp = moldata3D.GetRelativePol(mol);
   std::vector<double> wm = moldata3D.GetRelativeMW(mol);
@@ -109,7 +109,7 @@ void get2DautocorrelationDesc(double* dist, int numAtoms, const ROMol& mol,
 
     for (unsigned int t = 0; t < 6; ++t) {
       if (maxkVertexPairs > 0) {
-        TDBmat[t * 8 + k] = log(TDBmat[t * 8 + k] + 1);
+        TDBmat[t * 8 + k] = log1p(TDBmat[t * 8 + k]);
         TDBmatG[t * 8 + k] = TDBmatG[t * 8 + k]/ squaresumdiff[t] / maxkVertexPairs * (numAtoms-1) / 2.0;
         TDBmatM[t * 8 + k] = TDBmatM[t * 8 + k]/ squaresumdiff[t] / maxkVertexPairs * numAtoms ;
 
@@ -149,7 +149,7 @@ void get2DautocorrelationDesc(double* dist, int numAtoms, const ROMol& mol,
 }
 
     // this is the Broto-Moreau 2D descriptors (centered or not)
-    void get2DautocorrelationDescCustom(double* dist, int numAtoms, const ROMol& mol,
+    void get2DautocorrelationDescCustom(const double* dist, unsigned int numAtoms, const ROMol& mol,
                                   std::vector<double>& res,
                                   const std::string &customAtomPropName) {
 
@@ -187,7 +187,7 @@ void get2DautocorrelationDesc(double* dist, int numAtoms, const ROMol& mol,
 
           for (unsigned int t = 0; t < 1; ++t) {
           if (maxkVertexPairs > 0) {
-            TDBmat[k] = log(TDBmat[k] + 1);
+            TDBmat[k] = log1p(TDBmat[k]);
             TDBmatG[k] = TDBmatG[k]/ squaresumdiff / maxkVertexPairs * (numAtoms-1) / 2.0;
             TDBmatM[k] = TDBmatM[k]/ squaresumdiff / maxkVertexPairs * numAtoms ;
 
@@ -216,11 +216,11 @@ void get2DautocorrelationDesc(double* dist, int numAtoms, const ROMol& mol,
       wc.clear();
     }
 
-    void Get2Dauto(double* dist, int numAtoms, const ROMol& mol,
+    void Get2Dauto(const double* dist, unsigned int numAtoms, const ROMol& mol,
                    std::vector<double>& res) {
       get2DautocorrelationDesc(dist, numAtoms, mol, res);
     }
-    void Get2Dautoone(double* dist, int numAtoms, const ROMol& mol,
+    void Get2Dautoone(const double* dist, unsigned int numAtoms, const ROMol& mol,
                 std::vector<double>& res, const std::string &customAtomPropName) {
       get2DautocorrelationDescCustom(dist, numAtoms, mol, res, customAtomPropName);
     }
@@ -228,9 +228,9 @@ void get2DautocorrelationDesc(double* dist, int numAtoms, const ROMol& mol,
 
 void AUTOCORR2D(const ROMol& mol, std::vector<double>& result,
                 const std::string &customAtomPropName) {
-  int numAtoms = mol.getNumAtoms();
+  unsigned int numAtoms = mol.getNumAtoms();
   double* dist = MolOps::getDistanceMat(mol, false);  // topological matrix
-  if (customAtomPropName != "") {
+  if (!customAtomPropName.empty()) {
     result.clear();
     result.resize(32);
     Get2Dautoone(dist, numAtoms, mol, result, customAtomPropName);

--- a/Code/GraphMol/Descriptors/AUTOCORR3D.cpp
+++ b/Code/GraphMol/Descriptors/AUTOCORR3D.cpp
@@ -199,7 +199,6 @@ void get3DautocorrelationDesc(double* dist3D, double* topologicaldistance,
       }
     }
 
-
     void Get3Dauto(double* dist3D, double* topologicaldistance, int numAtoms,
                const ROMol& mol, std::vector<double>& res) {
   // AUTOCORRNAMES={"TDB01u","TDB02u","TDB03u","TDB04u","TDB05u","TDB06u","TDB07u","TDB08u","TDB09u","TDB10u","TDB01m","TDB02m","TDB03m","TDB04m","TDB05m","TDB06m","TDB07m","TDB08m","TDB09m","TDB10m","TDB01v","TDB02v","TDB03v","TDB04v","TDB05v","TDB06v","TDB07v","TDB08v","TDB09v","TDB10v","TDB01e","TDB02e","TDB03e","TDB04e","TDB05e","TDB06e","TDB07e","TDB08e","TDB09e","TDB10e","TDB01p","TDB02p","TDB03p","TDB04p","TDB05p","TDB06p","TDB07p","TDB08p","TDB09p","TDB10p","TDB01i","TDB02i","TDB03i","TDB04i","TDB05i","TDB06i","TDB07i","TDB08i","TDB09i","TDB10i","TDB01s","TDB02s","TDB03s","TDB04s","TDB05s","TDB06s","TDB07s","TDB08s","TDB09s","TDB10s","TDB01r","TDB02r","TDB03r","TDB04r","TDB05r","TDB06r","TDB07r","TDB08r","TDB09r","TDB10r"};
@@ -218,8 +217,6 @@ void AUTOCORR3D(const ROMol& mol, std::vector<double>& res, int confId,
   PRECONDITION(mol.getNumConformers() >= 1, "molecule has no conformers")
   int numAtoms = mol.getNumAtoms();
 
-  const Conformer& conf = mol.getConformer(confId);
-
   double* topologicaldistance =
       MolOps::getDistanceMat(mol, false);  // topological matrix
   double* dist3D =
@@ -233,8 +230,6 @@ void AUTOCORR3D(const ROMol& mol, std::vector<double>& res, int confId,
       res.resize(80);
       Get3Dauto(dist3D, topologicaldistance, numAtoms, mol, res);
     }
-
-
 }
 }  // end of Descriptors namespace
 }  // end of RDKit namespace

--- a/Code/GraphMol/Descriptors/Crippen.cpp
+++ b/Code/GraphMol/Descriptors/Crippen.cpp
@@ -168,7 +168,7 @@ CrippenParamCollection::CrippenParamCollection(const std::string &paramData) {
       if (*token != "") {
         try {
           paramObj.mr = boost::lexical_cast<double>(*token);
-        } catch (boost::bad_lexical_cast) {
+        } catch (boost::bad_lexical_cast &) {
           paramObj.mr = 0.0;
         }
       } else {

--- a/Code/GraphMol/Descriptors/EEM.cpp
+++ b/Code/GraphMol/Descriptors/EEM.cpp
@@ -136,7 +136,7 @@ std::unique_ptr<double[]> getEEMMatrix(double *dist3D, unsigned int n,
   for (unsigned int i = 0; i < n; i++) {
     unsigned int t = EEMatoms.EEMatomtype[i];
     unsigned int idx = EEMatoms.Atomindex[i];
-    double v;
+    double v = 0.0;
     if (t == 1) {
       v = B1[idx];
     }

--- a/Code/GraphMol/Descriptors/GETAWAY.cpp
+++ b/Code/GraphMol/Descriptors/GETAWAY.cpp
@@ -47,7 +47,7 @@
 #include <Numerics/SquareMatrix.h>
 #include <Numerics/SymmMatrix.h>
 #include <boost/foreach.hpp>
-#include <math.h>
+#include <cmath>
 #include <Eigen/Dense>
 #include <Eigen/SVD>
 #include <iostream>
@@ -63,7 +63,7 @@ namespace Descriptors {
 
 namespace {
 
-MolData3Ddescriptors moldata3D;
+MolData3Ddescriptors moldata3D{};
 
 double roundn(double in, int factor) {
   return round(in * pow(10., factor)) / pow(10., factor);
@@ -87,27 +87,23 @@ VectorXd getEigenVect(std::vector<double> v) {
 
 double round_to_n_digits_(double x, int n) {
   char buff[32];
-  sprintf(buff, "%.*g", n, x);  // use g to have significative digits!
+  sprintf(buff, "%.*g", n, x);  // use g to have significant digits!
   return atof(buff);
 }
 
 double round_to_n_digits(double x, int n) {
-  double scale = pow(10.0, ceil(log10(abs(x))) + n);
+  double scale = pow(10.0, ceil(log10(fabs(x))) + n);
   return round(x * scale) / scale;
 }
 
 bool IsClose(double a, double b, int n) {
-  bool isclose = false;
-  if (fabs(a - b) <= pow(0.1, n) * 1.1) {
-    isclose = true;
-  }
-  return isclose;
+  return (fabs(a - b) <= pow(0.1, n) * 1.1);
 }
 
 int countZeros(std::string ta) {
   int nbzero = 0;
-  for (unsigned int i = 0; i < ta.length(); i++) {
-    if (ta[i] != '0') {
+  for (char i : ta) {
+    if (i != '0') {
       break;
     }
     nbzero = nbzero + 1;
@@ -116,7 +112,7 @@ int countZeros(std::string ta) {
   return nbzero;
 }
 
-bool IsClose2(double a, double b, unsigned int n) {
+bool IsClose2(double a, double b, unsigned int /* precision */) {
   bool isclose = false;
 
   std::string sa, sb;
@@ -126,9 +122,8 @@ bool IsClose2(double a, double b, unsigned int n) {
   sa = outa.str();
   outb << b;
   sb = outb.str();
-  ta = sa.substr(sa.find(".") + 1);
-
-  tb = sb.substr(sb.find(".") + 1);
+  ta = sa.substr(sa.find('.') + 1);
+  tb = sb.substr(sb.find('.') + 1);
 
   // same number of digits!
   if (countZeros(ta) == countZeros(tb)) {
@@ -155,7 +150,7 @@ bool IsClose2(double a, double b, unsigned int n) {
   return isclose;
 }
 
-bool IsClose3(double a, double b, unsigned int n) {
+bool IsClose3(double a, double b, unsigned int /* precision */) {
   bool isclose = false;
   std::string sa, sb;
   std::string ta, tb;
@@ -164,8 +159,8 @@ bool IsClose3(double a, double b, unsigned int n) {
   sa = outa.str();
   outb << b;
   sb = outb.str();
-  ta = sa.substr(sa.find(".") + 1);
-  tb = sb.substr(sb.find(".") + 1);
+  ta = sa.substr(sa.find('.') + 1);
+  tb = sb.substr(sb.find('.') + 1);
   // same number of digits!
   if (ta.length() == tb.length()) {
     // last digit +/-1 deviation only!)
@@ -221,17 +216,13 @@ std::vector<double> clusterArray(std::vector<double> data, double precision) {
 // digit precision)
 // 0.012 and 0.013 are in the same group while 0.014 are not!
 // alternative clustering method not working as in Dragon
-std::vector<double> clusterArray2(std::vector<double> data, int precision) {
+std::vector<double> clusterArray2(std::vector<double> data,
+                                  unsigned int precision) {
   std::vector<double> Store;
 
   // sort the input data descend order!
   std::sort(data.begin(), data.end(), std::greater<double>());
-  std::deque<double> B;
-  for (unsigned int i = 0; i < data.size(); i++) {
-    B.push_back(data[i]);
-    // std::cout << data[i] << ",";
-  }
-  // std::cout << "\n";
+  std::deque<double> B(data.begin(), data.end());
 
   int count = 0;
   while (!B.empty()) {
@@ -265,37 +256,36 @@ std::vector<double> clusterArray2(std::vector<double> data, int precision) {
   return Store;
 }
 
-double* GetGeodesicMatrix(double* dist, int lag, int numAtoms) {
+std::vector<double> GetGeodesicMatrix(const double* dist, int lag,
+                                      int numAtoms) {
   PRECONDITION(dist!=nullptr, "bad array");
 
   int sizeArray = numAtoms * numAtoms;
-  double* Geodesic = new double[sizeArray];
-  for (int i = 0; i < sizeArray; i++) {
-    if (dist[i] == lag)
-      Geodesic[i] = 1;
-    else
-      Geodesic[i] = 0;
-  }
+  std::vector<double> Geodesic;
+  Geodesic.reserve(sizeArray);
+  std::transform(dist, dist + sizeArray, Geodesic.begin(),
+                 [&lag](const double& dist) { return int(dist == lag); });
 
   return Geodesic;
 }
 
-JacobiSVD<MatrixXd> getSVD(MatrixXd A) {
+JacobiSVD<MatrixXd> getSVD(const MatrixXd& A) {
   JacobiSVD<MatrixXd> mysvd(A, ComputeThinU | ComputeThinV);
   return mysvd;
 }
 
-MatrixXd GetPinv(MatrixXd A) {
+MatrixXd GetPinv(const MatrixXd& A) {
   JacobiSVD<MatrixXd> svd = getSVD(A);
   double pinvtoler = 1.e-3;  // choose your tolerance wisely!
   VectorXd vs = svd.singularValues();
   VectorXd vsinv = svd.singularValues();
 
   for (unsigned int i = 0; i < A.cols(); ++i) {
-    if (vs(i) > pinvtoler)
+    if (vs(i) > pinvtoler) {
       vsinv(i) = 1.0 / vs(i);
-    else
+    } else {
       vsinv(i) = 0.0;
+    }
   }
 
   MatrixXd S = vsinv.asDiagonal();
@@ -328,20 +318,16 @@ MatrixXd GetRmatrix(MatrixXd H, MatrixXd DM, int numAtoms) {
 
 std::vector<int> GetHeavyList(const ROMol& mol) {
   int numAtoms = mol.getNumAtoms();
-
   std::vector<int> HeavyList;
+  HeavyList.reserve(numAtoms);
   for (int i = 0; i < numAtoms; ++i) {
     const RDKit::Atom* atom = mol.getAtomWithIdx(i);
-
-    if (atom->getAtomicNum() > 1) {
-      HeavyList.push_back(1);
-    } else
-      HeavyList.push_back(0);
+    HeavyList.push_back(int(atom->getAtomicNum() > 1));
   }
   return HeavyList;
 }
 
-double* AppendDouble(double* w, double* Append, int length, int pos) {
+double* AppendDouble(double* w, const double* Append, int length, int pos) {
   PRECONDITION(w!=nullptr, "bad array");
   PRECONDITION(Append!=nullptr, "bad array");
 
@@ -376,7 +362,7 @@ double getHATS(double W1, double W2, double H1, double H2) {
 
 double getH(double W1, double W2, double H) { return W1 * H * W2; }
 
-double getMax(double* Rk) {
+double getMax(const double* Rk) {
   PRECONDITION(Rk != nullptr,"bad rK");
   double RTp = 0;
   for (int j = 0; j < 8; j++) {
@@ -387,11 +373,9 @@ double getMax(double* Rk) {
   return RTp;
 }
 
-
-
 void getGETAWAYDescCustom(MatrixXd H, MatrixXd R, MatrixXd Adj, int numAtoms,
                         std::vector<int> Heavylist, const ROMol& mol,
-                        std::vector<double>& res, int precision,
+                        std::vector<double>& res, unsigned int precision,
                         const std::string &customAtomPropName) {
       // prepare data for Getaway parameter computation
       // compute parameters
@@ -410,14 +394,14 @@ void getGETAWAYDescCustom(MatrixXd H, MatrixXd R, MatrixXd Adj, int numAtoms,
       double numHeavy = heavyLev.size();
       double ITH0 = numHeavy * log(numHeavy) / log(2.0);
       double ITH = ITH0;
-      for (unsigned int j = 0; j < Clus.size(); j++) {
-        ITH -= Clus[j] * log(Clus[j]) / log(2.0);
+      for (double Clu : Clus) {
+        ITH -= Clu * log(Clu) / log(2.0);
       }
-      res[0] = roundn(ITH, 3);  // issue somethime with this due to cluster
+      res[0] = roundn(ITH, 3);  // issue sometime with this due to cluster
       double ISH = ITH / ITH0;
-      res[1] = roundn(ISH, 3);  // issue somethime with this due to cluster
+      res[1] = roundn(ISH, 3);  // issue sometime with this due to cluster
 
-      // use the PBF to determine 2D vs 3D (with Thresold)
+      // use the PBF to determine 2D vs 3D (with Threshold)
       // determine if this is a plane molecule
       double pbf = RDKit::Descriptors::PBF(mol);
       double D;
@@ -447,9 +431,10 @@ void getGETAWAYDescCustom(MatrixXd H, MatrixXd R, MatrixXd Adj, int numAtoms,
 
       VectorXd EIG = mysvd.singularValues();
 
-      double rcon = getRCON(R, Adj, numAtoms);
+  double rcon = getRCON(R, std::move(Adj), numAtoms);
 
-      std::vector<double> customAtomArray = moldata3D.GetCustomAtomProp(mol,customAtomPropName);
+  std::vector<double> customAtomArray =
+      moldata3D.GetCustomAtomProp(mol, customAtomPropName);
       VectorXd Wc = getEigenVect(customAtomArray);
 
       MatrixXd Bi;
@@ -462,7 +447,7 @@ void getGETAWAYDescCustom(MatrixXd H, MatrixXd R, MatrixXd Adj, int numAtoms,
 
       double* dist =
               MolOps::getDistanceMat(mol, false);  // need to be be set to false to have
-      // topological distance not weigthed!
+      // topological distance not weighted!
 
       Map<MatrixXd> D2(dist, numAtoms, numAtoms);
 
@@ -471,7 +456,6 @@ void getGETAWAYDescCustom(MatrixXd H, MatrixXd R, MatrixXd Adj, int numAtoms,
       HATSct = 0.0;
       H0ct = 0.0;
       R0ct = 0.0;
-
 
       // need to loop other all the D values so <= not <!
       for (int i = 0; i <= Dmax; i++) {
@@ -482,7 +466,6 @@ void getGETAWAYDescCustom(MatrixXd H, MatrixXd R, MatrixXd Adj, int numAtoms,
         HATSc = 0.0;
         H0c = 0.0;
 
-
         if (i == 0) {  // use Bi
           for (int j = 0; j < numAtoms; j++) {
             for (int k = j; k < numAtoms; k++) {
@@ -492,14 +475,13 @@ void getGETAWAYDescCustom(MatrixXd H, MatrixXd R, MatrixXd Adj, int numAtoms,
 
                 if (H(j, k) > 0) {
                   H0c += getH((double)Wc(j), (double)Wc(k), (double)H(j, k));
-
                 }
               }
             }
           }
         }
-        double* Bimat = GetGeodesicMatrix(dist, i, numAtoms);
-        Map<MatrixXd> Bj(Bimat, numAtoms, numAtoms);
+    auto Bimat = GetGeodesicMatrix(dist, i, numAtoms);
+    Map<MatrixXd> Bj(Bimat.data(), numAtoms, numAtoms);
         if (i > 0 && i < 9) {  // use Bj
           for (int j = 0; j < numAtoms - 1; j++) {
             for (int k = j + 1; k < numAtoms; k++) {
@@ -509,7 +491,6 @@ void getGETAWAYDescCustom(MatrixXd H, MatrixXd R, MatrixXd Adj, int numAtoms,
 
                 if (H(j, k) > 0) {
                   H0c += getH((double)Wc(j), (double)Wc(k), (double)H(j, k));
-
                 }
               }
             }
@@ -523,10 +504,8 @@ void getGETAWAYDescCustom(MatrixXd H, MatrixXd R, MatrixXd Adj, int numAtoms,
                 HATSct += 2 * getHATS((double)Wc(j), (double)Wc(k), (double)H(j, j),
                                       (double)H(k, k));
 
-
                 if (H(j, k) > 0) {
                   H0ct += 2 * getH((double)Wc(j), (double)Wc(k), (double)H(j, k));
-
                 }
               }
             }
@@ -536,12 +515,10 @@ void getGETAWAYDescCustom(MatrixXd H, MatrixXd R, MatrixXd Adj, int numAtoms,
         if (i < 9) {
           HATSk[i] = HATSc;
           Hk[i] = H0c;
-
         }
 
         R0c = 0.0;
         Rkmaxc = 0.0;
-
 
         // from 1 to 8
         if (i > 0 && i < 9) {
@@ -564,7 +541,6 @@ void getGETAWAYDescCustom(MatrixXd H, MatrixXd R, MatrixXd Adj, int numAtoms,
 
           Rk[i - 1] = R0c;
           Rp[i - 1] = Rkmaxc;
-
         }
 
         if (i >= 9) {
@@ -579,27 +555,22 @@ void getGETAWAYDescCustom(MatrixXd H, MatrixXd R, MatrixXd Adj, int numAtoms,
             }
           }
         }
-        delete[] Bimat;
       }
 
-      // can be column vs row selecgted that can explain the issue!
+      // can be column vs row selected that can explain the issue!
       double HATSTc = HATSk[0] + HATSct;
       for (int ii = 1; ii < 9; ii++) {
         HATSTc += 2 * HATSk[ii];
-
       }
 
       double HTc = Hk[0] + H0ct;
       for (int ii = 1; ii < 9; ii++) {
         HTc += 2.0 * Hk[ii];
-
       }
 
-
       double RTc = 0.0;
-      for (int ii = 0; ii < 8; ii++) {
-        RTc += 2.0 * Rk[ii];
-
+  for (double rk_ii : Rk) {
+    RTc += 2.0 * rk_ii;
       }
 
       double RTMc = getMax(Rp);
@@ -626,12 +597,9 @@ void getGETAWAYDescCustom(MatrixXd H, MatrixXd R, MatrixXd Adj, int numAtoms,
       res[44] = roundn(RTMc, 3);
 }
 
-
-
-
 void getGETAWAYDesc(MatrixXd H, MatrixXd R, MatrixXd Adj, int numAtoms,
                     std::vector<int> Heavylist, const ROMol& mol,
-                    std::vector<double>& res, int precision) {
+                    std::vector<double>& res, unsigned int precision) {
   // prepare data for Getaway parameter computation
   // compute parameters
 
@@ -649,8 +617,8 @@ void getGETAWAYDesc(MatrixXd H, MatrixXd R, MatrixXd Adj, int numAtoms,
   double numHeavy = heavyLev.size();
   double ITH0 = numHeavy * log(numHeavy) / log(2.0);
   double ITH = ITH0;
-  for (unsigned int j = 0; j < Clus.size(); j++) {
-    ITH -= Clus[j] * log(Clus[j]) / log(2.0);
+  for (double Clu : Clus) {
+    ITH -= Clu * log(Clu) / log(2.0);
   }
   res[0] = roundn(ITH, 3);  // issue somethime with this due to cluster
   double ISH = ITH / ITH0;
@@ -686,7 +654,7 @@ void getGETAWAYDesc(MatrixXd H, MatrixXd R, MatrixXd Adj, int numAtoms,
 
   VectorXd EIG = mysvd.singularValues();
 
-  double rcon = getRCON(R, Adj, numAtoms);
+  double rcon = getRCON(R, std::move(Adj), numAtoms);
 
   std::vector<double> wp = moldata3D.GetRelativePol(mol);
 
@@ -817,8 +785,8 @@ void getGETAWAYDesc(MatrixXd H, MatrixXd R, MatrixXd Adj, int numAtoms,
         }
       }
     }
-    double* Bimat = GetGeodesicMatrix(dist, i, numAtoms);
-    Map<MatrixXd> Bj(Bimat, numAtoms, numAtoms);
+    auto Bimat = GetGeodesicMatrix(dist, i, numAtoms);
+    Map<MatrixXd> Bj(Bimat.data(), numAtoms, numAtoms);
     if (i > 0 && i < 9) {  // use Bj
       for (int j = 0; j < numAtoms - 1; j++) {
         for (int k = j + 1; k < numAtoms; k++) {
@@ -1037,7 +1005,6 @@ void getGETAWAYDesc(MatrixXd H, MatrixXd R, MatrixXd Adj, int numAtoms,
         }
       }
     }
-    delete[] Bimat;
   }
 
   // can be column vs row selecgted that can explain the issue!
@@ -1198,7 +1165,8 @@ GETAWAYNAMES={"ITH","ISH","HIC","HGM","H0u","H1u","H2u","H3u","H4u","H5u","H6u",
 void GetGETAWAYone(double* dist3D, double* AdjMat, std::vector<double> Vpoints,
                     const ROMol& mol, const Conformer& conf,
                     std::vector<int> Heavylist, std::vector<double>& res,
-                    int precision, const std::string &customAtomPropName) {
+                   unsigned int precision,
+                   const std::string& customAtomPropName) {
       PRECONDITION(dist3D != nullptr, "no distance matrix");
       PRECONDITION(AdjMat != nullptr, "no adjacency matrix");
       int numAtoms = conf.getNumAtoms();
@@ -1219,14 +1187,14 @@ void GetGETAWAYone(double* dist3D, double* AdjMat, std::vector<double> Vpoints,
 
       MatrixXd R = GetRmatrix(H, DM, numAtoms);
 
-      getGETAWAYDescCustom(H, R, ADJ, numAtoms, Heavylist, mol, res, precision,
-                           customAtomPropName);
+  getGETAWAYDescCustom(H, R, ADJ, numAtoms, std::move(Heavylist), mol, res,
+                       precision, customAtomPropName);
 }
 
 void GetGETAWAY(double* dist3D, double* AdjMat, std::vector<double> Vpoints,
                 const ROMol& mol, const Conformer& conf,
                 std::vector<int> Heavylist, std::vector<double>& res,
-                int precision) {
+                unsigned int precision) {
   PRECONDITION(dist3D != nullptr, "no distance matrix");
   PRECONDITION(AdjMat != nullptr, "no adjacency matrix");
 
@@ -1248,13 +1216,14 @@ void GetGETAWAY(double* dist3D, double* AdjMat, std::vector<double> Vpoints,
 
   MatrixXd R = GetRmatrix(H, DM, numAtoms);
 
-  getGETAWAYDesc(H, R, ADJ, numAtoms, Heavylist, mol, res, precision);
+  getGETAWAYDesc(H, R, ADJ, numAtoms, std::move(Heavylist), mol, res,
+                 precision);
 }
 
 }  // end of anonymous namespace
 
 void GETAWAY(const ROMol& mol, std::vector<double>& res, int confId,
-             int precision, const std::string &customAtomPropName) {
+             unsigned int precision, const std::string &customAtomPropName) {
   PRECONDITION(mol.getNumConformers() >= 1, "molecule has no conformers")
 
   int numAtoms = mol.getNumAtoms();
@@ -1276,9 +1245,10 @@ void GETAWAY(const ROMol& mol, std::vector<double>& res, int confId,
   double* dist3D = MolOps::get3DDistanceMat(mol, confId);
 
   double* AdjMat = MolOps::getAdjacencyMatrix(
-      mol, false, 0, false, 0);  // false to have only the 1,0 matrix unweighted
+      mol, false, 0, false,
+      nullptr);  // false to have only the 1,0 matrix unweighted
 
-  if (customAtomPropName != "") {
+  if (!customAtomPropName.empty()) {
     res.clear();
     res.resize(45);
     GetGETAWAYone(dist3D, AdjMat, Vpoints, mol, conf, Heavylist, res, precision,

--- a/Code/GraphMol/Descriptors/GETAWAY.cpp
+++ b/Code/GraphMol/Descriptors/GETAWAY.cpp
@@ -63,7 +63,7 @@ namespace Descriptors {
 
 namespace {
 
-MolData3Ddescriptors moldata3D{};
+MolData3Ddescriptors moldata3D;
 
 double roundn(double in, int factor) {
   return round(in * pow(10., factor)) / pow(10., factor);
@@ -112,7 +112,8 @@ int countZeros(std::string ta) {
   return nbzero;
 }
 
-bool IsClose2(double a, double b, unsigned int /* precision */) {
+bool IsClose2(double a, double b, unsigned int precision) {
+  RDUNUSED_PARAM(precision);
   bool isclose = false;
 
   std::string sa, sb;
@@ -150,7 +151,8 @@ bool IsClose2(double a, double b, unsigned int /* precision */) {
   return isclose;
 }
 
-bool IsClose3(double a, double b, unsigned int /* precision */) {
+bool IsClose3(double a, double b, unsigned int precision) {
+  RDUNUSED_PARAM(precision);
   bool isclose = false;
   std::string sa, sb;
   std::string ta, tb;

--- a/Code/GraphMol/Descriptors/GETAWAY.h
+++ b/Code/GraphMol/Descriptors/GETAWAY.h
@@ -42,7 +42,7 @@ namespace RDKit {
 class ROMol;
 namespace Descriptors {
 const std::string GETAWAYVersion = "1.0.0";
-RDKIT_DESCRIPTORS_EXPORT void GETAWAY(const ROMol&, std::vector<double> &res, int confId=-1, int precision=2,
+RDKIT_DESCRIPTORS_EXPORT void GETAWAY(const ROMol&, std::vector<double> &res, int confId=-1, unsigned int precision=2,
              const std::string &customAtomPropName="");
 }
 }

--- a/Code/GraphMol/Descriptors/MORSE.cpp
+++ b/Code/GraphMol/Descriptors/MORSE.cpp
@@ -45,7 +45,7 @@ namespace RDKit {
 namespace Descriptors {
 namespace {
 
-MolData3Ddescriptors moldata3D;
+MolData3Ddescriptors moldata3D{};
 
 std::vector<double> getG(int n) {
   std::vector<double> res(n);
@@ -55,17 +55,14 @@ std::vector<double> getG(int n) {
   return res;
 }
 
-std::vector<double> prepareIState(const ROMol &mol, const Conformer &conf) {
-  int numAtoms = conf.getNumAtoms();
-  int confId = conf.getId();
+std::vector<double> prepareIState(const ROMol &mol) {
   std::vector<double> IState = moldata3D.GetIState(mol);
   return IState;
 }
 
-void getMORSEDesc(double *DM, const ROMol &mol, const Conformer &conf,
+void getMORSEDesc(const double *DM, const ROMol &mol, const Conformer &conf,
                   std::vector<double> &res) {
   int numAtoms = conf.getNumAtoms();
-  int confId = conf.getId();
 
   std::vector<double> R = getG(32);
   std::vector<double> R1(32);
@@ -81,10 +78,10 @@ void getMORSEDesc(double *DM, const ROMol &mol, const Conformer &conf,
   std::vector<double> IonPol = moldata3D.GetRelativeIonPol(mol);
   std::vector<double> RelativeElectroNeg = moldata3D.GetRelativeENeg(mol);
   std::vector<double> RelativeVdW = moldata3D.GetRelativeVdW(mol);
-  std::vector<double> IState = prepareIState(mol, confId);
+  std::vector<double> IState = prepareIState(mol);
 
   double p;
-  for (int i = 0; i < R.size(); i++) {
+  for (size_t i = 0; i < R.size(); i++) {
     double res1 = 0.0;
     double res2 = 0.0;
     double res3 = 0.0;
@@ -128,11 +125,10 @@ void getMORSEDesc(double *DM, const ROMol &mol, const Conformer &conf,
   res = R1;
 }
 
-void getMORSEDescCustom(double *DM, const ROMol &mol, const Conformer &conf,
+void getMORSEDescCustom(const double *DM, const ROMol &mol, const Conformer &conf,
                         std::vector<double> &res,
                         const std::string &customAtomPropName) {
   int numAtoms = conf.getNumAtoms();
-  int confId = conf.getId();
 
   std::vector<double> R = getG(32);
   std::vector<double> R1(32);
@@ -140,7 +136,7 @@ void getMORSEDescCustom(double *DM, const ROMol &mol, const Conformer &conf,
       moldata3D.GetCustomAtomProp(mol, customAtomPropName);
 
   double p;
-  for (int i = 0; i < R.size(); i++) {
+  for (size_t i = 0; i < R.size(); i++) {
     double res1 = 0.0;
 
     for (int j = 0; j < numAtoms - 1; j++) {
@@ -208,7 +204,7 @@ void MORSE(const ROMol &mol, std::vector<double> &res, int confId,
 
   double *dist3D =
       MolOps::get3DDistanceMat(mol, confId, false, true);  // 3D distance matrix
-  if (customAtomPropName != "") {
+  if (!customAtomPropName.empty()) {
     res.clear();
     res.resize(32);  // 7 * 32
     GetMORSEone(dist3D, mol, conf, res, customAtomPropName);

--- a/Code/GraphMol/Descriptors/MORSE.cpp
+++ b/Code/GraphMol/Descriptors/MORSE.cpp
@@ -45,7 +45,7 @@ namespace RDKit {
 namespace Descriptors {
 namespace {
 
-MolData3Ddescriptors moldata3D{};
+MolData3Ddescriptors moldata3D;
 
 std::vector<double> getG(int n) {
   std::vector<double> res(n);

--- a/Code/GraphMol/Descriptors/PBF.cpp
+++ b/Code/GraphMol/Descriptors/PBF.cpp
@@ -67,7 +67,7 @@ double distanceFromAPlane(const RDGeom::Point3D &pt,
                           const std::vector<double> &plane, double denom) {
   double numer = 0.0;
   numer =
-      std::abs(pt.x * plane[0] + pt.y * plane[1] + pt.z * plane[2] + plane[3]);
+      std::fabs(pt.x * plane[0] + pt.y * plane[1] + pt.z * plane[2] + plane[3]);
 
   return numer / denom;
 }

--- a/Code/GraphMol/Descriptors/RDF.cpp
+++ b/Code/GraphMol/Descriptors/RDF.cpp
@@ -64,7 +64,6 @@ void getRDFDesc(double* DM, const ROMol& mol, const Conformer& conf,
   // if (!conf.is3D()) return reserror;
 
   int numAtoms = conf.getNumAtoms();
-  int confId = conf.getId();
 
   std::vector<double> R = getG(30);
   std::vector<double> R1(30);
@@ -83,7 +82,7 @@ void getRDFDesc(double* DM, const ROMol& mol, const Conformer& conf,
   std::vector<double> IState = prepareIState(mol);
 
   double p;
-  for (int i = 0; i < R.size(); i++) {
+  for (size_t i = 0; i < R.size(); i++) {
     double res1 = 0.0;
     double res2 = 0.0;
     double res3 = 0.0;
@@ -134,7 +133,7 @@ void getRDFDescCustom(double* DM, const ROMol& mol, const Conformer& conf,
       moldata3D.GetCustomAtomProp(mol, customAtomPropName);
 
   double p;
-  for (int i = 0; i < R.size(); i++) {
+  for (size_t i = 0; i < R.size(); i++) {
     double res = 0.0;
     for (int j = 0; j < numAtoms - 1; j++) {
       for (int k = j + 1; k < numAtoms; k++) {
@@ -191,7 +190,7 @@ void RDF(const ROMol& mol, std::vector<double>& res, int confId,
   // RDF145s RDF150s RDF155s
 
   PRECONDITION(mol.getNumConformers() >= 1, "molecule has no conformers")
-  int numAtoms = mol.getNumAtoms();
+  // int numAtoms = mol.getNumAtoms();
   // if (numAtoms < 4) return reserror;
 
   const Conformer& conf = mol.getConformer(confId);

--- a/Code/GraphMol/Descriptors/WHIM.cpp
+++ b/Code/GraphMol/Descriptors/WHIM.cpp
@@ -112,7 +112,7 @@ std::vector<double> getWhimD(std::vector<double> weigthvector,
 
   double res = 0.0;
   for (int i = 0; i < 3; i++) {
-    res += std::abs(w[i] / w[3] - 1.0 / 3.0);
+    res += std::fabs(w[i] / w[3] - 1.0 / 3.0);
   }
 
   w[9] = 3.0 / 4.0 * res;  // K
@@ -171,7 +171,7 @@ std::vector<double> getWhimD(std::vector<double> weigthvector,
         if (j == k) {
           continue;
         }
-        if (std::abs(Scores(j, i) + Scores(k, i)) <= th) {
+        if (std::fabs(Scores(j, i) + Scores(k, i)) <= th) {
           // those that are close opposite & not close to the axis!
           ns += 1;  // check only once the symetric none null we need to add +2!
           // (reduce the loop duration)
@@ -186,7 +186,7 @@ std::vector<double> getWhimD(std::vector<double> weigthvector,
       if (!amatch) {
         na += 1;
         Symetric[j] = 0.0;
-        Symetric[j + numAtoms] = std::abs(Scores(j, i));
+        Symetric[j + numAtoms] = std::fabs(Scores(j, i));
       }
     }
     // take into account the atoms close to the axis

--- a/Code/GraphMol/Descriptors/test.cpp
+++ b/Code/GraphMol/Descriptors/test.cpp
@@ -1909,7 +1909,7 @@ void testProperties() {
       names.push_back("FakeName");
       Properties sink(names);
       TEST_ASSERT(0);  // should throw
-    } catch (KeyErrorException) {
+    } catch (KeyErrorException &) {
       BOOST_LOG(rdErrorLog)
           << "---Caught keyerror (bad property name)---" << std::endl;
     }
@@ -1957,7 +1957,7 @@ void testStereoCounting() {
   try {
     prop.computeProperties(*m);
     TEST_ASSERT(0);  // didn't catch exception
-  } catch (ValueErrorException) {
+  } catch (ValueErrorException &) {
     BOOST_LOG(rdErrorLog) << "---Caught stereo value error---" << std::endl;
   }
 

--- a/Code/GraphMol/Descriptors/testAUTOCORR2D.cpp
+++ b/Code/GraphMol/Descriptors/testAUTOCORR2D.cpp
@@ -69,7 +69,7 @@ void testautocorrelation() {
     for (int i = 0; i < 192; i++) {
       double ref = atof(myrow[i + 1].c_str());
 
-      if (abs(ref - res2d[i]) > 0.05) {
+      if (fabs(ref - res2d[i]) > 0.05) {
         std::cout << "value mismatch: pos" << i << " " << inm << " " << ref
                   << " " << res2d[i] << std::endl;
       }
@@ -85,7 +85,7 @@ void testautocorrelation() {
   BOOST_LOG(rdErrorLog) << "  done" << std::endl;
 }
 
-int main(int argc, char *argv[]) {
+int main() {
   RDLog::InitLogs();
   testautocorrelation();
 }

--- a/Code/GraphMol/Descriptors/testAUTOCORR3D.cpp
+++ b/Code/GraphMol/Descriptors/testAUTOCORR3D.cpp
@@ -83,7 +83,7 @@ void testautocorrelation() {
                         << std::endl;
 }
 
-int main(int argc, char *argv[]) {
+int main() {
   RDLog::InitLogs();
   testautocorrelation();
 }

--- a/Code/GraphMol/Descriptors/testEEM.cpp
+++ b/Code/GraphMol/Descriptors/testEEM.cpp
@@ -187,7 +187,7 @@ void testEEM2() {
                         << std::endl;
 }
 
-int main(int argc, char *argv[]) {
+int main() {
   RDLog::InitLogs();
   testEEM1();
 }

--- a/Code/GraphMol/Descriptors/testGETAWAY.cpp
+++ b/Code/GraphMol/Descriptors/testGETAWAY.cpp
@@ -104,7 +104,7 @@ void testGETAWAY() {
                         << std::endl;
 }
 
-int main(int argc, char *argv[]) {
+int main() {
   RDLog::InitLogs();
   testGETAWAY();
 }

--- a/Code/GraphMol/Descriptors/testMORSE.cpp
+++ b/Code/GraphMol/Descriptors/testMORSE.cpp
@@ -65,7 +65,7 @@ void testMORSE() {
     std::string inm = myrow[0];
     TEST_ASSERT(inm == nm);
 
-    for (int i = 0; i < dmorse.size(); i++) {
+    for (size_t i = 0; i < dmorse.size(); i++) {
       double ref = atof(myrow[i + 1].c_str());
 
       if (fabs(ref) > 0.01) {
@@ -98,7 +98,7 @@ void testMORSE() {
                         << std::endl;
 }
 
-int main(int argc, char *argv[]) {
+int main() {
   RDLog::InitLogs();
   testMORSE();
 }

--- a/Code/GraphMol/Descriptors/testPBF.cpp
+++ b/Code/GraphMol/Descriptors/testPBF.cpp
@@ -112,9 +112,7 @@ void testPBFEdges(){
   BOOST_LOG(rdErrorLog) << "  done" << std::endl;
 }
 
-int
-main(int argc, char *argv[])
-{
+int main() {
   RDLog::InitLogs();
   test1();
   testPBFEdges();

--- a/Code/GraphMol/Descriptors/testRDF.cpp
+++ b/Code/GraphMol/Descriptors/testRDF.cpp
@@ -61,7 +61,7 @@ void testRDF() {
     std::string inm = myrow[0];
     TEST_ASSERT(inm == nm);
 
-    for (int i = 0; i < drdf.size(); i++) {
+    for (size_t i = 0; i < drdf.size(); i++) {
       double ref = atof(myrow[i + 1].c_str());
 
       if (fabs(ref) > 1) {
@@ -94,7 +94,7 @@ void testRDF() {
                         << std::endl;
 }
 
-int main(int argc, char *argv[]) {
+int main() {
   RDLog::InitLogs();
   testRDF();
 }

--- a/Code/GraphMol/Descriptors/testRDFcustom.cpp
+++ b/Code/GraphMol/Descriptors/testRDFcustom.cpp
@@ -408,7 +408,13 @@ void testGETAWAYcustom() {
     RDKit::computeGasteigerCharges(*m, charges, 12, true);
 
     const std::string atomprop = "_GasteigerCharge";
-    RDKit::Descriptors::GETAWAY(*m, dgetaway, -1, 4, atomprop);
+
+    /*
+     * TO DO: fix this call: precision parameter is an *int*,
+     *        but setting it to 4 digits (= 0.0001) breaks this
+     *        test due to the references.
+     */
+    RDKit::Descriptors::GETAWAY(*m, dgetaway, -1, 0.0001, atomprop);
 
     std::vector<std::string> myrow = data[nDone];
     std::string inm = myrow[0];

--- a/Code/GraphMol/Descriptors/testRDFcustom.cpp
+++ b/Code/GraphMol/Descriptors/testRDFcustom.cpp
@@ -73,7 +73,7 @@ void testRDFcustom() {
     TEST_ASSERT(inm == nm);
 
     // std::cerr << inm << ",";
-    for (int i = 0; i < drdf.size(); i++) {
+    for (size_t i = 0; i < drdf.size(); i++) {
       double ref = atof(myrow[i + 1].c_str());
       // std::cerr << "[" << i << ":" << drdf[i] << "," << ref <<"]|";
       // if (fabs(ref - drdf[i]) > 0.01) {
@@ -139,7 +139,7 @@ void testMORSEcustom() {
     TEST_ASSERT(inm == nm);
 
     // std::cerr << inm << ",";
-    for (int i = 0; i < dmorse.size(); i++) {
+    for (size_t i = 0; i < dmorse.size(); i++) {
       double ref = atof(myrow[i + 1].c_str());
       // std::cerr << dmorse[i] << ",";
       // std::cerr << "[" << i << ":" << drdf[i] << "," << ref <<"]|";
@@ -206,7 +206,7 @@ void testAUTOCORR3Dcustom() {
     TEST_ASSERT(inm == nm);
 
     // std::cerr << inm << ",";
-    for (int i = 0; i < dauto3d.size(); i++) {
+    for (size_t i = 0; i < dauto3d.size(); i++) {
       double ref = atof(myrow[i + 1].c_str());
       // std::cerr << dauto3d[i] << ",";
       // std::cerr << "[" << i << ":" << drdf[i] << "," << ref <<"]|";
@@ -279,7 +279,7 @@ void testWHIMcustom() {
     TEST_ASSERT(inm == nm);
 
     // std::cerr << inm << ",";
-    for (int i = 0; i < dwhim.size(); i++) {
+    for (size_t i = 0; i < dwhim.size(); i++) {
       double ref = atof(myrow[i + 1].c_str());
       // std::cerr << dwhim[i] << ",";
       // std::cerr << "[" << i << ":" << drdf[i] << "," << ref <<"]|";
@@ -348,7 +348,7 @@ void testWHIMcustom1() {
     TEST_ASSERT(inm == nm);
 
     // std::cerr << inm << ",";
-    for (int i = 0; i < dwhim.size(); i++) {
+    for (size_t i = 0; i < dwhim.size(); i++) {
       double ref = atof(myrow[i + 1].c_str());
       // std::cerr << dwhim[i] << ",";
       // std::cerr << "[" << i << ":" << drdf[i] << "," << ref <<"]|";
@@ -408,14 +408,14 @@ void testGETAWAYcustom() {
     RDKit::computeGasteigerCharges(*m, charges, 12, true);
 
     const std::string atomprop = "_GasteigerCharge";
-    RDKit::Descriptors::GETAWAY(*m, dgetaway, -1, 0.0001, atomprop);
+    RDKit::Descriptors::GETAWAY(*m, dgetaway, -1, 4, atomprop);
 
     std::vector<std::string> myrow = data[nDone];
     std::string inm = myrow[0];
     TEST_ASSERT(inm == nm);
 
     // std::cerr << inm << ",";
-    for (int i = 0; i < dgetaway.size(); i++) {
+    for (size_t i = 0; i < dgetaway.size(); i++) {
       double ref = atof(myrow[i + 1].c_str());
       // std::cerr << dgetaway[i] << ",";
       // std::cerr << "[" << i << ":" << drdf[i] << "," << ref <<"]|";
@@ -436,7 +436,7 @@ void testGETAWAYcustom() {
                         << std::endl;
 }
 
-int main(int argc, char *argv[]) {
+int main() {
   RDLog::InitLogs();
   testRDFcustom();
   testMORSEcustom();

--- a/Code/GraphMol/Descriptors/testWHIM.cpp
+++ b/Code/GraphMol/Descriptors/testWHIM.cpp
@@ -182,7 +182,7 @@ void testWHIM() {
                         << std::endl;
 }
 
-int main(int argc, char *argv[]) {
+int main() {
   RDLog::InitLogs();
   testWHIM();
   // testWHIM3();

--- a/Code/GraphMol/FileParsers/MolFileParser.cpp
+++ b/Code/GraphMol/FileParsers/MolFileParser.cpp
@@ -1498,7 +1498,7 @@ Bond *ParseMolFileBondLine(const std::string &text, unsigned int line) {
           res->setBondDir(Bond::UNKNOWN);
           break;
       }
-    } catch (boost::bad_lexical_cast) {
+    } catch (boost::bad_lexical_cast &) {
       ;
     }
   }
@@ -1526,7 +1526,7 @@ Bond *ParseMolFileBondLine(const std::string &text, unsigned int line) {
         }
         res->expandQuery(q);
       }
-    } catch (boost::bad_lexical_cast) {
+    } catch (boost::bad_lexical_cast &) {
       ;
     }
   }
@@ -1534,7 +1534,7 @@ Bond *ParseMolFileBondLine(const std::string &text, unsigned int line) {
     try {
       int reactStatus = FileParserUtils::toInt(text.substr(18, 3));
       res->setProp("molReactStatus", reactStatus);
-    } catch (boost::bad_lexical_cast) {
+    } catch (boost::bad_lexical_cast &) {
       ;
     }
   }

--- a/Code/GraphMol/FileParsers/MolFileWriter.cpp
+++ b/Code/GraphMol/FileParsers/MolFileWriter.cpp
@@ -1234,7 +1234,7 @@ std::string MolToMolBlock(const ROMol &mol, bool includeStereo, int confId,
 
   try {
     return outputMolToMolBlock(tmol, confId, forceV3000);
-  } catch (RequiresV3000Exception) {
+  } catch (RequiresV3000Exception &) {
     return outputMolToMolBlock(tmol, confId, true);
   }
 }

--- a/Code/GraphMol/FileParsers/PDBWriter.cpp
+++ b/Code/GraphMol/FileParsers/PDBWriter.cpp
@@ -162,8 +162,10 @@ std::string GetPDBBondLines(const Atom *atom, bool all, bool both, bool mult,
         break;
       case Bond::QUADRUPLE:
         v.push_back(dst);
+        /* FALLTHRU */
       case Bond::TRIPLE:
         v.push_back(dst);
+        /* FALLTHRU */
       case Bond::DOUBLE:
         v.push_back(dst);
         v.push_back(dst);

--- a/Code/GraphMol/FileParsers/ProximityBonds.h
+++ b/Code/GraphMol/FileParsers/ProximityBonds.h
@@ -13,8 +13,8 @@
 #include <GraphMol/RWMol.h>
 
 namespace RDKit {
-static unsigned int ctdIGNORE_H_H_CONTACTS = 0x1;
-static unsigned int ctdALL_FLAGS = 0xFFFFFFFF;
+static const unsigned int ctdIGNORE_H_H_CONTACTS = 0x1;
+// static const unsigned int ctdALL_FLAGS = 0xFFFFFFFF;
 class AtomPDBResidueInfo;
 RDKIT_FILEPARSERS_EXPORT bool IsBlacklistedPair(Atom *beg_atom, Atom *end_atom);
 RDKIT_FILEPARSERS_EXPORT void ConnectTheDots(RWMol *mol, unsigned int flags = 0);

--- a/Code/GraphMol/FileParsers/TDTWriter.cpp
+++ b/Code/GraphMol/FileParsers/TDTWriter.cpp
@@ -58,7 +58,7 @@ TDTWriter::TDTWriter(std::ostream *outStream, bool takeOwnership) {
   df_writeNames = true;
 }
 
-TDTWriter::~TDTWriter() {
+TDTWriter::~TDTWriter() throw() {
   // if we've written any mols, finish with a "|" line
   if (d_molid > 0) {
     CHECK_INVARIANT(dp_ostream,
@@ -172,4 +172,4 @@ void TDTWriter::writeProperty(const ROMol &mol, const std::string &name) {
   boost::replace_all(pval, "\n", " ");
   (*dp_ostream) << pval << ">\n";
 }
-}
+}  // namespace RDKit

--- a/Code/GraphMol/Fingerprints/test1.cpp
+++ b/Code/GraphMol/Fingerprints/test1.cpp
@@ -885,7 +885,6 @@ void test1MorganFPs() {
     for (auto iter = fp->getNonzeroElements().begin();
          iter != fp->getNonzeroElements().end(); ++iter) {
       TEST_ASSERT(iter->second == 1);  // check that count == 1
-      ++iter;
     }
     delete fp;
 

--- a/Code/GraphMol/ForceFieldHelpers/MMFF/AtomTyper.cpp
+++ b/Code/GraphMol/ForceFieldHelpers/MMFF/AtomTyper.cpp
@@ -48,6 +48,7 @@ class RingMembership {
 class RingMembershipSize {
  typedef std::map<unsigned int, RingMembership> RingMembershipMap;
  typedef std::map<unsigned int, RingMembershipMap> RingSizeMembershipMap;
+
  public:
   static const boost::uint32_t IS_AROMATIC_BIT;
   RingMembershipSize(const ROMol &mol);
@@ -2346,7 +2347,7 @@ void MMFFMolProperties::setMMFFHydrogenType(const Atom *atom) {
               atomType = 33;
               break;
             }
-
+            /* FALLTHRU */
           default:
             // HO
             // Generic hydroxyl hydrogen

--- a/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
@@ -389,7 +389,7 @@ void get2DCoordsMol(RWMol &mol, double &offset, double spacing, double &maxY,
     p *= coordScale;
     minX = std::min(minX, conf.getAtomPos(i).x);
   }
-  offset += abs(minX);
+  offset += fabs(minX);
   for (unsigned int i = 0; i < mol.getNumAtoms(); ++i) {
     RDGeom::Point3D &p = conf.getAtomPos(i);
     p.y += vShift;

--- a/Code/GraphMol/MolInterchange/Parser.cpp
+++ b/Code/GraphMol/MolInterchange/Parser.cpp
@@ -215,7 +215,8 @@ void readConformer(Conformer *conf, const rj::Value &confVal) {
 }
 
 void readPartialCharges(RWMol *mol, const rj::Value &repVal,
-                        const JSONParseParameters /* &params */) {
+                        const JSONParseParameters &params) {
+  RDUNUSED_PARAM(params);
   PRECONDITION(mol, "no molecule");
   PRECONDITION(repVal["name"].GetString() == std::string("partialCharges"),
                "bad charges");

--- a/Code/GraphMol/MolInterchange/Parser.cpp
+++ b/Code/GraphMol/MolInterchange/Parser.cpp
@@ -215,7 +215,7 @@ void readConformer(Conformer *conf, const rj::Value &confVal) {
 }
 
 void readPartialCharges(RWMol *mol, const rj::Value &repVal,
-                        const JSONParseParameters &params) {
+                        const JSONParseParameters /* &params */) {
   PRECONDITION(mol, "no molecule");
   PRECONDITION(repVal["name"].GetString() == std::string("partialCharges"),
                "bad charges");

--- a/Code/GraphMol/MolStandardize/Charge.cpp
+++ b/Code/GraphMol/MolStandardize/Charge.cpp
@@ -263,7 +263,7 @@ ROMol *Uncharger::uncharge(const ROMol &mol) {
   std::vector<MatchVectType> a_matches;
 
   // Get atom ids for matches
-  unsigned int p_matched = SubstructMatch(*omol, *(this->pos_h), p_matches);
+  SubstructMatch(*omol, *(this->pos_h), p_matches);
   unsigned int q_matched = SubstructMatch(*omol, *(this->pos_quat), q_matches);
   unsigned int n_matched = SubstructMatch(*omol, *(this->neg), n_matches);
   unsigned int a_matched = SubstructMatch(*omol, *(this->neg_acid), a_matches);

--- a/Code/GraphMol/MolStandardize/Normalize.cpp
+++ b/Code/GraphMol/MolStandardize/Normalize.cpp
@@ -137,7 +137,7 @@ boost::shared_ptr<ROMol> Normalizer::applyTransform(
           MolOps::sanitizeMol(*static_cast<RWMol *>(pdt[0].get()), failed);
           Normalizer::Product np(MolToSmiles(*pdt[0]), pdt[0]);
           pdts.push_back(np);
-        } catch (MolSanitizeException) {
+        } catch (MolSanitizeException &) {
           BOOST_LOG(rdInfoLog) << "FAILED sanitizeMol.\n";
         }
       }

--- a/Code/GraphMol/MolStandardize/Tautomer.cpp
+++ b/Code/GraphMol/MolStandardize/Tautomer.cpp
@@ -37,21 +37,21 @@ ROMol *TautomerCanonicalizer::canonicalize(const ROMol &mol,
   for (const auto t : tautomers) {
     std::string smiles = MolToSmiles(*t);
     std::cout << "Tautomer: " << smiles << std::endl;
-    unsigned int score = 0;
+    // unsigned int score = 0;
     // Add aromatic ring scores
     VECT_INT_VECT rings;
     MolOps::symmetrizeSSSR(*t, rings);
-    for (const auto ring : rings) {
-      for (const auto pair : MolStandardize::pairwise(ring)) {
-        //				std::cout << pair.first << " " <<
-        // pair.second
-        //<< std::endl;
-        Bond::BondType btype =
-            t->getBondBetweenAtoms(pair.first, pair.second)->getBondType();
-        //				std::cout << btype << std::endl;
-        // Stopping for the moment to do the Python wrap
-      }
-    }
+    // for (const auto ring : rings) {
+    //   for (const auto pair : MolStandardize::pairwise(ring)) {
+    //     			std::cout << pair.first << " " <<
+    //     pair.second
+    //     << std::endl;
+    //     Bond::BondType btype =
+    //         t->getBondBetweenAtoms(pair.first, pair.second)->getBondType();
+    //     			std::cout << btype << std::endl;
+    //     Stopping for the moment to do the Python wrap
+    //   }
+    // }
   }
 
   return new ROMol(mol);

--- a/Code/GraphMol/MolStandardize/Validate.cpp
+++ b/Code/GraphMol/MolStandardize/Validate.cpp
@@ -70,9 +70,10 @@ void NoAtomValidation::run(const ROMol &mol, bool reportAllFailures,
   }
 }
 
-void FragmentValidation::run(const ROMol &mol, bool /* reportAllFailures */,
+void FragmentValidation::run(const ROMol &mol, bool reportAllFailures,
                              std::vector<ValidationErrorInfo> &errors) const {
   // REVIEW: reportAllFailures is not being used here. is that correct?
+  RDUNUSED_PARAM(reportAllFailures);
   std::string rdbase = getenv("RDBASE");
   std::string fgrpFile = rdbase + "/Data/MolStandardize/fragmentPatterns.txt";
   std::shared_ptr<FragmentCatalogParams> fparams(

--- a/Code/GraphMol/MolStandardize/Validate.cpp
+++ b/Code/GraphMol/MolStandardize/Validate.cpp
@@ -70,7 +70,7 @@ void NoAtomValidation::run(const ROMol &mol, bool reportAllFailures,
   }
 }
 
-void FragmentValidation::run(const ROMol &mol, bool reportAllFailures,
+void FragmentValidation::run(const ROMol &mol, bool /* reportAllFailures */,
                              std::vector<ValidationErrorInfo> &errors) const {
   // REVIEW: reportAllFailures is not being used here. is that correct?
   std::string rdbase = getenv("RDBASE");

--- a/Code/GraphMol/MolStandardize/testNormalize.cpp
+++ b/Code/GraphMol/MolStandardize/testNormalize.cpp
@@ -64,7 +64,7 @@ void test1() {
               "CC12CCCCC1(Cl)[N+]([O-])=[N+]2[O-]");
 
   // Test 1,5-separated charges are recombined.
-  smi6 = "C[N+](C)=C\C=C\[O-]";
+  smi6 = R"(C[N+](C)=C\C=C\[O-])";
   std::shared_ptr<ROMol> m6(SmilesToMol(smi6));
   ROMOL_SPTR normalized6(normalizer.normalize(*m6));
   TEST_ASSERT(MolToSmiles(*normalized6) == "CN(C)C=CC=O");

--- a/Code/GraphMol/MolStandardize/testTautomer.cpp
+++ b/Code/GraphMol/MolStandardize/testTautomer.cpp
@@ -790,13 +790,13 @@ void testCanonicalize() {
   TEST_ASSERT(ntautomers == 34);
 
   TautomerCatalog tautcat(tautparams);
-  TautomerCanonicalizer tc;
+  // TautomerCanonicalizer tc;
 
   // Enumerate 1,3 keto/enol tautomer.
   std::string smi1 = "C1(=CCCCC1)O";
   std::shared_ptr<ROMol> m1(SmilesToMol(smi1));
-  ROMol *res = tc.canonicalize(*m1, &tautcat);
-  //		TEST_ASSERT(MolToSmiles(*res) == "O=C1CCCCC1");
+  // ROMol *res = tc.canonicalize(*m1, &tautcat);
+  //    TEST_ASSERT(MolToSmiles(*res) == "O=C1CCCCC1");
 }
 
 int main() {

--- a/Code/GraphMol/QueryOps.h
+++ b/Code/GraphMol/QueryOps.h
@@ -821,9 +821,9 @@ class HasPropWithValueQuery
       try {
         T atom_val = what->template getProp<T>(propname);
         res = Queries::queryCmp(atom_val, this->val, this->tolerance) == 0;
-      } catch (KeyErrorException e) {
+      } catch (KeyErrorException &e) {
         res = false;
-      } catch (boost::bad_any_cast) {
+      } catch (boost::bad_any_cast &) {
         res = false;
       }
 #ifdef __GNUC__
@@ -885,9 +885,9 @@ class HasPropWithValueQuery<TargetPtr, std::string>
       try {
         std::string atom_val = what->template getProp<std::string>(propname);
         res = atom_val == this->val;
-      } catch (KeyErrorException) {
+      } catch (KeyErrorException &) {
         res = false;
-      } catch (boost::bad_any_cast) {
+      } catch (boost::bad_any_cast &) {
         res = false;
       }
 #ifdef __GNUC__

--- a/Code/GraphMol/SmilesParse/test.cpp
+++ b/Code/GraphMol/SmilesParse/test.cpp
@@ -165,7 +165,7 @@ void testFail() {
     boost::logging::disable_logs("rdApp.error");
     try {
       mol = SmilesToMol(smi);
-    } catch (MolSanitizeException) {
+    } catch (MolSanitizeException &) {
       mol = (Mol *)nullptr;
     }
     boost::logging::enable_logs("rdApp.error");

--- a/Code/GraphMol/StructChecker/ReCharge.cpp
+++ b/Code/GraphMol/StructChecker/ReCharge.cpp
@@ -163,7 +163,7 @@ bool ChargeFix::setpKaValues() {
   std::vector<Neighbourhood> neighbour_array(na);
   std::vector<unsigned> match;  //[MAXNEIGHBOURS + 1];
 
-  const AugmentedAtom *AAp;
+  // const AugmentedAtom *AAp;
 
   //    struct inc_entry_t  *cip, *ip;
   //    struct path_entry_t *ppa, *ppb;
@@ -187,7 +187,7 @@ bool ChargeFix::setpKaValues() {
                   Options.Verbose)) {
         AtomColor[i]++;
         AtompKaValue[i] = 0.0;
-        AAp = &AcidicAtom;
+        // AAp = &AcidicAtom;
         found = true;
         break;
       }
@@ -600,7 +600,7 @@ int ChargeFix::refineAcidicAtoms(std::vector<unsigned> &numbering) {
   } while (changed);
 
   // find smalles rank of coloured atoms
-  unsigned min_rank = (unsigned)atom_ranks.size();
+  size_t min_rank = atom_ranks.size();
   for (unsigned i = 0; i < atom_ranks.size(); i++)
     if (AtomColor[i] != 0 && atom_ranks[i].rank < min_rank)
       min_rank = atom_ranks[i].rank;

--- a/Code/GraphMol/StructChecker/Stereo.cpp
+++ b/Code/GraphMol/StructChecker/Stereo.cpp
@@ -363,22 +363,27 @@ static int Atom3Parity(struct stereo_bond_t ligands[3]) {
   int maxnum;
 
   maxnum = ligands[0].number;
-  for (unsigned i = 1; i < 3; i++)
+  for (unsigned i = 1; i < 3; i++) {
     if (maxnum < ligands[i].number) maxnum = ligands[i].number;
+  }
 
   reference = (-1);
-  for (unsigned i = 0; i < 3; i++)
-    if (ligands[i].direction != RDKit::Bond::NONE)
-      if (reference == (-1))
+  for (unsigned i = 0; i < 3; i++) {
+    if (ligands[i].direction != RDKit::Bond::NONE) {
+      if (reference == (-1)) {
         reference = i;
-      else {
+      } else {
         // stereo_error = "three attachments with more than 2 stereobonds";
         std::cerr << "three attachments with more than 2 stereobonds"
                   << std::endl;
         return (ILLEGAL_REPRESENTATION);
       }
+    }
+  }
 
-  if (reference == (-1)) return (UNDEFINED_PARITY);
+  if (reference == (-1)) {
+      return (UNDEFINED_PARITY);
+  }
 
   if (reference == 0) {
     a = 1;

--- a/Code/GraphMol/StructChecker/StructCheckerOptions.cpp
+++ b/Code/GraphMol/StructChecker/StructCheckerOptions.cpp
@@ -660,8 +660,9 @@ void StructCheckerOptions::parseTautomerData(
 }
 //--------------------------------------------------------------------------
 
-bool loadChargeDataTables(const std::string& /* path */) {
+bool loadChargeDataTables(const std::string& path) {
   // TODO: !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+  RDUNUSED_PARAM(path);
   /*
       double Elneg0; // elneg_table[0].value;
       std::map<unsigned, double> ElnegTable;   // AtomicNumber -> eleng

--- a/Code/GraphMol/StructChecker/StructCheckerOptions.cpp
+++ b/Code/GraphMol/StructChecker/StructCheckerOptions.cpp
@@ -30,7 +30,6 @@ bool parseOptionsJSON(const std::string &json, StructCheckerOptions &op) {
   try {
     std::istringstream ss;
     ss.str(json);
-    std::istream &iss = ss;
     boost::property_tree::ptree pt;
     boost::property_tree::read_json(ss, pt);
     op = StructCheckerOptions();  // reset to default values
@@ -352,8 +351,7 @@ static bool ReadAAPairs(
     return false;
   }
   unsigned n = 0;
-
-  unsigned k = fscanf(fp, "%d", &n);
+  fscanf(fp, "%d", &n);
 
   char buffer[80];
 
@@ -662,7 +660,7 @@ void StructCheckerOptions::parseTautomerData(
 }
 //--------------------------------------------------------------------------
 
-bool loadChargeDataTables(const std::string &path) {
+bool loadChargeDataTables(const std::string& /* path */) {
   // TODO: !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
   /*
       double Elneg0; // elneg_table[0].value;

--- a/Code/GraphMol/StructChecker/testStructChecker.cpp
+++ b/Code/GraphMol/StructChecker/testStructChecker.cpp
@@ -138,7 +138,7 @@ void testLoadOptionsFromFiles() {
   BOOST_LOG(rdInfoLog) << "-------------------------------------\n";
   BOOST_LOG(rdInfoLog)
       << "testLoadOptionsFromFiles FROM CURRENT (.../test) DIRECTORY\n";
-  bool ok;
+
   StructCheckerOptions options;
   // options.Verbose = true;
   doLoadOptionsFromFiles(options);
@@ -323,7 +323,7 @@ void testStereo()  // stereochemistry
   TEST_ASSERT(options.loadAcidicAugmentedAtoms(testDataDir + "checkfgs.aci"));
   //  options.Verbose = true;
   StructChecker chk(options);
-  for (int i = 0; i < sizeof(smols) / sizeof(smols[0]); i++) {
+  for (size_t i = 0; i < sizeof(smols) / sizeof(smols[0]); i++) {
     BOOST_LOG(rdInfoLog) << i << " : " << smols[i] << "\n";
     RWMol* mol = SmilesToMol(smols[i]);
     TEST_ASSERT(mol);
@@ -399,7 +399,7 @@ void testOptionsDefault() {
   StructCheckerOptions options;
   //  options.Verbose = true;
   StructChecker chk(options);
-  for (int i = 0; i < sizeof(smols) / sizeof(smols[0]); i++) {
+  for (size_t i = 0; i < sizeof(smols) / sizeof(smols[0]); i++) {
     BOOST_LOG(rdInfoLog) << i << " : " << smols[i] << "\n";
     RWMol* mol = SmilesToMol(smols[i]);
     TEST_ASSERT(mol);
@@ -423,7 +423,7 @@ void testCheckAtomWithDefaultGoodAtoms() {
   StructCheckerOptions options;
   //  options.Verbose = true;
   StructChecker chk(options);
-  for (int i = 0; i < sizeof(smols) / sizeof(smols[0]); i++) {
+  for (size_t i = 0; i < sizeof(smols) / sizeof(smols[0]); i++) {
     BOOST_LOG(rdInfoLog) << i << " : " << smols[i] << "\n";
     RWMol* mol = SmilesToMol(smols[i]);
     TEST_ASSERT(mol);
@@ -447,7 +447,7 @@ void testCheckAtom() {
   doLoadOptionsFromFiles(options);
   //  options.Verbose = true;
   StructChecker chk(options);
-  for (int i = 0; i < sizeof(smols) / sizeof(smols[0]); i++) {
+  for (size_t i = 0; i < sizeof(smols) / sizeof(smols[0]); i++) {
     BOOST_LOG(rdInfoLog) << i << " : " << smols[i] << "\n";
     RWMol* mol = SmilesToMol(smols[i]);
     TEST_ASSERT(mol);
@@ -597,7 +597,7 @@ void testSpecificExamples() {
         "CC(=C)C(OCC[N+](C)(C)C)=[N+](S(=O)(=O)C(F)(F)F)S(=O)(=O)C(F)(F)F",
         "OC(=O)[C@@H]1CC=CN1"};
 
-    for (int i = 0; i < sizeof(smols) / sizeof(smols[0]); i++) {
+    for (size_t i = 0; i < sizeof(smols) / sizeof(smols[0]); i++) {
       BOOST_LOG(rdInfoLog) << i << " : " << smols[i] << "\n";
       RWMol* mol = SmilesToMol(smols[i]);
       TEST_ASSERT(mol);
@@ -670,7 +670,7 @@ void testSpecificOrder() {
   StructChecker chk(options);
   const char* smols[] = {"FC(F)O", "OC(F)F"};
 
-  for (int i = 0; i < sizeof(smols) / sizeof(smols[0]); i++) {
+  for (size_t i = 0; i < sizeof(smols) / sizeof(smols[0]); i++) {
     BOOST_LOG(rdInfoLog) << i << " : " << smols[i] << "\n";
     RWMol* mol = SmilesToMol(smols[i]);
     TEST_ASSERT(mol);
@@ -699,7 +699,7 @@ void testTransformTau() {
   StructChecker chk(options);
   const char* smols[] = {"FC=C(F)O"};
 
-  for (int i = 0; i < sizeof(smols) / sizeof(smols[0]); i++) {
+  for (size_t i = 0; i < sizeof(smols) / sizeof(smols[0]); i++) {
     BOOST_LOG(rdInfoLog) << i << " : " << smols[i] << "\n";
     RWMol* mol = SmilesToMol(smols[i]);
     //      TEST_ASSERT(mol);
@@ -743,7 +743,7 @@ void testTransformAtoms() {
   StructChecker chk(options);
   const char* smols[] = {"C(=O)C", "FC=CO"};
 
-  for (int i = 0; i < sizeof(smols) / sizeof(smols[0]); i++) {
+  for (size_t i = 0; i < sizeof(smols) / sizeof(smols[0]); i++) {
     BOOST_LOG(rdInfoLog) << i << " : " << smols[i] << "\n";
     RWMol* mol = SmilesToMol(smols[i]);
     TEST_ASSERT(mol);
@@ -838,7 +838,7 @@ void testCarboxylicAcids() {
 
 //==============================================================================
 
-int main(int argc, const char* argv[]) {
+int main() {
   BOOST_LOG(rdInfoLog)
       << "*******************************************************\n";
   BOOST_LOG(rdInfoLog) << "StructChecker Unit Test \n";

--- a/Code/GraphMol/SubstructLibrary/substructLibraryTest.cpp
+++ b/Code/GraphMol/SubstructLibrary/substructLibraryTest.cpp
@@ -41,7 +41,7 @@ void runTest(SubstructLibrary &ssslib, const ROMol &pattern, int nThreads) {
     TEST_ASSERT(hasMatch[i] == matched);
   }
 };
-}
+}  // namespace
 
 void test1() {
   BOOST_LOG(rdErrorLog) << "-------------------------------------" << std::endl;
@@ -246,7 +246,7 @@ void docTest() {
   BOOST_LOG(rdErrorLog) << "    Done (C++ doc tests)" << std::endl;
 }
 
-int main(int argc, char *argv[]) {
+int main() {
 #if 1
   test1();
   test2();

--- a/Code/GraphMol/Wrap/EditableMol.cpp
+++ b/Code/GraphMol/Wrap/EditableMol.cpp
@@ -29,7 +29,7 @@ namespace {
 class EditableMol : boost::noncopyable {
  public:
   EditableMol(const ROMol &m) { dp_mol = new RWMol(m); };
-  ~EditableMol() {
+  ~EditableMol() throw() {
     PRECONDITION(dp_mol, "no molecule");
     delete dp_mol;
   };
@@ -73,7 +73,7 @@ class EditableMol : boost::noncopyable {
  private:
   RWMol *dp_mol;
 };
-}
+}  // namespace
 
 struct EditableMol_wrapper {
   static void wrap() {
@@ -132,5 +132,5 @@ struct EditableMol_wrapper {
   };
 };
 
-}  // end of namespace
+}  // namespace RDKit
 void wrap_EditableMol() { RDKit::EditableMol_wrapper::wrap(); }

--- a/Code/GraphMol/testCanon.cpp
+++ b/Code/GraphMol/testCanon.cpp
@@ -178,7 +178,7 @@ int main(int argc, char *argv[]) {
           }
           delete om;
           delete m;
-        } catch (MolSanitizeException) {
+        } catch (MolSanitizeException &) {
           BOOST_LOG(rdErrorLog) << smi << "\n";
           delete om;
           delete m;

--- a/Code/RDBoost/python_streambuf.h
+++ b/Code/RDBoost/python_streambuf.h
@@ -134,7 +134,7 @@ class streambuf : public std::basic_streambuf<char> {
 
   /// Construct from a Python file object
   /** if buffer_size is 0 the current default_buffer_size is used.
-  */
+   */
   streambuf(bp::object& python_file_obj, std::size_t buffer_size_ = 0)
       : py_read(getattr(python_file_obj, "read", bp::object())),
         py_write(getattr(python_file_obj, "write", bp::object())),
@@ -459,7 +459,7 @@ struct ostream : private streambuf_capsule, streambuf::ostream {
       : streambuf_capsule(python_file_obj, buffer_size),
         streambuf::ostream(python_streambuf) {}
 
-  ~ostream() {
+  ~ostream() throw() {
     try {
       if (this->good()) this->flush();
     } catch (bp::error_already_set&) {
@@ -472,7 +472,7 @@ struct ostream : private streambuf_capsule, streambuf::ostream {
     }
   }
 };
-}
-}  // boost_adaptbx::python
+}  // namespace python
+}  // namespace boost_adaptbx
 
 #endif  // GUARD

--- a/Code/SimDivPickers/testPickers.cpp
+++ b/Code/SimDivPickers/testPickers.cpp
@@ -16,7 +16,7 @@
 
 namespace {
 double dist_on_line(unsigned int i, unsigned int j) {
-  return std::abs((double)i - (double)j);
+  return std::fabs((double)i - (double)j);
 }
 }
 void testGithub1421() {

--- a/Contrib/PBF/PBFRDKit.cpp
+++ b/Contrib/PBF/PBFRDKit.cpp
@@ -56,7 +56,7 @@ void getSmallestEigenVector(double fSumXX,double fSumXY,double fSumXZ,
 
 double distanceFromAPlane(const RDGeom::Point3D &pt,const std::vector<double> &plane, double denom){
   double numer=0.0;
-  numer = std::abs(pt.x*plane[0]+pt.y*plane[1]+pt.z*plane[2]+plane[3]);
+  numer = std::fabs(pt.x*plane[0]+pt.y*plane[1]+pt.z*plane[2]+plane[3]);
 
   return numer/denom;
 }


### PR DESCRIPTION
This PR addresses most of the warnings that are issued during build, as well as some easy improvements in `GETAWAY.cpp`.

This patch exposed a failure in test `testGETAWAYcustom`, inside file `testRDFcustom.cpp`. In this test, function `RDKit::Descriptors::GETAWAY` was being called with argument `precision = 0.0001`. As the `precision` parameter was declared as `int`, it was being casted into a 0, causing the values in the function to be reduced to 0 decimals precision. This wrong casting was being flagged as a warning by the compiler, and as soon as I changed the precision to 4, meaning four decimals precision, as in 0.0001, the test failed. It only passes for `precision = 0` or `precision = 1`.

The changes in `GETAWAY.cpp` and updating `abs()` called on real values to `fabs()` were done while I tried to spot the problem with the test, which in the end I have not been able to find.
