### PR TITLE
Coordgen: stop printing Templates location

### DIFF
--- a/External/CoordGen/CoordGen.h
+++ b/External/CoordGen/CoordGen.h
@@ -62,7 +62,7 @@ unsigned int addCoords(T& mol, const CoordGenParams* params = nullptr) {
   auto min_mol = new sketcherMinimizerMolecule();
 
   // FIX: only do this check once.
-  std::cerr << "  TEMPLATES: " << templateFileDir << std::endl;
+  // std::cerr << "  TEMPLATES: " << templateFileDir << std::endl;
   if (templateFileDir != "") {
     minimizer.setTemplateFileDir(templateFileDir);
   }


### PR DESCRIPTION
This should not have been in the release in the first place

