### PR TITLE
Enable ctest -T memcheck

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,8 @@ IF(NOT CMAKE_BUILD_TYPE)
       FORCE)
 ENDIF(NOT CMAKE_BUILD_TYPE)
 
-enable_testing()
+# Enable CTest
+include(CTest)
 
 set(CMAKE_MODULE_PATH
     ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/Code/cmake/Modules/")
@@ -481,6 +482,10 @@ endif(RDK_BUILD_PYTHON_WRAPPERS)
 if(RDK_BUILD_CONTRIB)
   add_subdirectory(Contrib)
 endif(RDK_BUILD_CONTRIB)
+
+# Memory testing setup
+FIND_PROGRAM(MEMORYCHECK_COMMAND valgrind)
+CONFIGURE_FILE(CTestCustom.ctest.in ${CMAKE_CURRENT_BINARY_DIR}/CTestCustom.ctest)
 
 # Packaging
 SET(CPACK_GENERATOR "TGZ;DEB;RPM")

--- a/CTestConfig.cmake
+++ b/CTestConfig.cmake
@@ -1,0 +1,2 @@
+# For some reason, MEMORYCHECK_SUPPRESSIONS_FILE is not being caught, so I hardcoded it here
+SET(MEMORYCHECK_COMMAND_OPTIONS "--tool=memcheck --time-stamp=yes --num-callers=20 --gen-suppressions=all --leak-check=full --show-reachable=no --trace-children=yes --suppressions=${RDKit_SOURCE_DIR}/rdkit_valgrind.suppressions")

--- a/CTestCustom.ctest.in
+++ b/CTestCustom.ctest.in
@@ -1,0 +1,15 @@
+SET(CTEST_CUSTOM_MEMCHECK_IGNORE
+  ${CTEST_CUSTOM_MEMCHECK_IGNORE}
+
+  # python tests are not memchecked: these are slow, and difficult to interpret
+  ${RDKIT_PYTEST_CACHE}
+
+  # Skip tests that which take too long to run and timeout.
+  # These can be run explcitly, with a longer timeout,
+  # i.e., as ctest -T memcheck -R [test] --timeout 10800
+  testDistGeomHelpers
+  testMolAlign
+)
+
+
+

--- a/CTestCustom.ctest.in
+++ b/CTestCustom.ctest.in
@@ -3,12 +3,6 @@ SET(CTEST_CUSTOM_MEMCHECK_IGNORE
 
   # python tests are not memchecked: these are slow, and difficult to interpret
   ${RDKIT_PYTEST_CACHE}
-
-  # Skip tests that which take too long to run and timeout.
-  # These can be run explcitly, with a longer timeout,
-  # i.e., as ctest -T memcheck -R [test] --timeout 10800
-  testDistGeomHelpers
-  testMolAlign
 )
 
 

--- a/Code/cmake/Modules/RDKitUtils.cmake
+++ b/Code/cmake/Modules/RDKitUtils.cmake
@@ -8,6 +8,7 @@ ENDIF(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 set(RDKit_VERSION "${RDKit_VERSION}.${RDKit_Revision}${RDKit_RevisionModifier}")
 set(RDKit_RELEASENAME "${RDKit_Year}.${RDKit_Month}.${RDKit_Revision}${RDKit_RevisionModifier}")
 
+
 set(compilerID "${CMAKE_CXX_COMPILER_ID}")
 set(systemAttribute "")
 if(MINGW)
@@ -23,6 +24,7 @@ else()
 endif()
 set(RDKit_BUILDNAME "${CMAKE_SYSTEM_NAME}|${CMAKE_SYSTEM_VERSION}|${systemAttribute}|${compilerID}|${bit3264}")
 set(RDKit_EXPORTED_TARGETS rdkit-targets)
+
 
 macro(rdkit_library)
   PARSE_ARGUMENTS(RDKLIB
@@ -179,6 +181,7 @@ macro(add_pytest)
   if(RDK_BUILD_PYTHON_WRAPPERS)
     add_test(${PYTEST_NAME}  ${PYTHON_EXECUTABLE}
              ${PYTEST_SOURCES})
+    SET(RDKIT_PYTEST_CACHE "${PYTEST_NAME};${RDKIT_PYTEST_CACHE}" CACHE INTERNAL "Global list of python tests")
   endif(RDK_BUILD_PYTHON_WRAPPERS)
 endmacro(add_pytest)
 

--- a/rdkit_valgrind.suppressions
+++ b/rdkit_valgrind.suppressions
@@ -1,35 +1,2837 @@
 {
-   uninitialised value used in logic
+   uninitialised value used in logic 4
    Memcheck:Cond
-   fun:_IO_default_xsputn
+   fun:__mpn_addmul_1
+   obj:*
+   obj:*
+   fun:__mpn_mul
+   obj:*
+   obj:*
+   obj:*
+   obj:*
+   obj:*
+   obj:*
+   obj:*
    fun:__printf_fp
-   fun:vfprintf
-   fun:vsnprintf
+   obj:*
+   obj:*
+   obj:*
+   obj:*
+   obj:*
+   obj:*
+   obj:*
    obj:*
 }
 {
+   uninitialised value used in logic 5
+   Memcheck:Cond
+   fun:__mpn_addmul_1
+   obj:*
+   obj:*
+   fun:__mpn_mul
+   obj:*
+   obj:*
+   obj:*
+   obj:*
+   obj:*
+   obj:*
+   obj:*
+   obj:*
+   obj:*
+   obj:*
+   obj:*
+   obj:*
+   obj:*
+   obj:*
+   obj:*
+   obj:*
+}
+{
+   memory possibly lost 8
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:RDValue
+   fun:_ZN5RDKit4Dict6setValISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS8_EEEEvRKS8_RT_
+   fun:setProp<unsigned int>
+   fun:_ZN5RDKit9Chirality18assignAtomCIPRanksERKNS_5ROMolERSt6vectorIjSaIjEE
+   fun:_ZN5RDKit9Chirality21assignAtomChiralCodesERNS_5ROMolERSt6vectorIjSaIjEEb
+   fun:_ZN5RDKit6MolOps21assignStereochemistryERNS_5ROMolEbbb
+   fun:_ZN5RDKit11SmilesToMolERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERKNS_18SmilesParserParamsE
+   fun:_ZN5RDKit17SmilesMolSupplier11processLineENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE
+   fun:_ZN5RDKit17SmilesMolSupplier4nextEv
+}
+{
+   memory possibly lost 61
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:allocate
+   fun:allocate
+   fun:_M_allocate
+   fun:_M_create_storage
+   fun:_Vector_base
+   fun:vector
+   fun:RDValue
+   fun:_ZN5RDKit4Dict6setValISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS8_EEEEvRKS8_RT_
+   fun:setProp<unsigned int>
+   fun:_ZN5RDKit9Chirality18assignAtomCIPRanksERKNS_5ROMolERSt6vectorIjSaIjEE
+   fun:_ZN5RDKit9Chirality21assignAtomChiralCodesERNS_5ROMolERSt6vectorIjSaIjEEb
+   fun:_ZN5RDKit6MolOps21assignStereochemistryERNS_5ROMolEbbb
+   fun:_ZN5RDKit11SmilesToMolERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERKNS_18SmilesParserParamsE
+   fun:_ZN5RDKit17SmilesMolSupplier11processLineENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE
+   fun:_ZN5RDKit17SmilesMolSupplier4nextEv
+}
+{
+   memory possibly lost 81
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:allocate
+   fun:allocate
+   fun:_M_allocate
+   fun:_ZNSt6vectorIN5RDKit4Dict4PairESaIS2_EE17_M_realloc_insertIJS2_EEEvN9__gnu_cxx17__normal_iteratorIPS2_S4_EEDpOT_
+   fun:push_back
+   fun:setPODVal<unsigned int>
+   fun:setVal
+   fun:setProp<unsigned int>
+   fun:_ZN5RDKit9Chirality18assignAtomCIPRanksERKNS_5ROMolERSt6vectorIjSaIjEE
+   fun:_ZN5RDKit9Chirality21assignAtomChiralCodesERNS_5ROMolERSt6vectorIjSaIjEEb
+   fun:_ZN5RDKit6MolOps21assignStereochemistryERNS_5ROMolEbbb
+   fun:_ZN5RDKit11SmilesToMolERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERKNS_18SmilesParserParamsE
+   fun:_ZN5RDKit17SmilesMolSupplier11processLineENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE
+   fun:_ZN5RDKit17SmilesMolSupplier4nextEv
+}
+{
+   uninitialised value used 3
+   Memcheck:Value8
+   fun:__mpn_addmul_1
+   obj:*
+   obj:*
+   fun:__mpn_mul
+   obj:*
+   obj:*
+   obj:*
+   obj:*
+   obj:*
+   obj:*
+   obj:*
+   fun:__printf_fp
+   obj:*
+   obj:*
+   obj:*
+   obj:*
+   obj:*
+   obj:*
+   obj:*
+   obj:*
+}
+{
+   uninitialised value used 4
+   Memcheck:Value8
+   fun:__mpn_addmul_1
+   obj:*
+   obj:*
+   fun:__mpn_mul
+   obj:*
+   obj:*
+   obj:*
+   obj:*
+   obj:*
+   obj:*
+   obj:*
+   obj:*
+   obj:*
+   obj:*
+   obj:*
+   obj:*
+   obj:*
+   obj:*
+   obj:*
+   obj:*
+}
+{
+   memory possibly lost 1
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:RDValue
+   fun:_ZN5RDKit4Dict6setValISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS8_EEEEvRKS8_RT_
+   fun:_ZNK5RDKit7RDProps18clearComputedPropsEv
+   fun:_ZNK5RDKit5ROMol18clearComputedPropsEb
+   fun:_ZN5RDKit6MolOps5addHsERNS_5RWMolEbbPKSt6vectorIjSaIjEEb
+   fun:_ZN5RDKit6MolOps5addHsERKNS_5ROMolEbbPKSt6vectorIjSaIjEEb
+}
+{
+   memory possibly lost 3
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:RDValue
+   fun:_ZN5RDKit4Dict6setValISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS8_EEEEvRKS8_RT_
+   fun:setProp<bool>
+   fun:_ZN5RDKit6MolOps5addHsERNS_5RWMolEbbPKSt6vectorIjSaIjEEb
+   fun:_ZN5RDKit6MolOps5addHsERKNS_5ROMolEbbPKSt6vectorIjSaIjEEb
+}
+{
+   memory possibly lost 24
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:_ZN5RDKit4BondC1ERKS0_
+   fun:_ZNK5RDKit4Bond4copyEv
+   fun:_ZN5RDKit5ROMol13initFromOtherERKS0_bi
+   fun:ROMol
+   fun:RWMol
+   fun:_ZN5RDKit6MolOps5addHsERKNS_5ROMolEbbPKSt6vectorIjSaIjEEb
+}
+{
+   memory possibly lost 26
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:_ZN5RDKit5ROMol13initFromOtherERKS0_bi
+   fun:ROMol
+   fun:RWMol
+   fun:_ZN5RDKit6MolOps5addHsERKNS_5ROMolEbbPKSt6vectorIjSaIjEEb
+}
+{
+   memory possibly lost 34
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:_ZN5RDKit5RWMol7addBondEjjNS_4Bond8BondTypeE
+   fun:_ZN5RDKit6MolOps5addHsERNS_5RWMolEbbPKSt6vectorIjSaIjEEb
+   fun:_ZN5RDKit6MolOps5addHsERKNS_5ROMolEbbPKSt6vectorIjSaIjEEb
+}
+{
+   memory possibly lost 35
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:_ZN5RDKit6MolOps5addHsERKNS_5ROMolEbbPKSt6vectorIjSaIjEEb
+}
+{
+   memory possibly lost 37
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:_ZN5RDKit6MolOps5addHsERNS_5RWMolEbbPKSt6vectorIjSaIjEEb
+   fun:_ZN5RDKit6MolOps5addHsERKNS_5ROMolEbbPKSt6vectorIjSaIjEEb
+}
+{
+   memory possibly lost 38
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:_ZNK5RDKit4Atom4copyEv
+   fun:_ZN5RDKit5ROMol13initFromOtherERKS0_bi
+   fun:ROMol
+   fun:RWMol
+   fun:_ZN5RDKit6MolOps5addHsERKNS_5ROMolEbbPKSt6vectorIjSaIjEEb
+}
+{
+   memory possibly lost 41
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:_ZNK5RDKit4Bond4copyEv
+   fun:_ZN5RDKit5ROMol13initFromOtherERKS0_bi
+   fun:ROMol
+   fun:RWMol
+   fun:_ZN5RDKit6MolOps5addHsERKNS_5ROMolEbbPKSt6vectorIjSaIjEEb
+}
+{
+   memory possibly lost 49
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:adjacency_list
+   fun:ROMol
+   fun:RWMol
+   fun:_ZN5RDKit6MolOps5addHsERKNS_5ROMolEbbPKSt6vectorIjSaIjEEb
+}
+{
+   memory possibly lost 54
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:allocate
+   fun:allocate
+   fun:_M_allocate
+   fun:_M_create_storage
+   fun:_Vector_base
+   fun:vector
+   fun:Dict
+   fun:RDProps
+   fun:_ZN5RDKit4AtomC1ERKS0_
+   fun:_ZNK5RDKit4Atom4copyEv
+   fun:_ZN5RDKit5ROMol13initFromOtherERKS0_bi
+   fun:ROMol
+   fun:RWMol
+   fun:_ZN5RDKit6MolOps5addHsERKNS_5ROMolEbbPKSt6vectorIjSaIjEEb
+}
+{
+   memory possibly lost 56
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:allocate
+   fun:allocate
+   fun:_M_allocate
+   fun:_M_create_storage
+   fun:_Vector_base
+   fun:vector
+   fun:RDValue
+   fun:_ZN5RDKit4Dict6setValISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS8_EEEEvRKS8_RT_
+   fun:setProp<bool>
+   fun:_ZN5RDKit6MolOps5addHsERNS_5RWMolEbbPKSt6vectorIjSaIjEEb
+   fun:_ZN5RDKit6MolOps5addHsERKNS_5ROMolEbbPKSt6vectorIjSaIjEEb
+}
+{
+   memory possibly lost 64
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:allocate
+   fun:allocate
+   fun:_M_allocate
+   fun:_M_create_storage
+   fun:_Vector_base
+   fun:vector
+   fun:RingInfo
+   fun:_ZN5RDKit5ROMol13initFromOtherERKS0_bi
+   fun:ROMol
+   fun:RWMol
+   fun:_ZN5RDKit6MolOps5addHsERKNS_5ROMolEbbPKSt6vectorIjSaIjEEb
+}
+{
+   memory possibly lost 65
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:allocate
+   fun:allocate
+   fun:_M_allocate
+   fun:_M_create_storage
+   fun:_Vector_base
+   fun:vector
+   fun:_Construct<std::vector<int>, const std::vector<int, std::allocator<int> >&>
+   fun:__uninit_copy<__gnu_cxx::__normal_iterator<const std::vector<int>*, std::vector<std::vector<int> > >, std::vector<int>*>
+   fun:uninitialized_copy<__gnu_cxx::__normal_iterator<const std::vector<int>*, std::vector<std::vector<int> > >, std::vector<int>*>
+   fun:__uninitialized_copy_a<__gnu_cxx::__normal_iterator<const std::vector<int>*, std::vector<std::vector<int> > >, std::vector<int>*, std::vector<int> >
+   fun:vector
+   fun:RingInfo
+   fun:_ZN5RDKit5ROMol13initFromOtherERKS0_bi
+   fun:ROMol
+   fun:RWMol
+   fun:_ZN5RDKit6MolOps5addHsERKNS_5ROMolEbbPKSt6vectorIjSaIjEEb
+}
+{
+   memory possibly lost 71
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:allocate
+   fun:allocate
+   fun:_M_allocate
+   fun:_M_create_storage
+   fun:_Vector_base
+   fun:vector
+   fun:operator=
+   fun:_ZN5RDKit5ROMol13initFromOtherERKS0_bi
+   fun:ROMol
+   fun:RWMol
+   fun:_ZN5RDKit6MolOps5addHsERKNS_5ROMolEbbPKSt6vectorIjSaIjEEb
+}
+{
+   memory possibly lost 79
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:allocate
+   fun:allocate
+   fun:_M_allocate
+   fun:_ZNSt6vectorIN5RDKit4Dict4PairESaIS2_EE17_M_realloc_insertIJS2_EEEvN9__gnu_cxx17__normal_iteratorIPS2_S4_EEDpOT_
+   fun:push_back
+   fun:setPODVal<int>
+   fun:setVal
+   fun:setProp<int>
+   fun:_ZN5RDKit6MolOps5addHsERNS_5RWMolEbbPKSt6vectorIjSaIjEEb
+   fun:_ZN5RDKit6MolOps5addHsERKNS_5ROMolEbbPKSt6vectorIjSaIjEEb
+}
+{
+   memory possibly lost 90
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:allocate
+   fun:allocate
+   fun:_M_allocate
+   fun:_ZNSt6vectorIN5boost6detail12adj_list_genINS0_14adjacency_listINS0_4vecSES4_NS0_11undirectedSEPN5RDKit4AtomEPNS6_4BondENS0_11no_propertyENS0_5listSEEES4_S4_S5_S8_SA_SB_SC_E6config13stored_vertexESaISG_EE17_M_default_appendEm
+   fun:resize
+   fun:add_vertex<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::detail::adj_list_gen<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*, boost::no_property, boost::listS>::config, boost::undirected_graph_helper<boost::detail::adj_list_gen<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*, boost::no_property, boost::listS>::config> >
+   fun:_ZN5RDKit5ROMol7addAtomEPNS_4AtomEbb
+   fun:addAtom
+   fun:_ZN5RDKit6MolOps5addHsERNS_5RWMolEbbPKSt6vectorIjSaIjEEb
+   fun:_ZN5RDKit6MolOps5addHsERKNS_5ROMolEbbPKSt6vectorIjSaIjEEb
+}
+{
+   memory possibly lost 91
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:allocate
+   fun:allocate
+   fun:_M_allocate
+   fun:_ZNSt6vectorIN5boost6detail16stored_edge_iterImSt14_List_iteratorINS0_9list_edgeImPN5RDKit4BondEEEES7_EESaISA_EE17_M_realloc_insertIJSA_EEEvN9__gnu_cxx17__normal_iteratorIPSA_SC_EEDpOT_
+   fun:push_back
+   fun:push_dispatch<std::vector<boost::detail::stored_edge_iter<long unsigned int, std::_List_iterator<boost::list_edge<long unsigned int, RDKit::Bond*> >, RDKit::Bond*>, std::allocator<boost::detail::stored_edge_iter<long unsigned int, std::_List_iterator<boost::list_edge<long unsigned int, RDKit::Bond*> >, RDKit::Bond*> > >, boost::detail::stored_edge_iter<long unsigned int, std::_List_iterator<boost::list_edge<long unsigned int, RDKit::Bond*> >, RDKit::Bond*> >
+   fun:push<std::vector<boost::detail::stored_edge_iter<long unsigned int, std::_List_iterator<boost::list_edge<long unsigned int, RDKit::Bond*> >, RDKit::Bond*>, std::allocator<boost::detail::stored_edge_iter<long unsigned int, std::_List_iterator<boost::list_edge<long unsigned int, RDKit::Bond*> >, RDKit::Bond*> > >, boost::detail::stored_edge_iter<long unsigned int, std::_List_iterator<boost::list_edge<long unsigned int, RDKit::Bond*> >, RDKit::Bond*> >
+   fun:add_edge<boost::detail::adj_list_gen<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*, boost::no_property, boost::listS>::config>
+   fun:add_edge<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::detail::adj_list_gen<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*, boost::no_property, boost::listS>::config, boost::undirected_graph_helper<boost::detail::adj_list_gen<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*, boost::no_property, boost::listS>::config> >
+   fun:add_edge<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::detail::adj_list_gen<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*, boost::no_property, boost::listS>::config, boost::undirected_graph_helper<boost::detail::adj_list_gen<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*, boost::no_property, boost::listS>::config> >
+   fun:_ZN5RDKit5ROMol7addBondEPNS_4BondEb
+   fun:_ZN5RDKit5ROMol13initFromOtherERKS0_bi
+   fun:ROMol
+   fun:RWMol
+   fun:_ZN5RDKit6MolOps5addHsERKNS_5ROMolEbbPKSt6vectorIjSaIjEEb
+}
+{
+   memory possibly lost 98
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:allocate
+   fun:allocate
+   fun:_M_allocate
+   fun:_ZNSt6vectorIN5boost6detail16stored_edge_iterImSt14_List_iteratorINS0_9list_edgeImPN5RDKit4BondEEEES7_EESaISA_EE17_M_realloc_insertIJSA_EEEvN9__gnu_cxx17__normal_iteratorIPSA_SC_EEDpOT_
+   fun:push_back
+   fun:push_dispatch<std::vector<boost::detail::stored_edge_iter<long unsigned int, std::_List_iterator<boost::list_edge<long unsigned int, RDKit::Bond*> >, RDKit::Bond*>, std::allocator<boost::detail::stored_edge_iter<long unsigned int, std::_List_iterator<boost::list_edge<long unsigned int, RDKit::Bond*> >, RDKit::Bond*> > >, boost::detail::stored_edge_iter<long unsigned int, std::_List_iterator<boost::list_edge<long unsigned int, RDKit::Bond*> >, RDKit::Bond*> >
+   fun:push<std::vector<boost::detail::stored_edge_iter<long unsigned int, std::_List_iterator<boost::list_edge<long unsigned int, RDKit::Bond*> >, RDKit::Bond*>, std::allocator<boost::detail::stored_edge_iter<long unsigned int, std::_List_iterator<boost::list_edge<long unsigned int, RDKit::Bond*> >, RDKit::Bond*> > >, boost::detail::stored_edge_iter<long unsigned int, std::_List_iterator<boost::list_edge<long unsigned int, RDKit::Bond*> >, RDKit::Bond*> >
+   fun:add_edge<boost::detail::adj_list_gen<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*, boost::no_property, boost::listS>::config>
+   fun:add_edge<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::detail::adj_list_gen<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*, boost::no_property, boost::listS>::config, boost::undirected_graph_helper<boost::detail::adj_list_gen<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*, boost::no_property, boost::listS>::config> >
+   fun:add_edge<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::detail::adj_list_gen<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*, boost::no_property, boost::listS>::config, boost::undirected_graph_helper<boost::detail::adj_list_gen<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*, boost::no_property, boost::listS>::config> >
+   fun:_ZN5RDKit5RWMol7addBondEjjNS_4Bond8BondTypeE
+   fun:_ZN5RDKit6MolOps5addHsERNS_5RWMolEbbPKSt6vectorIjSaIjEEb
+   fun:_ZN5RDKit6MolOps5addHsERKNS_5ROMolEbbPKSt6vectorIjSaIjEEb
+}
+{
+   memory possibly lost 110
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:allocate
+   fun:allocate
+   fun:_M_get_node
+   fun:_M_create_node<const boost::list_edge<long unsigned int, RDKit::Bond*>&>
+   fun:_M_insert<const boost::list_edge<long unsigned int, RDKit::Bond*>&>
+   fun:push_back
+   fun:push_dispatch<std::__cxx11::list<boost::list_edge<long unsigned int, RDKit::Bond*>, std::allocator<boost::list_edge<long unsigned int, RDKit::Bond*> > >, boost::list_edge<long unsigned int, RDKit::Bond*>&>
+   fun:push<std::__cxx11::list<boost::list_edge<long unsigned int, RDKit::Bond*>, std::allocator<boost::list_edge<long unsigned int, RDKit::Bond*> > >, boost::list_edge<long unsigned int, RDKit::Bond*>&>
+   fun:add_edge<boost::detail::adj_list_gen<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*, boost::no_property, boost::listS>::config>
+   fun:add_edge<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::detail::adj_list_gen<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*, boost::no_property, boost::listS>::config, boost::undirected_graph_helper<boost::detail::adj_list_gen<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*, boost::no_property, boost::listS>::config> >
+   fun:add_edge<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::detail::adj_list_gen<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*, boost::no_property, boost::listS>::config, boost::undirected_graph_helper<boost::detail::adj_list_gen<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*, boost::no_property, boost::listS>::config> >
+   fun:_ZN5RDKit5ROMol7addBondEPNS_4BondEb
+   fun:_ZN5RDKit5ROMol13initFromOtherERKS0_bi
+   fun:ROMol
+   fun:RWMol
+   fun:_ZN5RDKit6MolOps5addHsERKNS_5ROMolEbbPKSt6vectorIjSaIjEEb
+}
+{
+   memory possibly lost 117
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:allocate
+   fun:allocate
+   fun:_M_get_node
+   fun:_M_create_node<const boost::list_edge<long unsigned int, RDKit::Bond*>&>
+   fun:_M_insert<const boost::list_edge<long unsigned int, RDKit::Bond*>&>
+   fun:push_back
+   fun:push_dispatch<std::__cxx11::list<boost::list_edge<long unsigned int, RDKit::Bond*>, std::allocator<boost::list_edge<long unsigned int, RDKit::Bond*> > >, boost::list_edge<long unsigned int, RDKit::Bond*>&>
+   fun:push<std::__cxx11::list<boost::list_edge<long unsigned int, RDKit::Bond*>, std::allocator<boost::list_edge<long unsigned int, RDKit::Bond*> > >, boost::list_edge<long unsigned int, RDKit::Bond*>&>
+   fun:add_edge<boost::detail::adj_list_gen<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*, boost::no_property, boost::listS>::config>
+   fun:add_edge<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::detail::adj_list_gen<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*, boost::no_property, boost::listS>::config, boost::undirected_graph_helper<boost::detail::adj_list_gen<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*, boost::no_property, boost::listS>::config> >
+   fun:add_edge<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::detail::adj_list_gen<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*, boost::no_property, boost::listS>::config, boost::undirected_graph_helper<boost::detail::adj_list_gen<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*, boost::no_property, boost::listS>::config> >
+   fun:_ZN5RDKit5RWMol7addBondEjjNS_4Bond8BondTypeE
+   fun:_ZN5RDKit6MolOps5addHsERNS_5RWMolEbbPKSt6vectorIjSaIjEEb
+   fun:_ZN5RDKit6MolOps5addHsERKNS_5ROMolEbbPKSt6vectorIjSaIjEEb
+}
+{
+   syscall param write(buf) points to uninitialised byte(s) 0
+   Memcheck:Param
+   write(buf)
+   fun:__write_nocancel
+   fun:_IO_file_write*
+   fun:_IO_file_xsputn*
+   fun:vfprintf
+   fun:printf
+}
+{
+   uninitialised value used 14
+   Memcheck:Value8
+   fun:__mpn_submul_1
+   obj:*
+}
+{
+   invalid read of size 13
+   Memcheck:Addr8
+   fun:_ZNK5RDKit4Dict6getValERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERS6_
+   fun:getProp<std::__cxx11::basic_string<char> >
+}
+{
+   memory definitely lost
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:_Znam
+   fun:calculate_EEM_parameters
+   fun:getEEMs
+   fun:_ZN5RDKit11Descriptors3EEMERNS_5ROMolERSt6vectorIdSaIdEEi
+}
+{
+   memory definitely lost 0
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:_Znwm
+}
+{
+   memory indirectly lost
+   Memcheck:Leak
+   match-leak-kinds: indirect
+   fun:_Znam
+   fun:Matrix
+   fun:SquareMatrix
+   fun:Transform3D
+   fun:_ZN13MolTransforms25computeCanonicalTransformERKN5RDKit9ConformerEPKN6RDGeom7Point3DEbb
+}
+{
+   memory indirectly lost 0
+   Memcheck:Leak
+   match-leak-kinds: indirect
+   fun:_Znam
+   fun:_ZN11ForceFields10ForceField10initializeEv
+}
+{
+   memory indirectly lost 1
+   Memcheck:Leak
+   match-leak-kinds: indirect
+   fun:_Znam
+   fun:_ZN5RDKit6MolOps14getDistanceMatERKNS_5ROMolEbbbPKc
+}
+{
+   memory indirectly lost 2
+   Memcheck:Leak
+   match-leak-kinds: indirect
+   fun:_Znam
+   fun:_ZN5RDKit6MolOps18getAdjacencyMatrixERKNS_5ROMolEbibPKcPKN5boost14dynamic_bitsetImSaImEEE
+}
+{
+   memory indirectly lost 3
+   Memcheck:Leak
+   match-leak-kinds: indirect
+   fun:_Znam
+   fun:_ZNSt13basic_filebufIcSt11char_traitsIcEE27_M_allocate_internal_bufferEv
+   fun:_ZNSt13basic_filebufIcSt11char_traitsIcEE4openEPKcSt13_Ios_Openmode
+   fun:open
+   fun:basic_ifstream
+   fun:_ZN5RDKit17SmilesMolSupplierC1ERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEES8_iibb
+}
+{
+   memory indirectly lost 4
+   Memcheck:Leak
+   match-leak-kinds: indirect
+   fun:_Znwm
+}
+{
+   memory possibly lost
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:ParseMolFileBondLine
+   fun:_ZN5RDKit12_GLOBAL__N_118ParseMolBlockBondsEPSiRjjPNS_5RWMolERb
+   fun:_ZN5RDKit15FileParserUtils14ParseV2000CTABEPSiRjPNS_5RWMolERPNS_9ConformerERbS2_S2_b
+   fun:_ZN5RDKit18MolDataStreamToMolEPSiRjbbb
+   fun:_ZN5RDKit20ForwardSDMolSupplier5_nextEv
+   fun:_ZN5RDKit13SDMolSupplier4nextEv
+}
+{
+   memory possibly lost 0
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:RDValue
+   fun:_ZN5RDKit4Dict6setValISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS8_EEEEvRKS8_RT_
+   fun:_ZN5RDKit5ROMol7initMolEv
+   fun:ROMol
+   fun:_ZN5RDKit18MolDataStreamToMolEPSiRjbbb
+   fun:_ZN5RDKit20ForwardSDMolSupplier5_nextEv
+   fun:_ZN5RDKit13SDMolSupplier4nextEv
+   fun:_ZN5RDKit13SDMolSupplierixEj
+   fun:_Z19mmffValidationSuiteiPPc
+}
+{
+   memory possibly lost 4
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:RDValue
+   fun:_ZN5RDKit4Dict6setValISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS8_EEEEvRKS8_RT_
+   fun:setProp<int>
+   fun:_ZN5RDKit6MolOps21assignStereochemistryERNS_5ROMolEbbb
+   fun:_ZN5RDKit11SmilesToMolERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERKNS_18SmilesParserParamsE
+   fun:SmilesToMol
+}
+{
+   memory possibly lost 5
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:RDValue
+   fun:_ZN5RDKit4Dict6setValISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS8_EEEEvRKS8_RT_
+   fun:setProp<int>
+   fun:_ZN5RDKit6MolOps21assignStereochemistryERNS_5ROMolEbbb
+   fun:_ZN5RDKit11SmilesToMolERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERKNS_18SmilesParserParamsE
+   fun:_ZN5RDKit17SmilesMolSupplier11processLineENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE
+   fun:_ZN5RDKit17SmilesMolSupplier4nextEv
+   fun:_ZN5RDKit17SmilesMolSupplierixEj
+}
+{
+   memory possibly lost 6
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:RDValue
+   fun:_ZN5RDKit4Dict6setValISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS8_EEEEvRKS8_RT_
+   fun:setProp<int>
+   fun:_ZN5RDKit6MolOps21assignStereochemistryERNS_5ROMolEbbb
+   fun:_ZN5RDKit18MolDataStreamToMolEPSiRjbbb
+   fun:_ZN5RDKit20ForwardSDMolSupplier5_nextEv
+   fun:_ZN5RDKit13SDMolSupplier4nextEv
+}
+{
+   memory possibly lost 7
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:RDValue
+   fun:_ZN5RDKit4Dict6setValISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS8_EEEEvRKS8_RT_
+   fun:setProp<unsigned int>
+   fun:_ZN5RDKit9Chirality18assignAtomCIPRanksERKNS_5ROMolERSt6vectorIjSaIjEE
+   fun:_ZN5RDKit9Chirality21assignAtomChiralCodesERNS_5ROMolERSt6vectorIjSaIjEEb
+   fun:_ZN5RDKit6MolOps21assignStereochemistryERNS_5ROMolEbbb
+   fun:_ZN5RDKit11SmilesToMolERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERKNS_18SmilesParserParamsE
+   fun:SmilesToMol
+}
+{
+   memory possibly lost 9
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:RDValue
+   fun:_ZN5RDKit4Dict6setValISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS8_EEEEvRKS8_RT_
+   fun:setProp<unsigned int>
+   fun:_ZN5RDKit9Chirality18assignAtomCIPRanksERKNS_5ROMolERSt6vectorIjSaIjEE
+   fun:_ZN5RDKit9Chirality21assignAtomChiralCodesERNS_5ROMolERSt6vectorIjSaIjEEb
+   fun:_ZN5RDKit6MolOps21assignStereochemistryERNS_5ROMolEbbb
+   fun:_ZN5RDKit18MolDataStreamToMolEPSiRjbbb
+   fun:_ZN5RDKit20ForwardSDMolSupplier5_nextEv
+   fun:_ZN5RDKit13SDMolSupplier4nextEv
+}
+{
+   memory possibly lost 10
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:RDValue
+   fun:setVal<std::__cxx11::basic_string<char> >
+   fun:_ZNK5RDKit7RDProps7setPropINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEEvRKS7_T_b
+   fun:_ZN5RDKit17SmilesMolSupplier11processLineENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE
+   fun:_ZN5RDKit17SmilesMolSupplier4nextEv
+   fun:_ZN5RDKit17SmilesMolSupplierixEj
+}
+{
+   memory possibly lost 11
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:RDValue
+   fun:setVal<std::__cxx11::basic_string<char> >
+   fun:_ZNK5RDKit7RDProps7setPropINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEEvRKS7_T_b
+   fun:_ZN5RDKit18MolDataStreamToMolEPSiRjbbb
+   fun:_ZN5RDKit20ForwardSDMolSupplier5_nextEv
+   fun:_ZN5RDKit13SDMolSupplier4nextEv
+}
+{
+   memory possibly lost 12
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:RDValue
+   fun:setVal<std::__cxx11::basic_string<char> >
+   fun:setProp<std::__cxx11::basic_string<char> >
+   fun:_ZN5RDKit20ForwardSDMolSupplier12readMolPropsEPNS_5ROMolE
+   fun:_ZN5RDKit20ForwardSDMolSupplier5_nextEv
+   fun:_ZN5RDKit13SDMolSupplier4nextEv
+}
+{
+   memory possibly lost 13
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:RDValue
+   fun:setVal<std::__cxx11::basic_string<char> >
+   fun:setProp<std::__cxx11::basic_string<char> >
+   fun:_ZN5RDKit9Chirality21assignAtomChiralCodesERNS_5ROMolERSt6vectorIjSaIjEEb
+   fun:_ZN5RDKit6MolOps21assignStereochemistryERNS_5ROMolEbbb
+   fun:_ZN5RDKit11SmilesToMolERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERKNS_18SmilesParserParamsE
+   fun:SmilesToMol
+}
+{
+   memory possibly lost 14
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:RDValue
+   fun:setVal<std::vector<std::__cxx11::basic_string<char> > >
+   fun:_ZNK5RDKit7RDProps7setPropIiEEvRKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEET_b
+   fun:_ZN5RDKit4MMFF15sanitizeMMFFMolERNS_5RWMolE
+   fun:_Z19mmffValidationSuiteiPPc
+}
+{
+   memory possibly lost 15
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:RDValue
+   fun:setVal<std::vector<std::__cxx11::basic_string<char> > >
+   fun:clearComputedProps
+   fun:_ZNK5RDKit5ROMol18clearComputedPropsEb
+   fun:_ZN5RDKit6MolOps11sanitizeMolERNS_5RWMolERjj
+   fun:_ZN5RDKit4MMFF15sanitizeMMFFMolERNS_5RWMolE
+   fun:_Z19mmffValidationSuiteiPPc
+}
+{
+   memory possibly lost 16
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:_Z12yysmiles_lexP7YYSTYPEPvRi
+   fun:_Z14yysmiles_parsePKcPSt6vectorIPN5RDKit5RWMolESaIS4_EERPNS2_4AtomERPNS2_4BondEPNSt7__cxx114listIjSaIjEEEPvRi
+   fun:_ZN5RDKit12_GLOBAL__N_112smiles_parseERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERSt6vectorIPNS_5RWMolESaISB_EE
+   fun:_ZN5RDKit5toMolERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEPFiS7_RSt6vectorIPNS_5RWMolESaISA_EEES7_
+   fun:_ZN5RDKit11SmilesToMolERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERKNS_18SmilesParserParamsE
+   fun:SmilesToMol
+}
+{
+   memory possibly lost 17
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:_Z12yysmiles_lexP7YYSTYPEPvRi
+   fun:_Z14yysmiles_parsePKcPSt6vectorIPN5RDKit5RWMolESaIS4_EERPNS2_4AtomERPNS2_4BondEPNSt7__cxx114listIjSaIjEEEPvRi
+   fun:_ZN5RDKit12_GLOBAL__N_112smiles_parseERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERSt6vectorIPNS_5RWMolESaISB_EE
+   fun:_ZN5RDKit5toMolERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEPFiS7_RSt6vectorIPNS_5RWMolESaISA_EEES7_
+   fun:_ZN5RDKit11SmilesToMolERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERKNS_18SmilesParserParamsE
+   fun:_ZN5RDKit17SmilesMolSupplier11processLineENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE
+   fun:_ZN5RDKit17SmilesMolSupplier4nextEv
+   fun:_ZN5RDKit17SmilesMolSupplierixEj
+}
+{
+   memory possibly lost 18
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:_Z14yysmiles_parsePKcPSt6vectorIPN5RDKit5RWMolESaIS4_EERPNS2_4AtomERPNS2_4BondEPNSt7__cxx114listIjSaIjEEEPvRi
+   fun:_ZN5RDKit12_GLOBAL__N_112smiles_parseERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERSt6vectorIPNS_5RWMolESaISB_EE
+   fun:_ZN5RDKit5toMolERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEPFiS7_RSt6vectorIPNS_5RWMolESaISA_EEES7_
+   fun:_ZN5RDKit11SmilesToMolERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERKNS_18SmilesParserParamsE
+   fun:SmilesToMol
+}
+{
+   memory possibly lost 19
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:_Z14yysmiles_parsePKcPSt6vectorIPN5RDKit5RWMolESaIS4_EERPNS2_4AtomERPNS2_4BondEPNSt7__cxx114listIjSaIjEEEPvRi
+   fun:_ZN5RDKit12_GLOBAL__N_112smiles_parseERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERSt6vectorIPNS_5RWMolESaISB_EE
+   fun:_ZN5RDKit5toMolERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEPFiS7_RSt6vectorIPNS_5RWMolESaISA_EEES7_
+   fun:_ZN5RDKit11SmilesToMolERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERKNS_18SmilesParserParamsE
+   fun:_ZN5RDKit17SmilesMolSupplier11processLineENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE
+   fun:_ZN5RDKit17SmilesMolSupplier4nextEv
+   fun:_ZN5RDKit17SmilesMolSupplierixEj
+}
+{
+   memory possibly lost 20
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:_ZN5RDKit12DGeomHelpers18EmbedMultipleConfsERNS_5ROMolERSt6vectorIiSaIiEEjRKNS0_15EmbedParametersE
+   fun:EmbedMolecule
+   fun:EmbedMolecule
+   fun:_Z19mmffValidationSuiteiPPc
+}
+{
+   memory possibly lost 21
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:_ZN5RDKit12_GLOBAL__N_120ParseMolFileAtomLineENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERN6RDGeom7Point3DEj
+   fun:_ZN5RDKit12_GLOBAL__N_118ParseMolBlockAtomsEPSiRjjPNS_5RWMolEPNS_9ConformerE
+   fun:_ZN5RDKit15FileParserUtils14ParseV2000CTABEPSiRjPNS_5RWMolERPNS_9ConformerERbS2_S2_b
+   fun:_ZN5RDKit18MolDataStreamToMolEPSiRjbbb
+   fun:_ZN5RDKit20ForwardSDMolSupplier5_nextEv
+   fun:_ZN5RDKit13SDMolSupplier4nextEv
+}
+{
+   memory possibly lost 22
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:_ZN5RDKit15FileParserUtils14ParseV2000CTABEPSiRjPNS_5RWMolERPNS_9ConformerERbS2_S2_b
+   fun:_ZN5RDKit18MolDataStreamToMolEPSiRjbbb
+   fun:_ZN5RDKit20ForwardSDMolSupplier5_nextEv
+   fun:_ZN5RDKit13SDMolSupplier4nextEv
+}
+{
+   memory possibly lost 23
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:_ZN5RDKit18MolDataStreamToMolEPSiRjbbb
+   fun:_ZN5RDKit20ForwardSDMolSupplier5_nextEv
+   fun:_ZN5RDKit13SDMolSupplier4nextEv
+}
+{
+   memory possibly lost 25
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:_ZN5RDKit4MMFF17MMFFMolPropertiesC1ERNS_5ROMolERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEhRSo
+   fun:_Z19mmffValidationSuiteiPPc
+}
+{
+   memory possibly lost 27
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:_ZN5RDKit5ROMol7initMolEv
+   fun:ROMol
+   fun:_Z14yysmiles_parsePKcPSt6vectorIPN5RDKit5RWMolESaIS4_EERPNS2_4AtomERPNS2_4BondEPNSt7__cxx114listIjSaIjEEEPvRi
+   fun:_ZN5RDKit12_GLOBAL__N_112smiles_parseERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERSt6vectorIPNS_5RWMolESaISB_EE
+   fun:_ZN5RDKit5toMolERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEPFiS7_RSt6vectorIPNS_5RWMolESaISA_EEES7_
+   fun:_ZN5RDKit11SmilesToMolERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERKNS_18SmilesParserParamsE
+   fun:SmilesToMol
+}
+{
+   memory possibly lost 28
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:_ZN5RDKit5ROMol7initMolEv
+   fun:ROMol
+   fun:_Z14yysmiles_parsePKcPSt6vectorIPN5RDKit5RWMolESaIS4_EERPNS2_4AtomERPNS2_4BondEPNSt7__cxx114listIjSaIjEEEPvRi
+   fun:_ZN5RDKit12_GLOBAL__N_112smiles_parseERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERSt6vectorIPNS_5RWMolESaISB_EE
+   fun:_ZN5RDKit5toMolERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEPFiS7_RSt6vectorIPNS_5RWMolESaISA_EEES7_
+   fun:_ZN5RDKit11SmilesToMolERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERKNS_18SmilesParserParamsE
+   fun:_ZN5RDKit17SmilesMolSupplier11processLineENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE
+   fun:_ZN5RDKit17SmilesMolSupplier4nextEv
+   fun:_ZN5RDKit17SmilesMolSupplierixEj
+}
+{
+   memory possibly lost 29
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:_ZN5RDKit5ROMol7initMolEv
+   fun:ROMol
+   fun:_ZN5RDKit18MolDataStreamToMolEPSiRjbbb
+   fun:_ZN5RDKit20ForwardSDMolSupplier5_nextEv
+   fun:_ZN5RDKit13SDMolSupplier4nextEv
+}
+{
+   memory possibly lost 30
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:_ZN5RDKit5RWMol17createPartialBondEjNS_4Bond8BondTypeE
+   fun:_Z14yysmiles_parsePKcPSt6vectorIPN5RDKit5RWMolESaIS4_EERPNS2_4AtomERPNS2_4BondEPNSt7__cxx114listIjSaIjEEEPvRi
+   fun:_ZN5RDKit12_GLOBAL__N_112smiles_parseERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERSt6vectorIPNS_5RWMolESaISB_EE
+   fun:_ZN5RDKit5toMolERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEPFiS7_RSt6vectorIPNS_5RWMolESaISA_EEES7_
+   fun:_ZN5RDKit11SmilesToMolERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERKNS_18SmilesParserParamsE
+   fun:_ZN5RDKit17SmilesMolSupplier11processLineENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE
+   fun:_ZN5RDKit17SmilesMolSupplier4nextEv
+   fun:_ZN5RDKit17SmilesMolSupplierixEj
+}
+{
+   memory possibly lost 31
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:_ZN5RDKit5RWMol7addBondEjjNS_4Bond8BondTypeE
+   fun:_Z14yysmiles_parsePKcPSt6vectorIPN5RDKit5RWMolESaIS4_EERPNS2_4AtomERPNS2_4BondEPNSt7__cxx114listIjSaIjEEEPvRi
+   fun:_ZN5RDKit12_GLOBAL__N_112smiles_parseERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERSt6vectorIPNS_5RWMolESaISB_EE
+   fun:_ZN5RDKit5toMolERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEPFiS7_RSt6vectorIPNS_5RWMolESaISA_EEES7_
+   fun:_ZN5RDKit11SmilesToMolERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERKNS_18SmilesParserParamsE
+   fun:SmilesToMol
+}
+{
+   memory possibly lost 32
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:_ZN5RDKit5RWMol7addBondEjjNS_4Bond8BondTypeE
+   fun:_Z14yysmiles_parsePKcPSt6vectorIPN5RDKit5RWMolESaIS4_EERPNS2_4AtomERPNS2_4BondEPNSt7__cxx114listIjSaIjEEEPvRi
+   fun:_ZN5RDKit12_GLOBAL__N_112smiles_parseERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERSt6vectorIPNS_5RWMolESaISB_EE
+   fun:_ZN5RDKit5toMolERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEPFiS7_RSt6vectorIPNS_5RWMolESaISA_EEES7_
+   fun:_ZN5RDKit11SmilesToMolERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERKNS_18SmilesParserParamsE
+   fun:_ZN5RDKit17SmilesMolSupplier11processLineENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE
+   fun:_ZN5RDKit17SmilesMolSupplier4nextEv
+   fun:_ZN5RDKit17SmilesMolSupplierixEj
+}
+{
+   memory possibly lost 33
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:_ZN5RDKit5RWMol7addBondEjjNS_4Bond8BondTypeE
+   fun:_ZN5RDKit6MolOps5addHsERNS_5RWMolEbbPKSt6vectorIjSaIjEEb
+   fun:_Z19mmffValidationSuiteiPPc
+}
+{
+   memory possibly lost 36
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:_ZN5RDKit6MolOps5addHsERNS_5RWMolEbbPKSt6vectorIjSaIjEEb
+   fun:_Z19mmffValidationSuiteiPPc
+}
+{
+   memory possibly lost 39
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:_ZNK5RDKit4Atom4copyEv
+   fun:_ZN5RDKit5ROMol7addAtomEPNS_4AtomEbb
+   fun:addAtom
+   fun:_Z14yysmiles_parsePKcPSt6vectorIPN5RDKit5RWMolESaIS4_EERPNS2_4AtomERPNS2_4BondEPNSt7__cxx114listIjSaIjEEEPvRi
+   fun:_ZN5RDKit12_GLOBAL__N_112smiles_parseERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERSt6vectorIPNS_5RWMolESaISB_EE
+   fun:_ZN5RDKit5toMolERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEPFiS7_RSt6vectorIPNS_5RWMolESaISA_EEES7_
+   fun:_ZN5RDKit11SmilesToMolERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERKNS_18SmilesParserParamsE
+   fun:SmilesToMol
+}
+{
+   memory possibly lost 40
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:_ZNK5RDKit4Atom4copyEv
+   fun:_ZN5RDKit5ROMol7addAtomEPNS_4AtomEbb
+   fun:addAtom
+   fun:_Z14yysmiles_parsePKcPSt6vectorIPN5RDKit5RWMolESaIS4_EERPNS2_4AtomERPNS2_4BondEPNSt7__cxx114listIjSaIjEEEPvRi
+   fun:_ZN5RDKit12_GLOBAL__N_112smiles_parseERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERSt6vectorIPNS_5RWMolESaISB_EE
+   fun:_ZN5RDKit5toMolERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEPFiS7_RSt6vectorIPNS_5RWMolESaISA_EEES7_
+   fun:_ZN5RDKit11SmilesToMolERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERKNS_18SmilesParserParamsE
+   fun:_ZN5RDKit17SmilesMolSupplier11processLineENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE
+   fun:_ZN5RDKit17SmilesMolSupplier4nextEv
+   fun:_ZN5RDKit17SmilesMolSupplierixEj
+}
+{
+   memory possibly lost 42
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE12_M_constructIPcEEvT_S7_St20forward_iterator_tag.isra.251
+   fun:_M_construct_aux<char*>
+   fun:_M_construct<char*>
+   fun:basic_string
+   fun:Pair
+   fun:setVal<std::__cxx11::basic_string<char> >
+   fun:_ZNK5RDKit7RDProps7setPropINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEEvRKS7_T_b
+   fun:_ZN5RDKit18MolDataStreamToMolEPSiRjbbb
+   fun:_ZN5RDKit20ForwardSDMolSupplier5_nextEv
+   fun:_ZN5RDKit13SDMolSupplier4nextEv
+}
+{
+   memory possibly lost 43
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE12_M_constructIPcEEvT_S7_St20forward_iterator_tag.isra.251
+   fun:_M_construct_aux<char*>
+   fun:_M_construct<char*>
+   fun:basic_string
+   fun:RDValue
+   fun:setVal<std::__cxx11::basic_string<char> >
+   fun:_ZNK5RDKit7RDProps7setPropINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEEvRKS7_T_b
+   fun:_ZN5RDKit17SmilesMolSupplier11processLineENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE
+   fun:_ZN5RDKit17SmilesMolSupplier4nextEv
+   fun:_ZN5RDKit17SmilesMolSupplierixEj
+}
+{
+   memory possibly lost 44
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE12_M_constructIPcEEvT_S7_St20forward_iterator_tag.isra.251
+   fun:_M_construct_aux<char*>
+   fun:_M_construct<char*>
+   fun:basic_string
+   fun:RDValue
+   fun:setVal<std::__cxx11::basic_string<char> >
+   fun:_ZNK5RDKit7RDProps7setPropINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEEvRKS7_T_b
+   fun:_ZN5RDKit18MolDataStreamToMolEPSiRjbbb
+   fun:_ZN5RDKit20ForwardSDMolSupplier5_nextEv
+   fun:_ZN5RDKit13SDMolSupplier4nextEv
+}
+{
+   memory possibly lost 45
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE12_M_constructIPcEEvT_S7_St20forward_iterator_tag.isra.413
+   fun:_M_construct_aux<char*>
+   fun:_M_construct<char*>
+   fun:basic_string
+   fun:Pair
+   fun:setPODVal<int>
+   fun:setVal
+   fun:_ZNK5RDKit7RDProps7setPropIiEEvRKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEET_b
+   fun:_ZN5RDKit9Chirality21assignAtomChiralCodesERNS_5ROMolERSt6vectorIjSaIjEEb
+   fun:_ZN5RDKit6MolOps21assignStereochemistryERNS_5ROMolEbbb
+   fun:_ZN5RDKit11SmilesToMolERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERKNS_18SmilesParserParamsE
+   fun:SmilesToMol
+}
+{
+   memory possibly lost 46
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE12_M_constructIPcEEvT_S7_St20forward_iterator_tag.isra.413
+   fun:_M_construct_aux<char*>
+   fun:_M_construct<char*>
+   fun:basic_string
+   fun:Pair
+   fun:setPODVal<int>
+   fun:setVal
+   fun:_ZNK5RDKit7RDProps7setPropIiEEvRKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEET_b
+   fun:_ZN5RDKit9Chirality21assignAtomChiralCodesERNS_5ROMolERSt6vectorIjSaIjEEb
+   fun:_ZN5RDKit6MolOps21assignStereochemistryERNS_5ROMolEbbb
+   fun:_ZN5RDKit11SmilesToMolERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERKNS_18SmilesParserParamsE
+   fun:_ZN5RDKit17SmilesMolSupplier11processLineENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE
+   fun:_ZN5RDKit17SmilesMolSupplier4nextEv
+   fun:_ZN5RDKit17SmilesMolSupplierixEj
+   fun:_Z19mmffValidationSuiteiPPc
+}
+{
+   memory possibly lost 47
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE12_M_constructIPcEEvT_S7_St20forward_iterator_tag.isra.89
+   fun:_M_construct_aux<char*>
+   fun:_M_construct<char*>
+   fun:basic_string
+   fun:Pair
+   fun:setVal<std::__cxx11::basic_string<char> >
+   fun:setProp<std::__cxx11::basic_string<char> >
+   fun:_ZN5RDKit20ForwardSDMolSupplier12readMolPropsEPNS_5ROMolE
+   fun:_ZN5RDKit20ForwardSDMolSupplier5_nextEv
+   fun:_ZN5RDKit13SDMolSupplier4nextEv
+}
+{
+   memory possibly lost 48
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE12_M_constructIPcEEvT_S7_St20forward_iterator_tag.isra.89
+   fun:_M_construct_aux<char*>
+   fun:_M_construct<char*>
+   fun:basic_string
+   fun:RDValue
+   fun:setVal<std::__cxx11::basic_string<char> >
+   fun:setProp<std::__cxx11::basic_string<char> >
+   fun:_ZN5RDKit20ForwardSDMolSupplier12readMolPropsEPNS_5ROMolE
+   fun:_ZN5RDKit20ForwardSDMolSupplier5_nextEv
+   fun:_ZN5RDKit13SDMolSupplier4nextEv
+}
+{
+   memory possibly lost 50
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:adjacency_list
+   fun:ROMol
+   fun:_Z14yysmiles_parsePKcPSt6vectorIPN5RDKit5RWMolESaIS4_EERPNS2_4AtomERPNS2_4BondEPNSt7__cxx114listIjSaIjEEEPvRi
+   fun:_ZN5RDKit12_GLOBAL__N_112smiles_parseERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERSt6vectorIPNS_5RWMolESaISB_EE
+   fun:_ZN5RDKit5toMolERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEPFiS7_RSt6vectorIPNS_5RWMolESaISA_EEES7_
+   fun:_ZN5RDKit11SmilesToMolERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERKNS_18SmilesParserParamsE
+   fun:SmilesToMol
+}
+{
+   memory possibly lost 51
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:adjacency_list
+   fun:ROMol
+   fun:_Z14yysmiles_parsePKcPSt6vectorIPN5RDKit5RWMolESaIS4_EERPNS2_4AtomERPNS2_4BondEPNSt7__cxx114listIjSaIjEEEPvRi
+   fun:_ZN5RDKit12_GLOBAL__N_112smiles_parseERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERSt6vectorIPNS_5RWMolESaISB_EE
+   fun:_ZN5RDKit5toMolERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEPFiS7_RSt6vectorIPNS_5RWMolESaISA_EEES7_
+   fun:_ZN5RDKit11SmilesToMolERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERKNS_18SmilesParserParamsE
+   fun:_ZN5RDKit17SmilesMolSupplier11processLineENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE
+   fun:_ZN5RDKit17SmilesMolSupplier4nextEv
+   fun:_ZN5RDKit17SmilesMolSupplierixEj
+}
+{
+   memory possibly lost 52
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:adjacency_list
+   fun:ROMol
+   fun:_ZN5RDKit18MolDataStreamToMolEPSiRjbbb
+   fun:_ZN5RDKit20ForwardSDMolSupplier5_nextEv
+   fun:_ZN5RDKit13SDMolSupplier4nextEv
+}
+{
+   memory possibly lost 53
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:allocate
+   fun:allocate
+   fun:_M_allocate
+   fun:_M_allocate_and_copy<const RDGeom::Point3D*>
+   fun:_ZNSt6vectorIN6RDGeom7Point3DESaIS1_EE7reserveEm
+   fun:reserve
+   fun:_ZN5RDKit6MolOps5addHsERNS_5RWMolEbbPKSt6vectorIjSaIjEEb
+   fun:_Z19mmffValidationSuiteiPPc
+}
+{
+   memory possibly lost 57
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:allocate
+   fun:allocate
+   fun:_M_allocate
+   fun:_M_create_storage
+   fun:_Vector_base
+   fun:vector
+   fun:RDValue
+   fun:_ZN5RDKit4Dict6setValISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS8_EEEEvRKS8_RT_
+   fun:setProp<int>
+   fun:_ZN5RDKit6MolOps21assignStereochemistryERNS_5ROMolEbbb
+   fun:_ZN5RDKit11SmilesToMolERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERKNS_18SmilesParserParamsE
+   fun:SmilesToMol
+}
+{
+   memory possibly lost 58
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:allocate
+   fun:allocate
+   fun:_M_allocate
+   fun:_M_create_storage
+   fun:_Vector_base
+   fun:vector
+   fun:RDValue
+   fun:_ZN5RDKit4Dict6setValISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS8_EEEEvRKS8_RT_
+   fun:setProp<int>
+   fun:_ZN5RDKit6MolOps21assignStereochemistryERNS_5ROMolEbbb
+   fun:_ZN5RDKit11SmilesToMolERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERKNS_18SmilesParserParamsE
+   fun:_ZN5RDKit17SmilesMolSupplier11processLineENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE
+   fun:_ZN5RDKit17SmilesMolSupplier4nextEv
+   fun:_ZN5RDKit17SmilesMolSupplierixEj
+}
+{
+   memory possibly lost 59
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:allocate
+   fun:allocate
+   fun:_M_allocate
+   fun:_M_create_storage
+   fun:_Vector_base
+   fun:vector
+   fun:RDValue
+   fun:_ZN5RDKit4Dict6setValISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS8_EEEEvRKS8_RT_
+   fun:setProp<int>
+   fun:_ZN5RDKit6MolOps21assignStereochemistryERNS_5ROMolEbbb
+   fun:_ZN5RDKit18MolDataStreamToMolEPSiRjbbb
+   fun:_ZN5RDKit20ForwardSDMolSupplier5_nextEv
+   fun:_ZN5RDKit13SDMolSupplier4nextEv
+}
+{
+   memory possibly lost 60
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:allocate
+   fun:allocate
+   fun:_M_allocate
+   fun:_M_create_storage
+   fun:_Vector_base
+   fun:vector
+   fun:RDValue
+   fun:_ZN5RDKit4Dict6setValISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS8_EEEEvRKS8_RT_
+   fun:setProp<unsigned int>
+   fun:_ZN5RDKit9Chirality18assignAtomCIPRanksERKNS_5ROMolERSt6vectorIjSaIjEE
+   fun:_ZN5RDKit9Chirality21assignAtomChiralCodesERNS_5ROMolERSt6vectorIjSaIjEEb
+   fun:_ZN5RDKit6MolOps21assignStereochemistryERNS_5ROMolEbbb
+   fun:_ZN5RDKit11SmilesToMolERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERKNS_18SmilesParserParamsE
+   fun:SmilesToMol
+}
+{
+   memory possibly lost 62
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:allocate
+   fun:allocate
+   fun:_M_allocate
+   fun:_M_create_storage
+   fun:_Vector_base
+   fun:vector
+   fun:RDValue
+   fun:_ZN5RDKit4Dict6setValISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS8_EEEEvRKS8_RT_
+   fun:setProp<unsigned int>
+   fun:_ZN5RDKit9Chirality18assignAtomCIPRanksERKNS_5ROMolERSt6vectorIjSaIjEE
+   fun:_ZN5RDKit9Chirality21assignAtomChiralCodesERNS_5ROMolERSt6vectorIjSaIjEEb
+   fun:_ZN5RDKit6MolOps21assignStereochemistryERNS_5ROMolEbbb
+   fun:_ZN5RDKit18MolDataStreamToMolEPSiRjbbb
+   fun:_ZN5RDKit20ForwardSDMolSupplier5_nextEv
+   fun:_ZN5RDKit13SDMolSupplier4nextEv
+}
+{
+   memory possibly lost 63
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:allocate
+   fun:allocate
+   fun:_M_allocate
+   fun:_M_create_storage
+   fun:_Vector_base
+   fun:vector
+   fun:RDValue
+   fun:setVal<std::vector<std::__cxx11::basic_string<char> > >
+   fun:_ZNK5RDKit7RDProps7setPropIiEEvRKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEET_b
+   fun:_ZN5RDKit4MMFF15sanitizeMMFFMolERNS_5RWMolE
+   fun:_Z19mmffValidationSuiteiPPc
+}
+{
+   memory possibly lost 66
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:allocate
+   fun:allocate
+   fun:_M_allocate
+   fun:_M_create_storage
+   fun:_Vector_base
+   fun:vector
+   fun:_ZN5RDKit4MMFF17MMFFMolPropertiesC1ERNS_5ROMolERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEhRSo
+   fun:_Z19mmffValidationSuiteiPPc
+}
+{
+   memory possibly lost 67
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:allocate
+   fun:allocate
+   fun:_M_allocate
+   fun:_M_create_storage
+   fun:_Vector_base
+   fun:vector
+   fun:construct<std::vector<int>, const std::vector<int, std::allocator<int> >&>
+   fun:construct<std::vector<int>, const std::vector<int, std::allocator<int> >&>
+   fun:_ZNSt6vectorIS_IiSaIiEESaIS1_EE17_M_realloc_insertIJRKS1_EEEvN9__gnu_cxx17__normal_iteratorIPS1_S3_EEDpOT_
+   fun:push_back
+   fun:_ZN5RDKit8RingInfo7addRingERKSt6vectorIiSaIiEES5_
+   fun:_ZN9FindRings13storeRingInfoERKN5RDKit5ROMolERKSt6vectorIiSaIiEE
+   fun:_ZN9FindRings14storeRingsInfoERKN5RDKit5ROMolERKSt6vectorIS4_IiSaIiEESaIS6_EE
+   fun:_ZN5RDKit6MolOps8findSSSRERKNS_5ROMolERSt6vectorIS4_IiSaIiEESaIS6_EE
+   fun:_ZN5RDKit6MolOps14symmetrizeSSSRERNS_5ROMolERSt6vectorIS3_IiSaIiEESaIS5_EE
+   fun:_ZN5RDKit6MolOps11sanitizeMolERNS_5RWMolERjj
+   fun:_ZN5RDKit6MolOps11sanitizeMolERNS_5RWMolE
+   fun:_ZN5RDKit6MolOps8removeHsERNS_5RWMolEbbb
+   fun:_ZN5RDKit11SmilesToMolERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERKNS_18SmilesParserParamsE
+   fun:_ZN5RDKit17SmilesMolSupplier11processLineENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE
+   fun:_ZN5RDKit17SmilesMolSupplier4nextEv
+   fun:_ZN5RDKit17SmilesMolSupplierixEj
+}
+{
+   memory possibly lost 68
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:allocate
+   fun:allocate
+   fun:_M_allocate
+   fun:_M_create_storage
+   fun:_Vector_base
+   fun:vector
+   fun:construct<std::vector<int>, const std::vector<int, std::allocator<int> >&>
+   fun:construct<std::vector<int>, const std::vector<int, std::allocator<int> >&>
+   fun:_ZNSt6vectorIS_IiSaIiEESaIS1_EE17_M_realloc_insertIJRKS1_EEEvN9__gnu_cxx17__normal_iteratorIPS1_S3_EEDpOT_
+   fun:push_back
+   fun:_ZN5RDKit8RingInfo7addRingERKSt6vectorIiSaIiEES5_
+   fun:_ZN9FindRings13storeRingInfoERKN5RDKit5ROMolERKSt6vectorIiSaIiEE
+   fun:_ZN9FindRings14storeRingsInfoERKN5RDKit5ROMolERKSt6vectorIS4_IiSaIiEESaIS6_EE
+   fun:_ZN5RDKit6MolOps8findSSSRERKNS_5ROMolERSt6vectorIS4_IiSaIiEESaIS6_EE
+   fun:_ZN5RDKit6MolOps14symmetrizeSSSRERNS_5ROMolERSt6vectorIS3_IiSaIiEESaIS5_EE
+   fun:_ZN5RDKit6MolOps11sanitizeMolERNS_5RWMolERjj
+   fun:_ZN5RDKit6MolOps11sanitizeMolERNS_5RWMolE
+   fun:_ZN5RDKit6MolOps8removeHsERNS_5RWMolEbbb
+   fun:_ZN5RDKit18MolDataStreamToMolEPSiRjbbb
+   fun:_ZN5RDKit20ForwardSDMolSupplier5_nextEv
+   fun:_ZN5RDKit13SDMolSupplier4nextEv
+}
+{
+   memory possibly lost 69
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:allocate
+   fun:allocate
+   fun:_M_allocate
+   fun:_M_create_storage
+   fun:_Vector_base
+   fun:vector
+   fun:construct<std::vector<int>, const std::vector<int, std::allocator<int> >&>
+   fun:construct<std::vector<int>, const std::vector<int, std::allocator<int> >&>
+   fun:push_back
+   fun:_ZN5RDKit8RingInfo7addRingERKSt6vectorIiSaIiEES5_
+   fun:_ZN9FindRings13storeRingInfoERKN5RDKit5ROMolERKSt6vectorIiSaIiEE
+   fun:_ZN9FindRings14storeRingsInfoERKN5RDKit5ROMolERKSt6vectorIS4_IiSaIiEESaIS6_EE
+   fun:_ZN5RDKit6MolOps8findSSSRERKNS_5ROMolERSt6vectorIS4_IiSaIiEESaIS6_EE
+   fun:_ZN5RDKit6MolOps14symmetrizeSSSRERNS_5ROMolERSt6vectorIS3_IiSaIiEESaIS5_EE
+   fun:_ZN5RDKit6MolOps11sanitizeMolERNS_5RWMolERjj
+   fun:_ZN5RDKit4MMFF15sanitizeMMFFMolERNS_5RWMolE
+   fun:_Z19mmffValidationSuiteiPPc
+}
+{
+   memory possibly lost 70
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:allocate
+   fun:allocate
+   fun:_M_allocate
+   fun:_M_create_storage
+   fun:_Vector_base
+   fun:vector
+   fun:construct<std::vector<int>, const std::vector<int, std::allocator<int> >&>
+   fun:construct<std::vector<int>, const std::vector<int, std::allocator<int> >&>
+   fun:push_back
+   fun:_ZN5RDKit8RingInfo7addRingERKSt6vectorIiSaIiEES5_
+   fun:_ZN9FindRings13storeRingInfoERKN5RDKit5ROMolERKSt6vectorIiSaIiEE
+   fun:_ZN9FindRings14storeRingsInfoERKN5RDKit5ROMolERKSt6vectorIS4_IiSaIiEESaIS6_EE
+   fun:_ZN5RDKit6MolOps8findSSSRERKNS_5ROMolERSt6vectorIS4_IiSaIiEESaIS6_EE
+   fun:_ZN5RDKit6MolOps14symmetrizeSSSRERNS_5ROMolERSt6vectorIS3_IiSaIiEESaIS5_EE
+   fun:_ZN5RDKit6MolOps11sanitizeMolERNS_5RWMolERjj
+   fun:_ZN5RDKit6MolOps11sanitizeMolERNS_5RWMolE
+   fun:_ZN5RDKit6MolOps8removeHsERNS_5RWMolEbbb
+   fun:_ZN5RDKit11SmilesToMolERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERKNS_18SmilesParserParamsE
+   fun:_ZN5RDKit17SmilesMolSupplier11processLineENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE
+   fun:_ZN5RDKit17SmilesMolSupplier4nextEv
+   fun:_ZN5RDKit17SmilesMolSupplierixEj
+   fun:_Z19mmffValidationSuiteiPPc
+}
+{
+   memory possibly lost 73
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:allocate
+   fun:allocate
+   fun:_M_allocate
+   fun:_ZNSt6vectorIN5RDKit4Dict4PairESaIS2_EE17_M_realloc_insertIJS2_EEEvN9__gnu_cxx17__normal_iteratorIPS2_S4_EEDpOT_
+   fun:push_back
+   fun:setPODVal<int>
+   fun:setVal
+   fun:_ZNK5RDKit7RDProps7setPropIiEEvRKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEET_b
+   fun:_Z14yysmiles_parsePKcPSt6vectorIPN5RDKit5RWMolESaIS4_EERPNS2_4AtomERPNS2_4BondEPNSt7__cxx114listIjSaIjEEEPvRi
+   fun:_ZN5RDKit12_GLOBAL__N_112smiles_parseERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERSt6vectorIPNS_5RWMolESaISB_EE
+   fun:_ZN5RDKit5toMolERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEPFiS7_RSt6vectorIPNS_5RWMolESaISA_EEES7_
+   fun:_ZN5RDKit11SmilesToMolERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERKNS_18SmilesParserParamsE
+   fun:_ZN5RDKit17SmilesMolSupplier11processLineENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE
+   fun:_ZN5RDKit17SmilesMolSupplier4nextEv
+   fun:_ZN5RDKit17SmilesMolSupplierixEj
+}
+{
+   memory possibly lost 74
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:allocate
+   fun:allocate
+   fun:_M_allocate
+   fun:_ZNSt6vectorIN5RDKit4Dict4PairESaIS2_EE17_M_realloc_insertIJS2_EEEvN9__gnu_cxx17__normal_iteratorIPS2_S4_EEDpOT_
+   fun:push_back
+   fun:setPODVal<int>
+   fun:setVal
+   fun:_ZNK5RDKit7RDProps7setPropIiEEvRKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEET_b
+   fun:_ZN5RDKit9Chirality21assignAtomChiralCodesERNS_5ROMolERSt6vectorIjSaIjEEb
+   fun:_ZN5RDKit6MolOps21assignStereochemistryERNS_5ROMolEbbb
+   fun:_ZN5RDKit11SmilesToMolERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERKNS_18SmilesParserParamsE
+   fun:SmilesToMol
+}
+{
+   memory possibly lost 75
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:allocate
+   fun:allocate
+   fun:_M_allocate
+   fun:_ZNSt6vectorIN5RDKit4Dict4PairESaIS2_EE17_M_realloc_insertIJS2_EEEvN9__gnu_cxx17__normal_iteratorIPS2_S4_EEDpOT_
+   fun:push_back
+   fun:setPODVal<int>
+   fun:setVal
+   fun:_ZNK5RDKit7RDProps7setPropIiEEvRKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEET_b
+   fun:_ZN5RDKit9Chirality21assignAtomChiralCodesERNS_5ROMolERSt6vectorIjSaIjEEb
+   fun:_ZN5RDKit6MolOps21assignStereochemistryERNS_5ROMolEbbb
+   fun:_ZN5RDKit11SmilesToMolERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERKNS_18SmilesParserParamsE
+   fun:_ZN5RDKit17SmilesMolSupplier11processLineENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE
+   fun:_ZN5RDKit17SmilesMolSupplier4nextEv
+   fun:_ZN5RDKit17SmilesMolSupplierixEj
+   fun:_Z19mmffValidationSuiteiPPc
+}
+{
+   memory possibly lost 76
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:allocate
+   fun:allocate
+   fun:_M_allocate
+   fun:_ZNSt6vectorIN5RDKit4Dict4PairESaIS2_EE17_M_realloc_insertIJS2_EEEvN9__gnu_cxx17__normal_iteratorIPS2_S4_EEDpOT_
+   fun:push_back
+   fun:setPODVal<int>
+   fun:setVal
+   fun:setProp<int>
+   fun:_ZN5RDKit6MolOps21assignStereochemistryERNS_5ROMolEbbb
+   fun:_ZN5RDKit11SmilesToMolERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERKNS_18SmilesParserParamsE
+   fun:SmilesToMol
+}
+{
+   memory possibly lost 77
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:allocate
+   fun:allocate
+   fun:_M_allocate
+   fun:_ZNSt6vectorIN5RDKit4Dict4PairESaIS2_EE17_M_realloc_insertIJS2_EEEvN9__gnu_cxx17__normal_iteratorIPS2_S4_EEDpOT_
+   fun:push_back
+   fun:setPODVal<int>
+   fun:setVal
+   fun:setProp<int>
+   fun:_ZN5RDKit6MolOps21assignStereochemistryERNS_5ROMolEbbb
+   fun:_ZN5RDKit11SmilesToMolERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERKNS_18SmilesParserParamsE
+   fun:_ZN5RDKit17SmilesMolSupplier11processLineENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE
+   fun:_ZN5RDKit17SmilesMolSupplier4nextEv
+   fun:_ZN5RDKit17SmilesMolSupplierixEj
+}
+{
+   memory possibly lost 78
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:allocate
+   fun:allocate
+   fun:_M_allocate
+   fun:_ZNSt6vectorIN5RDKit4Dict4PairESaIS2_EE17_M_realloc_insertIJS2_EEEvN9__gnu_cxx17__normal_iteratorIPS2_S4_EEDpOT_
+   fun:push_back
+   fun:setPODVal<int>
+   fun:setVal
+   fun:setProp<int>
+   fun:_ZN5RDKit6MolOps5addHsERNS_5RWMolEbbPKSt6vectorIjSaIjEEb
+   fun:_Z19mmffValidationSuiteiPPc
+}
+{
+   memory possibly lost 80
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:allocate
+   fun:allocate
+   fun:_M_allocate
+   fun:_ZNSt6vectorIN5RDKit4Dict4PairESaIS2_EE17_M_realloc_insertIJS2_EEEvN9__gnu_cxx17__normal_iteratorIPS2_S4_EEDpOT_
+   fun:push_back
+   fun:setPODVal<unsigned int>
+   fun:setVal
+   fun:setProp<unsigned int>
+   fun:_ZN5RDKit9Chirality18assignAtomCIPRanksERKNS_5ROMolERSt6vectorIjSaIjEE
+   fun:_ZN5RDKit9Chirality21assignAtomChiralCodesERNS_5ROMolERSt6vectorIjSaIjEEb
+   fun:_ZN5RDKit6MolOps21assignStereochemistryERNS_5ROMolEbbb
+   fun:_ZN5RDKit11SmilesToMolERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERKNS_18SmilesParserParamsE
+   fun:SmilesToMol
+}
+{
+   memory possibly lost 82
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:allocate
+   fun:allocate
+   fun:_M_allocate
+   fun:_ZNSt6vectorIN5RDKit4Dict4PairESaIS2_EE17_M_realloc_insertIJS2_EEEvN9__gnu_cxx17__normal_iteratorIPS2_S4_EEDpOT_
+   fun:push_back
+   fun:setPODVal<unsigned int>
+   fun:setVal
+   fun:setProp<unsigned int>
+   fun:_ZN5RDKit9Chirality18assignAtomCIPRanksERKNS_5ROMolERSt6vectorIjSaIjEE
+   fun:_ZN5RDKit9Chirality21assignAtomChiralCodesERNS_5ROMolERSt6vectorIjSaIjEEb
+   fun:_ZN5RDKit6MolOps21assignStereochemistryERNS_5ROMolEbbb
+   fun:_ZN5RDKit18MolDataStreamToMolEPSiRjbbb
+   fun:_ZN5RDKit20ForwardSDMolSupplier5_nextEv
+   fun:_ZN5RDKit13SDMolSupplier4nextEv
+}
+{
+   memory possibly lost 83
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:allocate
+   fun:allocate
+   fun:_M_allocate
+   fun:_ZNSt6vectorIN5RDKit4Dict4PairESaIS2_EE17_M_realloc_insertIJS2_EEEvN9__gnu_cxx17__normal_iteratorIPS2_S4_EEDpOT_
+   fun:push_back
+   fun:setVal<std::__cxx11::basic_string<char> >
+   fun:_ZNK5RDKit7RDProps7setPropINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEEvRKS7_T_b
+   fun:_ZN5RDKit18MolDataStreamToMolEPSiRjbbb
+   fun:_ZN5RDKit20ForwardSDMolSupplier5_nextEv
+   fun:_ZN5RDKit13SDMolSupplier4nextEv
+   fun:_ZN5RDKit13SDMolSupplierixEj
+   fun:_Z19mmffValidationSuiteiPPc
+}
+{
+   memory possibly lost 84
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:allocate
+   fun:allocate
+   fun:_M_allocate
+   fun:_ZNSt6vectorIN5RDKit4Dict4PairESaIS2_EE17_M_realloc_insertIJS2_EEEvN9__gnu_cxx17__normal_iteratorIPS2_S4_EEDpOT_
+   fun:push_back
+   fun:setVal<std::__cxx11::basic_string<char> >
+   fun:setProp<std::__cxx11::basic_string<char> >
+   fun:_ZN5RDKit20ForwardSDMolSupplier12readMolPropsEPNS_5ROMolE
+   fun:_ZN5RDKit20ForwardSDMolSupplier5_nextEv
+   fun:_ZN5RDKit13SDMolSupplier4nextEv
+}
+{
+   memory possibly lost 85
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:allocate
+   fun:allocate
+   fun:_M_allocate
+   fun:_ZNSt6vectorIN5RDKit4Dict4PairESaIS2_EE17_M_realloc_insertIJS2_EEEvN9__gnu_cxx17__normal_iteratorIPS2_S4_EEDpOT_
+   fun:push_back
+   fun:setVal<std::vector<int> >
+   fun:_ZNK5RDKit7RDProps7setPropISt6vectorIiSaIiEEEEvRKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEET_b
+   fun:_Z14yysmiles_parsePKcPSt6vectorIPN5RDKit5RWMolESaIS4_EERPNS2_4AtomERPNS2_4BondEPNSt7__cxx114listIjSaIjEEEPvRi
+   fun:_ZN5RDKit12_GLOBAL__N_112smiles_parseERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERSt6vectorIPNS_5RWMolESaISB_EE
+   fun:_ZN5RDKit5toMolERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEPFiS7_RSt6vectorIPNS_5RWMolESaISA_EEES7_
+   fun:_ZN5RDKit11SmilesToMolERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERKNS_18SmilesParserParamsE
+   fun:_ZN5RDKit17SmilesMolSupplier11processLineENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE
+   fun:_ZN5RDKit17SmilesMolSupplier4nextEv
+   fun:_ZN5RDKit17SmilesMolSupplierixEj
+}
+{
+   memory possibly lost 86
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:allocate
+   fun:allocate
+   fun:_M_allocate
+   fun:_ZNSt6vectorIN5boost6detail12adj_list_genINS0_14adjacency_listINS0_4vecSES4_NS0_11undirectedSEPN5RDKit4AtomEPNS6_4BondENS0_11no_propertyENS0_5listSEEES4_S4_S5_S8_SA_SB_SC_E6config13stored_vertexESaISG_EE17_M_default_appendEm
+   fun:resize
+   fun:add_vertex<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::detail::adj_list_gen<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*, boost::no_property, boost::listS>::config, boost::undirected_graph_helper<boost::detail::adj_list_gen<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*, boost::no_property, boost::listS>::config> >
+   fun:_ZN5RDKit5ROMol7addAtomEPNS_4AtomEbb
+   fun:addAtom
+   fun:_Z14yysmiles_parsePKcPSt6vectorIPN5RDKit5RWMolESaIS4_EERPNS2_4AtomERPNS2_4BondEPNSt7__cxx114listIjSaIjEEEPvRi
+   fun:_ZN5RDKit12_GLOBAL__N_112smiles_parseERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERSt6vectorIPNS_5RWMolESaISB_EE
+   fun:_ZN5RDKit5toMolERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEPFiS7_RSt6vectorIPNS_5RWMolESaISA_EEES7_
+   fun:_ZN5RDKit11SmilesToMolERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERKNS_18SmilesParserParamsE
+   fun:SmilesToMol
+}
+{
+   memory possibly lost 87
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:allocate
+   fun:allocate
+   fun:_M_allocate
+   fun:_ZNSt6vectorIN5boost6detail12adj_list_genINS0_14adjacency_listINS0_4vecSES4_NS0_11undirectedSEPN5RDKit4AtomEPNS6_4BondENS0_11no_propertyENS0_5listSEEES4_S4_S5_S8_SA_SB_SC_E6config13stored_vertexESaISG_EE17_M_default_appendEm
+   fun:resize
+   fun:add_vertex<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::detail::adj_list_gen<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*, boost::no_property, boost::listS>::config, boost::undirected_graph_helper<boost::detail::adj_list_gen<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*, boost::no_property, boost::listS>::config> >
+   fun:_ZN5RDKit5ROMol7addAtomEPNS_4AtomEbb
+   fun:addAtom
+   fun:_Z14yysmiles_parsePKcPSt6vectorIPN5RDKit5RWMolESaIS4_EERPNS2_4AtomERPNS2_4BondEPNSt7__cxx114listIjSaIjEEEPvRi
+   fun:_ZN5RDKit12_GLOBAL__N_112smiles_parseERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERSt6vectorIPNS_5RWMolESaISB_EE
+   fun:_ZN5RDKit5toMolERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEPFiS7_RSt6vectorIPNS_5RWMolESaISA_EEES7_
+   fun:_ZN5RDKit11SmilesToMolERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERKNS_18SmilesParserParamsE
+   fun:_ZN5RDKit17SmilesMolSupplier11processLineENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE
+   fun:_ZN5RDKit17SmilesMolSupplier4nextEv
+   fun:_ZN5RDKit17SmilesMolSupplierixEj
+}
+{
+   memory possibly lost 88
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:allocate
+   fun:allocate
+   fun:_M_allocate
+   fun:_ZNSt6vectorIN5boost6detail12adj_list_genINS0_14adjacency_listINS0_4vecSES4_NS0_11undirectedSEPN5RDKit4AtomEPNS6_4BondENS0_11no_propertyENS0_5listSEEES4_S4_S5_S8_SA_SB_SC_E6config13stored_vertexESaISG_EE17_M_default_appendEm
+   fun:resize
+   fun:add_vertex<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::detail::adj_list_gen<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*, boost::no_property, boost::listS>::config, boost::undirected_graph_helper<boost::detail::adj_list_gen<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*, boost::no_property, boost::listS>::config> >
+   fun:_ZN5RDKit5ROMol7addAtomEPNS_4AtomEbb
+   fun:addAtom
+   fun:_ZN5RDKit12_GLOBAL__N_118ParseMolBlockAtomsEPSiRjjPNS_5RWMolEPNS_9ConformerE
+   fun:_ZN5RDKit15FileParserUtils14ParseV2000CTABEPSiRjPNS_5RWMolERPNS_9ConformerERbS2_S2_b
+   fun:_ZN5RDKit18MolDataStreamToMolEPSiRjbbb
+   fun:_ZN5RDKit20ForwardSDMolSupplier5_nextEv
+   fun:_ZN5RDKit13SDMolSupplier4nextEv
+}
+{
+   memory possibly lost 89
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:allocate
+   fun:allocate
+   fun:_M_allocate
+   fun:_ZNSt6vectorIN5boost6detail12adj_list_genINS0_14adjacency_listINS0_4vecSES4_NS0_11undirectedSEPN5RDKit4AtomEPNS6_4BondENS0_11no_propertyENS0_5listSEEES4_S4_S5_S8_SA_SB_SC_E6config13stored_vertexESaISG_EE17_M_default_appendEm
+   fun:resize
+   fun:add_vertex<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::detail::adj_list_gen<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*, boost::no_property, boost::listS>::config, boost::undirected_graph_helper<boost::detail::adj_list_gen<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*, boost::no_property, boost::listS>::config> >
+   fun:_ZN5RDKit5ROMol7addAtomEPNS_4AtomEbb
+   fun:addAtom
+   fun:_ZN5RDKit6MolOps5addHsERNS_5RWMolEbbPKSt6vectorIjSaIjEEb
+   fun:_Z19mmffValidationSuiteiPPc
+}
+{
+   memory possibly lost 92
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:allocate
+   fun:allocate
+   fun:_M_allocate
+   fun:_ZNSt6vectorIN5boost6detail16stored_edge_iterImSt14_List_iteratorINS0_9list_edgeImPN5RDKit4BondEEEES7_EESaISA_EE17_M_realloc_insertIJSA_EEEvN9__gnu_cxx17__normal_iteratorIPSA_SC_EEDpOT_
+   fun:push_back
+   fun:push_dispatch<std::vector<boost::detail::stored_edge_iter<long unsigned int, std::_List_iterator<boost::list_edge<long unsigned int, RDKit::Bond*> >, RDKit::Bond*>, std::allocator<boost::detail::stored_edge_iter<long unsigned int, std::_List_iterator<boost::list_edge<long unsigned int, RDKit::Bond*> >, RDKit::Bond*> > >, boost::detail::stored_edge_iter<long unsigned int, std::_List_iterator<boost::list_edge<long unsigned int, RDKit::Bond*> >, RDKit::Bond*> >
+   fun:push<std::vector<boost::detail::stored_edge_iter<long unsigned int, std::_List_iterator<boost::list_edge<long unsigned int, RDKit::Bond*> >, RDKit::Bond*>, std::allocator<boost::detail::stored_edge_iter<long unsigned int, std::_List_iterator<boost::list_edge<long unsigned int, RDKit::Bond*> >, RDKit::Bond*> > >, boost::detail::stored_edge_iter<long unsigned int, std::_List_iterator<boost::list_edge<long unsigned int, RDKit::Bond*> >, RDKit::Bond*> >
+   fun:add_edge<boost::detail::adj_list_gen<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*, boost::no_property, boost::listS>::config>
+   fun:add_edge<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::detail::adj_list_gen<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*, boost::no_property, boost::listS>::config, boost::undirected_graph_helper<boost::detail::adj_list_gen<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*, boost::no_property, boost::listS>::config> >
+   fun:add_edge<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::detail::adj_list_gen<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*, boost::no_property, boost::listS>::config, boost::undirected_graph_helper<boost::detail::adj_list_gen<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*, boost::no_property, boost::listS>::config> >
+   fun:_ZN5RDKit5ROMol7addBondEPNS_4BondEb
+   fun:addBond
+   fun:_Z14yysmiles_parsePKcPSt6vectorIPN5RDKit5RWMolESaIS4_EERPNS2_4AtomERPNS2_4BondEPNSt7__cxx114listIjSaIjEEEPvRi
+   fun:_ZN5RDKit12_GLOBAL__N_112smiles_parseERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERSt6vectorIPNS_5RWMolESaISB_EE
+   fun:_ZN5RDKit5toMolERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEPFiS7_RSt6vectorIPNS_5RWMolESaISA_EEES7_
+   fun:_ZN5RDKit11SmilesToMolERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERKNS_18SmilesParserParamsE
+   fun:_ZN5RDKit17SmilesMolSupplier11processLineENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE
+   fun:_ZN5RDKit17SmilesMolSupplier4nextEv
+   fun:_ZN5RDKit17SmilesMolSupplierixEj
+   fun:_Z19mmffValidationSuiteiPPc
+}
+{
+   memory possibly lost 93
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:allocate
+   fun:allocate
+   fun:_M_allocate
+   fun:_ZNSt6vectorIN5boost6detail16stored_edge_iterImSt14_List_iteratorINS0_9list_edgeImPN5RDKit4BondEEEES7_EESaISA_EE17_M_realloc_insertIJSA_EEEvN9__gnu_cxx17__normal_iteratorIPSA_SC_EEDpOT_
+   fun:push_back
+   fun:push_dispatch<std::vector<boost::detail::stored_edge_iter<long unsigned int, std::_List_iterator<boost::list_edge<long unsigned int, RDKit::Bond*> >, RDKit::Bond*>, std::allocator<boost::detail::stored_edge_iter<long unsigned int, std::_List_iterator<boost::list_edge<long unsigned int, RDKit::Bond*> >, RDKit::Bond*> > >, boost::detail::stored_edge_iter<long unsigned int, std::_List_iterator<boost::list_edge<long unsigned int, RDKit::Bond*> >, RDKit::Bond*> >
+   fun:push<std::vector<boost::detail::stored_edge_iter<long unsigned int, std::_List_iterator<boost::list_edge<long unsigned int, RDKit::Bond*> >, RDKit::Bond*>, std::allocator<boost::detail::stored_edge_iter<long unsigned int, std::_List_iterator<boost::list_edge<long unsigned int, RDKit::Bond*> >, RDKit::Bond*> > >, boost::detail::stored_edge_iter<long unsigned int, std::_List_iterator<boost::list_edge<long unsigned int, RDKit::Bond*> >, RDKit::Bond*> >
+   fun:add_edge<boost::detail::adj_list_gen<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*, boost::no_property, boost::listS>::config>
+   fun:add_edge<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::detail::adj_list_gen<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*, boost::no_property, boost::listS>::config, boost::undirected_graph_helper<boost::detail::adj_list_gen<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*, boost::no_property, boost::listS>::config> >
+   fun:add_edge<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::detail::adj_list_gen<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*, boost::no_property, boost::listS>::config, boost::undirected_graph_helper<boost::detail::adj_list_gen<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*, boost::no_property, boost::listS>::config> >
+   fun:_ZN5RDKit5ROMol7addBondEPNS_4BondEb
+   fun:addBond
+   fun:_ZN14SmilesParseOps13CloseMolRingsEPN5RDKit5RWMolEb
+   fun:_ZN5RDKit5toMolERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEPFiS7_RSt6vectorIPNS_5RWMolESaISA_EEES7_
+   fun:_ZN5RDKit11SmilesToMolERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERKNS_18SmilesParserParamsE
+   fun:_ZN5RDKit17SmilesMolSupplier11processLineENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE
+   fun:_ZN5RDKit17SmilesMolSupplier4nextEv
+   fun:_ZN5RDKit17SmilesMolSupplierixEj
+}
+{
+   memory possibly lost 94
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:allocate
+   fun:allocate
+   fun:_M_allocate
+   fun:_ZNSt6vectorIN5boost6detail16stored_edge_iterImSt14_List_iteratorINS0_9list_edgeImPN5RDKit4BondEEEES7_EESaISA_EE17_M_realloc_insertIJSA_EEEvN9__gnu_cxx17__normal_iteratorIPSA_SC_EEDpOT_
+   fun:push_back
+   fun:push_dispatch<std::vector<boost::detail::stored_edge_iter<long unsigned int, std::_List_iterator<boost::list_edge<long unsigned int, RDKit::Bond*> >, RDKit::Bond*>, std::allocator<boost::detail::stored_edge_iter<long unsigned int, std::_List_iterator<boost::list_edge<long unsigned int, RDKit::Bond*> >, RDKit::Bond*> > >, boost::detail::stored_edge_iter<long unsigned int, std::_List_iterator<boost::list_edge<long unsigned int, RDKit::Bond*> >, RDKit::Bond*> >
+   fun:push<std::vector<boost::detail::stored_edge_iter<long unsigned int, std::_List_iterator<boost::list_edge<long unsigned int, RDKit::Bond*> >, RDKit::Bond*>, std::allocator<boost::detail::stored_edge_iter<long unsigned int, std::_List_iterator<boost::list_edge<long unsigned int, RDKit::Bond*> >, RDKit::Bond*> > >, boost::detail::stored_edge_iter<long unsigned int, std::_List_iterator<boost::list_edge<long unsigned int, RDKit::Bond*> >, RDKit::Bond*> >
+   fun:add_edge<boost::detail::adj_list_gen<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*, boost::no_property, boost::listS>::config>
+   fun:add_edge<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::detail::adj_list_gen<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*, boost::no_property, boost::listS>::config, boost::undirected_graph_helper<boost::detail::adj_list_gen<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*, boost::no_property, boost::listS>::config> >
+   fun:add_edge<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::detail::adj_list_gen<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*, boost::no_property, boost::listS>::config, boost::undirected_graph_helper<boost::detail::adj_list_gen<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*, boost::no_property, boost::listS>::config> >
+   fun:_ZN5RDKit5ROMol7addBondEPNS_4BondEb
+   fun:addBond
+   fun:_ZN5RDKit12_GLOBAL__N_118ParseMolBlockBondsEPSiRjjPNS_5RWMolERb
+   fun:_ZN5RDKit15FileParserUtils14ParseV2000CTABEPSiRjPNS_5RWMolERPNS_9ConformerERbS2_S2_b
+   fun:_ZN5RDKit18MolDataStreamToMolEPSiRjbbb
+   fun:_ZN5RDKit20ForwardSDMolSupplier5_nextEv
+   fun:_ZN5RDKit13SDMolSupplier4nextEv
+}
+{
+   memory possibly lost 95
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:allocate
+   fun:allocate
+   fun:_M_allocate
+   fun:_ZNSt6vectorIN5boost6detail16stored_edge_iterImSt14_List_iteratorINS0_9list_edgeImPN5RDKit4BondEEEES7_EESaISA_EE17_M_realloc_insertIJSA_EEEvN9__gnu_cxx17__normal_iteratorIPSA_SC_EEDpOT_
+   fun:push_back
+   fun:push_dispatch<std::vector<boost::detail::stored_edge_iter<long unsigned int, std::_List_iterator<boost::list_edge<long unsigned int, RDKit::Bond*> >, RDKit::Bond*>, std::allocator<boost::detail::stored_edge_iter<long unsigned int, std::_List_iterator<boost::list_edge<long unsigned int, RDKit::Bond*> >, RDKit::Bond*> > >, boost::detail::stored_edge_iter<long unsigned int, std::_List_iterator<boost::list_edge<long unsigned int, RDKit::Bond*> >, RDKit::Bond*> >
+   fun:push<std::vector<boost::detail::stored_edge_iter<long unsigned int, std::_List_iterator<boost::list_edge<long unsigned int, RDKit::Bond*> >, RDKit::Bond*>, std::allocator<boost::detail::stored_edge_iter<long unsigned int, std::_List_iterator<boost::list_edge<long unsigned int, RDKit::Bond*> >, RDKit::Bond*> > >, boost::detail::stored_edge_iter<long unsigned int, std::_List_iterator<boost::list_edge<long unsigned int, RDKit::Bond*> >, RDKit::Bond*> >
+   fun:add_edge<boost::detail::adj_list_gen<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*, boost::no_property, boost::listS>::config>
+   fun:add_edge<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::detail::adj_list_gen<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*, boost::no_property, boost::listS>::config, boost::undirected_graph_helper<boost::detail::adj_list_gen<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*, boost::no_property, boost::listS>::config> >
+   fun:add_edge<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::detail::adj_list_gen<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*, boost::no_property, boost::listS>::config, boost::undirected_graph_helper<boost::detail::adj_list_gen<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*, boost::no_property, boost::listS>::config> >
+   fun:_ZN5RDKit5RWMol7addBondEjjNS_4Bond8BondTypeE
+   fun:_Z14yysmiles_parsePKcPSt6vectorIPN5RDKit5RWMolESaIS4_EERPNS2_4AtomERPNS2_4BondEPNSt7__cxx114listIjSaIjEEEPvRi
+   fun:_ZN5RDKit12_GLOBAL__N_112smiles_parseERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERSt6vectorIPNS_5RWMolESaISB_EE
+   fun:_ZN5RDKit5toMolERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEPFiS7_RSt6vectorIPNS_5RWMolESaISA_EEES7_
+   fun:_ZN5RDKit11SmilesToMolERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERKNS_18SmilesParserParamsE
+   fun:SmilesToMol
+}
+{
+   memory possibly lost 96
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:allocate
+   fun:allocate
+   fun:_M_allocate
+   fun:_ZNSt6vectorIN5boost6detail16stored_edge_iterImSt14_List_iteratorINS0_9list_edgeImPN5RDKit4BondEEEES7_EESaISA_EE17_M_realloc_insertIJSA_EEEvN9__gnu_cxx17__normal_iteratorIPSA_SC_EEDpOT_
+   fun:push_back
+   fun:push_dispatch<std::vector<boost::detail::stored_edge_iter<long unsigned int, std::_List_iterator<boost::list_edge<long unsigned int, RDKit::Bond*> >, RDKit::Bond*>, std::allocator<boost::detail::stored_edge_iter<long unsigned int, std::_List_iterator<boost::list_edge<long unsigned int, RDKit::Bond*> >, RDKit::Bond*> > >, boost::detail::stored_edge_iter<long unsigned int, std::_List_iterator<boost::list_edge<long unsigned int, RDKit::Bond*> >, RDKit::Bond*> >
+   fun:push<std::vector<boost::detail::stored_edge_iter<long unsigned int, std::_List_iterator<boost::list_edge<long unsigned int, RDKit::Bond*> >, RDKit::Bond*>, std::allocator<boost::detail::stored_edge_iter<long unsigned int, std::_List_iterator<boost::list_edge<long unsigned int, RDKit::Bond*> >, RDKit::Bond*> > >, boost::detail::stored_edge_iter<long unsigned int, std::_List_iterator<boost::list_edge<long unsigned int, RDKit::Bond*> >, RDKit::Bond*> >
+   fun:add_edge<boost::detail::adj_list_gen<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*, boost::no_property, boost::listS>::config>
+   fun:add_edge<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::detail::adj_list_gen<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*, boost::no_property, boost::listS>::config, boost::undirected_graph_helper<boost::detail::adj_list_gen<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*, boost::no_property, boost::listS>::config> >
+   fun:add_edge<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::detail::adj_list_gen<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*, boost::no_property, boost::listS>::config, boost::undirected_graph_helper<boost::detail::adj_list_gen<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*, boost::no_property, boost::listS>::config> >
+   fun:_ZN5RDKit5RWMol7addBondEjjNS_4Bond8BondTypeE
+   fun:_Z14yysmiles_parsePKcPSt6vectorIPN5RDKit5RWMolESaIS4_EERPNS2_4AtomERPNS2_4BondEPNSt7__cxx114listIjSaIjEEEPvRi
+   fun:_ZN5RDKit12_GLOBAL__N_112smiles_parseERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERSt6vectorIPNS_5RWMolESaISB_EE
+   fun:_ZN5RDKit5toMolERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEPFiS7_RSt6vectorIPNS_5RWMolESaISA_EEES7_
+   fun:_ZN5RDKit11SmilesToMolERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERKNS_18SmilesParserParamsE
+   fun:_ZN5RDKit17SmilesMolSupplier11processLineENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE
+   fun:_ZN5RDKit17SmilesMolSupplier4nextEv
+   fun:_ZN5RDKit17SmilesMolSupplierixEj
+}
+{
+   memory possibly lost 97
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:allocate
+   fun:allocate
+   fun:_M_allocate
+   fun:_ZNSt6vectorIN5boost6detail16stored_edge_iterImSt14_List_iteratorINS0_9list_edgeImPN5RDKit4BondEEEES7_EESaISA_EE17_M_realloc_insertIJSA_EEEvN9__gnu_cxx17__normal_iteratorIPSA_SC_EEDpOT_
+   fun:push_back
+   fun:push_dispatch<std::vector<boost::detail::stored_edge_iter<long unsigned int, std::_List_iterator<boost::list_edge<long unsigned int, RDKit::Bond*> >, RDKit::Bond*>, std::allocator<boost::detail::stored_edge_iter<long unsigned int, std::_List_iterator<boost::list_edge<long unsigned int, RDKit::Bond*> >, RDKit::Bond*> > >, boost::detail::stored_edge_iter<long unsigned int, std::_List_iterator<boost::list_edge<long unsigned int, RDKit::Bond*> >, RDKit::Bond*> >
+   fun:push<std::vector<boost::detail::stored_edge_iter<long unsigned int, std::_List_iterator<boost::list_edge<long unsigned int, RDKit::Bond*> >, RDKit::Bond*>, std::allocator<boost::detail::stored_edge_iter<long unsigned int, std::_List_iterator<boost::list_edge<long unsigned int, RDKit::Bond*> >, RDKit::Bond*> > >, boost::detail::stored_edge_iter<long unsigned int, std::_List_iterator<boost::list_edge<long unsigned int, RDKit::Bond*> >, RDKit::Bond*> >
+   fun:add_edge<boost::detail::adj_list_gen<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*, boost::no_property, boost::listS>::config>
+   fun:add_edge<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::detail::adj_list_gen<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*, boost::no_property, boost::listS>::config, boost::undirected_graph_helper<boost::detail::adj_list_gen<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*, boost::no_property, boost::listS>::config> >
+   fun:add_edge<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::detail::adj_list_gen<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*, boost::no_property, boost::listS>::config, boost::undirected_graph_helper<boost::detail::adj_list_gen<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*, boost::no_property, boost::listS>::config> >
+   fun:_ZN5RDKit5RWMol7addBondEjjNS_4Bond8BondTypeE
+   fun:_ZN5RDKit6MolOps5addHsERNS_5RWMolEbbPKSt6vectorIjSaIjEEb
+   fun:_Z19mmffValidationSuiteiPPc
+}
+{
+   memory possibly lost 99
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:allocate
+   fun:allocate
+   fun:_M_allocate
+   fun:_ZNSt6vectorIN6RDGeom7Point3DESaIS1_EE14_M_fill_insertEN9__gnu_cxx17__normal_iteratorIPS1_S3_EEmRKS1_
+   fun:resize
+   fun:_ZN5RDKit9ConformerC1Ej
+   fun:_ZN5RDKit12DGeomHelpers18EmbedMultipleConfsERNS_5ROMolERSt6vectorIiSaIiEEjRKNS0_15EmbedParametersE
+   fun:EmbedMolecule
+   fun:EmbedMolecule
+   fun:_Z19mmffValidationSuiteiPPc
+}
+{
+   memory possibly lost 100
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:allocate
+   fun:allocate
+   fun:_M_allocate
+   fun:_ZNSt6vectorIN6RDGeom7Point3DESaIS1_EE14_M_fill_insertEN9__gnu_cxx17__normal_iteratorIPS1_S3_EEmRKS1_
+   fun:resize
+   fun:_ZN5RDKit9ConformerC1Ej
+   fun:_ZN5RDKit15FileParserUtils14ParseV2000CTABEPSiRjPNS_5RWMolERPNS_9ConformerERbS2_S2_b
+   fun:_ZN5RDKit18MolDataStreamToMolEPSiRjbbb
+   fun:_ZN5RDKit20ForwardSDMolSupplier5_nextEv
+   fun:_ZN5RDKit13SDMolSupplier4nextEv
+}
+{
+   memory possibly lost 101
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:allocate
+   fun:allocate
+   fun:_M_allocate
+   fun:_ZNSt6vectorIS_IiSaIiEESaIS1_EE17_M_default_appendEm
+   fun:resize
+   fun:_ZN5RDKit8RingInfo7addRingERKSt6vectorIiSaIiEES5_
+   fun:_ZN9FindRings13storeRingInfoERKN5RDKit5ROMolERKSt6vectorIiSaIiEE
+   fun:_ZN9FindRings14storeRingsInfoERKN5RDKit5ROMolERKSt6vectorIS4_IiSaIiEESaIS6_EE
+   fun:_ZN5RDKit6MolOps13fastFindRingsERKNS_5ROMolE
+   fun:_ZN5RDKit6MolOps31setDoubleBondNeighborDirectionsERNS_5ROMolEPKNS_9ConformerE
+   fun:_ZN5RDKit18MolDataStreamToMolEPSiRjbbb
+   fun:_ZN5RDKit20ForwardSDMolSupplier5_nextEv
+   fun:_ZN5RDKit13SDMolSupplier4nextEv
+   fun:_ZN5RDKit13SDMolSupplierixEj
+   fun:_Z19mmffValidationSuiteiPPc
+}
+{
+   memory possibly lost 102
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:allocate
+   fun:allocate
+   fun:_M_allocate
+   fun:_ZNSt6vectorIS_IiSaIiEESaIS1_EE17_M_default_appendEm
+   fun:resize
+   fun:_ZN5RDKit8RingInfo7addRingERKSt6vectorIiSaIiEES5_
+   fun:_ZN9FindRings13storeRingInfoERKN5RDKit5ROMolERKSt6vectorIiSaIiEE
+   fun:_ZN9FindRings14storeRingsInfoERKN5RDKit5ROMolERKSt6vectorIS4_IiSaIiEESaIS6_EE
+   fun:_ZN5RDKit6MolOps8findSSSRERKNS_5ROMolERSt6vectorIS4_IiSaIiEESaIS6_EE
+   fun:_ZN5RDKit6MolOps14symmetrizeSSSRERNS_5ROMolERSt6vectorIS3_IiSaIiEESaIS5_EE
+   fun:_ZN5RDKit6MolOps11sanitizeMolERNS_5RWMolERjj
+   fun:_ZN5RDKit6MolOps11sanitizeMolERNS_5RWMolE
+   fun:_ZN5RDKit6MolOps8removeHsERNS_5RWMolEbbb
+   fun:_ZN5RDKit11SmilesToMolERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERKNS_18SmilesParserParamsE
+   fun:_ZN5RDKit17SmilesMolSupplier11processLineENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE
+   fun:_ZN5RDKit17SmilesMolSupplier4nextEv
+   fun:_ZN5RDKit17SmilesMolSupplierixEj
+}
+{
+   memory possibly lost 103
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:allocate
+   fun:allocate
+   fun:_M_allocate
+   fun:_ZNSt6vectorIS_IiSaIiEESaIS1_EE17_M_default_appendEm
+   fun:resize
+   fun:_ZN5RDKit8RingInfo7addRingERKSt6vectorIiSaIiEES5_
+   fun:_ZN9FindRings13storeRingInfoERKN5RDKit5ROMolERKSt6vectorIiSaIiEE
+   fun:_ZN9FindRings14storeRingsInfoERKN5RDKit5ROMolERKSt6vectorIS4_IiSaIiEESaIS6_EE
+   fun:_ZN5RDKit6MolOps8findSSSRERKNS_5ROMolERSt6vectorIS4_IiSaIiEESaIS6_EE
+   fun:_ZN5RDKit6MolOps14symmetrizeSSSRERNS_5ROMolERSt6vectorIS3_IiSaIiEESaIS5_EE
+   fun:_ZN5RDKit6MolOps11sanitizeMolERNS_5RWMolERjj
+   fun:_ZN5RDKit6MolOps11sanitizeMolERNS_5RWMolE
+   fun:_ZN5RDKit6MolOps8removeHsERNS_5RWMolEbbb
+   fun:_ZN5RDKit18MolDataStreamToMolEPSiRjbbb
+   fun:_ZN5RDKit20ForwardSDMolSupplier5_nextEv
+   fun:_ZN5RDKit13SDMolSupplier4nextEv
+}
+{
+   memory possibly lost 104
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:allocate
+   fun:allocate
+   fun:_M_allocate
+   fun:_ZNSt6vectorIS_IiSaIiEESaIS1_EE17_M_realloc_insertIJRKS1_EEEvN9__gnu_cxx17__normal_iteratorIPS1_S3_EEDpOT_
+   fun:push_back
+   fun:_ZN5RDKit8RingInfo7addRingERKSt6vectorIiSaIiEES5_
+   fun:_ZN9FindRings13storeRingInfoERKN5RDKit5ROMolERKSt6vectorIiSaIiEE
+   fun:_ZN9FindRings14storeRingsInfoERKN5RDKit5ROMolERKSt6vectorIS4_IiSaIiEESaIS6_EE
+   fun:_ZN5RDKit6MolOps13fastFindRingsERKNS_5ROMolE
+   fun:_ZN5RDKit6MolOps31setDoubleBondNeighborDirectionsERNS_5ROMolEPKNS_9ConformerE
+   fun:_ZN5RDKit18MolDataStreamToMolEPSiRjbbb
+   fun:_ZN5RDKit20ForwardSDMolSupplier5_nextEv
+   fun:_ZN5RDKit13SDMolSupplier4nextEv
+   fun:_ZN5RDKit13SDMolSupplierixEj
+   fun:_Z19mmffValidationSuiteiPPc
+}
+{
+   memory possibly lost 105
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:allocate
+   fun:allocate
+   fun:_M_allocate
+   fun:_ZNSt6vectorIS_IiSaIiEESaIS1_EE17_M_realloc_insertIJRKS1_EEEvN9__gnu_cxx17__normal_iteratorIPS1_S3_EEDpOT_
+   fun:push_back
+   fun:_ZN5RDKit8RingInfo7addRingERKSt6vectorIiSaIiEES5_
+   fun:_ZN9FindRings13storeRingInfoERKN5RDKit5ROMolERKSt6vectorIiSaIiEE
+   fun:_ZN9FindRings14storeRingsInfoERKN5RDKit5ROMolERKSt6vectorIS4_IiSaIiEESaIS6_EE
+   fun:_ZN5RDKit6MolOps8findSSSRERKNS_5ROMolERSt6vectorIS4_IiSaIiEESaIS6_EE
+   fun:_ZN5RDKit6MolOps14symmetrizeSSSRERNS_5ROMolERSt6vectorIS3_IiSaIiEESaIS5_EE
+   fun:_ZN5RDKit6MolOps11sanitizeMolERNS_5RWMolERjj
+   fun:_ZN5RDKit6MolOps11sanitizeMolERNS_5RWMolE
+   fun:_ZN5RDKit6MolOps8removeHsERNS_5RWMolEbbb
+   fun:_ZN5RDKit11SmilesToMolERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERKNS_18SmilesParserParamsE
+   fun:_ZN5RDKit17SmilesMolSupplier11processLineENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE
+   fun:_ZN5RDKit17SmilesMolSupplier4nextEv
+   fun:_ZN5RDKit17SmilesMolSupplierixEj
+}
+{
+   memory possibly lost 106
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:allocate
+   fun:allocate
+   fun:_M_allocate
+   fun:_ZNSt6vectorIS_IiSaIiEESaIS1_EE17_M_realloc_insertIJRKS1_EEEvN9__gnu_cxx17__normal_iteratorIPS1_S3_EEDpOT_
+   fun:push_back
+   fun:_ZN5RDKit8RingInfo7addRingERKSt6vectorIiSaIiEES5_
+   fun:_ZN9FindRings13storeRingInfoERKN5RDKit5ROMolERKSt6vectorIiSaIiEE
+   fun:_ZN9FindRings14storeRingsInfoERKN5RDKit5ROMolERKSt6vectorIS4_IiSaIiEESaIS6_EE
+   fun:_ZN5RDKit6MolOps8findSSSRERKNS_5ROMolERSt6vectorIS4_IiSaIiEESaIS6_EE
+   fun:_ZN5RDKit6MolOps14symmetrizeSSSRERNS_5ROMolERSt6vectorIS3_IiSaIiEESaIS5_EE
+   fun:_ZN5RDKit6MolOps11sanitizeMolERNS_5RWMolERjj
+   fun:_ZN5RDKit6MolOps11sanitizeMolERNS_5RWMolE
+   fun:_ZN5RDKit6MolOps8removeHsERNS_5RWMolEbbb
+   fun:_ZN5RDKit18MolDataStreamToMolEPSiRjbbb
+   fun:_ZN5RDKit20ForwardSDMolSupplier5_nextEv
+   fun:_ZN5RDKit13SDMolSupplier4nextEv
+}
+{
+   memory possibly lost 107
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:allocate
+   fun:allocate
+   fun:_M_allocate
+   fun:_ZNSt6vectorIiSaIiEE17_M_realloc_insertIJRKiEEEvN9__gnu_cxx17__normal_iteratorIPiS1_EEDpOT_
+   fun:push_back
+   fun:_ZN5RDKit8RingInfo7addRingERKSt6vectorIiSaIiEES5_
+   fun:_ZN9FindRings13storeRingInfoERKN5RDKit5ROMolERKSt6vectorIiSaIiEE
+   fun:_ZN9FindRings14storeRingsInfoERKN5RDKit5ROMolERKSt6vectorIS4_IiSaIiEESaIS6_EE
+   fun:_ZN5RDKit6MolOps8findSSSRERKNS_5ROMolERSt6vectorIS4_IiSaIiEESaIS6_EE
+   fun:_ZN5RDKit6MolOps14symmetrizeSSSRERNS_5ROMolERSt6vectorIS3_IiSaIiEESaIS5_EE
+   fun:_ZN5RDKit6MolOps11sanitizeMolERNS_5RWMolERjj
+   fun:_ZN5RDKit4MMFF15sanitizeMMFFMolERNS_5RWMolE
+   fun:_Z19mmffValidationSuiteiPPc
+}
+{
+   memory possibly lost 108
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:allocate
+   fun:allocate
+   fun:_M_allocate
+   fun:_ZNSt6vectorIiSaIiEE17_M_realloc_insertIJRKiEEEvN9__gnu_cxx17__normal_iteratorIPiS1_EEDpOT_
+   fun:push_back
+   fun:_ZN5RDKit8RingInfo7addRingERKSt6vectorIiSaIiEES5_
+   fun:_ZN9FindRings13storeRingInfoERKN5RDKit5ROMolERKSt6vectorIiSaIiEE
+   fun:_ZN9FindRings14storeRingsInfoERKN5RDKit5ROMolERKSt6vectorIS4_IiSaIiEESaIS6_EE
+   fun:_ZN5RDKit6MolOps8findSSSRERKNS_5ROMolERSt6vectorIS4_IiSaIiEESaIS6_EE
+   fun:_ZN5RDKit6MolOps14symmetrizeSSSRERNS_5ROMolERSt6vectorIS3_IiSaIiEESaIS5_EE
+   fun:_ZN5RDKit6MolOps11sanitizeMolERNS_5RWMolERjj
+   fun:_ZN5RDKit6MolOps11sanitizeMolERNS_5RWMolE
+   fun:_ZN5RDKit6MolOps8removeHsERNS_5RWMolEbbb
+   fun:_ZN5RDKit11SmilesToMolERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERKNS_18SmilesParserParamsE
+   fun:_ZN5RDKit17SmilesMolSupplier11processLineENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE
+   fun:_ZN5RDKit17SmilesMolSupplier4nextEv
+   fun:_ZN5RDKit17SmilesMolSupplierixEj
+}
+{
+   memory possibly lost 109
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:allocate
+   fun:allocate
+   fun:_M_allocate
+   fun:_ZNSt6vectorIiSaIiEE17_M_realloc_insertIJRKiEEEvN9__gnu_cxx17__normal_iteratorIPiS1_EEDpOT_
+   fun:push_back
+   fun:_ZN5RDKit8RingInfo7addRingERKSt6vectorIiSaIiEES5_
+   fun:_ZN9FindRings13storeRingInfoERKN5RDKit5ROMolERKSt6vectorIiSaIiEE
+   fun:_ZN9FindRings14storeRingsInfoERKN5RDKit5ROMolERKSt6vectorIS4_IiSaIiEESaIS6_EE
+   fun:_ZN5RDKit6MolOps8findSSSRERKNS_5ROMolERSt6vectorIS4_IiSaIiEESaIS6_EE
+   fun:_ZN5RDKit6MolOps14symmetrizeSSSRERNS_5ROMolERSt6vectorIS3_IiSaIiEESaIS5_EE
+   fun:_ZN5RDKit6MolOps11sanitizeMolERNS_5RWMolERjj
+   fun:_ZN5RDKit6MolOps11sanitizeMolERNS_5RWMolE
+   fun:_ZN5RDKit6MolOps8removeHsERNS_5RWMolEbbb
+   fun:_ZN5RDKit18MolDataStreamToMolEPSiRjbbb
+   fun:_ZN5RDKit20ForwardSDMolSupplier5_nextEv
+   fun:_ZN5RDKit13SDMolSupplier4nextEv
+}
+{
+   memory possibly lost 111
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:allocate
+   fun:allocate
+   fun:_M_get_node
+   fun:_M_create_node<const boost::list_edge<long unsigned int, RDKit::Bond*>&>
+   fun:_M_insert<const boost::list_edge<long unsigned int, RDKit::Bond*>&>
+   fun:push_back
+   fun:push_dispatch<std::__cxx11::list<boost::list_edge<long unsigned int, RDKit::Bond*>, std::allocator<boost::list_edge<long unsigned int, RDKit::Bond*> > >, boost::list_edge<long unsigned int, RDKit::Bond*>&>
+   fun:push<std::__cxx11::list<boost::list_edge<long unsigned int, RDKit::Bond*>, std::allocator<boost::list_edge<long unsigned int, RDKit::Bond*> > >, boost::list_edge<long unsigned int, RDKit::Bond*>&>
+   fun:add_edge<boost::detail::adj_list_gen<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*, boost::no_property, boost::listS>::config>
+   fun:add_edge<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::detail::adj_list_gen<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*, boost::no_property, boost::listS>::config, boost::undirected_graph_helper<boost::detail::adj_list_gen<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*, boost::no_property, boost::listS>::config> >
+   fun:add_edge<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::detail::adj_list_gen<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*, boost::no_property, boost::listS>::config, boost::undirected_graph_helper<boost::detail::adj_list_gen<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*, boost::no_property, boost::listS>::config> >
+   fun:_ZN5RDKit5ROMol7addBondEPNS_4BondEb
+   fun:addBond
+   fun:_Z14yysmiles_parsePKcPSt6vectorIPN5RDKit5RWMolESaIS4_EERPNS2_4AtomERPNS2_4BondEPNSt7__cxx114listIjSaIjEEEPvRi
+   fun:_ZN5RDKit12_GLOBAL__N_112smiles_parseERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERSt6vectorIPNS_5RWMolESaISB_EE
+   fun:_ZN5RDKit5toMolERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEPFiS7_RSt6vectorIPNS_5RWMolESaISA_EEES7_
+   fun:_ZN5RDKit11SmilesToMolERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERKNS_18SmilesParserParamsE
+   fun:_ZN5RDKit17SmilesMolSupplier11processLineENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE
+   fun:_ZN5RDKit17SmilesMolSupplier4nextEv
+   fun:_ZN5RDKit17SmilesMolSupplierixEj
+}
+{
+   memory possibly lost 112
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:allocate
+   fun:allocate
+   fun:_M_get_node
+   fun:_M_create_node<const boost::list_edge<long unsigned int, RDKit::Bond*>&>
+   fun:_M_insert<const boost::list_edge<long unsigned int, RDKit::Bond*>&>
+   fun:push_back
+   fun:push_dispatch<std::__cxx11::list<boost::list_edge<long unsigned int, RDKit::Bond*>, std::allocator<boost::list_edge<long unsigned int, RDKit::Bond*> > >, boost::list_edge<long unsigned int, RDKit::Bond*>&>
+   fun:push<std::__cxx11::list<boost::list_edge<long unsigned int, RDKit::Bond*>, std::allocator<boost::list_edge<long unsigned int, RDKit::Bond*> > >, boost::list_edge<long unsigned int, RDKit::Bond*>&>
+   fun:add_edge<boost::detail::adj_list_gen<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*, boost::no_property, boost::listS>::config>
+   fun:add_edge<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::detail::adj_list_gen<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*, boost::no_property, boost::listS>::config, boost::undirected_graph_helper<boost::detail::adj_list_gen<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*, boost::no_property, boost::listS>::config> >
+   fun:add_edge<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::detail::adj_list_gen<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*, boost::no_property, boost::listS>::config, boost::undirected_graph_helper<boost::detail::adj_list_gen<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*, boost::no_property, boost::listS>::config> >
+   fun:_ZN5RDKit5ROMol7addBondEPNS_4BondEb
+   fun:addBond
+   fun:_ZN14SmilesParseOps13CloseMolRingsEPN5RDKit5RWMolEb
+   fun:_ZN5RDKit5toMolERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEPFiS7_RSt6vectorIPNS_5RWMolESaISA_EEES7_
+   fun:_ZN5RDKit11SmilesToMolERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERKNS_18SmilesParserParamsE
+   fun:_ZN5RDKit17SmilesMolSupplier11processLineENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE
+   fun:_ZN5RDKit17SmilesMolSupplier4nextEv
+   fun:_ZN5RDKit17SmilesMolSupplierixEj
+}
+{
+   memory possibly lost 113
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:allocate
+   fun:allocate
+   fun:_M_get_node
+   fun:_M_create_node<const boost::list_edge<long unsigned int, RDKit::Bond*>&>
+   fun:_M_insert<const boost::list_edge<long unsigned int, RDKit::Bond*>&>
+   fun:push_back
+   fun:push_dispatch<std::__cxx11::list<boost::list_edge<long unsigned int, RDKit::Bond*>, std::allocator<boost::list_edge<long unsigned int, RDKit::Bond*> > >, boost::list_edge<long unsigned int, RDKit::Bond*>&>
+   fun:push<std::__cxx11::list<boost::list_edge<long unsigned int, RDKit::Bond*>, std::allocator<boost::list_edge<long unsigned int, RDKit::Bond*> > >, boost::list_edge<long unsigned int, RDKit::Bond*>&>
+   fun:add_edge<boost::detail::adj_list_gen<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*, boost::no_property, boost::listS>::config>
+   fun:add_edge<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::detail::adj_list_gen<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*, boost::no_property, boost::listS>::config, boost::undirected_graph_helper<boost::detail::adj_list_gen<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*, boost::no_property, boost::listS>::config> >
+   fun:add_edge<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::detail::adj_list_gen<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*, boost::no_property, boost::listS>::config, boost::undirected_graph_helper<boost::detail::adj_list_gen<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*, boost::no_property, boost::listS>::config> >
+   fun:_ZN5RDKit5ROMol7addBondEPNS_4BondEb
+   fun:addBond
+   fun:_ZN5RDKit12_GLOBAL__N_118ParseMolBlockBondsEPSiRjjPNS_5RWMolERb
+   fun:_ZN5RDKit15FileParserUtils14ParseV2000CTABEPSiRjPNS_5RWMolERPNS_9ConformerERbS2_S2_b
+   fun:_ZN5RDKit18MolDataStreamToMolEPSiRjbbb
+   fun:_ZN5RDKit20ForwardSDMolSupplier5_nextEv
+   fun:_ZN5RDKit13SDMolSupplier4nextEv
+}
+{
+   memory possibly lost 114
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:allocate
+   fun:allocate
+   fun:_M_get_node
+   fun:_M_create_node<const boost::list_edge<long unsigned int, RDKit::Bond*>&>
+   fun:_M_insert<const boost::list_edge<long unsigned int, RDKit::Bond*>&>
+   fun:push_back
+   fun:push_dispatch<std::__cxx11::list<boost::list_edge<long unsigned int, RDKit::Bond*>, std::allocator<boost::list_edge<long unsigned int, RDKit::Bond*> > >, boost::list_edge<long unsigned int, RDKit::Bond*>&>
+   fun:push<std::__cxx11::list<boost::list_edge<long unsigned int, RDKit::Bond*>, std::allocator<boost::list_edge<long unsigned int, RDKit::Bond*> > >, boost::list_edge<long unsigned int, RDKit::Bond*>&>
+   fun:add_edge<boost::detail::adj_list_gen<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*, boost::no_property, boost::listS>::config>
+   fun:add_edge<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::detail::adj_list_gen<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*, boost::no_property, boost::listS>::config, boost::undirected_graph_helper<boost::detail::adj_list_gen<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*, boost::no_property, boost::listS>::config> >
+   fun:add_edge<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::detail::adj_list_gen<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*, boost::no_property, boost::listS>::config, boost::undirected_graph_helper<boost::detail::adj_list_gen<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*, boost::no_property, boost::listS>::config> >
+   fun:_ZN5RDKit5RWMol7addBondEjjNS_4Bond8BondTypeE
+   fun:_Z14yysmiles_parsePKcPSt6vectorIPN5RDKit5RWMolESaIS4_EERPNS2_4AtomERPNS2_4BondEPNSt7__cxx114listIjSaIjEEEPvRi
+   fun:_ZN5RDKit12_GLOBAL__N_112smiles_parseERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERSt6vectorIPNS_5RWMolESaISB_EE
+   fun:_ZN5RDKit5toMolERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEPFiS7_RSt6vectorIPNS_5RWMolESaISA_EEES7_
+   fun:_ZN5RDKit11SmilesToMolERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERKNS_18SmilesParserParamsE
+   fun:SmilesToMol
+}
+{
+   memory possibly lost 115
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:allocate
+   fun:allocate
+   fun:_M_get_node
+   fun:_M_create_node<const boost::list_edge<long unsigned int, RDKit::Bond*>&>
+   fun:_M_insert<const boost::list_edge<long unsigned int, RDKit::Bond*>&>
+   fun:push_back
+   fun:push_dispatch<std::__cxx11::list<boost::list_edge<long unsigned int, RDKit::Bond*>, std::allocator<boost::list_edge<long unsigned int, RDKit::Bond*> > >, boost::list_edge<long unsigned int, RDKit::Bond*>&>
+   fun:push<std::__cxx11::list<boost::list_edge<long unsigned int, RDKit::Bond*>, std::allocator<boost::list_edge<long unsigned int, RDKit::Bond*> > >, boost::list_edge<long unsigned int, RDKit::Bond*>&>
+   fun:add_edge<boost::detail::adj_list_gen<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*, boost::no_property, boost::listS>::config>
+   fun:add_edge<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::detail::adj_list_gen<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*, boost::no_property, boost::listS>::config, boost::undirected_graph_helper<boost::detail::adj_list_gen<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*, boost::no_property, boost::listS>::config> >
+   fun:add_edge<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::detail::adj_list_gen<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*, boost::no_property, boost::listS>::config, boost::undirected_graph_helper<boost::detail::adj_list_gen<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*, boost::no_property, boost::listS>::config> >
+   fun:_ZN5RDKit5RWMol7addBondEjjNS_4Bond8BondTypeE
+   fun:_Z14yysmiles_parsePKcPSt6vectorIPN5RDKit5RWMolESaIS4_EERPNS2_4AtomERPNS2_4BondEPNSt7__cxx114listIjSaIjEEEPvRi
+   fun:_ZN5RDKit12_GLOBAL__N_112smiles_parseERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERSt6vectorIPNS_5RWMolESaISB_EE
+   fun:_ZN5RDKit5toMolERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEPFiS7_RSt6vectorIPNS_5RWMolESaISA_EEES7_
+   fun:_ZN5RDKit11SmilesToMolERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERKNS_18SmilesParserParamsE
+   fun:_ZN5RDKit17SmilesMolSupplier11processLineENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE
+   fun:_ZN5RDKit17SmilesMolSupplier4nextEv
+   fun:_ZN5RDKit17SmilesMolSupplierixEj
+}
+{
+   memory possibly lost 116
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:allocate
+   fun:allocate
+   fun:_M_get_node
+   fun:_M_create_node<const boost::list_edge<long unsigned int, RDKit::Bond*>&>
+   fun:_M_insert<const boost::list_edge<long unsigned int, RDKit::Bond*>&>
+   fun:push_back
+   fun:push_dispatch<std::__cxx11::list<boost::list_edge<long unsigned int, RDKit::Bond*>, std::allocator<boost::list_edge<long unsigned int, RDKit::Bond*> > >, boost::list_edge<long unsigned int, RDKit::Bond*>&>
+   fun:push<std::__cxx11::list<boost::list_edge<long unsigned int, RDKit::Bond*>, std::allocator<boost::list_edge<long unsigned int, RDKit::Bond*> > >, boost::list_edge<long unsigned int, RDKit::Bond*>&>
+   fun:add_edge<boost::detail::adj_list_gen<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*, boost::no_property, boost::listS>::config>
+   fun:add_edge<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::detail::adj_list_gen<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*, boost::no_property, boost::listS>::config, boost::undirected_graph_helper<boost::detail::adj_list_gen<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*, boost::no_property, boost::listS>::config> >
+   fun:add_edge<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::detail::adj_list_gen<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*, boost::no_property, boost::listS>::config, boost::undirected_graph_helper<boost::detail::adj_list_gen<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*, boost::no_property, boost::listS>::config> >
+   fun:_ZN5RDKit5RWMol7addBondEjjNS_4Bond8BondTypeE
+   fun:_ZN5RDKit6MolOps5addHsERNS_5RWMolEbbPKSt6vectorIjSaIjEEb
+   fun:_Z19mmffValidationSuiteiPPc
+}
+{
+   memory possibly lost 118
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:allocate
+   fun:allocate
+   fun:_M_get_node
+   fun:_M_create_node<const boost::shared_ptr<RDKit::Conformer>&>
+   fun:_M_insert<const boost::shared_ptr<RDKit::Conformer>&>
+   fun:push_back
+   fun:_ZN5RDKit5ROMol12addConformerEPNS_9ConformerEb
+   fun:_ZN5RDKit12DGeomHelpers18EmbedMultipleConfsERNS_5ROMolERSt6vectorIiSaIiEEjRKNS0_15EmbedParametersE
+   fun:EmbedMolecule
+   fun:EmbedMolecule
+   fun:_Z19mmffValidationSuiteiPPc
+}
+{
+   memory possibly lost 119
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:allocate
+   fun:allocate
+   fun:_M_get_node
+   fun:_M_create_node<const boost::shared_ptr<RDKit::Conformer>&>
+   fun:_M_insert<const boost::shared_ptr<RDKit::Conformer>&>
+   fun:push_back
+   fun:_ZN5RDKit5ROMol12addConformerEPNS_9ConformerEb
+   fun:_ZN5RDKit15FileParserUtils14ParseV2000CTABEPSiRjPNS_5RWMolERPNS_9ConformerERbS2_S2_b
+   fun:_ZN5RDKit18MolDataStreamToMolEPSiRjbbb
+   fun:_ZN5RDKit20ForwardSDMolSupplier5_nextEv
+   fun:_ZN5RDKit13SDMolSupplier4nextEv
+}
+{
+   memory possibly lost 120
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:getStereoAtoms
+   fun:_ZN5RDKit6MolOps21assignStereochemistryERNS_5ROMolEbbb
+   fun:_ZN5RDKit11SmilesToMolERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERKNS_18SmilesParserParamsE
+   fun:_ZN5RDKit17SmilesMolSupplier11processLineENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE
+   fun:_ZN5RDKit17SmilesMolSupplier4nextEv
+   fun:_ZN5RDKit17SmilesMolSupplierixEj
+}
+{
+   memory possibly lost 121
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:getStereoAtoms
+   fun:_ZN5RDKit6MolOps21assignStereochemistryERNS_5ROMolEbbb
+   fun:_ZN5RDKit18MolDataStreamToMolEPSiRjbbb
+   fun:_ZN5RDKit20ForwardSDMolSupplier5_nextEv
+   fun:_ZN5RDKit13SDMolSupplier4nextEv
+}
+{
+   memory possibly lost 122
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:shared_count<RDKit::Conformer>
+   fun:sp_pointer_construct<RDKit::Conformer, RDKit::Conformer>
+   fun:shared_ptr<RDKit::Conformer>
+   fun:_ZN5RDKit5ROMol12addConformerEPNS_9ConformerEb
+   fun:_ZN5RDKit12DGeomHelpers18EmbedMultipleConfsERNS_5ROMolERSt6vectorIiSaIiEEjRKNS0_15EmbedParametersE
+   fun:EmbedMolecule
+   fun:EmbedMolecule
+   fun:_Z19mmffValidationSuiteiPPc
+}
+{
+   memory possibly lost 123
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:shared_count<RDKit::Conformer>
+   fun:sp_pointer_construct<RDKit::Conformer, RDKit::Conformer>
+   fun:shared_ptr<RDKit::Conformer>
+   fun:_ZN5RDKit5ROMol12addConformerEPNS_9ConformerEb
+   fun:_ZN5RDKit15FileParserUtils14ParseV2000CTABEPSiRjPNS_5RWMolERPNS_9ConformerERbS2_S2_b
+   fun:_ZN5RDKit18MolDataStreamToMolEPSiRjbbb
+   fun:_ZN5RDKit20ForwardSDMolSupplier5_nextEv
+   fun:_ZN5RDKit13SDMolSupplier4nextEv
+}
+{
+   memory possibly lost 124
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:shared_count<RDKit::MMFF::MMFFAtomProperties>
+   fun:sp_pointer_construct<RDKit::MMFF::MMFFAtomProperties, RDKit::MMFF::MMFFAtomProperties>
+   fun:shared_ptr<RDKit::MMFF::MMFFAtomProperties>
+   fun:_ZN5RDKit4MMFF17MMFFMolPropertiesC1ERNS_5ROMolERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEhRSo
+   fun:_Z19mmffValidationSuiteiPPc
+}
+{
+   invalid read of size 1
+   Memcheck:Addr1
+   fun:_ZN5boost14char_separatorIcSt11char_traitsIcEEclIN9__gnu_cxx17__normal_iteratorIPKcNSt7__cxx1112basic_stringIcS2_SaIcEEEEESC_EEbRT_SE_RT0_
+   fun:initialize
+   fun:token_iterator
+   fun:begin
+}
+{
+   invalid read of size 2
+   Memcheck:Addr1
+   fun:getFormalCharge
+   fun:_ZN5RDKit14StructureCheck23TransformAugmentedAtomsERNS_5RWMolERKSt6vectorISt4pairINS0_13AugmentedAtomES5_ESaIS6_EEb
+   fun:_ZNK5RDKit14StructureCheck13StructChecker17checkMolStructureERNS_5RWMolE
+}
+{
+   invalid read of size 3
+   Memcheck:Addr1
+   fun:getNumRadicalElectrons
+   fun:_ZN5RDKit14StructureCheck23TransformAugmentedAtomsERNS_5RWMolERKSt6vectorISt4pairINS0_13AugmentedAtomES5_ESaIS6_EEb
+   fun:_ZNK5RDKit14StructureCheck13StructChecker17checkMolStructureERNS_5RWMolE
+}
+{
    invalid read of size 4
+   Memcheck:Addr1
+   fun:memcpy*
+   fun:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE10_M_replaceEmmPKcm
+   fun:replace
+   fun:replace
+   fun:assign<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> > >
+   fun:assign<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> >
+   fun:_ZN5boost14char_separatorIcSt11char_traitsIcEEclIN9__gnu_cxx17__normal_iteratorIPKcNSt7__cxx1112basic_stringIcS2_SaIcEEEEESC_EEbRT_SE_RT0_
+   fun:initialize
+   fun:token_iterator
+   fun:begin
+}
+{
+   invalid read of size 5
+   Memcheck:Addr1
+   fun:memcpy*
+   fun:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE10_M_replaceEmmPKcm
+   fun:replace
+   fun:replace
+   fun:assign<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> > >
+   fun:assign<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> >
+   fun:operator()<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> >
+   fun:increment
+   fun:increment<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
+   fun:operator++
+   fun:__distance<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
+   fun:distance<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
+   fun:_M_range_initialize<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
+   fun:_M_initialize_dispatch<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
+   fun:vector<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
+}
+{
+   invalid read of size 6
+   Memcheck:Addr1
+   fun:memcpy*
+   fun:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE10_M_replaceEmmPKcm
+   fun:replace
+   fun:replace
+   fun:assign<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> > >
+   fun:assign<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> >
+   fun:operator()<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> >
+   fun:increment
+   fun:increment<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
+   fun:operator++
+   fun:__uninit_copy<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char>*>
+   fun:uninitialized_copy<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char>*>
+   fun:__uninitialized_copy_a<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char>*, std::__cxx11::basic_string<char> >
+   fun:_M_range_initialize<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
+   fun:_M_initialize_dispatch<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
+   fun:vector<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
+}
+{
+   invalid read of size 7
+   Memcheck:Addr1
+   fun:operator()<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> >
+   fun:increment
+   fun:increment<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
+   fun:operator++
+   fun:__distance<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
+   fun:distance<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
+   fun:_M_range_initialize<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
+   fun:_M_initialize_dispatch<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
+   fun:vector<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
+}
+{
+   invalid read of size 8
+   Memcheck:Addr1
+   fun:operator()<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> >
+   fun:increment
+   fun:increment<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
+   fun:operator++
+   fun:__uninit_copy<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char>*>
+   fun:uninitialized_copy<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char>*>
+   fun:__uninitialized_copy_a<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char>*, std::__cxx11::basic_string<char> >
+   fun:_M_range_initialize<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
+   fun:_M_initialize_dispatch<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
+   fun:vector<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
+}
+{
+   invalid read of size 9
+   Memcheck:Addr2
+   fun:memcpy*
+   fun:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE10_M_replaceEmmPKcm
+   fun:replace
+   fun:replace
+   fun:assign<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> > >
+   fun:assign<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> >
+   fun:_ZN5boost14char_separatorIcSt11char_traitsIcEEclIN9__gnu_cxx17__normal_iteratorIPKcNSt7__cxx1112basic_stringIcS2_SaIcEEEEESC_EEbRT_SE_RT0_
+   fun:initialize
+   fun:token_iterator
+   fun:begin
+}
+{
+   invalid read of size 10
+   Memcheck:Addr2
+   fun:memcpy*
+   fun:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE10_M_replaceEmmPKcm
+   fun:replace
+   fun:replace
+   fun:assign<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> > >
+   fun:assign<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> >
+   fun:operator()<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> >
+   fun:increment
+   fun:increment<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
+   fun:operator++
+   fun:__distance<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
+   fun:distance<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
+   fun:_M_range_initialize<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
+   fun:_M_initialize_dispatch<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
+   fun:vector<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
+}
+{
+   invalid read of size 11
+   Memcheck:Addr2
+   fun:memcpy*
+   fun:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE10_M_replaceEmmPKcm
+   fun:replace
+   fun:replace
+   fun:assign<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> > >
+   fun:assign<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> >
+   fun:operator()<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> >
+   fun:increment
+   fun:increment<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
+   fun:operator++
+   fun:__uninit_copy<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char>*>
+   fun:uninitialized_copy<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char>*>
+   fun:__uninitialized_copy_a<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char>*, std::__cxx11::basic_string<char> >
+   fun:_M_range_initialize<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
+   fun:_M_initialize_dispatch<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
+   fun:vector<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
+}
+{
+   invalid read of size 12
    Memcheck:Addr4
    fun:_ZN5RDKit19addRecursiveQueriesERNS_5ROMolERKSt3mapINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEN5boost10shared_ptrIS0_EESt4lessIS8_ESaISt4pairIKS8_SB_EEERSF_PSt6vectorISE_IjS8_ESaISN_EE
 }
 {
-   uninitialised value used in logic 0
+   invalid read of size 14
+   Memcheck:Addr8
+   fun:size
+   fun:vertex_set
+   fun:num_vertices<boost::detail::adj_list_gen<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*, boost::no_property, boost::listS>::config, boost::undirected_graph_helper<boost::detail::adj_list_gen<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*, boost::no_property, boost::listS>::config> >
+   fun:_ZNK5RDKit5ROMol11getNumAtomsEb
+   fun:_ZN5RDKit11MolToSmartsB5cxx11ERNS_5ROMolEb
+}
+{
+   uninitialised value used in logic
    Memcheck:Cond
    fun:_ZN5RDKit5Canon16RefinePartitionsI19atomcomparefunctor3EEvRKNS_5ROMolEPNS0_10canon_atomET_iPiS9_RiS9_S9_Pc
 }
 {
-   uninitialised value used in logic 1
+   uninitialised value used in logic 0
    Memcheck:Cond
    fun:_ZN5RDKit5Canon9BreakTiesI19atomcomparefunctor3EEvRKNS_5ROMolEPNS0_10canon_atomET_iPiS9_RiS9_S9_Pc
 }
 {
-   uninitialised value used in logic 2
+   uninitialised value used in logic 1
    Memcheck:Cond
    fun:__GI_memcpy
    fun:__printf_fp
    fun:vfprintf
    fun:vsnprintf
+   fun:_ZSt16__convert_from_vRKP15__locale_structPciPKcz
+   fun:_ZNKSt7num_putIcSt19ostreambuf_iteratorIcSt11char_traitsIcEEE15_M_insert_floatIdEES3_S3_RSt8ios_baseccT_
+   fun:_ZNSo9_M_insertIdEERSoT_
+   fun:put_last<char, std::char_traits<char> >
+   fun:_ZN5boost2io6detail3putIcSt11char_traitsIcESaIcERKNS1_10put_holderIcS4_EEEEvT2_RKNS1_11format_itemIT_T0_T1_EERNS_12basic_formatISC_SD_SE_E11string_typeERNSJ_20internal_streambuf_tEPSt6locale
+   fun:_ZN5boost2io6detail10distributeIcSt11char_traitsIcESaIcERKNS1_10put_holderIcS4_EEEEvRNS_12basic_formatIT_T0_T1_EET2_
+   fun:_ZN5boost2io6detail9feed_implIcSt11char_traitsIcESaIcERKNS1_10put_holderIcS4_EEEERNS_12basic_formatIT_T0_T1_EESF_T2_
+   fun:feed<char, std::char_traits<char>, std::allocator<char>, double const&>
+   fun:operator%<double>
+   fun:_ZN5RDKit14GetPDBAtomLineB5cxx11EPKNS_4AtomEPKNS_9ConformerERSt3mapIjjSt4lessIjESaISt4pairIKjjEEE
+   fun:_ZN5RDKit12MolToPDBBodyB5cxx11ERKNS_5ROMolEPKNS_9ConformerEjRjS6_S6_
+   fun:_ZN5RDKit13MolToPDBBlockB5cxx11ERKNS_5ROMolEij
+}
+{
+   uninitialised value used in logic 2
+   Memcheck:Cond
+   fun:__mpn_addmul_1
    obj:*
+   fun:__printf_fp
+   fun:vfprintf
+   fun:vsnprintf
+   fun:_ZSt16__convert_from_vRKP15__locale_structPciPKcz
+   fun:_ZNKSt7num_putIcSt19ostreambuf_iteratorIcSt11char_traitsIcEEE15_M_insert_floatIdEES3_S3_RSt8ios_baseccT_
+   fun:_ZNSo9_M_insertIdEERSoT_
+   fun:put_last<char, std::char_traits<char> >
+   fun:_ZN5boost2io6detail3putIcSt11char_traitsIcESaIcERKNS1_10put_holderIcS4_EEEEvT2_RKNS1_11format_itemIT_T0_T1_EERNS_12basic_formatISC_SD_SE_E11string_typeERNSJ_20internal_streambuf_tEPSt6locale
+   fun:_ZN5boost2io6detail10distributeIcSt11char_traitsIcESaIcERKNS1_10put_holderIcS4_EEEEvRNS_12basic_formatIT_T0_T1_EET2_
+   fun:_ZN5boost2io6detail9feed_implIcSt11char_traitsIcESaIcERKNS1_10put_holderIcS4_EEEERNS_12basic_formatIT_T0_T1_EESF_T2_
+   fun:feed<char, std::char_traits<char>, std::allocator<char>, double const&>
+   fun:operator%<double>
+   fun:_ZN5RDKit14GetPDBAtomLineB5cxx11EPKNS_4AtomEPKNS_9ConformerERSt3mapIjjSt4lessIjESaISt4pairIKjjEEE
+   fun:_ZN5RDKit12MolToPDBBodyB5cxx11ERKNS_5ROMolEPKNS_9ConformerEjRjS6_S6_
+   fun:_ZN5RDKit13MolToPDBBlockB5cxx11ERKNS_5ROMolEij
+}
+{
+   uninitialised value used in logic 3
+   Memcheck:Cond
+   fun:__mpn_addmul_1
+   obj:*
+   obj:*
+   fun:__mpn_mul
+   obj:*
+   obj:*
+   obj:*
+   fun:deallocate
+   fun:deallocate
+   fun:_M_deallocate
+   fun:~_Vector_base
+   fun:~vector
+   fun:~dynamic_bitset
+   fun:_ZN5RDKit5Canon13dfsBuildStackERNS_5ROMolEiiRSt6vectorINS0_10AtomColorsESaIS4_EERS3_IS3_IiSaIiEESaIS9_EERKS3_IjSaIjEERS9_RS3_INS0_12MolStackElemESaISI_EESH_SH_SC_RS3_INSt7__cxx114listIiS8_EESaISO_EEPKN5boost14dynamic_bitsetImSaImEEEPKS3_INSM_12basic_stringIcSt11char_traitsIcESaIcEEESaIS12_EE
+   obj:*
+   obj:*
+}
+{
+   uninitialised value used in logic 6
+   Memcheck:Cond
+   fun:__mpn_cmp
+   fun:__printf_fp
+   fun:vfprintf
+   fun:vsnprintf
+   fun:_ZSt16__convert_from_vRKP15__locale_structPciPKcz
+   fun:_ZNKSt7num_putIcSt19ostreambuf_iteratorIcSt11char_traitsIcEEE15_M_insert_floatIdEES3_S3_RSt8ios_baseccT_
+   fun:_ZNSo9_M_insertIdEERSoT_
+   fun:put_last<char, std::char_traits<char> >
+   fun:_ZN5boost2io6detail3putIcSt11char_traitsIcESaIcERKNS1_10put_holderIcS4_EEEEvT2_RKNS1_11format_itemIT_T0_T1_EERNS_12basic_formatISC_SD_SE_E11string_typeERNSJ_20internal_streambuf_tEPSt6locale
+   fun:_ZN5boost2io6detail10distributeIcSt11char_traitsIcESaIcERKNS1_10put_holderIcS4_EEEEvRNS_12basic_formatIT_T0_T1_EET2_
+   fun:_ZN5boost2io6detail9feed_implIcSt11char_traitsIcESaIcERKNS1_10put_holderIcS4_EEEERNS_12basic_formatIT_T0_T1_EESF_T2_
+   fun:feed<char, std::char_traits<char>, std::allocator<char>, double const&>
+   fun:operator%<double>
+   fun:_ZN5RDKit14GetPDBAtomLineB5cxx11EPKNS_4AtomEPKNS_9ConformerERSt3mapIjjSt4lessIjESaISt4pairIKjjEEE
+   fun:_ZN5RDKit12MolToPDBBodyB5cxx11ERKNS_5ROMolEPKNS_9ConformerEjRjS6_S6_
+   fun:_ZN5RDKit13MolToPDBBlockB5cxx11ERKNS_5ROMolEij
+}
+{
+   uninitialised value used in logic 7
+   Memcheck:Cond
+   fun:__mpn_divrem
+   fun:hack_digit.13624
+   fun:__printf_fp
+   fun:vfprintf
+   fun:vsnprintf
+   fun:_ZSt16__convert_from_vRKP15__locale_structPciPKcz
+   fun:_ZNKSt7num_putIcSt19ostreambuf_iteratorIcSt11char_traitsIcEEE15_M_insert_floatIdEES3_S3_RSt8ios_baseccT_
+   fun:_ZNSo9_M_insertIdEERSoT_
+   fun:put_last<char, std::char_traits<char> >
+   fun:_ZN5boost2io6detail3putIcSt11char_traitsIcESaIcERKNS1_10put_holderIcS4_EEEEvT2_RKNS1_11format_itemIT_T0_T1_EERNS_12basic_formatISC_SD_SE_E11string_typeERNSJ_20internal_streambuf_tEPSt6locale
+   fun:_ZN5boost2io6detail10distributeIcSt11char_traitsIcESaIcERKNS1_10put_holderIcS4_EEEEvRNS_12basic_formatIT_T0_T1_EET2_
+   fun:_ZN5boost2io6detail9feed_implIcSt11char_traitsIcESaIcERKNS1_10put_holderIcS4_EEEERNS_12basic_formatIT_T0_T1_EESF_T2_
+   fun:feed<char, std::char_traits<char>, std::allocator<char>, double const&>
+   fun:operator%<double>
+   fun:_ZN5RDKit14GetPDBAtomLineB5cxx11EPKNS_4AtomEPKNS_9ConformerERSt3mapIjjSt4lessIjESaISt4pairIKjjEEE
+   fun:_ZN5RDKit12MolToPDBBodyB5cxx11ERKNS_5ROMolEPKNS_9ConformerEjRjS6_S6_
+   fun:_ZN5RDKit13MolToPDBBlockB5cxx11ERKNS_5ROMolEij
+}
+{
+   uninitialised value used in logic 8
+   Memcheck:Cond
+   fun:__mpn_extract_double
+   fun:__printf_fp
+   fun:vfprintf
+   fun:vsnprintf
+   fun:_ZSt16__convert_from_vRKP15__locale_structPciPKcz
+   fun:_ZNKSt7num_putIcSt19ostreambuf_iteratorIcSt11char_traitsIcEEE15_M_insert_floatIdEES3_S3_RSt8ios_baseccT_
+   fun:_ZNSo9_M_insertIdEERSoT_
+   fun:put_last<char, std::char_traits<char> >
+   fun:_ZN5boost2io6detail3putIcSt11char_traitsIcESaIcERKNS1_10put_holderIcS4_EEEEvT2_RKNS1_11format_itemIT_T0_T1_EERNS_12basic_formatISC_SD_SE_E11string_typeERNSJ_20internal_streambuf_tEPSt6locale
+   fun:_ZN5boost2io6detail10distributeIcSt11char_traitsIcESaIcERKNS1_10put_holderIcS4_EEEEvRNS_12basic_formatIT_T0_T1_EET2_
+   fun:_ZN5boost2io6detail9feed_implIcSt11char_traitsIcESaIcERKNS1_10put_holderIcS4_EEEERNS_12basic_formatIT_T0_T1_EESF_T2_
+   fun:feed<char, std::char_traits<char>, std::allocator<char>, double const&>
+   fun:operator%<double>
+   fun:_ZN5RDKit14GetPDBAtomLineB5cxx11EPKNS_4AtomEPKNS_9ConformerERSt3mapIjjSt4lessIjESaISt4pairIKjjEEE
+   fun:_ZN5RDKit12MolToPDBBodyB5cxx11ERKNS_5ROMolEPKNS_9ConformerEjRjS6_S6_
+   fun:_ZN5RDKit13MolToPDBBlockB5cxx11ERKNS_5ROMolEij
+}
+{
+   uninitialised value used in logic 9
+   Memcheck:Cond
+   fun:__mpn_lshift
+   fun:__printf_fp
+   fun:vfprintf
+   fun:vsnprintf
+   fun:_ZSt16__convert_from_vRKP15__locale_structPciPKcz
+   fun:_ZNKSt7num_putIcSt19ostreambuf_iteratorIcSt11char_traitsIcEEE15_M_insert_floatIdEES3_S3_RSt8ios_baseccT_
+   fun:_ZNSo9_M_insertIdEERSoT_
+   fun:put_last<char, std::char_traits<char> >
+   fun:_ZN5boost2io6detail3putIcSt11char_traitsIcESaIcERKNS1_10put_holderIcS4_EEEEvT2_RKNS1_11format_itemIT_T0_T1_EERNS_12basic_formatISC_SD_SE_E11string_typeERNSJ_20internal_streambuf_tEPSt6locale
+   fun:_ZN5boost2io6detail10distributeIcSt11char_traitsIcESaIcERKNS1_10put_holderIcS4_EEEEvRNS_12basic_formatIT_T0_T1_EET2_
+   fun:_ZN5boost2io6detail9feed_implIcSt11char_traitsIcESaIcERKNS1_10put_holderIcS4_EEEERNS_12basic_formatIT_T0_T1_EESF_T2_
+   fun:feed<char, std::char_traits<char>, std::allocator<char>, double const&>
+   fun:operator%<double>
+   fun:_ZN5RDKit14GetPDBAtomLineB5cxx11EPKNS_4AtomEPKNS_9ConformerERSt3mapIjjSt4lessIjESaISt4pairIKjjEEE
+   fun:_ZN5RDKit12MolToPDBBodyB5cxx11ERKNS_5ROMolEPKNS_9ConformerEjRjS6_S6_
+   fun:_ZN5RDKit13MolToPDBBlockB5cxx11ERKNS_5ROMolEij
+}
+{
+   uninitialised value used in logic 10
+   Memcheck:Cond
+   fun:__mpn_mul
+   fun:__printf_fp
+   fun:vfprintf
+   fun:vsnprintf
+   fun:_ZSt16__convert_from_vRKP15__locale_structPciPKcz
+   fun:_ZNKSt7num_putIcSt19ostreambuf_iteratorIcSt11char_traitsIcEEE15_M_insert_floatIdEES3_S3_RSt8ios_baseccT_
+   fun:_ZNSo9_M_insertIdEERSoT_
+   fun:put_last<char, std::char_traits<char> >
+   fun:_ZN5boost2io6detail3putIcSt11char_traitsIcESaIcERKNS1_10put_holderIcS4_EEEEvT2_RKNS1_11format_itemIT_T0_T1_EERNS_12basic_formatISC_SD_SE_E11string_typeERNSJ_20internal_streambuf_tEPSt6locale
+   fun:_ZN5boost2io6detail10distributeIcSt11char_traitsIcESaIcERKNS1_10put_holderIcS4_EEEEvRNS_12basic_formatIT_T0_T1_EET2_
+   fun:_ZN5boost2io6detail9feed_implIcSt11char_traitsIcESaIcERKNS1_10put_holderIcS4_EEEERNS_12basic_formatIT_T0_T1_EESF_T2_
+   fun:feed<char, std::char_traits<char>, std::allocator<char>, double const&>
+   fun:operator%<double>
+   fun:_ZN5RDKit14GetPDBAtomLineB5cxx11EPKNS_4AtomEPKNS_9ConformerERSt3mapIjjSt4lessIjESaISt4pairIKjjEEE
+   fun:_ZN5RDKit12MolToPDBBodyB5cxx11ERKNS_5ROMolEPKNS_9ConformerEjRjS6_S6_
+   fun:_ZN5RDKit13MolToPDBBlockB5cxx11ERKNS_5ROMolEij
+}
+{
+   uninitialised value used in logic 11
+   Memcheck:Cond
+   fun:__mpn_mul_1
+   fun:__mpn_mul
+   fun:__printf_fp
+   fun:vfprintf
+   fun:vsnprintf
+   fun:_ZSt16__convert_from_vRKP15__locale_structPciPKcz
+   fun:_ZNKSt7num_putIcSt19ostreambuf_iteratorIcSt11char_traitsIcEEE15_M_insert_floatIdEES3_S3_RSt8ios_baseccT_
+   fun:_ZNSo9_M_insertIdEERSoT_
+   fun:put_last<char, std::char_traits<char> >
+   fun:_ZN5boost2io6detail3putIcSt11char_traitsIcESaIcERKNS1_10put_holderIcS4_EEEEvT2_RKNS1_11format_itemIT_T0_T1_EERNS_12basic_formatISC_SD_SE_E11string_typeERNSJ_20internal_streambuf_tEPSt6locale
+   fun:_ZN5boost2io6detail10distributeIcSt11char_traitsIcESaIcERKNS1_10put_holderIcS4_EEEEvRNS_12basic_formatIT_T0_T1_EET2_
+   fun:_ZN5boost2io6detail9feed_implIcSt11char_traitsIcESaIcERKNS1_10put_holderIcS4_EEEERNS_12basic_formatIT_T0_T1_EESF_T2_
+   fun:feed<char, std::char_traits<char>, std::allocator<char>, double const&>
+   fun:operator%<double>
+   fun:_ZN5RDKit14GetPDBAtomLineB5cxx11EPKNS_4AtomEPKNS_9ConformerERSt3mapIjjSt4lessIjESaISt4pairIKjjEEE
+   fun:_ZN5RDKit12MolToPDBBodyB5cxx11ERKNS_5ROMolEPKNS_9ConformerEjRjS6_S6_
+   fun:_ZN5RDKit13MolToPDBBlockB5cxx11ERKNS_5ROMolEij
+}
+{
+   uninitialised value used in logic 12
+   Memcheck:Cond
+   fun:__mpn_mul_1
+   fun:__printf_fp
+   fun:vfprintf
+   fun:vsnprintf
+   fun:_ZSt16__convert_from_vRKP15__locale_structPciPKcz
+   fun:_ZNKSt7num_putIcSt19ostreambuf_iteratorIcSt11char_traitsIcEEE15_M_insert_floatIdEES3_S3_RSt8ios_baseccT_
+   fun:_ZNSo9_M_insertIdEERSoT_
+   fun:put_last<char, std::char_traits<char> >
+   fun:_ZN5boost2io6detail3putIcSt11char_traitsIcESaIcERKNS1_10put_holderIcS4_EEEEvT2_RKNS1_11format_itemIT_T0_T1_EERNS_12basic_formatISC_SD_SE_E11string_typeERNSJ_20internal_streambuf_tEPSt6locale
+   fun:_ZN5boost2io6detail10distributeIcSt11char_traitsIcESaIcERKNS1_10put_holderIcS4_EEEEvRNS_12basic_formatIT_T0_T1_EET2_
+   fun:_ZN5boost2io6detail9feed_implIcSt11char_traitsIcESaIcERKNS1_10put_holderIcS4_EEEERNS_12basic_formatIT_T0_T1_EESF_T2_
+   fun:feed<char, std::char_traits<char>, std::allocator<char>, double const&>
+   fun:operator%<double>
+   fun:_ZN5RDKit14GetPDBAtomLineB5cxx11EPKNS_4AtomEPKNS_9ConformerERSt3mapIjjSt4lessIjESaISt4pairIKjjEEE
+   fun:_ZN5RDKit12MolToPDBBodyB5cxx11ERKNS_5ROMolEPKNS_9ConformerEjRjS6_S6_
+   fun:_ZN5RDKit13MolToPDBBlockB5cxx11ERKNS_5ROMolEij
+}
+{
+   uninitialised value used in logic 13
+   Memcheck:Cond
+   fun:__mpn_rshift
+   fun:__printf_fp
+   fun:vfprintf
+   fun:vsnprintf
+   fun:_ZSt16__convert_from_vRKP15__locale_structPciPKcz
+   fun:_ZNKSt7num_putIcSt19ostreambuf_iteratorIcSt11char_traitsIcEEE15_M_insert_floatIdEES3_S3_RSt8ios_baseccT_
+   fun:_ZNSo9_M_insertIdEERSoT_
+   fun:put_last<char, std::char_traits<char> >
+   fun:_ZN5boost2io6detail3putIcSt11char_traitsIcESaIcERKNS1_10put_holderIcS4_EEEEvT2_RKNS1_11format_itemIT_T0_T1_EERNS_12basic_formatISC_SD_SE_E11string_typeERNSJ_20internal_streambuf_tEPSt6locale
+   fun:_ZN5boost2io6detail10distributeIcSt11char_traitsIcESaIcERKNS1_10put_holderIcS4_EEEEvRNS_12basic_formatIT_T0_T1_EET2_
+   fun:_ZN5boost2io6detail9feed_implIcSt11char_traitsIcESaIcERKNS1_10put_holderIcS4_EEEERNS_12basic_formatIT_T0_T1_EESF_T2_
+   fun:feed<char, std::char_traits<char>, std::allocator<char>, double const&>
+   fun:operator%<double>
+   fun:_ZN5RDKit14GetPDBAtomLineB5cxx11EPKNS_4AtomEPKNS_9ConformerERSt3mapIjjSt4lessIjESaISt4pairIKjjEEE
+   fun:_ZN5RDKit12MolToPDBBodyB5cxx11ERKNS_5ROMolEPKNS_9ConformerEjRjS6_S6_
+   fun:_ZN5RDKit13MolToPDBBlockB5cxx11ERKNS_5ROMolEij
+}
+{
+   uninitialised value used in logic 14
+   Memcheck:Cond
+   fun:__printf_fp
+   fun:vfprintf
+   fun:vsnprintf
+   fun:_ZSt16__convert_from_vRKP15__locale_structPciPKcz
+   fun:_ZNKSt7num_putIcSt19ostreambuf_iteratorIcSt11char_traitsIcEEE15_M_insert_floatIdEES3_S3_RSt8ios_baseccT_
+   fun:_ZNSo9_M_insertIdEERSoT_
+   fun:put_last<char, std::char_traits<char> >
+   fun:_ZN5boost2io6detail3putIcSt11char_traitsIcESaIcERKNS1_10put_holderIcS4_EEEEvT2_RKNS1_11format_itemIT_T0_T1_EERNS_12basic_formatISC_SD_SE_E11string_typeERNSJ_20internal_streambuf_tEPSt6locale
+   fun:_ZN5boost2io6detail10distributeIcSt11char_traitsIcESaIcERKNS1_10put_holderIcS4_EEEEvRNS_12basic_formatIT_T0_T1_EET2_
+   fun:_ZN5boost2io6detail9feed_implIcSt11char_traitsIcESaIcERKNS1_10put_holderIcS4_EEEERNS_12basic_formatIT_T0_T1_EESF_T2_
+   fun:feed<char, std::char_traits<char>, std::allocator<char>, double const&>
+   fun:operator%<double>
+   fun:_ZN5RDKit14GetPDBAtomLineB5cxx11EPKNS_4AtomEPKNS_9ConformerERSt3mapIjjSt4lessIjESaISt4pairIKjjEEE
+   fun:_ZN5RDKit12MolToPDBBodyB5cxx11ERKNS_5ROMolEPKNS_9ConformerEjRjS6_S6_
+   fun:_ZN5RDKit13MolToPDBBlockB5cxx11ERKNS_5ROMolEij
+}
+{
+   uninitialised value used in logic 15
+   Memcheck:Cond
+   fun:hack_digit.13624
+   fun:__printf_fp
+   fun:vfprintf
+   fun:vsnprintf
+   fun:_ZSt16__convert_from_vRKP15__locale_structPciPKcz
+   fun:_ZNKSt7num_putIcSt19ostreambuf_iteratorIcSt11char_traitsIcEEE15_M_insert_floatIdEES3_S3_RSt8ios_baseccT_
+   fun:_ZNSo9_M_insertIdEERSoT_
+   fun:put_last<char, std::char_traits<char> >
+   fun:_ZN5boost2io6detail3putIcSt11char_traitsIcESaIcERKNS1_10put_holderIcS4_EEEEvT2_RKNS1_11format_itemIT_T0_T1_EERNS_12basic_formatISC_SD_SE_E11string_typeERNSJ_20internal_streambuf_tEPSt6locale
+   fun:_ZN5boost2io6detail10distributeIcSt11char_traitsIcESaIcERKNS1_10put_holderIcS4_EEEEvRNS_12basic_formatIT_T0_T1_EET2_
+   fun:_ZN5boost2io6detail9feed_implIcSt11char_traitsIcESaIcERKNS1_10put_holderIcS4_EEEERNS_12basic_formatIT_T0_T1_EESF_T2_
+   fun:feed<char, std::char_traits<char>, std::allocator<char>, double const&>
+   fun:operator%<double>
+   fun:_ZN5RDKit14GetPDBAtomLineB5cxx11EPKNS_4AtomEPKNS_9ConformerERSt3mapIjjSt4lessIjESaISt4pairIKjjEEE
+   fun:_ZN5RDKit12MolToPDBBodyB5cxx11ERKNS_5ROMolEPKNS_9ConformerEjRjS6_S6_
+   fun:_ZN5RDKit13MolToPDBBlockB5cxx11ERKNS_5ROMolEij
+}
+{
+   uninitialised value used in logic 16
+   Memcheck:Cond
+   fun:is_overlap
+   fun:__GI_memcpy
+   fun:__printf_fp
+   fun:vfprintf
+   fun:vsnprintf
+   fun:_ZSt16__convert_from_vRKP15__locale_structPciPKcz
+   fun:_ZNKSt7num_putIcSt19ostreambuf_iteratorIcSt11char_traitsIcEEE15_M_insert_floatIdEES3_S3_RSt8ios_baseccT_
+   fun:_ZNSo9_M_insertIdEERSoT_
+   fun:put_last<char, std::char_traits<char> >
+   fun:_ZN5boost2io6detail3putIcSt11char_traitsIcESaIcERKNS1_10put_holderIcS4_EEEEvT2_RKNS1_11format_itemIT_T0_T1_EERNS_12basic_formatISC_SD_SE_E11string_typeERNSJ_20internal_streambuf_tEPSt6locale
+   fun:_ZN5boost2io6detail10distributeIcSt11char_traitsIcESaIcERKNS1_10put_holderIcS4_EEEEvRNS_12basic_formatIT_T0_T1_EET2_
+   fun:_ZN5boost2io6detail9feed_implIcSt11char_traitsIcESaIcERKNS1_10put_holderIcS4_EEEERNS_12basic_formatIT_T0_T1_EESF_T2_
+   fun:feed<char, std::char_traits<char>, std::allocator<char>, double const&>
+   fun:operator%<double>
+   fun:_ZN5RDKit14GetPDBAtomLineB5cxx11EPKNS_4AtomEPKNS_9ConformerERSt3mapIjjSt4lessIjESaISt4pairIKjjEEE
+   fun:_ZN5RDKit12MolToPDBBodyB5cxx11ERKNS_5ROMolEPKNS_9ConformerEjRjS6_S6_
+   fun:_ZN5RDKit13MolToPDBBlockB5cxx11ERKNS_5ROMolEij
+}
+{
+   uninitialised value used in logic 17
+   Memcheck:Cond
+   fun:memchr
+   fun:_ZNKSt7num_putIcSt19ostreambuf_iteratorIcSt11char_traitsIcEEE15_M_insert_floatIdEES3_S3_RSt8ios_baseccT_
+   fun:_ZNSo9_M_insertIdEERSoT_
+   fun:put_last<char, std::char_traits<char> >
+   fun:_ZN5boost2io6detail3putIcSt11char_traitsIcESaIcERKNS1_10put_holderIcS4_EEEEvT2_RKNS1_11format_itemIT_T0_T1_EERNS_12basic_formatISC_SD_SE_E11string_typeERNSJ_20internal_streambuf_tEPSt6locale
+   fun:_ZN5boost2io6detail10distributeIcSt11char_traitsIcESaIcERKNS1_10put_holderIcS4_EEEEvRNS_12basic_formatIT_T0_T1_EET2_
+   fun:_ZN5boost2io6detail9feed_implIcSt11char_traitsIcESaIcERKNS1_10put_holderIcS4_EEEERNS_12basic_formatIT_T0_T1_EESF_T2_
+   fun:feed<char, std::char_traits<char>, std::allocator<char>, double const&>
+   fun:operator%<double>
+   fun:_ZN5RDKit14GetPDBAtomLineB5cxx11EPKNS_4AtomEPKNS_9ConformerERSt3mapIjjSt4lessIjESaISt4pairIKjjEEE
+   fun:_ZN5RDKit12MolToPDBBodyB5cxx11ERKNS_5ROMolEPKNS_9ConformerEjRjS6_S6_
+   fun:_ZN5RDKit13MolToPDBBlockB5cxx11ERKNS_5ROMolEij
+}
+{
+   uninitialised value used in logic 18
+   Memcheck:Cond
+   fun:memset
+   fun:__mpn_mul
+   fun:__printf_fp
+   fun:vfprintf
+   fun:vsnprintf
+   fun:_ZSt16__convert_from_vRKP15__locale_structPciPKcz
+   fun:_ZNKSt7num_putIcSt19ostreambuf_iteratorIcSt11char_traitsIcEEE15_M_insert_floatIdEES3_S3_RSt8ios_baseccT_
+   fun:_ZNSo9_M_insertIdEERSoT_
+   fun:put_last<char, std::char_traits<char> >
+   fun:_ZN5boost2io6detail3putIcSt11char_traitsIcESaIcERKNS1_10put_holderIcS4_EEEEvT2_RKNS1_11format_itemIT_T0_T1_EERNS_12basic_formatISC_SD_SE_E11string_typeERNSJ_20internal_streambuf_tEPSt6locale
+   fun:_ZN5boost2io6detail10distributeIcSt11char_traitsIcESaIcERKNS1_10put_holderIcS4_EEEEvRNS_12basic_formatIT_T0_T1_EET2_
+   fun:_ZN5boost2io6detail9feed_implIcSt11char_traitsIcESaIcERKNS1_10put_holderIcS4_EEEERNS_12basic_formatIT_T0_T1_EESF_T2_
+   fun:feed<char, std::char_traits<char>, std::allocator<char>, double const&>
+   fun:operator%<double>
+   fun:_ZN5RDKit14GetPDBAtomLineB5cxx11EPKNS_4AtomEPKNS_9ConformerERSt3mapIjjSt4lessIjESaISt4pairIKjjEEE
+   fun:_ZN5RDKit12MolToPDBBodyB5cxx11ERKNS_5ROMolEPKNS_9ConformerEjRjS6_S6_
+   fun:_ZN5RDKit13MolToPDBBlockB5cxx11ERKNS_5ROMolEij
+}
+{
+   uninitialised value used in logic 19
+   Memcheck:Cond
+   fun:memset
+   fun:__printf_fp
+   fun:vfprintf
+   fun:vsnprintf
+   fun:_ZSt16__convert_from_vRKP15__locale_structPciPKcz
+   fun:_ZNKSt7num_putIcSt19ostreambuf_iteratorIcSt11char_traitsIcEEE15_M_insert_floatIdEES3_S3_RSt8ios_baseccT_
+   fun:_ZNSo9_M_insertIdEERSoT_
+   fun:put_last<char, std::char_traits<char> >
+   fun:_ZN5boost2io6detail3putIcSt11char_traitsIcESaIcERKNS1_10put_holderIcS4_EEEEvT2_RKNS1_11format_itemIT_T0_T1_EERNS_12basic_formatISC_SD_SE_E11string_typeERNSJ_20internal_streambuf_tEPSt6locale
+   fun:_ZN5boost2io6detail10distributeIcSt11char_traitsIcESaIcERKNS1_10put_holderIcS4_EEEEvRNS_12basic_formatIT_T0_T1_EET2_
+   fun:_ZN5boost2io6detail9feed_implIcSt11char_traitsIcESaIcERKNS1_10put_holderIcS4_EEEERNS_12basic_formatIT_T0_T1_EESF_T2_
+   fun:feed<char, std::char_traits<char>, std::allocator<char>, double const&>
+   fun:operator%<double>
+   fun:_ZN5RDKit14GetPDBAtomLineB5cxx11EPKNS_4AtomEPKNS_9ConformerERSt3mapIjjSt4lessIjESaISt4pairIKjjEEE
+   fun:_ZN5RDKit12MolToPDBBodyB5cxx11ERKNS_5ROMolEPKNS_9ConformerEjRjS6_S6_
+   fun:_ZN5RDKit13MolToPDBBlockB5cxx11ERKNS_5ROMolEij
+}
+{
+   uninitialised value used in logic 20
+   Memcheck:Cond
+   fun:vfprintf
+   fun:printf
+}
+{
+   memory definitely lost 1
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:calloc
+   fun:_renumberTest2
+}
+{
+   memory definitely lost 2
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:malloc
+}
+{
+   memory indirectly lost 5
+   Memcheck:Leak
+   match-leak-kinds: indirect
+   fun:malloc
+   fun:_Z17yysln__scan_bytesPKcmPv
+   fun:_Z16setup_sln_stringRKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEPv
+   fun:_Z9sln_parseRKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEbRSt6vectorIPN5RDKit5RWMolESaISA_EE
+   fun:_ZN5RDKit8SLNParse5toMolENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEbi
+   fun:_ZN5RDKit8SLNToMolERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEbi
+}
+{
+   memory indirectly lost 6
+   Memcheck:Leak
+   match-leak-kinds: indirect
+   fun:malloc
+   fun:_Z18yysln__scan_bufferPcmPv
+   fun:_Z17yysln__scan_bytesPKcmPv
+   fun:_Z16setup_sln_stringRKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEPv
+   fun:_Z9sln_parseRKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEbRSt6vectorIPN5RDKit5RWMolESaISA_EE
+   fun:_ZN5RDKit8SLNParse5toMolENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEbi
+   fun:_ZN5RDKit8SLNToMolERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEbi
+}
+{
+   memory indirectly lost 7
+   Memcheck:Leak
+   match-leak-kinds: indirect
+   fun:malloc
+   fun:_ZL13yy_push_stateiPv
+   fun:_Z9yysln_lexP7YYSTYPEPv
+   fun:_Z11yysln_parsePKcPSt6vectorIPN5RDKit5RWMolESaIS4_EEbPv
+   fun:_Z9sln_parseRKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEbRSt6vectorIPN5RDKit5RWMolESaISA_EE
+   fun:_ZN5RDKit8SLNParse5toMolENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEbi
+   fun:_ZN5RDKit8SLNToMolERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEbi
+}
+{
+   memory indirectly lost 8
+   Memcheck:Leak
+   match-leak-kinds: indirect
+   fun:malloc
+   fun:_ZL25yysln_ensure_buffer_stackPv
+   fun:_Z23yysln__switch_to_bufferP15yy_buffer_statePv
+   fun:_Z18yysln__scan_bufferPcmPv
+   fun:_Z17yysln__scan_bytesPKcmPv
+   fun:_Z16setup_sln_stringRKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEPv
+   fun:_Z9sln_parseRKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEbRSt6vectorIPN5RDKit5RWMolESaISA_EE
+   fun:_ZN5RDKit8SLNParse5toMolENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEbi
+   fun:_ZN5RDKit8SLNToMolERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEbi
+}
+{
+   memory possibly lost 125
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_Z3hs1RKSt6vectorIS_IiSaIiEESaIS1_EE
+}
+{
+   syscall param write(buf) points to uninitialised byte(s)
+   Memcheck:Param
+   write(buf)
+   fun:__write_nocancel
+   fun:_IO_file_write*
+   fun:_IO_do_write*
+   fun:_IO_file_xsputn*
+   fun:vfprintf
+   fun:printf
 }
 {
    uninitialised value used
@@ -38,41 +2840,64 @@
    fun:__printf_fp
    fun:vfprintf
    fun:vsnprintf
-   obj:*
+   fun:_ZSt16__convert_from_vRKP15__locale_structPciPKcz
+   fun:_ZNKSt7num_putIcSt19ostreambuf_iteratorIcSt11char_traitsIcEEE15_M_insert_floatIdEES3_S3_RSt8ios_baseccT_
+   fun:_ZNSo9_M_insertIdEERSoT_
+   fun:put_last<char, std::char_traits<char> >
+   fun:_ZN5boost2io6detail3putIcSt11char_traitsIcESaIcERKNS1_10put_holderIcS4_EEEEvT2_RKNS1_11format_itemIT_T0_T1_EERNS_12basic_formatISC_SD_SE_E11string_typeERNSJ_20internal_streambuf_tEPSt6locale
+   fun:_ZN5boost2io6detail10distributeIcSt11char_traitsIcESaIcERKNS1_10put_holderIcS4_EEEEvRNS_12basic_formatIT_T0_T1_EET2_
+   fun:_ZN5boost2io6detail9feed_implIcSt11char_traitsIcESaIcERKNS1_10put_holderIcS4_EEEERNS_12basic_formatIT_T0_T1_EESF_T2_
+   fun:feed<char, std::char_traits<char>, std::allocator<char>, double const&>
+   fun:operator%<double>
+   fun:_ZN5RDKit14GetPDBAtomLineB5cxx11EPKNS_4AtomEPKNS_9ConformerERSt3mapIjjSt4lessIjESaISt4pairIKjjEEE
+   fun:_ZN5RDKit12MolToPDBBodyB5cxx11ERKNS_5ROMolEPKNS_9ConformerEjRjS6_S6_
+   fun:_ZN5RDKit13MolToPDBBlockB5cxx11ERKNS_5ROMolEij
 }
 {
-   uninitialised value used 1
+   uninitialised value used 0
    Memcheck:Value8
    fun:__mpn_add_n
    fun:__mpn_mul
    fun:__printf_fp
    fun:vfprintf
    fun:vsnprintf
-   obj:*
+   fun:_ZSt16__convert_from_vRKP15__locale_structPciPKcz
+   fun:_ZNKSt7num_putIcSt19ostreambuf_iteratorIcSt11char_traitsIcEEE15_M_insert_floatIdEES3_S3_RSt8ios_baseccT_
+   fun:_ZNSo9_M_insertIdEERSoT_
+   fun:put_last<char, std::char_traits<char> >
+   fun:_ZN5boost2io6detail3putIcSt11char_traitsIcESaIcERKNS1_10put_holderIcS4_EEEEvT2_RKNS1_11format_itemIT_T0_T1_EERNS_12basic_formatISC_SD_SE_E11string_typeERNSJ_20internal_streambuf_tEPSt6locale
+   fun:_ZN5boost2io6detail10distributeIcSt11char_traitsIcESaIcERKNS1_10put_holderIcS4_EEEEvRNS_12basic_formatIT_T0_T1_EET2_
+   fun:_ZN5boost2io6detail9feed_implIcSt11char_traitsIcESaIcERKNS1_10put_holderIcS4_EEEERNS_12basic_formatIT_T0_T1_EESF_T2_
+   fun:feed<char, std::char_traits<char>, std::allocator<char>, double const&>
+   fun:operator%<double>
+   fun:_ZN5RDKit14GetPDBAtomLineB5cxx11EPKNS_4AtomEPKNS_9ConformerERSt3mapIjjSt4lessIjESaISt4pairIKjjEEE
+   fun:_ZN5RDKit12MolToPDBBodyB5cxx11ERKNS_5ROMolEPKNS_9ConformerEjRjS6_S6_
+   fun:_ZN5RDKit13MolToPDBBlockB5cxx11ERKNS_5ROMolEij
 }
 {
-   uninitialised value used 2
+   uninitialised value used 1
    Memcheck:Value8
    fun:__mpn_addmul_1
    obj:*
    fun:__printf_fp
    fun:vfprintf
    fun:vsnprintf
-   obj:*
+   fun:_ZSt16__convert_from_vRKP15__locale_structPciPKcz
+   fun:_ZNKSt7num_putIcSt19ostreambuf_iteratorIcSt11char_traitsIcEEE15_M_insert_floatIdEES3_S3_RSt8ios_baseccT_
+   fun:_ZNSo9_M_insertIdEERSoT_
+   fun:put_last<char, std::char_traits<char> >
+   fun:_ZN5boost2io6detail3putIcSt11char_traitsIcESaIcERKNS1_10put_holderIcS4_EEEEvT2_RKNS1_11format_itemIT_T0_T1_EERNS_12basic_formatISC_SD_SE_E11string_typeERNSJ_20internal_streambuf_tEPSt6locale
+   fun:_ZN5boost2io6detail10distributeIcSt11char_traitsIcESaIcERKNS1_10put_holderIcS4_EEEEvRNS_12basic_formatIT_T0_T1_EET2_
+   fun:_ZN5boost2io6detail9feed_implIcSt11char_traitsIcESaIcERKNS1_10put_holderIcS4_EEEERNS_12basic_formatIT_T0_T1_EESF_T2_
+   fun:feed<char, std::char_traits<char>, std::allocator<char>, double const&>
+   fun:operator%<double>
+   fun:_ZN5RDKit14GetPDBAtomLineB5cxx11EPKNS_4AtomEPKNS_9ConformerERSt3mapIjjSt4lessIjESaISt4pairIKjjEEE
+   fun:_ZN5RDKit12MolToPDBBodyB5cxx11ERKNS_5ROMolEPKNS_9ConformerEjRjS6_S6_
+   fun:_ZN5RDKit13MolToPDBBlockB5cxx11ERKNS_5ROMolEij
 }
 {
-   uninitialised value used in logic 5
-   Memcheck:Cond
-   fun:__mpn_addmul_1
-   obj:*
-   fun:__printf_fp
-   fun:vfprintf
-   fun:vsnprintf
-   obj:*
-}
-{
-   uninitialised value used in logic 7
-   Memcheck:Cond
+   uninitialised value used 2
+   Memcheck:Value8
    fun:__mpn_addmul_1
    obj:*
    obj:*
@@ -93,174 +2918,168 @@
 {
    uninitialised value used 5
    Memcheck:Value8
-   fun:__mpn_addmul_1
-   obj:*
-   obj:*
-   fun:__mpn_mul
-   obj:*
-   obj:*
-   obj:*
-   fun:deallocate
-   fun:deallocate
-   fun:_M_deallocate
-   fun:~_Vector_base
-   fun:~vector
-   fun:~dynamic_bitset
-   fun:_ZN5RDKit5Canon13dfsBuildStackERNS_5ROMolEiiRSt6vectorINS0_10AtomColorsESaIS4_EERS3_IS3_IiSaIiEESaIS9_EERKS3_IjSaIjEERS9_RS3_INS0_12MolStackElemESaISI_EESH_SH_SC_RS3_INSt7__cxx114listIiS8_EESaISO_EEPKN5boost14dynamic_bitsetImSaImEEEPKS3_INSM_12basic_stringIcSt11char_traitsIcESaIcEEESaIS12_EE
-   obj:*
-   obj:*
+   fun:__mpn_cmp
+   fun:__printf_fp
+   fun:vfprintf
+   fun:vsnprintf
+   fun:_ZSt16__convert_from_vRKP15__locale_structPciPKcz
+   fun:_ZNKSt7num_putIcSt19ostreambuf_iteratorIcSt11char_traitsIcEEE15_M_insert_floatIdEES3_S3_RSt8ios_baseccT_
+   fun:_ZNSo9_M_insertIdEERSoT_
+   fun:put_last<char, std::char_traits<char> >
+   fun:_ZN5boost2io6detail3putIcSt11char_traitsIcESaIcERKNS1_10put_holderIcS4_EEEEvT2_RKNS1_11format_itemIT_T0_T1_EERNS_12basic_formatISC_SD_SE_E11string_typeERNSJ_20internal_streambuf_tEPSt6locale
+   fun:_ZN5boost2io6detail10distributeIcSt11char_traitsIcESaIcERKNS1_10put_holderIcS4_EEEEvRNS_12basic_formatIT_T0_T1_EET2_
+   fun:_ZN5boost2io6detail9feed_implIcSt11char_traitsIcESaIcERKNS1_10put_holderIcS4_EEEERNS_12basic_formatIT_T0_T1_EESF_T2_
+   fun:feed<char, std::char_traits<char>, std::allocator<char>, double const&>
+   fun:operator%<double>
+   fun:_ZN5RDKit14GetPDBAtomLineB5cxx11EPKNS_4AtomEPKNS_9ConformerERSt3mapIjjSt4lessIjESaISt4pairIKjjEEE
+   fun:_ZN5RDKit12MolToPDBBodyB5cxx11ERKNS_5ROMolEPKNS_9ConformerEjRjS6_S6_
+   fun:_ZN5RDKit13MolToPDBBlockB5cxx11ERKNS_5ROMolEij
+}
+{
+   uninitialised value used 6
+   Memcheck:Value8
+   fun:__mpn_divrem
+   fun:hack_digit.13624
+   fun:__printf_fp
+   fun:vfprintf
+   fun:vsnprintf
+   fun:_ZSt16__convert_from_vRKP15__locale_structPciPKcz
+   fun:_ZNKSt7num_putIcSt19ostreambuf_iteratorIcSt11char_traitsIcEEE15_M_insert_floatIdEES3_S3_RSt8ios_baseccT_
+   fun:_ZNSo9_M_insertIdEERSoT_
+   fun:put_last<char, std::char_traits<char> >
+   fun:_ZN5boost2io6detail3putIcSt11char_traitsIcESaIcERKNS1_10put_holderIcS4_EEEEvT2_RKNS1_11format_itemIT_T0_T1_EERNS_12basic_formatISC_SD_SE_E11string_typeERNSJ_20internal_streambuf_tEPSt6locale
+   fun:_ZN5boost2io6detail10distributeIcSt11char_traitsIcESaIcERKNS1_10put_holderIcS4_EEEEvRNS_12basic_formatIT_T0_T1_EET2_
+   fun:_ZN5boost2io6detail9feed_implIcSt11char_traitsIcESaIcERKNS1_10put_holderIcS4_EEEERNS_12basic_formatIT_T0_T1_EESF_T2_
+   fun:feed<char, std::char_traits<char>, std::allocator<char>, double const&>
+   fun:operator%<double>
+   fun:_ZN5RDKit14GetPDBAtomLineB5cxx11EPKNS_4AtomEPKNS_9ConformerERSt3mapIjjSt4lessIjESaISt4pairIKjjEEE
+   fun:_ZN5RDKit12MolToPDBBodyB5cxx11ERKNS_5ROMolEPKNS_9ConformerEjRjS6_S6_
+   fun:_ZN5RDKit13MolToPDBBlockB5cxx11ERKNS_5ROMolEij
 }
 {
    uninitialised value used 7
    Memcheck:Value8
-   fun:__mpn_cmp
+   fun:__mpn_lshift
    fun:__printf_fp
    fun:vfprintf
    fun:vsnprintf
-   obj:*
-}
-{
-   uninitialised value used in logic 9
-   Memcheck:Cond
-   fun:__mpn_cmp
-   fun:__printf_fp
-   fun:vfprintf
-   fun:vsnprintf
-   obj:*
+   fun:_ZSt16__convert_from_vRKP15__locale_structPciPKcz
+   fun:_ZNKSt7num_putIcSt19ostreambuf_iteratorIcSt11char_traitsIcEEE15_M_insert_floatIdEES3_S3_RSt8ios_baseccT_
+   fun:_ZNSo9_M_insertIdEERSoT_
+   fun:put_last<char, std::char_traits<char> >
+   fun:_ZN5boost2io6detail3putIcSt11char_traitsIcESaIcERKNS1_10put_holderIcS4_EEEEvT2_RKNS1_11format_itemIT_T0_T1_EERNS_12basic_formatISC_SD_SE_E11string_typeERNSJ_20internal_streambuf_tEPSt6locale
+   fun:_ZN5boost2io6detail10distributeIcSt11char_traitsIcESaIcERKNS1_10put_holderIcS4_EEEEvRNS_12basic_formatIT_T0_T1_EET2_
+   fun:_ZN5boost2io6detail9feed_implIcSt11char_traitsIcESaIcERKNS1_10put_holderIcS4_EEEERNS_12basic_formatIT_T0_T1_EESF_T2_
+   fun:feed<char, std::char_traits<char>, std::allocator<char>, double const&>
+   fun:operator%<double>
+   fun:_ZN5RDKit14GetPDBAtomLineB5cxx11EPKNS_4AtomEPKNS_9ConformerERSt3mapIjjSt4lessIjESaISt4pairIKjjEEE
+   fun:_ZN5RDKit12MolToPDBBodyB5cxx11ERKNS_5ROMolEPKNS_9ConformerEjRjS6_S6_
+   fun:_ZN5RDKit13MolToPDBBlockB5cxx11ERKNS_5ROMolEij
 }
 {
    uninitialised value used 8
    Memcheck:Value8
-   fun:__mpn_divrem
+   fun:__mpn_mul
+   fun:__printf_fp
+   fun:vfprintf
+   fun:vsnprintf
+   fun:_ZSt16__convert_from_vRKP15__locale_structPciPKcz
+   fun:_ZNKSt7num_putIcSt19ostreambuf_iteratorIcSt11char_traitsIcEEE15_M_insert_floatIdEES3_S3_RSt8ios_baseccT_
+   fun:_ZNSo9_M_insertIdEERSoT_
+   fun:put_last<char, std::char_traits<char> >
+   fun:_ZN5boost2io6detail3putIcSt11char_traitsIcESaIcERKNS1_10put_holderIcS4_EEEEvT2_RKNS1_11format_itemIT_T0_T1_EERNS_12basic_formatISC_SD_SE_E11string_typeERNSJ_20internal_streambuf_tEPSt6locale
+   fun:_ZN5boost2io6detail10distributeIcSt11char_traitsIcESaIcERKNS1_10put_holderIcS4_EEEEvRNS_12basic_formatIT_T0_T1_EET2_
+   fun:_ZN5boost2io6detail9feed_implIcSt11char_traitsIcESaIcERKNS1_10put_holderIcS4_EEEERNS_12basic_formatIT_T0_T1_EESF_T2_
+   fun:feed<char, std::char_traits<char>, std::allocator<char>, double const&>
+   fun:operator%<double>
+   fun:_ZN5RDKit14GetPDBAtomLineB5cxx11EPKNS_4AtomEPKNS_9ConformerERSt3mapIjjSt4lessIjESaISt4pairIKjjEEE
+   fun:_ZN5RDKit12MolToPDBBodyB5cxx11ERKNS_5ROMolEPKNS_9ConformerEjRjS6_S6_
+   fun:_ZN5RDKit13MolToPDBBlockB5cxx11ERKNS_5ROMolEij
+}
+{
+   uninitialised value used 9
+   Memcheck:Value8
+   fun:__mpn_mul_1
+   fun:__mpn_mul
+   fun:__printf_fp
+   fun:vfprintf
+   fun:vsnprintf
+   fun:_ZSt16__convert_from_vRKP15__locale_structPciPKcz
+   fun:_ZNKSt7num_putIcSt19ostreambuf_iteratorIcSt11char_traitsIcEEE15_M_insert_floatIdEES3_S3_RSt8ios_baseccT_
+   fun:_ZNSo9_M_insertIdEERSoT_
+   fun:put_last<char, std::char_traits<char> >
+   fun:_ZN5boost2io6detail3putIcSt11char_traitsIcESaIcERKNS1_10put_holderIcS4_EEEEvT2_RKNS1_11format_itemIT_T0_T1_EERNS_12basic_formatISC_SD_SE_E11string_typeERNSJ_20internal_streambuf_tEPSt6locale
+   fun:_ZN5boost2io6detail10distributeIcSt11char_traitsIcESaIcERKNS1_10put_holderIcS4_EEEEvRNS_12basic_formatIT_T0_T1_EET2_
+   fun:_ZN5boost2io6detail9feed_implIcSt11char_traitsIcESaIcERKNS1_10put_holderIcS4_EEEERNS_12basic_formatIT_T0_T1_EESF_T2_
+   fun:feed<char, std::char_traits<char>, std::allocator<char>, double const&>
+   fun:operator%<double>
+   fun:_ZN5RDKit14GetPDBAtomLineB5cxx11EPKNS_4AtomEPKNS_9ConformerERSt3mapIjjSt4lessIjESaISt4pairIKjjEEE
+   fun:_ZN5RDKit12MolToPDBBodyB5cxx11ERKNS_5ROMolEPKNS_9ConformerEjRjS6_S6_
+   fun:_ZN5RDKit13MolToPDBBlockB5cxx11ERKNS_5ROMolEij
+}
+{
+   uninitialised value used 10
+   Memcheck:Value8
+   fun:__mpn_mul_1
+   fun:__printf_fp
+   fun:vfprintf
+   fun:vsnprintf
+   fun:_ZSt16__convert_from_vRKP15__locale_structPciPKcz
+   fun:_ZNKSt7num_putIcSt19ostreambuf_iteratorIcSt11char_traitsIcEEE15_M_insert_floatIdEES3_S3_RSt8ios_baseccT_
+   fun:_ZNSo9_M_insertIdEERSoT_
+   fun:put_last<char, std::char_traits<char> >
+   fun:_ZN5boost2io6detail3putIcSt11char_traitsIcESaIcERKNS1_10put_holderIcS4_EEEEvT2_RKNS1_11format_itemIT_T0_T1_EERNS_12basic_formatISC_SD_SE_E11string_typeERNSJ_20internal_streambuf_tEPSt6locale
+   fun:_ZN5boost2io6detail10distributeIcSt11char_traitsIcESaIcERKNS1_10put_holderIcS4_EEEEvRNS_12basic_formatIT_T0_T1_EET2_
+   fun:_ZN5boost2io6detail9feed_implIcSt11char_traitsIcESaIcERKNS1_10put_holderIcS4_EEEERNS_12basic_formatIT_T0_T1_EESF_T2_
+   fun:feed<char, std::char_traits<char>, std::allocator<char>, double const&>
+   fun:operator%<double>
+   fun:_ZN5RDKit14GetPDBAtomLineB5cxx11EPKNS_4AtomEPKNS_9ConformerERSt3mapIjjSt4lessIjESaISt4pairIKjjEEE
+   fun:_ZN5RDKit12MolToPDBBodyB5cxx11ERKNS_5ROMolEPKNS_9ConformerEjRjS6_S6_
+   fun:_ZN5RDKit13MolToPDBBlockB5cxx11ERKNS_5ROMolEij
+}
+{
+   uninitialised value used 11
+   Memcheck:Value8
+   fun:__mpn_mul_1
    fun:hack_digit.13624
    fun:__printf_fp
    fun:vfprintf
    fun:vsnprintf
-   obj:*
+   fun:_ZSt16__convert_from_vRKP15__locale_structPciPKcz
+   fun:_ZNKSt7num_putIcSt19ostreambuf_iteratorIcSt11char_traitsIcEEE15_M_insert_floatIdEES3_S3_RSt8ios_baseccT_
+   fun:_ZNSo9_M_insertIdEERSoT_
+   fun:put_last<char, std::char_traits<char> >
+   fun:_ZN5boost2io6detail3putIcSt11char_traitsIcESaIcERKNS1_10put_holderIcS4_EEEEvT2_RKNS1_11format_itemIT_T0_T1_EERNS_12basic_formatISC_SD_SE_E11string_typeERNSJ_20internal_streambuf_tEPSt6locale
+   fun:_ZN5boost2io6detail10distributeIcSt11char_traitsIcESaIcERKNS1_10put_holderIcS4_EEEEvRNS_12basic_formatIT_T0_T1_EET2_
+   fun:_ZN5boost2io6detail9feed_implIcSt11char_traitsIcESaIcERKNS1_10put_holderIcS4_EEEERNS_12basic_formatIT_T0_T1_EESF_T2_
+   fun:feed<char, std::char_traits<char>, std::allocator<char>, double const&>
+   fun:operator%<double>
+   fun:_ZN5RDKit14GetPDBAtomLineB5cxx11EPKNS_4AtomEPKNS_9ConformerERSt3mapIjjSt4lessIjESaISt4pairIKjjEEE
+   fun:_ZN5RDKit12MolToPDBBodyB5cxx11ERKNS_5ROMolEPKNS_9ConformerEjRjS6_S6_
+   fun:_ZN5RDKit13MolToPDBBlockB5cxx11ERKNS_5ROMolEij
 }
 {
-   uninitialised value used in logic 10
-   Memcheck:Cond
-   fun:__mpn_divrem
-   fun:hack_digit.13624
+   uninitialised value used 12
+   Memcheck:Value8
+   fun:__mpn_rshift
    fun:__printf_fp
    fun:vfprintf
    fun:vsnprintf
-   obj:*
-}
-{
-   uninitialised value used in logic 15
-   Memcheck:Cond
-   fun:__mpn_extract_double
-   fun:__printf_fp
-   fun:vfprintf
-   fun:vsnprintf
-   obj:*
+   fun:_ZSt16__convert_from_vRKP15__locale_structPciPKcz
+   fun:_ZNKSt7num_putIcSt19ostreambuf_iteratorIcSt11char_traitsIcEEE15_M_insert_floatIdEES3_S3_RSt8ios_baseccT_
+   fun:_ZNSo9_M_insertIdEERSoT_
+   fun:put_last<char, std::char_traits<char> >
+   fun:_ZN5boost2io6detail3putIcSt11char_traitsIcESaIcERKNS1_10put_holderIcS4_EEEEvT2_RKNS1_11format_itemIT_T0_T1_EERNS_12basic_formatISC_SD_SE_E11string_typeERNSJ_20internal_streambuf_tEPSt6locale
+   fun:_ZN5boost2io6detail10distributeIcSt11char_traitsIcESaIcERKNS1_10put_holderIcS4_EEEEvRNS_12basic_formatIT_T0_T1_EET2_
+   fun:_ZN5boost2io6detail9feed_implIcSt11char_traitsIcESaIcERKNS1_10put_holderIcS4_EEEERNS_12basic_formatIT_T0_T1_EESF_T2_
+   fun:feed<char, std::char_traits<char>, std::allocator<char>, double const&>
+   fun:operator%<double>
+   fun:_ZN5RDKit14GetPDBAtomLineB5cxx11EPKNS_4AtomEPKNS_9ConformerERSt3mapIjjSt4lessIjESaISt4pairIKjjEEE
+   fun:_ZN5RDKit12MolToPDBBodyB5cxx11ERKNS_5ROMolEPKNS_9ConformerEjRjS6_S6_
+   fun:_ZN5RDKit13MolToPDBBlockB5cxx11ERKNS_5ROMolEij
 }
 {
    uninitialised value used 13
-   Memcheck:Value8
-   fun:__mpn_lshift
-   fun:__printf_fp
-   fun:vfprintf
-   fun:vsnprintf
-   obj:*
-}
-{
-   uninitialised value used in logic 16
-   Memcheck:Cond
-   fun:__mpn_lshift
-   fun:__printf_fp
-   fun:vfprintf
-   fun:vsnprintf
-   obj:*
-}
-{
-   uninitialised value used 16
-   Memcheck:Value8
-   fun:__mpn_mul
-   fun:__printf_fp
-   fun:vfprintf
-   fun:vsnprintf
-   obj:*
-}
-{
-   uninitialised value used in logic 18
-   Memcheck:Cond
-   fun:__mpn_mul
-   fun:__printf_fp
-   fun:vfprintf
-   fun:vsnprintf
-   obj:*
-}
-{
-   uninitialised value used 21
-   Memcheck:Value8
-   fun:__mpn_mul_1
-   fun:__mpn_mul
-   fun:__printf_fp
-   fun:vfprintf
-   fun:vsnprintf
-   obj:*
-}
-{
-   uninitialised value used in logic 23
-   Memcheck:Cond
-   fun:__mpn_mul_1
-   fun:__mpn_mul
-   fun:__printf_fp
-   fun:vfprintf
-   fun:vsnprintf
-   obj:*
-}
-{
-   uninitialised value used 24
-   Memcheck:Value8
-   fun:__mpn_mul_1
-   fun:__printf_fp
-   fun:vfprintf
-   fun:vsnprintf
-   obj:*
-}
-{
-   uninitialised value used in logic 25
-   Memcheck:Cond
-   fun:__mpn_mul_1
-   fun:__printf_fp
-   fun:vfprintf
-   fun:vsnprintf
-   obj:*
-}
-{
-   uninitialised value used 27
-   Memcheck:Value8
-   fun:__mpn_mul_1
-   fun:hack_digit.13624
-   fun:__printf_fp
-   fun:vfprintf
-   fun:vsnprintf
-   obj:*
-}
-{
-   uninitialised value used in logic 27
-   Memcheck:Cond
-   fun:__mpn_rshift
-   fun:__printf_fp
-   fun:vfprintf
-   fun:vsnprintf
-   obj:*
-}
-{
-   uninitialised value used 28
-   Memcheck:Value8
-   fun:__mpn_rshift
-   fun:__printf_fp
-   fun:vfprintf
-   fun:vsnprintf
-   obj:*
-}
-{
-   uninitialised value used 34
    Memcheck:Value8
    fun:__mpn_sub_n
    fun:__mpn_divrem
@@ -268,516 +3087,149 @@
    fun:__printf_fp
    fun:vfprintf
    fun:vsnprintf
-   obj:*
+   fun:_ZSt16__convert_from_vRKP15__locale_structPciPKcz
+   fun:_ZNKSt7num_putIcSt19ostreambuf_iteratorIcSt11char_traitsIcEEE15_M_insert_floatIdEES3_S3_RSt8ios_baseccT_
+   fun:_ZNSo9_M_insertIdEERSoT_
+   fun:put_last<char, std::char_traits<char> >
+   fun:_ZN5boost2io6detail3putIcSt11char_traitsIcESaIcERKNS1_10put_holderIcS4_EEEEvT2_RKNS1_11format_itemIT_T0_T1_EERNS_12basic_formatISC_SD_SE_E11string_typeERNSJ_20internal_streambuf_tEPSt6locale
+   fun:_ZN5boost2io6detail10distributeIcSt11char_traitsIcESaIcERKNS1_10put_holderIcS4_EEEEvRNS_12basic_formatIT_T0_T1_EET2_
+   fun:_ZN5boost2io6detail9feed_implIcSt11char_traitsIcESaIcERKNS1_10put_holderIcS4_EEEERNS_12basic_formatIT_T0_T1_EESF_T2_
+   fun:feed<char, std::char_traits<char>, std::allocator<char>, double const&>
+   fun:operator%<double>
+   fun:_ZN5RDKit14GetPDBAtomLineB5cxx11EPKNS_4AtomEPKNS_9ConformerERSt3mapIjjSt4lessIjESaISt4pairIKjjEEE
+   fun:_ZN5RDKit12MolToPDBBodyB5cxx11ERKNS_5ROMolEPKNS_9ConformerEjRjS6_S6_
+   fun:_ZN5RDKit13MolToPDBBlockB5cxx11ERKNS_5ROMolEij
 }
 {
-   uninitialised value used 36
-   Memcheck:Value8
-   fun:__mpn_submul_1
-   obj:*
-}
-{
-   uninitialised value used in logic 34
-   Memcheck:Cond
-   fun:__printf_fp
-   fun:vfprintf
-   fun:vsnprintf
-   obj:*
-}
-{
-   uninitialised value used 37
+   uninitialised value used 15
    Memcheck:Value8
    fun:__printf_fp
    fun:vfprintf
    fun:vsnprintf
-   obj:*
+   fun:_ZSt16__convert_from_vRKP15__locale_structPciPKcz
+   fun:_ZNKSt7num_putIcSt19ostreambuf_iteratorIcSt11char_traitsIcEEE15_M_insert_floatIdEES3_S3_RSt8ios_baseccT_
+   fun:_ZNSo9_M_insertIdEERSoT_
+   fun:put_last<char, std::char_traits<char> >
+   fun:_ZN5boost2io6detail3putIcSt11char_traitsIcESaIcERKNS1_10put_holderIcS4_EEEEvT2_RKNS1_11format_itemIT_T0_T1_EERNS_12basic_formatISC_SD_SE_E11string_typeERNSJ_20internal_streambuf_tEPSt6locale
+   fun:_ZN5boost2io6detail10distributeIcSt11char_traitsIcESaIcERKNS1_10put_holderIcS4_EEEEvRNS_12basic_formatIT_T0_T1_EET2_
+   fun:_ZN5boost2io6detail9feed_implIcSt11char_traitsIcESaIcERKNS1_10put_holderIcS4_EEEERNS_12basic_formatIT_T0_T1_EESF_T2_
+   fun:feed<char, std::char_traits<char>, std::allocator<char>, double const&>
+   fun:operator%<double>
+   fun:_ZN5RDKit14GetPDBAtomLineB5cxx11EPKNS_4AtomEPKNS_9ConformerERSt3mapIjjSt4lessIjESaISt4pairIKjjEEE
+   fun:_ZN5RDKit12MolToPDBBodyB5cxx11ERKNS_5ROMolEPKNS_9ConformerEjRjS6_S6_
+   fun:_ZN5RDKit13MolToPDBBlockB5cxx11ERKNS_5ROMolEij
 }
 {
-   invalid read of size 2
-   Memcheck:Addr1
-   fun:getFormalCharge
-   fun:_ZN5RDKit14StructureCheck23TransformAugmentedAtomsERNS_5RWMolERKSt6vectorISt4pairINS0_13AugmentedAtomES5_ESaIS6_EEb
-   fun:_ZNK5RDKit14StructureCheck13StructChecker17checkMolStructureERNS_5RWMolE
-}
-{
-   invalid read of size 3
-   Memcheck:Addr1
-   fun:getNumRadicalElectrons
-   fun:_ZN5RDKit14StructureCheck23TransformAugmentedAtomsERNS_5RWMolERKSt6vectorISt4pairINS0_13AugmentedAtomES5_ESaIS6_EEb
-   fun:_ZNK5RDKit14StructureCheck13StructChecker17checkMolStructureERNS_5RWMolE
-}
-{
-   uninitialised value used in logic 46
-   Memcheck:Cond
-   fun:hack_digit.13624
-   fun:__printf_fp
-   fun:vfprintf
-   fun:vsnprintf
-   obj:*
-}
-{
-   uninitialised value used 48
+   uninitialised value used 16
    Memcheck:Value8
    fun:hack_digit.13624
    fun:__printf_fp
    fun:vfprintf
    fun:vsnprintf
-   obj:*
+   fun:_ZSt16__convert_from_vRKP15__locale_structPciPKcz
+   fun:_ZNKSt7num_putIcSt19ostreambuf_iteratorIcSt11char_traitsIcEEE15_M_insert_floatIdEES3_S3_RSt8ios_baseccT_
+   fun:_ZNSo9_M_insertIdEERSoT_
+   fun:put_last<char, std::char_traits<char> >
+   fun:_ZN5boost2io6detail3putIcSt11char_traitsIcESaIcERKNS1_10put_holderIcS4_EEEEvT2_RKNS1_11format_itemIT_T0_T1_EERNS_12basic_formatISC_SD_SE_E11string_typeERNSJ_20internal_streambuf_tEPSt6locale
+   fun:_ZN5boost2io6detail10distributeIcSt11char_traitsIcESaIcERKNS1_10put_holderIcS4_EEEEvRNS_12basic_formatIT_T0_T1_EET2_
+   fun:_ZN5boost2io6detail9feed_implIcSt11char_traitsIcESaIcERKNS1_10put_holderIcS4_EEEERNS_12basic_formatIT_T0_T1_EESF_T2_
+   fun:feed<char, std::char_traits<char>, std::allocator<char>, double const&>
+   fun:operator%<double>
+   fun:_ZN5RDKit14GetPDBAtomLineB5cxx11EPKNS_4AtomEPKNS_9ConformerERSt3mapIjjSt4lessIjESaISt4pairIKjjEEE
+   fun:_ZN5RDKit12MolToPDBBodyB5cxx11ERKNS_5ROMolEPKNS_9ConformerEjRjS6_S6_
+   fun:_ZN5RDKit13MolToPDBBlockB5cxx11ERKNS_5ROMolEij
 }
 {
-   uninitialised value used in logic 49
-   Memcheck:Cond
-   fun:is_overlap
-   fun:__GI_memcpy
-   fun:__printf_fp
-   fun:vfprintf
-   fun:vsnprintf
-   obj:*
-}
-{
-   uninitialised value used in logic 50
-   Memcheck:Cond
-   fun:memchr
-   obj:*
-   obj:*
-   obj:*
-   obj:*
-   obj:*
-   obj:*
-   obj:*
-   obj:*
-   obj:*
-   obj:*
-   obj:*
-   obj:*
-   obj:*
-   obj:*
-   obj:*
-   obj:*
-   obj:*
-}
-{
-   uninitialised value used in logic 51
-   Memcheck:Cond
-   fun:memset
-   fun:__mpn_mul
-   fun:__printf_fp
-   fun:vfprintf
-   fun:vsnprintf
-   obj:*
-}
-{
-   uninitialised value used 50
+   uninitialised value used 17
    Memcheck:Value8
    fun:memset
    fun:__mpn_mul
    fun:__printf_fp
    fun:vfprintf
    fun:vsnprintf
-   obj:*
+   fun:_ZSt16__convert_from_vRKP15__locale_structPciPKcz
+   fun:_ZNKSt7num_putIcSt19ostreambuf_iteratorIcSt11char_traitsIcEEE15_M_insert_floatIdEES3_S3_RSt8ios_baseccT_
+   fun:_ZNSo9_M_insertIdEERSoT_
+   fun:put_last<char, std::char_traits<char> >
+   fun:_ZN5boost2io6detail3putIcSt11char_traitsIcESaIcERKNS1_10put_holderIcS4_EEEEvT2_RKNS1_11format_itemIT_T0_T1_EERNS_12basic_formatISC_SD_SE_E11string_typeERNSJ_20internal_streambuf_tEPSt6locale
+   fun:_ZN5boost2io6detail10distributeIcSt11char_traitsIcESaIcERKNS1_10put_holderIcS4_EEEEvRNS_12basic_formatIT_T0_T1_EET2_
+   fun:_ZN5boost2io6detail9feed_implIcSt11char_traitsIcESaIcERKNS1_10put_holderIcS4_EEEERNS_12basic_formatIT_T0_T1_EESF_T2_
+   fun:feed<char, std::char_traits<char>, std::allocator<char>, double const&>
+   fun:operator%<double>
+   fun:_ZN5RDKit14GetPDBAtomLineB5cxx11EPKNS_4AtomEPKNS_9ConformerERSt3mapIjjSt4lessIjESaISt4pairIKjjEEE
+   fun:_ZN5RDKit12MolToPDBBodyB5cxx11ERKNS_5ROMolEPKNS_9ConformerEjRjS6_S6_
+   fun:_ZN5RDKit13MolToPDBBlockB5cxx11ERKNS_5ROMolEij
 }
 {
-   uninitialised value used in logic 55
-   Memcheck:Cond
-   fun:memset
-   fun:__printf_fp
-   fun:vfprintf
-   fun:vsnprintf
-   obj:*
-}
-{
-   uninitialised value used 53
+   uninitialised value used 18
    Memcheck:Value8
    fun:memset
    fun:__printf_fp
    fun:vfprintf
    fun:vsnprintf
-   obj:*
+   fun:_ZSt16__convert_from_vRKP15__locale_structPciPKcz
+   fun:_ZNKSt7num_putIcSt19ostreambuf_iteratorIcSt11char_traitsIcEEE15_M_insert_floatIdEES3_S3_RSt8ios_baseccT_
+   fun:_ZNSo9_M_insertIdEERSoT_
+   fun:put_last<char, std::char_traits<char> >
+   fun:_ZN5boost2io6detail3putIcSt11char_traitsIcESaIcERKNS1_10put_holderIcS4_EEEEvT2_RKNS1_11format_itemIT_T0_T1_EERNS_12basic_formatISC_SD_SE_E11string_typeERNSJ_20internal_streambuf_tEPSt6locale
+   fun:_ZN5boost2io6detail10distributeIcSt11char_traitsIcESaIcERKNS1_10put_holderIcS4_EEEEvRNS_12basic_formatIT_T0_T1_EET2_
+   fun:_ZN5boost2io6detail9feed_implIcSt11char_traitsIcESaIcERKNS1_10put_holderIcS4_EEEERNS_12basic_formatIT_T0_T1_EESF_T2_
+   fun:feed<char, std::char_traits<char>, std::allocator<char>, double const&>
+   fun:operator%<double>
+   fun:_ZN5RDKit14GetPDBAtomLineB5cxx11EPKNS_4AtomEPKNS_9ConformerERSt3mapIjjSt4lessIjESaISt4pairIKjjEEE
+   fun:_ZN5RDKit12MolToPDBBodyB5cxx11ERKNS_5ROMolEPKNS_9ConformerEjRjS6_S6_
+   fun:_ZN5RDKit13MolToPDBBlockB5cxx11ERKNS_5ROMolEij
 }
 {
-   invalid read of size 23
-   Memcheck:Addr8
-   fun:size
-   fun:vertex_set
-   fun:num_vertices<boost::detail::adj_list_gen<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*, boost::no_property, boost::listS>::config, boost::undirected_graph_helper<boost::detail::adj_list_gen<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*, boost::no_property, boost::listS>::config> >
-   fun:_ZNK5RDKit5ROMol11getNumAtomsEb
-   fun:_ZN5RDKit11MolToSmartsB5cxx11ERNS_5ROMolEb
-}
-{
-   uninitialised value used in logic 58
-   Memcheck:Cond
-   fun:vfprintf
-   fun:printf
-}
-{
-   memory definitely lost
-   Memcheck:Leak
-   match-leak-kinds: definite
-   fun:calloc
-   fun:_renumberTest2
-}
-{
-   memory definitely lost 0
-   Memcheck:Leak
-   match-leak-kinds: definite
-   fun:malloc
-}
-{
-   memory indirectly lost
-   Memcheck:Leak
-   match-leak-kinds: indirect
-   fun:malloc
-   fun:_Z17yysln__scan_bytesPKcmPv
-   fun:_Z16setup_sln_stringRKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEPv
-   fun:_Z9sln_parseRKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEbRSt6vectorIPN5RDKit5RWMolESaISA_EE
-   fun:_ZN5RDKit8SLNParse5toMolENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEbi
-   fun:_ZN5RDKit8SLNToMolERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEbi
-}
-{
-   memory indirectly lost 0
-   Memcheck:Leak
-   match-leak-kinds: indirect
-   fun:malloc
-   fun:_Z18yysln__scan_bufferPcmPv
-   fun:_Z17yysln__scan_bytesPKcmPv
-   fun:_Z16setup_sln_stringRKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEPv
-   fun:_Z9sln_parseRKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEbRSt6vectorIPN5RDKit5RWMolESaISA_EE
-   fun:_ZN5RDKit8SLNParse5toMolENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEbi
-   fun:_ZN5RDKit8SLNToMolERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEbi
-}
-{
-   memory indirectly lost 1
-   Memcheck:Leak
-   match-leak-kinds: indirect
-   fun:malloc
-   fun:_ZL13yy_push_stateiPv
-   fun:_Z9yysln_lexP7YYSTYPEPv
-   fun:_Z11yysln_parsePKcPSt6vectorIPN5RDKit5RWMolESaIS4_EEbPv
-   fun:_Z9sln_parseRKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEbRSt6vectorIPN5RDKit5RWMolESaISA_EE
-   fun:_ZN5RDKit8SLNParse5toMolENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEbi
-   fun:_ZN5RDKit8SLNToMolERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEbi
-}
-{
-   memory indirectly lost 2
-   Memcheck:Leak
-   match-leak-kinds: indirect
-   fun:malloc
-   fun:_ZL25yysln_ensure_buffer_stackPv
-   fun:_Z23yysln__switch_to_bufferP15yy_buffer_statePv
-   fun:_Z18yysln__scan_bufferPcmPv
-   fun:_Z17yysln__scan_bytesPKcmPv
-   fun:_Z16setup_sln_stringRKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEPv
-   fun:_Z9sln_parseRKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEbRSt6vectorIPN5RDKit5RWMolESaISA_EE
-   fun:_ZN5RDKit8SLNParse5toMolENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEbi
-   fun:_ZN5RDKit8SLNToMolERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEbi
-}
-{
-   memory indirectly lost 3
-   Memcheck:Leak
-   match-leak-kinds: indirect
-   fun:malloc
-   obj:*
-}
-{
-   memory possibly lost
+   memory possibly lost 2
    Memcheck:Leak
    match-leak-kinds: possible
-   fun:malloc
-   fun:_Z3hs1RKSt6vectorIS_IiSaIiEESaIS1_EE
+   fun:_Znwm
+   fun:RDValue
+   fun:_ZN5RDKit4Dict6setValISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS8_EEEEvRKS8_RT_
+   fun:_ZNK5RDKit7RDProps7setPropIiEEvRKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEET_b
+   fun:_ZN5RDKit6MolOps12_GLOBAL__N_117aromaticityHelperERNS_5RWMolERKSt6vectorIS4_IiSaIiEESaIS6_EEjjb
+   fun:_ZN5RDKit6MolOps14setAromaticityERNS_5RWMolENS0_16AromaticityModelEPFiS2_E
+   fun:_ZN5RDKit6MolOps11sanitizeMolERNS_5RWMolERjj
+   fun:_ZN5RDKit6MolOps11sanitizeMolERNS_5RWMolE
+   fun:_ZN5RDKit6MolOps8removeHsERNS_5RWMolEbbb
+   fun:_ZN5RDKit6MolOps8removeHsERKNS_5ROMolEbbb
 }
 {
-   memory possibly lost 0
+   memory possibly lost 55
    Memcheck:Leak
    match-leak-kinds: possible
-   fun:malloc
-   obj:*
+   fun:_Znwm
+   fun:allocate
+   fun:allocate
+   fun:_M_allocate
+   fun:_M_create_storage
+   fun:_Vector_base
+   fun:vector
+   fun:RDValue
+   fun:_ZN5RDKit4Dict6setValISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS8_EEEEvRKS8_RT_
+   fun:_ZNK5RDKit7RDProps7setPropIiEEvRKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEET_b
+   fun:_ZN5RDKit6MolOps12_GLOBAL__N_117aromaticityHelperERNS_5RWMolERKSt6vectorIS4_IiSaIiEESaIS6_EEjjb
+   fun:_ZN5RDKit6MolOps14setAromaticityERNS_5RWMolENS0_16AromaticityModelEPFiS2_E
+   fun:_ZN5RDKit6MolOps11sanitizeMolERNS_5RWMolERjj
+   fun:_ZN5RDKit6MolOps11sanitizeMolERNS_5RWMolE
+   fun:_ZN5RDKit6MolOps8removeHsERNS_5RWMolEbbb
+   fun:_ZN5RDKit6MolOps8removeHsERKNS_5ROMolEbbb
 }
 {
-   syscall param write(buf) points to uninitialised byte(s)
-   Memcheck:Param
-   write(buf)
-   fun:__write_nocancel
-   fun:_IO_file_write
-   fun:_IO_do_write
-   fun:_IO_file_xsputn
-   fun:vfprintf
-   fun:printf
-}
-{
-   syscall param write(buf) points to uninitialised byte(s) 0
-   Memcheck:Param
-   write(buf)
-   fun:__write_nocancel
-   fun:_IO_file_write
-   fun:_IO_file_xsputn
-   fun:vfprintf
-   fun:printf
-}
-{
-   invalid read of size 1
-   Memcheck:Addr1
-   fun:_ZN5boost14char_separatorIcSt11char_traitsIcEEclIN9__gnu_cxx17__normal_iteratorIPKcNSt7__cxx1112basic_stringIcS2_SaIcEEEEESC_EEbRT_SE_RT0_
-   fun:initialize
-   fun:token_iterator
-   fun:begin
-}
-{
-   invalid read of size 5
-   Memcheck:Addr2
-   fun:memcpy
-   fun:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE10_M_replaceEmmPKcm
-   fun:replace
-   fun:replace
-   fun:assign<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> > >
-   fun:assign<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> >
-   fun:_ZN5boost14char_separatorIcSt11char_traitsIcEEclIN9__gnu_cxx17__normal_iteratorIPKcNSt7__cxx1112basic_stringIcS2_SaIcEEEEESC_EEbRT_SE_RT0_
-   fun:initialize
-   fun:token_iterator
-   fun:begin
-}
-{
-   invalid read of size 6
-   Memcheck:Addr1
-   fun:memcpy
-   fun:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE10_M_replaceEmmPKcm
-   fun:replace
-   fun:replace
-   fun:assign<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> > >
-   fun:assign<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> >
-   fun:_ZN5boost14char_separatorIcSt11char_traitsIcEEclIN9__gnu_cxx17__normal_iteratorIPKcNSt7__cxx1112basic_stringIcS2_SaIcEEEEESC_EEbRT_SE_RT0_
-   fun:initialize
-   fun:token_iterator
-   fun:begin
-}
-{
-   invalid read of size 7
-   Memcheck:Addr2
-   fun:memcpy
-   fun:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE10_M_replaceEmmPKcm
-   fun:replace
-   fun:replace
-   fun:assign<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> > >
-   fun:assign<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> >
-   fun:operator()<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> >
-   fun:increment
-   fun:increment<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
-   fun:operator++
-   fun:__distance<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
-   fun:distance<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
-   fun:_M_range_initialize<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
-   fun:_M_initialize_dispatch<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
-   fun:vector<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
-}
-{
-   invalid read of size 8
-   Memcheck:Addr1
-   fun:memcpy
-   fun:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE10_M_replaceEmmPKcm
-   fun:replace
-   fun:replace
-   fun:assign<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> > >
-   fun:assign<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> >
-   fun:operator()<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> >
-   fun:increment
-   fun:increment<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
-   fun:operator++
-   fun:__distance<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
-   fun:distance<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
-   fun:_M_range_initialize<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
-   fun:_M_initialize_dispatch<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
-   fun:vector<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
-}
-{
-   invalid read of size 10
-   Memcheck:Addr2
-   fun:memcpy
-   fun:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE10_M_replaceEmmPKcm
-   fun:replace
-   fun:replace
-   fun:assign<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> > >
-   fun:assign<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> >
-   fun:operator()<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> >
-   fun:increment
-   fun:increment<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
-   fun:operator++
-   fun:__uninit_copy<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char>*>
-   fun:uninitialized_copy<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char>*>
-   fun:__uninitialized_copy_a<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char>*, std::__cxx11::basic_string<char> >
-   fun:_M_range_initialize<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
-   fun:_M_initialize_dispatch<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
-   fun:vector<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
-}
-{
-   invalid read of size 11
-   Memcheck:Addr1
-   fun:memcpy
-   fun:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE10_M_replaceEmmPKcm
-   fun:replace
-   fun:replace
-   fun:assign<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> > >
-   fun:assign<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> >
-   fun:operator()<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> >
-   fun:increment
-   fun:increment<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
-   fun:operator++
-   fun:__uninit_copy<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char>*>
-   fun:uninitialized_copy<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char>*>
-   fun:__uninitialized_copy_a<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char>*, std::__cxx11::basic_string<char> >
-   fun:_M_range_initialize<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
-   fun:_M_initialize_dispatch<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
-   fun:vector<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
-}
-{
-   invalid read of size 21
-   Memcheck:Addr1
-   fun:operator()<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> >
-   fun:increment
-   fun:increment<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
-   fun:operator++
-   fun:__distance<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
-   fun:distance<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
-   fun:_M_range_initialize<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
-   fun:_M_initialize_dispatch<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
-   fun:vector<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
-}
-{
-   invalid read of size 22
-   Memcheck:Addr1
-   fun:operator()<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> >
-   fun:increment
-   fun:increment<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
-   fun:operator++
-   fun:__uninit_copy<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char>*>
-   fun:uninitialized_copy<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char>*>
-   fun:__uninitialized_copy_a<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char>*, std::__cxx11::basic_string<char> >
-   fun:_M_range_initialize<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
-   fun:_M_initialize_dispatch<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
-   fun:vector<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
-}
-{
-   invalid read of size 13
-   Memcheck:Addr2
-   fun:memcpy@GLIBC_2.2.5
-   fun:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE10_M_replaceEmmPKcm
-   fun:replace
-   fun:replace
-   fun:assign<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> > >
-   fun:assign<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> >
-   fun:_ZN5boost14char_separatorIcSt11char_traitsIcEEclIN9__gnu_cxx17__normal_iteratorIPKcNSt7__cxx1112basic_stringIcS2_SaIcEEEEESC_EEbRT_SE_RT0_
-   fun:initialize
-   fun:token_iterator
-   fun:begin
-}
-{
-   invalid read of size 14
-   Memcheck:Addr1
-   fun:memcpy@GLIBC_2.2.5
-   fun:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE10_M_replaceEmmPKcm
-   fun:replace
-   fun:replace
-   fun:assign<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> > >
-   fun:assign<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> >
-   fun:_ZN5boost14char_separatorIcSt11char_traitsIcEEclIN9__gnu_cxx17__normal_iteratorIPKcNSt7__cxx1112basic_stringIcS2_SaIcEEEEESC_EEbRT_SE_RT0_
-   fun:initialize
-   fun:token_iterator
-   fun:begin
-}
-{
-   invalid read of size 15
-   Memcheck:Addr2
-   fun:memcpy@GLIBC_2.2.5
-   fun:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE10_M_replaceEmmPKcm
-   fun:replace
-   fun:replace
-   fun:assign<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> > >
-   fun:assign<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> >
-   fun:operator()<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> >
-   fun:increment
-   fun:increment<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
-   fun:operator++
-   fun:__distance<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
-   fun:distance<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
-   fun:_M_range_initialize<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
-   fun:_M_initialize_dispatch<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
-   fun:vector<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
-}
-{
-   invalid read of size 16
-   Memcheck:Addr1
-   fun:memcpy@GLIBC_2.2.5
-   fun:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE10_M_replaceEmmPKcm
-   fun:replace
-   fun:replace
-   fun:assign<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> > >
-   fun:assign<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> >
-   fun:operator()<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> >
-   fun:increment
-   fun:increment<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
-   fun:operator++
-   fun:__distance<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
-   fun:distance<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
-   fun:_M_range_initialize<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
-   fun:_M_initialize_dispatch<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
-   fun:vector<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
-}
-{
-   invalid read of size 18
-   Memcheck:Addr2
-   fun:memcpy@GLIBC_2.2.5
-   fun:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE10_M_replaceEmmPKcm
-   fun:replace
-   fun:replace
-   fun:assign<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> > >
-   fun:assign<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> >
-   fun:operator()<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> >
-   fun:increment
-   fun:increment<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
-   fun:operator++
-   fun:__uninit_copy<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char>*>
-   fun:uninitialized_copy<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char>*>
-   fun:__uninitialized_copy_a<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char>*, std::__cxx11::basic_string<char> >
-   fun:_M_range_initialize<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
-   fun:_M_initialize_dispatch<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
-   fun:vector<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
-}
-{
-   invalid read of size 19
-   Memcheck:Addr1
-   fun:memcpy@GLIBC_2.2.5
-   fun:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE10_M_replaceEmmPKcm
-   fun:replace
-   fun:replace
-   fun:assign<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> > >
-   fun:assign<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> >
-   fun:operator()<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> >
-   fun:increment
-   fun:increment<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
-   fun:operator++
-   fun:__uninit_copy<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char>*>
-   fun:uninitialized_copy<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char>*>
-   fun:__uninitialized_copy_a<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char>*, std::__cxx11::basic_string<char> >
-   fun:_M_range_initialize<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
-   fun:_M_initialize_dispatch<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
-   fun:vector<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
-}
-{
-   syscall param write(buf) points to uninitialised byte(s) 1
-   Memcheck:Param
-   write(buf)
-   fun:__write_nocancel
-   fun:_IO_file_write@@GLIBC_2.2.5
-   fun:_IO_do_write@@GLIBC_2.2.5
-   fun:_IO_file_xsputn@@GLIBC_2.2.5
-   fun:vfprintf
-   fun:printf
-}
-{
-   syscall param write(buf) points to uninitialised byte(s) 2
-   Memcheck:Param
-   write(buf)
-   fun:__write_nocancel
-   fun:_IO_file_write@@GLIBC_2.2.5
-   fun:_IO_file_xsputn@@GLIBC_2.2.5
-   fun:vfprintf
-   fun:printf
+   memory possibly lost 72
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:allocate
+   fun:allocate
+   fun:_M_allocate
+   fun:_M_create_storage
+   fun:_Vector_base
+   fun:vector
+   fun:operator=
+   fun:_ZN5RDKit5ROMol13initFromOtherERKS0_bi
+   fun:ROMol
+   fun:RWMol
+   fun:_ZN5RDKit6MolOps8removeHsERKNS_5ROMolEbbb
 }

--- a/rdkit_valgrind.suppressions
+++ b/rdkit_valgrind.suppressions
@@ -1,0 +1,783 @@
+{
+   uninitialised value used in logic
+   Memcheck:Cond
+   fun:_IO_default_xsputn
+   fun:__printf_fp
+   fun:vfprintf
+   fun:vsnprintf
+   obj:*
+}
+{
+   invalid read of size 4
+   Memcheck:Addr4
+   fun:_ZN5RDKit19addRecursiveQueriesERNS_5ROMolERKSt3mapINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEN5boost10shared_ptrIS0_EESt4lessIS8_ESaISt4pairIKS8_SB_EEERSF_PSt6vectorISE_IjS8_ESaISN_EE
+}
+{
+   uninitialised value used in logic 0
+   Memcheck:Cond
+   fun:_ZN5RDKit5Canon16RefinePartitionsI19atomcomparefunctor3EEvRKNS_5ROMolEPNS0_10canon_atomET_iPiS9_RiS9_S9_Pc
+}
+{
+   uninitialised value used in logic 1
+   Memcheck:Cond
+   fun:_ZN5RDKit5Canon9BreakTiesI19atomcomparefunctor3EEvRKNS_5ROMolEPNS0_10canon_atomET_iPiS9_RiS9_S9_Pc
+}
+{
+   uninitialised value used in logic 2
+   Memcheck:Cond
+   fun:__GI_memcpy
+   fun:__printf_fp
+   fun:vfprintf
+   fun:vsnprintf
+   obj:*
+}
+{
+   uninitialised value used
+   Memcheck:Value8
+   fun:__GI_memcpy
+   fun:__printf_fp
+   fun:vfprintf
+   fun:vsnprintf
+   obj:*
+}
+{
+   uninitialised value used 1
+   Memcheck:Value8
+   fun:__mpn_add_n
+   fun:__mpn_mul
+   fun:__printf_fp
+   fun:vfprintf
+   fun:vsnprintf
+   obj:*
+}
+{
+   uninitialised value used 2
+   Memcheck:Value8
+   fun:__mpn_addmul_1
+   obj:*
+   fun:__printf_fp
+   fun:vfprintf
+   fun:vsnprintf
+   obj:*
+}
+{
+   uninitialised value used in logic 5
+   Memcheck:Cond
+   fun:__mpn_addmul_1
+   obj:*
+   fun:__printf_fp
+   fun:vfprintf
+   fun:vsnprintf
+   obj:*
+}
+{
+   uninitialised value used in logic 7
+   Memcheck:Cond
+   fun:__mpn_addmul_1
+   obj:*
+   obj:*
+   fun:__mpn_mul
+   obj:*
+   obj:*
+   obj:*
+   fun:deallocate
+   fun:deallocate
+   fun:_M_deallocate
+   fun:~_Vector_base
+   fun:~vector
+   fun:~dynamic_bitset
+   fun:_ZN5RDKit5Canon13dfsBuildStackERNS_5ROMolEiiRSt6vectorINS0_10AtomColorsESaIS4_EERS3_IS3_IiSaIiEESaIS9_EERKS3_IjSaIjEERS9_RS3_INS0_12MolStackElemESaISI_EESH_SH_SC_RS3_INSt7__cxx114listIiS8_EESaISO_EEPKN5boost14dynamic_bitsetImSaImEEEPKS3_INSM_12basic_stringIcSt11char_traitsIcESaIcEEESaIS12_EE
+   obj:*
+   obj:*
+}
+{
+   uninitialised value used 5
+   Memcheck:Value8
+   fun:__mpn_addmul_1
+   obj:*
+   obj:*
+   fun:__mpn_mul
+   obj:*
+   obj:*
+   obj:*
+   fun:deallocate
+   fun:deallocate
+   fun:_M_deallocate
+   fun:~_Vector_base
+   fun:~vector
+   fun:~dynamic_bitset
+   fun:_ZN5RDKit5Canon13dfsBuildStackERNS_5ROMolEiiRSt6vectorINS0_10AtomColorsESaIS4_EERS3_IS3_IiSaIiEESaIS9_EERKS3_IjSaIjEERS9_RS3_INS0_12MolStackElemESaISI_EESH_SH_SC_RS3_INSt7__cxx114listIiS8_EESaISO_EEPKN5boost14dynamic_bitsetImSaImEEEPKS3_INSM_12basic_stringIcSt11char_traitsIcESaIcEEESaIS12_EE
+   obj:*
+   obj:*
+}
+{
+   uninitialised value used 7
+   Memcheck:Value8
+   fun:__mpn_cmp
+   fun:__printf_fp
+   fun:vfprintf
+   fun:vsnprintf
+   obj:*
+}
+{
+   uninitialised value used in logic 9
+   Memcheck:Cond
+   fun:__mpn_cmp
+   fun:__printf_fp
+   fun:vfprintf
+   fun:vsnprintf
+   obj:*
+}
+{
+   uninitialised value used 8
+   Memcheck:Value8
+   fun:__mpn_divrem
+   fun:hack_digit.13624
+   fun:__printf_fp
+   fun:vfprintf
+   fun:vsnprintf
+   obj:*
+}
+{
+   uninitialised value used in logic 10
+   Memcheck:Cond
+   fun:__mpn_divrem
+   fun:hack_digit.13624
+   fun:__printf_fp
+   fun:vfprintf
+   fun:vsnprintf
+   obj:*
+}
+{
+   uninitialised value used in logic 15
+   Memcheck:Cond
+   fun:__mpn_extract_double
+   fun:__printf_fp
+   fun:vfprintf
+   fun:vsnprintf
+   obj:*
+}
+{
+   uninitialised value used 13
+   Memcheck:Value8
+   fun:__mpn_lshift
+   fun:__printf_fp
+   fun:vfprintf
+   fun:vsnprintf
+   obj:*
+}
+{
+   uninitialised value used in logic 16
+   Memcheck:Cond
+   fun:__mpn_lshift
+   fun:__printf_fp
+   fun:vfprintf
+   fun:vsnprintf
+   obj:*
+}
+{
+   uninitialised value used 16
+   Memcheck:Value8
+   fun:__mpn_mul
+   fun:__printf_fp
+   fun:vfprintf
+   fun:vsnprintf
+   obj:*
+}
+{
+   uninitialised value used in logic 18
+   Memcheck:Cond
+   fun:__mpn_mul
+   fun:__printf_fp
+   fun:vfprintf
+   fun:vsnprintf
+   obj:*
+}
+{
+   uninitialised value used 21
+   Memcheck:Value8
+   fun:__mpn_mul_1
+   fun:__mpn_mul
+   fun:__printf_fp
+   fun:vfprintf
+   fun:vsnprintf
+   obj:*
+}
+{
+   uninitialised value used in logic 23
+   Memcheck:Cond
+   fun:__mpn_mul_1
+   fun:__mpn_mul
+   fun:__printf_fp
+   fun:vfprintf
+   fun:vsnprintf
+   obj:*
+}
+{
+   uninitialised value used 24
+   Memcheck:Value8
+   fun:__mpn_mul_1
+   fun:__printf_fp
+   fun:vfprintf
+   fun:vsnprintf
+   obj:*
+}
+{
+   uninitialised value used in logic 25
+   Memcheck:Cond
+   fun:__mpn_mul_1
+   fun:__printf_fp
+   fun:vfprintf
+   fun:vsnprintf
+   obj:*
+}
+{
+   uninitialised value used 27
+   Memcheck:Value8
+   fun:__mpn_mul_1
+   fun:hack_digit.13624
+   fun:__printf_fp
+   fun:vfprintf
+   fun:vsnprintf
+   obj:*
+}
+{
+   uninitialised value used in logic 27
+   Memcheck:Cond
+   fun:__mpn_rshift
+   fun:__printf_fp
+   fun:vfprintf
+   fun:vsnprintf
+   obj:*
+}
+{
+   uninitialised value used 28
+   Memcheck:Value8
+   fun:__mpn_rshift
+   fun:__printf_fp
+   fun:vfprintf
+   fun:vsnprintf
+   obj:*
+}
+{
+   uninitialised value used 34
+   Memcheck:Value8
+   fun:__mpn_sub_n
+   fun:__mpn_divrem
+   fun:hack_digit.13624
+   fun:__printf_fp
+   fun:vfprintf
+   fun:vsnprintf
+   obj:*
+}
+{
+   uninitialised value used 36
+   Memcheck:Value8
+   fun:__mpn_submul_1
+   obj:*
+}
+{
+   uninitialised value used in logic 34
+   Memcheck:Cond
+   fun:__printf_fp
+   fun:vfprintf
+   fun:vsnprintf
+   obj:*
+}
+{
+   uninitialised value used 37
+   Memcheck:Value8
+   fun:__printf_fp
+   fun:vfprintf
+   fun:vsnprintf
+   obj:*
+}
+{
+   invalid read of size 2
+   Memcheck:Addr1
+   fun:getFormalCharge
+   fun:_ZN5RDKit14StructureCheck23TransformAugmentedAtomsERNS_5RWMolERKSt6vectorISt4pairINS0_13AugmentedAtomES5_ESaIS6_EEb
+   fun:_ZNK5RDKit14StructureCheck13StructChecker17checkMolStructureERNS_5RWMolE
+}
+{
+   invalid read of size 3
+   Memcheck:Addr1
+   fun:getNumRadicalElectrons
+   fun:_ZN5RDKit14StructureCheck23TransformAugmentedAtomsERNS_5RWMolERKSt6vectorISt4pairINS0_13AugmentedAtomES5_ESaIS6_EEb
+   fun:_ZNK5RDKit14StructureCheck13StructChecker17checkMolStructureERNS_5RWMolE
+}
+{
+   uninitialised value used in logic 46
+   Memcheck:Cond
+   fun:hack_digit.13624
+   fun:__printf_fp
+   fun:vfprintf
+   fun:vsnprintf
+   obj:*
+}
+{
+   uninitialised value used 48
+   Memcheck:Value8
+   fun:hack_digit.13624
+   fun:__printf_fp
+   fun:vfprintf
+   fun:vsnprintf
+   obj:*
+}
+{
+   uninitialised value used in logic 49
+   Memcheck:Cond
+   fun:is_overlap
+   fun:__GI_memcpy
+   fun:__printf_fp
+   fun:vfprintf
+   fun:vsnprintf
+   obj:*
+}
+{
+   uninitialised value used in logic 50
+   Memcheck:Cond
+   fun:memchr
+   obj:*
+   obj:*
+   obj:*
+   obj:*
+   obj:*
+   obj:*
+   obj:*
+   obj:*
+   obj:*
+   obj:*
+   obj:*
+   obj:*
+   obj:*
+   obj:*
+   obj:*
+   obj:*
+   obj:*
+}
+{
+   uninitialised value used in logic 51
+   Memcheck:Cond
+   fun:memset
+   fun:__mpn_mul
+   fun:__printf_fp
+   fun:vfprintf
+   fun:vsnprintf
+   obj:*
+}
+{
+   uninitialised value used 50
+   Memcheck:Value8
+   fun:memset
+   fun:__mpn_mul
+   fun:__printf_fp
+   fun:vfprintf
+   fun:vsnprintf
+   obj:*
+}
+{
+   uninitialised value used in logic 55
+   Memcheck:Cond
+   fun:memset
+   fun:__printf_fp
+   fun:vfprintf
+   fun:vsnprintf
+   obj:*
+}
+{
+   uninitialised value used 53
+   Memcheck:Value8
+   fun:memset
+   fun:__printf_fp
+   fun:vfprintf
+   fun:vsnprintf
+   obj:*
+}
+{
+   invalid read of size 23
+   Memcheck:Addr8
+   fun:size
+   fun:vertex_set
+   fun:num_vertices<boost::detail::adj_list_gen<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*, boost::no_property, boost::listS>::config, boost::undirected_graph_helper<boost::detail::adj_list_gen<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*>, boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*, boost::no_property, boost::listS>::config> >
+   fun:_ZNK5RDKit5ROMol11getNumAtomsEb
+   fun:_ZN5RDKit11MolToSmartsB5cxx11ERNS_5ROMolEb
+}
+{
+   uninitialised value used in logic 58
+   Memcheck:Cond
+   fun:vfprintf
+   fun:printf
+}
+{
+   memory definitely lost
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:calloc
+   fun:_renumberTest2
+}
+{
+   memory definitely lost 0
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:malloc
+}
+{
+   memory indirectly lost
+   Memcheck:Leak
+   match-leak-kinds: indirect
+   fun:malloc
+   fun:_Z17yysln__scan_bytesPKcmPv
+   fun:_Z16setup_sln_stringRKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEPv
+   fun:_Z9sln_parseRKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEbRSt6vectorIPN5RDKit5RWMolESaISA_EE
+   fun:_ZN5RDKit8SLNParse5toMolENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEbi
+   fun:_ZN5RDKit8SLNToMolERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEbi
+}
+{
+   memory indirectly lost 0
+   Memcheck:Leak
+   match-leak-kinds: indirect
+   fun:malloc
+   fun:_Z18yysln__scan_bufferPcmPv
+   fun:_Z17yysln__scan_bytesPKcmPv
+   fun:_Z16setup_sln_stringRKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEPv
+   fun:_Z9sln_parseRKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEbRSt6vectorIPN5RDKit5RWMolESaISA_EE
+   fun:_ZN5RDKit8SLNParse5toMolENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEbi
+   fun:_ZN5RDKit8SLNToMolERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEbi
+}
+{
+   memory indirectly lost 1
+   Memcheck:Leak
+   match-leak-kinds: indirect
+   fun:malloc
+   fun:_ZL13yy_push_stateiPv
+   fun:_Z9yysln_lexP7YYSTYPEPv
+   fun:_Z11yysln_parsePKcPSt6vectorIPN5RDKit5RWMolESaIS4_EEbPv
+   fun:_Z9sln_parseRKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEbRSt6vectorIPN5RDKit5RWMolESaISA_EE
+   fun:_ZN5RDKit8SLNParse5toMolENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEbi
+   fun:_ZN5RDKit8SLNToMolERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEbi
+}
+{
+   memory indirectly lost 2
+   Memcheck:Leak
+   match-leak-kinds: indirect
+   fun:malloc
+   fun:_ZL25yysln_ensure_buffer_stackPv
+   fun:_Z23yysln__switch_to_bufferP15yy_buffer_statePv
+   fun:_Z18yysln__scan_bufferPcmPv
+   fun:_Z17yysln__scan_bytesPKcmPv
+   fun:_Z16setup_sln_stringRKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEPv
+   fun:_Z9sln_parseRKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEbRSt6vectorIPN5RDKit5RWMolESaISA_EE
+   fun:_ZN5RDKit8SLNParse5toMolENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEbi
+   fun:_ZN5RDKit8SLNToMolERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEbi
+}
+{
+   memory indirectly lost 3
+   Memcheck:Leak
+   match-leak-kinds: indirect
+   fun:malloc
+   obj:*
+}
+{
+   memory possibly lost
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_Z3hs1RKSt6vectorIS_IiSaIiEESaIS1_EE
+}
+{
+   memory possibly lost 0
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   obj:*
+}
+{
+   syscall param write(buf) points to uninitialised byte(s)
+   Memcheck:Param
+   write(buf)
+   fun:__write_nocancel
+   fun:_IO_file_write
+   fun:_IO_do_write
+   fun:_IO_file_xsputn
+   fun:vfprintf
+   fun:printf
+}
+{
+   syscall param write(buf) points to uninitialised byte(s) 0
+   Memcheck:Param
+   write(buf)
+   fun:__write_nocancel
+   fun:_IO_file_write
+   fun:_IO_file_xsputn
+   fun:vfprintf
+   fun:printf
+}
+{
+   invalid read of size 1
+   Memcheck:Addr1
+   fun:_ZN5boost14char_separatorIcSt11char_traitsIcEEclIN9__gnu_cxx17__normal_iteratorIPKcNSt7__cxx1112basic_stringIcS2_SaIcEEEEESC_EEbRT_SE_RT0_
+   fun:initialize
+   fun:token_iterator
+   fun:begin
+}
+{
+   invalid read of size 5
+   Memcheck:Addr2
+   fun:memcpy
+   fun:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE10_M_replaceEmmPKcm
+   fun:replace
+   fun:replace
+   fun:assign<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> > >
+   fun:assign<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> >
+   fun:_ZN5boost14char_separatorIcSt11char_traitsIcEEclIN9__gnu_cxx17__normal_iteratorIPKcNSt7__cxx1112basic_stringIcS2_SaIcEEEEESC_EEbRT_SE_RT0_
+   fun:initialize
+   fun:token_iterator
+   fun:begin
+}
+{
+   invalid read of size 6
+   Memcheck:Addr1
+   fun:memcpy
+   fun:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE10_M_replaceEmmPKcm
+   fun:replace
+   fun:replace
+   fun:assign<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> > >
+   fun:assign<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> >
+   fun:_ZN5boost14char_separatorIcSt11char_traitsIcEEclIN9__gnu_cxx17__normal_iteratorIPKcNSt7__cxx1112basic_stringIcS2_SaIcEEEEESC_EEbRT_SE_RT0_
+   fun:initialize
+   fun:token_iterator
+   fun:begin
+}
+{
+   invalid read of size 7
+   Memcheck:Addr2
+   fun:memcpy
+   fun:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE10_M_replaceEmmPKcm
+   fun:replace
+   fun:replace
+   fun:assign<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> > >
+   fun:assign<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> >
+   fun:operator()<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> >
+   fun:increment
+   fun:increment<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
+   fun:operator++
+   fun:__distance<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
+   fun:distance<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
+   fun:_M_range_initialize<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
+   fun:_M_initialize_dispatch<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
+   fun:vector<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
+}
+{
+   invalid read of size 8
+   Memcheck:Addr1
+   fun:memcpy
+   fun:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE10_M_replaceEmmPKcm
+   fun:replace
+   fun:replace
+   fun:assign<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> > >
+   fun:assign<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> >
+   fun:operator()<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> >
+   fun:increment
+   fun:increment<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
+   fun:operator++
+   fun:__distance<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
+   fun:distance<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
+   fun:_M_range_initialize<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
+   fun:_M_initialize_dispatch<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
+   fun:vector<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
+}
+{
+   invalid read of size 10
+   Memcheck:Addr2
+   fun:memcpy
+   fun:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE10_M_replaceEmmPKcm
+   fun:replace
+   fun:replace
+   fun:assign<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> > >
+   fun:assign<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> >
+   fun:operator()<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> >
+   fun:increment
+   fun:increment<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
+   fun:operator++
+   fun:__uninit_copy<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char>*>
+   fun:uninitialized_copy<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char>*>
+   fun:__uninitialized_copy_a<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char>*, std::__cxx11::basic_string<char> >
+   fun:_M_range_initialize<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
+   fun:_M_initialize_dispatch<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
+   fun:vector<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
+}
+{
+   invalid read of size 11
+   Memcheck:Addr1
+   fun:memcpy
+   fun:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE10_M_replaceEmmPKcm
+   fun:replace
+   fun:replace
+   fun:assign<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> > >
+   fun:assign<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> >
+   fun:operator()<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> >
+   fun:increment
+   fun:increment<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
+   fun:operator++
+   fun:__uninit_copy<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char>*>
+   fun:uninitialized_copy<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char>*>
+   fun:__uninitialized_copy_a<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char>*, std::__cxx11::basic_string<char> >
+   fun:_M_range_initialize<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
+   fun:_M_initialize_dispatch<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
+   fun:vector<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
+}
+{
+   invalid read of size 21
+   Memcheck:Addr1
+   fun:operator()<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> >
+   fun:increment
+   fun:increment<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
+   fun:operator++
+   fun:__distance<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
+   fun:distance<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
+   fun:_M_range_initialize<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
+   fun:_M_initialize_dispatch<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
+   fun:vector<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
+}
+{
+   invalid read of size 22
+   Memcheck:Addr1
+   fun:operator()<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> >
+   fun:increment
+   fun:increment<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
+   fun:operator++
+   fun:__uninit_copy<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char>*>
+   fun:uninitialized_copy<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char>*>
+   fun:__uninitialized_copy_a<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char>*, std::__cxx11::basic_string<char> >
+   fun:_M_range_initialize<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
+   fun:_M_initialize_dispatch<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
+   fun:vector<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
+}
+{
+   invalid read of size 13
+   Memcheck:Addr2
+   fun:memcpy@GLIBC_2.2.5
+   fun:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE10_M_replaceEmmPKcm
+   fun:replace
+   fun:replace
+   fun:assign<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> > >
+   fun:assign<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> >
+   fun:_ZN5boost14char_separatorIcSt11char_traitsIcEEclIN9__gnu_cxx17__normal_iteratorIPKcNSt7__cxx1112basic_stringIcS2_SaIcEEEEESC_EEbRT_SE_RT0_
+   fun:initialize
+   fun:token_iterator
+   fun:begin
+}
+{
+   invalid read of size 14
+   Memcheck:Addr1
+   fun:memcpy@GLIBC_2.2.5
+   fun:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE10_M_replaceEmmPKcm
+   fun:replace
+   fun:replace
+   fun:assign<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> > >
+   fun:assign<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> >
+   fun:_ZN5boost14char_separatorIcSt11char_traitsIcEEclIN9__gnu_cxx17__normal_iteratorIPKcNSt7__cxx1112basic_stringIcS2_SaIcEEEEESC_EEbRT_SE_RT0_
+   fun:initialize
+   fun:token_iterator
+   fun:begin
+}
+{
+   invalid read of size 15
+   Memcheck:Addr2
+   fun:memcpy@GLIBC_2.2.5
+   fun:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE10_M_replaceEmmPKcm
+   fun:replace
+   fun:replace
+   fun:assign<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> > >
+   fun:assign<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> >
+   fun:operator()<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> >
+   fun:increment
+   fun:increment<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
+   fun:operator++
+   fun:__distance<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
+   fun:distance<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
+   fun:_M_range_initialize<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
+   fun:_M_initialize_dispatch<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
+   fun:vector<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
+}
+{
+   invalid read of size 16
+   Memcheck:Addr1
+   fun:memcpy@GLIBC_2.2.5
+   fun:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE10_M_replaceEmmPKcm
+   fun:replace
+   fun:replace
+   fun:assign<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> > >
+   fun:assign<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> >
+   fun:operator()<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> >
+   fun:increment
+   fun:increment<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
+   fun:operator++
+   fun:__distance<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
+   fun:distance<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
+   fun:_M_range_initialize<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
+   fun:_M_initialize_dispatch<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
+   fun:vector<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
+}
+{
+   invalid read of size 18
+   Memcheck:Addr2
+   fun:memcpy@GLIBC_2.2.5
+   fun:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE10_M_replaceEmmPKcm
+   fun:replace
+   fun:replace
+   fun:assign<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> > >
+   fun:assign<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> >
+   fun:operator()<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> >
+   fun:increment
+   fun:increment<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
+   fun:operator++
+   fun:__uninit_copy<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char>*>
+   fun:uninitialized_copy<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char>*>
+   fun:__uninitialized_copy_a<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char>*, std::__cxx11::basic_string<char> >
+   fun:_M_range_initialize<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
+   fun:_M_initialize_dispatch<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
+   fun:vector<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
+}
+{
+   invalid read of size 19
+   Memcheck:Addr1
+   fun:memcpy@GLIBC_2.2.5
+   fun:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE10_M_replaceEmmPKcm
+   fun:replace
+   fun:replace
+   fun:assign<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> > >
+   fun:assign<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> >
+   fun:operator()<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> >
+   fun:increment
+   fun:increment<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
+   fun:operator++
+   fun:__uninit_copy<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char>*>
+   fun:uninitialized_copy<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char>*>
+   fun:__uninitialized_copy_a<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char>*, std::__cxx11::basic_string<char> >
+   fun:_M_range_initialize<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
+   fun:_M_initialize_dispatch<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
+   fun:vector<boost::token_iterator<boost::char_separator<char>, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> > >
+}
+{
+   syscall param write(buf) points to uninitialised byte(s) 1
+   Memcheck:Param
+   write(buf)
+   fun:__write_nocancel
+   fun:_IO_file_write@@GLIBC_2.2.5
+   fun:_IO_do_write@@GLIBC_2.2.5
+   fun:_IO_file_xsputn@@GLIBC_2.2.5
+   fun:vfprintf
+   fun:printf
+}
+{
+   syscall param write(buf) points to uninitialised byte(s) 2
+   Memcheck:Param
+   write(buf)
+   fun:__write_nocancel
+   fun:_IO_file_write@@GLIBC_2.2.5
+   fun:_IO_file_xsputn@@GLIBC_2.2.5
+   fun:vfprintf
+   fun:printf
+}


### PR DESCRIPTION
This PR addresses Issue #2107.

With the changes suggested here, the ctest tool can be invoked with the option "-T memcheck", which will find and use valgrind to memcheck the tests.

A mechanism is also included to ignore all pytests, since checking those will also check the python executable, which would make the check very slow and the results difficult to interpret.

To ignore other individual tests, these may be added to the tests, these may be included in the copy of  CTestCustom.ctest.in that gets put into the build directory. Also, the same mechanism I used for pytests may potentially be replicated to ignore other tests (Java ones?).

Finally, a suppressions file for the current code is provided. These have been generated from a "conda on linux" build, so that these might silence all current problems in similar environments, although I am afraid these won't work for other architecture/libraries/compilers.