### PR TITLE
PgSQL: fix boolean definitions for Postgresql 11

### DIFF
--- a/Code/PgSQL/rdkit/bfp_gin.c
+++ b/Code/PgSQL/rdkit/bfp_gin.c
@@ -116,7 +116,7 @@ Datum gin_bfp_consistent(PG_FUNCTION_ARGS) {
 
   int32 i, nCommon = 0;
   for (i = 0; i < nkeys; ++i) {
-    if (check[i] == TRUE) {
+    if (check[i] == true) {
       ++nCommon;
     }
   }

--- a/Code/PgSQL/rdkit/bfp_gist.c
+++ b/Code/PgSQL/rdkit/bfp_gist.c
@@ -137,7 +137,7 @@ gbfp_compress(PG_FUNCTION_ARGS)
     
     gistentryinit(*retval, PointerGetDatum(gbfp),
 		  entry->rel, entry->page,
-		  entry->offset, FALSE);
+		  entry->offset, false);
   }
   /* no change should be required on inner nodes */
   else {
@@ -166,7 +166,7 @@ gbfp_decompress(PG_FUNCTION_ARGS)
     retval = (GISTENTRY *) palloc(sizeof(GISTENTRY));
     gistentryinit(*retval, PointerGetDatum(key),
 		  entry->rel, entry->page,
-		  entry->offset, FALSE);
+		  entry->offset, false);
     PG_RETURN_POINTER(retval);
   }
 
@@ -680,7 +680,7 @@ gbfp_fetch(PG_FUNCTION_ARGS)
   retval = palloc(sizeof(GISTENTRY));
   
   gistentryinit(*retval, PointerGetDatum(bfp),
-		entry->rel, entry->page, entry->offset, FALSE);
+		entry->rel, entry->page, entry->offset, false);
   
   PG_RETURN_POINTER(retval);
 }

--- a/Code/PgSQL/rdkit/low_gist.c
+++ b/Code/PgSQL/rdkit/low_gist.c
@@ -55,7 +55,7 @@ gslfp_compress(PG_FUNCTION_ARGS)
 
     gistentryinit(*retval, PointerGetDatum(makeLowSparseFingerPrint(fp, NUMRANGE)),
                   entry->rel, entry->page,
-                  entry->offset, FALSE);
+                  entry->offset, false);
     freeCSfp(fp);
   }       
                 
@@ -76,7 +76,7 @@ gslfp_decompress(PG_FUNCTION_ARGS)
 
       gistentryinit(*retval, PointerGetDatum(key),
                     entry->rel, entry->page,
-                    entry->offset, FALSE);
+                    entry->offset, false);
 
       PG_RETURN_POINTER(retval);
     }

--- a/Code/PgSQL/rdkit/rdkit_gist.c
+++ b/Code/PgSQL/rdkit/rdkit_gist.c
@@ -69,7 +69,7 @@ compressAllTrue(GISTENTRY *entry)
   
   gistentryinit(*retval, PointerGetDatum(b),
 		entry->rel, entry->page,
-		entry->offset, FALSE);
+		entry->offset, false);
   
   return retval;
 }
@@ -89,7 +89,7 @@ gmol_compress(PG_FUNCTION_ARGS)
 
     gistentryinit(*retval, PointerGetDatum(makeMolSignature(m)),
                   entry->rel, entry->page,
-                  entry->offset, FALSE);
+                  entry->offset, false);
     freeCROMol(m);
   }       
   else if ( !ISALLTRUE(DatumGetPointer(entry->key)) ) {
@@ -114,7 +114,7 @@ gsfp_compress(PG_FUNCTION_ARGS)
 
     gistentryinit(*retval, PointerGetDatum(makeSfpSignature(fp, NUMBITS)),
                   entry->rel, entry->page,
-                  entry->offset, FALSE);
+                  entry->offset, false);
     freeCSfp(fp);
   }       
   else if ( !ISALLTRUE(DatumGetPointer(entry->key)) ) {
@@ -137,7 +137,7 @@ gmol_decompress(PG_FUNCTION_ARGS)
 
     gistentryinit(*retval, PointerGetDatum(key),
 		  entry->rel, entry->page,
-		  entry->offset, FALSE);
+		  entry->offset, false);
     
     PG_RETURN_POINTER(retval);
   }
@@ -738,7 +738,7 @@ greaction_compress(PG_FUNCTION_ARGS)
     
     gistentryinit(*retval, PointerGetDatum(makeReactionSign(rxn)),
                   entry->rel, entry->page,
-                  entry->offset, FALSE);
+                  entry->offset, false);
     freeChemReaction(rxn);
   }
   else if ( !ISALLTRUE(DatumGetPointer(entry->key)) ) {


### PR DESCRIPTION
#### Reference Issue
https://git.postgresql.org/gitweb/?p=postgresql.git;a=commit;h=6337865f36da34e9c89aaa292f976bde6df0b065

#### What does this implement/fix? Explain your changes.
Upper-cased spelling for boolean definitions has been removed in Postgresql 11 in favour of using just lower-cased spelling. As mentioned in the postgresql commit, existing code can be changed to
the lower-cased spelling in a backward compatible way.