### PR TITLE
Fix typo in RecapHierarchyNode destructor

### DIFF
--- a/rdkit/Chem/Recap.py
+++ b/rdkit/Chem/Recap.py
@@ -138,7 +138,7 @@ class RecapHierarchyNode(object):
 
   def __del__(self):
     self.children = {}
-    self.parent = {}
+    self.parents = {}
     self.mol = None
 
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! 
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->
Recap.py line 141

#### What does this implement/fix? Explain your changes.
Recap.py
In RecapHierarchyNode class, __init__ defines 'parents' but __del__ defines 'parent'. It seems bug.

Taka
#### Any other comments?

