### PR TITLE
Fixes #2151

### DIFF
--- a/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
@@ -49,21 +49,6 @@ void getBondHighlightsForAtoms(const ROMol &mol,
 }  // namespace
 
 // ****************************************************************************
-MolDraw2D::MolDraw2D(int width, int height, int panelWidth, int panelHeight)
-    : needs_scale_(true),
-      width_(width),
-      height_(height),
-      panel_width_(panelWidth > 0 ? panelWidth : width),
-      panel_height_(panelHeight > 0 ? panelHeight : height),
-      scale_(1.0),
-      x_trans_(0.0),
-      y_trans_(0.0),
-      x_offset_(0),
-      y_offset_(0),
-      font_size_(0.5),
-      curr_width_(2),
-      fill_polys_(true),
-      activeMolIdx_(-1) {}
 
 // ****************************************************************************
 void MolDraw2D::drawMolecule(const ROMol &mol,

--- a/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
@@ -166,6 +166,10 @@ void MolDraw2D::drawMolecule(const ROMol &mol,
   atom_syms_.push_back(std::vector<std::pair<std::string, OrientType>>());
   activeMolIdx_++;
 
+  int origWidth = curr_width_;
+  if (drawOptions().bondLineWidth >= 0)
+    curr_width_ = drawOptions().bondLineWidth;
+
   if (!activeMolIdx_) {  // on the first pass we need to do some work
     if (drawOptions().clearBackground) {
       clearDrawing();
@@ -176,7 +180,8 @@ void MolDraw2D::drawMolecule(const ROMol &mol,
       calculateScale();
       needs_scale_ = false;
     }
-    // make sure the font doesn't end up too large (the constants are empirical)
+    // make sure the font doesn't end up too large (the constants are
+    // empirical)
     if (scale_ <= 40.) {
       setFontSize(font_size_);
     } else {
@@ -307,6 +312,8 @@ void MolDraw2D::drawMolecule(const ROMol &mol,
   if (drawOptions().flagCloseContactsDist >= 0) {
     highlightCloseContacts();
   }
+
+  curr_width_ = origWidth;
 
   // {
   //   Point2D p1(x_min_, y_min_), p2(x_min_ + x_range_, y_min_ + y_range_);

--- a/Code/GraphMol/MolDraw2D/MolDraw2D.h
+++ b/Code/GraphMol/MolDraw2D/MolDraw2D.h
@@ -90,6 +90,8 @@ struct RDKIT_MOLDRAW2D_EXPORT MolDrawOptions {
   std::vector<std::vector<int>> atomRegions;  // regions
   DrawColour
       symbolColour;  // color to be used for the symbols and arrows in reactions
+  int bondLineWidth;  // if positive, this overrides the default line width
+                      // when drawing bonds
   std::vector<DrawColour> highlightColourPalette;  // defining 10 default colors
   // for highlighting atoms and bonds
   // or reactants in a reactions
@@ -113,7 +115,8 @@ struct RDKIT_MOLDRAW2D_EXPORT MolDrawOptions {
         multipleBondOffset(0.15),
         padding(0.05),
         additionalAtomLabelPadding(0.0),
-        symbolColour(0, 0, 0) {
+        symbolColour(0, 0, 0),
+        bondLineWidth(-1) {
     highlightColourPalette.push_back(
         DrawColour(1., 1., .67));                              // popcorn yellow
     highlightColourPalette.push_back(DrawColour(1., .8, .6));  // sand

--- a/Code/GraphMol/MolDraw2D/MolDraw2D.h
+++ b/Code/GraphMol/MolDraw2D/MolDraw2D.h
@@ -86,8 +86,8 @@ struct RDKIT_MOLDRAW2D_EXPORT MolDrawOptions {
   double additionalAtomLabelPadding;  // additional padding to leave around atom
                                       // labels. Expressed as a fraction of the
                                       // font size.
-  std::map<int, std::string> atomLabels;       // replacement labels for atoms
-  std::vector<std::vector<int> > atomRegions;  // regions
+  std::map<int, std::string> atomLabels;      // replacement labels for atoms
+  std::vector<std::vector<int>> atomRegions;  // regions
   DrawColour
       symbolColour;  // color to be used for the symbols and arrows in reactions
   std::vector<DrawColour> highlightColourPalette;  // defining 10 default colors
@@ -150,7 +150,21 @@ class RDKIT_MOLDRAW2D_EXPORT MolDraw2D {
     sizes of the panels individual molecules are drawn in when
     \c drawMolecules() is called.
   */
-  MolDraw2D(int width, int height, int panelWidth = -1, int panelHeight = -1);
+  MolDraw2D(int width, int height, int panelWidth, int panelHeight)
+      : needs_scale_(true),
+        width_(width),
+        height_(height),
+        panel_width_(panelWidth > 0 ? panelWidth : width),
+        panel_height_(panelHeight > 0 ? panelHeight : height),
+        scale_(1.0),
+        x_trans_(0.0),
+        y_trans_(0.0),
+        x_offset_(0),
+        y_offset_(0),
+        font_size_(0.5),
+        curr_width_(2),
+        fill_polys_(true),
+        activeMolIdx_(-1) {}
 
   virtual ~MolDraw2D() {}
 
@@ -231,11 +245,11 @@ class RDKIT_MOLDRAW2D_EXPORT MolDraw2D {
   virtual void drawMolecules(
       const std::vector<ROMol *> &mols,
       const std::vector<std::string> *legends = NULL,
-      const std::vector<std::vector<int> > *highlight_atoms = NULL,
-      const std::vector<std::vector<int> > *highlight_bonds = NULL,
-      const std::vector<std::map<int, DrawColour> > *highlight_atom_maps = NULL,
-      const std::vector<std::map<int, DrawColour> > *highlight_bond_maps = NULL,
-      const std::vector<std::map<int, double> > *highlight_radii = NULL,
+      const std::vector<std::vector<int>> *highlight_atoms = NULL,
+      const std::vector<std::vector<int>> *highlight_bonds = NULL,
+      const std::vector<std::map<int, DrawColour>> *highlight_atom_maps = NULL,
+      const std::vector<std::map<int, DrawColour>> *highlight_bond_maps = NULL,
+      const std::vector<std::map<int, double>> *highlight_radii = NULL,
       const std::vector<int> *confIds = NULL);
 
   //! draw a ChemicalReaction
@@ -388,7 +402,7 @@ class RDKIT_MOLDRAW2D_EXPORT MolDraw2D {
     return at_cds_[activeMolIdx_];
   };
   //! returns the atomic symbols of the current molecule
-  const std::vector<std::pair<std::string, OrientType> > &atomSyms() const {
+  const std::vector<std::pair<std::string, OrientType>> &atomSyms() const {
     PRECONDITION(activeMolIdx_ >= 0, "no index");
     return atom_syms_[activeMolIdx_];
   };
@@ -411,9 +425,9 @@ class RDKIT_MOLDRAW2D_EXPORT MolDraw2D {
   DashPattern curr_dash_;
   MolDrawOptions options_;
 
-  std::vector<std::vector<Point2D> > at_cds_;  // from mol
-  std::vector<std::vector<int> > atomic_nums_;
-  std::vector<std::vector<std::pair<std::string, OrientType> > > atom_syms_;
+  std::vector<std::vector<Point2D>> at_cds_;  // from mol
+  std::vector<std::vector<int>> atomic_nums_;
+  std::vector<std::vector<std::pair<std::string, OrientType>>> atom_syms_;
   Point2D bbox_[2];
 
   // draw the char, with the bottom left hand corner at cds
@@ -431,8 +445,8 @@ class RDKIT_MOLDRAW2D_EXPORT MolDraw2D {
 
   virtual void drawLine(const Point2D &cds1, const Point2D &cds2,
                         const DrawColour &col1, const DrawColour &col2);
-  void drawBond(const ROMol &mol, const Bond* bond, int at1_idx,
-                int at2_idx, const std::vector<int> *highlight_atoms = NULL,
+  void drawBond(const ROMol &mol, const Bond *bond, int at1_idx, int at2_idx,
+                const std::vector<int> *highlight_atoms = NULL,
                 const std::map<int, DrawColour> *highlight_atom_map = NULL,
                 const std::vector<int> *highlight_bonds = NULL,
                 const std::map<int, DrawColour> *highlight_bond_map = NULL);
@@ -445,12 +459,12 @@ class RDKIT_MOLDRAW2D_EXPORT MolDraw2D {
   // cds1 and cds2 are 2 atoms in a ring.  Returns the perpendicular pointing
   // into
   // the ring.
-  Point2D bondInsideRing(const ROMol &mol, const Bond* bond,
+  Point2D bondInsideRing(const ROMol &mol, const Bond *bond,
                          const Point2D &cds1, const Point2D &cds2);
   // cds1 and cds2 are 2 atoms in a chain double bond.  Returns the
   // perpendicular
   // pointing into the inside of the bond
-  Point2D bondInsideDoubleBond(const ROMol &mol, const Bond* bond);
+  Point2D bondInsideDoubleBond(const ROMol &mol, const Bond *bond);
   // calculate normalised perpendicular to vector between two coords, such
   // that
   // it's inside the angle made between (1 and 2) and (2 and 3).
@@ -480,6 +494,6 @@ class RDKIT_MOLDRAW2D_EXPORT MolDraw2D {
   // calculate normalised perpendicular to vector between two coords
   Point2D calcPerpendicular(const Point2D &cds1, const Point2D &cds2);
 };
-}
+}  // namespace RDKit
 
 #endif  // RDKITMOLDRAW2D_H

--- a/Code/GraphMol/MolDraw2D/Wrap/rdMolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/Wrap/rdMolDraw2D.cpp
@@ -282,6 +282,12 @@ void setBgColour(RDKit::MolDrawOptions &self, python::tuple tpl) {
 void setHighlightColour(RDKit::MolDrawOptions &self, python::tuple tpl) {
   self.highlightColour = pyTupleToDrawColour(tpl);
 }
+python::object getSymbolColour(const RDKit::MolDrawOptions &self) {
+  return colourToPyTuple(self.symbolColour);
+}
+void setSymbolColour(RDKit::MolDrawOptions &self, python::tuple tpl) {
+  self.symbolColour = pyTupleToDrawColour(tpl);
+}
 void useDefaultAtomPalette(RDKit::MolDrawOptions &self) {
   assignDefaultPalette(self.atomColourPalette);
 }
@@ -317,9 +323,6 @@ BOOST_PYTHON_MODULE(rdMolDraw2D) {
       .def_readwrite("dummiesAreAttachments",
                      &RDKit::MolDrawOptions::dummiesAreAttachments)
       .def_readwrite("circleAtoms", &RDKit::MolDrawOptions::circleAtoms)
-      //.def_readwrite("highlightColour",
-      //&RDKit::MolDrawOptions::highlightColour,
-      //               "the highlight colour")
       .def("getBackgroundColour", &RDKit::getBgColour,
            "method returning the background colour")
       .def("getHighlightColour", &RDKit::getHighlightColour,
@@ -328,6 +331,10 @@ BOOST_PYTHON_MODULE(rdMolDraw2D) {
            "method for setting the background colour")
       .def("setHighlightColour", &RDKit::setHighlightColour,
            "method for setting the highlight colour")
+      .def("getSymbolColour", &RDKit::getSymbolColour,
+           "method returning the symbol colour")
+      .def("setSymbolColour", &RDKit::setSymbolColour,
+           "method for setting the symbol colour")
       .def("useDefaultAtomPalette", &RDKit::useDefaultAtomPalette,
            "use the default colour palette for atoms and bonds")
       .def("useBWAtomPalette", &RDKit::useBWAtomPalette,
@@ -362,6 +369,9 @@ BOOST_PYTHON_MODULE(rdMolDraw2D) {
           "offset (in Angstroms) for the extra lines in a multiple bond")
       .def_readwrite("padding", &RDKit::MolDrawOptions::padding,
                      "fraction of empty space to leave around molecule")
+      .def_readwrite(
+          "bondLineWidth", &RDKit::MolDrawOptions::bondLineWidth,
+          "if positive, this overrides the default line width for bonds")
       .def_readwrite("additionalAtomLabelPadding",
                      &RDKit::MolDrawOptions::additionalAtomLabelPadding,
                      "additional padding to leave around atom labels. "

--- a/Code/GraphMol/MolDraw2D/test1.cpp
+++ b/Code/GraphMol/MolDraw2D/test1.cpp
@@ -614,7 +614,7 @@ void testMultiThreaded() {
   for (auto &fut : tg) {
     fut.get();
   }
-  for (auto&& mol : mols) {
+  for (auto &&mol : mols) {
     delete mol;
   }
   std::cerr << " Done" << std::endl;
@@ -2119,7 +2119,7 @@ void test15ContinuousHighlightingWithGrid() {
       TEST_ASSERT(text.find("stroke:#FF7F7F;stroke-width:8px;") !=
                   std::string::npos);
     }
-    for (auto&& mol : mols) {
+    for (auto &&mol : mols) {
       delete mol;
     }
   }
@@ -2260,6 +2260,43 @@ M  END)molb";
   std::cerr << " Done" << std::endl;
 }
 
+void testGithub2151() {
+  std::cout << " ----------------- Testing Github2151: MolDraw2D: line width "
+               "should be controlled by MolDrawOptions"
+            << std::endl;
+  {
+    auto m1 = "C[C@H](F)c1ccc(C#N)cc1"_smiles;
+    TEST_ASSERT(m1);
+    MolDraw2DUtils::prepareMolForDrawing(*m1);
+    {
+      MolDraw2DSVG drawer(200, 200);
+      drawer.drawMolecule(*m1);
+      drawer.addMoleculeMetadata(*m1);
+      drawer.finishDrawing();
+      std::string text = drawer.getDrawingText();
+      std::ofstream outs("testGithub2151_1.svg");
+      outs << text;
+      outs.flush();
+      TEST_ASSERT(text.find("stroke-width:2px") != std::string::npos);
+      TEST_ASSERT(text.find("stroke-width:4px") == std::string::npos);
+    }
+    {
+      MolDraw2DSVG drawer(200, 200);
+      drawer.drawOptions().bondLineWidth = 4;
+      drawer.drawMolecule(*m1);
+      drawer.addMoleculeMetadata(*m1);
+      drawer.finishDrawing();
+      std::string text = drawer.getDrawingText();
+      std::ofstream outs("testGithub2151_2.svg");
+      outs << text;
+      outs.flush();
+      TEST_ASSERT(text.find("stroke-width:2px") == std::string::npos);
+      TEST_ASSERT(text.find("stroke-width:4px") != std::string::npos);
+    }
+  }
+  std::cerr << " Done" << std::endl;
+}
+
 int main() {
 #ifdef RDK_BUILD_COORDGEN_SUPPORT
   RDDepict::preferCoordGen = false;
@@ -2302,4 +2339,5 @@ int main() {
 #endif
   test16MoleculeMetadata();
   testGithub2063();
+  testGithub2151();
 }


### PR DESCRIPTION
Adds a bondLineWidth parameter to `MolDrawOptions` and exposes it to Python.
also adds the symbolColour to the wrapper