### PR TITLE
Fix #2176: InChI functions should return NULL on un-InChI-able input molecules.

### DIFF
--- a/Code/PgSQL/rdkit/expected/inchi.out
+++ b/Code/PgSQL/rdkit/expected/inchi.out
@@ -67,3 +67,16 @@ select mol_inchikey('CC1=NC=CN1'::mol,'/FixedH');
  LXBGSDVWAMZHDD-JSWHHWTPNA-N
 (1 row)
 
+-- Non-InChI-able molecules should return NULL.
+select coalesce(mol_inchi('CC*'), '<NULL>');
+ coalesce 
+----------
+ <NULL>
+(1 row)
+
+select coalesce(mol_inchikey('CC*'), '<NULL>');
+ coalesce 
+----------
+ <NULL>
+(1 row)
+

--- a/Code/PgSQL/rdkit/mol_op.c
+++ b/Code/PgSQL/rdkit/mol_op.c
@@ -222,7 +222,7 @@ Datum mol_inchi(PG_FUNCTION_ARGS) {
       searchMolCache(fcinfo->flinfo->fn_extra, fcinfo->flinfo->fn_mcxt,
                      PG_GETARG_DATUM(0), NULL, &mol, NULL);
   str = MolInchi(mol, opts);
-  if (!str || *str == 0) {
+  if (*str == 0) {
     free((void *)str);
     PG_RETURN_NULL();
   }
@@ -244,7 +244,7 @@ Datum mol_inchikey(PG_FUNCTION_ARGS) {
       searchMolCache(fcinfo->flinfo->fn_extra, fcinfo->flinfo->fn_mcxt,
                      PG_GETARG_DATUM(0), NULL, &mol, NULL);
   str = MolInchiKey(mol, opts);
-  if (!str || *str == 0) {
+  if (*str == 0) {
     free((void *)str);
     PG_RETURN_NULL();
   }

--- a/Code/PgSQL/rdkit/mol_op.c
+++ b/Code/PgSQL/rdkit/mol_op.c
@@ -222,9 +222,15 @@ Datum mol_inchi(PG_FUNCTION_ARGS) {
       searchMolCache(fcinfo->flinfo->fn_extra, fcinfo->flinfo->fn_mcxt,
                      PG_GETARG_DATUM(0), NULL, &mol, NULL);
   str = MolInchi(mol, opts);
-  res = pnstrdup(str, strlen(str));
-  free((void *)str);
-  PG_RETURN_CSTRING(res);
+  if (!str || *str == 0) {
+    free((void *)str);
+    PG_RETURN_NULL();
+  }
+  else {
+    res = pnstrdup(str, strlen(str));
+    free((void *)str);
+    PG_RETURN_CSTRING(res);
+  }
 }
 
 PGDLLEXPORT Datum mol_inchikey(PG_FUNCTION_ARGS);
@@ -238,9 +244,15 @@ Datum mol_inchikey(PG_FUNCTION_ARGS) {
       searchMolCache(fcinfo->flinfo->fn_extra, fcinfo->flinfo->fn_mcxt,
                      PG_GETARG_DATUM(0), NULL, &mol, NULL);
   str = MolInchiKey(mol, opts);
-  res = pnstrdup(str, strlen(str));
-  free((void *)str);
-  PG_RETURN_CSTRING(res);
+  if (!str || *str == 0) {
+    free((void *)str);
+    PG_RETURN_NULL();
+  }
+  else {
+    res = pnstrdup(str, strlen(str));
+    free((void *)str);
+    PG_RETURN_CSTRING(res);
+  }
 }
 PGDLLEXPORT Datum mol_murckoscaffold(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(mol_murckoscaffold);

--- a/Code/PgSQL/rdkit/sql/inchi.sql
+++ b/Code/PgSQL/rdkit/sql/inchi.sql
@@ -12,3 +12,7 @@ select mol_inchi('CC1=NC=CN1'::mol);
 select mol_inchikey('CC1=NC=CN1'::mol);
 select mol_inchi('CC1=NC=CN1'::mol,'/FixedH');
 select mol_inchikey('CC1=NC=CN1'::mol,'/FixedH');
+
+-- Non-InChI-able molecules should return NULL.
+select coalesce(mol_inchi('CC*'), '<NULL>');
+select coalesce(mol_inchikey('CC*'), '<NULL>');


### PR DESCRIPTION
#### Reference Issue
Fixes #2176

#### What does this implement/fix? Explain your changes.
Adds check of returned string from MolInchi() and MolInchiKey() and converts blank results into NULL. Valid InChI strings or InChI keys will never be blank strings.