### PR TITLE
Update installation instructions for Linux

### DIFF
--- a/Docs/Book/Install.md
+++ b/Docs/Book/Install.md
@@ -96,7 +96,8 @@ At this point, you should be able to clone the RDKit repository to the desired b
 		-DRDK_INSTALL_INTREE=ON \
 		-DRDK_INSTALL_STATIC_LIBS=OFF \
 		-DRDK_BUILD_CPP_TESTS=ON \
-		-DPYTHON_NUMPY_INCLUDE_PATH="$CONDA_PREFIX/lib/python3.6/site-packages/numpy/core/include"
+		-DPYTHON_NUMPY_INCLUDE_PATH="$CONDA_PREFIX/lib/python3.6/site-packages/numpy/core/include" \
+		-DBOOST_ROOT="$CONDA_PREFIX"
 
 And finally, `make`, `make install` and `ctest`
 


### PR DESCRIPTION
If boost is installed with conda, cmake will not find it. For that reason,
we have to specify BOOST_ROOT.