### PR TITLE
Update CMake rules to find external coorgen & maeparser libs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,9 +46,10 @@ __pycache__/
 /Data/templates.mae
 
 /External/catch/catch/
-/External/CoordGen/coordgenlibs/
+/External/CoordGen/coordgen/
 /External/CoordGen/maeparser/
-/External/CoordGen/master.tar.gz
+/External/CoordGen/maeparser-v*.tar.gz
+/External/CoordGen/coordgenlibs-v*.tar.gz
 /External/FreeSASA/freesasa-2.0.1/
 /External/FreeSASA/master.tar.gz
 /External/INCHI-API/INCHI-1-SRC.zip

--- a/Code/GraphMol/Depictor/CMakeLists.txt
+++ b/Code/GraphMol/Depictor/CMakeLists.txt
@@ -1,6 +1,18 @@
 
 remove_definitions(-DRDKIT_GRAPHMOL_BUILD)
 add_definitions(-DRDKIT_DEPICTOR_BUILD)
+
+if(RDK_BUILD_COORDGEN_SUPPORT)
+
+    if(MSVC AND (NOT RDK_INSTALL_DLLS_MSVC))
+      add_definitions(-DSTATIC_COORDGEN)
+    else(MSVC AND (NOT RDK_INSTALL_DLLS_MSVC))
+      add_definitions(-DIN_COORDGEN)
+    endif(MSVC AND (NOT RDK_INSTALL_DLLS_MSVC))
+
+    include_directories(${coordgen_INCLUDE_DIRS})
+endif()
+
 rdkit_library(Depictor
               RDDepictor.cpp EmbeddedFrag.cpp DepictUtils.cpp
               LINK_LIBRARIES ${RDK_COORDGEN_LIBS} SubstructMatch GraphMol)

--- a/Code/GraphMol/FileParsers/CMakeLists.txt
+++ b/Code/GraphMol/FileParsers/CMakeLists.txt
@@ -3,11 +3,8 @@ remove_definitions(-DRDKIT_GRAPHMOL_BUILD)
 add_definitions(-DRDKIT_FILEPARSERS_BUILD)
 
 if(RDK_BUILD_COORDGEN_SUPPORT)
+    include_directories(${maeparser_INCLUDE_DIRS})
     set (maesupplier MaeMolSupplier.cpp)
-    set (maeparser_var maeparser)
-else()
-    set (maesupplier "")
-    set (maeparser_var "")
 endif()
 
 if(RDK_USE_BOOST_REGEX)
@@ -28,7 +25,7 @@ rdkit_library(FileParsers
               ProximityBonds.cpp
               SequenceParsers.cpp SequenceWriters.cpp
               SVGParser.cpp
-              LINK_LIBRARIES Depictor SmilesParse GraphMol ${maeparser_var} ${regex_lib})
+              LINK_LIBRARIES Depictor SmilesParse GraphMol ${RDK_COORDGEN_LIBS} ${regex_lib})
 
 rdkit_headers(FileParsers.h
               FileParserUtils.h

--- a/Code/GraphMol/FileParsers/MaeMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/MaeMolSupplier.cpp
@@ -16,8 +16,7 @@
 #include <GraphMol/MolOps.h>
 #include <GraphMol/RWMol.h>
 #include <GraphMol/FileParsers/MolSupplier.h>
-#include <CoordGen/maeparser/Reader.hpp>
-
+#include <maeparser/Reader.hpp>
 
 namespace RDKit {
 

--- a/Code/GraphMol/Wrap/CMakeLists.txt
+++ b/Code/GraphMol/Wrap/CMakeLists.txt
@@ -24,8 +24,7 @@ rdkit_python_extension(rdqueries
 
 if(RDK_BUILD_COORDGEN_SUPPORT)
     set (maesupplier MaeMolSupplier.cpp)
-else()
-    set (maesupplier "")
+    include_directories(${maeparser_INCLUDE_DIRS})
 endif()
 
 if(RDK_BUILD_COMPRESSED_SUPPLIERS)

--- a/Code/GraphMol/Wrap/MaeMolSupplier.cpp
+++ b/Code/GraphMol/Wrap/MaeMolSupplier.cpp
@@ -20,7 +20,7 @@
 #include <GraphMol/RDKitBase.h>
 #include <RDBoost/python_streambuf.h>
 #include <RDBoost/iterator_next.h>
-#include <CoordGen/maeparser/Reader.hpp>
+#include <maeparser/Reader.hpp>
 
 #include "MolSupplier.h"
 

--- a/Code/cmake/Modules/Findcoordgen.cmake
+++ b/Code/cmake/Modules/Findcoordgen.cmake
@@ -1,0 +1,46 @@
+# Try to find Schrodinger's CoorgGen libraries.
+#
+# Different version handling is not yet supported
+#
+# Once found, this will find and define the following variables:
+#
+# coordgen_INCLUDE_DIRS   - CoordGen's includes directory
+# coordgen_LIBRARIES      - CoordGen's shared libraries
+# coordgen_TEMPLATE_FILE  - CoordGen templates file
+#
+#
+
+include(FindPackageHandleStandardArgs)
+
+find_path(coordgen_INCLUDE_DIRS
+    NAMES "coordgen/sketcherMinimizer.h"
+    HINTS ${COORDGEN_DIR} ${coordgen_DIR}
+    PATH_SUFFIXES "include"
+    DOC "include path for coordgen"
+)
+message("-- coordgen include dir set as ${coordgen_INCLUDE_DIRS}")
+
+find_library(coordgen_LIBRARIES
+    NAMES coordgen coordgenlibs
+    HINTS ${COORDGEN_DIR} ${coordgen_DIR}
+    PATH_SUFFIXES "lib"
+    DOC "libraries for coordgen"
+)
+message("-- coordgen libraries set as '${coordgen_LIBRARIES}'")
+
+# Just in case, add parent directory above libraries to templates search hints
+get_filename_component(libs_parent_dir ${coordgen_LIBRARIES} PATH)
+find_file(coordgen_TEMPLATE_FILE
+    NAMES templates.mae
+    HINTS ${COORDGEN_DIR} ${coordgen_DIR} ${libs_parent_dir}
+    PATH_SUFFIXES "share" "share/coordgen"
+    DOC "templates file for coordgen"
+)
+message("-- coordgen templates file set as '${coordgen_TEMPLATE_FILE}'")
+
+find_package_handle_standard_args(coordgen FOUND_VAR coordgen_FOUND
+                                  REQUIRED_VARS coordgen_INCLUDE_DIRS
+                                  coordgen_LIBRARIES coordgen_TEMPLATE_FILE)
+
+
+

--- a/Code/cmake/Modules/Findmaeparser.cmake
+++ b/Code/cmake/Modules/Findmaeparser.cmake
@@ -1,0 +1,32 @@
+# Try to find Schrodinger's MAEParser libraries.
+#
+# Different version handling is not yet supported
+#
+# Once found, this will find and define the following variables:
+#
+# maeparser_INCLUDE_DIRS  - maeparser's includes directory
+# maeparser_LIBRARIES     - maeparser's shared libraries
+#
+#
+
+include(FindPackageHandleStandardArgs)
+
+find_path(maeparser_INCLUDE_DIRS
+    NAMES "maeparser/Reader.hpp"
+    HINTS ${MAEPARSER_DIR} ${maeparser_DIR}
+    PATH_SUFFIXES "include"
+    DOC "include path for maeparser"
+)
+message("-- maeparser include dir set as '${maeparser_INCLUDE_DIRS}'")
+
+find_library(maeparser_LIBRARIES
+    NAMES maeparser
+    HINTS ${MAEPARSER_DIR} ${maeparser_DIR}
+    PATH_SUFFIXES "lib"
+    DOC "libraries for maeparser"
+)
+message("-- maeparser libraries set as '${maeparser_LIBRARIES}'")
+
+find_package_handle_standard_args(maeparser FOUND_VAR maeparser_FOUND
+                                  REQUIRED_VARS maeparser_INCLUDE_DIRS
+                                  maeparser_LIBRARIES)

--- a/External/CoordGen/CMakeLists.txt
+++ b/External/CoordGen/CMakeLists.txt
@@ -1,77 +1,101 @@
 add_custom_target(coordgen_support ALL)
 
 if(RDK_BUILD_COORDGEN_SUPPORT)
+  include(RDKitUtils)
+
+  if(MSVC AND (NOT RDK_INSTALL_DLLS_MSVC))
+    add_definitions(-DSTATIC_COORDGEN)
+  else(MSVC AND (NOT RDK_INSTALL_DLLS_MSVC))
     add_definitions(-DIN_MAEPARSER)
     add_definitions(-DIN_COORDGEN)
-    include(RDKitUtils)
+  endif(MSVC AND (NOT RDK_INSTALL_DLLS_MSVC))
+
+  find_package(maeparser MODULE)
+
+  if(MAEPARSER_FORCE_BUILD OR (NOT maeparser_FOUND))
     if(NOT DEFINED MAEPARSER_DIR)
       set(MAEPARSER_DIR "${CMAKE_CURRENT_SOURCE_DIR}/maeparser")
     endif()
+
     if(NOT EXISTS "${MAEPARSER_DIR}/MaeParser.hpp")
         set(RELEASE_NO "1.0.1")
+        set(MD5 "1292494df756e95fd1cce722286f28fe")
         downloadAndCheckMD5("https://github.com/schrodinger/maeparser/archive/v${RELEASE_NO}.tar.gz"
-              "${CMAKE_CURRENT_SOURCE_DIR}/master.tar.gz"
-              "1292494df756e95fd1cce722286f28fe")
+              "${CMAKE_CURRENT_SOURCE_DIR}/maeparser-v${RELEASE_NO}.tar.gz" ${MD5})
         execute_process(COMMAND ${CMAKE_COMMAND} -E tar zxf
-          ${CMAKE_CURRENT_SOURCE_DIR}/master.tar.gz
+          ${CMAKE_CURRENT_SOURCE_DIR}/maeparser-v${RELEASE_NO}.tar.gz
           WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
         file(RENAME "maeparser-${RELEASE_NO}" "${MAEPARSER_DIR}")
         patchCoordGenMaeExportHeaders("MAEPARSER" "${MAEPARSER_DIR}/MaeParserConfig.hpp")
 
-        # patch a bug in the 1.0.0 release of maeparser
-        #file(READ "${MAEPARSER_DIR}/Buffer.cpp" buffer)
-        #string(REPLACE "m_data->reserve(m_size + 1);"
-        #       "m_data->resize(m_size + 1);" buffer "${buffer}")
-        #file(WRITE "${MAEPARSER_DIR}/Buffer.cpp" "${buffer}")
     else()
       message("-- Found MAEParser source in ${MAEPARSER_DIR}")
     endif()
 
+    set(maeparser_INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}
+        CACHE STRING "MaeParser Include Dir" FORCE)
     file(GLOB MAESOURCES "${MAEPARSER_DIR}/*.cpp")
     rdkit_library(maeparser ${MAESOURCES} SHARED )
     install(TARGETS maeparser DESTINATION ${RDKit_LibDir})
+    set(maeparser_LIBRARIES maeparser)
+
+  endif(MAEPARSER_FORCE_BUILD OR (NOT maeparser_FOUND))
+
+  find_package(coordgen MODULE)
+  if(COORDGEN_FORCE_BUILD OR (NOT coordgen_FOUND))
 
     if(NOT DEFINED COORDGEN_DIR)
-      set(COORDGEN_DIR "${CMAKE_CURRENT_SOURCE_DIR}/coordgenlibs")
+      set(COORDGEN_DIR "${CMAKE_CURRENT_SOURCE_DIR}/coordgen")
     endif()
+
     if(NOT EXISTS "${COORDGEN_DIR}/sketcherMinimizer.h")
-        set(RELEASE_NO "1.1")
-        set(SHA "ede3191bf1c1dde53f70ca086014ff9ec7768c55")
+        set(RELEASE_NO "1.2")
+        set(MD5 "cc132a4655e194143d760239f69dd265")
         downloadAndCheckMD5("https://github.com/schrodinger/coordgenlibs/archive/v${RELEASE_NO}.tar.gz"
-              "${CMAKE_CURRENT_SOURCE_DIR}/master.tar.gz"
-              "493cf2eab7d4ab6242e25da112831798")
+              "${CMAKE_CURRENT_SOURCE_DIR}/coordgenlibs-${RELEASE_NO}.tar.gz" ${MD5})
         execute_process(COMMAND ${CMAKE_COMMAND} -E tar zxf
-          ${CMAKE_CURRENT_SOURCE_DIR}/master.tar.gz
+          ${CMAKE_CURRENT_SOURCE_DIR}/coordgenlibs-${RELEASE_NO}.tar.gz
           WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
         file(RENAME "coordgenlibs-${RELEASE_NO}" "${COORDGEN_DIR}")
-        patchCoordGenMaeExportHeaders("COORDGEN" "${COORDGEN_DIR}/CoordgenConfig.hpp")
+
     else()
       message("-- Found coordgenlibs source in ${COORDGEN_DIR}")
     endif()
 
+    set(coordgen_INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}
+        CACHE STRING "CoordGen Include File" FORCE)
     file(GLOB CGSOURCES "${COORDGEN_DIR}/*.cpp")
-    rdkit_library(coordgenlib ${CGSOURCES} SHARED LINK_LIBRARIES maeparser)
-    install(TARGETS coordgenlib DESTINATION ${RDKit_LibDir})
+    rdkit_library(coordgen ${CGSOURCES} SHARED LINK_LIBRARIES maeparser)
+    install(TARGETS coordgen DESTINATION ${RDKit_LibDir})
+    set(coordgen_LIBRARIES coordgen)
+    set(coordgen_TEMPLATE_FILE ${COORDGEN_DIR}/templates.mae )
 
-    set(MAE_FILES ${COORDGEN_DIR}/templates.mae )
-    install(FILES ${MAE_FILES}
-            DESTINATION ${RDKit_ShareDir}/Data
-            COMPONENT data )
+  endif(COORDGEN_FORCE_BUILD OR (NOT coordgen_FOUND))
 
-    include_directories(${CMAKE_CURRENT_SOURCE_DIR})
-    set(RDK_COORDGEN_LIBS MolAlign coordgenlib maeparser CACHE STRING "the external libraries" FORCE)
-    rdkit_headers(CoordGen.h DEST GraphMol)
+  include_directories(${maeparser_INCLUDE_DIRS})
+  include_directories(${coordgen_INCLUDE_DIRS})
 
-    if(RDK_BUILD_PYTHON_WRAPPERS)
-      add_subdirectory(Wrap)
-    endif(RDK_BUILD_PYTHON_WRAPPERS)
+  install(FILES ${coordgen_TEMPLATE_FILE}
+          DESTINATION ${RDKit_ShareDir}/Data
+          COMPONENT data)
 
-    rdkit_test(testCoordGen test.cpp
-      LINK_LIBRARIES
-      ${RDK_COORDGEN_LIBS} Depictor
-      FileParsers SmilesParse SubstructMatch GraphMol
-      RDGeneral DataStructs RDGeneral RDGeometryLib
-      ${RDKit_THREAD_LIBS})
+  set(RDK_COORDGEN_LIBS MolAlign ${coordgen_LIBRARIES} ${maeparser_LIBRARIES}
+      CACHE STRING "the external libraries" FORCE)
+  rdkit_headers(CoordGen.h DEST GraphMol)
+
+  if(RDK_BUILD_PYTHON_WRAPPERS)
+    add_subdirectory(Wrap)
+  endif(RDK_BUILD_PYTHON_WRAPPERS)
+
+  rdkit_test(testCoordGen test.cpp
+    LINK_LIBRARIES
+    ${RDK_COORDGEN_LIBS} Depictor
+    FileParsers SmilesParse SubstructMatch GraphMol
+    RDGeneral DataStructs RDGeneral RDGeometryLib
+    ${RDKit_THREAD_LIBS})
+
 else (RDK_BUILD_COORDGEN_SUPPORT)
-    set(RDK_COORDGEN_LIBS  CACHE STRING "the external libraries" FORCE)
+
+  set(RDK_COORDGEN_LIBS CACHE STRING "the external libraries" FORCE)
+
 endif(RDK_BUILD_COORDGEN_SUPPORT)

--- a/External/CoordGen/CoordGen.h
+++ b/External/CoordGen/CoordGen.h
@@ -13,7 +13,7 @@
 #include <GraphMol/Substruct/SubstructMatch.h>
 #include <cstdlib>
 
-#include "coordgenlibs/sketcherMinimizer.h"
+#include "coordgen/sketcherMinimizer.h"
 
 namespace RDKit {
 namespace CoordGen {

--- a/External/CoordGen/test.cpp
+++ b/External/CoordGen/test.cpp
@@ -18,7 +18,7 @@
 
 #include <RDGeneral/RDLog.h>
 
-#include "coordgenlibs/sketcherMinimizer.h"
+#include "coordgen/sketcherMinimizer.h"
 #include <CoordGen/CoordGen.h>
 
 using namespace RDKit;


### PR DESCRIPTION
#### Reference Issue
This PR addresses #2104 (Find externally installed maeparser and coordgenlibs dynamic libraries).

#### What does this implement/fix? Explain your changes.
This comment mostly includes changes to CMake files to enable finding these libraries. Some of the changes update include paths for coordgen and maeparser to be able to use them either with source code or headers to libraries, and also to adapt to the changes in release v1.2 of CoordGen.

#### Any other comments?
Some considerations about the changes:
- The version of CoordGen that gets downloaded and built if libraries are not found has been bumped up to v1.2. This should also be the version to be used for external libraries, as v1.1 was missing some files in the install targed (but should still work if these have been added).

- As previously, paths to the libraries or the source code can be specified via the "maeparser_DIR" and "coordgen_DIR" macros ("maeparser" and "coordgen" are accepted both in lower and upper cases). 

- If defined, MAEPARSER_FORCE_BUILD and/or COORDGEN_FORCE_BUILD will force building the libraries from source, even if external libraries are found on the system.

- This patch has been tested (by building and running the tests) under the following environments/configurations:
    - Linux conda environment: dynamic build + external libraries.
    - Windows 7 / VS2017: dynamic build + static build + external libraries.
