### PR TITLE
Remove Unicode From AcidBasePair Name

### DIFF
--- a/rdkit/Chem/MolStandardize/charge.py
+++ b/rdkit/Chem/MolStandardize/charge.py
@@ -64,7 +64,7 @@ class AcidBasePair(object):
 #: Administration Substance Registration System Standard Operating Procedure guide.
 ACID_BASE_PAIRS = (
     AcidBasePair('-OSO3H', 'OS(=O)(=O)[OH]', 'OS(=O)(=O)[O-]'),
-    AcidBasePair('–SO3H', '[!O]S(=O)(=O)[OH]', '[!O]S(=O)(=O)[O-]'),
+    AcidBasePair('--SO3H', '[!O]S(=O)(=O)[OH]', '[!O]S(=O)(=O)[O-]'),
     AcidBasePair('-OSO2H', 'O[SD3](=O)[OH]', 'O[SD3](=O)[O-]'),
     AcidBasePair('-SO2H', '[!O][SD3](=O)[OH]', '[!O][SD3](=O)[O-]'),
     AcidBasePair('-OPO3H2', 'OP(=O)([OH])[OH]', 'OP(=O)([OH])[O-]'),

--- a/rdkit/Chem/MolStandardize/charge.py
+++ b/rdkit/Chem/MolStandardize/charge.py
@@ -64,7 +64,7 @@ class AcidBasePair(object):
 #: Administration Substance Registration System Standard Operating Procedure guide.
 ACID_BASE_PAIRS = (
     AcidBasePair('-OSO3H', 'OS(=O)(=O)[OH]', 'OS(=O)(=O)[O-]'),
-    AcidBasePair('--SO3H', '[!O]S(=O)(=O)[OH]', '[!O]S(=O)(=O)[O-]'),
+    AcidBasePair('-SO3H', '[!O]S(=O)(=O)[OH]', '[!O]S(=O)(=O)[O-]'),
     AcidBasePair('-OSO2H', 'O[SD3](=O)[OH]', 'O[SD3](=O)[O-]'),
     AcidBasePair('-SO2H', '[!O][SD3](=O)[OH]', '[!O][SD3](=O)[O-]'),
     AcidBasePair('-OPO3H2', 'OP(=O)([OH])[OH]', 'OP(=O)([OH])[O-]'),


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! 
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->
AcidBasePair Name was Incorrect.  
It was using an em dash instead of a double minus.  
This likely happened due to autocorrect in a text editor when placing it in.

#### What does this implement/fix? Explain your changes.
Replace \u2013 with --.


#### Any other comments?
It might only be one minus?  I don't know enough chemistry to know what it *should* be.
