### PR TITLE
Issue #2109: Enumerate all stereoisomers associated with StereoGroups

### DIFF
--- a/rdkit/Chem/UnitTestMol3D.py
+++ b/rdkit/Chem/UnitTestMol3D.py
@@ -326,5 +326,32 @@ class TestCase(unittest.TestCase):
                                   'F[C@@H](Cl)/C=C\\C=C\\[C@@H](F)Cl',
                                   'F[C@@H](Cl)/C=C\\C=C/[C@@H](F)Cl']))
 
+  def testEnumerateStereoisomersOnlyEnhancedStereo(self):
+    rdbase = os.environ["RDBASE"]
+    filename = os.path.join(rdbase, 'Code/GraphMol/FileParsers/test_data/two_centers_or.mol')
+    mol = Chem.MolFromMolFile(filename)
+    smiles = set(Chem.MolToSmiles(m) for m in AllChem.EnumerateStereoisomers(mol))
+    # switches the centers linked by an "OR", but not the absolute group
+    self.assertEqual(smiles, {r'C[C@@H](F)[C@@H](C)[C@@H](C)Br',
+                              r'C[C@H](F)[C@H](C)[C@@H](C)Br'})
+
+    original_smiles = Chem.MolToSmiles(mol)
+    self.assertIn(original_smiles, smiles)
+
+  def testNoExtrasIfEnumeratingAllWithEnhancedStereo(self):
+    """
+    If the onlyUnassigned option is False, make sure that enhanced stereo
+    groups aren't double-counted.
+    """
+    rdbase = os.environ["RDBASE"]
+    filename = os.path.join(rdbase, 'Code/GraphMol/FileParsers/test_data/two_centers_or.mol')
+    mol = Chem.MolFromMolFile(filename)
+
+    opts = AllChem.StereoEnumerationOptions(onlyUnassigned=False, unique=False)
+    smiles = [Chem.MolToSmiles(m) for m in AllChem.EnumerateStereoisomers(mol, opts)]
+    self.assertEqual(len(smiles), len(set(smiles)))
+    self.assertEqual(len(smiles), 2**3)
+
+
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
#### Reference Issue
<!-- Issue #2109,  Enumerate all stereoisomers associated with StereoGroups -->

#### What does this implement/fix? Explain your changes.
Since #2022, RDkit mols have had information about groups of atom
with defined relative stereochemistry (StereoGroup). This commit
allows EnumerateStereoisomers to generate stereoisomers defined
in a mol's stereo groups.

By default, this includes the stereo groups in the generated
stereoisomers. Also adds an option to constrain stereo expansion
to _only_ expand sites specified at a stereogroup. This allows
the resulting set of molecules to (optionally) retain any
ambiguity in assignment in the original mol.

#### Any other comments?

