### PR TITLE
RGroupDecomposition fixes, keep userLabels more robust onlyMatchAtRGroups

### DIFF
--- a/Code/GraphMol/RGroupDecomposition/RGroupDecomp.cpp
+++ b/Code/GraphMol/RGroupDecomposition/RGroupDecomp.cpp
@@ -574,13 +574,14 @@ struct RGroupDecompData {
       auto atm = atoms.find(userLabel);
       if (atm == atoms.end()) continue;  // label not used in the rgroup
       Atom *atom = atm->second;
-      mappings[userLabel] = ++count;
-
+      mappings[userLabel] = userLabel;
+      if(count < userLabel)
+        count = userLabel;
       if (atom->getAtomicNum() == 0) {  // add to existing dummy/rlabel
-        setRlabel(atom, count);
+        setRlabel(atom, userLabel);
       } else {  // adds new rlabel
         auto *newAt = new Atom(0);
-        setRlabel(newAt, count);
+        setRlabel(newAt, userLabel);
         atomsToAdd.push_back(std::make_pair(atom, newAt));
       }
     }

--- a/Code/GraphMol/RGroupDecomposition/Wrap/test_rgroups.py
+++ b/Code/GraphMol/RGroupDecomposition/Wrap/test_rgroups.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2017, Novartis Institutes for BioMedical Research Inc.
+#  Copyright (c) 2018, Novartis Institutes for BioMedical Research Inc.
 #  All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -164,6 +164,33 @@ C1CCO[C@@](S)(P)1
         res, unmatched = RGroupDecompose(cores, mols)
         self.assertEqual(len(res), 1)
         self.assertEqual(unmatched, [0,1,2,4])
+
+    def test_userlabels(self):
+        smis = ["C(Cl)N(N)O(O)"]
+        mols = [Chem.MolFromSmiles(smi) for smi in smis]
+        smarts = 'C([*:1])N([*:5])O([*:6])'
+        rg = RGroupDecomposition(core)
+        for m in mols:
+            rg.Add(m)
+        rg.Process()
+        self.assertEqual(rg.GetRGroupsAsColumns(asSmiles=True),
+                         {'Core': ['C(N(O[*:6])[*:5])[*:4]'],
+                          'R1': ['Cl[*:1]'],
+                          'R5': ['[H]N([H])[*:5]'],
+                          'R6': ['[H]O[*:6]']})
+
+        smarts = 'C([*:4])N([*:5])O([*:6])'
+
+        core = Chem.MolFromSmarts(smarts)
+        rg = RGroupDecomposition(core)
+        for m in mols:
+            rg.Add(m)
+        rg.Process()
+        self.assertEqual(rg.GetRGroupsAsColumns(asSmiles=True),
+                         {'Core': ['C(N(O[*:6])[*:5])[*:4]'],
+                          'R4': ['Cl[*:4]'],
+                          'R5': ['[H]N([H])[*:5]'],
+                          'R6': ['[H]O[*:6]']})
 
     def test_match_only_at_rgroups(self):
         smiles = ['c1ccccc1']#, 'c1(Cl)ccccc1', 'c1(Cl)cc(Br)ccc1']

--- a/Code/GraphMol/RGroupDecomposition/Wrap/test_rgroups.py
+++ b/Code/GraphMol/RGroupDecomposition/Wrap/test_rgroups.py
@@ -41,7 +41,7 @@ from rdkit.Chem.rdRGroupDecomposition import RGroupDecompose, RGroupDecompositio
 from collections import OrderedDict
 
 class TestCase(unittest.TestCase) :
-    def atest_multicores(self):
+    def test_multicores(self):
         cores_smi_easy = OrderedDict()
         cores_smi_hard = OrderedDict()
 
@@ -162,9 +162,21 @@ C1CCO[C@@](S)(P)1
                 Chem.MolFromSmiles("CC")]
 
         res, unmatched = RGroupDecompose(cores, mols)
-        self.assertEquals(len(res), 1)
-        self.assertEquals(unmatched, [0,1,2,4])
-        
+        self.assertEqual(len(res), 1)
+        self.assertEqual(unmatched, [0,1,2,4])
+
+    def test_match_only_at_rgroups(self):
+        smiles = ['c1ccccc1']#, 'c1(Cl)ccccc1', 'c1(Cl)cc(Br)ccc1']
+        mols = [Chem.MolFromSmiles(smi) for smi in smiles]
+
+        core1 = Chem.MolFromSmiles("c1([*:5])cc([*:6])ccc1")
+        params = RGroupDecompositionParameters()
+        params.onlyMatchAtRGroups=True
+        rg = RGroupDecomposition(core1, params)
+        for smi,m in zip(smiles,mols):
+            self.assertTrue(rg.Add(m)!=-1, smi)
+
+
 
 if __name__ == '__main__':
   unittest.main()

--- a/Code/GraphMol/RGroupDecomposition/Wrap/test_rgroups.py
+++ b/Code/GraphMol/RGroupDecomposition/Wrap/test_rgroups.py
@@ -169,12 +169,13 @@ C1CCO[C@@](S)(P)1
         smis = ["C(Cl)N(N)O(O)"]
         mols = [Chem.MolFromSmiles(smi) for smi in smis]
         smarts = 'C([*:1])N([*:5])O([*:6])'
+        core = Chem.MolFromSmarts(smarts)
         rg = RGroupDecomposition(core)
         for m in mols:
             rg.Add(m)
         rg.Process()
         self.assertEqual(rg.GetRGroupsAsColumns(asSmiles=True),
-                         {'Core': ['C(N(O[*:6])[*:5])[*:4]'],
+                         {'Core': ['C(N(O[*:6])[*:5])[*:1]'],
                           'R1': ['Cl[*:1]'],
                           'R5': ['[H]N([H])[*:5]'],
                           'R6': ['[H]O[*:6]']})


### PR DESCRIPTION
Two fixes to the RGropuDecomposition code.

 1. Using the adjustQuery method of fixing degrees wasn't working as expected, this hand-rolls a solution to reject matches not at rgroups
 2. Keep the user supplied rlabels (i.e. don't relabel)