### PR TITLE
Do not allow PandasTools to overwrite pandas settings

### DIFF
--- a/rdkit/Chem/PandasTools.py
+++ b/rdkit/Chem/PandasTools.py
@@ -134,8 +134,6 @@ try:
           file=sys.stderr)
     pd = None
   else:
-    # do not allow pandas to truncate text since PNG byte strings are lengthy
-    pd.set_option("display.max_colwidth", -1)
     # saves the default pandas rendering to allow restoration
     defPandasRendering = pd.core.frame.DataFrame.to_html
 except ImportError:
@@ -171,7 +169,9 @@ def patchPandasHTMLrepr(self, **kwargs):
   # set escape to False if not set
   kwargs['escape'] = kwargs.get('escape') or False
 
-  return defPandasRendering(self, **kwargs)
+  # do not allow pandas to truncate text since PNG byte strings are lengthy
+  with pd.option_context('display.max_colwidth', -1):
+    return defPandasRendering(self, **kwargs)
 
 
 def patchPandasHeadMethod(self, n=5):

--- a/rdkit/Chem/PandasTools.py
+++ b/rdkit/Chem/PandasTools.py
@@ -134,16 +134,8 @@ try:
           file=sys.stderr)
     pd = None
   else:
-    if 'display.width' in pd.core.config._registered_options:
-      pd.set_option('display.width', 1000000000)
-    if 'display.max_rows' in pd.core.config._registered_options:
-      pd.set_option('display.max_rows', 1000000000)
-    elif 'display.height' in pd.core.config._registered_options:
-      pd.set_option('display.height', 1000000000)
-    if 'display.max_colwidth' in pd.core.config._registered_options:
-      pd.set_option('display.max_colwidth', 1000000000)
-    if 'display.max_columns' in pd.core.config._registered_options:
-      pd.set_option('display.max_columns', 20)
+    # do not allow pandas to truncate text since PNG byte strings are lengthy
+    pd.set_option("display.max_colwidth", -1)
     # saves the default pandas rendering to allow restoration
     defPandasRendering = pd.core.frame.DataFrame.to_html
 except ImportError:
@@ -176,13 +168,10 @@ def patchPandasHTMLrepr(self, **kwargs):
   '''
   Patched default escaping of HTML control characters to allow molecule image rendering dataframes
   '''
-  formatter = fmt.DataFrameFormatter(
-    self, buf=None, columns=None, col_space=None, colSpace=None, header=True, index=True,
-    na_rep='NaN', formatters=None, float_format=None, sparsify=None, index_names=True, justify=None,
-    force_unicode=None, bold_rows=True, classes=None, escape=False)
-  formatter.to_html()
-  html = formatter.buf.getvalue()
-  return html
+  # set escape to False if not set
+  kwargs['escape'] = kwargs.get('escape') or False
+
+  return defPandasRendering(self, **kwargs)
 
 
 def patchPandasHeadMethod(self, n=5):
@@ -196,12 +185,7 @@ def patchPandasHeadMethod(self, n=5):
 
 def _get_image(x):
   """displayhook function for PNG data"""
-  s = b64encode(x).decode('ascii')
-  pd.set_option('display.max_columns', len(s) + 1000)
-  pd.set_option('display.max_rows', len(s) + 1000)
-  if len(s) + 100 > pd.get_option("display.max_colwidth"):
-    pd.set_option("display.max_colwidth", len(s) + 1000)
-  return s
+  return b64encode(x).decode('ascii')
 
 
 def _get_svg_image(mol, size=(200, 200), highlightAtoms=[]):

--- a/rdkit/Chem/UnitTestPandasTools.py
+++ b/rdkit/Chem/UnitTestPandasTools.py
@@ -35,6 +35,7 @@ class TestPandasTools(unittest.TestCase):
   def setUp(self):
     PandasTools.InstallPandasTools()
     PandasTools.ChangeMoleculeRendering(renderer='PNG')
+    PandasTools.pd.set_option('display.max_columns', None)
     self._molRepresentation = PandasTools.molRepresentation
     self._highlightSubstructures = PandasTools.highlightSubstructures
 


### PR DESCRIPTION
When PandasTools is used, setting global pandas variables like
'display.max_rows' or 'display.max_columns' have no effect. For example,
executing the following code results in printing ten rows although
'display.max_rows' is set to 5:

```python
import pandas as pd
from rdkit.Chem import PandasTools
PandasTools.RenderImagesInAllDataFrames()
pd.set_option('display.max_rows', 5)
pd.DataFrame(['some text'] * 10)
```

Solve this problem by using pandas' default HTML rendering method instead
of the DataFrameFormatter. Additionally, remove all unnecessary
'pd.set_option' calls.

<!--
Thanks for contributing a pull request! 
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.


#### Any other comments?

