### PR TITLE
Fixes #2220

### DIFF
--- a/Code/GraphMol/MolDraw2D/CMakeLists.txt
+++ b/Code/GraphMol/MolDraw2D/CMakeLists.txt
@@ -46,6 +46,12 @@ rdkit_test(moldraw2DTest1 test1.cpp LINK_LIBRARIES
   RDGeometryLib
   MolDraw2D ${RDKit_THREAD_LIBS} )
 
+rdkit_catch_test(moldraw2DTestCatch catch_tests.cpp LINK_LIBRARIES
+  ChemReactions FileParsers SmilesParse Depictor RDGeometryLib
+  RDGeneral SubstructMatch Subgraphs GraphMol MolTransforms EigenSolvers
+  RDGeometryLib
+  MolDraw2D ${RDKit_THREAD_LIBS} )
+
 rdkit_test(moldraw2DRxnTest1 rxn_test1.cpp LINK_LIBRARIES
     ChemReactions FileParsers SmilesParse Depictor RDGeometryLib
     RDGeneral SubstructMatch Subgraphs GraphMol MolTransforms EigenSolvers

--- a/Code/GraphMol/MolDraw2D/MolDraw2D.h
+++ b/Code/GraphMol/MolDraw2D/MolDraw2D.h
@@ -194,30 +194,30 @@ class RDKIT_MOLDRAW2D_EXPORT MolDraw2D {
       const ROMol &mol, const std::string &legend,
       const std::vector<int> *highlight_atoms,
       const std::vector<int> *highlight_bonds,
-      const std::map<int, DrawColour> *highlight_atom_map = NULL,
-      const std::map<int, DrawColour> *highlight_bond_map = NULL,
-      const std::map<int, double> *highlight_radii = NULL, int confId = -1);
+      const std::map<int, DrawColour> *highlight_atom_map = nullptr,
+      const std::map<int, DrawColour> *highlight_bond_map = nullptr,
+      const std::map<int, double> *highlight_radii = nullptr, int confId = -1);
 
   //! \overload
   virtual void drawMolecule(
-      const ROMol &mol, const std::vector<int> *highlight_atoms = NULL,
-      const std::map<int, DrawColour> *highlight_map = NULL,
-      const std::map<int, double> *highlight_radii = NULL, int confId = -1);
+      const ROMol &mol, const std::vector<int> *highlight_atoms = nullptr,
+      const std::map<int, DrawColour> *highlight_map = nullptr,
+      const std::map<int, double> *highlight_radii = nullptr, int confId = -1);
 
   //! \overload
   virtual void drawMolecule(
       const ROMol &mol, const std::string &legend,
-      const std::vector<int> *highlight_atoms = NULL,
-      const std::map<int, DrawColour> *highlight_map = NULL,
-      const std::map<int, double> *highlight_radii = NULL, int confId = -1);
+      const std::vector<int> *highlight_atoms = nullptr,
+      const std::map<int, DrawColour> *highlight_map = nullptr,
+      const std::map<int, double> *highlight_radii = nullptr, int confId = -1);
 
   //! \overload
   virtual void drawMolecule(
       const ROMol &mol, const std::vector<int> *highlight_atoms,
       const std::vector<int> *highlight_bonds,
-      const std::map<int, DrawColour> *highlight_atom_map = NULL,
-      const std::map<int, DrawColour> *highlight_bond_map = NULL,
-      const std::map<int, double> *highlight_radii = NULL, int confId = -1);
+      const std::map<int, DrawColour> *highlight_atom_map = nullptr,
+      const std::map<int, DrawColour> *highlight_bond_map = nullptr,
+      const std::map<int, double> *highlight_radii = nullptr, int confId = -1);
 
   //! draw multiple molecules in a grid
   /*!
@@ -247,13 +247,15 @@ class RDKIT_MOLDRAW2D_EXPORT MolDraw2D {
   */
   virtual void drawMolecules(
       const std::vector<ROMol *> &mols,
-      const std::vector<std::string> *legends = NULL,
-      const std::vector<std::vector<int>> *highlight_atoms = NULL,
-      const std::vector<std::vector<int>> *highlight_bonds = NULL,
-      const std::vector<std::map<int, DrawColour>> *highlight_atom_maps = NULL,
-      const std::vector<std::map<int, DrawColour>> *highlight_bond_maps = NULL,
-      const std::vector<std::map<int, double>> *highlight_radii = NULL,
-      const std::vector<int> *confIds = NULL);
+      const std::vector<std::string> *legends = nullptr,
+      const std::vector<std::vector<int>> *highlight_atoms = nullptr,
+      const std::vector<std::vector<int>> *highlight_bonds = nullptr,
+      const std::vector<std::map<int, DrawColour>> *highlight_atom_maps =
+          nullptr,
+      const std::vector<std::map<int, DrawColour>> *highlight_bond_maps =
+          nullptr,
+      const std::vector<std::map<int, double>> *highlight_radii = nullptr,
+      const std::vector<int> *confIds = nullptr);
 
   //! draw a ChemicalReaction
   /*!
@@ -269,8 +271,8 @@ class RDKIT_MOLDRAW2D_EXPORT MolDraw2D {
   */
   virtual void drawReaction(
       const ChemicalReaction &rxn, bool highlightByReactant = false,
-      const std::vector<DrawColour> *highlightColorsReactants = NULL,
-      const std::vector<int> *confIds = NULL);
+      const std::vector<DrawColour> *highlightColorsReactants = nullptr,
+      const std::vector<int> *confIds = nullptr);
 
   //! \name Transformations
   //@{
@@ -438,9 +440,9 @@ class RDKIT_MOLDRAW2D_EXPORT MolDraw2D {
 
   // return a DrawColour based on the contents of highlight_atoms or
   // highlight_map, falling back to atomic number by default
-  DrawColour getColour(int atom_idx,
-                       const std::vector<int> *highlight_atoms = NULL,
-                       const std::map<int, DrawColour> *highlight_map = NULL);
+  DrawColour getColour(
+      int atom_idx, const std::vector<int> *highlight_atoms = nullptr,
+      const std::map<int, DrawColour> *highlight_map = nullptr);
   DrawColour getColourByAtomicNum(int atomic_num);
 
   void extractAtomCoords(const ROMol &mol, int confId, bool updateBBox);
@@ -449,16 +451,16 @@ class RDKIT_MOLDRAW2D_EXPORT MolDraw2D {
   virtual void drawLine(const Point2D &cds1, const Point2D &cds2,
                         const DrawColour &col1, const DrawColour &col2);
   void drawBond(const ROMol &mol, const Bond *bond, int at1_idx, int at2_idx,
-                const std::vector<int> *highlight_atoms = NULL,
-                const std::map<int, DrawColour> *highlight_atom_map = NULL,
-                const std::vector<int> *highlight_bonds = NULL,
-                const std::map<int, DrawColour> *highlight_bond_map = NULL);
+                const std::vector<int> *highlight_atoms = nullptr,
+                const std::map<int, DrawColour> *highlight_atom_map = nullptr,
+                const std::vector<int> *highlight_bonds = nullptr,
+                const std::map<int, DrawColour> *highlight_bond_map = nullptr);
   void drawWedgedBond(const Point2D &cds1, const Point2D &cds2,
                       bool draw_dashed, const DrawColour &col1,
                       const DrawColour &col2);
   void drawAtomLabel(int atom_num,
-                     const std::vector<int> *highlight_atoms = NULL,
-                     const std::map<int, DrawColour> *highlight_map = NULL);
+                     const std::vector<int> *highlight_atoms = nullptr,
+                     const std::map<int, DrawColour> *highlight_map = nullptr);
   // cds1 and cds2 are 2 atoms in a ring.  Returns the perpendicular pointing
   // into
   // the ring.

--- a/Code/GraphMol/MolDraw2D/MolDraw2DUtils.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DUtils.cpp
@@ -79,7 +79,7 @@ void prepareAndDrawMolecule(MolDraw2D &drawer, const ROMol &mol,
                             int confId) {
   RWMol cpy(mol);
   prepareMolForDrawing(cpy);
-  drawer.drawMolecule(mol, legend, highlight_atoms, highlight_bonds,
+  drawer.drawMolecule(cpy, legend, highlight_atoms, highlight_bonds,
                       highlight_atom_map, highlight_bond_map, highlight_radii,
                       confId);
 }

--- a/Code/GraphMol/MolDraw2D/MolDraw2DUtils.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DUtils.cpp
@@ -7,8 +7,8 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-#include <GraphMol/MolDraw2D/MolDraw2DUtils.h>
 #include <GraphMol/MolDraw2D/MolDraw2D.h>
+#include <GraphMol/MolDraw2D/MolDraw2DUtils.h>
 
 #include <GraphMol/RWMol.h>
 #include <GraphMol/MolOps.h>
@@ -69,6 +69,21 @@ void prepareMolForDrawing(RWMol &mol, bool kekulize, bool addChiralHs,
   }
 }
 
+void prepareAndDrawMolecule(MolDraw2D &drawer, const ROMol &mol,
+                            const std::string &legend,
+                            const std::vector<int> *highlight_atoms,
+                            const std::vector<int> *highlight_bonds,
+                            const std::map<int, DrawColour> *highlight_atom_map,
+                            const std::map<int, DrawColour> *highlight_bond_map,
+                            const std::map<int, double> *highlight_radii,
+                            int confId) {
+  RWMol cpy(mol);
+  prepareMolForDrawing(cpy);
+  drawer.drawMolecule(mol, legend, highlight_atoms, highlight_bonds,
+                      highlight_atom_map, highlight_bond_map, highlight_radii,
+                      confId);
+}
+
 void updateDrawerParamsFromJSON(MolDraw2D &drawer, const char *json) {
   PRECONDITION(json, "no parameter string");
   updateDrawerParamsFromJSON(drawer, std::string(json));
@@ -119,5 +134,5 @@ void updateDrawerParamsFromJSON(MolDraw2D &drawer, const std::string &json) {
   }
 }
 
-}  // end of MolDraw2DUtils namespace
-}  // end of RDKit namespace
+}  // namespace MolDraw2DUtils
+}  // namespace RDKit

--- a/Code/GraphMol/MolDraw2D/MolDraw2DUtils.h
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DUtils.h
@@ -13,10 +13,14 @@
 #define MOLDRAW2DUTILS_H
 #include <GraphMol/RWMol.h>
 
+#include <boost/tuple/tuple.hpp>
+
 // ****************************************************************************
 
 namespace RDKit {
+typedef boost::tuple<float, float, float> DrawColour;
 class MolDraw2D;
+
 namespace MolDraw2DUtils {
 //! Does some cleanup operations on the molecule to prepare it to draw nicely
 /*
@@ -35,12 +39,42 @@ happens the molecule will be in an inconsistent, partially kekulized, state.
 This isn't normally a problem for molecules that have been sanitized, but can be
 problematic if the molecules have been modified post santitization.
 */
-RDKIT_MOLDRAW2D_EXPORT void prepareMolForDrawing(RWMol &mol, bool kekulize = true,
-                          bool addChiralHs = true, bool wedgeBonds = true,
-                          bool forceCoords = false);
+RDKIT_MOLDRAW2D_EXPORT void prepareMolForDrawing(RWMol &mol,
+                                                 bool kekulize = true,
+                                                 bool addChiralHs = true,
+                                                 bool wedgeBonds = true,
+                                                 bool forceCoords = false);
 
-RDKIT_MOLDRAW2D_EXPORT void updateDrawerParamsFromJSON(MolDraw2D &drawer, const char *json);
-RDKIT_MOLDRAW2D_EXPORT void updateDrawerParamsFromJSON(MolDraw2D &drawer, const std::string &json);
-}
-}
+//! prepare a molecule for drawing and draw it
+/*
+  \param mol: the molecule to draw
+  \param legend: (optional) the legend (to be drawn under the molecule)
+  \param highlight_atoms: (optional) vector of atom ids to highlight
+  \param highlight_atoms: (optional) vector of bond ids to highlight
+  \param highlight_atom_map: (optional) map from atomId -> DrawColour
+            providing the highlight colors. If not provided the default
+            higlight colour from \c drawOptions() will be used.
+  \param highlight_bond_map: (optional) map from bondId -> DrawColour
+            providing the highlight colors. If not provided the default
+            highlight colour from \c drawOptions() will be used.
+  \param highlight_radii: (optional) map from atomId -> radius (in molecule
+            coordinates) for the radii of atomic highlights. If not provided
+            the default value from \c drawOptions() will be used.
+  \param confId: (optional) conformer ID to be used for atomic coordinates
+
+*/
+RDKIT_MOLDRAW2D_EXPORT void prepareAndDrawMolecule(
+    MolDraw2D &drawer, const ROMol &mol, const std::string &legend = "",
+    const std::vector<int> *highlight_atoms = nullptr,
+    const std::vector<int> *highlight_bonds = nullptr,
+    const std::map<int, DrawColour> *highlight_atom_map = nullptr,
+    const std::map<int, DrawColour> *highlight_bond_map = nullptr,
+    const std::map<int, double> *highlight_radii = nullptr, int confId = -1);
+
+RDKIT_MOLDRAW2D_EXPORT void updateDrawerParamsFromJSON(MolDraw2D &drawer,
+                                                       const char *json);
+RDKIT_MOLDRAW2D_EXPORT void updateDrawerParamsFromJSON(MolDraw2D &drawer,
+                                                       const std::string &json);
+}  // namespace MolDraw2DUtils
+}  // namespace RDKit
 #endif  // MOLDRAW2DUTILS_H

--- a/Code/GraphMol/MolDraw2D/Wrap/rdMolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/Wrap/rdMolDraw2D.cpp
@@ -129,6 +129,31 @@ void drawMoleculeHelper2(MolDraw2D &self, const ROMol &mol,
   delete hbm;
   delete har;
 }
+
+void prepareAndDrawMoleculeHelper(MolDraw2D &drawer, const ROMol &mol,
+                         std::string legend,
+                         python::object highlight_atoms,
+                         python::object highlight_bonds,
+                         python::object highlight_atom_map,
+                         python::object highlight_bond_map,
+                         python::object highlight_atom_radii, int confId) {
+  std::unique_ptr<std::vector<int>> highlightAtoms =
+      pythonObjectToVect(highlight_atoms, static_cast<int>(mol.getNumAtoms()));
+  std::unique_ptr<std::vector<int>> highlightBonds =
+      pythonObjectToVect(highlight_bonds, static_cast<int>(mol.getNumBonds()));
+  // FIX: support these
+  ColourPalette *ham = pyDictToColourMap(highlight_atom_map);
+  ColourPalette *hbm = pyDictToColourMap(highlight_bond_map);
+  std::map<int, double> *har = pyDictToDoubleMap(highlight_atom_radii);
+  MolDraw2DUtils::prepareAndDrawMolecule(drawer, mol, legend, highlightAtoms.get(), 
+                                         highlightBonds.get(), ham, hbm, har, confId);
+
+  delete ham;
+  delete hbm;
+  delete har;
+}
+
+
 void drawMoleculesHelper2(MolDraw2D &self, python::object pmols,
                           python::object highlight_atoms,
                           python::object highlight_bonds,
@@ -492,4 +517,16 @@ BOOST_PYTHON_MODULE(rdMolDraw2D) {
        python::arg("forceCoords") = false),
       docString.c_str(),
       python::return_value_policy<python::manage_new_object>());
+  python::def(
+          "PrepareAndDrawMolecule", &RDKit::prepareAndDrawMoleculeHelper,
+          (python::arg("drawer"), python::arg("mol"),python::arg("legend") = "",
+           python::arg("highlightAtoms") = python::object(), 
+           python::arg("highlightBonds") = python::object(),
+           python::arg("highlightAtomColors") = python::object(),
+           python::arg("highlightBondColors") = python::object(),
+           python::arg("highlightAtomRadii") = python::object(),
+           python::arg("confId") = -1),
+          "Preps a molecule for drawing and actually draws it\n");
+
+
 }

--- a/Code/GraphMol/MolDraw2D/Wrap/testMolDraw2D.py
+++ b/Code/GraphMol/MolDraw2D/Wrap/testMolDraw2D.py
@@ -312,6 +312,13 @@ M  END""")
     self.assertTrue(txt.find("stroke-width:2px") == -1)
     self.assertTrue(txt.find("stroke-width:4px") >= 0)
  
+  def testPrepareAndDrawMolecule(self):
+    m = Chem.MolFromSmiles("C1N[C@@H]2OCC12")
+    d = Draw.MolDraw2DSVG(300, 300)
+    rdMolDraw2D.PrepareAndDrawMolecule(d,m)
+    d.FinishDrawing()
+    txt = d.GetDrawingText()
+    self.assertTrue(txt.find("<tspan>H</tspan>")>0)
 
 
 if __name__ == "__main__":

--- a/Code/GraphMol/MolDraw2D/catch_tests.cpp
+++ b/Code/GraphMol/MolDraw2D/catch_tests.cpp
@@ -32,6 +32,5 @@ TEST_CASE("prepareAndDrawMolecule", "[drawing]") {
     drawer.finishDrawing();
     std::string text = drawer.getDrawingText();
     CHECK(text.find("<tspan>H</tspan>")!=std::string::npos);
-    std::cerr << text << std::endl;
   }
 }

--- a/Code/GraphMol/MolDraw2D/catch_tests.cpp
+++ b/Code/GraphMol/MolDraw2D/catch_tests.cpp
@@ -22,7 +22,7 @@ using namespace RDKit;
 
 TEST_CASE("prepareAndDrawMolecule", "[drawing]") {
   SECTION("basics") {
-    auto m1 = "C[C@H](F)Cl"_smiles;
+    auto m1 = "C1N[C@@H]2OCC12"_smiles;
     REQUIRE(m1);
 
     // we will be able to recognize that the prep worked because there
@@ -31,6 +31,7 @@ TEST_CASE("prepareAndDrawMolecule", "[drawing]") {
     MolDraw2DUtils::prepareAndDrawMolecule(drawer, *m1);
     drawer.finishDrawing();
     std::string text = drawer.getDrawingText();
+    CHECK(text.find("<tspan>H</tspan>")!=std::string::npos);
     std::cerr << text << std::endl;
   }
 }

--- a/Code/GraphMol/MolDraw2D/catch_tests.cpp
+++ b/Code/GraphMol/MolDraw2D/catch_tests.cpp
@@ -1,0 +1,36 @@
+//
+//  Copyright (C) 2019 Greg Landrum
+//
+//   @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
+//
+#define CATCH_CONFIG_MAIN  // This tells Catch to provide a main() - only do
+                           // this in one cpp file
+#include "catch.hpp"
+
+#include <GraphMol/RDKitBase.h>
+
+#include <GraphMol/SmilesParse/SmilesParse.h>
+#include <GraphMol/MolDraw2D/MolDraw2D.h>
+#include <GraphMol/MolDraw2D/MolDraw2DSVG.h>
+#include <GraphMol/MolDraw2D/MolDraw2DUtils.h>
+
+using namespace RDKit;
+
+TEST_CASE("prepareAndDrawMolecule", "[drawing]") {
+  SECTION("basics") {
+    auto m1 = "C[C@H](F)Cl"_smiles;
+    REQUIRE(m1);
+
+    // we will be able to recognize that the prep worked because there
+    // will be an H in the output:
+    MolDraw2DSVG drawer(200, 200);
+    MolDraw2DUtils::prepareAndDrawMolecule(drawer, *m1);
+    drawer.finishDrawing();
+    std::string text = drawer.getDrawingText();
+    std::cerr << text << std::endl;
+  }
+}


### PR DESCRIPTION
Fixes #2220 

Adds a free function on both the C++ and Python side that takes a `Drawer` and `const ROMol` and calls `prepareMolForDrawing()` before drawing it.