### PR TITLE
Added exports for SGroup functions

### DIFF
--- a/Code/GraphMol/ROMol.h
+++ b/Code/GraphMol/ROMol.h
@@ -670,8 +670,9 @@ class RDKIT_GRAPHMOL_EXPORT ROMol : public RDProps {
   RingInfo *dp_ringInfo;
   CONF_SPTR_LIST d_confs;
   std::vector<SGroup> d_sgroups;
-  friend std::vector<SGroup> &getSGroups(ROMol &);
-  friend const std::vector<SGroup> &getSGroups(const ROMol &);
+  friend RDKIT_GRAPHMOL_EXPORT std::vector<SGroup> &getSGroups(ROMol &);
+  friend RDKIT_GRAPHMOL_EXPORT const std::vector<SGroup> &getSGroups(
+      const ROMol &);
   void clearSGroups() { d_sgroups.clear(); }
   std::vector<StereoGroup> d_stereo_groups;
 

--- a/Code/GraphMol/Sgroup.h
+++ b/Code/GraphMol/Sgroup.h
@@ -148,28 +148,28 @@ const std::vector<std::string> sGroupTypes = {
 const std::vector<std::string> sGroupSubtypes = {"ALT", "RAN", "BLO"};
 const std::vector<std::string> sGroupConnectTypes = {"HH", "HT", "EU"};
 
-bool isValidType(const std::string &type);
+RDKIT_GRAPHMOL_EXPORT bool isValidType(const std::string &type);
 
-bool isValidSubType(const std::string &type);
+RDKIT_GRAPHMOL_EXPORT bool isValidSubType(const std::string &type);
 
-bool isValidConnectType(const std::string &type);
+RDKIT_GRAPHMOL_EXPORT bool isValidConnectType(const std::string &type);
 
-bool isSGroupIdFree(const ROMol &mol, unsigned int id);
+RDKIT_GRAPHMOL_EXPORT bool isSGroupIdFree(const ROMol &mol, unsigned int id);
 
 }  // namespace SGroupChecks
 
 //! \name SGroups and molecules
 //@{
 
-std::vector<SGroup> &getSGroups(ROMol &mol);
-const std::vector<SGroup> &getSGroups(const ROMol &mol);
+RDKIT_GRAPHMOL_EXPORT std::vector<SGroup> &getSGroups(ROMol &mol);
+RDKIT_GRAPHMOL_EXPORT const std::vector<SGroup> &getSGroups(const ROMol &mol);
 
 //! Add a new SGroup. A copy is added, so we can be sure that no other
 //! references to the SGroup exist.
 /*!
   \param sgroup - SGroup to be added to the molecule.
 */
-unsigned int addSGroup(ROMol &mol, SGroup sgroup);
+RDKIT_GRAPHMOL_EXPORT unsigned int addSGroup(ROMol &mol, SGroup sgroup);
 //@}
 
 }  // namespace RDKit


### PR DESCRIPTION
#### Reference Issue

My commit of the SGroups apparently breaks compilation with DLLs under Windows due to linking problems in the FileParsers caused by missing exports for the SGroup functions.

#### What does this implement/fix? Explain your changes.
This fixes the issue by adding the required "RDKIT_GRAPHMOL_EXPORT" to the functions used in FileParsers library.

#### Any other comments?
My bad, sorry!
