### PR TITLE
Improve interactivity of output SVG

### DIFF
--- a/Code/GraphMol/MolDraw2D/MolDraw2D.h
+++ b/Code/GraphMol/MolDraw2D/MolDraw2D.h
@@ -450,11 +450,6 @@ class RDKIT_MOLDRAW2D_EXPORT MolDraw2D {
 
   virtual void drawLine(const Point2D &cds1, const Point2D &cds2,
                         const DrawColour &col1, const DrawColour &col2);
-  void drawBond(const ROMol &mol, const Bond *bond, int at1_idx, int at2_idx,
-                const std::vector<int> *highlight_atoms = nullptr,
-                const std::map<int, DrawColour> *highlight_atom_map = nullptr,
-                const std::vector<int> *highlight_bonds = nullptr,
-                const std::map<int, DrawColour> *highlight_bond_map = nullptr);
   void drawWedgedBond(const Point2D &cds1, const Point2D &cds2,
                       bool draw_dashed, const DrawColour &col1,
                       const DrawColour &col2);
@@ -495,6 +490,12 @@ class RDKIT_MOLDRAW2D_EXPORT MolDraw2D {
       const std::map<int, double> *highlight_radii);
 
   virtual void highlightCloseContacts();
+  virtual void drawBond(
+      const ROMol &mol, const Bond *bond, int at1_idx, int at2_idx,
+      const std::vector<int> *highlight_atoms = nullptr,
+      const std::map<int, DrawColour> *highlight_atom_map = nullptr,
+      const std::vector<int> *highlight_bonds = nullptr,
+      const std::map<int, DrawColour> *highlight_bond_map = nullptr);
 
   // calculate normalised perpendicular to vector between two coords
   Point2D calcPerpendicular(const Point2D &cds1, const Point2D &cds2);

--- a/Code/GraphMol/MolDraw2D/MolDraw2DSVG.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DSVG.cpp
@@ -421,24 +421,29 @@ void MolDraw2DSVG::addMoleculeMetadata(const std::vector<ROMol *> &mols,
   }
 };
 
-void MolDraw2DSVG::tagAtoms(const ROMol &mol) {
+void MolDraw2DSVG::tagAtoms(const ROMol &mol, double radius,
+                            const std::map<std::string, std::string> &events) {
   PRECONDITION(d_os, "no output stream");
-  ROMol::VERTEX_ITER this_at, end_at;
-  boost::tie(this_at, end_at) = mol.getVertices();
-  while (this_at != end_at) {
-    int this_idx = mol[*this_at]->getIdx();
-    ++this_at;
-    Point2D pos = getDrawCoords(atomCoords()[this_idx]);
-    std::string lbl = atomSyms()[this_idx].first;
-
-    d_os << "<rdkit:atom"
-         << " idx=\"" << this_idx + 1 << "\"";
-    if (lbl != "") {
-      d_os << " label=\"" << lbl << "\"";
+  for (const auto &at : mol.atoms()) {
+    auto this_idx = at->getIdx();
+    auto pos = getDrawCoords(atomCoords()[this_idx]);
+    d_os << "<circle "
+         << " cx='" << pos.x << "'"
+         << " cy='" << pos.y << "'"
+         << " r='" << (scale() * radius) << "'";
+    d_os << " class='atom-selector atom-" << this_idx;
+    if (d_activeClass != "") {
+      d_os << " " << d_activeClass;
     }
-    d_os << " x=\"" << pos.x << "\""
-         << " y=\"" << pos.y << "\""
-         << " />" << std::endl;
+    d_os << "'";
+    d_os << " style='fill:#fff;stroke:#fff;stroke-width:1px;fill-opacity:0;"
+            "stroke-opacity:0' ";
+    for (const auto &event : events) {
+      d_os << " " << event.first << "='" << event.second << "(" << this_idx
+           << ");"
+           << "'";
+    }
+    d_os << "/>\n";
   }
 }
 }  // namespace RDKit

--- a/Code/GraphMol/MolDraw2D/MolDraw2DSVG.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DSVG.cpp
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2015 Greg Landrum
+//  Copyright (C) 2015-2019 Greg Landrum
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -92,6 +92,9 @@ void MolDraw2DSVG::drawWavyLine(const Point2D &cds1, const Point2D &cds2,
   std::string col = DrawColourToSVG(colour());
   unsigned int width = lineWidth();
   d_os << "<path ";
+  if (d_activeClass != "") {
+    d_os << "class='" << d_activeClass << "' ";
+  }
   d_os << "d='M" << c1.x << "," << c1.y;
   for (unsigned int i = 0; i < nSegments; ++i) {
     Point2D startpt = cds1 + delta * i;
@@ -111,6 +114,21 @@ void MolDraw2DSVG::drawWavyLine(const Point2D &cds1, const Point2D &cds2,
   d_os << " />\n";
 }
 
+void MolDraw2DSVG::drawBond(
+    const ROMol &mol, const Bond *bond, int at1_idx, int at2_idx,
+    const std::vector<int> *highlight_atoms,
+    const std::map<int, DrawColour> *highlight_atom_map,
+    const std::vector<int> *highlight_bonds,
+    const std::map<int, DrawColour> *highlight_bond_map) {
+  PRECONDITION(bond, "bad bond");
+  std::string o_class = d_activeClass;
+  if (d_activeClass != "") d_activeClass += " ";
+  d_activeClass += boost::str(boost::format("bond-%d") % bond->getIdx());
+  MolDraw2D::drawBond(mol, bond, at1_idx, at2_idx, highlight_atoms,
+                      highlight_atom_map, highlight_bonds, highlight_bond_map);
+  d_activeClass = o_class;
+};
+
 // ****************************************************************************
 void MolDraw2DSVG::drawLine(const Point2D &cds1, const Point2D &cds2) {
   Point2D c1 = getDrawCoords(cds1);
@@ -128,6 +146,9 @@ void MolDraw2DSVG::drawLine(const Point2D &cds1, const Point2D &cds2) {
     dashString = dss.str();
   }
   d_os << "<path ";
+  if (d_activeClass != "") {
+    d_os << "class='" << d_activeClass << "' ";
+  }
   d_os << "d='M " << c1.x << "," << c1.y << " " << c2.x << "," << c2.y << "' ";
   d_os << "style='fill:none;fill-rule:evenodd;stroke:" << col
        << ";stroke-width:" << width
@@ -162,6 +183,9 @@ void MolDraw2DSVG::drawPolygon(const std::vector<Point2D> &cds) {
   unsigned int width = lineWidth();
   std::string dashString = "";
   d_os << "<path ";
+  if (d_activeClass != "") {
+    d_os << "class='" << d_activeClass << "' ";
+  }
   d_os << "d='M";
   Point2D c0 = getDrawCoords(cds[0]);
   d_os << " " << c0.x << "," << c0.y;
@@ -201,6 +225,9 @@ void MolDraw2DSVG::drawEllipse(const Point2D &cds1, const Point2D &cds2) {
        << " rx='" << w / 2 << "'"
        << " ry='" << h / 2 << "'";
 
+  if (d_activeClass != "") {
+    d_os << " class='" << d_activeClass << "'";
+  }
   d_os << " style='";
   if (fillPolys())
     d_os << "fill:" << col << ";fill-rule:evenodd;";
@@ -313,9 +340,11 @@ void MolDraw2DSVG::drawString(const std::string &str, const Point2D &cds) {
 
   d_os << "<text";
   d_os << " x='" << draw_coords.x;
-
   d_os << "' y='" << draw_coords.y << "'";
 
+  if (d_activeClass != "") {
+    d_os << " class='" << d_activeClass << "'";
+  }
   d_os << " style='font-size:" << fontSz
        << "px;font-style:normal;font-weight:normal;fill-opacity:1;stroke:none;"
           "font-family:sans-serif;text-anchor:start;"

--- a/Code/GraphMol/MolDraw2D/MolDraw2DSVG.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DSVG.cpp
@@ -57,6 +57,8 @@ void MolDraw2DSVG::initDrawing() {
         xmlns:xlink='http://www.w3.org/1999/xlink'\n          \
         xml:space='preserve'\n";
   d_os << "width='" << width() << "px' height='" << height() << "px' >\n";
+  d_os << "<!-- END OF HEADER -->\n";
+
   // d_os<<"<g transform='translate("<<width()*.05<<","<<height()*.05<<")
   // scale(.85,.85)'>";
 }

--- a/Code/GraphMol/MolDraw2D/MolDraw2DSVG.h
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DSVG.h
@@ -67,7 +67,8 @@ class RDKIT_MOLDRAW2D_EXPORT MolDraw2DSVG : public MolDraw2D {
   // this only makes sense if the object was initialized without a stream
   std::string getDrawingText() const { return d_ss.str(); };
 
-  void tagAtoms(const ROMol &mol);
+  void tagAtoms(const ROMol &mol, double radius = 0.2,
+                const std::map<std::string, std::string> &events = {});
 
   void addMoleculeMetadata(const ROMol &mol, int confId = -1) const;
   void addMoleculeMetadata(const std::vector<ROMol *> &mols,

--- a/Code/GraphMol/MolDraw2D/MolDraw2DSVG.h
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DSVG.h
@@ -77,9 +77,18 @@ class RDKIT_MOLDRAW2D_EXPORT MolDraw2DSVG : public MolDraw2D {
  private:
   std::ostream &d_os;
   std::stringstream d_ss;
+  std::string d_activeClass;
 
   void drawChar(char c, const Point2D &cds);
   void initDrawing();
+
+ protected:
+  void drawBond(
+      const ROMol &mol, const Bond *bond, int at1_idx, int at2_idx,
+      const std::vector<int> *highlight_atoms = nullptr,
+      const std::map<int, DrawColour> *highlight_atom_map = nullptr,
+      const std::vector<int> *highlight_bonds = nullptr,
+      const std::map<int, DrawColour> *highlight_bond_map = nullptr) override;
 };
 }  // namespace RDKit
 #endif  // MOLDRAW2DSVG_H

--- a/Code/GraphMol/MolDraw2D/Wrap/testMolDraw2D.py
+++ b/Code/GraphMol/MolDraw2D/Wrap/testMolDraw2D.py
@@ -320,6 +320,18 @@ M  END""")
     txt = d.GetDrawingText()
     self.assertTrue(txt.find("<tspan>H</tspan>")>0)
 
+  def testAtomTagging(self):
+    m = Chem.MolFromSmiles("C1N[C@@H]2OCC12")
+    d = Draw.MolDraw2DSVG(300, 300)
+    dm = Draw.PrepareMolForDrawing(m)
+    rdMolDraw2D.PrepareAndDrawMolecule(d,dm)
+    d.TagAtoms(dm,events={'onclick':'alert'})
+    d.FinishDrawing()
+    txt = d.GetDrawingText()
+    self.assertTrue(txt.find("<circle")>0)
+    self.assertTrue(txt.find("onclick=") > 0)
+
+
 
 if __name__ == "__main__":
   unittest.main()

--- a/Code/GraphMol/MolDraw2D/catch_tests.cpp
+++ b/Code/GraphMol/MolDraw2D/catch_tests.cpp
@@ -31,6 +31,29 @@ TEST_CASE("prepareAndDrawMolecule", "[drawing]") {
     MolDraw2DUtils::prepareAndDrawMolecule(drawer, *m1);
     drawer.finishDrawing();
     std::string text = drawer.getDrawingText();
-    CHECK(text.find("<tspan>H</tspan>")!=std::string::npos);
+    CHECK(text.find("<tspan>H</tspan>") != std::string::npos);
+  }
+}
+
+TEST_CASE("tag atoms in SVG", "[drawing, SVG]") {
+  SECTION("basics") {
+    auto m1 = "C1N[C@@H]2OCC12"_smiles;
+    REQUIRE(m1);
+
+    MolDraw2DSVG drawer(200, 200);
+    MolDraw2DUtils::prepareMolForDrawing(*m1);
+    drawer.drawMolecule(*m1);
+    std::map<std::string, std::string> actions;
+    actions["onclick"] = "alert";
+    double radius = 0.2;
+    drawer.tagAtoms(*m1, radius, actions);
+    drawer.finishDrawing();
+    std::string text = drawer.getDrawingText();
+    std::ofstream outs("testAtomTags_1.svg");
+    outs << text;
+    outs.flush();
+
+    CHECK(text.find("<circle") != std::string::npos);
+    CHECK(text.find("onclick") != std::string::npos);
   }
 }

--- a/Code/GraphMol/MolDraw2D/test1.cpp
+++ b/Code/GraphMol/MolDraw2D/test1.cpp
@@ -1245,9 +1245,10 @@ M  END";
     std::ofstream outs("test983_1.svg");
     outs << text;
     outs.flush();
-    TEST_ASSERT(text.find("<path d='M 130.309,117.496 194.727,89.1159 "
-                          "187.092,75.893 130.309,117.496' "
-                          "style='fill:#000000") != std::string::npos);
+    TEST_ASSERT(
+        text.find("<path class='bond-1' d='M 130.309,117.496 194.727,89.1159 "
+                  "187.092,75.893 130.309,117.496' "
+                  "style='fill:#000000") != std::string::npos);
     delete m;
   }
   {
@@ -1296,9 +1297,10 @@ M  END";
     std::ofstream outs("test983_2.svg");
     outs << text;
     outs.flush();
-    TEST_ASSERT(text.find("<path d='M 107.911,115.963 80.5887,91.4454 "
-                          "75.9452,97.9126 107.911,115.963' "
-                          "style='fill:#000000;") != std::string::npos);
+    TEST_ASSERT(
+        text.find("<path class='bond-3' d='M 107.911,115.963 80.5887,91.4454 "
+                  "75.9452,97.9126 107.911,115.963' "
+                  "style='fill:#000000;") != std::string::npos);
 
     MolDraw2DUtils::prepareMolForDrawing(*m);
     TEST_ASSERT(m->getBondBetweenAtoms(2, 1)->getBondType() == Bond::SINGLE);
@@ -2222,10 +2224,14 @@ M  END)molb";
     std::ofstream outs("testGithub2063_1.svg");
     outs << text;
     outs.flush();
-    TEST_ASSERT(text.find("<path d='M 65.8823,110.884 134.118,89.1159'") !=
-                std::string::npos);
-    TEST_ASSERT(text.find("<path d='M 69.6998,117.496 9.09091,82.5044'") !=
-                std::string::npos);
+    TEST_ASSERT(
+        text.find(
+            "<path class='bond-0' d='M 65.8823,110.884 134.118,89.1159'") !=
+        std::string::npos);
+    TEST_ASSERT(
+        text.find(
+            "<path class='bond-1' d='M 69.6998,117.496 9.09091,82.5044'") !=
+        std::string::npos);
   }
   {
     std::string molb = R"molb(crossed bond
@@ -2252,10 +2258,14 @@ M  END)molb";
     std::ofstream outs("testGithub2063_2.svg");
     outs << text;
     outs.flush();
-    TEST_ASSERT(text.find("<path d='M 65.8823,110.884 134.118,89.1159'") !=
-                std::string::npos);
-    TEST_ASSERT(text.find("<path d='M 69.6998,117.496 9.09091,82.5044'") !=
-                std::string::npos);
+    TEST_ASSERT(
+        text.find(
+            "<path class='bond-0' d='M 65.8823,110.884 134.118,89.1159'") !=
+        std::string::npos);
+    TEST_ASSERT(
+        text.find(
+            "<path class='bond-1' d='M 69.6998,117.496 9.09091,82.5044'") !=
+        std::string::npos);
   }
   std::cerr << " Done" << std::endl;
 }


### PR DESCRIPTION
Allows atoms to be selected by adding a transparent circle on top of them with `tagAtoms()` is called. These can have JS events associated with them.

Here's an example, part of the output from `d.TagAtoms(dm,events={'onclick':'alert'})`:
```
<circle  cx='45.869' cy='261.564' r='14.8752' class='atom-selector atom-0' style='fill:#fff;stroke:#fff;stroke-width:1px;fill-opacity:0;stroke-opacity:0'  onclick='alert(0);'/>
<circle  cx='45.869' cy='150' r='14.8752' class='atom-selector atom-1' style='fill:#fff;stroke:#fff;stroke-width:1px;fill-opacity:0;stroke-opacity:0'  onclick='alert(1);'/>

```
Also adds a class to lines from each bond with bond IDs:

Example for a bond:
```
<path class='bond-4' d='M 268.997,261.564 157.433,261.564' style='fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1'/>
```

Finally, this removes the old-style metadata that `tagAtoms()` used to add. The information provided by `addMoleculeMetadata()` is better.