### PR TITLE
don't use a ctab as input for the computation of 2D coordinates

### DIFF
--- a/External/AvalonTools/AvalonTools.cpp
+++ b/External/AvalonTools/AvalonTools.cpp
@@ -222,8 +222,16 @@ namespace AvalonTools {
 
     auto *conf = new RDKit::Conformer(mol.getNumAtoms());
     conf->set3D(false);
+
+    // Atoms in the intermediate smiles representation may be ordered
+    // differently compared to the original input molecule.
+    // Make sure that output coordinates are assigned in the correct order.
+    std::vector<unsigned int> atomOrdering;
+    mol.getProp(common_properties::_smilesAtomOutputOrder, atomOrdering);
     for(unsigned int i=0;i<mol.getNumAtoms();++i){
-      RDGeom::Point3D loc(mp2->atom_array[i].x,mp2->atom_array[i].y,mp2->atom_array[i].z);
+      auto x = mp2->atom_array[atomOrdering[i]].x;
+      auto y = mp2->atom_array[atomOrdering[i]].y;
+      RDGeom::Point3D loc(x,y,0.);
       conf->setAtomPos(i,loc);
     }
 

--- a/External/AvalonTools/AvalonTools.cpp
+++ b/External/AvalonTools/AvalonTools.cpp
@@ -85,7 +85,7 @@ namespace AvalonTools {
 
       MyFree(fingerprint);
     };
-  
+
     void reaccsToCounts(struct reaccs_molecule_t *molPtr,SparseIntVect<boost::uint32_t> &res,
                         unsigned int bitFlags=32767U,bool isQuery=false,
                         unsigned int nBytes=64){
@@ -99,7 +99,7 @@ namespace AvalonTools {
       }
       MyFree((char *)fingerprint);
     };
-  
+
     void reaccsToFingerprint(struct reaccs_molecule_t *molPtr,ExplicitBitVect &res,
                              unsigned int bitFlags=32767U,bool isQuery=false,
                              bool resetVect=true,unsigned int nBytes=64){
@@ -123,7 +123,7 @@ namespace AvalonTools {
       }
       MyFree(fingerprint);
     };
-  
+
     struct reaccs_molecule_t *reaccsGetCoords(struct reaccs_molecule_t *molPtr){
       PRECONDITION(molPtr,"bad molecule");
 
@@ -170,7 +170,7 @@ namespace AvalonTools {
     } else {
       std::string rdMB=MolToMolBlock(mol);
       res = getCanonSmiles(rdMB,false,flags);
-      
+
     }
     return res;
   }
@@ -215,7 +215,8 @@ namespace AvalonTools {
   }
 
   unsigned int set2DCoords(ROMol &mol,bool clearConfs){
-    struct reaccs_molecule_t *mp=molToReaccs(mol);
+    auto smiles = MolToSmiles(mol);
+    struct reaccs_molecule_t *mp=stringToReaccs(smiles,true);
     struct reaccs_molecule_t *mp2=reaccsGetCoords(mp);
     TEST_ASSERT(mp2->n_atoms==mol.getNumAtoms());
 
@@ -252,7 +253,7 @@ namespace AvalonTools {
       FreeMolecule(mp);
       FreeMolecule(mp2);
       MyFree(molB);
-    } 
+    }
     return res;
   }
 
@@ -338,7 +339,7 @@ namespace AvalonTools {
     }
     return res;
   }
-  
+
   /**
    * Wrapper around struchk.CheckMol
    * The molecule to check is passed in as a string. isSmiles
@@ -349,7 +350,7 @@ namespace AvalonTools {
    **/
   int checkMolString(const std::string &data, const bool isSmiles,
 		     struct reaccs_molecule_t **mp) {
-	// clean msg list from previous call (if no previous call, freemsglist does nothing)	
+	// clean msg list from previous call (if no previous call, freemsglist does nothing)
     FreeMsgList();
 
     int errs = 0;
@@ -388,7 +389,7 @@ namespace AvalonTools {
   }
 
   RDKit::ROMOL_SPTR checkMol(int &errs, RDKit::ROMol& inMol) {
-	// clean msg list from previous call (if no previous call, freemsglist does nothing)	
+	// clean msg list from previous call (if no previous call, freemsglist does nothing)
     FreeMsgList();
 
     struct reaccs_molecule_t *mp;

--- a/External/AvalonTools/Wrap/testAvalonTools.py
+++ b/External/AvalonTools/Wrap/testAvalonTools.py
@@ -262,6 +262,15 @@ class TestCase(unittest.TestCase):
     self.assertEqual(m.GetNumConformers(), 1)
     self.assertTrue(m.GetConformer(0).Is3D() == False)
 
+  def testGitHub1062(self):
+    s1 = 'C/C=C\C'
+    m1 = Chem.MolFromSmiles(s1)
+    pyAvalonTools.Generate2DCoords(m1)
+    mb = Chem.MolToMolBlock(m1)
+    m2 = Chem.MolFromMolBlock(mb)
+    s2 = Chem.MolToSmiles(m2)
+    self.assertEqual(s1, s2)
+
   def testRDK151(self):
     smi = "C[C@H](F)Cl"
     m = Chem.MolFromSmiles(smi)
@@ -301,7 +310,7 @@ class TestCase(unittest.TestCase):
       (err, fixed_mol) = pyAvalonTools.CheckMoleculeString(atom_clash, False)
       log =  pyAvalonTools.GetCheckMolLog()
       self.assertTrue("of average bond length from bond" in log)
-      
+
       # make sure that the log is cleared for the next molecule
       (err, fixed_mol) = pyAvalonTools.CheckMoleculeString("c1ccccc1", True)
       log =  pyAvalonTools.GetCheckMolLog()
@@ -309,7 +318,7 @@ class TestCase(unittest.TestCase):
 
     finally:
       pyAvalonTools.CloseCheckMolFiles()
-    
+
 
   #   def testIsotopeBug(self):
   #     mb="""D isotope problem.mol

--- a/External/AvalonTools/Wrap/testAvalonTools.py
+++ b/External/AvalonTools/Wrap/testAvalonTools.py
@@ -263,13 +263,28 @@ class TestCase(unittest.TestCase):
     self.assertTrue(m.GetConformer(0).Is3D() == False)
 
   def testGitHub1062(self):
-    s1 = 'C/C=C\C'
-    m1 = Chem.MolFromSmiles(s1)
+    s0 = 'C/C=C\C'
+    m1 = Chem.MolFromSmiles(s0)
+    s1 = Chem.MolToSmiles(m1)
     pyAvalonTools.Generate2DCoords(m1)
     mb = Chem.MolToMolBlock(m1)
     m2 = Chem.MolFromMolBlock(mb)
     s2 = Chem.MolToSmiles(m2)
     self.assertEqual(s1, s2)
+
+    # repeat the test with an input smiles that is not canonical
+    # to verify that the implementation is not sensitive to the
+    # ordering of atoms
+    s0 = 'C/C=C(F)\C'
+    m1 = Chem.MolFromSmiles(s0)
+    s1 = Chem.MolToSmiles(m1)
+    self.assertNotEqual(s1, s0)
+    pyAvalonTools.Generate2DCoords(m1)
+    mb = Chem.MolToMolBlock(m1)
+    m2 = Chem.MolFromMolBlock(mb)
+    s2 = Chem.MolToSmiles(m2)
+    self.assertEqual(s1, s2)
+
 
   def testRDK151(self):
     smi = "C[C@H](F)Cl"

--- a/External/AvalonTools/test1.cpp
+++ b/External/AvalonTools/test1.cpp
@@ -12,6 +12,7 @@
 #include <RDGeneral/RDLog.h>
 #include <GraphMol/RDKitBase.h>
 #include <GraphMol/SmilesParse/SmilesParse.h>
+#include <GraphMol/SmilesParse/SmilesWrite.h>
 #include <GraphMol/FileParsers/FileParsers.h>
 #include <RDGeneral/Invariant.h>
 #include <DataStructs/ExplicitBitVect.h>
@@ -156,6 +157,22 @@ void test3() {
   }
 
   BOOST_LOG(rdInfoLog) << "done" << std::endl;
+}
+
+void testGitHub1062() {
+  BOOST_LOG(rdInfoLog) << "testing GitHub issue #1062:  pyAvalonTools not "
+                          "preserving the stereochemistry of double bonds when "
+                          "computing 2D coordinates"
+                       << std::endl;
+  std::string s1 = "C/C=C\\C";
+  ROMol * m1 = SmilesToMol(s1);
+  AvalonTools::set2DCoords(*m1);
+  std::string mb = MolToMolBlock(*m1);
+  ROMol * m2 = MolBlockToMol(mb);
+  std::string s2 = MolToSmiles(*m2);
+  delete m1;
+  delete m2;
+  TEST_ASSERT(s1 == s2);
 }
 
 void testRDK151() {
@@ -422,6 +439,7 @@ int main() {
   test1();
   test2();
   test3();
+  testGitHub1062();
   testRDK151();
   testSmilesFailures();
   testSubstructFps();

--- a/External/AvalonTools/test1.cpp
+++ b/External/AvalonTools/test1.cpp
@@ -164,15 +164,34 @@ void testGitHub1062() {
                           "preserving the stereochemistry of double bonds when "
                           "computing 2D coordinates"
                        << std::endl;
-  std::string s1 = "C/C=C\\C";
-  ROMol * m1 = SmilesToMol(s1);
-  AvalonTools::set2DCoords(*m1);
-  std::string mb = MolToMolBlock(*m1);
-  ROMol * m2 = MolBlockToMol(mb);
-  std::string s2 = MolToSmiles(*m2);
-  delete m1;
-  delete m2;
-  TEST_ASSERT(s1 == s2);
+  {
+    std::string s0 = "C/C=C\\C";
+    ROMol * m1 = SmilesToMol(s0);
+    auto s1 = MolToSmiles(*m1);
+    AvalonTools::set2DCoords(*m1);
+    std::string mb = MolToMolBlock(*m1);
+    ROMol * m2 = MolBlockToMol(mb);
+    std::string s2 = MolToSmiles(*m2);
+    delete m1;
+    delete m2;
+    TEST_ASSERT(s1 == s2);
+  }
+  {
+    // repeat the test with an input smiles that is not canonical
+    // to verify that the implementation is not sensitive to the
+    // ordering of atoms
+    std::string s0 = "C/C=C(F)\\C";
+    ROMol * m1 = SmilesToMol(s0);
+    auto s1 = MolToSmiles(*m1);
+    TEST_ASSERT(s1 != s0);
+    AvalonTools::set2DCoords(*m1);
+    std::string mb = MolToMolBlock(*m1);
+    ROMol * m2 = MolBlockToMol(mb);
+    std::string s2 = MolToSmiles(*m2);
+    delete m1;
+    delete m2;
+    TEST_ASSERT(s1 == s2);
+  }
 }
 
 void testRDK151() {


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! 
-->
#### Reference Issue
Fixes #1062 


#### What does this implement/fix? Explain your changes.
Works around an AvalonTools issue in the computation of 2D coordinates, that could ignore/discard the double bond stereochemistry when an intermediate ctab representation is used for an input molecule, and possibly assign inconsistent 2D layout data.

#### Any other comments?
These changes should resolve the problem in the assignment of a 2D layout. The general correctness of using a mol block in function molToReaccs is still unclear.

