### PR TITLE
keep extra information about bonds from Mol files

### DIFF
--- a/Code/GraphMol/FileParsers/MolFileParser.cpp
+++ b/Code/GraphMol/FileParsers/MolFileParser.cpp
@@ -1326,7 +1326,7 @@ Atom *ParseMolFileAtomLine(const std::string text, RDGeom::Point3D &pos,
 }
 
 Bond *ParseMolFileBondLine(const std::string &text, unsigned int line) {
-  int idx1, idx2, bType, stereo;
+  unsigned int idx1, idx2, bType, stereo;
   int spos = 0;
 
   if (text.size() < 9) {
@@ -1423,6 +1423,7 @@ Bond *ParseMolFileBondLine(const std::string &text, unsigned int line) {
   res->setBeginAtomIdx(idx1);
   res->setEndAtomIdx(idx2);
   res->setBondType(type);
+  res->setProp(common_properties::_MolFileBondType, bType);
 
   if (text.size() >= 12 && text.substr(9, 3) != "  0") {
     try {
@@ -1445,6 +1446,7 @@ Bond *ParseMolFileBondLine(const std::string &text, unsigned int line) {
           res->setBondDir(Bond::UNKNOWN);
           break;
       }
+      res->setProp(common_properties::_MolFileBondStereo, stereo);
     } catch (boost::bad_lexical_cast &) {
       ;
     }
@@ -2173,6 +2175,7 @@ void ParseV3000BondBlock(std::istream *inStream, unsigned int &line,
         }
         break;
     }
+    bond->setProp(common_properties::_MolFileBondType, bType);
 
     // additional bond properties:
     unsigned int lPos = 4;
@@ -2209,6 +2212,7 @@ void ParseV3000BondBlock(std::istream *inStream, unsigned int &line,
             errout << "bad bond CFG " << val << "' on line " << line;
             throw FileParseException(errout.str());
         }
+        bond->setProp(common_properties::_MolFileBondCfg, cfg);
       } else if (prop == "TOPO") {
         if (val != "0") {
           if (!bond->hasQuery()) {

--- a/Code/GraphMol/FileParsers/catch_tests.cpp
+++ b/Code/GraphMol/FileParsers/catch_tests.cpp
@@ -216,3 +216,58 @@ TEST_CASE(
     REQUIRE(mol2->getBondWithIdx(7)->hasQuery());
   }
 }
+TEST_CASE("preserve mol file properties on bonds", "[parser,ctab]") {
+  SECTION("basics") {
+    std::string molblock = R"CTAB(
+  Mrv1810 02111915042D          
+
+  4  3  0  0  0  0            999 V2000
+   -1.5625    1.6071    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -0.8480    2.0196    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -2.2770    2.0196    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -1.5625    0.7821    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+  1  3  1  0  0  0  0
+  1  2  6  0  0  0  0
+  1  4  1  1  0  0  0
+M  END
+      )CTAB";
+    std::unique_ptr<ROMol> mol(MolBlockToMol(molblock));
+    REQUIRE(mol);
+    CHECK(mol->getBondWithIdx(1)->getProp<unsigned int>(
+              common_properties::_MolFileBondType) == 6);
+    CHECK(mol->getBondWithIdx(2)->getProp<unsigned int>(
+              common_properties::_MolFileBondType) == 1);
+    CHECK(mol->getBondWithIdx(2)->getProp<unsigned int>(
+              common_properties::_MolFileBondStereo) == 1);
+  }
+  SECTION("basics-v3k") {
+    std::string molblock = R"CTAB(
+  Mrv1810 02111915102D          
+
+  0  0  0     0  0            999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 4 3 0 0 0
+M  V30 BEGIN ATOM
+M  V30 1 C -2.9167 3 0 0
+M  V30 2 C -1.583 3.77 0 0
+M  V30 3 C -4.2503 3.77 0 0
+M  V30 4 C -2.9167 1.46 0 0
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 1 1 3
+M  V30 2 6 1 2
+M  V30 3 1 1 4 CFG=1
+M  V30 END BOND
+M  V30 END CTAB
+M  END
+)CTAB";
+    std::unique_ptr<ROMol> mol(MolBlockToMol(molblock));
+    REQUIRE(mol);
+    CHECK(mol->getBondWithIdx(1)->getProp<unsigned int>(
+              common_properties::_MolFileBondType) == 6);
+    CHECK(mol->getBondWithIdx(2)->getProp<unsigned int>(
+              common_properties::_MolFileBondType) == 1);
+    CHECK(mol->getBondWithIdx(2)->getProp<unsigned int>(
+              common_properties::_MolFileBondCfg) == 1);
+  }
+}

--- a/Code/RDGeneral/types.cpp
+++ b/Code/RDGeneral/types.cpp
@@ -42,6 +42,10 @@ const std::string _MolFileAtomQuery = "_MolFileAtomQuery";
 const std::string _MolFileBondQuery = "_MolFileBondQuery";
 const std::string _MolFileBondEndPts = "_MolFileBondEndPts";
 const std::string _MolFileBondAttach = "_MolFileBondAttach";
+const std::string _MolFileBondType = "_MolFileBondType";
+const std::string _MolFileBondStereo = "_MolFileBondStereo";
+const std::string _MolFileBondCfg = "_MolFileBondCfg";
+
 const std::string _Name = "_Name";
 const std::string _NeedsQueryScan = "_NeedsQueryScan";
 const std::string _QueryFormalCharge = "_QueryFormalCharge";

--- a/Code/RDGeneral/types.h
+++ b/Code/RDGeneral/types.h
@@ -167,6 +167,12 @@ RDKIT_RDGENERAL_EXPORT extern const std::string _MolFileAtomQuery;   // int
 RDKIT_RDGENERAL_EXPORT extern const std::string _MolFileBondQuery;   // int
 RDKIT_RDGENERAL_EXPORT extern const std::string _MolFileBondEndPts;  // string
 RDKIT_RDGENERAL_EXPORT extern const std::string _MolFileBondAttach;  // string
+RDKIT_RDGENERAL_EXPORT extern const std::string _MolFileBondType;    // unsigned int
+RDKIT_RDGENERAL_EXPORT extern const std::string
+    _MolFileBondStereo;  // unsigned int
+RDKIT_RDGENERAL_EXPORT extern const std::string
+    _MolFileBondCfg;  // unsigned int
+
 RDKIT_RDGENERAL_EXPORT extern const std::string
     MRV_SMA;  // smarts string from Marvin
 RDKIT_RDGENERAL_EXPORT extern const std::string dummyLabel;  // atom string


### PR DESCRIPTION
There's always some processing applied to molecules read from CTABs which has the side effect of removing info from bonds.
This adds the stereo and bond-type information from the CTAB as bond properties so that we can access them later if we care to.