### PR TITLE
Fixes #2266

### DIFF
--- a/Code/GraphMol/Chirality.cpp
+++ b/Code/GraphMol/Chirality.cpp
@@ -444,7 +444,6 @@ bool atomIsCandidateForRingStereochem(const ROMol &mol, const Atom *atom) {
         }
         ++beg;
       }
-
       unsigned int rank1 = 0, rank2 = 0;
       switch (nonRingNbrs.size()) {
         case 2:
@@ -460,7 +459,7 @@ bool atomIsCandidateForRingStereochem(const ROMol &mol, const Atom *atom) {
           }
           break;
         case 1:
-          if (ringNbrs.size() == 2) res = true;
+          if (ringNbrs.size() >= 2) res = true;
           break;
         case 0:
           if (ringNbrs.size() == 4 && nbrRanks.size() == 3) {
@@ -1164,9 +1163,9 @@ void assignStereochemistry(ROMol &mol, bool cleanIt, bool force,
   mol.setProp(common_properties::_StereochemDone, 1, true);
 
 #if 0
-      std::cerr<<"---\n";
-      mol.debugMol(std::cerr);
-      std::cerr<<"<<<<<<<<<<<<<<<<\n";
+  std::cerr << "---\n";
+  mol.debugMol(std::cerr);
+  std::cerr << "<<<<<<<<<<<<<<<<\n";
 #endif
 }
 

--- a/Code/GraphMol/FileParsers/catch_tests.cpp
+++ b/Code/GraphMol/FileParsers/catch_tests.cpp
@@ -271,3 +271,110 @@ M  END
               common_properties::_MolFileBondCfg) == 1);
   }
 }
+
+TEST_CASE(
+    "github #2266: missing stereo in adamantyl-like cages with "
+    "exocyclic bonds",
+    "[bug]") {
+  SECTION("basics") {
+    std::string molblock = R"CTAB(
+        SciTegic12231509382D
+
+ 14 16  0  0  0  0            999 V2000
+    1.5584   -5.7422    0.0000 C   0  0
+    2.2043   -5.0535    0.0000 C   0  0  2  0  0  0
+    2.3688   -5.5155    0.0000 C   0  0  1  0  0  0
+    2.9210   -5.3181    0.0000 C   0  0
+    3.1270   -5.8206    0.0000 C   0  0
+    3.6744   -5.1312    0.0000 C   0  0  2  0  0  0
+    2.3619   -4.6609    0.0000 C   0  0
+    2.9268   -3.9939    0.0000 C   0  0  2  0  0  0
+    2.1999   -4.2522    0.0000 C   0  0
+    3.6803   -4.3062    0.0000 C   0  0
+    2.9436   -3.1692    0.0000 N   0  0
+    4.4569   -5.4095    0.0000 H   0  0
+    2.3246   -6.3425    0.0000 H   0  0
+    1.4365   -4.7500    0.0000 H   0  0
+  1  2  1  0
+  1  3  1  0
+  2  4  1  0
+  3  5  1  0
+  4  6  1  0
+  5  6  1  0
+  7  8  1  0
+  3  7  1  0
+  2  9  1  0
+  6 10  1  0
+ 10  8  1  0
+  8  9  1  0
+  8 11  1  1
+  6 12  1  6
+  3 13  1  1
+  2 14  1  6
+M  END)CTAB";
+    {
+      std::unique_ptr<ROMol> mol(MolBlockToMol(molblock));
+      REQUIRE(mol);
+      CHECK(mol->getNumAtoms() == 11);
+      CHECK(mol->getAtomWithIdx(1)->getChiralTag() != Atom::CHI_UNSPECIFIED);
+      CHECK(mol->getAtomWithIdx(2)->getChiralTag() != Atom::CHI_UNSPECIFIED);
+      CHECK(mol->getAtomWithIdx(5)->getChiralTag() != Atom::CHI_UNSPECIFIED);
+    }
+    {
+      bool sanitize = true;
+      bool removeHs = false;
+      std::unique_ptr<ROMol> mol(MolBlockToMol(molblock, sanitize, removeHs));
+      REQUIRE(mol);
+      CHECK(mol->getNumAtoms() == 14);
+
+      CHECK(mol->getAtomWithIdx(1)->getChiralTag() != Atom::CHI_UNSPECIFIED);
+      CHECK(mol->getAtomWithIdx(2)->getChiralTag() != Atom::CHI_UNSPECIFIED);
+      CHECK(mol->getAtomWithIdx(5)->getChiralTag() != Atom::CHI_UNSPECIFIED);
+    }
+  }
+  SECTION("with F") {
+    std::string molblock = R"CTAB(
+        SciTegic12231509382D
+
+ 14 16  0  0  0  0            999 V2000
+    1.5584   -5.7422    0.0000 C   0  0
+    2.2043   -5.0535    0.0000 C   0  0  2  0  0  0
+    2.3688   -5.5155    0.0000 C   0  0  1  0  0  0
+    2.9210   -5.3181    0.0000 C   0  0
+    3.1270   -5.8206    0.0000 C   0  0
+    3.6744   -5.1312    0.0000 C   0  0  2  0  0  0
+    2.3619   -4.6609    0.0000 C   0  0
+    2.9268   -3.9939    0.0000 C   0  0  2  0  0  0
+    2.1999   -4.2522    0.0000 C   0  0
+    3.6803   -4.3062    0.0000 C   0  0
+    2.9436   -3.1692    0.0000 N   0  0
+    4.4569   -5.4095    0.0000 F   0  0
+    2.3246   -6.3425    0.0000 F   0  0
+    1.4365   -4.7500    0.0000 F   0  0
+  1  2  1  0
+  1  3  1  0
+  2  4  1  0
+  3  5  1  0
+  4  6  1  0
+  5  6  1  0
+  7  8  1  0
+  3  7  1  0
+  2  9  1  0
+  6 10  1  0
+ 10  8  1  0
+  8  9  1  0
+  8 11  1  1
+  6 12  1  6
+  3 13  1  1
+  2 14  1  6
+M  END)CTAB";
+    {
+      std::unique_ptr<ROMol> mol(MolBlockToMol(molblock));
+      REQUIRE(mol);
+      CHECK(mol->getNumAtoms() == 14);
+      CHECK(mol->getAtomWithIdx(1)->getChiralTag() != Atom::CHI_UNSPECIFIED);
+      CHECK(mol->getAtomWithIdx(2)->getChiralTag() != Atom::CHI_UNSPECIFIED);
+      CHECK(mol->getAtomWithIdx(5)->getChiralTag() != Atom::CHI_UNSPECIFIED);
+    }
+  }
+}

--- a/Code/GraphMol/testChirality.cpp
+++ b/Code/GraphMol/testChirality.cpp
@@ -1014,7 +1014,7 @@ void testRingStereochemistry() {
     m = SmilesToMol(smi);
     std::string smi2 = MolToSmiles(*m, true);
     BOOST_LOG(rdInfoLog) << " : " << smi2 << " " << smi1 << std::endl;
-    TEST_ASSERT(smi2 == smi1);
+    TEST_ASSERT(smi2 != smi1);
     delete m;
   }
 
@@ -2658,7 +2658,7 @@ void stereochemTester(RWMol *m, std::string expectedCIP,
                   common_properties::_CIPCode) == expectedCIP);
   TEST_ASSERT(m->getBondWithIdx(3)->getStereo() == expectedStereo);
 }
-}
+}  // namespace
 void testAssignStereochemistryFrom3D() {
   BOOST_LOG(rdInfoLog) << "-------------------------------------" << std::endl;
   BOOST_LOG(rdInfoLog) << "Testing assignStereochemistryFrom3D" << std::endl;
@@ -2697,11 +2697,13 @@ void testAssignStereochemistryFrom3D() {
 
 void testDoubleBondStereoInRings() {
   BOOST_LOG(rdInfoLog) << "-------------------------------------" << std::endl;
-  BOOST_LOG(rdInfoLog) << "Testing double bond stereochemistry in rings" << std::endl;
+  BOOST_LOG(rdInfoLog) << "Testing double bond stereochemistry in rings"
+                       << std::endl;
   std::string pathName = getenv("RDBASE");
   pathName += "/Code/GraphMol/test_data/";
   {
-    RWMol *m = MolFileToMol(pathName + "cyclohexene_3D.mol", true, false); // don't remove Hs
+    RWMol *m = MolFileToMol(pathName + "cyclohexene_3D.mol", true,
+                            false);  // don't remove Hs
     MolOps::detectBondStereochemistry(*m);
     MolOps::assignChiralTypesFrom3D(*m);
     MolOps::assignStereochemistry(*m, true, true);
@@ -2711,7 +2713,8 @@ void testDoubleBondStereoInRings() {
     delete m;
   }
   {
-    RWMol *m = MolFileToMol(pathName + "CHEMBL501674_3D.mol", true, false); // don't remove Hs
+    RWMol *m = MolFileToMol(pathName + "CHEMBL501674_3D.mol", true,
+                            false);  // don't remove Hs
     MolOps::detectBondStereochemistry(*m);
     MolOps::assignChiralTypesFrom3D(*m);
     MolOps::assignStereochemistry(*m, true, true);
@@ -2724,7 +2727,7 @@ void testDoubleBondStereoInRings() {
     delete m;
   }
   {
-    RWMol *m = MolFileToMol(pathName + "CHEMBL501674.mol"); // don't remove Hs
+    RWMol *m = MolFileToMol(pathName + "CHEMBL501674.mol");  // don't remove Hs
     const Bond *b = m->getBondBetweenAtoms(6, 7);
     TEST_ASSERT(b);
     TEST_ASSERT(b->getStereo() == Bond::STEREOE);
@@ -2734,7 +2737,7 @@ void testDoubleBondStereoInRings() {
     delete m;
   }
   {
-    RWMol *m = MolFileToMol(pathName + "CHEMBL501674.mol"); // don't remove Hs
+    RWMol *m = MolFileToMol(pathName + "CHEMBL501674.mol");  // don't remove Hs
     std::string smi = MolToSmiles(*m, true);
     unsigned int nTrans = 0;
     size_t pos = 0;
@@ -2761,8 +2764,12 @@ void testIssue1735() {
 }
 
 void testStereoGroupUpdating() {
-  BOOST_LOG(rdInfoLog) << "-----------------------------------------------------------" << std::endl;
-  BOOST_LOG(rdInfoLog) << "Are stereo groups updated when atoms and bonds are deleted?" << std::endl;
+  BOOST_LOG(rdInfoLog)
+      << "-----------------------------------------------------------"
+      << std::endl;
+  BOOST_LOG(rdInfoLog)
+      << "Are stereo groups updated when atoms and bonds are deleted?"
+      << std::endl;
 
   std::string rdbase = getenv("RDBASE");
   std::string fName =
@@ -2777,10 +2784,9 @@ void testStereoGroupUpdating() {
   TEST_ASSERT(m->getStereoGroups().size() == 0u);
 }
 
-
 int main() {
   RDLog::InitLogs();
-// boost::logging::enable_logs("rdApp.debug");
+  // boost::logging::enable_logs("rdApp.debug");
 
 #if 1
   testSmiles1();
@@ -2803,7 +2809,7 @@ int main() {
   testGithub553();
   testGithub803();
   testGithub1294();
-  #endif
+#endif
   testGithub1423();
   testAssignStereochemistryFrom3D();
   testDoubleBondStereoInRings();


### PR DESCRIPTION
Bridgehead atoms shouldn't be excluded from ring chirality.

I suppose one can argue about this, but this is at least consistent with how InChI handles it and that is, after all, IUPAC. ;-)