### PR TITLE
Fix #2148 and #2244

### DIFF
--- a/Code/GraphMol/Chirality.cpp
+++ b/Code/GraphMol/Chirality.cpp
@@ -389,7 +389,8 @@ void findAtomNeighborDirHelper(const ROMol &mol, const Atom *atom,
 // will be returned
 void findAtomNeighborsHelper(const ROMol &mol, const Atom *atom,
                              const Bond *refBond, UINT_VECT &neighbors,
-                             bool checkDir = false) {
+                             bool checkDir = false,
+                             bool includeAromatic = false) {
   PRECONDITION(atom, "bad atom");
   PRECONDITION(refBond, "bad bond");
   neighbors.clear();
@@ -398,7 +399,8 @@ void findAtomNeighborsHelper(const ROMol &mol, const Atom *atom,
   while (beg != end) {
     const Bond *bond = mol[*beg];
     Bond::BondDir dir = bond->getBondDir();
-    if (bond->getBondType() == Bond::SINGLE &&
+    if ((bond->getBondType() == Bond::SINGLE ||
+         (includeAromatic && bond->getBondType() == Bond::AROMATIC)) &&
         bond->getIdx() != refBond->getIdx()) {
       if (checkDir) {
         if ((dir != Bond::ENDDOWNRIGHT) && (dir != Bond::ENDUPRIGHT)) {
@@ -1202,7 +1204,7 @@ void findPotentialStereoBonds(ROMol &mol, bool cleanIt) {
         // if the bond is flagged as EITHERDOUBLE, we ignore it:
         if (dblBond->getBondDir() == Bond::EITHERDOUBLE ||
             dblBond->getStereo() == Bond::STEREOANY) {
-          break;
+          continue;
         }
         // proceed only if we either want to clean the stereocode on this bond
         // or if none is set on it yet
@@ -1229,10 +1231,14 @@ void findPotentialStereoBonds(ROMol &mol, bool cleanIt) {
             }
             // find the neighbors for the begin atom and the endAtom
             UINT_VECT begAtomNeighbors, endAtomNeighbors;
+            bool checkDir = false;
+            bool includeAromatic = true;
             Chirality::findAtomNeighborsHelper(mol, begAtom, dblBond,
-                                               begAtomNeighbors);
+                                               begAtomNeighbors, checkDir,
+                                               includeAromatic);
             Chirality::findAtomNeighborsHelper(mol, endAtom, dblBond,
-                                               endAtomNeighbors);
+                                               endAtomNeighbors, checkDir,
+                                               includeAromatic);
             if (begAtomNeighbors.size() > 0 && endAtomNeighbors.size() > 0) {
               if ((begAtomNeighbors.size() == 2) &&
                   (endAtomNeighbors.size() == 2)) {

--- a/Code/GraphMol/Chirality.cpp
+++ b/Code/GraphMol/Chirality.cpp
@@ -444,7 +444,6 @@ bool atomIsCandidateForRingStereochem(const ROMol &mol, const Atom *atom) {
         }
         ++beg;
       }
-
       unsigned int rank1 = 0, rank2 = 0;
       switch (nonRingNbrs.size()) {
         case 2:
@@ -460,7 +459,7 @@ bool atomIsCandidateForRingStereochem(const ROMol &mol, const Atom *atom) {
           }
           break;
         case 1:
-          if (ringNbrs.size() == 2) res = true;
+          if (ringNbrs.size() >= 2) res = true;
           break;
         case 0:
           if (ringNbrs.size() == 4 && nbrRanks.size() == 3) {
@@ -1164,9 +1163,9 @@ void assignStereochemistry(ROMol &mol, bool cleanIt, bool force,
   mol.setProp(common_properties::_StereochemDone, 1, true);
 
 #if 0
-      std::cerr<<"---\n";
-      mol.debugMol(std::cerr);
-      std::cerr<<"<<<<<<<<<<<<<<<<\n";
+  std::cerr << "---\n";
+  mol.debugMol(std::cerr);
+  std::cerr << "<<<<<<<<<<<<<<<<\n";
 #endif
 }
 

--- a/Code/GraphMol/Chirality.cpp
+++ b/Code/GraphMol/Chirality.cpp
@@ -664,6 +664,11 @@ std::pair<bool, bool> isAtomPotentialChiralCenter(
                (atom->getExplicitValence() == 3 &&
                 atom->getFormalCharge() == 1))) {
             legalCenter = true;
+          } else if (atom->getAtomicNum() == 7 &&
+                     mol.getRingInfo()->isAtomInRingOfSize(atom->getIdx(), 3)) {
+            // N in a three-membered ring is another one of the InChI special
+            // cases
+            legalCenter = true;
           }
         }
       }

--- a/Code/GraphMol/FileParsers/catch_tests.cpp
+++ b/Code/GraphMol/FileParsers/catch_tests.cpp
@@ -271,3 +271,110 @@ M  END
               common_properties::_MolFileBondCfg) == 1);
   }
 }
+
+TEST_CASE(
+    "github #2266: missing stereo in adamantyl-like cages with "
+    "exocyclic bonds",
+    "[bug]") {
+  SECTION("basics") {
+    std::string molblock = R"CTAB(
+        SciTegic12231509382D
+
+ 14 16  0  0  0  0            999 V2000
+    1.5584   -5.7422    0.0000 C   0  0
+    2.2043   -5.0535    0.0000 C   0  0  2  0  0  0
+    2.3688   -5.5155    0.0000 C   0  0  1  0  0  0
+    2.9210   -5.3181    0.0000 C   0  0
+    3.1270   -5.8206    0.0000 C   0  0
+    3.6744   -5.1312    0.0000 C   0  0  2  0  0  0
+    2.3619   -4.6609    0.0000 C   0  0
+    2.9268   -3.9939    0.0000 C   0  0  2  0  0  0
+    2.1999   -4.2522    0.0000 C   0  0
+    3.6803   -4.3062    0.0000 C   0  0
+    2.9436   -3.1692    0.0000 N   0  0
+    4.4569   -5.4095    0.0000 H   0  0
+    2.3246   -6.3425    0.0000 H   0  0
+    1.4365   -4.7500    0.0000 H   0  0
+  1  2  1  0
+  1  3  1  0
+  2  4  1  0
+  3  5  1  0
+  4  6  1  0
+  5  6  1  0
+  7  8  1  0
+  3  7  1  0
+  2  9  1  0
+  6 10  1  0
+ 10  8  1  0
+  8  9  1  0
+  8 11  1  1
+  6 12  1  6
+  3 13  1  1
+  2 14  1  6
+M  END)CTAB";
+    {
+      std::unique_ptr<ROMol> mol(MolBlockToMol(molblock));
+      REQUIRE(mol);
+      CHECK(mol->getNumAtoms() == 11);
+      CHECK(mol->getAtomWithIdx(1)->getChiralTag() != Atom::CHI_UNSPECIFIED);
+      CHECK(mol->getAtomWithIdx(2)->getChiralTag() != Atom::CHI_UNSPECIFIED);
+      CHECK(mol->getAtomWithIdx(5)->getChiralTag() != Atom::CHI_UNSPECIFIED);
+    }
+    {
+      bool sanitize = true;
+      bool removeHs = false;
+      std::unique_ptr<ROMol> mol(MolBlockToMol(molblock, sanitize, removeHs));
+      REQUIRE(mol);
+      CHECK(mol->getNumAtoms() == 14);
+
+      CHECK(mol->getAtomWithIdx(1)->getChiralTag() != Atom::CHI_UNSPECIFIED);
+      CHECK(mol->getAtomWithIdx(2)->getChiralTag() != Atom::CHI_UNSPECIFIED);
+      CHECK(mol->getAtomWithIdx(5)->getChiralTag() != Atom::CHI_UNSPECIFIED);
+    }
+  }
+  SECTION("with F") {
+    std::string molblock = R"CTAB(
+        SciTegic12231509382D
+
+ 14 16  0  0  0  0            999 V2000
+    1.5584   -5.7422    0.0000 C   0  0
+    2.2043   -5.0535    0.0000 C   0  0  2  0  0  0
+    2.3688   -5.5155    0.0000 C   0  0  1  0  0  0
+    2.9210   -5.3181    0.0000 C   0  0
+    3.1270   -5.8206    0.0000 C   0  0
+    3.6744   -5.1312    0.0000 C   0  0  2  0  0  0
+    2.3619   -4.6609    0.0000 C   0  0
+    2.9268   -3.9939    0.0000 C   0  0  2  0  0  0
+    2.1999   -4.2522    0.0000 C   0  0
+    3.6803   -4.3062    0.0000 C   0  0
+    2.9436   -3.1692    0.0000 N   0  0
+    4.4569   -5.4095    0.0000 F   0  0
+    2.3246   -6.3425    0.0000 F   0  0
+    1.4365   -4.7500    0.0000 F   0  0
+  1  2  1  0
+  1  3  1  0
+  2  4  1  0
+  3  5  1  0
+  4  6  1  0
+  5  6  1  0
+  7  8  1  0
+  3  7  1  0
+  2  9  1  0
+  6 10  1  0
+ 10  8  1  0
+  8  9  1  0
+  8 11  1  1
+  6 12  1  6
+  3 13  1  1
+  2 14  1  6
+M  END)CTAB";
+    {
+      std::unique_ptr<ROMol> mol(MolBlockToMol(molblock));
+      REQUIRE(mol);
+      CHECK(mol->getNumAtoms() == 14);
+      CHECK(mol->getAtomWithIdx(1)->getChiralTag() != Atom::CHI_UNSPECIFIED);
+      CHECK(mol->getAtomWithIdx(2)->getChiralTag() != Atom::CHI_UNSPECIFIED);
+      CHECK(mol->getAtomWithIdx(5)->getChiralTag() != Atom::CHI_UNSPECIFIED);
+    }
+  }
+}

--- a/Code/GraphMol/MolDraw2D/MolDraw2D.h
+++ b/Code/GraphMol/MolDraw2D/MolDraw2D.h
@@ -450,11 +450,6 @@ class RDKIT_MOLDRAW2D_EXPORT MolDraw2D {
 
   virtual void drawLine(const Point2D &cds1, const Point2D &cds2,
                         const DrawColour &col1, const DrawColour &col2);
-  void drawBond(const ROMol &mol, const Bond *bond, int at1_idx, int at2_idx,
-                const std::vector<int> *highlight_atoms = nullptr,
-                const std::map<int, DrawColour> *highlight_atom_map = nullptr,
-                const std::vector<int> *highlight_bonds = nullptr,
-                const std::map<int, DrawColour> *highlight_bond_map = nullptr);
   void drawWedgedBond(const Point2D &cds1, const Point2D &cds2,
                       bool draw_dashed, const DrawColour &col1,
                       const DrawColour &col2);
@@ -495,6 +490,12 @@ class RDKIT_MOLDRAW2D_EXPORT MolDraw2D {
       const std::map<int, double> *highlight_radii);
 
   virtual void highlightCloseContacts();
+  virtual void drawBond(
+      const ROMol &mol, const Bond *bond, int at1_idx, int at2_idx,
+      const std::vector<int> *highlight_atoms = nullptr,
+      const std::map<int, DrawColour> *highlight_atom_map = nullptr,
+      const std::vector<int> *highlight_bonds = nullptr,
+      const std::map<int, DrawColour> *highlight_bond_map = nullptr);
 
   // calculate normalised perpendicular to vector between two coords
   Point2D calcPerpendicular(const Point2D &cds1, const Point2D &cds2);

--- a/Code/GraphMol/MolDraw2D/MolDraw2DSVG.h
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DSVG.h
@@ -67,7 +67,8 @@ class RDKIT_MOLDRAW2D_EXPORT MolDraw2DSVG : public MolDraw2D {
   // this only makes sense if the object was initialized without a stream
   std::string getDrawingText() const { return d_ss.str(); };
 
-  void tagAtoms(const ROMol &mol);
+  void tagAtoms(const ROMol &mol, double radius = 0.2,
+                const std::map<std::string, std::string> &events = {});
 
   void addMoleculeMetadata(const ROMol &mol, int confId = -1) const;
   void addMoleculeMetadata(const std::vector<ROMol *> &mols,
@@ -76,9 +77,18 @@ class RDKIT_MOLDRAW2D_EXPORT MolDraw2DSVG : public MolDraw2D {
  private:
   std::ostream &d_os;
   std::stringstream d_ss;
+  std::string d_activeClass;
 
   void drawChar(char c, const Point2D &cds);
   void initDrawing();
+
+ protected:
+  void drawBond(
+      const ROMol &mol, const Bond *bond, int at1_idx, int at2_idx,
+      const std::vector<int> *highlight_atoms = nullptr,
+      const std::map<int, DrawColour> *highlight_atom_map = nullptr,
+      const std::vector<int> *highlight_bonds = nullptr,
+      const std::map<int, DrawColour> *highlight_bond_map = nullptr) override;
 };
 }  // namespace RDKit
 #endif  // MOLDRAW2DSVG_H

--- a/Code/GraphMol/MolDraw2D/Wrap/testMolDraw2D.py
+++ b/Code/GraphMol/MolDraw2D/Wrap/testMolDraw2D.py
@@ -320,6 +320,18 @@ M  END""")
     txt = d.GetDrawingText()
     self.assertTrue(txt.find("<tspan>H</tspan>")>0)
 
+  def testAtomTagging(self):
+    m = Chem.MolFromSmiles("C1N[C@@H]2OCC12")
+    d = Draw.MolDraw2DSVG(300, 300)
+    dm = Draw.PrepareMolForDrawing(m)
+    rdMolDraw2D.PrepareAndDrawMolecule(d,dm)
+    d.TagAtoms(dm,events={'onclick':'alert'})
+    d.FinishDrawing()
+    txt = d.GetDrawingText()
+    self.assertTrue(txt.find("<circle")>0)
+    self.assertTrue(txt.find("onclick=") > 0)
+
+
 
 if __name__ == "__main__":
   unittest.main()

--- a/Code/GraphMol/MolDraw2D/catch_tests.cpp
+++ b/Code/GraphMol/MolDraw2D/catch_tests.cpp
@@ -31,6 +31,29 @@ TEST_CASE("prepareAndDrawMolecule", "[drawing]") {
     MolDraw2DUtils::prepareAndDrawMolecule(drawer, *m1);
     drawer.finishDrawing();
     std::string text = drawer.getDrawingText();
-    CHECK(text.find("<tspan>H</tspan>")!=std::string::npos);
+    CHECK(text.find("<tspan>H</tspan>") != std::string::npos);
+  }
+}
+
+TEST_CASE("tag atoms in SVG", "[drawing, SVG]") {
+  SECTION("basics") {
+    auto m1 = "C1N[C@@H]2OCC12"_smiles;
+    REQUIRE(m1);
+
+    MolDraw2DSVG drawer(200, 200);
+    MolDraw2DUtils::prepareMolForDrawing(*m1);
+    drawer.drawMolecule(*m1);
+    std::map<std::string, std::string> actions;
+    actions["onclick"] = "alert";
+    double radius = 0.2;
+    drawer.tagAtoms(*m1, radius, actions);
+    drawer.finishDrawing();
+    std::string text = drawer.getDrawingText();
+    std::ofstream outs("testAtomTags_1.svg");
+    outs << text;
+    outs.flush();
+
+    CHECK(text.find("<circle") != std::string::npos);
+    CHECK(text.find("onclick") != std::string::npos);
   }
 }

--- a/Code/GraphMol/MolDraw2D/test1.cpp
+++ b/Code/GraphMol/MolDraw2D/test1.cpp
@@ -1245,9 +1245,10 @@ M  END";
     std::ofstream outs("test983_1.svg");
     outs << text;
     outs.flush();
-    TEST_ASSERT(text.find("<path d='M 130.309,117.496 194.727,89.1159 "
-                          "187.092,75.893 130.309,117.496' "
-                          "style='fill:#000000") != std::string::npos);
+    TEST_ASSERT(
+        text.find("<path class='bond-1' d='M 130.309,117.496 194.727,89.1159 "
+                  "187.092,75.893 130.309,117.496' "
+                  "style='fill:#000000") != std::string::npos);
     delete m;
   }
   {
@@ -1296,9 +1297,10 @@ M  END";
     std::ofstream outs("test983_2.svg");
     outs << text;
     outs.flush();
-    TEST_ASSERT(text.find("<path d='M 107.911,115.963 80.5887,91.4454 "
-                          "75.9452,97.9126 107.911,115.963' "
-                          "style='fill:#000000;") != std::string::npos);
+    TEST_ASSERT(
+        text.find("<path class='bond-3' d='M 107.911,115.963 80.5887,91.4454 "
+                  "75.9452,97.9126 107.911,115.963' "
+                  "style='fill:#000000;") != std::string::npos);
 
     MolDraw2DUtils::prepareMolForDrawing(*m);
     TEST_ASSERT(m->getBondBetweenAtoms(2, 1)->getBondType() == Bond::SINGLE);
@@ -2222,10 +2224,14 @@ M  END)molb";
     std::ofstream outs("testGithub2063_1.svg");
     outs << text;
     outs.flush();
-    TEST_ASSERT(text.find("<path d='M 65.8823,110.884 134.118,89.1159'") !=
-                std::string::npos);
-    TEST_ASSERT(text.find("<path d='M 69.6998,117.496 9.09091,82.5044'") !=
-                std::string::npos);
+    TEST_ASSERT(
+        text.find(
+            "<path class='bond-0' d='M 65.8823,110.884 134.118,89.1159'") !=
+        std::string::npos);
+    TEST_ASSERT(
+        text.find(
+            "<path class='bond-1' d='M 69.6998,117.496 9.09091,82.5044'") !=
+        std::string::npos);
   }
   {
     std::string molb = R"molb(crossed bond
@@ -2252,10 +2258,14 @@ M  END)molb";
     std::ofstream outs("testGithub2063_2.svg");
     outs << text;
     outs.flush();
-    TEST_ASSERT(text.find("<path d='M 65.8823,110.884 134.118,89.1159'") !=
-                std::string::npos);
-    TEST_ASSERT(text.find("<path d='M 69.6998,117.496 9.09091,82.5044'") !=
-                std::string::npos);
+    TEST_ASSERT(
+        text.find(
+            "<path class='bond-0' d='M 65.8823,110.884 134.118,89.1159'") !=
+        std::string::npos);
+    TEST_ASSERT(
+        text.find(
+            "<path class='bond-1' d='M 69.6998,117.496 9.09091,82.5044'") !=
+        std::string::npos);
   }
   std::cerr << " Done" << std::endl;
 }

--- a/Code/GraphMol/SmilesParse/SmilesParse.cpp
+++ b/Code/GraphMol/SmilesParse/SmilesParse.cpp
@@ -238,6 +238,7 @@ RWMol *toMol(const std::string &inp,
     if (!molVect.empty()) {
       res = molVect[0];
       SmilesParseOps::CloseMolRings(res, false);
+      SmilesParseOps::SetUnspecifiedBondTypes(res);
       SmilesParseOps::AdjustAtomChiralityFlags(res);
       // No sense leaving this bookmark intact:
       if (res->hasAtomBookmark(ci_RIGHTMOST_ATOM)) {

--- a/Code/GraphMol/SmilesParse/SmilesParseOps.cpp
+++ b/Code/GraphMol/SmilesParse/SmilesParseOps.cpp
@@ -424,6 +424,41 @@ Bond::BondType GetUnspecifiedBondType(const RWMol *mol, const Atom *atom1,
   }
   return res;
 }
+void SetUnspecifiedBondTypes(RWMol *mol) {
+  PRECONDITION(mol, "no molecule");
+  for (auto bond : mol->bonds()) {
+    if (bond->hasProp(RDKit::common_properties::_unspecifiedOrder)) {
+      bond->setBondType(GetUnspecifiedBondType(mol, bond->getBeginAtom(),
+                                               bond->getEndAtom()));
+      if (bond->getBondType() == Bond::AROMATIC) {
+        bond->setIsAromatic(true);
+      } else {
+        bond->setIsAromatic(false);
+      }
+    }
+  }
+}
+
+namespace {
+void swapBondDirIfNeeded(Bond *bond1, const Bond *bond2) {
+  if (bond1->getBondDir() == Bond::NONE && bond2->getBondDir() != Bond::NONE) {
+    bond1->setBondDir(bond2->getBondDir());
+    if (bond1->getBeginAtom() != bond2->getBeginAtom()) {
+      switch (bond1->getBondDir()) {
+        case Bond::ENDDOWNRIGHT:
+          bond1->setBondDir(Bond::ENDUPRIGHT);
+          break;
+        case Bond::ENDUPRIGHT:
+          bond1->setBondDir(Bond::ENDDOWNRIGHT);
+          break;
+        default:
+          break;
+      }
+    }
+  }
+}
+}  // namespace
+
 void CloseMolRings(RWMol *mol, bool toleratePartials) {
   //  Here's what we want to do here:
   //    loop through the molecule's atom bookmarks
@@ -472,9 +507,9 @@ void CloseMolRings(RWMol *mol, bool toleratePartials) {
                           "Missing bond bookmark");
 
           // now use the info from the partial bond:
-          // The partial bond itself will have a proper order and directionality
-          // (with a minor caveat documented below) and will have its beginning
-          // atom set already:
+          // The partial bond itself will have a proper order and
+          // directionality (with a minor caveat documented below) and will
+          // have its beginning atom set already:
           RWMol::BOND_PTR_LIST bonds =
               mol->getAllBondsWithBookmark(bookmarkIt->first);
           auto bondIt = bonds.begin();
@@ -498,20 +533,31 @@ void CloseMolRings(RWMol *mol, bool toleratePartials) {
           Bond *matchedBond;
 
           // figure out which (if either) bond has a specified type, we'll
-          // keep that one.  We also need to update the end atom index to match
-          // FIX: daylight barfs when you give it multiple specs for the closure
+          // keep that one.  We also need to update the end atom index to
+          // match FIX: daylight barfs when you give it multiple specs for the
+          // closure
           //   bond, we'll just take the first one and ignore others
           //   NOTE: we used to do this the other way (take the last
           //   specification),
           //   but that turned out to be troublesome in odd cases like
           //   C1CC11CC1.
+          // std::cerr << ">-------------" << std::endl;
+          // std::cerr << atom1->getIdx() << "-" << atom2->getIdx() << ": "
+          //           << bond1->getBondType() << "("
+          //           << bond1->hasProp(common_properties::_unspecifiedOrder)
+          //           << "):" << bond1->getBondDir() << " "
+          //           << bond2->getBondType() << "("
+          //           << bond2->hasProp(common_properties::_unspecifiedOrder)
+          //           << "):" << bond2->getBondDir() << std::endl;
           if (!bond1->hasProp(common_properties::_unspecifiedOrder)) {
             matchedBond = bond1;
             matchedBond->setEndAtomIdx(atom2->getIdx());
+            swapBondDirIfNeeded(bond1, bond2);
             delete bond2;
           } else {
             matchedBond = bond2;
             matchedBond->setEndAtomIdx(atom1->getIdx());
+            swapBondDirIfNeeded(bond2, bond1);
             delete bond1;
           }
           if (matchedBond->getBondType() == Bond::UNSPECIFIED &&
@@ -524,6 +570,11 @@ void CloseMolRings(RWMol *mol, bool toleratePartials) {
             matchedBond->setIsAromatic(true);
           }
 
+          // std::cerr << "     " <<
+          // matchedBond->getBeginAtomIdx()<<"-"<<matchedBond->getEndAtomIdx()<<":
+          // "<<matchedBond->getBondType() << " a:
+          // "<<matchedBond->getIsAromatic()<<std::endl; std::cerr <<
+          // "<-------------" << std::endl;
 #if 0
             //
             //  In cases like this: Cl\C=C1.F/1, we need to

--- a/Code/GraphMol/SmilesParse/SmilesParseOps.h
+++ b/Code/GraphMol/SmilesParse/SmilesParseOps.h
@@ -15,7 +15,7 @@
 namespace RDKit {
 class RWMol;
 class Atom;
-}
+}  // namespace RDKit
 namespace SmilesParseOps {
 void CheckRingClosureBranchStatus(RDKit::Atom *atom, RDKit::RWMol *mp);
 void ReportParseError(const char *message, bool throwIt = true);
@@ -28,12 +28,13 @@ RDKit::Bond::BondType GetUnspecifiedBondType(const RDKit::RWMol *mol,
                                              const RDKit::Atom *atom1,
                                              const RDKit::Atom *atom2);
 void CloseMolRings(RDKit::RWMol *mol, bool toleratePartials);
+void SetUnspecifiedBondTypes(RDKit::RWMol *mol);
 void AdjustAtomChiralityFlags(RDKit::RWMol *mol);
 void CleanupAfterParsing(RDKit::RWMol *mol);
 void parseCXExtensions(RDKit::RWMol &mol, const std::string &extText,
                        std::string::const_iterator &pos);
 //! removes formal charge, isotope, etc. Primarily useful for QueryAtoms
 void ClearAtomChemicalProps(RDKit::Atom *atom);
-};
+};  // namespace SmilesParseOps
 
 #endif

--- a/Code/GraphMol/SmilesParse/catch_tests.cpp
+++ b/Code/GraphMol/SmilesParse/catch_tests.cpp
@@ -1,3 +1,14 @@
+//
+//
+//  Copyright (C) 2018-2019 Greg Landrum and T5 Informatics GmbH
+//
+//   @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
+//
+
 #define CATCH_CONFIG_MAIN  // This tells Catch to provide a main() - only do
                            // this in one cpp file
 #include "catch.hpp"
@@ -141,4 +152,44 @@ TEST_CASE(
       REQUIRE(MolToSmarts(*mol) == sma);
     }
   }
+}
+
+TEST_CASE("Github #2148", "[bug, Smiles, Smarts]") {
+  SECTION("SMILES") {
+    auto mol = "C(=C\\F)\\4.O=C1C=4CCc2ccccc21"_smiles;
+    REQUIRE(mol);
+    REQUIRE(mol->getBondBetweenAtoms(0, 5));
+    CHECK(mol->getBondBetweenAtoms(0, 5)->getBondType() == Bond::DOUBLE);
+  }
+  SECTION("SMILES edges") {
+    auto m1 = "C/C=C/C"_smiles;
+    REQUIRE(m1);
+    CHECK(m1->getBondBetweenAtoms(2, 1)->getBondType() == Bond::DOUBLE);
+    CHECK(m1->getBondBetweenAtoms(2, 1)->getStereo() != Bond::STEREONONE);
+
+    {
+      std::vector<std::string> smis = {"C1=C/C.C/1", "C/1=C/C.C1",
+                                       "C-1=C/C.C/1", "C/1=C/C.C-1"};
+      for (auto smi : smis) {
+        std::unique_ptr<RWMol> mol(SmilesToMol(smi));
+        REQUIRE(mol);
+        CHECK(mol->getBondBetweenAtoms(0, 3)->getBondType() == Bond::SINGLE);
+        CHECK(mol->getBondBetweenAtoms(0, 3)->getBondDir() != Bond::NONE);
+        CHECK(mol->getBondBetweenAtoms(0, 1)->getBondType() == Bond::DOUBLE);
+        CHECK(mol->getBondBetweenAtoms(0, 1)->getStereo() != Bond::STEREONONE);
+      }
+    }
+  }
+
+  SECTION("Writing SMILES") {
+    auto mol = "C/C=c1/ncc(=C)cc1"_smiles;
+    REQUIRE(mol);
+    REQUIRE(mol->getBondBetweenAtoms(1, 2));
+    CHECK(mol->getBondBetweenAtoms(1, 2)->getBondType() == Bond::DOUBLE);
+    CHECK(mol->getBondBetweenAtoms(1, 2)->getStereo() == Bond::STEREOE);
+    auto smi = MolToSmiles(*mol);
+    CHECK(smi=="C=c1cc/c(=C\\C)nc1");    
+  }
+
+
 }

--- a/Code/GraphMol/SmilesParse/lex.yysmiles.cpp.cmake
+++ b/Code/GraphMol/SmilesParse/lex.yysmiles.cpp.cmake
@@ -2111,89 +2111,91 @@ YY_RULE_SETUP
 case 168:
 YY_RULE_SETUP
 #line 335 "smiles.ll"
-{ yylval->bond = new Bond(Bond::SINGLE);
+{ yylval->bond = new Bond(Bond::UNSPECIFIED);
+	yylval->bond->setProp(RDKit::common_properties::_unspecifiedOrder,1);
 	yylval->bond->setBondDir(Bond::ENDDOWNRIGHT);
 	return BOND_TOKEN;  }
 	YY_BREAK
 case 169:
 YY_RULE_SETUP
-#line 339 "smiles.ll"
-{ yylval->bond = new Bond(Bond::SINGLE);
+#line 340 "smiles.ll"
+{ yylval->bond = new Bond(Bond::UNSPECIFIED);
+	yylval->bond->setProp(RDKit::common_properties::_unspecifiedOrder,1);
 	yylval->bond->setBondDir(Bond::ENDUPRIGHT);
 	return BOND_TOKEN;  }
 	YY_BREAK
 case 170:
 YY_RULE_SETUP
-#line 343 "smiles.ll"
+#line 345 "smiles.ll"
 { return MINUS_TOKEN; }
 	YY_BREAK
 case 171:
 YY_RULE_SETUP
-#line 345 "smiles.ll"
+#line 347 "smiles.ll"
 { return PLUS_TOKEN; }
 	YY_BREAK
 case 172:
 YY_RULE_SETUP
-#line 347 "smiles.ll"
+#line 349 "smiles.ll"
 { return GROUP_OPEN_TOKEN; }
 	YY_BREAK
 case 173:
 YY_RULE_SETUP
-#line 348 "smiles.ll"
+#line 350 "smiles.ll"
 { return GROUP_CLOSE_TOKEN; }
 	YY_BREAK
 case 174:
 YY_RULE_SETUP
-#line 351 "smiles.ll"
+#line 353 "smiles.ll"
 { BEGIN IN_ATOM_STATE; return ATOM_OPEN_TOKEN; }
 	YY_BREAK
 case 175:
 YY_RULE_SETUP
-#line 352 "smiles.ll"
+#line 354 "smiles.ll"
 { BEGIN INITIAL; return ATOM_CLOSE_TOKEN; }
 	YY_BREAK
 case 176:
 YY_RULE_SETUP
-#line 354 "smiles.ll"
+#line 356 "smiles.ll"
 { return SEPARATOR_TOKEN; }
 	YY_BREAK
 case 177:
 YY_RULE_SETUP
-#line 356 "smiles.ll"
+#line 358 "smiles.ll"
 { return PERCENT_TOKEN; }
 	YY_BREAK
 case 178:
 YY_RULE_SETUP
-#line 358 "smiles.ll"
+#line 360 "smiles.ll"
 { yylval->ival = 0; return ZERO_TOKEN; }
 	YY_BREAK
 case 179:
 YY_RULE_SETUP
-#line 359 "smiles.ll"
+#line 361 "smiles.ll"
 { yylval->ival = atoi( yytext ); return NONZERO_DIGIT_TOKEN; }
 	YY_BREAK
 case 180:
 /* rule 180 can match eol */
 YY_RULE_SETUP
-#line 363 "smiles.ll"
+#line 365 "smiles.ll"
 return 0;
 	YY_BREAK
 case YY_STATE_EOF(INITIAL):
 case YY_STATE_EOF(IN_ATOM_STATE):
-#line 365 "smiles.ll"
+#line 367 "smiles.ll"
 { return EOS_TOKEN; }
 	YY_BREAK
 case 181:
 YY_RULE_SETUP
-#line 366 "smiles.ll"
+#line 368 "smiles.ll"
 return yytext[0];
 	YY_BREAK
 case 182:
 YY_RULE_SETUP
-#line 368 "smiles.ll"
+#line 370 "smiles.ll"
 ECHO;
 	YY_BREAK
-#line 2197 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/lex.yysmiles.cpp"
+#line 2199 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/lex.yysmiles.cpp"
 
 	case YY_END_OF_BUFFER:
 		{
@@ -3372,7 +3374,7 @@ void yyfree (void * ptr , yyscan_t yyscanner)
 
 #define YYTABLES_NAME "yytables"
 
-#line 368 "smiles.ll"
+#line 370 "smiles.ll"
 
 
 #undef yysmiles_wrap

--- a/Code/GraphMol/SmilesParse/smiles.ll
+++ b/Code/GraphMol/SmilesParse/smiles.ll
@@ -331,11 +331,13 @@ s		    {	yylval->atom = new Atom( 16 );
 	  yylval->bond->setQuery(makeBondNullQuery());
 	  return BOND_TOKEN;  }
 
-[\\]{1,2}    { yylval->bond = new Bond(Bond::SINGLE);
+[\\]{1,2}    { yylval->bond = new Bond(Bond::UNSPECIFIED);
+	yylval->bond->setProp(RDKit::common_properties::_unspecifiedOrder,1);
 	yylval->bond->setBondDir(Bond::ENDDOWNRIGHT);
 	return BOND_TOKEN;  }
 
-[\/]    { yylval->bond = new Bond(Bond::SINGLE);
+[\/]    { yylval->bond = new Bond(Bond::UNSPECIFIED);
+	yylval->bond->setProp(RDKit::common_properties::_unspecifiedOrder,1);
 	yylval->bond->setBondDir(Bond::ENDUPRIGHT);
 	return BOND_TOKEN;  }
 

--- a/Code/GraphMol/SmilesParse/smiles.tab.cpp.cmake
+++ b/Code/GraphMol/SmilesParse/smiles.tab.cpp.cmake
@@ -93,7 +93,6 @@
 
 extern int yysmiles_lex(YYSTYPE *,void *,int &);
 
-
 using namespace RDKit;
 namespace {
  void yyErrorCleanup(std::vector<RDKit::RWMol *> *molList){
@@ -129,7 +128,7 @@ yysmiles_error( const char *input,
 
 
 
-#line 133 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:339  */
+#line 132 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:339  */
 
 # ifndef YY_NULLPTR
 #  if defined __cplusplus && 201103L <= __cplusplus
@@ -198,14 +197,14 @@ extern int yysmiles_debug;
 
 union YYSTYPE
 {
-#line 78 "smiles.yy" /* yacc.c:355  */
+#line 77 "smiles.yy" /* yacc.c:355  */
 
   int                      moli;
   RDKit::Atom * atom;
   RDKit::Bond * bond;
   int                      ival;
 
-#line 209 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:355  */
+#line 208 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:355  */
 };
 
 typedef union YYSTYPE YYSTYPE;
@@ -217,18 +216,18 @@ typedef union YYSTYPE YYSTYPE;
 
 int yysmiles_parse (const char *input, std::vector<RDKit::RWMol *> *molList, RDKit::Atom* &lastAtom, RDKit::Bond* &lastBond, std::list<unsigned int> *branchPoints, void *scanner, int& start_token);
 /* "%code provides" blocks.  */
-#line 73 "smiles.yy" /* yacc.c:355  */
+#line 72 "smiles.yy" /* yacc.c:355  */
 
 #define YY_DECL int yylex \
                (YYSTYPE * yylval_param , yyscan_t yyscanner, int& start_token)
 
-#line 226 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:355  */
+#line 225 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:355  */
 
 #endif /* !YY_YYSMILES_SCRATCH_RDKIT_GIT_CODE_GRAPHMOL_SMILESPARSE_SMILES_TAB_HPP_INCLUDED  */
 
 /* Copy the second part of user declarations.  */
 
-#line 232 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:358  */
+#line 231 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:358  */
 
 #ifdef short
 # undef short
@@ -468,18 +467,18 @@ union yyalloc
 #endif /* !YYCOPY_NEEDED */
 
 /* YYFINAL -- State number of the termination state.  */
-#define YYFINAL  17
+#define YYFINAL  33
 /* YYLAST -- Last index in YYTABLE.  */
-#define YYLAST   115
+#define YYLAST   149
 
 /* YYNTOKENS -- Number of terminals.  */
 #define YYNTOKENS  29
 /* YYNNTS -- Number of nonterminals.  */
-#define YYNNTS  14
+#define YYNNTS  15
 /* YYNRULES -- Number of rules.  */
-#define YYNRULES  64
+#define YYNRULES  71
 /* YYNSTATES -- Number of states.  */
-#define YYNSTATES  92
+#define YYNSTATES  105
 
 /* YYTRANSLATE[YYX] -- Symbol number corresponding to YYX as returned
    by yylex, with out-of-bounds checking.  */
@@ -528,13 +527,14 @@ static const yytype_uint8 yytranslate[] =
   /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
 static const yytype_uint16 yyrline[] =
 {
-       0,   103,   103,   106,   109,   112,   118,   121,   132,   143,
-     153,   173,   181,   187,   206,   224,   240,   250,   270,   278,
-     287,   288,   296,   297,   304,   312,   313,   314,   315,   316,
-     317,   318,   322,   323,   324,   325,   326,   327,   328,   329,
-     330,   334,   335,   336,   340,   341,   342,   343,   344,   345,
-     349,   350,   354,   355,   356,   357,   358,   359,   360,   364,
-     365,   369,   370,   373,   374
+       0,   107,   107,   110,   114,   117,   121,   125,   128,   133,
+     136,   144,   145,   146,   147,   155,   166,   176,   196,   204,
+     210,   228,   249,   265,   275,   295,   303,   312,   313,   319,
+     320,   326,   334,   335,   336,   337,   338,   339,   340,   344,
+     345,   346,   347,   348,   349,   350,   351,   352,   356,   357,
+     358,   362,   363,   364,   365,   366,   367,   371,   372,   376,
+     377,   378,   379,   380,   381,   382,   386,   387,   391,   392,
+     395,   396
 };
 #endif
 
@@ -550,9 +550,10 @@ static const char *const yytname[] =
   "MINUS_TOKEN", "PLUS_TOKEN", "CHIRAL_MARKER_TOKEN", "CHI_CLASS_TOKEN",
   "CHI_CLASS_OH_TOKEN", "H_TOKEN", "AT_TOKEN", "PERCENT_TOKEN",
   "COLON_TOKEN", "HASH_TOKEN", "BOND_TOKEN", "ATOM_OPEN_TOKEN",
-  "ATOM_CLOSE_TOKEN", "EOS_TOKEN", "$accept", "meta_start", "mol", "bondd",
-  "atomd", "charge_element", "h_element", "chiral_element", "element",
-  "simple_atom", "ring_number", "number", "nonzero_number", "digit", YY_NULLPTR
+  "ATOM_CLOSE_TOKEN", "EOS_TOKEN", "$accept", "meta_start", "bad_atom_def",
+  "mol", "bondd", "atomd", "charge_element", "h_element", "chiral_element",
+  "element", "simple_atom", "ring_number", "number", "nonzero_number",
+  "digit", YY_NULLPTR
 };
 #endif
 
@@ -567,30 +568,31 @@ static const yytype_uint16 yytoknum[] =
 };
 # endif
 
-#define YYPACT_NINF -32
+#define YYPACT_NINF -30
 
 #define yypact_value_is_default(Yystate) \
-  (!!((Yystate) == (-32)))
+  (!!((Yystate) == (-30)))
 
-#define YYTABLE_NINF -1
+#define YYTABLE_NINF -30
 
 #define yytable_value_is_error(Yytable_value) \
   0
 
   /* YYPACT[STATE-NUM] -- Index in YYTABLE of the portion describing
      STATE-NUM.  */
-static const yytype_int8 yypact[] =
+static const yytype_int16 yypact[] =
 {
-       5,   -11,     8,     8,   -10,     2,   -32,   -32,   -32,    88,
-      54,   -32,   -32,   -32,   -32,   -32,   -32,   -32,    -8,   -32,
-     -32,   -32,   -32,     4,    68,    -5,    74,     9,    15,   -32,
-      79,   105,   -32,   -32,    67,   -32,     8,    62,    39,    62,
-     -32,   -32,   -32,   -32,    68,   -32,    68,   -32,    32,     3,
-      68,    18,   -32,    25,    68,   -32,   -32,     8,     8,   -32,
-     -32,   -32,   -32,   105,   105,   -32,   -32,   -32,    24,   -32,
-     -32,   -32,   -32,   -32,   -32,    68,   -32,   -32,   -32,   -32,
-      34,   -32,   -32,   -32,    92,   -32,    97,   -32,   101,   -32,
-      49,   -32
+      62,   -10,    11,    51,     7,     1,   -30,   -30,   -30,   106,
+      82,   -30,   -30,   -30,   -30,   -30,    -6,    76,    -4,    76,
+      76,   -30,    -1,   -30,    26,    31,    41,    48,   113,    96,
+     -30,   -30,    70,   -30,    73,   -30,   -20,   -30,   -30,   -30,
+     103,   -30,    11,     2,    27,     2,   -30,   -30,   -30,    -4,
+      76,   -30,   -30,   -30,   -20,   -30,   -30,   125,    30,    -4,
+      58,   -30,    49,    -4,   -30,   -30,   -30,   -30,    -4,   -30,
+      11,    11,   -30,   -30,   -30,   -30,    96,    96,   -30,   -30,
+     -30,   -30,   -30,   -30,   -30,   -30,   -30,    -4,   -30,    83,
+     -30,   -30,   -30,   115,   -30,   -30,   -30,   129,   -30,   133,
+     -30,   137,   -30,   105,   -30
 };
 
   /* YYDEFACT[STATE-NUM] -- Default reduction number in state STATE-NUM.
@@ -598,65 +600,72 @@ static const yytype_int8 yypact[] =
      means the default is an error.  */
 static const yytype_uint8 yydefact[] =
 {
-       0,     0,     0,     0,     0,     0,     7,    51,    50,     0,
-       2,     8,    22,     3,    21,    20,     4,     1,     0,     6,
-      46,    61,    59,    32,     0,     0,    25,    38,    41,    44,
-       0,    60,    63,    64,     0,    19,     0,     0,     0,     0,
-       9,    13,    52,     5,    34,    48,     0,    24,    29,    26,
-      39,    42,    47,    33,     0,    45,    62,     0,     0,    16,
-      12,    11,    15,     0,     0,    10,    14,    36,     0,    30,
-      31,    27,    28,    40,    43,    35,    49,    18,    17,    53,
-       0,    23,    37,    54,     0,    55,     0,    56,     0,    57,
-       0,    58
+       0,     0,     0,     0,     7,     0,    10,    58,    57,     0,
+       2,    15,    29,    53,    68,    66,    39,     0,     0,     0,
+       0,     4,     0,    14,    32,    45,    48,    51,     0,    67,
+      28,    27,     6,     1,     0,     9,     0,    51,    70,    71,
+       0,    26,     0,     0,     0,     0,    16,    20,    59,    41,
+       0,    13,    55,    11,    14,    12,     3,    36,    33,    46,
+      49,    54,    40,     0,    52,    69,     5,     8,     0,    31,
+       0,     0,    23,    19,    18,    22,     0,     0,    17,    21,
+      43,    37,    38,    34,    35,    47,    50,    42,    56,     0,
+      25,    24,    60,     0,    44,    30,    61,     0,    62,     0,
+      63,     0,    64,     0,    65
 };
 
   /* YYPGOTO[NTERM-NUM].  */
 static const yytype_int8 yypgoto[] =
 {
-     -32,   -32,   -32,   -32,     1,   -32,   -32,   -32,   -32,    -2,
-      17,   -23,   -32,   -31
+     -30,   -30,    13,   -30,   -30,    10,    12,   -30,   -30,   -30,
+       6,    44,   -14,   -30,   -29
 };
 
   /* YYDEFGOTO[NTERM-NUM].  */
 static const yytype_int8 yydefgoto[] =
 {
-      -1,     5,    10,    16,    11,    25,    26,    27,    28,    12,
-      41,    30,    31,    42
+      -1,     5,    53,    10,    32,    11,    23,    24,    25,    26,
+      12,    47,    28,    29,    48
 };
 
   /* YYTABLE[YYPACT[STATE-NUM]] -- What to do in state STATE-NUM.  If
      positive, shift that token.  If negative, reduce the rule whose
      number is the opposite.  If YYTABLE_NINF, syntax error.  */
-static const yytype_uint8 yytable[] =
+static const yytype_int8 yytable[] =
 {
-      56,    45,    17,    18,    13,    14,     1,    29,     2,     3,
-       4,    40,    21,    22,     7,    15,     8,     6,    46,    71,
-      43,    67,    47,    68,    44,    70,    72,    73,    55,    50,
-      19,    76,    79,    80,     9,    59,    51,    60,    61,    74,
-      65,    21,    22,    32,    33,    75,    83,    69,    63,    84,
-      64,    81,    82,    86,    62,    88,    66,    90,    77,    78,
-       7,    91,     8,    32,    33,    34,    35,    36,     7,    37,
-       8,    32,    33,     7,     0,     8,    38,    21,    22,    39,
-       9,     0,    57,     0,    38,     7,    52,     8,     9,    48,
-      49,     0,    58,     9,     7,    20,     8,    21,    22,    53,
-       0,    32,    33,    54,    85,     0,    32,    33,    23,    87,
-      32,    33,    24,    89,    32,    33
+      65,    33,    34,    68,    52,    14,    15,    69,     7,    27,
+       8,    38,    39,    22,    49,    37,    21,     7,     6,     8,
+      46,    36,    30,    37,    44,    37,    37,    56,     9,    35,
+      51,    54,    31,    55,    64,    80,    76,     9,    77,    14,
+      15,    57,    58,    82,    84,    85,    83,    92,    93,    88,
+      72,    59,    73,    74,    89,    78,    37,     7,    13,     8,
+      14,    15,    60,     1,    97,     2,     3,     4,    99,    87,
+     101,    16,   103,    94,    17,    18,   -29,    19,    20,    86,
+      90,    91,     7,    13,     8,    14,    15,    75,     7,    79,
+       8,    38,    39,    40,    41,    42,    16,    43,    66,    17,
+      18,    67,    50,    20,    44,    38,    39,    45,     9,     7,
+      95,     8,     7,    13,     8,    14,    15,   104,    70,     7,
+      61,     8,     0,     0,    38,    39,    16,    96,    71,     9,
+      18,     0,     0,    62,    14,    15,     0,    63,    38,    39,
+      81,    98,    38,    39,     0,   100,    38,    39,     0,   102
 };
 
 static const yytype_int8 yycheck[] =
 {
-      31,    24,     0,     1,     3,    15,     1,     9,     3,     4,
-       5,    10,     9,    10,     6,    25,     8,    28,    23,    16,
-      28,    44,    27,    46,    20,    48,    49,    50,    30,    20,
-      28,    54,    63,    64,    26,    34,    21,    36,    37,    21,
-      39,     9,    10,     9,    10,    20,    12,    15,     9,    80,
-      11,    27,    75,    84,    37,    86,    39,    88,    57,    58,
-       6,    12,     8,     9,    10,    11,    12,    13,     6,    15,
-       8,     9,    10,     6,    -1,     8,    22,     9,    10,    25,
-      26,    -1,    15,    -1,    22,     6,     7,     8,    26,    15,
-      16,    -1,    25,    26,     6,     7,     8,     9,    10,    20,
-      -1,     9,    10,    24,    12,    -1,     9,    10,    20,    12,
-       9,    10,    24,    12,     9,    10
+      29,     0,     1,    23,    18,     9,    10,    27,     6,     3,
+       8,     9,    10,     3,    20,     9,     3,     6,    28,     8,
+      10,     9,    15,    17,    22,    19,    20,    28,    26,    28,
+      17,    19,    25,    20,    28,    49,     9,    26,    11,     9,
+      10,    15,    16,    57,    58,    59,    16,    76,    77,    63,
+      40,    20,    42,    43,    68,    45,    50,     6,     7,     8,
+       9,    10,    21,     1,    93,     3,     4,     5,    97,    20,
+      99,    20,   101,    87,    23,    24,    28,    26,    27,    21,
+      70,    71,     6,     7,     8,     9,    10,    43,     6,    45,
+       8,     9,    10,    11,    12,    13,    20,    15,    28,    23,
+      24,    28,    26,    27,    22,     9,    10,    25,    26,     6,
+      27,     8,     6,     7,     8,     9,    10,    12,    15,     6,
+       7,     8,    -1,    -1,     9,    10,    20,    12,    25,    26,
+      24,    -1,    -1,    20,     9,    10,    -1,    24,     9,    10,
+      15,    12,     9,    10,    -1,    12,     9,    10,    -1,    12
 };
 
   /* YYSTOS[STATE-NUM] -- The (internal number of the) accessing
@@ -664,39 +673,42 @@ static const yytype_int8 yycheck[] =
 static const yytype_uint8 yystos[] =
 {
        0,     1,     3,     4,     5,    30,    28,     6,     8,    26,
-      31,    33,    38,    33,    15,    25,    32,     0,     1,    28,
-       7,     9,    10,    20,    24,    34,    35,    36,    37,    38,
-      40,    41,     9,    10,    11,    12,    13,    15,    22,    25,
-      33,    39,    42,    28,    20,    40,    23,    27,    15,    16,
-      20,    21,     7,    20,    24,    38,    42,    15,    25,    33,
-      33,    33,    39,     9,    11,    33,    39,    40,    40,    15,
-      40,    16,    40,    40,    21,    20,    40,    33,    33,    42,
-      42,    27,    40,    12,    42,    12,    42,    12,    42,    12,
-      42,    12
+      32,    34,    39,     7,     9,    10,    20,    23,    24,    26,
+      27,    31,    34,    35,    36,    37,    38,    39,    41,    42,
+      15,    25,    33,     0,     1,    28,    35,    39,     9,    10,
+      11,    12,    13,    15,    22,    25,    34,    40,    43,    20,
+      26,    31,    41,    31,    35,    31,    28,    15,    16,    20,
+      21,     7,    20,    24,    39,    43,    28,    28,    23,    27,
+      15,    25,    34,    34,    34,    40,     9,    11,    34,    40,
+      41,    15,    41,    16,    41,    41,    21,    20,    41,    41,
+      34,    34,    43,    43,    41,    27,    12,    43,    12,    43,
+      12,    43,    12,    43,    12
 };
 
   /* YYR1[YYN] -- Symbol number of symbol that rule YYN derives.  */
 static const yytype_uint8 yyr1[] =
 {
-       0,    29,    30,    30,    30,    30,    30,    30,    31,    31,
-      31,    31,    31,    31,    31,    31,    31,    31,    31,    31,
-      32,    32,    33,    33,    33,    34,    34,    34,    34,    34,
-      34,    34,    35,    35,    35,    35,    35,    35,    35,    35,
-      35,    36,    36,    36,    37,    37,    37,    37,    37,    37,
-      38,    38,    39,    39,    39,    39,    39,    39,    39,    40,
-      40,    41,    41,    42,    42
+       0,    29,    30,    30,    30,    30,    30,    30,    30,    30,
+      30,    31,    31,    31,    31,    32,    32,    32,    32,    32,
+      32,    32,    32,    32,    32,    32,    32,    33,    33,    34,
+      34,    34,    35,    35,    35,    35,    35,    35,    35,    36,
+      36,    36,    36,    36,    36,    36,    36,    36,    37,    37,
+      37,    38,    38,    38,    38,    38,    38,    39,    39,    40,
+      40,    40,    40,    40,    40,    40,    41,    41,    42,    42,
+      43,    43
 };
 
   /* YYR2[YYN] -- Number of symbols on the right hand side of rule YYN.  */
 static const yytype_uint8 yyr2[] =
 {
-       0,     2,     2,     2,     2,     3,     2,     2,     1,     2,
-       3,     3,     3,     2,     3,     3,     3,     4,     4,     2,
-       1,     1,     1,     5,     3,     1,     2,     3,     3,     2,
-       3,     3,     1,     2,     2,     3,     3,     4,     1,     2,
-       3,     1,     2,     3,     1,     2,     1,     2,     2,     3,
-       1,     1,     1,     3,     4,     5,     6,     7,     8,     1,
-       1,     1,     2,     1,     1
+       0,     2,     2,     3,     2,     3,     2,     1,     3,     2,
+       2,     2,     2,     2,     1,     1,     2,     3,     3,     3,
+       2,     3,     3,     3,     4,     4,     2,     1,     1,     1,
+       5,     3,     1,     2,     3,     3,     2,     3,     3,     1,
+       2,     2,     3,     3,     4,     1,     2,     3,     1,     2,
+       3,     1,     2,     1,     2,     2,     3,     1,     1,     1,
+       3,     4,     5,     6,     7,     8,     1,     1,     1,     2,
+       1,     1
 };
 
 
@@ -1131,7 +1143,42 @@ yydestruct (const char *yymsg, int yytype, YYSTYPE *yyvaluep, const char *input,
   YY_SYMBOL_PRINT (yymsg, yytype, yyvaluep, yylocationp);
 
   YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
-  YYUSE (yytype);
+  switch (yytype)
+    {
+          case 6: /* AROMATIC_ATOM_TOKEN  */
+#line 98 "smiles.yy" /* yacc.c:1257  */
+      { delete ((*yyvaluep).atom); }
+#line 1152 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1257  */
+        break;
+
+    case 7: /* ATOM_TOKEN  */
+#line 98 "smiles.yy" /* yacc.c:1257  */
+      { delete ((*yyvaluep).atom); }
+#line 1158 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1257  */
+        break;
+
+    case 8: /* ORGANIC_ATOM_TOKEN  */
+#line 98 "smiles.yy" /* yacc.c:1257  */
+      { delete ((*yyvaluep).atom); }
+#line 1164 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1257  */
+        break;
+
+    case 25: /* BOND_TOKEN  */
+#line 99 "smiles.yy" /* yacc.c:1257  */
+      { delete ((*yyvaluep).bond); }
+#line 1170 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1257  */
+        break;
+
+    case 33: /* bondd  */
+#line 99 "smiles.yy" /* yacc.c:1257  */
+      { delete ((*yyvaluep).bond); }
+#line 1176 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1257  */
+        break;
+
+
+      default:
+        break;
+    }
   YY_IGNORE_MAYBE_UNINITIALIZED_END
 }
 
@@ -1391,76 +1438,110 @@ yyreduce:
   switch (yyn)
     {
         case 2:
-#line 103 "smiles.yy" /* yacc.c:1646  */
+#line 107 "smiles.yy" /* yacc.c:1646  */
     {
 // the molList has already been updated, no need to do anything
 }
-#line 1399 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
+#line 1446 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
     break;
 
   case 3:
-#line 106 "smiles.yy" /* yacc.c:1646  */
+#line 110 "smiles.yy" /* yacc.c:1646  */
     {
-  lastAtom = (yyvsp[0].atom);
+  lastAtom = (yyvsp[-1].atom);
+  YYACCEPT;
 }
-#line 1407 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
+#line 1455 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
     break;
 
   case 4:
-#line 109 "smiles.yy" /* yacc.c:1646  */
+#line 114 "smiles.yy" /* yacc.c:1646  */
     {
-  lastBond = (yyvsp[0].bond);
+  YYABORT;
 }
-#line 1415 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
+#line 1463 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
     break;
 
   case 5:
-#line 112 "smiles.yy" /* yacc.c:1646  */
+#line 117 "smiles.yy" /* yacc.c:1646  */
     {
-  yyclearin;
-  yyerrok;
-  yyErrorCleanup(molList);
-  YYABORT;
+  lastBond = (yyvsp[-1].bond);
+  YYACCEPT;
 }
-#line 1426 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
+#line 1472 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
     break;
 
   case 6:
-#line 118 "smiles.yy" /* yacc.c:1646  */
+#line 121 "smiles.yy" /* yacc.c:1646  */
     {
-  YYACCEPT;
+  delete (yyvsp[0].bond);
+  YYABORT;
 }
-#line 1434 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
+#line 1481 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
     break;
 
   case 7:
-#line 121 "smiles.yy" /* yacc.c:1646  */
+#line 125 "smiles.yy" /* yacc.c:1646  */
     {
-  yyclearin;
+  YYABORT;
+}
+#line 1489 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
+    break;
+
+  case 8:
+#line 128 "smiles.yy" /* yacc.c:1646  */
+    {
   yyerrok;
   yyErrorCleanup(molList);
   YYABORT;
 }
-#line 1445 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
+#line 1499 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
     break;
 
-  case 8:
-#line 132 "smiles.yy" /* yacc.c:1646  */
+  case 9:
+#line 133 "smiles.yy" /* yacc.c:1646  */
+    {
+  YYACCEPT;
+}
+#line 1507 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
+    break;
+
+  case 10:
+#line 136 "smiles.yy" /* yacc.c:1646  */
+    {
+  yyerrok;
+  yyErrorCleanup(molList);
+  YYABORT;
+}
+#line 1517 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
+    break;
+
+  case 14:
+#line 147 "smiles.yy" /* yacc.c:1646  */
+    {
+  delete (yyvsp[0].atom);
+  YYABORT;
+}
+#line 1526 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
+    break;
+
+  case 15:
+#line 155 "smiles.yy" /* yacc.c:1646  */
     {
   int sz     = molList->size();
   molList->resize( sz + 1);
   (*molList)[ sz ] = new RWMol();
   RDKit::RWMol *curMol = (*molList)[ sz ];
   (yyvsp[0].atom)->setProp(RDKit::common_properties::_SmilesStart,1);
-  curMol->addAtom((yyvsp[0].atom),true,true);
-  //delete (yyvsp[0].atom);
+  curMol->addAtom((yyvsp[0].atom), true, true);
+  //delete $1;
   (yyval.moli) = sz;
 }
-#line 1460 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
+#line 1541 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
     break;
 
-  case 9:
-#line 143 "smiles.yy" /* yacc.c:1646  */
+  case 16:
+#line 166 "smiles.yy" /* yacc.c:1646  */
     {
   RWMol *mp = (*molList)[(yyval.moli)];
   Atom *a1 = mp->getActiveAtom();
@@ -1470,11 +1551,11 @@ yyreduce:
 	      SmilesParseOps::GetUnspecifiedBondType(mp,a1,mp->getAtomWithIdx(atomIdx2)));
   //delete $2;
 }
-#line 1474 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
+#line 1555 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
     break;
 
-  case 10:
-#line 153 "smiles.yy" /* yacc.c:1646  */
+  case 17:
+#line 176 "smiles.yy" /* yacc.c:1646  */
     {
   RWMol *mp = (*molList)[(yyval.moli)];
   int atomIdx1 = mp->getActiveAtom()->getIdx();
@@ -1494,11 +1575,11 @@ yyreduce:
   mp->addBond((yyvsp[-1].bond),true);
   //delete $3;
 }
-#line 1498 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
+#line 1579 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
     break;
 
-  case 11:
-#line 173 "smiles.yy" /* yacc.c:1646  */
+  case 18:
+#line 196 "smiles.yy" /* yacc.c:1646  */
     {
   RWMol *mp = (*molList)[(yyval.moli)];
   int atomIdx1 = mp->getActiveAtom()->getIdx();
@@ -1506,21 +1587,21 @@ yyreduce:
   mp->addBond(atomIdx1,atomIdx2,Bond::SINGLE);
   //delete $3;
 }
-#line 1510 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
+#line 1591 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
     break;
 
-  case 12:
-#line 181 "smiles.yy" /* yacc.c:1646  */
+  case 19:
+#line 204 "smiles.yy" /* yacc.c:1646  */
     {
   RWMol *mp = (*molList)[(yyval.moli)];
   (yyvsp[0].atom)->setProp(RDKit::common_properties::_SmilesStart,1,true);
   mp->addAtom((yyvsp[0].atom),true,true);
 }
-#line 1520 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
+#line 1601 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
     break;
 
-  case 13:
-#line 187 "smiles.yy" /* yacc.c:1646  */
+  case 20:
+#line 210 "smiles.yy" /* yacc.c:1646  */
     {
   RWMol * mp = (*molList)[(yyval.moli)];
   Atom *atom=mp->getActiveAtom();
@@ -1537,18 +1618,20 @@ yyreduce:
   atom->getPropIfPresent(RDKit::common_properties::_RingClosures,tmp);
   tmp.push_back(-((yyvsp[0].ival)+1));
   atom->setProp(RDKit::common_properties::_RingClosures,tmp);
-
 }
-#line 1543 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
+#line 1623 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
     break;
 
-  case 14:
-#line 206 "smiles.yy" /* yacc.c:1646  */
+  case 21:
+#line 228 "smiles.yy" /* yacc.c:1646  */
     {
   RWMol * mp = (*molList)[(yyval.moli)];
   Atom *atom=mp->getActiveAtom();
   Bond *newB = mp->createPartialBond(atom->getIdx(),
 				     (yyvsp[-1].bond)->getBondType());
+  if((yyvsp[-1].bond)->hasProp(RDKit::common_properties::_unspecifiedOrder)){
+    newB->setProp(RDKit::common_properties::_unspecifiedOrder,1);
+  }
   newB->setBondDir((yyvsp[-1].bond)->getBondDir());
   mp->setAtomBookmark(atom,(yyvsp[0].ival));
   mp->setBondBookmark(newB,(yyvsp[0].ival));
@@ -1561,11 +1644,11 @@ yyreduce:
   atom->setProp(RDKit::common_properties::_RingClosures,tmp);
   delete (yyvsp[-1].bond);
 }
-#line 1565 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
+#line 1648 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
     break;
 
-  case 15:
-#line 224 "smiles.yy" /* yacc.c:1646  */
+  case 22:
+#line 249 "smiles.yy" /* yacc.c:1646  */
     {
   RWMol * mp = (*molList)[(yyval.moli)];
   Atom *atom=mp->getActiveAtom();
@@ -1581,11 +1664,11 @@ yyreduce:
   tmp.push_back(-((yyvsp[0].ival)+1));
   atom->setProp(RDKit::common_properties::_RingClosures,tmp);
 }
-#line 1585 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
+#line 1668 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
     break;
 
-  case 16:
-#line 240 "smiles.yy" /* yacc.c:1646  */
+  case 23:
+#line 265 "smiles.yy" /* yacc.c:1646  */
     {
   RWMol *mp = (*molList)[(yyval.moli)];
   Atom *a1 = mp->getActiveAtom();
@@ -1596,11 +1679,11 @@ yyreduce:
   //delete $3;
   branchPoints->push_back(atomIdx1);
 }
-#line 1600 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
+#line 1683 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
     break;
 
-  case 17:
-#line 250 "smiles.yy" /* yacc.c:1646  */
+  case 24:
+#line 275 "smiles.yy" /* yacc.c:1646  */
     {
   RWMol *mp = (*molList)[(yyval.moli)];
   int atomIdx1 = mp->getActiveAtom()->getIdx();
@@ -1621,11 +1704,11 @@ yyreduce:
   //delete $4;
   branchPoints->push_back(atomIdx1);
 }
-#line 1625 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
+#line 1708 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
     break;
 
-  case 18:
-#line 270 "smiles.yy" /* yacc.c:1646  */
+  case 25:
+#line 295 "smiles.yy" /* yacc.c:1646  */
     {
   RWMol *mp = (*molList)[(yyval.moli)];
   int atomIdx1 = mp->getActiveAtom()->getIdx();
@@ -1634,211 +1717,211 @@ yyreduce:
   //delete $4;
   branchPoints->push_back(atomIdx1);
 }
-#line 1638 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
+#line 1721 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
     break;
 
-  case 19:
-#line 278 "smiles.yy" /* yacc.c:1646  */
+  case 26:
+#line 303 "smiles.yy" /* yacc.c:1646  */
     {
   if(branchPoints->empty()) yyerror(input,molList,branchPoints,scanner,start_token,"extra close parentheses");
   RWMol *mp = (*molList)[(yyval.moli)];
   mp->setActiveAtom(branchPoints->back());
   branchPoints->pop_back();
 }
-#line 1649 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
+#line 1732 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
     break;
 
-  case 21:
-#line 288 "smiles.yy" /* yacc.c:1646  */
+  case 28:
+#line 313 "smiles.yy" /* yacc.c:1646  */
     {
           (yyval.bond) = new Bond(Bond::SINGLE);
           }
-#line 1657 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
+#line 1740 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
     break;
 
-  case 23:
-#line 298 "smiles.yy" /* yacc.c:1646  */
+  case 30:
+#line 321 "smiles.yy" /* yacc.c:1646  */
     {
   (yyval.atom) = (yyvsp[-3].atom);
   (yyval.atom)->setNoImplicit(true);
   (yyval.atom)->setProp(RDKit::common_properties::molAtomMapNumber,(yyvsp[-1].ival));
 }
-#line 1667 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
+#line 1750 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
     break;
 
-  case 24:
-#line 305 "smiles.yy" /* yacc.c:1646  */
+  case 31:
+#line 327 "smiles.yy" /* yacc.c:1646  */
     {
   (yyval.atom) = (yyvsp[-1].atom);
   (yyvsp[-1].atom)->setNoImplicit(true);
 }
-#line 1676 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
-    break;
-
-  case 26:
-#line 313 "smiles.yy" /* yacc.c:1646  */
-    { (yyvsp[-1].atom)->setFormalCharge(1); }
-#line 1682 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
-    break;
-
-  case 27:
-#line 314 "smiles.yy" /* yacc.c:1646  */
-    { (yyvsp[-2].atom)->setFormalCharge(2); }
-#line 1688 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
-    break;
-
-  case 28:
-#line 315 "smiles.yy" /* yacc.c:1646  */
-    { (yyvsp[-2].atom)->setFormalCharge((yyvsp[0].ival)); }
-#line 1694 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
-    break;
-
-  case 29:
-#line 316 "smiles.yy" /* yacc.c:1646  */
-    { (yyvsp[-1].atom)->setFormalCharge(-1); }
-#line 1700 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
-    break;
-
-  case 30:
-#line 317 "smiles.yy" /* yacc.c:1646  */
-    { (yyvsp[-2].atom)->setFormalCharge(-2); }
-#line 1706 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
-    break;
-
-  case 31:
-#line 318 "smiles.yy" /* yacc.c:1646  */
-    { (yyvsp[-2].atom)->setFormalCharge(-(yyvsp[0].ival)); }
-#line 1712 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
-    break;
-
-  case 32:
-#line 322 "smiles.yy" /* yacc.c:1646  */
-    { (yyval.atom) = new Atom(1); }
-#line 1718 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
+#line 1759 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
     break;
 
   case 33:
-#line 323 "smiles.yy" /* yacc.c:1646  */
-    { (yyval.atom) = new Atom(1); (yyval.atom)->setIsotope((yyvsp[-1].ival)); }
-#line 1724 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
+#line 335 "smiles.yy" /* yacc.c:1646  */
+    { (yyvsp[-1].atom)->setFormalCharge(1); }
+#line 1765 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
     break;
 
   case 34:
-#line 324 "smiles.yy" /* yacc.c:1646  */
-    { (yyval.atom) = new Atom(1); (yyval.atom)->setNumExplicitHs(1); }
-#line 1730 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
+#line 336 "smiles.yy" /* yacc.c:1646  */
+    { (yyvsp[-2].atom)->setFormalCharge(2); }
+#line 1771 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
     break;
 
   case 35:
-#line 325 "smiles.yy" /* yacc.c:1646  */
-    { (yyval.atom) = new Atom(1); (yyval.atom)->setIsotope((yyvsp[-2].ival)); (yyval.atom)->setNumExplicitHs(1);}
-#line 1736 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
+#line 337 "smiles.yy" /* yacc.c:1646  */
+    { (yyvsp[-2].atom)->setFormalCharge((yyvsp[0].ival)); }
+#line 1777 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
     break;
 
   case 36:
-#line 326 "smiles.yy" /* yacc.c:1646  */
-    { (yyval.atom) = new Atom(1); (yyval.atom)->setNumExplicitHs((yyvsp[0].ival)); }
-#line 1742 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
+#line 338 "smiles.yy" /* yacc.c:1646  */
+    { (yyvsp[-1].atom)->setFormalCharge(-1); }
+#line 1783 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
     break;
 
   case 37:
-#line 327 "smiles.yy" /* yacc.c:1646  */
-    { (yyval.atom) = new Atom(1); (yyval.atom)->setIsotope((yyvsp[-3].ival)); (yyval.atom)->setNumExplicitHs((yyvsp[0].ival));}
-#line 1748 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
+#line 339 "smiles.yy" /* yacc.c:1646  */
+    { (yyvsp[-2].atom)->setFormalCharge(-2); }
+#line 1789 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
+    break;
+
+  case 38:
+#line 340 "smiles.yy" /* yacc.c:1646  */
+    { (yyvsp[-2].atom)->setFormalCharge(-(yyvsp[0].ival)); }
+#line 1795 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
     break;
 
   case 39:
-#line 329 "smiles.yy" /* yacc.c:1646  */
-    { (yyval.atom) = (yyvsp[-1].atom); (yyvsp[-1].atom)->setNumExplicitHs(1);}
-#line 1754 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
+#line 344 "smiles.yy" /* yacc.c:1646  */
+    { (yyval.atom) = new Atom(1); }
+#line 1801 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
     break;
 
   case 40:
-#line 330 "smiles.yy" /* yacc.c:1646  */
-    { (yyval.atom) = (yyvsp[-2].atom); (yyvsp[-2].atom)->setNumExplicitHs((yyvsp[0].ival));}
-#line 1760 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
+#line 345 "smiles.yy" /* yacc.c:1646  */
+    { (yyval.atom) = new Atom(1); (yyval.atom)->setIsotope((yyvsp[-1].ival)); }
+#line 1807 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
+    break;
+
+  case 41:
+#line 346 "smiles.yy" /* yacc.c:1646  */
+    { (yyval.atom) = new Atom(1); (yyval.atom)->setNumExplicitHs(1); }
+#line 1813 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
     break;
 
   case 42:
-#line 335 "smiles.yy" /* yacc.c:1646  */
-    { (yyvsp[-1].atom)->setChiralTag(Atom::CHI_TETRAHEDRAL_CCW); }
-#line 1766 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
+#line 347 "smiles.yy" /* yacc.c:1646  */
+    { (yyval.atom) = new Atom(1); (yyval.atom)->setIsotope((yyvsp[-2].ival)); (yyval.atom)->setNumExplicitHs(1);}
+#line 1819 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
     break;
 
   case 43:
-#line 336 "smiles.yy" /* yacc.c:1646  */
-    { (yyvsp[-2].atom)->setChiralTag(Atom::CHI_TETRAHEDRAL_CW); }
-#line 1772 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
+#line 348 "smiles.yy" /* yacc.c:1646  */
+    { (yyval.atom) = new Atom(1); (yyval.atom)->setNumExplicitHs((yyvsp[0].ival)); }
+#line 1825 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
     break;
 
-  case 45:
-#line 341 "smiles.yy" /* yacc.c:1646  */
-    { (yyvsp[0].atom)->setIsotope( (yyvsp[-1].ival) ); (yyval.atom) = (yyvsp[0].atom); }
-#line 1778 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
+  case 44:
+#line 349 "smiles.yy" /* yacc.c:1646  */
+    { (yyval.atom) = new Atom(1); (yyval.atom)->setIsotope((yyvsp[-3].ival)); (yyval.atom)->setNumExplicitHs((yyvsp[0].ival));}
+#line 1831 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
+    break;
+
+  case 46:
+#line 351 "smiles.yy" /* yacc.c:1646  */
+    { (yyval.atom) = (yyvsp[-1].atom); (yyvsp[-1].atom)->setNumExplicitHs(1);}
+#line 1837 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
     break;
 
   case 47:
-#line 343 "smiles.yy" /* yacc.c:1646  */
-    { (yyvsp[0].atom)->setIsotope( (yyvsp[-1].ival) ); (yyval.atom) = (yyvsp[0].atom); }
-#line 1784 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
-    break;
-
-  case 48:
-#line 344 "smiles.yy" /* yacc.c:1646  */
-    { (yyval.atom) = new Atom((yyvsp[0].ival)); }
-#line 1790 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
+#line 352 "smiles.yy" /* yacc.c:1646  */
+    { (yyval.atom) = (yyvsp[-2].atom); (yyvsp[-2].atom)->setNumExplicitHs((yyvsp[0].ival));}
+#line 1843 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
     break;
 
   case 49:
-#line 345 "smiles.yy" /* yacc.c:1646  */
-    { (yyval.atom) = new Atom((yyvsp[0].ival)); (yyval.atom)->setIsotope((yyvsp[-2].ival)); }
-#line 1796 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
+#line 357 "smiles.yy" /* yacc.c:1646  */
+    { (yyvsp[-1].atom)->setChiralTag(Atom::CHI_TETRAHEDRAL_CCW); }
+#line 1849 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
     break;
 
-  case 53:
-#line 355 "smiles.yy" /* yacc.c:1646  */
-    { (yyval.ival) = (yyvsp[-1].ival)*10+(yyvsp[0].ival); }
-#line 1802 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
+  case 50:
+#line 358 "smiles.yy" /* yacc.c:1646  */
+    { (yyvsp[-2].atom)->setChiralTag(Atom::CHI_TETRAHEDRAL_CW); }
+#line 1855 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
+    break;
+
+  case 52:
+#line 363 "smiles.yy" /* yacc.c:1646  */
+    { (yyvsp[0].atom)->setIsotope( (yyvsp[-1].ival) ); (yyval.atom) = (yyvsp[0].atom); }
+#line 1861 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
     break;
 
   case 54:
-#line 356 "smiles.yy" /* yacc.c:1646  */
-    { (yyval.ival) = (yyvsp[-1].ival); }
-#line 1808 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
+#line 365 "smiles.yy" /* yacc.c:1646  */
+    { (yyvsp[0].atom)->setIsotope( (yyvsp[-1].ival) ); (yyval.atom) = (yyvsp[0].atom); }
+#line 1867 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
     break;
 
   case 55:
-#line 357 "smiles.yy" /* yacc.c:1646  */
-    { (yyval.ival) = (yyvsp[-2].ival)*10+(yyvsp[-1].ival); }
-#line 1814 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
+#line 366 "smiles.yy" /* yacc.c:1646  */
+    { (yyval.atom) = new Atom((yyvsp[0].ival)); }
+#line 1873 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
     break;
 
   case 56:
-#line 358 "smiles.yy" /* yacc.c:1646  */
-    { (yyval.ival) = (yyvsp[-3].ival)*100+(yyvsp[-2].ival)*10+(yyvsp[-1].ival); }
-#line 1820 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
+#line 367 "smiles.yy" /* yacc.c:1646  */
+    { (yyval.atom) = new Atom((yyvsp[0].ival)); (yyval.atom)->setIsotope((yyvsp[-2].ival)); }
+#line 1879 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
     break;
 
-  case 57:
-#line 359 "smiles.yy" /* yacc.c:1646  */
-    { (yyval.ival) = (yyvsp[-4].ival)*1000+(yyvsp[-3].ival)*100+(yyvsp[-2].ival)*10+(yyvsp[-1].ival); }
-#line 1826 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
+  case 60:
+#line 377 "smiles.yy" /* yacc.c:1646  */
+    { (yyval.ival) = (yyvsp[-1].ival)*10+(yyvsp[0].ival); }
+#line 1885 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
     break;
 
-  case 58:
-#line 360 "smiles.yy" /* yacc.c:1646  */
-    { (yyval.ival) = (yyvsp[-5].ival)*10000+(yyvsp[-4].ival)*1000+(yyvsp[-3].ival)*100+(yyvsp[-2].ival)*10+(yyvsp[-1].ival); }
-#line 1832 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
+  case 61:
+#line 378 "smiles.yy" /* yacc.c:1646  */
+    { (yyval.ival) = (yyvsp[-1].ival); }
+#line 1891 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
     break;
 
   case 62:
-#line 370 "smiles.yy" /* yacc.c:1646  */
+#line 379 "smiles.yy" /* yacc.c:1646  */
+    { (yyval.ival) = (yyvsp[-2].ival)*10+(yyvsp[-1].ival); }
+#line 1897 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
+    break;
+
+  case 63:
+#line 380 "smiles.yy" /* yacc.c:1646  */
+    { (yyval.ival) = (yyvsp[-3].ival)*100+(yyvsp[-2].ival)*10+(yyvsp[-1].ival); }
+#line 1903 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
+    break;
+
+  case 64:
+#line 381 "smiles.yy" /* yacc.c:1646  */
+    { (yyval.ival) = (yyvsp[-4].ival)*1000+(yyvsp[-3].ival)*100+(yyvsp[-2].ival)*10+(yyvsp[-1].ival); }
+#line 1909 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
+    break;
+
+  case 65:
+#line 382 "smiles.yy" /* yacc.c:1646  */
+    { (yyval.ival) = (yyvsp[-5].ival)*10000+(yyvsp[-4].ival)*1000+(yyvsp[-3].ival)*100+(yyvsp[-2].ival)*10+(yyvsp[-1].ival); }
+#line 1915 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
+    break;
+
+  case 69:
+#line 392 "smiles.yy" /* yacc.c:1646  */
     { (yyval.ival) = (yyvsp[-1].ival)*10 + (yyvsp[0].ival); }
-#line 1838 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
+#line 1921 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
     break;
 
 
-#line 1842 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
+#line 1925 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp" /* yacc.c:1646  */
       default: break;
     }
   /* User semantic actions sometimes alter yychar, and that requires
@@ -2066,5 +2149,5 @@ yyreturn:
 #endif
   return yyresult;
 }
-#line 384 "smiles.yy" /* yacc.c:1906  */
+#line 406 "smiles.yy" /* yacc.c:1906  */
 

--- a/Code/GraphMol/SmilesParse/smiles.yy
+++ b/Code/GraphMol/SmilesParse/smiles.yy
@@ -223,7 +223,6 @@ mol: atomd {
   atom->getPropIfPresent(RDKit::common_properties::_RingClosures,tmp);
   tmp.push_back(-($2+1));
   atom->setProp(RDKit::common_properties::_RingClosures,tmp);
-
 }
 
 | mol BOND_TOKEN ring_number {
@@ -231,6 +230,9 @@ mol: atomd {
   Atom *atom=mp->getActiveAtom();
   Bond *newB = mp->createPartialBond(atom->getIdx(),
 				     $2->getBondType());
+  if($2->hasProp(RDKit::common_properties::_unspecifiedOrder)){
+    newB->setProp(RDKit::common_properties::_unspecifiedOrder,1);
+  }
   newB->setBondDir($2->getBondDir());
   mp->setAtomBookmark(atom,$3);
   mp->setBondBookmark(newB,$3);

--- a/Code/GraphMol/catch_tests.cpp
+++ b/Code/GraphMol/catch_tests.cpp
@@ -74,66 +74,133 @@ TEST_CASE("Github #2086", "[bug, molops]") {
   }
 }
 
-TEST_CASE("github #299", "[bug, molops, SSSR]"){
-  SECTION("simplified"){
-    auto mol = "C13%13%14.C124%18.C25%13%15.C368%17.C4679.C75%10%17.C8%11%14%16.C9%11%12%18.C%10%12%15%16"_smiles;
+TEST_CASE("github #299", "[bug, molops, SSSR]") {
+  SECTION("simplified") {
+    auto mol =
+        "C13%13%14.C124%18.C25%13%15.C368%17.C4679.C75%10%17.C8%11%14%16.C9%11%12%18.C%10%12%15%16"_smiles;
     REQUIRE(mol);
-    REQUIRE(mol->getNumAtoms()==9);
+    REQUIRE(mol->getNumAtoms() == 9);
   }
 
-  SECTION("old example from molopstest"){
+  SECTION("old example from molopstest") {
     auto mol = "C123C45C11C44C55C22C33C14C523"_smiles;
     REQUIRE(mol);
-    REQUIRE(mol->getNumAtoms()==9);
+    REQUIRE(mol->getNumAtoms() == 9);
   }
 
-  SECTION("carborane"){
-    std::unique_ptr<RWMol> mol(SmilesToMol("[B]1234[B]567[B]118[B]229[B]33%10[B]454[B]656[B]711[B]822[C]933[B]%1045[C]6123",0,false));
+  SECTION("carborane") {
+    std::unique_ptr<RWMol> mol(
+        SmilesToMol("[B]1234[B]567[B]118[B]229[B]33%10[B]454[B]656[B]711[B]822["
+                    "C]933[B]%1045[C]6123",
+                    0, false));
     REQUIRE(mol);
-    CHECK(mol->getNumAtoms()==12);
+    CHECK(mol->getNumAtoms() == 12);
     mol->updatePropertyCache(false);
     MolOps::findSSSR(*mol);
     REQUIRE(mol->getRingInfo()->isInitialized());
   }
-  SECTION("original report from ChEbI"){
+  SECTION("original report from ChEbI") {
     std::string pathName = getenv("RDBASE");
     pathName += "/Code/GraphMol/test_data/";
-    std::unique_ptr<RWMol> mol(MolFileToMol(pathName + "ChEBI_50252.mol",false));
+    std::unique_ptr<RWMol> mol(
+        MolFileToMol(pathName + "ChEBI_50252.mol", false));
     REQUIRE(mol);
-    CHECK(mol->getNumAtoms()==80);
+    CHECK(mol->getNumAtoms() == 80);
     mol->updatePropertyCache(false);
     MolOps::findSSSR(*mol);
     REQUIRE(mol->getRingInfo()->isInitialized());
-
   }
 }
 
-TEST_CASE("github #2224", "[bug, molops, removeHs, query]"){
-  SECTION("the original report"){
+TEST_CASE("github #2224", "[bug, molops, removeHs, query]") {
+  SECTION("the original report") {
     std::string pathName = getenv("RDBASE");
     pathName += "/Code/GraphMol/test_data/";
     std::unique_ptr<RWMol> mol(MolFileToMol(pathName + "github2224_1.mol"));
     REQUIRE(mol);
-    REQUIRE(mol->getNumAtoms()==7);
+    REQUIRE(mol->getNumAtoms() == 7);
   }
   SECTION("basics") {
-  SmilesParserParams ps;
+    SmilesParserParams ps;
     ps.removeHs = false;
     ps.sanitize = true;
     std::unique_ptr<ROMol> mol(SmilesToMol("C[H]", ps));
     REQUIRE(mol);
-    REQUIRE(mol->getNumAtoms()==2);
-    { // The H without a query is removed
+    REQUIRE(mol->getNumAtoms() == 2);
+    {  // The H without a query is removed
       std::unique_ptr<ROMol> m2(MolOps::removeHs(*mol));
-      CHECK(m2->getNumAtoms()==1);
+      CHECK(m2->getNumAtoms() == 1);
     }
-    { // but if we add a query feature it's not removed
+    {  // but if we add a query feature it's not removed
       RWMol m2(*mol);
-      m2.replaceAtom(1,new QueryAtom(1));
+      m2.replaceAtom(1, new QueryAtom(1));
       m2.getAtomWithIdx(1)->setAtomicNum(1);
       MolOps::removeHs(m2);
-      CHECK(m2.getNumAtoms()==2);
+      CHECK(m2.getNumAtoms() == 2);
     }
   }
 }
 
+TEST_CASE(
+    "github #2268: Recognize N in three-membered rings as potentially chiral",
+    "[bug,stereo]") {
+  SECTION("basics: N in a 3 ring") {
+    const auto mol = "C[N@]1CC1C"_smiles;
+    REQUIRE(mol);
+    CHECK(mol->getAtomWithIdx(1)->getChiralTag() != Atom::CHI_UNSPECIFIED);
+  }
+  SECTION("basics: N in a 4 ring") {
+    const auto mol = "C[N@]1CCC1C"_smiles;
+    REQUIRE(mol);
+    CHECK(mol->getAtomWithIdx(1)->getChiralTag() == Atom::CHI_UNSPECIFIED);
+  }
+  SECTION("the original molecule") {
+    std::string mb = R"CTAB(
+  Mrv1810 02131915062D          
+
+ 18 20  0  0  1  0            999 V2000
+   -0.7207   -1.3415    0.0000 N   0  0  1  0  0  0  0  0  0  0  0  0
+   -0.0583   -0.8416    0.0000 C   0  0  2  0  0  0  0  0  0  0  0  0
+   -0.0083   -1.7540    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
+   -1.3956   -0.8666    0.0000 C   0  0  2  0  0  0  0  0  0  0  0  0
+   -0.3250   -0.0667    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -2.1955   -0.6499    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -1.1499   -0.0792    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    0.6541   -0.4292    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -2.7830   -1.2291    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
+   -1.6081   -1.6623    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -2.4080    0.1500    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
+    1.3665   -0.8374    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    0.6416    0.3958    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -3.1996    0.3708    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -3.4121    1.1624    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    1.3498    0.8207    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    2.0790   -0.4167    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    2.0665    0.4083    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+  2  1  1  0  0  0  0
+  1  3  1  1  0  0  0
+  4  1  1  0  0  0  0
+  5  2  1  0  0  0  0
+  4  6  1  0  0  0  0
+  7  4  1  0  0  0  0
+  2  8  1  6  0  0  0
+  9  6  2  0  0  0  0
+  4 10  1  1  0  0  0
+ 11  6  1  0  0  0  0
+ 12  8  2  0  0  0  0
+ 13  8  1  0  0  0  0
+ 14 11  1  0  0  0  0
+ 15 14  1  0  0  0  0
+ 16 13  2  0  0  0  0
+ 17 12  1  0  0  0  0
+ 18 16  1  0  0  0  0
+  2  3  1  0  0  0  0
+  5  7  1  0  0  0  0
+ 17 18  2  0  0  0  0
+M  END
+)CTAB";
+    std::unique_ptr<ROMol> mol(MolBlockToMol(mb));
+    REQUIRE(mol);
+    CHECK(mol->getAtomWithIdx(0)->getChiralTag() != Atom::CHI_UNSPECIFIED);
+  }
+}

--- a/Code/GraphMol/catch_tests.cpp
+++ b/Code/GraphMol/catch_tests.cpp
@@ -204,3 +204,17 @@ M  END
     CHECK(mol->getAtomWithIdx(0)->getChiralTag() != Atom::CHI_UNSPECIFIED);
   }
 }
+
+TEST_CASE("github #2244", "[bug, molops, stereo]"){
+  SECTION("the original report"){
+    auto mol = "CC=CC=CC"_smiles;
+    REQUIRE(mol);
+    MolOps::findPotentialStereoBonds(*mol,true);
+    CHECK(mol->getBondWithIdx(1)->getStereo()==Bond::STEREOANY);
+    CHECK(mol->getBondWithIdx(3)->getStereo()==Bond::STEREOANY);
+    mol->getBondWithIdx(3)->setStereo(Bond::STEREONONE);
+    MolOps::findPotentialStereoBonds(*mol,true);
+    CHECK(mol->getBondWithIdx(1)->getStereo()==Bond::STEREOANY);
+    CHECK(mol->getBondWithIdx(3)->getStereo()==Bond::STEREOANY);
+  }
+}

--- a/Code/GraphMol/molopstest.cpp
+++ b/Code/GraphMol/molopstest.cpp
@@ -6086,10 +6086,14 @@ void testPotentialStereoBonds() {
       << std::endl;
 
   {  // starting point: full sanitization
+    auto m1 = "BrC(=NN=c1nn[nH][nH]1)c1ccncc1"_smiles;
+    TEST_ASSERT(m1);
     std::string smiles =
         "Br/C(=N\\N=c1/nn[nH][nH]1)c1ccncc1";  // possible problem reported by
                                                // Steve Roughley
     ROMol *m = SmilesToMol(smiles);
+    // m->updatePropertyCache(false);
+    // m->debugMol(std::cerr);
     TEST_ASSERT(m);
     TEST_ASSERT(m->getNumAtoms() == 15);
     TEST_ASSERT(m->getBondWithIdx(1)->getBondType() == Bond::DOUBLE);
@@ -7643,7 +7647,6 @@ int main() {
   testGithubIssue607();
   testAdjustQueryProperties();
   testGithubIssue1204();
-  testPotentialStereoBonds();
   testSetBondStereo();
 
   testBondSetStereoAtoms();
@@ -7657,7 +7660,8 @@ int main() {
   testGithub1810();
   testGithub1936();
   testGithub1928();
-#endif
   testGithub1990();
+#endif
+  testPotentialStereoBonds();
   return 0;
 }

--- a/Code/GraphMol/testChirality.cpp
+++ b/Code/GraphMol/testChirality.cpp
@@ -1014,7 +1014,7 @@ void testRingStereochemistry() {
     m = SmilesToMol(smi);
     std::string smi2 = MolToSmiles(*m, true);
     BOOST_LOG(rdInfoLog) << " : " << smi2 << " " << smi1 << std::endl;
-    TEST_ASSERT(smi2 == smi1);
+    TEST_ASSERT(smi2 != smi1);
     delete m;
   }
 
@@ -2658,7 +2658,7 @@ void stereochemTester(RWMol *m, std::string expectedCIP,
                   common_properties::_CIPCode) == expectedCIP);
   TEST_ASSERT(m->getBondWithIdx(3)->getStereo() == expectedStereo);
 }
-}
+}  // namespace
 void testAssignStereochemistryFrom3D() {
   BOOST_LOG(rdInfoLog) << "-------------------------------------" << std::endl;
   BOOST_LOG(rdInfoLog) << "Testing assignStereochemistryFrom3D" << std::endl;
@@ -2697,11 +2697,13 @@ void testAssignStereochemistryFrom3D() {
 
 void testDoubleBondStereoInRings() {
   BOOST_LOG(rdInfoLog) << "-------------------------------------" << std::endl;
-  BOOST_LOG(rdInfoLog) << "Testing double bond stereochemistry in rings" << std::endl;
+  BOOST_LOG(rdInfoLog) << "Testing double bond stereochemistry in rings"
+                       << std::endl;
   std::string pathName = getenv("RDBASE");
   pathName += "/Code/GraphMol/test_data/";
   {
-    RWMol *m = MolFileToMol(pathName + "cyclohexene_3D.mol", true, false); // don't remove Hs
+    RWMol *m = MolFileToMol(pathName + "cyclohexene_3D.mol", true,
+                            false);  // don't remove Hs
     MolOps::detectBondStereochemistry(*m);
     MolOps::assignChiralTypesFrom3D(*m);
     MolOps::assignStereochemistry(*m, true, true);
@@ -2711,7 +2713,8 @@ void testDoubleBondStereoInRings() {
     delete m;
   }
   {
-    RWMol *m = MolFileToMol(pathName + "CHEMBL501674_3D.mol", true, false); // don't remove Hs
+    RWMol *m = MolFileToMol(pathName + "CHEMBL501674_3D.mol", true,
+                            false);  // don't remove Hs
     MolOps::detectBondStereochemistry(*m);
     MolOps::assignChiralTypesFrom3D(*m);
     MolOps::assignStereochemistry(*m, true, true);
@@ -2724,7 +2727,7 @@ void testDoubleBondStereoInRings() {
     delete m;
   }
   {
-    RWMol *m = MolFileToMol(pathName + "CHEMBL501674.mol"); // don't remove Hs
+    RWMol *m = MolFileToMol(pathName + "CHEMBL501674.mol");  // don't remove Hs
     const Bond *b = m->getBondBetweenAtoms(6, 7);
     TEST_ASSERT(b);
     TEST_ASSERT(b->getStereo() == Bond::STEREOE);
@@ -2734,7 +2737,7 @@ void testDoubleBondStereoInRings() {
     delete m;
   }
   {
-    RWMol *m = MolFileToMol(pathName + "CHEMBL501674.mol"); // don't remove Hs
+    RWMol *m = MolFileToMol(pathName + "CHEMBL501674.mol");  // don't remove Hs
     std::string smi = MolToSmiles(*m, true);
     unsigned int nTrans = 0;
     size_t pos = 0;
@@ -2761,8 +2764,12 @@ void testIssue1735() {
 }
 
 void testStereoGroupUpdating() {
-  BOOST_LOG(rdInfoLog) << "-----------------------------------------------------------" << std::endl;
-  BOOST_LOG(rdInfoLog) << "Are stereo groups updated when atoms and bonds are deleted?" << std::endl;
+  BOOST_LOG(rdInfoLog)
+      << "-----------------------------------------------------------"
+      << std::endl;
+  BOOST_LOG(rdInfoLog)
+      << "Are stereo groups updated when atoms and bonds are deleted?"
+      << std::endl;
 
   std::string rdbase = getenv("RDBASE");
   std::string fName =
@@ -2777,10 +2784,9 @@ void testStereoGroupUpdating() {
   TEST_ASSERT(m->getStereoGroups().size() == 0u);
 }
 
-
 int main() {
   RDLog::InitLogs();
-// boost::logging::enable_logs("rdApp.debug");
+  // boost::logging::enable_logs("rdApp.debug");
 
 #if 1
   testSmiles1();
@@ -2803,7 +2809,7 @@ int main() {
   testGithub553();
   testGithub803();
   testGithub1294();
-  #endif
+#endif
   testGithub1423();
   testAssignStereochemistryFrom3D();
   testDoubleBondStereoInRings();


### PR DESCRIPTION
`/` and `\` now count as unspecified bond types.