### PR TITLE
Store extra CXSMILES data as a property

### DIFF
--- a/Code/GraphMol/SmilesParse/SmilesParse.cpp
+++ b/Code/GraphMol/SmilesParse/SmilesParse.cpp
@@ -374,7 +374,7 @@ RWMol *SmilesToMol(const std::string &smiles,
   if (res && params.allowCXSMILES && !cxPart.empty()) {
     std::string::const_iterator pos = cxPart.cbegin();
     SmilesParseOps::parseCXExtensions(*res, cxPart, pos);
-    res->setProp("_CXSMILES_Data", cxPart.substr(0, pos - cxPart.cbegin()));
+    res->setProp("_CXSMILES_Data", std::string(cxPart.cbegin(), pos));
     if (params.parseName && pos != cxPart.cend()) {
       std::string nmpart(pos, cxPart.cend());
       name = boost::trim_copy(nmpart);

--- a/Code/GraphMol/SmilesParse/SmilesParse.cpp
+++ b/Code/GraphMol/SmilesParse/SmilesParse.cpp
@@ -374,6 +374,7 @@ RWMol *SmilesToMol(const std::string &smiles,
   if (res && params.allowCXSMILES && !cxPart.empty()) {
     std::string::const_iterator pos = cxPart.cbegin();
     SmilesParseOps::parseCXExtensions(*res, cxPart, pos);
+    res->setProp("_CXSMILES_Data", cxPart.substr(0, pos - cxPart.cbegin()));
     if (params.parseName && pos != cxPart.cend()) {
       std::string nmpart(pos, cxPart.cend());
       name = boost::trim_copy(nmpart);

--- a/Code/GraphMol/SmilesParse/cxsmiles_test.cpp
+++ b/Code/GraphMol/SmilesParse/cxsmiles_test.cpp
@@ -191,6 +191,7 @@ void testCXSmilesAndName() {
     TEST_ASSERT(m->getNumAtoms() == 3);
     TEST_ASSERT(m->getAtomWithIdx(0)->getProp<std::string>(
                     common_properties::atomLabel) == "foo");
+    TEST_ASSERT(m->getProp<std::string>("_CXSMILES_Data") == "|$foo;;bar$|");
     TEST_ASSERT(!m->hasProp("_Name"));
     delete m;
   }
@@ -205,6 +206,7 @@ void testCXSmilesAndName() {
     TEST_ASSERT(m->getNumAtoms() == 3);
     TEST_ASSERT(m->getAtomWithIdx(0)->getProp<std::string>(
                     common_properties::atomLabel) == "foo");
+    TEST_ASSERT(m->getProp<std::string>("_CXSMILES_Data") == "|$foo;;bar$|");
     TEST_ASSERT(m->getProp<std::string>(common_properties::_Name) == "ourname");
     delete m;
   }

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -4440,6 +4440,7 @@ CAS<~>
     self.assertEqual(m.GetAtomWithIdx(0).GetProp('atomLabel'), "foo")
     self.assertTrue(m.HasProp('_Name'))
     self.assertEqual(m.GetProp('_Name'), "ourname")
+    self.assertEqual(m.GetProp("_CXSMILES_Data"), "|$foo;;bar$|")
 
   def testPickleProps(self):
     from rdkit.six.moves import cPickle


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
This is a very quick patch to store extra CXSMILES information as a property, so that this information can be consulted or reused.


#### Any other comments?
By storing the extra CXSMILES information, it is available to be examined, so that even parts that are not currently being understood by RDKit are available to the user..
