### PR TITLE
Allow custom type-handlers in the RDProps interface

### DIFF
--- a/Code/DataStructs/CMakeLists.txt
+++ b/Code/DataStructs/CMakeLists.txt
@@ -16,6 +16,7 @@ rdkit_headers(base64.h
               BitVects.h
               BitVectUtils.h
               DatastructsException.h
+              DatastructsStreamOps.h
               DiscreteDistMat.h
               DiscreteValueVect.h
               ExplicitBitVect.h

--- a/Code/DataStructs/DatastructsStreamOps.h
+++ b/Code/DataStructs/DatastructsStreamOps.h
@@ -1,0 +1,78 @@
+//  Copyright (c) 2019, Novartis Institutes for BioMedical Research Inc.
+//  All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+//       copyright notice, this list of conditions and the following
+//       disclaimer in the documentation and/or other materials provided
+//       with the distribution.
+//     * Neither the name of Novartis Institutes for BioMedical Research Inc.
+//       nor the names of its contributors may be used to endorse or promote
+//       products derived from this software without specific prior written
+//       permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+#ifndef RDKIT_DATASTRUCTS_STREAMOPS
+#define RDKIT_DATASTRUCTS_STREAMOPS
+#include <RDGeneral/StreamOps.h>
+#include <DataStructs/ExplicitBitVect.h>
+#include <boost/any.hpp>
+
+namespace RDKit {
+class DataStructsExplicitBitVecPropHandler : public CustomPropHandler {
+public:
+  const char *getPropName() const { return "DataStructsExplicitBitVecPropHandler"; }
+  bool canSerialize(const RDValue &value) const {
+    try {
+      // this is expensive, but hopefully it won't be called too often....
+      rdvalue_cast<const ExplicitBitVect&>(value);
+      return true;
+    } catch ( boost::bad_any_cast & ) {
+      return false;
+    }
+  }
+  
+  bool read(std::istream &ss, RDValue &value) const {
+    std::string v;
+    int version = 0;
+    streamRead(ss, v, version);
+    ExplicitBitVect bv(v);
+    value = bv;
+    return true;
+  }
+  
+  bool write(std::ostream &ss, const RDValue &value) const {
+    try {
+      std::string output = rdvalue_cast<const ExplicitBitVect&>(value).toString();
+      streamWrite(ss, output);
+      return true;
+    } catch ( boost::bad_any_cast & ) {
+      return false;
+    }
+  }
+
+  CustomPropHandler *clone() const {
+    return new DataStructsExplicitBitVecPropHandler;
+  }
+
+};
+
+}
+#endif
+

--- a/Code/DataStructs/DatastructsStreamOps.h
+++ b/Code/DataStructs/DatastructsStreamOps.h
@@ -37,7 +37,7 @@
 namespace RDKit {
 class DataStructsExplicitBitVecPropHandler : public CustomPropHandler {
 public:
-  const char *getPropName() const { return "DataStructsExplicitBitVecPropHandler"; }
+  const char *getPropName() const { return "ExplicitBVProp"; }
   bool canSerialize(const RDValue &value) const {
     try {
       // this is expensive, but hopefully it won't be called too often....

--- a/Code/DataStructs/DatastructsStreamOps.h
+++ b/Code/DataStructs/DatastructsStreamOps.h
@@ -32,6 +32,7 @@
 #define RDKIT_DATASTRUCTS_STREAMOPS
 #include <RDGeneral/StreamOps.h>
 #include <DataStructs/ExplicitBitVect.h>
+#include <typeinfo>
 #include <boost/any.hpp>
 
 namespace RDKit {
@@ -39,13 +40,7 @@ class DataStructsExplicitBitVecPropHandler : public CustomPropHandler {
 public:
   const char *getPropName() const { return "ExplicitBVProp"; }
   bool canSerialize(const RDValue &value) const {
-    try {
-      // this is expensive, but hopefully it won't be called too often....
-      rdvalue_cast<const ExplicitBitVect&>(value);
-      return true;
-    } catch ( boost::bad_any_cast & ) {
-      return false;
-    }
+    return rdvalue_is<ExplicitBitVect>(value);
   }
   
   bool read(std::istream &ss, RDValue &value) const {

--- a/Code/DataStructs/testDatastructs.cpp
+++ b/Code/DataStructs/testDatastructs.cpp
@@ -24,7 +24,7 @@
 #include <RDGeneral/RDLog.h>
 #include <RDGeneral/Exceptions.h>
 #include <DataStructs/SparseIntVect.h>
-
+#include <DataStructs/DatastructsStreamOps.h>
 #include <stdlib.h>
 
 using namespace std;
@@ -1399,6 +1399,37 @@ void test15BitmapOps() {
   }
 }
 
+void test16BitVectProps() {
+  ExplicitBitVect bv(32);
+  for(int i=0;i<32;i+=2){
+    bv.setBit(i);
+  }
+
+  ExplicitBitVect bv2(bv.toString());
+  TEST_ASSERT(bv == bv2);
+  
+  Dict d;
+  d.setVal<ExplicitBitVect>("exp", bv);
+  RDValue &value = d.getData()[0].val;
+  
+  DataStructsExplicitBitVecPropHandler bv_handler;
+  std::vector<CustomPropHandler*> handlers = {&bv_handler,
+                                              bv_handler.clone()};
+  for(auto handler: handlers)
+  {
+    TEST_ASSERT(handler->canSerialize(value));
+    RDValue bad_value = 1;
+    TEST_ASSERT(!handler->canSerialize(bad_value));
+    std::stringstream ss;
+    TEST_ASSERT(handler->write(ss, value));
+    RDValue newValue;
+    TEST_ASSERT(handler->read(ss, newValue));
+    TEST_ASSERT(from_rdvalue<ExplicitBitVect>(newValue) == bv);
+  }
+  delete handlers[1];
+}
+
+
 int main() {
   RDLog::InitLogs();
   try {
@@ -1498,5 +1529,9 @@ int main() {
                        << std::endl;
   test15BitmapOps();
 
+  BOOST_LOG(rdInfoLog) << " Test bitmaps as properties "
+                          "-------------------------------"
+                       << std::endl;
+  test16BitVectProps();
   return 0;
 }

--- a/Code/GraphMol/MolPickler.h
+++ b/Code/GraphMol/MolPickler.h
@@ -16,6 +16,7 @@
 #include <GraphMol/QueryAtom.h>
 #include <GraphMol/Bond.h>
 #include <GraphMol/QueryBond.h>
+#include <RDGeneral/StreamOps.h>
 #include <boost/utility/binary.hpp>
 // Std stuff
 #include <iostream>
@@ -138,6 +139,9 @@ class RDKIT_GRAPHMOL_EXPORT MolPickler {
 
   static unsigned int getDefaultPickleProperties();
   static void setDefaultPickleProperties(unsigned int);
+
+  static const CustomPropHandlerVec &getCustomPropHandlers();
+  static void addCustomPropHandler(const CustomPropHandler &handler);
 
   //! pickles a molecule and sends the results to stream \c ss
   static void pickleMol(const ROMol *mol, std::ostream &ss);

--- a/Code/RDGeneral/StreamOps.h
+++ b/Code/RDGeneral/StreamOps.h
@@ -416,12 +416,12 @@ inline bool streamWriteProp(std::ostream &ss, const Dict::Pair &pair,
           //  customPropName (must be unique)
           //  custom serialization
           streamWrite(ss, DTags::CustomTag);
-          streamWrite(ss, handler->getPropName());
+          streamWrite(ss, std::string(handler->getPropName()));
           handler->write(ss, pair.val);
+          return true;
         }
       }
       
-      std::cerr << "Failed to write " << pair.key << std::endl;
       return false;
   }
   return true;
@@ -537,15 +537,13 @@ inline bool streamReadProp(std::istream &ss, Dict::Pair &pair,
         std::string propType;
         int version=0;
         streamRead(ss, propType, version);
-
         for(auto &handler: handlers) {
-          if(handler->getPropName() == propType) {
+          if(propType == handler->getPropName()) {
             handler->read(ss, pair.val);
             dictHasNonPOD = true;
             return true;
           }
         }
-        std::cerr << "Failed to read (unhandled custom type) " << pair.key << std::endl;
         return false;
       }
 

--- a/Code/RDGeneral/StreamOps.h
+++ b/Code/RDGeneral/StreamOps.h
@@ -357,8 +357,10 @@ inline bool isSerializable(const Dict::Pair &pair, const CustomPropHandlerVec &h
 
 inline bool streamWriteProp(std::ostream &ss, const Dict::Pair &pair,
                             const CustomPropHandlerVec &handlers = {}) {
-  if (!isSerializable(pair)) return false;
-
+  if (!isSerializable(pair, handlers)) {
+    return false;
+  }
+  
   streamWrite(ss, pair.key);
   switch (pair.val.getTag()) {
     case RDTypeTag::StringTag:
@@ -436,8 +438,10 @@ inline bool streamWriteProps(std::ostream &ss, const RDProps &props,
   for(Dict::DataType::const_iterator it = dict.getData().begin();
       it != dict.getData().end();
       ++it) {
-    if(isSerializable(*it) && propnames.find(it->key) != propnames.end()) {
-      count ++;
+    if(propnames.find(it->key) != propnames.end()) {
+      if (isSerializable(*it, handlers)) {
+        count ++;
+      }
     }
   }
 
@@ -448,7 +452,7 @@ inline bool streamWriteProps(std::ostream &ss, const RDProps &props,
       it != dict.getData().end();
       ++it) {
     if (propnames.find(it->key) != propnames.end()) {
-      if (isSerializable(*it)) {
+      if (isSerializable(*it, handlers)) {
         // note - not all properties are serializable, this may be
         //  a null op
         if (streamWriteProp(ss, *it, handlers)) {

--- a/Code/RDGeneral/testDict.cpp
+++ b/Code/RDGeneral/testDict.cpp
@@ -679,7 +679,6 @@ public:
   }
 };
 
-
 void testCustomProps() {
   Foo f(1,2.f);
   Dict d;
@@ -796,5 +795,6 @@ int main() {
 #endif
   testConstReturns();
   testUpdate();
+  testCustomProps();
   return 0;
 }

--- a/Code/RDGeneral/testDict.cpp
+++ b/Code/RDGeneral/testDict.cpp
@@ -641,16 +641,8 @@ class FooHandler : public CustomPropHandler {
 public:
   virtual const char *getPropName() const { return "Foo"; }
   virtual bool canSerialize(const RDValue &value) const {
-    try {
-      // this is expensive, but hopefully it won't be called too often....
-      rdvalue_cast<const Foo&>(value);
-      return true;
-    } catch ( boost::bad_any_cast & ) {
-      return false;
-    }
-
+    return rdvalue_is<Foo>(value);
   }
-  
   virtual bool read(std::istream &ss, RDValue &value) const {
     int version = 0;
     streamRead(ss, version);


### PR DESCRIPTION
Adds custom handlers to pickle arbitrary properties.

An example implementation of an ExplicitBitVector serializer is given.

I'm not super thrilled about using the bad_any_cast exception as flow control, I'll look for another solution.