### PR TITLE
Update maeparser & coordgen libraries

### DIFF
--- a/Code/GraphMol/FileParsers/MaeMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/MaeMolSupplier.cpp
@@ -25,16 +25,19 @@ using RDKit::MolInterchange::bolookup;
 MaeMolSupplier::MaeMolSupplier(std::istream *inStream, bool takeOwnership,
                                bool sanitize, bool removeHs) {
   PRECONDITION(inStream, "bad stream");
+  PRECONDITION(takeOwnership, "takeOwnership is required for MaeMolSupplier");
   dp_inStream = inStream;
-  df_owner = takeOwnership;
+  dp_sInStream.reset(dp_inStream);
+  df_owner = takeOwnership;  // always true
   df_sanitize = sanitize;
   df_removeHs = removeHs;
 
-  d_reader.reset(new schrodinger::mae::Reader(*inStream));
+  d_reader.reset(new schrodinger::mae::Reader(dp_sInStream));
   d_next_struct = d_reader->next("f_m_ct");
 }
 
-MaeMolSupplier::MaeMolSupplier(const std::string &fileName, bool sanitize, bool removeHs) {
+MaeMolSupplier::MaeMolSupplier(const std::string &fileName, bool sanitize,
+                               bool removeHs) {
   df_owner = true;
   auto *ifs = new std::ifstream(fileName.c_str(), std::ios_base::binary);
   if (!ifs || !(*ifs) || ifs->bad()) {
@@ -42,11 +45,12 @@ MaeMolSupplier::MaeMolSupplier(const std::string &fileName, bool sanitize, bool 
     errout << "Bad input file " << fileName;
     throw BadFileException(errout.str());
   }
-  dp_inStream = static_cast<std::istream*>(ifs);
+  dp_inStream = static_cast<std::istream *>(ifs);
+  dp_sInStream.reset(dp_inStream);
   df_sanitize = sanitize;
   df_removeHs = removeHs;
 
-  d_reader.reset(new schrodinger::mae::Reader(*ifs));
+  d_reader.reset(new schrodinger::mae::Reader(dp_sInStream));
   d_next_struct = d_reader->next("f_m_ct");
 }
 
@@ -67,7 +71,7 @@ ROMol *MaeMolSupplier::next() {
   // Atom data is in the m_atom indexed block
   {
     const auto atom_data = current_struct->getIndexedBlock("m_atom");
-    // All atoms are gauranteed to have these three field names:
+    // All atoms are guaranteed to have these three field names:
     const auto atomic_numbers = atom_data->getIntProperty("i_m_atomic_number");
     const auto xs = atom_data->getRealProperty("r_m_x_coord");
     const auto ys = atom_data->getRealProperty("r_m_y_coord");
@@ -101,7 +105,7 @@ ROMol *MaeMolSupplier::next() {
   // Bond data is in the m_bond indexed block
   {
     const auto bond_data = current_struct->getIndexedBlock("m_bond");
-    // All bonds are gauranteed to have these three field names:
+    // All bonds are guaranteed to have these three field names:
     auto from_atoms = bond_data->getIntProperty("i_m_from");
     auto to_atoms = bond_data->getIntProperty("i_m_to");
     auto orders = bond_data->getIntProperty("i_m_order");

--- a/Code/GraphMol/FileParsers/MaeMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/MaeMolSupplier.cpp
@@ -22,6 +22,19 @@ namespace RDKit {
 
 using RDKit::MolInterchange::bolookup;
 
+MaeMolSupplier::MaeMolSupplier(std::shared_ptr<std::istream> inStream,
+                               bool sanitize, bool removeHs) {
+  PRECONDITION(inStream, "bad stream");
+  dp_sInStream = inStream;
+  dp_inStream = inStream.get();
+  df_owner = true;
+  df_sanitize = sanitize;
+  df_removeHs = removeHs;
+
+  d_reader.reset(new schrodinger::mae::Reader(dp_sInStream));
+  d_next_struct = d_reader->next("f_m_ct");
+}
+
 MaeMolSupplier::MaeMolSupplier(std::istream *inStream, bool takeOwnership,
                                bool sanitize, bool removeHs) {
   PRECONDITION(inStream, "bad stream");

--- a/Code/GraphMol/FileParsers/MolSupplier.h
+++ b/Code/GraphMol/FileParsers/MolSupplier.h
@@ -364,15 +364,23 @@ class RDKIT_FILEPARSERS_EXPORT PDBMolSupplier : public MolSupplier {
 #ifdef RDK_BUILD_COORDGEN_SUPPORT
 //! lazy file parser for MAE files
 class RDKIT_FILEPARSERS_EXPORT MaeMolSupplier : public MolSupplier {
+  /**
+   * Due to maeparser's shared_ptr<istream> Reader interface, MaeMolSupplier
+   * always requires taking ownership of the istream ptr, as the shared ptr will
+   * always clear it upon destruction.
+   */
+
  public:
   MaeMolSupplier() { init(); };
+
   explicit MaeMolSupplier(std::istream *inStream, bool takeOwnership = true,
                           bool sanitize = true, bool removeHs = true);
+
   explicit MaeMolSupplier(const std::string &fname, bool sanitize = true,
                           bool removeHs = true);
 
-  virtual ~MaeMolSupplier() {
-    if (df_owner && dp_inStream) delete dp_inStream;
+  virtual ~MaeMolSupplier(){
+      // The dp_sInStream shared_ptr will take care of cleaning up.
   };
 
   virtual void init();
@@ -384,6 +392,7 @@ class RDKIT_FILEPARSERS_EXPORT MaeMolSupplier : public MolSupplier {
   bool df_sanitize, df_removeHs;
   std::shared_ptr<schrodinger::mae::Reader> d_reader;
   std::shared_ptr<schrodinger::mae::Block> d_next_struct;
+  std::shared_ptr<std::istream> dp_sInStream;
 };
 #endif  // RDK_BUILD_COORDGEN_SUPPORT
 }  // namespace RDKit

--- a/Code/GraphMol/FileParsers/MolSupplier.h
+++ b/Code/GraphMol/FileParsers/MolSupplier.h
@@ -373,6 +373,9 @@ class RDKIT_FILEPARSERS_EXPORT MaeMolSupplier : public MolSupplier {
  public:
   MaeMolSupplier() { init(); };
 
+  explicit MaeMolSupplier(std::shared_ptr<std::istream> inStream,
+                          bool sanitize = true, bool removeHs = true);
+
   explicit MaeMolSupplier(std::istream *inStream, bool takeOwnership = true,
                           bool sanitize = true, bool removeHs = true);
 

--- a/Code/GraphMol/FileParsers/testMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/testMolSupplier.cpp
@@ -2176,7 +2176,7 @@ int testForwardSDSupplier() {
   }
   // looks good, now do a supplier:
   {
-    auto *strm = new io::filtering_istream();
+    auto strm = std::make_shared<io::filtering_istream>();
     // the stream must be opened in binary mode otherwise it won't work on
     // Windows
     std::ifstream is(maefname2.c_str(), std::ios_base::binary);

--- a/Code/GraphMol/FileParsers/testMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/testMolSupplier.cpp
@@ -2176,13 +2176,13 @@ int testForwardSDSupplier() {
   }
   // looks good, now do a supplier:
   {
-    io::filtering_istream strm;
+    auto *strm = new io::filtering_istream();
     // the stream must be opened in binary mode otherwise it won't work on
     // Windows
     std::ifstream is(maefname2.c_str(), std::ios_base::binary);
-    strm.push(io::gzip_decompressor());
-    strm.push(is);
-    MaeMolSupplier maesup(&strm, false);
+    strm->push(io::gzip_decompressor());
+    strm->push(is);
+    MaeMolSupplier maesup(strm);
     unsigned int i = 0;
     std::shared_ptr<ROMol> nmol;
     while (!maesup.atEnd()) {

--- a/Code/GraphMol/Wrap/MaeMolSupplier.cpp
+++ b/Code/GraphMol/Wrap/MaeMolSupplier.cpp
@@ -35,42 +35,43 @@ class LocalMaeMolSupplier : public RDKit::MaeMolSupplier {
     // FIX: minor leak here
     auto *sb = new streambuf(input);
     dp_inStream = new streambuf::istream(*sb);
+    dp_sInStream.reset(dp_inStream);
     df_owner = true;
     df_sanitize = sanitize;
     df_removeHs = removeHs;
-    d_reader.reset(new schrodinger::mae::Reader(*dp_inStream));
+    d_reader.reset(new schrodinger::mae::Reader(dp_sInStream));
     d_next_struct = d_reader->next("f_m_ct");
     POSTCONDITION(dp_inStream, "bad instream");
   }
   LocalMaeMolSupplier(streambuf &input, bool sanitize, bool removeHs) {
     dp_inStream = new streambuf::istream(input);
+    dp_sInStream.reset(dp_inStream);
     df_owner = true;
     df_sanitize = sanitize;
     df_removeHs = removeHs;
-    d_reader.reset(new schrodinger::mae::Reader(*dp_inStream));
+    d_reader.reset(new schrodinger::mae::Reader(dp_sInStream));
     d_next_struct = d_reader->next("f_m_ct");
     POSTCONDITION(dp_inStream, "bad instream");
   }
 
   LocalMaeMolSupplier(const std::string &fname, bool sanitize = true,
-          bool removeHs = true)
-    {
-        df_owner = true;
-        auto *ifs = new std::ifstream(fname.c_str(), std::ios_base::binary);
-        if (!ifs || !(*ifs) || ifs->bad()) {
-            std::ostringstream errout;
-            errout << "Bad input file " << fname;
-            throw RDKit::BadFileException(errout.str());
-        }
-        dp_inStream = (std::istream *)ifs;
-        df_sanitize = sanitize;
-        df_removeHs = removeHs;
+                      bool removeHs = true) {
+    df_owner = true;
+    auto *ifs = new std::ifstream(fname.c_str(), std::ios_base::binary);
+    if (!ifs || !(*ifs) || ifs->bad()) {
+      std::ostringstream errout;
+      errout << "Bad input file " << fname;
+      throw RDKit::BadFileException(errout.str());
+    }
+    dp_inStream = (std::istream *)ifs;
+    dp_sInStream.reset(dp_inStream);
+    df_sanitize = sanitize;
+    df_removeHs = removeHs;
 
-        d_reader.reset(new schrodinger::mae::Reader(*ifs));
-        d_next_struct = d_reader->next("f_m_ct");
-        POSTCONDITION(dp_inStream, "bad instream");
-    };
-
+    d_reader.reset(new schrodinger::mae::Reader(dp_sInStream));
+    d_next_struct = d_reader->next("f_m_ct");
+    POSTCONDITION(dp_inStream, "bad instream");
+  };
 };
 
 LocalMaeMolSupplier *FwdMolSupplIter(LocalMaeMolSupplier *self) {

--- a/External/CoordGen/CMakeLists.txt
+++ b/External/CoordGen/CMakeLists.txt
@@ -35,7 +35,14 @@ if(RDK_BUILD_COORDGEN_SUPPORT)
     set(maeparser_INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}
         CACHE STRING "MaeParser Include Dir" FORCE)
     file(GLOB MAESOURCES "${MAEPARSER_DIR}/*.cpp")
-    rdkit_library(maeparser ${MAESOURCES} SHARED)
+
+    find_package(Boost 1.56.0 COMPONENTS system iostreams REQUIRED)
+    set (link_iostreams ${Boost_LIBRARIES})
+    if (NOT Boost_USE_STATIC_LIBS)
+      add_definitions("-DBOOST_IOSTREAMS_DYN_LINK")
+    endif()
+
+    rdkit_library(maeparser ${MAESOURCES} LINK_LIBRARIES ${Boost_LIBRARIES} SHARED)
     install(TARGETS maeparser DESTINATION ${RDKit_LibDir})
     set(maeparser_LIBRARIES maeparser)
 
@@ -79,14 +86,8 @@ if(RDK_BUILD_COORDGEN_SUPPORT)
           DESTINATION ${RDKit_ShareDir}/Data
           COMPONENT data)
 
-  find_package(Boost 1.56.0 COMPONENTS system iostreams REQUIRED)
-  set (link_iostreams ${Boost_LIBRARIES})
-  if (NOT Boost_USE_STATIC_LIBS)
-    add_definitions("-DBOOST_IOSTREAMS_DYN_LINK")
-  endif()
-
   set(RDK_COORDGEN_LIBS MolAlign ${coordgen_LIBRARIES} ${maeparser_LIBRARIES}
-      ${link_iostreams} CACHE STRING "the external libraries" FORCE)
+      CACHE STRING "the external libraries" FORCE)
   rdkit_headers(CoordGen.h DEST GraphMol)
 
   if(RDK_BUILD_PYTHON_WRAPPERS)

--- a/External/CoordGen/CMakeLists.txt
+++ b/External/CoordGen/CMakeLists.txt
@@ -18,8 +18,8 @@ if(RDK_BUILD_COORDGEN_SUPPORT)
     endif()
 
     if(NOT EXISTS "${MAEPARSER_DIR}/MaeParser.hpp")
-        set(RELEASE_NO "1.0.1")
-        set(MD5 "1292494df756e95fd1cce722286f28fe")
+        set(RELEASE_NO "1.1")
+        set(MD5 "336235a4c46de5e520826c2f9de9c07b")
         downloadAndCheckMD5("https://github.com/schrodinger/maeparser/archive/v${RELEASE_NO}.tar.gz"
               "${CMAKE_CURRENT_SOURCE_DIR}/maeparser-v${RELEASE_NO}.tar.gz" ${MD5})
         execute_process(COMMAND ${CMAKE_COMMAND} -E tar zxf
@@ -35,7 +35,7 @@ if(RDK_BUILD_COORDGEN_SUPPORT)
     set(maeparser_INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}
         CACHE STRING "MaeParser Include Dir" FORCE)
     file(GLOB MAESOURCES "${MAEPARSER_DIR}/*.cpp")
-    rdkit_library(maeparser ${MAESOURCES} SHARED )
+    rdkit_library(maeparser ${MAESOURCES} SHARED)
     install(TARGETS maeparser DESTINATION ${RDKit_LibDir})
     set(maeparser_LIBRARIES maeparser)
 
@@ -49,8 +49,8 @@ if(RDK_BUILD_COORDGEN_SUPPORT)
     endif()
 
     if(NOT EXISTS "${COORDGEN_DIR}/sketcherMinimizer.h")
-        set(RELEASE_NO "1.2")
-        set(MD5 "cc132a4655e194143d760239f69dd265")
+        set(RELEASE_NO "1.2.1")
+        set(MD5 "f7faf4878bd7cfcfb500fa6c664fb036")
         downloadAndCheckMD5("https://github.com/schrodinger/coordgenlibs/archive/v${RELEASE_NO}.tar.gz"
               "${CMAKE_CURRENT_SOURCE_DIR}/coordgenlibs-${RELEASE_NO}.tar.gz" ${MD5})
         execute_process(COMMAND ${CMAKE_COMMAND} -E tar zxf
@@ -79,8 +79,14 @@ if(RDK_BUILD_COORDGEN_SUPPORT)
           DESTINATION ${RDKit_ShareDir}/Data
           COMPONENT data)
 
+  find_package(Boost 1.56.0 COMPONENTS system iostreams REQUIRED)
+  set (link_iostreams ${Boost_LIBRARIES})
+  if (NOT Boost_USE_STATIC_LIBS)
+    add_definitions("-DBOOST_IOSTREAMS_DYN_LINK")
+  endif()
+
   set(RDK_COORDGEN_LIBS MolAlign ${coordgen_LIBRARIES} ${maeparser_LIBRARIES}
-      CACHE STRING "the external libraries" FORCE)
+      ${link_iostreams} CACHE STRING "the external libraries" FORCE)
   rdkit_headers(CoordGen.h DEST GraphMol)
 
   if(RDK_BUILD_PYTHON_WRAPPERS)

--- a/External/CoordGen/test.cpp
+++ b/External/CoordGen/test.cpp
@@ -111,7 +111,7 @@ void test1() {
 }
 
 namespace {
-bool compareConfs(const ROMol* m, const ROMol* templ, const MatchVectType& mv,
+bool compareConfs(const ROMol* m, ROMol* templ, const MatchVectType& mv,
                   bool alignFirst = false, int molConfId = -1,
                   int templateConfId = -1, double postol = 1e-2,
                   double rmstol = 0.1) {
@@ -120,9 +120,8 @@ bool compareConfs(const ROMol* m, const ROMol* templ, const MatchVectType& mv,
   TEST_ASSERT(m->getNumAtoms() >= templ->getNumAtoms());
 
   if (alignFirst) {
-    RDGeom::Transform3D trans;
-    double rmsd = MolAlign::getAlignmentTransform(*templ, *m, trans, molConfId,
-                                                  templateConfId, &mv);
+    double rmsd =
+        MolAlign::alignMol(*templ, *m, molConfId, templateConfId, &mv);
     if (rmsd > rmstol) return false;
   }
 
@@ -335,7 +334,9 @@ void test2() {
     TEST_ASSERT(m->getNumConformers() == 1);
     mb = MolToMolBlock(*m);
     std::cerr << mb << std::endl;
-    TEST_ASSERT(!compareConfs(m, core, mv, true));
+    // This is a rigid core: if we provide the matching substructure,
+    // and do alignment, the conformations will still match.
+    TEST_ASSERT(!compareConfs(m, core, mv, false));
 
     {
       CoordGen::CoordGenParams params;
@@ -372,7 +373,10 @@ void test2() {
     TEST_ASSERT(m->getNumConformers() == 1);
     mb = MolToMolBlock(*m);
     std::cerr << mb << std::endl;
-    TEST_ASSERT(!compareConfs(m, core, mv, true));
+    // This mol is just slightly bigger than the core, providing
+    // the matching substructure and doing alignment will cause
+    // the conformations to match.
+    TEST_ASSERT(!compareConfs(m, core, mv, false));
 
     {
       CoordGen::CoordGenParams params;


### PR DESCRIPTION
#### What does this implement/fix?
Update maeparser to release v1.1 and coordgen to v1.2.1.

#### Any other comments?

- The update to the latest maeparser comes with a change in the interface: the constructors for MaeParser and Reader that previously took a reference to a stream now take a shared_ptr to a stream. I have updated the MaeMolSupplier with the simplest change I can think of: adding an extra property to hold the shared_ptr to guarantee it is available as long as the object exists. But having the shared_ptr means that, as soon as the object is destroyed, the pointer to the stream will also be deleted. So, now, the MaeMolSupplier(std::istream *inStream, ...) interface always has to take ownership of the stream, so I added a precondition to check that. I'm open to any alternate suggestions on hwo to implement the update, though.

- The latest maeparser also supports reading from compressed mae files (maegz), and now requires acess to Boost iostreams.

- The update to coordgen broke a couple of tests in testCoordGen. I have updated them and added a couple of comments with my understading of what is happening there. Please feel free to correct me.

