### PR TITLE
Add a skip_all_if_match option to the FragmentRemover

### DIFF
--- a/Code/GraphMol/MolStandardize/CMakeLists.txt
+++ b/Code/GraphMol/MolStandardize/CMakeLists.txt
@@ -61,6 +61,9 @@ rdkit_test(molStandardizeSmallTest test2.cpp LINK_LIBRARIES MolStandardize
 rdkit_test(molFragmentTest testFragment.cpp LINK_LIBRARIES MolStandardize
 	Catalogs SmilesParse RDGeneral GraphMol SubstructMatch FileParsers
 	ChemTransforms Descriptors)
+rdkit_catch_test(molStandardizeCatchTest catch_tests.cpp LINK_LIBRARIES MolStandardize
+	Catalogs SmilesParse RDGeneral GraphMol SubstructMatch FileParsers
+	ChemTransforms Descriptors)
 
 #find_package(Boost 1.56.0 COMPONENTS system iostreams REQUIRED)
 #if (NOT Boost_USE_STATIC_LIBS)

--- a/Code/GraphMol/MolStandardize/Fragment.cpp
+++ b/Code/GraphMol/MolStandardize/Fragment.cpp
@@ -82,20 +82,24 @@ ROMol *FragmentRemover::remove(const ROMol &mol) {
                              SubstructMatch(*frag.first, *fgci).size() > 0;
                     }),
                 frags.end());
+    if (this->LEAVE_LAST && !this->SKIP_IF_ALL_MATCH && frags.empty()) {
+      // All the remaining fragments match this pattern - leave them all
+      frags = tfrags;
+      break;
+    }
     if (frags.size() != oCount) {
       BOOST_LOG(rdInfoLog) << "Removed fragment: "
                            << fgci->getProp<std::string>(
                                   common_properties::_Name)
                            << "\n";
     }
-    if (this->LEAVE_LAST && !this->SKIP_IF_ALL_MATCH && frags.empty()) {
-      // All the remaining fragments match this pattern - leave them all
-      frags = tfrags;
-      break;
-    }
   }
   if (frags.empty()) {
-    if (this->SKIP_IF_ALL_MATCH) return new ROMol(mol);
+    if (this->SKIP_IF_ALL_MATCH) {
+      BOOST_LOG(rdInfoLog)
+          << "All fragments matched; original molecule returned." << std::endl;
+      return new ROMol(mol);
+    }
     return new ROMol();
   }
 

--- a/Code/GraphMol/MolStandardize/Fragment.h
+++ b/Code/GraphMol/MolStandardize/Fragment.h
@@ -8,8 +8,8 @@
 //  of the RDKit source tree.
 //
 #include <RDGeneral/export.h>
-#ifndef __RD_FRAGMENT_REMOVER_H__
-#define __RD_FRAGMENT_REMOVER_H__
+#ifndef RD_FRAGMENT_REMOVER_H
+#define RD_FRAGMENT_REMOVER_H
 
 #include <Catalogs/Catalog.h>
 #include <GraphMol/MolStandardize/FragmentCatalog/FragmentCatalogEntry.h>
@@ -31,12 +31,13 @@ typedef RDCatalog::HierarchCatalog<FragmentCatalogEntry, FragmentCatalogParams,
 class RDKIT_MOLSTANDARDIZE_EXPORT FragmentRemover {
  public:
   FragmentRemover();
-  FragmentRemover(const std::string fragmentFile, const bool leave_last);
-  //  FragmentRemover(bool leave_last) : LEAVE_LAST(leave_last){};
+  FragmentRemover(const std::string fragmentFile, bool leave_last,
+                  bool skip_if_all_match = false);
+  ~FragmentRemover();
+
   //! making FragmentRemover objects non-copyable
   FragmentRemover(const FragmentRemover &other) = delete;
   FragmentRemover &operator=(FragmentRemover const &) = delete;
-  ~FragmentRemover();
 
   ROMol *remove(const ROMol &mol);
 
@@ -45,6 +46,9 @@ class RDKIT_MOLSTANDARDIZE_EXPORT FragmentRemover {
   //  is left in the molecule, even if it is matched by a
   //  FragmentPattern
   bool LEAVE_LAST;
+  // If set, this causes the original molecule to be returned
+  // if every fragment in it matches the salt list
+  bool SKIP_IF_ALL_MATCH;
   FragmentCatalog *d_fcat;
 
 };  // class FragmentRemover

--- a/Code/GraphMol/MolStandardize/Wrap/Fragment.cpp
+++ b/Code/GraphMol/MolStandardize/Wrap/Fragment.cpp
@@ -38,7 +38,10 @@ struct fragment_wrapper {
 
     python::class_<MolStandardize::FragmentRemover, boost::noncopyable>(
         "FragmentRemover", python::init<>())
-        .def(python::init<std::string, bool>())
+        .def(python::init<std::string, bool, bool>(
+            (python::arg("fragmentFilename") = "",
+            python::arg("leave_last") = true,
+            python::arg("skip_if_all_match") = false)))
         .def("remove", &removeHelper, (python::arg("self"), python::arg("mol")),
              "", python::return_value_policy<python::manage_new_object>());
 

--- a/Code/GraphMol/MolStandardize/Wrap/testMolStandardize.py
+++ b/Code/GraphMol/MolStandardize/Wrap/testMolStandardize.py
@@ -3,7 +3,9 @@
 #         All Rights Reserved
 #
 from rdkit import RDConfig
-import os, sys, math
+import os
+import sys
+import math
 import unittest
 from rdkit import DataStructs
 from rdkit import Chem
@@ -14,147 +16,154 @@ from rdkit.Chem.MolStandardize import rdMolStandardize
 
 class TestCase(unittest.TestCase):
 
-  def setUp(self):
-    pass
+    def setUp(self):
+        pass
 
-  def test1Cleanup(self):
-    mol = Chem.MolFromSmiles("CCC(=O)O[Na]")
-    nmol = rdMolStandardize.Cleanup(mol)
-    self.assertEqual(Chem.MolToSmiles(nmol), "CCC(=O)[O-].[Na+]")
+    def test1Cleanup(self):
+        mol = Chem.MolFromSmiles("CCC(=O)O[Na]")
+        nmol = rdMolStandardize.Cleanup(mol)
+        self.assertEqual(Chem.MolToSmiles(nmol), "CCC(=O)[O-].[Na+]")
 
-  def test2StandardizeSmiles(self):
-    self.assertEqual(rdMolStandardize.StandardizeSmiles("CCC(=O)O[Na]"), "CCC(=O)[O-].[Na+]")
-    # should get ValueError
+    def test2StandardizeSmiles(self):
+        self.assertEqual(rdMolStandardize.StandardizeSmiles("CCC(=O)O[Na]"), "CCC(=O)[O-].[Na+]")
+        # should get ValueError
 
 
 #    rdMolStandardize.StandardizeSmiles("C1CCC1C(=O)O.Na")
 
-  def test3FragmentParent(self):
-    mol = Chem.MolFromSmiles("[Na]OC(=O)c1ccccc1")
-    nmol = rdMolStandardize.FragmentParent(mol)
-    self.assertEqual(Chem.MolToSmiles(nmol), "O=C([O-])c1ccccc1")
 
-  def test4ChargeParent(self):
-    mol = Chem.MolFromSmiles("C[NH+](C)(C).[Cl-]")
-    nmol = rdMolStandardize.ChargeParent(mol)
-    self.assertEqual(Chem.MolToSmiles(nmol), "CN(C)C")
+    def test3FragmentParent(self):
+        mol = Chem.MolFromSmiles("[Na]OC(=O)c1ccccc1")
+        nmol = rdMolStandardize.FragmentParent(mol)
+        self.assertEqual(Chem.MolToSmiles(nmol), "O=C([O-])c1ccccc1")
 
-  def test4Normalize(self):
-    mol = Chem.MolFromSmiles("C[N+](C)=C\C=C\[O-]")
-    nmol = rdMolStandardize.Normalize(mol)
-    self.assertEqual(Chem.MolToSmiles(nmol), "CN(C)C=CC=O")
+    def test4ChargeParent(self):
+        mol = Chem.MolFromSmiles("C[NH+](C)(C).[Cl-]")
+        nmol = rdMolStandardize.ChargeParent(mol)
+        self.assertEqual(Chem.MolToSmiles(nmol), "CN(C)C")
 
-  def test4Reionize(self):
-    mol = Chem.MolFromSmiles("C1=C(C=CC(=C1)[S]([O-])=O)[S](O)(=O)=O")
-    nmol = rdMolStandardize.Reionize(mol)
-    self.assertEqual(Chem.MolToSmiles(nmol), "O=S(O)c1ccc(S(=O)(=O)[O-])cc1")
+    def test4Normalize(self):
+        mol = Chem.MolFromSmiles("C[N+](C)=C\C=C\[O-]")
+        nmol = rdMolStandardize.Normalize(mol)
+        self.assertEqual(Chem.MolToSmiles(nmol), "CN(C)C=CC=O")
 
-  def test5Metal(self):
-    mol = Chem.MolFromSmiles("C1(CCCCC1)[Zn]Br")
-    md = rdMolStandardize.MetalDisconnector()
-    nm = md.Disconnect(mol)
-    #    Metal.MetalDisconnector.Disconnect(mol)
-    self.assertEqual(Chem.MolToSmiles(nm), "[Br-].[CH-]1CCCCC1.[Zn+2]")
+    def test4Reionize(self):
+        mol = Chem.MolFromSmiles("C1=C(C=CC(=C1)[S]([O-])=O)[S](O)(=O)=O")
+        nmol = rdMolStandardize.Reionize(mol)
+        self.assertEqual(Chem.MolToSmiles(nmol), "O=S(O)c1ccc(S(=O)(=O)[O-])cc1")
 
-    # test user defined metal_nof
-    md.SetMetalNof(
-      Chem.MolFromSmarts(
-        "[Li,K,Rb,Cs,Fr,Be,Mg,Ca,Sr,Ba,Ra,Sc,Ti,V,Cr,Mn,Fe,Co,Ni,Cu,Zn,Al,Ga,Y,Zr,Nb,Mo,Tc,Ru,Rh,Pd,Ag,Cd,In,Sn,Hf,Ta,W,Re,Os,Ir,Pt,Au,Hg,Tl,Pb,Bi]~[N,O,F]"
-      ))
-    mol2 = Chem.MolFromSmiles("CCC(=O)O[Na]")
-    nm2 = md.Disconnect(mol2)
-    self.assertEqual(Chem.MolToSmiles(nm2), "CCC(=O)O[Na]")
+    def test5Metal(self):
+        mol = Chem.MolFromSmiles("C1(CCCCC1)[Zn]Br")
+        md = rdMolStandardize.MetalDisconnector()
+        nm = md.Disconnect(mol)
+        #    Metal.MetalDisconnector.Disconnect(mol)
+        self.assertEqual(Chem.MolToSmiles(nm), "[Br-].[CH-]1CCCCC1.[Zn+2]")
 
-  def test6Charge(self):
-    mol = Chem.MolFromSmiles("C1=C(C=CC(=C1)[S]([O-])=O)[S](O)(=O)=O")
-    # instantiate with default acid base pair library
-    reionizer = rdMolStandardize.Reionizer()
-    nm = reionizer.reionize(mol)
-    self.assertEqual(Chem.MolToSmiles(nm), "O=S(O)c1ccc(S(=O)(=O)[O-])cc1")
+        # test user defined metal_nof
+        md.SetMetalNof(
+          Chem.MolFromSmarts(
+            "[Li,K,Rb,Cs,Fr,Be,Mg,Ca,Sr,Ba,Ra,Sc,Ti,V,Cr,Mn,Fe,Co,Ni,Cu,Zn,Al,Ga,Y,Zr,Nb,Mo,Tc,Ru,Rh,Pd,Ag,Cd,In,Sn,Hf,Ta,W,Re,Os,Ir,Pt,Au,Hg,Tl,Pb,Bi]~[N,O,F]"
+          ))
+        mol2 = Chem.MolFromSmiles("CCC(=O)O[Na]")
+        nm2 = md.Disconnect(mol2)
+        self.assertEqual(Chem.MolToSmiles(nm2), "CCC(=O)O[Na]")
 
-    # try reionize with another acid base pair library without the right
-    # pairs
-    abfile = os.path.join(RDConfig.RDDataDir, 'MolStandardize', 'acid_base_pairs2.txt')
-    reionizer2 = rdMolStandardize.Reionizer(abfile)
-    nm2 = reionizer2.reionize(mol)
-    self.assertEqual(Chem.MolToSmiles(nm2), "O=S([O-])c1ccc(S(=O)(=O)O)cc1")
+    def test6Charge(self):
+        mol = Chem.MolFromSmiles("C1=C(C=CC(=C1)[S]([O-])=O)[S](O)(=O)=O")
+        # instantiate with default acid base pair library
+        reionizer = rdMolStandardize.Reionizer()
+        nm = reionizer.reionize(mol)
+        self.assertEqual(Chem.MolToSmiles(nm), "O=S(O)c1ccc(S(=O)(=O)[O-])cc1")
 
-    # test Uncharger
-    uncharger = rdMolStandardize.Uncharger()
-    mol3 = Chem.MolFromSmiles("O=C([O-])c1ccccc1")
-    nm3 = uncharger.uncharge(mol3)
-    self.assertEqual(Chem.MolToSmiles(nm3), "O=C(O)c1ccccc1")
+        # try reionize with another acid base pair library without the right
+        # pairs
+        abfile = os.path.join(RDConfig.RDDataDir, 'MolStandardize', 'acid_base_pairs2.txt')
+        reionizer2 = rdMolStandardize.Reionizer(abfile)
+        nm2 = reionizer2.reionize(mol)
+        self.assertEqual(Chem.MolToSmiles(nm2), "O=S([O-])c1ccc(S(=O)(=O)O)cc1")
 
-  def test7Fragment(self):
-    fragremover = rdMolStandardize.FragmentRemover()
-    mol = Chem.MolFromSmiles("CN(C)C.Cl.Cl.Br")
-    nm = fragremover.remove(mol)
-    self.assertEqual(Chem.MolToSmiles(nm), "CN(C)C")
+        # test Uncharger
+        uncharger = rdMolStandardize.Uncharger()
+        mol3 = Chem.MolFromSmiles("O=C([O-])c1ccccc1")
+        nm3 = uncharger.uncharge(mol3)
+        self.assertEqual(Chem.MolToSmiles(nm3), "O=C(O)c1ccccc1")
 
-    lfragchooser = rdMolStandardize.LargestFragmentChooser()
-    mol2 = Chem.MolFromSmiles("[N+](=O)([O-])[O-].[CH3+]")
-    nm2 = lfragchooser.choose(mol2)
-    self.assertEqual(Chem.MolToSmiles(nm2), "O=[N+]([O-])[O-]")
+    def test7Fragment(self):
+        fragremover = rdMolStandardize.FragmentRemover()
+        mol = Chem.MolFromSmiles("CN(C)C.Cl.Cl.Br")
+        nm = fragremover.remove(mol)
+        self.assertEqual(Chem.MolToSmiles(nm), "CN(C)C")
 
-    lfragchooser2 = rdMolStandardize.LargestFragmentChooser(preferOrganic=True)
-    nm3 = lfragchooser2.choose(mol2)
-    self.assertEqual(Chem.MolToSmiles(nm3), "[CH3+]")
+        lfragchooser = rdMolStandardize.LargestFragmentChooser()
+        mol2 = Chem.MolFromSmiles("[N+](=O)([O-])[O-].[CH3+]")
+        nm2 = lfragchooser.choose(mol2)
+        self.assertEqual(Chem.MolToSmiles(nm2), "O=[N+]([O-])[O-]")
 
-  def test8Normalize(self):
-    normalizer = rdMolStandardize.Normalizer()
-    mol = Chem.MolFromSmiles("C[n+]1ccccc1[O-]")
-    nm = normalizer.normalize(mol)
-    self.assertEqual(Chem.MolToSmiles(nm), "Cn1ccccc1=O")
+        lfragchooser2 = rdMolStandardize.LargestFragmentChooser(preferOrganic=True)
+        nm3 = lfragchooser2.choose(mol2)
+        self.assertEqual(Chem.MolToSmiles(nm3), "[CH3+]")
 
-  def test9Validate(self):
-    vm = rdMolStandardize.RDKitValidation()
-    mol = Chem.MolFromSmiles("CO(C)C", sanitize=False)
-    msg = vm.validate(mol)
-    self.assertEqual(len(msg), 1)
-    self.assertEqual
-    ("""INFO: [ValenceValidation] Explicit valence for atom # 1 O, 3, is greater than permitted""",
-     msg[0])
+        fragremover = rdMolStandardize.FragmentRemover(skip_if_all_match=True)
+        mol = Chem.MolFromSmiles("[Na+].Cl.Cl.Br")
+        nm = fragremover.remove(mol)
+        self.assertEqual(nm.GetNumAtoms(), mol.GetNumAtoms())
 
-    vm2 = rdMolStandardize.MolVSValidation([rdMolStandardize.FragmentValidation()])
-    # with no argument it also works
-    #    vm2 = rdMolStandardize.MolVSValidation()
-    mol2 = Chem.MolFromSmiles("COc1cccc(C=N[N-]C(N)=O)c1[O-].O.O.O.O=[U+2]=O")
-    msg2 = vm2.validate(mol2)
-    self.assertEqual(len(msg2), 1)
-    self.assertEqual
-    ("""INFO: [FragmentValidation] water/hydroxide is present""", msg2[0])
+    def test8Normalize(self):
+        normalizer = rdMolStandardize.Normalizer()
+        mol = Chem.MolFromSmiles("C[n+]1ccccc1[O-]")
+        nm = normalizer.normalize(mol)
+        self.assertEqual(Chem.MolToSmiles(nm), "Cn1ccccc1=O")
 
-    vm3 = rdMolStandardize.MolVSValidation()
-    mol3 = Chem.MolFromSmiles("C1COCCO1.O=C(NO)NO")
-    msg3 = vm3.validate(mol3)
-    self.assertEqual(len(msg3), 2)
-    self.assertEqual
-    ("""INFO: [FragmentValidation] 1,2-dimethoxyethane is present""", msg3[0])
-    self.assertEqual
-    ("""INFO: [FragmentValidation] 1,4-dioxane is present""", msg3[1])
+    def test9Validate(self):
+        vm = rdMolStandardize.RDKitValidation()
+        mol = Chem.MolFromSmiles("CO(C)C", sanitize=False)
+        msg = vm.validate(mol)
+        self.assertEqual(len(msg), 1)
+        self.assertEqual
+        ("""INFO: [ValenceValidation] Explicit valence for atom # 1 O, 3, is greater than permitted""",
+         msg[0])
 
-    atomic_no = [6, 7, 8]
-    allowed_atoms = [Atom(i) for i in atomic_no]
-    vm4 = rdMolStandardize.AllowedAtomsValidation(allowed_atoms)
-    mol4 = Chem.MolFromSmiles("CC(=O)CF")
-    msg4 = vm4.validate(mol4)
-    self.assertEqual(len(msg4), 1)
-    self.assertEqual
-    ("""INFO: [AllowedAtomsValidation] Atom F is not in allowedAtoms list""", msg4[0])
+        vm2 = rdMolStandardize.MolVSValidation([rdMolStandardize.FragmentValidation()])
+        # with no argument it also works
+        #    vm2 = rdMolStandardize.MolVSValidation()
+        mol2 = Chem.MolFromSmiles("COc1cccc(C=N[N-]C(N)=O)c1[O-].O.O.O.O=[U+2]=O")
+        msg2 = vm2.validate(mol2)
+        self.assertEqual(len(msg2), 1)
+        self.assertEqual
+        ("""INFO: [FragmentValidation] water/hydroxide is present""", msg2[0])
 
-    atomic_no = [9, 17, 35]
-    disallowed_atoms = [Atom(i) for i in atomic_no]
-    vm5 = rdMolStandardize.DisallowedAtomsValidation(disallowed_atoms)
-    mol5 = Chem.MolFromSmiles("CC(=O)CF")
-    msg5 = vm4.validate(mol5)
-    self.assertEqual(len(msg5), 1)
-    self.assertEqual
-    ("""INFO: [DisallowedAtomsValidation] Atom F is in disallowedAtoms list""", msg5[0])
+        vm3 = rdMolStandardize.MolVSValidation()
+        mol3 = Chem.MolFromSmiles("C1COCCO1.O=C(NO)NO")
+        msg3 = vm3.validate(mol3)
+        self.assertEqual(len(msg3), 2)
+        self.assertEqual
+        ("""INFO: [FragmentValidation] 1,2-dimethoxyethane is present""", msg3[0])
+        self.assertEqual
+        ("""INFO: [FragmentValidation] 1,4-dioxane is present""", msg3[1])
 
-    msg6 = rdMolStandardize.ValidateSmiles("ClCCCl.c1ccccc1O")
-    self.assertEqual(len(msg6), 1)
-    self.assertEqual
-    ("""INFO: [FragmentValidation] 1,2-dichloroethane is present""", msg6[0])
+        atomic_no = [6, 7, 8]
+        allowed_atoms = [Atom(i) for i in atomic_no]
+        vm4 = rdMolStandardize.AllowedAtomsValidation(allowed_atoms)
+        mol4 = Chem.MolFromSmiles("CC(=O)CF")
+        msg4 = vm4.validate(mol4)
+        self.assertEqual(len(msg4), 1)
+        self.assertEqual
+        ("""INFO: [AllowedAtomsValidation] Atom F is not in allowedAtoms list""", msg4[0])
+
+        atomic_no = [9, 17, 35]
+        disallowed_atoms = [Atom(i) for i in atomic_no]
+        vm5 = rdMolStandardize.DisallowedAtomsValidation(disallowed_atoms)
+        mol5 = Chem.MolFromSmiles("CC(=O)CF")
+        msg5 = vm4.validate(mol5)
+        self.assertEqual(len(msg5), 1)
+        self.assertEqual
+        ("""INFO: [DisallowedAtomsValidation] Atom F is in disallowedAtoms list""", msg5[0])
+
+        msg6 = rdMolStandardize.ValidateSmiles("ClCCCl.c1ccccc1O")
+        self.assertEqual(len(msg6), 1)
+        self.assertEqual
+        ("""INFO: [FragmentValidation] 1,2-dichloroethane is present""", msg6[0])
+
 
 if __name__ == "__main__":
-  unittest.main()
+    unittest.main()

--- a/Code/GraphMol/MolStandardize/catch_tests.cpp
+++ b/Code/GraphMol/MolStandardize/catch_tests.cpp
@@ -1,0 +1,62 @@
+//
+//  Copyright (C) 2019 Greg Landrum
+//
+//   @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
+//
+#define CATCH_CONFIG_MAIN  // This tells Catch to provide a main() - only do
+                           // this in one cpp file
+#include "catch.hpp"
+
+#include <GraphMol/MolStandardize/FragmentCatalog/FragmentCatalogParams.h>
+#include <GraphMol/MolStandardize/FragmentCatalog/FragmentCatalogUtils.h>
+#include <GraphMol/MolStandardize/Fragment.h>
+#include <RDGeneral/Invariant.h>
+#include <GraphMol/RDKitBase.h>
+#include <GraphMol/ROMol.h>
+#include <GraphMol/SmilesParse/SmilesParse.h>
+#include <GraphMol/SmilesParse/SmilesWrite.h>
+#include <GraphMol/FileParsers/FileParsers.h>
+#include <RDGeneral/FileParseException.h>
+#include <GraphMol/FileParsers/MolSupplier.h>
+#include <GraphMol/MolStandardize/MolStandardize.h>
+
+#include <iostream>
+#include <fstream>
+
+using namespace RDKit;
+
+TEST_CASE("SKIP_IF_ALL_MATCH") {
+  auto m = "[Na+].[Cl-]"_smiles;
+  REQUIRE(m);
+
+  SECTION("default") {
+    MolStandardize::FragmentRemover fragRemover;
+    std::unique_ptr<ROMol> outm(fragRemover.remove(*m));
+    REQUIRE(outm);
+    CHECK(MolToSmiles(*outm) == "[Na+]");
+  }
+  SECTION("don't remove all") {
+    MolStandardize::FragmentRemover fragRemover("", true, true);
+    std::unique_ptr<ROMol> outm(fragRemover.remove(*m));
+    REQUIRE(outm);
+    CHECK(MolToSmiles(*outm) == "[Cl-].[Na+]");
+  }
+  SECTION("feel free to remove everything") {
+    MolStandardize::FragmentRemover fragRemover("", false, false);
+    std::unique_ptr<ROMol> outm(fragRemover.remove(*m));
+    REQUIRE(outm);
+    CHECK(outm->getNumAtoms() == 0);
+  }
+  SECTION("don't remove all 2") {
+    MolStandardize::FragmentRemover fragRemover("", true, true);
+    auto m = "[Na+].[Cl-].[Na+].[Cl-]"_smiles;
+    REQUIRE(m);
+    std::unique_ptr<ROMol> outm(fragRemover.remove(*m));
+    REQUIRE(outm);
+    CHECK(MolToSmiles(*outm) == "[Cl-].[Cl-].[Na+].[Na+]");
+  }
+}

--- a/Code/GraphMol/MolStandardize/testFragment.cpp
+++ b/Code/GraphMol/MolStandardize/testFragment.cpp
@@ -197,6 +197,8 @@ void test_largest_fragment() {
 }
 
 int main() {
+  // may want to enable this for debugging
+  // RDLog::InitLogs();
   test2();
   test_largest_fragment();
   return 0;


### PR DESCRIPTION
The idea of the option is to not remove anything from molecules where every fragment matches a salt.
An example:
```
In [3]: fm = rdMolStandardize.FragmentRemover(skip_if_all_match=True)                                                                          

In [4]: Chem.MolToSmiles(fm.remove(Chem.MolFromSmiles('C.[Na+].[Cl-]')))                                                                       
[15:39:02] Running FragmentRemover
[15:39:02] Removed fragment: chlorine
[15:39:02] Removed fragment: sodium
Out[4]: 'C'

In [5]: Chem.MolToSmiles(fm.remove(Chem.MolFromSmiles('[Na+].[Cl-]')))                                                                         
[15:39:07] Running FragmentRemover
[15:39:07] Removed fragment: chlorine
[15:39:07] Removed fragment: sodium
[15:39:07] All fragments matched; original molecule returned.
Out[5]: '[Cl-].[Na+]'
```

Since I was in there, there's also some refactoring of `FragmentRemover::remove()` to make it a ton faster.
