### PR TITLE
change to make the SWIG builds work on windows

### DIFF
--- a/Code/JavaWrappers/CMakeLists.txt
+++ b/Code/JavaWrappers/CMakeLists.txt
@@ -35,7 +35,12 @@ set(swigRDKitLibs "")
 foreach(swigRDKitLib ${swigRDKitLibList})
   set(swigRDKitLibs "${swigRDKitLibs}${swigRDKitLib}${swigRDKitLibSuffix};")
 endforeach()
-set(swigRDKitLibs "${swigRDKitLibs}${Boost_SERIALIZATION_LIBRARY}")
+set(swigRDKitLibs "${swigRDKitLibs}${Boost_SERIALIZATION_LIBRARY};")
+
+if(RDK_BUILD_COORDGEN_SUPPORT)
+  find_package(Boost 1.56.0 COMPONENTS system iostreams REQUIRED)
+  set(swigRDKitLibs "${swigRDKitLibs}${Boost_IOSTREAMS_LIBRARY};${Boost_SYSTEM_LIBRARY};")
+endif(RDK_BUILD_COORDGEN_SUPPORT)
 
 set(RDKit_Wrapper_Libs ${swigRDKitLibs})
 


### PR DESCRIPTION
made necessary by the new iostreams dependency of coordgen