### PR TITLE
Update the type hint in types.h for _MolFileRLabel

### DIFF
--- a/Code/RDGeneral/types.h
+++ b/Code/RDGeneral/types.h
@@ -161,7 +161,7 @@ RDKIT_RDGENERAL_EXPORT extern const std::string molParity;           // int
 RDKIT_RDGENERAL_EXPORT extern const std::string molRxnComponent;     // int
 RDKIT_RDGENERAL_EXPORT extern const std::string molRxnRole;          // int
 RDKIT_RDGENERAL_EXPORT extern const std::string molTotValence;       // int
-RDKIT_RDGENERAL_EXPORT extern const std::string _MolFileRLabel;      // int
+RDKIT_RDGENERAL_EXPORT extern const std::string _MolFileRLabel;      // unsigned int
 RDKIT_RDGENERAL_EXPORT extern const std::string _MolFileChiralFlag;  // int
 RDKIT_RDGENERAL_EXPORT extern const std::string _MolFileAtomQuery;   // int
 RDKIT_RDGENERAL_EXPORT extern const std::string _MolFileBondQuery;   // int


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
_MolFileRLabel are unsigned int, not int. if a user accidentally sets them to int, confusing problems occur (e.g. exception while writing an SD file).