### PR TITLE
Add ExplicitBitVect prop and query

### DIFF
--- a/Code/GraphMol/QueryOps.h
+++ b/Code/GraphMol/QueryOps.h
@@ -933,14 +933,14 @@ class HasPropWithValueQuery<TargetPtr, ExplicitBitVect>
 
  public:
   HasPropWithValueQuery()
-      : Queries::EqualityQuery<int, TargetPtr, true>(), propname(), val(), tol(1.0) {
+      : Queries::EqualityQuery<int, TargetPtr, true>(), propname(), val(), tol(0.0) {
     this->setDescription("HasPropWithValue");
     this->setDataFunc(0);
   };
   
   explicit HasPropWithValueQuery(const std::string &prop,
                                  const ExplicitBitVect &v,
-                                 float tol = 1.0)
+                                 float tol = 0.0)
       : Queries::EqualityQuery<int, TargetPtr, true>(), propname(prop), val(v), tol(tol) {
     this->setDescription("HasPropWithValue");
     this->setDataFunc(0);

--- a/Code/GraphMol/Wrap/Atom.cpp
+++ b/Code/GraphMol/Wrap/Atom.cpp
@@ -347,6 +347,22 @@ struct atom_wrapper {
              "    - If the property has not been set, a KeyError exception "
              "will be raised.\n")
 
+        .def("SetExplicitBitVectProp", AtomSetProp<ExplicitBitVect>,
+             (python::arg("self"), python::arg("key"), python::arg("val")),
+             "Sets an atomic property\n\n"
+             "  ARGUMENTS:\n"
+             "    - key: the name of the property to be set (an ExplicitBitVect).\n"
+             "    - value: the property value (an ExplicitBitVect).\n\n")
+
+        .def("GetExplicitBitVectProp", GetProp<Atom, ExplicitBitVect>,
+             "Returns the value of the property.\n\n"
+             "  ARGUMENTS:\n"
+             "    - key: the name of the property to return (a ExplicitBitVect).\n\n"
+             "  RETURNS: an ExplicitBitVect \n\n"
+             "  NOTE:\n"
+             "    - If the property has not been set, a KeyError exception "
+             "will be raised.\n")
+        
         .def("HasProp", AtomHasProp,
              "Queries a Atom to see if a particular property has been "
              "assigned.\n\n"

--- a/Code/GraphMol/Wrap/Queries.cpp
+++ b/Code/GraphMol/Wrap/Queries.cpp
@@ -114,6 +114,15 @@ Ret *PropQueryWithTol(const std::string &propname, const T &v, bool negate,
   return res;
 }
 
+template <class Ob, class Ret>
+Ret *PropQueryWithTol(const std::string &propname, const ExplicitBitVect &v,
+                      bool negate, float tol = 0.0) {
+  auto *res = new Ret();
+  res->setQuery(makePropQuery<Ob>(propname, v, tol));
+  if (negate) res->getQuery()->setNegation(true);
+  return res;
+}
+
 struct queries_wrapper {
   static void wrap() {
 #define QADEF1(_funcname_)                                                     \
@@ -214,6 +223,16 @@ struct queries_wrapper {
                 "value +- tolerance",
                 python::return_value_policy<python::manage_new_object>());
 
+    python::def("HasBitVectPropWithValueQueryAtom",
+                PropQueryWithTol<Atom, QueryAtom>,
+                (python::arg("propname"), python::arg("val"),
+                 python::arg("negate") = false, python::arg("tolerance") = 0),
+                "Returns a QueryAtom that matches when the propery 'propname' "
+                "has the specified explicit bit vector"
+                " value.  Tolerance here is allowed difference in Tanimoto",
+                python::return_value_policy<python::manage_new_object>());
+
+    
     /////////////////////////////////////////////////////////////////////////////////////
     //  Bond Queries
     python::def("HasPropQueryBond", HasPropQueryBond,

--- a/Code/GraphMol/Wrap/Queries.cpp
+++ b/Code/GraphMol/Wrap/Queries.cpp
@@ -229,7 +229,7 @@ struct queries_wrapper {
                  python::arg("negate") = false, python::arg("tolerance") = 0),
                 "Returns a QueryAtom that matches when the propery 'propname' "
                 "has the specified explicit bit vector"
-                " value.  Tolerance here is allowed difference in Tanimoto",
+                " value.  The Tolerance is the allowed Tanimoto difference",
                 python::return_value_policy<python::manage_new_object>());
 
     

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -14,6 +14,7 @@ from rdkit import RDConfig, rdBase
 from rdkit import DataStructs
 from rdkit import Chem
 import rdkit.Chem.rdDepictor
+from rdkit.Chem import rdqueries
 
 from rdkit import __version__
 
@@ -5137,7 +5138,69 @@ M  END
     else:
       self.assertTrue(supp.next() is not None)
 
+  def testBitVectProp(self):
+    bv = DataStructs.ExplicitBitVect(100)
+    m = Chem.MolFromSmiles("CC")
+    for atom in m.GetAtoms():
+      bv.SetBit(atom.GetIdx())
+      atom.SetExplicitBitVectProp("prop", bv)
       
+    for atom in m.GetAtoms():
+      bv = atom.GetExplicitBitVectProp("prop")
+      self.assertTrue(bv.GetBit(atom.GetIdx()))
+
+  def testBitVectQuery(self):
+    bv = DataStructs.ExplicitBitVect(4)
+    bv.SetBit(0)
+    bv.SetBit(2)
+
+    # wow, what a mouthfull..
+    qa = rdqueries.HasBitVectPropWithValueQueryAtom("prop", bv, tolerance=0.0)
+
+    m = Chem.MolFromSmiles("CC")
+    for atom in m.GetAtoms():
+      if atom.GetIdx() == 0:
+        atom.SetExplicitBitVectProp("prop", bv)
+      
+    l = tuple([x.GetIdx() for x in m.GetAtomsMatchingQuery(qa)])
+    self.assertEqual(l, (0,))
+
+    m = Chem.MolFromSmiles("CC")
+    for atom in m.GetAtoms():
+      bv = DataStructs.ExplicitBitVect(4)
+      bv.SetBit(atom.GetIdx())
+      atom.SetExplicitBitVectProp("prop", bv)
+        
+    sma = Chem.MolFromSmarts("C")
+    for atom in sma.GetAtoms():
+        bv = DataStructs.ExplicitBitVect(4)
+        bv.SetBit(1)
+        qa = rdqueries.HasBitVectPropWithValueQueryAtom("prop", bv, tolerance=0.0)
+        atom.ExpandQuery(qa)
+
+    res = m.GetSubstructMatches(sma)
+    self.assertEqual(res, ((1,),))
+
+    sma = Chem.MolFromSmarts("C")
+    for atom in sma.GetAtoms():
+        bv = DataStructs.ExplicitBitVect(4)
+        bv.SetBit(0)
+        qa = rdqueries.HasBitVectPropWithValueQueryAtom("prop", bv, tolerance=0.0)
+        atom.ExpandQuery(qa)
+
+    res = m.GetSubstructMatches(sma)
+    self.assertEqual(res, ((0,),))
+    
+    sma = Chem.MolFromSmarts("C")
+    for atom in sma.GetAtoms():
+        bv = DataStructs.ExplicitBitVect(4)
+        bv.SetBit(0)
+        qa = rdqueries.HasBitVectPropWithValueQueryAtom("prop", bv, tolerance=1.0)
+        atom.ExpandQuery(qa)
+
+    res = m.GetSubstructMatches(sma)
+    self.assertEqual(res, ((0,),(1,)))
+        
 if __name__ == '__main__':
   if "RDTESTCASE" in os.environ:
     suite = unittest.TestSuite()


### PR DESCRIPTION
Adds queries for bit explicit bit vector prop.

Example:

```
    m = Chem.MolFromSmiles("CC")
    for atom in m.GetAtoms():
      bv = DataStructs.ExplicitBitVect(4)
      bv.SetBit(atom.GetIdx())
      atom.SetExplicitBitVectProp("prop", bv)
        
    sma = Chem.MolFromSmarts("C")
    for atom in sma.GetAtoms():
        bv = DataStructs.ExplicitBitVect(4)
        bv.SetBit(1)
        qa = rdqueries.HasBitVectPropWithValueQueryAtom("prop", bv, tolerance=0.0)

    res = m.GetSubstructMatches(sma)
    assertEqual(res, ((1,),))
```

This returns true if the tanimoto distance between bv and the atom bit vector prop "prop" is less than or equal to the supplied value.