### PR TITLE
CXSMILES parsing chokes on HTML char codes

### DIFF
--- a/Code/GraphMol/SmilesParse/CXSmilesOps.cpp
+++ b/Code/GraphMol/SmilesParse/CXSmilesOps.cpp
@@ -325,7 +325,8 @@ bool parse_it(Iterator &first, Iterator last, RDKit::RWMol &mol) {
       if (!parse_coordinate_bonds(first, last, mol)) return false;
     } else if (*first == '^') {
       if (!parse_radicals(first, last, mol)) return false;
-    } else if (*first == 'a' || *first == 'o' || *first == '&') {
+    } else if (*first == 'a' || *first == 'o' ||
+               (*first == '&' && first + 1 < last && first[1] != '#')) {
       if (!parse_enhanced_stereo(first, last, mol)) return false;
     } else {
       ++first;

--- a/Code/GraphMol/SmilesParse/cxsmiles_test.cpp
+++ b/Code/GraphMol/SmilesParse/cxsmiles_test.cpp
@@ -479,6 +479,23 @@ void testEnhancedStereo() {
   BOOST_LOG(rdInfoLog) << "done" << std::endl;
 }
 
+void testHTMLCharCodes() {
+  BOOST_LOG(rdInfoLog) << "Testing CXSMILES with HTML char codes" << std::endl;
+
+  {
+    std::string smiles = R"(CCCC* |$;;;;_AP1$,Sg:n:2:2&#44;6-7:ht|)";
+    SmilesParserParams params;
+    params.allowCXSMILES = true;
+
+    ROMol *m = SmilesToMol(smiles, params);
+    TEST_ASSERT(m);
+
+    TEST_ASSERT(m->getNumAtoms() == 5);
+
+    delete m;
+  }
+}
+
 int main(int argc, char *argv[]) {
   (void)argc;
   (void)argv;
@@ -495,4 +512,5 @@ int main(int argc, char *argv[]) {
   testAtomProps();
   testGithub1968();
   testEnhancedStereo();
+  testHTMLCharCodes();
 }


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
Parsing a CXSMILES string that contains HTML char codes in the format "&#nnnn;" (which are something legal, apparently) makes the parser choke on the initial ampersand, as it triggers parsing of an enhanced stereo group.

This patch mitigates the issue by triggering the enhanced stereo parsing only if the ampersand is not followed by a hashtag (HTML char codes are still not supported). I also included a simple test for this issue.

