### PR TITLE
Trim whitespace from mol fragment SMARTS and check SMARTS presence

### DIFF
--- a/Code/GraphMol/FragCatalog/FragCatalogUtils.cpp
+++ b/Code/GraphMol/FragCatalog/FragCatalogUtils.cpp
@@ -19,14 +19,18 @@
 #include <string>
 #include <GraphMol/SmilesParse/SmilesParse.h>
 #include <boost/tokenizer.hpp>
-typedef boost::tokenizer<boost::char_separator<char> > tokenizer;
+typedef boost::tokenizer<boost::char_separator<char>> tokenizer;
 #include <boost/algorithm/string.hpp>
 
 namespace RDKit {
 // local utility namespace
 namespace {
-ROMol *getSmarts(const std::string &tmpStr) {
+ROMol *getSmarts(std::string &&tmpStr) {
   ROMol *mol = nullptr;
+
+  // Remove whitespace
+  boost::trim(tmpStr);
+
   if (tmpStr.length() == 0) {
     // empty line
     return mol;
@@ -45,6 +49,9 @@ ROMol *getSmarts(const std::string &tmpStr) {
   boost::erase_all(name, " ");
   ++token;
 
+  // There must be a SMARTS expression
+  CHECK_INVARIANT(token != tokens.end(), tmpStr);
+
   // grab the smarts:
   std::string smarts = *token;
   boost::erase_all(smarts, " ");
@@ -56,23 +63,23 @@ ROMol *getSmarts(const std::string &tmpStr) {
   mol->setProp(common_properties::_fragSMARTS, smarts);
   return mol;
 }
-}  // end of local utility namespace
+}  // namespace
 
 MOL_SPTR_VECT readFuncGroups(std::istream &inStream, int nToRead) {
-  MOL_SPTR_VECT funcGroups;
-  funcGroups.clear();
   if (inStream.bad()) {
     throw BadFileException("Bad stream contents.");
   }
+
   const int MAX_LINE_LEN = 512;
   char inLine[MAX_LINE_LEN];
-  std::string tmpstr;
   int nRead = 0;
+
+  MOL_SPTR_VECT funcGroups;
   while (!inStream.eof() && (nToRead < 0 || nRead < nToRead)) {
     inStream.getline(inLine, MAX_LINE_LEN, '\n');
-    tmpstr = inLine;
+    std::string tmpstr(inLine);
     // parse the molecule on this line (if there is one)
-    ROMol *mol = getSmarts(tmpstr);
+    ROMol *mol = getSmarts(std::move(tmpstr));
     if (mol) {
       funcGroups.push_back(ROMOL_SPTR(mol));
       nRead++;
@@ -204,4 +211,4 @@ ROMol *prepareMol(const ROMol &mol, const FragCatParams *fparams,
 
   return coreMol;
 }
-}
+}  // namespace RDKit

--- a/Code/GraphMol/MolStandardize/testFragment.cpp
+++ b/Code/GraphMol/MolStandardize/testFragment.cpp
@@ -196,10 +196,59 @@ void test_largest_fragment() {
   //
 }
 
+void testWhiteSpaceInSmarts() {
+  BOOST_LOG(rdInfoLog) << "----- Test Whitespace in SMARTS Fragment string."
+                       << std::endl;
+
+  std::vector<std::string> data({
+      "          ",    // whitespace only
+      "          \n",  // whitespace plus new line
+      " //   initial space plus comment\nfluorine\t[F]\n"
+  });
+
+  std::vector<size_t> reference_sizes({0, 0, 1});
+
+  auto reference = reference_sizes.cbegin();
+  for (const auto& smarts : data) {
+    std::istringstream input(smarts);
+    auto groups = readFuncGroups(input);
+    TEST_ASSERT(groups.size() == *reference);
+    ++reference;
+  }
+  BOOST_LOG(rdInfoLog) << "---- Done" << std::endl;
+}
+
+void testFragmentWithoutSmarts() {
+  BOOST_LOG(rdInfoLog) << "----- Test Fragment string without SMARTS."
+                       << std::endl;
+
+  std::vector<std::string> data({
+      "//   Name	SMARTS\nnonsense\n",
+      "//   Name	SMARTS\nnonsense no new line",
+      "//   Name	SMARTS\nnonsense with tab\t\n"
+  });
+
+  for (const auto& smarts : data) {
+    bool ok = false;
+    std::istringstream input(smarts);
+    std::vector<std::shared_ptr<RDKit::ROMol>> groups;
+    try {
+      groups = readFuncGroups(input);
+    } catch (const Invar::Invariant&) {
+      ok = true;
+    }
+    TEST_ASSERT(ok);
+    TEST_ASSERT(groups.empty());
+  }
+  BOOST_LOG(rdInfoLog) << "---- Done" << std::endl;
+}
+
 int main() {
   // may want to enable this for debugging
   // RDLog::InitLogs();
   test2();
   test_largest_fragment();
+  testWhiteSpaceInSmarts();
+  testFragmentWithoutSmarts();
   return 0;
 }


### PR DESCRIPTION
Test `testMolStandardize.py::TestCase::test11FragmentParams` was failing on my home computer. Upon investigation, the problem was the whitespace in the last line in the test data, right before the triple quotes. The input to function `getSmarts()` is only checked to be empty or a comment, and a whitespace-only string gets past both checks and may be parsed as a "name" without an actual SMARTS string.

I don't really know why this wasn't failing anywhere else.

I added trimming of whitespace before the checks, and also an additional check to make sure we actually have a SMARTS string to parse before actually trying to parse it.

The code seems to be duplicated in FragCatalogUtils.cpp and FragmentCatalogUtils.cpp (the only difference I see is the return of `readFuncGroups()` which uses a `boost::shared_ptr` in one, and a `std::shared_ptr` in the other), so I also duplicated the fix and the tests I implemented.
