### PR TITLE
Issue #2403: Speed up SSSR symmetrization

### DIFF
--- a/Code/GraphMol/molopstest.cpp
+++ b/Code/GraphMol/molopstest.cpp
@@ -228,7 +228,7 @@ void test3() {
   smi = "C(C1C2C3C41)(C2C35)C45";  // cubane
   // smi = "C1(C2C3C4C5C6C72)C3C4C5C6C71"; // from Figureras paper
   // smi = "C17C5C4C3C2C1C6C2C3C4C5C67";
-  // we cannot use the sanitzation code, because that finds *symmetric*
+  // we cannot use the sanitization code, because that finds *symmetric*
   // rings, which will break this case:
   m = SmilesToMol(smi, 0, 0);
   int bfs = MolOps::findSSSR(*m);
@@ -253,6 +253,35 @@ void test3() {
   BOOST_LOG(rdInfoLog) << smi << "\n";
 
   delete m;
+
+  // Figueras figure 4:
+  //  * The third ring is bigger, and shouldn't be accessed in symmetrizeSSSR
+  smi = "C12CC(CC2)CC1";
+  m = SmilesToMol(smi, 0, 0);
+  bfs = MolOps::findSSSR(*m);
+  TEST_ASSERT(bfs == 2);
+  bfrs.resize(0);
+  bfs = MolOps::symmetrizeSSSR(*m, bfrs);
+  TEST_ASSERT(bfs == 2);
+  delete m;
+
+
+  // Counterexamples in ring perception figure 4:
+  //  * The native Figueras algorithm cannot work on this molecule, it will
+  //    fail after finding one ring. Naive modified Figueras finds a 6 membered
+  //    ring, which is wrong.
+  smi = "C123C4C5C6(C3)C7C1C8C2C4C5C6C78";
+  m = SmilesToMol(smi, 0, 0);
+  bfs = MolOps::findSSSR(*m);
+  TEST_ASSERT(bfs == 7);
+  bfrs.resize(0);
+  bfs = MolOps::symmetrizeSSSR(*m, bfrs);
+  TEST_ASSERT(bfs == 8);
+  for (auto bring : bfrs) {
+    TEST_ASSERT(bring.size() < 6);
+  }
+  delete m;
+
 
   smi = "C1CC2C1CCC2";
   m = SmilesToMol(smi);


### PR DESCRIPTION
#### Reference Issue:
Fixes #2403

#### What does this implement/fix? Explain your changes.
For my horrible example molecule (a highly symmetric
nanotube with 2400 atoms and > 1000 rings), this speeds up
`symmetrizeSSSR()` from 5s to about 0.001s. `findSSSR()` takes
another .4s or so.

#### Any other comments?
I've got some ideas about speeding up SSSR a bit more, but I
don't know if that is the bottleneck in sanitization for real
molecules, so I probably won't pursue it yet.

Is the symmetric SSSR supposed to be the "relevant cycles"? (relevant cycles are the union of all SSSR). SSSSR looks pretty close.
