### PR TITLE
Chem.MolStandardize.standardize.Standardizer drops molecular properties

### DIFF
--- a/rdkit/Chem/MolStandardize/standardize.py
+++ b/rdkit/Chem/MolStandardize/standardize.py
@@ -91,6 +91,7 @@ class Standardizer(object):
         :returns: The standardized molecule.
         :rtype: :rdkit:`Mol <Chem.rdchem.Mol-class.html>`
         """
+        mol_props = mol.GetPropsAsDict()
         mol = copy.deepcopy(mol)
         Chem.SanitizeMol(mol)
         mol = Chem.RemoveHs(mol)
@@ -98,6 +99,8 @@ class Standardizer(object):
         mol = self.normalize(mol)
         mol = self.reionize(mol)
         Chem.AssignStereochemistry(mol, force=True, cleanIt=True)
+        for k, v in mol_props.items():
+            mol.SetProp(k, v)
         # TODO: Check this removes symmetric stereocenters
         return mol
 

--- a/rdkit/Chem/MolStandardize/test_standardizer.py
+++ b/rdkit/Chem/MolStandardize/test_standardizer.py
@@ -1,0 +1,26 @@
+import unittest
+from rdkit import Chem
+from rdkit.Chem.MolStandardize.standardize import Standardizer
+
+
+class FakeStandardizer(Standardizer):
+    def normalize(self):
+        def fake_normalize(y):
+            props = y.GetPropsAsDict()
+            for k, v in props:
+                y.ClearProp(k)
+            return y
+        return fake_normalize
+
+class TestCase(unittest.TestCase):
+
+    def testPreserveProps(self):
+        PROP_NAME = "MyProp"
+        PROP_VALUE = "foo"
+        standardizer = FakeStandardizer()
+        m = Chem.MolFromSmiles("C")
+        m.SetProp(PROP_NAME, PROP_VALUE)
+
+        standardized_mol = standardizer.standardize(m)
+        self.assertTrue(standardized_mol.HasProp(PROP_NAME))
+        self.assertEqual(PROP_VALUE, standardized_mol.GetProp(PROP_NAME))


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! 
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.
Currently rdkit.Chem.MolStandardize.standardize.Standardizer sometimes maintains molecular properties and sometimes does not.  Specifically this sometimes happens in the normalize step for certain molecules.

I chose to fix the problem at the Standardizer level instead of the Normalize layer because I'm not sure if normalize is intended to maintain molecule level properties or not.

#### Any other comments?
is UnitTestMolVS run?  It requires a MolVs dependency.
