### PR TITLE
add prepareMolsBeforeDrawing option for drawMols 

### DIFF
--- a/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
@@ -682,7 +682,8 @@ void MolDraw2D::drawMolecules(
       continue;
     }
     tmols.push_back(*(mols[i]));
-    MolDraw2DUtils::prepareMolForDrawing(tmols[i]);
+    if (drawOptions().prepareMolsBeforeDrawing)
+      MolDraw2DUtils::prepareMolForDrawing(tmols[i]);
     Conformer &conf = tmols[i].getConformer(confIds ? (*confIds)[i] : -1);
     RDGeom::Point3D centroid = MolTransforms::computeCentroid(conf, false);
     for (unsigned int j = 0; j < conf.getNumAtoms(); ++j) {

--- a/Code/GraphMol/MolDraw2D/MolDraw2D.h
+++ b/Code/GraphMol/MolDraw2D/MolDraw2D.h
@@ -92,6 +92,8 @@ struct RDKIT_MOLDRAW2D_EXPORT MolDrawOptions {
       symbolColour;  // color to be used for the symbols and arrows in reactions
   int bondLineWidth;  // if positive, this overrides the default line width
                       // when drawing bonds
+  bool prepareMolsBeforeDrawing;  // call prepareMolForDrawing() on each
+                                  // molecule passed to drawMolecules()
   std::vector<DrawColour> highlightColourPalette;  // defining 10 default colors
   // for highlighting atoms and bonds
   // or reactants in a reactions
@@ -116,7 +118,8 @@ struct RDKIT_MOLDRAW2D_EXPORT MolDrawOptions {
         padding(0.05),
         additionalAtomLabelPadding(0.0),
         symbolColour(0, 0, 0),
-        bondLineWidth(-1) {
+        bondLineWidth(-1),
+        prepareMolsBeforeDrawing(true) {
     highlightColourPalette.push_back(
         DrawColour(1., 1., .67));                              // popcorn yellow
     highlightColourPalette.push_back(DrawColour(1., .8, .6));  // sand

--- a/Code/GraphMol/MolDraw2D/Wrap/rdMolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/Wrap/rdMolDraw2D.cpp
@@ -410,6 +410,10 @@ BOOST_PYTHON_MODULE(rdMolDraw2D) {
       .def_readwrite(
           "bondLineWidth", &RDKit::MolDrawOptions::bondLineWidth,
           "if positive, this overrides the default line width for bonds")
+      .def_readwrite("prepareMolsBeforeDrawing",
+                     &RDKit::MolDrawOptions::prepareMolsBeforeDrawing,
+                     "call prepareMolForDrawing() on each molecule passed to "
+                     "DrawMolecules()")
       .def_readwrite("additionalAtomLabelPadding",
                      &RDKit::MolDrawOptions::additionalAtomLabelPadding,
                      "additional padding to leave around atom labels. "

--- a/rdkit/Chem/Draw/__init__.py
+++ b/rdkit/Chem/Draw/__init__.py
@@ -423,6 +423,11 @@ def _MolsToGridImage(mols, molsPerRow=3, subImgSize=(200, 200), legends=None,
   else:
     fullSize = (molsPerRow * subImgSize[0], nRows * subImgSize[1])
     d2d = rdMolDraw2D.MolDraw2DCairo(fullSize[0], fullSize[1], subImgSize[0], subImgSize[1])
+    dops = d2d.drawOptions()
+    for k, v in list(kwargs.items()):
+      if hasattr(dops, k):
+        setattr(dops, k, v)
+        del kwargs[k]
     d2d.DrawMolecules(
       list(mols), legends=legends, highlightAtoms=highlightAtomLists,
       highlightBonds=highlightBondLists, **kwargs)
@@ -448,6 +453,11 @@ def _MolsToGridSVG(mols, molsPerRow=3, subImgSize=(200, 200), legends=None, high
   fullSize = (molsPerRow * subImgSize[0], nRows * subImgSize[1])
 
   d2d = rdMolDraw2D.MolDraw2DSVG(fullSize[0], fullSize[1], subImgSize[0], subImgSize[1])
+  dops = d2d.drawOptions()
+  for k,v in list(kwargs.items()):
+    if hasattr(dops,k):
+      setattr(dops,k,v)
+      del kwargs[k]
   d2d.DrawMolecules(mols, legends=legends, highlightAtoms=highlightAtomLists,
                     highlightBonds=highlightBondLists, **kwargs)
   d2d.FinishDrawing()


### PR DESCRIPTION
Adds an option so that the call to `prepareMolForDrawing()` in `MolDraw2D::drawMols()` can be disabled