### PR TITLE
Fixes #2450

### DIFF
--- a/Code/GraphMol/Atom.h
+++ b/Code/GraphMol/Atom.h
@@ -119,6 +119,9 @@ class RDKIT_GRAPHMOL_EXPORT Atom : public RDProps {
   //! returns our symbol (determined by our atomic number)
   std::string getSymbol() const;
 
+  //! returns whether or not this Atom belongs to a molecule
+  bool hasOwningMol() const { return dp_mol != nullptr; };
+
   //! returns a reference to the ROMol that owns this Atom
   ROMol &getOwningMol() const {
     PRECONDITION(dp_mol, "no owner");

--- a/Code/GraphMol/Atom.h
+++ b/Code/GraphMol/Atom.h
@@ -119,10 +119,10 @@ class RDKIT_GRAPHMOL_EXPORT Atom : public RDProps {
   //! returns our symbol (determined by our atomic number)
   std::string getSymbol() const;
 
-  //! returns whether or not this Atom belongs to a molecule
+  //! returns whether or not this instance belongs to a molecule
   bool hasOwningMol() const { return dp_mol != nullptr; };
 
-  //! returns a reference to the ROMol that owns this Atom
+  //! returns a reference to the ROMol that owns this instance
   ROMol &getOwningMol() const {
     PRECONDITION(dp_mol, "no owner");
     return *dp_mol;

--- a/Code/GraphMol/Bond.h
+++ b/Code/GraphMol/Bond.h
@@ -142,10 +142,10 @@ class RDKIT_GRAPHMOL_EXPORT Bond : public RDProps {
   //! returns the status of our \c isConjugated flag
   bool getIsConjugated() const { return df_isConjugated; };
 
-  //! returns whether or not this Bond belongs to a molecule
+  //! returns whether or not this instance belongs to a molecule
   bool hasOwningMol() const { return dp_mol != nullptr; };
 
-  //! returns a reference to the ROMol that owns this Bond
+  //! returns a reference to the ROMol that owns this instance
   ROMol &getOwningMol() const {
     PRECONDITION(dp_mol, "no owner");
     return *dp_mol;

--- a/Code/GraphMol/Bond.h
+++ b/Code/GraphMol/Bond.h
@@ -142,6 +142,9 @@ class RDKIT_GRAPHMOL_EXPORT Bond : public RDProps {
   //! returns the status of our \c isConjugated flag
   bool getIsConjugated() const { return df_isConjugated; };
 
+  //! returns whether or not this Bond belongs to a molecule
+  bool hasOwningMol() const { return dp_mol != nullptr; };
+
   //! returns a reference to the ROMol that owns this Bond
   ROMol &getOwningMol() const {
     PRECONDITION(dp_mol, "no owner");

--- a/Code/GraphMol/Conformer.h
+++ b/Code/GraphMol/Conformer.h
@@ -74,7 +74,10 @@ class RDKIT_GRAPHMOL_EXPORT Conformer : public RDProps {
   bool hasOwningMol() const { return dp_mol != nullptr; };
 
   //! Get the molecule that owns this instance
-  ROMol &getOwningMol() const { return *dp_mol; }
+  ROMol &getOwningMol() const {     
+    PRECONDITION(dp_mol, "no owner");
+    return *dp_mol; 
+  }
 
   //! Get a const reference to the vector of atom positions
   const RDGeom::POINT3D_VECT &getPositions() const;

--- a/Code/GraphMol/Conformer.h
+++ b/Code/GraphMol/Conformer.h
@@ -16,7 +16,6 @@
 #include <boost/smart_ptr.hpp>
 #include <RDGeneral/RDProps.h>
 
-
 namespace RDKit {
 class ROMol;
 
@@ -71,7 +70,10 @@ class RDKIT_GRAPHMOL_EXPORT Conformer : public RDProps {
   //! Reserve more space for atom position
   void reserve(unsigned int size) { d_positions.reserve(size); }
 
-  //! Get the molecule that oqns this conformation
+  //! returns whether or not this instance belongs to a molecule
+  bool hasOwningMol() const { return dp_mol != nullptr; };
+
+  //! Get the molecule that owns this instance
   ROMol &getOwningMol() const { return *dp_mol; }
 
   //! Get a const reference to the vector of atom positions

--- a/Code/GraphMol/SmilesParse/SmartsWrite.cpp
+++ b/Code/GraphMol/SmilesParse/SmartsWrite.cpp
@@ -302,7 +302,8 @@ std::string getAtomSmartsSimple(const QueryAtom *qatom,
   }
 
   // handle atomic stereochemistry
-  if (qatom->getOwningMol().hasProp(common_properties::_doIsoSmiles)) {
+  if (qatom->hasOwningMol() &&
+      qatom->getOwningMol().hasProp(common_properties::_doIsoSmiles)) {
     if (qatom->getChiralTag() != Atom::CHI_UNSPECIFIED &&
         !qatom->hasProp(_qatomHasStereoSet) &&
         !qatom->hasProp(common_properties::_brokenChirality)) {
@@ -402,10 +403,11 @@ std::string getBondSmartsSimple(const Bond *bond,
     bool reverseDative =
         (atomToLeftIdx >= 0 &&
          bond->getBeginAtomIdx() == static_cast<unsigned int>(atomToLeftIdx));
-    res += getBasicBondRepr(
-        static_cast<Bond::BondType>(bquery->getVal()), bond->getBondDir(),
-        bond->getOwningMol().hasProp(common_properties::_doIsoSmiles),
-        reverseDative);
+    bool doIsoSmiles =
+        !bond->hasOwningMol() ||
+        bond->getOwningMol().hasProp(common_properties::_doIsoSmiles);
+    res += getBasicBondRepr(static_cast<Bond::BondType>(bquery->getVal()),
+                            bond->getBondDir(), doIsoSmiles, reverseDative);
   } else {
     std::stringstream msg;
     msg << "Canot write smarts for this query bond type : " << descrip;
@@ -715,7 +717,8 @@ std::string getNonQueryAtomSmarts(const QueryAtom *qatom) {
     res << qatom->getSymbol();
   }
 
-  if (qatom->getOwningMol().hasProp(common_properties::_doIsoSmiles)) {
+  if (qatom->hasOwningMol() &&
+      qatom->getOwningMol().hasProp(common_properties::_doIsoSmiles)) {
     if (qatom->getChiralTag() != Atom::CHI_UNSPECIFIED &&
         !qatom->hasProp(_qatomHasStereoSet) &&
         !qatom->hasProp(common_properties::_brokenChirality)) {
@@ -774,10 +777,11 @@ std::string getNonQueryBondSmarts(const QueryBond *qbond, int atomToLeftIdx) {
     bool reverseDative =
         (atomToLeftIdx >= 0 &&
          qbond->getBeginAtomIdx() == static_cast<unsigned int>(atomToLeftIdx));
-    res = getBasicBondRepr(
-        qbond->getBondType(), qbond->getBondDir(),
-        qbond->getOwningMol().hasProp(common_properties::_doIsoSmiles),
-        reverseDative);
+    bool doIsoSmiles =
+        !qbond->hasOwningMol() ||
+        qbond->getOwningMol().hasProp(common_properties::_doIsoSmiles);
+    res = getBasicBondRepr(qbond->getBondType(), qbond->getBondDir(),
+                           doIsoSmiles, reverseDative);
   }
 
   return res;

--- a/Code/GraphMol/SmilesParse/SmilesWrite.cpp
+++ b/Code/GraphMol/SmilesParse/SmilesWrite.cpp
@@ -62,7 +62,8 @@ std::string GetAtomSmiles(const Atom *atom, bool doKekule, const Bond *bondIn,
   // check for atomic stereochemistry
   std::string atString = "";
   if (isomericSmiles ||
-      atom->getOwningMol().hasProp(common_properties::_doIsoSmiles)) {
+      (atom->hasOwningMol() &&
+       atom->getOwningMol().hasProp(common_properties::_doIsoSmiles))) {
     if (atom->getChiralTag() != Atom::CHI_UNSPECIFIED &&
         !atom->hasProp(common_properties::_brokenChirality)) {
       switch (atom->getChiralTag()) {
@@ -108,8 +109,9 @@ std::string GetAtomSmiles(const Atom *atom, bool doKekule, const Bond *bondIn,
     if (fc || nonStandard ||
         atom->hasProp(common_properties::molAtomMapNumber)) {
       needsBracket = true;
-    } else if ((isomericSmiles || atom->getOwningMol().hasProp(
-                                      common_properties::_doIsoSmiles)) &&
+    } else if ((isomericSmiles || (atom->hasOwningMol() &&
+                                   atom->getOwningMol().hasProp(
+                                       common_properties::_doIsoSmiles))) &&
                (isotope || atString != "")) {
       needsBracket = true;
     }
@@ -118,8 +120,9 @@ std::string GetAtomSmiles(const Atom *atom, bool doKekule, const Bond *bondIn,
   }
   if (needsBracket) res += "[";
 
-  if (isotope && (isomericSmiles || atom->getOwningMol().hasProp(
-                                        common_properties::_doIsoSmiles))) {
+  if (isotope && (isomericSmiles || (atom->hasOwningMol() &&
+                                     atom->getOwningMol().hasProp(
+                                         common_properties::_doIsoSmiles)))) {
     res += std::to_string(isotope);
   }
   // this was originally only done for the organic subset,
@@ -176,13 +179,16 @@ std::string GetBondSmiles(const Bond *bond, int atomToLeftIdx, bool doKekule,
   if (!doKekule && (bond->getBondType() == Bond::SINGLE ||
                     bond->getBondType() == Bond::DOUBLE ||
                     bond->getBondType() == Bond::AROMATIC)) {
-    Atom *a1, *a2;
-    a1 = bond->getOwningMol().getAtomWithIdx(atomToLeftIdx);
-    a2 = bond->getOwningMol().getAtomWithIdx(
-        bond->getOtherAtomIdx(atomToLeftIdx));
-    if ((a1->getIsAromatic() && a2->getIsAromatic()) &&
-        (a1->getAtomicNum() || a2->getAtomicNum()))
-      aromatic = true;
+    if (bond->hasOwningMol()) {
+      auto a1 = bond->getOwningMol().getAtomWithIdx(atomToLeftIdx);
+      auto a2 = bond->getOwningMol().getAtomWithIdx(
+          bond->getOtherAtomIdx(atomToLeftIdx));
+      if ((a1->getIsAromatic() && a2->getIsAromatic()) &&
+          (a1->getAtomicNum() || a2->getAtomicNum()))
+        aromatic = true;
+    } else {
+      aromatic = false;
+    }
   }
 
   Bond::BondDir dir = bond->getBondDir();
@@ -201,12 +207,14 @@ std::string GetBondSmiles(const Bond *bond, int atomToLeftIdx, bool doKekule,
         switch (dir) {
           case Bond::ENDDOWNRIGHT:
             if (allBondsExplicit ||
-                bond->getOwningMol().hasProp(common_properties::_doIsoSmiles))
+                (bond->hasOwningMol() &&
+                 bond->getOwningMol().hasProp(common_properties::_doIsoSmiles)))
               res = "\\";
             break;
           case Bond::ENDUPRIGHT:
             if (allBondsExplicit ||
-                bond->getOwningMol().hasProp(common_properties::_doIsoSmiles))
+                (bond->hasOwningMol() &&
+                 bond->getOwningMol().hasProp(common_properties::_doIsoSmiles)))
               res = "/";
             break;
           default:
@@ -238,12 +246,14 @@ std::string GetBondSmiles(const Bond *bond, int atomToLeftIdx, bool doKekule,
         switch (dir) {
           case Bond::ENDDOWNRIGHT:
             if (allBondsExplicit ||
-                bond->getOwningMol().hasProp(common_properties::_doIsoSmiles))
+                (bond->hasOwningMol() &&
+                 bond->getOwningMol().hasProp(common_properties::_doIsoSmiles)))
               res = "\\";
             break;
           case Bond::ENDUPRIGHT:
             if (allBondsExplicit ||
-                bond->getOwningMol().hasProp(common_properties::_doIsoSmiles))
+                (bond->hasOwningMol() &&
+                 bond->getOwningMol().hasProp(common_properties::_doIsoSmiles)))
               res = "/";
             break;
           default:

--- a/Code/GraphMol/SmilesParse/catch_tests.cpp
+++ b/Code/GraphMol/SmilesParse/catch_tests.cpp
@@ -437,4 +437,9 @@ TEST_CASE("github#2450: getAtomSmarts() fails for free atoms", "[bug]") {
     auto smarts = SmartsWrite::GetBondSmarts(qbnd.get());
     CHECK(smarts == ":");
   }
+  SECTION("SMILES works too") {
+    std::unique_ptr<Bond> bnd(new Bond(Bond::AROMATIC));
+    auto smiles = SmilesWrite::GetBondSmiles(bnd.get());
+    CHECK(smiles == ":");
+  }
 }

--- a/Code/GraphMol/SubstanceGroup.h
+++ b/Code/GraphMol/SubstanceGroup.h
@@ -102,7 +102,10 @@ class RDKIT_GRAPHMOL_EXPORT SubstanceGroup : public RDProps {
   bool hasOwningMol() const { return dp_mol != nullptr; };
 
   //! Get the molecule that owns this instance
-  ROMol &getOwningMol() const { return *dp_mol; }
+  ROMol &getOwningMol() const {     
+    PRECONDITION(dp_mol, "no owner");
+    return *dp_mol; 
+  }
 
   //! get the index of this sgroup in dp_mol's sgroups vector
   //! (do not mistake this by the ID!)

--- a/Code/GraphMol/SubstanceGroup.h
+++ b/Code/GraphMol/SubstanceGroup.h
@@ -98,7 +98,10 @@ class RDKIT_GRAPHMOL_EXPORT SubstanceGroup : public RDProps {
   //! Destructor
   ~SubstanceGroup(){};
 
-  //! Get the molecule that owns this conformation
+  //! returns whether or not this belongs to a molecule
+  bool hasOwningMol() const { return dp_mol != nullptr; };
+
+  //! Get the molecule that owns this instance
   ROMol &getOwningMol() const { return *dp_mol; }
 
   //! get the index of this sgroup in dp_mol's sgroups vector

--- a/Code/GraphMol/Wrap/Atom.cpp
+++ b/Code/GraphMol/Wrap/Atom.cpp
@@ -147,8 +147,8 @@ struct atom_wrapper {
             "Constructor, takes either an int (atomic number) or a string "
             "(atomic symbol).\n"))
 
-        .def("__copy__", &Atom::copy, 
-            python::return_value_policy<
+        .def("__copy__", &Atom::copy,
+             python::return_value_policy<
                  python::manage_new_object,
                  python::with_custodian_and_ward_postcall<0, 1>>(),
              "Create a copy of the atom")
@@ -225,6 +225,8 @@ struct atom_wrapper {
         .def("GetHybridization", &Atom::getHybridization,
              "Returns the atom's hybridization.\n")
 
+        .def("HasOwningMol", &Atom::hasOwningMol,
+             "Returns whether or not this instance belongs to a molecule.\n")
         .def("GetOwningMol", &Atom::getOwningMol,
              "Returns the Mol that owns this atom.\n",
              python::return_internal_reference<>())
@@ -351,18 +353,20 @@ struct atom_wrapper {
              (python::arg("self"), python::arg("key"), python::arg("val")),
              "Sets an atomic property\n\n"
              "  ARGUMENTS:\n"
-             "    - key: the name of the property to be set (an ExplicitBitVect).\n"
+             "    - key: the name of the property to be set (an "
+             "ExplicitBitVect).\n"
              "    - value: the property value (an ExplicitBitVect).\n\n")
 
         .def("GetExplicitBitVectProp", GetProp<Atom, ExplicitBitVect>,
              "Returns the value of the property.\n\n"
              "  ARGUMENTS:\n"
-             "    - key: the name of the property to return (a ExplicitBitVect).\n\n"
+             "    - key: the name of the property to return (a "
+             "ExplicitBitVect).\n\n"
              "  RETURNS: an ExplicitBitVect \n\n"
              "  NOTE:\n"
              "    - If the property has not been set, a KeyError exception "
              "will be raised.\n")
-        
+
         .def("HasProp", AtomHasProp,
              "Queries a Atom to see if a particular property has been "
              "assigned.\n\n"

--- a/Code/GraphMol/Wrap/Bond.cpp
+++ b/Code/GraphMol/Wrap/Bond.cpp
@@ -82,6 +82,8 @@ struct bond_wrapper {
   static void wrap() {
     python::class_<Bond>("Bond", bondClassDoc.c_str(), python::no_init)
 
+        .def("HasOwningMol", &Bond::hasOwningMol,
+             "Returns whether or not this instance belongs to a molecule.\n")
         .def("GetOwningMol", &Bond::getOwningMol,
              "Returns the Mol that owns this bond.\n",
              python::return_value_policy<python::reference_existing_object>())
@@ -325,5 +327,5 @@ These cannot currently be constructed directly from Python\n";
         "QueryBond", bondClassDoc.c_str(), python::no_init);
   };
 };
-}  // end of namespace
+}  // namespace RDKit
 void wrap_bond() { RDKit::bond_wrapper::wrap(); }

--- a/Code/GraphMol/Wrap/Conformer.cpp
+++ b/Code/GraphMol/Wrap/Conformer.cpp
@@ -76,6 +76,8 @@ struct conformer_wrapper {
         .def("GetNumAtoms", &Conformer::getNumAtoms,
              "Get the number of atoms in the conformer\n")
 
+        .def("HasOwningMol", &Conformer::hasOwningMol,
+             "Returns whether or not this instance belongs to a molecule.\n")
         .def("GetOwningMol", &Conformer::getOwningMol,
              "Get the owning molecule\n",
              python::return_value_policy<python::reference_existing_object>())


### PR DESCRIPTION
Adds `hasOwningMol()` to a few objects.

Note that `SmilesWrite::GetAtomSmiles()` still doesn't work (and won't) since it relies upon information about valence that's only available for atoms associated with molecules. We could think about changing that, but that's a bigger project.
