### PR TITLE
Typo in UFF torsion terms for SP2-SP2 

### DIFF
--- a/Code/GraphMol/ForceFieldHelpers/UFF/Builder.cpp
+++ b/Code/GraphMol/ForceFieldHelpers/UFF/Builder.cpp
@@ -560,7 +560,7 @@ void addTorsions(const ROMol &mol, const AtomicParamVect &params,
                 // here.
                 bool hasSP2 = false;
                 if (mol.getAtomWithIdx(bIdx)->getHybridization() == Atom::SP2 ||
-                    mol.getAtomWithIdx(bIdx)->getHybridization() == Atom::SP2) {
+                    mol.getAtomWithIdx(eIdx)->getHybridization() == Atom::SP2) {
                   hasSP2 = true;
                 }
                 // std::cout << "Torsion: " << bIdx << "-" << idx1 << "-" <<


### PR DESCRIPTION
#### Reference Issue
There is no reference issue.

#### What does this implement/fix? Explain your changes.
In the torsion contribution addition method of the UFF force field builder, SP2 hybridization of the end atoms is checked, but there was a typo in the code (probably due to copy-and-paste) that resulted in an erroneous check for the condition. This change fixes that typo.

#### Any other comments?
Nothing.