### PR TITLE
Odd behaviour for S and P fixed in number of pi-bonding electrons calculation

### DIFF
--- a/rdkit/Chem/AllChem.py
+++ b/rdkit/Chem/AllChem.py
@@ -438,6 +438,55 @@ def AssignBondOrdersFromTemplate(refmol, mol):
     return mol2
 
 
+def GetNumOfUnsaturatedBonds(atom):
+    """
+    Returns
+        The number of electrons an atom is using for pi bonding
+        OR
+        The Number of Unsaturated bonds, an atom has
+    >>> m = Chem.MolFromSmiles('C=C')
+    >>> GetNumOfUnsaturatedBonds(m.GetAtomWithIdx(0))
+    1
+    >>> m = Chem.MolFromSmiles('C#CC')
+    >>> GetNumOfUnsaturatedBonds(m.GetAtomWithIdx(0))
+    2
+    >>> GetNumOfUnsaturatedBonds(m.GetAtomWithIdx(1))
+    2
+    >>> m = Chem.MolFromSmiles('O=C=CC')
+    >>> GetNumOfUnsaturatedBonds(m.GetAtomWithIdx(0))
+    1
+    >>> GetNumOfUnsaturatedBonds(m.GetAtomWithIdx(1))
+    2
+    >>> GetNumOfUnsaturatedBonds(m.GetAtomWithIdx(2))
+    1
+    >>> GetNumOfUnsaturatedBonds(m.GetAtomWithIdx(3))
+    0
+    >>> m = Chem.MolFromSmiles('c1ccccc1')
+    >>> GetNumOfUnsaturatedBonds(m.GetAtomWithIdx(0))
+    1
+    This fixes the problem of S and P in old version:
+    >>> m = Chem.MolFromSmiles('S(=O)(=O)(O)O')
+    >>> GetNumOfUnsaturatedBonds(m.GetAtomWithIdx(0))
+    2
+    >>> m = Chem.MolFromSmiles('P(=O)(O)(O)O')
+    >>> GetNumOfUnsaturatedBonds(m.GetAtomWithIdx(0))
+    1
+    """
+   
+    # For aromatic atoms, num of unsaturated bonds = 1
+    if atom.GetIsAromatic():
+        num_uns_bonds = 1
+    
+    # For other bonded atoms, num of unsaturated bonds = Sum of bond orders - Number of non-hydrogen neighbors
+    else:
+        bond_order = 0
+        for bond in atom.GetBonds():
+            bond_order += bond.GetBondTypeAsDouble()
+        num_uns_bonds = bond_order - len(atom.GetNeighbors())
+
+    return int(num_uns_bonds)
+
+
 # ------------------------------------
 #
 #  doctest boilerplate

--- a/rdkit/Chem/AllChem.py
+++ b/rdkit/Chem/AllChem.py
@@ -20,6 +20,7 @@ from rdkit import DataStructs
 from rdkit import ForceField
 from rdkit import RDConfig
 from rdkit import rdBase
+from rdkit import Chem
 from rdkit.Chem import *
 from rdkit.Chem.ChemicalFeatures import *
 from rdkit.Chem.rdChemReactions import *

--- a/rdkit/Chem/AllChem.py
+++ b/rdkit/Chem/AllChem.py
@@ -445,33 +445,43 @@ def GetNumOfUnsaturatedBonds(atom):
         The number of electrons an atom is using for pi bonding
         OR
         The Number of Unsaturated bonds, an atom has
+    
     >>> m = Chem.MolFromSmiles('C=C')
     >>> GetNumOfUnsaturatedBonds(m.GetAtomWithIdx(0))
     1
+    
     >>> m = Chem.MolFromSmiles('C#CC')
     >>> GetNumOfUnsaturatedBonds(m.GetAtomWithIdx(0))
     2
+    
     >>> GetNumOfUnsaturatedBonds(m.GetAtomWithIdx(1))
     2
+    
     >>> m = Chem.MolFromSmiles('O=C=CC')
     >>> GetNumOfUnsaturatedBonds(m.GetAtomWithIdx(0))
     1
+    
     >>> GetNumOfUnsaturatedBonds(m.GetAtomWithIdx(1))
     2
+    
     >>> GetNumOfUnsaturatedBonds(m.GetAtomWithIdx(2))
     1
+    
     >>> GetNumOfUnsaturatedBonds(m.GetAtomWithIdx(3))
     0
+    
     >>> m = Chem.MolFromSmiles('c1ccccc1')
     >>> GetNumOfUnsaturatedBonds(m.GetAtomWithIdx(0))
     1
-    This fixes the problem of S and P in old version:
+    
     >>> m = Chem.MolFromSmiles('S(=O)(=O)(O)O')
     >>> GetNumOfUnsaturatedBonds(m.GetAtomWithIdx(0))
     2
+    
     >>> m = Chem.MolFromSmiles('P(=O)(O)(O)O')
     >>> GetNumOfUnsaturatedBonds(m.GetAtomWithIdx(0))
     1
+    
     """
    
     # For aromatic atoms, num of unsaturated bonds = 1

--- a/rdkit/Chem/AtomPairs/Utils.py
+++ b/rdkit/Chem/AtomPairs/Utils.py
@@ -143,19 +143,17 @@ def NumPiElectrons(atom):
     1
 
     """
-    bond_order = 0
-    pi_electrons = 0
-
-    for bond in atom.GetBonds():
-
-        # For aromatic atoms, pi-electrons = 1
-        if bond.GetBondTypeAsDouble() == 1.5:
-            pi_electrons = 1
-
-        # For other bonded atoms, pi-electrons = Sum of bond orders - Number of non-hydrogen neighbors
-        else:
+   
+    # For aromatic atoms, pi-electrons = 1
+    if atom.GetIsAromatic():
+        pi_electrons = 1
+    
+    # For other bonded atoms, pi-electrons = Sum of bond orders - Number of non-hydrogen neighbors
+    else:
+        bond_order = 0
+        for bond in atom.GetBonds():
             bond_order += bond.GetBondTypeAsDouble()
-            pi_electrons = bond_order - len(atom.GetNeighbors())
+        pi_electrons = bond_order - len(atom.GetNeighbors())
 
     return int(pi_electrons)
 

--- a/rdkit/Chem/AtomPairs/Utils.py
+++ b/rdkit/Chem/AtomPairs/Utils.py
@@ -378,7 +378,7 @@ def _runDoctests(verbose=None):  # pragma: nocover
 
 
 if __name__ == '__main__':  # pragma: nocover
-    # _runDoctests()
+    _runDoctests()
 
-    mol = Chem.MolFromSmiles("S(=O)(=O)(O)O")
-    print(NumPiElectrons(mol.GetAtomWithIdx(0)))
+    # mol = Chem.MolFromSmiles("S(=O)(=O)(O)O")
+    # print(NumPiElectrons(mol.GetAtomWithIdx(0)))

--- a/rdkit/Chem/AtomPairs/Utils.py
+++ b/rdkit/Chem/AtomPairs/Utils.py
@@ -167,7 +167,7 @@ def NumPiElectrons(atom):
             bond_order += bond.GetBondTypeAsDouble()
             pi_electrons = bond_order - len(atom.GetNeighbors())
 
-    return pi_electrons
+    return int(pi_electrons)
 
 
 def BitsInCommon(v1, v2):

--- a/rdkit/Chem/AtomPairs/Utils.py
+++ b/rdkit/Chem/AtomPairs/Utils.py
@@ -134,16 +134,6 @@ def NumPiElectrons(atom):
 
     This fixes the problem of S and P in old version:
 
-    **Old version**
-    >>> m = Chem.MolFromSmiles('S(=O)(=O)(O)O')
-    >>> NumPiElectrons(m.GetAtomWithIdx(0))
-    0  # Wrong
-
-    >>> m = Chem.MolFromSmiles('P(=O)(O)(O)O')
-    >>> NumPiElectrons(m.GetAtomWithIdx(0))
-    0  # Wrong
-
-    **New version**
     >>> m = Chem.MolFromSmiles('S(=O)(=O)(O)O')
     >>> NumPiElectrons(m.GetAtomWithIdx(0))
     2

--- a/rdkit/Chem/AtomPairs/Utils.py
+++ b/rdkit/Chem/AtomPairs/Utils.py
@@ -106,36 +106,47 @@ GetAtomCode = rdMolDescriptors.GetAtomPairAtomCode
 
 def NumPiElectrons(atom):
     """ Returns the number of electrons an atom is using for pi bonding
+    
     >>> m = Chem.MolFromSmiles('C=C')
     >>> NumPiElectrons(m.GetAtomWithIdx(0))
     1
+    
     >>> m = Chem.MolFromSmiles('C#CC')
     >>> NumPiElectrons(m.GetAtomWithIdx(0))
     2
+    
     >>> NumPiElectrons(m.GetAtomWithIdx(1))
     2
+    
     >>> m = Chem.MolFromSmiles('O=C=CC')
     >>> NumPiElectrons(m.GetAtomWithIdx(0))
     1
+    
     >>> NumPiElectrons(m.GetAtomWithIdx(1))
     2
+    
     >>> NumPiElectrons(m.GetAtomWithIdx(2))
     1
+    
     >>> NumPiElectrons(m.GetAtomWithIdx(3))
     0
+    
     >>> m = Chem.MolFromSmiles('c1ccccc1')
     >>> NumPiElectrons(m.GetAtomWithIdx(0))
     1
+    
     FIX: this behaves oddly in these cases:
+    
     >>> m = Chem.MolFromSmiles('S(=O)(=O)')
     >>> NumPiElectrons(m.GetAtomWithIdx(0))
     2
+    
     >>> m = Chem.MolFromSmiles('S(=O)(=O)(O)O')
     >>> NumPiElectrons(m.GetAtomWithIdx(0))
     0
+    
     In the second case, the S atom is tagged as sp3 hybridized.
     """
-
     res = 0
     if atom.GetIsAromatic():
         res = 1


### PR DESCRIPTION
`File modified: ` rdkit/rdkit/Chem/AtomPairs/Utils.py

Earlier version of the number of pi-bonded electrons calculation script behaved oddly for some of the molecules containing S and P. Below are two examples:

    **Old version**
    >>> m = Chem.MolFromSmiles('S(=O)(=O)(O)O')
    >>> NumPiElectrons(m.GetAtomWithIdx(0))
    0  # Wrong

    >>> m = Chem.MolFromSmiles('P(=O)(O)(O)O')
    >>> NumPiElectrons(m.GetAtomWithIdx(0))
    0  # Wrong

    **New version**
    >>> m = Chem.MolFromSmiles('S(=O)(=O)(O)O')
    >>> NumPiElectrons(m.GetAtomWithIdx(0))
    2

    >>> m = Chem.MolFromSmiles('P(=O)(O)(O)O')
    >>> NumPiElectrons(m.GetAtomWithIdx(0))
    1

This has been fixed in the modification. The formula used for the calculation is simply the difference of total bond order and number of non-hydrogen neighbors for non-aromatic atoms.