### PR TITLE
Fix/rgroup multiple labels

### DIFF
--- a/Code/GraphMol/RGroupDecomposition/RGroupDecomp.cpp
+++ b/Code/GraphMol/RGroupDecomposition/RGroupDecomp.cpp
@@ -280,6 +280,10 @@ bool RGroupDecompositionParameters::prepareCore(RWMol &core,
         found = true;
     }
 
+    // Unless there is an MCS match from above, we need to give different
+    //  RLABELS to each core so keep track of which labels
+    //  we have used (note that these are negative since they are
+    //  potential rgroups and haven't been assigned yet)
     if (!found && (autoLabels & AtomIndexLabels)) {
       if (setLabel(atom, indexOffset - atom->getIdx(), foundLabels, maxLabel,
                    relabel, Labelling::INDEX_LABELS))

--- a/Code/GraphMol/RGroupDecomposition/RGroupDecomp.cpp
+++ b/Code/GraphMol/RGroupDecomposition/RGroupDecomp.cpp
@@ -59,26 +59,32 @@ const std::string done = "RLABEL_PROCESSED";
 // Various places where rgroups can be labeled
 //  the order of precedence
 enum class Labelling {
-		      RGROUP_LABELS,
-		      ISOTOPE_LABELS,
-		      ATOMMAP_LABELS,
-		      INDEX_LABELS,
-		      DUMMY_LABELS,
-		      INTERNAL_LABELS
+  RGROUP_LABELS,
+  ISOTOPE_LABELS,
+  ATOMMAP_LABELS,
+  INDEX_LABELS,
+  DUMMY_LABELS,
+  INTERNAL_LABELS
 };
 
 std::string labellingToString(Labelling type) {
-  switch(type) {
-   case Labelling::RGROUP_LABELS: return "RGroupLabels";
-   case Labelling::ISOTOPE_LABELS: return "IsotopeLabels";
-   case Labelling::ATOMMAP_LABELS: return "AtomMapLabels";
-   case Labelling::INDEX_LABELS: return "IndexLabels";
-   case Labelling::DUMMY_LABELS: return "DummyLabels";
-   case Labelling::INTERNAL_LABELS: return "InternalLabels";
+  switch (type) {
+    case Labelling::RGROUP_LABELS:
+      return "RGroupLabels";
+    case Labelling::ISOTOPE_LABELS:
+      return "IsotopeLabels";
+    case Labelling::ATOMMAP_LABELS:
+      return "AtomMapLabels";
+    case Labelling::INDEX_LABELS:
+      return "IndexLabels";
+    case Labelling::DUMMY_LABELS:
+      return "DummyLabels";
+    case Labelling::INTERNAL_LABELS:
+      return "InternalLabels";
   }
   return "unknown";
 }
-  
+
 // Return the current set of rlabels for the molecule
 //  Negative RLabels are ones not assigned by the user and are
 //   either set to the index of the atom OR set to the index of
@@ -94,11 +100,11 @@ std::map<int, Atom *> getRlabels(const RWMol &mol) {
       CHECK_INVARIANT(atoms.find(rlabel) == atoms.end(),
                       "Duplicate labels in rgroup core!");
       atoms[rlabel] = atom;
-    } 
+    }
   }
   return atoms;
 }
-  
+
 void clearInputLabels(Atom *atom) {
   // atom->setIsotope(0); Don't want to clear deuterium and things like that if
   // they aren't labels
@@ -124,14 +130,14 @@ bool setLabel(Atom *atom, int label, std::set<int> &labels, int &maxLabel,
   if (label) {
     if (labels.find(label) != labels.end()) {
       if (relabel) {
-	if (type == Labelling::INTERNAL_LABELS)
-	  std::cerr << "WARNING:  relabelling existing label" << std::endl;
+        if (type == Labelling::INTERNAL_LABELS)
+          std::cerr << "WARNING:  relabelling existing label" << std::endl;
         label = maxLabel + 1;
-      }
-      else
+      } else
         // XXX FIX me - get label id
         throw ValueErrorException(
-	    std::string("Duplicate label in input, current type is:") + labellingToString(type));
+            std::string("Duplicate label in input, current type is:") +
+            labellingToString(type));
     }
 
     atom->setProp<int>(RLABEL, label);
@@ -640,7 +646,7 @@ struct RGroupDecompData {
     if (params.rgroupLabelling & AtomMap) {
       atom->setAtomMapNum(rlabel);
     }
-    
+
     if (params.rgroupLabelling & MDLRGroup) {
       std::string dLabel = "R" + std::to_string(rlabel);
       atom->setProp(common_properties::dummyLabel, dLabel);
@@ -648,7 +654,7 @@ struct RGroupDecompData {
     }
 
     if (params.rgroupLabelling & Isotope) {
-      atom->setIsotope(rlabel+1);
+      atom->setIsotope(rlabel + 1);
     }
   }
 
@@ -680,28 +686,30 @@ struct RGroupDecompData {
 
       // This logic is a bit tricky, find all labels that have common cores
       //  and analyze those sets independently.
-      //  i.e. if core 1 doesn't have R1 then don't analyze it in when looking at label 1
-      std::map<int, std::set<int>> labelCores; // map from label->cores
+      //  i.e. if core 1 doesn't have R1 then don't analyze it in when looking
+      //  at label 1
+      std::map<int, std::set<int>> labelCores;  // map from label->cores
       for (auto &position : results) {
-	int core_idx = position.core_idx;
-	if (labelCores.find(core_idx) == labelCores.end()) {
-	  auto core = cores.find(core_idx);
-	  if (core != cores.end())  {
-	    for (auto rlabels :  getRlabels(core->second)) {
-		int rlabel = rlabels.first;
-		labelCores[rlabel].insert(core_idx);
-	      }
-	  }
-	}
+        int core_idx = position.core_idx;
+        if (labelCores.find(core_idx) == labelCores.end()) {
+          auto core = cores.find(core_idx);
+          if (core != cores.end()) {
+            for (auto rlabels : getRlabels(core->second)) {
+              int rlabel = rlabels.first;
+              labelCores[rlabel].insert(core_idx);
+            }
+          }
+        }
       }
-	
+
       for (int label : labels) {
         bool allH = true;
         for (auto &position : results) {
           R_DECOMP::const_iterator rgroup = position.rgroups.find(label);
-	  bool labelHasCore = labelCores[label].find(position.core_idx) != labelCores[label].end();
-          if ( labelHasCore &&
-	      (rgroup == position.rgroups.end() || !rgroup->second->isHydrogen())) {
+          bool labelHasCore = labelCores[label].find(position.core_idx) !=
+                              labelCores[label].end();
+          if (labelHasCore && (rgroup == position.rgroups.end() ||
+                               !rgroup->second->isHydrogen())) {
             allH = false;
             break;
           }
@@ -717,9 +725,7 @@ struct RGroupDecompData {
     return results;
   }
 
-  void relabelCore(RWMol &core,
-		   std::map<int, int> &mappings,
-		   int &count,
+  void relabelCore(RWMol &core, std::map<int, int> &mappings, int &count,
                    const std::set<int> &indexLabels,
                    std::map<int, std::vector<int>> extraAtomRLabels) {
     // Now remap to proper rlabel ids
@@ -763,13 +769,13 @@ struct RGroupDecompData {
       if (atm == atoms.end()) continue;  // label not used in the rgroup
 
       Atom *atom = atm->second;
-      
+
       int rlabel;
       auto mapping = mappings.find(indexLabel);
-      if(mapping == mappings.end()) {
-	rlabel = mappings[indexLabel] = ++count;
+      if (mapping == mappings.end()) {
+        rlabel = mappings[indexLabel] = ++count;
       } else {
-	rlabel = mapping->second;
+        rlabel = mapping->second;
       }
 
       if (atom->getAtomicNum() == 0) {  // add to dummy
@@ -879,7 +885,7 @@ struct RGroupDecompData {
     for (auto &it : best) {
       for (auto rit = it.rgroups.begin(); rit != it.rgroups.end(); ++rit) {
         if (rit->first >= 0) userLabels.insert(rit->first);
-        if (rit->first < 0)  indexLabels.insert(rit->first);
+        if (rit->first < 0) indexLabels.insert(rit->first);
 
         std::map<int, int> rlabelsUsedInRGroup =
             rit->second->getNumBondsToRlabels();
@@ -896,15 +902,15 @@ struct RGroupDecompData {
     // Assign final RGroup labels to the cores and propogate these to
     //  the scaffold
     finalRlabelMapping.clear();
-    
+
     int count = 0;
     for (std::map<int, RWMol>::const_iterator coreIt = cores.begin();
          coreIt != cores.end(); ++coreIt) {
       boost::shared_ptr<RWMol> labelledCore(new RWMol(coreIt->second));
       labelledCores[coreIt->first] = labelledCore;
 
-      relabelCore(*labelledCore.get(), finalRlabelMapping, count,
-                  indexLabels, extraAtomRLabels);
+      relabelCore(*labelledCore.get(), finalRlabelMapping, count, indexLabels,
+                  extraAtomRLabels);
     }
 
     for (auto &it : best) {

--- a/Code/GraphMol/RGroupDecomposition/RGroupDecomp.cpp
+++ b/Code/GraphMol/RGroupDecomposition/RGroupDecomp.cpp
@@ -58,12 +58,33 @@ const std::string done = "RLABEL_PROCESSED";
 
 // Various places where rgroups can be labeled
 //  the order of precedence
-const std::string RGROUP_LABELS = "RGroupLabels";
-const std::string ISOTOPE_LABELS = "IsotopeLabels";
-const std::string ATOMMAP_LABELS = "AtomMapLabels";
-const std::string INDEX_LABELS = "IndexLabels";
-const std::string DUMMY_LABELS = "DummyLabels";
+enum class Labelling {
+		      RGROUP_LABELS,
+		      ISOTOPE_LABELS,
+		      ATOMMAP_LABELS,
+		      INDEX_LABELS,
+		      DUMMY_LABELS,
+		      INTERNAL_LABELS
+};
 
+std::string labellingToString(Labelling type) {
+  switch(type) {
+   case Labelling::RGROUP_LABELS: return "RGroupLabels";
+   case Labelling::ISOTOPE_LABELS: return "IsotopeLabels";
+   case Labelling::ATOMMAP_LABELS: return "AtomMapLabels";
+   case Labelling::INDEX_LABELS: return "IndexLabels";
+   case Labelling::DUMMY_LABELS: return "DummyLabels";
+   case Labelling::INTERNAL_LABELS: return "InternalLabels";
+  }
+  return "unknown";
+}
+  
+// Return the current set of rlabels for the molecule
+//  Negative RLabels are ones not assigned by the user and are
+//   either set to the index of the atom OR set to the index of
+//   the atom from the core with the best MCS.
+//  Positive rlabels are user defined (i.e. the user has specified
+//   specific R1, R2 etc...
 std::map<int, Atom *> getRlabels(const RWMol &mol) {
   std::map<int, Atom *> atoms;
 
@@ -73,11 +94,11 @@ std::map<int, Atom *> getRlabels(const RWMol &mol) {
       CHECK_INVARIANT(atoms.find(rlabel) == atoms.end(),
                       "Duplicate labels in rgroup core!");
       atoms[rlabel] = atom;
-    }
+    } 
   }
   return atoms;
 }
-
+  
 void clearInputLabels(Atom *atom) {
   // atom->setIsotope(0); Don't want to clear deuterium and things like that if
   // they aren't labels
@@ -88,12 +109,12 @@ void clearInputLabels(Atom *atom) {
 }
 
 bool setLabel(Atom *atom, int label, std::set<int> &labels, int &maxLabel,
-              bool relabel, const std::string &type) {
-  if (type == ISOTOPE_LABELS) {
+              bool relabel, Labelling type) {
+  if (type == Labelling::ISOTOPE_LABELS) {
     atom->setIsotope(0);
-  } else if (type == ATOMMAP_LABELS) {
+  } else if (type == Labelling::ATOMMAP_LABELS) {
     atom->setAtomMapNum(0);
-  } else if (type == RGROUP_LABELS) {
+  } else if (type == Labelling::RGROUP_LABELS) {
     if (atom->hasProp(common_properties::_MolFileRLabel)) {
       atom->clearProp(common_properties::_MolFileRLabel);
       atom->setIsotope(0);
@@ -102,12 +123,15 @@ bool setLabel(Atom *atom, int label, std::set<int> &labels, int &maxLabel,
 
   if (label) {
     if (labels.find(label) != labels.end()) {
-      if (relabel)
+      if (relabel) {
+	if (type == Labelling::INTERNAL_LABELS)
+	  std::cerr << "WARNING:  relabelling existing label" << std::endl;
         label = maxLabel + 1;
+      }
       else
         // XXX FIX me - get label id
         throw ValueErrorException(
-            std::string("Duplicate label in input, current type is:") + type);
+	    std::string("Duplicate label in input, current type is:") + labellingToString(type));
     }
 
     atom->setProp<int>(RLABEL, label);
@@ -152,6 +176,7 @@ unsigned int RGroupDecompositionParameters::autoGetLabels(const RWMol &core) {
 
   return autoLabels;
 }
+
 bool RGroupDecompositionParameters::prepareCore(RWMol &core,
                                                 const RWMol *alignCore) {
   const bool relabel = labels & RelabelDuplicateLabels;
@@ -203,7 +228,6 @@ bool RGroupDecompositionParameters::prepareCore(RWMol &core,
             if (alignCoreAtm->hasProp(RLABEL)) {
               int rlabel = alignCoreAtm->getProp<int>(RLABEL);
               coreAtm->setProp(RLABEL, rlabel);
-              // DEBUG -- getRlabels(core);
             }
           }
         }
@@ -211,7 +235,6 @@ bool RGroupDecompositionParameters::prepareCore(RWMol &core,
       }
     }
   }
-
   std::set<int> foundLabels;
 
   int maxLabel = 0;
@@ -223,7 +246,7 @@ bool RGroupDecompositionParameters::prepareCore(RWMol &core,
 
     if (atom->hasProp(RLABEL)) {
       if (setLabel(atom, atom->getProp<int>(RLABEL), foundLabels, maxLabel,
-                   relabel, "RLABEL"))
+                   relabel, Labelling::INTERNAL_LABELS))
         found = true;
     }
 
@@ -232,20 +255,20 @@ bool RGroupDecompositionParameters::prepareCore(RWMol &core,
       if (atom->getPropIfPresent<unsigned int>(
               common_properties::_MolFileRLabel, rgroup)) {
         if (setLabel(atom, rdcast<int>(rgroup), foundLabels, maxLabel, relabel,
-                     RGROUP_LABELS))
+                     Labelling::RGROUP_LABELS))
           found = true;
       }
     }
 
     if (!found && (autoLabels & IsotopeLabels) && atom->getIsotope() > 0) {
       if (setLabel(atom, rdcast<int>(atom->getIsotope()), foundLabels, maxLabel,
-                   relabel, ISOTOPE_LABELS))
+                   relabel, Labelling::ISOTOPE_LABELS))
         found = true;
     }
 
     if (!found && (autoLabels & AtomMapLabels) && atom->getAtomMapNum() > 0) {
       if (setLabel(atom, rdcast<int>(atom->getAtomMapNum()), foundLabels,
-                   maxLabel, relabel, ATOMMAP_LABELS))
+                   maxLabel, relabel, Labelling::ATOMMAP_LABELS))
         found = true;
     }
 
@@ -253,13 +276,13 @@ bool RGroupDecompositionParameters::prepareCore(RWMol &core,
       const bool forceRelabellingWithDummies = true;
       int defaultDummyStartLabel = 1;
       if (setLabel(atom, defaultDummyStartLabel, foundLabels, maxLabel,
-                   forceRelabellingWithDummies, DUMMY_LABELS))
+                   forceRelabellingWithDummies, Labelling::DUMMY_LABELS))
         found = true;
     }
 
     if (!found && (autoLabels & AtomIndexLabels)) {
       if (setLabel(atom, indexOffset - atom->getIdx(), foundLabels, maxLabel,
-                   relabel, INDEX_LABELS))
+                   relabel, Labelling::INDEX_LABELS))
         nextOffset++;
       found = true;
     }
@@ -279,7 +302,6 @@ bool RGroupDecompositionParameters::prepareCore(RWMol &core,
   adjustQueryProperties(core, &adjustParams);
   for (auto &it : atomToLabel) {
     core.getAtomWithIdx(it.first)->setProp(RLABEL, it.second);
-    // DEBUG -- getRlabels(core);
   }
   return true;
 }
@@ -610,11 +632,11 @@ struct RGroupDecompData {
   }
 
   void setRlabel(Atom *atom, int rlabel) {
-    // XXX Fix me - use parameters to decide what to do.  Currenty does
-    // everything
     PRECONDITION(rlabel != 0, "RLabels must be >0");
-    if (params.rgroupLabelling & AtomMap) atom->setAtomMapNum(rlabel);
-
+    if (params.rgroupLabelling & AtomMap) {
+      atom->setAtomMapNum(rlabel);
+    }
+    
     if (params.rgroupLabelling & MDLRGroup) {
       std::string dLabel = "R" + std::to_string(rlabel);
       atom->setProp(common_properties::dummyLabel, dLabel);
@@ -622,7 +644,7 @@ struct RGroupDecompData {
     }
 
     if (params.rgroupLabelling & Isotope) {
-      atom->setIsotope(rlabel);
+      atom->setIsotope(rlabel+1);
     }
   }
 
@@ -640,39 +662,60 @@ struct RGroupDecompData {
   std::vector<RGroupMatch> GetCurrentBestPermutation() const {
     const bool removeAllHydrogenRGroups = params.removeAllHydrogenRGroups;
 
-    std::vector<RGroupMatch> result;  // std::map<int, RGroup> > result;
+    std::vector<RGroupMatch> results;  // std::map<int, RGroup> > result;
     for (size_t i = 0; i < permutation.size(); ++i) {
       CHECK_INVARIANT(i < matches.size(),
                       "Best Permutation mol idx out of range");
       CHECK_INVARIANT(permutation[i] < matches[i].size(),
                       "Selected match at permutation out of range");
-      result.push_back(matches[i][permutation[i]]);
+      results.push_back(matches[i][permutation[i]]);
     }
 
     if (removeAllHydrogenRGroups) {
       // if a label is all hydrogens, remove it
+
+      // This logic is a bit tricky, find all labels that have common cores
+      //  and analyze those sets independently.
+      //  i.e. if core 1 doesn't have R1 then don't analyze it in when looking at label 1
+      std::map<int, std::set<int>> labelCores; // map from label->cores
+      for (auto &position : results) {
+	int core_idx = position.core_idx;
+	if (labelCores.find(core_idx) == labelCores.end()) {
+	  auto core = cores.find(core_idx);
+	  if (core != cores.end())  {
+	    for (auto rlabels :  getRlabels(core->second)) {
+		int rlabel = rlabels.first;
+		labelCores[rlabel].insert(core_idx);
+	      }
+	  }
+	}
+      }
+	
       for (int label : labels) {
         bool allH = true;
-        for (auto &i : result) {
-          R_DECOMP::const_iterator rgroup = i.rgroups.find(label);
-          if (rgroup == i.rgroups.end() || !rgroup->second->isHydrogen()) {
+        for (auto &position : results) {
+          R_DECOMP::const_iterator rgroup = position.rgroups.find(label);
+	  bool labelHasCore = labelCores[label].find(position.core_idx) != labelCores[label].end();
+          if ( labelHasCore &&
+	      (rgroup == position.rgroups.end() || !rgroup->second->isHydrogen())) {
             allH = false;
             break;
           }
         }
 
         if (allH) {
-          for (auto &i : result) {
-            i.rgroups.erase(label);
+          for (auto &position : results) {
+            position.rgroups.erase(label);
           }
         }
       }
     }
-    return result;
+    return results;
   }
 
-  void relabelCore(RWMol &mol, std::map<int, int> &mappings,
-                   const std::set<int> &userLabels,
+  void relabelCore(RWMol &core,
+		   std::map<int, int> &mappings,
+		   int &count,
                    const std::set<int> &indexLabels,
                    std::map<int, std::vector<int>> extraAtomRLabels) {
     // Now remap to proper rlabel ids
@@ -682,9 +725,7 @@ struct RGroupDecompData {
     //
     //  Some indices are attached to multiple bonds,
     //   these rlabels should be incrementally added last
-    int count = 0;
-    std::map<int, Atom *> atoms = getRlabels(mol);
-
+    std::map<int, Atom *> atoms = getRlabels(core);
     // a core only has one labelled index
     //  a secondary structure extraAtomRLabels contains the number
     //  of bonds between this atom and the side chain
@@ -698,7 +739,7 @@ struct RGroupDecompData {
     // Deal with user supplied labels
     for (auto rlabels : atoms) {
       int userLabel = rlabels.first;
-      if (userLabel <= 0) continue;
+      if (userLabel <= 0) continue;  // not a user specified label
       Atom *atom = rlabels.second;
       if (count < userLabel) count = userLabel;
       mappings[userLabel] = userLabel;
@@ -718,9 +759,17 @@ struct RGroupDecompData {
       if (atm == atoms.end()) continue;  // label not used in the rgroup
 
       Atom *atom = atm->second;
-      mappings[indexLabel] = ++count;
+      
+      int rlabel;
+      auto mapping = mappings.find(indexLabel);
+      if(mapping == mappings.end()) {
+	rlabel = mappings[indexLabel] = ++count;
+      } else {
+	rlabel = mapping->second;
+      }
+
       if (atom->getAtomicNum() == 0) {  // add to dummy
-        setRlabel(atom, count);
+        setRlabel(atom, rlabel);
       } else {
         auto *newAt = new Atom(0);
         setRlabel(newAt, count);
@@ -747,10 +796,10 @@ struct RGroupDecompData {
     }
 
     for (auto &i : atomsToAdd) {
-      mol.addAtom(i.second, false, true);
-      mol.addBond(i.first, i.second, Bond::SINGLE);
+      core.addAtom(i.second, false, true);
+      core.addBond(i.first, i.second, Bond::SINGLE);
     }
-    mol.updatePropertyCache(false);  // this was github #1550
+    core.updatePropertyCache(false);  // this was github #1550
   }
 
   void relabelRGroup(RGroupData &rgroup, const std::map<int, int> &mappings) {
@@ -763,7 +812,6 @@ struct RGroupDecompData {
     }
 
     mol.setProp(done, true);
-
     std::vector<std::pair<Atom *, Atom *>> atomsToAdd;  // adds -R if necessary
 
     for (RWMol::AtomIterator atIt = mol.beginAtoms(); atIt != mol.endAtoms();
@@ -827,13 +875,13 @@ struct RGroupDecompData {
     for (auto &it : best) {
       for (auto rit = it.rgroups.begin(); rit != it.rgroups.end(); ++rit) {
         if (rit->first >= 0) userLabels.insert(rit->first);
-        if (rit->first < 0) indexLabels.insert(rit->first);
+        if (rit->first < 0)  indexLabels.insert(rit->first);
 
         std::map<int, int> rlabelsUsedInRGroup =
             rit->second->getNumBondsToRlabels();
         for (auto &numBondsUsed : rlabelsUsedInRGroup) {
           // Make space for the extra labels
-          if (numBondsUsed.second > 1) {  // multiple
+          if (numBondsUsed.second > 1) {  // multiple rgroup bonds to same atom
             extraAtomRLabels[numBondsUsed.first].resize(numBondsUsed.second -
                                                         1);
           }
@@ -841,13 +889,17 @@ struct RGroupDecompData {
       }
     }
 
+    // Assign final RGroup labels to the cores and propogate these to
+    //  the scaffold
     finalRlabelMapping.clear();
+    
+    int count = 0;
     for (std::map<int, RWMol>::const_iterator coreIt = cores.begin();
          coreIt != cores.end(); ++coreIt) {
       boost::shared_ptr<RWMol> labelledCore(new RWMol(coreIt->second));
       labelledCores[coreIt->first] = labelledCore;
 
-      relabelCore(*labelledCore.get(), finalRlabelMapping, userLabels,
+      relabelCore(*labelledCore.get(), finalRlabelMapping, count,
                   indexLabels, extraAtomRLabels);
     }
 

--- a/Code/GraphMol/RGroupDecomposition/Wrap/test_rgroups.py
+++ b/Code/GraphMol/RGroupDecomposition/Wrap/test_rgroups.py
@@ -205,6 +205,58 @@ C1CCO[C@@](S)(P)1
             self.assertTrue(rg.Add(m)!=-1, smi)
 
 
+    def test_incorrect_multiple_rlabels(self):
+        mols = [Chem.MolFromSmiles(smi) for smi in ( 
+            "C1NC(Cl)CC1",   
+            "C1OC(Cl)CC1",
+            "C1(Cl)OCCC1", )]
 
+        scaffolds = [Chem.MolFromSmarts(x) for x in ("C1NCCC1",)]
+        groups,unmatched = RGroupDecompose(scaffolds, mols,
+                                               asSmiles=True, asRows=False) 
+            
+        self.assertEqual(groups,
+                         {'Core': ['C1CNC([*:1])C1'],
+                          'R1': ['Cl[*:1].[H][*:1]']})
+        
+        scaffolds = [Chem.MolFromSmarts(x) for x in ("C1OCCC1",)]
+        groups,unmatched = RGroupDecompose(scaffolds, mols,
+                                               asSmiles=True, asRows=False) 
+        self.assertEqual(groups,
+                         {'Core': ['C1COC([*:1])C1', 'C1COC([*:1])C1'],
+                          'R1': ['Cl[*:1].[H][*:1]', 'Cl[*:1].[H][*:1]']})
+        scaffolds = [Chem.MolFromSmarts(x) for x in ("C1NCCC1","C1OCCC1")]
+        groups,unmatched = RGroupDecompose(scaffolds, mols,
+                                           asSmiles=True, asRows=False)
+        self.assertEqual(groups,
+                         {'Core': ['C1CNC([*:1])C1', 'C1COC([*:1])C1', 'C1COC([*:1])C1'],
+                          'R1': ['Cl[*:1].[H][*:1]', 'Cl[*:1].[H][*:1]', 'Cl[*:1].[H][*:1]']})
+
+    def test_aligned_cores(self):
+        scaffolds = [Chem.MolFromSmarts(x) for x in ("C1NC1OC", "C1NC1NC")]
+        mols = [Chem.MolFromSmiles(smi) for smi in ("C1NC1OCCC", "C1NC1NCCC")]
+        groups,unmatched = RGroupDecompose(scaffolds, mols,
+                                           asSmiles=True, asRows=True)
+        self.assertEqual(groups,
+                         [{'Core': 'C1NC1OC[*:1]',
+                           'R1': '[H]C([H])([H])C([H])([H])[*:1].[H][*:1].[H][*:1]'},
+                          {'Core': 'C1NC1NC[*:2]',
+                           'R2': '[H]C([H])([H])C([H])([H])[*:2].[H][*:2].[H][*:2]'}])
+        
+
+    def test_aligned_cores2(self):
+        scaffolds = [Chem.MolFromSmarts(x) for x in ("C1NCC1", "C1SCC1")]
+        mols = [Chem.MolFromSmiles(smi) for smi in ("C1N(P)CC1", "C1S(P)CC1")]
+        print(scaffolds)
+        print(mols)
+        groups,unmatched = RGroupDecompose(scaffolds, mols,
+                                           asSmiles=True, asRows=True)
+        print(groups)
+        self.assertEqual(groups,
+                         [{'Core': 'C1CN([*:1])C1',
+                           'R1': '[H]P([H])[*:1]'},
+                          {'Core': 'C1C[SH]([*:2])C1',
+                           'R2': '[H]P([H])[*:2].[H][*:2]'}])
+        
 if __name__ == '__main__':
   unittest.main()

--- a/Code/GraphMol/RGroupDecomposition/testRGroupDecomp.cpp
+++ b/Code/GraphMol/RGroupDecomposition/testRGroupDecomp.cpp
@@ -56,8 +56,8 @@ void CHECK_RGROUP(RGroupRows::const_iterator &it, std::string expected,
   std::string result = str.str();
 
   if (expected != result) {
-    std::cerr << "Expected: " << expected << std::endl;
-    std::cerr << "Got:      " << result << std::endl;
+    std::cerr << "Expected: '" << expected << "'" << std::endl;
+    std::cerr << "Got:      '" << result << "'" << std::endl;
   }
 
   if (doassert) TEST_ASSERT(result == expected);
@@ -261,10 +261,10 @@ const char *coreSmi[] = {
 
     "C1CCOC(Cl)CC1", "C1CC(Cl)OCCC1", "C1CCOC(I)CC1", "C1CC(I)OCCC1"};
 
-const char *coreSmiRes[] = {"Core:C1CCC([*:2])N([*:1])CC1 R1:Cl[*:1].[H][*:1]",
-                            "Core:C1CCC([*:2])N([*:1])CC1 R1:Cl[*:1].[H][*:1]",
-                            "Core:C1CCC([*:2])N([*:1])CC1 R1:I[*:1].[H][*:1]",
-                            "Core:C1CCC([*:2])N([*:1])CC1 R1:I[*:1].[H][*:1]",
+const char *coreSmiRes[] = {"Core:C1CCNC([*:1])CC1 R1:Cl[*:1].[H][*:1]",
+                            "Core:C1CCNC([*:1])CC1 R1:Cl[*:1].[H][*:1]",
+                            "Core:C1CCNC([*:1])CC1 R1:I[*:1].[H][*:1]",
+                            "Core:C1CCNC([*:1])CC1 R1:I[*:1].[H][*:1]",
                             "Core:C1CCSC([*:1])CC1 R1:Cl[*:1].[H][*:1]",
                             "Core:C1CCSC([*:1])CC1 R1:Cl[*:1].[H][*:1]",
                             "Core:C1CCSC([*:1])CC1 R1:I[*:1].[H][*:1]",
@@ -835,8 +835,7 @@ $$$$)CTAB";
         ROMol *mol = sdsup.next();
         TEST_ASSERT(mol);
         std::cerr << "adding: " << MolToSmiles(*mol) << std::endl;
-        int addedIndex = decomp.add(*mol);
-        // TEST_ASSERT(addedIndex == -1);   // none should match
+        decomp.add(*mol);
         ++idx;
         delete mol;
       }
@@ -846,23 +845,17 @@ $$$$)CTAB";
     RGroupRows rows = decomp.getRGroupsAsRows();
 
     const char *expected[4] = {
-        "Core:N1C(N([*:2])[*:4])C2C(N([*:7])C1[*:1])[*:5]C([*:3])[*:6]2 "
-        "R1:[H][*:1] R2:C(CC[*:2])CC[*:5] R5:C(CC[*:2])CC[*:5] "
-        "R6:N([*:6])[*:6] R7:[H][*:7]",
-        "Core:N1C(N([*:2])[*:4])C2C(N([*:7])C1[*:1])[*:5]C([*:3])[*:6]2 "
-        "R1:[H][*:1] R2:C[*:2] R5:[H][*:5] R6:S([*:6])[*:6] R7:[H][*:7]",
-        "Core:N1C(N([*:2])[*:5])C2C(C([*:4])C1[*:1])[*:6]C([*:3])[*:7]2 "
-        "R1:[H][*:1] R2:C[*:2] R4:[H][*:4].[H][*:4] R5:[H][*:5] "
-        "R6:S([*:6])[*:6] R7:CC(C)C([*:7])[*:7]",
-        "Core:N1C(N([*:2])[*:5])C2C(C([*:4])C1[*:1])[*:6]C([*:3])[*:7]2 "
-        "R1:O[*:1] R2:[H][*:2] R4:[H][*:4].[H][*:4] R5:[H][*:5] "
-        "R6:CN([*:6])[*:6] R7:N([*:7])[*:7]"};
+      "Core:N1C(N([*:2])[*:4])C2C(NC1[*:1])[*:5]C([*:3])[*:6]2 R2:C(CC[*:2])CC[*:4] R4:C(CC[*:2])CC[*:4] R5:N([*:5])[*:5] R6:C([*:6])[*:6]",
+      "Core:N1C(N([*:2])[*:4])C2C(NC1[*:1])[*:5]C([*:3])[*:6]2 R2:C[*:2] R4:[H][*:4] R5:S([*:5])[*:5] R6:CC(C)C([*:6])[*:6]",
+      "Core:C1C([*:1])NC(N([*:2])[*:6])C2C1[*:5]C([*:3])[*:6]2 R2:C[*:2] R4:[H][*:4] R5:S([*:5])[*:5] R6:CC(C)C([*:6])[*:6]",
+      "Core:C1C([*:1])NC(N([*:2])[*:6])C2C1[*:5]C([*:3])[*:6]2 R2:[H][*:2] R4:[H][*:4] R5:CN([*:5])[*:5] R6:N([*:6])[*:6]"
+    };
 
-    // All Cl's should be labeled with the same rgroup
     int i = 0;
     for (RGroupRows::const_iterator it = rows.begin(); it != rows.end();
          ++it, ++i) {
-      CHECK_RGROUP(it, expected[i], true);
+      TEST_ASSERT(i<4);
+      CHECK_RGROUP(it, expected[i]);
     }
   }
 }
@@ -894,12 +887,17 @@ void testRowColumnAlignmentProblem() {
 
     auto rows = decomp.getRGroupsAsRows();
     TEST_ASSERT(rows.size() == mols.size());
+    // dump rgroups
+    for (RGroupRows::const_iterator it = rows.begin(); it != rows.end(); ++it) {
+      CHECK_RGROUP(it, "", false);
+    }
+
     for (const auto row : rows) {
       TEST_ASSERT(row.count("Core") == 1);
       TEST_ASSERT(row.count("R1") == 1);
     }
-    TEST_ASSERT(rows[0].count("R2") == 1);
-    TEST_ASSERT(rows[2].count("R2") == 1);
+    TEST_ASSERT(rows[0].count("R2") == 0);
+    TEST_ASSERT(rows[2].count("R2") == 0);
     TEST_ASSERT(rows[1].count("R2") == 0);
 
     auto cols = decomp.getRGroupsAsColumns();
@@ -912,13 +910,7 @@ void testRowColumnAlignmentProblem() {
       TEST_ASSERT(rg->getNumAtoms());
     }
     auto &R2 = cols["R2"];
-    TEST_ASSERT(R2.size() == 3);
-    TEST_ASSERT(R2[0]);
-    TEST_ASSERT(R2[0]->getNumAtoms());
-    TEST_ASSERT(R2[2]);
-    TEST_ASSERT(R2[2]->getNumAtoms());
-    TEST_ASSERT(R2[1]);
-    TEST_ASSERT(R2[1]->getNumAtoms() == 0);
+    TEST_ASSERT(R2.size() == 0);
   }
 }
 


### PR DESCRIPTION
Fixes a bug with multicores.  I was incrementing the RGroup for the atoms matched by the MCS in the second (and third) cores when it should have stayed the same.

Additionally, when removing hydrogens, only look at molecules which have the same rgroups.

And, change the strings to enums where appropriate.

See the new tests for more info.