### PR TITLE
Fixes #2479

### DIFF
--- a/Code/GraphMol/FileParsers/ForwardSDMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/ForwardSDMolSupplier.cpp
@@ -216,7 +216,6 @@ ROMol *ForwardSDMolSupplier::_next() {
       }
     }
   } catch (FileParseException &fe) {
-    if (dp_inStream->eof()) df_eofHitOnRead = true;
     if (d_line < static_cast<int>(line)) d_line = line;
     // we couldn't read a mol block or the data for the molecule. In this case
     // advance forward in the stream until we hit the next record and then
@@ -227,6 +226,8 @@ ROMol *ForwardSDMolSupplier::_next() {
         << "ERROR: moving to the begining of the next molecule\n";
 
     // FIX: report files missing the $$$$ marker
+    d_line++;
+    std::getline(*dp_inStream, tempStr);
     while (!(dp_inStream->eof()) &&
            (tempStr[0] != '$' || tempStr.substr(0, 4) != "$$$$")) {
       d_line++;
@@ -242,18 +243,25 @@ ROMol *ForwardSDMolSupplier::_next() {
         << std::endl;
     BOOST_LOG(rdErrorLog) << "ERROR: " << se.message() << "\n";
 
+    d_line++;
+    std::getline(*dp_inStream, tempStr);
+    if (dp_inStream->eof()) df_eofHitOnRead = true;
     while (!(dp_inStream->eof()) &&
            (tempStr[0] != '$' || tempStr.substr(0, 4) != "$$$$")) {
       d_line++;
       std::getline(*dp_inStream, tempStr);
     }
   } catch (...) {
+    if (dp_inStream->eof()) df_eofHitOnRead = true;
     if (d_line < static_cast<int>(line)) d_line = line;
 
     BOOST_LOG(rdErrorLog) << "Unexpected error hit on line " << d_line
                           << std::endl;
     BOOST_LOG(rdErrorLog)
         << "ERROR: moving to the begining of the next molecule\n";
+    d_line++;
+    std::getline(*dp_inStream, tempStr);
+    if (dp_inStream->eof()) df_eofHitOnRead = true;
     while (!(dp_inStream->eof()) &&
            (tempStr[0] != '$' || tempStr.substr(0, 4) != "$$$$")) {
       d_line++;

--- a/Code/GraphMol/FileParsers/MolSupplier.h
+++ b/Code/GraphMol/FileParsers/MolSupplier.h
@@ -109,6 +109,8 @@ class RDKIT_FILEPARSERS_EXPORT ForwardSDMolSupplier : public MolSupplier {
   void setProcessPropertyLists(bool val) { df_processPropertyLists = val; }
   bool getProcessPropertyLists() const { return df_processPropertyLists; }
 
+  bool getEOFHitOnRead() const { return df_eofHitOnRead; }
+
  protected:
   virtual void checkForEnd();
   ROMol *_next();
@@ -117,6 +119,7 @@ class RDKIT_FILEPARSERS_EXPORT ForwardSDMolSupplier : public MolSupplier {
   int d_line;  // line number we are currently on
   bool df_sanitize, df_removeHs, df_strictParsing;
   bool df_processPropertyLists;
+  bool df_eofHitOnRead = false;
 };
 
 // \brief a lazy supplier from an SD file

--- a/Code/GraphMol/FileParsers/SmilesMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/SmilesMolSupplier.cpp
@@ -16,7 +16,7 @@
 #include "FileParsers.h"
 #include <GraphMol/SmilesParse/SmilesParse.h>
 #include <boost/tokenizer.hpp>
-typedef boost::tokenizer<boost::char_separator<char> > tokenizer;
+typedef boost::tokenizer<boost::char_separator<char>> tokenizer;
 
 #include <fstream>
 #include <iostream>
@@ -192,8 +192,8 @@ ROMol *SmilesMolSupplier::processLine(std::string inLine) {
       res->setProp(common_properties::_Name, mname);
     } else {
       if (d_name >= static_cast<int>(recs.size())) {
-        BOOST_LOG(rdWarningLog) << "WARNING: no name column found on line "
-                                << d_line << std::endl;
+        BOOST_LOG(rdWarningLog)
+            << "WARNING: no name column found on line " << d_line << std::endl;
       } else {
         res->setProp(common_properties::_Name, recs[d_name]);
       }
@@ -456,7 +456,6 @@ ROMol *SmilesMolSupplier::next() {
   std::string inLine = getLine(dp_inStream);
   // and process it:
   res = this->processLine(inLine);
-
   // if we don't already know the length of the supplier,
   // check if we can read another line:
   if (d_len < 0 && this->skipComments() < 0) {
@@ -533,4 +532,4 @@ unsigned int SmilesMolSupplier::length() {
 }
 
 bool SmilesMolSupplier::atEnd() { return df_end; }
-}
+}  // namespace RDKit

--- a/Code/GraphMol/FileParsers/testMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/testMolSupplier.cpp
@@ -2418,6 +2418,108 @@ $$$$
     TEST_ASSERT(suppl.atEnd());
     TEST_ASSERT(suppl.getEOFHitOnRead());
   }
+
+  // truncated file1
+  std::string sdf2 = R"SDF(
+  Mrv1810 06051911332D          
+
+  3  2  0  0  0  0            999 V2000
+  -13.3985    4.9850    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+  -12.7066    5.4343    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
+  -12.0654    4.9151    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+  1  2  1  0  0  0  0
+  2  3  1  0  0  0  0
+M  END
+$$$$
+
+  Mrv1810 06051911332D          
+
+  3  2  0  0  0  0            999 V2000
+  -10.3083    4.8496    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -9.6408    5.3345    0.0000 F   0  0  0  0  0  0  0  0  0  0  0  0
+   -9.0277    4.7825    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+  1  2  1  0  0  0  0
+  2  3  1  0  0  0  0
+M  END
+$$$$
+
+  Mrv1810 06051911332D          
+
+  3  2  0  0  0  0            999 V2000
+  -10.3083    4.8496    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -9.6
+)SDF";
+  {
+    std::stringstream iss(sdf2);
+    SDMolSupplier suppl(&iss, false);
+    std::unique_ptr<ROMol> mol1(suppl.next());
+    TEST_ASSERT(mol1);
+    std::unique_ptr<ROMol> mol2(suppl.next());
+    TEST_ASSERT(!mol2);
+    std::unique_ptr<ROMol> mol3(suppl.next());
+    TEST_ASSERT(!mol3);
+    TEST_ASSERT(suppl.atEnd());
+  }
+  {
+    std::stringstream iss(sdf2);
+    ForwardSDMolSupplier suppl(&iss, false);
+    std::unique_ptr<ROMol> mol1(suppl.next());
+    TEST_ASSERT(mol1);
+    std::unique_ptr<ROMol> mol2(suppl.next());
+    TEST_ASSERT(!mol2);
+    TEST_ASSERT(!suppl.atEnd());
+    TEST_ASSERT(!suppl.getEOFHitOnRead());
+    std::unique_ptr<ROMol> mol3(suppl.next());
+    TEST_ASSERT(!mol3);
+    TEST_ASSERT(suppl.atEnd());
+    TEST_ASSERT(!suppl.getEOFHitOnRead());
+  }
+  // truncated file2
+  std::string sdf3 = R"SDF(
+  Mrv1810 06051911332D          
+
+  3  2  0  0  0  0            999 V2000
+  -13.3985    4.9850    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+  -12.7066    5.4343    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
+  -12.0654    4.9151    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+  1  2  1  0  0  0  0
+  2  3  1  0  0  0  0
+M  END
+>  <pval>  (1) 
+[1,2,]
+
+$$$$
+
+  Mrv1810 06051911332D          
+
+  3  2  0  0  0  0            999 V2000
+  -10.3083    4.8496    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -9.6408    5.3345    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
+   -9.0277    4.7825    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+  1  2  1  0  0  0  0
+  2  3  1  0  0  0  0
+M  END
+>  <pval>  (1) 
+[1,2,]
+)SDF";
+  {
+    std::stringstream iss(sdf3);
+    SDMolSupplier suppl(&iss, false);
+    std::unique_ptr<ROMol> mol1(suppl.next());
+    TEST_ASSERT(mol1);
+    std::unique_ptr<ROMol> mol2(suppl.next());
+    TEST_ASSERT(mol2);
+    TEST_ASSERT(suppl.atEnd());
+  }
+  {
+    std::stringstream iss(sdf3);
+    ForwardSDMolSupplier suppl(&iss, false);
+    std::unique_ptr<ROMol> mol1(suppl.next());
+    TEST_ASSERT(mol1);
+    std::unique_ptr<ROMol> mol2(suppl.next());
+    TEST_ASSERT(mol2);
+    TEST_ASSERT(suppl.atEnd());
+  }
 }
 
 int main() {

--- a/Code/GraphMol/FileParsers/testMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/testMolSupplier.cpp
@@ -1,6 +1,5 @@
-//  $Id$
 //
-//   Copyright (C) 2002-2008 Greg Landrum and Rational Discovery LLC
+//   Copyright (C) 2002-2019 Greg Landrum and Rational Discovery LLC
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -2353,6 +2352,74 @@ void testGitHub2285() {
   }
 }
 
+void testGitHub2479() {
+  std::string smiles1 = R"DATA(smiles id
+c1ccccc duff
+c1ccccc1 ok
+C(C garbage
+C1CC1 ok2
+CC(C)(C)(C)C duff2
+)DATA";
+  {
+    SmilesMolSupplier suppl;
+    suppl.setData(smiles1);
+    unsigned int cnt = 0;
+    while (!suppl.atEnd()) {
+      std::unique_ptr<ROMol> mol(suppl.next());
+      if (cnt % 2) TEST_ASSERT(mol);
+      ++cnt;
+    }
+    TEST_ASSERT(cnt == 5);
+  }
+
+  std::string sdf1 = R"SDF(
+  Mrv1810 06051911332D          
+
+  3  2  0  0  0  0            999 V2000
+  -13.3985    4.9850    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+  -12.7066    5.4343    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
+  -12.0654    4.9151    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+  1  2  1  0  0  0  0
+  2  3  1  0  0  0  0
+M  END
+$$$$
+
+  Mrv1810 06051911332D          
+
+  3  2  0  0  0  0            999 V2000
+  -10.3083    4.8496    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -9.6408    5.3345    0.0000 F   0  0  0  0  0  0  0  0  0  0  0  0
+   -9.0277    4.7825    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+  1  2  1  0  0  0  0
+  2  3  1  0  0  0  0
+M  END
+$$$$
+)SDF";
+  {
+    std::stringstream iss(sdf1);
+    SDMolSupplier suppl(&iss, false);
+    std::unique_ptr<ROMol> mol1(suppl.next());
+    TEST_ASSERT(mol1);
+    std::unique_ptr<ROMol> mol2(suppl.next());
+    TEST_ASSERT(!mol2);
+    TEST_ASSERT(suppl.atEnd());
+  }
+  {
+    std::stringstream iss(sdf1);
+    ForwardSDMolSupplier suppl(&iss, false);
+    std::unique_ptr<ROMol> mol1(suppl.next());
+    TEST_ASSERT(mol1);
+    std::unique_ptr<ROMol> mol2(suppl.next());
+    TEST_ASSERT(!mol2);
+    TEST_ASSERT(!suppl.atEnd());
+    TEST_ASSERT(!suppl.getEOFHitOnRead());
+    std::unique_ptr<ROMol> mol3(suppl.next());
+    TEST_ASSERT(!mol3);
+    TEST_ASSERT(suppl.atEnd());
+    TEST_ASSERT(suppl.getEOFHitOnRead());
+  }
+}
+
 int main() {
   RDLog::InitLogs();
 
@@ -2501,7 +2568,6 @@ int main() {
   testIssue3482695();
   BOOST_LOG(rdErrorLog) << "Finished: testIssue3482695()\n";
   BOOST_LOG(rdErrorLog) << "-----------------------------------------\n\n";
-#endif
   BOOST_LOG(rdErrorLog) << "-----------------------------------------\n";
   testIssue3525673();
   BOOST_LOG(rdErrorLog) << "Finished: testIssue3525673()\n";
@@ -2530,6 +2596,12 @@ int main() {
   BOOST_LOG(rdErrorLog) << "-----------------------------------------\n";
   testGitHub2285();
   BOOST_LOG(rdErrorLog) << "Finished: testGitHub2285()\n";
+  BOOST_LOG(rdErrorLog) << "-----------------------------------------\n\n";
+#endif
+
+  BOOST_LOG(rdErrorLog) << "-----------------------------------------\n";
+  testGitHub2479();
+  BOOST_LOG(rdErrorLog) << "Finished: testGitHub2479()\n";
   BOOST_LOG(rdErrorLog) << "-----------------------------------------\n\n";
 
   return 0;

--- a/Code/GraphMol/Wrap/ForwardSDMolSupplier.cpp
+++ b/Code/GraphMol/Wrap/ForwardSDMolSupplier.cpp
@@ -115,12 +115,15 @@ struct forwardsdmolsup_wrap {
              python::arg("removeHs") = true,
              python::arg("strictParsing") = true)))
         .def(NEXT_METHOD,
-             (ROMol * (*)(LocalForwardSDMolSupplier *)) & MolSupplNext,
+             (ROMol * (*)(LocalForwardSDMolSupplier *)) & MolForwardSupplNext,
              "Returns the next molecule in the file.  Raises _StopIteration_ "
              "on EOF.\n",
              python::return_value_policy<python::manage_new_object>())
         .def("atEnd", &ForwardSDMolSupplier::atEnd,
              "Returns whether or not we have hit EOF.\n")
+        .def("GetEOFHitOnRead", &ForwardSDMolSupplier::getEOFHitOnRead,
+             "Returns whether or EOF was hit while parsing the previous "
+             "entry.\n")
         .def("__iter__", &FwdMolSupplIter,
              python::return_internal_reference<1>())
         .def("GetProcessPropertyLists",

--- a/Code/GraphMol/Wrap/MolSupplier.h
+++ b/Code/GraphMol/Wrap/MolSupplier.h
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2005-2008 Greg Landrumm and Rational Discovery LLC
+//  Copyright (C) 2005-2019 Greg Landrumm and Rational Discovery LLC
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -8,8 +8,8 @@
 //  of the RDKit source tree.
 //
 #include <RDGeneral/export.h>
-#ifndef _RD_WRAP_MOLSUPPLIER_H_
-#define _RD_WRAP_MOLSUPPLIER_H_
+#ifndef RD_WRAP_MOLSUPPLIER_H
+#define RD_WRAP_MOLSUPPLIER_H
 //! Template functions for wrapping suppliers as python iterators.
 
 #include <RDBoost/python.h>
@@ -26,6 +26,26 @@ T *MolSupplIter(T *suppl) {
 }
 
 template <typename T>
+ROMol *MolForwardSupplNext(T *suppl) {
+  ROMol *res = 0;
+  if (!suppl->atEnd()) {
+    try {
+      res = suppl->next();
+    } catch (...) {
+      res = 0;
+    }
+  } else {
+    PyErr_SetString(PyExc_StopIteration, "End of supplier hit");
+    throw boost::python::error_already_set();
+  }
+  if (suppl->atEnd() && suppl->getEOFHitOnRead()) {
+    PyErr_SetString(PyExc_StopIteration, "End of supplier hit");
+    throw boost::python::error_already_set();
+  }
+  return res;
+}
+
+template <typename T>
 ROMol *MolSupplNext(T *suppl) {
   ROMol *res = 0;
   if (!suppl->atEnd()) {
@@ -34,17 +54,13 @@ ROMol *MolSupplNext(T *suppl) {
     } catch (...) {
       res = 0;
     }
-  }
-  // FIX: there is an edge case here that we ought to catch:
-  //    suppliers where the last molecule has a chemistry problem
-  //    With the current behavior, those empty molecules will not
-  //    show up in the list
-  if (suppl->atEnd() && !res) {
+  } else {
     PyErr_SetString(PyExc_StopIteration, "End of supplier hit");
     throw boost::python::error_already_set();
   }
+
   return res;
-}
+}  // namespace RDKit
 
 template <typename T>
 ROMol *MolSupplNextAcceptNullLastMolecule(T *suppl) {

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -5216,7 +5216,36 @@ M  END
     self.assertEqual(m.GetConformer().GetProp("bar"),"foo")
     self.assertEqual(m.GetConformer().GetIntProp("foo"),1)
 
-    
+  def testGithub2479(self):
+    # Chemistry failure in last entry
+    smi2='''c1ccccc  duff
+c1ccccc1 ok
+c1ccncc1 pyridine
+C(C garbage
+C1CC1 ok2
+C1C(Cl)C1 ok3
+CC(C)(C)(C)C duff2
+'''
+    suppl2 = Chem.SmilesMolSupplier()
+    suppl2.SetData(smi2, titleLine=False, nameColumn=1)
+    l = [x for x in suppl2]
+    self.assertEqual(len(l),7)
+
+    # SMILES failure in last entry
+    smi2='''c1ccccc  duff
+c1ccccc1 ok
+c1ccncc1 pyridine
+C(C garbage
+C1CC1 ok2
+C1C(Cl)C1 ok3
+C1C(Cl)CCCC duff2
+'''
+    suppl2 = Chem.SmilesMolSupplier()
+    suppl2.SetData(smi2, titleLine=False, nameColumn=1)
+    l = [x for x in suppl2]
+    self.assertEqual(len(l),7)
+      
+      
 
 if __name__ == '__main__':
   if "RDTESTCASE" in os.environ:

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -5230,6 +5230,7 @@ CC(C)(C)(C)C duff2
     suppl2.SetData(smi2, titleLine=False, nameColumn=1)
     l = [x for x in suppl2]
     self.assertEqual(len(l),7)
+    self.assertTrue(l[6] is None)
 
     # SMILES failure in last entry
     smi2='''c1ccccc  duff
@@ -5244,6 +5245,7 @@ C1C(Cl)CCCC duff2
     suppl2.SetData(smi2, titleLine=False, nameColumn=1)
     l = [x for x in suppl2]
     self.assertEqual(len(l),7)
+    self.assertTrue(l[6] is None)
       
     sdf=b"""
   Mrv1810 06051911332D          

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -5245,8 +5245,91 @@ C1C(Cl)CCCC duff2
     l = [x for x in suppl2]
     self.assertEqual(len(l),7)
       
-      
+    sdf=b"""
+  Mrv1810 06051911332D          
 
+  3  2  0  0  0  0            999 V2000
+  -13.3985    4.9850    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+  -12.7066    5.4343    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
+  -12.0654    4.9151    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+  1  2  1  0  0  0  0
+  2  3  1  0  0  0  0
+M  END
+$$$$
+
+  Mrv1810 06051911332D          
+
+  3  2  0  0  0  0            999 V2000
+  -10.3083    4.8496    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -9.6408    5.3345    0.0000 F   0  0  0  0  0  0  0  0  0  0  0  0
+   -9.0277    4.7825    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+  1  2  1  0  0  0  0
+  2  3  1  0  0  0  0
+M  END
+$$$$
+
+  Mrv1810 06051911332D          
+
+  3  2  0  0  0  0            999 V2000
+  -10.3083    4.8496    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -9.6"""
+    suppl3 = Chem.SDMolSupplier()
+    suppl3.SetData(sdf)
+    l = [x for x in suppl3]
+    self.assertEqual(len(l),3)
+    self.assertTrue(l[1] is None)
+    self.assertTrue(l[2] is None)
+    
+    from io import BytesIO
+    sio = BytesIO(sdf)
+    suppl3 = Chem.ForwardSDMolSupplier(sio)
+    l = [x for x in suppl3]
+    self.assertEqual(len(l),3)
+    self.assertTrue(l[1] is None)
+    self.assertTrue(l[2] is None)
+      
+    sdf=b"""
+  Mrv1810 06051911332D          
+
+  3  2  0  0  0  0            999 V2000
+  -13.3985    4.9850    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+  -12.7066    5.4343    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
+  -12.0654    4.9151    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+  1  2  1  0  0  0  0
+  2  3  1  0  0  0  0
+M  END
+>  <pval>  (1) 
+[1,2,]
+
+$$$$
+
+  Mrv1810 06051911332D          
+
+  3  2  0  0  0  0            999 V2000
+  -10.3083    4.8496    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -9.6408    5.3345    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
+   -9.0277    4.7825    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+  1  2  1  0  0  0  0
+  2  3  1  0  0  0  0
+M  END
+>  <pval>  (1) 
+[1,2,]
+"""
+    suppl3 = Chem.SDMolSupplier()
+    suppl3.SetData(sdf)
+    l = [x for x in suppl3]
+    self.assertEqual(len(l),2)
+    self.assertTrue(l[0] is not None)
+    self.assertTrue(l[1] is not None)
+    
+    from io import BytesIO
+    sio = BytesIO(sdf)
+    suppl3 = Chem.ForwardSDMolSupplier(sio)
+    l = [x for x in suppl3]
+    self.assertEqual(len(l),2)
+    self.assertTrue(l[0] is not None)
+    self.assertTrue(l[1] is not None)
+ 
 if __name__ == '__main__':
   if "RDTESTCASE" in os.environ:
     suite = unittest.TestSuite()

--- a/Code/RDGeneral/FileParseException.h
+++ b/Code/RDGeneral/FileParseException.h
@@ -8,8 +8,8 @@
 //  of the RDKit source tree.
 //
 #include <RDGeneral/export.h>
-#ifndef _RD_FILEPARSEEXCEPTION_H
-#define _RD_FILEPARSEEXCEPTION_H
+#ifndef RD_FILEPARSEEXCEPTION_H
+#define RD_FILEPARSEEXCEPTION_H
 
 #include <string>
 #include <stdexcept>


### PR DESCRIPTION
The problem was that "standard" MolSuppliers would detect EOF and return the final molecule at the same time, but `ForwardSDMolSupplier` wouldn't detect EOF until the subsequent call to `next()`.

The workaround for this in `MolSupplNext()`, which is used in the Python wrapper, ended up causing the reported bug in the `SmilesMolSupplier`.

The changes here should make all of this more robust 