### PR TITLE
Fix 2d depict

### DIFF
--- a/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
@@ -177,7 +177,7 @@ void MolDraw2D::drawMolecule(const ROMol &mol,
     extractAtomCoords(mol, confId, true);
     extractAtomSymbols(mol);
     if (needs_scale_) {
-      calculateScale();
+      calculateScale(panel_width_, panel_height_, highlight_atoms, highlight_radii);
       needs_scale_ = false;
     }
     // make sure the font doesn't end up too large (the constants are
@@ -859,7 +859,9 @@ void MolDraw2D::setScale(int width, int height, const Point2D &minv,
 }
 
 // ****************************************************************************
-void MolDraw2D::calculateScale(int width, int height) {
+void MolDraw2D::calculateScale(int width, int height,
+                               const std::vector<int> *highlight_atoms,
+                               const std::map<int, double> *highlight_radii) {
   PRECONDITION(width > 0, "bad width");
   PRECONDITION(height > 0, "bad height");
   PRECONDITION(activeMolIdx_ >= 0, "bad active mol");
@@ -891,6 +893,7 @@ void MolDraw2D::calculateScale(int width, int height) {
   // we may need to adjust the scale if there are atom symbols that go off
   // the edges, and we probably need to do it iteratively because
   // get_string_size uses the current value of scale_.
+  // We also need to adjust for highlighted atoms if there are any.
   while (scale_ > 1e-4) {
     for (int i = 0, is = atom_syms_[activeMolIdx_].size(); i < is; ++i) {
       if (!atom_syms_[activeMolIdx_][i].first.empty()) {
@@ -911,6 +914,23 @@ void MolDraw2D::calculateScale(int width, int height) {
         x_max = std::max(x_max, this_x_max);
         x_min_ = std::min(x_min_, this_x_min);
         y_max = std::max(y_max, this_y);
+      }
+      if(highlight_atoms) {
+          if(highlight_atoms->end() != find(highlight_atoms->begin(), highlight_atoms->end(), i)) {
+              double radius = 0.4;
+              if (highlight_radii &&
+                  highlight_radii->find(i) != highlight_radii->end()) {
+                  radius = highlight_radii->find(i)->second;
+              }
+              double this_x_min = at_cds_[activeMolIdx_][i].x - radius;
+              double this_x_max = at_cds_[activeMolIdx_][i].x + radius;
+              double this_y_min = at_cds_[activeMolIdx_][i].y - radius;
+              double this_y_max = at_cds_[activeMolIdx_][i].y + radius;
+              x_max = std::max(x_max, this_x_max);
+              x_min_ = std::min(x_min_, this_x_min);
+              y_max = std::max(y_max, this_y_max);
+              y_min_ = std::min(y_min_, this_y_min);
+          }
       }
     }
     double old_scale = scale_;

--- a/Code/GraphMol/MolDraw2D/MolDraw2D.h
+++ b/Code/GraphMol/MolDraw2D/MolDraw2D.h
@@ -315,7 +315,9 @@ class RDKIT_MOLDRAW2D_EXPORT MolDraw2D {
   double scale() const { return scale_; }
   //! calculates the drawing scale (conversion from molecular coords -> drawing
   // coords)
-  void calculateScale(int width, int height);
+  void calculateScale(int width, int height,
+                      const std::vector<int> *highlight_atoms = nullptr,
+                      const std::map<int, double> *highlight_radii = nullptr);
   //! \overload
   void calculateScale() { calculateScale(panel_width_, panel_height_); };
   //! explicitly sets the scaling factors for the drawing


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! 
-->
#### Reference Issue
Fixes issue 2486


#### What does this implement/fix? Explain your changes.
calculateScale takes account of the  highlight radius of any highlighted atoms so the circles aren't clipped at the edges of the picture.

#### Any other comments?
I have done basic testing in C++ on MacOS.  Sadly, I seem to have lost my RDKit mojo completely, and have been unable to build the python wrappers on MacOS and totally failed to build it on Ubuntu, C++ and python.  I can try harder if necessary, but I hope this is a small enough change that it won't be.
