### PR TITLE
Support XYZ format for output

### DIFF
--- a/Code/GraphMol/FileParsers/CMakeLists.txt
+++ b/Code/GraphMol/FileParsers/CMakeLists.txt
@@ -40,6 +40,7 @@ rdkit_library(FileParsers
               TDTMolSupplier.cpp TDTWriter.cpp
               TplFileParser.cpp TplFileWriter.cpp
               PDBParser.cpp PDBWriter.cpp PDBSupplier.cpp
+              XYZFileWriter.cpp
               ${maesupplier}
               ProximityBonds.cpp
               SequenceParsers.cpp SequenceWriters.cpp

--- a/Code/GraphMol/FileParsers/FileParsers.h
+++ b/Code/GraphMol/FileParsers/FileParsers.h
@@ -130,6 +130,11 @@ RDKIT_FILEPARSERS_EXPORT void MolToMolFile(
     const ROMol &mol, const std::string &fName, bool includeStereo = true,
     int confId = -1, bool kekulize = true, bool forceV3000 = false);
 
+RDKIT_FILEPARSERS_EXPORT std::string MolToXYZBlock(const ROMol &mol, int confId = -1);
+
+RDKIT_FILEPARSERS_EXPORT void MolToXYZFile(
+    const ROMol &mol, const std::string &fName, int confId = -1);
+
 //-----
 //  TPL handling:
 //-----

--- a/Code/GraphMol/FileParsers/XYZFileWriter.cpp
+++ b/Code/GraphMol/FileParsers/XYZFileWriter.cpp
@@ -1,0 +1,55 @@
+//  Copyright (C) 2019 Eisuke Kawashima
+//
+//   @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
+//
+
+#include "FileParsers.h"
+#include <fstream>
+#include <sstream>
+#include <boost/format.hpp>
+#include <RDGeneral/BadFileException.h>
+
+namespace RDKit {
+
+std::string MolToXYZBlock(const ROMol& mol, int confId) {
+  if (!mol.getNumConformers()) {
+    BOOST_LOG(rdErrorLog)
+        << "Cannot write molecules with no conformers to XYZ block\n";
+    return "";
+  }
+
+  const auto& conf = mol.getConformer(confId);
+  const unsigned int nAtoms = mol.getNumAtoms();
+
+  std::stringstream ss;
+  ss << nAtoms << '\n';
+
+  std::string name;
+  if (mol.getPropIfPresent(common_properties::_Name, name)) {
+    ss << name.substr(0, name.find_first_of('\n'));
+  }
+  ss << '\n';
+
+  for (unsigned int i = 0; i < nAtoms; i++) {
+    const auto& symbol = mol.getAtomWithIdx(i)->getSymbol();
+    const auto& pos = conf.getAtomPos(i);
+    ss << boost::format{"%-3s %11.6f %11.6f %11.6f\n"} % symbol % pos.x % pos.y % pos.z;
+  }
+  return ss.str();
+}
+
+void MolToXYZFile(const ROMol& mol, const std::string& fName, int confId) {
+  std::ofstream outStream(fName);
+  if (!outStream) {
+    std::ostringstream errout;
+    errout << "Bad output file " << fName;
+    throw BadFileException(errout.str());
+  }
+  outStream << MolToXYZBlock(mol, confId);
+}
+
+}  // namespace RDKit

--- a/Code/GraphMol/FileParsers/catch_tests.cpp
+++ b/Code/GraphMol/FileParsers/catch_tests.cpp
@@ -717,3 +717,35 @@ M  END
     CHECK(sgroups[0].getProp<std::string>("FIELDNAME") == "MRV_IMPLICIT_H");
   }
 }
+
+TEST_CASE("XYZ", "[XYZ,writer]"){
+  SECTION("basics") {
+    std::unique_ptr<RWMol> mol{new RWMol{}};
+    mol->setProp(common_properties::_Name, "methane\nthis part should not be output");
+
+    for (unsigned z : {6, 1, 1, 1, 1}) {
+      auto* a = new Atom{z};
+      mol->addAtom(a, false, true);
+    }
+
+    auto* conf = new Conformer{5};
+    conf->setId(0);
+    conf->setAtomPos(0, RDGeom::Point3D{0.000, 0.000, 0.000});
+    conf->setAtomPos(1, RDGeom::Point3D{-0.635, -0.635, 0.635});
+    conf->setAtomPos(2, RDGeom::Point3D{-0.635, 0.635, -0.635});
+    conf->setAtomPos(3, RDGeom::Point3D{0.635, -0.635, -0.635});
+    conf->setAtomPos(4, RDGeom::Point3D{0.635, 0.635, 0.635});
+    mol->addConformer(conf);
+
+    const std::string xyzblock = MolToXYZBlock(*mol);
+    std::string xyzblock_expected = R"XYZ(5
+methane
+C      0.000000    0.000000    0.000000
+H     -0.635000   -0.635000    0.635000
+H     -0.635000    0.635000   -0.635000
+H      0.635000   -0.635000   -0.635000
+H      0.635000    0.635000    0.635000
+)XYZ";
+    CHECK(xyzblock == xyzblock_expected);
+  }
+}

--- a/Code/GraphMol/Wrap/rdmolfiles.cpp
+++ b/Code/GraphMol/Wrap/rdmolfiles.cpp
@@ -695,6 +695,38 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
        python::arg("kekulize") = true, python::arg("forceV3000") = false),
       docString.c_str());
 
+  //
+
+  docString =
+      "Returns a XYZ block for a molecule\n\
+  ARGUMENTS:\n\
+\n\
+    - mol: the molecule\n\
+    - confId: (optional) selects which conformation to output (-1 = default)\n\
+\n\
+  RETURNS:\n\
+\n\
+    a string\n\
+\n";
+  python::def("MolToXYZBlock", RDKit::MolToXYZBlock,
+              (python::arg("mol"), python::arg("confId") = -1),
+              docString.c_str());
+
+  docString =
+      "Writes a XYZ file for a molecule\n\
+  ARGUMENTS:\n\
+\n\
+    - mol: the molecule\n\
+    - filename: the file to write to\n\
+    - confId: (optional) selects which conformation to output (-1 = default)\n\
+\n";
+  python::def(
+      "MolToXYZFile", RDKit::MolToXYZFile,
+      (python::arg("mol"), python::arg("filename"), python::arg("confId") = -1),
+      docString.c_str());
+
+  //
+
   python::class_<RDKit::SmilesParserParams, boost::noncopyable>(
       "SmilesParserParams", "Parameters controlling SMILES Parsing")
       .def_readwrite("maxIterations", &RDKit::SmilesParserParams::debugParse,

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -5331,7 +5331,34 @@ M  END
     self.assertEqual(len(l),2)
     self.assertTrue(l[0] is not None)
     self.assertTrue(l[1] is not None)
- 
+
+  def testXYZ(self):
+    conf = Chem.Conformer(5)
+    conf.SetAtomPosition(0, [0.000, 0.000, 0.000])
+    conf.SetAtomPosition(1, [-0.635, -0.635, 0.635])
+    conf.SetAtomPosition(2, [-0.635, 0.635, -0.635])
+    conf.SetAtomPosition(3, [0.635, -0.635, -0.635])
+    conf.SetAtomPosition(4, [0.635, 0.635, 0.635])
+
+    emol = Chem.EditableMol(Chem.Mol())
+    for z in [6, 1, 1, 1, 1]:
+      emol.AddAtom(Chem.Atom(z))
+    mol = emol.GetMol()
+    mol.SetProp('_Name', 'methane\nthis part should not be output')
+    mol.AddConformer(conf)
+
+    xyzblock_expected = """5
+methane
+C      0.000000    0.000000    0.000000
+H     -0.635000   -0.635000    0.635000
+H     -0.635000    0.635000   -0.635000
+H      0.635000   -0.635000   -0.635000
+H      0.635000    0.635000    0.635000
+"""
+
+    self.assertEqual(Chem.MolToXYZBlock(mol), xyzblock_expected)
+
+
 if __name__ == '__main__':
   if "RDTESTCASE" in os.environ:
     suite = unittest.TestSuite()

--- a/Code/JavaWrappers/ROMol.i
+++ b/Code/JavaWrappers/ROMol.i
@@ -187,6 +187,13 @@ void setPreferCoordGen(bool);
     return RDKit::MolToHELM(*($self));
   }
 
+  std::string MolToXYZBlock(int confId=-1) {
+    return RDKit::MolToXYZBlock(*($self), confId);
+  }
+  void MolToXYZFile(std::string fName, int confId=-1) {
+    RDKit::MolToXYZFile(*($self), fName, confId);
+  }
+
   bool hasSubstructMatch(RDKit::ROMol &query,bool useChirality=false){
     RDKit::MatchVectType mv;
     return SubstructMatch(*($self),query,mv,true,useChirality);


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! 
#### Reference Issue
Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.
XYZ file format is very simple and easily usable as input geometries for such quantum chemistry packages as Gaussian.
This PR adds support of XYZ format for output. Usage is as follows:

```python
>>> from rdkit.Chem import AllChem
>>> m = AllChem.AddHs(AllChem.MolFromSmiles('O'))
>>> AllChem.EmbedMolecule(m)
0
>>> print(AllChem.MolToXYZBlock(m))
3

O    -0.005703    0.385159   -0.000000
H    -0.796078   -0.194675   -0.000000
H     0.801781   -0.190484    0.000000

```

First line: number of atoms
Second line: title (optional)
Remaining lines: element symbol and x, y and z coordinates in Å.

<!--
#### Any other comments?
-->
