### PR TITLE
Thread safety cleanups in the MMFF code

### DIFF
--- a/Code/ForceField/MMFF/Params.cpp
+++ b/Code/ForceField/MMFF/Params.cpp
@@ -28,14 +28,13 @@ typedef boost::tokenizer<boost::char_separator<char> > tokenizer;
 namespace ForceFields {
 namespace MMFF {
 
-class std::unique_ptr<MMFFAromCollection> MMFFAromCollection::ds_instance = nullptr;
-
 extern const std::uint8_t defaultMMFFArom[];
 
 MMFFAromCollection *MMFFAromCollection::getMMFFArom(
     const std::uint8_t *mmffArom) {
-  if (!ds_instance || mmffArom) {
-    ds_instance.reset(new MMFFAromCollection(mmffArom));
+  static std::unique_ptr<MMFFAromCollection> ds_instance(new MMFFAromCollection(nullptr));
+  if(mmffArom){
+    return new MMFFAromCollection(mmffArom);
   }
   return ds_instance.get();
 }
@@ -52,13 +51,12 @@ MMFFAromCollection::MMFFAromCollection(const std::uint8_t *mmffArom) {
 const std::uint8_t defaultMMFFArom[] = {37, 38, 39, 44, 58, 59, 63, 64, 65,
                                           66, 69, 76, 78, 79, 80, 81, 82};
 
-class std::unique_ptr<MMFFDefCollection> MMFFDefCollection::ds_instance = nullptr;
-
 extern const std::string defaultMMFFDef;
 
 MMFFDefCollection *MMFFDefCollection::getMMFFDef(const std::string &mmffDef) {
-  if (!ds_instance || !mmffDef.empty()) {
-    ds_instance.reset(new MMFFDefCollection(mmffDef));
+  static std::unique_ptr<MMFFDefCollection> ds_instance(new MMFFDefCollection(""));
+  if (!mmffDef.empty()) {
+    return new MMFFDefCollection(mmffDef);
   }
   return ds_instance.get();
 }
@@ -443,14 +441,13 @@ const std::string defaultMMFFDef =
     "MG+2	99	99	99	99	99	DIPOSITIVE	"
     "MAGNESIUM	CATION\n";
 
-class std::unique_ptr<MMFFPropCollection> MMFFPropCollection::ds_instance = nullptr;
-
 extern const std::string defaultMMFFProp;
 
 MMFFPropCollection *MMFFPropCollection::getMMFFProp(
     const std::string &mmffProp) {
-  if (!ds_instance || !mmffProp.empty()) {
-    ds_instance.reset(new MMFFPropCollection(mmffProp));
+  static std::unique_ptr<MMFFPropCollection> ds_instance(new MMFFPropCollection(""));
+  if (!mmffProp.empty()) {
+    return new MMFFPropCollection(mmffProp);
   }
   return ds_instance.get();
 }
@@ -612,14 +609,13 @@ const std::string defaultMMFFProp =
     "98	29	0	0	0	0	0	0	0\n"
     "99	12	0	0	0	0	0	0	0\n";
 
-class std::unique_ptr<MMFFPBCICollection> MMFFPBCICollection::ds_instance = nullptr;
-
 extern const std::string defaultMMFFPBCI;
 
 MMFFPBCICollection *MMFFPBCICollection::getMMFFPBCI(
     const std::string &mmffPBCI) {
-  if (!ds_instance || !mmffPBCI.empty()) {
-    ds_instance.reset(new MMFFPBCICollection(mmffPBCI));
+  static std::unique_ptr<MMFFPBCICollection> ds_instance(new MMFFPBCICollection(""));
+  if (!mmffPBCI.empty()) {
+    return new MMFFPBCICollection(mmffPBCI);
   }
   return ds_instance.get();
 }
@@ -768,13 +764,12 @@ const std::string defaultMMFFPBCI =
     "0	98	2.000	0.000	Ionic	charge\n"
     "0	99	2.000	0.000	Ionic	charge\n";
 
-class std::unique_ptr<MMFFChgCollection> MMFFChgCollection::ds_instance = nullptr;
-
 extern const std::string defaultMMFFChg;
 
 MMFFChgCollection *MMFFChgCollection::getMMFFChg(const std::string &mmffChg) {
-  if (!ds_instance || !mmffChg.empty()) {
-    ds_instance.reset(new MMFFChgCollection(mmffChg));
+  static std::unique_ptr<MMFFChgCollection> ds_instance(new MMFFChgCollection(""));
+  if (!mmffChg.empty()) {
+    return new MMFFChgCollection(mmffChg);
   }
   return ds_instance.get();
 }
@@ -1337,14 +1332,13 @@ const std::string defaultMMFFChg =
     "0	79	81	-0.0430	E94\n"
     "0	80	81	-0.4000	#C94\n";
 
-class std::unique_ptr<MMFFBondCollection> MMFFBondCollection::ds_instance = nullptr;
-
 extern const std::string defaultMMFFBond;
 
 MMFFBondCollection *MMFFBondCollection::getMMFFBond(
     const std::string &mmffBond) {
-  if (!ds_instance || !mmffBond.empty()) {
-    ds_instance.reset(new MMFFBondCollection(mmffBond));
+  static std::unique_ptr<MMFFBondCollection> ds_instance(new MMFFBondCollection(""));
+  if (!mmffBond.empty()) {
+    return new MMFFBondCollection(mmffBond);
   }
   return ds_instance.get();
 }
@@ -1905,14 +1899,13 @@ const std::string defaultMMFFBond =
     "0	79	81	4.305	1.356	E94\n"
     "0	80	81	8.237	1.335	C94\n";
 
-class std::unique_ptr<MMFFBndkCollection> MMFFBndkCollection::ds_instance = nullptr;
-
 extern const std::string defaultMMFFBndk;
 
 MMFFBndkCollection *MMFFBndkCollection::getMMFFBndk(
     const std::string &mmffBndk) {
-  if (!ds_instance || !mmffBndk.empty()) {
-    ds_instance.reset(new MMFFBndkCollection(mmffBndk));
+  static std::unique_ptr<MMFFBndkCollection> ds_instance(new MMFFBndkCollection(""));
+  if (!mmffBndk.empty()) {
+    return new MMFFBndkCollection(mmffBndk);
   }
   return ds_instance.get();
 }
@@ -2027,16 +2020,14 @@ const std::string defaultMMFFBndk =
     "35	35	2.28	2.4	E94\n"
     "53	53	2.67	1.6	E94\n";
 
-class std::unique_ptr<MMFFHerschbachLaurieCollection>
-    MMFFHerschbachLaurieCollection::ds_instance = nullptr;
-
 extern const std::string defaultMMFFHerschbachLaurie;
 
 MMFFHerschbachLaurieCollection *
 MMFFHerschbachLaurieCollection::getMMFFHerschbachLaurie(
     const std::string &mmffHerschbachLaurie) {
-  if (!ds_instance || !mmffHerschbachLaurie.empty()) {
-    ds_instance.reset(new MMFFHerschbachLaurieCollection(mmffHerschbachLaurie));
+  static std::unique_ptr<MMFFHerschbachLaurieCollection> ds_instance(new MMFFHerschbachLaurieCollection(""));
+  if (!mmffHerschbachLaurie.empty()) {
+    return new MMFFHerschbachLaurieCollection(mmffHerschbachLaurie);
   }
   return ds_instance.get();
 }
@@ -2115,15 +2106,13 @@ const std::string defaultMMFFHerschbachLaurie =
     "4	4	2.85	1.62	1.62\n"
     "4	5	2.76	1.25	1.51\n";
 
-class std::unique_ptr<MMFFCovRadPauEleCollection> MMFFCovRadPauEleCollection::ds_instance =
-    nullptr;
-
 extern const std::string defaultMMFFCovRadPauEle;
 
 MMFFCovRadPauEleCollection *MMFFCovRadPauEleCollection::getMMFFCovRadPauEle(
     const std::string &mmffCovRadPauEle) {
-  if (!ds_instance || !mmffCovRadPauEle.empty()) {
-    ds_instance.reset(new MMFFCovRadPauEleCollection(mmffCovRadPauEle));
+  static std::unique_ptr<MMFFCovRadPauEleCollection> ds_instance(new MMFFCovRadPauEleCollection(""));
+  if (!mmffCovRadPauEle.empty()) {
+    return new MMFFCovRadPauEleCollection(mmffCovRadPauEle);
   }
   return ds_instance.get();
 }
@@ -2184,14 +2173,13 @@ const std::string defaultMMFFCovRadPauEle =
     "35	1.15	2.74\n"
     "53	1.33	2.21\n";
 
-class std::unique_ptr<MMFFAngleCollection> MMFFAngleCollection::ds_instance = nullptr;
-
 extern const std::string defaultMMFFAngleData[];
 
 MMFFAngleCollection *MMFFAngleCollection::getMMFFAngle(
     const std::string &mmffAngle) {
-  if (!ds_instance || !mmffAngle.empty()) {
-    ds_instance.reset(new MMFFAngleCollection(mmffAngle));
+  static std::unique_ptr<MMFFAngleCollection> ds_instance(new MMFFAngleCollection(""));
+  if (!mmffAngle.empty()) {
+    return new MMFFAngleCollection(mmffAngle);
   }
   return ds_instance.get();
 }
@@ -4615,14 +4603,13 @@ const std::string defaultMMFFAngleData[] = {
     "0	64	82	65	1.281	112.955	E94\n",
     "EOS"};
 
-class std::unique_ptr<MMFFStbnCollection> MMFFStbnCollection::ds_instance = nullptr;
-
 extern const std::string defaultMMFFStbn;
 
 MMFFStbnCollection *MMFFStbnCollection::getMMFFStbn(
     const std::string &mmffStbn) {
-  if (!ds_instance || !mmffStbn.empty()) {
-    ds_instance.reset(new MMFFStbnCollection(mmffStbn));
+  static std::unique_ptr<MMFFStbnCollection> ds_instance(new MMFFStbnCollection(""));
+  if (!mmffStbn.empty()) {
+    return new MMFFStbnCollection(mmffStbn);
   }
   return ds_instance.get();
 }
@@ -4975,14 +4962,13 @@ const std::string defaultMMFFStbn =
     "0	36	81	80	0.018	0.422	C94\n"
     "0	78	81	80	0.366	0.419	C94\n";
 
-class std::unique_ptr<MMFFDfsbCollection> MMFFDfsbCollection::ds_instance = nullptr;
-
 extern const std::string defaultMMFFDfsb;
 
 MMFFDfsbCollection *MMFFDfsbCollection::getMMFFDfsb(
     const std::string &mmffDfsb) {
-  if (!ds_instance || !mmffDfsb.empty()) {
-    ds_instance.reset(new MMFFDfsbCollection(mmffDfsb));
+  static std::unique_ptr<MMFFDfsbCollection> ds_instance(new MMFFDfsbCollection(""));
+  if (!mmffDfsb.empty()) {
+    return new MMFFDfsbCollection(mmffDfsb);
   }
   return ds_instance.get();
 }
@@ -5055,18 +5041,19 @@ const std::string defaultMMFFDfsb =
     "3	2	4	0.25	0.25\n"
     "4	2	4	0.25	0.25\n";
 
-class std::unique_ptr<MMFFOopCollection> MMFFOopCollection::ds_instance[2] = {nullptr, nullptr};
 
 extern const std::string defaultMMFFOop;
 extern const std::string defaultMMFFsOop;
 
 MMFFOopCollection *MMFFOopCollection::getMMFFOop(const bool isMMFFs,
                                                  const std::string &mmffOop) {
-  unsigned int i = (isMMFFs ? 1 : 0);
-  if (!ds_instance[i] || !mmffOop.empty()) {
-    ds_instance[i] = std::unique_ptr<MMFFOopCollection>(new MMFFOopCollection(isMMFFs, mmffOop));
+  static std::unique_ptr<MMFFOopCollection> ds_instance0(new MMFFOopCollection(0,""));
+  static std::unique_ptr<MMFFOopCollection> ds_instance1(new MMFFOopCollection(1,""));
+  if (!mmffOop.empty()) {
+    return new MMFFOopCollection(isMMFFs, mmffOop);
   }
-  return ds_instance[i].get();
+  if(!isMMFFs) return ds_instance0.get();
+  else return ds_instance1.get();
 }
 
 MMFFOopCollection::MMFFOopCollection(const bool isMMFFs, std::string mmffOop) {
@@ -5378,18 +5365,18 @@ const std::string defaultMMFFsOop =
     "36	81	78	80	0.016	C94\n"
     "0	82	0	0	0.000	*-82-*-*	E94	DEF\n";
 
-class std::unique_ptr<MMFFTorCollection> MMFFTorCollection::ds_instance[2] = {nullptr, nullptr};
-
 extern const std::string defaultMMFFTor;
 extern const std::string defaultMMFFsTor;
 
 MMFFTorCollection *MMFFTorCollection::getMMFFTor(const bool isMMFFs,
                                                  const std::string &mmffTor) {
-  unsigned int i = (isMMFFs ? 1 : 0);
-  if (!ds_instance[i] || !mmffTor.empty()) {
-    ds_instance[i] = std::unique_ptr<MMFFTorCollection>(new MMFFTorCollection(isMMFFs, mmffTor));
+  static std::unique_ptr<MMFFTorCollection> ds_instance0(new MMFFTorCollection(0,""));
+  static std::unique_ptr<MMFFTorCollection> ds_instance1(new MMFFTorCollection(1,""));
+  if (!mmffTor.empty()) {
+    return new MMFFTorCollection(isMMFFs, mmffTor);
   }
-  return ds_instance[i].get();
+  if(!isMMFFs) return ds_instance0.get();
+  else return ds_instance1.get();
 }
 
 MMFFTorCollection::MMFFTorCollection(const bool isMMFFs, std::string mmffTor) {
@@ -8387,13 +8374,12 @@ const std::string defaultMMFFsTor =
     "0	0	80	81	0	0.000	4.000	0.000	C94	"
     "0:*-80-81-*	Def\n";
 
-class std::unique_ptr<MMFFVdWCollection> MMFFVdWCollection::ds_instance = nullptr;
-
 extern const std::string defaultMMFFVdW;
 
 MMFFVdWCollection *MMFFVdWCollection::getMMFFVdW(const std::string &mmffVdW) {
-  if (!ds_instance || !mmffVdW.empty()) {
-    ds_instance.reset(new MMFFVdWCollection(mmffVdW));
+  static std::unique_ptr<MMFFVdWCollection> ds_instance(new MMFFVdWCollection(""));
+  if (!mmffVdW.empty()) {
+    return new MMFFVdWCollection(mmffVdW);
   }
   return ds_instance.get();
 }

--- a/Code/ForceField/MMFF/Params.h
+++ b/Code/ForceField/MMFF/Params.h
@@ -191,7 +191,6 @@ class RDKIT_FORCEFIELD_EXPORT MMFFAromCollection {
  private:
   //! to force this to be a singleton, the constructor must be private
   MMFFAromCollection(const std::uint8_t mmffArom[]);
-  static class std::unique_ptr<MMFFAromCollection> ds_instance;  //!< the singleton
   std::vector<std::uint8_t> d_params;          //!< the aromatic type vector
 };
 
@@ -236,7 +235,6 @@ class RDKIT_FORCEFIELD_EXPORT MMFFDefCollection {
  private:
   //! to force this to be a singleton, the constructor must be private
   MMFFDefCollection(std::string mmffDef);
-  static class std::unique_ptr<MMFFDefCollection> ds_instance;  //!< the singleton
 #ifdef RDKIT_MMFF_PARAMS_USE_STD_MAP
   std::map<const unsigned int, MMFFDef> d_params;  //!< the parameter map
 #else
@@ -288,7 +286,6 @@ class RDKIT_FORCEFIELD_EXPORT MMFFPropCollection {
  private:
   //! to force this to be a singleton, the constructor must be private
   MMFFPropCollection(std::string mmffProp);
-  static class std::unique_ptr<MMFFPropCollection> ds_instance;  //!< the singleton
 #ifdef RDKIT_MMFF_PARAMS_USE_STD_MAP
   std::map<const unsigned int, MMFFProp> d_params;  //!< the parameter map
 #else
@@ -337,7 +334,6 @@ class RDKIT_FORCEFIELD_EXPORT MMFFPBCICollection {
  private:
   //! to force this to be a singleton, the constructor must be private
   MMFFPBCICollection(std::string mmffPBCI);
-  static class std::unique_ptr<MMFFPBCICollection> ds_instance;  //!< the singleton
 #ifdef RDKIT_MMFF_PARAMS_USE_STD_MAP
   std::map<const unsigned int, MMFFPBCI> d_params;  //!< the parameter map
 #else
@@ -421,7 +417,6 @@ class RDKIT_FORCEFIELD_EXPORT MMFFChgCollection {
  private:
   //! to force this to be a singleton, the constructor must be private
   MMFFChgCollection(std::string mmffChg);
-  static class std::unique_ptr<MMFFChgCollection> ds_instance;  //!< the singleton
 //!< the parameter 3D-map
 #ifdef RDKIT_MMFF_PARAMS_USE_STD_MAP
   std::map<
@@ -516,7 +511,6 @@ class RDKIT_FORCEFIELD_EXPORT MMFFBondCollection {
  private:
   //! to force this to be a singleton, the constructor must be private
   MMFFBondCollection(std::string mmffBond);
-  static class std::unique_ptr<MMFFBondCollection> ds_instance;  //!< the singleton
 #ifdef RDKIT_MMFF_PARAMS_USE_STD_MAP
   std::map<
       const unsigned int,
@@ -595,7 +589,6 @@ class RDKIT_FORCEFIELD_EXPORT MMFFBndkCollection {
  private:
   //! to force this to be a singleton, the constructor must be private
   MMFFBndkCollection(std::string mmffBndk);
-  static class std::unique_ptr<MMFFBndkCollection> ds_instance;  //!< the singleton
 #ifdef RDKIT_MMFF_PARAMS_USE_STD_MAP
   std::map<const unsigned int, std::map<const unsigned int, MMFFBond> >
       d_params;  //!< the parameter 2D-map
@@ -674,7 +667,6 @@ class RDKIT_FORCEFIELD_EXPORT MMFFHerschbachLaurieCollection {
  private:
   //! to force this to be a singleton, the constructor must be private
   MMFFHerschbachLaurieCollection(std::string mmffHerschbachLaurie);
-  static class std::unique_ptr<MMFFHerschbachLaurieCollection> ds_instance;  //!< the singleton
 #ifdef RDKIT_MMFF_PARAMS_USE_STD_MAP
   std::map<const unsigned int,
            std::map<const unsigned int, MMFFHerschbachLaurie> >
@@ -734,7 +726,6 @@ class RDKIT_FORCEFIELD_EXPORT MMFFCovRadPauEleCollection {
  private:
   //! to force this to be a singleton, the constructor must be private
   MMFFCovRadPauEleCollection(std::string mmffCovRadPauEle);
-  static class std::unique_ptr<MMFFCovRadPauEleCollection> ds_instance;  //!< the singleton
 #ifdef RDKIT_MMFF_PARAMS_USE_STD_MAP
   std::map<const unsigned int, MMFFCovRadPauEle>
       d_params;  //!< the parameter map
@@ -861,7 +852,6 @@ class RDKIT_FORCEFIELD_EXPORT MMFFAngleCollection {
  private:
   //! to force this to be a singleton, the constructor must be private
   MMFFAngleCollection(std::string mmffAngle);
-  static class std::unique_ptr<MMFFAngleCollection> ds_instance;  //!< the singleton
 #ifdef RDKIT_MMFF_PARAMS_USE_STD_MAP
   std::map<const unsigned int,
            std::map<const unsigned int,
@@ -980,7 +970,6 @@ class RDKIT_FORCEFIELD_EXPORT MMFFStbnCollection {
  private:
   //! to force this to be a singleton, the constructor must be private
   MMFFStbnCollection(std::string mmffStbn);
-  static class std::unique_ptr<MMFFStbnCollection> ds_instance;  //!< the singleton
 #ifdef RDKIT_MMFF_PARAMS_USE_STD_MAP
   std::map<const unsigned int,
            std::map<const unsigned int,
@@ -1058,7 +1047,6 @@ class RDKIT_FORCEFIELD_EXPORT MMFFDfsbCollection {
  private:
   //! to force this to be a singleton, the constructor must be private
   MMFFDfsbCollection(std::string mmffDfsb);
-  static class std::unique_ptr<MMFFDfsbCollection> ds_instance;  //!< the singleton
   std::map<
       const unsigned int,
       std::map<const unsigned int, std::map<const unsigned int, MMFFStbn> > >
@@ -1178,7 +1166,6 @@ class RDKIT_FORCEFIELD_EXPORT MMFFOopCollection {
  private:
   //! to force this to be a singleton, the constructor must be private
   MMFFOopCollection(const bool isMMFFs, std::string mmffOop);
-  static class std::unique_ptr<MMFFOopCollection> ds_instance[2];  //!< the singleton
 #ifdef RDKIT_MMFF_PARAMS_USE_STD_MAP
   std::map<const unsigned int,
            std::map<const unsigned int,
@@ -1363,7 +1350,6 @@ class RDKIT_FORCEFIELD_EXPORT MMFFTorCollection {
  private:
   //! to force this to be a singleton, the constructor must be private
   MMFFTorCollection(const bool isMMFFs, std::string mmffTor);
-  static class std::unique_ptr<MMFFTorCollection> ds_instance[2];  //!< the singleton
 #ifdef RDKIT_MMFF_PARAMS_USE_STD_MAP
   std::map<const unsigned int,
            std::map<const unsigned int,
@@ -1432,7 +1418,6 @@ class RDKIT_FORCEFIELD_EXPORT MMFFVdWCollection {
  private:
   //! to force this to be a singleton, the constructor must be private
   MMFFVdWCollection(std::string mmffVdW);
-  static class std::unique_ptr<MMFFVdWCollection> ds_instance;  //!< the singleton
 #ifdef RDKIT_MMFF_PARAMS_USE_STD_MAP
   std::map<const unsigned int, MMFFVdW> d_params;  //!< the parameter map
 #else


### PR DESCRIPTION
The changes made as part of #2123 introduced a thread-safety problem in the MMFF code.
This fixes that.

This is a quick fix so that we can patch a crashing bug in the currently release. It would make sense to change the API that's being used here to be a little bit more modern, but that would be for the next major release.