### PR TITLE
Fix/mmff threadsafety issues

### DIFF
--- a/Code/ForceField/MMFF/Nonbonded.cpp
+++ b/Code/ForceField/MMFF/Nonbonded.cpp
@@ -21,7 +21,7 @@
 namespace ForceFields {
 namespace MMFF {
 namespace Utils {
-double calcUnscaledVdWMinimum(MMFFVdWCollection *mmffVdW,
+double calcUnscaledVdWMinimum(const MMFFVdWCollection *mmffVdW,
                               const MMFFVdW *mmffVdWParamsIAtom,
                               const MMFFVdW *mmffVdWParamsJAtom) {
   double gamma_ij = (mmffVdWParamsIAtom->R_star - mmffVdWParamsJAtom->R_star) /
@@ -68,7 +68,7 @@ double calcVdWEnergy(const double dist, const double R_star_ij,
 }
 
 void scaleVdWParams(double &R_star_ij, double &wellDepth,
-                    MMFFVdWCollection *mmffVdW,
+                    const MMFFVdWCollection *mmffVdW,
                     const MMFFVdW *mmffVdWParamsIAtom,
                     const MMFFVdW *mmffVdWParamsJAtom) {
   if (((mmffVdWParamsIAtom->DA == 'D') && (mmffVdWParamsJAtom->DA == 'A')) ||

--- a/Code/ForceField/MMFF/Nonbonded.h
+++ b/Code/ForceField/MMFF/Nonbonded.h
@@ -75,7 +75,7 @@ namespace Utils {
 //! calculates and returns the unscaled minimum distance (R*ij) for a MMFF VdW
 // contact
 RDKIT_FORCEFIELD_EXPORT double calcUnscaledVdWMinimum(
-    MMFFVdWCollection *mmffVdW, const MMFFVdW *mmffVdWParamsAtom1,
+    const MMFFVdWCollection *mmffVdW, const MMFFVdW *mmffVdWParamsAtom1,
     const MMFFVdW *mmffVdWParamsAtom2);
 //! calculates and returns the unscaled well depth (epsilon) for a MMFF VdW
 // contact
@@ -85,7 +85,7 @@ RDKIT_FORCEFIELD_EXPORT double calcUnscaledVdWWellDepth(
 //! scales the VdW parameters
 RDKIT_FORCEFIELD_EXPORT void scaleVdWParams(double &R_star_ij,
                                             double &wellDepth,
-                                            MMFFVdWCollection *mmffVdW,
+                                            const MMFFVdWCollection *mmffVdW,
                                             const MMFFVdW *mmffVdWParamsIAtom,
                                             const MMFFVdW *mmffVdWParamsJAtom);
 //! calculates and returns the Van der Waals MMFF energy

--- a/Code/ForceField/MMFF/Params.cpp
+++ b/Code/ForceField/MMFF/Params.cpp
@@ -28,17 +28,7 @@ typedef boost::tokenizer<boost::char_separator<char> > tokenizer;
 namespace ForceFields {
 namespace MMFF {
 
-class std::unique_ptr<MMFFAromCollection> MMFFAromCollection::ds_instance = nullptr;
-
 extern const std::uint8_t defaultMMFFArom[];
-
-MMFFAromCollection *MMFFAromCollection::getMMFFArom(
-    const std::uint8_t *mmffArom) {
-  if (!ds_instance || mmffArom) {
-    ds_instance.reset(new MMFFAromCollection(mmffArom));
-  }
-  return ds_instance.get();
-}
 
 MMFFAromCollection::MMFFAromCollection(const std::uint8_t *mmffArom) {
   if (!mmffArom) {
@@ -52,16 +42,7 @@ MMFFAromCollection::MMFFAromCollection(const std::uint8_t *mmffArom) {
 const std::uint8_t defaultMMFFArom[] = {37, 38, 39, 44, 58, 59, 63, 64, 65,
                                           66, 69, 76, 78, 79, 80, 81, 82};
 
-class std::unique_ptr<MMFFDefCollection> MMFFDefCollection::ds_instance = nullptr;
-
 extern const std::string defaultMMFFDef;
-
-MMFFDefCollection *MMFFDefCollection::getMMFFDef(const std::string &mmffDef) {
-  if (!ds_instance || !mmffDef.empty()) {
-    ds_instance.reset(new MMFFDefCollection(mmffDef));
-  }
-  return ds_instance.get();
-}
 
 MMFFDefCollection::MMFFDefCollection(std::string mmffDef) {
   if (mmffDef.empty()) {
@@ -443,17 +424,7 @@ const std::string defaultMMFFDef =
     "MG+2	99	99	99	99	99	DIPOSITIVE	"
     "MAGNESIUM	CATION\n";
 
-class std::unique_ptr<MMFFPropCollection> MMFFPropCollection::ds_instance = nullptr;
-
 extern const std::string defaultMMFFProp;
-
-MMFFPropCollection *MMFFPropCollection::getMMFFProp(
-    const std::string &mmffProp) {
-  if (!ds_instance || !mmffProp.empty()) {
-    ds_instance.reset(new MMFFPropCollection(mmffProp));
-  }
-  return ds_instance.get();
-}
 
 MMFFPropCollection::MMFFPropCollection(std::string mmffProp) {
   if (mmffProp.empty()) {
@@ -612,17 +583,7 @@ const std::string defaultMMFFProp =
     "98	29	0	0	0	0	0	0	0\n"
     "99	12	0	0	0	0	0	0	0\n";
 
-class std::unique_ptr<MMFFPBCICollection> MMFFPBCICollection::ds_instance = nullptr;
-
 extern const std::string defaultMMFFPBCI;
-
-MMFFPBCICollection *MMFFPBCICollection::getMMFFPBCI(
-    const std::string &mmffPBCI) {
-  if (!ds_instance || !mmffPBCI.empty()) {
-    ds_instance.reset(new MMFFPBCICollection(mmffPBCI));
-  }
-  return ds_instance.get();
-}
 
 MMFFPBCICollection::MMFFPBCICollection(std::string mmffPBCI) {
   if (mmffPBCI.empty()) {
@@ -768,16 +729,7 @@ const std::string defaultMMFFPBCI =
     "0	98	2.000	0.000	Ionic	charge\n"
     "0	99	2.000	0.000	Ionic	charge\n";
 
-class std::unique_ptr<MMFFChgCollection> MMFFChgCollection::ds_instance = nullptr;
-
 extern const std::string defaultMMFFChg;
-
-MMFFChgCollection *MMFFChgCollection::getMMFFChg(const std::string &mmffChg) {
-  if (!ds_instance || !mmffChg.empty()) {
-    ds_instance.reset(new MMFFChgCollection(mmffChg));
-  }
-  return ds_instance.get();
-}
 
 MMFFChgCollection::MMFFChgCollection(std::string mmffChg) {
   if (mmffChg.empty()) {
@@ -1337,17 +1289,7 @@ const std::string defaultMMFFChg =
     "0	79	81	-0.0430	E94\n"
     "0	80	81	-0.4000	#C94\n";
 
-class std::unique_ptr<MMFFBondCollection> MMFFBondCollection::ds_instance = nullptr;
-
 extern const std::string defaultMMFFBond;
-
-MMFFBondCollection *MMFFBondCollection::getMMFFBond(
-    const std::string &mmffBond) {
-  if (!ds_instance || !mmffBond.empty()) {
-    ds_instance.reset(new MMFFBondCollection(mmffBond));
-  }
-  return ds_instance.get();
-}
 
 MMFFBondCollection::MMFFBondCollection(std::string mmffBond) {
   if (mmffBond.empty()) {
@@ -1905,17 +1847,7 @@ const std::string defaultMMFFBond =
     "0	79	81	4.305	1.356	E94\n"
     "0	80	81	8.237	1.335	C94\n";
 
-class std::unique_ptr<MMFFBndkCollection> MMFFBndkCollection::ds_instance = nullptr;
-
 extern const std::string defaultMMFFBndk;
-
-MMFFBndkCollection *MMFFBndkCollection::getMMFFBndk(
-    const std::string &mmffBndk) {
-  if (!ds_instance || !mmffBndk.empty()) {
-    ds_instance.reset(new MMFFBndkCollection(mmffBndk));
-  }
-  return ds_instance.get();
-}
 
 MMFFBndkCollection::MMFFBndkCollection(std::string mmffBndk) {
   if (mmffBndk.empty()) {
@@ -2027,19 +1959,7 @@ const std::string defaultMMFFBndk =
     "35	35	2.28	2.4	E94\n"
     "53	53	2.67	1.6	E94\n";
 
-class std::unique_ptr<MMFFHerschbachLaurieCollection>
-    MMFFHerschbachLaurieCollection::ds_instance = nullptr;
-
 extern const std::string defaultMMFFHerschbachLaurie;
-
-MMFFHerschbachLaurieCollection *
-MMFFHerschbachLaurieCollection::getMMFFHerschbachLaurie(
-    const std::string &mmffHerschbachLaurie) {
-  if (!ds_instance || !mmffHerschbachLaurie.empty()) {
-    ds_instance.reset(new MMFFHerschbachLaurieCollection(mmffHerschbachLaurie));
-  }
-  return ds_instance.get();
-}
 
 MMFFHerschbachLaurieCollection::MMFFHerschbachLaurieCollection(
     std::string mmffHerschbachLaurie) {
@@ -2115,18 +2035,7 @@ const std::string defaultMMFFHerschbachLaurie =
     "4	4	2.85	1.62	1.62\n"
     "4	5	2.76	1.25	1.51\n";
 
-class std::unique_ptr<MMFFCovRadPauEleCollection> MMFFCovRadPauEleCollection::ds_instance =
-    nullptr;
-
 extern const std::string defaultMMFFCovRadPauEle;
-
-MMFFCovRadPauEleCollection *MMFFCovRadPauEleCollection::getMMFFCovRadPauEle(
-    const std::string &mmffCovRadPauEle) {
-  if (!ds_instance || !mmffCovRadPauEle.empty()) {
-    ds_instance.reset(new MMFFCovRadPauEleCollection(mmffCovRadPauEle));
-  }
-  return ds_instance.get();
-}
 
 MMFFCovRadPauEleCollection::MMFFCovRadPauEleCollection(
     std::string mmffCovRadPauEle) {
@@ -2184,17 +2093,7 @@ const std::string defaultMMFFCovRadPauEle =
     "35	1.15	2.74\n"
     "53	1.33	2.21\n";
 
-class std::unique_ptr<MMFFAngleCollection> MMFFAngleCollection::ds_instance = nullptr;
-
 extern const std::string defaultMMFFAngleData[];
-
-MMFFAngleCollection *MMFFAngleCollection::getMMFFAngle(
-    const std::string &mmffAngle) {
-  if (!ds_instance || !mmffAngle.empty()) {
-    ds_instance.reset(new MMFFAngleCollection(mmffAngle));
-  }
-  return ds_instance.get();
-}
 
 MMFFAngleCollection::MMFFAngleCollection(std::string mmffAngle) {
   if (mmffAngle.empty()) {
@@ -4615,17 +4514,7 @@ const std::string defaultMMFFAngleData[] = {
     "0	64	82	65	1.281	112.955	E94\n",
     "EOS"};
 
-class std::unique_ptr<MMFFStbnCollection> MMFFStbnCollection::ds_instance = nullptr;
-
 extern const std::string defaultMMFFStbn;
-
-MMFFStbnCollection *MMFFStbnCollection::getMMFFStbn(
-    const std::string &mmffStbn) {
-  if (!ds_instance || !mmffStbn.empty()) {
-    ds_instance.reset(new MMFFStbnCollection(mmffStbn));
-  }
-  return ds_instance.get();
-}
 
 MMFFStbnCollection::MMFFStbnCollection(std::string mmffStbn) {
   if (mmffStbn.empty()) {
@@ -4975,17 +4864,7 @@ const std::string defaultMMFFStbn =
     "0	36	81	80	0.018	0.422	C94\n"
     "0	78	81	80	0.366	0.419	C94\n";
 
-class std::unique_ptr<MMFFDfsbCollection> MMFFDfsbCollection::ds_instance = nullptr;
-
 extern const std::string defaultMMFFDfsb;
-
-MMFFDfsbCollection *MMFFDfsbCollection::getMMFFDfsb(
-    const std::string &mmffDfsb) {
-  if (!ds_instance || !mmffDfsb.empty()) {
-    ds_instance.reset(new MMFFDfsbCollection(mmffDfsb));
-  }
-  return ds_instance.get();
-}
 
 MMFFDfsbCollection::MMFFDfsbCollection(std::string mmffDfsb) {
   if (mmffDfsb.empty()) {
@@ -5055,19 +4934,8 @@ const std::string defaultMMFFDfsb =
     "3	2	4	0.25	0.25\n"
     "4	2	4	0.25	0.25\n";
 
-class std::unique_ptr<MMFFOopCollection> MMFFOopCollection::ds_instance[2] = {nullptr, nullptr};
-
 extern const std::string defaultMMFFOop;
 extern const std::string defaultMMFFsOop;
-
-MMFFOopCollection *MMFFOopCollection::getMMFFOop(const bool isMMFFs,
-                                                 const std::string &mmffOop) {
-  unsigned int i = (isMMFFs ? 1 : 0);
-  if (!ds_instance[i] || !mmffOop.empty()) {
-    ds_instance[i] = std::unique_ptr<MMFFOopCollection>(new MMFFOopCollection(isMMFFs, mmffOop));
-  }
-  return ds_instance[i].get();
-}
 
 MMFFOopCollection::MMFFOopCollection(const bool isMMFFs, std::string mmffOop) {
   if (mmffOop.empty()) {
@@ -5378,19 +5246,8 @@ const std::string defaultMMFFsOop =
     "36	81	78	80	0.016	C94\n"
     "0	82	0	0	0.000	*-82-*-*	E94	DEF\n";
 
-class std::unique_ptr<MMFFTorCollection> MMFFTorCollection::ds_instance[2] = {nullptr, nullptr};
-
 extern const std::string defaultMMFFTor;
 extern const std::string defaultMMFFsTor;
-
-MMFFTorCollection *MMFFTorCollection::getMMFFTor(const bool isMMFFs,
-                                                 const std::string &mmffTor) {
-  unsigned int i = (isMMFFs ? 1 : 0);
-  if (!ds_instance[i] || !mmffTor.empty()) {
-    ds_instance[i] = std::unique_ptr<MMFFTorCollection>(new MMFFTorCollection(isMMFFs, mmffTor));
-  }
-  return ds_instance[i].get();
-}
 
 MMFFTorCollection::MMFFTorCollection(const bool isMMFFs, std::string mmffTor) {
   if (mmffTor.empty()) {
@@ -8387,16 +8244,7 @@ const std::string defaultMMFFsTor =
     "0	0	80	81	0	0.000	4.000	0.000	C94	"
     "0:*-80-81-*	Def\n";
 
-class std::unique_ptr<MMFFVdWCollection> MMFFVdWCollection::ds_instance = nullptr;
-
 extern const std::string defaultMMFFVdW;
-
-MMFFVdWCollection *MMFFVdWCollection::getMMFFVdW(const std::string &mmffVdW) {
-  if (!ds_instance || !mmffVdW.empty()) {
-    ds_instance.reset(new MMFFVdWCollection(mmffVdW));
-  }
-  return ds_instance.get();
-}
 
 MMFFVdWCollection::MMFFVdWCollection(std::string mmffVdW) {
   if (mmffVdW.empty()) {

--- a/Code/ForceField/MMFF/Params.h
+++ b/Code/ForceField/MMFF/Params.h
@@ -157,26 +157,6 @@ class RDKIT_FORCEFIELD_EXPORT MMFFVdWRijstarEps {
 
 class RDKIT_FORCEFIELD_EXPORT MMFFAromCollection {
  public:
-  //! gets a pointer to the singleton MMFFAromCollection
-  /*!
-    \param mmffArom (optional) a string with parameter data. See
-     below for more information about this argument
-
-    \return a pointer to the singleton MMFFAromCollection
-
-    <b>Notes:</b>
-      - do <b>not</b> delete the pointer returned here
-      - if the singleton MMFFAromCollection has already been instantiated and
-        \c mmffArom is empty, the singleton will be returned.
-      - if \c mmffArom is empty and the singleton MMFFAromCollection has
-        not yet been instantiated, the default MMFFArom parameters (from
-    Params.cpp)
-        will be used.
-      - if \c mmffArom is supplied, a new singleton will be instantiated.
-        The current instantiation (if there is one) will be deleted.
-  */
-  static MMFFAromCollection *getMMFFArom(
-      const std::uint8_t *aromatic_types = NULL);
   //! Looks up the parameters for a particular key and returns them.
   /*!
     \return a pointer to the MMFFArom object, NULL on failure.
@@ -188,35 +168,12 @@ class RDKIT_FORCEFIELD_EXPORT MMFFAromCollection {
                 : false);
   }
 
- private:
-  //! to force this to be a singleton, the constructor must be private
-  MMFFAromCollection(const std::uint8_t mmffArom[]);
-  static class std::unique_ptr<MMFFAromCollection>
-      ds_instance;                     //!< the singleton
+  MMFFAromCollection(const std::uint8_t mmffArom[]=nullptr);
   std::vector<std::uint8_t> d_params;  //!< the aromatic type vector
 };
 
 class RDKIT_FORCEFIELD_EXPORT MMFFDefCollection {
  public:
-  //! gets a pointer to the singleton MMFFDefCollection
-  /*!
-    \param mmffDef (optional) a string with parameter data. See
-     below for more information about this argument
-
-    \return a pointer to the singleton MMFFDefCollection
-
-    <b>Notes:</b>
-      - do <b>not</b> delete the pointer returned here
-      - if the singleton MMFFDefCollection has already been instantiated and
-        \c mmffDef is empty, the singleton will be returned.
-      - if \c mmffDef is empty and the singleton MMFFDefCollection has
-        not yet been instantiated, the default MMFFDef parameters (from
-    Params.cpp)
-        will be used.
-      - if \c mmffDef is supplied, a new singleton will be instantiated.
-        The current instantiation (if there is one) will be deleted.
-  */
-  static MMFFDefCollection *getMMFFDef(const std::string &mmffDef = "");
   //! Looks up the parameters for a particular key and returns them.
   /*!
     \return a pointer to the MMFFDef object, NULL on failure.
@@ -234,11 +191,8 @@ class RDKIT_FORCEFIELD_EXPORT MMFFDefCollection {
 #endif
   }
 
- private:
-  //! to force this to be a singleton, the constructor must be private
-  MMFFDefCollection(std::string mmffDef);
-  static class std::unique_ptr<MMFFDefCollection>
-      ds_instance;  //!< the singleton
+  MMFFDefCollection(std::string mmffDef="");
+
 #ifdef RDKIT_MMFF_PARAMS_USE_STD_MAP
   std::map<const unsigned int, MMFFDef> d_params;  //!< the parameter map
 #else
@@ -248,24 +202,6 @@ class RDKIT_FORCEFIELD_EXPORT MMFFDefCollection {
 
 class RDKIT_FORCEFIELD_EXPORT MMFFPropCollection {
  public:
-  //! gets a pointer to the singleton MMFFPropCollection
-  /*!
-    \param mmffProp (optional) a string with parameter data. See
-     below for more information about this argument
-
-    \return a pointer to the singleton MMFFPropCollection
-
-    <b>Notes:</b>
-      - do <b>not</b> delete the pointer returned here
-      - if the singleton MMFFPropCollection has already been instantiated and
-        \c mmffProp is empty, the singleton will be returned.
-      - if \c mmffProp is empty and the singleton MMFFPropCollection has
-        not yet been instantiated, the default parameters (from Params.cpp)
-        will be used.
-      - if \c mmffProp is supplied, a new singleton will be instantiated.
-        The current instantiation (if there is one) will be deleted.
-  */
-  static MMFFPropCollection *getMMFFProp(const std::string &mmffProp = "");
   //! Looks up the parameters for a particular key and returns them.
   /*!
     \return a pointer to the MMFFProp object, NULL on failure.
@@ -288,11 +224,7 @@ class RDKIT_FORCEFIELD_EXPORT MMFFPropCollection {
 #endif
   }
 
- private:
-  //! to force this to be a singleton, the constructor must be private
-  MMFFPropCollection(std::string mmffProp);
-  static class std::unique_ptr<MMFFPropCollection>
-      ds_instance;  //!< the singleton
+  MMFFPropCollection(std::string mmffProp="");
 #ifdef RDKIT_MMFF_PARAMS_USE_STD_MAP
   std::map<const unsigned int, MMFFProp> d_params;  //!< the parameter map
 #else
@@ -303,24 +235,6 @@ class RDKIT_FORCEFIELD_EXPORT MMFFPropCollection {
 
 class RDKIT_FORCEFIELD_EXPORT MMFFPBCICollection {
  public:
-  //! gets a pointer to the singleton MMFFPBCICollection
-  /*!
-    \param mmffPBCI (optional) a string with parameter data. See
-     below for more information about this argument
-
-    \return a pointer to the singleton MMFFPBCICollection
-
-    <b>Notes:</b>
-      - do <b>not</b> delete the pointer returned here
-      - if the singleton MMFFPBCICollection has already been instantiated and
-        \c mmffPBCI is empty, the singleton will be returned.
-      - if \c mmffPBCI is empty and the singleton MMFFPBCICollection has
-        not yet been instantiated, the default parameters (from Params.cpp)
-        will be used.
-      - if \c mmffPBCI is supplied, a new singleton will be instantiated.
-        The current instantiation (if there is one) will be deleted.
-  */
-  static MMFFPBCICollection *getMMFFPBCI(const std::string &mmffPBCI = "");
   //! Looks up the parameters for a particular key and returns them.
   /*!
     \return a pointer to the MMFFPBCI object, NULL on failure.
@@ -338,11 +252,8 @@ class RDKIT_FORCEFIELD_EXPORT MMFFPBCICollection {
 #endif
   }
 
- private:
-  //! to force this to be a singleton, the constructor must be private
-  MMFFPBCICollection(std::string mmffPBCI);
-  static class std::unique_ptr<MMFFPBCICollection>
-      ds_instance;  //!< the singleton
+  MMFFPBCICollection(std::string mmffPBCI="");
+
 #ifdef RDKIT_MMFF_PARAMS_USE_STD_MAP
   std::map<const unsigned int, MMFFPBCI> d_params;  //!< the parameter map
 #else
@@ -352,31 +263,13 @@ class RDKIT_FORCEFIELD_EXPORT MMFFPBCICollection {
 
 class RDKIT_FORCEFIELD_EXPORT MMFFChgCollection {
  public:
-  //! gets a pointer to the singleton MMFFChgCollection
-  /*!
-    \param mmffChg (optional) a string with parameter data. See
-     below for more information about this argument
-
-    \return a pointer to the singleton MMFFChgCollection
-
-    <b>Notes:</b>
-      - do <b>not</b> delete the pointer returned here
-      - if the singleton MMFFChgCollection has already been instantiated and
-        \c mmffChg is empty, the singleton will be returned.
-      - if \c mmffChg is empty and the singleton MMFFChgCollection has
-        not yet been instantiated, the default parameters (from Params.cpp)
-        will be used.
-      - if \c mmffChg is supplied, a new singleton will be instantiated.
-        The current instantiation (if there is one) will be deleted.
-  */
-  static MMFFChgCollection *getMMFFChg(const std::string &mmffChg = "");
   //! Looks up the parameters for a particular key and returns them.
   /*!
     \return a pointer to the MMFFChg object, NULL on failure.
   */
   const std::pair<int, const MMFFChg *> getMMFFChgParams(
       const unsigned int bondType, const unsigned int iAtomType,
-      const unsigned int jAtomType) {
+      const unsigned int jAtomType) const {
     int sign = -1;
     const MMFFChg *mmffChgParams = NULL;
     unsigned int canIAtomType = iAtomType;
@@ -424,11 +317,8 @@ class RDKIT_FORCEFIELD_EXPORT MMFFChgCollection {
     return std::make_pair(sign, mmffChgParams);
   }
 
- private:
-  //! to force this to be a singleton, the constructor must be private
-  MMFFChgCollection(std::string mmffChg);
-  static class std::unique_ptr<MMFFChgCollection>
-      ds_instance;  //!< the singleton
+  MMFFChgCollection(std::string mmffChg="");
+
 //!< the parameter 3D-map
 #ifdef RDKIT_MMFF_PARAMS_USE_STD_MAP
   std::map<const unsigned int,
@@ -444,31 +334,13 @@ class RDKIT_FORCEFIELD_EXPORT MMFFChgCollection {
 
 class RDKIT_FORCEFIELD_EXPORT MMFFBondCollection {
  public:
-  //! gets a pointer to the singleton MMFFBondCollection
-  /*!
-    \param mmffBond (optional) a string with parameter data. See
-     below for more information about this argument
-
-    \return a pointer to the singleton MMFFBondCollection
-
-    <b>Notes:</b>
-      - do <b>not</b> delete the pointer returned here
-      - if the singleton MMFFBondCollection has already been instantiated and
-        \c mmffBond is empty, the singleton will be returned.
-      - if \c mmffBond is empty and the singleton MMFFBondCollection has
-        not yet been instantiated, the default parameters (from Params.cpp)
-        will be used.
-      - if \c mmffBond is supplied, a new singleton will be instantiated.
-        The current instantiation (if there is one) will be deleted.
-  */
-  static MMFFBondCollection *getMMFFBond(const std::string &mmffBond = "");
   //! Looks up the parameters for a particular key and returns them.
   /*!
     \return a pointer to the MMFFBond object, NULL on failure.
   */
   const MMFFBond *operator()(const unsigned int bondType,
                              const unsigned int atomType,
-                             const unsigned int nbrAtomType) {
+                             const unsigned int nbrAtomType) const {
     const MMFFBond *mmffBondParams = NULL;
     unsigned int canAtomType = atomType;
     unsigned int canNbrAtomType = nbrAtomType;
@@ -520,11 +392,7 @@ class RDKIT_FORCEFIELD_EXPORT MMFFBondCollection {
     return mmffBondParams;
   }
 
- private:
-  //! to force this to be a singleton, the constructor must be private
-  MMFFBondCollection(std::string mmffBond);
-  static class std::unique_ptr<MMFFBondCollection>
-      ds_instance;  //!< the singleton
+  MMFFBondCollection(std::string mmffBond="");
 #ifdef RDKIT_MMFF_PARAMS_USE_STD_MAP
   std::map<const unsigned int,
            std::map<const unsigned int, std::map<const unsigned int, MMFFBond>>>
@@ -539,29 +407,11 @@ class RDKIT_FORCEFIELD_EXPORT MMFFBondCollection {
 
 class RDKIT_FORCEFIELD_EXPORT MMFFBndkCollection {
  public:
-  //! gets a pointer to the singleton MMFFBndkCollection
-  /*!
-    \param mmffBndk (optional) a string with parameter data. See
-     below for more information about this argument
-
-    \return a pointer to the singleton MMFFBndkCollection
-
-    <b>Notes:</b>
-      - do <b>not</b> delete the pointer returned here
-      - if the singleton MMFFBndkCollection has already been instantiated and
-        \c mmffBndk is empty, the singleton will be returned.
-      - if \c mmffBndk is empty and the singleton MMFFBndkCollection has
-        not yet been instantiated, the default parameters (from Params.cpp)
-        will be used.
-      - if \c mmffBndk is supplied, a new singleton will be instantiated.
-        The current instantiation (if there is one) will be deleted.
-  */
-  static MMFFBndkCollection *getMMFFBndk(const std::string &mmffBndk = "");
   //! Looks up the parameters for a particular key and returns them.
   /*!
     \return a pointer to the MMFFBndk object, NULL on failure.
   */
-  const MMFFBond *operator()(const int atomicNum, const int nbrAtomicNum) {
+  const MMFFBond *operator()(const int atomicNum, const int nbrAtomicNum) const {
     const MMFFBond *mmffBndkParams = NULL;
     unsigned int canAtomicNum = atomicNum;
     unsigned int canNbrAtomicNum = nbrAtomicNum;
@@ -600,11 +450,7 @@ class RDKIT_FORCEFIELD_EXPORT MMFFBndkCollection {
     return mmffBndkParams;
   }
 
- private:
-  //! to force this to be a singleton, the constructor must be private
-  MMFFBndkCollection(std::string mmffBndk);
-  static class std::unique_ptr<MMFFBndkCollection>
-      ds_instance;  //!< the singleton
+  MMFFBndkCollection(std::string mmffBndk="");
 #ifdef RDKIT_MMFF_PARAMS_USE_STD_MAP
   std::map<const unsigned int, std::map<const unsigned int, MMFFBond>>
       d_params;  //!< the parameter 2D-map
@@ -617,33 +463,11 @@ class RDKIT_FORCEFIELD_EXPORT MMFFBndkCollection {
 
 class RDKIT_FORCEFIELD_EXPORT MMFFHerschbachLaurieCollection {
  public:
-  //! gets a pointer to the singleton MMFFHerschbachLaurieCollection
-  /*!
-    \param mmffHerschbachLaurie (optional) a string with parameter data. See
-     below for more information about this argument
-
-    \return a pointer to the singleton MMFFHerschbachLaurieCollection
-
-    <b>Notes:</b>
-      - do <b>not</b> delete the pointer returned here
-      - if the singleton MMFFHerschbachLaurieCollection has already been
-    instantiated and
-        \c mmffHerschbachLaurie is empty, the singleton will be returned.
-      - if \c mmffHerschbachLaurie is empty and the singleton
-    MMFFHerschbachLaurieCollection has
-        not yet been instantiated, the default parameters (from Params.cpp)
-        will be used.
-      - if \c mmffHerschbachLaurie is supplied, a new singleton will be
-    instantiated.
-        The current instantiation (if there is one) will be deleted.
-  */
-  static MMFFHerschbachLaurieCollection *getMMFFHerschbachLaurie(
-      const std::string &mmffHerschbachLaurie = "");
   //! Looks up the parameters for a particular key and returns them.
   /*!
     \return a pointer to the MMFFHerschbachLaurie object, NULL on failure.
   */
-  const MMFFHerschbachLaurie *operator()(const int iRow, const int jRow) {
+  const MMFFHerschbachLaurie *operator()(const int iRow, const int jRow) const {
     const MMFFHerschbachLaurie *mmffHerschbachLaurieParams = NULL;
     unsigned int canIRow = iRow;
     unsigned int canJRow = jRow;
@@ -681,11 +505,8 @@ class RDKIT_FORCEFIELD_EXPORT MMFFHerschbachLaurieCollection {
     return mmffHerschbachLaurieParams;
   }
 
- private:
-  //! to force this to be a singleton, the constructor must be private
-  MMFFHerschbachLaurieCollection(std::string mmffHerschbachLaurie);
-  static class std::unique_ptr<MMFFHerschbachLaurieCollection>
-      ds_instance;  //!< the singleton
+  MMFFHerschbachLaurieCollection(std::string mmffHerschbachLaurie="");
+
 #ifdef RDKIT_MMFF_PARAMS_USE_STD_MAP
   std::map<const unsigned int,
            std::map<const unsigned int, MMFFHerschbachLaurie>>
@@ -699,28 +520,6 @@ class RDKIT_FORCEFIELD_EXPORT MMFFHerschbachLaurieCollection {
 
 class RDKIT_FORCEFIELD_EXPORT MMFFCovRadPauEleCollection {
  public:
-  //! gets a pointer to the singleton MMFFCovRadPauEleCollection
-  /*!
-    \param mmffCovRadPauEle (optional) a string with parameter data. See
-     below for more information about this argument
-
-    \return a pointer to the singleton MMFFCovRadPauEleCollection
-
-    <b>Notes:</b>
-      - do <b>not</b> delete the pointer returned here
-      - if the singleton MMFFCovRadPauEleCollection has already been
-    instantiated and
-        \c mmffCovRadPauEle is empty, the singleton will be returned.
-      - if \c mmffCovRadPauEle is empty and the singleton
-    MMFFCovRadPauEleCollection has
-        not yet been instantiated, the default parameters (from Params.cpp)
-        will be used.
-      - if \c mmffCovRadPauEle is supplied, a new singleton will be
-    instantiated.
-        The current instantiation (if there is one) will be deleted.
-  */
-  static MMFFCovRadPauEleCollection *getMMFFCovRadPauEle(
-      const std::string &mmffCovRadPauEle = "");
   //! Looks up the parameters for a particular key and returns them.
   /*!
     \return a pointer to the MMFFCovRadPauEle object, NULL on failure.
@@ -743,11 +542,7 @@ class RDKIT_FORCEFIELD_EXPORT MMFFCovRadPauEleCollection {
 #endif
   }
 
- private:
-  //! to force this to be a singleton, the constructor must be private
-  MMFFCovRadPauEleCollection(std::string mmffCovRadPauEle);
-  static class std::unique_ptr<MMFFCovRadPauEleCollection>
-      ds_instance;  //!< the singleton
+  MMFFCovRadPauEleCollection(std::string mmffCovRadPauEle="");
 #ifdef RDKIT_MMFF_PARAMS_USE_STD_MAP
   std::map<const unsigned int, MMFFCovRadPauEle>
       d_params;  //!< the parameter map
@@ -759,36 +554,18 @@ class RDKIT_FORCEFIELD_EXPORT MMFFCovRadPauEleCollection {
 
 class RDKIT_FORCEFIELD_EXPORT MMFFAngleCollection {
  public:
-  //! gets a pointer to the singleton MMFFAngleCollection
-  /*!
-    \param mmffAngle (optional) a string with parameter data. See
-     below for more information about this argument
-
-    \return a pointer to the singleton MMFFAngleCollection
-
-    <b>Notes:</b>
-      - do <b>not</b> delete the pointer returned here
-      - if the singleton MMFFAngleCollection has already been instantiated and
-        \c mmffAngle is empty, the singleton will be returned.
-      - if \c mmffAngle is empty and the singleton MMFFAngleCollection has
-        not yet been instantiated, the default parameters (from Params.cpp)
-        will be used.
-      - if \c mmffAngle is supplied, a new singleton will be instantiated.
-        The current instantiation (if there is one) will be deleted.
-  */
-  static MMFFAngleCollection *getMMFFAngle(const std::string &mmffAngle = "");
   //! Looks up the parameters for a particular key and returns them.
   /*!
     \return a pointer to the MMFFAngle object, NULL on failure.
   */
-  const MMFFAngle *operator()(const unsigned int angleType,
+  const MMFFAngle *operator()(const MMFFDefCollection *mmffDef,
+			      const unsigned int angleType,
                               const unsigned int iAtomType,
                               const unsigned int jAtomType,
-                              const unsigned int kAtomType) {
-    MMFFDefCollection *mmffDef = MMFFDefCollection::getMMFFDef();
+                              const unsigned int kAtomType) const {
     const MMFFAngle *mmffAngleParams = NULL;
     unsigned int iter = 0;
-
+ 
 // For bending of the i-j-k angle, a five-stage process based
 // in the level combinations 1-1-1,2-2-2,3-2-3,4-2-4, and
 // 5-2-5 is used. (MMFF.I, note 68, page 519)
@@ -873,11 +650,7 @@ class RDKIT_FORCEFIELD_EXPORT MMFFAngleCollection {
     return mmffAngleParams;
   }
 
- private:
-  //! to force this to be a singleton, the constructor must be private
-  MMFFAngleCollection(std::string mmffAngle);
-  static class std::unique_ptr<MMFFAngleCollection>
-      ds_instance;  //!< the singleton
+  MMFFAngleCollection(std::string mmffAngle="");
 #ifdef RDKIT_MMFF_PARAMS_USE_STD_MAP
   std::map<const unsigned int,
            std::map<const unsigned int,
@@ -895,24 +668,6 @@ class RDKIT_FORCEFIELD_EXPORT MMFFAngleCollection {
 
 class RDKIT_FORCEFIELD_EXPORT MMFFStbnCollection {
  public:
-  //! gets a pointer to the singleton MMFFStbnCollection
-  /*!
-    \param mmffStbn (optional) a string with parameter data. See
-     below for more information about this argument
-
-    \return a pointer to the singleton MMFFStbnCollection
-
-    <b>Notes:</b>
-      - do <b>not</b> delete the pointer returned here
-      - if the singleton MMFFStbnCollection has already been instantiated and
-        \c mmffStbn is empty, the singleton will be returned.
-      - if \c mmffStbn is empty and the singleton MMFFStbnCollection has
-        not yet been instantiated, the default parameters (from Params.cpp)
-        will be used.
-      - if \c mmffStbn is supplied, a new singleton will be instantiated.
-        The current instantiation (if there is one) will be deleted.
-  */
-  static MMFFStbnCollection *getMMFFStbn(const std::string &mmffStbn = "");
   //! Looks up the parameters for a particular key and returns them.
   /*!
     \return a pointer to the MMFFStbn object, NULL on failure.
@@ -920,7 +675,7 @@ class RDKIT_FORCEFIELD_EXPORT MMFFStbnCollection {
   const std::pair<bool, const MMFFStbn *> getMMFFStbnParams(
       const unsigned int stretchBendType, const unsigned int bondType1,
       const unsigned int bondType2, const unsigned int iAtomType,
-      const unsigned int jAtomType, const unsigned int kAtomType) {
+      const unsigned int jAtomType, const unsigned int kAtomType) const {
     const MMFFStbn *mmffStbnParams = NULL;
     bool swap = false;
     unsigned int canIAtomType = iAtomType;
@@ -994,11 +749,7 @@ class RDKIT_FORCEFIELD_EXPORT MMFFStbnCollection {
     return std::make_pair(swap, mmffStbnParams);
   }
 
- private:
-  //! to force this to be a singleton, the constructor must be private
-  MMFFStbnCollection(std::string mmffStbn);
-  static class std::unique_ptr<MMFFStbnCollection>
-      ds_instance;  //!< the singleton
+  MMFFStbnCollection(std::string mmffStbn="");
 #ifdef RDKIT_MMFF_PARAMS_USE_STD_MAP
   std::map<const unsigned int,
            std::map<const unsigned int,
@@ -1017,24 +768,6 @@ class RDKIT_FORCEFIELD_EXPORT MMFFStbnCollection {
 
 class RDKIT_FORCEFIELD_EXPORT MMFFDfsbCollection {
  public:
-  //! gets a pointer to the singleton MMFFDfsbCollection
-  /*!
-    \param mmffDfsb (optional) a string with parameter data. See
-     below for more information about this argument
-
-    \return a pointer to the singleton MMFFDfsbCollection
-
-    <b>Notes:</b>
-      - do <b>not</b> delete the pointer returned here
-      - if the singleton MMFFDfsbCollection has already been instantiated and
-        \c mmffDfsb is empty, the singleton will be returned.
-      - if \c mmffDfsb is empty and the singleton MMFFDfsbCollection has
-        not yet been instantiated, the default parameters (from Params.cpp)
-        will be used.
-      - if \c mmffDfsb is supplied, a new singleton will be instantiated.
-        The current instantiation (if there is one) will be deleted.
-  */
-  static MMFFDfsbCollection *getMMFFDfsb(const std::string &mmffDfsb = "");
   //! Looks up the parameters for a particular key and returns them.
   /*!
     \return a pointer to the MMFFStbn object, NULL on failure.
@@ -1042,7 +775,7 @@ class RDKIT_FORCEFIELD_EXPORT MMFFDfsbCollection {
   const std::pair<bool, const MMFFStbn *> getMMFFDfsbParams(
       const unsigned int periodicTableRow1,
       const unsigned int periodicTableRow2,
-      const unsigned int periodicTableRow3) {
+      const unsigned int periodicTableRow3) const {
     std::map<const unsigned int,
              std::map<const unsigned int,
                       std::map<const unsigned int, MMFFStbn>>>::const_iterator
@@ -1073,11 +806,7 @@ class RDKIT_FORCEFIELD_EXPORT MMFFDfsbCollection {
     return std::make_pair(swap, mmffDfsbParams);
   }
 
- private:
-  //! to force this to be a singleton, the constructor must be private
-  MMFFDfsbCollection(std::string mmffDfsb);
-  static class std::unique_ptr<MMFFDfsbCollection>
-      ds_instance;  //!< the singleton
+  MMFFDfsbCollection(std::string mmffDfsb="");
   std::map<const unsigned int,
            std::map<const unsigned int, std::map<const unsigned int, MMFFStbn>>>
       d_params;  //!< the parameter 3D-map
@@ -1085,34 +814,15 @@ class RDKIT_FORCEFIELD_EXPORT MMFFDfsbCollection {
 
 class RDKIT_FORCEFIELD_EXPORT MMFFOopCollection {
  public:
-  //! gets a pointer to the singleton MMFFOopCollection
-  /*!
-    \param mmffOop (optional) a string with parameter data. See
-     below for more information about this argument
-
-    \return a pointer to the singleton MMFFOopCollection
-
-    <b>Notes:</b>
-      - do <b>not</b> delete the pointer returned here
-      - if the singleton MMFFOopCollection has already been instantiated and
-        \c mmffOop is empty, the singleton will be returned.
-      - if \c mmffOop is empty and the singleton MMFFOopCollection has
-        not yet been instantiated, the default parameters (from Params.cpp)
-        will be used.
-      - if \c mmffOop is supplied, a new singleton will be instantiated.
-        The current instantiation (if there is one) will be deleted.
-  */
-  static MMFFOopCollection *getMMFFOop(const bool isMMFFs = false,
-                                       const std::string &mmffOop = "");
   //! Looks up the parameters for a particular key and returns them.
   /*!
     \return a pointer to the MMFFOop object, NULL on failure.
   */
-  const MMFFOop *operator()(const unsigned int iAtomType,
+  const MMFFOop *operator()(const MMFFDefCollection *mmffDef,
+			    const unsigned int iAtomType,
                             const unsigned int jAtomType,
                             const unsigned int kAtomType,
-                            const unsigned int lAtomType) {
-    MMFFDefCollection *mmffDef = MMFFDefCollection::getMMFFDef();
+                            const unsigned int lAtomType) const {
     const MMFFOop *mmffOopParams = NULL;
     unsigned int iter = 0;
     std::vector<unsigned int> canIKLAtomType(3);
@@ -1195,11 +905,8 @@ class RDKIT_FORCEFIELD_EXPORT MMFFOopCollection {
     return mmffOopParams;
   }
 
- private:
-  //! to force this to be a singleton, the constructor must be private
-  MMFFOopCollection(const bool isMMFFs, std::string mmffOop);
-  static class std::unique_ptr<MMFFOopCollection>
-      ds_instance[2];  //!< the singleton
+  MMFFOopCollection(const bool isMMFFs, std::string mmffOop="");
+
 #ifdef RDKIT_MMFF_PARAMS_USE_STD_MAP
   std::map<const unsigned int,
            std::map<const unsigned int,
@@ -1217,34 +924,15 @@ class RDKIT_FORCEFIELD_EXPORT MMFFOopCollection {
 
 class RDKIT_FORCEFIELD_EXPORT MMFFTorCollection {
  public:
-  //! gets a pointer to the singleton MMFFTorCollection
-  /*!
-    \param mmffTor (optional) a string with parameter data. See
-     below for more information about this argument
-
-    \return a pointer to the singleton MMFFTorCollection
-
-    <b>Notes:</b>
-      - do <b>not</b> delete the pointer returned here
-      - if the singleton MMFFTorCollection has already been instantiated and
-        \c mmffTor is empty, the singleton will be returned.
-      - if \c mmffTor is empty and the singleton MMFFTorCollection has
-        not yet been instantiated, the default parameters (from Params.cpp)
-        will be used.
-      - if \c mmffTor is supplied, a new singleton will be instantiated.
-        The current instantiation (if there is one) will be deleted.
-  */
-  static MMFFTorCollection *getMMFFTor(const bool isMMFFs,
-                                       const std::string &mmffTor = "");
   //! Looks up the parameters for a particular key and returns them.
   /*!
     \return a pointer to the MMFFTor object, NULL on failure.
   */
   const std::pair<const unsigned int, const MMFFTor *> getMMFFTorParams(
+      const MMFFDefCollection *mmffDef,									
       const std::pair<unsigned int, unsigned int> torType,
       const unsigned int iAtomType, const unsigned int jAtomType,
-      const unsigned int kAtomType, const unsigned int lAtomType) {
-    MMFFDefCollection *mmffDef = MMFFDefCollection::getMMFFDef();
+      const unsigned int kAtomType, const unsigned int lAtomType) const {
     const MMFFTor *mmffTorParams = NULL;
     unsigned int iter = 0;
     unsigned int iWildCard = 0;
@@ -1382,11 +1070,7 @@ class RDKIT_FORCEFIELD_EXPORT MMFFTorCollection {
     return std::make_pair(canTorType, mmffTorParams);
   }
 
- private:
-  //! to force this to be a singleton, the constructor must be private
-  MMFFTorCollection(const bool isMMFFs, std::string mmffTor);
-  static class std::unique_ptr<MMFFTorCollection>
-      ds_instance[2];  //!< the singleton
+  MMFFTorCollection(const bool isMMFFs, std::string mmffTor="");
 #ifdef RDKIT_MMFF_PARAMS_USE_STD_MAP
   std::map<
       const unsigned int,
@@ -1410,28 +1094,11 @@ class RDKIT_FORCEFIELD_EXPORT MMFFTorCollection {
 class RDKIT_FORCEFIELD_EXPORT MMFFVdWCollection {
  public:
   //! gets a pointer to the singleton MMFFVdWCollection
-  /*!
-    \param mmffVdW (optional) a string with parameter data. See
-     below for more information about this argument
-
-    \return a pointer to the singleton MMFFVdWCollection
-
-    <b>Notes:</b>
-      - do <b>not</b> delete the pointer returned here
-      - if the singleton MMFFVdWCollection has already been instantiated and
-        \c mmffVdW is empty, the singleton will be returned.
-      - if \c mmffVdW is empty and the singleton MMFFVdWCollection has
-        not yet been instantiated, the default parameters (from Params.cpp)
-        will be used.
-      - if \c mmffVdW is supplied, a new singleton will be instantiated.
-        The current instantiation (if there is one) will be deleted.
-  */
   double power;
   double B;
   double Beta;
   double DARAD;
   double DAEPS;
-  static MMFFVdWCollection *getMMFFVdW(const std::string &mmffVdW = "");
   //! Looks up the parameters for a particular key and returns them.
   /*!
     \return a pointer to the MMFFVdW object, NULL on failure.
@@ -1454,11 +1121,7 @@ class RDKIT_FORCEFIELD_EXPORT MMFFVdWCollection {
 #endif
   }
 
- private:
-  //! to force this to be a singleton, the constructor must be private
-  MMFFVdWCollection(std::string mmffVdW);
-  static class std::unique_ptr<MMFFVdWCollection>
-      ds_instance;  //!< the singleton
+  MMFFVdWCollection(std::string mmffVdW="");
 #ifdef RDKIT_MMFF_PARAMS_USE_STD_MAP
   std::map<const unsigned int, MMFFVdW> d_params;  //!< the parameter map
 #else

--- a/Code/GraphMol/ForceFieldHelpers/MMFF/AtomTyper.cpp
+++ b/Code/GraphMol/ForceFieldHelpers/MMFF/AtomTyper.cpp
@@ -26,83 +26,82 @@ namespace MMFF {
 using namespace ForceFields::MMFF;
 namespace DefaultParameters {
 
-MMFFPropCollection *getMMFFProp() {
-  static MMFFPropCollection *ds_instance(MMFFPropCollection::getMMFFProp());  
-  return ds_instance;
+const MMFFPropCollection *getMMFFProp() {
+  static MMFFPropCollection ds_instance("");
+  return &ds_instance;
 }
 
-MMFFAromCollection *getMMFFArom() {
-  static MMFFAromCollection *ds_instance(MMFFAromCollection::getMMFFArom());  
-  return ds_instance;
+const MMFFAromCollection *getMMFFArom() {
+  static MMFFAromCollection ds_instance;
+  return &ds_instance;
 }
 
-MMFFBndkCollection *getMMFFBndk() {
-  static MMFFBndkCollection *ds_instance(MMFFBndkCollection::getMMFFBndk());  
-  return ds_instance;
+const MMFFBndkCollection *getMMFFBndk() {
+  static MMFFBndkCollection ds_instance;
+  return &ds_instance;
 }
 
-MMFFBondCollection *getMMFFBond() {
-  static MMFFBondCollection *ds_instance(MMFFBondCollection::getMMFFBond());  
-  return ds_instance;
+const MMFFBondCollection *getMMFFBond() {
+  static MMFFBondCollection ds_instance;
+  return &ds_instance;
 }
   
-MMFFChgCollection *getMMFFChg() {
-  static MMFFChgCollection *ds_instance(MMFFChgCollection::getMMFFChg());
-  return ds_instance;
+const MMFFChgCollection *getMMFFChg() {
+  static MMFFChgCollection ds_instance;
+  return &ds_instance;
 }
   
-MMFFDefCollection *getMMFFDef() {
-  static MMFFDefCollection *ds_instance(MMFFDefCollection::getMMFFDef());
-  return ds_instance;
+const MMFFDefCollection *getMMFFDef() {
+  static MMFFDefCollection ds_instance;
+  return &ds_instance;
 }
 
-MMFFHerschbachLaurieCollection * getMMFFHerschbachLaurie() {
-  static MMFFHerschbachLaurieCollection *ds_instance(
-	     MMFFHerschbachLaurieCollection::getMMFFHerschbachLaurie());
-  return ds_instance;
+const MMFFHerschbachLaurieCollection * getMMFFHerschbachLaurie() {
+  static MMFFHerschbachLaurieCollection ds_instance;
+  return &ds_instance;
 }
 
-MMFFPBCICollection *getMMFFPBCI() {
-  static MMFFPBCICollection *ds_instance(MMFFPBCICollection::getMMFFPBCI());
-  return ds_instance;
+const MMFFPBCICollection *getMMFFPBCI() {
+  static MMFFPBCICollection ds_instance;
+  return &ds_instance;
 }
 
-MMFFAngleCollection *getMMFFAngle() {
-  static MMFFAngleCollection *ds_instance(MMFFAngleCollection::getMMFFAngle());
-  return ds_instance;
+const MMFFAngleCollection *getMMFFAngle() {
+  static MMFFAngleCollection ds_instance;
+  return &ds_instance;
 }
 
   
-MMFFStbnCollection *getMMFFStbn() {
-  static MMFFStbnCollection *ds_instance(MMFFStbnCollection::getMMFFStbn());
-  return ds_instance;
+const MMFFStbnCollection *getMMFFStbn() {
+  static MMFFStbnCollection ds_instance;
+  return &ds_instance;
 }
 
-MMFFDfsbCollection *getMMFFDfsb() {
-  static MMFFDfsbCollection *ds_instance(MMFFDfsbCollection::getMMFFDfsb());
-  return ds_instance;
+const MMFFDfsbCollection *getMMFFDfsb() {
+  static MMFFDfsbCollection ds_instance;
+  return &ds_instance;
 }
 
-MMFFCovRadPauEleCollection *getMMFFCovRadPauEle() {
-  static MMFFCovRadPauEleCollection *ds_instance(MMFFCovRadPauEleCollection::getMMFFCovRadPauEle());
-  return ds_instance;
+const MMFFCovRadPauEleCollection *getMMFFCovRadPauEle() {
+  static MMFFCovRadPauEleCollection ds_instance;
+  return &ds_instance;
 }
 
-MMFFTorCollection *getMMFFTor(const bool isMMFFs) {
-  static MMFFTorCollection *MMFF94(MMFFTorCollection::getMMFFTor(false, ""));
-  static MMFFTorCollection *MMFF94s(MMFFTorCollection::getMMFFTor(true, ""));
-  return (isMMFFs) ? MMFF94s : MMFF94;  
+const MMFFTorCollection *getMMFFTor(const bool isMMFFs) {
+  static MMFFTorCollection MMFF94(false, "");
+  static MMFFTorCollection MMFF94s(true, "");
+  return (isMMFFs) ? &MMFF94s : &MMFF94;  
 }
 
-MMFFOopCollection *getMMFFOop(const bool isMMFFs) {
-  static MMFFOopCollection *MMFF94(MMFFOopCollection::getMMFFOop(false, ""));
-  static MMFFOopCollection *MMFF94s(MMFFOopCollection::getMMFFOop(true, ""));
-  return (isMMFFs) ? MMFF94s : MMFF94;  
+const MMFFOopCollection *getMMFFOop(const bool isMMFFs) {
+  static MMFFOopCollection MMFF94(false, "");
+  static MMFFOopCollection MMFF94s(true, "");
+  return (isMMFFs) ? &MMFF94s : &MMFF94;  
 }
 
-MMFFVdWCollection *getMMFFVdW() {
-  static MMFFVdWCollection *ds_instance(MMFFVdWCollection::getMMFFVdW(""));
-  return ds_instance;
+const MMFFVdWCollection *getMMFFVdW() {
+  static MMFFVdWCollection ds_instance;
+  return &ds_instance;
 }
 
 }
@@ -2736,11 +2735,11 @@ MMFFMolProperties::getMMFFBondStretchEmpiricalRuleParams(const ROMol &mol,
   const MMFFHerschbachLaurie *mmffHerschbachLaurieParams;
   const MMFFProp *mmffAtomPropParams[2];
   const MMFFCovRadPauEle *mmffAtomCovRadPauEleParams[2];
-  MMFFBndkCollection *mmffBndk = DefaultParameters::getMMFFBndk();
-  MMFFHerschbachLaurieCollection *mmffHerschbachLaurie =
-      DefaultParameters::getMMFFHerschbachLaurie();
+  const MMFFBndkCollection *mmffBndk = DefaultParameters::getMMFFBndk();
+  const MMFFHerschbachLaurieCollection *mmffHerschbachLaurie =
+    DefaultParameters::getMMFFHerschbachLaurie();
   const MMFFCovRadPauEleCollection *mmffCovRadPauEle =
-      DefaultParameters::getMMFFCovRadPauEle();
+    DefaultParameters::getMMFFCovRadPauEle();
   const MMFFPropCollection *mmffProp = DefaultParameters::getMMFFProp();
 
   unsigned int atomicNum1 = bond->getBeginAtom()->getAtomicNum();
@@ -3243,7 +3242,7 @@ void MMFFMolProperties::computeMMFFCharges(const ROMol &mol) {
   ROMol::ADJ_ITER end2Nbrs;
   const MMFFPropCollection *mmffProp = DefaultParameters::getMMFFProp();
   const MMFFPBCICollection *mmffPBCI = DefaultParameters::getMMFFPBCI();
-  MMFFChgCollection *mmffChg = DefaultParameters::getMMFFChg();
+  const MMFFChgCollection *mmffChg = DefaultParameters::getMMFFChg();
 
   // We need to set formal charges upfront
   for (idx = 0; idx < mol.getNumAtoms(); ++idx) {
@@ -3645,7 +3644,7 @@ void MMFFMolProperties::computeMMFFCharges(const ROMol &mol) {
 bool MMFFMolProperties::getMMFFBondStretchParams(
     const ROMol &mol, const unsigned int idx1, const unsigned int idx2,
     unsigned int &bondType, MMFFBond &mmffBondStretchParams) {
-  MMFFBondCollection *mmffBond = DefaultParameters::getMMFFBond();
+  const MMFFBondCollection *mmffBond = DefaultParameters::getMMFFBond();
   bool res = false;
   if (isValid()) {
     unsigned int iAtomType = getMMFFAtomType(idx1);
@@ -3681,7 +3680,7 @@ bool MMFFMolProperties::getMMFFAngleBendParams(const ROMol &mol,
   bool res = false;
   if (isValid() && mol.getBondBetweenAtoms(idx1, idx2) &&
       mol.getBondBetweenAtoms(idx2, idx3)) {
-    MMFFAngleCollection *mmffAngle = DefaultParameters::getMMFFAngle();
+    const MMFFAngleCollection *mmffAngle = DefaultParameters::getMMFFAngle();
     const MMFFPropCollection *mmffProp = DefaultParameters::getMMFFProp();
     unsigned int idx[3] = {idx1, idx2, idx3};
     MMFFBond mmffBondParams[2];
@@ -3693,7 +3692,7 @@ bool MMFFMolProperties::getMMFFAngleBendParams(const ROMol &mol,
       atomType[i] = getMMFFAtomType(idx[i]);
     }
     const MMFFAngle *mmffAngleParams =
-        (*mmffAngle)(angleType, atomType[0], atomType[1], atomType[2]);
+      (*mmffAngle)(DefaultParameters::getMMFFDef(), angleType, atomType[0], atomType[1], atomType[2]);
     const MMFFProp *mmffPropParamsCentralAtom = (*mmffProp)(atomType[1]);
     if ((!mmffAngleParams) || (isDoubleZero(mmffAngleParams->ka))) {
       areMMFFAngleParamsEmpirical = true;
@@ -3727,8 +3726,8 @@ bool MMFFMolProperties::getMMFFStretchBendParams(
   bool res = false;
   if (isValid()) {
     const MMFFPropCollection *mmffProp = DefaultParameters::getMMFFProp();
-    MMFFStbnCollection *mmffStbn = DefaultParameters::getMMFFStbn();
-    MMFFDfsbCollection *mmffDfsb = DefaultParameters::getMMFFDfsb();
+    const MMFFStbnCollection *mmffStbn = DefaultParameters::getMMFFStbn();
+    const MMFFDfsbCollection *mmffDfsb = DefaultParameters::getMMFFDfsb();
     unsigned int idx[3] = {idx1, idx2, idx3};
     unsigned int atomType[3];
     unsigned int bondType[2];
@@ -3790,7 +3789,7 @@ bool MMFFMolProperties::getMMFFTorsionParams(
     unsigned int i;
     unsigned int idx[4] = {idx1, idx2, idx3, idx4};
     unsigned int atomType[4];
-    MMFFTorCollection *mmffTor =
+    const MMFFTorCollection *mmffTor =
         DefaultParameters::getMMFFTor(getMMFFVariant() == "MMFF94s");
     for (i = 0; i < 4; ++i) {
       atomType[i] = getMMFFAtomType(idx[i]);
@@ -3799,8 +3798,9 @@ bool MMFFMolProperties::getMMFFTorsionParams(
         getMMFFTorsionType(mol, idx1, idx2, idx3, idx4);
     bool areMMFFTorParamsEmpirical = false;
     const std::pair<const unsigned int, const MMFFTor *> mmffTorPair =
-        mmffTor->getMMFFTorParams(torTypePair, atomType[0], atomType[1],
-                                  atomType[2], atomType[3]);
+      mmffTor->getMMFFTorParams(DefaultParameters::getMMFFDef(),
+				torTypePair, atomType[0], atomType[1],
+				atomType[2], atomType[3]);
     torsionType = (mmffTorPair.first ? mmffTorPair.first : torTypePair.first);
     const MMFFTor *mmffTorParams = mmffTorPair.second;
     if (!mmffTorParams) {
@@ -3835,13 +3835,14 @@ bool MMFFMolProperties::getMMFFOopBendParams(const ROMol &mol,
     unsigned int idx[4] = {idx1, idx2, idx3, idx4};
     unsigned int atomType[4];
 
-    MMFFOopCollection *mmffOop =
+    const MMFFOopCollection *mmffOop =
         DefaultParameters::getMMFFOop(getMMFFVariant() == "MMFF94s");
     for (i = 0; i < 4; ++i) {
       atomType[i] = getMMFFAtomType(idx[i]);
     }
     const MMFFOop *mmffOopParams =
-        (*mmffOop)(atomType[0], atomType[1], atomType[2], atomType[3]);
+      (*mmffOop)(DefaultParameters::getMMFFDef(),
+		 atomType[0], atomType[1], atomType[2], atomType[3]);
     // if no parameters could be found, we exclude this term (SURDOX02)
     if (mmffOopParams) {
       mmffOopBendParams = *mmffOopParams;
@@ -3856,7 +3857,7 @@ bool MMFFMolProperties::getMMFFVdWParams(const unsigned int idx1,
                                          MMFFVdWRijstarEps &mmffVdWParams) {
   bool res = false;
   if (isValid()) {
-    MMFFVdWCollection *mmffVdW = DefaultParameters::getMMFFVdW();
+    const MMFFVdWCollection *mmffVdW = DefaultParameters::getMMFFVdW();
     const unsigned int iAtomType = getMMFFAtomType(idx1);
     const unsigned int jAtomType = getMMFFAtomType(idx2);
     const MMFFVdW *mmffVdWParamsIAtom = (*mmffVdW)(iAtomType);

--- a/Code/GraphMol/ForceFieldHelpers/MMFF/AtomTyper.cpp
+++ b/Code/GraphMol/ForceFieldHelpers/MMFF/AtomTyper.cpp
@@ -24,7 +24,88 @@
 namespace RDKit {
 namespace MMFF {
 using namespace ForceFields::MMFF;
+namespace DefaultParameters {
 
+MMFFPropCollection *getMMFFProp() {
+  static MMFFPropCollection *ds_instance(MMFFPropCollection::getMMFFProp());  
+  return ds_instance;
+}
+
+MMFFAromCollection *getMMFFArom() {
+  static MMFFAromCollection *ds_instance(MMFFAromCollection::getMMFFArom());  
+  return ds_instance;
+}
+
+MMFFBndkCollection *getMMFFBndk() {
+  static MMFFBndkCollection *ds_instance(MMFFBndkCollection::getMMFFBndk());  
+  return ds_instance;
+}
+
+MMFFBondCollection *getMMFFBond() {
+  static MMFFBondCollection *ds_instance(MMFFBondCollection::getMMFFBond());  
+  return ds_instance;
+}
+  
+MMFFChgCollection *getMMFFChg() {
+  static MMFFChgCollection *ds_instance(MMFFChgCollection::getMMFFChg());
+  return ds_instance;
+}
+  
+MMFFDefCollection *getMMFFDef() {
+  static MMFFDefCollection *ds_instance(MMFFDefCollection::getMMFFDef());
+  return ds_instance;
+}
+
+MMFFHerschbachLaurieCollection * getMMFFHerschbachLaurie() {
+  static MMFFHerschbachLaurieCollection *ds_instance(
+	     MMFFHerschbachLaurieCollection::getMMFFHerschbachLaurie());
+  return ds_instance;
+}
+
+MMFFPBCICollection *getMMFFPBCI() {
+  static MMFFPBCICollection *ds_instance(MMFFPBCICollection::getMMFFPBCI());
+  return ds_instance;
+}
+
+MMFFAngleCollection *getMMFFAngle() {
+  static MMFFAngleCollection *ds_instance(MMFFAngleCollection::getMMFFAngle());
+  return ds_instance;
+}
+
+  
+MMFFStbnCollection *getMMFFStbn() {
+  static MMFFStbnCollection *ds_instance(MMFFStbnCollection::getMMFFStbn());
+  return ds_instance;
+}
+
+MMFFDfsbCollection *getMMFFDfsb() {
+  static MMFFDfsbCollection *ds_instance(MMFFDfsbCollection::getMMFFDfsb());
+  return ds_instance;
+}
+
+MMFFCovRadPauEleCollection *getMMFFCovRadPauEle() {
+  static MMFFCovRadPauEleCollection *ds_instance(MMFFCovRadPauEleCollection::getMMFFCovRadPauEle());
+  return ds_instance;
+}
+
+MMFFTorCollection *getMMFFTor(const bool isMMFFs) {
+  static MMFFTorCollection *MMFF94(MMFFTorCollection::getMMFFTor(false, ""));
+  static MMFFTorCollection *MMFF94s(MMFFTorCollection::getMMFFTor(true, ""));
+  return (isMMFFs) ? MMFF94s : MMFF94;  
+}
+
+MMFFOopCollection *getMMFFOop(const bool isMMFFs) {
+  static MMFFOopCollection *MMFF94(MMFFOopCollection::getMMFFOop(false, ""));
+  static MMFFOopCollection *MMFF94s(MMFFOopCollection::getMMFFOop(true, ""));
+  return (isMMFFs) ? MMFF94s : MMFF94;  
+}
+
+MMFFVdWCollection *getMMFFVdW() {
+  static MMFFVdWCollection *ds_instance(MMFFVdWCollection::getMMFFVdW(""));
+  return ds_instance;
+}
+
+}
 class RingMembership {
  public:
   RingMembership() : d_isInAromaticRing(false) {};
@@ -2530,7 +2611,7 @@ unsigned int MMFFMolProperties::getMMFFBondType(const Bond *bond) {
   PRECONDITION(this->isValid(), "missing atom types - invalid force-field");
   PRECONDITION(bond, "invalid bond");
 
-  MMFFPropCollection *mmffProp = MMFFPropCollection::getMMFFProp();
+  const MMFFPropCollection *mmffProp = DefaultParameters::getMMFFProp();
   const ForceFields::MMFF::MMFFProp *mmffPropAtom1 =
       (*mmffProp)(this->getMMFFAtomType(bond->getBeginAtomIdx()));
   const ForceFields::MMFF::MMFFProp *mmffPropAtom2 =
@@ -2655,12 +2736,12 @@ MMFFMolProperties::getMMFFBondStretchEmpiricalRuleParams(const ROMol &mol,
   const MMFFHerschbachLaurie *mmffHerschbachLaurieParams;
   const MMFFProp *mmffAtomPropParams[2];
   const MMFFCovRadPauEle *mmffAtomCovRadPauEleParams[2];
-  MMFFBndkCollection *mmffBndk = MMFFBndkCollection::getMMFFBndk();
+  MMFFBndkCollection *mmffBndk = DefaultParameters::getMMFFBndk();
   MMFFHerschbachLaurieCollection *mmffHerschbachLaurie =
-      MMFFHerschbachLaurieCollection::getMMFFHerschbachLaurie();
-  MMFFCovRadPauEleCollection *mmffCovRadPauEle =
-      MMFFCovRadPauEleCollection::getMMFFCovRadPauEle();
-  MMFFPropCollection *mmffProp = MMFFPropCollection::getMMFFProp();
+      DefaultParameters::getMMFFHerschbachLaurie();
+  const MMFFCovRadPauEleCollection *mmffCovRadPauEle =
+      DefaultParameters::getMMFFCovRadPauEle();
+  const MMFFPropCollection *mmffProp = DefaultParameters::getMMFFProp();
 
   unsigned int atomicNum1 = bond->getBeginAtom()->getAtomicNum();
   unsigned int atomicNum2 = bond->getEndAtom()->getAtomicNum();
@@ -2955,8 +3036,8 @@ MMFFMolProperties::getMMFFTorsionEmpiricalRuleParams(const ROMol &mol,
                                                      unsigned int idx3) {
   PRECONDITION(this->isValid(), "missing atom types - invalid force-field");
 
-  MMFFPropCollection *mmffProp = MMFFPropCollection::getMMFFProp();
-  MMFFAromCollection *mmffArom = MMFFAromCollection::getMMFFArom();
+  const MMFFPropCollection *mmffProp = DefaultParameters::getMMFFProp();
+  const MMFFAromCollection *mmffArom = DefaultParameters::getMMFFArom();
   auto *mmffTorParams = new ForceFields::MMFF::MMFFTor();
   unsigned int jAtomType = this->getMMFFAtomType(idx2);
   unsigned int kAtomType = this->getMMFFAtomType(idx3);
@@ -3160,9 +3241,9 @@ void MMFFMolProperties::computeMMFFCharges(const ROMol &mol) {
   ROMol::ADJ_ITER endNbrs;
   ROMol::ADJ_ITER nbr2Idx;
   ROMol::ADJ_ITER end2Nbrs;
-  MMFFPropCollection *mmffProp = MMFFPropCollection::getMMFFProp();
-  MMFFPBCICollection *mmffPBCI = MMFFPBCICollection::getMMFFPBCI();
-  MMFFChgCollection *mmffChg = MMFFChgCollection::getMMFFChg();
+  const MMFFPropCollection *mmffProp = DefaultParameters::getMMFFProp();
+  const MMFFPBCICollection *mmffPBCI = DefaultParameters::getMMFFPBCI();
+  MMFFChgCollection *mmffChg = DefaultParameters::getMMFFChg();
 
   // We need to set formal charges upfront
   for (idx = 0; idx < mol.getNumAtoms(); ++idx) {
@@ -3564,7 +3645,7 @@ void MMFFMolProperties::computeMMFFCharges(const ROMol &mol) {
 bool MMFFMolProperties::getMMFFBondStretchParams(
     const ROMol &mol, const unsigned int idx1, const unsigned int idx2,
     unsigned int &bondType, MMFFBond &mmffBondStretchParams) {
-  MMFFBondCollection *mmffBond = MMFFBondCollection::getMMFFBond();
+  MMFFBondCollection *mmffBond = DefaultParameters::getMMFFBond();
   bool res = false;
   if (isValid()) {
     unsigned int iAtomType = getMMFFAtomType(idx1);
@@ -3600,8 +3681,8 @@ bool MMFFMolProperties::getMMFFAngleBendParams(const ROMol &mol,
   bool res = false;
   if (isValid() && mol.getBondBetweenAtoms(idx1, idx2) &&
       mol.getBondBetweenAtoms(idx2, idx3)) {
-    MMFFAngleCollection *mmffAngle = MMFFAngleCollection::getMMFFAngle();
-    MMFFPropCollection *mmffProp = MMFFPropCollection::getMMFFProp();
+    MMFFAngleCollection *mmffAngle = DefaultParameters::getMMFFAngle();
+    const MMFFPropCollection *mmffProp = DefaultParameters::getMMFFProp();
     unsigned int idx[3] = {idx1, idx2, idx3};
     MMFFBond mmffBondParams[2];
     unsigned int atomType[3];
@@ -3645,9 +3726,9 @@ bool MMFFMolProperties::getMMFFStretchBendParams(
     MMFFAngle &mmffAngleBendParams) {
   bool res = false;
   if (isValid()) {
-    MMFFPropCollection *mmffProp = MMFFPropCollection::getMMFFProp();
-    MMFFStbnCollection *mmffStbn = MMFFStbnCollection::getMMFFStbn();
-    MMFFDfsbCollection *mmffDfsb = MMFFDfsbCollection::getMMFFDfsb();
+    const MMFFPropCollection *mmffProp = DefaultParameters::getMMFFProp();
+    MMFFStbnCollection *mmffStbn = DefaultParameters::getMMFFStbn();
+    MMFFDfsbCollection *mmffDfsb = DefaultParameters::getMMFFDfsb();
     unsigned int idx[3] = {idx1, idx2, idx3};
     unsigned int atomType[3];
     unsigned int bondType[2];
@@ -3710,7 +3791,7 @@ bool MMFFMolProperties::getMMFFTorsionParams(
     unsigned int idx[4] = {idx1, idx2, idx3, idx4};
     unsigned int atomType[4];
     MMFFTorCollection *mmffTor =
-        MMFFTorCollection::getMMFFTor(getMMFFVariant() == "MMFF94s");
+        DefaultParameters::getMMFFTor(getMMFFVariant() == "MMFF94s");
     for (i = 0; i < 4; ++i) {
       atomType[i] = getMMFFAtomType(idx[i]);
     }
@@ -3755,7 +3836,7 @@ bool MMFFMolProperties::getMMFFOopBendParams(const ROMol &mol,
     unsigned int atomType[4];
 
     MMFFOopCollection *mmffOop =
-        MMFFOopCollection::getMMFFOop(getMMFFVariant() == "MMFF94s");
+        DefaultParameters::getMMFFOop(getMMFFVariant() == "MMFF94s");
     for (i = 0; i < 4; ++i) {
       atomType[i] = getMMFFAtomType(idx[i]);
     }
@@ -3775,7 +3856,7 @@ bool MMFFMolProperties::getMMFFVdWParams(const unsigned int idx1,
                                          MMFFVdWRijstarEps &mmffVdWParams) {
   bool res = false;
   if (isValid()) {
-    MMFFVdWCollection *mmffVdW = MMFFVdWCollection::getMMFFVdW();
+    MMFFVdWCollection *mmffVdW = DefaultParameters::getMMFFVdW();
     const unsigned int iAtomType = getMMFFAtomType(idx1);
     const unsigned int jAtomType = getMMFFAtomType(idx2);
     const MMFFVdW *mmffVdWParamsIAtom = (*mmffVdW)(iAtomType);

--- a/Code/GraphMol/ForceFieldHelpers/MMFF/AtomTyper.h
+++ b/Code/GraphMol/ForceFieldHelpers/MMFF/AtomTyper.h
@@ -28,18 +28,18 @@ class Bond;
 namespace MMFF {
   
 namespace DefaultParameters {
-RDKIT_FORCEFIELDHELPERS_EXPORT ForceFields::MMFF::MMFFPropCollection *getMMFFProp();
-RDKIT_FORCEFIELDHELPERS_EXPORT ForceFields::MMFF::MMFFAromCollection *getMMFFArom();
-RDKIT_FORCEFIELDHELPERS_EXPORT ForceFields::MMFF::MMFFDefCollection *getMMFFDef();
-RDKIT_FORCEFIELDHELPERS_EXPORT ForceFields::MMFF::MMFFHerschbachLaurieCollection *
+RDKIT_FORCEFIELDHELPERS_EXPORT const ForceFields::MMFF::MMFFPropCollection *getMMFFProp();
+RDKIT_FORCEFIELDHELPERS_EXPORT const ForceFields::MMFF::MMFFAromCollection *getMMFFArom();
+RDKIT_FORCEFIELDHELPERS_EXPORT const ForceFields::MMFF::MMFFDefCollection *getMMFFDef();
+RDKIT_FORCEFIELDHELPERS_EXPORT const ForceFields::MMFF::MMFFHerschbachLaurieCollection *
   getMMFFHerschbachLaurie();
-RDKIT_FORCEFIELDHELPERS_EXPORT ForceFields::MMFF::MMFFPBCICollection *getMMFFPBCI();
-RDKIT_FORCEFIELDHELPERS_EXPORT ForceFields::MMFF::MMFFAngleCollection *getMMFFAngle();
-RDKIT_FORCEFIELDHELPERS_EXPORT ForceFields::MMFF::MMFFStbnCollection *getMMFFStbn();
-RDKIT_FORCEFIELDHELPERS_EXPORT ForceFields::MMFF::MMFFDfsbCollection *getMMFFDfsb();
-RDKIT_FORCEFIELDHELPERS_EXPORT ForceFields::MMFF::MMFFTorCollection *getMMFFTor(const bool isMMFFs);
-RDKIT_FORCEFIELDHELPERS_EXPORT ForceFields::MMFF::MMFFOopCollection *getMMFFOop(const bool isMMFFs);
-RDKIT_FORCEFIELDHELPERS_EXPORT ForceFields::MMFF::MMFFVdWCollection *getMMFFVdW();
+RDKIT_FORCEFIELDHELPERS_EXPORT const ForceFields::MMFF::MMFFPBCICollection *getMMFFPBCI();
+RDKIT_FORCEFIELDHELPERS_EXPORT const ForceFields::MMFF::MMFFAngleCollection *getMMFFAngle();
+RDKIT_FORCEFIELDHELPERS_EXPORT const ForceFields::MMFF::MMFFStbnCollection *getMMFFStbn();
+RDKIT_FORCEFIELDHELPERS_EXPORT const ForceFields::MMFF::MMFFDfsbCollection *getMMFFDfsb();
+RDKIT_FORCEFIELDHELPERS_EXPORT const ForceFields::MMFF::MMFFTorCollection *getMMFFTor(const bool isMMFFs);
+RDKIT_FORCEFIELDHELPERS_EXPORT const ForceFields::MMFF::MMFFOopCollection *getMMFFOop(const bool isMMFFs);
+RDKIT_FORCEFIELDHELPERS_EXPORT const ForceFields::MMFF::MMFFVdWCollection *getMMFFVdW();
 }
  
 class RingMembershipSize;
@@ -139,7 +139,8 @@ class RDKIT_FORCEFIELDHELPERS_EXPORT MMFFMolProperties {
   bool getMMFFBondStretchParams(const ROMol &mol, const unsigned int idx1,
                                 const unsigned int idx2, unsigned int &bondType,
                                 MMFFBond &mmffBondStretchParams);
-  bool getMMFFAngleBendParams(const ROMol &mol, const unsigned int idx1,
+  bool getMMFFAngleBendParams(const ROMol &mol,
+			      const unsigned int idx1,
                               const unsigned int idx2, const unsigned int idx3,
                               unsigned int &angleType,
                               MMFFAngle &mmffAngleBendParams);

--- a/Code/GraphMol/ForceFieldHelpers/MMFF/AtomTyper.h
+++ b/Code/GraphMol/ForceFieldHelpers/MMFF/AtomTyper.h
@@ -26,6 +26,22 @@ class Atom;
 class Bond;
 
 namespace MMFF {
+  
+namespace DefaultParameters {
+RDKIT_FORCEFIELDHELPERS_EXPORT ForceFields::MMFF::MMFFPropCollection *getMMFFProp();
+RDKIT_FORCEFIELDHELPERS_EXPORT ForceFields::MMFF::MMFFAromCollection *getMMFFArom();
+RDKIT_FORCEFIELDHELPERS_EXPORT ForceFields::MMFF::MMFFDefCollection *getMMFFDef();
+RDKIT_FORCEFIELDHELPERS_EXPORT ForceFields::MMFF::MMFFHerschbachLaurieCollection *
+  getMMFFHerschbachLaurie();
+RDKIT_FORCEFIELDHELPERS_EXPORT ForceFields::MMFF::MMFFPBCICollection *getMMFFPBCI();
+RDKIT_FORCEFIELDHELPERS_EXPORT ForceFields::MMFF::MMFFAngleCollection *getMMFFAngle();
+RDKIT_FORCEFIELDHELPERS_EXPORT ForceFields::MMFF::MMFFStbnCollection *getMMFFStbn();
+RDKIT_FORCEFIELDHELPERS_EXPORT ForceFields::MMFF::MMFFDfsbCollection *getMMFFDfsb();
+RDKIT_FORCEFIELDHELPERS_EXPORT ForceFields::MMFF::MMFFTorCollection *getMMFFTor(const bool isMMFFs);
+RDKIT_FORCEFIELDHELPERS_EXPORT ForceFields::MMFF::MMFFOopCollection *getMMFFOop(const bool isMMFFs);
+RDKIT_FORCEFIELDHELPERS_EXPORT ForceFields::MMFF::MMFFVdWCollection *getMMFFVdW();
+}
+ 
 class RingMembershipSize;
 using namespace ForceFields::MMFF;
 class RDKIT_FORCEFIELDHELPERS_EXPORT MMFFAtomProperties {

--- a/Code/GraphMol/ForceFieldHelpers/MMFF/Builder.cpp
+++ b/Code/GraphMol/ForceFieldHelpers/MMFF/Builder.cpp
@@ -270,7 +270,8 @@ void addAngles(const ROMol &mol, MMFFMolProperties *mmffMolProperties,
           auto *contrib =
               new AngleBendContrib(field, idx[0], idx[1], idx[2],
                                    &mmffAngleParams, mmffPropParamsCentralAtom);
-          field->contribs().push_back(ForceFields::ContribPtr(contrib));
+	  auto sptr = ForceFields::ContribPtr(contrib);
+          field->contribs().push_back(sptr);
           if (mmffMolProperties->getMMFFVerbosity()) {
             unsigned int iAtomType = mmffMolProperties->getMMFFAtomType(idx[0]);
             unsigned int kAtomType = mmffMolProperties->getMMFFAtomType(idx[2]);

--- a/Code/GraphMol/ForceFieldHelpers/MMFF/Builder.cpp
+++ b/Code/GraphMol/ForceFieldHelpers/MMFF/Builder.cpp
@@ -222,7 +222,7 @@ void addAngles(const ROMol &mol, MMFFMolProperties *mmffMolProperties,
 
   std::ostream &oStream = mmffMolProperties->getMMFFOStream();
   unsigned int idx[3];
-  MMFFPropCollection *mmffProp = MMFFPropCollection::getMMFFProp();
+  const MMFFPropCollection *mmffProp = DefaultParameters::getMMFFProp();
   ROMol::ADJ_ITER nbr1Idx;
   ROMol::ADJ_ITER end1Nbrs;
   ROMol::ADJ_ITER nbr2Idx;
@@ -335,7 +335,7 @@ void addStretchBend(const ROMol &mol, MMFFMolProperties *mmffMolProperties,
 
   std::ostream &oStream = mmffMolProperties->getMMFFOStream();
   unsigned int idx[3];
-  MMFFPropCollection *mmffProp = MMFFPropCollection::getMMFFProp();
+  const MMFFPropCollection *mmffProp = DefaultParameters::getMMFFProp();
   std::pair<bool, const MMFFStbn *> mmffStbnParams;
   ROMol::ADJ_ITER nbr1Idx;
   ROMol::ADJ_ITER end1Nbrs;

--- a/Code/GraphMol/ForceFieldHelpers/MMFF/CMakeLists.txt
+++ b/Code/GraphMol/ForceFieldHelpers/MMFF/CMakeLists.txt
@@ -2,3 +2,8 @@ rdkit_test(testMMFFForceFieldHelpers testMMFFHelpers.cpp
            LINK_LIBRARIES
            ForceFieldHelpers
 DistGeomHelpers DistGeometry FileParsers MolTransforms SmilesParse SubstructMatch ForceField MolAlign Optimizer EigenSolvers Alignment GraphMol RDGeometryLib RDGeneral ${RDKit_THREAD_LIBS})
+
+rdkit_test(testMMFFForceFieldHelpersMultiThread testMultiThread.cpp
+           LINK_LIBRARIES
+           ForceFieldHelpers
+DistGeomHelpers DistGeometry FileParsers MolTransforms SmilesParse SubstructMatch ForceField MolAlign Optimizer EigenSolvers Alignment GraphMol RDGeometryLib RDGeneral ${RDKit_THREAD_LIBS})

--- a/Code/GraphMol/ForceFieldHelpers/MMFF/testMultiThread.cpp
+++ b/Code/GraphMol/ForceFieldHelpers/MMFF/testMultiThread.cpp
@@ -36,7 +36,7 @@ namespace {
 void runblock_mmff(const std::vector<ROMol *> &mols) {
     for (unsigned int i = 0; i < mols.size(); ++i) {
       ROMol *mol = mols[i];
-      ForceFields::ForceField *field = MMFF::constructForceField(mol);
+      ForceFields::ForceField *field = MMFF::constructForceField(*mol);
       TEST_ASSERT(field);
       field->initialize();
       field->minimize(1);

--- a/Code/GraphMol/ForceFieldHelpers/MMFF/testMultiThread.cpp
+++ b/Code/GraphMol/ForceFieldHelpers/MMFF/testMultiThread.cpp
@@ -35,7 +35,7 @@ using namespace RDKit;
 namespace {
 void runblock_mmff(const std::vector<ROMol *> &mols) {
     for (unsigned int i = 0; i < mols.size(); ++i) {
-      ROMol mol(*mols[i]);
+      ROMol *mol = mols[i];
       ForceFields::ForceField *field = MMFF::constructForceField(mol);
       TEST_ASSERT(field);
       field->initialize();

--- a/Code/GraphMol/ForceFieldHelpers/MMFF/testMultiThread.cpp
+++ b/Code/GraphMol/ForceFieldHelpers/MMFF/testMultiThread.cpp
@@ -1,0 +1,96 @@
+//
+//  Copyright (C) 2004-2018 Greg Landrum and Rational Discovery LLC
+//
+//   @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
+//
+
+#include <RDGeneral/test.h>
+#include <iostream>
+#include <RDGeneral/Invariant.h>
+#include <RDGeneral/RDLog.h>
+#include <RDGeneral/utils.h>
+
+#include <GraphMol/RDKitBase.h>
+#include <GraphMol/SmilesParse/SmilesParse.h>
+#include <GraphMol/SmilesParse/SmilesWrite.h>
+#include <GraphMol/FileParsers/FileParsers.h>
+#include <GraphMol/FileParsers/MolSupplier.h>
+
+#include <GraphMol/ForceFieldHelpers/FFConvenience.h>
+#include <GraphMol/ForceFieldHelpers/MMFF/AtomTyper.h>
+#include <GraphMol/ForceFieldHelpers/MMFF/Builder.h>
+#include <GraphMol/ForceFieldHelpers/MMFF/MMFF.h>
+#include <ForceField/ForceField.h>
+#include <ForceField/MMFF/Params.h>
+#include <GraphMol/DistGeomHelpers/Embedder.h>
+#include <GraphMol/Substruct/SubstructMatch.h>
+#include <boost/math/special_functions/round.hpp>
+
+using namespace RDKit;
+#ifdef RDK_TEST_MULTITHREADED
+namespace {
+void runblock_mmff(const std::vector<ROMol *> &mols) {
+    for (unsigned int i = 0; i < mols.size(); ++i) {
+      ROMol *mol = mols[i];
+      ForceFields::ForceField *field = MMFF::constructForceField(*mol);
+      TEST_ASSERT(field);
+      field->initialize();
+      field->minimize(1);
+      delete field;
+    }
+}
+}  // namespace
+#include <thread>
+#include <future>
+void testMMFFMultiThread() {
+  BOOST_LOG(rdErrorLog) << "-------------------------------------" << std::endl;
+  BOOST_LOG(rdErrorLog) << "    Test MMFF multithreading" << std::endl;
+
+  // ForceFields::ForceField *field;
+
+  std::string pathName = getenv("RDBASE");
+  pathName += "/Code/GraphMol/ForceFieldHelpers/MMFF/test_data";
+  SDMolSupplier suppl(pathName + "/bulk.sdf");
+  std::vector<ROMol *> mols;
+  while (!suppl.atEnd() && mols.size() < 100) {
+    ROMol *mol = nullptr;
+    try {
+      mol = suppl.next();
+    } catch (...) {
+      continue;
+    }
+    if (!mol) continue;
+    mols.push_back(mol);
+  }
+
+  std::vector<std::future<void>> tg;
+
+  std::cerr << "processing" << std::endl;
+  unsigned int count = 8;
+  for (unsigned int i = 0; i < count; ++i) {
+    std::cerr << " launch :" << i << std::endl;
+    std::cerr.flush();
+    tg.emplace_back(std::async(std::launch::async, runblock_mmff, mols));
+  }
+  for (auto &fut : tg) {
+    fut.get();
+  }
+
+  BOOST_FOREACH (ROMol *mol, mols) { delete mol; }
+  BOOST_LOG(rdErrorLog) << "  done" << std::endl;
+}
+
+#endif
+//-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
+//
+//-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
+int main() {
+  RDLog::InitLogs();
+#ifdef RDK_TEST_MULTITHREADED
+  testMMFFMultiThread();
+#endif
+}

--- a/Code/GraphMol/ForceFieldHelpers/MMFF/testMultiThread.cpp
+++ b/Code/GraphMol/ForceFieldHelpers/MMFF/testMultiThread.cpp
@@ -50,12 +50,10 @@ void testMMFFMultiThread() {
   BOOST_LOG(rdErrorLog) << "-------------------------------------" << std::endl;
   BOOST_LOG(rdErrorLog) << "    Test MMFF multithreading" << std::endl;
 
-  // ForceFields::ForceField *field;
-
   std::string pathName = getenv("RDBASE");
   pathName += "/Code/GraphMol/ForceFieldHelpers/MMFF/test_data";
   SDMolSupplier suppl(pathName + "/bulk.sdf");
-  unsigned int count = 8;
+  unsigned int count = 24;
   std::vector<std::vector<ROMol*>> mols;
   for(unsigned int i=0;i<count;++i) mols.push_back(std::vector<ROMol*>());
   


### PR DESCRIPTION
This is a strawman for updating the MMFF parameter API.  A handful of changes are made:

1. remove the old singleton API and use c++ static initialization
2. make all parameter collections classes const correct and use them when appropriate

This still has the side-effect that you can't really use different parameters, but perhaps make this easier to refactor.