### PR TITLE
fix to SDWriter docs

### DIFF
--- a/Code/GraphMol/Wrap/SDWriter.cpp
+++ b/Code/GraphMol/Wrap/SDWriter.cpp
@@ -63,7 +63,7 @@ struct sdwriter_wrap {
 \n\
     2) writing to a file-like object: \n\n\
        >>> import gzip\n\
-       >>> outf=gzip.open('out.sdf.gz','w+')\n\
+       >>> outf=gzip.open('out.sdf.gz','wt+')\n\
        >>> writer = SDWriter(outf)\n\
        >>> for mol in list_of_mols:\n\
        ...   writer.write(mol)\n\


### PR DESCRIPTION
The previous SDWriter docs for writing to a gzipped object throws an error in python3. From the mailing this, 'wt+' seems to work fine.
https://sourceforge.net/p/rdkit/mailman/message/36406080/