### PR TITLE
Add RDKIT_FILEPARSERS_EXPORT to finishMolProcessing

### DIFF
--- a/Code/GraphMol/FileParsers/FileParserUtils.h
+++ b/Code/GraphMol/FileParsers/FileParserUtils.h
@@ -55,7 +55,7 @@ RDKIT_FILEPARSERS_EXPORT bool ParseV2000CTAB(
     bool strictParsing = true);
 
 //! finishes up the processing (sanitization, etc.) of a molecule read from CTAB
-void finishMolProcessing(RWMol *res, bool chiralityPossible, bool sanitize,
+RDKIT_FILEPARSERS_EXPORT void finishMolProcessing(RWMol *res, bool chiralityPossible, bool sanitize,
                          bool removeHs);
 
 RDKIT_FILEPARSERS_EXPORT Atom *replaceAtomWithQueryAtom(RWMol *mol, Atom *atom);


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
This addresses a linking error when using dynamic libraries on Windows:

    MDLParser.cpp.obj : error LNK2019: unresolved external symbol "void __cdecl RDKit::FileParserUtils::finishMolProcessing(class RDKit::RWMol *,bool,bool,bool)" (?finishMolProcessing@FileParserUtils@RDKit@@YAXPEAVRWMol@2@_N11@Z) referenced in function "void __cdecl RDKit::`anonymous namespace'::ParseV3000RxnBlock(class std::basic_istream<char,struct std::char_traits<char> > &,unsigned int &,class RDKit::ChemicalReaction * &)" (?ParseV3000RxnBlock@?A0xcb91cdb2@RDKit@@YAXAEAV?$basic_istream@DU?$char_traits@D@std@@@std@@AEAIAEAPEAVChemicalReaction@2@@Z)
    ..\..\..\bin\RDKitChemReactions.dll : fatal error LNK1120: 1 unresolved externals

#### Any other comments?
We may want to set default visibility on Linux to hidden, too, so that we can catch linking errors like this more easily cross-platform.


