### PR TITLE
Allow providing a bounds matrix to EmbedMol

### DIFF
--- a/Code/GraphMol/DistGeomHelpers/Embedder.cpp
+++ b/Code/GraphMol/DistGeomHelpers/Embedder.cpp
@@ -954,8 +954,14 @@ void EmbedMultipleConfs(ROMol &mol, INT_VECT &res, unsigned int numConfs,
   confsOk.set();
 
   INT_VECT fragMapping;
-  std::vector<ROMOL_SPTR> molFrags =
-      MolOps::getMolFrags(mol, true, &fragMapping);
+  std::vector<ROMOL_SPTR> molFrags;
+  if (params.embedFragmentsSeparately) {
+    molFrags = MolOps::getMolFrags(mol, true, &fragMapping);
+  } else {
+    molFrags.push_back(ROMOL_SPTR(new ROMol(mol)));
+    fragMapping.resize(mol.getNumAtoms());
+    std::fill(fragMapping.begin(), fragMapping.end(), 0);
+  }
   const std::map<int, RDGeom::Point3D> *coordMap = params.coordMap;
   if (molFrags.size() > 1 && coordMap) {
     BOOST_LOG(rdWarningLog)

--- a/Code/GraphMol/DistGeomHelpers/Embedder.cpp
+++ b/Code/GraphMol/DistGeomHelpers/Embedder.cpp
@@ -973,7 +973,7 @@ void EmbedMultipleConfs(ROMol &mol, INT_VECT &res, unsigned int numConfs,
 
   if (molFrags.size() > 1 && params.boundsMat != nullptr) {
     BOOST_LOG(rdWarningLog)
-        << "Conformer generation using a client-provided boundsMat "
+        << "Conformer generation using a user-provided boundsMat "
            "does not work with molecules that have multiple fragments. The "
            "boundsMat will be ignored."
         << std::endl;

--- a/Code/GraphMol/DistGeomHelpers/Embedder.h
+++ b/Code/GraphMol/DistGeomHelpers/Embedder.h
@@ -15,6 +15,8 @@
 #include <map>
 #include <Geometry/point.h>
 #include <GraphMol/ROMol.h>
+#include <boost/shared_ptr.hpp>
+#include <DistGeom/BoundsMatrix.h>
 
 namespace RDKit {
 namespace DGeomHelpers {
@@ -116,6 +118,7 @@ struct RDKIT_DISTGEOMHELPERS_EXPORT EmbedParameters {
   double pruneRmsThresh;
   bool onlyHeavyAtomsForRMS;
   unsigned int ETversion;
+  boost::shared_ptr<const DistGeom::BoundsMatrix> boundsMat;
   EmbedParameters()
       : maxIterations(0),
         numThreads(1),
@@ -135,7 +138,8 @@ struct RDKIT_DISTGEOMHELPERS_EXPORT EmbedParameters {
         basinThresh(5.0),
         pruneRmsThresh(-1.0),
         onlyHeavyAtomsForRMS(false),
-        ETversion(1){};
+        ETversion(1),
+        boundsMat(nullptr){};
   EmbedParameters(unsigned int maxIterations, int numThreads, int randomSeed,
                   bool clearConfs, bool useRandomCoords, double boxSizeMult,
                   bool randNegEig, unsigned int numZeroFail,
@@ -144,7 +148,8 @@ struct RDKIT_DISTGEOMHELPERS_EXPORT EmbedParameters {
                   bool enforceChirality, bool useExpTorsionAnglePrefs,
                   bool useBasicKnowledge, bool verbose, double basinThresh,
                   double pruneRmsThresh, bool onlyHeavyAtomsForRMS,
-                  unsigned int ETversion = 1)
+                  unsigned int ETversion = 1,
+                  const DistGeom::BoundsMatrix *boundsMat = nullptr)
       : maxIterations(maxIterations),
         numThreads(numThreads),
         randomSeed(randomSeed),
@@ -163,7 +168,8 @@ struct RDKIT_DISTGEOMHELPERS_EXPORT EmbedParameters {
         basinThresh(basinThresh),
         pruneRmsThresh(pruneRmsThresh),
         onlyHeavyAtomsForRMS(onlyHeavyAtomsForRMS),
-        ETversion(ETversion){};
+        ETversion(ETversion),
+        boundsMat(boundsMat){};
 };
 
 //*! Embed multiple conformations for a molecule

--- a/Code/GraphMol/DistGeomHelpers/Embedder.h
+++ b/Code/GraphMol/DistGeomHelpers/Embedder.h
@@ -119,6 +119,7 @@ struct RDKIT_DISTGEOMHELPERS_EXPORT EmbedParameters {
   bool onlyHeavyAtomsForRMS;
   unsigned int ETversion;
   boost::shared_ptr<const DistGeom::BoundsMatrix> boundsMat;
+  bool embedFragmentsSeparately;
   EmbedParameters()
       : maxIterations(0),
         numThreads(1),
@@ -139,7 +140,8 @@ struct RDKIT_DISTGEOMHELPERS_EXPORT EmbedParameters {
         pruneRmsThresh(-1.0),
         onlyHeavyAtomsForRMS(false),
         ETversion(1),
-        boundsMat(nullptr){};
+        boundsMat(nullptr),
+        embedFragmentsSeparately(true){};
   EmbedParameters(unsigned int maxIterations, int numThreads, int randomSeed,
                   bool clearConfs, bool useRandomCoords, double boxSizeMult,
                   bool randNegEig, unsigned int numZeroFail,
@@ -149,7 +151,8 @@ struct RDKIT_DISTGEOMHELPERS_EXPORT EmbedParameters {
                   bool useBasicKnowledge, bool verbose, double basinThresh,
                   double pruneRmsThresh, bool onlyHeavyAtomsForRMS,
                   unsigned int ETversion = 1,
-                  const DistGeom::BoundsMatrix *boundsMat = nullptr)
+                  const DistGeom::BoundsMatrix *boundsMat = nullptr,
+                  bool embedFragmentsSeparately = true)
       : maxIterations(maxIterations),
         numThreads(numThreads),
         randomSeed(randomSeed),
@@ -169,7 +172,8 @@ struct RDKIT_DISTGEOMHELPERS_EXPORT EmbedParameters {
         pruneRmsThresh(pruneRmsThresh),
         onlyHeavyAtomsForRMS(onlyHeavyAtomsForRMS),
         ETversion(ETversion),
-        boundsMat(boundsMat){};
+        boundsMat(boundsMat),
+        embedFragmentsSeparately(embedFragmentsSeparately){};
 };
 
 //*! Embed multiple conformations for a molecule

--- a/Code/GraphMol/DistGeomHelpers/Wrap/rdDistGeom.cpp
+++ b/Code/GraphMol/DistGeomHelpers/Wrap/rdDistGeom.cpp
@@ -147,7 +147,33 @@ DGeomHelpers::EmbedParameters *getKDG() {
 DGeomHelpers::EmbedParameters *getETDG() {
   return new DGeomHelpers::EmbedParameters(DGeomHelpers::ETDG);
 }
+
+bool setBoundsMatrix(DGeomHelpers::EmbedParameters *self,
+                     python::object boundsMatArg) {
+  PyObject *boundsMatObj = boundsMatArg.ptr();
+  if (!PyArray_Check(boundsMatObj))
+    throw_value_error("Argument isn't an array");
+
+  PyArrayObject *boundsMat = reinterpret_cast<PyArrayObject *>(boundsMatObj);
+  // get the dimensions of the array
+  int nrows = PyArray_DIM(boundsMat, 0);
+  int ncols = PyArray_DIM(boundsMat, 1);
+  if (nrows != ncols) throw_value_error("The array has to be square");
+  if (nrows <= 0) throw_value_error("The array has to have a nonzero size");
+  if (PyArray_DESCR(boundsMat)->type_num != NPY_DOUBLE)
+    throw_value_error("Only double arrays are currently supported");
+
+  unsigned int dSize = nrows * nrows;
+  auto *cData = new double[dSize];
+  double *inData = reinterpret_cast<double *>(PyArray_DATA(boundsMat));
+  memcpy(static_cast<void *>(cData), static_cast<const void *>(inData),
+         dSize * sizeof(double));
+  DistGeom::BoundsMatrix::DATA_SPTR sdata(cData);
+  self->boundsMat = boost::shared_ptr<const DistGeom::BoundsMatrix>(
+      new DistGeom::BoundsMatrix(nrows, sdata));
 }
+
+}  // namespace RDKit
 
 BOOST_PYTHON_MODULE(rdDistGeom) {
   python::scope().attr("__doc__") =
@@ -338,7 +364,10 @@ BOOST_PYTHON_MODULE(rdDistGeom) {
       .def_readwrite(
           "onlyHeavyAtomsForRMS",
           &RDKit::DGeomHelpers::EmbedParameters::onlyHeavyAtomsForRMS,
-          "Only consider heavy atoms when doing RMS filtering");
+          "Only consider heavy atoms when doing RMS filtering")
+      .def("SetBoundsMat", &RDKit::setBoundsMatrix,
+           "set the distance-bounds matrix to be used (no triangle smoothing "
+           "will be done on this) from a Numpy array");
   docString =
       "Use distance geometry to obtain multiple sets of \n\
  coordinates for a molecule\n\

--- a/Code/GraphMol/DistGeomHelpers/Wrap/rdDistGeom.cpp
+++ b/Code/GraphMol/DistGeomHelpers/Wrap/rdDistGeom.cpp
@@ -365,6 +365,10 @@ BOOST_PYTHON_MODULE(rdDistGeom) {
           "onlyHeavyAtomsForRMS",
           &RDKit::DGeomHelpers::EmbedParameters::onlyHeavyAtomsForRMS,
           "Only consider heavy atoms when doing RMS filtering")
+      .def_readwrite(
+          "embedFragmentsSeparately",
+          &RDKit::DGeomHelpers::EmbedParameters::embedFragmentsSeparately,
+          "split the molecule into fragments and embed them separately")
       .def("SetBoundsMat", &RDKit::setBoundsMatrix,
            "set the distance-bounds matrix to be used (no triangle smoothing "
            "will be done on this) from a Numpy array");

--- a/Code/GraphMol/DistGeomHelpers/Wrap/rdDistGeom.cpp
+++ b/Code/GraphMol/DistGeomHelpers/Wrap/rdDistGeom.cpp
@@ -148,7 +148,7 @@ DGeomHelpers::EmbedParameters *getETDG() {
   return new DGeomHelpers::EmbedParameters(DGeomHelpers::ETDG);
 }
 
-bool setBoundsMatrix(DGeomHelpers::EmbedParameters *self,
+void setBoundsMatrix(DGeomHelpers::EmbedParameters *self,
                      python::object boundsMatArg) {
   PyObject *boundsMatObj = boundsMatArg.ptr();
   if (!PyArray_Check(boundsMatObj))

--- a/Code/GraphMol/DistGeomHelpers/testDgeomHelpers.cpp
+++ b/Code/GraphMol/DistGeomHelpers/testDgeomHelpers.cpp
@@ -2177,6 +2177,26 @@ void testProvideBoundsMatrix() {
   }
 }
 
+void testDisableFragmentation() {
+  {  // make sure the mechanics work
+    auto m = "OO.OO"_smiles;
+    TEST_ASSERT(m);
+
+    DGeomHelpers::EmbedParameters params;
+    params.embedFragmentsSeparately = false;
+    params.randomSeed = 0xf00d;
+    int cid = DGeomHelpers::EmbedMolecule(*m, params);
+    TEST_ASSERT(cid >= 0);
+
+    const auto conf = m->getConformer(cid);
+
+    TEST_ASSERT((conf.getAtomPos(0) - conf.getAtomPos(2)).length() > 2.0);
+    TEST_ASSERT((conf.getAtomPos(0) - conf.getAtomPos(3)).length() > 2.0);
+    TEST_ASSERT((conf.getAtomPos(1) - conf.getAtomPos(2)).length() > 2.0);
+    TEST_ASSERT((conf.getAtomPos(1) - conf.getAtomPos(3)).length() > 2.0);
+  }
+}
+
 int main() {
   RDLog::InitLogs();
   BOOST_LOG(rdInfoLog)
@@ -2367,6 +2387,10 @@ int main() {
   BOOST_LOG(rdInfoLog) << "\t---------------------------------\n";
   BOOST_LOG(rdInfoLog) << "\t Providing a distance bounds matrix.\n";
   testProvideBoundsMatrix();
+
+  BOOST_LOG(rdInfoLog) << "\t---------------------------------\n";
+  BOOST_LOG(rdInfoLog) << "\t Disabling fragmentation.\n";
+  testDisableFragmentation();
 
   BOOST_LOG(rdInfoLog)
       << "*******************************************************\n";


### PR DESCRIPTION
This allows you to provide a specific distance bounds matrix to the molecule embedding functions.
This allows you to take advantage of all the features of the molecule embedding code (like random coordinates, ETKDG, etc.) but seed the initial geometries with the bounds matrix.