### PR TITLE
Do not run UnitTestMCS.py::TestTimeout in debug builds

### DIFF
--- a/rdkit/CMakeLists.txt
+++ b/rdkit/CMakeLists.txt
@@ -24,7 +24,7 @@ add_pytest(pythonTestDirSimDivFilters
 add_pytest(pythonTestDirVLib
          ${CMAKE_CURRENT_SOURCE_DIR}/VLib/test_list.py --testDir ${CMAKE_CURRENT_SOURCE_DIR}/VLib )
 add_pytest(pythonTestDirChem
-         ${CMAKE_CURRENT_SOURCE_DIR}/Chem/test_list.py --testDir ${CMAKE_CURRENT_SOURCE_DIR}/Chem )
+         ${CMAKE_CURRENT_SOURCE_DIR}/Chem/test_list.py --testDir ${CMAKE_CURRENT_SOURCE_DIR}/Chem --buildType ${CMAKE_BUILD_TYPE})
 add_pytest(pythonTestSping
          ${CMAKE_CURRENT_SOURCE_DIR}/Chem/test_list.py --testDir ${CMAKE_CURRENT_SOURCE_DIR}/sping )
 

--- a/rdkit/Chem/Pharm2D/UnitTestMatcher.py
+++ b/rdkit/Chem/Pharm2D/UnitTestMatcher.py
@@ -51,7 +51,7 @@ class TestCase(unittest.TestCase):
             # self.assertEqual(matches,tgt)
 
     def test2Bug28(self):
-        smi = 'Cc([s]1)nnc1SCC(\CS2)=C(/C([O-])=O)N3C(=O)[C@H]([C@@H]23)NC(=O)C[n]4cnnn4'
+        smi = r'Cc([s]1)nnc1SCC(\CS2)=C(/C([O-])=O)N3C(=O)[C@H]([C@@H]23)NC(=O)C[n]4cnnn4'
         mol = Chem.MolFromSmiles(smi)
         factory = Gobbi_Pharm2D.factory
         factory.SetBins([(2, 3), (3, 4), (4, 5), (5, 8), (8, 100)])

--- a/rdkit/Chem/UnitTestFragmentDescriptors.py
+++ b/rdkit/Chem/UnitTestFragmentDescriptors.py
@@ -162,7 +162,7 @@ class TestCase(unittest.TestCase):
 
   def test16(self):
     data = [
-      ('C1(CCC(O1)=O)(C)CC/C=C\CC', 1),
+      (r'C1(CCC(O1)=O)(C)CC/C=C\CC', 1),
       ('CN(CC3=CSC(C(C)C)=N3)C(N[C@@H]([C@H](C)C)C(N[C@@H](CC4=CC=CC=C4)C[C@H](O)[C@H](CC2=CC=CC=C2)NC(OCC1=CN=CS1)=O)=O)=O',
        0),  # ritonavir
       ('c1(C)ccccc1CCN', 0)
@@ -191,7 +191,7 @@ class TestCase(unittest.TestCase):
 
   def test19(self):
     data = [('CC(C)(C)NCC(O)C1=CC(O)=CC(O)=C1', 1),  # terbulatine
-            ('OCCN1CCN(CC/C=C2\C3=CC=CC=C3SC4C=CC(Cl)=CC2=4)CC1', 1),  # clopenthixol
+            (r'OCCN1CCN(CC/C=C2\C3=CC=CC=C3SC4C=CC(Cl)=CC2=4)CC1', 1),  # clopenthixol
             ('c1ccccc1-C(=O)-CCO', 0),
             ('CC(=O)NCCC', 0)]
     self._runTest(data, Fragments.fr_HOCCN)
@@ -203,7 +203,7 @@ class TestCase(unittest.TestCase):
     self._runTest(data, Fragments.fr_methoxy)
 
   def test21(self):
-    data = [('C/C(C(C)=O)=N\O', 1),
+    data = [(r'C/C(C(C)=O)=N\O', 1),
             ('C(=N/OC(C(=O)O)(C)C)(/C1=CS[N+](=N1)C)C(N[C@@H]2C(N([C@@H]2C)S(O)(=O)=O)=O)=O',
              1),  # aztreonam
             ('c1ccccc1OCC', 0), ]

--- a/rdkit/Chem/UnitTestMCS.py
+++ b/rdkit/Chem/UnitTestMCS.py
@@ -3,7 +3,7 @@ import time
 
 from rdkit import Chem
 from rdkit.Chem import rdFMCS
-
+from rdkit.TestRunner import isDebugBuild
 
 def load_smiles(text):
   mols = []
@@ -321,6 +321,7 @@ lengthy_mols = [Chem.MolFromSmiles("Nc1ccccc1" * 20), Chem.MolFromSmiles("Nc1ccc
 
 class TestTimeout(MCSTestCase):
   # This should take over two minutes to process. Give it 1 seconds.
+  @unittest.skipIf(isDebugBuild(), "Timeout test will fail on debug builds.")
   def test_timeout(self):
     t1 = time.time()
     result = rdFMCS.FindMCS(lengthy_mols, timeout=1)

--- a/rdkit/TestRunner.py
+++ b/rdkit/TestRunner.py
@@ -8,8 +8,12 @@
 #  of the RDKit source tree.
 #
 
+import os
+import sys
+import time
+
 from rdkit import RDConfig
-import os, sys, time
+
 try:
   import subprocess
 except ImportError:
@@ -17,6 +21,15 @@ except ImportError:
 
 TEST_FAILED = -1
 TEST_PASSED = 0
+
+BUILD_TYPE_ENVVAR = 'RDKIT_BUILD_TYPE'
+
+
+def isDebugBuild():
+  try:
+    return os.environ[BUILD_TYPE_ENVVAR] == 'DEBUG'
+  except KeyError:
+    return False
 
 
 def RunTest(exeName, args, extras):
@@ -50,8 +63,10 @@ def RunScript(script, doLongTests, verbose):
     # setting environment allows this setting to recursively pass to all child
     # processes
     os.environ['PYTHON_TEST_FAILFAST'] = '1'
-  if len(sys.argv) == 3 and sys.argv[1] == '--testDir':
+  if len(sys.argv) >= 3 and sys.argv[1] == '--testDir':
     os.chdir(sys.argv[2])
+  if len(sys.argv) >= 5 and sys.argv[3] == '--buildType':
+    os.environ[BUILD_TYPE_ENVVAR] = sys.argv[4].upper()
   # -------------------------------------------------------
   # this is pretty funny.  Whatever directory we started python in
   # will be in the search path, and if we've changed to another
@@ -244,6 +259,7 @@ class OutputRedirectC:
   >>>
 
   """
+
   def __init__(self, stdout=os.devnull, stderr=os.devnull, mode='wb'):
     self.outfiles = stdout, stderr
     self.combine = (stdout == stderr)


### PR DESCRIPTION
This has been bugging me for some time: as debug builds are (way) slower than release ones, the timeout test failed every time. This led me to ignore failures from UnitTestMCS, which I know is not a good idea, because eventually something else will fail.

I have now implemented something that will skip the timeout test on debug builds, but still run the other ones.

I also corrected some warning messages about 'invalid escape sequences' which should actually be ENDDOWNRIGHT bond directions.