### PR TITLE
Allow Point2D to be constructed from Point3D

### DIFF
--- a/Code/Geometry/CMakeLists.txt
+++ b/Code/Geometry/CMakeLists.txt
@@ -16,6 +16,8 @@ rdkit_headers(Grid3D.h
 
 rdkit_test(testTransforms testTransforms.cpp LINK_LIBRARIES RDGeometryLib DataStructs RDGeneral )
 rdkit_test(testGrid testGrid.cpp LINK_LIBRARIES RDGeometryLib DataStructs RDGeneral )
+rdkit_catch_test(geometryTestsCatch catch_tests.cpp
+           LINK_LIBRARIES RDGeometryLib RDGeneral)
 
 if(RDK_BUILD_PYTHON_WRAPPERS)
 add_subdirectory(Wrap)

--- a/Code/Geometry/Wrap/Point.cpp
+++ b/Code/Geometry/Wrap/Point.cpp
@@ -43,7 +43,7 @@ struct PointND_pickle_suite : python::pickle_suite {
     }
   }
 };
-}
+}  // namespace
 
 namespace RDGeom {
 
@@ -161,7 +161,9 @@ struct Point_wrapper {
     python::class_<Point2D>("Point2D", Point2Ddoc.c_str(),
                             python::init<>("Default Constructor"))
         .def(python::init<double, double>())
-        .def(python::init<const Point3D &>())
+        .def(python::init<const Point3D &>(
+            (python::args("self"), python::args("other")),
+            "construct from a Point3D (ignoring the z component)"))
         .def_readwrite("x", &Point2D::x)
         .def_readwrite("y", &Point2D::y)
         .def("__getitem__", point2dGetItem)
@@ -246,6 +248,6 @@ struct Point_wrapper {
                 "Point3D objects");
   }
 };
-}
+}  // namespace RDGeom
 
 void wrap_point() { RDGeom::Point_wrapper::wrap(); }

--- a/Code/Geometry/Wrap/Point.cpp
+++ b/Code/Geometry/Wrap/Point.cpp
@@ -161,6 +161,7 @@ struct Point_wrapper {
     python::class_<Point2D>("Point2D", Point2Ddoc.c_str(),
                             python::init<>("Default Constructor"))
         .def(python::init<double, double>())
+        .def(python::init<const Point3D &>())
         .def_readwrite("x", &Point2D::x)
         .def_readwrite("y", &Point2D::y)
         .def("__getitem__", point2dGetItem)

--- a/Code/Geometry/Wrap/testGeometry.py
+++ b/Code/Geometry/Wrap/testGeometry.py
@@ -1,4 +1,3 @@
-
 import os, sys
 import unittest
 import copy
@@ -401,6 +400,12 @@ class TestCase(unittest.TestCase):
     self.assertEqual(xi, 3)
     self.assertEqual(yi, 2)
     self.assertEqual(zi, 1)
+
+  def test8InitPoint2DFromPoint3D(self):
+    p3 = geom.Point3D(1., 2., 3.)
+    p2 = geom.Point2D(p3)
+    self.assertEqual(p2.x, p3.x)
+    self.assertEqual(p2.y, p3.y)
 
 
 if __name__ == '__main__':

--- a/Code/Geometry/catch_tests.cpp
+++ b/Code/Geometry/catch_tests.cpp
@@ -1,0 +1,13 @@
+#define CATCH_CONFIG_MAIN  // This tells Catch to provide a main() - only do
+                           // this in one cpp file
+#include "catch.hpp"
+#include <Geometry/point.h>
+
+TEST_CASE("construct Point2D from Point3D", "[point]") {
+  SECTION("basics") {
+    RDGeom::Point3D p3(1., 2., 3.);
+    RDGeom::Point2D p2(p3);
+    CHECK(p2.x == p3.x);
+    CHECK(p2.y == p3.y);
+  }
+}

--- a/Code/Geometry/point.h
+++ b/Code/Geometry/point.h
@@ -264,6 +264,7 @@ class RDKIT_RDGEOMETRYLIB_EXPORT Point2D : public Point {
   ~Point2D(){};
 
   Point2D(const Point2D &other) : Point(other), x(other.x), y(other.y) {}
+  //! construct from a Point3D (ignoring the z coordinate)
   Point2D(const Point3D &p3d) : Point(p3d), x(p3d.x), y(p3d.y){};
 
   virtual Point *copy() const { return new Point2D(*this); }

--- a/Code/Geometry/point.h
+++ b/Code/Geometry/point.h
@@ -261,10 +261,10 @@ class RDKIT_RDGEOMETRYLIB_EXPORT Point2D : public Point {
 
   Point2D() : x(0.0), y(0.0){};
   Point2D(double xv, double yv) : x(xv), y(yv){};
-
   ~Point2D(){};
 
   Point2D(const Point2D &other) : Point(other), x(other.x), y(other.y) {}
+  Point2D(const Point3D &p3d) : Point(p3d), x(p3d.x), y(p3d.y){};
 
   virtual Point *copy() const { return new Point2D(*this); }
 


### PR DESCRIPTION
Adds a `Point2D(const Point3D &other)` ctor.

This is a convenience thing.