### PR TITLE
Remove arbitrary lower bound on the number of steps. [closes #2581]

### DIFF
--- a/Code/GraphMol/FMCS/MaximumCommonSubgraph.cpp
+++ b/Code/GraphMol/FMCS/MaximumCommonSubgraph.cpp
@@ -571,7 +571,7 @@ bool MaximumCommonSubgraph::growSeeds() {
     }
     if (NotSet == si->GrowingStage)  // finished
       Seeds.erase(si);
-    if (Parameters.ProgressCallback && (steps >= 377)) {
+    if (Parameters.ProgressCallback) {
       steps = 0;
       Stat.NumAtoms = getMaxNumberAtoms();
       Stat.NumBonds = getMaxNumberBonds();


### PR DESCRIPTION
This pull request removes a lower bound on the number of steps used in the rdFMCS algorithm, which would result in the timeout option being ignored and extremely slow matching when the search space is large.

See [issue 2581](#2581) for further details.