### PR TITLE
fix the inclusion path for the targets file (#2584)

### DIFF
--- a/rdkit-config.cmake.in
+++ b/rdkit-config.cmake.in
@@ -1,5 +1,5 @@
 # Compute installation prefix relative to this file
-get_filename_component (_dir "${CMAKE_CURRENT_LIST_FILE}" PATH)
+get_filename_component (_dir "${CMAKE_CURRENT_LIST_FILE}" DIRECTORY)
 get_filename_component (_prefix "${_dir}/.." ABSOLUTE)
 
 # Import the targets

--- a/rdkit-config.cmake.in
+++ b/rdkit-config.cmake.in
@@ -3,7 +3,7 @@ get_filename_component (_dir "${CMAKE_CURRENT_LIST_FILE}" PATH)
 get_filename_component (_prefix "${_dir}/.." ABSOLUTE)
 
 # Import the targets
-include ("${_prefix}/lib@LIB_SUFFIX@/@RDKit_EXPORTED_TARGETS@.cmake")
+include ("${_dir}/@RDKit_EXPORTED_TARGETS@.cmake")
 
 # Report other info
 set (RDKit_INCLUDE_DIRS "${_prefix}/@RDKit_HdrDir@")


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! 
-->
#### Reference Issue
Fixes #2584


#### What does this implement/fix? Explain your changes.
The inclusion statement for rdkit-targets.cmake was using a path that depended explicitly on the install location under $PREFIX. This was unnecessary (because both files are installed into the same directory), and prone to issues when this install location is modified.

