### PR TITLE
raise ValueErrors when constructing streambuffs with the incorrect type.

### DIFF
--- a/Code/GraphMol/Wrap/ForwardSDMolSupplier.cpp
+++ b/Code/GraphMol/Wrap/ForwardSDMolSupplier.cpp
@@ -34,7 +34,7 @@ class LocalForwardSDMolSupplier : public RDKit::ForwardSDMolSupplier {
   LocalForwardSDMolSupplier(python::object &input, bool sanitize, bool removeHs,
                             bool strictParsing) {
     // FIX: minor leak here
-    auto *sb = new streambuf(input);
+    auto *sb = new streambuf(input,'b');
     dp_inStream = new streambuf::istream(*sb);
     df_owner = true;
     df_sanitize = sanitize;

--- a/Code/GraphMol/Wrap/PDBWriter.cpp
+++ b/Code/GraphMol/Wrap/PDBWriter.cpp
@@ -26,11 +26,11 @@ using boost_adaptbx::python::streambuf;
 namespace {
 PDBWriter *getPDBWriter(python::object &fileobj, unsigned int flavor = 0) {
   // FIX: minor leak here
-  auto *sb = new streambuf(fileobj);
+  auto *sb = new streambuf(fileobj, 't');
   auto *ost = new streambuf::ostream(*sb);
   return new PDBWriter(ost, true, flavor);
 }
-}
+}  // namespace
 std::string pdbwDocStr =
     "Constructor.\n\n"
     "   ARGUMENTS:\n\n"
@@ -65,6 +65,6 @@ struct pdbwriter_wrap {
              "Returns the number of molecules written so far.\n\n");
   };
 };
-}
+}  // namespace RDKit
 
 void wrap_pdbwriter() { RDKit::pdbwriter_wrap::wrap(); }

--- a/Code/GraphMol/Wrap/SDWriter.cpp
+++ b/Code/GraphMol/Wrap/SDWriter.cpp
@@ -26,7 +26,7 @@ using boost_adaptbx::python::streambuf;
 namespace RDKit {
 SDWriter *getSDWriter(python::object &fileobj) {
   // FIX: minor leak here
-  auto *sb = new streambuf(fileobj);
+  auto *sb = new streambuf(fileobj, 't');
   auto *ost = new streambuf::ostream(*sb);
   return new SDWriter(ost, true);
 }

--- a/Code/GraphMol/Wrap/SmilesWriter.cpp
+++ b/Code/GraphMol/Wrap/SmilesWriter.cpp
@@ -30,7 +30,7 @@ SmilesWriter *getSmilesWriter(python::object &fileobj,
                               bool isomericSmiles = true,
                               bool kekuleSmiles = false) {
   // FIX: minor leak here
-  auto *sb = new streambuf(fileobj);
+  auto *sb = new streambuf(fileobj, 't');
   auto *ost = new streambuf::ostream(*sb);
   return new SmilesWriter(ost, delimiter, nameHeader, includeHeader, true,
                           isomericSmiles, kekuleSmiles);
@@ -104,6 +104,6 @@ struct smiwriter_wrap {
              "Returns the number of molecules written so far.\n\n");
   };
 };
-}
+}  // namespace RDKit
 
 void wrap_smiwriter() { RDKit::smiwriter_wrap::wrap(); }

--- a/Code/GraphMol/Wrap/TDTWriter.cpp
+++ b/Code/GraphMol/Wrap/TDTWriter.cpp
@@ -26,7 +26,7 @@ namespace RDKit {
 using boost_adaptbx::python::streambuf;
 TDTWriter *getTDTWriter(python::object &fileobj) {
   // FIX: minor leak here
-  auto *sb = new streambuf(fileobj);
+  auto *sb = new streambuf(fileobj, 't');
   auto *ost = new streambuf::ostream(*sb);
   return new TDTWriter(ost, true);
 }
@@ -51,8 +51,8 @@ struct tdtwriter_wrap {
         "TDTWriter", "A class for writing molecules to TDT files.\n",
         python::no_init)
         .def("__init__", python::make_constructor(&getTDTWriter))
-        .def(python::init<std::string>(python::args("fileName"),
-                                       docStr.c_str()))
+        .def(
+            python::init<std::string>(python::args("fileName"), docStr.c_str()))
         .def("SetProps", SetTDTWriterProps,
              "Sets the properties to be written to the output file\n\n"
              "  ARGUMENTS:\n\n"
@@ -86,6 +86,6 @@ struct tdtwriter_wrap {
         .def("GetNumDigits", &TDTWriter::getNumDigits);
   };
 };
-}
+}  // namespace RDKit
 
 void wrap_tdtwriter() { RDKit::tdtwriter_wrap::wrap(); }

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -3642,37 +3642,8 @@ CAS<~>
 
   def testGithub497(self):
     outf = gzip.open(tempfile.mktemp(), 'wb+')
-    m = Chem.MolFromSmiles('C')
-    w = Chem.SDWriter(outf)
-    e = False
-    try:
-      w.write(m)
-    except Exception:
-      sys.stderr.write('Opening gzip as binary fails on Python3 ' \
-        'upon writing to SDWriter without crashing the RDKit\n')
-      e = True
-    else:
-      e = (sys.version_info < (3, 0))
-    try:
-      w.close()
-    except Exception:
-      sys.stderr.write('Opening gzip as binary fails on Python3 ' \
-        'upon closing SDWriter without crashing the RDKit\n')
-      e = True
-    else:
-      if (not e):
-        e = (sys.version_info < (3, 0))
-    w = None
-    try:
-      outf.close()
-    except Exception:
-      sys.stderr.write('Opening gzip as binary fails on Python3 ' \
-        'upon closing the stream without crashing the RDKit\n')
-      e = True
-    else:
-      if (not e):
-        e = (sys.version_info < (3, 0))
-    self.assertTrue(e)
+    with self.assertRaises(ValueError):
+      w = Chem.SDWriter(outf)
 
   def testGithub498(self):
     if (sys.version_info < (3, 0)):

--- a/Code/RDBoost/python_streambuf.h
+++ b/Code/RDBoost/python_streambuf.h
@@ -26,6 +26,7 @@
 
 //#include <tbxx/error_utils.hpp>
 #include <RDGeneral/Invariant.h>
+#include <RDGeneral/Exceptions.h>
 
 #include <streambuf>
 #include <iostream>
@@ -185,6 +186,32 @@ class streambuf : public std::basic_streambuf<char> {
       off_type py_pos = bp::extract<off_type>(py_tell());
       pos_of_read_buffer_end_in_py_file = py_pos;
       pos_of_write_buffer_end_in_py_file = py_pos;
+    }
+  }
+
+  /// constructor to enforce a mode (binary or text)
+  streambuf(bp::object& python_file_obj, char mode,
+            std::size_t buffer_size_ = 0)
+      : streambuf(python_file_obj, buffer_size_) {
+    static bp::object io_mod = bp::import("io");
+    static bp::object iobase = io_mod.attr("TextIOBase");
+    bool isTextMode = PyObject_IsInstance(python_file_obj.ptr(), iobase.ptr());
+    switch (mode) {
+      case 's':  /// yeah, is redundant, but it is somehow natural to do "s"
+      case 't':
+        if (!isTextMode)
+          throw ValueErrorException(
+              "Need a text mode file object like StringIO or a file opened "
+              "with mode 't'");
+        break;
+      case 'b':
+        if (isTextMode)
+          throw ValueErrorException(
+              "Need a binary mode file object like BytesIO or a file opened "
+              "with mode 'b'");
+        break;
+      default:
+        throw std::invalid_argument("bad mode character");
     }
   }
 

--- a/Code/RDBoost/python_streambuf.h
+++ b/Code/RDBoost/python_streambuf.h
@@ -193,8 +193,24 @@ class streambuf : public std::basic_streambuf<char> {
   streambuf(bp::object& python_file_obj, char mode,
             std::size_t buffer_size_ = 0)
       : streambuf(python_file_obj, buffer_size_) {
-    static bp::object io_mod = bp::import("io");
-    static bp::object iobase = io_mod.attr("TextIOBase");
+#if 1
+    bp::object io_mod = bp::import("io");
+    CHECK_INVARIANT(io_mod,"module not found");
+    bp::object iobase = io_mod.attr("TextIOBase");;
+    CHECK_INVARIANT(iobase,"base class not found");
+#else 
+    // using statics to save an undetermined amount of time results in
+    // alarming seg faults on windows. so we don't do it. Keep this here
+    // for the moment though in case someone manages to figure that out in
+    // the future       
+    static bp::object io_mod = bp::object();
+    static bp::object iobase = bp::object();
+    if(!io_mod) io_mod = bp::import("io");
+    if(io_mod && !iobase) iobase = io_mod.attr("TextIOBase");
+    CHECK_INVARIANT(io_mod,"module not found");
+    CHECK_INVARIANT(iobase,"base class not found");
+#endif
+
     bool isTextMode = PyObject_IsInstance(python_file_obj.ptr(), iobase.ptr());
     switch (mode) {
       case 's':  /// yeah, is redundant, but it is somehow natural to do "s"


### PR DESCRIPTION
This behavior from the current code is irritating:
```
In [22]: bio = BytesIO()                                                                                               

In [23]: w = Chem.SDWriter(bio)                                                                                        

In [24]: w.write(Chem.MolFromSmiles('CC'))                                                                             

In [25]: w.close()                                                                                                     
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
TypeError: a bytes-like object is required, not 'str'

The above exception was the direct cause of the following exception:

SystemError                               Traceback (most recent call last)
<ipython-input-25-267db82f7bf0> in <module>
----> 1 w.close()

SystemError: <Boost.Python.function object at 0x55846d750dc0> returned a result with an error set
```
The error comes way too late. The same thing happens when passing a `StringIO` to things like the `ForwardSDMolSupplier`.

The PR causes a `ValueError` to be raised immediately:
```
In [10]: bio = BytesIO()                                                                                                                                 

In [11]: w = Chem.SDWriter(bio)                                                                                                                          
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-11-3ec7d729782d> in <module>
----> 1 w = Chem.SDWriter(bio)

ValueError: Need a text mode file object like StringIO or a file opened with mode 't'

In [12]: sio = StringIO()                                                                                                                                

In [13]: Chem.ForwardSDMolSupplier(sio)                                                                                                                  
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-13-d3503929d8e8> in <module>
----> 1 Chem.ForwardSDMolSupplier(sio)

ValueError: Need a binary mode file object like BytesIO or a file opened with mode 'b'
```
We can't (as far as I tell) adjust the types of these things or the way we write to them, but this seems like a second-best solution.