### PR TITLE
Adds MolFragmentToSmarts to generate smarts for a subset of a Molecule

### DIFF
--- a/Code/GraphMol/SmilesParse/SmartsWrite.h
+++ b/Code/GraphMol/SmilesParse/SmartsWrite.h
@@ -12,6 +12,7 @@
 #define _RD_SMARTSWRITE_H
 
 #include <string>
+#include <vector>
 
 namespace RDKit {
 class QueryAtom;
@@ -26,7 +27,12 @@ RDKIT_SMILESPARSE_EXPORT std::string GetBondSmarts(const QueryBond *qbond,
 
 class ROMol;
 //! returns the SMARTS for a molecule
-RDKIT_SMILESPARSE_EXPORT std::string MolToSmarts(ROMol &mol,
+RDKIT_SMILESPARSE_EXPORT std::string MolToSmarts(const ROMol &mol,
+                                                 bool doIsomericSmarts = true);
+
+RDKIT_SMILESPARSE_EXPORT std::string MolFragmentToSmarts(const ROMol &mol,
+                                                 const std::vector<int>& atomsToUse,
+                                                 const std::vector<int> *bondsToUse = nullptr,
                                                  bool doIsomericSmarts = true);
 };  // namespace RDKit
 

--- a/Code/GraphMol/SmilesParse/catch_tests.cpp
+++ b/Code/GraphMol/SmilesParse/catch_tests.cpp
@@ -443,3 +443,32 @@ TEST_CASE("github#2450: getAtomSmarts() fails for free atoms", "[bug]") {
     CHECK(smiles == ":");
   }
 }
+
+TEST_CASE("MolFragmentToSmarts", "[Smarts]")
+{
+  SECTION("BasicFragment") {
+    auto m = "CCCCCN"_smiles;
+    std::vector<int> indices = {3, 4, 5};
+    const auto smarts = MolFragmentToSmarts(*m, indices);
+    CHECK(smarts == "[#6]-[#6]-[#7]");
+  }
+  SECTION("FragmentWithParity") {
+    auto m = "C[C@H](F)CCCN"_smiles;
+    std::vector<int> indices = {0, 1, 2};
+    const auto smarts = MolFragmentToSmarts(*m, indices);
+    CHECK(smarts == "[#6]-[#6@H]-[#9]");
+  }
+  SECTION("FragmentWithSpecifiedBonds") {
+    auto m = "C1CC1O"_smiles;
+    std::vector<int> atomIndices = {0, 1, 2};
+    std::vector<int> bondIndices = {0};
+    const auto smarts = MolFragmentToSmarts(*m, atomIndices, &bondIndices);
+    CHECK(smarts == "[#6]-[#6].[#6]");
+  }
+  SECTION("SmartsFragmentFromQueryMol") {
+    auto m = "CCCC[C,N]N"_smarts;
+    std::vector<int> indices = {3, 4, 5};
+    const auto smarts = MolFragmentToSmarts(*m, indices);
+    CHECK(smarts == "C[C,N]N");
+  }
+}

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -3747,6 +3747,18 @@ CAS<~>
     am = Chem.AdjustQueryProperties(m, qps)
     self.assertEqual(Chem.MolToSmarts(am), '[#6&D2]1-[#6&D2]-[#6&D2]-[#6&D3]-1~[#8]~[#6]')
 
+  def testMolFragmentSmarts(self):
+    m = Chem.MolFromSmiles('C1CCC1OC')
+    self.assertEqual(Chem.MolFragmentToSmarts(m, [0, 1, 2]), '[#6]-[#6]-[#6]')
+    # if bondsToUse is honored, the ring won't show up
+    self.assertEqual(Chem.MolFragmentToSmarts(m, [0, 1, 2, 3], bondsToUse=[0, 1, 2, 3]), '[#6]-[#6]-[#6]-[#6]')
+
+    # Does MolFragmentToSmarts accept output of AdjustQueryProperties?
+    qps = Chem.AdjustQueryParameters()
+    qps.makeAtomsGeneric = True
+    am = Chem.AdjustQueryProperties(m, qps)
+    self.assertEqual(Chem.MolFragmentToSmarts(am, [0, 1, 2]), '*-*-*')
+
   def testAdjustQueryPropertiesgithubIssue1474(self):
     core = Chem.MolFromSmiles('[*:1]C1N([*:2])C([*:3])O1')
     core.GetAtomWithIdx(0).SetProp('foo', 'bar')


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

We have MolFragmentToSmiles already. But I think that when talking
about a fragment or part of a molecule, maybe SMARTS makes more
sense. If I see a SMILES string, I'll definitely think that
it should be a valid molecule, but I have no such
presumption about SMARTS.

Additionally, Schrodinger software sometimes generates SMARTS
for selection using a set of atoms picked in a GUI. It would
be useful to generate these SMARTS using RDKit.

#### Any other comments?
Oh, these functions should probably take ROMol by value, instead of by reference. They make an internal copy anyway, so if they took the ROMol by value, we might eliminate a couple of ROMol copies when a move is possible. Doubt this would have a noticeable effect anywhere, though.

