### PR TITLE
E/Z and CIS/TRANS stereo bonds are incorrectly matched

### DIFF
--- a/Code/GraphMol/Chirality.cpp
+++ b/Code/GraphMol/Chirality.cpp
@@ -1290,6 +1290,18 @@ void rerankAtoms(const ROMol &mol, UINT_VECT &ranks) {
   }
 #endif
 }
+
+Bond::BondStereo translateEZLabelToCisTrans(Bond::BondStereo label) {
+  switch (label) {
+    case Bond::STEREOE:
+      return Bond::STEREOTRANS;
+    case Bond::STEREOZ:
+      return Bond::STEREOCIS;
+    default:
+      return label;
+  }
+}
+
 }  // namespace Chirality
 
 namespace MolOps {

--- a/Code/GraphMol/Chirality.h
+++ b/Code/GraphMol/Chirality.h
@@ -16,10 +16,12 @@
 #ifndef _RD_CHIRALITY_20AUG2008_H_
 #define _RD_CHIRALITY_20AUG2008_H_
 #include <RDGeneral/types.h>
+#include <GraphMol/Bond.h>
 
 /// @cond
 namespace RDKit {
 class ROMol;
+
 namespace Chirality {
 /*!
   \param mol the molecule to be altered
@@ -33,6 +35,13 @@ namespace Chirality {
 */
 RDKIT_GRAPHMOL_EXPORT void assignAtomCIPRanks(const ROMol &mol,
                                               UINT_VECT &ranks);
+
+//! This just translates the labels, setting/translating StereoAtoms or the
+//! Label is not the responsibility of this function.
+//! If the passed label is not E/Z, it will be returned unchanged.
+RDKIT_GRAPHMOL_EXPORT Bond::BondStereo translateEZLabelToCisTrans(
+    Bond::BondStereo label);
+
 }  // namespace Chirality
 }  // namespace RDKit
 /// @endcond

--- a/Code/GraphMol/Substruct/SubstructMatch.cpp
+++ b/Code/GraphMol/Substruct/SubstructMatch.cpp
@@ -14,6 +14,7 @@
 #include <GraphMol/RDKitQueries.h>
 #include <GraphMol/Resonance.h>
 #include <GraphMol/MolBundle.h>
+#include "GraphMol/Chirality.h"
 
 #include "SubstructMatch.h"
 #include "SubstructUtils.h"
@@ -183,16 +184,15 @@ class MolMatchFinalCheckFunctor {
         if (c2[qMap[qBnd->getStereoAtoms()[1]]] == mBnd->getStereoAtoms()[0])
           end2Matches = 1;
       }
-      // std::cerr << "  bnd: " << qBnd->getIdx() << ":" << qBnd->getStereo()
-      //           << " - " << mBnd->getIdx() << ":" << mBnd->getStereo()
-      //           << "  --  " << end1Matches << " " << end2Matches <<
-      //           std::endl;
-      if (mBnd->getStereo() == qBnd->getStereo() &&
-          (end1Matches + end2Matches) == 1)
-        return false;
-      if (mBnd->getStereo() != qBnd->getStereo() &&
-          (end1Matches + end2Matches) != 1)
-        return false;
+
+      const unsigned totalMatches = end1Matches + end2Matches;
+      const auto mStereo =
+          Chirality::translateEZLabelToCisTrans(mBnd->getStereo());
+      const auto qStereo =
+          Chirality::translateEZLabelToCisTrans(qBnd->getStereo());
+
+      if (mStereo == qStereo && totalMatches == 1) return false;
+      if (mStereo != qStereo && totalMatches != 1) return false;
     }
 
     return true;


### PR DESCRIPTION
Example:
```python
from rdkit import Chem

mol = Chem.MolFromSmiles(r'C/C=C/C')

query = Chem.MolFromSmiles(r'C/C=C/C')
bond = query.GetBondWithIdx(1)
bond.SetStereoAtoms(0, 3)
bond.SetStereo(Chem.BondStereo.STEREOTRANS)

assert mol.HasSubstructMatch(query, useChirality=True)
-----
<ipython-input-2-63fb196a0558> in <module>()
      9 bond.SetStereo(Chem.BondStereo.STEREOTRANS)
     10 
---> 11 assert mol.HasSubstructMatch(query, useChirality=True)

AssertionError: 
```

This happens because of stereo labels are matched like this:
https://github.com/rdkit/rdkit/blob/cb64898b3d0725624138f4fcf99c9a277e89010a/Code/GraphMol/Substruct/SubstructMatch.cpp#L190-L194