### PR TITLE
Use the same criteria to flip chiral atoms in SMILES parsing/writing (Fixes #1028)

### DIFF
--- a/Code/GraphMol/Canon.cpp
+++ b/Code/GraphMol/Canon.cpp
@@ -10,12 +10,72 @@
 //
 #include <GraphMol/RDKitBase.h>
 #include <GraphMol/Canon.h>
+#include <GraphMol/SmilesParse/SmilesParseOps.h>
+#include <GraphMol/RDKitQueries.h>
 #include <RDGeneral/Exceptions.h>
 #include <RDGeneral/hash/hash.hpp>
 #include <algorithm>
 
 namespace RDKit {
 namespace Canon {
+namespace {
+bool isUnsaturated(const Atom *atom, const ROMol &mol) {
+  ROMol::OEDGE_ITER beg, end;
+  boost::tie(beg, end) = mol.getAtomBonds(atom);
+  while (beg != end) {
+    const Bond *bond = mol[*beg];
+    ++beg;
+    if (bond->getBondType() != Bond::SINGLE) return true;
+  }
+  return false;
+}
+
+bool hasSingleHQuery(const Atom::QUERYATOM_QUERY *q) {
+  // list queries are series of nested ors of AtomAtomicNum queries
+  PRECONDITION(q, "bad query");
+  bool res = false;
+  std::string descr = q->getDescription();
+  if (descr == "AtomAnd") {
+    for (auto cIt = q->beginChildren(); cIt != q->endChildren(); ++cIt) {
+      std::string descr = (*cIt)->getDescription();
+      if (descr == "AtomHCount") {
+        if (!(*cIt)->getNegation() &&
+            ((ATOM_EQUALS_QUERY *)(*cIt).get())->getVal() == 1) {
+          return true;
+        }
+        return false;
+      } else if (descr == "AtomAnd") {
+        res = hasSingleHQuery((*cIt).get());
+        if (res) return true;
+      }
+    }
+  }
+  return res;
+}
+
+bool atomHasExplicitHs(const Atom *atom) {
+  if (atom->getNumExplicitHs()) return true;
+  if (atom->hasQuery()) {
+    // the SMARTS [C@@H] produces an atom with a H query, but we also
+    // need to treat this like an explicit H for chirality purposes
+    // This was Github #1489
+    bool res = hasSingleHQuery(atom->getQuery());
+    return res;
+  }
+  return false;
+}
+}  // end of anonymous namespace
+
+bool chiralAtomNeedsTagInversion(const RDKit::ROMol &mol,
+                                 const RDKit::Atom *atom, bool isAtomFirst,
+                                 size_t numClosures) {
+  PRECONDITION(atom, "bad atom");
+  return atom->getDegree() == 3 &&
+         ((isAtomFirst && atom->getNumExplicitHs() == 1) ||
+          (!atomHasExplicitHs(atom) && numClosures == 1 &&
+           !isUnsaturated(atom, mol)));
+}
+
 struct _possibleCompare
     : public std::binary_function<PossibleType, PossibleType, bool> {
   bool operator()(const PossibleType &arg1, const PossibleType &arg2) const {
@@ -1031,8 +1091,10 @@ void canonicalizeFragment(ROMol &mol, int atomIdx,
         // Test if the atom is in current fragment
         if (trueOrder.size() > 0) {
           int nSwaps = (*atomIt)->getPerturbationOrder(trueOrder);
-          if ((*atomIt)->getDegree() == 3 &&
-              molStack.begin()->obj.atom->getIdx() == (*atomIt)->getIdx()) {
+          if (chiralAtomNeedsTagInversion(
+                  mol, *atomIt,
+                  molStack.begin()->obj.atom->getIdx() == (*atomIt)->getIdx(),
+                  atomRingClosures[(*atomIt)->getIdx()].size())) {
             // This is a special case. Here's an example:
             //   Our internal representation of a chiral center is equivalent
             //   to:

--- a/Code/GraphMol/Canon.cpp
+++ b/Code/GraphMol/Canon.cpp
@@ -53,8 +53,10 @@ bool hasSingleHQuery(const Atom::QUERYATOM_QUERY *q) {
   return res;
 }
 
-bool atomHasExplicitHs(const Atom *atom) {
-  if (atom->getNumExplicitHs()) return true;
+bool atomHasFourthValence(const Atom *atom) {
+  if (atom->getNumExplicitHs() == 1 || atom->getImplicitValence() == 1) {
+    return true;
+  }
   if (atom->hasQuery()) {
     // the SMARTS [C@@H] produces an atom with a H query, but we also
     // need to treat this like an explicit H for chirality purposes
@@ -72,7 +74,7 @@ bool chiralAtomNeedsTagInversion(const RDKit::ROMol &mol,
   PRECONDITION(atom, "bad atom");
   return atom->getDegree() == 3 &&
          ((isAtomFirst && atom->getNumExplicitHs() == 1) ||
-          (!atomHasExplicitHs(atom) && numClosures == 1 &&
+          (!atomHasFourthValence(atom) && numClosures == 1 &&
            !isUnsaturated(atom, mol)));
 }
 

--- a/Code/GraphMol/Canon.h
+++ b/Code/GraphMol/Canon.h
@@ -118,6 +118,13 @@ RDKIT_GRAPHMOL_EXPORT void canonicalizeFragment(
     const std::vector<std::string> *bondSymbols = 0,
     bool doIsomericSmiles = false, bool doRandom = false);
 
+//! Check if a chiral atom needs to have its tag flipped after reading or before
+//! writing SMILES
+RDKIT_GRAPHMOL_EXPORT bool chiralAtomNeedsTagInversion(const RDKit::ROMol &mol,
+                                                       const RDKit::Atom *atom,
+                                                       bool isAtomFirst,
+                                                       size_t numClosures);
+
 }  // end of namespace Canon
 }  // end of namespace RDKit
 #endif

--- a/Code/GraphMol/SmilesParse/test.cpp
+++ b/Code/GraphMol/SmilesParse/test.cpp
@@ -4247,6 +4247,21 @@ void testGithub2556() {
   BOOST_LOG(rdInfoLog) << "done" << std::endl;
 }
 
+void testGithub1028() {
+  BOOST_LOG(rdInfoLog) << "-------------------------------------" << std::endl;
+  BOOST_LOG(rdInfoLog) << "Testing github issue #1028: Alternating canonical SMILES for ring with chiral N"
+                       << std::endl;
+
+    const std::string smi = "C[N@]1C[C@@H](O)C1";
+    for(int i = 0; i < 3; ++i) {
+      const auto mol = std::unique_ptr<ROMol>(SmilesToMol(smi));
+      TEST_ASSERT(mol);
+      const std::string out = MolToSmiles(*mol);
+      TEST_ASSERT(out == smi);
+    }
+  BOOST_LOG(rdInfoLog) << "done" << std::endl;
+}
+
 int main(int argc, char *argv[]) {
   (void)argc;
   (void)argv;
@@ -4324,4 +4339,5 @@ int main(int argc, char *argv[]) {
   testGithub2556();
 #endif
   testdoRandomSmileGeneration();
+  testGithub1028();
 }

--- a/Code/GraphMol/SmilesParse/test.cpp
+++ b/Code/GraphMol/SmilesParse/test.cpp
@@ -2451,7 +2451,7 @@ void testBug3139534() {
     delete m;
   }
 
-  { // Github #2023
+  {  // Github #2023
     RWMol *m;
     // the initial directed bond is redundant
     std::string smiles = R"(CO/C1=C/C=C\C=C/C=N\1)";
@@ -4238,9 +4238,9 @@ void testGithub1972() {
 }
 
 void testGithub2556() {
-  BOOST_LOG(rdInfoLog)
-      << "Testing Github #2556: Test correct parsing and fix memory leak for C1C1"
-      << std::endl;  
+  BOOST_LOG(rdInfoLog) << "Testing Github #2556: Test correct parsing and fix "
+                          "memory leak for C1C1"
+                       << std::endl;
   RWMol *m = nullptr;
   m = SmilesToMol("C1C1");
   TEST_ASSERT(!m);
@@ -4249,16 +4249,31 @@ void testGithub2556() {
 
 void testGithub1028() {
   BOOST_LOG(rdInfoLog) << "-------------------------------------" << std::endl;
-  BOOST_LOG(rdInfoLog) << "Testing github issue #1028: Alternating canonical SMILES for ring with chiral N"
+  BOOST_LOG(rdInfoLog) << "Testing github issue #1028: Alternating canonical "
+                          "SMILES for ring with chiral N"
                        << std::endl;
 
-    const std::string smi = "C[N@]1C[C@@H](O)C1";
-    for(int i = 0; i < 3; ++i) {
+  {
+    const std::string smi = "O[C@H]1CC2CCC(C1)[N@@]2C";
+    const std::string ref = "C[N@]1C2CCC1C[C@H](O)C2";
+    for (int i = 0; i < 3; ++i) {
       const auto mol = std::unique_ptr<ROMol>(SmilesToMol(smi));
       TEST_ASSERT(mol);
       const std::string out = MolToSmiles(*mol);
-      TEST_ASSERT(out == smi);
+      TEST_ASSERT(out == ref);
     }
+
+    {
+      const std::string smi = "C[N@]1C[C@@H](O)C1";
+      for (int i = 0; i < 3; ++i) {
+        const auto mol = std::unique_ptr<ROMol>(SmilesToMol(smi));
+        TEST_ASSERT(mol);
+        const std::string out = MolToSmiles(*mol);
+        TEST_ASSERT(out == smi);
+      }
+    }
+  }
+
   BOOST_LOG(rdInfoLog) << "done" << std::endl;
 }
 

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -1684,7 +1684,7 @@ M  END
         Chem.AssignStereochemistry(mol, force=True)
       smi = Chem.MolToSmiles(mol, isomericSmiles=True)
       self.allStereoBonds([bond])
-      self.assertEqual(smi, "F/C=C\F")
+      self.assertEqual(smi, r"F/C=C\F")
       self.assertDoubleBondStereo(smi, Chem.BondStereo.STEREOZ)
 
   def recursive_enumerate_stereo_bonds(self, mol, done_bonds, bonds):

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -3771,7 +3771,7 @@ CAS<~>
     helm = 'PEPTIDE1{C.Y.I.Q.N.C.P.L.G}$$$$'
     seq = 'CYIQNCPLG'
     fasta = '>\nCYIQNCPLG\n'
-    smi = 'CC[C@H](C)[C@H](NC(=O)[C@H](Cc1ccc(O)cc1)NC(=O)[C@@H](N)CS)C(=O)N[C@@H](CCC(N)=O)C(=O)N[C@@H](CC(N)=O)C(=O)N[C@@H](CS)C(=O)N1CCC[C@H]1C(=O)N[C@@H](CC(C)C)C(=O)NCC(=O)O'
+    smi = 'CC[C@H](C)[C@H](NC(=O)[C@H](Cc1ccc(O)cc1)NC(=O)[C@@H](N)CS)C(=O)N[C@@H](CCC(N)=O)C(=O)N[C@@H](CC(N)=O)C(=O)N[C@@H](CS)C(=O)N1CCC[C@@H]1C(=O)N[C@@H](CC(C)C)C(=O)NCC(=O)O'
 
     m = Chem.MolFromSequence(seq)
     self.assertTrue(m is not None)

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -8,19 +8,25 @@ it's intended to be shallow, but broad
 
 """
 
-import os, sys, tempfile, gzip, gc
-import unittest, doctest
-from rdkit import RDConfig, rdBase
-from rdkit import DataStructs
-from rdkit import Chem
-import rdkit.Chem.rdDepictor
-from rdkit.Chem import rdqueries
-
-from rdkit import __version__
-
+import doctest
+import gc
+import gzip
 # Boost functions are NOT found by doctest, this "fixes" them
 #  by adding the doctests to a fake module
 import importlib.util
+import os
+import sys
+import tempfile
+import unittest
+
+import rdkit.Chem.rdDepictor
+from rdkit import Chem
+from rdkit import DataStructs
+from rdkit import RDConfig
+from rdkit import __version__
+from rdkit import rdBase
+from rdkit.Chem import rdqueries
+
 spec = importlib.util.spec_from_loader("TestReplaceCore", loader=None)
 TestReplaceCore = importlib.util.module_from_spec(spec)
 code = """
@@ -3771,7 +3777,7 @@ CAS<~>
     helm = 'PEPTIDE1{C.Y.I.Q.N.C.P.L.G}$$$$'
     seq = 'CYIQNCPLG'
     fasta = '>\nCYIQNCPLG\n'
-    smi = 'CC[C@H](C)[C@H](NC(=O)[C@H](Cc1ccc(O)cc1)NC(=O)[C@@H](N)CS)C(=O)N[C@@H](CCC(N)=O)C(=O)N[C@@H](CC(N)=O)C(=O)N[C@@H](CS)C(=O)N1CCC[C@@H]1C(=O)N[C@@H](CC(C)C)C(=O)NCC(=O)O'
+    smi = 'CC[C@H](C)[C@H](NC(=O)[C@H](Cc1ccc(O)cc1)NC(=O)[C@@H](N)CS)C(=O)N[C@@H](CCC(N)=O)C(=O)N[C@@H](CC(N)=O)C(=O)N[C@@H](CS)C(=O)N1CCC[C@H]1C(=O)N[C@@H](CC(C)C)C(=O)NCC(=O)O'
 
     m = Chem.MolFromSequence(seq)
     self.assertTrue(m is not None)

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -8,25 +8,19 @@ it's intended to be shallow, but broad
 
 """
 
-import doctest
-import gc
-import gzip
+import os, sys, tempfile, gzip, gc
+import unittest, doctest
+from rdkit import RDConfig, rdBase
+from rdkit import DataStructs
+from rdkit import Chem
+import rdkit.Chem.rdDepictor
+from rdkit.Chem import rdqueries
+
+from rdkit import __version__
+
 # Boost functions are NOT found by doctest, this "fixes" them
 #  by adding the doctests to a fake module
 import importlib.util
-import os
-import sys
-import tempfile
-import unittest
-
-import rdkit.Chem.rdDepictor
-from rdkit import Chem
-from rdkit import DataStructs
-from rdkit import RDConfig
-from rdkit import __version__
-from rdkit import rdBase
-from rdkit.Chem import rdqueries
-
 spec = importlib.util.spec_from_loader("TestReplaceCore", loader=None)
 TestReplaceCore = importlib.util.module_from_spec(spec)
 code = """


### PR DESCRIPTION
Explanation of the problem is in the comments of Issue #1028 . But it summarizes into that SMILES parsing and writing were using different criteria to decide if the chiral tag of an atom had to be flipped or not.

This PR moves the code to decide whether to flip a chiral atom into Canon.cpp, and uses the same function to check chiral atoms at writing and parsing of SMILES strings.

I have not checked the change in the python test, but both strings seem to be "stable" and not flip on roundtripping the SMILES -- if the fix of the reference is wrong, then maybe the algorithm to decide the flipping is not quite correct.