### PR TITLE
Fix/github2611

### DIFF
--- a/Code/GraphMol/Wrap/rdmolfiles.cpp
+++ b/Code/GraphMol/Wrap/rdmolfiles.cpp
@@ -1299,6 +1299,8 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
     - atomSymbols : (optional) a list with the symbols to use for the atoms\n\
       in the SMILES. This should have be mol.GetNumAtoms() long.\n\
     - breakTies: (optional) force breaking of ranked ties\n\
+    - includeChirality: (optional) use chiral information when computing rank [default=True]\n\
+    - includeIsotopes: (optional) use isotope information when computing rank [default=True]\n\
 \n\
   RETURNS:\n\
 \n\

--- a/Code/GraphMol/Wrap/rdmolfiles.cpp
+++ b/Code/GraphMol/Wrap/rdmolfiles.cpp
@@ -316,8 +316,9 @@ std::vector<int> CanonicalRankAtomsInFragment(const ROMol &mol,
                                               python::object atomsToUse,
                                               python::object bondsToUse,
                                               python::object atomSymbols,
-                                              python::object bondSymbols,
-                                              bool breakTies = true)
+                                              bool breakTies = true,
+					      bool includeChirality = true,
+					      bool includeIsotopes = true)
 
 {
   std::unique_ptr<std::vector<int>> avect =
@@ -329,13 +330,8 @@ std::vector<int> CanonicalRankAtomsInFragment(const ROMol &mol,
       pythonObjectToVect(bondsToUse, static_cast<int>(mol.getNumBonds()));
   std::unique_ptr<std::vector<std::string>> asymbols =
       pythonObjectToVect<std::string>(atomSymbols);
-  std::unique_ptr<std::vector<std::string>> bsymbols =
-      pythonObjectToVect<std::string>(bondSymbols);
   if (asymbols.get() && asymbols->size() != mol.getNumAtoms()) {
     throw_value_error("length of atom symbol list != number of atoms");
-  }
-  if (bsymbols.get() && bsymbols->size() != mol.getNumBonds()) {
-    throw_value_error("length of bond symbol list != number of bonds");
   }
 
   boost::dynamic_bitset<> atoms(mol.getNumAtoms());
@@ -347,7 +343,7 @@ std::vector<int> CanonicalRankAtomsInFragment(const ROMol &mol,
 
   std::vector<unsigned int> ranks(mol.getNumAtoms());
   Canon::rankFragmentAtoms(mol, ranks, atoms, bonds, asymbols.get(),
-                           bsymbols.get(), breakTies);
+                           breakTies, includeChirality, includeIsotopes);
 
   std::vector<int> resRanks(mol.getNumAtoms());
   // set unused ranks to -1 for the Python interface
@@ -1302,8 +1298,6 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
       will be included.\n\
     - atomSymbols : (optional) a list with the symbols to use for the atoms\n\
       in the SMILES. This should have be mol.GetNumAtoms() long.\n\
-    - bondSymbols : (optional) a list with the symbols to use for the bonds\n\
-      in the SMILES. This should have be mol.GetNumBonds() long.\n\
     - breakTies: (optional) force breaking of ranked ties\n\
 \n\
   RETURNS:\n\
@@ -1313,7 +1307,9 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
   python::def("CanonicalRankAtomsInFragment", CanonicalRankAtomsInFragment,
               (python::arg("mol"), python::arg("atomsToUse"),
                python::arg("bondsToUse") = 0, python::arg("atomSymbols") = 0,
-               python::arg("bondSymbols") = 0, python::arg("breakTies") = true),
+               python::arg("breakTies") = true,
+	       python::arg("includeChirality") = true,
+               python::arg("includeIsotopes") = true),
               docString.c_str());
 
   python::def(

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -5522,8 +5522,9 @@ H      0.635000    0.635000    0.635000
       atom.SetIsotope(atom.GetIdx())
     
     order1 = list(Chem.CanonicalRankAtomsInFragment(mol, atomsToUse=range(0, 4), breakTies=False, includeIsotopes=True))
-    order2 = list(Chem.CanonicalRankAtomsInFragment(mol, atomsToUse=range(4, 8), breakTies=False, includeIsotopes=False))
+    order2 = list(Chem.CanonicalRankAtomsInFragment(mol, atomsToUse=range(0, 8), breakTies=False, includeIsotopes=False))
     self.assertNotEqual(order1[:4], order2[4:])
+    # ensure that the orders are ignored in the second batch
     self.assertEqual(order2[:4], order2[4:])
 
   

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -3471,13 +3471,8 @@ CAS<~>
       list(Chem.CanonicalRankAtomsInFragment(mol, atomsToUse=range(4, 8), breakTies=True)),
       [-1, -1, -1, -1, 4, 6, 4, 6])
 
-    for atom in mol.GetAtoms():
-      atom.SetIsotope(atom.GetIdx())
-
-    order1 = list(Chem.CanonicalRankAtomsInFragment(mol, atomsToUse=range(0, 4), breakTies=False, includeIsotopes=True))
-    order2 = list(Chem.CanonicalRankAtomsInFragment(mol, atomsToUse=range(4, 8), breakTies=False, includeIsotopes=False))
-    self.assertNotEqual(order1[:4], order2[4:])
     
+
 
   def test93RWMolsAsROMol(self):
     """ test the RWMol class as a proper ROMol
@@ -5521,6 +5516,31 @@ H      0.635000    0.635000    0.635000
 
     self.assertEqual(Chem.MolToXYZBlock(mol), xyzblock_expected)
 
+  def testGithub2611(self):
+    mol = Chem.MolFromSmiles('ONCS.ONCS')
+    for atom in mol.GetAtoms():
+      atom.SetIsotope(atom.GetIdx())
+    
+    order1 = list(Chem.CanonicalRankAtomsInFragment(mol, atomsToUse=range(0, 4), breakTies=False, includeIsotopes=True))
+    order2 = list(Chem.CanonicalRankAtomsInFragment(mol, atomsToUse=range(4, 8), breakTies=False, includeIsotopes=False))
+    self.assertNotEqual(order1[:4], order2[4:])
+
+  
+    for smi in ['ONCS.ONCS', 'F[C@@H](Br)[C@H](F)Cl']:
+      mol = Chem.MolFromSmiles(smi)
+      for atom in mol.GetAtoms():
+        atom.SetIsotope(atom.GetIdx())
+
+        for iso,chiral in [(True,True),(True,False),(False,True), (False,False)]:
+          order1 = list(Chem.CanonicalRankAtomsInFragment(mol, atomsToUse=range(0, mol.GetNumAtoms()), bondsToUse=range(0,mol.GetNumBonds()),
+                                                          breakTies=False, includeIsotopes=iso, includeChirality=chiral))
+          order2 = list(Chem.CanonicalRankAtomsInFragment(mol, atomsToUse=range(0, mol.GetNumAtoms()), bondsToUse=range(0,mol.GetNumBonds()),
+                                                          breakTies=True, includeIsotopes=iso, includeChirality=chiral))
+          order3 = list(Chem.CanonicalRankAtoms(mol, breakTies=False, includeIsotopes=iso, includeChirality=chiral))
+          order4 = list(Chem.CanonicalRankAtoms(mol, breakTies=True, includeIsotopes=iso, includeChirality=chiral))
+          self.assertEqual(order1,order3)
+          self.assertEqual(order2,order4)
+    
 
 if __name__ == '__main__':
   if "RDTESTCASE" in os.environ:

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -5524,6 +5524,7 @@ H      0.635000    0.635000    0.635000
     order1 = list(Chem.CanonicalRankAtomsInFragment(mol, atomsToUse=range(0, 4), breakTies=False, includeIsotopes=True))
     order2 = list(Chem.CanonicalRankAtomsInFragment(mol, atomsToUse=range(4, 8), breakTies=False, includeIsotopes=False))
     self.assertNotEqual(order1[:4], order2[4:])
+    self.assertEqual(order2[:4], order2[4:])
 
   
     for smi in ['ONCS.ONCS', 'F[C@@H](Br)[C@H](F)Cl']:

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -3461,9 +3461,23 @@ CAS<~>
     self.assertEqual(
       list(Chem.CanonicalRankAtomsInFragment(mol, atomsToUse=range(0, 4), breakTies=False)),
       [4, 6, 4, 6, -1, -1, -1, -1])
+    self.assertNotEqual(
+      list(Chem.CanonicalRankAtomsInFragment(mol, atomsToUse=range(0, 4), breakTies=True)),
+      [4, 6, 4, 6, -1, -1, -1, -1])
     self.assertEqual(
       list(Chem.CanonicalRankAtomsInFragment(mol, atomsToUse=range(4, 8), breakTies=False)),
       [-1, -1, -1, -1, 4, 6, 4, 6])
+    self.assertNotEqual(
+      list(Chem.CanonicalRankAtomsInFragment(mol, atomsToUse=range(4, 8), breakTies=True)),
+      [-1, -1, -1, -1, 4, 6, 4, 6])
+
+    for atom in mol.GetAtoms():
+      atom.SetIsotope(atom.GetIdx())
+
+    order1 = list(Chem.CanonicalRankAtomsInFragment(mol, atomsToUse=range(0, 4), breakTies=False, includeIsotopes=True))
+    order2 = list(Chem.CanonicalRankAtomsInFragment(mol, atomsToUse=range(4, 8), breakTies=False, includeIsotopes=False))
+    self.assertNotEqual(order1[:4], order2[4:])
+    
 
   def test93RWMolsAsROMol(self):
     """ test the RWMol class as a proper ROMol


### PR DESCRIPTION
fixes #2611 

Since we are breaking the api, also exposes includeIsotopes/Chirality to python for CanonicalRankAtomsInFragments.