### PR TITLE
Rework MaeMolSupplier, fix #2617

### DIFF
--- a/Code/GraphMol/FileParsers/MaeMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/MaeMolSupplier.cpp
@@ -10,6 +10,7 @@
 #include <iostream>
 #include <fstream>
 #include <map>
+
 #include <RDGeneral/BadFileException.h>
 #include <RDGeneral/FileParseException.h>
 #include <GraphMol/MolInterchange/details.h>
@@ -17,16 +18,333 @@
 #include <GraphMol/MonomerInfo.h>
 #include <GraphMol/RWMol.h>
 #include <GraphMol/FileParsers/MolSupplier.h>
+#include <GraphMol/FileParsers/FileParserUtils.h>
+
+#include <boost/tokenizer.hpp>
+
+#include <maeparser/MaeConstants.hpp>
 #include <maeparser/Reader.hpp>
 
-using std::shared_ptr;
-using namespace schrodinger::mae;
+using namespace schrodinger;
+using RDKit::MolInterchange::bolookup;
 
 namespace RDKit {
 
-using RDKit::MolInterchange::bolookup;
+namespace {
 
-MaeMolSupplier::MaeMolSupplier(shared_ptr<std::istream> inStream,
+const std::string PDB_ATOM_NAME = "s_m_pdb_atom_name";
+const std::string PDB_RESIDUE_NAME = "s_m_pdb_residue_name";
+const std::string PDB_CHAIN_NAME = "s_m_chain_name";
+const std::string PDB_INSERTION_CODE = "s_m_insertion_code";
+const std::string PDB_RESIDUE_NUMBER = "i_m_residue_number";
+const std::string PDB_OCCUPANCY = "r_m_pdb_occupancy";
+const std::string PDB_TFACTOR = "r_m_pdb_tfactor";
+
+class PDBInfo {
+ public:
+  PDBInfo(const mae::IndexedBlock &atom_block) {
+    try {
+      m_atom_name = atom_block.getStringProperty(PDB_ATOM_NAME);
+    } catch (std::out_of_range &) {
+    }
+
+    try {
+      m_residue_name = atom_block.getStringProperty(PDB_RESIDUE_NAME);
+    } catch (std::out_of_range &) {
+    }
+
+    try {
+      m_chain_id = atom_block.getStringProperty(PDB_CHAIN_NAME);
+    } catch (std::out_of_range &) {
+    }
+
+    try {
+      m_insertion_code = atom_block.getStringProperty(PDB_INSERTION_CODE);
+    } catch (std::out_of_range &) {
+    }
+
+    try {
+      m_resnum = atom_block.getIntProperty(PDB_RESIDUE_NUMBER);
+    } catch (std::out_of_range &) {
+    }
+
+    try {
+      m_occupancy = atom_block.getRealProperty(PDB_OCCUPANCY);
+    } catch (std::out_of_range &) {
+    }
+
+    try {
+      m_tempfac = atom_block.getRealProperty(PDB_TFACTOR);
+    } catch (std::out_of_range &) {
+    }
+  }
+
+  void addPDBData(Atom *atom, size_t atom_num) {
+    if (!m_atom_name || !m_atom_name->isDefined(atom_num)) {
+      return;  // Need a PDB atom name to populate info
+    }
+    AtomPDBResidueInfo *rd_info =
+        new AtomPDBResidueInfo(m_atom_name->at(atom_num));
+
+    atom->setMonomerInfo(rd_info);
+
+    if (m_residue_name && m_residue_name->isDefined(atom_num)) {
+      rd_info->setResidueName(m_residue_name->at(atom_num));
+    }
+
+    if (m_chain_id && m_chain_id->isDefined(atom_num)) {
+      rd_info->setChainId(m_chain_id->at(atom_num));
+    }
+
+    if (m_insertion_code && m_insertion_code->isDefined(atom_num)) {
+      rd_info->setInsertionCode(m_insertion_code->at(atom_num));
+    }
+
+    if (m_resnum && m_resnum->isDefined(atom_num)) {
+      rd_info->setResidueNumber(m_resnum->at(atom_num));
+    }
+
+    if (m_occupancy && m_occupancy->isDefined(atom_num)) {
+      rd_info->setOccupancy(m_occupancy->at(atom_num));
+    }
+
+    if (m_tempfac && m_tempfac->isDefined(atom_num)) {
+      rd_info->setTempFactor(m_tempfac->at(atom_num));
+    }
+  }
+
+ private:
+  std::shared_ptr<mae::IndexedStringProperty> m_atom_name;
+  std::shared_ptr<mae::IndexedStringProperty> m_residue_name;
+  std::shared_ptr<mae::IndexedStringProperty> m_chain_id;
+  std::shared_ptr<mae::IndexedStringProperty> m_insertion_code;
+
+  std::shared_ptr<mae::IndexedIntProperty> m_resnum;
+
+  std::shared_ptr<mae::IndexedRealProperty> m_occupancy;
+  std::shared_ptr<mae::IndexedRealProperty> m_tempfac;
+};
+
+bool streamIsGoodOrExhausted(std::istream *stream) {
+  PRECONDITION(stream, "bad stream");
+  return stream->good() || (stream->eof() && stream->fail() && !stream->bad());
+}
+
+void parseChiralityLabel(RWMol &mol, const std::string &stereo_prop) {
+  boost::char_separator<char> sep{"_"};
+  boost::tokenizer<boost::char_separator<char>> tokenizer{stereo_prop, sep};
+
+  auto tItr = tokenizer.begin();
+
+  const int chiral_idx = FileParserUtils::toInt(*tItr) - 1;
+  Atom *chiral_atom = mol.getAtomWithIdx(chiral_idx);
+  CHECK_INVARIANT(chiral_atom != nullptr, "bad prop value");
+
+  unsigned nSwaps = 2;
+  switch (*((++tItr)->rbegin())) {
+    case 'R':  // R, ANR
+      nSwaps = 0;
+      break;
+    case 'S':  // S, ANS
+      nSwaps = 1;
+      break;
+    default:
+      break;
+  }
+  CHECK_INVARIANT(nSwaps < 2, "bad prop value");
+
+  INT_LIST bond_indexes;
+  for (++tItr; tItr != tokenizer.end(); ++tItr) {
+    const int nbr_idx = FileParserUtils::toInt(*tItr) - 1;
+    const Bond *bnd = mol.getBondBetweenAtoms(chiral_idx, nbr_idx);
+    bond_indexes.push_back(bnd->getIdx());
+  }
+  CHECK_INVARIANT(bond_indexes.size() == chiral_atom->getDegree(),
+                  "bad prop value");
+
+  nSwaps += chiral_atom->getPerturbationOrder(bond_indexes);
+  switch (nSwaps % 2) {
+    case 0:
+      chiral_atom->setChiralTag(Atom::CHI_TETRAHEDRAL_CW);
+      break;
+    case 1:
+      chiral_atom->setChiralTag(Atom::CHI_TETRAHEDRAL_CCW);
+      break;
+  }
+}
+
+void parseStereoBondLabel(RWMol &mol, const std::string &stereo_prop) {
+  boost::char_separator<char> sep{"_"};
+  boost::tokenizer<boost::char_separator<char>> tokenizer{stereo_prop, sep};
+
+  Bond::BondStereo type = Bond::STEREONONE;
+  std::vector<int> atom_indexes;
+  for (const auto &t : tokenizer) {
+    if (t == "E") {
+      type = Bond::STEREOTRANS;
+    } else if (t == "Z") {
+      type = Bond::STEREOCIS;
+    } else {
+      // Atom indexes are 0-based in RDKit, and 1-based in Mae.
+      atom_indexes.push_back(FileParserUtils::toInt(t) - 1);
+    }
+  }
+  CHECK_INVARIANT(type != Bond::STEREONONE, "bad prop value");
+
+  // We currently don't support allenes or allene-likes
+  if (atom_indexes.size() != 4) {
+    return;
+  }
+
+  auto *bond = mol.getBondBetweenAtoms(atom_indexes[1], atom_indexes[2]);
+  CHECK_INVARIANT(bond, "bad stereo bond");
+  CHECK_INVARIANT(bond->getBondType() == Bond::DOUBLE, "bad stereo bond");
+
+  bond->setStereoAtoms(atom_indexes[0], atom_indexes[3]);
+  bond->setStereo(type);
+}
+
+//! Copy over the structure properties, including stereochemistry.
+void set_mol_properties(RWMol &mol, const mae::Block &ct_block) {
+  for (const auto &prop : ct_block.getProperties<std::string>()) {
+    if (prop.first == mae::CT_TITLE) {
+      mol.setProp(common_properties::_Name, prop.second);
+    } else if (prop.first.find(mae::CT_CHIRALITY_PROP_PREFIX) == 0 ||
+               prop.first.find(mae::CT_PSEUDOCHIRALITY_PROP_PREFIX) == 0) {
+      parseChiralityLabel(mol, prop.second);
+    } else if (prop.first.find(mae::CT_EZ_PROP_PREFIX) == 0) {
+      parseStereoBondLabel(mol, prop.second);
+    } else {
+      mol.setProp(prop.first, prop.second);
+    }
+  }
+  for (const auto &prop : ct_block.getProperties<double>()) {
+    mol.setProp(prop.first, prop.second);
+  }
+  for (const auto &prop : ct_block.getProperties<int>()) {
+    mol.setProp(prop.first, prop.second);
+  }
+  for (const auto &prop : ct_block.getProperties<mae::BoolProperty>()) {
+    mol.setProp(prop.first, static_cast<bool>(prop.second));
+  }
+}
+
+//! Set atom properties. Some of these have already been parsed to construct the
+//! Atom object, and should be skipped. Also, atom properties may be undefined
+//! for an atom, and should also be skipped for that atom.
+void set_atom_properties(Atom &atom, const mae::IndexedBlock &atom_block,
+                         size_t i) {
+  for (const auto &prop : atom_block.getProperties<std::string>()) {
+    if (prop.first == PDB_ATOM_NAME || prop.first == PDB_RESIDUE_NAME ||
+        prop.first == PDB_CHAIN_NAME || prop.first == PDB_INSERTION_CODE) {
+      // PDB information is parsed separately.
+      continue;
+    } else if (!prop.second->isDefined(i)) {
+      continue;
+    }
+
+    atom.setProp(prop.first, prop.second->at(i));
+  }
+
+  for (const auto &prop : atom_block.getProperties<double>()) {
+    if (prop.first == mae::ATOM_X_COORD || prop.first == mae::ATOM_Y_COORD ||
+        // Coordinates are used in defining a conformation, and should not be
+        // set on the atom.
+        prop.first == mae::ATOM_Z_COORD) {
+      continue;
+    } else if (prop.first == PDB_OCCUPANCY || prop.first == PDB_TFACTOR) {
+      // PDB information is parsed separately.
+      continue;
+    } else if (!prop.second->isDefined(i)) {
+      continue;
+    }
+
+    atom.setProp(prop.first, prop.second->at(i));
+  }
+  for (const auto &prop : atom_block.getProperties<int>()) {
+    if (prop.first == mae::ATOM_ATOMIC_NUM) {
+      // Atomic number was already used in the creation of the atom
+      continue;
+    } else if (prop.first == PDB_RESIDUE_NUMBER) {
+      // PDB information is parsed separately.
+      continue;
+    } else if (!prop.second->isDefined(i)) {
+      continue;
+    }
+
+    if (prop.first == mae::ATOM_FORMAL_CHARGE) {
+      // Formal charge has a specific setter
+      atom.setFormalCharge(prop.second->at(i));
+    } else {
+      atom.setProp(prop.first, prop.second->at(i));
+    }
+  }
+  for (const auto &prop : atom_block.getProperties<mae::BoolProperty>()) {
+    if (!prop.second->isDefined(i)) {
+      continue;
+    }
+
+    atom.setProp(prop.first, static_cast<bool>(prop.second->at(i)));
+  }
+}
+
+void addAtoms(const mae::IndexedBlock &atom_block, RWMol &mol) {
+  // All atoms are guaranteed to have these three field names:
+  const auto atomic_numbers = atom_block.getIntProperty(mae::ATOM_ATOMIC_NUM);
+  const auto xs = atom_block.getRealProperty(mae::ATOM_X_COORD);
+  const auto ys = atom_block.getRealProperty(mae::ATOM_Y_COORD);
+  const auto zs = atom_block.getRealProperty(mae::ATOM_Z_COORD);
+
+  std::shared_ptr<mae::IndexedIntProperty> atomic_charges;
+
+  // atomic numbers, and x, y, and z coordinates
+  const auto size = atomic_numbers->size();
+  auto conf = new RDKit::Conformer(size);
+  conf->set3D(true);
+  conf->setId(0);
+
+  PDBInfo pdb_info(atom_block);
+
+  for (size_t i = 0; i < size; ++i) {
+    Atom *atom = new Atom(atomic_numbers->at(i));
+    mol.addAtom(atom, true, true);
+
+    pdb_info.addPDBData(atom, i);
+    set_atom_properties(*atom, atom_block, i);
+
+    RDGeom::Point3D pos;
+    pos.x = xs->at(i);
+    pos.y = ys->at(i);
+    pos.z = zs->at(i);
+    conf->setAtomPos(i, pos);
+  }
+  mol.addConformer(conf, false);
+}
+
+void addBonds(const mae::IndexedBlock &bond_block, RWMol &mol) {
+  // All bonds are guaranteed to have these three field names:
+  const auto from_atoms = bond_block.getIntProperty(mae::BOND_ATOM_1);
+  const auto to_atoms = bond_block.getIntProperty(mae::BOND_ATOM_2);
+  const auto orders = bond_block.getIntProperty(mae::BOND_ORDER);
+  const auto size = from_atoms->size();
+
+  for (size_t i = 0; i < size; ++i) {
+    // Maestro atoms are 1 indexed!
+    const auto from_atom = from_atoms->at(i) - 1;
+    const auto to_atom = to_atoms->at(i) - 1;
+    const auto order = bolookup.find(orders->at(i))->second;
+    if (from_atom > to_atom) continue;  // Maestro files double-list bonds
+
+    auto bond = new Bond(order);
+    bond->setOwningMol(mol);
+    bond->setBeginAtomIdx(from_atom);
+    bond->setEndAtomIdx(to_atom);
+    mol.addBond(bond, true);
+  }
+}
+}  // namespace
+
+MaeMolSupplier::MaeMolSupplier(std::shared_ptr<std::istream> inStream,
                                bool sanitize, bool removeHs) {
   PRECONDITION(inStream, "bad stream");
   dp_sInStream = inStream;
@@ -35,8 +353,14 @@ MaeMolSupplier::MaeMolSupplier(shared_ptr<std::istream> inStream,
   df_sanitize = sanitize;
   df_removeHs = removeHs;
 
-  d_reader.reset(new Reader(dp_sInStream));
-  d_next_struct = d_reader->next("f_m_ct");
+  d_reader.reset(new mae::Reader(dp_sInStream));
+  CHECK_INVARIANT(streamIsGoodOrExhausted(dp_inStream), "bad instream");
+
+  try {
+    d_next_struct = d_reader->next(mae::CT_BLOCK);
+  } catch (const mae::read_exception &e) {
+    throw FileParseException(e.what());
+  }
 }
 
 MaeMolSupplier::MaeMolSupplier(std::istream *inStream, bool takeOwnership,
@@ -49,8 +373,14 @@ MaeMolSupplier::MaeMolSupplier(std::istream *inStream, bool takeOwnership,
   df_sanitize = sanitize;
   df_removeHs = removeHs;
 
-  d_reader.reset(new Reader(dp_sInStream));
-  d_next_struct = d_reader->next("f_m_ct");
+  d_reader.reset(new mae::Reader(dp_sInStream));
+  CHECK_INVARIANT(streamIsGoodOrExhausted(dp_inStream), "bad instream");
+
+  try {
+    d_next_struct = d_reader->next(mae::CT_BLOCK);
+  } catch (const mae::read_exception &e) {
+    throw FileParseException(e.what());
+  }
 }
 
 MaeMolSupplier::MaeMolSupplier(const std::string &fileName, bool sanitize,
@@ -67,186 +397,37 @@ MaeMolSupplier::MaeMolSupplier(const std::string &fileName, bool sanitize,
   df_sanitize = sanitize;
   df_removeHs = removeHs;
 
-  d_reader.reset(new Reader(dp_sInStream));
-  d_next_struct = d_reader->next("f_m_ct");
+  d_reader.reset(new mae::Reader(dp_sInStream));
+  CHECK_INVARIANT(streamIsGoodOrExhausted(dp_inStream), "bad instream");
+
+  try {
+    d_next_struct = d_reader->next(mae::CT_BLOCK);
+  } catch (const mae::read_exception &e) {
+    throw FileParseException(e.what());
+  }
 }
 
 void MaeMolSupplier::init() {}
 void MaeMolSupplier::reset() {}
 
-class PDBInfo
-{
-public:
-    PDBInfo(const shared_ptr<const IndexedBlock>& atom_data);
-
-    shared_ptr<IndexedStringProperty> m_atom_name;
-    shared_ptr<IndexedStringProperty> m_residue_name;
-    shared_ptr<IndexedStringProperty> m_chain_id;
-    shared_ptr<IndexedStringProperty> m_insertion_code;
-
-    shared_ptr<IndexedIntProperty> m_resnum;
-
-    shared_ptr<IndexedRealProperty> m_occupancy;
-    shared_ptr<IndexedRealProperty> m_tempfac;
-
-};
-
-PDBInfo::PDBInfo(const shared_ptr<const IndexedBlock>& atom_data)
-{
-    try {
-    m_atom_name = atom_data->getStringProperty("s_m_pdb_atom_name");
-    } catch (std::out_of_range &) { }
-
-    try {
-    m_residue_name = atom_data->getStringProperty("s_m_pdb_residue_name");
-    } catch (std::out_of_range &) { }
-
-    try {
-    m_chain_id = atom_data->getStringProperty("s_m_chain_name");
-    } catch (std::out_of_range &) { }
-
-    try {
-    m_insertion_code = atom_data->getStringProperty("s_m_insertion_code");
-    } catch (std::out_of_range &) { }
-
-    try {
-    m_resnum = atom_data->getIntProperty("i_m_residue_number");
-    } catch (std::out_of_range &) { }
-
-    try {
-    m_occupancy = atom_data->getRealProperty("r_m_pdb_occupancy");
-    } catch (std::out_of_range &) { }
-
-    try {
-    m_tempfac = atom_data->getRealProperty("r_m_pdb_tfactor");
-    } catch (std::out_of_range &) { }
-}
-
-void addAtomPDBData(const PDBInfo& pdb_info, Atom* atom, size_t atom_num)
-{
-    if(!pdb_info.m_atom_name->isDefined(atom_num)) {
-        return;  // Need a PDB atom name to populate info
-    }
-    AtomPDBResidueInfo *rd_info = new AtomPDBResidueInfo(
-            pdb_info.m_atom_name->at(atom_num));
-
-    atom->setMonomerInfo(rd_info);
-
-    if(pdb_info.m_residue_name && pdb_info.m_residue_name->isDefined(atom_num))
-    {
-        rd_info->setResidueName(pdb_info.m_residue_name->at(atom_num));
-    }
-
-    if(pdb_info.m_chain_id && pdb_info.m_chain_id->isDefined(atom_num))
-    {
-        rd_info->setChainId(pdb_info.m_chain_id->at(atom_num));
-    }
-
-    if(pdb_info.m_insertion_code &&
-            pdb_info.m_insertion_code->isDefined(atom_num))
-    {
-        rd_info->setInsertionCode(pdb_info.m_insertion_code->at(atom_num));
-    }
-
-    if(pdb_info.m_resnum && pdb_info.m_resnum->isDefined(atom_num))
-    {
-        rd_info->setResidueNumber(pdb_info.m_resnum->at(atom_num));
-    }
-
-    if(pdb_info.m_occupancy && pdb_info.m_occupancy->isDefined(atom_num))
-    {
-        rd_info->setOccupancy(pdb_info.m_occupancy->at(atom_num));
-    }
-
-    if(pdb_info.m_tempfac && pdb_info.m_tempfac->isDefined(atom_num))
-    {
-        rd_info->setTempFactor(pdb_info.m_tempfac->at(atom_num));
-    }
-}
-
-void addAtoms(shared_ptr<Block>& current_struct, RWMol& mol)
-{
-  // Atom data is in the m_atom indexed block
-  {
-    const auto atom_data = current_struct->getIndexedBlock("m_atom");
-    // All atoms are guaranteed to have these three field names:
-    const auto atomic_numbers = atom_data->getIntProperty("i_m_atomic_number");
-    const auto xs = atom_data->getRealProperty("r_m_x_coord");
-    const auto ys = atom_data->getRealProperty("r_m_y_coord");
-    const auto zs = atom_data->getRealProperty("r_m_z_coord");
-    const auto atom_count = atomic_numbers->size();
-    shared_ptr<IndexedIntProperty> atomic_charges;
-    try {
-      atomic_charges = atom_data->getIntProperty("i_m_formal_charge");
-    } catch (std::out_of_range &) {
-    }
-
-    // atomic numbers, and x, y, and z coordinates
-    auto conf = new RDKit::Conformer(atom_count);
-    conf->set3D(true);
-    conf->setId(0);
-    PDBInfo pdb_info(atom_data);
-    for (size_t i = 0; i < atom_count; ++i) {
-      Atom *atom = new Atom(atomic_numbers->at(i));
-      mol.addAtom(atom, true, true);
-      if (atomic_charges) {
-        atom->setFormalCharge(atomic_charges->at(i));
-      }
-
-      RDGeom::Point3D pos;
-      pos.x = xs->at(i);
-      pos.y = ys->at(i);
-      pos.z = zs->at(i);
-      conf->setAtomPos(i, pos);
-
-      if(pdb_info.m_atom_name) {
-          addAtomPDBData(pdb_info, atom, i);
-      }
-    }
-    mol.addConformer(conf, false);
-  }
-
-}
-
-void addBonds(shared_ptr<Block>& current_struct, RWMol& mol)
-{
-    const auto bond_data = current_struct->getIndexedBlock("m_bond");
-    // All bonds are guaranteed to have these three field names:
-    auto from_atoms = bond_data->getIntProperty("i_m_from");
-    auto to_atoms = bond_data->getIntProperty("i_m_to");
-    auto orders = bond_data->getIntProperty("i_m_order");
-    const auto size = from_atoms->size();
-
-    for (size_t i = 0; i < size; ++i) {
-        // Maestro atoms are 1 indexed!
-        const auto from_atom = from_atoms->at(i) - 1;
-        const auto to_atom = to_atoms->at(i) - 1;
-        const auto order = bolookup.find(orders->at(i))->second;
-        if (from_atom > to_atom) continue;  // Maestro files double-list bonds
-
-        auto bond = new Bond(order);
-        bond->setOwningMol(mol);
-        bond->setBeginAtomIdx(from_atom);
-        bond->setEndAtomIdx(to_atom);
-        mol.addBond(bond, true);
-    }
-}
-
-
 ROMol *MaeMolSupplier::next() {
-  if (d_next_struct == nullptr) {
+  if (!d_stored_exc.empty()) {
+    throw FileParseException(d_stored_exc);
+  } else if (atEnd()) {
     throw FileParseException("All structures read from Maestro file");
   }
-  // Make sure even if later calls except, we're ready to read the next struct
-  auto current_struct = d_next_struct;
-  d_next_struct = d_reader->next("f_m_ct");
 
-  auto mol = new RWMol();
-  auto mol_title = current_struct->getStringProperty("s_m_title");
-  mol->setProp(common_properties::_Name, mol_title);
+  auto *mol = new RWMol();
 
-  addAtoms(current_struct, *mol);
-  addBonds(current_struct, *mol);
+  const auto atom_block = d_next_struct->getIndexedBlock(mae::ATOM_BLOCK);
+  addAtoms(*atom_block, *mol);
+
+  const auto bond_block = d_next_struct->getIndexedBlock(mae::BOND_BLOCK);
+  addBonds(*bond_block, *mol);
+
+  // These properties need to be set last, as stereochemistry is defined here,
+  // and it requires atoms and bonds to be available.
+  set_mol_properties(*mol, *d_next_struct);
 
   if (df_sanitize) {
     if (df_removeHs) {
@@ -259,11 +440,24 @@ ROMol *MaeMolSupplier::next() {
     mol->updatePropertyCache(false);
   }
 
-  /* Set tetrahedral chirality from 3D co-ordinates */
-  MolOps::assignChiralTypesFrom3D(*mol);
-  MolOps::detectBondStereochemistry(*mol);
+  // If there are 3D coordinates, try to read more chiralities from them, but do
+  // not override the ones that were read from properties
+  bool replaceExistingTags = false;
+  if (mol->getNumConformers() && mol->getConformer().is3D()) {
+    MolOps::assignChiralTypesFrom3D(*mol, -1, replaceExistingTags);
+  }
 
-  return (ROMol *)mol;
+  // Find more stereo bonds, assign labels, but don't replace the existing ones
+  MolOps::detectBondStereochemistry(*mol, replaceExistingTags);
+  MolOps::assignStereochemistry(*mol, replaceExistingTags);
+
+  try {
+    d_next_struct = d_reader->next(mae::CT_BLOCK);
+  } catch (const mae::read_exception &e) {
+    d_stored_exc = e.what();
+  }
+
+  return static_cast<ROMol *>(mol);
 }
 
 bool MaeMolSupplier::atEnd() { return d_next_struct == nullptr; }

--- a/Code/GraphMol/FileParsers/MaeMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/MaeMolSupplier.cpp
@@ -249,9 +249,9 @@ void set_atom_properties(Atom &atom, const mae::IndexedBlock &atom_block,
 
   for (const auto &prop : atom_block.getProperties<double>()) {
     if (prop.first == mae::ATOM_X_COORD || prop.first == mae::ATOM_Y_COORD ||
-        // Coordinates are used in defining a conformation, and should not be
-        // set on the atom.
         prop.first == mae::ATOM_Z_COORD) {
+      // Coordinates are used in defining a conformation, and should not be
+      // set on the atom.
       continue;
     } else if (prop.first == PDB_OCCUPANCY || prop.first == PDB_TFACTOR) {
       // PDB information is parsed separately.
@@ -334,7 +334,9 @@ void addBonds(const mae::IndexedBlock &bond_block, RWMol &mol) {
     const auto from_atom = from_atoms->at(i) - 1;
     const auto to_atom = to_atoms->at(i) - 1;
     const auto order = bolookup.find(orders->at(i))->second;
-    if (from_atom > to_atom) continue;  // Maestro files double-list bonds
+    if (from_atom > to_atom) {
+      continue;  // Maestro files may double-list some bonds
+    }
 
     auto bond = new Bond(order);
     bond->setOwningMol(mol);

--- a/Code/GraphMol/FileParsers/MaeMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/MaeMolSupplier.cpp
@@ -141,7 +141,8 @@ void parseChiralityLabel(RWMol &mol, const std::string &stereo_prop) {
   CHECK_INVARIANT(chiral_atom != nullptr, "bad prop value");
 
   unsigned nSwaps = 2;
-  switch (*((++tItr)->rbegin())) {
+  const char rotation_direction = (++tItr)->back();
+  switch (rotation_direction) {
     case 'R':  // R, ANR
       nSwaps = 0;
       break;

--- a/Code/GraphMol/FileParsers/MolSupplier.h
+++ b/Code/GraphMol/FileParsers/MolSupplier.h
@@ -404,6 +404,7 @@ class RDKIT_FILEPARSERS_EXPORT MaeMolSupplier : public MolSupplier {
   std::shared_ptr<schrodinger::mae::Reader> d_reader;
   std::shared_ptr<schrodinger::mae::Block> d_next_struct;
   std::shared_ptr<std::istream> dp_sInStream;
+  std::string d_stored_exc;
 };
 #endif  // RDK_BUILD_COORDGEN_SUPPORT
 }  // namespace RDKit

--- a/Code/GraphMol/FileParsers/testMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/testMolSupplier.cpp
@@ -104,7 +104,118 @@ int testMolSup() {
     TEST_ASSERT(i == 16);
   }
 #ifdef RDK_BUILD_COORDGEN_SUPPORT
-  {
+  {  // Test reading properties
+    fname = rdbase + "/Code/GraphMol/FileParsers/test_data/props_test.mae";
+
+    MaeMolSupplier maesup(fname);
+    std::unique_ptr<ROMol> nmol(maesup.next());
+    TEST_ASSERT(nmol);
+
+    // Test mol properties
+    TEST_ASSERT(nmol->hasProp(common_properties::_Name));
+    TEST_ASSERT(nmol->hasProp("b_sd_chiral_flag"));
+    TEST_ASSERT(nmol->getProp<bool>("b_sd_chiral_flag") == false);
+    TEST_ASSERT(nmol->hasProp("i_sd_NSC"));
+    TEST_ASSERT(nmol->getProp<int>("i_sd_NSC") == 48);
+    TEST_ASSERT(nmol->hasProp("s_m_entry_name"));
+    TEST_ASSERT(nmol->getProp<std::string>("s_m_entry_name") ==
+                "NCI_aids_few.1");
+    TEST_ASSERT(nmol->hasProp("r_f3d_dummy"));
+    TEST_ASSERT(abs(nmol->getProp<double>("r_f3d_dummy") - 42.123) < 0.0001);
+
+    // Test atom properties
+    TEST_ASSERT(nmol->getNumAtoms() == 19);
+    for (int i = 0; i < 19; ++i) {
+      const auto *atom = nmol->getAtomWithIdx(i);
+
+      // The integer property is present for all atoms
+      TEST_ASSERT(atom->hasProp("i_m_minimize_atom_index"));
+      TEST_ASSERT(atom->getProp<int>("i_m_minimize_atom_index") == 1 + i);
+
+      // The bool property is only defined for i < 10
+      if (i < 10) {
+        TEST_ASSERT(atom->hasProp("b_m_dummy"));
+        TEST_ASSERT(atom->getProp<bool>("b_m_dummy") ==
+                    static_cast<bool>(i % 2));
+      } else {
+        TEST_ASSERT(!atom->hasProp("b_m_dummy"));
+      }
+
+      // The real property is only defined for i >= 10
+      if (i >= 10) {
+        TEST_ASSERT(atom->hasProp("r_f3d_dummy"));
+        TEST_ASSERT(
+            abs(atom->getProp<double>("r_f3d_dummy") - (19.1 - i) < 0.0001));
+      } else {
+        TEST_ASSERT(!atom->hasProp("r_f3d_dummy"));
+      }
+
+      // All atoms have the string prop
+      TEST_ASSERT(atom->hasProp("s_m_dummy"));
+      TEST_ASSERT(atom->getProp<std::string>("s_m_dummy") ==
+                  std::to_string(19 - i));
+    }
+
+    TEST_ASSERT(maesup.atEnd());
+  }
+  {  // Test parsing stereo properties. Mol is 2D and has stereo labels.
+    fname = rdbase + "/Code/GraphMol/FileParsers/test_data/stereochem.mae";
+    MaeMolSupplier maesup(fname);
+
+    {  // Stereo bonds. These get overwritten by the double bond detection.
+      std::unique_ptr<ROMol> nmol(maesup.next());
+      TEST_ASSERT(nmol);
+      {
+        Bond *bnd = nmol->getBondWithIdx(1);
+        TEST_ASSERT(bnd);
+        TEST_ASSERT(bnd->getStereoAtoms() == INT_VECT({0, 3}));
+        TEST_ASSERT(bnd->getStereo() == Bond::STEREOTRANS);
+      }
+      {
+        Bond *bnd = nmol->getBondWithIdx(3);
+        TEST_ASSERT(bnd);
+        TEST_ASSERT(bnd->getStereoAtoms() == INT_VECT({2, 5}));
+        TEST_ASSERT(bnd->getStereo() == Bond::STEREOCIS);
+      }
+    }
+    {  // Chiralities (these get CIP codes)
+      std::unique_ptr<ROMol> nmol(maesup.next());
+      TEST_ASSERT(nmol);
+      {
+        Atom *at = nmol->getAtomWithIdx(1);
+        TEST_ASSERT(at);
+        TEST_ASSERT(at->getChiralTag() == Atom::CHI_TETRAHEDRAL_CCW);
+        TEST_ASSERT(at->getProp<std::string>(common_properties::_CIPCode) ==
+                    "R");
+      }
+      {
+        Atom *at = nmol->getAtomWithIdx(3);
+        TEST_ASSERT(at);
+        TEST_ASSERT(at->getChiralTag() == Atom::CHI_TETRAHEDRAL_CCW);
+        TEST_ASSERT(at->getProp<std::string>(common_properties::_CIPCode) ==
+                    "S");
+      }
+    }
+    {  // Pseudochiralities (no CIP codes)
+      std::unique_ptr<ROMol> nmol(maesup.next());
+      TEST_ASSERT(nmol);
+      {
+        Atom *at = nmol->getAtomWithIdx(2);
+        TEST_ASSERT(at);
+        TEST_ASSERT(at->getChiralTag() == Atom::CHI_TETRAHEDRAL_CW);
+        TEST_ASSERT(!at->hasProp(common_properties::_CIPCode));
+      }
+      {
+        Atom *at = nmol->getAtomWithIdx(5);
+        TEST_ASSERT(at);
+        TEST_ASSERT(at->getChiralTag() == Atom::CHI_TETRAHEDRAL_CW);
+        TEST_ASSERT(!at->hasProp(common_properties::_CIPCode));
+      }
+    }
+
+    TEST_ASSERT(maesup.atEnd());
+  }
+  {  // Test loop reading
     fname = rdbase + "/Code/GraphMol/FileParsers/test_data/NCI_aids_few.mae";
     MaeMolSupplier maesup(fname);
     std::shared_ptr<ROMol> nmol;
@@ -116,7 +227,7 @@ int testMolSup() {
         if (i == 0) {
           auto smiles = MolToSmiles(*nmol);
           TEST_ASSERT(smiles ==
-                      "CCC1=[O+][Cu]2([O+]=C(CC)C1)[O+]=C(CC)CC(CC)=[O+]2");
+                      "CCC1=[O+][Cu@]2([O+]=C(CC)CC(CC)=[O+]2)[O+]=C(CC)C1");
         }
       }
     }
@@ -130,14 +241,43 @@ int testMolSup() {
     TEST_ASSERT(ok);
   }
 
-  { // Test Maestro PDB property reading
+  {
+    fname = rdbase + "/Code/GraphMol/FileParsers/test_data/bad_ppty.mae";
+    const std::string err_msg_substr = "Bad format for property";
+
+    bool ok = false;
+    std::unique_ptr<ROMol> mol;
+    MaeMolSupplier maesup(fname);
+
+    // This is in excess: there are only 3 mols in the file, and the second one
+    // has an invalid property name, so it won't be read
+    for (unsigned int i = 0; i < 5; ++i) {
+      try {
+        mol.reset(maesup.next());
+      } catch (const FileParseException &e) {
+        const std::string err_msg(e.message());
+        TEST_ASSERT(i == 1);
+        TEST_ASSERT(err_msg.find(err_msg_substr) != std::string::npos);
+        ok = true;
+        break;
+      }
+      TEST_ASSERT(mol);
+      TEST_ASSERT(mol->hasProp(common_properties::_Name));
+      TEST_ASSERT(mol->getNumAtoms() == 1);
+      TEST_ASSERT(!maesup.atEnd());
+    }
+    TEST_ASSERT(!maesup.atEnd());
+    TEST_ASSERT(ok);
+  }
+
+  {  // Test Maestro PDB property reading
     fname = rdbase + "/Code/GraphMol/FileParsers/test_data/1kv1.maegz";
     gzstream *strm = new gzstream(fname);
     MaeMolSupplier maesup(strm);
 
     std::shared_ptr<ROMol> nmol;
     nmol.reset(maesup.next());
-    const Atom* atom = nmol->getAtomWithIdx(0);
+    const Atom *atom = nmol->getAtomWithIdx(0);
     AtomPDBResidueInfo *info = (AtomPDBResidueInfo *)(atom->getMonomerInfo());
     TEST_ASSERT(info->getResidueName() == "ARG ");
     TEST_ASSERT(info->getChainId() == "A");

--- a/Code/GraphMol/FileParsers/test_data/bad_ppty.mae
+++ b/Code/GraphMol/FileParsers/test_data/bad_ppty.mae
@@ -1,0 +1,125 @@
+{ 
+ s_m_m2io_version
+ :::
+ 2.0.0 
+} 
+
+f_m_ct { 
+ s_m_title
+ i_m_ct_format
+ :::
+ "methane1" 
+  2
+ m_atom[5] { 
+  # First column is atom index #
+  i_m_mmod_type
+  r_m_x_coord
+  r_m_y_coord
+  r_m_z_coord
+  i_m_residue_number
+  i_m_color
+  s_m_pdb_residue_name
+  s_m_grow_name
+  i_m_atomic_number
+  :::
+  1 3 -0.128665 0.614765 0.000000 1 2 "    " "  c1" 6
+  2 41 -0.774660 1.260760 0.645995 1 21 "    " "  c2" 1
+  3 41 -0.774660 -0.031230 -0.645995 1 21 "    " "  n2" 1
+  4 41 0.517330 1.260760 -0.645995 1 21 "    " "    " 1
+  5 41 0.517330 -0.031230 0.645995 1 21 "    " "    " 1
+  :::
+ } 
+ m_bond[4] { 
+  # First column is bond index #
+  i_m_from
+  i_m_to
+  i_m_order
+  :::
+  1 1 2 1
+  2 1 3 1
+  3 1 4 1
+  4 1 5 1
+  :::
+ } 
+} 
+
+f_m_ct { 
+ s_m_title
+ i_m_ct_format
+ this_property_name_is_+_than_invalid
+ :::
+ "methane with bad prop" 
+  2
+ "this is the property with an invalid name"
+ m_atom[5] { 
+  # First column is atom index #
+  i_m_mmod_type
+  r_m_x_coord
+  r_m_y_coord
+  r_m_z_coord
+  i_m_residue_number
+  i_m_color
+  s_m_pdb_residue_name
+  s_m_grow_name
+  i_m_atomic_number
+  :::
+  1 3 -0.128665 0.614765 0.000000 1 2 "    " "  c1" 6
+  2 41 -0.774660 1.260760 0.645995 1 21 "    " "  c2" 1
+  3 41 -0.774660 -0.031230 -0.645995 1 21 "    " "  n2" 1
+  4 41 0.517330 1.260760 -0.645995 1 21 "    " "    " 1
+  5 41 0.517330 -0.031230 0.645995 1 21 "    " "    " 1
+  :::
+ } 
+ m_bond[4] { 
+  # First column is bond index #
+  i_m_from
+  i_m_to
+  i_m_order
+  :::
+  1 1 2 1
+  2 1 3 1
+  3 1 4 1
+  4 1 5 1
+  :::
+ } 
+} 
+
+f_m_ct { 
+ s_m_title
+ i_m_ct_format
+ :::
+ "methane3" 
+  2
+ m_atom[5] { 
+  # First column is atom index #
+  i_m_mmod_type
+  r_m_x_coord
+  r_m_y_coord
+  r_m_z_coord
+  i_m_residue_number
+  i_m_color
+  s_m_pdb_residue_name
+  s_m_grow_name
+  i_m_atomic_number
+  :::
+  1 3 -0.128665 0.614765 0.000000 1 2 "    " "  c1" 6
+  2 41 -0.774660 1.260760 0.645995 1 21 "    " "  c2" 1
+  3 41 -0.774660 -0.031230 -0.645995 1 21 "    " "  n2" 1
+  4 41 0.517330 1.260760 -0.645995 1 21 "    " "    " 1
+  5 41 0.517330 -0.031230 0.645995 1 21 "    " "    " 1
+  :::
+ } 
+ m_bond[4] { 
+  # First column is bond index #
+  i_m_from
+  i_m_to
+  i_m_order
+  :::
+  1 1 2 1
+  2 1 3 1
+  3 1 4 1
+  4 1 5 1
+  :::
+ } 
+} 
+

--- a/Code/GraphMol/FileParsers/test_data/props_test.mae
+++ b/Code/GraphMol/FileParsers/test_data/props_test.mae
@@ -1,0 +1,113 @@
+{ 
+ s_m_m2io_version
+ :::
+ 2.0.0 
+} 
+
+f_m_ct { 
+ s_m_title
+ s_m_entry_id
+ s_m_entry_name
+ i_sd_NSC
+ s_sd_CAS\_RN
+ s_sd_NCI\_AIDS\_Antiviral\_Screen\_IC50
+ s_sd_NCI\_AIDS\_Antiviral\_Screen\_EC50
+ s_sd_NCI\_AIDS\_Antiviral\_Screen\_Conclusion
+ b_sd_chiral_flag
+ i_sd_version
+ i_m_ct_enhanced_stereo_status
+ s_m_Source_Path
+ s_m_Source_File
+ i_m_Source_File_Index
+ s_m_subgroup_title
+ s_m_subgroupid
+ b_m_subgroup_collapsed
+ r_f3d_dummy
+ i_m_ct_format
+ :::
+ 48 
+  1 
+  NCI_aids_few.1 
+  48
+  15716-70-8 
+  "2.00E-04	M	=	2.46E-05	3" 
+  "2.00E-04	M	>	2.00E-04	3" 
+  CI 
+  0
+  0
+  0
+  /Users/lorton/Desktop 
+  NCI_aids_few.sdf 
+  1
+  NCI_aids_few 
+  NCI_aids_few 
+  0
+  42.123
+  2
+ m_atom[19] { 
+  # First column is atom index #
+  i_m_mmod_type
+  r_m_x_coord
+  r_m_y_coord
+  r_m_z_coord
+  i_m_residue_number
+  i_m_color
+  i_m_atomic_number
+  i_m_formal_charge
+  s_m_color_rgb
+  i_m_minimize_atom_index
+  b_m_dummy
+  r_f3d_dummy
+  s_m_dummy
+  :::
+  1 5 1.397061 -2.611162 -1.314020 900 2 6 0 A0A0A0  1 0 <> "19"
+  2 6 0.617928 -3.334828 -0.196596 900 2 6 0 A0A0A0  2 1 <> "18"
+  3 2 2.732411 -2.034793 -0.841139 900 2 6 0 A0A0A0  3 0 <> "17"
+  4 20 2.839828 -0.686768 -0.673014 900 70 8 1 FF2F2F  4 1 <> "16"
+  5 5 3.944737 -2.883585 -0.484556 900 2 6 0 A0A0A0  5 0 <> "15"
+  6 85 3.741314 -0.025539 0.237863 900 4 29 0 1E1EE1  6 1 <> "14"
+  7 2 4.968398 -2.161871 0.387270 900 2 6 0 A0A0A0  7 0 <> "13"
+  8 20 2.794694 0.657596 1.112194 900 70 8 1 FF2F2F  8 1 <> "12"
+  9 20 4.695954 0.864963 -0.371680 900 70 8 1 FF2F2F  9 0 <> "11"
+  10 20 4.624730 -0.950167 0.948767 900 70 8 1 FF2F2F  10 1 <> "10"
+  11 5 6.368986 -2.710753 0.670636 900 2 6 0 A0A0A0  11 <> 9.100000 "9"
+  12 2 2.701594 2.011042 1.258879 900 2 6 0 A0A0A0  12 <> 8.100000 "8"
+  13 2 4.991026 2.116804 0.111189 900 2 6 0 A0A0A0  13 <> 7.100000 "7"
+  14 6 6.354735 -4.065574 1.405169 900 2 6 0 A0A0A0  14 <> 6.100000 "6"
+  15 5 1.361960 2.605791 1.694724 900 2 6 0 A0A0A0  15 <> 5.100000 "5"
+  16 5 3.932152 2.848878 0.932186 900 2 6 0 A0A0A0  16 <> 4.100000 "4"
+  17 5 6.379352 2.690720 -0.184727 900 2 6 0 A0A0A0  17 <> 3.100000 "3"
+  18 6 0.644094 3.380844 0.570671 900 2 6 0 A0A0A0  18 <> 2.100000 "2"
+  19 6 6.344370 4.108667 -0.787523 900 2 6 0 A0A0A0  19 <> 1.100000 "1"
+  :::
+ } 
+ m_bond[20] { 
+  # First column is bond index #
+  i_m_from
+  i_m_to
+  i_m_order
+  :::
+  1 1 2 1
+  2 1 3 1
+  3 3 4 2
+  4 3 5 1
+  5 4 6 1
+  6 5 7 1
+  7 6 8 1
+  8 6 9 1
+  9 6 10 1
+  10 7 11 1
+  11 7 10 2
+  12 8 12 2
+  13 9 13 2
+  14 11 14 1
+  15 12 15 1
+  16 12 16 1
+  17 13 17 1
+  18 13 16 1
+  19 15 18 1
+  20 17 19 1
+  :::
+ } 
+} 
+

--- a/Code/GraphMol/FileParsers/test_data/stereochem.mae
+++ b/Code/GraphMol/FileParsers/test_data/stereochem.mae
@@ -1,0 +1,192 @@
+{ 
+ s_m_m2io_version
+ :::
+ 2.0.0 
+} 
+
+f_m_ct { 
+ s_m_title
+ b_sd_chiral_flag
+ i_sd_version
+ i_m_ct_enhanced_stereo_status
+ s_st_EZ_1
+ s_st_EZ_2
+ i_m_ct_format
+ :::
+ "" 
+  0
+  0
+  0
+  1_2_3_4_E 
+  3_4_5_6_Z 
+  2
+ m_depend[2] { 
+  # First column is dependency index #
+  i_m_depend_dependency
+  s_m_depend_property
+  :::
+  1 10 s_st_EZ_1 
+  2 10 s_st_EZ_2 
+  :::
+ } 
+ m_atom[6] { 
+  # First column is atom index #
+  i_m_mmod_type
+  r_m_x_coord
+  r_m_y_coord
+  r_m_z_coord
+  i_m_residue_number
+  i_m_color
+  i_m_atomic_number
+  :::
+  1 6 -1.683500 -0.582600 0.000000 900 2 6
+  2 7 -1.131500 0.030500 0.000000 900 2 6
+  3 7 -0.306500 0.030500 0.000000 900 2 6
+  4 7 0.306500 0.582600 0.000000 900 2 6
+  5 7 1.131500 0.582600 0.000000 900 2 6
+  6 6 1.683500 -0.030500 0.000000 900 2 6
+  :::
+ } 
+ m_bond[5] { 
+  # First column is bond index #
+  i_m_from
+  i_m_to
+  i_m_order
+  :::
+  1 1 2 1
+  2 2 3 2
+  3 3 4 1
+  4 4 5 2
+  5 5 6 1
+  :::
+ } 
+} 
+
+
+f_m_ct { 
+ s_m_title
+ b_sd_chiral_flag
+ i_sd_version
+ s_st_Chirality_1
+ s_st_Chirality_2
+ i_m_ct_enhanced_stereo_status
+ i_m_ct_format
+ :::
+ "" 
+  0
+  0
+  2_R_1_3_5_4 
+  5_S_6_2_7 
+  0
+  2
+ m_depend[2] { 
+  # First column is dependency index #
+  i_m_depend_dependency
+  s_m_depend_property
+  :::
+  1 10 s_st_Chirality_1 
+  2 10 s_st_Chirality_2 
+  :::
+ } 
+ m_atom[7] { 
+  # First column is atom index #
+  i_m_mmod_type
+  r_m_x_coord
+  r_m_y_coord
+  r_m_z_coord
+  i_m_residue_number
+  i_m_color
+  i_m_atomic_number
+  i_sd_original_parity
+  :::
+  1 57 -1.182200 -0.023400 0.000000 900 9 17 <>
+  2 3 -0.357200 -0.023400 0.000000 900 2 6 1
+  3 56 0.055100 0.690900 0.000000 900 8 9 <>
+  4 41 0.127600 -0.690900 0.000000 900 21 1 <>
+  5 4 0.467700 -0.023400 0.000000 900 2 6 1
+  6 56 1.182200 0.389000 0.000000 900 8 9 <>
+  7 6 1.135200 -0.508400 0.000000 900 2 6 <>
+  :::
+ } 
+ m_bond[6] { 
+  # First column is bond index #
+  i_m_from
+  i_m_to
+  i_m_order
+  i_sd_original_parity
+  :::
+  1 1 2 1 <>
+  2 2 5 1 <>
+  3 2 3 1 3
+  4 2 4 1 <>
+  5 5 7 1 1
+  6 5 6 1 <>
+  :::
+ } 
+} 
+
+f_m_ct { 
+ s_m_title
+ b_sd_chiral_flag
+ i_sd_version
+ s_st_AtomNumChirality_1
+ s_st_AtomNumChirality_2
+ i_m_ct_enhanced_stereo_status
+ i_m_ct_format
+ :::
+ "" 
+  0
+  0
+  3_ANR_2_4_8 
+  6_ANR_1_5_7 
+  0
+  2
+ m_depend[2] { 
+  # First column is dependency index #
+  i_m_depend_dependency
+  s_m_depend_property
+  :::
+  1 10 s_st_AtomNumChirality_1 
+  2 10 s_st_AtomNumChirality_2 
+  :::
+ } 
+ m_atom[8] { 
+  # First column is atom index #
+  i_m_mmod_type
+  r_m_x_coord
+  r_m_y_coord
+  r_m_z_coord
+  i_m_residue_number
+  i_m_color
+  i_m_atomic_number
+  i_sd_original_parity
+  :::
+  1 5 0.000000 0.825000 0.000000 900 2 6 <>
+  2 5 -0.714500 0.412500 0.000000 900 2 6 <>
+  3 4 -0.714500 -0.412600 0.000000 900 2 6 1
+  4 5 0.000000 -0.825000 0.000000 900 2 6 <>
+  5 5 0.714500 -0.412600 0.000000 900 2 6 <>
+  6 4 0.714500 0.412500 0.000000 900 2 6 1
+  7 6 1.429000 0.825100 0.000000 900 2 6 <>
+  8 6 -1.429000 -0.825100 0.000000 900 2 6 <>
+  :::
+ } 
+ m_bond[8] { 
+  # First column is bond index #
+  i_m_from
+  i_m_to
+  i_m_order
+  i_sd_original_parity
+  :::
+  1 1 2 1 <>
+  2 1 6 1 <>
+  3 2 3 1 <>
+  4 3 4 1 <>
+  5 3 8 1 1
+  6 4 5 1 <>
+  7 5 6 1 <>
+  8 6 7 1 3
+  :::
+ } 
+} 
+

--- a/Code/GraphMol/Wrap/MaeMolSupplier.cpp
+++ b/Code/GraphMol/Wrap/MaeMolSupplier.cpp
@@ -16,18 +16,27 @@
 
 // ours
 #include <RDGeneral/BadFileException.h>
+#include <RDGeneral/FileParseException.h>
 #include <GraphMol/FileParsers/MolSupplier.h>
 #include <GraphMol/RDKitBase.h>
 #include <RDBoost/python_streambuf.h>
 #include <RDBoost/iterator_next.h>
+
+#include <maeparser/MaeConstants.hpp>
 #include <maeparser/Reader.hpp>
 
 #include "MolSupplier.h"
 
 namespace python = boost::python;
 
+using namespace schrodinger;
 using boost_adaptbx::python::streambuf;
 namespace {
+
+bool streamIsGoodOrExhausted(std::istream *stream) {
+  PRECONDITION(stream, "bad stream");
+  return stream->good() || (stream->eof() && stream->fail() && !stream->bad());
+}
 
 class LocalMaeMolSupplier : public RDKit::MaeMolSupplier {
  public:
@@ -39,9 +48,14 @@ class LocalMaeMolSupplier : public RDKit::MaeMolSupplier {
     df_owner = true;
     df_sanitize = sanitize;
     df_removeHs = removeHs;
-    d_reader.reset(new schrodinger::mae::Reader(dp_sInStream));
-    d_next_struct = d_reader->next("f_m_ct");
-    POSTCONDITION(dp_inStream, "bad instream");
+    d_reader.reset(new mae::Reader(dp_sInStream));
+    CHECK_INVARIANT(streamIsGoodOrExhausted(dp_inStream), "bad instream");
+
+    try {
+      d_next_struct = d_reader->next(mae::CT_BLOCK);
+    } catch (const mae::read_exception &e) {
+      throw RDKit::FileParseException(e.what());
+    }
   }
   LocalMaeMolSupplier(streambuf &input, bool sanitize, bool removeHs) {
     dp_inStream = new streambuf::istream(input);
@@ -49,9 +63,14 @@ class LocalMaeMolSupplier : public RDKit::MaeMolSupplier {
     df_owner = true;
     df_sanitize = sanitize;
     df_removeHs = removeHs;
-    d_reader.reset(new schrodinger::mae::Reader(dp_sInStream));
-    d_next_struct = d_reader->next("f_m_ct");
-    POSTCONDITION(dp_inStream, "bad instream");
+    d_reader.reset(new mae::Reader(dp_sInStream));
+    CHECK_INVARIANT(streamIsGoodOrExhausted(dp_inStream), "bad instream");
+
+    try {
+      d_next_struct = d_reader->next(mae::CT_BLOCK);
+    } catch (const mae::read_exception &e) {
+      throw RDKit::FileParseException(e.what());
+    }
   }
 
   LocalMaeMolSupplier(const std::string &fname, bool sanitize = true,
@@ -68,9 +87,14 @@ class LocalMaeMolSupplier : public RDKit::MaeMolSupplier {
     df_sanitize = sanitize;
     df_removeHs = removeHs;
 
-    d_reader.reset(new schrodinger::mae::Reader(dp_sInStream));
-    d_next_struct = d_reader->next("f_m_ct");
-    POSTCONDITION(dp_inStream, "bad instream");
+    d_reader.reset(new mae::Reader(dp_sInStream));
+    CHECK_INVARIANT(streamIsGoodOrExhausted(dp_inStream), "bad instream");
+
+    try {
+      d_next_struct = d_reader->next(mae::CT_BLOCK);
+    } catch (const mae::read_exception &e) {
+      throw RDKit::FileParseException(e.what());
+    }
   };
 };
 

--- a/Code/GraphMol/Wrap/MolSupplier.h
+++ b/Code/GraphMol/Wrap/MolSupplier.h
@@ -31,6 +31,8 @@ ROMol *MolForwardSupplNext(T *suppl) {
   if (!suppl->atEnd()) {
     try {
       res = suppl->next();
+    } catch (const FileParseException&) {
+      throw;
     } catch (...) {
       res = 0;
     }
@@ -51,6 +53,8 @@ ROMol *MolSupplNext(T *suppl) {
   if (!suppl->atEnd()) {
     try {
       res = suppl->next();
+    } catch (const FileParseException&) {
+      throw;
     } catch (...) {
       res = 0;
     }
@@ -68,6 +72,8 @@ ROMol *MolSupplNextAcceptNullLastMolecule(T *suppl) {
   if (!suppl->atEnd()) {
     try {
       res = suppl->next();
+    } catch (const FileParseException&) {
+      throw;
     } catch (...) {
       res = 0;
     }

--- a/Code/GraphMol/Wrap/rdmolfiles.cpp
+++ b/Code/GraphMol/Wrap/rdmolfiles.cpp
@@ -46,6 +46,11 @@ void rdBadFileExceptionTranslator(RDKit::BadFileException const &x) {
   ss << "File error: " << x.message();
   PyErr_SetString(PyExc_IOError, ss.str().c_str());
 }
+void rdFileParseExceptionTranslator(RDKit::FileParseException const &x) {
+  std::ostringstream ss;
+  ss << "File parsing error: " << x.message();
+  PyErr_SetString(PyExc_RuntimeError, ss.str().c_str());
+}
 
 namespace RDKit {
 std::string pyObjectToString(python::object input) {
@@ -400,6 +405,10 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
       "formats.";
   python::register_exception_translator<RDKit::BadFileException>(
       &rdBadFileExceptionTranslator);
+
+  python::register_exception_translator<RDKit::FileParseException>(
+      &rdFileParseExceptionTranslator);
+
 
   docString =
       "Construct a molecule from a TPL file.\n\n\

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -2810,6 +2810,34 @@ CAS<~>
       i += 1
     self.assertEqual(i, 16)
 
+  def testMaeFileSupplierException(self):
+    try:
+      MaeMolSupplier = Chem.MaeMolSupplier
+    except AttributeError:  # Built without Maestro support, return w/o testing
+      return
+
+    fileN = os.path.join(RDConfig.RDBaseDir, 'Code', 'GraphMol', 'FileParsers', 'test_data',
+                         'bad_ppty.mae')
+    err_msg_substr = "Bad format for property";
+
+    ok = False
+    suppl = MaeMolSupplier(fileN)
+    for i in range(5):
+      try:
+        mol = next(suppl)
+      except RuntimeError as e:
+        self.assertEqual(i, 1)
+        self.assertTrue(err_msg_substr in str(e))
+        ok = True
+        break
+      else:
+        self.assertTrue(mol)
+        self.assertTrue(mol.HasProp("_Name"))
+        self.assertTrue(mol.GetNumAtoms() == 1)
+
+    self.assertFalse(suppl.atEnd())
+    self.assertTrue(ok)
+
   def test66StreamSupplierIter(self):
     fileN = os.path.join(RDConfig.RDBaseDir, 'Code', 'GraphMol', 'FileParsers', 'test_data',
                          'NCI_aids_few.sdf.gz')


### PR DESCRIPTION
This started as a fix for #2617, but I added some more changes. That issue is caused by #2579, but after finding the problem, the `MaeMolSupplier` does not stop iteration despite it does not get any more structures, and continues returning "None" forever.

Also, this depends on schrodinger/maeparser#46 and schrodinger/maeparser#49, and should not be merged until these changes are accessible to RDKit.

Changes in the PR:

- Check the state of the stream after the creation of the Supplier: on construction, the `Reader` populates the internal buffer, so that, if there aren't any problems, the stream may be left either in a `good` state, if there was more data available than fits in the internal buffer, or with the `failed` and `eof` bits activated if there was less data than the buffer tried to read (both states are ok).

- Do not read the next block / structure before it is requested. Before this change, the MaeMolSupplier attempted to read the first structure still inside the constructor, right after constructing the Reader object; the second one when the first was requested, etc. With this mechanism, if a problem was encountered while reading the second structure, the first one would not have been returned.

- Catching of exceptions thrown during and after reading of the `mae::Block`, and rethrowing them as `FileParseException` so that they can be handled by RDKit (e.g., by preventing further reads, like should happen in #2617).

- Changed the way how `atEnd()` is handled. This depends on schrodinger/maeparser#49.

- Provide translation of `FileParseException`s into Python `RuntimeErrors`. This is the part that would actually prevent an infinite reading loop as in #2617, and also the one I am most interested in, especially because of the comment at:
https://github.com/rdkit/rdkit/blob/01fbec33ff434432d840828b7fb02cc22680fd42/Code/GraphMol/Wrap/MolSupplier.h#L90-L94
I tried to iterate over a `MaeMolSupplier`, a `SDMolSupplier` and a `ForwardSDMolSupplier` after introducing this patch, and did not observe any problems like unexpected `RuntimeError`s, e.g. at the end of the iteration).
