### PR TITLE
optimization of the MolStandardize code

### DIFF
--- a/Code/Catalogs/Catalog.h
+++ b/Code/Catalogs/Catalog.h
@@ -163,7 +163,7 @@ class HierarchCatalog : public Catalog<entryType, paramType> {
 
   //------------------------------------
   //! Construct by making a copy of the input \c params object
-  HierarchCatalog<entryType, paramType, orderType>(paramType *params)
+  HierarchCatalog<entryType, paramType, orderType>(const paramType *params)
       : Catalog<entryType, paramType>() {
     this->setCatalogParams(params);
   }

--- a/Code/GraphMol/MolStandardize/Metal.cpp
+++ b/Code/GraphMol/MolStandardize/Metal.cpp
@@ -89,7 +89,6 @@ void MetalDisconnector::disconnect(RWMol &mol) {
     //	std::cout << "After removing bond and charge adjustment: " <<
     //MolToSmiles(mol) << std::endl;
   }
-  MolOps::sanitizeMol(mol);
 }
 }  // namespace MolStandardize
 }  // namespace RDKit

--- a/Code/GraphMol/MolStandardize/MolStandardize.cpp
+++ b/Code/GraphMol/MolStandardize/MolStandardize.cpp
@@ -29,7 +29,6 @@ const CleanupParameters defaultCleanupParameters;
 
 RWMol *cleanup(const RWMol &mol, const CleanupParameters &params) {
   RWMol m(mol);
-  MolOps::sanitizeMol(m);
   MolOps::removeHs(m);
 
   MolStandardize::MetalDisconnector md;

--- a/Code/GraphMol/MolStandardize/Normalize.h
+++ b/Code/GraphMol/MolStandardize/Normalize.h
@@ -82,13 +82,13 @@ class RDKIT_MOLSTANDARDIZE_EXPORT Normalizer {
   };
 
  private:
-  TransformCatalog *d_tcat;
+  const TransformCatalog *d_tcat;
   unsigned int MAX_RESTARTS;
 
-  ROMol *normalizeFragment(
+  boost::shared_ptr<ROMol> normalizeFragment(
       const ROMol &mol,
       const std::vector<std::shared_ptr<ChemicalReaction>> &transforms);
-  boost::shared_ptr<ROMol> applyTransform(const ROMol &mol,
+  boost::shared_ptr<ROMol> applyTransform(const boost::shared_ptr<ROMol> mol,
                                           ChemicalReaction &rule);
 
 };  // Normalizer class


### PR DESCRIPTION
This is mostly mechanical "stop copying things that don't need to be copied" work.

There's definitely still some more fat in here to be pruned, but I think this takes out most of the big chunks.

For what it's worth, this reduces the C++ run time on the set of examples provided in #2615 from 20.8 sec to 7.4 sec.
