### PR TITLE
Dev/rgroup handle ties in symmetry matching

### DIFF
--- a/Code/GraphMol/RGroupDecomposition/RGroupDecomp.cpp
+++ b/Code/GraphMol/RGroupDecomposition/RGroupDecomp.cpp
@@ -775,9 +775,7 @@ struct RGroupDecompData {
       if (userLabel < 0) continue;  // not a user specified label
       Atom *atom = rlabels.second;
       mappings[userLabel] = userLabel;
-      if (!used_labels.add(userLabel)) {
-	std::cerr << "WARNING: duplicate labels" << std::endl;
-      }
+      used_labels.add(userLabel);
 
       if (atom->getAtomicNum() == 0) {  // add to existing dummy/rlabel
         setRlabel(atom, userLabel);

--- a/Code/GraphMol/RGroupDecomposition/RGroupDecomp.cpp
+++ b/Code/GraphMol/RGroupDecomposition/RGroupDecomp.cpp
@@ -747,7 +747,8 @@ struct RGroupDecompData {
     }
   };
   
-  void relabelCore(RWMol &core, std::map<int, int> &mappings, int &count,
+  void relabelCore(RWMol &core, std::map<int, int> &mappings,
+		   UsedLabels &used_labels,
                    const std::set<int> &indexLabels,
                    std::map<int, std::vector<int>> extraAtomRLabels) {
     // Now remap to proper rlabel ids
@@ -757,7 +758,6 @@ struct RGroupDecompData {
     //
     //  Some indices are attached to multiple bonds,
     //   these rlabels should be incrementally added last
-    UsedLabels used_labels;
     std::map<int, Atom *> atoms = getRlabels(core);
     // a core only has one labelled index
     //  a secondary structure extraAtomRLabels contains the number
@@ -774,7 +774,6 @@ struct RGroupDecompData {
       int userLabel = rlabels.first;
       if (userLabel < 0) continue;  // not a user specified label
       Atom *atom = rlabels.second;
-      if (count < userLabel) count = userLabel;
       mappings[userLabel] = userLabel;
       if (!used_labels.add(userLabel)) {
 	std::cerr << "WARNING: duplicate labels" << std::endl;
@@ -824,7 +823,7 @@ struct RGroupDecompData {
 
       for (size_t i = 0; i < extraAtomRLabel.second.size(); ++i) {
 	int rlabel = used_labels.next();
-        extraAtomRLabel.second[i] = rlabel;//++count;
+        extraAtomRLabel.second[i] = rlabel;
         // Is this necessary?
         CHECK_INVARIANT(
             atom->getAtomicNum() > 1,
@@ -933,13 +932,13 @@ struct RGroupDecompData {
     //  the scaffold
     finalRlabelMapping.clear();
 
-    int count = 0;
+    UsedLabels used_labels;
     for (std::map<int, RWMol>::const_iterator coreIt = cores.begin();
          coreIt != cores.end(); ++coreIt) {
       boost::shared_ptr<RWMol> labelledCore(new RWMol(coreIt->second));
       labelledCores[coreIt->first] = labelledCore;
 
-      relabelCore(*labelledCore.get(), finalRlabelMapping, count, indexLabels,
+      relabelCore(*labelledCore.get(), finalRlabelMapping, used_labels, indexLabels,
                   extraAtomRLabels);
     }
 

--- a/Code/GraphMol/RGroupDecomposition/RGroupDecomp.cpp
+++ b/Code/GraphMol/RGroupDecomposition/RGroupDecomp.cpp
@@ -1039,7 +1039,7 @@ struct RGroupDecompData {
       }
     }
 
-    permutation = best_permutation;    
+    permutation = best_permutation;
     if (pruneMatches || finalize) {
       prune();
     }
@@ -1050,7 +1050,6 @@ struct RGroupDecompData {
 
     return true;
   }
-  
 };
 
 RGroupDecomposition::RGroupDecomposition(

--- a/Code/GraphMol/RGroupDecomposition/RGroupDecomp.cpp
+++ b/Code/GraphMol/RGroupDecomposition/RGroupDecomp.cpp
@@ -1030,8 +1030,6 @@ struct RGroupDecompData {
       //  (2) the group has any substituent with heavy atoms
       //   XXX Might be more efficient to add this comp to the score function
       int smallest_added_rgroups = 100000000;
-      
-	
       for(auto tied_permutation: ties) {
 	int num_added_rgroups = compute_num_added_rgroups(tied_permutation);
 	if(num_added_rgroups  < smallest_added_rgroups) {
@@ -1041,8 +1039,7 @@ struct RGroupDecompData {
       }
     }
 
-    permutation = best_permutation;
-    
+    permutation = best_permutation;    
     if (pruneMatches || finalize) {
       prune();
     }

--- a/Code/GraphMol/RGroupDecomposition/RGroupDecomp.cpp
+++ b/Code/GraphMol/RGroupDecomposition/RGroupDecomp.cpp
@@ -39,7 +39,6 @@
 #include <GraphMol/FMCS/FMCS.h>
 #include <boost/scoped_ptr.hpp>
 #include <boost/dynamic_bitset.hpp>
-#include <boost/range/adaptor/reversed.hpp>
 #include <set>
 #include <utility>
 #include <vector>
@@ -751,9 +750,6 @@ struct RGroupDecompData {
   void relabelCore(RWMol &core, std::map<int, int> &mappings, int &count,
                    const std::set<int> &indexLabels,
                    std::map<int, std::vector<int>> extraAtomRLabels) {
-    if(core.hasProp("relabeled"))
-      std::cerr << "RELABELED CORE!!!!" << std::endl;
-    core.setProp<bool>("relabeled", true);
     // Now remap to proper rlabel ids
     //  if labels are positive, they come from User labels
     //  if they are negative, they come from indices and should be
@@ -794,14 +790,7 @@ struct RGroupDecompData {
     }
 
     // Deal with non-user supplied labels
-    //  It is important to go in reverse order as the symmetry mappings
-    //  prefers symmetries that add 'larger' labels
-    //for (auto rlabels : boost::adaptors::reverse(atoms)) {
     for (auto newLabel : indexLabels) {
-      //int newLabel = rlabels.first;
-      //if (newLabel >= 0) continue;  // we already dealt with these
-      //Atom *atom = rlabels.second;
-      
       auto atm = atoms.find(newLabel);
       if (atm == atoms.end()) {
 	continue;

--- a/Code/GraphMol/RGroupDecomposition/Wrap/test_rgroups.py
+++ b/Code/GraphMol/RGroupDecomposition/Wrap/test_rgroups.py
@@ -237,26 +237,27 @@ C1CCO[C@@](S)(P)1
         mols = [Chem.MolFromSmiles(smi) for smi in ("C1NC1OCCC", "C1NC1NCCC")]
         groups,unmatched = RGroupDecompose(scaffolds, mols,
                                            asSmiles=True, asRows=True)
+        print("groups:", groups)
         self.assertEqual(groups,
                          [{'Core': 'C1NC1OC[*:1]',
                            'R1': '[H]C([H])([H])C([H])([H])[*:1].[H][*:1].[H][*:1]'},
-                          {'Core': 'C1NC1NC[*:2]',
-                           'R2': '[H]C([H])([H])C([H])([H])[*:2].[H][*:2].[H][*:2]'}])
+                          {'Core': 'C1NC1NC[*:1]',
+                           'R1': '[H]C([H])([H])C([H])([H])[*:1].[H][*:1].[H][*:1]'}])
         
 
     def test_aligned_cores2(self):
         scaffolds = [Chem.MolFromSmarts(x) for x in ("C1NCC1", "C1SCC1")]
         mols = [Chem.MolFromSmiles(smi) for smi in ("C1N(P)CC1", "C1S(P)CC1")]
-        print(scaffolds)
-        print(mols)
+        print("scaffolds:", scaffolds)
+        print("mols: ", mols)
         groups,unmatched = RGroupDecompose(scaffolds, mols,
                                            asSmiles=True, asRows=True)
-        print(groups)
+        print("groups: ", groups)
         self.assertEqual(groups,
                          [{'Core': 'C1CN([*:1])C1',
                            'R1': '[H]P([H])[*:1]'},
-                          {'Core': 'C1C[SH]([*:2])C1',
-                           'R2': '[H]P([H])[*:2].[H][*:2]'}])
+                          {'Core': 'C1C[SH]([*:1])C1',
+                           'R1': '[H]P([H])[*:1].[H][*:1]'}])
         
 if __name__ == '__main__':
   unittest.main()

--- a/Code/GraphMol/RGroupDecomposition/Wrap/test_rgroups.py
+++ b/Code/GraphMol/RGroupDecomposition/Wrap/test_rgroups.py
@@ -237,27 +237,26 @@ C1CCO[C@@](S)(P)1
         mols = [Chem.MolFromSmiles(smi) for smi in ("C1NC1OCCC", "C1NC1NCCC")]
         groups,unmatched = RGroupDecompose(scaffolds, mols,
                                            asSmiles=True, asRows=True)
+        print("test_aligned_Cores")
         print("groups:", groups)
         self.assertEqual(groups,
                          [{'Core': 'C1NC1OC[*:1]',
                            'R1': '[H]C([H])([H])C([H])([H])[*:1].[H][*:1].[H][*:1]'},
-                          {'Core': 'C1NC1NC[*:1]',
-                           'R1': '[H]C([H])([H])C([H])([H])[*:1].[H][*:1].[H][*:1]'}])
-        
-
+                          {'Core': 'C1NC1NC[*:2]',
+                           'R2': '[H]C([H])([H])C([H])([H])[*:2].[H][*:2].[H][*:2]'}])
+                          
     def test_aligned_cores2(self):
         scaffolds = [Chem.MolFromSmarts(x) for x in ("C1NCC1", "C1SCC1")]
         mols = [Chem.MolFromSmiles(smi) for smi in ("C1N(P)CC1", "C1S(P)CC1")]
-        print("scaffolds:", scaffolds)
-        print("mols: ", mols)
+        print("test_aligned_Cores2")
         groups,unmatched = RGroupDecompose(scaffolds, mols,
                                            asSmiles=True, asRows=True)
         print("groups: ", groups)
         self.assertEqual(groups,
                          [{'Core': 'C1CN([*:1])C1',
                            'R1': '[H]P([H])[*:1]'},
-                          {'Core': 'C1C[SH]([*:1])C1',
-                           'R1': '[H]P([H])[*:1].[H][*:1]'}])
+                          {'Core': 'C1C[SH]([*:2])C1',
+                           'R2': '[H]P([H])[*:2].[H][*:2]'}])
         
 if __name__ == '__main__':
   unittest.main()

--- a/Code/GraphMol/RGroupDecomposition/Wrap/test_rgroups.py
+++ b/Code/GraphMol/RGroupDecomposition/Wrap/test_rgroups.py
@@ -237,8 +237,8 @@ C1CCO[C@@](S)(P)1
         mols = [Chem.MolFromSmiles(smi) for smi in ("C1NC1OCCC", "C1NC1NCCC")]
         groups,unmatched = RGroupDecompose(scaffolds, mols,
                                            asSmiles=True, asRows=True)
-        print("test_aligned_Cores")
-        print("groups:", groups)
+        #print("test_aligned_Cores")
+        #print("groups:", groups)
         self.assertEqual(groups,
                          [{'Core': 'C1NC1OC[*:1]',
                            'R1': '[H]C([H])([H])C([H])([H])[*:1].[H][*:1].[H][*:1]'},
@@ -248,10 +248,10 @@ C1CCO[C@@](S)(P)1
     def test_aligned_cores2(self):
         scaffolds = [Chem.MolFromSmarts(x) for x in ("C1NCC1", "C1SCC1")]
         mols = [Chem.MolFromSmiles(smi) for smi in ("C1N(P)CC1", "C1S(P)CC1")]
-        print("test_aligned_Cores2")
+        #print("test_aligned_Cores2")
         groups,unmatched = RGroupDecompose(scaffolds, mols,
                                            asSmiles=True, asRows=True)
-        print("groups: ", groups)
+        #print("groups: ", groups)
         self.assertEqual(groups,
                          [{'Core': 'C1CN([*:1])C1',
                            'R1': '[H]P([H])[*:1]'},

--- a/Code/GraphMol/RGroupDecomposition/testRGroupDecomp.cpp
+++ b/Code/GraphMol/RGroupDecomposition/testRGroupDecomp.cpp
@@ -933,6 +933,24 @@ void testRowColumnAlignmentProblem() {
   }
 }
 
+void testSymmetryIssues() {
+  BOOST_LOG(rdInfoLog)
+    << "********************************************************\n";
+  BOOST_LOG(rdInfoLog) << "Testing R-Group symmetry issues \n";
+
+  auto m1 = "c1c(F)cccn1"_smiles; 
+  auto m2 = "c1c(Cl)c(C)ccn1"_smiles;
+  auto m3 = "c1c(O)cccn1"_smiles;
+  auto m4 = "c1cc(C)c(F)cn1"_smiles;
+  auto core = "c1c([*:1])c([*:2])ccn1"_smiles;
+  RGroupDecomposition decomp(*core);
+  decomp.add(*m1);
+  decomp.add(*m2);
+  decomp.add(*m3);
+  decomp.add(*m4);
+  decomp.process();
+  auto cols = decomp.getRGroupsAsColumns();
+}
 int main() {
   RDLog::InitLogs();
 
@@ -956,7 +974,7 @@ int main() {
   testSDFGRoupMultiCoreNoneShouldMatch();
 #endif
   testRowColumnAlignmentProblem();
-
+  testSymmetryIssues();
   BOOST_LOG(rdInfoLog)
       << "********************************************************\n";
   return 0;


### PR DESCRIPTION
Fixes #2601 

Break ties in symmetry by choosing the permutation that adds the fewest rgroups.  Should have though of this before :)

Consolidates how new labels are added, instead of a maximum count we just grab the first available rgroup starting from 1.

Fixes the meaning of onlyH, this doesn't seem to change anything which indicates it may not really be tested.