### PR TITLE
draw zero-order bonds

### DIFF
--- a/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
@@ -1178,6 +1178,7 @@ void MolDraw2D::drawBond(const ROMol &mol, const Bond *bond, int at1_idx,
   static const DashPattern noDash;
   static const DashPattern dots = assign::list_of(2)(6);
   static const DashPattern dashes = assign::list_of(6)(6);
+  static const DashPattern shortDashes = assign::list_of(2)(2);
   // the percent shorter that the extra bonds in a double bond are
   const double multipleBondTruncation = 0.15;
 
@@ -1292,6 +1293,10 @@ void MolDraw2D::drawBond(const ROMol &mol, const Bond *bond, int at1_idx,
         drawArrow(at2_cds, at1_cds, asPolygon, frac, angle);
       }
       setFillPolys(fps);
+    } else if (Bond::ZERO == bt) {
+      setDash(shortDashes);
+      drawLine(at1_cds, at2_cds, col1, col2);
+      setDash(noDash);
     } else {
       // in all other cases, we will definitely want to draw a line between
       // the two atoms

--- a/Code/GraphMol/MolDraw2D/catch_tests.cpp
+++ b/Code/GraphMol/MolDraw2D/catch_tests.cpp
@@ -242,3 +242,21 @@ TEST_CASE("dative bonds", "[drawing, organometallics]") {
           std::string::npos);
   }
 }
+
+TEST_CASE("zero-order bonds", "[drawing, organometallics]") {
+  SECTION("basics") {
+    auto m1 = "N-[Pt]"_smiles;
+    REQUIRE(m1);
+    m1->getBondWithIdx(0)->setBondType(Bond::ZERO);
+    MolDraw2DSVG drawer(200, 200);
+    MolDraw2DUtils::prepareMolForDrawing(*m1);
+    drawer.drawMolecule(*m1);
+    drawer.finishDrawing();
+    std::string text = drawer.getDrawingText();
+    std::ofstream outs("testZeroOrderBonds_1.svg");
+    outs << text;
+    outs.flush();
+
+    CHECK(text.find("stroke-dasharray:2,2") != std::string::npos);
+  }
+}


### PR DESCRIPTION
zero order bonds were being drawn the same as single bonds.
This fixes that.