### PR TITLE
Fix SMARTS from MCS has no chiral tags (Issue #1405)

### DIFF
--- a/Code/GraphMol/QueryOps.cpp
+++ b/Code/GraphMol/QueryOps.cpp
@@ -334,6 +334,13 @@ ATOM_EQUALS_QUERY *makeAtomMissingChiralTagQuery() {
   return res;
 }
 
+ATOM_EQUALS_QUERY *makeAtomHasChiralityValueQuery(Atom::ChiralType what) {
+  ATOM_EQUALS_QUERY *res = makeAtomSimpleQuery<ATOM_EQUALS_QUERY>(
+      static_cast<int>(what), queryAtomHasChiralityValue);
+  res->setDescription("AtomChirality");
+  return res;
+}
+
 ATOM_EQUALS_QUERY *makeAtomInRingQuery() {
   ATOM_EQUALS_QUERY *res =
       makeAtomSimpleQuery<ATOM_EQUALS_QUERY>(true, queryIsAtomInRing);

--- a/Code/GraphMol/QueryOps.h
+++ b/Code/GraphMol/QueryOps.h
@@ -166,6 +166,9 @@ static inline int queryAtomMissingChiralTag(Atom const *at) {
   return at->getChiralTag() == Atom::CHI_UNSPECIFIED &&
          at->hasProp(common_properties::_ChiralityPossible);
 };
+static inline int queryAtomHasChiralityValue(Atom const *at) {
+  return static_cast<int>(at->getChiralTag());
+};
 
 static inline int queryAtomHasHeteroatomNbrs(Atom const *at) {
   ROMol::ADJ_ITER nbrIdx, endNbrs;
@@ -495,6 +498,16 @@ T *makeAtomMissingChiralTagQuery(const std::string &descr) {
 }
 //! \overloadquery
 RDKIT_GRAPHMOL_EXPORT ATOM_EQUALS_QUERY *makeAtomMissingChiralTagQuery();
+
+//! returns a Query for matching whether a specific chirality has been set on
+//! the atom
+template <class T>
+T *makeAtomHasChiralityValueQuery(int what, const std::string &descr) {
+  return makeAtomSimpleQuery<T>(what, queryAtomHasChiralityValue, descr);
+}
+//! \overloadquery
+RDKIT_GRAPHMOL_EXPORT ATOM_EQUALS_QUERY *makeAtomHasChiralityValueQuery(
+    Atom::ChiralType what);
 
 //! returns a Query for matching atoms with unsaturation:
 template <class T>

--- a/Code/GraphMol/SmilesParse/SmartsWrite.cpp
+++ b/Code/GraphMol/SmilesParse/SmartsWrite.cpp
@@ -252,6 +252,19 @@ std::string getAtomSmartsSimple(const QueryAtom *qatom,
   } else if (descrip == "AtomMass") {
     res << query->getVal() / massIntegerConversionFactor << "*";
     needParen = true;
+  } else if (descrip == "AtomChirality") {
+    switch (static_cast<Atom::ChiralType>(query->getVal())) {
+      case Atom::CHI_TETRAHEDRAL_CW:
+        res << "@@";
+        needParen = true;
+        break;
+      case Atom::CHI_TETRAHEDRAL_CCW:
+        res << "@";
+        needParen = true;
+        break;
+      default:
+        break;
+    }
   } else if (descrip == "AtomIsotope") {
     res << query->getVal() << "*";
     needParen = true;


### PR DESCRIPTION
This is a draft of a PR for fixing #1405.

I checked the issue, looked a bit around the MCS code, and I think the problem of the missing chiral tags comes from here:

https://github.com/rdkit/rdkit/blob/574caeba572e98b6863713c657739064e3dfd3e4/Code/GraphMol/FMCS/MaximumCommonSubgraph.cpp#L667-L681

The chiral tags are only added if there are any matches in `atomMatchSet[ai]`, but in the example posted in the issue it is empty (what are the conditions for it not to be?).

To get the chiral tags in to the SMARTS, it would be required to set the chiral tag outside the loop, right after setting the atomic number on `a`, but that would cause two other issues: (1) in case `atomMatchSet[ai]` is not empty, the chiral tags would be overwritten (although I would expect the matches in `atomMatchSet[ai]` should have the same chirality?, so maybe not an issue), and (2) the additional atomic number queries added in the loop would not carry chiral tags.

To fix these new issues, I have made an attempt to implement an Atom Query for a specific chiral tag, which would be also set in the loop. So far, tests pass, and using the snippet in the issue shows chirality in SMARTS, and when (hackingly) making `atomMatchSet[ai]` not to be empty, additional queries also have tags.

I haven't included any tests for the new code, but will do if we agree this is the right way to fix the problem.

It would also be useful to know some cases in which `atomMatchSet[ai]` ends up not being empty, especially if these lead to matches with different chiralities.