### PR TITLE
Fixes: Atoms in non-standard valences not being properly written to mol blocks

### DIFF
--- a/Code/GraphMol/FileParsers/MolFileWriter.cpp
+++ b/Code/GraphMol/FileParsers/MolFileWriter.cpp
@@ -795,13 +795,14 @@ void GetMolFileBondStereoInfo(const Bond *bond, const INT_MAP_INT &wedgeBonds,
         if (bond->getBondDir() == Bond::EITHERDOUBLE) {
           dirCode = 3;
         } else {
-          if((bond->getBeginAtom()->getTotalValence()-bond->getBeginAtom()->getTotalDegree())==1 &&
-          (bond->getEndAtom()->getTotalValence()-bond->getEndAtom()->getTotalDegree())==1
-          ) {
+          if ((bond->getBeginAtom()->getTotalValence() -
+               bond->getBeginAtom()->getTotalDegree()) == 1 &&
+              (bond->getEndAtom()->getTotalValence() -
+               bond->getEndAtom()->getTotalDegree()) == 1) {
             // we only do this if each atom only has one unsaturation
-            // FIX: this is the fix for github #2649, but we will need to change it
-            // once we start handling allenes properly
-            
+            // FIX: this is the fix for github #2649, but we will need to change
+            // it once we start handling allenes properly
+
             bool nbrHasDir = false;
 
             ROMol::OEDGE_ITER beg, end;
@@ -811,7 +812,7 @@ void GetMolFileBondStereoInfo(const Bond *bond, const INT_MAP_INT &wedgeBonds,
               const Bond *nbrBond = bond->getOwningMol()[*beg];
               if (nbrBond->getBondType() == Bond::SINGLE &&
                   (nbrBond->getBondDir() == Bond::ENDUPRIGHT ||
-                  nbrBond->getBondDir() == Bond::ENDDOWNRIGHT)) {
+                   nbrBond->getBondDir() == Bond::ENDDOWNRIGHT)) {
                 nbrHasDir = true;
               }
               ++beg;
@@ -822,7 +823,7 @@ void GetMolFileBondStereoInfo(const Bond *bond, const INT_MAP_INT &wedgeBonds,
               const Bond *nbrBond = bond->getOwningMol()[*beg];
               if (nbrBond->getBondType() == Bond::SINGLE &&
                   (nbrBond->getBondDir() == Bond::ENDUPRIGHT ||
-                  nbrBond->getBondDir() == Bond::ENDDOWNRIGHT)) {
+                   nbrBond->getBondDir() == Bond::ENDDOWNRIGHT)) {
                 nbrHasDir = true;
               }
               ++beg;

--- a/Code/GraphMol/FileParsers/MolFileWriter.cpp
+++ b/Code/GraphMol/FileParsers/MolFileWriter.cpp
@@ -29,6 +29,7 @@
 #include <boost/format.hpp>
 #include <boost/dynamic_bitset.hpp>
 #include <RDGeneral/BadFileException.h>
+#include <GraphMol/SmilesParse/SmilesWrite.h>
 #include <GraphMol/SmilesParse/SmartsWrite.h>
 #include <GraphMol/Depictor/RDDepictor.h>
 
@@ -539,19 +540,17 @@ unsigned int getAtomParityFlag(const Atom *atom, const Conformer *conf) {
 bool hasNonDefaultValence(const Atom *atom) {
   if (atom->getNumRadicalElectrons() != 0) return true;
   if (atom->hasQuery()) return false;
-  switch (atom->getAtomicNum()) {
-    case 1:   // H
-    case 5:   // B
-    case 6:   // C
-    case 7:   // N
-    case 8:   // O
-    case 9:   // F
-    case 15:  // P
-    case 16:  // S
-    case 17:  // Cl
-    case 35:  // Br
-    case 53:  // I
+  if (atom->getAtomicNum() == 1 ||
+      SmilesWrite ::inOrganicSubset(atom->getAtomicNum())) {
+    // for the ones we "know", we may have to specify the valence if it's
+    // not the default value
+    if (atom->getNoImplicit() &&
+        (atom->getExplicitValence() !=
+         PeriodicTable::getTable()->getDefaultValence(atom->getAtomicNum()))) {
+      return true;
+    } else {
       return false;
+    }
   }
   return true;
 }

--- a/Code/GraphMol/FileParsers/MolFileWriter.cpp
+++ b/Code/GraphMol/FileParsers/MolFileWriter.cpp
@@ -795,33 +795,41 @@ void GetMolFileBondStereoInfo(const Bond *bond, const INT_MAP_INT &wedgeBonds,
         if (bond->getBondDir() == Bond::EITHERDOUBLE) {
           dirCode = 3;
         } else {
-          bool nbrHasDir = false;
+          if((bond->getBeginAtom()->getTotalValence()-bond->getBeginAtom()->getTotalDegree())==1 &&
+          (bond->getEndAtom()->getTotalValence()-bond->getEndAtom()->getTotalDegree())==1
+          ) {
+            // we only do this if each atom only has one unsaturation
+            // FIX: this is the fix for github #2649, but we will need to change it
+            // once we start handling allenes properly
+            
+            bool nbrHasDir = false;
 
-          ROMol::OEDGE_ITER beg, end;
-          boost::tie(beg, end) =
-              bond->getOwningMol().getAtomBonds(bond->getBeginAtom());
-          while (beg != end && !nbrHasDir) {
-            const Bond *nbrBond = bond->getOwningMol()[*beg];
-            if (nbrBond->getBondType() == Bond::SINGLE &&
-                (nbrBond->getBondDir() == Bond::ENDUPRIGHT ||
-                 nbrBond->getBondDir() == Bond::ENDDOWNRIGHT)) {
-              nbrHasDir = true;
+            ROMol::OEDGE_ITER beg, end;
+            boost::tie(beg, end) =
+                bond->getOwningMol().getAtomBonds(bond->getBeginAtom());
+            while (beg != end && !nbrHasDir) {
+              const Bond *nbrBond = bond->getOwningMol()[*beg];
+              if (nbrBond->getBondType() == Bond::SINGLE &&
+                  (nbrBond->getBondDir() == Bond::ENDUPRIGHT ||
+                  nbrBond->getBondDir() == Bond::ENDDOWNRIGHT)) {
+                nbrHasDir = true;
+              }
+              ++beg;
             }
-            ++beg;
-          }
-          boost::tie(beg, end) =
-              bond->getOwningMol().getAtomBonds(bond->getEndAtom());
-          while (beg != end && !nbrHasDir) {
-            const Bond *nbrBond = bond->getOwningMol()[*beg];
-            if (nbrBond->getBondType() == Bond::SINGLE &&
-                (nbrBond->getBondDir() == Bond::ENDUPRIGHT ||
-                 nbrBond->getBondDir() == Bond::ENDDOWNRIGHT)) {
-              nbrHasDir = true;
+            boost::tie(beg, end) =
+                bond->getOwningMol().getAtomBonds(bond->getEndAtom());
+            while (beg != end && !nbrHasDir) {
+              const Bond *nbrBond = bond->getOwningMol()[*beg];
+              if (nbrBond->getBondType() == Bond::SINGLE &&
+                  (nbrBond->getBondDir() == Bond::ENDUPRIGHT ||
+                  nbrBond->getBondDir() == Bond::ENDDOWNRIGHT)) {
+                nbrHasDir = true;
+              }
+              ++beg;
             }
-            ++beg;
-          }
-          if (!nbrHasDir) {
-            dirCode = 3;
+            if (!nbrHasDir) {
+              dirCode = 3;
+            }
           }
         }
       }

--- a/Code/GraphMol/catch_tests.cpp
+++ b/Code/GraphMol/catch_tests.cpp
@@ -537,7 +537,7 @@ M  END)CTAB";
     CHECK(mol->getBondWithIdx(1)->getStereo() == Bond::STEREONONE);
     CHECK(mol->getBondWithIdx(3)->getStereo() == Bond::STEREONONE);
     auto outmolb = MolToMolBlock(*mol);
-    //std::cerr<<outmolb<<std::endl;
+    // std::cerr<<outmolb<<std::endl;
     CHECK(outmolb.find("1  3  2  0") != std::string::npos);
     CHECK(outmolb.find("2  1  2  0") != std::string::npos);
     CHECK(outmolb.find("4  2  2  0") != std::string::npos);

--- a/Code/GraphMol/catch_tests.cpp
+++ b/Code/GraphMol/catch_tests.cpp
@@ -510,3 +510,36 @@ M  END
     CHECK(mol->getAtomWithIdx(0)->getTotalNumHs() == 0);
   }
 }
+
+TEST_CASE(
+    "github #2649: Allenes read from mol blocks have crossed bonds assigned"
+    "[bug, stereochemistry]") {
+  SECTION("basics") {
+    std::string mb = R"CTAB(mol
+  Mrv1824 09191901002D          
+
+  6  5  0  0  0  0            999 V2000
+   -1.6986   -7.4294    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -2.2522   -6.8245    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -1.1438   -8.0357    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -2.8095   -6.2156    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -0.3374   -7.8470    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -3.6162   -6.3886    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+  1  3  2  0  0  0  0
+  2  1  2  0  0  0  0
+  3  5  1  0  0  0  0
+  4  2  2  0  0  0  0
+  6  4  1  0  0  0  0
+M  END)CTAB";
+    std::unique_ptr<ROMol> mol(MolBlockToMol(mb));
+    REQUIRE(mol);
+    CHECK(mol->getBondWithIdx(0)->getStereo() == Bond::STEREONONE);
+    CHECK(mol->getBondWithIdx(1)->getStereo() == Bond::STEREONONE);
+    CHECK(mol->getBondWithIdx(3)->getStereo() == Bond::STEREONONE);
+    auto outmolb = MolToMolBlock(*mol);
+    //std::cerr<<outmolb<<std::endl;
+    CHECK(outmolb.find("1  3  2  0") != std::string::npos);
+    CHECK(outmolb.find("2  1  2  0") != std::string::npos);
+    CHECK(outmolb.find("4  2  2  0") != std::string::npos);
+  }
+}


### PR DESCRIPTION
Atoms from the "organic subset" that have ununusual non-standard valences were not having those valences written to mol blocks.

This clears that up.

It only affects atoms in the organic subset that have the `noImplicit` flag set and that have a non-standard valence.

This also fixes #2649. That's not really related except that it also is related to reading/writing mol blocks.