### PR TITLE
Fixes #2647

### DIFF
--- a/Code/GraphMol/Subgraphs/SubgraphUtils.cpp
+++ b/Code/GraphMol/Subgraphs/SubgraphUtils.cpp
@@ -30,15 +30,19 @@ ROMol *pathToSubmol(const ROMol &mol, const PATH_TYPE &path, bool useQuery) {
 ROMol *pathToSubmol(const ROMol &mol, const PATH_TYPE &path, bool useQuery,
                     INT_MAP_INT &atomIdxMap) {
   auto *subMol = new RWMol();
+  // path needs to be in sorted order to preserve chirality
+  PATH_TYPE sorted_path(path);
+  std::sort(sorted_path.begin(), sorted_path.end());
+
   PATH_TYPE::const_iterator pathIter;
   atomIdxMap.clear();
 
   if (useQuery) {
     // have to do this in two different blocks because of issues with variable
     // scopes.
-    for (pathIter = path.begin(); pathIter != path.end(); ++pathIter) {
+    for(auto bondidx : sorted_path) {
       QueryBond *bond;
-      bond = new QueryBond(*(mol.getBondWithIdx(*pathIter)));
+      bond = new QueryBond(*(mol.getBondWithIdx(bondidx)));
 
       int begIdx = bond->getBeginAtomIdx();
       int endIdx = bond->getEndAtomIdx();
@@ -62,9 +66,9 @@ ROMol *pathToSubmol(const ROMol &mol, const PATH_TYPE &path, bool useQuery,
       subMol->addBond(bond, true);
     }
   } else {
-    for (pathIter = path.begin(); pathIter != path.end(); ++pathIter) {
+    for(auto bondidx : sorted_path) {
       Bond *bond;
-      bond = mol.getBondWithIdx(*pathIter)->copy();
+      bond = mol.getBondWithIdx(bondidx)->copy();
 
       int begIdx = bond->getBeginAtomIdx();
       int endIdx = bond->getEndAtomIdx();

--- a/Code/GraphMol/Subgraphs/SubgraphUtils.cpp
+++ b/Code/GraphMol/Subgraphs/SubgraphUtils.cpp
@@ -34,15 +34,13 @@ ROMol *pathToSubmol(const ROMol &mol, const PATH_TYPE &path, bool useQuery,
   PATH_TYPE sorted_path(path);
   std::sort(sorted_path.begin(), sorted_path.end());
 
-  PATH_TYPE::const_iterator pathIter;
   atomIdxMap.clear();
 
   if (useQuery) {
     // have to do this in two different blocks because of issues with variable
     // scopes.
     for(auto bondidx : sorted_path) {
-      QueryBond *bond;
-      bond = new QueryBond(*(mol.getBondWithIdx(bondidx)));
+      QueryBond *bond = new QueryBond(*(mol.getBondWithIdx(bondidx)));
 
       int begIdx = bond->getBeginAtomIdx();
       int endIdx = bond->getEndAtomIdx();
@@ -67,8 +65,7 @@ ROMol *pathToSubmol(const ROMol &mol, const PATH_TYPE &path, bool useQuery,
     }
   } else {
     for(auto bondidx : sorted_path) {
-      Bond *bond;
-      bond = mol.getBondWithIdx(bondidx)->copy();
+      Bond *bond = mol.getBondWithIdx(bondidx)->copy();
 
       int begIdx = bond->getBeginAtomIdx();
       int endIdx = bond->getEndAtomIdx();

--- a/Code/GraphMol/Subgraphs/test2.cpp
+++ b/Code/GraphMol/Subgraphs/test2.cpp
@@ -163,7 +163,7 @@ void testGithubIssue103() {
     TEST_ASSERT(pth.size() == 5);
     ROMol *frag = Subgraphs::pathToSubmol(*mol, pth, false);
     smiles = MolToSmarts(*frag);
-    TEST_ASSERT(smiles == "[#6](-[#6@H](-[#8])-[#6]=[#6])=[#6]");
+    TEST_ASSERT(smiles == "[#6]=[#6]-[#6@H](-[#8])-[#6]=[#6]");
     delete frag;
     delete mol;
   }
@@ -176,7 +176,9 @@ void testGithubIssue103() {
     TEST_ASSERT(pth.size() == 5);
     ROMol *frag = Subgraphs::pathToSubmol(*mol, pth, true);
     smiles = MolToSmarts(*frag);
-    TEST_ASSERT(smiles == "[#6](-[#6@](-[#8])-[#6]=[#6])=[#6]");
+    std::cerr << smiles << std::endl;
+    TEST_ASSERT(smiles == "[#6]=[#6]-[#6@](-[#8])-[#6]=[#6]");
+    std::cerr << "ok!" << endl;
     delete frag;
     delete mol;
   }

--- a/Code/GraphMol/Subgraphs/test2.cpp
+++ b/Code/GraphMol/Subgraphs/test2.cpp
@@ -20,6 +20,12 @@
 using namespace std;
 using namespace RDKit;
 
+std::string canon(std::string smiles) {
+  unique_ptr<ROMol> m(SmilesToMol(smiles));
+  const bool useStereo = true;
+  return MolToSmiles(*m, useStereo);
+}
+
 void test1() {
   std::cout << "-----------------------\n Test1: pathToSubmol" << std::endl;
   {
@@ -123,7 +129,7 @@ void test2() {
     TEST_ASSERT(pth.size() == 8);
     ROMol *frag = Subgraphs::pathToSubmol(*mol, pth, false);
     smiles = MolToSmiles(*frag, true, false, 0, false);
-    TEST_ASSERT(smiles == "C(C(C(O)C)C(C)C)C");
+    TEST_ASSERT(canon(smiles) == canon("C(C(C(O)C)C(C)C)C"));
     delete frag;
     delete mol;
   }
@@ -144,7 +150,7 @@ void testGithubIssue103() {
     TEST_ASSERT(pth.size() == 5);
     ROMol *frag = Subgraphs::pathToSubmol(*mol, pth, false);
     smiles = MolToSmiles(*frag, true);
-    TEST_ASSERT(smiles == "C=CC(O)C=C");
+    TEST_ASSERT(canon(smiles) == canon("C=CC(O)C=C"));
     delete frag;
     delete mol;
   }
@@ -178,10 +184,25 @@ void testGithubIssue103() {
   std::cout << "Finished" << std::endl;
 }
 
+void testGithubIssue2647() {
+  std::cout << "-----------------------\n Testing github Issue103: "
+               "more stereochemistry and pathToSubmol (path needs to be in sorted order)"
+            << std::endl;
+  std::string smiles = "I[C@](F)(Br)O";
+  std::unique_ptr<ROMol> mol(SmilesToMol(smiles));
+  std::vector<int> path = { 0, 3, 2, 1 };
+  const bool useQuery=false;
+  const bool useStereo=true;
+  std::unique_ptr<ROMol> mol2(Subgraphs::pathToSubmol(*mol, path, useQuery));
+  TEST_ASSERT(MolToSmiles(*mol2) == MolToSmiles(*mol, useStereo));
+  std::cout << "Finished" << std::endl;
+}
+
 // -------------------------------------------------------------------
 int main() {
   test1();
   test2();
   testGithubIssue103();
+  testGithubIssue2647();
   return 0;
 }

--- a/Code/GraphMol/Subgraphs/test2.cpp
+++ b/Code/GraphMol/Subgraphs/test2.cpp
@@ -176,9 +176,7 @@ void testGithubIssue103() {
     TEST_ASSERT(pth.size() == 5);
     ROMol *frag = Subgraphs::pathToSubmol(*mol, pth, true);
     smiles = MolToSmarts(*frag);
-    std::cerr << smiles << std::endl;
     TEST_ASSERT(smiles == "[#6]=[#6]-[#6@](-[#8])-[#6]=[#6]");
-    std::cerr << "ok!" << endl;
     delete frag;
     delete mol;
   }
@@ -194,9 +192,8 @@ void testGithubIssue2647() {
   std::unique_ptr<ROMol> mol(SmilesToMol(smiles));
   std::vector<int> path = { 0, 3, 2, 1 };
   const bool useQuery=false;
-  const bool useStereo=true;
   std::unique_ptr<ROMol> mol2(Subgraphs::pathToSubmol(*mol, path, useQuery));
-  TEST_ASSERT(MolToSmiles(*mol2) == MolToSmiles(*mol, useStereo));
+  TEST_ASSERT(MolToSmiles(*mol2) == MolToSmiles(*mol));
   std::cout << "Finished" << std::endl;
 }
 


### PR DESCRIPTION
Fixes #2647 

PathToSubmol copied the bonds over in the order of the indices.  This played higglety pigglety on the stereo order.
