### PR TITLE
Get numpy include dir programmatically

### DIFF
--- a/Docs/Book/Install.md
+++ b/Docs/Book/Install.md
@@ -120,7 +120,7 @@ cmake -DPy_ENABLE_SHARED=1 \
   -DRDK_INSTALL_INTREE=ON \
   -DRDK_INSTALL_STATIC_LIBS=OFF \
   -DRDK_BUILD_CPP_TESTS=ON \
-  -DPYTHON_NUMPY_INCLUDE_PATH="$CONDA_PREFIX/lib/python3.6/site-packages/numpy/core/include" \
+  -DPYTHON_NUMPY_INCLUDE_PATH="$(python -c 'import numpy ; print(numpy.get_include())')" \
   -DBOOST_ROOT="$CONDA_PREFIX" \
   ..
 ```


### PR DESCRIPTION
So far, the installation instructions for Linux rely on a specific 
python version in order to include numpy. Replace the hard-coded path 
with a call to numpy.get_include().

<!--
Thanks for contributing a pull request! 
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.


#### Any other comments?

