### PR TITLE
Fix long columns pandas

### DIFF
--- a/rdkit/Chem/UnitTestPandasTools.py
+++ b/rdkit/Chem/UnitTestPandasTools.py
@@ -122,17 +122,17 @@ class TestPandasTools(unittest.TestCase):
     @unittest.skipIf(IPython is None, 'Package IPython required for testing')
     def test_svgRendering(self):
         df = PandasTools.LoadSDF(getStreamIO(methane + peroxide))
-        self.assertIn('image/png', str(df))
-        self.assertNotIn('svg', str(df))
+        self.assertIn('image/png', df.to_html())
+        self.assertNotIn('svg', df.to_html())
 
         PandasTools.molRepresentation = 'svg'
-        self.assertIn('svg', str(df))
-        self.assertNotIn('image/png', str(df))
+        self.assertIn('svg', df.to_html())
+        self.assertNotIn('image/png', df.to_html())
 
         # we can use upper case for the molRepresentation
         PandasTools.molRepresentation = 'PNG'
-        self.assertNotIn('svg', str(df))
-        self.assertIn('image/png', str(df))
+        self.assertNotIn('svg', df.to_html())
+        self.assertIn('image/png', df.to_html())
 
     def test_patchHeadFrame(self):
         df = self.df.copy()


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! 
-->
#### Reference Issue

In #2206 someone noted that cells in pandas data frames are not truncated if rdkit.Chem.PandasTools is used. Even data frames without molecules are affected.

#### What does this implement/fix? 

Instead of setting the global pandas variable display.max_colwidth to -1 (infinite), a different mechanism is used to render molecule images in data frames. 

Before (note: any HTML is rendered, text is not truncated):
![image](https://user-images.githubusercontent.com/8418161/65681262-cc3ffc00-e058-11e9-9294-a39ecf64880e.png)

After changes:
![image](https://user-images.githubusercontent.com/8418161/65682353-1aee9580-e05b-11e9-8bef-7a0a6a5804df.png)
