### PR TITLE
Added AtomComparator.AtomCompareAnyHeavyAtom and test cases to FMCS code

### DIFF
--- a/Code/GraphMol/FMCS/FMCS.cpp
+++ b/Code/GraphMol/FMCS/FMCS.cpp
@@ -111,7 +111,7 @@ MCSResult findMCS(const std::vector<ROMOL_SPTR>& mols, bool maximizeBonds,
     case AtomCompareIsotopes:
       ps->AtomTyper = MCSAtomCompareIsotopes;
       break;
-	case AromCompareAnyHeavyAtom:
+	case AtomCompareAnyHeavyAtom:
 	  ps->AtomTyper = MCSAtomCompareAnyHeavyAtom;
 	  break;
   }

--- a/Code/GraphMol/FMCS/FMCS.cpp
+++ b/Code/GraphMol/FMCS/FMCS.cpp
@@ -233,6 +233,9 @@ bool MCSAtomCompareAnyHeavyAtom(const MCSAtomCompareParameters& p,
   const Atom& a2 = *mol2.getAtomWithIdx(atom2);
   //Any atom, including H, matches another atom of the same type,  according to the other flags
   if (a1.getAtomicNum() == a2.getAtomicNum() || (a1.getAtomicNum() > 1 && a2.getAtomicNum() > 1)){
+      return MCSAtomCompareAny(p,mol1,atom1,mol2,atom2,nullptr);
+  }
+  return false;
     if (p.MatchValences && a1.getTotalValence() != a2.getTotalValence())
       return false;
     if (p.MatchChiralTag && !checkAtomChirality(p, mol1, atom1, mol2, atom2))

--- a/Code/GraphMol/FMCS/FMCS.cpp
+++ b/Code/GraphMol/FMCS/FMCS.cpp
@@ -236,17 +236,6 @@ bool MCSAtomCompareAnyHeavyAtom(const MCSAtomCompareParameters& p,
       return MCSAtomCompareAny(p,mol1,atom1,mol2,atom2,nullptr);
   }
   return false;
-    if (p.MatchValences && a1.getTotalValence() != a2.getTotalValence())
-      return false;
-    if (p.MatchChiralTag && !checkAtomChirality(p, mol1, atom1, mol2, atom2))
-      return false;
-    if (p.MatchFormalCharge && !checkAtomCharge(p, mol1, atom1, mol2, atom2))
-      return false;
-    if (p.RingMatchesRingOnly)
-      return checkRingMatch(p, mol1, atom1, mol2, atom2);
-    return true;
-  }
-  return false;
 }
 
 //=== BOND COMPARE ========================================================

--- a/Code/GraphMol/FMCS/FMCS.h
+++ b/Code/GraphMol/FMCS/FMCS.h
@@ -49,6 +49,10 @@ RDKIT_FMCS_EXPORT bool MCSAtomCompareAny(const MCSAtomCompareParameters& p,
                                          const ROMol& mol1, unsigned int atom1,
                                          const ROMol& mol2, unsigned int atom2,
                                          void* userData);
+RDKIT_FMCS_EXPORT bool MCSAtomCompareAnyHeavyAtom(const MCSAtomCompareParameters& p,
+                                         const ROMol& mol1, unsigned int atom1,
+                                         const ROMol& mol2, unsigned int atom2,
+                                         void* userData);
 
 RDKIT_FMCS_EXPORT bool MCSAtomCompareElements(
     const MCSAtomCompareParameters& p, const ROMol& mol1, unsigned int atom1,
@@ -125,7 +129,8 @@ RDKIT_FMCS_EXPORT MCSResult findMCS_P(const std::vector<ROMOL_SPTR>& mols,
 typedef enum {
   AtomCompareAny,
   AtomCompareElements,
-  AtomCompareIsotopes
+  AtomCompareIsotopes,
+  AtomCompareAnyHeavyAtom
 } AtomComparator;
 typedef enum {
   BondCompareAny,

--- a/Code/GraphMol/FMCS/Wrap/rdFMCS.cpp
+++ b/Code/GraphMol/FMCS/Wrap/rdFMCS.cpp
@@ -27,6 +27,9 @@ void SetMCSAtomTyper(MCSParameters &p, AtomComparator atomComp) {
     case AtomCompareIsotopes:
       p.AtomTyper = MCSAtomCompareIsotopes;
       break;
+    case AtomCompareAnyHeavyAtom:
+      p.AtomTyper = MCSAtomCompareAnyHeavyAtom;
+	  break;
   }
 }
 void SetMCSBondTyper(MCSParameters &p, BondComparator bondComp) {
@@ -120,7 +123,8 @@ BOOST_PYTHON_MODULE(rdFMCS) {
   python::enum_<RDKit::AtomComparator>("AtomCompare")
       .value("CompareAny", RDKit::AtomCompareAny)
       .value("CompareElements", RDKit::AtomCompareElements)
-      .value("CompareIsotopes", RDKit::AtomCompareIsotopes);
+      .value("CompareIsotopes", RDKit::AtomCompareIsotopes)
+      .value("CompareAnyHeavyAtom", RDKit::AtomCompareAnyHeavyAtom);
   python::enum_<RDKit::BondComparator>("BondCompare")
       .value("CompareAny", RDKit::BondCompareAny)
       .value("CompareOrder", RDKit::BondCompareOrder)

--- a/Code/GraphMol/FMCS/Wrap/testFMCS.py
+++ b/Code/GraphMol/FMCS/Wrap/testFMCS.py
@@ -8,275 +8,275 @@ from rdkit.Chem import rdFMCS
 
 class TestCase(unittest.TestCase):
 
-	def setUp(self):
-		pass
+    def setUp(self):
+        pass
 
-	def test1(self):
-		smis = (
-		  "Cc1nc(CN(C(C)c2ncccc2)CCCCN)ccc1 CHEMBL1682991",  # -- QUERY
-		  "Cc1ccc(CN(C(C)c2ccccn2)CCCCN)nc1 CHEMBL1682990",
-		  "Cc1cccnc1CN(C(C)c1ccccn1)CCCCN CHEMBL1682998",
-		  "CC(N(CCCCN)Cc1c(N)cccn1)c1ccccn1 CHEMBL1682987",
-		  "Cc1cc(C)c(CN(C(C)c2ccccn2)CCCCN)nc1 CHEMBL1682992",
-		  "Cc1cc(C(C)N(CCCCN)Cc2c(C)cccn2)ncc1 CHEMBL1682993",
-		  "Cc1nc(C(C)N(CCCCN)Cc2nc3c([nH]2)cccc3)ccc1 CHEMBL1682878",
-		  "CC(c1ncccc1)N(CCCCN)Cc1nc2c([nH]1)cccc2 CHEMBL1682867",
-		  "CC(N(CCCCN)Cc1c(C(C)(C)C)cccn1)c1ccccn1 CHEMBL1682989",
-		  "CC(N(CCCCN)Cc1c(C(F)(F)F)cccn1)c1ccccn1 CHEMBL1682988",
-		)
-		ms = [Chem.MolFromSmiles(x.split()[0]) for x in smis]
-		qm = ms[0]
-		ms = ms[1:]
-		mcs = rdFMCS.FindMCS(ms)
-		self.assertEqual(mcs.numBonds, 21)
-		self.assertEqual(mcs.numAtoms, 21)
-		self.assertEqual(
-		  mcs.smartsString,
-		  '[#6](:[#6]:[#6]):[#6]:[#7]:[#6]-[#6]-[#7](-[#6](-[#6])-[#6]1:[#6]:[#6]:[#6]:[#6]:[#7]:1)-[#6]-[#6]-[#6]-[#6]-[#7]'
-		)
-		qm = Chem.MolFromSmarts(mcs.smartsString)
-		self.assertTrue(qm is not None)
-		for m in ms:
-			self.assertTrue(m.HasSubstructMatch(qm))
+    def test1(self):
+        smis = (
+          "Cc1nc(CN(C(C)c2ncccc2)CCCCN)ccc1 CHEMBL1682991",  # -- QUERY
+          "Cc1ccc(CN(C(C)c2ccccn2)CCCCN)nc1 CHEMBL1682990",
+          "Cc1cccnc1CN(C(C)c1ccccn1)CCCCN CHEMBL1682998",
+          "CC(N(CCCCN)Cc1c(N)cccn1)c1ccccn1 CHEMBL1682987",
+          "Cc1cc(C)c(CN(C(C)c2ccccn2)CCCCN)nc1 CHEMBL1682992",
+          "Cc1cc(C(C)N(CCCCN)Cc2c(C)cccn2)ncc1 CHEMBL1682993",
+          "Cc1nc(C(C)N(CCCCN)Cc2nc3c([nH]2)cccc3)ccc1 CHEMBL1682878",
+          "CC(c1ncccc1)N(CCCCN)Cc1nc2c([nH]1)cccc2 CHEMBL1682867",
+          "CC(N(CCCCN)Cc1c(C(C)(C)C)cccn1)c1ccccn1 CHEMBL1682989",
+          "CC(N(CCCCN)Cc1c(C(F)(F)F)cccn1)c1ccccn1 CHEMBL1682988",
+        )
+        ms = [Chem.MolFromSmiles(x.split()[0]) for x in smis]
+        qm = ms[0]
+        ms = ms[1:]
+        mcs = rdFMCS.FindMCS(ms)
+        self.assertEqual(mcs.numBonds, 21)
+        self.assertEqual(mcs.numAtoms, 21)
+        self.assertEqual(
+          mcs.smartsString,
+          '[#6](:[#6]:[#6]):[#6]:[#7]:[#6]-[#6]-[#7](-[#6](-[#6])-[#6]1:[#6]:[#6]:[#6]:[#6]:[#7]:1)-[#6]-[#6]-[#6]-[#6]-[#7]'
+        )
+        qm = Chem.MolFromSmarts(mcs.smartsString)
+        self.assertTrue(qm is not None)
+        for m in ms:
+            self.assertTrue(m.HasSubstructMatch(qm))
 
-		mcs = rdFMCS.FindMCS(ms, threshold=0.8)
-		self.assertEqual(mcs.numBonds, 21)
-		self.assertEqual(mcs.numAtoms, 21)
-		self.assertEqual(
-		  mcs.smartsString,
-		  '[#6](:[#6]:[#6]):[#6]:[#7]:[#6]-[#6]-[#7](-[#6](-[#6])-[#6]1:[#6]:[#6]:[#6]:[#6]:[#7]:1)-[#6]-[#6]-[#6]-[#6]-[#7]'
-		)
-		qm = Chem.MolFromSmarts(mcs.smartsString)
-		self.assertTrue(qm is not None)
-		for m in ms:
-			self.assertTrue(m.HasSubstructMatch(qm))
+        mcs = rdFMCS.FindMCS(ms, threshold=0.8)
+        self.assertEqual(mcs.numBonds, 21)
+        self.assertEqual(mcs.numAtoms, 21)
+        self.assertEqual(
+          mcs.smartsString,
+          '[#6](:[#6]:[#6]):[#6]:[#7]:[#6]-[#6]-[#7](-[#6](-[#6])-[#6]1:[#6]:[#6]:[#6]:[#6]:[#7]:1)-[#6]-[#6]-[#6]-[#6]-[#7]'
+        )
+        qm = Chem.MolFromSmarts(mcs.smartsString)
+        self.assertTrue(qm is not None)
+        for m in ms:
+            self.assertTrue(m.HasSubstructMatch(qm))
 
-	def test2(self):
-		smis = (
-		  "CHEMBL122452 CN(CCCN(C)CCc1ccccc1)CCOC(c1ccccc1)c1ccccc1",
-		  "CHEMBL123252 CN(CCCc1ccccc1)CCCN(C)CCOC(c1ccccc1)c1ccccc1",
-		  "CHEMBL121611 Fc1ccc(C(OCCNCCCNCCc2ccccc2)c2ccc(F)cc2)cc1",
-		  "CHEMBL121050 O=C(Cc1ccccc1)NCCCCNCCOC(c1ccc(F)cc1)c1ccc(F)cc1",
-		  "CHEMBL333667 O=C(Cc1ccccc1)NCCNCCOC(c1ccc(F)cc1)c1ccc(F)cc1",
-		  "CHEMBL121486 O=C(Cc1ccc(Br)cc1)NC=CNCCOC(c1ccc(F)cc1)c1ccc(F)cc1",
-		  "CHEMBL123830 O=C(Cc1ccc(F)cc1)NCCNCCOC(c1ccc(F)cc1)c1ccc(F)cc1",
-		  "CHEMBL420900 O=C(Cc1ccccc1)NCCCNCCOC(c1ccc(F)cc1)c1ccc(F)cc1",
-		  "CHEMBL121460 CN(CCOC(c1ccc(F)cc1)c1ccc(F)cc1)CCN(C)CCOC(c1ccc(F)cc1)c1ccc(F)cc1",
-		  "CHEMBL120901 COC(=O)C1C2CCC(CC1C(=O)Oc1ccccc1)N2C",
-		  "CHEMBL122859 O=C1CN(CCc2ccccc2)CCN1CCOC(c1ccc(F)cc1)c1ccc(F)cc1",
-		  "CHEMBL121027 CN(CCOC(c1ccccc1)c1ccccc1)CCN(C)CCc1ccc(F)cc1",
-		)
+    def test2(self):
+        smis = (
+          "CHEMBL122452 CN(CCCN(C)CCc1ccccc1)CCOC(c1ccccc1)c1ccccc1",
+          "CHEMBL123252 CN(CCCc1ccccc1)CCCN(C)CCOC(c1ccccc1)c1ccccc1",
+          "CHEMBL121611 Fc1ccc(C(OCCNCCCNCCc2ccccc2)c2ccc(F)cc2)cc1",
+          "CHEMBL121050 O=C(Cc1ccccc1)NCCCCNCCOC(c1ccc(F)cc1)c1ccc(F)cc1",
+          "CHEMBL333667 O=C(Cc1ccccc1)NCCNCCOC(c1ccc(F)cc1)c1ccc(F)cc1",
+          "CHEMBL121486 O=C(Cc1ccc(Br)cc1)NC=CNCCOC(c1ccc(F)cc1)c1ccc(F)cc1",
+          "CHEMBL123830 O=C(Cc1ccc(F)cc1)NCCNCCOC(c1ccc(F)cc1)c1ccc(F)cc1",
+          "CHEMBL420900 O=C(Cc1ccccc1)NCCCNCCOC(c1ccc(F)cc1)c1ccc(F)cc1",
+          "CHEMBL121460 CN(CCOC(c1ccc(F)cc1)c1ccc(F)cc1)CCN(C)CCOC(c1ccc(F)cc1)c1ccc(F)cc1",
+          "CHEMBL120901 COC(=O)C1C2CCC(CC1C(=O)Oc1ccccc1)N2C",
+          "CHEMBL122859 O=C1CN(CCc2ccccc2)CCN1CCOC(c1ccc(F)cc1)c1ccc(F)cc1",
+          "CHEMBL121027 CN(CCOC(c1ccccc1)c1ccccc1)CCN(C)CCc1ccc(F)cc1",
+        )
 
-		ms = [Chem.MolFromSmiles(x.split()[1]) for x in smis]
-		qm = ms[0]
-		ms = ms[1:]
-		mcs = rdFMCS.FindMCS(ms)
-		self.assertEqual(mcs.numBonds, 9)
-		self.assertEqual(mcs.numAtoms, 10)
-		qm = Chem.MolFromSmarts(mcs.smartsString)
-		self.assertTrue(qm is not None)
-		for m in ms:
-			self.assertTrue(m.HasSubstructMatch(qm))
-		# smarts too hard to canonicalize this
-		# self.assertEqual(mcs.smartsString,'[#6]-,:[#6]-,:[#6]-,:[#6]-,:[#6](-[#6]-[#8]-[#6]:,-[#6])-,:[#6]')
+        ms = [Chem.MolFromSmiles(x.split()[1]) for x in smis]
+        qm = ms[0]
+        ms = ms[1:]
+        mcs = rdFMCS.FindMCS(ms)
+        self.assertEqual(mcs.numBonds, 9)
+        self.assertEqual(mcs.numAtoms, 10)
+        qm = Chem.MolFromSmarts(mcs.smartsString)
+        self.assertTrue(qm is not None)
+        for m in ms:
+            self.assertTrue(m.HasSubstructMatch(qm))
+        # smarts too hard to canonicalize this
+        # self.assertEqual(mcs.smartsString,'[#6]-,:[#6]-,:[#6]-,:[#6]-,:[#6](-[#6]-[#8]-[#6]:,-[#6])-,:[#6]')
 
-		mcs = rdFMCS.FindMCS(ms, threshold=0.8)
-		self.assertEqual(mcs.numBonds, 20)
-		self.assertEqual(mcs.numAtoms, 19)
-		qm = Chem.MolFromSmarts(mcs.smartsString)
-		self.assertTrue(qm is not None)
-		nHits = 0
-		for m in ms:
-			if m.HasSubstructMatch(qm):
-				nHits += 1
-		self.assertTrue(nHits >= int(0.8 * len(smis)))
-		# smarts too hard to canonicalize this
-		# self.assertEqual(mcs.smartsString,'[#6]1:[#6]:[#6]:[#6](:[#6]:[#6]:1)-[#6](-[#8]-[#6]-[#6]-[#7]-[#6]-[#6])-[#6]2:[#6]:[#6]:[#6]:[#6]:[#6]:2')
+        mcs = rdFMCS.FindMCS(ms, threshold=0.8)
+        self.assertEqual(mcs.numBonds, 20)
+        self.assertEqual(mcs.numAtoms, 19)
+        qm = Chem.MolFromSmarts(mcs.smartsString)
+        self.assertTrue(qm is not None)
+        nHits = 0
+        for m in ms:
+            if m.HasSubstructMatch(qm):
+                nHits += 1
+        self.assertTrue(nHits >= int(0.8 * len(smis)))
+        # smarts too hard to canonicalize this
+        # self.assertEqual(mcs.smartsString,'[#6]1:[#6]:[#6]:[#6](:[#6]:[#6]:1)-[#6](-[#8]-[#6]-[#6]-[#7]-[#6]-[#6])-[#6]2:[#6]:[#6]:[#6]:[#6]:[#6]:2')
 
-	def test3IsotopeMatch(self):
-		smis = (
-		  "CC[14NH2]",
-		  "CC[14CH3]",
-		)
+    def test3IsotopeMatch(self):
+        smis = (
+          "CC[14NH2]",
+          "CC[14CH3]",
+        )
 
-		ms = [Chem.MolFromSmiles(x) for x in smis]
-		mcs = rdFMCS.FindMCS(ms)
-		self.assertEqual(mcs.numBonds, 1)
-		self.assertEqual(mcs.numAtoms, 2)
-		qm = Chem.MolFromSmarts(mcs.smartsString)
+        ms = [Chem.MolFromSmiles(x) for x in smis]
+        mcs = rdFMCS.FindMCS(ms)
+        self.assertEqual(mcs.numBonds, 1)
+        self.assertEqual(mcs.numAtoms, 2)
+        qm = Chem.MolFromSmarts(mcs.smartsString)
 
-		mcs = rdFMCS.FindMCS(ms, atomCompare=rdFMCS.AtomCompare.CompareIsotopes)
-		self.assertEqual(mcs.numBonds, 2)
-		self.assertEqual(mcs.numAtoms, 3)
-		qm = Chem.MolFromSmarts(mcs.smartsString)
+        mcs = rdFMCS.FindMCS(ms, atomCompare=rdFMCS.AtomCompare.CompareIsotopes)
+        self.assertEqual(mcs.numBonds, 2)
+        self.assertEqual(mcs.numAtoms, 3)
+        qm = Chem.MolFromSmarts(mcs.smartsString)
 
-		self.assertTrue(Chem.MolFromSmiles('CC[14CH3]').HasSubstructMatch(qm))
-		self.assertFalse(Chem.MolFromSmiles('CC[13CH3]').HasSubstructMatch(qm))
-		self.assertTrue(Chem.MolFromSmiles('OO[14CH3]').HasSubstructMatch(qm))
-		self.assertFalse(Chem.MolFromSmiles('O[13CH2][14CH3]').HasSubstructMatch(qm))
+        self.assertTrue(Chem.MolFromSmiles('CC[14CH3]').HasSubstructMatch(qm))
+        self.assertFalse(Chem.MolFromSmiles('CC[13CH3]').HasSubstructMatch(qm))
+        self.assertTrue(Chem.MolFromSmiles('OO[14CH3]').HasSubstructMatch(qm))
+        self.assertFalse(Chem.MolFromSmiles('O[13CH2][14CH3]').HasSubstructMatch(qm))
 
-	def test4RingMatches(self):
-		smis = ['CCCCC', 'CCC1CCCCC1']
-		ms = [Chem.MolFromSmiles(x) for x in smis]
-		mcs = rdFMCS.FindMCS(ms)
-		self.assertEqual(mcs.numBonds, 4)
-		self.assertEqual(mcs.numAtoms, 5)
-		self.assertEqual(mcs.smartsString, '[#6]-[#6]-[#6]-[#6]-[#6]')
+    def test4RingMatches(self):
+        smis = ['CCCCC', 'CCC1CCCCC1']
+        ms = [Chem.MolFromSmiles(x) for x in smis]
+        mcs = rdFMCS.FindMCS(ms)
+        self.assertEqual(mcs.numBonds, 4)
+        self.assertEqual(mcs.numAtoms, 5)
+        self.assertEqual(mcs.smartsString, '[#6]-[#6]-[#6]-[#6]-[#6]')
 
-		mcs = rdFMCS.FindMCS(ms, completeRingsOnly=True)
-		self.assertEqual(mcs.numBonds, 2)
-		self.assertEqual(mcs.numAtoms, 3)
-		self.assertEqual(mcs.smartsString, '[#6]-[#6]-[#6]')
+        mcs = rdFMCS.FindMCS(ms, completeRingsOnly=True)
+        self.assertEqual(mcs.numBonds, 2)
+        self.assertEqual(mcs.numAtoms, 3)
+        self.assertEqual(mcs.smartsString, '[#6]-[#6]-[#6]')
 
-		mcs = rdFMCS.FindMCS(ms, ringMatchesRingOnly=True)
-		self.assertEqual(mcs.numBonds, 1)
-		self.assertEqual(mcs.numAtoms, 2)
-		self.assertEqual(mcs.smartsString, '[#6]-[#6]')
+        mcs = rdFMCS.FindMCS(ms, ringMatchesRingOnly=True)
+        self.assertEqual(mcs.numBonds, 1)
+        self.assertEqual(mcs.numAtoms, 2)
+        self.assertEqual(mcs.smartsString, '[#6]-[#6]')
 
-		smis = ['CC1CCC1', 'CCC1CCCCC1']
-		ms = [Chem.MolFromSmiles(x) for x in smis]
-		mcs = rdFMCS.FindMCS(ms)
-		self.assertEqual(mcs.numBonds, 4)
-		self.assertEqual(mcs.numAtoms, 5)
-		self.assertEqual(mcs.smartsString, '[#6]-[#6](-[#6]-[#6])-[#6]')
+        smis = ['CC1CCC1', 'CCC1CCCCC1']
+        ms = [Chem.MolFromSmiles(x) for x in smis]
+        mcs = rdFMCS.FindMCS(ms)
+        self.assertEqual(mcs.numBonds, 4)
+        self.assertEqual(mcs.numAtoms, 5)
+        self.assertEqual(mcs.smartsString, '[#6]-[#6](-[#6]-[#6])-[#6]')
 
-		mcs = rdFMCS.FindMCS(ms, completeRingsOnly=True)
-		self.assertEqual(mcs.numBonds, 0)
-		self.assertEqual(mcs.numAtoms, 0)
-		self.assertEqual(mcs.smartsString, '')
+        mcs = rdFMCS.FindMCS(ms, completeRingsOnly=True)
+        self.assertEqual(mcs.numBonds, 0)
+        self.assertEqual(mcs.numAtoms, 0)
+        self.assertEqual(mcs.smartsString, '')
 
-		mcs = rdFMCS.FindMCS(ms, ringMatchesRingOnly=True)
-		self.assertEqual(mcs.numBonds, 4)
-		self.assertEqual(mcs.numAtoms, 5)
-		self.assertEqual(mcs.smartsString, '[#6]-[#6](-[#6]-[#6])-[#6]')
+        mcs = rdFMCS.FindMCS(ms, ringMatchesRingOnly=True)
+        self.assertEqual(mcs.numBonds, 4)
+        self.assertEqual(mcs.numAtoms, 5)
+        self.assertEqual(mcs.smartsString, '[#6]-[#6](-[#6]-[#6])-[#6]')
 
-	def test5AnyMatch(self):
-		smis = ('c1ccccc1C', 'c1ccccc1O', 'c1ccccc1Cl')
-		ms = [Chem.MolFromSmiles(x) for x in smis]
-		mcs = rdFMCS.FindMCS(ms, atomCompare=rdFMCS.AtomCompare.CompareAny)
-		self.assertEqual(mcs.numBonds, 7)
-		self.assertEqual(mcs.numAtoms, 7)
-		qm = Chem.MolFromSmarts(mcs.smartsString)
+    def test5AnyMatch(self):
+        smis = ('c1ccccc1C', 'c1ccccc1O', 'c1ccccc1Cl')
+        ms = [Chem.MolFromSmiles(x) for x in smis]
+        mcs = rdFMCS.FindMCS(ms, atomCompare=rdFMCS.AtomCompare.CompareAny)
+        self.assertEqual(mcs.numBonds, 7)
+        self.assertEqual(mcs.numAtoms, 7)
+        qm = Chem.MolFromSmarts(mcs.smartsString)
 
-		for m in ms:
-			self.assertTrue(m.HasSubstructMatch(qm))
+        for m in ms:
+            self.assertTrue(m.HasSubstructMatch(qm))
 
-		smis = ('c1cccnc1C', 'c1cnncc1O', 'c1cccnc1Cl')
-		ms = [Chem.MolFromSmiles(x) for x in smis]
-		mcs = rdFMCS.FindMCS(ms, atomCompare=rdFMCS.AtomCompare.CompareAny)
-		self.assertEqual(mcs.numBonds, 7)
-		self.assertEqual(mcs.numAtoms, 7)
-		qm = Chem.MolFromSmarts(mcs.smartsString)
+        smis = ('c1cccnc1C', 'c1cnncc1O', 'c1cccnc1Cl')
+        ms = [Chem.MolFromSmiles(x) for x in smis]
+        mcs = rdFMCS.FindMCS(ms, atomCompare=rdFMCS.AtomCompare.CompareAny)
+        self.assertEqual(mcs.numBonds, 7)
+        self.assertEqual(mcs.numAtoms, 7)
+        qm = Chem.MolFromSmarts(mcs.smartsString)
 
-		for m in ms:
-			self.assertTrue(m.HasSubstructMatch(qm))
+        for m in ms:
+            self.assertTrue(m.HasSubstructMatch(qm))
 
-	def testAtomCompareAnyHeavyAtom(self):
-		# H matches H, O matches C
-		smis = ('[H]c1ccccc1C', '[H]c1ccccc1O')
-		ms = [Chem.MolFromSmiles(x, sanitize=False) for x in smis]
-		mcs = rdFMCS.FindMCS(ms, atomCompare=rdFMCS.AtomCompare.CompareAnyHeavyAtom)
-		self.assertEqual(mcs.numBonds, 8)
-		self.assertEqual(mcs.numAtoms, 8)
-		qm = Chem.MolFromSmarts(mcs.smartsString)
+    def testAtomCompareAnyHeavyAtom(self):
+        # H matches H, O matches C
+        smis = ('[H]c1ccccc1C', '[H]c1ccccc1O')
+        ms = [Chem.MolFromSmiles(x, sanitize=False) for x in smis]
+        mcs = rdFMCS.FindMCS(ms, atomCompare=rdFMCS.AtomCompare.CompareAnyHeavyAtom)
+        self.assertEqual(mcs.numBonds, 8)
+        self.assertEqual(mcs.numAtoms, 8)
+        qm = Chem.MolFromSmarts(mcs.smartsString)
 
-		for m in ms:
-			self.assertTrue(m.HasSubstructMatch(qm))
+        for m in ms:
+            self.assertTrue(m.HasSubstructMatch(qm))
 
-	def testAtomCompareAnyHeavyAtom1(self):
-		# O matches C, H does not match O
-		smis = ('[H]c1ccccc1C', 'Oc1ccccc1O')
-		ms = [Chem.MolFromSmiles(x, sanitize=False) for x in smis]
-		mcs = rdFMCS.FindMCS(ms, atomCompare=rdFMCS.AtomCompare.CompareAnyHeavyAtom)
-		self.assertEqual(mcs.numBonds, 7)
-		self.assertEqual(mcs.numAtoms, 7)
-		qm = Chem.MolFromSmarts(mcs.smartsString)
+    def testAtomCompareAnyHeavyAtom1(self):
+        # O matches C, H does not match O
+        smis = ('[H]c1ccccc1C', 'Oc1ccccc1O')
+        ms = [Chem.MolFromSmiles(x, sanitize=False) for x in smis]
+        mcs = rdFMCS.FindMCS(ms, atomCompare=rdFMCS.AtomCompare.CompareAnyHeavyAtom)
+        self.assertEqual(mcs.numBonds, 7)
+        self.assertEqual(mcs.numAtoms, 7)
+        qm = Chem.MolFromSmarts(mcs.smartsString)
 
-		for m in ms:
-			self.assertTrue(m.HasSubstructMatch(qm))
-		
-	def test6MatchValences(self):
-		ms = (Chem.MolFromSmiles('NC1OC1'), Chem.MolFromSmiles('C1OC1[N+](=O)[O-]'))
-		mcs = rdFMCS.FindMCS(ms)
-		self.assertEqual(mcs.numBonds, 4)
-		self.assertEqual(mcs.numAtoms, 4)
-		mcs = rdFMCS.FindMCS(ms, matchValences=True)
-		self.assertEqual(mcs.numBonds, 3)
-		self.assertEqual(mcs.numAtoms, 3)
+        for m in ms:
+            self.assertTrue(m.HasSubstructMatch(qm))
+        
+    def test6MatchValences(self):
+        ms = (Chem.MolFromSmiles('NC1OC1'), Chem.MolFromSmiles('C1OC1[N+](=O)[O-]'))
+        mcs = rdFMCS.FindMCS(ms)
+        self.assertEqual(mcs.numBonds, 4)
+        self.assertEqual(mcs.numAtoms, 4)
+        mcs = rdFMCS.FindMCS(ms, matchValences=True)
+        self.assertEqual(mcs.numBonds, 3)
+        self.assertEqual(mcs.numAtoms, 3)
 
-	def test7Seed(self):
-		smis = ['C1CCC1CC1CC1', 'C1CCC1OC1CC1', 'C1CCC1NC1CC1', 'C1CCC1SC1CC1']
-		ms = [Chem.MolFromSmiles(x) for x in smis]
-		r = rdFMCS.FindMCS(ms)
-		self.assertEqual(r.smartsString, "[#6]1-[#6]-[#6]-[#6]-1")
-		r = rdFMCS.FindMCS(ms, seedSmarts='C1CC1')
-		self.assertEqual(r.smartsString, "[#6]1-[#6]-[#6]-1")
-		r = rdFMCS.FindMCS(ms, seedSmarts='C1OC1')
-		self.assertEqual(r.smartsString, "")
+    def test7Seed(self):
+        smis = ['C1CCC1CC1CC1', 'C1CCC1OC1CC1', 'C1CCC1NC1CC1', 'C1CCC1SC1CC1']
+        ms = [Chem.MolFromSmiles(x) for x in smis]
+        r = rdFMCS.FindMCS(ms)
+        self.assertEqual(r.smartsString, "[#6]1-[#6]-[#6]-[#6]-1")
+        r = rdFMCS.FindMCS(ms, seedSmarts='C1CC1')
+        self.assertEqual(r.smartsString, "[#6]1-[#6]-[#6]-1")
+        r = rdFMCS.FindMCS(ms, seedSmarts='C1OC1')
+        self.assertEqual(r.smartsString, "")
 
-	def test8MatchParams(self):
-		smis = ("CCC1NC1", "CCC1N(C)C1", "CCC1OC1")
-		ms = [Chem.MolFromSmiles(x) for x in smis]
+    def test8MatchParams(self):
+        smis = ("CCC1NC1", "CCC1N(C)C1", "CCC1OC1")
+        ms = [Chem.MolFromSmiles(x) for x in smis]
 
-		mcs = rdFMCS.FindMCS(ms)
-		self.assertEqual(mcs.numAtoms, 4)
+        mcs = rdFMCS.FindMCS(ms)
+        self.assertEqual(mcs.numAtoms, 4)
 
-		ps = rdFMCS.MCSParameters()
-		ps.BondCompareParameters.CompleteRingsOnly = True
-		mcs = rdFMCS.FindMCS(ms, ps)
-		self.assertEqual(mcs.numAtoms, 3)
+        ps = rdFMCS.MCSParameters()
+        ps.BondCompareParameters.CompleteRingsOnly = True
+        mcs = rdFMCS.FindMCS(ms, ps)
+        self.assertEqual(mcs.numAtoms, 3)
 
-		ps = rdFMCS.MCSParameters()
-		ps.SetAtomTyper(rdFMCS.AtomCompare.CompareAny)
-		mcs = rdFMCS.FindMCS(ms, ps)
-		self.assertEqual(mcs.numAtoms, 5)
+        ps = rdFMCS.MCSParameters()
+        ps.SetAtomTyper(rdFMCS.AtomCompare.CompareAny)
+        mcs = rdFMCS.FindMCS(ms, ps)
+        self.assertEqual(mcs.numAtoms, 5)
 
-	def test9MatchCharge(self):
-		smis = ("CCNC", "CCN(C)C", "CC[N+](C)C")
-		ms = [Chem.MolFromSmiles(x) for x in smis]
+    def test9MatchCharge(self):
+        smis = ("CCNC", "CCN(C)C", "CC[N+](C)C")
+        ms = [Chem.MolFromSmiles(x) for x in smis]
 
-		mcs = rdFMCS.FindMCS(ms)
-		self.assertEqual(mcs.numAtoms, 4)
+        mcs = rdFMCS.FindMCS(ms)
+        self.assertEqual(mcs.numAtoms, 4)
 
-		ps = rdFMCS.MCSParameters()
-		ps.AtomCompareParameters.MatchFormalCharge = True
-		mcs = rdFMCS.FindMCS(ms, ps)
-		self.assertEqual(mcs.numAtoms, 2)
+        ps = rdFMCS.MCSParameters()
+        ps.AtomCompareParameters.MatchFormalCharge = True
+        mcs = rdFMCS.FindMCS(ms, ps)
+        self.assertEqual(mcs.numAtoms, 2)
 
-	def test10MatchChargeAndParams(self):
-		smis = ("CCNC", "CCN(C)C", "CC[N+](C)C", "CC[C+](C)C")
-		ms = [Chem.MolFromSmiles(x) for x in smis]
+    def test10MatchChargeAndParams(self):
+        smis = ("CCNC", "CCN(C)C", "CC[N+](C)C", "CC[C+](C)C")
+        ms = [Chem.MolFromSmiles(x) for x in smis]
 
-		mcs = rdFMCS.FindMCS(ms)
-		self.assertEqual(mcs.numAtoms, 2)
+        mcs = rdFMCS.FindMCS(ms)
+        self.assertEqual(mcs.numAtoms, 2)
 
-		ps = rdFMCS.MCSParameters()
-		ps.SetAtomTyper(rdFMCS.AtomCompare.CompareAny)
-		mcs = rdFMCS.FindMCS(ms, ps)
-		self.assertEqual(mcs.numAtoms, 4)
+        ps = rdFMCS.MCSParameters()
+        ps.SetAtomTyper(rdFMCS.AtomCompare.CompareAny)
+        mcs = rdFMCS.FindMCS(ms, ps)
+        self.assertEqual(mcs.numAtoms, 4)
 
-		ps.AtomCompareParameters.MatchFormalCharge = True
-		mcs = rdFMCS.FindMCS(ms, ps)
-		self.assertEqual(mcs.numAtoms, 2)
+        ps.AtomCompareParameters.MatchFormalCharge = True
+        mcs = rdFMCS.FindMCS(ms, ps)
+        self.assertEqual(mcs.numAtoms, 2)
 
-	def test11Github2034(self):
-		smis = ("C1CC1N2CC2", "C1CC1N")
-		ms = [Chem.MolFromSmiles(x) for x in smis]
+    def test11Github2034(self):
+        smis = ("C1CC1N2CC2", "C1CC1N")
+        ms = [Chem.MolFromSmiles(x) for x in smis]
 
-		mcs = rdFMCS.FindMCS(ms)
-		self.assertEqual(mcs.numAtoms, 4)
-		self.assertEqual(mcs.numBonds, 4)
+        mcs = rdFMCS.FindMCS(ms)
+        self.assertEqual(mcs.numAtoms, 4)
+        self.assertEqual(mcs.numBonds, 4)
 
-		mcs = rdFMCS.FindMCS(ms, ringMatchesRingOnly=True)
-		self.assertEqual(mcs.numAtoms, 3)
-		self.assertEqual(mcs.numBonds, 3)
+        mcs = rdFMCS.FindMCS(ms, ringMatchesRingOnly=True)
+        self.assertEqual(mcs.numAtoms, 3)
+        self.assertEqual(mcs.numBonds, 3)
 
-		ps = rdFMCS.MCSParameters()
-		ps.AtomCompareParameters.RingMatchesRingOnly = True
-		mcs = rdFMCS.FindMCS(ms, ps)
-		self.assertEqual(mcs.numAtoms, 3)
-		self.assertEqual(mcs.numBonds, 3)
+        ps = rdFMCS.MCSParameters()
+        ps.AtomCompareParameters.RingMatchesRingOnly = True
+        mcs = rdFMCS.FindMCS(ms, ps)
+        self.assertEqual(mcs.numAtoms, 3)
+        self.assertEqual(mcs.numBonds, 3)
 
 
 if __name__ == "__main__":
-	unittest.main()
+    unittest.main()

--- a/Code/GraphMol/FMCS/Wrap/testFMCS.py
+++ b/Code/GraphMol/FMCS/Wrap/testFMCS.py
@@ -171,6 +171,30 @@ class TestCase(unittest.TestCase):
         for m in ms:
             self.assertTrue(m.HasSubstructMatch(qm))
 
+    def testAtomCompareAnyHeavyAtom(self) {
+        # H matches H, O matches C
+		smis = ('[H]c1ccccc1C', '[H]c1ccccc1O')
+        ms = [Chem.MolFromSmiles(x) for x in smis]
+        mcs = rdFMCS.FindMCS(ms, atomCompare=rdFMCS.AtomCompare.CompareAnyHeavyAtom)
+        self.assertEqual(mcs.numBonds, 8)
+        self.assertEqual(mcs.numAtoms, 8)
+        qm = Chem.MolFromSmarts(mcs.smartsString)
+
+        for m in ms:
+            self.assertTrue(m.HasSubstructMatch(qm))
+
+	def testAtomCompareAnyHeavyAtom1(self) {
+        # O matches C, H does not match O
+		smis = ('[H]c1ccccc1C', 'Oc1ccccc1O')
+        ms = [Chem.MolFromSmiles(x) for x in smis]
+        mcs = rdFMCS.FindMCS(ms, atomCompare=rdFMCS.AtomCompare.CompareAnyHeavyAtom)
+        self.assertEqual(mcs.numBonds, 7)
+        self.assertEqual(mcs.numAtoms, 7)
+        qm = Chem.MolFromSmarts(mcs.smartsString)
+
+        for m in ms:
+            self.assertTrue(m.HasSubstructMatch(qm))
+		
     def test6MatchValences(self):
         ms = (Chem.MolFromSmiles('NC1OC1'), Chem.MolFromSmiles('C1OC1[N+](=O)[O-]'))
         mcs = rdFMCS.FindMCS(ms)

--- a/Code/GraphMol/FMCS/Wrap/testFMCS.py
+++ b/Code/GraphMol/FMCS/Wrap/testFMCS.py
@@ -171,7 +171,7 @@ class TestCase(unittest.TestCase):
         for m in ms:
             self.assertTrue(m.HasSubstructMatch(qm))
 
-    def testAtomCompareAnyHeavyAtom(self) {
+    def testAtomCompareAnyHeavyAtom(self):
         # H matches H, O matches C
 		smis = ('[H]c1ccccc1C', '[H]c1ccccc1O')
         ms = [Chem.MolFromSmiles(x) for x in smis]
@@ -183,7 +183,7 @@ class TestCase(unittest.TestCase):
         for m in ms:
             self.assertTrue(m.HasSubstructMatch(qm))
 
-	def testAtomCompareAnyHeavyAtom1(self) {
+	def testAtomCompareAnyHeavyAtom1(self):
         # O matches C, H does not match O
 		smis = ('[H]c1ccccc1C', 'Oc1ccccc1O')
         ms = [Chem.MolFromSmiles(x) for x in smis]

--- a/Code/GraphMol/FMCS/Wrap/testFMCS.py
+++ b/Code/GraphMol/FMCS/Wrap/testFMCS.py
@@ -8,275 +8,275 @@ from rdkit.Chem import rdFMCS
 
 class TestCase(unittest.TestCase):
 
-    def setUp(self):
-        pass
+	def setUp(self):
+		pass
 
-    def test1(self):
-        smis = (
-          "Cc1nc(CN(C(C)c2ncccc2)CCCCN)ccc1 CHEMBL1682991",  # -- QUERY
-          "Cc1ccc(CN(C(C)c2ccccn2)CCCCN)nc1 CHEMBL1682990",
-          "Cc1cccnc1CN(C(C)c1ccccn1)CCCCN CHEMBL1682998",
-          "CC(N(CCCCN)Cc1c(N)cccn1)c1ccccn1 CHEMBL1682987",
-          "Cc1cc(C)c(CN(C(C)c2ccccn2)CCCCN)nc1 CHEMBL1682992",
-          "Cc1cc(C(C)N(CCCCN)Cc2c(C)cccn2)ncc1 CHEMBL1682993",
-          "Cc1nc(C(C)N(CCCCN)Cc2nc3c([nH]2)cccc3)ccc1 CHEMBL1682878",
-          "CC(c1ncccc1)N(CCCCN)Cc1nc2c([nH]1)cccc2 CHEMBL1682867",
-          "CC(N(CCCCN)Cc1c(C(C)(C)C)cccn1)c1ccccn1 CHEMBL1682989",
-          "CC(N(CCCCN)Cc1c(C(F)(F)F)cccn1)c1ccccn1 CHEMBL1682988",
-        )
-        ms = [Chem.MolFromSmiles(x.split()[0]) for x in smis]
-        qm = ms[0]
-        ms = ms[1:]
-        mcs = rdFMCS.FindMCS(ms)
-        self.assertEqual(mcs.numBonds, 21)
-        self.assertEqual(mcs.numAtoms, 21)
-        self.assertEqual(
-          mcs.smartsString,
-          '[#6](:[#6]:[#6]):[#6]:[#7]:[#6]-[#6]-[#7](-[#6](-[#6])-[#6]1:[#6]:[#6]:[#6]:[#6]:[#7]:1)-[#6]-[#6]-[#6]-[#6]-[#7]'
-        )
-        qm = Chem.MolFromSmarts(mcs.smartsString)
-        self.assertTrue(qm is not None)
-        for m in ms:
-            self.assertTrue(m.HasSubstructMatch(qm))
+	def test1(self):
+		smis = (
+		  "Cc1nc(CN(C(C)c2ncccc2)CCCCN)ccc1 CHEMBL1682991",  # -- QUERY
+		  "Cc1ccc(CN(C(C)c2ccccn2)CCCCN)nc1 CHEMBL1682990",
+		  "Cc1cccnc1CN(C(C)c1ccccn1)CCCCN CHEMBL1682998",
+		  "CC(N(CCCCN)Cc1c(N)cccn1)c1ccccn1 CHEMBL1682987",
+		  "Cc1cc(C)c(CN(C(C)c2ccccn2)CCCCN)nc1 CHEMBL1682992",
+		  "Cc1cc(C(C)N(CCCCN)Cc2c(C)cccn2)ncc1 CHEMBL1682993",
+		  "Cc1nc(C(C)N(CCCCN)Cc2nc3c([nH]2)cccc3)ccc1 CHEMBL1682878",
+		  "CC(c1ncccc1)N(CCCCN)Cc1nc2c([nH]1)cccc2 CHEMBL1682867",
+		  "CC(N(CCCCN)Cc1c(C(C)(C)C)cccn1)c1ccccn1 CHEMBL1682989",
+		  "CC(N(CCCCN)Cc1c(C(F)(F)F)cccn1)c1ccccn1 CHEMBL1682988",
+		)
+		ms = [Chem.MolFromSmiles(x.split()[0]) for x in smis]
+		qm = ms[0]
+		ms = ms[1:]
+		mcs = rdFMCS.FindMCS(ms)
+		self.assertEqual(mcs.numBonds, 21)
+		self.assertEqual(mcs.numAtoms, 21)
+		self.assertEqual(
+		  mcs.smartsString,
+		  '[#6](:[#6]:[#6]):[#6]:[#7]:[#6]-[#6]-[#7](-[#6](-[#6])-[#6]1:[#6]:[#6]:[#6]:[#6]:[#7]:1)-[#6]-[#6]-[#6]-[#6]-[#7]'
+		)
+		qm = Chem.MolFromSmarts(mcs.smartsString)
+		self.assertTrue(qm is not None)
+		for m in ms:
+			self.assertTrue(m.HasSubstructMatch(qm))
 
-        mcs = rdFMCS.FindMCS(ms, threshold=0.8)
-        self.assertEqual(mcs.numBonds, 21)
-        self.assertEqual(mcs.numAtoms, 21)
-        self.assertEqual(
-          mcs.smartsString,
-          '[#6](:[#6]:[#6]):[#6]:[#7]:[#6]-[#6]-[#7](-[#6](-[#6])-[#6]1:[#6]:[#6]:[#6]:[#6]:[#7]:1)-[#6]-[#6]-[#6]-[#6]-[#7]'
-        )
-        qm = Chem.MolFromSmarts(mcs.smartsString)
-        self.assertTrue(qm is not None)
-        for m in ms:
-            self.assertTrue(m.HasSubstructMatch(qm))
+		mcs = rdFMCS.FindMCS(ms, threshold=0.8)
+		self.assertEqual(mcs.numBonds, 21)
+		self.assertEqual(mcs.numAtoms, 21)
+		self.assertEqual(
+		  mcs.smartsString,
+		  '[#6](:[#6]:[#6]):[#6]:[#7]:[#6]-[#6]-[#7](-[#6](-[#6])-[#6]1:[#6]:[#6]:[#6]:[#6]:[#7]:1)-[#6]-[#6]-[#6]-[#6]-[#7]'
+		)
+		qm = Chem.MolFromSmarts(mcs.smartsString)
+		self.assertTrue(qm is not None)
+		for m in ms:
+			self.assertTrue(m.HasSubstructMatch(qm))
 
-    def test2(self):
-        smis = (
-          "CHEMBL122452 CN(CCCN(C)CCc1ccccc1)CCOC(c1ccccc1)c1ccccc1",
-          "CHEMBL123252 CN(CCCc1ccccc1)CCCN(C)CCOC(c1ccccc1)c1ccccc1",
-          "CHEMBL121611 Fc1ccc(C(OCCNCCCNCCc2ccccc2)c2ccc(F)cc2)cc1",
-          "CHEMBL121050 O=C(Cc1ccccc1)NCCCCNCCOC(c1ccc(F)cc1)c1ccc(F)cc1",
-          "CHEMBL333667 O=C(Cc1ccccc1)NCCNCCOC(c1ccc(F)cc1)c1ccc(F)cc1",
-          "CHEMBL121486 O=C(Cc1ccc(Br)cc1)NC=CNCCOC(c1ccc(F)cc1)c1ccc(F)cc1",
-          "CHEMBL123830 O=C(Cc1ccc(F)cc1)NCCNCCOC(c1ccc(F)cc1)c1ccc(F)cc1",
-          "CHEMBL420900 O=C(Cc1ccccc1)NCCCNCCOC(c1ccc(F)cc1)c1ccc(F)cc1",
-          "CHEMBL121460 CN(CCOC(c1ccc(F)cc1)c1ccc(F)cc1)CCN(C)CCOC(c1ccc(F)cc1)c1ccc(F)cc1",
-          "CHEMBL120901 COC(=O)C1C2CCC(CC1C(=O)Oc1ccccc1)N2C",
-          "CHEMBL122859 O=C1CN(CCc2ccccc2)CCN1CCOC(c1ccc(F)cc1)c1ccc(F)cc1",
-          "CHEMBL121027 CN(CCOC(c1ccccc1)c1ccccc1)CCN(C)CCc1ccc(F)cc1",
-        )
+	def test2(self):
+		smis = (
+		  "CHEMBL122452 CN(CCCN(C)CCc1ccccc1)CCOC(c1ccccc1)c1ccccc1",
+		  "CHEMBL123252 CN(CCCc1ccccc1)CCCN(C)CCOC(c1ccccc1)c1ccccc1",
+		  "CHEMBL121611 Fc1ccc(C(OCCNCCCNCCc2ccccc2)c2ccc(F)cc2)cc1",
+		  "CHEMBL121050 O=C(Cc1ccccc1)NCCCCNCCOC(c1ccc(F)cc1)c1ccc(F)cc1",
+		  "CHEMBL333667 O=C(Cc1ccccc1)NCCNCCOC(c1ccc(F)cc1)c1ccc(F)cc1",
+		  "CHEMBL121486 O=C(Cc1ccc(Br)cc1)NC=CNCCOC(c1ccc(F)cc1)c1ccc(F)cc1",
+		  "CHEMBL123830 O=C(Cc1ccc(F)cc1)NCCNCCOC(c1ccc(F)cc1)c1ccc(F)cc1",
+		  "CHEMBL420900 O=C(Cc1ccccc1)NCCCNCCOC(c1ccc(F)cc1)c1ccc(F)cc1",
+		  "CHEMBL121460 CN(CCOC(c1ccc(F)cc1)c1ccc(F)cc1)CCN(C)CCOC(c1ccc(F)cc1)c1ccc(F)cc1",
+		  "CHEMBL120901 COC(=O)C1C2CCC(CC1C(=O)Oc1ccccc1)N2C",
+		  "CHEMBL122859 O=C1CN(CCc2ccccc2)CCN1CCOC(c1ccc(F)cc1)c1ccc(F)cc1",
+		  "CHEMBL121027 CN(CCOC(c1ccccc1)c1ccccc1)CCN(C)CCc1ccc(F)cc1",
+		)
 
-        ms = [Chem.MolFromSmiles(x.split()[1]) for x in smis]
-        qm = ms[0]
-        ms = ms[1:]
-        mcs = rdFMCS.FindMCS(ms)
-        self.assertEqual(mcs.numBonds, 9)
-        self.assertEqual(mcs.numAtoms, 10)
-        qm = Chem.MolFromSmarts(mcs.smartsString)
-        self.assertTrue(qm is not None)
-        for m in ms:
-            self.assertTrue(m.HasSubstructMatch(qm))
-        # smarts too hard to canonicalize this
-        # self.assertEqual(mcs.smartsString,'[#6]-,:[#6]-,:[#6]-,:[#6]-,:[#6](-[#6]-[#8]-[#6]:,-[#6])-,:[#6]')
+		ms = [Chem.MolFromSmiles(x.split()[1]) for x in smis]
+		qm = ms[0]
+		ms = ms[1:]
+		mcs = rdFMCS.FindMCS(ms)
+		self.assertEqual(mcs.numBonds, 9)
+		self.assertEqual(mcs.numAtoms, 10)
+		qm = Chem.MolFromSmarts(mcs.smartsString)
+		self.assertTrue(qm is not None)
+		for m in ms:
+			self.assertTrue(m.HasSubstructMatch(qm))
+		# smarts too hard to canonicalize this
+		# self.assertEqual(mcs.smartsString,'[#6]-,:[#6]-,:[#6]-,:[#6]-,:[#6](-[#6]-[#8]-[#6]:,-[#6])-,:[#6]')
 
-        mcs = rdFMCS.FindMCS(ms, threshold=0.8)
-        self.assertEqual(mcs.numBonds, 20)
-        self.assertEqual(mcs.numAtoms, 19)
-        qm = Chem.MolFromSmarts(mcs.smartsString)
-        self.assertTrue(qm is not None)
-        nHits = 0
-        for m in ms:
-            if m.HasSubstructMatch(qm):
-                nHits += 1
-        self.assertTrue(nHits >= int(0.8 * len(smis)))
-        # smarts too hard to canonicalize this
-        # self.assertEqual(mcs.smartsString,'[#6]1:[#6]:[#6]:[#6](:[#6]:[#6]:1)-[#6](-[#8]-[#6]-[#6]-[#7]-[#6]-[#6])-[#6]2:[#6]:[#6]:[#6]:[#6]:[#6]:2')
+		mcs = rdFMCS.FindMCS(ms, threshold=0.8)
+		self.assertEqual(mcs.numBonds, 20)
+		self.assertEqual(mcs.numAtoms, 19)
+		qm = Chem.MolFromSmarts(mcs.smartsString)
+		self.assertTrue(qm is not None)
+		nHits = 0
+		for m in ms:
+			if m.HasSubstructMatch(qm):
+				nHits += 1
+		self.assertTrue(nHits >= int(0.8 * len(smis)))
+		# smarts too hard to canonicalize this
+		# self.assertEqual(mcs.smartsString,'[#6]1:[#6]:[#6]:[#6](:[#6]:[#6]:1)-[#6](-[#8]-[#6]-[#6]-[#7]-[#6]-[#6])-[#6]2:[#6]:[#6]:[#6]:[#6]:[#6]:2')
 
-    def test3IsotopeMatch(self):
-        smis = (
-          "CC[14NH2]",
-          "CC[14CH3]",
-        )
+	def test3IsotopeMatch(self):
+		smis = (
+		  "CC[14NH2]",
+		  "CC[14CH3]",
+		)
 
-        ms = [Chem.MolFromSmiles(x) for x in smis]
-        mcs = rdFMCS.FindMCS(ms)
-        self.assertEqual(mcs.numBonds, 1)
-        self.assertEqual(mcs.numAtoms, 2)
-        qm = Chem.MolFromSmarts(mcs.smartsString)
+		ms = [Chem.MolFromSmiles(x) for x in smis]
+		mcs = rdFMCS.FindMCS(ms)
+		self.assertEqual(mcs.numBonds, 1)
+		self.assertEqual(mcs.numAtoms, 2)
+		qm = Chem.MolFromSmarts(mcs.smartsString)
 
-        mcs = rdFMCS.FindMCS(ms, atomCompare=rdFMCS.AtomCompare.CompareIsotopes)
-        self.assertEqual(mcs.numBonds, 2)
-        self.assertEqual(mcs.numAtoms, 3)
-        qm = Chem.MolFromSmarts(mcs.smartsString)
+		mcs = rdFMCS.FindMCS(ms, atomCompare=rdFMCS.AtomCompare.CompareIsotopes)
+		self.assertEqual(mcs.numBonds, 2)
+		self.assertEqual(mcs.numAtoms, 3)
+		qm = Chem.MolFromSmarts(mcs.smartsString)
 
-        self.assertTrue(Chem.MolFromSmiles('CC[14CH3]').HasSubstructMatch(qm))
-        self.assertFalse(Chem.MolFromSmiles('CC[13CH3]').HasSubstructMatch(qm))
-        self.assertTrue(Chem.MolFromSmiles('OO[14CH3]').HasSubstructMatch(qm))
-        self.assertFalse(Chem.MolFromSmiles('O[13CH2][14CH3]').HasSubstructMatch(qm))
+		self.assertTrue(Chem.MolFromSmiles('CC[14CH3]').HasSubstructMatch(qm))
+		self.assertFalse(Chem.MolFromSmiles('CC[13CH3]').HasSubstructMatch(qm))
+		self.assertTrue(Chem.MolFromSmiles('OO[14CH3]').HasSubstructMatch(qm))
+		self.assertFalse(Chem.MolFromSmiles('O[13CH2][14CH3]').HasSubstructMatch(qm))
 
-    def test4RingMatches(self):
-        smis = ['CCCCC', 'CCC1CCCCC1']
-        ms = [Chem.MolFromSmiles(x) for x in smis]
-        mcs = rdFMCS.FindMCS(ms)
-        self.assertEqual(mcs.numBonds, 4)
-        self.assertEqual(mcs.numAtoms, 5)
-        self.assertEqual(mcs.smartsString, '[#6]-[#6]-[#6]-[#6]-[#6]')
+	def test4RingMatches(self):
+		smis = ['CCCCC', 'CCC1CCCCC1']
+		ms = [Chem.MolFromSmiles(x) for x in smis]
+		mcs = rdFMCS.FindMCS(ms)
+		self.assertEqual(mcs.numBonds, 4)
+		self.assertEqual(mcs.numAtoms, 5)
+		self.assertEqual(mcs.smartsString, '[#6]-[#6]-[#6]-[#6]-[#6]')
 
-        mcs = rdFMCS.FindMCS(ms, completeRingsOnly=True)
-        self.assertEqual(mcs.numBonds, 2)
-        self.assertEqual(mcs.numAtoms, 3)
-        self.assertEqual(mcs.smartsString, '[#6]-[#6]-[#6]')
+		mcs = rdFMCS.FindMCS(ms, completeRingsOnly=True)
+		self.assertEqual(mcs.numBonds, 2)
+		self.assertEqual(mcs.numAtoms, 3)
+		self.assertEqual(mcs.smartsString, '[#6]-[#6]-[#6]')
 
-        mcs = rdFMCS.FindMCS(ms, ringMatchesRingOnly=True)
-        self.assertEqual(mcs.numBonds, 1)
-        self.assertEqual(mcs.numAtoms, 2)
-        self.assertEqual(mcs.smartsString, '[#6]-[#6]')
+		mcs = rdFMCS.FindMCS(ms, ringMatchesRingOnly=True)
+		self.assertEqual(mcs.numBonds, 1)
+		self.assertEqual(mcs.numAtoms, 2)
+		self.assertEqual(mcs.smartsString, '[#6]-[#6]')
 
-        smis = ['CC1CCC1', 'CCC1CCCCC1']
-        ms = [Chem.MolFromSmiles(x) for x in smis]
-        mcs = rdFMCS.FindMCS(ms)
-        self.assertEqual(mcs.numBonds, 4)
-        self.assertEqual(mcs.numAtoms, 5)
-        self.assertEqual(mcs.smartsString, '[#6]-[#6](-[#6]-[#6])-[#6]')
+		smis = ['CC1CCC1', 'CCC1CCCCC1']
+		ms = [Chem.MolFromSmiles(x) for x in smis]
+		mcs = rdFMCS.FindMCS(ms)
+		self.assertEqual(mcs.numBonds, 4)
+		self.assertEqual(mcs.numAtoms, 5)
+		self.assertEqual(mcs.smartsString, '[#6]-[#6](-[#6]-[#6])-[#6]')
 
-        mcs = rdFMCS.FindMCS(ms, completeRingsOnly=True)
-        self.assertEqual(mcs.numBonds, 0)
-        self.assertEqual(mcs.numAtoms, 0)
-        self.assertEqual(mcs.smartsString, '')
+		mcs = rdFMCS.FindMCS(ms, completeRingsOnly=True)
+		self.assertEqual(mcs.numBonds, 0)
+		self.assertEqual(mcs.numAtoms, 0)
+		self.assertEqual(mcs.smartsString, '')
 
-        mcs = rdFMCS.FindMCS(ms, ringMatchesRingOnly=True)
-        self.assertEqual(mcs.numBonds, 4)
-        self.assertEqual(mcs.numAtoms, 5)
-        self.assertEqual(mcs.smartsString, '[#6]-[#6](-[#6]-[#6])-[#6]')
+		mcs = rdFMCS.FindMCS(ms, ringMatchesRingOnly=True)
+		self.assertEqual(mcs.numBonds, 4)
+		self.assertEqual(mcs.numAtoms, 5)
+		self.assertEqual(mcs.smartsString, '[#6]-[#6](-[#6]-[#6])-[#6]')
 
-    def test5AnyMatch(self):
-        smis = ('c1ccccc1C', 'c1ccccc1O', 'c1ccccc1Cl')
-        ms = [Chem.MolFromSmiles(x) for x in smis]
-        mcs = rdFMCS.FindMCS(ms, atomCompare=rdFMCS.AtomCompare.CompareAny)
-        self.assertEqual(mcs.numBonds, 7)
-        self.assertEqual(mcs.numAtoms, 7)
-        qm = Chem.MolFromSmarts(mcs.smartsString)
+	def test5AnyMatch(self):
+		smis = ('c1ccccc1C', 'c1ccccc1O', 'c1ccccc1Cl')
+		ms = [Chem.MolFromSmiles(x) for x in smis]
+		mcs = rdFMCS.FindMCS(ms, atomCompare=rdFMCS.AtomCompare.CompareAny)
+		self.assertEqual(mcs.numBonds, 7)
+		self.assertEqual(mcs.numAtoms, 7)
+		qm = Chem.MolFromSmarts(mcs.smartsString)
 
-        for m in ms:
-            self.assertTrue(m.HasSubstructMatch(qm))
+		for m in ms:
+			self.assertTrue(m.HasSubstructMatch(qm))
 
-        smis = ('c1cccnc1C', 'c1cnncc1O', 'c1cccnc1Cl')
-        ms = [Chem.MolFromSmiles(x) for x in smis]
-        mcs = rdFMCS.FindMCS(ms, atomCompare=rdFMCS.AtomCompare.CompareAny)
-        self.assertEqual(mcs.numBonds, 7)
-        self.assertEqual(mcs.numAtoms, 7)
-        qm = Chem.MolFromSmarts(mcs.smartsString)
+		smis = ('c1cccnc1C', 'c1cnncc1O', 'c1cccnc1Cl')
+		ms = [Chem.MolFromSmiles(x) for x in smis]
+		mcs = rdFMCS.FindMCS(ms, atomCompare=rdFMCS.AtomCompare.CompareAny)
+		self.assertEqual(mcs.numBonds, 7)
+		self.assertEqual(mcs.numAtoms, 7)
+		qm = Chem.MolFromSmarts(mcs.smartsString)
 
-        for m in ms:
-            self.assertTrue(m.HasSubstructMatch(qm))
+		for m in ms:
+			self.assertTrue(m.HasSubstructMatch(qm))
 
-    def testAtomCompareAnyHeavyAtom(self):
-        # H matches H, O matches C
+	def testAtomCompareAnyHeavyAtom(self):
+		# H matches H, O matches C
 		smis = ('[H]c1ccccc1C', '[H]c1ccccc1O')
-        ms = [Chem.MolFromSmiles(x) for x in smis]
-        mcs = rdFMCS.FindMCS(ms, atomCompare=rdFMCS.AtomCompare.CompareAnyHeavyAtom)
-        self.assertEqual(mcs.numBonds, 8)
-        self.assertEqual(mcs.numAtoms, 8)
-        qm = Chem.MolFromSmarts(mcs.smartsString)
+		ms = [Chem.MolFromSmiles(x) for x in smis]
+		mcs = rdFMCS.FindMCS(ms, atomCompare=rdFMCS.AtomCompare.CompareAnyHeavyAtom)
+		self.assertEqual(mcs.numBonds, 8)
+		self.assertEqual(mcs.numAtoms, 8)
+		qm = Chem.MolFromSmarts(mcs.smartsString)
 
-        for m in ms:
-            self.assertTrue(m.HasSubstructMatch(qm))
+		for m in ms:
+			self.assertTrue(m.HasSubstructMatch(qm))
 
 	def testAtomCompareAnyHeavyAtom1(self):
-        # O matches C, H does not match O
+		# O matches C, H does not match O
 		smis = ('[H]c1ccccc1C', 'Oc1ccccc1O')
-        ms = [Chem.MolFromSmiles(x) for x in smis]
-        mcs = rdFMCS.FindMCS(ms, atomCompare=rdFMCS.AtomCompare.CompareAnyHeavyAtom)
-        self.assertEqual(mcs.numBonds, 7)
-        self.assertEqual(mcs.numAtoms, 7)
-        qm = Chem.MolFromSmarts(mcs.smartsString)
+		ms = [Chem.MolFromSmiles(x) for x in smis]
+		mcs = rdFMCS.FindMCS(ms, atomCompare=rdFMCS.AtomCompare.CompareAnyHeavyAtom)
+		self.assertEqual(mcs.numBonds, 7)
+		self.assertEqual(mcs.numAtoms, 7)
+		qm = Chem.MolFromSmarts(mcs.smartsString)
 
-        for m in ms:
-            self.assertTrue(m.HasSubstructMatch(qm))
+		for m in ms:
+			self.assertTrue(m.HasSubstructMatch(qm))
 		
-    def test6MatchValences(self):
-        ms = (Chem.MolFromSmiles('NC1OC1'), Chem.MolFromSmiles('C1OC1[N+](=O)[O-]'))
-        mcs = rdFMCS.FindMCS(ms)
-        self.assertEqual(mcs.numBonds, 4)
-        self.assertEqual(mcs.numAtoms, 4)
-        mcs = rdFMCS.FindMCS(ms, matchValences=True)
-        self.assertEqual(mcs.numBonds, 3)
-        self.assertEqual(mcs.numAtoms, 3)
+	def test6MatchValences(self):
+		ms = (Chem.MolFromSmiles('NC1OC1'), Chem.MolFromSmiles('C1OC1[N+](=O)[O-]'))
+		mcs = rdFMCS.FindMCS(ms)
+		self.assertEqual(mcs.numBonds, 4)
+		self.assertEqual(mcs.numAtoms, 4)
+		mcs = rdFMCS.FindMCS(ms, matchValences=True)
+		self.assertEqual(mcs.numBonds, 3)
+		self.assertEqual(mcs.numAtoms, 3)
 
-    def test7Seed(self):
-        smis = ['C1CCC1CC1CC1', 'C1CCC1OC1CC1', 'C1CCC1NC1CC1', 'C1CCC1SC1CC1']
-        ms = [Chem.MolFromSmiles(x) for x in smis]
-        r = rdFMCS.FindMCS(ms)
-        self.assertEqual(r.smartsString, "[#6]1-[#6]-[#6]-[#6]-1")
-        r = rdFMCS.FindMCS(ms, seedSmarts='C1CC1')
-        self.assertEqual(r.smartsString, "[#6]1-[#6]-[#6]-1")
-        r = rdFMCS.FindMCS(ms, seedSmarts='C1OC1')
-        self.assertEqual(r.smartsString, "")
+	def test7Seed(self):
+		smis = ['C1CCC1CC1CC1', 'C1CCC1OC1CC1', 'C1CCC1NC1CC1', 'C1CCC1SC1CC1']
+		ms = [Chem.MolFromSmiles(x) for x in smis]
+		r = rdFMCS.FindMCS(ms)
+		self.assertEqual(r.smartsString, "[#6]1-[#6]-[#6]-[#6]-1")
+		r = rdFMCS.FindMCS(ms, seedSmarts='C1CC1')
+		self.assertEqual(r.smartsString, "[#6]1-[#6]-[#6]-1")
+		r = rdFMCS.FindMCS(ms, seedSmarts='C1OC1')
+		self.assertEqual(r.smartsString, "")
 
-    def test8MatchParams(self):
-        smis = ("CCC1NC1", "CCC1N(C)C1", "CCC1OC1")
-        ms = [Chem.MolFromSmiles(x) for x in smis]
+	def test8MatchParams(self):
+		smis = ("CCC1NC1", "CCC1N(C)C1", "CCC1OC1")
+		ms = [Chem.MolFromSmiles(x) for x in smis]
 
-        mcs = rdFMCS.FindMCS(ms)
-        self.assertEqual(mcs.numAtoms, 4)
+		mcs = rdFMCS.FindMCS(ms)
+		self.assertEqual(mcs.numAtoms, 4)
 
-        ps = rdFMCS.MCSParameters()
-        ps.BondCompareParameters.CompleteRingsOnly = True
-        mcs = rdFMCS.FindMCS(ms, ps)
-        self.assertEqual(mcs.numAtoms, 3)
+		ps = rdFMCS.MCSParameters()
+		ps.BondCompareParameters.CompleteRingsOnly = True
+		mcs = rdFMCS.FindMCS(ms, ps)
+		self.assertEqual(mcs.numAtoms, 3)
 
-        ps = rdFMCS.MCSParameters()
-        ps.SetAtomTyper(rdFMCS.AtomCompare.CompareAny)
-        mcs = rdFMCS.FindMCS(ms, ps)
-        self.assertEqual(mcs.numAtoms, 5)
+		ps = rdFMCS.MCSParameters()
+		ps.SetAtomTyper(rdFMCS.AtomCompare.CompareAny)
+		mcs = rdFMCS.FindMCS(ms, ps)
+		self.assertEqual(mcs.numAtoms, 5)
 
-    def test9MatchCharge(self):
-        smis = ("CCNC", "CCN(C)C", "CC[N+](C)C")
-        ms = [Chem.MolFromSmiles(x) for x in smis]
+	def test9MatchCharge(self):
+		smis = ("CCNC", "CCN(C)C", "CC[N+](C)C")
+		ms = [Chem.MolFromSmiles(x) for x in smis]
 
-        mcs = rdFMCS.FindMCS(ms)
-        self.assertEqual(mcs.numAtoms, 4)
+		mcs = rdFMCS.FindMCS(ms)
+		self.assertEqual(mcs.numAtoms, 4)
 
-        ps = rdFMCS.MCSParameters()
-        ps.AtomCompareParameters.MatchFormalCharge = True
-        mcs = rdFMCS.FindMCS(ms, ps)
-        self.assertEqual(mcs.numAtoms, 2)
+		ps = rdFMCS.MCSParameters()
+		ps.AtomCompareParameters.MatchFormalCharge = True
+		mcs = rdFMCS.FindMCS(ms, ps)
+		self.assertEqual(mcs.numAtoms, 2)
 
-    def test10MatchChargeAndParams(self):
-        smis = ("CCNC", "CCN(C)C", "CC[N+](C)C", "CC[C+](C)C")
-        ms = [Chem.MolFromSmiles(x) for x in smis]
+	def test10MatchChargeAndParams(self):
+		smis = ("CCNC", "CCN(C)C", "CC[N+](C)C", "CC[C+](C)C")
+		ms = [Chem.MolFromSmiles(x) for x in smis]
 
-        mcs = rdFMCS.FindMCS(ms)
-        self.assertEqual(mcs.numAtoms, 2)
+		mcs = rdFMCS.FindMCS(ms)
+		self.assertEqual(mcs.numAtoms, 2)
 
-        ps = rdFMCS.MCSParameters()
-        ps.SetAtomTyper(rdFMCS.AtomCompare.CompareAny)
-        mcs = rdFMCS.FindMCS(ms, ps)
-        self.assertEqual(mcs.numAtoms, 4)
+		ps = rdFMCS.MCSParameters()
+		ps.SetAtomTyper(rdFMCS.AtomCompare.CompareAny)
+		mcs = rdFMCS.FindMCS(ms, ps)
+		self.assertEqual(mcs.numAtoms, 4)
 
-        ps.AtomCompareParameters.MatchFormalCharge = True
-        mcs = rdFMCS.FindMCS(ms, ps)
-        self.assertEqual(mcs.numAtoms, 2)
+		ps.AtomCompareParameters.MatchFormalCharge = True
+		mcs = rdFMCS.FindMCS(ms, ps)
+		self.assertEqual(mcs.numAtoms, 2)
 
-    def test11Github2034(self):
-        smis = ("C1CC1N2CC2", "C1CC1N")
-        ms = [Chem.MolFromSmiles(x) for x in smis]
+	def test11Github2034(self):
+		smis = ("C1CC1N2CC2", "C1CC1N")
+		ms = [Chem.MolFromSmiles(x) for x in smis]
 
-        mcs = rdFMCS.FindMCS(ms)
-        self.assertEqual(mcs.numAtoms, 4)
-        self.assertEqual(mcs.numBonds, 4)
+		mcs = rdFMCS.FindMCS(ms)
+		self.assertEqual(mcs.numAtoms, 4)
+		self.assertEqual(mcs.numBonds, 4)
 
-        mcs = rdFMCS.FindMCS(ms, ringMatchesRingOnly=True)
-        self.assertEqual(mcs.numAtoms, 3)
-        self.assertEqual(mcs.numBonds, 3)
+		mcs = rdFMCS.FindMCS(ms, ringMatchesRingOnly=True)
+		self.assertEqual(mcs.numAtoms, 3)
+		self.assertEqual(mcs.numBonds, 3)
 
-        ps = rdFMCS.MCSParameters()
-        ps.AtomCompareParameters.RingMatchesRingOnly = True
-        mcs = rdFMCS.FindMCS(ms, ps)
-        self.assertEqual(mcs.numAtoms, 3)
-        self.assertEqual(mcs.numBonds, 3)
+		ps = rdFMCS.MCSParameters()
+		ps.AtomCompareParameters.RingMatchesRingOnly = True
+		mcs = rdFMCS.FindMCS(ms, ps)
+		self.assertEqual(mcs.numAtoms, 3)
+		self.assertEqual(mcs.numBonds, 3)
 
 
 if __name__ == "__main__":
-    unittest.main()
+	unittest.main()

--- a/Code/GraphMol/FMCS/Wrap/testFMCS.py
+++ b/Code/GraphMol/FMCS/Wrap/testFMCS.py
@@ -174,7 +174,7 @@ class TestCase(unittest.TestCase):
 	def testAtomCompareAnyHeavyAtom(self):
 		# H matches H, O matches C
 		smis = ('[H]c1ccccc1C', '[H]c1ccccc1O')
-		ms = [Chem.MolFromSmiles(x) for x in smis]
+		ms = [Chem.MolFromSmiles(x, sanitize=False) for x in smis]
 		mcs = rdFMCS.FindMCS(ms, atomCompare=rdFMCS.AtomCompare.CompareAnyHeavyAtom)
 		self.assertEqual(mcs.numBonds, 8)
 		self.assertEqual(mcs.numAtoms, 8)
@@ -186,7 +186,7 @@ class TestCase(unittest.TestCase):
 	def testAtomCompareAnyHeavyAtom1(self):
 		# O matches C, H does not match O
 		smis = ('[H]c1ccccc1C', 'Oc1ccccc1O')
-		ms = [Chem.MolFromSmiles(x) for x in smis]
+		ms = [Chem.MolFromSmiles(x, sanitize=False) for x in smis]
 		mcs = rdFMCS.FindMCS(ms, atomCompare=rdFMCS.AtomCompare.CompareAnyHeavyAtom)
 		self.assertEqual(mcs.numBonds, 7)
 		self.assertEqual(mcs.numAtoms, 7)

--- a/Code/GraphMol/FMCS/testFMCS_Unit.cpp
+++ b/Code/GraphMol/FMCS/testFMCS_Unit.cpp
@@ -593,7 +593,7 @@ void testAtomCompareAnyHeavyAtom() {
   const char* smi[] = {
       "[H]c1ccccc1C", "[H]c1ccccc1O",  // H matches H, O matches C
   };
-  for (auto& i : smi) mols.push_back(ROMOL_SPTR(SmilesToMol(getSmilesOnly(i))));
+  for (auto& i : smi) mols.push_back(ROMOL_SPTR(SmilesToMol(getSmilesOnly(i),0,false)));
   MCSParameters p;
   p.AtomTyper = MCSAtomCompareAnyHeavyAtom;
   t0 = nanoClock();
@@ -613,7 +613,7 @@ void testAtomCompareAnyHeavyAtom1() {
   const char* smi[] = {
       "[H]c1ccccc1C", "Oc1ccccc1O",  // O matches C, H does not match O
   };
-  for (auto& i : smi) mols.push_back(ROMOL_SPTR(SmilesToMol(getSmilesOnly(i))));
+  for (auto& i : smi) mols.push_back(ROMOL_SPTR(SmilesToMol(getSmilesOnly(i),0,false)));
   MCSParameters p;
   p.AtomTyper = MCSAtomCompareAnyHeavyAtom;
   t0 = nanoClock();

--- a/Code/GraphMol/FMCS/testFMCS_Unit.cpp
+++ b/Code/GraphMol/FMCS/testFMCS_Unit.cpp
@@ -585,6 +585,46 @@ void testAtomCompareAnyAtomBond() {
   BOOST_LOG(rdInfoLog) << "\tdone" << std::endl;
 }
 
+void testAtomCompareAnyHeavyAtom() {
+  BOOST_LOG(rdInfoLog) << "-------------------------------------" << std::endl;
+  BOOST_LOG(rdInfoLog) << "Testing FMCS testAtomCompareAnyAtom" << std::endl;
+  std::cout << "\ntestAtomCompareAnyAtom()\n";
+  std::vector<ROMOL_SPTR> mols;
+  const char* smi[] = {
+      "[H]c1ccccc1C", "[H]c1ccccc1O",  // H matches H, O matches C
+  };
+  for (auto& i : smi) mols.push_back(ROMOL_SPTR(SmilesToMol(getSmilesOnly(i))));
+  MCSParameters p;
+  p.AtomTyper = MCSAtomCompareAnyHeavyAtom;
+  t0 = nanoClock();
+  MCSResult res = findMCS(mols, &p);
+  std::cout << "MCS: " << res.SmartsString << " " << res.NumAtoms << " atoms, "
+            << res.NumBonds << " bonds\n";
+  printTime();
+  TEST_ASSERT(res.NumAtoms == 8 && res.NumBonds == 8);
+  BOOST_LOG(rdInfoLog) << "\tdone" << std::endl;
+}
+
+void testAtomCompareAnyHeavyAtom1() {
+  BOOST_LOG(rdInfoLog) << "-------------------------------------" << std::endl;
+  BOOST_LOG(rdInfoLog) << "Testing FMCS testAtomCompareAnyAtom" << std::endl;
+  std::cout << "\ntestAtomCompareAnyAtom()\n";
+  std::vector<ROMOL_SPTR> mols;
+  const char* smi[] = {
+      "[H]c1ccccc1C", "Oc1ccccc1O",  // O matches C, H does not match O
+  };
+  for (auto& i : smi) mols.push_back(ROMOL_SPTR(SmilesToMol(getSmilesOnly(i))));
+  MCSParameters p;
+  p.AtomTyper = MCSAtomCompareAnyHeavyAtom;
+  t0 = nanoClock();
+  MCSResult res = findMCS(mols, &p);
+  std::cout << "MCS: " << res.SmartsString << " " << res.NumAtoms << " atoms, "
+            << res.NumBonds << " bonds\n";
+  printTime();
+  TEST_ASSERT(res.NumAtoms == 7 && res.NumBonds == 7);
+  BOOST_LOG(rdInfoLog) << "\tdone" << std::endl;
+}
+
 void testSimple() {
   BOOST_LOG(rdInfoLog) << "-------------------------------------" << std::endl;
   BOOST_LOG(rdInfoLog) << "Testing FMCS testSimple" << std::endl;
@@ -1313,6 +1353,8 @@ int main(int argc, const char* argv[]) {
   testAtomCompareIsotopes();
   testAtomCompareAnyAtom();
   testAtomCompareAnyAtomBond();
+  testAtomCompareAnyHeavyAtom();
+  testAtomCompareAnyHeavyAtom1();
 
   test18();
   test504();

--- a/Code/JavaWrappers/gmwrapper/src-test/org/RDKit/FMCSTests.java
+++ b/Code/JavaWrappers/gmwrapper/src-test/org/RDKit/FMCSTests.java
@@ -86,6 +86,37 @@ public class FMCSTests extends GraphMolTest {
                 assertEquals(false,mcs.getCanceled());
 
 	}
+	
+	@Test
+	void testAtomCompareAnyHeavyAtom() {
+		ROMol_Vect mols = new ROMol_Vect();
+		mols.add(RWMol.MolFromSmiles("[H]c1ccccc1C"));
+		mols.add(RWMol.MolFromSmiles("[H]c1ccccc1O"));
+		        // H matches H, O matches C
+                MCSResult mcs=RDKFuncs.findMCS(mols,true,1,60,false,false,false,false,false,
+                                               AtomComparator.AtomCompareAnyHeavyAtom,
+                                               BondComparator.BondCompareAny);
+                assertEquals(8,mcs.getNumAtoms());
+                assertEquals(8,mcs.getNumBonds());
+                //assertEquals("[#6]1:,-[#6]:,-[#6]:,-[#6]:,-[#6]:,-[#6]:,-1",mcs.getSmartsString());
+                assertEquals(false,mcs.getCanceled());
+}
+
+	@Test
+	void testAtomCompareAnyHeavyAtom1() {
+		ROMol_Vect mols = new ROMol_Vect();
+			mols.add(RWMol.MolFromSmiles("[H]c1ccccc1C"));
+			mols.add(RWMol.MolFromSmiles("Oc1ccccc1O"));
+					// O matches C, H does not match O
+					MCSResult mcs=RDKFuncs.findMCS(mols,true,1,60,false,false,false,false,false,
+												   AtomComparator.AtomCompareAnyHeavyAtom,
+												   BondComparator.BondCompareAny);
+					assertEquals(7,mcs.getNumAtoms());
+					assertEquals(7,mcs.getNumBonds());
+					//assertEquals("[#6]1:,-[#6]:,-[#6]:,-[#6]:,-[#6]:,-[#6]:,-1",mcs.getSmartsString());
+					assertEquals(false,mcs.getCanceled());
+	  
+	}
 
 	public static void main(String args[]) {
 		org.junit.runner.JUnitCore.main("org.RDKit.FMCSTests");

--- a/Code/JavaWrappers/gmwrapper/src-test/org/RDKit/FMCSTests.java
+++ b/Code/JavaWrappers/gmwrapper/src-test/org/RDKit/FMCSTests.java
@@ -88,7 +88,7 @@ public class FMCSTests extends GraphMolTest {
 	}
 	
 	@Test
-	void testAtomCompareAnyHeavyAtom() {
+	public void testAtomCompareAnyHeavyAtom() {
 		ROMol_Vect mols = new ROMol_Vect();
 		mols.add(RWMol.MolFromSmiles("[H]c1ccccc1C",0, false));
 		mols.add(RWMol.MolFromSmiles("[H]c1ccccc1O",0, false));
@@ -103,7 +103,7 @@ public class FMCSTests extends GraphMolTest {
 }
 
 	@Test
-	void testAtomCompareAnyHeavyAtom1() {
+	public void testAtomCompareAnyHeavyAtom1() {
 		ROMol_Vect mols = new ROMol_Vect();
 			mols.add(RWMol.MolFromSmiles("[H]c1ccccc1C",0, false));
 			mols.add(RWMol.MolFromSmiles("Oc1ccccc1O",0, false));

--- a/Code/JavaWrappers/gmwrapper/src-test/org/RDKit/FMCSTests.java
+++ b/Code/JavaWrappers/gmwrapper/src-test/org/RDKit/FMCSTests.java
@@ -90,8 +90,8 @@ public class FMCSTests extends GraphMolTest {
 	@Test
 	void testAtomCompareAnyHeavyAtom() {
 		ROMol_Vect mols = new ROMol_Vect();
-		mols.add(RWMol.MolFromSmiles("[H]c1ccccc1C"));
-		mols.add(RWMol.MolFromSmiles("[H]c1ccccc1O"));
+		mols.add(RWMol.MolFromSmiles("[H]c1ccccc1C",0, false));
+		mols.add(RWMol.MolFromSmiles("[H]c1ccccc1O",0, false));
 		        // H matches H, O matches C
                 MCSResult mcs=RDKFuncs.findMCS(mols,true,1,60,false,false,false,false,false,
                                                AtomComparator.AtomCompareAnyHeavyAtom,
@@ -105,8 +105,8 @@ public class FMCSTests extends GraphMolTest {
 	@Test
 	void testAtomCompareAnyHeavyAtom1() {
 		ROMol_Vect mols = new ROMol_Vect();
-			mols.add(RWMol.MolFromSmiles("[H]c1ccccc1C"));
-			mols.add(RWMol.MolFromSmiles("Oc1ccccc1O"));
+			mols.add(RWMol.MolFromSmiles("[H]c1ccccc1C",0, false));
+			mols.add(RWMol.MolFromSmiles("Oc1ccccc1O",0, false));
 					// O matches C, H does not match O
 					MCSResult mcs=RDKFuncs.findMCS(mols,true,1,60,false,false,false,false,false,
 												   AtomComparator.AtomCompareAnyHeavyAtom,


### PR DESCRIPTION
This pull request adds an alternative AtomComparator option for the FMCS code.

The option, `AtomCompareAnyHeavyAtom` allows MCS generation on structures with explicit hydrogen atoms, where a match is wanted between different heavy atoms, or between hydrogens, but not Hydrogen <--> Heavy atom.

For example, consider the following pair of structures:
`Oc1c([H])c([H])c([H])c([H])c1O`
`[H]c1c([H])c([H])c([H])c([H])c1[Cl]`

A standard 'AnyAtom' MCS will allow the first atom of each to match each other, e.g. 'O' matches '[H]', in addition to the last pair of atoms matching each other (i.e. 'O' matches '[Cl]'). In some applications, it may be preferrable to allow the latter match, but not the former.  This pull request adds that functionality and test cases in C++, Java and Python wrappers

