### PR TITLE
add bond-selector info to SVGs

### DIFF
--- a/Code/GraphMol/MolDraw2D/MolDraw2DSVG.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DSVG.cpp
@@ -457,6 +457,28 @@ void MolDraw2DSVG::addMoleculeMetadata(const std::vector<ROMol *> &mols,
 void MolDraw2DSVG::tagAtoms(const ROMol &mol, double radius,
                             const std::map<std::string, std::string> &events) {
   PRECONDITION(d_os, "no output stream");
+// first bonds so that they are under the atoms
+  for (const auto &bond : mol.bonds()) {
+    auto this_idx = bond->getIdx();
+    auto a1pos = getDrawCoords(atomCoords()[bond->getBeginAtomIdx()]);
+    auto a2pos = getDrawCoords(atomCoords()[bond->getEndAtomIdx()]);
+    d_os << "<path "
+         << " d='M " << a1pos.x << "," << a1pos.y << " L "<<a2pos.x<<","<<a2pos.y<<
+         "'";
+    d_os << " class='bond-selector bond-" << this_idx;
+    if (d_activeClass != "") {
+      d_os << " " << d_activeClass;
+    }
+    d_os << "'";
+    d_os << " style='fill:#fff;stroke:#fff;stroke-width:5px;fill-opacity:0;"
+            "stroke-opacity:0' ";
+    // for (const auto &event : events) {
+    //   d_os << " " << event.first << "='" << event.second << "(" << this_idx
+    //        << ");"
+    //        << "'";
+    // }
+    d_os << "/>\n";
+  }
   for (const auto &at : mol.atoms()) {
     auto this_idx = at->getIdx();
     auto pos = getDrawCoords(atomCoords()[this_idx]);

--- a/Code/GraphMol/MolDraw2D/MolDraw2DSVG.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DSVG.cpp
@@ -457,26 +457,23 @@ void MolDraw2DSVG::addMoleculeMetadata(const std::vector<ROMol *> &mols,
 void MolDraw2DSVG::tagAtoms(const ROMol &mol, double radius,
                             const std::map<std::string, std::string> &events) {
   PRECONDITION(d_os, "no output stream");
-// first bonds so that they are under the atoms
+  // first bonds so that they are under the atoms
   for (const auto &bond : mol.bonds()) {
     auto this_idx = bond->getIdx();
     auto a1pos = getDrawCoords(atomCoords()[bond->getBeginAtomIdx()]);
     auto a2pos = getDrawCoords(atomCoords()[bond->getEndAtomIdx()]);
+    auto width = 2 + lineWidth();
     d_os << "<path "
-         << " d='M " << a1pos.x << "," << a1pos.y << " L "<<a2pos.x<<","<<a2pos.y<<
-         "'";
+         << " d='M " << a1pos.x << "," << a1pos.y << " L " << a2pos.x << ","
+         << a2pos.y << "'";
     d_os << " class='bond-selector bond-" << this_idx;
     if (d_activeClass != "") {
       d_os << " " << d_activeClass;
     }
     d_os << "'";
-    d_os << " style='fill:#fff;stroke:#fff;stroke-width:5px;fill-opacity:0;"
+    d_os << " style='fill:#fff;stroke:#fff;stroke-width:" << width
+         << "px;fill-opacity:0;"
             "stroke-opacity:0' ";
-    // for (const auto &event : events) {
-    //   d_os << " " << event.first << "='" << event.second << "(" << this_idx
-    //        << ");"
-    //        << "'";
-    // }
     d_os << "/>\n";
   }
   for (const auto &at : mol.atoms()) {

--- a/Code/GraphMol/MolDraw2D/MolDraw2DSVG.h
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DSVG.h
@@ -68,11 +68,15 @@ class RDKIT_MOLDRAW2D_EXPORT MolDraw2DSVG : public MolDraw2D {
   // this only makes sense if the object was initialized without a stream
   std::string getDrawingText() const { return d_ss.str(); };
 
+  // adds additional tags to the atoms and bonds in the SVG. This should be
+  // invoked *after* the molecule has been drawn
   using MolDraw2D::tagAtoms;  // Avoid overload warning.
   void tagAtoms(const ROMol &mol) { tagAtoms(mol, 0.2); }
   void tagAtoms(const ROMol &mol, double radius,
                 const std::map<std::string, std::string> &events = {});
 
+  // adds metadata describing the molecule to the SVG. This allows
+  // molecules to be re-built from SVG with MolFromSVG
   void addMoleculeMetadata(const ROMol &mol, int confId = -1) const;
   void addMoleculeMetadata(const std::vector<ROMol *> &mols,
                            const std::vector<int> confIds = {}) const;

--- a/Code/GraphMol/MolDraw2D/catch_tests.cpp
+++ b/Code/GraphMol/MolDraw2D/catch_tests.cpp
@@ -54,7 +54,9 @@ TEST_CASE("tag atoms in SVG", "[drawing, SVG]") {
     outs.flush();
 
     CHECK(text.find("<circle") != std::string::npos);
-    CHECK(text.find("onclick") != std::string::npos);
+    CHECK(text.find("<circle") != std::string::npos);
+    CHECK(text.find("atom-selector") != std::string::npos);
+    CHECK(text.find("bond-selector") != std::string::npos);
   }
 }
 TEST_CASE("contour data", "[drawing, conrec]") {


### PR DESCRIPTION
Modifies `tagAtoms()` to add bond selector class info as well as atom selector info.

Also includes a bit more documentation