### PR TITLE
Fixes #2662 and #2663

### DIFF
--- a/Code/GraphMol/FMCS/MaximumCommonSubgraph.cpp
+++ b/Code/GraphMol/FMCS/MaximumCommonSubgraph.cpp
@@ -700,6 +700,11 @@ std::string MaximumCommonSubgraph::generateResultSMARTS(
           bm->second->getStereo() > Bond::STEREOANY)
         b.setStereo(bm->second->getStereo());
     }
+    if (Parameters.BondCompareParameters.RingMatchesRingOnly) {
+      BOND_EQUALS_QUERY *q = makeBondIsInRingQuery();
+      q->setNegation(!queryIsBondInRing(*bond));
+      b.expandQuery(q, Queries::COMPOSITE_AND, true);
+    }
     mol.addBond(&b, false);
   }
 

--- a/Code/GraphMol/FMCS/MaximumCommonSubgraph.cpp
+++ b/Code/GraphMol/FMCS/MaximumCommonSubgraph.cpp
@@ -819,16 +819,21 @@ MCSResult MaximumCommonSubgraph::find(const std::vector<ROMOL_SPTR>& src_mols) {
     res.Canceled = growSeeds() ? false : true;
     // verify what MCS is equal to one of initial seed for chirality match
     if (FinalChiralityCheckFunction == Parameters.FinalMatchChecker &&
-        1 == getMaxNumberBonds()) {
+        1 == getMaxNumberBonds() || 0 == getMaxNumberBonds()) {
       McsIdx = MCS();      // clear
       makeInitialSeeds();  // check all possible initial seeds
       if (!Seeds.empty()) {
         const Seed& fs = Seeds.front();
-        McsIdx.QueryMolecule = QueryMolecule;
-        McsIdx.Atoms = fs.MoleculeFragment.Atoms;
-        McsIdx.Bonds = fs.MoleculeFragment.Bonds;
-        McsIdx.AtomsIdx = fs.MoleculeFragment.AtomsIdx;
-        McsIdx.BondsIdx = fs.MoleculeFragment.BondsIdx;
+        if (1 == getMaxNumberBonds()
+          || !(Parameters.BondCompareParameters.CompleteRingsOnly
+          && fs.MoleculeFragment.Bonds.size() == 1
+          && queryIsBondInRing(fs.MoleculeFragment.Bonds.front()))) {
+          McsIdx.QueryMolecule = QueryMolecule;
+          McsIdx.Atoms = fs.MoleculeFragment.Atoms;
+          McsIdx.Bonds = fs.MoleculeFragment.Bonds;
+          McsIdx.AtomsIdx = fs.MoleculeFragment.AtomsIdx;
+          McsIdx.BondsIdx = fs.MoleculeFragment.BondsIdx;
+        }
       }
 
     } else if (i + 1 < Molecules.size() - ThresholdCount) {

--- a/Code/GraphMol/FMCS/Wrap/testFMCS.py
+++ b/Code/GraphMol/FMCS/Wrap/testFMCS.py
@@ -126,12 +126,12 @@ class TestCase(unittest.TestCase):
         mcs = rdFMCS.FindMCS(ms, completeRingsOnly=True)
         self.assertEqual(mcs.numBonds, 2)
         self.assertEqual(mcs.numAtoms, 3)
-        self.assertEqual(mcs.smartsString, '[#6]-[#6]-[#6]')
+        self.assertEqual(mcs.smartsString, '[#6]-&!@[#6]-&!@[#6]')
 
         mcs = rdFMCS.FindMCS(ms, ringMatchesRingOnly=True)
         self.assertEqual(mcs.numBonds, 1)
         self.assertEqual(mcs.numAtoms, 2)
-        self.assertEqual(mcs.smartsString, '[#6]-[#6]')
+        self.assertEqual(mcs.smartsString, '[#6]-&!@[#6]')
 
         smis = ['CC1CCC1', 'CCC1CCCCC1']
         ms = [Chem.MolFromSmiles(x) for x in smis]
@@ -148,7 +148,7 @@ class TestCase(unittest.TestCase):
         mcs = rdFMCS.FindMCS(ms, ringMatchesRingOnly=True)
         self.assertEqual(mcs.numBonds, 4)
         self.assertEqual(mcs.numAtoms, 5)
-        self.assertEqual(mcs.smartsString, '[#6]-[#6](-[#6]-[#6])-[#6]')
+        self.assertEqual(mcs.smartsString, '[#6]-&!@[#6](-&@[#6]-&@[#6])-&@[#6]')
 
     def test5AnyMatch(self):
         smis = ('c1ccccc1C', 'c1ccccc1O', 'c1ccccc1Cl')

--- a/Code/GraphMol/FMCS/Wrap/testFMCS.py
+++ b/Code/GraphMol/FMCS/Wrap/testFMCS.py
@@ -141,9 +141,9 @@ class TestCase(unittest.TestCase):
         self.assertEqual(mcs.smartsString, '[#6]-[#6](-[#6]-[#6])-[#6]')
 
         mcs = rdFMCS.FindMCS(ms, completeRingsOnly=True)
-        self.assertEqual(mcs.numBonds, 0)
-        self.assertEqual(mcs.numAtoms, 0)
-        self.assertEqual(mcs.smartsString, '')
+        self.assertEqual(mcs.numBonds, 1)
+        self.assertEqual(mcs.numAtoms, 2)
+        self.assertEqual(mcs.smartsString, '[#6]-&!@[#6]')
 
         mcs = rdFMCS.FindMCS(ms, ringMatchesRingOnly=True)
         self.assertEqual(mcs.numBonds, 4)

--- a/Code/GraphMol/FMCS/testFMCS_Unit.cpp
+++ b/Code/GraphMol/FMCS/testFMCS_Unit.cpp
@@ -1303,6 +1303,37 @@ void testGithub2663() {
   BOOST_LOG(rdInfoLog) << "\tdone" << std::endl;
 }
 
+void testGithub2662() {
+  BOOST_LOG(rdInfoLog) << "-------------------------------------" << std::endl;
+  BOOST_LOG(rdInfoLog) << "Testing Github #2662: C++ MCS code returns a null "
+                          "MCS between methylcyclopentane and methylcyclohexane"
+                       << std::endl;
+
+  {
+    std::vector<ROMOL_SPTR> mols;
+    const char* smi[] = {"CC1CCCC1", "CC1CCCCC1"};
+
+    for (auto& i : smi) {
+      auto m = SmilesToMol(getSmilesOnly(i));
+      TEST_ASSERT(m);
+
+      mols.push_back(ROMOL_SPTR(m));
+    }
+    MCSParameters p;
+    p.BondCompareParameters.CompleteRingsOnly = true;
+    MCSResult res = findMCS(mols, &p);
+    std::cerr << "MCS: " << res.SmartsString << " " << res.NumAtoms
+              << " atoms, " << res.NumBonds << " bonds\n"
+              << std::endl;
+    TEST_ASSERT(res.NumAtoms == 2);
+    TEST_ASSERT(res.NumBonds == 1);
+  }
+
+  BOOST_LOG(rdInfoLog) << "============================================"
+                       << std::endl;
+  BOOST_LOG(rdInfoLog) << "\tdone" << std::endl;
+}
+
 //====================================================================================================
 //====================================================================================================
 
@@ -1367,6 +1398,7 @@ int main(int argc, const char* argv[]) {
   testGithub945();
   testGithub2420();
   testGithub2663();
+  testGithub2662();
 
   unsigned long long t1 = nanoClock();
   double sec = double(t1 - T0) / 1000000.;

--- a/Code/GraphMol/FMCS/testFMCS_Unit.cpp
+++ b/Code/GraphMol/FMCS/testFMCS_Unit.cpp
@@ -1271,6 +1271,38 @@ void testGithub2420() {
   BOOST_LOG(rdInfoLog) << "\tdone" << std::endl;
 }
 
+void testGithub2663() {
+  BOOST_LOG(rdInfoLog) << "-------------------------------------" << std::endl;
+  BOOST_LOG(rdInfoLog) << "Testing Github #2663: The C++ MCS code "
+                          "generates ambiguous SMARTS strings"
+                       << std::endl;
+
+  {
+    std::vector<ROMOL_SPTR> mols;
+    const char* smi[] = {"C1C(C)CC2CC12", "CC1CCCC2CCCC12"};
+
+    for (auto& i : smi) {
+      auto m = SmilesToMol(getSmilesOnly(i));
+      TEST_ASSERT(m);
+
+      mols.push_back(ROMOL_SPTR(m));
+    }
+    MCSParameters p;
+    p.BondCompareParameters.CompleteRingsOnly = true;
+    MCSResult res = findMCS(mols, &p);
+    std::cerr << "MCS: " << res.SmartsString << " " << res.NumAtoms
+              << " atoms, " << res.NumBonds << " bonds\n"
+              << std::endl;
+    TEST_ASSERT(res.NumAtoms == 7);
+    TEST_ASSERT(res.NumBonds == 7);
+    TEST_ASSERT(res.SmartsString == "[#6]1-&@[#6](-&!@[#6])-&@[#6]-&@[#6]-&@[#6]-&@[#6]-&@1");
+  }
+
+  BOOST_LOG(rdInfoLog) << "============================================"
+                       << std::endl;
+  BOOST_LOG(rdInfoLog) << "\tdone" << std::endl;
+}
+
 //====================================================================================================
 //====================================================================================================
 
@@ -1334,6 +1366,7 @@ int main(int argc, const char* argv[]) {
 #endif
   testGithub945();
   testGithub2420();
+  testGithub2663();
 
   unsigned long long t1 = nanoClock();
   double sec = double(t1 - T0) / 1000000.;


### PR DESCRIPTION
This PR fixes #2663 by adding a ring/non-ring bond query as in the original MCS code by Andrew Dalke.
It also updates a few test cases to cope with the new bond notation and adds a specific C++ test case.