### PR TITLE
Adds additional capabilities to the minimal JS wrapper

### DIFF
--- a/Code/MinimalLib/demo/demo.html
+++ b/Code/MinimalLib/demo/demo.html
@@ -42,8 +42,9 @@
     var qmol = Module.get_qmol(text);
     var mol = Module.get_mol(document.getElementById("smiles_input").value);
     if (mol.is_valid() && qmol.is_valid()) {
-      match = JSON.parse(mol.get_substruct_match(qmol));
-      if (match.length) draw_with_highlights(mol, JSON.stringify({ atoms: match }));
+      var mdetails = mol.get_substruct_match(qmol);
+      var match = JSON.parse(mdetails);
+      if (match.atoms.length) draw_with_highlights(mol, mdetails);
     }
     mol.delete();
     qmol.delete();

--- a/Code/MinimalLib/demo/demo.html
+++ b/Code/MinimalLib/demo/demo.html
@@ -44,7 +44,7 @@
     if (mol.is_valid() && qmol.is_valid()) {
       var mdetails = mol.get_substruct_match(qmol);
       var match = JSON.parse(mdetails);
-      if (match.atoms.length) draw_with_highlights(mol, mdetails);
+      if (match.atoms && match.atoms.length) draw_with_highlights(mol, mdetails);
     }
     mol.delete();
     qmol.delete();
@@ -60,6 +60,6 @@
 <br>
 SMILES: <input id="smiles_input" type="text" value="CC(=O)Oc1ccccc1C(=O)O" onkeyup="callback(this.value)">
 <br>
-SMARTS: <input id="smart_input" type="text" value="" onkeyup="sma_callback(this.value)">
+SMARTS: <input id="smarts_input" type="text" value="" onkeyup="sma_callback(this.value)">
 
 </html>

--- a/Code/MinimalLib/jswrapper.cpp
+++ b/Code/MinimalLib/jswrapper.cpp
@@ -21,6 +21,7 @@ EMSCRIPTEN_BINDINGS(RDKit_minimal) {
       .function("get_svg", &JSMol::get_svg)
       .function("get_svg_with_highlights", &JSMol::get_svg_with_highlights)
       .function("get_substruct_match", &JSMol::get_substruct_match)
+      .function("get_substruct_matches", &JSMol::get_substruct_matches)
       .function("get_descriptors", &JSMol::get_descriptors)
       .function("get_morgan_fp",
                 select_overload<std::string() const>(&JSMol::get_morgan_fp))

--- a/Code/MinimalLib/jswrapper.cpp
+++ b/Code/MinimalLib/jswrapper.cpp
@@ -13,7 +13,7 @@
 
 using namespace emscripten;
 EMSCRIPTEN_BINDINGS(RDKit_minimal) {
-   class_<JSMol>("Mol")
+  class_<JSMol>("Mol")
       .function("is_valid", &JSMol::is_valid)
       .function("get_smiles", &JSMol::get_smiles)
       .function("get_molblock", &JSMol::get_molblock)
@@ -26,7 +26,16 @@ EMSCRIPTEN_BINDINGS(RDKit_minimal) {
                 select_overload<std::string() const>(&JSMol::get_morgan_fp))
       .function("get_morgan_fp",
                 select_overload<std::string(unsigned int, unsigned int) const>(
-                    &JSMol::get_morgan_fp));
+                    &JSMol::get_morgan_fp))
+
+      // functionality primarily useful in ketcher
+      .function("get_stereo_tags", &JSMol::get_stereo_tags)
+      .function("get_aromatic_form", &JSMol::get_aromatic_form)
+      .function("get_kekule_form", &JSMol::get_kekule_form)
+      .function("get_new_coords",
+                select_overload<std::string() const>(&JSMol::get_new_coords))
+      .function("get_new_coords", select_overload<std::string(bool) const>(
+                                      &JSMol::get_new_coords));
 
   function("version", &version);
   function("get_inchikey_for_inchi", &get_inchikey_for_inchi);

--- a/Code/MinimalLib/minilib.cpp
+++ b/Code/MinimalLib/minilib.cpp
@@ -147,30 +147,62 @@ std::string JSMol::get_molblock() const {
   if (!d_mol) return "";
   return MolToMolBlock(*d_mol);
 }
+
+namespace {
+void get_sss_json(const ROMol *d_mol, const ROMol *q_mol,
+                  const MatchVectType &match, rj::Value &obj,
+                  rj::Document &doc) {
+  rj::Value rjAtoms(rj::kArrayType);
+  for (const auto &pr : match) {
+    rjAtoms.PushBack(pr.second, doc.GetAllocator());
+  }
+  obj.AddMember("atoms", rjAtoms, doc.GetAllocator());
+
+  rj::Value rjBonds(rj::kArrayType);
+  for (const auto qbond : q_mol->bonds()) {
+    unsigned int idx1 = match[qbond->getBeginAtomIdx()].second;
+    unsigned int idx2 = match[qbond->getEndAtomIdx()].second;
+    const auto bond = d_mol->getBondBetweenAtoms(idx1, idx2);
+    if (bond != nullptr) {
+      rjBonds.PushBack(bond->getIdx(), doc.GetAllocator());
+    }
+  }
+  obj.AddMember("bonds", rjBonds, doc.GetAllocator());
+}
+}  // namespace
+
 std::string JSMol::get_substruct_match(const JSMol &q) const {
   std::string res = "{}";
-  if (!d_mol) return res;
+  if (!d_mol || !q.d_mol) return res;
 
   MatchVectType match;
   if (SubstructMatch(*d_mol, *(q.d_mol), match)) {
     rj::Document doc;
     doc.SetObject();
-    rj::Value rjAtoms(rj::kArrayType);
-    for (const auto &pr : match) {
-      rjAtoms.PushBack(pr.second, doc.GetAllocator());
-    }
-    doc.AddMember("atoms", rjAtoms, doc.GetAllocator());
+    get_sss_json(d_mol.get(), q.d_mol.get(), match, doc, doc);
+    rj::StringBuffer buffer;
+    rj::Writer<rj::StringBuffer> writer(buffer);
+    doc.Accept(writer);
+    res = buffer.GetString();
+  }
 
-    rj::Value rjBonds(rj::kArrayType);
-    for (const auto qbond : q.d_mol->bonds()) {
-      unsigned int idx1 = match[qbond->getBeginAtomIdx()].second;
-      unsigned int idx2 = match[qbond->getEndAtomIdx()].second;
-      const auto bond = d_mol->getBondBetweenAtoms(idx1, idx2);
-      if (bond != nullptr) {
-        rjBonds.PushBack(bond->getIdx(), doc.GetAllocator());
-      }
+  return res;
+}
+
+std::string JSMol::get_substruct_matches(const JSMol &q) const {
+  std::string res = "{}";
+  if (!d_mol || !q.d_mol) return res;
+
+  auto matches = SubstructMatch(*d_mol, (*q.d_mol));
+  if (!matches.empty()) {
+    rj::Document doc;
+    doc.SetArray();
+
+    for (const auto match : matches) {
+      rj::Value rjMatch(rj::kObjectType);
+      get_sss_json(d_mol.get(), q.d_mol.get(), match, rjMatch, doc);
+      doc.PushBack(rjMatch, doc.GetAllocator());
     }
-    doc.AddMember("bonds", rjBonds, doc.GetAllocator());
 
     rj::StringBuffer buffer;
     rj::Writer<rj::StringBuffer> writer(buffer);
@@ -180,6 +212,7 @@ std::string JSMol::get_substruct_match(const JSMol &q) const {
 
   return res;
 }
+
 std::string JSMol::get_descriptors() const {
   if (!d_mol) return "{}";
   rj::Document doc;

--- a/Code/MinimalLib/minilib.h
+++ b/Code/MinimalLib/minilib.h
@@ -24,7 +24,15 @@ class JSMol {
   std::string get_descriptors() const;
   std::string get_morgan_fp(unsigned int radius, unsigned int len) const;
   std::string get_morgan_fp() const { return get_morgan_fp(2, 2048); };
+
   bool is_valid() const { return d_mol.get() != nullptr; };
+
+  // functionality primarily useful in ketcher
+  std::string get_stereo_tags() const;
+  std::string get_aromatic_form() const;
+  std::string get_kekule_form() const;
+  std::string get_new_coords(bool useCoordGen) const;
+  std::string get_new_coords() const { return get_new_coords(false); };
 
  private:
   std::unique_ptr<RDKit::ROMol> d_mol;

--- a/Code/MinimalLib/minilib.h
+++ b/Code/MinimalLib/minilib.h
@@ -21,6 +21,7 @@ class JSMol {
   std::string get_svg() const;
   std::string get_svg_with_highlights(const std::string &details) const;
   std::string get_substruct_match(const JSMol &q) const;
+  std::string get_substruct_matches(const JSMol &q) const;
   std::string get_descriptors() const;
   std::string get_morgan_fp(unsigned int radius, unsigned int len) const;
   std::string get_morgan_fp() const { return get_morgan_fp(2, 2048); };


### PR DESCRIPTION
what's in this PR:

- `get_substruct_match()` now returns matching atoms and bonds
- `get_substruct_matches()`
- a set of functions that should (I hope) allow the JS code to be used by ketcher as an alternative to a server.