### PR TITLE
Issue #2666: Missing separator in CXSMILES with enhanced stereo

### DIFF
--- a/Code/GraphMol/SmilesParse/CXSmilesOps.cpp
+++ b/Code/GraphMol/SmilesParse/CXSmilesOps.cpp
@@ -573,6 +573,17 @@ std::string get_atom_props_block(const ROMol &mol,
   }
   return res;
 }
+
+void appendToCXExtension(const std::string& addition, std::string& base)
+{
+  if (!addition.empty()) {
+    if (base.size() > 1) {
+      base += ",";
+    }
+    base += addition;
+  }
+}
+
 }  // namespace
 std::string getCXExtensions(const ROMol &mol) {
   std::string res = "|";
@@ -607,13 +618,12 @@ std::string getCXExtensions(const ROMol &mol) {
     res += radblock;
     if (res.back() == ',') res.erase(res.size() - 1);
   }
-  auto atomblock = get_atom_props_block(mol, atomOrder);
-  if (atomblock.size()) {
-    if (res.size() > 1) res += ",";
-    res += atomblock;
-  }
 
-  res += get_enhanced_stereo_block(mol, atomOrder);
+  const auto atomblock = get_atom_props_block(mol, atomOrder);
+  appendToCXExtension(atomblock, res);
+
+  const auto stereoblock = get_enhanced_stereo_block(mol, atomOrder);
+  appendToCXExtension(stereoblock, res);
 
   if (res.size() > 1) {
     res += "|";

--- a/Code/GraphMol/SmilesParse/catch_tests.cpp
+++ b/Code/GraphMol/SmilesParse/catch_tests.cpp
@@ -286,6 +286,13 @@ TEST_CASE("github #2257: writing cxsmiles", "[smiles,cxsmiles]") {
     CHECK(smi == "C[C@@H]1CCO[C@H](C)C1 |a:1,5|");
   }
 
+  SECTION("enhanced stereo with other properties") {
+    auto mol = "CC[C@H](C)O |atomProp:3.p2.v2,o1:2|"_smiles;
+    REQUIRE(mol);
+    auto smi = MolToCXSmiles(*mol);
+    CHECK(smi == "CC[C@H](C)O |atomProp:3.p2.v2,o1:2|");
+  }
+
   SECTION("mol fragments1") {
     auto mol = "Cl.OC |(1,0,0;0,.75,0.1;0,-.75,-0.1)|"_smiles;
     REQUIRE(mol);


### PR DESCRIPTION
#### Reference Issue
Example: Fixes #2666

#### What does this implement/fix? Explain your changes.
Before this commit, if enhanced stereochemistry information was
added to a CXSMILES string as well as other information, the
separator would be missing. This made CXSMILES written by
RDKit unreadable if enhanced stereo information was present.

#### Any other comments?
Also adds a test and a simple function for reducing the probability
that this mistake will be made with other new CXSMILES sections.
