### PR TITLE
Allow Java to see RGroup labels in the std::map wrapper.

### DIFF
--- a/Code/GraphMol/RGroupDecomposition/RGroupDecomp.cpp
+++ b/Code/GraphMol/RGroupDecomposition/RGroupDecomp.cpp
@@ -1220,6 +1220,17 @@ bool RGroupDecomposition::process() {
   }
 }
 
+std::vector<std::string> RGroupDecomposition::getRGroupLabels() const {
+  // this is a bit of a cheat
+  RGroupColumns cols = getRGroupsAsColumns();
+  std::vector<std::string> labels;
+  for(auto it : cols) {
+    labels.push_back(it.first);
+  }
+  std::sort(labels.begin(), labels.end());
+  return labels;
+}
+  
 RGroupRows RGroupDecomposition::getRGroupsAsRows() const {
   std::vector<RGroupMatch> permutation = data->GetCurrentBestPermutation();
 

--- a/Code/GraphMol/RGroupDecomposition/RGroupDecomp.h
+++ b/Code/GraphMol/RGroupDecomposition/RGroupDecomp.h
@@ -117,6 +117,9 @@ class RDKIT_RGROUPDECOMPOSITION_EXPORT RGroupDecomposition {
   int add(const ROMol &mol);
   bool process();
 
+  //! return the current group labels
+  std::vector<std::string> getRGroupLabels() const;
+  
   //! return rgroups in row order group[row][attachment_point] = ROMol
   RGroupRows getRGroupsAsRows() const;
   //! return rgroups in column order group[attachment_point][row] = ROMol

--- a/Code/GraphMol/RGroupDecomposition/Wrap/rdRGroupComposition.cpp
+++ b/Code/GraphMol/RGroupDecomposition/Wrap/rdRGroupComposition.cpp
@@ -77,6 +77,14 @@ class RGroupDecompositionHelper {
   int Add(const ROMol &mol) { return decomp->add(mol); }
   bool Process() { return decomp->process(); }
 
+  python::list GetRGroupLabels() {
+    python::list result;
+    std::vector<std::string> labels = decomp->getRGroupLabels();
+    for(auto label : labels) {
+      result.append(label);
+    }
+    return result;
+  }
   python::list GetRGroupsAsRows(bool asSmiles = false) {
     const RGroupRows &groups = decomp->getRGroupsAsRows();
     python::list result;
@@ -256,7 +264,10 @@ struct rgroupdecomp_wrapper {
         .def("Add", &RGroupDecompositionHelper::Add)
         .def("Process", &RGroupDecompositionHelper::Process,
              "Process the rgroups (must be done prior to "
-             "GetRGroupsAsRows/Columns)")
+             "GetRGroupsAsRows/Columns and GetRGroupLabels)")
+        .def("GetRGroupLabels", &RGroupDecompositionHelper::GetRGroupLabels,
+	     "Return the current list of found rgroups.\n"
+	     "Note, Process() should be called first")
         .def("GetRGroupsAsRows", &RGroupDecompositionHelper::GetRGroupsAsRows,
              python::arg("asSmiles") = false,
              "Return the rgroups as rows (note: can be fed directrly into a "

--- a/Code/GraphMol/RGroupDecomposition/Wrap/test_rgroups.py
+++ b/Code/GraphMol/RGroupDecomposition/Wrap/test_rgroups.py
@@ -257,6 +257,19 @@ C1CCO[C@@](S)(P)1
                            'R1': '[H]P([H])[*:1]'},
                           {'Core': 'C1C[SH]([*:2])C1',
                            'R2': '[H]P([H])[*:2].[H][*:2]'}])
+
+    def test_getrgrouplabels(self):
+        smis = ["C(Cl)N(N)O(O)"]
+        mols = [Chem.MolFromSmiles(smi) for smi in smis]
+        smarts = 'C([*:1])N([*:5])O([*:6])'
+        core = Chem.MolFromSmarts(smarts)
+        rg = RGroupDecomposition(core)
+        for m in mols:
+            rg.Add(m)
+        rg.Process()
+        self.assertEqual(set(rg.GetRGroupLabels()),
+                         set(rg.GetRGroupsAsColumns()))
+
         
 if __name__ == '__main__':
   unittest.main()

--- a/Code/JavaWrappers/RGroupDecomposition.i
+++ b/Code/JavaWrappers/RGroupDecomposition.i
@@ -11,13 +11,37 @@
 */
 %{
 #include <GraphMol/RGroupDecomposition/RGroupDecomp.h>
+typedef std::vector<std::string> STR_VECT;
 %}
 
 %template(SparseIntVect64) RDKit::SparseIntVect<boost::int64_t>;
+
 
 %template(StringMolMap) std::map<std::string, boost::shared_ptr<RDKit::ROMol>>;
 %template(ROMol_Vect) std::vector<boost::shared_ptr<RDKit::ROMol>>;
 %template(StringMolMap_Vect) std::vector<std::map<std::string, boost::shared_ptr<RDKit::ROMol>>>;
 %template(StringROMol_VectMap) std::map<std::string,std::vector<boost::shared_ptr<RDKit::ROMol>>>;
+
+
+%extend std::map<std::string, boost::shared_ptr<RDKit::ROMol>> {
+  std::vector<std::string> keys() {
+    std::vector<std::string> _keys;
+    for(auto it : *self) {
+      std::cerr << "* '" << it.first << "'" << std::endl;
+      _keys.push_back(it.first);
+    }
+    return _keys;
+  }
+}
+
+%extend std::map<std::string,std::vector<boost::shared_ptr<RDKit::ROMol>>> {
+  std::vector<std::string> keys() {
+    std::vector<std::string> _keys;
+    for(auto it : *self) {
+      _keys.push_back(it.first);
+    }
+    return _keys;
+  }
+}
 
 %include <GraphMol/RGroupDecomposition/RGroupDecomp.h>

--- a/Code/JavaWrappers/gmwrapper/src-test/org/RDKit/RGroupDecompositionTests.java
+++ b/Code/JavaWrappers/gmwrapper/src-test/org/RDKit/RGroupDecompositionTests.java
@@ -30,7 +30,16 @@ public class RGroupDecompositionTests extends GraphMolTest {
             m = RWMol.MolFromSmiles("c1c(Cl)cccc1");
             assertEquals(1,decomp.add(m));
             assertTrue(decomp.process());
+	    Str_Vect keys = decomp.getRGroupsAsColumns().keys();
+	    assertTrue(keys.size() == 2);
+	    assertTrue(keys.get(0).equals("Core"));
+	    assertTrue(keys.get(1).equals("R1"));
 
+	    Str_Vect keys2 = decomp.getRGroupLabels();
+	    assertTrue(keys2.size() == 2);
+	    assertTrue(keys2.get(0).equals("Core"));
+	    assertTrue(keys2.get(1).equals("R1"));
+	    
 	}
   
 	public static void main(String args[]) {


### PR DESCRIPTION
Adds RGroupDecomposigion::getRGroupLabels.

Adds keys() method to wrapped std::maps.

```
            ROMol core = RWMol.MolFromSmiles("c1ccccc1");
            RGroupDecomposition decomp = new RGroupDecomposition(core);

            m = RWMol.MolFromSmiles("c1(Cl)ccccc1");
            assertEquals(0,decomp.add(m));
            m = RWMol.MolFromSmiles("c1c(Cl)cccc1");
            assertEquals(1,decomp.add(m));
            assertTrue(decomp.process());

	    Str_Vect keys = decomp.getRGroupsAsColumns().keys();
	    assertTrue(keys.size() == 2);
	    assertTrue(keys.get(0).equals("Core"));
	    assertTrue(keys.get(1).equals("R1"));
```