### PR TITLE
fix a problem with normalize, ringinfo, and fragments

### DIFF
--- a/Code/GraphMol/MolStandardize/Normalize.cpp
+++ b/Code/GraphMol/MolStandardize/Normalize.cpp
@@ -102,6 +102,8 @@ boost::shared_ptr<ROMol> Normalizer::normalizeFragment(
     const ROMol &mol,
     const std::vector<std::shared_ptr<ChemicalReaction>> &transforms) {
   boost::shared_ptr<ROMol> nfrag(new ROMol(mol));
+  MolOps::fastFindRings(
+      *nfrag);  // this doesn't do anything if rings are already there
   for (unsigned int i = 0; i < MAX_RESTARTS; ++i) {
     bool loop_brake = false;
     // Iterate through Normalization transforms and apply each in order

--- a/Code/GraphMol/MolStandardize/catch_tests.cpp
+++ b/Code/GraphMol/MolStandardize/catch_tests.cpp
@@ -17,6 +17,7 @@
 #include <GraphMol/SmilesParse/SmilesWrite.h>
 #include <GraphMol/FileParsers/FileParsers.h>
 #include <GraphMol/MolStandardize/MolStandardize.h>
+#include <GraphMol/MolStandardize/Normalize.h>
 #include <GraphMol/MolStandardize/Fragment.h>
 #include <GraphMol/MolStandardize/Charge.h>
 
@@ -239,5 +240,20 @@ TEST_CASE("github #2610: Uncharger incorrectly modifying a zwitterion.",
     CHECK(outm->getAtomWithIdx(5)->getFormalCharge() == 1);
     CHECK(outm->getAtomWithIdx(6)->getFormalCharge() == -1);
     CHECK(MolToSmiles(*outm) == "[O-][NH+]1C=CC=CC1");
+  }
+}
+
+TEST_CASE("problems with ringInfo initialization", "normalizer") {
+  std::string tfs =
+      R"TXT(Bad amide tautomer1	[C:1]([OH1;D1:2])=;!@[NH1:3]>>[C:1](=[OH0:2])-[NH2:3]
+Bad amide tautomer2	[C:1]([OH1;D1:2])=;!@[NH0:3]>>[C:1](=[OH0:2])-[NH1:3])TXT";
+  std::stringstream iss(tfs);
+  MolStandardize::Normalizer nrml(iss, 20);
+  SECTION("example1") {
+    auto m = "Cl.Cl.OC(=N)NCCCCCCCCCCCCNC(O)=N"_smiles;
+    REQUIRE(m);
+    std::unique_ptr<ROMol> res(nrml.normalize(*m));
+    REQUIRE(res);
+    CHECK(MolToSmiles(*res) == "Cl.Cl.NC(=O)NCCCCCCCCCCCCNC(N)=O");
   }
 }


### PR DESCRIPTION
The Normalizer would generate an exception for molecules with fragments if the transforms had ring queries.

The simple fix is to just always call `fastFindRings()` in `normalizeFragment()`.