### PR TITLE
Fixes #2677

### DIFF
--- a/Code/JavaWrappers/CMakeLists.txt
+++ b/Code/JavaWrappers/CMakeLists.txt
@@ -20,7 +20,7 @@ if(RDK_BUILD_INCHI_SUPPORT)
   set(swigRDKitLibList "${swigRDKitLibList}RDInchiLib;${INCHI_LIBRARIES};")
 endif(RDK_BUILD_INCHI_SUPPORT)
 set(swigRDKitLibList "${swigRDKitLibList}"
-  "RGroupDecomposition;SubstructLibrary;"
+  "MolHash;RGroupDecomposition;SubstructLibrary;"
   "MolStandardize;FilterCatalog;Catalogs;FMCS;MolDraw2D;FileParsers;SmilesParse;"
   "Depictor;SubstructMatch;ChemReactions;Fingerprints;ChemTransforms;"
   "Subgraphs;GraphMol;DataStructs;Trajectory;Descriptors;"

--- a/Code/JavaWrappers/MolHash.i
+++ b/Code/JavaWrappers/MolHash.i
@@ -1,0 +1,25 @@
+/*
+ *  Copyright (c) 2019 Greg Landrum
+ *  All rights reserved.
+ *
+ *  This file is part of the RDKit.
+ *  The contents are covered by the terms of the BSD license
+ *  which is included in the file license.txt, found at the root
+ *  of the RDKit source tree.
+ */
+
+%include "std_string.i"
+
+%{
+#include <GraphMol/MolHash/MolHash.h>
+%}
+
+%ignore RDKit::MolHash::generateMoleculeHashCode;
+%ignore RDKit::MolHash::CodeFlags;
+%ignore RDKit::MolHash::fillAtomBondCodes;
+%ignore RDKit::MolHash::HashSet;
+%ignore RDKit::MolHash::generateMoleculeHashSet;
+%ignore RDKit::MolHash::encode;
+
+%include<GraphMol/MolHash/nmmolhash.h>
+

--- a/Code/JavaWrappers/csharp_wrapper/GraphMolCSharp.i
+++ b/Code/JavaWrappers/csharp_wrapper/GraphMolCSharp.i
@@ -251,6 +251,7 @@ typedef unsigned long long int	uintmax_t;
 %include "../FilterCatalog.i"
 %include "../Trajectory.i"
 %include "../SubstructLibrary.i"
+%include "../MolHash.i"
 %include "../Streams.i"
 
 

--- a/Code/JavaWrappers/gmwrapper/CMakeLists.txt
+++ b/Code/JavaWrappers/gmwrapper/CMakeLists.txt
@@ -354,6 +354,11 @@ ADD_TEST(JavaRGroupDecompositionTests
 	-cp "${JUNIT_JAR}${PATH_SEP}${CMAKE_JAVA_TEST_OUTDIR}${PATH_SEP}${CMAKE_CURRENT_SOURCE_DIR}/org.RDKit.jar"
 	org.RDKit.RGroupDecompositionTests)
 
+ADD_TEST(JavaMolHashTest
+    java -Djava.library.path=${CMAKE_CURRENT_SOURCE_DIR}
+	-cp "${JUNIT_JAR}${PATH_SEP}${CMAKE_JAVA_TEST_OUTDIR}${PATH_SEP}${CMAKE_CURRENT_SOURCE_DIR}/org.RDKit.jar"
+	org.RDKit.MolHashTest)
+
 ADD_TEST(JavaDiversityPickerTests
 	    java -Djava.library.path=${CMAKE_CURRENT_SOURCE_DIR}
 		-cp "${JUNIT_JAR}${PATH_SEP}${CMAKE_JAVA_TEST_OUTDIR}${PATH_SEP}${CMAKE_CURRENT_SOURCE_DIR}/org.RDKit.jar"

--- a/Code/JavaWrappers/gmwrapper/GraphMolJava.i
+++ b/Code/JavaWrappers/gmwrapper/GraphMolJava.i
@@ -231,6 +231,7 @@ typedef unsigned long long int	uintmax_t;
 %include "../MolStandardize.i"
 %include "../SubstructLibrary.i"
 %include "../RGroupDecomposition.i"
+%include "../MolHash.i"
 %include "../Streams.i"
 
 // Create a class to throw various sorts of errors for testing.  Required for unit tests in ErrorHandlingTests.java

--- a/Code/JavaWrappers/gmwrapper/src-test/org/RDKit/MolHashTest.java
+++ b/Code/JavaWrappers/gmwrapper/src-test/org/RDKit/MolHashTest.java
@@ -1,0 +1,25 @@
+package org.RDKit;
+
+import static org.junit.Assert.*;
+
+import java.io.File;
+
+import org.junit.*;
+
+/**
+ * JUnit tests for MolHash wrappers.
+ */
+ public class MolHashTest extends GraphMolTest {
+	@Test
+	public void testMolHash1() {
+		ROMol m1;
+        m1 = RWMol.MolFromSmiles("C1CCCC(O)C1c1ccnc(OC)c1");
+		// we just test a few to make sure that the enum works
+		assertEquals("***1****(*2*****2*)*1", RDKFuncs.MolHash(new RWMol(m1),HashFunction.AnonymousGraph));
+		assertEquals("COc1cc(C2CCCCC2O)ccn1", RDKFuncs.MolHash(new RWMol(m1),HashFunction.CanonicalSmiles));
+		assertEquals("COC1CC(C2CCCCC2O)CCN1", RDKFuncs.MolHash(new RWMol(m1),HashFunction.ElementGraph));
+	}
+	public static void main(String args[]) {
+						org.junit.runner.JUnitCore.main("org.RDKit.MolHashTest");
+	}
+}


### PR DESCRIPTION
exposes MolHash to the SWIG wrappers
Includes a test for the java wrappers, but not C#