### PR TITLE
Add a drawOptions object to IPythonConsole

### DIFF
--- a/Code/GraphMol/MolDraw2D/Wrap/rdMolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/Wrap/rdMolDraw2D.cpp
@@ -457,6 +457,10 @@ void drawWavyLineHelper(RDKit::MolDraw2D &self, const Point2D &cds1,
   self.drawWavyLine(cds1, cds2, col1, col2, nSegments, vertOffset);
 }
 
+void setDrawOptions(RDKit::MolDraw2D &self, const MolDrawOptions &opts) {
+  self.drawOptions() = opts;
+}
+
 }  // namespace RDKit
 
 BOOST_PYTHON_MODULE(rdMolDraw2D) {
@@ -655,7 +659,11 @@ BOOST_PYTHON_MODULE(rdMolDraw2D) {
                RDKit::MolDraw2D::drawOptions,
            python::return_internal_reference<
                1, python::with_custodian_and_ward_postcall<0, 1>>(),
-           "Returns a modifiable version of the current drawing options");
+           "Returns a modifiable version of the current drawing options")
+      .def("SetDrawOptions", RDKit::setDrawOptions,
+           "Copies the drawing options passed in over our drawing options");
+
+  ;
   docString = "SVG molecule drawer";
   python::class_<RDKit::MolDraw2DSVG, python::bases<RDKit::MolDraw2D>,
                  boost::noncopyable>("MolDraw2DSVG", docString.c_str(),

--- a/Code/GraphMol/MolDraw2D/Wrap/testMolDraw2D.py
+++ b/Code/GraphMol/MolDraw2D/Wrap/testMolDraw2D.py
@@ -456,6 +456,25 @@ M  END
     with open("extras_1.svg", "w+") as outf:
       outf.write(txt)
 
+  def testSetDrawOptions(self):
+    m = Chem.MolFromSmiles('CCNC(=O)O')
+    d = rdMolDraw2D.MolDraw2DSVG(250, 200)
+    rdMolDraw2D.PrepareAndDrawMolecule(d, m)
+    d.FinishDrawing()
+    txt = d.GetDrawingText()
+    self.assertNotEqual(txt.find("fill:#0000FF' ><tspan>NH"), -1)
+    self.assertEqual(txt.find("fill:#000000' ><tspan>NH"), -1)
+
+    d = rdMolDraw2D.MolDraw2DSVG(250, 200)
+    do = rdMolDraw2D.MolDrawOptions()
+    do.useBWAtomPalette()
+    d.SetDrawOptions(do)
+    rdMolDraw2D.PrepareAndDrawMolecule(d, m)
+    d.FinishDrawing()
+    txt = d.GetDrawingText()
+    self.assertEqual(txt.find("fill:#0000FF' ><tspan>NH"), -1)
+    self.assertNotEqual(txt.find("fill:#000000' ><tspan>NH"), -1)
+
 
 if __name__ == "__main__":
   unittest.main()

--- a/Code/GraphMol/MolDraw2D/catch_tests.cpp
+++ b/Code/GraphMol/MolDraw2D/catch_tests.cpp
@@ -262,3 +262,39 @@ TEST_CASE("zero-order bonds", "[drawing, organometallics]") {
     CHECK(text.find("stroke-dasharray:2,2") != std::string::npos);
   }
 }
+
+TEST_CASE("copying drawing options", "[drawing]") {
+  auto m1 = "C1N[C@@H]2OCC12"_smiles;
+  REQUIRE(m1);
+  SECTION("foundations") {
+    {
+      MolDraw2DSVG drawer(200, 200);
+      MolDraw2DUtils::prepareAndDrawMolecule(drawer, *m1);
+      drawer.finishDrawing();
+      std::string text = drawer.getDrawingText();
+      CHECK(text.find("fill:#0000FF' ><tspan>NH") != std::string::npos);
+    }
+    {
+      MolDraw2DSVG drawer(200, 200);
+      assignBWPalette(drawer.drawOptions().atomColourPalette);
+      MolDraw2DUtils::prepareAndDrawMolecule(drawer, *m1);
+      drawer.finishDrawing();
+      std::string text = drawer.getDrawingText();
+      CHECK(text.find("fill:#0000FF' ><tspan>NH") == std::string::npos);
+      CHECK(text.find("fill:#000000' ><tspan>NH") != std::string::npos);
+    }
+  }
+  SECTION("test") {
+    {
+      MolDraw2DSVG drawer(200, 200);
+      MolDrawOptions options = drawer.drawOptions();
+      assignBWPalette(options.atomColourPalette);
+      drawer.drawOptions() = options;
+      MolDraw2DUtils::prepareAndDrawMolecule(drawer, *m1);
+      drawer.finishDrawing();
+      std::string text = drawer.getDrawingText();
+      CHECK(text.find("fill:#0000FF' ><tspan>NH") == std::string::npos);
+      CHECK(text.find("fill:#000000' ><tspan>NH") != std::string::npos);
+    }
+  }
+}

--- a/rdkit/Chem/Draw/IPythonConsole.py
+++ b/rdkit/Chem/Draw/IPythonConsole.py
@@ -23,18 +23,17 @@ import sys
 import IPython
 
 if IPython.release.version < '0.11':
-    raise ImportError('this module requires at least v0.11 of IPython')
+  raise ImportError('this module requires at least v0.11 of IPython')
 try:
-    import py3Dmol
-    _canUse3D = True
+  import py3Dmol
+  _canUse3D = True
 except ImportError:
-    _canUse3D = False
+  _canUse3D = False
 
 try:
-    import Image
+  import Image
 except ImportError:
-    from PIL import Image
-
+  from PIL import Image
 
 molSize = (450, 150)
 highlightSubstructs = True
@@ -45,117 +44,120 @@ ipython_3d = False
 molSize_3d = (400, 400)
 drawing_type_3d = 'stick'  # default drawing type for 3d structures
 bgcolor_3d = '0xeeeeee'
+drawOptions = rdMolDraw2D.MolDrawOptions()
+
 # expose RDLogs to Python StdErr so they are shown
 #  in the IPythonConsole not the server logs.
 Chem.WrapLogs()
 
 
 def addMolToView(mol, view, confId=-1, drawAs=None):
-    if mol.GetNumAtoms() >= 999 or drawAs == 'cartoon':
-        # py3DMol is happier with TER and MASTER records present
-        pdb = Chem.MolToPDBBlock(mol, flavor=0x20 | 0x10)
-        view.addModel(pdb, 'pdb')
-    else:
-        # py3Dmol does not currently support v3k mol files, so
-        # we can only provide those with "smaller" molecules
-        mb = Chem.MolToMolBlock(mol, confId=confId)
-        view.addModel(mb, 'sdf')
-    if drawAs is None:
-        drawAs = drawing_type_3d
-    view.setStyle({drawAs: {}})
+  if mol.GetNumAtoms() >= 999 or drawAs == 'cartoon':
+    # py3DMol is happier with TER and MASTER records present
+    pdb = Chem.MolToPDBBlock(mol, flavor=0x20 | 0x10)
+    view.addModel(pdb, 'pdb')
+  else:
+    # py3Dmol does not currently support v3k mol files, so
+    # we can only provide those with "smaller" molecules
+    mb = Chem.MolToMolBlock(mol, confId=confId)
+    view.addModel(mb, 'sdf')
+  if drawAs is None:
+    drawAs = drawing_type_3d
+  view.setStyle({drawAs: {}})
 
 
 def drawMol3D(m, view=None, confId=-1, drawAs=None, bgColor=None, size=None):
-    if bgColor is None:
-        bgColor = bgcolor_3d
-    if size is None:
-        size = molSize_3d
-    if view is None:
-        view = py3Dmol.view(width=size[0], height=size[1])
-    view.removeAllModels()
-    try:
-        iter(m)
-    except TypeError:
-        addMolToView(m, view, confId, drawAs)
-    else:
-        ms = m
-        for m in ms:
-            addMolToView(m, view, confId, drawAs)
+  if bgColor is None:
+    bgColor = bgcolor_3d
+  if size is None:
+    size = molSize_3d
+  if view is None:
+    view = py3Dmol.view(width=size[0], height=size[1])
+  view.removeAllModels()
+  try:
+    iter(m)
+  except TypeError:
+    addMolToView(m, view, confId, drawAs)
+  else:
+    ms = m
+    for m in ms:
+      addMolToView(m, view, confId, drawAs)
 
-    view.setBackgroundColor(bgColor)
-    view.zoomTo()
-    return view.show()
+  view.setBackgroundColor(bgColor)
+  view.zoomTo()
+  return view.show()
 
 
 def _toJSON(mol):
-    """For IPython notebook, renders 3D webGL objects."""
-    if not ipython_3d or not mol.GetNumConformers():
-        return None
-    conf = mol.GetConformer()
-    if not conf.Is3D():
-        return None
-    res = drawMol3D(mol)
-    if hasattr(res, 'data'):
-        return res.data
-    return ""
+  """For IPython notebook, renders 3D webGL objects."""
+  if not ipython_3d or not mol.GetNumConformers():
+    return None
+  conf = mol.GetConformer()
+  if not conf.Is3D():
+    return None
+  res = drawMol3D(mol)
+  if hasattr(res, 'data'):
+    return res.data
+  return ""
 
 
 def _toPNG(mol):
-    if hasattr(mol, '__sssAtoms'):
-        highlightAtoms = mol.__sssAtoms
-    else:
-        highlightAtoms = []
-    kekulize = kekulizeStructures
-    return Draw._moltoimg(mol, molSize, highlightAtoms, "", returnPNG=True, kekulize=kekulize)
+  if hasattr(mol, '__sssAtoms'):
+    highlightAtoms = mol.__sssAtoms
+  else:
+    highlightAtoms = []
+  kekulize = kekulizeStructures
+  return Draw._moltoimg(mol, molSize, highlightAtoms, "", returnPNG=True, kekulize=kekulize,
+                        drawOptions=drawOptions)
 
 
 def _toSVG(mol):
-    if not ipython_useSVG:
-        return None
-    if hasattr(mol, '__sssAtoms'):
-        highlightAtoms = mol.__sssAtoms
-    else:
-        highlightAtoms = []
-    kekulize = kekulizeStructures
-    return Draw._moltoSVG(mol, molSize, highlightAtoms, "", kekulize)
+  if not ipython_useSVG:
+    return None
+  if hasattr(mol, '__sssAtoms'):
+    highlightAtoms = mol.__sssAtoms
+  else:
+    highlightAtoms = []
+  kekulize = kekulizeStructures
+  return Draw._moltoSVG(mol, molSize, highlightAtoms, "", kekulize, drawOptions=drawOptions)
 
 
 def _toReactionPNG(rxn):
-    rc = copy.deepcopy(rxn)
-    img = Draw.ReactionToImage(rc, subImgSize=(int(molSize[0] / 3), molSize[1]),
-                               highlightByReactant=highlightByReactant)
-    bio = BytesIO()
-    img.save(bio, format='PNG')
-    return bio.getvalue()
+  rc = copy.deepcopy(rxn)
+  img = Draw.ReactionToImage(rc, subImgSize=(int(molSize[0] / 3), molSize[1]),
+                             highlightByReactant=highlightByReactant, drawOptions=drawOptions)
+  bio = BytesIO()
+  img.save(bio, format='PNG')
+  return bio.getvalue()
 
 
 def _toReactionSVG(rxn):
-    if not ipython_useSVG:
-        return None
-    rc = copy.deepcopy(rxn)
-    return Draw.ReactionToImage(rc, subImgSize=(int(molSize[0] / 3), molSize[1]), useSVG=True,
-                                highlightByReactant=highlightByReactant)
+  if not ipython_useSVG:
+    return None
+  rc = copy.deepcopy(rxn)
+  return Draw.ReactionToImage(rc, subImgSize=(int(molSize[0] / 3), molSize[1]), useSVG=True,
+                              highlightByReactant=highlightByReactant, drawOptions=drawOptions)
 
 
 def _GetSubstructMatch(mol, query, **kwargs):
-    res = mol.__GetSubstructMatch(query, **kwargs)
-    if highlightSubstructs:
-        mol.__sssAtoms = list(res)
-    else:
-        mol.__sssAtoms = []
-    return res
+  res = mol.__GetSubstructMatch(query, **kwargs)
+  if highlightSubstructs:
+    mol.__sssAtoms = list(res)
+  else:
+    mol.__sssAtoms = []
+  return res
 
 
 _GetSubstructMatch.__doc__ = rdchem.Mol.GetSubstructMatch.__doc__
 
 
 def _GetSubstructMatches(mol, query, **kwargs):
-    res = mol.__GetSubstructMatches(query, **kwargs)
-    mol.__sssAtoms = []
-    if highlightSubstructs:
-        for entry in res:
-            mol.__sssAtoms.extend(list(entry))
-    return res
+  res = mol.__GetSubstructMatches(query, **kwargs)
+  mol.__sssAtoms = []
+  if highlightSubstructs:
+    for entry in res:
+      mol.__sssAtoms.extend(list(entry))
+  return res
 
 
 _GetSubstructMatches.__doc__ = rdchem.Mol.GetSubstructMatches.__doc__
@@ -163,74 +165,73 @@ _GetSubstructMatches.__doc__ = rdchem.Mol.GetSubstructMatches.__doc__
 
 # code for displaying PIL images directly,
 def display_pil_image(img):
-    """displayhook function for PIL Images, rendered as PNG"""
-    bio = BytesIO()
-    img.save(bio, format='PNG')
-    return bio.getvalue()
+  """displayhook function for PIL Images, rendered as PNG"""
+  bio = BytesIO()
+  img.save(bio, format='PNG')
+  return bio.getvalue()
 
 
 _MolsToGridImageSaved = None
 
 
 def ShowMols(mols, maxMols=50, **kwargs):
-    global _MolsToGridImageSaved
-    if 'useSVG' not in kwargs:
-        kwargs['useSVG'] = ipython_useSVG
-    if _MolsToGridImageSaved is not None:
-        fn = _MolsToGridImageSaved
-    else:
-        fn = Draw.MolsToGridImage
-    if len(mols) > maxMols:
-        warnings.warn(
-          "Truncating the list of molecules to be displayed to %d. Change the maxMols value to display more."
-          % (maxMols))
-        mols = mols[:maxMols]
-        for prop in ('legends', 'highlightAtoms', 'highlightBonds'):
-            if prop in kwargs:
-                kwargs[prop] = kwargs[prop][:maxMols]
-
-    res = fn(mols, **kwargs)
-    if kwargs['useSVG']:
-        return SVG(res)
-    else:
-        return res
+  global _MolsToGridImageSaved
+  if 'useSVG' not in kwargs:
+    kwargs['useSVG'] = ipython_useSVG
+  if _MolsToGridImageSaved is not None:
+    fn = _MolsToGridImageSaved
+  else:
+    fn = Draw.MolsToGridImage
+  if len(mols) > maxMols:
+    warnings.warn(
+      "Truncating the list of molecules to be displayed to %d. Change the maxMols value to display more."
+      % (maxMols))
+    mols = mols[:maxMols]
+    for prop in ('legends', 'highlightAtoms', 'highlightBonds'):
+      if prop in kwargs:
+        kwargs[prop] = kwargs[prop][:maxMols]
+  res = fn(mols, drawOptions=drawOptions, **kwargs)
+  if kwargs['useSVG']:
+    return SVG(res)
+  else:
+    return res
 
 
 ShowMols.__doc__ = Draw.MolsToGridImage.__doc__
 
 
 def _DrawBit(fn, *args, **kwargs):
-    if 'useSVG' not in kwargs:
-        kwargs['useSVG'] = ipython_useSVG
-    res = fn(*args, **kwargs)
-    if kwargs['useSVG']:
-        return SVG(res)
-    else:
-        sio = BytesIO(res)
-        return Image.open(sio)
+  if 'useSVG' not in kwargs:
+    kwargs['useSVG'] = ipython_useSVG
+  res = fn(*args, **kwargs)
+  if kwargs['useSVG']:
+    return SVG(res)
+  else:
+    sio = BytesIO(res)
+    return Image.open(sio)
 
 
 def _DrawBits(fn, *args, **kwargs):
-    if 'useSVG' not in kwargs:
-        kwargs['useSVG'] = ipython_useSVG
-    res = fn(*args, **kwargs)
-    if kwargs['useSVG']:
-        return SVG(res)
-    else:
-        sio = BytesIO(res)
-        return Image.open(sio)
+  if 'useSVG' not in kwargs:
+    kwargs['useSVG'] = ipython_useSVG
+  res = fn(*args, **kwargs)
+  if kwargs['useSVG']:
+    return SVG(res)
+  else:
+    sio = BytesIO(res)
+    return Image.open(sio)
 
 
 _DrawMorganBitSaved = None
 
 
-def DrawMorganBit(mol, bitId, bitInfo, **kwargs):
-    global _DrawMorganBitSaved
-    if _DrawMorganBitSaved is not None:
-        fn = _DrawMorganBitSaved
-    else:
-        fn = Draw.DrawMorganBit
-    return _DrawBit(fn, mol, bitId, bitInfo, **kwargs)
+def DrawMorganBit(mol, bitId, bitInfo, drawOptions=drawOptions, **kwargs):
+  global _DrawMorganBitSaved
+  if _DrawMorganBitSaved is not None:
+    fn = _DrawMorganBitSaved
+  else:
+    fn = Draw.DrawMorganBit
+  return _DrawBit(fn, mol, bitId, bitInfo, drawOptions=drawOptions, **kwargs)
 
 
 DrawMorganBit.__doc__ = Draw.DrawMorganBit.__doc__
@@ -238,13 +239,13 @@ DrawMorganBit.__doc__ = Draw.DrawMorganBit.__doc__
 _DrawMorganBitsSaved = None
 
 
-def DrawMorganBits(*args, **kwargs):
-    global _DrawMorganBitsSaved
-    if _DrawMorganBitsSaved is not None:
-        fn = _DrawMorganBitsSaved
-    else:
-        fn = Draw.DrawMorganBits
-    return _DrawBit(fn, *args, **kwargs)
+def DrawMorganBits(*args, drawOptions=drawOptions, **kwargs):
+  global _DrawMorganBitsSaved
+  if _DrawMorganBitsSaved is not None:
+    fn = _DrawMorganBitsSaved
+  else:
+    fn = Draw.DrawMorganBits
+  return _DrawBit(fn, *args, drawOptions=drawOptions, **kwargs)
 
 
 DrawMorganBits.__doc__ = Draw.DrawMorganBits.__doc__
@@ -252,13 +253,13 @@ DrawMorganBits.__doc__ = Draw.DrawMorganBits.__doc__
 _DrawRDKitBitSaved = None
 
 
-def DrawRDKitBit(mol, bitId, bitInfo, **kwargs):
-    global _DrawRDKitBitSaved
-    if _DrawRDKitBitSaved is not None:
-        fn = _DrawRDKitBitSaved
-    else:
-        fn = Draw.DrawRDKitBit
-    return _DrawBit(fn, mol, bitId, bitInfo, **kwargs)
+def DrawRDKitBit(mol, bitId, bitInfo, drawOptions=drawOptions, **kwargs):
+  global _DrawRDKitBitSaved
+  if _DrawRDKitBitSaved is not None:
+    fn = _DrawRDKitBitSaved
+  else:
+    fn = Draw.DrawRDKitBit
+  return _DrawBit(fn, mol, bitId, bitInfo, drawOptions=drawOptions, **kwargs)
 
 
 DrawRDKitBit.__doc__ = Draw.DrawRDKitBit.__doc__
@@ -266,13 +267,13 @@ DrawRDKitBit.__doc__ = Draw.DrawRDKitBit.__doc__
 _DrawRDKitBitsSaved = None
 
 
-def DrawRDKitBits(*args, **kwargs):
-    global _DrawRDKitBitsSaved
-    if _DrawRDKitBitsSaved is not None:
-        fn = _DrawRDKitBitsSaved
-    else:
-        fn = Draw.DrawRDKitBits
-    return _DrawBit(fn, *args, **kwargs)
+def DrawRDKitBits(*args, drawOptions=drawOptions, **kwargs):
+  global _DrawRDKitBitsSaved
+  if _DrawRDKitBitsSaved is not None:
+    fn = _DrawRDKitBitsSaved
+  else:
+    fn = Draw.DrawRDKitBits
+  return _DrawBit(fn, *args, drawOptions=drawOptions, **kwargs)
 
 
 DrawRDKitBits.__doc__ = Draw.DrawRDKitBits.__doc__
@@ -281,69 +282,69 @@ _rendererInstalled = False
 
 
 def InstallIPythonRenderer():
-    global _MolsToGridImageSaved, _DrawRDKitBitSaved, _DrawRDKitBitsSaved, _DrawMorganBitSaved, _DrawMorganBitsSaved
-    global _rendererInstalled
-    if _rendererInstalled:
-        return
-    rdchem.Mol._repr_png_ = _toPNG
-    rdchem.Mol._repr_svg_ = _toSVG
-    if _canUse3D:
-        rdchem.Mol._repr_html_ = _toJSON
-    rdChemReactions.ChemicalReaction._repr_png_ = _toReactionPNG
-    rdChemReactions.ChemicalReaction._repr_svg_ = _toReactionSVG
-    if not hasattr(rdchem.Mol, '__GetSubstructMatch'):
-        rdchem.Mol.__GetSubstructMatch = rdchem.Mol.GetSubstructMatch
-    rdchem.Mol.GetSubstructMatch = _GetSubstructMatch
-    if not hasattr(rdchem.Mol, '__GetSubstructMatches'):
-        rdchem.Mol.__GetSubstructMatches = rdchem.Mol.GetSubstructMatches
-    rdchem.Mol.GetSubstructMatches = _GetSubstructMatches
-    Image.Image._repr_png_ = display_pil_image
-    _MolsToGridImageSaved = Draw.MolsToGridImage
-    Draw.MolsToGridImage = ShowMols
-    _DrawRDKitBitSaved = Draw.DrawRDKitBit
-    Draw.DrawRDKitBit = DrawRDKitBit
-    _DrawRDKitBitsSaved = Draw.DrawRDKitBits
-    Draw.DrawRDKitBits = DrawRDKitBits
-    _DrawMorganBitSaved = Draw.DrawMorganBit
-    Draw.DrawMorganBit = DrawMorganBit
-    _DrawMorganBitsSaved = Draw.DrawMorganBits
-    Draw.DrawMorganBits = DrawMorganBits
-    rdchem.Mol.__DebugMol = rdchem.Mol.Debug
-    rdchem.Mol.Debug = lambda self, useStdout=False: self.__DebugMol(useStdout=useStdout)
-    _rendererInstalled = True
+  global _MolsToGridImageSaved, _DrawRDKitBitSaved, _DrawRDKitBitsSaved, _DrawMorganBitSaved, _DrawMorganBitsSaved
+  global _rendererInstalled
+  if _rendererInstalled:
+    return
+  rdchem.Mol._repr_png_ = _toPNG
+  rdchem.Mol._repr_svg_ = _toSVG
+  if _canUse3D:
+    rdchem.Mol._repr_html_ = _toJSON
+  rdChemReactions.ChemicalReaction._repr_png_ = _toReactionPNG
+  rdChemReactions.ChemicalReaction._repr_svg_ = _toReactionSVG
+  if not hasattr(rdchem.Mol, '__GetSubstructMatch'):
+    rdchem.Mol.__GetSubstructMatch = rdchem.Mol.GetSubstructMatch
+  rdchem.Mol.GetSubstructMatch = _GetSubstructMatch
+  if not hasattr(rdchem.Mol, '__GetSubstructMatches'):
+    rdchem.Mol.__GetSubstructMatches = rdchem.Mol.GetSubstructMatches
+  rdchem.Mol.GetSubstructMatches = _GetSubstructMatches
+  Image.Image._repr_png_ = display_pil_image
+  _MolsToGridImageSaved = Draw.MolsToGridImage
+  Draw.MolsToGridImage = ShowMols
+  _DrawRDKitBitSaved = Draw.DrawRDKitBit
+  Draw.DrawRDKitBit = DrawRDKitBit
+  _DrawRDKitBitsSaved = Draw.DrawRDKitBits
+  Draw.DrawRDKitBits = DrawRDKitBits
+  _DrawMorganBitSaved = Draw.DrawMorganBit
+  Draw.DrawMorganBit = DrawMorganBit
+  _DrawMorganBitsSaved = Draw.DrawMorganBits
+  Draw.DrawMorganBits = DrawMorganBits
+  rdchem.Mol.__DebugMol = rdchem.Mol.Debug
+  rdchem.Mol.Debug = lambda self, useStdout=False: self.__DebugMol(useStdout=useStdout)
+  _rendererInstalled = True
 
 
 InstallIPythonRenderer()
 
 
 def UninstallIPythonRenderer():
-    global _MolsToGridImageSaved, _DrawRDKitBitSaved, _DrawMorganBitSaved, _DrawMorganBitsSaved
-    global _rendererInstalled
-    if not _rendererInstalled:
-        return
-    del rdchem.Mol._repr_svg_
-    del rdchem.Mol._repr_png_
-    if _canUse3D:
-        del rdchem.Mol._repr_html_
-    del rdChemReactions.ChemicalReaction._repr_png_
-    if hasattr(rdchem.Mol, '__GetSubstructMatch'):
-        rdchem.Mol.GetSubstructMatch = rdchem.Mol.__GetSubstructMatch
-        del rdchem.Mol.__GetSubstructMatch
-    if hasattr(rdchem.Mol, '__GetSubstructMatches'):
-        rdchem.Mol.GetSubstructMatches = rdchem.Mol.__GetSubstructMatches
-        del rdchem.Mol.__GetSubstructMatches
-    del Image.Image._repr_png_
-    if _MolsToGridImageSaved is not None:
-        Draw.MolsToGridImage = _MolsToGridImageSaved
-    if _DrawRDKitBitSaved is not None:
-        Draw.DrawRDKitBit = _DrawRDKitBitSaved
-    if _DrawRDKitBitsSaved is not None:
-        Draw.DrawRDKitBits = _DrawRDKitBitsSaved
-    if _DrawMorganBitSaved is not None:
-        Draw.DrawMorganBit = _DrawMorganBitSaved
-    if _DrawMorganBitsSaved is not None:
-        Draw.DrawMorganBits = _DrawMorganBitsSaved
-    if hasattr(rdchem.Mol, '__DebugMol'):
-        rdchem.Mol.Debug = rdchem.Mol.__DebugMol
-        del rdchem.Mol.__DebugMol
-    _rendererInstalled = False
+  global _MolsToGridImageSaved, _DrawRDKitBitSaved, _DrawMorganBitSaved, _DrawMorganBitsSaved
+  global _rendererInstalled
+  if not _rendererInstalled:
+    return
+  del rdchem.Mol._repr_svg_
+  del rdchem.Mol._repr_png_
+  if _canUse3D:
+    del rdchem.Mol._repr_html_
+  del rdChemReactions.ChemicalReaction._repr_png_
+  if hasattr(rdchem.Mol, '__GetSubstructMatch'):
+    rdchem.Mol.GetSubstructMatch = rdchem.Mol.__GetSubstructMatch
+    del rdchem.Mol.__GetSubstructMatch
+  if hasattr(rdchem.Mol, '__GetSubstructMatches'):
+    rdchem.Mol.GetSubstructMatches = rdchem.Mol.__GetSubstructMatches
+    del rdchem.Mol.__GetSubstructMatches
+  del Image.Image._repr_png_
+  if _MolsToGridImageSaved is not None:
+    Draw.MolsToGridImage = _MolsToGridImageSaved
+  if _DrawRDKitBitSaved is not None:
+    Draw.DrawRDKitBit = _DrawRDKitBitSaved
+  if _DrawRDKitBitsSaved is not None:
+    Draw.DrawRDKitBits = _DrawRDKitBitsSaved
+  if _DrawMorganBitSaved is not None:
+    Draw.DrawMorganBit = _DrawMorganBitSaved
+  if _DrawMorganBitsSaved is not None:
+    Draw.DrawMorganBits = _DrawMorganBitsSaved
+  if hasattr(rdchem.Mol, '__DebugMol'):
+    rdchem.Mol.Debug = rdchem.Mol.__DebugMol
+    del rdchem.Mol.__DebugMol
+  _rendererInstalled = False


### PR DESCRIPTION
This, plus the change in the Python API to support it, makes it possible to control the drawing options that are used in jupyter.

It also makes it easy on the Python side to have a "global" set of drawing options that can be used with any MolDraw2D object. This has been possible on the C++ side all along.