### PR TITLE
[WIP] Make StructureGroups editable from Python

### DIFF
--- a/Code/GraphMol/SubstanceGroup.h
+++ b/Code/GraphMol/SubstanceGroup.h
@@ -84,7 +84,7 @@ class RDKIT_GRAPHMOL_EXPORT SubstanceGroup : public RDProps {
   //! No default constructor
   SubstanceGroup() = delete;
 
-  //! Main Constructor. Ownsership is only set on this side of the relationship:
+  //! Main Constructor. Ownership is only set on this side of the relationship:
   //! mol->addSubstanceGroup(sgroup) still needs to be called to get ownership
   //! on the other side.
   SubstanceGroup(ROMol *owning_mol, const std::string &type);
@@ -102,9 +102,9 @@ class RDKIT_GRAPHMOL_EXPORT SubstanceGroup : public RDProps {
   bool hasOwningMol() const { return dp_mol != nullptr; };
 
   //! Get the molecule that owns this instance
-  ROMol &getOwningMol() const {     
+  ROMol &getOwningMol() const {
     PRECONDITION(dp_mol, "no owner");
-    return *dp_mol; 
+    return *dp_mol;
   }
 
   //! get the index of this sgroup in dp_mol's sgroups vector

--- a/Code/GraphMol/Wrap/SubstanceGroup.cpp
+++ b/Code/GraphMol/Wrap/SubstanceGroup.cpp
@@ -47,7 +47,7 @@ SubstanceGroup *createMolSubstanceGroup(ROMol &mol, std::string type) {
 
 void addBracketHelper(SubstanceGroup &self, python::object pts) {
   unsigned int sz = python::extract<unsigned int>(pts.attr("__len__")());
-  if (sz != 2 and sz != 3)
+  if (sz != 2 && sz != 3)
     throw_value_error("pts object have a length of 2 or 3");
 
   SubstanceGroup::Bracket bkt;

--- a/Code/GraphMol/Wrap/SubstanceGroup.cpp
+++ b/Code/GraphMol/Wrap/SubstanceGroup.cpp
@@ -23,6 +23,14 @@ namespace python = boost::python;
 namespace RDKit {
 
 namespace {
+SubstanceGroup *getMolSubstanceGroupWithIdx(ROMol &mol, unsigned int idx) {
+  auto &sgs = getSubstanceGroups(mol);
+  if (idx >= sgs.size()) {
+    throw_index_error(idx);
+  }
+  return &(sgs[idx]);
+}
+
 std::vector<SubstanceGroup> getMolSubstanceGroups(ROMol &mol) {
   return getSubstanceGroups(mol);
 }
@@ -70,6 +78,12 @@ struct sgroup_wrap {
             "GetBonds", &SubstanceGroup::getBonds,
             "returns a list of the indices of the bonds in this SubstanceGroup",
             python::return_value_policy<python::copy_const_reference>())
+        .def("SetProp",
+             (void (RDProps::*)(const std::string &, std::string, bool) const) &
+                 SubstanceGroup::setProp<std::string>,
+             (python::arg("self"), python::arg("key"), python::arg("val"),
+              python::arg("computed") = false),
+             "sets the value of a particular property")
         .def("HasProp",
              (bool (RDProps::*)(const std::string &) const) &
                  SubstanceGroup::hasProp,
@@ -105,8 +119,12 @@ struct sgroup_wrap {
              "SubstanceGroup.\n"
              " n.b. some properties cannot be converted to python types.\n");
     python::def("GetMolSubstanceGroups", &getMolSubstanceGroups,
-                "returns the SubstanceGroups for a molecule (if any)",
+                "returns a copy of a molecule's SubstanceGroups (if any)",
                 python::with_custodian_and_ward_postcall<0, 1>());
+    python::def("GetMolSubstanceGroupWithIdx", &getMolSubstanceGroupWithIdx,
+                "returns a particular SubstanceGroup from the molecule",
+                python::return_internal_reference<
+                    1, python::with_custodian_and_ward_postcall<0, 1>>());
     python::def("ClearMolSubstanceGroups", &clearMolSubstanceGroups,
                 "removes all SubstanceGroups from a molecule (if any)");
     // FIX: needs something tying the lifetime to the mol

--- a/Code/GraphMol/Wrap/SubstanceGroup.cpp
+++ b/Code/GraphMol/Wrap/SubstanceGroup.cpp
@@ -38,6 +38,28 @@ void clearMolSubstanceGroups(ROMol &mol) {
   std::vector<SubstanceGroup> &sgs = getSubstanceGroups(mol);
   sgs.clear();
 }
+
+SubstanceGroup *createMolSubstanceGroup(ROMol &mol, std::string type) {
+  SubstanceGroup sg(&mol, type);
+  addSubstanceGroup(mol, sg);
+  return &(getSubstanceGroups(mol).back());
+}
+
+void addBracketHelper(SubstanceGroup &self, python::object pts) {
+  unsigned int sz = python::extract<unsigned int>(pts.attr("__len__")());
+  if (sz != 2 and sz != 3)
+    throw_value_error("pts object have a length of 2 or 3");
+
+  SubstanceGroup::Bracket bkt;
+  python::stl_input_iterator<RDGeom::Point3D> beg(pts);
+  unsigned int i = 0;
+  for (unsigned int i = 0; i < sz; ++i) {
+    bkt[i] = *beg;
+    ++beg;
+  }
+  self.addBracket(bkt);
+}
+
 }  // namespace
 
 std::string sGroupClassDoc =
@@ -78,9 +100,45 @@ struct sgroup_wrap {
             "GetBonds", &SubstanceGroup::getBonds,
             "returns a list of the indices of the bonds in this SubstanceGroup",
             python::return_value_policy<python::copy_const_reference>())
+        .def("AddAtomWithIdx", &SubstanceGroup::addAtomWithIdx)
+        .def("AddBondWithIdx", &SubstanceGroup::addBondWithIdx)
+        .def("AddParentAtomWithIdx", &SubstanceGroup::addParentAtomWithIdx)
+        .def("AddAtomWithBookmark", &SubstanceGroup::addAtomWithBookmark)
+        .def("AddParentAtomWithBookmark",
+             &SubstanceGroup::addParentAtomWithBookmark)
+        .def("AddCState", &SubstanceGroup::addCState)
+        .def("AddBondWithBookmark", &SubstanceGroup::addBondWithBookmark)
+        .def("AddAttachPoint", &SubstanceGroup::addAttachPoint)
+        .def("AddBracket", addBracketHelper)
+
         .def("SetProp",
              (void (RDProps::*)(const std::string &, std::string, bool) const) &
                  SubstanceGroup::setProp<std::string>,
+             (python::arg("self"), python::arg("key"), python::arg("val"),
+              python::arg("computed") = false),
+             "sets the value of a particular property")
+        .def("SetDoubleProp",
+             (void (RDProps::*)(const std::string &, double, bool) const) &
+                 SubstanceGroup::setProp<double>,
+             (python::arg("self"), python::arg("key"), python::arg("val"),
+              python::arg("computed") = false),
+             "sets the value of a particular property")
+        .def("SetIntProp",
+             (void (RDProps::*)(const std::string &, int, bool) const) &
+                 SubstanceGroup::setProp<int>,
+             (python::arg("self"), python::arg("key"), python::arg("val"),
+              python::arg("computed") = false),
+             "sets the value of a particular property")
+        .def(
+            "SetUnsignedProp",
+            (void (RDProps::*)(const std::string &, unsigned int, bool) const) &
+                SubstanceGroup::setProp<unsigned int>,
+            (python::arg("self"), python::arg("key"), python::arg("val"),
+             python::arg("computed") = false),
+            "sets the value of a particular property")
+        .def("SetBoolProp",
+             (void (RDProps::*)(const std::string &, bool, bool) const) &
+                 SubstanceGroup::setProp<bool>,
              (python::arg("self"), python::arg("key"), python::arg("val"),
               python::arg("computed") = false),
              "sets the value of a particular property")
@@ -119,7 +177,7 @@ struct sgroup_wrap {
              "SubstanceGroup.\n"
              " n.b. some properties cannot be converted to python types.\n");
     python::def("GetMolSubstanceGroups", &getMolSubstanceGroups,
-                "returns a copy of a molecule's SubstanceGroups (if any)",
+                "returns a copy of the molecule's SubstanceGroups (if any)",
                 python::with_custodian_and_ward_postcall<0, 1>());
     python::def("GetMolSubstanceGroupWithIdx", &getMolSubstanceGroupWithIdx,
                 "returns a particular SubstanceGroup from the molecule",
@@ -127,7 +185,12 @@ struct sgroup_wrap {
                     1, python::with_custodian_and_ward_postcall<0, 1>>());
     python::def("ClearMolSubstanceGroups", &clearMolSubstanceGroups,
                 "removes all SubstanceGroups from a molecule (if any)");
-    // FIX: needs something tying the lifetime to the mol
+    python::def("CreateMolSubstanceGroup", &createMolSubstanceGroup,
+                (python::arg("mol"), python::arg("type")),
+                "creates a new SubstanceGroup associated with a molecule",
+                python::return_value_policy<
+                    python::reference_existing_object,
+                    python::with_custodian_and_ward_postcall<0, 1>>());
   }
 };
 }  // namespace RDKit

--- a/Code/GraphMol/Wrap/testSGroups.py
+++ b/Code/GraphMol/Wrap/testSGroups.py
@@ -9,6 +9,7 @@
 #
 
 from rdkit import Chem
+from rdkit import Geometry
 from rdkit.Chem import RDConfig
 import os
 import sys
@@ -110,6 +111,41 @@ M  END"""
     pd = sgs2[0].GetPropsAsDict()
     self.assertTrue('foo' in pd)
     self.assertEqual(pd['foo'], 'bar')
+
+  def testCreateSGroup(self):
+    mol = Chem.MolFromMolBlock('''
+  Mrv1810 10061910532D          
+
+  0  0  0     0  0            999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 4 3 0 0 0
+M  V30 BEGIN ATOM
+M  V30 1 O -14.8632 3.7053 0 0
+M  V30 2 C -13.3232 3.7053 0 0
+M  V30 3 O -11.7832 3.7053 0 0
+M  V30 4 * -10.2453 3.6247 0 0
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 1 1 2
+M  V30 2 1 2 3
+M  V30 3 1 3 4
+M  V30 END BOND
+M  V30 END CTAB
+M  END''')
+    self.assertTrue(mol is not None)
+    mcpy = Chem.Mol(mol)
+    sg = Chem.CreateMolSubstanceGroup(mcpy, "SRU")
+    self.assertEqual(sg.GetProp("TYPE"), "SRU")
+    sg = Chem.GetMolSubstanceGroupWithIdx(mcpy, 0)
+    sg.AddBracket((Geometry.Point3D(-11.1, 4.6, 0), Geometry.Point3D(-11.1, 2.7, 0)))
+    sg.AddBracket((Geometry.Point3D(-13.9, 2.7, 0), Geometry.Point3D(-13.9, 4.6, 0)))
+    sg.AddAtomWithIdx(1)
+    sg.AddAtomWithIdx(2)
+    sg.AddBondWithIdx(0)
+    sg.AddBondWithIdx(2)
+    sg.SetProp("CONNECT", "HT")
+    sg.SetProp("LABEL", "n")
+    print(Chem.MolToMolBlock(mcpy, forceV3000=True))
 
 
 if __name__ == '__main__':

--- a/Code/GraphMol/Wrap/testSGroups.py
+++ b/Code/GraphMol/Wrap/testSGroups.py
@@ -145,7 +145,10 @@ M  END''')
     sg.AddBondWithIdx(2)
     sg.SetProp("CONNECT", "HT")
     sg.SetProp("LABEL", "n")
-    print(Chem.MolToMolBlock(mcpy, forceV3000=True))
+    mb = Chem.MolToMolBlock(mcpy, forceV3000=True)
+    self.assertNotEqual(mb.find('V30 1 SRU'), -1)
+    self.assertNotEqual(mb.find('BRKXYZ'), -1)
+    self.assertNotEqual(mb.find('CONNECT=HT'), -1)
 
 
 if __name__ == '__main__':

--- a/Code/GraphMol/Wrap/testSGroups.py
+++ b/Code/GraphMol/Wrap/testSGroups.py
@@ -16,8 +16,9 @@ import unittest
 
 
 class TestCase(unittest.TestCase):
-    def setUp(self):
-        mb = """
+
+  def setUp(self):
+    mb = """
   ACCLDraw04231812452D
 
  13 13  0  0  0  0  0  0  0  0999 V2000
@@ -59,46 +60,58 @@ M  SDT   2 Stereo
 M  SDD   2     0.0000    0.0000    DR    ALL  1       6
 M  SED   2 E/Z unknown
 M  END"""
-        self.m1 = Chem.MolFromMolBlock(mb)
+    self.m1 = Chem.MolFromMolBlock(mb)
 
-    def testBasics(self):
-        self.assertTrue(self.m1 is not None)
-        sgs = Chem.GetMolSubstanceGroups(self.m1)
-        self.assertEqual(len(sgs), 2)
-        self.assertTrue(sgs[0].HasProp("TYPE"))
-        self.assertTrue(sgs[1].HasProp("TYPE"))
-        self.assertEqual(sgs[0].GetProp("TYPE"), "DAT")
-        self.assertEqual(sgs[1].GetProp("TYPE"), "DAT")
+  def testBasics(self):
+    self.assertTrue(self.m1 is not None)
+    sgs = Chem.GetMolSubstanceGroups(self.m1)
+    self.assertEqual(len(sgs), 2)
+    self.assertTrue(sgs[0].HasProp("TYPE"))
+    self.assertTrue(sgs[1].HasProp("TYPE"))
+    self.assertEqual(sgs[0].GetProp("TYPE"), "DAT")
+    self.assertEqual(sgs[1].GetProp("TYPE"), "DAT")
 
-        self.assertTrue(sgs[0].HasProp("FIELDNAME"))
-        self.assertEqual(sgs[0].GetProp("FIELDNAME"), "pH")
+    self.assertTrue(sgs[0].HasProp("FIELDNAME"))
+    self.assertEqual(sgs[0].GetProp("FIELDNAME"), "pH")
 
-        self.assertEqual(sorted(sgs[0].GetPropNames()), [
-                         'DATAFIELDS', 'FIELDDISP', 'FIELDINFO', 'FIELDNAME', 'FIELDTYPE', 'ID', 'QUERYOP', 'QUERYTYPE', 'TYPE'])
-        dd = sgs[0].GetPropsAsDict()
-        self.assertTrue("TYPE" in dd)
-        self.assertEqual(dd["TYPE"], "DAT")
-        self.assertTrue("FIELDNAME" in dd)
-        self.assertEqual(dd["FIELDNAME"], "pH")
+    self.assertEqual(sorted(sgs[0].GetPropNames()), [
+      'DATAFIELDS', 'FIELDDISP', 'FIELDINFO', 'FIELDNAME', 'FIELDTYPE', 'ID', 'QUERYOP',
+      'QUERYTYPE', 'TYPE'
+    ])
+    dd = sgs[0].GetPropsAsDict()
+    self.assertTrue("TYPE" in dd)
+    self.assertEqual(dd["TYPE"], "DAT")
+    self.assertTrue("FIELDNAME" in dd)
+    self.assertEqual(dd["FIELDNAME"], "pH")
 
-        Chem.ClearMolSubstanceGroups(self.m1)
-        self.assertEqual(len(Chem.GetMolSubstanceGroups(self.m1)), 0)
+    Chem.ClearMolSubstanceGroups(self.m1)
+    self.assertEqual(len(Chem.GetMolSubstanceGroups(self.m1)), 0)
 
-    def testLifetime(self):
-        self.assertTrue(self.m1 is not None)
-        mcpy = Chem.Mol(self.m1)
-        smi = Chem.MolToSmiles(mcpy)
-        sgs = Chem.GetMolSubstanceGroups(mcpy)
-        self.assertEqual(len(sgs), 2)
-        mcpy = None
-        parent = sgs[0].GetOwningMol()
-        self.assertEqual(smi, Chem.MolToSmiles(parent))
-        sgl = list(sgs)
-        sgs = None
-        parent = sgl[0].GetOwningMol()
-        self.assertEqual(smi, Chem.MolToSmiles(parent))
+  def testLifetime(self):
+    self.assertTrue(self.m1 is not None)
+    mcpy = Chem.Mol(self.m1)
+    smi = Chem.MolToSmiles(mcpy)
+    sgs = Chem.GetMolSubstanceGroups(mcpy)
+    self.assertEqual(len(sgs), 2)
+    mcpy = None
+    parent = sgs[0].GetOwningMol()
+    self.assertEqual(smi, Chem.MolToSmiles(parent))
+    sgl = list(sgs)
+    sgs = None
+    parent = sgl[0].GetOwningMol()
+    self.assertEqual(smi, Chem.MolToSmiles(parent))
+
+  def testSetProp(self):
+    self.assertTrue(self.m1 is not None)
+    mcpy = Chem.Mol(self.m1)
+    sg = Chem.GetMolSubstanceGroupWithIdx(mcpy, 0)
+    sg.SetProp("foo", "bar")
+    sgs2 = Chem.GetMolSubstanceGroups(mcpy)
+    pd = sgs2[0].GetPropsAsDict()
+    self.assertTrue('foo' in pd)
+    self.assertEqual(pd['foo'], 'bar')
 
 
 if __name__ == '__main__':
-    print("Testing SubstanceGroups wrapper")
-    unittest.main()
+  print("Testing SubstanceGroups wrapper")
+  unittest.main()


### PR DESCRIPTION
This adds code to allow StructureGroups to be created and edited from Python.

This may be ready to go as-is, but I'd like to see if there are any comments before merging

This addresses #2489 