### PR TITLE
Fixes #2639

### DIFF
--- a/Code/GraphMol/Wrap/Atom.cpp
+++ b/Code/GraphMol/Wrap/Atom.cpp
@@ -139,8 +139,8 @@ Note that, though it is possible to create one, having an Atom on its own\n\
 (i.e not associated with a molecule) is not particularly useful.\n";
 struct atom_wrapper {
   static void wrap() {
-    python::class_<Atom, Atom *>("Atom", atomClassDoc.c_str(),
-                                 python::init<std::string>())
+    python::class_<Atom>("Atom", atomClassDoc.c_str(),
+                         python::init<std::string>())
 
         .def(python::init<const Atom &>())
         .def(python::init<unsigned int>(

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -5115,6 +5115,17 @@ M  END
     # file is 1 indexed and says 5
     self.assertEqual(stereo_atoms[1].GetIdx(), 4)
 
+    # make sure the atoms are connected to the parent molecule
+    stereo_atoms[1].SetProp("foo","bar")
+    self.assertTrue(m.GetAtomWithIdx(4).HasProp("foo"))
+
+    # make sure that we can iterate over the atoms:
+    for at in stereo_atoms:
+      at.SetProp("foo2","bar2")
+      self.assertTrue(m.GetAtomWithIdx(at.GetIdx()).HasProp("foo2"))
+    
+        
+
   def testEnhancedStereoPreservesMol(self):
     """
     Check that the stereo group (and the atoms therein) preserve the lifetime


### PR DESCRIPTION
The key here is to use an `Atom` as the held type of the wrapper class, not an `Atom *`.

Required some changes to the StereoGroups wrapper code too since returning an `std::vector<Atom *>` directly to Python no longer works. Returning a tuple isn't such a bad thing. :-)


