### PR TITLE
Add viewBox to SVG (close #2680)

### DIFF
--- a/Code/GraphMol/MolDraw2D/MolDraw2DSVG.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DSVG.cpp
@@ -56,7 +56,8 @@ void MolDraw2DSVG::initDrawing() {
         xmlns:rdkit='http://www.rdkit.org/xml'\n              \
         xmlns:xlink='http://www.w3.org/1999/xlink'\n          \
         xml:space='preserve'\n";
-  d_os << "width='" << width() << "px' height='" << height() << "px' >\n";
+  d_os << boost::format{"width='%1%px' height='%2%px' viewBox='0 0 %1% %2%'>\n"}
+      % width() % height();
   d_os << "<!-- END OF HEADER -->\n";
 
   // d_os<<"<g transform='translate("<<width()*.05<<","<<height()*.05<<")


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! 
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->
Close #2680

#### What does this implement/fix? Explain your changes.
Write `viewBox` attribute in `RDKit::MolDraw2DSVG::initDrawing`.

<!--
#### Any other comments?
-->
