### PR TITLE
Fix set stereo bond labels to SMARTS mol

### DIFF
--- a/Code/GraphMol/Chirality.cpp
+++ b/Code/GraphMol/Chirality.cpp
@@ -2279,32 +2279,33 @@ void detectBondStereochemistry(ROMol &mol, int confId) {
 void setBondStereoFromDirections(ROMol &mol) {
   for (Bond *bond : mol.bonds()) {
     if (bond->getBondType() == Bond::DOUBLE) {
-      const Atom *startAtom = bond->getBeginAtom();
-      const Atom *endAtom = bond->getEndAtom();
+      const Atom *stereoBondBeginAtom = bond->getBeginAtom();
+      const Atom *stereoBondEndAtom = bond->getEndAtom();
 
-      const Bond *startDirBond =
-          Chirality::getNeighboringDirectedBond(mol, startAtom);
-      const Bond *endDirBond =
-          Chirality::getNeighboringDirectedBond(mol, endAtom);
+      const Bond *directedBondAtBegin =
+          Chirality::getNeighboringDirectedBond(mol, stereoBondBeginAtom);
+      const Bond *directedBondAtEnd =
+          Chirality::getNeighboringDirectedBond(mol, stereoBondEndAtom);
 
-      if (startDirBond != nullptr && endDirBond != nullptr) {
-        unsigned startStereoAtom =
-            startDirBond->getOtherAtomIdx(startAtom->getIdx());
-        unsigned endStereoAtom = endDirBond->getOtherAtomIdx(endAtom->getIdx());
+      if (directedBondAtBegin != nullptr && directedBondAtEnd != nullptr) {
+        unsigned beginSideStereoAtom =
+            directedBondAtBegin->getOtherAtomIdx(stereoBondBeginAtom->getIdx());
+        unsigned endSideStereoAtom =
+            directedBondAtEnd->getOtherAtomIdx(stereoBondEndAtom->getIdx());
 
-        bond->setStereoAtoms(startStereoAtom, endStereoAtom);
+        bond->setStereoAtoms(beginSideStereoAtom, endSideStereoAtom);
 
-        auto startBondDir = startDirBond->getBondDir();
-        if (startDirBond->getBeginAtom() == startAtom) {
-          startBondDir = getOppositeBondDir(startBondDir);
+        auto beginSideBondDirection = directedBondAtBegin->getBondDir();
+        if (directedBondAtBegin->getBeginAtom() == stereoBondBeginAtom) {
+          beginSideBondDirection = getOppositeBondDir(beginSideBondDirection);
         }
 
-        auto endBondDir = endDirBond->getBondDir();
-        if (endDirBond->getEndAtom() == endAtom) {
-          endBondDir = getOppositeBondDir(endBondDir);
+        auto endSideBondDirection = directedBondAtEnd->getBondDir();
+        if (directedBondAtEnd->getEndAtom() == stereoBondEndAtom) {
+          endSideBondDirection = getOppositeBondDir(endSideBondDirection);
         }
 
-        if (startBondDir == endBondDir) {
+        if (beginSideBondDirection == endSideBondDirection) {
           bond->setStereo(Bond::STEREOTRANS);
         } else {
           bond->setStereo(Bond::STEREOCIS);

--- a/Code/GraphMol/SmilesParse/smatest.cpp
+++ b/Code/GraphMol/SmilesParse/smatest.cpp
@@ -2770,6 +2770,15 @@ void testSmartsStereoBonds() {
       TEST_ASSERT(bnd->getStereo() == Bond::STEREONONE);
     }
   }
+  {
+    // A weird way of writing C/C=C/O:
+    const auto mol = R"([#6](=[#6]/[#8])\[#6])"_smarts;
+
+    const Bond *bnd = mol->getBondWithIdx(1);
+
+    TEST_ASSERT(bnd->getStereoAtoms() == INT_VECT({3, 2}));
+    TEST_ASSERT(bnd->getStereo() == Bond::STEREOTRANS);
+  }
 
   BOOST_LOG(rdInfoLog) << "done" << std::endl;
 }

--- a/Code/GraphMol/Wrap/MolOps.cpp
+++ b/Code/GraphMol/Wrap/MolOps.cpp
@@ -868,6 +868,17 @@ struct molops_wrapper {
                 (python::arg("mol"), python::arg("confId") = -1),
                 docString.c_str());
 
+    docString =
+        "Uses the directions of neighboring bonds to set cis/trans stereo on double bonds.\n\
+        \n\
+  ARGUMENTS:\n\
+  \n\
+    - mol: the molecule to be modified\n\
+\n";
+    python::def("SetBondStereoFromDirections", MolOps::setBondStereoFromDirections,
+                (python::arg("mol")),
+                docString.c_str());
+
     // ------------------------------------------------------------------------
     docString =
         "Kekulize, check valencies, set aromaticity, conjugation and hybridization\n\

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -5568,6 +5568,45 @@ H      0.635000    0.635000    0.635000
           self.assertEqual(order1,order3)
           self.assertEqual(order2,order4)
     
+  def testSetBondStereoFromDirections(self):
+    m1 = Chem.MolFromMolBlock('''
+  Mrv1810 10141909482D          
+
+  4  3  0  0  0  0            999 V2000
+    3.3412   -2.9968    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    2.5162   -2.9968    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    2.1037   -3.7112    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    3.7537   -2.2823    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+  1  2  2  0  0  0  0
+  2  3  1  0  0  0  0
+  1  4  1  0  0  0  0
+M  END
+''', sanitize=False)
+    self.assertEqual(m1.GetBondBetweenAtoms(0,1).GetBondType(),Chem.BondType.DOUBLE)
+    self.assertEqual(m1.GetBondBetweenAtoms(0,1).GetStereo(),Chem.BondStereo.STEREONONE)
+    Chem.SetBondStereoFromDirections(m1)
+    self.assertEqual(m1.GetBondBetweenAtoms(0,1).GetStereo(),Chem.BondStereo.STEREOTRANS)
+    
+    m2 = Chem.MolFromMolBlock('''
+  Mrv1810 10141909542D          
+
+  4  3  0  0  0  0            999 V2000
+    3.4745   -5.2424    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    2.6495   -5.2424    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    2.2370   -5.9569    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    3.8870   -5.9569    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+  1  2  2  0  0  0  0
+  2  3  1  0  0  0  0
+  1  4  1  0  0  0  0
+M  END
+''',sanitize=False)
+    self.assertEqual(m2.GetBondBetweenAtoms(0,1).GetBondType(),Chem.BondType.DOUBLE)
+    self.assertEqual(m2.GetBondBetweenAtoms(0,1).GetStereo(),Chem.BondStereo.STEREONONE)
+    Chem.SetBondStereoFromDirections(m2)
+    self.assertEqual(m2.GetBondBetweenAtoms(0,1).GetStereo(),Chem.BondStereo.STEREOCIS)
+
+
+
 if __name__ == '__main__':
   if "RDTESTCASE" in os.environ:
     suite = unittest.TestSuite()

--- a/Code/GraphMol/catch_tests.cpp
+++ b/Code/GraphMol/catch_tests.cpp
@@ -543,3 +543,96 @@ M  END)CTAB";
     CHECK(outmolb.find("4  2  2  0") != std::string::npos);
   }
 }
+
+TEST_CASE(
+    "GitHub 2712: setBondStereoFromDirections() returning incorrect results"
+    "[stereochemistry]") {
+  SECTION("basics 1a") {
+    std::string mb = R"CTAB(
+  Mrv1810 10141909562D          
+
+  4  3  0  0  0  0            999 V2000
+    3.3412   -2.9968    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    2.5162   -2.9968    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    2.1037   -3.7112    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    3.7537   -2.2823    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+  1  2  2  0  0  0  0
+  2  3  1  0  0  0  0
+  1  4  1  0  0  0  0
+M  END
+)CTAB";
+    bool sanitize = false;
+    std::unique_ptr<ROMol> mol(MolBlockToMol(mb, sanitize));
+    REQUIRE(mol);
+    CHECK(mol->getBondWithIdx(0)->getBondType() == Bond::DOUBLE);
+    CHECK(mol->getBondWithIdx(0)->getStereo() == Bond::STEREONONE);
+    MolOps::setBondStereoFromDirections(*mol);
+    CHECK(mol->getBondWithIdx(0)->getStereo() == Bond::STEREOTRANS);
+  }
+  SECTION("basics 1b") {
+    std::string mb = R"CTAB(
+  Mrv1810 10141909562D          
+
+  4  3  0  0  0  0            999 V2000
+    3.3412   -2.9968    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    2.5162   -2.9968    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    2.1037   -3.7112    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    3.7537   -2.2823    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+  1  2  2  0  0  0  0
+  2  3  1  0  0  0  0
+  4  1  1  0  0  0  0
+M  END
+)CTAB";
+    bool sanitize = false;
+    std::unique_ptr<ROMol> mol(MolBlockToMol(mb, sanitize));
+    REQUIRE(mol);
+    CHECK(mol->getBondWithIdx(0)->getBondType() == Bond::DOUBLE);
+    CHECK(mol->getBondWithIdx(0)->getStereo() == Bond::STEREONONE);
+    MolOps::setBondStereoFromDirections(*mol);
+    CHECK(mol->getBondWithIdx(0)->getStereo() == Bond::STEREOTRANS);
+  }
+  SECTION("basics 2a") {
+    std::string mb = R"CTAB(
+  Mrv1810 10141909582D          
+
+  4  3  0  0  0  0            999 V2000
+    3.4745   -5.2424    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    2.6495   -5.2424    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    2.2370   -5.9569    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    3.8870   -5.9569    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+  1  2  2  0  0  0  0
+  2  3  1  0  0  0  0
+  1  4  1  0  0  0  0
+M  END
+)CTAB";
+    bool sanitize = false;
+    std::unique_ptr<ROMol> mol(MolBlockToMol(mb, sanitize));
+    REQUIRE(mol);
+    CHECK(mol->getBondWithIdx(0)->getBondType() == Bond::DOUBLE);
+    CHECK(mol->getBondWithIdx(0)->getStereo() == Bond::STEREONONE);
+    MolOps::setBondStereoFromDirections(*mol);
+    CHECK(mol->getBondWithIdx(0)->getStereo() == Bond::STEREOCIS);
+  }
+  SECTION("basics 2b") {
+    std::string mb = R"CTAB(
+  Mrv1810 10141909582D          
+
+  4  3  0  0  0  0            999 V2000
+    3.4745   -5.2424    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    2.6495   -5.2424    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    2.2370   -5.9569    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    3.8870   -5.9569    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+  1  2  2  0  0  0  0
+  2  3  1  0  0  0  0
+  4  1  1  0  0  0  0
+M  END
+)CTAB";
+    bool sanitize = false;
+    std::unique_ptr<ROMol> mol(MolBlockToMol(mb, sanitize));
+    REQUIRE(mol);
+    CHECK(mol->getBondWithIdx(0)->getBondType() == Bond::DOUBLE);
+    CHECK(mol->getBondWithIdx(0)->getStereo() == Bond::STEREONONE);
+    MolOps::setBondStereoFromDirections(*mol);
+    CHECK(mol->getBondWithIdx(0)->getStereo() == Bond::STEREOCIS);
+  }
+}


### PR DESCRIPTION
It took several weeks, but I finally found something to complain about in PR #2623:

There is a small detail I did not consider: bonds can be written in reverse, so that their direction needs to be reversed to be correctly considered.

I just hit this:

```python
from rdkit import Chem
mol = Chem.MolFromMolBlock(
"""C/C=C/O
     RDKit          3D

  4  3  0  0  0  0  0  0  0  0999 V2000
    0.0175    0.0570   -0.2095 C   0  0  0  0  0  0  0  0  0  0  0  0
   -0.7490    1.1168    0.0782 C   0  0  0  0  0  0  0  0  0  0  0  0
   -2.0935    1.1693   -0.1018 O   0  0  0  0  0  0  0  0  0  0  0  0
    1.5185   -0.0072   -0.0078 C   0  0  0  0  0  0  0  0  0  0  0  0
  4  1  1  0
  1  2  2  0
  3  2  1  0
M  END
""")
print(mol.GetBondWithIdx(1).GetStereo())
sma = Chem.MolToSmarts(mol)
print(sma)
q = Chem.MolFromSmarts(sma)
print(q.GetBondWithIdx(1).GetStereo())
```
The output shows that, indeed, the bond stereo was reversed through the SMARTS conversion:
```
STEREOE
[#6](=[#6]/[#8])\[#6]
STEREOCIS
```

I wrote a small patch to check if the bond direction needs to be reversed, and a small test using the SMARTS in this example.