### PR TITLE
Eat our own dogfood, Clone is deprecated so use copy

### DIFF
--- a/Code/GraphMol/FilterCatalog/FilterCatalogEntry.h
+++ b/Code/GraphMol/FilterCatalog/FilterCatalogEntry.h
@@ -62,7 +62,7 @@ class RDKIT_FILTERCATALOG_EXPORT FilterCatalogEntry
   FilterCatalogEntry() : d_matcher(), d_props() {}
 
   FilterCatalogEntry(const std::string &name, const FilterMatcherBase &matcher)
-      : RDCatalog::CatalogEntry(), d_matcher(matcher.Clone()) {
+      : RDCatalog::CatalogEntry(), d_matcher(matcher.copy()) {
     setDescription(name);
   }
 


### PR DESCRIPTION
Removes the deprecation warning when creating a FilterCatalogEntry object.  This should have been fixed a long time ago ...