### PR TITLE
Fixes #2714 (The MCS smartsString may still be ambiguous)

### DIFF
--- a/Code/GraphMol/FMCS/MaximumCommonSubgraph.cpp
+++ b/Code/GraphMol/FMCS/MaximumCommonSubgraph.cpp
@@ -658,13 +658,12 @@ std::string MaximumCommonSubgraph::generateResultSMARTS(
   unsigned ai = 0;  // SeedAtomIdx
   for (auto atom = mcsIdx.Atoms.begin(); atom != mcsIdx.Atoms.end();
        atom++, ai++) {
+    QueryAtom a;
     if (Parameters.AtomTyper ==
         MCSAtomCompareIsotopes) {  // do '[0*]-[0*]-[13*]' for CC[13NH2]
-      QueryAtom a;
       a.setQuery(makeAtomIsotopeQuery((int)(*atom)->getIsotope()));
-      mol.addAtom(&a, true, false);
     } else {
-      QueryAtom a;  // generate [#6] instead of C or c !
+      // generate [#6] instead of C or c !
       a.setQuery(makeAtomNumQuery((*atom)->getAtomicNum()));
       // for all atomMatchSet[ai] items add atom query to template like
       // [#6,#17,#9, ... ]
@@ -678,8 +677,13 @@ std::string MaximumCommonSubgraph::generateResultSMARTS(
              am->second->getChiralTag() == Atom::CHI_TETRAHEDRAL_CCW))
           a.setChiralTag(am->second->getChiralTag());
       }
-      mol.addAtom(&a, true, false);
     }
+    if (Parameters.AtomCompareParameters.RingMatchesRingOnly) {
+      ATOM_EQUALS_QUERY *q = makeAtomInRingQuery();
+      q->setNegation(!queryIsAtomInRing(*atom));
+      a.expandQuery(q, Queries::COMPOSITE_AND, true);
+    }
+    mol.addAtom(&a, true, false);
   }
   unsigned bi = 0;  // Seed Idx
   for (auto bond = mcsIdx.Bonds.begin(); bond != mcsIdx.Bonds.end();

--- a/Code/GraphMol/FMCS/Wrap/testFMCS.py
+++ b/Code/GraphMol/FMCS/Wrap/testFMCS.py
@@ -131,7 +131,7 @@ class TestCase(unittest.TestCase):
         mcs = rdFMCS.FindMCS(ms, ringMatchesRingOnly=True)
         self.assertEqual(mcs.numBonds, 1)
         self.assertEqual(mcs.numAtoms, 2)
-        self.assertEqual(mcs.smartsString, '[#6]-&!@[#6]')
+        self.assertEqual(mcs.smartsString, '[#6&!R]-&!@[#6&!R]')
 
         smis = ['CC1CCC1', 'CCC1CCCCC1']
         ms = [Chem.MolFromSmiles(x) for x in smis]
@@ -145,10 +145,15 @@ class TestCase(unittest.TestCase):
         self.assertEqual(mcs.numAtoms, 2)
         self.assertEqual(mcs.smartsString, '[#6]-&!@[#6]')
 
+        mcs = rdFMCS.FindMCS(ms, ringMatchesRingOnly=True, completeRingsOnly=True)
+        self.assertEqual(mcs.numBonds, 1)
+        self.assertEqual(mcs.numAtoms, 2)
+        self.assertEqual(mcs.smartsString, '[#6&!R]-&!@[#6&R]')
+
         mcs = rdFMCS.FindMCS(ms, ringMatchesRingOnly=True)
         self.assertEqual(mcs.numBonds, 4)
         self.assertEqual(mcs.numAtoms, 5)
-        self.assertEqual(mcs.smartsString, '[#6]-&!@[#6](-&@[#6]-&@[#6])-&@[#6]')
+        self.assertEqual(mcs.smartsString, '[#6&!R]-&!@[#6&R](-&@[#6&R]-&@[#6&R])-&@[#6&R]')
 
     def test5AnyMatch(self):
         smis = ('c1ccccc1C', 'c1ccccc1O', 'c1ccccc1Cl')

--- a/Code/GraphMol/FMCS/testFMCS_Unit.cpp
+++ b/Code/GraphMol/FMCS/testFMCS_Unit.cpp
@@ -1374,6 +1374,39 @@ void testGithub2662() {
   BOOST_LOG(rdInfoLog) << "\tdone" << std::endl;
 }
 
+void testGithub2714() {
+  BOOST_LOG(rdInfoLog) << "-------------------------------------" << std::endl;
+  BOOST_LOG(rdInfoLog) << "Testing Github #2714"
+                       << std::endl;
+
+  {
+    std::vector<ROMOL_SPTR> mols;
+    const char* smi[] = {"CC1CCC1", "CCC1CC1"};
+
+    for (auto& i : smi) {
+      auto m = SmilesToMol(getSmilesOnly(i));
+      TEST_ASSERT(m);
+
+      mols.push_back(ROMOL_SPTR(m));
+    }
+    MCSParameters p;
+    p.BondCompareParameters.CompleteRingsOnly = true;
+    p.BondCompareParameters.RingMatchesRingOnly = true;
+    p.AtomCompareParameters.RingMatchesRingOnly = true;
+    MCSResult res = findMCS(mols, &p);
+    std::cerr << "MCS: " << res.SmartsString << " " << res.NumAtoms
+              << " atoms, " << res.NumBonds << " bonds\n"
+              << std::endl;
+    TEST_ASSERT(res.NumAtoms == 2);
+    TEST_ASSERT(res.NumBonds == 1);
+    TEST_ASSERT(res.SmartsString == "[#6&!R]-&!@[#6&R]");
+  }
+
+  BOOST_LOG(rdInfoLog) << "============================================"
+                       << std::endl;
+  BOOST_LOG(rdInfoLog) << "\tdone" << std::endl;
+}
+
 //====================================================================================================
 //====================================================================================================
 
@@ -1441,6 +1474,7 @@ int main(int argc, const char* argv[]) {
   testGithub2420();
   testGithub2663();
   testGithub2662();
+  testGithub2714();
 
   unsigned long long t1 = nanoClock();
   double sec = double(t1 - T0) / 1000000.;


### PR DESCRIPTION
#2714 can be fixed by writing a more specific SMARTS string, containing ring membership specifiers, with negation if appropriate.
This PR implements this change as well as updating unit tests and adding relevant tests in both the C++ and Python layers.