### PR TITLE
Add threaded runner for the filter catalog

### DIFF
--- a/Code/GraphMol/FilterCatalog/CMakeLists.txt
+++ b/Code/GraphMol/FilterCatalog/CMakeLists.txt
@@ -28,6 +28,7 @@ rdkit_library(FilterCatalog
               Filters.cpp
               FilterCatalog.cpp
               FilterCatalogEntry.cpp
+	      FilterCatalogRunner.cpp
               FilterMatchers.cpp
               FunctionalGroupHierarchy.cpp
               LINK_LIBRARIES Subgraphs SubstructMatch SmilesParse

--- a/Code/GraphMol/FilterCatalog/FilterCatalog.h
+++ b/Code/GraphMol/FilterCatalog/FilterCatalog.h
@@ -114,17 +114,9 @@ class RDKIT_FILTERCATALOG_EXPORT FilterCatalog : public FCatalog {
   // syntactic sugar for getMatch(es) return values.
   typedef boost::shared_ptr<FilterCatalogEntry> SENTRY;
 
-#if BOOST_VERSION / 100000 >= 1 && (BOOST_VERSION / 100 % 1000) > 44
-#define BOOST_PYTHON_SUPPORT_SHARED_CONST
-#endif
-
-#ifdef BOOST_PYTHON_SUPPORT_SHARED_CONST
   // If boost::python can support shared_ptr of const objects
   //  we can enable support for this feature
   typedef boost::shared_ptr<const entryType_t> CONST_SENTRY;
-#else
-  typedef boost::shared_ptr<entryType_t> CONST_SENTRY;
-#endif
 
   FilterCatalog() : FCatalog(), d_entries() {}
 
@@ -250,13 +242,13 @@ RDKIT_FILTERCATALOG_EXPORT bool FilterCatalogCanSerialize();
 //! Run a filter catalog on a set of smiles strings
 /*
   \param smiles vector of smiles strings to analyze
-  \param nthreads specify the number of threads to use, -1 is use all processors
-                         [default -1]
+  \param nthreads specify the number of threads to use or specify 0 to use all processors
+                         [default 1]
   \returns a vector of shared_ptr::FilterMatchEntries, null entries matched
      no filters
 */
 RDKIT_FILTERCATALOG_EXPORT
-std::vector<std::vector<FilterCatalog::CONST_SENTRY>> RunFilterCatalog(
+std::vector<std::vector<boost::shared_ptr<const FilterCatalogEntry>>> RunFilterCatalog(
               const FilterCatalog &filterCatalog,
 	      const std::vector<std::string> &smiles,
 	      int numThreads=-1);

--- a/Code/GraphMol/FilterCatalog/FilterCatalog.h
+++ b/Code/GraphMol/FilterCatalog/FilterCatalog.h
@@ -244,8 +244,11 @@ RDKIT_FILTERCATALOG_EXPORT bool FilterCatalogCanSerialize();
   \param smiles vector of smiles strings to analyze
   \param nthreads specify the number of threads to use or specify 0 to use all processors
                          [default 1]
-  \returns a vector of shared_ptr::FilterMatchEntries, null entries matched
-     no filters
+  \returns a vector of vectors.  For each input smiles string, returns
+                   a vector of shared_ptr::FilterMatchEntry objects.
+                   If a molecule matches no filters, the vector will be empty.
+                   If a smiles can't be parsed, a 'Bad smiles' catalog entry is returned.
+
 */
 RDKIT_FILTERCATALOG_EXPORT
 std::vector<std::vector<boost::shared_ptr<const FilterCatalogEntry>>> RunFilterCatalog(

--- a/Code/GraphMol/FilterCatalog/FilterCatalog.h
+++ b/Code/GraphMol/FilterCatalog/FilterCatalog.h
@@ -246,6 +246,20 @@ class RDKIT_FILTERCATALOG_EXPORT FilterCatalog : public FCatalog {
 };
 
 RDKIT_FILTERCATALOG_EXPORT bool FilterCatalogCanSerialize();
+
+//! Run a filter catalog on a set of smiles strings
+/*
+  \param smiles vector of smiles strings to analyze
+  \param nthreads specify the number of threads to use, -1 is use all processors
+                         [default -1]
+  \returns a vector of shared_ptr::FilterMatchEntries, null entries matched
+     no filters
+*/
+RDKIT_FILTERCATALOG_EXPORT
+std::vector<std::vector<FilterCatalog::CONST_SENTRY>> RunFilterCatalog(
+              const FilterCatalog &filterCatalog,
+	      const std::vector<std::string> &smiles,
+	      int numThreads=-1);
 }  // namespace RDKit
 
 #endif

--- a/Code/GraphMol/FilterCatalog/FilterCatalog.h
+++ b/Code/GraphMol/FilterCatalog/FilterCatalog.h
@@ -247,14 +247,14 @@ RDKIT_FILTERCATALOG_EXPORT bool FilterCatalogCanSerialize();
   \returns a vector of vectors.  For each input smiles string, returns
                    a vector of shared_ptr::FilterMatchEntry objects.
                    If a molecule matches no filters, the vector will be empty.
-                   If a smiles can't be parsed, a 'Bad smiles' catalog entry is returned.
+                   If a smiles can't be parsed, a 'no valid RDKit molecule' catalog entry is returned.
 
 */
 RDKIT_FILTERCATALOG_EXPORT
 std::vector<std::vector<boost::shared_ptr<const FilterCatalogEntry>>> RunFilterCatalog(
               const FilterCatalog &filterCatalog,
 	      const std::vector<std::string> &smiles,
-	      int numThreads=-1);
+	      int numThreads=1);
 }  // namespace RDKit
 
 #endif

--- a/Code/GraphMol/FilterCatalog/FilterCatalogRunner.cpp
+++ b/Code/GraphMol/FilterCatalog/FilterCatalogRunner.cpp
@@ -1,0 +1,98 @@
+//  Copyright (c) 2019 Brian P Kelley
+//  All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+//       copyright notice, this list of conditions and the following
+//       disclaimer in the documentation and/or other materials provided
+//       with the distribution.
+//     * Neither the name of Novartis Institutes for BioMedical Research Inc.
+//       nor the names of its contributors may be used to endorse or promote
+//       products derived from this software without specific prior written
+//       permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+#include "FilterCatalog.h"
+#include "Filters.h"
+#include "FilterMatchers.h"
+#include <GraphMol/SmilesParse/SmilesParse.h>
+
+#ifdef RDK_THREADSAFE_SSS
+#include <RDGeneral/RDThreads.h>
+#include <thread>
+#include <future>
+#endif
+
+namespace RDKit {
+namespace {
+void CatalogSearcher(const FilterCatalog &fc,
+		     const std::vector<std::string> &smiles,
+		     std::vector<std::vector<FilterCatalog::CONST_SENTRY>> &results,
+		     int start,
+		     int numThreads) {
+  for(unsigned int idx = start;
+      idx < smiles.size();
+      idx += numThreads) {
+    std::unique_ptr<ROMol> mol(SmilesToMol(smiles[idx]));
+    if(mol.get()) {
+      results[idx] = fc.getMatches(*mol);
+    }
+  } 
+}
+}
+  
+std::vector<std::vector<FilterCatalog::CONST_SENTRY>> RunFilterCatalog(
+              const FilterCatalog &fc,
+	      const std::vector<std::string> &smiles,
+	      int numThreads) {
+  // preallocate results, hopefully this won't grow in the thread...
+  std::vector<std::vector<FilterCatalog::CONST_SENTRY>> results(smiles.size());
+
+#ifdef RDK_THREADSAFE_SSS  
+  if (numThreads == -1)
+    numThreads = (int)getNumThreadsToUse(numThreads);
+  else
+    numThreads = std::min(numThreads, (int)getNumThreadsToUse(numThreads));
+
+  std::vector<std::future<void>> thread_group;  
+  for (int thread_group_idx = 0; thread_group_idx < numThreads;
+       ++thread_group_idx) {
+    // need to use boost::ref otherwise things are passed by value
+    thread_group.emplace_back(
+		   std::async(std::launch::async, CatalogSearcher,
+			      std::ref(fc),
+			      std::ref(smiles),
+			      std::ref(results),
+			      thread_group_idx,
+			      numThreads));
+  }
+  for (auto &fut : thread_group) {
+    fut.get();
+  }
+
+#else
+  int start = 0;
+  numThreads = 1;
+  CatalogSearcher(fc, smiles, results, start, numThreads);
+#endif
+  return results;
+}
+  
+}

--- a/Code/GraphMol/FilterCatalog/FilterCatalogRunner.cpp
+++ b/Code/GraphMol/FilterCatalog/FilterCatalogRunner.cpp
@@ -42,6 +42,12 @@
 
 namespace RDKit {
 namespace {
+boost::shared_ptr<FilterCatalogEntry>  & makeBadSmilesEntry() {
+  static boost::shared_ptr<FilterCatalogEntry> bad_smiles(
+       new FilterCatalogEntry("Bad smiles",
+			  boost::shared_ptr<FilterMatcherBase>()));
+  return bad_smiles;
+}
 void CatalogSearcher(const FilterCatalog &fc,
 		     const std::vector<std::string> &smiles,
 		     std::vector<std::vector<FilterCatalog::CONST_SENTRY>> &results,
@@ -53,6 +59,8 @@ void CatalogSearcher(const FilterCatalog &fc,
     std::unique_ptr<ROMol> mol(SmilesToMol(smiles[idx]));
     if(mol.get()) {
       results[idx] = fc.getMatches(*mol);
+    } else {
+      results[idx].push_back( makeBadSmilesEntry() );
     }
   } 
 }
@@ -72,7 +80,7 @@ std::vector<std::vector<boost::shared_ptr<const FilterCatalogEntry>>> RunFilterC
     numThreads = std::min(numThreads, (int)getNumThreadsToUse(numThreads));
 
   std::vector<std::future<void>> thread_group;  
-  for (int thread_group_idx = 0; thread_group_idx < numThreads;
+  for (int thread_group_idx = 0; thread_group_idx < numThreads+1;
        ++thread_group_idx) {
     // need to use boost::ref otherwise things are passed by value
     thread_group.emplace_back(

--- a/Code/GraphMol/FilterCatalog/FilterCatalogRunner.cpp
+++ b/Code/GraphMol/FilterCatalog/FilterCatalogRunner.cpp
@@ -1,32 +1,10 @@
 //  Copyright (c) 2019 Brian P Kelley
 //  All rights reserved.
 //
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are
-// met:
-//
-//     * Redistributions of source code must retain the above copyright
-//       notice, this list of conditions and the following disclaimer.
-//     * Redistributions in binary form must reproduce the above
-//       copyright notice, this list of conditions and the following
-//       disclaimer in the documentation and/or other materials provided
-//       with the distribution.
-//     * Neither the name of Novartis Institutes for BioMedical Research Inc.
-//       nor the names of its contributors may be used to endorse or promote
-//       products derived from this software without specific prior written
-//       permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
 //
 
 #include "FilterCatalog.h"
@@ -70,7 +48,8 @@ std::vector<std::vector<boost::shared_ptr<const FilterCatalogEntry>>> RunFilterC
               const FilterCatalog &fc,
 	      const std::vector<std::string> &smiles,
 	      int numThreads) {
-  // preallocate results, hopefully this won't grow in the thread...
+  // preallocate results so the threads don't move the vector around in memory
+  //  There is one result per input smiles
   std::vector<std::vector<FilterCatalog::CONST_SENTRY>> results(smiles.size());
 
 #ifdef RDK_THREADSAFE_SSS  
@@ -82,7 +61,7 @@ std::vector<std::vector<boost::shared_ptr<const FilterCatalogEntry>>> RunFilterC
   std::vector<std::future<void>> thread_group;  
   for (int thread_group_idx = 0; thread_group_idx < numThreads+1;
        ++thread_group_idx) {
-    // need to use boost::ref otherwise things are passed by value
+    // need to use std::ref otherwise things are passed by value
     thread_group.emplace_back(
 		   std::async(std::launch::async, CatalogSearcher,
 			      std::ref(fc),

--- a/Code/GraphMol/FilterCatalog/FilterCatalogRunner.cpp
+++ b/Code/GraphMol/FilterCatalog/FilterCatalogRunner.cpp
@@ -58,7 +58,7 @@ void CatalogSearcher(const FilterCatalog &fc,
 }
 }
   
-std::vector<std::vector<FilterCatalog::CONST_SENTRY>> RunFilterCatalog(
+std::vector<std::vector<boost::shared_ptr<const FilterCatalogEntry>>> RunFilterCatalog(
               const FilterCatalog &fc,
 	      const std::vector<std::string> &smiles,
 	      int numThreads) {

--- a/Code/GraphMol/FilterCatalog/FilterCatalogRunner.cpp
+++ b/Code/GraphMol/FilterCatalog/FilterCatalogRunner.cpp
@@ -22,7 +22,7 @@ namespace RDKit {
 namespace {
 boost::shared_ptr<FilterCatalogEntry>  & makeBadSmilesEntry() {
   static boost::shared_ptr<FilterCatalogEntry> bad_smiles(
-       new FilterCatalogEntry("Bad smiles",
+       new FilterCatalogEntry("no valid RDKit molecule",
 			  boost::shared_ptr<FilterMatcherBase>()));
   return bad_smiles;
 }

--- a/Code/GraphMol/FilterCatalog/Wrap/FilterCatalog.cpp
+++ b/Code/GraphMol/FilterCatalog/Wrap/FilterCatalog.cpp
@@ -454,12 +454,27 @@ struct filtercat_wrapper {
         .def(python::vector_indexing_suite<
              std::vector<boost::shared_ptr<const FilterCatalogEntry> >,
              true>());
+    
+    python::class_<
+      std::vector<
+	std::vector<boost::shared_ptr<const FilterCatalogEntry>>>>(
+			   "FilterCatalogListOfEntryList")
+      .def(python::vector_indexing_suite<
+	   std::vector<std::vector<boost::shared_ptr<const FilterCatalogEntry> > > >());
 
 #else
     python::class_<std::vector<boost::shared_ptr<FilterCatalogEntry> > >(
         "FilterCatalogEntryList")
         .def(python::vector_indexing_suite<
              std::vector<boost::shared_ptr<FilterCatalogEntry> >, true>());
+    python::class_<
+      std::vector<
+	std::vector<boost::shared_ptr<FilterCatalogEntry>>>>(
+			   "FilterCatalogListOfEntryList")
+      .def(python::vector_indexing_suite<
+	   std::vector<std::vector<boost::shared_ptr<FilterCatalogEntry> > > >());
+
+
 #endif
 
     {
@@ -518,6 +533,12 @@ struct filtercat_wrapper {
     python::def("FilterCatalogCanSerialize", FilterCatalogCanSerialize,
                 "Returns True if the FilterCatalog is serializable "
                 "(requires boost serialization");
+    
+    python::def("RunFilterCatalog", RunFilterCatalog,
+		(python::arg("filterCatalog"),
+		 python::arg("smiles"),
+		 python::arg("numThreads") = -1),
+                "Run the filter catalog on the input list of smiles strings");
 
     std::string nested_name = python::extract<std::string>(
         python::scope().attr("__name__") + ".FilterMatchOps");
@@ -537,6 +558,8 @@ struct filtercat_wrapper {
     python::class_<FilterMatchOps::Not, FilterMatchOps::Not *,
                    python::bases<FilterMatcherBase> >(
         "Not", python::init<FilterMatcherBase &>());
+
+    
   };
 };
 

--- a/Code/GraphMol/FilterCatalog/Wrap/FilterCatalog.cpp
+++ b/Code/GraphMol/FilterCatalog/Wrap/FilterCatalog.cpp
@@ -525,7 +525,10 @@ struct filtercat_wrapper {
 		(python::arg("filterCatalog"),
 		 python::arg("smiles"),
 		 python::arg("numThreads") = 1),
-                "Run the filter catalog on the input list of smiles strings.\nUse numThreads=0 to use all available processors.");
+                "Run the filter catalog on the input list of smiles strings.\nUse numThreads=0 to use all available processors. "
+		"Returns a vector of vectors.  For each input smiles, a vector of FilterCatalogEntry objects are "
+		"returned for each matched filter.  If a molecule matches no filter, the vector will be empty. "
+		"If a smiles string can't be parsed, a 'Bad smiles' entry is returned.");
 
     std::string nested_name = python::extract<std::string>(
         python::scope().attr("__name__") + ".FilterMatchOps");

--- a/Code/GraphMol/FilterCatalog/Wrap/FilterCatalog.cpp
+++ b/Code/GraphMol/FilterCatalog/Wrap/FilterCatalog.cpp
@@ -404,8 +404,10 @@ struct filtercat_wrapper {
     python::class_<std::vector<RDKit::ROMol *> >("MolList").def(
         python::vector_indexing_suite<std::vector<ROMol *>, true>());
 
-    python::class_<FilterCatalogEntry, FilterCatalogEntry *,
-                   const FilterCatalogEntry *>(
+    python::class_<FilterCatalogEntry,
+		   FilterCatalogEntry *,
+                   const FilterCatalogEntry *,
+		   boost::shared_ptr<const FilterCatalogEntry>>(
         "FilterCatalogEntry", FilterCatalogEntryDoc, python::init<>())
         .def(python::init<const std::string &, FilterMatcherBase &>())
         .def("IsValid", &FilterCatalogEntry::isValid)
@@ -434,7 +436,8 @@ struct filtercat_wrapper {
         .def("ClearProp", (void (FilterCatalogEntry::*)(const std::string &)) &
                               FilterCatalogEntry::clearProp);
 
-    python::register_ptr_to_python<boost::shared_ptr<FilterCatalogEntry> >();
+    python::register_ptr_to_python<boost::shared_ptr<FilterCatalogEntry> >();    
+    python::register_ptr_to_python<boost::shared_ptr<const FilterCatalogEntry> >();
     python::def(
         "GetFunctionalGroupHierarchy", GetFunctionalGroupHierarchy,
         "Returns the functional group hierarchy filter catalog",
@@ -446,36 +449,20 @@ struct filtercat_wrapper {
         "Returns the flattened functional group hierarchy as a dictionary "
         " of name:ROMOL_SPTR substructure items");
 
-#ifdef BOOST_PYTHON_SUPPORT_SHARED_CONST
     python::register_ptr_to_python<
         boost::shared_ptr<const FilterCatalogEntry> >();
-    python::class_<std::vector<boost::shared_ptr<const FilterCatalogEntry> > >(
+    python::class_<std::vector<boost::shared_ptr<FilterCatalogEntry const> > >(
         "FilterCatalogEntryList")
         .def(python::vector_indexing_suite<
-             std::vector<boost::shared_ptr<const FilterCatalogEntry> >,
+             std::vector<boost::shared_ptr<FilterCatalogEntry const> >,
              true>());
     
     python::class_<
       std::vector<
-	std::vector<boost::shared_ptr<const FilterCatalogEntry>>>>(
+	std::vector<boost::shared_ptr<FilterCatalogEntry const>>>>(
 			   "FilterCatalogListOfEntryList")
       .def(python::vector_indexing_suite<
-	   std::vector<std::vector<boost::shared_ptr<const FilterCatalogEntry> > > >());
-
-#else
-    python::class_<std::vector<boost::shared_ptr<FilterCatalogEntry> > >(
-        "FilterCatalogEntryList")
-        .def(python::vector_indexing_suite<
-             std::vector<boost::shared_ptr<FilterCatalogEntry> >, true>());
-    python::class_<
-      std::vector<
-	std::vector<boost::shared_ptr<FilterCatalogEntry>>>>(
-			   "FilterCatalogListOfEntryList")
-      .def(python::vector_indexing_suite<
-	   std::vector<std::vector<boost::shared_ptr<FilterCatalogEntry> > > >());
-
-
-#endif
+	   std::vector<std::vector<boost::shared_ptr<FilterCatalogEntry const> > > >());
 
     {
       python::scope in_FilterCatalogParams =
@@ -537,8 +524,8 @@ struct filtercat_wrapper {
     python::def("RunFilterCatalog", RunFilterCatalog,
 		(python::arg("filterCatalog"),
 		 python::arg("smiles"),
-		 python::arg("numThreads") = -1),
-                "Run the filter catalog on the input list of smiles strings");
+		 python::arg("numThreads") = 1),
+                "Run the filter catalog on the input list of smiles strings.\nUse numThreads=0 to use all available processors.");
 
     std::string nested_name = python::extract<std::string>(
         python::scope().attr("__name__") + ".FilterMatchOps");

--- a/Code/GraphMol/FilterCatalog/Wrap/rough_test.py
+++ b/Code/GraphMol/FilterCatalog/Wrap/rough_test.py
@@ -540,7 +540,8 @@ class TestCase(unittest.TestCase):
     # Test with some bad input
     smiles = ['mydoghasfleas']
     results = FilterCatalog.RunFilterCatalog(fc, smiles)
-    self.assertEquals(len(results[0]), 0)
+    self.assertEquals(len(results[0]), 1)
+    self.assertEquals(results[0][0].GetDescription(), "Bad smiles");
 
 
 if __name__ == '__main__':

--- a/Code/GraphMol/FilterCatalog/Wrap/rough_test.py
+++ b/Code/GraphMol/FilterCatalog/Wrap/rough_test.py
@@ -514,6 +514,29 @@ class TestCase(unittest.TestCase):
       hits = [name for name, pat in items if mol.HasSubstructMatch(pat)]
       self.assertEquals(hits, res)
 
+  def testThreadedRunner(self):
+    path = os.path.join(os.environ['RDBASE'], 'Code', 'GraphMol', 'test_data', 'pains.smi')
+    with open(path) as f:
+      smiles = [f.strip() for f in f.readlines()][1:]
+
+    self.assertEquals(len(smiles), 3)
+    params = FilterCatalog.FilterCatalogParams()
+    params.AddCatalog(FilterCatalogParams.FilterCatalogs.PAINS_A)
+    params.AddCatalog(FilterCatalogParams.FilterCatalogs.PAINS_B)
+    params.AddCatalog(FilterCatalogParams.FilterCatalogs.PAINS_C)
+    fc = FilterCatalog.FilterCatalog(params)
+    
+    results = FilterCatalog.RunFilterCatalog(fc, smiles)
+    self.assertEquals(len(results), 3)
+
+    descriptions = ["hzone_phenol_A(479)",
+                    "cyano_imine_B(17)",
+                    "keto_keto_gamma(5)"]
+
+    for i, res in enumerate(results):
+      self.assertTrue(len(res) > 0)
+      self.assertEquals(res[0].GetDescription(), descriptions[i])
+
 
 if __name__ == '__main__':
   unittest.main()

--- a/Code/GraphMol/FilterCatalog/Wrap/rough_test.py
+++ b/Code/GraphMol/FilterCatalog/Wrap/rough_test.py
@@ -539,9 +539,9 @@ class TestCase(unittest.TestCase):
 
     # Test with some bad input
     smiles = ['mydoghasfleas']
-    results = FilterCatalog.RunFilterCatalog(fc, smiles)
+    results = FilterCatalog.RunFilterCatalog(fc, smiles, numThreads=3)
     self.assertEquals(len(results[0]), 1)
-    self.assertEquals(results[0][0].GetDescription(), "Bad smiles");
+    self.assertEquals(results[0][0].GetDescription(), "no valid RDKit molecule");
 
 
 if __name__ == '__main__':

--- a/Code/GraphMol/FilterCatalog/Wrap/rough_test.py
+++ b/Code/GraphMol/FilterCatalog/Wrap/rough_test.py
@@ -537,6 +537,11 @@ class TestCase(unittest.TestCase):
       self.assertTrue(len(res) > 0)
       self.assertEquals(res[0].GetDescription(), descriptions[i])
 
+    # Test with some bad input
+    smiles = ['mydoghasfleas']
+    results = FilterCatalog.RunFilterCatalog(fc, smiles)
+    self.assertEquals(len(results[0]), 0)
+
 
 if __name__ == '__main__':
   unittest.main()

--- a/Code/GraphMol/FilterCatalog/filtercatalogtest.cpp
+++ b/Code/GraphMol/FilterCatalog/filtercatalogtest.cpp
@@ -248,8 +248,9 @@ void testFilterCatalogThreadedRunner() {
       count += 1;
     }
     TEST_ASSERT(smiles.size() == 3);
-    
-    auto results = RunFilterCatalog(catalog, smiles);
+
+    int numThreads = 3;  // one per entry
+    auto results = RunFilterCatalog(catalog, smiles, numThreads);
     TEST_ASSERT(results.size() == smiles.size());
     count=0;
     for(auto &entries : results) {

--- a/Code/GraphMol/FilterCatalog/filtercatalogtest.cpp
+++ b/Code/GraphMol/FilterCatalog/filtercatalogtest.cpp
@@ -34,7 +34,7 @@
 #include <GraphMol/FileParsers/MolSupplier.h>
 #include <GraphMol/FilterCatalog/FilterCatalog.h>
 #include <GraphMol/SmilesParse/SmilesParse.h>
-
+#include <fstream>
 #include <iostream>
 #include <map>
 #include <algorithm>
@@ -144,6 +144,7 @@ void testFilterCatalog() {
       }
       // More detailed
       FilterCatalog::CONST_SENTRY entry = catalog.getFirstMatch(*mol);
+      TEST_ASSERT(entry);
       if (entry) {
         std::cerr << "Warning: molecule failed filter: reason "
                   << entry->getDescription() << std::endl;
@@ -222,11 +223,59 @@ void testFilterCatalogEntry() {
   delete newM;
 }
 
+void testFilterCatalogThreadedRunner() {
+    FilterCatalogParams params;
+    params.addCatalog(FilterCatalogParams::PAINS_A);
+    params.addCatalog(FilterCatalogParams::PAINS_B);
+    params.addCatalog(FilterCatalogParams::PAINS_C);
+
+    FilterCatalog catalog(params);
+    
+    std::string pathName = getenv("RDBASE");
+    pathName += "/Code/GraphMol/test_data/pains.smi";
+
+    std::ifstream infile(pathName);
+    std::vector<std::string> smiles;
+
+    std::string line;
+    int count=0;
+    while (std::getline(infile, line))
+    {
+      if (count) {
+	std::cerr << line << std::endl;
+	smiles.push_back(line);
+      }
+      count += 1;
+    }
+    TEST_ASSERT(smiles.size() == 3);
+    
+    auto results = RunFilterCatalog(catalog, smiles);
+    TEST_ASSERT(results.size() == smiles.size());
+    count=0;
+    for(auto &entries : results) {
+      TEST_ASSERT(entries.size() > 0);
+      std::cerr << count << " " << entries[0]->getDescription() << std::endl;
+      switch (count) {
+      case 0:
+	TEST_ASSERT(entries[0]->getDescription() == "hzone_phenol_A(479)");
+	break;
+      case 1:
+	TEST_ASSERT(entries[0]->getDescription() == "cyano_imine_B(17)");
+	break;
+      case 2:
+	TEST_ASSERT(entries[0]->getDescription() == "keto_keto_gamma(5)");
+	break;
+      }
+      count += 1;
+    }
+}
+
 int main() {
   RDLog::InitLogs();
   // boost::logging::enable_logs("rdApp.debug");
 
   testFilterCatalog();
   testFilterCatalogEntry();
+  testFilterCatalogThreadedRunner();
   return 0;
 }

--- a/Code/JavaWrappers/FilterCatalog.i
+++ b/Code/JavaWrappers/FilterCatalog.i
@@ -32,7 +32,8 @@
 //%import "ROMol.i"
 %include "std_string.i"
 %include "std_vector.i"
-
+%include <boost_shared_ptr.i>
+%shared_ptr(RDKit::FilterCatalogEntry)
 
 %{
 #include <../RDGeneral/Dict.h>
@@ -42,13 +43,15 @@
 #include <GraphMol/FilterCatalog/FilterCatalogEntry.h>
 #include <GraphMol/FilterCatalog/FilterCatalog.h>
 
-  // bug fix for swig, it removes these from their namespaces
-  typedef RDCatalog::Catalog<RDKit::FilterCatalogEntry, RDKit::FilterCatalogParams>::paramType_t paramType_t;
-  typedef RDCatalog::Catalog<RDKit::FilterCatalogEntry, RDKit::FilterCatalogParams>::entryType_t entryType_t;
-  typedef std::vector<std::string> STR_VECT;
+// bug fix for swig, it removes these from their namespaces
+typedef RDCatalog::Catalog<RDKit::FilterCatalogEntry, RDKit::FilterCatalogParams>::paramType_t paramType_t;
+
+typedef std::vector<std::string> STR_VECT;
 %}
 
 %template(FilterCatalogEntry_Vect) std::vector< boost::shared_ptr<RDKit::FilterCatalogEntry> >;
+%template(FilterCatalogEntry_VectVect) std::vector<std::vector< boost::shared_ptr<const RDKit::FilterCatalogEntry> > >;
+
 %template(FilterCatalogEntryVect) std::vector< const RDKit::FilterCatalogEntry* >;
 %template(UChar_Vect) std::vector<unsigned char>;
 %template(FilterMatch_Vect) std::vector<RDKit::FilterMatch>;

--- a/Code/JavaWrappers/gmwrapper/src-test/org/RDKit/FilterCatalogTests.java
+++ b/Code/JavaWrappers/gmwrapper/src-test/org/RDKit/FilterCatalogTests.java
@@ -147,6 +147,18 @@ public class FilterCatalogTests extends GraphMolTest {
             
         }
 
+        @Test
+	public void testFilterCatalogRunner() {
+	    FilterCatalog catalog = new FilterCatalog(
+                FilterCatalogParams.FilterCatalogs.PAINS_A);
+            assertEquals(16, catalog.getNumEntries());
+	    Str_Vect smiles = new Str_Vect(1);
+	    smiles.set(0, "O=C(Cn1cnc2c1c(=O)n(C)c(=O)n2C)N/N=C/c1c(O)ccc2c1cccc2");
+
+	    FilterCatalogEntry_VectVect result = RDKFuncs.RunFilterCatalog(catalog, smiles);
+
+	}
+
 	public static void main(String args[]) {
 		org.junit.runner.JUnitCore.main("org.RDKit.FilterCatalogTests");
 	}


### PR DESCRIPTION
This adds a simple threaded runner to the filter catalog.

```
smiles = [...]
results = FilterCatalog.RunFilterCatalog(fc, smiles, numThreads=-1)
assert len(results) == len(smiles)
for result in results:
  if len(result): # filters have been hit
     filters = [x.GetDescription() for x in result]
```

The one thing I don't like is that we don't have a "bad smiles" filter, so smiles strings that can't be parsed return an empty filter list.