### PR TITLE
fixes #2727

### DIFF
--- a/Code/JavaWrappers/gmwrapper/src-test/org/RDKit/DistanceGeometryTests.java
+++ b/Code/JavaWrappers/gmwrapper/src-test/org/RDKit/DistanceGeometryTests.java
@@ -493,14 +493,12 @@ public class DistanceGeometryTests extends GraphMolTest {
     double ssd;
 		ssd = test.alignMol(ref);
 		assertTrue(ssd < 0.1);
-		System.out.println(" ssd1: "+ssd);
     // make sure we didn't change the global params
 	EmbedParameters eps2 = RDKFuncs.getETKDG();
 		assertEquals(eps2.getRandomSeed(),-1);
 		cid = DistanceGeom.EmbedMolecule(test,eps2);
 		assertTrue(cid>-1);
 		ssd = test.alignMol(ref);
-		System.out.println(" ssd2: "+ssd+" seed: "+eps2.getRandomSeed());
 		assertTrue(ssd > 0.1);
 
 	}

--- a/Code/JavaWrappers/gmwrapper/src-test/org/RDKit/DistanceGeometryTests.java
+++ b/Code/JavaWrappers/gmwrapper/src-test/org/RDKit/DistanceGeometryTests.java
@@ -481,19 +481,26 @@ public class DistanceGeometryTests extends GraphMolTest {
 		ROMol ref=RWMol.MolFromMolFile(molFile.getPath(), true, false);;
 		ROMol test = RWMol.MolFromSmiles("OCCC").addHs(false,false);
     assertTrue(test.getNumAtoms()==ref.getNumAtoms());
-    EmbedParameters eps = new EmbedParameters(RDKFuncs.getETKDG());
+
+	// basic embedding works:
+	int cid = DistanceGeom.EmbedMolecule(test);
+    assertTrue(cid>-1);
+
+	EmbedParameters eps = new EmbedParameters(RDKFuncs.getETKDG());
     eps.setRandomSeed(42);
-		int cid = DistanceGeom.EmbedMolecule(test,eps);
+		cid = DistanceGeom.EmbedMolecule(test,eps);
 		assertTrue(cid>-1);
     double ssd;
 		ssd = test.alignMol(ref);
 		assertTrue(ssd < 0.1);
-
+		System.out.println(" ssd1: "+ssd);
     // make sure we didn't change the global params
-    EmbedParameters eps2 = RDKFuncs.getETKDG();
+	EmbedParameters eps2 = RDKFuncs.getETKDG();
+		assertEquals(eps2.getRandomSeed(),-1);
 		cid = DistanceGeom.EmbedMolecule(test,eps2);
 		assertTrue(cid>-1);
 		ssd = test.alignMol(ref);
+		System.out.println(" ssd2: "+ssd+" seed: "+eps2.getRandomSeed());
 		assertTrue(ssd > 0.1);
 
 	}

--- a/Code/JavaWrappers/gmwrapper/src-test/org/RDKit/DistanceGeometryTests.java
+++ b/Code/JavaWrappers/gmwrapper/src-test/org/RDKit/DistanceGeometryTests.java
@@ -483,6 +483,10 @@ public class DistanceGeometryTests extends GraphMolTest {
     assertTrue(test.getNumAtoms()==ref.getNumAtoms());
 
 	// basic embedding works:
+        // The default random seed is 42, but we don't want to start at the beginning
+        //  of the random source stream since this is also our explicit seed, so
+        //  ensure that we don't, otherwise we can't tell if we are really
+        //  using the seed specified in the parameter object.
 	int cid = DistanceGeom.EmbedMolecule(test);
     assertTrue(cid>-1);
 


### PR DESCRIPTION
The default seed for the RNG used by the distance geometry code is 42u, same as the explicit seed in this test. The order in which tests are run is apparently not deterministic.
When `test9ETKDGParams2()` runs before any of the other tests that don't seed the RNG it ends up using the RNG which has just been seeded with 42u, so it generates the same results as the tests where the seed is explicitly set to 42.

Fix this by calling the conformation generator once without a seed before making the call that we check the results of.

way more words to explain than fix. :-)