### PR TITLE
Add consideration of ring fusion to the MCS algorithm

### DIFF
--- a/Code/GraphMol/FMCS/FMCS.cpp
+++ b/Code/GraphMol/FMCS/FMCS.cpp
@@ -107,9 +107,6 @@ MCSResult findMCS(const std::vector<ROMOL_SPTR>& mols, bool maximizeBonds,
                   bool completeRingsOnly, bool matchChiralTag,
                   AtomComparator atomComp, BondComparator bondComp,
                   RingComparator ringComp) {
-  // AtomComparator atomComp=AtomCompareElements;
-  // BondComparator bondComp=BondCompareOrder;
-  // RingComparator bondComp=IgnoreRingFusion;
   auto* ps = new MCSParameters();
   ps->MaximizeBonds = maximizeBonds;
   ps->Threshold = threshold;

--- a/Code/GraphMol/FMCS/FMCS.cpp
+++ b/Code/GraphMol/FMCS/FMCS.cpp
@@ -47,6 +47,10 @@ void parseMCSParametersJSON(const char* json, MCSParameters* params) {
         "RingMatchesRingOnly", p.BondCompareParameters.RingMatchesRingOnly);
     p.BondCompareParameters.CompleteRingsOnly = pt.get<bool>(
         "CompleteRingsOnly", p.BondCompareParameters.CompleteRingsOnly);
+    p.BondCompareParameters.MatchFusedRings = pt.get<bool>(
+        "MatchFusedRings", p.BondCompareParameters.MatchFusedRings);
+    p.BondCompareParameters.MatchFusedRingsStrict = pt.get<bool>(
+        "MatchFusedRingsStrict", p.BondCompareParameters.MatchFusedRingsStrict);
     p.BondCompareParameters.MatchStereo =
         pt.get<bool>("MatchStereo", p.BondCompareParameters.MatchStereo);
 
@@ -58,7 +62,7 @@ void parseMCSParametersJSON(const char* json, MCSParameters* params) {
     else if (0 == strcmp("Isotopes", s.c_str()))
       p.AtomTyper = MCSAtomCompareIsotopes;
     else if (0 == strcmp("AnyHeavy", s.c_str()))
-	  p.AtomTyper = MCSAtomCompareAnyHeavyAtom;
+      p.AtomTyper = MCSAtomCompareAnyHeavyAtom;
 
     s = pt.get<std::string>("BondCompare", "def");
     if (0 == strcmp("Any", s.c_str()))
@@ -88,12 +92,24 @@ MCSResult findMCS_P(const std::vector<ROMOL_SPTR>& mols,
 }
 
 MCSResult findMCS(const std::vector<ROMOL_SPTR>& mols, bool maximizeBonds,
+        double threshold, unsigned timeout, bool verbose,
+        bool matchValences, bool ringMatchesRingOnly,
+        bool completeRingsOnly, bool matchChiralTag,
+        AtomComparator atomComp, BondComparator bondComp) {
+  return findMCS(mols, maximizeBonds, threshold, timeout, verbose,
+          matchValences, ringMatchesRingOnly, completeRingsOnly,
+          matchChiralTag, atomComp, bondComp, IgnoreRingFusion);
+}
+
+MCSResult findMCS(const std::vector<ROMOL_SPTR>& mols, bool maximizeBonds,
                   double threshold, unsigned timeout, bool verbose,
                   bool matchValences, bool ringMatchesRingOnly,
                   bool completeRingsOnly, bool matchChiralTag,
-                  AtomComparator atomComp, BondComparator bondComp) {
+                  AtomComparator atomComp, BondComparator bondComp,
+                  RingComparator ringComp) {
   // AtomComparator atomComp=AtomCompareElements;
   // BondComparator bondComp=BondCompareOrder;
+  // RingComparator bondComp=IgnoreRingFusion;
   auto* ps = new MCSParameters();
   ps->MaximizeBonds = maximizeBonds;
   ps->Threshold = threshold;
@@ -111,9 +127,9 @@ MCSResult findMCS(const std::vector<ROMOL_SPTR>& mols, bool maximizeBonds,
     case AtomCompareIsotopes:
       ps->AtomTyper = MCSAtomCompareIsotopes;
       break;
-	case AtomCompareAnyHeavyAtom:
-	  ps->AtomTyper = MCSAtomCompareAnyHeavyAtom;
-	  break;
+    case AtomCompareAnyHeavyAtom:
+      ps->AtomTyper = MCSAtomCompareAnyHeavyAtom;
+      break;
   }
   ps->AtomCompareParameters.RingMatchesRingOnly = ringMatchesRingOnly;
   switch (bondComp) {
@@ -129,6 +145,8 @@ MCSResult findMCS(const std::vector<ROMOL_SPTR>& mols, bool maximizeBonds,
   }
   ps->BondCompareParameters.RingMatchesRingOnly = ringMatchesRingOnly;
   ps->BondCompareParameters.CompleteRingsOnly = completeRingsOnly;
+  ps->BondCompareParameters.MatchFusedRings = (ringComp != IgnoreRingFusion);
+  ps->BondCompareParameters.MatchFusedRingsStrict = (ringComp == StrictRingFusion);
   MCSResult res = findMCS(mols, ps);
   delete ps;
   return res;
@@ -287,7 +305,7 @@ static bool checkBondStereo(const MCSBondCompareParameters& p,
   return true;
 }
 
-static bool checkRingMatch(const MCSBondCompareParameters& p, const ROMol& mol1,
+static bool checkRingMatch(const MCSBondCompareParameters&, const ROMol&,
                            unsigned int bond1, const ROMol& mol2,
                            unsigned int bond2, void* v_ringMatchMatrixSet) {
   if (!v_ringMatchMatrixSet) throw "v_ringMatchMatrixSet is NULL";  // never
@@ -301,10 +319,8 @@ static bool checkRingMatch(const MCSBondCompareParameters& p, const ROMol& mol1,
   bool bond1inRing = !ringsIdx1.empty();
   bool bond2inRing = !ringsIdx2.empty();
 
-  if (bond1inRing != bond2inRing) return false;
-
-  // both bonds are either in rings or not:
-  return true;
+  // bond are both either in a ring or not
+  return (bond1inRing == bond2inRing);
 }
 
 bool MCSBondCompareAny(const MCSBondCompareParameters& p, const ROMol& mol1,
@@ -351,6 +367,140 @@ bool MCSBondCompareOrderExact(const MCSBondCompareParameters& p,
     return true;
   }
   return false;
+}
+
+//=== RING COMPARE ========================================================
+inline static bool ringFusionCheck(const short unsigned c1[],
+    const short unsigned c2[], const ROMol& mol1,
+    const FMCS::Graph& query, const ROMol& mol2,
+    const FMCS::Graph& target, const MCSParameters* p) {
+  const RingInfo *ri2 = mol2.getRingInfo();
+  const VECT_INT_VECT &br2 = ri2->bondRings();
+  std::vector<size_t> nonFusedBonds(br2.size(), 0);
+  std::vector<size_t> numMcsBondRings(br2.size(), 0);
+  RDKit::FMCS::Graph::BOND_ITER_PAIR bpIter = boost::edges(query);
+  size_t i = 0;
+  // numMcsBondRings stores the number of bonds which
+  // are part of the MCS for each ring
+  for (auto it = bpIter.first; it != bpIter.second; ++it) {
+    const Bond *b = mol2.getBondBetweenAtoms(
+      target[c2[boost::source(*it, query)]], target[c2[boost::target(*it, query)]]);
+    if (!b) continue;
+    unsigned int bi = b->getIdx();
+    if (!ri2->numBondRings(bi)) continue;
+    for (i = 0; i < br2.size(); ++i) {
+      if (std::find(br2[i].begin(), br2[i].end(), bi) != br2[i].end())
+        ++numMcsBondRings[i];
+    }
+  }
+  // nonFusedBonds stores the number of non-fused bonds
+  // (i.e., which belong to a single ring) for each ring
+  for (i = 0; i < br2.size(); ++i) {
+    for (auto bi: br2[i]) {
+      if (ri2->numBondRings(bi) == 1)
+        ++nonFusedBonds[i];
+    }
+  }
+  /* if a ring has at least one bond which is part of the MCS,
+     we need to check how many bonds are actually part of the MCS:
+     if they are greater than the number of fused bonds but lower
+     than the number of non-fused bonds, then the ring is not
+     complete and we should return true straightaway
+     We need to check that the number of bonds in a ring
+     is greater than the number of fused bonds because that
+     guarantees that this ring is actually involved in the
+     MCS and not just adjacent to another ring which is
+     indeed part of the MCS. */
+  bool missingFusedBond = false;
+  for (i = 0; i < br2.size(); ++i) {
+    if (numMcsBondRings[i]
+      && numMcsBondRings[i] > (br2[i].size() - nonFusedBonds[i])
+      && numMcsBondRings[i] < nonFusedBonds[i])
+      break;
+    if (numMcsBondRings[i] == nonFusedBonds[i]
+      && numMcsBondRings[i] < br2[i].size())
+      missingFusedBond = true;
+  }
+  if (i < br2.size())
+    return true;
+  /* If we found that the MCS is missing a fused bond, we may need to
+     check against the smaller molecule as well.
+     Consider this case: MCS between
+     2-methylbicyclo[4.3.0]nonane and 1-methylbicyclo[3.1.0]hexane
+
+                   \__
+                   /  \_                          \___
+                   \__/ \                         / \/
+                      \ /                         \ /
+                       C                           C
+                       H2                          H2
+
+     In permissive mode, we are happy for methylcyclohexane to be the MCS.
+     in strict mode, we don't want methylcyclohexane to be the MCS.
+
+                                         \__
+                                         /  \
+                                         \__/
+
+     When methylcyclohexane is checked against 2-methylbicyclo[4.3.0]nonane
+     there is no missing fused bond. This is OK for permissive mode.
+     In strict mode, we also need to check against 1-methylbicyclo[3.1.0]hexane,
+     where there is indeed a missing fused bond. */
+  bool missingFusedBond2 = false;
+  if (missingFusedBond ^ p->BondCompareParameters.MatchFusedRingsStrict) {
+    // if we are in permissive mode we allow one of the molecules to miss
+    // fused bonds, but not both. In strict mode we allow neither.
+    if (!p->BondCompareParameters.MatchFusedRingsStrict)
+      missingFusedBond = false;
+    const RingInfo *ri1 = mol1.getRingInfo();
+    const VECT_INT_VECT &br1 = ri1->bondRings();
+    std::set<unsigned int> mcsRingBondIdxSet;
+    // put all MCS bond indices which belong to one or more rings in a set
+    for (auto it = bpIter.first; it != bpIter.second; ++it) {
+      const Bond *b = mol1.getBondBetweenAtoms(
+        query[c1[boost::source(*it, query)]], query[c1[boost::target(*it, query)]]);
+      if (b && ri1->numBondRings(b->getIdx()))
+        mcsRingBondIdxSet.insert(b->getIdx());
+    }
+    for (i = 0; i < br1.size(); ++i) {
+      size_t foundBonds = 0;
+      size_t fusedBonds = 0;
+      // for each ring, check how many bonds belong to MCS (foundBonds)
+      // and how many belong to multiple rings (fused bonds).
+      for (auto bi: br1[i]) {
+        if (std::find(mcsRingBondIdxSet.begin(),
+          mcsRingBondIdxSet.end(), bi) != mcsRingBondIdxSet.end()) {
+          ++foundBonds;
+          if (ri1->numBondRings(bi) > 1)
+            ++fusedBonds;
+        }
+      }
+      // if the ring is part of the MCS, and we found more bonds than the fused ones
+      // (i.e., the ring is not simply adjacent to an MCS ring) but less than
+      // the bonds which are part of this ring, then some fused bond is missing.
+      if (foundBonds && foundBonds > fusedBonds && foundBonds < br1[i].size()) {
+        missingFusedBond2 = true;
+        break;
+      }
+    }
+  }
+  // if both missingFusedBond and missingFusedBond2 are false, return true
+  return (!missingFusedBond && !missingFusedBond2);
+}
+
+bool FinalMatchCheckFunction(const short unsigned c1[],
+                             const short unsigned c2[], const ROMol& mol1,
+                             const FMCS::Graph& query, const ROMol& mol2,
+                             const FMCS::Graph& target,
+                             const MCSParameters *p) {
+  if ((p->BondCompareParameters.MatchFusedRings
+      || p->BondCompareParameters.MatchFusedRingsStrict)
+      && !ringFusionCheck(c1, c2, mol1, query, mol2, target, p))
+    return false;
+  if (p->AtomCompareParameters.MatchChiralTag
+    && !FinalChiralityCheckFunction(c1, c2, mol1, query, mol2, target, p))
+    return false;
+  return true;
 }
 
 bool FinalChiralityCheckFunction(const short unsigned c1[],

--- a/Code/GraphMol/FMCS/FMCS.h
+++ b/Code/GraphMol/FMCS/FMCS.h
@@ -28,6 +28,8 @@ struct RDKIT_FMCS_EXPORT MCSAtomCompareParameters {
 struct RDKIT_FMCS_EXPORT MCSBondCompareParameters {
   bool RingMatchesRingOnly = false;
   bool CompleteRingsOnly = false;
+  bool MatchFusedRings = false;
+  bool MatchFusedRingsStrict = false;
   bool MatchStereo = false;
 };
 
@@ -103,7 +105,7 @@ struct RDKIT_FMCS_EXPORT MCSParameters {
       nullptr;  // return false to interrupt execution
   void* ProgressCallbackUserData = nullptr;
   MCSFinalMatchCheckFunction FinalMatchChecker =
-      nullptr;  // FinalChiralityCheckFunction() to check chirality
+      nullptr;  // FinalMatchCheckFunction() to check chirality and ring fusion
   std::string InitialSeed = "";  // user defined or empty string (default)
 };
 
@@ -137,6 +139,19 @@ typedef enum {
   BondCompareOrder,
   BondCompareOrderExact
 } BondComparator;
+typedef enum {
+  IgnoreRingFusion,
+  PermissiveRingFusion,
+  StrictRingFusion
+} RingComparator;
+RDKIT_FMCS_EXPORT MCSResult
+findMCS(const std::vector<ROMOL_SPTR>& mols, bool maximizeBonds,
+        double threshold, unsigned timeout, bool verbose,
+        bool matchValences, bool ringMatchesRingOnly,
+        bool completeRingsOnly, bool matchChiralTag,
+        AtomComparator atomComp,
+        BondComparator bondComp,
+        RingComparator ringComp);
 RDKIT_FMCS_EXPORT MCSResult
 findMCS(const std::vector<ROMOL_SPTR>& mols, bool maximizeBonds,
         double threshold = 1.0, unsigned timeout = 3600, bool verbose = false,

--- a/Code/GraphMol/FMCS/MaximumCommonSubgraph.h
+++ b/Code/GraphMol/FMCS/MaximumCommonSubgraph.h
@@ -25,11 +25,17 @@
 
 namespace RDKit {
 
-bool FinalChiralityCheckFunction(const short unsigned c1[],
-                                 const short unsigned c2[], const ROMol& mol1,
-                                 const FMCS::Graph& query, const ROMol& mol2,
-                                 const FMCS::Graph& target,
-                                 const MCSParameters* p);
+inline bool FinalChiralityCheckFunction(const short unsigned c1[],
+                                        const short unsigned c2[], const ROMol& mol1,
+                                        const FMCS::Graph& query, const ROMol& mol2,
+                                        const FMCS::Graph& target,
+                                        const MCSParameters* p);
+
+bool FinalMatchCheckFunction(const short unsigned c1[],
+                             const short unsigned c2[], const ROMol& mol1,
+                             const FMCS::Graph& query, const ROMol& mol2,
+                             const FMCS::Graph& target,
+                             const MCSParameters* p);
 
 namespace FMCS {
 class RDKIT_FMCS_EXPORT MaximumCommonSubgraph {

--- a/Code/GraphMol/FMCS/Wrap/testFMCS.py
+++ b/Code/GraphMol/FMCS/Wrap/testFMCS.py
@@ -128,6 +128,16 @@ class TestCase(unittest.TestCase):
         self.assertEqual(mcs.numAtoms, 3)
         self.assertEqual(mcs.smartsString, '[#6]-&!@[#6]-&!@[#6]')
 
+        mcs = rdFMCS.FindMCS(ms, ringCompare=rdFMCS.RingCompare.PermissiveRingFusion)
+        self.assertEqual(mcs.numBonds, 2)
+        self.assertEqual(mcs.numAtoms, 3)
+        self.assertEqual(mcs.smartsString, '[#6]-&!@[#6]-&!@[#6]')
+
+        mcs = rdFMCS.FindMCS(ms, ringCompare=rdFMCS.RingCompare.StrictRingFusion)
+        self.assertEqual(mcs.numBonds, 2)
+        self.assertEqual(mcs.numAtoms, 3)
+        self.assertEqual(mcs.smartsString, '[#6]-&!@[#6]-&!@[#6]')
+
         mcs = rdFMCS.FindMCS(ms, ringMatchesRingOnly=True)
         self.assertEqual(mcs.numBonds, 1)
         self.assertEqual(mcs.numAtoms, 2)
@@ -146,6 +156,16 @@ class TestCase(unittest.TestCase):
         self.assertEqual(mcs.smartsString, '[#6]-&!@[#6]')
 
         mcs = rdFMCS.FindMCS(ms, ringMatchesRingOnly=True, completeRingsOnly=True)
+        self.assertEqual(mcs.numBonds, 1)
+        self.assertEqual(mcs.numAtoms, 2)
+        self.assertEqual(mcs.smartsString, '[#6&!R]-&!@[#6&R]')
+
+        mcs = rdFMCS.FindMCS(ms, ringMatchesRingOnly=True, ringCompare=rdFMCS.RingCompare.PermissiveRingFusion)
+        self.assertEqual(mcs.numBonds, 1)
+        self.assertEqual(mcs.numAtoms, 2)
+        self.assertEqual(mcs.smartsString, '[#6&!R]-&!@[#6&R]')
+
+        mcs = rdFMCS.FindMCS(ms, ringMatchesRingOnly=True, ringCompare=rdFMCS.RingCompare.StrictRingFusion)
         self.assertEqual(mcs.numBonds, 1)
         self.assertEqual(mcs.numAtoms, 2)
         self.assertEqual(mcs.smartsString, '[#6&!R]-&!@[#6&R]')
@@ -199,7 +219,7 @@ class TestCase(unittest.TestCase):
 
         for m in ms:
             self.assertTrue(m.HasSubstructMatch(qm))
-        
+
     def test6MatchValences(self):
         ms = (Chem.MolFromSmiles('NC1OC1'), Chem.MolFromSmiles('C1OC1[N+](=O)[O-]'))
         mcs = rdFMCS.FindMCS(ms)
@@ -228,6 +248,16 @@ class TestCase(unittest.TestCase):
 
         ps = rdFMCS.MCSParameters()
         ps.BondCompareParameters.CompleteRingsOnly = True
+        mcs = rdFMCS.FindMCS(ms, ps)
+        self.assertEqual(mcs.numAtoms, 3)
+
+        ps = rdFMCS.MCSParameters()
+        ps.BondCompareParameters.MatchFusedRings = True
+        mcs = rdFMCS.FindMCS(ms, ps)
+        self.assertEqual(mcs.numAtoms, 3)
+
+        ps = rdFMCS.MCSParameters()
+        ps.BondCompareParameters.MatchFusedRingsStrict = True
         mcs = rdFMCS.FindMCS(ms, ps)
         self.assertEqual(mcs.numAtoms, 3)
 

--- a/Code/GraphMol/FMCS/testFMCS_Unit.cpp
+++ b/Code/GraphMol/FMCS/testFMCS_Unit.cpp
@@ -249,15 +249,39 @@ void testRing1() {
     mols.push_back(
         ROMOL_SPTR(SmilesToMol(getSmilesOnly(i))));  // with RING INFO
 
-  MCSParameters p;
-  p.BondCompareParameters.RingMatchesRingOnly = true;
-  p.BondCompareParameters.CompleteRingsOnly = true;
-  t0 = nanoClock();
-  MCSResult res = findMCS(mols, &p);
-  std::cout << "MCS: " << res.SmartsString << " " << res.NumAtoms << " atoms, "
-            << res.NumBonds << " bonds\n";
-  printTime();
-  TEST_ASSERT(res.NumAtoms == 16 && res.NumBonds == 17);
+  {
+    MCSParameters p;
+    p.BondCompareParameters.RingMatchesRingOnly = true;
+    p.BondCompareParameters.CompleteRingsOnly = true;
+    t0 = nanoClock();
+    MCSResult res = findMCS(mols, &p);
+    std::cout << "MCS: " << res.SmartsString << " " << res.NumAtoms << " atoms, "
+              << res.NumBonds << " bonds\n";
+    printTime();
+    TEST_ASSERT(res.NumAtoms == 16 && res.NumBonds == 17);
+  }
+  {
+    MCSParameters p;
+    p.BondCompareParameters.MatchFusedRings = true;
+    t0 = nanoClock();
+    MCSResult res = findMCS(mols, &p);
+    std::cout << "MCS MatchFusedRings: "
+              << res.SmartsString << " " << res.NumAtoms << " atoms, "
+              << res.NumBonds << " bonds\n";
+    printTime();
+    TEST_ASSERT(res.NumAtoms == 16 && res.NumBonds == 17);
+  }
+  {
+    MCSParameters p;
+    p.BondCompareParameters.MatchFusedRingsStrict = true;
+    t0 = nanoClock();
+    MCSResult res = findMCS(mols, &p);
+    std::cout << "MCS MatchFusedRingsStrict: "
+              << res.SmartsString << " " << res.NumAtoms << " atoms, "
+              << res.NumBonds << " bonds\n";
+    printTime();
+    TEST_ASSERT(res.NumAtoms == 12 && res.NumBonds == 12);
+  }
   BOOST_LOG(rdInfoLog) << "\tdone" << std::endl;
 }
 
@@ -506,15 +530,39 @@ void testSegFault() {
       "CN(CCOC(c1ccccc1)c1ccccc1)CCN(C)CCc1ccc(F)cc1",
   };
   for (auto& i : smi) mols.push_back(ROMOL_SPTR(SmilesToMol(getSmilesOnly(i))));
-  MCSParameters p;
-  p.BondCompareParameters.RingMatchesRingOnly = true;
-  p.BondCompareParameters.CompleteRingsOnly = true;
-  t0 = nanoClock();
-  MCSResult res = findMCS(mols, &p);
-  std::cout << "MCS: " << res.SmartsString << " " << res.NumAtoms << " atoms, "
-            << res.NumBonds << " bonds\n";
-  printTime();
-  TEST_ASSERT(res.NumAtoms == 6 && res.NumBonds == 6);
+  {
+    MCSParameters p;
+    p.BondCompareParameters.RingMatchesRingOnly = true;
+    p.BondCompareParameters.CompleteRingsOnly = true;
+    t0 = nanoClock();
+    MCSResult res = findMCS(mols, &p);
+    std::cout << "MCS: " << res.SmartsString << " " << res.NumAtoms << " atoms, "
+              << res.NumBonds << " bonds\n";
+    printTime();
+    TEST_ASSERT(res.NumAtoms == 6 && res.NumBonds == 6);
+  }
+  {
+    MCSParameters p;
+    p.BondCompareParameters.MatchFusedRings = true;
+    t0 = nanoClock();
+    MCSResult res = findMCS(mols, &p);
+    std::cout << "MCS MatchFusedRings: "
+              << res.SmartsString << " " << res.NumAtoms << " atoms, "
+              << res.NumBonds << " bonds\n";
+    printTime();
+    TEST_ASSERT(res.NumAtoms == 6 && res.NumBonds == 6);
+  }
+  {
+    MCSParameters p;
+    p.BondCompareParameters.MatchFusedRingsStrict = true;
+    t0 = nanoClock();
+    MCSResult res = findMCS(mols, &p);
+    std::cout << "MCS MatchFusedRingsStrict: "
+              << res.SmartsString << " " << res.NumAtoms << " atoms, "
+              << res.NumBonds << " bonds\n";
+    printTime();
+    TEST_ASSERT(res.NumAtoms == 6 && res.NumBonds == 6);
+  }
   BOOST_LOG(rdInfoLog) << "\tdone" << std::endl;
 }
 
@@ -663,15 +711,39 @@ void testSimple() {
       "CCC3O)C(=O)C(Cc3ccccc3)NC(=O)C(CSSC2)NC1=O CHEMBL1076370",
   };
   for (auto& i : smi) mols.push_back(ROMOL_SPTR(SmilesToMol(getSmilesOnly(i))));
-  MCSParameters p;
-  p.BondCompareParameters.RingMatchesRingOnly = true;
-  p.BondCompareParameters.CompleteRingsOnly = true;
-  t0 = nanoClock();
-  MCSResult res = findMCS(mols, &p);
-  std::cout << "MCS: " << res.SmartsString << " " << res.NumAtoms << " atoms, "
-            << res.NumBonds << " bonds\n";
-  printTime();
-  TEST_ASSERT(res.NumAtoms == 15 && res.NumBonds == 14);
+  {
+    MCSParameters p;
+    p.BondCompareParameters.RingMatchesRingOnly = true;
+    p.BondCompareParameters.CompleteRingsOnly = true;
+    t0 = nanoClock();
+    MCSResult res = findMCS(mols, &p);
+    std::cout << "MCS: " << res.SmartsString << " " << res.NumAtoms << " atoms, "
+              << res.NumBonds << " bonds\n";
+    printTime();
+    TEST_ASSERT(res.NumAtoms == 15 && res.NumBonds == 14);
+  }
+  {
+    MCSParameters p;
+    p.BondCompareParameters.MatchFusedRings = true;
+    t0 = nanoClock();
+    MCSResult res = findMCS(mols, &p);
+    std::cout << "MCS MatchFusedRings: "
+              << res.SmartsString << " " << res.NumAtoms << " atoms, "
+              << res.NumBonds << " bonds\n";
+    printTime();
+    TEST_ASSERT(res.NumAtoms == 15 && res.NumBonds == 14);
+  }
+  {
+    MCSParameters p;
+    p.BondCompareParameters.MatchFusedRingsStrict = true;
+    t0 = nanoClock();
+    MCSResult res = findMCS(mols, &p);
+    std::cout << "MCS MatchFusedRingsStrict: "
+              << res.SmartsString << " " << res.NumAtoms << " atoms, "
+              << res.NumBonds << " bonds\n";
+    printTime();
+    TEST_ASSERT(res.NumAtoms == 15 && res.NumBonds == 14);
+  }
   BOOST_LOG(rdInfoLog) << "\tdone" << std::endl;
 }
 
@@ -812,14 +884,18 @@ void testJSONParameters() {
               pj.AtomCompareParameters.MatchChiralTag == false &&
               pj.BondCompareParameters.MatchStereo == false &&
               pj.BondCompareParameters.RingMatchesRingOnly == false &&
-              pj.BondCompareParameters.CompleteRingsOnly == false);
+              pj.BondCompareParameters.CompleteRingsOnly == false &&
+              pj.BondCompareParameters.MatchFusedRings == false &&
+              pj.BondCompareParameters.MatchFusedRingsStrict == false);
 
   pj = MCSParameters();
   const char json[] =
       "{\"MaximizeBonds\": false, \"Threshold\": 0.7, \"Timeout\": 3"
       ", \"MatchValences\": true, \"MatchChiralTag\": true"
-      ", \"MatchStereo\": true, \"RingMatchesRingOnly\": true, "
-      "\"CompleteRingsOnly\": true"
+      ", \"MatchStereo\": true, \"RingMatchesRingOnly\": true"
+      ", \"CompleteRingsOnly\": true"
+      ", \"MatchFusedRings\": true"
+      ", \"MatchFusedRingsStrict\": true"
       ", \"InitialSeed\": \"CNC\""
       "}";
   parseMCSParametersJSON(json, &pj);
@@ -830,6 +906,8 @@ void testJSONParameters() {
               pj.BondCompareParameters.MatchStereo == true &&
               pj.BondCompareParameters.RingMatchesRingOnly == true &&
               pj.BondCompareParameters.CompleteRingsOnly == true &&
+              pj.BondCompareParameters.MatchFusedRings == true &&
+              pj.BondCompareParameters.MatchFusedRingsStrict == true &&
               0 == strcmp(pj.InitialSeed.c_str(), "CNC"));
   BOOST_LOG(rdInfoLog) << "\tdone" << std::endl;
 }
@@ -1232,16 +1310,41 @@ void testGithub945() {
 
       mols.push_back(ROMOL_SPTR(m));
     }
-    MCSParameters p;
-    // p.Verbose = true;
-    p.BondCompareParameters.CompleteRingsOnly = true;
-    MCSResult res = findMCS(mols, &p);
-    // std::cerr << "MCS: " << res.SmartsString << " " << res.NumAtoms
-    //           << " atoms, " << res.NumBonds << " bonds\n"
-    //           << std::endl;
+    {
+      MCSParameters p;
+      // p.Verbose = true;
+      p.BondCompareParameters.CompleteRingsOnly = true;
+      MCSResult res = findMCS(mols, &p);
+      // std::cerr << "MCS CompleteRingsOnly: "
+      //           << res.SmartsString << " " << res.NumAtoms
+      //           << " atoms, " << res.NumBonds << " bonds\n"
+      //           << std::endl;
 
-    TEST_ASSERT(res.NumAtoms == 6);
-    TEST_ASSERT(res.NumBonds == 6);
+      TEST_ASSERT(res.NumAtoms == 6);
+      TEST_ASSERT(res.NumBonds == 6);
+    }
+    {
+      MCSParameters p;
+      p.BondCompareParameters.MatchFusedRings = true;
+      MCSResult res = findMCS(mols, &p);
+      // std::cerr << "MCS MatchFusedRings: "
+      //           << res.SmartsString << " " << res.NumAtoms
+      //           << " atoms, " << res.NumBonds << " bonds\n"
+      //           << std::endl;
+      TEST_ASSERT(res.NumAtoms == 6);
+      TEST_ASSERT(res.NumBonds == 6);
+    }
+    {
+      MCSParameters p;
+      p.BondCompareParameters.MatchFusedRingsStrict = true;
+      MCSResult res = findMCS(mols, &p);
+      // std::cerr << "MCS MatchFusedRingsStrict: "
+      //           << res.SmartsString << " " << res.NumAtoms
+      //           << " atoms, " << res.NumBonds << " bonds\n"
+      //           << std::endl;
+      TEST_ASSERT(res.NumAtoms == 6);
+      TEST_ASSERT(res.NumBonds == 6);
+    }
   }
 #endif
   {
@@ -1254,25 +1357,53 @@ void testGithub945() {
 
       mols.push_back(ROMOL_SPTR(m));
     }
-    MCSParameters p;
-    // p.Verbose = true;
-    p.BondCompareParameters.CompleteRingsOnly = true;
-    MCSResult res = findMCS(mols, &p);
-    // std::cerr << "MCS: " << res.SmartsString << " " << res.NumAtoms
-    //           << " atoms, " << res.NumBonds << " bonds\n"
-    //           << std::endl;
-    TEST_ASSERT(res.NumAtoms == 9);
-    TEST_ASSERT(res.NumBonds == 10);
+    {
+      MCSParameters p;
+      // p.Verbose = true;
+      p.BondCompareParameters.CompleteRingsOnly = true;
+      MCSResult res = findMCS(mols, &p);
+      // std::cerr << "MCS CompleteRingsOnly: "
+      //           << res.SmartsString << " " << res.NumAtoms
+      //           << " atoms, " << res.NumBonds << " bonds\n"
+      //           << std::endl;
+      TEST_ASSERT(res.NumAtoms == 9);
+      TEST_ASSERT(res.NumBonds == 10);
+    }
+    {
+      MCSParameters p;
+      p.BondCompareParameters.MatchFusedRings = true;
+      MCSResult res = findMCS(mols, &p);
+      // std::cerr << "MCS MatchFusedRings: "
+      //           << res.SmartsString << " " << res.NumAtoms
+      //           << " atoms, " << res.NumBonds << " bonds\n"
+      //           << std::endl;
+      TEST_ASSERT(res.NumAtoms == 9);
+      TEST_ASSERT(res.NumBonds == 10);
+    }
+    {
+      MCSParameters p;
+      p.BondCompareParameters.MatchFusedRingsStrict = true;
+      MCSResult res = findMCS(mols, &p);
+      // std::cerr << "MCS MatchFusedRingsStrict: "
+      //           << res.SmartsString << " " << res.NumAtoms
+      //           << " atoms, " << res.NumBonds << " bonds\n"
+      //           << std::endl;
+      TEST_ASSERT(res.NumAtoms == 9);
+      TEST_ASSERT(res.NumBonds == 10);
+    }
 
     // if we don't require rings to be closed, then we get the solution that
     // has more atoms:
-    p.BondCompareParameters.CompleteRingsOnly = false;
-    res = findMCS(mols, &p);
-    // std::cerr << "MCS: " << res.SmartsString << " " << res.NumAtoms
-    //           << " atoms, " << res.NumBonds << " bonds\n"
-    //           << std::endl;
-    TEST_ASSERT(res.NumAtoms == 10);
-    TEST_ASSERT(res.NumBonds == 10);
+    {
+      MCSParameters p;
+      p.BondCompareParameters.CompleteRingsOnly = false;
+      MCSResult res = findMCS(mols, &p);
+      // std::cerr << "MCS: " << res.SmartsString << " " << res.NumAtoms
+      //           << " atoms, " << res.NumBonds << " bonds\n"
+      //           << std::endl;
+      TEST_ASSERT(res.NumAtoms == 10);
+      TEST_ASSERT(res.NumBonds == 10);
+    }
   }
 
   BOOST_LOG(rdInfoLog) << "============================================"
@@ -1286,24 +1417,47 @@ void testGithub2420() {
                           "envelope MCS if CompleteRingsOnly is true"
                        << std::endl;
 
+  std::vector<ROMOL_SPTR> mols;
+  const char* smi[] = {"C1CC2C(CC1)CCCC2", "C1CCCCCCCCC1"};
+
+  for (auto& i : smi) {
+    auto m = SmilesToMol(getSmilesOnly(i));
+    TEST_ASSERT(m);
+
+    mols.push_back(ROMOL_SPTR(m));
+  }
   {
-    std::vector<ROMOL_SPTR> mols;
-    const char* smi[] = {"C1CC2C(CC1)CCCC2", "C1CCCCCCCCC1"};
-
-    for (auto& i : smi) {
-      auto m = SmilesToMol(getSmilesOnly(i));
-      TEST_ASSERT(m);
-
-      mols.push_back(ROMOL_SPTR(m));
-    }
     MCSParameters p;
     p.BondCompareParameters.CompleteRingsOnly = true;
     MCSResult res = findMCS(mols, &p);
-    std::cerr << "MCS: " << res.SmartsString << " " << res.NumAtoms
-              << " atoms, " << res.NumBonds << " bonds\n"
-              << std::endl;
+    // std::cerr << "MCS CompleteRingsOnly: "
+    //           << res.SmartsString << " " << res.NumAtoms
+    //           << " atoms, " << res.NumBonds << " bonds\n"
+    //           << std::endl;
     TEST_ASSERT(res.NumAtoms == 10);
     TEST_ASSERT(res.NumBonds == 10);
+  }
+  {
+    MCSParameters p;
+    p.BondCompareParameters.MatchFusedRings = true;
+    MCSResult res = findMCS(mols, &p);
+    // std::cerr << "MCS MatchFusedRings: "
+    //           << res.SmartsString << " " << res.NumAtoms
+    //           << " atoms, " << res.NumBonds << " bonds\n"
+    //           << std::endl;
+    TEST_ASSERT(res.NumAtoms == 10);
+    TEST_ASSERT(res.NumBonds == 10);
+  }
+  {
+    MCSParameters p;
+    p.BondCompareParameters.MatchFusedRingsStrict = true;
+    MCSResult res = findMCS(mols, &p);
+    // std::cerr << "MCS MatchFusedRingsStrict: "
+    //           << res.SmartsString << " " << res.NumAtoms
+    //           << " atoms, " << res.NumBonds << " bonds\n"
+    //           << std::endl;
+    TEST_ASSERT(res.NumAtoms == 0);
+    TEST_ASSERT(res.NumBonds == 0);
   }
 
   BOOST_LOG(rdInfoLog) << "============================================"
@@ -1367,6 +1521,270 @@ void testGithub2662() {
               << std::endl;
     TEST_ASSERT(res.NumAtoms == 2);
     TEST_ASSERT(res.NumBonds == 1);
+  }
+
+  BOOST_LOG(rdInfoLog) << "============================================"
+                       << std::endl;
+  BOOST_LOG(rdInfoLog) << "\tdone" << std::endl;
+}
+
+void testNaphthalenes() {
+  BOOST_LOG(rdInfoLog) << "-------------------------------------" << std::endl;
+  BOOST_LOG(rdInfoLog) << "Testing naphthalenes with different substitution "
+                          "patterns"
+                       << std::endl;
+
+  std::vector<ROMOL_SPTR> mols;
+  const char* smi[] = {"Cc1cccc2ccccc12", "Cc1ccc2ccccc2c1"};
+
+  for (auto& i : smi) {
+    auto m = SmilesToMol(getSmilesOnly(i));
+    TEST_ASSERT(m);
+
+    mols.push_back(ROMOL_SPTR(m));
+  }
+  {
+    MCSParameters p;
+    p.BondCompareParameters.CompleteRingsOnly = true;
+    MCSResult res = findMCS(mols, &p);
+    // std::cerr << "MCS CompleteRingsOnly: "
+    //           << res.SmartsString << " " << res.NumAtoms
+    //           << " atoms, " << res.NumBonds << " bonds\n"
+    //           << std::endl;
+    TEST_ASSERT(res.NumAtoms == 11);
+    TEST_ASSERT(res.NumBonds == 11);
+  }
+  {
+    MCSParameters p;
+    p.BondCompareParameters.CompleteRingsOnly = true;
+    p.BondCompareParameters.MatchFusedRings = true;
+    MCSResult res = findMCS(mols, &p);
+    // std::cerr << "MCS MatchFusedRings: "
+    //           << res.SmartsString << " " << res.NumAtoms
+    //           << " atoms, " << res.NumBonds << " bonds\n"
+    //           << std::endl;
+    TEST_ASSERT(res.NumAtoms == 10);
+    TEST_ASSERT(res.NumBonds == 11);
+  }
+  {
+    MCSParameters p;
+    p.BondCompareParameters.CompleteRingsOnly = true;
+    p.BondCompareParameters.MatchFusedRingsStrict = true;
+    MCSResult res = findMCS(mols, &p);
+    // std::cerr << "MCS MatchFusedRingsStrict: "
+    //           << res.SmartsString << " " << res.NumAtoms
+    //           << " atoms, " << res.NumBonds << " bonds\n"
+    //           << std::endl;
+    TEST_ASSERT(res.NumAtoms == 10);
+    TEST_ASSERT(res.NumBonds == 11);
+  }
+  // add cyclodecapentaene: then we'll get the envelope
+  // unless we specify MatchFusedRingsStrict
+  char cyclodecapentaene[] = "Cc1ccccccccc1";
+  {
+    auto m = SmilesToMol(cyclodecapentaene);
+    TEST_ASSERT(m);
+    mols.push_back(ROMOL_SPTR(m));
+  }
+  {
+    MCSParameters p;
+    p.BondCompareParameters.CompleteRingsOnly = true;
+    MCSResult res = findMCS(mols, &p);
+    // std::cerr << "MCS CompleteRingsOnly: "
+    //           << res.SmartsString << " " << res.NumAtoms
+    //           << " atoms, " << res.NumBonds << " bonds\n"
+    //           << std::endl;
+    TEST_ASSERT(res.NumAtoms == 11);
+    TEST_ASSERT(res.NumBonds == 11);
+  }
+  {
+    MCSParameters p;
+    p.BondCompareParameters.CompleteRingsOnly = true;
+    p.BondCompareParameters.MatchFusedRings = true;
+    MCSResult res = findMCS(mols, &p);
+    // std::cerr << "MCS MatchFusedRings: "
+    //           << res.SmartsString << " " << res.NumAtoms
+    //           << " atoms, " << res.NumBonds << " bonds\n"
+    //           << std::endl;
+    TEST_ASSERT(res.NumAtoms == 11);
+    TEST_ASSERT(res.NumBonds == 11);
+  }
+  {
+    MCSParameters p;
+    p.BondCompareParameters.CompleteRingsOnly = true;
+    p.BondCompareParameters.MatchFusedRingsStrict = true;
+    MCSResult res = findMCS(mols, &p);
+    // std::cerr << "MCS MatchFusedRingsStrict: "
+    //           << res.SmartsString << " " << res.NumAtoms
+    //           << " atoms, " << res.NumBonds << " bonds\n"
+    //           << std::endl;
+    TEST_ASSERT(res.NumAtoms == 2);
+    TEST_ASSERT(res.NumBonds == 1);
+  }
+
+  BOOST_LOG(rdInfoLog) << "============================================"
+                       << std::endl;
+  BOOST_LOG(rdInfoLog) << "\tdone" << std::endl;
+}
+
+void testBicycles() {
+  BOOST_LOG(rdInfoLog) << "-------------------------------------" << std::endl;
+  BOOST_LOG(rdInfoLog) << "Testing bicycles with different substitution "
+                          "patterns"
+                       << std::endl;
+
+  std::vector<ROMOL_SPTR> mols;
+  const char* smi[] = {"CC1CCCC2CCCC12", "CC1CCC2CC12", "C1C(C)CC2CC12"};
+
+  for (auto& i : smi) {
+    auto m = SmilesToMol(getSmilesOnly(i));
+    TEST_ASSERT(m);
+
+    mols.push_back(ROMOL_SPTR(m));
+  }
+  {
+    MCSParameters p;
+    p.BondCompareParameters.CompleteRingsOnly = true;
+    MCSResult res = findMCS(mols, &p);
+    // std::cerr << "MCS CompleteRingsOnly: "
+    //           << res.SmartsString << " " << res.NumAtoms
+    //           << " atoms, " << res.NumBonds << " bonds\n"
+    //           << std::endl;
+    TEST_ASSERT(res.NumAtoms == 7);
+    TEST_ASSERT(res.NumBonds == 7);
+  }
+  {
+    MCSParameters p;
+    p.BondCompareParameters.CompleteRingsOnly = true;
+    p.BondCompareParameters.MatchFusedRings = true;
+    MCSResult res = findMCS(mols, &p);
+    // std::cerr << "MCS MatchFusedRings: "
+    //           << res.SmartsString << " " << res.NumAtoms
+    //           << " atoms, " << res.NumBonds << " bonds\n"
+    //           << std::endl;
+    TEST_ASSERT(res.NumAtoms == 5);
+    TEST_ASSERT(res.NumBonds == 5);
+  }
+  {
+    MCSParameters p;
+    p.BondCompareParameters.CompleteRingsOnly = true;
+    p.BondCompareParameters.MatchFusedRingsStrict = true;
+    MCSResult res = findMCS(mols, &p);
+    // std::cerr << "MCS MatchFusedRingsStrict: "
+    //           << res.SmartsString << " " << res.NumAtoms
+    //           << " atoms, " << res.NumBonds << " bonds\n"
+    //           << std::endl;
+    TEST_ASSERT(res.NumAtoms == 5);
+    TEST_ASSERT(res.NumBonds == 5);
+  }
+
+  BOOST_LOG(rdInfoLog) << "============================================"
+                       << std::endl;
+  BOOST_LOG(rdInfoLog) << "\tdone" << std::endl;
+}
+
+void testBicyclesTricycles() {
+  BOOST_LOG(rdInfoLog) << "-------------------------------------" << std::endl;
+  BOOST_LOG(rdInfoLog) << "Testing bicycles and tricycles with "
+                          "different substitution patterns"
+                       << std::endl;
+
+  std::vector<ROMOL_SPTR> mols;
+  const char* smi[] = {"CC1CCCC2CCCC12", "C1C(C)CCC2CCCC12",
+                       "CC1CCCC(C3)2CCCC123", "C1C(C)CCC(C3)2CCCC123"};
+
+  for (auto& i : smi) {
+    auto m = SmilesToMol(getSmilesOnly(i));
+    TEST_ASSERT(m);
+
+    mols.push_back(ROMOL_SPTR(m));
+  }
+  {
+    MCSParameters p;
+    p.BondCompareParameters.CompleteRingsOnly = true;
+    MCSResult res = findMCS(mols, &p);
+    // std::cerr << "MCS CompleteRingsOnly: "
+    //           << res.SmartsString << " " << res.NumAtoms
+    //           << " atoms, " << res.NumBonds << " bonds\n"
+    //           << std::endl;
+    TEST_ASSERT(res.NumAtoms == 10);
+    TEST_ASSERT(res.NumBonds == 10);
+  }
+  {
+    MCSParameters p;
+    p.BondCompareParameters.CompleteRingsOnly = true;
+    p.BondCompareParameters.MatchFusedRings = true;
+    MCSResult res = findMCS(mols, &p);
+    // std::cerr << "MCS MatchFusedRings: "
+    //           << res.SmartsString << " " << res.NumAtoms
+    //           << " atoms, " << res.NumBonds << " bonds\n"
+    //           << std::endl;
+    TEST_ASSERT(res.NumAtoms == 9);
+    TEST_ASSERT(res.NumBonds == 10);
+  }
+  {
+    MCSParameters p;
+    p.BondCompareParameters.CompleteRingsOnly = true;
+    p.BondCompareParameters.MatchFusedRingsStrict = true;
+    MCSResult res = findMCS(mols, &p);
+    // std::cerr << "MCS MatchFusedRingsStrict: "
+    //           << res.SmartsString << " " << res.NumAtoms
+    //           << " atoms, " << res.NumBonds << " bonds\n"
+    //           << std::endl;
+    TEST_ASSERT(res.NumAtoms == 9);
+    TEST_ASSERT(res.NumBonds == 10);
+  }
+
+  BOOST_LOG(rdInfoLog) << "============================================"
+                       << std::endl;
+  BOOST_LOG(rdInfoLog) << "\tdone" << std::endl;
+}
+
+void test_p38() {
+  BOOST_LOG(rdInfoLog) << "-------------------------------------" << std::endl;
+  BOOST_LOG(rdInfoLog) << "Testing p38 ligands"
+                       << std::endl;
+
+  std::vector<ROMOL_SPTR> mols;
+  const char* smi[] = {"C1COCCC1Nc1ncc2cc(Cc3c(F)cccc3)c(=O)n(C)c2n1",
+                       "O(c1cc2c(n(C)c1=O)nc(NC1CCOCC1)nc2)c1ccccc1"};
+
+  for (auto& i : smi) {
+    auto m = SmilesToMol(getSmilesOnly(i));
+    TEST_ASSERT(m);
+
+    mols.push_back(ROMOL_SPTR(m));
+  }
+  {
+    MCSResult res = findMCS(mols, true);
+    // std::cerr << "MCS CompleteRingsOnly: "
+    //           << res.SmartsString << " " << res.NumAtoms
+    //           << " atoms, " << res.NumBonds << " bonds\n"
+    //           << std::endl;
+    TEST_ASSERT(res.NumAtoms == 19);
+    TEST_ASSERT(res.NumBonds == 21);
+  }
+  {
+    MCSResult res = findMCS(mols, true, 1.0, 3600, false, false,
+                            true, true, false, AtomCompareElements,
+                            BondCompareOrder, PermissiveRingFusion);
+    // std::cerr << "MCS MatchFusedRings: "
+    //           << res.SmartsString << " " << res.NumAtoms
+    //           << " atoms, " << res.NumBonds << " bonds\n"
+    //           << std::endl;
+    TEST_ASSERT(res.NumAtoms == 19);
+    TEST_ASSERT(res.NumBonds == 21);
+  }
+  {
+    MCSResult res = findMCS(mols, true, 1.0, 3600, false, false,
+                            true, true, false, AtomCompareElements,
+                            BondCompareOrder, StrictRingFusion);
+    // std::cerr << "MCS MatchFusedRings: "
+    //           << res.SmartsString << " " << res.NumAtoms
+    //           << " atoms, " << res.NumBonds << " bonds\n"
+    //           << std::endl;
+    TEST_ASSERT(res.NumAtoms == 19);
+    TEST_ASSERT(res.NumBonds == 21);
   }
 
   BOOST_LOG(rdInfoLog) << "============================================"
@@ -1474,6 +1892,10 @@ int main(int argc, const char* argv[]) {
   testGithub2420();
   testGithub2663();
   testGithub2662();
+  testNaphthalenes();
+  testBicycles();
+  testBicyclesTricycles();
+  test_p38();
   testGithub2714();
 
   unsigned long long t1 = nanoClock();


### PR DESCRIPTION
This PR implements what I presented in my lightning talk at the RDKit UGM 2019.

Following discussions with Greg, I decided to implement three different levels of consideration of ring fusion:
- `RingCompare=IgnoreRingFusion` (corresponding to `BondCompareParameters.MatchFusedRings=False`): this is the default, and keeps the current MCS behaviour, where ring fusion is not taken into account, and the MCS between &alpha;-methylnaphthalene and &beta;-methylnaphthalene will return 11 atoms and 11 bonds, corresponding to methylcyclodecapentaene
- `RingCompare=Permissive` (corresponding to `BondCompareParameters.MatchFusedRings=True, BondCompareParameters.MatchFusedRingsStrict=False`): ring fusion is taken into account, but if one of the molecules does not feature any ring fusion in the MCS, then the envelope can be returned. For example, the MCS between &alpha;-methylnaphthalene and &beta;-methylnaphthalene will return 10 atoms and 11 bonds, corresponding to the naphthalene core, as both rings feature a ring fusion within the MCS. However, the MCS between cyclodecane and decalin will be cyclodecane, as cyclodecane does not feature any ring fusion
- `RingCompare=Strict` (corresponding to `BondCompareParameters.MatchFusedRings=True, BondCompareParameters.MatchFusedRingsStrict=True`): ring fusion is taken into account, and must be honored by all molecules. For example, the MCS between &alpha;-methylnaphthalene and &beta;-methylnaphthalene will return 10 atoms and 11 bonds, corresponding to the naphthalene core, as both rings feature a ring fusion within the MCS. The MCS between cyclodecane and decalin will be null, because the two ring systems are considered as completely different and not comparable

Relevant tests were also added.