### PR TITLE
Cleanup some unintended consequences of #2553

### DIFF
--- a/Code/GraphMol/Bond.cpp
+++ b/Code/GraphMol/Bond.cpp
@@ -298,7 +298,13 @@ std::ostream &operator<<(std::ostream &target, const RDKit::Bond &bond) {
   target << bond.getBeginAtomIdx() << "->" << bond.getEndAtomIdx();
   target << " order: " << bond.getBondType();
   if (bond.getBondDir()) target << " dir: " << bond.getBondDir();
-  if (bond.getStereo()) target << " stereo: " << bond.getStereo();
+  if (bond.getStereo()) {
+    target << " stereo: " << bond.getStereo();
+    if (bond.getStereoAtoms().size() == 2) {
+      const auto &ats = bond.getStereoAtoms();
+      target << " stereoAts: (" << ats[0] << " " << ats[1] << ")";
+    }
+  }
   target << " conj?: " << bond.getIsConjugated();
   target << " aromatic?: " << bond.getIsAromatic();
 

--- a/Code/GraphMol/ChemReactions/ReactionRunner.cpp
+++ b/Code/GraphMol/ChemReactions/ReactionRunner.cpp
@@ -162,17 +162,19 @@ const Atom *findHighestCIPNeighbor(const Atom *atom, const Atom *skipAtom) {
     }
     unsigned cip = 0;
     if (!neighbor->getPropIfPresent(common_properties::_CIPRank, cip)) {
-      // If at least one of the atoms doesn't have a CIP rank, the highest rank
-      // does not make sense, so return a nullptr.
-      return nullptr;
-    }
-    if (cip > bestCipRank || bestCipRankedAtom == nullptr) {
+      if (bestCipRankedAtom == nullptr) {
+        bestCipRankedAtom = neighbor;
+      }
+    } else if (cip > bestCipRank || bestCipRankedAtom == nullptr) {
       bestCipRank = cip;
       bestCipRankedAtom = neighbor;
     } else if (cip == bestCipRank) {
       // This also doesn't make sense if there is a tie (if that's possible).
       // We still keep the best CIP rank in case something better comes around
       // (also not sure if that's possible).
+      BOOST_LOG(rdWarningLog)
+          << "Warning: duplicate CIP ranks found in findHighestCIPNeighbor()"
+          << std::endl;
       bestCipRankedAtom = nullptr;
     }
   }
@@ -681,7 +683,6 @@ void updateStereoBonds(RWMOL_SPTR product, const ROMol &reactant,
     if (pBond->getBondType() != Bond::BondType::DOUBLE) {
       continue;
     }
-
     // If the product bond was previously marked as STEREOANY, check if it can
     // actually sustain stereo (this could not be checked until we had all the
     // atoms in the product)
@@ -1285,7 +1286,6 @@ void addReactantAtomsAndBonds(const ChemicalReaction &rxn, RWMOL_SPTR product,
                       "mapped reactant atom not present in product.");
 
       const Atom *reactantAtom = reactant->getAtomWithIdx(reactantAtomIdx);
-
       for (unsigned i = 0;
            i < mapping->reactProdAtomMap[reactantAtomIdx].size(); i++) {
         // here's a pointer to the atom in the product:

--- a/Code/GraphMol/ChemReactions/testReaction.cpp
+++ b/Code/GraphMol/ChemReactions/testReaction.cpp
@@ -7351,6 +7351,22 @@ void testDblBondCrash() {
       MolOps::sanitizeMol(*(RWMol *)prods[0][0].get());
       TEST_ASSERT(MolToSmiles(*prods[0][0]) == "CC(=O)/N=C(\\C)c1nonc1N");
     }
+    {
+      // another example
+      const std::string reaction2(R"([N;!H0;$(N-c):1]>>[N:1]-c1cncnn1)");
+      std::unique_ptr<ChemicalReaction> rxn2(
+          RxnSmartsToChemicalReaction(reaction2));
+      TEST_ASSERT(rxn2);
+      rxn2->initReactantMatchers();
+      auto mol = RWMOL_SPTR(SmilesToMol("CC(=O)/C=C(\\N)c1nonc1N"));
+      std::vector<ROMOL_SPTR> v{mol};
+      auto prods = rxn2->runReactants(v);
+      TEST_ASSERT(prods.size() == 1);
+      TEST_ASSERT(prods[0].size() == 1);
+      MolOps::sanitizeMol(*(RWMol *)prods[0][0].get());
+      TEST_ASSERT(MolToSmiles(*prods[0][0]) ==
+                  "CC(=O)/C=C(\\N)c1nonc1Nc1cncnn1");
+    }
   }
 }
 

--- a/Code/GraphMol/ChemReactions/testReaction.cpp
+++ b/Code/GraphMol/ChemReactions/testReaction.cpp
@@ -7135,6 +7135,12 @@ void testOtherBondStereo() {
         TEST_ASSERT(Bond::BondStereo::STEREONONE == bond->getStereo());
       }
     }
+    // and if we don't strip direction?
+    auto lmol = RWMOL_SPTR(SmilesToMol(R"(C/C=C/[Br])"));
+    auto product_sets2 = rxn->runReactant(lmol, 0);
+    TEST_ASSERT(!product_sets2.empty());
+    auto osmi = MolToSmiles(*product_sets2[0][0]);
+    TEST_ASSERT(osmi == "CCCBr");
   }
   {  // Reaction explicitly destroys stereochemistry
      // (no directed bonds enclosing the double bond)
@@ -7160,6 +7166,12 @@ void testOtherBondStereo() {
         }
       }
     }
+    // and if we don't strip direction?
+    auto lmol = RWMOL_SPTR(SmilesToMol(R"(C/C=C/[Br])"));
+    auto product_sets2 = rxn->runReactant(lmol, 0);
+    TEST_ASSERT(!product_sets.empty());
+    auto osmi = MolToSmiles(*product_sets2[0][0]);
+    TEST_ASSERT(osmi == "CC=CBr");
   }
   {  // Reaction with 2 product sets
     const std::string reaction(R"([C:1]=[C:2]>>[Si:1]=[C:2])");
@@ -7176,6 +7188,14 @@ void testOtherBondStereo() {
       TEST_ASSERT(check_bond_stereo(products[0], 0, 2, 3,
                                     Bond::BondStereo::STEREOTRANS));
     }
+    // and if we don't strip direction?
+    auto lmol = RWMOL_SPTR(SmilesToMol(R"(C/C=C/[Br])"));
+    auto product_sets2 = rxn->runReactant(lmol, 0);
+    TEST_ASSERT(!product_sets2.empty());
+    auto osmi = MolToSmiles(*product_sets2[0][0]);
+    TEST_ASSERT(osmi == "C/[SiH]=C/Br");
+    osmi = MolToSmiles(*product_sets2[1][0]);
+    TEST_ASSERT(osmi == "C/C=[SiH]/Br");
   }
   {  // Reactant stereo propagated by (stereoatom, anti-stereoatom) pair
     auto mol2 = RWMOL_SPTR(SmilesToMol(R"(Cl/C(C)=C(/Br)F)"));
@@ -7195,6 +7215,13 @@ void testOtherBondStereo() {
     // We are only interested in the product that keeps the double bond
     TEST_ASSERT(check_bond_stereo(product_sets[0][0], 0, 2, 4,
                                   Bond::BondStereo::STEREOCIS));
+
+    // and if we don't strip direction?
+    auto lmol = RWMOL_SPTR(SmilesToMol(R"(Cl/C(C)=C(/Br)F)"));
+    auto product_sets2 = rxn->runReactant(lmol, 0);
+    TEST_ASSERT(!product_sets2.empty());
+    auto osmi = MolToSmiles(*product_sets2[0][0]);
+    TEST_ASSERT(osmi == "C/C(Cl)=C/F");
   }
   {  // Reactant stereo propagated by anti-stereoatoms pair
     auto mol2 = RWMOL_SPTR(SmilesToMol(R"(Cl/C(C)=C(/Br)F)"));
@@ -7215,6 +7242,13 @@ void testOtherBondStereo() {
     // We are only interested in the product that keeps the double bond
     TEST_ASSERT(check_bond_stereo(product_sets[0][0], 0, 2, 3,
                                   Bond::BondStereo::STEREOTRANS));
+
+    // and if we don't strip direction?
+    auto lmol = RWMOL_SPTR(SmilesToMol(R"(Cl/C(C)=C(/Br)F)"));
+    auto product_sets2 = rxn->runReactant(lmol, 0);
+    TEST_ASSERT(!product_sets2.empty());
+    auto osmi = MolToSmiles(*product_sets2[0][0]);
+    TEST_ASSERT(osmi == "C/C=C/F");
   }
 }
 

--- a/Code/GraphMol/Chirality.cpp
+++ b/Code/GraphMol/Chirality.cpp
@@ -2260,13 +2260,6 @@ void setDoubleBondNeighborDirections(ROMol &mol, const Conformer *conf) {
     //           << pairIter->second->getStereo() << std::endl;
     updateDoubleBondNeighbors(mol, pairIter->second, conf, needsDir,
                               singleBondCounts, singleBondNbrs);
-    // if the bond is cis or trans we've now set the directions
-    // that correspond to that, so we can remove the bond stereo setting
-    if (pairIter->second->getStereo() == Bond::STEREOCIS ||
-        pairIter->second->getStereo() == Bond::STEREOTRANS) {
-      // std::cerr << "RESET: " << pairIter->second->getIdx() << std::endl;
-      pairIter->second->setStereo(Bond::STEREONONE);
-    }
   }
   if (resetRings) mol.getRingInfo()->reset();
 }

--- a/Code/GraphMol/MolOps.h
+++ b/Code/GraphMol/MolOps.h
@@ -885,17 +885,13 @@ RDKIT_GRAPHMOL_EXPORT void assignStereochemistryFrom3D(
 RDKIT_GRAPHMOL_EXPORT void assignChiralTypesFromBondDirs(
     ROMol &mol, int confId = -1, bool replaceExistingTags = true);
 
-//! \brief Uses a conformer to assign directionality to the single bonds
-//!   around double bonds
-/*!
-
-  \param mol                  the molecule of interest
-  \param confId               the conformer to use
-*/
+//! \deprecated: this function will be removed in a future release. Use
+//! setDoubleBondNeighborDirections() instead
 RDKIT_GRAPHMOL_EXPORT void detectBondStereochemistry(ROMol &mol,
                                                      int confId = -1);
+//! Sets bond directions based on double bond stereochemistry
 RDKIT_GRAPHMOL_EXPORT void setDoubleBondNeighborDirections(
-    ROMol &mol, const Conformer *conf = NULL);
+    ROMol &mol, const Conformer *conf = nullptr);
 
 //! Assign CIS/TRANS bond stereochemistry tags based on neighboring directions
 RDKIT_GRAPHMOL_EXPORT void setBondStereoFromDirections(ROMol &mol);

--- a/Code/GraphMol/Wrap/MolOps.cpp
+++ b/Code/GraphMol/Wrap/MolOps.cpp
@@ -824,6 +824,14 @@ ROMol *replaceCoreHelper(const ROMol &mol, const ROMol &core,
                      requireDummyMatch);
 }
 
+void setDoubleBondNeighborDirectionsHelper(ROMol &mol, python::object confObj) {
+  Conformer *conf = nullptr;
+  if (confObj) {
+    conf = python::extract<Conformer *>(confObj);
+  }
+  MolOps::setDoubleBondNeighborDirections(mol, conf);
+}
+
 struct molops_wrapper {
   static void wrap() {
     std::string docString;
@@ -846,7 +854,7 @@ struct molops_wrapper {
     // ------------------------------------------------------------------------
     docString =
         "Assign stereochemistry to bonds based on coordinates and a conformer.\n\
-        DEPRECATED: Please use the version that takes a conformer ID instead.\n\
+        DEPRECATED\n\
         \n\
   ARGUMENTS:\n\
   \n\
@@ -857,8 +865,7 @@ struct molops_wrapper {
                 (python::arg("mol"), python::arg("conformer")),
                 docString.c_str());
     docString =
-        "Assign stereochemistry to bonds based on coordinates.\n\
-        \n\
+        "DEPRECATED, use SetDoubleBondNeighborDirections() instead\n\
   ARGUMENTS:\n\
   \n\
     - mol: the molecule to be modified\n\
@@ -869,14 +876,26 @@ struct molops_wrapper {
                 docString.c_str());
 
     docString =
+        "Uses the stereo info on double bonds to set the directions of neighboring single bonds\n\
+        \n\
+  ARGUMENTS:\n\
+  \n\
+    - mol: the molecule to be modified\n\
+\n";
+    python::def("SetDoubleBondNeighborDirections",
+                setDoubleBondNeighborDirectionsHelper,
+                (python::arg("mol"), python::arg("conf") = python::object()),
+                docString.c_str());
+
+    docString =
         "Uses the directions of neighboring bonds to set cis/trans stereo on double bonds.\n\
         \n\
   ARGUMENTS:\n\
   \n\
     - mol: the molecule to be modified\n\
 \n";
-    python::def("SetBondStereoFromDirections", MolOps::setBondStereoFromDirections,
-                (python::arg("mol")),
+    python::def("SetBondStereoFromDirections",
+                MolOps::setBondStereoFromDirections, (python::arg("mol")),
                 docString.c_str());
 
     // ------------------------------------------------------------------------

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -5622,7 +5622,7 @@ M  END
     m1.GetBondWithIdx(1).SetStereoAtoms(0,3)
     m1.GetBondWithIdx(1).SetStereo(Chem.BondStereo.STEREOCIS)
     Chem.SetDoubleBondNeighborDirections(m1)
-    self.assertEqual(Chem.MolToSmiles(m1),"C/C=C\\C")   
+    self.assertEqual(Chem.MolToSmiles(m1),r"C/C=C\C")   
     self.assertEqual(m1.GetBondWithIdx(0).GetBondDir(),Chem.BondDir.ENDUPRIGHT)
     self.assertEqual(m1.GetBondWithIdx(2).GetBondDir(),Chem.BondDir.ENDDOWNRIGHT)
 

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -5617,6 +5617,16 @@ M  END
     self.assertEqual(m2.GetBondBetweenAtoms(0,1).GetStereo(),Chem.BondStereo.STEREOCIS)
 
 
+  def testSetBondDirFromStereo(self):
+    m1 = Chem.MolFromSmiles('CC=CC')
+    m1.GetBondWithIdx(1).SetStereoAtoms(0,3)
+    m1.GetBondWithIdx(1).SetStereo(Chem.BondStereo.STEREOCIS)
+    Chem.SetDoubleBondNeighborDirections(m1)
+    self.assertEqual(Chem.MolToSmiles(m1),"C/C=C\\C")   
+    self.assertEqual(m1.GetBondWithIdx(0).GetBondDir(),Chem.BondDir.ENDUPRIGHT)
+    self.assertEqual(m1.GetBondWithIdx(2).GetBondDir(),Chem.BondDir.ENDDOWNRIGHT)
+
+
 
 if __name__ == '__main__':
   if "RDTESTCASE" in os.environ:

--- a/Code/GraphMol/catch_tests.cpp
+++ b/Code/GraphMol/catch_tests.cpp
@@ -766,3 +766,16 @@ M  END
     CHECK(m->getBondWithIdx(9)->getStereoAtoms()[1] == 30);
   }
 }
+
+TEST_CASE("setDoubleBondNeighborDirections()", "[stereochemistry,bug]") {
+  SECTION("basics") {
+    auto m = "CC=CC"_smiles;
+    REQUIRE(m);
+    m->getBondWithIdx(1)->getStereoAtoms() = {0, 3};
+    m->getBondWithIdx(1)->setStereo(Bond::STEREOCIS);
+    MolOps::setDoubleBondNeighborDirections(*m);
+    CHECK(m->getBondWithIdx(0)->getBondDir() == Bond::ENDUPRIGHT);
+    CHECK(m->getBondWithIdx(2)->getBondDir() == Bond::ENDDOWNRIGHT);
+    CHECK(MolToSmiles(*m) == "C/C=C\\C");
+  }
+}

--- a/Code/JavaWrappers/gmwrapper/src-test/org/RDKit/ChemReactionTests.java
+++ b/Code/JavaWrappers/gmwrapper/src-test/org/RDKit/ChemReactionTests.java
@@ -489,18 +489,19 @@ public class ChemReactionTests extends GraphMolTest {
         @Test
         public void test101RunSingleReactant() {
           ChemicalReaction rxn = 
-              ChemicalReaction.ReactionFromSmarts("[N;!H0;$(N-c);!$(N-[!#6;!#1]);!$(N-C=[O,N,S]):1]>>[N:1]-c1ncn([C:2]=[O:3])n1");
+              ChemicalReaction.ReactionFromSmarts("[N;!H0;$(N-c):1]>>[N:1]-c1cncnn1");
           
  		  ROMol_Vect reacts = new ROMol_Vect(1);
 
-                  RWMol mol = RWMol.MolFromSmiles("CC(=O)/N=C(\\N)c1nonc1N");
-                  mol.sanitizeMol();
-                  reacts.set(0,mol);
+		  RWMol mol = RWMol.MolFromSmiles("CC(=O)/C=C(\\N)c1nonc1N");
+		  //mol.sanitizeMol();
+		  reacts.set(0,mol);
          
           ROMol_Vect_Vect prods = rxn.runReactants(reacts);;
           assertEquals( 1,prods.size() );
           assertEquals( 1,prods.get(0).size() );
-		  assertEquals("foo",prods.get(0).get(0).MolToSmiles());
+		  RWMol pmol = new RWMol(prods.get(0).get(0));
+		  assertEquals("CC(=O)/C=C(\\N)c1nonc1Nc1cncnn1",pmol.MolToSmiles(true));
 		}
 
 

--- a/Code/JavaWrappers/gmwrapper/src-test/org/RDKit/ChemReactionTests.java
+++ b/Code/JavaWrappers/gmwrapper/src-test/org/RDKit/ChemReactionTests.java
@@ -486,6 +486,24 @@ public class ChemReactionTests extends GraphMolTest {
           
         }
   
+        @Test
+        public void test101RunSingleReactant() {
+          ChemicalReaction rxn = 
+              ChemicalReaction.ReactionFromSmarts("[N;!H0;$(N-c);!$(N-[!#6;!#1]);!$(N-C=[O,N,S]):1]>>[N:1]-c1ncn([C:2]=[O:3])n1");
+          
+ 		  ROMol_Vect reacts = new ROMol_Vect(1);
+
+                  RWMol mol = RWMol.MolFromSmiles("CC(=O)/N=C(\\N)c1nonc1N");
+                  mol.sanitizeMol();
+                  reacts.set(0,mol);
+         
+          ROMol_Vect_Vect prods = rxn.runReactants(reacts);;
+          assertEquals( 1,prods.size() );
+          assertEquals( 1,prods.get(0).size() );
+		  assertEquals("foo",prods.get(0).get(0).MolToSmiles());
+		}
+
+
         public static void main(String args[]) {
           org.junit.runner.JUnitCore.main("org.RDKit.ChemReactionTests");
         }


### PR DESCRIPTION
The fix to allow bond stereochem to be handled correctly in reactions introduced in #2553 works by setting `BondStereo` flags (which are generally pretty straightforward to translate into products) and removing `BondDir` flags (which are considerably more problematic). Unfortunately there's (still) plenty of downstream code that expects those bond dirs to be there and this change breaks all of that. Frighteningly, it didn't break it in a way that showed up in the tests. 

This PR fixes that problem (by reassigning bond dirs in the products if there were any in the reactants). It also adds some new tests to increase the size of our safety net. Finally it exposes `MolOps::setDoubleBondNeighborDirections()` to python, which should have been done a while ago.

