### PR TITLE
Apply fix for #1592 to _MolsToGridSVG

### DIFF
--- a/rdkit/Chem/Draw/__init__.py
+++ b/rdkit/Chem/Draw/__init__.py
@@ -471,7 +471,7 @@ def _MolsToGridSVG(mols, molsPerRow=3, subImgSize=(200, 200), legends=None, high
       if hasattr(dops, k):
         setattr(dops, k, v)
         del kwargs[k]
-  d2d.DrawMolecules(mols, legends=legends, highlightAtoms=highlightAtomLists,
+  d2d.DrawMolecules(list(mols), legends=legends, highlightAtoms=highlightAtomLists,
                     highlightBonds=highlightBondLists, **kwargs)
   d2d.FinishDrawing()
   res = d2d.GetDrawingText()


### PR DESCRIPTION
It fix the problem when using `useSVG=True` in `MolsToGridImage` with an `SDMolSupplier` object as `mols`. Fixed as of #1592.