### PR TITLE
Removed RDKIT_SIMDIVPICKERS_EXPORT

### DIFF
--- a/Code/SimDivPickers/LeaderPicker.h
+++ b/Code/SimDivPickers/LeaderPicker.h
@@ -8,7 +8,6 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-#include <RDGeneral/export.h>
 #ifndef RD_LEADERPICKER_H
 #define RD_LEADERPICKER_H
 
@@ -29,7 +28,7 @@ namespace RDPickers {
  *strategy aimed at diversity. See documentation for "pick()" member function
  *for the algorithm details
  */
-class RDKIT_SIMDIVPICKERS_EXPORT LeaderPicker : public DistPicker {
+class LeaderPicker : public DistPicker {
  public:
   double default_threshold;
   int default_nthreads;


### PR DESCRIPTION
Removed `RDKIT_SIMDIVPICKERS_EXPORT` directive which should not be there (`LeaderPicker.cpp` is part of `rdSimDivPickers` so it should not be imported nor exported) and prevents DLLs from building on Windows.

<!--
Thanks for contributing a pull request! 
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.


#### Any other comments?

