### PR TITLE
Fix data race in sascorer.py

### DIFF
--- a/Contrib/SA_Score/sascorer.py
+++ b/Contrib/SA_Score/sascorer.py
@@ -35,9 +35,9 @@ def readFragmentScores(name='fpscores'):
     # generate the full path filename:
     if name == "fpscores":
         name = op.join(op.dirname(__file__), name)
-    _fscores = pickle.load(gzip.open('%s.pkl.gz' % name))
+    data = pickle.load(gzip.open('%s.pkl.gz' % name))
     outDict = {}
-    for i in _fscores:
+    for i in data:
         for j in range(1, len(i)):
             outDict[i[j]] = float(i[0])
     _fscores = outDict


### PR DESCRIPTION
When using SA_Score in a parallel setting, I sometimes get random failures due to `calculateScore` reading from an intermediate value of `_fscores`. This PR avoids updating the global variable until the loaded features are ready for use.