### PR TITLE
Fix installed header directory structure

### DIFF
--- a/Code/GraphMol/ChemReactions/CMakeLists.txt
+++ b/Code/GraphMol/ChemReactions/CMakeLists.txt
@@ -34,14 +34,17 @@ rdkit_headers(Reaction.h
               ReactionRunner.h
               PreprocessRxn.h
               SanitizeRxn.h
-              Enumerate/Enumerate.h
+              DEST GraphMol/ChemReactions)
+
+rdkit_headers(Enumerate/Enumerate.h
               Enumerate/EnumerateBase.h
+              Enumerate/EnumerateTypes.h
               Enumerate/EnumerationPickler.h
               Enumerate/EnumerationStrategyBase.h
               Enumerate/CartesianProduct.h
               Enumerate/RandomSample.h
               Enumerate/RandomSampleAllBBs.h
-              DEST GraphMol/ChemReactions)
+              DEST GraphMol/ChemReactions/Enumerate)
 
 rdkit_test(testReaction testReaction.cpp LINK_LIBRARIES
  ChemReactions ChemTransforms Descriptors Fingerprints

--- a/Code/GraphMol/FMCS/CMakeLists.txt
+++ b/Code/GraphMol/FMCS/CMakeLists.txt
@@ -5,19 +5,8 @@ rdkit_library(FMCS
               FMCS.cpp Seed.cpp MaximumCommonSubgraph.cpp SubstructMatchCustom.cpp
               LINK_LIBRARIES Depictor FileParsers ChemTransforms SubstructMatch)
 
-rdkit_headers(DebugTrace.h
-              DuplicatedSeedCache.h
-              FMCS.h
+rdkit_headers(FMCS.h
               Graph.h
-              Seed.h
-              SeedSet.h
-              MatchTable.h
-              RingMatchTableSet.h
-              SubstructureCache.h
-              SubstructMatchCustom.h
-              MaximumCommonSubgraph.h
-              Target.h
-              TargetMatch.h
               DEST GraphMol/FMCS)
 
 rdkit_test(testFMCS testFMCS_Unit.cpp LINK_LIBRARIES

--- a/Code/GraphMol/FMCS/CMakeLists.txt
+++ b/Code/GraphMol/FMCS/CMakeLists.txt
@@ -5,7 +5,9 @@ rdkit_library(FMCS
               FMCS.cpp Seed.cpp MaximumCommonSubgraph.cpp SubstructMatchCustom.cpp
               LINK_LIBRARIES Depictor FileParsers ChemTransforms SubstructMatch)
 
-rdkit_headers(FMCS.h
+rdkit_headers(DebugTrace.h
+              DuplicatedSeedCache.h
+              FMCS.h
               Graph.h
               Seed.h
               SeedSet.h
@@ -14,10 +16,12 @@ rdkit_headers(FMCS.h
               SubstructureCache.h
               SubstructMatchCustom.h
               MaximumCommonSubgraph.h
+              Target.h
+              TargetMatch.h
               DEST GraphMol/FMCS)
 
 rdkit_test(testFMCS testFMCS_Unit.cpp LINK_LIBRARIES
-FMCS ChemTransforms Depictor FileParsers SmilesParse 
+FMCS ChemTransforms Depictor FileParsers SmilesParse
 GraphMol RDGeneral RDGeometryLib SubstructMatch  ${RDKit_THREAD_LIBS})
 
 if(RDK_BUILD_PYTHON_WRAPPERS)

--- a/Code/GraphMol/MolStandardize/CMakeLists.txt
+++ b/Code/GraphMol/MolStandardize/CMakeLists.txt
@@ -30,19 +30,27 @@ rdkit_headers(MolStandardize.h
 	      Charge.h
 	      Tautomer.h
 	      Fragment.h
-        FragmentCatalog/FragmentCatalogEntry.h
+	      DEST GraphMol/MolStandardize)
+
+rdkit_headers(FragmentCatalog/FragmentCatalogEntry.h
         FragmentCatalog/FragmentCatalogParams.h
         FragmentCatalog/FragmentCatalogUtils.h
-        AcidBaseCatalog/AcidBaseCatalogEntry.h
+	    DEST GraphMol/MolStandardize/FragmentCatalog)
+
+rdkit_headers(AcidBaseCatalog/AcidBaseCatalogEntry.h
         AcidBaseCatalog/AcidBaseCatalogParams.h
         AcidBaseCatalog/AcidBaseCatalogUtils.h
-        TransformCatalog/TransformCatalogEntry.h
+	    DEST GraphMol/MolStandardize/AcidBaseCatalog)
+
+rdkit_headers(TransformCatalog/TransformCatalogEntry.h
         TransformCatalog/TransformCatalogParams.h
         TransformCatalog/TransformCatalogUtils.h
-        TautomerCatalog/TautomerCatalogEntry.h
+	    DEST GraphMol/MolStandardize/TransformCatalog)
+
+rdkit_headers(TautomerCatalog/TautomerCatalogEntry.h
         TautomerCatalog/TautomerCatalogParams.h
         TautomerCatalog/TautomerCatalogUtils.h
-	      DEST GraphMol/MolStandardize)
+	    DEST GraphMol/MolStandardize/TautomerCatalog)
 
 if(RDK_BUILD_PYTHON_WRAPPERS)
 add_subdirectory(Wrap)

--- a/Code/RDGeneral/CMakeLists.txt
+++ b/Code/RDGeneral/CMakeLists.txt
@@ -61,9 +61,10 @@ rdkit_headers(Exceptions.h
               export.h
               test.h
               DEST RDGeneral)
+
 if (NOT RDK_INSTALL_INTREE)
-  install(DIRECTORY hash DESTINATION ${RDKit_HdrDir}/RDGeneral/hash
-        PATTERN ".svn" EXCLUDE)
+  install(DIRECTORY hash DESTINATION ${RDKit_HdrDir}/RDGeneral)
 endif (NOT RDK_INSTALL_INTREE)
+
 rdkit_test(testDict testDict.cpp LINK_LIBRARIES RDGeneral)
 rdkit_test(testRDValue testRDValue.cpp LINK_LIBRARIES RDGeneral)


### PR DESCRIPTION
Installing RDKit breaks the directory structure for headers: directories under Graphmol/ChemReactions/ and Graphmol/MolStandardize/ get flattened.

So if you include, e.g. Graphmol/ChemReactions/Enumerate.h, it includes EnumerateBase.h, which in turn includes "../Reaction.h", which in the source is in the parent directory but in the installation is in the same directory as Enumerate.h and EnumerateBase.h, instead of in the parent directory as specified, thus breaking the build.

I patched the CMakeFiles to reproduce the same directory structure as in the sources.

Also, some header files that get included from other header files are not included in the installation, e.g. EnumerateTypes.h or Target.h. I added those to the installation.

Finally, path "hash" under RDGeneral gets duplicated in the installation, effectively placing its content at ${installed_include_path}/RDGeneral/hash/hash/*. When I patched this, I removed the exclusion of ".svn" as I couldn't find it anymore.


