### PR TITLE
Make the cartridge tests work with PostgreSQL 12

### DIFF
--- a/Code/PgSQL/rdkit/expected/avalon.out
+++ b/Code/PgSQL/rdkit/expected/avalon.out
@@ -1,3 +1,4 @@
+SET extra_float_digits=0;
 select tanimoto_sml(avalon_fp('c1ccccc1'::mol),avalon_fp('c1ccccc1'::mol));
  tanimoto_sml 
 --------------

--- a/Code/PgSQL/rdkit/expected/bfpgist-91.out
+++ b/Code/PgSQL/rdkit/expected/bfpgist-91.out
@@ -1,3 +1,4 @@
+SET extra_float_digits=0;
 CREATE INDEX fpidx ON pgbfp USING gist (f);
 CREATE INDEX maccsfpidx ON pgbfp USING gist (maccsf);
 SET rdkit.tanimoto_threshold = 0.5;

--- a/Code/PgSQL/rdkit/expected/fps.out
+++ b/Code/PgSQL/rdkit/expected/fps.out
@@ -1,3 +1,4 @@
+SET extra_float_digits=0;
 SELECT dice_sml(rdkit_fp('c1ccccc1'::mol),rdkit_fp('c1ccncc1'::mol));
      dice_sml      
 -------------------

--- a/Code/PgSQL/rdkit/expected/props.out
+++ b/Code/PgSQL/rdkit/expected/props.out
@@ -1,3 +1,4 @@
+SET extra_float_digits=0;
 SELECT mol_amw('c1ccccc1'::mol) mol_amw;
  mol_amw 
 ---------

--- a/Code/PgSQL/rdkit/expected/rdkit-91.out
+++ b/Code/PgSQL/rdkit/expected/rdkit-91.out
@@ -5,6 +5,7 @@
 SET client_min_messages = warning;
 \set ECHO none
 RESET client_min_messages;
+SET extra_float_digits=0;
 SELECT is_valid_smiles('c1ccccc1');
  is_valid_smiles 
 -----------------

--- a/Code/PgSQL/rdkit/expected/reaction.out
+++ b/Code/PgSQL/rdkit/expected/reaction.out
@@ -1,3 +1,4 @@
+SET extra_float_digits=0;
 PREPARE dummy AS SELECT rdkit_version();
 SET rdkit.ignore_reaction_agents=false;
 SET rdkit.agent_FP_bit_ratio=0.2;

--- a/Code/PgSQL/rdkit/expected/sfpgist.out
+++ b/Code/PgSQL/rdkit/expected/sfpgist.out
@@ -1,3 +1,4 @@
+SET extra_float_digits=0;
 CREATE INDEX fpidx ON pgsfp USING gist (f);
 SET rdkit.tanimoto_threshold = 0.6;
 SET rdkit.dice_threshold = 0.6;

--- a/Code/PgSQL/rdkit/expected/slfpgist.out
+++ b/Code/PgSQL/rdkit/expected/slfpgist.out
@@ -1,3 +1,4 @@
+SET extra_float_digits=0;
 CREATE INDEX fpidx ON pgsfp USING gist (f gist_sfp_low_ops);
 SET rdkit.tanimoto_threshold = 0.6;
 SET rdkit.dice_threshold = 0.6;

--- a/Code/PgSQL/rdkit/sql/avalon.sql
+++ b/Code/PgSQL/rdkit/sql/avalon.sql
@@ -1,3 +1,4 @@
+SET extra_float_digits=0;
 select tanimoto_sml(avalon_fp('c1ccccc1'::mol),avalon_fp('c1ccccc1'::mol));
 select tanimoto_sml(avalon_fp('c1ccccc1'::mol),avalon_fp('c1ccccc1'::mol,true));
 select tanimoto_sml(avalon_fp('c1ccccc1'::mol),avalon_fp('c1ccccn1'::mol));

--- a/Code/PgSQL/rdkit/sql/bfpgist-91.sql
+++ b/Code/PgSQL/rdkit/sql/bfpgist-91.sql
@@ -1,3 +1,4 @@
+SET extra_float_digits=0;
 CREATE INDEX fpidx ON pgbfp USING gist (f);
 CREATE INDEX maccsfpidx ON pgbfp USING gist (maccsf);
 

--- a/Code/PgSQL/rdkit/sql/fps.sql
+++ b/Code/PgSQL/rdkit/sql/fps.sql
@@ -1,3 +1,4 @@
+SET extra_float_digits=0;
 SELECT dice_sml(rdkit_fp('c1ccccc1'::mol),rdkit_fp('c1ccncc1'::mol));
 SELECT tversky_sml(rdkit_fp('c1ccccc1'::mol),rdkit_fp('c1ccncc1'::mol),0.5,0.5);
 SELECT tanimoto_sml(rdkit_fp('c1ccccc1'::mol),rdkit_fp('c1ccncc1'::mol));

--- a/Code/PgSQL/rdkit/sql/props.sql
+++ b/Code/PgSQL/rdkit/sql/props.sql
@@ -1,3 +1,4 @@
+SET extra_float_digits=0;
 SELECT mol_amw('c1ccccc1'::mol) mol_amw;
 SELECT mol_logp('c1ccccc1'::mol) mol_logp;
 SELECT mol_hba('c1ccccc1'::mol) mol_hba;

--- a/Code/PgSQL/rdkit/sql/rdkit-91.sql
+++ b/Code/PgSQL/rdkit/sql/rdkit-91.sql
@@ -7,6 +7,7 @@ SET client_min_messages = warning;
 CREATE EXTENSION rdkit;
 \set ECHO all
 RESET client_min_messages;
+SET extra_float_digits=0;
 
 SELECT is_valid_smiles('c1ccccc1');
 SELECT mol_from_smiles('c1ccccc1');

--- a/Code/PgSQL/rdkit/sql/reaction.sql
+++ b/Code/PgSQL/rdkit/sql/reaction.sql
@@ -1,3 +1,4 @@
+SET extra_float_digits=0;
 PREPARE dummy AS SELECT rdkit_version();
 SET rdkit.ignore_reaction_agents=false;
 SET rdkit.agent_FP_bit_ratio=0.2;

--- a/Code/PgSQL/rdkit/sql/sfpgist.sql
+++ b/Code/PgSQL/rdkit/sql/sfpgist.sql
@@ -1,3 +1,4 @@
+SET extra_float_digits=0;
 CREATE INDEX fpidx ON pgsfp USING gist (f);
 
 SET rdkit.tanimoto_threshold = 0.6;

--- a/Code/PgSQL/rdkit/sql/slfpgist.sql
+++ b/Code/PgSQL/rdkit/sql/slfpgist.sql
@@ -1,3 +1,4 @@
+SET extra_float_digits=0;
 CREATE INDEX fpidx ON pgsfp USING gist (f gist_sfp_low_ops);
 
 SET rdkit.tanimoto_threshold = 0.6;


### PR DESCRIPTION
The problem was test output that didn't match what was expected due to the "Improve performance by using a new algorithm for output of real and double precision values" change in PostgreSQL 12:
https://www.postgresql.org/docs/12/release-12.html

We change the output `extra_float_digits` setting to get postgresql 12 to behave like previous versions.

This came up in the discussion of #2700 