### PR TITLE
Salt stripper should consider bond matches as well as atom matches

### DIFF
--- a/Code/GraphMol/MolStandardize/Fragment.cpp
+++ b/Code/GraphMol/MolStandardize/Fragment.cpp
@@ -91,6 +91,7 @@ ROMol *FragmentRemover::remove(const ROMol &mol) {
                     [&fgci](const std::pair<boost::shared_ptr<ROMol>,
                                             unsigned int> &frag) -> bool {
                       return fgci->getNumAtoms() == frag.first->getNumAtoms() &&
+                             fgci->getNumBonds() == frag.first->getNumBonds() &&
                              SubstructMatch(*frag.first, *fgci).size() > 0;
                     }),
                 frags.end());


### PR DESCRIPTION
Fragments were being incorrectly removed from molecules because the salt stripper was only considering that the number of atoms in the fragment has to match the number of atoms in the molecule, 

The specific example that brought this up was this salt definition (benethamine):
![image](https://user-images.githubusercontent.com/540511/68394862-e3e9c480-016e-11ea-9ace-9fd34286b8d1.png)

which was matching:
![image](https://user-images.githubusercontent.com/540511/68394903-f6fc9480-016e-11ea-9199-d4bebee82de5.png)

The simple fix is to just consider bond counts as well as atom counts when considering whether or not a fragment matches.