### PR TITLE
Add OFFTK to open-source users

### DIFF
--- a/Docs/Book/Overview.md
+++ b/Docs/Book/Overview.md
@@ -50,6 +50,7 @@
 ## Usage by other open-source projects
 This will, inevitably, be out of date. If you know of others, please let us know or submit a pull request!
 
+- [Open Force Field Toolkit](https://github.com/openforcefield/openforcefield/) - A parametrization engine for force fields based on direct chemical perception.
 - [stk](https://github.com/lukasturcani/stk) ([docs](https://lukasturcani.github.io/stk/docs/build/html/), [paper](https://onlinelibrary.wiley.com/doi/10.1002/jcc.25377)) -
 a Python library for building, manipulating, analyzing and automatic design of molecules.
 - [gpusimilarity](https://github.com/schrodinger/gpusimilarity) - A Cuda/Thrust implementation of fingerprint similarity searching
@@ -76,7 +77,6 @@ a Python library for building, manipulating, analyzing and automatic design of m
 - [Vernalis KNIME nodes](https://www.knime.com/book/vernalis-nodes-for-knime-trusted-extension)
 - [Erlwood KNIME nodes](https://www.knime.com/community/erlwood)
 - [AZOrange](https://github.com/AZcompTox/AZOrange)
-- [Open Force Field Toolkit](https://github.com/openforcefield/openforcefield/) - A parametrization engine for force fields based on direct chemical perception.
 
 
 ## The Contrib Directory

--- a/Docs/Book/Overview.md
+++ b/Docs/Book/Overview.md
@@ -76,6 +76,7 @@ a Python library for building, manipulating, analyzing and automatic design of m
 - [Vernalis KNIME nodes](https://www.knime.com/book/vernalis-nodes-for-knime-trusted-extension)
 - [Erlwood KNIME nodes](https://www.knime.com/community/erlwood)
 - [AZOrange](https://github.com/AZcompTox/AZOrange)
+- [Open Force Field Toolkit](https://github.com/openforcefield/openforcefield/) - A parametrization engine for force fields based on direct chemical perception.
 
 
 ## The Contrib Directory


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! 
-->
#### Reference Issue
None


#### What does this implement/fix? Explain your changes.
Adds the Open Force Field toolkit to the list of open-source packages that use RDKit

#### Any other comments?
A truly open-source OFF toolkit wouldn't be possible without RDKit. Thanks to @greglandrum and all of the other maintainers for their hard work!
