### PR TITLE
Fix build without boost serialization library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -361,6 +361,8 @@ if(RDK_USE_BOOST_SERIALIZATION)
     find_package(Boost 1.56.0 COMPONENTS serialization)
     if (Boost_SERIALIZATION_LIBRARY)
       set(Boost_LIBRARIES ${T_LIBS} ${Boost_LIBRARIES})
+    else()
+      set(Boost_LIBRARIES ${T_LIBS})
     endif()
 endif()
 


### PR DESCRIPTION
When serialization library is not found CMakeLists.txt would clear out
${Boost_LIBRARIES} var, breaking linkage of Python bindings (at least).

----

We've hit this while building RDKit locally with minimum of Boost libraries installed.

I can't resist linking this great wiki page: https://wiki.gentoo.org/wiki/Project:Quality_Assurance/Automagic_dependencies#What_are_automagic_dependencies.3F (this section and the next one).