### PR TITLE
Fix MolHash compile with VS2015 - fixes #2752

### DIFF
--- a/Code/GraphMol/MolHash/hashfunctions.cpp
+++ b/Code/GraphMol/MolHash/hashfunctions.cpp
@@ -680,7 +680,7 @@ static std::string ArthorSubOrderHash(RWMol *mol) {
   return buffer;
 }
 
-std::string MolHash(RWMol *mol, enum HashFunction func) {
+std::string MolHash(RWMol *mol, HashFunction func) {
   std::string result;
   char buffer[32];
   NMRDKitSanitizeHydrogens(mol);

--- a/Code/GraphMol/MolHash/nmmolhash.h
+++ b/Code/GraphMol/MolHash/nmmolhash.h
@@ -42,7 +42,7 @@ enum class RDKIT_MOLHASH_EXPORT HashFunction {
   ArthorSubstructureOrder = 17
 };
 
-RDKIT_MOLHASH_EXPORT std::string MolHash(RWMol *mol, enum HashFunction func);
+RDKIT_MOLHASH_EXPORT std::string MolHash(RWMol *mol, HashFunction func);
 
 enum class RDKIT_MOLHASH_EXPORT StripType {
   AtomStereo = 1,


### PR DESCRIPTION
Just realised we missed this for v2019.09.2.
<!--
Thanks for contributing a pull request! 
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->
 Fixes #2752

#### What does this implement/fix? Explain your changes.
Changes as recommended by Greg in #2752.

#### Any other comments?
Patch currently in conda-forge recipe: https://github.com/conda-forge/rdkit-feedstock/pull/38/commits/a495c5ac3b6685c317c6199fdb78059386560601
