### PR TITLE
small documentation fix in enumeration examples

### DIFF
--- a/Code/GraphMol/ChemReactions/Wrap/Enumerate.cpp
+++ b/Code/GraphMol/ChemReactions/Wrap/Enumerate.cpp
@@ -265,7 +265,7 @@ template and products2 are the molecule products for the second product\n\
 template.  Since each reactant can match more than once, there may be\n\
 multiple product molecules for each template.\n\
 \n\
-for result in library:\n\
+for products in library:\n\
     for results_for_product_template in products:\n\
         for mol in results_for_product_template:\n\
             Chem.MolToSmiles(mol) # finally have a molecule!\n\


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! 
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->
Small documentation fix

#### What does this implement/fix? Explain your changes.
The library enumeration had some example code available here https://www.rdkit.org/docs/source/rdkit.Chem.rdChemReactions.html which is wrong for this part : 
`for result in library:
   for results_for_product_template in products:
   for mol in results_for_product_template:
   Chem.MolToSmiles(mol) # finally have a molecule!`

result should be products 

#### Any other comments?

