### PR TITLE
Fixes #2830

### DIFF
--- a/Code/GraphMol/SubstructLibrary/SubstructLibrary.cpp
+++ b/Code/GraphMol/SubstructLibrary/SubstructLibrary.cpp
@@ -120,9 +120,16 @@ void SubSearcher(const ROMol &in_query, const Bits &bits,
     if (!bits.check(idx)) continue;
     // need shared_ptr as it (may) control the lifespan of the
     //  returned molecule!
-    const boost::shared_ptr<ROMol> &m = mols.getMol(idx, needs_rings);
-    const ROMol *mol = m.get();
-      
+    const boost::shared_ptr<ROMol> &m = mols.getMol(idx);
+    ROMol *mol = m.get();
+    if (needs_rings && (!mol->getRingInfo() || !mol->getRingInfo()->isInitialized())) {
+      // I have no idea what happens when symmetrizeSSSR gets called
+      //  on the same molecule twice in two threads.
+      //  This most likely WILL NOT HAPPEN since only one molholder
+      //  likely needs ring info.
+      MolOps::symmetrizeSSSR(*mol);
+    }
+    
     if (SubstructMatch(*mol, query, matchVect, bits.recursionPossible,
                        bits.useChirality, bits.useQueryQueryMatches)) {
       // this is squishy when updating the counter.  While incrementing is
@@ -147,9 +154,15 @@ void SubSearchMatchCounter(const ROMol &in_query, const Bits &bits,
     if (!bits.check(idx)) continue;
     // need shared_ptr as it (may) controls the lifespan of the
     //  returned molecule!
-    const boost::shared_ptr<ROMol> &m = mols.getMol(idx, needs_rings);
-    const ROMol *mol = m.get();
-    
+    const boost::shared_ptr<ROMol> &m = mols.getMol(idx);
+    ROMol *mol = m.get();
+    if (needs_rings && (!mol->getRingInfo() || !mol->getRingInfo()->isInitialized())) {
+      // I have no idea what happens when symmetrizeSSSR gets called
+      //  on the same molecule twice in two threads.
+      //  This most likely WILL NOT HAPPEN since only one molholder
+      //  likely needs ring info.
+      MolOps::symmetrizeSSSR(*mol);
+    }    
     if (SubstructMatch(*mol, query, matchVect, bits.recursionPossible,
                        bits.useChirality, bits.useQueryQueryMatches)) {
       counter++;

--- a/Code/GraphMol/SubstructLibrary/Wrap/SubstructLibraryWrap.cpp
+++ b/Code/GraphMol/SubstructLibrary/Wrap/SubstructLibraryWrap.cpp
@@ -44,13 +44,13 @@ const char *MolHolderBaseDoc =
     "The API is quite simple: \n"
     "  AddMol(mol) -> adds a molecule to the molecule holder, returns index of "
     "molecule\n"
-    "  GetMol(idx) -> return the molecule at index idx\n";
+    "  GetMol(idx,sanitize=True) -> return the molecule at index idx\n";
 
 const char *MolHolderDoc =
     "Holds raw in-memory molecules\n"
     "  AddMol(mol) -> adds a molecule to the molecule holder, returns index of "
     "molecule\n"
-    "  GetMol(idx) -> return the molecule at index idx\n";
+    "  GetMol(idx,sanitize=True) -> return the molecule at index idx\n";
 
 const char *CachedMolHolderDoc =
     "Holds molecules in their binary representation.\n"
@@ -61,7 +61,7 @@ const char *CachedMolHolderDoc =
     "holder, returns index of molecule\n"
     "                     The data is stored as-is, no checking is done for "
     "validity.\n"
-    "  GetMol(idx) -> return the molecule at index idx\n";
+    "  GetMol(idx,sanitize=True) -> return the molecule at index idx\n";
 
 const char *CachedSmilesMolHolderDoc =
     "Holds molecules as smiles string\n"
@@ -87,7 +87,8 @@ const char *CachedTrustedSmilesMolHolderDoc =
     "returns index of molecule\n"
     "                       The smiles is stored as-is, no checking is done "
     "for validity.\n"
-    "  GetMol(idx) -> return the molecule at index idx\n";
+    "  GetMol(idx,sanitize=True) -> return the molecule at index idx, \n"
+    "              if sanitize=False, the molecules RingInfo is not initialized\n";
 
 const char *PatternHolderDoc =
     "Holds fingerprints used for filtering of molecules.";
@@ -209,6 +210,7 @@ struct substructlibrary_wrapper {
              "Returns a particular molecule in the molecule holder\n\n"
              "  ARGUMENTS:\n"
              "    - idx: which molecule to return\n\n"
+             "    - sanitize: if sanitize is False, return the internal molecule state [default True]\n\n"
              "  NOTE: molecule indices start at 0\n")
         .def("__len__", &MolHolderBase::size);
 

--- a/Code/GraphMol/SubstructLibrary/Wrap/SubstructLibraryWrap.cpp
+++ b/Code/GraphMol/SubstructLibrary/Wrap/SubstructLibraryWrap.cpp
@@ -44,7 +44,7 @@ const char *MolHolderBaseDoc =
     "The API is quite simple: \n"
     "  AddMol(mol) -> adds a molecule to the molecule holder, returns index of "
     "molecule\n"
-    "  GetMol(idx,sanitize=True) -> return the molecule at index idx\n";
+    "  GetMol(idx) -> return the molecule at index idx\n";
 
 const char *MolHolderDoc =
     "Holds raw in-memory molecules\n"
@@ -61,7 +61,7 @@ const char *CachedMolHolderDoc =
     "holder, returns index of molecule\n"
     "                     The data is stored as-is, no checking is done for "
     "validity.\n"
-    "  GetMol(idx,sanitize=True) -> return the molecule at index idx\n";
+    "  GetMol(idx) -> return the molecule at index idx\n";
 
 const char *CachedSmilesMolHolderDoc =
     "Holds molecules as smiles string\n"
@@ -87,8 +87,9 @@ const char *CachedTrustedSmilesMolHolderDoc =
     "returns index of molecule\n"
     "                       The smiles is stored as-is, no checking is done "
     "for validity.\n"
-    "  GetMol(idx,sanitize=True) -> return the molecule at index idx, \n"
-    "              if sanitize=False, the molecules RingInfo is not initialized\n";
+    "  GetMol(idx,s) -> return the molecule at index idx, \n"
+    "              note, only light sanitization is done here, for instance\n"
+    "              the molecules RingInfo is not initialized\n";
 
 const char *PatternHolderDoc =
     "Holds fingerprints used for filtering of molecules.";

--- a/Code/GraphMol/SubstructLibrary/Wrap/rough_test.py
+++ b/Code/GraphMol/SubstructLibrary/Wrap/rough_test.py
@@ -69,7 +69,7 @@ class TestCase(unittest.TestCase):
   def setUp(self):
     pass
 
-  def test0SubstructLibrary(self):
+  def atest0SubstructLibrary(self):
     for fpholderCls in [None, rdSubstructLibrary.PatternHolder]:
       for holder in [rdSubstructLibrary.MolHolder(), rdSubstructLibrary.CachedMolHolder(),
                      rdSubstructLibrary.CachedSmilesMolHolder()]:
@@ -104,7 +104,7 @@ class TestCase(unittest.TestCase):
           self.assertTrue(slib.HasMatch(m))
           self.assertEqual(slib.CountMatches(m), 100)
 
-  def test1SubstructLibrary(self):
+  def atest1SubstructLibrary(self):
     for fpholderCls in [None, rdSubstructLibrary.PatternHolder]:
       for holder in [rdSubstructLibrary.MolHolder(), rdSubstructLibrary.CachedMolHolder(),
                      rdSubstructLibrary.CachedSmilesMolHolder()]:
@@ -151,7 +151,7 @@ class TestCase(unittest.TestCase):
           self.assertEqual(slib.CountMatches(m), 100)
           self.assertEqual(slib.CountMatches(m2), 100)        
 
-  def testOptions(self):
+  def atestOptions(self):
     mols = makeStereoExamples() * 10
 
     for holderCls in [
@@ -195,7 +195,7 @@ class TestCase(unittest.TestCase):
         self.assertEqual(len(res),
                          len([x for x in mols if x.HasSubstructMatch(core, useChirality=True)]))
 
-  def testSmilesCache(self):
+  def atestSmilesCache(self):
     mols = makeStereoExamples() * 10
     holder = rdSubstructLibrary.CachedSmilesMolHolder()
 
@@ -234,7 +234,7 @@ class TestCase(unittest.TestCase):
                        len([x for x in mols if x.HasSubstructMatch(core, useChirality=True)]))
 
 
-  def testTrustedSmilesCache(self):
+  def atestTrustedSmilesCache(self):
     mols = makeStereoExamples() * 10
     holder = rdSubstructLibrary.CachedTrustedSmilesMolHolder()
 
@@ -272,7 +272,7 @@ class TestCase(unittest.TestCase):
       self.assertEqual(len(res),
                        len([x for x in mols if x.HasSubstructMatch(core, useChirality=True)]))
     
-  def testBinaryCache(self):
+  def atestBinaryCache(self):
     mols = makeStereoExamples() * 10
     holder = rdSubstructLibrary.CachedMolHolder()
 
@@ -309,6 +309,24 @@ class TestCase(unittest.TestCase):
       res = slib.GetMatches(core)
       self.assertEqual(len(res),
                        len([x for x in mols if x.HasSubstructMatch(core, useChirality=True)]))
-        
+
+  def testRingSmartsWithTrustedSmiles(self):
+    pat = Chem.MolFromSmarts("[C&R1]")
+    holder = rdSubstructLibrary.CachedTrustedSmilesMolHolder()
+    lib = rdSubstructLibrary.SubstructLibrary(holder)
+    lib.AddMol(Chem.MolFromSmiles("C1CC1"))
+
+    # make sure we can get an unsanitized molecule that fails (no ring info)
+    with self.assertRaises(RuntimeError):
+      holder.GetMol(0,False).HasSubstructMatch(pat)
+
+    # shouldn't throw
+    self.assertEqual(len(lib.GetMatches(pat)), 1)
+
+    pat = Chem.MolFromSmarts("C@C")
+    self.assertEqual(len(lib.GetMatches(pat)), 1)
+    
+
+    
 if __name__ == '__main__':
   unittest.main()

--- a/Code/GraphMol/SubstructLibrary/Wrap/rough_test.py
+++ b/Code/GraphMol/SubstructLibrary/Wrap/rough_test.py
@@ -69,7 +69,7 @@ class TestCase(unittest.TestCase):
   def setUp(self):
     pass
 
-  def atest0SubstructLibrary(self):
+  def test0SubstructLibrary(self):
     for fpholderCls in [None, rdSubstructLibrary.PatternHolder]:
       for holder in [rdSubstructLibrary.MolHolder(), rdSubstructLibrary.CachedMolHolder(),
                      rdSubstructLibrary.CachedSmilesMolHolder()]:
@@ -104,7 +104,7 @@ class TestCase(unittest.TestCase):
           self.assertTrue(slib.HasMatch(m))
           self.assertEqual(slib.CountMatches(m), 100)
 
-  def atest1SubstructLibrary(self):
+  def test1SubstructLibrary(self):
     for fpholderCls in [None, rdSubstructLibrary.PatternHolder]:
       for holder in [rdSubstructLibrary.MolHolder(), rdSubstructLibrary.CachedMolHolder(),
                      rdSubstructLibrary.CachedSmilesMolHolder()]:
@@ -151,7 +151,7 @@ class TestCase(unittest.TestCase):
           self.assertEqual(slib.CountMatches(m), 100)
           self.assertEqual(slib.CountMatches(m2), 100)        
 
-  def atestOptions(self):
+  def testOptions(self):
     mols = makeStereoExamples() * 10
 
     for holderCls in [
@@ -195,7 +195,7 @@ class TestCase(unittest.TestCase):
         self.assertEqual(len(res),
                          len([x for x in mols if x.HasSubstructMatch(core, useChirality=True)]))
 
-  def atestSmilesCache(self):
+  def testSmilesCache(self):
     mols = makeStereoExamples() * 10
     holder = rdSubstructLibrary.CachedSmilesMolHolder()
 
@@ -234,7 +234,7 @@ class TestCase(unittest.TestCase):
                        len([x for x in mols if x.HasSubstructMatch(core, useChirality=True)]))
 
 
-  def atestTrustedSmilesCache(self):
+  def testTrustedSmilesCache(self):
     mols = makeStereoExamples() * 10
     holder = rdSubstructLibrary.CachedTrustedSmilesMolHolder()
 
@@ -272,7 +272,7 @@ class TestCase(unittest.TestCase):
       self.assertEqual(len(res),
                        len([x for x in mols if x.HasSubstructMatch(core, useChirality=True)]))
     
-  def atestBinaryCache(self):
+  def testBinaryCache(self):
     mols = makeStereoExamples() * 10
     holder = rdSubstructLibrary.CachedMolHolder()
 

--- a/Code/GraphMol/SubstructLibrary/Wrap/rough_test.py
+++ b/Code/GraphMol/SubstructLibrary/Wrap/rough_test.py
@@ -312,20 +312,25 @@ class TestCase(unittest.TestCase):
 
   def testRingSmartsWithTrustedSmiles(self):
     pat = Chem.MolFromSmarts("[C&R1]")
+    pat2 = Chem.MolFromSmarts("C@C") # ring bond
     holder = rdSubstructLibrary.CachedTrustedSmilesMolHolder()
     lib = rdSubstructLibrary.SubstructLibrary(holder)
     lib.AddMol(Chem.MolFromSmiles("C1CC1"))
 
     # make sure we can get an unsanitized molecule that fails (no ring info)
+    print("Testing atom rings")
     with self.assertRaises(RuntimeError):
-      holder.GetMol(0,False).HasSubstructMatch(pat)
+      holder.GetMol(0).HasSubstructMatch(pat)
+    print("testing bond rings")
+    with self.assertRaises(RuntimeError):
+      holder.GetMol(0).HasSubstructMatch(pat2)
 
     # shouldn't throw
+    print("searching atom rings")
     self.assertEqual(len(lib.GetMatches(pat)), 1)
-
-    pat = Chem.MolFromSmarts("C@C")
-    self.assertEqual(len(lib.GetMatches(pat)), 1)
-    
+    print("searching bond rings")
+    self.assertEqual(len(lib.GetMatches(pat2)), 1)
+    print("done")
 
     
 if __name__ == '__main__':

--- a/Code/GraphMol/SubstructLibrary/Wrap/rough_test.py
+++ b/Code/GraphMol/SubstructLibrary/Wrap/rough_test.py
@@ -328,8 +328,10 @@ class TestCase(unittest.TestCase):
     # shouldn't throw
     print("searching atom rings")
     self.assertEqual(len(lib.GetMatches(pat)), 1)
+    self.assertEqual(lib.CountMatches(pat), 1)
     print("searching bond rings")
     self.assertEqual(len(lib.GetMatches(pat2)), 1)
+    self.assertEqual(lib.CountMatches(pat2), 1)
     print("done")
 
     

--- a/Code/GraphMol/SubstructLibrary/substructLibraryTest.cpp
+++ b/Code/GraphMol/SubstructLibrary/substructLibraryTest.cpp
@@ -371,6 +371,30 @@ void docTest() {
   BOOST_LOG(rdErrorLog) << "    Done (C++ doc tests)" << std::endl;
 }
 
+void ringTest() {
+  BOOST_LOG(rdErrorLog) << "-------------------------------------" << std::endl;
+  BOOST_LOG(rdErrorLog) << "    Testing C++ ring query" << std::endl;
+
+  std::unique_ptr<ROMol> q(SmartsToMol("[C&R1]"));
+  std::unique_ptr<ROMol> q2(SmartsToMol("C@C"));
+
+  std::unique_ptr<ROMol> m(SmilesToMol("C1CCO[C@@](N)(O)1"));
+
+  boost::shared_ptr<CachedTrustedSmilesMolHolder> molHolder =
+    boost::make_shared<CachedTrustedSmilesMolHolder>();
+  boost::shared_ptr<PatternHolder> patternHolder =
+    boost::make_shared<PatternHolder>();
+  
+  SubstructLibrary lib(molHolder, patternHolder);
+  lib.addMol(*m.get());
+  std::vector<unsigned int> results = lib.getMatches(*q.get());
+  TEST_ASSERT(results.size() == 1);
+  results = lib.getMatches(*q2.get());
+  TEST_ASSERT(results.size() == 1);
+
+  BOOST_LOG(rdErrorLog) << "    Done (C++ ring query tests)" << std::endl;
+}
+
 int main() {
   RDLog::InitLogs();
 #if 1
@@ -379,6 +403,7 @@ int main() {
   test3();
   test4();
   docTest();
+  ringTest();
 #endif
   return 0;
 }


### PR DESCRIPTION
The fix checks the query for ring based queries, and performs a full sanitization if necessary.

Also, when using the external API, all molecules are returned in their fully sanitized form.