### PR TITLE
Tidy Up

### DIFF
--- a/Code/DataStructs/DatastructsException.h
+++ b/Code/DataStructs/DatastructsException.h
@@ -20,7 +20,7 @@ class RDKIT_DATASTRUCTS_EXPORT DatastructsException : public std::exception {
   DatastructsException(const std::string &msg) : _msg(msg){};
   //! get the error message
   const char *message() const { return _msg.c_str(); };
-  ~DatastructsException() throw(){};
+  ~DatastructsException() noexcept {};
 
  private:
   std::string _msg;

--- a/Code/Demos/RDKit/Basement/TemplEnum/TemplEnum.h
+++ b/Code/Demos/RDKit/Basement/TemplEnum/TemplEnum.h
@@ -17,7 +17,7 @@ class EnumException : public std::exception {
   EnumException(const char *msg) : _msg(msg){};
   EnumException(const std::string msg) : _msg(msg){};
   const char *message() const { return _msg.c_str(); };
-  ~EnumException() throw(){};
+  ~EnumException() noexcept {};
 
  private:
   std::string _msg;

--- a/Code/Geometry/Grid3D.h
+++ b/Code/Geometry/Grid3D.h
@@ -27,7 +27,7 @@ class RDKIT_RDGEOMETRYLIB_EXPORT GridException : public std::exception {
   GridException(const std::string &msg) : _msg(msg){};
   //! get the error message
   const char *message() const { return _msg.c_str(); };
-  ~GridException() throw(){};
+  ~GridException() noexcept {};
 
  private:
   std::string _msg;

--- a/Code/Geometry/UniformGrid3D.cpp
+++ b/Code/Geometry/UniformGrid3D.cpp
@@ -39,6 +39,7 @@ UniformGrid3D &UniformGrid3D::operator=(const UniformGrid3D &other) {
   initGrid(other.d_numX * other.d_spacing, other.d_numY * other.d_spacing,
            other.d_numZ * other.d_spacing, other.d_spacing,
            other.dp_storage->getValueType(), other.d_offSet, data);
+  return *this;
 }
 
 void UniformGrid3D::initGrid(

--- a/Code/GraphMol/ChemReactions/Enumerate/EnumerationStrategyBase.h
+++ b/Code/GraphMol/ChemReactions/Enumerate/EnumerationStrategyBase.h
@@ -59,7 +59,7 @@ class RDKIT_CHEMREACTIONS_EXPORT EnumerationStrategyException
   EnumerationStrategyException(const char *msg) : _msg(msg){};
   EnumerationStrategyException(const std::string &msg) : _msg(msg){};
   const char *message() const { return _msg.c_str(); };
-  ~EnumerationStrategyException() throw(){};
+  ~EnumerationStrategyException() noexcept {};
 
  private:
   std::string _msg;

--- a/Code/GraphMol/ChemReactions/Reaction.h
+++ b/Code/GraphMol/ChemReactions/Reaction.h
@@ -52,7 +52,7 @@ class RDKIT_CHEMREACTIONS_EXPORT ChemicalReactionException
   explicit ChemicalReactionException(const std::string msg) : _msg(msg){};
   //! get the error message
   const char *message() const { return _msg.c_str(); };
-  ~ChemicalReactionException() throw(){};
+  ~ChemicalReactionException() noexcept {};
 
  private:
   std::string _msg;

--- a/Code/GraphMol/ChemReactions/ReactionParser.h
+++ b/Code/GraphMol/ChemReactions/ReactionParser.h
@@ -51,7 +51,7 @@ class RDKIT_CHEMREACTIONS_EXPORT ChemicalReactionParserException
       : _msg(msg){};
   //! get the error message
   const char *message() const { return _msg.c_str(); };
-  ~ChemicalReactionParserException() throw(){};
+  ~ChemicalReactionParserException() noexcept {};
 
  private:
   std::string _msg;

--- a/Code/GraphMol/ChemReactions/ReactionPickler.h
+++ b/Code/GraphMol/ChemReactions/ReactionPickler.h
@@ -31,7 +31,7 @@ class RDKIT_CHEMREACTIONS_EXPORT ReactionPicklerException
   ReactionPicklerException(const char *msg) : _msg(msg){};
   ReactionPicklerException(const std::string msg) : _msg(msg){};
   const char *message() const { return _msg.c_str(); };
-  ~ReactionPicklerException() throw(){};
+  ~ReactionPicklerException() noexcept {};
 
  private:
   std::string _msg;

--- a/Code/GraphMol/ChemReactions/SanitizeRxn.h
+++ b/Code/GraphMol/ChemReactions/SanitizeRxn.h
@@ -46,7 +46,7 @@ class RDKIT_CHEMREACTIONS_EXPORT RxnSanitizeException : public std::exception {
   RxnSanitizeException(const char *msg) : _msg(msg){};
   RxnSanitizeException(const std::string &msg) : _msg(msg){};
   const char *message() const { return _msg.c_str(); };
-  ~RxnSanitizeException() throw(){};
+  ~RxnSanitizeException() noexcept {};
 
  private:
   std::string _msg;

--- a/Code/GraphMol/Conformer.h
+++ b/Code/GraphMol/Conformer.h
@@ -28,7 +28,7 @@ class RDKIT_GRAPHMOL_EXPORT ConformerException : public std::exception {
   ConformerException(const std::string &msg) : _msg(msg){};
   //! get the error message
   const char *message() const { return _msg.c_str(); };
-  ~ConformerException() throw(){};
+  ~ConformerException() noexcept {};
 
  private:
   std::string _msg;

--- a/Code/GraphMol/Depictor/RDDepictor.h
+++ b/Code/GraphMol/Depictor/RDDepictor.h
@@ -33,7 +33,7 @@ class RDKIT_DEPICTOR_EXPORT DepictException : public std::exception {
   DepictException(const char *msg) : _msg(msg){};
   DepictException(const std::string msg) : _msg(msg){};
   const char *message() const { return _msg.c_str(); };
-  ~DepictException() throw(){};
+  ~DepictException() noexcept {};
 
  private:
   std::string _msg;

--- a/Code/GraphMol/Fingerprints/FingerprintGenerator.h
+++ b/Code/GraphMol/Fingerprints/FingerprintGenerator.h
@@ -306,7 +306,7 @@ class RDKIT_FINGERPRINTS_EXPORT UnimplementedFPException
   UnimplementedFPException(const std::string &msg) : _msg(msg){};
   //! get the error message
   const char *message() const { return _msg.c_str(); };
-  ~UnimplementedFPException() throw(){};
+  ~UnimplementedFPException() noexcept {};
 
  private:
   std::string _msg;

--- a/Code/GraphMol/MolAlign/AlignMolecules.h
+++ b/Code/GraphMol/MolAlign/AlignMolecules.h
@@ -29,7 +29,7 @@ class RDKIT_MOLALIGN_EXPORT MolAlignException : public std::exception {
   MolAlignException(const std::string msg) : _msg(msg){};
   //! get the error message
   const char *message() const { return _msg.c_str(); };
-  ~MolAlignException() throw(){};
+  ~MolAlignException() noexcept {};
 
  private:
   std::string _msg;

--- a/Code/GraphMol/MolChemicalFeatures/FeatureParser.h
+++ b/Code/GraphMol/MolChemicalFeatures/FeatureParser.h
@@ -28,7 +28,7 @@ class RDKIT_MOLCHEMICALFEATURES_EXPORT FeatureFileParseException
   unsigned int lineNo() const { return d_lineNo; };
   std::string line() const { return d_line; };
   std::string message() const { return d_msg; };
-  ~FeatureFileParseException() throw(){};
+  ~FeatureFileParseException() noexcept {};
 
  private:
   unsigned int d_lineNo;

--- a/Code/GraphMol/MolPickler.h
+++ b/Code/GraphMol/MolPickler.h
@@ -38,7 +38,7 @@ class RDKIT_GRAPHMOL_EXPORT MolPicklerException : public std::exception {
   MolPicklerException(const char *msg) : _msg(msg){};
   MolPicklerException(const std::string msg) : _msg(msg){};
   const char *message() const { return _msg.c_str(); };
-  ~MolPicklerException() throw(){};
+  ~MolPicklerException() noexcept {};
 
  private:
   std::string _msg;

--- a/Code/GraphMol/MolStandardize/Validate.h
+++ b/Code/GraphMol/MolStandardize/Validate.h
@@ -40,7 +40,7 @@ class RDKIT_MOLSTANDARDIZE_EXPORT ValidationErrorInfo : public std::exception {
     BOOST_LOG(rdInfoLog) << d_msg << std::endl;
   };
   const char *message() const { return d_msg.c_str(); };
-  ~ValidationErrorInfo() throw(){};
+  ~ValidationErrorInfo() noexcept {};
 
  private:
   std::string d_msg;

--- a/Code/GraphMol/SLNParse/SLNParse.h
+++ b/Code/GraphMol/SLNParse/SLNParse.h
@@ -59,7 +59,7 @@ class RDKIT_SLNPARSE_EXPORT SLNParseException : public std::exception {
   SLNParseException(const char *msg) : _msg(msg){};
   SLNParseException(const std::string &msg) : _msg(msg){};
   const char *message() const { return _msg.c_str(); };
-  ~SLNParseException() throw(){};
+  ~SLNParseException() noexcept {};
 
  private:
   std::string _msg;

--- a/Code/GraphMol/SanitException.h
+++ b/Code/GraphMol/SanitException.h
@@ -31,7 +31,7 @@ class RDKIT_GRAPHMOL_EXPORT MolSanitizeException : public std::exception {
   MolSanitizeException(const MolSanitizeException &other)
       : d_msg(other.d_msg){};
   virtual const char *message() const { return d_msg.c_str(); };
-  virtual ~MolSanitizeException() throw(){};
+  virtual ~MolSanitizeException() noexcept {};
   virtual MolSanitizeException *copy() const {
     return new MolSanitizeException(*this);
   };
@@ -51,7 +51,7 @@ class RDKIT_GRAPHMOL_EXPORT AtomSanitizeException
   AtomSanitizeException(const AtomSanitizeException &other)
       : MolSanitizeException(other), d_atomIdx(other.d_atomIdx){};
   unsigned int getAtomIdx() const { return d_atomIdx; };
-  virtual ~AtomSanitizeException() throw(){};
+  virtual ~AtomSanitizeException() noexcept {};
   virtual MolSanitizeException *copy() const {
     return new AtomSanitizeException(*this);
   };
@@ -70,7 +70,7 @@ class RDKIT_GRAPHMOL_EXPORT AtomValenceException
       : AtomSanitizeException(msg, atomIdx){};
   AtomValenceException(const AtomValenceException &other)
       : AtomSanitizeException(other){};
-  virtual ~AtomValenceException() throw(){};
+  virtual ~AtomValenceException() noexcept {};
   MolSanitizeException *copy() const {
     return new AtomValenceException(*this);
   };
@@ -86,7 +86,7 @@ class RDKIT_GRAPHMOL_EXPORT AtomKekulizeException
       : AtomSanitizeException(msg, atomIdx){};
   AtomKekulizeException(const AtomKekulizeException &other)
       : AtomSanitizeException(other){};
-  virtual ~AtomKekulizeException() throw(){};
+  virtual ~AtomKekulizeException() noexcept {};
   MolSanitizeException *copy() const {
     return new AtomKekulizeException(*this);
   };
@@ -105,7 +105,7 @@ class RDKIT_GRAPHMOL_EXPORT KekulizeException : public MolSanitizeException {
   const std::vector<unsigned int> &getAtomIndices() const {
     return d_atomIndices;
   };
-  virtual ~KekulizeException() throw(){};
+  virtual ~KekulizeException() noexcept {};
   MolSanitizeException *copy() const { return new KekulizeException(*this); };
   std::string getType() const { return "KekulizeException"; };
 

--- a/Code/GraphMol/SmilesParse/SmilesParse.h
+++ b/Code/GraphMol/SmilesParse/SmilesParse.h
@@ -107,7 +107,7 @@ class RDKIT_SMILESPARSE_EXPORT SmilesParseException : public std::exception {
   SmilesParseException(const char *msg) : _msg(msg){};
   SmilesParseException(const std::string msg) : _msg(msg){};
   const char *message() const { return _msg.c_str(); };
-  ~SmilesParseException() throw(){};
+  ~SmilesParseException() noexcept {};
 
  private:
   std::string _msg;

--- a/Code/GraphMol/Wrap/EditableMol.cpp
+++ b/Code/GraphMol/Wrap/EditableMol.cpp
@@ -29,7 +29,7 @@ namespace {
 class EditableMol : boost::noncopyable {
  public:
   EditableMol(const ROMol &m) { dp_mol = new RWMol(m); };
-  ~EditableMol() throw() {
+  ~EditableMol() noexcept {
     PRECONDITION(dp_mol, "no molecule");
     delete dp_mol;
   };

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -1962,7 +1962,7 @@ CAS<~>
     for m in ms:
       self.assertTrue(m.HasProp('_MolFileInfo'))
       self.assertTrue(m.HasProp('_MolFileComments'))
-    fName = tempfile.mktemp('.sdf')
+    fName = tempfile.NamedTemporaryFile(suffix='.sdf', delete=False).name
     w = Chem.SDWriter(fName)
     w.SetProps(ms[0].GetPropNames())
     for m in ms:
@@ -3678,22 +3678,20 @@ CAS<~>
     self.assertEqual(path, (1, 2, 3, 16, 17, 18, 20))
 
   def testGithub497(self):
-    outf = gzip.open(tempfile.mktemp(), 'wb+')
-    with self.assertRaises(ValueError):
-      w = Chem.SDWriter(outf)
+    with tempfile.TemporaryFile() as tmp, gzip.open(tmp) as outf:
+      with self.assertRaises(ValueError):
+        w = Chem.SDWriter(outf)
 
   def testGithub498(self):
     if (sys.version_info < (3, 0)):
       mode = 'w+'
     else:
       mode = 'wt+'
-    outf = gzip.open(tempfile.mktemp(), mode)
     m = Chem.MolFromSmiles('C')
-    w = Chem.SDWriter(outf)
-    w.write(m)
-    w.close()
-    w = None
-    outf.close()
+    with tempfile.NamedTemporaryFile() as tmp, gzip.open(tmp, mode) as outf:
+      w = Chem.SDWriter(outf)
+      w.write(m)
+      w.close()
 
   def testReplaceBond(self):
     origmol = Chem.RWMol(Chem.MolFromSmiles("CC"))

--- a/Code/JavaWrappers/GenericRDKitException.h
+++ b/Code/JavaWrappers/GenericRDKitException.h
@@ -19,7 +19,7 @@ class GenericRDKitException : public std::exception {
   GenericRDKitException(const std::string &i) : _value(i){};
   GenericRDKitException(const char *msg) : _value(msg){};
   std::string message() const { return _value; };
-  ~GenericRDKitException() throw(){};
+  ~GenericRDKitException() noexcept {};
 
  private:
   std::string _value;

--- a/Code/RDBoost/python_streambuf.h
+++ b/Code/RDBoost/python_streambuf.h
@@ -502,7 +502,7 @@ struct ostream : private streambuf_capsule, streambuf::ostream {
       : streambuf_capsule(python_file_obj, buffer_size),
         streambuf::ostream(python_streambuf) {}
 
-  ~ostream() throw() {
+  ~ostream() noexcept {
     try {
       if (this->good()) this->flush();
     } catch (bp::error_already_set&) {

--- a/Code/RDGeneral/BadFileException.h
+++ b/Code/RDGeneral/BadFileException.h
@@ -28,7 +28,7 @@ class BadFileException : public std::runtime_error {
       : std::runtime_error("BadFileException"), _msg(msg){};
   //! get the error message
   const char *message() const { return _msg.c_str(); };
-  ~BadFileException() throw(){};
+  ~BadFileException() noexcept {};
 
  private:
   std::string _msg;

--- a/Code/RDGeneral/Exceptions.h
+++ b/Code/RDGeneral/Exceptions.h
@@ -21,7 +21,7 @@ class IndexErrorException : public std::runtime_error {
   IndexErrorException(int i)
       : std::runtime_error("IndexErrorException"), _idx(i){};
   int index() const { return _idx; };
-  ~IndexErrorException() throw(){};
+  ~IndexErrorException() noexcept {};
 
  private:
   int _idx;
@@ -37,7 +37,7 @@ class ValueErrorException : public std::runtime_error {
   ValueErrorException(const char *msg)
       : std::runtime_error("ValueErrorException"), _value(msg){};
   std::string message() const { return _value; };
-  ~ValueErrorException() throw(){};
+  ~ValueErrorException() noexcept {};
 
  private:
   std::string _value;
@@ -51,7 +51,7 @@ class KeyErrorException : public std::runtime_error {
   KeyErrorException(std::string key)
       : std::runtime_error("KeyErrorException"), _key(key){};
   std::string key() const { return _key; };
-  ~KeyErrorException() throw(){};
+  ~KeyErrorException() noexcept {};
 
  private:
   std::string _key;

--- a/Code/RDGeneral/FileParseException.h
+++ b/Code/RDGeneral/FileParseException.h
@@ -26,7 +26,7 @@ class FileParseException : public std::runtime_error {
       : std::runtime_error("FileParseException"), _msg(msg){};
   //! get the error message
   const char *message() const { return _msg.c_str(); };
-  ~FileParseException() throw(){};
+  ~FileParseException() noexcept {};
 
  private:
   std::string _msg;

--- a/Code/RDGeneral/Invariant.h
+++ b/Code/RDGeneral/Invariant.h
@@ -66,7 +66,7 @@ class RDKIT_RDGENERAL_EXPORT Invariant : public std::runtime_error {
         prefix_d(prefix),
         file_dp(file),
         line_d(line) {}
-  ~Invariant() throw(){};
+  ~Invariant() noexcept {};
 
   std::string getMessage() const { return mess_d; }
 

--- a/External/pymol/modules/pymol/rpc.py
+++ b/External/pymol/modules/pymol/rpc.py
@@ -455,10 +455,10 @@ def rpcLoadSurfaceData(data, objName='surface', format='', surfaceLevel=1.0):
   gridName = 'grid-%s' % objName
   # it would be nice if we didn't have to go by way of the temporary file,
   # but at the moment pymol will only read shapes from files
-  tempnm = tempfile.mktemp('.grd')
-  open(tempnm, 'w+').write(data)
-  res = rpcLoadSurface(tempnm, objName, format='', surfaceLevel=surfaceLevel)
-  os.unlink(tempnm)
+  with tempfile.NamedTemporaryFile('w+', suffix='.grd', delete=False) as tmp:
+    tmp.write(data)
+  res = rpcLoadSurface(tmp.name, objName, format='', surfaceLevel=surfaceLevel)
+  os.unlink(tmp.name)
   if res is not None:
     return res
   else:

--- a/Web/RDExtras/MolImage.py
+++ b/Web/RDExtras/MolImage.py
@@ -23,7 +23,7 @@ def gif(req, smiles, width=100, height=100, highlight='[]', frame=0, dblSize=0, 
   highlight = eval(highlight)
   imgD = ''
   if smiles:
-    fName = tempfile.mktemp('.gif')
+    fName = tempfile.NamedTemporaryFile(suffix='.gif', delete=False).name
     cactvs.SmilesToGif(smiles, fName, (width, height), dblSize=dblSize, frame=frame)
     if os.path.exists(fName):
       imgD = open(fName, 'rb').read()

--- a/rdkit/Chem/DSViewer.py
+++ b/rdkit/Chem/DSViewer.py
@@ -134,13 +134,12 @@ class MolViewer(object):
       obj = Displayable(self.doc)
     if not hasattr(obj, '_molBlock') or obj._molBlock != molB:
       obj._molBlock = molB
-      fN = tempfile.mktemp('.mol')
-      open(fN, 'w+').write(molB)
-      self.doc.DoCommand('PasteFrom %s' % fN)
+      with tempfile.NamedTemporaryFile('w+', suffix='.mol') as tmpf:
+        tmpf.write(molB)
+      self.doc.DoCommand('PasteFrom %s' % tmp.name)
       self.doc.DoCommand('SetProperty molecule id=0 : RD_Visual=%d' % (obj.id))
       self.doc.DoCommand('SetProperty molecule id=0 : id=%d' % (obj.id))
       self.doc.DoCommand('SetProperty molecule id=0 : select=off')
-      os.unlink(fN)
     else:
       obj.Select(state=True)
       self.doc.DoCommand('Show')

--- a/rdkit/Chem/PropertyMol.py
+++ b/rdkit/Chem/PropertyMol.py
@@ -56,8 +56,8 @@ class PropertyMol(Chem.Mol):
 
      This is a test for sf.net issue 2880943: make sure properties end up in SD files:
 
-     >>> import tempfile,os
-     >>> fn = tempfile.mktemp('.sdf')
+     >>> import tempfile, os
+     >>> fn = tempfile.NamedTemporaryFile(suffix='.sdf', delete=False).name
      >>> w = Chem.SDWriter(fn)
      >>> w.write(pm)
      >>> w=None
@@ -73,7 +73,7 @@ class PropertyMol(Chem.Mol):
      The next level of that bug: does writing a *depickled* propertymol
      to an SD file include properties:
 
-     >>> fn = tempfile.mktemp('.sdf')
+     >>> fn = tempfile.NamedTemporaryFile(suffix='.sdf', delete=False).name
      >>> w = Chem.SDWriter(fn)
      >>> pm = pickle.loads(pickle.dumps(pm))
      >>> w.write(pm)

--- a/rdkit/Chem/Subshape/SubshapeBuilder.py
+++ b/rdkit/Chem/Subshape/SubshapeBuilder.py
@@ -107,7 +107,7 @@ if __name__ == '__main__':  # pragma: nocover
     shape = builder.GenerateSubshapeShape(cmpd)
   v = MolViewer()
   if 1:
-    tmpFile = tempfile.mktemp('.grd')
+    tmpFile = tempfile.NamedTemporaryFile(suffix='.grd', delete=False).name
     v.server.deleteAll()
     Geometry.WriteGridToFile(shape.grid, tmpFile)
     time.sleep(1)

--- a/rdkit/Chem/Subshape/SubshapeObjects.py
+++ b/rdkit/Chem/Subshape/SubshapeObjects.py
@@ -68,7 +68,7 @@ def DisplaySubshape(viewer, shape, name, showSkelPts=True, color=(1, 0, 1)):
   import os
   import tempfile
   from rdkit import Geometry
-  fName = tempfile.mktemp('.grd')
+  fName = tempfile.NamedTemporaryFile(suffix='.grd', delete=False).name
   Geometry.WriteGridToFile(shape.grid, fName)
   viewer.server.loadSurface(fName, name, '', 2.5)
   if showSkelPts:

--- a/rdkit/Chem/Subshape/testCombined.py
+++ b/rdkit/Chem/Subshape/testCombined.py
@@ -43,11 +43,13 @@ print(pruneStats)
 
 import os, tempfile
 from rdkit import Geometry
-fName = tempfile.mktemp('.grd')
+
+
+fName = tempfile.NamedTemporaryFile(suffix='.grd', delete=False).name
 Geometry.WriteGridToFile(ns1.coarseGrid.grid, fName)
 v.server.loadSurface(fName, 'coarse', '', 2.5)
 os.unlink(fName)
-fName = tempfile.mktemp('.grd')
+fName = tempfile.NamedTemporaryFile(suffix='.grd', delete=False).name
 Geometry.WriteGridToFile(ns1.medGrid.grid, fName)
 v.server.loadSurface(fName, 'med', '', 2.5)
 os.unlink(fName)

--- a/rdkit/Chem/Suppliers/UnitTestSDMolSupplier.py
+++ b/rdkit/Chem/Suppliers/UnitTestSDMolSupplier.py
@@ -66,7 +66,7 @@ class TestCase(unittest.TestCase):
     def test_SDWriter(self):
         # tests writes using a file name
         supp = Chem.SDMolSupplier(self.fName)
-        _, outName = tempfile.mkstemp('.sdf')
+        outName = tempfile.NamedTemporaryFile(suffix='.sdf', delete=False).name
         writer = Chem.SDWriter(outName)
         m1 = next(supp)
         writer.SetProps(m1.GetPropNames())

--- a/rdkit/Chem/UnitTestSuppliers.py
+++ b/rdkit/Chem/UnitTestSuppliers.py
@@ -85,11 +85,10 @@ CCOC,5
 """
         RDLogger.DisableLog('rdApp.error')
 
-        fileN = tempfile.mktemp('.csv')
         try:
-            with open(fileN, 'w+') as f:
-                f.write(txt)
-            suppl = Chem.SmilesMolSupplier(fileN, delimiter=',', smilesColumn=0, nameColumn=1,
+            with tempfile.NamedTemporaryFile('w+', suffix='.csv', delete=False) as tmp:
+                tmp.write(txt)
+            suppl = Chem.SmilesMolSupplier(tmp.name, delimiter=',', smilesColumn=0, nameColumn=1,
                                            titleLine=0)
             ms = [x for x in suppl]
             suppl = None
@@ -97,7 +96,7 @@ CCOC,5
                 ms.remove(None)
             self.assertEqual(len(ms), 3)
         finally:
-            os.unlink(fileN)
+            os.unlink(tmp.name)
 
 
 if __name__ == '__main__':

--- a/rdkit/utils/cactvs.py
+++ b/rdkit/utils/cactvs.py
@@ -30,10 +30,10 @@ def SmilesToGif(smiles, fileNames, size=(200, 200), cmd=None, dblSize=0, frame=0
       )
     nDone += 1
   if args:
-    fN = tempfile.mktemp('.cmd')
-    open(fN, 'w+').write(args + '\n')
+    with tempfile.NamedTemporaryFile('w+', suffix='.cmd', delete=False) as tmp:
+      tmp.write(args + '\n')
     try:
-      cmd = "%s < %s" % (baseCmd, fN)
+      cmd = "%s < %s" % (baseCmd, tmp.name)
       os.system(cmd)
     except Exception:
       import traceback
@@ -47,18 +47,17 @@ def SmilesToGif(smiles, fileNames, size=(200, 200), cmd=None, dblSize=0, frame=0
           res = 0
           break
     try:
-      os.unlink(fN)
+      os.unlink(tmp.name)
     except Exception:
       pass
   return res
 
 
 def SmilesToImage(smiles, **kwargs):
-  tempFilename = tempfile.mktemp('.gif')
-  ok = SmilesToGif(smiles, tempFilename, **kwargs)
-  if ok:
-    img = Image.open(tempFilename)
-    os.unlink(tempFilename)
-  else:
-    img = None
+  with tempfile.NamedTemporaryFile(suffix='.gif') as tmp:
+    ok = SmilesToGif(smiles, tmp.name, **kwargs)
+    if ok:
+      img = Image.open(tmp.name)
+    else:
+      img = None
   return img

--- a/rdkit/utils/chemdraw.py
+++ b/rdkit/utils/chemdraw.py
@@ -314,9 +314,9 @@ def Add3DCoordsToMol(data, format, props={}):
     molData = CDXClean(data, format, 'chemical/mdl-molfile')
   else:
     molData = data
-  molFName = tempfile.mktemp('.mol')
-  open(molFName, 'wb+').write(molData)
-  doc = c3dApp.Documents.Open(molFName)
+  with tempfile.NamedTemporaryFile(suffix='.mol', delete=False) as molF:
+    molF.write(molData)
+  doc = c3dApp.Documents.Open(molF.name)
 
   if not doc:
     print('cannot open molecule')
@@ -344,7 +344,7 @@ def Add3DCoordsToMol(data, format, props={}):
 
   doc.Close(0)
 
-  os.unlink(molFName)
+  os.unlink(molF.name)
   c3dData = open(outFName, 'r').read()
   gone = 0
   while not gone:


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! 

#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.
- Replace obsolete `throw()` with `noexcept` 
  http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2016/p0003r4.html
- Avoid deprecated tempfile.mktemp
  https://docs.python.org/3/library/tempfile.html#deprecated-functions-and-variables
- Fix "warning: control reaches end of non-void function"

<!--
#### Any other comments?
-->