### PR TITLE
Fix windows substructure crash

### DIFF
--- a/Code/GraphMol/SmilesParse/smatest.cpp
+++ b/Code/GraphMol/SmilesParse/smatest.cpp
@@ -2814,7 +2814,7 @@ int main(int argc, char *argv[]) {
   (void)argc;
   (void)argv;
   RDLog::InitLogs();
-#if 0
+#if 1
   testPass();
   testFail();
   testMatches();

--- a/Code/GraphMol/SmilesParse/smatest.cpp
+++ b/Code/GraphMol/SmilesParse/smatest.cpp
@@ -2797,10 +2797,24 @@ void testSmartsStereoBonds() {
   BOOST_LOG(rdInfoLog) << "done" << std::endl;
 }
 
+void testRingBondCrash() {
+    BOOST_LOG(rdInfoLog) << "-------------------------------------" << std::endl;
+    BOOST_LOG(rdInfoLog)
+        << "Testing a crash arising from negated ring bond queries" << std::endl;
+    {
+        auto m2 = "CC"_smiles;
+        auto q = "[C]@[Cl]"_smarts;
+        auto matches0 = SubstructMatch(*m2, *q);
+    }
+
+    BOOST_LOG(rdInfoLog) << "done" << std::endl;
+}
+
 int main(int argc, char *argv[]) {
   (void)argc;
   (void)argv;
   RDLog::InitLogs();
+#if 0
   testPass();
   testFail();
   testMatches();
@@ -2850,6 +2864,7 @@ int main(int argc, char *argv[]) {
   testGithub2142();
   testGithub2565();
   testSmartsStereoBonds();
-
+#endif
+  testRingBondCrash();
   return 0;
 }

--- a/Code/GraphMol/Substruct/vf2.hpp
+++ b/Code/GraphMol/Substruct/vf2.hpp
@@ -308,12 +308,13 @@ namespace boost{
             ++pair.nbrbeg;
           }
           
-          if (pair.nbrbeg < pair.nbrend)
-            pair.n2=*pair.nbrbeg;
-          else
-            pair.n2=n2;
-          
-          ++pair.nbrbeg;
+          if (pair.nbrbeg < pair.nbrend) {
+              pair.n2 = *pair.nbrbeg;
+              ++pair.nbrbeg;
+          }
+          else {
+              pair.n2 = n2;
+          }
         }
         else if (t1_len>core_len && t2_len>core_len) {
           while (pair.n2<n2 &&


### PR DESCRIPTION
Something I didn't catch in the review of #2500 

There's a situation where an iterator was being incremented past the end of the vector and this was leading to a crash under some circumstances under Windows (possibly only a problem when doing debug builds).

It's an easy enough fix.
