### PR TITLE
Fix YAeHMOP build

### DIFF
--- a/External/YAeHMOP/CMakeLists.txt
+++ b/External/YAeHMOP/CMakeLists.txt
@@ -29,16 +29,17 @@ ExternalProject_Add(yaehmop_project
 
 include_directories(${PROJECT_BINARY_DIR}/include)
 link_directories(${PROJECT_BINARY_DIR}/lib)
+link_directories(${CMAKE_CURRENT_SOURCE_DIR}/src/yaehmop_project-build)
 
 set(EHT_PARAM_FILE ${CMAKE_CURRENT_SOURCE_DIR}/yaehmop/tightbind/eht_parms.dat )
 install(FILES ${EHT_PARAM_FILE}
         DESTINATION ${RDKit_ShareDir}/Data
         COMPONENT data)
 
-message("include_dirs: ${PROJECT_BINARY_DIR}/include")
-message("link_dirs: ${PROJECT_BINARY_DIR}/lib")
+message("YAeHMOP include_dirs: ${PROJECT_BINARY_DIR}/include")
+message("YAeHMOP link_dirs: ${PROJECT_BINARY_DIR}/lib ${CMAKE_CURRENT_SOURCE_DIR}/src/yaehmop_project-build")
 
-add_definitions(-DRDKIT_AVALONLIB_BUILD)
+add_definitions(-DRDKIT_EHTLIB_BUILD)
 rdkit_library(EHTLib EHTTools.cpp SHARED LINK_LIBRARIES yaehmop_eht GraphMol DataStructs RDGeometryLib RDGeneral )
 add_dependencies(EHTLib yaehmop_project)
 rdkit_headers(EHTTools.h DEST GraphMol)

--- a/External/YAeHMOP/EHTTools.cpp
+++ b/External/YAeHMOP/EHTTools.cpp
@@ -8,7 +8,7 @@
 #include <fstream>
 
 extern "C" {
-#include <yaehmop/bind.h>
+#include <yaehmop/tightbind/bind.h>
 }
 
 namespace RDKit {

--- a/External/YAeHMOP/EHTTools.h
+++ b/External/YAeHMOP/EHTTools.h
@@ -12,6 +12,7 @@
 
 */
 
+#include <RDGeneral/export.h>
 #include <string>
 #include <memory>
 
@@ -19,7 +20,7 @@ namespace RDKit {
 class ROMol;
 namespace EHTTools {
 
-struct EHTResults {
+struct RDKIT_EHTLIB_EXPORT EHTResults {
   unsigned int numAtoms;
   unsigned int numOrbitals;
   std::unique_ptr<double[]> overlapPopulationMatrix;
@@ -36,7 +37,7 @@ struct EHTResults {
 
 //! Runs an extended Hueckel calculation for a molecule
 //!   The results are returned in the EHTResults structure
-bool runMol(const ROMol &mol, EHTResults &results, int confId = -1);
+RDKIT_EHTLIB_EXPORT bool runMol(const ROMol &mol, EHTResults &results, int confId = -1);
 
 }  // namespace EHTTools
 }  // namespace RDKit


### PR DESCRIPTION
Today I tried for the first time to build RDKit support for YAeHMOP and I failed.
This PR fixes a few issues and allows building YAeHMOP under both Linux and Windows.