### PR TITLE
Fixing #2854 by using utf-8 encoding in rdkit.Chem.Draw

### DIFF
--- a/rdkit/Chem/Draw/cairoCanvas.py
+++ b/rdkit/Chem/Draw/cairoCanvas.py
@@ -282,12 +282,12 @@ class Canvas(CanvasBase):
         if have_cairocffi:
             measureLout = pangocairo.pango_cairo_create_layout(self.ctx._pointer)
             pango.pango_layout_set_alignment(measureLout, pango.PANGO_ALIGN_LEFT)
-            pango.pango_layout_set_markup(measureLout, plainText.encode('latin1'), -1)
+            pango.pango_layout_set_markup(measureLout, plainText.encode('utf-8'), -1)
             lout = pangocairo.pango_cairo_create_layout(self.ctx._pointer)
             pango.pango_layout_set_alignment(lout, pango.PANGO_ALIGN_LEFT)
-            pango.pango_layout_set_markup(lout, text.encode('latin1'), -1)
+            pango.pango_layout_set_markup(lout, text.encode('utf-8'), -1)
             fnt = pango.pango_font_description_new()
-            pango.pango_font_description_set_family(fnt, font.face.encode('latin1'))
+            pango.pango_font_description_set_family(fnt, font.face.encode('utf-8'))
             pango.pango_font_description_set_size(fnt,
                                                   int(round(font.size * pango.PANGO_SCALE * pangoCoeff)))
             pango.pango_layout_set_font_description(lout, fnt)


### PR DESCRIPTION
#### Reference Issue
Fixes #2854 

#### What does this implement/fix? Explain your changes.

Issue #2854 outlines a problem with the use of the `latin1` encoding since e.g. the bullet operator character (`\u2219`) can't be encoded with `latin1`. The use of `latin1` probably has historical reasons in this part of the source code but I don't see any reason why this shouldn't be upgraded to `utf-8`. This commit does exactly that - it introduces the `utf-8` encoding instead of `latin1` in order to be able to handle a larger character spectrum when encoding canvas text with `rdkit.Chem.Draw`.

#### Any other comments?

Nope.