### PR TITLE
add define for RDK_USE_BOOST_SERIALIZATION

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -364,6 +364,7 @@ if(RDK_USE_BOOST_SERIALIZATION)
     else()
       set(Boost_LIBRARIES ${T_LIBS})
     endif()
+  target_compile_definitions(rdkit_base INTERFACE -DRDK_USE_BOOST_SERIALIZATION)
 endif()
 
 

--- a/Code/GraphMol/ChemReactions/CMakeLists.txt
+++ b/Code/GraphMol/ChemReactions/CMakeLists.txt
@@ -1,5 +1,4 @@
 if(RDK_USE_BOOST_SERIALIZATION AND Boost_SERIALIZATION_LIBRARY)
-    ADD_DEFINITIONS("-DRDK_USE_BOOST_SERIALIZATION")
     set(RDKit_SERIALIZATION_LIBS ${Boost_SERIALIZATION_LIBRARY})
 else()
       message("== Making EnumerateLibrary without boost Serialization support")

--- a/Code/GraphMol/FilterCatalog/CMakeLists.txt
+++ b/Code/GraphMol/FilterCatalog/CMakeLists.txt
@@ -1,5 +1,4 @@
 if(RDK_USE_BOOST_SERIALIZATION AND Boost_SERIALIZATION_LIBRARY)
-    ADD_DEFINITIONS("-DRDK_USE_BOOST_SERIALIZATION")
     set(RDKit_SERIALIZATION_LIBS ${Boost_SERIALIZATION_LIBRARY})
 else()
     message("== Making FilterCatalog without boost Serialization support")

--- a/Code/GraphMol/SubstructLibrary/CMakeLists.txt
+++ b/Code/GraphMol/SubstructLibrary/CMakeLists.txt
@@ -1,13 +1,7 @@
-
-
-
-
 if(RDK_USE_BOOST_SERIALIZATION AND Boost_SERIALIZATION_LIBRARY)
     set(RDKit_SERIALIZATION_LIBS ${Boost_SERIALIZATION_LIBRARY})
-    add_definitions(-DRDK_USE_BOOST_SERIALIZATION)
 else()
     message("== Making SubstructLibrary without boost Serialization support")
-    remove_definitions(-DRDK_USE_BOOST_SERIALIZATION)
     set(RDKit_SERIALIZATION_LIBS )
 endif()
 


### PR DESCRIPTION
Since we never add a define for `RDK_USE_BOOST_SERIALIZATION` it doesn't end up getting used most of the time, even if it's requested.