### PR TITLE
Fixes the size of the reduced charge matrix from eHT calculations

### DIFF
--- a/External/YAeHMOP/EHTTools.cpp
+++ b/External/YAeHMOP/EHTTools.cpp
@@ -115,7 +115,7 @@ bool runMol(const ROMol &mol, EHTResults &results, int confId) {
   std::memcpy(static_cast<void *>(results.atomicCharges.get()),
               static_cast<void *>(properties.net_chgs),
               mol.getNumAtoms() * sizeof(double));
-  size_t sz = mol.getNumAtoms() * mol.getNumAtoms();
+  size_t sz = mol.getNumAtoms() * num_orbs;
   results.reducedChargeMatrix = std::make_unique<double[]>(sz);
   memcpy(static_cast<void *>(results.reducedChargeMatrix.get()),
          static_cast<void *>(properties.Rchg_mat), sz * sizeof(double));

--- a/External/YAeHMOP/EHTTools.cpp
+++ b/External/YAeHMOP/EHTTools.cpp
@@ -109,6 +109,7 @@ bool runMol(const ROMol &mol, EHTResults &results, int confId) {
   // pull properties
   results.numAtoms = mol.getNumAtoms();
   results.numOrbitals = num_orbs;
+  results.numElectrons = std::lround(unit_cell->num_electrons);
   results.fermiEnergy = properties.Fermi_E;
   results.totalEnergy = properties.total_E;
   results.atomicCharges = std::make_unique<double[]>(mol.getNumAtoms());

--- a/External/YAeHMOP/EHTTools.h
+++ b/External/YAeHMOP/EHTTools.h
@@ -23,6 +23,7 @@ namespace EHTTools {
 struct RDKIT_EHTLIB_EXPORT EHTResults {
   unsigned int numAtoms;
   unsigned int numOrbitals;
+  unsigned int numElectrons;
   std::unique_ptr<double[]> overlapPopulationMatrix;
   std::unique_ptr<double[]> reducedOverlapPopulationMatrix;
   std::unique_ptr<double[]> chargeMatrix;

--- a/External/YAeHMOP/Wrap/rdEHTTools.cpp
+++ b/External/YAeHMOP/Wrap/rdEHTTools.cpp
@@ -46,16 +46,16 @@ boost::python::object transfer_to_python(T *t) {
   return python::object(handle);
 }
 
-PyObject *getMatrixProp(const double *mat, unsigned int sz) {
+PyObject *getMatrixProp(const double *mat, unsigned int dim1, unsigned int dim2) {
   if (!mat) throw_value_error("matrix has not be initialized");
   npy_intp dims[2];
-  dims[0] = sz;
-  dims[1] = sz;
+  dims[0] = dim1;
+  dims[1] = dim2;
 
   PyArrayObject *res = (PyArrayObject *)PyArray_SimpleNew(2, dims, NPY_DOUBLE);
 
   memcpy(PyArray_DATA(res), static_cast<const void *>(mat),
-         sz * sz * sizeof(double));
+         dim1 * dim2 * sizeof(double));
 
   return PyArray_Return(res);
 }
@@ -84,7 +84,7 @@ PyObject *getVectorProp(const double *mat, unsigned int sz) {
   return PyArray_Return(res);
 }
 PyObject *getChargeMatrix(EHTTools::EHTResults &self) {
-  return getMatrixProp(self.reducedChargeMatrix.get(), self.numAtoms);
+  return getMatrixProp(self.reducedChargeMatrix.get(), self.numAtoms, self.numOrbitals);
 }
 
 PyObject *getOPMatrix(EHTTools::EHTResults &self) {

--- a/External/YAeHMOP/Wrap/rdEHTTools.cpp
+++ b/External/YAeHMOP/Wrap/rdEHTTools.cpp
@@ -109,6 +109,8 @@ struct EHT_wrapper {
 
     python::class_<RDKit::EHTTools::EHTResults, boost::noncopyable>(
         "EHTResults", docString.c_str(), python::no_init)
+        .def_readonly("numOrbitals", &RDKit::EHTTools::EHTResults::numOrbitals)
+        .def_readonly("numElectrons", &RDKit::EHTTools::EHTResults::numElectrons)
         .def_readonly("fermiEnergy", &RDKit::EHTTools::EHTResults::fermiEnergy)
         .def_readonly("totalEnergy", &RDKit::EHTTools::EHTResults::totalEnergy)
         .def("GetReducedChargeMatrix", getChargeMatrix,

--- a/External/YAeHMOP/Wrap/testEHTTools.py
+++ b/External/YAeHMOP/Wrap/testEHTTools.py
@@ -35,10 +35,15 @@ class TestCase(unittest.TestCase):
         ok, res = rdEHTTools.RunMol(mol)
         self.assertTrue(ok)
         cm = res.GetReducedChargeMatrix()
-        self.assertEqual(cm.shape, (12, 12))
-        self.assertAlmostEqual(cm[0][0], 0.161, places=3)
-        self.assertAlmostEqual(cm[1][0], 0.118, places=3)
-        self.assertAlmostEqual(cm[11][10], 0.004, places=3)
+        self.assertEqual(cm.shape, (12, res.numOrbitals))
+        for i in range(6):
+            self.assertAlmostEqual(cm[i][0], 0.161, places=3)
+            self.assertAlmostEqual(cm[i+6][0], 0.005, places=3)
+            self.assertAlmostEqual(cm[i][6], 0.1066, places=3)
+            self.assertAlmostEqual(cm[i+6][6], 0.060, places=3)
+            self.assertAlmostEqual(cm[i][9], 0.167, places=3)
+            self.assertAlmostEqual(cm[i+6][9], 0.000, places=3)
+        
 
     def test3(self):
         mol = Chem.MolFromMolFile(os.path.join(

--- a/External/YAeHMOP/Wrap/testEHTTools.py
+++ b/External/YAeHMOP/Wrap/testEHTTools.py
@@ -34,6 +34,8 @@ class TestCase(unittest.TestCase):
         self.assertEqual(mol.GetNumAtoms(), 12)
         ok, res = rdEHTTools.RunMol(mol)
         self.assertTrue(ok)
+        self.assertEqual(res.numOrbitals,30)
+        self.assertEqual(res.numElectrons,30)
         cm = res.GetReducedChargeMatrix()
         self.assertEqual(cm.shape, (12, res.numOrbitals))
         for i in range(6):
@@ -43,7 +45,6 @@ class TestCase(unittest.TestCase):
             self.assertAlmostEqual(cm[i+6][6], 0.060, places=3)
             self.assertAlmostEqual(cm[i][9], 0.167, places=3)
             self.assertAlmostEqual(cm[i+6][9], 0.000, places=3)
-        
 
     def test3(self):
         mol = Chem.MolFromMolFile(os.path.join(

--- a/External/YAeHMOP/test1.cpp
+++ b/External/YAeHMOP/test1.cpp
@@ -38,6 +38,9 @@ TEST_CASE("benzene", "[basics]") {
   REQUIRE(mol->getNumAtoms() == 12);
   EHTTools::EHTResults res;
   REQUIRE(EHTTools::runMol(*mol, res));
+  CHECK(res.numElectrons == 30);
+  CHECK(res.numOrbitals == 30);
+  CHECK(res.numAtoms == 12);
   for (unsigned int i = 0; i < 6; ++i) {
     CHECK(res.atomicCharges[i] == Approx(-0.026).margin(0.001));
   }

--- a/External/YAeHMOP/test1.cpp
+++ b/External/YAeHMOP/test1.cpp
@@ -44,6 +44,16 @@ TEST_CASE("benzene", "[basics]") {
   for (unsigned int i = 6; i < 12; ++i) {
     CHECK(res.atomicCharges[i] == Approx(0.026).margin(0.001));
   }
+  for (unsigned int i = 0; i < 6; ++i) {
+    CHECK(res.reducedChargeMatrix[i*res.numOrbitals] == Approx(0.1615).margin(0.001));
+    CHECK(res.reducedChargeMatrix[i*res.numOrbitals+6] == Approx(0.1066).margin(0.001));
+    CHECK(res.reducedChargeMatrix[i*res.numOrbitals+9] == Approx(0.1667).margin(0.001));
+  }
+  for (unsigned int i = 6; i < 12; ++i) {
+    CHECK(res.reducedChargeMatrix[i*res.numOrbitals] == Approx(0.0052).margin(0.001));
+    CHECK(res.reducedChargeMatrix[i*res.numOrbitals+6] == Approx(0.0600).margin(0.001));
+    CHECK(res.reducedChargeMatrix[i*res.numOrbitals+9] == Approx(0.0000).margin(0.001));
+  }
   CHECK(res.totalEnergy == Approx(-535.026).margin(0.001));
   CHECK(res.fermiEnergy == Approx(-12.804).margin(0.001));
 }


### PR DESCRIPTION
The matrix that was being returned was `numAtoms x numAtoms`. It should be `numAtoms x numOrbitals`. This fixes that.

The reference values in the tests are from a calculation run using the `bind` command line tool.