### PR TITLE
Fixes #2790

### DIFF
--- a/Code/PgSQL/rdkit/adapter.cpp
+++ b/Code/PgSQL/rdkit/adapter.cpp
@@ -441,13 +441,20 @@ extern "C" int molcmp(CROMol i, CROMol a) {
   if (res) return res;
 
   RDKit::MatchVectType matchVect;
-  bool ss1 = RDKit::SubstructMatch(*im, *am, matchVect, false, false);
-  bool ss2 = RDKit::SubstructMatch(*am, *im, matchVect, false, false);
-  if (ss1 != ss2) return ss1;
+  bool recursionPossible = false;
+  bool doChiralMatch = getDoChiralSSS();
+  bool ss1 = RDKit::SubstructMatch(*im, *am, matchVect, recursionPossible,
+                                   doChiralMatch);
+  bool ss2 = RDKit::SubstructMatch(*am, *im, matchVect, recursionPossible,
+                                   doChiralMatch);
+  if (ss1 && !ss2)
+    return 1;
+  else if (!ss1 && ss2)
+    return -1;
 
   // the above can still fail in some chirality cases
-  std::string smi1 = MolToSmiles(*im, true);
-  std::string smi2 = MolToSmiles(*am, true);
+  std::string smi1 = MolToSmiles(*im, doChiralMatch);
+  std::string smi2 = MolToSmiles(*am, doChiralMatch);
   return smi1 == smi2 ? 0 : (smi1 < smi2 ? -1 : 1);
 }
 

--- a/Code/PgSQL/rdkit/expected/rdkit-91.out
+++ b/Code/PgSQL/rdkit/expected/rdkit-91.out
@@ -559,6 +559,7 @@ select 'C1CC2CC3C45C2C2C6C7C8C9C%10C(C1)C1C%11%10C%109C98C87C76C42C24C65C3C3C56C
 (1 row)
 
 -- chiral matching
+set rdkit.do_chiral_sss=false;
 select 'C[C@H](F)Cl'::mol@>'CC(F)Cl'::mol as match;
  match 
 -------
@@ -594,6 +595,82 @@ select 'C[C@H](F)Cl'::mol@>'C[C@@H](F)Cl'::mol as match;
  match 
 -------
  f
+(1 row)
+
+set rdkit.do_chiral_sss=false;
+-- github #2790
+set rdkit.do_chiral_sss=false;
+select 'C[C@H](F)Cl'::mol@='C[C@H](F)Cl'::mol;
+ ?column? 
+----------
+ t
+(1 row)
+
+select 'C[C@H](F)Cl'::mol@='C[C@@H](F)Cl'::mol;
+ ?column? 
+----------
+ t
+(1 row)
+
+select 'C[C@H](F)Cl'::mol@='CC(F)Cl'::mol;
+ ?column? 
+----------
+ t
+(1 row)
+
+select 'CC(F)Cl'::mol@='C[C@@H](F)Cl'::mol;
+ ?column? 
+----------
+ t
+(1 row)
+
+select 'CC(F)Cl'::mol@='C[C@H](F)Cl'::mol;
+ ?column? 
+----------
+ t
+(1 row)
+
+select 'CC(F)Cl'::mol@='CC(F)Cl'::mol;
+ ?column? 
+----------
+ t
+(1 row)
+
+set rdkit.do_chiral_sss=true;
+select 'C[C@H](F)Cl'::mol@='C[C@H](F)Cl'::mol;
+ ?column? 
+----------
+ t
+(1 row)
+
+select 'C[C@H](F)Cl'::mol@='C[C@@H](F)Cl'::mol;
+ ?column? 
+----------
+ f
+(1 row)
+
+select 'C[C@H](F)Cl'::mol@='CC(F)Cl'::mol;
+ ?column? 
+----------
+ f
+(1 row)
+
+select 'CC(F)Cl'::mol@='C[C@@H](F)Cl'::mol;
+ ?column? 
+----------
+ f
+(1 row)
+
+select 'CC(F)Cl'::mol@='C[C@H](F)Cl'::mol;
+ ?column? 
+----------
+ f
+(1 row)
+
+select 'CC(F)Cl'::mol@='CC(F)Cl'::mol;
+ ?column? 
+----------
+ t
 (1 row)
 
 set rdkit.do_chiral_sss=false;

--- a/Code/PgSQL/rdkit/sql/rdkit-91.sql
+++ b/Code/PgSQL/rdkit/sql/rdkit-91.sql
@@ -214,6 +214,7 @@ select tanimoto_sml(bfp_from_binary_text(bfp_to_binary_text(morganbv_fp('c1ccccn
 select 'C1CC2CC3C45C2C2C6C7C8C9C%10C(C1)C1C%11%10C%109C98C87C76C42C24C65C3C3C56C64C4%12C72C28C79C8%10C9%11C1C1C%109C98C87C42C24C7%12C%116C65C3C3C56C6%11C%117C74C4%12C82C29C8%10C1C1C98C42C24C89C1C1C98C84C4%10C%122C27C7%11C%116C65C3C3C56C6%11C%117C42C24C7%11C%116C65C3C3C56C6%11C%117C74C4%12C%102C28C89C1C1C98C42C24C89C1C1C98C84C4%10C%122C27C7%11C%116C65C3C3C56C6%11C%117C42C24C7%11C%116C65C3C3C56C6%11C%117C74C4%12C%102C28C89C1C1C98C42C24C89C1CC8C4C1C%122C27C4%11C76C65C3CC6C7C4C12'::mol;
 
 -- chiral matching
+set rdkit.do_chiral_sss=false;
 select 'C[C@H](F)Cl'::mol@>'CC(F)Cl'::mol as match;
 select 'C[C@H](F)Cl'::mol@>'C[C@H](F)Cl'::mol as match;
 select 'C[C@H](F)Cl'::mol@>'C[C@@H](F)Cl'::mol as match;
@@ -221,6 +222,23 @@ set rdkit.do_chiral_sss=true;
 select 'C[C@H](F)Cl'::mol@>'CC(F)Cl'::mol as match;
 select 'C[C@H](F)Cl'::mol@>'C[C@H](F)Cl'::mol as match;
 select 'C[C@H](F)Cl'::mol@>'C[C@@H](F)Cl'::mol as match;
+set rdkit.do_chiral_sss=false;
+
+-- github #2790
+set rdkit.do_chiral_sss=false;
+select 'C[C@H](F)Cl'::mol@='C[C@H](F)Cl'::mol;
+select 'C[C@H](F)Cl'::mol@='C[C@@H](F)Cl'::mol;
+select 'C[C@H](F)Cl'::mol@='CC(F)Cl'::mol;
+select 'CC(F)Cl'::mol@='C[C@@H](F)Cl'::mol;
+select 'CC(F)Cl'::mol@='C[C@H](F)Cl'::mol;
+select 'CC(F)Cl'::mol@='CC(F)Cl'::mol;
+set rdkit.do_chiral_sss=true;
+select 'C[C@H](F)Cl'::mol@='C[C@H](F)Cl'::mol;
+select 'C[C@H](F)Cl'::mol@='C[C@@H](F)Cl'::mol;
+select 'C[C@H](F)Cl'::mol@='CC(F)Cl'::mol;
+select 'CC(F)Cl'::mol@='C[C@@H](F)Cl'::mol;
+select 'CC(F)Cl'::mol@='C[C@H](F)Cl'::mol;
+select 'CC(F)Cl'::mol@='CC(F)Cl'::mol;
 set rdkit.do_chiral_sss=false;
 
 -- substructure counts

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,3 +1,13 @@
+# Release_2020.03.1
+(Changes relative to Release_2019.09.1)
+
+## Backwards incompatible changes
+- Searches for equal molecules (i.e. `mol1 @= mol2`) in the PostgreSQL cartridge
+  now use the `do_chiral_sss` option. So if `do_chiral_sss` is false (the
+  default), the molecules `CC(F)Cl` and `C[C@H](F)Cl` will be considered to be equal.
+  Previously these molecules were always considered to be different.
+
+
 # Release_2019.09.1
 (Changes relative to Release_2019.03.1)
 


### PR DESCRIPTION
This is a straightforward fix, but it does change the default behavior of molecular equality queries in the cartridge, so it gets a mention in the release notes.