### PR TITLE
Fix #2848: add options to control removeHs

### DIFF
--- a/Code/GraphMol/AddHs.cpp
+++ b/Code/GraphMol/AddHs.cpp
@@ -791,6 +791,31 @@ ROMol *removeHs(const ROMol &mol, bool implicitOnly, bool updateExplicitCount,
   return static_cast<ROMol *>(res);
 }
 
+void removeAllHs(RWMol &mol, bool sanitize) {
+  RemoveHsParameters ps;
+  ps.removeDegreeZero = true;
+  ps.removeHigherDegrees = true;
+  ps.removeOnlyHNeighbors = true;
+  ps.removeIsotopes = true;
+  ps.removeDummyNeighbors = true;
+  ps.removeDefiningBondStereo = true;
+  ps.removeWithWedgedBond = true;
+  ps.removeWithQuery = true;
+  ps.removeNonimplicit = true;
+  ps.showWarnings = false;
+  removeHs(mol, ps, sanitize);
+};
+ROMol *removeAllHs(const ROMol &mol, bool sanitize) {
+  auto *res = new RWMol(mol);
+  try {
+    removeAllHs(*res, sanitize);
+  } catch (MolSanitizeException &se) {
+    delete res;
+    throw se;
+  }
+  return static_cast<ROMol *>(res);
+}
+
 namespace {
 bool isQueryH(const Atom *atom) {
   PRECONDITION(atom, "bogus atom");

--- a/Code/GraphMol/AddHs.cpp
+++ b/Code/GraphMol/AddHs.cpp
@@ -687,6 +687,9 @@ void removeHs(RWMol &mol, const RemoveHsParameters &ps, bool sanitize) {
         !atom->hasProp(common_properties::isImplicit)) {
       continue;
     }
+    if (!ps.removeMapped && atom->getAtomMapNum()) {
+      continue;
+    }
     bool removeIt = true;
     if (atom->getDegree() &&
         (!ps.removeDummyNeighbors || !ps.removeDefiningBondStereo ||

--- a/Code/GraphMol/AddHs.cpp
+++ b/Code/GraphMol/AddHs.cpp
@@ -771,7 +771,7 @@ ROMol *removeHs(const ROMol &mol, const RemoveHsParameters &ps, bool sanitize) {
     removeHs(*res, ps, sanitize);
   } catch (MolSanitizeException &se) {
     delete res;
-    throw se;
+    throw;
   }
   return static_cast<ROMol *>(res);
 }
@@ -789,7 +789,7 @@ ROMol *removeHs(const ROMol &mol, bool implicitOnly, bool updateExplicitCount,
     removeHs(*res, implicitOnly, updateExplicitCount, sanitize);
   } catch (MolSanitizeException &se) {
     delete res;
-    throw se;
+    throw;
   }
   return static_cast<ROMol *>(res);
 }
@@ -814,7 +814,7 @@ ROMol *removeAllHs(const ROMol &mol, bool sanitize) {
     removeAllHs(*res, sanitize);
   } catch (MolSanitizeException &se) {
     delete res;
-    throw se;
+    throw;
   }
   return static_cast<ROMol *>(res);
 }

--- a/Code/GraphMol/AddHs.cpp
+++ b/Code/GraphMol/AddHs.cpp
@@ -688,8 +688,9 @@ void removeHs(RWMol &mol, const RemoveHsParameters &ps, bool sanitize) {
       continue;
     }
     bool removeIt = true;
-    if (!ps.removeDummyNeighbors || !ps.removeDefiningBondStereo ||
-        !ps.removeOnlyHNeighbors) {
+    if (atom->getDegree() &&
+        (!ps.removeDummyNeighbors || !ps.removeDefiningBondStereo ||
+         !ps.removeOnlyHNeighbors)) {
       bool onlyHNeighbors = true;
       ROMol::ADJ_ITER begin, end;
       boost::tie(begin, end) = mol.getAtomNeighbors(atom);
@@ -761,7 +762,16 @@ void removeHs(RWMol &mol, const RemoveHsParameters &ps, bool sanitize) {
     sanitizeMol(mol);
   }
 };
-
+ROMol *removeHs(const ROMol &mol, const RemoveHsParameters &ps, bool sanitize) {
+  auto *res = new RWMol(mol);
+  try {
+    removeHs(*res, ps, sanitize);
+  } catch (MolSanitizeException &se) {
+    delete res;
+    throw se;
+  }
+  return static_cast<ROMol *>(res);
+}
 void removeHs(RWMol &mol, bool implicitOnly, bool updateExplicitCount,
               bool sanitize) {
   RemoveHsParameters ps;

--- a/Code/GraphMol/MolOps.h
+++ b/Code/GraphMol/MolOps.h
@@ -244,7 +244,8 @@ struct RDKIT_GRAPHMOL_EXPORT RemoveHsParameters {
       false; /**< hydrogens defining bond stereochemistry */
   bool removeWithWedgedBond = true; /**< hydrogens with wedged bonds to them */
   bool removeWithQuery = false;     /**< hydrogens with queries defined */
-  bool showWarnings = true; /**< display warnings for Hs that are not removed */
+  bool removeMapped = true;  /**< mapped hydrogens */
+  bool showWarnings = true;  /**< display warnings for Hs that are not removed */
   bool removeNonimplicit = true; /**< DEPRECATED equivalent of implicitOnly */
   bool updateExplicitCount =
       false; /**< DEPRECATED equivalent of updateExplicitCount */

--- a/Code/GraphMol/MolOps.h
+++ b/Code/GraphMol/MolOps.h
@@ -249,8 +249,15 @@ struct RDKIT_GRAPHMOL_EXPORT RemoveHsParameters {
   bool updateExplicitCount =
       false; /**< DEPRECATED equivalent of updateExplicitCount */
 };
+//! \overload
+// modifies the molecule in place
 RDKIT_GRAPHMOL_EXPORT void removeHs(RWMol &mol, const RemoveHsParameters &ps,
                                     bool sanitize = true);
+//! \overload
+// The caller owns the pointer this returns
+RDKIT_GRAPHMOL_EXPORT ROMol *removeHs(const ROMol &mol,
+                                      const RemoveHsParameters &ps,
+                                      bool sanitize = true);
 
 //! returns a copy of a molecule with hydrogens removed and added as queries
 //!  to the heavy atoms to which they are bound.

--- a/Code/GraphMol/MolOps.h
+++ b/Code/GraphMol/MolOps.h
@@ -259,6 +259,13 @@ RDKIT_GRAPHMOL_EXPORT ROMol *removeHs(const ROMol &mol,
                                       const RemoveHsParameters &ps,
                                       bool sanitize = true);
 
+//! removes all Hs from a molecule
+RDKIT_GRAPHMOL_EXPORT void removeAllHs(RWMol &mol, bool sanitize = true);
+//! \overload
+// The caller owns the pointer this returns
+RDKIT_GRAPHMOL_EXPORT ROMol *removeAllHs(const ROMol &mol,
+                                         bool sanitize = true);
+
 //! returns a copy of a molecule with hydrogens removed and added as queries
 //!  to the heavy atoms to which they are bound.
 /*!

--- a/Code/GraphMol/MolOps.h
+++ b/Code/GraphMol/MolOps.h
@@ -232,6 +232,25 @@ RDKIT_GRAPHMOL_EXPORT ROMol *removeHs(const ROMol &mol,
 RDKIT_GRAPHMOL_EXPORT void removeHs(RWMol &mol, bool implicitOnly = false,
                                     bool updateExplicitCount = false,
                                     bool sanitize = true);
+struct RDKIT_GRAPHMOL_EXPORT RemoveHsParameters {
+  bool removeDegreeZero = false;    /**< hydrogens that have no bonds */
+  bool removeHigherDegrees = false; /**< hydrogens with two (or more) bonds */
+  bool removeNoHeavyAtoms =
+      false;                   /**< hydrogens with bonds to non-heavy atoms */
+  bool removeIsotopes = false; /**< hydrogens with non-default isotopes */
+  bool removeDummyNeighbors =
+      false; /**< hydrogens with at least one dummy-atom neighbor */
+  bool removeDefiningBondStereo =
+      false; /**< hydrogens defining bond stereochemistry */
+  bool removeWithWedgedBond = true; /**< hydrogens with wedged bonds to them */
+  bool removeWithQuery = false;     /**< hydrogens with queries defined */
+  bool showWarnings = true; /**< display warnings for Hs that are not removed */
+  bool removeNonimplicit = true; /**< DEPRECATED equivalent of implicitOnly */
+  bool updateExplicitCount =
+      false; /**< DEPRECATED equivalent of updateExplicitCount */
+};
+RDKIT_GRAPHMOL_EXPORT void removeHs(RWMol &mol, const RemoveHsParameters &ps,
+                                    bool sanitize = true);
 
 //! returns a copy of a molecule with hydrogens removed and added as queries
 //!  to the heavy atoms to which they are bound.
@@ -251,7 +270,8 @@ RDKIT_GRAPHMOL_EXPORT void removeHs(RWMol &mol, bool implicitOnly = false,
     - Hydrogens which aren't connected to a heavy atom will not be
       removed.  This prevents molecules like <tt>"[H][H]"</tt> from having
       all atoms removed.
-    - the caller is responsible for <tt>delete</tt>ing the pointer this returns.
+    - the caller is responsible for <tt>delete</tt>ing the pointer this
+  returns.
     - By default all hydrogens are removed, however if
       mergeUnmappedOnly is true, any hydrogen participating
       in an atom map will be retained
@@ -957,7 +977,8 @@ RDKIT_GRAPHMOL_EXPORT void findPotentialStereoBonds(ROMol &mol,
                                                     bool cleanIt = false);
 //@}
 
-//! \brief Uses the molParity atom property to assign ChiralType to a molecule's atoms
+//! \brief Uses the molParity atom property to assign ChiralType to a molecule's
+//! atoms
 /*!
   \param mol                  the molecule of interest
   \param replaceExistingTags  if this flag is true, any existing atomic chiral

--- a/Code/GraphMol/MolOps.h
+++ b/Code/GraphMol/MolOps.h
@@ -235,8 +235,8 @@ RDKIT_GRAPHMOL_EXPORT void removeHs(RWMol &mol, bool implicitOnly = false,
 struct RDKIT_GRAPHMOL_EXPORT RemoveHsParameters {
   bool removeDegreeZero = false;    /**< hydrogens that have no bonds */
   bool removeHigherDegrees = false; /**< hydrogens with two (or more) bonds */
-  bool removeNoHeavyAtoms =
-      false;                   /**< hydrogens with bonds to non-heavy atoms */
+  bool removeOnlyHNeighbors =
+      false; /**< hydrogens with bonds only to other hydrogens */
   bool removeIsotopes = false; /**< hydrogens with non-default isotopes */
   bool removeDummyNeighbors =
       false; /**< hydrogens with at least one dummy-atom neighbor */

--- a/Code/GraphMol/Wrap/MolOps.cpp
+++ b/Code/GraphMol/Wrap/MolOps.cpp
@@ -1077,7 +1077,13 @@ struct molops_wrapper {
                              bool)) MolOps::removeHs,
                 (python::arg("mol"), python::arg("params"),
                  python::arg("sanitize") = true),
-                docString.c_str(),
+                "Returns a copy of the molecule with Hs removed. Which Hs are "
+                "removed is controlled by the params argument",
+                python::return_value_policy<python::manage_new_object>());
+    python::def("RemoveAllHs",
+                (ROMol * (*)(const ROMol &, bool)) MolOps::removeAllHs,
+                (python::arg("mol"), python::arg("sanitize") = true),
+                "Returns a copy of the molecule with all Hs removed.",
                 python::return_value_policy<python::manage_new_object>());
     python::def("MergeQueryHs",
                 (ROMol * (*)(const ROMol &, bool)) & MolOps::mergeQueryHs,

--- a/Code/GraphMol/Wrap/MolOps.cpp
+++ b/Code/GraphMol/Wrap/MolOps.cpp
@@ -1086,16 +1086,17 @@ struct molops_wrapper {
         .def_readwrite("updateExplicitCount",
                        &MolOps::RemoveHsParameters::updateExplicitCount,
                        "DEPRECATED");
-    python::def("RemoveHs",
-                (ROMol * (*)(const ROMol &, const MolOps::RemoveHsParameters &,
-                             bool)) MolOps::removeHs,
-                (python::arg("mol"), python::arg("params"),
-                 python::arg("sanitize") = true),
-                "Returns a copy of the molecule with Hs removed. Which Hs are "
-                "removed is controlled by the params argument",
-                python::return_value_policy<python::manage_new_object>());
+    python::def(
+        "RemoveHs",
+        (ROMol * (*)(const ROMol &, const MolOps::RemoveHsParameters &, bool)) &
+            MolOps::removeHs,
+        (python::arg("mol"), python::arg("params"),
+         python::arg("sanitize") = true),
+        "Returns a copy of the molecule with Hs removed. Which Hs are "
+        "removed is controlled by the params argument",
+        python::return_value_policy<python::manage_new_object>());
     python::def("RemoveAllHs",
-                (ROMol * (*)(const ROMol &, bool)) MolOps::removeAllHs,
+                (ROMol * (*)(const ROMol &, bool)) & MolOps::removeAllHs,
                 (python::arg("mol"), python::arg("sanitize") = true),
                 "Returns a copy of the molecule with all Hs removed.",
                 python::return_value_policy<python::manage_new_object>());

--- a/Code/GraphMol/Wrap/MolOps.cpp
+++ b/Code/GraphMol/Wrap/MolOps.cpp
@@ -1051,27 +1051,41 @@ struct molops_wrapper {
     python::class_<MolOps::RemoveHsParameters>("RemoveHsParameters",
                                                docString.c_str())
         .def_readwrite("removeDegreeZero",
-                       &MolOps::RemoveHsParameters::removeDegreeZero)
+                       &MolOps::RemoveHsParameters::removeDegreeZero,
+                       "hydrogens that have no bonds")
         .def_readwrite("removeHigherDegrees",
-                       &MolOps::RemoveHsParameters::removeHigherDegrees)
+                       &MolOps::RemoveHsParameters::removeHigherDegrees,
+                       "hydrogens with two (or more) bonds")
         .def_readwrite("removeOnlyHNeighbors",
-                       &MolOps::RemoveHsParameters::removeOnlyHNeighbors)
+                       &MolOps::RemoveHsParameters::removeOnlyHNeighbors,
+                       "hydrogens with bonds only to other hydrogens")
         .def_readwrite("removeIsotopes",
-                       &MolOps::RemoveHsParameters::removeIsotopes)
+                       &MolOps::RemoveHsParameters::removeIsotopes,
+                       "hydrogens with non-default isotopes")
         .def_readwrite("removeDummyNeighbors",
-                       &MolOps::RemoveHsParameters::removeDummyNeighbors)
+                       &MolOps::RemoveHsParameters::removeDummyNeighbors,
+                       "hydrogens with at least one dummy-atom neighbor")
         .def_readwrite("removeDefiningBondStereo",
-                       &MolOps::RemoveHsParameters::removeDefiningBondStereo)
+                       &MolOps::RemoveHsParameters::removeDefiningBondStereo,
+                       "hydrogens defining bond stereochemistry")
         .def_readwrite("removeWithWedgedBond",
-                       &MolOps::RemoveHsParameters::removeWithWedgedBond)
+                       &MolOps::RemoveHsParameters::removeWithWedgedBond,
+                       "hydrogens with wedged bonds to them")
         .def_readwrite("removeWithQuery",
-                       &MolOps::RemoveHsParameters::removeWithQuery)
+                       &MolOps::RemoveHsParameters::removeWithQuery,
+                       "hydrogens with queries defined")
+        .def_readwrite("removeMapped",
+                       &MolOps::RemoveHsParameters::removeMapped,
+                       "mapped hydrogens")
         .def_readwrite("removeNonimplicit",
-                       &MolOps::RemoveHsParameters::removeNonimplicit)
-        .def_readwrite("showWarnings",
-                       &MolOps::RemoveHsParameters::showWarnings)
+                       &MolOps::RemoveHsParameters::removeNonimplicit,
+                       "DEPRECATED")
+        .def_readwrite(
+            "showWarnings", &MolOps::RemoveHsParameters::showWarnings,
+            "display warning messages for some classes of removed Hs")
         .def_readwrite("updateExplicitCount",
-                       &MolOps::RemoveHsParameters::updateExplicitCount);
+                       &MolOps::RemoveHsParameters::updateExplicitCount,
+                       "DEPRECATED");
     python::def("RemoveHs",
                 (ROMol * (*)(const ROMol &, const MolOps::RemoveHsParameters &,
                              bool)) MolOps::removeHs,

--- a/Code/GraphMol/Wrap/MolOps.cpp
+++ b/Code/GraphMol/Wrap/MolOps.cpp
@@ -1046,6 +1046,39 @@ struct molops_wrapper {
                 docString.c_str(),
                 python::return_value_policy<python::manage_new_object>());
 
+    // ------------------------------------------------------------------------
+    docString = R"DOC(Parameters controlling which Hs are removed.)DOC";
+    python::class_<MolOps::RemoveHsParameters>("RemoveHsParameters",
+                                               docString.c_str())
+        .def_readwrite("removeDegreeZero",
+                       &MolOps::RemoveHsParameters::removeDegreeZero)
+        .def_readwrite("removeHigherDegrees",
+                       &MolOps::RemoveHsParameters::removeHigherDegrees)
+        .def_readwrite("removeOnlyHNeighbors",
+                       &MolOps::RemoveHsParameters::removeOnlyHNeighbors)
+        .def_readwrite("removeIsotopes",
+                       &MolOps::RemoveHsParameters::removeIsotopes)
+        .def_readwrite("removeDummyNeighbors",
+                       &MolOps::RemoveHsParameters::removeDummyNeighbors)
+        .def_readwrite("removeDefiningBondStereo",
+                       &MolOps::RemoveHsParameters::removeDefiningBondStereo)
+        .def_readwrite("removeWithWedgedBond",
+                       &MolOps::RemoveHsParameters::removeWithWedgedBond)
+        .def_readwrite("removeWithQuery",
+                       &MolOps::RemoveHsParameters::removeWithQuery)
+        .def_readwrite("removeNonimplicit",
+                       &MolOps::RemoveHsParameters::removeNonimplicit)
+        .def_readwrite("showWarnings",
+                       &MolOps::RemoveHsParameters::showWarnings)
+        .def_readwrite("updateExplicitCount",
+                       &MolOps::RemoveHsParameters::updateExplicitCount);
+    python::def("RemoveHs",
+                (ROMol * (*)(const ROMol &, const MolOps::RemoveHsParameters &,
+                             bool)) MolOps::removeHs,
+                (python::arg("mol"), python::arg("params"),
+                 python::arg("sanitize") = true),
+                docString.c_str(),
+                python::return_value_policy<python::manage_new_object>());
     python::def("MergeQueryHs",
                 (ROMol * (*)(const ROMol &, bool)) & MolOps::mergeQueryHs,
                 (python::arg("mol"), python::arg("mergeUnmappedOnly") = false),
@@ -1705,8 +1738,7 @@ struct molops_wrapper {
 \n";
     python::def("AssignAtomChiralTagsFromMolParity",
                 MolOps::assignChiralTypesFromMolParity,
-                (python::arg("mol"),
-                 python::arg("replaceExistingTags") = true),
+                (python::arg("mol"), python::arg("replaceExistingTags") = true),
                 docString.c_str());
 
     // ------------------------------------------------------------------------

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -5743,37 +5743,55 @@ M  END
     smips.removeHs = False
 
     m = Chem.MolFromSmiles('F.[H]',smips)
+    m = Chem.MolFromSmiles('F.[H]',smips)
     ps = Chem.RemoveHsParameters()
+    m = Chem.RemoveHs(m,ps)
+    self.assertEqual(m.GetNumAtoms(),2)
     ps.removeDegreeZero = True
     m = Chem.RemoveHs(m,ps)
     self.assertEqual(m.GetNumAtoms(),1)
 
     m = Chem.MolFromSmiles('F[H-]F',smips)
     ps = Chem.RemoveHsParameters()
+    m = Chem.RemoveHs(m,ps)
+    self.assertEqual(m.GetNumAtoms(),3)
+    m = Chem.MolFromSmiles('F[H-]F',smips)
     ps.removeHigherDegrees = True
     m = Chem.RemoveHs(m,ps)
     self.assertEqual(m.GetNumAtoms(),2)
 
     m = Chem.MolFromSmiles('[H][H]',smips)
     ps = Chem.RemoveHsParameters()
+    m = Chem.RemoveHs(m,ps)
+    self.assertEqual(m.GetNumAtoms(),2)
+    m = Chem.MolFromSmiles('[H][H]',smips)
     ps.removeOnlyHNeighbors = True
     m = Chem.RemoveHs(m,ps)
     self.assertEqual(m.GetNumAtoms(),0)
 
     m = Chem.MolFromSmiles('F[2H]',smips)
     ps = Chem.RemoveHsParameters()
+    m = Chem.RemoveHs(m,ps)
+    self.assertEqual(m.GetNumAtoms(),2)
+    m = Chem.MolFromSmiles('F[2H]',smips)
     ps.removeIsotopes = True
     m = Chem.RemoveHs(m,ps)
     self.assertEqual(m.GetNumAtoms(),1)
 
     m = Chem.MolFromSmiles('*[H]',smips)
     ps = Chem.RemoveHsParameters()
+    m = Chem.RemoveHs(m, ps)
+    self.assertEqual(m.GetNumAtoms(), 2)
+    m = Chem.MolFromSmiles('*[H]',smips)
     ps.removeDummyNeighbors = True
     m = Chem.RemoveHs(m, ps)
     self.assertEqual(m.GetNumAtoms(), 1)
 
-    m = Chem.MolFromSmiles('F/C=C/[H]',smips)
+    m = Chem.MolFromSmiles('F/C=N/[H]',smips)
     ps = Chem.RemoveHsParameters()
+    m = Chem.RemoveHs(m,ps)
+    self.assertEqual(m.GetNumAtoms(),4)
+    m = Chem.MolFromSmiles('F/C=N/[H]',smips)
     ps.removeDefiningBondStereo = True
     m = Chem.RemoveHs(m,ps)
     self.assertEqual(m.GetNumAtoms(),3)
@@ -5781,16 +5799,22 @@ M  END
     m = Chem.MolFromSmiles('FC([H])(O)Cl', smips)
     m.GetBondBetweenAtoms(1,2).SetBondDir(Chem.BondDir.BEGINWEDGE)
     ps = Chem.RemoveHsParameters()
+    m = Chem.RemoveHs(m, ps)
+    self.assertEqual(m.GetNumAtoms(), 4)
+    m = Chem.MolFromSmiles('FC([H])(O)Cl', smips)
+    m.GetBondBetweenAtoms(1,2).SetBondDir(Chem.BondDir.BEGINWEDGE)
     ps.removeWithWedgedBond = False
     m = Chem.RemoveHs(m, ps)
     self.assertEqual(m.GetNumAtoms(), 5)
 
     m = Chem.MolFromSmarts('F[#1]')
     ps = Chem.RemoveHsParameters()
+    m = Chem.RemoveHs(m, ps)
+    self.assertEqual(m.GetNumAtoms(), 2)
+    m = Chem.MolFromSmarts('F[#1]')
     ps.removeWithQuery = True
     m = Chem.RemoveHs(m, ps)
     self.assertEqual(m.GetNumAtoms(), 1)
-
 
     m = Chem.MolFromSmiles('[C@]12([H])CCC1CO2.[H+].F[H-]F.[H][H].[H]*.F/C=C/[H]')
     m = Chem.RemoveAllHs(m)

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -5792,6 +5792,11 @@ M  END
     self.assertEqual(m.GetNumAtoms(), 1)
 
 
+    m = Chem.MolFromSmiles('[C@]12([H])CCC1CO2.[H+].F[H-]F.[H][H].[H]*.F/C=C/[H]')
+    m = Chem.RemoveAllHs(m)
+    for at in m.GetAtoms():
+      self.assertNotEqual(at.GetAtomicNum(),1)
+
 if __name__ == '__main__':
   if "RDTESTCASE" in os.environ:
     suite = unittest.TestSuite()

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -3499,7 +3499,7 @@ CAS<~>
       list(Chem.CanonicalRankAtomsInFragment(mol, atomsToUse=range(4, 8), breakTies=True)),
       [-1, -1, -1, -1, 4, 6, 4, 6])
 
-    
+
 
 
   def test93RWMolsAsROMol(self):
@@ -5149,8 +5149,8 @@ M  END
     for at in stereo_atoms:
       at.SetProp("foo2","bar2")
       self.assertTrue(m.GetAtomWithIdx(at.GetIdx()).HasProp("foo2"))
-    
-        
+
+
 
   def testEnhancedStereoPreservesMol(self):
     """
@@ -5543,14 +5543,14 @@ H      0.635000    0.635000    0.635000
       self.assertEqual(exc.cause.GetAtomIdx(),1)
     else:
       self.assertFalse(True)
-      
+
     try:
       Chem.SanitizeMol(Chem.MolFromSmiles('c1cc1',sanitize=False))
     except Chem.KekulizeException as exc:
       self.assertEqual(exc.cause.GetAtomIndices(),(0,1,2))
     else:
       self.assertFalse(True)
-          
+
 
   def testSanitizationExceptionHierarchy(self):
     with self.assertRaises(Chem.AtomValenceException):
@@ -5582,14 +5582,14 @@ H      0.635000    0.635000    0.635000
     mol = Chem.MolFromSmiles('ONCS.ONCS')
     for atom in mol.GetAtoms():
       atom.SetIsotope(atom.GetIdx())
-    
+
     order1 = list(Chem.CanonicalRankAtomsInFragment(mol, atomsToUse=range(0, 4), breakTies=False, includeIsotopes=True))
     order2 = list(Chem.CanonicalRankAtomsInFragment(mol, atomsToUse=range(0, 8), breakTies=False, includeIsotopes=False))
     self.assertNotEqual(order1[:4], order2[4:])
     # ensure that the orders are ignored in the second batch
     self.assertEqual(order2[:4], order2[4:])
 
-  
+
     for smi in ['ONCS.ONCS', 'F[C@@H](Br)[C@H](F)Cl']:
       mol = Chem.MolFromSmiles(smi)
       for atom in mol.GetAtoms():
@@ -5604,7 +5604,7 @@ H      0.635000    0.635000    0.635000
           order4 = list(Chem.CanonicalRankAtoms(mol, breakTies=True, includeIsotopes=iso, includeChirality=chiral))
           self.assertEqual(order1,order3)
           self.assertEqual(order2,order4)
-    
+
   def testSetBondStereoFromDirections(self):
     m1 = Chem.MolFromMolBlock('''
   Mrv1810 10141909482D          
@@ -5623,7 +5623,7 @@ M  END
     self.assertEqual(m1.GetBondBetweenAtoms(0,1).GetStereo(),Chem.BondStereo.STEREONONE)
     Chem.SetBondStereoFromDirections(m1)
     self.assertEqual(m1.GetBondBetweenAtoms(0,1).GetStereo(),Chem.BondStereo.STEREOTRANS)
-    
+
     m2 = Chem.MolFromMolBlock('''
   Mrv1810 10141909542D          
 
@@ -5648,7 +5648,7 @@ M  END
     m1.GetBondWithIdx(1).SetStereoAtoms(0,3)
     m1.GetBondWithIdx(1).SetStereo(Chem.BondStereo.STEREOCIS)
     Chem.SetDoubleBondNeighborDirections(m1)
-    self.assertEqual(Chem.MolToSmiles(m1),r"C/C=C\C")   
+    self.assertEqual(Chem.MolToSmiles(m1),r"C/C=C\C")
     self.assertEqual(m1.GetBondWithIdx(0).GetBondDir(),Chem.BondDir.ENDUPRIGHT)
     self.assertEqual(m1.GetBondWithIdx(2).GetBondDir(),Chem.BondDir.ENDDOWNRIGHT)
 
@@ -5737,6 +5737,59 @@ M  END
       molb, sanitize = True, removeHs = False))
     self.assertIsNotNone(m)
     TestAssignChiralTypesFromMolParity(m, self)
+
+  def testRemoveHsParams(self):
+    smips = Chem.SmilesParserParams()
+    smips.removeHs = False
+
+    m = Chem.MolFromSmiles('F.[H]',smips)
+    ps = Chem.RemoveHsParameters()
+    ps.removeDegreeZero = True
+    m = Chem.RemoveHs(m,ps)
+    self.assertEqual(m.GetNumAtoms(),1)
+
+    m = Chem.MolFromSmiles('F[H-]F',smips)
+    ps = Chem.RemoveHsParameters()
+    ps.removeHigherDegrees = True
+    m = Chem.RemoveHs(m,ps)
+    self.assertEqual(m.GetNumAtoms(),2)
+
+    m = Chem.MolFromSmiles('[H][H]',smips)
+    ps = Chem.RemoveHsParameters()
+    ps.removeOnlyHNeighbors = True
+    m = Chem.RemoveHs(m,ps)
+    self.assertEqual(m.GetNumAtoms(),0)
+
+    m = Chem.MolFromSmiles('F[2H]',smips)
+    ps = Chem.RemoveHsParameters()
+    ps.removeIsotopes = True
+    m = Chem.RemoveHs(m,ps)
+    self.assertEqual(m.GetNumAtoms(),1)
+
+    m = Chem.MolFromSmiles('*[H]',smips)
+    ps = Chem.RemoveHsParameters()
+    ps.removeDummyNeighbors = True
+    m = Chem.RemoveHs(m, ps)
+    self.assertEqual(m.GetNumAtoms(), 1)
+
+    m = Chem.MolFromSmiles('F/C=C/[H]',smips)
+    ps = Chem.RemoveHsParameters()
+    ps.removeDefiningBondStereo = True
+    m = Chem.RemoveHs(m,ps)
+    self.assertEqual(m.GetNumAtoms(),3)
+
+    m = Chem.MolFromSmiles('FC([H])(O)Cl', smips)
+    m.GetBondBetweenAtoms(1,2).SetBondDir(Chem.BondDir.BEGINWEDGE)
+    ps = Chem.RemoveHsParameters()
+    ps.removeWithWedgedBond = False
+    m = Chem.RemoveHs(m, ps)
+    self.assertEqual(m.GetNumAtoms(), 5)
+
+    m = Chem.MolFromSmarts('F[#1]')
+    ps = Chem.RemoveHsParameters()
+    ps.removeWithQuery = True
+    m = Chem.RemoveHs(m, ps)
+    self.assertEqual(m.GetNumAtoms(), 1)
 
 
 if __name__ == '__main__':

--- a/Code/GraphMol/catch_tests.cpp
+++ b/Code/GraphMol/catch_tests.cpp
@@ -1058,4 +1058,16 @@ TEST_CASE("RemoveHsParameters", "[molops]") {
       CHECK(cp.getNumAtoms() == 2);
     }
   }
+  SECTION("allHs") {
+    std::unique_ptr<RWMol> m{SmilesToMol(
+        "[C@]12([H])CCC1CO2.[H+].F[H-]F.[H][H].[H]*.F/C=C/[H]", smilesPs)};
+    REQUIRE(m);
+    // artificial wedging since we don't have a conformer
+    m->getBondBetweenAtoms(0, 1)->setBondDir(Bond::BEGINWEDGE);
+    RWMol cp(*m);
+    MolOps::removeAllHs(cp);
+    for (auto atom : cp.atoms()) {
+      CHECK(atom->getAtomicNum() != 1);
+    }
+  }
 }

--- a/Code/GraphMol/catch_tests.cpp
+++ b/Code/GraphMol/catch_tests.cpp
@@ -989,7 +989,7 @@ TEST_CASE("RemoveHsParameters", "[molops]") {
   }
 
   SECTION("defining bond stereo") {
-    std::unique_ptr<RWMol> m{SmilesToMol("F/C=C/[H]", smilesPs)};
+    std::unique_ptr<RWMol> m{SmilesToMol("F/C=N/[H]", smilesPs)};
     REQUIRE(m);
     CHECK(m->getNumAtoms() == 4);
     {
@@ -1084,6 +1084,17 @@ TEST_CASE("RemoveHsParameters", "[molops]") {
     RWMol cp(*m);
     MolOps::removeAllHs(cp);
     for (auto atom : cp.atoms()) {
+      CHECK(atom->getAtomicNum() != 1);
+    }
+  }
+  SECTION("allHs2") {
+    std::unique_ptr<ROMol> m{SmilesToMol(
+        "[C@]12([H])CCC1CO2.[H+].F[H-]F.[H][H].[H]*.F/C=C/[H]", smilesPs)};
+    REQUIRE(m);
+    // artificial wedging since we don't have a conformer
+    m->getBondBetweenAtoms(0, 1)->setBondDir(Bond::BEGINWEDGE);
+    std::unique_ptr<ROMol> cp{MolOps::removeAllHs(*m)};
+    for (auto atom : cp->atoms()) {
       CHECK(atom->getAtomicNum() != 1);
     }
   }

--- a/Code/GraphMol/catch_tests.cpp
+++ b/Code/GraphMol/catch_tests.cpp
@@ -1058,6 +1058,23 @@ TEST_CASE("RemoveHsParameters", "[molops]") {
       CHECK(cp.getNumAtoms() == 2);
     }
   }
+  SECTION("mapped Hs") {
+    std::unique_ptr<RWMol> m{SmilesToMol("[H:1]O[H]", smilesPs)};
+    REQUIRE(m);
+    CHECK(m->getNumAtoms() == 3);
+    {
+      RWMol cp(*m);
+      MolOps::removeHs(cp);
+      CHECK(cp.getNumAtoms() == 1);
+    }
+    {
+      MolOps::RemoveHsParameters ps;
+      ps.removeMapped = false;
+      RWMol cp(*m);
+      MolOps::removeHs(cp, ps);
+      CHECK(cp.getNumAtoms() == 2);
+    }
+  }
   SECTION("allHs") {
     std::unique_ptr<RWMol> m{SmilesToMol(
         "[C@]12([H])CCC1CO2.[H+].F[H-]F.[H][H].[H]*.F/C=C/[H]", smilesPs)};

--- a/Code/GraphMol/catch_tests.cpp
+++ b/Code/GraphMol/catch_tests.cpp
@@ -860,3 +860,202 @@ M  END
     CHECK(m->getAtomWithIdx(13)->getNumImplicitHs() == 0);
   }
 }
+
+TEST_CASE("RemoveHsParameters", "[molops]") {
+  SmilesParserParams smilesPs;
+  smilesPs.removeHs = false;
+
+  SECTION("H-H") {
+    std::unique_ptr<RWMol> m{SmilesToMol("[H][H].[H]O[H]", smilesPs)};
+    REQUIRE(m);
+    CHECK(m->getNumAtoms() == 5);
+    {
+      RWMol cp(*m);
+      MolOps::removeHs(cp);
+      CHECK(cp.getNumAtoms() == 3);
+    }
+    {
+      MolOps::RemoveHsParameters ps;
+      RWMol cp(*m);
+      MolOps::removeHs(cp, ps);
+      CHECK(cp.getNumAtoms() == 3);
+    }
+    {
+      MolOps::RemoveHsParameters ps;
+      ps.removeOnlyHNeighbors = true;
+      RWMol cp(*m);
+      MolOps::removeHs(cp, ps);
+      CHECK(cp.getNumAtoms() == 1);
+    }
+  }
+
+  SECTION("dummies") {
+    std::unique_ptr<RWMol> m{SmilesToMol("[H][*]O[H]", smilesPs)};
+    REQUIRE(m);
+    CHECK(m->getNumAtoms() == 4);
+    {
+      RWMol cp(*m);
+      MolOps::removeHs(cp);
+      CHECK(cp.getNumAtoms() == 3);
+    }
+    {
+      MolOps::RemoveHsParameters ps;
+      RWMol cp(*m);
+      MolOps::removeHs(cp, ps);
+      CHECK(cp.getNumAtoms() == 3);
+    }
+    {
+      MolOps::RemoveHsParameters ps;
+      ps.removeDummyNeighbors = true;
+      RWMol cp(*m);
+      MolOps::removeHs(cp, ps);
+      CHECK(cp.getNumAtoms() == 2);
+    }
+  }
+
+  SECTION("chiralHs") {
+    std::unique_ptr<RWMol> m{SmilesToMol("[C@]12([H])CCC1CO2", smilesPs)};
+    REQUIRE(m);
+    CHECK(m->getNumAtoms() == 7);
+    // artificial wedging since we don't have a conformer
+    m->getBondBetweenAtoms(0, 1)->setBondDir(Bond::BEGINWEDGE);
+
+    {
+      RWMol cp(*m);
+      MolOps::removeHs(cp);
+      CHECK(cp.getNumAtoms() == 6);
+    }
+    {
+      MolOps::RemoveHsParameters ps;
+      RWMol cp(*m);
+      MolOps::removeHs(cp, ps);
+      CHECK(cp.getNumAtoms() == 6);
+    }
+    {
+      MolOps::RemoveHsParameters ps;
+      ps.removeWithWedgedBond = false;
+      RWMol cp(*m);
+      MolOps::removeHs(cp, ps);
+      CHECK(cp.getNumAtoms() == 7);
+    }
+  }
+
+  SECTION("degree zero") {
+    std::unique_ptr<RWMol> m{SmilesToMol("[F-].[H+]", smilesPs)};
+    REQUIRE(m);
+    CHECK(m->getNumAtoms() == 2);
+    {
+      RWMol cp(*m);
+      MolOps::removeHs(cp);
+      CHECK(cp.getNumAtoms() == 2);
+    }
+    {
+      MolOps::RemoveHsParameters ps;
+      RWMol cp(*m);
+      MolOps::removeHs(cp, ps);
+      CHECK(cp.getNumAtoms() == 2);
+    }
+    {
+      MolOps::RemoveHsParameters ps;
+      ps.removeDegreeZero = true;
+      RWMol cp(*m);
+      MolOps::removeHs(cp, ps);
+      CHECK(cp.getNumAtoms() == 1);
+    }
+  }
+
+  SECTION("isotopes") {
+    std::unique_ptr<RWMol> m{SmilesToMol("F[2H]", smilesPs)};
+    REQUIRE(m);
+    CHECK(m->getNumAtoms() == 2);
+    {
+      RWMol cp(*m);
+      MolOps::removeHs(cp);
+      CHECK(cp.getNumAtoms() == 2);
+    }
+    {
+      MolOps::RemoveHsParameters ps;
+      RWMol cp(*m);
+      MolOps::removeHs(cp, ps);
+      CHECK(cp.getNumAtoms() == 2);
+    }
+    {
+      MolOps::RemoveHsParameters ps;
+      ps.removeIsotopes = true;
+      RWMol cp(*m);
+      MolOps::removeHs(cp, ps);
+      CHECK(cp.getNumAtoms() == 1);
+    }
+  }
+
+  SECTION("defining bond stereo") {
+    std::unique_ptr<RWMol> m{SmilesToMol("F/C=C/[H]", smilesPs)};
+    REQUIRE(m);
+    CHECK(m->getNumAtoms() == 4);
+    {
+      RWMol cp(*m);
+      MolOps::removeHs(cp);
+      CHECK(cp.getNumAtoms() == 4);
+    }
+    {
+      MolOps::RemoveHsParameters ps;
+      RWMol cp(*m);
+      MolOps::removeHs(cp, ps);
+      CHECK(cp.getNumAtoms() == 4);
+    }
+    {
+      MolOps::RemoveHsParameters ps;
+      ps.removeDefiningBondStereo = true;
+      RWMol cp(*m);
+      MolOps::removeHs(cp, ps);
+      CHECK(cp.getNumAtoms() == 3);
+    }
+  }
+  SECTION("Query atoms") {
+    std::unique_ptr<RWMol> m{SmartsToMol("O[#1]")};
+    REQUIRE(m);
+    CHECK(m->getNumAtoms() == 2);
+    {
+      RWMol cp(*m);
+      MolOps::removeHs(cp);
+      CHECK(cp.getNumAtoms() == 2);
+    }
+    {
+      MolOps::RemoveHsParameters ps;
+      RWMol cp(*m);
+      MolOps::removeHs(cp, ps);
+      CHECK(cp.getNumAtoms() == 2);
+    }
+    {
+      MolOps::RemoveHsParameters ps;
+      ps.removeWithQuery = true;
+      RWMol cp(*m);
+      MolOps::removeHs(cp, ps);
+      CHECK(cp.getNumAtoms() == 1);
+    }
+  }
+  SECTION("higher degree") {
+    // this is a silly example
+    std::unique_ptr<RWMol> m{SmilesToMol("F[H-]F", smilesPs)};
+    REQUIRE(m);
+    CHECK(m->getNumAtoms() == 3);
+    {
+      RWMol cp(*m);
+      MolOps::removeHs(cp);
+      CHECK(cp.getNumAtoms() == 3);
+    }
+    {
+      MolOps::RemoveHsParameters ps;
+      RWMol cp(*m);
+      MolOps::removeHs(cp, ps);
+      CHECK(cp.getNumAtoms() == 3);
+    }
+    {
+      MolOps::RemoveHsParameters ps;
+      ps.removeHigherDegrees = true;
+      RWMol cp(*m);
+      MolOps::removeHs(cp, ps);
+      CHECK(cp.getNumAtoms() == 2);
+    }
+  }
+}


### PR DESCRIPTION
Introduces a new parameters object that gives better control
We also add a `removeAllHs()` function to make it easy to really get rid of everything.