### PR TITLE
Add a cartridge test to the azure devops config

### DIFF
--- a/.azure-pipelines/linux_build_cartridge.yml
+++ b/.azure-pipelines/linux_build_cartridge.yml
@@ -1,12 +1,11 @@
 steps:
 - bash: |
-    sudo apt-get install -y postgresql-10 postgresql-server-dev-10
+    sudo apt-get install -y libboost-all-dev postgresql-10 postgresql-server-dev-10
     sudo service postgresql start
     #sudo su postgres
     sudo -u postgres createuser -s `whoami`
   displayName: Setup build environment
 - bash: |
-    echo $BOOST_ROOT
     mkdir build && cd build && \
     cmake .. \
     -DCMAKE_BUILD_TYPE=Release \

--- a/.azure-pipelines/linux_build_cartridge.yml
+++ b/.azure-pipelines/linux_build_cartridge.yml
@@ -27,7 +27,7 @@ steps:
 - bash: |
     cd build
     make -j $( $(number_of_cores) ) install
-    sh ./Code/PgSQL/rdkit/pgsql_install.sh
+    sudo sh ./Code/PgSQL/rdkit/pgsql_install.sh
   displayName: Build
 - bash: |
     cd build

--- a/.azure-pipelines/linux_build_cartridge.yml
+++ b/.azure-pipelines/linux_build_cartridge.yml
@@ -6,6 +6,7 @@ steps:
     sudo -u postgres createuser -s `whoami`
   displayName: Setup build environment
 - bash: |
+    echo $BOOST_ROOT
     mkdir build && cd build && \
     cmake .. \
     -DCMAKE_BUILD_TYPE=Release \

--- a/.azure-pipelines/linux_build_cartridge.yml
+++ b/.azure-pipelines/linux_build_cartridge.yml
@@ -1,9 +1,9 @@
 steps:
 - bash: |
-    apt-get install -y postgresql-10 postgresql-server-dev-10
-    service postgresql start
-    su postgres
-    createuser -s root
+    sudo apt-get install -y postgresql-10 postgresql-server-dev-10
+    sudo service postgresql start
+    #sudo su postgres
+    sudo -u postgres createuser -s `whoami`
   displayName: Setup build environment
 - bash: |
     mkdir build && cd build && \

--- a/.azure-pipelines/linux_build_cartridge.yml
+++ b/.azure-pipelines/linux_build_cartridge.yml
@@ -1,0 +1,36 @@
+steps:
+- bash: |
+    apt-get install -y postgresql-10 postgresql-server-dev-10
+    service postgresql start
+    su postgres
+    createuser -s root
+  displayName: Setup build environment
+- bash: |
+    mkdir build && cd build && \
+    cmake .. \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DRDK_INSTALL_INTREE=ON \
+    -DRDK_BUILD_CPP_TESTS=OFF \
+    -DRDK_BUILD_PYTHON_WRAPPERS=OFF \
+    -DRDK_USE_BOOST_REGEX=OFF \
+    -DRDK_BUILD_COORDGEN_SUPPORT=ON \
+    -DRDK_OPTIMIZE_POPCNT=ON \
+    -DRDK_BUILD_TEST_GZIP=ON \
+    -DRDK_BUILD_AVALON_SUPPORT=ON \
+    -DRDK_BUILD_INCHI_SUPPORT=ON \
+    -DRDK_BUILD_SWIG_WRAPPERS=OFF \
+    -DRDK_BUILD_THREADSAFE_SSS=ON \
+    -DRDK_TEST_MULTITHREADED=ON \
+    -DRDK_BUILD_PGSQL=ON \
+    -DPostgreSQL_CONFIG=/usr/bin/pg_config
+  displayName: Configure build (Run CMake)
+- bash: |
+    cd build
+    make -j $( $(number_of_cores) ) install
+    sh ./Code/PgSQL/rdkit/pgsql_install.sh
+  displayName: Build
+- bash: |
+    cd build
+    sh ./Code/PgSQL/rdkit/pgsql_regress.sh
+  displayName: Run tests
+

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,6 +4,74 @@ trigger:
 - dev/*
 
 jobs:
+- job: Ubuntu_16_04_x64
+  timeoutInMinutes: 90
+  pool:
+    vmImage: ubuntu-16.04
+  variables:
+    compiler: gxx_linux-64=7.2.0
+    boost_version: 1.67.0
+    number_of_cores: nproc
+    python_name: python37
+  steps:
+  - template: .azure-pipelines/linux_build.yml
+- job: macOS_10_13_x64
+  timeoutInMinutes: 90
+  pool:
+    vmImage: macos-10.13
+  variables:
+    compiler: clangxx_osx-64
+    boost_version: 1.67.0
+    number_of_cores: sysctl -n hw.ncpu
+    python_name: python37
+    target_platform: 10.9
+  steps:
+  - template: .azure-pipelines/mac_build.yml
+- job: Windows_VS2017_x64
+  timeoutInMinutes: 90
+  pool:
+    vmImage: vs2017-win2016
+  variables:
+    compiler: vs2017_win-64
+    boost_version: 1.67.0
+    number_of_cores: '%NUMBER_OF_PROCESSORS%'
+    python_name: python37
+  steps:
+  - template: .azure-pipelines/vs_build.yml
+- job: Windows_VS2017_x64_dll
+  timeoutInMinutes: 90
+  pool:
+    vmImage: vs2017-win2016
+  variables:
+    compiler: vs2017_win-64
+    boost_version: 1.67.0
+    number_of_cores: '%NUMBER_OF_PROCESSORS%'
+    python_name: python37
+  steps:
+  - template: .azure-pipelines/vs_build_dll.yml
+- job: Ubuntu_16_04_x64_java
+  timeoutInMinutes: 90
+  pool:
+    vmImage: ubuntu-16.04
+  variables:
+    compiler: gxx_linux-64=7.2.0
+    boost_version: 1.67.0
+    number_of_cores: nproc
+    python_name: python37
+  steps:
+  - template: .azure-pipelines/linux_build_java.yml
+- job: macOS_10_13_x64_java
+  timeoutInMinutes: 90
+  pool:
+    vmImage: macos-10.13
+  variables:
+    compiler: clangxx_osx-64
+    boost_version: 1.67.0
+    number_of_cores: sysctl -n hw.ncpu
+    python_name: python37
+    target_platform: 10.9
+  steps:
+  - template: .azure-pipelines/mac_build_java.yml
 - job: Ubuntu_18_04_x64_cartridge
   timeoutInMinutes: 90
   pool:
@@ -13,71 +81,3 @@ jobs:
     number_of_cores: nproc
   steps:
   - template: .azure-pipelines/linux_build_cartridge.yml
-# - job: Ubuntu_16_04_x64
-#   timeoutInMinutes: 90
-#   pool:
-#     vmImage: ubuntu-16.04
-#   variables:
-#     compiler: gxx_linux-64=7.2.0
-#     boost_version: 1.67.0
-#     number_of_cores: nproc
-#     python_name: python37
-#   steps:
-#   - template: .azure-pipelines/linux_build.yml
-# - job: macOS_10_13_x64
-#   timeoutInMinutes: 90
-#   pool:
-#     vmImage: macos-10.13
-#   variables:
-#     compiler: clangxx_osx-64
-#     boost_version: 1.67.0
-#     number_of_cores: sysctl -n hw.ncpu
-#     python_name: python37
-#     target_platform: 10.9
-#   steps:
-#   - template: .azure-pipelines/mac_build.yml
-# - job: Windows_VS2017_x64
-#   timeoutInMinutes: 90
-#   pool:
-#     vmImage: vs2017-win2016
-#   variables:
-#     compiler: vs2017_win-64
-#     boost_version: 1.67.0
-#     number_of_cores: '%NUMBER_OF_PROCESSORS%'
-#     python_name: python37
-#   steps:
-#   - template: .azure-pipelines/vs_build.yml
-# - job: Windows_VS2017_x64_dll
-#   timeoutInMinutes: 90
-#   pool:
-#     vmImage: vs2017-win2016
-#   variables:
-#     compiler: vs2017_win-64
-#     boost_version: 1.67.0
-#     number_of_cores: '%NUMBER_OF_PROCESSORS%'
-#     python_name: python37
-#   steps:
-#   - template: .azure-pipelines/vs_build_dll.yml
-# - job: Ubuntu_16_04_x64_java
-#   timeoutInMinutes: 90
-#   pool:
-#     vmImage: ubuntu-16.04
-#   variables:
-#     compiler: gxx_linux-64=7.2.0
-#     boost_version: 1.67.0
-#     number_of_cores: nproc
-#     python_name: python37
-#   steps:
-#   - template: .azure-pipelines/linux_build_java.yml
-# - job: macOS_10_13_x64_java
-#   timeoutInMinutes: 90
-#   pool:
-#     vmImage: macos-10.13
-#   variables:
-#     compiler: clangxx_osx-64
-#     boost_version: 1.67.0
-#     number_of_cores: sysctl -n hw.ncpu
-#     python_name: python37
-#     target_platform: 10.9
-#   steps:
-#   - template: .azure-pipelines/mac_build_java.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -80,4 +80,4 @@ jobs:
     boost_version: 1.69.0
     number_of_cores: nproc
   steps:
-  - template: .azure-pipelines/linux_build_catridge.yml
+  - template: .azure-pipelines/linux_build_cartridge.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -72,3 +72,12 @@ jobs:
     target_platform: 10.9
   steps:
   - template: .azure-pipelines/mac_build_java.yml
+- job: Ubuntu_18_04_x64 cartridge
+  timeoutInMinutes: 90
+  pool:
+    vmImage: ubuntu-18.04
+  variables:
+    boost_version: 1.69.0
+    number_of_cores: nproc
+  steps:
+  - template: .azure-pipelines/linux_build_catridge.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,75 +4,7 @@ trigger:
 - dev/*
 
 jobs:
-- job: Ubuntu_16_04_x64
-  timeoutInMinutes: 90
-  pool:
-    vmImage: ubuntu-16.04
-  variables:
-    compiler: gxx_linux-64=7.2.0
-    boost_version: 1.67.0
-    number_of_cores: nproc
-    python_name: python37
-  steps:
-  - template: .azure-pipelines/linux_build.yml
-- job: macOS_10_13_x64
-  timeoutInMinutes: 90
-  pool:
-    vmImage: macos-10.13
-  variables:
-    compiler: clangxx_osx-64
-    boost_version: 1.67.0
-    number_of_cores: sysctl -n hw.ncpu
-    python_name: python37
-    target_platform: 10.9
-  steps:
-  - template: .azure-pipelines/mac_build.yml
-- job: Windows_VS2017_x64
-  timeoutInMinutes: 90
-  pool:
-    vmImage: vs2017-win2016
-  variables:
-    compiler: vs2017_win-64
-    boost_version: 1.67.0
-    number_of_cores: '%NUMBER_OF_PROCESSORS%'
-    python_name: python37
-  steps:
-  - template: .azure-pipelines/vs_build.yml
-- job: Windows_VS2017_x64_dll
-  timeoutInMinutes: 90
-  pool:
-    vmImage: vs2017-win2016
-  variables:
-    compiler: vs2017_win-64
-    boost_version: 1.67.0
-    number_of_cores: '%NUMBER_OF_PROCESSORS%'
-    python_name: python37
-  steps:
-  - template: .azure-pipelines/vs_build_dll.yml
-- job: Ubuntu_16_04_x64_java
-  timeoutInMinutes: 90
-  pool:
-    vmImage: ubuntu-16.04
-  variables:
-    compiler: gxx_linux-64=7.2.0
-    boost_version: 1.67.0
-    number_of_cores: nproc
-    python_name: python37
-  steps:
-  - template: .azure-pipelines/linux_build_java.yml
-- job: macOS_10_13_x64_java
-  timeoutInMinutes: 90
-  pool:
-    vmImage: macos-10.13
-  variables:
-    compiler: clangxx_osx-64
-    boost_version: 1.67.0
-    number_of_cores: sysctl -n hw.ncpu
-    python_name: python37
-    target_platform: 10.9
-  steps:
-  - template: .azure-pipelines/mac_build_java.yml
-- job: Ubuntu_18_04_x64 cartridge
+- job: Ubuntu_18_04_x64_cartridge
   timeoutInMinutes: 90
   pool:
     vmImage: ubuntu-18.04
@@ -81,3 +13,71 @@ jobs:
     number_of_cores: nproc
   steps:
   - template: .azure-pipelines/linux_build_cartridge.yml
+# - job: Ubuntu_16_04_x64
+#   timeoutInMinutes: 90
+#   pool:
+#     vmImage: ubuntu-16.04
+#   variables:
+#     compiler: gxx_linux-64=7.2.0
+#     boost_version: 1.67.0
+#     number_of_cores: nproc
+#     python_name: python37
+#   steps:
+#   - template: .azure-pipelines/linux_build.yml
+# - job: macOS_10_13_x64
+#   timeoutInMinutes: 90
+#   pool:
+#     vmImage: macos-10.13
+#   variables:
+#     compiler: clangxx_osx-64
+#     boost_version: 1.67.0
+#     number_of_cores: sysctl -n hw.ncpu
+#     python_name: python37
+#     target_platform: 10.9
+#   steps:
+#   - template: .azure-pipelines/mac_build.yml
+# - job: Windows_VS2017_x64
+#   timeoutInMinutes: 90
+#   pool:
+#     vmImage: vs2017-win2016
+#   variables:
+#     compiler: vs2017_win-64
+#     boost_version: 1.67.0
+#     number_of_cores: '%NUMBER_OF_PROCESSORS%'
+#     python_name: python37
+#   steps:
+#   - template: .azure-pipelines/vs_build.yml
+# - job: Windows_VS2017_x64_dll
+#   timeoutInMinutes: 90
+#   pool:
+#     vmImage: vs2017-win2016
+#   variables:
+#     compiler: vs2017_win-64
+#     boost_version: 1.67.0
+#     number_of_cores: '%NUMBER_OF_PROCESSORS%'
+#     python_name: python37
+#   steps:
+#   - template: .azure-pipelines/vs_build_dll.yml
+# - job: Ubuntu_16_04_x64_java
+#   timeoutInMinutes: 90
+#   pool:
+#     vmImage: ubuntu-16.04
+#   variables:
+#     compiler: gxx_linux-64=7.2.0
+#     boost_version: 1.67.0
+#     number_of_cores: nproc
+#     python_name: python37
+#   steps:
+#   - template: .azure-pipelines/linux_build_java.yml
+# - job: macOS_10_13_x64_java
+#   timeoutInMinutes: 90
+#   pool:
+#     vmImage: macos-10.13
+#   variables:
+#     compiler: clangxx_osx-64
+#     boost_version: 1.67.0
+#     number_of_cores: sysctl -n hw.ncpu
+#     python_name: python37
+#     target_platform: 10.9
+#   steps:
+#   - template: .azure-pipelines/mac_build_java.yml


### PR DESCRIPTION
Adds a new configuration and does a basic build against the system (ubuntu 18.04) postgresql install.

I just did a linux version of this because (I believe) we don't really need to do cross-platform testing of the cartridge. A possible exception to this could be windows... if we could get a reproducible windows cartridge build working in azure devops