### PR TITLE
Fixing docs for Chem/FragmentMatcher.py

### DIFF
--- a/rdkit/Chem/FragmentMatcher.py
+++ b/rdkit/Chem/FragmentMatcher.py
@@ -7,15 +7,17 @@
 #  which is included in the file license.txt, found at the root
 #  of the RDKit source tree.
 #
-""" exposes a class for matching fragments of molecules.
+"""Exposes a class for matching fragments of molecules.
 
 The class exposes a simple API:
 
 If you want a matcher that hits C=O, you'd do:
+
 >>> p = FragmentMatcher()
 >>> p.Init('C=O')
 
 you can then match with:
+
 >>> mol = Chem.MolFromSmiles('CC(=O)O')
 >>> p.HasMatch(mol)
 1
@@ -23,15 +25,18 @@ you can then match with:
 0
 
 information about the matches:
+
 >>> len(p.GetMatches(Chem.MolFromSmiles('CC=O')))
 1
 >>> len(p.GetMatches(Chem.MolFromSmiles('O=CC=O')))
 2
 
 or, you can add exclusion fragments (defined as smarts) with:
+
 >>> p.AddExclusion('c1ccccc1')
 
 now the matcher will not hit anything that has a benzene ring.
+
 >>> p.HasMatch(Chem.MolFromSmiles('CC=O'))
 1
 >>> p.HasMatch(Chem.MolFromSmiles('c1ccccc1CC=O'))


### PR DESCRIPTION
hopefully ipython examples are rendered properly now

#### What does this implement/fix? Explain your changes.

Docs here aren't being rendered, I think this is because of missing blank lines

https://www.rdkit.org/docs/source/rdkit.Chem.FragmentMatcher.html

#### Any other comments?

I think this should work, I couldn't find the instructions for how to build the docs locally to check though
