### PR TITLE
Fixes #2881

### DIFF
--- a/Code/GraphMol/FileParsers/MaeMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/MaeMolSupplier.cpp
@@ -158,6 +158,7 @@ void parseChiralityLabel(RWMol &mol, const std::string &stereo_prop) {
   for (++tItr; tItr != tokenizer.end(); ++tItr) {
     const int nbr_idx = FileParserUtils::toInt(*tItr) - 1;
     const Bond *bnd = mol.getBondBetweenAtoms(chiral_idx, nbr_idx);
+    CHECK_INVARIANT(bnd, "bad chiral bond");
     bond_indexes.push_back(bnd->getIdx());
   }
   CHECK_INVARIANT(bond_indexes.size() == chiral_atom->getDegree(),

--- a/Code/GraphMol/FileParsers/testMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/testMolSupplier.cpp
@@ -2677,6 +2677,112 @@ M  END
   }
 }
 
+void testGitHub2881() {
+  std::string data = R"DATA(f_m_ct { 
+ s_m_title
+ s_m_entry_id
+ s_m_entry_name
+ s_m_Source_Path
+ s_m_Source_File
+ i_m_Source_File_Index
+ s_st_Chirality_1
+ s_st_Chirality_2
+ s_m_subgroup_title
+ s_m_subgroupid
+ b_m_subgroup_collapsed
+ i_m_ct_format
+ :::
+ "Untitled Document-4" 
+  17 
+  newTemplates2.1 
+  /Users/nicola/schrodinger/coordgen_standalone 
+  templates.mae 
+  17
+  3_S_4_6_2 
+  7_S_8_9_6_10 
+  templates->templates->templates 
+  templates->templates1->templates11 
+  0
+  2
+ m_depend[2] { 
+  # First column is dependency index #
+  i_m_depend_dependency
+  s_m_depend_property
+  :::
+  1 10 s_st_Chirality_1 
+  2 10 s_st_Chirality_2 
+  :::
+ } 
+ m_atom[15] { 
+  # First column is atom index #
+  i_m_mmod_type
+  r_m_x_coord
+  r_m_y_coord
+  r_m_z_coord
+  i_m_residue_number
+  i_m_color
+  i_m_atomic_number
+  s_m_color_rgb
+  s_m_atom_name
+  :::
+  1 5 1.186400 1.035900 0.000000 900 2 6 A0A0A0  C1 
+  2 5 0.370300 1.157000 0.000000 900 2 6 A0A0A0  C2 
+  3 4 -0.326500 0.715300 0.000000 900 2 6 A0A0A0  C3 
+  4 5 0.085100 0.000400 0.000000 900 2 6 A0A0A0  C4 
+  5 26 -0.328300 -0.713600 0.000000 900 43 7 5757FF  N5 
+  6 5 -1.151500 0.716400 0.000000 900 2 6 A0A0A0  C6 
+  7 5 -1.564900 0.002400 0.000000 900 2 6 A0A0A0  C7 
+  8 5 -1.153300 -0.712600 0.000000 900 2 6 A0A0A0  C9 
+  9 2 1.724800 0.410800 0.000000 900 2 6 A0A0A0  C12 
+  10 2 1.723800 -0.414200 0.000000 900 2 6 A0A0A0  C13 
+  11 5 1.183800 -1.037900 0.000000 900 2 6 A0A0A0  C14 
+  12 5 0.367400 -1.157000 0.000000 900 2 6 A0A0A0  C15 
+  13 7 2.508100 -0.670100 0.000000 900 2 6 A0A0A0  C16 
+  14 7 2.993800 -0.003300 0.000000 900 2 6 A0A0A0  C17 
+  15 29 2.509700 0.664800 0.000000 900 43 7 5757FF  N18 
+  :::
+ } 
+ m_bond[17] { 
+  # First column is bond index #
+  i_m_from
+  i_m_to
+  i_m_order
+  :::
+  1 1 2 1
+  2 1 9 1
+  3 2 3 1
+  4 3 4 1
+  5 3 6 1
+  6 4 5 1
+  7 5 8 1
+  8 5 12 1
+  9 6 7 1
+  10 7 8 1
+  11 9 10 2
+  12 9 15 1
+  13 10 11 1
+  14 10 13 1
+  15 11 12 1
+  16 13 14 2
+  17 14 15 1
+  :::
+ } 
+} 
+)DATA";
+  {
+    std::istringstream *iss = new std::istringstream(data);
+    bool sanitize = false;
+    bool takeOwnership = true;
+    MaeMolSupplier suppl(iss, takeOwnership, sanitize);
+    ROMol *mol = nullptr;
+    try {
+      mol = suppl.next();
+    } catch (...) {
+    }
+    TEST_ASSERT(!mol);
+  }
+}
+
 int main() {
   RDLog::InitLogs();
 
@@ -2859,6 +2965,11 @@ int main() {
   BOOST_LOG(rdErrorLog) << "-----------------------------------------\n";
   testGitHub2479();
   BOOST_LOG(rdErrorLog) << "Finished: testGitHub2479()\n";
+  BOOST_LOG(rdErrorLog) << "-----------------------------------------\n\n";
+
+  BOOST_LOG(rdErrorLog) << "-----------------------------------------\n";
+  testGitHub2881();
+  BOOST_LOG(rdErrorLog) << "Finished: testGitHub2881()\n";
   BOOST_LOG(rdErrorLog) << "-----------------------------------------\n\n";
 
   return 0;

--- a/Code/GraphMol/FileParsers/testMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/testMolSupplier.cpp
@@ -2777,7 +2777,7 @@ void testGitHub2881() {
     ROMol *mol = nullptr;
     try {
       mol = suppl.next();
-    } catch (...) {
+    } catch (Invar::Invariant) {
     }
     TEST_ASSERT(!mol);
   }


### PR DESCRIPTION
We should also consider changing the behavior of `MaeMolSupplier` for the next release and make it throw an easily recognizable exception (maybe `FileParseException`) when it hits bad stuff in the input instead of using invariants for everything. But that's an enhancement for the next release.