### PR TITLE
Add MolVS tautomer canonicalization

### DIFF
--- a/Code/GraphMol/MolStandardize/MolStandardize.cpp
+++ b/Code/GraphMol/MolStandardize/MolStandardize.cpp
@@ -145,11 +145,9 @@ std::vector<std::string> enumerateTautomerSmiles(
 
   auto *tautparams = new TautomerCatalogParams(params.tautomerTransforms);
   //	unsigned int ntautomers = tautparams->getNumTautomers();
-  TautomerCatalog tautcat(tautparams);
-  TautomerEnumerator te;
+  TautomerEnumerator te(new TautomerCatalog(tautparams));
 
-  std::vector<ROMOL_SPTR> res =
-      te.enumerate(static_cast<ROMol>(*mol), &tautcat);
+  std::vector<ROMOL_SPTR> res = te.enumerate(*mol);
 
   std::vector<std::string> tsmiles;
   for (const auto &r : res) {

--- a/Code/GraphMol/MolStandardize/Tautomer.cpp
+++ b/Code/GraphMol/MolStandardize/Tautomer.cpp
@@ -160,7 +160,7 @@ unsigned int MAX_TAUTOMERS = 1000;
 
 ROMol *TautomerEnumerator::pickCanonical(
     const std::vector<ROMOL_SPTR> &tautomers,
-    int (*scoreFunc)(const ROMol &)) const {
+    boost::function<int(const ROMol &mol)> scoreFunc) const {
   PRECONDITION(scoreFunc, "no scoring function");
   if (tautomers.size() == 1) {
     return new ROMol(*tautomers[0]);

--- a/Code/GraphMol/MolStandardize/Tautomer.cpp
+++ b/Code/GraphMol/MolStandardize/Tautomer.cpp
@@ -140,7 +140,9 @@ int scoreHeteroHs(const ROMol &mol) {
 unsigned int MAX_TAUTOMERS = 1000;
 
 ROMol *TautomerEnumerator::pickCanonical(
-    const std::vector<ROMOL_SPTR> &tautomers) const {
+    const std::vector<ROMOL_SPTR> &tautomers,
+    int (*scoreFunc)(const ROMol &)) const {
+  PRECONDITION(scoreFunc, "no scoring function");
   if (tautomers.size() == 1) {
     return new ROMol(*tautomers[0]);
   }
@@ -149,7 +151,7 @@ ROMol *TautomerEnumerator::pickCanonical(
   std::string bestSmiles = "";
   ROMOL_SPTR bestMol;
   for (const auto t : tautomers) {
-    auto score = TautomerScoringFunctions::scoreTautomer(*t);
+    auto score = scoreFunc(*t);
     if (score > bestScore) {
       bestScore = score;
       bestSmiles = MolToSmiles(*t);

--- a/Code/GraphMol/MolStandardize/Tautomer.cpp
+++ b/Code/GraphMol/MolStandardize/Tautomer.cpp
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2018 Susan H. Leung
+//  Copyright (C) 2018-2020 Susan H. Leung and Greg Landrum
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -12,7 +12,10 @@
 #include <GraphMol/MolStandardize/FragmentCatalog/FragmentCatalogUtils.h>
 #include <GraphMol/SmilesParse/SmilesParse.h>
 #include <GraphMol/SmilesParse/SmilesWrite.h>
+#include <GraphMol/Substruct/SubstructMatch.h>
+#include <boost/dynamic_bitset.hpp>
 #include <algorithm>
+#include <limits>
 
 using namespace RDKit;
 
@@ -20,41 +23,154 @@ namespace RDKit {
 
 namespace MolStandardize {
 
+namespace detail {
+std::vector<std::pair<unsigned int, unsigned int>> pairwise(
+    const std::vector<int> vect) {
+  std::vector<std::pair<unsigned int, unsigned int>> pvect;
+  for (size_t i = 0; i < vect.size() - 1; ++i) {
+    std::pair<unsigned int, unsigned int> p =
+        std::pair<unsigned int, unsigned int>(vect[i], vect[i + 1]);
+    pvect.push_back(p);
+  }
+  return pvect;
+}
+
+}  // namespace detail
+
+namespace TautomerScoringFunctions {
+int scoreRings(const ROMol &mol) {
+  int score = 0;
+  auto ringInfo = mol.getRingInfo();
+  std::unique_ptr<ROMol> cp;
+  if (!ringInfo->isInitialized()) {
+    cp.reset(new ROMol(mol));
+    MolOps::symmetrizeSSSR(*cp);
+    ringInfo = cp->getRingInfo();
+  }
+  boost::dynamic_bitset<> isArom(mol.getNumBonds());
+  boost::dynamic_bitset<> bothCarbon(mol.getNumBonds());
+  for (const auto &bnd : mol.bonds()) {
+    if (bnd->getIsAromatic()) {
+      isArom.set(bnd->getIdx());
+      if(bnd->getBeginAtom()->getAtomicNum()==6 && bnd->getEndAtom()->getAtomicNum()==6){
+        bothCarbon.set(bnd->getIdx());
+      }
+    }
+  }
+  for (const auto &bring : ringInfo->bondRings()) {
+    bool allC = true;
+    bool allAromatic = true;
+    for (const auto bidx : bring) {
+      if (!isArom[bidx]) {
+        allAromatic = false;
+        break;
+      }
+      if(!bothCarbon[bidx]){
+        allC = false;
+      }
+    }
+    if (allAromatic) {
+      score += 100;
+      if (allC) {
+        score += 150;
+      }
+    }
+  }
+  return score;
+};
+
+struct SubstructTerm {
+  std::string name;
+  std::string smarts;
+  int score;
+  std::shared_ptr<ROMol> matcher;
+  SubstructTerm(const std::string &aname, const std::string &asmarts,
+                int ascore)
+      : name(aname), smarts(asmarts), score(ascore) {
+    matcher.reset(SmartsToMol(smarts));
+  };
+};
+
+int scoreSubstructs(const ROMol &mol) {
+  // EFF: this is really not the best way to do this.
+  const std::vector<SubstructTerm> substructureTerms{
+      {"benzoquinone", "[#6]1([#6]=[#6][#6]([#6]=[#6]1)=,:[N,S,O])=,:[N,S,O]",
+       25},
+      {"oxim", "[#6]=[N][OH]", 4},
+      {"C=O", "[#6]=,:[#8]", 2},
+      {"N=O", "[#7]=,:[#8]", 2},
+      {"P=O", "[#15]=,:[#8]", 2},
+      {"C=hetero", "[#6]=[!#1;!#6]", 1},
+      {"methyl", "[CX4H3]", 1},
+      {"guanidine terminal=N", "[#7][#6](=[NR0])[#7H0]", 1},
+      {"guanidine endocyclic=N", "[#7;R][#6;R]([N])=[#7;R]", 2},
+      {"aci-nitro", "[#6]=[N+]([O-])[OH]", -4}};
+  int score = 0;
+  for (const auto &term : substructureTerms) {
+    if (!term.matcher) {
+      BOOST_LOG(rdErrorLog) << " matcher for term " << term.name
+                            << " is invalid, ignoring it." << std::endl;
+      continue;
+    }
+    SubstructMatchParameters params;
+    const auto matches = SubstructMatch(mol, *term.matcher, params);
+    // if (!matches.empty()) {
+    //   std::cerr << " " << matches.size() << " matches to " << term.name
+    //             << std::endl;
+    // }
+    score += matches.size() * term.score;
+  }
+  return score;
+};
+int scoreHeteroHs(const ROMol &mol) { 
+  int score=0;
+  for(const auto &at:mol.atoms()){
+    int anum = at->getAtomicNum();
+    if(anum==15 || anum==16 || anum==34 || anum==52){
+      score -= at->getTotalNumHs();
+    }
+  }
+  return score;
+  
+  return 1; };
+}  // namespace TautomerScoringFunctions
+
 unsigned int MAX_TAUTOMERS = 1000;
 
 ROMol *TautomerCanonicalizer::canonicalize(const ROMol &mol,
                                            TautomerCatalog *tautcat) {
-  PRECONDITION(tautcat, "tautcat not provided");
-  // REVIEW: I think it's a good idea to raise an error if this unfinished code
-  // is called.
-  UNDER_CONSTRUCTION("Tautomer canonicalization not yet implemented");
   TautomerEnumerator tenum;
   std::vector<ROMOL_SPTR> tautomers = tenum.enumerate(mol, tautcat);
   if (tautomers.size() == 1) {
-    return tautomers[0].get();
+    return new ROMol(*tautomers[0]);
   }
   // Calculate score for each tautomer
+  int bestScore = std::numeric_limits<int>::min();
+  std::string bestSmiles = "";
+  ROMOL_SPTR bestMol;
   for (const auto t : tautomers) {
-    std::string smiles = MolToSmiles(*t);
-    std::cout << "Tautomer: " << smiles << std::endl;
-    // unsigned int score = 0;
-    // Add aromatic ring scores
-    VECT_INT_VECT rings;
-    MolOps::symmetrizeSSSR(*t, rings);
-    // for (const auto ring : rings) {
-    //   for (const auto pair : MolStandardize::pairwise(ring)) {
-    //     			std::cout << pair.first << " " <<
-    //     pair.second
-    //     << std::endl;
-    //     Bond::BondType btype =
-    //         t->getBondBetweenAtoms(pair.first, pair.second)->getBondType();
-    //     			std::cout << btype << std::endl;
-    //     Stopping for the moment to do the Python wrap
-    //   }
-    // }
+    auto score = TautomerScoringFunctions::scoreTautomer(*t);
+    // std::cerr<<"    "<<MolToSmiles(*t)<<" "<<score<<std::endl;
+    if (score > bestScore) {
+      bestScore = score;
+      bestSmiles = MolToSmiles(*t);
+      bestMol = t;
+    } else if (score == bestScore) {
+      auto smiles = MolToSmiles(*t);
+      if (smiles < bestSmiles) {
+        bestSmiles = smiles;
+        bestMol = t;
+      }
+    }
   }
 
-  return new ROMol(mol);
+  if (!bestSmiles.empty()) {
+    return new ROMol(*bestMol);
+  } else {
+    BOOST_LOG(rdWarningLog)
+        << "no tautomers found, returning input molecule" << std::endl;
+    return new ROMol(mol);
+  }
 }
 
 std::vector<ROMOL_SPTR> TautomerEnumerator::enumerate(
@@ -143,7 +259,7 @@ std::vector<ROMOL_SPTR> TautomerEnumerator::enumerate(
             // Adjust bond orders
             unsigned int bi = 0;
             std::vector<std::pair<unsigned int, unsigned int>> pvect =
-                MolStandardize::pairwise(idx_matches);
+                detail::pairwise(idx_matches);
             for (const auto &pair : pvect) {
               Bond *bond =
                   product->getBondBetweenAtoms(pair.first, pair.second);
@@ -268,17 +384,6 @@ std::vector<ROMOL_SPTR> TautomerEnumerator::enumerate(
     // std::cout << MolToSmiles(*(tautomer.second)) << std::endl;
   }
   return res;
-}
-
-std::vector<std::pair<unsigned int, unsigned int>> pairwise(
-    const std::vector<int> vect) {
-  std::vector<std::pair<unsigned int, unsigned int>> pvect;
-  for (size_t i = 0; i < vect.size() - 1; ++i) {
-    std::pair<unsigned int, unsigned int> p =
-        std::pair<unsigned int, unsigned int>(vect[i], vect[i + 1]);
-    pvect.push_back(p);
-  }
-  return pvect;
 }
 
 }  // namespace MolStandardize

--- a/Code/GraphMol/MolStandardize/Tautomer.cpp
+++ b/Code/GraphMol/MolStandardize/Tautomer.cpp
@@ -52,7 +52,8 @@ int scoreRings(const ROMol &mol) {
   for (const auto &bnd : mol.bonds()) {
     if (bnd->getIsAromatic()) {
       isArom.set(bnd->getIdx());
-      if(bnd->getBeginAtom()->getAtomicNum()==6 && bnd->getEndAtom()->getAtomicNum()==6){
+      if (bnd->getBeginAtom()->getAtomicNum() == 6 &&
+          bnd->getEndAtom()->getAtomicNum() == 6) {
         bothCarbon.set(bnd->getIdx());
       }
     }
@@ -65,7 +66,7 @@ int scoreRings(const ROMol &mol) {
         allAromatic = false;
         break;
       }
-      if(!bothCarbon[bidx]){
+      if (!bothCarbon[bidx]) {
         allC = false;
       }
     }
@@ -122,17 +123,18 @@ int scoreSubstructs(const ROMol &mol) {
   }
   return score;
 };
-int scoreHeteroHs(const ROMol &mol) { 
-  int score=0;
-  for(const auto &at:mol.atoms()){
+int scoreHeteroHs(const ROMol &mol) {
+  int score = 0;
+  for (const auto &at : mol.atoms()) {
     int anum = at->getAtomicNum();
-    if(anum==15 || anum==16 || anum==34 || anum==52){
+    if (anum == 15 || anum == 16 || anum == 34 || anum == 52) {
       score -= at->getTotalNumHs();
     }
   }
   return score;
-  
-  return 1; };
+
+  return 1;
+};
 }  // namespace TautomerScoringFunctions
 
 unsigned int MAX_TAUTOMERS = 1000;

--- a/Code/GraphMol/MolStandardize/Tautomer.h
+++ b/Code/GraphMol/MolStandardize/Tautomer.h
@@ -49,15 +49,19 @@ class RDKIT_MOLSTANDARDIZE_EXPORT TautomerEnumerator {
   }
 
   std::vector<ROMOL_SPTR> enumerate(const ROMol &mol) const;
-  ROMol *pickCanonical(const std::vector<ROMOL_SPTR> &tautomers) const;
-  ROMol *canonicalize(const ROMol &mol) const {
+  ROMol *pickCanonical(const std::vector<ROMOL_SPTR> &tautomers,
+                       int (*scoreFunc)(const ROMol &) =
+                           TautomerScoringFunctions::scoreTautomer) const;
+  ROMol *canonicalize(const ROMol &mol,
+                      int (*scoreFunc)(const ROMol &) =
+                          TautomerScoringFunctions::scoreTautomer) const {
     auto tautomers = enumerate(mol);
     if (!tautomers.size()) {
       BOOST_LOG(rdWarningLog)
           << "no tautomers found, returning input molecule" << std::endl;
       return new ROMol(mol);
     }
-    return pickCanonical(tautomers);
+    return pickCanonical(tautomers, scoreFunc);
   };
 
  private:

--- a/Code/GraphMol/MolStandardize/Tautomer.h
+++ b/Code/GraphMol/MolStandardize/Tautomer.h
@@ -8,8 +8,8 @@
 //  of the RDKit source tree.
 //
 #include <RDGeneral/export.h>
-#ifndef __RD_TAUTOMER_H__
-#define __RD_TAUTOMER_H__
+#ifndef RD_TAUTOMER_H
+#define RD_TAUTOMER_H
 
 #include <string>
 #include <Catalogs/Catalog.h>
@@ -26,50 +26,27 @@ typedef RDCatalog::HierarchCatalog<TautomerCatalogEntry, TautomerCatalogParams,
                                    int>
     TautomerCatalog;
 
+namespace TautomerScoringFunctions{
+  RDKIT_MOLSTANDARDIZE_EXPORT int scoreRings(const ROMol &mol);
+  RDKIT_MOLSTANDARDIZE_EXPORT int scoreSubstructs(const ROMol &mol);
+  RDKIT_MOLSTANDARDIZE_EXPORT int scoreHeteroHs(const ROMol &mol);
+
+  inline int scoreTautomer(const ROMol &mol){
+    return scoreRings(mol)+scoreSubstructs(mol)+scoreHeteroHs(mol);
+  }
+}
+
+
 class RDKIT_MOLSTANDARDIZE_EXPORT TautomerCanonicalizer {
  public:
-  //	TautomerCanonicalizer(unsigned int max_tautomers)
-  //			: MAX_TAUTOMERS(max_tautomers) {};
-  //	TautomerCanonicalizer(const TautomerCanonicalizer &other) {
-  //		MAX_TAUTOMERS = other.MAX_TAUTOMERS;
-  //	};
-  //	~TautomerCanonicalizer() {};
-
   ROMol *canonicalize(const ROMol &mol, TautomerCatalog *tautcat);
-
-  //	private:
-  //		unsigned int MAX_TAUTOMERS;
 };  // TautomerCanonicalizer class
 
 class RDKIT_MOLSTANDARDIZE_EXPORT TautomerEnumerator {
  public:
   std::vector<ROMOL_SPTR> enumerate(const ROMol &mol, TautomerCatalog *tautcat);
-
-  //		struct Tautomer {
-  //			std::string Smiles;
-  //			boost::shared_ptr<ROMol> Mol;
-  //			Tautomer(std::string smiles, boost::shared_ptr<ROMol>
-  // mol) 				: Smiles(smiles), Mol(mol) {}
-  //
-  //			// sorting products alphabetically by SMILES
-  //			bool operator < (const Tautomer &tautomer) const {
-  //				return (Smiles < tautomer.Smiles);
-  //			}
-  //
-  //		};
-
-  //		TautomerEnumerator(unsigned int max_tautomers)
-  //			: MAX_TAUTOMERS(max_tautomers) {};
-  //		TautomerEnumerator(const TautomerEnumerator &other) {
-  //			MAX_TAUTOMERS = other.MAX_TAUTOMERS;
-  //		};
-  //		~TautomerEnumerator() {};
-  //	private:
-  //		unsigned int MAX_TAUTOMERS;
 };  // TautomerEnumerator class
 
-std::vector<std::pair<unsigned int, unsigned int>> pairwise(
-    const std::vector<int> vect);
 }  // namespace MolStandardize
 }  // namespace RDKit
 

--- a/Code/GraphMol/MolStandardize/Tautomer.h
+++ b/Code/GraphMol/MolStandardize/Tautomer.h
@@ -28,6 +28,8 @@ typedef RDCatalog::HierarchCatalog<TautomerCatalogEntry, TautomerCatalogParams,
     TautomerCatalog;
 
 namespace TautomerScoringFunctions {
+const std::string tautomerScoringVersion = "1.0.0";
+
 RDKIT_MOLSTANDARDIZE_EXPORT int scoreRings(const ROMol &mol);
 RDKIT_MOLSTANDARDIZE_EXPORT int scoreSubstructs(const ROMol &mol);
 RDKIT_MOLSTANDARDIZE_EXPORT int scoreHeteroHs(const ROMol &mol);
@@ -49,10 +51,29 @@ class RDKIT_MOLSTANDARDIZE_EXPORT TautomerEnumerator {
     return *this;
   }
 
+  //! returns all tautomers for the input molecule
   std::vector<ROMOL_SPTR> enumerate(const ROMol &mol) const;
+
+  //! returns the canonical tautomer from a set of possible tautomers
+  /*!
+    Note that the canonical tautomer is very likely not the most stable tautomer
+    for any given conditions. The default scoring rules are designed to produce
+    "reasonable" tautomers, but the primary concern is that the results are
+    canonical: you always get the same canonical tautomer for a molecule
+    regardless of what the input tautomer or atom ordering were.
+  */
   ROMol *pickCanonical(const std::vector<ROMOL_SPTR> &tautomers,
                        boost::function<int(const ROMol &mol)> scoreFunc =
                            TautomerScoringFunctions::scoreTautomer) const;
+
+  //! returns the canonical tautomer for a molecule
+  /*!
+    Note that the canonical tautomer is very likely not the most stable tautomer
+    for any given conditions. The default scoring rules are designed to produce
+    "reasonable" tautomers, but the primary concern is that the results are
+    canonical: you always get the same canonical tautomer for a molecule
+    regardless of what the input tautomer or atom ordering were.
+  */
   ROMol *canonicalize(const ROMol &mol,
                       boost::function<int(const ROMol &mol)> scoreFunc =
                           TautomerScoringFunctions::scoreTautomer) const {

--- a/Code/GraphMol/MolStandardize/Tautomer.h
+++ b/Code/GraphMol/MolStandardize/Tautomer.h
@@ -11,6 +11,7 @@
 #ifndef RD_TAUTOMER_H
 #define RD_TAUTOMER_H
 
+#include <boost/function.hpp>
 #include <string>
 #include <Catalogs/Catalog.h>
 #include <GraphMol/MolStandardize/TautomerCatalog/TautomerCatalogEntry.h>
@@ -50,10 +51,10 @@ class RDKIT_MOLSTANDARDIZE_EXPORT TautomerEnumerator {
 
   std::vector<ROMOL_SPTR> enumerate(const ROMol &mol) const;
   ROMol *pickCanonical(const std::vector<ROMOL_SPTR> &tautomers,
-                       int (*scoreFunc)(const ROMol &) =
+                       boost::function<int(const ROMol &mol)> scoreFunc =
                            TautomerScoringFunctions::scoreTautomer) const;
   ROMol *canonicalize(const ROMol &mol,
-                      int (*scoreFunc)(const ROMol &) =
+                      boost::function<int(const ROMol &mol)> scoreFunc =
                           TautomerScoringFunctions::scoreTautomer) const {
     auto tautomers = enumerate(mol);
     if (!tautomers.size()) {

--- a/Code/GraphMol/MolStandardize/Wrap/CMakeLists.txt
+++ b/Code/GraphMol/MolStandardize/Wrap/CMakeLists.txt
@@ -1,6 +1,6 @@
 remove_definitions(-DRDKIT_MOLSTANDARDIZE_BUILD)
 rdkit_python_extension(rdMolStandardize rdMolStandardize.cpp Validate.cpp
-	Charge.cpp Fragment.cpp Normalize.cpp Metal.cpp
+	Charge.cpp Fragment.cpp Normalize.cpp Metal.cpp Tautomer.cpp
                        DEST Chem/MolStandardize
                        LINK_LIBRARIES
 LINK_LIBRARIES MolStandardize SmilesParse

--- a/Code/GraphMol/MolStandardize/Wrap/Tautomer.cpp
+++ b/Code/GraphMol/MolStandardize/Wrap/Tautomer.cpp
@@ -31,6 +31,11 @@ MolStandardize::TautomerEnumerator *EnumeratorFromParams(
   return new MolStandardize::TautomerEnumerator(cat);
 }
 
+MolStandardize::TautomerEnumerator *createDefaultEnumerator() {
+  MolStandardize::CleanupParameters ps;
+  return EnumeratorFromParams(ps);
+}
+
 ROMol *canonicalizeHelper(MolStandardize::TautomerEnumerator &self,
                           const ROMol &mol) {
   return self.canonicalize(mol);
@@ -43,15 +48,14 @@ struct tautomer_wrapper {
 
     python::class_<MolStandardize::TautomerEnumerator, boost::noncopyable>(
         "TautomerEnumerator", python::no_init)
+        .def("__init__", python::make_constructor(createDefaultEnumerator))
+        .def("__init__", python::make_constructor(EnumeratorFromParams))
         .def("Enumerate", &MolStandardize::TautomerEnumerator::enumerate,
              (python::arg("self"), python::arg("mol")), "")
         .def("Canonicalize", &canonicalizeHelper,
              (python::arg("self"), python::arg("mol")), "",
              python::return_value_policy<python::manage_new_object>());
     ;
-    python::def("TautomerEnumeratorFromParams", &EnumeratorFromParams,
-                (python::arg("params")), "creates a tautomer enumerator",
-                python::return_value_policy<python::manage_new_object>());
   }
 };
 

--- a/Code/GraphMol/MolStandardize/Wrap/Tautomer.cpp
+++ b/Code/GraphMol/MolStandardize/Wrap/Tautomer.cpp
@@ -66,15 +66,21 @@ struct tautomer_wrapper {
              "generates the tautomers for a molecule")
         .def("Canonicalize", &canonicalizeHelper,
              (python::arg("self"), python::arg("mol")),
-             "returns the canonical tautomer for a molecule",
+             R"DOC(Returns the canonical tautomer for a molecule.
+  Note that the canonical tautomer is very likely not the most stable tautomer for any given
+  conditions. The scoring rules are designed to produce "reasonable" tautomers, but the primary 
+  concern is that the results are canonical: you always get the same canonical tautomer for a
+  molecule regardless of what the input tautomer or atom ordering were.)DOC",
              python::return_value_policy<python::manage_new_object>())
         .def(
             "Canonicalize", &canonicalizeHelper2,
             (python::arg("self"), python::arg("mol"), python::arg("scoreFunc")),
-            "returns the canonical tautomer for a molecul using a custom "
+            "returns the canonical tautomer for a molecule using a custom "
             "scoring function",
-            python::return_value_policy<python::manage_new_object>());
-    ;
+            python::return_value_policy<python::manage_new_object>())
+        .def_readonly(
+            "tautomerScoreVersion",
+            MolStandardize::TautomerScoringFunctions::tautomerScoringVersion);
   }
 };
 

--- a/Code/GraphMol/MolStandardize/Wrap/Tautomer.cpp
+++ b/Code/GraphMol/MolStandardize/Wrap/Tautomer.cpp
@@ -30,6 +30,11 @@ MolStandardize::TautomerEnumerator *EnumeratorFromParams(
   auto cat = new MolStandardize::TautomerCatalog(tautparams);
   return new MolStandardize::TautomerEnumerator(cat);
 }
+
+ROMol *canonicalizeHelper(MolStandardize::TautomerEnumerator &self,
+                          const ROMol &mol) {
+  return self.canonicalize(mol);
+}
 }  // namespace
 
 struct tautomer_wrapper {
@@ -40,7 +45,7 @@ struct tautomer_wrapper {
         "TautomerEnumerator", python::no_init)
         .def("Enumerate", &MolStandardize::TautomerEnumerator::enumerate,
              (python::arg("self"), python::arg("mol")), "")
-        .def("Canonicalize", &MolStandardize::TautomerEnumerator::canonicalize,
+        .def("Canonicalize", &canonicalizeHelper,
              (python::arg("self"), python::arg("mol")), "",
              python::return_value_policy<python::manage_new_object>());
     ;

--- a/Code/GraphMol/MolStandardize/Wrap/Tautomer.cpp
+++ b/Code/GraphMol/MolStandardize/Wrap/Tautomer.cpp
@@ -1,0 +1,53 @@
+//
+//  Copyright (C) 2020 Greg Landrum
+//
+//   @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
+//
+#include <RDBoost/Wrap.h>
+
+#include <GraphMol/RDKitBase.h>
+#include <GraphMol/MolStandardize/MolStandardize.h>
+#include <GraphMol/MolStandardize/Tautomer.h>
+#include <sstream>
+
+namespace python = boost::python;
+using namespace RDKit;
+
+namespace {
+
+// ROMol *normalizeHelper(MolStandardize::Normalizer &self, const ROMol &mol) {
+//   return self.normalize(mol);
+// }
+
+MolStandardize::TautomerEnumerator *EnumeratorFromParams(
+    const MolStandardize::CleanupParameters &params) {
+  auto tautparams =
+      new MolStandardize::TautomerCatalogParams(params.tautomerTransforms);
+  auto cat = new MolStandardize::TautomerCatalog(tautparams);
+  return new MolStandardize::TautomerEnumerator(cat);
+}
+}  // namespace
+
+struct tautomer_wrapper {
+  static void wrap() {
+    std::string docString = "";
+
+    python::class_<MolStandardize::TautomerEnumerator, boost::noncopyable>(
+        "TautomerEnumerator", python::no_init)
+        .def("Enumerate", &MolStandardize::TautomerEnumerator::enumerate,
+             (python::arg("self"), python::arg("mol")), "")
+        .def("Canonicalize", &MolStandardize::TautomerEnumerator::canonicalize,
+             (python::arg("self"), python::arg("mol")), "",
+             python::return_value_policy<python::manage_new_object>());
+    ;
+    python::def("TautomerEnumeratorFromParams", &EnumeratorFromParams,
+                (python::arg("params")), "creates a tautomer enumerator",
+                python::return_value_policy<python::manage_new_object>());
+  }
+};
+
+void wrap_tautomer() { tautomer_wrapper::wrap(); }

--- a/Code/GraphMol/MolStandardize/Wrap/rdMolStandardize.cpp
+++ b/Code/GraphMol/MolStandardize/Wrap/rdMolStandardize.cpp
@@ -77,6 +77,7 @@ void wrap_charge();
 void wrap_metal();
 void wrap_fragment();
 void wrap_normalize();
+void wrap_tautomer();
 
 BOOST_PYTHON_MODULE(rdMolStandardize) {
   python::scope().attr("__doc__") =
@@ -154,4 +155,5 @@ BOOST_PYTHON_MODULE(rdMolStandardize) {
   wrap_metal();
   wrap_fragment();
   wrap_normalize();
+  wrap_tautomer();
 }

--- a/Code/GraphMol/MolStandardize/Wrap/testMolStandardize.py
+++ b/Code/GraphMol/MolStandardize/Wrap/testMolStandardize.py
@@ -16,193 +16,192 @@ from rdkit.Chem.MolStandardize import rdMolStandardize
 
 class TestCase(unittest.TestCase):
 
-    def setUp(self):
-        pass
+  def setUp(self):
+    pass
 
-    def test1Cleanup(self):
-        mol = Chem.MolFromSmiles("CCC(=O)O[Na]")
-        nmol = rdMolStandardize.Cleanup(mol)
-        self.assertEqual(Chem.MolToSmiles(nmol), "CCC(=O)[O-].[Na+]")
+  def test1Cleanup(self):
+    mol = Chem.MolFromSmiles("CCC(=O)O[Na]")
+    nmol = rdMolStandardize.Cleanup(mol)
+    self.assertEqual(Chem.MolToSmiles(nmol), "CCC(=O)[O-].[Na+]")
 
-    def test2StandardizeSmiles(self):
-        self.assertEqual(rdMolStandardize.StandardizeSmiles("CCC(=O)O[Na]"), "CCC(=O)[O-].[Na+]")
-        # should get ValueError
+  def test2StandardizeSmiles(self):
+    self.assertEqual(rdMolStandardize.StandardizeSmiles("CCC(=O)O[Na]"), "CCC(=O)[O-].[Na+]")
+    # should get ValueError
 
 
 #    rdMolStandardize.StandardizeSmiles("C1CCC1C(=O)O.Na")
 
+  def test3FragmentParent(self):
+    mol = Chem.MolFromSmiles("[Na]OC(=O)c1ccccc1")
+    nmol = rdMolStandardize.FragmentParent(mol)
+    self.assertEqual(Chem.MolToSmiles(nmol), "O=C([O-])c1ccccc1")
 
-    def test3FragmentParent(self):
-        mol = Chem.MolFromSmiles("[Na]OC(=O)c1ccccc1")
-        nmol = rdMolStandardize.FragmentParent(mol)
-        self.assertEqual(Chem.MolToSmiles(nmol), "O=C([O-])c1ccccc1")
+  def test4ChargeParent(self):
+    mol = Chem.MolFromSmiles("C[NH+](C)(C).[Cl-]")
+    nmol = rdMolStandardize.ChargeParent(mol)
+    self.assertEqual(Chem.MolToSmiles(nmol), "CN(C)C")
 
-    def test4ChargeParent(self):
-        mol = Chem.MolFromSmiles("C[NH+](C)(C).[Cl-]")
-        nmol = rdMolStandardize.ChargeParent(mol)
-        self.assertEqual(Chem.MolToSmiles(nmol), "CN(C)C")
+  def test4Normalize(self):
+    mol = Chem.MolFromSmiles("C[N+](C)=C\C=C\[O-]")
+    nmol = rdMolStandardize.Normalize(mol)
+    self.assertEqual(Chem.MolToSmiles(nmol), "CN(C)C=CC=O")
 
-    def test4Normalize(self):
-        mol = Chem.MolFromSmiles("C[N+](C)=C\C=C\[O-]")
-        nmol = rdMolStandardize.Normalize(mol)
-        self.assertEqual(Chem.MolToSmiles(nmol), "CN(C)C=CC=O")
+  def test4Reionize(self):
+    mol = Chem.MolFromSmiles("C1=C(C=CC(=C1)[S]([O-])=O)[S](O)(=O)=O")
+    nmol = rdMolStandardize.Reionize(mol)
+    self.assertEqual(Chem.MolToSmiles(nmol), "O=S(O)c1ccc(S(=O)(=O)[O-])cc1")
 
-    def test4Reionize(self):
-        mol = Chem.MolFromSmiles("C1=C(C=CC(=C1)[S]([O-])=O)[S](O)(=O)=O")
-        nmol = rdMolStandardize.Reionize(mol)
-        self.assertEqual(Chem.MolToSmiles(nmol), "O=S(O)c1ccc(S(=O)(=O)[O-])cc1")
+  def test5Metal(self):
+    mol = Chem.MolFromSmiles("C1(CCCCC1)[Zn]Br")
+    md = rdMolStandardize.MetalDisconnector()
+    nm = md.Disconnect(mol)
+    #    Metal.MetalDisconnector.Disconnect(mol)
+    self.assertEqual(Chem.MolToSmiles(nm), "[Br-].[CH-]1CCCCC1.[Zn+2]")
 
-    def test5Metal(self):
-        mol = Chem.MolFromSmiles("C1(CCCCC1)[Zn]Br")
-        md = rdMolStandardize.MetalDisconnector()
-        nm = md.Disconnect(mol)
-        #    Metal.MetalDisconnector.Disconnect(mol)
-        self.assertEqual(Chem.MolToSmiles(nm), "[Br-].[CH-]1CCCCC1.[Zn+2]")
+    # test user defined metal_nof
+    md.SetMetalNof(
+      Chem.MolFromSmarts(
+        "[Li,K,Rb,Cs,Fr,Be,Mg,Ca,Sr,Ba,Ra,Sc,Ti,V,Cr,Mn,Fe,Co,Ni,Cu,Zn,Al,Ga,Y,Zr,Nb,Mo,Tc,Ru,Rh,Pd,Ag,Cd,In,Sn,Hf,Ta,W,Re,Os,Ir,Pt,Au,Hg,Tl,Pb,Bi]~[N,O,F]"
+      ))
+    mol2 = Chem.MolFromSmiles("CCC(=O)O[Na]")
+    nm2 = md.Disconnect(mol2)
+    self.assertEqual(Chem.MolToSmiles(nm2), "CCC(=O)O[Na]")
 
-        # test user defined metal_nof
-        md.SetMetalNof(
-          Chem.MolFromSmarts(
-            "[Li,K,Rb,Cs,Fr,Be,Mg,Ca,Sr,Ba,Ra,Sc,Ti,V,Cr,Mn,Fe,Co,Ni,Cu,Zn,Al,Ga,Y,Zr,Nb,Mo,Tc,Ru,Rh,Pd,Ag,Cd,In,Sn,Hf,Ta,W,Re,Os,Ir,Pt,Au,Hg,Tl,Pb,Bi]~[N,O,F]"
-          ))
-        mol2 = Chem.MolFromSmiles("CCC(=O)O[Na]")
-        nm2 = md.Disconnect(mol2)
-        self.assertEqual(Chem.MolToSmiles(nm2), "CCC(=O)O[Na]")
+  def test6Charge(self):
+    mol = Chem.MolFromSmiles("C1=C(C=CC(=C1)[S]([O-])=O)[S](O)(=O)=O")
+    # instantiate with default acid base pair library
+    reionizer = rdMolStandardize.Reionizer()
+    nm = reionizer.reionize(mol)
+    self.assertEqual(Chem.MolToSmiles(nm), "O=S(O)c1ccc(S(=O)(=O)[O-])cc1")
 
-    def test6Charge(self):
-        mol = Chem.MolFromSmiles("C1=C(C=CC(=C1)[S]([O-])=O)[S](O)(=O)=O")
-        # instantiate with default acid base pair library
-        reionizer = rdMolStandardize.Reionizer()
-        nm = reionizer.reionize(mol)
-        self.assertEqual(Chem.MolToSmiles(nm), "O=S(O)c1ccc(S(=O)(=O)[O-])cc1")
+    # try reionize with another acid base pair library without the right
+    # pairs
+    abfile = os.path.join(RDConfig.RDDataDir, 'MolStandardize', 'acid_base_pairs2.txt')
+    reionizer2 = rdMolStandardize.Reionizer(abfile)
+    nm2 = reionizer2.reionize(mol)
+    self.assertEqual(Chem.MolToSmiles(nm2), "O=S([O-])c1ccc(S(=O)(=O)O)cc1")
 
-        # try reionize with another acid base pair library without the right
-        # pairs
-        abfile = os.path.join(RDConfig.RDDataDir, 'MolStandardize', 'acid_base_pairs2.txt')
-        reionizer2 = rdMolStandardize.Reionizer(abfile)
-        nm2 = reionizer2.reionize(mol)
-        self.assertEqual(Chem.MolToSmiles(nm2), "O=S([O-])c1ccc(S(=O)(=O)O)cc1")
+    # test Uncharger
+    uncharger = rdMolStandardize.Uncharger()
+    mol3 = Chem.MolFromSmiles("O=C([O-])c1ccccc1")
+    nm3 = uncharger.uncharge(mol3)
+    self.assertEqual(Chem.MolToSmiles(nm3), "O=C(O)c1ccccc1")
 
-        # test Uncharger
-        uncharger = rdMolStandardize.Uncharger()
-        mol3 = Chem.MolFromSmiles("O=C([O-])c1ccccc1")
-        nm3 = uncharger.uncharge(mol3)
-        self.assertEqual(Chem.MolToSmiles(nm3), "O=C(O)c1ccccc1")
+    # test canonical Uncharger
+    uncharger = rdMolStandardize.Uncharger(canonicalOrder=False)
+    mol3 = Chem.MolFromSmiles("C[N+](C)(C)CC(C(=O)[O-])CC(=O)[O-]")
+    nm3 = uncharger.uncharge(mol3)
+    self.assertEqual(Chem.MolToSmiles(nm3), "C[N+](C)(C)CC(CC(=O)[O-])C(=O)O")
+    uncharger = rdMolStandardize.Uncharger(canonicalOrder=True)
+    nm3 = uncharger.uncharge(mol3)
+    self.assertEqual(Chem.MolToSmiles(nm3), "C[N+](C)(C)CC(CC(=O)O)C(=O)[O-]")
 
-        # test canonical Uncharger
-        uncharger = rdMolStandardize.Uncharger(canonicalOrder=False)
-        mol3 = Chem.MolFromSmiles("C[N+](C)(C)CC(C(=O)[O-])CC(=O)[O-]")
-        nm3 = uncharger.uncharge(mol3)
-        self.assertEqual(Chem.MolToSmiles(nm3), "C[N+](C)(C)CC(CC(=O)[O-])C(=O)O")
-        uncharger = rdMolStandardize.Uncharger(canonicalOrder=True)
-        nm3 = uncharger.uncharge(mol3)
-        self.assertEqual(Chem.MolToSmiles(nm3), "C[N+](C)(C)CC(CC(=O)O)C(=O)[O-]")
+  def test7Fragment(self):
+    fragremover = rdMolStandardize.FragmentRemover()
+    mol = Chem.MolFromSmiles("CN(C)C.Cl.Cl.Br")
+    nm = fragremover.remove(mol)
+    self.assertEqual(Chem.MolToSmiles(nm), "CN(C)C")
 
-    def test7Fragment(self):
-        fragremover = rdMolStandardize.FragmentRemover()
-        mol = Chem.MolFromSmiles("CN(C)C.Cl.Cl.Br")
-        nm = fragremover.remove(mol)
-        self.assertEqual(Chem.MolToSmiles(nm), "CN(C)C")
+    lfragchooser = rdMolStandardize.LargestFragmentChooser()
+    mol2 = Chem.MolFromSmiles("[N+](=O)([O-])[O-].[CH3+]")
+    nm2 = lfragchooser.choose(mol2)
+    self.assertEqual(Chem.MolToSmiles(nm2), "O=[N+]([O-])[O-]")
 
-        lfragchooser = rdMolStandardize.LargestFragmentChooser()
-        mol2 = Chem.MolFromSmiles("[N+](=O)([O-])[O-].[CH3+]")
-        nm2 = lfragchooser.choose(mol2)
-        self.assertEqual(Chem.MolToSmiles(nm2), "O=[N+]([O-])[O-]")
+    lfragchooser2 = rdMolStandardize.LargestFragmentChooser(preferOrganic=True)
+    nm3 = lfragchooser2.choose(mol2)
+    self.assertEqual(Chem.MolToSmiles(nm3), "[CH3+]")
 
-        lfragchooser2 = rdMolStandardize.LargestFragmentChooser(preferOrganic=True)
-        nm3 = lfragchooser2.choose(mol2)
-        self.assertEqual(Chem.MolToSmiles(nm3), "[CH3+]")
+    fragremover = rdMolStandardize.FragmentRemover(skip_if_all_match=True)
+    mol = Chem.MolFromSmiles("[Na+].Cl.Cl.Br")
+    nm = fragremover.remove(mol)
+    self.assertEqual(nm.GetNumAtoms(), mol.GetNumAtoms())
 
-        fragremover = rdMolStandardize.FragmentRemover(skip_if_all_match=True)
-        mol = Chem.MolFromSmiles("[Na+].Cl.Cl.Br")
-        nm = fragremover.remove(mol)
-        self.assertEqual(nm.GetNumAtoms(), mol.GetNumAtoms())
+  def test8Normalize(self):
+    normalizer = rdMolStandardize.Normalizer()
+    mol = Chem.MolFromSmiles("C[n+]1ccccc1[O-]")
+    nm = normalizer.normalize(mol)
+    self.assertEqual(Chem.MolToSmiles(nm), "Cn1ccccc1=O")
 
-    def test8Normalize(self):
-        normalizer = rdMolStandardize.Normalizer()
-        mol = Chem.MolFromSmiles("C[n+]1ccccc1[O-]")
-        nm = normalizer.normalize(mol)
-        self.assertEqual(Chem.MolToSmiles(nm), "Cn1ccccc1=O")
+  def test9Validate(self):
+    vm = rdMolStandardize.RDKitValidation()
+    mol = Chem.MolFromSmiles("CO(C)C", sanitize=False)
+    msg = vm.validate(mol)
+    self.assertEqual(len(msg), 1)
+    self.assertEqual
+    ("""INFO: [ValenceValidation] Explicit valence for atom # 1 O, 3, is greater than permitted""",
+     msg[0])
 
-    def test9Validate(self):
-        vm = rdMolStandardize.RDKitValidation()
-        mol = Chem.MolFromSmiles("CO(C)C", sanitize=False)
-        msg = vm.validate(mol)
-        self.assertEqual(len(msg), 1)
-        self.assertEqual
-        ("""INFO: [ValenceValidation] Explicit valence for atom # 1 O, 3, is greater than permitted""",
-         msg[0])
+    vm2 = rdMolStandardize.MolVSValidation([rdMolStandardize.FragmentValidation()])
+    # with no argument it also works
+    #    vm2 = rdMolStandardize.MolVSValidation()
+    mol2 = Chem.MolFromSmiles("COc1cccc(C=N[N-]C(N)=O)c1[O-].O.O.O.O=[U+2]=O")
+    msg2 = vm2.validate(mol2)
+    self.assertEqual(len(msg2), 1)
+    self.assertEqual
+    ("""INFO: [FragmentValidation] water/hydroxide is present""", msg2[0])
 
-        vm2 = rdMolStandardize.MolVSValidation([rdMolStandardize.FragmentValidation()])
-        # with no argument it also works
-        #    vm2 = rdMolStandardize.MolVSValidation()
-        mol2 = Chem.MolFromSmiles("COc1cccc(C=N[N-]C(N)=O)c1[O-].O.O.O.O=[U+2]=O")
-        msg2 = vm2.validate(mol2)
-        self.assertEqual(len(msg2), 1)
-        self.assertEqual
-        ("""INFO: [FragmentValidation] water/hydroxide is present""", msg2[0])
+    vm3 = rdMolStandardize.MolVSValidation()
+    mol3 = Chem.MolFromSmiles("C1COCCO1.O=C(NO)NO")
+    msg3 = vm3.validate(mol3)
+    self.assertEqual(len(msg3), 2)
+    self.assertEqual
+    ("""INFO: [FragmentValidation] 1,2-dimethoxyethane is present""", msg3[0])
+    self.assertEqual
+    ("""INFO: [FragmentValidation] 1,4-dioxane is present""", msg3[1])
 
-        vm3 = rdMolStandardize.MolVSValidation()
-        mol3 = Chem.MolFromSmiles("C1COCCO1.O=C(NO)NO")
-        msg3 = vm3.validate(mol3)
-        self.assertEqual(len(msg3), 2)
-        self.assertEqual
-        ("""INFO: [FragmentValidation] 1,2-dimethoxyethane is present""", msg3[0])
-        self.assertEqual
-        ("""INFO: [FragmentValidation] 1,4-dioxane is present""", msg3[1])
+    atomic_no = [6, 7, 8]
+    allowed_atoms = [Atom(i) for i in atomic_no]
+    vm4 = rdMolStandardize.AllowedAtomsValidation(allowed_atoms)
+    mol4 = Chem.MolFromSmiles("CC(=O)CF")
+    msg4 = vm4.validate(mol4)
+    self.assertEqual(len(msg4), 1)
+    self.assertEqual
+    ("""INFO: [AllowedAtomsValidation] Atom F is not in allowedAtoms list""", msg4[0])
 
-        atomic_no = [6, 7, 8]
-        allowed_atoms = [Atom(i) for i in atomic_no]
-        vm4 = rdMolStandardize.AllowedAtomsValidation(allowed_atoms)
-        mol4 = Chem.MolFromSmiles("CC(=O)CF")
-        msg4 = vm4.validate(mol4)
-        self.assertEqual(len(msg4), 1)
-        self.assertEqual
-        ("""INFO: [AllowedAtomsValidation] Atom F is not in allowedAtoms list""", msg4[0])
+    atomic_no = [9, 17, 35]
+    disallowed_atoms = [Atom(i) for i in atomic_no]
+    vm5 = rdMolStandardize.DisallowedAtomsValidation(disallowed_atoms)
+    mol5 = Chem.MolFromSmiles("CC(=O)CF")
+    msg5 = vm4.validate(mol5)
+    self.assertEqual(len(msg5), 1)
+    self.assertEqual
+    ("""INFO: [DisallowedAtomsValidation] Atom F is in disallowedAtoms list""", msg5[0])
 
-        atomic_no = [9, 17, 35]
-        disallowed_atoms = [Atom(i) for i in atomic_no]
-        vm5 = rdMolStandardize.DisallowedAtomsValidation(disallowed_atoms)
-        mol5 = Chem.MolFromSmiles("CC(=O)CF")
-        msg5 = vm4.validate(mol5)
-        self.assertEqual(len(msg5), 1)
-        self.assertEqual
-        ("""INFO: [DisallowedAtomsValidation] Atom F is in disallowedAtoms list""", msg5[0])
+    msg6 = rdMolStandardize.ValidateSmiles("ClCCCl.c1ccccc1O")
+    self.assertEqual(len(msg6), 1)
+    self.assertEqual
+    ("""INFO: [FragmentValidation] 1,2-dichloroethane is present""", msg6[0])
 
-        msg6 = rdMolStandardize.ValidateSmiles("ClCCCl.c1ccccc1O")
-        self.assertEqual(len(msg6), 1)
-        self.assertEqual
-        ("""INFO: [FragmentValidation] 1,2-dichloroethane is present""", msg6[0])
-
-    def test10NormalizeParams(self):
-        data = """//	Name	SMIRKS
+  def test10NormalizeParams(self):
+    data = """//	Name	SMIRKS
 Nitro to N+(O-)=O	[N,P,As,Sb;X3:1](=[O,S,Se,Te:2])=[O,S,Se,Te:3]>>[*+1:1]([*-1:2])=[*:3]
 Sulfone to S(=O)(=O)	[S+2:1]([O-:2])([O-:3])>>[S+0:1](=[O-0:2])(=[O-0:3])
 Pyridine oxide to n+O-	[n:1]=[O:2]>>[n+:1][O-:2]
 // Azide to N=N+=N-	[*,H:1][N:2]=[N:3]#[N:4]>>[*,H:1][N:2]=[N+:3]=[N-:4]
 """
-        normalizer1 = rdMolStandardize.Normalizer()
-        params = rdMolStandardize.CleanupParameters()
-        normalizer2 = rdMolStandardize.NormalizerFromData(data, params)
+    normalizer1 = rdMolStandardize.Normalizer()
+    params = rdMolStandardize.CleanupParameters()
+    normalizer2 = rdMolStandardize.NormalizerFromData(data, params)
 
-        imol = Chem.MolFromSmiles("O=N(=O)CCN=N#N", sanitize=False)
-        mol1 = normalizer1.normalize(imol)
-        mol2 = normalizer2.normalize(imol)
-        self.assertEqual(Chem.MolToSmiles(imol), "N#N=NCCN(=O)=O")
-        self.assertEqual(Chem.MolToSmiles(mol1), "[N-]=[N+]=NCC[N+](=O)[O-]")
-        self.assertEqual(Chem.MolToSmiles(mol2), "N#N=NCC[N+](=O)[O-]")
+    imol = Chem.MolFromSmiles("O=N(=O)CCN=N#N", sanitize=False)
+    mol1 = normalizer1.normalize(imol)
+    mol2 = normalizer2.normalize(imol)
+    self.assertEqual(Chem.MolToSmiles(imol), "N#N=NCCN(=O)=O")
+    self.assertEqual(Chem.MolToSmiles(mol1), "[N-]=[N+]=NCC[N+](=O)[O-]")
+    self.assertEqual(Chem.MolToSmiles(mol2), "N#N=NCC[N+](=O)[O-]")
 
-    def test11FragmentParams(self):
-        data = """//   Name	SMARTS
+  def test11FragmentParams(self):
+    data = """//   Name	SMARTS
 fluorine	[F]
 chlorine	[Cl]
         """
-        fragremover = rdMolStandardize.FragmentRemoverFromData(data)
-        mol = Chem.MolFromSmiles("CN(C)C.Cl.Cl.Br")
-        nm = fragremover.remove(mol)
-        self.assertEqual(Chem.MolToSmiles(nm), "Br.CN(C)C")
+    fragremover = rdMolStandardize.FragmentRemoverFromData(data)
+    mol = Chem.MolFromSmiles("CN(C)C.Cl.Cl.Br")
+    nm = fragremover.remove(mol)
+    self.assertEqual(Chem.MolToSmiles(nm), "Br.CN(C)C")
 
-    def test12ChargeParams(self):
-        params = """// The default list of AcidBasePairs, sorted from strongest to weakest.
+  def test12ChargeParams(self):
+    params = """// The default list of AcidBasePairs, sorted from strongest to weakest.
 // This list is derived from the Food and Drug: Administration Substance
 // Registration System Standard Operating Procedure guide.
 //
@@ -210,13 +209,24 @@ chlorine	[Cl]
 -SO2H	[!O][SD3](=O)[OH]	[!O][SD3](=O)[O-]
 -SO3H	[!O]S(=O)(=O)[OH]	[!O]S(=O)(=O)[O-]
 """
-        mol = Chem.MolFromSmiles("C1=C(C=CC(=C1)[S]([O-])=O)[S](O)(=O)=O")
-        # instantiate with default acid base pair library
-        reionizer = rdMolStandardize.ReionizerFromData(params, [])
-        print("done")
-        nm = reionizer.reionize(mol)
-        self.assertEqual(Chem.MolToSmiles(nm), "O=S([O-])c1ccc(S(=O)(=O)O)cc1")
+    mol = Chem.MolFromSmiles("C1=C(C=CC(=C1)[S]([O-])=O)[S](O)(=O)=O")
+    # instantiate with default acid base pair library
+    reionizer = rdMolStandardize.ReionizerFromData(params, [])
+    print("done")
+    nm = reionizer.reionize(mol)
+    self.assertEqual(Chem.MolToSmiles(nm), "O=S([O-])c1ccc(S(=O)(=O)O)cc1")
 
+  def test13Tautomers(self):
+    params = rdMolStandardize.CleanupParameters()
+    enumerator = rdMolStandardize.TautomerEnumeratorFromParams(params)
+    m = Chem.MolFromSmiles("C1(=CCCCC1)O")
+    ctaut = enumerator.Canonicalize(m)
+    self.assertEqual(Chem.MolToSmiles(ctaut), "O=C1CCCCC1")
+
+    tauts = enumerator.Enumerate(m)
+    self.assertEqual(len(tauts), 2)
+    ctauts = list(sorted(Chem.MolToSmiles(x) for x in tauts))
+    self.assertEqual(ctauts, ['O=C1CCCCC1', 'OC1=CCCCC1'])
 
 if __name__ == "__main__":
-    unittest.main()
+  unittest.main()

--- a/Code/GraphMol/MolStandardize/Wrap/testMolStandardize.py
+++ b/Code/GraphMol/MolStandardize/Wrap/testMolStandardize.py
@@ -233,5 +233,21 @@ chlorine	[Cl]
     ctauts = list(sorted(Chem.MolToSmiles(x) for x in tauts))
     self.assertEqual(ctauts, ['O=C1CCCCC1', 'OC1=CCCCC1'])
 
+    def scorefunc1(mol):
+      ' stupid tautomer scoring function '
+      p = Chem.MolFromSmarts('[OH]')
+      return len(mol.GetSubstructMatches(p))
+
+    def scorefunc2(mol):
+      ' stupid tautomer scoring function '
+      p = Chem.MolFromSmarts('O=C')
+      return len(mol.GetSubstructMatches(p))
+
+    m = Chem.MolFromSmiles("C1(=CCCCC1)O")
+    ctaut = enumerator.Canonicalize(m, scorefunc1)
+    self.assertEqual(Chem.MolToSmiles(ctaut), "OC1=CCCCC1")
+    ctaut = enumerator.Canonicalize(m, scorefunc2)
+    self.assertEqual(Chem.MolToSmiles(ctaut), "O=C1CCCCC1")
+
 if __name__ == "__main__":
   unittest.main()

--- a/Code/GraphMol/MolStandardize/Wrap/testMolStandardize.py
+++ b/Code/GraphMol/MolStandardize/Wrap/testMolStandardize.py
@@ -217,8 +217,13 @@ chlorine	[Cl]
     self.assertEqual(Chem.MolToSmiles(nm), "O=S([O-])c1ccc(S(=O)(=O)O)cc1")
 
   def test13Tautomers(self):
+    enumerator = rdMolStandardize.TautomerEnumerator()
+    m = Chem.MolFromSmiles("C1(=CCCCC1)O")
+    ctaut = enumerator.Canonicalize(m)
+    self.assertEqual(Chem.MolToSmiles(ctaut), "O=C1CCCCC1")
+
     params = rdMolStandardize.CleanupParameters()
-    enumerator = rdMolStandardize.TautomerEnumeratorFromParams(params)
+    enumerator = rdMolStandardize.TautomerEnumerator(params)
     m = Chem.MolFromSmiles("C1(=CCCCC1)O")
     ctaut = enumerator.Canonicalize(m)
     self.assertEqual(Chem.MolToSmiles(ctaut), "O=C1CCCCC1")

--- a/Code/GraphMol/MolStandardize/Wrap/testMolStandardize.py
+++ b/Code/GraphMol/MolStandardize/Wrap/testMolStandardize.py
@@ -248,6 +248,14 @@ chlorine	[Cl]
     self.assertEqual(Chem.MolToSmiles(ctaut), "OC1=CCCCC1")
     ctaut = enumerator.Canonicalize(m, scorefunc2)
     self.assertEqual(Chem.MolToSmiles(ctaut), "O=C1CCCCC1")
+    # make sure lambdas work
+    ctaut = enumerator.Canonicalize(
+      m, lambda x: len(x.GetSubstructMatches(Chem.MolFromSmarts('C=O'))))
+    self.assertEqual(Chem.MolToSmiles(ctaut), "O=C1CCCCC1")
+
+    # make sure we behave if we return something bogus from the scoring function
+    with self.assertRaises(TypeError):
+      ctaut = enumerator.Canonicalize(m, lambda x: 'fail')
 
 if __name__ == "__main__":
   unittest.main()

--- a/Code/GraphMol/MolStandardize/testTautomer.cpp
+++ b/Code/GraphMol/MolStandardize/testTautomer.cpp
@@ -22,7 +22,8 @@ void testEnumerator() {
   std::string rdbase = getenv("RDBASE");
   std::string tautomerFile =
       rdbase + "/Data/MolStandardize/tautomerTransforms.in";
-  auto tautparams = std::unique_ptr<TautomerCatalogParams>(new TautomerCatalogParams(tautomerFile));
+  auto tautparams = std::unique_ptr<TautomerCatalogParams>(
+      new TautomerCatalogParams(tautomerFile));
   unsigned int ntautomers = tautparams->getNumTautomers();
   TEST_ASSERT(ntautomers == 34);
 
@@ -792,95 +793,95 @@ void testCanonicalize() {
   TautomerCatalog tautcat(tautparams);
   TautomerCanonicalizer tc;
 
-{  // Enumerate 1,3 keto/enol tautomer.
-  std::string smi1 = "C1(=CCCCC1)O";
-  std::unique_ptr<ROMol> m1(SmilesToMol(smi1));
-  ROMol *res = tc.canonicalize(*m1, &tautcat);
-  std::cerr << MolToSmiles(*res)<<std::endl;
-  TEST_ASSERT(MolToSmiles(*res) == "O=C1CCCCC1");
-  delete res;
-}
-  // tests from the molvs repo: https://github.com/mcs07/MolVS/blob/456f2fe723acfedbf634a8bcfe943b83ea7d4c20/tests/test_tautomer.py
-  std::vector<std::pair<std::string,std::string>> data{{"C1(=CCCCC1)O","O=C1CCCCC1"},
-    {"C1(CCCCC1)=O","O=C1CCCCC1"},
-    {"C(=C)(O)C1=CC=CC=C1","CC(=O)c1ccccc1"},
-    {"CC(C)=O","CC(C)=O"},
-    {"OC(C)=C(C)C","CC(=O)C(C)C"},
-    {"c1(ccccc1)CC(=O)C","CC(=O)Cc1ccccc1"},
-    {"Oc1nccc2cc[nH]c(=N)c12","N=c1[nH]ccc2cc[nH]c(=O)c12"},
-    {"C1(C=CCCC1)=O","O=C1C=CCCC1"},
-    {"C1(CCCCC1)=N", "N=C1CCCCC1"},
-    {"C1(=CCCCC1)N", "N=C1CCCCC1"},
-    {"C1(C=CC=CN1)=CC", "CCc1ccccn1"},
-    {"C1(=NC=CC=C1)CC", "CCc1ccccn1"},
-    {"O=c1cccc[nH]1", "O=c1cccc[nH]1"},
-    {"Oc1ccccn1", "O=c1cccc[nH]1"},
-    {"Oc1ncc[nH]1", "O=c1[nH]cc[nH]1"},
-    {"OC(C)=NC", "CNC(C)=O"},
-    {"CNC(C)=O", "CNC(C)=O"},
-    {"S=C(N)N", "NC(N)=S"},
-    {"SC(N)=N", "NC(N)=S"},
-    {"N=c1[nH]ccn(C)1", "Cn1cc[nH]c1=N"},
-    {"CN=c1[nH]cncc1", "CN=c1cc[nH]cn1"},
-    {"Oc1cccc2ccncc12", "Oc1cccc2ccncc12"},
-    {"O=c1cccc2cc[nH]cc1-2", "Oc1cccc2ccncc12"},
-    {"Cc1n[nH]c2ncnn12", "Cc1n[nH]c2ncnn12"},
-    {"Cc1nnc2nc[nH]n12", "Cc1n[nH]c2ncnn12"},
-    {"Oc1ccncc1", "O=c1cc[nH]cc1"},
-    {"Oc1c(cccc3)c3nc2ccncc12", "O=c1c2ccccc2[nH]c2ccncc12"},
-    {"Oc1ncncc1", "O=c1cc[nH]cn1"},
-    {"C2(=C1C(=NC=N1)[NH]C(=N2)N)O", "N=c1[nH]c(=O)c2[nH]cnc2[nH]1"},
-    {"C2(C1=C([NH]C=N1)[NH]C(=N2)N)=O", "N=c1[nH]c(=O)c2[nH]cnc2[nH]1"},
-    {"Oc1n(C)ncc1", "Cn1[nH]ccc1=O"},
-    {"O=c1nc2[nH]ccn2cc1", "O=c1ccn2cc[nH]c2n1"},
-    {"N=c1nc[nH]cc1", "N=c1cc[nH]cn1"},
-    {"N=c(c1)ccn2cc[nH]c12", "N=c1ccn2cc[nH]c2c1"},
-    {"CN=c1nc[nH]cc1", "CN=c1cc[nH]cn1"},
-    {"c1ccc2[nH]c(-c3nc4ccccc4[nH]3)nc2c1", "c1ccc2[nH]c(-c3nc4ccccc4[nH]3)nc2c1"},
-    {"c1ccc2c(c1)NC(=C1N=c3ccccc3=N1)N2", "c1ccc2[nH]c(-c3nc4ccccc4[nH]3)nc2c1"},
-    {"CNc1ccnc2ncnn21", "CN=c1cc[nH]c2ncnn12"},
-    {"CN=c1ccnc2nc[nH]n21", "CN=c1cc[nH]c2ncnn12"},
-    {"Nc1ccc(C=C2C=CC(=O)C=C2)cc1", "Nc1ccc(C=C2C=CC(=O)C=C2)cc1"},
-    {"N=C1C=CC(=Cc2ccc(O)cc2)C=C1", "Nc1ccc(C=C2C=CC(=O)C=C2)cc1"},
-    {"n1ccc2ccc[nH]c12", "c1cnc2[nH]ccc2c1"},
-    {"c1cc(=O)[nH]c2nccn12", "O=c1ccn2cc[nH]c2n1"},
-    {"c1cnc2c[nH]ccc12", "c1cc2cc[nH]c2cn1"},
-    {"n1ccc2c[nH]ccc12", "c1cc2[nH]ccc2cn1"},
-    {"c1cnc2ccc[nH]c12", "c1cnc2cc[nH]c2c1"},
-    {"C1=CC=C(O1)O", "Oc1ccco1"},
-    {"O=C1CC=CO1", "Oc1ccco1"},
-    {"CC=C=O", "CC=C=O"},
-    {"CC#CO", "CC=C=O"},
-    {"C([N+](=O)[O-])C", "CC[N+](=O)[O-]"},
-    {"C(=[N+](O)[O-])C", "CC[N+](=O)[O-]"},
-    {"CC(C)=NO", "CC(C)=NO"},
-    {"CC(C)N=O", "CC(C)=NO"},
-    {"O=Nc1ccc(O)cc1", "O=Nc1ccc(O)cc1"},
-    {"O=C1C=CC(=NO)C=C1", "O=Nc1ccc(O)cc1"},
-    {"C(#N)O", "N=C=O"},
-    {"C(=N)=O", "N=C=O"},
-    {"N=C(N)S(=O)O", "N=C(N)S(=O)O"},
-    {"C#N", "C#N"},
-    {"[C-]#[NH+]", "C#N"},
-    {"[PH](=O)(O)(O)", "O=[PH](O)O"},
-    {"P(O)(O)O", "O=[PH](O)O"}
-  };
-  for(const auto itm : data){
+  {  // Enumerate 1,3 keto/enol tautomer.
+    std::string smi1 = "C1(=CCCCC1)O";
+    std::unique_ptr<ROMol> m1(SmilesToMol(smi1));
+    ROMol *res = tc.canonicalize(*m1, &tautcat);
+    std::cerr << MolToSmiles(*res) << std::endl;
+    TEST_ASSERT(MolToSmiles(*res) == "O=C1CCCCC1");
+    delete res;
+  }
+  // tests from the molvs repo:
+  // https://github.com/mcs07/MolVS/blob/456f2fe723acfedbf634a8bcfe943b83ea7d4c20/tests/test_tautomer.py
+  std::vector<std::pair<std::string, std::string>> data{
+      {"C1(=CCCCC1)O", "O=C1CCCCC1"},
+      {"C1(CCCCC1)=O", "O=C1CCCCC1"},
+      {"C(=C)(O)C1=CC=CC=C1", "CC(=O)c1ccccc1"},
+      {"CC(C)=O", "CC(C)=O"},
+      {"OC(C)=C(C)C", "CC(=O)C(C)C"},
+      {"c1(ccccc1)CC(=O)C", "CC(=O)Cc1ccccc1"},
+      {"Oc1nccc2cc[nH]c(=N)c12", "N=c1[nH]ccc2cc[nH]c(=O)c12"},
+      {"C1(C=CCCC1)=O", "O=C1C=CCCC1"},
+      {"C1(CCCCC1)=N", "N=C1CCCCC1"},
+      {"C1(=CCCCC1)N", "N=C1CCCCC1"},
+      {"C1(C=CC=CN1)=CC", "CCc1ccccn1"},
+      {"C1(=NC=CC=C1)CC", "CCc1ccccn1"},
+      {"O=c1cccc[nH]1", "O=c1cccc[nH]1"},
+      {"Oc1ccccn1", "O=c1cccc[nH]1"},
+      {"Oc1ncc[nH]1", "O=c1[nH]cc[nH]1"},
+      {"OC(C)=NC", "CNC(C)=O"},
+      {"CNC(C)=O", "CNC(C)=O"},
+      {"S=C(N)N", "NC(N)=S"},
+      {"SC(N)=N", "NC(N)=S"},
+      {"N=c1[nH]ccn(C)1", "Cn1cc[nH]c1=N"},
+      {"CN=c1[nH]cncc1", "CN=c1cc[nH]cn1"},
+      {"Oc1cccc2ccncc12", "Oc1cccc2ccncc12"},
+      {"O=c1cccc2cc[nH]cc1-2", "Oc1cccc2ccncc12"},
+      {"Cc1n[nH]c2ncnn12", "Cc1n[nH]c2ncnn12"},
+      {"Cc1nnc2nc[nH]n12", "Cc1n[nH]c2ncnn12"},
+      {"Oc1ccncc1", "O=c1cc[nH]cc1"},
+      {"Oc1c(cccc3)c3nc2ccncc12", "O=c1c2ccccc2[nH]c2ccncc12"},
+      {"Oc1ncncc1", "O=c1cc[nH]cn1"},
+      {"C2(=C1C(=NC=N1)[NH]C(=N2)N)O", "N=c1[nH]c(=O)c2[nH]cnc2[nH]1"},
+      {"C2(C1=C([NH]C=N1)[NH]C(=N2)N)=O", "N=c1[nH]c(=O)c2[nH]cnc2[nH]1"},
+      {"Oc1n(C)ncc1", "Cn1[nH]ccc1=O"},
+      {"O=c1nc2[nH]ccn2cc1", "O=c1ccn2cc[nH]c2n1"},
+      {"N=c1nc[nH]cc1", "N=c1cc[nH]cn1"},
+      {"N=c(c1)ccn2cc[nH]c12", "N=c1ccn2cc[nH]c2c1"},
+      {"CN=c1nc[nH]cc1", "CN=c1cc[nH]cn1"},
+      {"c1ccc2[nH]c(-c3nc4ccccc4[nH]3)nc2c1",
+       "c1ccc2[nH]c(-c3nc4ccccc4[nH]3)nc2c1"},
+      {"c1ccc2c(c1)NC(=C1N=c3ccccc3=N1)N2",
+       "c1ccc2[nH]c(-c3nc4ccccc4[nH]3)nc2c1"},
+      {"CNc1ccnc2ncnn21", "CN=c1cc[nH]c2ncnn12"},
+      {"CN=c1ccnc2nc[nH]n21", "CN=c1cc[nH]c2ncnn12"},
+      {"Nc1ccc(C=C2C=CC(=O)C=C2)cc1", "Nc1ccc(C=C2C=CC(=O)C=C2)cc1"},
+      {"N=C1C=CC(=Cc2ccc(O)cc2)C=C1", "Nc1ccc(C=C2C=CC(=O)C=C2)cc1"},
+      {"n1ccc2ccc[nH]c12", "c1cnc2[nH]ccc2c1"},
+      {"c1cc(=O)[nH]c2nccn12", "O=c1ccn2cc[nH]c2n1"},
+      {"c1cnc2c[nH]ccc12", "c1cc2cc[nH]c2cn1"},
+      {"n1ccc2c[nH]ccc12", "c1cc2[nH]ccc2cn1"},
+      {"c1cnc2ccc[nH]c12", "c1cnc2cc[nH]c2c1"},
+      {"C1=CC=C(O1)O", "Oc1ccco1"},
+      {"O=C1CC=CO1", "Oc1ccco1"},
+      {"CC=C=O", "CC=C=O"},
+      {"CC#CO", "CC=C=O"},
+      {"C([N+](=O)[O-])C", "CC[N+](=O)[O-]"},
+      {"C(=[N+](O)[O-])C", "CC[N+](=O)[O-]"},
+      {"CC(C)=NO", "CC(C)=NO"},
+      {"CC(C)N=O", "CC(C)=NO"},
+      {"O=Nc1ccc(O)cc1", "O=Nc1ccc(O)cc1"},
+      {"O=C1C=CC(=NO)C=C1", "O=Nc1ccc(O)cc1"},
+      {"C(#N)O", "N=C=O"},
+      {"C(=N)=O", "N=C=O"},
+      {"N=C(N)S(=O)O", "N=C(N)S(=O)O"},
+      {"C#N", "C#N"},
+      {"[C-]#[NH+]", "C#N"},
+      {"[PH](=O)(O)(O)", "O=[PH](O)O"},
+      {"P(O)(O)O", "O=[PH](O)O"}};
+  for (const auto itm : data) {
     std::unique_ptr<ROMol> mol{SmilesToMol(itm.first)};
     TEST_ASSERT(mol);
-    std::unique_ptr<ROMol> res{tc.canonicalize(*mol,&tautcat)};
+    std::unique_ptr<ROMol> res{tc.canonicalize(*mol, &tautcat)};
     TEST_ASSERT(res);
-    std::cerr << itm.first<<" -> "<<MolToSmiles(*res)<<std::endl;
+    // std::cerr << itm.first<<" -> "<<MolToSmiles(*res)<<std::endl;
     TEST_ASSERT(MolToSmiles(*res) == itm.second);
-
-    
   }
-
 }
 
 int main() {
   RDLog::InitLogs();
-#if 0
+#if 1
   testEnumerator();
 #endif
   testCanonicalize();

--- a/Code/GraphMol/MolStandardize/testTautomer.cpp
+++ b/Code/GraphMol/MolStandardize/testTautomer.cpp
@@ -27,13 +27,12 @@ void testEnumerator() {
   unsigned int ntautomers = tautparams->getNumTautomers();
   TEST_ASSERT(ntautomers == 34);
 
-  TautomerCatalog tautcat(tautparams.get());
-  TautomerEnumerator te;
+  TautomerEnumerator te(new TautomerCatalog(tautparams.get()));
 
   // Enumerate 1,3 keto/enol tautomer.
   std::string smi1 = "C1(=CCCCC1)O";
   std::shared_ptr<ROMol> m1(SmilesToMol(smi1));
-  std::vector<ROMOL_SPTR> res = te.enumerate(*m1, &tautcat);
+  std::vector<ROMOL_SPTR> res = te.enumerate(*m1);
   std::vector<std::string> ans = {"O=C1CCCCC1", "OC1=CCCCC1"};
   TEST_ASSERT(res.size() == ans.size());
   for (size_t i = 0; i < res.size(); ++i) {
@@ -43,7 +42,7 @@ void testEnumerator() {
   // Enumerate 1,3 keto/enol tautomer.
   std::string smi2 = "C1(CCCCC1)=O";
   std::shared_ptr<ROMol> m2(SmilesToMol(smi2));
-  std::vector<ROMOL_SPTR> res2 = te.enumerate(*m2, &tautcat);
+  std::vector<ROMOL_SPTR> res2 = te.enumerate(*m2);
   std::vector<std::string> ans2 = {"O=C1CCCCC1", "OC1=CCCCC1"};
   TEST_ASSERT(res2.size() == ans2.size());
   for (size_t i = 0; i < res2.size(); ++i) {
@@ -53,7 +52,7 @@ void testEnumerator() {
   // Enumerate acetophenone keto/enol tautomer.
   std::string smi3 = "C(=C)(O)C1=CC=CC=C1";
   std::shared_ptr<ROMol> m3(SmilesToMol(smi3));
-  std::vector<ROMOL_SPTR> res3 = te.enumerate(*m3, &tautcat);
+  std::vector<ROMOL_SPTR> res3 = te.enumerate(*m3);
   std::vector<std::string> ans3 = {"C=C(O)c1ccccc1", "CC(=O)c1ccccc1"};
   TEST_ASSERT(res3.size() == ans3.size());
   for (size_t i = 0; i < res3.size(); ++i) {
@@ -63,7 +62,7 @@ void testEnumerator() {
   // Enumerate acetone keto/enol tautomer.
   std::string smi4 = "CC(C)=O";
   std::shared_ptr<ROMol> m4(SmilesToMol(smi4));
-  std::vector<ROMOL_SPTR> res4 = te.enumerate(*m4, &tautcat);
+  std::vector<ROMOL_SPTR> res4 = te.enumerate(*m4);
   std::vector<std::string> ans4 = {"C=C(C)O", "CC(C)=O"};
   TEST_ASSERT(res4.size() == ans4.size());
   for (size_t i = 0; i < res4.size(); ++i) {
@@ -73,7 +72,7 @@ void testEnumerator() {
   // keto/enol tautomer
   std::string smi5 = "OC(C)=C(C)C";
   std::shared_ptr<ROMol> m5(SmilesToMol(smi5));
-  std::vector<ROMOL_SPTR> res5 = te.enumerate(*m5, &tautcat);
+  std::vector<ROMOL_SPTR> res5 = te.enumerate(*m5);
   std::vector<std::string> ans5 = {"C=C(O)C(C)C", "CC(=O)C(C)C", "CC(C)=C(C)O"};
   TEST_ASSERT(res5.size() == ans5.size());
   for (size_t i = 0; i < res5.size(); ++i) {
@@ -83,7 +82,7 @@ void testEnumerator() {
   // 1-phenyl-2-propanone enol/keto
   std::string smi6 = "c1(ccccc1)CC(=O)C";
   std::shared_ptr<ROMol> m6(SmilesToMol(smi6));
-  std::vector<ROMOL_SPTR> res6 = te.enumerate(*m6, &tautcat);
+  std::vector<ROMOL_SPTR> res6 = te.enumerate(*m6);
   std::vector<std::string> ans6 = {"C=C(O)Cc1ccccc1", "CC(=O)Cc1ccccc1",
                                    "CC(O)=Cc1ccccc1"};
   TEST_ASSERT(res6.size() == ans6.size());
@@ -94,7 +93,7 @@ void testEnumerator() {
   // 1,5 keto/enol tautomer
   std::string smi7 = "Oc1nccc2cc[nH]c(=N)c12";
   std::shared_ptr<ROMol> m7(SmilesToMol(smi7));
-  std::vector<ROMOL_SPTR> res7 = te.enumerate(*m7, &tautcat);
+  std::vector<ROMOL_SPTR> res7 = te.enumerate(*m7);
   std::vector<std::string> ans7 = {
       "N=c1[nH]ccc2cc[nH]c(=O)c12", "N=c1[nH]ccc2ccnc(O)c12",
       "N=c1nccc2cc[nH]c(O)c1-2",    "Nc1[nH]ccc2ccnc(=O)c1-2",
@@ -107,7 +106,7 @@ void testEnumerator() {
   // 1,5 keto/enol tautomer
   std::string smi8 = "C1(C=CCCC1)=O";
   std::shared_ptr<ROMol> m8(SmilesToMol(smi8));
-  std::vector<ROMOL_SPTR> res8 = te.enumerate(*m8, &tautcat);
+  std::vector<ROMOL_SPTR> res8 = te.enumerate(*m8);
   std::vector<std::string> ans8 = {"O=C1C=CCCC1", "O=C1CC=CCC1", "OC1=CC=CCC1",
                                    "OC1=CCC=CC1", "OC1=CCCC=C1"};
   TEST_ASSERT(res8.size() == ans8.size());
@@ -118,7 +117,7 @@ void testEnumerator() {
   // 1,5 keto/enol tautomer
   std::string smi9 = "C1(=CC=CCC1)O";
   std::shared_ptr<ROMol> m9(SmilesToMol(smi9));
-  std::vector<ROMOL_SPTR> res9 = te.enumerate(*m9, &tautcat);
+  std::vector<ROMOL_SPTR> res9 = te.enumerate(*m9);
   std::vector<std::string> ans9 = {"O=C1C=CCCC1", "O=C1CC=CCC1", "OC1=CC=CCC1",
                                    "OC1=CCC=CC1", "OC1=CCCC=C1"};
   TEST_ASSERT(res9.size() == ans9.size());
@@ -129,7 +128,7 @@ void testEnumerator() {
   // aliphatic imine tautomer
   std::string smi10 = "C1(CCCCC1)=N";
   std::shared_ptr<ROMol> m10(SmilesToMol(smi10));
-  std::vector<ROMOL_SPTR> res10 = te.enumerate(*m10, &tautcat);
+  std::vector<ROMOL_SPTR> res10 = te.enumerate(*m10);
   std::vector<std::string> ans10 = {"N=C1CCCCC1", "NC1=CCCCC1"};
   TEST_ASSERT(res10.size() == ans10.size());
   for (size_t i = 0; i < res10.size(); ++i) {
@@ -139,7 +138,7 @@ void testEnumerator() {
   // aliphatic imine tautomer
   std::string smi11 = "C1(=CCCCC1)N";
   std::shared_ptr<ROMol> m11(SmilesToMol(smi11));
-  std::vector<ROMOL_SPTR> res11 = te.enumerate(*m11, &tautcat);
+  std::vector<ROMOL_SPTR> res11 = te.enumerate(*m11);
   std::vector<std::string> ans11 = {"N=C1CCCCC1", "NC1=CCCCC1"};
   TEST_ASSERT(res11.size() == ans11.size());
   for (size_t i = 0; i < res11.size(); ++i) {
@@ -149,7 +148,7 @@ void testEnumerator() {
   // special imine tautomer
   std::string smi12 = "C1(C=CC=CN1)=CC";
   std::shared_ptr<ROMol> m12(SmilesToMol(smi12));
-  std::vector<ROMOL_SPTR> res12 = te.enumerate(*m12, &tautcat);
+  std::vector<ROMOL_SPTR> res12 = te.enumerate(*m12);
   std::vector<std::string> ans12 = {"CC=C1C=CC=CN1", "CC=C1C=CCC=N1",
                                     "CCc1ccccn1"};
   TEST_ASSERT(res12.size() == ans12.size());
@@ -160,7 +159,7 @@ void testEnumerator() {
   // special imine tautomer
   std::string smi13 = "C1(=NC=CC=C1)CC";
   std::shared_ptr<ROMol> m13(SmilesToMol(smi13));
-  std::vector<ROMOL_SPTR> res13 = te.enumerate(*m13, &tautcat);
+  std::vector<ROMOL_SPTR> res13 = te.enumerate(*m13);
   std::vector<std::string> ans13 = {"CC=C1C=CC=CN1", "CC=C1C=CCC=N1",
                                     "CCc1ccccn1"};
   TEST_ASSERT(res13.size() == ans13.size());
@@ -171,7 +170,7 @@ void testEnumerator() {
   // 1,3 aromatic heteroatom H shift
   std::string smi14 = "O=c1cccc[nH]1";
   std::shared_ptr<ROMol> m14(SmilesToMol(smi14));
-  std::vector<ROMOL_SPTR> res14 = te.enumerate(*m14, &tautcat);
+  std::vector<ROMOL_SPTR> res14 = te.enumerate(*m14);
   std::vector<std::string> ans14 = {"O=c1cccc[nH]1", "Oc1ccccn1"};
   TEST_ASSERT(res14.size() == ans14.size());
   for (size_t i = 0; i < res14.size(); ++i) {
@@ -181,7 +180,7 @@ void testEnumerator() {
   // 1,3 aromatic heteroatom H shift
   std::string smi15 = "Oc1ccccn1";
   std::shared_ptr<ROMol> m15(SmilesToMol(smi15));
-  std::vector<ROMOL_SPTR> res15 = te.enumerate(*m15, &tautcat);
+  std::vector<ROMOL_SPTR> res15 = te.enumerate(*m15);
   std::vector<std::string> ans15 = {"O=c1cccc[nH]1", "Oc1ccccn1"};
   TEST_ASSERT(res15.size() == ans15.size());
   for (size_t i = 0; i < res15.size(); ++i) {
@@ -191,7 +190,7 @@ void testEnumerator() {
   // 1,3 aromatic heteroatom H shift
   std::string smi16 = "Oc1ncc[nH]1";
   std::shared_ptr<ROMol> m16(SmilesToMol(smi16));
-  std::vector<ROMOL_SPTR> res16 = te.enumerate(*m16, &tautcat);
+  std::vector<ROMOL_SPTR> res16 = te.enumerate(*m16);
   std::vector<std::string> ans16 = {"O=c1[nH]cc[nH]1", "Oc1ncc[nH]1"};
   TEST_ASSERT(res16.size() == ans16.size());
   for (size_t i = 0; i < res16.size(); ++i) {
@@ -201,7 +200,7 @@ void testEnumerator() {
   // 1,3 heteroatom H shift
   std::string smi17 = "OC(C)=NC";
   std::shared_ptr<ROMol> m17(SmilesToMol(smi17));
-  std::vector<ROMOL_SPTR> res17 = te.enumerate(*m17, &tautcat);
+  std::vector<ROMOL_SPTR> res17 = te.enumerate(*m17);
   std::vector<std::string> ans17 = {"C=C(O)NC", "CN=C(C)O", "CNC(C)=O"};
   TEST_ASSERT(res17.size() == ans17.size());
   for (size_t i = 0; i < res17.size(); ++i) {
@@ -211,7 +210,7 @@ void testEnumerator() {
   // 1,3 heteroatom H shift
   std::string smi18 = "CNC(C)=O";
   std::shared_ptr<ROMol> m18(SmilesToMol(smi18));
-  std::vector<ROMOL_SPTR> res18 = te.enumerate(*m18, &tautcat);
+  std::vector<ROMOL_SPTR> res18 = te.enumerate(*m18);
   std::vector<std::string> ans18 = {"C=C(O)NC", "CN=C(C)O", "CNC(C)=O"};
   TEST_ASSERT(res18.size() == ans18.size());
   for (size_t i = 0; i < res18.size(); ++i) {
@@ -221,7 +220,7 @@ void testEnumerator() {
   // 1,3 heteroatom H shift
   std::string smi19 = "S=C(N)N";
   std::shared_ptr<ROMol> m19(SmilesToMol(smi19));
-  std::vector<ROMOL_SPTR> res19 = te.enumerate(*m19, &tautcat);
+  std::vector<ROMOL_SPTR> res19 = te.enumerate(*m19);
   std::vector<std::string> ans19 = {"N=C(N)S", "NC(N)=S"};
   TEST_ASSERT(res19.size() == ans19.size());
   for (size_t i = 0; i < res19.size(); ++i) {
@@ -231,7 +230,7 @@ void testEnumerator() {
   // 1,3 heteroatom H shift
   std::string smi20 = "SC(N)=N";
   std::shared_ptr<ROMol> m20(SmilesToMol(smi20));
-  std::vector<ROMOL_SPTR> res20 = te.enumerate(*m20, &tautcat);
+  std::vector<ROMOL_SPTR> res20 = te.enumerate(*m20);
   std::vector<std::string> ans20 = {"N=C(N)S", "NC(N)=S"};
   TEST_ASSERT(res20.size() == ans20.size());
   for (size_t i = 0; i < res20.size(); ++i) {
@@ -241,7 +240,7 @@ void testEnumerator() {
   // 1,3 heteroatom H shift
   std::string smi21 = "N=c1[nH]ccn(C)1";
   std::shared_ptr<ROMol> m21(SmilesToMol(smi21));
-  std::vector<ROMOL_SPTR> res21 = te.enumerate(*m21, &tautcat);
+  std::vector<ROMOL_SPTR> res21 = te.enumerate(*m21);
   std::vector<std::string> ans21 = {"Cn1cc[nH]c1=N", "Cn1ccnc1N"};
   TEST_ASSERT(res21.size() == ans21.size());
   for (size_t i = 0; i < res21.size(); ++i) {
@@ -251,7 +250,7 @@ void testEnumerator() {
   // 1,3 heteroatom H shift
   std::string smi22 = "CN=c1[nH]cncc1";
   std::shared_ptr<ROMol> m22(SmilesToMol(smi22));
-  std::vector<ROMOL_SPTR> res22 = te.enumerate(*m22, &tautcat);
+  std::vector<ROMOL_SPTR> res22 = te.enumerate(*m22);
   std::vector<std::string> ans22 = {"CN=c1cc[nH]cn1", "CN=c1ccnc[nH]1",
                                     "CNc1ccncn1"};
   TEST_ASSERT(res22.size() == ans22.size());
@@ -262,7 +261,7 @@ void testEnumerator() {
   // 1,5 aromatic heteroatom H shift
   std::string smi23 = "Oc1cccc2ccncc12";
   std::shared_ptr<ROMol> m23(SmilesToMol(smi23));
-  std::vector<ROMOL_SPTR> res23 = te.enumerate(*m23, &tautcat);
+  std::vector<ROMOL_SPTR> res23 = te.enumerate(*m23);
   std::vector<std::string> ans23 = {"O=c1cccc2cc[nH]cc1-2", "Oc1cccc2ccncc12"};
   TEST_ASSERT(res23.size() == ans23.size());
   for (size_t i = 0; i < res23.size(); ++i) {
@@ -272,7 +271,7 @@ void testEnumerator() {
   // 1,5 aromatic heteroatom H shift
   std::string smi24 = "O=c1cccc2cc[nH]cc1-2";
   std::shared_ptr<ROMol> m24(SmilesToMol(smi24));
-  std::vector<ROMOL_SPTR> res24 = te.enumerate(*m24, &tautcat);
+  std::vector<ROMOL_SPTR> res24 = te.enumerate(*m24);
   std::vector<std::string> ans24 = {"O=c1cccc2cc[nH]cc1-2", "Oc1cccc2ccncc12"};
   TEST_ASSERT(res24.size() == ans24.size());
   for (size_t i = 0; i < res24.size(); ++i) {
@@ -282,7 +281,7 @@ void testEnumerator() {
   // 1,5 aromatic heteroatom H shift
   std::string smi25 = "Cc1n[nH]c2ncnn12";
   std::shared_ptr<ROMol> m25(SmilesToMol(smi25));
-  std::vector<ROMOL_SPTR> res25 = te.enumerate(*m25, &tautcat);
+  std::vector<ROMOL_SPTR> res25 = te.enumerate(*m25);
   std::vector<std::string> ans25 = {"C=C1NN=C2N=CNN12", "C=C1NN=C2NC=NN12",
                                     "C=C1NNc2ncnn21",   "Cc1n[nH]c2ncnn12",
                                     "Cc1nnc2[nH]cnn12", "Cc1nnc2nc[nH]n12"};
@@ -294,7 +293,7 @@ void testEnumerator() {
   // 1,5 aromatic heteroatom H shift
   std::string smi26 = "Cc1nnc2nc[nH]n12";
   std::shared_ptr<ROMol> m26(SmilesToMol(smi26));
-  std::vector<ROMOL_SPTR> res26 = te.enumerate(*m26, &tautcat);
+  std::vector<ROMOL_SPTR> res26 = te.enumerate(*m26);
   std::vector<std::string> ans26 = {"C=C1NN=C2N=CNN12", "C=C1NN=C2NC=NN12",
                                     "C=C1NNc2ncnn21",   "Cc1n[nH]c2ncnn12",
                                     "Cc1nnc2[nH]cnn12", "Cc1nnc2nc[nH]n12"};
@@ -306,7 +305,7 @@ void testEnumerator() {
   // 1,5 aromatic heteroatom H shift
   std::string smi29 = "Oc1ccncc1";
   std::shared_ptr<ROMol> m29(SmilesToMol(smi29));
-  std::vector<ROMOL_SPTR> res29 = te.enumerate(*m29, &tautcat);
+  std::vector<ROMOL_SPTR> res29 = te.enumerate(*m29);
   std::vector<std::string> ans29 = {"O=c1cc[nH]cc1", "Oc1ccncc1"};
   TEST_ASSERT(res29.size() == ans29.size());
   for (size_t i = 0; i < res29.size(); ++i) {
@@ -316,7 +315,7 @@ void testEnumerator() {
   // 1,5 aromatic heteroatom H shift
   std::string smi27 = "Oc1c(cccc3)c3nc2ccncc12";
   std::shared_ptr<ROMol> m27(SmilesToMol(smi27));
-  std::vector<ROMOL_SPTR> res27 = te.enumerate(*m27, &tautcat);
+  std::vector<ROMOL_SPTR> res27 = te.enumerate(*m27);
   std::vector<std::string> ans27 = {"O=c1c2c[nH]ccc-2nc2ccccc12",
                                     "O=c1c2ccccc2[nH]c2ccncc12",
                                     "Oc1c2ccccc2nc2ccncc12"};
@@ -328,7 +327,7 @@ void testEnumerator() {
   // 1,3 and 1,5 aromatic heteroatom H shift
   std::string smi28 = "Oc1ncncc1";
   std::shared_ptr<ROMol> m28(SmilesToMol(smi28));
-  std::vector<ROMOL_SPTR> res28 = te.enumerate(*m28, &tautcat);
+  std::vector<ROMOL_SPTR> res28 = te.enumerate(*m28);
   std::vector<std::string> ans28 = {"O=c1cc[nH]cn1", "O=c1ccnc[nH]1",
                                     "Oc1ccncn1"};
   TEST_ASSERT(res28.size() == ans28.size());
@@ -339,7 +338,7 @@ void testEnumerator() {
   // 1,5 aromatic heteroatom H shift
   std::string smi30 = "C2(=C1C(=NC=N1)[NH]C(=N2)N)O";
   std::shared_ptr<ROMol> m30(SmilesToMol(smi30));
-  std::vector<ROMOL_SPTR> res30 = te.enumerate(*m30, &tautcat);
+  std::vector<ROMOL_SPTR> res30 = te.enumerate(*m30);
   std::vector<std::string> ans30 = {
       "N=c1[nH]c(=O)c2[nH]cnc2[nH]1", "N=c1[nH]c(=O)c2nc[nH]c2[nH]1",
       "N=c1[nH]c2ncnc-2c(O)[nH]1",    "N=c1nc(O)c2[nH]cnc2[nH]1",
@@ -357,7 +356,7 @@ void testEnumerator() {
   // 1,5 aromatic heteroatom H shift
   std::string smi31 = "C2(C1=C([NH]C=N1)[NH]C(=N2)N)=O";
   std::shared_ptr<ROMol> m31(SmilesToMol(smi31));
-  std::vector<ROMOL_SPTR> res31 = te.enumerate(*m31, &tautcat);
+  std::vector<ROMOL_SPTR> res31 = te.enumerate(*m31);
   std::vector<std::string> ans31 = {
       "N=c1[nH]c(=O)c2[nH]cnc2[nH]1", "N=c1[nH]c(=O)c2nc[nH]c2[nH]1",
       "N=c1[nH]c2ncnc-2c(O)[nH]1",    "N=c1nc(O)c2[nH]cnc2[nH]1",
@@ -375,7 +374,7 @@ void testEnumerator() {
   // 1,5 aromatic heteroatom H shift
   std::string smi32 = "Oc1n(C)ncc1";
   std::shared_ptr<ROMol> m32(SmilesToMol(smi32));
-  std::vector<ROMOL_SPTR> res32 = te.enumerate(*m32, &tautcat);
+  std::vector<ROMOL_SPTR> res32 = te.enumerate(*m32);
   std::vector<std::string> ans32 = {"CN1N=CCC1=O", "Cn1[nH]ccc1=O",
                                     "Cn1nccc1O"};
   TEST_ASSERT(res32.size() == ans32.size());
@@ -386,7 +385,7 @@ void testEnumerator() {
   // 1,5 aromatic heteroatom H shift
   std::string smi33 = "O=c1nc2[nH]ccn2cc1";
   std::shared_ptr<ROMol> m33(SmilesToMol(smi33));
-  std::vector<ROMOL_SPTR> res33 = te.enumerate(*m33, &tautcat);
+  std::vector<ROMOL_SPTR> res33 = te.enumerate(*m33);
   std::vector<std::string> ans33 = {"O=c1ccn2cc[nH]c2n1", "O=c1ccn2ccnc2[nH]1",
                                     "Oc1ccn2ccnc2n1"};
   TEST_ASSERT(res33.size() == ans33.size());
@@ -397,7 +396,7 @@ void testEnumerator() {
   // 1,5 aromatic heteroatom H shift
   std::string smi34 = "N=c1nc[nH]cc1";
   std::shared_ptr<ROMol> m34(SmilesToMol(smi34));
-  std::vector<ROMOL_SPTR> res34 = te.enumerate(*m34, &tautcat);
+  std::vector<ROMOL_SPTR> res34 = te.enumerate(*m34);
   std::vector<std::string> ans34 = {"N=c1cc[nH]cn1", "N=c1ccnc[nH]1",
                                     "Nc1ccncn1"};
   TEST_ASSERT(res34.size() == ans34.size());
@@ -408,7 +407,7 @@ void testEnumerator() {
   // 1,5 aromatic heteroatom H shift
   std::string smi35 = "N=c(c1)ccn2cc[nH]c12";
   std::shared_ptr<ROMol> m35(SmilesToMol(smi35));
-  std::vector<ROMOL_SPTR> res35 = te.enumerate(*m35, &tautcat);
+  std::vector<ROMOL_SPTR> res35 = te.enumerate(*m35);
   std::vector<std::string> ans35 = {"N=c1ccn2cc[nH]c2c1", "Nc1ccn2ccnc2c1"};
   TEST_ASSERT(res35.size() == ans35.size());
   for (size_t i = 0; i < res35.size(); ++i) {
@@ -418,7 +417,7 @@ void testEnumerator() {
   // 1,5 aromatic heteroatom H shift
   std::string smi36 = "CN=c1nc[nH]cc1";
   std::shared_ptr<ROMol> m36(SmilesToMol(smi36));
-  std::vector<ROMOL_SPTR> res36 = te.enumerate(*m36, &tautcat);
+  std::vector<ROMOL_SPTR> res36 = te.enumerate(*m36);
   std::vector<std::string> ans36 = {"CN=c1cc[nH]cn1", "CN=c1ccnc[nH]1",
                                     "CNc1ccncn1"};
   TEST_ASSERT(res36.size() == ans36.size());
@@ -429,7 +428,7 @@ void testEnumerator() {
   // 1,7 aromatic heteroatom H shift
   std::string smi37 = "c1ccc2[nH]c(-c3nc4ccccc4[nH]3)nc2c1";
   std::shared_ptr<ROMol> m37(SmilesToMol(smi37));
-  std::vector<ROMOL_SPTR> res37 = te.enumerate(*m37, &tautcat);
+  std::vector<ROMOL_SPTR> res37 = te.enumerate(*m37);
   std::vector<std::string> ans37 = {"c1ccc2[nH]c(-c3nc4ccccc4[nH]3)nc2c1",
                                     "c1ccc2c(c1)=NC(c1nc3ccccc3[nH]1)N=2",
                                     "c1ccc2c(c1)NC(=C1N=c3ccccc3=N1)N2"};
@@ -441,7 +440,7 @@ void testEnumerator() {
   // 1,7 aromatic heteroatom H shift
   std::string smi38 = "c1ccc2c(c1)NC(=C1N=c3ccccc3=N1)N2";
   std::shared_ptr<ROMol> m38(SmilesToMol(smi38));
-  std::vector<ROMOL_SPTR> res38 = te.enumerate(*m38, &tautcat);
+  std::vector<ROMOL_SPTR> res38 = te.enumerate(*m38);
   std::vector<std::string> ans38 = {"c1ccc2[nH]c(-c3nc4ccccc4[nH]3)nc2c1",
                                     "c1ccc2c(c1)=NC(c1nc3ccccc3[nH]1)N=2",
                                     "c1ccc2c(c1)NC(=C1N=c3ccccc3=N1)N2"};
@@ -453,7 +452,7 @@ void testEnumerator() {
   // 1,9 aromatic heteroatom H shift
   std::string smi39 = "CNc1ccnc2ncnn21";
   std::shared_ptr<ROMol> m39(SmilesToMol(smi39));
-  std::vector<ROMOL_SPTR> res39 = te.enumerate(*m39, &tautcat);
+  std::vector<ROMOL_SPTR> res39 = te.enumerate(*m39);
   std::vector<std::string> ans39 = {"CN=c1cc[nH]c2ncnn12",
                                     "CN=c1ccnc2[nH]cnn12",
                                     "CN=c1ccnc2nc[nH]n12", "CNc1ccnc2ncnn12"};
@@ -465,7 +464,7 @@ void testEnumerator() {
   // 1,9 aromatic heteroatom H shift
   std::string smi40 = "CN=c1ccnc2nc[nH]n21";
   std::shared_ptr<ROMol> m40(SmilesToMol(smi40));
-  std::vector<ROMOL_SPTR> res40 = te.enumerate(*m40, &tautcat);
+  std::vector<ROMOL_SPTR> res40 = te.enumerate(*m40);
   std::vector<std::string> ans40 = {"CN=c1cc[nH]c2ncnn12",
                                     "CN=c1ccnc2[nH]cnn12",
                                     "CN=c1ccnc2nc[nH]n12", "CNc1ccnc2ncnn12"};
@@ -477,7 +476,7 @@ void testEnumerator() {
   // 1,11 aromatic heteroatom H shift
   std::string smi41 = "Nc1ccc(C=C2C=CC(=O)C=C2)cc1";
   std::shared_ptr<ROMol> m41(SmilesToMol(smi41));
-  std::vector<ROMOL_SPTR> res41 = te.enumerate(*m41, &tautcat);
+  std::vector<ROMOL_SPTR> res41 = te.enumerate(*m41);
   std::vector<std::string> ans41 = {
       "N=C1C=CC(=CC2C=CC(=O)C=C2)C=C1", "N=C1C=CC(=Cc2ccc(O)cc2)C=C1",
       "N=C1C=CC(C=C2C=CC(=O)C=C2)C=C1", "Nc1ccc(C=C2C=CC(=O)C=C2)cc1"};
@@ -489,7 +488,7 @@ void testEnumerator() {
   // 1,11 aromatic heteroatom H shift
   std::string smi42 = "N=C1C=CC(=Cc2ccc(O)cc2)C=C1";
   std::shared_ptr<ROMol> m42(SmilesToMol(smi42));
-  std::vector<ROMOL_SPTR> res42 = te.enumerate(*m42, &tautcat);
+  std::vector<ROMOL_SPTR> res42 = te.enumerate(*m42);
   std::vector<std::string> ans42 = {
       "N=C1C=CC(=CC2C=CC(=O)C=C2)C=C1", "N=C1C=CC(=Cc2ccc(O)cc2)C=C1",
       "N=C1C=CC(C=C2C=CC(=O)C=C2)C=C1", "Nc1ccc(C=C2C=CC(=O)C=C2)cc1"};
@@ -501,7 +500,7 @@ void testEnumerator() {
   // heterocyclic tautomer
   std::string smi43 = "n1ccc2ccc[nH]c12";
   std::shared_ptr<ROMol> m43(SmilesToMol(smi43));
-  std::vector<ROMOL_SPTR> res43 = te.enumerate(*m43, &tautcat);
+  std::vector<ROMOL_SPTR> res43 = te.enumerate(*m43);
   std::vector<std::string> ans43 = {"c1c[nH]c2nccc-2c1", "c1cnc2[nH]ccc2c1"};
   TEST_ASSERT(res43.size() == ans43.size());
   for (size_t i = 0; i < res43.size(); ++i) {
@@ -511,7 +510,7 @@ void testEnumerator() {
   // heterocyclic tautomer
   std::string smi44 = "c1cc(=O)[nH]c2nccn12";
   std::shared_ptr<ROMol> m44(SmilesToMol(smi44));
-  std::vector<ROMOL_SPTR> res44 = te.enumerate(*m44, &tautcat);
+  std::vector<ROMOL_SPTR> res44 = te.enumerate(*m44);
   std::vector<std::string> ans44 = {"O=c1ccn2cc[nH]c2n1", "O=c1ccn2ccnc2[nH]1",
                                     "Oc1ccn2ccnc2n1"};
   TEST_ASSERT(res44.size() == ans44.size());
@@ -522,7 +521,7 @@ void testEnumerator() {
   // heterocyclic tautomer
   std::string smi45 = "c1cnc2c[nH]ccc12";
   std::shared_ptr<ROMol> m45(SmilesToMol(smi45));
-  std::vector<ROMOL_SPTR> res45 = te.enumerate(*m45, &tautcat);
+  std::vector<ROMOL_SPTR> res45 = te.enumerate(*m45);
   std::vector<std::string> ans45 = {"c1cc2cc[nH]c2cn1", "c1cc2cc[nH]cc-2n1"};
   TEST_ASSERT(res45.size() == ans45.size());
   for (size_t i = 0; i < res45.size(); ++i) {
@@ -532,7 +531,7 @@ void testEnumerator() {
   // heterocyclic tautomer
   std::string smi46 = "n1ccc2c[nH]ccc12";
   std::shared_ptr<ROMol> m46(SmilesToMol(smi46));
-  std::vector<ROMOL_SPTR> res46 = te.enumerate(*m46, &tautcat);
+  std::vector<ROMOL_SPTR> res46 = te.enumerate(*m46);
   std::vector<std::string> ans46 = {"c1cc2[nH]ccc2cn1", "c1cc2c[nH]ccc-2n1"};
   TEST_ASSERT(res46.size() == ans46.size());
   for (size_t i = 0; i < res46.size(); ++i) {
@@ -542,7 +541,7 @@ void testEnumerator() {
   // heterocyclic tautomer
   std::string smi47 = "c1cnc2ccc[nH]c12";
   std::shared_ptr<ROMol> m47(SmilesToMol(smi47));
-  std::vector<ROMOL_SPTR> res47 = te.enumerate(*m47, &tautcat);
+  std::vector<ROMOL_SPTR> res47 = te.enumerate(*m47);
   std::vector<std::string> ans47 = {"c1c[nH]c2ccnc-2c1", "c1cnc2cc[nH]c2c1"};
   TEST_ASSERT(res47.size() == ans47.size());
   for (size_t i = 0; i < res47.size(); ++i) {
@@ -552,7 +551,7 @@ void testEnumerator() {
   // furanone tautomer
   std::string smi48 = "C1=CC=C(O1)O";
   std::shared_ptr<ROMol> m48(SmilesToMol(smi48));
-  std::vector<ROMOL_SPTR> res48 = te.enumerate(*m48, &tautcat);
+  std::vector<ROMOL_SPTR> res48 = te.enumerate(*m48);
   std::vector<std::string> ans48 = {"O=C1CC=CO1", "Oc1ccco1"};
   TEST_ASSERT(res48.size() == ans48.size());
   for (size_t i = 0; i < res48.size(); ++i) {
@@ -562,7 +561,7 @@ void testEnumerator() {
   // furanone tautomer
   std::string smi49 = "O=C1CC=CO1";
   std::shared_ptr<ROMol> m49(SmilesToMol(smi49));
-  std::vector<ROMOL_SPTR> res49 = te.enumerate(*m49, &tautcat);
+  std::vector<ROMOL_SPTR> res49 = te.enumerate(*m49);
   std::vector<std::string> ans49 = {"O=C1CC=CO1", "Oc1ccco1"};
   TEST_ASSERT(res49.size() == ans49.size());
   for (size_t i = 0; i < res49.size(); ++i) {
@@ -572,7 +571,7 @@ void testEnumerator() {
   // keten/ynol tautomer
   std::string smi50 = "CC=C=O";
   std::shared_ptr<ROMol> m50(SmilesToMol(smi50));
-  std::vector<ROMOL_SPTR> res50 = te.enumerate(*m50, &tautcat);
+  std::vector<ROMOL_SPTR> res50 = te.enumerate(*m50);
   std::vector<std::string> ans50 = {"CC#CO", "CC=C=O"};
   TEST_ASSERT(res50.size() == ans50.size());
   for (size_t i = 0; i < res50.size(); ++i) {
@@ -582,7 +581,7 @@ void testEnumerator() {
   // keten/ynol tautomer
   std::string smi51 = "CC#CO";
   std::shared_ptr<ROMol> m51(SmilesToMol(smi51));
-  std::vector<ROMOL_SPTR> res51 = te.enumerate(*m51, &tautcat);
+  std::vector<ROMOL_SPTR> res51 = te.enumerate(*m51);
   std::vector<std::string> ans51 = {"CC#CO", "CC=C=O"};
   TEST_ASSERT(res51.size() == ans51.size());
   for (size_t i = 0; i < res51.size(); ++i) {
@@ -592,7 +591,7 @@ void testEnumerator() {
   // ionic nitro/aci-nitro tautomer
   std::string smi52 = "C([N+](=O)[O-])C";
   std::shared_ptr<ROMol> m52(SmilesToMol(smi52));
-  std::vector<ROMOL_SPTR> res52 = te.enumerate(*m52, &tautcat);
+  std::vector<ROMOL_SPTR> res52 = te.enumerate(*m52);
   std::vector<std::string> ans52 = {"CC=[N+]([O-])O", "CC[N+](=O)[O-]"};
   TEST_ASSERT(res52.size() == ans52.size());
   for (size_t i = 0; i < res52.size(); ++i) {
@@ -602,7 +601,7 @@ void testEnumerator() {
   // ionic nitro/aci-nitro tautomer
   std::string smi53 = "C(=[N+](O)[O-])C";
   std::shared_ptr<ROMol> m53(SmilesToMol(smi53));
-  std::vector<ROMOL_SPTR> res53 = te.enumerate(*m53, &tautcat);
+  std::vector<ROMOL_SPTR> res53 = te.enumerate(*m53);
   std::vector<std::string> ans53 = {"CC=[N+]([O-])O", "CC[N+](=O)[O-]"};
   TEST_ASSERT(res53.size() == ans53.size());
   for (size_t i = 0; i < res53.size(); ++i) {
@@ -612,7 +611,7 @@ void testEnumerator() {
   // oxim nitroso tautomer
   std::string smi54 = "CC(C)=NO";
   std::shared_ptr<ROMol> m54(SmilesToMol(smi54));
-  std::vector<ROMOL_SPTR> res54 = te.enumerate(*m54, &tautcat);
+  std::vector<ROMOL_SPTR> res54 = te.enumerate(*m54);
   std::vector<std::string> ans54 = {"C=C(C)NO", "CC(C)=NO", "CC(C)N=O"};
   TEST_ASSERT(res54.size() == ans54.size());
   for (size_t i = 0; i < res54.size(); ++i) {
@@ -622,7 +621,7 @@ void testEnumerator() {
   // oxim nitroso tautomer
   std::string smi55 = "CC(C)N=O";
   std::shared_ptr<ROMol> m55(SmilesToMol(smi55));
-  std::vector<ROMOL_SPTR> res55 = te.enumerate(*m55, &tautcat);
+  std::vector<ROMOL_SPTR> res55 = te.enumerate(*m55);
   std::vector<std::string> ans55 = {"C=C(C)NO", "CC(C)=NO", "CC(C)N=O"};
   TEST_ASSERT(res55.size() == ans55.size());
   for (size_t i = 0; i < res55.size(); ++i) {
@@ -632,7 +631,7 @@ void testEnumerator() {
   // oxim/nitroso tautomer via phenol
   std::string smi56 = "O=Nc1ccc(O)cc1";
   std::shared_ptr<ROMol> m56(SmilesToMol(smi56));
-  std::vector<ROMOL_SPTR> res56 = te.enumerate(*m56, &tautcat);
+  std::vector<ROMOL_SPTR> res56 = te.enumerate(*m56);
   std::vector<std::string> ans56 = {"O=C1C=CC(=NO)C=C1", "O=NC1C=CC(=O)C=C1",
                                     "O=Nc1ccc(O)cc1"};
   TEST_ASSERT(res56.size() == ans56.size());
@@ -643,7 +642,7 @@ void testEnumerator() {
   // oxim/nitroso tautomer via phenol
   std::string smi57 = "O=C1C=CC(=NO)C=C1";
   std::shared_ptr<ROMol> m57(SmilesToMol(smi57));
-  std::vector<ROMOL_SPTR> res57 = te.enumerate(*m57, &tautcat);
+  std::vector<ROMOL_SPTR> res57 = te.enumerate(*m57);
   std::vector<std::string> ans57 = {"O=C1C=CC(=NO)C=C1", "O=NC1C=CC(=O)C=C1",
                                     "O=Nc1ccc(O)cc1"};
   TEST_ASSERT(res57.size() == ans57.size());
@@ -654,7 +653,7 @@ void testEnumerator() {
   // cyano/iso-cyanic acid tautomer
   std::string smi58 = "C(#N)O";
   std::shared_ptr<ROMol> m58(SmilesToMol(smi58));
-  std::vector<ROMOL_SPTR> res58 = te.enumerate(*m58, &tautcat);
+  std::vector<ROMOL_SPTR> res58 = te.enumerate(*m58);
   std::vector<std::string> ans58 = {"N#CO", "N=C=O"};
   TEST_ASSERT(res58.size() == ans58.size());
   for (size_t i = 0; i < res58.size(); ++i) {
@@ -664,7 +663,7 @@ void testEnumerator() {
   // cyano/iso-cyanic acid tautomer
   std::string smi59 = "C(=N)=O";
   std::shared_ptr<ROMol> m59(SmilesToMol(smi59));
-  std::vector<ROMOL_SPTR> res59 = te.enumerate(*m59, &tautcat);
+  std::vector<ROMOL_SPTR> res59 = te.enumerate(*m59);
   std::vector<std::string> ans59 = {"N#CO", "N=C=O"};
   TEST_ASSERT(res59.size() == ans59.size());
   for (size_t i = 0; i < res59.size(); ++i) {
@@ -674,7 +673,7 @@ void testEnumerator() {
   // isocyanide tautomer
   std::string smi60 = "C#N";
   std::shared_ptr<ROMol> m60(SmilesToMol(smi60));
-  std::vector<ROMOL_SPTR> res60 = te.enumerate(*m60, &tautcat);
+  std::vector<ROMOL_SPTR> res60 = te.enumerate(*m60);
   std::vector<std::string> ans60 = {"C#N", "[C-]#[NH+]"};
   TEST_ASSERT(res60.size() == ans60.size());
   for (size_t i = 0; i < res60.size(); ++i) {
@@ -684,7 +683,7 @@ void testEnumerator() {
   // isocyanide tautomer
   std::string smi61 = "[C-]#[NH+]";
   std::shared_ptr<ROMol> m61(SmilesToMol(smi61));
-  std::vector<ROMOL_SPTR> res61 = te.enumerate(*m61, &tautcat);
+  std::vector<ROMOL_SPTR> res61 = te.enumerate(*m61);
   std::vector<std::string> ans61 = {"C#N", "[C-]#[NH+]"};
   TEST_ASSERT(res61.size() == ans61.size());
   for (size_t i = 0; i < res61.size(); ++i) {
@@ -694,7 +693,7 @@ void testEnumerator() {
   // phosphonic acid tautomer
   std::string smi62 = "[PH](=O)(O)(O)";
   std::shared_ptr<ROMol> m62(SmilesToMol(smi62));
-  std::vector<ROMOL_SPTR> res62 = te.enumerate(*m62, &tautcat);
+  std::vector<ROMOL_SPTR> res62 = te.enumerate(*m62);
   std::vector<std::string> ans62 = {"O=[PH](O)O", "OP(O)O"};
   TEST_ASSERT(res62.size() == ans62.size());
   for (size_t i = 0; i < res62.size(); ++i) {
@@ -704,7 +703,7 @@ void testEnumerator() {
   // phosphonic acid tautomer
   std::string smi63 = "P(O)(O)O";
   std::shared_ptr<ROMol> m63(SmilesToMol(smi63));
-  std::vector<ROMOL_SPTR> res63 = te.enumerate(*m63, &tautcat);
+  std::vector<ROMOL_SPTR> res63 = te.enumerate(*m63);
   std::vector<std::string> ans63 = {"O=[PH](O)O", "OP(O)O"};
   TEST_ASSERT(res63.size() == ans63.size());
   for (size_t i = 0; i < res63.size(); ++i) {
@@ -714,7 +713,7 @@ void testEnumerator() {
   // Remove stereochemistry from mobile double bonds
   std::string smi64 = "c1(ccccc1)/C=C(/O)\\C";
   std::shared_ptr<ROMol> m64(SmilesToMol(smi64));
-  std::vector<ROMOL_SPTR> res64 = te.enumerate(*m64, &tautcat);
+  std::vector<ROMOL_SPTR> res64 = te.enumerate(*m64);
   std::vector<std::string> ans64 = {"CC(O)=Cc1ccccc1", "C=C(O)Cc1ccccc1",
                                     "CC(=O)Cc1ccccc1"};
   TEST_ASSERT(res64.size() == ans64.size());
@@ -726,7 +725,7 @@ void testEnumerator() {
   // Remove stereochemistry from mobile double bonds
   std::string smi65 = "C/C=C/C(C)=O";
   std::shared_ptr<ROMol> m65(SmilesToMol(smi65));
-  std::vector<ROMOL_SPTR> res65 = te.enumerate(*m65, &tautcat);
+  std::vector<ROMOL_SPTR> res65 = te.enumerate(*m65);
   std::vector<std::string> ans65 = {"CC=CC(C)=O", "C=C(O)C=CC", "C=CC=C(C)O",
                                     "C=CCC(=C)O", "C=CCC(C)=O"};
   TEST_ASSERT(res65.size() == ans65.size());
@@ -737,7 +736,7 @@ void testEnumerator() {
   // Remove stereochemistry from mobile double bonds
   std::string smi66 = "C/C=C\\C(C)=O";
   std::shared_ptr<ROMol> m66(SmilesToMol(smi66));
-  std::vector<ROMOL_SPTR> res66 = te.enumerate(*m66, &tautcat);
+  std::vector<ROMOL_SPTR> res66 = te.enumerate(*m66);
   std::vector<std::string> ans66 = {"C=C(O)C=CC", "C=CC=C(C)O", "CC=CC(C)=O",
                                     "C=CCC(=C)O", "C=CCC(C)=O"};
   TEST_ASSERT(res66.size() == ans66.size());
@@ -754,7 +753,7 @@ void testEnumerator() {
   // Gaunine tautomers
   std::string smi67 = "N1C(N)=NC=2N=CNC2C1=O";
   std::shared_ptr<ROMol> m67(SmilesToMol(smi67));
-  std::vector<ROMOL_SPTR> res67 = te.enumerate(*m67, &tautcat);
+  std::vector<ROMOL_SPTR> res67 = te.enumerate(*m67);
   std::vector<std::string> ans67 = {
       "N=c1[nH]c(=O)c2[nH]cnc2[nH]1", "N=c1[nH]c(=O)c2nc[nH]c2[nH]1",
       "N=c1[nH]c2ncnc-2c(O)[nH]1",    "N=c1nc(O)c2[nH]cnc2[nH]1",
@@ -777,12 +776,85 @@ void testEnumerator() {
   // Test a structure with hundreds of tautomers.
   std::string smi68 = "[H][C](CO)(NC(=O)C1=C(O)C(O)=CC=C1)C(O)=O";
   std::shared_ptr<ROMol> m68(SmilesToMol(smi68));
-  std::vector<ROMOL_SPTR> res68 = te.enumerate(*m68, &tautcat);
+  std::vector<ROMOL_SPTR> res68 = te.enumerate(*m68);
   TEST_ASSERT(res68.size() == 375);
   BOOST_LOG(rdInfoLog) << "Finished" << std::endl;
 }
 
+// tests from the molvs repo:
+// https://github.com/mcs07/MolVS/blob/456f2fe723acfedbf634a8bcfe943b83ea7d4c20/tests/test_tautomer.py
+std::vector<std::pair<std::string, std::string>> canonTautomerData{
+    {"C1(=CCCCC1)O", "O=C1CCCCC1"},
+    {"C1(CCCCC1)=O", "O=C1CCCCC1"},
+    {"C(=C)(O)C1=CC=CC=C1", "CC(=O)c1ccccc1"},
+    {"CC(C)=O", "CC(C)=O"},
+    {"OC(C)=C(C)C", "CC(=O)C(C)C"},
+    {"c1(ccccc1)CC(=O)C", "CC(=O)Cc1ccccc1"},
+    {"Oc1nccc2cc[nH]c(=N)c12", "N=c1[nH]ccc2cc[nH]c(=O)c12"},
+    {"C1(C=CCCC1)=O", "O=C1C=CCCC1"},
+    {"C1(CCCCC1)=N", "N=C1CCCCC1"},
+    {"C1(=CCCCC1)N", "N=C1CCCCC1"},
+    {"C1(C=CC=CN1)=CC", "CCc1ccccn1"},
+    {"C1(=NC=CC=C1)CC", "CCc1ccccn1"},
+    {"O=c1cccc[nH]1", "O=c1cccc[nH]1"},
+    {"Oc1ccccn1", "O=c1cccc[nH]1"},
+    {"Oc1ncc[nH]1", "O=c1[nH]cc[nH]1"},
+    {"OC(C)=NC", "CNC(C)=O"},
+    {"CNC(C)=O", "CNC(C)=O"},
+    {"S=C(N)N", "NC(N)=S"},
+    {"SC(N)=N", "NC(N)=S"},
+    {"N=c1[nH]ccn(C)1", "Cn1cc[nH]c1=N"},
+    {"CN=c1[nH]cncc1", "CN=c1cc[nH]cn1"},
+    {"Oc1cccc2ccncc12", "Oc1cccc2ccncc12"},
+    {"O=c1cccc2cc[nH]cc1-2", "Oc1cccc2ccncc12"},
+    {"Cc1n[nH]c2ncnn12", "Cc1n[nH]c2ncnn12"},
+    {"Cc1nnc2nc[nH]n12", "Cc1n[nH]c2ncnn12"},
+    {"Oc1ccncc1", "O=c1cc[nH]cc1"},
+    {"Oc1c(cccc3)c3nc2ccncc12", "O=c1c2ccccc2[nH]c2ccncc12"},
+    {"Oc1ncncc1", "O=c1cc[nH]cn1"},
+    {"C2(=C1C(=NC=N1)[NH]C(=N2)N)O", "N=c1[nH]c(=O)c2[nH]cnc2[nH]1"},
+    {"C2(C1=C([NH]C=N1)[NH]C(=N2)N)=O", "N=c1[nH]c(=O)c2[nH]cnc2[nH]1"},
+    {"Oc1n(C)ncc1", "Cn1[nH]ccc1=O"},
+    {"O=c1nc2[nH]ccn2cc1", "O=c1ccn2cc[nH]c2n1"},
+    {"N=c1nc[nH]cc1", "N=c1cc[nH]cn1"},
+    {"N=c(c1)ccn2cc[nH]c12", "N=c1ccn2cc[nH]c2c1"},
+    {"CN=c1nc[nH]cc1", "CN=c1cc[nH]cn1"},
+    {"c1ccc2[nH]c(-c3nc4ccccc4[nH]3)nc2c1",
+     "c1ccc2[nH]c(-c3nc4ccccc4[nH]3)nc2c1"},
+    {"c1ccc2c(c1)NC(=C1N=c3ccccc3=N1)N2",
+     "c1ccc2[nH]c(-c3nc4ccccc4[nH]3)nc2c1"},
+    {"CNc1ccnc2ncnn21", "CN=c1cc[nH]c2ncnn12"},
+    {"CN=c1ccnc2nc[nH]n21", "CN=c1cc[nH]c2ncnn12"},
+    {"Nc1ccc(C=C2C=CC(=O)C=C2)cc1", "Nc1ccc(C=C2C=CC(=O)C=C2)cc1"},
+    {"N=C1C=CC(=Cc2ccc(O)cc2)C=C1", "Nc1ccc(C=C2C=CC(=O)C=C2)cc1"},
+    {"n1ccc2ccc[nH]c12", "c1cnc2[nH]ccc2c1"},
+    {"c1cc(=O)[nH]c2nccn12", "O=c1ccn2cc[nH]c2n1"},
+    {"c1cnc2c[nH]ccc12", "c1cc2cc[nH]c2cn1"},
+    {"n1ccc2c[nH]ccc12", "c1cc2[nH]ccc2cn1"},
+    {"c1cnc2ccc[nH]c12", "c1cnc2cc[nH]c2c1"},
+    {"C1=CC=C(O1)O", "Oc1ccco1"},
+    {"O=C1CC=CO1", "Oc1ccco1"},
+    {"CC=C=O", "CC=C=O"},
+    {"CC#CO", "CC=C=O"},
+    {"C([N+](=O)[O-])C", "CC[N+](=O)[O-]"},
+    {"C(=[N+](O)[O-])C", "CC[N+](=O)[O-]"},
+    {"CC(C)=NO", "CC(C)=NO"},
+    {"CC(C)N=O", "CC(C)=NO"},
+    {"O=Nc1ccc(O)cc1", "O=Nc1ccc(O)cc1"},
+    {"O=C1C=CC(=NO)C=C1", "O=Nc1ccc(O)cc1"},
+    {"C(#N)O", "N=C=O"},
+    {"C(=N)=O", "N=C=O"},
+    {"N=C(N)S(=O)O", "N=C(N)S(=O)O"},
+    {"C#N", "C#N"},
+    {"[C-]#[NH+]", "C#N"},
+    {"[PH](=O)(O)(O)", "O=[PH](O)O"},
+    {"P(O)(O)O", "O=[PH](O)O"}};
+
 void testCanonicalize() {
+  BOOST_LOG(rdInfoLog)
+      << "-----------------------\n Testing tautomer canonicalization"
+      << std::endl;
+
   std::string rdbase = getenv("RDBASE");
   std::string tautomerFile =
       rdbase + "/Data/MolStandardize/tautomerTransforms.in";
@@ -790,93 +862,42 @@ void testCanonicalize() {
   unsigned int ntautomers = tautparams->getNumTautomers();
   TEST_ASSERT(ntautomers == 34);
 
-  TautomerCatalog tautcat(tautparams);
-  TautomerCanonicalizer tc;
+  TautomerEnumerator te(new TautomerCatalog(tautparams));
 
-  {  // Enumerate 1,3 keto/enol tautomer.
-    std::string smi1 = "C1(=CCCCC1)O";
-    std::unique_ptr<ROMol> m1(SmilesToMol(smi1));
-    ROMol *res = tc.canonicalize(*m1, &tautcat);
-    std::cerr << MolToSmiles(*res) << std::endl;
-    TEST_ASSERT(MolToSmiles(*res) == "O=C1CCCCC1");
-    delete res;
-  }
-  // tests from the molvs repo:
-  // https://github.com/mcs07/MolVS/blob/456f2fe723acfedbf634a8bcfe943b83ea7d4c20/tests/test_tautomer.py
-  std::vector<std::pair<std::string, std::string>> data{
-      {"C1(=CCCCC1)O", "O=C1CCCCC1"},
-      {"C1(CCCCC1)=O", "O=C1CCCCC1"},
-      {"C(=C)(O)C1=CC=CC=C1", "CC(=O)c1ccccc1"},
-      {"CC(C)=O", "CC(C)=O"},
-      {"OC(C)=C(C)C", "CC(=O)C(C)C"},
-      {"c1(ccccc1)CC(=O)C", "CC(=O)Cc1ccccc1"},
-      {"Oc1nccc2cc[nH]c(=N)c12", "N=c1[nH]ccc2cc[nH]c(=O)c12"},
-      {"C1(C=CCCC1)=O", "O=C1C=CCCC1"},
-      {"C1(CCCCC1)=N", "N=C1CCCCC1"},
-      {"C1(=CCCCC1)N", "N=C1CCCCC1"},
-      {"C1(C=CC=CN1)=CC", "CCc1ccccn1"},
-      {"C1(=NC=CC=C1)CC", "CCc1ccccn1"},
-      {"O=c1cccc[nH]1", "O=c1cccc[nH]1"},
-      {"Oc1ccccn1", "O=c1cccc[nH]1"},
-      {"Oc1ncc[nH]1", "O=c1[nH]cc[nH]1"},
-      {"OC(C)=NC", "CNC(C)=O"},
-      {"CNC(C)=O", "CNC(C)=O"},
-      {"S=C(N)N", "NC(N)=S"},
-      {"SC(N)=N", "NC(N)=S"},
-      {"N=c1[nH]ccn(C)1", "Cn1cc[nH]c1=N"},
-      {"CN=c1[nH]cncc1", "CN=c1cc[nH]cn1"},
-      {"Oc1cccc2ccncc12", "Oc1cccc2ccncc12"},
-      {"O=c1cccc2cc[nH]cc1-2", "Oc1cccc2ccncc12"},
-      {"Cc1n[nH]c2ncnn12", "Cc1n[nH]c2ncnn12"},
-      {"Cc1nnc2nc[nH]n12", "Cc1n[nH]c2ncnn12"},
-      {"Oc1ccncc1", "O=c1cc[nH]cc1"},
-      {"Oc1c(cccc3)c3nc2ccncc12", "O=c1c2ccccc2[nH]c2ccncc12"},
-      {"Oc1ncncc1", "O=c1cc[nH]cn1"},
-      {"C2(=C1C(=NC=N1)[NH]C(=N2)N)O", "N=c1[nH]c(=O)c2[nH]cnc2[nH]1"},
-      {"C2(C1=C([NH]C=N1)[NH]C(=N2)N)=O", "N=c1[nH]c(=O)c2[nH]cnc2[nH]1"},
-      {"Oc1n(C)ncc1", "Cn1[nH]ccc1=O"},
-      {"O=c1nc2[nH]ccn2cc1", "O=c1ccn2cc[nH]c2n1"},
-      {"N=c1nc[nH]cc1", "N=c1cc[nH]cn1"},
-      {"N=c(c1)ccn2cc[nH]c12", "N=c1ccn2cc[nH]c2c1"},
-      {"CN=c1nc[nH]cc1", "CN=c1cc[nH]cn1"},
-      {"c1ccc2[nH]c(-c3nc4ccccc4[nH]3)nc2c1",
-       "c1ccc2[nH]c(-c3nc4ccccc4[nH]3)nc2c1"},
-      {"c1ccc2c(c1)NC(=C1N=c3ccccc3=N1)N2",
-       "c1ccc2[nH]c(-c3nc4ccccc4[nH]3)nc2c1"},
-      {"CNc1ccnc2ncnn21", "CN=c1cc[nH]c2ncnn12"},
-      {"CN=c1ccnc2nc[nH]n21", "CN=c1cc[nH]c2ncnn12"},
-      {"Nc1ccc(C=C2C=CC(=O)C=C2)cc1", "Nc1ccc(C=C2C=CC(=O)C=C2)cc1"},
-      {"N=C1C=CC(=Cc2ccc(O)cc2)C=C1", "Nc1ccc(C=C2C=CC(=O)C=C2)cc1"},
-      {"n1ccc2ccc[nH]c12", "c1cnc2[nH]ccc2c1"},
-      {"c1cc(=O)[nH]c2nccn12", "O=c1ccn2cc[nH]c2n1"},
-      {"c1cnc2c[nH]ccc12", "c1cc2cc[nH]c2cn1"},
-      {"n1ccc2c[nH]ccc12", "c1cc2[nH]ccc2cn1"},
-      {"c1cnc2ccc[nH]c12", "c1cnc2cc[nH]c2c1"},
-      {"C1=CC=C(O1)O", "Oc1ccco1"},
-      {"O=C1CC=CO1", "Oc1ccco1"},
-      {"CC=C=O", "CC=C=O"},
-      {"CC#CO", "CC=C=O"},
-      {"C([N+](=O)[O-])C", "CC[N+](=O)[O-]"},
-      {"C(=[N+](O)[O-])C", "CC[N+](=O)[O-]"},
-      {"CC(C)=NO", "CC(C)=NO"},
-      {"CC(C)N=O", "CC(C)=NO"},
-      {"O=Nc1ccc(O)cc1", "O=Nc1ccc(O)cc1"},
-      {"O=C1C=CC(=NO)C=C1", "O=Nc1ccc(O)cc1"},
-      {"C(#N)O", "N=C=O"},
-      {"C(=N)=O", "N=C=O"},
-      {"N=C(N)S(=O)O", "N=C(N)S(=O)O"},
-      {"C#N", "C#N"},
-      {"[C-]#[NH+]", "C#N"},
-      {"[PH](=O)(O)(O)", "O=[PH](O)O"},
-      {"P(O)(O)O", "O=[PH](O)O"}};
-  for (const auto itm : data) {
+  for (const auto itm : canonTautomerData) {
     std::unique_ptr<ROMol> mol{SmilesToMol(itm.first)};
     TEST_ASSERT(mol);
-    std::unique_ptr<ROMol> res{tc.canonicalize(*mol, &tautcat)};
+    std::unique_ptr<ROMol> res{te.canonicalize(*mol)};
     TEST_ASSERT(res);
     // std::cerr << itm.first<<" -> "<<MolToSmiles(*res)<<std::endl;
     TEST_ASSERT(MolToSmiles(*res) == itm.second);
   }
+  BOOST_LOG(rdInfoLog) << "Finished" << std::endl;
+}
+
+void testPickCanonical() {
+  BOOST_LOG(rdInfoLog) << "-----------------------\n Testing pickCanonical"
+                       << std::endl;
+
+  std::string rdbase = getenv("RDBASE");
+  std::string tautomerFile =
+      rdbase + "/Data/MolStandardize/tautomerTransforms.in";
+  auto *tautparams = new TautomerCatalogParams(tautomerFile);
+  unsigned int ntautomers = tautparams->getNumTautomers();
+  TEST_ASSERT(ntautomers == 34);
+
+  TautomerEnumerator te(new TautomerCatalog(tautparams));
+
+  for (const auto itm : canonTautomerData) {
+    std::unique_ptr<ROMol> mol{SmilesToMol(itm.first)};
+    TEST_ASSERT(mol);
+    auto tauts = te.enumerate(*mol);
+    std::unique_ptr<ROMol> res{te.pickCanonical(tauts)};
+    TEST_ASSERT(res);
+    // std::cerr << itm.first<<" -> "<<MolToSmiles(*res)<<std::endl;
+    TEST_ASSERT(MolToSmiles(*res) == itm.second);
+  }
+  BOOST_LOG(rdInfoLog) << "Finished" << std::endl;
 }
 
 int main() {
@@ -885,5 +906,6 @@ int main() {
   testEnumerator();
 #endif
   testCanonicalize();
+  testPickCanonical();
   return 0;
 }

--- a/Code/GraphMol/MolStandardize/testTautomer.cpp
+++ b/Code/GraphMol/MolStandardize/testTautomer.cpp
@@ -790,17 +790,99 @@ void testCanonicalize() {
   TEST_ASSERT(ntautomers == 34);
 
   TautomerCatalog tautcat(tautparams);
-  // TautomerCanonicalizer tc;
+  TautomerCanonicalizer tc;
 
-  // Enumerate 1,3 keto/enol tautomer.
+{  // Enumerate 1,3 keto/enol tautomer.
   std::string smi1 = "C1(=CCCCC1)O";
-  std::shared_ptr<ROMol> m1(SmilesToMol(smi1));
-  // ROMol *res = tc.canonicalize(*m1, &tautcat);
-  //    TEST_ASSERT(MolToSmiles(*res) == "O=C1CCCCC1");
+  std::unique_ptr<ROMol> m1(SmilesToMol(smi1));
+  ROMol *res = tc.canonicalize(*m1, &tautcat);
+  std::cerr << MolToSmiles(*res)<<std::endl;
+  TEST_ASSERT(MolToSmiles(*res) == "O=C1CCCCC1");
+  delete res;
+}
+  // tests from the molvs repo: https://github.com/mcs07/MolVS/blob/456f2fe723acfedbf634a8bcfe943b83ea7d4c20/tests/test_tautomer.py
+  std::vector<std::pair<std::string,std::string>> data{{"C1(=CCCCC1)O","O=C1CCCCC1"},
+    {"C1(CCCCC1)=O","O=C1CCCCC1"},
+    {"C(=C)(O)C1=CC=CC=C1","CC(=O)c1ccccc1"},
+    {"CC(C)=O","CC(C)=O"},
+    {"OC(C)=C(C)C","CC(=O)C(C)C"},
+    {"c1(ccccc1)CC(=O)C","CC(=O)Cc1ccccc1"},
+    {"Oc1nccc2cc[nH]c(=N)c12","N=c1[nH]ccc2cc[nH]c(=O)c12"},
+    {"C1(C=CCCC1)=O","O=C1C=CCCC1"},
+    {"C1(CCCCC1)=N", "N=C1CCCCC1"},
+    {"C1(=CCCCC1)N", "N=C1CCCCC1"},
+    {"C1(C=CC=CN1)=CC", "CCc1ccccn1"},
+    {"C1(=NC=CC=C1)CC", "CCc1ccccn1"},
+    {"O=c1cccc[nH]1", "O=c1cccc[nH]1"},
+    {"Oc1ccccn1", "O=c1cccc[nH]1"},
+    {"Oc1ncc[nH]1", "O=c1[nH]cc[nH]1"},
+    {"OC(C)=NC", "CNC(C)=O"},
+    {"CNC(C)=O", "CNC(C)=O"},
+    {"S=C(N)N", "NC(N)=S"},
+    {"SC(N)=N", "NC(N)=S"},
+    {"N=c1[nH]ccn(C)1", "Cn1cc[nH]c1=N"},
+    {"CN=c1[nH]cncc1", "CN=c1cc[nH]cn1"},
+    {"Oc1cccc2ccncc12", "Oc1cccc2ccncc12"},
+    {"O=c1cccc2cc[nH]cc1-2", "Oc1cccc2ccncc12"},
+    {"Cc1n[nH]c2ncnn12", "Cc1n[nH]c2ncnn12"},
+    {"Cc1nnc2nc[nH]n12", "Cc1n[nH]c2ncnn12"},
+    {"Oc1ccncc1", "O=c1cc[nH]cc1"},
+    {"Oc1c(cccc3)c3nc2ccncc12", "O=c1c2ccccc2[nH]c2ccncc12"},
+    {"Oc1ncncc1", "O=c1cc[nH]cn1"},
+    {"C2(=C1C(=NC=N1)[NH]C(=N2)N)O", "N=c1[nH]c(=O)c2[nH]cnc2[nH]1"},
+    {"C2(C1=C([NH]C=N1)[NH]C(=N2)N)=O", "N=c1[nH]c(=O)c2[nH]cnc2[nH]1"},
+    {"Oc1n(C)ncc1", "Cn1[nH]ccc1=O"},
+    {"O=c1nc2[nH]ccn2cc1", "O=c1ccn2cc[nH]c2n1"},
+    {"N=c1nc[nH]cc1", "N=c1cc[nH]cn1"},
+    {"N=c(c1)ccn2cc[nH]c12", "N=c1ccn2cc[nH]c2c1"},
+    {"CN=c1nc[nH]cc1", "CN=c1cc[nH]cn1"},
+    {"c1ccc2[nH]c(-c3nc4ccccc4[nH]3)nc2c1", "c1ccc2[nH]c(-c3nc4ccccc4[nH]3)nc2c1"},
+    {"c1ccc2c(c1)NC(=C1N=c3ccccc3=N1)N2", "c1ccc2[nH]c(-c3nc4ccccc4[nH]3)nc2c1"},
+    {"CNc1ccnc2ncnn21", "CN=c1cc[nH]c2ncnn12"},
+    {"CN=c1ccnc2nc[nH]n21", "CN=c1cc[nH]c2ncnn12"},
+    {"Nc1ccc(C=C2C=CC(=O)C=C2)cc1", "Nc1ccc(C=C2C=CC(=O)C=C2)cc1"},
+    {"N=C1C=CC(=Cc2ccc(O)cc2)C=C1", "Nc1ccc(C=C2C=CC(=O)C=C2)cc1"},
+    {"n1ccc2ccc[nH]c12", "c1cnc2[nH]ccc2c1"},
+    {"c1cc(=O)[nH]c2nccn12", "O=c1ccn2cc[nH]c2n1"},
+    {"c1cnc2c[nH]ccc12", "c1cc2cc[nH]c2cn1"},
+    {"n1ccc2c[nH]ccc12", "c1cc2[nH]ccc2cn1"},
+    {"c1cnc2ccc[nH]c12", "c1cnc2cc[nH]c2c1"},
+    {"C1=CC=C(O1)O", "Oc1ccco1"},
+    {"O=C1CC=CO1", "Oc1ccco1"},
+    {"CC=C=O", "CC=C=O"},
+    {"CC#CO", "CC=C=O"},
+    {"C([N+](=O)[O-])C", "CC[N+](=O)[O-]"},
+    {"C(=[N+](O)[O-])C", "CC[N+](=O)[O-]"},
+    {"CC(C)=NO", "CC(C)=NO"},
+    {"CC(C)N=O", "CC(C)=NO"},
+    {"O=Nc1ccc(O)cc1", "O=Nc1ccc(O)cc1"},
+    {"O=C1C=CC(=NO)C=C1", "O=Nc1ccc(O)cc1"},
+    {"C(#N)O", "N=C=O"},
+    {"C(=N)=O", "N=C=O"},
+    {"N=C(N)S(=O)O", "N=C(N)S(=O)O"},
+    {"C#N", "C#N"},
+    {"[C-]#[NH+]", "C#N"},
+    {"[PH](=O)(O)(O)", "O=[PH](O)O"},
+    {"P(O)(O)O", "O=[PH](O)O"}
+  };
+  for(const auto itm : data){
+    std::unique_ptr<ROMol> mol{SmilesToMol(itm.first)};
+    TEST_ASSERT(mol);
+    std::unique_ptr<ROMol> res{tc.canonicalize(*mol,&tautcat)};
+    TEST_ASSERT(res);
+    std::cerr << itm.first<<" -> "<<MolToSmiles(*res)<<std::endl;
+    TEST_ASSERT(MolToSmiles(*res) == itm.second);
+
+    
+  }
+
 }
 
 int main() {
+  RDLog::InitLogs();
+#if 0
   testEnumerator();
-  // testCanonicalize();
+#endif
+  testCanonicalize();
   return 0;
 }


### PR DESCRIPTION
During the 2018 GSoC project to do a C++ implementation of MolVS, doing the tautomer enumeration and canonicalization were stretch goals. @susanhleung actually managed to complete the tautomer enumeration, but since canonicalization wasn't complete, we didn't publicize this particularly widely.

This PR does the last bit of work and adds tautomer canonicalization.

Notes to reviewers: 
- the goal of this first merge is to implement the tautomer scoring and canonicalization schemes that are used in MolVS. Once we have that in place the arguments can start (if really necessary) about whether or not we want a different/modified default scoring scheme.
- I will be probably be adding some additional tests over the next couple of days, those won't the design or (hopefully) scoring/canonicalization code itself, so it should be fine to start looking at this.