### PR TITLE
Fix to allow multistructure images in Java/C# and use MCS for c# wrapper

### DIFF
--- a/Code/JavaWrappers/MolDraw2D.i
+++ b/Code/JavaWrappers/MolDraw2D.i
@@ -53,6 +53,7 @@
 %template(Int_Double_Map) std::map< int, double >;
 %template(Float_Pair) std::pair<float,float>;
 %template(Float_Pair_Vect) std::vector< std::pair<float,float> >;
+%template(ROMol_Ptr_Vect) std::vector<RDKit::ROMol*>;
 
 %ignore RDKit::MolDraw2DSVG::MolDraw2DSVG(int,int,std::ostream &);
 

--- a/Code/JavaWrappers/csharp_wrapper/CMakeLists.txt
+++ b/Code/JavaWrappers/csharp_wrapper/CMakeLists.txt
@@ -2,12 +2,12 @@ project (GraphMolCSharp)
 
 include_directories( ${RDKit_ExternalDir} )
 
-# find the gmcs executables on non-windows systems:
+# find the mcs executables on non-windows systems:
 if(NOT WIN32)
-  find_program(GMCS_EXE gmcs)
+  find_program(GMCS_EXE mcs)
   if (NOT GMCS_EXE)
-	MESSAGE ("gmcs (executable) is not found. Please add it to PATH and rerun cmake.")
-	MESSAGE(FATAL_ERROR "Cannot find required executable gmcs")
+	MESSAGE ("mcs (executable) is not found. Please add it to PATH and rerun cmake.")
+	MESSAGE(FATAL_ERROR "Cannot find required executable mcs")
   endif (NOT GMCS_EXE)
 endif(NOT WIN32)
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! 
-->

#### What does this implement/fix? Explain your changes.

This pull request does two things- 

1. Simple change to the MolDraw.i swig interface so that I can create a ROMol_Ptr_Vect in Java or C# and draw those molecules using  MolDraw2DSVG

2. A change the the csharp_wrapper CMakeLists.txt to use mcs as the mono compiler rather than gmcs (which isn't shipped any more).  Without this change it is not possible to create a makefile for building the wrapper.

#### Any other comments?

The current code base does not compile the c sharp assembly as `PropertyPickleOptions.cs` will not compile.  As I don't need that code I can delete that file and compile manually.

I'm using dotnet core to build a Linux library.  If it's of interest and I could look at replacing mcs with dotnet in CMakeLists.txt.

I've published a [Nuget](https://www.nuget.org/packages/RDKit2DotNetCoreLinux/2019.9.0-alpha1) package for dotnet core on Ubuntu built on Rdkit 2019.9 release.  We're using it to run dotnet services on Linux containers.
