### PR TITLE
patch to make PandasTools tests pass with pandas v0.22

### DIFF
--- a/rdkit/Chem/PandasTools.py
+++ b/rdkit/Chem/PandasTools.py
@@ -224,11 +224,16 @@ def patchPandasHTMLrepr(self, **kwargs):
       kwargs['escape'] = False  # disable escaping
       return defPandasRendering(self, **kwargs)
 
-  import pandas.io.formats.html  # necessary for loading HTMLFormatter
-  if not hasattr(pd.io.formats.html, 'HTMLFormatter') or \
-     not hasattr(pd.io.formats.html.HTMLFormatter, '_write_cell') or \
-     not hasattr(pd.io.formats.format, '_get_adjustment'):
+  try:
+    import pandas.io.formats.html  # necessary for loading HTMLFormatter
+  except:
+    # this happens up until at least pandas v0.22
     return patch_v1()
+  else:
+    if not hasattr(pd.io.formats.html, 'HTMLFormatter') or \
+      not hasattr(pd.io.formats.html.HTMLFormatter, '_write_cell') or \
+      not hasattr(pd.io.formats.format, '_get_adjustment'):
+      return patch_v1()
 
   # The "clean" patch:
   # 1. Temporarily set escape=False in HTMLFormatter._write_cell


### PR DESCRIPTION
the module `pandas.io.formats.html` didn't show up until a more recent version, so we need to catch the `ImportError` when it's missing.

Hopefully nobody's actually using this ancient version, but it is what you get from apt in Ubuntu 18.04