### PR TITLE
fix doctest problem with Pandas v1.0

### DIFF
--- a/rdkit/Chem/PandasTools.py
+++ b/rdkit/Chem/PandasTools.py
@@ -694,7 +694,17 @@ def RGroupDecompositionToFrame(groups, mols, include_core=False, redraw_sidechai
   ['Mol', 'Core', 'R1', 'R2']
   >>> len(df)
   5
-  
+  >>> df.columns() # doctest: +SKIP
+  <class 'pandas*...*DataFrame'>
+  RangeIndex: 5 entries, 0 to 4
+  Data columns (total 4 columns):
+  Mol     5 non-null object
+  Core    5 non-null object
+  R1      5 non-null object
+  R2      5 non-null object
+  dtypes: object(4)
+  memory usage: *...*
+
   """
   cols = ['Mol'] + list(groups.keys())
   if redraw_sidechains:

--- a/rdkit/Chem/PandasTools.py
+++ b/rdkit/Chem/PandasTools.py
@@ -690,17 +690,11 @@ def RGroupDecompositionToFrame(groups, mols, include_core=False, redraw_sidechai
   >>> mols = [Chem.MolFromSmiles(smi) for smi in 'c1c(F)cccn1 c1c(Cl)c(C)ccn1 c1c(O)cccn1 c1c(F)c(C)ccn1 c1cc(Cl)c(F)cn1'.split()]
   >>> groups,_ = rdRGroupDecomposition.RGroupDecompose([scaffold],mols,asSmiles=False,asRows=False) 
   >>> df = PandasTools.RGroupDecompositionToFrame(groups,mols,include_core=True)
-  >>> df.info() # doctest: +ELLIPSIS
-  <class 'pandas*...*DataFrame'>
-  RangeIndex: 5 entries, 0 to 4
-  Data columns (total 4 columns):
-  Mol     5 non-null object
-  Core    5 non-null object
-  R1      5 non-null object
-  R2      5 non-null object
-  dtypes: object(4)
-  memory usage: *...*
-
+  >>> list(df.columns)
+  ['Mol', 'Core', 'R1', 'R2']
+  >>> len(df)
+  5
+  
   """
   cols = ['Mol'] + list(groups.keys())
   if redraw_sidechains:


### PR DESCRIPTION
Pandas 1.0 (which just came out and which is now used by the CI systems) changes the output of the `.info()` method.
Rather than continuing to chase that, this adds a couple of simpler tests and skips testing the `.info()` output in the doc string.