### PR TITLE
Override `what()` in exceptions (Addresses #2920)

### DIFF
--- a/Code/DataStructs/DatastructsException.h
+++ b/Code/DataStructs/DatastructsException.h
@@ -19,7 +19,8 @@ class RDKIT_DATASTRUCTS_EXPORT DatastructsException : public std::exception {
   //! construct with an error message
   DatastructsException(const std::string &msg) : _msg(msg){};
   //! get the error message
-  const char *message() const { return _msg.c_str(); };
+  const char *what() const noexcept override { return _msg.c_str(); };
+  const char *message() const noexcept { return what(); };
   ~DatastructsException() noexcept {};
 
  private:

--- a/Code/Demos/RDKit/Basement/TemplEnum/TemplEnum.h
+++ b/Code/Demos/RDKit/Basement/TemplEnum/TemplEnum.h
@@ -16,7 +16,8 @@ class EnumException : public std::exception {
  public:
   EnumException(const char *msg) : _msg(msg){};
   EnumException(const std::string msg) : _msg(msg){};
-  const char *message() const { return _msg.c_str(); };
+  const char *what() const noexcept override { return _msg.c_str(); };
+  const char *message() const noexcept { return what(); };
   ~EnumException() noexcept {};
 
  private:

--- a/Code/Geometry/Grid3D.h
+++ b/Code/Geometry/Grid3D.h
@@ -26,7 +26,8 @@ class RDKIT_RDGEOMETRYLIB_EXPORT GridException : public std::exception {
   //! construct with an error message
   GridException(const std::string &msg) : _msg(msg){};
   //! get the error message
-  const char *message() const { return _msg.c_str(); };
+  const char *what() const noexcept override { return _msg.c_str(); };
+  const char *message() const noexcept { return what(); };
   ~GridException() noexcept {};
 
  private:

--- a/Code/GraphMol/ChemReactions/Enumerate/EnumerationStrategyBase.h
+++ b/Code/GraphMol/ChemReactions/Enumerate/EnumerationStrategyBase.h
@@ -58,7 +58,8 @@ class RDKIT_CHEMREACTIONS_EXPORT EnumerationStrategyException
  public:
   EnumerationStrategyException(const char *msg) : _msg(msg){};
   EnumerationStrategyException(const std::string &msg) : _msg(msg){};
-  const char *message() const { return _msg.c_str(); };
+  const char *what() const noexcept override { return _msg.c_str(); };
+  const char *message() const noexcept { return what(); };
   ~EnumerationStrategyException() noexcept {};
 
  private:

--- a/Code/GraphMol/ChemReactions/Reaction.h
+++ b/Code/GraphMol/ChemReactions/Reaction.h
@@ -51,7 +51,8 @@ class RDKIT_CHEMREACTIONS_EXPORT ChemicalReactionException
   //! construct with an error message
   explicit ChemicalReactionException(const std::string msg) : _msg(msg){};
   //! get the error message
-  const char *message() const { return _msg.c_str(); };
+  const char *what() const noexcept override { return _msg.c_str(); };
+  const char *message() const noexcept { return what(); };
   ~ChemicalReactionException() noexcept {};
 
  private:

--- a/Code/GraphMol/ChemReactions/ReactionParser.h
+++ b/Code/GraphMol/ChemReactions/ReactionParser.h
@@ -50,7 +50,8 @@ class RDKIT_CHEMREACTIONS_EXPORT ChemicalReactionParserException
   explicit ChemicalReactionParserException(const std::string &msg)
       : _msg(msg){};
   //! get the error message
-  const char *message() const { return _msg.c_str(); };
+  const char *what() const noexcept override{ return _msg.c_str(); };
+  const char *message() const noexcept{ return what(); };
   ~ChemicalReactionParserException() noexcept {};
 
  private:

--- a/Code/GraphMol/ChemReactions/ReactionPickler.h
+++ b/Code/GraphMol/ChemReactions/ReactionPickler.h
@@ -30,7 +30,8 @@ class RDKIT_CHEMREACTIONS_EXPORT ReactionPicklerException
  public:
   ReactionPicklerException(const char *msg) : _msg(msg){};
   ReactionPicklerException(const std::string msg) : _msg(msg){};
-  const char *message() const { return _msg.c_str(); };
+  const char *what() const noexcept override{ return _msg.c_str(); };
+  const char *message() const noexcept{ return what(); };
   ~ReactionPicklerException() noexcept {};
 
  private:

--- a/Code/GraphMol/ChemReactions/SanitizeRxn.h
+++ b/Code/GraphMol/ChemReactions/SanitizeRxn.h
@@ -45,7 +45,8 @@ class RDKIT_CHEMREACTIONS_EXPORT RxnSanitizeException : public std::exception {
  public:
   RxnSanitizeException(const char *msg) : _msg(msg){};
   RxnSanitizeException(const std::string &msg) : _msg(msg){};
-  const char *message() const { return _msg.c_str(); };
+  const char *what() const noexcept override { return _msg.c_str(); };
+  const char *message() const noexcept { return what(); };
   ~RxnSanitizeException() noexcept {};
 
  private:

--- a/Code/GraphMol/ChemReactions/Wrap/rdChemReactions.cpp
+++ b/Code/GraphMol/ChemReactions/Wrap/rdChemReactions.cpp
@@ -929,7 +929,7 @@ unrecognized final group types are returned as None:
   >>> nWarn,nError,nReacts,nProds,reactantLabels = PreprocessReaction(rxn)
   Traceback (most recent call last):
     ...
-  RuntimeError: KeyErrorException
+  KeyError: 'boromicacid'
 
 One unrecognized group type in a comma-separated list makes the whole thing fail:
   >>> testFile = os.path.join(RDConfig.RDCodeDir,'Chem','SimpleEnum','test_data','bad_value2.rxn')
@@ -938,14 +938,14 @@ One unrecognized group type in a comma-separated list makes the whole thing fail
   >>> nWarn,nError,nReacts,nProds,reactantLabels = PreprocessReaction(rxn)
   Traceback (most recent call last):
     ...
-  RuntimeError: KeyErrorException
+  KeyError: 'carboxylicacid,acidchlroide'
   >>> testFile = os.path.join(RDConfig.RDCodeDir,'Chem','SimpleEnum','test_data','bad_value3.rxn')
   >>> rxn = AllChem.ReactionFromRxnFile(testFile)
   >>> rxn.Initialize()
   >>> nWarn,nError,nReacts,nProds,reactantLabels = PreprocessReaction(rxn)
   Traceback (most recent call last):
     ...
-  RuntimeError: KeyErrorException
+  KeyError: 'carboxyliccaid,acidchloride'
   >>> rxn = rdChemReactions.ChemicalReaction()
   >>> rxn.Initialize()
   >>> nWarn,nError,nReacts,nProds,reactantLabels = PreprocessReaction(rxn)

--- a/Code/GraphMol/Conformer.h
+++ b/Code/GraphMol/Conformer.h
@@ -27,7 +27,8 @@ class RDKIT_GRAPHMOL_EXPORT ConformerException : public std::exception {
   //! construct with an error message
   ConformerException(const std::string &msg) : _msg(msg){};
   //! get the error message
-  const char *message() const { return _msg.c_str(); };
+  const char *what() const noexcept override { return _msg.c_str(); };
+  const char *message() const noexcept { return what(); };
   ~ConformerException() noexcept {};
 
  private:

--- a/Code/GraphMol/Depictor/RDDepictor.h
+++ b/Code/GraphMol/Depictor/RDDepictor.h
@@ -32,7 +32,8 @@ class RDKIT_DEPICTOR_EXPORT DepictException : public std::exception {
  public:
   DepictException(const char *msg) : _msg(msg){};
   DepictException(const std::string msg) : _msg(msg){};
-  const char *message() const { return _msg.c_str(); };
+  const char *what() const noexcept override{ return _msg.c_str(); };
+  const char *message() const noexcept{ return what(); };
   ~DepictException() noexcept {};
 
  private:

--- a/Code/GraphMol/Descriptors/Wrap/testMolDescriptors.py
+++ b/Code/GraphMol/Descriptors/Wrap/testMolDescriptors.py
@@ -503,7 +503,7 @@ class TestCase(unittest.TestCase):
     try:
       props = rdMD.Properties(["property that doesn't exist"])
       self.assertEqual("should not get here", "but did")
-    except RuntimeError:
+    except KeyError:
       pass
 
   def testPythonDescriptorFunctor(self):

--- a/Code/GraphMol/FileParsers/FileParsers.h
+++ b/Code/GraphMol/FileParsers/FileParsers.h
@@ -33,7 +33,8 @@ class MolFileUnhandledFeatureException : public std::exception {
   explicit MolFileUnhandledFeatureException(const std::string msg)
       : _msg(msg){};
   //! get the error message
-  const char *message() const { return _msg.c_str(); };
+  const char *what() const noexcept override { return _msg.c_str(); };
+  const char *message() const noexcept { return what(); };
   ~MolFileUnhandledFeatureException() noexcept override{};
 
  private:

--- a/Code/GraphMol/Fingerprints/FingerprintGenerator.h
+++ b/Code/GraphMol/Fingerprints/FingerprintGenerator.h
@@ -305,7 +305,8 @@ class RDKIT_FINGERPRINTS_EXPORT UnimplementedFPException
   //! construct with an error message
   UnimplementedFPException(const std::string &msg) : _msg(msg){};
   //! get the error message
-  const char *message() const { return _msg.c_str(); };
+  const char *what() const noexcept override{ return _msg.c_str(); };
+  const char *message() const noexcept{ return what(); };
   ~UnimplementedFPException() noexcept {};
 
  private:

--- a/Code/GraphMol/MolAlign/AlignMolecules.h
+++ b/Code/GraphMol/MolAlign/AlignMolecules.h
@@ -28,7 +28,8 @@ class RDKIT_MOLALIGN_EXPORT MolAlignException : public std::exception {
   //! construct with an error message
   MolAlignException(const std::string msg) : _msg(msg){};
   //! get the error message
-  const char *message() const { return _msg.c_str(); };
+  const char *what() const noexcept override { return _msg.c_str(); };
+  const char *message() const noexcept { return what(); };
   ~MolAlignException() noexcept {};
 
  private:

--- a/Code/GraphMol/MolChemicalFeatures/FeatureParser.h
+++ b/Code/GraphMol/MolChemicalFeatures/FeatureParser.h
@@ -28,7 +28,7 @@ class RDKIT_MOLCHEMICALFEATURES_EXPORT FeatureFileParseException
   unsigned int lineNo() const { return d_lineNo; };
   std::string line() const { return d_line; };
   const char *what() const noexcept override { return d_msg.c_str(); };
-  std::string message() const noexcept { return d_msg; };
+  const char *message() const noexcept { return what(); };
   ~FeatureFileParseException() noexcept {};
 
  private:

--- a/Code/GraphMol/MolChemicalFeatures/FeatureParser.h
+++ b/Code/GraphMol/MolChemicalFeatures/FeatureParser.h
@@ -27,7 +27,8 @@ class RDKIT_MOLCHEMICALFEATURES_EXPORT FeatureFileParseException
       : d_lineNo(lineNo), d_line(line), d_msg(msg){};
   unsigned int lineNo() const { return d_lineNo; };
   std::string line() const { return d_line; };
-  std::string message() const { return d_msg; };
+  const char *what() const noexcept override { return d_msg.c_str(); };
+  std::string message() const noexcept { return d_msg; };
   ~FeatureFileParseException() noexcept {};
 
  private:

--- a/Code/GraphMol/MolPickler.h
+++ b/Code/GraphMol/MolPickler.h
@@ -37,7 +37,8 @@ class RDKIT_GRAPHMOL_EXPORT MolPicklerException : public std::exception {
  public:
   MolPicklerException(const char *msg) : _msg(msg){};
   MolPicklerException(const std::string msg) : _msg(msg){};
-  const char *message() const { return _msg.c_str(); };
+  const char *what() const noexcept override { return _msg.c_str(); };
+  const char *message() const noexcept { return what(); };
   ~MolPicklerException() noexcept {};
 
  private:

--- a/Code/GraphMol/MolStandardize/Validate.h
+++ b/Code/GraphMol/MolStandardize/Validate.h
@@ -39,7 +39,8 @@ class RDKIT_MOLSTANDARDIZE_EXPORT ValidationErrorInfo : public std::exception {
   ValidationErrorInfo(const std::string &msg) : d_msg(msg) {
     BOOST_LOG(rdInfoLog) << d_msg << std::endl;
   };
-  const char *message() const { return d_msg.c_str(); };
+  const char *what() const noexcept override { return d_msg.c_str(); };
+  const char *message() const noexcept { return what(); };
   ~ValidationErrorInfo() noexcept {};
 
  private:

--- a/Code/GraphMol/MolStandardize/testValidate.cpp
+++ b/Code/GraphMol/MolStandardize/testValidate.cpp
@@ -241,7 +241,6 @@ void testAllowedAtomsValidation() {
   vector<ValidationErrorInfo> errout1 = vm.validate(*m1, true);
   for (auto &query : errout1) {
     std::string msg = query.message();
-    std::cout << msg << std::endl;
     TEST_ASSERT(
         msg ==
         "INFO: [AllowedAtomsValidation] Atom F is not in allowedAtoms list");
@@ -271,7 +270,6 @@ void testDisallowedAtomsValidation() {
   vector<ValidationErrorInfo> errout1 = vm.validate(*m1, true);
   for (auto &query : errout1) {
     std::string msg = query.message();
-    std::cout << msg << std::endl;
     TEST_ASSERT(
         msg ==
         "INFO: [DisallowedAtomsValidation] Atom F is in disallowedAtoms list");
@@ -293,7 +291,6 @@ void testFragment() {
   vector<ValidationErrorInfo> errout1 = vm.validate(*m1, true);
   for (auto &query : errout1) {
     std::string msg = query.message();
-    std::cout << msg << std::endl;
     TEST_ASSERT(msg ==
                 "INFO: [FragmentValidation] 1,2-dichloroethane is present");
   }
@@ -303,7 +300,6 @@ void testFragment() {
   vector<ValidationErrorInfo> errout2 = vm.validate(*m2, true);
   for (auto &query : errout2) {
     std::string msg = query.message();
-    std::cout << msg << std::endl;
     TEST_ASSERT(msg ==
                 "INFO: [FragmentValidation] 1,2-dimethoxyethane is present");
   }
@@ -318,15 +314,14 @@ void testValidateSmiles() {
   try {
     vector<ValidationErrorInfo> errout1 = validateSmiles("3478q439g98h");
   } catch (const ValueErrorException &e) {
-    std::cout << e.message() << std::endl;
-    TEST_ASSERT(e.message() ==
+    std::string msg = e.message();
+    TEST_ASSERT(msg ==
                 "SMILES Parse Error: syntax error for input: 3478q439g98h")
   };
 
   vector<ValidationErrorInfo> errout2 = validateSmiles("");
   for (auto &query : errout2) {
     std::string msg = query.message();
-    std::cout << msg << std::endl;
     TEST_ASSERT(msg == "ERROR: [NoAtomValidation] Molecule has no atoms");
   }
 

--- a/Code/GraphMol/SLNParse/SLNParse.h
+++ b/Code/GraphMol/SLNParse/SLNParse.h
@@ -58,7 +58,8 @@ class RDKIT_SLNPARSE_EXPORT SLNParseException : public std::exception {
  public:
   SLNParseException(const char *msg) : _msg(msg){};
   SLNParseException(const std::string &msg) : _msg(msg){};
-  const char *message() const { return _msg.c_str(); };
+  const char *what() const noexcept override { return _msg.c_str(); };
+  const char *message() const noexcept { return what(); };
   ~SLNParseException() noexcept {};
 
  private:

--- a/Code/GraphMol/SanitException.h
+++ b/Code/GraphMol/SanitException.h
@@ -30,7 +30,8 @@ class RDKIT_GRAPHMOL_EXPORT MolSanitizeException : public std::exception {
   MolSanitizeException(const std::string &msg) : d_msg(msg){};
   MolSanitizeException(const MolSanitizeException &other)
       : d_msg(other.d_msg){};
-  virtual const char *message() const { return d_msg.c_str(); };
+  virtual const char *what() const noexcept override { return d_msg.c_str(); };
+  virtual const char *message() const noexcept { return what(); };
   virtual ~MolSanitizeException() noexcept {};
   virtual MolSanitizeException *copy() const {
     return new MolSanitizeException(*this);

--- a/Code/GraphMol/SmilesParse/SmilesParse.h
+++ b/Code/GraphMol/SmilesParse/SmilesParse.h
@@ -102,7 +102,8 @@ class RDKIT_SMILESPARSE_EXPORT SmilesParseException : public std::exception {
  public:
   SmilesParseException(const char *msg) : _msg(msg){};
   SmilesParseException(const std::string msg) : _msg(msg){};
-  const char *message() const { return _msg.c_str(); };
+  const char *what() const noexcept override { return _msg.c_str(); };
+  const char *message() const noexcept { return what(); };
   ~SmilesParseException() noexcept {};
 
  private:

--- a/Code/JavaWrappers/GenericRDKitException.h
+++ b/Code/JavaWrappers/GenericRDKitException.h
@@ -19,7 +19,7 @@ class GenericRDKitException : public std::exception {
   GenericRDKitException(const std::string &i) : _value(i){};
   GenericRDKitException(const char *msg) : _value(msg){};
   const char *what() const noexcept override { return _value.c_str(); };
-  std::string message() const noexcept { return _value; };
+  const char *message() const noexcept { return what(); };
   ~GenericRDKitException() noexcept {};
 
  private:

--- a/Code/JavaWrappers/GenericRDKitException.h
+++ b/Code/JavaWrappers/GenericRDKitException.h
@@ -18,7 +18,8 @@ class GenericRDKitException : public std::exception {
  public:
   GenericRDKitException(const std::string &i) : _value(i){};
   GenericRDKitException(const char *msg) : _value(msg){};
-  std::string message() const { return _value; };
+  const char *what() const noexcept override { return _value.c_str(); };
+  std::string message() const noexcept { return _value; };
   ~GenericRDKitException() noexcept {};
 
  private:

--- a/Code/PgSQL/rdkit/adapter.cpp
+++ b/Code/PgSQL/rdkit/adapter.cpp
@@ -646,7 +646,7 @@ extern "C" CROMol MolAdjustQueryProperties(CROMol i, const char *params) {
     try {
       MolOps::parseAdjustQueryParametersFromJSON(p, pstring);
     } catch (const ValueErrorException &e) {
-      elog(ERROR, e.message().c_str());
+      elog(ERROR, e.message());
     } catch (...) {
       elog(WARNING,
            "adjustQueryProperties: Invalid argument \'params\' ignored");

--- a/Code/PgSQL/rdkit/adapter.cpp
+++ b/Code/PgSQL/rdkit/adapter.cpp
@@ -950,7 +950,7 @@ extern "C" double calcSparseTanimotoSml(CSfp a, CSfp b) {
   try {
     res = TanimotoSimilarity(*(SparseFP *)a, *(SparseFP *)b);
   } catch (ValueErrorException &e) {
-    elog(ERROR, "TanimotoSimilarity: %s", e.message().c_str());
+    elog(ERROR, "TanimotoSimilarity: %s", e.message());
   } catch (...) {
     elog(ERROR, "calcSparseTanimotoSml: Unknown exception");
   }
@@ -968,7 +968,7 @@ extern "C" double calcSparseDiceSml(CSfp a, CSfp b) {
   try {
     res = DiceSimilarity(*(SparseFP *)a, *(SparseFP *)b);
   } catch (ValueErrorException &e) {
-    elog(ERROR, "DiceSimilarity: %s", e.message().c_str());
+    elog(ERROR, "DiceSimilarity: %s", e.message());
   } catch (...) {
     elog(ERROR, "calcSparseDiceSml: Unknown exception");
   }

--- a/Code/RDBoost/Wrap.cpp
+++ b/Code/RDBoost/Wrap.cpp
@@ -29,12 +29,22 @@ void throw_value_error(const std::string err) {
   python::throw_error_already_set();
 }
 
+// A helper function for dealing with errors. Throw a Python KeyError
+void throw_key_error(const std::string key) {
+  PyErr_SetString(PyExc_KeyError, key.c_str());
+  python::throw_error_already_set();
+}
+
 void translate_index_error(IndexErrorException const& e) {
   throw_index_error(e.index());
 }
 
 void translate_value_error(ValueErrorException const& e) {
   throw_value_error(e.message());
+}
+
+void translate_key_error(KeyErrorException const& e) {
+  throw_key_error(e.key());
 }
 
 #ifdef INVARIANT_EXCEPTION_METHOD
@@ -44,9 +54,7 @@ void throw_runtime_error(const std::string err) {
   python::throw_error_already_set();
 }
 
-
-void translate_invariant_error(Invar::Invariant const &e) {
+void translate_invariant_error(Invar::Invariant const& e) {
   throw_runtime_error(e.toUserString());
 }
-#endif                                               
-
+#endif

--- a/Code/RDBoost/Wrap.h
+++ b/Code/RDBoost/Wrap.h
@@ -37,8 +37,11 @@ RDKIT_RDBOOST_EXPORT void throw_index_error(
     int key);  //!< construct and throw an \c IndexError
 RDKIT_RDBOOST_EXPORT void throw_value_error(
     const std::string err);  //!< construct and throw a \c ValueError
+RDKIT_RDBOOST_EXPORT void throw_key_error(
+    const std::string key);  //!< construct and throw a \c KeyError
 RDKIT_RDBOOST_EXPORT void translate_index_error(IndexErrorException const &e);
 RDKIT_RDBOOST_EXPORT void translate_value_error(ValueErrorException const &e);
+RDKIT_RDBOOST_EXPORT void translate_key_error(KeyErrorException const &e);
 
 #ifdef INVARIANT_EXCEPTION_METHOD
 RDKIT_RDBOOST_EXPORT void throw_runtime_error(
@@ -53,11 +56,11 @@ RDKIT_RDBOOST_EXPORT void translate_invariant_error(Invar::Invariant const &e);
 template <typename T>
 void RegisterVectorConverter(const char *name, bool noproxy = false) {
   if (noproxy) {
-    python::class_<std::vector<T>>(name)
-        .def(python::vector_indexing_suite<std::vector<T>, 1>());
+    python::class_<std::vector<T>>(name).def(
+        python::vector_indexing_suite<std::vector<T>, 1>());
   } else {
-    python::class_<std::vector<T>>(name)
-        .def(python::vector_indexing_suite<std::vector<T>>());
+    python::class_<std::vector<T>>(name).def(
+        python::vector_indexing_suite<std::vector<T>>());
   }
 }
 

--- a/Code/RDBoost/Wrap/RDBase.cpp
+++ b/Code/RDBoost/Wrap/RDBase.cpp
@@ -122,6 +122,8 @@ BOOST_PYTHON_MODULE(rdBase) {
       &translate_index_error);
   python::register_exception_translator<ValueErrorException>(
       &translate_value_error);
+  python::register_exception_translator<KeyErrorException>(
+      &translate_key_error);
 
 #if INVARIANT_EXCEPTION_METHOD
   python::register_exception_translator<Invar::Invariant>(

--- a/Code/RDGeneral/BadFileException.h
+++ b/Code/RDGeneral/BadFileException.h
@@ -27,7 +27,8 @@ class BadFileException : public std::runtime_error {
   explicit BadFileException(const std::string &msg)
       : std::runtime_error("BadFileException"), _msg(msg){};
   //! get the error message
-  const char *message() const { return _msg.c_str(); };
+  const char *what() const noexcept override { return _msg.c_str(); };
+  const char *message() const noexcept { return what(); };
   ~BadFileException() noexcept {};
 
  private:

--- a/Code/RDGeneral/Exceptions.h
+++ b/Code/RDGeneral/Exceptions.h
@@ -44,7 +44,7 @@ class ValueErrorException : public std::runtime_error {
   ValueErrorException(const char* msg)
       : std::runtime_error("ValueErrorException"), _value(msg){};
   const char* what() const noexcept override { return _value.c_str(); };
-  std::string message() const noexcept { return _value; };
+  const char* message() const noexcept { return what(); };
   ~ValueErrorException() noexcept {};
 
  private:

--- a/Code/RDGeneral/Exceptions.h
+++ b/Code/RDGeneral/Exceptions.h
@@ -21,6 +21,13 @@ class IndexErrorException : public std::runtime_error {
   IndexErrorException(int i)
       : std::runtime_error("IndexErrorException"), _idx(i){};
   int index() const { return _idx; };
+
+  const char* what() const noexcept override {
+    std::string msg{"Index Error: "};
+    msg.append(std::to_string(_idx));
+    return msg.c_str();
+  };
+
   ~IndexErrorException() noexcept {};
 
  private:
@@ -32,11 +39,12 @@ class IndexErrorException : public std::runtime_error {
 //!
 class ValueErrorException : public std::runtime_error {
  public:
-  ValueErrorException(const std::string &i)
+  ValueErrorException(const std::string& i)
       : std::runtime_error("ValueErrorException"), _value(i){};
-  ValueErrorException(const char *msg)
+  ValueErrorException(const char* msg)
       : std::runtime_error("ValueErrorException"), _value(msg){};
-  std::string message() const { return _value; };
+  const char* what() const noexcept override { return _value.c_str(); };
+  std::string message() const noexcept { return _value; };
   ~ValueErrorException() noexcept {};
 
  private:
@@ -51,6 +59,13 @@ class KeyErrorException : public std::runtime_error {
   KeyErrorException(std::string key)
       : std::runtime_error("KeyErrorException"), _key(key){};
   std::string key() const { return _key; };
+
+  const char* what() const noexcept override {
+    std::string msg{"Key Error: "};
+    msg.append(_key);
+    return msg.c_str();
+  };
+
   ~KeyErrorException() noexcept {};
 
  private:

--- a/Code/RDGeneral/FileParseException.h
+++ b/Code/RDGeneral/FileParseException.h
@@ -25,7 +25,8 @@ class FileParseException : public std::runtime_error {
   explicit FileParseException(const std::string msg)
       : std::runtime_error("FileParseException"), _msg(msg){};
   //! get the error message
-  const char *message() const { return _msg.c_str(); };
+  const char *what() const noexcept override { return _msg.c_str(); };
+  const char *message() const noexcept { return what(); };
   ~FileParseException() noexcept {};
 
  private:

--- a/Code/RDGeneral/Invariant.h
+++ b/Code/RDGeneral/Invariant.h
@@ -68,7 +68,8 @@ class RDKIT_RDGENERAL_EXPORT Invariant : public std::runtime_error {
         line_d(line) {}
   ~Invariant() noexcept {};
 
-  std::string getMessage() const { return mess_d; }
+  const char* what() const noexcept override { return mess_d.c_str(); }
+  std::string getMessage() const noexcept { return mess_d; }
 
   const char* getFile() const { return file_dp; }
 

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,3 +1,12 @@
+# Release_2020.09.1
+(Changes relative to Release_2020.03.1)
+
+## Deprecations
+- To improve API consistency of the exceptions in RDKit with the default ones in
+  the STL, the several `message()` methods and `Invariant::getMessage()` in RDKit's
+  exceptions are from now on deprecated in favor of `what()`. Both `message()` and
+  `Invariant::getMessage()` will be removed in the next release.
+
 # Release_2020.03.1
 (Changes relative to Release_2019.09.1)
 

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,14 +1,11 @@
-# Release_2020.09.1
-(Changes relative to Release_2020.03.1)
+# Release_2020.03.1
+(Changes relative to Release_2019.09.1)
 
 ## Deprecations
 - To improve API consistency of the exceptions in RDKit with the default ones in
   the STL, the several `message()` methods and `Invariant::getMessage()` in RDKit's
   exceptions are from now on deprecated in favor of `what()`. Both `message()` and
   `Invariant::getMessage()` will be removed in the next release.
-
-# Release_2020.03.1
-(Changes relative to Release_2019.09.1)
 
 ## Backwards incompatible changes
 - Searches for equal molecules (i.e. `mol1 @= mol2`) in the PostgreSQL cartridge

--- a/rdkit/Chem/SimpleEnum/Enumerator.py
+++ b/rdkit/Chem/SimpleEnum/Enumerator.py
@@ -114,7 +114,7 @@ def PreprocessReaction(reaction, funcGroupFilename=None, propName='molFileValue'
       nWarn,nError,nReacts,nProds,reactantLabels = PreprocessReaction(rxn)
     File "Enumerator.py", line 105, in PreprocessReaction
       reactantLabels = reaction.AddRecursiveQueriesToReaction(queryDict, propName='molFileValue', getLabels=True)
-  RuntimeError: KeyErrorException
+  KeyError: 'boromicacid'
 
   One unrecognized group type in a comma-separated list makes the whole thing fail:
 
@@ -129,7 +129,7 @@ def PreprocessReaction(reaction, funcGroupFilename=None, propName='molFileValue'
       nWarn,nError,nReacts,nProds,reactantLabels = PreprocessReaction(rxn)
     File "Enumerator.py", line 105, in PreprocessReaction
       reactantLabels = reaction.AddRecursiveQueriesToReaction(queryDict, propName='molFileValue', getLabels=True)
-  RuntimeError: KeyErrorException
+  KeyError: 'carboxylicacid,acidchlroide'
   >>> testFile = os.path.join(RDConfig.RDCodeDir,'Chem','SimpleEnum','test_data','bad_value3.rxn')
   >>> rxn = AllChem.ReactionFromRxnFile(testFile)
   >>> rxn.Initialize()
@@ -141,7 +141,7 @@ def PreprocessReaction(reaction, funcGroupFilename=None, propName='molFileValue'
       nWarn,nError,nReacts,nProds,reactantLabels = PreprocessReaction(rxn)
     File "Enumerator.py", line 105, in PreprocessReaction
       reactantLabels = reaction.AddRecursiveQueriesToReaction(queryDict, propName='molFileValue', getLabels=True)
-  RuntimeError: KeyErrorException
+  KeyError: 'carboxyliccaid,acidchloride'
   >>> rxn = rdChemReactions.ChemicalReaction()
   >>> rxn.Initialize()
   >>> nWarn,nError,nReacts,nProds,reactantLabels = PreprocessReaction(rxn)


### PR DESCRIPTION
I added an override for `what()` in all the exceptions I found (Addresses #2920). I made `message()` to be an alias of `what()` in most of them, but some returned a `std::string`, so I left them unchanged to avoid building another string from `what()`'s `const char*` return value.

I ran the tests and noticed adding a `what()` method for the `KeyErrorException` broke some doctests and one unit test, so I added a translation to the wrapper, so that it raises a Python `KeyError` exception instead of a `RuntimeError`, with a proper error string mentioned the bad keys.

I did not update the calls to `message()` in the unit tests, though.