### PR TITLE
Fixes #2936

### DIFF
--- a/Code/MinimalLib/minilib.cpp
+++ b/Code/MinimalLib/minilib.cpp
@@ -273,12 +273,19 @@ std::string JSMol::get_stereo_tags() const {
 
   bool cleanIt = true;
   bool force = true;
-  MolOps::assignStereochemistry(*d_mol, cleanIt, force);
+  bool flagPossibleStereocenters = true;
+  MolOps::assignStereochemistry(*d_mol, cleanIt, force,
+                                flagPossibleStereocenters);
 
   rj::Value rjAtoms(rj::kArrayType);
   for (const auto atom : d_mol->atoms()) {
     std::string cip;
-    if (atom->getPropIfPresent(common_properties::_CIPCode, cip)) {
+    if (!atom->getPropIfPresent(common_properties::_CIPCode, cip)) {
+      if (atom->hasProp(common_properties::_ChiralityPossible)) {
+        cip = "?";
+      }
+    }
+    if (!cip.empty()) {
       cip = "(" + cip + ")";
       rj::Value entry(rj::kArrayType);
       entry.PushBack(atom->getIdx(), doc.GetAllocator());

--- a/Code/MinimalLib/minilib.cpp
+++ b/Code/MinimalLib/minilib.cpp
@@ -128,25 +128,31 @@ std::string JSMol::get_svg_with_highlights(const std::string &details) const {
     atomIds.push_back(static_cast<unsigned int>(molval.GetInt()));
   }
   std::vector<unsigned int> bondIds;
-  if (doc.HasMember("bonds") && !doc["bonds"].IsArray()) {
-    return "JSON contain 'bonds' field, but it is not an array";
-  }
-  for (const auto &molval : doc["bonds"].GetArray()) {
-    if (!molval.IsInt()) return ("Bond IDs should be integers");
-    bondIds.push_back(static_cast<unsigned int>(molval.GetInt()));
+  if (doc.HasMember("bonds")) {
+    if (!doc["bonds"].IsArray()) {
+      return "JSON contain 'bonds' field, but it is not an array";
+    }
+    for (const auto &molval : doc["bonds"].GetArray()) {
+      if (!molval.IsInt()) return ("Bond IDs should be integers");
+      bondIds.push_back(static_cast<unsigned int>(molval.GetInt()));
+    }
   }
 
   unsigned int w = d_defaultWidth;
-  if (doc.HasMember("width") && !doc["width"].IsUint()) {
-    return "JSON contains 'width' field, but it is not an unsigned int";
+  if (doc.HasMember("width")) {
+    if (!doc["width"].IsUint()) {
+      return "JSON contains 'width' field, but it is not an unsigned int";
+    }
+    w = doc["width"].GetUint();
   }
-  w = doc["width"].GetUint();
 
   unsigned int h = d_defaultHeight;
-  if (doc.HasMember("height") && !doc["height"].IsUint()) {
-    return "JSON contains 'height' field, but it is not an unsigned int";
+  if (doc.HasMember("height")) {
+    if (!doc["height"].IsUint()) {
+      return "JSON contains 'height' field, but it is not an unsigned int";
+    }
+    h = doc["height"].GetUint();
   }
-  h = doc["height"].GetUint();
 
   return svg_(*d_mol, w, h, &atomIds, &bondIds);
 }

--- a/Code/MinimalLib/tests/tests.js
+++ b/Code/MinimalLib/tests/tests.js
@@ -56,12 +56,19 @@ function test_basics(){
     assert(svg2.search("svg")>0);
     assert(svg.search("#FF7F7F")<0);
     assert(svg2.search("#FF7F7F")>0);
+}
 
+function test_sketcher_services(){
+    var mol = Module.get_mol("C[C@](F)(Cl)/C=C/C(F)Br");
+    assert.equal(mol.is_valid(),1);
+    var tags = mol.get_stereo_tags();
+    assert.equal(tags,'{"CIP_atoms":[[1,"(S)"],[6,"(?)"]],"CIP_bonds":[[4,5,"(E)"]]}');
 }
 
 Module.onRuntimeInitialized = () => {
     console.log(Module.version());
     test_basics();
+    test_sketcher_services();
 };
 
 


### PR DESCRIPTION
A couple small fixes to the JS wrappers:
- return potential stereocenters as well as specified ones (was #2936)
- fix the logic for handling the JSON for highlighting substructures (it was failing unless all optional values were provided)