### PR TITLE
Avoid data race warning in SmilesParse.cpp

### DIFF
--- a/Code/GraphMol/SmilesParse/SmilesParse.cpp
+++ b/Code/GraphMol/SmilesParse/SmilesParse.cpp
@@ -347,9 +347,10 @@ Bond *SmilesToBond(const std::string &smiles) {
 
 RWMol *SmilesToMol(const std::string &smiles,
                    const SmilesParserParams &params) {
-  // Calling SmilesToMol in a multithreaded context is generally safe *unless* the value of debugParse is different for
-  // different threads. The if statement below avoids a TSAN warning in the case where multiple threads all use the
-  // same value for debugParse.
+  // Calling SmilesToMol in a multithreaded context is generally safe *unless*
+  // the value of debugParse is different for different threads. The if
+  // statement below avoids a TSAN warning in the case where multiple threads
+  // all use the same value for debugParse.
   if (yysmiles_debug != params.debugParse) {
     yysmiles_debug = params.debugParse;
   }
@@ -417,9 +418,10 @@ Bond *SmartsToBond(const std::string &smiles) {
 
 RWMol *SmartsToMol(const std::string &smarts, int debugParse, bool mergeHs,
                    std::map<std::string, std::string> *replacements) {
-  // Calling SmartsToMol in a multithreaded context is generally safe *unless* the value of debugParse is different for
-  // different threads. The if statement below avoids a TSAN warning in the case where multiple threads all use the
-  // same value for debugParse.
+  // Calling SmartsToMol in a multithreaded context is generally safe *unless*
+  // the value of debugParse is different for different threads. The if
+  // statement below avoids a TSAN warning in the case where multiple threads
+  // all use the same value for debugParse.
   if (yysmarts_debug != debugParse) {
     yysmarts_debug = debugParse;
   }

--- a/Code/GraphMol/SmilesParse/SmilesParse.cpp
+++ b/Code/GraphMol/SmilesParse/SmilesParse.cpp
@@ -347,7 +347,10 @@ Bond *SmilesToBond(const std::string &smiles) {
 
 RWMol *SmilesToMol(const std::string &smiles,
                    const SmilesParserParams &params) {
-  yysmiles_debug = params.debugParse;
+  // Avoid data race by checking before setting yysmiles_debug.
+  if (yysmiles_debug != params.debugParse) {
+    yysmiles_debug = params.debugParse;
+  }
 
   std::string lsmiles, name, cxPart;
   preprocessSmiles(smiles, params, lsmiles, name, cxPart);
@@ -412,7 +415,10 @@ Bond *SmartsToBond(const std::string &smiles) {
 
 RWMol *SmartsToMol(const std::string &smarts, int debugParse, bool mergeHs,
                    std::map<std::string, std::string> *replacements) {
-  yysmarts_debug = debugParse;
+  // Avoid data race by checking before setting yysmarts_debug.
+  if (yysmarts_debug != debugParse) {
+    yysmarts_debug = debugParse;
+  }
   // boost::trim_if(sma,boost::is_any_of(" \t\r\n"));
   std::string sma;
   RWMol *res;

--- a/Code/GraphMol/SmilesParse/SmilesParse.cpp
+++ b/Code/GraphMol/SmilesParse/SmilesParse.cpp
@@ -347,7 +347,9 @@ Bond *SmilesToBond(const std::string &smiles) {
 
 RWMol *SmilesToMol(const std::string &smiles,
                    const SmilesParserParams &params) {
-  // Avoid data race by checking before setting yysmiles_debug.
+  // Calling SmilesToMol in a multithreaded context is generally safe *unless* the value of debugParse is different for
+  // different threads. The if statement below avoids a TSAN warning in the case where multiple threads all use the
+  // same value for debugParse.
   if (yysmiles_debug != params.debugParse) {
     yysmiles_debug = params.debugParse;
   }
@@ -415,7 +417,9 @@ Bond *SmartsToBond(const std::string &smiles) {
 
 RWMol *SmartsToMol(const std::string &smarts, int debugParse, bool mergeHs,
                    std::map<std::string, std::string> *replacements) {
-  // Avoid data race by checking before setting yysmarts_debug.
+  // Calling SmartsToMol in a multithreaded context is generally safe *unless* the value of debugParse is different for
+  // different threads. The if statement below avoids a TSAN warning in the case where multiple threads all use the
+  // same value for debugParse.
   if (yysmarts_debug != debugParse) {
     yysmarts_debug = debugParse;
   }


### PR DESCRIPTION
This PR avoids a data race identified by TSan in SmilesParse.cpp. I'm not sure it's the best solution---the race could still exist if multiple callers of `{Smarts,Smiles}ToMol` use different settings for `debugParse`---but it avoids the issue in the usual case of repeated calls to `{Smarts,Smiles}ToMol` with the same params.
