### PR TITLE
Fix build without boost serialization.

### DIFF
--- a/Code/GraphMol/ScaffoldNetwork/Wrap/CMakeLists.txt
+++ b/Code/GraphMol/ScaffoldNetwork/Wrap/CMakeLists.txt
@@ -7,3 +7,6 @@ GraphMol RDGeometryLib RDGeneral DataStructs
 RDBoost) 
 
 add_pytest(pyScaffoldNetwork ${CMAKE_CURRENT_SOURCE_DIR}/testScaffoldNetwork.py)
+if (RDK_USE_BOOST_SERIALIZATION)
+    add_pytest(pyScaffoldNetwork ${CMAKE_CURRENT_SOURCE_DIR}/testPickleScaffoldNetwork.py)
+endif()

--- a/Code/GraphMol/ScaffoldNetwork/Wrap/CMakeLists.txt
+++ b/Code/GraphMol/ScaffoldNetwork/Wrap/CMakeLists.txt
@@ -8,5 +8,5 @@ RDBoost)
 
 add_pytest(pyScaffoldNetwork ${CMAKE_CURRENT_SOURCE_DIR}/testScaffoldNetwork.py)
 if (RDK_USE_BOOST_SERIALIZATION)
-    add_pytest(pyScaffoldNetwork ${CMAKE_CURRENT_SOURCE_DIR}/testPickleScaffoldNetwork.py)
+    add_pytest(pyScaffoldNetworkPickling ${CMAKE_CURRENT_SOURCE_DIR}/testPickleScaffoldNetwork.py)
 endif()

--- a/Code/GraphMol/ScaffoldNetwork/Wrap/rdScaffoldNetwork.cpp
+++ b/Code/GraphMol/ScaffoldNetwork/Wrap/rdScaffoldNetwork.cpp
@@ -144,9 +144,11 @@ BOOST_PYTHON_MODULE(rdScaffoldNetwork) {
 
   python::class_<ScaffoldNetwork::ScaffoldNetwork>(
       "ScaffoldNetwork", "A scaffold network", python::init<>())
+#ifdef RDK_USE_BOOST_SERIALIZATION
       .def(python::init<const std::string &>())
       // enable pickle support
       .def_pickle(scaffoldnetwork_pickle_suite())
+#endif
       .def_readonly("nodes", &ScaffoldNetwork::ScaffoldNetwork::nodes,
                     "the sequence of SMILES defining the nodes")
       .def_readonly("counts", &ScaffoldNetwork::ScaffoldNetwork::counts,

--- a/Code/GraphMol/ScaffoldNetwork/Wrap/testPickleScaffoldNetwork.py
+++ b/Code/GraphMol/ScaffoldNetwork/Wrap/testPickleScaffoldNetwork.py
@@ -1,0 +1,46 @@
+#
+# Copyright (C) 2019 Greg Landrum and T5 Informatics GmbH
+#  All Rights Reserved
+#
+#  This file is part of the RDKit.
+#  The contents are covered by the terms of the BSD license
+#  which is included in the file license.txt, found at the root
+#  of the RDKit source tree.
+#
+
+import pickle
+import unittest
+
+from rdkit import Chem
+from rdkit import RDConfig
+from rdkit import rdBase
+from rdkit.Chem.Scaffolds import rdScaffoldNetwork
+
+rdBase.DisableLog("rdApp.info")
+
+
+class TestScaffoldNetwork(unittest.TestCase):
+  """
+  RDKit must have been built with Boost serialization support
+  for this test to pass.
+  """
+
+  def test1Pickle(self):
+    smis = ["c1ccccc1CC1NC(=O)CCC1", "c1cccnc1CC1NC(=O)CCC1"]
+    ms = [Chem.MolFromSmiles(x) for x in smis]
+    params = rdScaffoldNetwork.ScaffoldNetworkParams()
+    params.includeScaffoldsWithoutAttachments = False
+    net = rdScaffoldNetwork.CreateScaffoldNetwork(ms, params)
+    self.assertEqual(len(net.nodes), 7)
+    self.assertEqual(len(net.edges), 7)
+
+    pkl = pickle.dumps(net)
+    net2 = pickle.loads(pkl)
+    self.assertEqual(len(net2.nodes), 7)
+    self.assertEqual(len(net2.edges), 7)
+    self.assertEqual(list(net2.nodes), list(net.nodes))
+    self.assertEqual([str(x) for x in net2.edges], [str(x) for x in net.edges])
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/Code/GraphMol/ScaffoldNetwork/Wrap/testScaffoldNetwork.py
+++ b/Code/GraphMol/ScaffoldNetwork/Wrap/testScaffoldNetwork.py
@@ -8,16 +8,18 @@
 #  of the RDKit source tree.
 #
 
+import pickle
 import unittest
+
 from rdkit import Chem
-from rdkit.Chem.Scaffolds import rdScaffoldNetwork
 from rdkit import RDConfig
 from rdkit import rdBase
-import pickle
+from rdkit.Chem.Scaffolds import rdScaffoldNetwork
+
 rdBase.DisableLog("rdApp.info")
 
 
-class TestCase(unittest.TestCase):
+class TestScaffoldNetwork(unittest.TestCase):
 
   def setUp(self):
     pass
@@ -31,8 +33,8 @@ class TestCase(unittest.TestCase):
     self.assertEqual(len(net.nodes), 12)
     self.assertEqual(len(net.edges), 12)
     self.assertEqual(len(net.counts), len(net.nodes))
-    self.assertEqual(len([x for x in net.edges if x.type == rdScaffoldNetwork.EdgeType.Fragment]),
-                     4)
+    self.assertEqual(
+      len([x for x in net.edges if x.type == rdScaffoldNetwork.EdgeType.Fragment]), 4)
     self.assertEqual(len([x for x in net.edges if x.type == rdScaffoldNetwork.EdgeType.Generic]), 3)
     self.assertEqual(
       len([x for x in net.edges if x.type == rdScaffoldNetwork.EdgeType.RemoveAttachment]), 5)
@@ -41,8 +43,8 @@ class TestCase(unittest.TestCase):
     rdScaffoldNetwork.UpdateScaffoldNetwork(ms, net, params)
     self.assertEqual(len(net.nodes), 12)
     self.assertEqual(len(net.edges), 12)
-    self.assertEqual(len([x for x in net.edges if x.type == rdScaffoldNetwork.EdgeType.Fragment]),
-                     4)
+    self.assertEqual(
+      len([x for x in net.edges if x.type == rdScaffoldNetwork.EdgeType.Fragment]), 4)
     self.assertEqual(len([x for x in net.edges if x.type == rdScaffoldNetwork.EdgeType.Generic]), 3)
     self.assertEqual(
       len([x for x in net.edges if x.type == rdScaffoldNetwork.EdgeType.RemoveAttachment]), 5)
@@ -55,8 +57,8 @@ class TestCase(unittest.TestCase):
     net = rdScaffoldNetwork.CreateScaffoldNetwork(ms, params)
     self.assertEqual(len(net.nodes), 7)
     self.assertEqual(len(net.edges), 7)
-    self.assertEqual(len([x for x in net.edges if x.type == rdScaffoldNetwork.EdgeType.Fragment]),
-                     4)
+    self.assertEqual(
+      len([x for x in net.edges if x.type == rdScaffoldNetwork.EdgeType.Fragment]), 4)
     self.assertEqual(len([x for x in net.edges if x.type == rdScaffoldNetwork.EdgeType.Generic]), 3)
 
   def test3Update(self):
@@ -73,8 +75,8 @@ class TestCase(unittest.TestCase):
     self.assertEqual(len(net.nodes), 12)
     self.assertEqual(len(net.edges), 12)
     self.assertEqual(len(net.counts), len(net.nodes))
-    self.assertEqual(len([x for x in net.edges if x.type == rdScaffoldNetwork.EdgeType.Fragment]),
-                     4)
+    self.assertEqual(
+      len([x for x in net.edges if x.type == rdScaffoldNetwork.EdgeType.Fragment]), 4)
     self.assertEqual(len([x for x in net.edges if x.type == rdScaffoldNetwork.EdgeType.Generic]), 3)
     self.assertEqual(
       len([x for x in net.edges if x.type == rdScaffoldNetwork.EdgeType.RemoveAttachment]), 5)
@@ -83,8 +85,8 @@ class TestCase(unittest.TestCase):
     rdScaffoldNetwork.UpdateScaffoldNetwork(ms[1:2], net, params)
     self.assertEqual(len(net.nodes), 12)
     self.assertEqual(len(net.edges), 12)
-    self.assertEqual(len([x for x in net.edges if x.type == rdScaffoldNetwork.EdgeType.Fragment]),
-                     4)
+    self.assertEqual(
+      len([x for x in net.edges if x.type == rdScaffoldNetwork.EdgeType.Fragment]), 4)
     self.assertEqual(len([x for x in net.edges if x.type == rdScaffoldNetwork.EdgeType.Generic]), 3)
     self.assertEqual(
       len([x for x in net.edges if x.type == rdScaffoldNetwork.EdgeType.RemoveAttachment]), 5)
@@ -99,23 +101,7 @@ class TestCase(unittest.TestCase):
     self.assertEqual(len(net.edges), 8)
     self.assertEqual(str(net.edges[0]), "NetworkEdge( 0->1, type:Fragment )")
 
-  def test5Pickle(self):
-    smis = ["c1ccccc1CC1NC(=O)CCC1", "c1cccnc1CC1NC(=O)CCC1"]
-    ms = [Chem.MolFromSmiles(x) for x in smis]
-    params = rdScaffoldNetwork.ScaffoldNetworkParams()
-    params.includeScaffoldsWithoutAttachments = False
-    net = rdScaffoldNetwork.CreateScaffoldNetwork(ms, params)
-    self.assertEqual(len(net.nodes), 7)
-    self.assertEqual(len(net.edges), 7)
-
-    pkl = pickle.dumps(net)
-    net2 = pickle.loads(pkl)
-    self.assertEqual(len(net2.nodes), 7)
-    self.assertEqual(len(net2.edges), 7)
-    self.assertEqual(list(net2.nodes), list(net.nodes))
-    self.assertEqual([str(x) for x in net2.edges], [str(x) for x in net.edges])
-
-  def test6FragmentationReactions(self):
+  def test5FragmentationReactions(self):
     smis = ["c1c(CC2CC2)cc(NC2CC2)cc1OC1CC1"]
     ms = [Chem.MolFromSmiles(x) for x in smis]
     params = rdScaffoldNetwork.ScaffoldNetworkParams(


### PR DESCRIPTION
The python wrapping of ScaffoldNetworks fails to build when Boost serialization is not available. The reason is that, when serialization is not available, the string constructor for `ScaffoldNetwork` isn't available either, but it is still specified in the python wrapper.

This patch removes the pickling capability from `ScaffoldNetwork` when boost serialization is disabled. I also split off the pickling test to a separate test file that does not get run when serialization is turned off (else, it will fail with a message saying serialization is not available for that class). I also (accidentally) yapf-formatted the original test file.