### PR TITLE
Enable larger ring matches in SMARTS expressions

### DIFF
--- a/Code/GraphMol/QueryOps.cpp
+++ b/Code/GraphMol/QueryOps.cpp
@@ -87,6 +87,7 @@ ATOM_EQUALS_QUERY *makeAtomInRingOfSizeQuery(int tgt) {
   res->setDescription("AtomRingSize");
   return res;
 }
+
 BOND_EQUALS_QUERY *makeBondInRingOfSizeQuery(int tgt) {
   RANGE_CHECK(3, tgt, 20);
   auto *res = new BOND_EQUALS_QUERY;
@@ -152,7 +153,6 @@ BOND_EQUALS_QUERY *makeBondInRingOfSizeQuery(int tgt) {
 }
 
 ATOM_EQUALS_QUERY *makeAtomMinRingSizeQuery(int tgt) {
-  RANGE_CHECK(3, tgt, 20);
   auto *res = new ATOM_EQUALS_QUERY;
   res->setVal(tgt);
   res->setDataFunc(queryAtomMinRingSize);
@@ -160,7 +160,6 @@ ATOM_EQUALS_QUERY *makeAtomMinRingSizeQuery(int tgt) {
   return res;
 }
 BOND_EQUALS_QUERY *makeBondMinRingSizeQuery(int tgt) {
-  RANGE_CHECK(3, tgt, 20);
   auto *res = new BOND_EQUALS_QUERY;
   res->setVal(tgt);
   res->setDataFunc(queryBondMinRingSize);

--- a/Code/GraphMol/SmilesParse/catch_tests.cpp
+++ b/Code/GraphMol/SmilesParse/catch_tests.cpp
@@ -613,3 +613,12 @@ TEST_CASE(
     REQUIRE(q2);
   }
 }
+
+TEST_CASE("large rings", "[smarts]") {
+  auto query = "[r24]"_smarts;
+  auto m_r24 = "C1CCCCCCCCCCCCCCCCCCCCCCC1"_smiles;
+  auto m_r23 = "C1CCCCCCCCCCCCCCCCCCCCCC1"_smiles;
+
+  CHECK(SubstructMatch(*m_r23, *query).empty());
+  CHECK(SubstructMatch(*m_r24, *query).size() == 24);
+}

--- a/Docs/Book/RDKit_Book.rst
+++ b/Docs/Book/RDKit_Book.rst
@@ -359,7 +359,7 @@ A          "aliphatic atom"
 D          "explicit degree"                          1                Y
 h          "number of implicit hs"                    >0               Y
 H          "total number of Hs"                       1
-r          "in SSSR ring of size"                     >0               Y
+r          "size of smallest SSSR ring"               >0               Y
 R          "number of SSSR rings"                     >0               Y
 v          "total valence"                            1                Y
 x          "number of ring bonds"                     >0               Y
@@ -367,7 +367,7 @@ X          "total degree"                             1                Y
 z          "number of heteroatom neighbors"           >0               Y       extension
 Z          "number of aliphatic heteroatom neighbors" >0               Y       extension
 \*         "any atom"
-\+         "positive charge"                          1                Y 
+\+         "positive charge"                          1                Y
 ++         "+2 charge"
 \-         "negative charge"                          1                Y
 \--        "-2 charge"


### PR DESCRIPTION
Although these are probably nonsense, I've seen some pretty
big [r#] expressions in SMARTS expressions. In particular, for
SMARTS generated for toolkits that don't have the range
extension, people do this to mean "in rings bigger than 6" or
whatever:

    [r7,r8,r9,r10,r11,r12,r13,r14,r15,r16,r17,r18,r19,r20,r21,...]

stopping at some point. Usually 17 or 18 (a heme is 16), but I've seen 24. Bumping to 40, but I don't see a strong reason not to eliminate the upper bound. Unless we want it to match the maximum size in `makeAtomInRingOfSizeQuery()`?

One funny note is that even before this, the SMARTS expression `[r{17-400}]` was allowed.
