### PR TITLE
Fix atom highlighting in notebook PNGs

### DIFF
--- a/rdkit/Chem/Draw/__init__.py
+++ b/rdkit/Chem/Draw/__init__.py
@@ -442,8 +442,12 @@ def _moltoimg(mol, sz, highlights, legend, returnPNG=False, drawOptions=None, **
     if 'highlightColor' in kwargs:
       d2d.drawOptions().setHighlightColor(kwargs['highlightColor'])
 
-    d2d.DrawMolecule(mc, legend=legend, highlightAtoms=highlights, 
-                     highlightBonds = kwargs.get('highlightBonds',[]))
+    bondHighlights = kwargs.get('highlightBonds',None)
+    if bondHighlights is not None:
+      d2d.DrawMolecule(mc, legend=legend, highlightAtoms=highlights, 
+                      highlightBonds=bondHighlights)
+    else:
+      d2d.DrawMolecule(mc, legend=legend, highlightAtoms=highlights)
     d2d.FinishDrawing()
     if returnPNG:
       img = d2d.GetDrawingText()
@@ -468,7 +472,12 @@ def _moltoSVG(mol, sz, highlights, legend, kekulize, drawOptions=None, **kwargs)
   if drawOptions is not None:
     d2d.SetDrawOptions(drawOptions)
 
-  d2d.DrawMolecule(mc, legend=legend, highlightAtoms=highlights)
+  bondHighlights = kwargs.get('highlightBonds',None)
+  if bondHighlights is not None:
+    d2d.DrawMolecule(mc, legend=legend, highlightAtoms=highlights, 
+                    highlightBonds=bondHighlights)
+  else:
+    d2d.DrawMolecule(mc, legend=legend, highlightAtoms=highlights)
   d2d.FinishDrawing()
   svg = d2d.GetDrawingText()
   return svg


### PR DESCRIPTION
Also allows bond highlighting in notebook SVGs

The code to allow `_moltoimg()` to display bond highlights was misbehaving when no bond highlights were provided. The default to an empty bond highlight list leads to a different C++ function being called which disables continuous highlights.
This fix uses different overloads for the cases where bond highlights are/are not provided.

I also added the same logic to `_moltoSVG()`

Unfortunately the testing of this cannot reasonably be automated - comparing PNGs to each other doesn't make much sense.