### PR TITLE
Add support for the rest of the v3000 atom properties

### DIFF
--- a/Code/GraphMol/FileParsers/FileParsers.h
+++ b/Code/GraphMol/FileParsers/FileParsers.h
@@ -115,6 +115,20 @@ RDKIT_FILEPARSERS_EXPORT std::string MolToMolBlock(const ROMol &mol,
                                                    int confId = -1,
                                                    bool kekulize = true,
                                                    bool forceV3000 = false);
+
+// \brief generates an MDL v3000 mol block for a molecule
+/*!
+ *   \param mol           - the molecule in question
+ *   \param includeStereo - toggles inclusion of stereochemistry information
+ *   \param confId        - selects the conformer to be used
+ *   \param kekulize      - triggers kekulization of the molecule before it is
+ * written
+ */
+inline std::string MolToV3KMolBlock(const ROMol &mol, bool includeStereo = true,
+                                    int confId = -1, bool kekulize = true) {
+  return MolToMolBlock(mol, includeStereo, confId, kekulize, true);
+}
+
 // \brief Writes a molecule to an MDL mol file
 /*!
  *   \param mol           - the molecule in question
@@ -130,6 +144,21 @@ RDKIT_FILEPARSERS_EXPORT std::string MolToMolBlock(const ROMol &mol,
 RDKIT_FILEPARSERS_EXPORT void MolToMolFile(
     const ROMol &mol, const std::string &fName, bool includeStereo = true,
     int confId = -1, bool kekulize = true, bool forceV3000 = false);
+
+// \brief Writes a molecule to an MDL V3000 mol file
+/*!
+ *   \param mol           - the molecule in question
+ *   \param fName         - the name of the file to use
+ *   \param includeStereo - toggles inclusion of stereochemistry information
+ *   \param confId        - selects the conformer to be used
+ *   \param kekulize      - triggers kekulization of the molecule before it is
+ * written
+ */
+inline void MolToV3KMolFile(const ROMol &mol, const std::string &fName,
+                            bool includeStereo = true, int confId = -1,
+                            bool kekulize = true) {
+  MolToMolFile(mol, fName, includeStereo, confId, kekulize);
+}
 
 RDKIT_FILEPARSERS_EXPORT std::string MolToXYZBlock(const ROMol &mol,
                                                    int confId = -1);

--- a/Code/GraphMol/FileParsers/FileParsers.h
+++ b/Code/GraphMol/FileParsers/FileParsers.h
@@ -157,7 +157,7 @@ RDKIT_FILEPARSERS_EXPORT void MolToMolFile(
 inline void MolToV3KMolFile(const ROMol &mol, const std::string &fName,
                             bool includeStereo = true, int confId = -1,
                             bool kekulize = true) {
-  MolToMolFile(mol, fName, includeStereo, confId, kekulize);
+  MolToMolFile(mol, fName, includeStereo, confId, kekulize, true);
 }
 
 RDKIT_FILEPARSERS_EXPORT std::string MolToXYZBlock(const ROMol &mol,

--- a/Code/GraphMol/FileParsers/MolFileParser.cpp
+++ b/Code/GraphMol/FileParsers/MolFileParser.cpp
@@ -2001,8 +2001,7 @@ void ParseV3000AtomProps(RWMol *mol, Atom *&atom, typename T::iterator &token,
     } else if (prop == "SUBST") {
       if (val != "0") {
         auto ival = FileParserUtils::toInt(val);
-        atom->setProp("molAtomSubstCount", ival);
-        // FIX: FINISH THIS
+        atom->setProp(common_properties::molSubstCount, ival);
       }
     } else if (prop == "EXACHG") {
       if (val != "0") {
@@ -2453,27 +2452,54 @@ void processSGroups(RWMol *mol) {
 
 void ProcessMolProps(RWMol *mol) {
   PRECONDITION(mol, "no molecule");
-  for (auto atom : mol->atoms()) {
-    int totV;
-    if (atom->getPropIfPresent(common_properties::molTotValence, totV) &&
-        !atom->hasProp("_ZBO_H")) {
-      if (totV == 0) {
-        continue;
+  // we have to loop the ugly way because we may need to actually replace an
+  // atom
+  for (unsigned int aidx = 0; aidx < mol->getNumAtoms(); ++aidx) {
+    auto atom = mol->getAtomWithIdx(aidx);
+    int ival = 0;
+    if (atom->getPropIfPresent(common_properties::molSubstCount, ival) &&
+        ival != 0) {
+      if (!atom->hasQuery()) {
+        atom = FileParserUtils::replaceAtomWithQueryAtom(mol, atom);
       }
+      bool gtQuery = false;
+      if (ival == -1) {
+        ival = 0;
+      } else if (ival == -2) {
+        // as drawn
+        ival = atom->getDegree();
+      } else if (ival == 6) {
+        // 6 or more
+        gtQuery = true;
+      }
+      if (!gtQuery) {
+        atom->expandQuery(makeAtomExplicitDegreeQuery(ival));
+      } else {
+        // create a temp query the normal way so that we can be sure to get
+        // the description right
+        std::unique_ptr<ATOM_EQUALS_QUERY> tmp{
+            makeAtomExplicitDegreeQuery(ival)};
+        atom->expandQuery(makeAtomSimpleQuery<ATOM_LESSEQUAL_QUERY>(
+            ival, tmp->getDataFunc(),
+            std::string("less_") + tmp->getDescription()));
+      }
+    }
+    if (atom->getPropIfPresent(common_properties::molTotValence, ival) &&
+        ival != 0 && !atom->hasProp("_ZBO_H")) {
       atom->setNoImplicit(true);
-      if (totV == 15     // V2000
-          || totV == -1  // v3000
+      if (ival == 15     // V2000
+          || ival == -1  // v3000
       ) {
         atom->setNumExplicitHs(0);
       } else {
-        if (atom->getExplicitValence() > totV) {
+        if (atom->getExplicitValence() > ival) {
           BOOST_LOG(rdWarningLog)
-              << "atom " << atom->getIdx() << " has specified valence (" << totV
+              << "atom " << atom->getIdx() << " has specified valence (" << ival
               << ") smaller than the drawn valence "
               << atom->getExplicitValence() << "." << std::endl;
           atom->setNumExplicitHs(0);
         } else {
-          atom->setNumExplicitHs(totV - atom->getExplicitValence());
+          atom->setNumExplicitHs(ival - atom->getExplicitValence());
         }
       }
     }

--- a/Code/GraphMol/FileParsers/MolFileParser.cpp
+++ b/Code/GraphMol/FileParsers/MolFileParser.cpp
@@ -2344,7 +2344,7 @@ void ParseV3000BondBlock(std::istream *inStream, unsigned int &line,
         }
       } else if (prop == "RXCTR") {
         int reactStatus = FileParserUtils::toInt(val);
-        bond->setProp("molReactStatus", reactStatus);
+        bond->setProp(common_properties::molReactStatus, reactStatus);
       } else if (prop == "STBOX") {
         bond->setProp(common_properties::molStereoCare, val);
       } else if (prop == "ENDPTS") {

--- a/Code/GraphMol/FileParsers/MolFileParser.cpp
+++ b/Code/GraphMol/FileParsers/MolFileParser.cpp
@@ -1998,6 +1998,39 @@ void ParseV3000AtomProps(RWMol *mol, Atom *&atom, typename T::iterator &token,
         auto ival = FileParserUtils::toInt(val);
         atom->setProp(common_properties::molStereoCare, ival);
       }
+    } else if (prop == "SUBST") {
+      if (val != "0") {
+        auto ival = FileParserUtils::toInt(val);
+        atom->setProp("molAtomSubstCount", ival);
+        // FIX: FINISH THIS
+      }
+    } else if (prop == "EXACHG") {
+      if (val != "0") {
+        auto ival = FileParserUtils::toInt(val);
+        atom->setProp(common_properties::molRxnExactChange, ival);
+      }
+    } else if (prop == "INVRET") {
+      if (val != "0") {
+        auto ival = FileParserUtils::toInt(val);
+        atom->setProp(common_properties::molInversionFlag, ival);
+      }
+    } else if (prop == "ATTCHPT") {
+      if (val != "0") {
+        auto ival = FileParserUtils::toInt(val);
+        atom->setProp(common_properties::molAttachPoint, ival);
+      }
+    } else if (prop == "ATTCHORD") {
+      if (val != "0") {
+        auto ival = FileParserUtils::toInt(val);
+        atom->setProp(common_properties::molAttachOrder, ival);
+      }
+    } else if (prop == "CLASS") {
+      atom->setProp(common_properties::molAtomClass, val);
+    } else if (prop == "SEQID") {
+      if (val != "0") {
+        auto ival = FileParserUtils::toInt(val);
+        atom->setProp(common_properties::molAtomSeqId, ival);
+      }
     }
     ++token;
   }

--- a/Code/GraphMol/FileParsers/MolFileParser.cpp
+++ b/Code/GraphMol/FileParsers/MolFileParser.cpp
@@ -2468,7 +2468,7 @@ void ProcessMolProps(RWMol *mol) {
       } else if (ival == -2) {
         // as drawn
         ival = atom->getDegree();
-      } else if (ival == 6) {
+      } else if (ival >= 6) {
         // 6 or more
         gtQuery = true;
       }

--- a/Code/GraphMol/FileParsers/MolFileWriter.cpp
+++ b/Code/GraphMol/FileParsers/MolFileWriter.cpp
@@ -1103,6 +1103,31 @@ const std::string GetV3000MolFileBondLine(const Bond *bond,
       ss << " TOPO=" << topol;
     }
   }
+
+  {
+    int iprop;
+    if (bond->getPropIfPresent(common_properties::molReactStatus, iprop) &&
+        iprop) {
+      ss << " RXCTR=" << iprop;
+    }
+  }
+
+  {
+    std::string sprop;
+    if (bond->getPropIfPresent(common_properties::molStereoCare, sprop) &&
+        sprop != "0") {
+      ss << " STBOX=" << sprop;
+    }
+    if (bond->getPropIfPresent(common_properties::_MolFileBondEndPts, sprop) &&
+        sprop != "0") {
+      ss << " ENDPTS=" << sprop;
+    }
+    if (bond->getPropIfPresent(common_properties::_MolFileBondAttach, sprop) &&
+        sprop != "0") {
+      ss << " ATTACH=" << sprop;
+    }
+  }
+
   return ss.str();
 }
 

--- a/Code/GraphMol/FileParsers/MolFileWriter.cpp
+++ b/Code/GraphMol/FileParsers/MolFileWriter.cpp
@@ -971,6 +971,40 @@ const std::string GetV3000MolFileAtomLine(
     atom->getPropIfPresent(common_properties::_MolFileRLabel, rLabel);
     ss << " RGROUPS=(1 " << rLabel << ")";
   }
+
+  {
+    int iprop;
+    if (atom->getPropIfPresent(common_properties::molAttachOrder, iprop) &&
+        iprop) {
+      ss << " ATTCHORD=" << iprop;
+    }
+    if (atom->getPropIfPresent(common_properties::molAttachPoint, iprop) &&
+        iprop) {
+      ss << " ATTCHPT=" << iprop;
+    }
+    if (atom->getPropIfPresent(common_properties::molAtomSeqId, iprop) &&
+        iprop) {
+      ss << " SEQID=" << iprop;
+    }
+    if (atom->getPropIfPresent(common_properties::molRxnExactChange, iprop) &&
+        iprop) {
+      ss << " EXACHG=" << iprop;
+    }
+    if (atom->getPropIfPresent(common_properties::molInversionFlag, iprop) &&
+        iprop) {
+      if (iprop == 1 || iprop == 2) ss << " INVRET=" << iprop;
+    }
+    if (atom->getPropIfPresent(common_properties::molStereoCare, iprop) &&
+        iprop) {
+      ss << " STBOX=" << iprop;
+    }
+  }
+  {
+    std::string sprop;
+    if (atom->getPropIfPresent(common_properties::molAtomClass, sprop)) {
+      ss << " CLASS=" << sprop;
+    }
+  }
   // HCOUNT - *query* hydrogen count. Not written by this writer.
 
   return ss.str();

--- a/Code/GraphMol/FileParsers/MolFileWriter.cpp
+++ b/Code/GraphMol/FileParsers/MolFileWriter.cpp
@@ -998,6 +998,10 @@ const std::string GetV3000MolFileAtomLine(
         iprop) {
       ss << " STBOX=" << iprop;
     }
+    if (atom->getPropIfPresent(common_properties::molSubstCount, iprop) &&
+        iprop) {
+      ss << " SUBST=" << iprop;
+    }
   }
   {
     std::string sprop;

--- a/Code/GraphMol/FileParsers/file_parsers_catch.cpp
+++ b/Code/GraphMol/FileParsers/file_parsers_catch.cpp
@@ -1392,4 +1392,38 @@ M  END
     CHECK(molb.find("SUBST=-2") != std::string::npos);
     CHECK(molb.find("SUBST=-1") != std::string::npos);
   }
+  SECTION("bond props") {
+    auto mol = R"CTAB(bogus example
+  Mrv2007 03132017102D          
+
+  0  0  0     0  0            999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 8 7 0 0 0
+M  V30 BEGIN ATOM
+M  V30 1 C -28.125 8.2067 0 0
+M  V30 2 C -26.7913 7.4367 0 0
+M  V30 3 C -26.7913 5.8967 0 0
+M  V30 4 C -28.125 5.1267 0 0
+M  V30 5 N -29.4587 5.8967 0 0
+M  V30 6 C -29.4587 7.4367 0 0
+M  V30 7 * -27.2359 7.18 0 0
+M  V30 8 R# -25.2354 8.335 0 0 RGROUPS=(1 1)
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 1 1 2
+M  V30 2 2 2 3
+M  V30 3 1 3 4
+M  V30 4 2 4 5
+M  V30 5 1 5 6 
+M  V30 6 2 1 6 RXCTR=1
+M  V30 7 1 7 8 ENDPTS=(3 1 2 3) ATTACH=ANY
+M  V30 END BOND
+M  V30 END CTAB
+M  END)CTAB"_ctab;
+    REQUIRE(mol);
+
+    auto molb = MolToV3KMolBlock(*mol);
+    CHECK(molb.find("ENDPTS=(3 1 2 3) ATTACH=ANY") != std::string::npos);
+    CHECK(molb.find("RXCTR=1") != std::string::npos);
+  }
 }

--- a/Code/GraphMol/FileParsers/file_parsers_catch.cpp
+++ b/Code/GraphMol/FileParsers/file_parsers_catch.cpp
@@ -1363,4 +1363,33 @@ M  END
     CHECK(molb.find("CLASS=foo") != std::string::npos);
     CHECK(molb.find("SEQID=4") != std::string::npos);
   }
+  SECTION("SUBST") {
+    auto mol = R"CTAB(
+  Mrv2007 03132014352D          
+
+  0  0  0     0  0            999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 3 2 0 0 0
+M  V30 BEGIN ATOM
+M  V30 1 C -16.625 7.1667 0 0 SUBST=3
+M  V30 2 C -15.2913 7.9367 0 0 SUBST=-2
+M  V30 3 N -13.9576 7.1667 0 0 SUBST=-1
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 1 1 2
+M  V30 2 1 2 3
+M  V30 END BOND
+M  V30 END CTAB
+M  END
+)CTAB"_ctab;
+    REQUIRE(mol);
+
+    auto smarts = MolToSmarts(*mol);
+    CHECK(smarts == "[#6&D3]-[#6&D2]-[#7&D0]");
+
+    auto molb = MolToV3KMolBlock(*mol);
+    CHECK(molb.find("SUBST=3") != std::string::npos);
+    CHECK(molb.find("SUBST=-2") != std::string::npos);
+    CHECK(molb.find("SUBST=-1") != std::string::npos);
+  }
 }

--- a/Code/GraphMol/FileParsers/file_parsers_catch.cpp
+++ b/Code/GraphMol/FileParsers/file_parsers_catch.cpp
@@ -1364,20 +1364,22 @@ M  END
     CHECK(molb.find("SEQID=4") != std::string::npos);
   }
   SECTION("SUBST") {
-    auto mol = R"CTAB(
-  Mrv2007 03132014352D          
+    auto mol = R"CTAB(test
+  Mrv2007 03132018122D          
 
   0  0  0     0  0            999 V3000
 M  V30 BEGIN CTAB
-M  V30 COUNTS 3 2 0 0 0
+M  V30 COUNTS 4 3 0 0 0
 M  V30 BEGIN ATOM
-M  V30 1 C -16.625 7.1667 0 0 SUBST=3
-M  V30 2 C -15.2913 7.9367 0 0 SUBST=-2
-M  V30 3 N -13.9576 7.1667 0 0 SUBST=-1
+M  V30 1 C -16.6248 7.1666 0 0 SUBST=3
+M  V30 2 C -15.2911 7.9366 0 0 SUBST=-2
+M  V30 3 N -13.9574 7.1666 0 0 SUBST=-1
+M  V30 4 C -17.9585 7.9366 0 0 SUBST=6
 M  V30 END ATOM
 M  V30 BEGIN BOND
 M  V30 1 1 1 2
 M  V30 2 1 2 3
+M  V30 3 1 1 4
 M  V30 END BOND
 M  V30 END CTAB
 M  END
@@ -1385,7 +1387,7 @@ M  END
     REQUIRE(mol);
 
     auto smarts = MolToSmarts(*mol);
-    CHECK(smarts == "[#6&D3]-[#6&D2]-[#7&D0]");
+    CHECK(smarts == "[#6&D3](-[#6&D2]-[#7&D0])-[#6&D{6-}]");
 
     auto molb = MolToV3KMolBlock(*mol);
     CHECK(molb.find("SUBST=3") != std::string::npos);

--- a/Code/GraphMol/Wrap/rdmolfiles.cpp
+++ b/Code/GraphMol/Wrap/rdmolfiles.cpp
@@ -696,6 +696,25 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
                python::arg("confId") = -1, python::arg("kekulize") = true,
                python::arg("forceV3000") = false),
               docString.c_str());
+  docString =
+      "Returns a V3000 Mol block for a molecule\n\
+  ARGUMENTS:\n\
+\n\
+    - mol: the molecule\n\
+    - includeStereo: (optional) toggles inclusion of stereochemical\n\
+      information in the output\n\
+    - confId: (optional) selects which conformation to output (-1 = default)\n\
+    - kekulize: (optional) triggers kekulization of the molecule before it's written,\n\
+      as suggested by the MDL spec.\n\
+\n\
+  RETURNS:\n\
+\n\
+    a string\n\
+\n";
+  python::def("MolToV3KMolBlock", RDKit::MolToV3KMolBlock,
+              (python::arg("mol"), python::arg("includeStereo") = true,
+               python::arg("confId") = -1, python::arg("kekulize") = true),
+              docString.c_str());
 
   docString =
       "Writes a Mol file for a molecule\n\
@@ -721,6 +740,28 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
        python::arg("includeStereo") = true, python::arg("confId") = -1,
        python::arg("kekulize") = true, python::arg("forceV3000") = false),
       docString.c_str());
+
+  docString =
+      "Writes a V3000 Mol file for a molecule\n\
+  ARGUMENTS:\n\
+\n\
+    - mol: the molecule\n\
+    - filename: the file to write to\n\
+    - includeStereo: (optional) toggles inclusion of stereochemical\n\
+      information in the output\n\
+    - confId: (optional) selects which conformation to output (-1 = default)\n\
+    - kekulize: (optional) triggers kekulization of the molecule before it's written,\n\
+      as suggested by the MDL spec.\n\
+\n\
+  RETURNS:\n\
+\n\
+    a string\n\
+\n";
+  python::def("MolToV3KMolFile", RDKit::MolToV3KMolFile,
+              (python::arg("mol"), python::arg("filename"),
+               python::arg("includeStereo") = true, python::arg("confId") = -1,
+               python::arg("kekulize") = true),
+              docString.c_str());
 
   //
 

--- a/Code/RDGeneral/types.cpp
+++ b/Code/RDGeneral/types.cpp
@@ -114,6 +114,7 @@ const std::string smilesSymbol = "smilesSymbol";
 const std::string atomLabel = "atomLabel";
 const std::string internalRgroupSmiles = "internalRgroupSmiles";
 
+const std::string molSubstCount = "molSubstCount";
 const std::string molAttachPoint = "molAttchpt";
 const std::string molAttachOrder = "molAttchord";
 const std::string molAtomClass = "molClass";

--- a/Code/RDGeneral/types.cpp
+++ b/Code/RDGeneral/types.cpp
@@ -114,6 +114,12 @@ const std::string smilesSymbol = "smilesSymbol";
 const std::string atomLabel = "atomLabel";
 const std::string internalRgroupSmiles = "internalRgroupSmiles";
 
+const std::string molAttachPoint = "molAttchpt";
+const std::string molAttachOrder = "molAttchord";
+const std::string molAtomClass = "molClass";
+const std::string molAtomSeqId = "molSeqid";
+const std::string molRxnExactChange = "molRxnExachg";
+
 }  // namespace common_properties
 
 const double MAX_DOUBLE = std::numeric_limits<double>::max();

--- a/Code/RDGeneral/types.cpp
+++ b/Code/RDGeneral/types.cpp
@@ -120,6 +120,7 @@ const std::string molAttachOrder = "molAttchord";
 const std::string molAtomClass = "molClass";
 const std::string molAtomSeqId = "molSeqid";
 const std::string molRxnExactChange = "molRxnExachg";
+const std::string molReactStatus = "molReactStatus";
 
 }  // namespace common_properties
 

--- a/Code/RDGeneral/types.h
+++ b/Code/RDGeneral/types.h
@@ -168,6 +168,7 @@ RDKIT_RDGENERAL_EXPORT extern const std::string molAttachOrder;     // int
 RDKIT_RDGENERAL_EXPORT extern const std::string molAtomClass;       // string
 RDKIT_RDGENERAL_EXPORT extern const std::string molAtomSeqId;       // int
 RDKIT_RDGENERAL_EXPORT extern const std::string molRxnExactChange;  // int
+RDKIT_RDGENERAL_EXPORT extern const std::string molReactStatus;     // int
 
 RDKIT_RDGENERAL_EXPORT extern const std::string _MolFileRLabel;  // unsigned int
 RDKIT_RDGENERAL_EXPORT extern const std::string _MolFileChiralFlag;  // int

--- a/Code/RDGeneral/types.h
+++ b/Code/RDGeneral/types.h
@@ -162,6 +162,7 @@ RDKIT_RDGENERAL_EXPORT extern const std::string molStereoCare;      // int
 RDKIT_RDGENERAL_EXPORT extern const std::string molRxnComponent;    // int
 RDKIT_RDGENERAL_EXPORT extern const std::string molRxnRole;         // int
 RDKIT_RDGENERAL_EXPORT extern const std::string molTotValence;      // int
+RDKIT_RDGENERAL_EXPORT extern const std::string molSubstCount;      // int
 RDKIT_RDGENERAL_EXPORT extern const std::string molAttachPoint;     // int
 RDKIT_RDGENERAL_EXPORT extern const std::string molAttachOrder;     // int
 RDKIT_RDGENERAL_EXPORT extern const std::string molAtomClass;       // string

--- a/Code/RDGeneral/types.h
+++ b/Code/RDGeneral/types.h
@@ -153,15 +153,21 @@ RDKIT_RDGENERAL_EXPORT extern const std::string
     atomLabel;  // atom string from CXSMILES
 
 // MDL Style Properties (MolFileParser)
-RDKIT_RDGENERAL_EXPORT extern const std::string molAtomMapNumber;  // int
-RDKIT_RDGENERAL_EXPORT extern const std::string molFileAlias;      // string
-RDKIT_RDGENERAL_EXPORT extern const std::string molFileValue;      // string
-RDKIT_RDGENERAL_EXPORT extern const std::string molInversionFlag;  // int
-RDKIT_RDGENERAL_EXPORT extern const std::string molParity;         // int
-RDKIT_RDGENERAL_EXPORT extern const std::string molStereoCare;     // int
-RDKIT_RDGENERAL_EXPORT extern const std::string molRxnComponent;   // int
-RDKIT_RDGENERAL_EXPORT extern const std::string molRxnRole;        // int
-RDKIT_RDGENERAL_EXPORT extern const std::string molTotValence;     // int
+RDKIT_RDGENERAL_EXPORT extern const std::string molAtomMapNumber;   // int
+RDKIT_RDGENERAL_EXPORT extern const std::string molFileAlias;       // string
+RDKIT_RDGENERAL_EXPORT extern const std::string molFileValue;       // string
+RDKIT_RDGENERAL_EXPORT extern const std::string molInversionFlag;   // int
+RDKIT_RDGENERAL_EXPORT extern const std::string molParity;          // int
+RDKIT_RDGENERAL_EXPORT extern const std::string molStereoCare;      // int
+RDKIT_RDGENERAL_EXPORT extern const std::string molRxnComponent;    // int
+RDKIT_RDGENERAL_EXPORT extern const std::string molRxnRole;         // int
+RDKIT_RDGENERAL_EXPORT extern const std::string molTotValence;      // int
+RDKIT_RDGENERAL_EXPORT extern const std::string molAttachPoint;     // int
+RDKIT_RDGENERAL_EXPORT extern const std::string molAttachOrder;     // int
+RDKIT_RDGENERAL_EXPORT extern const std::string molAtomClass;       // string
+RDKIT_RDGENERAL_EXPORT extern const std::string molAtomSeqId;       // int
+RDKIT_RDGENERAL_EXPORT extern const std::string molRxnExactChange;  // int
+
 RDKIT_RDGENERAL_EXPORT extern const std::string _MolFileRLabel;  // unsigned int
 RDKIT_RDGENERAL_EXPORT extern const std::string _MolFileChiralFlag;  // int
 RDKIT_RDGENERAL_EXPORT extern const std::string _MolFileAtomQuery;   // int


### PR DESCRIPTION
All the previously missing properties can now be read and written.
The bond properties were all already parsed, this completes writing them.

This also adds convenience functions to make it easier to write V3000 mol blocks or mol files, which we should be using more often