### PR TITLE
Move jupyter extension logging to the python logger

### DIFF
--- a/rdkit/__init__.py
+++ b/rdkit/__init__.py
@@ -4,6 +4,8 @@ except ImportError:
   __version__ = 'Unknown'
   raise
 
+import logging
+logger = logging.getLogger("rdkit")
 # if we are running in a jupyter notebook, enable the extensions
 try:
   kernel_name = get_ipython().__class__.__name__
@@ -12,7 +14,7 @@ try:
     from rdkit.Chem.Draw import IPythonConsole
     from rdkit.Chem import LogWarningMsg, WrapLogs
     WrapLogs()  
-    LogWarningMsg("Enabling RDKit %s jupyter extensions"%__version__)
+    logger.info("Enabling RDKit %s jupyter extensions"%__version__)
     
 except:
   pass


### PR DESCRIPTION
Moves the Jupyter extension notification to the python logger.  This enables us to turn it on or off.

Fixes #3006 