### PR TITLE
Update Maeparser & Coordgen Dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,8 +43,6 @@ __pycache__/
 /Code/GraphMol/SmilesParse/smiles.tab.cpp
 /Code/GraphMol/SmilesParse/smiles.tab.hpp
 
-/Data/templates.mae
-
 /External/**/*.tar.gz
 /External/**/*.zip
 /External/catch/catch/

--- a/Code/cmake/Modules/Findcoordgen.cmake
+++ b/Code/cmake/Modules/Findcoordgen.cmake
@@ -6,7 +6,6 @@
 #
 # coordgen_INCLUDE_DIRS   - CoordGen's includes directory
 # coordgen_LIBRARIES      - CoordGen's shared libraries
-# coordgen_TEMPLATE_FILE  - CoordGen templates file
 #
 #
 
@@ -28,19 +27,9 @@ find_library(coordgen_LIBRARIES
 )
 message("-- coordgen libraries set as '${coordgen_LIBRARIES}'")
 
-# Just in case, add parent directory above libraries to templates search hints
-get_filename_component(libs_parent_dir ${coordgen_LIBRARIES} PATH)
-find_file(coordgen_TEMPLATE_FILE
-    NAMES templates.mae
-    HINTS ${COORDGEN_DIR} ${coordgen_DIR} ${libs_parent_dir}
-    PATH_SUFFIXES "share" "share/coordgen"
-    DOC "templates file for coordgen"
-)
-message("-- coordgen templates file set as '${coordgen_TEMPLATE_FILE}'")
-
 find_package_handle_standard_args(coordgen FOUND_VAR coordgen_FOUND
                                   REQUIRED_VARS coordgen_INCLUDE_DIRS
-                                  coordgen_LIBRARIES coordgen_TEMPLATE_FILE)
+                                  coordgen_LIBRARIES)
 
 
 

--- a/External/CoordGen/CMakeLists.txt
+++ b/External/CoordGen/CMakeLists.txt
@@ -37,8 +37,8 @@ if(RDK_BUILD_COORDGEN_SUPPORT)
     endif()
 
     if(NOT EXISTS "${MAEPARSER_DIR}/MaeParser.hpp")
-        set(RELEASE_NO "1.2.2")
-        set(MD5 "3c42d4f98e5fc3214ff991ccf76938bd")
+        set(RELEASE_NO "1.2.3")
+        set(MD5 "4ead02a0bf87110d1caae79ab42a5747")
         downloadAndCheckMD5("https://github.com/schrodinger/maeparser/archive/v${RELEASE_NO}.tar.gz"
               "${CMAKE_CURRENT_SOURCE_DIR}/maeparser-v${RELEASE_NO}.tar.gz" ${MD5})
         execute_process(COMMAND ${CMAKE_COMMAND} -E tar zxf
@@ -69,8 +69,8 @@ if(RDK_BUILD_COORDGEN_SUPPORT)
     endif()
 
     if(NOT EXISTS "${COORDGEN_DIR}/sketcherMinimizer.h")
-        set(RELEASE_NO "1.3.2")
-        set(MD5 "06a67c9ba7668946e89d0baa52dc8d04")
+        set(RELEASE_NO "1.4.0")
+        set(MD5 "5f663c8809b494f0548dd504c011c739")
         downloadAndCheckMD5("https://github.com/schrodinger/coordgenlibs/archive/v${RELEASE_NO}.tar.gz"
               "${CMAKE_CURRENT_SOURCE_DIR}/coordgenlibs-${RELEASE_NO}.tar.gz" ${MD5})
         execute_process(COMMAND ${CMAKE_COMMAND} -E tar zxf

--- a/External/CoordGen/CMakeLists.txt
+++ b/External/CoordGen/CMakeLists.txt
@@ -88,15 +88,13 @@ if(RDK_BUILD_COORDGEN_SUPPORT)
     rdkit_library(coordgen ${CGSOURCES} SHARED LINK_LIBRARIES ${maeparser_LIBRARIES})
     install(TARGETS coordgen DESTINATION ${RDKit_LibDir})
     set(coordgen_LIBRARIES coordgen)
-    set(coordgen_TEMPLATE_FILE ${COORDGEN_DIR}/templates.mae )
 
   endif(COORDGEN_FORCE_BUILD OR (NOT coordgen_FOUND))
 
   include_directories(${maeparser_INCLUDE_DIRS})
   include_directories(${coordgen_INCLUDE_DIRS})
 
-  install(FILES ${coordgen_TEMPLATE_FILE}
-          DESTINATION ${RDKit_ShareDir}/Data
+  install(FILES DESTINATION ${RDKit_ShareDir}/Data
           COMPONENT data)
 
   set(RDK_COORDGEN_LIBS MolAlign ${coordgen_LIBRARIES} ${maeparser_LIBRARIES} ${Boost_LIBRARIES}


### PR DESCRIPTION
This updates maeparser to v1.2.3 and coordgen v.1.4.0:

- Changes in maeparser are all build-related.
- Changes to coordgen also include build improvements, but also a bug fix to prevent propagation of bad chirality (schrodinger/coordgenlibs#54), some performance improvements, and hardcoding of the templates into the code. This means that templates.mae no longer needs to be in the installation (so I removed any references from RDKit). Also, it makes maeparser an optional dependency of coordgen (it is enabled by default; now it is only used in case the user provides a custom templates file).

The build improvements in maeparser and coordgen allow for building static libraries out of the box. At present, this is not of great relevance to RDKit, as we don't use maeparsers or coordgens cmake files, but we might update to take advantage of them.

Also, in the future we might consider if we really need coordgen to use maeparser, and whether we should split both libraries into independent optional dependencies. 