### PR TITLE
Address issue #2890

### DIFF
--- a/Code/GraphMol/Chirality.cpp
+++ b/Code/GraphMol/Chirality.cpp
@@ -1645,14 +1645,18 @@ void findPotentialStereoBonds(ROMol &mol, bool cleanIt) {
           !(mol.getRingInfo()->numBondRings((*bondIt)->getIdx()))) {
         // we are ignoring ring bonds here - read the FIX above
         Bond *dblBond = *bondIt;
-        // if the bond is flagged as EITHERDOUBLE, we ignore it:
+        // We ignore bonds flagged as EITHERDOUBLE or STEREOANY which have
+        // stereo atoms set.
         if (dblBond->getBondDir() == Bond::EITHERDOUBLE ||
-            dblBond->getStereo() == Bond::STEREOANY) {
+            (dblBond->getStereo() == Bond::STEREOANY &&
+             dblBond->getStereoAtoms().size() == 2)) {
           continue;
         }
-        // proceed only if we either want to clean the stereocode on this bond
-        // or if none is set on it yet
-        if (cleanIt || dblBond->getStereo() == Bond::STEREONONE) {
+        // proceed only if we either want to clean the stereocode on this bond,
+        // if none is set on it yet, or it is STEREOANY and we need to find
+        // stereoatoms
+        if (cleanIt || dblBond->getStereo() == Bond::STEREONONE ||
+            dblBond->getStereo() == Bond::STEREOANY) {
           dblBond->setStereo(Bond::STEREONONE);
           const Atom *begAtom = dblBond->getBeginAtom(),
                      *endAtom = dblBond->getEndAtom();

--- a/Code/GraphMol/catch_graphmol.cpp
+++ b/Code/GraphMol/catch_graphmol.cpp
@@ -1473,3 +1473,16 @@ TEST_CASE("phosphine and arsine chirality", "[Chirality]") {
     CHECK(MolToSmiles(*mol1) != MolToSmiles(*mol2));
   }
 }
+
+TEST_CASE("github #2890", "[bug, molops, stereo]") {
+    auto mol = "CC=CC"_smiles;
+    REQUIRE(mol);
+
+    auto bond = mol->getBondWithIdx(1);
+    bond->setStereo(Bond::STEREOANY);
+    REQUIRE(bond->getStereoAtoms().empty());
+
+    MolOps::findPotentialStereoBonds(*mol);
+    CHECK(bond->getStereo() == Bond::STEREOANY);
+    CHECK(bond->getStereoAtoms().size() == 2);
+}

--- a/rdkit/Chem/UnitTestMol3D.py
+++ b/rdkit/Chem/UnitTestMol3D.py
@@ -352,6 +352,11 @@ class TestCase(unittest.TestCase):
     self.assertEqual(len(smiles), len(set(smiles)))
     self.assertEqual(len(smiles), 2**3)
 
+  def testIssue2890(self):
+    mol = Chem.MolFromSmiles('CC=CC')
+    mol.GetBondWithIdx(1).SetStereo(Chem.rdchem.BondStereo.STEREOANY)
+
+    assert len(list(AllChem.EnumerateStereoisomers(mol))) == 2
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
I have patched `FindPotentialStereoBonds()` to check that bonds marked as STEREOANY have stereo bonds. If they have, the bond is skipped, but if not, then the bond is rechecked in order to have stereo atoms assigned, or be relabeled as STEREONONE.

This fixes #2890: `EnumerateStereoisomers()` was failing because the input STEREOANY bond did not have stereoatoms assigned. Once it gets them, the enumeration succeeds.
