### PR TITLE
phosphine&arsine chirality support isAtomPotentialChiralCenter()

### DIFF
--- a/Code/GraphMol/Chirality.cpp
+++ b/Code/GraphMol/Chirality.cpp
@@ -1014,9 +1014,17 @@ std::pair<bool, bool> isAtomPotentialChiralCenter(
 
     // figure out if this is a legal chiral center or not:
     if (!hasDupes) {
-      if (nbrs.size() < 3) {
+      if (nbrs.size() < 3 
+       && (atom->getAtomicNum() != 15 && atom->getAtomicNum() != 33)) {
         // less than three neighbors is never stereogenic
+        // unless it is a phosphine/arsine with implicit H
         legalCenter = false;
+      } else if (atom->getAtomicNum() == 15 || atom->getAtomicNum() == 33) {
+        // from logical flow: nbrs.size is 3 or 4, or 2 (implicit H)
+        // Since InChI Software v. 1.02-standard (2009), phosphines and arsines
+        // are always treated as stereogenic even with H atom neighbors.
+        // Accept automatically.
+        legalCenter = true;
       } else if (nbrs.size() == 3) {
         // three-coordinate with a single H we'll accept automatically:
         if (atom->getTotalNumHs() != 1) {

--- a/Code/GraphMol/catch_graphmol.cpp
+++ b/Code/GraphMol/catch_graphmol.cpp
@@ -1410,3 +1410,66 @@ TEST_CASE("updateQueryParameters from JSON") {
     CHECK_THROWS_AS(MolOps::parseAdjustQueryParametersFromJSON(ps, json),ValueErrorException);
   }
 }
+
+TEST_CASE("phosphine and arsine chirality", "[Chirality]") {
+  SECTION("chiral center recognized"){
+    auto mol1 = "C[P@](C1CCCC1)C1=CC=CC=C1"_smiles;
+    auto mol2 = "C[As@](C1CCCC1)C1=CC=CC=C1"_smiles;
+    REQUIRE(mol1);
+    REQUIRE(mol2);
+    CHECK(mol1->getAtomWithIdx(1)->getChiralTag() != Atom::CHI_UNSPECIFIED);
+    CHECK(mol2->getAtomWithIdx(1)->getChiralTag() != Atom::CHI_UNSPECIFIED);
+  }
+  SECTION("chiral center selective"){
+    auto mol1 = "C[P@](C)C1CCCCC1"_smiles;
+    auto mol2 = "C[As@](C)C1CCCCC1"_smiles;
+    REQUIRE(mol1);
+    REQUIRE(mol2);
+    CHECK(mol1->getAtomWithIdx(1)->getChiralTag() == Atom::CHI_UNSPECIFIED);
+    CHECK(mol2->getAtomWithIdx(1)->getChiralTag() == Atom::CHI_UNSPECIFIED);
+  }
+  SECTION("chiral center specific: P"){
+    auto mol1 = "C[P@](C1CCCC1)C1=CC=CC=C1"_smiles;
+    auto mol2 = "C[P@@](C1CCCC1)C1=CC=CC=C1"_smiles;
+    REQUIRE(mol1); 
+    REQUIRE(mol2);
+    CHECK(MolToSmiles(*mol1) != MolToSmiles(*mol2));
+  }
+  SECTION("chiral center specific: As"){
+    auto mol1 = "C[As@](C1CCCC1)C1=CC=CC=C1"_smiles;
+    auto mol2 = "C[As@@](C1CCCC1)C1=CC=CC=C1"_smiles;
+    REQUIRE(mol1); 
+    REQUIRE(mol2);
+    CHECK(MolToSmiles(*mol1) != MolToSmiles(*mol2));
+  }
+  SECTION("chiral center, implicit H: P"){
+    auto mol1 = "C[P@H]C1CCCCC1"_smiles;
+    auto mol2 = "C[P@@H]C1CCCCC1"_smiles;
+    REQUIRE(mol1);
+    REQUIRE(mol2);
+    CHECK(mol1->getAtomWithIdx(1)->getChiralTag() != Atom::CHI_UNSPECIFIED);
+    CHECK(mol1->getAtomWithIdx(1)->getChiralTag() != Atom::CHI_UNSPECIFIED);
+  }
+  SECTION("chiral center, implicit H: As"){
+    auto mol1 = "C[As@H]C1CCCCC1"_smiles;
+    auto mol2 = "C[As@@H]C1CCCCC1"_smiles;
+    REQUIRE(mol1);
+    REQUIRE(mol2);
+    CHECK(mol1->getAtomWithIdx(1)->getChiralTag() != Atom::CHI_UNSPECIFIED);
+    CHECK(mol1->getAtomWithIdx(1)->getChiralTag() != Atom::CHI_UNSPECIFIED);
+  }
+  SECTION("chiral center specific, implicit H: P"){
+    auto mol1 = "C[P@H]C1CCCCC1"_smiles;
+    auto mol2 = "C[P@@H]C1CCCCC1"_smiles;
+    REQUIRE(mol1);
+    REQUIRE(mol2);
+    CHECK(MolToSmiles(*mol1) != MolToSmiles(*mol2));
+  }
+  SECTION("chiral center specific, implicit H: As"){
+    auto mol1 = "C[As@H]C1CCCCC1"_smiles;
+    auto mol2 = "C[As@@H]C1CCCCC1"_smiles;
+    REQUIRE(mol1);
+    REQUIRE(mol2);
+    CHECK(MolToSmiles(*mol1) != MolToSmiles(*mol2));
+  }
+}


### PR DESCRIPTION
- Add tests for phosphine and arsine chirality
- Add support to isAtomPotentialChiralCenter()
  Accept both 2 (implicit H), 3 and 4 coordinate P and As atoms as potential
chiral centers

#### Reference Issue
Fixes #2949 

#### What does this implement/fix? Explain your changes.
Adds support for phosphine and arsine chirality in isAtomPotentialChiralCenter()

#### Any other comments?
Support for phosphine and arsine chirality in assignChiralTypesFromBondDirs() will be added in a separate, future PR. 
