### PR TITLE
Added support for Python FMCS functors

### DIFF
--- a/Code/GraphMol/FMCS/FMCS.cpp
+++ b/Code/GraphMol/FMCS/FMCS.cpp
@@ -39,11 +39,12 @@ void MCSParameters::setMCSAtomTyperFromEnum(AtomComparator atomComp) {
       AtomTyper = MCSAtomCompareAnyHeavyAtom;
       break;
     default:
-      throw std::runtime_error("Unknown AtomComparator");
+      throw ValueErrorException("Unknown AtomComparator");
   }
 }
 
 void MCSParameters::setMCSAtomTyperFromConstChar(const char *atomComp) {
+  PRECONDITION(atomComp, "atomComp must not be NULL");
   static const std::map<const char *, AtomComparator> atomCompStringToEnum = {
     { "Any", AtomCompareAny },
     { "Elements", AtomCompareElements },
@@ -70,11 +71,12 @@ void MCSParameters::setMCSBondTyperFromEnum(BondComparator bondComp) {
       BondTyper = MCSBondCompareOrderExact;
       break;
     default:
-      throw std::runtime_error("Unknown BondComparator");
+      throw ValueErrorException("Unknown BondComparator");
   }
 }
 
 void MCSParameters::setMCSBondTyperFromConstChar(const char *bondComp) {
+  PRECONDITION(bondComp, "bondComp must not be NULL");
   static const std::map<const char *, BondComparator> bondCompStringToEnum = {
     { "Any", BondCompareAny },
     { "Order", BondCompareOrder },
@@ -181,6 +183,7 @@ MCSResult findMCS(const std::vector<ROMOL_SPTR>& mols, bool maximizeBonds,
 bool MCSProgressCallbackTimeout(const MCSProgressData& stat,
                                 const MCSParameters& params, void* userData) {
   RDUNUSED_PARAM(stat);
+  PRECONDITION(userData, "userData must not be NULL");
   auto* t0 = (unsigned long long*)userData;
   unsigned long long t = nanoClock();
   return t - *t0 <= params.Timeout * 1000000ULL;
@@ -431,6 +434,7 @@ inline bool ringFusionCheck(const std::uint32_t c1[],
                             const FMCS::Graph& query, const ROMol& mol2,
                             const FMCS::Graph& target,
                             const MCSParameters* p) {
+  PRECONDITION(p, "p must not be NULL");
   const RingInfo* ri2 = mol2.getRingInfo();
   const VECT_INT_VECT& br2 = ri2->bondRings();
   std::vector<size_t> nonFusedBonds(br2.size(), 0);
@@ -576,6 +580,7 @@ bool FinalMatchCheckFunction(const std::uint32_t c1[], const std::uint32_t c2[],
                              const ROMol& mol1, const FMCS::Graph& query,
                              const ROMol& mol2, const FMCS::Graph& target,
                              const MCSParameters* p) {
+  PRECONDITION(p, "p must not be NULL");
   if ((p->BondCompareParameters.MatchFusedRings ||
        p->BondCompareParameters.MatchFusedRingsStrict) &&
       !ringFusionCheck(c1, c2, mol1, query, mol2, target, p)) {

--- a/Code/GraphMol/FMCS/FMCS.cpp
+++ b/Code/GraphMol/FMCS/FMCS.cpp
@@ -24,6 +24,70 @@
 
 namespace RDKit {
 
+void MCSParameters::setMCSAtomTyperFromEnum(AtomComparator atomComp) {
+  switch (atomComp) {
+    case AtomCompareAny:
+      AtomTyper = MCSAtomCompareAny;
+      break;
+    case AtomCompareElements:
+      AtomTyper = MCSAtomCompareElements;
+      break;
+    case AtomCompareIsotopes:
+      AtomTyper = MCSAtomCompareIsotopes;
+      break;
+    case AtomCompareAnyHeavyAtom:
+      AtomTyper = MCSAtomCompareAnyHeavyAtom;
+      break;
+    default:
+      throw std::runtime_error("Unknown AtomComparator");
+  }
+}
+
+void MCSParameters::setMCSAtomTyperFromConstChar(const char *atomComp) {
+  static const std::map<const char *, AtomComparator> atomCompStringToEnum = {
+    { "Any", AtomCompareAny },
+    { "Elements", AtomCompareElements },
+    { "Isotopes", AtomCompareIsotopes },
+    { "AnyHeavy", AtomCompareAnyHeavyAtom }
+  };
+  try {
+    setMCSAtomTyperFromEnum(atomCompStringToEnum.at(atomComp));
+  }
+  catch(const std::out_of_range&) {
+    // we accept "def" as a no-op
+  }
+}
+
+void MCSParameters::setMCSBondTyperFromEnum(BondComparator bondComp) {
+  switch (bondComp) {
+    case BondCompareAny:
+      BondTyper = MCSBondCompareAny;
+      break;
+    case BondCompareOrder:
+      BondTyper = MCSBondCompareOrder;
+      break;
+    case BondCompareOrderExact:
+      BondTyper = MCSBondCompareOrderExact;
+      break;
+    default:
+      throw std::runtime_error("Unknown BondComparator");
+  }
+}
+
+void MCSParameters::setMCSBondTyperFromConstChar(const char *bondComp) {
+  static const std::map<const char *, BondComparator> bondCompStringToEnum = {
+    { "Any", BondCompareAny },
+    { "Order", BondCompareOrder },
+    { "OrderExact", BondCompareOrderExact }
+  };
+  try {
+    setMCSBondTyperFromEnum(bondCompStringToEnum.at(bondComp));
+  }
+  catch(const std::out_of_range&) {
+    // we accept "def" as a no-op
+  }
+}
+
 void parseMCSParametersJSON(const char* json, MCSParameters* params) {
   if (params && json && 0 != strlen(json)) {
     std::istringstream ss;
@@ -54,25 +118,8 @@ void parseMCSParametersJSON(const char* json, MCSParameters* params) {
     p.BondCompareParameters.MatchStereo =
         pt.get<bool>("MatchStereo", p.BondCompareParameters.MatchStereo);
 
-    std::string s = pt.get<std::string>("AtomCompare", "def");
-    if (0 == strcmp("Any", s.c_str())) {
-      p.AtomTyper = MCSAtomCompareAny;
-    } else if (0 == strcmp("Elements", s.c_str())) {
-      p.AtomTyper = MCSAtomCompareElements;
-    } else if (0 == strcmp("Isotopes", s.c_str())) {
-      p.AtomTyper = MCSAtomCompareIsotopes;
-    } else if (0 == strcmp("AnyHeavy", s.c_str())) {
-      p.AtomTyper = MCSAtomCompareAnyHeavyAtom;
-    }
-
-    s = pt.get<std::string>("BondCompare", "def");
-    if (0 == strcmp("Any", s.c_str())) {
-      p.BondTyper = MCSBondCompareAny;
-    } else if (0 == strcmp("Order", s.c_str())) {
-      p.BondTyper = MCSBondCompareOrder;
-    } else if (0 == strcmp("OrderExact", s.c_str())) {
-      p.BondTyper = MCSBondCompareOrderExact;
-    }
+    p.setMCSAtomTyperFromConstChar(pt.get<std::string>("AtomCompare", "def").c_str());
+    p.setMCSBondTyperFromConstChar(pt.get<std::string>("BondCompare", "def").c_str());
 
     p.InitialSeed = pt.get<std::string>("InitialSeed", "");
   }
@@ -116,34 +163,11 @@ MCSResult findMCS(const std::vector<ROMOL_SPTR>& mols, bool maximizeBonds,
   ps->Threshold = threshold;
   ps->Timeout = timeout;
   ps->Verbose = verbose;
+  ps->setMCSAtomTyperFromEnum(atomComp);
   ps->AtomCompareParameters.MatchValences = matchValences;
   ps->AtomCompareParameters.MatchChiralTag = matchChiralTag;
-  switch (atomComp) {
-    case AtomCompareAny:
-      ps->AtomTyper = MCSAtomCompareAny;
-      break;
-    case AtomCompareElements:
-      ps->AtomTyper = MCSAtomCompareElements;
-      break;
-    case AtomCompareIsotopes:
-      ps->AtomTyper = MCSAtomCompareIsotopes;
-      break;
-    case AtomCompareAnyHeavyAtom:
-      ps->AtomTyper = MCSAtomCompareAnyHeavyAtom;
-      break;
-  }
   ps->AtomCompareParameters.RingMatchesRingOnly = ringMatchesRingOnly;
-  switch (bondComp) {
-    case BondCompareAny:
-      ps->BondTyper = MCSBondCompareAny;
-      break;
-    case BondCompareOrder:
-      ps->BondTyper = MCSBondCompareOrder;
-      break;
-    case BondCompareOrderExact:
-      ps->BondTyper = MCSBondCompareOrderExact;
-      break;
-  }
+  ps->setMCSBondTyperFromEnum(bondComp);
   ps->BondCompareParameters.RingMatchesRingOnly = ringMatchesRingOnly;
   ps->BondCompareParameters.CompleteRingsOnly = completeRingsOnly;
   ps->BondCompareParameters.MatchFusedRings = (ringComp != IgnoreRingFusion);
@@ -165,9 +189,9 @@ bool MCSProgressCallbackTimeout(const MCSProgressData& stat,
 // PREDEFINED FUNCTORS:
 
 //=== ATOM COMPARE ========================================================
-static bool checkRingMatch(const MCSAtomCompareParameters& p, const ROMol& mol1,
-                           unsigned int atom1, const ROMol& mol2,
-                           unsigned int atom2) {
+bool checkAtomRingMatch(const MCSAtomCompareParameters& p, const ROMol& mol1,
+                        unsigned int atom1, const ROMol& mol2,
+                        unsigned int atom2) {
   if (p.RingMatchesRingOnly) {
     bool atom1inRing = queryIsAtomInRing(mol1.getAtomWithIdx(atom1));
     bool atom2inRing = queryIsAtomInRing(mol2.getAtomWithIdx(atom2));
@@ -177,17 +201,18 @@ static bool checkRingMatch(const MCSAtomCompareParameters& p, const ROMol& mol1,
   }
 }
 
-static bool checkAtomCharge(const MCSAtomCompareParameters& p,
-                            const ROMol& mol1, unsigned int atom1,
-                            const ROMol& mol2, unsigned int atom2) {
+bool checkAtomCharge(const MCSAtomCompareParameters& p,
+                     const ROMol& mol1, unsigned int atom1,
+                     const ROMol& mol2, unsigned int atom2) {
   RDUNUSED_PARAM(p);
   const Atom& a1 = *mol1.getAtomWithIdx(atom1);
   const Atom& a2 = *mol2.getAtomWithIdx(atom2);
   return a1.getFormalCharge() == a2.getFormalCharge();
 }
-static bool checkAtomChirality(const MCSAtomCompareParameters& p,
-                               const ROMol& mol1, unsigned int atom1,
-                               const ROMol& mol2, unsigned int atom2) {
+
+bool checkAtomChirality(const MCSAtomCompareParameters& p,
+                        const ROMol& mol1, unsigned int atom1,
+                        const ROMol& mol2, unsigned int atom2) {
   RDUNUSED_PARAM(p);
   const Atom& a1 = *mol1.getAtomWithIdx(atom1);
   const Atom& a2 = *mol2.getAtomWithIdx(atom2);
@@ -210,7 +235,7 @@ bool MCSAtomCompareAny(const MCSAtomCompareParameters& p, const ROMol& mol1,
     return false;
   }
   if (p.RingMatchesRingOnly) {
-    return checkRingMatch(p, mol1, atom1, mol2, atom2);
+    return checkAtomRingMatch(p, mol1, atom1, mol2, atom2);
   }
 
   return true;
@@ -234,7 +259,7 @@ bool MCSAtomCompareElements(const MCSAtomCompareParameters& p,
     return false;
   }
   if (p.RingMatchesRingOnly) {
-    return checkRingMatch(p, mol1, atom1, mol2, atom2);
+    return checkAtomRingMatch(p, mol1, atom1, mol2, atom2);
   }
   return true;
 }
@@ -258,7 +283,7 @@ bool MCSAtomCompareIsotopes(const MCSAtomCompareParameters& p,
     return false;
   }
   if (p.RingMatchesRingOnly) {
-    return checkRingMatch(p, mol1, atom1, mol2, atom2);
+    return checkAtomRingMatch(p, mol1, atom1, mol2, atom2);
   }
   return true;
 }
@@ -312,9 +337,9 @@ class BondMatchOrderMatrix {
   }
 };
 
-static bool checkBondStereo(const MCSBondCompareParameters& p,
-                            const ROMol& mol1, unsigned int bond1,
-                            const ROMol& mol2, unsigned int bond2) {
+bool checkBondStereo(const MCSBondCompareParameters& p,
+                     const ROMol& mol1, unsigned int bond1,
+                     const ROMol& mol2, unsigned int bond2) {
   RDUNUSED_PARAM(p);
   const Bond* b1 = mol1.getBondWithIdx(bond1);
   const Bond* b2 = mol2.getBondWithIdx(bond2);
@@ -328,9 +353,9 @@ static bool checkBondStereo(const MCSBondCompareParameters& p,
   return true;
 }
 
-static bool checkRingMatch(const MCSBondCompareParameters&, const ROMol&,
-                           unsigned int bond1, const ROMol& mol2,
-                           unsigned int bond2, void* v_ringMatchMatrixSet) {
+bool checkBondRingMatch(const MCSBondCompareParameters&, const ROMol&,
+                               unsigned int bond1, const ROMol& mol2,
+                               unsigned int bond2, void* v_ringMatchMatrixSet) {
   if (!v_ringMatchMatrixSet) {
     throw "v_ringMatchMatrixSet is NULL";  // never
   }
@@ -355,7 +380,7 @@ bool MCSBondCompareAny(const MCSBondCompareParameters& p, const ROMol& mol1,
     return false;
   }
   if (p.RingMatchesRingOnly) {
-    return checkRingMatch(p, mol1, bond1, mol2, bond2, ud);
+    return checkBondRingMatch(p, mol1, bond1, mol2, bond2, ud);
   }
   return true;
 }
@@ -373,7 +398,7 @@ bool MCSBondCompareOrder(const MCSBondCompareParameters& p, const ROMol& mol1,
       return false;
     }
     if (p.RingMatchesRingOnly) {
-      return checkRingMatch(p, mol1, bond1, mol2, bond2, ud);
+      return checkBondRingMatch(p, mol1, bond1, mol2, bond2, ud);
     }
     return true;
   }
@@ -393,7 +418,7 @@ bool MCSBondCompareOrderExact(const MCSBondCompareParameters& p,
       return false;
     }
     if (p.RingMatchesRingOnly) {
-      return checkRingMatch(p, mol1, bond1, mol2, bond2, ud);
+      return checkBondRingMatch(p, mol1, bond1, mol2, bond2, ud);
     }
     return true;
   }
@@ -401,11 +426,11 @@ bool MCSBondCompareOrderExact(const MCSBondCompareParameters& p,
 }
 
 //=== RING COMPARE ========================================================
-inline static bool ringFusionCheck(const std::uint32_t c1[],
-                                   const std::uint32_t c2[], const ROMol& mol1,
-                                   const FMCS::Graph& query, const ROMol& mol2,
-                                   const FMCS::Graph& target,
-                                   const MCSParameters* p) {
+inline bool ringFusionCheck(const std::uint32_t c1[],
+                            const std::uint32_t c2[], const ROMol& mol1,
+                            const FMCS::Graph& query, const ROMol& mol2,
+                            const FMCS::Graph& target,
+                            const MCSParameters* p) {
   const RingInfo* ri2 = mol2.getRingInfo();
   const VECT_INT_VECT& br2 = ri2->bondRings();
   std::vector<size_t> nonFusedBonds(br2.size(), 0);

--- a/Code/GraphMol/FMCS/FMCS.h
+++ b/Code/GraphMol/FMCS/FMCS.h
@@ -18,11 +18,31 @@
 namespace RDKit {
 struct MCSParameters;
 
+typedef enum {
+  AtomCompareAny,
+  AtomCompareElements,
+  AtomCompareIsotopes,
+  AtomCompareAnyHeavyAtom
+} AtomComparator;
+
+typedef enum {
+  BondCompareAny,
+  BondCompareOrder,
+  BondCompareOrderExact
+} BondComparator;
+
+typedef enum {
+  IgnoreRingFusion,
+  PermissiveRingFusion,
+  StrictRingFusion
+} RingComparator;
+
 struct RDKIT_FMCS_EXPORT MCSAtomCompareParameters {
   bool MatchValences = false;
   bool MatchChiralTag = false;
   bool MatchFormalCharge = false;
   bool RingMatchesRingOnly = false;
+  bool MatchIsotope = false;
 };
 
 struct RDKIT_FMCS_EXPORT MCSBondCompareParameters {
@@ -47,6 +67,16 @@ typedef bool (*MCSBondCompareFunction)(const MCSBondCompareParameters& p,
                                        void* userData);
 
 // Some predefined functors:
+RDKIT_FMCS_EXPORT bool checkAtomRingMatch(const MCSAtomCompareParameters& p,
+                                          const ROMol& mol1, unsigned int atom1,
+                                          const ROMol& mol2, unsigned int atom2);
+RDKIT_FMCS_EXPORT bool checkAtomCharge(const MCSAtomCompareParameters& p,
+                                       const ROMol& mol1, unsigned int atom1,
+                                       const ROMol& mol2, unsigned int atom2);
+RDKIT_FMCS_EXPORT bool checkAtomChirality(const MCSAtomCompareParameters& p,
+                                          const ROMol& mol1, unsigned int atom1,
+                                          const ROMol& mol2, unsigned int atom2);
+
 RDKIT_FMCS_EXPORT bool MCSAtomCompareAny(const MCSAtomCompareParameters& p,
                                          const ROMol& mol1, unsigned int atom1,
                                          const ROMol& mol2, unsigned int atom2,
@@ -61,6 +91,14 @@ RDKIT_FMCS_EXPORT bool MCSAtomCompareElements(
 RDKIT_FMCS_EXPORT bool MCSAtomCompareIsotopes(
     const MCSAtomCompareParameters& p, const ROMol& mol1, unsigned int atom1,
     const ROMol& mol2, unsigned int atom2, void* userData);
+
+RDKIT_FMCS_EXPORT bool checkBondStereo(const MCSBondCompareParameters& p,
+                                       const ROMol& mol1, unsigned int bond1,
+                                       const ROMol& mol2, unsigned int bond2);
+RDKIT_FMCS_EXPORT bool checkBondRingMatch(const MCSBondCompareParameters &p,
+                                          const ROMol& mol1, unsigned int bond1,
+                                          const ROMol& mol2, unsigned int bond2,
+                                          void* v_ringMatchMatrixSet);
 
 RDKIT_FMCS_EXPORT bool MCSBondCompareAny(const MCSBondCompareParameters& p,
                                          const ROMol& mol1, unsigned int bond1,
@@ -106,6 +144,10 @@ struct RDKIT_FMCS_EXPORT MCSParameters {
   MCSFinalMatchCheckFunction FinalMatchChecker =
       nullptr;  // FinalMatchCheckFunction() to check chirality and ring fusion
   std::string InitialSeed = "";  // user defined or empty string (default)
+  void setMCSAtomTyperFromEnum(AtomComparator atomComp);
+  void setMCSAtomTyperFromConstChar(const char *atomComp);
+  void setMCSBondTyperFromEnum(BondComparator bondComp);
+  void setMCSBondTyperFromConstChar(const char *bondComp);
 };
 
 struct RDKIT_FMCS_EXPORT MCSResult {
@@ -114,7 +156,7 @@ struct RDKIT_FMCS_EXPORT MCSResult {
   std::string SmartsString;
   bool Canceled;  // interrupted by timeout or user defined progress callback.
                   // Contains valid current MCS !
-  RWMOL_SPTR QueryMol;
+  ROMOL_SPTR QueryMol;
 
  public:
   MCSResult() : NumAtoms(0), NumBonds(0), Canceled(false) {}
@@ -129,22 +171,6 @@ RDKIT_FMCS_EXPORT MCSResult findMCS(const std::vector<ROMOL_SPTR>& mols,
 RDKIT_FMCS_EXPORT MCSResult findMCS_P(const std::vector<ROMOL_SPTR>& mols,
                                       const char* params_json);
 
-typedef enum {
-  AtomCompareAny,
-  AtomCompareElements,
-  AtomCompareIsotopes,
-  AtomCompareAnyHeavyAtom
-} AtomComparator;
-typedef enum {
-  BondCompareAny,
-  BondCompareOrder,
-  BondCompareOrderExact
-} BondComparator;
-typedef enum {
-  IgnoreRingFusion,
-  PermissiveRingFusion,
-  StrictRingFusion
-} RingComparator;
 RDKIT_FMCS_EXPORT MCSResult findMCS(
     const std::vector<ROMOL_SPTR>& mols, bool maximizeBonds, double threshold,
     unsigned timeout, bool verbose, bool matchValences,

--- a/Code/GraphMol/FMCS/RingMatchTableSet.h
+++ b/Code/GraphMol/FMCS/RingMatchTableSet.h
@@ -171,7 +171,7 @@ class RDKIT_FMCS_EXPORT RingMatchTableSet {
             FMCS::SubstructMatchCustom(
                 graph2, *targetMolecule, graph1, *query, parameters.AtomTyper,
                 parameters.BondTyper, NULL, parameters.AtomCompareParameters,
-                bp, NULL);
+                bp, parameters.CompareFunctionsUserData);
 #endif
         if (match) m.setMatch(i, &*r2);
       }

--- a/Code/GraphMol/FMCS/Test/testFMCS.cpp
+++ b/Code/GraphMol/FMCS/Test/testFMCS.cpp
@@ -258,10 +258,11 @@ void testFileMCSB(
 #ifdef xxVERBOSE_STATISTICS_ON
   FILE* ft = fopen((outFile + ".stat.csv").c_str(), "wt");
   setvbuf(ft, 0, _IOFBF, 4 * 1024);  // small file
-  if (ft)
+  if (ft) {
     fprintf(ft,
             "N; Status; dAtoms; dBonds; t(sec); ref.t; Seed; MatchCall; "
             "AtomCmp; BondCmp\n");  // CSV Header
+  }
 #endif
   n = 0;
   p.Timeout = timeout;

--- a/Code/GraphMol/FMCS/Wrap/rdFMCS.cpp
+++ b/Code/GraphMol/FMCS/Wrap/rdFMCS.cpp
@@ -194,6 +194,7 @@ public:
     p->InitialSeed = value;
   }
   void setMCSAtomTyper(PyObject *atomComp) {
+    PRECONDITION(atomComp, "atomComp must not be NULL");
     python::object atomCompObject(python::handle<>(python::borrowed(atomComp)));
     python::extract<AtomComparator> extractAtomComparator(atomCompObject);
     if (extractAtomComparator.check()) {
@@ -253,6 +254,7 @@ public:
     return res;
   }
   void setMCSBondTyper(PyObject *bondComp) {
+    PRECONDITION(bondComp, "bondComp must not be NULL");
     python::object bondCompObject(python::handle<>(python::borrowed(bondComp)));
     python::extract<BondComparator> extractBondComparator(bondCompObject);
     if (extractBondComparator.check()) {
@@ -315,6 +317,7 @@ public:
     return res;
   }
   void setMCSProgressCallback(PyObject *progress) {
+    PRECONDITION(progress, "progress must not be NULL");
     python::object progressObject(python::handle<>(python::borrowed(progress)));
     python::extract<PyMCSProgress *> extractMCSProgress(progressObject);
     if (extractMCSProgress.check()) {
@@ -337,16 +340,19 @@ public:
     return python::object();
   }
   void clearRingTableCache() {
-    if (cfud->ringMatchTablesMols)
+    if (cfud->ringMatchTablesMols) {
       cfud->ringMatchTablesMols->clear();
-    if (cfud->ringMatchTables)
+    }
+    if (cfud->ringMatchTables) {
       cfud->ringMatchTables->clear();
+    }
   }
 private:
   static bool MCSAtomComparePyFunc(const MCSAtomCompareParameters& p,
                                    const ROMol& mol1, unsigned int atom1,
                                    const ROMol& mol2, unsigned int atom2,
                                    void* userData) {
+    PRECONDITION(userData, "userData must not be NULL");
     PyCompareFunctionUserData *cfud = static_cast<PyCompareFunctionUserData *>(userData);
     bool res = false;
     {
@@ -361,6 +367,7 @@ private:
                                    const ROMol& mol1, unsigned int bond1,
                                    const ROMol& mol2, unsigned int bond2,
                                    void* userData) {
+    PRECONDITION(userData, "userData must not be NULL");
     PyCompareFunctionUserData *cfud = static_cast<PyCompareFunctionUserData *>(userData);
     bool res = false;
     {
@@ -373,6 +380,7 @@ private:
   }
   static bool MCSProgressCallbackPyFunc(const MCSProgressData& stat,
                                         const MCSParameters& params, void* userData) {
+    PRECONDITION(userData, "userData must not be NULL");
     PyProgressCallbackUserData *pcud = static_cast<PyProgressCallbackUserData *>(userData);
     bool res = false;
     {

--- a/Code/GraphMol/FMCS/Wrap/rdFMCS.cpp
+++ b/Code/GraphMol/FMCS/Wrap/rdFMCS.cpp
@@ -11,41 +11,383 @@
 #include <GraphMol/ROMol.h>
 #include <RDBoost/Wrap.h>
 #include <GraphMol/FMCS/FMCS.h>
+#include <GraphMol/FMCS/RingMatchTableSet.h>
+
+#define COMPARE_FUNC_NAME "compare"
+#define CALLBACK_FUNC_NAME "callback"
 
 namespace python = boost::python;
 
 namespace RDKit {
 
-void SetMCSAtomTyper(MCSParameters &p, AtomComparator atomComp) {
-  switch (atomComp) {
-    case AtomCompareAny:
-      p.AtomTyper = MCSAtomCompareAny;
-      break;
-    case AtomCompareElements:
-      p.AtomTyper = MCSAtomCompareElements;
-      break;
-    case AtomCompareIsotopes:
-      p.AtomTyper = MCSAtomCompareIsotopes;
-      break;
-    case AtomCompareAnyHeavyAtom:
-      p.AtomTyper = MCSAtomCompareAnyHeavyAtom;
-      break;
+struct PyMCSAtomCompare {
+  inline bool checkAtomRingMatch(const MCSAtomCompareParameters& p,
+                                 const ROMol& mol1, unsigned int atom1,
+                                 const ROMol& mol2, unsigned int atom2) const {
+    return RDKit::checkAtomRingMatch(p, mol1, atom1, mol2, atom2);
   }
-}
+  inline bool checkAtomCharge(const MCSAtomCompareParameters& p,
+                              const ROMol& mol1, unsigned int atom1,
+                              const ROMol& mol2, unsigned int atom2) const {
+    return RDKit::checkAtomCharge(p, mol1, atom1, mol2, atom2);
+  }
+  inline bool checkAtomChirality(const MCSAtomCompareParameters& p,
+                                 const ROMol& mol1, unsigned int atom1,
+                                 const ROMol& mol2, unsigned int atom2) const {
+    return RDKit::checkAtomChirality(p, mol1, atom1, mol2, atom2);
+  }
+  virtual bool compare(const MCSAtomCompareParameters&,
+                       const ROMol&, unsigned int, const ROMol&, unsigned int) {
+    PyErr_SetString(PyExc_AttributeError,
+      "The " COMPARE_FUNC_NAME "() method "
+      "must be overridden in the rdFMCS.MCSAtomCompare subclass");
+    python::throw_error_already_set();
+    return false;
+  }
+};
 
-void SetMCSBondTyper(MCSParameters &p, BondComparator bondComp) {
-  switch (bondComp) {
-    case BondCompareAny:
-      p.BondTyper = MCSBondCompareAny;
-      break;
-    case BondCompareOrder:
-      p.BondTyper = MCSBondCompareOrder;
-      break;
-    case BondCompareOrderExact:
-      p.BondTyper = MCSBondCompareOrderExact;
-      break;
+struct PyMCSBondCompare {
+  inline bool checkBondStereo(const MCSBondCompareParameters& p,
+                              const ROMol& mol1, unsigned int bond1,
+                              const ROMol& mol2, unsigned int bond2) const {
+    return RDKit::checkBondStereo(p, mol1, bond1, mol2, bond2);
   }
-}
+  inline bool checkBondRingMatch(const MCSBondCompareParameters& p,
+                                 const ROMol& mol1, unsigned int bond1,
+                                 const ROMol& mol2, unsigned int bond2) {
+    if (!ringMatchTablesMols.count(&mol1)) {
+      ringMatchTables.init(&mol1);
+      ringMatchTables.computeRingMatchTable(&mol1, &mol1, *mcsParameters);
+      ringMatchTablesMols.insert(&mol1);
+    }
+    if (!ringMatchTablesMols.count(&mol2)) {
+      ringMatchTables.computeRingMatchTable(&mol1, &mol2, *mcsParameters);
+      ringMatchTables.addTargetBondRingsIndeces(&mol2);
+      ringMatchTablesMols.insert(&mol2);
+    }
+    return RDKit::checkBondRingMatch(p, mol1, bond1, mol2, bond2, &ringMatchTables);
+  }
+  virtual bool compare(const MCSBondCompareParameters&,
+                       const ROMol&, unsigned int, const ROMol&, unsigned int) {
+    PyErr_SetString(PyExc_AttributeError,
+      "The " COMPARE_FUNC_NAME "() method "
+      "must be overridden in the rdFMCS.MCSBondCompare subclass");
+    python::throw_error_already_set();
+    return false;
+  };
+  const MCSParameters *mcsParameters;
+  std::set<const ROMol *> ringMatchTablesMols;
+  FMCS::RingMatchTableSet ringMatchTables;
+};
+
+struct PyCompareFunctionUserData {
+  const MCSParameters *mcsParameters;
+  std::set<const ROMol *> *ringMatchTablesMols;
+  FMCS::RingMatchTableSet *ringMatchTables;
+  python::object pyAtomComp;
+  python::object pyBondComp;
+};
+
+struct PyProgressCallbackUserData {
+  const MCSProgressData *mcsProgressData;
+  python::object pyMCSProgress;
+  python::object pyAtomComp;
+  python::object pyBondComp;
+};
+
+struct PyMCSProgress {
+  virtual bool callback(const MCSProgressData&,
+                        const MCSParameters&) {
+    PyErr_SetString(PyExc_AttributeError,
+      "The " CALLBACK_FUNC_NAME "() method "
+      "must be overridden in the rdFMCS.MCSProgress subclass");
+    python::throw_error_already_set();
+    return false;
+  }
+};
+
+class PyMCSProgressData {
+public:
+  PyMCSProgressData() :
+    pd(new MCSProgressData()),
+    pcud(new PyProgressCallbackUserData()) {
+      pcud->mcsProgressData = pd.get();
+    }
+  PyMCSProgressData(const MCSProgressData &other) :
+    PyMCSProgressData() {
+      *pd = other;
+    }
+  unsigned int getNumAtoms() const {
+    return pd->NumAtoms;
+  }
+  unsigned int getNumBonds() const {
+    return pd->NumBonds;
+  }
+  unsigned int getSeedProcessed() const {
+    return pd->SeedProcessed;
+  }
+private:
+  std::unique_ptr<MCSProgressData> pd;
+  std::unique_ptr<PyProgressCallbackUserData> pcud;
+};
+
+class PyMCSParameters {
+public:
+  PyMCSParameters() :
+    p(new MCSParameters()),
+    cfud(new PyCompareFunctionUserData()),
+    pcud(new PyProgressCallbackUserData()) {
+      cfud->mcsParameters = p.get();
+      pcud->mcsProgressData = nullptr;
+    }
+  PyMCSParameters(const MCSParameters &other,
+                  const PyProgressCallbackUserData &pcudOther) :
+    PyMCSParameters() {
+      *p = other;
+      pcud->pyMCSProgress = pcudOther.pyMCSProgress;
+      cfud->pyAtomComp = pcudOther.pyAtomComp;
+      cfud->pyBondComp = pcudOther.pyBondComp;
+    }
+  const MCSParameters *get() const {
+    return p.get();
+  }
+  bool getMaximizeBonds() const {
+    return p->MaximizeBonds;
+  }
+  void setMaximizeBonds(bool value) {
+    p->MaximizeBonds = value;
+  }
+  double getThreshold() const {
+    return p->Threshold;
+  }
+  void setThreshold(double value) {
+    p->Threshold = value;
+  }
+  unsigned int getTimeout() const {
+    return p->Timeout;
+  }
+  void setTimeout(unsigned int value) {
+    p->Timeout = value;
+  }
+  bool getVerbose() const {
+    return p->Verbose;
+  }
+  void setVerbose(bool value) {
+    p->Verbose = value;
+  }
+  const MCSAtomCompareParameters& getAtomCompareParameters() const {
+    return p->AtomCompareParameters;
+  }
+  void setAtomCompareParameters(const MCSAtomCompareParameters &value) {
+    p->AtomCompareParameters = value;
+  }
+  const MCSBondCompareParameters& getBondCompareParameters() const {
+    return p->BondCompareParameters;
+  }
+  void setBondCompareParameters(const MCSBondCompareParameters &value) {
+    p->BondCompareParameters = value;
+  }
+  std::string getInitialSeed() const {
+    return p->InitialSeed;
+  }
+  void setInitialSeed(const std::string &value) {
+    p->InitialSeed = value;
+  }
+  void setMCSAtomTyper(PyObject *atomComp) {
+    python::object atomCompObject(python::handle<>(python::borrowed(atomComp)));
+    python::extract<AtomComparator> extractAtomComparator(atomCompObject);
+    if (extractAtomComparator.check()) {
+      AtomComparator ac(extractAtomComparator());
+      p->setMCSAtomTyperFromEnum(ac);
+    }
+    else {
+      python::extract<PyMCSAtomCompare *> extractPyMCSAtomCompare(atomCompObject);
+      if (extractPyMCSAtomCompare.check()) {
+        PyObject *callable = PyObject_GetAttrString(atomCompObject.ptr(), COMPARE_FUNC_NAME);
+        if (!callable) {
+          // should never get here
+          PyErr_SetString(PyExc_AttributeError,
+            "The " COMPARE_FUNC_NAME "() method must be defined "
+            "in the rdFMCS.MCSAtomCompare subclass");
+          python::throw_error_already_set();
+        }
+        if (!PyCallable_Check(callable)) {
+          PyErr_SetString(PyExc_TypeError,
+            "The " COMPARE_FUNC_NAME " attribute in the "
+            "rdFMCS.MCSAtomCompare subclass is not a callable method");
+          python::throw_error_already_set();
+        }
+        p->CompareFunctionsUserData = cfud.get();
+        p->AtomTyper = MCSAtomComparePyFunc;
+        cfud->pyAtomComp = atomCompObject;
+        cfud->mcsParameters = p.get();
+      }
+      else {
+        PyErr_SetString(PyExc_TypeError,
+          "expected an instance of a rdFMCS.MCSAtomCompare subclass "
+          "or a member of the AtomCompare class");
+        python::throw_error_already_set();
+      }
+    }
+  }
+  python::object getMCSAtomTyper() {
+    static const std::map<RDKit::MCSAtomCompareFunction,
+                          RDKit::AtomComparator> atomTyperToComp = {
+      { MCSAtomCompareAny, AtomCompareAny },
+      { MCSAtomCompareElements, AtomCompareElements },
+      { MCSAtomCompareIsotopes, AtomCompareIsotopes },
+      { MCSAtomCompareAnyHeavyAtom, AtomCompareAnyHeavyAtom }
+    };
+    if (!cfud->pyAtomComp.is_none()) {
+      return cfud->pyAtomComp;
+    }
+    python::object res;
+    try {
+      res = python::object(atomTyperToComp.at(p->AtomTyper));
+    }
+    catch(const std::out_of_range&) {
+      PyErr_SetString(PyExc_TypeError,
+        "Unknown AtomTyper");
+      python::throw_error_already_set();
+    }
+    return res;
+  }
+  void setMCSBondTyper(PyObject *bondComp) {
+    python::object bondCompObject(python::handle<>(python::borrowed(bondComp)));
+    python::extract<BondComparator> extractBondComparator(bondCompObject);
+    if (extractBondComparator.check()) {
+      BondComparator bc(extractBondComparator());
+      p->setMCSBondTyperFromEnum(bc);
+    }
+    else {
+      python::extract<PyMCSBondCompare *> extractPyMCSBondCompare(bondCompObject);
+      if (extractPyMCSBondCompare.check()) {
+        PyObject *callable = PyObject_GetAttrString(bondCompObject.ptr(), COMPARE_FUNC_NAME);
+        if (!callable) {
+          // should never get here
+          PyErr_SetString(PyExc_AttributeError,
+            "The " COMPARE_FUNC_NAME "() method must be defined "
+            "in the rdFMCS.MCSBondCompare subclass");
+          python::throw_error_already_set();
+        }
+        if (!PyCallable_Check(callable)) {
+          PyErr_SetString(PyExc_TypeError,
+            "The " COMPARE_FUNC_NAME " attribute in the "
+            "rdFMCS.MCSBondCompare subclass is not a callable method");
+          python::throw_error_already_set();
+        }
+        p->CompareFunctionsUserData = cfud.get();
+        p->BondTyper = MCSBondComparePyFunc;
+        cfud->pyBondComp = bondCompObject;
+        PyMCSBondCompare *bc = extractPyMCSBondCompare();
+        bc->mcsParameters = p.get();
+        cfud->mcsParameters = p.get();
+        cfud->ringMatchTablesMols = &bc->ringMatchTablesMols;
+        cfud->ringMatchTables = &bc->ringMatchTables;
+      }
+      else {
+        PyErr_SetString(PyExc_TypeError,
+          "expected an instance of a rdFMCS.MCSBondCompare subclass "
+          "or a member of the BondCompare class");
+        python::throw_error_already_set();
+      }
+    }
+  }
+  python::object getMCSBondTyper() {
+    static const std::map<RDKit::MCSBondCompareFunction,
+                          RDKit::BondComparator> bondTyperToComp = {
+      { MCSBondCompareAny, BondCompareAny },
+      { MCSBondCompareOrder, BondCompareOrder },
+      { MCSBondCompareOrderExact, BondCompareOrderExact }
+    };
+    if (!cfud->pyBondComp.is_none()) {
+      return cfud->pyBondComp;
+    }
+    python::object res;
+    try {
+      res = python::object(bondTyperToComp.at(p->BondTyper));
+    }
+    catch(const std::out_of_range&) {
+      PyErr_SetString(PyExc_TypeError,
+        "Unknown BondTyper");
+      python::throw_error_already_set();
+    }
+    return res;
+  }
+  void setMCSProgressCallback(PyObject *progress) {
+    python::object progressObject(python::handle<>(python::borrowed(progress)));
+    python::extract<PyMCSProgress *> extractMCSProgress(progressObject);
+    if (extractMCSProgress.check()) {
+      p->ProgressCallbackUserData = pcud.get();
+      p->ProgressCallback = MCSProgressCallbackPyFunc;
+      pcud->pyMCSProgress = progressObject;
+      pcud->pyAtomComp = cfud->pyAtomComp;
+      pcud->pyBondComp = cfud->pyBondComp;
+    }
+    else {
+      PyErr_SetString(PyExc_TypeError,
+        "expected an instance of a rdFMCS.MCSProgress subclass");
+      python::throw_error_already_set();
+    }
+  }
+  python::object getMCSProgressCallback() {
+    if (!pcud->pyMCSProgress.is_none()) {
+      return pcud->pyMCSProgress;
+    }
+    return python::object();
+  }
+  void clearRingTableCache() {
+    if (cfud->ringMatchTablesMols)
+      cfud->ringMatchTablesMols->clear();
+    if (cfud->ringMatchTables)
+      cfud->ringMatchTables->clear();
+  }
+private:
+  static bool MCSAtomComparePyFunc(const MCSAtomCompareParameters& p,
+                                   const ROMol& mol1, unsigned int atom1,
+                                   const ROMol& mol2, unsigned int atom2,
+                                   void* userData) {
+    PyCompareFunctionUserData *cfud = static_cast<PyCompareFunctionUserData *>(userData);
+    bool res = false;
+    {
+      PyGILStateHolder h;
+      res = python::call_method<bool>(cfud->pyAtomComp.ptr(), COMPARE_FUNC_NAME,
+                                      boost::ref(p), boost::ref(mol1),
+                                      atom1, boost::ref(mol2), atom2);
+    }
+    return res;
+  }
+  static bool MCSBondComparePyFunc(const MCSBondCompareParameters& p,
+                                   const ROMol& mol1, unsigned int bond1,
+                                   const ROMol& mol2, unsigned int bond2,
+                                   void* userData) {
+    PyCompareFunctionUserData *cfud = static_cast<PyCompareFunctionUserData *>(userData);
+    bool res = false;
+    {
+      PyGILStateHolder h;
+      res = python::call_method<bool>(cfud->pyBondComp.ptr(), COMPARE_FUNC_NAME,
+                                      boost::ref(p), boost::ref(mol1),
+                                      bond1, boost::ref(mol2), bond2);
+    }
+    return res;
+  }
+  static bool MCSProgressCallbackPyFunc(const MCSProgressData& stat,
+                                        const MCSParameters& params, void* userData) {
+    PyProgressCallbackUserData *pcud = static_cast<PyProgressCallbackUserData *>(userData);
+    bool res = false;
+    {
+      PyMCSParameters ps(params, *pcud);
+      PyMCSProgressData pd(stat);
+      PyGILStateHolder h;
+      res = python::call_method<bool>(pcud->pyMCSProgress.ptr(), CALLBACK_FUNC_NAME,
+                                      boost::ref(pd), boost::ref(ps));
+    }
+    return res;
+  }
+  std::unique_ptr<MCSParameters> p;
+  std::unique_ptr<PyCompareFunctionUserData> cfud;
+  std::unique_ptr<PyProgressCallbackUserData> pcud;
+};
 
 MCSResult *FindMCSWrapper(python::object mols, bool maximizeBonds,
                           double threshold, unsigned timeout, bool verbose,
@@ -71,8 +413,8 @@ MCSResult *FindMCSWrapper(python::object mols, bool maximizeBonds,
   p.AtomCompareParameters.MatchValences = matchValences;
   p.AtomCompareParameters.MatchChiralTag = matchChiralTag;
   p.AtomCompareParameters.RingMatchesRingOnly = ringMatchesRingOnly;
-  SetMCSAtomTyper(p, atomComp);
-  SetMCSBondTyper(p, bondComp);
+  p.setMCSAtomTyperFromEnum(atomComp);
+  p.setMCSBondTyperFromEnum(bondComp);
   p.BondCompareParameters.RingMatchesRingOnly = ringMatchesRingOnly;
   p.BondCompareParameters.CompleteRingsOnly = completeRingsOnly;
   p.BondCompareParameters.MatchFusedRings = (ringComp != IgnoreRingFusion);
@@ -86,7 +428,7 @@ MCSResult *FindMCSWrapper(python::object mols, bool maximizeBonds,
   return res;
 }
 
-MCSResult *FindMCSWrapper2(python::object mols, const MCSParameters &params) {
+MCSResult *FindMCSWrapper2(python::object mols, PyMCSParameters &pyMcsParams) {
   std::vector<ROMOL_SPTR> ms;
   unsigned int nElems = python::extract<unsigned int>(mols.attr("__len__")());
   ms.resize(nElems);
@@ -98,9 +440,10 @@ MCSResult *FindMCSWrapper2(python::object mols, const MCSParameters &params) {
   }
 
   MCSResult *res = nullptr;
+  pyMcsParams.clearRingTableCache();
   {
     NOGIL gil;
-    res = new MCSResult(findMCS(ms, &params));
+    res = new MCSResult(findMCS(ms, pyMcsParams.get()));
   }
   return res;
 }
@@ -159,40 +502,71 @@ BOOST_PYTHON_MODULE(rdFMCS) {
       python::return_value_policy<python::manage_new_object>(),
       docString.c_str());
 
-  python::class_<RDKit::MCSParameters, boost::noncopyable>(
+  python::class_<RDKit::PyMCSParameters, boost::noncopyable>(
       "MCSParameters", "Parameters controlling how the MCS is constructed")
-      .def_readwrite("MaximizeBonds", &RDKit::MCSParameters::MaximizeBonds,
-                     "toggles maximizing the number of bonds (instead of the "
-                     "number of atoms)")
-      .def_readwrite("Threshold", &RDKit::MCSParameters::Threshold,
-                     "fraction of the dataset that must contain the MCS")
-      .def_readwrite("Timeout", &RDKit::MCSParameters::Timeout,
-                     "timeout (in seconds) for the calculation")
-      .def_readwrite("Verbose", &RDKit::MCSParameters::Verbose,
-                     "toggles verbose mode")
-      .def_readwrite("AtomCompareParameters",
-                     &RDKit::MCSParameters::AtomCompareParameters,
-                     "parameters for comparing atoms")
-      .def_readwrite("BondCompareParameters",
-                     &RDKit::MCSParameters::BondCompareParameters,
-                     "parameters for comparing bonds")
-      // haven't been able to get these properly working
-      // .def_readwrite("AtomTyper", &RDKit::MCSParameters::AtomTyper,
-      //                "function for comparing atoms")
-      // .def_readwrite("BondTyper", &RDKit::MCSParameters::BondTyper,
-      //                "function for comparing bonds")
-      .def_readwrite("InitialSeed", &RDKit::MCSParameters::InitialSeed,
-                     "SMILES string to be used as the seed of the MCS")
-      .def("SetAtomTyper", RDKit::SetMCSAtomTyper,
+      .add_property("MaximizeBonds",
+                    &RDKit::PyMCSParameters::getMaximizeBonds,
+                    &RDKit::PyMCSParameters::setMaximizeBonds,
+                    "toggles maximizing the number of bonds (instead of the "
+                    "number of atoms)")
+      .add_property("Threshold",
+                    &RDKit::PyMCSParameters::getThreshold,
+                    &RDKit::PyMCSParameters::setThreshold,
+                    "fraction of the dataset that must contain the MCS")
+      .add_property("Timeout",
+                    &RDKit::PyMCSParameters::getTimeout,
+                    &RDKit::PyMCSParameters::setTimeout,
+                    "timeout (in seconds) for the calculation")
+      .add_property("Verbose",
+                    &RDKit::PyMCSParameters::getVerbose,
+                    &RDKit::PyMCSParameters::setVerbose,
+                    "toggles verbose mode")
+      .add_property("AtomCompareParameters", python::make_function(
+                    &RDKit::PyMCSParameters::getAtomCompareParameters,
+                    python::return_internal_reference<>()),
+                    &RDKit::PyMCSParameters::setAtomCompareParameters,
+                    "parameters for comparing atoms")
+      .add_property("BondCompareParameters", python::make_function(
+                    &RDKit::PyMCSParameters::getBondCompareParameters,
+                    python::return_internal_reference<>()),
+                    &RDKit::PyMCSParameters::setBondCompareParameters,
+                    "parameters for comparing bonds")
+      .add_property("AtomTyper",
+                    &RDKit::PyMCSParameters::getMCSAtomTyper,
+                    &RDKit::PyMCSParameters::setMCSAtomTyper,
+                    "atom typer to be used. Must be one of the "
+                    "members of the rdFMCS.AtomCompare class or "
+                    "an instance of a user-defined subclass of "
+                    "rdFMCS.MCSAtomCompare")
+      .add_property("BondTyper",
+                    &RDKit::PyMCSParameters::getMCSBondTyper,
+                    &RDKit::PyMCSParameters::setMCSBondTyper,
+                    "bond typer to be used. Must be one of the "
+                    "members of the rdFMCS.BondCompare class or "
+                    "an instance of a user-defined subclass of "
+                    "rdFMCS.MCSBondCompare")
+      .add_property("ProgressCallback",
+                    &RDKit::PyMCSParameters::getMCSProgressCallback,
+                    &RDKit::PyMCSParameters::setMCSProgressCallback,
+                    "progress callback class. Must be a "
+                    "user-defined subclass of rdFMCS.Progress")
+      .add_property("InitialSeed",
+                    &RDKit::PyMCSParameters::getInitialSeed,
+                    &RDKit::PyMCSParameters::setInitialSeed,
+                    "SMILES string to be used as the seed of the MCS")
+      .def("SetAtomTyper", &RDKit::PyMCSParameters::setMCSAtomTyper,
            (python::arg("self"), python::arg("comparator")),
-           "sets the atom typer to be used. The argument should be one of the "
-           "members of the rdFMCS.AtomCompare class.")
-      .def("SetBondTyper", RDKit::SetMCSBondTyper,
+           "DEPRECATED: please use the AtomTyper property instead. "
+           "Sets the atom typer to be used. The argument must be one "
+           "of the members of the rdFMCS.MCSAtomCompare class or an "
+           "instance of a user-defined subclass of rdFMCS.MCSAtomCompare")
+      .def("SetBondTyper", &RDKit::PyMCSParameters::setMCSBondTyper,
            (python::arg("self"), python::arg("comparator")),
-           "sets the bond typer to be used. The argument should be one of the "
-           "members of the rdFMCS.BondCompare class.");
+           "DEPRECATED: please use the BondTyper property instead. "
+           "Sets the bond typer to be used. The argument must be one "
+           "of the members of the rdFMCS.MCSBondCompare class or an "
+           "instance of a user-defined subclass of rdFMCS.MCSBondCompare");
 
-  ;
   python::class_<RDKit::MCSAtomCompareParameters, boost::noncopyable>(
       "MCSAtomCompareParameters",
       "Parameters controlling how atom-atom matching is done")
@@ -207,7 +581,11 @@ BOOST_PYTHON_MODULE(rdFMCS) {
                      "include formal charge in the match")
       .def_readwrite("RingMatchesRingOnly",
                      &RDKit::MCSAtomCompareParameters::RingMatchesRingOnly,
-                     "ring atoms are only allowed to match other ring atoms");
+                     "ring atoms are only allowed to match other ring atoms")
+      .def_readwrite("MatchIsotope",
+                     &RDKit::MCSAtomCompareParameters::MatchIsotope,
+                     "use isotope atom queries in MCSResults");
+
   python::class_<RDKit::MCSBondCompareParameters, boost::noncopyable>(
       "MCSBondCompareParameters",
       "Parameters controlling how bond-bond matching is done")
@@ -231,7 +609,71 @@ BOOST_PYTHON_MODULE(rdFMCS) {
                      &RDKit::MCSBondCompareParameters::MatchStereo,
                      "include bond stereo in the comparison");
 
-  docString = "Find the MCS for a set of molecules";
+  python::class_<RDKit::PyMCSProgress, boost::noncopyable>(
+      "MCSProgress", "Base class. Subclass and override "
+      "MCSProgress." CALLBACK_FUNC_NAME "callback() "
+      "to define a custom callback function")
+      .def(CALLBACK_FUNC_NAME, &RDKit::PyMCSProgress::callback,
+           (python::arg("self"), python::arg("stat"),
+              python::arg("parameters")),
+              "override to implement a custom progress callback");
+
+  python::class_<RDKit::PyMCSProgressData, boost::noncopyable>(
+      "MCSProgressData", "Information about the MCS progress")
+      .add_property("numAtoms", &RDKit::PyMCSProgressData::getNumAtoms,
+                    "number of atoms in MCS")
+      .add_property("numBonds", &RDKit::PyMCSProgressData::getNumBonds,
+                    "number of bonds in MCS")
+      .add_property("seedProcessed", &RDKit::PyMCSProgressData::getSeedProcessed,
+                    "number of processed seeds");
+
+  python::class_<RDKit::PyMCSAtomCompare, boost::noncopyable>(
+      "MCSAtomCompare", "Base class. Subclass and override "
+      "MCSAtomCompare." COMPARE_FUNC_NAME "() to define custom "
+      "atom compare functions, then set MCSParameters.AtomTyper "
+      "to an instance of the subclass")
+      .def("CheckAtomRingMatch", &RDKit::PyMCSAtomCompare::checkAtomRingMatch,
+           (python::arg("self"), python::arg("parameters"),
+              python::arg("mol1"), python::arg("atom1"),
+              python::arg("mol2"), python::arg("atom2")),
+              "Return True if both atoms are, or are not, in a ring")
+      .def("CheckAtomCharge", &RDKit::PyMCSAtomCompare::checkAtomCharge,
+           (python::arg("self"), python::arg("parameters"),
+              python::arg("mol1"), python::arg("atom1"),
+              python::arg("mol2"), python::arg("atom2")),
+              "Return True if both atoms have the same formal charge")
+      .def("CheckAtomChirality", &RDKit::PyMCSAtomCompare::checkAtomChirality,
+           (python::arg("self"), python::arg("parameters"),
+              python::arg("mol1"), python::arg("atom1"),
+              python::arg("mol2"), python::arg("atom2")),
+              "Return True if both atoms have, or have not, a chiral tag")
+      .def(COMPARE_FUNC_NAME, &RDKit::PyMCSAtomCompare::compare,
+           (python::arg("self"), python::arg("parameters"),
+              python::arg("mol1"), python::arg("atom1"),
+              python::arg("mol2"), python::arg("atom2")),
+              "override to implement custom atom comparison");
+
+  python::class_<RDKit::PyMCSBondCompare, boost::noncopyable>(
+      "MCSBondCompare", "Base class. Subclass and override "
+      "MCSBondCompare." COMPARE_FUNC_NAME "() to define custom "
+      "bond compare functions, then set MCSParameters.BondTyper "
+      "to an instance of the subclass")
+      .def("CheckBondStereo", &RDKit::PyMCSBondCompare::checkBondStereo,
+           (python::arg("self"), python::arg("parameters"),
+              python::arg("mol1"), python::arg("bond1"),
+              python::arg("mol2"), python::arg("bond2")),
+              "Return True if both bonds have, or have not, a stereo descriptor")
+      .def("CheckBondRingMatch", &RDKit::PyMCSBondCompare::checkBondRingMatch,
+           (python::arg("self"), python::arg("parameters"),
+              python::arg("mol1"), python::arg("bond1"),
+              python::arg("mol2"), python::arg("bond2")),
+              "Return True if both bonds are, or are not, part of a ring")
+      .def(COMPARE_FUNC_NAME, &RDKit::PyMCSBondCompare::compare,
+           (python::arg("self"), python::arg("parameters"),
+              python::arg("mol1"), python::arg("bond1"),
+              python::arg("mol2"), python::arg("bond2")),
+              "override to implement custom bond comparison");
+
   python::def("FindMCS", RDKit::FindMCSWrapper2,
               (python::arg("mols"), python::arg("parameters")),
               python::return_value_policy<python::manage_new_object>(),

--- a/Code/GraphMol/FMCS/Wrap/testFMCS.py
+++ b/Code/GraphMol/FMCS/Wrap/testFMCS.py
@@ -1,17 +1,201 @@
-from rdkit import RDConfig
-import os
-import sys
 import unittest
 from rdkit import Chem
 from rdkit.Chem import rdFMCS
 
 
-class TestCase(unittest.TestCase):
+class BondMatchOrderMatrix:
+    def __init__(self, ignoreAromatization):
+        self.MatchMatrix = [[False]*(Chem.BondType.ZERO + 1)
+                            for i in range(Chem.BondType.ZERO + 1)]
+        for i in range(Chem.BondType.ZERO + 1):
+            # fill cells of the same and unspecified type
+            self.MatchMatrix[i][i] = True
+            self.MatchMatrix[Chem.BondType.UNSPECIFIED][i] = \
+                self.MatchMatrix[i][Chem.BondType.UNSPECIFIED] = True
+            self.MatchMatrix[Chem.BondType.ZERO][i] = \
+                self.MatchMatrix[i][Chem.BondType.ZERO] = True
+        if ignoreAromatization:
+            self.MatchMatrix[Chem.BondType.SINGLE][Chem.BondType.AROMATIC] = \
+                self.MatchMatrix[Chem.BondType.AROMATIC][Chem.BondType.SINGLE] = True
+            self.MatchMatrix[Chem.BondType.DOUBLE][Chem.BondType.AROMATIC] = \
+                self.MatchMatrix[Chem.BondType.AROMATIC][Chem.BondType.DOUBLE] = True
+        self.MatchMatrix[Chem.BondType.SINGLE][Chem.BondType.ONEANDAHALF] = \
+            self.MatchMatrix[Chem.BondType.ONEANDAHALF][Chem.BondType.SINGLE] = True
+        self.MatchMatrix[Chem.BondType.DOUBLE][Chem.BondType.TWOANDAHALF] = \
+            self.MatchMatrix[Chem.BondType.TWOANDAHALF][Chem.BondType.DOUBLE] = True
+        self.MatchMatrix[Chem.BondType.TRIPLE][Chem.BondType.THREEANDAHALF] = \
+            self.MatchMatrix[Chem.BondType.THREEANDAHALF][Chem.BondType.TRIPLE] = True
+        self.MatchMatrix[Chem.BondType.QUADRUPLE][Chem.BondType.FOURANDAHALF] = \
+            self.MatchMatrix[Chem.BondType.FOURANDAHALF][Chem.BondType.QUADRUPLE] = True
+        self.MatchMatrix[Chem.BondType.QUINTUPLE][Chem.BondType.FIVEANDAHALF] = \
+            self.MatchMatrix[Chem.BondType.FIVEANDAHALF][Chem.BondType.QUINTUPLE] = True
+    def isEqual(self, i, j):
+        return self.MatchMatrix[i][j]
 
-    def setUp(self):
-        pass
+class CompareAny(rdFMCS.MCSAtomCompare):
+    def compare(self, p, mol1, atom1, mol2, atom2):
+        if (p.MatchChiralTag and not self.CheckAtomChirality(p, mol1, atom1, mol2, atom2)):
+            return False
+        if (p.MatchFormalCharge and not self.CheckAtomCharge(p, mol1, atom1, mol2, atom2)):
+            return False
+        if (p.RingMatchesRingOnly):
+            return self.CheckAtomRingMatch(p, mol1, atom1, mol2, atom2)
+        return True
 
-    def test1(self):
+class CompareAnyHeavyAtom(CompareAny):
+    def compare(self, p, mol1, atom1, mol2, atom2):
+        a1 = mol1.GetAtomWithIdx(atom1)
+        a2 = mol2.GetAtomWithIdx(atom2)
+        # Any atom, including H, matches another atom of the same type,  according to
+        # the other flags
+        if (a1.GetAtomicNum() == a2.GetAtomicNum() or
+            (a1.GetAtomicNum() > 1 and a2.GetAtomicNum() > 1)):
+            return CompareAny.compare(self, p, mol1, atom1, mol2, atom2)
+        return False
+
+class CompareElements(rdFMCS.MCSAtomCompare):
+    def compare(self, p, mol1, atom1, mol2, atom2):
+        a1 = mol1.GetAtomWithIdx(atom1)
+        a2 = mol2.GetAtomWithIdx(atom2)
+        if (a1.GetAtomicNum() != a2.GetAtomicNum()):
+            return False
+        if (p.MatchValences and a1.GetTotalValence() != a2.GetTotalValence()):
+            return False
+        if (p.MatchChiralTag and not self.CheckAtomChirality(p, mol1, atom1, mol2, atom2)):
+            return False
+        if (p.MatchFormalCharge and not self.CheckAtomCharge(p, mol1, atom1, mol2, atom2)):
+            return False
+        if p.RingMatchesRingOnly:
+            return self.CheckAtomRingMatch(p, mol1, atom1, mol2, atom2)
+        return True
+
+class CompareIsotopes(rdFMCS.MCSAtomCompare):
+    def compare(self, p, mol1, atom1, mol2, atom2):
+        a1 = mol1.GetAtomWithIdx(atom1)
+        a2 = mol2.GetAtomWithIdx(atom2)
+        if (a1.GetIsotope() != a2.GetIsotope()):
+            return False
+        if (p.MatchChiralTag and not self.CheckAtomChirality(p, mol1, atom1, mol2, atom2)):
+            return False
+        if (p.MatchFormalCharge and not self.CheckAtomCharge(p, mol1, atom1, mol2, atom2)):
+            return False
+        if p.RingMatchesRingOnly:
+            return self.CheckAtomRingMatch(p, mol1, atom1, mol2, atom2)
+        return True
+
+class CompareOrder(rdFMCS.MCSBondCompare):
+    match = BondMatchOrderMatrix(True)  # ignore Aromatization
+    def compare(self, p, mol1, bond1, mol2, bond2):
+        b1 = mol1.GetBondWithIdx(bond1)
+        b2 = mol2.GetBondWithIdx(bond2)
+        t1 = b1.GetBondType()
+        t2 = b2.GetBondType()
+        if self.match.isEqual(t1, t2):
+            if (p.MatchStereo and not self.CheckBondStereo(p, mol1, bond1, mol2, bond2)):
+                return False
+            if p.RingMatchesRingOnly:
+                return self.CheckBondRingMatch(p, mol1, bond1, mol2, bond2)
+            return True
+        return False
+
+class AtomCompareCompareIsInt(rdFMCS.MCSAtomCompare):
+    compare = 1
+
+class AtomCompareNoCompare(rdFMCS.MCSAtomCompare):
+    pass
+
+class AtomCompareUserData(rdFMCS.MCSAtomCompare):
+    def __init__(self):
+        super().__init__()
+        self._matchAnyHet = False
+    def setMatchAnyHet(self, v):
+        self._matchAnyHet = v
+    def compare(self, p, mol1, atom1, mol2, atom2):
+        a1 = mol1.GetAtomWithIdx(atom1)
+        a2 = mol2.GetAtomWithIdx(atom2)
+        if (a1.GetAtomicNum() != a2.GetAtomicNum() and
+            ((not self._matchAnyHet) or
+            a1.GetAtomicNum() == 6 or
+            a2.GetAtomicNum() == 6)):
+            return False
+        if (p.MatchValences and a1.GetTotalValence() != a2.GetTotalValence()):
+            return False
+        if (p.MatchChiralTag and not self.CheckAtomChirality(p, mol1, atom1, mol2, atom2)):
+            return False
+        if (p.MatchFormalCharge and not self.CheckAtomCharge(p, mol1, atom1, mol2, atom2)):
+            return False
+        if p.RingMatchesRingOnly:
+            return self.CheckAtomRingMatch(p, mol1, atom1, mol2, atom2)
+        return True
+
+class BondCompareCompareIsInt(rdFMCS.MCSBondCompare):
+    compare = 1
+
+class BondCompareNoCompare(rdFMCS.MCSBondCompare):
+    pass
+
+class BondCompareUserData(rdFMCS.MCSBondCompare):
+    def __init__(self):
+        super().__init__()
+        self.match = None
+    def setIgnoreAromatization(self, v):
+        self.match = BondMatchOrderMatrix(v)
+    def compare(self, p, mol1, bond1, mol2, bond2):
+        b1 = mol1.GetBondWithIdx(bond1)
+        b2 = mol2.GetBondWithIdx(bond2)
+        t1 = b1.GetBondType()
+        t2 = b2.GetBondType()
+        if self.match.isEqual(t1, t2):
+            if (p.MatchStereo and not self.CheckBondStereo(p, mol1, bond1, mol2, bond2)):
+                return False
+            if p.RingMatchesRingOnly:
+                return self.CheckBondRingMatch(p, mol1, bond1, mol2, bond2)
+            return True
+        return False
+
+class ProgressCallbackCallbackIsInt(rdFMCS.MCSProgress):
+    callback = 1
+
+class ProgressCallbackNoCallback(rdFMCS.MCSProgress):
+    pass
+
+class ProgressCallback(rdFMCS.MCSProgress):
+    def __init__(self, parent):
+        super().__init__()
+        self.parent = parent
+        self.callCount = 0
+    def callback(self, stat, params):
+        self.callCount += 1
+        self.parent.assertTrue(isinstance(stat, rdFMCS.MCSProgressData))
+        self.parent.assertTrue(hasattr(stat, "numAtoms"))
+        self.parent.assertTrue(isinstance(stat.numAtoms, int))
+        self.parent.assertTrue(hasattr(stat, "numBonds"))
+        self.parent.assertTrue(isinstance(stat.numBonds, int))
+        self.parent.assertTrue(hasattr(stat, "seedProcessed"))
+        self.parent.assertTrue(isinstance(stat.seedProcessed, int))
+        self.parent.assertTrue(isinstance(params, rdFMCS.MCSParameters))
+        self.parent.assertTrue(isinstance(params.AtomTyper, rdFMCS.MCSAtomCompare))
+        self.parent.assertTrue(isinstance(params.BondTyper, rdFMCS.BondCompare))
+        self.parent.assertEqual(params.ProgressCallback, self)
+        return (self.callCount < 3)
+
+class Common:
+    @staticmethod
+    def getParams(**kwargs):
+        have_kw = False
+        params = rdFMCS.MCSParameters()
+        for kw in ("AtomTyper", "BondTyper"):
+            try:
+                v = kwargs[kw]
+            except KeyError:
+                pass
+            else:
+                have_kw = True
+                setattr(params, kw, v())
+        return params
+
+    @staticmethod
+    def test1(self, **kwargs):
         smis = (
           "Cc1nc(CN(C(C)c2ncccc2)CCCCN)ccc1 CHEMBL1682991",  # -- QUERY
           "Cc1ccc(CN(C(C)c2ccccn2)CCCCN)nc1 CHEMBL1682990",
@@ -27,7 +211,11 @@ class TestCase(unittest.TestCase):
         ms = [Chem.MolFromSmiles(x.split()[0]) for x in smis]
         qm = ms[0]
         ms = ms[1:]
-        mcs = rdFMCS.FindMCS(ms)
+        if kwargs:
+            params = Common.getParams(**kwargs)
+            mcs = rdFMCS.FindMCS(ms, params)
+        else:
+            mcs = rdFMCS.FindMCS(ms)
         self.assertEqual(mcs.numBonds, 21)
         self.assertEqual(mcs.numAtoms, 21)
         self.assertEqual(
@@ -39,7 +227,12 @@ class TestCase(unittest.TestCase):
         for m in ms:
             self.assertTrue(m.HasSubstructMatch(qm))
 
-        mcs = rdFMCS.FindMCS(ms, threshold=0.8)
+        if kwargs:
+            params = Common.getParams(**kwargs)
+            params.Threshold = 0.8
+            mcs = rdFMCS.FindMCS(ms, params)
+        else:
+            mcs = rdFMCS.FindMCS(ms, threshold=0.8)
         self.assertEqual(mcs.numBonds, 21)
         self.assertEqual(mcs.numAtoms, 21)
         self.assertEqual(
@@ -51,7 +244,7 @@ class TestCase(unittest.TestCase):
         for m in ms:
             self.assertTrue(m.HasSubstructMatch(qm))
 
-    def test2(self):
+    def test2(self, **kwargs):
         smis = (
           "CHEMBL122452 CN(CCCN(C)CCc1ccccc1)CCOC(c1ccccc1)c1ccccc1",
           "CHEMBL123252 CN(CCCc1ccccc1)CCCN(C)CCOC(c1ccccc1)c1ccccc1",
@@ -70,7 +263,11 @@ class TestCase(unittest.TestCase):
         ms = [Chem.MolFromSmiles(x.split()[1]) for x in smis]
         qm = ms[0]
         ms = ms[1:]
-        mcs = rdFMCS.FindMCS(ms)
+        if kwargs:
+            params = Common.getParams(**kwargs)
+            mcs = rdFMCS.FindMCS(ms, params)
+        else:
+            mcs = rdFMCS.FindMCS(ms)
         self.assertEqual(mcs.numBonds, 9)
         self.assertEqual(mcs.numAtoms, 10)
         qm = Chem.MolFromSmarts(mcs.smartsString)
@@ -80,7 +277,12 @@ class TestCase(unittest.TestCase):
         # smarts too hard to canonicalize this
         # self.assertEqual(mcs.smartsString,'[#6]-,:[#6]-,:[#6]-,:[#6]-,:[#6](-[#6]-[#8]-[#6]:,-[#6])-,:[#6]')
 
-        mcs = rdFMCS.FindMCS(ms, threshold=0.8)
+        if kwargs:
+            params = Common.getParams(**kwargs)
+            params.Threshold = 0.8
+            mcs = rdFMCS.FindMCS(ms, params)
+        else:
+            mcs = rdFMCS.FindMCS(ms, threshold=0.8)
         self.assertEqual(mcs.numBonds, 20)
         self.assertEqual(mcs.numAtoms, 19)
         qm = Chem.MolFromSmarts(mcs.smartsString)
@@ -93,19 +295,29 @@ class TestCase(unittest.TestCase):
         # smarts too hard to canonicalize this
         # self.assertEqual(mcs.smartsString,'[#6]1:[#6]:[#6]:[#6](:[#6]:[#6]:1)-[#6](-[#8]-[#6]-[#6]-[#7]-[#6]-[#6])-[#6]2:[#6]:[#6]:[#6]:[#6]:[#6]:2')
 
-    def test3IsotopeMatch(self):
+    def test3IsotopeMatch(self, **kwargs):
         smis = (
           "CC[14NH2]",
           "CC[14CH3]",
         )
 
         ms = [Chem.MolFromSmiles(x) for x in smis]
-        mcs = rdFMCS.FindMCS(ms)
+        if kwargs:
+            params = Common.getParams(**kwargs)
+            mcs = rdFMCS.FindMCS(ms, params)
+        else:
+            mcs = rdFMCS.FindMCS(ms)
         self.assertEqual(mcs.numBonds, 1)
         self.assertEqual(mcs.numAtoms, 2)
         qm = Chem.MolFromSmarts(mcs.smartsString)
 
-        mcs = rdFMCS.FindMCS(ms, atomCompare=rdFMCS.AtomCompare.CompareIsotopes)
+        if kwargs:
+            params = Common.getParams(**kwargs)
+            params.AtomTyper = CompareIsotopes()
+            params.AtomCompareParameters.MatchIsotope = True
+            mcs = rdFMCS.FindMCS(ms, params)
+        else:
+            mcs = rdFMCS.FindMCS(ms, atomCompare=rdFMCS.AtomCompare.CompareIsotopes)
         self.assertEqual(mcs.numBonds, 2)
         self.assertEqual(mcs.numAtoms, 3)
         qm = Chem.MolFromSmarts(mcs.smartsString)
@@ -115,74 +327,148 @@ class TestCase(unittest.TestCase):
         self.assertTrue(Chem.MolFromSmiles('OO[14CH3]').HasSubstructMatch(qm))
         self.assertFalse(Chem.MolFromSmiles('O[13CH2][14CH3]').HasSubstructMatch(qm))
 
-    def test4RingMatches(self):
+    def test4RingMatches(self, **kwargs):
         smis = ['CCCCC', 'CCC1CCCCC1']
         ms = [Chem.MolFromSmiles(x) for x in smis]
-        mcs = rdFMCS.FindMCS(ms)
+        if kwargs:
+            params = Common.getParams(**kwargs)
+            mcs = rdFMCS.FindMCS(ms, params)
+        else:
+            mcs = rdFMCS.FindMCS(ms)
         self.assertEqual(mcs.numBonds, 4)
         self.assertEqual(mcs.numAtoms, 5)
         self.assertEqual(mcs.smartsString, '[#6]-[#6]-[#6]-[#6]-[#6]')
 
-        mcs = rdFMCS.FindMCS(ms, completeRingsOnly=True)
+        if kwargs:
+            params = Common.getParams(**kwargs)
+            params.BondCompareParameters.CompleteRingsOnly = True
+            mcs = rdFMCS.FindMCS(ms, params)
+        else:
+            mcs = rdFMCS.FindMCS(ms, completeRingsOnly=True)
         self.assertEqual(mcs.numBonds, 2)
         self.assertEqual(mcs.numAtoms, 3)
         self.assertEqual(mcs.smartsString, '[#6]-&!@[#6]-&!@[#6]')
 
-        mcs = rdFMCS.FindMCS(ms, completeRingsOnly=True,
-                             ringCompare=rdFMCS.RingCompare.PermissiveRingFusion)
+        if kwargs:
+            params = Common.getParams(**kwargs)
+            params.BondCompareParameters.CompleteRingsOnly = True
+            params.BondCompareParameters.MatchFusedRings = True
+            params.BondCompareParameters.MatchFusedRingsStrict = False
+            mcs = rdFMCS.FindMCS(ms, params)
+        else:
+            mcs = rdFMCS.FindMCS(ms, completeRingsOnly=True,
+                                 ringCompare=rdFMCS.RingCompare.PermissiveRingFusion)
         self.assertEqual(mcs.numBonds, 2)
         self.assertEqual(mcs.numAtoms, 3)
         self.assertEqual(mcs.smartsString, '[#6]-&!@[#6]-&!@[#6]')
 
-        mcs = rdFMCS.FindMCS(ms, completeRingsOnly=True,
-                             ringCompare=rdFMCS.RingCompare.StrictRingFusion)
+        if kwargs:
+            params = Common.getParams(**kwargs)
+            params.BondCompareParameters.CompleteRingsOnly = True
+            params.BondCompareParameters.MatchFusedRings = True
+            params.BondCompareParameters.MatchFusedRingsStrict = True
+            mcs = rdFMCS.FindMCS(ms, params)
+        else:
+            mcs = rdFMCS.FindMCS(ms, completeRingsOnly=True,
+                                 ringCompare=rdFMCS.RingCompare.StrictRingFusion)
         self.assertEqual(mcs.numBonds, 2)
         self.assertEqual(mcs.numAtoms, 3)
         self.assertEqual(mcs.smartsString, '[#6]-&!@[#6]-&!@[#6]')
 
-        mcs = rdFMCS.FindMCS(ms, ringMatchesRingOnly=True)
+        if kwargs:
+            params = Common.getParams(**kwargs)
+            params.AtomCompareParameters.RingMatchesRingOnly = True
+            params.BondCompareParameters.RingMatchesRingOnly = True
+            mcs = rdFMCS.FindMCS(ms, params)
+        else:
+            mcs = rdFMCS.FindMCS(ms, ringMatchesRingOnly=True)
         self.assertEqual(mcs.numBonds, 1)
         self.assertEqual(mcs.numAtoms, 2)
         self.assertEqual(mcs.smartsString, '[#6&!R]-&!@[#6&!R]')
 
         smis = ['CC1CCC1', 'CCC1CCCCC1']
         ms = [Chem.MolFromSmiles(x) for x in smis]
-        mcs = rdFMCS.FindMCS(ms)
+        if kwargs:
+            params = Common.getParams(**kwargs)
+            mcs = rdFMCS.FindMCS(ms, params)
+        else:
+            mcs = rdFMCS.FindMCS(ms)
         self.assertEqual(mcs.numBonds, 4)
         self.assertEqual(mcs.numAtoms, 5)
         self.assertEqual(mcs.smartsString, '[#6]-[#6](-[#6]-[#6])-[#6]')
 
-        mcs = rdFMCS.FindMCS(ms, completeRingsOnly=True)
+        if kwargs:
+            params = Common.getParams(**kwargs)
+            params.BondCompareParameters.CompleteRingsOnly = True
+            mcs = rdFMCS.FindMCS(ms, params)
+        else:
+            mcs = rdFMCS.FindMCS(ms, completeRingsOnly=True)
         self.assertEqual(mcs.numBonds, 1)
         self.assertEqual(mcs.numAtoms, 2)
         self.assertEqual(mcs.smartsString, '[#6]-&!@[#6]')
 
-        mcs = rdFMCS.FindMCS(ms, ringMatchesRingOnly=True, completeRingsOnly=True)
+        if kwargs:
+            params = Common.getParams(**kwargs)
+            params.AtomCompareParameters.RingMatchesRingOnly = True
+            params.BondCompareParameters.CompleteRingsOnly = True
+            params.BondCompareParameters.RingMatchesRingOnly = True
+            mcs = rdFMCS.FindMCS(ms, params)
+        else:
+            mcs = rdFMCS.FindMCS(ms, ringMatchesRingOnly=True, completeRingsOnly=True)
         self.assertEqual(mcs.numBonds, 1)
         self.assertEqual(mcs.numAtoms, 2)
         self.assertEqual(mcs.smartsString, '[#6&!R]-&!@[#6&R]')
 
-        mcs = rdFMCS.FindMCS(ms, ringMatchesRingOnly=True, completeRingsOnly=True,
-                             ringCompare=rdFMCS.RingCompare.PermissiveRingFusion)
+        if kwargs:
+            params = Common.getParams(**kwargs)
+            params.AtomCompareParameters.RingMatchesRingOnly = True
+            params.BondCompareParameters.CompleteRingsOnly = True
+            params.BondCompareParameters.RingMatchesRingOnly = True
+            params.BondCompareParameters.MatchFusedRings = True
+            params.BondCompareParameters.MatchFusedRingsStrict = False
+            mcs = rdFMCS.FindMCS(ms, params)
+        else:
+            mcs = rdFMCS.FindMCS(ms, ringMatchesRingOnly=True, completeRingsOnly=True,
+                                 ringCompare=rdFMCS.RingCompare.PermissiveRingFusion)
         self.assertEqual(mcs.numBonds, 1)
         self.assertEqual(mcs.numAtoms, 2)
         self.assertEqual(mcs.smartsString, '[#6&!R]-&!@[#6&R]')
 
-        mcs = rdFMCS.FindMCS(ms, ringMatchesRingOnly=True, completeRingsOnly=True,
-                             ringCompare=rdFMCS.RingCompare.StrictRingFusion)
+        if kwargs:
+            params = Common.getParams(**kwargs)
+            params.AtomCompareParameters.RingMatchesRingOnly = True
+            params.BondCompareParameters.CompleteRingsOnly = True
+            params.BondCompareParameters.RingMatchesRingOnly = True
+            params.BondCompareParameters.MatchFusedRings = True
+            params.BondCompareParameters.MatchFusedRingsStrict = True
+            mcs = rdFMCS.FindMCS(ms, params)
+        else:
+            mcs = rdFMCS.FindMCS(ms, ringMatchesRingOnly=True, completeRingsOnly=True,
+                                 ringCompare=rdFMCS.RingCompare.StrictRingFusion)
         self.assertEqual(mcs.numBonds, 1)
         self.assertEqual(mcs.numAtoms, 2)
         self.assertEqual(mcs.smartsString, '[#6&!R]-&!@[#6&R]')
 
-        mcs = rdFMCS.FindMCS(ms, ringMatchesRingOnly=True)
+        if kwargs:
+            params = Common.getParams(**kwargs)
+            params.AtomCompareParameters.RingMatchesRingOnly = True
+            params.BondCompareParameters.RingMatchesRingOnly = True
+            mcs = rdFMCS.FindMCS(ms, params)
+        else:
+            mcs = rdFMCS.FindMCS(ms, ringMatchesRingOnly=True)
         self.assertEqual(mcs.numBonds, 4)
         self.assertEqual(mcs.numAtoms, 5)
         self.assertEqual(mcs.smartsString, '[#6&!R]-&!@[#6&R](-&@[#6&R]-&@[#6&R])-&@[#6&R]')
 
-    def test5AnyMatch(self):
+    def test5AnyMatch(self, **kwargs):
         smis = ('c1ccccc1C', 'c1ccccc1O', 'c1ccccc1Cl')
         ms = [Chem.MolFromSmiles(x) for x in smis]
-        mcs = rdFMCS.FindMCS(ms, atomCompare=rdFMCS.AtomCompare.CompareAny)
+        if kwargs:
+            params = Common.getParams(**kwargs)
+            params.AtomTyper = CompareAny()
+            mcs = rdFMCS.FindMCS(ms, params)
+        else:
+            mcs = rdFMCS.FindMCS(ms, atomCompare=rdFMCS.AtomCompare.CompareAny)
         self.assertEqual(mcs.numBonds, 7)
         self.assertEqual(mcs.numAtoms, 7)
         qm = Chem.MolFromSmarts(mcs.smartsString)
@@ -192,7 +478,12 @@ class TestCase(unittest.TestCase):
 
         smis = ('c1cccnc1C', 'c1cnncc1O', 'c1cccnc1Cl')
         ms = [Chem.MolFromSmiles(x) for x in smis]
-        mcs = rdFMCS.FindMCS(ms, atomCompare=rdFMCS.AtomCompare.CompareAny)
+        if kwargs:
+            params = Common.getParams(**kwargs)
+            params.AtomTyper = CompareAny()
+            mcs = rdFMCS.FindMCS(ms, params)
+        else:
+            mcs = rdFMCS.FindMCS(ms, atomCompare=rdFMCS.AtomCompare.CompareAny)
         self.assertEqual(mcs.numBonds, 7)
         self.assertEqual(mcs.numAtoms, 7)
         qm = Chem.MolFromSmarts(mcs.smartsString)
@@ -200,11 +491,16 @@ class TestCase(unittest.TestCase):
         for m in ms:
             self.assertTrue(m.HasSubstructMatch(qm))
 
-    def testAtomCompareAnyHeavyAtom(self):
+    def testAtomCompareAnyHeavyAtom(self, **kwargs):
         # H matches H, O matches C
         smis = ('[H]c1ccccc1C', '[H]c1ccccc1O')
         ms = [Chem.MolFromSmiles(x, sanitize=False) for x in smis]
-        mcs = rdFMCS.FindMCS(ms, atomCompare=rdFMCS.AtomCompare.CompareAnyHeavyAtom)
+        if kwargs:
+            params = Common.getParams(**kwargs)
+            params.AtomTyper = CompareAnyHeavyAtom()
+            mcs = rdFMCS.FindMCS(ms, params)
+        else:
+            mcs = rdFMCS.FindMCS(ms, atomCompare=rdFMCS.AtomCompare.CompareAnyHeavyAtom)
         self.assertEqual(mcs.numBonds, 8)
         self.assertEqual(mcs.numAtoms, 8)
         qm = Chem.MolFromSmarts(mcs.smartsString)
@@ -212,11 +508,16 @@ class TestCase(unittest.TestCase):
         for m in ms:
             self.assertTrue(m.HasSubstructMatch(qm))
 
-    def testAtomCompareAnyHeavyAtom1(self):
+    def testAtomCompareAnyHeavyAtom1(self, **kwargs):
         # O matches C, H does not match O
         smis = ('[H]c1ccccc1C', 'Oc1ccccc1O')
         ms = [Chem.MolFromSmiles(x, sanitize=False) for x in smis]
-        mcs = rdFMCS.FindMCS(ms, atomCompare=rdFMCS.AtomCompare.CompareAnyHeavyAtom)
+        if kwargs:
+            params = Common.getParams(**kwargs)
+            params.AtomTyper = CompareAnyHeavyAtom()
+            mcs = rdFMCS.FindMCS(ms, params)
+        else:
+            mcs = rdFMCS.FindMCS(ms, atomCompare=rdFMCS.AtomCompare.CompareAnyHeavyAtom)
         self.assertEqual(mcs.numBonds, 7)
         self.assertEqual(mcs.numAtoms, 7)
         qm = Chem.MolFromSmarts(mcs.smartsString)
@@ -224,100 +525,323 @@ class TestCase(unittest.TestCase):
         for m in ms:
             self.assertTrue(m.HasSubstructMatch(qm))
 
-    def test6MatchValences(self):
+    def test6MatchValences(self, **kwargs):
         ms = (Chem.MolFromSmiles('NC1OC1'), Chem.MolFromSmiles('C1OC1[N+](=O)[O-]'))
-        mcs = rdFMCS.FindMCS(ms)
+        if kwargs:
+            params = Common.getParams(**kwargs)
+            mcs = rdFMCS.FindMCS(ms, params)
+        else:
+            mcs = rdFMCS.FindMCS(ms)
         self.assertEqual(mcs.numBonds, 4)
         self.assertEqual(mcs.numAtoms, 4)
-        mcs = rdFMCS.FindMCS(ms, matchValences=True)
+        if kwargs:
+            params = Common.getParams(**kwargs)
+            params.AtomCompareParameters.MatchValences = True
+            mcs = rdFMCS.FindMCS(ms, params)
+        else:
+            mcs = rdFMCS.FindMCS(ms, matchValences=True)
         self.assertEqual(mcs.numBonds, 3)
         self.assertEqual(mcs.numAtoms, 3)
 
-    def test7Seed(self):
+    def test7Seed(self, **kwargs):
         smis = ['C1CCC1CC1CC1', 'C1CCC1OC1CC1', 'C1CCC1NC1CC1', 'C1CCC1SC1CC1']
         ms = [Chem.MolFromSmiles(x) for x in smis]
-        r = rdFMCS.FindMCS(ms)
+        if kwargs:
+            params = Common.getParams(**kwargs)
+            r = rdFMCS.FindMCS(ms, params)
+        else:
+            r = rdFMCS.FindMCS(ms)
         self.assertEqual(r.smartsString, "[#6]1-[#6]-[#6]-[#6]-1")
-        r = rdFMCS.FindMCS(ms, seedSmarts='C1CC1')
+        if kwargs:
+            params = Common.getParams(**kwargs)
+            params.InitialSeed = 'C1CC1'
+            r = rdFMCS.FindMCS(ms, params)
+        else:
+            r = rdFMCS.FindMCS(ms, seedSmarts='C1CC1')
         self.assertEqual(r.smartsString, "[#6]1-[#6]-[#6]-1")
-        r = rdFMCS.FindMCS(ms, seedSmarts='C1OC1')
+        if kwargs:
+            params = Common.getParams(**kwargs)
+            params.InitialSeed = 'C1OC1'
+            r = rdFMCS.FindMCS(ms, params)
+        else:
+            r = rdFMCS.FindMCS(ms, seedSmarts='C1OC1')
         self.assertEqual(r.smartsString, "")
 
-    def test8MatchParams(self):
+    def test8MatchParams(self, **kwargs):
         smis = ("CCC1NC1", "CCC1N(C)C1", "CCC1OC1")
         ms = [Chem.MolFromSmiles(x) for x in smis]
 
-        mcs = rdFMCS.FindMCS(ms)
+        if kwargs:
+            ps = Common.getParams(**kwargs)
+            mcs = rdFMCS.FindMCS(ms, ps)
+        else:
+            mcs = rdFMCS.FindMCS(ms)
         self.assertEqual(mcs.numAtoms, 4)
 
-        ps = rdFMCS.MCSParameters()
+        ps = Common.getParams(**kwargs)
         ps.BondCompareParameters.CompleteRingsOnly = True
         mcs = rdFMCS.FindMCS(ms, ps)
         self.assertEqual(mcs.numAtoms, 3)
 
-        ps = rdFMCS.MCSParameters()
+        ps = Common.getParams(**kwargs)
         ps.BondCompareParameters.CompleteRingsOnly = True;
         ps.BondCompareParameters.MatchFusedRings = True
         mcs = rdFMCS.FindMCS(ms, ps)
         self.assertEqual(mcs.numAtoms, 3)
 
-        ps = rdFMCS.MCSParameters()
+        ps = Common.getParams(**kwargs)
         ps.BondCompareParameters.CompleteRingsOnly = True;
         ps.BondCompareParameters.MatchFusedRingsStrict = True
         mcs = rdFMCS.FindMCS(ms, ps)
         self.assertEqual(mcs.numAtoms, 3)
 
-        ps = rdFMCS.MCSParameters()
-        ps.SetAtomTyper(rdFMCS.AtomCompare.CompareAny)
+        ps = Common.getParams(**kwargs)
+        if kwargs:
+            ps.SetAtomTyper(CompareAny())
+        else:
+            ps.SetAtomTyper(rdFMCS.AtomCompare.CompareAny)
         mcs = rdFMCS.FindMCS(ms, ps)
         self.assertEqual(mcs.numAtoms, 5)
 
-    def test9MatchCharge(self):
+    def test9MatchCharge(self, **kwargs):
         smis = ("CCNC", "CCN(C)C", "CC[N+](C)C")
         ms = [Chem.MolFromSmiles(x) for x in smis]
 
-        mcs = rdFMCS.FindMCS(ms)
+        if kwargs:
+            ps = Common.getParams(**kwargs)
+            mcs = rdFMCS.FindMCS(ms, ps)
+        else:
+            mcs = rdFMCS.FindMCS(ms)
+
         self.assertEqual(mcs.numAtoms, 4)
 
-        ps = rdFMCS.MCSParameters()
+        ps = Common.getParams(**kwargs)
         ps.AtomCompareParameters.MatchFormalCharge = True
         mcs = rdFMCS.FindMCS(ms, ps)
         self.assertEqual(mcs.numAtoms, 2)
 
-    def test10MatchChargeAndParams(self):
+    def test10MatchChargeAndParams(self, **kwargs):
         smis = ("CCNC", "CCN(C)C", "CC[N+](C)C", "CC[C+](C)C")
         ms = [Chem.MolFromSmiles(x) for x in smis]
 
-        mcs = rdFMCS.FindMCS(ms)
+        if kwargs:
+            ps = Common.getParams(**kwargs)
+            mcs = rdFMCS.FindMCS(ms, ps)
+        else:
+            mcs = rdFMCS.FindMCS(ms)
         self.assertEqual(mcs.numAtoms, 2)
 
-        ps = rdFMCS.MCSParameters()
-        ps.SetAtomTyper(rdFMCS.AtomCompare.CompareAny)
+        ps = Common.getParams(**kwargs)
+        if kwargs:
+            ps.AtomTyper = CompareAny()
+        else:
+            ps.AtomTyper = rdFMCS.AtomCompare.CompareAny
         mcs = rdFMCS.FindMCS(ms, ps)
         self.assertEqual(mcs.numAtoms, 4)
 
+        ps = Common.getParams(**kwargs)
         ps.AtomCompareParameters.MatchFormalCharge = True
         mcs = rdFMCS.FindMCS(ms, ps)
         self.assertEqual(mcs.numAtoms, 2)
 
-    def test11Github2034(self):
+    def test11Github2034(self, **kwargs):
         smis = ("C1CC1N2CC2", "C1CC1N")
         ms = [Chem.MolFromSmiles(x) for x in smis]
 
-        mcs = rdFMCS.FindMCS(ms)
+        if kwargs:
+            ps = Common.getParams(**kwargs)
+            mcs = rdFMCS.FindMCS(ms, ps)
+        else:
+            mcs = rdFMCS.FindMCS(ms)
         self.assertEqual(mcs.numAtoms, 4)
         self.assertEqual(mcs.numBonds, 4)
 
-        mcs = rdFMCS.FindMCS(ms, ringMatchesRingOnly=True)
+        if kwargs:
+            ps = Common.getParams(**kwargs)
+            ps.AtomCompareParameters.RingMatchesRingOnly = True
+            ps.BondCompareParameters.RingMatchesRingOnly = True
+            mcs = rdFMCS.FindMCS(ms, ps)
+        else:
+            mcs = rdFMCS.FindMCS(ms, ringMatchesRingOnly=True)
         self.assertEqual(mcs.numAtoms, 3)
         self.assertEqual(mcs.numBonds, 3)
 
-        ps = rdFMCS.MCSParameters()
+        ps = Common.getParams(**kwargs)
         ps.AtomCompareParameters.RingMatchesRingOnly = True
         mcs = rdFMCS.FindMCS(ms, ps)
         self.assertEqual(mcs.numAtoms, 3)
         self.assertEqual(mcs.numBonds, 3)
 
+class TestCase(unittest.TestCase):
+
+    def setUp(self):
+        pass
+
+    def test1(self):
+        Common.test1(self)
+
+    def test1PythonImpl(self):
+        Common.test1(self,
+            AtomTyper=CompareElements,
+            BondTyper=CompareOrder)
+
+    def test2(self):
+        Common.test2(self)
+
+    def test2PythonImpl(self):
+        Common.test2(self,
+            AtomTyper=CompareElements,
+            BondTyper=CompareOrder)
+
+    def test3IsotopeMatch(self):
+        Common.test3IsotopeMatch(self)
+
+    def test3IsotopeMatchPythonImpl(self):
+        Common.test3IsotopeMatch(self,
+            AtomTyper=CompareElements,
+            BondTyper=CompareOrder)
+
+    def test4RingMatches(self):
+        Common.test4RingMatches(self)
+
+    def test4RingMatchesPythonImpl(self):
+        Common.test4RingMatches(self,
+            AtomTyper=CompareElements,
+            BondTyper=CompareOrder)
+
+    def test5AnyMatch(self):
+        Common.test5AnyMatch(self)
+
+    def test5AnyMatchPythonImpl(self):
+        Common.test5AnyMatch(self,
+            AtomTyper=CompareElements,
+            BondTyper=CompareOrder)
+
+    def testAtomCompareAnyHeavyAtom(self):
+        Common.testAtomCompareAnyHeavyAtom(self)
+
+    def testAtomCompareAnyHeavyAtomPythonImpl(self):
+        Common.testAtomCompareAnyHeavyAtom(self,
+            AtomTyper=CompareElements,
+            BondTyper=CompareOrder)
+
+    def testAtomCompareAnyHeavyAtom1(self):
+        Common.testAtomCompareAnyHeavyAtom1(self)
+
+    def testAtomCompareAnyHeavyAtom1PythonImpl(self):
+        Common.testAtomCompareAnyHeavyAtom1(self,
+            AtomTyper=CompareElements,
+            BondTyper=CompareOrder)
+
+    def test6MatchValences(self):
+        Common.test6MatchValences(self)
+
+    def test6MatchValencesPythonImpl(self):
+        Common.test6MatchValences(self,
+            AtomTyper=CompareElements,
+            BondTyper=CompareOrder)
+
+    def test7Seed(self):
+        Common.test7Seed(self)
+
+    def test7SeedPythonImpl(self):
+        Common.test7Seed(self,
+            AtomTyper=CompareElements,
+            BondTyper=CompareOrder)
+
+    def test8MatchParams(self):
+        Common.test8MatchParams(self)
+
+    def test8MatchParamsPythonImpl(self):
+        Common.test8MatchParams(self,
+            AtomTyper=CompareElements,
+            BondTyper=CompareOrder)
+
+    def test9MatchCharge(self):
+        Common.test9MatchCharge(self)
+
+    def test9MatchChargePythonImpl(self):
+        Common.test9MatchCharge(self,
+            AtomTyper=CompareElements,
+            BondTyper=CompareOrder)
+
+    def test10MatchChargeAndParams(self):
+        Common.test10MatchChargeAndParams(self)
+
+    def test10MatchChargeAndParamsPythonImpl(self):
+        Common.test10MatchChargeAndParams(self,
+            AtomTyper=CompareElements,
+            BondTyper=CompareOrder)
+
+    def test11Github2034(self):
+        Common.test11Github2034(self)
+
+    def test11Github2034PythonImpl(self):
+        Common.test11Github2034(self,
+            AtomTyper=CompareElements,
+            BondTyper=CompareOrder)
+
+    def test12MCSAtomCompareExceptions(self):
+        ps = rdFMCS.MCSParameters()
+        smis = ['CCCCC', 'CCC1CCCCC1']
+        ms = [Chem.MolFromSmiles(x) for x in smis]
+        self.assertRaises(TypeError, lambda ps: setattr(ps, "AtomTyper",
+                          AtomCompareCompareIsInt()))
+        ps.AtomTyper = AtomCompareNoCompare()
+        self.assertRaises(TypeError, lambda ms, ps: rdFMCS.FindMCS(ms, ps))
+
+    def test13MCSAtomCompareUserData(self):
+        smis = ['CCOCCOC', 'CCNCCCC']
+        ms = [Chem.MolFromSmiles(x) for x in smis]
+        ps = rdFMCS.MCSParameters()
+        ps.AtomTyper = AtomCompareUserData()
+        ps.AtomTyper.setMatchAnyHet(False)
+        mcs = rdFMCS.FindMCS(ms, ps)
+        self.assertEqual(mcs.numAtoms, 2)
+        ps.AtomTyper.setMatchAnyHet(True)
+        mcs = rdFMCS.FindMCS(ms, ps)
+        self.assertEqual(mcs.numAtoms, 5)
+
+    def test14MCSBondCompareExceptions(self):
+        ps = rdFMCS.MCSParameters()
+        smis = ['CCCCC', 'CCC1CCCCC1']
+        ms = [Chem.MolFromSmiles(x) for x in smis]
+        self.assertRaises(TypeError, lambda ps: setattr(ps, "BondTyper",
+                          BondCompareCompareIsInt()))
+        ps.BondTyper = BondCompareNoCompare()
+        self.assertRaises(TypeError, lambda ms, ps: rdFMCS.FindMCS(ms, ps))
+
+    def test15MCSBondCompareUserData(self):
+        smis = ['C1CC=CCC1', 'c1ccccc1']
+        ms = [Chem.MolFromSmiles(x) for x in smis]
+        ps = rdFMCS.MCSParameters()
+        ps.BondTyper = BondCompareUserData()
+        ps.BondCompareParameters.CompleteRingsOnly = True
+        ps.BondTyper.setIgnoreAromatization(False)
+        mcs = rdFMCS.FindMCS(ms, ps)
+        self.assertEqual(mcs.numAtoms, 0)
+        ps.BondTyper.setIgnoreAromatization(True)
+        mcs = rdFMCS.FindMCS(ms, ps)
+        self.assertEqual(mcs.numAtoms, 6)
+
+    def test16MCSProgressCallbackExceptions(self):
+        ps = rdFMCS.MCSParameters()
+        smis = ['CCCC(C)CC(CC)CC', 'OC(N)CC(C)CC(CC)CC']
+        ms = [Chem.MolFromSmiles(x) for x in smis]
+        self.assertRaises(TypeError, lambda ps: setattr(ps, "ProgressCallback",
+                          ProgressCallbackCallbackIsInt()))
+        ps.ProgressCallback = ProgressCallbackNoCallback()
+        self.assertRaises(TypeError, lambda ms, ps: rdFMCS.FindMCS(ms, ps))
+
+    def test17MCSProgressCallbackCancel(self):
+        ps = rdFMCS.MCSParameters()
+        smis = ['CCCC(C)CC(CC)CC', 'OC(N)CC(C)CC(CC)CC']
+        ms = [Chem.MolFromSmiles(x) for x in smis]
+        ps.AtomTyper = CompareElements()
+        ps.ProgressCallback = ProgressCallback(self)
+        mcs = rdFMCS.FindMCS(ms, ps)
+        self.assertTrue(mcs.canceled)
+        self.assertEqual(ps.ProgressCallback.callCount, 3)
 
 if __name__ == "__main__":
     unittest.main()

--- a/Code/GraphMol/FMCS/testFMCS_Unit.cpp
+++ b/Code/GraphMol/FMCS/testFMCS_Unit.cpp
@@ -1997,6 +1997,70 @@ void testQueryMolVsSmarts() {
   BOOST_LOG(rdInfoLog) << "\tdone" << std::endl;
 }
 
+void testCompareNonExistent() {
+  BOOST_LOG(rdInfoLog) << "-------------------------------------" << std::endl;
+  BOOST_LOG(rdInfoLog) << "testAtomCompareNonExistent"
+                       << std::endl;
+
+  std::vector<ROMOL_SPTR> mols;
+  const char* smi[] = {"C", "CC"};
+
+  for (auto& i : smi) {
+    auto m = SmilesToMol(getSmilesOnly(i));
+    TEST_ASSERT(m);
+
+    mols.push_back(ROMOL_SPTR(m));
+  }
+  {
+    MCSParameters p;
+    bool hasThrown = false;
+    try {
+      p.setMCSAtomTyperFromEnum(static_cast<AtomComparator>(99));
+    }
+    catch (const std::runtime_error &e) {
+      BOOST_LOG(rdInfoLog) << e.what() << std::endl;
+      hasThrown = true;
+    }
+    TEST_ASSERT(hasThrown);
+  }
+  {
+    MCSParameters p;
+    bool hasThrown = false;
+    try {
+      p.setMCSAtomTyperFromConstChar("hello");
+    }
+    catch (const std::runtime_error &e) {
+      BOOST_LOG(rdInfoLog) << e.what() << std::endl;
+      hasThrown = true;
+    }
+    TEST_ASSERT(!hasThrown);
+  }
+  {
+    MCSParameters p;
+    bool hasThrown = false;
+    try {
+      p.setMCSBondTyperFromEnum(static_cast<BondComparator>(99));
+    }
+    catch (const std::runtime_error &e) {
+      BOOST_LOG(rdInfoLog) << e.what() << std::endl;
+      hasThrown = true;
+    }
+    TEST_ASSERT(hasThrown);
+  }
+  {
+    MCSParameters p;
+    bool hasThrown = false;
+    try {
+      p.setMCSBondTyperFromConstChar("hello");
+    }
+    catch (const std::runtime_error &e) {
+      BOOST_LOG(rdInfoLog) << e.what() << std::endl;
+      hasThrown = true;
+    }
+    TEST_ASSERT(!hasThrown);
+  }
+}
+
 //====================================================================================================
 //====================================================================================================
 
@@ -2071,6 +2135,7 @@ int main(int argc, const char* argv[]) {
   testGithub2714();
   testGitHub2731_comment546175466();
   testQueryMolVsSmarts();
+  testCompareNonExistent();
 
   unsigned long long t1 = nanoClock();
   double sec = double(t1 - T0) / 1000000.;

--- a/Code/GraphMol/Wrap/rdchem.cpp
+++ b/Code/GraphMol/Wrap/rdchem.cpp
@@ -67,10 +67,10 @@ struct PySysErrWrite : std::ostream, std::streambuf {
     buffer += c;
     if (c == '\n') {
       // Python IO is not thread safe, so grab the GIL
-      PyGILState_STATE gstate;
-      gstate = PyGILState_Ensure();
-      PySys_WriteStderr("%s", (prefix + buffer).c_str());
-      PyGILState_Release(gstate);
+      {
+        PyGILStateHolder h;
+        PySys_WriteStderr("%s", (prefix + buffer).c_str());
+      }
       buffer.clear();
     }
   }

--- a/Code/JavaWrappers/FMCS.i
+++ b/Code/JavaWrappers/FMCS.i
@@ -36,6 +36,22 @@
 
 %ignore MCSParameters;
 %ignore findMCS(const std::vector<ROMOL_SPTR>& mols, const MCSParameters* params);
+%ignore checkAtomRingMatch(const MCSAtomCompareParameters& p,
+                           const ROMol& mol1, unsigned int atom1,
+                           const ROMol& mol2, unsigned int atom2);
+%ignore checkAtomCharge(const MCSAtomCompareParameters& p,
+                        const ROMol& mol1, unsigned int atom1,
+                        const ROMol& mol2, unsigned int atom2);
+%ignore checkAtomChirality(const MCSAtomCompareParameters& p,
+                           const ROMol& mol1, unsigned int atom1,
+                           const ROMol& mol2, unsigned int atom2);
+%ignore checkBondStereo(const MCSBondCompareParameters& p,
+                        const ROMol& mol1, unsigned int bond1,
+                        const ROMol& mol2, unsigned int bond2);
+%ignore checkBondRingMatch(const MCSBondCompareParameters &p,
+                           const ROMol& mol1, unsigned int bond1,
+                           const ROMol& mol2, unsigned int bond2,
+                           void* v_ringMatchMatrixSet);
 %include <GraphMol/FMCS/FMCS.h>
 
 %{

--- a/Code/RDBoost/Wrap.h
+++ b/Code/RDBoost/Wrap.h
@@ -142,6 +142,17 @@ void pythonObjectToVect(const python::object &obj, std::vector<T> &res) {
 #define RDUNUSED
 #endif
 
+class PyGILStateHolder {
+public:
+  PyGILStateHolder() :
+    d_gstate(PyGILState_Ensure()) {}
+  ~PyGILStateHolder() {
+    PyGILState_Release(d_gstate);
+  }
+private:
+  PyGILState_STATE d_gstate;
+};
+
 #ifdef RDK_THREADSAFE_SSS
 // Release the Global Interpreter lock at certain places
 //  on construction - release the lock


### PR DESCRIPTION
This PR adds support for user-defined Python FMCS functors and progress callbacks.
The pre-defined C++ compare functions can be called from Python too, so users do not have to reimplement Python versions of the already available C++ functionality (e.g., `CheckAtomRingMatch`, `CheckAtomCharge`, `CheckAtomChirality`, `CheckBondStereo`, `CheckBondRingMatch`), and can focus only on the custom behavior which is not available OOTB in the C++ layer.
I struggled to maintain backwards compatibility with the previous FMCS C++ implementation, so users who have written custom C++ `compare` functions won't need to change anything.
I had to add a `bool MatchIsotope` variable to `MCSAtomCompareParameters` or isotopic SMARTS could not have been written from Python unless the built-in `MCSAtomCompareIsotopes` is used.
From Python users do not have to use the horrible opaque `userData` C++ pointer to pass their own data to their `compare` functions. Instead, they may subclass a base class and reimplement the `compare()` method. This provides a cleaner interface and users can store data as well as add their own methods to the subclass.
I have added a fairly comprehensive Python test suite, which re-runs existing tests using Python implementations of the C++ `compare` functions and adds some specific tests.