### PR TITLE
Support Chemical Markup Language, CML, for writing

### DIFF
--- a/Code/GraphMol/FileParsers/CMLWriter.cpp
+++ b/Code/GraphMol/FileParsers/CMLWriter.cpp
@@ -1,0 +1,298 @@
+//  Copyright (C) 2020 Eisuke Kawashima
+//
+//  Chemical Markup Language, CML, schema 3
+//  http://www.xml-cml.org/
+//  See
+//  http://www.xml-cml.org/convention/molecular
+//  http://www.xml-cml.org/schema/schema3/schema.xsd
+//
+//   @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
+//
+
+#include "FileParsers.h"
+#include <fstream>
+#include <sstream>
+#include <boost/format.hpp>
+#include <boost/property_tree/ptree.hpp>
+#include <boost/property_tree/xml_parser.hpp>
+#include <RDGeneral/Invariant.h>
+
+#if __cplusplus >= 201402L && __has_cpp_attribute(fallthrough)
+#define FALLTHROUGH [[fallthrough]]
+#else
+#define FALLTHROUGH
+#endif
+
+namespace RDKit {
+
+namespace {
+double determinant(double a00, double a01, double a10, double a11) noexcept {
+  return a00 * a11 - a01 * a10;
+}
+
+double determinant(double a00, double a01, double a02,  //
+                   double a10, double a11, double a12,  //
+                   double a20, double a21, double a22) noexcept {
+  return a00 * determinant(a11, a12, a21, a22) -
+         a01 * determinant(a10, a12, a20, a22) +
+         a02 * determinant(a10, a11, a20, a21);
+}
+
+boost::property_tree::ptree molToPTree(const ROMol& mol, int confId,
+                                       bool kekulize) {
+  RWMol rwmol{mol};
+  if (kekulize) {
+    MolOps::Kekulize(rwmol);
+  }
+
+  boost::property_tree::ptree pt;
+  // prefix namespaces
+  auto& root = pt.add("cml:cml", "");
+  root.put("<xmlattr>.xmlns:cml", "http://www.xml-cml.org/schema");
+  root.put("<xmlattr>.xmlns:convention", "http://www.xml-cml.org/convention/");
+  root.put("<xmlattr>.convention", "convention:molecular");
+
+  auto& molecule = root.add("cml:molecule", "");
+
+  // molecule/@id MUST start with an alphabetical character
+  // http://www.xml-cml.org/convention/molecular#molecule-id
+  const auto molecule_id_default_prefix = "m";
+  molecule.put("<xmlattr>.id",
+               boost::format{"%1%%2%"} % molecule_id_default_prefix % confId);
+
+  std::string name;
+  rwmol.getPropIfPresent(common_properties::_Name, name);
+  if (!name.empty()) {
+    molecule.put("cml:name", name);
+  }
+
+  int mol_formal_charge = 0;
+  unsigned mol_num_radical_electrons = 0u;
+
+  // atom/@id MUST start with an alphabetical character
+  // http://www.xml-cml.org/convention/molecular#atom-id
+  const auto atom_id_prefix = "a";
+
+  auto& atomArray = molecule.put("cml:atomArray", "");
+  for (unsigned i = 0u, nAtoms = rwmol.getNumAtoms(); i < nAtoms; i++) {
+    auto& atom = atomArray.add("cml:atom", "");
+    const auto& a = rwmol.getAtomWithIdx(i);
+
+    atom.put("<xmlattr>.id", boost::format{"%1%%2%"} % atom_id_prefix % i);
+    if (a->getAtomicNum()) {
+      atom.put("<xmlattr>.elementType", a->getSymbol());
+    } else {
+      atom.put("<xmlattr>.elementType", "Du");  // dummy
+    }
+
+    const auto charge = a->getFormalCharge();
+    mol_formal_charge += charge;
+    atom.put("<xmlattr>.formalCharge", charge);
+
+    atom.put("<xmlattr>.hydrogenCount", a->getTotalNumHs());
+
+    const auto isotope = a->getIsotope();
+    if (isotope) {
+      atom.put("<xmlattr>.isotopeNumber", isotope);
+    }
+
+    const auto n_rad_es = a->getNumRadicalElectrons();
+    mol_num_radical_electrons += n_rad_es;
+
+    if (!mol.getNumConformers()) {
+      continue;
+    }
+
+    const auto& conf = rwmol.getConformer(confId);
+    const auto& pos = conf.getAtomPos(i);
+    boost::format xyz_fmt{"%.6f"};
+
+    if (!conf.is3D()) {
+      atom.put("<xmlattr>.x2", xyz_fmt % pos.x);
+      atom.put("<xmlattr>.y2", xyz_fmt % pos.y);
+      continue;
+    }
+
+    atom.put("<xmlattr>.x3", xyz_fmt % pos.x);
+    atom.put("<xmlattr>.y3", xyz_fmt % pos.y);
+    atom.put("<xmlattr>.z3", xyz_fmt % pos.z);
+
+    // atom/@atomParity if chiral
+    // http://www.xml-cml.org/convention/molecular#atom-atomParity
+    const auto chiral = a->getChiralTag();
+    if (chiral == Atom::CHI_UNSPECIFIED || chiral == Atom::CHI_OTHER) {
+      continue;
+    }
+
+    std::vector<RDGeom::Point3D> xyzs;
+    std::vector<unsigned> neighbors;
+    for (auto nbri : boost::make_iterator_range(mol.getAtomBonds(a))) {
+      const auto* const b = mol[nbri];
+      const auto o = b->getOtherAtom(a)->getIdx();
+      neighbors.push_back(o);
+      xyzs.push_back(conf.getAtomPos(o));
+    }
+
+    if (neighbors.size() != 4u) {
+      continue;
+    }
+
+    /* atomParity = sign(det([[1,  1,  1,  1],
+                              [x0, x1, x2, x3],
+                              [y0, y1, y2, y3],
+                              [z0, z1, z2, z3]]))
+     */
+    const auto det = determinant(xyzs[1u].x, xyzs[2u].x, xyzs[3u].x,  //
+                                 xyzs[1u].y, xyzs[2u].y, xyzs[3u].y,  //
+                                 xyzs[1u].z, xyzs[2u].z, xyzs[3u].z) -
+                     determinant(xyzs[0u].x, xyzs[2u].x, xyzs[3u].x,  //
+                                 xyzs[0u].y, xyzs[2u].y, xyzs[3u].y,  //
+                                 xyzs[0u].z, xyzs[2u].z, xyzs[3u].z) +
+                     determinant(xyzs[0u].x, xyzs[1u].x, xyzs[3u].x,  //
+                                 xyzs[0u].y, xyzs[1u].y, xyzs[3u].y,  //
+                                 xyzs[0u].z, xyzs[1u].z, xyzs[3u].z) -
+                     determinant(xyzs[0u].x, xyzs[1u].x, xyzs[2u].x,  //
+                                 xyzs[0u].y, xyzs[1u].y, xyzs[2u].y,  //
+                                 xyzs[0u].z, xyzs[1u].z, xyzs[2u].z);
+    if (det == 0.0) {
+      continue;
+    }
+
+    auto& atomParity = atom.add("cml:atomParity", det > 0.0 ? 1 : -1);
+    atomParity.put("<xmlattr>.atomRefs4",
+                   boost::format{"%1%%2% %1%%3% %1%%4% %1%%5%"} %
+                       atom_id_prefix % neighbors[0u] % neighbors[1u] %
+                       neighbors[2u] % neighbors[3u]);
+  }
+
+  molecule.put("<xmlattr>.formalCharge", mol_formal_charge);
+  if (mol_num_radical_electrons < 2u) {
+    molecule.put("<xmlattr>.spinMultiplicity", mol_num_radical_electrons + 1u);
+  } else {
+    BOOST_LOG(rdInfoLog)
+        << "CMLWriter: Unable to determine molecule/@spinMultiplicity "
+        << boost::format{"(%1% radical electrons)\n"} %
+               mol_num_radical_electrons;
+  }
+
+  // bond/@id so that it can be referenced
+  // http://www.xml-cml.org/convention/molecular#bond-id
+  const auto bond_id_prefix = "b";
+  unsigned bond_id = 0u;
+
+  auto& bondArray = molecule.add("cml:bondArray", "");
+  for (auto atom_itr = rwmol.beginAtoms(), atom_itr_end = rwmol.endAtoms();
+       atom_itr != atom_itr_end; ++atom_itr) {
+    const auto& atom = *atom_itr;
+    PRECONDITION(atom, "bad atom");
+    const auto src = atom->getIdx();
+    const auto* const mol = &atom->getOwningMol();
+
+    for (auto bond_itrs = mol->getAtomBonds(atom);
+         bond_itrs.first != bond_itrs.second; ++bond_itrs.first) {
+      auto* bptr = (*mol)[*bond_itrs.first];
+      auto* nptr = bptr->getOtherAtom(atom);
+      const auto dst = nptr->getIdx();
+      if (dst < src) {
+        continue;
+      }
+
+      auto& bond = bondArray.add("cml:bond", "");
+      bond.put("<xmlattr>.atomRefs2",
+               boost::format{"%1%%2% %1%%3%"} % atom_id_prefix % src % dst);
+
+      bond.put("<xmlattr>.id",
+               boost::format{"%1%%2%"} % bond_id_prefix % bond_id++);
+
+      const auto btype = bptr->getBondType();
+      switch (btype) {
+        case Bond::SINGLE:
+          bond.put("<xmlattr>.order", 'S');
+          break;
+        case Bond::DOUBLE:
+          bond.put("<xmlattr>.order", 'D');
+          break;
+        case Bond::TRIPLE:
+          bond.put("<xmlattr>.order", 'T');
+          break;
+        case Bond::AROMATIC:
+          bond.put("<xmlattr>.order", 'A');
+          break;
+        case Bond::DATIVEONE:
+          FALLTHROUGH;
+        case Bond::DATIVE:
+          FALLTHROUGH;
+        case Bond::DATIVEL:
+          FALLTHROUGH;
+        case Bond::DATIVER:
+          bond.put("<xmlattr>.order", 'S');
+          break;
+        // XXX RDKit extension: bond orders greater than 3
+        case Bond::QUADRUPLE:
+          bond.put("<xmlattr>.order", 4);
+          break;
+        case Bond::QUINTUPLE:
+          bond.put("<xmlattr>.order", 5);
+          break;
+        case Bond::HEXTUPLE:
+          bond.put("<xmlattr>.order", 6);
+          break;
+        // XXX RDKit extension: half-integer orders
+        case Bond::THREECENTER:
+          bond.put("<xmlattr>.order", "0.5");
+          break;
+        case Bond::ONEANDAHALF:
+          bond.put("<xmlattr>.order", "1.5");
+          break;
+        case Bond::TWOANDAHALF:
+          bond.put("<xmlattr>.order", "2.5");
+          break;
+        case Bond::THREEANDAHALF:
+          bond.put("<xmlattr>.order", "3.5");
+          break;
+        case Bond::FOURANDAHALF:
+          bond.put("<xmlattr>.order", "4.5");
+          break;
+        case Bond::FIVEANDAHALF:
+          bond.put("<xmlattr>.order", "5.5");
+          break;
+        default:
+          BOOST_LOG(rdInfoLog)
+              << boost::format{"CMLWriter: Unsupported BondType %1%\n"} % btype;
+          bond.put("<xmlattr>.order", "");
+      }
+    }
+  }
+
+  return pt;
+}
+}  // namespace
+
+void MolToCMLBlock(std::ostream& os, const ROMol& mol, int confId,
+                   bool kekulize) {
+  auto pt = molToPTree(mol, confId, kekulize);
+  if (pt.empty()) {
+    return;
+  }
+  boost::property_tree::write_xml(
+      os, pt,
+      boost::property_tree::xml_writer_make_settings<std::string>(' ', 2));
+}
+
+std::string MolToCMLBlock(const ROMol& mol, int confId, bool kekulize) {
+  std::ostringstream ss;
+  MolToCMLBlock(ss, mol, confId, kekulize);
+  return ss.str();
+}
+
+void MolToCMLFile(const ROMol& mol, const std::string& fName, int confId,
+                  bool kekulize) {
+  std::ofstream ofs{fName};
+  MolToCMLBlock(ofs, mol, confId, kekulize);
+}
+
+}  // namespace RDKit

--- a/Code/GraphMol/FileParsers/CMakeLists.txt
+++ b/Code/GraphMol/FileParsers/CMakeLists.txt
@@ -50,7 +50,7 @@ rdkit_library(FileParsers
               TDTMolSupplier.cpp TDTWriter.cpp
               TplFileParser.cpp TplFileWriter.cpp
               PDBParser.cpp PDBWriter.cpp PDBSupplier.cpp
-              XYZFileWriter.cpp
+              CMLWriter.cpp XYZFileWriter.cpp
               ${maesupplier}
               ProximityBonds.cpp
               SequenceParsers.cpp SequenceWriters.cpp

--- a/Code/GraphMol/FileParsers/FileParsers.h
+++ b/Code/GraphMol/FileParsers/FileParsers.h
@@ -160,10 +160,6 @@ inline void MolToV3KMolFile(const ROMol &mol, const std::string &fName,
   MolToMolFile(mol, fName, includeStereo, confId, kekulize, true);
 }
 
-RDKIT_FILEPARSERS_EXPORT void MolToCMLBlock(std::ostream &os, const ROMol &mol,
-                                            int confId = -1,
-                                            bool kekulize = true);
-
 RDKIT_FILEPARSERS_EXPORT std::string MolToCMLBlock(const ROMol &mol,
                                                    int confId = -1,
                                                    bool kekulize = true);

--- a/Code/GraphMol/FileParsers/FileParsers.h
+++ b/Code/GraphMol/FileParsers/FileParsers.h
@@ -160,6 +160,19 @@ inline void MolToV3KMolFile(const ROMol &mol, const std::string &fName,
   MolToMolFile(mol, fName, includeStereo, confId, kekulize, true);
 }
 
+RDKIT_FILEPARSERS_EXPORT void MolToCMLBlock(std::ostream &os, const ROMol &mol,
+                                            int confId = -1,
+                                            bool kekulize = true);
+
+RDKIT_FILEPARSERS_EXPORT std::string MolToCMLBlock(const ROMol &mol,
+                                                   int confId = -1,
+                                                   bool kekulize = true);
+
+RDKIT_FILEPARSERS_EXPORT void MolToCMLFile(const ROMol &mol,
+                                           const std::string &fName,
+                                           int confId = -1,
+                                           bool kekulize = true);
+
 RDKIT_FILEPARSERS_EXPORT std::string MolToXYZBlock(const ROMol &mol,
                                                    int confId = -1);
 

--- a/Code/GraphMol/FileParsers/file_parsers_catch.cpp
+++ b/Code/GraphMol/FileParsers/file_parsers_catch.cpp
@@ -1339,6 +1339,91 @@ M  END
   }
 }
 
+TEST_CASE("CML writer", "[CML][writer]") {
+  SECTION("basics") {
+    std::unique_ptr<RWMol> mol{new RWMol{}};
+    mol->setProp(common_properties::_Name, "S-lactic acid");
+
+    for (auto z : {6u, 1u, 1u, 1u, 6u, 1u, 8u, 1u, 6u, 8u, 8u}) {
+      auto *a = new Atom{z};
+      mol->addAtom(a, false, true);
+    }
+    mol->getAtomWithIdx(0u)->setNumExplicitHs(3u);
+    mol->getAtomWithIdx(4u)->setNumExplicitHs(1u);
+    mol->getAtomWithIdx(6u)->setNumExplicitHs(1u);
+    mol->getAtomWithIdx(7u)->setIsotope(2u);
+    mol->getAtomWithIdx(10u)->setFormalCharge(-1);
+
+    mol->getAtomWithIdx(4u)->setChiralTag(Atom::CHI_TETRAHEDRAL_CCW);
+
+    mol->addBond(0u, 1u, Bond::SINGLE);
+    mol->addBond(0u, 2u, Bond::SINGLE);
+    mol->addBond(0u, 3u, Bond::SINGLE);
+    mol->addBond(0u, 4u, Bond::SINGLE);
+    mol->addBond(4u, 5u, Bond::SINGLE);
+    mol->addBond(4u, 6u, Bond::SINGLE);
+    mol->addBond(4u, 8u, Bond::SINGLE);
+    mol->addBond(6u, 7u, Bond::SINGLE);
+    mol->addBond(8u, 9u, Bond::DOUBLE);
+    mol->addBond(8u, 10u, Bond::SINGLE);
+
+    auto *conf = new Conformer{11u};
+    conf->setId(0u);
+
+    conf->setAtomPos(0u, RDGeom::Point3D{-0.95330, 0.60416, 1.01609});
+    conf->setAtomPos(1u, RDGeom::Point3D{-1.00832, 1.68746, 0.83520});
+    conf->setAtomPos(2u, RDGeom::Point3D{-1.96274, 0.16103, 0.94471});
+    conf->setAtomPos(3u, RDGeom::Point3D{-0.57701, 0.44737, 2.04167});
+    conf->setAtomPos(4u, RDGeom::Point3D{0.00000, 0.00000, 0.00000});
+    conf->setAtomPos(5u, RDGeom::Point3D{-0.43038, 0.18596, -1.01377});
+    conf->setAtomPos(6u, RDGeom::Point3D{0.22538, -1.36531, 0.19373});
+    conf->setAtomPos(7u, RDGeom::Point3D{1.21993, -1.33937, 0.14580});
+    conf->setAtomPos(8u, RDGeom::Point3D{1.38490, 0.73003, 0.00000});
+    conf->setAtomPos(9u, RDGeom::Point3D{1.38490, 1.96795, 0.00000});
+    conf->setAtomPos(10u, RDGeom::Point3D{2.35253, -0.07700, 0.00000});
+
+    mol->addConformer(conf);
+
+    const std::string cmlblock = MolToCMLBlock(*mol);
+    const std::string cmlblock_expected =
+        R"CML(<?xml version="1.0" encoding="utf-8"?>
+<cml:cml xmlns:cml="http://www.xml-cml.org/schema" xmlns:convention="http://www.xml-cml.org/convention/" convention="convention:molecular">
+  <cml:molecule id="m-1" formalCharge="-1" spinMultiplicity="1">
+    <cml:name>S-lactic acid</cml:name>
+    <cml:atomArray>
+      <cml:atom id="a0" elementType="C" formalCharge="0" hydrogenCount="3" x3="-0.953300" y3="0.604160" z3="1.016090"/>
+      <cml:atom id="a1" elementType="H" formalCharge="0" hydrogenCount="0" x3="-1.008320" y3="1.687460" z3="0.835200"/>
+      <cml:atom id="a2" elementType="H" formalCharge="0" hydrogenCount="0" x3="-1.962740" y3="0.161030" z3="0.944710"/>
+      <cml:atom id="a3" elementType="H" formalCharge="0" hydrogenCount="0" x3="-0.577010" y3="0.447370" z3="2.041670"/>
+      <cml:atom id="a4" elementType="C" formalCharge="0" hydrogenCount="1" x3="0.000000" y3="0.000000" z3="0.000000">
+        <cml:atomParity atomRefs4="a0 a5 a6 a8">-1</cml:atomParity>
+      </cml:atom>
+      <cml:atom id="a5" elementType="H" formalCharge="0" hydrogenCount="0" x3="-0.430380" y3="0.185960" z3="-1.013770"/>
+      <cml:atom id="a6" elementType="O" formalCharge="0" hydrogenCount="1" x3="0.225380" y3="-1.365310" z3="0.193730"/>
+      <cml:atom id="a7" elementType="H" formalCharge="0" hydrogenCount="0" isotopeNumber="2" x3="1.219930" y3="-1.339370" z3="0.145800"/>
+      <cml:atom id="a8" elementType="C" formalCharge="0" hydrogenCount="0" x3="1.384900" y3="0.730030" z3="0.000000"/>
+      <cml:atom id="a9" elementType="O" formalCharge="0" hydrogenCount="0" x3="1.384900" y3="1.967950" z3="0.000000"/>
+      <cml:atom id="a10" elementType="O" formalCharge="-1" hydrogenCount="0" x3="2.352530" y3="-0.077000" z3="0.000000"/>
+    </cml:atomArray>
+    <cml:bondArray>
+      <cml:bond atomRefs2="a0 a1" id="b0" order="S"/>
+      <cml:bond atomRefs2="a0 a2" id="b1" order="S"/>
+      <cml:bond atomRefs2="a0 a3" id="b2" order="S"/>
+      <cml:bond atomRefs2="a0 a4" id="b3" order="S"/>
+      <cml:bond atomRefs2="a4 a5" id="b4" order="S"/>
+      <cml:bond atomRefs2="a4 a6" id="b5" order="S"/>
+      <cml:bond atomRefs2="a4 a8" id="b6" order="S"/>
+      <cml:bond atomRefs2="a6 a7" id="b7" order="S"/>
+      <cml:bond atomRefs2="a8 a9" id="b8" order="D"/>
+      <cml:bond atomRefs2="a8 a10" id="b9" order="S"/>
+    </cml:bondArray>
+  </cml:molecule>
+</cml:cml>
+)CML";
+    CHECK(cmlblock == cmlblock_expected);
+  }
+}
+
 TEST_CASE("XYZ", "[XYZ][writer]") {
   SECTION("basics") {
     std::unique_ptr<RWMol> mol{new RWMol{}};

--- a/Code/GraphMol/Wrap/rdmolfiles.cpp
+++ b/Code/GraphMol/Wrap/rdmolfiles.cpp
@@ -944,9 +944,7 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
     - confId: (optional) selects which conformation to output\n\
     - kekulize: (optional) triggers kekulization of the molecule before it's written\n\
 \n";
-  python::def("MolToCMLBlock",
-              static_cast<std::string (*)(const ROMol &, int, bool)>(
-                  RDKit::MolToCMLBlock),
+  python::def("MolToCMLBlock", RDKit::MolToCMLBlock,
               (python::arg{"mol"}, python::arg{"confId"} = -1,
                python::arg{"kekulize"} = true),
               docString.c_str());

--- a/Code/GraphMol/Wrap/rdmolfiles.cpp
+++ b/Code/GraphMol/Wrap/rdmolfiles.cpp
@@ -934,6 +934,36 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
                python::arg("includeStereo") = true, python::arg("confId") = -1,
                python::arg("kekulize") = true),
               docString.c_str());
+  //
+
+  docString =
+      "Writes a CML block for a molecule\n\
+  ARGUMENTS:\n\
+\n\
+    - mol: the molecule\n\
+    - confId: (optional) selects which conformation to output\n\
+    - kekulize: (optional) triggers kekulization of the molecule before it's written\n\
+\n";
+  python::def("MolToCMLBlock",
+              static_cast<std::string (*)(const ROMol &, int, bool)>(
+                  RDKit::MolToCMLBlock),
+              (python::arg{"mol"}, python::arg{"confId"} = -1,
+               python::arg{"kekulize"} = true),
+              docString.c_str());
+
+  docString =
+      "Writes a CML file for a molecule\n\
+  ARGUMENTS:\n\
+\n\
+    - mol: the molecule\n\
+    - filename: the file to write to\n\
+    - confId: (optional) selects which conformation to output\n\
+    - kekulize: (optional) triggers kekulization of the molecule before it's written\n\
+\n";
+  python::def("MolToCMLFile", RDKit::MolToCMLFile,
+              (python::arg{"mol"}, python::arg{"filename"},
+               python::arg{"confId"} = -1, python::arg{"kekulize"} = true),
+              docString.c_str());
 
   //
 

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -5601,6 +5601,86 @@ M  END
     self.assertTrue(l[0] is not None)
     self.assertTrue(l[1] is not None)
 
+  def testCMLWriter(self):
+    self.maxDiff = None  # XXX
+    conf = Chem.Conformer(11)
+
+    conf.SetAtomPosition(0, [-0.95330, 0.60416, 1.01609])
+    conf.SetAtomPosition(1, [-1.00832, 1.68746, 0.83520])
+    conf.SetAtomPosition(2, [-1.96274, 0.16103, 0.94471])
+    conf.SetAtomPosition(3, [-0.57701, 0.44737, 2.04167])
+    conf.SetAtomPosition(4, [0.00000, 0.00000, 0.00000])
+    conf.SetAtomPosition(5, [-0.43038, 0.18596, -1.01377])
+    conf.SetAtomPosition(6, [0.22538, -1.36531, 0.19373])
+    conf.SetAtomPosition(7, [1.21993, -1.33937, 0.14580])
+    conf.SetAtomPosition(8, [1.38490, 0.73003, 0.00000])
+    conf.SetAtomPosition(9, [1.38490, 1.96795, 0.00000])
+    conf.SetAtomPosition(10, [2.35253, -0.07700, 0.00000])
+
+    emol = Chem.EditableMol(Chem.Mol())
+    for z in [6, 1, 1, 1, 6, 1, 8, 1, 6, 8, 8]:
+      emol.AddAtom(Chem.Atom(z))
+
+    emol.AddBond(0, 1, Chem.BondType.SINGLE)
+    emol.AddBond(0, 2, Chem.BondType.SINGLE)
+    emol.AddBond(0, 3, Chem.BondType.SINGLE)
+    emol.AddBond(0, 4, Chem.BondType.SINGLE)
+    emol.AddBond(4, 5, Chem.BondType.SINGLE)
+    emol.AddBond(4, 6, Chem.BondType.SINGLE)
+    emol.AddBond(4, 8, Chem.BondType.SINGLE)
+    emol.AddBond(6, 7, Chem.BondType.SINGLE)
+    emol.AddBond(8, 9, Chem.BondType.DOUBLE)
+    emol.AddBond(8, 10, Chem.BondType.SINGLE)
+
+    mol = emol.GetMol()
+    mol.SetProp('_Name', 'S-lactic acid')
+    mol.AddConformer(conf)
+
+    mol.GetAtomWithIdx(0).SetNumExplicitHs(3)
+    mol.GetAtomWithIdx(4).SetNumExplicitHs(1)
+    mol.GetAtomWithIdx(6).SetNumExplicitHs(1)
+    mol.GetAtomWithIdx(7).SetIsotope(2)
+    mol.GetAtomWithIdx(10).SetFormalCharge(-1)
+
+    mol.GetAtomWithIdx(4).SetChiralTag(Chem.ChiralType.CHI_TETRAHEDRAL_CCW)
+
+    cmlblock_expected = """<?xml version="1.0" encoding="utf-8"?>
+<cml:cml xmlns:cml="http://www.xml-cml.org/schema" xmlns:convention="http://www.xml-cml.org/convention/" convention="convention:molecular">
+  <cml:molecule id="m-1" formalCharge="-1" spinMultiplicity="1">
+    <cml:name>S-lactic acid</cml:name>
+    <cml:atomArray>
+      <cml:atom id="a0" elementType="C" formalCharge="0" hydrogenCount="3" x3="-0.953300" y3="0.604160" z3="1.016090"/>
+      <cml:atom id="a1" elementType="H" formalCharge="0" hydrogenCount="0" x3="-1.008320" y3="1.687460" z3="0.835200"/>
+      <cml:atom id="a2" elementType="H" formalCharge="0" hydrogenCount="0" x3="-1.962740" y3="0.161030" z3="0.944710"/>
+      <cml:atom id="a3" elementType="H" formalCharge="0" hydrogenCount="0" x3="-0.577010" y3="0.447370" z3="2.041670"/>
+      <cml:atom id="a4" elementType="C" formalCharge="0" hydrogenCount="1" x3="0.000000" y3="0.000000" z3="0.000000">
+        <cml:atomParity atomRefs4="a0 a5 a6 a8">-1</cml:atomParity>
+      </cml:atom>
+      <cml:atom id="a5" elementType="H" formalCharge="0" hydrogenCount="0" x3="-0.430380" y3="0.185960" z3="-1.013770"/>
+      <cml:atom id="a6" elementType="O" formalCharge="0" hydrogenCount="1" x3="0.225380" y3="-1.365310" z3="0.193730"/>
+      <cml:atom id="a7" elementType="H" formalCharge="0" hydrogenCount="0" isotopeNumber="2" x3="1.219930" y3="-1.339370" z3="0.145800"/>
+      <cml:atom id="a8" elementType="C" formalCharge="0" hydrogenCount="0" x3="1.384900" y3="0.730030" z3="0.000000"/>
+      <cml:atom id="a9" elementType="O" formalCharge="0" hydrogenCount="0" x3="1.384900" y3="1.967950" z3="0.000000"/>
+      <cml:atom id="a10" elementType="O" formalCharge="-1" hydrogenCount="0" x3="2.352530" y3="-0.077000" z3="0.000000"/>
+    </cml:atomArray>
+    <cml:bondArray>
+      <cml:bond atomRefs2="a0 a1" id="b0" order="S"/>
+      <cml:bond atomRefs2="a0 a2" id="b1" order="S"/>
+      <cml:bond atomRefs2="a0 a3" id="b2" order="S"/>
+      <cml:bond atomRefs2="a0 a4" id="b3" order="S"/>
+      <cml:bond atomRefs2="a4 a5" id="b4" order="S"/>
+      <cml:bond atomRefs2="a4 a6" id="b5" order="S"/>
+      <cml:bond atomRefs2="a4 a8" id="b6" order="S"/>
+      <cml:bond atomRefs2="a6 a7" id="b7" order="S"/>
+      <cml:bond atomRefs2="a8 a9" id="b8" order="D"/>
+      <cml:bond atomRefs2="a8 a10" id="b9" order="S"/>
+    </cml:bondArray>
+  </cml:molecule>
+</cml:cml>
+"""
+
+    self.assertEqual(Chem.MolToCMLBlock(mol), cmlblock_expected)
+
   def testXYZ(self):
     conf = Chem.Conformer(5)
     conf.SetAtomPosition(0, [0.000, 0.000, 0.000])

--- a/Code/JavaWrappers/ROMol.i
+++ b/Code/JavaWrappers/ROMol.i
@@ -190,6 +190,13 @@ void setPreferCoordGen(bool);
     return RDKit::MolToHELM(*($self));
   }
 
+  std::string MolToCMLBlock(int confId=-1, bool kekulize=true) {
+    return RDKit::MolToCMLBlock(*($self), confId, kekulize);
+  }
+  void MolToCMLFile(std::string fName, int confId=-1, bool kekulize=true) {
+    RDKit::MolToCMLFile(*($self), fName, confId, kekulize);
+  }
+
   std::string MolToXYZBlock(int confId=-1) {
     return RDKit::MolToXYZBlock(*($self), confId);
   }


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! 

#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.
Support Chemical Markup Language, CML, for writing
http://www.xml-cml.org/

CML is an XML variant and thus machine-friendly.

Example:
```python
from rdkit import Chem

mol = """acrylonitrile


  7  6  0  0  0  0  0  0  0  0999 V2000
   -0.6992   -1.1405    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
    0.0000    0.0000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
    1.5210    0.0000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
    2.7820    0.0000    0.0000 N   0  0  0  0  0  0  0  0  0  0  0  0
   -1.7845   -1.1255    0.0000 H   0  0  0  0  0  0  0  0  0  0  0  0
   -0.2103   -2.1109    0.0000 H   0  0  0  0  0  0  0  0  0  0  0  0
   -0.4773    0.9730    0.0000 H   0  0  0  0  0  0  0  0  0  0  0  0
  1  2  2  3
  1  5  1  0
  1  6  1  0
  2  3  1  0
  2  7  1  0
  3  4  3  0
M  ISO  1   7   2
M  END
"""

m = Chem.MolFromMolBlock(mol, removeHs=False)
print(Chem.MolToCMLBlock(m))
```

produces

```xml
<?xml version="1.0" encoding="utf-8"?>
<cml:cml xmlns:cml="http://www.xml-cml.org/schema" xmlns:convention="http://www.xml-cml.org/convention/" convention="convention:molecular">
  <cml:molecule id="m-1" formalCharge="0" spinMultiplicity="1">
    <cml:name>acrylonitrile</cml:name>
    <cml:atomArray>
      <cml:atom id="a0" elementType="C" formalCharge="0" hydrogenCount="2" spinMultiplicity="1" x3="-0.699200" y3="-1.140500" z3="0.000000"/>
      <cml:atom id="a1" elementType="C" formalCharge="0" hydrogenCount="1" spinMultiplicity="1" x3="0.000000" y3="0.000000" z3="0.000000"/>
      <cml:atom id="a2" elementType="C" formalCharge="0" hydrogenCount="0" spinMultiplicity="1" x3="1.521000" y3="0.000000" z3="0.000000"/>
      <cml:atom id="a3" elementType="N" formalCharge="0" hydrogenCount="0" spinMultiplicity="1" x3="2.782000" y3="0.000000" z3="0.000000"/>
      <cml:atom id="a4" elementType="H" formalCharge="0" hydrogenCount="0" spinMultiplicity="1" x3="-1.784500" y3="-1.125500" z3="0.000000"/>
      <cml:atom id="a5" elementType="H" formalCharge="0" hydrogenCount="0" spinMultiplicity="1" x3="-0.210300" y3="-2.110900" z3="0.000000"/>
      <cml:atom id="a6" elementType="H" formalCharge="0" hydrogenCount="0" isotopeNumber="2" spinMultiplicity="1" x3="-0.477300" y3="0.973000" z3="0.000000"/>
    </cml:atomArray>
    <cml:bondArray>
      <cml:bond atomRefs2="a0 a1" id="b0" order="2"/>
      <cml:bond atomRefs2="a0 a4" id="b1" order="1"/>
      <cml:bond atomRefs2="a0 a5" id="b2" order="1"/>
      <cml:bond atomRefs2="a1 a2" id="b3" order="1"/>
      <cml:bond atomRefs2="a1 a6" id="b4" order="1"/>
      <cml:bond atomRefs2="a2 a3" id="b5" order="3"/>
    </cml:bondArray>
  </cml:molecule>
</cml:cml>
```

Note that `hydrogenCount` is manually corrected.

#### Any other comments?
TODO
- [x] test