### PR TITLE
Removed dllexport from a function that lives in the anonymous namespace

### DIFF
--- a/Code/SimDivPickers/DistPicker.h
+++ b/Code/SimDivPickers/DistPicker.h
@@ -75,7 +75,7 @@ class RDKIT_SIMDIVPICKERS_EXPORT DistPicker {
 };
 
 namespace {
-class RDKIT_SIMDIVPICKERS_EXPORT distmatFunctor {
+class distmatFunctor {
  public:
   distmatFunctor(const double *distMat) : dp_distMat(distMat){};
   double operator()(unsigned int i, unsigned int j) {


### PR DESCRIPTION
That function is in the anonymous namespace so it is not reachable anyway, hence no point in exporting it. The `dllexport` raises a build error when building DLLs on Windows, though only in `Debug` mode for some reason.