### PR TITLE
This commit fixes the bug "segmenation fault/core dump when chargePar…

### DIFF
--- a/Code/GraphMol/MolStandardize/MolStandardize.cpp
+++ b/Code/GraphMol/MolStandardize/MolStandardize.cpp
@@ -64,7 +64,6 @@ RWMol *fragmentParent(const RWMol &mol, const CleanupParameters &params,
   LargestFragmentChooser lfragchooser(params.preferOrganic);
   ROMol nm(*cleaned);
   ROMOL_SPTR lfrag(lfragchooser.choose(nm));
-  delete cleaned;
   return new RWMol(*lfrag);
 }
 
@@ -85,13 +84,16 @@ RWMol *chargeParent(const RWMol &mol, const CleanupParameters &params,
   // Return the charge parent of a given molecule.
   // The charge parent is the uncharged version of the fragment parent.
 
-  RWMol *m = nullptr;
+  const RWMol *m = nullptr;
 
   if (!skip_standardize) {
     m = cleanup(mol, params);
+  } else {
+    m = &mol;
   }
 
-  RWMOL_SPTR fragparent(fragmentParent(*m, params, true));
+
+  RWMOL_SPTR fragparent(fragmentParent(*m, params, skip_standardize));
 
   // if fragment...
   ROMol nm(*fragparent);

--- a/Code/GraphMol/MolStandardize/MolStandardize.cpp
+++ b/Code/GraphMol/MolStandardize/MolStandardize.cpp
@@ -64,6 +64,11 @@ RWMol *fragmentParent(const RWMol &mol, const CleanupParameters &params,
   LargestFragmentChooser lfragchooser(params.preferOrganic);
   ROMol nm(*cleaned);
   ROMOL_SPTR lfrag(lfragchooser.choose(nm));
+
+  if (!skip_standardize) {
+    delete cleaned;
+  }
+
   return new RWMol(*lfrag);
 }
 
@@ -101,6 +106,9 @@ RWMol *chargeParent(const RWMol &mol, const CleanupParameters &params,
   Uncharger uncharger(params.doCanonical);
   ROMOL_SPTR uncharged(uncharger.uncharge(nm));
   RWMol *omol = cleanup(static_cast<RWMol>(*uncharged), params);
+  if (!skip_standardize) {
+    delete m;
+  }
   return omol;
 }
 

--- a/Code/GraphMol/MolStandardize/catch_tests.cpp
+++ b/Code/GraphMol/MolStandardize/catch_tests.cpp
@@ -603,7 +603,7 @@ TEST_CASE("github #2965: molecules properties not retained after cleanup", "[cle
 } 
 
 TEST_CASE("github #2970: chargeParent() segmentation fault when standardization is skipped i.e. skip_standardize is set to true") {
-    std::unique_ptr<RWMol> m(SmilesToMol("COC=1C=CC(NC=2N=CN=C3NC=NC23)=CC1"));
+    auto m = "COC=1C=CC(NC=2N=CN=C3NC=NC23)=CC1"_smiles;
     REQUIRE(m);
     MolStandardize::CleanupParameters params;
     std::unique_ptr<RWMol> res(MolStandardize::cleanup(*m, params));

--- a/Code/GraphMol/MolStandardize/catch_tests.cpp
+++ b/Code/GraphMol/MolStandardize/catch_tests.cpp
@@ -601,3 +601,15 @@ TEST_CASE("github #2965: molecules properties not retained after cleanup", "[cle
 	CHECK(x.getVal<std::string>("testing_prop") == "1234");
   }
 } 
+
+TEST_CASE("github #2970: chargeParent() segmentation fault when standardization is skipped i.e. skip_standardize is set to true") {
+    std::unique_ptr<RWMol> m(SmilesToMol("COC=1C=CC(NC=2N=CN=C3NC=NC23)=CC1"));
+    REQUIRE(m);
+    MolStandardize::CleanupParameters params;
+    std::unique_ptr<RWMol> res(MolStandardize::cleanup(*m, params));
+
+    std::unique_ptr<ROMol> outm(MolStandardize::chargeParent(*res, params, true));
+
+    REQUIRE(outm);
+    CHECK(MolToSmiles(*outm) == "COc1ccc(Nc2ncnc3[nH]cnc23)cc1");
+}


### PR DESCRIPTION
…ent is run with skip_standardize set to true" mentioned in #2970

Fixes issue #2970 

According to issue #2970 , a core dump/segmentation fault occurred when the chargeParent function was called with skip_standardize set to true. This was because of a line in function ```fragmentParent``` of Code/MolStandardize/MolStandardize.cpp which deleted the variable ```cleaned```. However when ```skip_standardize``` was set to true, the ```cleaned``` variable pointed to the original argument variable. Hence, its deletion caused a segmentation fault.
Moreover, a test for the same has also been implemented in  Code/MolStandardize/catch_tests.cpp


