### PR TITLE
Fix/add patterns reset holders

### DIFF
--- a/Code/GraphMol/SubstructLibrary/PatternFactory.cpp
+++ b/Code/GraphMol/SubstructLibrary/PatternFactory.cpp
@@ -9,6 +9,7 @@
 //
 #include "SubstructLibrary.h"
 #include "PatternFactory.h"
+#include <RDGeneral/RDThreads.h>
 
 #ifdef RDK_THREADSAFE_SSS
 #include <thread>
@@ -31,6 +32,8 @@ void fillPatterns(const SubstructLibrary &slib,
   
 void addPatterns(SubstructLibrary &sslib, int numThreads) {
   PRECONDITION(sslib.getFpHolder().get() == nullptr, "Substruct library already has fingerprints");
+  numThreads = (int)getNumThreadsToUse(numThreads);
+  
   boost::shared_ptr<PatternHolder> ptr(new PatternHolder);
   std::vector<ExplicitBitVect *> & fps = ptr->getFingerprints();
   unsigned int startIdx = 0;
@@ -53,7 +56,11 @@ void addPatterns(SubstructLibrary &sslib, int numThreads) {
 #else
   fillPaterns(lib, fps, 0, sslib.size(), 1);
 #endif
+  if (ptr->size() != sslib.size()) {
+    throw ValueErrorException("Number of fingerprints generated not equal to current number of molecules");
+  }
   
   sslib.getFpHolder() = ptr;
+  sslib.resetHolders();
 }
 }

--- a/Code/GraphMol/SubstructLibrary/SubstructLibrary.cpp
+++ b/Code/GraphMol/SubstructLibrary/SubstructLibrary.cpp
@@ -186,11 +186,7 @@ std::vector<unsigned int> internalGetMatches(
     int maxResults = 1000) {
   PRECONDITION(startIdx < mols.size(), "startIdx out of bounds");
   PRECONDITION(endIdx > startIdx, "endIdx > startIdx");
-  if (numThreads == -1) {
-    numThreads = (int)getNumThreadsToUse(numThreads);
-  } else {
-    numThreads = std::min(numThreads, (int)getNumThreadsToUse(numThreads));
-  }
+  numThreads = (int)getNumThreadsToUse(numThreads);
 
   endIdx = std::min(mols.size(), endIdx);
   if (endIdx < static_cast<unsigned int>(numThreads)) {
@@ -243,11 +239,7 @@ int internalMatchCounter(const ROMol &query, MolHolderBase &mols,
 
   endIdx = std::min(mols.size(), endIdx);
 
-  if (numThreads == -1) {
-    numThreads = (int)getNumThreadsToUse(numThreads);
-  } else {
-    numThreads = std::min(numThreads, (int)getNumThreadsToUse(numThreads));
-  }
+  numThreads = (int)getNumThreadsToUse(numThreads);
 
   if (endIdx < static_cast<unsigned int>(numThreads)) {
     numThreads = endIdx;

--- a/Code/GraphMol/SubstructLibrary/Wrap/rough_test.py
+++ b/Code/GraphMol/SubstructLibrary/Wrap/rough_test.py
@@ -413,6 +413,9 @@ class TestCase(unittest.TestCase):
     for nthreads in [1, 2, 0]:
       slib_without_patterns = rdSubstructLibrary.SubstructLibrary(holder, None)
       rdSubstructLibrary.AddPatterns(slib_without_patterns, nthreads)
+      # check for seg fault
+      #  were the fingerprints really created
+      slib_without_patterns.GetFpHolder().GetFingerprint(0)
       for mol in mols:
         l1 = slib_with_patterns.CountMatches(mol)
         l2 = slib_without_patterns.CountMatches(mol)


### PR DESCRIPTION
There were two bugs:

If numThreads was set to 0, no fingerprints were made.  This caused the patterns not to actually be made which causes a seg fault when trying to explicitly get a fingerprint at an index.

```
lib.GetFpHolder().GetFingerprint(0)
```

would seg fault.