### PR TITLE
Tweaks and refinements to new drawing code.

### DIFF
--- a/Code/GraphMol/MolDraw2D/CMakeLists.txt
+++ b/Code/GraphMol/MolDraw2D/CMakeLists.txt
@@ -8,7 +8,6 @@ rdkit_headers(MolDraw2D.h
   MolDraw2DSVG.h
   MolDraw2Dwx.h
   MolDraw2DUtils.h
-  MolDraw2DDetails.h
   DEST GraphMol/MolDraw2D
 )
 

--- a/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
@@ -1277,13 +1277,13 @@ unique_ptr<RWMol> MolDraw2D::setupDrawMolecule(
     curr_width_ = drawOptions().bondLineWidth;
   }
   if (drawOptions().addStereoAnnotation) {
-    MolDraw2DUtils::addStereoAnnotation(draw_mol);
+    MolDraw2D_detail::addStereoAnnotation(draw_mol);
   }
   if (drawOptions().addAtomIndices) {
-    MolDraw2DUtils::addAtomIndices(draw_mol);
+    MolDraw2D_detail::addAtomIndices(draw_mol);
   }
   if (drawOptions().addBondIndices) {
-    MolDraw2DUtils::addBondIndices(draw_mol);
+    MolDraw2D_detail::addBondIndices(draw_mol);
   }
   if (!activeMolIdx_) {  // on the first pass we need to do some work
     if (drawOptions().clearBackground) {

--- a/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
@@ -1277,7 +1277,13 @@ unique_ptr<RWMol> MolDraw2D::setupDrawMolecule(
     curr_width_ = drawOptions().bondLineWidth;
   }
   if (drawOptions().addStereoAnnotation) {
-    addStereoAnnotation(draw_mol);
+    MolDraw2DUtils::addStereoAnnotation(draw_mol);
+  }
+  if (drawOptions().addAtomIndices) {
+    MolDraw2DUtils::addAtomIndices(draw_mol);
+  }
+  if (drawOptions().addBondIndices) {
+    MolDraw2DUtils::addBondIndices(draw_mol);
   }
   if (!activeMolIdx_) {  // on the first pass we need to do some work
     if (drawOptions().clearBackground) {
@@ -1418,14 +1424,14 @@ void MolDraw2D::finishMoleculeDraw(const RDKit::ROMol &draw_mol,
   }
   for (auto atom : draw_mol.atoms()) {
     if (supportsAnnotations() && atom_notes_[activeMolIdx_][atom->getIdx()]) {
-      drawAnnotation(atom->getProp<string>("atomNote"),
+      drawAnnotation(atom->getProp<string>(common_properties::atomNote),
                      atom_notes_[activeMolIdx_][atom->getIdx()]);
     }
   }
 
   for (auto bond : draw_mol.bonds()) {
     if (supportsAnnotations() && bond_notes_[activeMolIdx_][bond->getIdx()]) {
-      drawAnnotation(bond->getProp<string>("bondNote"),
+      drawAnnotation(bond->getProp<string>(common_properties::bondNote),
                      bond_notes_[activeMolIdx_][bond->getIdx()]);
     }
   }
@@ -1576,7 +1582,7 @@ void MolDraw2D::calcLabelEllipse(int atom_idx,
 StringRect MolDraw2D::calcAnnotationPosition(const ROMol &mol,
                                              const Atom *atom) {
   StringRect note_rect;
-  string note = atom->getProp<string>("atomNote");
+  string note = atom->getProp<string>(common_properties::atomNote);
   if (note.empty()) {
     note_rect.width_ = -1.0;  // so we know it's not valid.
     return note_rect;
@@ -1605,7 +1611,7 @@ StringRect MolDraw2D::calcAnnotationPosition(const ROMol &mol,
 StringRect MolDraw2D::calcAnnotationPosition(const ROMol &mol,
                                              const Bond *bond) {
   StringRect note_rect;
-  string note = bond->getProp<string>("bondNote");
+  string note = bond->getProp<string>(common_properties::bondNote);
   if (note.empty()) {
     note_rect.width_ = -1.0;  // so we know it's not valid.
     return note_rect;
@@ -1932,10 +1938,10 @@ void MolDraw2D::extractAtomNotes(const ROMol &mol) {
 
   StringRect *note_rect;
   for (auto atom : mol.atoms()) {
-    if (!atom->hasProp("atomNote")) {
+    if (!atom->hasProp(common_properties::atomNote)) {
       note_rect = nullptr;
     } else {
-      string note = atom->getProp<string>("atomNote");
+      string note = atom->getProp<string>(common_properties::atomNote);
       if (note.empty()) {
         note_rect = nullptr;
       } else {
@@ -1961,10 +1967,10 @@ void MolDraw2D::extractBondNotes(const ROMol &mol) {
 
   StringRect *note_rect;
   for (auto bond : mol.bonds()) {
-    if (!bond->hasProp("bondNote")) {
+    if (!bond->hasProp(common_properties::bondNote)) {
       note_rect = nullptr;
     } else {
-      string note = bond->getProp<string>("bondNote");
+      string note = bond->getProp<string>(common_properties::bondNote);
       if (note.empty()) {
         note_rect = nullptr;
       } else {
@@ -3191,23 +3197,6 @@ void MolDraw2D::tabulaRasa() {
   x_offset_ = y_offset_ = 0;
   font_size_ = 0.5;
   curr_width_ = 2;
-}
-
-// ****************************************************************************
-void MolDraw2D::addStereoAnnotation(const ROMol &mol) {
-  for (auto atom : mol.atoms()) {
-    if (atom->hasProp("_CIPCode")) {
-      std::string lab = "(" + atom->getProp<std::string>("_CIPCode") + ")";
-      atom->setProp("atomNote", lab);
-    }
-  }
-  for (auto bond : mol.bonds()) {
-    if (bond->getStereo() == Bond::STEREOE) {
-      bond->setProp("bondNote", "(E)");
-    } else if (bond->getStereo() == Bond::STEREOZ) {
-      bond->setProp("bondNote", "(Z)");
-    }
-  }
 }
 
 // ****************************************************************************

--- a/Code/GraphMol/MolDraw2D/MolDraw2D.h
+++ b/Code/GraphMol/MolDraw2D/MolDraw2D.h
@@ -58,23 +58,22 @@ struct DrawColour {
     PRECONDITION(v != 0.0, "divide by zero");
     return {r / v, g / v, b / v, a / v};
   }
-  DrawColour operator*(double v) const {
-    return {r * v, g * v, b * v, a * v};
-  }
+  DrawColour operator*(double v) const { return {r * v, g * v, b * v, a * v}; }
 };
 
 // for holding dimensions of the rectangle round a string.
 struct StringRect {
   Point2D centre_;
   double width_, height_;
-  int clash_score_; // rough measure of how badly it clashed with other things
-                    // lower is better, 0 is no clash.
-  StringRect() : centre_(0.0, 0.0), width_(0.0), height_(0.0), clash_score_(0) {}
-  StringRect(const Point2D &in_cds) : centre_(in_cds), width_(0.0),
-                                      height_(0.0), clash_score_(0) {}
+  int clash_score_;  // rough measure of how badly it clashed with other things
+                     // lower is better, 0 is no clash.
+  StringRect()
+      : centre_(0.0, 0.0), width_(0.0), height_(0.0), clash_score_(0) {}
+  StringRect(const Point2D &in_cds)
+      : centre_(in_cds), width_(0.0), height_(0.0), clash_score_(0) {}
   bool doesItIntersect(const StringRect &other) const {
-    if(fabs(centre_.x - other.centre_.x) < (width_ + other.width_) / 2.0
-       && fabs(centre_.y - other.centre_.y) < (height_ + other.height_) / 2.0) {
+    if (fabs(centre_.x - other.centre_.x) < (width_ + other.width_) / 2.0 &&
+        fabs(centre_.y - other.centre_.y) < (height_ + other.height_) / 2.0) {
       return true;
     }
     return false;
@@ -105,111 +104,98 @@ inline void assignBWPalette(ColourPalette &palette) {
 };
 
 struct RDKIT_MOLDRAW2D_EXPORT MolDrawOptions {
-  bool atomLabelDeuteriumTritium;  // toggles replacing 2H with D and 3H with T
-  bool dummiesAreAttachments;      // draws "breaks" at dummy atoms
-  bool circleAtoms;                // draws circles under highlighted atoms
-  DrawColour highlightColour;      // default highlight color
-  bool continuousHighlight;  // highlight by drawing an outline *underneath* the
-                             // molecule
-  bool fillHighlights;       // fill the areas used to highlight atoms and atom
-                             // regions
-  double highlightRadius; // default if nothing given for a particular atom.
-                          // default=0.3 "Angstrom".
-  int flagCloseContactsDist;  // if positive, this will be used as a cutoff (in
-                              // pixels) for highlighting close contacts
-  bool includeAtomTags;  // toggles inclusion of atom tags in the output. does
-                         // not make sense for all renderers.
-  bool clearBackground;  // toggles clearing the background before drawing a
-                         // molecule
-  DrawColour
-      backgroundColour;  // color to be used while clearing the background
-  int legendFontSize;    // font size (in pixels) to be used for the legend (if
-                         // present)
-  int maxFontSize;  // maximum size in pixels for font in drawn molecule.
-                    // default=40. -1 means no max.
-  double annotationFontScale;  // scales font relative to atom labels for
-                               // atom and bond annotation. default=0.75.
-  DrawColour legendColour;    // color to be used for the legend (if present)
-  double multipleBondOffset;  // offset (in Angstrom) for the extra lines in a
-                              // multiple bond
-  double padding;  // fraction of empty space to leave around the molecule
-  double additionalAtomLabelPadding;  // additional padding to leave around atom
-                                      // labels. Expressed as a fraction of the
-                                      // font size.
-  std::map<int, std::string> atomLabels;      // replacement labels for atoms
+  bool atomLabelDeuteriumTritium =
+      false;  // toggles replacing 2H with D and 3H with T
+  bool dummiesAreAttachments = false;  // draws "breaks" at dummy atoms
+  bool circleAtoms = true;             // draws circles under highlighted atoms
+  DrawColour highlightColour{1, 0.5, 0.5};  // default highlight color
+  bool continuousHighlight = true;          // highlight by drawing an outline
+                                            // *underneath* the molecule
+  bool fillHighlights = true;     // fill the areas used to highlight atoms and
+                                  // atom regions
+  double highlightRadius = 0.3;   // default if nothing given for a particular
+                                  // atom. units are "Angstrom"
+  int flagCloseContactsDist = 3;  // if positive, this will be used as a cutoff
+                                  // (in pixels) for highlighting close contacts
+  bool includeAtomTags =
+      false;  // toggles inclusion of atom tags in the output. does
+              // not make sense for all renderers.
+  bool clearBackground = true;  // toggles clearing the background before
+                                // drawing a molecule
+  DrawColour backgroundColour{
+      1, 1, 1};             // color to be used while clearing the background
+  int legendFontSize = 12;  // font size (in pixels) to be used for the legend
+                            // (if present)
+  int maxFontSize = 40;  // maximum size in pixels for font in drawn molecule.
+                         // -1 means no max.
+  double annotationFontScale = 0.75;  // scales font relative to atom labels for
+                                      // atom and bond annotation.
+  DrawColour legendColour{0, 0,
+                          0};  // color to be used for the legend (if present)
+  double multipleBondOffset = 0.15;  // offset (in Angstrom) for the extra lines
+                                     // in a multiple bond
+  double padding =
+      0.05;  // fraction of empty space to leave around the molecule
+  double additionalAtomLabelPadding = 0.0;  // additional padding to leave
+                                            // around atom labels. Expressed as
+                                            // a fraction of the font size.
+  std::map<int, std::string> atomLabels;    // replacement labels for atoms
   std::vector<std::vector<int>> atomRegions;  // regions
-  DrawColour
-      symbolColour;  // color to be used for the symbols and arrows in reactions
-  int bondLineWidth;  // if positive, this overrides the default line width
-                      // when drawing bonds
-  int highlightBondWidthMultiplier; // what to multiply standard bond width
-                                    // by for highlighting. Default is 8.
-  bool prepareMolsBeforeDrawing;  // call prepareMolForDrawing() on each
-                                  // molecule passed to drawMolecules()
+  DrawColour symbolColour{
+      0, 0, 0};  // color to be used for the symbols and arrows in reactions
+  int bondLineWidth = -1;  // if positive, this overrides the default line width
+                           // when drawing bonds
+  int highlightBondWidthMultiplier = 8;  // what to multiply standard bond width
+                                         // by for highlighting.
+  bool prepareMolsBeforeDrawing = true;  // call prepareMolForDrawing() on each
+                                         // molecule passed to drawMolecules()
   std::vector<DrawColour> highlightColourPalette;  // defining 10 default colors
   // for highlighting atoms and bonds
   // or reactants in a reactions
   ColourPalette atomColourPalette;  // the palette used to assign
                                     // colors to atoms based on
-                                    // atomic number. -1 is the default value
-  double fixedScale; // fixes scale to this fraction of draw window width, so
-                     // an average bond is this fraction of the width.  If
-                     // scale comes out smaller than this, reduces scale, but
-                     // won't make it larger.  Default -1.0 means no fix.
-  double fixedBondLength; // fixes the bond length (and hence the scale) to
-                          // always be this number of pixels.  Assuming a bond
-                          // length in coordinates is 1, as is normal.  If
-                          // scale comes out smaller than this, reduces scale, but
-                          // won't make it larger.  Default -1.0 means no fix.
-                          // If both fixedScale and fixedBondLength are > 0.0,
-                          // fixedScale wins.
-  double rotate; // angle in degrees to rotate coords by about centre before
-                 // drawing. default=0.0.
-  bool addStereoAnnotation; // adds E/Z and R/S to drawings.  Default false.
-  bool atomHighlightsAreCircles; // forces atom highlights always to be circles.
-                                 // Default (false) is to put ellipses round
-                                 // longer labels.
-  bool centreMoleculesB4Drawing; // moves the centre of the drawn molecule to
-                                 // (0,0).  Default=true.
+                                    // atomic number.
+  double fixedScale =
+      -1.0;  // fixes scale to this fraction of draw window width, so
+             // an average bond is this fraction of the width.  If
+             // scale comes out smaller than this, reduces scale, but
+             // won't make it larger.  The default of -1.0 means no fix.
+  double fixedBondLength =
+      -1.0;             // fixes the bond length (and hence the scale) to
+                        // always be this number of pixels.  Assuming a bond
+                        // length in coordinates is 1, as is normal.  If
+                        // scale comes out smaller than this, reduces scale,
+                        // but won't make it larger.  The default -1.0 means no
+                        // fix. If both fixedScale and fixedBondLength are >
+                        // 0.0, fixedScale wins.
+  double rotate = 0.0;  // angle in degrees to rotate coords by about centre
+                        // before drawing.
+  bool addAtomIndices = false;  // adds atom indices to drawings.
+  bool addBondIndices = false;  // adds bond indices to drawings.
 
-  MolDrawOptions()
-      : atomLabelDeuteriumTritium(false),
-        dummiesAreAttachments(false),
-        circleAtoms(true),
-        highlightColour(1, .5, .5),
-        continuousHighlight(true),
-        fillHighlights(true),
-        highlightRadius(0.3),
-        flagCloseContactsDist(3),
-        includeAtomTags(false),
-        clearBackground(true),
-        backgroundColour(1, 1, 1),
-        legendFontSize(12),
-        maxFontSize(40),
-        annotationFontScale(0.75),
-        legendColour(0, 0, 0),
-        multipleBondOffset(0.15),
-        padding(0.05),
-        additionalAtomLabelPadding(0.0),
-        symbolColour(0, 0, 0),
-        bondLineWidth(-1),
-        highlightBondWidthMultiplier(8),
-        prepareMolsBeforeDrawing(true),
-        fixedScale(-1.0),
-        fixedBondLength(-1.0),
-        rotate(0.0),
-        addStereoAnnotation(false),
-        atomHighlightsAreCircles(false),
-        centreMoleculesB4Drawing(true) {
-    highlightColourPalette.emplace_back(DrawColour(1., 1., .67));  // popcorn yellow
+  bool addStereoAnnotation = false;       // adds E/Z and R/S to drawings.
+  bool atomHighlightsAreCircles = false;  // forces atom highlights always to be
+                                          // circles. Default (false) is to put
+                                          // ellipses round longer labels.
+  bool centreMoleculesBeforeDrawing = true;  // moves the centre of the drawn
+                                             // molecule to (0,0)
+
+  MolDrawOptions() {
+    highlightColourPalette.emplace_back(
+        DrawColour(1., 1., .67));  // popcorn yellow
     highlightColourPalette.emplace_back(DrawColour(1., .8, .6));  // sand
-    highlightColourPalette.emplace_back(DrawColour(1., .71, .76));  // light pink
-    highlightColourPalette.emplace_back(DrawColour(.8, 1., .8));  // offwhitegreen
+    highlightColourPalette.emplace_back(
+        DrawColour(1., .71, .76));  // light pink
+    highlightColourPalette.emplace_back(
+        DrawColour(.8, 1., .8));  // offwhitegreen
     highlightColourPalette.emplace_back(DrawColour(.87, .63, .87));  // plum
-    highlightColourPalette.emplace_back(DrawColour(.76, .94, .96));  // pastel blue
-    highlightColourPalette.emplace_back(DrawColour(.67, .67, 1.));   // periwinkle
+    highlightColourPalette.emplace_back(
+        DrawColour(.76, .94, .96));  // pastel blue
+    highlightColourPalette.emplace_back(
+        DrawColour(.67, .67, 1.));  // periwinkle
     highlightColourPalette.emplace_back(DrawColour(.64, .76, .34));  // avocado
-    highlightColourPalette.emplace_back(DrawColour(.56, .93, .56));  // light green
+    highlightColourPalette.emplace_back(
+        DrawColour(.56, .93, .56));  // light green
     highlightColourPalette.emplace_back(DrawColour(.20, .63, .79));  // peacock
     assignDefaultPalette(atomColourPalette);
   };
@@ -575,12 +561,7 @@ class RDKIT_MOLDRAW2D_EXPORT MolDraw2D {
   // reset to default values all the things the c'tor sets
   void tabulaRasa();
 
-  // add R/S and E/Z annotation to atoms and bonds respectively.
-  void addStereoAnnotation(const ROMol &mol);
-
-  virtual bool supportsAnnotations() {
-    return true;
-  }
+  virtual bool supportsAnnotations() { return true; }
 
  private:
   bool needs_scale_;
@@ -701,7 +682,7 @@ class RDKIT_MOLDRAW2D_EXPORT MolDraw2D {
                      const std::map<int, DrawColour> *highlight_map = nullptr);
   void drawAtomLabel(int atom_num, const DrawColour &draw_colour);
   virtual void drawAnnotation(const std::string &note,
-                      const std::shared_ptr<StringRect> &note_rect);
+                              const std::shared_ptr<StringRect> &note_rect);
   void drawRadicals(const ROMol &mol);
   // find a good starting point for scanning round the annotation
   // atom.  If we choose well, the first angle should be the one.
@@ -710,19 +691,18 @@ class RDKIT_MOLDRAW2D_EXPORT MolDraw2D {
   // see if the note will clash with anything else drawn on the molecule.
   // note_vec should have unit length.  note_rad is the radius along
   // note_vec that the note will be drawn.
-  bool doesAtomNoteClash(StringRect &note_rect,
-                         const StringRect &atsym_rect,
+  bool doesAtomNoteClash(StringRect &note_rect, const StringRect &atsym_rect,
                          const ROMol &mol, unsigned int atom_idx);
-  bool doesBondNoteClash(StringRect &note_rect,
-                         const ROMol &mol, const Bond *bond);
+  bool doesBondNoteClash(StringRect &note_rect, const ROMol &mol,
+                         const Bond *bond);
   // does the note_vec form an unacceptably acute angle with one of the
   // bonds from atom to its neighbours.
-  bool doesNoteClashNbourBonds(const StringRect &note_rect,
-                               const ROMol &mol, const Atom *atom) const;
+  bool doesNoteClashNbourBonds(const StringRect &note_rect, const ROMol &mol,
+                               const Atom *atom) const;
   // does the note intersect with atsym, and if not, any other atom symbol.
   bool doesNoteClashAtomLabels(const StringRect &note_rect,
-                               const StringRect &atsym_rect,
-                               const ROMol &mol, unsigned int atom_idx) const;
+                               const StringRect &atsym_rect, const ROMol &mol,
+                               unsigned int atom_idx) const;
   bool doesNoteClashOtherNotes(const StringRect &note_rect) const;
   // take the label for the given atom and return the individual pieces
   // that need to be drawn for it.  So NH<sub>2</sub> will return
@@ -758,7 +738,8 @@ class RDKIT_MOLDRAW2D_EXPORT MolDraw2D {
   // things used by calculateScale.
   void adjustScaleForAtomLabels(const std::vector<int> *highlight_atoms,
                                 const std::map<int, double> *highlight_radii);
-  void adjustScaleForAnnotation(const std::vector<std::shared_ptr<StringRect>> &notes);
+  void adjustScaleForAnnotation(
+      const std::vector<std::shared_ptr<StringRect>> &notes);
 
  protected:
   virtual void doContinuousHighlighting(
@@ -786,11 +767,10 @@ class RDKIT_MOLDRAW2D_EXPORT MolDraw2D {
   // assuming there's a double bond between atom1 and atom2, calculate
   // the ends of the 2 lines that should be used to draw it, distance
   // offset apart.  Includes bonds of type AROMATIC.
-  void calcDoubleBondLines(const ROMol &mol, double offset,
-                           const Bond *bond,
+  void calcDoubleBondLines(const ROMol &mol, double offset, const Bond *bond,
                            const Point2D &at1_cds, const Point2D &at2_cds,
-                           Point2D &l1s, Point2D &l1f,
-                           Point2D &l2s, Point2D &l2f) const;
+                           Point2D &l1s, Point2D &l1f, Point2D &l2s,
+                           Point2D &l2f) const;
   // returns true if atom has degree 2 and both bonds are close to
   // linear.
   bool isLinearAtom(const Atom &atom) const;
@@ -798,8 +778,8 @@ class RDKIT_MOLDRAW2D_EXPORT MolDraw2D {
   // so it doesn't need a separate return.
   void calcTripleBondLines(double offset, const Bond *bond,
                            const Point2D &at1_cds, const Point2D &at2_cds,
-                           Point2D &l1s, Point2D &l1f,
-                           Point2D &l2s, Point2D &l2f) const;
+                           Point2D &l1s, Point2D &l1f, Point2D &l2s,
+                           Point2D &l2f) const;
 
   // calculate the width to draw a line in draw coords.
   virtual unsigned int getDrawLineWidth();
@@ -807,22 +787,23 @@ class RDKIT_MOLDRAW2D_EXPORT MolDraw2D {
   // sort out coords and scale for drawing reactions.
   void get2DCoordsForReaction(ChemicalReaction &rxn, Point2D &arrowBegin,
                               Point2D &arrowEnd, std::vector<double> &plusLocs,
-                              double spacing,
-                              const std::vector<int> *confIds);
+                              double spacing, const std::vector<int> *confIds);
   // despite the name, this is only ever used for molecules in a reaction.
-  void get2DCoordsMol(RWMol &mol, double &offset, double spacing,
-                      double &maxY, double &minY, int confId,
-                      bool shiftAgents, double coordScale);
-
+  void get2DCoordsMol(RWMol &mol, double &offset, double spacing, double &maxY,
+                      double &minY, int confId, bool shiftAgents,
+                      double coordScale);
 };
 
 // return true if the line l1s->l1f intersects line l2s->l2f
-RDKIT_MOLDRAW2D_EXPORT bool doLinesIntersect(const Point2D &l1s, const Point2D &l1f,
-                      const Point2D &l2s, const Point2D &l2f);
+RDKIT_MOLDRAW2D_EXPORT bool doLinesIntersect(const Point2D &l1s,
+                                             const Point2D &l1f,
+                                             const Point2D &l2s,
+                                             const Point2D &l2f);
 // return true if line ls->lf intersects (or is fully inside) the
 // rectangle of the string.
-RDKIT_MOLDRAW2D_EXPORT bool doesLineIntersectLabel(const Point2D &ls, const Point2D &lf,
-                            const StringRect &lab_rect);
+RDKIT_MOLDRAW2D_EXPORT bool doesLineIntersectLabel(const Point2D &ls,
+                                                   const Point2D &lf,
+                                                   const StringRect &lab_rect);
 
 }  // namespace RDKit
 

--- a/Code/GraphMol/MolDraw2D/MolDraw2DDetails.h
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DDetails.h
@@ -51,6 +51,45 @@ const int char_widths[] = {
 RDKIT_MOLDRAW2D_EXPORT void arcPoints(const Point2D &cds1, const Point2D &cds2,
                                       std::vector<Point2D> &res,
                                       float startAng = 0, float extent = 360);
+
+//! add R/S and E/Z annotation to atoms and bonds respectively.
+RDKIT_MOLDRAW2D_EXPORT inline void addStereoAnnotation(const ROMol &mol) {
+  for (auto atom : mol.atoms()) {
+    if (atom->hasProp("_CIPCode")) {
+      std::string lab = "(" + atom->getProp<std::string>("_CIPCode") + ")";
+      atom->setProp(common_properties::atomNote, lab);
+    }
+  }
+  for (auto bond : mol.bonds()) {
+    if (bond->getStereo() == Bond::STEREOE) {
+      bond->setProp(common_properties::bondNote, "(E)");
+    } else if (bond->getStereo() == Bond::STEREOZ) {
+      bond->setProp(common_properties::bondNote, "(Z)");
+    }
+  }
+};
+
+//! add annotations with atom indices.
+RDKIT_MOLDRAW2D_EXPORT inline void addAtomIndices(const ROMol &mol) {
+  for (auto atom : mol.atoms()) {
+    auto lab = std::to_string(atom->getIdx());
+    if (atom->hasProp(common_properties::atomNote)) {
+      lab += "," + atom->getProp<std::string>(common_properties::atomNote);
+    }
+    atom->setProp(common_properties::atomNote, lab);
+  }
+};
+
+//! add annotations with bond indices.
+RDKIT_MOLDRAW2D_EXPORT inline void addBondIndices(const ROMol &mol) {
+  for (auto bond : mol.bonds()) {
+    auto lab = std::to_string(bond->getIdx());
+    if (bond->hasProp(common_properties::bondNote)) {
+      lab += "," + bond->getProp<std::string>(common_properties::bondNote);
+    }
+    bond->setProp(common_properties::bondNote, lab);
+  }
+};
 }  // namespace MolDraw2D_detail
 }  // namespace RDKit
 

--- a/Code/GraphMol/MolDraw2D/MolDraw2DUtils.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DUtils.cpp
@@ -151,7 +151,7 @@ void updateDrawerParamsFromJSON(MolDraw2D &drawer, const std::string &json) {
   PT_OPT_GET(rotate);
   PT_OPT_GET(addStereoAnnotation);
   PT_OPT_GET(atomHighlightsAreCircles);
-  PT_OPT_GET(centreMoleculesB4Drawing);
+  PT_OPT_GET(centreMoleculesBeforeDrawing);
   get_colour_option(&pt, "highlightColour", opts.highlightColour);
   get_colour_option(&pt, "backgroundColour", opts.backgroundColour);
   get_colour_option(&pt, "legendColour", opts.legendColour);

--- a/Code/GraphMol/MolDraw2D/MolDraw2DUtils.h
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DUtils.h
@@ -159,44 +159,6 @@ RDKIT_MOLDRAW2D_EXPORT inline void contourAndDrawGaussians(
   contourAndDrawGaussians(drawer, locs, heights, widths, nContours, levels, ps);
 };
 
-//! add R/S and E/Z annotation to atoms and bonds respectively.
-RDKIT_MOLDRAW2D_EXPORT inline void addStereoAnnotation(const ROMol &mol) {
-  for (auto atom : mol.atoms()) {
-    if (atom->hasProp("_CIPCode")) {
-      std::string lab = "(" + atom->getProp<std::string>("_CIPCode") + ")";
-      atom->setProp(common_properties::atomNote, lab);
-    }
-  }
-  for (auto bond : mol.bonds()) {
-    if (bond->getStereo() == Bond::STEREOE) {
-      bond->setProp(common_properties::bondNote, "(E)");
-    } else if (bond->getStereo() == Bond::STEREOZ) {
-      bond->setProp(common_properties::bondNote, "(Z)");
-    }
-  }
-};
-
-//! add R/S and E/Z annotation to atoms and bonds respectively.
-RDKIT_MOLDRAW2D_EXPORT inline void addAtomIndices(const ROMol &mol) {
-  for (auto atom : mol.atoms()) {
-    auto lab = std::to_string(atom->getIdx());
-    if (atom->hasProp(common_properties::atomNote)) {
-      lab += "," + atom->getProp<std::string>(common_properties::atomNote);
-    }
-    atom->setProp(common_properties::atomNote, lab);
-  }
-};
-
-RDKIT_MOLDRAW2D_EXPORT inline void addBondIndices(const ROMol &mol) {
-  for (auto bond : mol.bonds()) {
-    auto lab = std::to_string(bond->getIdx());
-    if (bond->hasProp(common_properties::bondNote)) {
-      lab += "," + bond->getProp<std::string>(common_properties::bondNote);
-    }
-    bond->setProp(common_properties::bondNote, lab);
-  }
-};
-
 }  // namespace MolDraw2DUtils
 }  // namespace RDKit
 #endif  // MOLDRAW2DUTILS_H

--- a/Code/GraphMol/MolDraw2D/MolDraw2DUtils.h
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DUtils.h
@@ -159,6 +159,44 @@ RDKIT_MOLDRAW2D_EXPORT inline void contourAndDrawGaussians(
   contourAndDrawGaussians(drawer, locs, heights, widths, nContours, levels, ps);
 };
 
+//! add R/S and E/Z annotation to atoms and bonds respectively.
+RDKIT_MOLDRAW2D_EXPORT inline void addStereoAnnotation(const ROMol &mol) {
+  for (auto atom : mol.atoms()) {
+    if (atom->hasProp("_CIPCode")) {
+      std::string lab = "(" + atom->getProp<std::string>("_CIPCode") + ")";
+      atom->setProp(common_properties::atomNote, lab);
+    }
+  }
+  for (auto bond : mol.bonds()) {
+    if (bond->getStereo() == Bond::STEREOE) {
+      bond->setProp(common_properties::bondNote, "(E)");
+    } else if (bond->getStereo() == Bond::STEREOZ) {
+      bond->setProp(common_properties::bondNote, "(Z)");
+    }
+  }
+};
+
+//! add R/S and E/Z annotation to atoms and bonds respectively.
+RDKIT_MOLDRAW2D_EXPORT inline void addAtomIndices(const ROMol &mol) {
+  for (auto atom : mol.atoms()) {
+    auto lab = std::to_string(atom->getIdx());
+    if (atom->hasProp(common_properties::atomNote)) {
+      lab += "," + atom->getProp<std::string>(common_properties::atomNote);
+    }
+    atom->setProp(common_properties::atomNote, lab);
+  }
+};
+
+RDKIT_MOLDRAW2D_EXPORT inline void addBondIndices(const ROMol &mol) {
+  for (auto bond : mol.bonds()) {
+    auto lab = std::to_string(bond->getIdx());
+    if (bond->hasProp(common_properties::bondNote)) {
+      lab += "," + bond->getProp<std::string>(common_properties::bondNote);
+    }
+    bond->setProp(common_properties::bondNote, lab);
+  }
+};
+
 }  // namespace MolDraw2DUtils
 }  // namespace RDKit
 #endif  // MOLDRAW2DUTILS_H

--- a/Code/GraphMol/MolDraw2D/Wrap/rdMolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/Wrap/rdMolDraw2D.cpp
@@ -134,7 +134,7 @@ void pyListToColourVec(python::object pyo, std::vector<DrawColour> &res) {
 }  // namespace
 
 void pyDictToMapColourVec(python::object pyo,
-                           std::map<int, std::vector<DrawColour> > &res) {
+                          std::map<int, std::vector<DrawColour>> &res) {
   python::dict tDict = python::extract<python::dict>(pyo);
   for (unsigned int i = 0;
        i < python::extract<unsigned int>(tDict.keys().attr("__len__")()); ++i) {
@@ -143,12 +143,12 @@ void pyDictToMapColourVec(python::object pyo,
     pyListToColourVec(pl, v);
     res[python::extract<int>(tDict.keys()[i])] = v;
   }
-
 }
-std::map<int, std::vector<DrawColour> > *pyDictToMapColourVec(python::object pyo) {
-  std::map<int, std::vector<DrawColour> > *res = nullptr;
-  if(pyo) {
-    res = new std::map<int, std::vector<DrawColour> >;
+std::map<int, std::vector<DrawColour>> *pyDictToMapColourVec(
+    python::object pyo) {
+  std::map<int, std::vector<DrawColour>> *res = nullptr;
+  if (pyo) {
+    res = new std::map<int, std::vector<DrawColour>>;
     pyDictToMapColourVec(pyo, *res);
   }
   return res;
@@ -193,34 +193,33 @@ void drawMoleculeHelper2(MolDraw2D &self, const ROMol &mol,
   delete har;
 }
 
-void drawMoleculeWithHighlightsHelper(MolDraw2D &self, const ROMol &mol,
-                                      std::string legend,
-                                      python::object highlight_atom_map,
-                                      python::object highlight_bond_map,
-                                      python::object highlight_atom_radii,
-                                      python::object highlight_linewidth_multipliers,
-                                      int confId) {
-
+void drawMoleculeWithHighlightsHelper(
+    MolDraw2D &self, const ROMol &mol, std::string legend,
+    python::object highlight_atom_map, python::object highlight_bond_map,
+    python::object highlight_atom_radii,
+    python::object highlight_linewidth_multipliers, int confId) {
   // highlight_atom_map and highlight_bond_map come in as a dict of
   // lists of tuples of floats (the R, G, B values for the colours),
   // and need to be changed to a map of vectors of DrawColour.
   // All of the dict to map converters return nullptr if the dict
   // was empty.  We need real objects in all cases for
   // drawMoleculeWithHighlights.
-  std::map<int, std::vector<DrawColour> > *ham = pyDictToMapColourVec(highlight_atom_map);
-  if(!ham) {
-    ham = new std::map<int, std::vector<DrawColour> >();
+  std::map<int, std::vector<DrawColour>> *ham =
+      pyDictToMapColourVec(highlight_atom_map);
+  if (!ham) {
+    ham = new std::map<int, std::vector<DrawColour>>();
   }
-  std::map<int, std::vector<DrawColour> > *hbm = pyDictToMapColourVec(highlight_bond_map);
-  if(!hbm) {
-    hbm = new std::map<int, std::vector<DrawColour> >();
+  std::map<int, std::vector<DrawColour>> *hbm =
+      pyDictToMapColourVec(highlight_bond_map);
+  if (!hbm) {
+    hbm = new std::map<int, std::vector<DrawColour>>();
   }
   std::map<int, double> *har = pyDictToDoubleMap(highlight_atom_radii);
-  if(!har) {
+  if (!har) {
     har = new std::map<int, double>();
   }
   std::map<int, int> *hlm = pyDictToIntMap(highlight_linewidth_multipliers);
-  if(!hlm) {
+  if (!hlm) {
     hlm = new std::map<int, int>();
   }
   self.drawMoleculeWithHighlights(mol, legend, *ham, *hbm, *har, *hlm, confId);
@@ -229,7 +228,6 @@ void drawMoleculeWithHighlightsHelper(MolDraw2D &self, const ROMol &mol,
   delete hbm;
   delete har;
   delete hlm;
-
 }
 
 void prepareAndDrawMoleculeHelper(
@@ -600,9 +598,10 @@ BOOST_PYTHON_MODULE(rdMolDraw2D) {
       .def_readwrite("maxFontSize", &RDKit::MolDrawOptions::maxFontSize,
                      "maximum font size in pixels. default=40, -1 means no"
                      " maximum.")
-      .def_readwrite("annotationFontScale", &RDKit::MolDrawOptions::annotationFontScale,
-                    "Scale of font for atom and bond annotation relative to atom"
-                    "label font.  Default=0.75.")
+      .def_readwrite(
+          "annotationFontScale", &RDKit::MolDrawOptions::annotationFontScale,
+          "Scale of font for atom and bond annotation relative to atom"
+          "label font.  Default=0.75.")
       .def_readwrite(
           "multipleBondOffset", &RDKit::MolDrawOptions::multipleBondOffset,
           "offset (in Angstroms) for the extra lines in a multiple bond")
@@ -611,9 +610,10 @@ BOOST_PYTHON_MODULE(rdMolDraw2D) {
       .def_readwrite(
           "bondLineWidth", &RDKit::MolDrawOptions::bondLineWidth,
           "if positive, this overrides the default line width for bonds")
-      .def_readwrite(
-          "highlightBondWidthMultiplier", &RDKit::MolDrawOptions::highlightBondWidthMultiplier,
-          "What to multiply default bond width by for highlighting bonds. Default-8.")
+      .def_readwrite("highlightBondWidthMultiplier",
+                     &RDKit::MolDrawOptions::highlightBondWidthMultiplier,
+                     "What to multiply default bond width by for highlighting "
+                     "bonds. Default-8.")
       .def_readwrite("prepareMolsBeforeDrawing",
                      &RDKit::MolDrawOptions::prepareMolsBeforeDrawing,
                      "call prepareMolForDrawing() on each molecule passed to "
@@ -634,13 +634,17 @@ BOOST_PYTHON_MODULE(rdMolDraw2D) {
       .def_readwrite("addStereoAnnotation",
                      &RDKit::MolDrawOptions::addStereoAnnotation,
                      "adds R/S and E/Z to drawings. Default False.")
+      .def_readwrite("addAtomIndices", &RDKit::MolDrawOptions::addAtomIndices,
+                     "adds atom indices drawings. Default False.")
+      .def_readwrite("addBondIndices", &RDKit::MolDrawOptions::addBondIndices,
+                     "adds bond indices drawings. Default False.")
       .def_readwrite("atomHighlightsAreCircles",
                      &RDKit::MolDrawOptions::atomHighlightsAreCircles,
                      "forces atom highlights always to be circles."
                      "Default (false) is to put ellipses round"
                      "longer labels.")
-      .def_readwrite("centreMoleculesB4Drawing",
-                     &RDKit::MolDrawOptions::centreMoleculesB4Drawing,
+      .def_readwrite("centreMoleculesBeforeDrawing",
+                     &RDKit::MolDrawOptions::centreMoleculesBeforeDrawing,
                      "Moves the centre of the drawn molecule to (0,0)."
                      "Default True.")
       .def_readwrite("additionalAtomLabelPadding",
@@ -670,16 +674,14 @@ BOOST_PYTHON_MODULE(rdMolDraw2D) {
            python::arg("highlightAtomRadii") = python::object(),
            python::arg("confId") = -1, python::arg("legend") = std::string("")),
           "renders a molecule\n")
-          .def("DrawMoleculeWithHighlights",
-               RDKit::drawMoleculeWithHighlightsHelper,
-               (python::arg("self"), python::arg("mol"),
-                   python::arg("legend"),
-                   python::arg("highlight_atom_map"),
-                   python::arg("highlight_bond_map"),
-                   python::arg("highlight_radii"),
-                   python::arg("highlight_linewidth_multipliers"),
-                   python::arg("confId") = -1),
-                   "renders a molecule with multiple highlight colours\n")
+      .def("DrawMoleculeWithHighlights",
+           RDKit::drawMoleculeWithHighlightsHelper,
+           (python::arg("self"), python::arg("mol"), python::arg("legend"),
+            python::arg("highlight_atom_map"),
+            python::arg("highlight_bond_map"), python::arg("highlight_radii"),
+            python::arg("highlight_linewidth_multipliers"),
+            python::arg("confId") = -1),
+           "renders a molecule with multiple highlight colours\n")
       .def("DrawMolecules", RDKit::drawMoleculesHelper2,
            (python::arg("self"), python::arg("mols"),
             python::arg("highlightAtoms") = python::object(),
@@ -758,15 +760,19 @@ BOOST_PYTHON_MODULE(rdMolDraw2D) {
             python::arg("nSegments") = 16, python::arg("vertOffset") = 0.05),
            "draw a line indicating the presence of an attachment point "
            "(normally a squiggle line perpendicular to a bond)")
-      .def("DrawString", (void(RDKit::MolDraw2D::*)(const std::string &, const RDGeom::Point2D &))&
+      .def("DrawString",
+           (void (RDKit::MolDraw2D::*)(const std::string &,
+                                       const RDGeom::Point2D &)) &
                RDKit::MolDraw2D::drawString,
            (python::arg("self"), python::arg("string"), python::arg("pos")),
            "add text to the canvas")
-      .def("DrawString", (void(RDKit::MolDraw2D::*)(const std::string &, const RDGeom::Point2D &,
-                                                    RDKit::MolDraw2D::AlignType))&
+      .def("DrawString",
+           (void (RDKit::MolDraw2D::*)(const std::string &,
+                                       const RDGeom::Point2D &,
+                                       RDKit::MolDraw2D::AlignType)) &
                RDKit::MolDraw2D::drawString,
            (python::arg("self"), python::arg("string"), python::arg("pos"),
-               python::arg("align")),
+            python::arg("align")),
            "add aligned text to the canvas")
       .def("GetDrawCoords",
            (RDGeom::Point2D(RDKit::MolDraw2D::*)(const RDGeom::Point2D &)

--- a/Code/GraphMol/MolDraw2D/test1.cpp
+++ b/Code/GraphMol/MolDraw2D/test1.cpp
@@ -1249,10 +1249,9 @@ M  END";
     std::ofstream outs("test983_1.svg");
     outs << text;
     outs.flush();
-    TEST_ASSERT(
-        text.find("<path class='bond-1' d='M 125.352,114.634"
-                  " L 179.234,90.896 L 172.848,79.8357 Z'"
-                  " style='fill:#000000") != std::string::npos);
+    TEST_ASSERT(text.find("<path class='bond-1' d='M 125.352,114.634"
+                          " L 179.234,90.896 L 172.848,79.8357 Z'"
+                          " style='fill:#000000") != std::string::npos);
     delete m;
   }
   {
@@ -1301,10 +1300,9 @@ M  END";
     std::ofstream outs("test983_2.svg");
     outs << text;
     outs.flush();
-    TEST_ASSERT(
-        text.find("<path class='bond-3' d='M 102.962,116.968 L"
-                  " 77.0085,93.6784 L 72.5976,99.8217 Z'"
-                  " style='fill:#000000;") != std::string::npos);
+    TEST_ASSERT(text.find("<path class='bond-3' d='M 102.962,116.968 L"
+                          " 77.0085,93.6784 L 72.5976,99.8217 Z'"
+                          " style='fill:#000000;") != std::string::npos);
 
     MolDraw2DUtils::prepareMolForDrawing(*m);
     TEST_ASSERT(m->getBondBetweenAtoms(2, 1)->getBondType() == Bond::SINGLE);
@@ -1689,17 +1687,18 @@ void test12DrawMols() {
     legends.push_back(leg);
   };
   std::vector<ROMol *> mols;
-  std::unique_ptr<std::vector<std::string>> legends(new std::vector<std::string>());
+  std::unique_ptr<std::vector<std::string>> legends(
+      new std::vector<std::string>());
   // made up SMILES, each with sequence F, Cl, Br so we can see which
   // ones are drawn, which ones are missing.
-  setup_mol("COc1cccc(NC(=O)[C@H](F)Sc2nc(ns2)c3ccccc3F)c1", "m1",
-            mols, *legends);
+  setup_mol("COc1cccc(NC(=O)[C@H](F)Sc2nc(ns2)c3ccccc3F)c1", "m1", mols,
+            *legends);
   setup_mol("NC(=O)[C@H](F)Sc1ncns1", "m2", mols, *legends);
-  setup_mol("COc1cccc(NC(=O)[C@H](Cl)Sc2nc(ns2)c3ccccc3F)c1", "m3",
-            mols, *legends);
+  setup_mol("COc1cccc(NC(=O)[C@H](Cl)Sc2nc(ns2)c3ccccc3F)c1", "m3", mols,
+            *legends);
   setup_mol("NC(=O)[C@H](Cl)Sc1ncns1", "m4", mols, *legends);
-  setup_mol("COc1cccc(NC(=O)[C@H](Br)Sc2nc(ns2)c3ccccc3F)c1", "m5",
-            mols, *legends);
+  setup_mol("COc1cccc(NC(=O)[C@H](Br)Sc2nc(ns2)c3ccccc3F)c1", "m5", mols,
+            *legends);
   setup_mol("NC(=O)[C@H](Br)Sc1ncns1", "m6", mols, *legends);
 
   {
@@ -1742,7 +1741,7 @@ void test12DrawMols() {
     outs << text;
     outs.flush();
   }
-  for(auto m: mols) {
+  for (auto m : mols) {
     delete m;
   }
   std::cerr << " Done" << std::endl;
@@ -1756,8 +1755,9 @@ void test13JSONConfig() {
     TEST_ASSERT(m);
     MolDraw2DUtils::prepareMolForDrawing(*m);
     MolDraw2DSVG drawer(250, 200);
-    const char *json = "{\"legendColour\":[1.0,0.5,1.0], \"rotate\": 90, "
-                       "\"bondLineWidth\": 5}";
+    const char *json =
+        "{\"legendColour\":[1.0,0.5,1.0], \"rotate\": 90, "
+        "\"bondLineWidth\": 5}";
     MolDraw2DUtils::updateDrawerParamsFromJSON(drawer, json);
     drawer.drawMolecule(*m, "foo");
     drawer.finishDrawing();
@@ -1765,14 +1765,12 @@ void test13JSONConfig() {
     std::ofstream outs("test13_1.svg");
     outs << text;
     outs.close();
-    TEST_ASSERT(text.find("sans-serif;fill:#FF7FFF") !=
+    TEST_ASSERT(text.find("sans-serif;fill:#FF7FFF") != std::string::npos);
+    TEST_ASSERT(text.find("'bond-0' d='M 122.883,9.09091 L 170.762,92.0201'") !=
                 std::string::npos);
-    TEST_ASSERT(text.find("'bond-0' d='M 122.883,9.09091 L 170.762,92.0201'")
-                != std::string::npos);
     // these days the bond line width scales with the rest of the
     // drawing, and at this size this comes out as 6px.
-    TEST_ASSERT(text.find("stroke-width:6px") !=
-                std::string::npos);
+    TEST_ASSERT(text.find("stroke-width:6px") != std::string::npos);
     delete m;
   }
   std::cerr << " Done" << std::endl;
@@ -2314,8 +2312,9 @@ void test18FixedScales() {
     }
   }
   {
-    std::string smi = "C[C@@H](N[C@@H]1CC[C@@H](C(=O)N2CCC(C(=O)N3CCCC3)"
-                      "(c3ccccc3)CC2)C(C)(C)C1)c1ccc(Cl)cc1";
+    std::string smi =
+        "C[C@@H](N[C@@H]1CC[C@@H](C(=O)N2CCC(C(=O)N3CCCC3)"
+        "(c3ccccc3)CC2)C(C)(C)C1)c1ccc(Cl)cc1";
     std::unique_ptr<ROMol> m(SmilesToMol(smi));
     TEST_ASSERT(m);
 
@@ -2374,8 +2373,8 @@ void test19RotateDrawing() {
       std::ofstream outs((nameBase + "1.svg").c_str());
       outs << text;
       outs.flush();
-      TEST_ASSERT(text.find("text-anchor=\"start\" x='256.907' y='154.276'")
-                  != std::string::npos);
+      TEST_ASSERT(text.find("text-anchor=\"start\" x='256.907' y='154.276'") !=
+                  std::string::npos);
     }
     {
       MolDraw2DSVG drawer(300, 300);
@@ -2386,8 +2385,8 @@ void test19RotateDrawing() {
       std::ofstream outs((nameBase + "2.svg").c_str());
       outs << text;
       outs.flush();
-      TEST_ASSERT(text.find("text-anchor=\"start\" x='136.604' y='276.316'")
-                  != std::string::npos);
+      TEST_ASSERT(text.find("text-anchor=\"start\" x='136.604' y='276.316'") !=
+                  std::string::npos);
     }
   }
   std::cerr << " Done" << std::endl;
@@ -2539,7 +2538,8 @@ void testGithub2931() {
                " molecule highlights."
             << std::endl;
 
-  auto get_all_hit_atoms = [](ROMol &mol, const std::string &smt) -> std::vector<int> {
+  auto get_all_hit_atoms = [](ROMol &mol,
+                              const std::string &smt) -> std::vector<int> {
     std::vector<int> hit_atoms;
     RWMol *query = SmartsToMol(smt);
     std::vector<MatchVectType> hits_vect;
@@ -2553,10 +2553,11 @@ void testGithub2931() {
     return hit_atoms;
   };
 
-  auto get_all_hit_bonds = [](ROMol &mol, const std::vector<int> &hit_atoms) -> std::vector<int> {
+  auto get_all_hit_bonds =
+      [](ROMol &mol, const std::vector<int> &hit_atoms) -> std::vector<int> {
     std::vector<int> hit_bonds;
-    for (int i: hit_atoms) {
-      for (int j: hit_atoms) {
+    for (int i : hit_atoms) {
+      for (int j : hit_atoms) {
         if (i > j) {
           Bond *bnd = mol.getBondBetweenAtoms(i, j);
           if (bnd) {
@@ -2569,14 +2570,15 @@ void testGithub2931() {
   };
 
   auto update_colour_map = [](const std::vector<int> &ats, DrawColour col,
-                              std::map<int, std::vector<DrawColour> > &ha_map) {
-    for (auto h: ats) {
+                              std::map<int, std::vector<DrawColour>> &ha_map) {
+    for (auto h : ats) {
       auto ex = ha_map.find(h);
       if (ex == ha_map.end()) {
         std::vector<DrawColour> cvec(1, col);
         ha_map.insert(make_pair(h, cvec));
       } else {
-        if (ex->second.end() == find(ex->second.begin(), ex->second.end(), col)) {
+        if (ex->second.end() ==
+            find(ex->second.begin(), ex->second.end(), col)) {
           ex->second.emplace_back(col);
         }
       }
@@ -2645,18 +2647,18 @@ void testGithub2931() {
 }
 
 void test20Annotate() {
-    std::cout << " ----------------- Testing annotation of 2D Drawing."
+  std::cout << " ----------------- Testing annotation of 2D Drawing."
             << std::endl;
 
   // add serial numbers to the atoms in the molecule
   auto addAtomSerialNumbers = [](ROMol &mol) {
-      for(auto atom: mol.atoms()) {
-        atom->setProp("atomNote", atom->getIdx());
-      }
+    for (auto atom : mol.atoms()) {
+      atom->setProp(common_properties::atomNote, atom->getIdx());
+    }
   };
   auto addBondSerialNumbers = [](ROMol &mol) {
-    for(auto bond: mol.bonds()) {
-      bond->setProp("bondNote", bond->getIdx());
+    for (auto bond : mol.bonds()) {
+      bond->setProp(common_properties::bondNote, bond->getIdx());
     }
   };
   {
@@ -2737,8 +2739,8 @@ void test20Annotate() {
                           "font-style:normal;font-weight:normal;"
                           "fill-opacity:1;stroke:none;"
                           "font-family:sans-serif;fill:#000000'"
-                          " ><tspan>foolish annotation</tspan>")
-                != std::string::npos);
+                          " ><tspan>foolish annotation</tspan>") !=
+                std::string::npos);
   }
   std::cerr << " Done" << std::endl;
 }

--- a/Code/RDGeneral/types.cpp
+++ b/Code/RDGeneral/types.cpp
@@ -122,6 +122,9 @@ const std::string molAtomSeqId = "molSeqid";
 const std::string molRxnExactChange = "molRxnExachg";
 const std::string molReactStatus = "molReactStatus";
 
+const std::string atomNote = "atomNote";
+const std::string bondNote = "bondNote";
+
 }  // namespace common_properties
 
 const double MAX_DOUBLE = std::numeric_limits<double>::max();

--- a/Code/RDGeneral/types.h
+++ b/Code/RDGeneral/types.h
@@ -236,6 +236,8 @@ RDKIT_RDGENERAL_EXPORT extern const std::string
 //  - note, confusing creation of names in
 //  - getDistanceMat
 RDKIT_RDGENERAL_EXPORT extern const std::string internalRgroupSmiles;
+RDKIT_RDGENERAL_EXPORT extern const std::string atomNote;
+RDKIT_RDGENERAL_EXPORT extern const std::string bondNote;
 
 }  // namespace common_properties
 #ifndef WIN32

--- a/rdkit/Chem/Draw/__init__.py
+++ b/rdkit/Chem/Draw/__init__.py
@@ -441,7 +441,8 @@ def _moltoimg(mol, sz, highlights, legend, returnPNG=False, drawOptions=None, **
       d2d.SetDrawOptions(drawOptions)
     if 'highlightColor' in kwargs:
       d2d.drawOptions().setHighlightColor(kwargs['highlightColor'])
-
+    # we already prepared the molecule:
+    d2d.drawOptions().prepareMolsBeforeDrawing = False
     bondHighlights = kwargs.get('highlightBonds',None)
     if bondHighlights is not None:
       d2d.DrawMolecule(mc, legend=legend, highlightAtoms=highlights, 


### PR DESCRIPTION
Several things here:
1) move "atomNote" and "bondNote" to common_properties
2) move addStereoAnnotation to the MolDraw2DUtils namespace
3) add addAtomIndices and addBondIndices
4) initialize MolDrawOptions members directly instead of via the ctor
5) add tests for all that
6) the usual reformatting

It's worth showing off how the atom index annotations work. 
This bit of C++:
```
    {
      MolDraw2DSVG drawer(250, 200);
      m1->getAtomWithIdx(2)->setProp(common_properties::atomNote, "foo");
      drawer.drawOptions().addAtomIndices = true;
      drawer.drawOptions().addStereoAnnotation = true;
      drawer.drawMolecule(*m1);
      drawer.finishDrawing();
      std::string text = drawer.getDrawingText();
      std::ofstream outs("testAtomBondIndices_5.svg");
      outs << text;
      outs.flush();
    }
```
Produces this image:
![image](https://user-images.githubusercontent.com/540511/77522448-8f788480-6e84-11ea-8b29-44017e20fc96.png)
