### PR TITLE
Fixed bug with annotation on degree-1 atoms.

### DIFF
--- a/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
@@ -2342,7 +2342,16 @@ double MolDraw2D::getNoteStartAngle(const ROMol &mol, const Atom *atom) const {
 
   Point2D ret_vec;
   if (bond_vecs.size() == 1) {
-    ret_vec = -bond_vecs[0];
+    if(atom_syms_[activeMolIdx_][atom->getIdx()].first.empty()) {
+      // go with perpendicular to bond.  This is mostly to avoid getting
+      // a zero at the end of a bond to carbon, which looks like a black
+      // oxygen atom in the default font in SVG and PNG.
+      ret_vec.x = bond_vecs[0].y;
+      ret_vec.y = -bond_vecs[0].x;
+    } else {
+      // go opposite end
+      ret_vec = -bond_vecs[0];
+    }
   } else if (bond_vecs.size() == 2) {
     ret_vec = bond_vecs[0] + bond_vecs[1];
     if (ret_vec.lengthSq() > 1.0e-6) {

--- a/Code/GraphMol/MolDraw2D/test1.cpp
+++ b/Code/GraphMol/MolDraw2D/test1.cpp
@@ -2681,10 +2681,12 @@ void test20Annotate() {
     std::ofstream outs("test20_1.svg");
     outs << text;
     outs.flush();
-    TEST_ASSERT(text.find("x='402.344' y='249.673' style='font-size:14px;"
+    // annotation for atom 11
+    TEST_ASSERT(text.find("x='423.22' y='249.655' style='font-size:14px;"
                           "font-style:normal;font-weight:normal;"
-                          "fill-opacity:1;stroke:none;font-family:sans-serif;"
-                          "fill:#000000' ><tspan>11") != std::string::npos);
+                          "fill-opacity:1;stroke:none;"
+                          "font-family:sans-serif;fill:#000000' ><tspan>11")
+                != std::string::npos);
   }
 
   {


### PR DESCRIPTION
Tweak to atom annotation to fix problem shown by:
rdDepictor.SetPreferCoordGen(False)
mol = Chem.MolFromSmiles('C[C@H](F)N')
d = rdMolDraw2D.MolDraw2DCairo(250, 200)
d.drawOptions().addAtomIndices = True
d.DrawMolecule(mol)
d.FinishDrawing()
with open('atom_annotation_3.png', 'wb') as f:
    f.write(d.GetDrawingText())

where the zero appeared at the end of the C-C bond so looked like an oxygen, espcecially in B/W.
Tested on Mac only.
