### PR TITLE
Fixes #2954:Rxn Smarts with Dative Bonds not parsed

### DIFF
--- a/Code/GraphMol/ChemReactions/DaylightParser.cpp
+++ b/Code/GraphMol/ChemReactions/DaylightParser.cpp
@@ -105,12 +105,33 @@ ROMol *constructMolFromString(const std::string &txt,
 ChemicalReaction *RxnSmartsToChemicalReaction(
     const std::string &text, std::map<std::string, std::string> *replacements,
     bool useSmiles) {
-  std::size_t pos1 = text.find('>');
-  std::size_t pos2 = text.rfind('>');
-  if (pos1 == std::string::npos) {
+
+  std::size_t pos1;
+  std::size_t pos2;
+
+  std::vector<std::size_t> pos;
+  std::vector<std::size_t> rxnDelimiterPos;
+
+  for (std::size_t i = 0; i < text.length(); i++) {
+    if (text[i] == '>') {
+      pos.push_back(i);
+    }
+  }
+
+  if (pos.size() == 0) {
     throw ChemicalReactionParserException(
         "a reaction requires at least one reactant and one product");
   }
+
+  for (std::size_t i = 0; i < pos.size(); i++) {
+    if (text[pos[i] - 1] != '-') {
+      rxnDelimiterPos.push_back(pos[i]);
+    }
+  }
+
+  pos1 = rxnDelimiterPos[0];
+  pos2 = rxnDelimiterPos[1];
+
   if (text.find('>', pos1 + 1) != pos2) {
     throw ChemicalReactionParserException("multi-step reactions not supported");
   }

--- a/Code/GraphMol/ChemReactions/DaylightParser.cpp
+++ b/Code/GraphMol/ChemReactions/DaylightParser.cpp
@@ -106,33 +106,23 @@ ChemicalReaction *RxnSmartsToChemicalReaction(
     const std::string &text, std::map<std::string, std::string> *replacements,
     bool useSmiles) {
 
-  std::size_t pos1;
-  std::size_t pos2;
-
   std::vector<std::size_t> pos;
-  std::vector<std::size_t> rxnDelimiterPos;
 
   for (std::size_t i = 0; i < text.length(); i++) {
-    if (text[i] == '>') {
+    if (text[i] == '>' && text[i-1] != '-') {
       pos.push_back(i);
     }
   }
 
-  if (pos.size() == 0) {
+  if (pos.size() < 2) {
     throw ChemicalReactionParserException(
-        "a reaction requires at least one reactant and one product");
+        "a reaction requires at least two > characters");
   }
 
-  for (std::size_t i = 0; i < pos.size(); i++) {
-    if (text[pos[i] - 1] != '-') {
-      rxnDelimiterPos.push_back(pos[i]);
-    }
-  }
+  std::size_t pos1 = pos[0];
+  std::size_t pos2 = pos[1];
 
-  pos1 = rxnDelimiterPos[0];
-  pos2 = rxnDelimiterPos[1];
-
-  if (text.find('>', pos1 + 1) != pos2) {
+  if (pos.size() > 2) {
     throw ChemicalReactionParserException("multi-step reactions not supported");
   }
 

--- a/Code/GraphMol/ChemReactions/catch_tests.cpp
+++ b/Code/GraphMol/ChemReactions/catch_tests.cpp
@@ -227,13 +227,35 @@ TEST_CASE("negative charge queries. Part of testing changes for github #2604",
 TEST_CASE("GithHub #2954: Reaction Smarts with Dative Bonds not parsed",
           "[Reaction, Bug]") {
   
-  SECTION("Rxn Smart Processing with Dative Bond") {
-    unique_ptr<ChemicalReaction> rxn(
+  SECTION("Rxn Smart Processing with Dative Bond in Product") {
+    unique_ptr<ChemicalReaction> rxn1(
       RxnSmartsToChemicalReaction("[O:1].[H+]>>[O:1]->[H+]")
     );
-    REQUIRE(rxn);
-    auto k = rxn->getProducts()[0]->getNumAtoms();
+
+    REQUIRE(rxn1);
+    auto k = rxn1->getProducts()[0]->getNumAtoms();
     CHECK(k == 2);
   }
 
+  SECTION("Rxn Smart Processing with Dative Bond in Reactant") {
+    unique_ptr<ChemicalReaction> rxn2(
+      RxnSmartsToChemicalReaction("[O:1]->[H+]>>[O:1].[H+]")
+    );
+
+    REQUIRE(rxn2);
+
+    auto k = rxn2->getReactants()[0]->getNumAtoms();
+    CHECK(k == 2);
+  }
+
+  SECTION("Rxm Smart Processing with Dative Bond in Agent") {
+    unique_ptr<ChemicalReaction> rxn(
+      RxnSmartsToChemicalReaction("[O:1][H]>N->[Cu]>[O:1].[H]")
+    );
+    REQUIRE(rxn);
+
+    auto k = rxn->getAgents()[0]->getNumAtoms();
+    CHECK(k == 2);
+  }
+ 
 }

--- a/Code/GraphMol/ChemReactions/catch_tests.cpp
+++ b/Code/GraphMol/ChemReactions/catch_tests.cpp
@@ -223,3 +223,17 @@ TEST_CASE("negative charge queries. Part of testing changes for github #2604",
     CHECK(nErrors == 0);
   }
 }
+
+TEST_CASE("GithHub #2954: Reaction Smarts with Dative Bonds not parsed",
+          "[Reaction, Bug]") {
+  
+  SECTION("Rxn Smart Processing with Dative Bond") {
+    unique_ptr<ChemicalReaction> rxn(
+      RxnSmartsToChemicalReaction("[O:1].[H+]>>[O:1]->[H+]")
+    );
+    REQUIRE(rxn);
+    auto k = rxn->getProducts()[0]->getNumAtoms();
+    CHECK(k == 2);
+  }
+
+}


### PR DESCRIPTION
Fixes #2954 
Implemented an approach which does not use std::string::find to find ">" occurrences. The new implementation checks the chracters around ">" and seperates the reactants and products accordingly. Corresponding tests have also been implemented.

