### PR TITLE
Coordinates from coordgen are not centered around the origin

### DIFF
--- a/Code/GraphMol/Depictor/RDDepictor.cpp
+++ b/Code/GraphMol/Depictor/RDDepictor.cpp
@@ -323,7 +323,6 @@ unsigned int compute2DCoords(RDKit::ROMol &mol,
           MolTransforms::computeCentroid(mol.getConformer(cid));
       RDGeom::Transform3D trans;
       trans.SetTranslation(-centroid);
-      RDGeom::POINT3D_VECT &locs = mol.getConformer(cid).getPositions();
       auto &conf = mol.getConformer(cid);
       MolTransforms::transformConformer(conf,trans);
     }

--- a/Code/GraphMol/Depictor/RDDepictor.cpp
+++ b/Code/GraphMol/Depictor/RDDepictor.cpp
@@ -318,12 +318,14 @@ unsigned int compute2DCoords(RDKit::ROMol &mol,
       params.coordMap = *coordMap;
     }
     unsigned int cid = RDKit::CoordGen::addCoords(mol, &params);
-    RDGeom::Point3D centroid = MolTransforms::computeCentroid(mol.getConformer(cid));
-    RDGeom::Transform3D trans;
-    trans.SetTranslation(-centroid);
-    RDGeom::POINT3D_VECT &locs = mol.getConformer(cid).getPositions();
-    for(auto atom: mol.atoms()) {
-      trans.TransformPoint(locs[atom->getIdx()]);
+    if(!coordMap) {
+      RDGeom::Point3D centroid =
+          MolTransforms::computeCentroid(mol.getConformer(cid));
+      RDGeom::Transform3D trans;
+      trans.SetTranslation(-centroid);
+      RDGeom::POINT3D_VECT &locs = mol.getConformer(cid).getPositions();
+      auto &conf = mol.getConformer(cid);
+      MolTransforms::transformConformer(conf,trans);
     }
     return cid;
   };

--- a/Code/GraphMol/Depictor/RDDepictor.cpp
+++ b/Code/GraphMol/Depictor/RDDepictor.cpp
@@ -23,6 +23,8 @@
 #include <GraphMol/Rings.h>
 #include <Geometry/point.h>
 #include <Geometry/Transform2D.h>
+#include <Geometry/Transform3D.h>
+#include <GraphMol/MolTransforms/MolTransforms.h>
 #include <GraphMol/Substruct/SubstructMatch.h>
 #include "EmbeddedFrag.h"
 #include "DepictUtils.h"
@@ -315,7 +317,15 @@ unsigned int compute2DCoords(RDKit::ROMol &mol,
     if (coordMap) {
       params.coordMap = *coordMap;
     }
-    return RDKit::CoordGen::addCoords(mol, &params);
+    unsigned int cid = RDKit::CoordGen::addCoords(mol, &params);
+    RDGeom::Point3D centroid = MolTransforms::computeCentroid(mol.getConformer(cid));
+    RDGeom::Transform3D trans;
+    trans.SetTranslation(-centroid);
+    RDGeom::POINT3D_VECT &locs = mol.getConformer(cid).getPositions();
+    for(auto atom: mol.atoms()) {
+      trans.TransformPoint(locs[atom->getIdx()]);
+    }
+    return cid;
   };
 #endif
   // storage for pieces of a molecule/s that are embedded in 2D

--- a/Code/GraphMol/MolTransforms/test1.cpp
+++ b/Code/GraphMol/MolTransforms/test1.cpp
@@ -16,7 +16,7 @@
 #include <GraphMol/SmilesParse/SmilesParse.h>
 #include <GraphMol/FileParsers/FileParsers.h>
 #include <Geometry/point.h>
-#include "MolTransforms.h"
+#include <GraphMol/MolTransforms/MolTransforms.h>
 
 using namespace RDKit;
 using namespace MolTransforms;


### PR DESCRIPTION
When using coordGen for 2D coords, always moves the coords to be centred on (0,0).  Fixes an issues laying out some molecules in grids.

Tested on Mac only.

