### PR TITLE
fix a typo in ScaffoldNetwork/CMakeLists.txt

### DIFF
--- a/Code/GraphMol/ScaffoldNetwork/CMakeLists.txt
+++ b/Code/GraphMol/ScaffoldNetwork/CMakeLists.txt
@@ -4,7 +4,7 @@ rdkit_library(ScaffoldNetwork
               ScaffoldNetwork.cpp
               LINK_LIBRARIES MolStandardize ChemReactions ChemTransforms SmilesParse SubstructMatch GraphMol RDGeneral)
 
-rdkit_headers(ScaffoldNetwork.h DEST GraphMol/ScaffoldNetwor)
+rdkit_headers(ScaffoldNetwork.h DEST GraphMol/ScaffoldNetwork)
 
 rdkit_catch_test(testScaffoldNetwork catch_main.cpp catch_tests.cpp 
 LINK_LIBRARIES ScaffoldNetwork SmilesParse GraphMol RDGeneral 


### PR DESCRIPTION
would be good to put those header files in a sensible place