### PR TITLE
Correct TEST_CASE tags for Catch2

### DIFF
--- a/Code/GraphMol/ChemReactions/catch_tests.cpp
+++ b/Code/GraphMol/ChemReactions/catch_tests.cpp
@@ -26,7 +26,7 @@
 using namespace RDKit;
 using std::unique_ptr;
 
-TEST_CASE("Github #1632", "[Reaction,PDB,bug]") {
+TEST_CASE("Github #1632", "[Reaction][PDB][bug]") {
   SECTION("basics") {
     bool sanitize = true;
     int flavor = 0;
@@ -61,7 +61,7 @@ static void clearAtomMappingProps(ROMol& mol) {
   }
 }
 
-TEST_CASE("Github #2366 Enhanced Stereo", "[Reaction,StereoGroup,bug]") {
+TEST_CASE("Github #2366 Enhanced Stereo", "[Reaction][StereoGroup][bug]") {
   SECTION("Reaction Preserves Stereo") {
     ROMOL_SPTR mol("F[C@H](Cl)Br |o1:1|"_smiles);
     REQUIRE(mol);
@@ -142,7 +142,7 @@ TEST_CASE("Github #2366 Enhanced Stereo", "[Reaction,StereoGroup,bug]") {
 }
 
 TEST_CASE("Github #2427 cannot set maxProducts>1000 in runReactants",
-          "[Reaction,bug]") {
+          "[Reaction][bug]") {
   SECTION("Basics") {
     std::string smi = "[C]";
     for (unsigned int i = 0; i < 49; ++i) {
@@ -225,7 +225,7 @@ TEST_CASE("negative charge queries. Part of testing changes for github #2604",
 }
 
 TEST_CASE("GithHub #2954: Reaction Smarts with Dative Bonds not parsed",
-          "[Reaction, Bug]") {
+          "[Reaction][Bug]") {
   
   SECTION("Rxn Smart Processing with Dative Bond in Product") {
     unique_ptr<ChemicalReaction> rxn1(

--- a/Code/GraphMol/FileParsers/file_parsers_catch.cpp
+++ b/Code/GraphMol/FileParsers/file_parsers_catch.cpp
@@ -19,7 +19,7 @@
 
 using namespace RDKit;
 
-TEST_CASE("Basic SVG Parsing", "[SVG,parser]") {
+TEST_CASE("Basic SVG Parsing", "[SVG][reader]") {
   SECTION("basics") {
     std::string svg = R"SVG(<?xml version='1.0' encoding='iso-8859-1'?>
 <svg version='1.1' baseProfile='full'
@@ -79,7 +79,7 @@ width='200px' height='200px' >
 TEST_CASE(
     "Github #2040: Failure to parse V3K mol file with bonds to multi-center "
     "linkage points",
-    "[bug,parser]") {
+    "[bug][reader]") {
   std::string rdbase = getenv("RDBASE");
   SECTION("basics") {
     std::string fName =
@@ -101,7 +101,7 @@ TEST_CASE(
 }
 
 TEST_CASE("Github #2225: failure round-tripping mol block with Q atoms",
-          "[bug,writer]") {
+          "[bug][writer]") {
   std::string rdbase = getenv("RDBASE");
   SECTION("basics") {
     std::string fName =
@@ -182,7 +182,7 @@ TEST_CASE("Github #2225: failure round-tripping mol block with Q atoms",
 }
 TEST_CASE(
     "Github #2229: problem round-tripping mol files with bond topology info",
-    "[bug,writer]") {
+    "[bug][writer]") {
   std::string rdbase = getenv("RDBASE");
   std::string fName =
       rdbase + "/Code/GraphMol/FileParsers/test_data/github2229_1.mol";
@@ -215,7 +215,7 @@ TEST_CASE(
     REQUIRE(mol2->getBondWithIdx(7)->hasQuery());
   }
 }
-TEST_CASE("preserve mol file properties on bonds", "[parser,ctab]") {
+TEST_CASE("preserve mol file properties on bonds", "[reader][ctab]") {
   SECTION("basics") {
     std::string molblock = R"CTAB(
   Mrv1810 02111915042D          
@@ -272,7 +272,7 @@ M  END
 }
 
 TEST_CASE("github #2277 : Failure when parsing mol block with M PXA",
-          "[parser,ctab]") {
+          "[reader][ctab]") {
   std::string molblock = R"CTAB(
   Mrv1810 02151911552D          
 
@@ -425,7 +425,7 @@ M  END)CTAB";
   }
 }
 
-TEST_CASE("parsing of SCN lines", "[bug, sgroups]") {
+TEST_CASE("parsing of SCN lines", "[bug][sgroups]") {
   SECTION("basics") {
     std::string molblock = R"CTAB(
   MJ171200
@@ -613,7 +613,7 @@ M  END
   }
 }
 
-TEST_CASE("A couple more S group problems", "[bug, sgroups]") {
+TEST_CASE("A couple more S group problems", "[bug][sgroups]") {
   std::string molblock = R"CTAB(CHEMBL3666739
       SciTegic05171617282D
 
@@ -738,7 +738,7 @@ M  END
   }
 }
 
-TEST_CASE("XYZ", "[XYZ,writer]") {
+TEST_CASE("XYZ", "[XYZ][writer]") {
   SECTION("basics") {
     std::unique_ptr<RWMol> mol{new RWMol{}};
     mol->setProp(common_properties::_Name,
@@ -771,7 +771,7 @@ H      0.635000    0.635000    0.635000
   }
 }
 
-TEST_CASE("valence writing 1", "[bug,writer]") {
+TEST_CASE("valence writing 1", "[bug][writer]") {
   SECTION("carbon") {
     std::string molblock = R"CTAB(carbon atom
 
@@ -815,7 +815,7 @@ M  END)CTAB";
 }
 
 TEST_CASE("Github #2695: Error when a squiggle bond is in an aromatic ring",
-          "[bug,reader]") {
+          "[bug][reader]") {
   SECTION("reported") {
     auto ctab = R"CTAB(
   -ISIS-  -- StrEd -- 
@@ -868,7 +868,7 @@ M  END)CTAB";
   }
 }
 
-TEST_CASE("Github #2917: _ctab _mol2 and _pdb support", "[feature,reader]") {
+TEST_CASE("Github #2917: _ctab _mol2 and _pdb support", "[feature][reader]") {
   SECTION("_ctab") {
     auto mol = R"CTAB(
   Mrv1810 01292008292D          
@@ -1000,7 +1000,7 @@ GASTEIGER
   }
 }
 
-TEST_CASE("handling STBOX properties from v3k ctabs", "[feature,v3k]") {
+TEST_CASE("handling STBOX properties from v3k ctabs", "[feature][v3k]") {
   SECTION("atoms and bonds") {
     auto mol = R"CTAB(basic test
   Mrv1810 01292006422D          
@@ -1144,7 +1144,7 @@ M  END
   }
 }
 
-TEST_CASE("github #2829: support MRV_IMPLICIT_H", "[feature,sgroups]") {
+TEST_CASE("github #2829: support MRV_IMPLICIT_H", "[feature][sgroups]") {
   SECTION("basics v2k") {
     auto mol = R"CTAB(
   Mrv1810 01302015262D          
@@ -1291,7 +1291,7 @@ M  END
   }
 }
 
-TEST_CASE("extra v3k mol file properties", "[ctab,v3k]") {
+TEST_CASE("extra v3k mol file properties", "[ctab][v3k]") {
   SECTION("ATTCHPT") {
     auto mol = R"CTAB(
   Mrv2007 03132014352D          

--- a/Code/GraphMol/FileParsers/testPropertyLists.cpp
+++ b/Code/GraphMol/FileParsers/testPropertyLists.cpp
@@ -132,7 +132,7 @@ TEST_CASE("processMolPropertyLists", "[atom_list_properties]") {
   }
 }
 
-TEST_CASE("basic SDF handling", "[SDF,atom_list_properties]") {
+TEST_CASE("basic SDF handling", "[SDF][atom_list_properties]") {
   std::string sdf = R"SDF(
      RDKit  2D
 

--- a/Code/GraphMol/Fingerprints/catch_tests.cpp
+++ b/Code/GraphMol/Fingerprints/catch_tests.cpp
@@ -26,7 +26,7 @@
 
 using namespace RDKit;
 
-TEST_CASE("Github 2051", "[patternfp,bug]") {
+TEST_CASE("Github 2051", "[patternfp][bug]") {
   auto mol = "CCC1CC1"_smiles;
   std::unique_ptr<ExplicitBitVect> mfp(PatternFingerprintMol(*mol));
 
@@ -46,7 +46,7 @@ TEST_CASE("Github 2051", "[patternfp,bug]") {
   }
 }
 
-TEST_CASE("Github 2614", "[patternfp,bug]") {
+TEST_CASE("Github 2614", "[patternfp][bug]") {
   SECTION("basics") {
     auto mol =
         "F[P-](F)(F)(F)(F)F.F[P-](F)(F)(F)(F)F.F[P-](F)(F)(F)(F)F.F[P-](F)(F)(F)(F)F.F[P-](F)(F)(F)(F)F.F[P-](F)(F)(F)(F)F.F[P-](F)(F)(F)(F)F.F[P-](F)(F)(F)(F)F.F[P-](F)(F)(F)(F)F.c1ccc2ccccc2c1"_smiles;
@@ -61,7 +61,7 @@ TEST_CASE("Github 2614", "[patternfp,bug]") {
   }
 }
 
-TEST_CASE("RDKit bits per feature", "[fpgenerator,rdkit]") {
+TEST_CASE("RDKit bits per feature", "[fpgenerator][rdkit]") {
   auto m1 = "CCCO"_smiles;
   REQUIRE(m1);
   SECTION("defaults") {

--- a/Code/GraphMol/MolDraw2D/catch_tests.cpp
+++ b/Code/GraphMol/MolDraw2D/catch_tests.cpp
@@ -35,7 +35,7 @@ TEST_CASE("prepareAndDrawMolecule", "[drawing]") {
   }
 }
 
-TEST_CASE("tag atoms in SVG", "[drawing, SVG]") {
+TEST_CASE("tag atoms in SVG", "[drawing][SVG]") {
   SECTION("basics") {
     auto m1 = "C1N[C@@H]2OCC12"_smiles;
     REQUIRE(m1);
@@ -59,7 +59,7 @@ TEST_CASE("tag atoms in SVG", "[drawing, SVG]") {
     CHECK(text.find("bond-selector") != std::string::npos);
   }
 }
-TEST_CASE("contour data", "[drawing, conrec]") {
+TEST_CASE("contour data", "[drawing][conrec]") {
   auto m1 = "C1N[C@@H]2OCC12"_smiles;
   REQUIRE(m1);
   SECTION("grid basics") {
@@ -215,7 +215,7 @@ TEST_CASE("contour data", "[drawing, conrec]") {
   }
 }
 
-TEST_CASE("dative bonds", "[drawing, organometallics]") {
+TEST_CASE("dative bonds", "[drawing][organometallics]") {
   SECTION("basics") {
     auto m1 = "N->[Pt]"_smiles;
     REQUIRE(m1);
@@ -249,7 +249,7 @@ TEST_CASE("dative bonds", "[drawing, organometallics]") {
   }
 }
 
-TEST_CASE("zero-order bonds", "[drawing, organometallics]") {
+TEST_CASE("zero-order bonds", "[drawing][organometallics]") {
   SECTION("basics") {
     auto m1 = "N-[Pt]"_smiles;
     REQUIRE(m1);
@@ -304,7 +304,7 @@ TEST_CASE("copying drawing options", "[drawing]") {
 }
 
 TEST_CASE("bad DrawMolecules() when molecules are not kekulized",
-          "[drawing,bug]") {
+          "[drawing][bug]") {
   auto m1 = "CCN(CC)CCn1nc2c3ccccc3sc3c(CNS(C)(=O)=O)ccc1c32"_smiles;
   REQUIRE(m1);
   SECTION("foundations") {

--- a/Code/GraphMol/MolStandardize/catch_tests.cpp
+++ b/Code/GraphMol/MolStandardize/catch_tests.cpp
@@ -58,7 +58,7 @@ TEST_CASE("SKIP_IF_ALL_MATCH") {
   }
 }
 
-TEST_CASE("symmetry in the uncharger", "uncharger") {
+TEST_CASE("symmetry in the uncharger", "[uncharger]") {
   SECTION("case 1") {
     auto m = "C[N+](C)(C)CC(C(=O)[O-])CC(=O)[O-]"_smiles;
     REQUIRE(m);
@@ -92,7 +92,7 @@ TEST_CASE("symmetry in the uncharger", "uncharger") {
   }
 }
 
-TEST_CASE("uncharger bug with duplicates", "uncharger") {
+TEST_CASE("uncharger bug with duplicates", "[uncharger]") {
   SECTION("case 1") {
     auto m = "[NH3+]CC([O-])C[O-]"_smiles;
     REQUIRE(m);
@@ -131,7 +131,7 @@ TEST_CASE("uncharger bug with duplicates", "uncharger") {
 
 TEST_CASE(
     "github #2411: MolStandardize: FragmentRemover should not sanitize "
-    "fragments") {
+    "[fragments]") {
   SECTION("demo") {
     std::string smi = "CN(C)(C)C.Cl";
     bool debugParse = false;
@@ -148,7 +148,7 @@ TEST_CASE(
 
 TEST_CASE(
     "github #2452: incorrectly removing charge from boron anions"
-    "fragments,uncharger") {
+    "[fragments][uncharger]") {
   SECTION("demo") {
     auto m = "C[B-](C)(C)C"_smiles;
     REQUIRE(m);
@@ -173,7 +173,7 @@ TEST_CASE(
   }
 }
 
-TEST_CASE("github #2602: Uncharger ignores dications", "uncharger") {
+TEST_CASE("github #2602: Uncharger ignores dications", "[uncharger]") {
   SECTION("demo") {
     auto m = "[O-]CCC[O-].[Ca+2]"_smiles;
     REQUIRE(m);
@@ -191,7 +191,7 @@ TEST_CASE("github #2602: Uncharger ignores dications", "uncharger") {
 TEST_CASE(
     "github #2605: Uncharger incorrectly neutralizes cations when "
     "non-neutralizable anions are present.",
-    "uncharger") {
+    "[uncharger]") {
   SECTION("demo") {
     auto m = "F[B-](F)(F)F.[NH3+]CCC"_smiles;
     REQUIRE(m);
@@ -229,7 +229,7 @@ TEST_CASE(
 }
 
 TEST_CASE("github #2610: Uncharger incorrectly modifying a zwitterion.",
-          "uncharger") {
+          "[uncharger]") {
   SECTION("demo") {
     auto m = "C1=CC=CC[NH+]1-[O-]"_smiles;
     REQUIRE(m);
@@ -243,7 +243,7 @@ TEST_CASE("github #2610: Uncharger incorrectly modifying a zwitterion.",
   }
 }
 
-TEST_CASE("problems with ringInfo initialization", "normalizer") {
+TEST_CASE("problems with ringInfo initialization", "[normalizer]") {
   std::string tfs =
       R"TXT(Bad amide tautomer1	[C:1]([OH1;D1:2])=;!@[NH1:3]>>[C:1](=[OH0:2])-[NH2:3]
 Bad amide tautomer2	[C:1]([OH1;D1:2])=;!@[NH0:3]>>[C:1](=[OH0:2])-[NH1:3])TXT";
@@ -258,7 +258,7 @@ Bad amide tautomer2	[C:1]([OH1;D1:2])=;!@[NH0:3]>>[C:1](=[OH0:2])-[NH1:3])TXT";
   }
 }
 
-TEST_CASE("segfault in normalizer", "normalizer") {
+TEST_CASE("segfault in normalizer", "[normalizer]") {
   std::string tfs =
       R"TXT(Bad amide tautomer1	[C:1]([OH1;D1:2])=;!@[NH1:3]>>[C:1](=[OH0:2])-[NH2:3]
 Bad amide tautomer2	[C:1]([OH1;D1:2])=;!@[NH0:3]>>[C:1](=[OH0:2])-[NH1:3])TXT";
@@ -386,7 +386,7 @@ M  END
           "[C@H]1C[C@H](O)CN1C");
   }
 }
-TEST_CASE("problems with uncharging HS- from mol file", "normalizer") {
+TEST_CASE("problems with uncharging HS- from mol file", "[normalizer]") {
   SECTION("example1") {
     std::string mb = R"CTAB(
   SciTegic12231509382D
@@ -403,7 +403,7 @@ M  END)CTAB";
   }
 }
 
-TEST_CASE("explicit Hs and Ns when neutralizing", "normalizer") {
+TEST_CASE("explicit Hs and Ns when neutralizing", "[normalizer]") {
   SECTION("example1") {
     std::string molblock = R"CTAB(
   Mrv1810 10301909502D          
@@ -429,7 +429,7 @@ M  END
   }
 }
 
-TEST_CASE("fragment remover not considering bond counts", "[fragments,bug]") {
+TEST_CASE("fragment remover not considering bond counts", "[fragments][bug]") {
   std::string salts = R"DATA(Benethamine	C(Cc1ccccc1)NCc2ccccc2
 Chloride	Cl
 )DATA";
@@ -538,7 +538,7 @@ M  END
   }
 }
 
-TEST_CASE("github #2792: carbon in the uncharger", "[uncharger,bug]") {
+TEST_CASE("github #2792: carbon in the uncharger", "[uncharger][bug]") {
   SECTION("carbocation 1") {
     auto m = "C[CH2+]"_smiles;
     REQUIRE(m);
@@ -589,7 +589,7 @@ TEST_CASE("github #2792: carbon in the uncharger", "[uncharger,bug]") {
   }
 }
 
-TEST_CASE("github #2965: molecules properties not retained after cleanup", "[cleanup, bug]") {
+TEST_CASE("github #2965: molecules properties not retained after cleanup", "[cleanup][bug]") {
   SECTION("example 1") {
 	MolStandardize::CleanupParameters params;
 	std::unique_ptr<RWMol> m(SmilesToMol("Cl.c1cnc(OCCCC2CCNCC2)cn1"));

--- a/Code/GraphMol/ScaffoldNetwork/catch_tests.cpp
+++ b/Code/GraphMol/ScaffoldNetwork/catch_tests.cpp
@@ -22,7 +22,7 @@
 using namespace RDKit;
 
 #if 1
-TEST_CASE("flattenMol", "[unittest, scaffolds]") {
+TEST_CASE("flattenMol", "[unittest][scaffolds]") {
   auto m = "Cl.[13CH3][C@H](F)/C=C/C"_smiles;
   REQUIRE(m);
   SECTION("defaults") {
@@ -77,7 +77,7 @@ TEST_CASE("flattenMol", "[unittest, scaffolds]") {
   }
 }
 
-TEST_CASE("pruneMol", "[unittest, scaffolds]") {
+TEST_CASE("pruneMol", "[unittest][scaffolds]") {
   auto m = "O=C(O)C1C(=O)CC1"_smiles;
   REQUIRE(m);
   SECTION("defaults") {
@@ -89,7 +89,7 @@ TEST_CASE("pruneMol", "[unittest, scaffolds]") {
   }
 }
 
-TEST_CASE("removeAttachmentPoints", "[unittest, scaffolds]") {
+TEST_CASE("removeAttachmentPoints", "[unittest][scaffolds]") {
   auto m = "*c1ccc(*)c*1"_smiles;
   REQUIRE(m);
   SECTION("defaults") {
@@ -102,7 +102,7 @@ TEST_CASE("removeAttachmentPoints", "[unittest, scaffolds]") {
   }
 }
 
-TEST_CASE("makeScaffoldGeneric", "[unittest, scaffolds]") {
+TEST_CASE("makeScaffoldGeneric", "[unittest][scaffolds]") {
   auto m = "c1[nH]ccc1"_smiles;
   REQUIRE(m);
   SECTION("atoms") {
@@ -128,7 +128,7 @@ TEST_CASE("makeScaffoldGeneric", "[unittest, scaffolds]") {
   }
 }
 
-TEST_CASE("getMolFragments", "[unittest, scaffolds]") {
+TEST_CASE("getMolFragments", "[unittest][scaffolds]") {
   auto m = "c1ccccc1CC1NC(=O)CCC1"_smiles;
   REQUIRE(m);
   SECTION("defaults") {
@@ -181,7 +181,7 @@ TEST_CASE("getMolFragments", "[unittest, scaffolds]") {
   }
 }
 
-TEST_CASE("addMolToNetwork", "[unittest, scaffolds]") {
+TEST_CASE("addMolToNetwork", "[unittest][scaffolds]") {
   SECTION("defaults") {
     auto m = "c1ccccc1CC1NC(=O)CCC1"_smiles;
     REQUIRE(m);
@@ -363,7 +363,7 @@ TEST_CASE("ostream integration", "[scaffolds]") {
   }
 }
 
-TEST_CASE("no attachment points", "[unittest, scaffolds]") {
+TEST_CASE("no attachment points", "[unittest][scaffolds]") {
   auto m = "c1ccccc1CC1NC(=O)CCC1"_smiles;
   REQUIRE(m);
   SECTION("others default") {
@@ -513,7 +513,7 @@ TEST_CASE("no attachment points", "[unittest, scaffolds]") {
   }
 }
 
-TEST_CASE("BRICS Fragmenter", "[unittest, scaffolds]") {
+TEST_CASE("BRICS Fragmenter", "[unittest][scaffolds]") {
   auto m = "c1ccccc1C(=O)NC1NC(=O)CCC1"_smiles;
   REQUIRE(m);
   SECTION("original behavior default") {
@@ -555,7 +555,7 @@ TEST_CASE("BRICS Fragmenter", "[unittest, scaffolds]") {
 }
 
 TEST_CASE("Implicit Hs on aromatic atoms with attachments",
-          "[bug, scaffolds]") {
+          "[bug][scaffolds]") {
   auto m = "c1cn(C3CCC3)nc1"_smiles;
   REQUIRE(m);
   SECTION("original behavior default") {
@@ -585,7 +585,7 @@ TEST_CASE("Implicit Hs on aromatic atoms with attachments",
 }
 
 TEST_CASE("scaffold with attachment when attachments are disabled",
-          "[bug, scaffolds]") {
+          "[bug][scaffolds]") {
   auto m = "C1CCC1C1CCCC1C1CCCCC1"_smiles;
   REQUIRE(m);
   SECTION("bug report") {
@@ -613,7 +613,7 @@ TEST_CASE("scaffold with attachment when attachments are disabled",
   }
 }
 
-TEST_CASE("larger multi-mol test", "[regression, scaffold]") {
+TEST_CASE("larger multi-mol test", "[regression][scaffold]") {
   std::vector<std::string> smiles{
       "Cc1onc(-c2c(F)cccc2Cl)c1C(=O)N[C@@H]1C(=O)N2[C@@H](C(=O)O)C(C)(C)S[C@H]"
       "12",

--- a/Code/GraphMol/SmilesParse/catch_tests.cpp
+++ b/Code/GraphMol/SmilesParse/catch_tests.cpp
@@ -23,7 +23,7 @@
 
 using namespace RDKit;
 
-TEST_CASE("Github #1972", "[SMILES,bug]") {
+TEST_CASE("Github #1972", "[SMILES][bug]") {
   SECTION("basics") {
     std::vector<std::vector<std::string>> smiles = {
         {"[C@@]1(Cl)(F)(I).Br1", "[C@@](Br)(Cl)(F)(I)"},
@@ -62,7 +62,7 @@ TEST_CASE("Github #1972", "[SMILES,bug]") {
   }
 }
 
-TEST_CASE("Github #2029", "[SMILES,bug]") {
+TEST_CASE("Github #2029", "[SMILES][bug]") {
   SECTION("wedging") {
     std::unique_ptr<ROMol> m1(SmilesToMol("CN[C@H](Cl)C(=O)O"));
     REQUIRE(m1);
@@ -156,7 +156,7 @@ TEST_CASE(
   }
 }
 
-TEST_CASE("github #2257: writing cxsmiles", "[smiles,cxsmiles]") {
+TEST_CASE("github #2257: writing cxsmiles", "[smiles][cxsmiles]") {
   SECTION("basics") {
     auto mol = "OCC"_smiles;
     REQUIRE(mol);
@@ -328,7 +328,7 @@ TEST_CASE("github #2257: writing cxsmiles", "[smiles,cxsmiles]") {
   }
 }
 
-TEST_CASE("Github #2148", "[bug, Smiles, Smarts]") {
+TEST_CASE("Github #2148", "[bug][Smiles][Smarts]") {
   SECTION("SMILES") {
     auto mol = "C(=C\\F)\\4.O=C1C=4CCc2ccccc21"_smiles;
     REQUIRE(mol);
@@ -366,7 +366,7 @@ TEST_CASE("Github #2148", "[bug, Smiles, Smarts]") {
   }
 }
 
-TEST_CASE("Github #2298", "[bug, Smarts, substructure]") {
+TEST_CASE("Github #2298", "[bug][Smarts][substructure]") {
   SubstructMatchParameters ps;
   ps.useQueryQueryMatches = true;
   SECTION("basics") {
@@ -387,7 +387,7 @@ TEST_CASE("Github #2298", "[bug, Smarts, substructure]") {
   }
 }
 
-TEST_CASE("dative ring closures", "[bug, smiles]") {
+TEST_CASE("dative ring closures", "[bug][smiles]") {
   SECTION("first closure1") {
     auto m1 = "N->1CCN->[Pt]1"_smiles;
     REQUIRE(m1);
@@ -492,7 +492,7 @@ TEST_CASE("MolFragmentToSmarts", "[Smarts]") {
 }
 
 TEST_CASE("github #2667: MolToCXSmiles generates error for empty molecule",
-          "[bug,cxsmiles]") {
+          "[bug][cxsmiles]") {
   SECTION("basics") {
     auto mol = ""_smiles;
     REQUIRE(mol);
@@ -502,7 +502,7 @@ TEST_CASE("github #2667: MolToCXSmiles generates error for empty molecule",
 }
 
 TEST_CASE("github #2604: support range-based charge queries from SMARTS",
-          "[ranges,smarts]") {
+          "[ranges][smarts]") {
   SECTION("positive") {
     auto query = "[N+{0-1}]"_smarts;
     REQUIRE(query);
@@ -566,7 +566,7 @@ TEST_CASE("_smarts fails gracefully", "[smarts]") {
 
 TEST_CASE(
     "github #2801: MolToSmarts may generate invalid SMARTS for bond queries",
-    "[bug,smarts]") {
+    "[bug][smarts]") {
   SECTION("original_report") {
     auto q1 = "*~CCC"_smarts;
     REQUIRE(q1);

--- a/Code/GraphMol/Substruct/catch_tests.cpp
+++ b/Code/GraphMol/Substruct/catch_tests.cpp
@@ -169,7 +169,7 @@ TEST_CASE("providing a final match function", "[substruct]") {
   }
 }
 
-TEST_CASE("Enhanced stereochemistry", "[substruct,StereoGroup]") {
+TEST_CASE("Enhanced stereochemistry", "[substruct][StereoGroup]") {
   // Chirality specifications.
   // 1. An achiral molecule: CC(O)C(CC)F means unknown/all stereoisomers
   // 2. A chiral molecule: C[C@H](O)[C@H](CC)F means 1 stereoisomer

--- a/Code/GraphMol/catch_graphmol.cpp
+++ b/Code/GraphMol/catch_graphmol.cpp
@@ -55,7 +55,7 @@ TEST_CASE("Sanitization tests", "[molops]") {
   }
 }
 
-TEST_CASE("Github #2062", "[bug, molops]") {
+TEST_CASE("Github #2062", "[bug][molops]") {
   SmilesParserParams ps;
   ps.removeHs = false;
   ps.sanitize = true;
@@ -72,7 +72,7 @@ TEST_CASE("Github #2062", "[bug, molops]") {
   }
 }
 
-TEST_CASE("Github #2086", "[bug, molops]") {
+TEST_CASE("Github #2086", "[bug][molops]") {
   SECTION("reported version") {
     auto mol = "C1CCCC1"_smiles;
     REQUIRE(mol);
@@ -84,7 +84,7 @@ TEST_CASE("Github #2086", "[bug, molops]") {
   }
 }
 
-TEST_CASE("github #299", "[bug, molops, SSSR]") {
+TEST_CASE("github #299", "[bug][molops][SSSR]") {
   SECTION("simplified") {
     auto mol =
         "C13%13%14.C124%18.C25%13%15.C368%17.C4679.C75%10%17.C8%11%14%16.C9%11%12%18.C%10%12%15%16"_smiles;
@@ -122,7 +122,7 @@ TEST_CASE("github #299", "[bug, molops, SSSR]") {
   }
 }
 
-TEST_CASE("github #2224", "[bug, molops, removeHs, query]") {
+TEST_CASE("github #2224", "[bug][molops][removeHs][query]") {
   SECTION("the original report") {
     std::string pathName = getenv("RDBASE");
     pathName += "/Code/GraphMol/test_data/";
@@ -155,7 +155,7 @@ TEST_CASE("github #2224", "[bug, molops, removeHs, query]") {
 
 TEST_CASE(
     "github #2268: Recognize N in three-membered rings as potentially chiral",
-    "[bug,stereo]") {
+    "[bug][stereo]") {
   SECTION("basics: N in a 3 ring") {
     const auto mol = "C[N@]1CC1C"_smiles;
     REQUIRE(mol);
@@ -217,7 +217,7 @@ M  END
   }
 }
 
-TEST_CASE("github #2244", "[bug, molops, stereo]") {
+TEST_CASE("github #2244", "[bug][molops][stereo]") {
   SECTION("the original report") {
     auto mol = "CC=CC=CC"_smiles;
     REQUIRE(mol);
@@ -233,7 +233,7 @@ TEST_CASE("github #2244", "[bug, molops, stereo]") {
 
 TEST_CASE(
     "github #2258: heterocycles with exocyclic bonds not failing valence check",
-    "[bug, molops]") {
+    "[bug][molops]") {
   SECTION("the original report") {
     std::vector<std::string> smiles = {"C=n1ccnc1", "C#n1ccnc1"};
     for (auto smi : smiles) {
@@ -243,7 +243,7 @@ TEST_CASE(
 }
 
 TEST_CASE("github #908: AddHs() using 3D coordinates with 2D conformations",
-          "[bug, molops]") {
+          "[bug][molops]") {
   SECTION("basics: single atom mols") {
     std::vector<std::string> smiles = {"Cl", "O", "N", "C"};
     for (auto smi : smiles) {
@@ -268,7 +268,7 @@ TEST_CASE("github #908: AddHs() using 3D coordinates with 2D conformations",
 TEST_CASE(
     "github #2437: Canon::rankMolAtoms results in crossed double bonds in "
     "rings",
-    "[bug, molops]") {
+    "[bug][molops]") {
   SECTION("underlying problem") {
     std::string molb = R"CTAB(testmol
   Mrv1824 05081910082D          
@@ -332,7 +332,7 @@ M  END
 TEST_CASE(
     "github #2423: Incorrect assignment of explicit Hs to Al+3 read from mol "
     "block",
-    "[bug, molops]") {
+    "[bug][molops]") {
   SECTION("basics: single atom mols") {
     std::string mb = R"CTAB(2300
   -OEChem-01301907122D
@@ -426,7 +426,7 @@ TEST_CASE("detectChemistryProblems", "[molops]") {
 
 TEST_CASE(
     "github #2606: Bad valence corrections on Pb, Sn"
-    "[bug, molops]") {
+    "[bug][molops]") {
   SECTION("basics-Pb") {
     std::string mb = R"CTAB(
   Mrv1810 08141905562D          
@@ -484,7 +484,7 @@ M  END
 }
 TEST_CASE(
     "github #2607: Pb, Sn should support valence 2"
-    "[bug, molops]") {
+    "[bug][molops]") {
   SECTION("basics-Pb") {
     std::string mb = R"CTAB(
   Mrv1810 08141905562D          
@@ -521,7 +521,7 @@ M  END
 
 TEST_CASE(
     "github #2649: Allenes read from mol blocks have crossed bonds assigned"
-    "[bug, stereochemistry]") {
+    "[bug][stereochemistry]") {
   SECTION("basics") {
     std::string mb = R"CTAB(mol
   Mrv1824 09191901002D          
@@ -645,7 +645,7 @@ M  END
   }
 }
 
-TEST_CASE("removeHs screwing up double bond stereo", "[bug,removeHs]") {
+TEST_CASE("removeHs screwing up double bond stereo", "[bug][removeHs]") {
   SECTION("example1") {
     std::string molblock = R"CTAB(molblock = """
   SciTegic12221702182D
@@ -775,7 +775,7 @@ M  END
   }
 }
 
-TEST_CASE("setDoubleBondNeighborDirections()", "[stereochemistry,bug]") {
+TEST_CASE("setDoubleBondNeighborDirections()", "[stereochemistry][bug]") {
   SECTION("basics") {
     auto m = "CC=CC"_smiles;
     REQUIRE(m);
@@ -808,7 +808,7 @@ TEST_CASE("github #2782: addHs() fails on atoms with 'bad' valences", "[bug]") {
 TEST_CASE(
     "Github #2784: Element symbol lookup for some transuranics returns "
     "incorrect results",
-    "[transuranics,bug]") {
+    "[transuranics][bug]") {
   auto pt = PeriodicTable::getTable();
   SECTION("number to symbol") {
     std::vector<std::pair<unsigned int, std::string>> data = {
@@ -827,7 +827,7 @@ TEST_CASE(
     }
   }
 }
-TEST_CASE("github #2775", "[valence,bug]") {
+TEST_CASE("github #2775", "[valence][bug]") {
   SECTION("basics") {
     std::string molblock = R"CTAB(bismuth citrate
   Mrv1810 11111908592D          
@@ -1109,7 +1109,7 @@ TEST_CASE("RemoveHsParameters", "[molops]") {
 }
 #endif
 TEST_CASE("github #2895: acepentalene aromaticity perception ",
-          "[molops,bug,aromaticity]") {
+          "[molops][bug][aromaticity]") {
   SECTION("acepentalene") {
     std::unique_ptr<RWMol> m{SmilesToMol("C1=CC2=CC=C3C2=C1C=C3")};
     REQUIRE(m);
@@ -1474,7 +1474,7 @@ TEST_CASE("phosphine and arsine chirality", "[Chirality]") {
   }
 }
 
-TEST_CASE("github #2890", "[bug, molops, stereo]") {
+TEST_CASE("github #2890", "[bug][molops][stereo]") {
     auto mol = "CC=CC"_smiles;
     REQUIRE(mol);
 


### PR DESCRIPTION
I think some Catch2 test cases are wrongly tagged—`[foo,bar]` should be `[foo][bar]`.

See https://github.com/catchorg/Catch2/blob/v2.1.2/docs/test-cases-and-sections.md#tags

<!--
Thanks for contributing a pull request! 

#### Reference Issue
Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.
<details>
<summary>build</summary>

```shellsession
$ cmake -Bbuild -GNinja ..
$ cmake --build build Code/GraphMol/ChemReactions/all
```

</details>

For example,  [Code/GraphMol/ChemReactions/catch_tests.cpp](https://github.com/rdkit/rdkit/blob/9ce1955e8d88b8113900b152f228a2ab49a747ea/Code/GraphMol/ChemReactions/catch_tests.cpp) has the following tests:

```shellsession
$ cd build
$ ./Code/GraphMol/ChemReactions/rxnTestCatch -l
All available test cases:
  Github #1632
      [Reaction,PDB,bug]
  Github #2366 Enhanced Stereo
      [Reaction,StereoGroup,bug]
  Github #2427 cannot set maxProducts>1000 in runReactants
      [Reaction,bug]
  negative charge queries. Part of testing changes for github #2604
      [Reaction]
  GithHub #2954: Reaction Smarts with Dative Bonds not parsed
      [Reaction, Bug]
5 test cases

```

However, `[Reaction,PDB,bug]` is considered as a *single* tag, but not as three tags, i.e., `[Reaction]`, `[PDB]`, and `[bug]`.

```shellsession
$ ./Code/GraphMol/ChemReactions/rxnTestCatch -t
All available tags:
   1  [Reaction]
   1  [Reaction, Bug]
   1  [Reaction,bug]
   1  [Reaction,PDB,bug]
   1  [Reaction,StereoGroup,bug]
5 tags

$ ./Code/GraphMol/ChemReactions/rxnTestCatch '[bug]'
===============================================================================
No tests ran

$ ./Code/GraphMol/ChemReactions/rxnTestCatch '[Reaction,PDB,bug]'
===============================================================================
All tests passed (10 assertions in 1 test case)

```

I believe this is unintentional.

<!--
#### Any other comments?

-->