### PR TITLE
Cleanup some cmake dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -216,7 +216,6 @@ endif(MSVC)
 # extra boost versions
 if(MSVC)
   # FIX: do we still need this?
-  SET(Boost_ADDITIONAL_VERSIONS "1.48" "1.48.0" "1.45" "1.45.0" "1.44" "1.44.0" "1.43" "1.43.0" "1.42" "1.42.0" "1.41" "1.41.0" "1.40" "1.40.0")
   target_compile_definitions(rdkit_base INTERFACE "-DBOOST_ALL_NO_LIB")
 endif(MSVC)
 
@@ -225,6 +224,8 @@ if(RDK_BUILD_INCHI_SUPPORT)
 endif(RDK_BUILD_INCHI_SUPPORT)
 
 if(RDK_BUILD_PYTHON_WRAPPERS)
+  add_library(rdkit_py_base INTERFACE)
+
   #-------
   # pull in python:
   find_package(PythonInterp)
@@ -238,6 +239,7 @@ if(RDK_BUILD_PYTHON_WRAPPERS)
 
   find_package(PythonLibs)
   target_include_directories(rdkit_base INTERFACE ${PYTHON_INCLUDE_DIR})
+  add_dependencies(rdkit_py_base ${PYTHON_LIBRARIES} )
   find_package(NumPy REQUIRED)
   target_include_directories(rdkit_base INTERFACE ${PYTHON_NUMPY_INCLUDE_PATH})
 
@@ -262,6 +264,9 @@ if(RDK_BUILD_PYTHON_WRAPPERS)
   if(NOT Boost_FOUND)
     find_package(Boost 1.56.0 COMPONENTS python REQUIRED)
   endif()
+
+  add_dependencies(rdkit_py_base Boost::${Boost_Python_Lib})
+
 
 
   if(RDK_INSTALL_INTREE)
@@ -351,6 +356,7 @@ if(RDK_BUILD_THREADSAFE_SSS)
   if(RDK_TEST_MULTITHREADED)
     target_compile_definitions(rdkit_base INTERFACE "-DRDK_TEST_MULTITHREADED")
   endif()
+  target_link_libraries(rdkit_base INTERFACE Threads::Threads)
 else()
   if(RDK_TEST_MULTITHREADED)
     message("RDK_TEST_MULTITHREADED does not make sense without RD_BUILD_THREADSAFE_SSS, disabling it.")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -239,7 +239,19 @@ if(RDK_BUILD_PYTHON_WRAPPERS)
 
   find_package(PythonLibs)
   target_include_directories(rdkit_base INTERFACE ${PYTHON_INCLUDE_DIR})
-  target_link_libraries(rdkit_py_base INTERFACE ${PYTHON_LIBRARIES} )
+
+  # determine linkage of python
+  execute_process(
+      COMMAND
+      ${PYTHON_EXECUTABLE} -c "from distutils import sysconfig; print(sysconfig.get_config_var('Py_ENABLE_SHARED'))"
+      OUTPUT_VARIABLE Py_ENABLE_SHARED
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+
+  if(WIN32 OR "${Py_ENABLE_SHARED}" STREQUAL "1")
+    target_link_libraries(rdkit_py_base INTERFACE ${PYTHON_LIBRARIES} )
+  endif()
+  
   find_package(NumPy REQUIRED)
   target_include_directories(rdkit_base INTERFACE ${PYTHON_NUMPY_INCLUDE_PATH})
 
@@ -305,13 +317,6 @@ if(RDK_BUILD_PYTHON_WRAPPERS)
 
   endif(RDK_INSTALL_INTREE)
 
-  # determine linkage of python
-  execute_process(
-      COMMAND
-      ${PYTHON_EXECUTABLE} -c "from distutils import sysconfig; print(sysconfig.get_config_var('Py_ENABLE_SHARED'))"
-      OUTPUT_VARIABLE Py_ENABLE_SHARED
-      OUTPUT_STRIP_TRAILING_WHITESPACE
-  )
   if(NOT WIN32)
     # See https://bugs.python.org/msg277944
     # The "command to create shared modules". Used as variable in the "Makefile (and similar) templates to build python modules"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 project (RDKit)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -268,8 +268,6 @@ if(RDK_BUILD_PYTHON_WRAPPERS)
 
   target_link_libraries(rdkit_py_base INTERFACE Boost::${Boost_Python_Lib})
 
-
-
   if(RDK_INSTALL_INTREE)
     set(RDKit_PythonDir "${CMAKE_SOURCE_DIR}/rdkit")
   else(RDK_INSTALL_INTREE)
@@ -329,6 +327,10 @@ if(RDK_BUILD_PYTHON_WRAPPERS)
      message("PYTHON Py_ENABLE_SHARED: ${Py_ENABLE_SHARED}")
      message("PYTHON USING LINK LINE: ${PYTHON_LDSHARED}")
   endif()
+
+  install(TARGETS rdkit_py_base EXPORT ${RDKit_EXPORTED_TARGETS}
+          COMPONENT dev )
+
 else(RDK_BUILD_PYTHON_WRAPPERS)
   find_package(Boost 1.56.0 REQUIRED)
 endif(RDK_BUILD_PYTHON_WRAPPERS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -239,7 +239,7 @@ if(RDK_BUILD_PYTHON_WRAPPERS)
 
   find_package(PythonLibs)
   target_include_directories(rdkit_base INTERFACE ${PYTHON_INCLUDE_DIR})
-  add_dependencies(rdkit_py_base ${PYTHON_LIBRARIES} )
+  target_link_libraries(rdkit_py_base INTERFACE ${PYTHON_LIBRARIES} )
   find_package(NumPy REQUIRED)
   target_include_directories(rdkit_base INTERFACE ${PYTHON_NUMPY_INCLUDE_PATH})
 
@@ -253,19 +253,20 @@ if(RDK_BUILD_PYTHON_WRAPPERS)
   list(APPEND Boost_Python_Names "python${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR}")
 
   # Try each potential boost-python name until one works
-  foreach(Boost_Python_Lib ${Boost_Python_Names})
-    find_package(Boost 1.56.0 COMPONENTS "${Boost_Python_Lib}" QUIET)
+  foreach(Boost_Python_LibN ${Boost_Python_Names})
+    find_package(Boost 1.56.0 COMPONENTS "${Boost_Python_LibN}" QUIET)
     if(Boost_FOUND)
+      set(Boost_Python_Lib ${Boost_Python_LibN})
       break()
     endif()
   endforeach()
-
   # Finally just try "python" and hope it is a compatible version
   if(NOT Boost_FOUND)
     find_package(Boost 1.56.0 COMPONENTS python REQUIRED)
+    set(Boost_Python_Lib "python")
   endif()
 
-  add_dependencies(rdkit_py_base Boost::${Boost_Python_Lib})
+  target_link_libraries(rdkit_py_base INTERFACE Boost::${Boost_Python_Lib})
 
 
 

--- a/Code/ChemicalFeatures/CMakeLists.txt
+++ b/Code/ChemicalFeatures/CMakeLists.txt
@@ -7,7 +7,7 @@ rdkit_headers(ChemicalFeature.h
               FreeChemicalFeature.h DEST ChemicalFeatures)
 
 rdkit_test(testChemicalFeatures testChemicalFeatures.cpp 
-           LINK_LIBRARIES ChemicalFeatures RDGeneral)
+           LINK_LIBRARIES ChemicalFeatures)
 
 if(RDK_BUILD_PYTHON_WRAPPERS)
 add_subdirectory(Wrap)

--- a/Code/ChemicalFeatures/Wrap/CMakeLists.txt
+++ b/Code/ChemicalFeatures/Wrap/CMakeLists.txt
@@ -3,7 +3,7 @@ rdkit_python_extension(rdChemicalFeatures
                        rdChemicalFeatures.cpp FreeChemicalFeature.cpp
                        DEST Chem
                        LINK_LIBRARIES
-                       ChemicalFeatures GraphMol RDGeometryLib RDGeneral RDBoost) 
+                       ChemicalFeatures GraphMol) 
 
 add_pytest(pyFeatures ${CMAKE_CURRENT_SOURCE_DIR}/testFeatures.py)
 

--- a/Code/DataManip/MetricMatrixCalc/Wrap/CMakeLists.txt
+++ b/Code/DataManip/MetricMatrixCalc/Wrap/CMakeLists.txt
@@ -1,7 +1,7 @@
 rdkit_python_extension(rdMetricMatrixCalc rdMetricMatrixCalc.cpp
                        DEST DataManip/Metric
                        LINK_LIBRARIES
-                       RDGeneral DataStructs RDBoost)
+                       DataStructs)
 
 add_pytest(pyMatCalc ${CMAKE_CURRENT_SOURCE_DIR}/testMatricCalc.py)
 

--- a/Code/DataStructs/CMakeLists.txt
+++ b/Code/DataStructs/CMakeLists.txt
@@ -27,13 +27,13 @@ rdkit_headers(base64.h
               DEST DataStructs)
 
 rdkit_test(testDataStructs testDatastructs.cpp
-           LINK_LIBRARIES DataStructs RDGeneral)
+           LINK_LIBRARIES DataStructs )
 
 rdkit_test(testFPB testFPB.cpp
-           LINK_LIBRARIES DataStructs RDGeneral)
+           LINK_LIBRARIES DataStructs )
 
 rdkit_test(testMultiFPB testMultiFPB.cpp
-           LINK_LIBRARIES DataStructs RDGeneral)
+           LINK_LIBRARIES DataStructs )
 
 if(RDK_BUILD_PYTHON_WRAPPERS)
 add_subdirectory(Wrap)

--- a/Code/DataStructs/Wrap/CMakeLists.txt
+++ b/Code/DataStructs/Wrap/CMakeLists.txt
@@ -6,7 +6,7 @@ rdkit_python_extension(cDataStructs
                        wrap_Utils.cpp
                        DEST DataStructs
                        LINK_LIBRARIES
-                       RDGeneral DataStructs RDBoost)
+                       DataStructs)
 
 add_pytest(pyBV
          ${CMAKE_CURRENT_SOURCE_DIR}/testBV.py)

--- a/Code/Demos/RDKit/GettingStarted/CMakeLists.txt
+++ b/Code/Demos/RDKit/GettingStarted/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.6)
+cmake_minimum_required (VERSION 3.5)
 project (GettingStartedDemo)
 
 find_package (RDKit 1.2011.09 REQUIRED)

--- a/Code/DistGeom/CMakeLists.txt
+++ b/Code/DistGeom/CMakeLists.txt
@@ -16,7 +16,7 @@ rdkit_headers(BoundsMatrix.h
               TriangleSmooth.h DEST DistGeom)
 
 rdkit_test(testDistGeom testDistGeom.cpp 
-LINK_LIBRARIES DistGeometry EigenSolvers ForceField ForceFieldHelpers Optimizer RDGeneral RDGeometryLib )
+LINK_LIBRARIES DistGeometry )
 
 if(RDK_BUILD_PYTHON_WRAPPERS)
 add_subdirectory(Wrap)

--- a/Code/DistGeom/Wrap/CMakeLists.txt
+++ b/Code/DistGeom/Wrap/CMakeLists.txt
@@ -1,7 +1,7 @@
 remove_definitions(-DRDKIT_DISTGEOMETRY_BUILD)
 rdkit_python_extension(DistGeom DistGeom.cpp
                        DEST DistanceGeometry
-LINK_LIBRARIES DistGeometry EigenSolvers ForceField ForceFieldHelpers Optimizer RDGeneral RDGeometryLib RDBoost )
+LINK_LIBRARIES DistGeometry )
 
 
 add_pytest(pyDistGeom ${CMAKE_CURRENT_SOURCE_DIR}/rough_test.py)

--- a/Code/ForceField/MMFF/CMakeLists.txt
+++ b/Code/ForceField/MMFF/CMakeLists.txt
@@ -8,7 +8,6 @@ if(RDK_TEST_MMFF_COMPLIANCE)
   endif()
 rdkit_test(testMMFFForceField testMMFFForceField.cpp
     LINK_LIBRARIES
-    DistGeomHelpers DistGeometry ForceFieldHelpers ForceField 
-    FileParsers MolTransforms SmilesParse SubstructMatch MolAlign
-    Optimizer EigenSolvers Alignment GraphMol RDGeometryLib RDGeneral ${RDKit_THREAD_LIBS} )
+    DistGeomHelpers ForceFieldHelpers  
+    FileParsers MolTransforms SmilesParse SubstructMatch MolAlign )
 endif(RDK_TEST_MMFF_COMPLIANCE)

--- a/Code/ForceField/UFF/CMakeLists.txt
+++ b/Code/ForceField/UFF/CMakeLists.txt
@@ -1,4 +1,3 @@
 rdkit_test(testUFFForceField testUFFForceField.cpp 
-LINK_LIBRARIES ForceField Optimizer RDGeometryLib RDGeneral
-  EigenSolvers SmilesParse SubstructMatch GraphMol
-  FileParsers MolTransforms ForceFieldHelpers ${RDKit_THREAD_LIBS} )
+LINK_LIBRARIES ForceFieldHelpers SmilesParse SubstructMatch 
+  FileParsers MolTransforms )

--- a/Code/ForceField/Wrap/CMakeLists.txt
+++ b/Code/ForceField/Wrap/CMakeLists.txt
@@ -1,6 +1,5 @@
 remove_definitions(-DRDKIT_FORCEFIELD_BUILD)
 rdkit_python_extension(rdForceField ForceField.cpp
                        DEST ForceField
-                       LINK_LIBRARIES GraphMol ForceField ForceFieldHelpers Optimizer
-                       RDGeneral RDGeometryLib RDBoost)
+                       LINK_LIBRARIES ForceFieldHelpers )
 add_pytest(pyForceFieldConstraints ${CMAKE_CURRENT_SOURCE_DIR}/testConstraints.py)

--- a/Code/Geometry/CMakeLists.txt
+++ b/Code/Geometry/CMakeLists.txt
@@ -14,10 +14,10 @@ rdkit_headers(Grid3D.h
               UniformGrid3D.h
               Utils.h DEST Geometry)
 
-rdkit_test(testTransforms testTransforms.cpp LINK_LIBRARIES RDGeometryLib DataStructs RDGeneral )
-rdkit_test(testGrid testGrid.cpp LINK_LIBRARIES RDGeometryLib DataStructs RDGeneral )
+rdkit_test(testTransforms testTransforms.cpp LINK_LIBRARIES RDGeometryLib )
+rdkit_test(testGrid testGrid.cpp LINK_LIBRARIES RDGeometryLib)
 rdkit_catch_test(geometryTestsCatch catch_tests.cpp
-           LINK_LIBRARIES RDGeometryLib RDGeneral)
+           LINK_LIBRARIES RDGeometryLib)
 
 if(RDK_BUILD_PYTHON_WRAPPERS)
 add_subdirectory(Wrap)

--- a/Code/Geometry/Wrap/CMakeLists.txt
+++ b/Code/Geometry/Wrap/CMakeLists.txt
@@ -2,7 +2,7 @@ remove_definitions(-DRDKIT_RDGEOMETRYLIB_BUILD)
 rdkit_python_extension(rdGeometry
                        Point.cpp UniformGrid3D.cpp rdGeometry.cpp
                        DEST Geometry
-                       LINK_LIBRARIES RDGeometryLib DataStructs RDGeneral RDBoost)
+                       LINK_LIBRARIES RDGeometryLib)
 
 add_pytest(testPyGeometry ${CMAKE_CURRENT_SOURCE_DIR}/testGeometry.py)
 

--- a/Code/GraphMol/CMakeLists.txt
+++ b/Code/GraphMol/CMakeLists.txt
@@ -10,11 +10,7 @@ rdkit_library(GraphMol
               Renumber.cpp AdjustQuery.cpp Resonance.cpp StereoGroup.cpp
               new_canon.cpp SubstanceGroup.cpp
               SHARED
-              LINK_LIBRARIES RDGeometryLib RDGeneral  
-                 ${RDKit_THREAD_LIBS} )
-
-target_link_libraries(GraphMol PUBLIC ${RDKit_THREAD_LIBS})
-
+              LINK_LIBRARIES RDGeometryLib RDGeneral  )
 if(RDK_USE_URF)
   target_link_libraries(GraphMol PUBLIC ${RDK_URF_LIBS})
 endif()
@@ -111,46 +107,46 @@ add_subdirectory(ScaffoldNetwork)
 
 
 rdkit_test(graphmolTest1 test1.cpp LINK_LIBRARIES FileParsers SmilesParse GraphMol
-RDGeometryLib RDGeneral SubstructMatch ForceFieldHelpers ForceField)
+ SubstructMatch ForceFieldHelpers ForceField)
 
-rdkit_test(graphmolcpTest cptest.cpp LINK_LIBRARIES  SmilesParse GraphMol RDGeometryLib RDGeneral)
+rdkit_test(graphmolcpTest cptest.cpp LINK_LIBRARIES  SmilesParse GraphMol)
 
-rdkit_test(graphmolqueryTest querytest.cpp LINK_LIBRARIES SubstructMatch SmilesParse GraphMol RDGeometryLib RDGeneral)
+rdkit_test(graphmolqueryTest querytest.cpp LINK_LIBRARIES SubstructMatch SmilesParse GraphMol)
 
 rdkit_test(graphmolMolOpsTest molopstest.cpp
            LINK_LIBRARIES SubstructMatch FileParsers
-	   SmilesParse GraphMol RDGeometryLib RDGeneral)
+	   SmilesParse GraphMol )
 
 rdkit_test(graphmoltestChirality testChirality.cpp
            LINK_LIBRARIES SmilesParse FileParsers
-	   GraphMol RDGeometryLib RDGeneral)
+	   GraphMol )
 
 rdkit_test(graphmoltestPickler testPickler.cpp
-           LINK_LIBRARIES SmilesParse SubstructMatch FileParsers GraphMol RDGeometryLib RDGeneral)
+           LINK_LIBRARIES SmilesParse SubstructMatch FileParsers GraphMol )
 
 rdkit_test(graphmoltestPicklerGlobalSetting testPicklerGlobalSettings.cpp
-           LINK_LIBRARIES SmilesParse SubstructMatch FileParsers GraphMol RDGeometryLib RDGeneral)
+           LINK_LIBRARIES SmilesParse SubstructMatch FileParsers GraphMol )
 
-rdkit_test(graphmolIterTest itertest.cpp LINK_LIBRARIES SmilesParse GraphMol RDGeometryLib RDGeneral)
+rdkit_test(graphmolIterTest itertest.cpp LINK_LIBRARIES SmilesParse GraphMol )
 
 rdkit_test(hanoiTest hanoitest.cpp LINK_LIBRARIES
      SubstructMatch SmilesParse FileParsers GraphMol
-     RDGeometryLib RDGeneral ${RDKit_THREAD_LIBS} )
+      )
 
-rdkit_test(graphmolMemTest1 memtest1.cpp LINK_LIBRARIES SmilesParse GraphMol RDGeometryLib RDGeneral)
+rdkit_test(graphmolMemTest1 memtest1.cpp LINK_LIBRARIES SmilesParse GraphMol )
 
 rdkit_test(resMolSupplierTest resMolSupplierTest.cpp
-           LINK_LIBRARIES SmilesParse GraphMol RDGeometryLib RDGeneral SubstructMatch FileParsers)
+           LINK_LIBRARIES SmilesParse GraphMol SubstructMatch FileParsers)
 
 rdkit_test(molBundleTest testMolBundle.cpp
-          LINK_LIBRARIES SmilesParse GraphMol RDGeometryLib RDGeneral SubstructMatch FileParsers)
+          LINK_LIBRARIES SmilesParse GraphMol SubstructMatch FileParsers)
 
 rdkit_test(testSGroup testSGroup.cpp LINK_LIBRARIES FileParsers GraphMol)
 
-rdkit_test(test-valgrind test-valgrind.cpp LINK_LIBRARIES SmilesParse GraphMol RDGeneral)
+rdkit_test(test-valgrind test-valgrind.cpp LINK_LIBRARIES SmilesParse GraphMol )
 
 rdkit_catch_test(graphmolTestsCatch catch_graphmol.cpp catch_main.cpp
-           LINK_LIBRARIES SubstructMatch FileParsers SmilesParse GraphMol RDGeometryLib RDGeneral)
+           LINK_LIBRARIES SubstructMatch FileParsers SmilesParse GraphMol )
 
 rdkit_catch_test(graphmolSGroupCatch catch_sgroups.cpp  catch_main.cpp
-           LINK_LIBRARIES SmilesParse GraphMol RDGeometryLib RDGeneral)
+           LINK_LIBRARIES SmilesParse GraphMol )

--- a/Code/GraphMol/ChemReactions/CMakeLists.txt
+++ b/Code/GraphMol/ChemReactions/CMakeLists.txt
@@ -20,10 +20,9 @@ rdkit_library(ChemReactions
                     Enumerate/Enumerate.cpp
                     Enumerate/EnumerationPickler.cpp
                     Enumerate/EvenSamplePairs.cpp
-
               LINK_LIBRARIES
               FilterCatalog Descriptors Fingerprints DataStructs Depictor
-              FileParsers SubstructMatch ChemTransforms ${RDKit_SERIALIZATION_LIBS})
+              FileParsers SubstructMatch ChemTransforms GraphMol ${RDKit_SERIALIZATION_LIBS})
 
 rdkit_headers(Reaction.h
               ReactionParser.h
@@ -46,21 +45,15 @@ rdkit_headers(Enumerate/Enumerate.h
               DEST GraphMol/ChemReactions/Enumerate)
 
 rdkit_test(testReaction testReaction.cpp LINK_LIBRARIES
- ChemReactions ChemTransforms Descriptors Fingerprints
-Subgraphs DataStructs  FileParsers SmilesParse SubstructMatch
-GraphMol RDGeneral RDGeometryLib ${RDKit_SERIALIZATION_LIBS})
+ ChemReactions )
 
 rdkit_test(testReactionFingerprints testReactionFingerprints.cpp LINK_LIBRARIES
-ChemReactions Descriptors Fingerprints Subgraphs DataStructs ChemTransforms FileParsers SmilesParse SubstructMatch
-GraphMol RDGeneral RDGeometryLib ${RDKit_SERIALIZATION_LIBS})
+ChemReactions )
 
 rdkit_test(testEnumeration Enumerate/testEnumerate.cpp LINK_LIBRARIES
-ChemReactions ChemTransforms Descriptors Fingerprints Subgraphs DataStructs FileParsers SmilesParse SubstructMatch
-GraphMol RDGeneral RDGeometryLib ${RDKit_SERIALIZATION_LIBS} )
+ChemReactions  )
 
-rdkit_catch_test(rxnTestCatch catch_tests.cpp LINK_LIBRARIES ChemReactions ChemTransforms Descriptors Fingerprints
-Subgraphs DataStructs  FileParsers SmilesParse SubstructMatch
-GraphMol RDGeneral RDGeometryLib ${RDKit_SERIALIZATION_LIBS} )
+rdkit_catch_test(rxnTestCatch catch_tests.cpp LINK_LIBRARIES ChemReactions )
 
 if(RDK_BUILD_PYTHON_WRAPPERS)
 add_subdirectory(Wrap)

--- a/Code/GraphMol/ChemReactions/Wrap/CMakeLists.txt
+++ b/Code/GraphMol/ChemReactions/Wrap/CMakeLists.txt
@@ -4,10 +4,7 @@ rdkit_python_extension(rdChemReactions
                        rdChemReactions.cpp
                        DEST Chem
                        LINK_LIBRARIES
-ChemReactions
- FilterCatalog ChemTransforms
-Descriptors Fingerprints Subgraphs DataStructs Depictor FileParsers SmilesParse SubstructMatch
-GraphMol Catalogs FilterCatalog RDGeneral RDGeometryLib RDBoost )
+ChemReactions )
 
 add_pytest(pyChemReactions
          ${CMAKE_CURRENT_SOURCE_DIR}/testReactionWrapper.py)

--- a/Code/GraphMol/ChemTransforms/CMakeLists.txt
+++ b/Code/GraphMol/ChemTransforms/CMakeLists.txt
@@ -2,8 +2,7 @@
 remove_definitions(-DRDKIT_GRAPHMOL_BUILD)
 add_definitions(-DRDKIT_CHEMTRANSFORMS_BUILD)
 rdkit_library(ChemTransforms ChemTransforms.cpp MolFragmenter.cpp LINK_LIBRARIES
-  SubstructMatch SmilesParse 
-  ${RDKit_THREAD_LIBS})
+  GraphMol SubstructMatch SmilesParse )
 
 rdkit_headers(ChemTransforms.h
    MolFragmenter.h
@@ -12,11 +11,7 @@ rdkit_headers(ChemTransforms.h
 # there's no Wrap subdirectory on the main trunk (but in "minimal" there is)..
 #add_subdirectory(Wrap)
 
-#rdkit_test(testChemTransforms testChemTransforms.cpp 
-#           LINK_LIBRARIES ChemTransforms FileParsers SmilesParse SubstructMatch GraphMol RDGeometryLib RDGeneral )
 rdkit_test(testChemTransforms testChemTransforms.cpp 
-           LINK_LIBRARIES ChemTransforms FileParsers SmilesParse SubstructMatch
-           GraphMol RDGeometryLib RDGeneral ${RDKit_THREAD_LIBS})
+           LINK_LIBRARIES ChemTransforms FileParsers)
 
-rdkit_catch_test(chemTransformsTestCatch catch_tests.cpp LINK_LIBRARIES ChemTransforms FileParsers SmilesParse 
-    SubstructMatch GraphMol RDGeometryLib RDGeneral ${RDKit_THREAD_LIBS} )
+rdkit_catch_test(chemTransformsTestCatch catch_tests.cpp LINK_LIBRARIES ChemTransforms FileParsers)

--- a/Code/GraphMol/Depictor/CMakeLists.txt
+++ b/Code/GraphMol/Depictor/CMakeLists.txt
@@ -15,14 +15,14 @@ endif()
 
 rdkit_library(Depictor
               RDDepictor.cpp EmbeddedFrag.cpp DepictUtils.cpp
-              LINK_LIBRARIES ${RDK_COORDGEN_LIBS} SubstructMatch GraphMol)
+              LINK_LIBRARIES ${RDK_COORDGEN_LIBS} SubstructMatch GraphMol RDGeneral)
 
 rdkit_headers(DepictUtils.h
               EmbeddedFrag.h
               RDDepictor.h DEST GraphMol/Depictor)
 
 rdkit_test(testDepictor testDepictor.cpp
-           LINK_LIBRARIES Depictor ChemTransforms FileParsers SmilesParse GraphMol RDGeometryLib RDGeneral )
+           LINK_LIBRARIES Depictor ChemTransforms FileParsers SmilesParse )
 
 FILE(GLOB TEST_OUTPUT_FILES "${CMAKE_CURRENT_SOURCE_DIR}/test_data/*.out.sdf")
 get_directory_property(extra_clean_files ADDITIONAL_MAKE_CLEAN_FILES)

--- a/Code/GraphMol/Depictor/Wrap/CMakeLists.txt
+++ b/Code/GraphMol/Depictor/Wrap/CMakeLists.txt
@@ -3,6 +3,6 @@ rdkit_python_extension(rdDepictor
                        rdDepictor.cpp
                        DEST Chem
                        LINK_LIBRARIES
-            Depictor SmilesParse FileParsers SubstructMatch GraphMol RDGeometryLib RDGeneral RDBoost )
+            Depictor )
 
 add_pytest(pyDepictor ${CMAKE_CURRENT_SOURCE_DIR}/testDepictor.py)

--- a/Code/GraphMol/Descriptors/CMakeLists.txt
+++ b/Code/GraphMol/Descriptors/CMakeLists.txt
@@ -16,7 +16,7 @@ rdkit_library(Descriptors
               USRDescriptor.cpp AtomFeat.cpp
               ${DESC3D_SOURCES}
               LINK_LIBRARIES PartialCharges SmilesParse FileParsers Subgraphs SubstructMatch MolTransforms GraphMol
-                 EigenSolvers ${RDKit_THREAD_LIBS})
+                 EigenSolvers RDGeneral)
 
 rdkit_headers(Crippen.h BCUT.h Lipinski.h
               MolDescriptors.h
@@ -30,40 +30,40 @@ rdkit_headers(Crippen.h BCUT.h Lipinski.h
               DEST GraphMol/Descriptors)
 
 rdkit_test(testDescriptors test.cpp
-LINK_LIBRARIES PartialCharges Descriptors FileParsers SmilesParse Subgraphs SubstructMatch MolTransforms GraphMol EigenSolvers DataStructs RDGeneral RDGeometryLib ${RDKit_THREAD_LIBS} )
+LINK_LIBRARIES PartialCharges Descriptors )
 
 rdkit_test(testAUTOCORR2D testAUTOCORR2D.cpp
-LINK_LIBRARIES  Descriptors FileParsers SmilesParse MolTransforms PartialCharges GraphMol DataStructs EigenSolvers RDGeneral RDGeometryLib ${RDKit_THREAD_LIBS} )
+LINK_LIBRARIES  Descriptors )
 
 rdkit_test(testATF testATF.cpp
-LINK_LIBRARIES  Descriptors FileParsers SmilesParse MolTransforms PartialCharges GraphMol DataStructs EigenSolvers RDGeneral RDGeometryLib ${RDKit_THREAD_LIBS} )
+LINK_LIBRARIES  Descriptors )
 
 if(RDK_HAS_EIGEN)
   rdkit_test(testBCUT testBCUT.cpp
-  LINK_LIBRARIES  Descriptors FileParsers SmilesParse MolTransforms PartialCharges GraphMol DataStructs EigenSolvers RDGeneral RDGeometryLib ${RDKit_THREAD_LIBS} )
+  LINK_LIBRARIES  Descriptors )
 endif(RDK_HAS_EIGEN)
 
 if(RDK_BUILD_DESCRIPTORS3D)
   rdkit_test(testEEM testEEM.cpp
-LINK_LIBRARIES  Descriptors FileParsers SmilesParse MolTransforms PartialCharges GraphMol DataStructs EigenSolvers RDGeneral RDGeometryLib ${RDKit_THREAD_LIBS} )
+LINK_LIBRARIES  Descriptors )
   rdkit_test(testPBF testPBF.cpp
-LINK_LIBRARIES  Descriptors FileParsers SmilesParse MolTransforms PartialCharges GraphMol DataStructs EigenSolvers RDGeneral RDGeometryLib ${RDKit_THREAD_LIBS} )
+LINK_LIBRARIES  Descriptors )
  rdkit_test(testRDFcustom testRDFcustom.cpp
-LINK_LIBRARIES  Descriptors FileParsers SmilesParse MolTransforms PartialCharges GraphMol DataStructs EigenSolvers RDGeneral RDGeometryLib ${RDKit_THREAD_LIBS} )
+LINK_LIBRARIES  Descriptors )
  rdkit_test(testRDF testRDF.cpp
-LINK_LIBRARIES  Descriptors FileParsers SmilesParse MolTransforms PartialCharges GraphMol DataStructs EigenSolvers RDGeneral RDGeometryLib ${RDKit_THREAD_LIBS} )
+LINK_LIBRARIES  Descriptors )
  rdkit_test(testMORSE testMORSE.cpp
-LINK_LIBRARIES  Descriptors FileParsers SmilesParse MolTransforms PartialCharges GraphMol DataStructs EigenSolvers RDGeneral RDGeometryLib ${RDKit_THREAD_LIBS} )
+LINK_LIBRARIES  Descriptors )
 rdkit_test(test3D test3D.cpp
-LINK_LIBRARIES  Descriptors FileParsers SmilesParse MolTransforms PartialCharges GraphMol DataStructs EigenSolvers RDGeneral RDGeometryLib ${RDKit_THREAD_LIBS} )
+LINK_LIBRARIES  Descriptors )
   rdkit_test(testWHIM testWHIM.cpp
-LINK_LIBRARIES  Descriptors FileParsers SmilesParse MolTransforms PartialCharges GraphMol DataStructs EigenSolvers RDGeneral RDGeometryLib ${RDKit_THREAD_LIBS} )
+LINK_LIBRARIES  Descriptors )
   rdkit_test(testGETAWAY testGETAWAY.cpp
-LINK_LIBRARIES  Descriptors FileParsers SmilesParse MolTransforms PartialCharges GraphMol DataStructs EigenSolvers RDGeneral RDGeometryLib ${RDKit_THREAD_LIBS} )
+LINK_LIBRARIES  Descriptors )
   rdkit_test(testAUTOCORR3D testAUTOCORR3D.cpp
-LINK_LIBRARIES  Descriptors FileParsers SmilesParse MolTransforms PartialCharges GraphMol DataStructs EigenSolvers RDGeneral RDGeometryLib ${RDKit_THREAD_LIBS} )
+LINK_LIBRARIES  Descriptors )
  rdkit_test(testCoulombMat testCoulombMat.cpp
-LINK_LIBRARIES  Descriptors FileParsers SmilesParse MolTransforms PartialCharges GraphMol DataStructs EigenSolvers RDGeneral RDGeometryLib ForceField ForceFieldHelpers Optimizer DistGeomHelpers ${RDKit_THREAD_LIBS} )
+LINK_LIBRARIES  Descriptors ForceFieldHelpers DistGeomHelpers  )
 endif(RDK_BUILD_DESCRIPTORS3D)
 
 

--- a/Code/GraphMol/Descriptors/Wrap/CMakeLists.txt
+++ b/Code/GraphMol/Descriptors/Wrap/CMakeLists.txt
@@ -2,8 +2,7 @@ remove_definitions(-DRDKIT_DESCRIPTORS_BUILD)
 rdkit_python_extension(rdMolDescriptors rdMolDescriptors.cpp
                        DEST Chem
                        LINK_LIBRARIES
-LINK_LIBRARIES Descriptors PartialCharges Fingerprints FileParsers SmilesParse Subgraphs
-SubstructMatch MolTransforms GraphMol EigenSolvers DataStructs RDGeneral RDGeometryLib RDBoost )
+LINK_LIBRARIES Descriptors Fingerprints )
 
 add_pytest(pyMolDescriptors ${CMAKE_CURRENT_SOURCE_DIR}/testMolDescriptors.py)
 add_pytest(pyMolDescriptors3D ${CMAKE_CURRENT_SOURCE_DIR}/test3D.py)

--- a/Code/GraphMol/DistGeomHelpers/CMakeLists.txt
+++ b/Code/GraphMol/DistGeomHelpers/CMakeLists.txt
@@ -2,16 +2,15 @@
 remove_definitions(-DRDKIT_GRAPHMOL_BUILD)
 add_definitions(-DRDKIT_DISTGEOMHELPERS_BUILD)
 rdkit_library(DistGeomHelpers BoundsMatrixBuilder.cpp Embedder.cpp
-              LINK_LIBRARIES ForceFieldHelpers DistGeometry Alignment
-                ${RDKit_THREAD_LIBS})
+              LINK_LIBRARIES ForceFieldHelpers GraphMol DistGeometry Alignment
+                )
 
 rdkit_headers(BoundsMatrixBuilder.h
               Embedder.h DEST GraphMol/DistGeomHelpers)
 
 rdkit_test(testDistGeomHelpers testDgeomHelpers.cpp
            LINK_LIBRARIES
-           DistGeomHelpers DistGeometry ForceFieldHelpers ForceField
-	   MolAlign MolTransforms  FileParsers SmilesParse SubstructMatch Optimizer EigenSolvers Alignment GraphMol RDGeometryLib RDGeneral ${RDKit_THREAD_LIBS} )
+           DistGeomHelpers MolAlign MolTransforms FileParsers SmilesParse SubstructMatch )
 
 if(RDK_BUILD_PYTHON_WRAPPERS)
 add_subdirectory(Wrap)

--- a/Code/GraphMol/DistGeomHelpers/Wrap/CMakeLists.txt
+++ b/Code/GraphMol/DistGeomHelpers/Wrap/CMakeLists.txt
@@ -5,6 +5,6 @@ rdkit_python_extension(rdDistGeom rdDistGeom.cpp
                        DEST Chem
                        LINK_LIBRARIES
            LINK_LIBRARIES
-           DistGeomHelpers DistGeometry FileParsers MolTransforms SmilesParse SubstructMatch ForceFieldHelpers ForceField MolAlign Optimizer EigenSolvers Alignment GraphMol DataStructs RDGeometryLib RDGeneral RDBoost)
+           DistGeomHelpers FileParsers MolTransforms SmilesParse SubstructMatch MolAlign EigenSolvers)
 
 add_pytest(pyDistGeomHelpers ${CMAKE_CURRENT_SOURCE_DIR}/testDistGeom.py)

--- a/Code/GraphMol/FMCS/CMakeLists.txt
+++ b/Code/GraphMol/FMCS/CMakeLists.txt
@@ -3,15 +3,14 @@ remove_definitions(-DRDKIT_GRAPHMOL_BUILD)
 add_definitions(-DRDKIT_FMCS_BUILD)
 rdkit_library(FMCS
               FMCS.cpp Seed.cpp MaximumCommonSubgraph.cpp SubstructMatchCustom.cpp
-              LINK_LIBRARIES Depictor FileParsers ChemTransforms SubstructMatch)
+              LINK_LIBRARIES Depictor SmilesParse FileParsers ChemTransforms SubstructMatch GraphMol )
 
 rdkit_headers(FMCS.h
               Graph.h
               DEST GraphMol/FMCS)
 
 rdkit_test(testFMCS testFMCS_Unit.cpp LINK_LIBRARIES
-FMCS ChemTransforms Depictor FileParsers SmilesParse
-GraphMol RDGeneral RDGeometryLib SubstructMatch  ${RDKit_THREAD_LIBS})
+FMCS )
 
 if(RDK_BUILD_PYTHON_WRAPPERS)
 add_subdirectory(Wrap)

--- a/Code/GraphMol/FMCS/Test/CMakeLists.txt
+++ b/Code/GraphMol/FMCS/Test/CMakeLists.txt
@@ -1,2 +1,2 @@
 rdkit_test(FMCStest testFMCS.cpp LINK_LIBRARIES
-FMCS FileParsers SmilesParse GraphMol SubstructMatch DataStructs RDGeneral RDGeometryLib ${RDKit_THREAD_LIBS})
+FMCS )

--- a/Code/GraphMol/FMCS/Wrap/CMakeLists.txt
+++ b/Code/GraphMol/FMCS/Wrap/CMakeLists.txt
@@ -2,8 +2,6 @@ remove_definitions(-DRDKIT_FMCS_BUILD)
 rdkit_python_extension(rdFMCS
                        rdFMCS.cpp
                        DEST Chem 
-                       LINK_LIBRARIES FMCS
-SmilesParse SubstructMatch GraphMol DataStructs RDGeometryLib RDGeneral 
-RDBoost)
+                       LINK_LIBRARIES FMCS)
 
 add_pytest(pyFMCS ${CMAKE_CURRENT_SOURCE_DIR}/testFMCS.py)

--- a/Code/GraphMol/FileParsers/CMakeLists.txt
+++ b/Code/GraphMol/FileParsers/CMakeLists.txt
@@ -56,26 +56,26 @@ rdkit_headers(FileParsers.h
               DEST GraphMol/FileParsers)
 
 rdkit_test(fileParsersTest1 test1.cpp
-           LINK_LIBRARIES FileParsers SmilesParse
-	   SubstructMatch GraphMol RDGeneral RDGeometryLib ${maeparser_var})
+           LINK_LIBRARIES FileParsers SubstructMatch )
 
 
 
 rdkit_test(testMolSupplier testMolSupplier.cpp
-           LINK_LIBRARIES  FileParsers SmilesParse SubstructMatch
-           GraphMol RDGeneral RDGeometryLib RDStreams)
+           LINK_LIBRARIES  FileParsers RDStreams)
 
-rdkit_test(testMolWriter testMolWriter.cpp LINK_LIBRARIES FileParsers SmilesParse GraphMol RDGeneral RDGeometryLib )
+rdkit_test(testMolWriter testMolWriter.cpp LINK_LIBRARIES FileParsers )
 
-rdkit_test(testTplParser testTpls.cpp LINK_LIBRARIES FileParsers SmilesParse GraphMol RDGeneral RDGeometryLib )
+rdkit_test(testTplParser testTpls.cpp LINK_LIBRARIES FileParsers )
 
-rdkit_test(testMol2ToMol testMol2ToMol.cpp LINK_LIBRARIES FileParsers SmilesParse GraphMol RDGeneral RDGeometryLib )
+rdkit_test(testMol2ToMol testMol2ToMol.cpp LINK_LIBRARIES FileParsers )
 
-rdkit_test(testSequence testSequence.cpp LINK_LIBRARIES FileParsers SmilesParse GraphMol RDGeneral RDGeometryLib )
+rdkit_test(testSequence testSequence.cpp LINK_LIBRARIES FileParsers )
 
 rdkit_test(testExtendedStereoParsing testExtendedStereoParsing.cpp
-           LINK_LIBRARIES FileParsers Depictor GraphMol RDGeneral RDGeometryLib )
+           LINK_LIBRARIES FileParsers )
 
-rdkit_catch_test(fileParsersCatchTest file_parsers_catch.cpp catch_main.cpp LINK_LIBRARIES FileParsers SmilesParse GraphMol RDGeneral RDGeometryLib )
+rdkit_catch_test(fileParsersCatchTest file_parsers_catch.cpp catch_main.cpp 
+           LINK_LIBRARIES FileParsers )
 
-rdkit_catch_test(testPropertyLists testPropertyLists.cpp catch_main.cpp LINK_LIBRARIES FileParsers SmilesParse GraphMol RDGeneral RDGeometryLib )
+rdkit_catch_test(testPropertyLists testPropertyLists.cpp catch_main.cpp 
+           LINK_LIBRARIES FileParsers )

--- a/Code/GraphMol/FilterCatalog/CMakeLists.txt
+++ b/Code/GraphMol/FilterCatalog/CMakeLists.txt
@@ -31,7 +31,7 @@ rdkit_library(FilterCatalog
               FilterMatchers.cpp
               FunctionalGroupHierarchy.cpp
               LINK_LIBRARIES Subgraphs SubstructMatch SmilesParse
-              GraphMol RDGeometryLib Catalogs RDGeneral ${RDKit_SERIALIZATION_LIBS} )
+              GraphMol Catalogs ${RDKit_SERIALIZATION_LIBS} )
 
 rdkit_headers(FilterCatalogEntry.h
               FilterCatalog.h
@@ -45,6 +45,4 @@ add_subdirectory(Wrap)
 endif()
 
 rdkit_test(filterCatalogTest filtercatalogtest.cpp
-           LINK_LIBRARIES FilterCatalog
-           Catalogs SubstructMatch FileParsers SmilesParse GraphMol RDGeometryLib RDGeneral
-           ${RDKit_SERIALIZATION_LIBS})
+           LINK_LIBRARIES FilterCatalog SmilesParse FileParsers )

--- a/Code/GraphMol/FilterCatalog/Wrap/CMakeLists.txt
+++ b/Code/GraphMol/FilterCatalog/Wrap/CMakeLists.txt
@@ -4,9 +4,6 @@ rdkit_python_extension(rdfiltercatalog
                        FilterCatalog.cpp
                        DEST Chem
                        LINK_LIBRARIES
-                       FilterCatalog
-Subgraphs SubstructMatch SmilesParse Catalogs FileParsers GraphMol DataStructs
-RDGeometryLib RDGeneral RDBoost
-)
+                       FilterCatalog )
 
 add_pytest(pyFilterCatalog ${CMAKE_CURRENT_SOURCE_DIR}/rough_test.py)

--- a/Code/GraphMol/Fingerprints/CMakeLists.txt
+++ b/Code/GraphMol/Fingerprints/CMakeLists.txt
@@ -6,8 +6,8 @@ rdkit_library(Fingerprints
               AtomPairs.cpp MACCS.cpp MHFP.cpp FingerprintGenerator.cpp 
               AtomPairGenerator.cpp MorganGenerator.cpp RDKitFPGenerator.cpp 
               FingerprintUtil.cpp TopologicalTorsionGenerator.cpp
-              LINK_LIBRARIES Subgraphs SubstructMatch SmilesParse GraphMol
-              ${RDKit_THREAD_LIBS} )
+              LINK_LIBRARIES DataStructs Subgraphs SubstructMatch SmilesParse GraphMol RDGeneral
+              )
 
 rdkit_headers(AtomPairs.h
               Fingerprints.h
@@ -23,19 +23,15 @@ rdkit_headers(AtomPairs.h
               DEST GraphMol/Fingerprints)
 
 rdkit_test(testFingerprints test1.cpp LINK_LIBRARIES 
-           Fingerprints FileParsers SubstructMatch SmilesParse
-           Subgraphs GraphMol DataStructs RDGeometryLib
-           RDGeneral  ${RDKit_THREAD_LIBS}  )
+           Fingerprints FileParsers )
 
 rdkit_test(testMHFPFingerprint testMHFPFingerprint.cpp LINK_LIBRARIES 
-           Fingerprints SmilesParse GraphMol DataStructs FileParsers
-           RDGeneral )
+           Fingerprints FileParsers )
 
 rdkit_test(testFingerprintGenerators testFingerprintGenerators.cpp LINK_LIBRARIES 
-           Fingerprints SmilesParse GraphMol DataStructs FileParsers
-           RDGeneral )
-rdkit_catch_test(fpTestCatch catch_tests.cpp LINK_LIBRARIES Fingerprints SmilesParse GraphMol DataStructs FileParsers
-           RDGeneral)
+           Fingerprints FileParsers )
+
+rdkit_catch_test(fpTestCatch catch_tests.cpp LINK_LIBRARIES Fingerprints FileParsers)
 
 
 if(RDK_BUILD_PYTHON_WRAPPERS)

--- a/Code/GraphMol/Fingerprints/Wrap/CMakeLists.txt
+++ b/Code/GraphMol/Fingerprints/Wrap/CMakeLists.txt
@@ -1,14 +1,12 @@
 rdkit_python_extension(rdFingerprintGenerator
                        FingerprintGeneratorWrapper.cpp
                        DEST Chem
-                       LINK_LIBRARIES Fingerprints 
-                       DataStructs RDGeneral RDBoost)
+                       LINK_LIBRARIES Fingerprints )
 
 rdkit_python_extension(rdMHFPFingerprint
                        MHFPWrapper.cpp
                        DEST Chem
-                       LINK_LIBRARIES Fingerprints 
-                       DataStructs RDGeneral RDBoost)
+                       LINK_LIBRARIES Fingerprints )
 
 add_pytest(pyTestGenerator ${CMAKE_CURRENT_SOURCE_DIR}/testGenerators.py)
 add_pytest(pyTestMHFP ${CMAKE_CURRENT_SOURCE_DIR}/testMHFP.py)

--- a/Code/GraphMol/ForceFieldHelpers/CrystalFF/CMakeLists.txt
+++ b/Code/GraphMol/ForceFieldHelpers/CrystalFF/CMakeLists.txt
@@ -1,4 +1,4 @@
 rdkit_test(testCrystalForceField testCrystalFF.cpp
            LINK_LIBRARIES 
            ForceFieldHelpers
-           DistGeomHelpers DistGeometry FileParsers MolTransforms SmilesParse SubstructMatch ForceField MolAlign Optimizer EigenSolvers Alignment GraphMol RDGeometryLib RDGeneral  ${RDKit_THREAD_LIBS})
+           DistGeomHelpers FileParsers MolTransforms SmilesParse )

--- a/Code/GraphMol/ForceFieldHelpers/MMFF/CMakeLists.txt
+++ b/Code/GraphMol/ForceFieldHelpers/MMFF/CMakeLists.txt
@@ -1,9 +1,9 @@
 rdkit_test(testMMFFForceFieldHelpers testMMFFHelpers.cpp
-           LINK_LIBRARIES
+           LINK_LIBRARIES 
            ForceFieldHelpers
-DistGeomHelpers DistGeometry FileParsers MolTransforms SmilesParse SubstructMatch ForceField MolAlign Optimizer EigenSolvers Alignment GraphMol RDGeometryLib RDGeneral ${RDKit_THREAD_LIBS})
+           DistGeomHelpers FileParsers MolTransforms SmilesParse)
 
 rdkit_test(testMMFFForceFieldHelpersMultiThread testMultiThread.cpp
-           LINK_LIBRARIES
+           LINK_LIBRARIES 
            ForceFieldHelpers
-DistGeomHelpers DistGeometry FileParsers MolTransforms SmilesParse SubstructMatch ForceField MolAlign Optimizer EigenSolvers Alignment GraphMol RDGeometryLib RDGeneral ${RDKit_THREAD_LIBS})
+           DistGeomHelpers FileParsers MolTransforms SmilesParse)

--- a/Code/GraphMol/ForceFieldHelpers/UFF/CMakeLists.txt
+++ b/Code/GraphMol/ForceFieldHelpers/UFF/CMakeLists.txt
@@ -1,7 +1,5 @@
 remove_definitions(-DRDKIT_FORCEFIELDHELPERS_BUILD)
 rdkit_test(testUFFForceFieldHelpers testUFFHelpers.cpp
-           LINK_LIBRARIES
+           LINK_LIBRARIES 
            ForceFieldHelpers
-           DistGeomHelpers DistGeometry FileParsers MolTransforms SmilesParse
-	   SubstructMatch ForceField MolAlign Optimizer EigenSolvers Alignment
-	   GraphMol RDGeometryLib RDGeneral  ${RDKit_THREAD_LIBS})
+           DistGeomHelpers FileParsers MolTransforms SmilesParse)

--- a/Code/GraphMol/ForceFieldHelpers/Wrap/CMakeLists.txt
+++ b/Code/GraphMol/ForceFieldHelpers/Wrap/CMakeLists.txt
@@ -2,9 +2,7 @@ remove_definitions(-DRDKIT_FORCEFIELDHELPERS_BUILD)
 rdkit_python_extension(rdForceFieldHelpers rdForceFields.cpp
                        DEST Chem
                        LINK_LIBRARIES
-                       ForceFieldHelpers 
-SmilesParse SubstructMatch GraphMol ForceField Optimizer RDGeometryLib RDGeneral DataStructs
-RDBoost) 
+                       ForceFieldHelpers ) 
 
 add_pytest(pyForceFieldHelpers ${CMAKE_CURRENT_SOURCE_DIR}/testHelpers.py)
 

--- a/Code/GraphMol/FragCatalog/CMakeLists.txt
+++ b/Code/GraphMol/FragCatalog/CMakeLists.txt
@@ -4,7 +4,7 @@ add_definitions(-DRDKIT_FRAGCATALOG_BUILD)
 rdkit_library(FragCatalog
               FragCatalogUtils.cpp FragCatGenerator.cpp FragCatalogEntry.cpp 
               FragCatParams.cpp FragFPGenerator.cpp
-              LINK_LIBRARIES Subgraphs SubstructMatch SmilesParse Catalogs GraphMol RDGeometryLib RDGeneral )
+              LINK_LIBRARIES Subgraphs SubstructMatch SmilesParse Catalogs GraphMol RDGeneral )
 
 rdkit_headers(FragCatalogEntry.h
               FragCatalogUtils.h
@@ -12,7 +12,7 @@ rdkit_headers(FragCatalogEntry.h
               FragCatParams.h
               FragFPGenerator.h DEST GraphMol/FragCatalog)
 
-rdkit_test(testFragCatalog test1.cpp LINK_LIBRARIES FragCatalog Subgraphs SubstructMatch SmilesParse Catalogs FileParsers GraphMol DataStructs RDGeometryLib RDGeneral  )
+rdkit_test(testFragCatalog test1.cpp LINK_LIBRARIES FragCatalog FileParsers )
 
 if(RDK_BUILD_PYTHON_WRAPPERS)
 add_subdirectory(Wrap)

--- a/Code/GraphMol/FragCatalog/Wrap/CMakeLists.txt
+++ b/Code/GraphMol/FragCatalog/Wrap/CMakeLists.txt
@@ -4,8 +4,6 @@ rdkit_python_extension(rdfragcatalog
                        FragCatGenerator.cpp FragFPGenerator.cpp
                        DEST Chem 
                        LINK_LIBRARIES 
-                       FragCatalog 
-Subgraphs SubstructMatch SmilesParse Catalogs FileParsers GraphMol DataStructs RDGeometryLib RDGeneral 
- RDBoost) 
+                       FragCatalog FileParsers) 
 
 add_pytest(pyFragCatalog ${CMAKE_CURRENT_SOURCE_DIR}/rough_test.py)

--- a/Code/GraphMol/MMPA/CMakeLists.txt
+++ b/Code/GraphMol/MMPA/CMakeLists.txt
@@ -7,14 +7,13 @@ remove_definitions(-DRDKIT_GRAPHMOL_BUILD)
 add_definitions(-DRDKIT_MMPA_BUILD)
 rdkit_library(MMPA
               MMPA.cpp
-              LINK_LIBRARIES SubstructMatch Depictor FileParsers ChemTransforms GraphMol ${RDKit_THREAD_LIBS} )
+              LINK_LIBRARIES SubstructMatch Depictor FileParsers ChemTransforms GraphMol RDGeneral )
 
 rdkit_headers(MMPA.h
               DEST GraphMol/MMPA)
 
 rdkit_test(testMMPA MMPA_UnitTest.cpp LINK_LIBRARIES
-  MMPA ChemTransforms Depictor FileParsers SmilesParse 
-  GraphMol RDGeneral RDGeometryLib SubstructMatch  ${RDKit_THREAD_LIBS})
+  MMPA SmilesParse )
 
 
 if(RDK_BUILD_PYTHON_WRAPPERS)

--- a/Code/GraphMol/MMPA/Wrap/CMakeLists.txt
+++ b/Code/GraphMol/MMPA/Wrap/CMakeLists.txt
@@ -2,8 +2,6 @@ remove_definitions(-DRDKIT_MMPA_BUILD)
 rdkit_python_extension(rdMMPA
                        rdMMPA.cpp
                        DEST Chem
-                       LINK_LIBRARIES MMPA
-SubstructMatch SmilesParse GraphMol DataStructs RDGeometryLib RDGeneral 
-RDBoost )
+                       LINK_LIBRARIES MMPA )
 
 add_pytest(pyMMPA ${CMAKE_CURRENT_SOURCE_DIR}/testMMPA.py)

--- a/Code/GraphMol/MolAlign/CMakeLists.txt
+++ b/Code/GraphMol/MolAlign/CMakeLists.txt
@@ -2,15 +2,13 @@
 remove_definitions(-DRDKIT_GRAPHMOL_BUILD)
 add_definitions(-DRDKIT_MOLALIGN_BUILD)
 rdkit_library(MolAlign AlignMolecules.cpp O3AAlignMolecules.cpp
-              LINK_LIBRARIES MolTransforms SubstructMatch Alignment RDGeometryLib RDGeneral ForceFieldHelpers)
+              LINK_LIBRARIES MolTransforms SubstructMatch Alignment GraphMol RDGeneral ForceFieldHelpers)
 
 rdkit_headers(AlignMolecules.h O3AAlignMolecules.h DEST GraphMol/MolAlign)
 
 rdkit_test(testMolAlign testMolAlign.cpp
            LINK_LIBRARIES MolAlign Descriptors
-FileParsers DistGeomHelpers ForceFieldHelpers
-SmilesParse DistGeometry ForceField Optimizer SubstructMatch
-GraphMol RDGeneral RDGeometryLib ${RDKit_THREAD_LIBS})
+FileParsers DistGeomHelpers SmilesParse)
 
 if(RDK_BUILD_PYTHON_WRAPPERS)
 add_subdirectory(Wrap)

--- a/Code/GraphMol/MolAlign/Wrap/CMakeLists.txt
+++ b/Code/GraphMol/MolAlign/Wrap/CMakeLists.txt
@@ -2,11 +2,7 @@ remove_definitions(-DRDKIT_MOLALIGN_BUILD)
 rdkit_python_extension(rdMolAlign rdMolAlign.cpp
                        DEST Chem
                        LINK_LIBRARIES
-MolAlign MolTransforms ForceFieldHelpers ForceField
-EigenSolvers Alignment Optimizer SubstructMatch
-GraphMol RDGeneral RDGeometryLib DataStructs
-Descriptors SmilesParse
-                       RDBoost)
+MolAlign DataStructs Descriptors SmilesParse)
 
 add_pytest(pyMolAlign ${CMAKE_CURRENT_SOURCE_DIR}/testMolAlign.py)
 

--- a/Code/GraphMol/MolCatalog/CMakeLists.txt
+++ b/Code/GraphMol/MolCatalog/CMakeLists.txt
@@ -9,7 +9,7 @@ rdkit_headers(MolCatalogEntry.h
               MolCatalogParams.h DEST GraphMol/MolCatalog)
 
 rdkit_test(testMolCatalog test1.cpp LINK_LIBRARIES 
-MolCatalog FileParsers Catalogs SmilesParse GraphMol DataStructs RDGeneral RDGeometryLib )
+MolCatalog FileParsers SmilesParse DataStructs )
 
 if(RDK_BUILD_PYTHON_WRAPPERS)
 add_subdirectory(Wrap)

--- a/Code/GraphMol/MolCatalog/Wrap/CMakeLists.txt
+++ b/Code/GraphMol/MolCatalog/Wrap/CMakeLists.txt
@@ -1,9 +1,7 @@
 remove_definitions(-DRDKIT_MOLCATALOG_BUILD)
 rdkit_python_extension(rdMolCatalog rdMolCatalog.cpp
                        DEST Chem
-                       LINK_LIBRARIES 
-MolCatalog FileParsers Catalogs SmilesParse GraphMol DataStructs RDGeneral RDGeometryLib 
-RDBoost)
+                       LINK_LIBRARIES MolCatalog )
 
 add_pytest(pyMolCatalog ${CMAKE_CURRENT_SOURCE_DIR}/rough_test.py)
 

--- a/Code/GraphMol/MolChemicalFeatures/CMakeLists.txt
+++ b/Code/GraphMol/MolChemicalFeatures/CMakeLists.txt
@@ -4,7 +4,7 @@ add_definitions(-DRDKIT_MOLCHEMICALFEATURES_BUILD)
 rdkit_library(MolChemicalFeatures
               MolChemicalFeature.cpp MolChemicalFeatureDef.cpp 
               MolChemicalFeatureFactory.cpp FeatureParser.cpp
-              LINK_LIBRARIES SubstructMatch SmilesParse)
+              LINK_LIBRARIES SubstructMatch SmilesParse GraphMol)
 
 rdkit_headers(FeatureParser.h MolChemicalFeatureFactory.h
               MolChemicalFeatureDef.h  MolChemicalFeature.h 
@@ -12,10 +12,7 @@ rdkit_headers(FeatureParser.h MolChemicalFeatureFactory.h
 
 
 rdkit_test(testFeatures testFeatures.cpp 
-           LINK_LIBRARIES MolChemicalFeatures Catalogs
-FileParsers SmilesParse SubstructMatch DataStructs
-GraphMol RDGeometryLib RDGeneral
-)
+           LINK_LIBRARIES MolChemicalFeatures FileParsers )
 
 if(RDK_BUILD_PYTHON_WRAPPERS)
 add_subdirectory(Wrap)

--- a/Code/GraphMol/MolChemicalFeatures/Wrap/CMakeLists.txt
+++ b/Code/GraphMol/MolChemicalFeatures/Wrap/CMakeLists.txt
@@ -3,11 +3,7 @@ rdkit_python_extension(rdMolChemicalFeatures
                        rdMolChemicalFeatures.cpp MolChemicalFeature.cpp 
                        MolChemicalFeatureFactory.cpp ChemicalFeatureUtils.cpp
 		       DEST Chem
-		       LINK_LIBRARIES MolChemicalFeatures 
-Catalogs
-SmilesParse SubstructMatch DataStructs
-GraphMol RDGeometryLib RDGeneral
-RDBoost)
+		       LINK_LIBRARIES MolChemicalFeatures )
 
 add_pytest(pyChemicalFeatures
          ${CMAKE_CURRENT_SOURCE_DIR}/testChemicalFeatures.py)

--- a/Code/GraphMol/MolDraw2D/CMakeLists.txt
+++ b/Code/GraphMol/MolDraw2D/CMakeLists.txt
@@ -17,10 +17,8 @@ add_definitions(-DRDKIT_MOLDRAW2D_BUILD)
 rdkit_library(MolDraw2D MolDraw2D.cpp MolDraw2DSVG.cpp
   MolDraw2DDetails.cpp MolDraw2DUtils.cpp
   LINK_LIBRARIES
-  ChemReactions FileParsers SmilesParse Depictor MolTransforms RDGeometryLib
-  RDGeneral SubstructMatch Subgraphs GraphMol EigenSolvers
-RDGeometryLib
-  ${RDKit_THREAD_LIBS} )
+  ChemReactions FileParsers SmilesParse Depictor MolTransforms 
+  SubstructMatch Subgraphs GraphMol EigenSolvers )
 
 if(RDK_BUILD_QT_SUPPORT)
   find_package(Qt5 COMPONENTS Widgets OpenGL REQUIRED)
@@ -40,22 +38,13 @@ if(RDK_BUILD_CAIRO_SUPPORT)
 endif(RDK_BUILD_CAIRO_SUPPORT)
 
 rdkit_test(moldraw2DTest1 test1.cpp LINK_LIBRARIES
-  ChemReactions FileParsers SmilesParse Depictor RDGeometryLib
-  RDGeneral SubstructMatch Subgraphs GraphMol MolTransforms EigenSolvers
-  RDGeometryLib
-  MolDraw2D ${RDKit_THREAD_LIBS} )
+  MolDraw2D )
 
 rdkit_catch_test(moldraw2DTestCatch catch_tests.cpp LINK_LIBRARIES
-  ChemReactions FileParsers SmilesParse Depictor RDGeometryLib
-  RDGeneral SubstructMatch Subgraphs GraphMol MolTransforms EigenSolvers
-  RDGeometryLib
-  MolDraw2D ${RDKit_THREAD_LIBS} )
+  MolDraw2D )
 
 rdkit_test(moldraw2DRxnTest1 rxn_test1.cpp LINK_LIBRARIES
-    ChemReactions FileParsers SmilesParse Depictor RDGeometryLib
-    RDGeneral SubstructMatch Subgraphs GraphMol MolTransforms EigenSolvers
-  RDGeometryLib
-    MolDraw2D ${RDKit_THREAD_LIBS} ${EXTRA_LOCAL_LIBS} )
+  MolDraw2D )
 
 if(RDK_BUILD_QT_DEMO)
   add_subdirectory(QTDemo)

--- a/Code/GraphMol/MolDraw2D/Wrap/CMakeLists.txt
+++ b/Code/GraphMol/MolDraw2D/Wrap/CMakeLists.txt
@@ -2,8 +2,6 @@ remove_definitions(-DRDKIT_MOLDRAW2D_BUILD)
 rdkit_python_extension(rdMolDraw2D
                        rdMolDraw2D.cpp
                        DEST Chem/Draw
-                       LINK_LIBRARIES MolDraw2D
-Depictor ChemReactions SmilesParse FileParsers SubstructMatch MolTransforms GraphMol
-DataStructs EigenSolvers RDGeometryLib RDGeneral RDBoost ${EXTRA_LOCAL_LIBS})
+                       LINK_LIBRARIES MolDraw2D )
 
 add_pytest(pyMolDraw2D ${CMAKE_CURRENT_SOURCE_DIR}/testMolDraw2D.py)

--- a/Code/GraphMol/MolHash/CMakeLists.txt
+++ b/Code/GraphMol/MolHash/CMakeLists.txt
@@ -3,7 +3,7 @@ remove_definitions(-DRDKIT_GRAPHMOL_BUILD)
 add_definitions(-DRDKIT_MOLHASH_BUILD)
 rdkit_library(MolHash
               hashfunctions.cpp normalize.cpp
-              LINK_LIBRARIES Depictor Descriptors GraphMol RDGeneral)
+              LINK_LIBRARIES Depictor Descriptors GraphMol)
 
 rdkit_headers(MolHash.h nmmolhash.h           
               DEST GraphMol/MolHash)

--- a/Code/GraphMol/MolHash/Wrap/CMakeLists.txt
+++ b/Code/GraphMol/MolHash/Wrap/CMakeLists.txt
@@ -2,8 +2,6 @@ remove_definitions(-DRDKIT_MOLHASH_BUILD)
 rdkit_python_extension(rdMolHash
                        rdMolHash.cpp
                        DEST Chem 
-                       LINK_LIBRARIES MolHash
-Descriptors GraphMol DataStructs 
-RDGeometryLib RDGeneral RDBoost)
+                       LINK_LIBRARIES MolHash)
 
 add_pytest(pyMolHash ${CMAKE_CURRENT_SOURCE_DIR}/testMolHash.py)

--- a/Code/GraphMol/MolInterchange/CMakeLists.txt
+++ b/Code/GraphMol/MolInterchange/CMakeLists.txt
@@ -23,7 +23,7 @@ rdkit_headers(MolInterchange.h details.h
               DEST GraphMol/MolInterchange)
 
 rdkit_test(molInterchangeTest1 test1.cpp
-           LINK_LIBRARIES MolInterchange FileParsers SmilesParse GraphMol RDGeneral)
+           LINK_LIBRARIES MolInterchange FileParsers SmilesParse)
 
 if(RDK_BUILD_PYTHON_WRAPPERS)
 add_subdirectory(Wrap)

--- a/Code/GraphMol/MolInterchange/Wrap/CMakeLists.txt
+++ b/Code/GraphMol/MolInterchange/Wrap/CMakeLists.txt
@@ -2,6 +2,6 @@ remove_definitions(-DRDKIT_MOLINTERCHANGE_BUILD)
 rdkit_python_extension(rdMolInterchange
                        rdMolInterchange.cpp
                        DEST Chem
-                       LINK_LIBRARIES MolInterchange GraphMol RDBoost)
+                       LINK_LIBRARIES MolInterchange)
 
 add_pytest(pyMolInterchange ${CMAKE_CURRENT_SOURCE_DIR}/testMolInterchange.py)

--- a/Code/GraphMol/MolStandardize/CMakeLists.txt
+++ b/Code/GraphMol/MolStandardize/CMakeLists.txt
@@ -21,7 +21,7 @@ rdkit_library(MolStandardize
         TautomerCatalog/TautomerCatalogEntry.cpp
         TautomerCatalog/TautomerCatalogParams.cpp
         TautomerCatalog/TautomerCatalogUtils.cpp
-	      LINK_LIBRARIES ChemReactions ChemTransforms GraphMol RDGeneral )
+	      LINK_LIBRARIES ChemReactions ChemTransforms SmilesParse SubstructMatch Descriptors GraphMol )
 
 rdkit_headers(MolStandardize.h
 	      Metal.h
@@ -56,28 +56,13 @@ if(RDK_BUILD_PYTHON_WRAPPERS)
 add_subdirectory(Wrap)
 endif()
 
-rdkit_test(molStandardizeTest test1.cpp LINK_LIBRARIES MolStandardize
-	SmilesParse RDGeneral GraphMol SubstructMatch )
-rdkit_test(molNormalizeTest testNormalize.cpp LINK_LIBRARIES MolStandardize
-	SmilesParse RDGeneral GraphMol SubstructMatch )
-rdkit_test(molValidateTest testValidate.cpp LINK_LIBRARIES MolStandardize
-	SmilesParse RDGeneral GraphMol SubstructMatch FileParsers )
-rdkit_test(molChargeTest testCharge.cpp LINK_LIBRARIES MolStandardize
-	SmilesParse RDGeneral GraphMol SubstructMatch FileParsers )
-rdkit_test(molTautomerTest testTautomer.cpp LINK_LIBRARIES MolStandardize
-	SmilesParse RDGeneral GraphMol SubstructMatch FileParsers )
-rdkit_test(molStandardizeSmallTest test2.cpp LINK_LIBRARIES MolStandardize
-	SmilesParse RDGeneral GraphMol SubstructMatch)
-rdkit_test(molFragmentTest testFragment.cpp LINK_LIBRARIES MolStandardize
-	Catalogs SmilesParse RDGeneral GraphMol SubstructMatch FileParsers
-	ChemTransforms Descriptors)
-rdkit_catch_test(molStandardizeCatchTest catch_tests.cpp LINK_LIBRARIES MolStandardize
-	Catalogs SmilesParse RDGeneral GraphMol SubstructMatch FileParsers
-	ChemTransforms Descriptors)
+rdkit_test(molStandardizeTest test1.cpp LINK_LIBRARIES MolStandardize )
+rdkit_test(molNormalizeTest testNormalize.cpp LINK_LIBRARIES MolStandardize )
+rdkit_test(molValidateTest testValidate.cpp LINK_LIBRARIES MolStandardize )
+rdkit_test(molChargeTest testCharge.cpp LINK_LIBRARIES MolStandardize )
+rdkit_test(molTautomerTest testTautomer.cpp LINK_LIBRARIES MolStandardize )
+rdkit_test(molStandardizeSmallTest test2.cpp LINK_LIBRARIES MolStandardize )
+rdkit_test(molFragmentTest testFragment.cpp LINK_LIBRARIES MolStandardize )
+rdkit_catch_test(molStandardizeCatchTest catch_tests.cpp LINK_LIBRARIES MolStandardize )
 
-#find_package(Boost 1.56.0 COMPONENTS system iostreams REQUIRED)
-#if (NOT Boost_USE_STATIC_LIBS)
-#  add_definitions("-DBOOST_IOSTREAMS_DYN_LINK")
-#endif()
 
-# rdkit_test(compareMolVSTest testPCS.cpp LINK_LIBRARIES RDGeneral SmilesParse RDGeneral GraphMol MolStandardize  ${Boost_LIBRARIES})

--- a/Code/GraphMol/MolStandardize/Wrap/CMakeLists.txt
+++ b/Code/GraphMol/MolStandardize/Wrap/CMakeLists.txt
@@ -3,7 +3,6 @@ rdkit_python_extension(rdMolStandardize rdMolStandardize.cpp Validate.cpp
 	Charge.cpp Fragment.cpp Normalize.cpp Metal.cpp Tautomer.cpp
                        DEST Chem/MolStandardize
                        LINK_LIBRARIES
-LINK_LIBRARIES MolStandardize SmilesParse
-SubstructMatch GraphMol RDGeneral RDGeometryLib RDBoost )
+LINK_LIBRARIES MolStandardize )
 
 add_pytest(pyMolStandardize ${CMAKE_CURRENT_SOURCE_DIR}/testMolStandardize.py)

--- a/Code/GraphMol/MolTransforms/CMakeLists.txt
+++ b/Code/GraphMol/MolTransforms/CMakeLists.txt
@@ -2,15 +2,13 @@
 remove_definitions(-DRDKIT_GRAPHMOL_BUILD)
 add_definitions(-DRDKIT_MOLTRANSFORMS_BUILD)
 rdkit_library(MolTransforms MolTransforms.cpp
-              LINK_LIBRARIES GraphMol EigenSolvers)
+              LINK_LIBRARIES GraphMol EigenSolvers RDGeneral )
 
 rdkit_headers(MolTransforms.h DEST GraphMol/MolTransforms)
 
 rdkit_test(testMolTransforms test1.cpp
            LINK_LIBRARIES MolTransforms
-	   SubstructMatch
-           FileParsers SmilesParse
-	   EigenSolvers GraphMol RDGeometryLib RDGeneral )
+           FileParsers SmilesParse )
 
 if(RDK_BUILD_PYTHON_WRAPPERS)
 add_subdirectory(Wrap)

--- a/Code/GraphMol/MolTransforms/Wrap/CMakeLists.txt
+++ b/Code/GraphMol/MolTransforms/Wrap/CMakeLists.txt
@@ -2,9 +2,6 @@ remove_definitions(-DRDKIT_MOLTRANSFORMS_BUILD)
 rdkit_python_extension(rdMolTransforms 
                        rdMolTransforms.cpp
                        DEST Chem 
-                       LINK_LIBRARIES MolTransforms 
-EigenSolvers 
-GraphMol DataStructs RDGeometryLib RDGeneral 
-RDBoost)
+                       LINK_LIBRARIES MolTransforms )
 
 add_pytest(pyMolTransforms ${CMAKE_CURRENT_SOURCE_DIR}/testMolTransforms.py)

--- a/Code/GraphMol/PartialCharges/CMakeLists.txt
+++ b/Code/GraphMol/PartialCharges/CMakeLists.txt
@@ -3,14 +3,13 @@ remove_definitions(-DRDKIT_GRAPHMOL_BUILD)
 add_definitions(-DRDKIT_PARTIALCHARGES_BUILD)
 rdkit_library(PartialCharges
               GasteigerCharges.cpp GasteigerParams.cpp
-              LINK_LIBRARIES GraphMol)
+              LINK_LIBRARIES GraphMol RDGeneral)
 
 rdkit_headers(GasteigerCharges.h
               GasteigerParams.h DEST GraphMol/PartialCharges)
 
 rdkit_test(testPartialCharges test1.cpp LINK_LIBRARIES  PartialCharges
-SmilesParse GraphMol RDGeometryLib RDGeneral DataStructs 
-${RDKit_THREAD_LIBS} )
+SmilesParse )
 
 if(RDK_BUILD_PYTHON_WRAPPERS)
 add_subdirectory(Wrap)

--- a/Code/GraphMol/PartialCharges/Wrap/CMakeLists.txt
+++ b/Code/GraphMol/PartialCharges/Wrap/CMakeLists.txt
@@ -2,8 +2,6 @@ remove_definitions(-DRDKIT_PARTIALCHARGES_BUILD)
 rdkit_python_extension(rdPartialCharges
                        rdPartialCharges.cpp
                        DEST Chem 
-                       LINK_LIBRARIES PartialCharges 
-GraphMol RDGeometryLib RDGeneral DataStructs
-RDBoost) 
+                       LINK_LIBRARIES PartialCharges ) 
 
 add_pytest(pyPartialCharges ${CMAKE_CURRENT_SOURCE_DIR}/testPartialCharges.py)

--- a/Code/GraphMol/RGroupDecomposition/CMakeLists.txt
+++ b/Code/GraphMol/RGroupDecomposition/CMakeLists.txt
@@ -4,7 +4,7 @@ add_definitions(-DRDKIT_RGROUPDECOMPOSITION_BUILD)
 rdkit_library(RGroupDecomposition RGroupDecomp.cpp
   LINK_LIBRARIES
   FMCS ChemTransforms SubstructMatch SmilesParse 
-  ${RDKit_THREAD_LIBS})
+ GraphMol RDGeneral)
 
 rdkit_headers(
    RGroupDecomp.h
@@ -17,6 +17,4 @@ endif()
 
 
 rdkit_test(testRGroupDecomp testRGroupDecomp.cpp 
-           LINK_LIBRARIES RGroupDecomposition ChemTransforms FMCS FileParsers
-           SmilesParse SubstructMatch GraphMol RDGeometryLib RDGeneral
-           ${RDKit_THREAD_LIBS})
+           LINK_LIBRARIES RGroupDecomposition )

--- a/Code/GraphMol/RGroupDecomposition/Wrap/CMakeLists.txt
+++ b/Code/GraphMol/RGroupDecomposition/Wrap/CMakeLists.txt
@@ -3,9 +3,7 @@ rdkit_python_extension(rdRGroupDecomposition
                        rdRGroupComposition.cpp
                        DEST Chem 
                        LINK_LIBRARIES
-     RGroupDecomposition FMCS ChemTransforms SubstructMatch SmilesParse GraphMol
-     RDGeneral RDGeometryLib RDBoost
-    ${RDKit_THREAD_LIBS})
+     RGroupDecomposition )
 
 
 

--- a/Code/GraphMol/ReducedGraphs/CMakeLists.txt
+++ b/Code/GraphMol/ReducedGraphs/CMakeLists.txt
@@ -3,17 +3,13 @@ remove_definitions(-DRDKIT_GRAPHMOL_BUILD)
 add_definitions(-DRDKIT_REDUCEDGRAPHS_BUILD)
 rdkit_library(ReducedGraphs
               ReducedGraphs.cpp
-              LINK_LIBRARIES SubstructMatch SmilesParse GraphMol
-                ${RDKit_THREAD_LIBS} )
+              LINK_LIBRARIES SubstructMatch SmilesParse GraphMol RDGeneral)
 
 rdkit_headers(ReducedGraphs.h
               DEST GraphMol/ReducedGraphs)
 
 rdkit_test(testReducedGraphs test1.cpp LINK_LIBRARIES
-           ReducedGraphs
-           SubstructMatch SmilesParse
-           GraphMol DataStructs RDGeometryLib
-           RDGeneral  )
+           ReducedGraphs )
 
 if(RDK_BUILD_PYTHON_WRAPPERS)
 add_subdirectory(Wrap)

--- a/Code/GraphMol/ReducedGraphs/Wrap/CMakeLists.txt
+++ b/Code/GraphMol/ReducedGraphs/Wrap/CMakeLists.txt
@@ -2,7 +2,7 @@ remove_definitions(-DRDKIT_REDUCEDGRAPHS_BUILD)
 rdkit_python_extension(rdReducedGraphs rdReducedGraphs.cpp
                        DEST Chem
                        LINK_LIBRARIES
-LINK_LIBRARIES ReducedGraphs SubstructMatch SmilesParse GraphMol DataStructs RDGeneral RDGeometryLib RDBoost )
+LINK_LIBRARIES ReducedGraphs )
 
 add_pytest(pyReducedGraphs ${CMAKE_CURRENT_SOURCE_DIR}/testReducedGraphs.py)
 

--- a/Code/GraphMol/SLNParse/CMakeLists.txt
+++ b/Code/GraphMol/SLNParse/CMakeLists.txt
@@ -44,16 +44,14 @@ add_definitions(-DRDKIT_SLNPARSE_BUILD)
 rdkit_library(SLNParse
               SLNParse.cpp SLNAttribs.cpp
               ${BISON_OUTPUT_FILES} ${FLEX_OUTPUT_FILES}
-              LINK_LIBRARIES GraphMol )
+              LINK_LIBRARIES GraphMol RDGeneral )
 
 rdkit_headers(SLNAttribs.h
               SLNParse.h
               SLNParseOps.h DEST GraphMol/SLNParse)
 
 rdkit_test(testSLNParse test.cpp
-           LINK_LIBRARIES SLNParse SmilesParse SubstructMatch
-GraphMol RDGeometryLib RDGeneral
-)
+           LINK_LIBRARIES SLNParse SmilesParse SubstructMatch )
 
 if(RDK_BUILD_PYTHON_WRAPPERS)
 add_subdirectory(Wrap)

--- a/Code/GraphMol/SLNParse/Wrap/CMakeLists.txt
+++ b/Code/GraphMol/SLNParse/Wrap/CMakeLists.txt
@@ -2,7 +2,6 @@ remove_definitions(-DRDKIT_SLNPARSE_BUILD)
 rdkit_python_extension(rdSLNParse rdSLNParse.cpp
                        DEST Chem
                        LINK_LIBRARIES
-                       SLNParse SmilesParse SubstructMatch GraphMol
-                       RDGeometryLib RDGeneral DataStructs RDBoost )
+                       SLNParse )
 
 add_pytest(pySLNParse ${CMAKE_CURRENT_SOURCE_DIR}/testSLN.py)

--- a/Code/GraphMol/ScaffoldNetwork/CMakeLists.txt
+++ b/Code/GraphMol/ScaffoldNetwork/CMakeLists.txt
@@ -2,13 +2,13 @@ remove_definitions(-DRDKIT_GRAPHMOL_BUILD)
 add_definitions(-DRDKIT_SCAFFOLDNETWORK_BUILD)
 rdkit_library(ScaffoldNetwork
               ScaffoldNetwork.cpp
-              LINK_LIBRARIES MolStandardize ChemReactions ChemTransforms SmilesParse SubstructMatch GraphMol RDGeneral)
+              LINK_LIBRARIES MolStandardize ChemReactions ChemTransforms SmilesParse 
+              SubstructMatch GraphMol RDGeneral)
 
 rdkit_headers(ScaffoldNetwork.h DEST GraphMol/ScaffoldNetwork)
 
 rdkit_catch_test(testScaffoldNetwork catch_main.cpp catch_tests.cpp 
-LINK_LIBRARIES ScaffoldNetwork SmilesParse GraphMol RDGeneral 
-${RDKit_THREAD_LIBS} )
+LINK_LIBRARIES ScaffoldNetwork SmilesParse )
 
 if(RDK_BUILD_PYTHON_WRAPPERS)
 add_subdirectory(Wrap)

--- a/Code/GraphMol/ScaffoldNetwork/Wrap/CMakeLists.txt
+++ b/Code/GraphMol/ScaffoldNetwork/Wrap/CMakeLists.txt
@@ -3,8 +3,7 @@ rdkit_python_extension(rdScaffoldNetwork
                        rdScaffoldNetwork.cpp
                        DEST Chem/Scaffolds 
                        LINK_LIBRARIES ScaffoldNetwork 
-GraphMol RDGeometryLib RDGeneral DataStructs
-RDBoost) 
+GraphMol ) 
 
 add_pytest(pyScaffoldNetwork ${CMAKE_CURRENT_SOURCE_DIR}/testScaffoldNetwork.py)
 if (RDK_USE_BOOST_SERIALIZATION)

--- a/Code/GraphMol/ShapeHelpers/CMakeLists.txt
+++ b/Code/GraphMol/ShapeHelpers/CMakeLists.txt
@@ -2,15 +2,14 @@
 remove_definitions(-DRDKIT_GRAPHMOL_BUILD)
 add_definitions(-DRDKIT_SHAPEHELPERS_BUILD)
 rdkit_library(ShapeHelpers ShapeEncoder.cpp ShapeUtils.cpp
-              LINK_LIBRARIES MolTransforms)
+              LINK_LIBRARIES MolTransforms GraphMol RDGeneral)
 
 rdkit_headers(ShapeEncoder.h
               ShapeUtils.h DEST GraphMol/ShapeHelpers)
 
 rdkit_test(testShapeHelpers testShapeHelpers.cpp
            LINK_LIBRARIES ShapeHelpers FileParsers MolAlign
-SmilesParse FileParsers MolTransforms SubstructMatch EigenSolvers Alignment DataStructs
-GraphMol RDGeneral RDGeometryLib )
+SmilesParse FileParsers SubstructMatch )
 
 if(RDK_BUILD_PYTHON_WRAPPERS)
 add_subdirectory(Wrap)

--- a/Code/GraphMol/ShapeHelpers/Wrap/CMakeLists.txt
+++ b/Code/GraphMol/ShapeHelpers/Wrap/CMakeLists.txt
@@ -2,10 +2,7 @@ remove_definitions(-DRDKIT_SHAPEHELPERS_BUILD)
 rdkit_python_extension(rdShapeHelpers rdShapeHelpers.cpp
                        DEST Chem
 		       LINK_LIBRARIES
-                       ShapeHelpers 
-MolTransforms EigenSolvers
-DataStructs GraphMol RDGeometryLib RDGeneral
-RDBoost)
+                       ShapeHelpers )
 
 add_pytest(pyShapeHelpers
          ${CMAKE_CURRENT_SOURCE_DIR}/testShapeHelpers.py)

--- a/Code/GraphMol/SmilesParse/CMakeLists.txt
+++ b/Code/GraphMol/SmilesParse/CMakeLists.txt
@@ -58,7 +58,7 @@ rdkit_library(SmilesParse
               SmilesWrite.cpp SmartsWrite.cpp CXSmilesOps.cpp
               ${BISON_OUTPUT_FILES}
               ${FLEX_OUTPUT_FILES}
-              LINK_LIBRARIES GraphMol)
+              LINK_LIBRARIES GraphMol RDGeneral)
 
 rdkit_headers(primes.h
               SmartsWrite.h
@@ -66,9 +66,9 @@ rdkit_headers(primes.h
               SmilesParseOps.h
               SmilesWrite.h DEST GraphMol/SmilesParse)
 
-rdkit_test(smiTest1 test.cpp LINK_LIBRARIES FileParsers SmilesParse GraphMol RDGeneral RDGeometryLib )
-rdkit_test(smiTest2 test2.cpp LINK_LIBRARIES SmilesParse GraphMol RDGeneral RDGeometryLib )
-rdkit_test(cxsmilesTest cxsmiles_test.cpp LINK_LIBRARIES FileParsers SmilesParse GraphMol RDGeneral RDGeometryLib )
+rdkit_test(smiTest1 test.cpp LINK_LIBRARIES FileParsers SmilesParse )
+rdkit_test(smiTest2 test2.cpp LINK_LIBRARIES SmilesParse )
+rdkit_test(cxsmilesTest cxsmiles_test.cpp LINK_LIBRARIES FileParsers SmilesParse )
 
-rdkit_test(smaTest1 smatest.cpp LINK_LIBRARIES SmilesParse SubstructMatch GraphMol RDGeneral RDGeometryLib )
-rdkit_catch_test(smiTestCatch catch_tests.cpp LINK_LIBRARIES FileParsers SmilesParse GraphMol RDGeneral RDGeometryLib )
+rdkit_test(smaTest1 smatest.cpp LINK_LIBRARIES SmilesParse SubstructMatch  )
+rdkit_catch_test(smiTestCatch catch_tests.cpp LINK_LIBRARIES FileParsers SmilesParse )

--- a/Code/GraphMol/StructChecker/CMakeLists.txt
+++ b/Code/GraphMol/StructChecker/CMakeLists.txt
@@ -5,7 +5,7 @@ rdkit_library(StructChecker
               StructChecker.cpp StructCheckerOptions.cpp StructureFlags.cpp Utilites.cpp
               Pattern.cpp Stereo.cpp AtomSymbolMatch.cpp StripSmallFragments.cpp ReCharge.cpp Tautomer.cpp
               LINK_LIBRARIES Depictor SubstructMatch FileParsers ChemTransforms Descriptors
-                             GraphMol RDGeometryLib RDGeneral ${RDKit_THREAD_LIBS})
+                             GraphMol RDGeneral )
 
 rdkit_headers(StructChecker.h Utilites.h Pattern.h Stereo.h StripSmallFragments.h ReCharge.h Tautomer.h
               DEST GraphMol/StructChecker)
@@ -15,6 +15,4 @@ add_subdirectory(Wrap)
 endif()
 
 rdkit_test(testStructChecker  testStructChecker.cpp 
-           LINK_LIBRARIES StructChecker ChemTransforms Depictor Descriptors
-                          SubstructMatch FileParsers SmilesParse 
-                          GraphMol RDGeneral RDGeometryLib ${RDKit_THREAD_LIBS})
+           LINK_LIBRARIES StructChecker SmilesParse )

--- a/Code/GraphMol/StructChecker/Wrap/CMakeLists.txt
+++ b/Code/GraphMol/StructChecker/Wrap/CMakeLists.txt
@@ -2,7 +2,5 @@ remove_definitions(-DRDKIT_STRUCTCHECKER_BUILD)
 rdkit_python_extension(rdStructChecker
         structchecker.cpp
         DEST Chem
-        LINK_LIBRARIES StructChecker ChemTransforms Depictor Descriptors
-                          SubstructMatch FileParsers SmilesParse 
-                          GraphMol RDGeneral RDGeometryLib)
+        LINK_LIBRARIES StructChecker )
 add_pytest(pyStructChecker ${CMAKE_CURRENT_SOURCE_DIR}/rough_test.py)

--- a/Code/GraphMol/Subgraphs/CMakeLists.txt
+++ b/Code/GraphMol/Subgraphs/CMakeLists.txt
@@ -2,12 +2,12 @@
 remove_definitions(-DRDKIT_GRAPHMOL_BUILD)
 add_definitions(-DRDKIT_SUBGRAPHS_BUILD)
 rdkit_library(Subgraphs Subgraphs.cpp SubgraphUtils.cpp
-              LINK_LIBRARIES GraphMol )
+              LINK_LIBRARIES GraphMol RDGeneral )
 
 rdkit_headers(Subgraphs.h
               SubgraphUtils.h DEST GraphMol/Subgraphs)
 
 target_include_directories(Subgraphs PUBLIC $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/External/boost-numeric-bindings>)
 
-rdkit_test(testSubgraphs1 test1.cpp LINK_LIBRARIES Subgraphs SmilesParse GraphMol RDGeometryLib RDGeneral  )
-rdkit_test(testSubgraphs2 test2.cpp LINK_LIBRARIES SmilesParse Subgraphs GraphMol RDGeometryLib RDGeneral  )
+rdkit_test(testSubgraphs1 test1.cpp LINK_LIBRARIES Subgraphs SmilesParse )
+rdkit_test(testSubgraphs2 test2.cpp LINK_LIBRARIES SmilesParse Subgraphs )

--- a/Code/GraphMol/Substruct/CMakeLists.txt
+++ b/Code/GraphMol/Substruct/CMakeLists.txt
@@ -3,14 +3,12 @@ remove_definitions(-DRDKIT_GRAPHMOL_BUILD)
 add_definitions(-DRDKIT_SUBSTRUCTMATCH_BUILD)
 rdkit_library(SubstructMatch 
               SubstructMatch.cpp SubstructUtils.cpp
-              LINK_LIBRARIES GraphMol
-                ${RDKit_THREAD_LIBS} )
+              LINK_LIBRARIES GraphMol RDGeneral )
 
 rdkit_headers(SubstructMatch.h
               SubstructUtils.h DEST GraphMol/Substruct)
 
-rdkit_test(testSubstructMatch test1.cpp LINK_LIBRARIES  FileParsers SmilesParse SubstructMatch
-GraphMol RDGeometryLib RDGeneral ${RDKit_THREAD_LIBS} )
+rdkit_test(testSubstructMatch test1.cpp LINK_LIBRARIES  FileParsers SmilesParse SubstructMatch )
 
 rdkit_catch_test(substructTestCatch catch_tests.cpp LINK_LIBRARIES FileParsers SmilesParse 
-SubstructMatch GraphMol RDGeneral RDGeometryLib ${RDKit_THREAD_LIBS})
+SubstructMatch )

--- a/Code/GraphMol/SubstructLibrary/CMakeLists.txt
+++ b/Code/GraphMol/SubstructLibrary/CMakeLists.txt
@@ -13,7 +13,7 @@ rdkit_library(SubstructLibrary
               SubstructLibrary.cpp
 	      PatternFactory.cpp
               LINK_LIBRARIES Fingerprints SubstructMatch SmilesParse
-              GraphMol RDGeometryLib Catalogs RDGeneral DataStructs ${RDKit_SERIALIZATION_LIBS})
+              GraphMol Catalogs DataStructs RDGeneral ${RDKit_SERIALIZATION_LIBS})
 
 rdkit_headers(SubstructLibrary.h
               SubstructLibrarySerialization.h
@@ -25,8 +25,6 @@ add_subdirectory(Wrap)
 endif()
 
 rdkit_test(substructLibraryTest substructLibraryTest.cpp
-           LINK_LIBRARIES SubstructLibrary Fingerprints
-           SubstructMatch FileParsers SmilesParse GraphMol RDGeometryLib RDGeneral DataStructs
-           ${RDKit_SERIALIZATION_LIBS})
+           LINK_LIBRARIES SubstructLibrary FileParsers )
 
 endif(RDK_BUILD_THREADSAFE_SSS)

--- a/Code/GraphMol/SubstructLibrary/Wrap/CMakeLists.txt
+++ b/Code/GraphMol/SubstructLibrary/Wrap/CMakeLists.txt
@@ -4,9 +4,6 @@ rdkit_python_extension(rdSubstructLibrary
                        SubstructLibraryWrap.cpp
                        DEST Chem
                        LINK_LIBRARIES
-                       SubstructLibrary
-Fingerprints SubstructMatch SmilesParse Catalogs FileParsers GraphMol DataStructs
-RDGeometryLib RDGeneral RDBoost
-)
+                       SubstructLibrary )
 
 add_pytest(pySubstructLibrary ${CMAKE_CURRENT_SOURCE_DIR}/rough_test.py)

--- a/Code/GraphMol/Trajectory/CMakeLists.txt
+++ b/Code/GraphMol/Trajectory/CMakeLists.txt
@@ -2,11 +2,10 @@
 remove_definitions(-DRDKIT_GRAPHMOL_BUILD)
 add_definitions(-DRDKIT_TRAJECTORY_BUILD)
 rdkit_library(Trajectory Trajectory.cpp
-              LINK_LIBRARIES RDGeneral RDGeometryLib GraphMol)
+              LINK_LIBRARIES GraphMol RDGeneral )
 
 rdkit_headers(Snapshot.h Trajectory.h DEST GraphMol/Trajectory)
 
 rdkit_test(trajectoryTest trajectoryTest.cpp
-           LINK_LIBRARIES Trajectory RDGeneral RDGeometryLib
-           GraphMol FileParsers
-           SmilesParse SubstructMatch ForceFieldHelpers ForceField)
+           LINK_LIBRARIES Trajectory FileParsers
+           SmilesParse SubstructMatch ForceFieldHelpers )

--- a/Code/GraphMol/Wrap/CMakeLists.txt
+++ b/Code/GraphMol/Wrap/CMakeLists.txt
@@ -5,7 +5,7 @@ rdkit_python_extension(rdchem
                        ResonanceMolSupplier.cpp MolBundle.cpp StereoGroup.cpp SubstanceGroup.cpp
                        DEST Chem
                        LINK_LIBRARIES
-                       SmilesParse ChemTransforms SubstructMatch GraphMol RDGeometryLib RDGeneral RDBoost)
+                       SmilesParse ChemTransforms SubstructMatch GraphMol)
 
 rdkit_python_extension(rdmolops
                        rdmolops.cpp MolOps.cpp
@@ -13,14 +13,13 @@ rdkit_python_extension(rdmolops
                        LINK_LIBRARIES
                        ChemReactions MolDraw2D Depictor
                        FileParsers SubstructMatch Fingerprints ChemTransforms
-                       Catalogs Subgraphs SmilesParse MolTransforms GraphMol EigenSolvers
-RDGeometryLib DataStructs RDGeneral RDBoost  )
+                       Subgraphs SmilesParse MolTransforms GraphMol )
 
 rdkit_python_extension(rdqueries
                        rdqueries.cpp Queries.cpp
                        DEST Chem
                        LINK_LIBRARIES
-                       GraphMol RDGeometryLib DataStructs RDGeneral RDBoost  )
+                       GraphMol  )
 
 if(RDK_BUILD_COORDGEN_SUPPORT)
     set (maesupplier MaeMolSupplier.cpp)

--- a/Code/JavaWrappers/gmwrapper/CMakeLists.txt
+++ b/Code/JavaWrappers/gmwrapper/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.5)
 
 project (jGraphMolJava Java)
 

--- a/Code/ML/Cluster/Murtagh/CMakeLists.txt
+++ b/Code/ML/Cluster/Murtagh/CMakeLists.txt
@@ -7,7 +7,7 @@ set_target_properties(hc PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
 rdkit_python_extension(Clustering Clustering.cpp
                        DEST ML/Cluster
                        LINK_LIBRARIES
-                       hc RDGeneral RDBoost)
+                       hc RDGeneral)
 
 
 

--- a/Code/ML/Data/CMakeLists.txt
+++ b/Code/ML/Data/CMakeLists.txt
@@ -1,3 +1,3 @@
 rdkit_python_extension(cQuantize cQuantize.cpp
                        DEST ML/Data
-                       LINK_LIBRARIES InfoTheory RDGeneral RDBoost )
+                       LINK_LIBRARIES InfoTheory RDGeneral)

--- a/Code/ML/InfoTheory/Wrap/CMakeLists.txt
+++ b/Code/ML/InfoTheory/Wrap/CMakeLists.txt
@@ -4,6 +4,6 @@ rdkit_python_extension(rdInfoTheory
                        rdInfoTheory.cpp 
                        DEST ML/InfoTheory
                        LINK_LIBRARIES
-                       InfoTheory RDGeneral DataStructs RDBoost)
+                       InfoTheory)
 
 add_pytest(pyRanker ${CMAKE_CURRENT_SOURCE_DIR}/testRanker.py)

--- a/Code/Numerics/Alignment/CMakeLists.txt
+++ b/Code/Numerics/Alignment/CMakeLists.txt
@@ -4,7 +4,7 @@ rdkit_library(Alignment AlignPoints.cpp LINK_LIBRARIES RDGeometryLib)
 
 rdkit_headers(AlignPoints.h DEST Numerics/Alignment)
 
-rdkit_test(testAlignment testAlignment.cpp LINK_LIBRARIES Alignment RDGeometryLib RDGeneral )
+rdkit_test(testAlignment testAlignment.cpp LINK_LIBRARIES Alignment )
 
 if(RDK_BUILD_PYTHON_WRAPPERS)
 add_subdirectory(Wrap)

--- a/Code/Numerics/Alignment/Wrap/CMakeLists.txt
+++ b/Code/Numerics/Alignment/Wrap/CMakeLists.txt
@@ -2,7 +2,7 @@ remove_definitions(-DRDKIT_ALIGNMENT_BUILD)
 rdkit_python_extension(rdAlignment
                        rdAlignment.cpp
                        DEST Numerics 
-                       LINK_LIBRARIES Alignment RDGeneral RDGeometryLib RDBoost)
+                       LINK_LIBRARIES Alignment)
 
 add_pytest(pyAlignment ${CMAKE_CURRENT_SOURCE_DIR}/testAlignment.py)
 

--- a/Code/Numerics/CMakeLists.txt
+++ b/Code/Numerics/CMakeLists.txt
@@ -9,4 +9,4 @@ rdkit_headers(Matrix.h
               Conrec.h DEST Numerics)
 
 rdkit_test(testMatrices testMatrices.cpp LINK_LIBRARIES RDGeneral)
-rdkit_catch_test(testConrec testConrec.cpp LINK_LIBRARIES RDGeometryLib RDGeneral)
+rdkit_catch_test(testConrec testConrec.cpp LINK_LIBRARIES RDGeometryLib )

--- a/Code/Numerics/EigenSolvers/CMakeLists.txt
+++ b/Code/Numerics/EigenSolvers/CMakeLists.txt
@@ -6,6 +6,6 @@ rdkit_headers(PowerEigenSolver.h DEST Numerics/EigenSolvers)
 
 IF (LAPACK_FOUND)
 rdkit_test(tesEigensolvers testEigenSolvers.cpp
-           LINK_LIBRARIES EigenSolvers  RDGeneral )
+           LINK_LIBRARIES EigenSolvers )
 target_include_directories(tesEigenSolvers PUBLIC ${CMAKE_SOURCE_DIR}/External/boost-numeric-bindings)
 ENDIF (LAPACK_FOUND)

--- a/Code/Numerics/Optimizer/CMakeLists.txt
+++ b/Code/Numerics/Optimizer/CMakeLists.txt
@@ -2,10 +2,10 @@
 add_definitions(-DRDKIT_OPTIMIZER_BUILD)
 rdkit_library(Optimizer 
               BFGSOpt.cpp LinearSearch.cpp
-              LINK_LIBRARIES RDGeometryLib Trajectory)
+              LINK_LIBRARIES RDGeometryLib Trajectory RDGeneral)
 
 rdkit_headers(BFGSOpt.h DEST Numerics/Optimizer)
 
-rdkit_test(testOptimizer testOptimizer.cpp LINK_LIBRARIES Optimizer RDGeometryLib RDGeneral )
+rdkit_test(testOptimizer testOptimizer.cpp LINK_LIBRARIES Optimizer )
 
 

--- a/Code/PgSQL/rdkit/CMakeLists.txt
+++ b/Code/PgSQL/rdkit/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.1)
-
 if(APPLE)
   set (EXTENSION_PREFIX "")
   set (EXTENSION_SUFFIX ".so")

--- a/Code/RDBoost/CMakeLists.txt
+++ b/Code/RDBoost/CMakeLists.txt
@@ -23,7 +23,9 @@ rdkit_headers(Wrap.h PySequenceHolder.h
               DEST RDBoost)
 
 if(RDK_BUILD_PYTHON_WRAPPERS)
-cmake_policy(SET CMP0079 NEW)
+if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.13.0")
+   cmake_policy(SET CMP0079 NEW)
+endif()
 add_subdirectory(Wrap)
 endif()
 

--- a/Code/RDBoost/CMakeLists.txt
+++ b/Code/RDBoost/CMakeLists.txt
@@ -9,8 +9,7 @@ else()
     rdkit_library(RDBoost Wrap.cpp
                 LINK_LIBRARIES RDGeneral rdkit_base)
     if("${PYTHON_LDSHARED}" STREQUAL "")
-    else()
-       # fixes an apple issue
+    else()       # fixes an apple issue
        STRING(REGEX REPLACE "-bundle" "" LDSHARED ${PYTHON_LDSHARED})
        set_target_properties(RDBoost PROPERTIES LINK_FLAGS ${LDSHARED})
     endif()
@@ -24,6 +23,7 @@ rdkit_headers(Wrap.h PySequenceHolder.h
               DEST RDBoost)
 
 if(RDK_BUILD_PYTHON_WRAPPERS)
+target_link_libraries(rdkit_py_base INTERFACE RDBoost )
 add_subdirectory(Wrap)
 endif()
 

--- a/Code/RDBoost/CMakeLists.txt
+++ b/Code/RDBoost/CMakeLists.txt
@@ -2,12 +2,12 @@ if(WIN32 OR "${Py_ENABLE_SHARED}" STREQUAL "1")
 
   add_definitions(-DRDKIT_RDBOOST_BUILD)
   rdkit_library(RDBoost Wrap.cpp
-                LINK_LIBRARIES RDGeneral ${PYTHON_LIBRARIES} ${Boost_LIBRARIES})
+                LINK_LIBRARIES RDGeneral rdkit_base)
 else()
 
     add_definitions(-DRDKIT_RDBOOST_BUILD)
     rdkit_library(RDBoost Wrap.cpp
-                LINK_LIBRARIES RDGeneral ${Boost_LIBRARIES})
+                LINK_LIBRARIES RDGeneral rdkit_base)
     if("${PYTHON_LDSHARED}" STREQUAL "")
     else()
        # fixes an apple issue

--- a/Code/RDBoost/CMakeLists.txt
+++ b/Code/RDBoost/CMakeLists.txt
@@ -23,6 +23,7 @@ rdkit_headers(Wrap.h PySequenceHolder.h
               DEST RDBoost)
 
 if(RDK_BUILD_PYTHON_WRAPPERS)
+cmake_policy(SET CMP0079 NEW)
 target_link_libraries(rdkit_py_base INTERFACE RDBoost )
 add_subdirectory(Wrap)
 endif()

--- a/Code/RDBoost/CMakeLists.txt
+++ b/Code/RDBoost/CMakeLists.txt
@@ -7,7 +7,7 @@ else()
 
     add_definitions(-DRDKIT_RDBOOST_BUILD)
     rdkit_library(RDBoost Wrap.cpp
-                LINK_LIBRARIES RDGeneral rdkit_py_base rdkit_base)
+                LINK_LIBRARIES RDGeneral rdkit_base)
     if("${PYTHON_LDSHARED}" STREQUAL "")
     else()       # fixes an apple issue
        STRING(REGEX REPLACE "-bundle" "" LDSHARED ${PYTHON_LDSHARED})

--- a/Code/RDBoost/CMakeLists.txt
+++ b/Code/RDBoost/CMakeLists.txt
@@ -2,12 +2,12 @@ if(WIN32 OR "${Py_ENABLE_SHARED}" STREQUAL "1")
 
   add_definitions(-DRDKIT_RDBOOST_BUILD)
   rdkit_library(RDBoost Wrap.cpp
-                LINK_LIBRARIES RDGeneral rdkit_base)
+                LINK_LIBRARIES RDGeneral rdkit_py_base rdkit_base)
 else()
 
     add_definitions(-DRDKIT_RDBOOST_BUILD)
     rdkit_library(RDBoost Wrap.cpp
-                LINK_LIBRARIES RDGeneral rdkit_base)
+                LINK_LIBRARIES RDGeneral rdkit_py_base rdkit_base)
     if("${PYTHON_LDSHARED}" STREQUAL "")
     else()       # fixes an apple issue
        STRING(REGEX REPLACE "-bundle" "" LDSHARED ${PYTHON_LDSHARED})
@@ -24,7 +24,6 @@ rdkit_headers(Wrap.h PySequenceHolder.h
 
 if(RDK_BUILD_PYTHON_WRAPPERS)
 cmake_policy(SET CMP0079 NEW)
-target_link_libraries(rdkit_py_base INTERFACE RDBoost )
 add_subdirectory(Wrap)
 endif()
 

--- a/Code/RDGeneral/BoostStartInclude.h
+++ b/Code/RDGeneral/BoostStartInclude.h
@@ -63,6 +63,7 @@
 #pragma GCC diagnostic ignored "-Wmissing-field-initializers"
 #pragma GCC diagnostic ignored "-Wsign-compare"
 #pragma GCC diagnostic ignored "-Wconversion"
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 #if (__GNUC__ > 4 || __GNUC_MINOR__ > 7)
 #pragma GCC diagnostic ignored "-Wunused-local-typedefs"
 #endif

--- a/Code/RDGeneral/CMakeLists.txt
+++ b/Code/RDGeneral/CMakeLists.txt
@@ -9,8 +9,7 @@ CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/RDConfig.h.cmake
 add_definitions(-DRDKIT_RDGENERAL_BUILD)
 rdkit_library(RDGeneral
               Invariant.cpp types.cpp utils.cpp RDLog.cpp 
-              LocaleSwitcher.cpp versions.cpp SHARED
-              LINK_LIBRARIES ${RDKit_THREAD_LIBS})
+              LocaleSwitcher.cpp versions.cpp SHARED)
 
 if(MINGW)
   set(hasMSVCRuntime "FALSE")

--- a/Code/RDStreams/CMakeLists.txt
+++ b/Code/RDStreams/CMakeLists.txt
@@ -1,8 +1,7 @@
 if(RDK_USE_BOOST_IOSTREAMS)
 ADD_DEFINITIONS("-DRDK_USE_BOOST_IOSTREAMS")
 
-find_package(Boost 1.56.0 COMPONENTS system iostreams REQUIRED)
-set (link_iostreams ${Boost_LIBRARIES})
+find_package(Boost 1.56.0 COMPONENTS iostreams REQUIRED)
 if (NOT Boost_USE_STATIC_LIBS)
    add_definitions("-DBOOST_IOSTREAMS_DYN_LINK")
 endif()
@@ -24,5 +23,5 @@ endif()
 add_definitions(-DRDKIT_RDSTREAMS_BUILD)
 endif(RDK_USE_BOOST_IOSTREAMS)
 rdkit_library(RDStreams streams.cpp
-              LINK_LIBRARIES ${Boost_LIBRARIES} ${link_iostreams} ${zlib_lib})
+              LINK_LIBRARIES Boost::iostreams ${zlib_lib})
 rdkit_headers(streams.h DEST RDStreams)

--- a/Code/SimDivPickers/CMakeLists.txt
+++ b/Code/SimDivPickers/CMakeLists.txt
@@ -8,10 +8,10 @@ rdkit_headers(DistPicker.h LeaderPicker.h
               HierarchicalClusterPicker.h
               MaxMinPicker.h DEST SimDivPickers)
 
-rdkit_test(testSimDivPickers testPickers.cpp LINK_LIBRARIES SimDivPickers RDGeneral)
+rdkit_test(testSimDivPickers testPickers.cpp LINK_LIBRARIES SimDivPickers)
 
 rdkit_catch_test(pickersTestsCatch catch_tests.cpp
-           LINK_LIBRARIES SimDivPickers DataStructs RDGeneral)
+           LINK_LIBRARIES SimDivPickers DataStructs)
 
 
 if(RDK_BUILD_PYTHON_WRAPPERS)

--- a/Code/SimDivPickers/Wrap/CMakeLists.txt
+++ b/Code/SimDivPickers/Wrap/CMakeLists.txt
@@ -3,9 +3,7 @@ rdkit_python_extension(rdSimDivPickers
                        MaxMinPicker.cpp LeaderPicker.cpp HierarchicalClusterPicker.cpp 
                        rdSimDivPickers.cpp 
                        DEST SimDivFilters
-                       LINK_LIBRARIES SimDivPickers 
-hc DataStructs
-RDGeneral RDBoost)
+                       LINK_LIBRARIES SimDivPickers DataStructs)
 
 add_pytest(pySimDivPickers ${CMAKE_CURRENT_SOURCE_DIR}/testPickers.py)
 

--- a/Code/cmake/Modules/RDKitUtils.cmake
+++ b/Code/cmake/Modules/RDKitUtils.cmake
@@ -115,6 +115,10 @@ macro(rdkit_python_extension)
     PYTHON_ADD_MODULE(${RDKPY_NAME} ${RDKPY_SOURCES})
     set_target_properties(${RDKPY_NAME} PROPERTIES PREFIX "")
 
+    if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+      # Stop a giant spew of warnings with gcc and boost up to at least 1.71
+      target_compile_options(${RDKPY_NAME} PRIVATE -Wno-maybe-uninitialized)
+    endif()
     if(WIN32)
       set_target_properties(${RDKPY_NAME} PROPERTIES SUFFIX ".pyd"
                            LIBRARY_OUTPUT_DIRECTORY
@@ -127,10 +131,10 @@ macro(rdkit_python_extension)
 
     if(WIN32 OR "${Py_ENABLE_SHARED}" STREQUAL "1")
       target_link_libraries(${RDKPY_NAME} ${RDKPY_LINK_LIBRARIES}
-                            ${PYTHON_LIBRARIES} ${Boost_LIBRARIES} )
+                            rdkit_py_base rdkit_base )
     else()
       target_link_libraries(${RDKPY_NAME} ${RDKPY_LINK_LIBRARIES}
-                            ${Boost_LIBRARIES} )
+                            rdkit_py_base rdkit_base )
       if("${PYTHON_LDSHARED}" STREQUAL "")
       else()
         set_target_properties(${RDKPY_NAME} PROPERTIES LINK_FLAGS ${PYTHON_LDSHARED})

--- a/Code/cmake/Modules/RDKitUtils.cmake
+++ b/Code/cmake/Modules/RDKitUtils.cmake
@@ -131,10 +131,10 @@ macro(rdkit_python_extension)
 
     if(WIN32 OR "${Py_ENABLE_SHARED}" STREQUAL "1")
       target_link_libraries(${RDKPY_NAME} ${RDKPY_LINK_LIBRARIES}
-                            rdkit_py_base rdkit_base )
+                            RDBoost rdkit_py_base rdkit_base )
     else()
       target_link_libraries(${RDKPY_NAME} ${RDKPY_LINK_LIBRARIES}
-                            rdkit_py_base rdkit_base )
+                            RDBoost rdkit_py_base rdkit_base )
       if("${PYTHON_LDSHARED}" STREQUAL "")
       else()
         set_target_properties(${RDKPY_NAME} PROPERTIES LINK_FLAGS ${PYTHON_LDSHARED})

--- a/Code/cmake/Modules/RDKitUtils.cmake
+++ b/Code/cmake/Modules/RDKitUtils.cmake
@@ -129,16 +129,11 @@ macro(rdkit_python_extension)
                               ${RDK_PYTHON_OUTPUT_DIRECTORY}/${RDKPY_DEST})
     endif(WIN32)
 
-    if(WIN32 OR "${Py_ENABLE_SHARED}" STREQUAL "1")
-      target_link_libraries(${RDKPY_NAME} ${RDKPY_LINK_LIBRARIES}
-                            RDBoost rdkit_py_base rdkit_base )
+    target_link_libraries(${RDKPY_NAME} ${RDKPY_LINK_LIBRARIES}
+                          RDBoost rdkit_py_base rdkit_base )
+    if("${PYTHON_LDSHARED}" STREQUAL "")
     else()
-      target_link_libraries(${RDKPY_NAME} ${RDKPY_LINK_LIBRARIES}
-                            RDBoost rdkit_py_base rdkit_base )
-      if("${PYTHON_LDSHARED}" STREQUAL "")
-      else()
-        set_target_properties(${RDKPY_NAME} PROPERTIES LINK_FLAGS ${PYTHON_LDSHARED})
-      endif()
+      set_target_properties(${RDKPY_NAME} PROPERTIES LINK_FLAGS ${PYTHON_LDSHARED})
     endif()
 
     INSTALL(TARGETS ${RDKPY_NAME}

--- a/Code/cmake/Modules/RDKitUtils.cmake
+++ b/Code/cmake/Modules/RDKitUtils.cmake
@@ -115,10 +115,6 @@ macro(rdkit_python_extension)
     PYTHON_ADD_MODULE(${RDKPY_NAME} ${RDKPY_SOURCES})
     set_target_properties(${RDKPY_NAME} PROPERTIES PREFIX "")
 
-    if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-      # Stop a giant spew of warnings with gcc and boost up to at least 1.71
-      target_compile_options(${RDKPY_NAME} PRIVATE -Wno-maybe-uninitialized)
-    endif()
     if(WIN32)
       set_target_properties(${RDKPY_NAME} PROPERTIES SUFFIX ".pyd"
                            LIBRARY_OUTPUT_DIRECTORY

--- a/Docs/Book/C++Examples/CMakeLists.txt
+++ b/Docs/Book/C++Examples/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.9 )
+cmake_minimum_required( VERSION 3.5 )
 
 project(RDKitSV)
 

--- a/External/AvalonTools/CMakeLists.txt
+++ b/External/AvalonTools/CMakeLists.txt
@@ -94,12 +94,11 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 include_directories(${AVALON_SRC_PATH})
 
 add_definitions(-DRDKIT_AVALONLIB_BUILD)
-rdkit_library(AvalonLib AvalonTools.cpp SHARED LINK_LIBRARIES avalon_clib FileParsers SmilesParse GraphMol DataStructs RDGeometryLib RDGeneral )
+rdkit_library(AvalonLib AvalonTools.cpp SHARED 
+     LINK_LIBRARIES avalon_clib FileParsers SmilesParse GraphMol DataStructs  )
 rdkit_headers(AvalonTools.h DEST GraphMol)
 rdkit_test(testAvalonLib1 test1.cpp
-           LINK_LIBRARIES AvalonLib avalon_clib
-	   SubstructMatch
-	   FileParsers SmilesParse GraphMol DataStructs RDGeometryLib RDGeneral)
+           LINK_LIBRARIES AvalonLib SubstructMatch )
 
 if(RDK_BUILD_PYTHON_WRAPPERS)
 add_subdirectory(Wrap)

--- a/External/AvalonTools/Wrap/CMakeLists.txt
+++ b/External/AvalonTools/Wrap/CMakeLists.txt
@@ -3,8 +3,6 @@ rdkit_python_extension(pyAvalonTools
                        pyAvalonTools.cpp
                        DEST Avalon
                        LINK_LIBRARIES
-                       AvalonLib avalon_clib
-		       SubstructMatch
-		       SmilesParse FileParsers GraphMol DataStructs RDGeometryLib RDGeneral RDBoost)
+                       AvalonLib )
 add_pytest(pyAvalonTools
          ${CMAKE_CURRENT_SOURCE_DIR}/testAvalonTools.py)

--- a/External/FreeSASA/CMakeLists.txt
+++ b/External/FreeSASA/CMakeLists.txt
@@ -90,12 +90,12 @@ if((MSVC AND RDK_INSTALL_DLLS_MSVC) OR ((NOT MSVC) AND WIN32))
 endif()
 include_directories("${FREESASA_SRC_DIR}/src")
 
-rdkit_library(FreeSASALib RDFreeSASA.cpp SHARED LINK_LIBRARIES freesasa_clib GraphMol DataStructs RDGeometryLib RDGeneral )
+rdkit_library(FreeSASALib RDFreeSASA.cpp SHARED 
+    LINK_LIBRARIES freesasa_clib GraphMol )
 rdkit_headers(RDFreeSASA.h DEST GraphMol)
 
 rdkit_test(testFreeSASALib testFreeSASA.cpp
-           LINK_LIBRARIES FreeSASALib freesasa_clib FileParsers SmilesParse
-                          GraphMol DataStructs RDGeometryLib RDGeneral)
+           LINK_LIBRARIES FreeSASALib FileParsers SmilesParse )
 
 if(RDK_BUILD_PYTHON_WRAPPERS)
 add_subdirectory(Wrap)

--- a/External/FreeSASA/Wrap/CMakeLists.txt
+++ b/External/FreeSASA/Wrap/CMakeLists.txt
@@ -3,6 +3,6 @@ rdkit_python_extension(rdFreeSASA
                        rdFreeSASA.cpp 
                        DEST Chem
                        LINK_LIBRARIES 
-                       FreeSASALib freesasa_clib GraphMol DataStructs RDGeometryLib RDGeneral RDBoost)
+                       FreeSASALib )
 add_pytest(pyFreeSASA
          ${CMAKE_CURRENT_SOURCE_DIR}/testFreeSASA.py)

--- a/External/INCHI-API/CMakeLists.txt
+++ b/External/INCHI-API/CMakeLists.txt
@@ -74,8 +74,8 @@ if(RDK_BUILD_INCHI_SUPPORT)
      endif()
   add_definitions(-DRDKIT_RDINCHILIB_BUILD)
   rdkit_library(RDInchiLib inchi.cpp SHARED LINK_LIBRARIES ${INCHI_LIBRARIES}
-                GraphMol RDGeneral Depictor SubstructMatch SmilesParse
-                ${RDKit_THREAD_LIBS})
+                GraphMol RDGeneral Depictor SubstructMatch SmilesParse )
+
   rdkit_headers(inchi.h DEST GraphMol)
   if(RDK_BUILD_PYTHON_WRAPPERS)
     add_subdirectory(Wrap)
@@ -85,11 +85,8 @@ if(RDK_BUILD_INCHI_SUPPORT)
 
   rdkit_test(testInchi test.cpp
     LINK_LIBRARIES
-    ${INCHI_LIBRARIES}
-    RDInchiLib ${INCHI_LIBRARIES}
-    FileParsers SmilesParse Descriptors Depictor SubstructMatch GraphMol
-    RDGeneral DataStructs RDGeneral RDGeometryLib
-    ${RDKit_THREAD_LIBS})
+    RDInchiLib 
+    FileParsers SmilesParse Descriptors )
 endif(RDK_BUILD_INCHI_SUPPORT)
 
 if(RDK_BUILD_PYTHON_WRAPPERS)

--- a/External/INCHI-API/Wrap/CMakeLists.txt
+++ b/External/INCHI-API/Wrap/CMakeLists.txt
@@ -2,5 +2,4 @@ rdkit_python_extension(rdinchi
                        pyInchi.cpp
 		       DEST Chem
                        LINK_LIBRARIES 
-                       RDInchiLib ${INCHI_LIBRARIES} SmilesParse SubstructMatch Depictor
-                       GraphMol DataStructs RDGeometryLib RDGeneral RDBoost ${RDKit_THREAD_LIBS})
+                       RDInchiLib )

--- a/External/YAeHMOP/CMakeLists.txt
+++ b/External/YAeHMOP/CMakeLists.txt
@@ -40,12 +40,11 @@ message("YAeHMOP include_dirs: ${PROJECT_BINARY_DIR}/include")
 message("YAeHMOP link_dirs: ${PROJECT_BINARY_DIR}/lib ${CMAKE_CURRENT_SOURCE_DIR}/src/yaehmop_project-build")
 
 add_definitions(-DRDKIT_EHTLIB_BUILD)
-rdkit_library(EHTLib EHTTools.cpp SHARED LINK_LIBRARIES yaehmop_eht GraphMol DataStructs RDGeometryLib RDGeneral )
+rdkit_library(EHTLib EHTTools.cpp SHARED LINK_LIBRARIES yaehmop_eht GraphMol )
 add_dependencies(EHTLib yaehmop_project)
 rdkit_headers(EHTTools.h DEST GraphMol)
 rdkit_catch_test(testEHTLib1 test1.cpp
-           LINK_LIBRARIES EHTLib yaehmop_eht 
-	   FileParsers SmilesParse GraphMol DataStructs RDGeometryLib RDGeneral)
+           LINK_LIBRARIES EHTLib FileParsers SmilesParse )
 
 if(RDK_BUILD_PYTHON_WRAPPERS)
 add_subdirectory(Wrap)

--- a/External/YAeHMOP/Wrap/CMakeLists.txt
+++ b/External/YAeHMOP/Wrap/CMakeLists.txt
@@ -3,8 +3,7 @@ rdkit_python_extension(rdEHTTools
                        rdEHTTools.cpp
                        DEST Chem
                        LINK_LIBRARIES
-                       EHTLib yaehmop_eht 
-	                   GraphMol DataStructs RDGeometryLib RDGeneral RDBoost)
+                       EHTLib )
                        
 add_pytest(pyEHTTools
          ${CMAKE_CURRENT_SOURCE_DIR}/testEHTTools.py)


### PR DESCRIPTION
This is the first step in a series of PRs connected to the way we use cmake

Major work in this PR:
1. Switch to requiring cmake 3.5 consistently
2. Cleaning up the dependencies listed for most of the build targets to be more minimal (i.e. if a target depends on GraphMol there's no reason to also explicitly include all of GraphMol's dependencies). This is why so many files are affected.

Some next steps are:
1. Cleanup the way the boost dependencies are handled
2. Look into fixing the handling of external dependencies like maeparser, catch, yaehmop, etc.
These will come in subsequent PRs
