### PR TITLE
Addresses #3078

### DIFF
--- a/Code/GraphMol/ChemReactions/ReactionRunner.cpp
+++ b/Code/GraphMol/ChemReactions/ReactionRunner.cpp
@@ -707,6 +707,16 @@ void updateStereoBonds(RWMOL_SPTR product, const ROMol &reactant,
 
       if (pStart->getTotalDegree() < 3 || pEnd->getTotalDegree() < 3) {
         pBond->setStereo(Bond::BondStereo::STEREONONE);
+      } else {
+        // Ring bonds shouldn't be marked as STEREOANY
+
+        if (!product->getRingInfo()->isInitialized()) {
+          MolOps::findSSSR(*product);
+        }
+
+        if (product->getRingInfo()->numBondRings(pBond->getIdx()) > 0) {
+          pBond->setStereo(Bond::BondStereo::STEREONONE);
+        }
       }
 
       continue;

--- a/Code/GraphMol/ChemReactions/testReaction.cpp
+++ b/Code/GraphMol/ChemReactions/testReaction.cpp
@@ -7385,6 +7385,26 @@ void testDblBondCrash() {
   }
 }
 
+void testringstereoany() {
+  BOOST_LOG(rdInfoLog) << "--------------------------------------" << std::endl;
+  BOOST_LOG(rdInfoLog)
+      << "Double bonds in rings should not be marked STEREOANY" << std::endl;
+
+    const std::string reaction(R"([C:1][C:2]1[C:3][N:4]1>>[C:1][C:2]1=[C:3][N:4]1)");
+    std::unique_ptr<ChemicalReaction> rxn(RxnSmartsToChemicalReaction(reaction));
+    TEST_ASSERT(rxn);
+    rxn->initReactantMatchers();
+    std::vector<ROMOL_SPTR> reactant{"CC1CN1"_smiles};
+
+    auto prods = rxn->runReactants(reactant);
+    TEST_ASSERT(prods.size() == 1);
+    TEST_ASSERT(prods[0].size() == 1);
+
+    const auto bond = prods[0][0]->getBondWithIdx(1);
+    TEST_ASSERT(bond->getBondType() == Bond::DOUBLE);
+    TEST_ASSERT(bond->getStereo() == Bond::STEREONONE);
+}
+
 int main() {
   RDLog::InitLogs();
 
@@ -7477,6 +7497,7 @@ int main() {
   testGithub2547();
 #endif
   testDblBondCrash();
+  testringstereoany();
 
   BOOST_LOG(rdInfoLog)
       << "*******************************************************\n";


### PR DESCRIPTION
This fixes #3078.

As mentioned in the issue, I think we don't want reactions setting STEREOANY on double bonds in rings. This patch adds a check to the reaction code to reset those bonds to STEREONONE.

I don't really love using `findSSSR()` in the reaction code, but we don't have ring information in the product molecules at this point.

Also, I'm not sure if we might have a similar issue with CIS/TRANS/Z/E bonds.
