### PR TITLE
- fixes GitHub #3048

### DIFF
--- a/Code/GraphMol/Resonance.cpp
+++ b/Code/GraphMol/Resonance.cpp
@@ -1057,28 +1057,14 @@ void CEVect2::idxToDepthWidth(unsigned int idx, unsigned int &d,
 
 // get the pointer to the BondElectrons object for bond having index bi
 BondElectrons *ConjElectrons::getBondElectronsWithIdx(unsigned int bi) {
-  BondElectrons *be;
-  try {
-    be = d_conjBondMap.at(bi);
-  }
-  catch (const std::out_of_range& e) {
-    be = nullptr;
-  }
-
-  return be;
+  auto it = d_conjBondMap.find(bi);
+  return (it != d_conjBondMap.end() ? it->second : nullptr);
 }
 
 // get the pointer to the AtomElectrons object for atom having index ai
 AtomElectrons *ConjElectrons::getAtomElectronsWithIdx(unsigned int ai) {
-  AtomElectrons *ae;
-  try {
-    ae = d_conjAtomMap.at(ai);
-  }
-  catch (const std::out_of_range& e) {
-    ae = nullptr;
-  }
-
-  return ae;
+  auto it = d_conjAtomMap.find(ai);
+  return (it != d_conjAtomMap.end() ? it->second : nullptr);
 }
 
 // count number of total electrons

--- a/Code/GraphMol/Resonance.cpp
+++ b/Code/GraphMol/Resonance.cpp
@@ -324,9 +324,15 @@ bool AtomElectrons::isNbrCharged(unsigned int bo, unsigned int oeConstraint) {
       continue;
     }
     BondElectrons *beNbr = d_parent->getBondElectronsWithIdx(biNbr);
+    if (!beNbr) {
+      continue;
+    }
     const Atom *atomNbr = bondNbr->getOtherAtom(d_atom);
     unsigned int aiNbr = atomNbr->getIdx();
     AtomElectrons *aeNbr = d_parent->getAtomElectronsWithIdx(aiNbr);
+    if (!aeNbr) {
+      continue;
+    }
     res = (((beNbr->isDefinitive() && !aeNbr->hasOctet()) ||
             (!beNbr->isDefinitive() && aeNbr->isDefinitive() &&
              (aeNbr->oe() < (5 - bo)))) &&
@@ -1051,12 +1057,28 @@ void CEVect2::idxToDepthWidth(unsigned int idx, unsigned int &d,
 
 // get the pointer to the BondElectrons object for bond having index bi
 BondElectrons *ConjElectrons::getBondElectronsWithIdx(unsigned int bi) {
-  return d_conjBondMap[bi];
+  BondElectrons *be;
+  try {
+    be = d_conjBondMap.at(bi);
+  }
+  catch (const std::out_of_range& e) {
+    be = nullptr;
+  }
+
+  return be;
 }
 
 // get the pointer to the AtomElectrons object for atom having index ai
 AtomElectrons *ConjElectrons::getAtomElectronsWithIdx(unsigned int ai) {
-  return d_conjAtomMap[ai];
+  AtomElectrons *ae;
+  try {
+    ae = d_conjAtomMap.at(ai);
+  }
+  catch (const std::out_of_range& e) {
+    ae = nullptr;
+  }
+
+  return ae;
 }
 
 // count number of total electrons
@@ -1473,7 +1495,7 @@ void ResonanceMolSupplier::buildCEMap(CEMap &ceMap, unsigned int conjGrpIdx) {
         }
         AtomElectrons *aeNbr = ce->getAtomElectronsWithIdx(aiNbr);
         // if we've already dealt with this neighbor before, ignore it
-        if (aeNbr->isDefinitive()) {
+        if (!aeNbr || aeNbr->isDefinitive()) {
           continue;
         }
         unsigned int biNbr =
@@ -1481,7 +1503,7 @@ void ResonanceMolSupplier::buildCEMap(CEMap &ceMap, unsigned int conjGrpIdx) {
         BondElectrons *beNbr = ce->getBondElectronsWithIdx(biNbr);
         // if we have already assigned the bond order to this bond,
         // ignore it
-        if (beNbr->isDefinitive()) {
+        if (!beNbr || beNbr->isDefinitive()) {
           continue;
         }
         // if this is the first neighbor we find, process it

--- a/Code/GraphMol/resMolSupplierTest.cpp
+++ b/Code/GraphMol/resMolSupplierTest.cpp
@@ -872,6 +872,18 @@ void testGitHub1166() {
   delete mol;
 }
 
+void testGitHub3048() {
+  BOOST_LOG(rdInfoLog) << "-----------------------\n"
+                       << "testGitHub3048" << std::endl;
+  RWMol *mol = SmilesToMol("C1CN3N(C1)c2ccccc2N=C3N");
+  auto *resMolSuppl = new ResonanceMolSupplier(
+      static_cast<ROMol &>(*mol), ResonanceMolSupplier::KEKULE_ALL);
+  // This caused a segfault due to a null ptr being accessed (#3048)
+  TEST_ASSERT(resMolSuppl->length() == 2);
+  delete resMolSuppl;
+  delete mol;
+}
+
 int main() {
   RDLog::InitLogs();
 #if 1
@@ -893,6 +905,7 @@ int main() {
   testCrambin();
   testGitHub1166();
   testConjGrpPerception();
+  testGitHub3048();
 #endif
   return 0;
 }


### PR DESCRIPTION
Accessing a non existing `std::map` key caused a default value to be returned, i.e. a `nullptr`, which once dereferenced caused a segfault. This PR fixes the problem with appropriate checks.