### PR TITLE
Fixes #3095 (single-atom MCSs are not captured)

### DIFF
--- a/Code/GraphMol/FMCS/MaximumCommonSubgraph.cpp
+++ b/Code/GraphMol/FMCS/MaximumCommonSubgraph.cpp
@@ -464,7 +464,7 @@ void MaximumCommonSubgraph::makeInitialSeeds() {
               QueryMoleculeSingleMatchedAtom = queryMolAtom;
             }
             else {
-              QueryMoleculeSingleMatchedAtom = std::max(queryMolAtom,
+              QueryMoleculeSingleMatchedAtom = (std::max)(queryMolAtom,
               QueryMoleculeSingleMatchedAtom, [](const Atom *a, const Atom *b) {
                 if (a->getDegree() != b->getDegree()) {
                   return (a->getDegree() < b->getDegree());

--- a/Code/GraphMol/FMCS/MaximumCommonSubgraph.cpp
+++ b/Code/GraphMol/FMCS/MaximumCommonSubgraph.cpp
@@ -460,18 +460,24 @@ void MaximumCommonSubgraph::makeInitialSeeds() {
           ++matched;
           if (!(Parameters.BondCompareParameters.CompleteRingsOnly &&
             (isQueryMolAtomInRing || isTargetMolAtomInRing))) {
-            QueryMoleculeSingleMatchedAtom = (QueryMoleculeSingleMatchedAtom
-              ? std::max(queryMolAtom,
-              QueryMoleculeSingleMatchedAtom,
-              [](const Atom *a, const Atom *b) {
-                return ((a->getDegree() != b->getDegree())
-                  ? a->getDegree() < b->getDegree()
-                  : (a->getFormalCharge() != b->getFormalCharge())
-                  ? a->getFormalCharge() < b->getFormalCharge()
-                  : (a->getAtomicNum() != b->getAtomicNum())
-                  ? a->getAtomicNum() < b->getAtomicNum()
-                  : a->getIdx() < b->getIdx());
-              }) : queryMolAtom);
+            if (!QueryMoleculeSingleMatchedAtom) {
+              QueryMoleculeSingleMatchedAtom = queryMolAtom;
+            }
+            else {
+              QueryMoleculeSingleMatchedAtom = std::max(queryMolAtom,
+              QueryMoleculeSingleMatchedAtom, [](const Atom *a, const Atom *b) {
+                if (a->getDegree() != b->getDegree()) {
+                  return (a->getDegree() < b->getDegree());
+                }
+                else if (a->getFormalCharge() != b->getFormalCharge()) {
+                  return (a->getFormalCharge() < b->getFormalCharge());
+                }
+                else if (a->getAtomicNum() != b->getAtomicNum()) {
+                  return (a->getAtomicNum() < b->getAtomicNum());
+                }
+                return (a->getIdx() < b->getIdx());
+              });
+            }
           }
           break;
         }

--- a/Code/GraphMol/FMCS/MaximumCommonSubgraph.cpp
+++ b/Code/GraphMol/FMCS/MaximumCommonSubgraph.cpp
@@ -333,6 +333,7 @@ void MaximumCommonSubgraph::makeInitialSeeds() {
   Seeds.clear();
   QueryMoleculeMatchedBonds = 0;
   QueryMoleculeMatchedAtoms = 0;
+  QueryMoleculeSingleMatchedAtom = nullptr;
   if (!Parameters.InitialSeed.empty()) {  // make user defined seed
     std::auto_ptr<const ROMol> initialSeedMolecule(
         (const ROMol*)SmartsToMol(Parameters.InitialSeed));
@@ -446,13 +447,32 @@ void MaximumCommonSubgraph::makeInitialSeeds() {
   }
   size_t nq = QueryMolecule->getNumAtoms();
   for (size_t i = 0; i < nq; i++) {  // all query's atoms
+    const Atom *queryMolAtom = QueryMolecule->getAtomWithIdx(i);
+    bool isQueryMolAtomInRing = queryIsAtomInRing(queryMolAtom);
     unsigned matched = 0;
     for (std::vector<Target>::const_iterator tag = Targets.begin();
          tag != Targets.end(); tag++) {
       size_t nt = tag->Molecule->getNumAtoms();
       for (size_t aj = 0; aj < nt; aj++) {
         if (tag->AtomMatchTable.at(i, aj)) {
+          const Atom *targetMolAtom = tag->Molecule->getAtomWithIdx(aj);
+          bool isTargetMolAtomInRing = queryIsAtomInRing(targetMolAtom);
           ++matched;
+          if (!(Parameters.BondCompareParameters.CompleteRingsOnly &&
+            (isQueryMolAtomInRing || isTargetMolAtomInRing))) {
+            QueryMoleculeSingleMatchedAtom = (QueryMoleculeSingleMatchedAtom
+              ? std::max(queryMolAtom,
+              QueryMoleculeSingleMatchedAtom,
+              [](const Atom *a, const Atom *b) {
+                return ((a->getDegree() != b->getDegree())
+                  ? a->getDegree() < b->getDegree()
+                  : (a->getFormalCharge() != b->getFormalCharge())
+                  ? a->getFormalCharge() < b->getFormalCharge()
+                  : (a->getAtomicNum() != b->getAtomicNum())
+                  ? a->getAtomicNum() < b->getAtomicNum()
+                  : a->getIdx() < b->getIdx());
+              }) : queryMolAtom);
+          }
           break;
         }
       }
@@ -660,40 +680,42 @@ MaximumCommonSubgraph::generateResultSMARTSAndQueryMol(
     seed.addBond(bond);
   }
 
-  unsigned itarget = 0;
-  for (auto tag = mcsIdx.Targets.begin(); tag != mcsIdx.Targets.end();
-       tag++, itarget++) {
-    match_V_t match;  // THERE IS NO Bonds match INFO !!!!
-    bool target_matched = SubstructMatchCustomTable(
-        tag->Topology, *tag->Molecule, seed.Topology, *QueryMolecule,
-        tag->AtomMatchTable, tag->BondMatchTable, &Parameters, &match);
-    if (!target_matched) {
-      continue;
-    }
-    atomMatchResult[itarget].resize(seed.getNumAtoms());
-    for (match_V_t::const_iterator mit = match.begin(); mit != match.end();
-         mit++) {
-      unsigned ai = mit->first;  // SeedAtomIdx
-      atomMatchResult[itarget][ai].QueryAtomIdx = seed.Topology[mit->first];
-      atomMatchResult[itarget][ai].TargetAtomIdx = tag->Topology[mit->second];
-      const Atom* ta =
-          tag->Molecule->getAtomWithIdx(tag->Topology[mit->second]);
-      if (ta && ta->getAtomicNum() !=
-                    seed.MoleculeFragment.Atoms[ai]->getAtomicNum()) {
-        atomMatchSet[ai][ta->getAtomicNum()] = ta;  // add
+  if (!mcsIdx.Bonds.empty()) {
+    unsigned itarget = 0;
+    for (auto tag = mcsIdx.Targets.begin(); tag != mcsIdx.Targets.end();
+         tag++, itarget++) {
+      match_V_t match;  // THERE IS NO Bonds match INFO !!!!
+      bool target_matched = SubstructMatchCustomTable(
+          tag->Topology, *tag->Molecule, seed.Topology, *QueryMolecule,
+          tag->AtomMatchTable, tag->BondMatchTable, &Parameters, &match);
+      if (!target_matched) {
+        continue;
       }
-    }
-    // AND BUILD BOND MATCH INFO
-    unsigned bi = 0;
-    for (auto bond = mcsIdx.Bonds.begin(); bond != mcsIdx.Bonds.end();
-         bond++, bi++) {
-      unsigned i = atomIdxMap[(*bond)->getBeginAtomIdx()];
-      unsigned j = atomIdxMap[(*bond)->getEndAtomIdx()];
-      unsigned ti = atomMatchResult[itarget][i].TargetAtomIdx;
-      unsigned tj = atomMatchResult[itarget][j].TargetAtomIdx;
-      const Bond* tb = tag->Molecule->getBondBetweenAtoms(ti, tj);
-      if (tb && (*bond)->getBondType() != tb->getBondType()) {
-        bondMatchSet[bi][tb->getBondType()] = tb;  // add
+      atomMatchResult[itarget].resize(seed.getNumAtoms());
+      for (match_V_t::const_iterator mit = match.begin(); mit != match.end();
+           mit++) {
+        unsigned ai = mit->first;  // SeedAtomIdx
+        atomMatchResult[itarget][ai].QueryAtomIdx = seed.Topology[mit->first];
+        atomMatchResult[itarget][ai].TargetAtomIdx = tag->Topology[mit->second];
+        const Atom* ta =
+            tag->Molecule->getAtomWithIdx(tag->Topology[mit->second]);
+        if (ta && ta->getAtomicNum() !=
+                      seed.MoleculeFragment.Atoms[ai]->getAtomicNum()) {
+          atomMatchSet[ai][ta->getAtomicNum()] = ta;  // add
+        }
+      }
+      // AND BUILD BOND MATCH INFO
+      unsigned bi = 0;
+      for (auto bond = mcsIdx.Bonds.begin(); bond != mcsIdx.Bonds.end();
+           bond++, bi++) {
+        unsigned i = atomIdxMap[(*bond)->getBeginAtomIdx()];
+        unsigned j = atomIdxMap[(*bond)->getEndAtomIdx()];
+        unsigned ti = atomMatchResult[itarget][i].TargetAtomIdx;
+        unsigned tj = atomMatchResult[itarget][j].TargetAtomIdx;
+        const Bond* tb = tag->Molecule->getBondBetweenAtoms(ti, tj);
+        if (tb && (*bond)->getBondType() != tb->getBondType()) {
+          bondMatchSet[bi][tb->getBondType()] = tb;  // add
+        }
       }
     }
   }
@@ -900,8 +922,9 @@ MCSResult MaximumCommonSubgraph::find(const std::vector<ROMOL_SPTR>& src_mols) {
   // molecule as a query
   std::stable_sort(Molecules.begin(), Molecules.end(), molPtr_NumBondLess);
 
-  for (size_t i = 0; i < Molecules.size() - ThresholdCount && !res.Canceled;
-       i++) {
+  bool areSeedsEmpty = false;
+  for (size_t i = 0; i < Molecules.size() - ThresholdCount &&
+       !areSeedsEmpty && !res.Canceled; ++i) {
     init();
     if (Targets.empty()) {
       break;
@@ -923,17 +946,15 @@ MCSResult MaximumCommonSubgraph::find(const std::vector<ROMOL_SPTR>& src_mols) {
                 << QueryMoleculeMatchedBonds << ") bonds\n";
     }
 
-    if (Seeds.empty()) {
-      break;
-    }
-    res.Canceled = growSeeds() ? false : true;
+    areSeedsEmpty = Seeds.empty();
+    res.Canceled = areSeedsEmpty || growSeeds() ? false : true;
     // verify what MCS is equal to one of initial seed for chirality match
     if ((FinalMatchCheckFunction == Parameters.FinalMatchChecker &&
          1 == getMaxNumberBonds()) ||
         0 == getMaxNumberBonds()) {
       McsIdx = MCS();      // clear
       makeInitialSeeds();  // check all possible initial seeds
-      if (!Seeds.empty()) {
+      if (!areSeedsEmpty) {
         const Seed& fs = Seeds.front();
         if (1 == getMaxNumberBonds() ||
             !(Parameters.BondCompareParameters.CompleteRingsOnly &&
@@ -945,6 +966,13 @@ MCSResult MaximumCommonSubgraph::find(const std::vector<ROMOL_SPTR>& src_mols) {
           McsIdx.AtomsIdx = fs.MoleculeFragment.AtomsIdx;
           McsIdx.BondsIdx = fs.MoleculeFragment.BondsIdx;
         }
+      }
+      if (!McsIdx.QueryMolecule && QueryMoleculeSingleMatchedAtom) {
+        McsIdx.QueryMolecule = QueryMolecule;
+        McsIdx.Atoms = std::vector<const Atom*>{QueryMoleculeSingleMatchedAtom};
+        McsIdx.Bonds = std::vector<const Bond*>();
+        McsIdx.AtomsIdx = std::vector<unsigned>{0};
+        McsIdx.BondsIdx = std::vector<unsigned>();
       }
 
     } else if (i + 1 < Molecules.size() - ThresholdCount) {
@@ -958,9 +986,12 @@ MCSResult MaximumCommonSubgraph::find(const std::vector<ROMOL_SPTR>& src_mols) {
   }
 
   res.NumAtoms = getMaxNumberAtoms();
+  if (!res.NumAtoms && QueryMoleculeSingleMatchedAtom) {
+    res.NumAtoms = 1;
+  }
   res.NumBonds = getMaxNumberBonds();
-  ;
-  if (res.NumBonds > 0) {
+
+  if (res.NumBonds > 0 || QueryMoleculeSingleMatchedAtom) {
     std::pair<std::string, RWMol*> smartsQueryMolPair =
         generateResultSMARTSAndQueryMol(McsIdx);
     res.SmartsString = smartsQueryMolPair.first;

--- a/Code/GraphMol/FMCS/MaximumCommonSubgraph.h
+++ b/Code/GraphMol/FMCS/MaximumCommonSubgraph.h
@@ -67,6 +67,7 @@ class RDKIT_FMCS_EXPORT MaximumCommonSubgraph {
   const ROMol* QueryMolecule;
   unsigned QueryMoleculeMatchedBonds;
   unsigned QueryMoleculeMatchedAtoms;
+  const Atom* QueryMoleculeSingleMatchedAtom;
   std::vector<Target> Targets;
   SeedSet Seeds;
   MCS McsIdx;

--- a/Code/GraphMol/FMCS/Wrap/testFMCS.py
+++ b/Code/GraphMol/FMCS/Wrap/testFMCS.py
@@ -565,7 +565,29 @@ class Common:
             r = rdFMCS.FindMCS(ms, params)
         else:
             r = rdFMCS.FindMCS(ms, seedSmarts='C1OC1')
+        self.assertEqual(r.smartsString, "[#6]")
+        self.assertEqual(r.numAtoms, 1)
+        self.assertEqual(r.numBonds, 0)
+        if kwargs:
+            params = Common.getParams(**kwargs)
+            params.InitialSeed = 'C1OC1'
+            params.AtomCompareParameters.RingMatchesRingOnly = True
+            r = rdFMCS.FindMCS(ms, params)
+        else:
+            r = rdFMCS.FindMCS(ms, seedSmarts='C1OC1', ringMatchesRingOnly=True)
+        self.assertEqual(r.smartsString, "[#6&R]")
+        self.assertEqual(r.numAtoms, 1)
+        self.assertEqual(r.numBonds, 0)
+        if kwargs:
+            params = Common.getParams(**kwargs)
+            params.InitialSeed = 'C1OC1'
+            params.BondCompareParameters.CompleteRingsOnly = True
+            r = rdFMCS.FindMCS(ms, params)
+        else:
+            r = rdFMCS.FindMCS(ms, seedSmarts='C1OC1', completeRingsOnly=True)
         self.assertEqual(r.smartsString, "")
+        self.assertEqual(r.numAtoms, 0)
+        self.assertEqual(r.numBonds, 0)
 
     def test8MatchParams(self, **kwargs):
         smis = ("CCC1NC1", "CCC1N(C)C1", "CCC1OC1")

--- a/Docs/Book/GettingStartedInPython.rst
+++ b/Docs/Book/GettingStartedInPython.rst
@@ -1294,7 +1294,7 @@ match if they have the same bond type. Specify ``atomCompare`` and
 
   >>> mols = (Chem.MolFromSmiles('NCC'),Chem.MolFromSmiles('OC=C'))
   >>> rdFMCS.FindMCS(mols).smartsString
-  ''
+  '[#6]'
   >>> rdFMCS.FindMCS(mols, atomCompare=rdFMCS.AtomCompare.CompareAny).smartsString
   '[#7,#8]-[#6]'
   >>> rdFMCS.FindMCS(mols, bondCompare=rdFMCS.BondCompare.CompareAny).smartsString
@@ -1315,7 +1315,7 @@ requires an exact order match otherwise:
   >>> rdFMCS.FindMCS(mols,bondCompare=rdFMCS.BondCompare.CompareAny).smartsString
   '[#6]1:,-[#6]:,-[#6]:,-[#6]:,-[#6]:,=[#6]:,-1'
   >>> rdFMCS.FindMCS(mols,bondCompare=rdFMCS.BondCompare.CompareOrderExact).smartsString
-  ''
+  '[#6]'
   >>> rdFMCS.FindMCS(mols,bondCompare=rdFMCS.BondCompare.CompareOrder).smartsString
   '[#6](:,-[#6]:,-[#6]:,-[#6]):,-[#6]:,-[#6]'
 

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -2,9 +2,9 @@
 (Changes relative to Release_2020.03.1)
 
 ## Backwards incompatible changes
-- FindMCS() will return single atom MCSs, whereas previously ir returned an empty
+- FindMCS() may return single atom MCSs, whereas previously it returned an empty
   MCS unless there was at least one commond bond across the input structures.
-  So the MCS between molecules `CC` and `CO` is `[#6]` rather than being null.
+  So the MCS between molecules `CC` and `CO` is now `[#6]` rather than being null.
 
 ## Code removed in this release:
 - To improve API consistency of the exceptions in RDKit with the default ones in

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -2,6 +2,9 @@
 (Changes relative to Release_2020.03.1)
 
 ## Backwards incompatible changes
+- FindMCS() will return single atom MCSs, whereas previously ir returned an empty
+  MCS unless there was at least one commond bond across the input structures.
+  So the MCS between molecules `CC` and `CO` is `[#6]` rather than being null.
 
 ## Code removed in this release:
 - To improve API consistency of the exceptions in RDKit with the default ones in


### PR DESCRIPTION
See #3095 
If the MCS is constituted by a single atom, it is not reported. While this is most likely not a major problem, I think it is reasonable to expect that even a single atom, with no bonds, should be considered as an acceptable MCS.
This PR implements recognition of single atoms as the MCS. As there can be multiple single-atom MCSs between two structures that do not share anything larger, a criterion is adopted to ensure consistency (see the `std::max` lambda in `MaximumCommonSubgraph::makeInitialSeeds()`.
If you think this is completely unreasonable, feel free to bin it.