### PR TITLE
Fixes #2795

### DIFF
--- a/Code/PgSQL/rdkit/expected/rdkit-91.out
+++ b/Code/PgSQL/rdkit/expected/rdkit-91.out
@@ -954,3 +954,10 @@ SELECT mol_to_cxsmiles(mol_from_smiles('C[C@H](F)[C@H](C)[C@@H](C)Br |a:1,o1:4,5
  C[C@H](F)[C@H](C)[C@@H](C)Br |a:1,o1:4,5|
 (1 row)
 
+-- CXSmiles from mol_out
+SELECT mol_out(mol_from_smiles('C[C@H](F)[C@H](C)[C@@H](C)Br |a:1,o1:4,5|'));
+                  mol_out                  
+-------------------------------------------
+ C[C@H](F)[C@H](C)[C@@H](C)Br |a:1,o1:4,5|
+(1 row)
+

--- a/Code/PgSQL/rdkit/sql/rdkit-91.sql
+++ b/Code/PgSQL/rdkit/sql/rdkit-91.sql
@@ -348,3 +348,6 @@ select 'C1C([2H])C1CCCC'::mol @> mol_adjust_query_properties('C1CC1CC'::mol,'{"a
 -- CXSmiles
 SELECT mol_to_smiles(mol_from_smiles('C[C@H](F)[C@H](C)[C@@H](C)Br |a:1,o1:4,5|'));
 SELECT mol_to_cxsmiles(mol_from_smiles('C[C@H](F)[C@H](C)[C@@H](C)Br |a:1,o1:4,5|'));
+
+-- CXSmiles from mol_out
+SELECT mol_out(mol_from_smiles('C[C@H](F)[C@H](C)[C@@H](C)Br |a:1,o1:4,5|'));


### PR DESCRIPTION
This commit adds testing for support of CXSmiles in the cartridge by testing the mol_out function which is called in pg_dump.
Fixes #2795 

