### PR TITLE
Modernize how legacy C headers are included

### DIFF
--- a/Code/DataManip/MetricMatrixCalc/testMatCalc.cpp
+++ b/Code/DataManip/MetricMatrixCalc/testMatCalc.cpp
@@ -13,7 +13,7 @@
 #include "MetricMatrixCalc.h"
 
 #include <cstdlib>
-#include <time.h>
+#include <ctime>
 
 using namespace RDDataManip;
 int main() {

--- a/Code/DataStructs/BitOps.cpp
+++ b/Code/DataStructs/BitOps.cpp
@@ -10,7 +10,7 @@
 //
 #include "BitVects.h"
 #include "BitOps.h"
-#include <math.h>
+#include <cmath>
 #include <string>
 #include <iostream>
 #include <RDGeneral/StreamOps.h>

--- a/Code/DataStructs/testDatastructs.cpp
+++ b/Code/DataStructs/testDatastructs.cpp
@@ -25,7 +25,7 @@
 #include <RDGeneral/Exceptions.h>
 #include <DataStructs/SparseIntVect.h>
 #include <DataStructs/DatastructsStreamOps.h>
-#include <stdlib.h>
+#include <cstdlib>
 
 using namespace std;
 using namespace RDKit;

--- a/Code/Demos/RDKit/Basement/TemplEnum/main.cpp
+++ b/Code/Demos/RDKit/Basement/TemplEnum/main.cpp
@@ -11,7 +11,7 @@
 using namespace RDKit;
 using namespace TemplateEnum;
 
-#include <math.h>
+#include <cmath>
 
 bool feq(RDGeom::Point3D p1, RDGeom::Point3D p2, double tol = 1e-4) {
   return feq(p1.x, p2.x, tol) && feq(p1.y, p2.y, tol) && feq(p1.z, p2.z, tol);

--- a/Code/Demos/RDKit/Basement/TemplEnum/simple.cpp
+++ b/Code/Demos/RDKit/Basement/TemplEnum/simple.cpp
@@ -9,7 +9,7 @@
 using namespace RDKit;
 using namespace TemplateEnum;
 
-#include <math.h>
+#include <cmath>
 
 bool feq(double v1, double v2, double tol = 1e-4) {
   return fabs(v1 - v2) <= tol;

--- a/Code/DistGeom/testDistGeom.cpp
+++ b/Code/DistGeom/testDistGeom.cpp
@@ -14,7 +14,7 @@
 #include "TriangleSmooth.h"
 #include <iostream>
 #include <boost/smart_ptr.hpp>
-#include <math.h>
+#include <cmath>
 #include <Numerics/SymmMatrix.h>
 #include "DistGeomUtils.h"
 #include <RDGeneral/utils.h>

--- a/Code/ForceField/UFF/AngleBend.cpp
+++ b/Code/ForceField/UFF/AngleBend.cpp
@@ -11,7 +11,7 @@
 #include "AngleBend.h"
 #include "BondStretch.h"
 #include "Params.h"
-#include <math.h>
+#include <cmath>
 #include <ForceField/ForceField.h>
 #include <RDGeneral/Invariant.h>
 #include <RDGeneral/utils.h>

--- a/Code/ForceField/UFF/BondStretch.cpp
+++ b/Code/ForceField/UFF/BondStretch.cpp
@@ -11,7 +11,7 @@
 
 #include "BondStretch.h"
 #include "Params.h"
-#include <math.h>
+#include <cmath>
 #include <ForceField/ForceField.h>
 #include <RDGeneral/Invariant.h>
 #include <RDGeneral/utils.h>

--- a/Code/ForceField/UFF/Inversion.cpp
+++ b/Code/ForceField/UFF/Inversion.cpp
@@ -13,7 +13,7 @@
 
 #include "Inversion.h"
 #include "Params.h"
-#include <math.h>
+#include <cmath>
 #include <ForceField/ForceField.h>
 #include <RDGeneral/Invariant.h>
 #include <RDGeneral/utils.h>

--- a/Code/ForceField/UFF/Nonbonded.cpp
+++ b/Code/ForceField/UFF/Nonbonded.cpp
@@ -10,7 +10,7 @@
 //
 #include "Nonbonded.h"
 #include "Params.h"
-#include <math.h>
+#include <cmath>
 #include <ForceField/ForceField.h>
 #include <RDGeneral/Invariant.h>
 #include <RDGeneral/utils.h>

--- a/Code/ForceField/UFF/TorsionAngle.cpp
+++ b/Code/ForceField/UFF/TorsionAngle.cpp
@@ -10,7 +10,7 @@
 //
 #include "TorsionAngle.h"
 #include "Params.h"
-#include <math.h>
+#include <cmath>
 #include <ForceField/ForceField.h>
 #include <RDGeneral/Invariant.h>
 

--- a/Code/ForceField/UFF/testUFFForceField.cpp
+++ b/Code/ForceField/UFF/testUFFForceField.cpp
@@ -11,7 +11,7 @@
 #include <RDGeneral/test.h>
 #include <iostream>
 #include <iomanip>
-#include <math.h>
+#include <cmath>
 #include <RDGeneral/Invariant.h>
 #include <RDGeneral/utils.h>
 #include <Geometry/point.h>

--- a/Code/Geometry/Transform2D.cpp
+++ b/Code/Geometry/Transform2D.cpp
@@ -12,7 +12,7 @@
 #include <cstring>
 #include "Transform.h"
 #include "Transform2D.h"
-#include <math.h>
+#include <cmath>
 #include "point.h"
 
 namespace RDGeom {

--- a/Code/Geometry/Transform3D.cpp
+++ b/Code/Geometry/Transform3D.cpp
@@ -13,7 +13,7 @@
 #include <cstring>
 #include "Transform.h"
 #include "Transform3D.h"
-#include <math.h>
+#include <cmath>
 #include "point.h"
 
 namespace RDGeom {

--- a/Code/Geometry/Utils.h
+++ b/Code/Geometry/Utils.h
@@ -11,7 +11,7 @@
 #ifndef __RD_DIST_UTILS_H__
 #define __RD_DIST_UTILS_H__
 
-#include <math.h>
+#include <cmath>
 #include "point.h"
 #include "Transform3D.h"
 #include "Transform.h"

--- a/Code/Geometry/testGrid.cpp
+++ b/Code/Geometry/testGrid.cpp
@@ -19,7 +19,7 @@
 #include <sstream>
 #include <fstream>
 #include <ios>
-#include <stdlib.h>
+#include <cstdlib>
 
 using namespace RDGeom;
 using namespace RDKit;

--- a/Code/Geometry/testTransforms.cpp
+++ b/Code/Geometry/testTransforms.cpp
@@ -17,7 +17,7 @@
 #include "Transform3D.h"
 #include "point.h"
 #include <cstdlib>
-#include <time.h>
+#include <ctime>
 
 using namespace RDGeom;
 using namespace std;

--- a/Code/GraphMol/Atom.cpp
+++ b/Code/GraphMol/Atom.cpp
@@ -7,7 +7,7 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-#include <math.h>
+#include <cmath>
 
 #include "ROMol.h"
 #include "Atom.h"

--- a/Code/GraphMol/Depictor/Basement/DepictorDLL.cpp
+++ b/Code/GraphMol/Depictor/Basement/DepictorDLL.cpp
@@ -12,7 +12,7 @@
 #include "Depictor.h"
 #include <GraphMol/Substruct/SubstructMatch.h>
 #include <RDGeneral/RDLog.h>
-#include <stdlib.h>
+#include <cstdlib>
 namespace RDKit {
 #ifdef WIN32_DLLBUILD
 //*************************************************************************************

--- a/Code/GraphMol/Depictor/DepictUtils.cpp
+++ b/Code/GraphMol/Depictor/DepictUtils.cpp
@@ -9,7 +9,7 @@
 //  of the RDKit source tree.
 //
 #include <RDGeneral/types.h>
-#include <math.h>
+#include <cmath>
 #include <Geometry/point.h>
 #include <Geometry/Transform2D.h>
 #include "DepictUtils.h"

--- a/Code/GraphMol/Depictor/EmbeddedFrag.cpp
+++ b/Code/GraphMol/Depictor/EmbeddedFrag.cpp
@@ -10,7 +10,7 @@
 #include <RDGeneral/types.h>
 #include <RDGeneral/utils.h>
 #include <GraphMol/RWMol.h>
-#include <math.h>
+#include <cmath>
 #include <GraphMol/MolOps.h>
 #include <Geometry/point.h>
 #include <Geometry/Transform2D.h>

--- a/Code/GraphMol/Depictor/RDDepictor.cpp
+++ b/Code/GraphMol/Depictor/RDDepictor.cpp
@@ -18,7 +18,7 @@
 #include <RDGeneral/types.h>
 #include <GraphMol/ROMol.h>
 #include <GraphMol/Conformer.h>
-#include <math.h>
+#include <cmath>
 #include <GraphMol/MolOps.h>
 #include <GraphMol/Rings.h>
 #include <Geometry/point.h>

--- a/Code/GraphMol/Depictor/testDepictor.cpp
+++ b/Code/GraphMol/Depictor/testDepictor.cpp
@@ -26,7 +26,7 @@
 #include <Geometry/point.h>
 #include <Geometry/Transform3D.h>
 #include <RDGeneral/utils.h>
-#include <stdlib.h>
+#include <cstdlib>
 
 #include <boost/tokenizer.hpp>
 typedef boost::tokenizer<boost::char_separator<char>> tokenizer;

--- a/Code/GraphMol/Descriptors/AUTOCORR2D.cpp
+++ b/Code/GraphMol/Descriptors/AUTOCORR2D.cpp
@@ -35,7 +35,7 @@
 
 #include "AUTOCORR2D.h"
 #include "MolData3Ddescriptors.h"
-#include <math.h>
+#include <cmath>
 #include <iostream>
 
 namespace RDKit {

--- a/Code/GraphMol/Descriptors/EEM.cpp
+++ b/Code/GraphMol/Descriptors/EEM.cpp
@@ -32,7 +32,7 @@
 
 #include "EEM.h"
 #include "MolData3Ddescriptors.h"
-#include <math.h>
+#include <cmath>
 #include <Eigen/Dense>
 #include <Eigen/SVD>
 

--- a/Code/GraphMol/Descriptors/MORSE.cpp
+++ b/Code/GraphMol/Descriptors/MORSE.cpp
@@ -36,7 +36,7 @@
 #include "MORSE.h"
 #include "MolData3Ddescriptors.h"
 
-#include <math.h>
+#include <cmath>
 
 // data checked using book Todeschini R., Consonni V. - Molecular Descriptors
 // for Chemoinformatics 2009 atomic properties page 21/22

--- a/Code/GraphMol/Descriptors/RDF.cpp
+++ b/Code/GraphMol/Descriptors/RDF.cpp
@@ -36,7 +36,7 @@
 #include "RDF.h"
 #include "MolData3Ddescriptors.h"
 
-#include <math.h>
+#include <cmath>
 
 namespace RDKit {
 namespace Descriptors {

--- a/Code/GraphMol/Descriptors/WHIM.cpp
+++ b/Code/GraphMol/Descriptors/WHIM.cpp
@@ -36,7 +36,7 @@
 #include "WHIM.h"
 #include "MolData3Ddescriptors.h"
 
-#include <math.h>
+#include <cmath>
 #include <Eigen/Dense>
 #include <Eigen/SVD>
 

--- a/Code/GraphMol/DistGeomHelpers/testDgeomHelpers.cpp
+++ b/Code/GraphMol/DistGeomHelpers/testDgeomHelpers.cpp
@@ -23,7 +23,7 @@
 #include <iostream>
 #include "BoundsMatrixBuilder.h"
 #include "Embedder.h"
-#include <stdlib.h>
+#include <cstdlib>
 #include <GraphMol/FileParsers/MolWriters.h>
 #include <GraphMol/FileParsers/MolSupplier.h>
 #include <GraphMol/ROMol.h>
@@ -32,7 +32,7 @@
 #include <RDGeneral/FileParseException.h>
 #include <ForceField/ForceField.h>
 #include <GraphMol/MolAlign/AlignMolecules.h>
-#include <math.h>
+#include <cmath>
 #include <RDGeneral/Exceptions.h>
 
 #include <boost/tokenizer.hpp>

--- a/Code/GraphMol/FMCS/DebugTrace.h
+++ b/Code/GraphMol/FMCS/DebugTrace.h
@@ -9,10 +9,10 @@
 //
 #include <RDGeneral/export.h>
 #pragma once
-#include <stdio.h>
-#include <string.h>
-#include <stddef.h>
-#include <time.h>
+#include <cstdio>
+#include <cstring>
+#include <cstddef>
+#include <ctime>
 #include <iostream>
 #ifdef _MSC_VER
 #define _CRT_SECURE_NO_WARNINGS

--- a/Code/GraphMol/FMCS/FMCS.cpp
+++ b/Code/GraphMol/FMCS/FMCS.cpp
@@ -9,7 +9,7 @@
 //
 #include <list>
 #include <algorithm>
-#include <math.h>
+#include <cmath>
 
 #include <RDGeneral/BoostStartInclude.h>
 #include <boost/property_tree/ptree.hpp>

--- a/Code/GraphMol/FMCS/MaximumCommonSubgraph.cpp
+++ b/Code/GraphMol/FMCS/MaximumCommonSubgraph.cpp
@@ -9,7 +9,7 @@
 //
 #include <list>
 #include <algorithm>
-#include <math.h>
+#include <cmath>
 #include "../QueryAtom.h"
 #include "../QueryBond.h"
 #include "../SmilesParse/SmilesWrite.h"

--- a/Code/GraphMol/FMCS/RingMatchTableSet.h
+++ b/Code/GraphMol/FMCS/RingMatchTableSet.h
@@ -10,7 +10,7 @@
 #include <RDGeneral/export.h>
 #include <list>
 #include <algorithm>
-#include <math.h>
+#include <cmath>
 #include "SubstructMatchCustom.h"
 
 namespace RDKit {

--- a/Code/GraphMol/FMCS/Test/testFMCS.cpp
+++ b/Code/GraphMol/FMCS/Test/testFMCS.cpp
@@ -40,9 +40,9 @@
 #include <sys/resource.h>
 #endif
 
-#include <stdio.h>
-#include <string.h>
-#include <time.h>
+#include <cstdio>
+#include <cstring>
+#include <ctime>
 #include <string>
 #include <iostream>
 #include "../../RDKitBase.h"

--- a/Code/GraphMol/FMCS/testFMCS_Unit.cpp
+++ b/Code/GraphMol/FMCS/testFMCS_Unit.cpp
@@ -39,9 +39,9 @@
 #include <sys/resource.h>
 #endif
 
-#include <stdio.h>
-#include <string.h>
-#include <time.h>
+#include <cstdio>
+#include <cstring>
+#include <ctime>
 #include <string>
 #include <iostream>
 #include <RDGeneral/RDLog.h>

--- a/Code/GraphMol/FileParsers/MolFileParser.cpp
+++ b/Code/GraphMol/FileParsers/MolFileParser.cpp
@@ -45,7 +45,7 @@ using std::smatch;
 #endif
 #include <sstream>
 #include <locale>
-#include <stdlib.h>
+#include <cstdlib>
 #include <cstdio>
 
 using namespace RDKit::SGroupParsing;

--- a/Code/GraphMol/FileParsers/PDBParser.cpp
+++ b/Code/GraphMol/FileParsers/PDBParser.cpp
@@ -7,8 +7,8 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-#include <string.h>
-#include <stdio.h>
+#include <cstring>
+#include <cstdio>
 #include <string>
 #include <iostream>
 #include <fstream>

--- a/Code/GraphMol/FileParsers/SequenceParsers.cpp
+++ b/Code/GraphMol/FileParsers/SequenceParsers.cpp
@@ -7,7 +7,7 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-#include <string.h>
+#include <cstring>
 
 #include <string>
 #include <vector>

--- a/Code/GraphMol/FileParsers/SequenceWriters.cpp
+++ b/Code/GraphMol/FileParsers/SequenceWriters.cpp
@@ -7,8 +7,8 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-#include <string.h>
-#include <stdio.h>
+#include <cstring>
+#include <cstdio>
 #include <string>
 
 #include "SequenceWriters.h"

--- a/Code/GraphMol/FileParsers/testSequence.cpp
+++ b/Code/GraphMol/FileParsers/testSequence.cpp
@@ -1,6 +1,6 @@
 #include <RDGeneral/test.h>
-#include <stdlib.h>
-#include <stdio.h>
+#include <cstdlib>
+#include <cstdio>
 
 #include <GraphMol/GraphMol.h>
 #include <GraphMol/RDKitBase.h>

--- a/Code/GraphMol/Fingerprints/FingerprintUtil.cpp
+++ b/Code/GraphMol/Fingerprints/FingerprintUtil.cpp
@@ -38,7 +38,7 @@
 #include <boost/random.hpp>
 #include <cstdint>
 #include <RDGeneral/BoostEndInclude.h>
-#include <limits.h>
+#include <climits>
 #include <RDGeneral/types.h>
 
 namespace RDKit {

--- a/Code/GraphMol/Fingerprints/Fingerprints.cpp
+++ b/Code/GraphMol/Fingerprints/Fingerprints.cpp
@@ -22,7 +22,7 @@
 #include <boost/random.hpp>
 #include <cstdint>
 #include <RDGeneral/BoostEndInclude.h>
-#include <limits.h>
+#include <climits>
 #include <RDGeneral/hash/hash.hpp>
 #include <RDGeneral/types.h>
 #include <algorithm>

--- a/Code/GraphMol/Fingerprints/MHFP.cpp
+++ b/Code/GraphMol/Fingerprints/MHFP.cpp
@@ -15,8 +15,8 @@
 #include <numeric>
 #include <random>
 #include <stdexcept>
-#include <stdint.h>
-#include <math.h>
+#include <cstdint>
+#include <cmath>
 #include <set>
 
 #include <RDGeneral/types.h>

--- a/Code/GraphMol/Fingerprints/PatternFingerprints.cpp
+++ b/Code/GraphMol/Fingerprints/PatternFingerprints.cpp
@@ -19,7 +19,7 @@
 #include <GraphMol/SmilesParse/SmilesParse.h>
 #include <RDGeneral/Invariant.h>
 #include <boost/random.hpp>
-#include <limits.h>
+#include <climits>
 #include <cstdint>
 #include <RDGeneral/hash/hash.hpp>
 #include <RDGeneral/types.h>

--- a/Code/GraphMol/Fingerprints/RDKitFPGenerator.cpp
+++ b/Code/GraphMol/Fingerprints/RDKitFPGenerator.cpp
@@ -25,7 +25,7 @@
 #include <RDGeneral/BoostStartInclude.h>
 #include <boost/random.hpp>
 #include <RDGeneral/BoostEndInclude.h>
-#include <limits.h>
+#include <climits>
 #include <RDGeneral/hash/hash.hpp>
 #include <RDGeneral/types.h>
 #include <algorithm>

--- a/Code/GraphMol/ForceFieldHelpers/CrystalFF/testCrystalFF.cpp
+++ b/Code/GraphMol/ForceFieldHelpers/CrystalFF/testCrystalFF.cpp
@@ -22,7 +22,7 @@
 #include <ForceField/ForceField.h>
 #include <iostream>
 #include <string>
-#include <math.h>
+#include <cmath>
 
 using namespace RDGeom;
 using namespace RDKit;

--- a/Code/GraphMol/FragCatalog/FragCatalogEntry.cpp
+++ b/Code/GraphMol/FragCatalog/FragCatalogEntry.cpp
@@ -17,7 +17,7 @@
 #include <GraphMol/MolPickler.h>
 #include <GraphMol/Subgraphs/SubgraphUtils.h>
 #include <GraphMol/Subgraphs/Subgraphs.h>
-#include <stdlib.h>
+#include <cstdlib>
 #include <iostream>
 #include <fstream>
 #include <cstdint>

--- a/Code/GraphMol/FragCatalog/test1.cpp
+++ b/Code/GraphMol/FragCatalog/test1.cpp
@@ -21,7 +21,7 @@
 #include "FragCatParams.h"
 #include "FragCatalogUtils.h"
 #include "FragFPGenerator.h"
-#include <stdlib.h>
+#include <cstdlib>
 #include <iostream>
 #include <fstream>
 

--- a/Code/GraphMol/MMPA/MMPA.cpp
+++ b/Code/GraphMol/MMPA/MMPA.cpp
@@ -10,7 +10,7 @@
 #include <map>
 #include <vector>
 #include <algorithm>
-#include <math.h>
+#include <cmath>
 
 #include "../MolOps.h"
 #include "../SmilesParse/SmilesParse.h"

--- a/Code/GraphMol/MMPA/MMPA_UnitTest.cpp
+++ b/Code/GraphMol/MMPA/MMPA_UnitTest.cpp
@@ -42,9 +42,9 @@
 #include <sys/resource.h>
 #endif
 
-#include <stdio.h>
-#include <string.h>
-#include <time.h>
+#include <cstdio>
+#include <cstring>
+#include <ctime>
 #include <string>
 #include <iostream>
 #include <RDGeneral/RDLog.h>

--- a/Code/GraphMol/MolCatalog/test1.cpp
+++ b/Code/GraphMol/MolCatalog/test1.cpp
@@ -13,7 +13,7 @@
 #include "MolCatalogEntry.h"
 #include "MolCatalogParams.h"
 
-#include <stdlib.h>
+#include <cstdlib>
 #include <iostream>
 #include <fstream>
 

--- a/Code/GraphMol/MolHash/hashfunctions.cpp
+++ b/Code/GraphMol/MolHash/hashfunctions.cpp
@@ -10,9 +10,9 @@
 /*==============================================*/
 #define _CRT_SECURE_NO_WARNINGS
 
-#include <string.h>
-#include <stdlib.h>
-#include <stdio.h>
+#include <cstring>
+#include <cstdlib>
+#include <cstdio>
 
 #include <string>
 #include <GraphMol/RDKitBase.h>

--- a/Code/GraphMol/RGroupDecomposition/Wrap/rdRGroupComposition.cpp
+++ b/Code/GraphMol/RGroupDecomposition/Wrap/rdRGroupComposition.cpp
@@ -36,7 +36,7 @@
 #include <boost/python/suite/indexing/map_indexing_suite.hpp>
 #include <boost/python/suite/indexing/vector_indexing_suite.hpp>
 #include <string>
-#include <math.h>
+#include <cmath>
 
 #include <RDGeneral/Exceptions.h>
 #include <GraphMol/SmilesParse/SmilesWrite.h>

--- a/Code/GraphMol/SLNParse/lex.yysln.cpp.cmake
+++ b/Code/GraphMol/SLNParse/lex.yysln.cpp.cmake
@@ -17,10 +17,10 @@
 /* First, we deal with  platform-specific or compiler-specific issues. */
 
 /* begin standard C headers. */
-#include <stdio.h>
-#include <string.h>
-#include <errno.h>
-#include <stdlib.h>
+#include <cstdio>
+#include <cstring>
+#include <cerrno>
+#include <cstdlib>
 
 /* end standard C headers. */
 
@@ -40,7 +40,7 @@
 #define __STDC_LIMIT_MACROS 1
 #endif
 
-#include <inttypes.h>
+#include <cinttypes>
 typedef int8_t flex_int8_t;
 typedef uint8_t flex_uint8_t;
 typedef int16_t flex_int16_t;

--- a/Code/GraphMol/SLNParse/sln.tab.cpp.cmake
+++ b/Code/GraphMol/SLNParse/sln.tab.cpp.cmake
@@ -295,7 +295,7 @@ typedef short yytype_int16;
 # elif defined size_t
 #  define YYSIZE_T size_t
 # elif ! defined YYSIZE_T
-#  include <stddef.h> /* INFRINGES ON USER NAME SPACE */
+#  include <cstddef> /* INFRINGES ON USER NAME SPACE */
 #  define YYSIZE_T size_t
 # else
 #  define YYSIZE_T unsigned
@@ -388,7 +388,7 @@ typedef short yytype_int16;
 #   else
 #    define YYSTACK_ALLOC alloca
 #    if ! defined _ALLOCA_H && ! defined EXIT_SUCCESS
-#     include <stdlib.h> /* INFRINGES ON USER NAME SPACE */
+#     include <cstdlib> /* INFRINGES ON USER NAME SPACE */
       /* Use EXIT_SUCCESS as a witness for stdlib.h.  */
 #     ifndef EXIT_SUCCESS
 #      define EXIT_SUCCESS 0
@@ -417,7 +417,7 @@ typedef short yytype_int16;
 #  if (defined __cplusplus && ! defined EXIT_SUCCESS \
        && ! ((defined YYMALLOC || defined malloc) \
              && (defined YYFREE || defined free)))
-#   include <stdlib.h> /* INFRINGES ON USER NAME SPACE */
+#   include <cstdlib> /* INFRINGES ON USER NAME SPACE */
 #   ifndef EXIT_SUCCESS
 #    define EXIT_SUCCESS 0
 #   endif
@@ -803,7 +803,7 @@ while (0)
 #if YYDEBUG
 
 # ifndef YYFPRINTF
-#  include <stdio.h> /* INFRINGES ON USER NAME SPACE */
+#  include <cstdio> /* INFRINGES ON USER NAME SPACE */
 #  define YYFPRINTF fprintf
 # endif
 

--- a/Code/GraphMol/SmilesParse/lex.yysmarts.cpp.cmake
+++ b/Code/GraphMol/SmilesParse/lex.yysmarts.cpp.cmake
@@ -239,10 +239,10 @@
 /* First, we deal with  platform-specific or compiler-specific issues. */
 
 /* begin standard C headers. */
-#include <stdio.h>
-#include <string.h>
-#include <errno.h>
-#include <stdlib.h>
+#include <cstdio>
+#include <cstring>
+#include <cerrno>
+#include <cstdlib>
 
 /* end standard C headers. */
 
@@ -262,7 +262,7 @@
 #define __STDC_LIMIT_MACROS 1
 #endif
 
-#include <inttypes.h>
+#include <cinttypes>
 typedef int8_t flex_int8_t;
 typedef uint8_t flex_uint8_t;
 typedef int16_t flex_int16_t;

--- a/Code/GraphMol/SmilesParse/lex.yysmiles.cpp.cmake
+++ b/Code/GraphMol/SmilesParse/lex.yysmiles.cpp.cmake
@@ -239,10 +239,10 @@
 /* First, we deal with  platform-specific or compiler-specific issues. */
 
 /* begin standard C headers. */
-#include <stdio.h>
-#include <string.h>
-#include <errno.h>
-#include <stdlib.h>
+#include <cstdio>
+#include <cstring>
+#include <cerrno>
+#include <cstdlib>
 
 /* end standard C headers. */
 
@@ -262,7 +262,7 @@
 #define __STDC_LIMIT_MACROS 1
 #endif
 
-#include <inttypes.h>
+#include <cinttypes>
 typedef int8_t flex_int8_t;
 typedef uint8_t flex_uint8_t;
 typedef int16_t flex_int16_t;

--- a/Code/GraphMol/SmilesParse/smarts.tab.cpp.cmake
+++ b/Code/GraphMol/SmilesParse/smarts.tab.cpp.cmake
@@ -271,7 +271,7 @@ typedef short int yytype_int16;
 # elif defined size_t
 #  define YYSIZE_T size_t
 # elif ! defined YYSIZE_T
-#  include <stddef.h> /* INFRINGES ON USER NAME SPACE */
+#  include <cstddef> /* INFRINGES ON USER NAME SPACE */
 #  define YYSIZE_T size_t
 # else
 #  define YYSIZE_T unsigned int
@@ -364,7 +364,7 @@ typedef short int yytype_int16;
 #   else
 #    define YYSTACK_ALLOC alloca
 #    if ! defined _ALLOCA_H && ! defined EXIT_SUCCESS
-#     include <stdlib.h> /* INFRINGES ON USER NAME SPACE */
+#     include <cstdlib> /* INFRINGES ON USER NAME SPACE */
       /* Use EXIT_SUCCESS as a witness for stdlib.h.  */
 #     ifndef EXIT_SUCCESS
 #      define EXIT_SUCCESS 0
@@ -393,7 +393,7 @@ typedef short int yytype_int16;
 #  if (defined __cplusplus && ! defined EXIT_SUCCESS \
        && ! ((defined YYMALLOC || defined malloc) \
              && (defined YYFREE || defined free)))
-#   include <stdlib.h> /* INFRINGES ON USER NAME SPACE */
+#   include <cstdlib> /* INFRINGES ON USER NAME SPACE */
 #   ifndef EXIT_SUCCESS
 #    define EXIT_SUCCESS 0
 #   endif
@@ -903,7 +903,7 @@ while (0)
 #if YYDEBUG
 
 # ifndef YYFPRINTF
-#  include <stdio.h> /* INFRINGES ON USER NAME SPACE */
+#  include <cstdio> /* INFRINGES ON USER NAME SPACE */
 #  define YYFPRINTF fprintf
 # endif
 

--- a/Code/GraphMol/SmilesParse/smiles.tab.cpp.cmake
+++ b/Code/GraphMol/SmilesParse/smiles.tab.cpp.cmake
@@ -273,7 +273,7 @@ typedef short yytype_int16;
 # elif defined size_t
 #  define YYSIZE_T size_t
 # elif ! defined YYSIZE_T
-#  include <stddef.h> /* INFRINGES ON USER NAME SPACE */
+#  include <cstddef> /* INFRINGES ON USER NAME SPACE */
 #  define YYSIZE_T size_t
 # else
 #  define YYSIZE_T unsigned
@@ -366,7 +366,7 @@ typedef short yytype_int16;
 #   else
 #    define YYSTACK_ALLOC alloca
 #    if ! defined _ALLOCA_H && ! defined EXIT_SUCCESS
-#     include <stdlib.h> /* INFRINGES ON USER NAME SPACE */
+#     include <cstdlib> /* INFRINGES ON USER NAME SPACE */
       /* Use EXIT_SUCCESS as a witness for stdlib.h.  */
 #     ifndef EXIT_SUCCESS
 #      define EXIT_SUCCESS 0
@@ -395,7 +395,7 @@ typedef short yytype_int16;
 #  if (defined __cplusplus && ! defined EXIT_SUCCESS \
        && ! ((defined YYMALLOC || defined malloc) \
              && (defined YYFREE || defined free)))
-#   include <stdlib.h> /* INFRINGES ON USER NAME SPACE */
+#   include <cstdlib> /* INFRINGES ON USER NAME SPACE */
 #   ifndef EXIT_SUCCESS
 #    define EXIT_SUCCESS 0
 #   endif
@@ -761,7 +761,7 @@ while (0)
 #if YYDEBUG
 
 # ifndef YYFPRINTF
-#  include <stdio.h> /* INFRINGES ON USER NAME SPACE */
+#  include <cstdio> /* INFRINGES ON USER NAME SPACE */
 #  define YYFPRINTF fprintf
 # endif
 

--- a/Code/GraphMol/StructChecker/AtomSymbolMatch.cpp
+++ b/Code/GraphMol/StructChecker/AtomSymbolMatch.cpp
@@ -12,8 +12,8 @@
 #define _GNU_SOURCE
 #endif
 
-#include <string.h>
-#include <ctype.h>
+#include <cstring>
+#include <cctype>
 #include "Pattern.h"
 
 namespace RDKit {

--- a/Code/GraphMol/StructChecker/Stereo.cpp
+++ b/Code/GraphMol/StructChecker/Stereo.cpp
@@ -7,7 +7,7 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-#include <math.h>
+#include <cmath>
 #include <boost/format.hpp>
 
 #include "../RDKitBase.h"

--- a/Code/GraphMol/StructChecker/StructCheckerOptions.cpp
+++ b/Code/GraphMol/StructChecker/StructCheckerOptions.cpp
@@ -7,9 +7,9 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-#include <ctype.h>
+#include <cctype>
 #include <memory.h>
-#include <errno.h>
+#include <cerrno>
 #include <iostream>
 #include <sstream>
 #include <fstream>

--- a/Code/GraphMol/Wrap/MolOps.cpp
+++ b/Code/GraphMol/Wrap/MolOps.cpp
@@ -14,7 +14,7 @@
 #include <numpy/arrayobject.h>
 
 #include <string>
-#include <math.h>
+#include <cmath>
 
 #include <DataStructs/ExplicitBitVect.h>
 #include <GraphMol/RDKitBase.h>

--- a/Code/GraphMol/bulktest.cpp
+++ b/Code/GraphMol/bulktest.cpp
@@ -16,7 +16,7 @@
 #include <RDGeneral/RDLog.h>
 
 #include <iostream>
-#include <stdlib.h>
+#include <cstdlib>
 
 using namespace RDKit;
 using namespace std;

--- a/Code/GraphMol/itertest.cpp
+++ b/Code/GraphMol/itertest.cpp
@@ -15,7 +15,7 @@
 #include <RDGeneral/RDLog.h>
 
 #include <iostream>
-#include <stdlib.h>
+#include <cstdlib>
 #include <vector>
 
 using namespace RDKit;

--- a/Code/GraphMol/sanitTest.cpp
+++ b/Code/GraphMol/sanitTest.cpp
@@ -15,7 +15,7 @@
 #include <GraphMol/SmilesParse/SmilesParse.h>
 #include <GraphMol/SmilesParse/SmilesWrite.h>
 
-#include <stdlib.h>
+#include <cstdlib>
 #include <iostream>
 #include <fstream>
 #include <RDGeneral/types.h>

--- a/Code/GraphMol/testPickler.cpp
+++ b/Code/GraphMol/testPickler.cpp
@@ -23,7 +23,7 @@
 
 #include <RDGeneral/RDLog.h>
 
-#include <stdlib.h>
+#include <cstdlib>
 #include <ctime>
 #include <iostream>
 #include <fstream>

--- a/Code/GraphMol/testPicklerGlobalSettings.cpp
+++ b/Code/GraphMol/testPicklerGlobalSettings.cpp
@@ -44,7 +44,7 @@
 
 #include <RDGeneral/RDLog.h>
 
-#include <stdlib.h>
+#include <cstdlib>
 #include <ctime>
 #include <iostream>
 #include <fstream>

--- a/Code/Numerics/Alignment/testAlignment.cpp
+++ b/Code/Numerics/Alignment/testAlignment.cpp
@@ -15,7 +15,7 @@
 #include <Geometry/Transform3D.h>
 #include <Geometry/point.h>
 
-#include <math.h>
+#include <cmath>
 
 using namespace RDNumeric;
 using namespace RDNumeric::Alignments;

--- a/Code/Numerics/EigenSolvers/PowerEigenSolver.cpp
+++ b/Code/Numerics/EigenSolvers/PowerEigenSolver.cpp
@@ -13,7 +13,7 @@
 #include <Numerics/Matrix.h>
 #include <Numerics/SymmMatrix.h>
 #include <RDGeneral/Invariant.h>
-#include <time.h>
+#include <ctime>
 
 #define MAX_ITERATIONS 1000
 #define TOLERANCE 0.001

--- a/Code/Numerics/Optimizer/BFGSOpt.h
+++ b/Code/Numerics/Optimizer/BFGSOpt.h
@@ -8,7 +8,7 @@
 //  of the RDKit source tree.
 //
 #include <RDGeneral/export.h>
-#include <math.h>
+#include <cmath>
 #include <RDGeneral/Invariant.h>
 #include <GraphMol/Trajectory/Snapshot.h>
 #include <cstring>

--- a/Code/Numerics/Optimizer/testOptimizer.cpp
+++ b/Code/Numerics/Optimizer/testOptimizer.cpp
@@ -10,7 +10,7 @@
 //
 #include <RDGeneral/test.h>
 #include <iostream>
-#include <math.h>
+#include <cmath>
 #include <RDGeneral/Invariant.h>
 
 #include "BFGSOpt.h"

--- a/Code/Numerics/Vector.h
+++ b/Code/Numerics/Vector.h
@@ -13,12 +13,12 @@
 
 #include <RDGeneral/Invariant.h>
 #include <RDGeneral/utils.h>
-#include <math.h>
+#include <cmath>
 #include <iostream>
 #include <iomanip>
 #include <cstdlib>
 #include <cstring>
-#include <time.h>
+#include <ctime>
 #include <boost/random.hpp>
 #include <boost/smart_ptr.hpp>
 

--- a/Code/Numerics/testConrec.cpp
+++ b/Code/Numerics/testConrec.cpp
@@ -16,7 +16,7 @@
 #include <iostream>
 #include <RDGeneral/Invariant.h>
 #include <RDGeneral/RDLog.h>
-#include <math.h>
+#include <cmath>
 #include <RDGeneral/utils.h>
 #include <Geometry/point.h>
 

--- a/Code/Numerics/testMatrices.cpp
+++ b/Code/Numerics/testMatrices.cpp
@@ -14,7 +14,7 @@
 #include <iostream>
 #include <RDGeneral/Invariant.h>
 #include <RDGeneral/RDLog.h>
-#include <math.h>
+#include <cmath>
 #include <RDGeneral/utils.h>
 
 using namespace RDNumeric;

--- a/Code/Query/test.cpp
+++ b/Code/Query/test.cpp
@@ -12,7 +12,7 @@
 #include <RDGeneral/test.h>
 #include "QueryObjects.h"
 #include <iostream>
-#include <math.h>
+#include <cmath>
 #include <boost/lexical_cast.hpp>
 
 using namespace std;

--- a/Code/RDGeneral/Invariant.h
+++ b/Code/RDGeneral/Invariant.h
@@ -13,7 +13,7 @@
 #ifndef __RD_INVARIANT_H__
 #define __RD_INVARIANT_H__
 
-#include <assert.h>
+#include <cassert>
 #include <string>
 #include <iostream>
 #include <stdexcept>

--- a/Code/RDGeneral/RDLog.cpp
+++ b/Code/RDGeneral/RDLog.cpp
@@ -13,7 +13,7 @@
 #if 1
 #include <iomanip>
 #include <string>
-#include <time.h>
+#include <ctime>
 
 std::shared_ptr<boost::logging::rdLogger> rdAppLog = nullptr;
 std::shared_ptr<boost::logging::rdLogger> rdDebugLog = nullptr;

--- a/Code/RDGeneral/hash/detail/hash_float.hpp
+++ b/Code/RDGeneral/hash/detail/hash_float.hpp
@@ -52,10 +52,10 @@
 #endif
 
 // On OpenBSD, numeric_limits is not reliable for long doubles, but
-// the macros defined in <float.h> are.
+// the macros defined in <cfloat> are.
 
 #if defined(__OpenBSD__)
-#include <float.h>
+#include <cfloat>
 #endif
 
 namespace gboost

--- a/Code/RDGeneral/utils.cpp
+++ b/Code/RDGeneral/utils.cpp
@@ -9,7 +9,7 @@
 //  of the RDKit source tree.
 //
 #include "utils.h"
-#include <math.h>
+#include <cmath>
 #include <string>
 #include <boost/random.hpp>
 

--- a/Code/SimDivPickers/pickersCLI.cpp
+++ b/Code/SimDivPickers/pickersCLI.cpp
@@ -1,6 +1,6 @@
 /* MaxMinPicker.cpp */
-#include <string.h>
-#include <stdio.h>
+#include <cstring>
+#include <cstdio>
 #include <sys/time.h>
 
 #include <vector>

--- a/Contrib/PBF/PBFRDKit.h
+++ b/Contrib/PBF/PBFRDKit.h
@@ -50,7 +50,7 @@
 #include <GraphMol/RDKitBase.h>
 #include <GraphMol/MolOps.h>
 #include <GraphMol/Conformer.h>
-#include <math.h>
+#include <cmath>
 
 using namespace RDKit;
 

--- a/External/FreeSASA/Wrap/rdFreeSASA.cpp
+++ b/External/FreeSASA/Wrap/rdFreeSASA.cpp
@@ -36,7 +36,7 @@
 //#include <boost/python/suite/indexing/map_indexing_suite.hpp>
 //#include <boost/python/suite/indexing/vector_indexing_suite.hpp>
 //#include <string>
-#include <math.h>
+#include <cmath>
 
 #include <RDGeneral/Exceptions.h>
 #include <GraphMol/RDKitBase.h>


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! 

#### Reference Issue
Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.
[N4681 C.6.1](https://github.com/cplusplus/draft/blob/n4861/source/compatibility.tex#L2654-L2656)

> For compatibility with the C standard library, the C++ standard library provides the C headers enumerated in [D.9](https://github.com/cplusplus/draft/blob/n4861/source/future.tex#L216-L248), but their use is deprecated in C ++ .

For example, `<math.h>` should be replaced with `<cmath>` in C++.

<!--
#### Any other comments?
-->