### PR TITLE
Fix/smiles parser memleak

### DIFF
--- a/Code/GraphMol/SmilesParse/SmilesParseOps.cpp
+++ b/Code/GraphMol/SmilesParse/SmilesParseOps.cpp
@@ -431,10 +431,6 @@ void CloseMolRings(RWMol *mol, bool toleratePartials) {
           ++bondIt;
           Bond *bond2 = *bondIt;
 
-          // remove those bonds from the bookmarks:
-          mol->clearBondBookmark(bookmark.first, bond1);
-          mol->clearBondBookmark(bookmark.first, bond2);
-
           // Make sure the bonds have the correct starting atoms:
           CHECK_INVARIANT(bond1->getBeginAtomIdx() == atom1->getIdx(),
                           "bad begin atom");
@@ -489,6 +485,12 @@ void CloseMolRings(RWMol *mol, bool toleratePartials) {
             swapBondDirIfNeeded(bond2, bond1);
             delete bond1;
           }
+
+	  // remove those bonds from the bookmarks:
+	  mol->clearBondBookmark(bookmark.first, bond1);
+	  mol->clearBondBookmark(bookmark.first, bond2);
+
+	  
           if (matchedBond->getBondType() == Bond::UNSPECIFIED &&
               !matchedBond->hasQuery()) {
             Bond::BondType bondT = GetUnspecifiedBondType(mol, atom1, atom2);

--- a/Code/GraphMol/SmilesParse/SmilesParseOps.cpp
+++ b/Code/GraphMol/SmilesParse/SmilesParseOps.cpp
@@ -431,6 +431,10 @@ void CloseMolRings(RWMol *mol, bool toleratePartials) {
           ++bondIt;
           Bond *bond2 = *bondIt;
 
+          // remove those bonds from the bookmarks:
+          mol->clearBondBookmark(bookmark.first, bond1);
+          mol->clearBondBookmark(bookmark.first, bond2);
+
           // Make sure the bonds have the correct starting atoms:
           CHECK_INVARIANT(bond1->getBeginAtomIdx() == atom1->getIdx(),
                           "bad begin atom");
@@ -485,12 +489,6 @@ void CloseMolRings(RWMol *mol, bool toleratePartials) {
             swapBondDirIfNeeded(bond2, bond1);
             delete bond1;
           }
-
-	  // remove those bonds from the bookmarks:
-	  mol->clearBondBookmark(bookmark.first, bond1);
-	  mol->clearBondBookmark(bookmark.first, bond2);
-
-	  
           if (matchedBond->getBondType() == Bond::UNSPECIFIED &&
               !matchedBond->hasQuery()) {
             Bond::BondType bondT = GetUnspecifiedBondType(mol, atom1, atom2);

--- a/Code/GraphMol/SmilesParse/smarts.tab.cpp.cmake
+++ b/Code/GraphMol/SmilesParse/smarts.tab.cpp.cmake
@@ -97,6 +97,7 @@ namespace {
  void yyErrorCleanup(std::vector<RDKit::RWMol *> *molList){
   for(std::vector<RDKit::RWMol *>::iterator iter=molList->begin();
       iter != molList->end(); ++iter){
+     SmilesParseOps::CleanupAfterParseError(*iter);
      delete *iter;
   }
   molList->clear();

--- a/Code/GraphMol/SmilesParse/smarts.yy
+++ b/Code/GraphMol/SmilesParse/smarts.yy
@@ -26,6 +26,7 @@ namespace {
  void yyErrorCleanup(std::vector<RDKit::RWMol *> *molList){
   for(std::vector<RDKit::RWMol *>::iterator iter=molList->begin();
       iter != molList->end(); ++iter){
+     SmilesParseOps::CleanupAfterParseError(*iter);
      delete *iter;
   }
   molList->clear();

--- a/Code/GraphMol/SmilesParse/smiles.tab.cpp.cmake
+++ b/Code/GraphMol/SmilesParse/smiles.tab.cpp.cmake
@@ -98,7 +98,8 @@ namespace {
  void yyErrorCleanup(std::vector<RDKit::RWMol *> *molList){
   for(std::vector<RDKit::RWMol *>::iterator iter=molList->begin();
       iter != molList->end(); ++iter){
-     delete *iter;
+      SmilesParseOps::CleanupAfterParseError(*iter);      
+      delete *iter;
   }
   molList->clear();
   molList->resize(0);

--- a/Code/GraphMol/SmilesParse/smiles.yy
+++ b/Code/GraphMol/SmilesParse/smiles.yy
@@ -25,7 +25,6 @@ extern int yysmiles_lex(YYSTYPE *,void *,int &);
 using namespace RDKit;
 namespace {
  void yyErrorCleanup(std::vector<RDKit::RWMol *> *molList){
- std::cerr << "yy error cleanup" << std::endl;
   for(std::vector<RDKit::RWMol *>::iterator iter=molList->begin();
       iter != molList->end(); ++iter){
       SmilesParseOps::CleanupAfterParseError(*iter);

--- a/Code/GraphMol/SmilesParse/smiles.yy
+++ b/Code/GraphMol/SmilesParse/smiles.yy
@@ -25,9 +25,11 @@ extern int yysmiles_lex(YYSTYPE *,void *,int &);
 using namespace RDKit;
 namespace {
  void yyErrorCleanup(std::vector<RDKit::RWMol *> *molList){
+ std::cerr << "yy error cleanup" << std::endl;
   for(std::vector<RDKit::RWMol *>::iterator iter=molList->begin();
       iter != molList->end(); ++iter){
-     delete *iter;
+      SmilesParseOps::CleanupAfterParseError(*iter);
+      delete *iter;
   }
   molList->clear();
   molList->resize(0);

--- a/Code/GraphMol/SmilesParse/test.cpp
+++ b/Code/GraphMol/SmilesParse/test.cpp
@@ -4298,6 +4298,20 @@ void testGithub1028() {
   BOOST_LOG(rdInfoLog) << "done" << std::endl;
 }
 
+void testGithub3139() {
+  BOOST_LOG(rdInfoLog) << "-------------------------------------" << std::endl;
+  BOOST_LOG(rdInfoLog) << "Testing github issue #3139: Partial bond mem leak"
+                       << std::endl;
+
+{
+  const std::string smi = "COc(c1)cccc1C#";
+  for (int i = 0; i < 3; ++i) {
+    const auto mol = std::unique_ptr<ROMol>(SmilesToMol(smi));
+  }
+ }
+ 
+  BOOST_LOG(rdInfoLog) << "done" << std::endl;
+}
 int main(int argc, char *argv[]) {
   (void)argc;
   (void)argv;
@@ -4376,4 +4390,5 @@ int main(int argc, char *argv[]) {
 #endif
   testdoRandomSmileGeneration();
   testGithub1028();
+  testGithub3139();
 }

--- a/Code/GraphMol/SmilesParse/test.cpp
+++ b/Code/GraphMol/SmilesParse/test.cpp
@@ -4307,6 +4307,7 @@ void testGithub3139() {
   const std::string smi = "COc(c1)cccc1C#";
   for (int i = 0; i < 3; ++i) {
     const auto mol = std::unique_ptr<ROMol>(SmilesToMol(smi));
+    const auto sma = std::unique_ptr<ROMol>(SmartsToMol(smi));
   }
  }
  


### PR DESCRIPTION
Fixes #3139 a memory leak in the smiles parser

A trailing bond with an end atom would leak, i.e.

"C#"

this is because the bond bookmarks were cleared before an invariant was thrown which means that the cleanup code couldn't see the dancing bond.

This should be validated with valgrind before inclusion.