### PR TITLE
Fixes #3150

### DIFF
--- a/Code/GraphMol/AddHs.cpp
+++ b/Code/GraphMol/AddHs.cpp
@@ -707,7 +707,7 @@ void removeHs(RWMol &mol, const RemoveHsParameters &ps, bool sanitize) {
     if (!ps.removeMapped && atom->getAtomMapNum()) {
       continue;
     }
-    if (!ps.removeHydrides && atom->getAtomicNum() == 1 && atom->getFormalCharge() == -1) {
+    if (!ps.removeHydrides && atom->getFormalCharge() == -1) {
       continue;
     }
     bool removeIt = true;

--- a/Code/GraphMol/AddHs.cpp
+++ b/Code/GraphMol/AddHs.cpp
@@ -707,6 +707,9 @@ void removeHs(RWMol &mol, const RemoveHsParameters &ps, bool sanitize) {
     if (!ps.removeMapped && atom->getAtomMapNum()) {
       continue;
     }
+    if (!ps.removeHydrides && atom->getAtomicNum() == 1 && atom->getFormalCharge() == -1) {
+      continue;
+    }
     bool removeIt = true;
     if (atom->getDegree() &&
         (!ps.removeDummyNeighbors || !ps.removeDefiningBondStereo ||

--- a/Code/GraphMol/AddHs.cpp
+++ b/Code/GraphMol/AddHs.cpp
@@ -826,6 +826,7 @@ void removeAllHs(RWMol &mol, bool sanitize) {
   ps.removeWithQuery = true;
   ps.removeNonimplicit = true;
   ps.showWarnings = false;
+  ps.removeHydrides = true;
   removeHs(mol, ps, sanitize);
 };
 ROMol *removeAllHs(const ROMol &mol, bool sanitize) {

--- a/Code/GraphMol/MolOps.h
+++ b/Code/GraphMol/MolOps.h
@@ -249,7 +249,7 @@ struct RDKIT_GRAPHMOL_EXPORT RemoveHsParameters {
   bool removeNonimplicit = true; /**< DEPRECATED equivalent of implicitOnly */
   bool updateExplicitCount =
       false; /**< DEPRECATED equivalent of updateExplicitCount */
-  bool removeHydrides = true; /**<Removing Hydrides */
+  bool removeHydrides = true; /**< Removing Hydrides */
 };
 //! \overload
 // modifies the molecule in place

--- a/Code/GraphMol/MolOps.h
+++ b/Code/GraphMol/MolOps.h
@@ -249,7 +249,7 @@ struct RDKIT_GRAPHMOL_EXPORT RemoveHsParameters {
   bool removeNonimplicit = true; /**< DEPRECATED equivalent of implicitOnly */
   bool updateExplicitCount =
       false; /**< DEPRECATED equivalent of updateExplicitCount */
-  bool removeHydrides = true; /**<Removing Hydrides>*/
+  bool removeHydrides = true; /**<Removing Hydrides */
 };
 //! \overload
 // modifies the molecule in place

--- a/Code/GraphMol/MolOps.h
+++ b/Code/GraphMol/MolOps.h
@@ -249,7 +249,7 @@ struct RDKIT_GRAPHMOL_EXPORT RemoveHsParameters {
   bool removeNonimplicit = true; /**< DEPRECATED equivalent of implicitOnly */
   bool updateExplicitCount =
       false; /**< DEPRECATED equivalent of updateExplicitCount */
-  bool removeHydrides = true; /**<Removing Hydrides>**/
+  bool removeHydrides = true; /**<Removing Hydrides>*/
 };
 //! \overload
 // modifies the molecule in place

--- a/Code/GraphMol/MolOps.h
+++ b/Code/GraphMol/MolOps.h
@@ -249,6 +249,7 @@ struct RDKIT_GRAPHMOL_EXPORT RemoveHsParameters {
   bool removeNonimplicit = true; /**< DEPRECATED equivalent of implicitOnly */
   bool updateExplicitCount =
       false; /**< DEPRECATED equivalent of updateExplicitCount */
+  bool removeHydrides = true; /**<Removing Hydrides>**/
 };
 //! \overload
 // modifies the molecule in place

--- a/Code/GraphMol/Wrap/MolOps.cpp
+++ b/Code/GraphMol/Wrap/MolOps.cpp
@@ -1090,6 +1090,9 @@ struct molops_wrapper {
         .def_readwrite("removeNonimplicit",
                        &MolOps::RemoveHsParameters::removeNonimplicit,
                        "DEPRECATED")
+        .def_readwrite("removeHydrids",
+                       &MolOps::RemoveHsParameters::removeHydrides,
+                       "hydrogens with formal charge -1")
         .def_readwrite(
             "showWarnings", &MolOps::RemoveHsParameters::showWarnings,
             "display warning messages for some classes of removed Hs")

--- a/Code/GraphMol/Wrap/MolOps.cpp
+++ b/Code/GraphMol/Wrap/MolOps.cpp
@@ -1090,7 +1090,7 @@ struct molops_wrapper {
         .def_readwrite("removeNonimplicit",
                        &MolOps::RemoveHsParameters::removeNonimplicit,
                        "DEPRECATED")
-        .def_readwrite("removeHydrids",
+        .def_readwrite("removeHydrides",
                        &MolOps::RemoveHsParameters::removeHydrides,
                        "hydrogens with formal charge -1")
         .def_readwrite(

--- a/Code/GraphMol/catch_graphmol.cpp
+++ b/Code/GraphMol/catch_graphmol.cpp
@@ -1486,3 +1486,61 @@ TEST_CASE("github #2890", "[bug][molops][stereo]") {
     CHECK(bond->getStereo() == Bond::STEREOANY);
     CHECK(bond->getStereoAtoms().size() == 2);
 }
+
+
+TEST_CASE("github #3150 MolOps::removeHs removes hydrides", "[bug][molops]") {
+  SmilesParserParams smilesPs;
+  smilesPs.removeHs = false;
+  
+  SECTION("Hydride ion") {
+    // auto m = "[H-]"_smiles;
+
+    // CHECK(m->getNumAtoms() == 1);
+    // CHECK(MolOps::getFormalCharge(*m) == -1);
+    std::unique_ptr<RWMol> m{SmilesToMol("[H-]", smilesPs)};
+    REQUIRE(m);
+    MolOps::RemoveHsParameters ps;
+    ps.removeHydrides = false;
+    RWMol cp(*m);
+    MolOps::removeHs(cp, ps);
+    CHECK(cp.getNumAtoms() == 1);
+    CHECK(MolOps::getFormalCharge(cp) == -1);
+  }
+
+  SECTION("Water") {
+    std::unique_ptr<RWMol> m{SmilesToMol("[OH+][H-]", smilesPs)};
+    REQUIRE(m);
+    MolOps::RemoveHsParameters ps;
+    ps.removeHydrides = false;
+    RWMol cp(*m);
+    MolOps::removeHs(cp, ps);
+    CHECK(cp.getNumAtoms() == 2);
+    CHECK(MolOps::getFormalCharge(cp) == 0);
+  }
+
+  SECTION("Iron Hydride") {
+    // auto m = "[Fe+2]<-[H-]"_smiles;
+    // int charge = MolOps::getFormalCharge(*m);
+    std::unique_ptr<RWMol> m{SmilesToMol("[Fe+2]<-[H-]", smilesPs)};
+    REQUIRE(m);
+    MolOps::RemoveHsParameters ps;
+    ps.removeHydrides = false;
+    RWMol cp(*m);
+    MolOps::removeHs(cp, ps);
+    CHECK(cp.getNumAtoms() == 2);
+    CHECK(MolOps::getFormalCharge(cp) == 1);
+  }
+
+  SECTION("Ferrous Hydroxide") {
+    // auto m = "[Fe+2]<-[OH-]"_smiles;
+    // int charge = MolOps::getFormalCharge(*m);
+    std::unique_ptr<RWMol> m{SmilesToMol("[Fe+2]<-[OH-]", smilesPs)};
+    REQUIRE(m);
+    MolOps::RemoveHsParameters ps;
+    ps.removeHydrides = false;
+    RWMol cp(*m);
+    MolOps::removeHs(cp, ps);
+    CHECK(cp.getNumAtoms() == 2);
+    CHECK(MolOps::getFormalCharge(cp) == 1);
+  }
+}

--- a/Code/GraphMol/catch_graphmol.cpp
+++ b/Code/GraphMol/catch_graphmol.cpp
@@ -1499,6 +1499,7 @@ TEST_CASE("github #3150 MolOps::removeHs removes hydrides", "[bug][molops]") {
     ps.removeHydrides = false;
     RWMol cp(*m);
     MolOps::removeHs(cp, ps);
+    // H atom not removed in this case because by default H atoms with degree 0 are not removed
     CHECK(cp.getNumAtoms() == 1);
     CHECK(MolOps::getFormalCharge(cp) == -1);
   }
@@ -1510,6 +1511,7 @@ TEST_CASE("github #3150 MolOps::removeHs removes hydrides", "[bug][molops]") {
     ps.removeHydrides = true;
     RWMol cp(*m);
     MolOps::removeHs(cp, ps);
+    // H atom not removed in this case because by default H atoms with degree 0 are not removed
     CHECK(cp.getNumAtoms() == 1);
     CHECK(MolOps::getFormalCharge(cp) == -1);
   }

--- a/Code/GraphMol/catch_graphmol.cpp
+++ b/Code/GraphMol/catch_graphmol.cpp
@@ -1492,15 +1492,22 @@ TEST_CASE("github #3150 MolOps::removeHs removes hydrides", "[bug][molops]") {
   SmilesParserParams smilesPs;
   smilesPs.removeHs = false;
   
-  SECTION("Hydride ion") {
-    // auto m = "[H-]"_smiles;
-
-    // CHECK(m->getNumAtoms() == 1);
-    // CHECK(MolOps::getFormalCharge(*m) == -1);
+  SECTION("Hydride ion remove Hydrides false") {
     std::unique_ptr<RWMol> m{SmilesToMol("[H-]", smilesPs)};
     REQUIRE(m);
     MolOps::RemoveHsParameters ps;
     ps.removeHydrides = false;
+    RWMol cp(*m);
+    MolOps::removeHs(cp, ps);
+    CHECK(cp.getNumAtoms() == 1);
+    CHECK(MolOps::getFormalCharge(cp) == -1);
+  }
+
+  SECTION("Hydride ion remove Hydrides true") {
+    std::unique_ptr<RWMol> m{SmilesToMol("[H-]", smilesPs)};
+    REQUIRE(m);
+    MolOps::RemoveHsParameters ps;
+    ps.removeHydrides = true;
     RWMol cp(*m);
     MolOps::removeHs(cp, ps);
     CHECK(cp.getNumAtoms() == 1);
@@ -1518,9 +1525,18 @@ TEST_CASE("github #3150 MolOps::removeHs removes hydrides", "[bug][molops]") {
     CHECK(MolOps::getFormalCharge(cp) == 0);
   }
 
+  SECTION("Water remove Hydrides true") {
+    std::unique_ptr<RWMol> m{SmilesToMol("[OH+][H-]", smilesPs)};
+    REQUIRE(m);
+    MolOps::RemoveHsParameters ps;
+    ps.removeHydrides = true;
+    RWMol cp(*m);
+    MolOps::removeHs(cp, ps);
+    CHECK(cp.getNumAtoms() == 1);
+    CHECK(MolOps::getFormalCharge(cp) == 1);
+  }
+
   SECTION("Iron Hydride") {
-    // auto m = "[Fe+2]<-[H-]"_smiles;
-    // int charge = MolOps::getFormalCharge(*m);
     std::unique_ptr<RWMol> m{SmilesToMol("[Fe+2]<-[H-]", smilesPs)};
     REQUIRE(m);
     MolOps::RemoveHsParameters ps;
@@ -1531,9 +1547,18 @@ TEST_CASE("github #3150 MolOps::removeHs removes hydrides", "[bug][molops]") {
     CHECK(MolOps::getFormalCharge(cp) == 1);
   }
 
+  SECTION("Iron Hydride remove Hydrides") {
+    std::unique_ptr<RWMol> m{SmilesToMol("[Fe+2]<-[H-]", smilesPs)};
+    REQUIRE(m);
+    MolOps::RemoveHsParameters ps;
+    ps.removeHydrides = true;
+    RWMol cp(*m);
+    MolOps::removeHs(cp, ps);
+    CHECK(cp.getNumAtoms() == 1);
+    CHECK(MolOps::getFormalCharge(cp) == 2);
+  }
+
   SECTION("Ferrous Hydroxide") {
-    // auto m = "[Fe+2]<-[OH-]"_smiles;
-    // int charge = MolOps::getFormalCharge(*m);
     std::unique_ptr<RWMol> m{SmilesToMol("[Fe+2]<-[OH-]", smilesPs)};
     REQUIRE(m);
     MolOps::RemoveHsParameters ps;
@@ -1543,4 +1568,36 @@ TEST_CASE("github #3150 MolOps::removeHs removes hydrides", "[bug][molops]") {
     CHECK(cp.getNumAtoms() == 2);
     CHECK(MolOps::getFormalCharge(cp) == 1);
   }
+
+  SECTION("Ferrous Hydroxide remove Hydrides") {
+    std::unique_ptr<RWMol> m{SmilesToMol("[Fe+2]<-[OH-]", smilesPs)};
+    REQUIRE(m);
+    MolOps::RemoveHsParameters ps;
+    ps.removeHydrides = true;
+    RWMol cp(*m);
+    MolOps::removeHs(cp, ps);
+    CHECK(cp.getNumAtoms() == 2);
+    CHECK(MolOps::getFormalCharge(cp) == 1);
+  }
+
+  SECTION("Remove All Hs in Hydrides Ferrous Hydride") {
+    std::unique_ptr<RWMol> m{SmilesToMol("[Fe+2]<-[H-]", smilesPs)};
+    REQUIRE(m);
+
+    RWMol cp(*m);
+    MolOps::removeAllHs(cp);
+    CHECK(cp.getNumAtoms() == 1);
+    CHECK(MolOps::getFormalCharge(cp) == 2);
+  }
+
+  SECTION("Remove All Hs in Hydrides Water") {
+    std::unique_ptr<RWMol> m{SmilesToMol("[OH+][H-]", smilesPs)};
+    REQUIRE(m);
+
+    RWMol cp(*m);
+    MolOps::removeAllHs(cp);
+    CHECK(cp.getNumAtoms() == 1);
+    CHECK(MolOps::getFormalCharge(cp) == 1);
+  }
+
 }


### PR DESCRIPTION
Fixes #3150 
Fixes removeHs removing Hydrides by adding a removeHydrides flag to RemoveHsParameters.
If removeHydrides is false, Hydrogen atoms with formal charge -1 and degree less than or equal to 1 are kept
removeHydrides is kept true by default

