### PR TITLE
Python wrapper: SetQuery and ExpandQuery for bonds

### DIFF
--- a/Code/GraphMol/Wrap/Bond.cpp
+++ b/Code/GraphMol/Wrap/Bond.cpp
@@ -30,6 +30,12 @@ void expandQuery(QueryBond *self, const QueryBond *other,
   }
 }
 
+void setQuery(QueryBond *self, const QueryBond *other) {
+  if (other->hasQuery()) {
+    self->setQuery(other->getQuery()->copy());
+  }
+}
+
 int BondHasProp(const Bond *bond, const char *key) {
   int res = bond->hasProp(key);
   return res;
@@ -324,7 +330,14 @@ struct bond_wrapper {
         "The class to store QueryBonds.\n\
 These cannot currently be constructed directly from Python\n";
     python::class_<QueryBond, python::bases<Bond>>(
-        "QueryBond", bondClassDoc.c_str(), python::no_init);
+        "QueryBond", bondClassDoc.c_str(), python::no_init)
+        .def("ExpandQuery", expandQuery,
+             (python::arg("self"), python::arg("other"),
+              python::arg("how") = Queries::COMPOSITE_AND,
+              python::arg("maintainOrder") = true),
+             "combines the query from other with ours")
+        .def("SetQuery", setQuery, (python::arg("self"), python::arg("other")),
+             "Replace our query with a copy of the other query");
   };
 };
 }  // namespace RDKit

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -5106,6 +5106,25 @@ M  END
 
     self.assertTrue(Chem.MolFromSmiles("c1ccccc1").HasSubstructMatch(pat))
 
+  def testBondSetQuery(self):
+    pat = Chem.MolFromSmarts('[#6]=[#6]')
+    mol = Chem.MolFromSmiles("c1ccccc1")
+    self.assertFalse(mol.HasSubstructMatch(pat))
+    pat2 = Chem.MolFromSmarts('C:C')
+    for bond in pat.GetBonds():
+        bond.SetQuery(pat2.GetBondWithIdx(0))
+    self.assertTrue(mol.HasSubstructMatch(pat))
+
+  def testBondExpandQuery(self):
+    pat = Chem.MolFromSmarts('C-C')
+    mol = Chem.MolFromSmiles("C=C-C")
+    self.assertEqual(len(mol.GetSubstructMatches(pat)), 1)
+    pat2 = Chem.MolFromSmarts('C=C')
+    for bond in pat.GetBonds():
+        bond.ExpandQuery(pat2.GetBondWithIdx(0),
+                         Chem.CompositeQueryType.COMPOSITE_OR)
+    self.assertEqual(len(mol.GetSubstructMatches(pat)), 2)
+
   def testGitHub1985(self):
     # simple check, this used to throw an exception
     try:


### PR DESCRIPTION
Basically copied over these two wrappers from Atom.cpp to Bond.cpp.

#### What does this implement/fix? Explain your changes.

Added the wrappers for completeness / consistency between QueryAtom and QueryBond, and because they'd actually be useful in a program in which I want to modify SMARTS patterns programmatically. (My workaround until now had been to convert to an EditableMol, delete the bond, and add a new bond to replace it. And still isn't as flexible.)