### PR TITLE
GetBestRMS with turned off alignment for molecular docking purposes

### DIFF
--- a/Code/GraphMol/MolAlign/AlignMolecules.cpp
+++ b/Code/GraphMol/MolAlign/AlignMolecules.cpp
@@ -169,7 +169,7 @@ double CalcRMS(ROMol &prbMol, const ROMol &refMol, int prbCid, int refCid,
     for (unsigned int i = 0; i < npt; i++) {
       rpt = refPoints[i];
       ppt = prbPoints[i];
-      double wt =  (*wts)[i];
+      double wt = (*wts)[i];
       ssr += wt * (*ppt - *rpt).lengthSq();
     }
     ssr /= (prbPoints.size());

--- a/Code/GraphMol/MolAlign/AlignMolecules.cpp
+++ b/Code/GraphMol/MolAlign/AlignMolecules.cpp
@@ -23,7 +23,7 @@ double getAlignmentTransform(const ROMol &prbMol, const ROMol &refMol,
                              RDGeom::Transform3D &trans, int prbCid, int refCid,
                              const MatchVectType *atomMap,
                              const RDNumeric::DoubleVector *weights,
-                             bool reflect, unsigned int maxIterations, bool doAlignment) {
+                             bool reflect, unsigned int maxIterations) {
   RDGeom::Point3DConstPtrVect refPoints, prbPoints;
   const Conformer &prbCnf = prbMol.getConformer(prbCid);
   const Conformer &refCnf = refMol.getConformer(refCid);
@@ -50,25 +50,8 @@ double getAlignmentTransform(const ROMol &prbMol, const ROMol &refMol,
       refPoints.push_back(&refCnf.getAtomPos(mi->second));
     }
   }
-  double ssr = 0.;
-  if (!doAlignment) {
-    unsigned int npt = refPoints.size();
-    PRECONDITION(npt == prbPoints.size(), "Mismatch in number of points");
-    ssr = 0.; 
-    const RDGeom::Point3D *rpt, *ppt;
-    for (unsigned int i = 0; i < npt; i++) {
-      rpt = refPoints[i];
-      ppt = prbPoints[i];
- 
-      ssr += ((ppt->x) - (rpt->x))*((ppt->x) - (rpt->x));
-      ssr += ((ppt->y) - (rpt->y))*((ppt->y) - (rpt->y));
-      ssr += ((ppt->z) - (rpt->z))*((ppt->z) - (rpt->z));
-    }
-  }
-  else { 
-    ssr = RDNumeric::Alignments::AlignPoints(
-    refPoints, prbPoints, trans, weights, reflect, maxIterations);
-  }
+  double ssr = RDNumeric::Alignments::AlignPoints(
+      refPoints, prbPoints, trans, weights, reflect, maxIterations);
   ssr /= (prbPoints.size());
   return sqrt(ssr);
 }
@@ -76,22 +59,18 @@ double getAlignmentTransform(const ROMol &prbMol, const ROMol &refMol,
 double alignMol(ROMol &prbMol, const ROMol &refMol, int prbCid, int refCid,
                 const MatchVectType *atomMap,
                 const RDNumeric::DoubleVector *weights, bool reflect,
-                unsigned int maxIterations, bool doAlignment) {
+                unsigned int maxIterations) {
   RDGeom::Transform3D trans;
   double res = getAlignmentTransform(prbMol, refMol, trans, prbCid, refCid,
-                                     atomMap, weights, reflect, maxIterations, 
-                                     doAlignment);
-  if (doAlignment) { 
-    // now transform the relevant conformation on prbMol
-    Conformer &conf = prbMol.getConformer(prbCid);
-    MolTransforms::transformConformer(conf, trans);
-  }
+                                     atomMap, weights, reflect, maxIterations);
+  // now transform the relevant conformation on prbMol
+  Conformer &conf = prbMol.getConformer(prbCid);
+  MolTransforms::transformConformer(conf, trans);
   return res;
 }
 
 double getBestRMS(ROMol &probeMol, ROMol &refMol, int probeId, int refId,
-                  const std::vector<MatchVectType> &map, int maxMatches,
-                  bool doAlignment) {
+                  const std::vector<MatchVectType> &map, int maxMatches) {
   std::vector<MatchVectType> matches = map;
   if (matches.empty()) {
     bool uniquify = false;
@@ -119,7 +98,7 @@ double getBestRMS(ROMol &probeMol, ROMol &refMol, int probeId, int refId,
   double bestRMS = 1.e300;
   MatchVectType &bestMatch = matches[0];
   for (auto &matche : matches) {
-    double rms = alignMol(probeMol, refMol, probeId, refId, &matche, 0, false, 50, doAlignment);
+    double rms = alignMol(probeMol, refMol, probeId, refId, &matche);
     if (rms < bestRMS) {
       bestRMS = rms;
       bestMatch = matche;
@@ -127,8 +106,9 @@ double getBestRMS(ROMol &probeMol, ROMol &refMol, int probeId, int refId,
   }
 
   // Perform a final alignment to the best alignment...
-  if (&bestMatch != &matches.back())
-    alignMol(probeMol, refMol, probeId, refId, &bestMatch, 0, false, 50, doAlignment);
+  if (&bestMatch != &matches.back()) {
+    alignMol(probeMol, refMol, probeId, refId, &bestMatch);
+  }
   return bestRMS;
 }
 

--- a/Code/GraphMol/MolAlign/AlignMolecules.cpp
+++ b/Code/GraphMol/MolAlign/AlignMolecules.cpp
@@ -169,8 +169,7 @@ double CalcRMS(ROMol &prbMol, const ROMol &refMol, int prbCid, int refCid,
     for (unsigned int i = 0; i < npt; i++) {
       rpt = refPoints[i];
       ppt = prbPoints[i];
-      double wt = (*wts)[i];
-      ssr += wt * (*ppt - *rpt).lengthSq();
+      ssr += (*wts)[i] * (*ppt - *rpt).lengthSq();
     }
     ssr /= (prbPoints.size());
     

--- a/Code/GraphMol/MolAlign/AlignMolecules.cpp
+++ b/Code/GraphMol/MolAlign/AlignMolecules.cpp
@@ -141,7 +141,7 @@ double CalcRMS(ROMol &prbMol, const ROMol &refMol, int prbCid, int refCid,
   
   unsigned int msize = matches[0].size();
   const RDNumeric::DoubleVector *wts;
-  if (weights) {
+  if (weights != nullptr) {
     PRECONDITION(msize == weights->size(), "Mismatch in number of points");
     wts = weights;
   } else {
@@ -156,9 +156,9 @@ double CalcRMS(ROMol &prbMol, const ROMol &refMol, int prbCid, int refCid,
     const Conformer &refCnf = refMol.getConformer(refCid);
     
     MatchVectType::const_iterator mi;
-    for (mi = matche.begin(); mi != matche.end(); mi++) {
-      prbPoints.push_back(&prbCnf.getAtomPos(mi->first));
-      refPoints.push_back(&refCnf.getAtomPos(mi->second));
+    for (const auto &mi : matche) {
+      prbPoints.push_back(&prbCnf.getAtomPos(mi.first));
+      refPoints.push_back(&refCnf.getAtomPos(mi.second));
     }
     
     unsigned int npt = refPoints.size();
@@ -170,10 +170,7 @@ double CalcRMS(ROMol &prbMol, const ROMol &refMol, int prbCid, int refCid,
       rpt = refPoints[i];
       ppt = prbPoints[i];
       double wt =  (*wts)[i];
- 
-      ssr += ((ppt->x) - (rpt->x)) * ((ppt->x) - (rpt->x)) * wt;
-      ssr += ((ppt->y) - (rpt->y)) * ((ppt->y) - (rpt->y)) * wt;
-      ssr += ((ppt->z) - (rpt->z)) * ((ppt->z) - (rpt->z)) * wt;
+      ssr += wt * (*ppt - *rpt).lengthSq();
     }
     ssr /= (prbPoints.size());
     
@@ -184,7 +181,7 @@ double CalcRMS(ROMol &prbMol, const ROMol &refMol, int prbCid, int refCid,
       bestMatch = matche;
     }
   }
-  if (!weights) {
+  if (weights == nullptr) {
     delete wts;
   }
 

--- a/Code/GraphMol/MolAlign/AlignMolecules.cpp
+++ b/Code/GraphMol/MolAlign/AlignMolecules.cpp
@@ -132,6 +132,85 @@ double getBestRMS(ROMol &probeMol, ROMol &refMol, int probeId, int refId,
   return bestRMS;
 }
 
+double CalcRMS(ROMol &prbMol, const ROMol &refMol, int prbCid, int refCid,
+               const std::vector<MatchVectType> &map, int maxMatches,
+               const RDNumeric::DoubleVector *weights) {    
+  std::vector<MatchVectType> matches = map;
+  if (matches.empty()) {
+    bool uniquify = false;
+    bool recursionPossible = true;
+    bool useChirality = false;
+    bool useQueryQueryMatches = false;
+
+    SubstructMatch(refMol, prbMol, matches, uniquify, recursionPossible,
+                   useChirality, useQueryQueryMatches, maxMatches);
+
+    if (matches.empty()) {
+      throw MolAlignException(
+          "No sub-structure match found between the reference and probe mol");
+    }
+
+    if (matches.size() > 1e6) {
+      std::string name;
+      prbMol.getPropIfPresent(common_properties::_Name, name);
+      std::cerr << "Warning in " << __FUNCTION__ << ": " << matches.size()
+                << " matches detected for molecule " << name << ", this may "
+                << "lead to a performance slowdown.\n";
+    }
+  }
+  
+  unsigned int msize = matches[0].size();
+  const RDNumeric::DoubleVector *wts;
+  if (weights) {
+    PRECONDITION(msize == weights->size(), "Mismatch in number of points");
+    wts = weights;
+  } else {
+    wts = new RDNumeric::DoubleVector(msize, 1.0);
+  }
+
+  double bestRMS = 1.e300;
+  MatchVectType &bestMatch = matches[0];
+  for (auto &matche : matches) {
+    RDGeom::Point3DConstPtrVect refPoints, prbPoints;
+    const Conformer &prbCnf = prbMol.getConformer(prbCid);
+    const Conformer &refCnf = refMol.getConformer(refCid);
+    
+    MatchVectType::const_iterator mi;
+    for (mi = matche.begin(); mi != matche.end(); mi++) {
+      prbPoints.push_back(&prbCnf.getAtomPos(mi->first));
+      refPoints.push_back(&refCnf.getAtomPos(mi->second));
+    }
+    
+    unsigned int npt = refPoints.size();
+    PRECONDITION(npt == prbPoints.size(), "Mismatch in number of points");
+    double ssr = 0.; 
+    
+    const RDGeom::Point3D *rpt, *ppt;
+    for (unsigned int i = 0; i < npt; i++) {
+      rpt = refPoints[i];
+      ppt = prbPoints[i];
+      double wt =  (*wts)[i];
+ 
+      ssr += ((ppt->x) - (rpt->x)) * ((ppt->x) - (rpt->x)) * wt;
+      ssr += ((ppt->y) - (rpt->y)) * ((ppt->y) - (rpt->y)) * wt;
+      ssr += ((ppt->z) - (rpt->z)) * ((ppt->z) - (rpt->z)) * wt;
+    }
+    ssr /= (prbPoints.size());
+    
+    double rms = sqrt(ssr);
+    
+    if (rms < bestRMS) {
+      bestRMS = rms;
+      bestMatch = matche;
+    }
+  }
+  if (!weights) {
+    delete wts;
+  }
+
+  return bestRMS;
+}
+
 void _fillAtomPositions(RDGeom::Point3DConstPtrVect &pts, const Conformer &conf,
                         const std::vector<unsigned int> *atomIds = nullptr) {
   unsigned int na = conf.getNumAtoms();

--- a/Code/GraphMol/MolAlign/AlignMolecules.h
+++ b/Code/GraphMol/MolAlign/AlignMolecules.h
@@ -67,7 +67,7 @@ RDKIT_MOLALIGN_EXPORT double getAlignmentTransform(
     const ROMol &prbMol, const ROMol &refMol, RDGeom::Transform3D &trans,
     int prbCid = -1, int refCid = -1, const MatchVectType *atomMap = 0,
     const RDNumeric::DoubleVector *weights = 0, bool reflect = false,
-    unsigned int maxIters = 50);
+    unsigned int maxIters = 50, bool doAlignment=true);
 
 //! Optimally (minimum RMSD) align a molecule to another molecule
 /*!
@@ -100,7 +100,7 @@ RDKIT_MOLALIGN_EXPORT double alignMol(
     ROMol &prbMol, const ROMol &refMol, int prbCid = -1, int refCid = -1,
     const MatchVectType *atomMap = 0,
     const RDNumeric::DoubleVector *weights = 0, bool reflect = false,
-    unsigned int maxIters = 50);
+    unsigned int maxIters = 50, bool doAlignment=true);
 
 //! Returns the optimal RMS for aligning two molecules, taking
 //  symmetry into account. As a side-effect, the probe molecule is
@@ -129,7 +129,7 @@ RDKIT_MOLALIGN_EXPORT double alignMol(
 RDKIT_MOLALIGN_EXPORT double getBestRMS(
     ROMol &probeMol, ROMol &refMol, int probeId = -1, int refId = -1,
     const std::vector<MatchVectType> &map = std::vector<MatchVectType>(),
-    int maxMatches = 1e6);
+    int maxMatches = 1e6, bool doAlignment=true);
 
 //! Align the conformations of a molecule using a common set of atoms. If
 // the molecules contains queries, then the queries must also match exactly.

--- a/Code/GraphMol/MolAlign/AlignMolecules.h
+++ b/Code/GraphMol/MolAlign/AlignMolecules.h
@@ -65,9 +65,9 @@ class RDKIT_MOLALIGN_EXPORT MolAlignException : public std::exception {
 */
 RDKIT_MOLALIGN_EXPORT double getAlignmentTransform(
     const ROMol &prbMol, const ROMol &refMol, RDGeom::Transform3D &trans,
-    int prbCid = -1, int refCid = -1, const MatchVectType *atomMap = 0,
-    const RDNumeric::DoubleVector *weights = 0, bool reflect = false,
-    unsigned int maxIters = 50, bool doAlignment=true);
+    int prbCid = -1, int refCid = -1, const MatchVectType *atomMap = nullptr,
+    const RDNumeric::DoubleVector *weights = nullptr, bool reflect = false,
+    unsigned int maxIters = 50);
 
 //! Optimally (minimum RMSD) align a molecule to another molecule
 /*!
@@ -98,9 +98,9 @@ RDKIT_MOLALIGN_EXPORT double getAlignmentTransform(
 */
 RDKIT_MOLALIGN_EXPORT double alignMol(
     ROMol &prbMol, const ROMol &refMol, int prbCid = -1, int refCid = -1,
-    const MatchVectType *atomMap = 0,
-    const RDNumeric::DoubleVector *weights = 0, bool reflect = false,
-    unsigned int maxIters = 50, bool doAlignment=true);
+    const MatchVectType *atomMap = nullptr,
+    const RDNumeric::DoubleVector *weights = nullptr, bool reflect = false,
+    unsigned int maxIters = 50);
 
 //! Returns the optimal RMS for aligning two molecules, taking
 //  symmetry into account. As a side-effect, the probe molecule is
@@ -129,7 +129,7 @@ RDKIT_MOLALIGN_EXPORT double alignMol(
 RDKIT_MOLALIGN_EXPORT double getBestRMS(
     ROMol &probeMol, ROMol &refMol, int probeId = -1, int refId = -1,
     const std::vector<MatchVectType> &map = std::vector<MatchVectType>(),
-    int maxMatches = 1e6, bool doAlignment=true);
+    int maxMatches = 1e6);
 
 
 //! Returns the RMS between two molecules, taking symmetry into account.
@@ -156,7 +156,7 @@ RDKIT_MOLALIGN_EXPORT double getBestRMS(
 RDKIT_MOLALIGN_EXPORT double CalcRMS(
     ROMol &probeMol, const ROMol &refMol, int prbCid=-1, int refCid=-1,
     const std::vector<MatchVectType> &map = std::vector<MatchVectType>(), int maxMatches=1e6,
-    const RDNumeric::DoubleVector *weights = 0);
+    const RDNumeric::DoubleVector *weights = nullptr);
 
 //! Align the conformations of a molecule using a common set of atoms. If
 // the molecules contains queries, then the queries must also match exactly.
@@ -175,10 +175,10 @@ RDKIT_MOLALIGN_EXPORT double CalcRMS(
                    conformations
 */
 RDKIT_MOLALIGN_EXPORT void alignMolConformers(
-    ROMol &mol, const std::vector<unsigned int> *atomIds = 0,
-    const std::vector<unsigned int> *confIds = 0,
-    const RDNumeric::DoubleVector *weights = 0, bool reflect = false,
-    unsigned int maxIters = 50, std::vector<double> *RMSlist = 0);
+    ROMol &mol, const std::vector<unsigned int> *atomIds = nullptr,
+    const std::vector<unsigned int> *confIds = nullptr,
+    const RDNumeric::DoubleVector *weights = nullptr, bool reflect = false,
+    unsigned int maxIters = 50, std::vector<double> *RMSlist = nullptr);
 }  // namespace MolAlign
 }  // namespace RDKit
 #endif

--- a/Code/GraphMol/MolAlign/AlignMolecules.h
+++ b/Code/GraphMol/MolAlign/AlignMolecules.h
@@ -131,6 +131,33 @@ RDKIT_MOLALIGN_EXPORT double getBestRMS(
     const std::vector<MatchVectType> &map = std::vector<MatchVectType>(),
     int maxMatches = 1e6, bool doAlignment=true);
 
+
+//! Returns the RMS between two molecules, taking symmetry into account.
+/*!
+  This function will attempt to align all permutations of matching atom
+  orders in both molecules, for some molecules it will lead to 'combinatorial
+  explosion' especially if hydrogens are present.
+
+  \param probeMol   the molecule to be aligned to the reference
+  \param refMol     the reference molecule
+  \param probeId    (optional) probe conformation to use
+  \param refId      (optional) reference conformation to use
+  \param map        (optional) a vector of vectors of pairs of atom IDs
+                    (probe AtomId, ref AtomId) used to compute the alignments.
+                    If not provided, these will be generated using a
+                    substructure search.
+  \param maxMatches (optional) if map is empty, this will be the max number of
+                    matches found in a SubstructMatch().
+  \param weights    (optional) weights for each pair of atom.
+
+  <b>Returns</b>
+  Best RMSD value found
+*/
+RDKIT_MOLALIGN_EXPORT double CalcRMS(
+    ROMol &probeMol, const ROMol &refMol, int prbCid=-1, int refCid=-1,
+    const std::vector<MatchVectType> &map = std::vector<MatchVectType>(), int maxMatches=1e6,
+    const RDNumeric::DoubleVector *weights = 0);
+
 //! Align the conformations of a molecule using a common set of atoms. If
 // the molecules contains queries, then the queries must also match exactly.
 

--- a/Code/GraphMol/MolAlign/Wrap/rdMolAlign.cpp
+++ b/Code/GraphMol/MolAlign/Wrap/rdMolAlign.cpp
@@ -145,7 +145,8 @@ PyObject *getMolAlignTransform(const ROMol &prbMol, const ROMol &refMol,
                                python::object atomMap = python::list(),
                                python::object weights = python::list(),
                                bool reflect = false,
-                               unsigned int maxIters = 50) {
+                               unsigned int maxIters = 50,
+                               bool doAlignment = true) {
   MatchVectType *aMap = _translateAtomMap(atomMap);
   unsigned int nAtms;
   if (aMap) {
@@ -164,7 +165,7 @@ PyObject *getMolAlignTransform(const ROMol &prbMol, const ROMol &refMol,
   {
     NOGIL gil;
     rmsd = MolAlign::getAlignmentTransform(
-        prbMol, refMol, trans, prbCid, refCid, aMap, wtsVec, reflect, maxIters);
+        prbMol, refMol, trans, prbCid, refCid, aMap, wtsVec, reflect, maxIters, doAlignment);
   }
   if (aMap) {
     delete aMap;
@@ -179,7 +180,8 @@ PyObject *getMolAlignTransform(const ROMol &prbMol, const ROMol &refMol,
 double AlignMolecule(ROMol &prbMol, const ROMol &refMol, int prbCid = -1,
                      int refCid = -1, python::object atomMap = python::list(),
                      python::object weights = python::list(),
-                     bool reflect = false, unsigned int maxIters = 50) {
+                     bool reflect = false, unsigned int maxIters = 50,
+                     bool doAlignment = true) {
   MatchVectType *aMap = _translateAtomMap(atomMap);
   unsigned int nAtms;
   if (aMap) {
@@ -198,7 +200,7 @@ double AlignMolecule(ROMol &prbMol, const ROMol &refMol, int prbCid = -1,
   {
     NOGIL gil;
     rmsd = MolAlign::alignMol(prbMol, refMol, prbCid, refCid, aMap, wtsVec,
-                              reflect, maxIters);
+                              reflect, maxIters, doAlignment);
   }
   if (aMap) {
     delete aMap;
@@ -210,7 +212,7 @@ double AlignMolecule(ROMol &prbMol, const ROMol &refMol, int prbCid = -1,
 }
 
 double GetBestRMS(ROMol &prbMol, ROMol &refMol, int prbId, int refId,
-                  python::object map, int maxMatches) {
+                  python::object map, int maxMatches, bool doAlignment) {
   std::vector<MatchVectType> aMapVec;
   if (map != python::object()) {
     aMapVec = _translateAtomMapVector(map);
@@ -220,7 +222,7 @@ double GetBestRMS(ROMol &prbMol, ROMol &refMol, int prbId, int refId,
   {
     NOGIL gil;
     rmsd =
-        MolAlign::getBestRMS(prbMol, refMol, prbId, refId, aMapVec, maxMatches);
+        MolAlign::getBestRMS(prbMol, refMol, prbId, refId, aMapVec, maxMatches, doAlignment);
   }
   return rmsd;
 }
@@ -627,7 +629,7 @@ BOOST_PYTHON_MODULE(rdMolAlign) {
       (python::arg("prbMol"), python::arg("refMol"), python::arg("prbCid") = -1,
        python::arg("refCid") = -1, python::arg("atomMap") = python::list(),
        python::arg("weights") = python::list(), python::arg("reflect") = false,
-       python::arg("maxIters") = 50),
+       python::arg("maxIters") = 50, python::arg("doAlignment") = true),
       docString.c_str());
 
   docString =
@@ -661,7 +663,7 @@ BOOST_PYTHON_MODULE(rdMolAlign) {
       (python::arg("prbMol"), python::arg("refMol"), python::arg("prbCid") = -1,
        python::arg("refCid") = -1, python::arg("atomMap") = python::list(),
        python::arg("weights") = python::list(), python::arg("reflect") = false,
-       python::arg("maxIters") = 50),
+       python::arg("maxIters") = 50, python::arg("doAlignment") = true),
       docString.c_str());
 
   docString =
@@ -695,7 +697,7 @@ BOOST_PYTHON_MODULE(rdMolAlign) {
       "GetBestRMS", RDKit::GetBestRMS,
       (python::arg("prbMol"), python::arg("refMol"), python::arg("prbId") = -1,
        python::arg("refId") = -1, python::arg("map") = python::object(),
-       python::arg("maxMatches") = 1000000),
+       python::arg("maxMatches") = 1000000, python::arg("doAlignment") = true),
       docString.c_str());
 
   docString =
@@ -704,14 +706,15 @@ BOOST_PYTHON_MODULE(rdMolAlign) {
       The first conformation in the molecule is used as the reference\n\
      \n\
      ARGUMENTS\n\
-      - mol       molecule of interest\n\
-      - atomIds   List of atom ids to use a points for alingment - defaults to all atoms\n\
-      - confIds   Ids of conformations to align - defaults to all conformers \n\
-      - weights   Optionally specify weights for each of the atom pairs\n\
-      - reflect   if true reflect the conformation of the probe molecule\n\
-      - maxIters  maximum number of iterations used in mimizing the RMSD\n\
-      - RMSlist   if provided, fills in the RMS values between the reference\n\
-		  conformation and the other aligned conformations\n\
+      - mol          molecule of interest\n\
+      - atomIds      List of atom ids to use a points for alingment - defaults to all atoms\n\
+      - confIds      Ids of conformations to align - defaults to all conformers \n\
+      - weights      Optionally specify weights for each of the atom pairs\n\
+      - reflect      if true reflect the conformation of the probe molecule\n\
+      - maxIters     maximum number of iterations used in mimizing the RMSD\n\
+      - RMSlist      if provided, fills in the RMS values between the reference\n\
+		     conformation and the other aligned conformations\n\
+      - doAlignment  (optional) compute rmsd with or without alignment\n\
        \n\
     \n";
   python::def(

--- a/Code/GraphMol/MolAlign/Wrap/rdMolAlign.cpp
+++ b/Code/GraphMol/MolAlign/Wrap/rdMolAlign.cpp
@@ -145,8 +145,7 @@ PyObject *getMolAlignTransform(const ROMol &prbMol, const ROMol &refMol,
                                python::object atomMap = python::list(),
                                python::object weights = python::list(),
                                bool reflect = false,
-                               unsigned int maxIters = 50,
-                               bool doAlignment = true) {
+                               unsigned int maxIters = 50) {
   MatchVectType *aMap = _translateAtomMap(atomMap);
   unsigned int nAtms;
   if (aMap) {
@@ -165,7 +164,7 @@ PyObject *getMolAlignTransform(const ROMol &prbMol, const ROMol &refMol,
   {
     NOGIL gil;
     rmsd = MolAlign::getAlignmentTransform(
-        prbMol, refMol, trans, prbCid, refCid, aMap, wtsVec, reflect, maxIters, doAlignment);
+        prbMol, refMol, trans, prbCid, refCid, aMap, wtsVec, reflect, maxIters);
   }
   if (aMap) {
     delete aMap;
@@ -180,8 +179,7 @@ PyObject *getMolAlignTransform(const ROMol &prbMol, const ROMol &refMol,
 double AlignMolecule(ROMol &prbMol, const ROMol &refMol, int prbCid = -1,
                      int refCid = -1, python::object atomMap = python::list(),
                      python::object weights = python::list(),
-                     bool reflect = false, unsigned int maxIters = 50,
-                     bool doAlignment = true) {
+                     bool reflect = false, unsigned int maxIters = 50) {
   MatchVectType *aMap = _translateAtomMap(atomMap);
   unsigned int nAtms;
   if (aMap) {
@@ -200,7 +198,7 @@ double AlignMolecule(ROMol &prbMol, const ROMol &refMol, int prbCid = -1,
   {
     NOGIL gil;
     rmsd = MolAlign::alignMol(prbMol, refMol, prbCid, refCid, aMap, wtsVec,
-                              reflect, maxIters, doAlignment);
+                              reflect, maxIters);
   }
   if (aMap) {
     delete aMap;
@@ -212,7 +210,7 @@ double AlignMolecule(ROMol &prbMol, const ROMol &refMol, int prbCid = -1,
 }
 
 double GetBestRMS(ROMol &prbMol, ROMol &refMol, int prbId, int refId,
-                  python::object map, int maxMatches, bool doAlignment) {
+                  python::object map, int maxMatches) {
   std::vector<MatchVectType> aMapVec;
   if (map != python::object()) {
     aMapVec = _translateAtomMapVector(map);
@@ -222,7 +220,7 @@ double GetBestRMS(ROMol &prbMol, ROMol &refMol, int prbId, int refId,
   {
     NOGIL gil;
     rmsd =
-        MolAlign::getBestRMS(prbMol, refMol, prbId, refId, aMapVec, maxMatches, doAlignment);
+        MolAlign::getBestRMS(prbMol, refMol, prbId, refId, aMapVec, maxMatches);
   }
   return rmsd;
 }
@@ -646,7 +644,7 @@ BOOST_PYTHON_MODULE(rdMolAlign) {
       (python::arg("prbMol"), python::arg("refMol"), python::arg("prbCid") = -1,
        python::arg("refCid") = -1, python::arg("atomMap") = python::list(),
        python::arg("weights") = python::list(), python::arg("reflect") = false,
-       python::arg("maxIters") = 50, python::arg("doAlignment") = true),
+       python::arg("maxIters") = 50),
       docString.c_str());
 
   docString =
@@ -680,7 +678,7 @@ BOOST_PYTHON_MODULE(rdMolAlign) {
       (python::arg("prbMol"), python::arg("refMol"), python::arg("prbCid") = -1,
        python::arg("refCid") = -1, python::arg("atomMap") = python::list(),
        python::arg("weights") = python::list(), python::arg("reflect") = false,
-       python::arg("maxIters") = 50, python::arg("doAlignment") = true),
+       python::arg("maxIters") = 50),
       docString.c_str());
 
   docString =
@@ -714,7 +712,7 @@ BOOST_PYTHON_MODULE(rdMolAlign) {
       "GetBestRMS", RDKit::GetBestRMS,
       (python::arg("prbMol"), python::arg("refMol"), python::arg("prbId") = -1,
        python::arg("refId") = -1, python::arg("map") = python::object(),
-       python::arg("maxMatches") = 1000000, python::arg("doAlignment") = true),
+       python::arg("maxMatches") = 1000000),
       docString.c_str());
   
   docString =
@@ -764,7 +762,6 @@ BOOST_PYTHON_MODULE(rdMolAlign) {
       - maxIters     maximum number of iterations used in mimizing the RMSD\n\
       - RMSlist      if provided, fills in the RMS values between the reference\n\
 		     conformation and the other aligned conformations\n\
-      - doAlignment  (optional) compute rmsd with or without alignment\n\
        \n\
     \n";
   python::def(

--- a/Code/GraphMol/MolAlign/Wrap/rdMolAlign.cpp
+++ b/Code/GraphMol/MolAlign/Wrap/rdMolAlign.cpp
@@ -227,6 +227,23 @@ double GetBestRMS(ROMol &prbMol, ROMol &refMol, int prbId, int refId,
   return rmsd;
 }
 
+double CalcRMS(ROMol &prbMol, ROMol &refMol, int prbCid, int refCid,
+               python::object map, int maxMatches,
+               python::object weights = python::list()) {
+  std::vector<MatchVectType> aMapVec;
+  if (map != python::object()) {
+    aMapVec = _translateAtomMapVector(map);
+  }
+  RDNumeric::DoubleVector *wtsVec = _translateWeights(weights);
+  double rmsd;
+  {
+    NOGIL gil;
+    rmsd =
+        MolAlign::CalcRMS(prbMol, refMol, prbCid, refCid, aMapVec, maxMatches, wtsVec);
+  }
+  return rmsd;
+}
+
 namespace MolAlign {
 class PyO3A {
  public:
@@ -698,6 +715,39 @@ BOOST_PYTHON_MODULE(rdMolAlign) {
       (python::arg("prbMol"), python::arg("refMol"), python::arg("prbId") = -1,
        python::arg("refId") = -1, python::arg("map") = python::object(),
        python::arg("maxMatches") = 1000000, python::arg("doAlignment") = true),
+      docString.c_str());
+  
+  docString =
+      "Returns the RMS between two molecules, taking symmetry into account.\n\
+      \n\
+       Note:\n\
+       This function will attempt to align all permutations of matching atom\n\
+       orders in both molecules, for some molecules it will lead to\n\
+       'combinatorial explosion' especially if hydrogens are present.\n\
+       Use 'rdkit.Chem.AllChem.AlignMol' to align molecules without changing\n\
+       the atom order.\n\
+      \n\
+       ARGUMENTS\n\
+        - prbMol:      the molecule to be aligned to the reference\n\
+        - refMol:      the reference molecule\n\
+        - prbId:       (optional) probe conformation to use\n\
+        - refId:       (optional) reference conformation to use\n\
+        - map:         (optional) a list of lists of (probeAtomId,refAtomId)\n\
+                       tuples with the atom-atom mappings of the two\n\
+                       molecules. If not provided, these will be generated\n\
+                       using a substructure search.\n\
+        - maxMatches:  (optional) if map isn't specified, this will be\n\
+                       the max number of matches found in a SubstructMatch()\n\
+        - weights:     (optional) weights for mapping \n\
+       \n\
+      RETURNS\n\
+      The best RMSD found\n\
+    \n";
+  python::def(
+      "CalcRMS", RDKit::CalcRMS,
+      (python::arg("prbMol"), python::arg("refMol"), python::arg("prbId") = -1,
+       python::arg("refId") = -1, python::arg("map") = python::object(),
+       python::arg("maxMatches") = 1000000, python::arg("weights") = python::list()),
       docString.c_str());
 
   docString =

--- a/Code/JavaWrappers/ROMol.i
+++ b/Code/JavaWrappers/ROMol.i
@@ -462,7 +462,7 @@ void setPreferCoordGen(bool);
                   int prbCid=-1, int refCid=-1,
                   const std::vector<std::pair<int,int> > *atomMap=0,
                   const RDNumeric::DoubleVector *weights=0,
-                  bool reflect=false, unsigned int maxIters=50, bool doAlignment=true)) {
+                  bool reflect=false, unsigned int maxIters=50, bool doAlignment=true) {
     return RDKit::MolAlign::alignMol(*($self), refMol, prbCid, refCid, atomMap, weights, reflect, maxIters, doAlignment);
   }
 

--- a/Code/JavaWrappers/ROMol.i
+++ b/Code/JavaWrappers/ROMol.i
@@ -462,14 +462,14 @@ void setPreferCoordGen(bool);
                   int prbCid=-1, int refCid=-1,
                   const std::vector<std::pair<int,int> > *atomMap=0,
                   const RDNumeric::DoubleVector *weights=0,
-                  bool reflect=false, unsigned int maxIters=50, bool doAlignment=true) {
-    return RDKit::MolAlign::alignMol(*($self), refMol, prbCid, refCid, atomMap, weights, reflect, maxIters, doAlignment);
+                  bool reflect=false, unsigned int maxIters=50) {
+    return RDKit::MolAlign::alignMol(*($self), refMol, prbCid, refCid, atomMap, weights, reflect, maxIters);
   }
 
   void alignMolConformers(ROMol &mol, const std::vector<unsigned int> *atomIds=0,
                           const std::vector<unsigned int> *confIds=0,
                           const RDNumeric::DoubleVector  *weights=0,
-                          bool reflect=false, unsigned int maxIters=50)) {
+                          bool reflect=false, unsigned int maxIters=50) {
     RDKit::MolAlign::alignMolConformers(*($self), atomIds, confIds, weights, reflect, maxIters);
   }
 
@@ -478,8 +478,8 @@ void setPreferCoordGen(bool);
                              RDGeom::Transform3D &trans, int prbCid = -1,
                              int refCid = -1, const std::vector<std::pair<int,int> > *atomMap = 0,
                              const RDNumeric::DoubleVector *weights = 0,
-                             bool reflect = false, unsigned int maxIters = 50, bool doAlignment=true){
-     return RDKit::MolAlign::getAlignmentTransform(*($self), refMol, trans, prbCid, refCid, atomMap, weights, reflect, maxIters, doAlignment);
+                             bool reflect = false, unsigned int maxIters = 50){
+     return RDKit::MolAlign::getAlignmentTransform(*($self), refMol, trans, prbCid, refCid, atomMap, weights, reflect, maxIters);
   }
 
   /* From GraphMol/MolAlign/AlignMolecules */

--- a/Code/JavaWrappers/ROMol.i
+++ b/Code/JavaWrappers/ROMol.i
@@ -462,14 +462,14 @@ void setPreferCoordGen(bool);
                   int prbCid=-1, int refCid=-1,
                   const std::vector<std::pair<int,int> > *atomMap=0,
                   const RDNumeric::DoubleVector *weights=0,
-                  bool reflect=false, unsigned int maxIters=50) {
-    return RDKit::MolAlign::alignMol(*($self), refMol, prbCid, refCid, atomMap, weights, reflect, maxIters);
+                  bool reflect=false, unsigned int maxIters=50, bool doAlignment=true)) {
+    return RDKit::MolAlign::alignMol(*($self), refMol, prbCid, refCid, atomMap, weights, reflect, maxIters, doAlignment);
   }
 
   void alignMolConformers(ROMol &mol, const std::vector<unsigned int> *atomIds=0,
                           const std::vector<unsigned int> *confIds=0,
                           const RDNumeric::DoubleVector  *weights=0,
-                          bool reflect=false, unsigned int maxIters=50) {
+                          bool reflect=false, unsigned int maxIters=50)) {
     RDKit::MolAlign::alignMolConformers(*($self), atomIds, confIds, weights, reflect, maxIters);
   }
 
@@ -478,8 +478,8 @@ void setPreferCoordGen(bool);
                              RDGeom::Transform3D &trans, int prbCid = -1,
                              int refCid = -1, const std::vector<std::pair<int,int> > *atomMap = 0,
                              const RDNumeric::DoubleVector *weights = 0,
-                             bool reflect = false, unsigned int maxIters = 50){
-     return RDKit::MolAlign::getAlignmentTransform(*($self), refMol, trans, prbCid, refCid, atomMap, weights, reflect, maxIters);
+                             bool reflect = false, unsigned int maxIters = 50, bool doAlignment=true){
+     return RDKit::MolAlign::getAlignmentTransform(*($self), refMol, trans, prbCid, refCid, atomMap, weights, reflect, maxIters, doAlignment);
   }
 
   /* From GraphMol/MolAlign/AlignMolecules */


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! 
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->
https://github.com/rdkit/rdkit/issues/1820

#### What does this implement/fix? Explain your changes.
Two common tasks in molecular docking results analysis are comparing predicted poses of a molecule with the reference one, and clustering the predicted poses. An extension of the current RDKit's function for symmetry-adapted RMSD computation would be helpful in such cases, where two molecules are compared with respect to their positions in a binding pocket, and alignment is excessive.

#### Any other comments?
Nope
