### PR TITLE
fix a small inconsistency in the name of the inchi package

### DIFF
--- a/Code/cmake/Modules/FindInchi.cmake
+++ b/Code/cmake/Modules/FindInchi.cmake
@@ -18,7 +18,7 @@ else()
   find_path(INCHI_INCLUDE_DIR NAMES inchi_api.h PATHS /usr/include/inchi )
   find_library(INCHI_LIBRARY NAMES inchi Inchi)
   include(FindPackageHandleStandardArgs)
-  find_package_handle_standard_args(INCHI
+  find_package_handle_standard_args(Inchi
 	  "Could NOT find InChI in system locations" INCHI_LIBRARY
 	  INCHI_INCLUDE_DIR)
   set(INCHI_INCLUDE_DIRS ${INCHI_INCLUDE_DIR} )


### PR DESCRIPTION
with cmake 3.17.2 the original code produced the following warning:
"The package name passed to `find_package_handle_standard_args` (INCHI) does
not match the name of the calling package (Inchi).  This can lead to
problems in calling code that expects `find_package` result variables
(e.g., `_FOUND`) to follow a certain pattern."

<!--
Thanks for contributing a pull request! 
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.


#### Any other comments?

