### PR TITLE
Remove usage of the deprecated random_shuffle() function

### DIFF
--- a/Code/GraphMol/hanoitest.cpp
+++ b/Code/GraphMol/hanoitest.cpp
@@ -20,7 +20,7 @@
 
 #include <iostream>
 #include <vector>
-#include <boost/random.hpp>
+#include <random>
 #include <cstdlib>
 
 using namespace RDKit;
@@ -901,11 +901,10 @@ void _renumberTest(const ROMol *m, std::string inSmiles,
     idxV[i] = i;
   }
 
-  std::srand(0xF00D);
   for (unsigned int i = 0; i < numRenumbers; ++i) {
     //      std::cerr<<"---------------------------------------------------"<<std::endl;
     std::vector<unsigned int> nVect(idxV);
-    std::random_shuffle(nVect.begin(), nVect.end());
+    std::shuffle(nVect.begin(), nVect.end(), std::mt19937(0xf00d));
     //      for(unsigned int j=0;j<m->getNumAtoms();++j){
     //        std::cerr<<"Renumber: "<<nVect[j]<<"->"<<j<<std::endl;
     //      }
@@ -940,10 +939,9 @@ void _renumberTest2(const ROMol *m, std::string inSmiles,
     idxV[i] = i;
   }
 
-  std::srand(0xF00D);
   for (unsigned int i = 0; i < numRenumbers; ++i) {
     std::vector<unsigned int> nVect(idxV);
-    std::random_shuffle(nVect.begin(), nVect.end());
+    std::shuffle(nVect.begin(), nVect.end(), std::mt19937(0xf00d));
 
     ROMol *nm = _renumber(m, nVect, inSmiles);
 

--- a/Code/GraphMol/molopstest.cpp
+++ b/Code/GraphMol/molopstest.cpp
@@ -26,6 +26,7 @@
 #include <map>
 #include <algorithm>
 #include <boost/foreach.hpp>
+#include <random>
 
 #ifndef M_PI
 #define M_PI 3.14159265358979323846
@@ -265,7 +266,6 @@ void test3() {
   TEST_ASSERT(bfs == 2);
   delete m;
 
-
   // Counterexamples in ring perception figure 4:
   //  * The native Figueras algorithm cannot work on this molecule, it will
   //    fail after finding one ring. Naive modified Figueras finds a 6 membered
@@ -281,7 +281,6 @@ void test3() {
     TEST_ASSERT(bring.size() < 6);
   }
   delete m;
-
 
   smi = "C1CC2C1CCC2";
   m = SmilesToMol(smi);
@@ -4681,7 +4680,7 @@ void _renumberTest(const ROMol *m) {
   std::string refSmi = MolToSmiles(*m, true);
   for (unsigned int i = 0; i < m->getNumAtoms(); ++i) {
     std::vector<unsigned int> nVect(idxV);
-    std::random_shuffle(nVect.begin(), nVect.end());
+    std::shuffle(nVect.begin(), nVect.end(), std::mt19937(0xf00d));
     // std::copy(nVect.begin(),nVect.end(),std::ostream_iterator<int>(std::cerr,",
     // "));
     // std::cerr<<std::endl;
@@ -7610,7 +7609,6 @@ void testRingFamilies() {
     TEST_ASSERT(numRings == 6);
     numRings = m->getRingInfo()->numRings();
     TEST_ASSERT(numRings == 6);
-
 
     delete m;
   }


### PR DESCRIPTION
`random_shuffle()` is deprecated in c++14 and removed in c++17, so we remove it here.
