### PR TITLE
clang-tidy modernize-use-default-member-init and modernize-use-emplace

### DIFF
--- a/Code/Catalogs/Catalog.h
+++ b/Code/Catalogs/Catalog.h
@@ -43,7 +43,7 @@ class Catalog {
   typedef paramType paramType_t;
 
   //------------------------------------
-  Catalog() : d_fpLength(0), dp_cParams(nullptr){};
+  Catalog() :  dp_cParams(nullptr){};
 
   //------------------------------------
   virtual ~Catalog() { delete dp_cParams; }
@@ -106,7 +106,7 @@ class Catalog {
   // in the catalog and does not correspond with the
   // id of the entry in the catalog.
   // this is more along the lines of bitId
-  unsigned int d_fpLength;  //!< the length of our fingerprint
+  unsigned int d_fpLength{0};  //!< the length of our fingerprint
   paramType *dp_cParams;    //!< our params object
 };
 

--- a/Code/ChemicalFeatures/FreeChemicalFeature.h
+++ b/Code/ChemicalFeatures/FreeChemicalFeature.h
@@ -33,7 +33,7 @@ class RDKIT_CHEMICALFEATURES_EXPORT FreeChemicalFeature
 
   //! start with everything blank
   FreeChemicalFeature()
-      : d_id(-1),
+      : 
         d_family(""),
         d_type(""),
         d_position(RDGeom::Point3D(0.0, 0.0, 0.0)) {}
@@ -85,7 +85,7 @@ class RDKIT_CHEMICALFEATURES_EXPORT FreeChemicalFeature
   void initFromString(const std::string &pickle);
 
  private:
-  int d_id;
+  int d_id{-1};
   std::string d_family;
   std::string d_type;
   RDGeom::Point3D d_position;

--- a/Code/DataStructs/ExplicitBitVect.h
+++ b/Code/DataStructs/ExplicitBitVect.h
@@ -28,7 +28,7 @@
  */
 class RDKIT_DATASTRUCTS_EXPORT ExplicitBitVect : public BitVect {
  public:
-  ExplicitBitVect() : dp_bits(nullptr), d_size(0), d_numOnBits(0){};
+  ExplicitBitVect()  {};
   //! initialize with a particular size;
   explicit ExplicitBitVect(unsigned int size)
       : dp_bits(nullptr), d_size(0), d_numOnBits(0) {
@@ -78,7 +78,7 @@ class RDKIT_DATASTRUCTS_EXPORT ExplicitBitVect : public BitVect {
   void clearBits() { dp_bits->reset(); };
   std::string toString() const;
 
-  boost::dynamic_bitset<> *dp_bits;  //!< our raw storage
+  boost::dynamic_bitset<> *dp_bits{nullptr};  //!< our raw storage
 
   bool operator==(const ExplicitBitVect &o) const {
     return *dp_bits == *o.dp_bits;
@@ -88,8 +88,8 @@ class RDKIT_DATASTRUCTS_EXPORT ExplicitBitVect : public BitVect {
   }
 
  private:
-  unsigned int d_size;
-  unsigned int d_numOnBits;
+  unsigned int d_size{0};
+  unsigned int d_numOnBits{0};
   void _initForSize(const unsigned int size);
 };
 

--- a/Code/DataStructs/FPBReader.cpp
+++ b/Code/DataStructs/FPBReader.cpp
@@ -470,7 +470,7 @@ void tanimotoNeighbors(const FPBReader_impl *dp_impl, const boost::uint8_t *bv,
           CalcBitmapTanimoto(dbv + j * dp_impl->numBytesStoredPerFingerprint,
                              bv, dp_impl->numBytesStoredPerFingerprint);
       if (tani >= threshold) {
-        res.push_back(std::make_pair(tani, i + j));
+        res.emplace_back(tani, i + j);
       }
     }
   }
@@ -524,7 +524,7 @@ void tverskyNeighbors(const FPBReader_impl *dp_impl, const boost::uint8_t *bv,
     // std::cerr << "  i:" << i << " " << tani << " ? " << threshold <<
     // std::endl;
     if (sim >= threshold) {
-      res.push_back(std::make_pair(sim, i));
+      res.emplace_back(sim, i);
     }
   }
   if (dp_impl->df_lazy) {

--- a/Code/DataStructs/FPBReader.h
+++ b/Code/DataStructs/FPBReader.h
@@ -58,11 +58,8 @@ struct FPBReader_impl;
 class RDKIT_DATASTRUCTS_EXPORT FPBReader {
  public:
   FPBReader()
-      : dp_istrm(nullptr),
-        dp_impl(nullptr),
-        df_owner(false),
-        df_init(false),
-        df_lazyRead(false){};
+      
+        {};
   //! ctor for reading from a named file
   /*!
   \param fname the name of the file to reads
@@ -248,11 +245,11 @@ class RDKIT_DATASTRUCTS_EXPORT FPBReader {
       const ExplicitBitVect &ebv) const;
 
  private:
-  std::istream *dp_istrm;
-  detail::FPBReader_impl *dp_impl;  // implementation details
-  bool df_owner;
-  bool df_init;
-  bool df_lazyRead;
+  std::istream *dp_istrm{nullptr};
+  detail::FPBReader_impl *dp_impl{nullptr};  // implementation details
+  bool df_owner{false};
+  bool df_init{false};
+  bool df_lazyRead{false};
 
   // disable automatic copy constructors and assignment operators
   // for this class and its subclasses.  They will likely be

--- a/Code/DataStructs/MultiFPBReader.cpp
+++ b/Code/DataStructs/MultiFPBReader.cpp
@@ -199,7 +199,7 @@ void get_containing_nbrs(
   for (unsigned int i = 0; i < d_readers.size(); ++i) {
     std::vector<unsigned int> &r_res = accum[i];
     BOOST_FOREACH (unsigned int ri, r_res) {
-      res.push_back(std::make_pair(ri, i));
+      res.emplace_back(ri, i);
     }
   }
 

--- a/Code/DataStructs/MultiFPBReader.h
+++ b/Code/DataStructs/MultiFPBReader.h
@@ -55,7 +55,7 @@ class RDKIT_DATASTRUCTS_EXPORT MultiFPBReader {
  public:
   typedef boost::tuple<double, unsigned int, unsigned int> ResultTuple;
   MultiFPBReader()
-      : df_init(false), df_initOnSearch(false), df_takeOwnership(false){};
+       {};
 
   /*!
     \param initOnSearch: if this is true, the \c init() method on child readers
@@ -198,7 +198,7 @@ class RDKIT_DATASTRUCTS_EXPORT MultiFPBReader {
 
  private:
   std::vector<FPBReader *> d_readers;
-  bool df_init, df_initOnSearch, df_takeOwnership;
+  bool df_init{false}, df_initOnSearch{false}, df_takeOwnership{false};
 
   // disable automatic copy constructors and assignment operators
   // for this class and its subclasses.  They will likely be

--- a/Code/DataStructs/SparseBitVect.h
+++ b/Code/DataStructs/SparseBitVect.h
@@ -33,7 +33,7 @@ typedef IntSet::const_iterator IntSetConstIter;
  */
 class RDKIT_DATASTRUCTS_EXPORT SparseBitVect : public BitVect {
  public:
-  SparseBitVect() : dp_bits(nullptr), d_size(0){};
+  SparseBitVect()  {};
   //! initialize with a particular size;
   explicit SparseBitVect(unsigned int size) : dp_bits(nullptr), d_size(0) {
     _initForSize(size);
@@ -83,7 +83,7 @@ class RDKIT_DATASTRUCTS_EXPORT SparseBitVect : public BitVect {
 
   void getOnBits(IntVect &v) const;
   void clearBits() { dp_bits->clear(); };
-  IntSet *dp_bits;  //!< our raw data, exposed for the sake of efficiency
+  IntSet *dp_bits{nullptr};  //!< our raw data, exposed for the sake of efficiency
 
   bool operator==(const SparseBitVect &o) const {
     return *dp_bits == *o.dp_bits;
@@ -93,7 +93,7 @@ class RDKIT_DATASTRUCTS_EXPORT SparseBitVect : public BitVect {
   }
 
  private:
-  unsigned int d_size;
+  unsigned int d_size{0};
   void _initForSize(const unsigned int size);
 };
 

--- a/Code/DistGeom/ChiralViolationContrib.h
+++ b/Code/DistGeom/ChiralViolationContrib.h
@@ -17,13 +17,8 @@ class RDKIT_DISTGEOMETRY_EXPORT ChiralViolationContrib
     : public ForceFields::ForceFieldContrib {
  public:
   ChiralViolationContrib()
-      : d_idx1(0),
-        d_idx2(0),
-        d_idx3(0),
-        d_idx4(0),
-        d_volLower(0.0),
-        d_volUpper(0.0),
-        d_weight(0.0){};
+      
+        {};
 
   //! Constructor
   /*!
@@ -93,10 +88,10 @@ class RDKIT_DISTGEOMETRY_EXPORT ChiralViolationContrib
   }
 
  private:
-  unsigned int d_idx1, d_idx2, d_idx3, d_idx4;
-  double d_volLower;
-  double d_volUpper;
-  double d_weight;
+  unsigned int d_idx1{0}, d_idx2{0}, d_idx3{0}, d_idx4{0};
+  double d_volLower{0.0};
+  double d_volUpper{0.0};
+  double d_weight{0.0};
 };
 }  // namespace DistGeom
 

--- a/Code/DistGeom/DistViolationContrib.h
+++ b/Code/DistGeom/DistViolationContrib.h
@@ -20,7 +20,7 @@ class RDKIT_DISTGEOMETRY_EXPORT DistViolationContrib
     : public ForceFields::ForceFieldContrib {
  public:
   DistViolationContrib()
-      : d_end1Idx(0), d_end2Idx(0), d_ub(1000.0), d_lb(0.0), d_weight(1.0){};
+       {};
 
   //! Constructor
   /*!
@@ -43,10 +43,10 @@ class RDKIT_DISTGEOMETRY_EXPORT DistViolationContrib
   };
 
  private:
-  unsigned int d_end1Idx, d_end2Idx;  //!< indices of end points
-  double d_ub;      //!< upper bound on the distance between d_end1Idx,d_end2Idx
-  double d_lb;      //!< lower bound on the distance between d_end1Idx,d_end2Idx
-  double d_weight;  //!< used to adjust relative contribution weights
+  unsigned int d_end1Idx{0}, d_end2Idx{0};  //!< indices of end points
+  double d_ub{1000.0};      //!< upper bound on the distance between d_end1Idx,d_end2Idx
+  double d_lb{0.0};      //!< lower bound on the distance between d_end1Idx,d_end2Idx
+  double d_weight{1.0};  //!< used to adjust relative contribution weights
 };
 }  // namespace DistGeom
 

--- a/Code/DistGeom/FourthDimContrib.h
+++ b/Code/DistGeom/FourthDimContrib.h
@@ -15,7 +15,7 @@ namespace DistGeom {
 class RDKIT_DISTGEOMETRY_EXPORT FourthDimContrib
     : public ForceFields::ForceFieldContrib {
  public:
-  FourthDimContrib() : d_idx(0), d_weight(0.0){};
+  FourthDimContrib()  {};
 
   //! Constructor
   /*!
@@ -57,8 +57,8 @@ class RDKIT_DISTGEOMETRY_EXPORT FourthDimContrib
   };
 
  private:
-  unsigned int d_idx;
-  double d_weight;
+  unsigned int d_idx{0};
+  double d_weight{0.0};
 };
 }  // namespace DistGeom
 

--- a/Code/ForceField/Contrib.h
+++ b/Code/ForceField/Contrib.h
@@ -19,7 +19,7 @@ class RDKIT_FORCEFIELD_EXPORT ForceFieldContrib {
  public:
   friend class ForceField;
 
-  ForceFieldContrib() : dp_forceField(nullptr){};
+  ForceFieldContrib()  {};
   ForceFieldContrib(ForceFields::ForceField *owner) : dp_forceField(owner){};
   virtual ~ForceFieldContrib(){};
 
@@ -33,7 +33,7 @@ class RDKIT_FORCEFIELD_EXPORT ForceFieldContrib {
   virtual ForceFieldContrib *copy() const = 0;
 
  protected:
-  ForceField *dp_forceField;  //!< our owning ForceField
+  ForceField *dp_forceField{nullptr};  //!< our owning ForceField
 };
 }  // namespace ForceFields
 

--- a/Code/ForceField/ForceField.h
+++ b/Code/ForceField/ForceField.h
@@ -81,10 +81,8 @@ class RDKIT_FORCEFIELD_EXPORT ForceField {
  public:
   //! construct with a dimension
   ForceField(unsigned int dimension = 3)
-      : d_dimension(dimension),
-        df_init(false),
-        d_numPoints(0),
-        dp_distMat(nullptr){};
+      : d_dimension(dimension)
+        {};
 
   ~ForceField();
 
@@ -232,9 +230,9 @@ class RDKIT_FORCEFIELD_EXPORT ForceField {
 
  protected:
   unsigned int d_dimension;
-  bool df_init;                      //!< whether or not we've been initialized
-  unsigned int d_numPoints;          //!< the number of active points
-  double *dp_distMat;                //!< our internal distance matrix
+  bool df_init{false};                      //!< whether or not we've been initialized
+  unsigned int d_numPoints{0};          //!< the number of active points
+  double *dp_distMat{nullptr};                //!< our internal distance matrix
   RDGeom::PointPtrVect d_positions;  //!< pointers to the points we're using
   ContribPtrVect d_contribs;         //!< contributions to the energy
   INT_VECT d_fixedPoints;

--- a/Code/ForceField/MMFF/AngleBend.h
+++ b/Code/ForceField/MMFF/AngleBend.h
@@ -25,7 +25,7 @@ class MMFFProp;
 //! The angle-bend term for MMFF
 class RDKIT_FORCEFIELD_EXPORT AngleBendContrib : public ForceFieldContrib {
  public:
-  AngleBendContrib() : d_at1Idx(-1), d_at2Idx(-1), d_at3Idx(-1){};
+  AngleBendContrib()  {};
   //! Constructor
   /*!
     The angle is between atom1 - atom2 - atom3
@@ -48,7 +48,7 @@ class RDKIT_FORCEFIELD_EXPORT AngleBendContrib : public ForceFieldContrib {
 
  private:
   bool d_isLinear;
-  int d_at1Idx, d_at2Idx, d_at3Idx;
+  int d_at1Idx{-1}, d_at2Idx{-1}, d_at3Idx{-1};
   double d_ka, d_theta0;
 };
 namespace Utils {

--- a/Code/ForceField/MMFF/AngleConstraint.h
+++ b/Code/ForceField/MMFF/AngleConstraint.h
@@ -22,7 +22,7 @@ namespace MMFF {
 class RDKIT_FORCEFIELD_EXPORT RDKIT_FORCEFIELD_EXPORT AngleConstraintContrib
     : public ForceFieldContrib {
  public:
-  AngleConstraintContrib() : d_at1Idx(-1), d_at2Idx(-1), d_at3Idx(-1){};
+  AngleConstraintContrib()  {};
   //! Constructor
   /*!
   \param owner       pointer to the owning ForceField
@@ -53,7 +53,7 @@ class RDKIT_FORCEFIELD_EXPORT RDKIT_FORCEFIELD_EXPORT AngleConstraintContrib
   };
 
  private:
-  int d_at1Idx, d_at2Idx, d_at3Idx;     //!< indices of atoms forming the angle
+  int d_at1Idx{-1}, d_at2Idx{-1}, d_at3Idx{-1};     //!< indices of atoms forming the angle
   double d_minAngleDeg, d_maxAngleDeg;  //!< rest amplitudes of the angle
   double d_forceConstant;  //!< force constant of the angle constraint
 };

--- a/Code/ForceField/MMFF/BondStretch.h
+++ b/Code/ForceField/MMFF/BondStretch.h
@@ -22,7 +22,7 @@ class MMFFBondStretchEmpiricalRule;
 //! The bond-stretch term for MMFF
 class RDKIT_FORCEFIELD_EXPORT BondStretchContrib : public ForceFieldContrib {
  public:
-  BondStretchContrib() : d_at1Idx(-1), d_at2Idx(-1){};
+  BondStretchContrib()  {};
   //! Constructor
   /*!
     \param owner       pointer to the owning ForceField
@@ -45,7 +45,7 @@ class RDKIT_FORCEFIELD_EXPORT BondStretchContrib : public ForceFieldContrib {
   };
 
  private:
-  int d_at1Idx, d_at2Idx;  //!< indices of end points
+  int d_at1Idx{-1}, d_at2Idx{-1};  //!< indices of end points
   double d_r0;             //!< rest length of the bond
   double d_kb;             //!< force constant of the bond
 };

--- a/Code/ForceField/MMFF/DistanceConstraint.h
+++ b/Code/ForceField/MMFF/DistanceConstraint.h
@@ -22,7 +22,7 @@ namespace MMFF {
 class RDKIT_FORCEFIELD_EXPORT DistanceConstraintContrib
     : public ForceFieldContrib {
  public:
-  DistanceConstraintContrib() : d_end1Idx(-1), d_end2Idx(-1){};
+  DistanceConstraintContrib()  {};
   //! Constructor
   /*!
     \param owner       pointer to the owning ForceField
@@ -52,7 +52,7 @@ class RDKIT_FORCEFIELD_EXPORT DistanceConstraintContrib
   };
 
  private:
-  int d_end1Idx, d_end2Idx;   //!< indices of end points
+  int d_end1Idx{-1}, d_end2Idx{-1};   //!< indices of end points
   double d_minLen, d_maxLen;  //!< rest length of the bond
   double d_forceConstant;     //!< force constant of the bond
 };

--- a/Code/ForceField/MMFF/Nonbonded.h
+++ b/Code/ForceField/MMFF/Nonbonded.h
@@ -23,7 +23,7 @@ class MMFFVdW;
 //! the van der Waals term for MMFF
 class RDKIT_FORCEFIELD_EXPORT VdWContrib : public ForceFieldContrib {
  public:
-  VdWContrib() : d_at1Idx(-1), d_at2Idx(-1){};
+  VdWContrib()  {};
 
   //! Constructor
   /*!
@@ -39,7 +39,7 @@ class RDKIT_FORCEFIELD_EXPORT VdWContrib : public ForceFieldContrib {
   virtual VdWContrib *copy() const { return new VdWContrib(*this); };
 
  private:
-  int d_at1Idx, d_at2Idx;
+  int d_at1Idx{-1}, d_at2Idx{-1};
   double d_R_ij_star;  //!< the preferred length of the contact
   double d_wellDepth;  //!< the vdW well depth (strength of the interaction)
 };
@@ -47,7 +47,7 @@ class RDKIT_FORCEFIELD_EXPORT VdWContrib : public ForceFieldContrib {
 //! the electrostatic term for MMFF
 class RDKIT_FORCEFIELD_EXPORT EleContrib : public ForceFieldContrib {
  public:
-  EleContrib() : d_at1Idx(-1), d_at2Idx(-1){};
+  EleContrib()  {};
 
   //! Constructor
   /*!
@@ -64,7 +64,7 @@ class RDKIT_FORCEFIELD_EXPORT EleContrib : public ForceFieldContrib {
   virtual EleContrib *copy() const { return new EleContrib(*this); };
 
  private:
-  int d_at1Idx, d_at2Idx;
+  int d_at1Idx{-1}, d_at2Idx{-1};
   double d_chargeTerm;  //!< q1 * q2 / D
   std::uint8_t
       d_dielModel;  //!< dielectric model (1: constant; 2: distance-dependent)

--- a/Code/ForceField/MMFF/OopBend.h
+++ b/Code/ForceField/MMFF/OopBend.h
@@ -23,7 +23,7 @@ class MMFFOop;
 //! the out-of-plane term for MMFF
 class RDKIT_FORCEFIELD_EXPORT OopBendContrib : public ForceFieldContrib {
  public:
-  OopBendContrib() : d_at1Idx(-1), d_at2Idx(-1), d_at3Idx(-1), d_at4Idx(-1){};
+  OopBendContrib()  {};
   //! Constructor
   /*!
     The Wilson angle is between the vector formed by atom2-atom4
@@ -43,7 +43,7 @@ and the angle formed by atom1-atom2-atom3
   virtual OopBendContrib *copy() const { return new OopBendContrib(*this); };
 
  private:
-  int d_at1Idx, d_at2Idx, d_at3Idx, d_at4Idx;
+  int d_at1Idx{-1}, d_at2Idx{-1}, d_at3Idx{-1}, d_at4Idx{-1};
   double d_koop;
 };
 

--- a/Code/ForceField/MMFF/PositionConstraint.h
+++ b/Code/ForceField/MMFF/PositionConstraint.h
@@ -23,7 +23,7 @@ namespace MMFF {
 class RDKIT_FORCEFIELD_EXPORT PositionConstraintContrib
     : public ForceFieldContrib {
  public:
-  PositionConstraintContrib() : d_atIdx(-1){};
+  PositionConstraintContrib()  {};
   //! Constructor
   /*!
     \param owner       pointer to the owning ForceField
@@ -45,7 +45,7 @@ class RDKIT_FORCEFIELD_EXPORT PositionConstraintContrib
   };
 
  private:
-  int d_atIdx;             //!< index of the restrained atom
+  int d_atIdx{-1};             //!< index of the restrained atom
   double d_maxDispl;       //!< maximum allowed displacement
   RDGeom::Point3D d_pos0;  //!< reference position
   double d_forceConstant;  //!< force constant of the bond

--- a/Code/ForceField/MMFF/StretchBend.h
+++ b/Code/ForceField/MMFF/StretchBend.h
@@ -26,7 +26,7 @@ class MMFFProp;
 //! The angle-bend term for MMFF
 class RDKIT_FORCEFIELD_EXPORT StretchBendContrib : public ForceFieldContrib {
  public:
-  StretchBendContrib() : d_at1Idx(-1), d_at2Idx(-1), d_at3Idx(-1){};
+  StretchBendContrib()  {};
   //! Constructor
   /*!
     The angle is between atom1 - atom2 - atom3
@@ -52,7 +52,7 @@ class RDKIT_FORCEFIELD_EXPORT StretchBendContrib : public ForceFieldContrib {
   };
 
  private:
-  int d_at1Idx, d_at2Idx, d_at3Idx;
+  int d_at1Idx{-1}, d_at2Idx{-1}, d_at3Idx{-1};
   double d_restLen1, d_restLen2, d_theta0;
   std::pair<double, double> d_forceConstants;
 };

--- a/Code/ForceField/MMFF/TorsionAngle.h
+++ b/Code/ForceField/MMFF/TorsionAngle.h
@@ -29,7 +29,7 @@ class RDKIT_FORCEFIELD_EXPORT RDKIT_FORCEFIELD_EXPORT TorsionAngleContrib
     : public ForceFieldContrib {
  public:
   TorsionAngleContrib()
-      : d_at1Idx(-1), d_at2Idx(-1), d_at3Idx(-1), d_at4Idx(-1){};
+       {};
   //! Constructor
   /*!
     The torsion is between atom1 - atom2 - atom3 - atom4
@@ -53,7 +53,7 @@ class RDKIT_FORCEFIELD_EXPORT RDKIT_FORCEFIELD_EXPORT TorsionAngleContrib
   };
 
  private:
-  int d_at1Idx, d_at2Idx, d_at3Idx, d_at4Idx;
+  int d_at1Idx{-1}, d_at2Idx{-1}, d_at3Idx{-1}, d_at4Idx{-1};
   double d_V1, d_V2, d_V3;
 };
 

--- a/Code/ForceField/MMFF/TorsionConstraint.h
+++ b/Code/ForceField/MMFF/TorsionConstraint.h
@@ -23,7 +23,7 @@ class RDKIT_FORCEFIELD_EXPORT RDKIT_FORCEFIELD_EXPORT TorsionConstraintContrib
     : public ForceFieldContrib {
  public:
   TorsionConstraintContrib()
-      : d_at1Idx(-1), d_at2Idx(-1), d_at3Idx(-1), d_at4Idx(-1){};
+       {};
   //! Constructor
   /*!
   \param owner          pointer to the owning ForceField
@@ -59,8 +59,8 @@ class RDKIT_FORCEFIELD_EXPORT RDKIT_FORCEFIELD_EXPORT TorsionConstraintContrib
     unsigned int idx2, unsigned int idx3, unsigned int idx4,
     double minDihedralDeg, double maxDihedralDeg, double forceConst);
   double computeDihedralTerm(double dihedral) const;
-  int d_at1Idx, d_at2Idx, d_at3Idx,
-      d_at4Idx;  //!< indices of atoms forming the dihedral angle
+  int d_at1Idx{-1}, d_at2Idx{-1}, d_at3Idx{-1},
+      d_at4Idx{-1};  //!< indices of atoms forming the dihedral angle
   double d_minDihedralDeg,
       d_maxDihedralDeg;    //!< rest amplitudes of the dihedral angle
   double d_forceConstant;  //!< force constant of the angle constraint

--- a/Code/ForceField/UFF/AngleBend.h
+++ b/Code/ForceField/UFF/AngleBend.h
@@ -21,7 +21,7 @@ class AtomicParams;
 //! The angle-bend term for the Universal Force Field
 class RDKIT_FORCEFIELD_EXPORT AngleBendContrib : public ForceFieldContrib {
  public:
-  AngleBendContrib() : d_at1Idx(-1), d_at2Idx(-1), d_at3Idx(-1), d_order(0){};
+  AngleBendContrib()  {};
   //! Constructor
   /*!
     The angle is between atom1 - atom2 - atom3
@@ -55,8 +55,8 @@ class RDKIT_FORCEFIELD_EXPORT AngleBendContrib : public ForceFieldContrib {
   };
 
  private:
-  int d_at1Idx, d_at2Idx, d_at3Idx;
-  unsigned int d_order;
+  int d_at1Idx{-1}, d_at2Idx{-1}, d_at3Idx{-1};
+  unsigned int d_order{0};
   double d_forceConstant, d_C0, d_C1, d_C2;
 
   double getEnergyTerm(double cosTheta, double sinThetaSq) const;

--- a/Code/ForceField/UFF/AngleBend.h
+++ b/Code/ForceField/UFF/AngleBend.h
@@ -21,7 +21,7 @@ class AtomicParams;
 //! The angle-bend term for the Universal Force Field
 class RDKIT_FORCEFIELD_EXPORT AngleBendContrib : public ForceFieldContrib {
  public:
-  AngleBendContrib()  {};
+  AngleBendContrib(){};
   //! Constructor
   /*!
     The angle is between atom1 - atom2 - atom3
@@ -55,7 +55,9 @@ class RDKIT_FORCEFIELD_EXPORT AngleBendContrib : public ForceFieldContrib {
   };
 
  private:
-  int d_at1Idx{-1}, d_at2Idx{-1}, d_at3Idx{-1};
+  int d_at1Idx{-1};
+  int d_at2Idx{-1};
+  int d_at3Idx{-1};
   unsigned int d_order{0};
   double d_forceConstant, d_C0, d_C1, d_C2;
 

--- a/Code/ForceField/UFF/AngleConstraint.h
+++ b/Code/ForceField/UFF/AngleConstraint.h
@@ -22,7 +22,7 @@ namespace UFF {
 class RDKIT_FORCEFIELD_EXPORT AngleConstraintContrib
     : public ForceFieldContrib {
  public:
-  AngleConstraintContrib() : d_at1Idx(-1), d_at2Idx(-1), d_at3Idx(-1){};
+  AngleConstraintContrib()  {};
   //! Constructor
   /*!
   \param owner       pointer to the owning ForceField
@@ -52,7 +52,7 @@ class RDKIT_FORCEFIELD_EXPORT AngleConstraintContrib
   };
 
  private:
-  int d_at1Idx, d_at2Idx, d_at3Idx;     //!< indices of atoms forming the angle
+  int d_at1Idx{-1}, d_at2Idx{-1}, d_at3Idx{-1};     //!< indices of atoms forming the angle
   double d_minAngleDeg, d_maxAngleDeg;  //!< rest amplitudes of the angle
   double d_forceConstant;  //!< force constant of the angle constraint
 };

--- a/Code/ForceField/UFF/BondStretch.h
+++ b/Code/ForceField/UFF/BondStretch.h
@@ -19,7 +19,7 @@ class AtomicParams;
 //! The bond-stretch term for the Universal Force Field
 class RDKIT_FORCEFIELD_EXPORT BondStretchContrib : public ForceFieldContrib {
  public:
-  BondStretchContrib()  {};
+  BondStretchContrib(){};
   //! Constructor
   /*!
     \param owner       pointer to the owning ForceField
@@ -43,9 +43,10 @@ class RDKIT_FORCEFIELD_EXPORT BondStretchContrib : public ForceFieldContrib {
   };
 
  private:
-  int d_end1Idx{-1}, d_end2Idx{-1};  //!< indices of end points
-  double d_restLen;          //!< rest length of the bond
-  double d_forceConstant;    //!< force constant of the bond
+  int d_end1Idx{-1};       //!< indices of end points
+  int d_end2Idx{-1};       //!< indices of end points
+  double d_restLen;        //!< rest length of the bond
+  double d_forceConstant;  //!< force constant of the bond
 };
 
 namespace Utils {

--- a/Code/ForceField/UFF/BondStretch.h
+++ b/Code/ForceField/UFF/BondStretch.h
@@ -19,7 +19,7 @@ class AtomicParams;
 //! The bond-stretch term for the Universal Force Field
 class RDKIT_FORCEFIELD_EXPORT BondStretchContrib : public ForceFieldContrib {
  public:
-  BondStretchContrib() : d_end1Idx(-1), d_end2Idx(-1){};
+  BondStretchContrib()  {};
   //! Constructor
   /*!
     \param owner       pointer to the owning ForceField
@@ -43,7 +43,7 @@ class RDKIT_FORCEFIELD_EXPORT BondStretchContrib : public ForceFieldContrib {
   };
 
  private:
-  int d_end1Idx, d_end2Idx;  //!< indices of end points
+  int d_end1Idx{-1}, d_end2Idx{-1};  //!< indices of end points
   double d_restLen;          //!< rest length of the bond
   double d_forceConstant;    //!< force constant of the bond
 };

--- a/Code/ForceField/UFF/DistanceConstraint.h
+++ b/Code/ForceField/UFF/DistanceConstraint.h
@@ -22,7 +22,7 @@ namespace UFF {
 class RDKIT_FORCEFIELD_EXPORT DistanceConstraintContrib
     : public ForceFieldContrib {
  public:
-  DistanceConstraintContrib() : d_end1Idx(-1), d_end2Idx(-1){};
+  DistanceConstraintContrib()  {};
   //! Constructor
   /*!
     \param owner       pointer to the owning ForceField
@@ -52,7 +52,7 @@ class RDKIT_FORCEFIELD_EXPORT DistanceConstraintContrib
   };
 
  private:
-  int d_end1Idx, d_end2Idx;   //!< indices of end points
+  int d_end1Idx{-1}, d_end2Idx{-1};   //!< indices of end points
   double d_minLen, d_maxLen;  //!< rest length of the bond
   double d_forceConstant;     //!< force constant of the bond
 };

--- a/Code/ForceField/UFF/DistanceConstraint.h
+++ b/Code/ForceField/UFF/DistanceConstraint.h
@@ -22,7 +22,7 @@ namespace UFF {
 class RDKIT_FORCEFIELD_EXPORT DistanceConstraintContrib
     : public ForceFieldContrib {
  public:
-  DistanceConstraintContrib()  {};
+  DistanceConstraintContrib(){};
   //! Constructor
   /*!
     \param owner       pointer to the owning ForceField
@@ -52,7 +52,8 @@ class RDKIT_FORCEFIELD_EXPORT DistanceConstraintContrib
   };
 
  private:
-  int d_end1Idx{-1}, d_end2Idx{-1};   //!< indices of end points
+  int d_end1Idx{-1};          //!< indices of end points
+  int d_end2Idx{-1};          //!< indices of end points
   double d_minLen, d_maxLen;  //!< rest length of the bond
   double d_forceConstant;     //!< force constant of the bond
 };

--- a/Code/ForceField/UFF/Inversion.h
+++ b/Code/ForceField/UFF/Inversion.h
@@ -23,7 +23,7 @@ class AtomicParams;
 //! The inversion term for the Universal Force Field
 class RDKIT_FORCEFIELD_EXPORT InversionContrib : public ForceFieldContrib {
  public:
-  InversionContrib() : d_at1Idx(-1), d_at2Idx(-1), d_at3Idx(-1), d_at4Idx(-1){};
+  InversionContrib()  {};
   //! Constructor
   /*!
     \param owner          pointer to the owning ForceField
@@ -48,7 +48,7 @@ class RDKIT_FORCEFIELD_EXPORT InversionContrib : public ForceFieldContrib {
   };
 
  private:
-  int d_at1Idx, d_at2Idx, d_at3Idx, d_at4Idx;
+  int d_at1Idx{-1}, d_at2Idx{-1}, d_at3Idx{-1}, d_at4Idx{-1};
   double d_forceConstant, d_C0, d_C1, d_C2;
 };
 

--- a/Code/ForceField/UFF/Inversion.h
+++ b/Code/ForceField/UFF/Inversion.h
@@ -23,7 +23,7 @@ class AtomicParams;
 //! The inversion term for the Universal Force Field
 class RDKIT_FORCEFIELD_EXPORT InversionContrib : public ForceFieldContrib {
  public:
-  InversionContrib()  {};
+  InversionContrib(){};
   //! Constructor
   /*!
     \param owner          pointer to the owning ForceField
@@ -48,7 +48,10 @@ class RDKIT_FORCEFIELD_EXPORT InversionContrib : public ForceFieldContrib {
   };
 
  private:
-  int d_at1Idx{-1}, d_at2Idx{-1}, d_at3Idx{-1}, d_at4Idx{-1};
+  int d_at1Idx{-1};
+  int d_at2Idx{-1};
+  int d_at3Idx{-1};
+  int d_at4Idx{-1};
   double d_forceConstant, d_C0, d_C1, d_C2;
 };
 

--- a/Code/ForceField/UFF/Nonbonded.h
+++ b/Code/ForceField/UFF/Nonbonded.h
@@ -30,7 +30,7 @@ class AtomicParams;
  */
 class RDKIT_FORCEFIELD_EXPORT vdWContrib : public ForceFieldContrib {
  public:
-  vdWContrib()  {};
+  vdWContrib(){};
 
   //! Constructor
   /*!
@@ -51,7 +51,8 @@ class RDKIT_FORCEFIELD_EXPORT vdWContrib : public ForceFieldContrib {
   virtual vdWContrib *copy() const { return new vdWContrib(*this); };
 
  private:
-  int d_at1Idx{-1}, d_at2Idx{-1};
+  int d_at1Idx{-1};
+  int d_at2Idx{-1};
   double d_xij;        //!< the preferred length of the contact
   double d_wellDepth;  //!< the vdW well depth (strength of the interaction)
   double d_thresh;     //!< the distance threshold

--- a/Code/ForceField/UFF/Nonbonded.h
+++ b/Code/ForceField/UFF/Nonbonded.h
@@ -30,7 +30,7 @@ class AtomicParams;
  */
 class RDKIT_FORCEFIELD_EXPORT vdWContrib : public ForceFieldContrib {
  public:
-  vdWContrib() : d_at1Idx(-1), d_at2Idx(-1){};
+  vdWContrib()  {};
 
   //! Constructor
   /*!
@@ -51,7 +51,7 @@ class RDKIT_FORCEFIELD_EXPORT vdWContrib : public ForceFieldContrib {
   virtual vdWContrib *copy() const { return new vdWContrib(*this); };
 
  private:
-  int d_at1Idx, d_at2Idx;
+  int d_at1Idx{-1}, d_at2Idx{-1};
   double d_xij;        //!< the preferred length of the contact
   double d_wellDepth;  //!< the vdW well depth (strength of the interaction)
   double d_thresh;     //!< the distance threshold

--- a/Code/ForceField/UFF/PositionConstraint.h
+++ b/Code/ForceField/UFF/PositionConstraint.h
@@ -23,7 +23,7 @@ namespace UFF {
 class RDKIT_FORCEFIELD_EXPORT PositionConstraintContrib
     : public ForceFieldContrib {
  public:
-  PositionConstraintContrib() : d_atIdx(-1){};
+  PositionConstraintContrib()  {};
   //! Constructor
   /*!
     \param owner       pointer to the owning ForceField
@@ -45,7 +45,7 @@ class RDKIT_FORCEFIELD_EXPORT PositionConstraintContrib
   };
 
  private:
-  int d_atIdx;             //!< index of the restrained atom
+  int d_atIdx{-1};             //!< index of the restrained atom
   double d_maxDispl;       //!< maximum allowed displacement
   RDGeom::Point3D d_pos0;  //!< reference position
   double d_forceConstant;  //!< force constant of the bond

--- a/Code/ForceField/UFF/TorsionAngle.h
+++ b/Code/ForceField/UFF/TorsionAngle.h
@@ -29,7 +29,7 @@ class AtomicParams;
 class RDKIT_FORCEFIELD_EXPORT TorsionAngleContrib : public ForceFieldContrib {
  public:
   TorsionAngleContrib()
-      : d_at1Idx(-1), d_at2Idx(-1), d_at3Idx(-1), d_at4Idx(-1), d_order(0){};
+       {};
   //! Constructor
   /*!
     The torsion is between atom1 - atom2 - atom3 - atom4
@@ -75,8 +75,8 @@ class RDKIT_FORCEFIELD_EXPORT TorsionAngleContrib : public ForceFieldContrib {
   };
 
  private:
-  int d_at1Idx, d_at2Idx, d_at3Idx, d_at4Idx;
-  unsigned int d_order;
+  int d_at1Idx{-1}, d_at2Idx{-1}, d_at3Idx{-1}, d_at4Idx{-1};
+  unsigned int d_order{0};
   double d_forceConstant, d_cosTerm;
 
   //! returns dE/dTheta

--- a/Code/ForceField/UFF/TorsionAngle.h
+++ b/Code/ForceField/UFF/TorsionAngle.h
@@ -28,8 +28,7 @@ class AtomicParams;
 //! the torsion term for the Universal Force Field
 class RDKIT_FORCEFIELD_EXPORT TorsionAngleContrib : public ForceFieldContrib {
  public:
-  TorsionAngleContrib()
-       {};
+  TorsionAngleContrib(){};
   //! Constructor
   /*!
     The torsion is between atom1 - atom2 - atom3 - atom4
@@ -75,7 +74,10 @@ class RDKIT_FORCEFIELD_EXPORT TorsionAngleContrib : public ForceFieldContrib {
   };
 
  private:
-  int d_at1Idx{-1}, d_at2Idx{-1}, d_at3Idx{-1}, d_at4Idx{-1};
+  int d_at1Idx{-1};
+  int d_at2Idx{-1};
+  int d_at3Idx{-1};
+  int d_at4Idx{-1};
   unsigned int d_order{0};
   double d_forceConstant, d_cosTerm;
 

--- a/Code/ForceField/UFF/TorsionConstraint.h
+++ b/Code/ForceField/UFF/TorsionConstraint.h
@@ -23,7 +23,7 @@ class RDKIT_FORCEFIELD_EXPORT TorsionConstraintContrib
     : public ForceFieldContrib {
  public:
   TorsionConstraintContrib()
-      : d_at1Idx(-1), d_at2Idx(-1), d_at3Idx(-1), d_at4Idx(-1){};
+       {};
   //! Constructor
   /*!
   \param owner          pointer to the owning ForceField
@@ -59,8 +59,8 @@ class RDKIT_FORCEFIELD_EXPORT TorsionConstraintContrib
     unsigned int idx2, unsigned int idx3, unsigned int idx4,
     double minDihedralDeg, double maxDihedralDeg, double forceConst);
   double computeDihedralTerm(double dihedral) const;
-  int d_at1Idx, d_at2Idx, d_at3Idx,
-      d_at4Idx;  //!< indices of atoms forming the dihedral angle
+  int d_at1Idx{-1}, d_at2Idx{-1}, d_at3Idx{-1},
+      d_at4Idx{-1};  //!< indices of atoms forming the dihedral angle
   double d_minDihedralDeg,
       d_maxDihedralDeg;    //!< rest amplitudes of the dihedral angle
   double d_forceConstant;  //!< force constant of the angle constraint

--- a/Code/Geometry/point.h
+++ b/Code/Geometry/point.h
@@ -45,7 +45,9 @@ class RDKIT_RDGEOMETRYLIB_EXPORT Point {
 // typedef class Point3D Point;
 class RDKIT_RDGEOMETRYLIB_EXPORT Point3D : public Point {
  public:
-  double x{0.0}, y{0.0}, z{0.0};
+  double x{ 0.0 };
+  double y{ 0.0 }; 
+  double z{ 0.0 };
 
   Point3D()  {};
   Point3D(double xv, double yv, double zv) : x(xv), y(yv), z(zv){};
@@ -257,7 +259,8 @@ RDKIT_RDGEOMETRYLIB_EXPORT double computeSignedDihedralAngle(
 
 class RDKIT_RDGEOMETRYLIB_EXPORT Point2D : public Point {
  public:
-  double x{0.0}, y{0.0};
+  double x{ 0.0 };
+  double y{ 0.0 };
 
   Point2D()  {};
   Point2D(double xv, double yv) : x(xv), y(yv){};

--- a/Code/Geometry/point.h
+++ b/Code/Geometry/point.h
@@ -45,9 +45,9 @@ class RDKIT_RDGEOMETRYLIB_EXPORT Point {
 // typedef class Point3D Point;
 class RDKIT_RDGEOMETRYLIB_EXPORT Point3D : public Point {
  public:
-  double x, y, z;
+  double x{0.0}, y{0.0}, z{0.0};
 
-  Point3D() : x(0.0), y(0.0), z(0.0){};
+  Point3D()  {};
   Point3D(double xv, double yv, double zv) : x(xv), y(yv), z(zv){};
 
   ~Point3D(){};
@@ -257,9 +257,9 @@ RDKIT_RDGEOMETRYLIB_EXPORT double computeSignedDihedralAngle(
 
 class RDKIT_RDGEOMETRYLIB_EXPORT Point2D : public Point {
  public:
-  double x, y;
+  double x{0.0}, y{0.0};
 
-  Point2D() : x(0.0), y(0.0){};
+  Point2D()  {};
   Point2D(double xv, double yv) : x(xv), y(yv){};
   ~Point2D(){};
 

--- a/Code/GraphMol/AddHs.cpp
+++ b/Code/GraphMol/AddHs.cpp
@@ -245,7 +245,7 @@ void setHydrogenCoords(ROMol *mol, unsigned int hydIdx, unsigned int heavyIdx) {
             unsigned int cip = 0;
             tAtom->getPropIfPresent<unsigned int>(common_properties::_CIPRank,
                                                   cip);
-            nbrs.push_back(std::make_pair(cip, rdcast<int>(*nbrIdx)));
+            nbrs.emplace_back(cip, rdcast<int>(*nbrIdx));
           }
           ++nbrIdx;
         }

--- a/Code/GraphMol/AtomIterators.h
+++ b/Code/GraphMol/AtomIterators.h
@@ -31,7 +31,7 @@ template <class Atom_, class Mol_>
 class RDKIT_GRAPHMOL_EXPORT AtomIterator_ {
  public:
   typedef AtomIterator_<Atom_, Mol_> ThisType;
-  AtomIterator_() :  _mol(nullptr){};
+  AtomIterator_() : _mol(nullptr){};
   AtomIterator_(Mol_ *mol);
   AtomIterator_(Mol_ *mol, int pos);
   AtomIterator_(const ThisType &other);
@@ -64,7 +64,8 @@ class RDKIT_GRAPHMOL_EXPORT AtomIterator_ {
   ThisType operator--(int);
 
  private:
-  int _pos{-1}, _max{-1};
+  int _pos{-1};
+  int _max{-1};
   Mol_ *_mol;
 };
 
@@ -73,7 +74,7 @@ template <class Atom_, class Mol_>
 class RDKIT_GRAPHMOL_EXPORT HeteroatomIterator_ {
  public:
   typedef HeteroatomIterator_<Atom_, Mol_> ThisType;
-  HeteroatomIterator_() :  _mol(nullptr){};
+  HeteroatomIterator_() : _mol(nullptr){};
   HeteroatomIterator_(Mol_ *mol);
   HeteroatomIterator_(Mol_ *mol, int pos);
   ~HeteroatomIterator_();
@@ -93,7 +94,8 @@ class RDKIT_GRAPHMOL_EXPORT HeteroatomIterator_ {
   ThisType operator--(int);
 
  private:
-  int _end{-1}, _pos{-1};
+  int _end{-1};
+  int _pos{-1};
   Mol_ *_mol;
   // FIX: somehow changing the following to a pointer make the regression test
   // pass
@@ -109,7 +111,7 @@ template <class Atom_, class Mol_>
 class RDKIT_GRAPHMOL_EXPORT AromaticAtomIterator_ {
  public:
   typedef AromaticAtomIterator_<Atom_, Mol_> ThisType;
-  AromaticAtomIterator_() :  _mol(nullptr){};
+  AromaticAtomIterator_() : _mol(nullptr){};
   AromaticAtomIterator_(Mol_ *mol);
   AromaticAtomIterator_(Mol_ *mol, int pos);
   ~AromaticAtomIterator_();
@@ -129,7 +131,8 @@ class RDKIT_GRAPHMOL_EXPORT AromaticAtomIterator_ {
   ThisType operator--(int);
 
  private:
-  int _end{-1}, _pos{-1};
+  int _end{-1};
+  int _pos{-1};
   Mol_ *_mol;
 
   int _findNext(int from);
@@ -141,7 +144,7 @@ template <class Atom_, class Mol_>
 class RDKIT_GRAPHMOL_EXPORT QueryAtomIterator_ {
  public:
   typedef QueryAtomIterator_<Atom_, Mol_> ThisType;
-  QueryAtomIterator_() :  _mol(nullptr) {};
+  QueryAtomIterator_() : _mol(nullptr){};
   QueryAtomIterator_(Mol_ *mol, QueryAtom const *what);
   QueryAtomIterator_(Mol_ *mol, int pos);
   ~QueryAtomIterator_();
@@ -161,7 +164,8 @@ class RDKIT_GRAPHMOL_EXPORT QueryAtomIterator_ {
   ThisType operator--(int);
 
  private:
-  int _end{-1}, _pos{-1};
+  int _end{-1};
+  int _pos{-1};
   Mol_ *_mol;
   QueryAtom *_qA{nullptr};
 
@@ -174,7 +178,7 @@ template <class Atom_, class Mol_>
 class RDKIT_GRAPHMOL_EXPORT MatchingAtomIterator_ {
  public:
   typedef MatchingAtomIterator_<Atom_, Mol_> ThisType;
-  MatchingAtomIterator_() :  _mol(nullptr), _qF(nullptr){};
+  MatchingAtomIterator_() : _mol(nullptr), _qF(nullptr){};
   MatchingAtomIterator_(Mol_ *mol, bool (*fn)(Atom_ *));
   MatchingAtomIterator_(Mol_ *mol, int pos);
   ~MatchingAtomIterator_();
@@ -194,7 +198,8 @@ class RDKIT_GRAPHMOL_EXPORT MatchingAtomIterator_ {
   ThisType operator--(int);
 
  private:
-  int _end{-1}, _pos{-1};
+  int _end{-1};
+  int _pos{-1};
   Mol_ *_mol;
   bool (*_qF)(Atom_ *);
 

--- a/Code/GraphMol/AtomIterators.h
+++ b/Code/GraphMol/AtomIterators.h
@@ -31,7 +31,7 @@ template <class Atom_, class Mol_>
 class RDKIT_GRAPHMOL_EXPORT AtomIterator_ {
  public:
   typedef AtomIterator_<Atom_, Mol_> ThisType;
-  AtomIterator_() : _pos(-1), _max(-1), _mol(nullptr){};
+  AtomIterator_() :  _mol(nullptr){};
   AtomIterator_(Mol_ *mol);
   AtomIterator_(Mol_ *mol, int pos);
   AtomIterator_(const ThisType &other);
@@ -64,7 +64,7 @@ class RDKIT_GRAPHMOL_EXPORT AtomIterator_ {
   ThisType operator--(int);
 
  private:
-  int _pos, _max;
+  int _pos{-1}, _max{-1};
   Mol_ *_mol;
 };
 
@@ -73,7 +73,7 @@ template <class Atom_, class Mol_>
 class RDKIT_GRAPHMOL_EXPORT HeteroatomIterator_ {
  public:
   typedef HeteroatomIterator_<Atom_, Mol_> ThisType;
-  HeteroatomIterator_() : _end(-1), _pos(-1), _mol(nullptr){};
+  HeteroatomIterator_() :  _mol(nullptr){};
   HeteroatomIterator_(Mol_ *mol);
   HeteroatomIterator_(Mol_ *mol, int pos);
   ~HeteroatomIterator_();
@@ -93,7 +93,7 @@ class RDKIT_GRAPHMOL_EXPORT HeteroatomIterator_ {
   ThisType operator--(int);
 
  private:
-  int _end, _pos;
+  int _end{-1}, _pos{-1};
   Mol_ *_mol;
   // FIX: somehow changing the following to a pointer make the regression test
   // pass
@@ -109,7 +109,7 @@ template <class Atom_, class Mol_>
 class RDKIT_GRAPHMOL_EXPORT AromaticAtomIterator_ {
  public:
   typedef AromaticAtomIterator_<Atom_, Mol_> ThisType;
-  AromaticAtomIterator_() : _end(-1), _pos(-1), _mol(nullptr){};
+  AromaticAtomIterator_() :  _mol(nullptr){};
   AromaticAtomIterator_(Mol_ *mol);
   AromaticAtomIterator_(Mol_ *mol, int pos);
   ~AromaticAtomIterator_();
@@ -129,7 +129,7 @@ class RDKIT_GRAPHMOL_EXPORT AromaticAtomIterator_ {
   ThisType operator--(int);
 
  private:
-  int _end, _pos;
+  int _end{-1}, _pos{-1};
   Mol_ *_mol;
 
   int _findNext(int from);
@@ -141,7 +141,7 @@ template <class Atom_, class Mol_>
 class RDKIT_GRAPHMOL_EXPORT QueryAtomIterator_ {
  public:
   typedef QueryAtomIterator_<Atom_, Mol_> ThisType;
-  QueryAtomIterator_() : _end(-1), _pos(-1), _mol(nullptr), _qA(nullptr){};
+  QueryAtomIterator_() :  _mol(nullptr) {};
   QueryAtomIterator_(Mol_ *mol, QueryAtom const *what);
   QueryAtomIterator_(Mol_ *mol, int pos);
   ~QueryAtomIterator_();
@@ -161,9 +161,9 @@ class RDKIT_GRAPHMOL_EXPORT QueryAtomIterator_ {
   ThisType operator--(int);
 
  private:
-  int _end, _pos;
+  int _end{-1}, _pos{-1};
   Mol_ *_mol;
-  QueryAtom *_qA;
+  QueryAtom *_qA{nullptr};
 
   int _findNext(int from);
   int _findPrev(int from);
@@ -174,7 +174,7 @@ template <class Atom_, class Mol_>
 class RDKIT_GRAPHMOL_EXPORT MatchingAtomIterator_ {
  public:
   typedef MatchingAtomIterator_<Atom_, Mol_> ThisType;
-  MatchingAtomIterator_() : _end(-1), _pos(-1), _mol(nullptr), _qF(nullptr){};
+  MatchingAtomIterator_() :  _mol(nullptr), _qF(nullptr){};
   MatchingAtomIterator_(Mol_ *mol, bool (*fn)(Atom_ *));
   MatchingAtomIterator_(Mol_ *mol, int pos);
   ~MatchingAtomIterator_();
@@ -194,7 +194,7 @@ class RDKIT_GRAPHMOL_EXPORT MatchingAtomIterator_ {
   ThisType operator--(int);
 
  private:
-  int _end, _pos;
+  int _end{-1}, _pos{-1};
   Mol_ *_mol;
   bool (*_qF)(Atom_ *);
 

--- a/Code/GraphMol/BondIterators.h
+++ b/Code/GraphMol/BondIterators.h
@@ -28,7 +28,7 @@ class RDKIT_GRAPHMOL_EXPORT BondIterator_ {
   // FIX: I'm not pleased with the lack of internal testing code
   //  (PREs and the like) in here
  public:
-  BondIterator_() : _mol(nullptr){};
+  BondIterator_()  {};
   BondIterator_(ROMol *mol);
   BondIterator_(ROMol *mol, ROMol::EDGE_ITER pos);
   BondIterator_(const BondIterator_ &other);
@@ -45,13 +45,13 @@ class RDKIT_GRAPHMOL_EXPORT BondIterator_ {
 
  private:
   ROMol::EDGE_ITER _beg, _end, _pos;
-  ROMol *_mol;
+  ROMol *_mol{nullptr};
 };
 //! \brief const iterator for a molecule's bonds, currently BiDirectional,
 //! but it theoretically ought to be RandomAccess.
 class RDKIT_GRAPHMOL_EXPORT ConstBondIterator_ {
  public:
-  ConstBondIterator_() : _mol(nullptr){};
+  ConstBondIterator_()  {};
   ConstBondIterator_(ROMol const *mol);
   ConstBondIterator_(ROMol const *mol, ROMol::EDGE_ITER pos);
   ConstBondIterator_(const ConstBondIterator_ &other);
@@ -68,7 +68,7 @@ class RDKIT_GRAPHMOL_EXPORT ConstBondIterator_ {
 
  private:
   ROMol::EDGE_ITER _beg, _end, _pos;
-  ROMol const *_mol;
+  ROMol const *_mol{nullptr};
 };
 }  // namespace RDKit
 

--- a/Code/GraphMol/Canon.cpp
+++ b/Code/GraphMol/Canon.cpp
@@ -627,7 +627,7 @@ void dfsFindCycles(ROMol &mol, int atomIdx, int inBondIdx,
       // std::cerr<<"aIdx: "<< atomIdx <<"   p: "<<otherIdx<<" Rank:
       // "<<ranks[otherIdx] <<" "<<colors[otherIdx]<<"
       // "<<theBond->getBondType()<<" "<<rank<<std::endl;
-      possibles.push_back(PossibleType(rank, otherIdx, theBond));
+      possibles.emplace_back(rank, otherIdx, theBond);
     }
   }
 
@@ -798,7 +798,7 @@ void dfsBuildStack(ROMol &mol, int atomIdx, int inBondIdx,
         rank = getRandomGenerator()();
       }
 
-      possibles.push_back(PossibleType(rank, otherIdx, theBond));
+      possibles.emplace_back(rank, otherIdx, theBond);
     }
   }
 

--- a/Code/GraphMol/ChemReactions/Enumerate/CartesianProduct.h
+++ b/Code/GraphMol/ChemReactions/Enumerate/CartesianProduct.h
@@ -69,11 +69,11 @@ See EnumerationStrategyBase for more details and usage.
 
 class RDKIT_CHEMREACTIONS_EXPORT CartesianProductStrategy
     : public EnumerationStrategyBase {
-  size_t m_numPermutationsProcessed;
+  size_t m_numPermutationsProcessed{};
 
  public:
   CartesianProductStrategy()
-      : EnumerationStrategyBase(), m_numPermutationsProcessed() {}
+      : EnumerationStrategyBase() {}
 
   using EnumerationStrategyBase::initialize;
 

--- a/Code/GraphMol/ChemReactions/Enumerate/Enumerate.h
+++ b/Code/GraphMol/ChemReactions/Enumerate/Enumerate.h
@@ -58,10 +58,10 @@ namespace RDKit {
      does not pass sanitization, then none of the products will.
 */
 struct RDKIT_CHEMREACTIONS_EXPORT EnumerationParams {
-  int reagentMaxMatchCount;
-  bool sanePartialProducts;
+  int reagentMaxMatchCount{INT_MAX};
+  bool sanePartialProducts{false};
   EnumerationParams()
-      : reagentMaxMatchCount(INT_MAX), sanePartialProducts(false) {}
+       {}
 
   EnumerationParams(const EnumerationParams &rhs)
       : reagentMaxMatchCount(rhs.reagentMaxMatchCount),

--- a/Code/GraphMol/ChemReactions/Enumerate/EnumerationStrategyBase.h
+++ b/Code/GraphMol/ChemReactions/Enumerate/EnumerationStrategyBase.h
@@ -123,13 +123,13 @@ class RDKIT_CHEMREACTIONS_EXPORT EnumerationStrategyBase {
   EnumerationTypes::RGROUPS
       m_permutationSizes;  // m_permutationSizes num bbs per group
   boost::uint64_t
-      m_numPermutations;  // total number of permutations for this group
+      m_numPermutations{};  // total number of permutations for this group
                           //  -1 if > ssize_t::max
  public:
   static const boost::uint64_t EnumerationOverflow =
       static_cast<boost::uint64_t>(-1);
   EnumerationStrategyBase()
-      : m_permutation(), m_permutationSizes(), m_numPermutations() {}
+      : m_permutation(), m_permutationSizes() {}
 
   virtual ~EnumerationStrategyBase() {}
 

--- a/Code/GraphMol/ChemReactions/Enumerate/EvenSamplePairs.h
+++ b/Code/GraphMol/ChemReactions/Enumerate/EvenSamplePairs.h
@@ -54,7 +54,7 @@ namespace RDKit {
 
 class RDKIT_CHEMREACTIONS_EXPORT EvenSamplePairsStrategy
     : public EnumerationStrategyBase {
-  boost::uint64_t m_numPermutationsProcessed;
+  boost::uint64_t m_numPermutationsProcessed{};
 
   std::vector<boost::int64_t> used_count;
   std::vector<std::vector<boost::uint64_t>> var_used;
@@ -62,31 +62,22 @@ class RDKIT_CHEMREACTIONS_EXPORT EvenSamplePairsStrategy
   std::vector<std::vector<boost::uint64_t>> pair_counts;
   std::set<boost::uint64_t> selected;
 
-  boost::uint64_t seed;     // last seed for permutation (starts at 0)
-  boost::uint64_t M, a, b;  // random number stuff
-  boost::uint64_t nslack, min_nslack;
-  boost::uint64_t rejected_period, rejected_unique;
-  boost::uint64_t rejected_slack_condition, rejected_bb_sampling_condition;
+  boost::uint64_t seed{};     // last seed for permutation (starts at 0)
+  boost::uint64_t M{}, a{}, b{};  // random number stuff
+  boost::uint64_t nslack{}, min_nslack{};
+  boost::uint64_t rejected_period{}, rejected_unique{};
+  boost::uint64_t rejected_slack_condition{}, rejected_bb_sampling_condition{};
 
  public:
   EvenSamplePairsStrategy()
       : EnumerationStrategyBase(),
-        m_numPermutationsProcessed(),
+        
         used_count(),
         var_used(),
         pair_used(),
         pair_counts(),
-        selected(),
-        seed(),
-        M(),
-        a(),
-        b(),
-        nslack(),
-        min_nslack(),
-        rejected_period(),
-        rejected_unique(),
-        rejected_slack_condition(),
-        rejected_bb_sampling_condition() {}
+        selected()
+        {}
 
   EvenSamplePairsStrategy(const EvenSamplePairsStrategy &rhs)
       : EnumerationStrategyBase(rhs),

--- a/Code/GraphMol/ChemReactions/Enumerate/RandomSample.h
+++ b/Code/GraphMol/ChemReactions/Enumerate/RandomSample.h
@@ -75,8 +75,7 @@ class RDKIT_CHEMREACTIONS_EXPORT RandomSampleStrategy
         m_rng(),
         m_distributions() {
     for (size_t i = 0; i < m_permutation.size(); ++i) {
-      m_distributions.push_back(
-          boost::random::uniform_int_distribution<>(0, m_permutation[i] - 1));
+      m_distributions.emplace_back(0, m_permutation[i] - 1);
     }
   }
 
@@ -86,8 +85,8 @@ class RDKIT_CHEMREACTIONS_EXPORT RandomSampleStrategy
                                   const EnumerationTypes::BBS &) {
     m_distributions.clear();
     for (size_t i = 0; i < m_permutationSizes.size(); ++i) {
-      m_distributions.push_back(boost::random::uniform_int_distribution<>(
-          0, m_permutationSizes[i] - 1));
+      m_distributions.emplace_back(
+          0, m_permutationSizes[i] - 1);
     }
 
     m_numPermutationsProcessed = 0;
@@ -146,8 +145,8 @@ class RDKIT_CHEMREACTIONS_EXPORT RandomSampleStrategy
     // reset the uniform distributions
     m_distributions.clear();
     for (size_t i = 0; i < m_permutationSizes.size(); ++i) {
-      m_distributions.push_back(boost::random::uniform_int_distribution<>(
-          0, m_permutationSizes[i] - 1));
+      m_distributions.emplace_back(
+          0, m_permutationSizes[i] - 1);
     }
   }
 

--- a/Code/GraphMol/ChemReactions/Enumerate/RandomSample.h
+++ b/Code/GraphMol/ChemReactions/Enumerate/RandomSample.h
@@ -64,14 +64,14 @@ namespace RDKit {
 */
 class RDKIT_CHEMREACTIONS_EXPORT RandomSampleStrategy
     : public EnumerationStrategyBase {
-  boost::uint64_t m_numPermutationsProcessed;
+  boost::uint64_t m_numPermutationsProcessed{};
   boost::minstd_rand m_rng;
   std::vector<boost::random::uniform_int_distribution<>> m_distributions;
 
  public:
   RandomSampleStrategy()
       : EnumerationStrategyBase(),
-        m_numPermutationsProcessed(),
+        
         m_rng(),
         m_distributions() {
     for (size_t i = 0; i < m_permutation.size(); ++i) {

--- a/Code/GraphMol/ChemReactions/Enumerate/RandomSampleAllBBs.h
+++ b/Code/GraphMol/ChemReactions/Enumerate/RandomSampleAllBBs.h
@@ -81,8 +81,7 @@ class RDKIT_CHEMREACTIONS_EXPORT RandomSampleAllBBsStrategy
         m_rng(),
         m_distributions() {
     for (size_t i = 0; i < m_permutation.size(); ++i) {
-      m_distributions.push_back(
-          boost::random::uniform_int_distribution<>(0, m_permutation[i] - 1));
+      m_distributions.emplace_back(0, m_permutation[i] - 1);
     }
   }
   using EnumerationStrategyBase::initialize;
@@ -95,8 +94,8 @@ class RDKIT_CHEMREACTIONS_EXPORT RandomSampleAllBBsStrategy
     m_maxoffset =
         *std::max_element(m_permutationSizes.begin(), m_permutationSizes.end());
     for (size_t i = 0; i < m_permutationSizes.size(); ++i) {
-      m_distributions.push_back(boost::random::uniform_int_distribution<>(
-          0, m_permutationSizes[i] - 1));
+      m_distributions.emplace_back(
+          0, m_permutationSizes[i] - 1);
     }
 
     m_numPermutationsProcessed = 0;
@@ -167,8 +166,8 @@ class RDKIT_CHEMREACTIONS_EXPORT RandomSampleAllBBsStrategy
     // reset the uniform distributions
     m_distributions.clear();
     for (size_t i = 0; i < m_permutationSizes.size(); ++i) {
-      m_distributions.push_back(boost::random::uniform_int_distribution<>(
-          0, m_permutationSizes[i] - 1));
+      m_distributions.emplace_back(
+          0, m_permutationSizes[i] - 1);
     }
   }
 

--- a/Code/GraphMol/ChemReactions/Enumerate/RandomSampleAllBBs.h
+++ b/Code/GraphMol/ChemReactions/Enumerate/RandomSampleAllBBs.h
@@ -67,9 +67,9 @@ namespace RDKit {
 
 class RDKIT_CHEMREACTIONS_EXPORT RandomSampleAllBBsStrategy
     : public EnumerationStrategyBase {
-  boost::uint64_t m_numPermutationsProcessed;
-  size_t m_offset;
-  size_t m_maxoffset;
+  boost::uint64_t m_numPermutationsProcessed{0};
+  size_t m_offset{0};
+  size_t m_maxoffset{0};
 
   boost::minstd_rand m_rng;
   std::vector<boost::random::uniform_int_distribution<>> m_distributions;
@@ -77,9 +77,7 @@ class RDKIT_CHEMREACTIONS_EXPORT RandomSampleAllBBsStrategy
  public:
   RandomSampleAllBBsStrategy()
       : EnumerationStrategyBase(),
-        m_numPermutationsProcessed(0),
-        m_offset(0),
-        m_maxoffset(0),
+        
         m_rng(),
         m_distributions() {
     for (size_t i = 0; i < m_permutation.size(); ++i) {

--- a/Code/GraphMol/ChemReactions/Enumerate/testEnumerate.cpp
+++ b/Code/GraphMol/ChemReactions/Enumerate/testEnumerate.cpp
@@ -108,14 +108,10 @@ void testSamplers() {
   EvenSamplePairsStrategy even;
   even.initialize(rxn, bbs);
   std::vector<boost::shared_ptr<EnumerationStrategyBase>> enumerators;
-  enumerators.push_back(
-      boost::shared_ptr<EnumerationStrategyBase>(cart.copy()));
-  enumerators.push_back(
-      boost::shared_ptr<EnumerationStrategyBase>(rand.copy()));
-  enumerators.push_back(
-      boost::shared_ptr<EnumerationStrategyBase>(randBBs.copy()));
-  enumerators.push_back(
-      boost::shared_ptr<EnumerationStrategyBase>(even.copy()));
+  enumerators.emplace_back(cart.copy());
+  enumerators.emplace_back(rand.copy());
+  enumerators.emplace_back(randBBs.copy());
+  enumerators.emplace_back(even.copy());
 #ifdef RDK_USE_BOOST_SERIALIZATION
   for (auto &enumerator : enumerators) {
     TEST_ASSERT(enumerator->getNumPermutations() == 10 * 5 * 6);

--- a/Code/GraphMol/ChemReactions/Reaction.h
+++ b/Code/GraphMol/ChemReactions/Reaction.h
@@ -120,8 +120,7 @@ class RDKIT_CHEMREACTIONS_EXPORT ChemicalReaction : public RDProps {
   friend class ReactionPickler;
 
  public:
-  ChemicalReaction()
-      : RDProps(), df_needsInit(true), df_implicitProperties(false){};
+  ChemicalReaction() : RDProps(){};
   ChemicalReaction(const ChemicalReaction &other) : RDProps() {
     df_needsInit = other.df_needsInit;
     df_implicitProperties = other.df_implicitProperties;
@@ -343,8 +342,8 @@ class RDKIT_CHEMREACTIONS_EXPORT ChemicalReaction : public RDProps {
   void setImplicitPropertiesFlag(bool val) { df_implicitProperties = val; };
 
  private:
-  bool df_needsInit;
-  bool df_implicitProperties;
+  bool df_needsInit{true};
+  bool df_implicitProperties{false};
   MOL_SPTR_VECT m_reactantTemplates, m_productTemplates, m_agentTemplates;
   ChemicalReaction &operator=(const ChemicalReaction &);  // disable assignment
 };

--- a/Code/GraphMol/ChemReactions/ReactionFingerprints.h
+++ b/Code/GraphMol/ChemReactions/ReactionFingerprints.h
@@ -74,12 +74,8 @@ enum FingerprintType {
  */
 struct RDKIT_CHEMREACTIONS_EXPORT ReactionFingerprintParams {
   ReactionFingerprintParams()
-      : includeAgents(false),
-        bitRatioAgents(0.2),
-        nonAgentWeight(10),
-        agentWeight(1),
-        fpSize(2048),
-        fpType(AtomPairFP) {}
+      
+        {}
 
   ReactionFingerprintParams(bool includeAgents, double bitRatioAgents,
                             unsigned int nonAgentWeight, int agentWeight,
@@ -91,12 +87,12 @@ struct RDKIT_CHEMREACTIONS_EXPORT ReactionFingerprintParams {
         fpSize(fpSize),
         fpType(fpType) {}
 
-  bool includeAgents;
-  double bitRatioAgents;
-  unsigned int nonAgentWeight;
-  int agentWeight;
-  unsigned int fpSize;
-  FingerprintType fpType;
+  bool includeAgents{false};
+  double bitRatioAgents{0.2};
+  unsigned int nonAgentWeight{10};
+  int agentWeight{1};
+  unsigned int fpSize{2048};
+  FingerprintType fpType{AtomPairFP};
 };
 
 RDKIT_CHEMREACTIONS_EXPORT extern const ReactionFingerprintParams

--- a/Code/GraphMol/ChemReactions/ReactionRunner.cpp
+++ b/Code/GraphMol/ChemReactions/ReactionRunner.cpp
@@ -1578,15 +1578,15 @@ ROMol *reduceProductToSideChains(const ROMOL_SPTR &product,
         if (!nbr->hasProp(common_properties::reactionMapNum) &&
             nbr->hasProp(common_properties::reactantAtomIdx)) {
           if (nbr->hasProp(WAS_DUMMY)) {
-            bonds_to_product.push_back(RGroup(
+            bonds_to_product.emplace_back(
                 nbr,
                 mol->getBondBetweenAtoms(scaffold_atom->getIdx(), *nbrIdx)
                     ->getBondType(),
-                nbr->getProp<int>(common_properties::reactionMapNum)));
+                nbr->getProp<int>(common_properties::reactionMapNum));
           } else {
-            bonds_to_product.push_back(RGroup(
+            bonds_to_product.emplace_back(
                 nbr, mol->getBondBetweenAtoms(scaffold_atom->getIdx(), *nbrIdx)
-                         ->getBondType()));
+                         ->getBondType());
           }
         }
 

--- a/Code/GraphMol/ChemTransforms/ChemTransforms.cpp
+++ b/Code/GraphMol/ChemTransforms/ChemTransforms.cpp
@@ -361,7 +361,7 @@ ROMol *replaceCore(const ROMol &mol, const ROMol &core,
   std::vector<std::pair<int, int>> matchorder_atomidx;
   for (unsigned int i = 0; i < origNumAtoms; ++i) {
     int queryatom = allIndices[i];
-    matchorder_atomidx.push_back(std::make_pair(queryatom, i));
+    matchorder_atomidx.emplace_back(queryatom, i);
   }
 
   std::sort(matchorder_atomidx.begin(), matchorder_atomidx.end());
@@ -412,9 +412,9 @@ ROMol *replaceCore(const ROMol &mol, const ROMol &core,
           //  order
           //  right now so save and sort later.
           if (mapping != -1) {
-            dummies.push_back(std::make_pair(mapping, newAt));
+            dummies.emplace_back(mapping, newAt);
           } else {
-            dummies.push_back(std::make_pair(matchingIndices[nbrIdx], newAt));
+            dummies.emplace_back(matchingIndices[nbrIdx], newAt);
           }
 
           newMol->addAtom(newAt, false, true);

--- a/Code/GraphMol/ChemTransforms/MolFragmenter.cpp
+++ b/Code/GraphMol/ChemTransforms/MolFragmenter.cpp
@@ -355,7 +355,7 @@ void fragmentOnSomeBonds(
     }
     ROMol *nm = fragmentOnBonds(mol, fragmentHere, addDummies, dummyLabelsHere,
                                 bondTypesHere, lCutsPerAtom);
-    resMols.push_back(ROMOL_SPTR(nm));
+    resMols.emplace_back(nm);
 
     state = nextBitCombo(state);
   }
@@ -562,9 +562,9 @@ ROMol *fragmentOnBonds(const ROMol &mol,
       bondsUsed.set(bond->getIdx());
       bondIndices.push_back(bond->getIdx());
       if (bond->getBeginAtomIdx() == static_cast<unsigned int>(mv[0].second)) {
-        dummyLabels.push_back(std::make_pair(fbt.atom1Label, fbt.atom2Label));
+        dummyLabels.emplace_back(fbt.atom1Label, fbt.atom2Label);
       } else {
-        dummyLabels.push_back(std::make_pair(fbt.atom2Label, fbt.atom1Label));
+        dummyLabels.emplace_back(fbt.atom2Label, fbt.atom1Label);
       }
       bondTypes.push_back(fbt.bondType);
     }

--- a/Code/GraphMol/Chirality.cpp
+++ b/Code/GraphMol/Chirality.cpp
@@ -2381,7 +2381,7 @@ void setDoubleBondNeighborDirections(ROMol &mol, const Conformer *conf) {
     if (!(mol.getRingInfo()->numBondRings(dblBond->getIdx()))) {
       countHere *= 10;
     }
-    orderedBondsInPlay.push_back(std::make_pair(countHere, dblBond));
+    orderedBondsInPlay.emplace_back(countHere, dblBond);
   }
   std::sort(orderedBondsInPlay.begin(), orderedBondsInPlay.end());
 

--- a/Code/GraphMol/Conformer.h
+++ b/Code/GraphMol/Conformer.h
@@ -45,12 +45,10 @@ class RDKIT_GRAPHMOL_EXPORT Conformer : public RDProps {
   friend class ROMol;
 
   //! Constructor
-  Conformer() : df_is3D(true), d_id(0), dp_mol(nullptr) {
-    d_positions.clear();
-  };
+  Conformer() { d_positions.clear(); };
 
   //! Constructor with number of atoms specified ID specification
-  Conformer(unsigned int numAtoms) : df_is3D(true), d_id(0), dp_mol(nullptr) {
+  Conformer(unsigned int numAtoms) {
     if (numAtoms) {
       d_positions.resize(numAtoms, RDGeom::Point3D(0.0, 0.0, 0.0));
     } else {
@@ -138,9 +136,9 @@ class RDKIT_GRAPHMOL_EXPORT Conformer : public RDProps {
   void setOwningMol(ROMol &mol);
 
  private:
-  bool df_is3D;                      // is this a 3D conformation?
-  unsigned int d_id;                 // id is the conformation
-  ROMol *dp_mol;                     // owning molecule
+  bool df_is3D{true};                // is this a 3D conformation?
+  unsigned int d_id{0};              // id is the conformation
+  ROMol *dp_mol{nullptr};            // owning molecule
   RDGeom::POINT3D_VECT d_positions;  // positions of the atoms
   void initFromOther(const Conformer &conf);
 };

--- a/Code/GraphMol/Depictor/EmbeddedFrag.cpp
+++ b/Code/GraphMol/Depictor/EmbeddedFrag.cpp
@@ -162,7 +162,7 @@ void EmbeddedFrag::computeNbrsAndAng(unsigned int aid,
       ang = computeAngle(d_eatoms[aid].loc, d_eatoms[*nbi1].loc,
                          d_eatoms[*nbi2].loc);
       INT_PAIR nbrPair = std::make_pair((*nbi1), (*nbi2));
-      anglePairs.push_back(std::make_pair(ang, nbrPair));
+      anglePairs.emplace_back(ang, nbrPair);
     }
   }
   anglePairs.sort(_anglComp);

--- a/Code/GraphMol/Depictor/EmbeddedFrag.h
+++ b/Code/GraphMol/Depictor/EmbeddedFrag.h
@@ -31,15 +31,8 @@ class RDKIT_DEPICTOR_EXPORT EmbeddedAtom {
   typedef enum { UNSPECIFIED = 0, CISTRANS, RING } EAtomType;
 
   EmbeddedAtom()
-      : aid(0),
-        angle(-1.0),
-        nbr1(-1),
-        nbr2(-1),
-        CisTransNbr(-1),
-        ccw(true),
-        rotDir(0),
-        d_density(-1.0),
-        df_fixed(false) {
+      
+        {
     neighs.clear();
   }
 
@@ -92,35 +85,35 @@ class RDKIT_DEPICTOR_EXPORT EmbeddedAtom {
     ccw = (!ccw);
   }
 
-  unsigned int aid;  // the id of the atom
+  unsigned int aid{0};  // the id of the atom
 
   //! the angle that is already takes at this atom, so any new atom attaching to
   // this
   //! atom with have to fall in the available part
-  double angle;
+  double angle{-1.0};
 
   //! the first neighbor of this atom that form the 'angle'
-  int nbr1;
+  int nbr1{-1};
 
   //! the second neighbor of atom that from the 'angle'
-  int nbr2;
+  int nbr2{-1};
 
   //! is this is a cis/trans atom the neighbor of this atom that is involved in
   // the
   //! cis/trans system - defaults to -1
-  int CisTransNbr;
+  int CisTransNbr{-1};
 
   //! which direction do we rotate this normal to add the next bond
   //! if ccw is true we rotate counter clockwise, otherwise rotate clock wise,
   // by an angle that is
   //! <= PI/2
-  bool ccw;
+  bool ccw{true};
 
   //! rotation direction around this atom when adding new atoms,
   //! we determine this for the first neighbor and stick to this direction after
   // that
   //! useful only on atoms that are degree >= 4
-  int rotDir;
+  int rotDir{0};
 
   RDGeom::Point2D loc;  // the current location of this atom
   //! this is a normal vector to one of the bonds that added this atom
@@ -137,11 +130,11 @@ class RDKIT_DEPICTOR_EXPORT EmbeddedAtom {
   // - this is sum of inverse of the square of distances to other atoms from
   // this atom
   // Used in the collision removal code - initialized to -1.0
-  double d_density;
+  double d_density{-1.0};
 
   //! if set this atom is fixed: further operations on the fragment may not
   //! move it.
-  bool df_fixed;
+  bool df_fixed{false};
 };
 
 typedef std::map<unsigned int, EmbeddedAtom> INT_EATOM_MAP;

--- a/Code/GraphMol/Descriptors/Lipinski.cpp
+++ b/Code/GraphMol/Descriptors/Lipinski.cpp
@@ -54,10 +54,10 @@ class ss_matcher {
   ~ss_matcher() { delete m_matcher; };
 
  private:
-  ss_matcher() : m_pattern(""), m_needCopies(false), m_matcher(nullptr){};
+  ss_matcher() : m_pattern("") {};
   std::string m_pattern;
-  bool m_needCopies;
-  const RDKit::ROMol *m_matcher;
+  bool m_needCopies{false};
+  const RDKit::ROMol *m_matcher{nullptr};
 };
 }
 

--- a/Code/GraphMol/Descriptors/Property.cpp
+++ b/Code/GraphMol/Descriptors/Property.cpp
@@ -98,7 +98,7 @@ int Properties::registerProperty(PropertyFunctor *prop) {
     }
   }
   // XXX Add mutex?
-  Properties::registry.push_back(boost::shared_ptr<PropertyFunctor>(prop));
+  Properties::registry.emplace_back(prop);
   return Properties::registry.size();
 }
 

--- a/Code/GraphMol/Descriptors/test.cpp
+++ b/Code/GraphMol/Descriptors/test.cpp
@@ -1897,8 +1897,8 @@ void testProperties() {
   }
   {
     std::vector<std::string> names;
-    names.push_back("NumSpiroAtoms");
-    names.push_back("NumBridgeheadAtoms");
+    names.emplace_back("NumSpiroAtoms");
+    names.emplace_back("NumBridgeheadAtoms");
     Properties sink(names);
     std::vector<std::string> sink_names = sink.getPropertyNames();
     TEST_ASSERT(names == sink_names);
@@ -1929,7 +1929,7 @@ void testProperties() {
   {
     try {
       std::vector<std::string> names;
-      names.push_back("FakeName");
+      names.emplace_back("FakeName");
       Properties sink(names);
       TEST_ASSERT(0);  // should throw
     } catch (KeyErrorException &) {
@@ -1977,8 +1977,8 @@ void testStereoCounting() {
   TEST_ASSERT(!m->hasProp(common_properties::_StereochemDone));
 
   std::vector<std::string> names;
-  names.push_back("NumAtomStereoCenters");
-  names.push_back("NumUnspecifiedAtomStereoCenters");
+  names.emplace_back("NumAtomStereoCenters");
+  names.emplace_back("NumUnspecifiedAtomStereoCenters");
   Properties prop(names);
 
   try {

--- a/Code/GraphMol/DistGeomHelpers/BoundsMatrixBuilder.cpp
+++ b/Code/GraphMol/DistGeomHelpers/BoundsMatrixBuilder.cpp
@@ -1561,8 +1561,7 @@ void collectBondsAndAngles(const ROMol &mol,
   angles.resize(0);
   bonds.reserve(mol.getNumBonds());
   for (const auto bondi : mol.bonds()) {
-    bonds.push_back(
-        std::make_pair(bondi->getBeginAtomIdx(), bondi->getEndAtomIdx()));
+    bonds.emplace_back(bondi->getBeginAtomIdx(), bondi->getEndAtomIdx());
 
     for (unsigned int j = bondi->getIdx() + 1; j < mol.getNumBonds(); ++j) {
       const Bond *bondj = mol.getBondWithIdx(j);

--- a/Code/GraphMol/DistGeomHelpers/Embedder.h
+++ b/Code/GraphMol/DistGeomHelpers/Embedder.h
@@ -90,56 +90,35 @@ namespace DGeomHelpers {
   CPCI	custom columbic interactions between atom pairs
 */
 struct RDKIT_DISTGEOMHELPERS_EXPORT EmbedParameters {
-  unsigned int maxIterations;
-  int numThreads;
-  int randomSeed;
-  bool clearConfs;
-  bool useRandomCoords;
-  double boxSizeMult;
-  bool randNegEig;
-  unsigned int numZeroFail;
-  const std::map<int, RDGeom::Point3D> *coordMap;
-  double optimizerForceTol;
-  bool ignoreSmoothingFailures;
-  bool enforceChirality;
-  bool useExpTorsionAnglePrefs;
-  bool useBasicKnowledge;
-  bool verbose;
-  double basinThresh;
-  double pruneRmsThresh;
-  bool onlyHeavyAtomsForRMS;
-  unsigned int ETversion;
+  unsigned int maxIterations{0};
+  int numThreads{1};
+  int randomSeed{-1};
+  bool clearConfs{true};
+  bool useRandomCoords{false};
+  double boxSizeMult{2.0};
+  bool randNegEig{true};
+  unsigned int numZeroFail{1};
+  const std::map<int, RDGeom::Point3D> *coordMap{nullptr};
+  double optimizerForceTol{1e-3};
+  bool ignoreSmoothingFailures{false};
+  bool enforceChirality{true};
+  bool useExpTorsionAnglePrefs{false};
+  bool useBasicKnowledge{false};
+  bool verbose{false};
+  double basinThresh{5.0};
+  double pruneRmsThresh{-1.0};
+  bool onlyHeavyAtomsForRMS{false};
+  unsigned int ETversion{1};
   boost::shared_ptr<const DistGeom::BoundsMatrix> boundsMat;
-  bool embedFragmentsSeparately;
-  bool useSmallRingTorsions;
-  bool useMacrocycleTorsions;
-  bool useMacrocycle14config;
+  bool embedFragmentsSeparately{true};
+  bool useSmallRingTorsions{false};
+  bool useMacrocycleTorsions{false};
+  bool useMacrocycle14config{false};
   std::shared_ptr<std::map<std::pair<unsigned int, unsigned int>, double>> CPCI;
   EmbedParameters()
-      : maxIterations(0),
-        numThreads(1),
-        randomSeed(-1),
-        clearConfs(true),
-        useRandomCoords(false),
-        boxSizeMult(2.0),
-        randNegEig(true),
-        numZeroFail(1),
-        coordMap(nullptr),
-        optimizerForceTol(1e-3),
-        ignoreSmoothingFailures(false),
-        enforceChirality(true),
-        useExpTorsionAnglePrefs(false),
-        useBasicKnowledge(false),
-        verbose(false),
-        basinThresh(5.0),
-        pruneRmsThresh(-1.0),
-        onlyHeavyAtomsForRMS(false),
-        ETversion(1),
+      : 
         boundsMat(nullptr),
-        embedFragmentsSeparately(true),
-        useSmallRingTorsions(false),
-        useMacrocycleTorsions(false),
-        useMacrocycle14config(false),
+        
         CPCI(nullptr){};
   EmbedParameters(
       unsigned int maxIterations, int numThreads, int randomSeed,

--- a/Code/GraphMol/FMCS/DebugTrace.h
+++ b/Code/GraphMol/FMCS/DebugTrace.h
@@ -111,47 +111,21 @@ namespace FMCS {
 //#define VERBOSE_STATISTICS_FASTCALLS_ON
 
 struct ExecStatistics {
-  unsigned TotalSteps, MCSFoundStep;
+  unsigned TotalSteps{0}, MCSFoundStep{0};
   unsigned long long MCSFoundTime;
-  unsigned InitialSeed, MismatchedInitialSeed;
-  unsigned Seed, RemainingSizeRejected;
-  unsigned SeedCheck, SingleBondExcluded;
-  unsigned MatchCall, MatchCallTrue;
-  unsigned FastMatchCall, FastMatchCallTrue, SlowMatchCallTrue;
-  unsigned ExactMatchCall, ExactMatchCallTrue;  // hash cache
-  unsigned FindHashInCache, HashKeyFoundInCache;
-  unsigned AtomCompareCalls, BondCompareCalls;  // long long
-  unsigned AtomFunctorCalls, BondFunctorCalls;  // long long
-  unsigned WrongCompositionRejected, WrongCompositionDetected;
-  unsigned DupCacheFound, DupCacheFoundMatch;
+  unsigned InitialSeed{0}, MismatchedInitialSeed{0};
+  unsigned Seed{0}, RemainingSizeRejected{0};
+  unsigned SeedCheck{0}, SingleBondExcluded{0};
+  unsigned MatchCall{0}, MatchCallTrue{0};
+  unsigned FastMatchCall{0}, FastMatchCallTrue{0}, SlowMatchCallTrue{0};
+  unsigned ExactMatchCall{0}, ExactMatchCallTrue{0};  // hash cache
+  unsigned FindHashInCache{0}, HashKeyFoundInCache{0};
+  unsigned AtomCompareCalls{0}, BondCompareCalls{0};  // long long
+  unsigned AtomFunctorCalls{0}, BondFunctorCalls{0};  // long long
+  unsigned WrongCompositionRejected{0}, WrongCompositionDetected{0};
+  unsigned DupCacheFound{0}, DupCacheFoundMatch{0};
 
-  ExecStatistics()
-      : TotalSteps(0),
-        MCSFoundStep(0),
-        MCSFoundTime(nanoClock()),
-        InitialSeed(0),
-        MismatchedInitialSeed(0),
-        Seed(0),
-        RemainingSizeRejected(0),
-        SeedCheck(0),
-        SingleBondExcluded(0),
-        MatchCall(0),
-        MatchCallTrue(0),
-        FastMatchCall(0),
-        FastMatchCallTrue(0),
-        SlowMatchCallTrue(0),
-        ExactMatchCall(0),
-        ExactMatchCallTrue(0),
-        FindHashInCache(0),
-        HashKeyFoundInCache(0),
-        AtomCompareCalls(0),
-        BondCompareCalls(0),
-        AtomFunctorCalls(0),
-        BondFunctorCalls(0),
-        WrongCompositionRejected(0),
-        WrongCompositionDetected(0),
-        DupCacheFound(0),
-        DupCacheFoundMatch(0) {}
+  ExecStatistics() : MCSFoundTime(nanoClock()) {}
 };
 #endif
 }  // namespace FMCS

--- a/Code/GraphMol/FMCS/DuplicatedSeedCache.h
+++ b/Code/GraphMol/FMCS/DuplicatedSeedCache.h
@@ -66,9 +66,9 @@ class DuplicatedSeedCache {
 
  private:
   std::map<TKey, TValue> Index;
-  size_t MaxAtoms;  // max key in the cache for fast failed find
+  size_t MaxAtoms{0};  // max key in the cache for fast failed find
  public:
-  DuplicatedSeedCache() : MaxAtoms(0) {}
+  DuplicatedSeedCache()  {}
   void clear() {
     Index.clear();
     MaxAtoms = 0;

--- a/Code/GraphMol/FMCS/FMCS.h
+++ b/Code/GraphMol/FMCS/FMCS.h
@@ -69,13 +69,15 @@ typedef bool (*MCSBondCompareFunction)(const MCSBondCompareParameters& p,
 // Some predefined functors:
 RDKIT_FMCS_EXPORT bool checkAtomRingMatch(const MCSAtomCompareParameters& p,
                                           const ROMol& mol1, unsigned int atom1,
-                                          const ROMol& mol2, unsigned int atom2);
+                                          const ROMol& mol2,
+                                          unsigned int atom2);
 RDKIT_FMCS_EXPORT bool checkAtomCharge(const MCSAtomCompareParameters& p,
                                        const ROMol& mol1, unsigned int atom1,
                                        const ROMol& mol2, unsigned int atom2);
 RDKIT_FMCS_EXPORT bool checkAtomChirality(const MCSAtomCompareParameters& p,
                                           const ROMol& mol1, unsigned int atom1,
-                                          const ROMol& mol2, unsigned int atom2);
+                                          const ROMol& mol2,
+                                          unsigned int atom2);
 
 RDKIT_FMCS_EXPORT bool MCSAtomCompareAny(const MCSAtomCompareParameters& p,
                                          const ROMol& mol1, unsigned int atom1,
@@ -95,7 +97,7 @@ RDKIT_FMCS_EXPORT bool MCSAtomCompareIsotopes(
 RDKIT_FMCS_EXPORT bool checkBondStereo(const MCSBondCompareParameters& p,
                                        const ROMol& mol1, unsigned int bond1,
                                        const ROMol& mol2, unsigned int bond2);
-RDKIT_FMCS_EXPORT bool checkBondRingMatch(const MCSBondCompareParameters &p,
+RDKIT_FMCS_EXPORT bool checkBondRingMatch(const MCSBondCompareParameters& p,
                                           const ROMol& mol1, unsigned int bond1,
                                           const ROMol& mol2, unsigned int bond2,
                                           void* v_ringMatchMatrixSet);
@@ -113,12 +115,12 @@ RDKIT_FMCS_EXPORT bool MCSBondCompareOrderExact(
     const ROMol& mol2, unsigned int bond2, void* userData);
 
 struct RDKIT_FMCS_EXPORT MCSProgressData {
-  unsigned NumAtoms;
-  unsigned NumBonds;
-  unsigned SeedProcessed;
+  unsigned NumAtoms{0};
+  unsigned NumBonds{0};
+  unsigned SeedProcessed{0};
 
  public:
-  MCSProgressData() : NumAtoms(0), NumBonds(0), SeedProcessed(0) {}
+  MCSProgressData() {}
 };
 
 typedef bool (*MCSProgressCallback)(const MCSProgressData& stat,
@@ -145,21 +147,21 @@ struct RDKIT_FMCS_EXPORT MCSParameters {
       nullptr;  // FinalMatchCheckFunction() to check chirality and ring fusion
   std::string InitialSeed = "";  // user defined or empty string (default)
   void setMCSAtomTyperFromEnum(AtomComparator atomComp);
-  void setMCSAtomTyperFromConstChar(const char *atomComp);
+  void setMCSAtomTyperFromConstChar(const char* atomComp);
   void setMCSBondTyperFromEnum(BondComparator bondComp);
-  void setMCSBondTyperFromConstChar(const char *bondComp);
+  void setMCSBondTyperFromConstChar(const char* bondComp);
 };
 
 struct RDKIT_FMCS_EXPORT MCSResult {
-  unsigned NumAtoms;
-  unsigned NumBonds;
+  unsigned NumAtoms{0};
+  unsigned NumBonds{0};
   std::string SmartsString;
-  bool Canceled;  // interrupted by timeout or user defined progress callback.
-                  // Contains valid current MCS !
+  bool Canceled{false};  // interrupted by timeout or user defined progress
+                         // callback. Contains valid current MCS !
   ROMOL_SPTR QueryMol;
 
  public:
-  MCSResult() : NumAtoms(0), NumBonds(0), Canceled(false) {}
+  MCSResult() {}
   bool isCompleted() const { return !Canceled; }
 };
 

--- a/Code/GraphMol/FMCS/MaximumCommonSubgraph.cpp
+++ b/Code/GraphMol/FMCS/MaximumCommonSubgraph.cpp
@@ -304,9 +304,9 @@ struct QueryRings {
 };  // namespace RDKit
 
 struct WeightedBond {
-  const Bond* BondPtr;
-  unsigned Weight;
-  WeightedBond() : BondPtr(nullptr), Weight(0) {}
+  const Bond* BondPtr{nullptr};
+  unsigned Weight{0};
+  WeightedBond()  {}
   WeightedBond(const Bond* bond, const QueryRings& r)
       : BondPtr(bond), Weight(0) {
     // score ((bond.is_in_ring + atom1.is_in_ring + atom2.is_in_ring)

--- a/Code/GraphMol/FMCS/MaximumCommonSubgraph.cpp
+++ b/Code/GraphMol/FMCS/MaximumCommonSubgraph.cpp
@@ -147,7 +147,7 @@ void MaximumCommonSubgraph::init() {
         }
         if (NotSet == QueryAtomLabels[ai]) {  // not found -> create new label
           QueryAtomLabels[ai] = ++currentLabelValue;
-          labels.push_back(LabelDefinition(ai, currentLabelValue));
+          labels.emplace_back(ai, currentLabelValue);
         }
       }
     }
@@ -202,7 +202,7 @@ void MaximumCommonSubgraph::init() {
       }
       if (NotSet == QueryAtomLabels[aj]) {  // not found -> create new label
         QueryBondLabels[aj] = ++currentLabelValue;
-        labels.push_back(LabelDefinition(aj, currentLabelValue));
+        labels.emplace_back(aj, currentLabelValue);
       }
     }
   }
@@ -401,7 +401,7 @@ void MaximumCommonSubgraph::makeInitialSeeds() {
     wb.reserve(QueryMolecule->getNumBonds());
     for (RWMol::ConstBondIterator bi = QueryMolecule->beginBonds();
          bi != QueryMolecule->endBonds(); bi++) {
-      wb.push_back(WeightedBond(*bi, r));
+      wb.emplace_back(*bi, r);
     }
 
     for (std::vector<WeightedBond>::const_iterator bi = wb.begin();

--- a/Code/GraphMol/FMCS/RingMatchTableSet.h
+++ b/Code/GraphMol/FMCS/RingMatchTableSet.h
@@ -55,7 +55,7 @@ class RDKIT_FMCS_EXPORT RingMatchTableSet {
   };
 
  private:
-  std::vector<std::vector<size_t>>* QueryBondRingsIndeces;
+  std::vector<std::vector<size_t>>* QueryBondRingsIndeces{nullptr};
   std::map<const ROMol*, std::vector<std::vector<size_t>>>
       TargetBondRingsIndecesSet;  // by target molecules
 
@@ -63,7 +63,7 @@ class RDKIT_FMCS_EXPORT RingMatchTableSet {
   std::map<const INT_VECT*, unsigned> QueryRingIndex;
 
  public:
-  RingMatchTableSet() : QueryBondRingsIndeces(nullptr) {}
+  RingMatchTableSet()  {}
 
   inline void clear() {
     if (QueryBondRingsIndeces) QueryBondRingsIndeces->clear();

--- a/Code/GraphMol/FMCS/Seed.cpp
+++ b/Code/GraphMol/FMCS/Seed.cpp
@@ -73,9 +73,8 @@ void Seed::fillNewBonds(const ROMol& qmol) {
             break;
           }
         }
-        NewBonds.push_back(
-            NewBond(srcAtomIdx, bond->getIdx(), ai, end_atom_idx,
-                    NotSet == end_atom_idx ? end_atom : nullptr));
+        NewBonds.emplace_back(srcAtomIdx, bond->getIdx(), ai, end_atom_idx,
+                    NotSet == end_atom_idx ? end_atom : nullptr);
       }
     }
   }

--- a/Code/GraphMol/FMCS/Seed.h
+++ b/Code/GraphMol/FMCS/Seed.h
@@ -33,22 +33,19 @@ struct RDKIT_FMCS_EXPORT
 };
 
 struct RDKIT_FMCS_EXPORT NewBond {
-  unsigned SourceAtomIdx;  // index in the seed. Atom is already in the seed
-  unsigned BondIdx;     // index in qmol of new bond scheduled to be added into
+  unsigned SourceAtomIdx{0};  // index in the seed. Atom is already in the seed
+  unsigned BondIdx{0};  // index in qmol of new bond scheduled to be added into
                         // seed. This is outgoing bond from SourceAtomIdx
-  unsigned NewAtomIdx;  // index in qmol of new atom scheduled to be added into
-                        // seed. Another end of new bond
-  const Atom* NewAtom;  // pointer to qmol's new atom scheduled to be added into
-                        // seed. Another end of new bond
-  unsigned EndAtomIdx;  // index in the seed. RING. "New" Atom on the another
-                        // end of new bond is already exists in the seed.
+  unsigned NewAtomIdx{0};  // index in qmol of new atom scheduled to be added
+                           // into seed. Another end of new bond
+  const Atom* NewAtom{nullptr};  // pointer to qmol's new atom scheduled to be
+                                 // added into seed. Another end of new bond
+  unsigned EndAtomIdx{0};  // index in the seed. RING. "New" Atom on the another
+                           // end of new bond is already exists in the seed.
 
   NewBond()
-      : SourceAtomIdx(-1),
-        BondIdx(-1),
-        NewAtomIdx(-1),
-        NewAtom(nullptr),
-        EndAtomIdx(-1) {}
+
+  {}
 
   NewBond(unsigned from_atom, unsigned bond_idx, unsigned new_atom,
           unsigned to_atom, const Atom* a)
@@ -64,31 +61,27 @@ class RDKIT_FMCS_EXPORT Seed {
   mutable std::vector<NewBond> NewBonds;  // for multistage growing. all
                                           // directly connected outgoing bonds
  public:
-  bool CopyComplete;  // this seed has been completely copied into list.
-                      // postponed non-locked copy for MULTI_THREAD
-  mutable unsigned GrowingStage;  // 0 new seed; -1 finished; n>0 in progress,
-                                  // exact stage of growing for SDF
-  MolFragment MoleculeFragment;   // Reference to a fragment of source molecule
+  bool CopyComplete{false};  // this seed has been completely copied into list.
+                             // postponed non-locked copy for MULTI_THREAD
+  mutable unsigned GrowingStage{0};  // 0 new seed; -1 finished; n>0 in
+                                     // progress, exact stage of growing for SDF
+  MolFragment MoleculeFragment;  // Reference to a fragment of source molecule
   Graph Topology;  // seed topology with references to source molecule
 
   std::vector<bool> ExcludedBonds;
-  unsigned LastAddedAtomsBeginIdx;  // in this subgraph for improving
-                                    // performance of future growing
-  unsigned LastAddedBondsBeginIdx;  // in this subgraph for DEBUG ONLY
-  unsigned RemainingBonds;
-  unsigned RemainingAtoms;
+  unsigned LastAddedAtomsBeginIdx{0};  // in this subgraph for improving
+                                       // performance of future growing
+  unsigned LastAddedBondsBeginIdx{0};  // in this subgraph for DEBUG ONLY
+  unsigned RemainingBonds{0};
+  unsigned RemainingAtoms{0};
 #ifdef DUP_SUBSTRUCT_CACHE
   DuplicatedSeedCache::TKey DupCacheKey;
 #endif
   std::vector<TargetMatch> MatchResult;  // for each target
  public:
   Seed()
-      : CopyComplete(false),
-        GrowingStage(0),
-        LastAddedAtomsBeginIdx(0),
-        LastAddedBondsBeginIdx(0),
-        RemainingBonds(-1),
-        RemainingAtoms(-1) {}
+
+  {}
 
   void setMoleculeFragment(const Seed& src) {
     MoleculeFragment = src.MoleculeFragment;

--- a/Code/GraphMol/FMCS/SubstructureCache.h
+++ b/Code/GraphMol/FMCS/SubstructureCache.h
@@ -26,10 +26,10 @@ class RDKIT_FMCS_EXPORT SubstructureCache {
 #pragma pack(push, 1)
   struct KeyNumericMetrics {
     typedef unsigned long long TValue;
-    TValue Value;
+    TValue Value{0};
 
    public:
-    KeyNumericMetrics() : Value(0) {}
+    KeyNumericMetrics()  {}
   };
 #pragma pack(pop)
 

--- a/Code/GraphMol/FMCS/SubstructureCache.h
+++ b/Code/GraphMol/FMCS/SubstructureCache.h
@@ -135,7 +135,7 @@ class RDKIT_FMCS_EXPORT SubstructureCache {
                                   // if not found
     if (!entry) {
       try {
-        ValueStorage.push_back(TIndexEntry());
+        ValueStorage.emplace_back();
       } catch (...) {
         return;  // not enough memory room to add the item, but it's just a
                  // cache

--- a/Code/GraphMol/FMCS/TargetMatch.h
+++ b/Code/GraphMol/FMCS/TargetMatch.h
@@ -16,15 +16,15 @@
 namespace RDKit {
 namespace FMCS {
 struct TargetMatch {
-  bool Empty;
-  size_t MatchedAtomSize;
-  size_t MatchedBondSize;
+  bool Empty{true};
+  size_t MatchedAtomSize{0};
+  size_t MatchedBondSize{0};
   std::vector<unsigned> TargetAtomIdx;
   std::vector<unsigned> TargetBondIdx;
   std::vector<bool> VisitedTargetBonds;
   std::vector<bool> VisitedTargetAtoms;  // for checking rings
  public:
-  TargetMatch() : Empty(true), MatchedAtomSize(0), MatchedBondSize(0) {}
+  TargetMatch()  {}
   TargetMatch(const TargetMatch& src) { *this = src; }
   TargetMatch& operator=(const TargetMatch& src) {
     Empty = src.Empty;

--- a/Code/GraphMol/FMCS/Test/testFMCS.cpp
+++ b/Code/GraphMol/FMCS/Test/testFMCS.cpp
@@ -204,7 +204,7 @@ void testFileMCSB(
         char name[256];
         unsigned nn, len;
         n++;
-        testCase.push_back(std::vector<std::string>());
+        testCase.emplace_back();
         sscanf(str, "%u%n", &nn, &len);
         while ('\0' != *(str + len) &&
                1 == sscanf(str + len, "%s%n", name, &nn)) {
@@ -237,7 +237,7 @@ void testFileMCSB(
       }
       std::string sm = getSmilesOnly(str, &id);
       smilesList.push_back(sm);                     // without Id and LineFeed
-      mols.push_back(ROMOL_SPTR(SmilesToMol(sm)));  // SmartsToMol ???
+      mols.emplace_back(SmilesToMol(sm));  // SmartsToMol ???
       molIdMap[id] = mols.size() - 1;               // index in mols
     }
   }
@@ -493,10 +493,9 @@ void test504() {
     atom->setProp(common_properties::molAtomMapNumber, (int)ai);
   }
   std::cout << "Query +MAP " << MolToSmiles(*qm) << "\n";
-  mols.push_back(ROMOL_SPTR(qm));  // with RING INFO
+  mols.emplace_back(qm);  // with RING INFO
   for (size_t i = 1; i < sizeof(smi) / sizeof(smi[0]); i++) {
-    mols.push_back(
-        ROMOL_SPTR(SmilesToMol(getSmilesOnly(smi[i]))));  // with RING INFO
+    mols.emplace_back(SmilesToMol(getSmilesOnly(smi[i])));  // with RING INFO
   }
   t0 = nanoClock();
   MCSResult res = findMCS(mols, &p);
@@ -527,7 +526,7 @@ std::string testChEMBL_Txt(const char* test, double th = 1.0,
       std::string id;
       std::string smi = getSmilesOnlyTxt(smiles, &id);
       fprintf(fsmi, "%s\n", (smi + " " + id).c_str());
-      mols.push_back(ROMOL_SPTR(SmilesToMol(smi)));
+      mols.emplace_back(SmilesToMol(smi));
     }
   }
   fclose(f);
@@ -980,7 +979,7 @@ void testChEMBLdat(const char* test, double th = 1.0) {
     std::cout << "\rLine: " << ++n << " ";
     if ('#' != smiles[0] && ' ' != smiles[0] &&
         '/' != smiles[0]) {  // commented to skip
-      mols.push_back(ROMOL_SPTR(SmilesToMol(getSmilesOnlyChEMBL(smiles))));
+      mols.emplace_back(SmilesToMol(getSmilesOnlyChEMBL(smiles)));
       fputs(getSmilesOnlyChEMBL(smiles).c_str(), fs);
     }
   }
@@ -1103,7 +1102,7 @@ void testTarget_no_10188_30149() {
       "CN(C)CCNC(=O)c1cccc(-c2[nH]nc3cc(Nc4ccccc4Cl)ccc32)c1 CHEMBL198821",
   };
   for (auto& i : smi) {
-    mols.push_back(ROMOL_SPTR(SmilesToMol(getSmilesOnly(i))));
+    mols.emplace_back(SmilesToMol(getSmilesOnly(i)));
   }
   t0 = nanoClock();
 #ifdef _DEBUG  // check memory leaks
@@ -1147,7 +1146,7 @@ void testTarget_no_10188_49064() {
       "CN1CCN(C(=O)c2ccc(Nc3ncc4cc(-c5c(Cl)cccc5Cl)c(=O)n(C)c4n3)cc2)CC1",
   };
   for (auto& i : smi) {
-    mols.push_back(ROMOL_SPTR(SmilesToMol(getSmilesOnly(i))));
+    mols.emplace_back(SmilesToMol(getSmilesOnly(i)));
   }
   t0 = nanoClock();
   MCSResult res = findMCS(mols, &p);
@@ -1159,7 +1158,7 @@ void testTarget_no_10188_49064() {
 void testCmndLineSMILES(int argc, const char* argv[]) {
   std::vector<ROMOL_SPTR> mols;
   for (int i = 1; i < argc; i++) {
-    mols.push_back(ROMOL_SPTR(SmilesToMol(argv[i])));
+    mols.emplace_back(SmilesToMol(argv[i]));
   }
   MCSResult res = findMCS(mols);
   std::cout << "MCS: " << res.SmartsString << " " << res.NumAtoms << " atoms, "
@@ -1175,7 +1174,7 @@ double testFileSDF(const char* test) {
   while (!suppl.atEnd()) {
     ROMol* m = suppl.next();
     if (m) {
-      mols.push_back(ROMOL_SPTR(m));
+      mols.emplace_back(m);
     }
   }
   t0 = nanoClock();
@@ -1214,7 +1213,7 @@ void testFileSDF_RandomSet_SMI(
     }
     char smiles[4096];
     while (fgets(smiles, sizeof(smiles), fsmi)) {
-      mols.push_back(ROMOL_SPTR(SmilesToMol(getSmilesOnly(smiles))));
+      mols.emplace_back(SmilesToMol(getSmilesOnly(smiles)));
     }
     fclose(fsmi);
     if (mols.size() > 1) {
@@ -1315,7 +1314,7 @@ void testFileSDF_RandomSet(const char* test = "chembl13-10000-random-pairs.sdf",
     for (int i = 0; i < 2 && !suppl->atEnd(); i++) {  // load sequential pair
       m = suppl->next();
       if (m) {
-        mols.push_back(ROMOL_SPTR(m));
+        mols.emplace_back(m);
         all_mols.push_back(mols.back());
         fprintf(fsmi, "%s Mol%u\n", MolToSmiles(*m).c_str(), n + i);
       }
@@ -1537,7 +1536,7 @@ void testFileSMILES(const char* test) {
     if ('#' != smiles[0] && ' ' != smiles[0] &&
         '/' != smiles[0]) {  // commented to skip
       //            if(strlen(smiles) > 92) // minimal query size !!!
-      mols.push_back(ROMOL_SPTR(SmilesToMol(getSmilesOnly(smiles))));
+      mols.emplace_back(SmilesToMol(getSmilesOnly(smiles)));
     }
   }
   fclose(f);

--- a/Code/GraphMol/FMCS/testFMCS_Unit.cpp
+++ b/Code/GraphMol/FMCS/testFMCS_Unit.cpp
@@ -94,7 +94,7 @@ void test1Basics() {
 
   for (auto& i : smi) {
     std::string id;
-    mols.push_back(ROMOL_SPTR(SmilesToMol(getSmilesOnly(i, &id))));
+    mols.emplace_back(SmilesToMol(getSmilesOnly(i, &id)));
   }
   t0 = nanoClock();
   MCSResult res = findMCS(mols);
@@ -133,7 +133,7 @@ void test32() {
       // 31 33 0.35 sec MCS: CCN(CC)c1ccc(cc1NC(=O)C=Cc1ccccc1)S(=O)(=O)N1CCOCC1
   };
   for (auto& i : smi) {
-    mols.push_back(ROMOL_SPTR(SmilesToMol(getSmilesOnly(i))));
+    mols.emplace_back(SmilesToMol(getSmilesOnly(i)));
   }
   t0 = nanoClock();
   MCSResult res = findMCS(mols);
@@ -165,7 +165,7 @@ void test190() {
       //  19 21 2.36 sec MCS: CC(=O)Nc1cccc(c1)-c1nc2ccccc2o1 19 atoms, 21 bonds
   };
   for (auto& i : smi) {
-    mols.push_back(ROMOL_SPTR(SmilesToMol(getSmilesOnly(i))));
+    mols.emplace_back(SmilesToMol(getSmilesOnly(i)));
   }
   t0 = nanoClock();
   MCSResult res = findMCS(mols);
@@ -202,7 +202,7 @@ void test45() {
       "CCCc1c(OC)ccc2nc3c(c(CC)c21)Cn1c-3cc2c(c1=O)COC(=O)C2(O)CC CHEMBL373316",
   };
   for (auto& i : smi) {
-    mols.push_back(ROMOL_SPTR(SmilesToMol(getSmilesOnly(i))));
+    mols.emplace_back(SmilesToMol(getSmilesOnly(i)));
   }
   t0 = nanoClock();
   MCSResult res = findMCS(mols);
@@ -233,7 +233,7 @@ void test3() {
       //# 3 . 1 14 14 0.08 sec MCS: CCCCNC(=O)Cc1ccccc1
   };
   for (auto& i : smi) {
-    mols.push_back(ROMOL_SPTR(SmilesToMol(getSmilesOnly(i))));
+    mols.emplace_back(SmilesToMol(getSmilesOnly(i)));
   }
   t0 = nanoClock();
   MCSResult res = findMCS(mols);
@@ -256,8 +256,7 @@ void testRing1() {
       "COCc1cnc(C(=O)OC(C)C)c2[nH]ccc(Oc4ccc(Cl)cc4)cccc12",  // ring 3 removed
   };
   for (auto& i : smi) {
-    mols.push_back(
-        ROMOL_SPTR(SmilesToMol(getSmilesOnly(i))));  // with RING INFO
+    mols.emplace_back(SmilesToMol(getSmilesOnly(i)));  // with RING INFO
   }
 
   {
@@ -334,10 +333,9 @@ void test504() {
     atom->setProp("molAtomMapNumber", (int)ai);
   }
   std::cout << "Query +MAP " << MolToSmiles(*qm) << "\n";
-  mols.push_back(ROMOL_SPTR(qm));  // with RING INFO
+  mols.emplace_back(qm);  // with RING INFO
   for (size_t i = 1; i < sizeof(smi) / sizeof(smi[0]); i++) {
-    mols.push_back(
-        ROMOL_SPTR(SmilesToMol(getSmilesOnly(smi[i]))));  // with RING INFO
+    mols.emplace_back(SmilesToMol(getSmilesOnly(smi[i])));  // with RING INFO
   }
   t0 = nanoClock();
   MCSResult res = findMCS(mols);
@@ -374,10 +372,9 @@ void test18() {
     atom->setProp("molAtomMapNumber", (int)ai);
   }
   std::cout << "Query +MAP " << MolToSmiles(*qm) << "\n";
-  mols.push_back(ROMOL_SPTR(qm));  // with RING INFO
+  mols.emplace_back(qm);  // with RING INFO
   for (size_t i = 1; i < sizeof(smi) / sizeof(smi[0]); i++) {
-    mols.push_back(
-        ROMOL_SPTR(SmilesToMol(getSmilesOnly(smi[i]))));  // with RING INFO
+    mols.emplace_back(SmilesToMol(getSmilesOnly(smi[i])));  // with RING INFO
   }
   t0 = nanoClock();
   MCSResult res = findMCS(mols);
@@ -398,7 +395,7 @@ void testThreshold() {
       //        "CCC", "CC", //th=0.5
   };
   for (auto& i : smi) {
-    mols.push_back(ROMOL_SPTR(SmilesToMol(getSmilesOnly(i))));
+    mols.emplace_back(SmilesToMol(getSmilesOnly(i)));
   }
   findMCS(mols);
   MCSParameters p;
@@ -450,7 +447,7 @@ void test330() {
       //[#6]-[#6](-[#7]-[#6](-[#6](-[#6])-[#7]-[#6](-[#6](-[#6])-[#7]-[#6](-[#6](-[#6]-[#6]-[#6])-[#7]-[#6](-[#6](-[#6])-[#7]-[#6](-[#6])=[#8])=[#8])=[#8])=[#8])=[#8])-[#6](-[#7]-[#6](-[#6]-[#6](:[#6]):[#6]:[#6]:[#6]:[#6])-[#6](-[#8])=[#8])=[#8]
   };
   for (auto& i : smi) {
-    mols.push_back(ROMOL_SPTR(SmilesToMol(getSmilesOnly(i))));
+    mols.emplace_back(SmilesToMol(getSmilesOnly(i)));
   }
   MCSParameters p;
   t0 = nanoClock();
@@ -481,7 +478,7 @@ void testTarget_no_10188_30149() {
       "CN(C)CCNC(=O)c1cccc(-c2[nH]nc3cc(Nc4ccccc4Cl)ccc32)c1 CHEMBL198821",
   };
   for (auto& i : smi) {
-    mols.push_back(ROMOL_SPTR(SmilesToMol(getSmilesOnly(i))));
+    mols.emplace_back(SmilesToMol(getSmilesOnly(i)));
   }
   MCSParameters p;
   t0 = nanoClock();
@@ -521,7 +518,7 @@ void testTarget_no_10188_49064() {
       "CN1CCN(C(=O)c2ccc(Nc3ncc4cc(-c5c(Cl)cccc5Cl)c(=O)n(C)c4n3)cc2)CC1",
   };
   for (auto& i : smi) {
-    mols.push_back(ROMOL_SPTR(SmilesToMol(getSmilesOnly(i))));
+    mols.emplace_back(SmilesToMol(getSmilesOnly(i)));
   }
   MCSParameters p;
   t0 = nanoClock();
@@ -553,7 +550,7 @@ void testSegFault() {
       "CN(CCOC(c1ccccc1)c1ccccc1)CCN(C)CCc1ccc(F)cc1",
   };
   for (auto& i : smi) {
-    mols.push_back(ROMOL_SPTR(SmilesToMol(getSmilesOnly(i))));
+    mols.emplace_back(SmilesToMol(getSmilesOnly(i)));
   }
   {
     MCSParameters p;
@@ -603,7 +600,7 @@ void testAtomCompareIsotopes() {
       "CC[13CH3]",
   };
   for (auto& i : smi) {
-    mols.push_back(ROMOL_SPTR(SmilesToMol(getSmilesOnly(i))));
+    mols.emplace_back(SmilesToMol(getSmilesOnly(i)));
   }
   MCSParameters p;
   p.AtomTyper = MCSAtomCompareIsotopes;
@@ -627,7 +624,7 @@ void testAtomCompareAnyAtom() {
       "c1ccccc1N",  // opt
   };
   for (auto& i : smi) {
-    mols.push_back(ROMOL_SPTR(SmilesToMol(getSmilesOnly(i))));
+    mols.emplace_back(SmilesToMol(getSmilesOnly(i)));
   }
   MCSParameters p;
   p.AtomTyper = MCSAtomCompareAny;
@@ -652,7 +649,7 @@ void testAtomCompareAnyAtomBond() {
       "c1ccccc1N",  // opt
   };
   for (auto& i : smi) {
-    mols.push_back(ROMOL_SPTR(SmilesToMol(getSmilesOnly(i))));
+    mols.emplace_back(SmilesToMol(getSmilesOnly(i)));
   }
   t0 = nanoClock();
   MCSParameters p;
@@ -675,7 +672,7 @@ void testAtomCompareAnyHeavyAtom() {
       "[H]c1ccccc1C", "[H]c1ccccc1O",  // H matches H, O matches C
   };
   for (auto& i : smi) {
-    mols.push_back(ROMOL_SPTR(SmilesToMol(getSmilesOnly(i), 0, false)));
+    mols.emplace_back(SmilesToMol(getSmilesOnly(i), 0, false));
   }
   MCSParameters p;
   p.AtomTyper = MCSAtomCompareAnyHeavyAtom;
@@ -697,7 +694,7 @@ void testAtomCompareAnyHeavyAtom1() {
       "[H]c1ccccc1C", "Oc1ccccc1O",  // O matches C, H does not match O
   };
   for (auto& i : smi) {
-    mols.push_back(ROMOL_SPTR(SmilesToMol(getSmilesOnly(i), 0, false)));
+    mols.emplace_back(SmilesToMol(getSmilesOnly(i), 0, false));
   }
   MCSParameters p;
   p.AtomTyper = MCSAtomCompareAnyHeavyAtom;
@@ -748,7 +745,7 @@ void testSimple() {
       "CCC3O)C(=O)C(Cc3ccccc3)NC(=O)C(CSSC2)NC1=O CHEMBL1076370",
   };
   for (auto& i : smi) {
-    mols.push_back(ROMOL_SPTR(SmilesToMol(getSmilesOnly(i))));
+    mols.emplace_back(SmilesToMol(getSmilesOnly(i)));
   }
   {
     MCSParameters p;
@@ -805,7 +802,7 @@ void testSimpleFast() {
       "COCc1cnc(C(=O)OC(C)C)c2[nH]c3cc(Oc4ccc(Cl)cc4)ccc3c12",
   };
   for (auto& i : smi) {
-    mols.push_back(ROMOL_SPTR(SmilesToMol(getSmilesOnly(i))));
+    mols.emplace_back(SmilesToMol(getSmilesOnly(i)));
   }
   MCSParameters p;
   t0 = nanoClock();
@@ -1115,7 +1112,7 @@ void testInitialSeed() {
 
   for (auto& i : smi) {
     std::string id;
-    mols.push_back(ROMOL_SPTR(SmilesToMol(getSmilesOnly(i, &id))));
+    mols.emplace_back(SmilesToMol(getSmilesOnly(i, &id)));
   }
   MCSParameters p;
   p.InitialSeed = "CC";
@@ -1142,7 +1139,7 @@ void testInitialSeed2() {
 
   for (auto& i : smi) {
     std::string id;
-    mols.push_back(ROMOL_SPTR(SmilesToMol(getSmilesOnly(i, &id))));
+    mols.emplace_back(SmilesToMol(getSmilesOnly(i, &id)));
     std::auto_ptr<ROMol> seed(SmartsToMol(initial_smarts));
     MatchVectType match;
     bool matched = SubstructMatch(*mols.back(), *seed, match);
@@ -1200,7 +1197,7 @@ void testGithub631() {
       }
                        // pass use all.
 
-      mols.push_back(ROMOL_SPTR(m));
+      mols.emplace_back(m);
       mols.push_back(ROMOL_SPTR(new ROMol(*m)));
       {
         MCSParameters p;
@@ -1250,7 +1247,7 @@ void testFormalChargeMatch() {
     RWMol* m = SmilesToMol(getSmilesOnly(i));
     TEST_ASSERT(m);
 
-    mols.push_back(ROMOL_SPTR(m));
+    mols.emplace_back(m);
   }
   {
     // by default charge is not used.
@@ -1295,7 +1292,7 @@ void testGithub2034() {
     auto m = SmilesToMol(getSmilesOnly(i));
     TEST_ASSERT(m);
 
-    mols.push_back(ROMOL_SPTR(m));
+    mols.emplace_back(m);
   }
   {
     // by default we're not doing ringMatchesRingOnly.
@@ -1354,7 +1351,7 @@ void testGithub945() {
       auto m = SmilesToMol(getSmilesOnly(i));
       TEST_ASSERT(m);
 
-      mols.push_back(ROMOL_SPTR(m));
+      mols.emplace_back(m);
     }
     {
       MCSParameters p;
@@ -1403,7 +1400,7 @@ void testGithub945() {
       auto m = SmilesToMol(getSmilesOnly(i));
       TEST_ASSERT(m);
 
-      mols.push_back(ROMOL_SPTR(m));
+      mols.emplace_back(m);
     }
     {
       MCSParameters p;
@@ -1474,7 +1471,7 @@ void testGithub2420() {
     auto m = SmilesToMol(getSmilesOnly(i));
     TEST_ASSERT(m);
 
-    mols.push_back(ROMOL_SPTR(m));
+    mols.emplace_back(m);
   }
   {
     MCSParameters p;
@@ -1531,7 +1528,7 @@ void testGithub2663() {
       auto m = SmilesToMol(getSmilesOnly(i));
       TEST_ASSERT(m);
 
-      mols.push_back(ROMOL_SPTR(m));
+      mols.emplace_back(m);
     }
     MCSParameters p;
     p.BondCompareParameters.CompleteRingsOnly = true;
@@ -1563,7 +1560,7 @@ void testGithub2662() {
       auto m = SmilesToMol(getSmilesOnly(i));
       TEST_ASSERT(m);
 
-      mols.push_back(ROMOL_SPTR(m));
+      mols.emplace_back(m);
     }
     MCSParameters p;
     p.BondCompareParameters.CompleteRingsOnly = true;
@@ -1593,7 +1590,7 @@ void testNaphthalenes() {
     auto m = SmilesToMol(getSmilesOnly(i));
     TEST_ASSERT(m);
 
-    mols.push_back(ROMOL_SPTR(m));
+    mols.emplace_back(m);
   }
   {
     MCSParameters p;
@@ -1636,7 +1633,7 @@ void testNaphthalenes() {
   {
     auto m = SmilesToMol(cyclodecapentaene);
     TEST_ASSERT(m);
-    mols.push_back(ROMOL_SPTR(m));
+    mols.emplace_back(m);
   }
   {
     MCSParameters p;
@@ -1692,7 +1689,7 @@ void testBicycles() {
     auto m = SmilesToMol(getSmilesOnly(i));
     TEST_ASSERT(m);
 
-    mols.push_back(ROMOL_SPTR(m));
+    mols.emplace_back(m);
   }
   {
     MCSParameters p;
@@ -1749,7 +1746,7 @@ void testBicyclesTricycles() {
     auto m = SmilesToMol(getSmilesOnly(i));
     TEST_ASSERT(m);
 
-    mols.push_back(ROMOL_SPTR(m));
+    mols.emplace_back(m);
   }
   {
     MCSParameters p;
@@ -1805,7 +1802,7 @@ void test_p38() {
     auto m = SmilesToMol(getSmilesOnly(i));
     TEST_ASSERT(m);
 
-    mols.push_back(ROMOL_SPTR(m));
+    mols.emplace_back(m);
   }
   {
     MCSResult res = findMCS(mols, true);
@@ -1857,7 +1854,7 @@ void testGithub2714() {
       auto m = SmilesToMol(getSmilesOnly(i));
       TEST_ASSERT(m);
 
-      mols.push_back(ROMOL_SPTR(m));
+      mols.emplace_back(m);
     }
     MCSParameters p;
     p.BondCompareParameters.CompleteRingsOnly = true;
@@ -1890,7 +1887,7 @@ void testGitHub2731_comment546175466() {
       auto m = SmilesToMol(getSmilesOnly(i));
       TEST_ASSERT(m);
 
-      mols.push_back(ROMOL_SPTR(m));
+      mols.emplace_back(m);
     }
     {
       MCSParameters p;
@@ -1924,7 +1921,7 @@ void testGitHub2731_comment546175466() {
       auto m = SmilesToMol(getSmilesOnly(i));
       TEST_ASSERT(m);
 
-      mols.push_back(ROMOL_SPTR(m));
+      mols.emplace_back(m);
     }
     {
       MCSParameters p;
@@ -1977,7 +1974,7 @@ void testQueryMolVsSmarts() {
     auto m = SmilesToMol(getSmilesOnly(i));
     TEST_ASSERT(m);
 
-    mols.push_back(ROMOL_SPTR(m));
+    mols.emplace_back(m);
   }
   MCSParameters p;
   p.BondCompareParameters.MatchFusedRingsStrict = true;
@@ -2010,7 +2007,7 @@ void testCompareNonExistent() {
     auto m = SmilesToMol(getSmilesOnly(i));
     TEST_ASSERT(m);
 
-    mols.push_back(ROMOL_SPTR(m));
+    mols.emplace_back(m);
   }
   {
     MCSParameters p;
@@ -2075,7 +2072,7 @@ void testGitHub3095() {
       auto m = SmilesToMol(getSmilesOnly(i));
       TEST_ASSERT(m);
 
-      mols.push_back(ROMOL_SPTR(m));
+      mols.emplace_back(m);
     }
     MCSParameters p;
     MCSResult res = findMCS(mols, &p);
@@ -2091,7 +2088,7 @@ void testGitHub3095() {
       auto m = SmilesToMol(getSmilesOnly(i));
       TEST_ASSERT(m);
 
-      mols.push_back(ROMOL_SPTR(m));
+      mols.emplace_back(m);
     }
     {
       MCSParameters p;
@@ -2118,7 +2115,7 @@ void testGitHub3095() {
       auto m = SmilesToMol(getSmilesOnly(i));
       TEST_ASSERT(m);
 
-      mols.push_back(ROMOL_SPTR(m));
+      mols.emplace_back(m);
     }
     {
       MCSParameters p;
@@ -2137,7 +2134,7 @@ void testGitHub3095() {
       auto m = SmilesToMol(getSmilesOnly(i));
       TEST_ASSERT(m);
 
-      mols.push_back(ROMOL_SPTR(m));
+      mols.emplace_back(m);
     }
     {
       MCSParameters p;

--- a/Code/GraphMol/FileParsers/MolFileStereochem.cpp
+++ b/Code/GraphMol/FileParsers/MolFileStereochem.cpp
@@ -178,8 +178,8 @@ INT_MAP_INT pickBondsToWedge(const ROMol &mol) {
       if (res.find(bid) == res.end()) {
         // very strong preference for Hs:
         if (bond->getOtherAtom(atom)->getAtomicNum() == 1) {
-          nbrScores.push_back(std::make_pair(
-              -1000000, bid));  // lower than anything else can be
+          nbrScores.emplace_back(
+              -1000000, bid);  // lower than anything else can be
           continue;
         }
         // prefer lower atomic numbers with lower degrees and no specified
@@ -201,7 +201,7 @@ INT_MAP_INT pickBondsToWedge(const ROMol &mol) {
         // std::cerr << "    nrbScore: " << idx << " - " << oIdx << " : "
         //           << nbrScore << " nChiralNbrs: " << nChiralNbrs[oIdx]
         //           << std::endl;
-        nbrScores.push_back(std::make_pair(nbrScore, bid));
+        nbrScores.emplace_back(nbrScore, bid);
       }
     }
     // There's still one situation where this whole thing can fail: an unlucky

--- a/Code/GraphMol/FileParsers/MolFileWriter.cpp
+++ b/Code/GraphMol/FileParsers/MolFileWriter.cpp
@@ -530,7 +530,7 @@ unsigned int getAtomParityFlag(const Atom *atom, const Conformer *conf) {
     if (at->getAtomicNum() == 1) {
       idx += mol.getNumAtoms();
     }
-    vs.push_back(std::make_pair(idx, v));
+    vs.emplace_back(idx, v);
     ++nbrIdx;
   }
   std::sort(vs.begin(), vs.end(),

--- a/Code/GraphMol/FileParsers/SequenceParsers.cpp
+++ b/Code/GraphMol/FileParsers/SequenceParsers.cpp
@@ -1505,7 +1505,7 @@ static const char *ParseHELMPeptide(RWMol *mol, const char *ptr,
         Atom *n = CreateAAAtom(mol, " N  ", info);
         CreateAABond(mol, vseq[len - 1].r2, n, 1);
         vseq[len - 1].r2 = (Atom *)nullptr;
-        vseq.push_back(HELMMonomer());
+        vseq.emplace_back();
         len++;
         return ptr + 5;
       }

--- a/Code/GraphMol/FileParsers/SequenceParsers.cpp
+++ b/Code/GraphMol/FileParsers/SequenceParsers.cpp
@@ -1133,12 +1133,12 @@ RWMol *FASTAToMol(const std::string &seq, bool sanitize, bool lowerD) {
 }
 
 struct HELMMonomer {
-  Atom *r1;
-  Atom *r2;
-  Atom *r3;
-  Atom *oxt;
+  Atom *r1{nullptr};
+  Atom *r2{nullptr};
+  Atom *r3{nullptr};
+  Atom *oxt{nullptr};
 
-  HELMMonomer() : r1(nullptr), r2(nullptr), r3(nullptr), oxt(nullptr) {}
+  HELMMonomer()  {}
   HELMMonomer(Atom *x, Atom *y, Atom *z) : r1(x), r2(y), r3(z), oxt(nullptr) {}
 };
 

--- a/Code/GraphMol/FileParsers/SmilesMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/SmilesMolSupplier.cpp
@@ -403,7 +403,7 @@ void SmilesMolSupplier::moveTo(unsigned int idx) {
              << "ran out of lines\n";
       throw FileParseException(errout.str());
     } else {
-      d_molpos.push_back(nextP);
+      d_molpos.emplace_back(nextP);
       d_lineNums.push_back(d_line);
       if (d_molpos.size() == idx + 1 && df_end) {
         // boundary condition: we could read the point we were looking for
@@ -521,7 +521,7 @@ unsigned int SmilesMolSupplier::length() {
     }
     int pos = this->skipComments();
     while (pos >= 0) {
-      d_molpos.push_back(pos);
+      d_molpos.emplace_back(pos);
       d_lineNums.push_back(d_line);
       pos = this->skipComments();
     }

--- a/Code/GraphMol/FileParsers/test1.cpp
+++ b/Code/GraphMol/FileParsers/test1.cpp
@@ -4354,7 +4354,7 @@ void testPDBResidues() {
     TEST_ASSERT(m->getAtomWithIdx(0)->getMonomerInfo()->getMonomerType() ==
                 AtomMonomerInfo::PDBRESIDUE);
     std::vector<std::string> keep;
-    keep.push_back("8NH");
+    keep.emplace_back("8NH");
     std::map<std::string, boost::shared_ptr<ROMol>> res =
         MolOps::getMolFragsWithQuery(*m, getResidue, false, &keep);
 
@@ -4380,7 +4380,7 @@ void testPDBResidues() {
     TEST_ASSERT(m->getAtomWithIdx(0)->getMonomerInfo()->getMonomerType() ==
                 AtomMonomerInfo::PDBRESIDUE);
     std::vector<std::string> keep;
-    keep.push_back("8NH");
+    keep.emplace_back("8NH");
     std::map<std::string, boost::shared_ptr<ROMol>> res =
         MolOps::getMolFragsWithQuery(*m, getResidue, false, &keep, true);
 

--- a/Code/GraphMol/FilterCatalog/FilterCatalog.cpp
+++ b/Code/GraphMol/FilterCatalog/FilterCatalog.cpp
@@ -229,7 +229,7 @@ const std::vector<FilterCatalog::CONST_SENTRY> FilterCatalog::getMatches(
   std::vector<CONST_SENTRY> result;
   for (const auto &d_entry : d_entries) {
     if (d_entry->hasFilterMatch(mol)) {
-      result.push_back(d_entry);
+      result.emplace_back(d_entry);
     }
   }
   return result;

--- a/Code/GraphMol/FilterCatalog/FilterMatchers.cpp
+++ b/Code/GraphMol/FilterCatalog/FilterMatchers.cpp
@@ -94,7 +94,7 @@ bool SmartsMatcher::getMatches(const ROMol &mol,
     RDKit::MatchVectType match;
     onPatExists = RDKit::SubstructMatch(mol, *d_pattern.get(), match);
     if (onPatExists) {
-      matchVect.push_back(FilterMatch(copy(), match));
+      matchVect.emplace_back(copy(), match);
     }
   } else {  // need to count
     const bool uniquify = true;
@@ -105,7 +105,7 @@ bool SmartsMatcher::getMatches(const ROMol &mol,
     if (onPatExists) {
       boost::shared_ptr<FilterMatcherBase> clone = copy();
       for (auto &match : matches) {
-        matchVect.push_back(FilterMatch(clone, match));
+        matchVect.emplace_back(clone, match);
       }
     }
   }

--- a/Code/GraphMol/FilterCatalog/FilterMatchers.h
+++ b/Code/GraphMol/FilterCatalog/FilterMatchers.h
@@ -229,7 +229,7 @@ class RDKIT_FILTERCATALOG_EXPORT Not : public FilterMatcherBase {
 RDKIT_FILTERCATALOG_EXPORT extern const char *SMARTS_MATCH_NAME_DEFAULT;
 class RDKIT_FILTERCATALOG_EXPORT SmartsMatcher : public FilterMatcherBase {
   ROMOL_SPTR d_pattern;
-  unsigned int d_min_count;
+  unsigned int d_min_count{0};
   unsigned int d_max_count;
 
  public:
@@ -237,7 +237,7 @@ class RDKIT_FILTERCATALOG_EXPORT SmartsMatcher : public FilterMatcherBase {
   SmartsMatcher(const std::string &name = SMARTS_MATCH_NAME_DEFAULT)
       : FilterMatcherBase(name),
         d_pattern(),
-        d_min_count(0),
+        
         d_max_count(UINT_MAX) {}
 
   //! Construct a SmartsMatcher from a query molecule

--- a/Code/GraphMol/Fingerprints/MorganFingerprints.cpp
+++ b/Code/GraphMol/Fingerprints/MorganFingerprints.cpp
@@ -146,9 +146,9 @@ void calcFingerprint(const ROMol &mol, unsigned int radius,
     std::vector<std::pair<int32_t, uint32_t>> ordering;
     for (unsigned int i = 0; i < nAtoms; ++i) {
       if (!(*invariants)[i]) {
-        ordering.push_back(std::make_pair(1, i));
+        ordering.emplace_back(1, i);
       } else {
-        ordering.push_back(std::make_pair(0, i));
+        ordering.emplace_back(0, i);
       }
     }
     std::sort(ordering.begin(), ordering.end());
@@ -197,7 +197,7 @@ void calcFingerprint(const ROMol &mol, unsigned int radius,
                    static_cast<int32_t>(bond->getStereo());
             }
           }
-          nbrs.push_back(std::make_pair(bt, (*invariants)[oIdx]));
+          nbrs.emplace_back(bt, (*invariants)[oIdx]);
 
           ++beg;
         }

--- a/Code/GraphMol/Fingerprints/MorganGenerator.cpp
+++ b/Code/GraphMol/Fingerprints/MorganGenerator.cpp
@@ -204,9 +204,9 @@ MorganEnvGenerator<OutputType>::getEnvironments(
     std::vector<std::pair<int32_t, uint32_t>> ordering;
     for (unsigned int i = 0; i < nAtoms; ++i) {
       if (!currentInvariants[i]) {
-        ordering.push_back(std::make_pair(1, i));
+        ordering.emplace_back(1, i);
       } else {
-        ordering.push_back(std::make_pair(0, i));
+        ordering.emplace_back(0, i);
       }
     }
     std::sort(ordering.begin(), ordering.end());

--- a/Code/GraphMol/Fingerprints/testFingerprintGenerators.cpp
+++ b/Code/GraphMol/Fingerprints/testFingerprintGenerators.cpp
@@ -2381,19 +2381,19 @@ void testBulkFP() {
 
   BOOST_FOREACH (std::string sm, smis) { molVect.push_back(SmilesToMol(sm)); }
 
-  testPairs.push_back(std::pair<FingerprintGenerator<std::uint64_t> *, FPType>(
-      AtomPair::getAtomPairGenerator<std::uint64_t>(), FPType::AtomPairFP));
+  testPairs.emplace_back(
+      AtomPair::getAtomPairGenerator<std::uint64_t>(), FPType::AtomPairFP);
 
-  testPairs.push_back(std::pair<FingerprintGenerator<std::uint64_t> *, FPType>(
+  testPairs.emplace_back(
       MorganFingerprint::getMorganGenerator<std::uint64_t>(2),
-      FPType::MorganFP));
+      FPType::MorganFP);
 
-  testPairs.push_back(std::pair<FingerprintGenerator<std::uint64_t> *, FPType>(
-      RDKitFP::getRDKitFPGenerator<std::uint64_t>(), FPType::RDKitFP));
+  testPairs.emplace_back(
+      RDKitFP::getRDKitFPGenerator<std::uint64_t>(), FPType::RDKitFP);
 
-  testPairs.push_back(std::pair<FingerprintGenerator<std::uint64_t> *, FPType>(
+  testPairs.emplace_back(
       TopologicalTorsion::getTopologicalTorsionGenerator<std::uint64_t>(),
-      FPType::TopologicalTorsionFP));
+      FPType::TopologicalTorsionFP);
 
   BOOST_FOREACH (auto it, testPairs) {
     std::vector<SparseIntVect<std::uint64_t> *> *results =

--- a/Code/GraphMol/ForceFieldHelpers/CrystalFF/TorsionAngleM6.h
+++ b/Code/GraphMol/ForceFieldHelpers/CrystalFF/TorsionAngleM6.h
@@ -34,7 +34,7 @@ class RDKIT_FORCEFIELDHELPERS_EXPORT TorsionAngleContribM6
     : public ForceFields::ForceFieldContrib {
  public:
   TorsionAngleContribM6()
-      : d_at1Idx(-1), d_at2Idx(-1), d_at3Idx(-1), d_at4Idx(-1){};
+       {};
   //! Constructor
   /*!
    The torsion is between atom1 - atom2 - atom3 - atom4
@@ -59,7 +59,7 @@ class RDKIT_FORCEFIELDHELPERS_EXPORT TorsionAngleContribM6
   };
 
  private:
-  int d_at1Idx, d_at2Idx, d_at3Idx, d_at4Idx;
+  int d_at1Idx{-1}, d_at2Idx{-1}, d_at3Idx{-1}, d_at4Idx{-1};
   std::vector<double> d_V;
   std::vector<int> d_sign;
 };

--- a/Code/GraphMol/ForceFieldHelpers/CrystalFF/TorsionPreferences.cpp
+++ b/Code/GraphMol/ForceFieldHelpers/CrystalFF/TorsionPreferences.cpp
@@ -226,8 +226,7 @@ void getExperimentalTorsions(const RDKit::ROMol &mol, CrystalFFDetails &details,
           atoms[2] = aid3;
           atoms[3] = aid4;
           details.expTorsionAtoms.push_back(atoms);
-          details.expTorsionAngles.push_back(
-              std::make_pair(param.signs, param.V));
+          details.expTorsionAngles.emplace_back(param.signs, param.V);
           if (verbose) {
             std::cout << param.smarts << ": " << aid1 << " " << aid2 << " "
                       << aid3 << " " << aid4 << ", (";
@@ -334,7 +333,7 @@ void getExperimentalTorsions(const RDKit::ROMol &mol, CrystalFFDetails &details,
           signs[1] = -1;  // MMFF sign for m = 2
           std::vector<double> fconsts(6, 0.0);
           fconsts[1] = 100.0;  // 7.0 is MMFF force constants for aromatic rings
-          details.expTorsionAngles.push_back(std::make_pair(signs, fconsts));
+          details.expTorsionAngles.emplace_back(signs, fconsts);
           /*if (verbose) {
             std::cout << "SP2 ring: " << aid1 << " " << aid2 << " " << aid3 << "
           " << aid4 << std::endl;

--- a/Code/GraphMol/ForceFieldHelpers/MMFF/AtomTyper.cpp
+++ b/Code/GraphMol/ForceFieldHelpers/MMFF/AtomTyper.cpp
@@ -106,7 +106,7 @@ const MMFFVdWCollection *getMMFFVdW() {
 }  // namespace DefaultParameters
 class RingMembership {
  public:
-  RingMembership() : d_isInAromaticRing(false){};
+  RingMembership()  {};
   bool getIsInAromaticRing() const { return d_isInAromaticRing; }
   void setIsInAromaticRing(bool isInAromaticRing) {
     d_isInAromaticRing = isInAromaticRing;
@@ -115,7 +115,7 @@ class RingMembership {
   std::set<std::uint32_t> &getRingIdxSet() { return d_ringIdxSet; }
 
  private:
-  bool d_isInAromaticRing;
+  bool d_isInAromaticRing{false};
   std::set<std::uint32_t> d_ringIdxSet;
 };
 

--- a/Code/GraphMol/ForceFieldHelpers/MMFF/AtomTyper.h
+++ b/Code/GraphMol/ForceFieldHelpers/MMFF/AtomTyper.h
@@ -47,11 +47,11 @@ using namespace ForceFields::MMFF;
 class RDKIT_FORCEFIELDHELPERS_EXPORT MMFFAtomProperties {
  public:
   MMFFAtomProperties()
-      : mmffAtomType(0), mmffFormalCharge(0.0), mmffPartialCharge(0.0){};
+       {};
   ~MMFFAtomProperties(){};
-  std::uint8_t mmffAtomType;
-  double mmffFormalCharge;
-  double mmffPartialCharge;
+  std::uint8_t mmffAtomType{0};
+  double mmffFormalCharge{0.0};
+  double mmffPartialCharge{0.0};
 };
 
 typedef boost::shared_ptr<MMFFAtomProperties> MMFFAtomPropertiesPtr;

--- a/Code/GraphMol/ForceFieldHelpers/MMFF/testMultiThread.cpp
+++ b/Code/GraphMol/ForceFieldHelpers/MMFF/testMultiThread.cpp
@@ -55,7 +55,7 @@ void testMMFFMultiThread() {
   unsigned int count = 24;
   std::vector<std::vector<ROMol*>> mols;
   for (unsigned int i = 0; i < count; ++i) {
-    mols.push_back(std::vector<ROMol *>());
+    mols.emplace_back();
   }
 
   while (!suppl.atEnd() && mols.size() < 100) {

--- a/Code/GraphMol/FragCatalog/FragCatalogEntry.h
+++ b/Code/GraphMol/FragCatalog/FragCatalogEntry.h
@@ -27,7 +27,7 @@ namespace RDKit {
 class RDKIT_FRAGCATALOG_EXPORT FragCatalogEntry
     : public RDCatalog::CatalogEntry {
  public:
-  FragCatalogEntry() : dp_mol(nullptr), d_descrip(""), d_order(0) {
+  FragCatalogEntry() :  d_descrip("") {
     dp_props = new Dict();
     setBitId(-1);
   }
@@ -117,12 +117,12 @@ class RDKIT_FRAGCATALOG_EXPORT FragCatalogEntry
   void initFromString(const std::string &text);
 
  private:
-  ROMol *dp_mol;
+  ROMol *dp_mol{nullptr};
   Dict *dp_props;
 
   std::string d_descrip;
 
-  unsigned int d_order;
+  unsigned int d_order{0};
 
   // a map between the atom ids in mol that connect to
   // a functional group and the corresponding functional

--- a/Code/GraphMol/MMPA/MMPA.cpp
+++ b/Code/GraphMol/MMPA/MMPA.cpp
@@ -78,7 +78,7 @@ static inline void convertMatchingToBondVect(
     const std::vector<MatchVectType>& matching_atoms, const ROMol& mol) {
   RDUNUSED_PARAM(mol);
   for (const auto& matching_atom : matching_atoms) {
-    matching_bonds.push_back(BondVector_t());
+    matching_bonds.emplace_back();
     BondVector_t& mb = matching_bonds.back();  // current match
     // assume pattern is only one bond pattern
     auto a1 = (unsigned)matching_atom[0].second;  // mol atom 1 index
@@ -346,7 +346,7 @@ static void addResult(std::vector<std::pair<ROMOL_SPTR, ROMOL_SPTR>>&
           // std::cerr << "atom_idx: " << atom_idx << " rank: " <<
           // ranks[atom_idx] <<
           //    " molAtomMapNumber: " << label << std::endl;
-          rankedAtoms.push_back(std::make_pair(idx, label));
+          rankedAtoms.emplace_back(idx, label);
         }
       }
       std::sort(rankedAtoms.begin(), rankedAtoms.end());
@@ -390,7 +390,7 @@ static void addResult(std::vector<std::pair<ROMOL_SPTR, ROMOL_SPTR>>&
       }
     }
 
-    res.push_back(std::pair<ROMOL_SPTR, ROMOL_SPTR>(core, side_chains));  //
+    res.emplace_back(core, side_chains);  //
   }
 #ifdef MMPA_DEBUG
   else

--- a/Code/GraphMol/MolAlign/O3AAlignMolecules.h
+++ b/Code/GraphMol/MolAlign/O3AAlignMolecules.h
@@ -76,8 +76,7 @@ class RDKIT_MOLALIGN_EXPORT O3AConstraintVect {
     o3aConstraint->d_prbIdx = prbIdx;
     o3aConstraint->d_refIdx = refIdx;
     o3aConstraint->d_weight = weight;
-    d_o3aConstraintVect.push_back(
-        boost::shared_ptr<O3AConstraint>(o3aConstraint));
+    d_o3aConstraintVect.emplace_back(o3aConstraint);
     std::sort(d_o3aConstraintVect.begin(), d_o3aConstraintVect.end(),
               d_compareO3AConstraint);
     ++d_count;

--- a/Code/GraphMol/MolAlign/O3AAlignMolecules.h
+++ b/Code/GraphMol/MolAlign/O3AAlignMolecules.h
@@ -68,7 +68,7 @@ class RDKIT_MOLALIGN_EXPORT O3AConstraint {
 //! they were appended.
 class RDKIT_MOLALIGN_EXPORT O3AConstraintVect {
  public:
-  O3AConstraintVect() : d_count(0){};
+  O3AConstraintVect()  {};
   ~O3AConstraintVect(){};
   void append(unsigned int prbIdx, unsigned int refIdx, double weight) {
     O3AConstraint *o3aConstraint = new O3AConstraint();
@@ -90,7 +90,7 @@ class RDKIT_MOLALIGN_EXPORT O3AConstraintVect {
   }
 
  private:
-  unsigned int d_count;
+  unsigned int d_count{0};
   std::vector<boost::shared_ptr<O3AConstraint>> d_o3aConstraintVect;
   static bool d_compareO3AConstraint(boost::shared_ptr<O3AConstraint> a,
                                      boost::shared_ptr<O3AConstraint> b) {

--- a/Code/GraphMol/MolCatalog/MolCatalogEntry.h
+++ b/Code/GraphMol/MolCatalog/MolCatalogEntry.h
@@ -16,7 +16,7 @@ class ROMol;
 //! This class is used to store ROMol objects in a MolCatalog
 class RDKIT_MOLCATALOG_EXPORT MolCatalogEntry : public RDCatalog::CatalogEntry {
  public:
-  MolCatalogEntry() : dp_mol(nullptr), d_order(0), d_descrip("") {
+  MolCatalogEntry() :  d_descrip("") {
     dp_props = new Dict();
     setBitId(-1);
   }
@@ -96,10 +96,10 @@ class RDKIT_MOLCATALOG_EXPORT MolCatalogEntry : public RDCatalog::CatalogEntry {
   void initFromString(const std::string &text);
 
  private:
-  const ROMol *dp_mol;
+  const ROMol *dp_mol{nullptr};
   Dict *dp_props;
 
-  unsigned int d_order;
+  unsigned int d_order{0};
   std::string d_descrip;
 };
 }  // namespace RDKit

--- a/Code/GraphMol/MolDraw2D/MolDraw2D.h
+++ b/Code/GraphMol/MolDraw2D/MolDraw2D.h
@@ -64,11 +64,11 @@ struct DrawColour {
 // for holding dimensions of the rectangle round a string.
 struct StringRect {
   Point2D centre_;
-  double width_{0.0}, height_{0.0};
-  int clash_score_{0};  // rough measure of how badly it clashed with other things
-                     // lower is better, 0 is no clash.
-  StringRect()
-      : centre_(0.0, 0.0) {}
+  double width_{0.0};
+  double height_{0.0};
+  int clash_score_{0};  // rough measure of how badly it clashed with other
+                        // things lower is better, 0 is no clash.
+  StringRect() : centre_(0.0, 0.0) {}
   StringRect(const Point2D &in_cds)
       : centre_(in_cds), width_(0.0), height_(0.0), clash_score_(0) {}
   // tl is top, left; br is bottom, right
@@ -213,7 +213,7 @@ struct RDKIT_MOLDRAW2D_EXPORT MolDrawOptions {
 //! MolDraw2D is the base class for doing 2D renderings of molecules
 class RDKIT_MOLDRAW2D_EXPORT MolDraw2D {
  public:
-  enum class OrientType: unsigned char { C = 0, N, E, S, W };
+  enum class OrientType : unsigned char { C = 0, N, E, S, W };
   // for aligning the drawing of text to the passed in coords.
   typedef enum { START, MIDDLE, END } AlignType;
   typedef enum {
@@ -819,7 +819,7 @@ RDKIT_MOLDRAW2D_EXPORT bool doesLineIntersectLabel(const Point2D &ls,
                                                    const Point2D &lf,
                                                    const StringRect &lab_rect);
 
-std::ostream& operator<<(std::ostream &oss, const MolDraw2D::OrientType &o);
+std::ostream &operator<<(std::ostream &oss, const MolDraw2D::OrientType &o);
 
 }  // namespace RDKit
 

--- a/Code/GraphMol/MolDraw2D/MolDraw2D.h
+++ b/Code/GraphMol/MolDraw2D/MolDraw2D.h
@@ -64,11 +64,11 @@ struct DrawColour {
 // for holding dimensions of the rectangle round a string.
 struct StringRect {
   Point2D centre_;
-  double width_, height_;
-  int clash_score_;  // rough measure of how badly it clashed with other things
+  double width_{0.0}, height_{0.0};
+  int clash_score_{0};  // rough measure of how badly it clashed with other things
                      // lower is better, 0 is no clash.
   StringRect()
-      : centre_(0.0, 0.0), width_(0.0), height_(0.0), clash_score_(0) {}
+      : centre_(0.0, 0.0) {}
   StringRect(const Point2D &in_cds)
       : centre_(in_cds), width_(0.0), height_(0.0), clash_score_(0) {}
   // tl is top, left; br is bottom, right

--- a/Code/GraphMol/MolInterchange/Parser.cpp
+++ b/Code/GraphMol/MolInterchange/Parser.cpp
@@ -484,7 +484,7 @@ std::vector<boost::shared_ptr<ROMol>> DocToMols(
       processMol(mol, molval, atomDefaults, bondDefaults, params);
       mol->updatePropertyCache(params.strictValenceCheck);
       mol->setProp(common_properties::_StereochemDone, 1);
-      res.push_back(boost::shared_ptr<ROMol>(static_cast<ROMol *>(mol)));
+      res.emplace_back(static_cast<ROMol *>(mol));
     }
   }
 

--- a/Code/GraphMol/MolStandardize/AcidBaseCatalog/AcidBaseCatalogParams.cpp
+++ b/Code/GraphMol/MolStandardize/AcidBaseCatalog/AcidBaseCatalogParams.cpp
@@ -33,8 +33,7 @@ AcidBaseCatalogParams::AcidBaseCatalogParams(
   const std::vector<std::pair<ROMOL_SPTR, ROMOL_SPTR>> &abpairs =
       other.getPairs();
   for (auto &pairi : abpairs) {
-    d_pairs.push_back(
-        std::pair<ROMOL_SPTR, ROMOL_SPTR>(pairi.first, pairi.second));
+    d_pairs.emplace_back(pairi.first, pairi.second);
   }
 }
 

--- a/Code/GraphMol/MolStandardize/AcidBaseCatalog/AcidBaseCatalogUtils.cpp
+++ b/Code/GraphMol/MolStandardize/AcidBaseCatalog/AcidBaseCatalogUtils.cpp
@@ -93,8 +93,8 @@ std::vector<std::pair<ROMOL_SPTR, ROMOL_SPTR>> readPairs(std::istream& inStream,
     // parse the molpair on this line (if there is one)
     std::shared_ptr<std::pair<ROMol*, ROMol*>> mol_pair(getPair(tmpstr));
     if (mol_pair != nullptr) {
-      pairs.push_back(std::pair<ROMOL_SPTR, ROMOL_SPTR>(
-          ROMOL_SPTR(mol_pair->first), ROMOL_SPTR(mol_pair->second)));
+      pairs.emplace_back(
+          ROMOL_SPTR(mol_pair->first), ROMOL_SPTR(mol_pair->second));
       nRead++;
     }
   }

--- a/Code/GraphMol/MolStandardize/Fragment.cpp
+++ b/Code/GraphMol/MolStandardize/Fragment.cpp
@@ -213,7 +213,7 @@ ROMol *LargestFragmentChooser::choose(const ROMol &mol) {
 }
 
 LargestFragmentChooser::Largest::Largest()
-    : Smiles(""), Fragment(nullptr), NumAtoms(0), Weight(0), Organic(false) {}
+    : Smiles(""), Fragment(nullptr) {}
 
 LargestFragmentChooser::Largest::Largest(std::string &smiles,
                                          boost::shared_ptr<ROMol> fragment,

--- a/Code/GraphMol/MolStandardize/Fragment.cpp
+++ b/Code/GraphMol/MolStandardize/Fragment.cpp
@@ -79,7 +79,7 @@ ROMol *FragmentRemover::remove(const ROMol &mol) {
   std::vector<std::pair<boost::shared_ptr<ROMol>, unsigned int>> frags;
   for (const auto frag :
        MolOps::getMolFrags(mol, sanitizeFrags, nullptr, &atomFragMapping)) {
-    frags.push_back(std::make_pair(frag, frags.size()));
+    frags.emplace_back(frag, frags.size());
   }
 
   for (auto &fgci : fgrps) {

--- a/Code/GraphMol/MolStandardize/Fragment.h
+++ b/Code/GraphMol/MolStandardize/Fragment.h
@@ -70,9 +70,9 @@ class RDKIT_MOLSTANDARDIZE_EXPORT LargestFragmentChooser {
             unsigned int &numatoms, double &weight, bool &organic);
     std::string Smiles;
     boost::shared_ptr<ROMol> Fragment;
-    unsigned int NumAtoms;
-    double Weight;
-    bool Organic;
+    unsigned int NumAtoms{0};
+    double Weight{0};
+    bool Organic{false};
   };
 
  private:

--- a/Code/GraphMol/MolStandardize/FragmentCatalog/FragmentCatalogEntry.h
+++ b/Code/GraphMol/MolStandardize/FragmentCatalog/FragmentCatalogEntry.h
@@ -23,7 +23,7 @@ namespace MolStandardize {
 class RDKIT_MOLSTANDARDIZE_EXPORT FragmentCatalogEntry
     : public RDCatalog::CatalogEntry {
  public:
-  FragmentCatalogEntry() : dp_mol(nullptr), d_descrip("") {
+  FragmentCatalogEntry() :  d_descrip("") {
     dp_props = new Dict();
     setBitId(-1);
   }
@@ -48,7 +48,7 @@ class RDKIT_MOLSTANDARDIZE_EXPORT FragmentCatalogEntry
   void initFromString(const std::string &text) override;
 
  private:
-  ROMol *dp_mol;
+  ROMol *dp_mol{nullptr};
   Dict *dp_props;
   std::string d_descrip;
 

--- a/Code/GraphMol/MolStandardize/MolStandardize.h
+++ b/Code/GraphMol/MolStandardize/MolStandardize.h
@@ -50,13 +50,13 @@ struct RDKIT_MOLSTANDARDIZE_EXPORT CleanupParameters {
   // std::vector<std::string> chargeCorrections;
   std::string tautomerTransforms;
   // std::vector<std::string> TautomerScores;
-  int maxRestarts;     // The maximum number of times to attempt to apply the
+  int maxRestarts{200};     // The maximum number of times to attempt to apply the
                        // series of normalizations (default 200).
-  int maxTautomers;    // The maximum number of tautomers to enumerate (default
+  int maxTautomers{1000};    // The maximum number of tautomers to enumerate (default
                        // 1000).
-  bool preferOrganic;  // Whether to prioritize organic fragments when choosing
+  bool preferOrganic{false};  // Whether to prioritize organic fragments when choosing
                        // fragment parent (default False).
-  bool doCanonical;    // whether or not to apply normalizations in a canonical
+  bool doCanonical{true};    // whether or not to apply normalizations in a canonical
                        // order
 
   CleanupParameters()
@@ -67,12 +67,8 @@ struct RDKIT_MOLSTANDARDIZE_EXPORT CleanupParameters {
         fragmentFile(rdbase + "/Data/MolStandardize/fragmentPatterns.txt"),
         // chargeCorrections()
         tautomerTransforms(rdbase +
-                           "/Data/MolStandardize/tautomerTransforms.in"),
-        // TautomerScores()
-        maxRestarts(200),
-        maxTautomers(1000),
-        preferOrganic(false),
-        doCanonical(true) {}
+                           "/Data/MolStandardize/tautomerTransforms.in")
+        {}
 };
 
 RDKIT_MOLSTANDARDIZE_EXPORT extern const CleanupParameters

--- a/Code/GraphMol/MolStandardize/TransformCatalog/TransformCatalogEntry.h
+++ b/Code/GraphMol/MolStandardize/TransformCatalog/TransformCatalogEntry.h
@@ -24,7 +24,7 @@ namespace MolStandardize {
 class RDKIT_MOLSTANDARDIZE_EXPORT TransformCatalogEntry
     : public RDCatalog::CatalogEntry {
  public:
-  TransformCatalogEntry() : dp_transform(nullptr), d_descrip("") {
+  TransformCatalogEntry() :  d_descrip("") {
     dp_props = new Dict();
     setBitId(-1);
   }
@@ -45,7 +45,7 @@ class RDKIT_MOLSTANDARDIZE_EXPORT TransformCatalogEntry
   void initFromString(const std::string &text) override;
 
  private:
-  ChemicalReaction *dp_transform;
+  ChemicalReaction *dp_transform{nullptr};
   Dict *dp_props;
   std::string d_descrip;
 

--- a/Code/GraphMol/MolStandardize/Validate.cpp
+++ b/Code/GraphMol/MolStandardize/Validate.cpp
@@ -37,8 +37,7 @@ std::vector<ValidationErrorInfo> RDKitValidation::validate(
   unsigned int na = mol.getNumAtoms();
 
   if (!na) {
-    errors.push_back(
-        ValidationErrorInfo("ERROR: [NoAtomValidation] Molecule has no atoms"));
+    errors.emplace_back("ERROR: [NoAtomValidation] Molecule has no atoms");
   }
 
   // loop over atoms
@@ -52,8 +51,8 @@ std::vector<ValidationErrorInfo> RDKitValidation::validate(
     try {
       atom->calcExplicitValence();
     } catch (const MolSanitizeException &e) {
-      errors.push_back(ValidationErrorInfo("INFO: [ValenceValidation] " +
-                                           std::string(e.what())));
+      errors.emplace_back("INFO: [ValenceValidation] " +
+                                           std::string(e.what()));
     }
   }
   return errors;
@@ -65,8 +64,7 @@ void NoAtomValidation::run(const ROMol &mol, bool reportAllFailures,
   unsigned int na = mol.getNumAtoms();
 
   if (!na) {
-    errors.push_back(
-        ValidationErrorInfo("ERROR: [NoAtomValidation] Molecule has no atoms"));
+    errors.emplace_back("ERROR: [NoAtomValidation] Molecule has no atoms");
   }
 }
 
@@ -125,8 +123,7 @@ void FragmentValidation::run(const ROMol &mol, bool reportAllFailures,
           //					//
           if ((molfragidx == substructidx) && !fpresent) {
             std::string msg = fname + " is present";
-            errors.push_back(
-                ValidationErrorInfo("INFO: [FragmentValidation] " + msg));
+            errors.emplace_back("INFO: [FragmentValidation] " + msg);
             fpresent = true;
           }
         }
@@ -147,7 +144,7 @@ void NeutralValidation::run(const ROMol &mol, bool reportAllFailures,
       charge_str = std::to_string(charge);
     }
     std::string msg = "Not an overall neutral system (" + charge_str + ')';
-    errors.push_back(ValidationErrorInfo("INFO: [NeutralValidation] " + msg));
+    errors.emplace_back("INFO: [NeutralValidation] " + msg);
   }
 }
 
@@ -172,8 +169,8 @@ void IsotopeValidation::run(const ROMol &mol, bool reportAllFailures,
   }
 
   for (auto &isotope : isotopes) {
-    errors.push_back(ValidationErrorInfo(
-        "INFO: [IsotopeValidation] Molecule contains isotope " + isotope));
+    errors.emplace_back(
+        "INFO: [IsotopeValidation] Molecule contains isotope " + isotope);
   }
 }
 
@@ -234,9 +231,8 @@ std::vector<ValidationErrorInfo> AllowedAtomsValidation::validate(
     // if no match, append to list of errors.
     if (!match) {
       std::string symbol = qatom->getSymbol();
-      errors.push_back(
-          ValidationErrorInfo("INFO: [AllowedAtomsValidation] Atom " + symbol +
-                              " is not in allowedAtoms list"));
+      errors.emplace_back("INFO: [AllowedAtomsValidation] Atom " + symbol +
+                              " is not in allowedAtoms list");
     }
   }
   return errors;
@@ -264,9 +260,8 @@ std::vector<ValidationErrorInfo> DisallowedAtomsValidation::validate(
     // if no match, append to list of errors.
     if (match) {
       std::string symbol = qatom->getSymbol();
-      errors.push_back(
-          ValidationErrorInfo("INFO: [DisallowedAtomsValidation] Atom " +
-                              symbol + " is in disallowedAtoms list"));
+      errors.emplace_back("INFO: [DisallowedAtomsValidation] Atom " +
+                              symbol + " is in disallowedAtoms list");
     }
   }
   return errors;

--- a/Code/GraphMol/MolStandardize/testValidate.cpp
+++ b/Code/GraphMol/MolStandardize/testValidate.cpp
@@ -59,7 +59,7 @@ void testRDKitValidation() {
       "INFO: [ValenceValidation] Explicit valence for atom # 5 N, 5, is "
       "greater than permitted"};
   for (auto &query : errout3) {
-    msgs1.push_back(query.what());
+    msgs1.emplace_back(query.what());
   }
   TEST_ASSERT(msgs1 == ans1);
 
@@ -73,7 +73,7 @@ void testRDKitValidation() {
       "INFO: [ValenceValidation] Explicit valence for atom # 1 O, 3, is "
       "greater than permitted"};
   for (auto &query : errout4) {
-    msgs2.push_back(query.what());
+    msgs2.emplace_back(query.what());
   }
   TEST_ASSERT(msgs2 == ans2);
   BOOST_LOG(rdInfoLog) << "Finished" << std::endl;

--- a/Code/GraphMol/MonomerInfo.h
+++ b/Code/GraphMol/MonomerInfo.h
@@ -28,7 +28,7 @@ class RDKIT_GRAPHMOL_EXPORT AtomMonomerInfo {
 
   virtual ~AtomMonomerInfo(){};
 
-  AtomMonomerInfo() : d_monomerType(UNKNOWN), d_name(""){};
+  AtomMonomerInfo() :  d_name(""){};
   AtomMonomerInfo(AtomMonomerType typ, const std::string &nm = "")
       : d_monomerType(typ), d_name(nm){};
   AtomMonomerInfo(const AtomMonomerInfo &other)
@@ -42,7 +42,7 @@ class RDKIT_GRAPHMOL_EXPORT AtomMonomerInfo {
   virtual AtomMonomerInfo *copy() const { return new AtomMonomerInfo(*this); }
 
  private:
-  AtomMonomerType d_monomerType;
+  AtomMonomerType d_monomerType{UNKNOWN};
   std::string d_name;
 };
 

--- a/Code/GraphMol/QueryAtom.h
+++ b/Code/GraphMol/QueryAtom.h
@@ -28,7 +28,7 @@ class RDKIT_GRAPHMOL_EXPORT QueryAtom : public Atom {
  public:
   typedef Queries::Query<int, Atom const *, true> QUERYATOM_QUERY;
 
-  QueryAtom() : Atom(), dp_query(nullptr){};
+  QueryAtom() : Atom(){};
   explicit QueryAtom(int num) : Atom(num), dp_query(makeAtomNumQuery(num)){};
   explicit QueryAtom(const Atom &other)
       : Atom(other), dp_query(makeAtomNumQuery(other.getAtomicNum())){};
@@ -86,7 +86,7 @@ class RDKIT_GRAPHMOL_EXPORT QueryAtom : public Atom {
   bool QueryMatch(QueryAtom const *what) const;
 
  private:
-  QUERYATOM_QUERY *dp_query;
+  QUERYATOM_QUERY *dp_query{nullptr};
 
 };  // end o' class
 

--- a/Code/GraphMol/QueryBond.h
+++ b/Code/GraphMol/QueryBond.h
@@ -29,7 +29,7 @@ class RDKIT_GRAPHMOL_EXPORT QueryBond : public Bond {
  public:
   typedef Queries::Query<int, Bond const *, true> QUERYBOND_QUERY;
 
-  QueryBond() : Bond(), dp_query(nullptr){};
+  QueryBond() : Bond(){};
   //! initialize with a particular bond order
   explicit QueryBond(BondType bT);
   //! initialize from a bond
@@ -91,7 +91,7 @@ class RDKIT_GRAPHMOL_EXPORT QueryBond : public Bond {
                    bool maintainOrder = true);
 
  protected:
-  QUERYBOND_QUERY *dp_query;
+  QUERYBOND_QUERY *dp_query{nullptr};
 };
 
 namespace detail {

--- a/Code/GraphMol/QueryOps.h
+++ b/Code/GraphMol/QueryOps.h
@@ -693,8 +693,7 @@ class RDKIT_GRAPHMOL_EXPORT AtomRingQuery
 class RDKIT_GRAPHMOL_EXPORT RecursiveStructureQuery
     : public Queries::SetQuery<int, Atom const *, true> {
  public:
-  RecursiveStructureQuery()
-      : Queries::SetQuery<int, Atom const *, true>(), d_serialNumber(0) {
+  RecursiveStructureQuery() : Queries::SetQuery<int, Atom const *, true>() {
     setDataFunc(getAtIdx);
     setDescription("RecursiveStructure");
   };
@@ -746,7 +745,7 @@ class RDKIT_GRAPHMOL_EXPORT RecursiveStructureQuery
 #endif
  private:
   boost::shared_ptr<const ROMol> dp_queryMol;
-  unsigned int d_serialNumber;
+  unsigned int d_serialNumber{0};
 };
 
 template <typename T>
@@ -943,14 +942,11 @@ class HasPropWithValueQuery<TargetPtr, ExplicitBitVect>
     : public Queries::EqualityQuery<int, TargetPtr, true> {
   std::string propname;
   ExplicitBitVect val;
-  float tol;
+  float tol{0.0};
 
  public:
   HasPropWithValueQuery()
-      : Queries::EqualityQuery<int, TargetPtr, true>(),
-        propname(),
-        val(),
-        tol(0.0) {
+      : Queries::EqualityQuery<int, TargetPtr, true>(), propname(), val() {
     this->setDescription("HasPropWithValue");
     this->setDataFunc(0);
   };

--- a/Code/GraphMol/RGroupDecomposition/RGroupDecomp.cpp
+++ b/Code/GraphMol/RGroupDecomposition/RGroupDecomp.cpp
@@ -347,7 +347,7 @@ struct RGroupData {
   std::string
       smiles;  // smiles for all the mols in the rgroup (with attachments)
   std::set<int> attachments;  // attachment points
-  bool labelled;
+  bool labelled{false};
 
  private:
   RGroupData(const RGroupData &rhs);
@@ -358,8 +358,8 @@ struct RGroupData {
         mols(),
         smilesSet(),
         smiles(),
-        attachments(),
-        labelled(false) {}
+        attachments()
+        {}
 
   void add(boost::shared_ptr<ROMol> newMol,
            const std::vector<int> &rlabel_attachments) {

--- a/Code/GraphMol/RGroupDecomposition/RGroupDecomp.cpp
+++ b/Code/GraphMol/RGroupDecomposition/RGroupDecomp.cpp
@@ -821,7 +821,7 @@ struct RGroupDecompData {
       } else {  // adds new rlabel
         auto *newAt = new Atom(0);
         setRlabel(newAt, userLabel);
-        atomsToAdd.push_back(std::make_pair(atom, newAt));
+        atomsToAdd.emplace_back(atom, newAt);
       }
     }
 
@@ -848,7 +848,7 @@ struct RGroupDecompData {
       } else {
         auto *newAt = new Atom(0);
         setRlabel(newAt, rlabel);
-        atomsToAdd.push_back(std::make_pair(atom, newAt));
+        atomsToAdd.emplace_back(atom, newAt);
       }
     }
 
@@ -869,7 +869,7 @@ struct RGroupDecompData {
             "Multiple attachments to a dummy (or hydrogen) is weird.");
         auto *newAt = new Atom(0);
         setRlabel(newAt, rlabel);
-        atomsToAdd.push_back(std::make_pair(atom, newAt));
+        atomsToAdd.emplace_back(atom, newAt);
       }
     }
 
@@ -910,7 +910,7 @@ struct RGroupDecompData {
           } else {
             auto *newAt = new Atom(0);
             setRlabel(newAt, label->second);
-            atomsToAdd.push_back(std::make_pair(atom, newAt));
+            atomsToAdd.emplace_back(atom, newAt);
           }
         }
       }
@@ -1308,7 +1308,7 @@ int RGroupDecomposition::add(const ROMol &inmol) {
       }
 
       if (match.size()) {
-        potentialMatches.push_back(RGroupMatch(core_idx, match));
+        potentialMatches.emplace_back(core_idx, match);
       }
     }
   }

--- a/Code/GraphMol/RGroupDecomposition/RGroupDecomp.h
+++ b/Code/GraphMol/RGroupDecomposition/RGroupDecomp.h
@@ -78,8 +78,8 @@ struct RDKIT_RGROUPDECOMPOSITION_EXPORT RGroupDecompositionParameters {
         chunkSize(chunkSize),
         onlyMatchAtRGroups(matchOnlyAtRGroups),
         removeAllHydrogenRGroups(removeHydrogenOnlyGroups),
-        removeHydrogensPostMatch(removeHydrogensPostMatch),
-        indexOffset(-1) {}
+        removeHydrogensPostMatch(removeHydrogensPostMatch)
+        {}
 
   // Determine how to assign the rgroup labels from the given core
   unsigned int autoGetLabels(const RWMol &);
@@ -88,7 +88,7 @@ struct RDKIT_RGROUPDECOMPOSITION_EXPORT RGroupDecompositionParameters {
   bool prepareCore(RWMol &, const RWMol *alignCore);
 
  private:
-  int indexOffset;
+  int indexOffset{-1};
 };
 
 typedef std::map<std::string, boost::shared_ptr<ROMol>> RGroupRow;

--- a/Code/GraphMol/RGroupDecomposition/testRGroupDecomp.cpp
+++ b/Code/GraphMol/RGroupDecomposition/testRGroupDecomp.cpp
@@ -283,9 +283,9 @@ void testMultiCore() {
       << "********************************************************\n";
   BOOST_LOG(rdInfoLog) << "test multi core" << std::endl;
   std::vector<ROMOL_SPTR> cores;
-  cores.push_back(ROMOL_SPTR(SmartsToMol("C1CCNCCC1")));
-  cores.push_back(ROMOL_SPTR(SmilesToMol("C1CCOCCC1")));
-  cores.push_back(ROMOL_SPTR(SmilesToMol("C1CCSCCC1")));
+  cores.emplace_back(SmartsToMol("C1CCNCCC1"));
+  cores.emplace_back(SmilesToMol("C1CCOCCC1"));
+  cores.emplace_back(SmilesToMol("C1CCSCCC1"));
 
   RGroupDecomposition decomp(cores);
   for (unsigned int i = 0; i < sizeof(coreSmi) / sizeof(const char *); ++i) {
@@ -801,7 +801,7 @@ $$$$)CTAB";
       SDMolSupplier sdsup;
       sdsup.setData(sdcores);
       while (!sdsup.atEnd()) {
-        cores.push_back(ROMOL_SPTR(sdsup.next()));
+        cores.emplace_back(sdsup.next());
       }
     }
 
@@ -832,7 +832,7 @@ $$$$)CTAB";
       SDMolSupplier sdsup;
       sdsup.setData(sdcores);
       while (!sdsup.atEnd()) {
-        cores.push_back(ROMOL_SPTR(sdsup.next()));
+        cores.emplace_back(sdsup.next());
       }
     }
 
@@ -884,7 +884,7 @@ void testRowColumnAlignmentProblem() {
   std::vector<std::string> csmiles = {"c1c([*:1])cncn1", "c1c([*:1])cccn1"};
   std::vector<ROMOL_SPTR> cores;
   for (auto smi : csmiles) {
-    cores.push_back(ROMOL_SPTR(SmilesToMol(smi)));
+    cores.emplace_back(SmilesToMol(smi));
   }
 
   std::vector<std::string> msmiles = {"c1c(F)cccn1", "c1c(F)cncn1",

--- a/Code/GraphMol/ROMol.h
+++ b/Code/GraphMol/ROMol.h
@@ -267,7 +267,7 @@ class RDKIT_GRAPHMOL_EXPORT ROMol : public RDProps {
     return {&d_graph};
   }
 
-  ROMol() : RDProps(), numBonds(0) { initMol(); }
+  ROMol() : RDProps() { initMol(); }
 
   //! copy constructor with a twist
   /*!
@@ -681,7 +681,7 @@ class RDKIT_GRAPHMOL_EXPORT ROMol : public RDProps {
       const ROMol &);  // disable assignment, RWMol's support assignment
 
  protected:
-  unsigned int numBonds;
+  unsigned int numBonds{0};
 #ifndef WIN32
  private:
 #endif

--- a/Code/GraphMol/RWMol.cpp
+++ b/Code/GraphMol/RWMol.cpp
@@ -221,7 +221,7 @@ void RWMol::removeAtom(Atom *atom) {
   ADJ_ITER b1, b2;
   boost::tie(b1, b2) = getAtomNeighbors(atom);
   while (b1 != b2) {
-    nbrs.push_back(std::make_pair(atom->getIdx(), rdcast<unsigned int>(*b1)));
+    nbrs.emplace_back(atom->getIdx(), rdcast<unsigned int>(*b1));
     ++b1;
   }
   for (auto &nbr : nbrs) {

--- a/Code/GraphMol/Resonance.cpp
+++ b/Code/GraphMol/Resonance.cpp
@@ -46,13 +46,13 @@ class CEMetrics {
   bool operator!=(const CEMetrics &other) { return !(*this == other); }
 
  private:
-  unsigned int d_absFormalCharges;
-  unsigned int d_fcSameSignDist;
-  unsigned int d_fcOppSignDist;
-  unsigned int d_nbMissing;
-  int d_wtdFormalCharges;
-  unsigned int d_sumFormalChargeIdxs;
-  unsigned int d_sumMultipleBondIdxs;
+  unsigned int d_absFormalCharges{0};
+  unsigned int d_fcSameSignDist{0};
+  unsigned int d_fcOppSignDist{0};
+  unsigned int d_nbMissing{0};
+  int d_wtdFormalCharges{0};
+  unsigned int d_sumFormalChargeIdxs{0};
+  unsigned int d_sumMultipleBondIdxs{0};
 };
 
 class ConjElectrons {
@@ -468,13 +468,8 @@ void BondElectrons::setOrder(unsigned int bo) {
 }
 
 CEMetrics::CEMetrics()
-    : d_absFormalCharges(0),
-      d_fcSameSignDist(0),
-      d_fcOppSignDist(0),
-      d_nbMissing(0),
-      d_wtdFormalCharges(0),
-      d_sumFormalChargeIdxs(0),
-      d_sumMultipleBondIdxs(0){};
+    
+      {};
 
 bool CEMetrics::operator==(const CEMetrics &other) {
   return ((d_absFormalCharges == other.d_absFormalCharges) &&

--- a/Code/GraphMol/RingInfo.h
+++ b/Code/GraphMol/RingInfo.h
@@ -34,7 +34,7 @@ class RDKIT_GRAPHMOL_EXPORT RingInfo {
   typedef std::vector<int> INT_VECT;
   typedef std::vector<INT_VECT> VECT_INT_VECT;
 
-  RingInfo() : df_init(false){};
+  RingInfo()  {};
   RingInfo(const RingInfo &other)
       : df_init(other.df_init),
         d_atomMembers(other.d_atomMembers),
@@ -207,7 +207,7 @@ class RDKIT_GRAPHMOL_EXPORT RingInfo {
   //! pre-allocates some memory to save time later
   void preallocate(unsigned int numAtoms, unsigned int numBonds);
 
-  bool df_init;
+  bool df_init{false};
   DataType d_atomMembers, d_bondMembers;
   VECT_INT_VECT d_atomRings, d_bondRings;
   VECT_INT_VECT d_atomRingFamilies, d_bondRingFamilies;

--- a/Code/GraphMol/SLNParse/SLNAttribs.cpp
+++ b/Code/GraphMol/SLNParse/SLNAttribs.cpp
@@ -500,7 +500,7 @@ void adjustAtomChiralities(RWMol *mol) {
       boost::tie(nbrIdx, endNbrs) = mol->getAtomNeighbors(*atomIt);
       while (nbrIdx != endNbrs) {
         Bond *nbrBond = mol->getBondBetweenAtoms((*atomIt)->getIdx(), *nbrIdx);
-        neighbors.push_back(std::make_pair(*nbrIdx, nbrBond->getIdx()));
+        neighbors.emplace_back(*nbrIdx, nbrBond->getIdx());
         ++nbrIdx;
       }
 

--- a/Code/GraphMol/SLNParse/SLNAttribs.h
+++ b/Code/GraphMol/SLNParse/SLNAttribs.h
@@ -54,12 +54,12 @@ typedef enum {
 class RDKIT_SLNPARSE_EXPORT AttribType {
  public:
   AttribType()
-      : first(""), second(""), op(""), negated(false), structQuery(nullptr){};
+      : first(""), second(""), op("") {};
   std::string first;
   std::string second;
   std::string op;
-  bool negated;
-  void *structQuery;
+  bool negated{false};
+  void *structQuery{nullptr};
 };
 
 typedef std::vector<std::pair<AttribCombineOp, boost::shared_ptr<AttribType>>>

--- a/Code/GraphMol/SmilesParse/SmilesParseOps.cpp
+++ b/Code/GraphMol/SmilesParse/SmilesParseOps.cpp
@@ -229,7 +229,7 @@ void AdjustAtomChiralityFlags(RWMol *mol) {
       std::list<SIZET_PAIR> neighbors;
       // push this atom onto the list of neighbors (we'll use this
       // to find our place later):
-      neighbors.push_back(std::make_pair(atom->getIdx(), -1));
+      neighbors.emplace_back(atom->getIdx(), -1);
       std::list<size_t> bondOrder;
       for (auto nbrIdx :
            boost::make_iterator_range(mol->getAtomNeighbors(atom))) {
@@ -237,7 +237,7 @@ void AdjustAtomChiralityFlags(RWMol *mol) {
         if (std::find(ringClosures.begin(), ringClosures.end(),
                       static_cast<int>(nbrBond->getIdx())) ==
             ringClosures.end()) {
-          neighbors.push_back(std::make_pair(nbrIdx, nbrBond->getIdx()));
+          neighbors.emplace_back(nbrIdx, nbrBond->getIdx());
         }
       }
       // sort the list of non-ring-closure bonds:

--- a/Code/GraphMol/StereoGroup.h
+++ b/Code/GraphMol/StereoGroup.h
@@ -40,11 +40,11 @@ enum class StereoGroupType {
  */
 class RDKIT_GRAPHMOL_EXPORT StereoGroup {
  private:
-  StereoGroupType d_grouptype;
+  StereoGroupType d_grouptype{StereoGroupType::STEREO_ABSOLUTE};
   std::vector<Atom*> d_atoms;
 
  public:
-  StereoGroup() : d_grouptype(StereoGroupType::STEREO_ABSOLUTE), d_atoms(0u){};
+  StereoGroup() :  d_atoms(0u){};
   // Takes control of atoms if possible.
   StereoGroup(StereoGroupType grouptype, std::vector<Atom*>&& atoms);
   StereoGroup(StereoGroupType grouptype, const std::vector<Atom*>& atoms);

--- a/Code/GraphMol/Subgraphs/Subgraphs.cpp
+++ b/Code/GraphMol/Subgraphs/Subgraphs.cpp
@@ -555,7 +555,7 @@ PATH_TYPE findAtomEnvironmentOfRadiusN(const ROMol &mol, unsigned int radius,
     if (useHs ||
         mol.getAtomWithIdx(bond->getOtherAtomIdx(rootedAtAtom))
                 ->getAtomicNum() != 1) {
-      nbrStack.push_back(std::make_pair(rootedAtAtom, bond->getIdx()));
+      nbrStack.emplace_back(rootedAtAtom, bond->getIdx());
     }
     ++beg;
   }
@@ -584,7 +584,7 @@ PATH_TYPE findAtomEnvironmentOfRadiusN(const ROMol &mol, unsigned int radius,
             if (useHs ||
                 mol.getAtomWithIdx(bond->getOtherAtomIdx(oAtom))
                         ->getAtomicNum() != 1) {
-              nextLayer.push_back(std::make_pair(oAtom, bond->getIdx()));
+              nextLayer.emplace_back(oAtom, bond->getIdx());
             }
           }
           ++beg;

--- a/Code/GraphMol/Substruct/vf2.hpp
+++ b/Code/GraphMol/Substruct/vf2.hpp
@@ -33,10 +33,10 @@ struct NodeInfo {
 template <class Graph>
 struct Pair {
   node_id n1, n2;
-  bool hasiter;
+  bool hasiter{false};
   RDK_ADJ_ITER nbrbeg, nbrend;
 
-  Pair() : n1(NULL_NODE), n2(NULL_NODE), hasiter(false) {}
+  Pair() : n1(NULL_NODE), n2(NULL_NODE) {}
 };
 
 /**

--- a/Code/GraphMol/SubstructLibrary/SubstructLibrary.h
+++ b/Code/GraphMol/SubstructLibrary/SubstructLibrary.h
@@ -368,14 +368,14 @@ class RDKIT_SUBSTRUCTLIBRARY_EXPORT SubstructLibrary {
   boost::shared_ptr<MolHolderBase> molholder;
   boost::shared_ptr<FPHolderBase> fpholder;
   MolHolderBase *mols;  // used for a small optimization
-  FPHolderBase *fps;
+  FPHolderBase *fps{nullptr};
 
  public:
   SubstructLibrary()
       : molholder(new MolHolder),
         fpholder(),
-        mols(molholder.get()),
-        fps(nullptr) {}
+        mols(molholder.get())
+        {}
 
   SubstructLibrary(boost::shared_ptr<MolHolderBase> molecules)
       : molholder(molecules), fpholder(), mols(molholder.get()), fps(nullptr) {}

--- a/Code/GraphMol/SubstructLibrary/SubstructLibrary.h
+++ b/Code/GraphMol/SubstructLibrary/SubstructLibrary.h
@@ -109,7 +109,7 @@ class RDKIT_SUBSTRUCTLIBRARY_EXPORT CachedMolHolder : public MolHolderBase {
   CachedMolHolder() : MolHolderBase(), mols() {}
 
   virtual unsigned int addMol(const ROMol &m) {
-    mols.push_back(std::string());
+    mols.emplace_back();
     MolPickler::pickleMol(m, mols.back());
     return size() - 1;
   }

--- a/Code/GraphMol/hanoitest.cpp
+++ b/Code/GraphMol/hanoitest.cpp
@@ -43,10 +43,10 @@ int icmp(int a, int b) {
 }
 
 class int_compare_ftor {
-  const int *dp_ints;
+  const int *dp_ints{nullptr};
 
  public:
-  int_compare_ftor() : dp_ints(nullptr){};
+  int_compare_ftor()  {};
   int_compare_ftor(const int *ints) : dp_ints(ints){};
   int operator()(int i, int j) const {
     PRECONDITION(dp_ints, "no ints");
@@ -130,10 +130,10 @@ void test1() {
 };
 
 class atomcomparefunctor {
-  Canon::canon_atom *d_atoms;
+  Canon::canon_atom *d_atoms{nullptr};
 
  public:
-  atomcomparefunctor() : d_atoms(nullptr){};
+  atomcomparefunctor()  {};
   atomcomparefunctor(Canon::canon_atom *atoms) : d_atoms(atoms){};
   int operator()(int i, int j) const {
     PRECONDITION(d_atoms, "no atoms");
@@ -160,10 +160,10 @@ class atomcomparefunctor {
   }
 };
 class atomcomparefunctor2 {
-  Canon::canon_atom *d_atoms;
+  Canon::canon_atom *d_atoms{nullptr};
 
  public:
-  atomcomparefunctor2() : d_atoms(nullptr){};
+  atomcomparefunctor2()  {};
   atomcomparefunctor2(Canon::canon_atom *atoms) : d_atoms(atoms){};
   int operator()(int i, int j) const {
     PRECONDITION(d_atoms, "no atoms");
@@ -361,8 +361,8 @@ void test3() {
 };
 
 class atomcomparefunctor3 {
-  Canon::canon_atom *dp_atoms;
-  const ROMol *dp_mol;
+  Canon::canon_atom *dp_atoms{nullptr};
+  const ROMol *dp_mol{nullptr};
   unsigned int getAtomNeighborhood(unsigned int i) const {
     unsigned int res = 0;
     const Atom *at = dp_mol->getAtomWithIdx(i);
@@ -419,9 +419,9 @@ class atomcomparefunctor3 {
   }
 
  public:
-  bool df_useNbrs;
+  bool df_useNbrs{false};
   atomcomparefunctor3()
-      : dp_atoms(nullptr), dp_mol(nullptr), df_useNbrs(false){};
+       {};
   atomcomparefunctor3(Canon::canon_atom *atoms, const ROMol &m)
       : dp_atoms(atoms), dp_mol(&m), df_useNbrs(false){};
   int operator()(int i, int j) const {

--- a/Code/GraphMol/molopstest.cpp
+++ b/Code/GraphMol/molopstest.cpp
@@ -5302,10 +5302,10 @@ void testGithubIssue539() {
   }
   {
     std::vector<std::string> smilesVec;
-    smilesVec.push_back("C1=C[CH+]1");
-    smilesVec.push_back("C1=CC=C[CH+]C=C1");
-    smilesVec.push_back("c1c[cH+]1");
-    smilesVec.push_back("c1ccc[cH+]cc1");
+    smilesVec.emplace_back("C1=C[CH+]1");
+    smilesVec.emplace_back("C1=CC=C[CH+]C=C1");
+    smilesVec.emplace_back("c1c[cH+]1");
+    smilesVec.emplace_back("c1ccc[cH+]cc1");
     for (std::vector<std::string>::const_iterator smiles = smilesVec.begin();
          smiles != smilesVec.end(); ++smiles) {
       RWMol *m = SmilesToMol(*smiles);

--- a/Code/GraphMol/new_canon.cpp
+++ b/Code/GraphMol/new_canon.cpp
@@ -422,10 +422,10 @@ void getChiralBonds(const ROMol &mol, const Atom *at,
 
   if (!at->needsUpdatePropertyCache()) {
     for (unsigned int ii = 0; ii < at->getTotalNumHs(); ++ii) {
-      nbrs.push_back(bondholder(Bond::SINGLE, Bond::STEREONONE,
-                                ATNUM_CLASS_OFFSET, ATNUM_CLASS_OFFSET));
-      nbrs.push_back(bondholder(Bond::SINGLE, Bond::STEREONONE,
-                                ATNUM_CLASS_OFFSET, ATNUM_CLASS_OFFSET));
+      nbrs.emplace_back(Bond::SINGLE, Bond::STEREONONE,
+                                ATNUM_CLASS_OFFSET, ATNUM_CLASS_OFFSET);
+      nbrs.emplace_back(Bond::SINGLE, Bond::STEREONONE,
+                                ATNUM_CLASS_OFFSET, ATNUM_CLASS_OFFSET);
     }
   }
 }
@@ -573,20 +573,20 @@ void updateAtomNeighborNumSwaps(
       int nSwaps = static_cast<int>(countSwapsToInterconvert(ref, probe));
       if (atoms[nbrIdx].atom->getChiralTag() == Atom::CHI_TETRAHEDRAL_CW) {
         if (nSwaps % 2) {
-          result.push_back(std::make_pair(nbr.nbrSymClass, 2));
+          result.emplace_back(nbr.nbrSymClass, 2);
         } else {
-          result.push_back(std::make_pair(nbr.nbrSymClass, 1));
+          result.emplace_back(nbr.nbrSymClass, 1);
         }
       } else if (atoms[nbrIdx].atom->getChiralTag() ==
                  Atom::CHI_TETRAHEDRAL_CCW) {
         if (nSwaps % 2) {
-          result.push_back(std::make_pair(nbr.nbrSymClass, 1));
+          result.emplace_back(nbr.nbrSymClass, 1);
         } else {
-          result.push_back(std::make_pair(nbr.nbrSymClass, 2));
+          result.emplace_back(nbr.nbrSymClass, 2);
         }
       }
     } else {
-      result.push_back(std::make_pair(nbr.nbrSymClass, 0));
+      result.emplace_back(nbr.nbrSymClass, 0);
     }
   }
   sort(result.begin(), result.end());

--- a/Code/GraphMol/new_canon.h
+++ b/Code/GraphMol/new_canon.h
@@ -30,15 +30,14 @@ namespace RDKit {
 namespace Canon {
 
 struct RDKIT_GRAPHMOL_EXPORT bondholder {
-  Bond::BondType bondType;
+  Bond::BondType bondType{Bond::UNSPECIFIED};
   unsigned int bondStereo;
-  unsigned int nbrSymClass;
-  unsigned int nbrIdx;
+  unsigned int nbrSymClass{0};
+  unsigned int nbrIdx{0};
   bondholder()
-      : bondType(Bond::UNSPECIFIED),
-        bondStereo(static_cast<unsigned int>(Bond::STEREONONE)),
-        nbrSymClass(0),
-        nbrIdx(0){};
+      : 
+        bondStereo(static_cast<unsigned int>(Bond::STEREONONE))
+        {};
   bondholder(Bond::BondType bt, Bond::BondStereo bs, unsigned int ni,
              unsigned int nsc)
       : bondType(bt),
@@ -76,27 +75,21 @@ struct RDKIT_GRAPHMOL_EXPORT bondholder {
 
 class RDKIT_GRAPHMOL_EXPORT canon_atom {
  public:
-  const Atom *atom;
-  int index;
-  unsigned int degree;
-  unsigned int totalNumHs;
-  bool hasRingNbr;
-  bool isRingStereoAtom;
-  int *nbrIds;
-  const std::string *p_symbol;  // if provided, this is used to order atoms
+  const Atom *atom{nullptr};
+  int index{-1};
+  unsigned int degree{0};
+  unsigned int totalNumHs{0};
+  bool hasRingNbr{false};
+  bool isRingStereoAtom{false};
+  int *nbrIds{nullptr};
+  const std::string *p_symbol{nullptr};  // if provided, this is used to order atoms
   std::vector<int> neighborNum;
   std::vector<int> revistedNeighbors;
   std::vector<bondholder> bonds;
 
   canon_atom()
-      : atom(nullptr),
-        index(-1),
-        degree(0),
-        totalNumHs(0),
-        hasRingNbr(false),
-        isRingStereoAtom(false),
-        nbrIds(nullptr),
-        p_symbol(nullptr){};
+      
+        {};
 
   ~canon_atom() { free(nbrIds); }
 };
@@ -121,15 +114,13 @@ RDKIT_GRAPHMOL_EXPORT void updateAtomNeighborNumSwaps(
 
 class RDKIT_GRAPHMOL_EXPORT SpecialChiralityAtomCompareFunctor {
  public:
-  Canon::canon_atom *dp_atoms;
-  const ROMol *dp_mol;
-  const boost::dynamic_bitset<> *dp_atomsInPlay, *dp_bondsInPlay;
+  Canon::canon_atom *dp_atoms{nullptr};
+  const ROMol *dp_mol{nullptr};
+  const boost::dynamic_bitset<> *dp_atomsInPlay{nullptr}, *dp_bondsInPlay{nullptr};
 
   SpecialChiralityAtomCompareFunctor()
-      : dp_atoms(nullptr),
-        dp_mol(nullptr),
-        dp_atomsInPlay(nullptr),
-        dp_bondsInPlay(nullptr){};
+      
+        {};
   SpecialChiralityAtomCompareFunctor(
       Canon::canon_atom *atoms, const ROMol &m,
       const boost::dynamic_bitset<> *atomsInPlay = nullptr,
@@ -177,15 +168,13 @@ class RDKIT_GRAPHMOL_EXPORT SpecialChiralityAtomCompareFunctor {
 
 class RDKIT_GRAPHMOL_EXPORT SpecialSymmetryAtomCompareFunctor {
  public:
-  Canon::canon_atom *dp_atoms;
-  const ROMol *dp_mol;
-  const boost::dynamic_bitset<> *dp_atomsInPlay, *dp_bondsInPlay;
+  Canon::canon_atom *dp_atoms{nullptr};
+  const ROMol *dp_mol{nullptr};
+  const boost::dynamic_bitset<> *dp_atomsInPlay{nullptr}, *dp_bondsInPlay{nullptr};
 
   SpecialSymmetryAtomCompareFunctor()
-      : dp_atoms(nullptr),
-        dp_mol(nullptr),
-        dp_atomsInPlay(nullptr),
-        dp_bondsInPlay(nullptr){};
+      
+        {};
   SpecialSymmetryAtomCompareFunctor(
       Canon::canon_atom *atoms, const ROMol &m,
       const boost::dynamic_bitset<> *atomsInPlay = nullptr,
@@ -371,23 +360,17 @@ class RDKIT_GRAPHMOL_EXPORT AtomCompareFunctor {
   }
 
  public:
-  Canon::canon_atom *dp_atoms;
-  const ROMol *dp_mol;
-  const boost::dynamic_bitset<> *dp_atomsInPlay, *dp_bondsInPlay;
-  bool df_useNbrs;
-  bool df_useIsotopes;
-  bool df_useChirality;
-  bool df_useChiralityRings;
+  Canon::canon_atom *dp_atoms{nullptr};
+  const ROMol *dp_mol{nullptr};
+  const boost::dynamic_bitset<> *dp_atomsInPlay{nullptr}, *dp_bondsInPlay{nullptr};
+  bool df_useNbrs{false};
+  bool df_useIsotopes{true};
+  bool df_useChirality{true};
+  bool df_useChiralityRings{true};
 
   AtomCompareFunctor()
-      : dp_atoms(nullptr),
-        dp_mol(nullptr),
-        dp_atomsInPlay(nullptr),
-        dp_bondsInPlay(nullptr),
-        df_useNbrs(false),
-        df_useIsotopes(true),
-        df_useChirality(true),
-        df_useChiralityRings(true){};
+      
+        {};
   AtomCompareFunctor(Canon::canon_atom *atoms, const ROMol &m,
                      const boost::dynamic_bitset<> *atomsInPlay = nullptr,
                      const boost::dynamic_bitset<> *bondsInPlay = nullptr)
@@ -510,11 +493,11 @@ class RDKIT_GRAPHMOL_EXPORT ChiralAtomCompareFunctor {
   }
 
  public:
-  Canon::canon_atom *dp_atoms;
-  const ROMol *dp_mol;
-  bool df_useNbrs;
+  Canon::canon_atom *dp_atoms{nullptr};
+  const ROMol *dp_mol{nullptr};
+  bool df_useNbrs{false};
   ChiralAtomCompareFunctor()
-      : dp_atoms(nullptr), dp_mol(nullptr), df_useNbrs(false){};
+       {};
   ChiralAtomCompareFunctor(Canon::canon_atom *atoms, const ROMol &m)
       : dp_atoms(atoms), dp_mol(&m), df_useNbrs(false){};
   int operator()(int i, int j) const {

--- a/Code/Numerics/Conrec.h
+++ b/Code/Numerics/Conrec.h
@@ -186,8 +186,8 @@ inline void Contour(const double *d, size_t ilb, size_t iub, size_t jlb,
           }
 
           /* Finally draw the line */
-          res.push_back(ConrecSegment(RDGeom::Point2D(x1, y1),
-                                      RDGeom::Point2D(x2, y2), z[k]));
+          res.emplace_back(RDGeom::Point2D(x1, y1),
+                                      RDGeom::Point2D(x2, y2), z[k]);
         } /* m */
       }   /* k - contour */
     }     /* i */

--- a/Code/Numerics/Matrix.h
+++ b/Code/Numerics/Matrix.h
@@ -229,10 +229,10 @@ class Matrix {
   }
 
  protected:
-  Matrix() : d_nRows(0), d_nCols(0), d_dataSize(0), d_data(){};
-  unsigned int d_nRows;
-  unsigned int d_nCols;
-  unsigned int d_dataSize;
+  Matrix() :  d_data(){};
+  unsigned int d_nRows{0};
+  unsigned int d_nCols{0};
+  unsigned int d_dataSize{0};
   DATA_SPTR d_data;
 
  private:

--- a/Code/Numerics/SymmMatrix.h
+++ b/Code/Numerics/SymmMatrix.h
@@ -233,9 +233,9 @@ class SymmMatrix {
   }
 
  protected:
-  SymmMatrix() : d_size(0), d_dataSize(0), d_data(0){};
-  unsigned int d_size;
-  unsigned int d_dataSize;
+  SymmMatrix() :  d_data(0){};
+  unsigned int d_size{0};
+  unsigned int d_dataSize{0};
   DATA_SPTR d_data;
 
  private:

--- a/Code/PgSQL/rdkit/adapter.cpp
+++ b/Code/PgSQL/rdkit/adapter.cpp
@@ -1757,11 +1757,11 @@ extern "C" int ReactionSubstructFP(CChemicalReaction rxn,
 namespace {
 
 struct MoleculeDescriptors {
-  MoleculeDescriptors() : nAtoms(0), nBonds(0), nRings(0), MW(0.0) {}
-  unsigned nAtoms;
-  unsigned nBonds;
-  unsigned nRings;
-  double MW;
+  MoleculeDescriptors()  {}
+  unsigned nAtoms{0};
+  unsigned nBonds{0};
+  unsigned nRings{0};
+  double MW{0.0};
 };
 
 MoleculeDescriptors *calcMolecularDescriptorsReaction(

--- a/Code/Query/Query.h
+++ b/Code/Query/Query.h
@@ -54,7 +54,7 @@ class Query {
 
   Query()
       : d_description(""),
-        df_negate(false),
+        
         d_matchFunc(nullptr),
         d_dataFunc(nullptr){};
   virtual ~Query() { this->d_children.clear(); };
@@ -146,7 +146,7 @@ class Query {
   MatchFuncArgType d_tol = 0;
   std::string d_description;
   CHILD_VECT d_children;
-  bool df_negate;
+  bool df_negate{false};
   bool (*d_matchFunc)(MatchFuncArgType);
 
   // MSVC complains at compile time when TypeConvert(MatchFuncArgType what,

--- a/Code/Query/RangeQuery.h
+++ b/Code/Query/RangeQuery.h
@@ -28,7 +28,7 @@ class RangeQuery
     : public Query<MatchFuncArgType, DataFuncArgType, needsConversion> {
  public:
   RangeQuery()
-      : d_upper(0), d_lower(0), df_upperOpen(true), df_lowerOpen(true) {
+      : d_upper(0), d_lower(0) {
     this->df_negate = false;
   };
   //! construct and set the lower and upper bounds
@@ -106,7 +106,7 @@ class RangeQuery
 
  protected:
   MatchFuncArgType d_upper, d_lower;
-  bool df_upperOpen, df_lowerOpen;
+  bool df_upperOpen{true}, df_lowerOpen{true};
 };
 }  // namespace Queries
 #endif

--- a/Code/RDGeneral/Dict.h
+++ b/Code/RDGeneral/Dict.h
@@ -46,7 +46,7 @@ class RDKIT_RDGENERAL_EXPORT Dict {
 
   typedef std::vector<Pair> DataType;
 
-  Dict() : _data(), _hasNonPodData(false) {}
+  Dict()  {}
 
   Dict(const Dict &other) : _data(other._data) {
     _hasNonPodData = other._hasNonPodData;
@@ -311,8 +311,8 @@ class RDKIT_RDGENERAL_EXPORT Dict {
   }
 
  private:
-  DataType _data;       //!< the actual dictionary
-  bool _hasNonPodData;  // if true, need a deep copy
+  DataType _data{};       //!< the actual dictionary
+  bool _hasNonPodData{false};  // if true, need a deep copy
                         //  (copy_rdvalue)
 };
 

--- a/Code/RDGeneral/testDict.cpp
+++ b/Code/RDGeneral/testDict.cpp
@@ -26,9 +26,9 @@ using namespace RDKit;
 using namespace std;
 
 struct Foo {
-  int bar;
-  float baz;
-  Foo() : bar(0), baz(0.f) {}
+  int bar{0};
+  float baz{0.f};
+  Foo()  {}
   Foo(int bar, float baz) : bar(bar), baz(baz) {}
   ~Foo() { std::cerr << "deleted!" << std::endl; }
 };

--- a/Code/RDGeneral/testRDValue.cpp
+++ b/Code/RDGeneral/testRDValue.cpp
@@ -94,10 +94,10 @@ void testPODVectors() {
 void testStringVect() {
   BOOST_LOG(rdErrorLog) << "Test String Vect" << std::endl;
   std::vector<std::string> vecs;
-  vecs.push_back("my");
-  vecs.push_back("dog");
-  vecs.push_back("has");
-  vecs.push_back("fleas");
+  vecs.emplace_back("my");
+  vecs.emplace_back("dog");
+  vecs.emplace_back("has");
+  vecs.emplace_back("fleas");
   RDValue v(vecs);
   CHECK_INVARIANT(rdvalue_cast<std::vector<std::string>>(v) == vecs,
                   "bad vect");
@@ -133,8 +133,8 @@ void testMapsAndLists() {
   }
   {
     std::list<std::string> m;
-    m.push_back("foo");
-    m.push_back("bar");
+    m.emplace_back("foo");
+    m.emplace_back("bar");
     RDValue v(m);
     CHECK_INVARIANT(rdvalue_cast<std::list<std::string>>(v) == m,
                     "bad map cast");

--- a/Code/RDGeneral/types.h
+++ b/Code/RDGeneral/types.h
@@ -318,7 +318,7 @@ typedef INT_SET::const_iterator INT_SET_CI;
 //! functor to compare two doubles with a tolerance
 struct RDKIT_RDGENERAL_EXPORT ltDouble {
  public:
-  ltDouble() : _tol(1.0e-8){};
+  ltDouble()  {};
   bool operator()(double d1, double d2) const {
     if (fabs(d1 - d2) < _tol) {
       return false;
@@ -328,7 +328,7 @@ struct RDKIT_RDGENERAL_EXPORT ltDouble {
   }
 
  private:
-  double _tol;
+  double _tol{1.0e-8};
 };
 
 //! std::map from double to integer.

--- a/Code/SimDivPickers/LeaderPicker.h
+++ b/Code/SimDivPickers/LeaderPicker.h
@@ -30,13 +30,13 @@ namespace RDPickers {
  */
 class LeaderPicker : public DistPicker {
  public:
-  double default_threshold;
-  int default_nthreads;
+  double default_threshold{0.0};
+  int default_nthreads{1};
 
   /*! \brief Default Constructor
    *
    */
-  LeaderPicker() : default_threshold(0.0), default_nthreads(1) {}
+  LeaderPicker()  {}
   LeaderPicker(double threshold)
       : default_threshold(threshold), default_nthreads(1) {}
   LeaderPicker(double threshold, int nthreads)

--- a/External/INCHI-API/inchi.cpp
+++ b/External/INCHI-API/inchi.cpp
@@ -1859,7 +1859,7 @@ std::string MolToInchi(const ROMol& mol, ExtraInchiReturnValues& rv,
         int cip = 0;
         // if (m->getAtomWithIdx(*nbrIter)->hasProp("_CIPRank"))
         //   m->getAtomWithIdx(*nbrIter)->getProp("_CIPRank", cip);
-        neighbors.push_back(std::make_pair(cip, *nbrIter));
+        neighbors.emplace_back(cip, *nbrIter);
         ++nbrIter;
       }
       // std::sort(neighbors.begin(), neighbors.end());


### PR DESCRIPTION
Two more clang-tidy modernizations.
