### PR TITLE
Reaction stereo mapped to non-bonded atoms causes exception

### DIFF
--- a/Code/GraphMol/ChemReactions/ReactionRunner.cpp
+++ b/Code/GraphMol/ChemReactions/ReactionRunner.cpp
@@ -631,23 +631,28 @@ void forwardReactantBondStereo(ReactantProductAtomMapping *mapping, Bond *pBond,
   unsigned pEndAnchorIdx =
       reactProdMapAnchorIdx(pBond->getEndAtom(), pEndAnchorCandidates.first);
 
-  pBond->setStereoAtoms(pStartAnchorIdx, pEndAnchorIdx);
+  if (pBond->getOwningMol().getBondBetweenAtoms(pStartAnchorIdx, pEndAnchorIdx) == nullptr) {
+    BOOST_LOG(rdWarningLog)
+      << "stereo atoms in input cannot be mapped to output (atoms are no longer bonded)\n";
+  } else {
+    pBond->setStereoAtoms(pStartAnchorIdx, pEndAnchorIdx);
 
-  bool flipStereo =
+    bool flipStereo =
       (pStartAnchorCandidates.second + pEndAnchorCandidates.second) % 2;
 
-  if (rBond->getStereo() == Bond::BondStereo::STEREOCIS ||
-      rBond->getStereo() == Bond::BondStereo::STEREOZ) {
-    if (flipStereo) {
-      pBond->setStereo(Bond::BondStereo::STEREOTRANS);
+    if (rBond->getStereo() == Bond::BondStereo::STEREOCIS ||
+	rBond->getStereo() == Bond::BondStereo::STEREOZ) {
+      if (flipStereo) {
+	pBond->setStereo(Bond::BondStereo::STEREOTRANS);
+      } else {
+	pBond->setStereo(Bond::BondStereo::STEREOCIS);
+      }
     } else {
-      pBond->setStereo(Bond::BondStereo::STEREOCIS);
-    }
-  } else {
-    if (flipStereo) {
-      pBond->setStereo(Bond::BondStereo::STEREOCIS);
-    } else {
-      pBond->setStereo(Bond::BondStereo::STEREOTRANS);
+      if (flipStereo) {
+	pBond->setStereo(Bond::BondStereo::STEREOCIS);
+      } else {
+	pBond->setStereo(Bond::BondStereo::STEREOTRANS);
+      }
     }
   }
 }

--- a/Code/GraphMol/ChemReactions/Wrap/testReactionWrapper.py
+++ b/Code/GraphMol/ChemReactions/Wrap/testReactionWrapper.py
@@ -900,6 +900,11 @@ class StereoGroupTests(unittest.TestCase):
         'CC(C)(OCC[C@@H](Br)C[C@@H](Cl)Br)OCC[C@@H](Br)C[C@@H](Cl)Br |&1:6,9,15,18|'
     )
 
+  def test_github(self):
+      rxn = rdChemReactions.ReactionFromSmarts('[C:2][C:3]>>[C:2][C][*:3]')
+      mol = Chem.MolFromSmiles("C/C=C/C")
+      #  this shouldn't raise
+      rxn.RunReactants([mol])
 
 if __name__ == '__main__':
     unittest.main(verbosity=True)


### PR DESCRIPTION
fixes #3155 

The fix is to not mapped stereo in these cases.