### PR TITLE
fix the CompressedSDMolSupplier python iterator interface

### DIFF
--- a/Code/GraphMol/Wrap/CompressedSDMolSupplier.cpp
+++ b/Code/GraphMol/Wrap/CompressedSDMolSupplier.cpp
@@ -109,7 +109,7 @@ struct compressedsdmolsup_wrap {
             "__iter__",
             (ForwardSDMolSupplier * (*)(ForwardSDMolSupplier *)) & MolSupplIter,
             python::return_internal_reference<1>())
-        .def("next", (ROMol * (*)(ForwardSDMolSupplier *)) & MolSupplNext,
+        .def("__next__", (ROMol * (*)(ForwardSDMolSupplier *)) & MolSupplNext,
              "Returns the next molecule in the file.  Raises _StopIteration_ "
              "on EOF.\n",
              python::return_value_policy<python::manage_new_object>());


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! 
-->
#### What does this implement/fix? Explain your changes.
This PR fixes the iterator interface of `CompressedSDMolSupplier`, which is not compliant with the python3 requirements.

