### PR TITLE
Add optional timeout to RGroupDecomposition

### DIFF
--- a/Code/GraphMol/RGroupDecomposition/RGroupDecomp.cpp
+++ b/Code/GraphMol/RGroupDecomposition/RGroupDecomp.cpp
@@ -1437,6 +1437,10 @@ RGroupColumns RGroupDecomposition::getRGroupsAsColumns() const {
   return groups;
 }
 
+const RGroupDecompositionParameters &RGroupDecomposition::params() const {
+  return data->params;
+}
+
 namespace {
 std::vector<unsigned int> Decomp(RGroupDecomposition &decomp,
                                  const std::vector<ROMOL_SPTR> &mols) {

--- a/Code/GraphMol/RGroupDecomposition/RGroupDecomp.cpp
+++ b/Code/GraphMol/RGroupDecomposition/RGroupDecomp.cpp
@@ -1180,7 +1180,9 @@ int RGroupDecomposition::add(const ROMol &inmol) {
       continue;
     } else {
       if (tmatches.size() > 1) {
-        if (data->matches.size() == 0) {
+        if (data->params.matchingStrategy == NoSymmetrization) {
+          tmatches.resize(1);
+        } else if (data->matches.size() == 0) {
           // Greedy strategy just grabs the first match and
           //  takes the best matches from the rest
           if (data->params.matchingStrategy == Greedy) {

--- a/Code/GraphMol/RGroupDecomposition/RGroupDecomp.cpp
+++ b/Code/GraphMol/RGroupDecomposition/RGroupDecomp.cpp
@@ -1078,13 +1078,7 @@ struct RGroupDecompData {
           best_permutation = tied_permutation;
         }
       }
-      if (params.timeout > 0) {
-        auto t1 = std::chrono::steady_clock::now();
-        std::chrono::duration<double> elapsed = t1 - t0;
-        if (elapsed.count() >= params.timeout) {
-          throw std::runtime_error("RGD timeout");
-        }
-      }
+      checkForTimeout(t0, params.timeout);
     }
 
     permutation = best_permutation;
@@ -1452,13 +1446,7 @@ std::vector<unsigned int> Decomp(RGroupDecomposition &decomp,
     if (v == -1) {
       unmatched.push_back(i);
     }
-    if (decomp.params().timeout > 0) {
-      auto t1 = std::chrono::steady_clock::now();
-      std::chrono::duration<double> elapsed = t1 - t0;
-      if (elapsed.count() >= decomp.params().timeout) {
-        throw std::runtime_error("RGD timeout");
-      }
-    }
+    checkForTimeout(t0, decomp.params().timeout);
   }
   decomp.process();
   return unmatched;

--- a/Code/GraphMol/RGroupDecomposition/RGroupDecomp.cpp
+++ b/Code/GraphMol/RGroupDecomposition/RGroupDecomp.cpp
@@ -42,8 +42,9 @@
 #include <set>
 #include <utility>
 #include <vector>
+#include <chrono>
 
-//#define DEBUG
+// #define DEBUG
 
 namespace RDKit {
 
@@ -353,13 +354,7 @@ struct RGroupData {
   RGroupData(const RGroupData &rhs);
 
  public:
-  RGroupData()
-      : combinedMol(),
-        mols(),
-        smilesSet(),
-        smiles(),
-        attachments()
-        {}
+  RGroupData() : combinedMol(), mols(), smilesSet(), smiles(), attachments() {}
 
   void add(boost::shared_ptr<ROMol> newMol,
            const std::vector<int> &rlabel_attachments) {
@@ -761,21 +756,19 @@ struct RGroupDecompData {
     return results;
   }
 
-  class UsedLabels
-  {
-  public:
-
+  class UsedLabels {
+   public:
     std::set<int> labels_used;
     bool add(int rlabel) {
       if (labels_used.find(rlabel) != labels_used.end()) {
-	return false;
+        return false;
       }
       labels_used.insert(rlabel);
       return true;
     }
 
     int next() {
-      int i=1;
+      int i = 1;
       while (labels_used.find(i) != labels_used.end()) {
         ++i;
       }
@@ -783,10 +776,9 @@ struct RGroupDecompData {
       return i;
     }
   };
-  
+
   void relabelCore(RWMol &core, std::map<int, int> &mappings,
-		   UsedLabels &used_labels,
-                   const std::set<int> &indexLabels,
+                   UsedLabels &used_labels, const std::set<int> &indexLabels,
                    std::map<int, std::vector<int>> extraAtomRLabels) {
     // Now remap to proper rlabel ids
     //  if labels are positive, they come from User labels
@@ -829,15 +821,15 @@ struct RGroupDecompData {
     for (auto newLabel : indexLabels) {
       auto atm = atoms.find(newLabel);
       if (atm == atoms.end()) {
-	continue;
+        continue;
       }
-      
-      Atom * atom = atm->second;
-      
+
+      Atom *atom = atm->second;
+
       int rlabel;
       auto mapping = mappings.find(newLabel);
       if (mapping == mappings.end()) {
-	rlabel = used_labels.next();
+        rlabel = used_labels.next();
         mappings[newLabel] = rlabel;
       } else {
         rlabel = mapping->second;
@@ -981,8 +973,8 @@ struct RGroupDecompData {
       boost::shared_ptr<RWMol> labelledCore(new RWMol(coreIt->second));
       labelledCores[coreIt->first] = labelledCore;
 
-      relabelCore(*labelledCore.get(), finalRlabelMapping, used_labels, indexLabels,
-                  extraAtomRLabels);
+      relabelCore(*labelledCore.get(), finalRlabelMapping, used_labels,
+                  indexLabels, extraAtomRLabels);
     }
 
     for (auto &it : best) {
@@ -997,23 +989,25 @@ struct RGroupDecompData {
   int compute_num_added_rgroups(std::vector<size_t> &tied_permutation) {
     int num_added_rgroups = 0;
     for (int label : labels) {
-      if (label <= 0) { // label is not user supplied
-	for (size_t m = 0; m < tied_permutation.size(); ++m) {  // for each molecule
-	  auto rg = matches[m][tied_permutation[m]].rgroups.find(label);
-	  if (rg != matches[m][tied_permutation[m]].rgroups.end()) {
-	    if(rg->second->smiles.find_first_not_of("0123456789[]*H:.") <
-	       rg->second->smiles.length()) {
-	      num_added_rgroups +=1;//= label;		  
-	      break;
-	    }
-	  }
-	}
+      if (label <= 0) {  // label is not user supplied
+        for (size_t m = 0; m < tied_permutation.size();
+             ++m) {  // for each molecule
+          auto rg = matches[m][tied_permutation[m]].rgroups.find(label);
+          if (rg != matches[m][tied_permutation[m]].rgroups.end()) {
+            if (rg->second->smiles.find_first_not_of("0123456789[]*H:.") <
+                rg->second->smiles.length()) {
+              num_added_rgroups += 1;  //= label;
+              break;
+            }
+          }
+        }
       }
     }
     return num_added_rgroups;
   }
-  
+
   bool process(bool pruneMatches, bool finalize = false) {
+    auto t0 = std::chrono::steady_clock::now();
     if (matches.size() == 0) {
       return false;
     }
@@ -1024,7 +1018,7 @@ struct RGroupDecompData {
     size_t N = 1;
 
     for (size_t m = 0; m < M; ++m) {
-      size_t sz = matches[m].size(); // # permutations for molecule m
+      size_t sz = matches[m].size();  // # permutations for molecule m
       permutations.push_back(sz);
       N *= sz;
     }
@@ -1036,7 +1030,7 @@ struct RGroupDecompData {
     double best_score = 0;
     std::vector<size_t> best_permutation = permutation;
     std::vector<std::vector<size_t>> ties;
-    
+
     size_t count = 0;
 #ifdef DEBUG
     std::cerr << "Processing" << std::endl;
@@ -1044,7 +1038,7 @@ struct RGroupDecompData {
     CartesianProduct iterator(permutations);
     // Iterates through the permutation idx, i.e.
     //  [m1_permutation_idx,  m2_permutation_idx, m3_permutation_idx]
-    
+
     while (iterator.next()) {
       if (count > N) {
         throw ValueErrorException("Next did not finish");
@@ -1055,34 +1049,41 @@ struct RGroupDecompData {
 #endif
       double newscore = score(iterator.permutation, matches, labels);
 
-      if (fabs(newscore - best_score) < 1e-6) { // heuristic to overcome floating point comparison issues
-	ties.push_back(iterator.permutation);
-      }
-      else if (newscore > best_score) {
+      if (fabs(newscore - best_score) <
+          1e-6) {  // heuristic to overcome floating point comparison issues
+        ties.push_back(iterator.permutation);
+      } else if (newscore > best_score) {
 #ifdef DEBUG
         std::cerr << " ===> current best:" << newscore << ">" << best_score
                   << std::endl;
 #endif
-	ties.clear();
-	ties.push_back(iterator.permutation);
+        ties.clear();
+        ties.push_back(iterator.permutation);
         best_score = newscore;
         best_permutation = iterator.permutation;
       }
     }
-    
-    if(ties.size() > 1) {
+
+    if (ties.size() > 1) {
       // choose one that doesn't add rgroups inappropriately
       //  an rgroup is added when
       //  (1) the label is <=0
       //  (2) the group has any substituent with heavy atoms
       //   XXX Might be more efficient to add this comp to the score function
       int smallest_added_rgroups = 100000000;
-      for(auto tied_permutation: ties) {
-	int num_added_rgroups = compute_num_added_rgroups(tied_permutation);
-	if(num_added_rgroups  < smallest_added_rgroups) {
-	  smallest_added_rgroups = num_added_rgroups;
-	  best_permutation = tied_permutation;
-	}
+      for (auto tied_permutation : ties) {
+        int num_added_rgroups = compute_num_added_rgroups(tied_permutation);
+        if (num_added_rgroups < smallest_added_rgroups) {
+          smallest_added_rgroups = num_added_rgroups;
+          best_permutation = tied_permutation;
+        }
+      }
+      if (params.timeout > 0) {
+        auto t1 = std::chrono::steady_clock::now();
+        std::chrono::duration<double> elapsed = t1 - t0;
+        if (elapsed.count() >= params.timeout) {
+          throw std::runtime_error("RGD timeout");
+        }
       }
     }
 
@@ -1357,13 +1358,13 @@ std::vector<std::string> RGroupDecomposition::getRGroupLabels() const {
   // this is a bit of a cheat
   RGroupColumns cols = getRGroupsAsColumns();
   std::vector<std::string> labels;
-  for(auto it : cols) {
+  for (auto it : cols) {
     labels.push_back(it.first);
   }
   std::sort(labels.begin(), labels.end());
   return labels;
 }
-  
+
 RGroupRows RGroupDecomposition::getRGroupsAsRows() const {
   std::vector<RGroupMatch> permutation = data->GetCurrentBestPermutation();
 
@@ -1444,11 +1445,19 @@ const RGroupDecompositionParameters &RGroupDecomposition::params() const {
 namespace {
 std::vector<unsigned int> Decomp(RGroupDecomposition &decomp,
                                  const std::vector<ROMOL_SPTR> &mols) {
+  auto t0 = std::chrono::steady_clock::now();
   std::vector<unsigned int> unmatched;
   for (size_t i = 0; i < mols.size(); ++i) {
     int v = decomp.add(*mols[i].get());
     if (v == -1) {
       unmatched.push_back(i);
+    }
+    if (decomp.params().timeout > 0) {
+      auto t1 = std::chrono::steady_clock::now();
+      std::chrono::duration<double> elapsed = t1 - t0;
+      if (elapsed.count() >= decomp.params().timeout) {
+        throw std::runtime_error("RGD timeout");
+      }
     }
   }
   decomp.process();

--- a/Code/GraphMol/RGroupDecomposition/RGroupDecomp.h
+++ b/Code/GraphMol/RGroupDecomposition/RGroupDecomp.h
@@ -40,6 +40,7 @@ typedef enum {
   Greedy = 0x01,
   GreedyChunks = 0x02,
   Exhaustive = 0x04,  // not really useful for large sets
+  NoSymmetrization = 0x08,
 } RGroupMatching;
 
 typedef enum {

--- a/Code/GraphMol/RGroupDecomposition/RGroupDecomp.h
+++ b/Code/GraphMol/RGroupDecomposition/RGroupDecomp.h
@@ -124,8 +124,8 @@ RDKIT_RGROUPDECOMPOSITION_EXPORT unsigned int RGroupDecompose(
     const RGroupDecompositionParameters &options =
         RGroupDecompositionParameters());
 
-bool checkForTimeout(const std::chrono::steady_clock::time_point &t0,
-                     double timeout, bool throwOnTimeout = true) {
+inline bool checkForTimeout(const std::chrono::steady_clock::time_point &t0,
+                            double timeout, bool throwOnTimeout = true) {
   if (timeout <= 0) return false;
   auto t1 = std::chrono::steady_clock::now();
   std::chrono::duration<double> elapsed = t1 - t0;

--- a/Code/GraphMol/RGroupDecomposition/RGroupDecomp.h
+++ b/Code/GraphMol/RGroupDecomposition/RGroupDecomp.h
@@ -13,6 +13,7 @@
 
 #include "../RDKitBase.h"
 #include <GraphMol/Substruct/SubstructMatch.h>
+#include <chrono>
 
 namespace RDKit {
 
@@ -121,6 +122,21 @@ RDKIT_RGROUPDECOMPOSITION_EXPORT unsigned int RGroupDecompose(
     RGroupColumns &columns, std::vector<unsigned int> *unmatched = nullptr,
     const RGroupDecompositionParameters &options =
         RGroupDecompositionParameters());
+
+bool checkForTimeout(const std::chrono::steady_clock::time_point &t0,
+                     double timeout, bool throwOnTimeout = true) {
+  if (timeout <= 0) return false;
+  auto t1 = std::chrono::steady_clock::now();
+  std::chrono::duration<double> elapsed = t1 - t0;
+  if (elapsed.count() >= timeout) {
+    if (throwOnTimeout) {
+      throw std::runtime_error("operation timed out");
+    }
+    return true;
+  }
+  return false;
+}
+
 }  // namespace RDKit
 
 #endif

--- a/Code/GraphMol/RGroupDecomposition/RGroupDecomp.h
+++ b/Code/GraphMol/RGroupDecomposition/RGroupDecomp.h
@@ -53,33 +53,16 @@ typedef enum {
 } RGroupCoreAlignment;
 
 struct RDKIT_RGROUPDECOMPOSITION_EXPORT RGroupDecompositionParameters {
-  unsigned int labels;
-  unsigned int matchingStrategy;
-  unsigned int rgroupLabelling;
-  unsigned int alignment;
+  unsigned int labels = AutoDetect;
+  unsigned int matchingStrategy = GreedyChunks;
+  unsigned int rgroupLabelling = AtomMap | MDLRGroup;
+  unsigned int alignment = MCS;
 
-  unsigned int chunkSize;
-  bool onlyMatchAtRGroups;
-  bool removeAllHydrogenRGroups;
-  bool removeHydrogensPostMatch;
-
-  RGroupDecompositionParameters(unsigned int labels = AutoDetect,
-                                unsigned int strategy = GreedyChunks,
-                                unsigned int labelling = AtomMap | MDLRGroup,
-                                unsigned int alignment = MCS,
-                                unsigned int chunkSize = 5,
-                                bool matchOnlyAtRGroups = false,
-                                bool removeHydrogenOnlyGroups = true,
-                                bool removeHydrogensPostMatch = true)
-      : labels(labels),
-        matchingStrategy(strategy),
-        rgroupLabelling(labelling),
-        alignment(alignment),
-        chunkSize(chunkSize),
-        onlyMatchAtRGroups(matchOnlyAtRGroups),
-        removeAllHydrogenRGroups(removeHydrogenOnlyGroups),
-        removeHydrogensPostMatch(removeHydrogensPostMatch)
-        {}
+  unsigned int chunkSize = 5;
+  bool onlyMatchAtRGroups = false;
+  bool removeAllHydrogenRGroups = true;
+  bool removeHydrogensPostMatch = true;
+  double timeout = -1.0;  ///< timeout in seconds. <=0 indicates no timeout
 
   // Determine how to assign the rgroup labels from the given core
   unsigned int autoGetLabels(const RWMol &);
@@ -117,9 +100,10 @@ class RDKIT_RGROUPDECOMPOSITION_EXPORT RGroupDecomposition {
   int add(const ROMol &mol);
   bool process();
 
+  const RGroupDecompositionParameters &params() const;
   //! return the current group labels
   std::vector<std::string> getRGroupLabels() const;
-  
+
   //! return rgroups in row order group[row][attachment_point] = ROMol
   RGroupRows getRGroupsAsRows() const;
   //! return rgroups in column order group[attachment_point][row] = ROMol

--- a/Code/GraphMol/RGroupDecomposition/Wrap/rdRGroupComposition.cpp
+++ b/Code/GraphMol/RGroupDecomposition/Wrap/rdRGroupComposition.cpp
@@ -190,6 +190,7 @@ struct rgroupdecomp_wrapper {
         .value("Greedy", RDKit::Greedy)
         .value("GreedyChunks", RDKit::GreedyChunks)
         .value("Exhaustive", RDKit::Exhaustive)
+        .value("NoSymmetrization", RDKit::NoSymmetrization)
         .export_values();
 
     python::enum_<RDKit::RGroupLabelling>("RGroupLabelling")

--- a/Code/GraphMol/RGroupDecomposition/Wrap/rdRGroupComposition.cpp
+++ b/Code/GraphMol/RGroupDecomposition/Wrap/rdRGroupComposition.cpp
@@ -154,13 +154,7 @@ python::object RGroupDecomp(python::object cores, python::object mols,
     }
     ++iter;
     ++idx;
-    if (options.timeout > 0) {
-      auto t1 = std::chrono::steady_clock::now();
-      std::chrono::duration<double> elapsed = t1 - t0;
-      if (elapsed.count() >= options.timeout) {
-        throw std::runtime_error("RGD timeout");
-      }
-    }
+    checkForTimeout(t0, options.timeout);
   }
 
   decomp.Process();
@@ -169,7 +163,7 @@ python::object RGroupDecomp(python::object cores, python::object mols,
   } else {
     return make_tuple(decomp.GetRGroupsAsColumn(asSmiles), unmatched);
   }
-}
+}  // namespace RDKit
 
 struct rgroupdecomp_wrapper {
   static void wrap() {

--- a/Code/GraphMol/RGroupDecomposition/Wrap/test_rgroups.py
+++ b/Code/GraphMol/RGroupDecomposition/Wrap/test_rgroups.py
@@ -29,9 +29,8 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-
 import unittest
-import os,sys, copy
+import os, sys, copy
 
 import pickle
 
@@ -40,50 +39,62 @@ from rdkit import Chem
 from rdkit.Chem.rdRGroupDecomposition import RGroupDecompose, RGroupDecomposition, RGroupDecompositionParameters
 from collections import OrderedDict
 
-class TestCase(unittest.TestCase) :
-    def test_multicores(self):
-        cores_smi_easy = OrderedDict()
-        cores_smi_hard = OrderedDict()
+# the RGD code can generate a lot of warnings. disable them
+from rdkit import RDLogger
+RDLogger.DisableLog("rdApp.warning")
 
-        #cores_smi_easy['cephem'] = Chem.MolFromSmiles('O=C1C([1*])[C@@H]2N1C(C(O)=O)=C([3*])CS2')
-        cores_smi_easy['cephem'] = Chem.MolFromSmarts('O=C1C([*:1])C2N1C(C(O)=O)=C([*:3])CS2')
-        cores_smi_hard['cephem'] = Chem.MolFromSmarts('O=C1C([2*])([1*])[C@@H]2N1C(C(O)=O)=C([3*])CS2')
 
-        #cores_smi_easy['carbacephem'] = Chem.MolFromSmiles('O=C1C([1*])[C@@H]2N1C(C(O)=O)=C([3*])CC2')
-        cores_smi_easy['carbacephem'] = Chem.MolFromSmarts('O=C1C([1*])C2N1C(C(O)=O)=C([3*])CC2')
-        cores_smi_hard['carbacephem'] = Chem.MolFromSmarts('O=C1C([2*])([1*])[C@@H]2N1C(C(O)=O)=C([3*])CC2')
+class TestCase(unittest.TestCase):
 
-        #cores_smi_easy['oxacephem'] = Chem.MolFromSmiles('O=C1C([1*])[C@@H]2N1C(C(O)=O)=C([3*])CO2')
-        cores_smi_easy['oxacephem'] = Chem.MolFromSmarts('O=C1C([1*])C2N1C(C(O)=O)=C([3*])CO2')
-        cores_smi_hard['oxacephem'] = Chem.MolFromSmarts('O=C1C([2*])([1*])[C@@H]2N1C(C(O)=O)=C([3*])CO2')
+  def test_multicores(self):
+    cores_smi_easy = OrderedDict()
+    cores_smi_hard = OrderedDict()
 
-        #cores_smi_easy['carbapenem'] = Chem.MolFromSmiles('O=C1C([1*])[C@@H]2N1C(C(O)=O)=C([3*])C2')
-        cores_smi_easy['carbapenem'] = Chem.MolFromSmarts('O=C1C([1*])C2N1C(C(O)=O)=C([3*])C2')
-        cores_smi_hard['carbapenem'] = Chem.MolFromSmarts('O=C1C([2*])([1*])[C@@H]2N1C(C(O)=O)=C([3*])C2')
+    #cores_smi_easy['cephem'] = Chem.MolFromSmiles('O=C1C([1*])[C@@H]2N1C(C(O)=O)=C([3*])CS2')
+    cores_smi_easy['cephem'] = Chem.MolFromSmarts('O=C1C([*:1])C2N1C(C(O)=O)=C([*:3])CS2')
+    cores_smi_hard['cephem'] = Chem.MolFromSmarts('O=C1C([2*])([1*])[C@@H]2N1C(C(O)=O)=C([3*])CS2')
 
-        #cores_smi_easy['carbapenam'] = Chem.MolFromSmiles('O=C1C([1*])[C@@H]2N1C(C(O)=O)C([3*])([4*])C2')
-        cores_smi_easy['carbapenam'] = Chem.MolFromSmarts('O=C1C([1*])C2N1C(C(O)=O)C([3*])([4*])C2')
-        cores_smi_hard['carbapenam'] = Chem.MolFromSmarts('O=C1C([2*])([1*])[C@@H]2N1C(C(O)=O)C([3*])([4*])C2')
+    #cores_smi_easy['carbacephem'] = Chem.MolFromSmiles('O=C1C([1*])[C@@H]2N1C(C(O)=O)=C([3*])CC2')
+    cores_smi_easy['carbacephem'] = Chem.MolFromSmarts('O=C1C([1*])C2N1C(C(O)=O)=C([3*])CC2')
+    cores_smi_hard['carbacephem'] = Chem.MolFromSmarts(
+      'O=C1C([2*])([1*])[C@@H]2N1C(C(O)=O)=C([3*])CC2')
 
-        #cores_smi_easy['penem'] = Chem.MolFromSmiles('O=C1C([1*])[C@@H]2N1C(C(O)=O)=C([3*])S2')
-        cores_smi_easy['penem'] = Chem.MolFromSmarts('O=C1C([1*])C2N1C(C(O)=O)=C([3*])S2')
-        cores_smi_hard['penem'] = Chem.MolFromSmarts('O=C1C([2*])([1*])[C@@H]2N1C(C(O)=O)=C([3*])S2')
+    #cores_smi_easy['oxacephem'] = Chem.MolFromSmiles('O=C1C([1*])[C@@H]2N1C(C(O)=O)=C([3*])CO2')
+    cores_smi_easy['oxacephem'] = Chem.MolFromSmarts('O=C1C([1*])C2N1C(C(O)=O)=C([3*])CO2')
+    cores_smi_hard['oxacephem'] = Chem.MolFromSmarts(
+      'O=C1C([2*])([1*])[C@@H]2N1C(C(O)=O)=C([3*])CO2')
 
-        #cores_smi_easy['penam'] = Chem.MolFromSmiles('O=C1C([1*])[C@@H]2N1C(C(O)=O)C([3*])([4*])S2')
-        cores_smi_easy['penam'] = Chem.MolFromSmarts('O=C1C([*:1])C2N1C(C(O)=O)C([*:3])([*:4])S2')
-        cores_smi_hard['penam'] = Chem.MolFromSmarts('O=C1C([*:2])([*:1])[C@@H]2N1C(C(O)=O)C([*:3])([*:4])S2')
+    #cores_smi_easy['carbapenem'] = Chem.MolFromSmiles('O=C1C([1*])[C@@H]2N1C(C(O)=O)=C([3*])C2')
+    cores_smi_easy['carbapenem'] = Chem.MolFromSmarts('O=C1C([1*])C2N1C(C(O)=O)=C([3*])C2')
+    cores_smi_hard['carbapenem'] = Chem.MolFromSmarts(
+      'O=C1C([2*])([1*])[C@@H]2N1C(C(O)=O)=C([3*])C2')
 
-        #cores_smi_easy['oxapenam'] = Chem.MolFromSmiles('O=C1C([1*])[C@@H]2N1C(C(O)=O)C([3*])([4*])O2')
-        cores_smi_easy['oxapenam'] = Chem.MolFromSmarts('O=C1C([1*])C2N1C(C(O)=O)C([3*])([4*])O2')
-        cores_smi_hard['oxapenam'] = Chem.MolFromSmarts('O=C1C([2*])([1*])[C@@H]2N1C(C(O)=O)C([3*])([4*])O2')
+    #cores_smi_easy['carbapenam'] = Chem.MolFromSmiles('O=C1C([1*])[C@@H]2N1C(C(O)=O)C([3*])([4*])C2')
+    cores_smi_easy['carbapenam'] = Chem.MolFromSmarts('O=C1C([1*])C2N1C(C(O)=O)C([3*])([4*])C2')
+    cores_smi_hard['carbapenam'] = Chem.MolFromSmarts(
+      'O=C1C([2*])([1*])[C@@H]2N1C(C(O)=O)C([3*])([4*])C2')
 
-        cores_smi_easy['monobactam'] = Chem.MolFromSmarts('O=C1C([1*])C([5*])N1')
-        cores_smi_hard['monobactam'] = Chem.MolFromSmarts('O=C1C([2*])([1*])C([6*])([5*])N1')
-        rg_easy = RGroupDecomposition(cores_smi_easy.values())
-        rg_stereo = RGroupDecomposition(cores_smi_hard.values())
+    #cores_smi_easy['penem'] = Chem.MolFromSmiles('O=C1C([1*])[C@@H]2N1C(C(O)=O)=C([3*])S2')
+    cores_smi_easy['penem'] = Chem.MolFromSmarts('O=C1C([1*])C2N1C(C(O)=O)=C([3*])S2')
+    cores_smi_hard['penem'] = Chem.MolFromSmarts('O=C1C([2*])([1*])[C@@H]2N1C(C(O)=O)=C([3*])S2')
 
-    def test_stereo(self):
-        smiles = """C1CCO[C@@H](N)1
+    #cores_smi_easy['penam'] = Chem.MolFromSmiles('O=C1C([1*])[C@@H]2N1C(C(O)=O)C([3*])([4*])S2')
+    cores_smi_easy['penam'] = Chem.MolFromSmarts('O=C1C([*:1])C2N1C(C(O)=O)C([*:3])([*:4])S2')
+    cores_smi_hard['penam'] = Chem.MolFromSmarts(
+      'O=C1C([*:2])([*:1])[C@@H]2N1C(C(O)=O)C([*:3])([*:4])S2')
+
+    #cores_smi_easy['oxapenam'] = Chem.MolFromSmiles('O=C1C([1*])[C@@H]2N1C(C(O)=O)C([3*])([4*])O2')
+    cores_smi_easy['oxapenam'] = Chem.MolFromSmarts('O=C1C([1*])C2N1C(C(O)=O)C([3*])([4*])O2')
+    cores_smi_hard['oxapenam'] = Chem.MolFromSmarts(
+      'O=C1C([2*])([1*])[C@@H]2N1C(C(O)=O)C([3*])([4*])O2')
+
+    cores_smi_easy['monobactam'] = Chem.MolFromSmarts('O=C1C([1*])C([5*])N1')
+    cores_smi_hard['monobactam'] = Chem.MolFromSmarts('O=C1C([2*])([1*])C([6*])([5*])N1')
+    rg_easy = RGroupDecomposition(cores_smi_easy.values())
+    rg_stereo = RGroupDecomposition(cores_smi_hard.values())
+
+  def test_stereo(self):
+    smiles = """C1CCO[C@@H](N)1
 C1CCO[C@H](N)1
 C1CCO[C@@](N)(O)1
 C1CCO[C@@](N)(P)1
@@ -104,172 +115,287 @@ C1CCO[C@@](S)(N)1
 C1CCO[C@@](S)(O)1
 C1CCO[C@@](S)(P)1
 """
-        mols = []
-        for smi in smiles.split():
-            m = Chem.MolFromSmiles(smi)
-            assert m, smi
-            mols.append(m)
-        core = Chem.MolFromSmarts("C1CCOC1")
-        rgroups = RGroupDecomposition(core)
-        for m in mols:
-            rgroups.Add(m)
-        rgroups.Process()
-        columns = rgroups.GetRGroupsAsColumns()
-        data = {}
-        for k,v in columns.items():
-            data[k] = [Chem.MolToSmiles(m,True) for m in v]
+    mols = []
+    for smi in smiles.split():
+      m = Chem.MolFromSmiles(smi)
+      assert m, smi
+      mols.append(m)
+    core = Chem.MolFromSmarts("C1CCOC1")
+    rgroups = RGroupDecomposition(core)
+    for m in mols:
+      rgroups.Add(m)
+    rgroups.Process()
+    columns = rgroups.GetRGroupsAsColumns()
+    data = {}
+    for k, v in columns.items():
+      data[k] = [Chem.MolToSmiles(m, True) for m in v]
 
-        rgroups2,unmatched = RGroupDecompose([core], mols)
-        columns2,unmatched = RGroupDecompose([core], mols, asRows=False)
-        data2 = {}
-        for k,v in columns2.items():
-            data2[k] = [Chem.MolToSmiles(m,True) for m in v]
+    rgroups2, unmatched = RGroupDecompose([core], mols)
+    columns2, unmatched = RGroupDecompose([core], mols, asRows=False)
+    data2 = {}
+    for k, v in columns2.items():
+      data2[k] = [Chem.MolToSmiles(m, True) for m in v]
 
-        self.assertEqual(data, data2)
-        columns3, unmatched = RGroupDecompose([core], mols, asRows=False, asSmiles=True)
-        self.assertEqual(data, columns3)
-        
+    self.assertEqual(data, data2)
+    columns3, unmatched = RGroupDecompose([core], mols, asRows=False, asSmiles=True)
+    self.assertEqual(data, columns3)
 
-    def test_h_options(self):
-        core = Chem.MolFromSmiles("O=c1oc2ccccc2cc1")
-        smiles = ("O=c1cc(Cn2ccnc2)c2ccc(Oc3ccccc3)cc2o1",
-                  "O=c1oc2ccccc2c(Cn2ccnc2)c1-c1ccccc1",
-                  "COc1ccc2c(Cn3cncn3)cc(=O)oc2c1")
-        params = RGroupDecompositionParameters()
-        rgd = RGroupDecomposition(core,params)
-        for smi in smiles:
-            m = Chem.MolFromSmiles(smi)
-            rgd.Add(m)
-        rgd.Process()
-        columns = rgd.GetRGroupsAsColumns()
-        self.assertEqual(columns['R2'][0].GetNumAtoms(),7)
+  def test_h_options(self):
+    core = Chem.MolFromSmiles("O=c1oc2ccccc2cc1")
+    smiles = ("O=c1cc(Cn2ccnc2)c2ccc(Oc3ccccc3)cc2o1", "O=c1oc2ccccc2c(Cn2ccnc2)c1-c1ccccc1",
+              "COc1ccc2c(Cn3cncn3)cc(=O)oc2c1")
+    params = RGroupDecompositionParameters()
+    rgd = RGroupDecomposition(core, params)
+    for smi in smiles:
+      m = Chem.MolFromSmiles(smi)
+      rgd.Add(m)
+    rgd.Process()
+    columns = rgd.GetRGroupsAsColumns()
+    self.assertEqual(columns['R2'][0].GetNumAtoms(), 7)
 
-        params.removeHydrogensPostMatch = False
-        rgd = RGroupDecomposition(core,params)
-        for smi in smiles:
-            m = Chem.MolFromSmiles(smi)
-            rgd.Add(m)
-        rgd.Process()
-        columns = rgd.GetRGroupsAsColumns()
-        self.assertEqual(columns['R2'][0].GetNumAtoms(),12)
+    params.removeHydrogensPostMatch = False
+    rgd = RGroupDecomposition(core, params)
+    for smi in smiles:
+      m = Chem.MolFromSmiles(smi)
+      rgd.Add(m)
+    rgd.Process()
+    columns = rgd.GetRGroupsAsColumns()
+    self.assertEqual(columns['R2'][0].GetNumAtoms(), 12)
 
-    def test_unmatched(self):
-        cores = [Chem.MolFromSmiles("N")]
-        mols = [Chem.MolFromSmiles("CC"),
-                Chem.MolFromSmiles("CC"),
-                Chem.MolFromSmiles("CC"),
-                Chem.MolFromSmiles("N"),
-                Chem.MolFromSmiles("CC")]
+  def test_unmatched(self):
+    cores = [Chem.MolFromSmiles("N")]
+    mols = [
+      Chem.MolFromSmiles("CC"),
+      Chem.MolFromSmiles("CC"),
+      Chem.MolFromSmiles("CC"),
+      Chem.MolFromSmiles("N"),
+      Chem.MolFromSmiles("CC")
+    ]
 
-        res, unmatched = RGroupDecompose(cores, mols)
-        self.assertEqual(len(res), 1)
-        self.assertEqual(unmatched, [0,1,2,4])
+    res, unmatched = RGroupDecompose(cores, mols)
+    self.assertEqual(len(res), 1)
+    self.assertEqual(unmatched, [0, 1, 2, 4])
 
-    def test_userlabels(self):
-        smis = ["C(Cl)N(N)O(O)"]
-        mols = [Chem.MolFromSmiles(smi) for smi in smis]
-        smarts = 'C([*:1])N([*:5])O([*:6])'
-        core = Chem.MolFromSmarts(smarts)
-        rg = RGroupDecomposition(core)
-        for m in mols:
-            rg.Add(m)
-        rg.Process()
-        self.assertEqual(rg.GetRGroupsAsColumns(asSmiles=True),
-                         {'Core': ['C(N(O[*:6])[*:5])[*:1]'],
-                          'R1': ['Cl[*:1]'],
-                          'R5': ['N[*:5]'],
-                          'R6': ['O[*:6]']})
+  def test_userlabels(self):
+    smis = ["C(Cl)N(N)O(O)"]
+    mols = [Chem.MolFromSmiles(smi) for smi in smis]
+    smarts = 'C([*:1])N([*:5])O([*:6])'
+    core = Chem.MolFromSmarts(smarts)
+    rg = RGroupDecomposition(core)
+    for m in mols:
+      rg.Add(m)
+    rg.Process()
+    self.assertEqual(rg.GetRGroupsAsColumns(asSmiles=True), {
+      'Core': ['C(N(O[*:6])[*:5])[*:1]'],
+      'R1': ['Cl[*:1]'],
+      'R5': ['N[*:5]'],
+      'R6': ['O[*:6]']
+    })
 
-        smarts = 'C([*:4])N([*:5])O([*:6])'
+    smarts = 'C([*:4])N([*:5])O([*:6])'
 
-        core = Chem.MolFromSmarts(smarts)
-        rg = RGroupDecomposition(core)
-        for m in mols:
-            rg.Add(m)
-        rg.Process()
-        self.assertEqual(rg.GetRGroupsAsColumns(asSmiles=True),
-                         {'Core': ['C(N(O[*:6])[*:5])[*:4]'],
-                          'R4': ['Cl[*:4]'],
-                          'R5': ['N[*:5]'],
-                          'R6': ['O[*:6]']})
+    core = Chem.MolFromSmarts(smarts)
+    rg = RGroupDecomposition(core)
+    for m in mols:
+      rg.Add(m)
+    rg.Process()
+    self.assertEqual(rg.GetRGroupsAsColumns(asSmiles=True), {
+      'Core': ['C(N(O[*:6])[*:5])[*:4]'],
+      'R4': ['Cl[*:4]'],
+      'R5': ['N[*:5]'],
+      'R6': ['O[*:6]']
+    })
 
-    def test_match_only_at_rgroups(self):
-        smiles = ['c1ccccc1']#, 'c1(Cl)ccccc1', 'c1(Cl)cc(Br)ccc1']
-        mols = [Chem.MolFromSmiles(smi) for smi in smiles]
+  def test_match_only_at_rgroups(self):
+    smiles = ['c1ccccc1']  #, 'c1(Cl)ccccc1', 'c1(Cl)cc(Br)ccc1']
+    mols = [Chem.MolFromSmiles(smi) for smi in smiles]
 
-        core1 = Chem.MolFromSmiles("c1([*:5])cc([*:6])ccc1")
-        params = RGroupDecompositionParameters()
-        params.onlyMatchAtRGroups=True
-        rg = RGroupDecomposition(core1, params)
-        for smi,m in zip(smiles,mols):
-            self.assertTrue(rg.Add(m)!=-1, smi)
+    core1 = Chem.MolFromSmiles("c1([*:5])cc([*:6])ccc1")
+    params = RGroupDecompositionParameters()
+    params.onlyMatchAtRGroups = True
+    rg = RGroupDecomposition(core1, params)
+    for smi, m in zip(smiles, mols):
+      self.assertTrue(rg.Add(m) != -1, smi)
+
+  def test_incorrect_multiple_rlabels(self):
+    mols = [Chem.MolFromSmiles(smi) for smi in (
+      "C1NC(Cl)CC1",
+      "C1OC(Cl)CC1",
+      "C1(Cl)OCCC1",
+    )]
+
+    scaffolds = [Chem.MolFromSmarts(x) for x in ("C1NCCC1", )]
+    groups, unmatched = RGroupDecompose(scaffolds, mols, asSmiles=True, asRows=False)
+
+    self.assertEqual(groups, {'Core': ['C1CNC([*:1])C1'], 'R1': ['Cl[*:1].[H][*:1]']})
+
+    scaffolds = [Chem.MolFromSmarts(x) for x in ("C1OCCC1", )]
+    groups, unmatched = RGroupDecompose(scaffolds, mols, asSmiles=True, asRows=False)
+    self.assertEqual(groups, {
+      'Core': ['C1COC([*:1])C1', 'C1COC([*:1])C1'],
+      'R1': ['Cl[*:1].[H][*:1]', 'Cl[*:1].[H][*:1]']
+    })
+    scaffolds = [Chem.MolFromSmarts(x) for x in ("C1NCCC1", "C1OCCC1")]
+    groups, unmatched = RGroupDecompose(scaffolds, mols, asSmiles=True, asRows=False)
+    self.assertEqual(
+      groups, {
+        'Core': ['C1CNC([*:1])C1', 'C1COC([*:1])C1', 'C1COC([*:1])C1'],
+        'R1': ['Cl[*:1].[H][*:1]', 'Cl[*:1].[H][*:1]', 'Cl[*:1].[H][*:1]']
+      })
+
+  def test_aligned_cores(self):
+    scaffolds = [Chem.MolFromSmarts(x) for x in ("C1NC1OC", "C1NC1NC")]
+    mols = [Chem.MolFromSmiles(smi) for smi in ("C1NC1OCCC", "C1NC1NCCC")]
+    groups, unmatched = RGroupDecompose(scaffolds, mols, asSmiles=True, asRows=True)
+    #print("test_aligned_Cores")
+    #print("groups:", groups)
+    self.assertEqual(groups, [{
+      'Core': 'C1NC1OC[*:1]',
+      'R1': 'CC[*:1].[H][*:1].[H][*:1]'
+    }, {
+      'Core': 'C1NC1NC[*:2]',
+      'R2': 'CC[*:2].[H][*:2].[H][*:2]'
+    }])
+
+  def test_aligned_cores2(self):
+    scaffolds = [Chem.MolFromSmarts(x) for x in ("C1NCC1", "C1SCC1")]
+    mols = [Chem.MolFromSmiles(smi) for smi in ("C1N(P)CC1", "C1S(P)CC1")]
+    #print("test_aligned_Cores2")
+    groups, unmatched = RGroupDecompose(scaffolds, mols, asSmiles=True, asRows=True)
+    #print("groups: ", groups)
+    self.assertEqual(groups, [{
+      'Core': 'C1CN([*:1])C1',
+      'R1': 'P[*:1]'
+    }, {
+      'Core': 'C1C[SH]([*:2])C1',
+      'R2': 'P[*:2].[H][*:2]'
+    }])
+
+  def test_getrgrouplabels(self):
+    smis = ["C(Cl)N(N)O(O)"]
+    mols = [Chem.MolFromSmiles(smi) for smi in smis]
+    smarts = 'C([*:1])N([*:5])O([*:6])'
+    core = Chem.MolFromSmarts(smarts)
+    rg = RGroupDecomposition(core)
+    for m in mols:
+      rg.Add(m)
+    rg.Process()
+    self.assertEqual(set(rg.GetRGroupLabels()), set(rg.GetRGroupsAsColumns()))
+
+  def test_timeout(self):
+    smis = '''CN(C)Cc1cccc(Oc2cc(N3CCN(Cc4ccccc4-c4ccc(Cl)cc4)CC3)ccc2C(=O)NS(=O)(=O)c2ccc(NCC3CCOCC3)c([N+](=O)[O-])c2)c1
+CNc1cccc(Oc2cc(N3CCN(Cc4ccccc4-c4ccc(Cl)cc4)CC3)ccc2C(=O)NS(=O)(=O)c2ccc(NCC3CCOCC3)c([N+](=O)[O-])c2)c1
+Cc1cc2cc(Oc3cc(N4CCN(CC5=C(c6ccc(Cl)cc6)CC(C)(C)CC5)CC4)ccc3C(=O)NS(=O)(=O)c3ccc(NC4CCN(C)CC4)c([N+](=O)[O-])c3)ccc2[nH]1
+Cc1cc2cc(Oc3cc(N4CCN(CC5=C(c6ccc(Cl)cc6)CC(C)(C)CC5)CC4)ccc3C(=O)NS(=O)(=O)c3ccc(NCCCN4CCOCC4)c([N+](=O)[O-])c3)ccc2[nH]1
+O=C(NS(=O)(=O)c1ccc(NCC2CCOCC2)c([N+](=O)[O-])c1)c1ccc(N2CCN(Cc3ccccc3-c3ccc(Cl)cc3)CC2)cc1Oc1ccccc1Cl
+O=C(NS(=O)(=O)c1ccc(NCC2CCOCC2)c([N+](=O)[O-])c1)c1ccc(N2CCN(Cc3ccccc3-c3ccc(Cl)cc3)CC2)cc1Oc1cccc(Cl)c1
+O=C(NS(=O)(=O)c1ccc(NCC2CCOCC2)c([N+](=O)[O-])c1)c1ccc(N2CCN(Cc3ccccc3-c3ccc(Cl)cc3)CC2)cc1Oc1ccc(Cl)cc1
+O=C(NS(=O)(=O)c1ccc(NCC2CCOCC2)c([N+](=O)[O-])c1)c1ccc(N2CCN(Cc3ccccc3-c3ccc(Cl)cc3)CC2)cc1Oc1cccc([N+](=O)[O-])c1
+O=C(NS(=O)(=O)c1ccc(NCCCN2CCOCC2)c([N+](=O)[O-])c1)c1ccc(N2CCN(Cc3ccccc3-c3ccc(Cl)cc3)CC2)cc1Oc1cccc(CO)c1
+CN(C)CCCNc1ccc(S(=O)(=O)NC(=O)c2ccc(N3CCN(Cc4ccccc4-c4ccc(Cl)cc4)CC3)cc2Oc2ccccc2Cl)cc1[N+](=O)[O-]
+O=C(NS(=O)(=O)c1ccc(NCCCN2CCOCC2)c([N+](=O)[O-])c1)c1ccc(N2CCN(Cc3ccccc3-c3ccc(Cl)cc3)CC2)cc1Oc1cccc(Cl)c1
+O=C(NS(=O)(=O)c1ccc(NCCCN2CCOCC2)c([N+](=O)[O-])c1)c1ccc(N2CCN(Cc3ccccc3-c3ccc(Cl)cc3)CC2)cc1Oc1ccc(Cl)cc1
+CN(C)CCCNc1ccc(S(=O)(=O)NC(=O)c2ccc(N3CCN(Cc4ccccc4-c4ccc(Cl)cc4)CC3)cc2Oc2cccc(Cl)c2)cc1[N+](=O)[O-]
+CN(C)CCCNc1ccc(S(=O)(=O)NC(=O)c2ccc(N3CCN(Cc4ccccc4-c4ccc(Cl)cc4)CC3)cc2Oc2ccc(Cl)cc2)cc1[N+](=O)[O-]
+CN(C)CCCNc1ccc(S(=O)(=O)NC(=O)c2ccc(N3CCN(Cc4ccccc4-c4ccc(Cl)cc4)CC3)cc2Oc2cccc3c2ccn3C)cc1[N+](=O)[O-]
+CC(=O)Nc1cccc(Oc2cc(N3CCN(Cc4ccccc4-c4ccc(Cl)cc4)CC3)ccc2C(=O)NS(=O)(=O)c2ccc(NCC3CCOCC3)c([N+](=O)[O-])c2)c1
+Nc1ccc(Oc2cc(N3CCN(Cc4ccccc4-c4ccc(Cl)cc4)CC3)ccc2C(=O)NS(=O)(=O)c2ccc(NCC3CCOCC3)c([N+](=O)[O-])c2)cc1
+Nc1cccc(Oc2cc(N3CCN(Cc4ccccc4-c4ccc(Cl)cc4)CC3)ccc2C(=O)NS(=O)(=O)c2ccc(NCC3CCOCC3)c([N+](=O)[O-])c2)c1
+COc1cccc(Oc2cc(N3CCN(Cc4ccccc4-c4ccc(Cl)cc4)CC3)ccc2C(=O)NS(=O)(=O)c2ccc(NCC3CCOCC3)c([N+](=O)[O-])c2)c1
+CN(C)c1cccc(Oc2cc(N3CCN(Cc4ccccc4-c4ccc(Cl)cc4)CC3)ccc2C(=O)NS(=O)(=O)c2ccc(NCC3CCOCC3)c([N+](=O)[O-])c2)c1
+N#Cc1cccc(Oc2cc(N3CCN(Cc4ccccc4-c4ccc(Cl)cc4)CC3)ccc2C(=O)NS(=O)(=O)c2ccc(NCC3CCOCC3)c([N+](=O)[O-])c2)c1
+Cc1nc2ccc(Oc3cc(N4CCN(Cc5ccccc5-c5ccc(Cl)cc5)CC4)ccc3C(=O)NS(=O)(=O)c3ccc(NCC4CCOCC4)c([N+](=O)[O-])c3)cc2s1
+Cc1nc2cc(Oc3cc(N4CCN(Cc5ccccc5-c5ccc(Cl)cc5)CC4)ccc3C(=O)NS(=O)(=O)c3ccc(NCCCN4CCOCC4)c([N+](=O)[O-])c3)ccc2s1
+Cc1nc2cc(Oc3cc(N4CCN(Cc5ccccc5-c5ccc(Cl)cc5)CC4)ccc3C(=O)NS(=O)(=O)c3ccc(NCCCN(C)C)c([N+](=O)[O-])c3)ccc2s1
+CN(C)C(=O)CCc1ccccc1Oc1cc(N2CCN(Cc3ccccc3-c3ccc(Cl)cc3)CC2)ccc1C(=O)NS(=O)(=O)c1ccc(NCC2CCOCC2)c([N+](=O)[O-])c1
+CN(C)C(=O)Cc1ccccc1Oc1cc(N2CCN(Cc3ccccc3-c3ccc(Cl)cc3)CC2)ccc1C(=O)NS(=O)(=O)c1ccc(NCC2CCOCC2)c([N+](=O)[O-])c1
+CN(C)CCCc1ccccc1Oc1cc(N2CCN(Cc3ccccc3-c3ccc(Cl)cc3)CC2)ccc1C(=O)NS(=O)(=O)c1ccc(NCC2CCOCC2)c([N+](=O)[O-])c1
+CN(C)CCc1ccccc1Oc1cc(N2CCN(Cc3ccccc3-c3ccc(Cl)cc3)CC2)ccc1C(=O)NS(=O)(=O)c1ccc(NCC2CCOCC2)c([N+](=O)[O-])c1
+CN(C)C(=O)c1ccccc1Oc1cc(N2CCN(Cc3ccccc3-c3ccc(Cl)cc3)CC2)ccc1C(=O)NS(=O)(=O)c1ccc(NCC2CCOCC2)c([N+](=O)[O-])c1
+CN(C)Cc1ccccc1Oc1cc(N2CCN(Cc3ccccc3-c3ccc(Cl)cc3)CC2)ccc1C(=O)NS(=O)(=O)c1ccc(NCC2CCOCC2)c([N+](=O)[O-])c1
+CN(C)CCCNc1ccc(S(=O)(=O)NC(=O)c2ccc(N3CCN(Cc4ccccc4-c4ccc(Cl)cc4)CC3)cc2Oc2cccc(N3CCOCC3)c2)cc1[N+](=O)[O-]
+Cc1nc(C)c(-c2cccc(Oc3cc(N4CCN(Cc5ccccc5-c5ccc(Cl)cc5)CC4)ccc3C(=O)NS(=O)(=O)c3ccc(NCCCN4CCOCC4)c([N+](=O)[O-])c3)c2)s1
+CN1CCC(Nc2ccc(S(=O)(=O)NC(=O)c3ccc(N4CCN(CC5=C(c6ccc(Cl)cc6)CC(C)(C)CC5)CC4)cc3Oc3cc(Cl)cc(Cl)c3)cc2[N+](=O)[O-])CC1
+CN1CCC(Nc2ccc(S(=O)(=O)NC(=O)c3ccc(N4CCN(CC5=C(c6ccc(Cl)cc6)CC(C)(C)CC5)CC4)cc3Oc3cccc(Cl)c3)cc2[N+](=O)[O-])CC1
+CN(C)CCOc1ccc(-c2ccc(Cl)cc2)c(CN2CCN(c3ccc(C(=O)NS(=O)(=O)c4ccc(NC5CCN(C)CC5)c([N+](=O)[O-])c4)c(Oc4cccc(Cl)c4)c3)CC2)c1
+CN1CCC(Nc2ccc(S(=O)(=O)NC(=O)c3ccc(N4CCN(CC5=C(c6ccc(Cl)cc6)CC(C)(C)OC5)CC4)cc3Oc3ccccc3Cl)cc2[N+](=O)[O-])CC1
+CN(C)CCOc1cccc(Oc2cc(N3CCN(Cc4ccccc4-c4ccc(Cl)cc4)CC3)ccc2C(=O)NS(=O)(=O)c2ccc(NCC3CCOCC3)c([N+](=O)[O-])c2)c1
+CN1CCC(Nc2ccc(S(=O)(=O)NC(=O)c3ccc(N4CCN(CC5=C(c6ccc(Cl)cc6)CC(C)(C)CC5)CC4)cc3Oc3ccc(N)c(Cl)c3)cc2[N+](=O)[O-])CC1
+CC(C)N1CCC(Nc2ccc(S(=O)(=O)NC(=O)c3ccc(N4CCN(CC5=C(c6ccc(Cl)cc6)CC(C)(C)CC5)CC4)cc3Oc3ccccc3Cl)cc2[N+](=O)[O-])CC1
+CN1CCC(Nc2ccc(S(=O)(=O)NC(=O)c3ccc(N4CCN(CC5=C(c6ccc(Cl)cc6)CC(C)(C)CC5)CC4)cc3Oc3ccccc3Br)cc2[N+](=O)[O-])CC1
+CN1CCC(Nc2ccc(S(=O)(=O)NC(=O)c3ccc(N4CCN(CC5=C(c6ccc(Cl)cc6)CCCC5)CC4)cc3Oc3ccccc3Cl)cc2[N+](=O)[O-])CC1
+Cc1n[nH]c2cccc(Oc3cc(N4CCN(CC5=C(c6ccc(Cl)cc6)CC(C)(C)CC5)CC4)ccc3C(=O)NS(=O)(=O)c3ccc(NCCCN4CCOCC4)c([N+](=O)[O-])c3)c12
+CN1CCC(Nc2ccc(S(=O)(=O)NC(=O)c3ccc(N4CCN(CC5=C(c6ccc(Cl)cc6)CC(C)(C)CC5)CC4)cc3Oc3cccc(F)c3F)cc2[N+](=O)[O-])CC1
+CN1CCC(Nc2ccc(S(=O)(=O)NC(=O)c3ccc(N4CCN(CC5=C(c6ccc(Cl)cc6)CC(C)(C)CC5)CC4)cc3Oc3cccc(Br)c3)cc2[N+](=O)[O-])CC1
+CCN1CCC(Nc2ccc(S(=O)(=O)NC(=O)c3ccc(N4CCN(CC5=C(c6ccc(Cl)cc6)CC(C)(C)CC5)CC4)cc3Oc3ccccc3Cl)cc2[N+](=O)[O-])CC1
+CN1C(C)(C)CC(Nc2ccc(S(=O)(=O)NC(=O)c3ccc(N4CCN(CC5=C(c6ccc(Cl)cc6)CC(C)(C)CC5)CC4)cc3Oc3ccccc3Cl)cc2[N+](=O)[O-])CC1(C)C
+CC1(C)CCC(CN2CCN(c3ccc(C(=O)NS(=O)(=O)c4ccc(NC5CCN(C6CCOCC6)CC5)c([N+](=O)[O-])c4)c(Oc4cccc(F)c4F)c3)CC2)=C(c2ccc(Cl)cc2)C1
+CN1CCC(Nc2ccc(S(=O)(=O)NC(=O)c3ccc(N4CCN(CC5=C(c6ccc(Cl)cc6)CC(C)(C)CC5)CC4)cc3Oc3cc(F)c4[nH]ccc4c3)cc2[N+](=O)[O-])CC1
+CC1(C)CCC(CN2CCN(c3ccc(C(=O)NS(=O)(=O)c4ccc(NCCCN5CCOCC5)c([N+](=O)[O-])c4)c(Oc4cccc(F)c4F)c3)CC2)=C(c2ccc(Cl)cc2)C1
+CC1(C)CCC(CN2CCN(c3ccc(C(=O)NS(=O)(=O)c4ccc(NCCCN5CCOCC5)c([N+](=O)[O-])c4)c(Oc4ccc(N)c(Cl)c4)c3)CC2)=C(c2ccc(Cl)cc2)C1
+O=C(NS(=O)(=O)c1ccc(NCC2CCOCC2)c([N+](=O)[O-])c1)c1ccc(N2CCN(Cc3cc(CCN4CCCC4)ccc3-c3ccc(Cl)cc3)CC2)cc1Oc1cccc(Cl)c1
+CN1CCC(Nc2ccc(S(=O)(=O)NC(=O)c3ccc(N4CCN(CC5=C(c6ccc(Cl)cc6)CC(C)(C)CC5)CC4)cc3Oc3cccc(Cl)c3Cl)cc2[N+](=O)[O-])CC1
+Cc1n[nH]c2cccc(Oc3cc(N4CCN(CC5=C(c6ccc(Cl)cc6)CC(C)(C)CC5)CC4)ccc3C(=O)NS(=O)(=O)c3ccc(NC4CCN(C)CC4)c([N+](=O)[O-])c3)c12
+CN1CCC(Nc2ccc(S(=O)(=O)NC(=O)c3ccc(N4CCN(CC5=C(c6ccc(Cl)cc6)CCCCC5)CC4)cc3Oc3ccccc3Cl)cc2[N+](=O)[O-])CC1
+CN1CCC(Nc2ccc(S(=O)(=O)NC(=O)c3ccc(N4CCN(CC5=C(c6ccc(Cl)cc6)CC(C)(C)CC5)CC4)cc3Oc3cccc(C(F)(F)F)c3)cc2[N+](=O)[O-])CC1
+CN(C)CCCNc1ccc(S(=O)(=O)NC(=O)c2ccc(N3CCN(Cc4ccccc4-c4ccc(Cl)cc4)CC3)cc2Oc2cccc3c2CCC(=O)N3)cc1[N+](=O)[O-]
+CN1CCC(Nc2ccc(S(=O)(=O)NC(=O)c3ccc(N4CCN(CC5=C(c6ccc(Cl)cc6)CC(C)(C)CC5)CC4)cc3Oc3ccccc3Cl)cc2S(=O)(=O)C(F)(F)F)CC1
+CN1CCC(Nc2ccc(S(=O)(=O)NC(=O)c3ccc(N4CCN(CC5=C(c6ccc(Cl)cc6)CC(C)(C)CC5)CC4)cc3Oc3cc(Cl)ccc3Cl)cc2[N+](=O)[O-])CC1
+CN1CCC(Nc2ccc(S(=O)(=O)NC(=O)c3ccc(N4CCN(CC5=C(c6ccc(Cl)cc6)CC(C)(C)CC5)CC4)cc3Oc3ccc(F)cc3Cl)cc2[N+](=O)[O-])CC1
+CN1CCC(Nc2ccc(S(=O)(=O)NC(=O)c3ccc(N4CCN(CC5=C(c6ccc(Cl)cc6)CC(C)(C)C5)CC4)cc3Oc3ccccc3Cl)cc2[N+](=O)[O-])CC1
+Cc1c[nH]c2cccc(Oc3cc(N4CCN(CC5=C(c6ccc(Cl)cc6)CC(C)(C)CC5)CC4)ccc3C(=O)NS(=O)(=O)c3ccc(NCCCN4CCOCC4)c([N+](=O)[O-])c3)c12
+CN1CCC(Nc2ccc(S(=O)(=O)NC(=O)c3ccc(N4CCN(CC5=C(c6ccc(Cl)cc6)CC(C)(C)CC5)CC4)cc3Oc3cccc(C(F)(F)F)c3Cl)cc2[N+](=O)[O-])CC1
+CC1(C)CCC(CN2CCN(c3ccc(C(=O)NS(=O)(=O)c4ccc(NC5CCN(C6CC6)CC5)c([N+](=O)[O-])c4)c(Oc4ccccc4Cl)c3)CC2)=C(c2ccc(Cl)cc2)C1
+Cc1c[nH]c2cccc(Oc3cc(N4CCN(CC5=C(c6ccc(Cl)cc6)CC(C)(C)CC5)CC4)ccc3C(=O)NS(=O)(=O)c3ccc(NC4CCN(C)CC4)c([N+](=O)[O-])c3)c12
+CC1(C)CCC(CN2CCN(c3ccc(C(=O)NS(=O)(=O)c4ccc(NCCCN5CCOCC5)c([N+](=O)[O-])c4)c(Oc4cc(Cl)ccc4Cl)c3)CC2)=C(c2ccc(Cl)cc2)C1
+Cn1ccc2c(Oc3cc(N4CCN(Cc5ccccc5-c5ccc(Cl)cc5)CC4)ccc3C(=O)NS(=O)(=O)c3ccc(NCCCN4CCOCC4)c([N+](=O)[O-])c3)cccc21
+O=C(NS(=O)(=O)c1ccc(NCCCN2CCOCC2)c([N+](=O)[O-])c1)c1ccc(N2CCN(Cc3ccccc3-c3ccc(Cl)cc3)CC2)cc1Oc1cccc(N2CCOCC2)c1
+CN(C)CCCNc1ccc(S(=O)(=O)NC(=O)c2ccc(N3CCN(Cc4ccccc4-c4ccc(Cl)cc4)CC3)cc2Oc2ccc3[nH]cc(CCC(=O)N4CCOCC4)c3c2)cc1[N+](=O)[O-]
+O=C(NS(=O)(=O)c1ccc(NCC2CCOCC2)c([N+](=O)[O-])c1)c1ccc(N2CCN(Cc3ccccc3-c3ccc(Cl)cc3)CC2)cc1Oc1cccc(OCc2ccccc2)c1
+N#Cc1ccc(Oc2cc(N3CCN(Cc4ccccc4-c4ccc(Cl)cc4)CC3)ccc2C(=O)NS(=O)(=O)c2ccc(NCC3CCOCC3)c([N+](=O)[O-])c2)cc1
+O=C(NS(=O)(=O)c1ccc(NCC2CCOCC2)c([N+](=O)[O-])c1)c1ccc(N2CCN(Cc3ccccc3-c3ccc(Cl)cc3)CC2)cc1Oc1ccc2[nH]cc(CCC(=O)N3CCOCC3)c2c1
+O=C(NS(=O)(=O)c1ccc(NCC2CCOCC2)c([N+](=O)[O-])c1)c1ccc(N2CCN(Cc3ccccc3-c3ccc(Cl)cc3)CC2)cc1Oc1ccc2[nH]cc(CCCN3CCOCC3)c2c1
+CN(C)Cc1ccc(Oc2cc(N3CCN(Cc4ccccc4-c4ccc(Cl)cc4)CC3)ccc2C(=O)NS(=O)(=O)c2ccc(NCC3CCOCC3)c([N+](=O)[O-])c2)cc1
+O=C(NS(=O)(=O)c1ccc(NCC2CCOCC2)c([N+](=O)[O-])c1)c1ccc(N2CCN(Cc3ccccc3-c3ccc(Cl)cc3)CC2)cc1Oc1ccc(-n2ccnc2)cc1
+O=C(NS(=O)(=O)c1ccc(NCC2CCOCC2)cc1)c1ccc(N2CCN(Cc3ccccc3-c3ccc(Cl)cc3)CC2)cc1Oc1cccc([N+](=O)[O-])c1
+CCN(Cc1ccc(Oc2cc(N3CCN(Cc4ccccc4-c4ccc(Cl)cc4)CC3)ccc2C(=O)NS(=O)(=O)c2ccc(NCC3CCOCC3)c([N+](=O)[O-])c2)cc1)C(=O)OC(C)(C)C
+CCN(Cc1cccc(Oc2cc(N3CCN(Cc4ccccc4-c4ccc(Cl)cc4)CC3)ccc2C(=O)NS(=O)(=O)c2ccc(NCC3CCOCC3)c([N+](=O)[O-])c2)c1)C(=O)OC(C)(C)C
+CCNCc1ccc(Oc2cc(N3CCN(Cc4ccccc4-c4ccc(Cl)cc4)CC3)ccc2C(=O)NS(=O)(=O)c2ccc(NCC3CCOCC3)c([N+](=O)[O-])c2)cc1
+CCNCc1cccc(Oc2cc(N3CCN(Cc4ccccc4-c4ccc(Cl)cc4)CC3)ccc2C(=O)NS(=O)(=O)c2ccc(NCC3CCOCC3)c([N+](=O)[O-])c2)c1
+CC(=O)Nc1ccc(Oc2cc(N3CCN(Cc4ccccc4-c4ccc(Cl)cc4)CC3)ccc2C(=O)NS(=O)(=O)c2ccc(NCC3CCOCC3)c([N+](=O)[O-])c2)cc1
+CC(C)(C)OC(=O)Nc1ccc(Oc2cc(N3CCN(Cc4ccccc4-c4ccc(Cl)cc4)CC3)ccc2C(=O)NS(=O)(=O)c2ccc(NCC3CCOCC3)c([N+](=O)[O-])c2)cc1
+O=C(NS(=O)(=O)c1ccc(NCC2CCOCC2)c([N+](=O)[O-])c1)c1ccc(N2CCN(Cc3ccccc3-c3ccc(Cl)cc3)CC2)cc1Oc1ccccc1-c1ccccc1
+CC(C)(C)OC(=O)Nc1cccc(Oc2cc(N3CCN(Cc4ccccc4-c4ccc(Cl)cc4)CC3)ccc2C(=O)NS(=O)(=O)c2ccc(NCC3CCOCC3)c([N+](=O)[O-])c2)c1
+O=C(NS(=O)(=O)c1ccc(NCC2CCOCC2)c([N+](=O)[O-])c1)c1ccc(N2CCN(Cc3ccccc3-c3ccc(Cl)cc3)CC2)cc1Oc1cccc(-c2ccccc2)c1
+CN(C)CCc1ccc(Oc2cc(N3CCN(Cc4ccccc4-c4ccc(Cl)cc4)CC3)ccc2C(=O)NS(=O)(=O)c2ccc(NCC3CCOCC3)c([N+](=O)[O-])c2)cc1
+O=C(NS(=O)(=O)c1ccc(NCC2CCOCC2)c([N+](=O)[O-])c1)c1ccc(N2CCN(Cc3ccccc3-c3ccc(Cl)cc3)CC2)cc1Oc1ccc(OCc2ccccc2)cc1
+O=C(NS(=O)(=O)c1ccc(NCC2CCOCC2)c([N+](=O)[O-])c1)c1ccc(N2CCN(Cc3ccccc3-c3ccc(Cl)cc3)CC2)cc1Oc1cccc(N2CCOCC2)c1
+Cc1nc2cc(Oc3cc(N4CCN(Cc5ccccc5-c5ccc(Cl)cc5)CC4)ccc3C(=O)NS(=O)(=O)c3ccc(NCC4CCOCC4)c([N+](=O)[O-])c3)ccc2s1
+CC(C)(C)OC(=O)N1CCN(c2cccc(Oc3cc(N4CCN(Cc5ccccc5-c5ccc(Cl)cc5)CC4)ccc3C(=O)NS(=O)(=O)c3ccc(NCC4CCOCC4)c([N+](=O)[O-])c3)c2)CC1
+CN(C)CCCNc1ccc(S(=O)(=O)NC(=O)c2ccc(N3CCN(Cc4ccccc4-c4ccc(Cl)cc4)CC3)cc2Oc2cccc(OCc3ccccc3)c2)cc1[N+](=O)[O-]
+O=C(NS(=O)(=O)c1ccc(NCCCN2CCOCC2)c([N+](=O)[O-])c1)c1ccc(N2CCN(Cc3ccccc3-c3ccc(Cl)cc3)CC2)cc1Oc1cccc(OCc2ccccc2)c1
+O=C(NS(=O)(=O)c1ccc(NCC2CCOCC2)c([N+](=O)[O-])c1)c1ccc(N2CCN(Cc3ccccc3-c3ccc(Cl)cc3)CC2)cc1Oc1ccc(OCCN2CCOCC2)cc1
+O=C1CCc2c(cccc2Oc2cc(N3CCN(Cc4ccccc4-c4ccc(Cl)cc4)CC3)ccc2C(=O)NS(=O)(=O)c2ccc(NCC3CCOCC3)c([N+](=O)[O-])c2)N1
+O=C(NS(=O)(=O)c1ccc(NCCCN2CCOCC2)c([N+](=O)[O-])c1)c1ccc(N2CCN(Cc3ccccc3-c3ccc(Cl)cc3)CC2)cc1Oc1ccc(OCc2ccccc2)cc1
+CC(C)(C)OC(=O)N1CCN(c2ccc(Oc3cc(N4CCN(Cc5ccccc5-c5ccc(Cl)cc5)CC4)ccc3C(=O)NS(=O)(=O)c3ccc(NCCCN4CCOCC4)c([N+](=O)[O-])c3)cc2)CC1
+O=C(NS(=O)(=O)c1ccc(NCCCN2CCOCC2)c([N+](=O)[O-])c1)c1ccc(N2CCN(Cc3ccccc3-c3ccc(Cl)cc3)CC2)cc1Oc1cccc(-c2ccncc2)c1
+O=C(NS(=O)(=O)c1ccc(NCCCN2CCOCC2)c([N+](=O)[O-])c1)c1ccc(N2CCN(Cc3ccccc3-c3ccc(Cl)cc3)CC2)cc1Oc1ccc(-c2ccncc2)cc1
+O=C(NS(=O)(=O)c1ccc(NCCCN2CCOCC2)c([N+](=O)[O-])c1)c1ccc(N2CCN(Cc3ccccc3-c3ccc(Cl)cc3)CC2)cc1Oc1ccc(-c2cccnc2)cc1
+CN(C)C(=O)COc1ccc(Oc2cc(N3CCN(Cc4ccccc4-c4ccc(Cl)cc4)CC3)ccc2C(=O)NS(=O)(=O)c2ccc(NCC3CCOCC3)c([N+](=O)[O-])c2)cc1
+Cn1cnc2cc(Oc3cc(N4CCN(Cc5ccccc5-c5ccc(Cl)cc5)CC4)ccc3C(=O)NS(=O)(=O)c3ccc(NCCCN4CCOCC4)c([N+](=O)[O-])c3)ccc21'''
+    mols = [Chem.MolFromSmiles(x) for x in smis.split('\n')]
+
+    core = Chem.MolFromSmarts('O=C(NS(=O)(=O)c1ccccc1)c1ccccc1Oc1ccccc1')
+    ps = RGroupDecompositionParameters()
+    ps.timeout = 1.0
+    with self.assertRaises(RuntimeError):
+      rg = RGroupDecomposition(core, ps)
+      for m in mols:
+        rg.Add(m)
+
+    with self.assertRaises(RuntimeError):
+      columns2, unmatched = RGroupDecompose([core], mols, asRows=False, options=ps)
 
 
-    def test_incorrect_multiple_rlabels(self):
-        mols = [Chem.MolFromSmiles(smi) for smi in ( 
-            "C1NC(Cl)CC1",   
-            "C1OC(Cl)CC1",
-            "C1(Cl)OCCC1", )]
-
-        scaffolds = [Chem.MolFromSmarts(x) for x in ("C1NCCC1",)]
-        groups,unmatched = RGroupDecompose(scaffolds, mols,
-                                               asSmiles=True, asRows=False) 
-            
-        self.assertEqual(groups,
-                         {'Core': ['C1CNC([*:1])C1'],
-                          'R1': ['Cl[*:1].[H][*:1]']})
-        
-        scaffolds = [Chem.MolFromSmarts(x) for x in ("C1OCCC1",)]
-        groups,unmatched = RGroupDecompose(scaffolds, mols,
-                                               asSmiles=True, asRows=False) 
-        self.assertEqual(groups,
-                         {'Core': ['C1COC([*:1])C1', 'C1COC([*:1])C1'],
-                          'R1': ['Cl[*:1].[H][*:1]', 'Cl[*:1].[H][*:1]']})
-        scaffolds = [Chem.MolFromSmarts(x) for x in ("C1NCCC1","C1OCCC1")]
-        groups,unmatched = RGroupDecompose(scaffolds, mols,
-                                           asSmiles=True, asRows=False)
-        self.assertEqual(groups,
-                         {'Core': ['C1CNC([*:1])C1', 'C1COC([*:1])C1', 'C1COC([*:1])C1'],
-                          'R1': ['Cl[*:1].[H][*:1]', 'Cl[*:1].[H][*:1]', 'Cl[*:1].[H][*:1]']})
-
-    def test_aligned_cores(self):
-        scaffolds = [Chem.MolFromSmarts(x) for x in ("C1NC1OC", "C1NC1NC")]
-        mols = [Chem.MolFromSmiles(smi) for smi in ("C1NC1OCCC", "C1NC1NCCC")]
-        groups,unmatched = RGroupDecompose(scaffolds, mols,
-                                           asSmiles=True, asRows=True)
-        #print("test_aligned_Cores")
-        #print("groups:", groups)
-        self.assertEqual(groups,
-                         [{'Core': 'C1NC1OC[*:1]',
-                           'R1': 'CC[*:1].[H][*:1].[H][*:1]'},
-                          {'Core': 'C1NC1NC[*:2]',
-                           'R2': 'CC[*:2].[H][*:2].[H][*:2]'}])
-                          
-    def test_aligned_cores2(self):
-        scaffolds = [Chem.MolFromSmarts(x) for x in ("C1NCC1", "C1SCC1")]
-        mols = [Chem.MolFromSmiles(smi) for smi in ("C1N(P)CC1", "C1S(P)CC1")]
-        #print("test_aligned_Cores2")
-        groups,unmatched = RGroupDecompose(scaffolds, mols,
-                                           asSmiles=True, asRows=True)
-        #print("groups: ", groups)
-        self.assertEqual(groups,
-                         [{'Core': 'C1CN([*:1])C1',
-                           'R1': 'P[*:1]'},
-                          {'Core': 'C1C[SH]([*:2])C1',
-                           'R2': 'P[*:2].[H][*:2]'}])
-
-    def test_getrgrouplabels(self):
-        smis = ["C(Cl)N(N)O(O)"]
-        mols = [Chem.MolFromSmiles(smi) for smi in smis]
-        smarts = 'C([*:1])N([*:5])O([*:6])'
-        core = Chem.MolFromSmarts(smarts)
-        rg = RGroupDecomposition(core)
-        for m in mols:
-            rg.Add(m)
-        rg.Process()
-        self.assertEqual(set(rg.GetRGroupLabels()),
-                         set(rg.GetRGroupsAsColumns()))
-
-        
 if __name__ == '__main__':
   unittest.main()

--- a/Code/GraphMol/RGroupDecomposition/testRGroupDecomp.cpp
+++ b/Code/GraphMol/RGroupDecomposition/testRGroupDecomp.cpp
@@ -40,6 +40,8 @@
 #include <GraphMol/FileParsers/FileParsers.h>
 #include <GraphMol/FileParsers/MolSupplier.h>
 #include <RDGeneral/Exceptions.h>
+#include <boost/tokenizer.hpp>
+typedef boost::tokenizer<boost::char_separator<char>> tokenizer;
 
 using namespace RDKit;
 
@@ -120,7 +122,8 @@ void testRGroupOnlyMatching() {
                        << std::endl;
 
   RWMol *core = SmilesToMol("c1ccccc1[1*]");
-  RGroupDecompositionParameters params(IsotopeLabels);
+  RGroupDecompositionParameters params;
+  params.labels = IsotopeLabels;
   params.onlyMatchAtRGroups = true;
 
   RGroupDecomposition decomp(*core, params);
@@ -160,7 +163,8 @@ void testRingMatching() {
   BOOST_LOG(rdInfoLog) << "test rgroup decomp ring matching" << std::endl;
 
   RWMol *core = SmilesToMol("c1ccc[1*]1");
-  RGroupDecompositionParameters params(IsotopeLabels);
+  RGroupDecompositionParameters params;
+  params.labels = IsotopeLabels;
 
   RGroupDecomposition decomp(*core, params);
   for (int i = 0; i < 3; ++i) {
@@ -525,8 +529,9 @@ void testMatchOnlyAtRgroupHs() {
     }
   }
   delete core;
-  TEST_ASSERT(ss.str() ==
-              "Rgroup===Core\nCCO[*:1]\nCCO[*:1]\nRgroup===R1\n[H][*:1]\nC[*:1]\n");
+  TEST_ASSERT(
+      ss.str() ==
+      "Rgroup===Core\nCCO[*:1]\nCCO[*:1]\nRgroup===R1\n[H][*:1]\nC[*:1]\n");
 }
 
 void testGithub2332() {
@@ -859,13 +864,12 @@ $$$$)CTAB";
         "Core:N1C(N([*:2])[*:4])C2C(NC1[*:1])[*:5]C([*:3])[*:6]2 "
         "R2:C(CC[*:2])CC[*:4] R4:C(CC[*:2])CC[*:4] R5:N([*:5])[*:5] "
         "R6:C([*:6])[*:6]",
-	"Core:N1C(N([*:2])[*:4])C2C(NC1[*:1])[*:5]C([*:3])[*:6]2 "
-	"R2:C[*:2] R4:[H][*:4] R5:S([*:5])[*:5] R6:CC(C)C([*:6])[*:6]",
-	"Core:C1C([*:1])NC(N([*:2])[*:4])C2C1[*:5]C([*:3])[*:6]2 "
-	"R2:C[*:2] R4:[H][*:4] R5:S([*:5])[*:5] R6:CC(C)C([*:6])[*:6]",
-	"Core:C1C([*:1])NC(N([*:2])[*:4])C2C1[*:5]C([*:3])[*:6]2 "
-	"R2:[H][*:2] R4:[H][*:4] R5:CN([*:5])[*:5] R6:N([*:6])[*:6]"
-    };
+        "Core:N1C(N([*:2])[*:4])C2C(NC1[*:1])[*:5]C([*:3])[*:6]2 "
+        "R2:C[*:2] R4:[H][*:4] R5:S([*:5])[*:5] R6:CC(C)C([*:6])[*:6]",
+        "Core:C1C([*:1])NC(N([*:2])[*:4])C2C1[*:5]C([*:3])[*:6]2 "
+        "R2:C[*:2] R4:[H][*:4] R5:S([*:5])[*:5] R6:CC(C)C([*:6])[*:6]",
+        "Core:C1C([*:1])NC(N([*:2])[*:4])C2C1[*:5]C([*:3])[*:6]2 "
+        "R2:[H][*:2] R4:[H][*:4] R5:CN([*:5])[*:5] R6:N([*:6])[*:6]"};
 
     int i = 0;
     for (RGroupRows::const_iterator it = rows.begin(); it != rows.end();
@@ -905,11 +909,12 @@ void testRowColumnAlignmentProblem() {
     TEST_ASSERT(rows.size() == mols.size());
     // dump rgroups
     const char *expected[] = {"Core:c1cncc([*:1])c1 R1:F[*:1]",
-			      "Core:c1ncc([*:1])cn1 R1:F[*:1]",
-			      "Core:c1cncc([*:1])c1 R1:Cl[*:1]"};
+                              "Core:c1ncc([*:1])cn1 R1:F[*:1]",
+                              "Core:c1cncc([*:1])c1 R1:Cl[*:1]"};
 
-    int i=0;
-    for (RGroupRows::const_iterator it = rows.begin(); it != rows.end(); ++it, ++i) {
+    int i = 0;
+    for (RGroupRows::const_iterator it = rows.begin(); it != rows.end();
+         ++it, ++i) {
       CHECK_RGROUP(it, expected[i]);
     }
 
@@ -937,10 +942,10 @@ void testRowColumnAlignmentProblem() {
 
 void testSymmetryIssues() {
   BOOST_LOG(rdInfoLog)
-    << "********************************************************\n";
+      << "********************************************************\n";
   BOOST_LOG(rdInfoLog) << "Testing R-Group symmetry issues \n";
 
-  auto m1 = "c1c(F)cccn1"_smiles; 
+  auto m1 = "c1c(F)cccn1"_smiles;
   auto m2 = "c1c(Cl)c(C)ccn1"_smiles;
   auto m3 = "c1c(O)cccn1"_smiles;
   auto m4 = "c1cc(C)c(F)cn1"_smiles;
@@ -962,10 +967,10 @@ void testSymmetryIssues() {
     }
   }
   // We only want two groups added
-  
-  TEST_ASSERT(r_labels == std::set<std::string>({"Core", "R1", "R2"}));  
+
+  TEST_ASSERT(r_labels == std::set<std::string>({"Core", "R1", "R2"}));
   TEST_ASSERT(groups.size() == 3);
-  
+
   TEST_ASSERT(ss.str() == R"RES(Rgroup===Core
 c1cc([*:2])c([*:1])cn1
 c1cc([*:2])c([*:1])cn1
@@ -983,6 +988,158 @@ C[*:2]
 C[*:2]
 )RES");
 }
+
+void testSymmetryPerformance() {
+  BOOST_LOG(rdInfoLog)
+      << "********************************************************\n";
+  BOOST_LOG(rdInfoLog) << "Testing R-Group symmetry issues \n";
+  std::string smis =
+      R"DATA(CN(C)Cc1cccc(Oc2cc(N3CCN(Cc4ccccc4-c4ccc(Cl)cc4)CC3)ccc2C(=O)NS(=O)(=O)c2ccc(NCC3CCOCC3)c([N+](=O)[O-])c2)c1
+CNc1cccc(Oc2cc(N3CCN(Cc4ccccc4-c4ccc(Cl)cc4)CC3)ccc2C(=O)NS(=O)(=O)c2ccc(NCC3CCOCC3)c([N+](=O)[O-])c2)c1
+Cc1cc2cc(Oc3cc(N4CCN(CC5=C(c6ccc(Cl)cc6)CC(C)(C)CC5)CC4)ccc3C(=O)NS(=O)(=O)c3ccc(NC4CCN(C)CC4)c([N+](=O)[O-])c3)ccc2[nH]1
+Cc1cc2cc(Oc3cc(N4CCN(CC5=C(c6ccc(Cl)cc6)CC(C)(C)CC5)CC4)ccc3C(=O)NS(=O)(=O)c3ccc(NCCCN4CCOCC4)c([N+](=O)[O-])c3)ccc2[nH]1
+O=C(NS(=O)(=O)c1ccc(NCC2CCOCC2)c([N+](=O)[O-])c1)c1ccc(N2CCN(Cc3ccccc3-c3ccc(Cl)cc3)CC2)cc1Oc1ccccc1Cl
+O=C(NS(=O)(=O)c1ccc(NCC2CCOCC2)c([N+](=O)[O-])c1)c1ccc(N2CCN(Cc3ccccc3-c3ccc(Cl)cc3)CC2)cc1Oc1cccc(Cl)c1
+O=C(NS(=O)(=O)c1ccc(NCC2CCOCC2)c([N+](=O)[O-])c1)c1ccc(N2CCN(Cc3ccccc3-c3ccc(Cl)cc3)CC2)cc1Oc1ccc(Cl)cc1
+O=C(NS(=O)(=O)c1ccc(NCC2CCOCC2)c([N+](=O)[O-])c1)c1ccc(N2CCN(Cc3ccccc3-c3ccc(Cl)cc3)CC2)cc1Oc1cccc([N+](=O)[O-])c1
+O=C(NS(=O)(=O)c1ccc(NCCCN2CCOCC2)c([N+](=O)[O-])c1)c1ccc(N2CCN(Cc3ccccc3-c3ccc(Cl)cc3)CC2)cc1Oc1cccc(CO)c1
+CN(C)CCCNc1ccc(S(=O)(=O)NC(=O)c2ccc(N3CCN(Cc4ccccc4-c4ccc(Cl)cc4)CC3)cc2Oc2ccccc2Cl)cc1[N+](=O)[O-]
+O=C(NS(=O)(=O)c1ccc(NCCCN2CCOCC2)c([N+](=O)[O-])c1)c1ccc(N2CCN(Cc3ccccc3-c3ccc(Cl)cc3)CC2)cc1Oc1cccc(Cl)c1
+O=C(NS(=O)(=O)c1ccc(NCCCN2CCOCC2)c([N+](=O)[O-])c1)c1ccc(N2CCN(Cc3ccccc3-c3ccc(Cl)cc3)CC2)cc1Oc1ccc(Cl)cc1
+CN(C)CCCNc1ccc(S(=O)(=O)NC(=O)c2ccc(N3CCN(Cc4ccccc4-c4ccc(Cl)cc4)CC3)cc2Oc2cccc(Cl)c2)cc1[N+](=O)[O-]
+CN(C)CCCNc1ccc(S(=O)(=O)NC(=O)c2ccc(N3CCN(Cc4ccccc4-c4ccc(Cl)cc4)CC3)cc2Oc2ccc(Cl)cc2)cc1[N+](=O)[O-]
+CN(C)CCCNc1ccc(S(=O)(=O)NC(=O)c2ccc(N3CCN(Cc4ccccc4-c4ccc(Cl)cc4)CC3)cc2Oc2cccc3c2ccn3C)cc1[N+](=O)[O-]
+CC(=O)Nc1cccc(Oc2cc(N3CCN(Cc4ccccc4-c4ccc(Cl)cc4)CC3)ccc2C(=O)NS(=O)(=O)c2ccc(NCC3CCOCC3)c([N+](=O)[O-])c2)c1
+Nc1ccc(Oc2cc(N3CCN(Cc4ccccc4-c4ccc(Cl)cc4)CC3)ccc2C(=O)NS(=O)(=O)c2ccc(NCC3CCOCC3)c([N+](=O)[O-])c2)cc1
+Nc1cccc(Oc2cc(N3CCN(Cc4ccccc4-c4ccc(Cl)cc4)CC3)ccc2C(=O)NS(=O)(=O)c2ccc(NCC3CCOCC3)c([N+](=O)[O-])c2)c1
+COc1cccc(Oc2cc(N3CCN(Cc4ccccc4-c4ccc(Cl)cc4)CC3)ccc2C(=O)NS(=O)(=O)c2ccc(NCC3CCOCC3)c([N+](=O)[O-])c2)c1
+CN(C)c1cccc(Oc2cc(N3CCN(Cc4ccccc4-c4ccc(Cl)cc4)CC3)ccc2C(=O)NS(=O)(=O)c2ccc(NCC3CCOCC3)c([N+](=O)[O-])c2)c1
+N#Cc1cccc(Oc2cc(N3CCN(Cc4ccccc4-c4ccc(Cl)cc4)CC3)ccc2C(=O)NS(=O)(=O)c2ccc(NCC3CCOCC3)c([N+](=O)[O-])c2)c1
+Cc1nc2ccc(Oc3cc(N4CCN(Cc5ccccc5-c5ccc(Cl)cc5)CC4)ccc3C(=O)NS(=O)(=O)c3ccc(NCC4CCOCC4)c([N+](=O)[O-])c3)cc2s1
+Cc1nc2cc(Oc3cc(N4CCN(Cc5ccccc5-c5ccc(Cl)cc5)CC4)ccc3C(=O)NS(=O)(=O)c3ccc(NCCCN4CCOCC4)c([N+](=O)[O-])c3)ccc2s1
+Cc1nc2cc(Oc3cc(N4CCN(Cc5ccccc5-c5ccc(Cl)cc5)CC4)ccc3C(=O)NS(=O)(=O)c3ccc(NCCCN(C)C)c([N+](=O)[O-])c3)ccc2s1
+CN(C)C(=O)CCc1ccccc1Oc1cc(N2CCN(Cc3ccccc3-c3ccc(Cl)cc3)CC2)ccc1C(=O)NS(=O)(=O)c1ccc(NCC2CCOCC2)c([N+](=O)[O-])c1
+CN(C)C(=O)Cc1ccccc1Oc1cc(N2CCN(Cc3ccccc3-c3ccc(Cl)cc3)CC2)ccc1C(=O)NS(=O)(=O)c1ccc(NCC2CCOCC2)c([N+](=O)[O-])c1
+CN(C)CCCc1ccccc1Oc1cc(N2CCN(Cc3ccccc3-c3ccc(Cl)cc3)CC2)ccc1C(=O)NS(=O)(=O)c1ccc(NCC2CCOCC2)c([N+](=O)[O-])c1
+CN(C)CCc1ccccc1Oc1cc(N2CCN(Cc3ccccc3-c3ccc(Cl)cc3)CC2)ccc1C(=O)NS(=O)(=O)c1ccc(NCC2CCOCC2)c([N+](=O)[O-])c1
+CN(C)C(=O)c1ccccc1Oc1cc(N2CCN(Cc3ccccc3-c3ccc(Cl)cc3)CC2)ccc1C(=O)NS(=O)(=O)c1ccc(NCC2CCOCC2)c([N+](=O)[O-])c1
+CN(C)Cc1ccccc1Oc1cc(N2CCN(Cc3ccccc3-c3ccc(Cl)cc3)CC2)ccc1C(=O)NS(=O)(=O)c1ccc(NCC2CCOCC2)c([N+](=O)[O-])c1
+CN(C)CCCNc1ccc(S(=O)(=O)NC(=O)c2ccc(N3CCN(Cc4ccccc4-c4ccc(Cl)cc4)CC3)cc2Oc2cccc(N3CCOCC3)c2)cc1[N+](=O)[O-]
+Cc1nc(C)c(-c2cccc(Oc3cc(N4CCN(Cc5ccccc5-c5ccc(Cl)cc5)CC4)ccc3C(=O)NS(=O)(=O)c3ccc(NCCCN4CCOCC4)c([N+](=O)[O-])c3)c2)s1
+CN1CCC(Nc2ccc(S(=O)(=O)NC(=O)c3ccc(N4CCN(CC5=C(c6ccc(Cl)cc6)CC(C)(C)CC5)CC4)cc3Oc3cc(Cl)cc(Cl)c3)cc2[N+](=O)[O-])CC1
+CN1CCC(Nc2ccc(S(=O)(=O)NC(=O)c3ccc(N4CCN(CC5=C(c6ccc(Cl)cc6)CC(C)(C)CC5)CC4)cc3Oc3cccc(Cl)c3)cc2[N+](=O)[O-])CC1
+CN(C)CCOc1ccc(-c2ccc(Cl)cc2)c(CN2CCN(c3ccc(C(=O)NS(=O)(=O)c4ccc(NC5CCN(C)CC5)c([N+](=O)[O-])c4)c(Oc4cccc(Cl)c4)c3)CC2)c1
+CN1CCC(Nc2ccc(S(=O)(=O)NC(=O)c3ccc(N4CCN(CC5=C(c6ccc(Cl)cc6)CC(C)(C)OC5)CC4)cc3Oc3ccccc3Cl)cc2[N+](=O)[O-])CC1
+CN(C)CCOc1cccc(Oc2cc(N3CCN(Cc4ccccc4-c4ccc(Cl)cc4)CC3)ccc2C(=O)NS(=O)(=O)c2ccc(NCC3CCOCC3)c([N+](=O)[O-])c2)c1
+CN1CCC(Nc2ccc(S(=O)(=O)NC(=O)c3ccc(N4CCN(CC5=C(c6ccc(Cl)cc6)CC(C)(C)CC5)CC4)cc3Oc3ccc(N)c(Cl)c3)cc2[N+](=O)[O-])CC1
+CC(C)N1CCC(Nc2ccc(S(=O)(=O)NC(=O)c3ccc(N4CCN(CC5=C(c6ccc(Cl)cc6)CC(C)(C)CC5)CC4)cc3Oc3ccccc3Cl)cc2[N+](=O)[O-])CC1
+CN1CCC(Nc2ccc(S(=O)(=O)NC(=O)c3ccc(N4CCN(CC5=C(c6ccc(Cl)cc6)CC(C)(C)CC5)CC4)cc3Oc3ccccc3Br)cc2[N+](=O)[O-])CC1
+CN1CCC(Nc2ccc(S(=O)(=O)NC(=O)c3ccc(N4CCN(CC5=C(c6ccc(Cl)cc6)CCCC5)CC4)cc3Oc3ccccc3Cl)cc2[N+](=O)[O-])CC1
+Cc1n[nH]c2cccc(Oc3cc(N4CCN(CC5=C(c6ccc(Cl)cc6)CC(C)(C)CC5)CC4)ccc3C(=O)NS(=O)(=O)c3ccc(NCCCN4CCOCC4)c([N+](=O)[O-])c3)c12
+CN1CCC(Nc2ccc(S(=O)(=O)NC(=O)c3ccc(N4CCN(CC5=C(c6ccc(Cl)cc6)CC(C)(C)CC5)CC4)cc3Oc3cccc(F)c3F)cc2[N+](=O)[O-])CC1
+CN1CCC(Nc2ccc(S(=O)(=O)NC(=O)c3ccc(N4CCN(CC5=C(c6ccc(Cl)cc6)CC(C)(C)CC5)CC4)cc3Oc3cccc(Br)c3)cc2[N+](=O)[O-])CC1
+CCN1CCC(Nc2ccc(S(=O)(=O)NC(=O)c3ccc(N4CCN(CC5=C(c6ccc(Cl)cc6)CC(C)(C)CC5)CC4)cc3Oc3ccccc3Cl)cc2[N+](=O)[O-])CC1
+CN1C(C)(C)CC(Nc2ccc(S(=O)(=O)NC(=O)c3ccc(N4CCN(CC5=C(c6ccc(Cl)cc6)CC(C)(C)CC5)CC4)cc3Oc3ccccc3Cl)cc2[N+](=O)[O-])CC1(C)C
+CC1(C)CCC(CN2CCN(c3ccc(C(=O)NS(=O)(=O)c4ccc(NC5CCN(C6CCOCC6)CC5)c([N+](=O)[O-])c4)c(Oc4cccc(F)c4F)c3)CC2)=C(c2ccc(Cl)cc2)C1
+CN1CCC(Nc2ccc(S(=O)(=O)NC(=O)c3ccc(N4CCN(CC5=C(c6ccc(Cl)cc6)CC(C)(C)CC5)CC4)cc3Oc3cc(F)c4[nH]ccc4c3)cc2[N+](=O)[O-])CC1
+CC1(C)CCC(CN2CCN(c3ccc(C(=O)NS(=O)(=O)c4ccc(NCCCN5CCOCC5)c([N+](=O)[O-])c4)c(Oc4cccc(F)c4F)c3)CC2)=C(c2ccc(Cl)cc2)C1
+CC1(C)CCC(CN2CCN(c3ccc(C(=O)NS(=O)(=O)c4ccc(NCCCN5CCOCC5)c([N+](=O)[O-])c4)c(Oc4ccc(N)c(Cl)c4)c3)CC2)=C(c2ccc(Cl)cc2)C1
+O=C(NS(=O)(=O)c1ccc(NCC2CCOCC2)c([N+](=O)[O-])c1)c1ccc(N2CCN(Cc3cc(CCN4CCCC4)ccc3-c3ccc(Cl)cc3)CC2)cc1Oc1cccc(Cl)c1
+CN1CCC(Nc2ccc(S(=O)(=O)NC(=O)c3ccc(N4CCN(CC5=C(c6ccc(Cl)cc6)CC(C)(C)CC5)CC4)cc3Oc3cccc(Cl)c3Cl)cc2[N+](=O)[O-])CC1
+Cc1n[nH]c2cccc(Oc3cc(N4CCN(CC5=C(c6ccc(Cl)cc6)CC(C)(C)CC5)CC4)ccc3C(=O)NS(=O)(=O)c3ccc(NC4CCN(C)CC4)c([N+](=O)[O-])c3)c12
+CN1CCC(Nc2ccc(S(=O)(=O)NC(=O)c3ccc(N4CCN(CC5=C(c6ccc(Cl)cc6)CCCCC5)CC4)cc3Oc3ccccc3Cl)cc2[N+](=O)[O-])CC1
+CN1CCC(Nc2ccc(S(=O)(=O)NC(=O)c3ccc(N4CCN(CC5=C(c6ccc(Cl)cc6)CC(C)(C)CC5)CC4)cc3Oc3cccc(C(F)(F)F)c3)cc2[N+](=O)[O-])CC1
+CN(C)CCCNc1ccc(S(=O)(=O)NC(=O)c2ccc(N3CCN(Cc4ccccc4-c4ccc(Cl)cc4)CC3)cc2Oc2cccc3c2CCC(=O)N3)cc1[N+](=O)[O-]
+CN1CCC(Nc2ccc(S(=O)(=O)NC(=O)c3ccc(N4CCN(CC5=C(c6ccc(Cl)cc6)CC(C)(C)CC5)CC4)cc3Oc3ccccc3Cl)cc2S(=O)(=O)C(F)(F)F)CC1
+CN1CCC(Nc2ccc(S(=O)(=O)NC(=O)c3ccc(N4CCN(CC5=C(c6ccc(Cl)cc6)CC(C)(C)CC5)CC4)cc3Oc3cc(Cl)ccc3Cl)cc2[N+](=O)[O-])CC1
+CN1CCC(Nc2ccc(S(=O)(=O)NC(=O)c3ccc(N4CCN(CC5=C(c6ccc(Cl)cc6)CC(C)(C)CC5)CC4)cc3Oc3ccc(F)cc3Cl)cc2[N+](=O)[O-])CC1
+CN1CCC(Nc2ccc(S(=O)(=O)NC(=O)c3ccc(N4CCN(CC5=C(c6ccc(Cl)cc6)CC(C)(C)C5)CC4)cc3Oc3ccccc3Cl)cc2[N+](=O)[O-])CC1
+Cc1c[nH]c2cccc(Oc3cc(N4CCN(CC5=C(c6ccc(Cl)cc6)CC(C)(C)CC5)CC4)ccc3C(=O)NS(=O)(=O)c3ccc(NCCCN4CCOCC4)c([N+](=O)[O-])c3)c12
+CN1CCC(Nc2ccc(S(=O)(=O)NC(=O)c3ccc(N4CCN(CC5=C(c6ccc(Cl)cc6)CC(C)(C)CC5)CC4)cc3Oc3cccc(C(F)(F)F)c3Cl)cc2[N+](=O)[O-])CC1
+CC1(C)CCC(CN2CCN(c3ccc(C(=O)NS(=O)(=O)c4ccc(NC5CCN(C6CC6)CC5)c([N+](=O)[O-])c4)c(Oc4ccccc4Cl)c3)CC2)=C(c2ccc(Cl)cc2)C1
+Cc1c[nH]c2cccc(Oc3cc(N4CCN(CC5=C(c6ccc(Cl)cc6)CC(C)(C)CC5)CC4)ccc3C(=O)NS(=O)(=O)c3ccc(NC4CCN(C)CC4)c([N+](=O)[O-])c3)c12
+CC1(C)CCC(CN2CCN(c3ccc(C(=O)NS(=O)(=O)c4ccc(NCCCN5CCOCC5)c([N+](=O)[O-])c4)c(Oc4cc(Cl)ccc4Cl)c3)CC2)=C(c2ccc(Cl)cc2)C1
+Cn1ccc2c(Oc3cc(N4CCN(Cc5ccccc5-c5ccc(Cl)cc5)CC4)ccc3C(=O)NS(=O)(=O)c3ccc(NCCCN4CCOCC4)c([N+](=O)[O-])c3)cccc21
+O=C(NS(=O)(=O)c1ccc(NCCCN2CCOCC2)c([N+](=O)[O-])c1)c1ccc(N2CCN(Cc3ccccc3-c3ccc(Cl)cc3)CC2)cc1Oc1cccc(N2CCOCC2)c1
+CN(C)CCCNc1ccc(S(=O)(=O)NC(=O)c2ccc(N3CCN(Cc4ccccc4-c4ccc(Cl)cc4)CC3)cc2Oc2ccc3[nH]cc(CCC(=O)N4CCOCC4)c3c2)cc1[N+](=O)[O-]
+O=C(NS(=O)(=O)c1ccc(NCC2CCOCC2)c([N+](=O)[O-])c1)c1ccc(N2CCN(Cc3ccccc3-c3ccc(Cl)cc3)CC2)cc1Oc1cccc(OCc2ccccc2)c1
+N#Cc1ccc(Oc2cc(N3CCN(Cc4ccccc4-c4ccc(Cl)cc4)CC3)ccc2C(=O)NS(=O)(=O)c2ccc(NCC3CCOCC3)c([N+](=O)[O-])c2)cc1
+O=C(NS(=O)(=O)c1ccc(NCC2CCOCC2)c([N+](=O)[O-])c1)c1ccc(N2CCN(Cc3ccccc3-c3ccc(Cl)cc3)CC2)cc1Oc1ccc2[nH]cc(CCC(=O)N3CCOCC3)c2c1
+O=C(NS(=O)(=O)c1ccc(NCC2CCOCC2)c([N+](=O)[O-])c1)c1ccc(N2CCN(Cc3ccccc3-c3ccc(Cl)cc3)CC2)cc1Oc1ccc2[nH]cc(CCCN3CCOCC3)c2c1
+CN(C)Cc1ccc(Oc2cc(N3CCN(Cc4ccccc4-c4ccc(Cl)cc4)CC3)ccc2C(=O)NS(=O)(=O)c2ccc(NCC3CCOCC3)c([N+](=O)[O-])c2)cc1
+O=C(NS(=O)(=O)c1ccc(NCC2CCOCC2)c([N+](=O)[O-])c1)c1ccc(N2CCN(Cc3ccccc3-c3ccc(Cl)cc3)CC2)cc1Oc1ccc(-n2ccnc2)cc1
+O=C(NS(=O)(=O)c1ccc(NCC2CCOCC2)cc1)c1ccc(N2CCN(Cc3ccccc3-c3ccc(Cl)cc3)CC2)cc1Oc1cccc([N+](=O)[O-])c1
+CCN(Cc1ccc(Oc2cc(N3CCN(Cc4ccccc4-c4ccc(Cl)cc4)CC3)ccc2C(=O)NS(=O)(=O)c2ccc(NCC3CCOCC3)c([N+](=O)[O-])c2)cc1)C(=O)OC(C)(C)C
+CCN(Cc1cccc(Oc2cc(N3CCN(Cc4ccccc4-c4ccc(Cl)cc4)CC3)ccc2C(=O)NS(=O)(=O)c2ccc(NCC3CCOCC3)c([N+](=O)[O-])c2)c1)C(=O)OC(C)(C)C
+CCNCc1ccc(Oc2cc(N3CCN(Cc4ccccc4-c4ccc(Cl)cc4)CC3)ccc2C(=O)NS(=O)(=O)c2ccc(NCC3CCOCC3)c([N+](=O)[O-])c2)cc1
+CCNCc1cccc(Oc2cc(N3CCN(Cc4ccccc4-c4ccc(Cl)cc4)CC3)ccc2C(=O)NS(=O)(=O)c2ccc(NCC3CCOCC3)c([N+](=O)[O-])c2)c1
+CC(=O)Nc1ccc(Oc2cc(N3CCN(Cc4ccccc4-c4ccc(Cl)cc4)CC3)ccc2C(=O)NS(=O)(=O)c2ccc(NCC3CCOCC3)c([N+](=O)[O-])c2)cc1
+CC(C)(C)OC(=O)Nc1ccc(Oc2cc(N3CCN(Cc4ccccc4-c4ccc(Cl)cc4)CC3)ccc2C(=O)NS(=O)(=O)c2ccc(NCC3CCOCC3)c([N+](=O)[O-])c2)cc1
+O=C(NS(=O)(=O)c1ccc(NCC2CCOCC2)c([N+](=O)[O-])c1)c1ccc(N2CCN(Cc3ccccc3-c3ccc(Cl)cc3)CC2)cc1Oc1ccccc1-c1ccccc1
+CC(C)(C)OC(=O)Nc1cccc(Oc2cc(N3CCN(Cc4ccccc4-c4ccc(Cl)cc4)CC3)ccc2C(=O)NS(=O)(=O)c2ccc(NCC3CCOCC3)c([N+](=O)[O-])c2)c1
+O=C(NS(=O)(=O)c1ccc(NCC2CCOCC2)c([N+](=O)[O-])c1)c1ccc(N2CCN(Cc3ccccc3-c3ccc(Cl)cc3)CC2)cc1Oc1cccc(-c2ccccc2)c1
+CN(C)CCc1ccc(Oc2cc(N3CCN(Cc4ccccc4-c4ccc(Cl)cc4)CC3)ccc2C(=O)NS(=O)(=O)c2ccc(NCC3CCOCC3)c([N+](=O)[O-])c2)cc1
+O=C(NS(=O)(=O)c1ccc(NCC2CCOCC2)c([N+](=O)[O-])c1)c1ccc(N2CCN(Cc3ccccc3-c3ccc(Cl)cc3)CC2)cc1Oc1ccc(OCc2ccccc2)cc1
+O=C(NS(=O)(=O)c1ccc(NCC2CCOCC2)c([N+](=O)[O-])c1)c1ccc(N2CCN(Cc3ccccc3-c3ccc(Cl)cc3)CC2)cc1Oc1cccc(N2CCOCC2)c1
+Cc1nc2cc(Oc3cc(N4CCN(Cc5ccccc5-c5ccc(Cl)cc5)CC4)ccc3C(=O)NS(=O)(=O)c3ccc(NCC4CCOCC4)c([N+](=O)[O-])c3)ccc2s1
+CC(C)(C)OC(=O)N1CCN(c2cccc(Oc3cc(N4CCN(Cc5ccccc5-c5ccc(Cl)cc5)CC4)ccc3C(=O)NS(=O)(=O)c3ccc(NCC4CCOCC4)c([N+](=O)[O-])c3)c2)CC1
+CN(C)CCCNc1ccc(S(=O)(=O)NC(=O)c2ccc(N3CCN(Cc4ccccc4-c4ccc(Cl)cc4)CC3)cc2Oc2cccc(OCc3ccccc3)c2)cc1[N+](=O)[O-]
+O=C(NS(=O)(=O)c1ccc(NCCCN2CCOCC2)c([N+](=O)[O-])c1)c1ccc(N2CCN(Cc3ccccc3-c3ccc(Cl)cc3)CC2)cc1Oc1cccc(OCc2ccccc2)c1
+O=C(NS(=O)(=O)c1ccc(NCC2CCOCC2)c([N+](=O)[O-])c1)c1ccc(N2CCN(Cc3ccccc3-c3ccc(Cl)cc3)CC2)cc1Oc1ccc(OCCN2CCOCC2)cc1
+O=C1CCc2c(cccc2Oc2cc(N3CCN(Cc4ccccc4-c4ccc(Cl)cc4)CC3)ccc2C(=O)NS(=O)(=O)c2ccc(NCC3CCOCC3)c([N+](=O)[O-])c2)N1
+O=C(NS(=O)(=O)c1ccc(NCCCN2CCOCC2)c([N+](=O)[O-])c1)c1ccc(N2CCN(Cc3ccccc3-c3ccc(Cl)cc3)CC2)cc1Oc1ccc(OCc2ccccc2)cc1
+CC(C)(C)OC(=O)N1CCN(c2ccc(Oc3cc(N4CCN(Cc5ccccc5-c5ccc(Cl)cc5)CC4)ccc3C(=O)NS(=O)(=O)c3ccc(NCCCN4CCOCC4)c([N+](=O)[O-])c3)cc2)CC1
+O=C(NS(=O)(=O)c1ccc(NCCCN2CCOCC2)c([N+](=O)[O-])c1)c1ccc(N2CCN(Cc3ccccc3-c3ccc(Cl)cc3)CC2)cc1Oc1cccc(-c2ccncc2)c1
+O=C(NS(=O)(=O)c1ccc(NCCCN2CCOCC2)c([N+](=O)[O-])c1)c1ccc(N2CCN(Cc3ccccc3-c3ccc(Cl)cc3)CC2)cc1Oc1ccc(-c2ccncc2)cc1
+O=C(NS(=O)(=O)c1ccc(NCCCN2CCOCC2)c([N+](=O)[O-])c1)c1ccc(N2CCN(Cc3ccccc3-c3ccc(Cl)cc3)CC2)cc1Oc1ccc(-c2cccnc2)cc1
+CN(C)C(=O)COc1ccc(Oc2cc(N3CCN(Cc4ccccc4-c4ccc(Cl)cc4)CC3)ccc2C(=O)NS(=O)(=O)c2ccc(NCC3CCOCC3)c([N+](=O)[O-])c2)cc1
+Cn1cnc2cc(Oc3cc(N4CCN(Cc5ccccc5-c5ccc(Cl)cc5)CC4)ccc3C(=O)NS(=O)(=O)c3ccc(NCCCN4CCOCC4)c([N+](=O)[O-])c3)ccc21)DATA";
+  std::vector<ROMOL_SPTR> ms;
+  boost::char_separator<char> sep(" \n");
+  tokenizer tokens(smis, sep);
+  for (tokenizer::iterator token = tokens.begin(); token != tokens.end();
+       ++token) {
+    std::string smi = *token;
+    RWMol *m = SmilesToMol(smi);
+    TEST_ASSERT(m);
+    ms.push_back(ROMOL_SPTR(m));
+  }
+  auto core = "O=C(NS(=O)(=O)c1ccccc1)c1ccccc1Oc1ccccc1"_smiles;
+
+  {
+    std::cerr << "iterative" << std::endl;
+    RGroupDecompositionParameters ps = RGroupDecompositionParameters();
+    ps.timeout = 1.0;
+    RGroupDecomposition decomp(*core, ps);
+    bool ok = false;
+    try {
+      size_t ndone = 0;
+      for (auto m : ms) {
+        decomp.add(*m);
+        ++ndone;
+      }
+    } catch (const std::runtime_error &) {
+      ok = true;
+    }
+    TEST_ASSERT(ok);
+  }
+  {
+    RGroupDecompositionParameters ps = RGroupDecompositionParameters();
+    ps.timeout = 2.0;
+    std::cerr << "bulk" << std::endl;
+    std::vector<ROMOL_SPTR> cores;
+    cores.push_back(ROMOL_SPTR(new ROMol(*core)));
+    RGroupRows rows;
+    bool ok = false;
+    try {
+      auto res = RGroupDecompose(cores, ms, rows, nullptr, ps);
+    } catch (const std::runtime_error &) {
+      ok = true;
+    }
+    TEST_ASSERT(ok);
+  }
+}
+
 int main() {
   RDLog::InitLogs();
 
@@ -990,7 +1147,7 @@ int main() {
       << "********************************************************\n";
   BOOST_LOG(rdInfoLog) << "Testing R-Group Decomposition \n";
 
-#if 1
+#if 0
   testSymmetryMatching();
   testRGroupOnlyMatching();
   testRingMatching();
@@ -1004,9 +1161,10 @@ int main() {
   testGitHubIssue1705();
   testGithub2332();
   testSDFGRoupMultiCoreNoneShouldMatch();
-#endif
   testRowColumnAlignmentProblem();
   testSymmetryIssues();
+#endif
+  testSymmetryPerformance();
   BOOST_LOG(rdInfoLog)
       << "********************************************************\n";
   return 0;

--- a/Code/GraphMol/RGroupDecomposition/testRGroupDecomp.cpp
+++ b/Code/GraphMol/RGroupDecomposition/testRGroupDecomp.cpp
@@ -993,6 +993,8 @@ void testSymmetryPerformance() {
   BOOST_LOG(rdInfoLog)
       << "********************************************************\n";
   BOOST_LOG(rdInfoLog) << "Testing R-Group symmetry issues \n";
+  boost::logging::disable_logs("rdApp.warning");
+
   std::string smis =
       R"DATA(CN(C)Cc1cccc(Oc2cc(N3CCN(Cc4ccccc4-c4ccc(Cl)cc4)CC3)ccc2C(=O)NS(=O)(=O)c2ccc(NCC3CCOCC3)c([N+](=O)[O-])c2)c1
 CNc1cccc(Oc2cc(N3CCN(Cc4ccccc4-c4ccc(Cl)cc4)CC3)ccc2C(=O)NS(=O)(=O)c2ccc(NCC3CCOCC3)c([N+](=O)[O-])c2)c1
@@ -1138,6 +1140,23 @@ Cn1cnc2cc(Oc3cc(N4CCN(Cc5ccccc5-c5ccc(Cl)cc5)CC4)ccc3C(=O)NS(=O)(=O)c3ccc(NCCCN4
     }
     TEST_ASSERT(ok);
   }
+  {
+    RGroupDecompositionParameters ps = RGroupDecompositionParameters();
+    ps.timeout = 1.0;
+    ps.matchingStrategy = RDKit::NoSymmetrization;
+    std::cerr << "bulk, no symmetry" << std::endl;
+    std::vector<ROMOL_SPTR> cores;
+    cores.push_back(ROMOL_SPTR(new ROMol(*core)));
+    RGroupRows rows;
+    bool ok = true;
+    try {
+      auto res = RGroupDecompose(cores, ms, rows, nullptr, ps);
+    } catch (const std::runtime_error &) {
+      ok = false;
+    }
+    TEST_ASSERT(ok);
+  }
+  boost::logging::enable_logs("rdApp.warning");
 }
 
 int main() {

--- a/Code/GraphMol/RGroupDecomposition/testRGroupDecomp.cpp
+++ b/Code/GraphMol/RGroupDecomposition/testRGroupDecomp.cpp
@@ -1147,7 +1147,7 @@ int main() {
       << "********************************************************\n";
   BOOST_LOG(rdInfoLog) << "Testing R-Group Decomposition \n";
 
-#if 0
+#if 1
   testSymmetryMatching();
   testRGroupOnlyMatching();
   testRingMatching();


### PR DESCRIPTION
There are times when the RGroupDecomposition code is extremely slow (more than minutes).
Since I suspect these situations will always exist and because it takes a while to fix problems as we find them, it seems logical to add an optional timeout.

The approach I took here is very simpleminded: if either an individual call to `process()` or the entire call to `Decomp()` take longer than the timeout then we throw a runtime_error.

I don't think there's a reasonable way to return partial results (like the MCS code does) given that we could time out before all the molecules have been added.

This also:
  - adds code to release the GIL when doing RGD from Python
  - resolves #3224 by adding an option to run without any symmetrization for those cases where it's just too slow
