### PR TITLE
lock CI cairo version to (hopefully) force an install from the rdkit repo

### DIFF
--- a/.azure-pipelines/linux_build.yml
+++ b/.azure-pipelines/linux_build.yml
@@ -11,7 +11,7 @@ steps:
         numpy matplotlib pillow eigen pandas \
         sphinx recommonmark jupyter
     conda activate rdkit_build
-    conda install -c rdkit nox cairo
+    conda install -c rdkit nox cairo=1.14.6
   displayName: Setup build environment
 - bash: |
     source ${CONDA}/etc/profile.d/conda.sh


### PR DESCRIPTION
the linux CI builds are now failing because we aren't doing this

the reason it's necessary:
The conda cairo package is built against X11, so you need to have X installed on the backend in order to use it. The rdkit cairo_nox build gets around this problem
