### PR TITLE
Speed up ring finding by skipping nodes not in rings

### DIFF
--- a/Code/GraphMol/FindRings.cpp
+++ b/Code/GraphMol/FindRings.cpp
@@ -318,6 +318,7 @@ void findRingsD2nodes(const ROMol &tMol, VECT_INT_VECT &res,
   RINGINVAR_INT_VECT_MAP dupD2Cands;
   int cand;
   INT_VECT_CI d2i;
+  INT_SET changed;
 
   INT_INT_VECT_MAP dupMap;
   // here is an example of molecule where the this scheme of finding other node
@@ -388,17 +389,26 @@ void findRingsD2nodes(const ROMol &tMol, VECT_INT_VECT &res,
 
     // We don't want to trim the bonds connecting cand here - this can disrupt
     // a second small ring. Here is an example SC(C3C1CC(C3)CC(C2S)(O)C1)2S
-    // by trimming the bond connecting to atom #4 , we loose the smallest ring
-    // that
-    // contains atom #7. Issue 134
-    // MolOps::trimBonds(cand, tMol, changed);
+    // by trimming the bond connecting to atom #4, we lose the smallest ring
+    // that contains atom #7. Issue 134
+
+    // But if there were no rings found, trimming isn't dangerous, and can
+    // save wasted time for long chains.
+    if (srings.empty()) {
+      changed = {cand};
+      while (!changed.empty()) {
+        int cand = *(changed.begin());
+        changed.erase(changed.begin());
+        trimBonds(cand, tMol, changed, atomDegrees, activeBonds);
+      }
+    }
   }
 
   // now deal with any d2 nodes that resulted in duplicate rings before trimming
   // their bonds.
   // it is possible that one of these nodes is involved a different small ring,
-  // that is not found
-  // because the first nodes has not be trimmed. Here is an example molecule:
+  // that is not found  because the first nodes has not be trimmed. Here is an
+  // example molecule:
   // CC1=CC=C(C=C1)S(=O)(=O)O[CH]2[CH]3CO[CH](O3)[CH]4OC(C)(C)O[CH]24
   findSSSRforDupCands(tMol, res, invars, dupMap, dupD2Cands, atomDegrees,
                       activeBonds);


### PR DESCRIPTION
When finding rings - If we've exhaustively searched
an atom and found no rings, we should mark the bonds to
that atom as "not in a ring". We can also mark any
neighboring low degree atoms in the same way.

This speeds up searches in large molecules, because
a ring search that _doesn't_ find any rings is very
expensive, and it's a bummer to pay for that search
on two neighboring atoms, for instance.

Ring finding is a bottleneck in sanitization,
especially for larger molecules.

Here are some SSSR timings on protiens from the RCSB PDB:

Before this commit:

 - 3EOH: 3.5s
 - 2J3N: 1.2s
 - 1NKS: 0.05s
    
After this commit:

-  3EOH: 0.8s
-  2J3N: 0.3s
-  1NKS: 0.02s

