### PR TITLE
Support enumerating some mol file features into `MolBundles`

### DIFF
--- a/Code/GraphMol/CMakeLists.txt
+++ b/Code/GraphMol/CMakeLists.txt
@@ -105,6 +105,7 @@ endif()
 
 add_subdirectory(MolStandardize)
 add_subdirectory(ScaffoldNetwork)
+add_subdirectory(MolEnumerator)
 
 
 rdkit_test(graphmolTest1 test1.cpp LINK_LIBRARIES FileParsers SmilesParse GraphMol

--- a/Code/GraphMol/ChemReactions/Reaction.cpp
+++ b/Code/GraphMol/ChemReactions/Reaction.cpp
@@ -60,9 +60,9 @@ ChemicalReaction::ChemicalReaction(const std::string &pickle) {
   ReactionPickler::reactionFromPickle(pickle, this);
 }
 
-void ChemicalReaction::initReactantMatchers() {
+void ChemicalReaction::initReactantMatchers(bool silent) {
   unsigned int nWarnings, nErrors;
-  if (!this->validate(nWarnings, nErrors)) {
+  if (!this->validate(nWarnings, nErrors, silent)) {
     BOOST_LOG(rdErrorLog) << "initialization failed\n";
     this->df_needsInit = true;
   } else {

--- a/Code/GraphMol/ChemReactions/Reaction.h
+++ b/Code/GraphMol/ChemReactions/Reaction.h
@@ -205,18 +205,16 @@ class RDKIT_CHEMREACTIONS_EXPORT ChemicalReaction : public RDProps {
   /*!
 
     \param reactants  the reactants to be used. The length of this must be equal
-    to
-                      this->getNumReactantTemplates()
+    to this->getNumReactantTemplates()
     \param maxProducts:  if non zero, the maximum number of products to generate
-                         before stopping.  If hit a warning will be generated.
+    before stopping.  If hit a warning will be generated.
 
     \return a vector of vectors of products. Each subvector will be
             this->getNumProductTemplates() long.
 
     We return a vector of vectors of products because each individual template
-    may
-    map multiple times onto its reactant. This leads to multiple possible result
-    sets.
+    may map multiple times onto its reactant. This leads to multiple possible
+    result sets.
   */
   std::vector<MOL_SPTR_VECT> runReactants(
       const MOL_SPTR_VECT reactants, unsigned int numProducts = 1000) const;
@@ -293,10 +291,8 @@ class RDKIT_CHEMREACTIONS_EXPORT ChemicalReaction : public RDProps {
       runReactants.
 
       \param silent: If this bool is true, no messages will be logged during the
-     validation.
-                     By default, validation problems are reported to the warning
-     and error
-                     logs depending on their severity.
+      validation. By default, validation problems are reported to the warning
+      and error logs depending on their severity.
   */
   void initReactantMatchers(bool silent = false);
 
@@ -306,17 +302,14 @@ class RDKIT_CHEMREACTIONS_EXPORT ChemicalReaction : public RDProps {
   //"reasonable"
   /*!
       \return   true if the reaction validates without errors (warnings do not
-     stop
-                validation)
+      stop validation)
 
       \param numWarnings used to return the number of validation warnings
       \param numErrors   used to return the number of validation errors
 
       \param silent: If this bool is true, no messages will be logged during the
-     validation.
-                     By default, validation problems are reported to the warning
-     and error
-                     logs depending on their severity.
+      validation. By default, validation problems are reported to the warning
+      and error logs depending on their severity.
 
   */
   bool validate(unsigned int &numWarnings, unsigned int &numErrors,
@@ -393,8 +386,7 @@ RDKIT_CHEMREACTIONS_EXPORT bool isMoleculeAgentOfReaction(
   \param rxn the reaction we are interested in
 
   \param mappedAtomsOnly if set, atoms that are not mapped will not be included
-  in
-       the list of changed atoms (otherwise they are automatically included)
+  in the list of changed atoms (otherwise they are automatically included)
 
    How are changed atoms recognized?
        1) Atoms whose degree changes

--- a/Code/GraphMol/ChemReactions/Reaction.h
+++ b/Code/GraphMol/ChemReactions/Reaction.h
@@ -291,8 +291,14 @@ class RDKIT_CHEMREACTIONS_EXPORT ChemicalReaction : public RDProps {
   /*!
       This must be called after adding reactants and before calling
       runReactants.
+
+      \param silent: If this bool is true, no messages will be logged during the
+     validation.
+                     By default, validation problems are reported to the warning
+     and error
+                     logs depending on their severity.
   */
-  void initReactantMatchers();
+  void initReactantMatchers(bool silent = false);
 
   bool isInitialized() const { return !df_needsInit; };
 

--- a/Code/GraphMol/ChemReactions/Wrap/rdChemReactions.cpp
+++ b/Code/GraphMol/ChemReactions/Wrap/rdChemReactions.cpp
@@ -526,6 +526,7 @@ Sample Usage:
                RDKit::RunReactant,
            "apply the reaction to a single reactant")
       .def("Initialize", &RDKit::ChemicalReaction::initReactantMatchers,
+           (python::arg("self"), python::arg("silent") = false),
            "initializes the reaction so that it can be used")
       .def("IsInitialized", &RDKit::ChemicalReaction::isInitialized,
            "checks if the reaction is ready for use")

--- a/Code/GraphMol/FileParsers/MolSGroupParsing.cpp
+++ b/Code/GraphMol/FileParsers/MolSGroupParsing.cpp
@@ -666,6 +666,10 @@ std::vector<T> ParseV3000Array(std::stringstream &stream) {
   return values;
 }
 
+// force instantiation of the versions of this that we use
+template std::vector<unsigned int> ParseV3000Array(std::stringstream &stream);
+template std::vector<int> ParseV3000Array(std::stringstream &stream);
+
 void ParseV3000CStateLabel(RWMol *mol, SubstanceGroup &sgroup,
                            std::stringstream &stream, unsigned int line) {
   stream.get();  // discard parentheses

--- a/Code/GraphMol/FileParsers/MolSGroupParsing.cpp
+++ b/Code/GraphMol/FileParsers/MolSGroupParsing.cpp
@@ -651,7 +651,11 @@ void ParseSGroupV2000SBTLine(IDX_TO_SGROUP_MAP &sGroupMap, RWMol *mol,
 
 template <class T>
 std::vector<T> ParseV3000Array(std::stringstream &stream) {
-  stream.get();  // discard parentheses
+  auto paren = stream.get();  // discard parentheses
+  if (paren != '(') {
+    BOOST_LOG(rdWarningLog)
+        << "WARNING: first character of V3000 array is not '('" << std::endl;
+  }
 
   unsigned int count;
   stream >> count;
@@ -662,7 +666,11 @@ std::vector<T> ParseV3000Array(std::stringstream &stream) {
     stream >> value;
     values.push_back(value);
   }
-  stream.get();  // discard parentheses
+  paren = stream.get();  // discard parentheses
+  if (paren != ')') {
+    BOOST_LOG(rdWarningLog)
+        << "WARNING: final character of V3000 array is not ')'" << std::endl;
+  }
   return values;
 }
 

--- a/Code/GraphMol/FileParsers/MolSGroupParsing.h
+++ b/Code/GraphMol/FileParsers/MolSGroupParsing.h
@@ -11,6 +11,7 @@
 
 #pragma once
 #include <GraphMol/SubstanceGroup.h>
+#include <sstream>
 
 namespace RDKit {
 
@@ -86,10 +87,16 @@ void ParseSGroupV2000SBTLine(IDX_TO_SGROUP_MAP &sGroupMap, RWMol *mol,
 template <class T>
 std::vector<T> ParseV3000Array(std::stringstream &stream);
 #if defined(WIN32) && defined(RDKIT_DYN_LINK)
-template RDKIT_FILEPARSERS_EXPORT std::vector<int> ParseV3000Array(std::stringstream &);
-template RDKIT_FILEPARSERS_EXPORT std::vector<unsigned int> ParseV3000Array(std::stringstream &);
+template RDKIT_FILEPARSERS_EXPORT std::vector<int> ParseV3000Array(
+    std::stringstream &);
+template RDKIT_FILEPARSERS_EXPORT std::vector<unsigned int> ParseV3000Array(
+    std::stringstream &);
 #endif
-
+template <class T>
+std::vector<T> ParseV3000Array(const std::string &s) {
+  std::stringstream stream(s);
+  return ParseV3000Array<T>(stream);
+}
 
 void ParseV3000CStateLabel(unsigned int line, const std::string &type,
                            SubstanceGroup *sgroup, std::stringstream &stream);

--- a/Code/GraphMol/FileParsers/MolSGroupParsing.h
+++ b/Code/GraphMol/FileParsers/MolSGroupParsing.h
@@ -7,6 +7,8 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
+#include <RDGeneral/export.h>
+
 #pragma once
 #include <GraphMol/SubstanceGroup.h>
 
@@ -83,6 +85,11 @@ void ParseSGroupV2000SBTLine(IDX_TO_SGROUP_MAP &sGroupMap, RWMol *mol,
 
 template <class T>
 std::vector<T> ParseV3000Array(std::stringstream &stream);
+#if defined(WIN32) && defined(RDKIT_DYN_LINK)
+template RDKIT_FILEPARSERS_EXPORT std::vector<int> ParseV3000Array(std::stringstream &);
+template RDKIT_FILEPARSERS_EXPORT std::vector<unsigned int> ParseV3000Array(std::stringstream &);
+#endif
+
 
 void ParseV3000CStateLabel(unsigned int line, const std::string &type,
                            SubstanceGroup *sgroup, std::stringstream &stream);

--- a/Code/GraphMol/MolEnumerator/CMakeLists.txt
+++ b/Code/GraphMol/MolEnumerator/CMakeLists.txt
@@ -2,7 +2,7 @@ remove_definitions(-DRDKIT_GRAPHMOL_BUILD)
 add_definitions(-DRDKIT_MOLENUMERATOR_BUILD)
 rdkit_library(MolEnumerator
               MolEnumerator.cpp
-              LINK_LIBRARIES ChemReactions ChemTransforms 
+              LINK_LIBRARIES FileParsers ChemReactions ChemTransforms 
               SubstructMatch GraphMol RDGeneral)
 
 rdkit_headers(MolEnumerator.h DEST GraphMol/MolEnumerator)

--- a/Code/GraphMol/MolEnumerator/CMakeLists.txt
+++ b/Code/GraphMol/MolEnumerator/CMakeLists.txt
@@ -1,7 +1,7 @@
 remove_definitions(-DRDKIT_GRAPHMOL_BUILD)
 add_definitions(-DRDKIT_MOLENUMERATOR_BUILD)
 rdkit_library(MolEnumerator
-              MolEnumerator.cpp
+              MolEnumerator.cpp PositionVariation.cpp LinkNode.cpp
               LINK_LIBRARIES FileParsers ChemReactions ChemTransforms 
               SubstructMatch GraphMol RDGeneral)
 

--- a/Code/GraphMol/MolEnumerator/CMakeLists.txt
+++ b/Code/GraphMol/MolEnumerator/CMakeLists.txt
@@ -10,6 +10,6 @@ rdkit_headers(MolEnumerator.h DEST GraphMol/MolEnumerator)
 rdkit_catch_test(testMolEnumerator catch_main.cpp enumerator_catch.cpp 
 LINK_LIBRARIES MolEnumerator SmilesParse FileParsers )
 
-#if(RDK_BUILD_PYTHON_WRAPPERS)
-#add_subdirectory(Wrap)
-#endif()
+if(RDK_BUILD_PYTHON_WRAPPERS)
+add_subdirectory(Wrap)
+endif()

--- a/Code/GraphMol/MolEnumerator/CMakeLists.txt
+++ b/Code/GraphMol/MolEnumerator/CMakeLists.txt
@@ -1,0 +1,15 @@
+remove_definitions(-DRDKIT_GRAPHMOL_BUILD)
+add_definitions(-DRDKIT_MOLENUMERATOR_BUILD)
+rdkit_library(MolEnumerator
+              MolEnumerator.cpp
+              LINK_LIBRARIES ChemReactions ChemTransforms 
+              SubstructMatch GraphMol RDGeneral)
+
+rdkit_headers(MolEnumerator.h DEST GraphMol/MolEnumerator)
+
+rdkit_catch_test(testMolEnumerator catch_main.cpp enumerator_catch.cpp 
+LINK_LIBRARIES MolEnumerator SmilesParse FileParsers )
+
+#if(RDK_BUILD_PYTHON_WRAPPERS)
+#add_subdirectory(Wrap)
+#endif()

--- a/Code/GraphMol/MolEnumerator/LinkNode.cpp
+++ b/Code/GraphMol/MolEnumerator/LinkNode.cpp
@@ -9,6 +9,17 @@
 //
 #include "MolEnumerator.h"
 #include <RDGeneral/Exceptions.h>
+#include <GraphMol/SmilesParse/SmilesWrite.h>
+#include <GraphMol/SmilesParse/SmartsWrite.h>
+#include <GraphMol/ChemReactions/Reaction.h>
+#include <GraphMol/ChemReactions/ReactionParser.h>
+
+#include <boost/lexical_cast.hpp>
+#include <boost/tokenizer.hpp>
+#include <boost/format.hpp>
+#include <algorithm>
+
+typedef boost::tokenizer<boost::char_separator<char>> tokenizer;
 
 namespace RDKit {
 namespace MolEnumerator {
@@ -18,10 +29,129 @@ void LinkNodeOp::initFromMol(const ROMol &mol) {
   initFromMol();
 }
 void LinkNodeOp::initFromMol() {
-  // d_variationPoints.clear();
   if (!dp_mol) {
     return;
   }
+  std::string pval;
+  if (!dp_mol->getPropIfPresent(common_properties::molFileLinkNodes, pval)) {
+    return;
+  }
+  std::vector<int> mapping;
+  if (MolOps::getMolFrags(*dp_mol, mapping) > 1) {
+    throw ValueErrorException(
+        "LINKNODE enumeration only supported for molecules with a single "
+        "fragment.");
+  }
+
+  dp_frame.reset(new RWMol(*dp_mol));
+  boost::char_separator<char> pipesep("|");
+  boost::char_separator<char> spacesep(" ");
+  std::string attachSmarts = "";
+  std::vector<std::string> linkEnums;
+  std::vector<std::string> molEnums;
+
+  for (auto linknode : tokenizer(pval, pipesep)) {
+    std::string productSmarts = "";
+    tokenizer tokens(linknode, spacesep);
+    std::vector<unsigned int> data;
+    try {
+      std::transform(tokens.begin(), tokens.end(), std::back_inserter(data),
+                     [](const std::string &token) -> unsigned int {
+                       return boost::lexical_cast<unsigned int>(token);
+                     });
+    } catch (boost::bad_lexical_cast &) {
+      std::ostringstream errout;
+      errout << "Cannot convert values in LINKNODE '" << linknode
+             << "' to unsigned ints";
+      throw ValueErrorException(errout.str());
+    }
+    // the second test here is for the atom-pairs defining the bonds
+    // data[2] contains the number of bonds
+    if (data.size() < 5 || data.size() < 3 + 2 * data[2]) {
+      std::ostringstream errout;
+      errout << "not enough values in LINKNODE '" << linknode << "'";
+      throw ValueErrorException(errout.str());
+    }
+    unsigned int minRep = data[0];
+    unsigned int maxRep = data[1];
+    if (minRep == 0 || maxRep < minRep) {
+      std::ostringstream errout;
+      errout << "bad counts in LINKNODE '" << linknode << "'";
+      throw ValueErrorException(errout.str());
+    }
+    d_countAtEachPoint.push_back(maxRep - minRep + 1);
+    d_pointRanges.push_back(std::make_pair(minRep, maxRep));
+    unsigned int variationIdx = d_countAtEachPoint.size();
+    unsigned int nBonds = data[2];
+    if (nBonds != 2) {
+      UNDER_CONSTRUCTION(
+          "only link nodes with 2 bonds are currently supported");
+    }
+    std::vector<std::string> bondSmarts;
+    for (unsigned int idx = 0; idx < nBonds; ++idx) {
+      auto begAtIdx = data[3 + 2 * idx] - 1;
+      auto endAtIdx = data[3 + 2 * idx + 1] - 1;
+      auto bnd = dp_frame->getBondBetweenAtoms(begAtIdx, endAtIdx);
+      if (!bnd) {
+        std::ostringstream errout;
+        errout << "bond not found between atoms for LINKNODE '" << linknode
+               << "'";
+        throw ValueErrorException(errout.str());
+      }
+      bondSmarts.push_back(SmartsWrite::GetBondSmarts((QueryBond *)(bnd)));
+      auto bondLabel = variationIdx * 100 + 10 * idx;
+      Atom dummy(0);
+      dummy.setIsotope(bondLabel);
+      auto d1idx = dp_frame->addAtom(&dummy);
+      dp_frame->addBond(begAtIdx, d1idx, Bond::SINGLE);
+      dummy.setIsotope(bondLabel + 1);
+      auto d2idx = dp_frame->addAtom(&dummy);
+      dp_frame->addBond(endAtIdx, d2idx, Bond::SINGLE);
+      dp_frame->removeBond(begAtIdx, endAtIdx);
+    }
+    // both bonds must start from the same atom:
+    if (data[3] != data[5]) {
+      std::ostringstream errout;
+      errout << "bonds don't start at the same atom for LINKNODE '" << linknode
+             << "'";
+      throw ValueErrorException(errout.str());
+    }
+
+#if 0    
+    auto fmt1 = boost::format("[%d#0]-[*:%d]-[%d#0]") % (variationIdx * 100) %
+                (variationIdx) % (variationIdx * 100 + 10);
+    std::string reactSmarts = fmt1.str();
+    // Unfortunately the enumeration reactions for the first pass, where the
+    // two attachment points are on the atom, and the second pass, where the two
+    // attachment points are on different atoms, have to be different:
+    auto fmt1 =
+        boost::format("[%d#0]-[*:%d]-[%d#0]>>[%d#0]-[*:%d]-[*:%d]-[%d#0]") %
+        (variationIdx * 100) % (variationIdx) % (variationIdx * 100 + 10) %
+        (variationIdx * 100) % (variationIdx) % (variationIdx) %
+        (variationIdx * 100 + 10);
+    auto fmt2 =
+        boost::format(
+            "([%d#0]-[*:%d].[*:%d]-[%d#0])>>[%d#0]-[*:%d]-[*:%d]-[%d#0]") %
+        (variationIdx * 100) % (variationIdx) % (variationIdx * 100 + 10) %
+        (variationIdx * 100) % (variationIdx) % (variationIdx) %
+        (variationIdx * 100 + 10);
+    auto rxn1 = std::shared_ptr<ChemicalReaction>(
+        RxnSmartsToChemicalReaction(fmt1.str()));
+    ASSERT_INVARIANT(rxn1, "reaction is somehow bad");
+    rxn1->initReactantMatchers();
+    enumReactions1.push_back(rxn1);
+    auto rxn1 = std::shared_ptr<ChemicalReaction>(
+        RxnSmartsToChemicalReaction(fmt1.str()));
+    ASSERT_INVARIANT(rxn1, "reaction is somehow bad");
+    rxn1->initReactantMatchers();
+    enumReactions1.push_back(rxn1);
+
+    std::cerr << "  react: " << reactSmarts << std::endl;
+    std::cerr << "  react enumerator: " << fmt2 << std::endl;
+#endif
+    // std::cerr << "  product: " << productSmarts << std::endl;
+  }
+  std::cerr << ">>>>  " << MolToSmiles(*dp_frame) << std::endl;
 }
 
 std::vector<size_t> LinkNodeOp::getVariationCounts() const {
@@ -32,21 +162,55 @@ std::vector<size_t> LinkNodeOp::getVariationCounts() const {
   //       return pr.second.size();
   //     });
   // return res;
-  std::vector<size_t> res;
-  std::string pval;
-  if (!dp_mol->getPropIfPresent(common_properties::molFileLinkNodes, pval)) {
-    return res;
-  }
-
-  return res;
+  return d_countAtEachPoint;
 }
 
 std::unique_ptr<ROMol> LinkNodeOp::operator()(
     const std::vector<size_t> &which) const {
   PRECONDITION(dp_mol, "no molecule");
-  // if (which.size() != d_variationPoints.size()) {
-  //   throw ValueErrorException("bad element choice in enumeration");
-  // }
+  PRECONDITION(dp_frame, "not initialized");
+  if (which.size() != d_countAtEachPoint.size()) {
+    throw ValueErrorException("bad element choice in enumeration");
+  }
+  // quick error checking before we do any work:
+  for (size_t i = 0; i < which.size(); ++i) {
+    if (which[i] >= d_countAtEachPoint[i]) {
+      throw ValueErrorException("bad element value in enumeration");
+    }
+  }
+  // we do the enumeration and attach one side in a single reaction.
+  // we can't attach both sides because it's entirely possible that a
+  // single atom has multiple attachment points and that would lead to
+  // a mess.
+  std::string reacts = "";
+  std::string prods = "";
+  for (size_t i = 0; i < which.size(); ++i) {
+    auto variationIdx = i + 1;
+    auto variationCount = d_pointRanges[i].first + which[i];
+    auto reactFormat = boost::format("[%d#0]-[*:%d]-[%d#0].[%d#0][*:%d]") %
+                       (variationIdx * 100) % (10 * variationIdx) %
+                       (variationIdx * 100 + 10) % (variationIdx * 100 + 1) %
+                       (10 * variationIdx + 1);
+    auto react = reactFormat.str();
+    if (!reacts.empty()) {
+      reacts += ".";
+    }
+    reacts += reactFormat.str();
+    auto prodFormat = boost::format("[*:%d]-[*:%d]") % (10 * variationIdx + 1) %
+                      (10 * variationIdx);
+    auto prod = prodFormat.str();
+    for (size_t j = 1; j < variationCount; ++j) {
+      prod += (boost::format("-[*:%d]") % variationIdx).str();
+    }
+    prod += (boost::format("-[%d#0]") % (variationIdx * 100 + 10)).str();
+    if (!prods.empty()) {
+      prods += ".";
+    }
+    prods += prod;
+  }
+  reacts = "(" + reacts + ")";
+  prods = "(" + prods + ")";
+  std::cerr << reacts << ">>" << prods << std::endl;
   RWMol *res = new RWMol(*dp_mol);
   return std::unique_ptr<ROMol>(static_cast<ROMol *>(res));
 }

--- a/Code/GraphMol/MolEnumerator/LinkNode.cpp
+++ b/Code/GraphMol/MolEnumerator/LinkNode.cpp
@@ -142,8 +142,6 @@ std::unique_ptr<ROMol> LinkNodeOp::operator()(
   // we do the enumeration of each of the variation points independantly
   ROMOL_SPTR res(new ROMol(*dp_frame));
   for (size_t i = 0; i < which.size(); ++i) {
-    // FIX need a special case here for when the variation points are bonded to
-    // each other
     auto variationIdx = i + 1;
     auto variationCount = d_pointRanges[i].first + which[i];
     auto reactFormat =

--- a/Code/GraphMol/MolEnumerator/LinkNode.cpp
+++ b/Code/GraphMol/MolEnumerator/LinkNode.cpp
@@ -167,9 +167,15 @@ std::unique_ptr<ROMol> LinkNodeOp::operator()(
     std::unique_ptr<ChemicalReaction> rxn(
         RxnSmartsToChemicalReaction(reactSmarts));
     ASSERT_INVARIANT(rxn, "reaction could not be constructed");
-    rxn->initReactantMatchers();
+    // we expect warnings for these alchemical reactions. :-)
+    bool silent = true;
+    rxn->initReactantMatchers(silent);
     ROMOL_SPTR reactant(new ROMol(*res));
-    auto ps = rxn->runReactant(reactant, 0);
+    std::vector<MOL_SPTR_VECT> ps;
+    {
+      RDLog::BlockLogs blocker;
+      ps = rxn->runReactant(reactant, 0);
+    }
     ASSERT_INVARIANT(!ps.empty(), "no products from reaction");
     ASSERT_INVARIANT(ps[0].size() == 1, "too many products from reaction");
     res = ps[0][0];

--- a/Code/GraphMol/MolEnumerator/LinkNode.cpp
+++ b/Code/GraphMol/MolEnumerator/LinkNode.cpp
@@ -1,0 +1,56 @@
+//
+//  Copyright (C) 2020 Greg Landrum and T5 Informatics GmbH
+//
+//   @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
+//
+#include "MolEnumerator.h"
+#include <RDGeneral/Exceptions.h>
+
+namespace RDKit {
+namespace MolEnumerator {
+
+void LinkNodeOp::initFromMol(const ROMol &mol) {
+  dp_mol.reset(new ROMol(mol));
+  initFromMol();
+}
+void LinkNodeOp::initFromMol() {
+  // d_variationPoints.clear();
+  if (!dp_mol) {
+    return;
+  }
+}
+
+std::vector<size_t> LinkNodeOp::getVariationCounts() const {
+  // std::vector<size_t> res(d_variationPoints.size());
+  // std::transform(
+  //     d_variationPoints.begin(), d_variationPoints.end(), res.begin(),
+  //     [](std::pair<unsigned int, std::vector<unsigned int>> pr) -> size_t {
+  //       return pr.second.size();
+  //     });
+  // return res;
+  std::vector<size_t> res;
+  std::string pval;
+  if (!dp_mol->getPropIfPresent(common_properties::molFileLinkNodes, pval)) {
+    return res;
+  }
+
+  return res;
+}
+
+std::unique_ptr<ROMol> LinkNodeOp::operator()(
+    const std::vector<size_t> &which) const {
+  PRECONDITION(dp_mol, "no molecule");
+  // if (which.size() != d_variationPoints.size()) {
+  //   throw ValueErrorException("bad element choice in enumeration");
+  // }
+  RWMol *res = new RWMol(*dp_mol);
+  return std::unique_ptr<ROMol>(static_cast<ROMol *>(res));
+}
+
+}  // namespace MolEnumerator
+
+}  // namespace RDKit

--- a/Code/GraphMol/MolEnumerator/MolEnumerator.cpp
+++ b/Code/GraphMol/MolEnumerator/MolEnumerator.cpp
@@ -22,25 +22,69 @@ void PositionVariationOp::initFromMol() {
   for (const auto bond : dp_mol->bonds()) {
     std::string endpts;
     std::string attach;
-    if (bond->getPropIfPresent("ENDPTS", endpts) &&
-        bond->getPropIfPresent("ATTACH", attach) && attach == "ANY") {
-      const auto atom = bond->getBeginAtom();
+    if (bond->getPropIfPresent(common_properties::_MolFileBondEndPts, endpts) &&
+        bond->getPropIfPresent(common_properties::_MolFileBondAttach, attach) &&
+        attach == "ANY") {
+      const Atom *atom = bond->getBeginAtom();
       if (atom->getAtomicNum() == 0) {
-        std::stringstream iss(endpts);
-        std::vector<unsigned int> oats =
-            RDKit::SGroupParsing::ParseV3000Array<unsigned int>(iss);
-        // decrement the indices and do error checking:
-        for (auto &oat : oats) {
-          --oat;
-          if (oat < 0 || oat >= dp_mol->getNumAtoms()) {
-            throw ValueErrorException("Bad variation point index");
-          }
+        atom = bond->getEndAtom();
+        if (atom->getAtomicNum() == 0) {
+          throw ValueErrorException(
+              "position variation bond does not have connection to a non-dummy "
+              "atom");
         }
-        d_variationPoints.push_back(std::make_pair(atom->getIdx(), oats));
       }
+      std::stringstream iss(endpts);
+      std::vector<unsigned int> oats =
+          RDKit::SGroupParsing::ParseV3000Array<unsigned int>(iss);
+      // decrement the indices and do error checking:
+      for (auto &oat : oats) {
+        if (oat == 0 || oat > dp_mol->getNumAtoms()) {
+          throw ValueErrorException("Bad variation point index");
+        }
+        --oat;
+      }
+      d_variationPoints.push_back(std::make_pair(atom->getIdx(), oats));
     }
   }
 }
 
+std::vector<size_t> PositionVariationOp::getVariationCounts() const {
+  std::vector<size_t> res(d_variationPoints.size());
+  std::transform(
+      d_variationPoints.begin(), d_variationPoints.end(), res.begin(),
+      [](std::pair<unsigned int, std::vector<unsigned int>> pr) -> size_t {
+        return pr.second.size();
+      });
+  return res;
+}
+
+ROMol *PositionVariationOp::operator()(const std::vector<size_t> &which) const {
+  PRECONDITION(dp_mol, "no molecule");
+  if (which.size() != d_variationPoints.size()) {
+    throw ValueErrorException("bad element choice in enumeration");
+  }
+  // a bit of quick error checking before starting the real work
+  for (unsigned int i = 0; i < d_variationPoints.size(); ++i) {
+    if (which[i] >= d_variationPoints[i].second.size()) {
+      throw ValueErrorException("bad element value in enumeration");
+    }
+  }
+  RWMol *res = new RWMol(*dp_mol);
+  for (unsigned int i = 0; i < d_variationPoints.size(); ++i) {
+    const auto tpl = d_variationPoints[i];
+    auto begAtomIdx = tpl.first;
+    auto endAtomIdx = tpl.second[which[i]];
+    // do we already have a bond?
+    if (res->getBondBetweenAtoms(begAtomIdx, endAtomIdx)) {
+      continue;
+    }
+    res->addBond(begAtomIdx, endAtomIdx, Bond::BondType::SINGLE);
+  }
+
+  return static_cast<ROMol *>(res);
+}
+
 }  // namespace MolEnumerator
+
 }  // namespace RDKit

--- a/Code/GraphMol/MolEnumerator/MolEnumerator.cpp
+++ b/Code/GraphMol/MolEnumerator/MolEnumerator.cpp
@@ -9,93 +9,9 @@
 //
 #include "MolEnumerator.h"
 #include <RDGeneral/Exceptions.h>
-#include <GraphMol/FileParsers/MolSGroupParsing.h>
 
 namespace RDKit {
 namespace MolEnumerator {
-
-void PositionVariationOp::initFromMol(const ROMol &mol) {
-  dp_mol.reset(new ROMol(mol));
-  initFromMol();
-}
-void PositionVariationOp::initFromMol() {
-  d_variationPoints.clear();
-  if (!dp_mol) {
-    return;
-  }
-  for (const auto bond : dp_mol->bonds()) {
-    std::string endpts;
-    std::string attach;
-    if (bond->getPropIfPresent(common_properties::_MolFileBondEndPts, endpts) &&
-        bond->getPropIfPresent(common_properties::_MolFileBondAttach, attach) &&
-        attach == "ANY") {
-      const Atom *atom = bond->getBeginAtom();
-      if (atom->getAtomicNum() == 0) {
-        atom = bond->getEndAtom();
-        if (atom->getAtomicNum() == 0) {
-          throw ValueErrorException(
-              "position variation bond does not have connection to a "
-              "non-dummy "
-              "atom");
-        }
-      }
-      d_dummiesAtEachPoint.push_back(bond->getOtherAtomIdx(atom->getIdx()));
-      std::vector<unsigned int> oats =
-          RDKit::SGroupParsing::ParseV3000Array<unsigned int>(endpts);
-      // decrement the indices and do error checking:
-      for (auto &oat : oats) {
-        if (oat == 0 || oat > dp_mol->getNumAtoms()) {
-          throw ValueErrorException("Bad variation point index");
-        }
-        --oat;
-      }
-      d_variationPoints.push_back(std::make_pair(atom->getIdx(), oats));
-    }
-  }
-}
-
-std::vector<size_t> PositionVariationOp::getVariationCounts() const {
-  std::vector<size_t> res(d_variationPoints.size());
-  std::transform(
-      d_variationPoints.begin(), d_variationPoints.end(), res.begin(),
-      [](std::pair<unsigned int, std::vector<unsigned int>> pr) -> size_t {
-        return pr.second.size();
-      });
-  return res;
-}
-
-std::unique_ptr<ROMol> PositionVariationOp::operator()(
-    const std::vector<size_t> &which) const {
-  PRECONDITION(dp_mol, "no molecule");
-  if (which.size() != d_variationPoints.size()) {
-    throw ValueErrorException("bad element choice in enumeration");
-  }
-  // a bit of quick error checking before starting the real work
-  for (unsigned int i = 0; i < d_variationPoints.size(); ++i) {
-    if (which[i] >= d_variationPoints[i].second.size()) {
-      throw ValueErrorException("bad element value in enumeration");
-    }
-  }
-  RWMol *res = new RWMol(*dp_mol);
-  for (unsigned int i = 0; i < d_variationPoints.size(); ++i) {
-    const auto tpl = d_variationPoints[i];
-    auto begAtomIdx = tpl.first;
-    auto endAtomIdx = tpl.second[which[i]];
-    // do we already have a bond?
-    if (res->getBondBetweenAtoms(begAtomIdx, endAtomIdx)) {
-      continue;
-    }
-    res->addBond(begAtomIdx, endAtomIdx, Bond::BondType::SINGLE);
-  }
-  // now remove the dummies:
-  std::vector<size_t> atsToRemove = d_dummiesAtEachPoint;
-  std::sort(atsToRemove.begin(), atsToRemove.end());
-  for (auto riter = atsToRemove.rbegin(); riter != atsToRemove.rend();
-       ++riter) {
-    res->removeAtom(*riter);
-  }
-  return std::unique_ptr<ROMol>(static_cast<ROMol *>(res));
-}
 
 namespace {
 

--- a/Code/GraphMol/MolEnumerator/MolEnumerator.cpp
+++ b/Code/GraphMol/MolEnumerator/MolEnumerator.cpp
@@ -34,6 +34,7 @@ void PositionVariationOp::initFromMol() {
               "atom");
         }
       }
+      d_dummiesAtEachPoint.push_back(bond->getOtherAtomIdx(atom->getIdx()));
       std::stringstream iss(endpts);
       std::vector<unsigned int> oats =
           RDKit::SGroupParsing::ParseV3000Array<unsigned int>(iss);
@@ -81,7 +82,13 @@ ROMol *PositionVariationOp::operator()(const std::vector<size_t> &which) const {
     }
     res->addBond(begAtomIdx, endAtomIdx, Bond::BondType::SINGLE);
   }
-
+  // now remove the dummies:
+  std::vector<size_t> atsToRemove = d_dummiesAtEachPoint;
+  std::sort(atsToRemove.begin(), atsToRemove.end());
+  for (auto riter = atsToRemove.rbegin(); riter != atsToRemove.rend();
+       ++riter) {
+    res->removeAtom(*riter);
+  }
   return static_cast<ROMol *>(res);
 }
 

--- a/Code/GraphMol/MolEnumerator/MolEnumerator.cpp
+++ b/Code/GraphMol/MolEnumerator/MolEnumerator.cpp
@@ -20,6 +20,7 @@ void getVariations(size_t level, std::vector<size_t> base,
                    std::vector<std::vector<size_t>> &variations,
                    const std::vector<size_t> &variationCounts,
                    size_t maxToEnumerate, bool doRandom) {
+  PRECONDITION(level < variationCounts.size(), "bad recursion");
   for (size_t i = 0; i < variationCounts[level]; ++i) {
     base[level] = i;
     if (level + 1 >= variationCounts.size()) {
@@ -46,14 +47,17 @@ void enumerateVariations(std::vector<std::vector<size_t>> &variations,
 }  // namespace
 
 MolBundle enumerate(const ROMol &mol, const MolEnumeratorParams &params) {
+  MolBundle res;
   PRECONDITION(params.dp_operation, "no operation set");
   // copy the op since we will modify it:
   auto op = params.dp_operation->copy();
   op->initFromMol(mol);
   auto variationCounts = op->getVariationCounts();
+  if (variationCounts.empty()) {
+    return res;
+  }
   std::vector<std::vector<size_t>> variations;
   enumerateVariations(variations, variationCounts, params);
-  MolBundle res;
   for (const auto &variation : variations) {
     auto newMol = (*op)(variation);
     res.addMol(ROMOL_SPTR(newMol.release()));

--- a/Code/GraphMol/MolEnumerator/MolEnumerator.cpp
+++ b/Code/GraphMol/MolEnumerator/MolEnumerator.cpp
@@ -8,6 +8,39 @@
 //  of the RDKit source tree.
 //
 #include "MolEnumerator.h"
+#include <RDGeneral/Exceptions.h>
+#include <GraphMol/FileParsers/MolSGroupParsing.h>
+
 namespace RDKit {
-namespace MolEnumerator {}  // namespace MolEnumerator
+namespace MolEnumerator {
+
+void PositionVariationOp::initFromMol() {
+  d_variationPoints.clear();
+  if (!dp_mol) {
+    return;
+  }
+  for (const auto bond : dp_mol->bonds()) {
+    std::string endpts;
+    std::string attach;
+    if (bond->getPropIfPresent("ENDPTS", endpts) &&
+        bond->getPropIfPresent("ATTACH", attach) && attach == "ANY") {
+      const auto atom = bond->getBeginAtom();
+      if (atom->getAtomicNum() == 0) {
+        std::stringstream iss(endpts);
+        std::vector<unsigned int> oats =
+            RDKit::SGroupParsing::ParseV3000Array<unsigned int>(iss);
+        // decrement the indices and do error checking:
+        for (auto &oat : oats) {
+          --oat;
+          if (oat < 0 || oat >= dp_mol->getNumAtoms()) {
+            throw ValueErrorException("Bad variation point index");
+          }
+        }
+        d_variationPoints.push_back(std::make_pair(atom->getIdx(), oats));
+      }
+    }
+  }
+}
+
+}  // namespace MolEnumerator
 }  // namespace RDKit

--- a/Code/GraphMol/MolEnumerator/MolEnumerator.cpp
+++ b/Code/GraphMol/MolEnumerator/MolEnumerator.cpp
@@ -99,6 +99,7 @@ ROMol *PositionVariationOp::operator()(const std::vector<size_t> &which) const {
 
 namespace {
 
+//! recursively builds the variations
 void getVariations(size_t level, std::vector<size_t> base,
                    std::vector<std::vector<size_t>> &variations,
                    const std::vector<size_t> &variationCounts,
@@ -117,13 +118,14 @@ void getVariations(size_t level, std::vector<size_t> base,
 }
 void enumerateVariations(std::vector<std::vector<size_t>> &variations,
                          const std::vector<size_t> &variationCounts,
-                         size_t maxToEnumerate, bool doRandom, int randomSeed) {
-  if (doRandom) {
+                         const MolEnumeratorParams &params) {
+  if (params.doRandom) {
     UNDER_CONSTRUCTION("random enumeration not yet supported");
   }
   variations.clear();
   std::vector<size_t> base(variationCounts.size(), 0);
-  getVariations(0, base, variations, variationCounts, maxToEnumerate, doRandom);
+  getVariations(0, base, variations, variationCounts, params.maxToEnumerate,
+                params.doRandom);
 }
 }  // namespace
 
@@ -134,8 +136,7 @@ MolBundle enumerate(const ROMol &mol, const MolEnumeratorParams &params) {
   op->initFromMol(mol);
   auto variationCounts = op->getVariationCounts();
   std::vector<std::vector<size_t>> variations;
-  enumerateVariations(variations, variationCounts, params.maxToEnumerate,
-                      params.doRandom, params.randomSeed);
+  enumerateVariations(variations, variationCounts, params);
   MolBundle res;
   for (const auto &variation : variations) {
     res.addMol(ROMOL_SPTR((*op)(variation)));

--- a/Code/GraphMol/MolEnumerator/MolEnumerator.cpp
+++ b/Code/GraphMol/MolEnumerator/MolEnumerator.cpp
@@ -1,0 +1,13 @@
+//
+//  Copyright (C) 2020 Greg Landrum and T5 Informatics GmbH
+//
+//   @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
+//
+#include "MolEnumerator.h"
+namespace RDKit {
+namespace MolEnumerator {}  // namespace MolEnumerator
+}  // namespace RDKit

--- a/Code/GraphMol/MolEnumerator/MolEnumerator.h
+++ b/Code/GraphMol/MolEnumerator/MolEnumerator.h
@@ -32,13 +32,13 @@ class RDKIT_MOLENUMERATOR_EXPORT MolEnumeratorOp {
   virtual std::vector<size_t> getVariationCounts() const = 0;
   //! returns a the molecule corresponding to a particular variation
   /*!  which.size() should be equal to the number of variation counts.
-      Note that the caller owns the returned pointer
-  */
-  virtual ROMol *operator()(const std::vector<size_t> &which) const = 0;
+   */
+  virtual std::unique_ptr<ROMol> operator()(
+      const std::vector<size_t> &which) const = 0;
   //! initializes this operation to work on a particular molecule
   virtual void initFromMol(const ROMol &mol) = 0;
   //! polymorphic copy
-  virtual MolEnumeratorOp *copy() const = 0;
+  virtual std::unique_ptr<MolEnumeratorOp> copy() const = 0;
 };
 
 //! Molecule enumeration operation corresponding to position variation bonds
@@ -70,14 +70,15 @@ class RDKIT_MOLENUMERATOR_EXPORT PositionVariationOp : public MolEnumeratorOp {
   std::vector<size_t> getVariationCounts() const override;
 
   //! \override
-  ROMol *operator()(const std::vector<size_t> &which) const override;
+  std::unique_ptr<ROMol> operator()(
+      const std::vector<size_t> &which) const override;
 
   //! \override
   void initFromMol(const ROMol &mol) override;
 
   //! \override
-  MolEnumeratorOp *copy() const override {
-    return new PositionVariationOp(*this);
+  std::unique_ptr<MolEnumeratorOp> copy() const override {
+    return std::unique_ptr<MolEnumeratorOp>(new PositionVariationOp(*this));
   }
 
  private:
@@ -99,7 +100,8 @@ struct RDKIT_MOLENUMERATOR_EXPORT MolEnumeratorParams {
 
 //! Returns a MolBundle containing the molecules resulting from applying the
 //! operator contained in \c params to \c mol.
-RDKIT_MOLENUMERATOR_EXPORT MolBundle enumerate(const ROMol &mol, const MolEnumeratorParams &params);
+RDKIT_MOLENUMERATOR_EXPORT MolBundle
+enumerate(const ROMol &mol, const MolEnumeratorParams &params);
 }  // namespace MolEnumerator
 }  // namespace RDKit
 

--- a/Code/GraphMol/MolEnumerator/MolEnumerator.h
+++ b/Code/GraphMol/MolEnumerator/MolEnumerator.h
@@ -99,7 +99,7 @@ struct RDKIT_MOLENUMERATOR_EXPORT MolEnumeratorParams {
 
 //! Returns a MolBundle containing the molecules resulting from applying the
 //! operator contained in \c params to \c mol.
-MolBundle enumerate(const ROMol &mol, const MolEnumeratorParams &params);
+RDKIT_MOLENUMERATOR_EXPORT MolBundle enumerate(const ROMol &mol, const MolEnumeratorParams &params);
 }  // namespace MolEnumerator
 }  // namespace RDKit
 

--- a/Code/GraphMol/MolEnumerator/MolEnumerator.h
+++ b/Code/GraphMol/MolEnumerator/MolEnumerator.h
@@ -101,7 +101,6 @@ class RDKIT_MOLENUMERATOR_EXPORT LinkNodeOp : public MolEnumeratorOp {
     initFromMol();
   };
   LinkNodeOp(const ROMol &mol) : dp_mol(new ROMol(mol)) { initFromMol(); };
-  // FIX: copy all members here and for operator=
   LinkNodeOp(const LinkNodeOp &other)
       : dp_mol(other.dp_mol),
         dp_frame(other.dp_frame),

--- a/Code/GraphMol/MolEnumerator/MolEnumerator.h
+++ b/Code/GraphMol/MolEnumerator/MolEnumerator.h
@@ -33,6 +33,7 @@ class RDKIT_MOLENUMERATOR_EXPORT MolEnumeratorOp {
 };
 
 class RDKIT_MOLENUMERATOR_EXPORT PositionVariationOp : public MolEnumeratorOp {
+ public:
   PositionVariationOp(const std::shared_ptr<ROMol> mol) : dp_mol(mol) {
     PRECONDITION(mol, "bad molecule");
     initFromMol();
@@ -49,11 +50,9 @@ class RDKIT_MOLENUMERATOR_EXPORT PositionVariationOp : public MolEnumeratorOp {
     dp_mol = other.dp_mol;
     d_variationPoints = other.d_variationPoints;
   };
+  std::vector<size_t> getVariationCounts() const override;
 
-  std::vector<size_t> getVariationCounts() const override { return {}; };
-  ROMol *operator()(const std::vector<size_t> &which) const override {
-    return nullptr;
-  };
+  ROMol *operator()(const std::vector<size_t> &which) const override;
 
  private:
   std::shared_ptr<ROMol> dp_mol;

--- a/Code/GraphMol/MolEnumerator/MolEnumerator.h
+++ b/Code/GraphMol/MolEnumerator/MolEnumerator.h
@@ -105,7 +105,10 @@ class RDKIT_MOLENUMERATOR_EXPORT LinkNodeOp : public MolEnumeratorOp {
   LinkNodeOp(const LinkNodeOp &other)
       : dp_mol(other.dp_mol),
         dp_frame(other.dp_frame),
-        d_countAtEachPoint(other.d_countAtEachPoint){};
+        d_countAtEachPoint(other.d_countAtEachPoint),
+        d_variations(other.d_variations),
+        d_pointRanges(other.d_pointRanges),
+        d_isotopeMap(other.d_isotopeMap){};
   LinkNodeOp &operator=(const LinkNodeOp &other) {
     if (&other == this) {
       return *this;
@@ -113,6 +116,9 @@ class RDKIT_MOLENUMERATOR_EXPORT LinkNodeOp : public MolEnumeratorOp {
     dp_mol = other.dp_mol;
     dp_frame = other.dp_frame;
     d_countAtEachPoint = other.d_countAtEachPoint;
+    d_variations = other.d_variations;
+    d_pointRanges = other.d_pointRanges;
+    d_isotopeMap = other.d_isotopeMap;
     return *this;
   };
   //! \override
@@ -134,7 +140,9 @@ class RDKIT_MOLENUMERATOR_EXPORT LinkNodeOp : public MolEnumeratorOp {
   std::shared_ptr<ROMol> dp_mol{nullptr};
   std::shared_ptr<RWMol> dp_frame{nullptr};
   std::vector<size_t> d_countAtEachPoint{};
+  std::vector<std::tuple<unsigned, unsigned, unsigned>> d_variations;
   std::vector<std::pair<unsigned, unsigned>> d_pointRanges;
+  std::map<unsigned, unsigned> d_isotopeMap;
 
   void initFromMol();
 };

--- a/Code/GraphMol/MolEnumerator/MolEnumerator.h
+++ b/Code/GraphMol/MolEnumerator/MolEnumerator.h
@@ -150,8 +150,8 @@ class RDKIT_MOLENUMERATOR_EXPORT LinkNodeOp : public MolEnumeratorOp {
 struct RDKIT_MOLENUMERATOR_EXPORT MolEnumeratorParams {
   bool sanitize = false;
   size_t maxToEnumerate = 1000;
-  bool doRandom = false;
-  int randomSeed = -1;
+  bool doRandom = false;  //< not yet implemented
+  int randomSeed = -1;    //< not yet implemented
   std::shared_ptr<MolEnumeratorOp> dp_operation;
 };
 

--- a/Code/GraphMol/MolEnumerator/MolEnumerator.h
+++ b/Code/GraphMol/MolEnumerator/MolEnumerator.h
@@ -58,6 +58,7 @@ class RDKIT_MOLENUMERATOR_EXPORT PositionVariationOp : public MolEnumeratorOp {
   std::shared_ptr<ROMol> dp_mol;
   std::vector<std::pair<unsigned int, std::vector<unsigned int>>>
       d_variationPoints;
+  std::vector<size_t> d_dummiesAtEachPoint;
   void initFromMol();
 };
 

--- a/Code/GraphMol/MolEnumerator/MolEnumerator.h
+++ b/Code/GraphMol/MolEnumerator/MolEnumerator.h
@@ -26,7 +26,7 @@ namespace MolEnumerator {
 class RDKIT_MOLENUMERATOR_EXPORT MolEnumeratorOp {
  public:
   MolEnumeratorOp(){};
-  ~MolEnumeratorOp(){};
+  virtual ~MolEnumeratorOp(){};
   //! returns a vector of the number of possible variations at variability point
   //! covered by this operation
   virtual std::vector<size_t> getVariationCounts() const = 0;
@@ -64,6 +64,7 @@ class RDKIT_MOLENUMERATOR_EXPORT PositionVariationOp : public MolEnumeratorOp {
     }
     dp_mol = other.dp_mol;
     d_variationPoints = other.d_variationPoints;
+    return *this;
   };
   //! \override
   std::vector<size_t> getVariationCounts() const override;
@@ -75,7 +76,9 @@ class RDKIT_MOLENUMERATOR_EXPORT PositionVariationOp : public MolEnumeratorOp {
   void initFromMol(const ROMol &mol) override;
 
   //! \override
-  MolEnumeratorOp *copy() const { return new PositionVariationOp(*this); }
+  MolEnumeratorOp *copy() const override {
+    return new PositionVariationOp(*this);
+  }
 
  private:
   std::shared_ptr<ROMol> dp_mol{nullptr};

--- a/Code/GraphMol/MolEnumerator/MolEnumerator.h
+++ b/Code/GraphMol/MolEnumerator/MolEnumerator.h
@@ -1,0 +1,52 @@
+//
+//  Copyright (C) 2020 Greg Landrum and T5 Informatics GmbH
+//
+//   @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
+//
+#ifndef RDKIT_MOLENUMERATOR_H
+#define RDKIT_MOLENUMERATOR_H
+
+#include <RDGeneral/export.h>
+#include <GraphMol/RDKitBase.h>
+#include <GraphMol/MolBundle.h>
+
+#include <vector>
+#include <map>
+#include <string>
+
+namespace RDKit {
+namespace MolEnumerator {
+
+//! abstract base class
+class RDKIT_MOLENUMERATOR_EXPORT MolEnumeratorOp {
+ private:
+  ROMol d_mol;
+
+ public:
+  MolEnumeratorOp(const ROMol &mol) : d_mol(mol){};
+  MolEnumeratorOp(const MolEnumeratorOp &other) : d_mol(other.d_mol){};
+  MolEnumeratorOp &operator=(const MolEnumeratorOp &other) {
+    if (&other != this) {
+      d_mol = ROMol(other.d_mol);
+    }
+    return *this;
+  };
+  ~MolEnumeratorOp() = default;
+};
+
+struct RDKIT_MOLENUMERATOR_EXPORT MolEnumeratorParams {
+  bool sanitize = false;
+  size_t maxToEnumerate = 0;
+  bool doRandom = false;
+  int randomSeed = -1;
+  std::vector<MolEnumeratorOp> operations;
+};
+
+}  // namespace MolEnumerator
+}  // namespace RDKit
+
+#endif

--- a/Code/GraphMol/MolEnumerator/MolEnumerator.h
+++ b/Code/GraphMol/MolEnumerator/MolEnumerator.h
@@ -20,6 +20,7 @@
 #include <memory>
 
 namespace RDKit {
+class ChemicalReaction;
 namespace MolEnumerator {
 
 //! abstract base class for the a molecule enumeration operation
@@ -86,6 +87,55 @@ class RDKIT_MOLENUMERATOR_EXPORT PositionVariationOp : public MolEnumeratorOp {
   std::vector<std::pair<unsigned int, std::vector<unsigned int>>>
       d_variationPoints{};
   std::vector<size_t> d_dummiesAtEachPoint{};
+  void initFromMol();
+};
+
+//! Molecule enumeration operation corresponding to LINKNODES
+/*!
+ */
+class RDKIT_MOLENUMERATOR_EXPORT LinkNodeOp : public MolEnumeratorOp {
+ public:
+  LinkNodeOp(){};
+  LinkNodeOp(const std::shared_ptr<ROMol> mol) : dp_mol(mol) {
+    PRECONDITION(mol, "bad molecule");
+    initFromMol();
+  };
+  LinkNodeOp(const ROMol &mol) : dp_mol(new ROMol(mol)) { initFromMol(); };
+  // FIX: copy all members here and for operator=
+  LinkNodeOp(const LinkNodeOp &other)
+      : dp_mol(other.dp_mol),
+        dp_frame(other.dp_frame),
+        d_countAtEachPoint(other.d_countAtEachPoint){};
+  LinkNodeOp &operator=(const LinkNodeOp &other) {
+    if (&other == this) {
+      return *this;
+    }
+    dp_mol = other.dp_mol;
+    dp_frame = other.dp_frame;
+    d_countAtEachPoint = other.d_countAtEachPoint;
+    return *this;
+  };
+  //! \override
+  std::vector<size_t> getVariationCounts() const override;
+
+  //! \override
+  std::unique_ptr<ROMol> operator()(
+      const std::vector<size_t> &which) const override;
+
+  //! \override
+  void initFromMol(const ROMol &mol) override;
+
+  //! \override
+  std::unique_ptr<MolEnumeratorOp> copy() const override {
+    return std::unique_ptr<MolEnumeratorOp>(new LinkNodeOp(*this));
+  }
+
+ private:
+  std::shared_ptr<ROMol> dp_mol{nullptr};
+  std::shared_ptr<RWMol> dp_frame{nullptr};
+  std::vector<size_t> d_countAtEachPoint{};
+  std::vector<std::pair<unsigned, unsigned>> d_pointRanges;
+
   void initFromMol();
 };
 

--- a/Code/GraphMol/MolEnumerator/PositionVariation.cpp
+++ b/Code/GraphMol/MolEnumerator/PositionVariation.cpp
@@ -1,0 +1,101 @@
+//
+//  Copyright (C) 2020 Greg Landrum and T5 Informatics GmbH
+//
+//   @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
+//
+#include "MolEnumerator.h"
+#include <RDGeneral/Exceptions.h>
+#include <GraphMol/FileParsers/MolSGroupParsing.h>
+
+namespace RDKit {
+namespace MolEnumerator {
+
+void PositionVariationOp::initFromMol(const ROMol &mol) {
+  dp_mol.reset(new ROMol(mol));
+  initFromMol();
+}
+void PositionVariationOp::initFromMol() {
+  d_variationPoints.clear();
+  if (!dp_mol) {
+    return;
+  }
+  for (const auto bond : dp_mol->bonds()) {
+    std::string endpts;
+    std::string attach;
+    if (bond->getPropIfPresent(common_properties::_MolFileBondEndPts, endpts) &&
+        bond->getPropIfPresent(common_properties::_MolFileBondAttach, attach) &&
+        attach == "ANY") {
+      const Atom *atom = bond->getBeginAtom();
+      if (atom->getAtomicNum() == 0) {
+        atom = bond->getEndAtom();
+        if (atom->getAtomicNum() == 0) {
+          throw ValueErrorException(
+              "position variation bond does not have connection to a "
+              "non-dummy atom");
+        }
+      }
+      d_dummiesAtEachPoint.push_back(bond->getOtherAtomIdx(atom->getIdx()));
+      std::vector<unsigned int> oats =
+          RDKit::SGroupParsing::ParseV3000Array<unsigned int>(endpts);
+      // decrement the indices and do error checking:
+      for (auto &oat : oats) {
+        if (oat == 0 || oat > dp_mol->getNumAtoms()) {
+          throw ValueErrorException("Bad variation point index");
+        }
+        --oat;
+      }
+      d_variationPoints.push_back(std::make_pair(atom->getIdx(), oats));
+    }
+  }
+}
+
+std::vector<size_t> PositionVariationOp::getVariationCounts() const {
+  std::vector<size_t> res(d_variationPoints.size());
+  std::transform(
+      d_variationPoints.begin(), d_variationPoints.end(), res.begin(),
+      [](std::pair<unsigned int, std::vector<unsigned int>> pr) -> size_t {
+        return pr.second.size();
+      });
+  return res;
+}
+
+std::unique_ptr<ROMol> PositionVariationOp::operator()(
+    const std::vector<size_t> &which) const {
+  PRECONDITION(dp_mol, "no molecule");
+  if (which.size() != d_variationPoints.size()) {
+    throw ValueErrorException("bad element choice in enumeration");
+  }
+  // a bit of quick error checking before starting the real work
+  for (unsigned int i = 0; i < d_variationPoints.size(); ++i) {
+    if (which[i] >= d_variationPoints[i].second.size()) {
+      throw ValueErrorException("bad element value in enumeration");
+    }
+  }
+  RWMol *res = new RWMol(*dp_mol);
+  for (unsigned int i = 0; i < d_variationPoints.size(); ++i) {
+    const auto tpl = d_variationPoints[i];
+    auto begAtomIdx = tpl.first;
+    auto endAtomIdx = tpl.second[which[i]];
+    // do we already have a bond?
+    if (res->getBondBetweenAtoms(begAtomIdx, endAtomIdx)) {
+      continue;
+    }
+    res->addBond(begAtomIdx, endAtomIdx, Bond::BondType::SINGLE);
+  }
+  // now remove the dummies:
+  std::vector<size_t> atsToRemove = d_dummiesAtEachPoint;
+  std::sort(atsToRemove.begin(), atsToRemove.end());
+  for (auto riter = atsToRemove.rbegin(); riter != atsToRemove.rend();
+       ++riter) {
+    res->removeAtom(*riter);
+  }
+  return std::unique_ptr<ROMol>(static_cast<ROMol *>(res));
+}
+
+}  // namespace MolEnumerator
+
+}  // namespace RDKit

--- a/Code/GraphMol/MolEnumerator/Wrap/CMakeLists.txt
+++ b/Code/GraphMol/MolEnumerator/Wrap/CMakeLists.txt
@@ -1,0 +1,8 @@
+remove_definitions(-DRDKIT_MOLENUMERATOR_BUILD)
+rdkit_python_extension(rdMolEnumerator
+                       rdMolEnumerator.cpp
+                       DEST Chem
+                       LINK_LIBRARIES
+                       MolEnumerator )
+
+add_pytest(pyMolEnumerator ${CMAKE_CURRENT_SOURCE_DIR}/rough_test.py)

--- a/Code/GraphMol/MolEnumerator/Wrap/rdMolEnumerator.cpp
+++ b/Code/GraphMol/MolEnumerator/Wrap/rdMolEnumerator.cpp
@@ -1,0 +1,76 @@
+//
+//  Copyright (C) 2020 Greg Landrum and T5 Informatics GmbH
+//
+//   @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
+//
+
+#include <RDBoost/python.h>
+#include <GraphMol/MolEnumerator/MolEnumerator.h>
+
+namespace python = boost::python;
+using namespace RDKit;
+namespace {
+
+enum class EnumeratorTypes { LinkNode, PositionVariation };
+
+std::shared_ptr<MolEnumerator::MolEnumeratorOp> opFromName(
+    EnumeratorTypes typ) {
+  std::shared_ptr<MolEnumerator::MolEnumeratorOp> res;
+  switch (typ) {
+    case EnumeratorTypes::LinkNode:
+      res.reset(new MolEnumerator::LinkNodeOp());
+      break;
+    case EnumeratorTypes::PositionVariation:
+      res.reset(new MolEnumerator::PositionVariationOp());
+      break;
+    default:
+      throw ValueErrorException("unrecognized operator type");
+  }
+  return res;
+}
+MolEnumerator::MolEnumeratorParams *createParamsFromName(EnumeratorTypes typ) {
+  auto res = new MolEnumerator::MolEnumeratorParams();
+  res->dp_operation = opFromName(typ);
+  return res;
+}
+void setEnumerationHelper(MolEnumerator::MolEnumeratorParams *self,
+                          EnumeratorTypes typ) {
+  self->dp_operation = opFromName(typ);
+}
+MolBundle *enumerateHelper(const ROMol &mol,
+                           const MolEnumerator::MolEnumeratorParams &ps) {
+  auto res = MolEnumerator::enumerate(mol, ps);
+  return new MolBundle(res);
+}
+}  // namespace
+BOOST_PYTHON_MODULE(rdMolEnumerator) {
+  python::scope().attr("__doc__") =
+      "Module containing classes and functions for enumerating query molecules";
+  python::enum_<EnumeratorTypes>("EnumeratorType")
+      .value("LinkNode", EnumeratorTypes::LinkNode)
+      .value("PositionVariation", EnumeratorTypes::PositionVariation);
+
+  python::class_<MolEnumerator::MolEnumeratorParams>(
+      "MolEnumeratorParams", "Molecular enumerator parameters",
+      python::init<>())
+      .def("__init__", python::make_constructor(createParamsFromName))
+      .def_readwrite("sanitize", &MolEnumerator::MolEnumeratorParams::sanitize,
+                     "sanitize molecules after enumeration")
+      .def_readwrite("maxToEnumerate",
+                     &MolEnumerator::MolEnumeratorParams::maxToEnumerate,
+                     "maximum number of molecules to enuemrate")
+      .def_readwrite("doRandom", &MolEnumerator::MolEnumeratorParams::doRandom,
+                     "do random enumeration (not yet implemented")
+      .def_readwrite("randomSeed",
+                     &MolEnumerator::MolEnumeratorParams::randomSeed,
+                     "seed for the random enumeration (not yet implemented")
+      .def("SetEnumerationOperator", &setEnumerationHelper,
+           "set the operator to be used for enumeration");
+  python::def("Enumerate", &enumerateHelper,
+              python::return_value_policy<python::manage_new_object>(),
+              "do an enumeration and return a MolBundle");
+}

--- a/Code/GraphMol/MolEnumerator/Wrap/rough_test.py
+++ b/Code/GraphMol/MolEnumerator/Wrap/rough_test.py
@@ -1,0 +1,92 @@
+#
+#  Copyright (C) 2020  Greg Landrum and T5 Informatics GmbH
+#         All Rights Reserved
+#
+#  This file is part of the RDKit.
+#  The contents are covered by the terms of the BSD license
+#  which is included in the file license.txt, found at the root
+#  of the RDKit source tree.
+#
+
+from rdkit import RDConfig
+from rdkit import Chem
+from rdkit.Chem import rdMolEnumerator
+import unittest
+
+
+class TestCase(unittest.TestCase):
+
+  def setUp(self):
+    pass
+
+  def testLinkNodes(self):
+    mb = '''one linknode
+  Mrv2007 06222005102D          
+
+  0  0  0     0  0            999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 6 6 0 0 0
+M  V30 BEGIN ATOM
+M  V30 1 C 8.25 12.1847 0 0
+M  V30 2 C 6.9164 12.9547 0 0
+M  V30 3 C 6.9164 14.4947 0 0
+M  V30 4 C 9.5836 14.4947 0 0
+M  V30 5 C 9.5836 12.9547 0 0
+M  V30 6 O 8.25 10.6447 0 0
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 1 1 2
+M  V30 2 1 2 3
+M  V30 3 1 4 5
+M  V30 4 1 1 5
+M  V30 5 1 3 4
+M  V30 6 1 1 6
+M  V30 END BOND
+M  V30 LINKNODE 1 4 2 1 2 1 5
+M  V30 END CTAB
+M  END'''
+    m = Chem.MolFromMolBlock(mb)
+    ps = rdMolEnumerator.MolEnumeratorParams(rdMolEnumerator.EnumeratorType.LinkNode)
+    bndl = rdMolEnumerator.Enumerate(m, ps)
+    self.assertEqual(bndl.Size(), 4)
+
+  def testPositionVariation(self):
+    mb = '''two position variation bonds
+  Mrv2007 06242006032D          
+
+  0  0  0     0  0            999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 10 8 0 0 0
+M  V30 BEGIN ATOM
+M  V30 1 C -1.7083 2.415 0 0
+M  V30 2 C -3.042 1.645 0 0
+M  V30 3 C -3.042 0.105 0 0
+M  V30 4 N -1.7083 -0.665 0 0
+M  V30 5 C -0.3747 0.105 0 0
+M  V30 6 C -0.3747 1.645 0 0
+M  V30 7 * -3.042 0.875 0 0
+M  V30 8 F -5.0434 0.875 0 0
+M  V30 9 * -1.0415 2.03 0 0
+M  V30 10 Cl -1.0415 4.34 0 0
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 1 1 2
+M  V30 2 2 2 3
+M  V30 3 1 3 4
+M  V30 4 2 4 5
+M  V30 5 1 5 6
+M  V30 6 2 1 6
+M  V30 7 1 7 8 ENDPTS=(2 2 3) ATTACH=ANY
+M  V30 8 1 9 10 ENDPTS=(2 1 6) ATTACH=ANY
+M  V30 END BOND
+M  V30 END CTAB
+M  END
+'''
+    m = Chem.MolFromMolBlock(mb)
+    ps = rdMolEnumerator.MolEnumeratorParams(rdMolEnumerator.EnumeratorType.PositionVariation)
+    bndl = rdMolEnumerator.Enumerate(m, ps)
+    self.assertEqual(bndl.Size(), 4)
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/Code/GraphMol/MolEnumerator/catch_main.cpp
+++ b/Code/GraphMol/MolEnumerator/catch_main.cpp
@@ -1,0 +1,12 @@
+//
+//  Copyright (C) 2020 Greg Landrum
+//   @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
+//
+
+#define CATCH_CONFIG_MAIN  // This tells Catch to provide a main() - only do
+                           // this in one cpp file
+#include "catch.hpp"

--- a/Code/GraphMol/MolEnumerator/enumerator_catch.cpp
+++ b/Code/GraphMol/MolEnumerator/enumerator_catch.cpp
@@ -395,20 +395,4 @@ M  END)CTAB"_ctab;
     }
     CHECK(smis == tsmis);
   }
-#if 0
-  SECTION("enumeration basics 2") {
-    MolEnumerator::MolEnumeratorParams ps;
-    ps.dp_operation = std::shared_ptr<MolEnumerator::MolEnumeratorOp>(
-        new MolEnumerator::PositionVariationOp());
-    auto bundle = MolEnumerator::enumerate(*mol2, ps);
-    CHECK(bundle.size() == 4);
-    std::vector<std::string> tsmis = {"Fc1cnccc1Cl", "Fc1cncc(Cl)c1",
-                                      "Fc1cc(Cl)ccn1", "Fc1ccc(Cl)cn1"};
-    std::vector<std::string> smis;
-    for (const auto molp : bundle.getMols()) {
-      smis.push_back(MolToSmiles(*molp));
-    }
-    CHECK(smis == tsmis);
-  }
-#endif
 }

--- a/Code/GraphMol/MolEnumerator/enumerator_catch.cpp
+++ b/Code/GraphMol/MolEnumerator/enumerator_catch.cpp
@@ -184,7 +184,26 @@ M  V30 LINKNODE 1 4 2 1 2 1 5
 M  V30 END CTAB
 M  END)CTAB"_ctab;
   REQUIRE(mol1);
-  auto mol2 = R"CTAB(two linknodes
+  SECTION("LinkNode unit tests 1") {
+    MolEnumerator::LinkNodeOp op;
+    op.initFromMol(*mol1);
+    auto vcnts = op.getVariationCounts();
+    REQUIRE(vcnts.size() == 1);
+    CHECK(vcnts[0] == 4);
+
+    {
+      std::vector<size_t> elems{0};
+      std::unique_ptr<ROMol> newmol(op(elems));
+      CHECK(MolToSmiles(*newmol) == "OC1CCCC1");
+    }
+    {
+      std::vector<size_t> elems{2};
+      std::unique_ptr<ROMol> newmol(op(elems));
+      CHECK(MolToSmiles(*newmol) == "OC1CCCCC(O)C1O");
+    }
+  }
+  SECTION("LinkNode unit tests 2") {
+    auto mol2 = R"CTAB(two linknodes
   Mrv2014 07072016412D          
 
   0  0  0     0  0            999 V3000
@@ -209,11 +228,129 @@ M  V30 6 1 1 6
 M  V30 7 1 4 7
 M  V30 END BOND
 M  V30 LINKNODE 1 3 2 1 2 1 5
-M  V30 LINKNODE 1 2 2 4 3 4 5
+M  V30 LINKNODE 1 4 2 4 3 4 5
 M  V30 END CTAB
 M  END)CTAB"_ctab;
-  REQUIRE(mol2);
-  auto mol3 = R"CTAB(no linknodes
+    REQUIRE(mol2);
+    MolEnumerator::LinkNodeOp op;
+    op.initFromMol(*mol2);
+    auto vcnts = op.getVariationCounts();
+    REQUIRE(vcnts.size() == 2);
+    CHECK(vcnts[0] == 3);
+    CHECK(vcnts[1] == 4);
+
+    {
+      std::vector<size_t> elems{0, 0};
+      std::unique_ptr<ROMol> newmol(op(elems));
+      CHECK(MolToSmiles(*newmol) == "OC1CCC(F)C1");
+    }
+    {
+      std::vector<size_t> elems{2, 0};
+      std::unique_ptr<ROMol> newmol(op(elems));
+      CHECK(MolToSmiles(*newmol) == "OC1CCC(F)CC(O)C1O");
+    }
+    {
+      std::vector<size_t> elems{1, 2};
+      std::unique_ptr<ROMol> newmol(op(elems));
+      CHECK(MolToSmiles(*newmol) == "OC1CCC(F)C(F)C(F)CC1O");
+    }
+  }
+  SECTION("LinkNode unit tests 3") {
+    auto mol = R"CTAB(neighboring linknodes
+  Mrv2014 07082008052D          
+
+  0  0  0     0  0            999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 9 9 0 0 0
+M  V30 BEGIN ATOM
+M  V30 1 C 8.25 12.1847 0 0
+M  V30 2 C 6.9164 12.9547 0 0
+M  V30 3 C 7.2366 14.4611 0 0
+M  V30 4 C 8.7681 14.622 0 0
+M  V30 5 C 9.3945 13.2151 0 0
+M  V30 6 O 8.25 10.6447 0 0
+M  V30 7 F 9.5382 15.9557 0 0
+M  V30 8 C 9.5837 9.8747 0 0
+M  V30 9 C 10.9008 12.8949 0 0
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 1 1 2
+M  V30 2 1 2 3
+M  V30 3 1 4 5
+M  V30 4 1 1 5
+M  V30 5 1 3 4
+M  V30 6 1 1 6
+M  V30 7 1 4 7
+M  V30 8 1 6 8
+M  V30 9 1 5 9
+M  V30 END BOND
+M  V30 LINKNODE 1 3 2 1 2 1 5
+M  V30 LINKNODE 1 2 2 5 1 5 4
+M  V30 END CTAB
+M  END
+)CTAB"_ctab;
+    REQUIRE(mol);
+    MolEnumerator::LinkNodeOp op;
+    op.initFromMol(*mol);
+    auto vcnts = op.getVariationCounts();
+    REQUIRE(vcnts.size() == 2);
+    CHECK(vcnts[0] == 3);
+    CHECK(vcnts[1] == 2);
+
+    {
+      std::vector<size_t> elems{0, 0};
+      std::unique_ptr<ROMol> newmol(op(elems));
+      CHECK(MolToSmiles(*newmol) == "COC1CCC(F)C1C");
+    }
+    {
+      std::vector<size_t> elems{1, 0};
+      std::unique_ptr<ROMol> newmol(op(elems));
+      CHECK(MolToSmiles(*newmol) == "COC1CCC(F)C(C)C1OC");
+    }
+    {
+      std::vector<size_t> elems{1, 1};
+      std::unique_ptr<ROMol> newmol(op(elems));
+      CHECK(MolToSmiles(*newmol) == "COC1CCC(F)C(C)C(C)C1OC");
+    }
+  }
+  SECTION("LinkNode unit tests: isotopes") {
+    auto mol = R"CTAB(isotopes and linknodes
+  Mrv2014 07082008362D          
+
+  0  0  0     0  0            999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 4 4 0 0 0
+M  V30 BEGIN ATOM
+M  V30 1 C 0.5 19.6392 0 0 MASS=14
+M  V30 2 C -0.27 18.3054 0 0 MASS=15
+M  V30 3 C 1.27 18.3054 0 0 MASS=13
+M  V30 4 O 2.6037 17.5354 0 0 MASS=12
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 1 1 2
+M  V30 2 1 3 1
+M  V30 3 1 2 3
+M  V30 4 1 3 4
+M  V30 END BOND
+M  V30 LINKNODE 1 3 2 3 1 3 2
+M  V30 END CTAB
+M  END
+)CTAB"_ctab;
+    REQUIRE(mol);
+    MolEnumerator::LinkNodeOp op;
+    op.initFromMol(*mol);
+    auto vcnts = op.getVariationCounts();
+    REQUIRE(vcnts.size() == 1);
+    CHECK(vcnts[0] == 3);
+
+    {
+      std::vector<size_t> elems{1};
+      std::unique_ptr<ROMol> newmol(op(elems));
+      CHECK(MolToSmiles(*newmol) == "[12OH][13CH]1[14CH2][15CH2][13CH]1[12OH]");
+    }
+  }
+  SECTION("LinkNode unit tests: no linknodes") {
+    auto mol = R"CTAB(no linknodes
   Mrv2007 06222005102D          
 
   0  0  0     0  0            999 V3000
@@ -237,56 +374,41 @@ M  V30 6 1 1 6
 M  V30 END BOND
 M  V30 END CTAB
 M  END)CTAB"_ctab;
-  REQUIRE(mol3);
-  // TODO: add a test for neighboring LINKNODES
-  SECTION("LinkNode unit tests 1") {
+    REQUIRE(mol);
     MolEnumerator::LinkNodeOp op;
-    op.initFromMol(*mol1);
-    auto vcnts = op.getVariationCounts();
-    REQUIRE(vcnts.size() == 1);
-    CHECK(vcnts[0] == 4);
-
-    {
-      std::vector<size_t> elems{0};
-      std::unique_ptr<ROMol> newmol(op(elems));
-      CHECK(MolToSmiles(*newmol) == "OC1CCCC1");
-    }
-    {
-      std::vector<size_t> elems{2};
-      std::unique_ptr<ROMol> newmol(op(elems));
-      CHECK(MolToSmiles(*newmol) == "OC1C(O)C(O)CCCC1");
-    }
-  }
-#if 1
-  SECTION("LinkNode unit tests 2") {
-    MolEnumerator::LinkNodeOp op;
-    op.initFromMol(*mol2);
-    auto vcnts = op.getVariationCounts();
-    REQUIRE(vcnts.size() == 2);
-    CHECK(vcnts[0] == 3);
-    CHECK(vcnts[1] == 2);
-
-    {
-      std::vector<size_t> elems{0, 0};
-      std::unique_ptr<ROMol> newmol(op(elems));
-      CHECK(MolToSmiles(*newmol) == "OC1CC(F)CC1");
-    }
-    {
-      std::vector<size_t> elems{2, 0};
-      std::unique_ptr<ROMol> newmol(op(elems));
-      CHECK(MolToSmiles(*newmol) == "OC1C(O)C(O)CC(F)CC1");
-    }
-    {
-      std::vector<size_t> elems{0, 1};
-      std::unique_ptr<ROMol> newmol(op(elems));
-      CHECK(MolToSmiles(*newmol) == "OC1C(F)CC(F)CC1");
-    }
-  }
-#endif
-  SECTION("LinkNode unit tests 3") {
-    MolEnumerator::LinkNodeOp op;
-    op.initFromMol(*mol3);
+    op.initFromMol(*mol);
     auto vcnts = op.getVariationCounts();
     REQUIRE(vcnts.size() == 0);
   }
+
+  SECTION("enumeration basics 1") {
+    MolEnumerator::MolEnumeratorParams ps;
+    ps.dp_operation = std::shared_ptr<MolEnumerator::MolEnumeratorOp>(
+        new MolEnumerator::LinkNodeOp());
+    auto bundle = MolEnumerator::enumerate(*mol1, ps);
+    std::vector<std::string> tsmis = {"OC1CCCC1", "OC1CCCCC1O",
+                                      "OC1CCCCC(O)C1O", "OC1CCCCC(O)C(O)C1O"};
+    CHECK(bundle.size() == tsmis.size());
+    std::vector<std::string> smis;
+    for (const auto molp : bundle.getMols()) {
+      smis.push_back(MolToSmiles(*molp));
+    }
+    CHECK(smis == tsmis);
+  }
+#if 0
+  SECTION("enumeration basics 2") {
+    MolEnumerator::MolEnumeratorParams ps;
+    ps.dp_operation = std::shared_ptr<MolEnumerator::MolEnumeratorOp>(
+        new MolEnumerator::PositionVariationOp());
+    auto bundle = MolEnumerator::enumerate(*mol2, ps);
+    CHECK(bundle.size() == 4);
+    std::vector<std::string> tsmis = {"Fc1cnccc1Cl", "Fc1cncc(Cl)c1",
+                                      "Fc1cc(Cl)ccn1", "Fc1ccc(Cl)cn1"};
+    std::vector<std::string> smis;
+    for (const auto molp : bundle.getMols()) {
+      smis.push_back(MolToSmiles(*molp));
+    }
+    CHECK(smis == tsmis);
+  }
+#endif
 }

--- a/Code/GraphMol/MolEnumerator/enumerator_catch.cpp
+++ b/Code/GraphMol/MolEnumerator/enumerator_catch.cpp
@@ -395,4 +395,36 @@ M  END)CTAB"_ctab;
     }
     CHECK(smis == tsmis);
   }
+  SECTION("enumeration basics 2") {
+    auto mol = R"CTAB(no linknodes
+  Mrv2007 06222005102D          
+
+  0  0  0     0  0            999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 6 6 0 0 0
+M  V30 BEGIN ATOM
+M  V30 1 C 8.25 12.1847 0 0
+M  V30 2 C 6.9164 12.9547 0 0
+M  V30 3 C 6.9164 14.4947 0 0
+M  V30 4 C 9.5836 14.4947 0 0
+M  V30 5 C 9.5836 12.9547 0 0
+M  V30 6 O 8.25 10.6447 0 0
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 1 1 2
+M  V30 2 1 2 3
+M  V30 3 1 4 5
+M  V30 4 1 1 5
+M  V30 5 1 3 4
+M  V30 6 1 1 6
+M  V30 END BOND
+M  V30 END CTAB
+M  END)CTAB"_ctab;
+    REQUIRE(mol);
+    MolEnumerator::MolEnumeratorParams ps;
+    ps.dp_operation = std::shared_ptr<MolEnumerator::MolEnumeratorOp>(
+        new MolEnumerator::LinkNodeOp());
+    auto bundle = MolEnumerator::enumerate(*mol, ps);
+    CHECK(bundle.size() == 0);
+  }
 }

--- a/Code/GraphMol/MolEnumerator/enumerator_catch.cpp
+++ b/Code/GraphMol/MolEnumerator/enumerator_catch.cpp
@@ -20,7 +20,7 @@
 using namespace RDKit;
 
 TEST_CASE("PositionVariation", "[MolEnumerator]") {
-  auto mol = R"CTAB(
+  auto mol1 = R"CTAB(
   Mrv2007 06232015292D          
 
   0  0  0     0  0            999 V3000
@@ -51,8 +51,41 @@ M  V30 END CTAB
 M  END)CTAB"_ctab;
   REQUIRE(mol);
 
-  SECTION("PositionVariationOp unit tests") {
-    MolEnumerator::PositionVariationOp op(*mol);
+  auto mol2 = R"CTAB(
+  Mrv2007 06242006032D          
+
+  0  0  0     0  0            999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 10 8 0 0 0
+M  V30 BEGIN ATOM
+M  V30 1 C -1.7083 2.415 0 0
+M  V30 2 C -3.042 1.645 0 0
+M  V30 3 C -3.042 0.105 0 0
+M  V30 4 N -1.7083 -0.665 0 0
+M  V30 5 C -0.3747 0.105 0 0
+M  V30 6 C -0.3747 1.645 0 0
+M  V30 7 * -3.042 0.875 0 0
+M  V30 8 F -5.0434 0.875 0 0
+M  V30 9 * -1.0415 2.03 0 0
+M  V30 10 Cl -1.0415 4.34 0 0
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 1 1 2
+M  V30 2 2 2 3
+M  V30 3 1 3 4
+M  V30 4 2 4 5
+M  V30 5 1 5 6
+M  V30 6 2 1 6
+M  V30 7 1 7 8 ENDPTS=(2 2 3) ATTACH=ANY
+M  V30 8 1 9 10 ENDPTS=(2 1 6) ATTACH=ANY
+M  V30 END BOND
+M  V30 END CTAB
+M  END
+)CTAB";
+  REQUIRE(mol2);
+
+  SECTION("PositionVariationOp unit tests 1") {
+    MolEnumerator::PositionVariationOp op(*mol1);
     auto vcnts = op.getVariationCounts();
     REQUIRE(vcnts.size() == 1);
     CHECK(vcnts[0] == 3);

--- a/Code/GraphMol/MolEnumerator/enumerator_catch.cpp
+++ b/Code/GraphMol/MolEnumerator/enumerator_catch.cpp
@@ -49,7 +49,7 @@ M  V30 8 1 8 9
 M  V30 END BOND
 M  V30 END CTAB
 M  END)CTAB"_ctab;
-  REQUIRE(mol);
+  REQUIRE(mol1);
 
   auto mol2 = R"CTAB(
   Mrv2007 06242006032D          
@@ -81,7 +81,7 @@ M  V30 8 1 9 10 ENDPTS=(2 1 6) ATTACH=ANY
 M  V30 END BOND
 M  V30 END CTAB
 M  END
-)CTAB";
+)CTAB"_ctab;
   REQUIRE(mol2);
 
   SECTION("PositionVariationOp unit tests 1") {
@@ -99,6 +99,24 @@ M  END
       std::vector<size_t> elems{2};
       std::unique_ptr<ROMol> newmol(op(elems));
       CHECK(MolToSmiles(*newmol) == "COc1cccnc1");
+    }
+  }
+  SECTION("PositionVariationOp unit tests 2") {
+    MolEnumerator::PositionVariationOp op(*mol2);
+    auto vcnts = op.getVariationCounts();
+    REQUIRE(vcnts.size() == 2);
+    CHECK(vcnts[0] == 2);
+    CHECK(vcnts[1] == 2);
+
+    {
+      std::vector<size_t> elems{1, 0};
+      std::unique_ptr<ROMol> newmol(op(elems));
+      CHECK(MolToSmiles(*newmol) == "Fc1cc(Cl)ccn1");
+    }
+    {
+      std::vector<size_t> elems{0, 1};
+      std::unique_ptr<ROMol> newmol(op(elems));
+      CHECK(MolToSmiles(*newmol) == "Fc1cncc(Cl)c1");
     }
   }
 }

--- a/Code/GraphMol/MolEnumerator/enumerator_catch.cpp
+++ b/Code/GraphMol/MolEnumerator/enumerator_catch.cpp
@@ -19,6 +19,50 @@
 
 using namespace RDKit;
 
+TEST_CASE("PositionVariation", "[MolEnumerator]") {
+  auto mol = R"CTAB(
+  Mrv2007 06232015292D          
+
+  0  0  0     0  0            999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 9 8 0 0 0
+M  V30 BEGIN ATOM
+M  V30 1 C -1.7083 2.415 0 0
+M  V30 2 C -3.042 1.645 0 0
+M  V30 3 C -3.042 0.105 0 0
+M  V30 4 C -1.7083 -0.665 0 0
+M  V30 5 C -0.3747 0.105 0 0
+M  V30 6 C -0.3747 1.645 0 0
+M  V30 7 * -0.8192 1.3883 0 0
+M  V30 8 O -0.8192 3.6983 0 0
+M  V30 9 C 0.5145 4.4683 0 0
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 1 1 2
+M  V30 2 2 2 3
+M  V30 3 1 3 4
+M  V30 4 2 4 5
+M  V30 5 1 5 6
+M  V30 6 2 1 6
+M  V30 7 1 7 8 ENDPTS=(3 1 5 6) ATTACH=ANY
+M  V30 8 1 8 9
+M  V30 END BOND
+M  V30 END CTAB
+M  END)CTAB"_ctab;
+  REQUIRE(mol);
+
+  SECTION("PositionVariationOp unit tests") {
+    MolEnumerator::PositionVariationOp op(*mol);
+    auto vcnts = op.getVariationCounts();
+    REQUIRE(vcnts.size() == 1);
+    CHECK(vcnts[0] == 3);
+
+    std::vector<size_t> elems{1};
+    std::unique_ptr<ROMol> newmol(op(elems));
+    CHECK(MolToSmiles(*newmol) == "");
+  }
+}
+
 TEST_CASE("LINKNODE", "[MolEnumerator]") {
   SECTION("basics") {
     auto mol = R"CTAB(

--- a/Code/GraphMol/MolEnumerator/enumerator_catch.cpp
+++ b/Code/GraphMol/MolEnumerator/enumerator_catch.cpp
@@ -1,0 +1,51 @@
+//
+//  Copyright (C) 2020 Greg Landrum
+//   @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
+//
+
+#include <RDGeneral/test.h>
+#include "catch.hpp"
+
+#include <GraphMol/RDKitBase.h>
+#include <GraphMol/FileParsers/FileParsers.h>
+#include <GraphMol/SmilesParse/SmilesWrite.h>
+#include <GraphMol/SmilesParse/SmilesParse.h>
+#include <GraphMol/SmilesParse/SmartsWrite.h>
+#include "MolEnumerator.h"
+
+using namespace RDKit;
+
+TEST_CASE("LINKNODE", "[MolEnumerator]") {
+  SECTION("basics") {
+    auto mol = R"CTAB(
+  Mrv2007 06222005102D          
+
+  0  0  0     0  0            999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 6 6 0 0 0
+M  V30 BEGIN ATOM
+M  V30 1 C 8.25 12.1847 0 0
+M  V30 2 C 6.9164 12.9547 0 0
+M  V30 3 C 6.9164 14.4947 0 0
+M  V30 4 C 9.5836 14.4947 0 0
+M  V30 5 C 9.5836 12.9547 0 0
+M  V30 6 O 8.25 10.6447 0 0
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 1 1 2
+M  V30 2 1 2 3
+M  V30 3 1 4 5
+M  V30 4 1 1 5
+M  V30 5 1 3 4
+M  V30 6 1 1 6
+M  V30 END BOND
+M  V30 LINKNODE 1 4 2 1 2 1 5
+M  V30 END CTAB
+M  END)CTAB"_ctab;
+    REQUIRE(mol);
+  }
+}

--- a/Code/GraphMol/MolEnumerator/enumerator_catch.cpp
+++ b/Code/GraphMol/MolEnumerator/enumerator_catch.cpp
@@ -119,6 +119,42 @@ M  END
       CHECK(MolToSmiles(*newmol) == "Fc1cncc(Cl)c1");
     }
   }
+
+  SECTION("PositionVariationOp unit tests 3") {
+    MolEnumerator::PositionVariationOp op;
+    op.initFromMol(*mol1);
+    auto vcnts = op.getVariationCounts();
+    REQUIRE(vcnts.size() == 1);
+    CHECK(vcnts[0] == 3);
+  }
+
+  SECTION("enumeration basics 1") {
+    MolEnumerator::MolEnumeratorParams ps;
+    ps.dp_operation = std::shared_ptr<MolEnumerator::MolEnumeratorOp>(
+        new MolEnumerator::PositionVariationOp());
+    auto bundle = MolEnumerator::enumerate(*mol1, ps);
+    CHECK(bundle.size() == 3);
+    std::vector<std::string> tsmis = {"COc1ccncc1", "COc1ccccn1", "COc1cccnc1"};
+    std::vector<std::string> smis;
+    for (const auto molp : bundle.getMols()) {
+      smis.push_back(MolToSmiles(*molp));
+    }
+    CHECK(smis == tsmis);
+  }
+  SECTION("enumeration basics 2") {
+    MolEnumerator::MolEnumeratorParams ps;
+    ps.dp_operation = std::shared_ptr<MolEnumerator::MolEnumeratorOp>(
+        new MolEnumerator::PositionVariationOp());
+    auto bundle = MolEnumerator::enumerate(*mol2, ps);
+    CHECK(bundle.size() == 4);
+    std::vector<std::string> tsmis = {"Fc1cnccc1Cl", "Fc1cncc(Cl)c1",
+                                      "Fc1cc(Cl)ccn1", "Fc1ccc(Cl)cn1"};
+    std::vector<std::string> smis;
+    for (const auto molp : bundle.getMols()) {
+      smis.push_back(MolToSmiles(*molp));
+    }
+    CHECK(smis == tsmis);
+  }
 }
 
 TEST_CASE("LINKNODE", "[MolEnumerator]") {

--- a/Code/GraphMol/MolEnumerator/enumerator_catch.cpp
+++ b/Code/GraphMol/MolEnumerator/enumerator_catch.cpp
@@ -30,7 +30,7 @@ M  V30 BEGIN ATOM
 M  V30 1 C -1.7083 2.415 0 0
 M  V30 2 C -3.042 1.645 0 0
 M  V30 3 C -3.042 0.105 0 0
-M  V30 4 C -1.7083 -0.665 0 0
+M  V30 4 N -1.7083 -0.665 0 0
 M  V30 5 C -0.3747 0.105 0 0
 M  V30 6 C -0.3747 1.645 0 0
 M  V30 7 * -0.8192 1.3883 0 0
@@ -57,9 +57,16 @@ M  END)CTAB"_ctab;
     REQUIRE(vcnts.size() == 1);
     CHECK(vcnts[0] == 3);
 
-    std::vector<size_t> elems{1};
-    std::unique_ptr<ROMol> newmol(op(elems));
-    CHECK(MolToSmiles(*newmol) == "");
+    {
+      std::vector<size_t> elems{1};
+      std::unique_ptr<ROMol> newmol(op(elems));
+      CHECK(MolToSmiles(*newmol) == "COc1ccccn1");
+    }
+    {
+      std::vector<size_t> elems{2};
+      std::unique_ptr<ROMol> newmol(op(elems));
+      CHECK(MolToSmiles(*newmol) == "COc1cccnc1");
+    }
   }
 }
 

--- a/Code/GraphMol/Wrap/MolBundle.cpp
+++ b/Code/GraphMol/Wrap/MolBundle.cpp
@@ -23,8 +23,7 @@ namespace python = boost::python;
 namespace RDKit {
 
 std::string molBundleClassDoc =
-    "A class for storing gropus of related molecules.\n\
-    Here related means that the molecules have to have the same number of atoms.\n\
+    "A class for storing groups of related molecules.\n\
 \n";
 struct molbundle_wrap {
   static void wrap() {
@@ -55,7 +54,7 @@ struct molbundle_wrap {
              "  RETURNS: True or False\n")
         .def("GetSubstructMatch",
              (PyObject * (*)(const MolBundle &m, const ROMol &query, bool,
-                             bool))GetSubstructMatch,
+                             bool)) GetSubstructMatch,
              (python::arg("self"), python::arg("query"),
               python::arg("useChirality") = false,
               python::arg("useQueryQueryMatches") = false),
@@ -77,7 +76,7 @@ struct molbundle_wrap {
              "query.\n")
         .def("GetSubstructMatches",
              (PyObject * (*)(const MolBundle &m, const ROMol &query, bool, bool,
-                             bool, unsigned int))GetSubstructMatches,
+                             bool, unsigned int)) GetSubstructMatches,
              (python::arg("self"), python::arg("query"),
               python::arg("uniquify") = true,
               python::arg("useChirality") = false,
@@ -129,7 +128,7 @@ struct molbundle_wrap {
              "  RETURNS: True or False\n")
         .def("GetSubstructMatch",
              (PyObject * (*)(const MolBundle &m, const MolBundle &query, bool,
-                             bool))GetSubstructMatch,
+                             bool)) GetSubstructMatch,
              (python::arg("self"), python::arg("query"),
               python::arg("useChirality") = false,
               python::arg("useQueryQueryMatches") = false),
@@ -152,7 +151,7 @@ struct molbundle_wrap {
 
         .def("GetSubstructMatches",
              (PyObject * (*)(const MolBundle &m, const MolBundle &query, bool,
-                             bool, bool, unsigned int))GetSubstructMatches,
+                             bool, bool, unsigned int)) GetSubstructMatches,
              (python::arg("self"), python::arg("query"),
               python::arg("uniquify") = true,
               python::arg("useChirality") = false,
@@ -190,9 +189,9 @@ struct molbundle_wrap {
 
         // ------------------------------------------------
         .def("HasSubstructMatch",
-             (bool (*)(const MolBundle &m, const ROMol &query, const SubstructMatchParameters &))helpHasSubstructMatch,
-             (python::arg("self"), python::arg("query"),
-              python::arg("params")),
+             (bool (*)(const MolBundle &m, const ROMol &query,
+                       const SubstructMatchParameters &))helpHasSubstructMatch,
+             (python::arg("self"), python::arg("query"), python::arg("params")),
              "Queries whether or not any molecule in the bundle contains a "
              "particular substructure.\n\n"
              "  ARGUMENTS:\n"
@@ -202,9 +201,10 @@ struct molbundle_wrap {
              "    - useQueryQueryMatches: use query-query matching logic\n\n"
              "  RETURNS: True or False\n")
         .def("GetSubstructMatch",
-             (PyObject * (*)(const MolBundle &m, const ROMol &query, const SubstructMatchParameters &))helpGetSubstructMatch,
-             (python::arg("self"), python::arg("query"),
-              python::arg("params")),
+             (PyObject * (*)(const MolBundle &m, const ROMol &query,
+                             const SubstructMatchParameters &))
+                 helpGetSubstructMatch,
+             (python::arg("self"), python::arg("query"), python::arg("params")),
              "Returns the indices of the atoms from the first molecule in a "
              "bundle that matches a substructure query.\n\n"
              "  ARGUMENTS:\n"
@@ -220,9 +220,10 @@ struct molbundle_wrap {
              "         this molecule that matches the first atom in the "
              "query.\n")
         .def("GetSubstructMatches",
-             (PyObject * (*)(const MolBundle &m, const ROMol &query, const SubstructMatchParameters &))helpGetSubstructMatches,
-             (python::arg("self"), python::arg("query"),
-              python::arg("params")),
+             (PyObject * (*)(const MolBundle &m, const ROMol &query,
+                             const SubstructMatchParameters &))
+                 helpGetSubstructMatches,
+             (python::arg("self"), python::arg("query"), python::arg("params")),
              "Returns tuple of all indices of the atoms from the first "
              "molecule in a bundle that matches a substructure query.\n\n"
              "  ARGUMENTS:\n"
@@ -237,9 +238,9 @@ struct molbundle_wrap {
              "         this molecule that matches the first atom in the "
              "query.\n")
         .def("HasSubstructMatch",
-             (bool (*)(const MolBundle &m, const MolBundle &query, const SubstructMatchParameters &))helpHasSubstructMatch,
-             (python::arg("self"), python::arg("query"),
-              python::arg("params")),
+             (bool (*)(const MolBundle &m, const MolBundle &query,
+                       const SubstructMatchParameters &))helpHasSubstructMatch,
+             (python::arg("self"), python::arg("query"), python::arg("params")),
              "Queries whether or not any molecule in the first bundle matches "
              "any molecule in the second bundle.\n\n"
              "  ARGUMENTS:\n"
@@ -247,9 +248,10 @@ struct molbundle_wrap {
              "    - params: parameters controlling the substructure match\n\n"
              "  RETURNS: True or False\n")
         .def("GetSubstructMatch",
-             (PyObject * (*)(const MolBundle &m, const MolBundle &query, const SubstructMatchParameters &))helpGetSubstructMatch,
-             (python::arg("self"), python::arg("query"),
-              python::arg("params")),
+             (PyObject * (*)(const MolBundle &m, const MolBundle &query,
+                             const SubstructMatchParameters &))
+                 helpGetSubstructMatch,
+             (python::arg("self"), python::arg("query"), python::arg("params")),
              "Returns the indices of the atoms from the first molecule in a "
              "bundle that matches a substructure query from a bundle.\n\n"
              "  ARGUMENTS:\n"
@@ -266,9 +268,10 @@ struct molbundle_wrap {
              "query.\n")
 
         .def("GetSubstructMatches",
-             (PyObject * (*)(const MolBundle &m, const MolBundle &query, const SubstructMatchParameters &))helpGetSubstructMatches,
-             (python::arg("self"), python::arg("query"),
-              python::arg("params")),
+             (PyObject * (*)(const MolBundle &m, const MolBundle &query,
+                             const SubstructMatchParameters &))
+                 helpGetSubstructMatches,
+             (python::arg("self"), python::arg("query"), python::arg("params")),
              "Returns tuple of all indices of the atoms from the first "
              "molecule in a bundle that matches a substructure query from the "
              "second bundle.\n\n"
@@ -283,8 +286,14 @@ struct molbundle_wrap {
              "atom in\n"
              "         this molecule that matches the first atom in the "
              "query.\n");
+    molBundleClassDoc =
+        "A class for storing groups of related molecules.\n\
+    Here related means that the molecules have to have the same number of atoms.\n\
+\n";
+    python::class_<FixedMolSizeMolBundle, python::bases<MolBundle>>(
+        "FixedMolSizeMolBundle", molBundleClassDoc.c_str(), python::init<>());
   };
 };
-}
+}  // namespace RDKit
 
 void wrap_molbundle() { RDKit::molbundle_wrap::wrap(); }

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -4817,6 +4817,25 @@ M  END
     self.assertEqual(len(Chem.MolFromSmiles('Fc1c(C)cccc1').GetSubstructMatch(b)), 0)
     self.assertEqual(len(Chem.MolFromSmiles('Fc1c(C)cccc1').GetSubstructMatches(b)), 0)
 
+  def testMolBundles3(self):
+    smis = ('CCC', 'CCO', 'CCN')
+    b = Chem.FixedMolSizeMolBundle()
+    for smi in smis:
+      b.AddMol(Chem.MolFromSmiles(smi))
+    self.assertEqual(len(b), 3)
+    self.assertEqual(b.Size(), 3)
+    with self.assertRaises(ValueError):
+      b.AddMol(Chem.MolFromSmiles('CCCC'))
+
+    b = Chem.MolBundle()
+    for smi in smis:
+      b.AddMol(Chem.MolFromSmiles(smi))
+    self.assertEqual(len(b), 3)
+    self.assertEqual(b.Size(), 3)
+    b.AddMol(Chem.MolFromSmiles('CCCC'))
+    self.assertEqual(b.Size(), 4)
+
+
   def testGithub1622(self):
     nonaromatics = (
       "C1=C[N]C=C1",  # radicals are not two electron donors

--- a/Code/GraphMol/testMolBundle.cpp
+++ b/Code/GraphMol/testMolBundle.cpp
@@ -110,45 +110,58 @@ void testExceptions() {
                        << "    testExceptions" << std::endl;
   ROMOL_SPTR mol(SmilesToMol("C1CCC1"));
 
-  MolBundle bundle;
-  TEST_ASSERT(bundle.size() == 0);
-  TEST_ASSERT(bundle.addMol(mol) == 1);
-  TEST_ASSERT(bundle.size() == 1);
   {
-    bool ok = false;
-    try {
-      bundle.addMol(ROMOL_SPTR(SmilesToMol("C1CC1")));
-    } catch (const ValueErrorException &) {
-      ok = true;
+    // FixedMolSizeMolBundle requires all molecules to have the same size
+    FixedMolSizeMolBundle bundle;
+    TEST_ASSERT(bundle.size() == 0);
+    TEST_ASSERT(bundle.addMol(mol) == 1);
+    TEST_ASSERT(bundle.size() == 1);
+    {
+      bool ok = false;
+      try {
+        bundle.addMol(ROMOL_SPTR(SmilesToMol("C1CC1")));
+      } catch (const ValueErrorException &) {
+        ok = true;
+      }
+      TEST_ASSERT(ok);
     }
-    TEST_ASSERT(ok);
+    {
+      bool ok = false;
+      try {
+        bundle.addMol(ROMOL_SPTR(SmilesToMol("CCCC")));
+      } catch (const ValueErrorException &) {
+        ok = true;
+      }
+      TEST_ASSERT(ok);
+    }
+    {
+      bool ok = false;
+      try {
+        bundle.getMol(1);
+      } catch (const IndexErrorException &) {
+        ok = true;
+      }
+      TEST_ASSERT(ok);
+    }
+    {
+      bool ok = false;
+      try {
+        bundle[1];
+      } catch (const IndexErrorException &) {
+        ok = true;
+      }
+      TEST_ASSERT(ok);
+    }
   }
   {
-    bool ok = false;
-    try {
-      bundle.addMol(ROMOL_SPTR(SmilesToMol("CCCC")));
-    } catch (const ValueErrorException &) {
-      ok = true;
-    }
-    TEST_ASSERT(ok);
-  }
-  {
-    bool ok = false;
-    try {
-      bundle.getMol(1);
-    } catch (const IndexErrorException &) {
-      ok = true;
-    }
-    TEST_ASSERT(ok);
-  }
-  {
-    bool ok = false;
-    try {
-      bundle[1];
-    } catch (const IndexErrorException &) {
-      ok = true;
-    }
-    TEST_ASSERT(ok);
+    // MolBundle requires supports different size molecules
+    MolBundle bundle;
+    TEST_ASSERT(bundle.size() == 0);
+    TEST_ASSERT(bundle.addMol(mol) == 1);
+    TEST_ASSERT(bundle.size() == 1);
+    bundle.addMol(ROMOL_SPTR(SmilesToMol("C1CC1")));
+    bundle.addMol(ROMOL_SPTR(SmilesToMol("CCCC")));
+    TEST_ASSERT(bundle.size() == 3);
   }
   BOOST_LOG(rdInfoLog) << "  Done." << std::endl;
 }

--- a/Code/JavaWrappers/CMakeLists.txt
+++ b/Code/JavaWrappers/CMakeLists.txt
@@ -21,6 +21,7 @@ if(RDK_BUILD_INCHI_SUPPORT)
 endif(RDK_BUILD_INCHI_SUPPORT)
 set(swigRDKitLibList "${swigRDKitLibList}"
   "ScaffoldNetwork;MolHash;RGroupDecomposition;SubstructLibrary;TautomerQuery;"
+  "MolEnumerator;"
   "MolStandardize;FilterCatalog;Catalogs;FMCS;MolDraw2D;FileParsers;SmilesParse;"
   "Depictor;SubstructMatch;ChemReactions;Fingerprints;ChemTransforms;"
   "Subgraphs;GraphMol;DataStructs;Trajectory;Descriptors;"

--- a/Code/JavaWrappers/MolBundle.i
+++ b/Code/JavaWrappers/MolBundle.i
@@ -1,0 +1,16 @@
+/*
+ *
+ *  Copyright (c) 2020, Greg Landrum and T5 Informatics GmbH
+ *  All rights reserved.
+ *
+ *  This file is part of the RDKit.
+ *  The contents are covered by the terms of the BSD license
+ *  which is included in the file license.txt, found at the root
+ *  of the RDKit source tree.
+ *
+ */
+%{
+#include <GraphMol/MolBundle.h>
+%}
+
+%include<GraphMol/MolBundle.h>

--- a/Code/JavaWrappers/MolEnumerator.i
+++ b/Code/JavaWrappers/MolEnumerator.i
@@ -1,0 +1,44 @@
+/*
+ *
+ *  Copyright (c) 2020, Greg Landrum and T5 Informatics GmbH
+ *  All rights reserved.
+ *
+ *  This file is part of the RDKit.
+ *  The contents are covered by the terms of the BSD license
+ *  which is included in the file license.txt, found at the root
+ *  of the RDKit source tree.
+ *
+ */
+%{
+#include <GraphMol/MolEnumerator/MolEnumerator.h>
+%}
+
+
+#if 0
+%ignore RDKit::MolEnumerator::MolEnumeratorOp::operator();
+%ignore RDKit::MolEnumerator::MolEnumeratorOp::copy;
+%ignore RDKit::MolEnumerator::PositionVariationOp::operator();
+%ignore RDKit::MolEnumerator::PositionVariationOp::copy;
+%ignore RDKit::MolEnumerator::LinkNodeOp::operator();
+%ignore RDKit::MolEnumerator::LinkNodeOp::copy;
+#endif
+
+%ignore RDKit::MolEnumerator::MolEnumeratorOp;
+%ignore RDKit::MolEnumerator::PositionVariationOp;
+%ignore RDKit::MolEnumerator::LinkNodeOp;
+
+%inline %{
+
+RDKit::MolEnumerator::MolEnumeratorParams getLinkNodeParams(){
+    RDKit::MolEnumerator::MolEnumeratorParams res;
+    res.dp_operation.reset(new RDKit::MolEnumerator::LinkNodeOp());
+    return res;
+}
+RDKit::MolEnumerator::MolEnumeratorParams getPositionVariationParams(){
+    RDKit::MolEnumerator::MolEnumeratorParams res;
+    res.dp_operation.reset(new RDKit::MolEnumerator::PositionVariationOp());
+    return res;
+}
+
+%}
+%include<GraphMol/MolEnumerator/MolEnumerator.h>

--- a/Code/JavaWrappers/gmwrapper/CMakeLists.txt
+++ b/Code/JavaWrappers/gmwrapper/CMakeLists.txt
@@ -364,6 +364,11 @@ ADD_TEST(JavaTautomerQueryTests
 	-cp "${JUNIT_JAR}${PATH_SEP}${CMAKE_JAVA_TEST_OUTDIR}${PATH_SEP}${CMAKE_CURRENT_SOURCE_DIR}/org.RDKit.jar"
 	org.RDKit.TautomerQueryTests)
 
+ADD_TEST(JavaMolEnumeratorTests
+    java -Djava.library.path=${CMAKE_CURRENT_SOURCE_DIR}
+	-cp "${JUNIT_JAR}${PATH_SEP}${CMAKE_JAVA_TEST_OUTDIR}${PATH_SEP}${CMAKE_CURRENT_SOURCE_DIR}/org.RDKit.jar"
+	org.RDKit.MolEnumeratorTests)
+
 ADD_TEST(JavaMolHashTest
     java -Djava.library.path=${CMAKE_CURRENT_SOURCE_DIR}
 	-cp "${JUNIT_JAR}${PATH_SEP}${CMAKE_JAVA_TEST_OUTDIR}${PATH_SEP}${CMAKE_CURRENT_SOURCE_DIR}/org.RDKit.jar"

--- a/Code/JavaWrappers/gmwrapper/GraphMolJava.i
+++ b/Code/JavaWrappers/gmwrapper/GraphMolJava.i
@@ -83,7 +83,6 @@
 %include "std_pair.i"
 %include "carrays.i"
 
-
 /*
  * Custom handler for longs.  The problem is described in swig-Bugs-2965875
  * and most of this solution is taken from the proposed patch in that bug report.
@@ -129,6 +128,8 @@ typedef unsigned long long int	uintmax_t;
 %shared_ptr(RDKit::QueryAtom)
 %shared_ptr(RDKit::QueryBond)
 %shared_ptr(RDKit::QueryOps)
+%shared_ptr(RDKit::MolBundle)
+%shared_ptr(RDKit::FixedMolSizeMolBundle)
 %shared_ptr(RDKit::MolSanitizeException)
 %shared_ptr(RDKit::AtomSanitizeException)
 %shared_ptr(RDKit::AtomValenceException)
@@ -201,6 +202,7 @@ typedef unsigned long long int	uintmax_t;
 %include "../QueryAtom.i"
 %include "../QueryBond.i"
 %include "../QueryOps.i"
+%include "../MolBundle.i"
 %include "../MonomerInfo.i"
 %include "../PeriodicTable.i"
 %include "../SanitException.i"
@@ -233,6 +235,7 @@ typedef unsigned long long int	uintmax_t;
 %include "../RGroupDecomposition.i"
 %include "../ScaffoldNetwork.i"
 %include "../TautomerQuery.i"
+%include "../MolEnumerator.i"
 %include "../MolHash.i"
 %include "../Streams.i"
 

--- a/Code/JavaWrappers/gmwrapper/src-test/org/RDKit/MolEnumeratorTests.java
+++ b/Code/JavaWrappers/gmwrapper/src-test/org/RDKit/MolEnumeratorTests.java
@@ -1,0 +1,89 @@
+
+//
+// Copyright (C) 2020 Greg Landrum and T5 Informatics GmbH
+//
+//
+package org.RDKit;
+
+import static org.junit.Assert.*;
+import org.junit.Test;
+
+public class MolEnumeratorTests extends  GraphMolTest {
+
+    @Test
+    public void linkNodes() {
+        RWMol mol = RWMol.MolFromMolBlock("one linknode\n"+
+"  Mrv2007 06222005102D          \n"+
+"\n"+
+"  0  0  0     0  0            999 V3000\n"+
+"M  V30 BEGIN CTAB\n"+
+"M  V30 COUNTS 6 6 0 0 0\n"+
+"M  V30 BEGIN ATOM\n"+
+"M  V30 1 C 8.25 12.1847 0 0\n"+
+"M  V30 2 C 6.9164 12.9547 0 0\n"+
+"M  V30 3 C 6.9164 14.4947 0 0\n"+
+"M  V30 4 C 9.5836 14.4947 0 0\n"+
+"M  V30 5 C 9.5836 12.9547 0 0\n"+
+"M  V30 6 O 8.25 10.6447 0 0\n"+
+"M  V30 END ATOM\n"+
+"M  V30 BEGIN BOND\n"+
+"M  V30 1 1 1 2\n"+
+"M  V30 2 1 2 3\n"+
+"M  V30 3 1 4 5\n"+
+"M  V30 4 1 1 5\n"+
+"M  V30 5 1 3 4\n"+
+"M  V30 6 1 1 6\n"+
+"M  V30 END BOND\n"+
+"M  V30 LINKNODE 1 4 2 1 2 1 5\n"+
+"M  V30 END CTAB\n"+
+"M  END");
+        MolEnumeratorParams ps = RDKFuncs.getLinkNodeParams();
+        MolBundle bndl = RDKFuncs.enumerate(mol,ps);
+        assertEquals(bndl.size(),4);
+        bndl.delete();        
+        mol.delete();
+    }
+
+    @Test
+    public void positionVariation() {
+        RWMol mol = RWMol.MolFromMolBlock("one variable attachment\n"+
+"  Mrv2007 06232015292D          \n"+
+"\n"+
+"  0  0  0     0  0            999 V3000\n"+
+"M  V30 BEGIN CTAB\n"+
+"M  V30 COUNTS 9 8 0 0 0\n"+
+"M  V30 BEGIN ATOM\n"+
+"M  V30 1 C -1.7083 2.415 0 0\n"+
+"M  V30 2 C -3.042 1.645 0 0\n"+
+"M  V30 3 C -3.042 0.105 0 0\n"+
+"M  V30 4 N -1.7083 -0.665 0 0\n"+
+"M  V30 5 C -0.3747 0.105 0 0\n"+
+"M  V30 6 C -0.3747 1.645 0 0\n"+
+"M  V30 7 * -0.8192 1.3883 0 0\n"+
+"M  V30 8 O -0.8192 3.6983 0 0\n"+
+"M  V30 9 C 0.5145 4.4683 0 0\n"+
+"M  V30 END ATOM\n"+
+"M  V30 BEGIN BOND\n"+
+"M  V30 1 1 1 2\n"+
+"M  V30 2 2 2 3\n"+
+"M  V30 3 1 3 4\n"+
+"M  V30 4 2 4 5\n"+
+"M  V30 5 1 5 6\n"+
+"M  V30 6 2 1 6\n"+
+"M  V30 7 1 7 8 ENDPTS=(3 1 5 6) ATTACH=ANY\n"+
+"M  V30 8 1 8 9\n"+
+"M  V30 END BOND\n"+
+"M  V30 END CTAB\n"+
+"M  END");
+        MolEnumeratorParams ps = RDKFuncs.getPositionVariationParams();
+        MolBundle bndl = RDKFuncs.enumerate(mol,ps);
+        assertEquals(bndl.size(),3);
+        
+        mol.delete();
+    }
+
+    public static void main(String args[]) {
+        org.junit.runner.JUnitCore.main("org.RDKit.MolEnumeratorTests");
+    }
+
+}

--- a/rdkit/Chem/AllChem.py
+++ b/rdkit/Chem/AllChem.py
@@ -33,14 +33,15 @@ from rdkit.Chem.rdPartialCharges import *
 from rdkit.Chem.rdReducedGraphs import *
 from rdkit.Chem.rdShapeHelpers import *
 from rdkit.Chem.rdqueries import *
+from rdkit.Chem.rdMolEnumerator import *
 from rdkit.Geometry import rdGeometry
 from rdkit.RDLogger import logger
 from rdkit.Chem.EnumerateStereoisomers import StereoEnumerationOptions, EnumerateStereoisomers
 
 try:
-    from rdkit.Chem.rdSLNParse import *
+  from rdkit.Chem.rdSLNParse import *
 except ImportError:
-    pass
+  pass
 
 Mol.Compute2DCoords = Compute2DCoords
 Mol.ComputeGasteigerCharges = ComputeGasteigerCharges
@@ -48,32 +49,32 @@ logger = logger()
 
 
 def TransformMol(mol, tform, confId=-1, keepConfs=False):
-    """  Applies the transformation (usually a 4x4 double matrix) to a molecule
+  """  Applies the transformation (usually a 4x4 double matrix) to a molecule
     if keepConfs is False then all but that conformer are removed
     """
-    refConf = mol.GetConformer(confId)
-    TransformConformer(refConf, tform)
-    if not keepConfs:
-        if confId == -1:
-            confId = 0
-        allConfIds = [c.GetId() for c in mol.GetConformers()]
-        for cid in allConfIds:
-            if not cid == confId:
-                mol.RemoveConformer(cid)
-        # reset the conf Id to zero since there is only one conformer left
-        mol.GetConformer(confId).SetId(0)
+  refConf = mol.GetConformer(confId)
+  TransformConformer(refConf, tform)
+  if not keepConfs:
+    if confId == -1:
+      confId = 0
+    allConfIds = [c.GetId() for c in mol.GetConformers()]
+    for cid in allConfIds:
+      if not cid == confId:
+        mol.RemoveConformer(cid)
+    # reset the conf Id to zero since there is only one conformer left
+    mol.GetConformer(confId).SetId(0)
 
 
 def ComputeMolShape(mol, confId=-1, boxDim=(20, 20, 20), spacing=0.5, **kwargs):
-    """ returns a grid representation of the molecule's shape
+  """ returns a grid representation of the molecule's shape
     """
-    res = rdGeometry.UniformGrid3D(boxDim[0], boxDim[1], boxDim[2], spacing=spacing)
-    EncodeShape(mol, res, confId, **kwargs)
-    return res
+  res = rdGeometry.UniformGrid3D(boxDim[0], boxDim[1], boxDim[2], spacing=spacing)
+  EncodeShape(mol, res, confId, **kwargs)
+  return res
 
 
 def ComputeMolVolume(mol, confId=-1, gridSpacing=0.2, boxMargin=2.0):
-    """ Calculates the volume of a particular conformer of a molecule
+  """ Calculates the volume of a particular conformer of a molecule
     based on a grid-encoding of the molecular shape.
 
     A bit of demo as well as a test of github #1883:
@@ -92,23 +93,23 @@ def ComputeMolVolume(mol, confId=-1, gridSpacing=0.2, boxMargin=2.0):
     20...
 
     """
-    mol = rdchem.Mol(mol)
-    conf = mol.GetConformer(confId)
-    CanonicalizeConformer(conf, ignoreHs=False)
-    box = ComputeConfBox(conf)
-    sideLen = (box[1].x - box[0].x + 2 * boxMargin, box[1].y - box[0].y + 2 * boxMargin,
-               box[1].z - box[0].z + 2 * boxMargin)
-    shape = rdGeometry.UniformGrid3D(sideLen[0], sideLen[1], sideLen[2], spacing=gridSpacing)
-    EncodeShape(mol, shape, confId, ignoreHs=False, vdwScale=1.0)
-    voxelVol = gridSpacing**3
-    occVect = shape.GetOccupancyVect()
-    voxels = [1 for x in occVect if x == 3]
-    vol = voxelVol * len(voxels)
-    return vol
+  mol = rdchem.Mol(mol)
+  conf = mol.GetConformer(confId)
+  CanonicalizeConformer(conf, ignoreHs=False)
+  box = ComputeConfBox(conf)
+  sideLen = (box[1].x - box[0].x + 2 * boxMargin, box[1].y - box[0].y + 2 * boxMargin,
+             box[1].z - box[0].z + 2 * boxMargin)
+  shape = rdGeometry.UniformGrid3D(sideLen[0], sideLen[1], sideLen[2], spacing=gridSpacing)
+  EncodeShape(mol, shape, confId, ignoreHs=False, vdwScale=1.0)
+  voxelVol = gridSpacing**3
+  occVect = shape.GetOccupancyVect()
+  voxels = [1 for x in occVect if x == 3]
+  vol = voxelVol * len(voxels)
+  return vol
 
 
 def GetConformerRMS(mol, confId1, confId2, atomIds=None, prealigned=False):
-    """ Returns the RMS between two conformations.
+  """ Returns the RMS between two conformations.
     By default, the conformers will be aligned to the first conformer
     before the RMS calculation and, as a side-effect, the second will be left
     in the aligned state.
@@ -124,27 +125,27 @@ def GetConformerRMS(mol, confId1, confId2, atomIds=None, prealigned=False):
                     to the first
 
     """
-    # align the conformers if necessary
-    # Note: the reference conformer is always the first one
-    if not prealigned:
-        if atomIds:
-            AlignMolConformers(mol, confIds=[confId1, confId2], atomIds=atomIds)
-        else:
-            AlignMolConformers(mol, confIds=[confId1, confId2])
+  # align the conformers if necessary
+  # Note: the reference conformer is always the first one
+  if not prealigned:
+    if atomIds:
+      AlignMolConformers(mol, confIds=[confId1, confId2], atomIds=atomIds)
+    else:
+      AlignMolConformers(mol, confIds=[confId1, confId2])
 
-    # calculate the RMS between the two conformations
-    conf1 = mol.GetConformer(id=confId1)
-    conf2 = mol.GetConformer(id=confId2)
-    ssr = 0
-    for i in range(mol.GetNumAtoms()):
-        d = conf1.GetAtomPosition(i).Distance(conf2.GetAtomPosition(i))
-        ssr += d * d
-    ssr /= mol.GetNumAtoms()
-    return numpy.sqrt(ssr)
+  # calculate the RMS between the two conformations
+  conf1 = mol.GetConformer(id=confId1)
+  conf2 = mol.GetConformer(id=confId2)
+  ssr = 0
+  for i in range(mol.GetNumAtoms()):
+    d = conf1.GetAtomPosition(i).Distance(conf2.GetAtomPosition(i))
+    ssr += d * d
+  ssr /= mol.GetNumAtoms()
+  return numpy.sqrt(ssr)
 
 
 def GetConformerRMSMatrix(mol, atomIds=None, prealigned=False):
-    """ Returns the RMS matrix of the conformers of a molecule.
+  """ Returns the RMS matrix of the conformers of a molecule.
     As a side-effect, the conformers will be aligned to the first
     conformer (i.e. the reference) and will left in the aligned state.
 
@@ -170,31 +171,30 @@ def GetConformerRMSMatrix(mol, atomIds=None, prealigned=False):
     clustering.
 
     """
-    # if necessary, align the conformers
-    # Note: the reference conformer is always the first one
-    rmsvals = []
-    confIds = [conf.GetId() for conf in mol.GetConformers()]
-    if not prealigned:
-        if atomIds:
-            AlignMolConformers(mol, atomIds=atomIds, RMSlist=rmsvals)
-        else:
-            AlignMolConformers(mol, RMSlist=rmsvals)
-    else:  # already prealigned
-        for i in range(1, len(confIds)):
-            rmsvals.append(
-              GetConformerRMS(mol, confIds[0], confIds[i], atomIds=atomIds, prealigned=prealigned))
-    # loop over the conformations (except the reference one)
-    cmat = []
+  # if necessary, align the conformers
+  # Note: the reference conformer is always the first one
+  rmsvals = []
+  confIds = [conf.GetId() for conf in mol.GetConformers()]
+  if not prealigned:
+    if atomIds:
+      AlignMolConformers(mol, atomIds=atomIds, RMSlist=rmsvals)
+    else:
+      AlignMolConformers(mol, RMSlist=rmsvals)
+  else:  # already prealigned
     for i in range(1, len(confIds)):
-        cmat.append(rmsvals[i - 1])
-        for j in range(1, i):
-            cmat.append(GetConformerRMS(mol, confIds[i],
-                        confIds[j], atomIds=atomIds, prealigned=True))
-    return cmat
+      rmsvals.append(
+        GetConformerRMS(mol, confIds[0], confIds[i], atomIds=atomIds, prealigned=prealigned))
+  # loop over the conformations (except the reference one)
+  cmat = []
+  for i in range(1, len(confIds)):
+    cmat.append(rmsvals[i - 1])
+    for j in range(1, i):
+      cmat.append(GetConformerRMS(mol, confIds[i], confIds[j], atomIds=atomIds, prealigned=True))
+  return cmat
 
 
 def EnumerateLibraryFromReaction(reaction, sidechainSets, returnReactants=False):
-    """ Returns a generator for the virtual library defined by
+  """ Returns a generator for the virtual library defined by
     a reaction and a sequence of sidechain sets
 
     >>> from rdkit import Chem
@@ -228,34 +228,34 @@ def EnumerateLibraryFromReaction(reaction, sidechainSets, returnReactants=False)
 
 
     """
-    if len(sidechainSets) != reaction.GetNumReactantTemplates():
-        raise ValueError('%d sidechains provided, %d required' % (len(sidechainSets),
-                                                                  reaction.GetNumReactantTemplates()))
+  if len(sidechainSets) != reaction.GetNumReactantTemplates():
+    raise ValueError('%d sidechains provided, %d required' %
+                     (len(sidechainSets), reaction.GetNumReactantTemplates()))
 
-    def _combiEnumerator(items, depth=0):
-        for item in items[depth]:
-            if depth + 1 < len(items):
-                v = _combiEnumerator(items, depth + 1)
-                for entry in v:
-                    l = [item]
-                    l.extend(entry)
-                    yield l
-            else:
-                yield [item]
+  def _combiEnumerator(items, depth=0):
+    for item in items[depth]:
+      if depth + 1 < len(items):
+        v = _combiEnumerator(items, depth + 1)
+        for entry in v:
+          l = [item]
+          l.extend(entry)
+          yield l
+      else:
+        yield [item]
 
-    ProductReactants = namedtuple('ProductReactants', 'products,reactants')
-    for chains in _combiEnumerator(sidechainSets):
-        prodSets = reaction.RunReactants(chains)
-        for prods in prodSets:
-            if returnReactants:
-                yield ProductReactants(prods, chains)
-            else:
-                yield prods
+  ProductReactants = namedtuple('ProductReactants', 'products,reactants')
+  for chains in _combiEnumerator(sidechainSets):
+    prodSets = reaction.RunReactants(chains)
+    for prods in prodSets:
+      if returnReactants:
+        yield ProductReactants(prods, chains)
+      else:
+        yield prods
 
 
 def ConstrainedEmbed(mol, core, useTethers=True, coreConfId=-1, randomseed=2342,
                      getForceField=UFFGetMoleculeForceField, **kwargs):
-    """ generates an embedding of a molecule where part of the molecule
+  """ generates an embedding of a molecule where part of the molecule
     is constrained to have particular coordinates
 
     Arguments
@@ -298,60 +298,60 @@ def ConstrainedEmbed(mol, core, useTethers=True, coreConfId=-1, randomseed=2342,
     True
 
     """
-    match = mol.GetSubstructMatch(core)
-    if not match:
-        raise ValueError("molecule doesn't match the core")
-    coordMap = {}
-    coreConf = core.GetConformer(coreConfId)
+  match = mol.GetSubstructMatch(core)
+  if not match:
+    raise ValueError("molecule doesn't match the core")
+  coordMap = {}
+  coreConf = core.GetConformer(coreConfId)
+  for i, idxI in enumerate(match):
+    corePtI = coreConf.GetAtomPosition(i)
+    coordMap[idxI] = corePtI
+
+  ci = EmbedMolecule(mol, coordMap=coordMap, randomSeed=randomseed, **kwargs)
+  if ci < 0:
+    raise ValueError('Could not embed molecule.')
+
+  algMap = [(j, i) for i, j in enumerate(match)]
+
+  if not useTethers:
+    # clean up the conformation
+    ff = getForceField(mol, confId=0)
     for i, idxI in enumerate(match):
-        corePtI = coreConf.GetAtomPosition(i)
-        coordMap[idxI] = corePtI
-
-    ci = EmbedMolecule(mol, coordMap=coordMap, randomSeed=randomseed, **kwargs)
-    if ci < 0:
-        raise ValueError('Could not embed molecule.')
-
-    algMap = [(j, i) for i, j in enumerate(match)]
-
-    if not useTethers:
-        # clean up the conformation
-        ff = getForceField(mol, confId=0)
-        for i, idxI in enumerate(match):
-            for j in range(i + 1, len(match)):
-                idxJ = match[j]
-                d = coordMap[idxI].Distance(coordMap[idxJ])
-                ff.AddDistanceConstraint(idxI, idxJ, d, d, 100.)
-        ff.Initialize()
-        n = 4
-        more = ff.Minimize()
-        while more and n:
-            more = ff.Minimize()
-            n -= 1
-        # rotate the embedded conformation onto the core:
-        rms = AlignMol(mol, core, atomMap=algMap)
-    else:
-        # rotate the embedded conformation onto the core:
-        rms = AlignMol(mol, core, atomMap=algMap)
-        ff = getForceField(mol, confId=0)
-        conf = core.GetConformer()
-        for i in range(core.GetNumAtoms()):
-            p = conf.GetAtomPosition(i)
-            pIdx = ff.AddExtraPoint(p.x, p.y, p.z, fixed=True) - 1
-            ff.AddDistanceConstraint(pIdx, match[i], 0, 0, 100.)
-        ff.Initialize()
-        n = 4
-        more = ff.Minimize(energyTol=1e-4, forceTol=1e-3)
-        while more and n:
-            more = ff.Minimize(energyTol=1e-4, forceTol=1e-3)
-            n -= 1
-        # realign
-        rms = AlignMol(mol, core, atomMap=algMap)
-    mol.SetProp('EmbedRMS', str(rms))
-    return mol
+      for j in range(i + 1, len(match)):
+        idxJ = match[j]
+        d = coordMap[idxI].Distance(coordMap[idxJ])
+        ff.AddDistanceConstraint(idxI, idxJ, d, d, 100.)
+    ff.Initialize()
+    n = 4
+    more = ff.Minimize()
+    while more and n:
+      more = ff.Minimize()
+      n -= 1
+    # rotate the embedded conformation onto the core:
+    rms = AlignMol(mol, core, atomMap=algMap)
+  else:
+    # rotate the embedded conformation onto the core:
+    rms = AlignMol(mol, core, atomMap=algMap)
+    ff = getForceField(mol, confId=0)
+    conf = core.GetConformer()
+    for i in range(core.GetNumAtoms()):
+      p = conf.GetAtomPosition(i)
+      pIdx = ff.AddExtraPoint(p.x, p.y, p.z, fixed=True) - 1
+      ff.AddDistanceConstraint(pIdx, match[i], 0, 0, 100.)
+    ff.Initialize()
+    n = 4
+    more = ff.Minimize(energyTol=1e-4, forceTol=1e-3)
+    while more and n:
+      more = ff.Minimize(energyTol=1e-4, forceTol=1e-3)
+      n -= 1
+    # realign
+    rms = AlignMol(mol, core, atomMap=algMap)
+  mol.SetProp('EmbedRMS', str(rms))
+  return mol
 
 
 def AssignBondOrdersFromTemplate(refmol, mol):
-    """ assigns bond orders to a molecule based on the
+  """ assigns bond orders to a molecule based on the
     bond orders in a template molecule
 
     Arguments
@@ -390,52 +390,52 @@ def AssignBondOrdersFromTemplate(refmol, mol):
     'COc1cc(-c2ccc3c(c2)Nc2ccc(CC(=O)N(C)C)cc2NC3=O)ccc1[N+](=O)[O-]'
 
     """
-    refmol2 = rdchem.Mol(refmol)
-    mol2 = rdchem.Mol(mol)
-    # do the molecules match already?
-    matching = mol2.GetSubstructMatch(refmol2)
-    if not matching:  # no, they don't match
-        # check if bonds of mol are SINGLE
-        for b in mol2.GetBonds():
-            if b.GetBondType() != BondType.SINGLE:
-                b.SetBondType(BondType.SINGLE)
-                b.SetIsAromatic(False)
-        # set the bonds of mol to SINGLE
-        for b in refmol2.GetBonds():
-            b.SetBondType(BondType.SINGLE)
-            b.SetIsAromatic(False)
-        # set atom charges to zero;
-        for a in refmol2.GetAtoms():
-            a.SetFormalCharge(0)
-        for a in mol2.GetAtoms():
-            a.SetFormalCharge(0)
+  refmol2 = rdchem.Mol(refmol)
+  mol2 = rdchem.Mol(mol)
+  # do the molecules match already?
+  matching = mol2.GetSubstructMatch(refmol2)
+  if not matching:  # no, they don't match
+    # check if bonds of mol are SINGLE
+    for b in mol2.GetBonds():
+      if b.GetBondType() != BondType.SINGLE:
+        b.SetBondType(BondType.SINGLE)
+        b.SetIsAromatic(False)
+    # set the bonds of mol to SINGLE
+    for b in refmol2.GetBonds():
+      b.SetBondType(BondType.SINGLE)
+      b.SetIsAromatic(False)
+    # set atom charges to zero;
+    for a in refmol2.GetAtoms():
+      a.SetFormalCharge(0)
+    for a in mol2.GetAtoms():
+      a.SetFormalCharge(0)
 
-        matching = mol2.GetSubstructMatches(refmol2, uniquify=False)
-        # do the molecules match now?
-        if matching:
-            if len(matching) > 1:
-                logger.warning("More than one matching pattern found - picking one")
-            matching = matching[0]
-            # apply matching: set bond properties
-            for b in refmol.GetBonds():
-                atom1 = matching[b.GetBeginAtomIdx()]
-                atom2 = matching[b.GetEndAtomIdx()]
-                b2 = mol2.GetBondBetweenAtoms(atom1, atom2)
-                b2.SetBondType(b.GetBondType())
-                b2.SetIsAromatic(b.GetIsAromatic())
-            # apply matching: set atom properties
-            for a in refmol.GetAtoms():
-                a2 = mol2.GetAtomWithIdx(matching[a.GetIdx()])
-                a2.SetHybridization(a.GetHybridization())
-                a2.SetIsAromatic(a.GetIsAromatic())
-                a2.SetNumExplicitHs(a.GetNumExplicitHs())
-                a2.SetFormalCharge(a.GetFormalCharge())
-            SanitizeMol(mol2)
-            if hasattr(mol2, '__sssAtoms'):
-                mol2.__sssAtoms = None  # we don't want all bonds highlighted
-        else:
-            raise ValueError("No matching found")
-    return mol2
+    matching = mol2.GetSubstructMatches(refmol2, uniquify=False)
+    # do the molecules match now?
+    if matching:
+      if len(matching) > 1:
+        logger.warning("More than one matching pattern found - picking one")
+      matching = matching[0]
+      # apply matching: set bond properties
+      for b in refmol.GetBonds():
+        atom1 = matching[b.GetBeginAtomIdx()]
+        atom2 = matching[b.GetEndAtomIdx()]
+        b2 = mol2.GetBondBetweenAtoms(atom1, atom2)
+        b2.SetBondType(b.GetBondType())
+        b2.SetIsAromatic(b.GetIsAromatic())
+      # apply matching: set atom properties
+      for a in refmol.GetAtoms():
+        a2 = mol2.GetAtomWithIdx(matching[a.GetIdx()])
+        a2.SetHybridization(a.GetHybridization())
+        a2.SetIsAromatic(a.GetIsAromatic())
+        a2.SetNumExplicitHs(a.GetNumExplicitHs())
+        a2.SetFormalCharge(a.GetFormalCharge())
+      SanitizeMol(mol2)
+      if hasattr(mol2, '__sssAtoms'):
+        mol2.__sssAtoms = None  # we don't want all bonds highlighted
+    else:
+      raise ValueError("No matching found")
+  return mol2
 
 
 # ------------------------------------
@@ -443,11 +443,11 @@ def AssignBondOrdersFromTemplate(refmol, mol):
 #  doctest boilerplate
 #
 def _runDoctests(verbose=None):  # pragma: nocover
-    import sys
-    import doctest
-    failed, _ = doctest.testmod(optionflags=doctest.ELLIPSIS, verbose=verbose)
-    sys.exit(failed)
+  import sys
+  import doctest
+  failed, _ = doctest.testmod(optionflags=doctest.ELLIPSIS, verbose=verbose)
+  sys.exit(failed)
 
 
 if __name__ == '__main__':  # pragma: nocover
-    _runDoctests()
+  _runDoctests()


### PR DESCRIPTION
Though what is here is already useful, I'm doing the PR to collection comments on the basic design before I do more work.

The primary goal is to be able to enumerate molecules from some of the interesting features that show up in Mol files. Three specific examples of the type of enumeration I'm thinking about.

**Position variation bonds**
This molecule with position variation bonds:
![image](https://user-images.githubusercontent.com/540511/85688524-1f230e80-b6d2-11ea-86c7-5f8cfc7f0e83.png)
Should enumerate to these four molecules:
![image](https://user-images.githubusercontent.com/540511/85688595-2c3ffd80-b6d2-11ea-8cee-068b92247fb4.png)

This enumeration is implemented in the current PR.

**Link atoms**
This molecule with a link node:
![image](https://user-images.githubusercontent.com/540511/85689780-3a424e00-b6d3-11ea-8783-e0e8fb251980.png)
Should expand to these four molecules:
![image](https://user-images.githubusercontent.com/540511/85689969-652ca200-b6d3-11ea-8086-02ab84db2dea.png)

**SRUs**
This molecule with an SRU that has associated counts:
![image](https://user-images.githubusercontent.com/540511/85690535-f734aa80-b6d3-11ea-814c-63e730f117be.png)
should expand to these three molecules:
![image](https://user-images.githubusercontent.com/540511/85690579-00257c00-b6d4-11ea-8a04-4d885af15d25.png)

The last one is not yet implemented.

Link atoms and SRUs require a change to the MolBundle class to remove the restriction that all members of the bundle have the same number of atoms and bonds. I have done that by introducing a new class - `FixedMolSizeMolBundle` - which derives from the `MolBundle` class. At the moment the only difference between the classes is that `FixedMolSizeMolBundle` checks that every molecule has the same number of atoms and bonds and `MolBundle` does not.

For this first iteration I am primarily thinking about expanding things in order to be able to do more powerful substructure queries (most/all of the enumerations I am doing in the first round cannot be expressed in SMARTS); that's why the output is a MolBundle. I think we should assume that we will be at some point in the future adding a version of `enumerate()` that returns a pair of iterators so that we can loop over the enumerated molecules without having to have them all in memory at once. I don't think the way I've written this precludes that in any way, but I would rather ensure that the basic functionality is there to help with the querying before starting along the more general case.

This is *not* targeted at reaction enumeration, but I could imagine using it at some point in the future as a more efficient way to do R-group expansion around a template (though in that case we almost certainly want to use an iterator-pair form of the enumerate function).

As an aside: we could (and should!) use this machinery to do a C++ implementation of the python `EnumerateStereiosomers()` function..

