### PR TITLE
Update to Coordgen v1.4.1

### DIFF
--- a/External/CoordGen/CMakeLists.txt
+++ b/External/CoordGen/CMakeLists.txt
@@ -69,8 +69,8 @@ if(RDK_BUILD_COORDGEN_SUPPORT)
     endif()
 
     if(NOT EXISTS "${COORDGEN_DIR}/sketcherMinimizer.h")
-        set(RELEASE_NO "1.4.0")
-        set(MD5 "5f663c8809b494f0548dd504c011c739")
+        set(RELEASE_NO "1.4.1")
+        set(MD5 "d9a925c9569bc08e241a01669f43d639")
         downloadAndCheckMD5("https://github.com/schrodinger/coordgenlibs/archive/v${RELEASE_NO}.tar.gz"
               "${CMAKE_CURRENT_SOURCE_DIR}/coordgenlibs-${RELEASE_NO}.tar.gz" ${MD5})
         execute_process(COMMAND ${CMAKE_COMMAND} -E tar zxf


### PR DESCRIPTION
This updates to build against the latest Coordgen release, v1.4.1. 

This new release only includes some performance improvements.