### PR TITLE
ScaffoldNetwork: add feature to count the number of molecules a scaffold originates from

### DIFF
--- a/Code/GraphMol/ScaffoldNetwork/ScaffoldNetwork.h
+++ b/Code/GraphMol/ScaffoldNetwork/ScaffoldNetwork.h
@@ -25,6 +25,7 @@
 #include <boost/archive/text_iarchive.hpp>
 #include <boost/serialization/vector.hpp>
 #include <boost/serialization/shared_ptr.hpp>
+#include <boost/serialization/version.hpp>
 #include <RDGeneral/BoostEndInclude.h>
 #endif
 
@@ -52,6 +53,8 @@ struct RDKIT_SCAFFOLDNETWORK_EXPORT ScaffoldNetworkParams {
       true;  ///< remove chirality and bond stereo when flattening
   bool flattenKeepLargest =
       true;  ///< keep only the largest fragment when doing flattening
+  bool collectMolCounts = true;  ///< keep track of the number of molecules each
+                                 ///< scaffold was reached from
 
   std::vector<std::shared_ptr<ChemicalReaction>>
       bondBreakersRxns;  ///< the reaction(s) used to fragment. Should expect a
@@ -100,6 +103,8 @@ struct RDKIT_SCAFFOLDNETWORK_EXPORT ScaffoldNetwork {
   std::vector<std::string> nodes;  ///< SMILES for the scaffolds
   std::vector<unsigned>
       counts;  ///< number of times each scaffold was encountered
+  std::vector<unsigned>
+      molCounts;  ///< number of molecules each scaffold was found in
   std::vector<NetworkEdge> edges;  ///< edges in the network
   ScaffoldNetwork(){};
 #ifdef RDK_USE_BOOST_SERIALIZATION
@@ -116,6 +121,9 @@ struct RDKIT_SCAFFOLDNETWORK_EXPORT ScaffoldNetwork {
     RDUNUSED_PARAM(version);
     ar &nodes;
     ar &counts;
+    if (version > 0) {
+      ar &molCounts;
+    }
     ar &edges;
   }
 #endif
@@ -173,5 +181,6 @@ RDKIT_SCAFFOLDNETWORK_EXPORT ScaffoldNetworkParams getBRICSNetworkParams();
 
 }  // namespace ScaffoldNetwork
 }  // namespace RDKit
+BOOST_CLASS_VERSION(RDKit::ScaffoldNetwork::ScaffoldNetwork, 1)
 
 #endif

--- a/Code/GraphMol/ScaffoldNetwork/ScaffoldNetwork.h
+++ b/Code/GraphMol/ScaffoldNetwork/ScaffoldNetwork.h
@@ -181,6 +181,14 @@ RDKIT_SCAFFOLDNETWORK_EXPORT ScaffoldNetworkParams getBRICSNetworkParams();
 
 }  // namespace ScaffoldNetwork
 }  // namespace RDKit
-BOOST_CLASS_VERSION(RDKit::ScaffoldNetwork::ScaffoldNetwork, 1)
+
+namespace boost {
+namespace serialization {
+template <>
+struct version<RDKit::ScaffoldNetwork::ScaffoldNetwork> {
+  BOOST_STATIC_CONSTANT(unsigned int, value = 1);
+};
+}  // namespace serialization
+}  // namespace boost
 
 #endif

--- a/Code/GraphMol/ScaffoldNetwork/ScaffoldNetwork.h
+++ b/Code/GraphMol/ScaffoldNetwork/ScaffoldNetwork.h
@@ -186,7 +186,7 @@ namespace boost {
 namespace serialization {
 template <>
 struct version<RDKit::ScaffoldNetwork::ScaffoldNetwork> {
-  BOOST_STATIC_CONSTANT(unsigned int, value = 1);
+  BOOST_STATIC_CONSTANT(int, value = 1);
 };
 }  // namespace serialization
 }  // namespace boost

--- a/Code/GraphMol/ScaffoldNetwork/Wrap/rdScaffoldNetwork.cpp
+++ b/Code/GraphMol/ScaffoldNetwork/Wrap/rdScaffoldNetwork.cpp
@@ -24,14 +24,21 @@ ScaffoldNetwork::ScaffoldNetwork *createNetworkHelper(
     const ScaffoldNetwork::ScaffoldNetworkParams &params) {
   auto mols = pythonObjectToVect<ROMOL_SPTR>(pmols);
   ScaffoldNetwork::ScaffoldNetwork *res = new ScaffoldNetwork::ScaffoldNetwork;
-  updateScaffoldNetwork(*mols, *res, params);
+  {
+    NOGIL gil;
+
+    updateScaffoldNetwork(*mols, *res, params);
+  }
   return res;
 }
 void updateNetworkHelper(python::object pmols,
                          ScaffoldNetwork::ScaffoldNetwork &net,
                          const ScaffoldNetwork::ScaffoldNetworkParams &params) {
   auto mols = pythonObjectToVect<ROMOL_SPTR>(pmols);
-  updateScaffoldNetwork(*mols, net, params);
+  {
+    NOGIL gil;
+    updateScaffoldNetwork(*mols, net, params);
+  }
 }
 
 ScaffoldNetwork::ScaffoldNetworkParams *getBRICSParams() {
@@ -123,7 +130,11 @@ BOOST_PYTHON_MODULE(rdScaffoldNetwork) {
       .def_readwrite(
           "flattenKeepLargest",
           &ScaffoldNetwork::ScaffoldNetworkParams::flattenKeepLargest,
-          "keep only the largest fragment when doing flattening");
+          "keep only the largest fragment when doing flattening")
+      .def_readwrite("collectMolCounts",
+                     &ScaffoldNetwork::ScaffoldNetworkParams::collectMolCounts,
+                     "keep track of the number of molecules each scaffold was "
+                     "found in");
 
   python::enum_<ScaffoldNetwork::EdgeType>("EdgeType")
       .value("Fragment", ScaffoldNetwork::EdgeType::Fragment)
@@ -154,6 +165,8 @@ BOOST_PYTHON_MODULE(rdScaffoldNetwork) {
       .def_readonly("counts", &ScaffoldNetwork::ScaffoldNetwork::counts,
                     "the number of times each node was encountered while "
                     "building the network.")
+      .def_readonly("molCounts", &ScaffoldNetwork::ScaffoldNetwork::molCounts,
+                    "the number of moleclues each node was found in.")
       .def_readonly("edges", &ScaffoldNetwork::ScaffoldNetwork::edges,
                     "the sequence of network edges");
 


### PR DESCRIPTION
This is a more intuitive measure of how often a scaffold "appears" in a dataset than the current `counts` metric, which is almost an implementation detail.

Since you can never be sure, I benchmarked this on a set of ~20K molecules and the new feature doesn't make the code take measurably longer to run