### PR TITLE
Stop trying to assign hybridization to actinides

### DIFF
--- a/Code/GraphMol/ConjugHybrid.cpp
+++ b/Code/GraphMol/ConjugHybrid.cpp
@@ -125,11 +125,7 @@ void setConjugation(ROMol &mol) {
   // start with all bonds being marked unconjugated
   // except for aromatic bonds
   for (auto bond : mol.bonds()) {
-    if (bond->getIsAromatic()) {
-      bond->setIsConjugated(true);
-    } else {
-      bond->setIsConjugated(false);
-    }
+    bond->setIsConjugated(bond->getIsAromatic());
   }
 
   // loop over each atom and check if the bonds connecting to it can

--- a/Code/GraphMol/catch_graphmol.cpp
+++ b/Code/GraphMol/catch_graphmol.cpp
@@ -19,6 +19,7 @@
 #include <GraphMol/SmilesParse/SmilesParse.h>
 #include <GraphMol/SmilesParse/SmilesWrite.h>
 #include <GraphMol/SmilesParse/SmartsWrite.h>
+#include <boost/format.hpp>
 
 using namespace RDKit;
 #if 1
@@ -1311,5 +1312,26 @@ TEST_CASE("github #3150 MolOps::removeHs removes hydrides", "[bug][molops]") {
     MolOps::removeAllHs(cp);
     CHECK(cp.getNumAtoms() == 1);
     CHECK(MolOps::getFormalCharge(cp) == 1);
+  }
+}
+
+TEST_CASE("hybridization of unknown atom types", "[bug][molops]") {
+  SECTION("Basics") {
+    auto m = "[U][U][U]"_smiles;
+    REQUIRE(m);
+    for (const auto atom : m->atoms()) {
+      CHECK(atom->getHybridization() == Atom::HybridizationType::S);
+    }
+  }
+  SECTION("comprehensive") {
+    std::string smiles = "";
+    for (unsigned int i = 89; i <= 118; ++i) {
+      smiles += (boost::format("[#%d]") % i).str();
+    }
+    std::unique_ptr<ROMol> m(SmilesToMol(smiles));
+    REQUIRE(m);
+    for (const auto atom : m->atoms()) {
+      CHECK(atom->getHybridization() == Atom::HybridizationType::S);
+    }
   }
 }


### PR DESCRIPTION
There's no sense trying to assign reasonable hybridization states to the actinides. They don't really make sense and end up with silly molecule renderings. This changes the behavior so that anything past Ac just gets assigned "S" as its hybridization state.

There's also some cleanup in this PR

