### PR TITLE
Fixes #3267

### DIFF
--- a/Code/MinimalLib/docker/Dockerfile
+++ b/Code/MinimalLib/docker/Dockerfile
@@ -34,8 +34,8 @@ RUN ./emsdk update-tags && \
 RUN mkdir /src
 WORKDIR /src
 ENV RDBASE=/src/rdkit
-ARG RDKIT_BRANCH=fix/github3267
-RUN git clone https://github.com/greglandrum/rdkit.git
+ARG RDKIT_BRANCH=master
+RUN git clone https://github.com/rdkit/rdkit.git
 WORKDIR $RDBASE
 RUN git checkout $RDKIT_BRANCH
 

--- a/Code/MinimalLib/docker/Dockerfile
+++ b/Code/MinimalLib/docker/Dockerfile
@@ -34,7 +34,7 @@ RUN ./emsdk update-tags && \
 RUN mkdir /src
 WORKDIR /src
 ENV RDBASE=/src/rdkit
-ARG RDKIT_BRANCH=dev/update_emscripten_build 
+ARG RDKIT_BRANCH=fix/github3267
 RUN git clone https://github.com/greglandrum/rdkit.git
 WORKDIR $RDBASE
 RUN git checkout $RDKIT_BRANCH
@@ -44,7 +44,7 @@ WORKDIR build
 
 RUN echo "source /opt/emsdk/emsdk_env.sh" >> ~/.bashrc
 SHELL ["/bin/bash", "-c", "-l"]
-RUN emcmake cmake -DBoost_INCLUDE_DIR=/opt/boost/include -DRDK_BUILD_FREETYPE_SUPPORT=ON -DRDK_BUILD_MINIMAL_LIB=ON \
+RUN emcmake cmake -DBoost_INCLUDE_DIR=/opt/boost/include -DRDK_BUILD_FREETYPE_SUPPORT=OFF -DRDK_BUILD_MINIMAL_LIB=ON \
   -DRDK_BUILD_PYTHON_WRAPPERS=OFF -DRDK_BUILD_CPP_TESTS=OFF -DRDK_BUILD_INCHI_SUPPORT=ON \
   -DRDK_USE_BOOST_SERIALIZATION=OFF -DRDK_OPTIMIZE_POPCNT=OFF -DRDK_BUILD_THREADSAFE_SSS=OFF \
   -DRDK_BUILD_DESCRIPTORS3D=OFF -DRDK_TEST_MULTITHREADED=OFF -DRDK_BUILD_COORDGEN_SUPPORT=OFF \

--- a/Code/MinimalLib/docker/Dockerfile
+++ b/Code/MinimalLib/docker/Dockerfile
@@ -25,18 +25,17 @@ WORKDIR /opt
 RUN git clone https://github.com/emscripten-core/emsdk.git
 
 WORKDIR /opt/emsdk
-# the embind output seems to only work with fastcomp, not upstream (Oct 2019)
 RUN ./emsdk update-tags && \
-  ./emsdk install latest-fastcomp && \
-  ./emsdk activate latest-fastcomp
+  ./emsdk install latest && \
+  ./emsdk activate latest
 
 #RUN source ./emsdk_env.sh
 
 RUN mkdir /src
 WORKDIR /src
 ENV RDBASE=/src/rdkit
-ARG RDKIT_BRANCH
-RUN git clone https://github.com/rdkit/rdkit.git
+ARG RDKIT_BRANCH=dev/update_emscripten_build 
+RUN git clone https://github.com/greglandrum/rdkit.git
 WORKDIR $RDBASE
 RUN git checkout $RDKIT_BRANCH
 
@@ -45,7 +44,7 @@ WORKDIR build
 
 RUN echo "source /opt/emsdk/emsdk_env.sh" >> ~/.bashrc
 SHELL ["/bin/bash", "-c", "-l"]
-RUN emconfigure cmake -DBoost_INCLUDE_DIR=/opt/boost/include -DRDK_BUILD_MINIMAL_LIB=ON \
+RUN emcmake cmake -DBoost_INCLUDE_DIR=/opt/boost/include -DRDK_BUILD_FREETYPE_SUPPORT=ON -DRDK_BUILD_MINIMAL_LIB=ON \
   -DRDK_BUILD_PYTHON_WRAPPERS=OFF -DRDK_BUILD_CPP_TESTS=OFF -DRDK_BUILD_INCHI_SUPPORT=ON \
   -DRDK_USE_BOOST_SERIALIZATION=OFF -DRDK_OPTIMIZE_POPCNT=OFF -DRDK_BUILD_THREADSAFE_SSS=OFF \
   -DRDK_BUILD_DESCRIPTORS3D=OFF -DRDK_TEST_MULTITHREADED=OFF -DRDK_BUILD_COORDGEN_SUPPORT=OFF \

--- a/Code/MinimalLib/tests/tests.js
+++ b/Code/MinimalLib/tests/tests.js
@@ -87,8 +87,6 @@ Module.onRuntimeInitialized = () => {
     test_basics();
     test_sketcher_services();
     test_sketcher_services2();
+    console.log("Tests finished successfully");
 };
-
-
-
 

--- a/Code/RDStreams/CMakeLists.txt
+++ b/Code/RDStreams/CMakeLists.txt
@@ -24,5 +24,5 @@ add_definitions(-DRDKIT_RDSTREAMS_BUILD)
 set(boost_iostreams Boost::iostreams)
 endif(RDK_USE_BOOST_IOSTREAMS)
 rdkit_library(RDStreams streams.cpp
-              LINK_LIBRARIES ${boost_iostrems} ${zlib_lib})
+              LINK_LIBRARIES ${boost_iostreams} ${zlib_lib})
 rdkit_headers(streams.h DEST RDStreams)

--- a/Code/RDStreams/CMakeLists.txt
+++ b/Code/RDStreams/CMakeLists.txt
@@ -21,7 +21,8 @@ else()
 endif()
 
 add_definitions(-DRDKIT_RDSTREAMS_BUILD)
+set(boost_iostreams Boost::iostreams)
 endif(RDK_USE_BOOST_IOSTREAMS)
 rdkit_library(RDStreams streams.cpp
-              LINK_LIBRARIES Boost::iostreams ${zlib_lib})
+              LINK_LIBRARIES ${boost_iostrems} ${zlib_lib})
 rdkit_headers(streams.h DEST RDStreams)


### PR DESCRIPTION
Two main (small) changes here:
- get `RDStreams` to build properly when `RDK_USE_BOOST_IOSTREAMS` is off
- update to use the new versions of the emscripten tools properly

This should not be merged until after the `Dockerfile` has been changed to point at master again.