### PR TITLE
Avoid really slow Windows conda builds

### DIFF
--- a/Code/cmake/Modules/RDKitUtils.cmake
+++ b/Code/cmake/Modules/RDKitUtils.cmake
@@ -216,21 +216,6 @@ function(downloadAndCheckMD5 url target md5chksum)
   endif()
 endfunction(downloadAndCheckMD5)
 
-function(overwriteIfChanged src dest)
-  set(overwrite TRUE)
-  if (EXISTS "${dest}")
-    computeMD5("${dest}" destMD5)
-    computeMD5("${src}" srcMD5)
-    if (${destMD5} STREQUAL ${srcMD5})
-      set(overwrite FALSE)
-    endif()
-  endif()
-  if (overwrite)
-    get_filename_component(destDir "${dest}" DIRECTORY)
-    file(COPY "${src}" DESTINATION "${destDir}")
-  endif()
-endfunction(overwriteIfChanged)
-
 function(createExportTestHeaders)
   file(GLOB_RECURSE cmakeLists LIST_DIRECTORIES false
        ${CMAKE_SOURCE_DIR}/CMakeLists.txt)
@@ -284,8 +269,10 @@ function(createExportTestHeaders)
       "#undef RDKIT_${exportLib}_BUILD\n"
       "#endif\n")
   endforeach()
-  overwriteIfChanged("${CMAKE_BINARY_DIR}/${exportPath}.tmp" "${CMAKE_SOURCE_DIR}/${exportPath}")
-  overwriteIfChanged("${CMAKE_BINARY_DIR}/${testPath}.tmp" "${CMAKE_SOURCE_DIR}/${testPath}")
+  execute_process(COMMAND ${CMAKE_COMMAND} -E copy_if_different
+    "${CMAKE_BINARY_DIR}/${exportPath}.tmp" "${CMAKE_SOURCE_DIR}/${exportPath}")
+  execute_process(COMMAND ${CMAKE_COMMAND} -E copy_if_different
+    "${CMAKE_BINARY_DIR}/${testPath}.tmp" "${CMAKE_SOURCE_DIR}/${testPath}")
 endfunction(createExportTestHeaders)
 
 function(patchCoordGenMaeExportHeaders keyword path)

--- a/Code/cmake/Modules/RDKitUtils.cmake
+++ b/Code/cmake/Modules/RDKitUtils.cmake
@@ -247,7 +247,7 @@ function(createExportTestHeaders)
   list(REMOVE_DUPLICATES exportLibs)
   list(SORT exportLibs)
   set(exportPath "Code/RDGeneral/export.h")
-  file(WRITE "${CMAKE_BINARY_DIR}/${exportPath}"
+  file(WRITE "${CMAKE_BINARY_DIR}/${exportPath}.tmp"
     "// auto-generated __declspec definition header\n"
     "#pragma once\n"
     "#ifndef SWIG\n"
@@ -259,12 +259,12 @@ function(createExportTestHeaders)
     "#include <boost/config.hpp>\n"
     "#endif\n")
   set(testPath "Code/RDGeneral/test.h")
-  file(WRITE "${CMAKE_BINARY_DIR}/${testPath}"
+  file(WRITE "${CMAKE_BINARY_DIR}/${testPath}.tmp"
     "// auto-generated header to be imported in all cpp tests\n"
     "#pragma once\n")
   foreach(exportLib ${exportLibs})
     string(TOUPPER "${exportLib}" exportLib)
-    file(APPEND "${CMAKE_BINARY_DIR}/${exportPath}"
+    file(APPEND "${CMAKE_BINARY_DIR}/${exportPath}.tmp"
       "\n"
       "// RDKIT_${exportLib}_EXPORT definitions\n"
       "#if defined(BOOST_HAS_DECLSPEC) && defined(RDKIT_DYN_LINK) && !defined(SWIG)\n"
@@ -278,14 +278,14 @@ function(createExportTestHeaders)
       "#define RDKIT_${exportLib}_EXPORT\n"
       "#endif\n"
       "// RDKIT_${exportLib}_EXPORT end definitions\n")
-    file(APPEND "${CMAKE_BINARY_DIR}/${testPath}"
+    file(APPEND "${CMAKE_BINARY_DIR}/${testPath}.tmp"
       "\n"
       "#ifdef RDKIT_${exportLib}_BUILD\n"
       "#undef RDKIT_${exportLib}_BUILD\n"
       "#endif\n")
   endforeach()
-  overwriteIfChanged("${CMAKE_BINARY_DIR}/${exportPath}" "${CMAKE_SOURCE_DIR}/${exportPath}")
-  overwriteIfChanged("${CMAKE_BINARY_DIR}/${testPath}" "${CMAKE_SOURCE_DIR}/${testPath}")
+  overwriteIfChanged("${CMAKE_BINARY_DIR}/${exportPath}.tmp" "${CMAKE_SOURCE_DIR}/${exportPath}")
+  overwriteIfChanged("${CMAKE_BINARY_DIR}/${testPath}.tmp" "${CMAKE_SOURCE_DIR}/${testPath}")
 endfunction(createExportTestHeaders)
 
 function(patchCoordGenMaeExportHeaders keyword path)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! 
-->
#### Reference Issue
Each `conda` incremental build on Windows was starting from scratch driving me _slightly_ nervous.

#### What does this implement/fix? Explain your changes.
This change avoids that if `CMAKE_BINARY_DIR==CMAKE_SOURCE_DIR` (as in `conda` builds)
`export.h` is overwritten at each incremental build causing the whole RDKit to be rebuilt every time.


#### Any other comments?

