### PR TITLE
ScaffoldNetwork not in C# wrappers

### DIFF
--- a/Code/JavaWrappers/ScaffoldNetwork.i
+++ b/Code/JavaWrappers/ScaffoldNetwork.i
@@ -21,3 +21,10 @@ typedef std::vector<unsigned> UINT_VECT;
 %include <GraphMol/ScaffoldNetwork/ScaffoldNetwork.h>
 %template(createScaffoldNetwork) RDKit::ScaffoldNetwork::createScaffoldNetwork<std::vector<boost::shared_ptr<RDKit::ROMol>>>;
 
+// this is needed for the csharp wrappers to access count values as it does
+// not seem to be possible to wrap std::vector<unsigned>
+%extend RDKit::ScaffoldNetwork::ScaffoldNetwork {
+    unsigned int nodeCount(unsigned int nodeNumber) {
+        return $self->counts.at(nodeNumber);
+    }
+}

--- a/Code/JavaWrappers/csharp_wrapper/GraphMolCSharp.i
+++ b/Code/JavaWrappers/csharp_wrapper/GraphMolCSharp.i
@@ -250,7 +250,10 @@ typedef unsigned long long int	uintmax_t;
 %include "../MolDraw2D.i"
 %include "../FilterCatalog.i"
 %include "../Trajectory.i"
+%include "../RGroupDecomposition.i"
 %include "../SubstructLibrary.i"
+%include "../ScaffoldNetwork.i"
+%include "../TautomerQuery.i"
 %include "../MolHash.i"
 %include "../Streams.i"
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! 
-->

#### What does this implement/fix? Explain your changes.

Exposes ScaffoldNetwork, TautomerQuery and RGroupDecomposition to SWIG C# wrappers. 

#### Any other comments?

I can't get ScaffoldNetwork.counts to wrap properly in C#, so I added an helper extension method.

On Linux building the C# wrappers does not wrap std::vector&lt;unsigned&gt;.  Adding a SWIG template for std::vector&lt;unsigned&gt; breaks the build because of conflicts with the template for std::vector&lt;boost::uint32_t&gt;.  Other than the extension method I was unable to find a workaround.  Interestingly, the Java wrappers do not have this problem with the std::vector&lt;boost::uint32_t&gt; template applied to std::vector&lt;unsigned&gt;.

