### PR TITLE
[WIP] Add deprotection library

### DIFF
--- a/Code/GraphMol/CMakeLists.txt
+++ b/Code/GraphMol/CMakeLists.txt
@@ -79,6 +79,7 @@ add_subdirectory(MolHash)
 add_subdirectory(MMPA)
 
 add_subdirectory(CIPLabeler)
+add_subdirectory(Deprotect)
 
 if(RDK_BUILD_STRUCTCHECKER_SUPPORT)
 add_subdirectory(StructChecker)

--- a/Code/GraphMol/Deprotect/CMakeLists.txt
+++ b/Code/GraphMol/Deprotect/CMakeLists.txt
@@ -1,0 +1,18 @@
+remove_definitions(-DRDKIT_GRAPHMOL_BUILD)
+add_definitions(-DRDKIT_DEPROTECT_BUILD)
+rdkit_library(Deprotect
+              Deprotect.cpp
+              LINK_LIBRARIES ChemReactions 
+	      FilterCatalog Descriptors Fingerprints DataStructs Depictor
+              FileParsers SubstructMatch ChemTransforms GraphMol ${RDKit_SERIALIZATION_LIBS})
+
+
+rdkit_headers(Deprotect.h
+              DEST GraphMol/Deprotect)
+
+if(RDK_BUILD_PYTHON_WRAPPERS)
+  add_subdirectory(Wrap)
+endif()
+
+rdkit_catch_test(deprotectTest deprotectTest.cpp LINK_LIBRARIES Deprotect )
+

--- a/Code/GraphMol/Deprotect/Deprotect.cpp
+++ b/Code/GraphMol/Deprotect/Deprotect.cpp
@@ -1,0 +1,98 @@
+#include "Deprotect.h"
+#include <GraphMol/RDKitBase.h>
+#include <GraphMol/SmilesParse/SmilesWrite.h>
+#include <GraphMol/ChemReactions/ReactionParser.h>
+
+#include <boost/smart_ptr.hpp>
+
+namespace RDKit {
+
+DeprotectData::DeprotectData(const std::string &deprotection_class,
+			     const std::string &reaction_smarts,
+			     const std::string &abbreviation,
+			     const std::string &full_name):
+
+  deprotection_class(deprotection_class), 
+  reaction_smarts(reaction_smarts), 
+  abbreviation(abbreviation),
+  full_name(full_name), 
+  rxn(RxnSmartsToChemicalReaction(reaction_smarts))
+{
+  if (rxn.get())
+    rxn->initReactantMatchers();
+}
+
+const std::vector<DeprotectData> &getDeprotections() {
+  static const std::vector<DeprotectData> deprotections {
+     {"alcohol", "CC(C)([Si](C)(C)[O;H0:1])C>>[O;H1:1]", "TBDMS", "tert-butyldimethylsilyl"},
+     {"alcohol", "COc1ccc(C([O;H0:1])(c2ccccc2)c2ccccc2)cc1>>[O;H1:1]", "MMT", "methoxytrityl"},
+     {"alcohol", "O1C([O;H0:1])[C;H2][C;H2][C;H2][C;H2]1>>[O;H1:1]", "THP", "tetrahydropyranyl"},
+     {"alcohol", "[C;H3][O;X2&R0][C;H2&R0][O;H0:1]>>[O;H1:1]", "MOM", "methoxymethyl_ether"},
+     {"alcohol", "[C;R0][O;R0][C;R0][C;R0][O;R0][C;R0][O;X2:1]>>[O;H1:1]", "MEM", "β-Methoxyethoxymethyl_ether"},
+     {"alcohol", "[O;!$(*C(=O)):1]c1[c;H1][c;H1][c;H1][c;H1][c;H1]1>>[O;H1:1]", "Bn", "benzyl"},
+     {"alcohol", "[O;H0&X2:1][Si]([C;H3])([C;H3])([C;H3])>>[O;H1:1]", "TMS", "trimethylsilyl"},
+     {"alcohol", "[O;H0:1]C(=O)c1[c;H1][c;H1][c;H1][c;H1][c;H1]1>>[O;H1:1]", "Bz", "benzoyl"},
+     {"alcohol", "[O;H0:1][C;R0](=O)[C;R0]([C;H3])([C;H3])[C;H3]>>[O;H1:1]", "Piv", "pivaloyl"},
+     {"alcohol", "[O;H0:1][Si](C(C)C)(C(C)C)(C(C)C)>>[O;H1:1]", "TIPS", "triisopropylsilyl"},
+     {"alcohol", "[O;R0:1][C;R0](=O)[C;H3]>>[O:1]", "Ac", "acetyl"},
+     {"alcohol", "[c;H1]1[c;H1]c(O[C;H3])[c;H1][c;H1]c1[C;H2][O;D2&R0:1]>>[O;H1:1]", "PMB", "para-methoxybenzyl_ether"},
+     {"alcohol", "c1ccc(C([NX3;H0,H1,H2:1])(c2ccccc2)c2ccccc2)cc1>>[N:1]", "Tr", "triphenylmethyl"},
+     {"amine", "O=C1[N;H0:1]C(c2[c;H1][c;H1][c;H1][c;H1]c21)=O>>[N:1]", "Phth", "phthaloyl"},
+     {"amine", "[#7:1]COCC[Si]([C;R0])([C;R0])[C;R0]>>[#7:1]", "SEM", "trimethylsilylethoxymethyl"},
+     {"amine", "[C;H3;R0][O;R0]c1[c;H1][c;H1][c]([NX3;H0,H1;!$(NC=O):1])[c;H1][c;H1]1>>[N:1]", "PMP", "para-methoxyphenyl"},
+     {"amine", "[C;H3]c1[c;H1][c;H1]c(S(=O)(=O)[NX3;H0,H1;!$(NC=O):1])[c;H1][c;H1]1>>[N:1]", "Ts", "tosyl"},
+     {"amine", "[C;R0][C;R0]([C;R0])([O;R0][C;R0](=[O;R0])[NX3;H0,H1:1])C>>[N:1]", "Boc", "tert-butyloxycarbonyl"},
+     {"amine", "[N;H0,H1:1]C(=O)C(F)(F)F>>[N:1]", "TFA", "trifluoroacetyl"},
+     {"amine", "[NX3;H0,H1;!$(NC=O):1]C(=O)c1[c;H1][c;H1][c;H1][c;H1][c;H1]1>>[N:1]", "Bz", "benzoyl"},
+     {"amine", "[NX3;H0,H1;!$(NC=O):1]C(OCC1C(cccc2)c2c3c1cccc3)=O>>[N:1]", "Fmoc", "9-fluorenylmethyloxycarbonyl"},
+     {"amine", "[NX3;H0,H1;!$(NC=O):1][C;H2]c1[c;H1][c;H1][c;H1][c;H1][c;H1]1>>[N:1]", "Bn", "benzyl"},
+     {"amine", "[NX3;H0,H1;!$(NC=O):1][C;R0](=O)[C;H3]>>[N:1]", "Ac", "acetamide"},
+     {"amine", "[NX3;H0,H1;!$(NC=O):1][C;R0](=O)[O;R0][C;R0]c1[c;H1][c;H1][c;H1][c;H1][c;H1]1>>[N:1]", "Cbz", "carbobenzyloxy"}
+  };
+  return deprotections;
+}
+  
+std::unique_ptr<ROMol> deprotect(const ROMol& mol, const std::vector<DeprotectData> &deprotections) {
+  std::set<std::string> found;
+  std::vector<std::string> deprotections_used;
+  
+  bool something_happened = true;
+  auto m = boost::make_shared<ROMol>(mol);
+  while (something_happened) {
+    something_happened = false;
+    for(auto & deprotect : deprotections) {
+      if (!deprotect.isValid()) {
+	// error and contine;
+	continue;
+      }
+      MOL_SPTR_VECT rVect = { m };
+      auto results = deprotect.rxn->runReactants(rVect);
+      for( auto &prods : results ) {
+	CHECK_INVARIANT(prods.size() == 1, "Number of products in deprotection reaction must be one");
+	auto prod = prods[0];
+	try {
+	  RDLog::BlockLogs blocker;
+	  MolOps::sanitizeMol(*dynamic_cast<RWMol*>(prod.get()));
+	} catch (MolSanitizeException &) {
+	  continue;
+	}
+
+	auto smiles = MolToSmiles(*prod);
+	if (found.find(smiles) == found.end()) {
+	  found.insert(smiles);
+	  deprotections_used.push_back(deprotect.abbreviation);
+	  something_happened = true;
+	  m = prod;
+	  break;//  prods : results
+	}
+      }
+    }
+  }
+
+  m->setProp("DEPROTECTIONS", deprotections_used);
+  m->setProp<int>("DEPROTECTION_COUNT", deprotections_used.size());
+  return std::unique_ptr<ROMol>(new ROMol(*m.get()));
+};
+
+}
+

--- a/Code/GraphMol/Deprotect/Deprotect.h
+++ b/Code/GraphMol/Deprotect/Deprotect.h
@@ -1,0 +1,68 @@
+#ifndef RDK_DEPROTECT_LIBRARY
+#define RDK_DEPROTECT_LIBRARY
+
+#include <RDGeneral/export.h>
+#include <GraphMol/RDKitBase.h>
+#include <GraphMol/ChemReactions/Reaction.h>
+#include <string>
+
+namespace RDKit
+{
+
+/*! Data for Deprotecting molecules
+
+ Deprotects are described as reactions that remove the protecting
+  group and leave behind the group being protected.
+
+  Each DeprotectData has the following attributes:
+
+    - <b>deprotection_class</b> functional group being protected (i.e. amine, alcohol, ...)
+    - <b>reaction_smarts</b> the reaction smarts pattern for removing the protecting group
+    - <b>abbreviation</b> common abbreviation for the protecting group (Boc, Fmoc)
+    - <b>full_name</b> full IUPAC name for the protecting group
+    - <b> rxn </b> the reaction itself.
+*/
+
+struct DeprotectData {
+  std::string deprotection_class;
+  std::string reaction_smarts;
+  std::string abbreviation;
+  std::string full_name;
+  boost::shared_ptr<ChemicalReaction> rxn; // so much easier than unique_ptr, sigh...
+
+  DeprotectData(const std::string &deprotection_class,
+		const std::string &reaction_smarts,
+		const std::string &abbrevition,
+		const std::string &full_name);
+
+  bool operator==(const DeprotectData &other) const {
+    return (deprotection_class == other.deprotection_class && full_name == other.full_name && 
+	    abbreviation == other.abbreviation && reaction_smarts == other.reaction_smarts &&
+	    isValid() == other.isValid());
+  }
+
+  //! Returns true if the deprotection is valid
+  bool isValid() const {
+    return rxn.get() != nullptr;
+  }
+
+};
+
+//! Retrieves the build in list of common deprotections
+const std::vector<DeprotectData> &getDeprotections();
+
+//! Deprotect a molecule
+/*!
+     The resulting molecule is annotated with the deprotections used (property DEPROTECTIONS) and
+      the number of deprotections applied (property DEPROTECTIION_COUNT)
+
+     \param mol the molecule to deprotect
+     \param deprotections - a vector of deprotections to use, defaults to the built in deprotections.
+
+     \return The deprotected form of the input molecule
+*/
+std::unique_ptr<ROMol> deprotect(const ROMol& mol,
+				 const std::vector<DeprotectData> &deprotections = getDeprotections());
+}
+
+#endif

--- a/Code/GraphMol/Deprotect/Wrap/CMakeLists.txt
+++ b/Code/GraphMol/Deprotect/Wrap/CMakeLists.txt
@@ -1,0 +1,9 @@
+remove_definitions(-DRDKIT_SUBSTRUCTLIBRARY_BUILD)
+rdkit_python_extension(rdDeprotect
+                       rdDeprotect.cpp
+                       DeprotectWrap.cpp
+                       DEST Chem
+                       LINK_LIBRARIES
+                       Deprotect )
+
+add_pytest(pyDeprotect ${CMAKE_CURRENT_SOURCE_DIR}/rough_test.py)

--- a/Code/GraphMol/Deprotect/Wrap/DeprotectWrap.cpp
+++ b/Code/GraphMol/Deprotect/Wrap/DeprotectWrap.cpp
@@ -1,0 +1,94 @@
+#include <RDBoost/python.h>
+#include <RDBoost/Wrap.h>
+#include <GraphMol/RDKitBase.h>
+#include <GraphMol/Deprotect/Deprotect.h>
+
+namespace python = boost::python;
+namespace RDKit {
+  // boost::python doesn't support unique_ptr so we convert to shared for
+  //  python.
+  template< typename T >
+  inline
+  std::vector< T > to_std_vector( const python::object& iterable )
+  {
+    return std::vector< T >( python::stl_input_iterator< T >( iterable ),
+                             python::stl_input_iterator< T >( ) );
+  }
+
+  boost::shared_ptr<ROMol> DeprotectVectWrap(
+		  const ROMol &mol,
+		  const python::object &iterable) {
+    //		  const std::vector<DeprotectData> &deprotections) {
+    auto deprotections = to_std_vector<DeprotectData>(iterable);
+    auto res = deprotect(mol, deprotections);
+    auto m = boost::shared_ptr<ROMol>(res.get());
+    res.release();
+    return m;
+  }
+
+  boost::shared_ptr<ROMol> DeprotectWrap(const ROMol &mol) {
+    auto res = deprotect(mol, getDeprotections());
+    auto m = boost::shared_ptr<ROMol>(res.get());
+    res.release();
+    return m;
+  }
+
+  //! Make a copy so we don't try and change a const vector
+  std::vector<DeprotectData> GetDeprotectionsWrap() {
+    return getDeprotections();
+  }
+}
+
+struct deprotect_wrap {
+  static void wrap() {
+    const char * constructor_doc = 
+      "Construct a new DeprotectData instance.\n"
+      "  >>> reaction_class = \"amine\"\n"
+      "  >>> reaction_smarts = \"[C;R0][C;R0]([C;R0])([O;R0][C;R0](=[O;R0])[NX3;H0,H1:1])C>>[N:1]\"\n"
+      "  >>> abbreviation = \"Boc\"\n"
+      "  >>> full_name = \"tert-butyloxycarbonyl\"\n"
+      "  >>> data = DeprotectData(reaction_class, reaction_smarts, abbreviation, full_name)\n"
+      "  >>> assert data.isValid()\n"
+      "\n";
+
+    const char * deprotect_doc_string = 
+      "DeprotectData class, contains a single deprotection reaction and information\n"
+      "\n"
+      " deprotectdata.deprotection_class - functional group being protected\n"
+      " deprotectdata.reaction_smarts - reaction smarts used for deprotection\n"
+      " deprotectdata.abbreviation - common abbreviation for the protecting group\n"
+      " deprotectdata.full_name - full IUPAC name for the protecting group\n"
+      "\n"
+      "\n"
+      ;
+      
+    python::class_<std::vector<RDKit::DeprotectData> >("DeprotectDataVect").
+      def(python::vector_indexing_suite<std::vector<RDKit::DeprotectData>>());
+							       
+    python::class_<RDKit::DeprotectData>(
+	    "DeprotectData",
+	    deprotect_doc_string,
+	    python::init<std::string, std::string,
+	    std::string, std::string>(constructor_doc))
+      .def_readonly("deprotection_class", &RDKit::DeprotectData::deprotection_class)
+      .def_readonly("full_name", &RDKit::DeprotectData::full_name)
+      .def_readonly("abbreviation", &RDKit::DeprotectData::abbreviation)
+      .def_readonly("reaction_smarts", &RDKit::DeprotectData::reaction_smarts)
+      .def("isValid", &RDKit::DeprotectData::isValid,
+	   "Returns True if the DeprotectData has a valid reaction");
+
+	  python::def("getDeprotections", &RDKit::GetDeprotectionsWrap,
+		      "Return the default list of deprotections");
+    
+    python::def("Deprotect", &RDKit::DeprotectWrap,
+		python::arg("mol"),
+		"Return the deprotected version of the molecule.");
+    
+    python::def("Deprotect", &RDKit::DeprotectVectWrap,
+		python::arg("mol"), python::arg("deprotections"),
+		"Given a list of deprotections, return the deprotected version of the molecule.");
+	  }
+	  
+};
+
+void wrap_deprotect() { deprotect_wrap::wrap(); }

--- a/Code/GraphMol/Deprotect/Wrap/rdDeprotect.cpp
+++ b/Code/GraphMol/Deprotect/Wrap/rdDeprotect.cpp
@@ -1,0 +1,8 @@
+#include "rdDeprotect.h"
+#include <RDBoost/python.h>
+
+namespace python = boost::python;
+
+void wrap_deprotect();
+
+BOOST_PYTHON_MODULE(rdDeprotect) { wrap_deprotect(); }

--- a/Code/GraphMol/Deprotect/Wrap/rdDeprotect.h
+++ b/Code/GraphMol/Deprotect/Wrap/rdDeprotect.h
@@ -1,0 +1,8 @@
+#include <RDGeneral/export.h>
+#ifndef RDDEPROTECT_INCL
+#define RDDEPROPTECT_INCL
+
+#define PY_ARRAY_UNIQUE_SYMBOL rddeprotect_array_API
+#include <RDBoost/Wrap.h>
+
+#endif

--- a/Code/GraphMol/Deprotect/Wrap/rough_test.py
+++ b/Code/GraphMol/Deprotect/Wrap/rough_test.py
@@ -1,0 +1,37 @@
+import unittest
+from rdkit import Chem
+from rdkit.Chem import rdDeprotect as rd
+
+class TestCase(unittest.TestCase):
+    def testDeprotect(self):
+        smiles = "N(C(=O)OC(C)(C)C)Cc1ccccc1NC(=O)OC(C)(C)C"
+        m = Chem.MolFromSmiles(smiles)
+        m2 = rd.Deprotect(m)
+        self.assertEqual(Chem.MolToSmiles(m2), Chem.CanonSmiles("NCc1ccccc1N"))
+        self.assertEqual(list(m2.GetPropsAsDict()["DEPROTECTIONS"]),
+                         ["Boc", "Boc"])
+        self.assertEqual(m2.GetPropsAsDict()["DEPROTECTION_COUNT"],
+                         2)
+
+    def testDeprotectVector(self):
+        reaction_class = "amine"
+        reaction_smarts = "[C;R0][C;R0]([C;R0])([O;R0][C;R0](=[O;R0])[NX3;H0,H1:1])C>>[N:1]"
+        abbreviation = "Boc"
+        full_name = "tert-butyloxycarbonyl"
+        data = rd.DeprotectData(reaction_class, reaction_smarts, abbreviation, full_name)
+
+        smiles = "N(C(=O)OC(C)(C)C)Cc1ccccc1NC(=O)OC(C)(C)C"
+        m = Chem.MolFromSmiles(smiles)
+        m2 = rd.Deprotect(m, [])
+        self.assertEqual(Chem.MolToSmiles(m), Chem.MolToSmiles(m2))
+        self.assertEqual(m2.GetPropsAsDict()["DEPROTECTION_COUNT"], 0)
+
+        m2 = rd.Deprotect(m, [data])
+        self.assertEqual(Chem.MolToSmiles(m2), Chem.CanonSmiles("NCc1ccccc1N"))
+        self.assertEqual(list(m2.GetPropsAsDict()["DEPROTECTIONS"]),
+                         ["Boc", "Boc"])
+        self.assertEqual(m2.GetPropsAsDict()["DEPROTECTION_COUNT"],
+                         2)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Code/GraphMol/Deprotect/deprotectTest.cpp
+++ b/Code/GraphMol/Deprotect/deprotectTest.cpp
@@ -1,0 +1,24 @@
+#define CATCH_CONFIG_MAIN  // This tells Catch to provide a main() - only do
+                           // this in one cpp file
+#include "catch.hpp"
+
+#include <GraphMol/RDKitBase.h>
+#include <GraphMol/ROMol.h>
+#include <GraphMol/SmilesParse/SmilesParse.h>
+#include <GraphMol/SmilesParse/SmilesWrite.h>
+#include <GraphMol/Deprotect/Deprotect.h>
+
+using namespace RDKit;
+
+TEST_CASE("Standard deprotections", "[deprotect]") {
+  SECTION("simple deprotections") {
+    auto m = "N(C(=O)OC(C)(C)C)Cc1ccccc1NC(=O)OC(C)(C)C"_smiles;
+    auto res = deprotect(*m);
+    REQUIRE(res);
+    CHECK(MolToSmiles(*res) == "NCc1ccccc1N");
+    CHECK(res->getProp<int>("DEPROTECTION_COUNT") == 2);
+    std::vector<std::string> expected {"Boc", "Boc"};
+    CHECK(res->getProp<std::vector<std::string>>("DEPROTECTIONS") ==
+	  expected);
+  }
+}


### PR DESCRIPTION
Adds a simple deprotection library

```
>>> from rdkit import Chem
>>> from rdkit.Chem import rdDeprotect

>>> smiles = "N(C(=O)OC(C)(C)C)Cc1ccccc1NC(=O)OC(C)(C)C"
>>> mol = Chem.MolFromSmiles(smiles)
>>> deprotected_mol = rdDeprotect.Deprotect(mol)
>>> print(list(deprotected_mol.GetPropsAsDict()["DEPROTECTIONS"]))
['Boc', 'Boc']
```