### PR TITLE
Use operator() and __call__() consistently across RDKit

### DIFF
--- a/Code/GraphMol/FMCS/Wrap/rdFMCS.cpp
+++ b/Code/GraphMol/FMCS/Wrap/rdFMCS.cpp
@@ -48,7 +48,7 @@ struct PyMCSAtomCompare : public boost::python::wrapper<PyMCSAtomCompare> {
     python::throw_error_already_set();
     return false;
   }
-  // DEPRECATED: remove from here in release 2021.01
+  // DEPRECATED: remove the following compare() method in release 2021.01
   virtual bool compare(const MCSAtomCompareParameters&,
                        const ROMol&, unsigned int, const ROMol&, unsigned int) {
     PyErr_SetString(PyExc_AttributeError,
@@ -57,7 +57,6 @@ struct PyMCSAtomCompare : public boost::python::wrapper<PyMCSAtomCompare> {
     python::throw_error_already_set();
     return false;
   }
-  // DEPRECATED: remove until here in release 2021.01
   bool hasPythonOverride(const char *attrName) {
     auto obj = get_override(attrName);
     return PyCallable_Check(obj.ptr());
@@ -97,7 +96,7 @@ struct PyMCSBondCompare : public boost::python::wrapper<PyMCSBondCompare> {
     python::throw_error_already_set();
     return false;
   }
-  // DEPRECATED: remove from here in release 2021.01
+  // DEPRECATED: remove the following compare() method in release 2021.01
   virtual bool compare(const MCSBondCompareParameters&,
                        const ROMol&, unsigned int, const ROMol&, unsigned int) {
     PyErr_SetString(PyExc_AttributeError,
@@ -106,7 +105,6 @@ struct PyMCSBondCompare : public boost::python::wrapper<PyMCSBondCompare> {
     python::throw_error_already_set();
     return false;
   }
-  // DEPRECATED: remove until here in release 2021.01
   const MCSParameters *mcsParameters;
   std::set<const ROMol *> ringMatchTablesMols;
   FMCS::RingMatchTableSet ringMatchTables;
@@ -146,7 +144,7 @@ struct PyMCSProgress : public boost::python::wrapper<PyMCSProgress> {
     python::throw_error_already_set();
     return false;
   }
-  // DEPRECATED: remove from here in release 2021.01
+  // DEPRECATED: remove the following callback() method in release 2021.01
   virtual bool callback(const MCSProgressData&,
                         const MCSParameters&) {
     PyErr_SetString(PyExc_AttributeError,
@@ -155,7 +153,6 @@ struct PyMCSProgress : public boost::python::wrapper<PyMCSProgress> {
     python::throw_error_already_set();
     return false;
   }
-  // DEPRECATED: remove until here in release 2021.01
 };
 
 class PyMCSProgressData {

--- a/Code/GraphMol/FMCS/Wrap/rdFMCS.cpp
+++ b/Code/GraphMol/FMCS/Wrap/rdFMCS.cpp
@@ -13,14 +13,18 @@
 #include <GraphMol/FMCS/FMCS.h>
 #include <GraphMol/FMCS/RingMatchTableSet.h>
 
-#define COMPARE_FUNC_NAME "compare"
-#define CALLBACK_FUNC_NAME "callback"
+#define COMPARE_FUNC_NAME "__call__"
+#define CALLBACK_FUNC_NAME "__call__"
+// DEPRECATED: remove from here in release 2021.01
+#define COMPARE_DEPRECATED_FUNC_NAME "compare"
+#define CALLBACK_DEPRECATED_FUNC_NAME "callback"
+// DEPRECATED: remove until here in release 2021.01
 
 namespace python = boost::python;
 
 namespace RDKit {
 
-struct PyMCSAtomCompare {
+struct PyMCSAtomCompare : public boost::python::wrapper<PyMCSAtomCompare> {
   inline bool checkAtomRingMatch(const MCSAtomCompareParameters& p,
                                  const ROMol& mol1, unsigned int atom1,
                                  const ROMol& mol2, unsigned int atom2) const {
@@ -36,17 +40,31 @@ struct PyMCSAtomCompare {
                                  const ROMol& mol2, unsigned int atom2) const {
     return RDKit::checkAtomChirality(p, mol1, atom1, mol2, atom2);
   }
-  virtual bool compare(const MCSAtomCompareParameters&,
-                       const ROMol&, unsigned int, const ROMol&, unsigned int) {
+  virtual bool operator()(const MCSAtomCompareParameters&,
+                          const ROMol&, unsigned int, const ROMol&, unsigned int) {
     PyErr_SetString(PyExc_AttributeError,
       "The " COMPARE_FUNC_NAME "() method "
       "must be overridden in the rdFMCS.MCSAtomCompare subclass");
     python::throw_error_already_set();
     return false;
   }
+  // DEPRECATED: remove from here in release 2021.01
+  virtual bool compare(const MCSAtomCompareParameters&,
+                       const ROMol&, unsigned int, const ROMol&, unsigned int) {
+    PyErr_SetString(PyExc_AttributeError,
+      "The " COMPARE_DEPRECATED_FUNC_NAME "() method (DEPRECATED) "
+      "must be overridden in the rdFMCS.MCSAtomCompare subclass");
+    python::throw_error_already_set();
+    return false;
+  }
+  // DEPRECATED: remove until here in release 2021.01
+  bool hasPythonOverride(const char *attrName) {
+    auto obj = get_override(attrName);
+    return PyCallable_Check(obj.ptr());
+  }
 };
 
-struct PyMCSBondCompare {
+struct PyMCSBondCompare : public boost::python::wrapper<PyMCSBondCompare> {
   inline bool checkBondStereo(const MCSBondCompareParameters& p,
                               const ROMol& mol1, unsigned int bond1,
                               const ROMol& mol2, unsigned int bond2) const {
@@ -67,43 +85,77 @@ struct PyMCSBondCompare {
     }
     return RDKit::checkBondRingMatch(p, mol1, bond1, mol2, bond2, &ringMatchTables);
   }
-  virtual bool compare(const MCSBondCompareParameters&,
-                       const ROMol&, unsigned int, const ROMol&, unsigned int) {
+  bool hasPythonOverride(const char *attrName) {
+    auto obj = get_override(attrName);
+    return PyCallable_Check(obj.ptr());
+  }
+  virtual bool operator()(const MCSBondCompareParameters&,
+                          const ROMol&, unsigned int, const ROMol&, unsigned int) {
     PyErr_SetString(PyExc_AttributeError,
       "The " COMPARE_FUNC_NAME "() method "
       "must be overridden in the rdFMCS.MCSBondCompare subclass");
     python::throw_error_already_set();
     return false;
-  };
+  }
+  // DEPRECATED: remove from here in release 2021.01
+  virtual bool compare(const MCSBondCompareParameters&,
+                       const ROMol&, unsigned int, const ROMol&, unsigned int) {
+    PyErr_SetString(PyExc_AttributeError,
+      "The " COMPARE_DEPRECATED_FUNC_NAME "() method (DEPRECATED) "
+      "must be overridden in the rdFMCS.MCSBondCompare subclass");
+    python::throw_error_already_set();
+    return false;
+  }
+  // DEPRECATED: remove until here in release 2021.01
   const MCSParameters *mcsParameters;
   std::set<const ROMol *> ringMatchTablesMols;
   FMCS::RingMatchTableSet ringMatchTables;
+};
+
+struct PyAtomBondCompData {
+  std::string atomCompFuncName;
+  std::string bondCompFuncName;
+  python::object pyAtomComp;
+  python::object pyBondComp;
 };
 
 struct PyCompareFunctionUserData {
   const MCSParameters *mcsParameters;
   std::set<const ROMol *> *ringMatchTablesMols;
   FMCS::RingMatchTableSet *ringMatchTables;
-  python::object pyAtomComp;
-  python::object pyBondComp;
+  PyAtomBondCompData pyAtomBondCompData;
 };
 
 struct PyProgressCallbackUserData {
   const MCSProgressData *mcsProgressData;
+  std::string callbackFuncName;
   python::object pyMCSProgress;
-  python::object pyAtomComp;
-  python::object pyBondComp;
+  PyAtomBondCompData pyAtomBondCompData;
 };
 
-struct PyMCSProgress {
-  virtual bool callback(const MCSProgressData&,
-                        const MCSParameters&) {
+struct PyMCSProgress : public boost::python::wrapper<PyMCSProgress> {
+  bool hasPythonOverride(const char *attrName) {
+    auto obj = get_override(attrName);
+    return PyCallable_Check(obj.ptr());
+  }
+  virtual bool operator()(const MCSProgressData&,
+                          const MCSParameters&) {
     PyErr_SetString(PyExc_AttributeError,
       "The " CALLBACK_FUNC_NAME "() method "
       "must be overridden in the rdFMCS.MCSProgress subclass");
     python::throw_error_already_set();
     return false;
   }
+  // DEPRECATED: remove from here in release 2021.01
+  virtual bool callback(const MCSProgressData&,
+                        const MCSParameters&) {
+    PyErr_SetString(PyExc_AttributeError,
+      "The " CALLBACK_DEPRECATED_FUNC_NAME "() method "
+      "must be overridden in the rdFMCS.MCSProgress subclass");
+    python::throw_error_already_set();
+    return false;
+  }
+  // DEPRECATED: remove until here in release 2021.01
 };
 
 class PyMCSProgressData {
@@ -145,8 +197,7 @@ public:
     PyMCSParameters() {
       *p = other;
       pcud->pyMCSProgress = pcudOther.pyMCSProgress;
-      cfud->pyAtomComp = pcudOther.pyAtomComp;
-      cfud->pyBondComp = pcudOther.pyBondComp;
+      cfud->pyAtomBondCompData = pcudOther.pyAtomBondCompData;
     }
   const MCSParameters *get() const {
     return p.get();
@@ -193,6 +244,28 @@ public:
   void setInitialSeed(const std::string &value) {
     p->InitialSeed = value;
   }
+  void errorNotDefined(const char *className, const char *funcName) {
+    // should never happen as the method is virtual but not pure in the C++ class
+    std::stringstream ss;
+    ss << "The " << funcName << "() method must be defined "
+      "in the " << className << " subclass";
+    PyErr_SetString(PyExc_AttributeError, ss.str().c_str());
+    python::throw_error_already_set();
+  }
+  void errorNotCallable(const char *className, const char *funcName) {
+    std::stringstream ss;
+    ss << "The " << funcName << " attribute in the "
+      << className << " subclass is not a callable method";
+    PyErr_SetString(PyExc_TypeError, ss.str().c_str());
+    python::throw_error_already_set();
+  }
+  void errorNotOverridden(const char *className, const char *funcName) {
+    std::stringstream ss;
+    ss << "The " << funcName << " method must be overridden in the "
+      << className << " subclass";
+    PyErr_SetString(PyExc_TypeError, ss.str().c_str());
+    python::throw_error_already_set();
+  }
   void setMCSAtomTyper(PyObject *atomComp) {
     PRECONDITION(atomComp, "atomComp must not be NULL");
     python::object atomCompObject(python::handle<>(python::borrowed(atomComp)));
@@ -206,21 +279,36 @@ public:
       if (extractPyMCSAtomCompare.check()) {
         PyObject *callable = PyObject_GetAttrString(atomCompObject.ptr(), COMPARE_FUNC_NAME);
         if (!callable) {
-          // should never get here
-          PyErr_SetString(PyExc_AttributeError,
-            "The " COMPARE_FUNC_NAME "() method must be defined "
-            "in the rdFMCS.MCSAtomCompare subclass");
-          python::throw_error_already_set();
+          errorNotDefined(COMPARE_FUNC_NAME, "rdFMCS.MCSAtomCompare");
         }
         if (!PyCallable_Check(callable)) {
-          PyErr_SetString(PyExc_TypeError,
-            "The " COMPARE_FUNC_NAME " attribute in the "
-            "rdFMCS.MCSAtomCompare subclass is not a callable method");
-          python::throw_error_already_set();
+          errorNotCallable(COMPARE_FUNC_NAME, "rdFMCS.MCSAtomCompare");
+        }
+        if (!extractPyMCSAtomCompare()->hasPythonOverride(COMPARE_FUNC_NAME)) {
+          // DEPRECATED: remove from here in release 2021.01
+          callable = PyObject_GetAttrString(atomCompObject.ptr(), COMPARE_DEPRECATED_FUNC_NAME);
+          if (!callable) {
+            errorNotDefined(COMPARE_DEPRECATED_FUNC_NAME, "rdFMCS.MCSAtomCompare");
+          }
+          if (!PyCallable_Check(callable)) {
+            errorNotCallable(COMPARE_DEPRECATED_FUNC_NAME, "rdFMCS.MCSAtomCompare");
+          }
+          if (!extractPyMCSAtomCompare()->hasPythonOverride(COMPARE_DEPRECATED_FUNC_NAME)) {
+            errorNotOverridden(COMPARE_FUNC_NAME, "rdFMCS.MCSAtomCompare");
+          }
+          else {
+            cfud->pyAtomBondCompData.atomCompFuncName = COMPARE_DEPRECATED_FUNC_NAME;
+          }
+          // DEPRECATED: remove until here in release 2021.01
+          // uncomment the following line in release 2021.01
+          // errorNotOverridden(COMPARE_FUNC_NAME, "rdFMCS.MCSAtomCompare");
+        }
+        else {
+          cfud->pyAtomBondCompData.atomCompFuncName = COMPARE_FUNC_NAME;
         }
         p->CompareFunctionsUserData = cfud.get();
         p->AtomTyper = MCSAtomComparePyFunc;
-        cfud->pyAtomComp = atomCompObject;
+        cfud->pyAtomBondCompData.pyAtomComp = atomCompObject;
         cfud->mcsParameters = p.get();
       }
       else {
@@ -239,8 +327,8 @@ public:
       { MCSAtomCompareIsotopes, AtomCompareIsotopes },
       { MCSAtomCompareAnyHeavyAtom, AtomCompareAnyHeavyAtom }
     };
-    if (!cfud->pyAtomComp.is_none()) {
-      return cfud->pyAtomComp;
+    if (!cfud->pyAtomBondCompData.pyAtomComp.is_none()) {
+      return cfud->pyAtomBondCompData.pyAtomComp;
     }
     python::object res;
     try {
@@ -266,21 +354,36 @@ public:
       if (extractPyMCSBondCompare.check()) {
         PyObject *callable = PyObject_GetAttrString(bondCompObject.ptr(), COMPARE_FUNC_NAME);
         if (!callable) {
-          // should never get here
-          PyErr_SetString(PyExc_AttributeError,
-            "The " COMPARE_FUNC_NAME "() method must be defined "
-            "in the rdFMCS.MCSBondCompare subclass");
-          python::throw_error_already_set();
+          errorNotDefined(COMPARE_FUNC_NAME, "rdFMCS.MCSBondCompare");
         }
         if (!PyCallable_Check(callable)) {
-          PyErr_SetString(PyExc_TypeError,
-            "The " COMPARE_FUNC_NAME " attribute in the "
-            "rdFMCS.MCSBondCompare subclass is not a callable method");
-          python::throw_error_already_set();
+          errorNotCallable(COMPARE_FUNC_NAME, "rdFMCS.MCSBondCompare");
+        }
+        if (!extractPyMCSBondCompare()->hasPythonOverride(COMPARE_FUNC_NAME)) {
+          // DEPRECATED: remove from here in release 2021.01
+          callable = PyObject_GetAttrString(bondCompObject.ptr(), COMPARE_DEPRECATED_FUNC_NAME);
+          if (!callable) {
+            errorNotDefined(COMPARE_DEPRECATED_FUNC_NAME, "rdFMCS.MCSBondCompare");
+          }
+          if (!PyCallable_Check(callable)) {
+            errorNotCallable(COMPARE_DEPRECATED_FUNC_NAME, "rdFMCS.MCSBondCompare");
+          }
+          if (!extractPyMCSBondCompare()->hasPythonOverride(COMPARE_DEPRECATED_FUNC_NAME)) {
+            errorNotOverridden(COMPARE_FUNC_NAME, "rdFMCS.MCSBondCompare");
+          }
+          else {
+            cfud->pyAtomBondCompData.bondCompFuncName = COMPARE_DEPRECATED_FUNC_NAME;
+          }
+          // DEPRECATED: remove until here in release 2021.01
+          // uncomment the following line in release 2021.01
+          // errorNotOverridden(COMPARE_FUNC_NAME, "rdFMCS.MCSBondCompare");
+        }
+        else {
+          cfud->pyAtomBondCompData.bondCompFuncName = COMPARE_FUNC_NAME;
         }
         p->CompareFunctionsUserData = cfud.get();
         p->BondTyper = MCSBondComparePyFunc;
-        cfud->pyBondComp = bondCompObject;
+        cfud->pyAtomBondCompData.pyBondComp = bondCompObject;
         PyMCSBondCompare *bc = extractPyMCSBondCompare();
         bc->mcsParameters = p.get();
         cfud->mcsParameters = p.get();
@@ -302,8 +405,8 @@ public:
       { MCSBondCompareOrder, BondCompareOrder },
       { MCSBondCompareOrderExact, BondCompareOrderExact }
     };
-    if (!cfud->pyBondComp.is_none()) {
-      return cfud->pyBondComp;
+    if (!cfud->pyAtomBondCompData.pyBondComp.is_none()) {
+      return cfud->pyAtomBondCompData.pyBondComp;
     }
     python::object res;
     try {
@@ -321,11 +424,39 @@ public:
     python::object progressObject(python::handle<>(python::borrowed(progress)));
     python::extract<PyMCSProgress *> extractMCSProgress(progressObject);
     if (extractMCSProgress.check()) {
+      PyObject *callable = PyObject_GetAttrString(progressObject.ptr(), CALLBACK_FUNC_NAME);
+      if (!callable) {
+        errorNotDefined(CALLBACK_FUNC_NAME, "rdFMCS.MCSProgress");
+      }
+      if (!PyCallable_Check(callable)) {
+        errorNotCallable(CALLBACK_FUNC_NAME, "rdFMCS.MCSProgress");
+      }
+      if (!extractMCSProgress()->hasPythonOverride(CALLBACK_FUNC_NAME)) {
+        // DEPRECATED: remove from here in release 2021.01
+        callable = PyObject_GetAttrString(progressObject.ptr(), CALLBACK_DEPRECATED_FUNC_NAME);
+        if (!callable) {
+          errorNotDefined(CALLBACK_DEPRECATED_FUNC_NAME, "rdFMCS.MCSProgress");
+        }
+        if (!PyCallable_Check(callable)) {
+          errorNotCallable(CALLBACK_DEPRECATED_FUNC_NAME, "rdFMCS.MCSProgress");
+        }
+        if (!extractMCSProgress()->hasPythonOverride(CALLBACK_DEPRECATED_FUNC_NAME)) {
+          errorNotOverridden(CALLBACK_FUNC_NAME, "rdFMCS.MCSProgress");
+        }
+        else {
+          pcud->callbackFuncName = CALLBACK_DEPRECATED_FUNC_NAME;
+        }
+        // DEPRECATED: remove until here in release 2021.01
+        // uncomment the following line in release 2021.01
+        // errorNotOverridden(COMPARE_FUNC_NAME, "rdFMCS.MCSAtomCompare");
+      }
+      else {
+        pcud->callbackFuncName = CALLBACK_FUNC_NAME;
+      }
       p->ProgressCallbackUserData = pcud.get();
       p->ProgressCallback = MCSProgressCallbackPyFunc;
       pcud->pyMCSProgress = progressObject;
-      pcud->pyAtomComp = cfud->pyAtomComp;
-      pcud->pyBondComp = cfud->pyBondComp;
+      pcud->pyAtomBondCompData = cfud->pyAtomBondCompData;
     }
     else {
       PyErr_SetString(PyExc_TypeError,
@@ -357,7 +488,8 @@ private:
     bool res = false;
     {
       PyGILStateHolder h;
-      res = python::call_method<bool>(cfud->pyAtomComp.ptr(), COMPARE_FUNC_NAME,
+      res = python::call_method<bool>(cfud->pyAtomBondCompData.pyAtomComp.ptr(),
+                                      cfud->pyAtomBondCompData.atomCompFuncName.c_str(),
                                       boost::ref(p), boost::ref(mol1),
                                       atom1, boost::ref(mol2), atom2);
     }
@@ -372,7 +504,8 @@ private:
     bool res = false;
     {
       PyGILStateHolder h;
-      res = python::call_method<bool>(cfud->pyBondComp.ptr(), COMPARE_FUNC_NAME,
+      res = python::call_method<bool>(cfud->pyAtomBondCompData.pyBondComp.ptr(),
+                                      cfud->pyAtomBondCompData.bondCompFuncName.c_str(),
                                       boost::ref(p), boost::ref(mol1),
                                       bond1, boost::ref(mol2), bond2);
     }
@@ -387,7 +520,7 @@ private:
       PyMCSParameters ps(params, *pcud);
       PyMCSProgressData pd(stat);
       PyGILStateHolder h;
-      res = python::call_method<bool>(pcud->pyMCSProgress.ptr(), CALLBACK_FUNC_NAME,
+      res = python::call_method<bool>(pcud->pyMCSProgress.ptr(), pcud->callbackFuncName.c_str(),
                                       boost::ref(pd), boost::ref(ps));
     }
     return res;
@@ -619,12 +752,20 @@ BOOST_PYTHON_MODULE(rdFMCS) {
 
   python::class_<RDKit::PyMCSProgress, boost::noncopyable>(
       "MCSProgress", "Base class. Subclass and override "
-      "MCSProgress." CALLBACK_FUNC_NAME "callback() "
+      "MCSProgress." CALLBACK_FUNC_NAME "() "
       "to define a custom callback function")
-      .def(CALLBACK_FUNC_NAME, &RDKit::PyMCSProgress::callback,
+      .def(CALLBACK_FUNC_NAME, &RDKit::PyMCSProgress::operator(),
            (python::arg("self"), python::arg("stat"),
               python::arg("parameters")),
-              "override to implement a custom progress callback");
+              "override to implement a custom progress callback")
+      // DEPRECATED: remove from here in release 2021.01
+      .def(CALLBACK_DEPRECATED_FUNC_NAME, &RDKit::PyMCSProgress::callback,
+           (python::arg("self"), python::arg("stat"),
+              python::arg("parameters")),
+              "DEPRECATED: override " CALLBACK_FUNC_NAME " instead.\n"
+              "override to implement a custom progress callback.\n")
+      // DEPRECATED: remove until here in release 2021.01
+      ;
 
   python::class_<RDKit::PyMCSProgressData, boost::noncopyable>(
       "MCSProgressData", "Information about the MCS progress")
@@ -655,11 +796,19 @@ BOOST_PYTHON_MODULE(rdFMCS) {
               python::arg("mol1"), python::arg("atom1"),
               python::arg("mol2"), python::arg("atom2")),
               "Return True if both atoms have, or have not, a chiral tag")
-      .def(COMPARE_FUNC_NAME, &RDKit::PyMCSAtomCompare::compare,
+      .def(COMPARE_FUNC_NAME, &RDKit::PyMCSAtomCompare::operator(),
            (python::arg("self"), python::arg("parameters"),
               python::arg("mol1"), python::arg("atom1"),
               python::arg("mol2"), python::arg("atom2")),
-              "override to implement custom atom comparison");
+              "override to implement custom atom comparison")
+      // DEPRECATED: remove from here in release 2020.03
+      .def(COMPARE_DEPRECATED_FUNC_NAME, &RDKit::PyMCSAtomCompare::compare,
+           (python::arg("self"), python::arg("parameters"),
+              python::arg("mol1"), python::arg("atom1"),
+              python::arg("mol2"), python::arg("atom2")),
+              "override to implement custom atom comparison")
+      // DEPRECATED: remove until here in release 2020.03
+      ;
 
   python::class_<RDKit::PyMCSBondCompare, boost::noncopyable>(
       "MCSBondCompare", "Base class. Subclass and override "
@@ -676,11 +825,19 @@ BOOST_PYTHON_MODULE(rdFMCS) {
               python::arg("mol1"), python::arg("bond1"),
               python::arg("mol2"), python::arg("bond2")),
               "Return True if both bonds are, or are not, part of a ring")
-      .def(COMPARE_FUNC_NAME, &RDKit::PyMCSBondCompare::compare,
+      .def(COMPARE_FUNC_NAME, &RDKit::PyMCSBondCompare::operator(),
            (python::arg("self"), python::arg("parameters"),
               python::arg("mol1"), python::arg("bond1"),
               python::arg("mol2"), python::arg("bond2")),
-              "override to implement custom bond comparison");
+              "override to implement custom bond comparison")
+      // DEPRECATED: remove from here in release 2020.03
+      .def(COMPARE_DEPRECATED_FUNC_NAME, &RDKit::PyMCSBondCompare::compare,
+           (python::arg("self"), python::arg("parameters"),
+              python::arg("mol1"), python::arg("bond1"),
+              python::arg("mol2"), python::arg("bond2")),
+              "override to implement custom bond comparison")
+      // DEPRECATED: remove until here in release 2020.03
+      ;
 
   python::def("FindMCS", RDKit::FindMCSWrapper2,
               (python::arg("mols"), python::arg("parameters")),

--- a/Code/GraphMol/FMCS/Wrap/testFMCS.py
+++ b/Code/GraphMol/FMCS/Wrap/testFMCS.py
@@ -33,7 +33,7 @@ class BondMatchOrderMatrix:
         return self.MatchMatrix[i][j]
 
 class CompareAny(rdFMCS.MCSAtomCompare):
-    def compare(self, p, mol1, atom1, mol2, atom2):
+    def __call__(self, p, mol1, atom1, mol2, atom2):
         if (p.MatchChiralTag and not self.CheckAtomChirality(p, mol1, atom1, mol2, atom2)):
             return False
         if (p.MatchFormalCharge and not self.CheckAtomCharge(p, mol1, atom1, mol2, atom2)):
@@ -43,18 +43,18 @@ class CompareAny(rdFMCS.MCSAtomCompare):
         return True
 
 class CompareAnyHeavyAtom(CompareAny):
-    def compare(self, p, mol1, atom1, mol2, atom2):
+    def __call__(self, p, mol1, atom1, mol2, atom2):
         a1 = mol1.GetAtomWithIdx(atom1)
         a2 = mol2.GetAtomWithIdx(atom2)
         # Any atom, including H, matches another atom of the same type,  according to
         # the other flags
         if (a1.GetAtomicNum() == a2.GetAtomicNum() or
             (a1.GetAtomicNum() > 1 and a2.GetAtomicNum() > 1)):
-            return CompareAny.compare(self, p, mol1, atom1, mol2, atom2)
+            return CompareAny.__call__(self, p, mol1, atom1, mol2, atom2)
         return False
 
 class CompareElements(rdFMCS.MCSAtomCompare):
-    def compare(self, p, mol1, atom1, mol2, atom2):
+    def __call__(self, p, mol1, atom1, mol2, atom2):
         a1 = mol1.GetAtomWithIdx(atom1)
         a2 = mol2.GetAtomWithIdx(atom2)
         if (a1.GetAtomicNum() != a2.GetAtomicNum()):
@@ -70,7 +70,7 @@ class CompareElements(rdFMCS.MCSAtomCompare):
         return True
 
 class CompareIsotopes(rdFMCS.MCSAtomCompare):
-    def compare(self, p, mol1, atom1, mol2, atom2):
+    def __call__(self, p, mol1, atom1, mol2, atom2):
         a1 = mol1.GetAtomWithIdx(atom1)
         a2 = mol2.GetAtomWithIdx(atom2)
         if (a1.GetIsotope() != a2.GetIsotope()):
@@ -85,7 +85,7 @@ class CompareIsotopes(rdFMCS.MCSAtomCompare):
 
 class CompareOrder(rdFMCS.MCSBondCompare):
     match = BondMatchOrderMatrix(True)  # ignore Aromatization
-    def compare(self, p, mol1, bond1, mol2, bond2):
+    def __call__(self, p, mol1, bond1, mol2, bond2):
         b1 = mol1.GetBondWithIdx(bond1)
         b2 = mol2.GetBondWithIdx(bond2)
         t1 = b1.GetBondType()
@@ -99,7 +99,7 @@ class CompareOrder(rdFMCS.MCSBondCompare):
         return False
 
 class AtomCompareCompareIsInt(rdFMCS.MCSAtomCompare):
-    compare = 1
+    __call__ = 1
 
 class AtomCompareNoCompare(rdFMCS.MCSAtomCompare):
     pass
@@ -110,7 +110,7 @@ class AtomCompareUserData(rdFMCS.MCSAtomCompare):
         self._matchAnyHet = False
     def setMatchAnyHet(self, v):
         self._matchAnyHet = v
-    def compare(self, p, mol1, atom1, mol2, atom2):
+    def __call__(self, p, mol1, atom1, mol2, atom2):
         a1 = mol1.GetAtomWithIdx(atom1)
         a2 = mol2.GetAtomWithIdx(atom2)
         if (a1.GetAtomicNum() != a2.GetAtomicNum() and
@@ -129,7 +129,7 @@ class AtomCompareUserData(rdFMCS.MCSAtomCompare):
         return True
 
 class BondCompareCompareIsInt(rdFMCS.MCSBondCompare):
-    compare = 1
+    __call__ = 1
 
 class BondCompareNoCompare(rdFMCS.MCSBondCompare):
     pass
@@ -140,7 +140,7 @@ class BondCompareUserData(rdFMCS.MCSBondCompare):
         self.match = None
     def setIgnoreAromatization(self, v):
         self.match = BondMatchOrderMatrix(v)
-    def compare(self, p, mol1, bond1, mol2, bond2):
+    def __call__(self, p, mol1, bond1, mol2, bond2):
         b1 = mol1.GetBondWithIdx(bond1)
         b2 = mol2.GetBondWithIdx(bond2)
         t1 = b1.GetBondType()
@@ -154,7 +154,7 @@ class BondCompareUserData(rdFMCS.MCSBondCompare):
         return False
 
 class ProgressCallbackCallbackIsInt(rdFMCS.MCSProgress):
-    callback = 1
+    __call__ = 1
 
 class ProgressCallbackNoCallback(rdFMCS.MCSProgress):
     pass
@@ -164,7 +164,7 @@ class ProgressCallback(rdFMCS.MCSProgress):
         super().__init__()
         self.parent = parent
         self.callCount = 0
-    def callback(self, stat, params):
+    def __call__(self, stat, params):
         self.callCount += 1
         self.parent.assertTrue(isinstance(stat, rdFMCS.MCSProgressData))
         self.parent.assertTrue(hasattr(stat, "numAtoms"))
@@ -182,16 +182,12 @@ class ProgressCallback(rdFMCS.MCSProgress):
 class Common:
     @staticmethod
     def getParams(**kwargs):
-        have_kw = False
         params = rdFMCS.MCSParameters()
         for kw in ("AtomTyper", "BondTyper"):
-            try:
-                v = kwargs[kw]
-            except KeyError:
-                pass
-            else:
-                have_kw = True
-                setattr(params, kw, v())
+            v = kwargs.get(kw, None)
+            if v is not None:
+                v_instance = v()
+                setattr(params, kw, v_instance)
         return params
 
     @staticmethod
@@ -707,6 +703,38 @@ class TestCase(unittest.TestCase):
             AtomTyper=CompareElements,
             BondTyper=CompareOrder)
 
+    # DEPRECATED: remove from here in release 2021.01
+    def test1PythonImplDeprecated(self):
+        atom_call = CompareElements.__call__
+        setattr(CompareElements, "compare", CompareElements.__call__)
+        delattr(CompareElements, "__call__")
+        bond_call = CompareOrder.__call__
+        setattr(CompareOrder, "compare", CompareOrder.__call__)
+        delattr(CompareOrder, "__call__")
+        Common.test1(self,
+            AtomTyper=CompareElements,
+            BondTyper=CompareOrder)
+        setattr(CompareElements, "__call__", atom_call)
+        delattr(CompareElements, "compare")
+        setattr(CompareOrder, "__call__", bond_call)
+        delattr(CompareOrder, "compare")
+
+    def test1PythonImplDeprecatedTypo(self):
+        atom_call = CompareElements.__call__
+        setattr(CompareElements, "comparx", CompareElements.__call__)
+        delattr(CompareElements, "__call__")
+        bond_call = CompareOrder.__call__
+        setattr(CompareOrder, "comparx", CompareOrder.__call__)
+        delattr(CompareOrder, "__call__")
+        self.assertRaises(TypeError, lambda self: Common.test1(self,
+            AtomTyper=CompareElements,
+            BondTyper=CompareOrder))
+        setattr(CompareElements, "__call__", atom_call)
+        delattr(CompareElements, "comparx")
+        setattr(CompareOrder, "__call__", bond_call)
+        delattr(CompareOrder, "comparx")
+    # DEPRECATED: remove until here in release 2021.01
+
     def test2(self):
         Common.test2(self)
 
@@ -809,8 +837,8 @@ class TestCase(unittest.TestCase):
         ms = [Chem.MolFromSmiles(x) for x in smis]
         self.assertRaises(TypeError, lambda ps: setattr(ps, "AtomTyper",
                           AtomCompareCompareIsInt()))
-        ps.AtomTyper = AtomCompareNoCompare()
-        self.assertRaises(TypeError, lambda ms, ps: rdFMCS.FindMCS(ms, ps))
+        self.assertRaises(TypeError, lambda ps: setattr(ps, "AtomTyper",
+                          AtomCompareNoCompare()))
 
     def test13MCSAtomCompareUserData(self):
         smis = ['CCOCCOC', 'CCNCCCC']
@@ -830,8 +858,8 @@ class TestCase(unittest.TestCase):
         ms = [Chem.MolFromSmiles(x) for x in smis]
         self.assertRaises(TypeError, lambda ps: setattr(ps, "BondTyper",
                           BondCompareCompareIsInt()))
-        ps.BondTyper = BondCompareNoCompare()
-        self.assertRaises(TypeError, lambda ms, ps: rdFMCS.FindMCS(ms, ps))
+        self.assertRaises(TypeError, lambda ps: setattr(ps, "BondTyper",
+                          BondCompareNoCompare()))
 
     def test15MCSBondCompareUserData(self):
         smis = ['C1CC=CCC1', 'c1ccccc1']
@@ -852,8 +880,8 @@ class TestCase(unittest.TestCase):
         ms = [Chem.MolFromSmiles(x) for x in smis]
         self.assertRaises(TypeError, lambda ps: setattr(ps, "ProgressCallback",
                           ProgressCallbackCallbackIsInt()))
-        ps.ProgressCallback = ProgressCallbackNoCallback()
-        self.assertRaises(TypeError, lambda ms, ps: rdFMCS.FindMCS(ms, ps))
+        self.assertRaises(TypeError, lambda ps: setattr(ps, "ProgressCallback",
+                          ProgressCallbackNoCallback()))
 
     def test17MCSProgressCallbackCancel(self):
         ps = rdFMCS.MCSParameters()
@@ -864,6 +892,24 @@ class TestCase(unittest.TestCase):
         mcs = rdFMCS.FindMCS(ms, ps)
         self.assertTrue(mcs.canceled)
         self.assertEqual(ps.ProgressCallback.callCount, 3)
+
+    # DEPRECATED: remove from here in release 2021.01
+    def test17MCSProgressCallbackCancelDeprecated(self):
+        callback = ProgressCallback.__call__
+        setattr(ProgressCallback, "callback", ProgressCallback.__call__)
+        delattr(ProgressCallback, "__call__")
+        self.test17MCSProgressCallbackCancel()
+        setattr(ProgressCallback, "__call__", callback)
+        delattr(ProgressCallback, "callback")
+
+    def test17MCSProgressCallbackCancelDeprecatedTypo(self):
+        callback = ProgressCallback.__call__
+        setattr(ProgressCallback, "callbacx", ProgressCallback.__call__)
+        delattr(ProgressCallback, "__call__")
+        self.assertRaises(TypeError, self.test17MCSProgressCallbackCancel)
+        setattr(ProgressCallback, "__call__", callback)
+        delattr(ProgressCallback, "callbacx")
+    # DEPRECATED: remove until here in release 2021.01
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
We have discussed this as part of #2597 with @greglandrum and we decided to use consistently `operator()` (C++) and `__call__()` (Python) for user-overridable methods (e.g., custom FMCS compare functions, callbacks).
I have made the old function names deprecated such that they can be removed in release 2021.01.
I have added relevant tests to make sure both the new and deprecated functions still work.
Additionally, the new code will throw a Python exception if the virtual C++ method is not overridden by the Python derived class as soon an attempt to set the compare/callback is made, whereas previously the exception was thrown only when the virtual C++ function was actually called in the absence of the Python override, which was a bit annoying.