### PR TITLE
Fix #3312

### DIFF
--- a/Code/GraphMol/CMakeLists.txt
+++ b/Code/GraphMol/CMakeLists.txt
@@ -154,7 +154,7 @@ rdkit_catch_test(graphmolTestsCatch catch_graphmol.cpp catch_main.cpp
            LINK_LIBRARIES SubstructMatch FileParsers SmilesParse GraphMol )
 
 rdkit_catch_test(graphmolSGroupCatch catch_sgroups.cpp  catch_main.cpp
-           LINK_LIBRARIES SmilesParse GraphMol )
+           LINK_LIBRARIES SmilesParse FileParsers GraphMol )
 
 rdkit_catch_test(graphmolAdjustQueryCatch catch_adjustquery.cpp catch_main.cpp
            LINK_LIBRARIES SubstructMatch FileParsers SmilesParse GraphMol )

--- a/Code/GraphMol/FileParsers/MolSGroupWriting.cpp
+++ b/Code/GraphMol/FileParsers/MolSGroupWriting.cpp
@@ -509,18 +509,19 @@ std::string FormatV3000StringPropertyBlock(const std::string &prop,
 
   std::string propValue;
   if (sgroup.getPropIfPresent(prop, propValue)) {
-    ret << ' ' << prop << '=';
-    bool hasSpaces =
-        (propValue.end() != find(propValue.begin(), propValue.end(), ' '));
+    if (!propValue.empty()) {
+      ret << ' ' << prop << '=';
+      bool hasSpaces = propValue.find(' ') != std::string::npos;
 
-    if (hasSpaces || propValue.empty()) {
-      ret << "\"";
-    }
+      if (hasSpaces) {
+        ret << "\"";
+      }
 
-    ret << propValue;
+      ret << propValue;
 
-    if (hasSpaces || propValue.empty()) {
-      ret << "\"";
+      if (hasSpaces) {
+        ret << "\"";
+      }
     }
   }
 

--- a/Code/GraphMol/Wrap/SubstanceGroup.cpp
+++ b/Code/GraphMol/Wrap/SubstanceGroup.cpp
@@ -45,6 +45,11 @@ SubstanceGroup *createMolSubstanceGroup(ROMol &mol, std::string type) {
   return &(getSubstanceGroups(mol).back());
 }
 
+SubstanceGroup *addMolSubstanceGroup(ROMol &mol, const SubstanceGroup &sgroup) {
+  addSubstanceGroup(mol, sgroup);
+  return &(getSubstanceGroups(mol).back());
+}
+
 void addBracketHelper(SubstanceGroup &self, python::object pts) {
   unsigned int sz = python::extract<unsigned int>(pts.attr("__len__")());
   if (sz != 2 && sz != 3) {
@@ -196,7 +201,15 @@ struct sgroup_wrap {
                 "removes all SubstanceGroups from a molecule (if any)");
     python::def("CreateMolSubstanceGroup", &createMolSubstanceGroup,
                 (python::arg("mol"), python::arg("type")),
-                "creates a new SubstanceGroup associated with a molecule",
+                "creates a new SubstanceGroup associated with a molecule, "
+                "returns the new SubstanceGroup",
+                python::return_value_policy<
+                    python::reference_existing_object,
+                    python::with_custodian_and_ward_postcall<0, 1>>());
+    python::def("AddMolSubstanceGroup", &addMolSubstanceGroup,
+                (python::arg("mol"), python::arg("sgroup")),
+                "adds a copy of a SubstanceGroup to a molecule, returns the "
+                "new SubstanceGroup",
                 python::return_value_policy<
                     python::reference_existing_object,
                     python::with_custodian_and_ward_postcall<0, 1>>());

--- a/Code/GraphMol/Wrap/testSGroups.py
+++ b/Code/GraphMol/Wrap/testSGroups.py
@@ -233,6 +233,62 @@ M  END
     pv = sg.GetStringVectProp('DATAFIELDS')
     self.assertEqual(list(pv), ['val2', 'val1'])
 
+  def testCopying(self):
+    mol = Chem.MolFromMolBlock('''
+  Mrv2014 07312005252D          
+ 
+  0  0  0     0  0            999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 7 6 3 0 0
+M  V30 BEGIN ATOM
+M  V30 1 * -12.75 11.5 0 0
+M  V30 2 O -11.4163 12.27 0 0
+M  V30 3 C -10.0826 11.5 0 0
+M  V30 4 C -8.749 12.27 0 0
+M  V30 5 O -10.0826 9.96 0 0
+M  V30 6 N -7.4153 11.5 0 0
+M  V30 7 C -6.0816 12.27 0 0
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 1 1 2
+M  V30 2 1 2 3
+M  V30 3 1 3 4
+M  V30 4 2 3 5
+M  V30 5 1 4 6
+M  V30 6 1 6 7
+M  V30 END BOND
+M  V30 BEGIN SGROUP
+M  V30 1 SRU 0 ATOMS=(3 2 3 5) XBONDS=(2 1 3) BRKXYZ=(9 -9.9955 12.6173 0 -
+M  V30 -9.0715 11.0169 0 0 0 0) BRKXYZ=(9 -11.5035 11.1527 0 -12.4275 12.7531 -
+M  V30 0 0 0 0) CONNECT=HT LABEL=n
+M  V30 2 DAT 0 ATOMS=(1 6) FIELDNAME=foo_data -
+M  V30 FIELDDISP="   -7.4153   11.5000    DAU   ALL  0       0" -
+M  V30 MRV_FIELDDISP=0 FIELDDATA=bar
+M  V30 3 DAT 0 ATOMS=(1 7) FIELDNAME=bar_data -
+M  V30 FIELDDISP="   -6.0816   12.2700    DAU   ALL  0       0" -
+M  V30 MRV_FIELDDISP=0 FIELDDATA=baz
+M  V30 END SGROUP
+M  V30 END CTAB
+M  END''')
+    self.assertEqual(len(Chem.GetMolSubstanceGroups(mol)), 3)
+    mol2 = Chem.Mol(mol)
+    Chem.ClearMolSubstanceGroups(mol2)
+    self.assertEqual(len(Chem.GetMolSubstanceGroups(mol2)), 0)
+    sgs = Chem.GetMolSubstanceGroups(mol)
+    Chem.AddMolSubstanceGroup(mol2, sgs[0])
+    Chem.AddMolSubstanceGroup(mol2, sgs[2])
+    self.assertEqual(len(Chem.GetMolSubstanceGroups(mol2)), 2)
+    molb = Chem.MolToV3KMolBlock(mol2)
+    self.assertEqual(molb.find("foo_data"), -1)
+    self.assertGreater(molb.find("M  V30 2 DAT 0 ATOMS=(1 7) FIELDNAME=bar_data"), 0)
+
+    # we can also use this to copy SGroups:
+    sgs2 = Chem.GetMolSubstanceGroups(mol2)
+    newsg = Chem.AddMolSubstanceGroup(mol2, sgs[1])
+    newsg.SetProp("FIELDNAME", "blah_data")
+    molb = Chem.MolToV3KMolBlock(mol2)
+    self.assertGreater(molb.find("M  V30 2 DAT 0 ATOMS=(1 7) FIELDNAME=blah_data"), 0)
+
 
 if __name__ == '__main__':
   print("Testing SubstanceGroups wrapper")

--- a/Code/GraphMol/Wrap/testSGroups.py
+++ b/Code/GraphMol/Wrap/testSGroups.py
@@ -287,7 +287,8 @@ M  END''')
     newsg = Chem.AddMolSubstanceGroup(mol2, sgs[1])
     newsg.SetProp("FIELDNAME", "blah_data")
     molb = Chem.MolToV3KMolBlock(mol2)
-    self.assertGreater(molb.find("M  V30 2 DAT 0 ATOMS=(1 7) FIELDNAME=blah_data"), 0)
+    print(molb)
+    self.assertGreater(molb.find("M  V30 3 DAT 0 ATOMS=(1 6) FIELDNAME=blah_data"), 0)
 
 
 if __name__ == '__main__':

--- a/Code/GraphMol/catch_sgroups.cpp
+++ b/Code/GraphMol/catch_sgroups.cpp
@@ -286,3 +286,55 @@ TEST_CASE("Build and test sample molecule", "[Sgroups]") {
     CHECK(dataFields[2] == "SAMPLE DATA FIELD 3");
   }
 }
+
+TEST_CASE("Removing sgroups", "[Sgroups]") {
+  SECTION("basics") {
+    auto m1 = R"CTAB(
+  Mrv2014 07312005252D          
+ 
+  0  0  0     0  0            999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 7 6 3 0 0
+M  V30 BEGIN ATOM
+M  V30 1 * -12.75 11.5 0 0
+M  V30 2 O -11.4163 12.27 0 0
+M  V30 3 C -10.0826 11.5 0 0
+M  V30 4 C -8.749 12.27 0 0
+M  V30 5 O -10.0826 9.96 0 0
+M  V30 6 N -7.4153 11.5 0 0
+M  V30 7 C -6.0816 12.27 0 0
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 1 1 2
+M  V30 2 1 2 3
+M  V30 3 1 3 4
+M  V30 4 2 3 5
+M  V30 5 1 4 6
+M  V30 6 1 6 7
+M  V30 END BOND
+M  V30 BEGIN SGROUP
+M  V30 1 SRU 0 ATOMS=(3 2 3 5) XBONDS=(2 1 3) BRKXYZ=(9 -9.9955 12.6173 0 -
+M  V30 -9.0715 11.0169 0 0 0 0) BRKXYZ=(9 -11.5035 11.1527 0 -12.4275 12.7531 -
+M  V30 0 0 0 0) CONNECT=HT LABEL=n
+M  V30 2 DAT 0 ATOMS=(1 6) FIELDNAME=foo_data -
+M  V30 FIELDDISP="   -7.4153   11.5000    DAU   ALL  0       0" -
+M  V30 MRV_FIELDDISP=0 FIELDDATA=bar
+M  V30 3 DAT 0 ATOMS=(1 7) FIELDNAME=bar_data -
+M  V30 FIELDDISP="   -6.0816   12.2700    DAU   ALL  0       0" -
+M  V30 MRV_FIELDDISP=0 FIELDDATA=baz
+M  V30 END SGROUP
+M  V30 END CTAB
+M  END
+)CTAB"_ctab;
+    REQUIRE(m1);
+    auto &sgs = getSubstanceGroups(*m1);
+    CHECK(sgs.size() == 3);
+    sgs.erase(++sgs.begin());
+    CHECK(sgs.size() == 2);
+    CHECK(getSubstanceGroups(*m1).size() == 2);
+    auto molb = MolToV3KMolBlock(*m1);
+    CHECK(molb.find("foo_data") == std::string::npos);
+    CHECK(molb.find("M  V30 2 DAT 0 ATOMS=(1 7) FIELDNAME=bar_data") !=
+          std::string::npos);
+  }
+}

--- a/Code/GraphMol/catch_sgroups.cpp
+++ b/Code/GraphMol/catch_sgroups.cpp
@@ -338,3 +338,31 @@ M  END
           std::string::npos);
   }
 }
+
+TEST_CASE(
+    "Github #3315: SubstanceGroups should not be written with quotes around "
+    "missing fields",
+    "[Sgroups][bug]") {
+  SECTION("basics") {
+    auto m1 = R"CTAB(
+  Mrv2014 07312012022D          
+
+  2  1  0  0  0  0            999 V2000
+    1.4295    0.1449    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    1.4266   -0.6801    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+  2  1  1  0  0  0  0
+M  STY  1   1 DAT
+M  SAL   1  1   1
+M  SDT   1 test sgroup                                           
+M  SDD   1     0.5348   -0.3403    DRU   ALL  0       0  
+M  SED   1 sgroupval
+M  END
+)CTAB"_ctab;
+    REQUIRE(m1);
+    auto molb = MolToV3KMolBlock(*m1);
+    CHECK(molb.find("FIELDINFO") == std::string::npos);
+    CHECK(molb.find("QUERYTYPE") == std::string::npos);
+    CHECK(molb.find("QUERYOP") == std::string::npos);
+    CHECK(molb.find("FIELDNAME") != std::string::npos);
+  }
+}


### PR DESCRIPTION
- Allows copies of `SubstanceGroup` objects to be added to molecules from Python. (#3312)
- Stops writing empty strings as SubstanceGroup properties in v3K output (#3315)

I also noticed that there weren't any tests demonstrating that we could safely remove `SubstanceGroup`s on the C++ side, so I added one