### PR TITLE
Fixes for aromatic bond fuzzy queries

### DIFF
--- a/Code/GraphMol/AdjustQuery.cpp
+++ b/Code/GraphMol/AdjustQuery.cpp
@@ -99,11 +99,7 @@ void adjustConjugatedFiveRings(RWMol &mol) {
     // FIX: replace this with the SingleOrDoubleOrAromatic query once the
     // tautomer PR is merged
     QueryBond qb;
-    qb.setQuery(makeBondOrderEqualsQuery(Bond::BondType::SINGLE));
-    qb.expandQuery(makeBondOrderEqualsQuery(Bond::BondType::DOUBLE),
-                   Queries::COMPOSITE_OR);
-    qb.expandQuery(makeBondOrderEqualsQuery(Bond::BondType::AROMATIC),
-                   Queries::COMPOSITE_OR);
+    qb.setQuery(makeSingleOrDoubleOrAromaticBondQuery());
     for (auto bi : ring) {
       const auto bond = mol.getBondWithIdx(bi);
       if (std::find(bondTypesToModify.begin(), bondTypesToModify.end(),
@@ -133,9 +129,7 @@ void adjustSingleBondsFromAromaticAtoms(RWMol &mol, bool toDegreeOneNeighbors,
     return;
   }
   QueryBond qb;
-  qb.setQuery(makeBondOrderEqualsQuery(Bond::BondType::SINGLE));
-  qb.expandQuery(makeBondOrderEqualsQuery(Bond::BondType::AROMATIC),
-                 Queries::COMPOSITE_OR);
+  qb.setQuery(makeSingleOrAromaticBondQuery());
   if (!mol.getRingInfo()->isInitialized()) {
     MolOps::symmetrizeSSSR(mol);
   }
@@ -143,8 +137,7 @@ void adjustSingleBondsFromAromaticAtoms(RWMol &mol, bool toDegreeOneNeighbors,
     const auto bAt = bond->getBeginAtom();
     const auto eAt = bond->getEndAtom();
     if (!bond->hasQuery() && bond->getBondType() == Bond::BondType::SINGLE &&
-        (bAt->getIsAromatic() || eAt->getIsAromatic()) &&
-        !mol.getRingInfo()->numBondRings(bond->getIdx())) {
+        (bAt->getIsAromatic() || eAt->getIsAromatic())) {
       if (toDegreeOneNeighbors &&
           (bAt->getIsAromatic() ^ eAt->getIsAromatic())) {
         if ((bAt->getIsAromatic() && eAt->getDegree() == 1) ||

--- a/Code/GraphMol/Fingerprints/PatternFingerprints.cpp
+++ b/Code/GraphMol/Fingerprints/PatternFingerprints.cpp
@@ -177,7 +177,7 @@ bool isPatternComplexQuery(const Bond *b) {
 bool isTautomerBondQuery(const Bond *b) {
   // assumes we have already tested true for isPatternComplexQuery
   auto description = b->getQuery()->getDescription();
-  return description == "SingleOrDoubleOrAromaticBond";
+  return description =="SingleOrDoubleOrAromaticBond" || description == "SingleOrAromaticBond";
 }
 
 }  // namespace

--- a/Code/GraphMol/SmilesParse/SmartsWrite.cpp
+++ b/Code/GraphMol/SmilesParse/SmartsWrite.cpp
@@ -375,6 +375,8 @@ std::string getBondSmartsSimple(const Bond *bond,
     res += "@";
   } else if (descrip == "SingleOrAromaticBond") {
     // don't need to do anything here... :-)
+  } else if (descrip == "SingleOrDoubleOrAromaticBond") {
+    res += "-,=,:";
   } else if (descrip == "BondDir") {
     int val = bquery->getVal();
     if (val == static_cast<int>(Bond::ENDDOWNRIGHT)) {

--- a/Code/GraphMol/TautomerQuery/catch_tests.cpp
+++ b/Code/GraphMol/TautomerQuery/catch_tests.cpp
@@ -218,13 +218,14 @@ TEST_CASE("TEST_FINGERPRINT") {
   auto templateMol = tautomerQuery->getTemplateMolecule();
 
   // this test molecule has complex query bonds where the template has query
-  // bonds, but they are not tautomer bonds.
+  // bonds, but they are not identified as tautomer bonds.
   RWMol molWithoutTautomerBonds(*mol);
   std::vector<std::pair<int, int>> atomIndexes;
   for (auto modifiedBondIdx : tautomerQuery->getModifiedBonds()) {
-    auto bondQuery = makeSingleOrAromaticBondQuery();
     auto queryBond = new QueryBond();
-    queryBond->setQuery(bondQuery);
+    queryBond->setQuery(makeBondOrderEqualsQuery(Bond::BondType::SINGLE));
+    queryBond->expandQuery(makeBondOrderEqualsQuery(Bond::BondType::AROMATIC),
+                   Queries::COMPOSITE_OR);
     molWithoutTautomerBonds.replaceBond(modifiedBondIdx, queryBond, true);
     delete queryBond;
   }

--- a/Code/JavaWrappers/ChemTransforms.i
+++ b/Code/JavaWrappers/ChemTransforms.i
@@ -37,11 +37,24 @@
 #include <GraphMol/Bond.h>
 // Fixes annoying compilation namespace issue
 typedef RDKit::MatchVectType MatchVectType;
+
+// Partial binding to one overload of RDKit::fragmentOnBonds
 RDKit::ROMol *fragmentMolOnBonds(
     const RDKit::ROMol &mol, const std::vector<int> &bondIndices,
-    bool addDummies = true,
-    const std::vector<std::pair<unsigned int, unsigned int> > *dummyLabels = nullptr,
-    std::vector<int> *nCutsPerAtom = nullptr);
+    bool addDummies = true, 
+    const std::vector<std::pair<unsigned int, unsigned int>> *dummyLabels = nullptr,
+    std::vector<int> *nCutsPerAtom = nullptr) {
+        // The c# wrapper is unable to wrap vector<unsigned int> so pass in vector<int> and convert
+        std::vector<unsigned int> uBondIndices(bondIndices.begin(), bondIndices.end());
+        std::vector<unsigned int> uNCutsPerAtom;
+        if (nCutsPerAtom) {
+            uNCutsPerAtom.insert(uNCutsPerAtom.begin(), nCutsPerAtom->begin(), nCutsPerAtom->end());
+        }
+        auto cutsPerAtomPtr = nCutsPerAtom ? &uNCutsPerAtom : nullptr;
+        // Can't handle the 5th argument of vector<BondType> as swig will not wrap vector of enum
+        return RDKit::MolFragmenter::fragmentOnBonds(mol, uBondIndices, addDummies, dummyLabels, nullptr, cutsPerAtomPtr);
+ }
+
 %}
 
 %newobject deleteSubstructs;
@@ -52,8 +65,16 @@ RDKit::ROMol *fragmentMolOnBonds(
 %include <GraphMol/Bond.h>
 %include <GraphMol/ChemTransforms/ChemTransforms.h>
 
+%newobject fragmentMolOnBonds;
 %ignore fragmentOnBonds;
 %rename("fragmentOnBonds") fragmentMolOnBonds;
+
+RDKit::ROMol *fragmentMolOnBonds(
+    const RDKit::ROMol &mol, const std::vector<int> &bondIndices,
+    bool addDummies = true, 
+    const std::vector<std::pair<unsigned int, unsigned int>> *dummyLabels = nullptr,
+    std::vector<int> *nCutsPerAtom = nullptr);
+
 %ignore fragmentOnSomeBonds;
 %ignore constructFragmenterAtomTypes;
 %ignore constructBRICSAtomTypes;
@@ -63,19 +84,3 @@ RDKit::ROMol *fragmentMolOnBonds(
 %newobject fragmentOnBRICSBonds;
 %template(UIntMolMap) std::map<unsigned int,boost::shared_ptr<RDKit::ROMol> >;
 %include <GraphMol/ChemTransforms/MolFragmenter.h>
-%newobject fragmentMolOnBonds;
-
-RDKit::ROMol *fragmentMolOnBonds(
-    const RDKit::ROMol &mol, const std::vector<int> &bondIndices,
-    bool addDummies = true, 
-    const std::vector<std::pair<unsigned int, unsigned int>> *dummyLabels = nullptr,
-    std::vector<int> *nCutsPerAtom = nullptr) {
-        std::vector<unsigned int> uBondIndices(bondIndices.begin(), bondIndices.end());
-        std::vector<unsigned int> uNCutsPerAtom;
-        if (nCutsPerAtom) {
-            uNCutsPerAtom.insert(uNCutsPerAtom.begin(), nCutsPerAtom->begin(), nCutsPerAtom->end());
-        }
-        auto cutsPerAtomPtr = nCutsPerAtom ? &uNCutsPerAtom : nullptr;
-        return RDKit::fragmentOnBonds(mol, uBondIndices, addDummies, dummyLabels, nullptr, cutsPerAtomPtr);
- }
-

--- a/Code/JavaWrappers/ChemTransforms.i
+++ b/Code/JavaWrappers/ChemTransforms.i
@@ -33,8 +33,15 @@
 
 %{
 #include <GraphMol/ChemTransforms/ChemTransforms.h>
+#include <GraphMol/ChemTransforms/MolFragmenter.h>
+#include <GraphMol/Bond.h>
 // Fixes annoying compilation namespace issue
 typedef RDKit::MatchVectType MatchVectType;
+RDKit::ROMol *fragmentMolOnBonds(
+    const RDKit::ROMol &mol, const std::vector<int> &bondIndices,
+    bool addDummies = true,
+    const std::vector<std::pair<unsigned int, unsigned int> > *dummyLabels = nullptr,
+    std::vector<int> *nCutsPerAtom = nullptr);
 %}
 
 %newobject deleteSubstructs;
@@ -42,9 +49,11 @@ typedef RDKit::MatchVectType MatchVectType;
 %newobject replaceCores;
 %newobject MurckoDecompose;
 %template(StringMolMap) std::map<std::string,boost::shared_ptr<RDKit::ROMol> >;
+%include <GraphMol/Bond.h>
 %include <GraphMol/ChemTransforms/ChemTransforms.h>
 
 %ignore fragmentOnBonds;
+%rename("fragmentOnBonds") fragmentMolOnBonds;
 %ignore fragmentOnSomeBonds;
 %ignore constructFragmenterAtomTypes;
 %ignore constructBRICSAtomTypes;
@@ -54,3 +63,19 @@ typedef RDKit::MatchVectType MatchVectType;
 %newobject fragmentOnBRICSBonds;
 %template(UIntMolMap) std::map<unsigned int,boost::shared_ptr<RDKit::ROMol> >;
 %include <GraphMol/ChemTransforms/MolFragmenter.h>
+%newobject fragmentMolOnBonds;
+
+RDKit::ROMol *fragmentMolOnBonds(
+    const RDKit::ROMol &mol, const std::vector<int> &bondIndices,
+    bool addDummies = true, 
+    const std::vector<std::pair<unsigned int, unsigned int>> *dummyLabels = nullptr,
+    std::vector<int> *nCutsPerAtom = nullptr) {
+        std::vector<unsigned int> uBondIndices(bondIndices.begin(), bondIndices.end());
+        std::vector<unsigned int> uNCutsPerAtom;
+        if (nCutsPerAtom) {
+            uNCutsPerAtom.insert(uNCutsPerAtom.begin(), nCutsPerAtom->begin(), nCutsPerAtom->end());
+        }
+        auto cutsPerAtomPtr = nCutsPerAtom ? &uNCutsPerAtom : nullptr;
+        return RDKit::fragmentOnBonds(mol, uBondIndices, addDummies, dummyLabels, nullptr, cutsPerAtomPtr);
+ }
+


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! 
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.

TautomerQuery catch test was broken when adding aromatic bond fuzzy matching to pattern fingerprinting.

The error was caused by using a test molecule which was similar to a tautomer template but without tautomer bonds.  By including singleOrAromatic in the tautomer pattern fingerprint, all the query bonds in the test molecule were identified as tautomer bonds.

#### Any other comments?

Also includes a wrapping of fragmentOnBonds for Java/C#.  I can remove and submit in another request if this is inappropriate.

