### PR TITLE
Sped up SSSR by not storing every path back to root

### DIFF
--- a/Code/GraphMol/FindRings.cpp
+++ b/Code/GraphMol/FindRings.cpp
@@ -728,7 +728,7 @@ int BFSWorkspace::smallestRingsBfs(const ROMol &mol, int root,
         ring = {nbrIdx};
         // forwards path
         int parent = d_parents[nbrIdx];
-        while (parent != -1) {
+        while (parent != -1 && parent != root) {
           ring.push_back(parent);
           parent = d_parents[parent];
         }
@@ -736,7 +736,7 @@ int BFSWorkspace::smallestRingsBfs(const ROMol &mol, int root,
         // backwards path
         ring.insert(ring.begin(), curr);
         parent = d_parents[curr];
-        while (parent != -1 && parent != root) {
+        while (parent != -1) {
           // Is the least common ancestor not the root?
           if (std::find(ring.begin(), ring.end(), parent) != ring.end()) {
             ring.clear();

--- a/Code/GraphMol/FindRings.cpp
+++ b/Code/GraphMol/FindRings.cpp
@@ -78,7 +78,9 @@ class BFSWorkspace {
                        INT_VECT *forbidden = nullptr);
 
  private:
-  VECT_INT_VECT d_atPaths;
+  INT_VECT d_parents;
+  std::vector<unsigned int> d_depths;
+  INT_VECT d_done;
 };
 
 void trimBonds(unsigned int cand, const ROMol &tMol, INT_SET &changed,
@@ -317,14 +319,12 @@ void findRingsD2nodes(const ROMol &tMol, VECT_INT_VECT &res,
                       boost::dynamic_bitset<> &ringAtoms) {
   // place to record any duplicate rings discovered from the current d2 nodes
   RINGINVAR_INT_VECT_MAP dupD2Cands;
-  int cand;
   INT_VECT_CI d2i;
   INT_SET changed;
 
   INT_INT_VECT_MAP dupMap;
   // here is an example of molecule where the this scheme of finding other node
-  // that
-  // result in duplicates is necessary : C12=CON=C1C(C4)CC3CC2CC4C3
+  // that result in duplicates is necessary : C12=CON=C1C(C4)CC3CC2CC4C3
   // It would help to draw this molecule, and number the atoms but here is what
   // happen
   //  - there are 6 d2 node - 1, 6, 7, 9, 11, 13
@@ -342,14 +342,12 @@ void findRingsD2nodes(const ROMol &tMol, VECT_INT_VECT &res,
   std::map<int, RINGINVAR_VECT> nodeInvars;
   std::map<int, RINGINVAR_VECT>::const_iterator nici;
   BFSWorkspace bfs_workspace;
-  for (d2i = d2nodes.begin(); d2i != d2nodes.end(); ++d2i) {
-    cand = (*d2i);
+  for (auto& cand: d2nodes) {
     // std::cerr<<"    smallest rings bfs: "<<cand<<std::endl;
     VECT_INT_VECT srings;
     // we have to find all non duplicate possible smallest rings for each node
     bfs_workspace.smallestRingsBfs(tMol, cand, srings, activeBonds);
-    for (VECT_INT_VECT_CI sri = srings.begin(); sri != srings.end(); ++sri) {
-      const INT_VECT &nring = (*sri);
+    for (const auto& nring: srings) {
       std::uint32_t invr =
           RingUtils::computeRingInvariant(nring, tMol.getNumAtoms());
       if (invars.find(invr) == invars.end()) {
@@ -374,14 +372,14 @@ void findRingsD2nodes(const ROMol &tMol, VECT_INT_VECT &res,
 
       nodeInvars[cand].push_back(invr);
       // check if this ring is duplicate with something else
-      for (nici = nodeInvars.begin(); nici != nodeInvars.end(); nici++) {
-        if (nici->first != cand) {
-          if (std::find(nici->second.begin(), nici->second.end(), invr) !=
-              nici->second.end()) {
+      for (auto& nici: nodeInvars) {
+        if (nici.first != cand) {
+          if (std::find(nici.second.begin(), nici.second.end(), invr) !=
+              nici.second.end()) {
             // ok we discovered this ring via another node before
             // add that node as duplicate to this node and vice versa
-            dupMap[cand].push_back(nici->first);
-            dupMap[nici->first].push_back(cand);
+            dupMap[cand].push_back(nici.first);
+            dupMap[nici.first].push_back(cand);
           }
         }
       }
@@ -605,7 +603,7 @@ int greatestComFac(long curfac, long nfac) {
 
 /******************************************************************************
  * SUMMARY:
- *  remove the bond in the molecule that connect to the spcified atom
+ *  remove the bond in the molecule that connect to the specified atom
  *
  * ARGUMENTS:
  *  cand - the node(atom) of interest
@@ -635,6 +633,8 @@ void trimBonds(unsigned int cand, const ROMol &tMol, INT_SET &changed,
     atomDegrees[cand] -= 1;
   }
 }
+
+
 
 /*******************************************************************************
  * SUMMARY:
@@ -666,29 +666,22 @@ int BFSWorkspace::smallestRingsBfs(const ROMol &mol, int root,
   // FIX: this should be number of atoms in the fragment (if it's required at
   // all, see below)
   const int WHITE = 0, GRAY = 1, BLACK = 2;
-  INT_VECT done(mol.getNumAtoms(), WHITE);
+  d_done.assign(mol.getNumAtoms(), WHITE);
 
   if (forbidden) {
     for (auto i : *forbidden) {
-      done[i] = BLACK;
+      d_done[i] = BLACK;
     }
   }
 
-  // it would be "nicer" to use a map for d_atPaths, but that ends up being too
-  // slow:
-  {
-    // reset all paths to 0 size, but don't deallocate.
-    for (auto &p : d_atPaths) {
-      p.clear();
-    }
-    d_atPaths.resize(mol.getNumAtoms());
-    d_atPaths[root].assign(1, root);
-  }
+  d_parents.assign(mol.getNumAtoms(), -1);
+  d_depths.assign(mol.getNumAtoms(), 0);
 
   std::deque<int> bfsq;
   bfsq.push_back(root);
 
-  int curr = -1;
+  INT_VECT ring;
+
   unsigned int curSize = UINT_MAX;
   while (bfsq.size() > 0) {
     if (bfsq.size() >= RingUtils::MAX_BFSQ_SIZE) {
@@ -699,12 +692,15 @@ int BFSWorkspace::smallestRingsBfs(const ROMol &mol, int root,
       throw ValueErrorException(msg);
     }
 
-    curr = bfsq.front();
+    const int curr = bfsq.front();
     bfsq.pop_front();
+    d_done[curr] = BLACK;
 
-    done[curr] = BLACK;
-
-    INT_VECT &cpath = d_atPaths[curr];
+    const unsigned int depth = d_depths[curr] + 1;
+    if (depth > curSize) {
+      // depth is the shortest cycle I _could_ find this round.
+      break;
+    }
 
     ROMol::OEDGE_ITER beg, end;
     boost::tie(beg, end) = mol.getAtomBonds(mol.getAtomWithIdx(curr));
@@ -715,69 +711,52 @@ int BFSWorkspace::smallestRingsBfs(const ROMol &mol, int root,
         continue;
       }
       int nbrIdx = bond->getOtherAtomIdx(curr);
-      if ((std::find(cpath.begin(), cpath.end(), nbrIdx) == cpath.end()) &&
-          done[nbrIdx] != BLACK) {
-        // i.e. we are not at a node that is making up the current path
-        // and we are not a node that has been completely explored before
-        // (it has been a curr node before)
+      if (d_done[nbrIdx] == BLACK || d_parents[curr] == nbrIdx) {
+        continue;
+      }
+      if (d_done[nbrIdx] == WHITE) {
+        // we have never been to this node before through via any path
+        d_parents[nbrIdx] = curr;
+        d_done[nbrIdx] = GRAY;
+        d_depths[nbrIdx] = depth;
+        bfsq.push_back(nbrIdx);
+      } else {
+        // we have been here via a different path
+        // there is a potential for ring closure here
+        // stitch together the two paths
 
-        // FIX: can we avoid this find by coloring atoms gray when they go into
-        // the queue and just looking up the colors?
-        if (done[nbrIdx] == WHITE) {
-          // we have never been to this node before through via any path
-          d_atPaths[nbrIdx] = cpath;
-          d_atPaths[nbrIdx].push_back(nbrIdx);
-          done[nbrIdx] = GRAY;
-          bfsq.push_back(nbrIdx);
-        }  // end of found a untouched node
-        else {
-          // we have been here via a different path
-          // there is a potential for ring closure here
-          INT_VECT npath = d_atPaths[nbrIdx];
-          // make sure that the intersections of cpath and npath give exactly
-          // one element and that should be the root element for correct ring
-          // closure
-          int id = -1;
-          unsigned int com = 0;
-          for (INT_VECT_CI ci = cpath.begin(); ci != cpath.end(); ++ci) {
-            if (std::find(npath.begin(), npath.end(), (*ci)) != npath.end()) {
-              com++;
-              id = (*ci);
-              if (id != root) {
-                break;
-              }
-            }
-          }  // end of found stuff in common with neighbor
+        ring = {nbrIdx};
+        // forwards path
+        int parent = d_parents[nbrIdx];
+        while (parent != -1) {
+          ring.push_back(parent);
+          parent = d_parents[parent];
+        }
 
-          if (id == root) {  // we found a ring
-            // make the ring
-            INT_VECT ring = cpath;
+        // backwards path
+        ring.insert(ring.begin(), curr);
+        parent = d_parents[curr];
+        while (parent != -1 && parent != root) {
+          // Is the least common ancestor not the root?
+          if (std::find(ring.begin(), ring.end(), parent) != ring.end()) {
+            ring.clear();
+            break;
+          }
+          ring.insert(ring.begin(), parent);
+          parent = d_parents[parent];
+        }
 
-            // remove the root node and attach the other half of the ring from
-            // npath
-            // reverse this piece so that the ring is traversed correctly
-
-            // FIX: we're probably assured that root is the first node, so we
-            // can
-            //  just pop it from the front
-            npath.erase(std::remove(npath.begin(), npath.end(), root));
-
-#ifndef WIN32
-            ring.insert(ring.end(), npath.rbegin(), npath.rend());
-#else  // I <heart> MSVC++ v6
-            std::reverse(npath.begin(), npath.end());
-            ring.insert(ring.end(), npath.begin(), npath.end());
-#endif
-            if (ring.size() <= curSize) {
-              curSize = rdcast<unsigned int>(ring.size());
-              rings.push_back(ring);
-            } else {
-              // we are done with the smallest rings
-              return rdcast<unsigned int>(rings.size());
-            }
-          }  // end of found a ring
-        }    // end of we have seen this neighbor before
-      }      // end of nbrIdx not part of current path and not a done atom
+        // Found a new small ring including the root.
+        if (ring.size() > 1) {
+          if (ring.size() <= curSize) {
+            curSize = rdcast<unsigned int>(ring.size());
+            rings.push_back(ring);
+          } else {
+            // we are done with the smallest rings
+            return rdcast<unsigned int>(rings.size());
+          }
+        }
+      }
     }        // end of loop over neighbors of current atom
   }          // moving to the next node
 
@@ -948,8 +927,8 @@ int findSSSR(const ROMol &mol, VECT_INT_VECT &res) {
   VECT_INT_VECT frags;
   INT_VECT curFrag;
   unsigned int nfrags = getMolFrags(mol, frags);
-  for (unsigned int fi = 0; fi < nfrags;
-       fi++) {  // loop over the fragments in a molecule
+  // loop over the fragments in a molecule
+  for (unsigned int fi = 0; fi < nfrags; ++fi) {
     VECT_INT_VECT fragRes;
     curFrag = frags[fi];
 
@@ -958,21 +937,19 @@ int findSSSR(const ROMol &mol, VECT_INT_VECT &res) {
     }
 
     // the following is the list of atoms that are useful in the next round of
-    // trimming
-    // basically atoms that become degree 0 or 1 because of bond removals
+    // trimming basically atoms that become degree 0 or 1 because of bond removals
     // initialized with atoms of degrees 0 and 1
     INT_SET changed;
     int bndcnt_with_zero_order_bonds = 0;
     unsigned int nbnds = 0;
-    for (INT_VECT_CI aidi = curFrag.begin(); aidi != curFrag.end(); aidi++) {
-      int atom_idx = *aidi;
+    for (auto atom_idx: curFrag) {
       bndcnt_with_zero_order_bonds += atomDegreesWithZeroOrderBonds[atom_idx];
 
       int deg = atomDegrees[atom_idx];
 
       nbnds += deg;
       if (deg < 2) {
-        changed.insert((*aidi));
+        changed.insert(atom_idx);
       }
     }
 


### PR DESCRIPTION
Before this commit:

3EOH: 0.72s
2J3N: 0.26s
1NKS: 0.018s

After this commit:
3EOH: 0.35s
2J3N: 0.07s
1NKS: 0.007s

<!--
Thanks for contributing a pull request! 
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.

This change speeds up ring performance by not storing every path back to the root. Instead, it keeps track of parents and rebuilds paths from the parents once a cycle is found. It also stops the BFS once the depth of the BFS is larger than the smallest ring (i.e., we found a path that is longer than the smallest ring).

#### Any other comments?

