### PR TITLE
Fixed return value of ConstrainedEmbed

### DIFF
--- a/rdkit/Chem/AllChem.py
+++ b/rdkit/Chem/AllChem.py
@@ -347,7 +347,7 @@ def ConstrainedEmbed(mol, core, useTethers=True, coreConfId=-1, randomseed=2342,
     # realign
     rms = AlignMol(mol, core, atomMap=algMap)
   mol.SetProp('EmbedRMS', str(rms))
-  return mol
+  return ci
 
 
 def AssignBondOrdersFromTemplate(refmol, mol):


### PR DESCRIPTION
The return value of the AllChem.ConstrainedEmbed function changed from an RDKit molecule to an index of a generated conformer.