### PR TITLE
switch to using target_compile_definitions instead of add_definitions

### DIFF
--- a/Code/Catalogs/CMakeLists.txt
+++ b/Code/Catalogs/CMakeLists.txt
@@ -1,8 +1,8 @@
 
-add_definitions(-DRDKIT_CATALOGS_BUILD)
 rdkit_library(Catalogs 
               Catalog.cpp CatalogParams.cpp CatalogEntry.cpp
               LINK_LIBRARIES RDGeneral)
+target_compile_definitions(Catalogs PRIVATE RDKIT_CATALOGS_BUILD)
 
 rdkit_headers(CatalogEntry.h
               Catalog.h

--- a/Code/ChemicalFeatures/CMakeLists.txt
+++ b/Code/ChemicalFeatures/CMakeLists.txt
@@ -1,7 +1,7 @@
 
-add_definitions(-DRDKIT_CHEMICALFEATURES_BUILD)
 rdkit_library(ChemicalFeatures FreeChemicalFeature.cpp
               LINK_LIBRARIES RDGeneral RDGeometryLib)
+target_compile_definitions(ChemicalFeatures PRIVATE RDKIT_CHEMICALFEATURES_BUILD)
 
 rdkit_headers(ChemicalFeature.h
               FreeChemicalFeature.h DEST ChemicalFeatures)

--- a/Code/DataStructs/CMakeLists.txt
+++ b/Code/DataStructs/CMakeLists.txt
@@ -3,12 +3,12 @@ if(RDK_OPTIMIZE_POPCNT)
 endif()
 
 
-add_definitions(-DRDKIT_DATASTRUCTS_BUILD)
 rdkit_library(DataStructs
               BitVect.cpp SparseBitVect.cpp ExplicitBitVect.cpp Utils.cpp
               base64.cpp BitOps.cpp DiscreteDistMat.cpp
               DiscreteValueVect.cpp FPBReader.cpp MultiFPBReader.cpp
               LINK_LIBRARIES RDGeneral)
+target_compile_definitions(DataStructs PRIVATE RDKIT_DATASTRUCTS_BUILD)
 
 rdkit_headers(base64.h
               BitOps.h

--- a/Code/DistGeom/CMakeLists.txt
+++ b/Code/DistGeom/CMakeLists.txt
@@ -1,11 +1,11 @@
 ### ISSUE: This library was originally named DistGeom. I've renamed it here
 ### to avoid a target name clash in ./Wrap
 
-add_definitions(-DRDKIT_DISTGEOMETRY_BUILD)
 rdkit_library(DistGeometry
               DistGeomUtils.cpp TriangleSmooth.cpp DistViolationContrib.cpp 
               ChiralViolationContrib.cpp
               LINK_LIBRARIES EigenSolvers ForceField ForceFieldHelpers)
+target_compile_definitions(DistGeometry PRIVATE RDKIT_DISTGEOMETRY_BUILD)
 
 rdkit_headers(BoundsMatrix.h
               ChiralSet.h

--- a/Code/ForceField/CMakeLists.txt
+++ b/Code/ForceField/CMakeLists.txt
@@ -1,5 +1,4 @@
 
-add_definitions(-DRDKIT_FORCEFIELD_BUILD)
 rdkit_library(ForceField
               ForceField.cpp 
               UFF/AngleBend.cpp UFF/BondStretch.cpp UFF/Nonbonded.cpp
@@ -13,6 +12,7 @@ rdkit_library(ForceField
               MMFF/TorsionConstraint.cpp MMFF/PositionConstraint.cpp
               MMFF/Params.cpp
               LINK_LIBRARIES Optimizer Trajectory)
+target_compile_definitions(ForceField PRIVATE RDKIT_FORCEFIELD_BUILD)
 
 rdkit_headers(Contrib.h
               ForceField.h DEST ForceField)

--- a/Code/Geometry/CMakeLists.txt
+++ b/Code/Geometry/CMakeLists.txt
@@ -1,9 +1,9 @@
 
-add_definitions(-DRDKIT_RDGEOMETRYLIB_BUILD)
 rdkit_library(RDGeometryLib 
               point.cpp Transform2D.cpp Transform3D.cpp 
               UniformGrid3D.cpp GridUtils.cpp
               LINK_LIBRARIES DataStructs RDGeneral)
+target_compile_definitions(RDGeometryLib PRIVATE RDKIT_RDGEOMETRYLIB_BUILD)
 
 rdkit_headers(Grid3D.h
               GridUtils.h

--- a/Code/GraphMol/CIPLabeler/CMakeLists.txt
+++ b/Code/GraphMol/CIPLabeler/CMakeLists.txt
@@ -1,4 +1,3 @@
-add_definitions(-DRDKIT_CIPLABELER_BUILD)
 
 set(configs_src
     configs/Configuration.cpp
@@ -23,6 +22,7 @@ rdkit_library(CIPLabeler
               Mancude.cpp Digraph.cpp Node.cpp Edge.cpp Sort.cpp
               ${configs_src} ${rules_src}
               LINK_LIBRARIES GraphMol)
+target_compile_definitions(CIPLabeler PRIVATE RDKIT_CIPLABELER_BUILD)
 
 rdkit_headers(CIPLabeler.h
               DEST CIPLabeler)

--- a/Code/GraphMol/CMakeLists.txt
+++ b/Code/GraphMol/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-add_definitions(-DRDKIT_GRAPHMOL_BUILD)
-
 rdkit_library(GraphMol
               Atom.cpp QueryAtom.cpp QueryBond.cpp Bond.cpp
               MolOps.cpp FindRings.cpp ROMol.cpp RWMol.cpp PeriodicTable.cpp
@@ -12,6 +10,7 @@ rdkit_library(GraphMol
               new_canon.cpp SubstanceGroup.cpp
               SHARED
               LINK_LIBRARIES RDGeometryLib RDGeneral  )
+target_compile_definitions(GraphMol PRIVATE RDKIT_GRAPHMOL_BUILD)
 if(RDK_USE_URF)
   target_link_libraries(GraphMol PUBLIC ${RDK_URF_LIBS})
 endif()

--- a/Code/GraphMol/ChemReactions/CMakeLists.txt
+++ b/Code/GraphMol/ChemReactions/CMakeLists.txt
@@ -11,9 +11,6 @@ if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 5)
   endif()
 endif()
 
-
-remove_definitions(-DRDKIT_GRAPHMOL_BUILD)
-add_definitions(-DRDKIT_CHEMREACTIONS_BUILD)
 rdkit_library(ChemReactions
               Reaction.cpp MDLParser.cpp DaylightParser.cpp ReactionPickler.cpp
 	            ReactionWriter.cpp ReactionDepict.cpp ReactionFingerprints.cpp ReactionUtils.cpp MoleculeParser.cpp ReactionRunner.cpp PreprocessRxn.cpp SanitizeRxn.cpp
@@ -23,6 +20,7 @@ rdkit_library(ChemReactions
               LINK_LIBRARIES
               FilterCatalog Descriptors Fingerprints DataStructs Depictor
               FileParsers SubstructMatch ChemTransforms GraphMol ${RDKit_SERIALIZATION_LIBS})
+target_compile_definitions(ChemReactions PRIVATE RDKIT_CHEMREACTIONS_BUILD)
 
 rdkit_headers(Reaction.h
               ReactionParser.h

--- a/Code/GraphMol/ChemTransforms/CMakeLists.txt
+++ b/Code/GraphMol/ChemTransforms/CMakeLists.txt
@@ -1,8 +1,7 @@
 
-remove_definitions(-DRDKIT_GRAPHMOL_BUILD)
-add_definitions(-DRDKIT_CHEMTRANSFORMS_BUILD)
 rdkit_library(ChemTransforms ChemTransforms.cpp MolFragmenter.cpp LINK_LIBRARIES
   GraphMol SubstructMatch SmilesParse )
+target_compile_definitions(ChemTransforms PRIVATE -DRDKIT_CHEMTRANSFORMS_BUILD)
 
 rdkit_headers(ChemTransforms.h
    MolFragmenter.h

--- a/Code/GraphMol/Depictor/CMakeLists.txt
+++ b/Code/GraphMol/Depictor/CMakeLists.txt
@@ -1,6 +1,5 @@
 
 remove_definitions(-DRDKIT_GRAPHMOL_BUILD)
-add_definitions(-DRDKIT_DEPICTOR_BUILD)
 
 if(RDK_BUILD_COORDGEN_SUPPORT)
 
@@ -16,6 +15,7 @@ endif()
 rdkit_library(Depictor
               RDDepictor.cpp EmbeddedFrag.cpp DepictUtils.cpp
               LINK_LIBRARIES ${RDK_COORDGEN_LIBS} SubstructMatch GraphMol RDGeneral)
+target_compile_definitions(Depictor PRIVATE RDKIT_DEPICTOR_BUILD)
 
 rdkit_headers(DepictUtils.h
               EmbeddedFrag.h

--- a/Code/GraphMol/Descriptors/CMakeLists.txt
+++ b/Code/GraphMol/Descriptors/CMakeLists.txt
@@ -6,8 +6,6 @@ if(RDK_BUILD_DESCRIPTORS3D)
 endif(RDK_BUILD_DESCRIPTORS3D)
 
 
-remove_definitions(-DRDKIT_GRAPHMOL_BUILD)
-add_definitions(-DRDKIT_DESCRIPTORS_BUILD)
 rdkit_library(Descriptors
               Crippen.cpp BCUT.cpp MolDescriptors.cpp MolSurf.cpp Lipinski.cpp ConnectivityDescriptors.cpp
               MQN.cpp
@@ -17,6 +15,7 @@ rdkit_library(Descriptors
               ${DESC3D_SOURCES}
               LINK_LIBRARIES PartialCharges SmilesParse FileParsers Subgraphs SubstructMatch MolTransforms GraphMol
                  EigenSolvers RDGeneral)
+target_compile_definitions(Descriptors PRIVATE RDKIT_DESCRIPTORS_BUILD)
 
 rdkit_headers(Crippen.h BCUT.h Lipinski.h
               MolDescriptors.h

--- a/Code/GraphMol/DistGeomHelpers/CMakeLists.txt
+++ b/Code/GraphMol/DistGeomHelpers/CMakeLists.txt
@@ -1,9 +1,8 @@
 
-remove_definitions(-DRDKIT_GRAPHMOL_BUILD)
-add_definitions(-DRDKIT_DISTGEOMHELPERS_BUILD)
 rdkit_library(DistGeomHelpers BoundsMatrixBuilder.cpp Embedder.cpp
               LINK_LIBRARIES ForceFieldHelpers GraphMol DistGeometry Alignment
                 )
+target_compile_definitions(DistGeomHelpers PRIVATE RDKIT_DISTGEOMHELPERS_BUILD)
 
 rdkit_headers(BoundsMatrixBuilder.h
               Embedder.h DEST GraphMol/DistGeomHelpers)

--- a/Code/GraphMol/FMCS/CMakeLists.txt
+++ b/Code/GraphMol/FMCS/CMakeLists.txt
@@ -1,9 +1,8 @@
 
-remove_definitions(-DRDKIT_GRAPHMOL_BUILD)
-add_definitions(-DRDKIT_FMCS_BUILD)
 rdkit_library(FMCS
               FMCS.cpp Seed.cpp MaximumCommonSubgraph.cpp SubstructMatchCustom.cpp
               LINK_LIBRARIES Depictor SmilesParse FileParsers ChemTransforms SubstructMatch GraphMol )
+target_compile_definitions(FMCS PRIVATE RDKIT_FMCS_BUILD)
 
 rdkit_headers(FMCS.h
               Graph.h

--- a/Code/GraphMol/FileParsers/CMakeLists.txt
+++ b/Code/GraphMol/FileParsers/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-remove_definitions(-DRDKIT_GRAPHMOL_BUILD)
-add_definitions(-DRDKIT_FILEPARSERS_BUILD)
 
 if(RDK_USE_BOOST_IOSTREAMS)
 if(WIN32)
@@ -46,6 +44,7 @@ rdkit_library(FileParsers
               SequenceParsers.cpp SequenceWriters.cpp
               SVGParser.cpp
               LINK_LIBRARIES Depictor SmilesParse GraphMol ${RDK_MAEPARSER_LIBS} ${regex_lib} ${link_iostreams})
+target_compile_definitions(FileParsers PRIVATE RDKIT_FILEPARSERS_BUILD)
 
 rdkit_headers(FileParsers.h
               FileParserUtils.h

--- a/Code/GraphMol/FilterCatalog/CMakeLists.txt
+++ b/Code/GraphMol/FilterCatalog/CMakeLists.txt
@@ -21,8 +21,6 @@ if (PYTHONINTERP_FOUND)
 endif()
 
 
-remove_definitions(-DRDKIT_GRAPHMOL_BUILD)
-add_definitions(-DRDKIT_FILTERCATALOG_BUILD)
 rdkit_library(FilterCatalog
               Filters.cpp
               FilterCatalog.cpp
@@ -32,6 +30,7 @@ rdkit_library(FilterCatalog
               FunctionalGroupHierarchy.cpp
               LINK_LIBRARIES Subgraphs SubstructMatch SmilesParse
               GraphMol Catalogs ${RDKit_SERIALIZATION_LIBS} )
+target_compile_definitions(FilterCatalog PRIVATE RDKIT_FILTERCATALOG_BUILD)
 
 rdkit_headers(FilterCatalogEntry.h
               FilterCatalog.h

--- a/Code/GraphMol/Fingerprints/CMakeLists.txt
+++ b/Code/GraphMol/Fingerprints/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-remove_definitions(-DRDKIT_GRAPHMOL_BUILD)
-add_definitions(-DRDKIT_FINGERPRINTS_BUILD)
 rdkit_library(Fingerprints
               Fingerprints.cpp PatternFingerprints.cpp MorganFingerprints.cpp
               AtomPairs.cpp MACCS.cpp MHFP.cpp FingerprintGenerator.cpp 
@@ -8,6 +6,7 @@ rdkit_library(Fingerprints
               FingerprintUtil.cpp TopologicalTorsionGenerator.cpp
               LINK_LIBRARIES DataStructs Subgraphs SubstructMatch SmilesParse GraphMol RDGeneral
               )
+target_compile_definitions(Fingerprints PRIVATE RDKIT_FINGERPRINTS_BUILD)
 
 rdkit_headers(AtomPairs.h
               Fingerprints.h

--- a/Code/GraphMol/ForceFieldHelpers/CMakeLists.txt
+++ b/Code/GraphMol/ForceFieldHelpers/CMakeLists.txt
@@ -1,11 +1,11 @@
 # moved back library build directives here
 
-remove_definitions(-DRDKIT_GRAPHMOL_BUILD)
-add_definitions(-DRDKIT_FORCEFIELDHELPERS_BUILD)
 rdkit_library(ForceFieldHelpers UFF/AtomTyper.cpp UFF/Builder.cpp
               MMFF/AtomTyper.cpp MMFF/Builder.cpp CrystalFF/TorsionAngleM6.cpp
               CrystalFF/TorsionPreferences.cpp
               LINK_LIBRARIES SmilesParse SubstructMatch ForceField)
+target_compile_definitions(ForceFieldHelpers PRIVATE RDKIT_FORCEFIELDHELPERS_BUILD)
+
 rdkit_headers(FFConvenience.h DEST GraphMol/ForceFieldHelpers)
 rdkit_headers(UFF/AtomTyper.h
               UFF/Builder.h UFF/UFF.h DEST GraphMol/ForceFieldHelpers/UFF)

--- a/Code/GraphMol/FragCatalog/CMakeLists.txt
+++ b/Code/GraphMol/FragCatalog/CMakeLists.txt
@@ -1,10 +1,9 @@
 
-remove_definitions(-DRDKIT_GRAPHMOL_BUILD)
-add_definitions(-DRDKIT_FRAGCATALOG_BUILD)
 rdkit_library(FragCatalog
               FragCatalogUtils.cpp FragCatGenerator.cpp FragCatalogEntry.cpp 
               FragCatParams.cpp FragFPGenerator.cpp
               LINK_LIBRARIES Subgraphs SubstructMatch SmilesParse Catalogs GraphMol RDGeneral )
+target_compile_definitions(FragCatalog PRIVATE RDKIT_FRAGCATALOG_BUILD)
 
 rdkit_headers(FragCatalogEntry.h
               FragCatalogUtils.h

--- a/Code/GraphMol/MMPA/CMakeLists.txt
+++ b/Code/GraphMol/MMPA/CMakeLists.txt
@@ -3,11 +3,10 @@ if (MSVC)
 endif(MSVC)
 
 
-remove_definitions(-DRDKIT_GRAPHMOL_BUILD)
-add_definitions(-DRDKIT_MMPA_BUILD)
 rdkit_library(MMPA
               MMPA.cpp
               LINK_LIBRARIES SubstructMatch Depictor FileParsers ChemTransforms GraphMol RDGeneral )
+target_compile_definitions(MMPA PRIVATE RDKIT_MMPA_BUILD)
 
 rdkit_headers(MMPA.h
               DEST GraphMol/MMPA)

--- a/Code/GraphMol/MolAlign/CMakeLists.txt
+++ b/Code/GraphMol/MolAlign/CMakeLists.txt
@@ -1,11 +1,11 @@
 
-remove_definitions(-DRDKIT_GRAPHMOL_BUILD)
-add_definitions(-DRDKIT_MOLALIGN_BUILD)
 rdkit_library(MolAlign AlignMolecules.cpp 
               LINK_LIBRARIES MolTransforms SubstructMatch Alignment GraphMol RDGeneral)
+target_compile_definitions(MolAlign PRIVATE RDKIT_MOLALIGN_BUILD)
 
 rdkit_library(O3AAlign O3AAlignMolecules.cpp
               LINK_LIBRARIES MolAlign MolTransforms SubstructMatch Alignment GraphMol RDGeneral ForceFieldHelpers)
+target_compile_definitions(O3AAlign PRIVATE RDKIT_MOLALIGN_BUILD)
 
 rdkit_headers(AlignMolecules.h O3AAlignMolecules.h DEST GraphMol/MolAlign)
 

--- a/Code/GraphMol/MolCatalog/CMakeLists.txt
+++ b/Code/GraphMol/MolCatalog/CMakeLists.txt
@@ -1,8 +1,7 @@
 
-remove_definitions(-DRDKIT_GRAPHMOL_BUILD)
-add_definitions(-DRDKIT_MOLCATALOG_BUILD)
 rdkit_library(MolCatalog MolCatalogEntry.cpp MolCatalogParams.cpp
               LINK_LIBRARIES GraphMol Catalogs)
+target_compile_definitions(MolCatalog PRIVATE RDKIT_MOLCATALOG_BUILD)
 
 rdkit_headers(MolCatalogEntry.h
               MolCatalog.h

--- a/Code/GraphMol/MolChemicalFeatures/CMakeLists.txt
+++ b/Code/GraphMol/MolChemicalFeatures/CMakeLists.txt
@@ -1,10 +1,9 @@
 
-remove_definitions(-DRDKIT_GRAPHMOL_BUILD)
-add_definitions(-DRDKIT_MOLCHEMICALFEATURES_BUILD)
 rdkit_library(MolChemicalFeatures
               MolChemicalFeature.cpp MolChemicalFeatureDef.cpp 
               MolChemicalFeatureFactory.cpp FeatureParser.cpp
               LINK_LIBRARIES SubstructMatch SmilesParse GraphMol)
+target_compile_definitions(MolChemicalFeatures PRIVATE RDKIT_MOLCHEMICALFEATURES_BUILD)
 
 rdkit_headers(FeatureParser.h MolChemicalFeatureFactory.h
               MolChemicalFeatureDef.h  MolChemicalFeature.h 

--- a/Code/GraphMol/MolDraw2D/CMakeLists.txt
+++ b/Code/GraphMol/MolDraw2D/CMakeLists.txt
@@ -13,14 +13,13 @@ rdkit_headers(MolDraw2D.h
   DEST GraphMol/MolDraw2D
 )
 
-remove_definitions(-DRDKIT_GRAPHMOL_BUILD)
-add_definitions(-DRDKIT_MOLDRAW2D_BUILD)
 rdkit_library(MolDraw2D MolDraw2D.cpp MolDraw2DSVG.cpp
   MolDraw2DDetails.cpp MolDraw2DUtils.cpp DrawText.cpp
   DrawTextSVG.cpp
   LINK_LIBRARIES
   ChemReactions Depictor MolTransforms 
   SubstructMatch Subgraphs GraphMol EigenSolvers )
+target_compile_definitions(MolDraw2D PRIVATE RDKIT_MOLDRAW2D_BUILD)
 
 if(RDK_BUILD_QT_SUPPORT)
   find_package(Qt5 COMPONENTS Widgets OpenGL REQUIRED)

--- a/Code/GraphMol/MolEnumerator/CMakeLists.txt
+++ b/Code/GraphMol/MolEnumerator/CMakeLists.txt
@@ -1,9 +1,8 @@
-remove_definitions(-DRDKIT_GRAPHMOL_BUILD)
-add_definitions(-DRDKIT_MOLENUMERATOR_BUILD)
 rdkit_library(MolEnumerator
               MolEnumerator.cpp PositionVariation.cpp LinkNode.cpp
               LINK_LIBRARIES FileParsers ChemReactions ChemTransforms 
               SubstructMatch GraphMol RDGeneral)
+target_compile_definitions(MolEnumerator PRIVATE RDKIT_MOLENUMERATOR_BUILD)
 
 rdkit_headers(MolEnumerator.h DEST GraphMol/MolEnumerator)
 

--- a/Code/GraphMol/MolHash/CMakeLists.txt
+++ b/Code/GraphMol/MolHash/CMakeLists.txt
@@ -1,9 +1,8 @@
 
-remove_definitions(-DRDKIT_GRAPHMOL_BUILD)
-add_definitions(-DRDKIT_MOLHASH_BUILD)
 rdkit_library(MolHash
               hashfunctions.cpp normalize.cpp
               LINK_LIBRARIES Depictor Descriptors GraphMol)
+target_compile_definitions(MolHash PRIVATE RDKIT_MOLHASH_BUILD)
 
 rdkit_headers(MolHash.h nmmolhash.h           
               DEST GraphMol/MolHash)

--- a/Code/GraphMol/MolInterchange/CMakeLists.txt
+++ b/Code/GraphMol/MolInterchange/CMakeLists.txt
@@ -13,11 +13,10 @@ endif()
 include_directories(${CMAKE_SOURCE_DIR}/External/rapidjson-1.1.0/include)
 
 
-remove_definitions(-DRDKIT_GRAPHMOL_BUILD)
-add_definitions(-DRDKIT_MOLINTERCHANGE_BUILD)
 rdkit_library(MolInterchange
               Parser.cpp Writer.cpp
               LINK_LIBRARIES GraphMol)
+target_compile_definitions(MolInterchange PRIVATE RDKIT_MOLINTERCHANGE_BUILD)
 
 rdkit_headers(MolInterchange.h details.h
               DEST GraphMol/MolInterchange)

--- a/Code/GraphMol/MolStandardize/CMakeLists.txt
+++ b/Code/GraphMol/MolStandardize/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-remove_definitions(-DRDKIT_GRAPHMOL_BUILD)
-add_definitions(-DRDKIT_MOLSTANDARDIZE_BUILD)
 rdkit_library(MolStandardize
               MolStandardize.cpp
 	      Metal.cpp
@@ -22,6 +20,7 @@ rdkit_library(MolStandardize
         TautomerCatalog/TautomerCatalogParams.cpp
         TautomerCatalog/TautomerCatalogUtils.cpp
 	      LINK_LIBRARIES ChemReactions ChemTransforms SmilesParse SubstructMatch Descriptors GraphMol )
+target_compile_definitions(MolStandardize PRIVATE RDKIT_MOLSTANDARDIZE_BUILD)
 
 rdkit_headers(MolStandardize.h
 	      Metal.h

--- a/Code/GraphMol/MolTransforms/CMakeLists.txt
+++ b/Code/GraphMol/MolTransforms/CMakeLists.txt
@@ -1,8 +1,7 @@
 
-remove_definitions(-DRDKIT_GRAPHMOL_BUILD)
-add_definitions(-DRDKIT_MOLTRANSFORMS_BUILD)
 rdkit_library(MolTransforms MolTransforms.cpp
               LINK_LIBRARIES GraphMol EigenSolvers RDGeneral )
+target_compile_definitions(MolTransforms PRIVATE RDKIT_MOLTRANSFORMS_BUILD)
 
 rdkit_headers(MolTransforms.h DEST GraphMol/MolTransforms)
 

--- a/Code/GraphMol/PartialCharges/CMakeLists.txt
+++ b/Code/GraphMol/PartialCharges/CMakeLists.txt
@@ -1,9 +1,8 @@
 
-remove_definitions(-DRDKIT_GRAPHMOL_BUILD)
-add_definitions(-DRDKIT_PARTIALCHARGES_BUILD)
 rdkit_library(PartialCharges
               GasteigerCharges.cpp GasteigerParams.cpp
               LINK_LIBRARIES GraphMol RDGeneral)
+target_compile_definitions(PartialCharges PRIVATE RDKIT_PARTIALCHARGES_BUILD)
 
 rdkit_headers(GasteigerCharges.h
               GasteigerParams.h DEST GraphMol/PartialCharges)

--- a/Code/GraphMol/RGroupDecomposition/CMakeLists.txt
+++ b/Code/GraphMol/RGroupDecomposition/CMakeLists.txt
@@ -1,11 +1,10 @@
 
-remove_definitions(-DRDKIT_GRAPHMOL_BUILD)
-add_definitions(-DRDKIT_RGROUPDECOMPOSITION_BUILD)
 rdkit_library(RGroupDecomposition RGroupDecomp.cpp RGroupUtils.cpp
 				  RGroupDecompParams.cpp RGroupScore.cpp
   LINK_LIBRARIES
   FMCS ChemTransforms SubstructMatch SmilesParse 
  GraphMol RDGeneral)
+target_compile_definitions(RGroupDecomposition PRIVATE RDKIT_RGROUPDECOMPOSITION_BUILD)
 
 rdkit_headers(
    RGroupDecomp.h

--- a/Code/GraphMol/ReducedGraphs/CMakeLists.txt
+++ b/Code/GraphMol/ReducedGraphs/CMakeLists.txt
@@ -1,9 +1,8 @@
 
-remove_definitions(-DRDKIT_GRAPHMOL_BUILD)
-add_definitions(-DRDKIT_REDUCEDGRAPHS_BUILD)
 rdkit_library(ReducedGraphs
               ReducedGraphs.cpp
               LINK_LIBRARIES SubstructMatch SmilesParse GraphMol RDGeneral)
+target_compile_definitions(ReducedGraphs PRIVATE RDKIT_REDUCEDGRAPHS_BUILD)
 
 rdkit_headers(ReducedGraphs.h
               DEST GraphMol/ReducedGraphs)

--- a/Code/GraphMol/SLNParse/CMakeLists.txt
+++ b/Code/GraphMol/SLNParse/CMakeLists.txt
@@ -39,12 +39,11 @@ endif(BISON_EXECUTABLE)
 
 
 
-remove_definitions(-DRDKIT_GRAPHMOL_BUILD)
-add_definitions(-DRDKIT_SLNPARSE_BUILD)
 rdkit_library(SLNParse
               SLNParse.cpp SLNAttribs.cpp
               ${BISON_OUTPUT_FILES} ${FLEX_OUTPUT_FILES}
               LINK_LIBRARIES GraphMol RDGeneral )
+target_compile_definitions(SLNParse PRIVATE RDKIT_SLNPARSE_BUILD)
 
 rdkit_headers(SLNAttribs.h
               SLNParse.h

--- a/Code/GraphMol/ScaffoldNetwork/CMakeLists.txt
+++ b/Code/GraphMol/ScaffoldNetwork/CMakeLists.txt
@@ -1,9 +1,8 @@
-remove_definitions(-DRDKIT_GRAPHMOL_BUILD)
-add_definitions(-DRDKIT_SCAFFOLDNETWORK_BUILD)
 rdkit_library(ScaffoldNetwork
               ScaffoldNetwork.cpp
               LINK_LIBRARIES MolStandardize ChemReactions ChemTransforms SmilesParse 
               SubstructMatch GraphMol RDGeneral)
+target_compile_definitions(ScaffoldNetwork PRIVATE RDKIT_SCAFFOLDNETWORK_BUILD)
 
 rdkit_headers(ScaffoldNetwork.h DEST GraphMol/ScaffoldNetwork)
 

--- a/Code/GraphMol/ShapeHelpers/CMakeLists.txt
+++ b/Code/GraphMol/ShapeHelpers/CMakeLists.txt
@@ -1,8 +1,7 @@
 
-remove_definitions(-DRDKIT_GRAPHMOL_BUILD)
-add_definitions(-DRDKIT_SHAPEHELPERS_BUILD)
 rdkit_library(ShapeHelpers ShapeEncoder.cpp ShapeUtils.cpp
               LINK_LIBRARIES MolTransforms GraphMol RDGeneral)
+target_compile_definitions(ShapeHelpers PRIVATE RDKIT_SHAPEHELPERS_BUILD)
 
 rdkit_headers(ShapeEncoder.h
               ShapeUtils.h DEST GraphMol/ShapeHelpers)

--- a/Code/GraphMol/SmilesParse/CMakeLists.txt
+++ b/Code/GraphMol/SmilesParse/CMakeLists.txt
@@ -51,14 +51,13 @@ else(BISON_EXECUTABLE)
 endif(BISON_EXECUTABLE)
 
 
-remove_definitions(-DRDKIT_GRAPHMOL_BUILD)
-add_definitions(-DRDKIT_SMILESPARSE_BUILD)
 rdkit_library(SmilesParse
               SmilesParse.cpp SmilesParseOps.cpp
               SmilesWrite.cpp SmartsWrite.cpp CXSmilesOps.cpp
               ${BISON_OUTPUT_FILES}
               ${FLEX_OUTPUT_FILES}
               LINK_LIBRARIES GraphMol RDGeneral)
+target_compile_definitions(SmilesParse PRIVATE RDKIT_SMILESPARSE_BUILD)
 
 rdkit_headers(primes.h
               SmartsWrite.h

--- a/Code/GraphMol/StructChecker/CMakeLists.txt
+++ b/Code/GraphMol/StructChecker/CMakeLists.txt
@@ -1,11 +1,10 @@
 
-remove_definitions(-DRDKIT_GRAPHMOL_BUILD)
-add_definitions(-DRDKIT_STRUCTCHECKER_BUILD)
 rdkit_library(StructChecker
               StructChecker.cpp StructCheckerOptions.cpp StructureFlags.cpp Utilites.cpp
               Pattern.cpp Stereo.cpp AtomSymbolMatch.cpp StripSmallFragments.cpp ReCharge.cpp Tautomer.cpp
               LINK_LIBRARIES Depictor SubstructMatch FileParsers ChemTransforms Descriptors
                              GraphMol RDGeneral )
+target_compile_definitions(StructChecker PRIVATE RDKIT_STRUCTCHECKER_BUILD)
 
 rdkit_headers(StructChecker.h Utilites.h Pattern.h Stereo.h StripSmallFragments.h ReCharge.h Tautomer.h
               DEST GraphMol/StructChecker)

--- a/Code/GraphMol/Subgraphs/CMakeLists.txt
+++ b/Code/GraphMol/Subgraphs/CMakeLists.txt
@@ -1,8 +1,7 @@
 
-remove_definitions(-DRDKIT_GRAPHMOL_BUILD)
-add_definitions(-DRDKIT_SUBGRAPHS_BUILD)
 rdkit_library(Subgraphs Subgraphs.cpp SubgraphUtils.cpp
               LINK_LIBRARIES GraphMol RDGeneral )
+target_compile_definitions(Subgraphs PRIVATE RDKIT_SUBGRAPHS_BUILD)
 
 rdkit_headers(Subgraphs.h
               SubgraphUtils.h DEST GraphMol/Subgraphs)

--- a/Code/GraphMol/Substruct/CMakeLists.txt
+++ b/Code/GraphMol/Substruct/CMakeLists.txt
@@ -1,9 +1,8 @@
 
-remove_definitions(-DRDKIT_GRAPHMOL_BUILD)
-add_definitions(-DRDKIT_SUBSTRUCTMATCH_BUILD)
 rdkit_library(SubstructMatch 
               SubstructMatch.cpp SubstructUtils.cpp
               LINK_LIBRARIES GraphMol RDGeneral)
+target_compile_definitions(SubstructMatch PRIVATE RDKIT_SUBSTRUCTMATCH_BUILD)
 
 rdkit_headers(SubstructMatch.h
               SubstructUtils.h DEST GraphMol/Substruct)

--- a/Code/GraphMol/SubstructLibrary/CMakeLists.txt
+++ b/Code/GraphMol/SubstructLibrary/CMakeLists.txt
@@ -7,13 +7,12 @@ endif()
 
 if(RDK_BUILD_THREADSAFE_SSS)
 
-remove_definitions(-DRDKIT_GRAPHMOL_BUILD)
-add_definitions(-DRDKIT_SUBSTRUCTLIBRARY_BUILD)
 rdkit_library(SubstructLibrary
               SubstructLibrary.cpp
 	      PatternFactory.cpp
               LINK_LIBRARIES Fingerprints SubstructMatch SmilesParse
               GraphMol Catalogs DataStructs RDGeneral ${RDKit_SERIALIZATION_LIBS})
+target_compile_definitions(SubstructLibrary PRIVATE RDKIT_SUBSTRUCTLIBRARY_BUILD)
 
 rdkit_headers(SubstructLibrary.h
               SubstructLibrarySerialization.h

--- a/Code/GraphMol/TautomerQuery/CMakeLists.txt
+++ b/Code/GraphMol/TautomerQuery/CMakeLists.txt
@@ -1,9 +1,8 @@
 
-remove_definitions(-DRDKIT_GRAPHMOL_BUILD)
-add_definitions(-DRDKIT_TAUTOMERQUERY_BUILD)
 rdkit_library(TautomerQuery 
               TautomerQuery.cpp
               LINK_LIBRARIES GraphMol RDGeneral MolStandardize)
+target_compile_definitions(TautomerQuery PRIVATE RDKIT_TAUTOMERQUERY_BUILD)
 
 rdkit_headers(TautomerQuery.h
               DEST GraphMol/TautomerQuery)

--- a/Code/GraphMol/Trajectory/CMakeLists.txt
+++ b/Code/GraphMol/Trajectory/CMakeLists.txt
@@ -1,8 +1,8 @@
 
 remove_definitions(-DRDKIT_GRAPHMOL_BUILD)
-add_definitions(-DRDKIT_TRAJECTORY_BUILD)
 rdkit_library(Trajectory Trajectory.cpp
               LINK_LIBRARIES GraphMol RDGeneral )
+target_compile_definitions(Trajectory PRIVATE RDKIT_TRAJECTORY_BUILD)
 
 rdkit_headers(Snapshot.h Trajectory.h DEST GraphMol/Trajectory)
 

--- a/Code/ML/Cluster/Murtagh/CMakeLists.txt
+++ b/Code/ML/Cluster/Murtagh/CMakeLists.txt
@@ -1,7 +1,8 @@
 
-add_definitions(-DRDKIT_HC_BUILD)
 
 rdkit_library(hc hc.c hcdriver.c)
+target_compile_definitions(hc PRIVATE RDKIT_HC_BUILD)
+
 set_target_properties(hc PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
 
 rdkit_python_extension(Clustering Clustering.cpp

--- a/Code/ML/InfoTheory/CMakeLists.txt
+++ b/Code/ML/InfoTheory/CMakeLists.txt
@@ -1,6 +1,6 @@
 
-add_definitions(-DRDKIT_INFOTHEORY_BUILD)
 rdkit_library(InfoTheory InfoBitRanker.cpp LINK_LIBRARIES DataStructs RDGeneral)
+target_compile_definitions(InfoTheory PRIVATE RDKIT_INFOTHEORY_BUILD)
 
 if(RDK_BUILD_PYTHON_WRAPPERS)
 add_subdirectory(Wrap)

--- a/Code/Numerics/Alignment/CMakeLists.txt
+++ b/Code/Numerics/Alignment/CMakeLists.txt
@@ -1,6 +1,6 @@
 
-add_definitions(-DRDKIT_ALIGNMENT_BUILD)
 rdkit_library(Alignment AlignPoints.cpp LINK_LIBRARIES RDGeometryLib)
+target_compile_definitions(Alignment PRIVATE RDKIT_ALIGNMENT_BUILD)
 
 rdkit_headers(AlignPoints.h DEST Numerics/Alignment)
 

--- a/Code/Numerics/EigenSolvers/CMakeLists.txt
+++ b/Code/Numerics/EigenSolvers/CMakeLists.txt
@@ -1,6 +1,6 @@
 
-add_definitions(-DRDKIT_EIGENSOLVERS_BUILD)
 rdkit_library(EigenSolvers PowerEigenSolver.cpp LINK_LIBRARIES RDGeneral)
+target_compile_definitions(EigenSolvers PRIVATE RDKIT_EIGENSOLVERS_BUILD)
 
 rdkit_headers(PowerEigenSolver.h DEST Numerics/EigenSolvers)
 

--- a/Code/Numerics/Optimizer/CMakeLists.txt
+++ b/Code/Numerics/Optimizer/CMakeLists.txt
@@ -1,8 +1,8 @@
 
-add_definitions(-DRDKIT_OPTIMIZER_BUILD)
 rdkit_library(Optimizer 
               BFGSOpt.cpp LinearSearch.cpp
               LINK_LIBRARIES RDGeometryLib Trajectory RDGeneral)
+target_compile_definitions(Optimizer PRIVATE RDKIT_OPTIMIZER_BUILD)
 
 rdkit_headers(BFGSOpt.h DEST Numerics/Optimizer)
 

--- a/Code/RDBoost/CMakeLists.txt
+++ b/Code/RDBoost/CMakeLists.txt
@@ -1,11 +1,7 @@
 if(WIN32 OR "${Py_ENABLE_SHARED}" STREQUAL "1")
-
-  add_definitions(-DRDKIT_RDBOOST_BUILD)
-  rdkit_library(RDBoost Wrap.cpp
+    rdkit_library(RDBoost Wrap.cpp
                 LINK_LIBRARIES RDGeneral rdkit_py_base rdkit_base)
 else()
-
-    add_definitions(-DRDKIT_RDBOOST_BUILD)
     rdkit_library(RDBoost Wrap.cpp
                 LINK_LIBRARIES RDGeneral rdkit_base)
     if("${PYTHON_LDSHARED}" STREQUAL "")
@@ -14,6 +10,7 @@ else()
        set_target_properties(RDBoost PROPERTIES LINK_FLAGS ${LDSHARED})
     endif()
 endif()
+target_compile_definitions(RDBoost PRIVATE RDKIT_RDBOOST_BUILD)
 
 rdkit_headers(Wrap.h PySequenceHolder.h
               list_indexing_suite.hpp

--- a/Code/RDGeneral/CMakeLists.txt
+++ b/Code/RDGeneral/CMakeLists.txt
@@ -6,10 +6,10 @@ CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/RDConfig.h.cmake
               ${CMAKE_CURRENT_SOURCE_DIR}/RDConfig.h )
 
 
-add_definitions(-DRDKIT_RDGENERAL_BUILD)
 rdkit_library(RDGeneral
               Invariant.cpp types.cpp utils.cpp RDLog.cpp 
               LocaleSwitcher.cpp versions.cpp SHARED)
+target_compile_definitions(RDGeneral PRIVATE RDKIT_RDGENERAL_BUILD)
 
 if(MINGW)
   set(hasMSVCRuntime "FALSE")

--- a/Code/RDStreams/CMakeLists.txt
+++ b/Code/RDStreams/CMakeLists.txt
@@ -20,9 +20,10 @@ else()
   endif()
 endif()
 
-add_definitions(-DRDKIT_RDSTREAMS_BUILD)
 set(boost_iostreams Boost::iostreams)
 endif(RDK_USE_BOOST_IOSTREAMS)
 rdkit_library(RDStreams streams.cpp
               LINK_LIBRARIES ${boost_iostreams} ${zlib_lib})
+target_compile_definitions(RDStreams PRIVATE RDKIT_RDSTREAMS_BUILD)
+
 rdkit_headers(streams.h DEST RDStreams)

--- a/Code/SimDivPickers/CMakeLists.txt
+++ b/Code/SimDivPickers/CMakeLists.txt
@@ -1,8 +1,8 @@
 
-add_definitions(-DRDKIT_SIMDIVPICKERS_BUILD)
 rdkit_library(SimDivPickers
               DistPicker.cpp MaxMinPicker.cpp HierarchicalClusterPicker.cpp
               LINK_LIBRARIES hc RDGeneral)
+target_compile_definitions(SimDivPickers PRIVATE RDKIT_SIMDIVPICKERS_BUILD)
 
 rdkit_headers(DistPicker.h LeaderPicker.h 
               HierarchicalClusterPicker.h

--- a/External/AvalonTools/CMakeLists.txt
+++ b/External/AvalonTools/CMakeLists.txt
@@ -38,7 +38,6 @@ if(needDownload)
   file(WRITE "${fileToPatch}" "${buffer}")
 endif()
 
-add_definitions(-DRDK_BUILD_AVALON_SUPPORT)
 if (MSVC)
   add_definitions( "/D_CRT_SECURE_NO_WARNINGS /wd4224 /wd4101 /wd4018 /wd4996 /wd4244 /wd4305 /wd4013 /wd4146 /wd4334 /wd4715 /wd4715  /nologo" )
 endif(MSVC)
@@ -86,6 +85,7 @@ endif()
 
 
 rdkit_library(avalon_clib ${avalon_clib_srcs})
+target_compile_definitions(avalon_clib PRIVATE RDKIT_AVALONLIB_BUILD)
 if((MSVC AND RDK_INSTALL_DLLS_MSVC) OR ((NOT MSVC) AND WIN32))
   set_target_properties(avalon_clib PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
 endif()
@@ -93,9 +93,9 @@ endif()
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 include_directories(${AVALON_SRC_PATH})
 
-add_definitions(-DRDKIT_AVALONLIB_BUILD)
 rdkit_library(AvalonLib AvalonTools.cpp SHARED 
      LINK_LIBRARIES avalon_clib FileParsers SmilesParse GraphMol DataStructs  )
+target_compile_definitions(AvalonLib PRIVATE RDKIT_AVALONLIB_BUILD)
 rdkit_headers(AvalonTools.h DEST GraphMol)
 rdkit_test(testAvalonLib1 test1.cpp
            LINK_LIBRARIES AvalonLib SubstructMatch )

--- a/External/FreeSASA/CMakeLists.txt
+++ b/External/FreeSASA/CMakeLists.txt
@@ -1,6 +1,5 @@
 if(RDK_BUILD_FREESASA_SUPPORT)
 
-add_definitions("-DRDKIT_FREESASALIB_BUILD")
 
 if(NOT DEFINED FREESASA_DIR)
   set(FREESASA_DIR "${CMAKE_CURRENT_SOURCE_DIR}/freesasa")
@@ -85,6 +84,8 @@ add_definitions(-DUSE_THREADS=0)
 add_definitions(-DUSE_JSON=0)
 add_definitions(-DUSE_XML=0)
 rdkit_library(freesasa_clib ${freesasa_clib_srcs})
+target_compile_definitions(freesasa_clib PRIVATE RDKIT_FREESASALIB_BUILD)
+
 if((MSVC AND RDK_INSTALL_DLLS_MSVC) OR ((NOT MSVC) AND WIN32))
   set_target_properties(freesasa_clib PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
 endif()
@@ -92,6 +93,8 @@ include_directories("${FREESASA_SRC_DIR}/src")
 
 rdkit_library(FreeSASALib RDFreeSASA.cpp SHARED 
     LINK_LIBRARIES freesasa_clib GraphMol )
+target_compile_definitions(FreeSASALib PRIVATE RDKIT_FREESASALIB_BUILD)
+
 rdkit_headers(RDFreeSASA.h DEST GraphMol)
 
 rdkit_test(testFreeSASALib testFreeSASA.cpp

--- a/External/INCHI-API/CMakeLists.txt
+++ b/External/INCHI-API/CMakeLists.txt
@@ -2,7 +2,6 @@ add_custom_target(inchi_support ALL)
 
 if(RDK_BUILD_INCHI_SUPPORT)
   if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/src/INCHI_BASE/src/ichican2.c)
-    add_definitions(-DRDKIT_INCHI_BUILD)
     rdkit_library(Inchi
       src/INCHI_BASE/src/ichi_bns.c
       src/INCHI_BASE/src/ichi_io.c
@@ -61,6 +60,8 @@ if(RDK_BUILD_INCHI_SUPPORT)
       src/INCHI_API/libinchi/src/ixa/ixa_read_inchi.c
       src/INCHI_API/libinchi/src/ixa/ixa_read_mol.c
       src/INCHI_API/libinchi/src/ixa/ixa_status.c SHARED)
+    target_compile_definitions(Inchi PRIVATE RDKIT_INCHI_BUILD)
+
       if((MSVC AND RDK_INSTALL_DLLS_MSVC) OR ((NOT MSVC) AND WIN32))
         set_target_properties(Inchi PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
       endif()
@@ -72,9 +73,9 @@ if(RDK_BUILD_INCHI_SUPPORT)
      if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
       set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-parentheses -Wno-logical-op-parentheses")
      endif()
-  add_definitions(-DRDKIT_RDINCHILIB_BUILD)
   rdkit_library(RDInchiLib inchi.cpp SHARED LINK_LIBRARIES ${INCHI_LIBRARIES}
                 GraphMol RDGeneral Depictor SubstructMatch SmilesParse )
+  target_compile_definitions(RDInchiLib PRIVATE RDKIT_RDINCHILIB_BUILD)
 
   rdkit_headers(inchi.h DEST GraphMol)
   if(RDK_BUILD_PYTHON_WRAPPERS)

--- a/External/RingFamilies/CMakeLists.txt
+++ b/External/RingFamilies/CMakeLists.txt
@@ -24,7 +24,6 @@ set(urflib_INCLUDE_DIRS ${URFLIB_DIR}
 file(GLOB URFSOURCES "${URFLIB_DIR}/*.c")
 
 if((MSVC AND RDK_INSTALL_DLLS_MSVC) OR ((NOT MSVC) AND WIN32))
-    add_definitions("-DRDKIT_URFLIB_BUILD")
     set (ringdecomposerlib_h ${URFLIB_DIR}/RingDecomposerLib.h)
     file(READ ${ringdecomposerlib_h} ringdecomposerlib_h_data)
     if (NOT "${ringdecomposerlib_h_data}" MATCHES "RDKIT_URFLIB_BUILD")
@@ -33,6 +32,7 @@ if((MSVC AND RDK_INSTALL_DLLS_MSVC) OR ((NOT MSVC) AND WIN32))
     endif()
 endif()
 rdkit_library(RingDecomposerLib ${URFSOURCES} SHARED)
+target_compile_definitions(RingDecomposerLib PRIVATE RDKIT_URFLIB_BUILD)
 install(TARGETS RingDecomposerLib DESTINATION ${RDKit_LibDir})
 rdkit_headers(${URFLIB_DIR}/RingDecomposerLib.h DEST "")
 

--- a/External/YAeHMOP/CMakeLists.txt
+++ b/External/YAeHMOP/CMakeLists.txt
@@ -39,8 +39,8 @@ install(FILES ${EHT_PARAM_FILE}
 message("YAeHMOP include_dirs: ${PROJECT_BINARY_DIR}/include")
 message("YAeHMOP link_dirs: ${PROJECT_BINARY_DIR}/lib ${CMAKE_CURRENT_SOURCE_DIR}/src/yaehmop_project-build")
 
-add_definitions(-DRDKIT_EHTLIB_BUILD)
 rdkit_library(EHTLib EHTTools.cpp SHARED LINK_LIBRARIES yaehmop_eht GraphMol )
+target_compile_definitions(EHTLib PRIVATE RDKIT_EHTLIB_BUILD)
 add_dependencies(EHTLib yaehmop_project)
 rdkit_headers(EHTTools.h DEST GraphMol)
 rdkit_catch_test(testEHTLib1 test1.cpp


### PR DESCRIPTION
This is another "let's use cmake in a more modern way" thing. 

Instead of having the `*_BUILD` defines for each library done at the directory level this makes those definitions available only when there are needed: building the library itself.

There's not really anything to review here - unless someone wants to look to see if I missed something... ;-) - if the CI builds pass then it's fine.