### PR TITLE
Fixes #3349

### DIFF
--- a/Code/GraphMol/Resonance.cpp
+++ b/Code/GraphMol/Resonance.cpp
@@ -297,12 +297,19 @@ void fixExplicitImplicitHs(ROMol &mol) {
 // object constructor
 AtomElectrons::AtomElectrons(ConjElectrons *parent, const Atom *a)
     : d_nb(0),
-      d_tv(static_cast<std::uint8_t>(a->getTotalDegree())),
       d_fc(0),
       d_flags(0),
       d_atom(a),
       d_parent(parent) {
   PRECONDITION(d_atom, "d_atom cannot be NULL");
+  d_tv = static_cast<std::uint8_t>(a->getTotalDegree());
+  const ROMol &mol = d_atom->getOwningMol();
+  for (const auto &bNbri :
+       boost::make_iterator_range(mol.getAtomBonds(d_atom))) {
+    if (d_tv && mol[bNbri]->getBondType() >= Bond::DATIVEONE) {
+      --d_tv;
+    }
+  }
 }
 
 // copy constructor

--- a/Code/GraphMol/Resonance.h
+++ b/Code/GraphMol/Resonance.h
@@ -72,7 +72,7 @@ class RDKIT_GRAPHMOL_EXPORT ResonanceMolSupplierCallback {
       \return true if the resonance structure generation should continue;
               false if the resonance structure generation should stop.
    */
-  virtual bool operator()() const = 0;
+  virtual bool operator()() = 0;
 
  private:
   struct ResonanceProgress {
@@ -158,7 +158,7 @@ class RDKIT_GRAPHMOL_EXPORT ResonanceMolSupplier {
    *  instance (do not delete it, has the ResonanceMolSupplier takes
    *  ownership of the pointer), or nullptr if none was set.
    */
-  ResonanceMolSupplierCallback *getProgressCallback() {
+  ResonanceMolSupplierCallback *getProgressCallback() const {
     return d_callback.get();
   }
   /*! Returns true if the resonance structure generation was canceled

--- a/Code/GraphMol/Wrap/ResonanceMolSupplier.cpp
+++ b/Code/GraphMol/Wrap/ResonanceMolSupplier.cpp
@@ -70,7 +70,7 @@ class PyResonanceMolSupplierCallback
   inline python::object getCallbackOverride() const {
     return get_override("__call__");
   }
-  bool operator()() const { return getCallbackOverride()(); }
+  bool operator()() { return getCallbackOverride()(); }
   python::object getPyCallbackObject() { return d_pyCallbackObject; }
 
  private:
@@ -78,7 +78,7 @@ class PyResonanceMolSupplierCallback
   python::object d_pyCallbackObject;
 };
 
-python::object getProgressCallbackHelper(ResonanceMolSupplier &suppl) {
+python::object getProgressCallbackHelper(const ResonanceMolSupplier &suppl) {
   PyResonanceMolSupplierCallback *cppCallback =
       dynamic_cast<PyResonanceMolSupplierCallback *>(
           suppl.getProgressCallback());
@@ -111,9 +111,9 @@ void setProgressCallbackHelper(ResonanceMolSupplier &suppl,
           new PyResonanceMolSupplierCallback(callbackObject));
     }
   } else {
-    PyErr_SetString(
-        PyExc_TypeError,
-        "Expected an instance of a Chem.ResonanceMolSupplierCallback subclass");
+    PyErr_SetString(PyExc_TypeError,
+                    "Expected an instance of a "
+                    "rdchem.ResonanceMolSupplierCallback subclass");
     python::throw_error_already_set();
   }
 }
@@ -197,8 +197,8 @@ struct resmolsup_wrap {
         .def("__call__",
              python::pure_virtual(&PyResonanceMolSupplierCallback::operator()),
              "This must be implemented in the derived class. "
-             "Return true if the resonance structure generation "
-             "should continue; false if the resonance structure "
+             "Return True if the resonance structure generation "
+             "should continue; False if the resonance structure "
              "generation should stop.\n");
 
     python::class_<ResonanceMolSupplier, boost::noncopyable>(
@@ -247,11 +247,11 @@ struct resmolsup_wrap {
             "structures (defaults to 1; 0 selects the number of concurrent\n"
             "threads supported by the hardware; negative values are added\n"
             "to the number of concurrent threads supported by the hardware).\n")
-        .def("SetProgressCallback", setProgressCallbackHelper,
+        .def("SetProgressCallback", &setProgressCallbackHelper,
              "Pass an instance of a class derived from\n"
              "ResonanceMolSupplierCallback, which must implement the\n"
-             "callback() method.\n")
-        .def("GetProgressCallback", getProgressCallbackHelper,
+             "__call__() method.\n")
+        .def("GetProgressCallback", &getProgressCallbackHelper,
              "Get the ResonanceMolSupplierCallback subclass instance,\n"
              "or None if none was set.\n")
         .def("WasCanceled", &ResonanceMolSupplier::wasCanceled,

--- a/Code/GraphMol/resMolSupplierTest.cpp
+++ b/Code/GraphMol/resMolSupplierTest.cpp
@@ -897,13 +897,13 @@ void testGitHub2597() {
                        << "testGitHub2597" << std::endl;
   {
     class MyCallBack : public ResonanceMolSupplierCallback {
-      bool operator()() const {
+      bool operator()() {
         TEST_ASSERT(getNumConjGrps() == 1);
         return (getNumStructures(0) < 12);
       }
     };
     class MyCallBack2 : public ResonanceMolSupplierCallback {
-      bool operator()() const {
+      bool operator()() {
         TEST_ASSERT(getNumConjGrps() == 1);
         return (getNumDiverseStructures(0) < 8);
       }
@@ -947,6 +947,20 @@ void testGitHub2597() {
   }
 }
 
+void testGitHub3349() {
+  BOOST_LOG(rdInfoLog) << "-----------------------\n"
+                       << "testGitHub3349" << std::endl;
+  RWMol *mol = SmilesToMol("CC(=O)[O-]->[*]");
+  auto *resMolSuppl =
+      new ResonanceMolSupplier(*mol, ResonanceMolSupplier::KEKULE_ALL);
+  // This erroneously returned a single resonance structure
+  // as dative and zero-order bonds were not accounted for (#3349)
+  TEST_ASSERT(resMolSuppl->length() == 2);
+  delete resMolSuppl;
+  delete mol;
+}
+
+
 int main() {
   RDLog::InitLogs();
 #if 1
@@ -970,6 +984,7 @@ int main() {
   testConjGrpPerception();
   testGitHub3048();
   testGitHub2597();
+  testGitHub3349();
 #endif
   return 0;
 }


### PR DESCRIPTION
- Fixed #3349
- fixed a few typos
- removed `const` from `ResonanceMolSupplierCallback::operator()`, which should be allowed to modify the owning object
- added missing `const` to some getters
