### PR TITLE
Replace fill-opacity= with fill-opacity: in MolDraw2DSVG and tests

### DIFF
--- a/Code/GraphMol/MolDraw2D/MolDraw2DSVG.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DSVG.cpp
@@ -249,7 +249,7 @@ void MolDraw2DSVG::drawPolygon(const std::vector<Point2D> &cds) {
   }
   if (fillPolys()) {
     // the Z closes the path which we don't want for unfilled polygons
-    d_os << " Z' style='fill:" << col << ";fill-rule:evenodd;fill-opacity=" << colour().a
+    d_os << " Z' style='fill:" << col << ";fill-rule:evenodd;fill-opacity:" << colour().a
          << ";";
   } else {
     d_os << "' style='fill:none;";

--- a/Code/GraphMol/MolDraw2D/test1.cpp
+++ b/Code/GraphMol/MolDraw2D/test1.cpp
@@ -1360,7 +1360,7 @@ M  END";
     TEST_ASSERT(text.find("<path class='bond-1' d='M 126.46,111.639"
                           " L 182.698,86.8632 L 176.033,75.3193 Z'"
                           " style='fill:#000000;fill-rule:evenodd;"
-                          "fill-opacity=1;stroke:#000000;")
+                          "fill-opacity:1;stroke:#000000;")
                 != std::string::npos);
 #endif
     delete m;
@@ -1420,7 +1420,7 @@ M  END";
     TEST_ASSERT(text.find("<path class='bond-3' d='M 105.087,114.797"
                           " L 78.5054,90.9436 L 73.9878,97.2355 Z'"
                           " style='fill:#000000;fill-rule:evenodd;"
-                          "fill-opacity=1;stroke:#000000;")
+                          "fill-opacity:1;stroke:#000000;")
                 != std::string::npos);
 #endif
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! 
-->
#### What does this implement/fix? Explain your changes.
Tiny improvement in SVG output.

The SVG generated by MolDraw2DSVG sometimes contains "fill-opacity=" as opposed to "fill-opacity:" as sub-attributes of a style attribute. This can break downstream parsing, for example, in my use case, svglib/reportlab in python.

#### Any other comments?
Thanks for the fantastic toolkit!
