### PR TITLE
expose additional SubstanceGroup data members to Python

### DIFF
--- a/Code/GraphMol/Wrap/SubstanceGroup.cpp
+++ b/Code/GraphMol/Wrap/SubstanceGroup.cpp
@@ -73,6 +73,14 @@ python::tuple getCStatesHelper(const SubstanceGroup &self) {
   return python::tuple(res);
 }
 
+python::tuple getBracketsHelper(const SubstanceGroup &self) {
+  python::list res;
+  for (const auto brk : self.getBrackets()) {
+    res.append(python::make_tuple(brk[0], brk[1], brk[2]));
+  }
+  return python::tuple(res);
+}
+
 }  // namespace
 
 std::string sGroupClassDoc =
@@ -121,6 +129,7 @@ struct sgroup_wrap {
         .def("AddBondWithBookmark", &SubstanceGroup::addBondWithBookmark)
         .def("AddAttachPoint", &SubstanceGroup::addAttachPoint)
         .def("AddBracket", addBracketHelper)
+        .def("GetBrackets", getBracketsHelper)
 
         .def("SetProp",
              (void (RDProps::*)(const std::string &, std::string, bool) const) &

--- a/Code/GraphMol/Wrap/SubstanceGroup.cpp
+++ b/Code/GraphMol/Wrap/SubstanceGroup.cpp
@@ -65,6 +65,14 @@ void addBracketHelper(SubstanceGroup &self, python::object pts) {
   self.addBracket(bkt);
 }
 
+python::tuple getCStatesHelper(const SubstanceGroup &self) {
+  python::list res;
+  for (const auto cs : self.getCStates()) {
+    res.append(cs);
+  }
+  return python::tuple(res);
+}
+
 }  // namespace
 
 std::string sGroupClassDoc =
@@ -72,18 +80,15 @@ std::string sGroupClassDoc =
 
 struct sgroup_wrap {
   static void wrap() {
-    // register the vector_indexing_suite for SubstanceGroups
-    // if it hasn't already been done.
-    // logic from https://stackoverflow.com/a/13017303
-    boost::python::type_info info =
-        boost::python::type_id<std::vector<RDKit::SubstanceGroup>>();
-    const boost::python::converter::registration *reg =
-        boost::python::converter::registry::query(info);
-    if (reg == nullptr || (*reg).m_to_python == nullptr) {
-      python::class_<std::vector<RDKit::SubstanceGroup>>("SubstanceGroup_VECT")
-          .def(python::vector_indexing_suite<
-               std::vector<RDKit::SubstanceGroup>>());
-    }
+    RegisterVectorConverter<SubstanceGroup>("SubstanceGroup_VECT");
+    RegisterVectorConverter<SubstanceGroup::CState>(
+        "SubstanceGroupCState_VECT");
+
+    python::class_<SubstanceGroup::CState,
+                   boost::shared_ptr<SubstanceGroup::CState>>(
+        "SubstanceGroupCState", "CSTATE for a SubstanceGroup", python::init<>())
+        .def_readwrite("bondIdx", &SubstanceGroup::CState::bondIdx)
+        .def_readwrite("vector", &SubstanceGroup::CState::vector);
 
     python::class_<SubstanceGroup, boost::shared_ptr<SubstanceGroup>>(
         "SubstanceGroup", sGroupClassDoc.c_str(), python::no_init)
@@ -93,18 +98,18 @@ struct sgroup_wrap {
         .def("GetIndexInMol", &SubstanceGroup::getIndexInMol,
              "returns the index of this SubstanceGroup in the owning "
              "molecule's list.")
-        .def(
-            "GetAtoms", &SubstanceGroup::getAtoms,
-            "returns a list of the indices of the atoms in this SubstanceGroup",
-            python::return_value_policy<python::copy_const_reference>())
+        .def("GetAtoms", &SubstanceGroup::getAtoms,
+             "returns a list of the indices of the atoms in this "
+             "SubstanceGroup",
+             python::return_value_policy<python::copy_const_reference>())
         .def("GetParentAtoms", &SubstanceGroup::getParentAtoms,
              "returns a list of the indices of the parent atoms in this "
              "SubstanceGroup",
              python::return_value_policy<python::copy_const_reference>())
-        .def(
-            "GetBonds", &SubstanceGroup::getBonds,
-            "returns a list of the indices of the bonds in this SubstanceGroup",
-            python::return_value_policy<python::copy_const_reference>())
+        .def("GetBonds", &SubstanceGroup::getBonds,
+             "returns a list of the indices of the bonds in this "
+             "SubstanceGroup",
+             python::return_value_policy<python::copy_const_reference>())
         .def("AddAtomWithIdx", &SubstanceGroup::addAtomWithIdx)
         .def("AddBondWithIdx", &SubstanceGroup::addBondWithIdx)
         .def("AddParentAtomWithIdx", &SubstanceGroup::addParentAtomWithIdx)
@@ -112,6 +117,7 @@ struct sgroup_wrap {
         .def("AddParentAtomWithBookmark",
              &SubstanceGroup::addParentAtomWithBookmark)
         .def("AddCState", &SubstanceGroup::addCState)
+        .def("GetCStates", getCStatesHelper)
         .def("AddBondWithBookmark", &SubstanceGroup::addBondWithBookmark)
         .def("AddAttachPoint", &SubstanceGroup::addAttachPoint)
         .def("AddBracket", addBracketHelper)
@@ -183,13 +189,15 @@ struct sgroup_wrap {
         .def("GetPropNames", &SubstanceGroup::getPropList,
              (python::arg("self"), python::arg("includePrivate") = false,
               python::arg("includeComputed") = false),
-             "Returns a list of the properties set on the SubstanceGroup.\n\n")
+             "Returns a list of the properties set on the "
+             "SubstanceGroup.\n\n")
         .def("GetPropsAsDict", GetPropsAsDict<SubstanceGroup>,
              (python::arg("self"), python::arg("includePrivate") = true,
               python::arg("includeComputed") = true),
              "Returns a dictionary of the properties set on the "
              "SubstanceGroup.\n"
              " n.b. some properties cannot be converted to python types.\n");
+
     python::def("GetMolSubstanceGroups", &getMolSubstanceGroups,
                 "returns a copy of the molecule's SubstanceGroups (if any)",
                 python::with_custodian_and_ward_postcall<0, 1>());

--- a/Code/GraphMol/Wrap/SubstanceGroup.cpp
+++ b/Code/GraphMol/Wrap/SubstanceGroup.cpp
@@ -81,6 +81,13 @@ python::tuple getBracketsHelper(const SubstanceGroup &self) {
   return python::tuple(res);
 }
 
+python::tuple getAttachPointsHelper(const SubstanceGroup &self) {
+  python::list res;
+  for (const auto ap : self.getAttachPoints()) {
+    res.append(ap);
+  }
+  return python::tuple(res);
+}
 }  // namespace
 
 std::string sGroupClassDoc =
@@ -89,14 +96,22 @@ std::string sGroupClassDoc =
 struct sgroup_wrap {
   static void wrap() {
     RegisterVectorConverter<SubstanceGroup>("SubstanceGroup_VECT");
-    RegisterVectorConverter<SubstanceGroup::CState>(
-        "SubstanceGroupCState_VECT");
 
     python::class_<SubstanceGroup::CState,
                    boost::shared_ptr<SubstanceGroup::CState>>(
         "SubstanceGroupCState", "CSTATE for a SubstanceGroup", python::init<>())
-        .def_readwrite("bondIdx", &SubstanceGroup::CState::bondIdx)
-        .def_readwrite("vector", &SubstanceGroup::CState::vector);
+        .def_readonly("bondIdx", &SubstanceGroup::CState::bondIdx)
+        .def_readonly("vector", &SubstanceGroup::CState::vector);
+
+    python::class_<SubstanceGroup::AttachPoint,
+                   boost::shared_ptr<SubstanceGroup::AttachPoint>>(
+        "SubstanceGroupAttach", "AttachPoint for a SubstanceGroup",
+        python::init<>())
+        .def_readonly("aIdx", &SubstanceGroup::AttachPoint::aIdx,
+                      "attachment index")
+        .def_readonly("lvIdx", &SubstanceGroup::AttachPoint::lvIdx,
+                      "leaving atom or index (0 for implied)")
+        .def_readonly("id", &SubstanceGroup::AttachPoint::id, "attachment id");
 
     python::class_<SubstanceGroup, boost::shared_ptr<SubstanceGroup>>(
         "SubstanceGroup", sGroupClassDoc.c_str(), python::no_init)
@@ -128,6 +143,7 @@ struct sgroup_wrap {
         .def("GetCStates", getCStatesHelper)
         .def("AddBondWithBookmark", &SubstanceGroup::addBondWithBookmark)
         .def("AddAttachPoint", &SubstanceGroup::addAttachPoint)
+        .def("GetAttachPoints", getAttachPointsHelper)
         .def("AddBracket", addBracketHelper)
         .def("GetBrackets", getBracketsHelper)
 

--- a/Code/GraphMol/Wrap/testSGroups.py
+++ b/Code/GraphMol/Wrap/testSGroups.py
@@ -392,6 +392,74 @@ M  END''')
     self.assertAlmostEqual(b[2].x, 0, 3)
     self.assertAlmostEqual(b[2].y, 0, 3)
 
+  def testAttachPoints(self):
+    mol = Chem.MolFromMolBlock('''
+  Mrv2014 09012006262D          
+
+  0  0  0     0  0            999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 4 3 1 0 0
+M  V30 BEGIN ATOM
+M  V30 1 C -5.0833 0.0833 0 0
+M  V30 2 C -3.7497 0.8533 0 0
+M  V30 3 O -2.416 0.0833 0 0
+M  V30 4 O -3.7497 2.3933 0 0
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 1 1 2
+M  V30 2 1 2 3
+M  V30 3 2 2 4
+M  V30 END BOND
+M  V30 BEGIN SGROUP
+M  V30 1 SUP 0 ATOMS=(3 2 3 4) SAP=(3 2 1 1) XBONDS=(1 1) LABEL=CO2H ESTATE=E
+M  V30 END SGROUP
+M  V30 END CTAB
+M  END''')
+    sgs = Chem.GetMolSubstanceGroups(mol)
+    self.assertEqual(len(sgs), 1)
+    sg0 = sgs[0]
+    pd = sg0.GetPropsAsDict()
+    self.assertTrue('TYPE' in pd)
+    self.assertEqual(pd['TYPE'], 'SUP')
+    aps = sg0.GetAttachPoints()
+    self.assertEqual(len(aps), 1)
+    self.assertEqual(aps[0].aIdx, 1)
+    self.assertEqual(aps[0].lvIdx, 0)
+    self.assertEqual(aps[0].id, '1')
+
+    mol = Chem.MolFromMolBlock('''
+  Mrv2014 09012006262D          
+
+  0  0  0     0  0            999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 4 3 0 0 0
+M  V30 BEGIN ATOM
+M  V30 1 C -5.0833 0.0833 0 0
+M  V30 2 C -3.7497 0.8533 0 0
+M  V30 3 O -2.416 0.0833 0 0
+M  V30 4 O -3.7497 2.3933 0 0
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 1 1 2
+M  V30 2 1 2 3
+M  V30 3 2 2 4
+M  V30 END BOND
+M  V30 END CTAB
+M  END''')
+    sgs = Chem.GetMolSubstanceGroups(mol)
+    self.assertEqual(len(sgs), 0)
+
+    sg = Chem.CreateMolSubstanceGroup(mol, "SUP")
+    sg.AddAtomWithIdx(1)
+    sg.AddAtomWithIdx(2)
+    sg.AddAtomWithIdx(3)
+    sg.AddBondWithIdx(0)
+    sg.SetProp('LABEL', 'CO2H')
+    sg.AddAttachPoint(1, 0, '1')
+    molb = Chem.MolToV3KMolBlock(mol)
+    self.assertGreater(
+      molb.find('M  V30 1 SUP 0 ATOMS=(3 2 3 4) XBONDS=(1 1) LABEL=CO2H SAP=(3 2 1 1)'), 0)
+
 
 if __name__ == '__main__':
   print("Testing SubstanceGroups wrapper")

--- a/Code/GraphMol/Wrap/testSGroups.py
+++ b/Code/GraphMol/Wrap/testSGroups.py
@@ -338,6 +338,60 @@ M  END
     self.assertAlmostEqual(cs0.vector.x, -1.02, 2)
     self.assertAlmostEqual(cs0.vector.y, -0.59, 2)
 
+  def testBrackets(self):
+    mol = Chem.MolFromMolBlock('''
+  Mrv2014 08282011142D          
+
+  0  0  0     0  0            999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 6 5 1 0 0
+M  V30 BEGIN ATOM
+M  V30 1 C -15.7083 2 0 0
+M  V30 2 C -14.3747 2.77 0 0
+M  V30 3 O -13.041 2 0 0
+M  V30 4 C -11.7073 2.77 0 0
+M  V30 5 C -10.3736 2 0 0
+M  V30 6 C -9.0399 2.77 0 0
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 1 1 2
+M  V30 2 1 2 3
+M  V30 3 1 3 4
+M  V30 4 1 4 5
+M  V30 5 1 5 6
+M  V30 END BOND
+M  V30 BEGIN SGROUP
+M  V30 1 MON 0 ATOMS=(2 3 4) BRKXYZ=(9 -13.811 1.23 0 -13.811 3.54 0 0 0 0) -
+M  V30 BRKXYZ=(9 -10.9373 3.54 0 -10.9373 1.23 0 0 0 0)
+M  V30 END SGROUP
+M  V30 END CTAB
+M  END''')
+    sgs = Chem.GetMolSubstanceGroups(mol)
+    self.assertEqual(len(sgs), 1)
+    sg0 = sgs[0]
+    pd = sg0.GetPropsAsDict()
+    self.assertTrue('TYPE' in pd)
+    self.assertEqual(pd['TYPE'], 'MON')
+    brackets = sg0.GetBrackets()
+    self.assertEqual(len(brackets), 2)
+    b = brackets[0]
+    self.assertEqual(len(b), 3)
+    self.assertAlmostEqual(b[0].x, -13.811, 3)
+    self.assertAlmostEqual(b[0].y, 1.230, 3)
+    self.assertAlmostEqual(b[1].x, -13.811, 3)
+    self.assertAlmostEqual(b[1].y, 3.540, 3)
+    self.assertAlmostEqual(b[2].x, 0, 3)
+    self.assertAlmostEqual(b[2].y, 0, 3)
+
+    b = brackets[1]
+    self.assertEqual(len(b), 3)
+    self.assertAlmostEqual(b[0].x, -10.937, 3)
+    self.assertAlmostEqual(b[0].y, 3.54, 3)
+    self.assertAlmostEqual(b[1].x, -10.937, 3)
+    self.assertAlmostEqual(b[1].y, 1.23, 3)
+    self.assertAlmostEqual(b[2].x, 0, 3)
+    self.assertAlmostEqual(b[2].y, 0, 3)
+
 
 if __name__ == '__main__':
   print("Testing SubstanceGroups wrapper")

--- a/Code/GraphMol/Wrap/testSGroups.py
+++ b/Code/GraphMol/Wrap/testSGroups.py
@@ -287,8 +287,56 @@ M  END''')
     newsg = Chem.AddMolSubstanceGroup(mol2, sgs[1])
     newsg.SetProp("FIELDNAME", "blah_data")
     molb = Chem.MolToV3KMolBlock(mol2)
-    print(molb)
     self.assertGreater(molb.find("M  V30 3 DAT 0 ATOMS=(1 6) FIELDNAME=blah_data"), 0)
+
+  def testCStates(self):
+    mol = Chem.MolFromMolBlock('''
+  ACCLDraw08282007542D
+
+  0  0  0     0  0            999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 9 9 1 0 0
+M  V30 BEGIN ATOM
+M  V30 1 C 8.759 -6.2839 0 0 
+M  V30 2 C 10.8013 -6.2833 0 0 
+M  V30 3 C 9.7821 -5.6936 0 0 
+M  V30 4 C 10.8013 -7.4648 0 0 
+M  V30 5 C 8.759 -7.4701 0 0 
+M  V30 6 C 9.7847 -8.0543 0 0 
+M  V30 7 C 11.8245 -5.6926 0 0 
+M  V30 8 O 12.8482 -6.2834 0 0 
+M  V30 9 O 11.8245 -4.5104 0 0 
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 1 6 4 
+M  V30 2 2 5 6 
+M  V30 3 1 2 3 
+M  V30 4 1 1 5 
+M  V30 5 2 4 2 
+M  V30 6 2 3 1 
+M  V30 7 2 7 9 
+M  V30 8 1 7 8 
+M  V30 9 1 2 7 
+M  V30 END BOND
+M  V30 BEGIN SGROUP
+M  V30 1 SUP 1 ATOMS=(3 7 8 9) XBONDS=(1 9) CSTATE=(4 9 -1.02 -0.59 0) LABEL=-
+M  V30 CO2H 
+M  V30 END SGROUP
+M  V30 END CTAB
+M  END
+''')
+    sgs = Chem.GetMolSubstanceGroups(mol)
+    self.assertEqual(len(sgs), 1)
+    sg0 = sgs[0]
+    pd = sg0.GetPropsAsDict()
+    self.assertTrue('TYPE' in pd)
+    self.assertEqual(pd['TYPE'], 'SUP')
+    cstates = sg0.GetCStates()
+    self.assertEqual(len(cstates), 1)
+    cs0 = cstates[0]
+    self.assertEqual(cs0.bondIdx, 8)
+    self.assertAlmostEqual(cs0.vector.x, -1.02, 2)
+    self.assertAlmostEqual(cs0.vector.y, -0.59, 2)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This specifically does:
- `GetCStates()`
- `GetBrackets()`
- `GetAttachPoints()`