### PR TITLE
Add APK package link for Alpine Linux distribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Installation instructions are available in [Docs/Book/Install.md](https://github
   * [debs](https://blends.debian.org/debichem/tasks/cheminformatics) for Ubuntu and other Debian-derived Linux distros. Contributed by the Debichem team.
   * [homebrew](https://github.com/rdkit/homebrew-rdkit) formula for building on the Mac. Contributed by Eddie Cao.
   * [recipes](https://github.com/rdkit/conda-rdkit) for building using the excellent conda package manager. Contributed by Riccardo Vianello.
-  * [APKs](https://github.com/daverona/alpine-rdkit) for Alpine Linux. Contributed by daVerona
+  * [APKs](https://github.com/daverona/alpine-rdkit) for Alpine Linux. Contributed by da Verona
 
 ## Projects using RDKit
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Installation instructions are available in [Docs/Book/Install.md](https://github
   * [debs](https://blends.debian.org/debichem/tasks/cheminformatics) for Ubuntu and other Debian-derived Linux distros. Contributed by the Debichem team.
   * [homebrew](https://github.com/rdkit/homebrew-rdkit) formula for building on the Mac. Contributed by Eddie Cao.
   * [recipes](https://github.com/rdkit/conda-rdkit) for building using the excellent conda package manager. Contributed by Riccardo Vianello.
+  * [APKs](https://github.com/daverona/alpine-rdkit) for Alpine Linux. Contributed by daVerona
 
 ## Projects using RDKit
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! 
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->

None

#### What does this implement/fix? Explain your changes.

None. Just added a link to Alpine APK packages

#### Any other comments?

The linked GitHub repository has a release page, which contains following APK packages:

* rdkit-*version*-r0.apk (dynamic libraries)
* rdkit-static-*version*-r0.apk (static libraries)
* rdkit-dev-*version*-r0.apk (header files)
* rdkit-doc-*version*-r0.apk (documentation)
* py3-rdkit-*version*-r0.apk (Python3 files)
* rdkit-java-*version*-r0.apk (Java wrapper files)
* rdkit-java-doc-*version*-r0.apk (Java wrapper documentation)
* rdkit-pgsql-*version*-r0.apk (PostgreSQL cartridge)

where *version* is between Release_2020_03_1 and Release_2020_03_5 (latest).
For each APK file, three Alpine versions available: v3.10, v3.11, and v3.12 (latest).