### PR TITLE
Fixes #3388

### DIFF
--- a/Code/GraphMol/QueryAtom.h
+++ b/Code/GraphMol/QueryAtom.h
@@ -31,7 +31,21 @@ class RDKIT_GRAPHMOL_EXPORT QueryAtom : public Atom {
   QueryAtom() : Atom(){};
   explicit QueryAtom(int num) : Atom(num), dp_query(makeAtomNumQuery(num)){};
   explicit QueryAtom(const Atom &other)
-      : Atom(other), dp_query(makeAtomNumQuery(other.getAtomicNum())){};
+      : Atom(other), dp_query(makeAtomNumQuery(other.getAtomicNum())) {
+    if (other.getIsotope()) {
+      this->expandQuery(makeAtomIsotopeQuery(other.getIsotope()),
+                        Queries::CompositeQueryType::COMPOSITE_AND);
+    }
+    if (other.getFormalCharge()) {
+      this->expandQuery(makeAtomFormalChargeQuery(other.getFormalCharge()),
+                        Queries::CompositeQueryType::COMPOSITE_AND);
+    }
+    if (other.getNumRadicalElectrons()) {
+      this->expandQuery(
+          makeAtomNumRadicalElectronsQuery(other.getNumRadicalElectrons()),
+          Queries::CompositeQueryType::COMPOSITE_AND);
+    }
+  };
   QueryAtom(const QueryAtom &other) : Atom(other) {
     dp_query = other.dp_query->copy();
   };

--- a/Code/GraphMol/catch_adjustquery.cpp
+++ b/Code/GraphMol/catch_adjustquery.cpp
@@ -578,5 +578,14 @@ TEST_CASE("github #3388: Information about charges and isotopes lost when callin
     auto sma = SmartsWrite::GetAtomSmarts(&atm);
     CHECK(sma=="[#6&13*&-]");
   }
+  SECTION("root cause2") {
+    // since we don't have a way to query for number of radical electrons in SMARTS,
+    // we need to check that a different way:
+    auto mol = "[CH2]C[O-]"_smiles;
+    REQUIRE(mol);
+    QueryAtom atm(*mol->getAtomWithIdx(0));
+    auto descr = describeQuery(&atm);
+    CHECK(descr.find("AtomNumRadicalElectrons 1 = val")!=std::string::npos);
+  }
 }
 

--- a/Code/GraphMol/catch_adjustquery.cpp
+++ b/Code/GraphMol/catch_adjustquery.cpp
@@ -559,3 +559,24 @@ TEST_CASE("single bonds to aromatic neighbors") {
     } 
   }
 }
+
+TEST_CASE("github #3388: Information about charges and isotopes lost when calling AdjustQueryProperties") {
+  MolOps::AdjustQueryParameters ps = MolOps::AdjustQueryParameters::noAdjustments();
+  ps.adjustDegree = true;
+  ps.adjustDegreeFlags = MolOps::AdjustQueryWhichFlags::ADJUST_IGNORENONE;
+  SECTION("basics") {
+    auto mol = "[13CH3]C[O-]"_smiles;
+    REQUIRE(mol);
+    MolOps::adjustQueryProperties(*mol,&ps);
+    auto sma = MolToSmarts(*mol);
+    CHECK(sma=="[#6&13*&D1]-[#6&D2]-[#8&-&D1]");
+  }
+  SECTION("root cause") {
+    auto mol = "[13CH2-]C[O-]"_smiles;
+    REQUIRE(mol);
+    QueryAtom atm(*mol->getAtomWithIdx(0));
+    auto sma = SmartsWrite::GetAtomSmarts(&atm);
+    CHECK(sma=="[#6&13*&-]");
+  }
+}
+


### PR DESCRIPTION
Modifies the `QueryAtom(const Atom &)` ctor to ensure that the following atom properties are translated into queries if they have non-zero values:
  - isotope
  - formal charge
  - num radical electrons


