### PR TITLE
Allow passing explicit removeHs, sanitize and strict flags to the MDL rxn parser

### DIFF
--- a/Code/GraphMol/ChemReactions/ReactionParser.h
+++ b/Code/GraphMol/ChemReactions/ReactionParser.h
@@ -120,13 +120,16 @@ RDKIT_CHEMREACTIONS_EXPORT ROMol *ChemicalReactionToRxnMol(
 
 //! Parse a text block in MDL rxn format into a ChemicalReaction
 RDKIT_CHEMREACTIONS_EXPORT ChemicalReaction *RxnBlockToChemicalReaction(
-    const std::string &rxnBlock);
+    const std::string &rxnBlock, bool sanitize = false, bool removeHs = false,
+    bool strictParsing = true);
 //! Parse a file in MDL rxn format into a ChemicalReaction
 RDKIT_CHEMREACTIONS_EXPORT ChemicalReaction *RxnFileToChemicalReaction(
-    const std::string &fileName);
+    const std::string &fileName, bool sanitize = false, bool removeHs = false,
+    bool strictParsing = true);
 //! Parse a text stream in MDL rxn format into a ChemicalReaction
 RDKIT_CHEMREACTIONS_EXPORT ChemicalReaction *RxnDataStreamToChemicalReaction(
-    std::istream &rxnStream, unsigned int &line);
+    std::istream &rxnStream, unsigned int &line, bool sanitize = false,
+    bool removeHs = false, bool strictParsing = true);
 //! returns an rxn block for a reaction
 /*!
    \param rxn            chemical reaction

--- a/Code/GraphMol/ChemReactions/Wrap/rdChemReactions.cpp
+++ b/Code/GraphMol/ChemReactions/Wrap/rdChemReactions.cpp
@@ -774,12 +774,18 @@ of the replacements argument.",
               (python::arg("reaction"), python::arg("canonical") = true),
               "construct a reaction SMILES string for a ChemicalReaction");
 
-  python::def("ReactionFromRxnFile", RDKit::RxnFileToChemicalReaction,
-              "construct a ChemicalReaction from an MDL rxn file",
-              python::return_value_policy<python::manage_new_object>());
-  python::def("ReactionFromRxnBlock", RDKit::RxnBlockToChemicalReaction,
-              "construct a ChemicalReaction from an string in MDL rxn format",
-              python::return_value_policy<python::manage_new_object>());
+  python::def(
+      "ReactionFromRxnFile", RDKit::RxnFileToChemicalReaction,
+      (python::arg("filename"), python::arg("sanitize") = false,
+       python::arg("removeHs") = false, python::arg("strictParsing") = true),
+      "construct a ChemicalReaction from an MDL rxn file",
+      python::return_value_policy<python::manage_new_object>());
+  python::def(
+      "ReactionFromRxnBlock", RDKit::RxnBlockToChemicalReaction,
+      (python::arg("rxnblock"), python::arg("sanitize") = false,
+       python::arg("removeHs") = false, python::arg("strictParsing") = true),
+      "construct a ChemicalReaction from a string in MDL rxn format",
+      python::return_value_policy<python::manage_new_object>());
   python::def("ReactionToRxnBlock", RDKit::ChemicalReactionToRxnBlock,
               (python::arg("reaction"), python::arg("separateAgents") = false),
               "construct a string in MDL rxn format for a ChemicalReaction");

--- a/Code/GraphMol/ChemReactions/Wrap/testReactionWrapper.py
+++ b/Code/GraphMol/ChemReactions/Wrap/testReactionWrapper.py
@@ -952,6 +952,79 @@ class StereoGroupTests(unittest.TestCase):
     #  this shouldn't raise
     rxn.RunReactants([mol])
 
+  def test_rxnblock_removehs(self):
+    rxnblock = """$RXN
+Dummy 0
+  Dummy        0123456789
+
+  1  1
+$MOL
+
+  Dummy   01234567892D
+
+ 10 10  0  0  0  0            999 V2000
+    7.0222  -11.1783    0.0000 C   0  0  0  0  0  0  0  0  0  1  0  0
+    8.0615  -11.7783    0.0000 O   0  0  0  0  0  0  0  0  0  2  0  0
+    7.0222   -9.6783    0.0000 N   0  0  0  0  0  0  0  0  0  3  0  0
+    5.7231   -8.9283    0.0000 C   0  0  0  0  0  0  0  0  0  4  0  0
+    5.7231   -7.7283    0.0000 A   0  0  0  0  0  0  0  0  0  5  0  0
+    4.4242   -9.6783    0.0000 C   0  0  0  0  0  0  0  0  0  6  0  0
+    4.4242  -11.1783    0.0000 C   0  0  0  0  0  0  0  0  0  7  0  0
+    3.3849  -11.7783    0.0000 A   0  0  0  0  0  0  0  0  0  8  0  0
+    5.7231  -11.9283    0.0000 N   0  0  0  0  0  0  0  0  0  9  0  0
+    5.7231  -13.1094    0.0000 H   0  0
+  1  2  2  0  0  0  8
+  1  3  1  0  0  0  8
+  3  4  2  0  0  0  8
+  4  5  1  0  0  0  2
+  4  6  1  0  0  0  8
+  6  7  2  0  0  0  8
+  7  8  1  0  0  0  2
+  7  9  1  0  0  0  8
+  9  1  1  0  0  0  8
+  9 10  1  0
+M  SUB  1   9   2
+M  END
+$MOL
+
+  Dummy   01234567892D
+
+  9  9  0  0  0  0            999 V2000
+   17.0447  -11.1783    0.0000 C   0  0  0  0  0  0  0  0  0  1  0  0
+   18.0840  -11.7783    0.0000 O   0  0  0  0  0  0  0  0  0  2  0  0
+   17.0447   -9.6783    0.0000 N   0  0  0  0  0  0  0  0  0  3  0  0
+   15.7457   -8.9283    0.0000 C   0  0  0  0  0  0  0  0  0  4  0  0
+   15.7457   -7.7283    0.0000 A   0  0  0  0  0  0  0  0  0  5  0  0
+   14.4467   -9.6783    0.0000 C   0  0  0  0  0  0  0  0  0  6  0  0
+   14.4467  -11.1783    0.0000 C   0  0  0  0  0  0  0  0  0  7  0  0
+   13.4074  -11.7783    0.0000 A   0  0  0  0  0  0  0  0  0  8  0  0
+   15.7457  -11.9283    0.0000 N   0  0  0  0  0  0  0  0  0  9  0  0
+  1  2  1  0  0  0  8
+  1  3  1  0  0  0  8
+  3  4  2  0  0  0  8
+  4  5  1  0  0  0  2
+  4  6  1  0  0  0  8
+  6  7  2  0  0  0  8
+  7  8  1  0  0  0  2
+  7  9  1  0  0  0  8
+  9  1  2  0  0  0  8
+M  END
+"""
+
+    mol = Chem.MolFromSmiles("c1(=O)nc([Cl])cc([F])[nH]1")
+    rxn = rdChemReactions.ReactionFromRxnBlock(rxnblock)
+    self.assertIsNotNone(rxn)
+    prods = rxn.RunReactants((mol,))
+    # if the explicit hydrogen is not removed and the reactant template
+    # is not sanitized, the reactant template is not aromatic and our
+    # aromatic reactant won't match
+    self.assertEqual(len(prods), 0)
+
+    rxn = rdChemReactions.ReactionFromRxnBlock(rxnblock, removeHs=True, sanitize=True)
+    self.assertIsNotNone(rxn)
+    prods = rxn.RunReactants((mol,))
+    self.assertEqual(len(prods), 2)
+
 
 if __name__ == '__main__':
   unittest.main(verbosity=True)

--- a/Code/GraphMol/ChemReactions/testReaction.cpp
+++ b/Code/GraphMol/ChemReactions/testReaction.cpp
@@ -7408,6 +7408,94 @@ void testGithub3097() {
   TEST_ASSERT(prods.size() > 0);
 }
 
+void testRxnBlockRemoveHs() {
+  BOOST_LOG(rdInfoLog) << "-------------------------------------" << std::endl;
+  BOOST_LOG(rdInfoLog) << "Testing removing explicit Hs from RxnBlock"
+                       << std::endl;
+  std::string rxnB = R"RXN($RXN
+Dummy 0
+  Dummy        0123456789
+
+  1  1
+$MOL
+
+  Dummy   01234567892D
+
+ 10 10  0  0  0  0            999 V2000
+    7.0222  -11.1783    0.0000 C   0  0  0  0  0  0  0  0  0  1  0  0
+    8.0615  -11.7783    0.0000 O   0  0  0  0  0  0  0  0  0  2  0  0
+    7.0222   -9.6783    0.0000 N   0  0  0  0  0  0  0  0  0  3  0  0
+    5.7231   -8.9283    0.0000 C   0  0  0  0  0  0  0  0  0  4  0  0
+    5.7231   -7.7283    0.0000 A   0  0  0  0  0  0  0  0  0  5  0  0
+    4.4242   -9.6783    0.0000 C   0  0  0  0  0  0  0  0  0  6  0  0
+    4.4242  -11.1783    0.0000 C   0  0  0  0  0  0  0  0  0  7  0  0
+    3.3849  -11.7783    0.0000 A   0  0  0  0  0  0  0  0  0  8  0  0
+    5.7231  -11.9283    0.0000 N   0  0  0  0  0  0  0  0  0  9  0  0
+    5.7231  -13.1094    0.0000 H   0  0
+  1  2  2  0  0  0  8
+  1  3  1  0  0  0  8
+  3  4  2  0  0  0  8
+  4  5  1  0  0  0  2
+  4  6  1  0  0  0  8
+  6  7  2  0  0  0  8
+  7  8  1  0  0  0  2
+  7  9  1  0  0  0  8
+  9  1  1  0  0  0  8
+  9 10  1  0
+M  SUB  1   9   2
+M  END
+$MOL
+
+  Dummy   01234567892D
+
+  9  9  0  0  0  0            999 V2000
+   17.0447  -11.1783    0.0000 C   0  0  0  0  0  0  0  0  0  1  0  0
+   18.0840  -11.7783    0.0000 O   0  0  0  0  0  0  0  0  0  2  0  0
+   17.0447   -9.6783    0.0000 N   0  0  0  0  0  0  0  0  0  3  0  0
+   15.7457   -8.9283    0.0000 C   0  0  0  0  0  0  0  0  0  4  0  0
+   15.7457   -7.7283    0.0000 A   0  0  0  0  0  0  0  0  0  5  0  0
+   14.4467   -9.6783    0.0000 C   0  0  0  0  0  0  0  0  0  6  0  0
+   14.4467  -11.1783    0.0000 C   0  0  0  0  0  0  0  0  0  7  0  0
+   13.4074  -11.7783    0.0000 A   0  0  0  0  0  0  0  0  0  8  0  0
+   15.7457  -11.9283    0.0000 N   0  0  0  0  0  0  0  0  0  9  0  0
+  1  2  1  0  0  0  8
+  1  3  1  0  0  0  8
+  3  4  2  0  0  0  8
+  4  5  1  0  0  0  2
+  4  6  1  0  0  0  8
+  6  7  2  0  0  0  8
+  7  8  1  0  0  0  2
+  7  9  1  0  0  0  8
+  9  1  2  0  0  0  8
+M  END
+)RXN";
+
+  ROMOL_SPTR mol(
+      static_cast<ROMol *>(SmilesToMol("c1(=O)nc([Cl])cc([F])[nH]1")));
+  std::vector<ROMOL_SPTR> v{mol};
+
+  {
+    std::unique_ptr<ChemicalReaction> rxn(RxnBlockToChemicalReaction(rxnB));
+    TEST_ASSERT(rxn.get());
+    rxn->initReactantMatchers();
+
+    auto prods = rxn->runReactants(v);
+    // if the explicit hydrogen is not removed and the reactant template
+    // is not sanitized, the reactant template is not aromatic and our
+    // aromatic reactant won't match
+    TEST_ASSERT(prods.size() == 0);
+  }
+  {
+    std::unique_ptr<ChemicalReaction> rxn(
+        RxnBlockToChemicalReaction(rxnB, true, true));
+    TEST_ASSERT(rxn.get());
+    rxn->initReactantMatchers();
+
+    auto prods = rxn->runReactants(v);
+    TEST_ASSERT(prods.size() == 2);
+  }
+}
+
 int main() {
   RDLog::InitLogs();
 
@@ -7501,6 +7589,7 @@ int main() {
   testGithub3097();
 #endif
   testDblBondCrash();
+  testRxnBlockRemoveHs();
 
   BOOST_LOG(rdInfoLog)
       << "*******************************************************\n";


### PR DESCRIPTION
Similarly to the MDL molblock parser I think it would be good to enable passing explicit flags to the MDL rxnblock parser.
Particularly from Python, that does not allow write to reactant and product templates, it makes life easier in situations like the one exemplified in the test case compared to `SanitizeRxn()`.