### PR TITLE
MolEnumerator::enumerate() should call updatePropertyCache()

### DIFF
--- a/Code/GraphMol/MolEnumerator/MolEnumerator.cpp
+++ b/Code/GraphMol/MolEnumerator/MolEnumerator.cpp
@@ -60,6 +60,7 @@ MolBundle enumerate(const ROMol &mol, const MolEnumeratorParams &params) {
   enumerateVariations(variations, variationCounts, params);
   for (const auto &variation : variations) {
     auto newMol = (*op)(variation);
+    newMol->updatePropertyCache(false);
     res.addMol(ROMOL_SPTR(newMol.release()));
   }
   return res;

--- a/Code/GraphMol/MolEnumerator/enumerator_catch.cpp
+++ b/Code/GraphMol/MolEnumerator/enumerator_catch.cpp
@@ -134,6 +134,10 @@ M  END
         new MolEnumerator::PositionVariationOp());
     auto bundle = MolEnumerator::enumerate(*mol1, ps);
     CHECK(bundle.size() == 3);
+
+    CHECK(bundle.getMols()[0]->getAtomWithIdx(0)->getDegree()==3);
+    CHECK(bundle.getMols()[0]->getAtomWithIdx(0)->getImplicitValence()==0);    
+
     std::vector<std::string> tsmis = {"COc1ccncc1", "COc1ccccn1", "COc1cccnc1"};
     std::vector<std::string> smis;
     for (const auto molp : bundle.getMols()) {


### PR DESCRIPTION
For efficiency reasons we don't want to do a full sanitization, but It doesn't make any sense to require client code to do this.
