### PR TITLE
set the ChiralityPossible tag when using the new code with FindMolChiralCenters

### DIFF
--- a/rdkit/Chem/__init__.py
+++ b/rdkit/Chem/__init__.py
@@ -159,6 +159,7 @@ def FindMolChiralCenters(mol, force=True, includeUnassigned=False, includeCIP=Tr
             code = str(si.descriptor)
           else:
             code = '?'
+            atm.SetIntProp('_ChiralityPossible',1)
         centers.append((idx, code))
   return centers
 


### PR DESCRIPTION
The tag is used in places like `EnumerateStereoisomers()`, which won't be updated to use the new code by default until the next release.