### PR TITLE
Fixes #3430

### DIFF
--- a/Code/GraphMol/MolStandardize/Tautomer.cpp
+++ b/Code/GraphMol/MolStandardize/Tautomer.cpp
@@ -115,7 +115,7 @@ int scoreSubstructs(const ROMol &mol) {
       {"C=hetero", "[C]=[!#1;!#6]", 1},
       {"aromatic C = exocyclic N", "[c]=!@[N]", -1},
       {"methyl", "[CX4H3]", 1},
-      {"guanidine terminal=N", "[#7][#6](=[NR0])[#7H0]", 1},
+      {"guanidine terminal=N", "[#7]C(=[NR0])[#7H0]", 1},
       {"guanidine endocyclic=N", "[#7;R][#6;R]([N])=[#7;R]", 2},
       {"aci-nitro", "[#6]=[N+]([O-])[OH]", -4}};
   int score = 0;
@@ -131,7 +131,7 @@ int scoreSubstructs(const ROMol &mol) {
     //   std::cerr << " " << matches.size() << " matches to " << term.name
     //             << std::endl;
     // }
-    score += matches.size() * term.score;
+    score += static_cast<int>(matches.size()) * term.score;
   }
   return score;
 }


### PR DESCRIPTION
Turns out this was a very simple fix. There was already a rule to penalize exocyclic nitrogen bonds from aromatics to nitrogen, which however was conflicting with another rule addressing guanidines, so the net effect of the rules was zero and the exocyclic double bonded ended up with exactly the same score as the exocyclic one.
Changing the guanidine pattern to only apply to aliphatic C fixes the issue.
I had to change a single unit test where before my fix tautomers had the same score and the exocyclic tautomer was chosen as the canonical one based on lexical order:
![image](https://user-images.githubusercontent.com/5244385/94271320-c3228d00-ff41-11ea-815d-e51a8d0fea8b.png)
After my fix the endocyclic tautomer scores higher, as expected.:
![image](https://user-images.githubusercontent.com/5244385/94271426-e9482d00-ff41-11ea-9af7-ee2924535c4c.png)
This is also the tautomer predicted to be the most stable by both UNICON (https://doi.org/10.1021/acs.jcim.6b00069) and MoKa (http://dx.doi.org/10.1021/ci800340j).