### PR TITLE
expose PNG metadata functions to python

### DIFF
--- a/Code/GraphMol/Wrap/rdmolfiles.cpp
+++ b/Code/GraphMol/Wrap/rdmolfiles.cpp
@@ -1719,7 +1719,7 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
        - filename: the PNG filename
 
      RETURNS:
-       a string with the updated PNG data)DOC";
+       the updated PNG data)DOC";
   python::def(
       "AddMetadataToPNGFile", addMetadataToPNGFileHelper,
       (python::arg("metadata"), python::arg("filename")),
@@ -1736,7 +1736,7 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
        - png: the PNG string
 
      RETURNS:
-       a string with the updated PNG data)DOC";
+       the updated PNG data)DOC";
   python::def(
       "AddMetadataToPNGString", addMetadataToPNGStringHelper,
       (python::arg("metadata"), python::arg("png")),

--- a/Code/GraphMol/Wrap/rdmolfiles.cpp
+++ b/Code/GraphMol/Wrap/rdmolfiles.cpp
@@ -451,6 +451,45 @@ python::object addMolToPNGStringHelper(const ROMol &mol, python::object png,
   return retval;
 }
 
+python::object addMetadataToPNGFileHelper(python::dict pymetadata, python::object fname) {
+  std::string cstr = python::extract<std::string>(fname);
+
+  std::vector<std::pair<std::string, std::string>> metadata;
+  for (unsigned int i = 0;
+       i < python::extract<unsigned int>(pymetadata.keys().attr("__len__")());
+       ++i) {
+    std::string key = python::extract<std::string>(pymetadata.keys()[i]); 
+    std::string val = python::extract<std::string>(pymetadata.values()[i]);
+    metadata.push_back(std::make_pair(key,val));
+  }
+
+  auto res = addMetadataToPNGFile(cstr, metadata);
+
+  python::object retval = python::object(
+      python::handle<>(PyBytes_FromStringAndSize(res.c_str(), res.length())));
+  return retval;
+}
+
+python::object addMetadataToPNGStringHelper(python::dict pymetadata, python::object png) {
+  std::string cstr = python::extract<std::string>(png);
+
+  std::vector<std::pair<std::string, std::string>> metadata;
+  for (unsigned int i = 0;
+       i < python::extract<unsigned int>(pymetadata.keys().attr("__len__")());
+       ++i) {
+    std::string key = python::extract<std::string>(pymetadata.keys()[i]); 
+    std::string val = python::extract<std::string>(pymetadata.values()[i]);
+    metadata.push_back(std::make_pair(key,val));
+  }
+
+  auto res = addMetadataToPNGString(cstr, metadata);
+
+  python::object retval = python::object(
+      python::handle<>(PyBytes_FromStringAndSize(res.c_str(), res.length())));
+  return retval;
+}
+
+
 python::object MolsFromPNGFile(const char *filename, const std::string &tag,
                                python::object pyParams) {
   SmilesParserParams params;
@@ -491,6 +530,28 @@ python::tuple MolsFromPNGString(python::object png, const std::string &tag,
   }
   return python::tuple(res);
 }
+
+python::dict MetadataFromPNGFile(python::object fname){
+  std::string cstr = python::extract<std::string>(fname);
+  auto metadata = PNGFileToMetadata(cstr);
+  python::dict res;
+  for(const auto &pr : metadata ){
+    res[pr.first] =pr.second;
+  }
+  return res;
+}
+
+python::dict MetadataFromPNGString(python::object png){
+  std::string cstr = python::extract<std::string>(png);
+  auto metadata = PNGStringToMetadata(cstr);
+  python::dict res;
+  for(const auto &pr : metadata ){
+    res[pr.first] =pr.second;
+  }
+  return res;
+}
+
+
 
 }  // namespace RDKit
 
@@ -1594,7 +1655,7 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
               "returns a tuple of molecules constructed from the PNG file");
 
   docString =
-      R"DOC(Writes molecular metadata to a PNG file.
+      R"DOC(Adds molecular metadata to PNG data read from a file.
 
      ARGUMENTS:
 
@@ -1609,7 +1670,7 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
        - includeMol: include CTAB (Mol) in the output
 
      RETURNS:
-       a Mol object, None on failure.)DOC";
+       the updated PNG data)DOC";
   python::def(
       "MolMetadataToPNGFile", addMolToPNGFileHelper,
       (python::arg("mol"), python::arg("filename"),
@@ -1633,12 +1694,58 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
        - includeMol: include CTAB (Mol) in the output
 
      RETURNS:
-       a Mol object, None on failure.)DOC";
+       the updated PNG data)DOC";
   python::def(
       "MolMetadataToPNGString", addMolToPNGStringHelper,
       (python::arg("mol"), python::arg("png"), python::arg("includePkl") = true,
        python::arg("includeSmiles") = true, python::arg("includeMol") = false),
       docString.c_str());
+
+  docString =
+      R"DOC(Adds metadata to PNG data read from a file.
+
+     ARGUMENTS:
+
+       - metadata: dict with the metadata to be written 
+                   (keys and values should be strings)
+
+       - filename: the PNG filename
+
+     RETURNS:
+       a string with the updated PNG data)DOC";
+  python::def(
+      "AddMetadataToPNGFile", addMetadataToPNGFileHelper,
+      (python::arg("metadata"), python::arg("filename")),
+      docString.c_str());
+
+  docString =
+      R"DOC(Adds metadata to a PNG string.
+
+     ARGUMENTS:
+
+       - metadata: dict with the metadata to be written 
+                   (keys and values should be strings)
+
+       - png: the PNG string
+
+     RETURNS:
+       a string with the updated PNG data)DOC";
+  python::def(
+      "AddMetadataToPNGString", addMetadataToPNGStringHelper,
+      (python::arg("metadata"), python::arg("png")),
+      docString.c_str());
+
+  python::def(
+      "MetadataFromPNGFile", MetadataFromPNGFile,
+      (python::arg("filename")),
+      "Returns a dict with all metadata from the PNG file");
+
+  python::def(
+      "MetadataFromPNGString", MetadataFromPNGString,
+      (python::arg("png")),
+      "Returns a dict with all metadata from the PNG string");
+
+
 
 /********************************************************
  * MolSupplier stuff

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -6124,7 +6124,8 @@ M  END
     self.assertIsNotNone(mol)
     self.assertEqual(mol.GetNumAtoms(), 29)
 
-    d = open(fileN, 'rb').read()
+    with open(fileN, 'rb') as inf:
+      d = inf.read()
     mol = Chem.MolFromPNGString(d)
     self.assertIsNotNone(mol)
     self.assertEqual(mol.GetNumAtoms(), 29)
@@ -6160,24 +6161,26 @@ M  END
 
   def testMetadataToPNG(self):
     fileN = os.path.join(RDConfig.RDBaseDir, 'Code', 'GraphMol', 'FileParsers', 'test_data',
-                         'colchicine.no_metadata.png')
+                         'colchicine.png')
 
     with open(fileN, 'rb') as inf:
       d = inf.read()
+    mol = Chem.MolFromPNGString(d)
+    nd = Chem.MolMetadataToPNGString(mol,d)
     vals = {'foo':'1','bar':'2'}
-    nd = Chem.AddMetadataToPNGString(vals, d)
+    nd = Chem.AddMetadataToPNGString(vals, nd)
     nvals = Chem.MetadataFromPNGString(nd)
     self.assertTrue('foo' in nvals)
-    self.assertEqual(nvals['foo'],'1')
+    self.assertEqual(nvals['foo'],b'1')
     self.assertTrue('bar' in nvals)
-    self.assertEqual(nvals['bar'],'2')
+    self.assertEqual(nvals['bar'],b'2')
 
     nd = Chem.AddMetadataToPNGFile(vals, fileN)
     nvals = Chem.MetadataFromPNGString(nd)
     self.assertTrue('foo' in nvals)
-    self.assertEqual(nvals['foo'],'1')
+    self.assertEqual(nvals['foo'],b'1')
     self.assertTrue('bar' in nvals)
-    self.assertEqual(nvals['bar'],'2')
+    self.assertEqual(nvals['bar'],b'2')
 
     vals = {'foo':1,'bar':'2'}
     with self.assertRaises(TypeError):

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -6133,7 +6133,8 @@ M  END
     fileN = os.path.join(RDConfig.RDBaseDir, 'Code', 'GraphMol', 'FileParsers', 'test_data',
                          'colchicine.no_metadata.png')
 
-    d = open(fileN, 'rb').read()
+    with open(fileN, 'rb') as inf:
+      d = inf.read()
     mol = Chem.MolFromSmiles("COc1cc2c(c(OC)c1OC)-c1ccc(OC)c(=O)cc1[C@@H](NC(C)=O)CC2")
     self.assertIsNotNone(mol)
     self.assertEqual(mol.GetNumAtoms(), 29)
@@ -6156,6 +6157,31 @@ M  END
     self.assertEqual(len(mols), len(refMols))
     for mol, refMol in zip(mols, refMols):
       self.assertEqual(Chem.MolToSmiles(mol), Chem.MolToSmiles(refMol))
+
+  def testMetadataToPNG(self):
+    fileN = os.path.join(RDConfig.RDBaseDir, 'Code', 'GraphMol', 'FileParsers', 'test_data',
+                         'colchicine.no_metadata.png')
+
+    with open(fileN, 'rb') as inf:
+      d = inf.read()
+    vals = {'foo':'1','bar':'2'}
+    nd = Chem.AddMetadataToPNGString(vals, d)
+    nvals = Chem.MetadataFromPNGString(nd)
+    self.assertTrue('foo' in nvals)
+    self.assertEqual(nvals['foo'],'1')
+    self.assertTrue('bar' in nvals)
+    self.assertEqual(nvals['bar'],'2')
+
+    nd = Chem.AddMetadataToPNGFile(vals, fileN)
+    nvals = Chem.MetadataFromPNGString(nd)
+    self.assertTrue('foo' in nvals)
+    self.assertEqual(nvals['foo'],'1')
+    self.assertTrue('bar' in nvals)
+    self.assertEqual(nvals['bar'],'2')
+
+    vals = {'foo':1,'bar':'2'}
+    with self.assertRaises(TypeError):
+      nd = Chem.AddMetadataToPNGString(vals,d)
 
   def test_github3403(self):
     core1 = "[$(C-!@[a])](=O)(Cl)"


### PR DESCRIPTION
This allows metadata to be added to/read from PNG files and strings.
Allows us to use PNG files like SDFs :-)
