### PR TITLE
Fix dead links to inchi-trust

### DIFF
--- a/External/INCHI-API/Wrap/pyInchi.cpp
+++ b/External/INCHI-API/Wrap/pyInchi.cpp
@@ -141,9 +141,9 @@ BOOST_PYTHON_MODULE(rdinchi) {
     - options: the InChI generation options.\n\
       Options should be prefixed with either a - or a /\n\
       Available options are explained in the InChI technical FAQ:\n\
-      http://www.inchi-trust.org/fileadmin/user_upload/html/inchifaq/inchi-faq.html#15.14\n\
-      and the User Guide:\n\
-      http://www.inchi-trust.org/fileadmin/user_upload/software/inchi-v1.04/InChI_UserGuide.pdf\n\
+      https://www.inchi-trust.org/technical-faq-2/#15.14\n\
+      and the User Guide available from:\n\
+      https://www.inchi-trust.org/downloads/\n\
   Returns: the InChI key\n";
   boost::python::def("MolToInchiKey", RDKit::MolToInchiKey,
                      (boost::python::arg("mol"),


### PR DESCRIPTION
The InChI Trust website has changed the locations of the documentation and FAQ for the InChI software APIs.

#### Reference Issue

No Issue


#### What does this implement/fix? Explain your changes.

I have updated the link for the FAQ, but unfortunately the User Guide is no longer directly linkable, but is available for download as part of a zip file of documentation from the main downloads page.


