### PR TITLE
Two simple MolStandardizer code cleanups

### DIFF
--- a/Code/GraphMol/MolStandardize/MolStandardize.cpp
+++ b/Code/GraphMol/MolStandardize/MolStandardize.cpp
@@ -89,16 +89,7 @@ RWMol *chargeParent(const RWMol &mol, const CleanupParameters &params,
   // Return the charge parent of a given molecule.
   // The charge parent is the uncharged version of the fragment parent.
 
-  const RWMol *m = nullptr;
-
-  if (!skip_standardize) {
-    m = cleanup(mol, params);
-  } else {
-    m = &mol;
-  }
-
-
-  RWMOL_SPTR fragparent(fragmentParent(*m, params, skip_standardize));
+  RWMOL_SPTR fragparent(fragmentParent(mol, params, skip_standardize));
 
   // if fragment...
   ROMol nm(*fragparent);
@@ -106,9 +97,6 @@ RWMol *chargeParent(const RWMol &mol, const CleanupParameters &params,
   Uncharger uncharger(params.doCanonical);
   ROMOL_SPTR uncharged(uncharger.uncharge(nm));
   RWMol *omol = cleanup(static_cast<RWMol>(*uncharged), params);
-  if (!skip_standardize) {
-    delete m;
-  }
   return omol;
 }
 
@@ -128,8 +116,7 @@ RWMol *normalize(const RWMol *mol, const CleanupParameters &params) {
 }
 
 RWMol *reionize(const RWMol *mol, const CleanupParameters &params) {
-  RDUNUSED_PARAM(params);
-  Reionizer reionizer;
+  Reionizer reionizer(params.acidbaseFile);
   ROMol m(*mol);
   ROMol *reionized = reionizer.reionize(m);
 


### PR DESCRIPTION
This PR contains two very simple MolStandardizer code cleanups:
- `MolStandardize::chargeParent()` does not need to call `cleanup()` because it calls `fragmentParent()` which already does
- `MolStandardize::reionize()` should pass `params.acidbaseFile` to the `Reionizer` constructor (it looks like this was forgotten)
