### PR TITLE
A few improvements to MolStandardize::Normalizer

### DIFF
--- a/Code/GraphMol/MolStandardize/Normalize.cpp
+++ b/Code/GraphMol/MolStandardize/Normalize.cpp
@@ -109,7 +109,7 @@ ROMOL_SPTR Normalizer::normalizeFragment(
     // Iterate through Normalization transforms and apply each in order
     for (auto &transform : transforms) {
       SmilesMolPair product = applyTransform(nfrag, *transform);
-      if (!product.first.empty() and !seenProductSmiles.count(product.first)) {
+      if (!product.first.empty() && !seenProductSmiles.count(product.first)) {
         seenProductSmiles.insert(product.first);
         BOOST_LOG(rdInfoLog)
             << "Rule applied: "

--- a/Code/GraphMol/MolStandardize/Normalize.cpp
+++ b/Code/GraphMol/MolStandardize/Normalize.cpp
@@ -79,9 +79,8 @@ ROMol *Normalizer::normalize(const ROMol &mol) {
   const std::vector<std::shared_ptr<ChemicalReaction>> &transforms =
       tparams->getTransformations();
   bool sanitizeFrags = false;
-  std::vector<boost::shared_ptr<ROMol>> frags =
-      MolOps::getMolFrags(mol, sanitizeFrags);
-  std::vector<ROMOL_SPTR> nfrags;  //( frags.size() );
+  MOL_SPTR_VECT frags = MolOps::getMolFrags(mol, sanitizeFrags);
+  MOL_SPTR_VECT nfrags;  //( frags.size() );
   for (const auto &frag : frags) {
     frag->updatePropertyCache(false);
     ROMOL_SPTR nfrag(this->normalizeFragment(*frag, transforms));
@@ -98,30 +97,31 @@ ROMol *Normalizer::normalize(const ROMol &mol) {
   return outmol;
 }
 
-boost::shared_ptr<ROMol> Normalizer::normalizeFragment(
+ROMOL_SPTR Normalizer::normalizeFragment(
     const ROMol &mol,
-    const std::vector<std::shared_ptr<ChemicalReaction>> &transforms) {
-  boost::shared_ptr<ROMol> nfrag(new ROMol(mol));
+    const std::vector<std::shared_ptr<ChemicalReaction>> &transforms) const {
+  ROMOL_SPTR nfrag(new ROMol(mol));
   MolOps::fastFindRings(
       *nfrag);  // this doesn't do anything if rings are already there
+  std::set<std::string> seenProductSmiles;
   for (unsigned int i = 0; i < MAX_RESTARTS; ++i) {
-    bool loop_brake = false;
+    bool loop_break = false;
     // Iterate through Normalization transforms and apply each in order
     for (auto &transform : transforms) {
-      boost::shared_ptr<ROMol> product =
-          this->applyTransform(nfrag, *transform);
-      if (product != nullptr) {
+      SmilesMolPair product = applyTransform(nfrag, *transform);
+      if (!product.first.empty() and !seenProductSmiles.count(product.first)) {
+        seenProductSmiles.insert(product.first);
         BOOST_LOG(rdInfoLog)
             << "Rule applied: "
             << transform->getProp<std::string>(common_properties::_Name)
             << "\n";
-        nfrag = product;
-        loop_brake = true;
+        nfrag = product.second;
+        loop_break = true;
         break;
       }
     }
     // For loop finishes normally, all applicable transforms have been applied
-    if (!loop_brake) {
+    if (!loop_break) {
       return nfrag;
     }
   }
@@ -130,8 +130,8 @@ boost::shared_ptr<ROMol> Normalizer::normalizeFragment(
   return nfrag;
 }
 
-boost::shared_ptr<ROMol> Normalizer::applyTransform(
-    const boost::shared_ptr<ROMol> mol, ChemicalReaction &transform) {
+SmilesMolPair Normalizer::applyTransform(const ROMOL_SPTR &mol,
+                                         ChemicalReaction &transform) const {
   // Repeatedly apply normalization transform to molecule until no changes
   // occur.
   //
@@ -142,56 +142,45 @@ boost::shared_ptr<ROMol> Normalizer::applyTransform(
   // If there are multiple unique products after the final application, the
   // first product (sorted alphabetically by SMILES) is chosen.
 
-  MOL_SPTR_VECT mols;
-  mols.push_back(mol);
+  SmilesMolPair smilesMolPair{std::string(), mol};
 
   if (!transform.isInitialized()) {
     transform.initReactantMatchers();
   }
   // REVIEW: what's the source of the 20 in the next line?
   for (unsigned int i = 0; i < 20; ++i) {
-    std::vector<Normalizer::Product> pdts;
-    for (auto &m : mols) {
-      std::vector<MOL_SPTR_VECT> products = transform.runReactants({m});
-      for (auto &pdt : products) {
-        // shared_ptr<ROMol> p0( new RWMol(*pdt[0]) );
-        //				std::cout << MolToSmiles(*p0) <<
-        // std::endl;
-        unsigned int failed;
-        try {
-          auto *tmol = static_cast<RWMol *>(pdt[0].get());
-          // we'll allow atoms with a valence that's too high to make it
-          // through, but we should fail if we just created something that
-          // can't, for example, be kekulized.
-          unsigned int sanitizeOps = MolOps::SANITIZE_ALL ^
-                                     MolOps::SANITIZE_CLEANUP ^
-                                     MolOps::SANITIZE_PROPERTIES;
-          MolOps::sanitizeMol(*tmol, failed, sanitizeOps);
-          // REVIEW: is it actually important that we use canonical SMILES here?
-          Normalizer::Product np(MolToSmiles(*tmol), pdt[0]);
-          pdts.push_back(np);
-        } catch (MolSanitizeException &) {
-          BOOST_LOG(rdInfoLog) << "FAILED sanitizeMol.\n";
-        }
+    std::map<std::string, ROMOL_SPTR> pdts;
+    std::vector<MOL_SPTR_VECT> products =
+        transform.runReactants({smilesMolPair.second});
+    for (auto &pdt : products) {
+      // shared_ptr<ROMol> p0( new RWMol(*pdt[0]) );
+      //				std::cout << MolToSmiles(*p0) <<
+      // std::endl;
+      unsigned int failed;
+      try {
+        auto *tmol = static_cast<RWMol *>(pdt.front().get());
+        // we'll allow atoms with a valence that's too high to make it
+        // through, but we should fail if we just created something that
+        // can't, for example, be kekulized.
+        unsigned int sanitizeOps = MolOps::SANITIZE_ALL ^
+                                   MolOps::SANITIZE_CLEANUP ^
+                                   MolOps::SANITIZE_PROPERTIES;
+        MolOps::sanitizeMol(*tmol, failed, sanitizeOps);
+        pdts[MolToSmiles(*tmol)] = pdt.front();
+      } catch (MolSanitizeException &) {
+        BOOST_LOG(rdInfoLog) << "FAILED sanitizeMol.\n";
       }
     }
-    if (pdts.size() != 0) {
-      std::sort(pdts.begin(), pdts.end());
-      mols.clear();
-      mols.push_back(pdts[0].Mol);
+    if (!pdts.empty()) {
+      smilesMolPair = std::move(*pdts.begin());
     } else {
-      if (i > 0) {
-        return mols[0];
-      } else {
-        return nullptr;
+      if (i) {
+        return smilesMolPair;
       }
+      return std::make_pair(std::string(), nullptr);
     }
   }
-  if (mols.size()) {
-    return mols[0];
-  } else {
-    return nullptr;
-  }
+  return smilesMolPair;
 }
 
 }  // namespace MolStandardize

--- a/Code/GraphMol/MolStandardize/Normalize.h
+++ b/Code/GraphMol/MolStandardize/Normalize.h
@@ -32,6 +32,7 @@ RDKIT_MOLSTANDARDIZE_EXPORT extern const CleanupParameters
 typedef RDCatalog::HierarchCatalog<TransformCatalogEntry,
                                    TransformCatalogParams, int>
     TransformCatalog;
+typedef std::pair<std::string, ROMOL_SPTR> SmilesMolPair;
 
 //! The Normalizer class for applying Normalization transforms.
 /*!
@@ -71,25 +72,16 @@ class RDKIT_MOLSTANDARDIZE_EXPORT Normalizer {
     reached.
   */
   ROMol *normalize(const ROMol &mol);
-  struct Product {
-    std::string Smiles;
-    boost::shared_ptr<ROMol> Mol;
-    Product(std::string smiles, boost::shared_ptr<ROMol> &mol)
-        : Smiles(smiles), Mol(mol) {}
-
-    // sorting products alphabetically by SMILES
-    bool operator<(const Product &pdt) const { return (Smiles < pdt.Smiles); }
-  };
 
  private:
   const TransformCatalog *d_tcat;
   unsigned int MAX_RESTARTS;
 
-  boost::shared_ptr<ROMol> normalizeFragment(
+  ROMOL_SPTR normalizeFragment(
       const ROMol &mol,
-      const std::vector<std::shared_ptr<ChemicalReaction>> &transforms);
-  boost::shared_ptr<ROMol> applyTransform(const boost::shared_ptr<ROMol> mol,
-                                          ChemicalReaction &rule);
+      const std::vector<std::shared_ptr<ChemicalReaction>> &transforms) const;
+  SmilesMolPair applyTransform(const ROMOL_SPTR &mol,
+                               ChemicalReaction &rule) const;
 
 };  // Normalizer class
 }  // namespace MolStandardize

--- a/Code/GraphMol/MolStandardize/Wrap/Normalize.cpp
+++ b/Code/GraphMol/MolStandardize/Wrap/Normalize.cpp
@@ -22,10 +22,16 @@ ROMol *normalizeHelper(MolStandardize::Normalizer &self, const ROMol &mol) {
   return self.normalize(mol);
 }
 
-MolStandardize::Normalizer *normalizerFromParams(
+MolStandardize::Normalizer *normalizerFromDataAndParams(
     const std::string &data, const MolStandardize::CleanupParameters &params) {
   std::istringstream sstr(data);
   return new MolStandardize::Normalizer(sstr, params.maxRestarts);
+}
+
+MolStandardize::Normalizer *normalizerFromParams(
+    const MolStandardize::CleanupParameters &params) {
+  return new MolStandardize::Normalizer(params.normalizations,
+                                        params.maxRestarts);
 }
 }  // namespace
 
@@ -43,9 +49,14 @@ struct normalize_wrapper {
         .def("normalize", &normalizeHelper,
              (python::arg("self"), python::arg("mol")), "",
              python::return_value_policy<python::manage_new_object>());
-    python::def("NormalizerFromData", &normalizerFromParams,
-                (python::arg("paramData")),
-                "creates a normalizer from a string containing parameter data",
+    python::def(
+        "NormalizerFromData", &normalizerFromDataAndParams,
+        (python::arg("paramData"), python::arg("params")),
+        "creates a Normalizer from a string containing normalization SMARTS",
+        python::return_value_policy<python::manage_new_object>());
+    python::def("NormalizerFromParams", &normalizerFromParams,
+                (python::arg("params")),
+                "creates a Normalizer from CleanupParameters",
                 python::return_value_policy<python::manage_new_object>());
   }
 };

--- a/Code/GraphMol/MolStandardize/Wrap/testMolStandardize.py
+++ b/Code/GraphMol/MolStandardize/Wrap/testMolStandardize.py
@@ -173,7 +173,7 @@ class TestCase(unittest.TestCase):
     self.assertEqual
     ("""INFO: [FragmentValidation] 1,2-dichloroethane is present""", msg6[0])
 
-  def test10NormalizeParams(self):
+  def test10NormalizeFromData(self):
     data = """//	Name	SMIRKS
 Nitro to N+(O-)=O	[N,P,As,Sb;X3:1](=[O,S,Se,Te:2])=[O,S,Se,Te:3]>>[*+1:1]([*-1:2])=[*:3]
 Sulfone to S(=O)(=O)	[S+2:1]([O-:2])([O-:3])>>[S+0:1](=[O-0:2])(=[O-0:3])
@@ -719,6 +719,12 @@ chlorine	[Cl]
         self.assertEqual(Chem.MolToSmiles(t), Chem.MolToSmiles(res[i]))
         i += 1
     self.assertEqual(i, 0)
+
+  def test19NormalizeFromParams(self):
+    params = rdMolStandardize.CleanupParameters()
+    params.normalizationsFile = "ThisFileDoesNotExist.txt"
+    with self.assertRaises(OSError):
+        rdMolStandardize.NormalizerFromParams(params)
 
 if __name__ == "__main__":
   unittest.main()


### PR DESCRIPTION
This PR contains a few improvements to `MolStandardize::Normalizer`:
- use `ROMOL_SPTR` consistently (cosmetic change)
- allow using multiple alternative normalization patterns that match the same functional groups. I have added a test case where multiple custom patterns all match malformed azides. With the current RDKit master the `Normalizer` keeps adding the custom pattern again and again until it reaches the maximum number of normalization restarts (200 by default), and then applies no other normalization SMARTS. With the fix included in this PR this does not happen anymore.
- add missing parameter to `NormalizerFromData` factory method (Python wrappers): apparently one of the parameters had been forgotten in the Python signature
- add `NormalizerFromParams` factory method (Python wrappers). This is analogue to the `NormalizerFromData` method, minus the string. I know that one could use the constructor that takes a file and a number of restarts in alternative, but given there is a `CleanupParameters` class why not using it?
