### PR TITLE
A few small tweaks to the drawing code

### DIFF
--- a/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
@@ -2243,9 +2243,9 @@ void MolDraw2D::drawWedgedBond(const Point2D &cds1, const Point2D &cds2,
     // empirical cutoff to make sure we don't have too many dashes in the
     // wedge:
     auto factor = scale_ * (cds1 - cds2).lengthSq();
-    if (factor < 35) {
+    if (factor < 20) {
       nDashes = 3;
-    } else if (factor < 40) {
+    } else if (factor < 30) {
       nDashes = 4;
     } else if (factor < 45) {
       nDashes = 5;

--- a/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
@@ -2292,8 +2292,8 @@ void MolDraw2D::drawDativeBond(const Point2D &cds1, const Point2D &cds2,
 
   setColour(col2);
   bool asPolygon = true;
-  double frac = 0.1;
-  double angle = M_PI / 8;
+  double frac = 0.2;
+  double angle = M_PI / 6;
   // the polygon triangle at the end extends past cds2, so step back a bit
   // so as not to trample on anything else.
   Point2D delta = mid - cds2;

--- a/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
@@ -1430,7 +1430,9 @@ void MolDraw2D::finishMoleculeDraw(const RDKit::ROMol &draw_mol,
     }
   }
 
-  drawRadicals(draw_mol);
+  if (drawOptions().includeRadicals) {
+    drawRadicals(draw_mol);
+  }
 
   if (drawOptions().flagCloseContactsDist >= 0) {
     highlightCloseContacts();

--- a/Code/GraphMol/MolDraw2D/MolDraw2D.h
+++ b/Code/GraphMol/MolDraw2D/MolDraw2D.h
@@ -249,6 +249,9 @@ struct RDKIT_MOLDRAW2D_EXPORT MolDrawOptions {
   bool centreMoleculesBeforeDrawing = false;  // moves the centre of the drawn
                                               // molecule to (0,0)
   bool explicitMethyl = false;  // draw terminal methyl and related as CH3
+  bool includeRadicals =
+      true;  // include radicals in the drawing (it can be useful to turn this
+             // off for reactions and queries)
   bool includeMetadata =
       true;  // when possible include metadata about molecules and reactions in
              // the output to allow them to be reconstructed

--- a/Code/GraphMol/MolDraw2D/MolDraw2D.h
+++ b/Code/GraphMol/MolDraw2D/MolDraw2D.h
@@ -193,7 +193,7 @@ struct RDKIT_MOLDRAW2D_EXPORT MolDrawOptions {
                             // (if present)
   int maxFontSize = 40;  // maximum size in pixels for font in drawn molecule.
                          // -1 means no max.
-  int minFontSize = 4;   // likewise for -1.
+  int minFontSize = 6;   // likewise for -1.
   double annotationFontScale = 0.5;  // scales font relative to atom labels for
                                      // atom and bond annotation.
   std::string fontFile = "";  // name of font for freetype rendering.  If given,

--- a/Code/GraphMol/MolDraw2D/MolDraw2DUtils.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DUtils.cpp
@@ -158,6 +158,7 @@ void updateDrawerParamsFromJSON(MolDraw2D &drawer, const std::string &json) {
   PT_OPT_GET(centreMoleculesBeforeDrawing);
   PT_OPT_GET(explicitMethyl);
   PT_OPT_GET(includeMetadata);
+  PT_OPT_GET(includeRadicals);
 
   get_colour_option(&pt, "highlightColour", opts.highlightColour);
   get_colour_option(&pt, "backgroundColour", opts.backgroundColour);

--- a/Code/GraphMol/MolDraw2D/Wrap/rdMolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/Wrap/rdMolDraw2D.cpp
@@ -671,7 +671,11 @@ BOOST_PYTHON_MODULE(rdMolDraw2D) {
       .def_readwrite(
           "includeMetadata", &RDKit::MolDrawOptions::includeMetadata,
           "When possible, include metadata about molecules and reactions to "
-          "allow them to be reconstructed. Default is true.");
+          "allow them to be reconstructed. Default is true.")
+      .def_readwrite(
+          "includeRadicals", &RDKit::MolDrawOptions::includeRadicals,
+          "include radicals in the drawing (it can be useful to turn this off "
+          "for reactions and queries). Default is true.");
   docString = "Drawer abstract base class";
   python::class_<RDKit::MolDraw2D, boost::noncopyable>(
       "MolDraw2D", docString.c_str(), python::no_init)

--- a/Code/GraphMol/MolDraw2D/catch_tests.cpp
+++ b/Code/GraphMol/MolDraw2D/catch_tests.cpp
@@ -285,6 +285,50 @@ TEST_CASE("dative bonds", "[drawing][organometallics]") {
                     " L 81.0244,149.68' style='fill:none;"
                     "fill-rule:evenodd;stroke:#0000FF;") != std::string::npos);
   }
+  SECTION("dative series") {
+    auto m1 = "N->1[C@@H]2CCCC[C@H]2N->[Pt]11OC(=O)C(=O)O1"_smiles;
+    REQUIRE(m1);
+    {
+      MolDraw2DSVG drawer(150, 150, -1, -1, NO_FREETYPE);
+      MolDraw2DUtils::prepareMolForDrawing(*m1);
+      drawer.drawMolecule(*m1);
+      drawer.finishDrawing();
+      std::string text = drawer.getDrawingText();
+      std::ofstream outs("testDativeBonds_2a.svg");
+      outs << text;
+      outs.flush();
+    }
+    {
+      MolDraw2DSVG drawer(250, 250, -1, -1, NO_FREETYPE);
+      MolDraw2DUtils::prepareMolForDrawing(*m1);
+      drawer.drawMolecule(*m1);
+      drawer.finishDrawing();
+      std::string text = drawer.getDrawingText();
+      std::ofstream outs("testDativeBonds_2b.svg");
+      outs << text;
+      outs.flush();
+    }
+    {
+      MolDraw2DSVG drawer(350, 350, -1, -1, NO_FREETYPE);
+      MolDraw2DUtils::prepareMolForDrawing(*m1);
+      drawer.drawMolecule(*m1);
+      drawer.finishDrawing();
+      std::string text = drawer.getDrawingText();
+      std::ofstream outs("testDativeBonds_2c.svg");
+      outs << text;
+      outs.flush();
+    }
+    {
+      MolDraw2DSVG drawer(450, 450, -1, -1, NO_FREETYPE);
+      MolDraw2DUtils::prepareMolForDrawing(*m1);
+      drawer.drawMolecule(*m1);
+      drawer.finishDrawing();
+      std::string text = drawer.getDrawingText();
+      std::ofstream outs("testDativeBonds_2d.svg");
+      outs << text;
+      outs.flush();
+    }
+  }
 }
 
 TEST_CASE("zero-order bonds", "[drawing][organometallics]") {

--- a/Code/GraphMol/MolDraw2D/catch_tests.cpp
+++ b/Code/GraphMol/MolDraw2D/catch_tests.cpp
@@ -787,3 +787,34 @@ TEST_CASE(
     outs.flush();
   }
 }
+
+TEST_CASE("includeRadicals", "[options]") {
+  SECTION("basics") {
+    auto m = "[O][C]"_smiles;
+    REQUIRE(m);
+    int panelHeight = -1;
+    int panelWidth = -1;
+    bool noFreeType = true;
+    {
+      MolDraw2DSVG drawer(250, 200, panelWidth, panelHeight, noFreeType);
+      drawer.drawMolecule(*m);
+      drawer.finishDrawing();
+      auto text = drawer.getDrawingText();
+      std::ofstream outs("testIncludeRadicals_1a.svg");
+      outs << text;
+      outs.flush();
+      CHECK(text.find("<path d='M") != std::string::npos);
+    }
+    {
+      MolDraw2DSVG drawer(250, 200, panelWidth, panelHeight, noFreeType);
+      drawer.drawOptions().includeRadicals = false;
+      drawer.drawMolecule(*m);
+      drawer.finishDrawing();
+      auto text = drawer.getDrawingText();
+      std::ofstream outs("testIncludeRadicals_1b.svg");
+      outs << text;
+      outs.flush();
+      CHECK(text.find("<path d='M") == std::string::npos);
+    }
+  }
+}

--- a/Code/GraphMol/MolDraw2D/catch_tests.cpp
+++ b/Code/GraphMol/MolDraw2D/catch_tests.cpp
@@ -505,7 +505,7 @@ TEST_CASE("Github #3226: Lines in wedge bonds being drawn too closely together",
       outs.flush();
       std::vector<std::string> tkns;
       boost::algorithm::find_all(tkns, text, "bond-0");
-      CHECK(tkns.size() == 3);
+      CHECK(tkns.size() == 4);
     }
   }
 #ifdef RDK_BUILD_CAIRO_SUPPORT
@@ -529,7 +529,7 @@ TEST_CASE("Github #3226: Lines in wedge bonds being drawn too closely together",
       outs.flush();
       std::vector<std::string> tkns;
       boost::algorithm::find_all(tkns, text, "bond-0");
-      CHECK(tkns.size() == 3);
+      CHECK(tkns.size() == 4);
     }
   }
 #ifdef RDK_BUILD_CAIRO_SUPPORT

--- a/Code/GraphMol/MolDraw2D/test1.cpp
+++ b/Code/GraphMol/MolDraw2D/test1.cpp
@@ -1157,6 +1157,51 @@ void testGithub852() {
     }
     delete m;
   }
+  {
+    std::string smiles =
+        "C[C@]12CC[C@@H]3c4ccc(cc4CC[C@H]3[C@@H]1CC[C@@H]2O)O";  // estradiol
+    RWMol *m = SmilesToMol(smiles);
+    TEST_ASSERT(m);
+    MolDraw2DUtils::prepareMolForDrawing(*m);
+    {
+      std::cerr << "----------------" << std::endl;
+      std::string nameBase = "test852_2a";
+      std::ofstream outs((nameBase + ".svg").c_str());
+      MolDraw2DSVG drawer(200, 200, outs);
+      drawer.drawMolecule(*m);
+      drawer.finishDrawing();
+      outs.flush();
+    }
+    {
+      std::cerr << "----------------" << std::endl;
+      std::string nameBase = "test852_2b";
+      std::ofstream outs((nameBase + ".svg").c_str());
+      MolDraw2DSVG drawer(250, 250, outs);
+      drawer.drawMolecule(*m);
+      drawer.finishDrawing();
+      outs.flush();
+    }
+    {
+      std::cerr << "----------------" << std::endl;
+      std::string nameBase = "test852_2c";
+      std::ofstream outs((nameBase + ".svg").c_str());
+      MolDraw2DSVG drawer(400, 400, outs);
+      drawer.drawMolecule(*m);
+      drawer.finishDrawing();
+      outs.flush();
+    }
+    {
+      std::cerr << "----------------" << std::endl;
+      std::string nameBase = "test852_2d";
+      std::ofstream outs((nameBase + ".svg").c_str());
+      MolDraw2DSVG drawer(500, 500, outs);
+      drawer.drawMolecule(*m);
+      drawer.finishDrawing();
+      outs.flush();
+    }
+
+    delete m;
+  }
   std::cerr << " Done" << std::endl;
 }
 


### PR DESCRIPTION
includes:
- increasing the minimum font size to 6
- further tweaking to the dash counts for wedged bonds
- making the arrows on dative bonds more prominent
- allowing the drawing of radicals to be disabled