### PR TITLE
BlockLogs was reenabling all logs, not just the ones that were disabled

### DIFF
--- a/Code/RDGeneral/RDLog.cpp
+++ b/Code/RDGeneral/RDLog.cpp
@@ -204,9 +204,10 @@ namespace RDLog {
 BlockLogs::BlockLogs() {
   auto logs = {rdDebugLog, rdInfoLog, rdWarningLog, rdErrorLog};
   for(auto log: logs) {
-    if(log != nullptr && is_log_enabled(log))
+    if(log != nullptr && is_log_enabled(log)) {
       log->df_enabled = false;
-    logs_to_reenable.push_back(log);
+      logs_to_reenable.push_back(log);
+    }
   }
 }
 


### PR DESCRIPTION
Simple fix to BlockLogs, it was turning on all logs when it went out of scope, this just turns on the logs that were turned off.