### PR TITLE
enable accidentally disabled inchi tests

### DIFF
--- a/External/INCHI-API/test.cpp
+++ b/External/INCHI-API/test.cpp
@@ -782,7 +782,7 @@ void testGithub3365() {
 //-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
 int main() {
   RDLog::InitLogs();
-#if 0
+#if 1
   testGithubIssue3();
   testGithubIssue8();
   testGithubIssue40();


### PR DESCRIPTION
I forgot to re-enable these in #3366 
