### PR TITLE
ROMol: add inline impl for common getNumAtoms call

### DIFF
--- a/Code/GraphMol/ROMol.h
+++ b/Code/GraphMol/ROMol.h
@@ -296,7 +296,10 @@ class RDKIT_GRAPHMOL_EXPORT ROMol : public RDProps {
   //@{
 
   //! returns our number of atoms
-  unsigned int getNumAtoms(bool onlyExplicit = 1) const;
+  inline unsigned int getNumAtoms() const {
+    return rdcast<unsigned int>(boost::num_vertices(d_graph));
+  };
+  unsigned int getNumAtoms(bool onlyExplicit) const;
   //! returns our number of heavy atoms (atomic number > 1)
   unsigned int getNumHeavyAtoms() const;
   //! returns a pointer to a particular Atom


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

This change improves the throughput of many common rdkit operations on my setup (x86_64 debian buster / clang 7 / 8-core cpu):

The number of `RDKit::MolToSmiles` calls/s is about 2.8% higher
The number of `RDKit::SmilesToMol` calls/s is about 5.8% higher
The number of `RDKit::MolToInchiKey` calls/s is about 2.0% higher
