### PR TITLE
Removed missing headers

### DIFF
--- a/Code/GraphMol/FileParsers/CMakeLists.txt
+++ b/Code/GraphMol/FileParsers/CMakeLists.txt
@@ -66,8 +66,6 @@ rdkit_headers(FileParsers.h
               MolWriters.h
               SequenceParsers.h SequenceWriters.h
               GeneralFileReader.h
-							MultithreadedMolSupplier.h
-							MulithreadedSmilesMolSupplier.h
 							MultithreadedSDMolSupplier.h
               PNGParser.h
               DEST GraphMol/FileParsers)


### PR DESCRIPTION
These missing headers are currently causing the build to fail.