### PR TITLE
Fixes typo that causes the build to fail

### DIFF
--- a/Code/GraphMol/FileParsers/CMakeLists.txt
+++ b/Code/GraphMol/FileParsers/CMakeLists.txt
@@ -67,7 +67,7 @@ rdkit_headers(FileParsers.h
               SequenceParsers.h SequenceWriters.h
               GeneralFileReader.h
 							MultithreadedMolSupplier.h
-							MulithreadedSmilesMolSupplier.h
+							MultithreadedSmilesMolSupplier.h
 							MultithreadedSDMolSupplier.h
               PNGParser.h
               DEST GraphMol/FileParsers)


### PR DESCRIPTION
OK, there was actually a problem, but it was just a typo.