### PR TITLE
Fix a crashing bug with None in rdMolStandardize

### DIFF
--- a/Code/GraphMol/MolStandardize/Wrap/rdMolStandardize.cpp
+++ b/Code/GraphMol/MolStandardize/Wrap/rdMolStandardize.cpp
@@ -18,6 +18,9 @@ namespace python = boost::python;
 
 namespace {
 RDKit::ROMol *cleanupHelper(const RDKit::ROMol *mol, python::object params) {
+  if (!mol) {
+    throw_value_error("Molecule is None");
+  }
   const RDKit::MolStandardize::CleanupParameters *ps =
       &RDKit::MolStandardize::defaultCleanupParameters;
   if (params) {
@@ -30,6 +33,9 @@ RDKit::ROMol *cleanupHelper(const RDKit::ROMol *mol, python::object params) {
 RDKit::ROMol *fragmentParentHelper(const RDKit::ROMol *mol,
                                    python::object params,
                                    bool skip_standardize) {
+  if (!mol) {
+    throw_value_error("Molecule is None");
+  }
   const RDKit::MolStandardize::CleanupParameters *ps =
       &RDKit::MolStandardize::defaultCleanupParameters;
   if (params) {
@@ -41,6 +47,9 @@ RDKit::ROMol *fragmentParentHelper(const RDKit::ROMol *mol,
 
 RDKit::ROMol *chargeParentHelper(const RDKit::ROMol *mol, python::object params,
                                  bool skip_standardize) {
+  if (!mol) {
+    throw_value_error("Molecule is None");
+  }
   const RDKit::MolStandardize::CleanupParameters *ps =
       &RDKit::MolStandardize::defaultCleanupParameters;
   if (params) {
@@ -51,6 +60,9 @@ RDKit::ROMol *chargeParentHelper(const RDKit::ROMol *mol, python::object params,
 }
 
 RDKit::ROMol *normalizeHelper(const RDKit::ROMol *mol, python::object params) {
+  if (!mol) {
+    throw_value_error("Molecule is None");
+  }
   const RDKit::MolStandardize::CleanupParameters *ps =
       &RDKit::MolStandardize::defaultCleanupParameters;
   if (params) {
@@ -61,6 +73,9 @@ RDKit::ROMol *normalizeHelper(const RDKit::ROMol *mol, python::object params) {
 }
 
 RDKit::ROMol *reionizeHelper(const RDKit::ROMol *mol, python::object params) {
+  if (!mol) {
+    throw_value_error("Molecule is None");
+  }
   const RDKit::MolStandardize::CleanupParameters *ps =
       &RDKit::MolStandardize::defaultCleanupParameters;
   if (params) {

--- a/Code/GraphMol/MolStandardize/Wrap/testMolStandardize.py
+++ b/Code/GraphMol/MolStandardize/Wrap/testMolStandardize.py
@@ -328,16 +328,16 @@ chlorine	[Cl]
     self.assertEqual(taut_res.modifiedAtoms,(7,9))
     self.assertEqual(len(taut_res.modifiedBonds),7)
     self.assertEqual(taut_res.modifiedBonds,(7,8,9,10,11,12,14))
-    
+
     taut_res = enumerator.Enumerate(m)
     self.assertEqual(len(taut_res.tautomers),2)
     self.assertEqual(taut_res.modifiedAtoms,(7,9))
-    
+
     taut_res = enumerator.Enumerate(m)
     self.assertEqual(len(taut_res.tautomers),2)
     self.assertEqual(len(taut_res.modifiedBonds),7)
     self.assertEqual(taut_res.modifiedBonds,(7,8,9,10,11,12,14))
-    
+
   def test15EnumeratorParams(self):
     # Test a structure with hundreds of tautomers.
     smi68 = "[H][C](CO)(NC(=O)C1=C(O)C(O)=CC=C1)C(O)=O"
@@ -702,29 +702,41 @@ chlorine	[Cl]
     res_it = iter(res)
     i = 0
     while 1:
-        try:
-            t = next(res_it)
-        except StopIteration:
-            break
-        self.assertEqual(Chem.MolToSmiles(t), Chem.MolToSmiles(res[i]))
-        i += 1
+      try:
+        t = next(res_it)
+      except StopIteration:
+        break
+      self.assertEqual(Chem.MolToSmiles(t), Chem.MolToSmiles(res[i]))
+      i += 1
     self.assertEqual(i, len(res))
     res_it = iter(res)
     i = -len(res)
     while 1:
-        try:
-            t = next(res_it)
-        except StopIteration:
-            break
-        self.assertEqual(Chem.MolToSmiles(t), Chem.MolToSmiles(res[i]))
-        i += 1
+      try:
+        t = next(res_it)
+      except StopIteration:
+        break
+      self.assertEqual(Chem.MolToSmiles(t), Chem.MolToSmiles(res[i]))
+      i += 1
     self.assertEqual(i, 0)
 
   def test19NormalizeFromParams(self):
     params = rdMolStandardize.CleanupParameters()
     params.normalizationsFile = "ThisFileDoesNotExist.txt"
     with self.assertRaises(OSError):
-        rdMolStandardize.NormalizerFromParams(params)
+      rdMolStandardize.NormalizerFromParams(params)
+
+  def test20NoneHandling(self):
+    with self.assertRaises(ValueError):
+      rdMolStandardize.ChargeParent(None)
+    with self.assertRaises(ValueError):
+      rdMolStandardize.Cleanup(None)
+    with self.assertRaises(ValueError):
+      rdMolStandardize.FragmentParent(None)
+    with self.assertRaises(ValueError):
+      rdMolStandardize.Normalize(None)
+    with self.assertRaises(ValueError):
+      rdMolStandardize.Reionize(None)
 
 if __name__ == "__main__":
   unittest.main()


### PR DESCRIPTION
Some of the rdMolStandardize functions were not checking that they were being passed valid pointers, so it was pretty easy to make them crash the kernel.

This fixes that.