### PR TITLE
Speed up GraphMol/Chirality.cpp/iterateCIPRanks

### DIFF
--- a/Code/GraphMol/Bond.cpp
+++ b/Code/GraphMol/Bond.cpp
@@ -177,6 +177,60 @@ double Bond::getBondTypeAsDouble() const {
   }
 }
 
+uint8_t Bond::getTwiceBondType() const {
+  switch (getBondType()) {
+    case UNSPECIFIED:
+    case IONIC:
+    case ZERO:
+      return 0;
+      break;
+    case SINGLE:
+      return 2;
+      break;
+    case DOUBLE:
+      return 4;
+      break;
+    case TRIPLE:
+      return 6;
+      break;
+    case QUADRUPLE:
+      return 8;
+      break;
+    case QUINTUPLE:
+      return 10;
+      break;
+    case HEXTUPLE:
+      return 12;
+      break;
+    case ONEANDAHALF:
+      return 3;
+      break;
+    case TWOANDAHALF:
+      return 5;
+      break;
+    case THREEANDAHALF:
+      return 7;
+      break;
+    case FOURANDAHALF:
+      return 9;
+      break;
+    case FIVEANDAHALF:
+      return 11;
+      break;
+    case AROMATIC:
+      return 3;
+      break;
+    case DATIVEONE:
+      return 2;
+      break;  // FIX: this should probably be different
+    case DATIVE:
+      return 2;
+      break;  // FIX: again probably wrong
+    default:
+      UNDER_CONSTRUCTION("Bad bond type");
+  }
+}
+
 double Bond::getValenceContrib(const Atom *atom) const {
   switch (getBondType()) {
     case UNSPECIFIED:

--- a/Code/GraphMol/Bond.cpp
+++ b/Code/GraphMol/Bond.cpp
@@ -177,60 +177,6 @@ double Bond::getBondTypeAsDouble() const {
   }
 }
 
-uint8_t Bond::getTwiceBondType() const {
-  switch (getBondType()) {
-    case UNSPECIFIED:
-    case IONIC:
-    case ZERO:
-      return 0;
-      break;
-    case SINGLE:
-      return 2;
-      break;
-    case DOUBLE:
-      return 4;
-      break;
-    case TRIPLE:
-      return 6;
-      break;
-    case QUADRUPLE:
-      return 8;
-      break;
-    case QUINTUPLE:
-      return 10;
-      break;
-    case HEXTUPLE:
-      return 12;
-      break;
-    case ONEANDAHALF:
-      return 3;
-      break;
-    case TWOANDAHALF:
-      return 5;
-      break;
-    case THREEANDAHALF:
-      return 7;
-      break;
-    case FOURANDAHALF:
-      return 9;
-      break;
-    case FIVEANDAHALF:
-      return 11;
-      break;
-    case AROMATIC:
-      return 3;
-      break;
-    case DATIVEONE:
-      return 2;
-      break;  // FIX: this should probably be different
-    case DATIVE:
-      return 2;
-      break;  // FIX: again probably wrong
-    default:
-      UNDER_CONSTRUCTION("Bad bond type");
-  }
-}
-
 double Bond::getValenceContrib(const Atom *atom) const {
   switch (getBondType()) {
     case UNSPECIFIED:
@@ -353,6 +299,60 @@ void Bond::setStereoAtoms(unsigned int bgnIdx, unsigned int endIdx) {
   atoms.push_back(bgnIdx);
   atoms.push_back(endIdx);
 };
+
+uint8_t getTwiceBondType(const Bond &b) {
+  switch (b.getBondType()) {
+    case Bond::UNSPECIFIED:
+    case Bond::IONIC:
+    case Bond::ZERO:
+      return 0;
+      break;
+    case Bond::SINGLE:
+      return 2;
+      break;
+    case Bond::DOUBLE:
+      return 4;
+      break;
+    case Bond::TRIPLE:
+      return 6;
+      break;
+    case Bond::QUADRUPLE:
+      return 8;
+      break;
+    case Bond::QUINTUPLE:
+      return 10;
+      break;
+    case Bond::HEXTUPLE:
+      return 12;
+      break;
+    case Bond::ONEANDAHALF:
+      return 3;
+      break;
+    case Bond::TWOANDAHALF:
+      return 5;
+      break;
+    case Bond::THREEANDAHALF:
+      return 7;
+      break;
+    case Bond::FOURANDAHALF:
+      return 9;
+      break;
+    case Bond::FIVEANDAHALF:
+      return 11;
+      break;
+    case Bond::AROMATIC:
+      return 3;
+      break;
+    case Bond::DATIVEONE:
+      return 2;
+      break;  // FIX: this should probably be different
+    case Bond::DATIVE:
+      return 2;
+      break;  // FIX: again probably wrong
+    default:
+      UNDER_CONSTRUCTION("Bad bond type");
+  }
+}
 
 };  // namespace RDKit
 

--- a/Code/GraphMol/Bond.h
+++ b/Code/GraphMol/Bond.h
@@ -124,6 +124,9 @@ class RDKIT_GRAPHMOL_EXPORT Bond : public RDProps {
   //! \brief returns our \c bondType as a double
   //!   (e.g. SINGLE->1.0, AROMATIC->1.5, etc.)
   double getBondTypeAsDouble() const;
+  //! \brief returns twice our \c bondType
+  //!   (e.g. SINGLE->2, AROMATIC->3, etc.)
+  uint8_t getTwiceBondType() const;
 
   //! returns our contribution to the explicit valence of an Atom
   /*!

--- a/Code/GraphMol/Bond.h
+++ b/Code/GraphMol/Bond.h
@@ -124,9 +124,6 @@ class RDKIT_GRAPHMOL_EXPORT Bond : public RDProps {
   //! \brief returns our \c bondType as a double
   //!   (e.g. SINGLE->1.0, AROMATIC->1.5, etc.)
   double getBondTypeAsDouble() const;
-  //! \brief returns twice our \c bondType
-  //!   (e.g. SINGLE->2, AROMATIC->3, etc.)
-  uint8_t getTwiceBondType() const;
 
   //! returns our contribution to the explicit valence of an Atom
   /*!
@@ -345,6 +342,11 @@ class RDKIT_GRAPHMOL_EXPORT Bond : public RDProps {
 
   void initBond();
 };
+
+//! returns twice the \c bondType
+//! (e.g. SINGLE->2, AROMATIC->3, etc.)
+uint8_t getTwiceBondType(const RDKit::Bond &b);
+
 };  // namespace RDKit
 
 //! allows Bond objects to be dumped to streams

--- a/Code/GraphMol/Chirality.cpp
+++ b/Code/GraphMol/Chirality.cpp
@@ -14,7 +14,6 @@
 #include <sstream>
 #include <set>
 #include <algorithm>
-#include <numeric>
 #include <RDGeneral/utils.h>
 #include <RDGeneral/Invariant.h>
 #include <RDGeneral/RDLog.h>
@@ -892,8 +891,6 @@ void iterateCIPRanks(const ROMol &mol, const DOUBLE_VECT &invars,
   for (auto& vec : cipEntries) {
     vec.reserve(16);
   }
-  INT_LIST allIndices(numAtoms);
-  std::iota(allIndices.begin(), allIndices.end(), 0);
 #ifdef VERBOSE_CANON
   BOOST_LOG(rdDebugLog) << "invariants:" << std::endl;
   for (unsigned int i = 0; i < numAtoms; i++) {
@@ -946,7 +943,7 @@ void iterateCIPRanks(const ROMol &mol, const DOUBLE_VECT &invars,
     //
     // for each atom, get a sorted list of its neighbors' ranks:
     //
-    for (int &index : allIndices) {
+    for (unsigned int index = 0; index < numAtoms; ++index) {
       // Note: counts is cleaned up when we drain into cipEntries.
       updatedNbrIdxs.clear();
 
@@ -1020,7 +1017,7 @@ void iterateCIPRanks(const ROMol &mol, const DOUBLE_VECT &invars,
     //
     // pad the entries so that we compare rounds to themselves:
     //
-    for (int &index : allIndices) {
+    for (unsigned int index = 0; index < numAtoms; ++index) {
       auto sz = rdcast<unsigned int>(cipEntries[index].size());
       if (sz < longestEntry) {
         cipEntries[index].insert(cipEntries[index].end(), longestEntry - sz,

--- a/Code/GraphMol/Chirality.cpp
+++ b/Code/GraphMol/Chirality.cpp
@@ -14,6 +14,7 @@
 #include <sstream>
 #include <set>
 #include <algorithm>
+#include <numeric>
 #include <RDGeneral/utils.h>
 #include <RDGeneral/Invariant.h>
 #include <RDGeneral/RDLog.h>
@@ -881,17 +882,18 @@ void buildCIPInvariants(const ROMol &mol, DOUBLE_VECT &res) {
   }
 }
 
-void iterateCIPRanks(const ROMol &mol, DOUBLE_VECT &invars, UINT_VECT &ranks,
-                     bool seedWithInvars) {
+void iterateCIPRanks(const ROMol &mol, const DOUBLE_VECT &invars,
+                     UINT_VECT &ranks, bool seedWithInvars) {
   PRECONDITION(invars.size() == mol.getNumAtoms(), "bad invars size");
   PRECONDITION(ranks.size() >= mol.getNumAtoms(), "bad ranks size");
 
   unsigned int numAtoms = mol.getNumAtoms();
   CIP_ENTRY_VECT cipEntries(numAtoms);
-  INT_LIST allIndices;
-  for (unsigned int i = 0; i < numAtoms; ++i) {
-    allIndices.push_back(i);
+  for (auto& vec : cipEntries) {
+    vec.reserve(16);
   }
+  INT_LIST allIndices(numAtoms);
+  std::iota(allIndices.begin(), allIndices.end(), 0);
 #ifdef VERBOSE_CANON
   BOOST_LOG(rdDebugLog) << "invariants:" << std::endl;
   for (unsigned int i = 0; i < numAtoms; i++) {
@@ -911,11 +913,11 @@ void iterateCIPRanks(const ROMol &mol, DOUBLE_VECT &invars, UINT_VECT &ranks,
   //  Note: in general one should avoid the temptation to
   //  use invariants here, those lead to incorrect answers
   for (unsigned int i = 0; i < numAtoms; i++) {
-    if (!seedWithInvars) {
+    if (seedWithInvars) {
+      cipEntries[i].push_back(static_cast<int>(invars[i]));
+    } else {
       cipEntries[i].push_back(mol[i]->getAtomicNum());
       cipEntries[i].push_back(static_cast<int>(ranks[i]));
-    } else {
-      cipEntries[i].push_back(static_cast<int>(invars[i]));
     }
   }
 
@@ -933,6 +935,9 @@ void iterateCIPRanks(const ROMol &mol, DOUBLE_VECT &invars, UINT_VECT &ranks,
   unsigned int numIts = 0;
   int lastNumRanks = -1;
   unsigned int numRanks = *std::max_element(ranks.begin(), ranks.end()) + 1;
+  std::vector<unsigned int> counts(ranks.size());
+  std::vector<unsigned int> updatedNbrIdxs;
+  updatedNbrIdxs.reserve(8);
   while (numRanks < numAtoms && numIts < maxIts &&
          (lastNumRanks < 0 ||
           static_cast<unsigned int>(lastNumRanks) < numRanks)) {
@@ -942,8 +947,8 @@ void iterateCIPRanks(const ROMol &mol, DOUBLE_VECT &invars, UINT_VECT &ranks,
     // for each atom, get a sorted list of its neighbors' ranks:
     //
     for (int &index : allIndices) {
-      CIP_ENTRY localEntry;
-      localEntry.reserve(16);
+      // Note: counts is cleaned up when we drain into cipEntries.
+      updatedNbrIdxs.clear();
 
       // start by pushing on our neighbors' ranks:
       ROMol::OEDGE_ITER beg, end;
@@ -952,51 +957,63 @@ void iterateCIPRanks(const ROMol &mol, DOUBLE_VECT &invars, UINT_VECT &ranks,
         const Bond *bond = mol[*beg];
         ++beg;
         unsigned int nbrIdx = bond->getOtherAtomIdx(index);
-        const Atom *nbr = mol[nbrIdx];
+        updatedNbrIdxs.push_back(nbrIdx);
 
-        int rank = ranks[nbrIdx] + 1;
         // put the neighbor in 2N times where N is the bond order as a double.
         // this is to treat aromatic linkages on fair footing. i.e. at least in
-        // the
-        // first iteration --c(:c):c and --C(=C)-C should look the same.
+        // the first iteration --c(:c):c and --C(=C)-C should look the same.
         // this was part of issue 3009911
 
-        unsigned int count;
-        if (bond->getBondType() == Bond::DOUBLE && nbr->getAtomicNum() == 15 &&
-            (nbr->getDegree() == 4 || nbr->getDegree() == 3)) {
-          // a special case for chiral phosphorous compounds
-          // (this was leading to incorrect assignment of
-          // R/S labels ):
-          count = 1;
+        // a special case for chiral phosphorus compounds
+        // (this was leading to incorrect assignment of R/S labels ):
+        bool isChiralPhosphorusSpecialCase;
+        if (bond->getBondType() != Bond::DOUBLE) {
+          isChiralPhosphorusSpecialCase = false;
+        } else {  // double bond
+          const Atom *nbr = mol[nbrIdx];
+          if (nbr->getAtomicNum() != 15) {
+            isChiralPhosphorusSpecialCase = false;
+          } else {
+            unsigned int nbrDeg = nbr->getDegree();
+            isChiralPhosphorusSpecialCase = nbrDeg == 3 || nbrDeg == 4;
+          }
+        };
 
-          // general justification of this is:
-          // Paragraph 2.2. in the 1966 article is "Valence-Bond Conventions:
-          // Multiple-Bond Unsaturation and Aromaticity". It contains several
-          // conventions of which convention (b) is the one applying here:
-          // "(b) Contributions by d orbitals to bonds of quadriligant atoms are
-          // neglected."
-          // FIX: this applies to more than just P
+        // general justification of this is:
+        // Paragraph 2.2. in the 1966 article is "Valence-Bond Conventions:
+        // Multiple-Bond Unsaturation and Aromaticity". It contains several
+        // conventions of which convention (b) is the one applying here:
+        // "(b) Contributions by d orbitals to bonds of quadriligant atoms are
+        // neglected."
+        // FIX: this applies to more than just P
+        if (isChiralPhosphorusSpecialCase) {
+          counts[nbrIdx] += 1;
         } else {
-          count = static_cast<unsigned int>(
-              floor(2. * bond->getBondTypeAsDouble() + .1));
+          counts[nbrIdx] += bond->getTwiceBondType();
         }
-        auto ePos =
-            std::lower_bound(localEntry.begin(), localEntry.end(), rank);
-        localEntry.insert(ePos, count, rank);
-        ++nbr;
-      }
-      // add a zero for each coordinated H:
-      // (as long as we're not a query atom)
-      if (!mol[index]->hasQuery()) {
-        localEntry.insert(localEntry.begin(), mol[index]->getTotalNumHs(), 0);
       }
 
       // we now have a sorted list of our neighbors' ranks,
       // copy it on in reversed order:
-      cipEntries[index].insert(cipEntries[index].end(), localEntry.rbegin(),
-                               localEntry.rend());
-      if (cipEntries[index].size() > longestEntry) {
-        longestEntry = rdcast<unsigned int>(cipEntries[index].size());
+      if (updatedNbrIdxs.size() > 1) {  // compare vs 1 for performance.
+        std::sort(std::begin(updatedNbrIdxs), std::end(updatedNbrIdxs),
+                  [&ranks](unsigned int idx1, unsigned int idx2) {
+                    return ranks[idx1] > ranks[idx2];
+                  });
+      }
+      auto& cipEntry = cipEntries[index];
+      for (auto nbrIdx : updatedNbrIdxs) {
+        unsigned int count = counts[nbrIdx];
+        cipEntry.insert(cipEntry.end(), count, ranks[nbrIdx] + 1);
+        counts[nbrIdx] = 0;
+      }
+      // add a zero for each coordinated H as long as we're not a query atom
+      if (!mol[index]->hasQuery()) {
+        cipEntry.insert(cipEntry.end(), mol[index]->getTotalNumHs(), 0);
+      }
+
+      if (cipEntry.size() > longestEntry) {
+        longestEntry = rdcast<unsigned int>(cipEntry.size());
       }
     }
     // ----------------------------------------------------

--- a/Code/GraphMol/Chirality.cpp
+++ b/Code/GraphMol/Chirality.cpp
@@ -963,14 +963,10 @@ void iterateCIPRanks(const ROMol &mol, const DOUBLE_VECT &invars,
 
         // a special case for chiral phosphorus compounds
         // (this was leading to incorrect assignment of R/S labels ):
-        bool isChiralPhosphorusSpecialCase;
-        if (bond->getBondType() != Bond::DOUBLE) {
-          isChiralPhosphorusSpecialCase = false;
-        } else {  // double bond
+        bool isChiralPhosphorusSpecialCase = false;
+        if (bond->getBondType() == Bond::DOUBLE) {
           const Atom *nbr = mol[nbrIdx];
-          if (nbr->getAtomicNum() != 15) {
-            isChiralPhosphorusSpecialCase = false;
-          } else {
+          if (nbr->getAtomicNum() == 15) {
             unsigned int nbrDeg = nbr->getDegree();
             isChiralPhosphorusSpecialCase = nbrDeg == 3 || nbrDeg == 4;
           }
@@ -986,12 +982,12 @@ void iterateCIPRanks(const ROMol &mol, const DOUBLE_VECT &invars,
         if (isChiralPhosphorusSpecialCase) {
           counts[nbrIdx] += 1;
         } else {
-          counts[nbrIdx] += bond->getTwiceBondType();
+          counts[nbrIdx] += getTwiceBondType(*bond);
         }
       }
 
-      // we now have a sorted list of our neighbors' ranks,
-      // copy it on in reversed order:
+      // For each of our neighbors' ranks weighted by bond type, copy it N times
+      // to our cipEntry in reverse rank order, where N is the weight.
       if (updatedNbrIdxs.size() > 1) {  // compare vs 1 for performance.
         std::sort(std::begin(updatedNbrIdxs), std::end(updatedNbrIdxs),
                   [&ranks](unsigned int idx1, unsigned int idx2) {

--- a/Code/RDGeneral/Ranking.h
+++ b/Code/RDGeneral/Ranking.h
@@ -72,14 +72,13 @@ void rankVect(const std::vector<T1> &vect, T2 &res) {
   std::sort(indices.begin(), indices.end(), argless<std::vector<T1>>(vect));
 
   int currRank = 0;
-  T1 lastV = vect[indices[0]];
+  unsigned int lastIdx = indices[0];
   BOOST_FOREACH (unsigned int idx, indices) {
-    T1 v = vect[idx];
-    if (v == lastV) {
+    if (vect[idx] == vect[lastIdx]) {
       res[idx] = currRank;
     } else {
       res[idx] = ++currRank;
-      lastV = v;
+      lastIdx = idx;
     }
   }
 }

--- a/Code/RDGeneral/Ranking.h
+++ b/Code/RDGeneral/Ranking.h
@@ -73,7 +73,7 @@ void rankVect(const std::vector<T1> &vect, T2 &res) {
 
   int currRank = 0;
   unsigned int lastIdx = indices[0];
-  BOOST_FOREACH (unsigned int idx, indices) {
+  for (auto idx : indices) {
     if (vect[idx] == vect[lastIdx]) {
       res[idx] = currRank;
     } else {


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

The changes in this patch increase throughput of `iterateCIPRanks` by about 62%.  This patch consists of many changes that all combine to contribute to the performance gains, and these are the major changes:

* Introduce `Bond.getTwiceBondType` to avoid floating point operations in `floor(2*bond->getBondTypeAsDouble() + .1)`
* In RDGeneral/Ranking.h/rankVect, just store the last index (instead of the last vector) and avoid creating a copy at the current index.
* In GraphMol/Chirality.cpp/iterateCIPRanks, reserve more capacity ahead of time.
* In GraphMol/Chirality.cpp/iterateCIPRanks, avoid materializing `localEntry` and then copying into `cipEntries`; instead, track the data to be added in a `counts` vector and a `updatedNbrIdxs` vector and directly insert into `cipEntries`.

In `GraphMol/Chirality.cpp/iterateCIPRanks`, we also make several micro-optimizations that were individually measured to give a small performance improvement.

#### Any other comments?

After this change, `iterateCIPRanks` still isn't as fast as we would like, and we are considering a few more changes:
* Introducing https://chromium.googlesource.com/chromium/chromium/+/master/base/stack_container.h to use stack-based vectors (as opposed to your typical heap-based vectors) for faster performance
* Updating iterateCIPRanks to skip re-processing atoms with unique ranks (currently, all atoms are continuously reprocessed even if they already have a unique rank).

Do those proposed follow-on changes sound reasonable?  Do you see alternative ways to improve performance?