### PR TITLE
fix problem with H+ caused by #3473

### DIFF
--- a/Code/GraphMol/Atom.cpp
+++ b/Code/GraphMol/Atom.cpp
@@ -25,7 +25,7 @@ namespace RDKit {
 
 // Determine whether or not a molecule is to the left of Carbon
 bool isEarlyAtom(int atomicNum) {
-  if ( atomicNum <= 1 ) {
+  if (atomicNum <= 1) {
     return false;
   }
   switch (PeriodicTable::getTable()->getNouterElecs(atomicNum)) {
@@ -329,6 +329,21 @@ int Atom::calcImplicitValence(bool strict) {
   if (d_explicitValence == -1) {
     this->calcExplicitValence(strict);
   }
+  // special cases
+  if (d_atomicNum == 0) {
+    d_implicitValence = 0;
+    return 0;
+  }
+  if (d_atomicNum == 1 && d_numRadicalElectrons == 0) {
+    if (d_formalCharge == 1 || d_formalCharge == -1) {
+      d_implicitValence = 0;
+      return 0;
+    } else if (d_formalCharge == 0) {
+      d_implicitValence = 1;
+      return 1;
+    }
+  }
+
   // this is basically the difference between the allowed valence of
   // the atom and the explicit valence already specified - tells how
   // many Hs to add

--- a/Code/GraphMol/Atom.cpp
+++ b/Code/GraphMol/Atom.cpp
@@ -334,13 +334,26 @@ int Atom::calcImplicitValence(bool strict) {
     d_implicitValence = 0;
     return 0;
   }
-  if (d_atomicNum == 1 && d_numRadicalElectrons == 0) {
+  if (d_explicitValence == 0 && d_atomicNum == 1 &&
+      d_numRadicalElectrons == 0) {
     if (d_formalCharge == 1 || d_formalCharge == -1) {
       d_implicitValence = 0;
       return 0;
     } else if (d_formalCharge == 0) {
       d_implicitValence = 1;
       return 1;
+    } else {
+      if (strict) {
+        std::ostringstream errout;
+        errout << "Unreasonable formal charge on hydrogen # " << getIdx()
+               << ".";
+        std::string msg = errout.str();
+        BOOST_LOG(rdErrorLog) << msg << std::endl;
+        throw AtomValenceException(msg, getIdx());
+      } else {
+        d_implicitValence = 0;
+        return 0;
+      }
     }
   }
 

--- a/Code/GraphMol/catch_graphmol.cpp
+++ b/Code/GraphMol/catch_graphmol.cpp
@@ -1384,6 +1384,30 @@ TEST_CASE("Github #3470: Hydrogen is incorrectly identified as an early atom",
     m.getAtomWithIdx(0)->setFormalCharge(-1);
     m.updatePropertyCache();
     CHECK(m.getAtomWithIdx(0)->getNumImplicitHs() == 0);
+    m.getAtomWithIdx(0)->setFormalCharge(1);
+    m.updatePropertyCache();
+    CHECK(m.getAtomWithIdx(0)->getNumImplicitHs() == 0);
+    m.getAtomWithIdx(0)->setFormalCharge(0);
+    m.updatePropertyCache();
+    CHECK(m.getAtomWithIdx(0)->getNumImplicitHs() == 1);
+
+    // make sure we still generate errors for stupid stuff
+    m.getAtomWithIdx(0)->setFormalCharge(-2);
+    CHECK_THROWS_AS(m.updatePropertyCache(), AtomValenceException);
+    CHECK(m.getAtomWithIdx(0)->getNumImplicitHs() == 1);
+  }
+  SECTION("confirm with SMILES") {
+    RWMol m;
+    m.addAtom(new Atom(1));
+    m.getAtomWithIdx(0)->setFormalCharge(-1);
+    m.updatePropertyCache();
+    CHECK(MolToSmiles(m) == "[H-]");
+    m.getAtomWithIdx(0)->setFormalCharge(+1);
+    m.updatePropertyCache();
+    CHECK(MolToSmiles(m) == "[H+]");
+    m.getAtomWithIdx(0)->setFormalCharge(0);
+    m.updatePropertyCache();
+    CHECK(MolToSmiles(m) == "[HH]");  // ugly, but I think [H] would be worse
   }
 }
 


### PR DESCRIPTION
Unintended (and untested for) consequences of changing Hs to be "early" atoms.
The fix here is to explicitly handle the special cases of implicit valence of H atoms:
- `H+`: no implicit Hs
- `H`: one implicit H
- `H-`: no implicit Hs

For the sake of (very minor) efficiency, I also added a special case for atomic number=0 (i.e. dummy atoms).