### PR TITLE
fix paths in ConformerParser tests

### DIFF
--- a/Contrib/ConformerParser/Wrap/testConformerParser.py
+++ b/Contrib/ConformerParser/Wrap/testConformerParser.py
@@ -13,8 +13,7 @@ class TestCase(unittest.TestCase):
     pass
 
   def testReadAmberTraj(self):
-    fileN = os.path.join(RDConfig.RDBaseDir, 'Contrib', 'ConformerParser', 'test_data',
-                         'water_coords.trx')
+    fileN = os.path.join(RDConfig.RDBaseDir, 'Code', 'GraphMol', 'test_data', 'water_coords.trx')
     mol = Chem.MolFromSmiles('O')
     mol = Chem.AddHs(mol)
     ids = rdConformerParser.AddConformersFromAmberTrajectory(mol, fileN)
@@ -22,8 +21,7 @@ class TestCase(unittest.TestCase):
     self.failUnless(len(ids) == 1)
     self.failUnless(ids[0] == 0)
 
-    fileN = os.path.join(RDConfig.RDBaseDir, 'Contrib', 'ConformerParser', 'test_data',
-                         'water_coords2.trx')
+    fileN = os.path.join(RDConfig.RDBaseDir, 'Code', 'GraphMol', 'test_data', 'water_coords2.trx')
     ids = rdConformerParser.AddConformersFromAmberTrajectory(mol, fileN, clearConfs=True)
     self.failUnless(mol.GetNumConformers() == 2)
     ids = rdConformerParser.AddConformersFromAmberTrajectory(mol, fileN, clearConfs=False)

--- a/Contrib/ConformerParser/test.cpp
+++ b/Contrib/ConformerParser/test.cpp
@@ -60,8 +60,7 @@ void test1() {
   ROMol *mol = SmilesToMol("CCC");
   std::vector<std::vector<double>> coords;
   std::string rdbase = getenv("RDBASE");
-  std::string fName =
-      rdbase + "/Contrib/ConformerParser/test_data/water_coords_bad.trx";
+  std::string fName = rdbase + "/Code/GraphMol/test_data/water_coords_bad.trx";
   bool ok = false;
   try {
     readAmberTrajectory(fName, coords, mol->getNumAtoms());
@@ -70,7 +69,7 @@ void test1() {
   }
   TEST_ASSERT(ok);
 
-  fName = rdbase + "/Contrib/ConformerParser/test_data/water_coords_bad2.trx";
+  fName = rdbase + "/Code/GraphMol/test_data/water_coords_bad2.trx";
   ok = false;
   try {
     readAmberTrajectory(fName, coords, mol->getNumAtoms());
@@ -80,7 +79,7 @@ void test1() {
   }
   TEST_ASSERT(ok);
 
-  fName = rdbase + "/Contrib/ConformerParser/test_data/water_coords.trx";
+  fName = rdbase + "/Code/GraphMol/test_data/water_coords.trx";
   readAmberTrajectory(fName, coords, mol->getNumAtoms());
   TEST_ASSERT(coords.size() == 1);
   TEST_ASSERT(coords[0].size() == 9);
@@ -99,7 +98,7 @@ void test1() {
 
   coords.resize(0);
   mol->clearConformers();
-  fName = rdbase + "/Contrib/ConformerParser/test_data/water_coords2.trx";
+  fName = rdbase + "/Code/GraphMol/test_data/water_coords2.trx";
   readAmberTrajectory(fName, coords, mol->getNumAtoms());
   TEST_ASSERT(coords.size() == 2);
   TEST_ASSERT(coords[1].size() == 9);


### PR DESCRIPTION
These two tests are failing because they look for their input files in paths that do not exist.

The tests are currently not exercised in the CI builds, so I didn't notice until I enabled some extra options in my build.