### PR TITLE
Fixes #3505

### DIFF
--- a/rdkit/Chem/EnumerateStereoisomers.py
+++ b/rdkit/Chem/EnumerateStereoisomers.py
@@ -326,7 +326,7 @@ def EnumerateStereoisomers(m, options=StereoEnumerationOptions(), verbose=False)
     Chem.SetDoubleBondNeighborDirections(isomer)
     isomer.ClearComputedProps()
 
-    Chem.AssignStereochemistry(isomer, cleanIt=True, force=True)
+    Chem.AssignStereochemistry(isomer, cleanIt=True, force=True, flagPossibleStereoCenters=True)
     if options.unique:
       cansmi = Chem.MolToSmiles(isomer, isomericSmiles=True)
       if cansmi in isomersSeen:

--- a/rdkit/Chem/UnitTestMol3D.py
+++ b/rdkit/Chem/UnitTestMol3D.py
@@ -422,6 +422,16 @@ class TestCase(unittest.TestCase):
                                     (14, 'S')], [(1, 'S'), (12, 'S'),
                                                  (14, 'R')], [(1, 'S'), (12, 'S'), (14, 'S')]])
 
+  def testIssue3505(self):
+    m = Chem.MolFromSmiles('CCC(C)Br')
+    mols = list(AllChem.EnumerateStereoisomers(m))
+    self.assertEqual(len(mols), 2)
+    for mol in mols:
+      at = mol.GetAtomWithIdx(2)
+      self.assertIn(at.GetChiralTag(),
+                    [Chem.ChiralType.CHI_TETRAHEDRAL_CW, Chem.ChiralType.CHI_TETRAHEDRAL_CCW])
+      self.assertTrue(at.HasProp("_ChiralityPossible"))
+
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
Passing `flagPossibleStereoCenters=True` to `AssignStereochemistry()` in `EnumerateStereoisomers` allows the stereo atoms in the enumerated mols to get the `_ChiralityPossible` property, and be counted by `rdMolDescriptors.CalcNumAtomStereoCenters()`.

I also added a test to check that the property is set on outputs of `EnumerateStereoisomers()`