### PR TITLE
Fix python invalid escape sequences

### DIFF
--- a/Code/GraphMol/Wrap/test_data/do_smiles.bomb.py
+++ b/Code/GraphMol/Wrap/test_data/do_smiles.bomb.py
@@ -1,7 +1,7 @@
 
 
 import re
-splitExpr = re.compile('[\t\ ]')
+splitExpr = re.compile('[\t ]')
 
 from Chem import rdmol
 

--- a/Code/GraphMol/Wrap/test_data/do_smiles.py
+++ b/Code/GraphMol/Wrap/test_data/do_smiles.py
@@ -1,6 +1,6 @@
 
 import re
-splitExpr = re.compile('[\t\ ]')
+splitExpr = re.compile('[\t ]')
 
 from rdkit import Chem
 

--- a/rdkit/Chem/EnumerateStereoisomers.py
+++ b/rdkit/Chem/EnumerateStereoisomers.py
@@ -230,14 +230,14 @@ def EnumerateStereoisomers(m, options=StereoEnumerationOptions(), verbose=False)
     ...
     F[C@@H](Cl)/C=C/C=C/[C@@H](F)Cl
     F[C@@H](Cl)/C=C/C=C/[C@H](F)Cl
-    F[C@@H](Cl)/C=C/C=C\[C@H](F)Cl
-    F[C@@H](Cl)/C=C\C=C/[C@@H](F)Cl
-    F[C@@H](Cl)/C=C\C=C/[C@H](F)Cl
-    F[C@@H](Cl)/C=C\C=C\[C@@H](F)Cl
-    F[C@@H](Cl)/C=C\C=C\[C@H](F)Cl
+    F[C@@H](Cl)/C=C/C=C\\[C@H](F)Cl
+    F[C@@H](Cl)/C=C\\C=C/[C@@H](F)Cl
+    F[C@@H](Cl)/C=C\\C=C/[C@H](F)Cl
+    F[C@@H](Cl)/C=C\\C=C\\[C@@H](F)Cl
+    F[C@@H](Cl)/C=C\\C=C\\[C@H](F)Cl
     F[C@H](Cl)/C=C/C=C/[C@H](F)Cl
-    F[C@H](Cl)/C=C\C=C/[C@H](F)Cl
-    F[C@H](Cl)/C=C\C=C\[C@H](F)Cl
+    F[C@H](Cl)/C=C\\C=C/[C@H](F)Cl
+    F[C@H](Cl)/C=C\\C=C\\[C@H](F)Cl
 
     By default the code only expands unspecified stereocenters:
 

--- a/rdkit/Chem/MolKey/InchiInfo.py
+++ b/rdkit/Chem/MolKey/InchiInfo.py
@@ -62,14 +62,14 @@ reconnected_re = re.compile('(.*?)/r(.*)')  # reconnected layer?
 fixed_h_re = re.compile('(.*?)/f(.*)')  # fixed-H layer?
 isotope_re = re.compile('(.*?)/i(.*)')  # isotope layer?
 
-stereo_re = re.compile('.*\/t(.*?)\/.*')
-stereo_all_re = re.compile('.*\/t([^\/]+)')
-undef_stereo_re = re.compile('(\d+)\?')
-all_stereo_re = re.compile('(\d+)[?+-]')
-defined_stereo_re = re.compile('(\d+)[+-]')
-h_layer_re = re.compile('.*\/h(.*)\/?')
-mobile_h_group_re = re.compile('(\(H.+?\))')
-mobile_h_atoms_re = re.compile(',(\d+)')
+stereo_re = re.compile(r'.*/t(.*?)/.*')
+stereo_all_re = re.compile(r'.*/t([^/]+)')
+undef_stereo_re = re.compile(r'(\d+)\?')
+all_stereo_re = re.compile(r'(\d+)[?+-]')
+defined_stereo_re = re.compile(r'(\d+)[+-]')
+h_layer_re = re.compile(r'.*/h(.*)/?')
+mobile_h_group_re = re.compile(r'(\(H.+?\))')
+mobile_h_atoms_re = re.compile(r',(\d+)')
 
 
 class InchiInfo(object):

--- a/rdkit/Chem/Pharm3D/Pharmacophore.py
+++ b/rdkit/Chem/Pharm3D/Pharmacophore.py
@@ -177,7 +177,7 @@ class ExplicitPharmacophore:
 
   def initFromLines(self, lines):
     import re
-    spaces = re.compile('[\ \t]+')
+    spaces = re.compile('[ \t]+')
 
     feats = []
     rads = []

--- a/rdkit/Chem/fmcs/fmcs.py
+++ b/rdkit/Chem/fmcs/fmcs.py
@@ -238,7 +238,7 @@ import sys
 
 try:
   from rdkit import Chem
-  
+
 except ImportError:
   sys.stderr.write("Please install RDKit from http://www.rdkit.org/\n")
   raise
@@ -2450,7 +2450,7 @@ class starting_from(object):
 
 
 range_pat = re.compile(r"(\d+)-(\d*)")
-value_pat = re.compile("(\d+)")
+value_pat = re.compile(r"(\d+)")
 
 
 def parse_select(s):

--- a/rdkit/ML/Data/DataUtils.py
+++ b/rdkit/ML/Data/DataUtils.py
@@ -153,7 +153,7 @@ def ReadQuantExamples(inFile):
 
     """
     expr1 = re.compile(r'^#')
-    expr2 = re.compile(r'[\ ]+|[\t]+')
+    expr2 = re.compile(r'[ ]+|[\t]+')
     examples = []
     names = []
     inLine = inFile.readline()
@@ -189,7 +189,7 @@ def ReadGeneralExamples(inFile):
 
     """
     expr1 = re.compile(r'^#')
-    expr2 = re.compile(r'[\ ]+|[\t]+')
+    expr2 = re.compile(r'[ ]+|[\t]+')
     examples = []
     names = []
     inLine = inFile.readline()

--- a/rdkit/ML/Descriptors/MoleculeDescriptors.py
+++ b/rdkit/ML/Descriptors/MoleculeDescriptors.py
@@ -106,7 +106,7 @@ class MolecularDescriptorCalculator(Descriptors.DescriptorCalculator):
       fn = getattr(DescriptorsMod, nm, lambda x: 777)
       if hasattr(fn, '__doc__') and fn.__doc__:
         doc = fn.__doc__.split('\n\n')[0].strip()
-        doc = re.sub('\ *\n\ *', ' ', doc)
+        doc = re.sub(' *\n *', ' ', doc)
       else:
         doc = 'N/A'
       res.append(doc)

--- a/rdkit/ML/Scoring/Scoring.py
+++ b/rdkit/ML/Scoring/Scoring.py
@@ -1,4 +1,4 @@
-"""
+r"""
 $Id$
 
 Scoring - Calculate rank statistics

--- a/rdkit/sping/PDF/pdfgen.py
+++ b/rdkit/sping/PDF/pdfgen.py
@@ -171,8 +171,8 @@ class Canvas:
     """PDF escapes are like Python ones, but brackets need slashes before them too.
         Use Python's repr function and chop off the quotes first"""
     s = repr(s)[1:-1]
-    s = s.replace('(', '\(')
-    s = s.replace(')', '\)')
+    s = s.replace('(', r'\(')
+    s = s.replace(')', r'\)')
     return s
 
   #info functions - non-standard

--- a/rdkit/sping/PDF/pdfutils.py
+++ b/rdkit/sping/PDF/pdfutils.py
@@ -51,7 +51,7 @@ def cacheImageFile(filename):
 
 
 def preProcessImages(spec):
-    """accepts either a filespec ('C:\mydir\*.jpg') or a list
+    r"""accepts either a filespec ('C:\mydir\*.jpg') or a list
       of image filenames, crunches them all to save time.  Run this
       to save huge amounts of time when repeatedly building image
       documents."""
@@ -94,8 +94,8 @@ def _escape(s):
       need slashes before them too. Use Python's repr function
       and chop off the quotes first"""
     s = repr(s)[1:-1]
-    s = s.replace('(', '\(')
-    s = s.replace(')', '\)')
+    s = s.replace('(', r'\(')
+    s = s.replace(')', r'\)')
     return s
 
 

--- a/rdkit/sping/PDF/pidPDF.py
+++ b/rdkit/sping/PDF/pidPDF.py
@@ -84,7 +84,7 @@ ps_font_map = {
 
 
 class PDFCanvas(Canvas):
-    """This works by accumulating a list of strings containing 
+    """This works by accumulating a list of strings containing
       PDF page marking operators, as you call its methods.  We could
       use a big string but this is more efficient - only concatenate
       it once, with control over line ends.  When
@@ -230,8 +230,8 @@ class PDFCanvas(Canvas):
         """PDF escapes are like Python ones, but brackets need slashes before them too.
             Use Python's repr function and chop off the quotes first"""
         s = repr(s)[1:-1]
-        s = s.replace('(', '\(')
-        s = s.replace(')', '\)')
+        s = s.replace('(', r'\(')
+        s = s.replace(')', r'\)')
         return s
 
     def resetDefaults(self):

--- a/rdkit/sping/PS/pidPS.py
+++ b/rdkit/sping/PS/pidPS.py
@@ -564,8 +564,8 @@ translate
     # Have not handled characters that are converted normally in python strings
     # i.e. \n -> newline
     str = s.replace(chr(0x5C), r'\\')
-    str = str.replace('(', '\(')
-    str = str.replace(')', '\)')
+    str = str.replace('(', r'\(')
+    str = str.replace(')', r'\)')
     return str
 
   # ??? check to see if \n response is handled correctly (should move cursor down)

--- a/rdkit/sping/stringformat.py
+++ b/rdkit/sping/stringformat.py
@@ -7,33 +7,33 @@ within the string. Therefore, the interface for the StringFormat module
 consists of wrapper functions for the SPING string interface and
 various XML tags and characters.
 
-StringFormat functions 
+StringFormat functions
 
-       drawString(canvas, s, x, y, [font], [color], [angle]) 
-       stringWidth(canvas, s, [font]) 
-       fontHeight(canvas, [font]) 
-       fontAscent(canvas, [font]) 
-       fontDescent(canvas, [font]) 
-StringFormat XML tags 
+       drawString(canvas, s, x, y, [font], [color], [angle])
+       stringWidth(canvas, s, [font])
+       fontHeight(canvas, [font])
+       fontAscent(canvas, [font])
+       fontDescent(canvas, [font])
+StringFormat XML tags
 
-       <b> </b> - bold 
-       <i> </i> - italics 
-       <u> </u> - underline 
-       <super> </super> - superscript 
-       <sub> </sub> - subscript 
+       <b> </b> - bold
+       <i> </i> - italics
+       <u> </u> - underline
+       <super> </super> - superscript
+       <sub> </sub> - subscript
 
-StringFormat XML characters 
+StringFormat XML characters
 
-       Greek Letter Symbols as specified in MathML 
+       Greek Letter Symbols as specified in MathML
 """
 
 
-#       How it works: Each tag grouping <b></b> sets a flag upon entry and 
-#       clears the flag upon exit.  Each call to handle_data creates a 
+#       How it works: Each tag grouping <b></b> sets a flag upon entry and
+#       clears the flag upon exit.  Each call to handle_data creates a
 #       StringSegment which takes on all of the characteristics specified
 #       by flags currently set.  The greek letters can be specified as either
 #       &alpha; or <alpha/>.  The are essentially transformed into <alpha/>
-#       no matter what and then there is a handler for each greek letter.  
+#       no matter what and then there is a handler for each greek letter.
 #       To add or change greek letter to symbol font mappings only
 #       the greekchars map needs to change.
 
@@ -97,7 +97,7 @@ greekchars = {
 #------------------------------------------------------------------------
 class StringSegment:
   """class StringSegment contains the intermediate representation of string
-        segments as they are being parsed by the XMLParser. 
+        segments as they are being parsed by the XMLParser.
         """
 
   def __init__(self):
@@ -149,18 +149,18 @@ class StringSegment:
     print("\tgreek = ", self.greek)
 
 
-#------------------------------------------------------------------     
+#------------------------------------------------------------------
 # The StringFormatter will be able to format the following xml
 # tags:
-#      < b > < /b > - bold 
-#      < i > < /i > - italics 
-#      < u > < /u > - underline 
-#      < super > < /super > - superscript 
-#      < sub > < /sub > - subscript 
+#      < b > < /b > - bold
+#      < i > < /i > - italics
+#      < u > < /u > - underline
+#      < super > < /super > - superscript
+#      < sub > < /sub > - subscript
 #
 # It will also be able to handle any MathML specified Greek characters.
 #
-# Possible future additions: changing color and font 
+# Possible future additions: changing color and font
 #       character-by-character
 #------------------------------------------------------------------
 class StringFormatter(xmllib.XMLParser):
@@ -171,7 +171,7 @@ class StringFormatter(xmllib.XMLParser):
   # start_<tag>(attributes)
   # end_<tag>()
   #
-  # While parsing the xml StringFormatter will call these 
+  # While parsing the xml StringFormatter will call these
   # functions to handle the string formatting tags.
   # At the start of each tag the corresponding field will
   # be set to 1 and at the end tag the corresponding field will
@@ -294,7 +294,7 @@ class StringFormatter(xmllib.XMLParser):
                 StringSegment objects with their calculated widths."
 
     # the xmlparser requires that all text be surrounded by xml
-    # tags, therefore we must throw some unused flags around the 
+    # tags, therefore we must throw some unused flags around the
     # given string
     self.feed("<formattedstring>" + s + "</formattedstring>")
     self.close()  # force parsing to complete
@@ -373,8 +373,8 @@ def drawString(canvas, s, x, y, font=None, color=None, angle=0):
   startpos = x
   for seg in segmentlist:
     # calculate x and y for this segment based on the angle
-    # if the string wasn't at an angle then 
-    # (draw_x,draw_y) = (startpos, seg.calcNewY(font, y)) want to 
+    # if the string wasn't at an angle then
+    # (draw_x,draw_y) = (startpos, seg.calcNewY(font, y)) want to
     # rotate around original x and y
     (delta_x, delta_y) = rotateXY(startpos - x, seg.calcNewY(font, y) - y, angle)
 
@@ -418,13 +418,13 @@ def test2():
   #       drawString(canvas, "a", 10, 50, Font(face="symbol"))
   #       drawString(canvas, "hello there!", 30, 90, angle= -90)
   #       drawString(canvas, "<b>goodbye!</b> <u>yall</u>", 100, 90, angle= 45)
-  #       drawString(canvas, "there is a <u>time</u> and a <b>place</b><super>2</super>", 
+  #       drawString(canvas, "there is a <u>time</u> and a <b>place</b><super>2</super>",
   #               100, 90, angle= -75)
   canvas.flush()
 
 
 def allTagCombos(canvas, x, y, font=None, color=None, angle=0):
-  """Try out all tags and various combinations of them. \ 
+  """Try out all tags and various combinations of them.
         Starts at given x,y and returns possible next (x,y)."""
 
   oldDefault = canvas.defaultFont
@@ -470,10 +470,10 @@ def stringformatTest():
   canvas = PDFCanvas('bigtest1.pdf')
 
   ################################################### testing drawString tags
-  #      < b > < /b > - bold 
-  #      < i > < /i > - italics 
-  #      < u > < /u > - underline 
-  #      < super > < /super > - superscript 
+  #      < b > < /b > - bold
+  #      < i > < /i > - italics
+  #      < u > < /u > - underline
+  #      < super > < /super > - superscript
   #      < sub > < /sub > - subscript
 
   x = 10


### PR DESCRIPTION
Sometimes, when working with python some Deprecation Warnings about invalid escape sequences show up:

```
rdkit\Chem\EnumerateStereoisomers.py:165: DeprecationWarning: invalid escape sequence \[
    """ returns a generator that yields possible stereoisomers for a molecule
```
```
rdkit\ML\Descriptors\MoleculeDescriptors.py:109: DeprecationWarning: invalid escape sequence \ 
    doc = re.sub('\ *\n\ *', ' ', doc)
```

Those aren't a problem (though someone mentioned that in a future python release these warnings might turn into errors), although they are sometimes an annoyance.

I thought I might get them fixed so that the warnings stop showing up. Also, along the way, I noticed my editor trimmed whitespace at the end of the lines of the files I edited.