### PR TITLE
Fix AUTOCORR2D descriptors

### DIFF
--- a/rdkit/Chem/ChemUtils/DescriptorUtilities.py
+++ b/rdkit/Chem/ChemUtils/DescriptorUtilities.py
@@ -22,10 +22,10 @@ def setDescriptorVersion(version='1.0.0'):
     return func
   return wrapper
 
-class VectorDescriptorNamespace:
+class VectorDescriptorNamespace(dict):
     def __init__(self, **kwargs):
-        self.__dict__.update(kwargs)
-        
+        self.update(kwargs)
+
 class VectorDescriptorWrapper:
     """Wrap a function that returns a vector and make it seem like there
     is one function for each entry.  These functions are added to the global
@@ -42,18 +42,19 @@ class VectorDescriptorWrapper:
             f.__qualname__ = n
             f.version = version
             function_namespace[n] = f
-        self.namespace = VectorDescriptorNamespace(**function_namespace)            
+        self.namespace = VectorDescriptorNamespace(**function_namespace)
+        self.namespace.update(namespace)
         namespace.update(function_namespace)
 
     def _get_key(self, index):
         return "%s%s"%(self.func_key, index)
-    
+
     def call_desc(self, mol, index):
         if hasattr(mol, self.func_key):
           results = getattr(mol, self.func_key, None)
           if results is not None:
             return results[index]
-        
+
         try:
           results = self.func(mol)
         except:

--- a/rdkit/Chem/Descriptors.py
+++ b/rdkit/Chem/Descriptors.py
@@ -31,7 +31,7 @@ def _setupDescriptors(namespace):
     from rdkit.Chem import GraphDescriptors, MolSurf, Lipinski, Fragments, Crippen, Descriptors3D
     from rdkit.Chem.EState import EState_VSA
     _descList.clear()
-    
+
     mods = [GraphDescriptors, MolSurf, EState_VSA, Lipinski, Crippen, Fragments]
 
     otherMods = [Chem]
@@ -224,13 +224,13 @@ _du.VectorDescriptorWrapper(_rdMolDescriptors.BCUT2D, names=names, version="1.0.
 _setupDescriptors(locals())
 
 names = ["AUTOCORR2D_%s"%str(i+1) for i in range(192)]
-autocorr = _du.VectorDescriptorWrapper(_rdMolDescriptors.CalcAUTOCORR2D, names=names, version="1.0.0", 
+autocorr = _du.VectorDescriptorWrapper(_rdMolDescriptors.CalcAUTOCORR2D, names=names, version="1.0.0",
                                        namespace=locals())
 
 def setupAUTOCorrDescriptors():
     """Adds AUTOCORR descriptors to the default descriptor lists"""
-    setupDescriptors(namespace=autocorr.namespace)
-    
+    _setupDescriptors(namespace=autocorr.namespace)
+
 class PropertyFunctor(rdMolDescriptors.PythonPropertyFunctor):
     """Creates a python based property function that can be added to the
     global property list.  To use, subclass this class and override the

--- a/rdkit/Chem/UnitTestDescriptors.py
+++ b/rdkit/Chem/UnitTestDescriptors.py
@@ -165,8 +165,10 @@ class TestCase(unittest.TestCase):
   def testVectorDescriptorsInDescList(self):
     # First try only bcuts should exist
     descriptors = set([n for n,_ in Descriptors.descList])
-    names = set(["BCUT2D_%s"%i for i in ('MWHI',"MWLOW","CHGHI","CHGLO",
-                                 "LOGPHI","LOGPLOW","MRHI","MRLOW")])
+    names = set([
+      "BCUT2D_%s" % i
+      for i in ('MWHI', "MWLOW", "CHGHI", "CHGLO", "LOGPHI", "LOGPLOW", "MRHI", "MRLOW")
+    ])
     self.assertEqual(descriptors.intersection(names), names)
 
     Descriptors.setupAUTOCorrDescriptors()

--- a/rdkit/Chem/UnitTestDescriptors.py
+++ b/rdkit/Chem/UnitTestDescriptors.py
@@ -162,18 +162,19 @@ class TestCase(unittest.TestCase):
       f = getattr(Descriptors, n)
       self.assertEqual(results[i], f(m))
 
-    def testVectorDescriptorsInDescList(self):
-      # First try only bcuts should exist
-      descriptors = set([n for n,_ in Descriptors.descList])
-      names = set(["BCUT2D_%s"%str(i+1) for i in range(8)])
-      self.assertEqual(descriptors.intersection(names), names)
-      
-      Descriptors.setupAUTOCORRDescriptors()
-      descriptors2 = set([n for n,_ in Descriptors.descList])
-      self.assertEqual(descriptors2.intersection(descriptors), descriptors)
+  def testVectorDescriptorsInDescList(self):
+    # First try only bcuts should exist
+    descriptors = set([n for n,_ in Descriptors.descList])
+    names = set(["BCUT2D_%s"%i for i in ('MWHI',"MWLOW","CHGHI","CHGLO",
+                                 "LOGPHI","LOGPLOW","MRHI","MRLOW")])
+    self.assertEqual(descriptors.intersection(names), names)
 
-      names = ["AUTOCORR2D_%s"%str(i+1) for i in range(192)]
-      self.assertEqual(descriptors.intersection(names), names)
+    Descriptors.setupAUTOCorrDescriptors()
+    descriptors2 = set([n for n,_ in Descriptors.descList])
+    self.assertEqual(descriptors2.intersection(descriptors), descriptors)
+
+    names = set(["AUTOCORR2D_%s"%str(i+1) for i in range(192)])
+    self.assertEqual(descriptors2.intersection(names), names)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Yesterday, looking at #3511, I became curious about the AUTOCORR2D descriptors: I noticed that while BCUT2D ones left over a cache (with a non-Python type), there wasn't one for the AUTOCORR2D descriptors.

Looking a bit further, I noticed these had to be explicitly set up... using a function that was missing an underscore (`setupDescriptors()`). From there, it was an interesting trip to find that the setup mechanism wasn't working... and neither was the test that was supposed to catch it, since it was over indented so that it was an inner function of the previous test, and therefore, never ran.

This is my attempt to fix it