### PR TITLE
Fixes #3511

### DIFF
--- a/Code/GraphMol/Descriptors/Wrap/rdMolDescriptors.cpp
+++ b/Code/GraphMol/Descriptors/Wrap/rdMolDescriptors.cpp
@@ -415,6 +415,10 @@ RDKit::SparseIntVect<std::uint32_t> *MorganFingerprintHelper(
 }
 
 #ifdef RDK_HAS_EIGEN3
+python::list BCUT(const RDKit::ROMol &mol) {
+  return python::list(RDKit::Descriptors::BCUT2D(mol));
+}
+
 std::pair<double, double> BCUT2D_list(const RDKit::ROMol &m,
                                       python::list atomprops) {
   std::vector<double> dvec;
@@ -1706,8 +1710,6 @@ BOOST_PYTHON_MODULE(rdMolDescriptors) {
 
 #ifdef RDK_HAS_EIGEN3
   python::scope().attr("_BCUT2D_version") = RDKit::Descriptors::BCUT2DVersion;
-  std::vector<double> (*BCUT)(const RDKit::ROMol &) =
-      &RDKit::Descriptors::BCUT2D;
   std::pair<double, double> (*BCUT_atomprops)(
       const RDKit::ROMol &, const std::string &) = &RDKit::Descriptors::BCUT2D;
   docString =

--- a/rdkit/ML/Descriptors/UnitTestMolDescriptors.py
+++ b/rdkit/ML/Descriptors/UnitTestMolDescriptors.py
@@ -5,16 +5,15 @@
 
 """
 import os.path
+import pickle
 import unittest
+from io import BytesIO, StringIO
 
 import numpy
 
-from rdkit import Chem
-from rdkit import RDConfig
-from rdkit.ML.Descriptors import MoleculeDescriptors, Descriptors
+from rdkit import Chem, RDConfig
+from rdkit.ML.Descriptors import Descriptors, MoleculeDescriptors
 from rdkit.TestRunner import redirect_stdout
-from io import BytesIO, StringIO
-import pickle
 
 
 class TestCase(unittest.TestCase):
@@ -85,6 +84,17 @@ class TestDescriptors(unittest.TestCase):
             self.assertIn(name, s)
         for name in calc.compoundList:
             self.assertIn(name, s)
+
+    def test_github3511(self):
+        mol = Chem.MolFromSmiles('C')
+        descriptors = [name for name, _ in Chem.Descriptors.descList]
+        calculator = MoleculeDescriptors.MolecularDescriptorCalculator(descriptors)
+        calculator.CalcDescriptors(mol)
+
+        # This should not raise a pickling exception
+        pickle.dumps(mol)
+
+
 
 
 if __name__ == '__main__':  # pragma: nocover


### PR DESCRIPTION
This resolves #3511.

A quick wrapping of the return type of the BCUT2D descriptors into a Python list.
I'd prefer a tuple, but AUTOCORR2D is also returning a list, so I guess it makes sense to follow the same pattern.