### PR TITLE
legend_height_ should be preserved after drawing the molecule

### DIFF
--- a/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
@@ -264,11 +264,12 @@ void MolDraw2D::drawMolecule(const ROMol &mol, const std::string &legend,
     if (legend_height_ < 20) {
       legend_height_ = 20;
     }
+  } else {
+    legend_height_ = 0;
   }
   drawMolecule(mol, highlight_atoms, highlight_bonds, highlight_atom_map,
                highlight_bond_map, highlight_radii, confId);
   drawLegend(legend);
-  legend_height_ = 0;
 }
 
 // ****************************************************************************
@@ -286,6 +287,8 @@ void MolDraw2D::drawMoleculeWithHighlights(
 
   if (!legend.empty()) {
     legend_height_ = int(0.05 * double(panelHeight()));
+  } else {
+    legend_height_ = 0;
   }
   pushDrawDetails();
   unique_ptr<RWMol> rwmol =
@@ -356,7 +359,6 @@ void MolDraw2D::drawMoleculeWithHighlights(
   setLineWidth(origWidth);
 
   drawLegend(legend);
-  legend_height_ = 0;
   popDrawDetails();
 }
 

--- a/Code/GraphMol/MolDraw2D/catch_tests.cpp
+++ b/Code/GraphMol/MolDraw2D/catch_tests.cpp
@@ -818,3 +818,32 @@ TEST_CASE("includeRadicals", "[options]") {
     }
   }
 }
+
+TEST_CASE("including legend in drawing results in offset drawing later",
+          "[bug]") {
+  SECTION("basics") {
+    auto m = "c1ccccc1"_smiles;
+    REQUIRE(m);
+    MolDraw2DUtils::prepareMolForDrawing(*m);
+    auto &conf = m->getConformer();
+    std::vector<Point2D> polyg;
+    for (const auto &pt : conf.getPositions()) {
+      polyg.emplace_back(pt);
+    }
+    MolDraw2DSVG drawer(350, 300);
+    drawer.drawMolecule(*m, "molecule legend");
+    drawer.setFillPolys(true);
+    drawer.setColour(DrawColour(1.0, 0.3, 1.0));
+    drawer.drawPolygon(polyg);
+    drawer.finishDrawing();
+    auto text = drawer.getDrawingText();
+    std::ofstream outs("testLegendsAndDrawing-1.svg");
+    outs << text;
+    outs.flush();
+
+    // make sure the polygon starts at a bond
+    CHECK(text.find("<path class='bond-0' d='M 321.962,140") !=
+          std::string::npos);
+    CHECK(text.find("<path d='M 321.962,140") != std::string::npos);
+  }
+}


### PR DESCRIPTION
Since `legend_height_` is being zeroed out at the end of `drawMolecules()` subsequent calls to drawing commands end up producing incorrect results (vertically offset by `legend_size_`).
Here's an example:
![image](https://user-images.githubusercontent.com/540511/96952650-a69d5480-14ef-11eb-99e2-a0e28b057596.png)
The hexagons there are drawn using atom coordinates.