### PR TITLE
Removes function which is an exact duplicate of another function

### DIFF
--- a/Code/GraphMol/Wrap/MolSupplier.h
+++ b/Code/GraphMol/Wrap/MolSupplier.h
@@ -67,24 +67,6 @@ ROMol *MolSupplNext(T *suppl) {
 }  // namespace RDKit
 
 template <typename T>
-ROMol *MolSupplNextAcceptNullLastMolecule(T *suppl) {
-  ROMol *res = nullptr;
-  if (!suppl->atEnd()) {
-    try {
-      res = suppl->next();
-    } catch (const FileParseException&) {
-      throw;
-    } catch (...) {
-      res = nullptr;
-    }
-  } else {
-    PyErr_SetString(PyExc_StopIteration, "End of supplier hit");
-    throw boost::python::error_already_set();
-  }
-  return res;
-}
-
-template <typename T>
 ROMol *MolSupplGetItem(T *suppl, int idx) {
   ROMol *res = nullptr;
   if (idx < 0) {

--- a/Code/GraphMol/Wrap/ResonanceMolSupplier.cpp
+++ b/Code/GraphMol/Wrap/ResonanceMolSupplier.cpp
@@ -212,7 +212,7 @@ struct resmolsup_wrap {
             python::return_internal_reference<1>())
         .def("__next__",
              (ROMol * (*)(ResonanceMolSupplier *)) &
-                 MolSupplNextAcceptNullLastMolecule,
+                 MolSupplNext,
              "Returns the next resonance structure in the supplier. Raises "
              "_StopIteration_ on end.\n",
              python::return_value_policy<python::manage_new_object>())

--- a/Code/GraphMol/Wrap/SDMolSupplier.cpp
+++ b/Code/GraphMol/Wrap/SDMolSupplier.cpp
@@ -83,7 +83,7 @@ struct sdmolsup_wrap {
              python::return_internal_reference<1>())
         .def(
             "__next__",
-            (ROMol * (*)(SDMolSupplier *)) & MolSupplNextAcceptNullLastMolecule,
+            (ROMol * (*)(SDMolSupplier *)) & MolSupplNext,
             "Returns the next molecule in the file.  Raises _StopIteration_ "
             "on EOF.\n",
             python::return_value_policy<python::manage_new_object>())


### PR DESCRIPTION
While working on #3523 I noticed that `MolSupplNextAcceptNullLastMolecule` is an exact duplicate of `MolSupplNext`. I guess probably originally it wasn't, but now it is, so it does not make sense to keep both.