### PR TITLE
Fixes #3492

### DIFF
--- a/Code/GraphMol/Wrap/Conformer.cpp
+++ b/Code/GraphMol/Wrap/Conformer.cpp
@@ -30,27 +30,27 @@ RDGeom::Point3D GetAtomPos(const Conformer *conf, unsigned int aid) {
   return res;
 }
 
-PyObject* GetPos(const Conformer *conf) {
-    const RDGeom::POINT3D_VECT &pos = conf->getPositions();
+PyObject *GetPos(const Conformer *conf) {
+  const RDGeom::POINT3D_VECT &pos = conf->getPositions();
 
-    // define a 2D array with the following size
-    npy_intp dims[2];
-    dims[0] = pos.size();
-    dims[1] = 3;
+  // define a 2D array with the following size
+  npy_intp dims[2];
+  dims[0] = pos.size();
+  dims[1] = 3;
 
-    // initialize the array
-    auto *res = (PyArrayObject *)PyArray_SimpleNew(2, dims, NPY_DOUBLE);
+  // initialize the array
+  auto *res = (PyArrayObject *)PyArray_SimpleNew(2, dims, NPY_DOUBLE);
 
-    // represent the array as a 1D/flat array of doubles
-    auto *resData = reinterpret_cast<double *>(PyArray_DATA(res));
+  // represent the array as a 1D/flat array of doubles
+  auto *resData = reinterpret_cast<double *>(PyArray_DATA(res));
 
-    // manually insert the data, 3 corresponds to the x, y and z dimensions
-    for (unsigned int i = 0; i < pos.size(); ++i) {
-        resData[3*i+0] = pos[i].x;
-        resData[3*i+1] = pos[i].y;
-        resData[3*i+2] = pos[i].z;
-    }
-    return PyArray_Return(res);
+  // manually insert the data, 3 corresponds to the x, y and z dimensions
+  for (unsigned int i = 0; i < pos.size(); ++i) {
+    resData[3 * i + 0] = pos[i].x;
+    resData[3 * i + 1] = pos[i].y;
+    resData[3 * i + 2] = pos[i].z;
+  }
+  return PyArray_Return(res);
 }
 
 void SetAtomPos(Conformer *conf, unsigned int aid, python::object loc) {

--- a/Code/GraphMol/Wrap/rdchem.cpp
+++ b/Code/GraphMol/Wrap/rdchem.cpp
@@ -159,11 +159,22 @@ PyObject *createExceptionClass(const char *name,
   return typeObj;
 }
 
+template <typename O, typename T>
+T *get_item_ptr(O &self, int i) {
+  return self.get_item(i).get();
+}
+
+template <typename O, typename T>
+T *next_ptr(O &self) {
+  return self.next().get();
+}
+
 BOOST_PYTHON_MODULE(rdchem) {
   python::scope().attr("__doc__") =
       "Module containing the core chemistry functionality of the RDKit";
   RegisterListConverter<RDKit::Atom *>();
   RegisterListConverter<RDKit::Bond *>();
+  RegisterListConverter<RDKit::CONFORMER_SPTR>();
   rdkit_import_array();
 
   // this is one of those parts where I think I wish that I knew how to do
@@ -241,37 +252,62 @@ BOOST_PYTHON_MODULE(rdchem) {
   //*********************************************
   python::class_<AtomIterSeq>(
       "_ROAtomSeq",
-      "Read-only sequence of atoms, not constructable from Python.",
+      "Read-only sequence of atoms, not constructible from Python.",
       python::no_init)
       .def("__iter__", &AtomIterSeq::__iter__,
            python::return_internal_reference<
                1, python::with_custodian_and_ward_postcall<0, 1>>())
       .def("__next__", &AtomIterSeq::next,
-           python::return_value_policy<python::reference_existing_object>())
+           python::return_internal_reference<
+               1, python::with_custodian_and_ward_postcall<0, 1>>())
 
       .def("__len__", &AtomIterSeq::len)
       .def("__getitem__", &AtomIterSeq::get_item,
-           python::return_value_policy<python::reference_existing_object>());
+           python::return_internal_reference<
+               1, python::with_custodian_and_ward_postcall<0, 1>>());
   python::class_<QueryAtomIterSeq>("_ROQAtomSeq",
                                    "Read-only sequence of atoms matching a "
-                                   "query, not constructable from Python.",
+                                   "query, not constructible from Python.",
                                    python::no_init)
       .def("__iter__", &QueryAtomIterSeq::__iter__,
            python::return_internal_reference<
                1, python::with_custodian_and_ward_postcall<0, 1>>())
       .def("__next__", &QueryAtomIterSeq::next,
-           python::return_value_policy<python::reference_existing_object>())
+           python::return_internal_reference<
+               1, python::with_custodian_and_ward_postcall<0, 1>>())
       .def("__len__", &QueryAtomIterSeq::len)
       .def("__getitem__", &QueryAtomIterSeq::get_item,
-           python::return_value_policy<python::reference_existing_object>());
+           python::return_internal_reference<
+               1, python::with_custodian_and_ward_postcall<0, 1>>());
   python::class_<BondIterSeq>(
       "_ROBondSeq",
-      "Read-only sequence of bonds, not constructable from Python.",
+      "Read-only sequence of bonds, not constructible from Python.",
       python::no_init)
-      // FIX: we ought to be able to expose an iteration interface
+      .def("__iter__", &BondIterSeq::__iter__,
+           python::return_internal_reference<
+               1, python::with_custodian_and_ward_postcall<0, 1>>())
+      .def("__next__", &BondIterSeq::next,
+           python::return_internal_reference<
+               1, python::with_custodian_and_ward_postcall<0, 1>>())
       .def("__len__", &BondIterSeq::len)
       .def("__getitem__", &BondIterSeq::get_item,
-           python::return_value_policy<python::reference_existing_object>());
+           python::return_internal_reference<
+               1, python::with_custodian_and_ward_postcall<0, 1>>());
+  python::class_<ConformerIterSeq>(
+      "_ROConformerSeq",
+      "Read-only sequence of conformers, not constructible from Python.",
+      python::no_init)
+      .def("__iter__", &ConformerIterSeq::__iter__,
+           python::return_internal_reference<
+               1, python::with_custodian_and_ward_postcall<0, 1>>())
+      .def("__next__", next_ptr<ConformerIterSeq, Conformer>,
+           python::return_internal_reference<
+               1, python::with_custodian_and_ward_postcall<0, 1>>())
+
+      .def("__len__", &ConformerIterSeq::len)
+      .def("__getitem__", get_item_ptr<ConformerIterSeq, Conformer>,
+           python::return_internal_reference<
+               1, python::with_custodian_and_ward_postcall<0, 1>>());
 
   //*********************************************
   //

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -6199,7 +6199,26 @@ M  END
     m = Chem.MolFromSmiles("c1ccccc1C(=O)Cl")
     self.assertFalse(m.HasSubstructMatch(sma, recursionPossible=False))
 
-    
+  def test_github3492(self):
+    def read_smile(s):
+        m = Chem.MolFromSmiles(s)
+        rdkit.Chem.rdDepictor.Compute2DCoords(m)
+        return m
+
+    def sq_dist(a, b):
+      ab = [a[i] - b[i] for i, _ in enumerate(a)]
+      return sum([d * d for d in ab])
+
+    self.assertIsNotNone(Chem.MolFromSmiles("OCCN").GetAtoms()[0].GetOwningMol())
+    self.assertEqual([Chem.MolFromSmiles("OCCN").GetAtoms()[i].GetAtomicNum() for i in range(4)], [8, 6, 6, 7])
+    self.assertIsNotNone(Chem.MolFromSmiles("O=CCC=N").GetBonds()[0].GetOwningMol())
+    self.assertEqual([Chem.MolFromSmiles("O=CCC=N").GetBonds()[i].GetBondType() for i in range(4)],
+                     [Chem.BondType.DOUBLE, Chem.BondType.SINGLE, Chem.BondType.SINGLE, Chem.BondType.DOUBLE])
+    self.assertIsNotNone(read_smile("CCC").GetConformers()[0].GetOwningMol())
+    pos = read_smile("CCC").GetConformers()[0].GetPositions()
+    self.assertAlmostEqual(sq_dist(pos[0], pos[1]), sq_dist(pos[1], pos[2]))
+
+
 if __name__ == '__main__':
   if "RDTESTCASE" in os.environ:
     suite = unittest.TestSuite()

--- a/Code/GraphMol/Wrap/seqs.hpp
+++ b/Code/GraphMol/Wrap/seqs.hpp
@@ -47,7 +47,7 @@ class ReadOnlySeq {
   int _size;
   T3 _lenFunc;
   size_t _origLen;
-  ROMOL_SPTR _mol;
+  const ROMOL_SPTR _mol;
 
  public:
   ~ReadOnlySeq() {}

--- a/Code/GraphMol/Wrap/seqs.hpp
+++ b/Code/GraphMol/Wrap/seqs.hpp
@@ -15,19 +15,27 @@ namespace RDKit {
 
 class AtomCountFunctor {
  private:
-  const ROMol &_mol;
+  const ROMOL_SPTR _mol;
 
  public:
-  AtomCountFunctor(const ROMol &mol) : _mol(mol){};
-  unsigned int operator()() const { return _mol.getNumAtoms(); };
+  AtomCountFunctor(const ROMOL_SPTR &mol) : _mol(mol){};
+  unsigned int operator()() const { return _mol->getNumAtoms(); };
 };
 class BondCountFunctor {
  private:
-  const ROMol &_mol;
+  const ROMOL_SPTR _mol;
 
  public:
-  BondCountFunctor(const ROMol &mol) : _mol(mol){};
-  unsigned int operator()() const { return _mol.getNumBonds(); };
+  BondCountFunctor(const ROMOL_SPTR &mol) : _mol(mol){};
+  unsigned int operator()() const { return _mol->getNumBonds(); };
+};
+class ConformerCountFunctor {
+ private:
+  const ROMOL_SPTR _mol;
+
+ public:
+  ConformerCountFunctor(const ROMOL_SPTR &mol) : _mol(mol){};
+  unsigned int operator()() const { return _mol->getNumConformers(); };
 };
 
 // Note: T1 should be some iterator type,
@@ -39,23 +47,26 @@ class ReadOnlySeq {
   int _size;
   T3 _lenFunc;
   size_t _origLen;
+  ROMOL_SPTR _mol;
 
  public:
   ~ReadOnlySeq() {}
-  ReadOnlySeq(T1 start, T1 end, T3 lenFunc)
+  ReadOnlySeq(const ROMOL_SPTR &mol, T1 start, T1 end, T3 lenFunc)
       : _start(start),
         _end(end),
         _pos(start),
         _size(-1),
         _lenFunc(lenFunc),
-        _origLen(lenFunc()){};
+        _origLen(lenFunc()),
+        _mol(mol) {}
   ReadOnlySeq(const ReadOnlySeq<T1, T2, T3> &other)
       : _start(other._start),
         _end(other._end),
         _pos(other._pos),
         _size(other._size),
         _lenFunc(other._lenFunc),
-        _origLen(other._origLen){};
+        _origLen(other._origLen),
+        _mol(other._mol) {}
   void reset() {
     // std::cerr << "**** reset ****" << this<< std::endl;
     _pos = _start;
@@ -65,7 +76,7 @@ class ReadOnlySeq {
     reset();
     // std::cerr << "  finish ****" << this << std::endl;
     return this;
-  };
+  }
   T2 next() {
     // std::cerr << "\tnext: " << _pos._pos << " " << _end._pos << std::endl;
     if (_pos == _end) {
@@ -114,5 +125,6 @@ typedef ReadOnlySeq<ROMol::AtomIterator, Atom *, AtomCountFunctor> AtomIterSeq;
 typedef ReadOnlySeq<ROMol::QueryAtomIterator, Atom *, AtomCountFunctor>
     QueryAtomIterSeq;
 typedef ReadOnlySeq<ROMol::BondIterator, Bond *, BondCountFunctor> BondIterSeq;
+typedef ReadOnlySeq<ROMol::ConformerIterator, CONFORMER_SPTR &, ConformerCountFunctor> ConformerIterSeq;
 }
 #endif

--- a/Code/GraphMol/Wrap/testConformer.py
+++ b/Code/GraphMol/Wrap/testConformer.py
@@ -120,7 +120,7 @@ class TestCase(unittest.TestCase):
     m.RemoveAllConformers()
     self.assertTrue(m.GetNumConformers() == 0)
     confs = m.GetConformers()
-    self.assertTrue(confs == ())
+    self.assertEqual(len(confs), 0)
 
   def test5PositionsArray(self):
     smi = 'c1ccccc1'
@@ -137,7 +137,7 @@ class TestCase(unittest.TestCase):
     m.RemoveAllConformers()
     self.assertTrue(m.GetNumConformers() == 0)
     confs = m.GetConformers()
-    self.assertTrue(confs == ())
+    self.assertEqual(len(confs), 0)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR fixes #3492 as well as other issues connected to C++ objects being destroyed too early.
For example, the current RDKit master branch segfaults when doing:

```
In [1]: from rdkit import Chem

In [2]: Chem.MolFromSmiles("CC").GetBonds()[0].GetOwningMol()
Segmentation fault
```

or

```
In [1]: from rdkit import Chem

In [2]: Chem.MolFromSmiles("CC").GetAtoms()[0].GetOwningMol()
Segmentation fault
```

while after this PR this does not happen anymore.