### PR TITLE
Fixes #3492 (through a different route)

### DIFF
--- a/Code/GraphMol/ROMol.cpp
+++ b/Code/GraphMol/ROMol.cpp
@@ -56,7 +56,7 @@ void ROMol::destroy() {
   d_stereo_groups.clear();
 };
 
-ROMol::ROMol(const std::string &pickle) : RDProps() {
+ROMol::ROMol(const std::string &pickle) : RDProps(), RDParent() {
   initMol();
   numBonds = 0;
   MolPickler::molFromPickle(pickle, *this);

--- a/Code/GraphMol/ROMol.h
+++ b/Code/GraphMol/ROMol.h
@@ -31,6 +31,7 @@
 // our stuff
 #include <RDGeneral/types.h>
 #include <RDGeneral/RDProps.h>
+#include <RDGeneral/RDParentChild.h>
 #include "Atom.h"
 #include "Bond.h"
 #include "Conformer.h"
@@ -168,7 +169,7 @@ struct CXXBondIterator {
   CXXBondIter end() { return {graph, vend}; }
 };
 
-class RDKIT_GRAPHMOL_EXPORT ROMol : public RDProps {
+class RDKIT_GRAPHMOL_EXPORT ROMol : public RDProps, public RDParent {
  public:
   friend class MolPickler;
   friend class RWMol;
@@ -267,7 +268,7 @@ class RDKIT_GRAPHMOL_EXPORT ROMol : public RDProps {
     return {&d_graph};
   }
 
-  ROMol() : RDProps() { initMol(); }
+  ROMol() : RDProps(), RDParent() { initMol(); }
 
   //! copy constructor with a twist
   /*!
@@ -281,7 +282,7 @@ class RDKIT_GRAPHMOL_EXPORT ROMol : public RDProps {
          the specified conformer from \c other.
   */
   ROMol(const ROMol &other, bool quickCopy = false, int confId = -1)
-      : RDProps() {
+      : RDProps(), RDParent() {
     dp_ringInfo = nullptr;
     initFromOther(other, quickCopy, confId);
     numBonds = rdcast<unsigned int>(boost::num_edges(d_graph));

--- a/Code/GraphMol/Wrap/Conformer.cpp
+++ b/Code/GraphMol/Wrap/Conformer.cpp
@@ -30,27 +30,27 @@ RDGeom::Point3D GetAtomPos(const Conformer *conf, unsigned int aid) {
   return res;
 }
 
-PyObject* GetPos(const Conformer *conf) {
-    const RDGeom::POINT3D_VECT &pos = conf->getPositions();
+PyObject *GetPos(const Conformer *conf) {
+  const RDGeom::POINT3D_VECT &pos = conf->getPositions();
 
-    // define a 2D array with the following size
-    npy_intp dims[2];
-    dims[0] = pos.size();
-    dims[1] = 3;
+  // define a 2D array with the following size
+  npy_intp dims[2];
+  dims[0] = pos.size();
+  dims[1] = 3;
 
-    // initialize the array
-    auto *res = (PyArrayObject *)PyArray_SimpleNew(2, dims, NPY_DOUBLE);
+  // initialize the array
+  auto *res = (PyArrayObject *)PyArray_SimpleNew(2, dims, NPY_DOUBLE);
 
-    // represent the array as a 1D/flat array of doubles
-    auto *resData = reinterpret_cast<double *>(PyArray_DATA(res));
+  // represent the array as a 1D/flat array of doubles
+  auto *resData = reinterpret_cast<double *>(PyArray_DATA(res));
 
-    // manually insert the data, 3 corresponds to the x, y and z dimensions
-    for (unsigned int i = 0; i < pos.size(); ++i) {
-        resData[3*i+0] = pos[i].x;
-        resData[3*i+1] = pos[i].y;
-        resData[3*i+2] = pos[i].z;
-    }
-    return PyArray_Return(res);
+  // manually insert the data, 3 corresponds to the x, y and z dimensions
+  for (unsigned int i = 0; i < pos.size(); ++i) {
+    resData[3 * i + 0] = pos[i].x;
+    resData[3 * i + 1] = pos[i].y;
+    resData[3 * i + 2] = pos[i].z;
+  }
+  return PyArray_Return(res);
 }
 
 void SetAtomPos(Conformer *conf, unsigned int aid, python::object loc) {

--- a/Code/GraphMol/Wrap/Mol.cpp
+++ b/Code/GraphMol/Wrap/Mol.cpp
@@ -97,17 +97,6 @@ Conformer *GetMolConformer(ROMol &mol, int id = -1) {
   return &(mol.getConformer(id));
 }
 
-PyObject *GetMolConformers(ROMol &mol) {
-  PyObject *res = PyTuple_New(mol.getNumConformers());
-  ROMol::ConformerIterator ci;
-  unsigned int i = 0;
-  for (ci = mol.beginConformers(); ci != mol.endConformers(); ci++) {
-    PyTuple_SetItem(res, i, python::converter::shared_ptr_to_python(*ci));
-    i++;
-  }
-  return res;
-}
-
 void MolDebug(const ROMol &mol, bool useStdout) {
   if (useStdout) {
     mol.debugMol(std::cout);
@@ -125,32 +114,35 @@ void MolDebug(const ROMol &mol, bool useStdout) {
 }
 
 // FIX: we should eventually figure out how to do iterators properly
-AtomIterSeq *MolGetAtoms(ROMol *mol) {
-  AtomIterSeq *res = new AtomIterSeq(mol->beginAtoms(), mol->endAtoms(),
-                                     AtomCountFunctor(*mol));
+AtomIterSeq *MolGetAtoms(ROMol &mol) {
+  AtomIterSeq *res = new AtomIterSeq(&mol, mol.beginAtoms(), mol.endAtoms(),
+                                     AtomCountFunctor(mol));
   return res;
 }
-QueryAtomIterSeq *MolGetAromaticAtoms(ROMol *mol) {
+QueryAtomIterSeq *MolGetAromaticAtoms(ROMol &mol) {
   auto *qa = new QueryAtom();
   qa->setQuery(makeAtomAromaticQuery());
-  QueryAtomIterSeq *res = new QueryAtomIterSeq(
-      mol->beginQueryAtoms(qa), mol->endQueryAtoms(), AtomCountFunctor(*mol));
+  QueryAtomIterSeq *res =
+      new QueryAtomIterSeq(&mol, mol.beginQueryAtoms(qa), mol.endQueryAtoms(),
+                           AtomCountFunctor(mol));
   return res;
 }
-QueryAtomIterSeq *MolGetQueryAtoms(ROMol *mol, QueryAtom *qa) {
-  QueryAtomIterSeq *res = new QueryAtomIterSeq(
-      mol->beginQueryAtoms(qa), mol->endQueryAtoms(), AtomCountFunctor(*mol));
+QueryAtomIterSeq *MolGetQueryAtoms(ROMol &mol, QueryAtom *qa) {
+  QueryAtomIterSeq *res =
+      new QueryAtomIterSeq(&mol, mol.beginQueryAtoms(qa), mol.endQueryAtoms(),
+                           AtomCountFunctor(mol));
   return res;
 }
 
-// AtomIterSeq *MolGetHeteros(ROMol *mol){
-//  AtomIterSeq *res = new AtomIterSeq(mol->beginHeteros(),
-//                                     mol->endHeteros());
-//  return res;
-//}
-BondIterSeq *MolGetBonds(ROMol *mol) {
-  BondIterSeq *res = new BondIterSeq(mol->beginBonds(), mol->endBonds(),
-                                     BondCountFunctor(*mol));
+BondIterSeq *MolGetBonds(ROMol &mol) {
+  BondIterSeq *res = new BondIterSeq(&mol, mol.beginBonds(), mol.endBonds(),
+                                     BondCountFunctor(mol));
+  return res;
+}
+ConformerIterSeq *GetMolConformers(ROMol &mol) {
+  ConformerIterSeq *res =
+      new ConformerIterSeq(&mol, mol.beginConformers(), mol.endConformers(),
+                           ConformerCountFunctor(mol));
   return res;
 }
 
@@ -396,7 +388,9 @@ struct mol_wrapper {
                  1, python::with_custodian_and_ward_postcall<0, 1>>())
 
         .def("GetConformers", GetMolConformers,
-             "Get all the conformers as a tuple")
+             python::return_value_policy<python::manage_new_object>(),
+             "Returns a read-only sequence containing all of the molecule's "
+             "Conformers.")
 
         .def("RemoveAllConformers", &ROMol::clearConformers,
              "Remove all the conformations on the molecule")
@@ -737,28 +731,20 @@ struct mol_wrapper {
              "  RETURNS: a dictionary\n")
 
         .def("GetAtoms", MolGetAtoms,
-             python::return_value_policy<
-                 python::manage_new_object,
-                 python::with_custodian_and_ward_postcall<0, 1>>(),
+             python::return_value_policy<python::manage_new_object>(),
              "Returns a read-only sequence containing all of the molecule's "
              "Atoms.\n")
         .def("GetAromaticAtoms", MolGetAromaticAtoms,
-             python::return_value_policy<
-                 python::manage_new_object,
-                 python::with_custodian_and_ward_postcall<0, 1>>(),
+             python::return_value_policy<python::manage_new_object>(),
              "Returns a read-only sequence containing all of the molecule's "
              "aromatic Atoms.\n")
         .def("GetAtomsMatchingQuery", MolGetQueryAtoms,
-             python::return_value_policy<
-                 python::manage_new_object,
-                 python::with_custodian_and_ward_postcall<0, 1>>(),
+             python::return_value_policy<python::manage_new_object>(),
              "Returns a read-only sequence containing all of the atoms in a "
              "molecule that match the query atom.\n")
 
         .def("GetBonds", MolGetBonds,
-             python::return_value_policy<
-                 python::manage_new_object,
-                 python::with_custodian_and_ward_postcall<0, 1>>(),
+             python::return_value_policy<python::manage_new_object>(),
              "Returns a read-only sequence containing all of the molecule's "
              "Bonds.\n")
 

--- a/Code/GraphMol/Wrap/rdchem.cpp
+++ b/Code/GraphMol/Wrap/rdchem.cpp
@@ -159,11 +159,22 @@ PyObject *createExceptionClass(const char *name,
   return typeObj;
 }
 
+template <typename O, typename T>
+T *get_item_ptr(O &self, int i) {
+  return self.get_item(i).get();
+}
+
+template <typename O, typename T>
+T *next_ptr(O &self) {
+  return self.next().get();
+}
+
 BOOST_PYTHON_MODULE(rdchem) {
   python::scope().attr("__doc__") =
       "Module containing the core chemistry functionality of the RDKit";
   RegisterListConverter<RDKit::Atom *>();
   RegisterListConverter<RDKit::Bond *>();
+  RegisterListConverter<RDKit::CONFORMER_SPTR>();
   rdkit_import_array();
 
   // this is one of those parts where I think I wish that I knew how to do
@@ -241,7 +252,7 @@ BOOST_PYTHON_MODULE(rdchem) {
   //*********************************************
   python::class_<AtomIterSeq>(
       "_ROAtomSeq",
-      "Read-only sequence of atoms, not constructable from Python.",
+      "Read-only sequence of atoms, not constructible from Python.",
       python::no_init)
       .def("__iter__", &AtomIterSeq::__iter__,
            python::return_internal_reference<
@@ -254,7 +265,7 @@ BOOST_PYTHON_MODULE(rdchem) {
            python::return_value_policy<python::reference_existing_object>());
   python::class_<QueryAtomIterSeq>("_ROQAtomSeq",
                                    "Read-only sequence of atoms matching a "
-                                   "query, not constructable from Python.",
+                                   "query, not constructible from Python.",
                                    python::no_init)
       .def("__iter__", &QueryAtomIterSeq::__iter__,
            python::return_internal_reference<
@@ -266,11 +277,28 @@ BOOST_PYTHON_MODULE(rdchem) {
            python::return_value_policy<python::reference_existing_object>());
   python::class_<BondIterSeq>(
       "_ROBondSeq",
-      "Read-only sequence of bonds, not constructable from Python.",
+      "Read-only sequence of bonds, not constructible from Python.",
       python::no_init)
-      // FIX: we ought to be able to expose an iteration interface
+      .def("__iter__", &BondIterSeq::__iter__,
+           python::return_internal_reference<
+               1, python::with_custodian_and_ward_postcall<0, 1>>())
+      .def("__next__", &BondIterSeq::next,
+           python::return_value_policy<python::reference_existing_object>())
       .def("__len__", &BondIterSeq::len)
       .def("__getitem__", &BondIterSeq::get_item,
+           python::return_value_policy<python::reference_existing_object>());
+  python::class_<ConformerIterSeq>(
+      "_ROConformerSeq",
+      "Read-only sequence of conformers, not constructible from Python.",
+      python::no_init)
+      .def("__iter__", &ConformerIterSeq::__iter__,
+           python::return_internal_reference<
+               1, python::with_custodian_and_ward_postcall<0, 1>>())
+      .def("__next__", next_ptr<ConformerIterSeq, Conformer>,
+           python::return_value_policy<python::reference_existing_object>())
+
+      .def("__len__", &ConformerIterSeq::len)
+      .def("__getitem__", get_item_ptr<ConformerIterSeq, Conformer>,
            python::return_value_policy<python::reference_existing_object>());
 
   //*********************************************

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -3009,16 +3009,18 @@ CAS<~>
     mol = Chem.MolFromSmiles("CCC1CNCC1CC")
     atoms = mol.GetAtoms()
     mol = None
-    for atom in atoms:
-      idx = atom.GetIdx()
-      p = atom.GetOwningMol().GetNumAtoms()
+    with self.assertRaises(RuntimeError):
+      for atom in atoms:
+        idx = atom.GetIdx()
+        p = atom.GetOwningMol().GetNumAtoms()
 
     mol = Chem.MolFromSmiles("CCC1CNCC1CC")
     bonds = mol.GetBonds()
     mol = None
-    for bond in bonds:
-      idx = bond.GetIdx()
-      p = atom.GetOwningMol().GetNumAtoms()
+    with self.assertRaises(RuntimeError):
+      for bond in bonds:
+        idx = bond.GetIdx()
+        p = atom.GetOwningMol().GetNumAtoms()
 
     mol = Chem.MolFromSmiles("CCC1CNCC1CC")
     bond = mol.GetBondBetweenAtoms(0, 1)
@@ -6199,7 +6201,76 @@ M  END
     m = Chem.MolFromSmiles("c1ccccc1C(=O)Cl")
     self.assertFalse(m.HasSubstructMatch(sma, recursionPossible=False))
 
-    
+  def test_github3492(self):
+    def read_smile(s):
+        m = Chem.MolFromSmiles(s)
+        rdkit.Chem.rdDepictor.Compute2DCoords(m)
+        m.AddConformer(m.GetConformer())
+        return m
+
+    with self.assertRaises(RuntimeError):
+      len(Chem.MolFromSmiles("OCCN").GetAtoms())
+    with self.assertRaises(RuntimeError):
+      Chem.MolFromSmiles("OCCN").GetAtoms()[0]
+    with self.assertRaises(RuntimeError):
+      Chem.MolFromSmiles("OCCN").GetAtoms()[1]
+    with self.assertRaises(RuntimeError):
+      next(Chem.MolFromSmiles("OCCN").GetAtoms())
+
+    with self.assertRaises(RuntimeError):
+      len(Chem.MolFromSmiles("OCCN").GetBonds())
+    with self.assertRaises(RuntimeError):
+      Chem.MolFromSmiles("O=CCC=N").GetBonds()[0]
+    with self.assertRaises(RuntimeError):
+      Chem.MolFromSmiles("O=CCC=N").GetBonds()[1]
+    with self.assertRaises(RuntimeError):
+      next(Chem.MolFromSmiles("O=CCC=N").GetBonds())
+
+    with self.assertRaises(RuntimeError):
+      len(Chem.MolFromSmiles("OCCN").GetConformers())
+    with self.assertRaises(RuntimeError):
+      read_smile("CCC").GetConformers()[0]
+    with self.assertRaises(RuntimeError):
+      read_smile("CCC").GetConformers()[1]
+    with self.assertRaises(RuntimeError):
+      next(read_smile("CCC").GetConformers())
+
+    mol = read_smile("CCC")
+    atoms = mol.GetAtoms()
+    self.assertEqual(len(atoms), 3)
+    del mol
+    self.assertEqual(len(atoms), 3)
+    with self.assertRaises(RuntimeError):
+      atoms[0]
+    with self.assertRaises(RuntimeError):
+      atoms[1]
+    with self.assertRaises(RuntimeError):
+      next(atoms)
+
+    mol = read_smile("CCC")
+    bonds = mol.GetBonds()
+    self.assertEqual(len(bonds), 2)
+    del mol
+    self.assertEqual(len(bonds), 2)
+    with self.assertRaises(RuntimeError):
+      bonds[0]
+    with self.assertRaises(RuntimeError):
+      bonds[1]
+    with self.assertRaises(RuntimeError):
+      next(bonds)
+
+    mol = read_smile("CCC")
+    conformers = mol.GetConformers()
+    self.assertEqual(len(conformers), 2)
+    del mol
+    self.assertEqual(len(conformers), 2)
+    with self.assertRaises(RuntimeError):
+      conformers[0]
+    with self.assertRaises(RuntimeError):
+      conformers[1]
+    with self.assertRaises(RuntimeError):
+      next(conformers)
+
 if __name__ == '__main__':
   if "RDTESTCASE" in os.environ:
     suite = unittest.TestSuite()

--- a/Code/GraphMol/Wrap/seqs.hpp
+++ b/Code/GraphMol/Wrap/seqs.hpp
@@ -29,33 +29,67 @@ class BondCountFunctor {
   BondCountFunctor(const ROMol &mol) : _mol(mol){};
   unsigned int operator()() const { return _mol.getNumBonds(); };
 };
+class ConformerCountFunctor {
+ private:
+  const ROMol &_mol;
+
+ public:
+  ConformerCountFunctor(const ROMol &mol) : _mol(mol){};
+  unsigned int operator()() const { return _mol.getNumConformers(); };
+};
 
 // Note: T1 should be some iterator type,
 //       T2 is the value when we dereference T
 template <class T1, class T2, class T3>
-class ReadOnlySeq {
+class ReadOnlySeq : public RDChild {
  private:
   T1 _start, _end, _pos;
   int _size;
   T3 _lenFunc;
   size_t _origLen;
+  ROMol *_mol;
 
  public:
   ~ReadOnlySeq() {}
-  ReadOnlySeq(T1 start, T1 end, T3 lenFunc)
-      : _start(start),
+  ReadOnlySeq(ROMol *mol, T1 start, T1 end, T3 lenFunc)
+      : RDChild(mol),
+        _start(start),
         _end(end),
         _pos(start),
         _size(-1),
         _lenFunc(lenFunc),
-        _origLen(lenFunc()){};
+        _origLen(lenFunc()),
+        _mol(mol) {}
   ReadOnlySeq(const ReadOnlySeq<T1, T2, T3> &other)
-      : _start(other._start),
+      : RDChild(other._mol),
+        _start(other._start),
         _end(other._end),
         _pos(other._pos),
         _size(other._size),
         _lenFunc(other._lenFunc),
-        _origLen(other._origLen){};
+        _origLen(other._origLen),
+        _mol(other._mol) {}
+  void throwIfParentMolDeleted() const {
+    if (!hasParent()) {
+      PyErr_SetString(PyExc_RuntimeError, "Underlying ROMol object deleted");
+      throw python::error_already_set();
+    }
+  }
+  void throwIfSequenceModified() const {
+    if (_lenFunc() != _origLen) {
+      PyErr_SetString(PyExc_RuntimeError, "Sequence modified during iteration");
+      throw python::error_already_set();
+    }
+  }
+  void throwEndOfSequenceHit() const {
+    PyErr_SetString(PyExc_StopIteration, "End of sequence hit");
+    throw python::error_already_set();
+  }
+  void throwIndexOutOfBounds() const {
+    PyErr_SetString(PyExc_IndexError, "IndexOutOfBounds");
+    throw python::error_already_set();
+  }
+
   void reset() {
     // std::cerr << "**** reset ****" << this<< std::endl;
     _pos = _start;
@@ -65,31 +99,25 @@ class ReadOnlySeq {
     reset();
     // std::cerr << "  finish ****" << this << std::endl;
     return this;
-  };
+  }
   T2 next() {
     // std::cerr << "\tnext: " << _pos._pos << " " << _end._pos << std::endl;
+    throwIfParentMolDeleted();
     if (_pos == _end) {
-      PyErr_SetString(PyExc_StopIteration, "End of sequence hit");
-      throw python::error_already_set();
+      throwEndOfSequenceHit();
     }
-    if (_lenFunc() != _origLen) {
-      PyErr_SetString(PyExc_RuntimeError, "Sequence modified during iteration");
-      throw python::error_already_set();
-    }
+    throwIfSequenceModified();
     T2 res = *_pos;
     ++_pos;
     return res;
   }
   T2 get_item(int which) {
     // std::cerr << "get_item: " <<which<< std::endl;
+    throwIfParentMolDeleted();
     if (which >= len()) {
-      PyErr_SetString(PyExc_IndexError, "End of sequence hit");
-      throw python::error_already_set();
+      throwIndexOutOfBounds();
     }
-    if (_lenFunc() != _origLen) {
-      PyErr_SetString(PyExc_RuntimeError, "Sequence modified during iteration");
-      throw python::error_already_set();
-    }
+    throwIfSequenceModified();
     T1 it = _start;
     for (int i = 0; i < which; i++) {
       ++it;
@@ -99,11 +127,10 @@ class ReadOnlySeq {
   int len() {
     // std::cerr << "len " << std::endl;
     if (_size < 0) {
+      throwIfParentMolDeleted();
       _size = 0;
-      for (T1 tmp = _start; tmp != _end; tmp++) {
-        // std::cerr << "\tincr: "  <<  std::endl;
-        _size++;
-      }
+      for (T1 tmp = _start; tmp != _end; ++tmp, ++_size)
+        ;
     }
     // std::cerr << "\tret" << std::endl;
     return _size;
@@ -114,5 +141,6 @@ typedef ReadOnlySeq<ROMol::AtomIterator, Atom *, AtomCountFunctor> AtomIterSeq;
 typedef ReadOnlySeq<ROMol::QueryAtomIterator, Atom *, AtomCountFunctor>
     QueryAtomIterSeq;
 typedef ReadOnlySeq<ROMol::BondIterator, Bond *, BondCountFunctor> BondIterSeq;
+typedef ReadOnlySeq<ROMol::ConformerIterator, CONFORMER_SPTR &, ConformerCountFunctor> ConformerIterSeq;
 }
 #endif

--- a/Code/GraphMol/Wrap/testConformer.py
+++ b/Code/GraphMol/Wrap/testConformer.py
@@ -120,7 +120,7 @@ class TestCase(unittest.TestCase):
     m.RemoveAllConformers()
     self.assertTrue(m.GetNumConformers() == 0)
     confs = m.GetConformers()
-    self.assertTrue(confs == ())
+    self.assertEqual(len(confs), 0)
 
   def test5PositionsArray(self):
     smi = 'c1ccccc1'
@@ -137,7 +137,7 @@ class TestCase(unittest.TestCase):
     m.RemoveAllConformers()
     self.assertTrue(m.GetNumConformers() == 0)
     confs = m.GetConformers()
-    self.assertTrue(confs == ())
+    self.assertEqual(len(confs), 0)
 
 
 if __name__ == '__main__':

--- a/Code/RDGeneral/CMakeLists.txt
+++ b/Code/RDGeneral/CMakeLists.txt
@@ -8,7 +8,7 @@ CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/RDConfig.h.cmake
 
 rdkit_library(RDGeneral
               Invariant.cpp types.cpp utils.cpp RDLog.cpp 
-              LocaleSwitcher.cpp versions.cpp SHARED)
+              RDParentChild.cpp LocaleSwitcher.cpp versions.cpp SHARED)
 target_compile_definitions(RDGeneral PRIVATE RDKIT_RDGENERAL_BUILD)
 
 if(MINGW)
@@ -52,6 +52,7 @@ rdkit_headers(Exceptions.h
               RDValue-doublemagic.h
               RDValue-taggedunion.h
               RDLog.h
+              RDParentChild.h
               RDProps.h
               RDThreads.h
               StreamOps.h

--- a/Code/RDGeneral/RDParentChild.cpp
+++ b/Code/RDGeneral/RDParentChild.cpp
@@ -1,0 +1,76 @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
+//
+
+#include <RDGeneral/RDParentChild.h>
+
+#ifdef RDK_THREADSAFE_SSS
+#include <mutex>
+#endif
+
+#ifdef RDK_THREADSAFE_SSS
+namespace {
+std::mutex &propmutex_get() {
+  // create on demand
+  static std::mutex _mutex;
+  return _mutex;
+}
+
+void propmutex_create() {
+  std::mutex &mutex = propmutex_get();
+  std::lock_guard<std::mutex> test_lock(mutex);
+}
+
+std::mutex &GetPropMutex() {
+  static std::once_flag flag;
+  std::call_once(flag, propmutex_create);
+  return propmutex_get();
+}
+}  // namespace
+#endif
+
+namespace RDKit {
+
+RDParent::~RDParent() {
+#ifdef RDK_THREADSAFE_SSS
+  std::lock_guard<std::mutex> lock(GetPropMutex());
+#endif
+  for (auto child : d_children) {
+    child->unsetParent();
+  }
+}
+
+bool RDParent::addChild(RDChild *child) {
+  return d_children.insert(child).second;
+}
+
+bool RDParent::removeChild(RDChild *child) {
+  auto it = d_children.find(child);
+  bool res = (it != d_children.end());
+  if (res) {
+    d_children.erase(it);
+  }
+  return res;
+}
+
+RDChild::RDChild(RDParent *parent) : d_parent(parent) {
+#ifdef RDK_THREADSAFE_SSS
+  std::lock_guard<std::mutex> lock(GetPropMutex());
+#endif
+  if (d_parent) {
+    d_parent->addChild(this);
+  }
+}
+
+RDChild::~RDChild() {
+#ifdef RDK_THREADSAFE_SSS
+  std::lock_guard<std::mutex> lock(GetPropMutex());
+#endif
+  if (d_parent) {
+    d_parent->removeChild(this);
+  }
+}
+
+}  // namespace RDKit

--- a/Code/RDGeneral/RDParentChild.cpp
+++ b/Code/RDGeneral/RDParentChild.cpp
@@ -7,6 +7,11 @@
 #include <RDGeneral/RDParentChild.h>
 
 #ifdef RDK_THREADSAFE_SSS
+#undef RDK_THREADSAFE_SSS
+#define RESTORE_RDK_THREADSAFE_SSS
+#endif
+
+#ifdef RDK_THREADSAFE_SSS
 #include <mutex>
 #endif
 
@@ -28,7 +33,7 @@ std::mutex &GetPropMutex() {
   std::call_once(flag, propmutex_create);
   return propmutex_get();
 }
-}  // namespace
+}
 #endif
 
 namespace RDKit {

--- a/Code/RDGeneral/RDParentChild.h
+++ b/Code/RDGeneral/RDParentChild.h
@@ -1,0 +1,47 @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
+//
+#include <RDGeneral/export.h>
+#ifndef RDKIT_RDPARENTCHILD_H
+#define RDKIT_RDPARENTCHILD_H
+
+#include <unordered_set>
+
+namespace RDKit {
+
+class RDChild;
+
+class RDKIT_RDGENERAL_EXPORT RDParent {
+  friend class RDChild;
+
+ public:
+  RDParent() {
+  }
+  ~RDParent();
+
+ private:
+  bool addChild(RDChild *child);
+  bool removeChild(RDChild *child);
+  std::unordered_set<RDChild *> d_children;
+};
+
+class RDKIT_RDGENERAL_EXPORT RDChild {
+  friend class RDParent;
+
+ public:
+  RDChild(RDParent *parent);
+  virtual ~RDChild();
+
+ protected:
+  bool hasParent() const { return (d_parent != nullptr); }
+
+ private:
+  RDParent *parent() const { return d_parent; }
+  void unsetParent() { d_parent = nullptr; }
+  RDParent *d_parent;
+};
+
+}  // namespace RDKit
+#endif


### PR DESCRIPTION
This PR addresses #3492 through a different route.
The outcome is the same, but the strategy used is quite different.
Less `custodian_and_ward` - I have even removed it from the `GetAtoms`, `Getbonds` and `GetConformers` methods, such that the attempt to access atoms if the underlying molecule has been deleted will fail earlier than before with a `Underlying ROMol object deleted` Python `RuntimeError`.
As a result, the performance impact in this `getconformers2` branch compared to `master` is much smaller than with the `getconformers` branch:

<h2><code>master</code> branch</h2>

```
%%timeit
for m in mols:
    for i in range(m.GetNumAtoms()):
        assert(m.GetAtoms()[i].GetOwningMol())
6.3 s ± 33.2 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

%%timeit
for m in mols:
    atoms = m.GetAtoms()
    for i in range(m.GetNumAtoms()):
        assert(atoms[i].GetOwningMol())
4.1 s ± 15.9 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

%%timeit
for m in mols:
    for a in m.GetAtoms():
        assert(a.GetOwningMol())
6.72 s ± 33.9 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

<h2><code>getconformers2</code> branch, i.e. this PR</h2>

```
%%timeit
for m in mols:
    for i in range(m.GetNumAtoms()):
        assert(m.GetAtoms()[i].GetOwningMol())
6.83 s ± 41.4 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

%%timeit
for m in mols:
    atoms = m.GetAtoms()
    for i in range(m.GetNumAtoms()):
        assert(atoms[i].GetOwningMol())
4.23 s ± 35.3 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

%%timeit
for m in mols:
    for a in m.GetAtoms():
        assert(a.GetOwningMol())
7.01 s ± 56.2 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

<h2><code>getconformers</code> branch</h2>

```
%%timeit
for m in mols:
    for i in range(m.GetNumAtoms()):
        assert(m.GetAtoms()[i].GetOwningMol())
7.95 s ± 180 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

%%timeit
for m in mols:
    atoms = m.GetAtoms()
    for i in range(m.GetNumAtoms()):
        assert(atoms[i].GetOwningMol())
4.73 s ± 211 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

%%timeit
for m in mols:
    for a in m.GetAtoms():
        assert(a.GetOwningMol())
7.51 s ± 40.5 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

We could push this approach even further making `Atom`, `Bond` and `Conformer` copy constructors register themselves as children of the parent `ROMol`, such that if people do something like:

```
mol = Chem.MolFromSmiles("CCC")
atoms = [a for a in mol.GetAtoms()]
del mol
atoms[0].GetOwningMol()
```

they don't get a segfault (this is the only case that still fails also in all 3 branches), because atoms could be dis-owned when the `ROMol` is deleted.
However, this would add some overhead (but only when atoms or bonds or conformers are copied).

Before going any further, I'd like to check @greglandrum and @bp-kelley opinion on this POC.
If you like it, I'll fix the threading issues and add relevant tests (you do not need the threading support until this is only used from Python, so it's OK as it is for this POC).
And let me know what you think of the further improvement I proposed.

Thanks!