### PR TITLE
Give a bit more time to RGD test in debug builds

### DIFF
--- a/Code/GraphMol/RGroupDecomposition/testRGroupDecomp.cpp
+++ b/Code/GraphMol/RGroupDecomposition/testRGroupDecomp.cpp
@@ -1174,7 +1174,11 @@ Cn1cnc2cc(Oc3cc(N4CCN(Cc5ccccc5-c5ccc(Cl)cc5)CC4)ccc3C(=O)NS(=O)(=O)c3ccc(NCCCN4
   }
   {
     RGroupDecompositionParameters ps = RGroupDecompositionParameters();
+#ifdef NDEBUG
     ps.timeout = 1.0;
+#else
+    ps.timeout = 5.0;
+#endif
     ps.matchingStrategy = RDKit::NoSymmetrization;
     std::cerr << "bulk, no symmetry" << std::endl;
     std::vector<ROMOL_SPTR> cores;


### PR DESCRIPTION
I have noticed that this test fails on `Debug` builds, which are sloooow. This gives it a bit more time.