### PR TITLE
Fixes #3529

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,10 +89,10 @@ if(RDK_BUILD_SWIG_WRAPPERS!=ON)
 endif()
 
 if(RDK_SWIG_STATIC AND RDK_BUILD_SWIG_WRAPPERS)
-  if(NOT RDK_INSTALL_STATIC_LIBS)
+  if(NOT MSVC AND NOT RDK_INSTALL_STATIC_LIBS)
     message("Enabling RDK_INSTALL_STATIC_LIBS because RDK_SWIG_STATIC is set.")
     set(RDK_INSTALL_STATIC_LIBS ON CACHE BOOL "install the rdkit static libraries" FORCE)
-  endif(NOT RDK_INSTALL_STATIC_LIBS)
+  endif(NOT MSVC AND NOT RDK_INSTALL_STATIC_LIBS)
 endif()
 
 if(NOT (MSVC AND (NOT RDK_INSTALL_DLLS_MSVC)))
@@ -100,10 +100,10 @@ if(NOT (MSVC AND (NOT RDK_INSTALL_DLLS_MSVC)))
 endif()
 
 if(RDK_PGSQL_STATIC AND RDK_BUILD_PGSQL)
-  if(NOT RDK_INSTALL_STATIC_LIBS)
+  if(NOT MSVC AND NOT RDK_INSTALL_STATIC_LIBS)
     message("Enabling RDK_INSTALL_STATIC_LIBS because RDK_PGSQL_STATIC is set.")
     set(RDK_INSTALL_STATIC_LIBS ON CACHE BOOL "install the rdkit static libraries" FORCE)
-  endif(NOT RDK_INSTALL_STATIC_LIBS)
+  endif(NOT MSVC AND NOT RDK_INSTALL_STATIC_LIBS)
 endif()
 
 
@@ -390,7 +390,10 @@ if(RDK_USE_BOOST_SERIALIZATION)
     else()
       set(Boost_LIBRARIES ${T_LIBS})
     endif()
-  target_compile_definitions(rdkit_base INTERFACE -DRDK_USE_BOOST_SERIALIZATION -DBOOST_SERIALIZATION_DYN_LINK)
+    target_compile_definitions(rdkit_base INTERFACE -DRDK_USE_BOOST_SERIALIZATION)
+    if(NOT Boost_USE_STATIC_LIBS)
+      target_compile_definitions(rdkit_base INTERFACE -DBOOST_SERIALIZATION_DYN_LINK)
+    endif()
 endif()
 
 

--- a/Code/GraphMol/ScaffoldNetwork/ScaffoldNetwork.h
+++ b/Code/GraphMol/ScaffoldNetwork/ScaffoldNetwork.h
@@ -182,6 +182,7 @@ RDKIT_SCAFFOLDNETWORK_EXPORT ScaffoldNetworkParams getBRICSNetworkParams();
 }  // namespace ScaffoldNetwork
 }  // namespace RDKit
 
+#ifdef RDK_USE_BOOST_SERIALIZATION
 namespace boost {
 namespace serialization {
 template <>
@@ -190,5 +191,5 @@ struct version<RDKit::ScaffoldNetwork::ScaffoldNetwork> {
 };
 }  // namespace serialization
 }  // namespace boost
-
+#endif
 #endif


### PR DESCRIPTION
Gets builds working when RDK_USE_BOOST_SERIALIZATION is disabled
Minor build system changes associated with this too.
