### PR TITLE
Add missing methods to remove SubstanceGroup attributes

### DIFF
--- a/Code/GraphMol/SubstanceGroup.h
+++ b/Code/GraphMol/SubstanceGroup.h
@@ -82,11 +82,12 @@ class RDKIT_GRAPHMOL_EXPORT SubstanceGroup : public RDProps {
     }
   };
 
-  //! No default constructor
-  #ifndef SWIG
-   // Unfortunately, SWIG generated wrapper code uses temporary variables that require a default ctor not be deleted.
-   SubstanceGroup() = delete;
-  #endif // !SWIG
+//! No default constructor
+#ifndef SWIG
+  // Unfortunately, SWIG generated wrapper code uses temporary variables that
+  // require a default ctor not be deleted.
+  SubstanceGroup() = delete;
+#endif  // !SWIG
 
   //! Main Constructor. Ownership is only set on this side of the relationship:
   //! mol->addSubstanceGroup(sgroup) still needs to be called to get ownership
@@ -136,6 +137,10 @@ class RDKIT_GRAPHMOL_EXPORT SubstanceGroup : public RDProps {
   const std::vector<Bracket> &getBrackets() const { return d_brackets; }
   const std::vector<CState> &getCStates() const { return d_cstates; }
   const std::vector<AttachPoint> &getAttachPoints() const { return d_saps; }
+
+  void clearBrackets() { d_brackets.clear(); };
+  void clearCStates() { d_cstates.clear(); };
+  void clearAttachPoints() { d_saps.clear(); };
 
   //! adjusts our atom IDs to reflect that an atom has been removed from the
   //! parent molecule

--- a/Code/GraphMol/Wrap/SubstanceGroup.cpp
+++ b/Code/GraphMol/Wrap/SubstanceGroup.cpp
@@ -146,6 +146,9 @@ struct sgroup_wrap {
         .def("GetAttachPoints", getAttachPointsHelper)
         .def("AddBracket", addBracketHelper)
         .def("GetBrackets", getBracketsHelper)
+        .def("ClearBrackets", &SubstanceGroup::clearBrackets)
+        .def("ClearCStates", &SubstanceGroup::clearCStates)
+        .def("ClearAttachPoints", &SubstanceGroup::clearAttachPoints)
 
         .def("SetProp",
              (void (RDProps::*)(const std::string &, std::string, bool) const) &

--- a/Code/GraphMol/Wrap/testSGroups.py
+++ b/Code/GraphMol/Wrap/testSGroups.py
@@ -460,6 +460,66 @@ M  END''')
     self.assertGreater(
       molb.find('M  V30 1 SUP 0 ATOMS=(3 2 3 4) XBONDS=(1 1) LABEL=CO2H SAP=(3 2 1 1)'), 0)
 
+  def testClearValues(self):
+    mol = Chem.MolFromMolBlock('''example
+ -ISIS-  10171405052D
+
+  0  0  0     0  0            999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 14 15 1 0 0
+M  V30 BEGIN ATOM
+M  V30 1 C 6.4292 -1.1916 0 0 CFG=3
+M  V30 2 C 7.0125 -0.6042 0 0
+M  V30 3 N 6.4292 -0.0250999 0 0
+M  V30 4 C 5.8416 -0.6042 0 0
+M  V30 5 C 5.8416 -1.7708 0 0
+M  V30 6 N 6.4292 -2.3584 0 0 CFG=3
+M  V30 7 C 7.0125 -1.7708 0 0
+M  V30 8 O 5.7166 -3.5875 0 0
+M  V30 9 C 5.7166 -4.4125 0 0 CFG=3
+M  V30 10 C 4.8875 -4.4125 0 0
+M  V30 11 C 6.5376 -4.4166 0 0
+M  V30 12 C 5.7166 -5.2376 0 0
+M  V30 13 C 6.4292 -3.175 0 0
+M  V30 14 O 7.1375 -3.5875 0 0
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 1 1 2
+M  V30 2 1 2 3
+M  V30 3 1 3 4
+M  V30 4 1 4 1
+M  V30 5 1 1 5
+M  V30 6 1 5 6
+M  V30 7 1 6 7
+M  V30 8 1 7 1
+M  V30 9 1 6 13
+M  V30 10 1 8 9
+M  V30 11 1 9 10
+M  V30 12 1 9 11
+M  V30 13 1 9 12
+M  V30 14 2 13 14
+M  V30 15 1 8 13
+M  V30 END BOND
+M  V30 BEGIN SGROUP
+M  V30 1 SUP 0 ATOMS=(7 8 9 10 11 12 13 14) XBONDS=(1 9) BRKXYZ=(9 6.24 -2.9 0 -
+M  V30 6.24 -2.9 0 0 0 0) CSTATE=(4 9 0 0.82 0) LABEL=Boc SAP=(3 13 6 1)
+M  V30 END SGROUP
+M  V30 END CTAB
+M  END''')
+    sgs = Chem.GetMolSubstanceGroups(mol)
+    self.assertEqual(len(sgs), 1)
+    self.assertEqual(len(sgs[0].GetBrackets()), 1)
+    sgs[0].ClearBrackets()
+    self.assertEqual(len(sgs[0].GetBrackets()), 0)
+
+    self.assertEqual(len(sgs[0].GetCStates()), 1)
+    sgs[0].ClearCStates()
+    self.assertEqual(len(sgs[0].GetCStates()), 0)
+
+    self.assertEqual(len(sgs[0].GetAttachPoints()), 1)
+    sgs[0].ClearAttachPoints()
+    self.assertEqual(len(sgs[0].GetAttachPoints()), 0)
+
 
 if __name__ == '__main__':
   print("Testing SubstanceGroups wrapper")

--- a/Code/GraphMol/catch_sgroups.cpp
+++ b/Code/GraphMol/catch_sgroups.cpp
@@ -366,3 +366,77 @@ M  END
     CHECK(molb.find("FIELDNAME") != std::string::npos);
   }
 }
+
+TEST_CASE("Allow brackets, cstates, and attachment points to be removed",
+          "[Sgroups]") {
+  auto m1 = R"CTAB(example
+ -ISIS-  10171405052D
+
+  0  0  0     0  0            999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 14 15 1 0 0
+M  V30 BEGIN ATOM
+M  V30 1 C 6.4292 -1.1916 0 0 CFG=3
+M  V30 2 C 7.0125 -0.6042 0 0
+M  V30 3 N 6.4292 -0.0250999 0 0
+M  V30 4 C 5.8416 -0.6042 0 0
+M  V30 5 C 5.8416 -1.7708 0 0
+M  V30 6 N 6.4292 -2.3584 0 0 CFG=3
+M  V30 7 C 7.0125 -1.7708 0 0
+M  V30 8 O 5.7166 -3.5875 0 0
+M  V30 9 C 5.7166 -4.4125 0 0 CFG=3
+M  V30 10 C 4.8875 -4.4125 0 0
+M  V30 11 C 6.5376 -4.4166 0 0
+M  V30 12 C 5.7166 -5.2376 0 0
+M  V30 13 C 6.4292 -3.175 0 0
+M  V30 14 O 7.1375 -3.5875 0 0
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 1 1 2
+M  V30 2 1 2 3
+M  V30 3 1 3 4
+M  V30 4 1 4 1
+M  V30 5 1 1 5
+M  V30 6 1 5 6
+M  V30 7 1 6 7
+M  V30 8 1 7 1
+M  V30 9 1 6 13
+M  V30 10 1 8 9
+M  V30 11 1 9 10
+M  V30 12 1 9 11
+M  V30 13 1 9 12
+M  V30 14 2 13 14
+M  V30 15 1 8 13
+M  V30 END BOND
+M  V30 BEGIN SGROUP
+M  V30 1 SUP 0 ATOMS=(7 8 9 10 11 12 13 14) XBONDS=(1 9) BRKXYZ=(9 6.24 -2.9 0 -
+M  V30 6.24 -2.9 0 0 0 0) CSTATE=(4 9 0 0.82 0) LABEL=Boc SAP=(3 13 6 1)
+M  V30 END SGROUP
+M  V30 END CTAB
+M  END)CTAB"_ctab;
+
+  REQUIRE(m1);
+
+  SECTION("brackets") {
+    REQUIRE(m1);
+    auto &sgs = getSubstanceGroups(*m1);
+    REQUIRE(sgs.size() == 1);
+    CHECK(sgs[0].getBrackets().size() == 1);
+    sgs[0].clearBrackets();
+    CHECK(sgs[0].getBrackets().size() == 0);
+  }
+  SECTION("cstates") {
+    auto &sgs = getSubstanceGroups(*m1);
+    REQUIRE(sgs.size() == 1);
+    CHECK(sgs[0].getCStates().size() == 1);
+    sgs[0].clearCStates();
+    CHECK(sgs[0].getCStates().size() == 0);
+  }
+  SECTION("attachpts") {
+    auto &sgs = getSubstanceGroups(*m1);
+    REQUIRE(sgs.size() == 1);
+    CHECK(sgs[0].getAttachPoints().size() == 1);
+    sgs[0].clearAttachPoints();
+    CHECK(sgs[0].getAttachPoints().size() == 0);
+  }
+}


### PR DESCRIPTION
The following attributes of SubstanceGroups could be added, but not modified/removed:
- Brackets
- CStates
- AttachPoints

Rather than adding an interface to modify or remove individual groups, this just adds simple methods to remove them entirely. New/modified values can then be added back to the SubstanceGroup being modified.