### PR TITLE
Fixes an RGD issue with cores having dummies adjacent to R-group labels

### DIFF
--- a/Code/GraphMol/RGroupDecomposition/RGroupCore.h
+++ b/Code/GraphMol/RGroupDecomposition/RGroupCore.h
@@ -35,6 +35,19 @@ struct RCore {
       }
     }
   }
+  // Return a copy of core where dummy atoms are replaced by
+  // the atomic number of the respective matching atom in mol
+  std::unique_ptr<ROMol> replaceCoreDummiesWithMolMatches(
+      const ROMol &mol, const MatchVectType &match) const {
+    std::unique_ptr<ROMol> coreReplacedDummies(new ROMol(*core));
+    for (const auto &p : match) {
+      auto a = coreReplacedDummies->getAtomWithIdx(p.first);
+      if (!a->getAtomicNum() && !a->hasProp(RLABEL)) {
+        a->setAtomicNum(mol.getAtomWithIdx(p.second)->getAtomicNum());
+      }
+    }
+    return coreReplacedDummies;
+  }
 };
 
 }  // namespace RDKit

--- a/Code/GraphMol/RGroupDecomposition/RGroupDecomp.cpp
+++ b/Code/GraphMol/RGroupDecomposition/RGroupDecomp.cpp
@@ -173,15 +173,21 @@ int RGroupDecomposition::add(const ROMol &inmol) {
 
   std::vector<RGroupMatch> potentialMatches;
 
+  std::unique_ptr<ROMol> tMol;
+  std::unique_ptr<ROMol> coreCopy;
   for (auto &tmatche : tmatches) {
-    boost::scoped_ptr<ROMol> tMol;
-    {
-      const bool replaceDummies = false;
-      const bool labelByIndex = true;
-      const bool requireDummyMatch = false;
-      tMol.reset(replaceCore(mol, *rcore->core, tmatche, replaceDummies,
-                             labelByIndex, requireDummyMatch));
+    const bool replaceDummies = false;
+    const bool labelByIndex = true;
+    const bool requireDummyMatch = false;
+    coreCopy.reset(new ROMol(*rcore->core));
+    for (const auto &p : tmatche) {
+      auto a = coreCopy->getAtomWithIdx(p.first);
+      if (!a->getAtomicNum() && !a->hasProp(RLABEL)) {
+        a->setAtomicNum(mol.getAtomWithIdx(p.second)->getAtomicNum());
+      }
     }
+    tMol.reset(replaceCore(mol, *coreCopy, tmatche, replaceDummies,
+                           labelByIndex, requireDummyMatch));
 
     if (tMol) {
       R_DECOMP match;

--- a/Code/GraphMol/RGroupDecomposition/RGroupDecomp.cpp
+++ b/Code/GraphMol/RGroupDecomposition/RGroupDecomp.cpp
@@ -174,18 +174,12 @@ int RGroupDecomposition::add(const ROMol &inmol) {
   std::vector<RGroupMatch> potentialMatches;
 
   std::unique_ptr<ROMol> tMol;
-  std::unique_ptr<ROMol> coreCopy;
   for (auto &tmatche : tmatches) {
     const bool replaceDummies = false;
     const bool labelByIndex = true;
     const bool requireDummyMatch = false;
-    coreCopy.reset(new ROMol(*rcore->core));
-    for (const auto &p : tmatche) {
-      auto a = coreCopy->getAtomWithIdx(p.first);
-      if (!a->getAtomicNum() && !a->hasProp(RLABEL)) {
-        a->setAtomicNum(mol.getAtomWithIdx(p.second)->getAtomicNum());
-      }
-    }
+    std::unique_ptr<ROMol> coreCopy =
+        rcore->replaceCoreDummiesWithMolMatches(mol, tmatche);
     tMol.reset(replaceCore(mol, *coreCopy, tmatche, replaceDummies,
                            labelByIndex, requireDummyMatch));
 


### PR DESCRIPTION
It took me a bit to figure this out, even though the fix is actually simple.
See a description of the issue below.

```
import rdkit
rdkit.__version__
'2021.03.1dev1'

from rdkit import Chem
from rdkit.Chem.Draw import MolsToGridImage
from rdkit.Chem import rdDepictor, rdRGroupDecomposition

core_molblock = """
     RDKit          2D

 10 10  0  0  0  0  0  0  0  0999 V2000
   -3.6689   -0.8582    0.0000 R#  0  0  0  0  0  1  0  0  0  0  0  0
   -2.2421   -1.3211    0.0000 N   0  0  0  0  0  0  0  0  0  0  0  0
   -1.1279   -0.3169    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
   -1.4403    1.1502    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
   -0.3261    2.1543    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
    1.1007    1.6914    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
    1.4132    0.2243    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
    0.2989   -0.7798    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
    2.8400   -0.2386    0.0000 Q   0  0  0  0  0  0  0  0  0  0  0  0
    3.1525   -1.7057    0.0000 R#  0  0  0  0  0  1  0  0  0  0  0  0
  1  2  1  0
  2  3  1  0
  3  4  2  0
  4  5  1  0
  5  6  2  0
  6  7  1  0
  7  8  2  0
  7  9  1  0
  9 10  1  0
  8  3  1  0
M  RGP  2   1   1  10   2
M  END
$$$$
"""

core = Chem.MolFromMolBlock(core_molblock)
mol = Chem.MolFromSmiles("CNc1cccc(c1)OC1CCC1")
MolsToGridImage([core, mol])
```

The core bears a query atom adjacent to one of the R-group labels:
![image](https://user-images.githubusercontent.com/5244385/98136412-31535b80-1ec1-11eb-9f98-3c2e6ef3df98.png)

```
ps = rdRGroupDecomposition.RGroupDecompositionParameters()                                                                                                  
ps.removeHydrogensPostMatch = True
ps.onlyMatchAtRGroups = True
rgd = rdRGroupDecomposition.RGroupDecomposition(core, ps)
rgd.Add(mol)
0
rgd.Process()
True
rgd.GetRGroupsAsColumns(asSmiles=True)
{'Core': ['*(c1cccc(N[*:1])c1)[*:2]'], 'R1': ['C[*:1]']}
```

The `R2` group has not been extracted.

If we replace the query atom with an oxygen atom, we get the expected result:

```
core_molblock_noquery = core_molblock.replace("Q  ", "O  ")
core_noquery = Chem.MolFromMolBlock(core_molblock_noquery)
rgd = rdRGroupDecomposition.RGroupDecomposition(core_noquery, ps)
rgd.Add(mol)
0
rgd.Process()
True
rgd.GetRGroupsAsColumns(asSmiles=True)
{'Core': ['c1cc(N[*:1])cc(O[*:2])c1'],
 'R1': ['C[*:1]'],
 'R2': ['C1CC([*:2])C1']}
```

The reason is that `replaceCore()` is called with `replaceDummies=false`, and therefore will not replace dummy atoms in the core, which is what we want for dummies used as R-group labels, but not for adjacent dummies used as queries. In fact, this will cause the oxygen atom to stay in the R-group fragment, thus causing the RGD to fail.

This PR fixes the problem with no side effects by setting the atomic number of the core dummies which are not R-group labels to the atomic number  of the matching atom in the molecule in `RGroupDecomposition::add`:

```
import rdkit
rdkit.__version__
'2021.03.1dev1'

from rdkit import Chem
from rdkit.Chem.Draw import MolsToGridImage
from rdkit.Chem import rdDepictor, rdRGroupDecomposition

core_molblock = """
     RDKit          2D

 10 10  0  0  0  0  0  0  0  0999 V2000
   -3.6689   -0.8582    0.0000 R#  0  0  0  0  0  1  0  0  0  0  0  0
   -2.2421   -1.3211    0.0000 N   0  0  0  0  0  0  0  0  0  0  0  0
   -1.1279   -0.3169    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
   -1.4403    1.1502    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
   -0.3261    2.1543    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
    1.1007    1.6914    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
    1.4132    0.2243    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
    0.2989   -0.7798    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
    2.8400   -0.2386    0.0000 Q   0  0  0  0  0  0  0  0  0  0  0  0
    3.1525   -1.7057    0.0000 R#  0  0  0  0  0  1  0  0  0  0  0  0
  1  2  1  0
  2  3  1  0
  3  4  2  0
  4  5  1  0
  5  6  2  0
  6  7  1  0
  7  8  2  0
  7  9  1  0
  9 10  1  0
  8  3  1  0
M  RGP  2   1   1  10   2
M  END
$$$$
"""

core = Chem.MolFromMolBlock(core_molblock)
mol = Chem.MolFromSmiles("CNc1cccc(c1)OC1CCC1")
MolsToGridImage([core, mol])
```

The core bears a query atom adjacent to one of the R-group labels:
![image](https://user-images.githubusercontent.com/5244385/98136412-31535b80-1ec1-11eb-9f98-3c2e6ef3df98.png)

```
ps = rdRGroupDecomposition.RGroupDecompositionParameters()                                                                                                  
ps.removeHydrogensPostMatch = True
ps.onlyMatchAtRGroups = True
rgd = rdRGroupDecomposition.RGroupDecomposition(core, ps)
rgd.Add(mol)
0
rgd.Process()
True
rgd.GetRGroupsAsColumns(asSmiles=True)
{'Core': ['*(c1cccc(N[*:1])c1)[*:2]'],
 'R1': ['C[*:1]'],
 'R2': ['C1CC([*:2])C1']}
```

This time the `R2` group was correctly extracted.
If we replace the query atom with an oxygen atom, we still get the expected result:

```
core_molblock_noquery = core_molblock.replace("Q  ", "O  ")
core_noquery = Chem.MolFromMolBlock(core_molblock_noquery)
rgd = rdRGroupDecomposition.RGroupDecomposition(core_noquery, ps)
rgd.Add(mol)
0
rgd.Process()
True
rgd.GetRGroupsAsColumns(asSmiles=True)
{'Core': ['c1cc(N[*:1])cc(O[*:2])c1'],
 'R1': ['C[*:1]'],
 'R2': ['C1CC([*:2])C1']}
```
