### PR TITLE
correct handling of amide distances for macrocycles

### DIFF
--- a/Code/GraphMol/DistGeomHelpers/Wrap/rdDistGeom.cpp
+++ b/Code/GraphMol/DistGeomHelpers/Wrap/rdDistGeom.cpp
@@ -121,7 +121,8 @@ INT_VECT EmbedMultipleConfs2(ROMol &mol, unsigned int numConfs,
 
 PyObject *getMolBoundsMatrix(ROMol &mol, bool set15bounds = true,
                              bool scaleVDW = false,
-                             bool doTriangleSmoothing = true) {
+                             bool doTriangleSmoothing = true,
+			     bool useMacrocycle14config = false) {
   unsigned int nats = mol.getNumAtoms();
   npy_intp dims[2];
   dims[0] = nats;
@@ -129,7 +130,7 @@ PyObject *getMolBoundsMatrix(ROMol &mol, bool set15bounds = true,
 
   DistGeom::BoundsMatPtr mat(new DistGeom::BoundsMatrix(nats));
   DGeomHelpers::initBoundsMat(mat);
-  DGeomHelpers::setTopolBounds(mol, mat, set15bounds, scaleVDW);
+  DGeomHelpers::setTopolBounds(mol, mat, set15bounds, scaleVDW, useMacrocycle14config);
   if (doTriangleSmoothing) {
     DistGeom::triangleSmoothBounds(mat);
   }
@@ -499,6 +500,7 @@ BOOST_PYTHON_MODULE(rdDistGeom) {
   python::def("GetMoleculeBoundsMatrix", RDKit::getMolBoundsMatrix,
               (python::arg("mol"), python::arg("set15bounds") = true,
                python::arg("scaleVDW") = false,
-               python::arg("doTriangleSmoothing") = true),
+               python::arg("doTriangleSmoothing") = true,
+               python::arg("useMacrocycle14config") = false),
               docString.c_str());
 }

--- a/Code/GraphMol/DistGeomHelpers/Wrap/testDistGeom.py
+++ b/Code/GraphMol/DistGeomHelpers/Wrap/testDistGeom.py
@@ -13,6 +13,7 @@ from rdkit.Chem import rdDistGeom, ChemicalForceFields, rdMolAlign
 import rdkit.DistanceGeometry as DG
 from rdkit import RDConfig, rdBase
 from rdkit.Geometry import rdGeometry as geom
+from rdkit.Geometry import ComputeSignedDihedralAngle
 from rdkit.RDLogger import logger
 logger = logger()
 
@@ -583,6 +584,34 @@ class TestCase(unittest.TestCase):
             self.assertTrue((conf2.GetAtomPosition(3)-conf2.GetAtomPosition(0)).Length() > (conf1.GetAtomPosition(3)-conf1.GetAtomPosition(0)).Length())
 
         
+    def testETKDGv3amide(self):
+        """
+        test for a macrocycle molecule, ETKDGv3 samples trans amide
+        """
+        def get_atom_mapping(mol, smirks = "[O:1]=[C:2]@;-[NX3:3]-[H:4]"):
+            qmol = Chem.MolFromSmarts(smirks)
+            ind_map = {}
+            for atom in qmol.GetAtoms():
+                map_num = atom.GetAtomMapNum()
+                if map_num:
+                    ind_map[map_num - 1] = atom.GetIdx()
+            map_list = [ind_map[x] for x in sorted(ind_map)]
+            matches = list()
+            for match in mol.GetSubstructMatches(qmol, uniquify = False) :
+                mas = [match[x] for x in map_list]
+                matches.append(tuple(mas))
+            return matches
+
+        smiles = "C1CCC(=O)NCCCCCC(=O)NC1"
+        smiles_mol = Chem.MolFromSmiles(smiles)
+        mol = Chem.AddHs(smiles_mol)
+        params = AllChem.ETKDGv3()
+        params.seed = 42
+        AllChem.EmbedMolecule(mol, params)
+        conf = mol.GetConformer(0)
+        for torsion in get_atom_mapping(mol):
+            a1,a2,a3,a4 = [conf.GetAtomPosition(i) for i in torsion]
+            self.assertAlmostEqual(abs(ComputeSignedDihedralAngle(a1,a2,a3,a4)), 3.14, delta = 0.05)
 
 
 if __name__ == '__main__':

--- a/Code/GraphMol/DistGeomHelpers/Wrap/testDistGeom.py
+++ b/Code/GraphMol/DistGeomHelpers/Wrap/testDistGeom.py
@@ -611,7 +611,7 @@ class TestCase(unittest.TestCase):
         conf = mol.GetConformer(0)
         for torsion in get_atom_mapping(mol):
             a1,a2,a3,a4 = [conf.GetAtomPosition(i) for i in torsion]
-            self.assertAlmostEqual(abs(ComputeSignedDihedralAngle(a1,a2,a3,a4)), 3.14, delta = 0.05)
+            self.assertAlmostEqual(abs(ComputeSignedDihedralAngle(a1,a2,a3,a4)), 3.14, delta = 0.1)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR is a patch to the previous [PR I submitted for macrocycle conformer generation](https://github.com/rdkit/rdkit/pull/2999) in order to get the trans preference behaviour when sampling amides in macrocycles. 

In the previous PR, I only forced trans configuration of amides when the three consecutive bonds are all ring bonds (in the function `_setMacrocycleAllInSameRing14Bounds`).

However, another enforcing is needed when faced with two consecutive ring bonds(in the function `_setMacrocycleTwoInSameRing14Bounds`), which was included during my [code development](https://github.com/rinikerlab/RDKit_mETKDG/blob/master/modified_rdkit/Code/GraphMol/DistGeomHelpers/BoundsMatrixBuilder.cpp#L884) and I (carelessly) neglected to add in that PR. 

This PR adds two more variants of the `checkAmideEster14`, please see illustration in the comment section above each of the two functions to understand the need for them.

In addition I also included:
- a test case for checking trans amide sampling when using macrocycle conformer generation (ETKDGv3)
- additional argument (`useMacrocycle14config`) when getting the bounds matrix of a molecule, which is needed when trying to set custom bounds matrix in order to bias sampling of macrocycles with amides



