### PR TITLE
Fixes #3540

### DIFF
--- a/Code/GraphMol/MolDraw2D/MolDraw2DCairo.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DCairo.cpp
@@ -167,7 +167,7 @@ void MolDraw2DCairo::drawPolygon(const std::vector<Point2D> &cds) {
 void MolDraw2DCairo::clearDrawing() {
   PRECONDITION(dp_cr, "no draw context");
   setColour(drawOptions().backgroundColour);
-  cairo_rectangle(dp_cr, 0, 0, width(), height());
+  cairo_rectangle(dp_cr, offset().x, offset().y, width(), height());
   cairo_fill(dp_cr);
 }
 

--- a/Code/GraphMol/MolDraw2D/MolDraw2DJS.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DJS.cpp
@@ -133,9 +133,9 @@ void MolDraw2DJS::drawEllipse(const Point2D &cds1, const Point2D &cds2) {
 // ****************************************************************************
 void MolDraw2DJS::clearDrawing() {
   std::string col = DrawColourToSVG(drawOptions().backgroundColour);
-  d_context.call<void>("clearRect", 0, 0, width(), height());
+  d_context.call<void>("clearRect", offset().x, offset().y, width(), height());
   d_context.set("fillStyle", col);
-  d_context.call<void>("fillRect", 0, 0, width(), height());
+  d_context.call<void>("fillRect", offset().x, offset().y, width(), height());
 }
 
 }  // namespace RDKit

--- a/Code/GraphMol/MolDraw2D/MolDraw2DQt.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DQt.cpp
@@ -103,7 +103,7 @@ void MolDraw2DQt::clearDrawing() {
                   int(255.0 * drawOptions().backgroundColour.a));
 
   qp_.setBackground(QBrush(this_col));
-  qp_.fillRect(0, 0, width(), height(), this_col);
+  qp_.fillRect(offset().x, offset().y, width(), height(), this_col);
 }
 
 // ****************************************************************************

--- a/Code/GraphMol/MolDraw2D/MolDraw2DSVG.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DSVG.cpp
@@ -298,7 +298,7 @@ void MolDraw2DSVG::clearDrawing() {
   d_os << "<rect";
   d_os << " style='opacity:1.0;fill:" << col << ";stroke:none'";
   d_os << " width='" << width() << "' height='" << height() << "'";
-  d_os << " x='0' y='0'";
+  d_os << " x='" << offset().x << "' y='" << offset().y << "'";
   d_os << "> </rect>\n";
 }
 


### PR DESCRIPTION
The `clearDrawing()` methods were not taking the `offset` into account when clearing the background prior to drawing the molecule. This PR fixes that.