### PR TITLE
A couple changes to speedup bulk similarity calculations from Python

### DIFF
--- a/Code/DataStructs/Wrap/testBV.py
+++ b/Code/DataStructs/Wrap/testBV.py
@@ -325,21 +325,18 @@ class TestCase(unittest.TestCase):
             bvs.append(bv)
         qs = bvs[:10]
         db = bvs[10:]
-        tgts = []
-        for q in qs:
-            sims = DataStructs.BulkTanimotoSimilarity(q,db)
-            sim, idx = max((sim, -idx) for idx, sim in enumerate(sims))
-            tgts.append((-idx,sim))
-        nbrs = DataStructs.TanimotoSimilarityNeighbors(qs,db)
-        self.assertEqual(tgts,nbrs)
-
-        tgts = []
-        for q in qs:
-            sims = DataStructs.BulkSokalSimilarity(q,db)
-            sim, idx = max((sim, -idx) for idx, sim in enumerate(sims))
-            tgts.append((-idx,sim))
-        nbrs = DataStructs.SokalSimilarityNeighbors(qs,db)
-        self.assertEqual(tgts,nbrs)
+        for metric in ['Tanimoto','Cosine', 'Kulczynski', 'Dice', 'Sokal', 
+                       'McConnaughey', 'Asymmetric', 'BraunBlanquet', 'Russel', 
+                       'RogotGoldberg']:
+            bulkSim = getattr(DataStructs,f'Bulk{metric}Similarity')
+            nbrSim = getattr(DataStructs,f'{metric}SimilarityNeighbors')
+            tgts = []
+            for q in qs:
+                sims = bulkSim(q,db)
+                sim, idx = max((sim, -idx) for idx, sim in enumerate(sims))
+                tgts.append((-idx,sim))
+            nbrs = nbrSim(qs,db)
+            self.assertEqual(tgts,nbrs)
 
 
 if __name__ == '__main__':

--- a/Code/DataStructs/Wrap/testBV.py
+++ b/Code/DataStructs/Wrap/testBV.py
@@ -87,7 +87,7 @@ class TestCase(unittest.TestCase):
         nbits = 10
         bv1 = DataStructs.ExplicitBitVect(nbits)
         bv1[0]
-        with self.assertRaisesRegexp(IndexError, ""):
+        with self.assertRaisesRegex(IndexError, ""):
             bv1[11]
 
     def test4OnBitsInCommon(self):
@@ -312,6 +312,34 @@ class TestCase(unittest.TestCase):
             self.assertTrue(feq(sim, sims[i]))
             sim = DataStructs.DiceSimilarity(bvs[0], bvs[i])
             self.assertTrue(feq(sim, sims[i]))
+
+
+    def test11BulkNeighbors(self):
+        nbits = 2048
+        bvs = []
+        for bvi in range(1000):
+            bv = DataStructs.ExplicitBitVect(nbits)
+            for j in range(nbits):
+                x = random.randrange(0, nbits)
+                bv.SetBit(x)
+            bvs.append(bv)
+        qs = bvs[:10]
+        db = bvs[10:]
+        tgts = []
+        for q in qs:
+            sims = DataStructs.BulkTanimotoSimilarity(q,db)
+            sim, idx = max((sim, -idx) for idx, sim in enumerate(sims))
+            tgts.append((-idx,sim))
+        nbrs = DataStructs.TanimotoSimilarityNeighbors(qs,db)
+        self.assertEqual(tgts,nbrs)
+
+        tgts = []
+        for q in qs:
+            sims = DataStructs.BulkSokalSimilarity(q,db)
+            sim, idx = max((sim, -idx) for idx, sim in enumerate(sims))
+            tgts.append((-idx,sim))
+        nbrs = DataStructs.SokalSimilarityNeighbors(qs,db)
+        self.assertEqual(tgts,nbrs)
 
 
 if __name__ == '__main__':

--- a/Code/DataStructs/Wrap/wrap_BitOps.cpp
+++ b/Code/DataStructs/Wrap/wrap_BitOps.cpp
@@ -1,6 +1,5 @@
-// $Id$
 //
-//  Copyright (C) 2003-2012 greg Landrum and Rational Discovery LLC
+//  Copyright (C) 2003-2020 greg Landrum and Rational Discovery LLC
 //
 //  @@ All Rights Reserved @@
 //  This file is part of the RDKit.

--- a/Code/DataStructs/Wrap/wrap_BitOps.cpp
+++ b/Code/DataStructs/Wrap/wrap_BitOps.cpp
@@ -30,7 +30,7 @@ python::object BVToBinaryText(const T &bv) {
       python::handle<>(PyBytes_FromStringAndSize(res.c_str(), res.length())));
   return retval;
 }
-}
+}  // namespace
 
 template <typename T>
 double SimilarityWrapper(const T &bv1, const std::string &pkl,
@@ -49,44 +49,95 @@ double SimilarityWrapper(const T &bv1, const std::string &pkl, double a,
 }
 
 template <typename T>
-python::list BulkWrapper(const T &bv1, python::object bvs,
+python::list NeighborWrapper(python::object queries, python::object bvs,
+                             double (*metric)(const T &, const T &)) {
+  python::list res;
+  unsigned int nbvs = python::extract<unsigned int>(bvs.attr("__len__")());
+  unsigned int nqs = python::extract<unsigned int>(queries.attr("__len__")());
+  for (unsigned int i = 0; i < nqs; ++i) {
+    const T *bv1 = python::extract<const T *>(queries[i])();
+    double closest = -1;
+    unsigned nbr;
+    for (unsigned int j = 0; j < nbvs; ++j) {
+      const T *bv2 = python::extract<const T *>(bvs[j])();
+      auto sim = metric(*bv1, *bv2);
+      if (sim > closest) {
+        closest = sim;
+        nbr = j;
+      }
+    }
+    res.append(python::make_tuple(nbr, closest));
+  }
+  return res;
+}
+
+template <typename T>
+python::list BulkWrapper(const T *bv1, python::object bvs,
                          double (*metric)(const T &, const T &),
                          bool returnDistance) {
   python::list res;
   unsigned int nbvs = python::extract<unsigned int>(bvs.attr("__len__")());
   for (unsigned int i = 0; i < nbvs; ++i) {
-    const T &bv2 = python::extract<T>(bvs[i])();
-    res.append(SimilarityWrapper(bv1, bv2, metric, returnDistance));
+    const T *bv2 = python::extract<const T *>(bvs[i])();
+    auto sim = metric(*bv1, *bv2);
+    if (returnDistance) {
+      sim = 1.0 - sim;
+    }
+    res.append(sim);
   }
   return res;
 }
 
 template <typename T>
-python::list BulkWrapper(const T &bv1, python::object bvs, double a, double b,
+python::list BulkWrapper(const T *bv1, python::object bvs, double a, double b,
                          double (*metric)(const T &, const T &, double, double),
                          bool returnDistance) {
   python::list res;
   unsigned int nbvs = python::extract<unsigned int>(bvs.attr("__len__")());
   for (unsigned int i = 0; i < nbvs; ++i) {
-    const T &bv2 = python::extract<T>(bvs[i])();
-    res.append(SimilarityWrapper(bv1, bv2, a, b, metric, returnDistance));
+    const T *bv2 = python::extract<T *>(bvs[i])();
+    auto sim = metric(*bv1, *bv2, a, b);
+    if (returnDistance) {
+      sim = 1.0 - sim;
+    }
+    res.append(sim);
   }
   return res;
 }
 
-template <typename T1, typename T2>
-double TanimotoSimilarity_w(const T1 &bv1, const T2 &bv2, bool returnDistance) {
-  return SimilarityWrapper(
-      bv1, bv2, (double (*)(const T1 &, const T1 &))TanimotoSimilarity,
-      returnDistance);
-}
-template <typename T>
-python::list BulkTanimotoSimilarity(const T &bv1, python::object bvs,
-                                    bool returnDistance) {
-  return BulkWrapper(bv1, bvs,
-                     (double (*)(const T &, const T &))TanimotoSimilarity,
-                     returnDistance);
-}
+#define METRIC_DEFS(_metricname_)                                              \
+  template <typename T1, typename T2>                                          \
+  double _metricname_##_w(const T1 &bv1, const T2 &bv2, bool returnDistance) { \
+    return SimilarityWrapper(bv1, bv2,                                         \
+                             (double (*)(const T1 &, const T1 &))_metricname_, \
+                             returnDistance);                                  \
+  }                                                                            \
+  template <typename T>                                                        \
+  python::list Bulk##_metricname_(const T *bv1, python::object bvs,            \
+                                  bool returnDistance) {                       \
+    return BulkWrapper(bv1, bvs,                                               \
+                       (double (*)(const T &, const T &))_metricname_,         \
+                       returnDistance);                                        \
+  }                                                                            \
+  template <typename T>                                                        \
+  python::list _metricname_##Neighbors(python::object queries,                 \
+                                       python::object bvs) {                   \
+    return NeighborWrapper(queries, bvs,                                       \
+                           (double (*)(const T &, const T &))_metricname_);    \
+  }
+
+METRIC_DEFS(TanimotoSimilarity)
+METRIC_DEFS(CosineSimilarity)
+METRIC_DEFS(KulczynskiSimilarity)
+METRIC_DEFS(DiceSimilarity)
+METRIC_DEFS(SokalSimilarity)
+METRIC_DEFS(McConnaugheySimilarity)
+METRIC_DEFS(AsymmetricSimilarity)
+METRIC_DEFS(BraunBlanquetSimilarity)
+METRIC_DEFS(RusselSimilarity)
+METRIC_DEFS(RogotGoldbergSimilarity)
+METRIC_DEFS(OnBitSimilarity)
+METRIC_DEFS(AllBitSimilarity)
 
 template <typename T1, typename T2>
 double TverskySimilarity_w(const T1 &bv1, const T2 &bv2, double a, double b,
@@ -97,156 +148,12 @@ double TverskySimilarity_w(const T1 &bv1, const T2 &bv2, double a, double b,
       returnDistance);
 }
 template <typename T>
-python::list BulkTverskySimilarity(const T &bv1, python::object bvs, double a,
+python::list BulkTverskySimilarity(const T *bv1, python::object bvs, double a,
                                    double b, bool returnDistance) {
-  return BulkWrapper(bv1, bvs, a, b, (double (*)(const T &, const T &, double,
-                                                 double))TverskySimilarity,
-                     returnDistance);
-}
-
-template <typename T1, typename T2>
-double CosineSimilarity_w(const T1 &bv1, const T2 &bv2, bool returnDistance) {
-  return SimilarityWrapper(bv1, bv2,
-                           (double (*)(const T1 &, const T1 &))CosineSimilarity,
-                           returnDistance);
-}
-template <typename T>
-python::list BulkCosineSimilarity(const T &bv1, python::object bvs,
-                                  bool returnDistance) {
-  return BulkWrapper(bv1, bvs,
-                     (double (*)(const T &, const T &))CosineSimilarity,
-                     returnDistance);
-}
-
-template <typename T1, typename T2>
-double KulczynskiSimilarity_w(const T1 &bv1, const T2 &bv2,
-                              bool returnDistance) {
-  return SimilarityWrapper(
-      bv1, bv2, (double (*)(const T1 &, const T1 &))KulczynskiSimilarity,
+  return BulkWrapper(
+      bv1, bvs, a, b,
+      (double (*)(const T &, const T &, double, double))TverskySimilarity,
       returnDistance);
-}
-template <typename T>
-python::list BulkKulczynskiSimilarity(const T &bv1, python::object bvs,
-                                      bool returnDistance) {
-  return BulkWrapper(bv1, bvs,
-                     (double (*)(const T &, const T &))KulczynskiSimilarity,
-                     returnDistance);
-}
-
-template <typename T1, typename T2>
-double DiceSimilarity_w(const T1 &bv1, const T2 &bv2, bool returnDistance) {
-  return SimilarityWrapper(bv1, bv2,
-                           (double (*)(const T1 &, const T1 &))DiceSimilarity,
-                           returnDistance);
-}
-template <typename T>
-python::list BulkDiceSimilarity(const T &bv1, python::object bvs,
-                                bool returnDistance) {
-  return BulkWrapper(bv1, bvs, (double (*)(const T &, const T &))DiceSimilarity,
-                     returnDistance);
-}
-
-template <typename T1, typename T2>
-double SokalSimilarity_w(const T1 &bv1, const T2 &bv2, bool returnDistance) {
-  return SimilarityWrapper(bv1, bv2,
-                           (double (*)(const T1 &, const T1 &))SokalSimilarity,
-                           returnDistance);
-}
-template <typename T>
-python::list BulkSokalSimilarity(const T &bv1, python::object bvs,
-                                 bool returnDistance) {
-  return BulkWrapper(bv1, bvs,
-                     (double (*)(const T &, const T &))SokalSimilarity,
-                     returnDistance);
-}
-
-template <typename T1, typename T2>
-double McConnaugheySimilarity_w(const T1 &bv1, const T2 &bv2,
-                                bool returnDistance) {
-  return SimilarityWrapper(
-      bv1, bv2, (double (*)(const T1 &, const T1 &))McConnaugheySimilarity,
-      returnDistance);
-}
-template <typename T>
-python::list BulkMcConnaugheySimilarity(const T &bv1, python::object bvs,
-                                        bool returnDistance) {
-  return BulkWrapper(bv1, bvs,
-                     (double (*)(const T &, const T &))McConnaugheySimilarity,
-                     returnDistance);
-}
-
-template <typename T1, typename T2>
-double AsymmetricSimilarity_w(const T1 &bv1, const T2 &bv2,
-                              bool returnDistance) {
-  return SimilarityWrapper(
-      bv1, bv2, (double (*)(const T1 &, const T1 &))AsymmetricSimilarity,
-      returnDistance);
-}
-template <typename T>
-python::list BulkAsymmetricSimilarity(const T &bv1, python::object bvs,
-                                      bool returnDistance) {
-  return BulkWrapper(bv1, bvs,
-                     (double (*)(const T &, const T &))AsymmetricSimilarity,
-                     returnDistance);
-}
-
-template <typename T1, typename T2>
-double BraunBlanquetSimilarity_w(const T1 &bv1, const T2 &bv2,
-                                 bool returnDistance) {
-  return SimilarityWrapper(
-      bv1, bv2, (double (*)(const T1 &, const T1 &))BraunBlanquetSimilarity,
-      returnDistance);
-}
-template <typename T>
-python::list BulkBraunBlanquetSimilarity(const T &bv1, python::object bvs,
-                                         bool returnDistance) {
-  return BulkWrapper(bv1, bvs,
-                     (double (*)(const T &, const T &))BraunBlanquetSimilarity,
-                     returnDistance);
-}
-
-template <typename T1, typename T2>
-double RusselSimilarity_w(const T1 &bv1, const T2 &bv2, bool returnDistance) {
-  return SimilarityWrapper(bv1, bv2,
-                           (double (*)(const T1 &, const T1 &))RusselSimilarity,
-                           returnDistance);
-}
-template <typename T>
-python::list BulkRusselSimilarity(const T &bv1, python::object bvs,
-                                  bool returnDistance) {
-  return BulkWrapper(bv1, bvs,
-                     (double (*)(const T &, const T &))RusselSimilarity,
-                     returnDistance);
-}
-
-template <typename T1, typename T2>
-double RogotGoldbergSimilarity_w(const T1 &bv1, const T2 &bv2,
-                                 bool returnDistance) {
-  return SimilarityWrapper(
-      bv1, bv2, (double (*)(const T1 &, const T1 &))RogotGoldbergSimilarity,
-      returnDistance);
-}
-template <typename T>
-python::list BulkRogotGoldbergSimilarity(const T &bv1, python::object bvs,
-                                         bool returnDistance) {
-  return BulkWrapper(bv1, bvs,
-                     (double (*)(const T &, const T &))RogotGoldbergSimilarity,
-                     returnDistance);
-}
-
-template <typename T>
-python::list BulkOnBitSimilarity(const T &bv1, python::object bvs,
-                                 bool returnDistance) {
-  return BulkWrapper(bv1, bvs,
-                     (double (*)(const T &, const T &))OnBitSimilarity,
-                     returnDistance);
-}
-template <typename T>
-python::list BulkAllBitSimilarity(const T &bv1, python::object bvs,
-                                  bool returnDistance) {
-  return BulkWrapper(bv1, bvs,
-                     (double (*)(const T &, const T &))AllBitSimilarity,
-                     returnDistance);
 }
 
 #define DBL_DEF(_funcname_, _bulkname_, _help_)                                \
@@ -255,15 +162,17 @@ python::list BulkAllBitSimilarity(const T &bv1, python::object bvs,
                 (python::args("v1"), python::args("v2")));                     \
     python::def(#_funcname_, (double (*)(const EBV &, const EBV &))_funcname_, \
                 (python::args("v1"), python::args("v2")), _help_);             \
-    python::def(#_bulkname_, (python::list (*)(const EBV &, python::object,    \
-                                               bool))_bulkname_,               \
-                (python::args("v1"), python::args("v2"),                       \
-                 python::args("returnDistance") = 0));                         \
-    python::def(#_bulkname_, (python::list (*)(const EBV &, python::object,    \
-                                               bool))_bulkname_,               \
-                (python::args("v1"), python::args("v2"),                       \
-                 python::args("returnDistance") = 0),                          \
-                _help_);                                                       \
+    python::def(                                                               \
+        #_bulkname_,                                                           \
+        (python::list(*)(const EBV *, python::object, bool))_bulkname_,        \
+        (python::args("v1"), python::args("v2"),                               \
+         python::args("returnDistance") = 0));                                 \
+    python::def(                                                               \
+        #_bulkname_,                                                           \
+        (python::list(*)(const EBV *, python::object, bool))_bulkname_,        \
+        (python::args("v1"), python::args("v2"),                               \
+         python::args("returnDistance") = 0),                                  \
+        _help_);                                                               \
   }
 
 #define BIG_DEF(_funcname_, _name_w_, _bulkname_, _help_)                     \
@@ -286,15 +195,25 @@ python::list BulkAllBitSimilarity(const T &bv1, python::object bvs,
                 (python::args("bv1"), python::args("pkl"),                    \
                  python::args("returnDistance") = 0),                         \
                 _help_);                                                      \
-    python::def(#_bulkname_, (python::list (*)(const SBV &, python::object,   \
-                                               bool))_bulkname_,              \
-                (python::args("bv1"), python::args("bvList"),                 \
-                 python::args("returnDistance") = 0));                        \
-    python::def(#_bulkname_, (python::list (*)(const EBV &, python::object,   \
-                                               bool))_bulkname_,              \
-                (python::args("bv1"), python::args("bvList"),                 \
-                 python::args("returnDistance") = 0),                         \
-                _help_);                                                      \
+    python::def(                                                              \
+        #_bulkname_,                                                          \
+        (python::list(*)(const SBV *, python::object, bool))_bulkname_,       \
+        (python::args("bv1"), python::args("bvList"),                         \
+         python::args("returnDistance") = 0));                                \
+    python::def(                                                              \
+        #_bulkname_,                                                          \
+        (python::list(*)(const EBV *, python::object, bool))_bulkname_,       \
+        (python::args("bv1"), python::args("bvList"),                         \
+         python::args("returnDistance") = 0),                                 \
+        _help_);                                                              \
+    python::def(#_funcname_ "Neighbors",                                      \
+                (python::list(*)(python::object, python::object))             \
+                    _funcname_##Neighbors<ExplicitBitVect>,                   \
+                (python::args("bvqueries"), python::args("bvList")), _help_); \
+    python::def(#_funcname_ "Neighbors_sparse",                               \
+                (python::list(*)(python::object, python::object))             \
+                    _funcname_##Neighbors<SparseBitVect>,                     \
+                (python::args("bvqueries"), python::args("bvList")), _help_); \
   }
 
 struct BitOps_wrapper {
@@ -350,14 +269,14 @@ struct BitOps_wrapper {
                   help.c_str());
       python::def(
           "BulkTverskySimilarity",
-          (python::list (*)(const SBV &, python::object, double, double,
-                            bool))BulkTverskySimilarity,
+          (python::list(*)(const SBV *, python::object, double, double,
+                           bool))BulkTverskySimilarity,
           (python::args("bv1"), python::args("bvList"), python::args("a"),
            python::args("b"), python::args("returnDistance") = 0));
       python::def(
           "BulkTverskySimilarity",
-          (python::list (*)(const EBV &, python::object, double, double,
-                            bool))BulkTverskySimilarity,
+          (python::list(*)(const EBV *, python::object, double, double,
+                           bool))BulkTverskySimilarity,
           (python::args("bv1"), python::args("bvList"), python::args("a"),
            python::args("b"), python::args("returnDistance") = 0),
           help.c_str());
@@ -368,15 +287,15 @@ struct BitOps_wrapper {
             "(B(bv1) - B(bv1^bv2)) / B(bv1)");
 
     python::def("OnBitProjSimilarity",
-                (DoubleVect (*)(const SBV &, const SBV &))OnBitProjSimilarity);
+                (DoubleVect(*)(const SBV &, const SBV &))OnBitProjSimilarity);
     python::def(
         "OnBitProjSimilarity",
-        (DoubleVect (*)(const EBV &, const EBV &))OnBitProjSimilarity,
+        (DoubleVect(*)(const EBV &, const EBV &))OnBitProjSimilarity,
         "Returns a 2-tuple: (B(bv1&bv2) / B(bv1), B(bv1&bv2) / B(bv2))");
     python::def("OffBitProjSimilarity",
-                (DoubleVect (*)(const SBV &, const SBV &))OffBitProjSimilarity);
+                (DoubleVect(*)(const SBV &, const SBV &))OffBitProjSimilarity);
     python::def("OffBitProjSimilarity",
-                (DoubleVect (*)(const EBV &, const EBV &))OffBitProjSimilarity);
+                (DoubleVect(*)(const EBV &, const EBV &))OffBitProjSimilarity);
 
     python::def("NumBitsInCommon",
                 (int (*)(const SBV &, const SBV &))NumBitsInCommon);
@@ -385,23 +304,23 @@ struct BitOps_wrapper {
                 "Returns the total number of bits in common between the two "
                 "bit vectors");
     python::def("OnBitsInCommon",
-                (IntVect (*)(const SBV &, const SBV &))OnBitsInCommon);
+                (IntVect(*)(const SBV &, const SBV &))OnBitsInCommon);
     python::def(
-        "OnBitsInCommon", (IntVect (*)(const EBV &, const EBV &))OnBitsInCommon,
+        "OnBitsInCommon", (IntVect(*)(const EBV &, const EBV &))OnBitsInCommon,
         "Returns the number of on bits in common between the two bit vectors");
     python::def("OffBitsInCommon",
-                (IntVect (*)(const SBV &, const SBV &))OffBitsInCommon);
+                (IntVect(*)(const SBV &, const SBV &))OffBitsInCommon);
     python::def(
         "OffBitsInCommon",
-        (IntVect (*)(const EBV &, const EBV &))OffBitsInCommon,
+        (IntVect(*)(const EBV &, const EBV &))OffBitsInCommon,
         "Returns the number of off bits in common between the two bit vectors");
 
     python::def("FoldFingerprint",
-                (SBV * (*)(const SBV &, unsigned int))FoldFingerprint,
+                (SBV * (*)(const SBV &, unsigned int)) FoldFingerprint,
                 (python::arg("bv"), python::arg("foldFactor") = 2),
                 python::return_value_policy<python::manage_new_object>());
     python::def("FoldFingerprint",
-                (EBV * (*)(const EBV &, unsigned int))FoldFingerprint,
+                (EBV * (*)(const EBV &, unsigned int)) FoldFingerprint,
                 (python::arg("bv"), python::arg("foldFactor") = 2),
                 python::return_value_policy<python::manage_new_object>(),
                 "Folds the fingerprint by the provided amount. The default, "
@@ -420,19 +339,19 @@ struct BitOps_wrapper {
         "Returns True if all bits in the first argument match all bits in the \n\
   vector defined by the pickle in the second argument.\n");
 
-    python::def("BitVectToText", (std::string (*)(const SBV &))BitVectToText);
+    python::def("BitVectToText", (std::string(*)(const SBV &))BitVectToText);
     python::def(
-        "BitVectToText", (std::string (*)(const EBV &))BitVectToText,
+        "BitVectToText", (std::string(*)(const EBV &))BitVectToText,
         "Returns a string of zeros and ones representing the bit vector.");
     python::def("BitVectToFPSText",
-                (std::string (*)(const SBV &))BitVectToFPSText);
+                (std::string(*)(const SBV &))BitVectToFPSText);
     python::def("BitVectToFPSText",
-                (std::string (*)(const EBV &))BitVectToFPSText,
+                (std::string(*)(const EBV &))BitVectToFPSText,
                 "Returns an FPS string representing the bit vector.");
     python::def("BitVectToBinaryText",
-                (python::object (*)(const SBV &))BVToBinaryText);
+                (python::object(*)(const SBV &))BVToBinaryText);
     python::def(
-        "BitVectToBinaryText", (python::object (*)(const EBV &))BVToBinaryText,
+        "BitVectToBinaryText", (python::object(*)(const EBV &))BVToBinaryText,
         "Returns a binary string (byte array) representing the bit vector.");
   }
 };


### PR DESCRIPTION
This makes a minor tweak to speed up calls to `BulkXSimilarity()` by about 10% and introduces new wrapper functions to find the nearest neighbors of a particular fingerprint in a list of other fingerprints.

Here's the performance impact:

| Action | master | this PR |
|----------|-----------|-----------|
| 10K calls to `BulkTanimotoSimilarity()` across ~36K fingerprints | 35.7s | 32.4s |
| find nearest neighbor in the 36K fingerprints for 3K fingerprints using `BulkTanimotoSimilarity()` and a Python sort | 20.0s | 18.7s |
| find nearest neighbor in the 36K fingerprints for 3K fingerprints using `TanimotoSimilarityNeighbors()` | N/A | 7.4s |

There's also a bit of refactoring to simplify `wrap_BitOps.cpp`