### PR TITLE
add a "comic mode" to MolDraw2D

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,6 +131,7 @@ string(REGEX REPLACE "^0" "" RDKit_intMonth ${RDKit_Month} )
 
 set(RDKit_CodeDir "${CMAKE_CURRENT_SOURCE_DIR}/Code")
 set(RDKit_ExternalDir "${CMAKE_CURRENT_SOURCE_DIR}/External")
+set(RDKit_DataDir "${CMAKE_CURRENT_SOURCE_DIR}/Data")
 
 #include catch
 add_subdirectory(${RDKit_ExternalDir}/catch)

--- a/Code/GraphMol/MolDraw2D/CMakeLists.txt
+++ b/Code/GraphMol/MolDraw2D/CMakeLists.txt
@@ -3,6 +3,24 @@ option(RDK_BUILD_QT_SUPPORT "build support for QT drawing" OFF )
 option(RDK_BUILD_QT_DEMO "build the QT drawing demo" OFF )
 option(RDK_BUILD_CAIRO_SUPPORT "build support for Cairo drawing" OFF )
 option(RDK_BUILD_FREETYPE_SUPPORT "build support for FreeType font handling" ON)
+option(RDK_INSTALL_COMIC_FONTS "download and install comic-neue to maximize the \"utility\" of the comic mode in MolDraw2D" ON)
+
+if(RDK_BUILD_FREETYPE_SUPPORT AND RDK_INSTALL_COMIC_FONTS)
+  set(needDownload "TRUE")
+  if(EXISTS "${RDKit_DataDir}/Fonts/ComicNeue-Regular.ttf")
+    message("${RDKit_DataDir}/Fonts/ComicNeue-Regular.ttf already there, skipping the download")
+    set(needDownload "FALSE")
+  endif()
+  if(needDownload)
+    set(MD5Sum "23ed3f833c1ae0adb141a26b4a30d73e")
+    downloadAndCheckMD5("https://fonts.google.com/download?family=Comic%20Neue"
+          "${CMAKE_CURRENT_SOURCE_DIR}/Comic_Neue.zip"
+          ${MD5Sum})
+    execute_process(COMMAND ${CMAKE_COMMAND} -E tar x
+      ${CMAKE_CURRENT_SOURCE_DIR}/Comic_Neue.zip --format=zip
+      WORKING_DIRECTORY ${RDKit_DataDir}/Fonts)
+  endif(needDownload)
+endif()
 
 rdkit_headers(MolDraw2D.h
   MolDraw2DSVG.h

--- a/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
@@ -1090,12 +1090,27 @@ void MolDraw2D::centrePicture(int width, int height) {
 
 namespace {
 // there are a several empirically determined constants here.
-std::vector<Point2D> handdrawnLine(const Point2D &cds1, const Point2D &cds2,
-                                   double scale, unsigned nSteps = 4,
-                                   double deviation = 0.03) {
+std::vector<Point2D> handdrawnLine(Point2D cds1, Point2D cds2, double scale,
+                                   bool shiftBegin = false,
+                                   bool shiftEnd = false, unsigned nSteps = 4,
+                                   double deviation = 0.03,
+                                   double endShift = 0.5) {
+  // std::cerr << "   " << scale << " " << endShift / scale << endl;
+  while (endShift / scale > 0.02) {
+    endShift *= 0.75;
+  }
+  if (shiftBegin) {
+    cds1.x += (std::rand() % 10 >= 5 ? endShift : -endShift) / scale;
+    cds1.y += (std::rand() % 10 >= 5 ? endShift : -endShift) / scale;
+  }
+  if (shiftEnd) {
+    cds2.x += (std::rand() % 10 >= 5 ? endShift : -endShift) / scale;
+    cds2.y += (std::rand() % 10 >= 5 ? endShift : -endShift) / scale;
+  }
+
   Point2D step = (cds2 - cds1) / nSteps;
   // make sure we aren't adding loads of wiggles to short lines
-  while (step.length() < 0.15 && nSteps > 2) {
+  while (step.length() < 0.2 && nSteps > 2) {
     --nSteps;
     step = (cds2 - cds1) / nSteps;
   }
@@ -1124,15 +1139,15 @@ void MolDraw2D::drawLine(const Point2D &cds1, const Point2D &cds2,
     setFillPolys(false);
     if (col1 == col2) {
       setColour(col1);
-      auto pts = handdrawnLine(cds1, cds2, scale_);
+      auto pts = handdrawnLine(cds1, cds2, scale_, true, true);
       drawPolygon(pts);
     } else {
       Point2D mid = (cds1 + cds2) * 0.5;
       setColour(col1);
-      auto pts = handdrawnLine(cds1, mid, scale_);
+      auto pts = handdrawnLine(cds1, mid, scale_, true, false);
       drawPolygon(pts);
       setColour(col2);
-      auto pts2 = handdrawnLine(mid, cds2, scale_);
+      auto pts2 = handdrawnLine(mid, cds2, scale_, false, true);
       drawPolygon(pts2);
     }
   } else {

--- a/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
@@ -1091,16 +1091,16 @@ void MolDraw2D::centrePicture(int width, int height) {
 namespace {
 // there are a several empirically determined constants here.
 std::vector<Point2D> handdrawnLine(const Point2D &cds1, const Point2D &cds2,
-                                   unsigned nSteps = 4,
+                                   double scale, unsigned nSteps = 4,
                                    double deviation = 0.03) {
   Point2D step = (cds2 - cds1) / nSteps;
   // make sure we aren't adding loads of wiggles to short lines
-  while (step.length() < 0.1 && nSteps > 2) {
+  while (step.length() < 0.15 && nSteps > 2) {
     --nSteps;
     step = (cds2 - cds1) / nSteps;
   }
   // make sure the wiggles aren't too big
-  while (deviation / step.length() > 0.15) {
+  while (deviation / step.length() > 0.15 || deviation * scale > 0.70) {
     deviation *= 0.75;
   }
   Point2D perp{step.y, -step.x};
@@ -1124,15 +1124,15 @@ void MolDraw2D::drawLine(const Point2D &cds1, const Point2D &cds2,
     setFillPolys(false);
     if (col1 == col2) {
       setColour(col1);
-      auto pts = handdrawnLine(cds1, cds2);
+      auto pts = handdrawnLine(cds1, cds2, scale_);
       drawPolygon(pts);
     } else {
       Point2D mid = (cds1 + cds2) * 0.5;
       setColour(col1);
-      auto pts = handdrawnLine(cds1, mid);
+      auto pts = handdrawnLine(cds1, mid, scale_);
       drawPolygon(pts);
       setColour(col2);
-      auto pts2 = handdrawnLine(mid, cds2);
+      auto pts2 = handdrawnLine(mid, cds2, scale_);
       drawPolygon(pts2);
     }
   } else {
@@ -2317,7 +2317,7 @@ void MolDraw2D::drawWedgedBond(const Point2D &cds1, const Point2D &cds2,
       Point2D e11 = cds1 + e1 * (rdcast<double>(i) / nDashes);
       Point2D e22 = cds1 + e2 * (rdcast<double>(i) / nDashes);
       if (drawOptions().comicMode) {
-        auto pts = handdrawnLine(e11, e22);
+        auto pts = handdrawnLine(e11, e22, scale_);
         drawPolygon(pts);
       } else {
         drawLine(e11, e22);
@@ -3392,11 +3392,11 @@ void MolDraw2D::drawTriangle(const Point2D &cds1, const Point2D &cds2,
   if (!drawOptions().comicMode) {
     pts = {cds1, cds2, cds3};
   } else {
-    auto lpts = handdrawnLine(cds1, cds2);
+    auto lpts = handdrawnLine(cds1, cds2, scale_);
     std::move(lpts.begin(), lpts.end(), std::back_inserter(pts));
-    lpts = handdrawnLine(cds2, cds3);
+    lpts = handdrawnLine(cds2, cds3, scale_);
     std::move(lpts.begin(), lpts.end(), std::back_inserter(pts));
-    lpts = handdrawnLine(cds3, cds1);
+    lpts = handdrawnLine(cds3, cds1, scale_);
     std::move(lpts.begin(), lpts.end(), std::back_inserter(pts));
   }
   drawPolygon(pts);

--- a/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
@@ -1089,38 +1089,20 @@ void MolDraw2D::centrePicture(int width, int height) {
 };
 
 namespace {
-void handdrawnLine1(MolDraw2D &d2d, const Point2D &cds1, const Point2D &cds2) {
-  unsigned nSteps = 50;
-  double deviation = 0.04;
-  Point2D step = (cds2 - cds1) / nSteps;
-  auto lastPos = cds1;
-  for (unsigned int i = 1; i < nSteps; ++i) {
-    auto tgt = cds1 + step * i;
-    tgt.x += deviation * (std::rand() % 20 - 10) / 10.0;
-    tgt.y += deviation * (std::rand() % 20 - 10) / 10.0;
-    d2d.drawLine(lastPos, tgt);
-    lastPos = tgt;
-  }
-}
-void handdrawnLine2(MolDraw2D &d2d, const Point2D &cds1, const Point2D &cds2) {
-  unsigned nSteps = 5;
-  double deviation = 0.03;
-  Point2D step = (cds2 - cds1) / nSteps;
-  std::vector<Point2D> pts;
-  pts.push_back(cds1);
-  for (unsigned int i = 1; i < nSteps; ++i) {
-    auto tgt = cds1 + step * i;
-    tgt.x += deviation * (std::rand() % 20 - 10) / 10.0;
-    tgt.y += deviation * (std::rand() % 20 - 10) / 10.0;
-    pts.push_back(tgt);
-  }
-  pts.push_back(cds2);
-  d2d.drawPolygon(pts);
-}
+// there are a several empirically determined constants here.
 std::vector<Point2D> handdrawnLine(const Point2D &cds1, const Point2D &cds2,
                                    unsigned nSteps = 4,
                                    double deviation = 0.03) {
   Point2D step = (cds2 - cds1) / nSteps;
+  // make sure we aren't adding loads of wiggles to short lines
+  while (step.length() < 0.1 && nSteps > 2) {
+    --nSteps;
+    step = (cds2 - cds1) / nSteps;
+  }
+  // make sure the wiggles aren't too big
+  while (deviation / step.length() > 0.15) {
+    deviation *= 0.75;
+  }
   Point2D perp{step.y, -step.x};
   perp.normalize();
   std::vector<Point2D> pts;

--- a/Code/GraphMol/MolDraw2D/MolDraw2D.h
+++ b/Code/GraphMol/MolDraw2D/MolDraw2D.h
@@ -255,6 +255,7 @@ struct RDKIT_MOLDRAW2D_EXPORT MolDrawOptions {
   bool includeMetadata =
       true;  // when possible include metadata about molecules and reactions in
              // the output to allow them to be reconstructed
+  bool comicMode = false;
 
   MolDrawOptions() {
     highlightColourPalette.emplace_back(

--- a/Code/GraphMol/MolDraw2D/MolDraw2D.h
+++ b/Code/GraphMol/MolDraw2D/MolDraw2D.h
@@ -255,7 +255,9 @@ struct RDKIT_MOLDRAW2D_EXPORT MolDrawOptions {
   bool includeMetadata =
       true;  // when possible include metadata about molecules and reactions in
              // the output to allow them to be reconstructed
-  bool comicMode = false;
+  bool comicMode = false;  // simulate hand-drawn lines for bonds. When combined
+                           // with a font like Comic-Sans or Comic-Neue, this
+                           // gives xkcd-like drawings.
 
   MolDrawOptions() {
     highlightColourPalette.emplace_back(

--- a/Code/GraphMol/MolDraw2D/MolDraw2DUtils.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DUtils.cpp
@@ -159,6 +159,7 @@ void updateDrawerParamsFromJSON(MolDraw2D &drawer, const std::string &json) {
   PT_OPT_GET(explicitMethyl);
   PT_OPT_GET(includeMetadata);
   PT_OPT_GET(includeRadicals);
+  PT_OPT_GET(comicMode);
 
   get_colour_option(&pt, "highlightColour", opts.highlightColour);
   get_colour_option(&pt, "backgroundColour", opts.backgroundColour);

--- a/Code/GraphMol/MolDraw2D/Wrap/rdMolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/Wrap/rdMolDraw2D.cpp
@@ -679,7 +679,11 @@ BOOST_PYTHON_MODULE(rdMolDraw2D) {
       .def_readwrite(
           "includeRadicals", &RDKit::MolDrawOptions::includeRadicals,
           "include radicals in the drawing (it can be useful to turn this off "
-          "for reactions and queries). Default is true.");
+          "for reactions and queries). Default is true.")
+      .def_readwrite("comicMode", &RDKit::MolDrawOptions::comicMode,
+                     "simulate hand-drawn lines for bonds. When combined with "
+                     "a font like Comic-Sans or Comic-Neue, this gives "
+                     "xkcd-like drawings. Default is false.");
   docString = "Drawer abstract base class";
   python::class_<RDKit::MolDraw2D, boost::noncopyable>(
       "MolDraw2D", docString.c_str(), python::no_init)

--- a/Code/GraphMol/MolDraw2D/catch_tests.cpp
+++ b/Code/GraphMol/MolDraw2D/catch_tests.cpp
@@ -964,4 +964,77 @@ TEST_CASE("hand drawn", "[play]") {
     }
 #endif
   }
+  SECTION("another one") {
+    auto m =
+        "CCCc1nn(C)c2c(=O)nc(-c3cc(S(=O)(=O)N4CCN(C)CC4)ccc3OCC)[nH]c12"_smiles;
+    REQUIRE(m);
+    RDDepict::preferCoordGen = true;
+    MolDraw2DUtils::prepareMolForDrawing(*m);
+
+    std::string fName = getenv("RDBASE");
+    fName += "/Data/Fonts/ComicNeue-Regular.ttf";
+
+    {
+      MolDraw2DSVG drawer(350, 300);
+      drawer.drawOptions().fontFile = fName;
+      drawer.drawOptions().comicMode = true;
+      drawer.drawMolecule(*m);
+      drawer.finishDrawing();
+      auto text = drawer.getDrawingText();
+      std::ofstream outs("testHandDrawn-4.svg");
+      outs << text;
+      outs.flush();
+    }
+#ifdef RDK_BUILD_CAIRO_SUPPORT
+    {
+      MolDraw2DCairo drawer(350, 300);
+      drawer.drawOptions().fontFile = fName;
+      drawer.drawOptions().comicMode = true;
+      drawer.drawMolecule(*m);
+      drawer.finishDrawing();
+      drawer.writeDrawingText("testHandDrawn-4.png");
+    }
+#endif
+  }
+  SECTION("large") {
+    auto m =
+        "CC[C@H](C)[C@@H](C(=O)N[C@@H]([C@@H](C)CC)C(=O)N[C@@H](CCCCN)C(=O)N[C@@H](CC(=O)N)C(=O)N[C@@H](C)C(=O)N[C@@H](Cc1ccc(cc1)O)C(=O)N[C@@H](CCCCN)C(=O)N[C@@H](CCCCN)C(=O)NCC(=O)N[C@@H](CCC(=O)N)C(=O)O)NC(=O)[C@H](C)NC(=O)[C@H](CC(=O)N)NC(=O)[C@H](CCCCN)NC(=O)[C@H](Cc2ccccc2)NC(=O)[C@H](CC(C)C)NC(=O)[C@H]([C@@H](C)O)NC(=O)[C@H](C(C)C)NC(=O)[C@H](CC(C)C)NC(=O)[C@@H]3CCCN3C(=O)[C@H]([C@@H](C)O)NC(=O)[C@H](CCC(=O)N)NC(=O)[C@H](CO)NC(=O)[C@H](CCCCN)NC(=O)[C@H](CCC(=O)N)NC(=O)[C@H](CO)NC(=O)[C@H]([C@@H](C)O)NC(=O)[C@H](CCSC)NC(=O)[C@H](Cc4ccccc4)NC(=O)CNC(=O)CNC(=O)[C@H](Cc5ccc(cc5)O)N"_smiles;
+    REQUIRE(m);
+    RDDepict::preferCoordGen = true;
+    MolDraw2DUtils::prepareMolForDrawing(*m);
+
+    std::string fName = getenv("RDBASE");
+    fName += "/Data/Fonts/ComicNeue-Regular.ttf";
+
+    {
+      MolDraw2DSVG drawer(900, 450);
+      drawer.drawMolecule(*m);
+      drawer.finishDrawing();
+      auto text = drawer.getDrawingText();
+      std::ofstream outs("testHandDrawn-5a.svg");
+      outs << text;
+      outs.flush();
+    }
+    {
+      MolDraw2DSVG drawer(900, 450);
+      drawer.drawOptions().fontFile = fName;
+      drawer.drawOptions().comicMode = true;
+      drawer.drawMolecule(*m);
+      drawer.finishDrawing();
+      auto text = drawer.getDrawingText();
+      std::ofstream outs("testHandDrawn-5b.svg");
+      outs << text;
+      outs.flush();
+    }
+#ifdef RDK_BUILD_CAIRO_SUPPORT
+    {
+      MolDraw2DCairo drawer(900, 450);
+      drawer.drawOptions().fontFile = fName;
+      drawer.drawOptions().comicMode = true;
+      drawer.drawMolecule(*m);
+      drawer.finishDrawing();
+      drawer.writeDrawingText("testHandDrawn-5.png");
+    }
+#endif
+  }
 }

--- a/Code/GraphMol/MolDraw2D/catch_tests.cpp
+++ b/Code/GraphMol/MolDraw2D/catch_tests.cpp
@@ -24,6 +24,7 @@
 #include <GraphMol/ChemReactions/Reaction.h>
 #include <GraphMol/ChemReactions/ReactionParser.h>
 #include <GraphMol/CIPLabeler/CIPLabeler.h>
+#include <GraphMol/Depictor/RDDepictor.h>
 
 #ifdef RDK_BUILD_CAIRO_SUPPORT
 #include <cairo.h>
@@ -864,5 +865,72 @@ TEST_CASE("Github #3577", "[bug]") {
     std::ofstream outs("testGithub3577-1.svg");
     outs << text;
     outs.flush();
+  }
+}
+
+TEST_CASE("hand drawn", "[play]") {
+  SECTION("basics") {
+    auto m =
+        "CC[CH](C)[CH]1NC(=O)[CH](Cc2ccc(O)cc2)NC(=O)[CH](N)CSSC[CH](C(=O)N2CCC[CH]2C(=O)N[CH](CC(C)C)C(=O)NCC(N)=O)NC(=O)[CH](CC(N)=O)NC(=O)[CH](CCC(N)=O)NC1=O"_smiles;
+    REQUIRE(m);
+    RDDepict::preferCoordGen = true;
+    MolDraw2DUtils::prepareMolForDrawing(*m);
+
+    std::string fName = getenv("RDBASE");
+    fName += "/Data/Fonts/ComicNeue-Regular.ttf";
+
+    {
+      MolDraw2DSVG drawer(450, 400);
+      drawer.drawOptions().fontFile = fName;
+      drawer.drawOptions().comicMode = true;
+      drawer.drawMolecule(*m, "Oxytocin (flat)");
+      drawer.finishDrawing();
+      auto text = drawer.getDrawingText();
+      std::ofstream outs("testHandDrawn-1.svg");
+      outs << text;
+      outs.flush();
+    }
+#ifdef RDK_BUILD_CAIRO_SUPPORT
+    {
+      MolDraw2DCairo drawer(450, 400);
+      drawer.drawOptions().fontFile = fName;
+      drawer.drawOptions().comicMode = true;
+      drawer.drawMolecule(*m, "Oxytocin (flat)");
+      drawer.finishDrawing();
+      drawer.writeDrawingText("testHandDrawn-1.png");
+    }
+#endif
+  }
+  SECTION("with chirality") {
+    auto m =
+        "CC[C@H](C)[C@@H]1NC(=O)[C@H](Cc2ccc(O)cc2)NC(=O)[C@@H](N)CSSC[C@@H](C(=O)N2CCC[C@H]2C(=O)N[C@@H](CC(C)C)C(=O)NCC(N)=O)NC(=O)[C@H](CC(N)=O)NC(=O)[C@H](CCC(N)=O)NC1=O"_smiles;
+    REQUIRE(m);
+    RDDepict::preferCoordGen = true;
+    MolDraw2DUtils::prepareMolForDrawing(*m);
+
+    std::string fName = getenv("RDBASE");
+    fName += "/Data/Fonts/ComicNeue-Regular.ttf";
+
+    {
+      MolDraw2DSVG drawer(450, 400);
+      drawer.drawOptions().fontFile = fName;
+      drawer.drawOptions().comicMode = true;
+      drawer.drawMolecule(*m, "Oxytocin");
+      drawer.finishDrawing();
+      auto text = drawer.getDrawingText();
+      std::ofstream outs("testHandDrawn-2.svg");
+      outs << text;
+      outs.flush();
+    }
+#ifdef RDK_BUILD_CAIRO_SUPPORT
+    {
+      MolDraw2DCairo drawer(450, 400);
+      drawer.drawOptions().fontFile = fName;
+      drawer.drawOptions().comicMode = true;
+      drawer.drawMolecule(*m, "Oxytocin");
+      drawer.finishDrawing();
+      drawer.writeDrawingText("testHandDrawn-2.png");
+    }
+#endif
   }
 }

--- a/Code/GraphMol/MolDraw2D/catch_tests.cpp
+++ b/Code/GraphMol/MolDraw2D/catch_tests.cpp
@@ -933,4 +933,35 @@ TEST_CASE("hand drawn", "[play]") {
     }
 #endif
   }
+  SECTION("smaller") {
+    auto m = "N=c1nc([C@H]2NCCCC2)cc(N)n1O"_smiles;
+    REQUIRE(m);
+    RDDepict::preferCoordGen = true;
+    MolDraw2DUtils::prepareMolForDrawing(*m);
+
+    std::string fName = getenv("RDBASE");
+    fName += "/Data/Fonts/ComicNeue-Regular.ttf";
+
+    {
+      MolDraw2DSVG drawer(350, 300);
+      drawer.drawOptions().fontFile = fName;
+      drawer.drawOptions().comicMode = true;
+      drawer.drawMolecule(*m);
+      drawer.finishDrawing();
+      auto text = drawer.getDrawingText();
+      std::ofstream outs("testHandDrawn-3.svg");
+      outs << text;
+      outs.flush();
+    }
+#ifdef RDK_BUILD_CAIRO_SUPPORT
+    {
+      MolDraw2DCairo drawer(350, 300);
+      drawer.drawOptions().fontFile = fName;
+      drawer.drawOptions().comicMode = true;
+      drawer.drawMolecule(*m);
+      drawer.finishDrawing();
+      drawer.writeDrawingText("testHandDrawn-3.png");
+    }
+#endif
+  }
 }

--- a/rdkit/Chem/Draw/__init__.py
+++ b/rdkit/Chem/Draw/__init__.py
@@ -16,6 +16,7 @@ from rdkit.Chem.Draw.MolDrawing import MolDrawing, DrawingOptions
 from rdkit.Chem.Draw.rdMolDraw2D import *
 from rdkit.Chem import rdDepictor
 from rdkit import Chem, rdBase
+from rdkit import RDConfig
 
 
 def _getCanvas():
@@ -970,3 +971,9 @@ def DrawRDKitEnv(mol, bondPath, molSize=(150, 150), baseRad=0.3, useSVG=True,
                       **kwargs)
   drawer.FinishDrawing()
   return drawer.GetDrawingText()
+
+
+def setComicMode(drawer):
+  opts = drawer.drawOptions()
+  opts.fontFile = os.path.join(RDConfig.RDDataDir, "Fonts", "ComicNeue-Regular.ttf")
+  opts.comicMode = True

--- a/rdkit/Chem/Draw/__init__.py
+++ b/rdkit/Chem/Draw/__init__.py
@@ -973,7 +973,6 @@ def DrawRDKitEnv(mol, bondPath, molSize=(150, 150), baseRad=0.3, useSVG=True,
   return drawer.GetDrawingText()
 
 
-def setComicMode(drawer):
-  opts = drawer.drawOptions()
+def SetComicMode(opts):
   opts.fontFile = os.path.join(RDConfig.RDDataDir, "Fonts", "ComicNeue-Regular.ttf")
   opts.comicMode = True


### PR DESCRIPTION
Since we can specify our own fonts, it was inevitable that molecules would be rendered with Comic Sans. This takes that game one step further and fakes hand-drawn lines for bonds.

This was originally just going to be a joke, but I unexpectedly find myself actually liking this way of drawing molecules.

A few examples:
![image](https://user-images.githubusercontent.com/540511/100070430-38271b80-2e3a-11eb-9a75-c288de170f02.png)
![image](https://user-images.githubusercontent.com/540511/100070458-3fe6c000-2e3a-11eb-9591-d3768cf40f74.png)
![image](https://user-images.githubusercontent.com/540511/100070489-48d79180-2e3a-11eb-88cd-cf36a34e2331.png)


