### PR TITLE
Add rendering of SGroup brackets to MolDraw2D

### DIFF
--- a/Code/GraphMol/MolDraw2D/DrawText.h
+++ b/Code/GraphMol/MolDraw2D/DrawText.h
@@ -24,9 +24,6 @@ using RDGeom::Point2D;
 
 namespace RDKit {
 
-// for aligning the drawing of text to the passed in coords.
-enum class OrientType : unsigned char { C = 0, N, E, S, W };
-enum class TextAlignType : unsigned char { START, MIDDLE, END };
 enum class TextDrawType : unsigned char {
   TextDrawNormal = 0,
   TextDrawSuperscript,

--- a/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
@@ -2097,7 +2097,7 @@ void MolDraw2D::extractBrackets(const ROMol &mol) {
                            at_cds_[activeMolIdx_][bnd->getBeginAtomIdx()]));
       }
     }
-    for (auto &brk : sg.getBrackets()) {
+    for (const auto &brk : sg.getBrackets()) {
       Point2D p1{brk[0]};
       Point2D p2{brk[1]};
       trans.TransformPoint(p1);
@@ -2108,7 +2108,21 @@ void MolDraw2D::extractBrackets(const ROMol &mol) {
       shp.shapeType = MolDrawShapeType::Polyline;
       shapes_[activeMolIdx_].emplace_back(std::move(shp));
     }
-    // FIX: extract the locations of the bracket annotations
+    if (supportsAnnotations()) {
+      std::string connect;
+      if (sg.getPropIfPresent("CONNECT", connect)) {
+        // annotations go on the last bracket of an sgroup
+        const auto &brkShp = shapes_[activeMolIdx_].back();
+        StringRect rect;
+        // CONNECT goes at the top
+        auto topPt = brkShp.points[1];
+        if (brkShp.points[2].y > topPt.y) {
+          topPt = brkShp.points[2];
+        }
+        rect.trans_ = topPt;
+        annotations_[activeMolIdx_].push_back(std::make_pair(connect, rect));
+      }
+    }
   }
 }  // namespace RDKit
 

--- a/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
@@ -2109,18 +2109,42 @@ void MolDraw2D::extractBrackets(const ROMol &mol) {
       shapes_[activeMolIdx_].emplace_back(std::move(shp));
     }
     if (supportsAnnotations()) {
+      // FIX: we could imagine changing this to always show the annotations on
+      // the right-most (or bottom-most) bracket
+
       std::string connect;
       if (sg.getPropIfPresent("CONNECT", connect)) {
+        // FIX: this is a workaround for #3577 and should not be merged as-is
+        if (connect == "HT") {
+          connect = "ht";
+        }
         // annotations go on the last bracket of an sgroup
         const auto &brkShp = shapes_[activeMolIdx_].back();
         StringRect rect;
         // CONNECT goes at the top
         auto topPt = brkShp.points[1];
+        auto brkPt = brkShp.points[0];
         if (brkShp.points[2].y > topPt.y) {
           topPt = brkShp.points[2];
+          brkPt = brkShp.points[3];
         }
-        rect.trans_ = topPt;
+        rect.trans_ = topPt + (topPt - brkPt);
         annotations_[activeMolIdx_].push_back(std::make_pair(connect, rect));
+      }
+      std::string label;
+      if (sg.getPropIfPresent("LABEL", label)) {
+        // annotations go on the last bracket of an sgroup
+        const auto &brkShp = shapes_[activeMolIdx_].back();
+        StringRect rect;
+        // LABEL goes at the bottom
+        auto botPt = brkShp.points[2];
+        auto brkPt = brkShp.points[3];
+        if (brkShp.points[1].y < botPt.y) {
+          botPt = brkShp.points[1];
+          brkPt = brkShp.points[0];
+        }
+        rect.trans_ = botPt + (botPt - brkPt);
+        annotations_[activeMolIdx_].push_back(std::make_pair(label, rect));
       }
     }
   }

--- a/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
@@ -1104,49 +1104,7 @@ void MolDraw2D::centrePicture(int width, int height) {
   y_trans_ = (mid.y - height / 2) / scale_;
 };
 
-namespace {
-// there are a several empirically determined constants here.
-std::vector<Point2D> handdrawnLine(Point2D cds1, Point2D cds2, double scale,
-                                   bool shiftBegin = false,
-                                   bool shiftEnd = false, unsigned nSteps = 4,
-                                   double deviation = 0.03,
-                                   double endShift = 0.5) {
-  // std::cerr << "   " << scale << " " << endShift / scale << endl;
-  while (endShift / scale > 0.02) {
-    endShift *= 0.75;
-  }
-  if (shiftBegin) {
-    cds1.x += (std::rand() % 10 >= 5 ? endShift : -endShift) / scale;
-    cds1.y += (std::rand() % 10 >= 5 ? endShift : -endShift) / scale;
-  }
-  if (shiftEnd) {
-    cds2.x += (std::rand() % 10 >= 5 ? endShift : -endShift) / scale;
-    cds2.y += (std::rand() % 10 >= 5 ? endShift : -endShift) / scale;
-  }
-
-  Point2D step = (cds2 - cds1) / nSteps;
-  // make sure we aren't adding loads of wiggles to short lines
-  while (step.length() < 0.2 && nSteps > 2) {
-    --nSteps;
-    step = (cds2 - cds1) / nSteps;
-  }
-  // make sure the wiggles aren't too big
-  while (deviation / step.length() > 0.15 || deviation * scale > 0.70) {
-    deviation *= 0.75;
-  }
-  Point2D perp{step.y, -step.x};
-  perp.normalize();
-  std::vector<Point2D> pts;
-  pts.push_back(cds1);
-  for (unsigned int i = 1; i < nSteps; ++i) {
-    auto tgt = cds1 + step * i;
-    tgt += perp * deviation * (std::rand() % 20 - 10) / 10.0;
-    pts.push_back(tgt);
-  }
-  pts.push_back(cds2);
-  return pts;
-}
-}  // namespace
+namespace {}  // namespace
 
 // ****************************************************************************
 void MolDraw2D::drawLine(const Point2D &cds1, const Point2D &cds2,
@@ -1155,15 +1113,18 @@ void MolDraw2D::drawLine(const Point2D &cds1, const Point2D &cds2,
     setFillPolys(false);
     if (col1 == col2) {
       setColour(col1);
-      auto pts = handdrawnLine(cds1, cds2, scale_, true, true);
+      auto pts =
+          MolDraw2D_detail::handdrawnLine(cds1, cds2, scale_, true, true);
       drawPolygon(pts);
     } else {
       Point2D mid = (cds1 + cds2) * 0.5;
       setColour(col1);
-      auto pts = handdrawnLine(cds1, mid, scale_, true, false);
+      auto pts =
+          MolDraw2D_detail::handdrawnLine(cds1, mid, scale_, true, false);
       drawPolygon(pts);
       setColour(col2);
-      auto pts2 = handdrawnLine(mid, cds2, scale_, false, true);
+      auto pts2 =
+          MolDraw2D_detail::handdrawnLine(mid, cds2, scale_, false, true);
       drawPolygon(pts2);
     }
   } else {
@@ -2441,7 +2402,7 @@ void MolDraw2D::drawWedgedBond(const Point2D &cds1, const Point2D &cds2,
       Point2D e11 = cds1 + e1 * (rdcast<double>(i) / nDashes);
       Point2D e22 = cds1 + e2 * (rdcast<double>(i) / nDashes);
       if (drawOptions().comicMode) {
-        auto pts = handdrawnLine(e11, e22, scale_);
+        auto pts = MolDraw2D_detail::handdrawnLine(e11, e22, scale_);
         drawPolygon(pts);
       } else {
         drawLine(e11, e22);
@@ -3508,11 +3469,11 @@ void MolDraw2D::drawTriangle(const Point2D &cds1, const Point2D &cds2,
   if (!drawOptions().comicMode) {
     pts = {cds1, cds2, cds3};
   } else {
-    auto lpts = handdrawnLine(cds1, cds2, scale_);
+    auto lpts = MolDraw2D_detail::handdrawnLine(cds1, cds2, scale_);
     std::move(lpts.begin(), lpts.end(), std::back_inserter(pts));
-    lpts = handdrawnLine(cds2, cds3, scale_);
+    lpts = MolDraw2D_detail::handdrawnLine(cds2, cds3, scale_);
     std::move(lpts.begin(), lpts.end(), std::back_inserter(pts));
-    lpts = handdrawnLine(cds3, cds1, scale_);
+    lpts = MolDraw2D_detail::handdrawnLine(cds3, cds1, scale_);
     std::move(lpts.begin(), lpts.end(), std::back_inserter(pts));
   }
   drawPolygon(pts);

--- a/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
@@ -1432,6 +1432,8 @@ void MolDraw2D::finishMoleculeDraw(const RDKit::ROMol &draw_mol,
     }
   }
 
+  drawBrackets(draw_mol, -1);
+
   if (drawOptions().includeRadicals) {
     drawRadicals(draw_mol);
   }
@@ -2449,6 +2451,19 @@ OrientType MolDraw2D::calcRadicalRect(const ROMol &mol, const Atom *atom,
   try_north();
   return OrientType::N;
 }
+
+namespace {}  // namespace
+
+// ****************************************************************************
+void MolDraw2D::drawBrackets(const ROMol &mol, int confId) {
+  const auto &conf = mol.getConformer(confId);
+  const auto &sgs = getSubstanceGroups(mol);
+  for (const auto &sg : sgs) {
+    if (!sg.getBrackets().empty()) {
+      MolDraw2D_detail::drawBracketsForSGroup(*this, mol, sg, conf);
+    }
+  }
+};
 
 // ****************************************************************************
 void MolDraw2D::drawRadicals(const ROMol &mol) {

--- a/Code/GraphMol/MolDraw2D/MolDraw2D.h
+++ b/Code/GraphMol/MolDraw2D/MolDraw2D.h
@@ -1,4 +1,6 @@
 //
+//  Copyright (C) 2014-2020 David Cosgrove and Greg Landrum
+//
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
 //  The contents are covered by the terms of the BSD license
@@ -64,6 +66,21 @@ struct DrawColour {
     return {r / v, g / v, b / v, a / v};
   }
   DrawColour operator*(double v) const { return {r * v, g * v, b * v, a * v}; }
+};
+
+//! for annotating the type of the extra shapes
+enum class MolDrawShapeType {
+  Arrow,  // ordering of points is: start, end, p1, p2
+  Polyline,
+};
+
+//! extra shape to add to canvas
+struct MolDrawShape {
+  MolDrawShapeType shapeType = MolDrawShapeType::Polyline;
+  std::vector<Point2D> points;
+  DrawColour lineColour{0, 0, 0};
+  int lineWidth = 2;
+  bool fill = false;
 };
 
 // for holding dimensions of the rectangle round a string.
@@ -637,7 +654,7 @@ class RDKIT_MOLDRAW2D_EXPORT MolDraw2D {
   std::vector<std::vector<std::pair<std::shared_ptr<StringRect>, OrientType>>>
       radicals_;
   Point2D bbox_[2];
-  std::vector<RDGeom::Transform2D> mol_transforms_;
+  std::vector<std::vector<MolDrawShape>> shapes_;
 
   // return a DrawColour based on the contents of highlight_atoms or
   // highlight_map, falling back to atomic number by default
@@ -721,7 +738,7 @@ class RDKIT_MOLDRAW2D_EXPORT MolDraw2D {
   void extractAtomNotes(const ROMol &mol);
   void extractBondNotes(const ROMol &mol);
   void extractRadicals(const ROMol &mol);
-  void extractBracketAnnotations(const ROMol &mol);
+  void extractBrackets(const ROMol &mol);
 
   // coords in atom coords
   virtual void drawLine(const Point2D &cds1, const Point2D &cds2,
@@ -738,7 +755,6 @@ class RDKIT_MOLDRAW2D_EXPORT MolDraw2D {
   OrientType calcRadicalRect(const ROMol &mol, const Atom *atom,
                              StringRect &rad_rect);
   void drawRadicals(const ROMol &mol);
-  void drawBrackets(const ROMol &mol);
   // find a good starting point for scanning round the annotation
   // atom.  If we choose well, the first angle should be the one.
   // Returns angle in radians.

--- a/Code/GraphMol/MolDraw2D/MolDraw2D.h
+++ b/Code/GraphMol/MolDraw2D/MolDraw2D.h
@@ -737,6 +737,7 @@ class RDKIT_MOLDRAW2D_EXPORT MolDraw2D {
   OrientType calcRadicalRect(const ROMol &mol, const Atom *atom,
                              StringRect &rad_rect);
   void drawRadicals(const ROMol &mol);
+  void drawBrackets(const ROMol &mol, int confId);
   // find a good starting point for scanning round the annotation
   // atom.  If we choose well, the first angle should be the one.
   // Returns angle in radians.

--- a/Code/GraphMol/MolDraw2D/MolDraw2D.h
+++ b/Code/GraphMol/MolDraw2D/MolDraw2D.h
@@ -627,16 +627,14 @@ class RDKIT_MOLDRAW2D_EXPORT MolDraw2D {
   std::vector<std::vector<Point2D>> at_cds_;  // from mol
   std::vector<std::vector<int>> atomic_nums_;
   std::vector<std::vector<std::pair<std::string, OrientType>>> atom_syms_;
-  // by the time atom_notes_ and bonds_notes_ are drawn, we're only ever
-  // using the trans_ member of the StringRect, but it is convenient to
-  // keep the whole thing rather than just a StringPos for the position
-  // for calculating the scale of the drawing.  Went a long way down
-  // the rabbit hole before realising this, hence this note.
-  std::vector<std::vector<std::shared_ptr<StringRect>>> atom_notes_;
-  std::vector<std::vector<std::shared_ptr<StringRect>>> bond_notes_;
+  // by the time annotations_ are drawn, we're only ever using the trans_ member
+  // of the StringRect, but it is convenient to keep the whole thing rather than
+  // just a StringPos for the position for calculating the scale of the drawing.
+  // Went a long way down the rabbit hole before realising this, hence this
+  // note.
+  std::vector<std::vector<std::pair<std::string, StringRect>>> annotations_;
   std::vector<std::vector<std::pair<std::shared_ptr<StringRect>, OrientType>>>
       radicals_;
-
   Point2D bbox_[2];
 
   // return a DrawColour based on the contents of highlight_atoms or
@@ -796,7 +794,7 @@ class RDKIT_MOLDRAW2D_EXPORT MolDraw2D {
                                 const std::map<int, double> *highlight_radii);
   void adjustScaleForRadicals(const ROMol &mol);
   void adjustScaleForAnnotation(
-      const std::vector<std::shared_ptr<StringRect>> &notes);
+      const std::vector<std::pair<std::string, StringRect>> &notes);
 
  private:
   virtual void updateMetadata(const ROMol &mol, int confId) {
@@ -832,7 +830,7 @@ class RDKIT_MOLDRAW2D_EXPORT MolDraw2D {
           nullptr);
   virtual void drawAtomLabel(int atom_num, const DrawColour &draw_colour);
   virtual void drawAnnotation(const std::string &note,
-                              const std::shared_ptr<StringRect> &note_rect);
+                              const StringRect &note_rect);
 
   // calculate normalised perpendicular to vector between two coords
   Point2D calcPerpendicular(const Point2D &cds1, const Point2D &cds2) const;

--- a/Code/GraphMol/MolDraw2D/MolDraw2D.h
+++ b/Code/GraphMol/MolDraw2D/MolDraw2D.h
@@ -26,6 +26,7 @@
 #include <vector>
 
 #include <Geometry/point.h>
+#include <Geometry/Transform2D.h>
 #include <GraphMol/RDKitBase.h>
 #include <GraphMol/ChemReactions/Reaction.h>
 
@@ -636,6 +637,7 @@ class RDKIT_MOLDRAW2D_EXPORT MolDraw2D {
   std::vector<std::vector<std::pair<std::shared_ptr<StringRect>, OrientType>>>
       radicals_;
   Point2D bbox_[2];
+  std::vector<RDGeom::Transform2D> mol_transforms_;
 
   // return a DrawColour based on the contents of highlight_atoms or
   // highlight_map, falling back to atomic number by default
@@ -719,6 +721,7 @@ class RDKIT_MOLDRAW2D_EXPORT MolDraw2D {
   void extractAtomNotes(const ROMol &mol);
   void extractBondNotes(const ROMol &mol);
   void extractRadicals(const ROMol &mol);
+  void extractBracketAnnotations(const ROMol &mol);
 
   // coords in atom coords
   virtual void drawLine(const Point2D &cds1, const Point2D &cds2,
@@ -735,7 +738,7 @@ class RDKIT_MOLDRAW2D_EXPORT MolDraw2D {
   OrientType calcRadicalRect(const ROMol &mol, const Atom *atom,
                              StringRect &rad_rect);
   void drawRadicals(const ROMol &mol);
-  void drawBrackets(const ROMol &mol, int confId);
+  void drawBrackets(const ROMol &mol);
   // find a good starting point for scanning round the annotation
   // atom.  If we choose well, the first angle should be the one.
   // Returns angle in radians.

--- a/Code/GraphMol/MolDraw2D/MolDraw2DDetails.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DDetails.cpp
@@ -115,58 +115,6 @@ void addStereoAnnotation(const ROMol &mol, bool includeRelativeCIP) {
   }
 }
 
-void drawBracketsForSGroup(MolDraw2D &drawer, const ROMol &mol,
-                           const SubstanceGroup &sg,
-                           const std::vector<Point2D> &atomPs,
-                           const RDGeom::Transform2D &tform) {
-  std::vector<SubstanceGroup::Bracket> brackets = sg.getBrackets();
-  if (brackets.empty()) {
-    return;
-  }
-  RDGeom::Point2D center{0, 0};
-  double avgLength = 0;
-  for (auto &brk : brackets) {
-    RDGeom::Point2D p1{brk[0]};
-    RDGeom::Point2D p2{brk[1]};
-    tform.TransformPoint(p1);
-    tform.TransformPoint(p2);
-    auto v = p2 - p1;
-    center += p1 + v / 2;
-    avgLength += v.length();
-  }
-  center /= brackets.size();
-  avgLength /= brackets.size();
-
-  const auto ocolor = drawer.colour();
-  const auto olw = drawer.lineWidth();
-  const auto ffs = drawer.fontSize();
-  drawer.setColour({0.4, 0.4, 0.4});
-  drawer.setLineWidth(2);
-  unsigned int whichBrk = 0;
-  for (const auto &brk : brackets) {
-    RDGeom::Point2D p1{brk[0]};
-    RDGeom::Point2D p2{brk[1]};
-    tform.TransformPoint(p1);
-    tform.TransformPoint(p2);
-
-    drawer.drawLine(p1, p2);
-    auto v = p2 - p1;
-    auto centerv = center - (p1 + v / 2);
-    RDGeom::Point2D perp{v.y, -v.x};
-    perp.normalize();
-    if (perp.dotProduct(centerv) < 0) {
-      perp *= -1;
-    }
-    perp *= avgLength / 10;
-    drawer.drawLine(p1, p1 + perp);
-    drawer.drawLine(p2, p2 + perp);
-    ++whichBrk;
-  }
-  drawer.setColour(ocolor);
-  drawer.setLineWidth(olw);
-  drawer.setFontSize(ffs);
-}
-
 namespace {
 // note, this is approximate since we're just using it for drawing
 bool lineSegmentsIntersect(const Point2D &s1, const Point2D &s2,

--- a/Code/GraphMol/MolDraw2D/MolDraw2DDetails.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DDetails.cpp
@@ -116,16 +116,20 @@ void addStereoAnnotation(const ROMol &mol, bool includeRelativeCIP) {
 }
 
 void drawBracketsForSGroup(MolDraw2D &drawer, const ROMol &mol,
-                           const SubstanceGroup &sg, const Conformer &conf) {
+                           const SubstanceGroup &sg,
+                           const std::vector<Point2D> &atomPs,
+                           const RDGeom::Transform2D &tform) {
   std::vector<SubstanceGroup::Bracket> brackets = sg.getBrackets();
   if (brackets.empty()) {
     return;
   }
   RDGeom::Point2D center{0, 0};
   double avgLength = 0;
-  for (const auto &brk : brackets) {
-    const RDGeom::Point2D p1{brk[0]};
-    const RDGeom::Point2D p2{brk[1]};
+  for (auto &brk : brackets) {
+    RDGeom::Point2D p1{brk[0]};
+    RDGeom::Point2D p2{brk[1]};
+    tform.TransformPoint(p1);
+    tform.TransformPoint(p2);
     auto v = p2 - p1;
     center += p1 + v / 2;
     avgLength += v.length();
@@ -140,8 +144,11 @@ void drawBracketsForSGroup(MolDraw2D &drawer, const ROMol &mol,
   drawer.setLineWidth(2);
   unsigned int whichBrk = 0;
   for (const auto &brk : brackets) {
-    const RDGeom::Point2D p1{brk[0]};
-    const RDGeom::Point2D p2{brk[1]};
+    RDGeom::Point2D p1{brk[0]};
+    RDGeom::Point2D p2{brk[1]};
+    tform.TransformPoint(p1);
+    tform.TransformPoint(p2);
+
     drawer.drawLine(p1, p2);
     auto v = p2 - p1;
     auto centerv = center - (p1 + v / 2);

--- a/Code/GraphMol/MolDraw2D/MolDraw2DDetails.h
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DDetails.h
@@ -16,6 +16,7 @@
 
 #include <Geometry/point.h>
 #include <GraphMol/RDKitBase.h>
+#include <GraphMol/MolDraw2D/MolDraw2D.h>
 
 #include <boost/tuple/tuple.hpp>
 #include <boost/format.hpp>
@@ -88,6 +89,12 @@ RDKIT_MOLDRAW2D_EXPORT inline void addBondIndices(const ROMol &mol) {
     bond->setProp(common_properties::bondNote, lab);
   }
 };
+
+RDKIT_MOLDRAW2D_EXPORT void drawBracketsForSGroup(MolDraw2D &drawer,
+                                                  const ROMol &mol,
+                                                  const SubstanceGroup &sg,
+                                                  const Conformer &conf);
+
 }  // namespace MolDraw2D_detail
 }  // namespace RDKit
 

--- a/Code/GraphMol/MolDraw2D/MolDraw2DDetails.h
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DDetails.h
@@ -97,6 +97,12 @@ RDKIT_MOLDRAW2D_EXPORT std::vector<Point2D> getBracketPoints(
 RDKIT_MOLDRAW2D_EXPORT void drawShapes(MolDraw2D &drawer,
                                        const std::vector<MolDrawShape> &shapes);
 
+// there are a several empirically determined constants here.
+RDKIT_MOLDRAW2D_EXPORT std::vector<Point2D> handdrawnLine(
+    Point2D cds1, Point2D cds2, double scale, bool shiftBegin = false,
+    bool shiftEnd = false, unsigned nSteps = 4, double deviation = 0.03,
+    double endShift = 0.5);
+
 }  // namespace MolDraw2D_detail
 }  // namespace RDKit
 

--- a/Code/GraphMol/MolDraw2D/MolDraw2DDetails.h
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DDetails.h
@@ -90,9 +90,15 @@ RDKIT_MOLDRAW2D_EXPORT inline void addBondIndices(const ROMol &mol) {
   }
 };
 
-RDKIT_MOLDRAW2D_EXPORT void drawBracketsForSGroup(
+RDKIT_MOLDRAW2D_EXPORT void drawBracketsPForSGroup(
     MolDraw2D &drawer, const ROMol &mol, const SubstanceGroup &sg,
     const std::vector<Point2D> &atomPs, const RDGeom::Transform2D &tform);
+RDKIT_MOLDRAW2D_EXPORT std::vector<Point2D> getBracketPoints(
+    const Point2D &p1, const Point2D &p2, const Point2D &refPt,
+    const std::vector<std::pair<Point2D, Point2D>> &bondSegments,
+    double bracketFrac = 0.1);
+RDKIT_MOLDRAW2D_EXPORT void drawShapes(MolDraw2D &drawer,
+                                       const std::vector<MolDrawShape> &shapes);
 
 }  // namespace MolDraw2D_detail
 }  // namespace RDKit

--- a/Code/GraphMol/MolDraw2D/MolDraw2DDetails.h
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DDetails.h
@@ -90,10 +90,9 @@ RDKIT_MOLDRAW2D_EXPORT inline void addBondIndices(const ROMol &mol) {
   }
 };
 
-RDKIT_MOLDRAW2D_EXPORT void drawBracketsForSGroup(MolDraw2D &drawer,
-                                                  const ROMol &mol,
-                                                  const SubstanceGroup &sg,
-                                                  const Conformer &conf);
+RDKIT_MOLDRAW2D_EXPORT void drawBracketsForSGroup(
+    MolDraw2D &drawer, const ROMol &mol, const SubstanceGroup &sg,
+    const std::vector<Point2D> &atomPs, const RDGeom::Transform2D &tform);
 
 }  // namespace MolDraw2D_detail
 }  // namespace RDKit

--- a/Code/GraphMol/MolDraw2D/MolDraw2DDetails.h
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DDetails.h
@@ -90,9 +90,6 @@ RDKIT_MOLDRAW2D_EXPORT inline void addBondIndices(const ROMol &mol) {
   }
 };
 
-RDKIT_MOLDRAW2D_EXPORT void drawBracketsPForSGroup(
-    MolDraw2D &drawer, const ROMol &mol, const SubstanceGroup &sg,
-    const std::vector<Point2D> &atomPs, const RDGeom::Transform2D &tform);
 RDKIT_MOLDRAW2D_EXPORT std::vector<Point2D> getBracketPoints(
     const Point2D &p1, const Point2D &p2, const Point2D &refPt,
     const std::vector<std::pair<Point2D, Point2D>> &bondSegments,

--- a/Code/GraphMol/MolDraw2D/MolDraw2DSVG.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DSVG.cpp
@@ -11,7 +11,7 @@
 //
 
 #include <GraphMol/MolDraw2D/MolDraw2DSVG.h>
-
+#include <GraphMol/MolDraw2D/DrawText.h>
 #include <GraphMol/SmilesParse/SmilesWrite.h>
 #include <Geometry/point.h>
 #ifdef RDK_BUILD_FREETYPE_SUPPORT
@@ -184,14 +184,13 @@ void MolDraw2DSVG::drawAtomLabel(int atom_num, const DrawColour &draw_colour) {
 }
 
 // ****************************************************************************
-void MolDraw2DSVG::drawAnnotation(const std::string &note,
-                                  const StringRect &note_rect) {
+void MolDraw2DSVG::drawAnnotation(const AnnotationType &annot) {
   std::string o_class = d_activeClass;
   if (!d_activeClass.empty()) {
     d_activeClass += " ";
   }
   d_activeClass += "note";
-  MolDraw2D::drawAnnotation(note, note_rect);
+  MolDraw2D::drawAnnotation(annot);
   d_activeClass = o_class;
 }
 

--- a/Code/GraphMol/MolDraw2D/MolDraw2DSVG.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DSVG.cpp
@@ -184,8 +184,8 @@ void MolDraw2DSVG::drawAtomLabel(int atom_num, const DrawColour &draw_colour) {
 }
 
 // ****************************************************************************
-void MolDraw2DSVG::drawAnnotation(
-    const std::string &note, const std::shared_ptr<StringRect> &note_rect) {
+void MolDraw2DSVG::drawAnnotation(const std::string &note,
+                                  const StringRect &note_rect) {
   std::string o_class = d_activeClass;
   if (!d_activeClass.empty()) {
     d_activeClass += " ";

--- a/Code/GraphMol/MolDraw2D/MolDraw2DSVG.h
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DSVG.h
@@ -94,7 +94,7 @@ class RDKIT_MOLDRAW2D_EXPORT MolDraw2DSVG : public MolDraw2D {
                     *bond_colours = nullptr) override;
   void drawAtomLabel(int atom_num, const DrawColour &draw_colour) override;
   void drawAnnotation(const std::string &note,
-                      const std::shared_ptr<StringRect> &note_rect) override;
+                      const StringRect &note_rect) override;
 };
 
 }  // namespace RDKit

--- a/Code/GraphMol/MolDraw2D/MolDraw2DSVG.h
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DSVG.h
@@ -93,8 +93,15 @@ class RDKIT_MOLDRAW2D_EXPORT MolDraw2DSVG : public MolDraw2D {
                 const std::vector<std::pair<DrawColour, DrawColour>>
                     *bond_colours = nullptr) override;
   void drawAtomLabel(int atom_num, const DrawColour &draw_colour) override;
-  void drawAnnotation(const std::string &note,
-                      const StringRect &note_rect) override;
+  void drawAnnotation(const AnnotationType &annot) override;
+  //! DEPRECATED
+  virtual void drawAnnotation(const std::string &note,
+                              const StringRect &note_rect) override {
+    AnnotationType annot;
+    annot.text_ = note;
+    annot.rect_ = note_rect;
+    drawAnnotation(annot);
+  }
 };
 
 }  // namespace RDKit

--- a/Code/GraphMol/MolDraw2D/MolDraw2DUtils.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DUtils.cpp
@@ -28,66 +28,6 @@ namespace RDKit {
 namespace MolDraw2DUtils {
 
 namespace {
-void drawBracketsForSGroup(MolDraw2D &drawer, const ROMol &mol,
-                           const SubstanceGroup &sg, bool regenerateCoords,
-                           const Conformer &conf) {
-  std::vector<SubstanceGroup::Bracket> brackets;
-  if (!regenerateCoords && !sg.getBrackets().empty()) {
-    brackets = sg.getBrackets();
-  } else {
-    // we're generating our own coordinates/brackets
-    for (auto bidx : sg.getBonds()) {
-      const auto bond = mol.getBondWithIdx(bidx);
-    }
-  }
-  RDGeom::Point2D center{0, 0};
-  double avgLength = 0;
-  for (const auto &brk : brackets) {
-    const RDGeom::Point2D p1{brk[0]};
-    const RDGeom::Point2D p2{brk[1]};
-    auto v = p2 - p1;
-    center += p1 + v / 2;
-    avgLength += v.length();
-  }
-  center /= brackets.size();
-  avgLength /= brackets.size();
-
-  const auto ocolor = drawer.colour();
-  const auto olw = drawer.lineWidth();
-  drawer.setColour({0.4, 0.4, 0.4});
-  drawer.setLineWidth(2);
-  for (const auto &brk : brackets) {
-    const RDGeom::Point2D p1{brk[0]};
-    const RDGeom::Point2D p2{brk[1]};
-    drawer.drawLine(p1, p2);
-    auto v = p2 - p1;
-    auto centerv = center - (p1 + v / 2);
-    RDGeom::Point2D perp{v.y, -v.x};
-    perp.normalize();
-    if (perp.dotProduct(centerv) < 0) {
-      perp *= -1;
-    }
-    perp *= avgLength / 10;
-    drawer.drawLine(p1, p1 + perp);
-    drawer.drawLine(p2, p2 + perp);
-  }
-  drawer.setColour(ocolor);
-  drawer.setLineWidth(olw);
-}
-}  // namespace
-
-void drawMoleculeBrackets(MolDraw2D &drawer, const ROMol &mol,
-                          bool regenerateCoords, int confId) {
-  const auto conf = mol.getConformer(confId);
-  const auto &sgs = getSubstanceGroups(mol);
-  for (const auto &sg : sgs) {
-    if (!sg.getBrackets().empty() || regenerateCoords) {
-      drawBracketsForSGroup(drawer, mol, sg, regenerateCoords, conf);
-    }
-  }
-};
-
-namespace {
 bool isAtomCandForChiralH(const RWMol &mol, const Atom *atom) {
   // conditions for needing a chiral H:
   //   - stereochem specified

--- a/Code/GraphMol/MolDraw2D/MolDraw2DUtils.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DUtils.cpp
@@ -28,29 +28,64 @@ namespace RDKit {
 namespace MolDraw2DUtils {
 
 namespace {
-  void drawBracketsForSGroup(MolDraw2D &drawer, const ROMol &mol, const SubstanceGroup &sg, bool regenerateCoords, 
-    const Conformer &conf){
-      for(const auto &brk : sg.getBrackets()){
-        const RDGeom::Point2D p1{brk[0]};
-        const RDGeom::Point2D p2{brk[1]};
-        drawer.setColour({0,0,0});
-        drawer.setLineWidth(2);
-        drawer.drawLine(p1,p2);
-      }
+void drawBracketsForSGroup(MolDraw2D &drawer, const ROMol &mol,
+                           const SubstanceGroup &sg, bool regenerateCoords,
+                           const Conformer &conf) {
+  std::vector<SubstanceGroup::Bracket> brackets;
+  if (!regenerateCoords && !sg.getBrackets().empty()) {
+    brackets = sg.getBrackets();
+  } else {
+    // we're generating our own coordinates/brackets
+    for (auto bidx : sg.getBonds()) {
+      const auto bond = mol.getBondWithIdx(bidx);
+    }
   }
+  RDGeom::Point2D center{0, 0};
+  double avgLength = 0;
+  for (const auto &brk : brackets) {
+    const RDGeom::Point2D p1{brk[0]};
+    const RDGeom::Point2D p2{brk[1]};
+    auto v = p2 - p1;
+    center += p1 + v / 2;
+    avgLength += v.length();
+  }
+  center /= brackets.size();
+  avgLength /= brackets.size();
+
+  const auto ocolor = drawer.colour();
+  const auto olw = drawer.lineWidth();
+  drawer.setColour({0.4, 0.4, 0.4});
+  drawer.setLineWidth(2);
+  for (const auto &brk : brackets) {
+    const RDGeom::Point2D p1{brk[0]};
+    const RDGeom::Point2D p2{brk[1]};
+    drawer.drawLine(p1, p2);
+    auto v = p2 - p1;
+    auto centerv = center - (p1 + v / 2);
+    RDGeom::Point2D perp{v.y, -v.x};
+    perp.normalize();
+    if (perp.dotProduct(centerv) < 0) {
+      perp *= -1;
+    }
+    perp *= avgLength / 10;
+    drawer.drawLine(p1, p1 + perp);
+    drawer.drawLine(p2, p2 + perp);
+  }
+  drawer.setColour(ocolor);
+  drawer.setLineWidth(olw);
 }
+}  // namespace
 
-void drawMoleculeBrackets(
-    MolDraw2D &drawer, const ROMol &mol, bool regenerateCoords, int confId){
-      const auto conf = mol.getConformer(confId);
-      const auto &sgs = getSubstanceGroups(mol);
-      for(const auto &sg : sgs){
-        if(!sg.getBrackets().empty()){
-          drawBracketsForSGroup(drawer,mol,sg,regenerateCoords,conf);
-        }
-      }
-    };
-
+void drawMoleculeBrackets(MolDraw2D &drawer, const ROMol &mol,
+                          bool regenerateCoords, int confId) {
+  const auto conf = mol.getConformer(confId);
+  const auto &sgs = getSubstanceGroups(mol);
+  for (const auto &sg : sgs) {
+    if (!sg.getBrackets().empty() || regenerateCoords) {
+      drawBracketsForSGroup(drawer, mol, sg, regenerateCoords, conf);
+    }
+  }
+};
 
 namespace {
 bool isAtomCandForChiralH(const RWMol &mol, const Atom *atom) {

--- a/Code/GraphMol/MolDraw2D/MolDraw2DUtils.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DUtils.cpp
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2016-2021 Greg Landrum
+//  Copyright (C) 2016-2020 Greg Landrum
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.

--- a/Code/GraphMol/MolDraw2D/MolDraw2DUtils.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DUtils.cpp
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2016-2019 Greg Landrum
+//  Copyright (C) 2016-2021 Greg Landrum
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -26,6 +26,31 @@
 
 namespace RDKit {
 namespace MolDraw2DUtils {
+
+namespace {
+  void drawBracketsForSGroup(MolDraw2D &drawer, const ROMol &mol, const SubstanceGroup &sg, bool regenerateCoords, 
+    const Conformer &conf){
+      for(const auto &brk : sg.getBrackets()){
+        const RDGeom::Point2D p1{brk[0]};
+        const RDGeom::Point2D p2{brk[1]};
+        drawer.setColour({0,0,0});
+        drawer.setLineWidth(2);
+        drawer.drawLine(p1,p2);
+      }
+  }
+}
+
+void drawMoleculeBrackets(
+    MolDraw2D &drawer, const ROMol &mol, bool regenerateCoords, int confId){
+      const auto conf = mol.getConformer(confId);
+      const auto &sgs = getSubstanceGroups(mol);
+      for(const auto &sg : sgs){
+        if(!sg.getBrackets().empty()){
+          drawBracketsForSGroup(drawer,mol,sg,regenerateCoords,conf);
+        }
+      }
+    };
+
 
 namespace {
 bool isAtomCandForChiralH(const RWMol &mol, const Atom *atom) {

--- a/Code/GraphMol/MolDraw2D/MolDraw2DUtils.h
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DUtils.h
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2016-2021 Greg Landrum
+//  Copyright (C) 2016-2020 Greg Landrum
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.

--- a/Code/GraphMol/MolDraw2D/MolDraw2DUtils.h
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DUtils.h
@@ -23,19 +23,6 @@ class MolDraw2DColour;
 
 namespace MolDraw2DUtils {
 
-//! adds the brackets from a molecule's SubstanceGroups to the drawing
-/*
-  \param drawer: the MolDraw2D object to use
-  \param mol: the molecule to draw
-  \param regenerateCoords: (optional) forces new coordinates to be regenerated for
-            all brackets
-  \param confId: (optional) conformer ID to be used for atomic coordinates
-
-*/
-RDKIT_MOLDRAW2D_EXPORT void drawMoleculeBrackets(
-    MolDraw2D &drawer, const ROMol &mol, bool regenerateCoords=false, int confId = -1);
-
-
 //! Does some cleanup operations on the molecule to prepare it to draw nicely
 /*
 The operations include: kekulization, addition of chiral Hs (so that we can draw

--- a/Code/GraphMol/MolDraw2D/MolDraw2DUtils.h
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DUtils.h
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2016-2019 Greg Landrum
+//  Copyright (C) 2016-2021 Greg Landrum
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -22,6 +22,20 @@ class MolDraw2D;
 class MolDraw2DColour;
 
 namespace MolDraw2DUtils {
+
+//! adds the brackets from a molecule's SubstanceGroups to the drawing
+/*
+  \param drawer: the MolDraw2D object to use
+  \param mol: the molecule to draw
+  \param regenerateCoords: (optional) forces new coordinates to be regenerated for
+            all brackets
+  \param confId: (optional) conformer ID to be used for atomic coordinates
+
+*/
+RDKIT_MOLDRAW2D_EXPORT void drawMoleculeBrackets(
+    MolDraw2D &drawer, const ROMol &mol, bool regenerateCoords=false, int confId = -1);
+
+
 //! Does some cleanup operations on the molecule to prepare it to draw nicely
 /*
 The operations include: kekulization, addition of chiral Hs (so that we can draw

--- a/Code/GraphMol/MolDraw2D/catch_tests.cpp
+++ b/Code/GraphMol/MolDraw2D/catch_tests.cpp
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2019 Greg Landrum
+//  Copyright (C) 2019-2021 Greg Landrum
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -864,5 +864,52 @@ TEST_CASE("Github #3577", "[bug]") {
     std::ofstream outs("testGithub3577-1.svg");
     outs << text;
     outs.flush();
+  }
+}
+
+TEST_CASE("drawMoleculeBrackets",
+          "[extras]") {
+  SECTION("basics") {
+    auto m = R"CTAB(
+  ACCLDraw11042015112D
+
+  0  0  0     0  0            999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 5 4 1 0 0
+M  V30 BEGIN ATOM
+M  V30 1 C 7 -6.7813 0 0 
+M  V30 2 C 8.0229 -6.1907 0 0 CFG=3 
+M  V30 3 C 8.0229 -5.0092 0 0 
+M  V30 4 C 9.046 -6.7814 0 0 
+M  V30 5 C 10.0692 -6.1907 0 0 
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 1 1 2 
+M  V30 2 1 2 3 
+M  V30 3 1 2 4 
+M  V30 4 1 4 5 
+M  V30 END BOND
+M  V30 BEGIN SGROUP
+M  V30 1 SRU 1 ATOMS=(3 3 2 4) XBONDS=(2 1 4) BRKXYZ=(9 7.51 -7.08 0 7.51 -
+M  V30 -5.9 0 0 0 0) BRKXYZ=(9 9.56 -5.9 0 9.56 -7.08 0 0 0 0) -
+M  V30 CONNECT=HT LABEL=n 
+M  V30 END SGROUP
+M  V30 END CTAB
+M  END
+)CTAB"_ctab;
+    REQUIRE(m);
+    MolDraw2DSVG drawer(350, 300);
+    drawer.drawMolecule(*m);
+    MolDraw2DUtils::drawMoleculeBrackets(drawer,*m);
+    drawer.finishDrawing();
+    auto text = drawer.getDrawingText();
+    std::ofstream outs("testBrackets-1.svg");
+    outs << text;
+    outs.flush();
+
+    // make sure the polygon starts at a bond
+    // CHECK(text.find("<path class='bond-0' d='M 321.962,140") !=
+    //       std::string::npos);
+    // CHECK(text.find("<path d='M 321.962,140") != std::string::npos);
   }
 }

--- a/Code/GraphMol/MolDraw2D/catch_tests.cpp
+++ b/Code/GraphMol/MolDraw2D/catch_tests.cpp
@@ -897,18 +897,46 @@ M  V30 END CTAB
 M  END
 )CTAB"_ctab;
     REQUIRE(m);
-    MolDraw2DSVG drawer(350, 300);
-    drawer.drawMolecule(*m);
-    drawer.finishDrawing();
-    auto text = drawer.getDrawingText();
-    std::ofstream outs("testBrackets-1.svg");
-    outs << text;
-    outs.flush();
-
-    // make sure the polygon starts at a bond
-    // CHECK(text.find("<path class='bond-0' d='M 321.962,140") !=
-    //       std::string::npos);
-    // CHECK(text.find("<path d='M 321.962,140") != std::string::npos);
+    {
+      MolDraw2DSVG drawer(350, 300);
+      drawer.drawMolecule(*m);
+      drawer.finishDrawing();
+      auto text = drawer.getDrawingText();
+      std::ofstream outs("testBrackets-1a.svg");
+      outs << text;
+      outs.flush();
+    }
+    {  // rotation
+      MolDraw2DSVG drawer(350, 300);
+      drawer.drawOptions().rotate = 90;
+      drawer.drawMolecule(*m);
+      drawer.finishDrawing();
+      auto text = drawer.getDrawingText();
+      std::ofstream outs("testBrackets-1b.svg");
+      outs << text;
+      outs.flush();
+    }
+    {  // centering
+      MolDraw2DSVG drawer(350, 300);
+      drawer.drawOptions().centreMoleculesBeforeDrawing = true;
+      drawer.drawMolecule(*m);
+      drawer.finishDrawing();
+      auto text = drawer.getDrawingText();
+      std::ofstream outs("testBrackets-1c.svg");
+      outs << text;
+      outs.flush();
+    }
+    {  // rotation + centering
+      MolDraw2DSVG drawer(350, 300);
+      drawer.drawOptions().centreMoleculesBeforeDrawing = true;
+      drawer.drawOptions().rotate = 90;
+      drawer.drawMolecule(*m);
+      drawer.finishDrawing();
+      auto text = drawer.getDrawingText();
+      std::ofstream outs("testBrackets-1d.svg");
+      outs << text;
+      outs.flush();
+    }
   }
   SECTION("three brackets") {
     auto m = R"CTAB(three brackets
@@ -941,17 +969,45 @@ M  V30 END SGROUP
 M  V30 END CTAB
 M  END)CTAB"_ctab;
     REQUIRE(m);
-    MolDraw2DSVG drawer(350, 300);
-    drawer.drawMolecule(*m);
-    drawer.finishDrawing();
-    auto text = drawer.getDrawingText();
-    std::ofstream outs("testBrackets-2.svg");
-    outs << text;
-    outs.flush();
-
-    // make sure the polygon starts at a bond
-    // CHECK(text.find("<path class='bond-0' d='M 321.962,140") !=
-    //       std::string::npos);
-    // CHECK(text.find("<path d='M 321.962,140") != std::string::npos);
+    {
+      MolDraw2DSVG drawer(350, 300);
+      drawer.drawMolecule(*m);
+      drawer.finishDrawing();
+      auto text = drawer.getDrawingText();
+      std::ofstream outs("testBrackets-2a.svg");
+      outs << text;
+      outs.flush();
+    }
+    {  // rotation
+      MolDraw2DSVG drawer(350, 300);
+      drawer.drawOptions().rotate = 90;
+      drawer.drawMolecule(*m);
+      drawer.finishDrawing();
+      auto text = drawer.getDrawingText();
+      std::ofstream outs("testBrackets-2b.svg");
+      outs << text;
+      outs.flush();
+    }
+    {  // centering
+      MolDraw2DSVG drawer(350, 300);
+      drawer.drawOptions().centreMoleculesBeforeDrawing = true;
+      drawer.drawMolecule(*m);
+      drawer.finishDrawing();
+      auto text = drawer.getDrawingText();
+      std::ofstream outs("testBrackets-2c.svg");
+      outs << text;
+      outs.flush();
+    }
+    {  // rotation + centering
+      MolDraw2DSVG drawer(350, 300);
+      drawer.drawOptions().centreMoleculesBeforeDrawing = true;
+      drawer.drawOptions().rotate = 90;
+      drawer.drawMolecule(*m);
+      drawer.finishDrawing();
+      auto text = drawer.getDrawingText();
+      std::ofstream outs("testBrackets-2d.svg");
+      outs << text;
+      outs.flush();
+    }
   }
 }

--- a/Code/GraphMol/MolDraw2D/catch_tests.cpp
+++ b/Code/GraphMol/MolDraw2D/catch_tests.cpp
@@ -897,7 +897,6 @@ M  V30 END CTAB
 M  END
 )CTAB"_ctab;
     REQUIRE(m);
-    m->getAtomWithIdx(2)->setProp("atomNote", "foo");
     {
       MolDraw2DSVG drawer(350, 300);
       drawer.drawMolecule(*m);

--- a/Code/GraphMol/MolDraw2D/catch_tests.cpp
+++ b/Code/GraphMol/MolDraw2D/catch_tests.cpp
@@ -899,7 +899,6 @@ M  END
     REQUIRE(m);
     MolDraw2DSVG drawer(350, 300);
     drawer.drawMolecule(*m);
-    MolDraw2DUtils::drawMoleculeBrackets(drawer, *m);
     drawer.finishDrawing();
     auto text = drawer.getDrawingText();
     std::ofstream outs("testBrackets-1.svg");
@@ -944,7 +943,6 @@ M  END)CTAB"_ctab;
     REQUIRE(m);
     MolDraw2DSVG drawer(350, 300);
     drawer.drawMolecule(*m);
-    MolDraw2DUtils::drawMoleculeBrackets(drawer, *m);
     drawer.finishDrawing();
     auto text = drawer.getDrawingText();
     std::ofstream outs("testBrackets-2.svg");

--- a/Code/GraphMol/MolDraw2D/catch_tests.cpp
+++ b/Code/GraphMol/MolDraw2D/catch_tests.cpp
@@ -1370,4 +1370,44 @@ M  END
       outs.flush();
     }
   }
+  SECTION("comic brackets (no font though)") {
+    auto m = R"CTAB(
+  ACCLDraw11042015112D
+
+  0  0  0     0  0            999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 5 4 1 0 0
+M  V30 BEGIN ATOM
+M  V30 1 C 7 -6.7813 0 0 
+M  V30 2 C 8.0229 -6.1907 0 0 CFG=3 
+M  V30 3 C 8.0229 -5.0092 0 0 
+M  V30 4 C 9.046 -6.7814 0 0 
+M  V30 5 C 10.0692 -6.1907 0 0 
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 1 1 2 
+M  V30 2 1 2 3 
+M  V30 3 1 2 4 
+M  V30 4 1 4 5 
+M  V30 END BOND
+M  V30 BEGIN SGROUP
+M  V30 1 SRU 1 ATOMS=(3 3 2 4) XBONDS=(2 1 4) BRKXYZ=(9 7.51 -7.08 0 7.51 -
+M  V30 -5.9 0 0 0 0) BRKXYZ=(9 9.56 -5.9 0 9.56 -7.08 0 0 0 0) -
+M  V30 CONNECT=HT LABEL=n 
+M  V30 END SGROUP
+M  V30 END CTAB
+M  END
+)CTAB"_ctab;
+    REQUIRE(m);
+    {
+      MolDraw2DSVG drawer(350, 300);
+      drawer.drawOptions().comicMode = true;
+      drawer.drawMolecule(*m);
+      drawer.finishDrawing();
+      auto text = drawer.getDrawingText();
+      std::ofstream outs("testBrackets-5a.svg");
+      outs << text;
+      outs.flush();
+    }
+  }
 }

--- a/Code/GraphMol/MolDraw2D/catch_tests.cpp
+++ b/Code/GraphMol/MolDraw2D/catch_tests.cpp
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2019-2021 Greg Landrum
+//  Copyright (C) 2019-2020 Greg Landrum
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.

--- a/Code/GraphMol/MolDraw2D/catch_tests.cpp
+++ b/Code/GraphMol/MolDraw2D/catch_tests.cpp
@@ -1010,4 +1010,183 @@ M  END)CTAB"_ctab;
       outs.flush();
     }
   }
+  SECTION("ChEBI 59342") {
+    // thanks to John Mayfield for pointing out the example
+    auto m = R"CTAB(ChEBI59342 
+Marvin  05041012302D          
+
+ 29 30  0  0  1  0            999 V2000
+   10.1615   -7.7974    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
+    8.7305   -6.9763    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
+    8.7309   -7.8004    0.0000 C   0  0  2  0  0  0  0  0  0  0  0  0
+    9.4464   -8.2109    0.0000 C   0  0  2  0  0  0  0  0  0  0  0  0
+    8.0153   -8.2225    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
+    9.4464   -9.0437    0.0000 C   0  0  2  0  0  0  0  0  0  0  0  0
+    8.0138   -9.0500    0.0000 C   0  0  1  0  0  0  0  0  0  0  0  0
+    8.7293   -9.4606    0.0000 C   0  0  1  0  0  0  0  0  0  0  0  0
+   10.1669   -9.4529    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
+    7.3058   -9.4590    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    8.7368  -10.2801    0.0000 N   0  0  0  0  0  0  0  0  0  0  0  0
+    8.0263  -10.6992    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    8.0339  -11.5241    0.0000 H   0  0  0  0  0  0  0  0  0  0  0  0
+    7.3081  -10.2933    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
+    8.7305   -5.3264    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
+    8.0159   -5.7369    0.0000 C   0  0  2  0  0  0  0  0  0  0  0  0
+    8.0159   -6.5618    0.0000 C   0  0  2  0  0  0  0  0  0  0  0  0
+    7.2936   -5.3263    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
+    7.2936   -6.9762    0.0000 C   0  0  2  0  0  0  0  0  0  0  0  0
+    6.5751   -5.7368    0.0000 C   0  0  1  0  0  0  0  0  0  0  0  0
+    6.5751   -6.5618    0.0000 C   0  0  1  0  0  0  0  0  0  0  0  0
+    7.2973   -7.8049    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
+    5.8681   -5.3263    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    5.8680   -6.9762    0.0000 N   0  0  0  0  0  0  0  0  0  0  0  0
+    5.1510   -6.5684    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    4.4392   -6.9856    0.0000 H   0  0  0  0  0  0  0  0  0  0  0  0
+    5.1455   -5.7435    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
+   10.4142   -5.3560    0.0000 *   0  0  0  0  0  0  0  0  0  0  0  0
+   11.5590   -7.8297    0.0000 *   0  0  0  0  0  0  0  0  0  0  0  0
+  3  2  1  6  0  0  0
+  3  4  1  0  0  0  0
+  3  5  1  0  0  0  0
+  4  6  1  0  0  0  0
+  4  1  1  1  0  0  0
+  5  7  1  0  0  0  0
+  6  8  1  0  0  0  0
+  6  9  1  1  0  0  0
+  7 10  1  1  0  0  0
+  8 11  1  6  0  0  0
+  7  8  1  0  0  0  0
+ 13 12  1  0  0  0  0
+ 14 12  2  0  0  0  0
+ 11 12  1  0  0  0  0
+ 16 15  1  6  0  0  0
+ 16 17  1  0  0  0  0
+ 16 18  1  0  0  0  0
+ 17 19  1  0  0  0  0
+ 17  2  1  1  0  0  0
+ 18 20  1  0  0  0  0
+ 19 21  1  0  0  0  0
+ 19 22  1  1  0  0  0
+ 20 23  1  1  0  0  0
+ 21 24  1  6  0  0  0
+ 20 21  1  0  0  0  0
+ 26 25  1  0  0  0  0
+ 27 25  2  0  0  0  0
+ 24 25  1  0  0  0  0
+ 15 28  1  0  0  0  0
+  1 29  1  0  0  0  0
+M  STY  1   1 SRU
+M  SCN  1   1 HT 
+M  SAL   1 15   1   2   3   4   5   6   7   8   9  10  11  12  13  14  15
+M  SAL   1 12  16  17  18  19  20  21  22  23  24  25  26  27
+M  SDI   1  4    9.4310   -4.9261    9.4165   -5.7510
+M  SDI   1  4   10.7464   -7.3983   10.7274   -8.2231
+M  SBL   1  2  30  29
+M  SMT   1 n
+M  END)CTAB"_ctab;
+    REQUIRE(m);
+    {
+      MolDraw2DSVG drawer(350, 300);
+      drawer.drawMolecule(*m);
+      drawer.finishDrawing();
+      auto text = drawer.getDrawingText();
+      std::ofstream outs("testBrackets-3a.svg");
+      outs << text;
+      outs.flush();
+    }
+  }
+  SECTION("pathological bracket orientation") {
+    {  // including the bonds
+      auto m = R"CTAB(bogus
+  Mrv2014 11202009512D          
+
+  0  0  0     0  0            999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 9 8 1 0 1
+M  V30 BEGIN ATOM
+M  V30 1 C 23.5462 -14.464 0 0
+M  V30 2 C 20.8231 -13.0254 0 0
+M  V30 3 C 20.8776 -14.5628 0 0
+M  V30 4 C 22.2391 -15.2819 0 0
+M  V30 5 C 16.2969 -9.9426 0 0
+M  V30 6 C 14.963 -10.7089 0 0
+M  V30 7 C 19.463 -12.2987 0 0
+M  V30 8 * 19.4398 -9.9979 0 0
+M  V30 9 * 26.1554 -14.4332 0 0
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 1 3 4
+M  V30 2 1 6 7
+M  V30 3 1 5 8
+M  V30 4 1 1 9
+M  V30 5 1 7 2
+M  V30 6 1 6 5
+M  V30 7 1 4 1
+M  V30 8 1 3 2
+M  V30 END BOND
+M  V30 BEGIN SGROUP
+M  V30 1 SRU 0 ATOMS=(7 4 3 7 6 5 2 1) XBONDS=(2 3 4) BRKXYZ=(9 17.6045 -
+M  V30 -9.1954 0 17.5775 -10.7352 0 0 0 0) BRKXYZ=(9 24.6113 -13.6813 0 -
+M  V30 24.6296 -15.2213 0 0 0 0) CONNECT=HT LABEL=n
+M  V30 END SGROUP
+M  V30 END CTAB
+M  END
+)CTAB"_ctab;
+      REQUIRE(m);
+      MolDraw2DSVG drawer(350, 300);
+      drawer.drawMolecule(*m);
+      drawer.finishDrawing();
+      auto text = drawer.getDrawingText();
+      std::ofstream outs("testBrackets-4a.svg");
+      outs << text;
+      outs.flush();
+    }
+
+    {  // no bonds in the sgroup, the bracket should point the other way
+       // (towards the majority of the atoms in the sgroup)
+      auto m = R"CTAB(bogus
+  Mrv2014 11202009512D          
+
+  0  0  0     0  0            999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 9 8 1 0 1
+M  V30 BEGIN ATOM
+M  V30 1 C 23.5462 -14.464 0 0
+M  V30 2 C 20.8231 -13.0254 0 0
+M  V30 3 C 20.8776 -14.5628 0 0
+M  V30 4 C 22.2391 -15.2819 0 0
+M  V30 5 C 16.2969 -9.9426 0 0
+M  V30 6 C 14.963 -10.7089 0 0
+M  V30 7 C 19.463 -12.2987 0 0
+M  V30 8 * 19.4398 -9.9979 0 0
+M  V30 9 * 26.1554 -14.4332 0 0
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 1 3 4
+M  V30 2 1 6 7
+M  V30 3 1 5 8
+M  V30 4 1 1 9
+M  V30 5 1 7 2
+M  V30 6 1 6 5
+M  V30 7 1 4 1
+M  V30 8 1 3 2
+M  V30 END BOND
+M  V30 BEGIN SGROUP
+M  V30 1 SRU 0 ATOMS=(7 4 3 7 6 5 2 1) BRKXYZ=(9 17.6045 -
+M  V30 -9.1954 0 17.5775 -10.7352 0 0 0 0) BRKXYZ=(9 24.6113 -13.6813 0 -
+M  V30 24.6296 -15.2213 0 0 0 0) CONNECT=HT LABEL=n
+M  V30 END SGROUP
+M  V30 END CTAB
+M  END
+)CTAB"_ctab;
+      REQUIRE(m);
+      MolDraw2DSVG drawer(350, 300);
+      drawer.drawMolecule(*m);
+      drawer.finishDrawing();
+      auto text = drawer.getDrawingText();
+      std::ofstream outs("testBrackets-4b.svg");
+      outs << text;
+      outs.flush();
+    }
+  }
 }

--- a/Code/GraphMol/MolDraw2D/catch_tests.cpp
+++ b/Code/GraphMol/MolDraw2D/catch_tests.cpp
@@ -937,6 +937,16 @@ M  END
       outs << text;
       outs.flush();
     }
+    {  // rotation
+      MolDraw2DSVG drawer(350, 300);
+      drawer.drawOptions().rotate = 180;
+      drawer.drawMolecule(*m);
+      drawer.finishDrawing();
+      auto text = drawer.getDrawingText();
+      std::ofstream outs("testBrackets-1e.svg");
+      outs << text;
+      outs.flush();
+    }
   }
   SECTION("three brackets") {
     auto m = R"CTAB(three brackets

--- a/Code/GraphMol/MolDraw2D/catch_tests.cpp
+++ b/Code/GraphMol/MolDraw2D/catch_tests.cpp
@@ -867,8 +867,7 @@ TEST_CASE("Github #3577", "[bug]") {
   }
 }
 
-TEST_CASE("drawMoleculeBrackets",
-          "[extras]") {
+TEST_CASE("drawMoleculeBrackets", "[extras]") {
   SECTION("basics") {
     auto m = R"CTAB(
   ACCLDraw11042015112D
@@ -900,10 +899,55 @@ M  END
     REQUIRE(m);
     MolDraw2DSVG drawer(350, 300);
     drawer.drawMolecule(*m);
-    MolDraw2DUtils::drawMoleculeBrackets(drawer,*m);
+    MolDraw2DUtils::drawMoleculeBrackets(drawer, *m);
     drawer.finishDrawing();
     auto text = drawer.getDrawingText();
     std::ofstream outs("testBrackets-1.svg");
+    outs << text;
+    outs.flush();
+
+    // make sure the polygon starts at a bond
+    // CHECK(text.find("<path class='bond-0' d='M 321.962,140") !=
+    //       std::string::npos);
+    // CHECK(text.find("<path d='M 321.962,140") != std::string::npos);
+  }
+  SECTION("three brackets") {
+    auto m = R"CTAB(three brackets
+  Mrv2014 11052006542D          
+
+  0  0  0     0  0            999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 6 5 1 0 0
+M  V30 BEGIN ATOM
+M  V30 1 * -1.375 3.1667 0 0
+M  V30 2 C -0.0413 3.9367 0 0
+M  V30 3 C 1.2924 3.1667 0 0
+M  V30 4 * 2.626 3.9367 0 0
+M  V30 5 C 0.0003 5.6017 0 0
+M  V30 6 * 1.334 6.3717 0 0
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 1 1 2
+M  V30 2 1 2 3
+M  V30 3 1 3 4
+M  V30 4 1 2 5
+M  V30 5 1 5 6
+M  V30 END BOND
+M  V30 BEGIN SGROUP
+M  V30 1 SRU 0 ATOMS=(3 2 3 5) XBONDS=(3 1 3 5) BRKXYZ=(9 0.0875 6.7189 0 -
+M  V30 1.0115 5.1185 0 0 0 0) BRKXYZ=(9 1.3795 4.2839 0 2.3035 2.6835 0 0 0 -
+M  V30 0) BRKXYZ=(9 -0.1285 2.8194 0 -1.0525 4.4198 0 0 0 0) CONNECT=HT -
+M  V30 LABEL=n
+M  V30 END SGROUP
+M  V30 END CTAB
+M  END)CTAB"_ctab;
+    REQUIRE(m);
+    MolDraw2DSVG drawer(350, 300);
+    drawer.drawMolecule(*m);
+    MolDraw2DUtils::drawMoleculeBrackets(drawer, *m);
+    drawer.finishDrawing();
+    auto text = drawer.getDrawingText();
+    std::ofstream outs("testBrackets-2.svg");
     outs << text;
     outs.flush();
 

--- a/Code/GraphMol/MolDraw2D/catch_tests.cpp
+++ b/Code/GraphMol/MolDraw2D/catch_tests.cpp
@@ -897,6 +897,7 @@ M  V30 END CTAB
 M  END
 )CTAB"_ctab;
     REQUIRE(m);
+    m->getAtomWithIdx(2)->setProp("atomNote", "foo");
     {
       MolDraw2DSVG drawer(350, 300);
       drawer.drawMolecule(*m);

--- a/Code/GraphMol/MolTransforms/MolTransforms.cpp
+++ b/Code/GraphMol/MolTransforms/MolTransforms.cpp
@@ -1,5 +1,5 @@
 //
-//   Copyright (C) 2003-2016 Greg Landrum and Rational Discovery LLC
+//   Copyright (C) 2003-2020 Greg Landrum and Rational Discovery LLC
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -142,7 +142,7 @@ void computeInertiaTerms(const Conformer &conf, const RDGeom::Point3D &center,
     yz -= w * loc.z * loc.y;
   }
 }
-}
+}  // namespace
 #ifdef RDK_HAS_EIGEN3
 #include <Eigen/Dense>
 
@@ -346,6 +346,20 @@ void transformConformer(Conformer &conf, const RDGeom::Transform3D &trans) {
   }
 }
 
+void transformMolSubstanceGroups(ROMol &mol, const RDGeom::Transform3D &trans) {
+  auto &sgs = getSubstanceGroups(mol);
+  for (auto &sg : sgs) {
+    for (auto &brk : sg.getBrackets()) {
+      trans.TransformPoint(brk[0]);
+      trans.TransformPoint(brk[1]);
+      trans.TransformPoint(brk[2]);
+    }
+    for (auto &cs : sg.getCStates()) {
+      trans.TransformPoint(cs.vector);
+    }
+  }
+}
+
 void canonicalizeConformer(Conformer &conf, const RDGeom::Point3D *center,
                            bool normalizeCovar, bool ignoreHs) {
   RDGeom::Transform3D *trans =
@@ -403,7 +417,7 @@ void _toBeMovedIdxList(const ROMol &mol, unsigned int iAtomId,
     }
   }
 }
-}
+}  // namespace
 double getBondLength(const Conformer &conf, unsigned int iAtomId,
                      unsigned int jAtomId) {
   const RDGeom::POINT3D_VECT &pos = conf.getPositions();
@@ -606,4 +620,4 @@ void setDihedralRad(Conformer &conf, unsigned int iAtomId, unsigned int jAtomId,
     pos[it] += rotAxisBegin;
   }
 }
-}
+}  // namespace MolTransforms

--- a/Code/GraphMol/MolTransforms/MolTransforms.h
+++ b/Code/GraphMol/MolTransforms/MolTransforms.h
@@ -117,6 +117,10 @@ RDKIT_MOLTRANSFORMS_EXPORT RDGeom::Transform3D *computeCanonicalTransform(
 RDKIT_MOLTRANSFORMS_EXPORT void transformConformer(
     RDKit::Conformer &conf, const RDGeom::Transform3D &trans);
 
+//! Transforms coordinates in a molecule's substance groups
+RDKIT_MOLTRANSFORMS_EXPORT void transformMolSubstanceGroups(
+    RDKit::ROMol &mol, const RDGeom::Transform3D &trans);
+
 //! Canonicalize the orientation of a conformer so that its principal axes
 //! around the specified center point coincide with the x, y, z axes
 /*!

--- a/Code/GraphMol/SubstanceGroup.h
+++ b/Code/GraphMol/SubstanceGroup.h
@@ -138,6 +138,10 @@ class RDKIT_GRAPHMOL_EXPORT SubstanceGroup : public RDProps {
   const std::vector<CState> &getCStates() const { return d_cstates; }
   const std::vector<AttachPoint> &getAttachPoints() const { return d_saps; }
 
+  std::vector<Bracket> &getBrackets() { return d_brackets; }
+  std::vector<CState> &getCStates() { return d_cstates; }
+  std::vector<AttachPoint> &getAttachPoints() { return d_saps; }
+
   void clearBrackets() { d_brackets.clear(); };
   void clearCStates() { d_cstates.clear(); };
   void clearAttachPoints() { d_saps.clear(); };

--- a/Code/GraphMol/SubstanceGroup.h
+++ b/Code/GraphMol/SubstanceGroup.h
@@ -113,7 +113,7 @@ class RDKIT_GRAPHMOL_EXPORT SubstanceGroup : public RDProps {
   }
 
   //! get the index of this sgroup in dp_mol's sgroups vector
-  //! (do not mistake this by the ID!)00
+  //! (do not mistake this by the ID!)
   unsigned int getIndexInMol() const;
 
   /* Atom and Bond methods */


### PR DESCRIPTION
There's also a bit of refactoring of how annotations are handed in general.

Example output:
![image](https://user-images.githubusercontent.com/540511/100234808-e6f75480-2f2b-11eb-8264-ec49090555ac.png)
![image](https://user-images.githubusercontent.com/540511/100234823-eced3580-2f2b-11eb-8561-b2271c2920e7.png)
![image](https://user-images.githubusercontent.com/540511/100234846-f2e31680-2f2b-11eb-8ddd-3b7ebeabc87f.png)

Some additional example files for more testing would certainly also be useful, but I think something is better than nothing and these aren't terrible.