### PR TITLE
update documentation, include reference to Debian Package Tracker

### DIFF
--- a/Docs/Book/Install.md
+++ b/Docs/Book/Install.md
@@ -173,13 +173,14 @@ If you are trying to use multiple installations of PostgreSQL in different envir
 
 ### Installation from repositories
 
-#### Ubuntu 12.04 and later
+#### Ubuntu 12.04 and later, Debian
 
-Thanks to the efforts of the Debichem team, RDKit is available via the Ubuntu repositories. To install:
+Thanks to the efforts of the Debichem team, RDKit is available via the Ubuntu and Debian repositories. To install:
 
 ```shellsession
 $ sudo apt-get install python-rdkit librdkit1 rdkit-data
 ```
+The current status of packaging RDKit for the branches of Debian is published on https://tracker.debian.org/pkg/rdkit
 
 #### Fedora, CentOS, and RHEL
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! 
-->
#### Reference Issue
The description of installing RDKit in Linux mentions Ubuntu, but not Debian.  Sometimes, the version packaged in Debian's repositories (branch testing) is ahead of RDKit's version in Ubuntu releases (especially Ubuntu LTS) releases.


#### What does this implement/fix? Explain your changes.
The change now additionally points to a site listing which version was made available as .deb in either branch stable / testing / unstable and offers contact to the debichem maintainers.

#### Any other comments?
I'm aware a (mini)conda environment may offer using a more recent version of RDKit, than by installing a .deb package.