### PR TITLE
Fixes #3597

### DIFF
--- a/Code/GraphMol/FileParsers/MolFileWriter.cpp
+++ b/Code/GraphMol/FileParsers/MolFileWriter.cpp
@@ -949,7 +949,7 @@ const std::string GetV3000MolFileAtomLine(
     }
   }
 
-  ss << " " << x << " " << y << " " << z;
+  ss << std::fixed << " " << x << " " << y << " " << z << std::defaultfloat;
   ss << " " << atomMapNumber;
 
   // Extra atom properties.

--- a/Code/GraphMol/FileParsers/file_parsers_catch.cpp
+++ b/Code/GraphMol/FileParsers/file_parsers_catch.cpp
@@ -2057,3 +2057,22 @@ M  END
     CHECK(sgs[0].getProp<std::string>("QUERYOP") == "\"");
   }
 }
+
+TEST_CASE("github #3597: Scientific notation in SDF V3000 files", "[bug]") {
+  SECTION("basics") {
+    auto m = R"CTAB(
+  Mrv2020 11302014062D          
+
+  2  1  0  0  0  0            999 V2000
+   -2.8125    1.9196    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -2.0980    2.3321    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+  1  2  1  0  0  0  0
+M  END
+)CTAB"_ctab;
+    REQUIRE(m);
+    m->getConformer().getAtomPos(0).z = 1e-6;
+    m->getConformer().getAtomPos(1).z = 1e-4;
+    auto mb = MolToV3KMolBlock(*m);
+    CHECK(mb.find("1e-06") == std::string::npos);
+  }
+  }

--- a/Code/GraphMol/FileParsers/file_parsers_catch.cpp
+++ b/Code/GraphMol/FileParsers/file_parsers_catch.cpp
@@ -2075,4 +2075,21 @@ M  END
     auto mb = MolToV3KMolBlock(*m);
     CHECK(mb.find("1e-06") == std::string::npos);
   }
+  SECTION("toosmall") {
+    auto m = R"CTAB(
+  Mrv2020 11302014062D          
+
+  2  1  0  0  0  0            999 V2000
+   -2.8125    1.9196    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -2.0980    2.3321    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+  1  2  1  0  0  0  0
+M  END
+)CTAB"_ctab;
+    REQUIRE(m);
+    m->getConformer().getAtomPos(0).z = 1e-17;
+    m->getConformer().getAtomPos(1).z = 1e-4;
+    auto mb = MolToV3KMolBlock(*m);
+    //std::cerr<<mb<<std::endl;
+    CHECK(mb.find("M  V30 1 C -2.812500 1.919600 0.000000 0") != std::string::npos);
+  }
   }


### PR DESCRIPTION
This is a super simple fix to make sure that atomic coordinates are not written using scientific notation.
It's worth noting that the code now always outputs six digits of precision because we've switched to fixed and the default precision for C++ is 6 digits: https://en.cppreference.com/w/cpp/io/ios_base/precision