### PR TITLE
Fixes a few residual issues with the RGD code

### DIFF
--- a/Code/GraphMol/RGroupDecomposition/RGroupData.h
+++ b/Code/GraphMol/RGroupDecomposition/RGroupData.h
@@ -27,7 +27,7 @@ namespace RDKit
 struct RGroupData {
   boost::shared_ptr<RWMol> combinedMol;
   std::vector<boost::shared_ptr<ROMol>> mols;  // All the mols in the rgroup
-  std::set<std::string> smilesSet;             // used for rgroup equivalence
+  std::vector<std::string> smilesVect;         // used for rgroup equivalence
   std::string smiles;                          // smiles for all the mols in the rgroup (with attachments)
   std::set<int> attachments;                   // core attachment points
   bool is_hydrogen = false;
@@ -40,7 +40,7 @@ struct RGroupData {
   RGroupData(const RGroupData &rhs);
 
  public:
-  RGroupData() : combinedMol(), mols(), smilesSet(), smiles(), attachments() {}
+  RGroupData() {}
 
   void add(boost::shared_ptr<ROMol> newMol,
            const std::vector<int> &rlabel_attachments) {
@@ -57,9 +57,7 @@ struct RGroupData {
 
     mols.push_back(newMol);
     std::string smi = MolToSmiles(*newMol, true);
-    // REVIEW: we probably shouldn't be using a set here... the merging of
-    // duplicates is likely not what we want
-    smilesSet.insert(smi);
+    smilesVect.emplace_back(smi);
     if (!combinedMol.get()) {
       combinedMol = boost::shared_ptr<RWMol>(new RWMol(*mols[0].get()));
     } else {
@@ -106,7 +104,7 @@ struct RGroupData {
   //! compute the canonical smiles for the attachments (bug: removes dupes since we are using a set...)
   std::string getSmiles() const {
     std::string s;
-    for (const auto &it : smilesSet) {
+    for (const auto &it : smilesVect) {
       if (s.length()) {
         s += ".";
       }

--- a/Code/GraphMol/RGroupDecomposition/RGroupData.h
+++ b/Code/GraphMol/RGroupDecomposition/RGroupData.h
@@ -56,8 +56,7 @@ struct RGroupData {
               std::inserter(attachments, attachments.end()));
 
     mols.push_back(newMol);
-    std::string smi = MolToSmiles(*newMol, true);
-    smilesVect.emplace_back(smi);
+    smilesVect.emplace_back(MolToSmiles(*newMol, true));
     if (!combinedMol.get()) {
       combinedMol = boost::shared_ptr<RWMol>(new RWMol(*mols[0].get()));
     } else {

--- a/Code/GraphMol/RGroupDecomposition/RGroupDecomp.cpp
+++ b/Code/GraphMol/RGroupDecomposition/RGroupDecomp.cpp
@@ -136,7 +136,7 @@ int RGroupDecomposition::add(const ROMol &inmol) {
       tmatches = tmatches_filtered;
     }
 
-    if (!tmatches.size()) {
+    if (tmatches.empty()) {
       continue;
     } else {
       if (tmatches.size() > 1) {
@@ -169,8 +169,6 @@ int RGroupDecomposition::add(const ROMol &inmol) {
 
   //  Should probably scan all mols first to find match with
   //  smallest number of matches...
-  size_t size = data->matches.size();
-
   std::vector<RGroupMatch> potentialMatches;
 
   std::unique_ptr<ROMol> tMol;
@@ -191,7 +189,7 @@ int RGroupDecomposition::add(const ROMol &inmol) {
         std::vector<int> attachments;
         boost::shared_ptr<ROMol> &newMol = fragments[i];
         newMol->setProp<int>("core", core_idx);
-        newMol->setProp<int>("idx", size);
+        newMol->setProp<int>("idx", data->matches.size());
         newMol->setProp<int>("frag_idx", i);
 
         for (auto at : newMol->atoms()) {
@@ -289,10 +287,11 @@ int RGroupDecomposition::add(const ROMol &inmol) {
   data->matches.push_back(potentialMatches);
   data->permutation = std::vector<size_t>(data->matches.size(), 0);
 
-  if (size) {
+  if (data->matches.size()) {
     if (data->params.matchingStrategy & Greedy ||
-        (data->params.matchingStrategy & GreedyChunks && size > 1 &&
-         size % data->params.chunkSize == 0)) {
+        (data->params.matchingStrategy & GreedyChunks &&
+         data->matches.size() > 1 &&
+         data->matches.size() % data->params.chunkSize == 0)) {
       data->process(true);
     }
   }

--- a/Code/GraphMol/RGroupDecomposition/RGroupDecompParams.cpp
+++ b/Code/GraphMol/RGroupDecomposition/RGroupDecompParams.cpp
@@ -93,10 +93,12 @@ bool RGroupDecompositionParameters::prepareCore(RWMol &core,
     autoLabels = autoGetLabels(core);
     if (!autoLabels) {
       BOOST_LOG(rdWarningLog) << "RGroupDecomposition auto detect found no "
-                                 "rgroups and onlyMatAtRgroups is set to true"
+                                 "rgroups and onlyMatchAtRgroups is set to true"
                               << std::endl;
       return false;
     }
+  } else if (!onlyMatchAtRGroups) {
+    autoLabels |= AtomIndexLabels;
   }
 
   int maxLabel = 1;

--- a/Code/GraphMol/RGroupDecomposition/RGroupScore.cpp
+++ b/Code/GraphMol/RGroupDecomposition/RGroupScore.cpp
@@ -53,25 +53,18 @@ double score(const std::vector<size_t> &permutation,
       std::cerr << " " << rg->second->combinedMol->getNumAtoms(false)
                 << " score: " << count << std::endl;
 #endif
-      for (size_t posStart = 0, i = 0; posStart < rg->second->smiles.size(); ++i) {
-        size_t posEnd = rg->second->smiles.find('.', posStart);
-        size_t posStartNext = 0;
-        if (posEnd != std::string::npos) {
-          posStartNext = posEnd + 1;
-          posEnd -= posStart;
-        } else {
-          posStartNext = rg->second->smiles.size();
-        }
+      size_t i = 0;
+      for (const auto &smiles : rg->second->smilesVect) {
         if (i == matchSetVect.size()) {
           matchSetVect.resize(i + 1);
         }
-        unsigned int &count = matchSetVect[i][rg->second->smiles.substr(posStart, posEnd)];
+        unsigned int &count = matchSetVect[i][smiles];
         ++count;
 #ifdef DEBUG
         std::cerr << " Linker Score: "
                   << linkerMatchSet[rg->second->attachments] << std::endl;
 #endif
-        posStart = posStartNext;
+        ++i;
       }
     }
     

--- a/Code/GraphMol/RGroupDecomposition/RGroupScore.h
+++ b/Code/GraphMol/RGroupDecomposition/RGroupScore.h
@@ -42,13 +42,15 @@ struct CartesianProduct {
     return increment(0);
   }
 
-  size_t value() {
+  size_t value(const std::vector<size_t> &p) {
     size_t v = 0;
-    for (size_t i = 0; i < permutation.size(); ++i) {
-      v += bases[i] * permutation[i];
+    for (size_t i = 0; i < p.size(); ++i) {
+      v += bases[i] * p[i];
     }
     return v;
   }
+
+  size_t value() { return value(permutation); }
 
   bool increment(size_t rowToIncrement) {
     if (permutationCount > maxPermutations) {

--- a/Code/GraphMol/RGroupDecomposition/testRGroupDecomp.cpp
+++ b/Code/GraphMol/RGroupDecomposition/testRGroupDecomp.cpp
@@ -43,12 +43,18 @@
 #include <boost/tokenizer.hpp>
 #include <regex>
 
+//#define DEBUG
+
 typedef boost::tokenizer<boost::char_separator<char>> tokenizer;
 
 using namespace RDKit;
 
 void CHECK_RGROUP(RGroupRows::const_iterator &it, const std::string &expected,
+#ifdef DEBUG
+                  bool doassert = false) {
+#else
                   bool doassert = true) {
+#endif
   std::ostringstream str;
   int i = 0;
 
@@ -425,7 +431,7 @@ void testGitHubIssue1705() {
       }
     }
     delete core;
-    TEST_ASSERT(ss.str() == R"RES(Rgroup===Core
+    std::string expected = R"RES(Rgroup===Core
 Oc1ccc([*:2])cc1[*:1]
 Oc1ccc([*:2])cc1[*:1]
 Oc1ccc([*:2])cc1[*:1]
@@ -443,7 +449,16 @@ Rgroup===R2
 [H][*:2]
 N[*:2]
 [H][*:2]
-)RES");
+)RES";
+#ifdef DEBUG
+    if (ss.str() != expected) {
+      std::cerr << __LINE__ << " ERROR got\n"
+                << ss.str() << "\nexpected\n"
+                << expected << std::endl;
+    }
+#else
+    TEST_ASSERT(ss.str() == expected);
+#endif
   }
 #endif
   // std::cerr<<"n\n\n\n\n\n--------------------------------------------------------------\n\n\n\n\n";
@@ -470,22 +485,31 @@ N[*:2]
       }
     }
     delete core;
-    TEST_ASSERT(ss.str() == R"RES(Rgroup===Core
+    std::string expected = R"RES(Rgroup===Core
 Cc1c([*:1])cccc1[*:2]
 Cc1c([*:1])cccc1[*:2]
 Cc1c([*:1])cccc1[*:2]
 Cc1c([*:1])cccc1[*:2]
 Rgroup===R1
 [H][*:1]
-[H][*:1]
-[H][*:1]
+F[*:1]
+F[*:1]
 F[*:1]
 Rgroup===R2
 [H][*:2]
+[H][*:2]
+[H][*:2]
 F[*:2]
-F[*:2]
-F[*:2]
-)RES");
+)RES";
+#ifdef DEBUG
+    if (ss.str() != expected) {
+      std::cerr << __LINE__ << " ERROR got\n"
+                << ss.str() << "\nexpected\n"
+                << expected << std::endl;
+    }
+#else
+    TEST_ASSERT(ss.str() == expected);
+#endif
   }
 }
 
@@ -575,6 +599,9 @@ M  END
 }
 
 void testSDFGRoupMultiCoreNoneShouldMatch() {
+  BOOST_LOG(rdInfoLog)
+      << "********************************************************\n";
+  BOOST_LOG(rdInfoLog) << "testSDFGRoupMultiCoreNoneShouldMatch" << std::endl;
   std::string sdcores = R"CTAB(
   Mrv1813 05061918272D          
 
@@ -930,7 +957,7 @@ void testRowColumnAlignmentProblem() {
 void testSymmetryIssues() {
   BOOST_LOG(rdInfoLog)
       << "********************************************************\n";
-  BOOST_LOG(rdInfoLog) << "Testing R-Group symmetry issues \n";
+  BOOST_LOG(rdInfoLog) << "Testing R-Group symmetry issues\n";
 
   auto m1 = "c1c(F)cccn1"_smiles;
   auto m2 = "c1c(Cl)c(C)ccn1"_smiles;
@@ -1025,7 +1052,7 @@ F[*:3]
 void testSymmetryPerformance() {
   BOOST_LOG(rdInfoLog)
       << "********************************************************\n";
-  BOOST_LOG(rdInfoLog) << "Testing R-Group symmetry issues \n";
+  BOOST_LOG(rdInfoLog) << "Testing R-Group symmetry performance\n";
   boost::logging::disable_logs("rdApp.warning");
 
   std::string smis =
@@ -1201,7 +1228,7 @@ Cn1cnc2cc(Oc3cc(N4CCN(Cc5ccccc5-c5ccc(Cl)cc5)CC4)ccc3C(=O)NS(=O)(=O)c3ccc(NCCCN4
 void testScorePermutations() {
   BOOST_LOG(rdInfoLog)
       << "********************************************************\n";
-  BOOST_LOG(rdInfoLog) << "Testing permutation scoring function \n";
+  BOOST_LOG(rdInfoLog) << "Testing permutation scoring function\n";
 
   {
     auto core = "Cc1ccccc1"_smiles;
@@ -1224,22 +1251,31 @@ void testScorePermutations() {
     }
     TEST_ASSERT(r_labels == std::set<std::string>({"Core", "R1", "R2"}));
     TEST_ASSERT(groups.size() == 3);
-    TEST_ASSERT(ss.str() == R"RES(Rgroup===Core
+    std::string expected = R"RES(Rgroup===Core
 Cc1c([*:1])cccc1[*:2]
 Cc1c([*:1])cccc1[*:2]
 Cc1c([*:1])cccc1[*:2]
 Cc1c([*:1])cccc1[*:2]
 Rgroup===R1
 [H][*:1]
-[H][*:1]
-[H][*:1]
+F[*:1]
+F[*:1]
 F[*:1]
 Rgroup===R2
 [H][*:2]
+[H][*:2]
+[H][*:2]
 F[*:2]
-F[*:2]
-F[*:2]
-)RES");
+)RES";
+#ifdef DEBUG
+    if (ss.str() != expected) {
+      std::cerr << __LINE__ << " ERROR got\n"
+                << ss.str() << "\nexpected\n"
+                << expected << std::endl;
+    }
+#else
+    TEST_ASSERT(ss.str() == expected);
+#endif
   }
   {
     auto core = "Cc1ccccc1"_smiles;
@@ -1263,7 +1299,7 @@ F[*:2]
     }
     TEST_ASSERT(r_labels == std::set<std::string>({"Core", "R1", "R2"}));
     TEST_ASSERT(groups.size() == 3);
-    TEST_ASSERT(ss.str() == R"RES(Rgroup===Core
+    std::string expected = R"RES(Rgroup===Core
 Cc1c([*:1])cccc1[*:2]
 Cc1c([*:1])cccc1[*:2]
 Cc1c([*:1])cccc1[*:2]
@@ -1278,7 +1314,16 @@ Cl[*:2]
 F[*:2]
 F[*:2]
 F[*:2]
-)RES");
+)RES";
+#ifdef DEBUG
+    if (ss.str() != expected) {
+      std::cerr << __LINE__ << " ERROR got\n"
+                << ss.str() << "\nexpected\n"
+                << expected << std::endl;
+    }
+#else
+    TEST_ASSERT(ss.str() == expected);
+#endif
   }
   {
     auto core = "O1C([*:1])([*:2])CCC1"_smiles;
@@ -1315,7 +1360,7 @@ F[*:2]
     }
     TEST_ASSERT(r_labels == std::set<std::string>({"Core", "R1", "R2"}));
     TEST_ASSERT(groups.size() == 3);
-    TEST_ASSERT(ss.str() == R"RES(Rgroup===Core
+    std::string expected = R"RES(Rgroup===Core
 C1COC([*:1])([*:2])C1
 C1COC([*:1])([*:2])C1
 C1COC([*:1])([*:2])C1
@@ -1357,7 +1402,16 @@ CC[*:2]
 OC[*:2]
 OC[*:2]
 CCCC[*:2]
-)RES");
+)RES";
+#ifdef DEBUG
+    if (ss.str() != expected) {
+      std::cerr << __LINE__ << " ERROR got\n"
+                << ss.str() << "\nexpected\n"
+                << expected << std::endl;
+    }
+#else
+    TEST_ASSERT(ss.str() == expected);
+#endif
   }
 }
 
@@ -1388,28 +1442,30 @@ void testMultiCorePreLabelled() {
       i = 0;
       for (RGroupRows::const_iterator it = rows.begin(); it != rows.end();
            ++it, ++i) {
-        CHECK_RGROUP(it, expectedRows[i] /*, false*/);
+        CHECK_RGROUP(it, expectedRows[i]);
       }
       RGroupColumns groups = decomp.getRGroupsAsColumns();
       i = 0;
       TEST_ASSERT(groups.size() == 3);
       for (const auto &pair : groups) {
-        /*
+#ifdef DEBUG
         if (pair.first != expectedLabels[i]) {
-          std::cerr << "ERROR: Expected " << expectedLabels[i] << ", got "
-                    << pair.first << std::endl;
+          std::cerr << __LINE__ << " ERROR: Expected " << expectedLabels[i]
+                    << ", got " << pair.first << std::endl;
         }
-        */
+#else
         TEST_ASSERT(pair.first == expectedLabels[i]);
+#endif
         unsigned int j = 0;
         for (const auto &item : pair.second) {
-          /*
+#ifdef DEBUG
           if (expectedItems[i][j] != MolToSmiles(*item)) {
-            std::cerr << "ERROR: Expected " << expectedItems[i][j] << ", got "
-                      << MolToSmiles(*item) << std::endl;
+            std::cerr << __LINE__ << " ERROR: Expected " << expectedItems[i][j]
+                      << ", got " << MolToSmiles(*item) << std::endl;
           }
-          */
+#else
           TEST_ASSERT(expectedItems[i][j] == MolToSmiles(*item));
+#endif
           ++j;
         }
         ++i;
@@ -1653,6 +1709,70 @@ $$$$
   }
 }
 
+void testGeminalRGroups() {
+  BOOST_LOG(rdInfoLog)
+      << "********************************************************\n";
+  BOOST_LOG(rdInfoLog) << "test core with geminal R-groups" << std::endl;
+  std::string core_ctab = R"CTAB(
+     RDKit          2D
+
+  8  8  0  0  0  0  0  0  0  0999 V2000
+   -0.6026    1.2267    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -1.3171    0.8142    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -1.3171   -0.0108    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -0.6026   -0.4232    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    0.1118   -0.0108    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    0.1118    0.8142    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -1.0714    1.7839    0.0000 R#  0  0  0  0  0  0  0  0  0  0  0  0
+   -0.0506    1.8398    0.0000 R#  0  0  0  0  0  0  0  0  0  0  0  0
+  2  3  1  0  0  0  0
+  3  4  1  0  0  0  0
+  4  5  1  0  0  0  0
+  5  6  1  0  0  0  0
+  1  2  1  0  0  0  0
+  1  6  1  0  0  0  0
+  1  7  1  0  0  0  0
+  1  8  1  0  0  0  0
+M  RGP  2   7   5   8   6
+M  END
+)CTAB";
+  ROMOL_SPTR core(MolBlockToMol(core_ctab));
+  const std::vector<const char *> smilesData{"C1CCCCC12CC2", "C1CCCCC1(C)C",
+                                             "C1CCCCC1(Cl)Br"};
+
+  // the test should yield the same results irrespective of the permutations
+  // across the two parameters
+  for (auto matchAtRGroup = 0; matchAtRGroup < 2; ++matchAtRGroup) {
+    for (auto mdlRGroupLabels = 0; mdlRGroupLabels < 2; ++mdlRGroupLabels) {
+      RGroupDecompositionParameters params;
+      if (matchAtRGroup) {
+        params.labels = MDLRGroupLabels;
+      }
+      if (mdlRGroupLabels) {
+        params.labels = MDLRGroupLabels;
+      }
+      RGroupDecomposition decomp(*core, params);
+      for (const auto &smi : smilesData) {
+        ROMol *mol = SmilesToMol(smi);
+        TEST_ASSERT(decomp.add(*mol) != -1);
+        delete mol;
+      }
+      TEST_ASSERT(decomp.process());
+      auto rows = decomp.getRGroupsAsRows();
+      const std::vector<const char *> res{
+          "Core:C1CCC([*:5])([*:6])CC1 R5:C(C[*:6])[*:5] R6:C(C[*:6])[*:5]",
+          "Core:C1CCC([*:5])([*:6])CC1 R5:C[*:5] R6:C[*:6]",
+          "Core:C1CCC([*:5])([*:6])CC1 R5:Br[*:5] R6:Cl[*:6]"};
+      TEST_ASSERT(rows.size() == res.size());
+      size_t i = 0;
+      for (RGroupRows::const_iterator it = rows.begin(); it != rows.end();
+           ++it) {
+        CHECK_RGROUP(it, res.at(i++));
+      }
+    }
+  }
+}
+
 int main() {
   RDLog::InitLogs();
 
@@ -1681,6 +1801,7 @@ int main() {
   testScorePermutations();
   testMultiCorePreLabelled();
   testCoreWithRGroupAdjQuery();
+  testGeminalRGroups();
   BOOST_LOG(rdInfoLog)
       << "********************************************************\n";
   return 0;


### PR DESCRIPTION
Sorry Brian, another one for the exclusive RGD club. If you get to the end of the PR review you'll get the "RGD Master" qualification and a life-long unlimited Advil liquid capsule supply.

- replaced `set` with `vector` for SMILES-based R-group equivalence
As anticipated in one of Brian's comment (that I have removed). the `set` should rather be a `vector` to properly address `bis` geminal susbtitution
- the first `GreedyChunk` is constituted by `chunkSize+1` mols
An outdated copy of `matches.size()` was being used, with the consequence that the first `GreedyChunk` was constituted by `chunkSize+1` mols rather than `chunkSize`
- labeled R-groups may not be extracted when `onlyMatchAtRGroups==false`
This bug was originally reported by @rvianello (see <i>Bug description</i> below) and it costed some proper headache to figure out what the problem was (1).
What happens is that when `onlyMatchAtRGroups==false` the code may decide that the best permutation is the one with all H's as it is soooo consistent, even though not particularly useful
- labeled geminal R-groups are incorrectly scored
This bug was originally reported by @rvianello (see <i>Bug description</i> below) and it costed some proper headache to figure out what the problem was (2).
This is due to the fact that added geminal R-groups need to be scored in isolation while going through permutations, or they consistently score higher than the user-labeled ones, which is annoying
- my attempt to introduce consistency in R-group labeling was buggy
My previous attempt at making R-group labeling consistent was buggy: the whole signed increment idea was incorrect; I have replaced it by proper label sorting (positive, user-defined labels first, followed by negative, auto-detected labels). On top of that, there were missing assignments and wrong signs. The combination of all this somehow yielded (almost) correct unit test results by pure chance. Yuk.
- added a `DEBUG` pre-processor directive to the tests to make debugging easier
This makes the life of RGD club members marginally less miserable when they decide to spend some nights chasing bugs
- added a unit test
To check that the RGD result in the example below do not change irrespective of the flags
- fixed unit test results which were inconsistent with the expected behavior
Some of the results of unit tests contradicted the consistency rules that I introduced in a previous PR, but I hadn't realized that

<h1>Bug description</h1>

```
from rdkit import Chem
from rdkit.Chem import Draw
from rdkit.Chem.Draw import IPythonConsole
IPythonConsole.molSize=(450,350)
from rdkit.Chem import rdRGroupDecomposition
from rdkit.Chem import rdqueries
from rdkit.Chem import rdDepictor
from rdkit.Chem.Draw import rdMolDraw2D
from rdkit import Geometry
rdDepictor.SetPreferCoordGen(True)

from IPython.display import SVG,Image

import rdkit
print(rdkit.__version__)
2021.03.1dev1

def draw(mol, **kwargs):
    mol_draw = rdMolDraw2D.PrepareMolForDrawing(mol)
    draw_opt = rdMolDraw2D.MolDrawOptions()
    draw_opt.addAtomIndices = True
    drawer = rdMolDraw2D.MolDraw2DSVG(400, 300)
    drawer.SetDrawOptions(draw_opt)
    drawer.DrawMolecule(mol_draw, **kwargs)
    drawer.FinishDrawing()
    return SVG(drawer.GetDrawingText())

core_ctab = '''
     RDKit          2D

  8  8  0  0  0  0  0  0  0  0999 V2000
   -0.6026    1.2267    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
   -1.3171    0.8142    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
   -1.3171   -0.0108    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
   -0.6026   -0.4232    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
    0.1118   -0.0108    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
    0.1118    0.8142    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
   -1.0714    1.7839    0.0000 R#  0  0  0  0  0  0  0  0  0  0  0  0
   -0.0506    1.8398    0.0000 R#  0  0  0  0  0  0  0  0  0  0  0  0
  2  3  1  0  0  0  0
  3  4  1  0  0  0  0
  4  5  1  0  0  0  0
  5  6  1  0  0  0  0
  1  2  1  0  0  0  0
  1  6  1  0  0  0  0
  1  7  1  0  0  0  0
  1  8  1  0  0  0  0
M  RGP  2   7   5   8   6
M  END'''
core = Chem.MolFromMolBlock(core_ctab)
```
This is the user-labeled core:
```
draw(core)
```
![image](https://user-images.githubusercontent.com/5244385/100753695-6d0f1180-33ea-11eb-88d6-fb5728c03f5f.png)
```
smiles = 'C1CCCCC12CC2', 'C1CCCCC1(C)C', 'C1CCCCC1(Cl)Br'
mols = [Chem.MolFromSmiles(s) for s in smiles]
```
And these are 3 mols that match the core:
```
draw(mols[0])
```
![image](https://user-images.githubusercontent.com/5244385/100753771-82843b80-33ea-11eb-904f-1036d0a133b2.png)
```
draw(mols[1])
```
![image](https://user-images.githubusercontent.com/5244385/100753840-9af45600-33ea-11eb-8080-e7d5941f6a2a.png)
```
draw(mols[2])
```
![image](https://user-images.githubusercontent.com/5244385/100753903-ae9fbc80-33ea-11eb-9761-c5e83d73088e.png)

<h2>Behavior 1</h2>

```
ps = rdRGroupDecomposition.RGroupDecompositionParameters()
#ps.onlyMatchAtRGroups = True
#ps.labels = rdRGroupDecomposition.MDLRGroupLabels
rgd = rdRGroupDecomposition.RGroupDecomposition(core, ps)
for s in smiles:
    rgd.Add(Chem.MolFromSmiles(s))
rgd.Process()
True

rgd.GetRGroupsAsRows(asSmiles=True)
[{'Core': 'C1CCC([*:5])([*:6])C([*:1])C1', 'R1': 'C(C[*:1])[*:1]'},
 {'Core': 'C1CCC([*:5])([*:6])C([*:1])C1', 'R1': 'C[*:1].C[*:1]'},
 {'Core': 'C1CCC([*:5])([*:6])C([*:1])C1', 'R1': 'Br[*:1].Cl[*:1]'}]
```
This is not the most desirable behavior: there are two user-labeled R-groups; nevertheless, the RGD code prefers the autodetected added R-group because it scores higher. This PR fixes this and you get the expected result:
```
[{'Core': 'C1CCC([*:5])([*:6])CC1',
  'R5': 'C(C[*:6])[*:5]',
  'R6': 'C(C[*:6])[*:5]'},
 {'Core': 'C1CCC([*:5])([*:6])CC1', 'R5': 'C[*:5]', 'R6': 'C[*:6]'},
 {'Core': 'C1CCC([*:5])([*:6])CC1', 'R5': 'Br[*:5]', 'R6': 'Cl[*:6]'}]
```

<h2>Behavior 2</h2>

```
ps = rdRGroupDecomposition.RGroupDecompositionParameters()
#ps.onlyMatchAtRGroups = True
ps.labels = rdRGroupDecomposition.MDLRGroupLabels
rgd = rdRGroupDecomposition.RGroupDecomposition(core, ps)
for s in smiles:
    rgd.Add(Chem.MolFromSmiles(s))
rgd.Process()
True
rgd.GetRGroupsAsRows(asSmiles=True)
[{'Core': 'C1CCC([*:5])([*:6])CC1'},
 {'Core': 'C1CCC([*:5])([*:6])CC1'},
 {'Core': 'C1CCC([*:5])([*:6])CC1'}]
```
In this case, no R-groups are extracted. Upon debugging, I realized that this happens because the `'[H],[H]', [H],[H]', [H],[H]'` triplet is the one that scores highest as it is the most consistent, though not really useful. This PR fixes this and you get the expected result:
```
[{'Core': 'C1CCC([*:5])([*:6])CC1',
  'R5': 'C(C[*:6])[*:5]',
  'R6': 'C(C[*:6])[*:5]'},
 {'Core': 'C1CCC([*:5])([*:6])CC1', 'R5': 'C[*:5]', 'R6': 'C[*:6]'},
 {'Core': 'C1CCC([*:5])([*:6])CC1', 'R5': 'Br[*:5]', 'R6': 'Cl[*:6]'}]
```

<h2>Behavior 3</h2>

```
ps = rdRGroupDecomposition.RGroupDecompositionParameters()
ps.onlyMatchAtRGroups = True
#ps.labels = rdRGroupDecomposition.MDLRGroupLabels
rgd = rdRGroupDecomposition.RGroupDecomposition(core, ps)
for s in smiles:
    rgd.Add(Chem.MolFromSmiles(s))
rgd.Process()
True
rgd.GetRGroupsAsRows(asSmiles=True)
[{'Core': 'C1CCC([*:5])([*:6])CC1',
  'R5': 'C(C[*:6])[*:5]',
  'R6': 'C(C[*:6])[*:5]'},
 {'Core': 'C1CCC([*:5])([*:6])CC1', 'R5': 'C[*:5]', 'R6': 'C[*:6]'},
 {'Core': 'C1CCC([*:5])([*:6])CC1', 'R5': 'Br[*:5]', 'R6': 'Cl[*:6]'}]
```
This the expected behavior, still works with this PR.

<h2>Behavior 4 (same as 3)</h2>

```
ps = rdRGroupDecomposition.RGroupDecompositionParameters()
ps.onlyMatchAtRGroups = True
ps.labels = rdRGroupDecomposition.MDLRGroupLabels
rgd = rdRGroupDecomposition.RGroupDecomposition(core, ps)
for s in smiles:
    rgd.Add(Chem.MolFromSmiles(s))
rgd.Process()
True
rgd.GetRGroupsAsRows(asSmiles=True)
[{'Core': 'C1CCC([*:5])([*:6])CC1',
  'R5': 'C(C[*:6])[*:5]',
  'R6': 'C(C[*:6])[*:5]'},
 {'Core': 'C1CCC([*:5])([*:6])CC1', 'R5': 'C[*:5]', 'R6': 'C[*:6]'},
 {'Core': 'C1CCC([*:5])([*:6])CC1', 'R5': 'Br[*:5]', 'R6': 'Cl[*:6]'}]
```
This the expected behavior, still works with this PR.
