### PR TITLE
Fixes #3543

### DIFF
--- a/Code/GraphMol/FileParsers/PNGParser.cpp
+++ b/Code/GraphMol/FileParsers/PNGParser.cpp
@@ -250,6 +250,7 @@ std::string addMetadataToPNGStream(
 std::string addMolToPNGStream(const ROMol &mol, std::istream &iStream,
                               bool includePkl, bool includeSmiles,
                               bool includeMol) {
+std::cerr<<"addMolToPngStream"<<std::endl;
   std::vector<std::pair<std::string, std::string>> metadata;
   if (includePkl) {
     std::string pkl;
@@ -261,9 +262,13 @@ std::string addMolToPNGStream(const ROMol &mol, std::istream &iStream,
     metadata.push_back(std::make_pair(augmentTagName(PNGData::smilesTag), smi));
   }
   if (includeMol) {
-    std::string mb = MolToMolBlock(mol);
+    bool includeStereo = true;
+    int confId = -1;
+    bool kekulize = false;
+    std::string mb = MolToMolBlock(mol,includeStereo,confId,kekulize);
     metadata.push_back(std::make_pair(augmentTagName(PNGData::molTag), mb));
   }
+std::cerr<<"done"<<std::endl;
   return addMetadataToPNGStream(iStream, metadata);
 };
 

--- a/Code/GraphMol/FileParsers/PNGParser.cpp
+++ b/Code/GraphMol/FileParsers/PNGParser.cpp
@@ -250,7 +250,6 @@ std::string addMetadataToPNGStream(
 std::string addMolToPNGStream(const ROMol &mol, std::istream &iStream,
                               bool includePkl, bool includeSmiles,
                               bool includeMol) {
-std::cerr<<"addMolToPngStream"<<std::endl;
   std::vector<std::pair<std::string, std::string>> metadata;
   if (includePkl) {
     std::string pkl;
@@ -265,10 +264,9 @@ std::cerr<<"addMolToPngStream"<<std::endl;
     bool includeStereo = true;
     int confId = -1;
     bool kekulize = false;
-    std::string mb = MolToMolBlock(mol,includeStereo,confId,kekulize);
+    std::string mb = MolToMolBlock(mol, includeStereo, confId, kekulize);
     metadata.push_back(std::make_pair(augmentTagName(PNGData::molTag), mb));
   }
-std::cerr<<"done"<<std::endl;
   return addMetadataToPNGStream(iStream, metadata);
 };
 

--- a/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
@@ -388,7 +388,6 @@ void MolDraw2D::get2DCoordsMol(RWMol &mol, double &offset, double spacing,
   const bool canonOrient = true;
   const bool kekulize = false;  // don't kekulize, we just did that
   RDDepict::compute2DCoords(mol, nullptr, canonOrient);
-      std::cerr<<" prepare prepare2"<<std::endl;
 
   MolDraw2DUtils::prepareMolForDrawing(mol, kekulize);
   double minX = 1e8;
@@ -1273,7 +1272,6 @@ unique_ptr<RWMol> MolDraw2D::setupDrawMolecule(
   unique_ptr<RWMol> rwmol;
   if (drawOptions().prepareMolsBeforeDrawing || !mol.getNumConformers()) {
     rwmol.reset(new RWMol(mol));
-    std::cerr<<" prepare prepare"<<std::endl;
     MolDraw2DUtils::prepareMolForDrawing(*rwmol);
   }
   if (drawOptions().centreMoleculesBeforeDrawing) {

--- a/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
@@ -388,6 +388,8 @@ void MolDraw2D::get2DCoordsMol(RWMol &mol, double &offset, double spacing,
   const bool canonOrient = true;
   const bool kekulize = false;  // don't kekulize, we just did that
   RDDepict::compute2DCoords(mol, nullptr, canonOrient);
+      std::cerr<<" prepare prepare2"<<std::endl;
+
   MolDraw2DUtils::prepareMolForDrawing(mol, kekulize);
   double minX = 1e8;
   double maxX = -1e8;
@@ -1271,6 +1273,7 @@ unique_ptr<RWMol> MolDraw2D::setupDrawMolecule(
   unique_ptr<RWMol> rwmol;
   if (drawOptions().prepareMolsBeforeDrawing || !mol.getNumConformers()) {
     rwmol.reset(new RWMol(mol));
+    std::cerr<<" prepare prepare"<<std::endl;
     MolDraw2DUtils::prepareMolForDrawing(*rwmol);
   }
   if (drawOptions().centreMoleculesBeforeDrawing) {

--- a/Code/GraphMol/MolDraw2D/MolDraw2DCairo.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DCairo.cpp
@@ -226,7 +226,8 @@ void addMoleculeMetadata(
 
   bool includeStereo = true;
   if (mol.getNumConformers()) {
-    auto molb = MolToMolBlock(mol, includeStereo, confId);
+    bool kekulize = false;
+    auto molb = MolToMolBlock(mol, includeStereo, confId, kekulize);
     metadata.push_back(
         std::make_pair(augmentTagName(PNGData::molTag + suffix), molb));
   }

--- a/Code/GraphMol/MolDraw2D/catch_tests.cpp
+++ b/Code/GraphMol/MolDraw2D/catch_tests.cpp
@@ -1409,3 +1409,37 @@ M  END
     }
   }
 }
+
+#ifdef RDK_BUILD_CAIRO_SUPPORT
+TEST_CASE("github #3543: Error adding PNG metadata when kekulize=False", "[bug][metadata][png]") {
+  SECTION("basics") {
+    auto m="n1cccc1"_smarts;
+    m->updatePropertyCache(false);
+    MolDraw2DCairo drawer(350, 300);
+    bool kekulize=false;
+    std::cerr<<"prepare"<<std::endl;
+    MolDraw2DUtils::prepareMolForDrawing(*m,kekulize);
+    std::cerr<<"draw"<<std::endl;
+    drawer.drawOptions().prepareMolsBeforeDrawing = false;
+    drawer.drawMolecule(*m);
+        std::cerr<<"done"<<std::endl;
+
+    drawer.finishDrawing();
+        std::cerr<<"text"<<std::endl;
+
+    auto png = drawer.getDrawingText();
+    std::cerr <<" finish"<<std::endl;
+  }
+  SECTION("as reported") {
+    auto m="n1cnc2c(n)ncnc12"_smarts;
+    m->updatePropertyCache(false);
+    MolDraw2DCairo drawer(350, 300);
+    bool kekulize=false;
+    MolDraw2DUtils::prepareMolForDrawing(*m,kekulize);
+    drawer.drawOptions().prepareMolsBeforeDrawing = false;
+    drawer.drawMolecule(*m);
+    drawer.finishDrawing();
+    auto png = drawer.getDrawingText();
+  }
+}
+#endif

--- a/Code/GraphMol/MolDraw2D/catch_tests.cpp
+++ b/Code/GraphMol/MolDraw2D/catch_tests.cpp
@@ -1411,31 +1411,25 @@ M  END
 }
 
 #ifdef RDK_BUILD_CAIRO_SUPPORT
-TEST_CASE("github #3543: Error adding PNG metadata when kekulize=False", "[bug][metadata][png]") {
+TEST_CASE("github #3543: Error adding PNG metadata when kekulize=False",
+          "[bug][metadata][png]") {
   SECTION("basics") {
-    auto m="n1cccc1"_smarts;
+    auto m = "n1cccc1"_smarts;
     m->updatePropertyCache(false);
     MolDraw2DCairo drawer(350, 300);
-    bool kekulize=false;
-    std::cerr<<"prepare"<<std::endl;
-    MolDraw2DUtils::prepareMolForDrawing(*m,kekulize);
-    std::cerr<<"draw"<<std::endl;
+    bool kekulize = false;
+    MolDraw2DUtils::prepareMolForDrawing(*m, kekulize);
     drawer.drawOptions().prepareMolsBeforeDrawing = false;
     drawer.drawMolecule(*m);
-        std::cerr<<"done"<<std::endl;
-
     drawer.finishDrawing();
-        std::cerr<<"text"<<std::endl;
-
     auto png = drawer.getDrawingText();
-    std::cerr <<" finish"<<std::endl;
   }
   SECTION("as reported") {
-    auto m="n1cnc2c(n)ncnc12"_smarts;
+    auto m = "n1cnc2c(n)ncnc12"_smarts;
     m->updatePropertyCache(false);
     MolDraw2DCairo drawer(350, 300);
-    bool kekulize=false;
-    MolDraw2DUtils::prepareMolForDrawing(*m,kekulize);
+    bool kekulize = false;
+    MolDraw2DUtils::prepareMolForDrawing(*m, kekulize);
     drawer.drawOptions().prepareMolsBeforeDrawing = false;
     drawer.drawMolecule(*m);
     drawer.finishDrawing();


### PR DESCRIPTION
Disables kekulization when generating the mol blocks for PNG metadata
This should also fix #3572