### PR TITLE
Support rendering variable attachment points

### DIFF
--- a/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
@@ -2235,14 +2235,13 @@ void MolDraw2D::extractVariableBonds(const ROMol &mol) {
         MolDrawShape shp;
         shp.shapeType = MolDrawShapeType::Ellipse;
         shp.lineWidth = 1;
-        shp.lineColour = DrawColour(0.8, 0.8, 0.8, 0.5);
+        shp.lineColour = drawOptions().variableAttachmentColour;
         shp.fill = true;
         auto center = at_cds_[activeMolIdx_][oat];
-        auto p1 = center + Point2D(0.4, 0.4);
-        auto p2 = center - Point2D(0.4, 0.4);
-        shp.points = {p1, p2};
+        Point2D offset{drawOptions().variableAtomRadius,
+                       drawOptions().variableAtomRadius};
+        shp.points = {center + offset, center - offset};
         pre_shapes_[activeMolIdx_].emplace_back(std::move(shp));
-        // shp.points.push_back(at_cds_[activeMolIdx_][oat]);
       }
 
       for (const auto bond : mol.bonds()) {
@@ -2251,14 +2250,20 @@ void MolDraw2D::extractVariableBonds(const ROMol &mol) {
           MolDrawShape shp;
           shp.shapeType = MolDrawShapeType::Polyline;
           shp.lineWidth =
-              lineWidth() * drawOptions().highlightBondWidthMultiplier * 2;
+              lineWidth() * drawOptions().variableBondWidthMultiplier;
           shp.scaleLineWidth = true;
-          shp.lineColour = DrawColour(0.8, 0.8, 0.8, 0.5);
+          shp.lineColour = drawOptions().variableAttachmentColour;
           shp.fill = false;
           shp.points = {at_cds_[activeMolIdx_][bond->getBeginAtomIdx()],
                         at_cds_[activeMolIdx_][bond->getEndAtomIdx()]};
           pre_shapes_[activeMolIdx_].emplace_back(std::move(shp));
         }
+      }
+      // correct the symbol of the end atom (remove it):
+      if (!bond->getBeginAtom()->getAtomicNum()) {
+        std::cerr << " ADJUST " << std::endl;
+        atom_syms_[activeMolIdx_][bond->getBeginAtomIdx()] =
+            std::make_pair("", OrientType::C);
       }
     }
   }

--- a/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
@@ -19,6 +19,7 @@
 #include <GraphMol/MolDraw2D/MolDraw2DDetails.h>
 #include <GraphMol/MolDraw2D/MolDraw2DUtils.h>
 #include <GraphMol/ChemReactions/ReactionParser.h>
+#include <GraphMol/FileParsers/MolSGroupParsing.h>
 #include <GraphMol/Depictor/RDDepictor.h>
 #include <Geometry/point.h>
 #include <Geometry/Transform2D.h>
@@ -195,6 +196,10 @@ void MolDraw2D::drawMolecule(const ROMol &mol,
     return;
   }
 
+  if (!pre_shapes_[activeMolIdx_].empty()) {
+    MolDraw2D_detail::drawShapes(*this, pre_shapes_[activeMolIdx_]);
+  }
+
   if (drawOptions().continuousHighlight) {
     // if we're doing continuous highlighting, start by drawing the highlights
     doContinuousHighlighting(draw_mol, highlight_atoms, highlight_bonds,
@@ -302,6 +307,10 @@ void MolDraw2D::drawMoleculeWithHighlights(
   if (!draw_mol.getNumConformers()) {
     // clearly, the molecule is in a sorry state.
     return;
+  }
+
+  if (!pre_shapes_[activeMolIdx_].empty()) {
+    MolDraw2D_detail::drawShapes(*this, pre_shapes_[activeMolIdx_]);
   }
 
   bool orig_fp = fillPolys();
@@ -958,7 +967,15 @@ void MolDraw2D::calculateScale(int width, int height, const ROMol &mol,
   }
 
   // adjust based on the shapes (if any)
-  for (const auto &shp : shapes_[activeMolIdx_]) {
+  for (const auto &shp : pre_shapes_[activeMolIdx_]) {
+    for (const auto &pt : shp.points) {
+      x_min_ = std::min(pt.x, x_min_);
+      y_min_ = std::min(pt.y, y_min_);
+      x_max = std::max(pt.x, x_max);
+      y_max = std::max(pt.y, y_max);
+    }
+  }
+  for (const auto &shp : post_shapes_[activeMolIdx_]) {
     for (const auto &pt : shp.points) {
       x_min_ = std::min(pt.x, x_min_);
       y_min_ = std::min(pt.y, y_min_);
@@ -1312,6 +1329,12 @@ unique_ptr<RWMol> MolDraw2D::setupDrawMolecule(
   extractAtomNotes(draw_mol);
   extractBondNotes(draw_mol);
   extractRadicals(draw_mol);
+  if (activeMolIdx_ >= 0 && post_shapes_.size() > activeMolIdx_ &&
+      pre_shapes_.size() > activeMolIdx_) {
+    post_shapes_[activeMolIdx_].clear();
+    pre_shapes_[activeMolIdx_].clear();
+  }
+  extractVariableBonds(draw_mol);
   extractBrackets(draw_mol);
 
   if (!activeMolIdx_ && needs_scale_) {
@@ -1328,7 +1351,8 @@ void MolDraw2D::pushDrawDetails() {
   atomic_nums_.push_back(std::vector<int>());
   atom_syms_.push_back(std::vector<std::pair<std::string, OrientType>>());
   annotations_.push_back(std::vector<AnnotationType>());
-  shapes_.push_back(std::vector<MolDrawShape>());
+  pre_shapes_.push_back(std::vector<MolDrawShape>());
+  post_shapes_.push_back(std::vector<MolDrawShape>());
   radicals_.push_back(
       std::vector<std::pair<std::shared_ptr<StringRect>, OrientType>>());
   activeMolIdx_++;
@@ -1338,7 +1362,8 @@ void MolDraw2D::pushDrawDetails() {
 void MolDraw2D::popDrawDetails() {
   activeMolIdx_--;
   annotations_.pop_back();
-  shapes_.pop_back();
+  pre_shapes_.pop_back();
+  post_shapes_.pop_back();
   atom_syms_.pop_back();
   atomic_nums_.pop_back();
   radicals_.pop_back();
@@ -1462,8 +1487,8 @@ void MolDraw2D::finishMoleculeDraw(const RDKit::ROMol &draw_mol,
     drawRadicals(draw_mol);
   }
 
-  if (!shapes_[activeMolIdx_].empty()) {
-    MolDraw2D_detail::drawShapes(*this, shapes_[activeMolIdx_]);
+  if (!post_shapes_[activeMolIdx_].empty()) {
+    MolDraw2D_detail::drawShapes(*this, post_shapes_[activeMolIdx_]);
   }
 
   if (drawOptions().flagCloseContactsDist >= 0) {
@@ -2077,11 +2102,10 @@ void MolDraw2D::extractRadicals(const ROMol &mol) {
 // ****************************************************************************
 void MolDraw2D::extractBrackets(const ROMol &mol) {
   PRECONDITION(activeMolIdx_ >= 0, "no mol id");
-  PRECONDITION(static_cast<int>(shapes_.size()) > activeMolIdx_, "no space");
+  PRECONDITION(static_cast<int>(post_shapes_.size()) > activeMolIdx_,
+               "no space");
   PRECONDITION(static_cast<int>(annotations_.size()) > activeMolIdx_,
                "no space");
-  shapes_[activeMolIdx_].clear();
-
   auto &sgs = getSubstanceGroups(mol);
   if (sgs.empty()) {
     return;
@@ -2132,7 +2156,7 @@ void MolDraw2D::extractBrackets(const ROMol &mol) {
       shp.points =
           MolDraw2D_detail::getBracketPoints(p1, p2, refPt, sgBondSegments);
       shp.shapeType = MolDrawShapeType::Polyline;
-      shapes_[activeMolIdx_].emplace_back(std::move(shp));
+      post_shapes_[activeMolIdx_].emplace_back(std::move(shp));
     }
     if (supportsAnnotations()) {
       // FIX: we could imagine changing this to always show the annotations on
@@ -2141,7 +2165,7 @@ void MolDraw2D::extractBrackets(const ROMol &mol) {
       std::string connect;
       if (sg.getPropIfPresent("CONNECT", connect)) {
         // annotations go on the last bracket of an sgroup
-        const auto &brkShp = shapes_[activeMolIdx_].back();
+        const auto &brkShp = post_shapes_[activeMolIdx_].back();
         StringRect rect;
         // CONNECT goes at the top
         auto topPt = brkShp.points[1];
@@ -2164,7 +2188,7 @@ void MolDraw2D::extractBrackets(const ROMol &mol) {
       std::string label;
       if (sg.getPropIfPresent("LABEL", label)) {
         // annotations go on the last bracket of an sgroup
-        const auto &brkShp = shapes_[activeMolIdx_].back();
+        const auto &brkShp = post_shapes_[activeMolIdx_].back();
         StringRect rect;
         // LABEL goes at the bottom
         auto botPt = brkShp.points[2];
@@ -2181,7 +2205,64 @@ void MolDraw2D::extractBrackets(const ROMol &mol) {
       }
     }
   }
-}  // namespace RDKit
+}
+
+// ****************************************************************************
+void MolDraw2D::extractVariableBonds(const ROMol &mol) {
+  PRECONDITION(activeMolIdx_ >= 0, "no mol id");
+  PRECONDITION(static_cast<int>(pre_shapes_.size()) > activeMolIdx_,
+               "no space");
+  PRECONDITION(static_cast<int>(annotations_.size()) > activeMolIdx_,
+               "no space");
+
+  boost::dynamic_bitset<> atomsInvolved(mol.getNumAtoms());
+  for (const auto bond : mol.bonds()) {
+    std::string endpts;
+    std::string attach;
+    if (bond->getPropIfPresent(common_properties::_MolFileBondEndPts, endpts) &&
+        bond->getPropIfPresent(common_properties::_MolFileBondAttach, attach)) {
+      // FIX: maybe distinguish between "ANY" and "ALL" values of attach here?
+      std::vector<unsigned int> oats =
+          RDKit::SGroupParsing::ParseV3000Array<unsigned int>(endpts);
+      atomsInvolved.reset();
+      // decrement the indices and do error checking:
+      for (auto &oat : oats) {
+        if (oat == 0 || oat > mol.getNumAtoms()) {
+          throw ValueErrorException("Bad variation point index");
+        }
+        --oat;
+        atomsInvolved.set(oat);
+        MolDrawShape shp;
+        shp.shapeType = MolDrawShapeType::Ellipse;
+        shp.lineWidth = 1;
+        shp.lineColour = DrawColour(0.8, 0.8, 0.8, 0.5);
+        shp.fill = true;
+        auto center = at_cds_[activeMolIdx_][oat];
+        auto p1 = center + Point2D(0.4, 0.4);
+        auto p2 = center - Point2D(0.4, 0.4);
+        shp.points = {p1, p2};
+        pre_shapes_[activeMolIdx_].emplace_back(std::move(shp));
+        // shp.points.push_back(at_cds_[activeMolIdx_][oat]);
+      }
+
+      for (const auto bond : mol.bonds()) {
+        if (atomsInvolved[bond->getBeginAtomIdx()] &&
+            atomsInvolved[bond->getEndAtomIdx()]) {
+          MolDrawShape shp;
+          shp.shapeType = MolDrawShapeType::Polyline;
+          shp.lineWidth =
+              lineWidth() * drawOptions().highlightBondWidthMultiplier * 2;
+          shp.scaleLineWidth = true;
+          shp.lineColour = DrawColour(0.8, 0.8, 0.8, 0.5);
+          shp.fill = false;
+          shp.points = {at_cds_[activeMolIdx_][bond->getBeginAtomIdx()],
+                        at_cds_[activeMolIdx_][bond->getEndAtomIdx()]};
+          pre_shapes_[activeMolIdx_].emplace_back(std::move(shp));
+        }
+      }
+    }
+  }
+}
 
 // ****************************************************************************
 void MolDraw2D::drawBond(

--- a/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
@@ -1329,8 +1329,9 @@ unique_ptr<RWMol> MolDraw2D::setupDrawMolecule(
   extractAtomNotes(draw_mol);
   extractBondNotes(draw_mol);
   extractRadicals(draw_mol);
-  if (activeMolIdx_ >= 0 && post_shapes_.size() > activeMolIdx_ &&
-      pre_shapes_.size() > activeMolIdx_) {
+  if (activeMolIdx_ >= 0 &&
+      post_shapes_.size() > static_cast<size_t>(activeMolIdx_) &&
+      pre_shapes_.size() > static_cast<size_t>(activeMolIdx_)) {
     post_shapes_[activeMolIdx_].clear();
     pre_shapes_[activeMolIdx_].clear();
   }
@@ -2259,9 +2260,8 @@ void MolDraw2D::extractVariableBonds(const ROMol &mol) {
           pre_shapes_[activeMolIdx_].emplace_back(std::move(shp));
         }
       }
-      // correct the symbol of the end atom (remove it):
+      // correct the symbol of the end atom (remove the *):
       if (!bond->getBeginAtom()->getAtomicNum()) {
-        std::cerr << " ADJUST " << std::endl;
         atom_syms_[activeMolIdx_][bond->getBeginAtomIdx()] =
             std::make_pair("", OrientType::C);
       }

--- a/Code/GraphMol/MolDraw2D/MolDraw2D.h
+++ b/Code/GraphMol/MolDraw2D/MolDraw2D.h
@@ -73,6 +73,7 @@ struct DrawColour {
 enum class MolDrawShapeType {
   Arrow,  // ordering of points is: start, end, p1, p2
   Polyline,
+  Ellipse,
 };
 
 //! extra shape to add to canvas
@@ -82,6 +83,7 @@ struct MolDrawShape {
   DrawColour lineColour{0, 0, 0};
   int lineWidth = 2;
   bool fill = false;
+  bool scaleLineWidth = false;
 };
 
 // for holding dimensions of the rectangle round a string.
@@ -665,7 +667,8 @@ class RDKIT_MOLDRAW2D_EXPORT MolDraw2D {
   std::vector<std::vector<std::pair<std::shared_ptr<StringRect>, OrientType>>>
       radicals_;
   Point2D bbox_[2];
-  std::vector<std::vector<MolDrawShape>> shapes_;
+  std::vector<std::vector<MolDrawShape>> pre_shapes_;
+  std::vector<std::vector<MolDrawShape>> post_shapes_;
 
   // return a DrawColour based on the contents of highlight_atoms or
   // highlight_map, falling back to atomic number by default
@@ -749,6 +752,7 @@ class RDKIT_MOLDRAW2D_EXPORT MolDraw2D {
   void extractAtomNotes(const ROMol &mol);
   void extractBondNotes(const ROMol &mol);
   void extractRadicals(const ROMol &mol);
+  void extractVariableBonds(const ROMol &mol);
   void extractBrackets(const ROMol &mol);
 
   // coords in atom coords

--- a/Code/GraphMol/MolDraw2D/MolDraw2D.h
+++ b/Code/GraphMol/MolDraw2D/MolDraw2D.h
@@ -201,9 +201,9 @@ struct RDKIT_MOLDRAW2D_EXPORT MolDrawOptions {
       false;  // toggles replacing 2H with D and 3H with T
   bool dummiesAreAttachments = false;  // draws "breaks" at dummy atoms
   bool circleAtoms = true;             // draws circles under highlighted atoms
-  DrawColour highlightColour{1, 0.5, 0.5};  // default highlight color
-  bool continuousHighlight = true;          // highlight by drawing an outline
-                                            // *underneath* the molecule
+  DrawColour highlightColour{1, 0.5, 0.5, 1.0};  // default highlight color
+  bool continuousHighlight = true;  // highlight by drawing an outline
+                                    // *underneath* the molecule
   bool fillHighlights = true;     // fill the areas used to highlight atoms and
                                   // atom regions
   double highlightRadius = 0.3;   // default if nothing given for a particular
@@ -216,7 +216,7 @@ struct RDKIT_MOLDRAW2D_EXPORT MolDrawOptions {
   bool clearBackground = true;  // toggles clearing the background before
                                 // drawing a molecule
   DrawColour backgroundColour{
-      1, 1, 1};             // color to be used while clearing the background
+      1, 1, 1, 1};          // color to be used while clearing the background
   int legendFontSize = 16;  // font size (in pixels) to be used for the legend
                             // (if present)
   int maxFontSize = 40;  // maximum size in pixels for font in drawn molecule.
@@ -238,7 +238,7 @@ struct RDKIT_MOLDRAW2D_EXPORT MolDrawOptions {
   std::map<int, std::string> atomLabels;    // replacement labels for atoms
   std::vector<std::vector<int>> atomRegions;  // regions
   DrawColour symbolColour{
-      0, 0, 0};  // color to be used for the symbols and arrows in reactions
+      0, 0, 0, 1};  // color to be used for the symbols and arrows in reactions
   int bondLineWidth = 2;        // default line width when drawing bonds
   bool scaleBondWidth = false;  // whether to apply scale() to the bond width
   bool scaleHighlightBondWidth = true;   // likewise with bond highlights.
@@ -286,6 +286,12 @@ struct RDKIT_MOLDRAW2D_EXPORT MolDrawOptions {
   bool comicMode = false;  // simulate hand-drawn lines for bonds. When combined
                            // with a font like Comic-Sans or Comic-Neue, this
                            // gives xkcd-like drawings.
+  int variableBondWidthMultiplier = 16;  // what to multiply standard bond width
+                                         // by for variable attachment points.
+  double variableAtomRadius = 0.4;  // radius value to use for atoms involved in
+                                    // variable attachment points.
+  DrawColour variableAttachmentColour = {
+      0.8, 0.8, 0.8, 0.5};  // colour to use for variable attachment points
 
   MolDrawOptions() {
     highlightColourPalette.emplace_back(

--- a/Code/GraphMol/MolDraw2D/MolDraw2D.h
+++ b/Code/GraphMol/MolDraw2D/MolDraw2D.h
@@ -291,7 +291,7 @@ struct RDKIT_MOLDRAW2D_EXPORT MolDrawOptions {
   double variableAtomRadius = 0.4;  // radius value to use for atoms involved in
                                     // variable attachment points.
   DrawColour variableAttachmentColour = {
-      0.8, 0.8, 0.8, 0.5};  // colour to use for variable attachment points
+      0.8, 0.8, 0.8, 1.0};  // colour to use for variable attachment points
 
   MolDrawOptions() {
     highlightColourPalette.emplace_back(

--- a/Code/GraphMol/MolDraw2D/MolDraw2DDetails.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DDetails.cpp
@@ -193,7 +193,14 @@ void drawPolyline(MolDraw2D &drawer, const MolDrawShape &shape) {
   PRECONDITION(shape.shapeType == MolDrawShapeType::Polyline, "bad shape type");
   PRECONDITION(shape.points.size() > 1, "not enough points");
   drawer.setColour(shape.lineColour);
-  drawer.setLineWidth(shape.lineWidth);
+  auto lw = shape.lineWidth;
+  if (shape.scaleLineWidth) {
+    lw *= drawer.scale() * 0.02;
+    if (lw < 0.0) {
+      lw = 0.0;
+    }
+  }
+  drawer.setLineWidth(lw);
   if (shape.points.size() > 2 && shape.fill) {
     drawer.setFillPolys(true);
   } else {
@@ -216,6 +223,18 @@ void drawPolyline(MolDraw2D &drawer, const MolDrawShape &shape) {
     }
   }
 }
+void drawEllipse(MolDraw2D &drawer, const MolDrawShape &shape) {
+  PRECONDITION(shape.shapeType == MolDrawShapeType::Ellipse, "bad shape type");
+  PRECONDITION(shape.points.size() == 2, "wrong points");
+  drawer.setColour(shape.lineColour);
+  drawer.setLineWidth(shape.lineWidth);
+  if (shape.fill) {
+    drawer.setFillPolys(true);
+  } else {
+    drawer.setFillPolys(false);
+  }
+  drawer.drawEllipse(shape.points[0], shape.points[1]);
+}
 }  // namespace
 void drawShapes(MolDraw2D &drawer, const std::vector<MolDrawShape> &shapes) {
   const auto ocolour = drawer.colour();
@@ -228,6 +247,9 @@ void drawShapes(MolDraw2D &drawer, const std::vector<MolDrawShape> &shapes) {
         break;
       case MolDrawShapeType::Arrow:
         drawArrow(drawer, shape);
+        break;
+      case MolDrawShapeType::Ellipse:
+        drawEllipse(drawer, shape);
         break;
       default:
         ASSERT_INVARIANT(false, "unrecognized shape type");

--- a/Code/GraphMol/MolDraw2D/MolDraw2DUtils.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DUtils.cpp
@@ -115,6 +115,10 @@ void get_colour_option(boost::property_tree::ptree *pt, const char *pnm,
   ++itm;
   colour.b = itm->second.get_value<float>();
   ++itm;
+  if (itm != pt->get_child(pnm).end()) {
+    colour.a = itm->second.get_value<float>();
+    ++itm;
+  }
 }
 
 void updateDrawerParamsFromJSON(MolDraw2D &drawer, const std::string &json) {
@@ -160,11 +164,15 @@ void updateDrawerParamsFromJSON(MolDraw2D &drawer, const std::string &json) {
   PT_OPT_GET(includeMetadata);
   PT_OPT_GET(includeRadicals);
   PT_OPT_GET(comicMode);
+  PT_OPT_GET(variableBondWidthMultiplier);
+  PT_OPT_GET(variableAtomRadius);
 
   get_colour_option(&pt, "highlightColour", opts.highlightColour);
   get_colour_option(&pt, "backgroundColour", opts.backgroundColour);
   get_colour_option(&pt, "legendColour", opts.legendColour);
   get_colour_option(&pt, "symbolColour", opts.symbolColour);
+  get_colour_option(&pt, "variableAttachmentColour",
+                    opts.variableAttachmentColour);
   if (pt.find("atomLabels") != pt.not_found()) {
     for (const auto &item : pt.get_child("atomLabels")) {
       opts.atomLabels[boost::lexical_cast<int>(item.first)] =

--- a/Code/GraphMol/MolDraw2D/Wrap/rdMolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/Wrap/rdMolDraw2D.cpp
@@ -412,6 +412,13 @@ python::object getSymbolColour(const RDKit::MolDrawOptions &self) {
 void setSymbolColour(RDKit::MolDrawOptions &self, python::tuple tpl) {
   self.symbolColour = pyTupleToDrawColour(tpl);
 }
+python::object getVariableAttachmentColour(const RDKit::MolDrawOptions &self) {
+  return colourToPyTuple(self.variableAttachmentColour);
+}
+void setVariableAttachmentColour(RDKit::MolDrawOptions &self,
+                                 python::tuple tpl) {
+  self.variableAttachmentColour = pyTupleToDrawColour(tpl);
+}
 void useDefaultAtomPalette(RDKit::MolDrawOptions &self) {
   assignDefaultPalette(self.atomColourPalette);
 }
@@ -683,7 +690,19 @@ BOOST_PYTHON_MODULE(rdMolDraw2D) {
       .def_readwrite("comicMode", &RDKit::MolDrawOptions::comicMode,
                      "simulate hand-drawn lines for bonds. When combined with "
                      "a font like Comic-Sans or Comic-Neue, this gives "
-                     "xkcd-like drawings. Default is false.");
+                     "xkcd-like drawings. Default is false.")
+      .def_readwrite("variableBondWidthMultiplier",
+                     &RDKit::MolDrawOptions::variableBondWidthMultiplier,
+                     "what to multiply standard bond width by for variable "
+                     "attachment points.")
+      .def_readwrite("variableAtomRadius",
+                     &RDKit::MolDrawOptions::variableAtomRadius,
+                     "radius value to use for atoms involved in variable "
+                     "attachment points.")
+      .def("getVariableAttachmentColour", &RDKit::getVariableAttachmentColour,
+           "method for getting the colour of variable attachment points")
+      .def("setVariableAttachmentColour", &RDKit::setVariableAttachmentColour,
+           "method for setting the colour of variable attachment points");
   docString = "Drawer abstract base class";
   python::class_<RDKit::MolDraw2D, boost::noncopyable>(
       "MolDraw2D", docString.c_str(), python::no_init)

--- a/Code/GraphMol/MolDraw2D/catch_tests.cpp
+++ b/Code/GraphMol/MolDraw2D/catch_tests.cpp
@@ -1437,3 +1437,216 @@ TEST_CASE("github #3543: Error adding PNG metadata when kekulize=False",
   }
 }
 #endif
+
+TEST_CASE("position variation bonds", "[extras]") {
+  SECTION("simple") {
+    auto m = R"CTAB(
+  Mrv2014 12092006072D          
+
+  0  0  0     0  0            999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 9 8 0 0 0
+M  V30 BEGIN ATOM
+M  V30 1 C -4.7083 4.915 0 0
+M  V30 2 C -6.042 4.145 0 0
+M  V30 3 C -6.042 2.605 0 0
+M  V30 4 C -4.7083 1.835 0 0
+M  V30 5 C -3.3747 2.605 0 0
+M  V30 6 C -3.3747 4.145 0 0
+M  V30 7 * -3.8192 3.8883 0 0
+M  V30 8 O -3.8192 6.1983 0 0
+M  V30 9 C -2.4855 6.9683 0 0
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 1 1 2
+M  V30 2 2 2 3
+M  V30 3 1 3 4
+M  V30 4 2 4 5
+M  V30 5 1 5 6
+M  V30 6 2 1 6
+M  V30 7 1 7 8 ENDPTS=(3 1 6 5) ATTACH=ANY
+M  V30 8 1 8 9
+M  V30 END BOND
+M  V30 END CTAB
+M  END
+)CTAB"_ctab;
+    REQUIRE(m);
+    {
+      MolDraw2DSVG drawer(350, 300);
+      drawer.drawMolecule(*m, "variations");
+      drawer.finishDrawing();
+      auto text = drawer.getDrawingText();
+      std::ofstream outs("testPositionVariation-1.svg");
+      outs << text;
+      outs.flush();
+    }
+  }
+  SECTION("multiple") {
+    auto m = R"CTAB(
+  Mrv2014 12092006082D          
+
+  0  0  0     0  0            999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 15 14 0 0 0
+M  V30 BEGIN ATOM
+M  V30 1 C -4.7083 4.915 0 0
+M  V30 2 C -6.042 4.145 0 0
+M  V30 3 C -6.042 2.605 0 0
+M  V30 4 C -4.7083 1.835 0 0
+M  V30 5 C -3.3747 2.605 0 0
+M  V30 6 C -3.3747 4.145 0 0
+M  V30 7 * -3.8192 3.8883 0 0
+M  V30 8 O -3.8192 6.1983 0 0
+M  V30 9 C -2.4855 6.9683 0 0
+M  V30 10 C -7.3757 4.915 0 0
+M  V30 11 C -8.7093 4.145 0 0
+M  V30 12 C -8.7093 2.605 0 0
+M  V30 13 C -7.3757 1.835 0 0
+M  V30 14 * -8.7093 3.375 0 0
+M  V30 15 O -10.2922 3.375 0 0
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 1 1 2
+M  V30 2 1 2 3
+M  V30 3 1 3 4
+M  V30 4 2 4 5
+M  V30 5 1 5 6
+M  V30 6 2 1 6
+M  V30 7 1 7 8 ENDPTS=(3 1 6 5) ATTACH=ANY
+M  V30 8 1 8 9
+M  V30 9 1 10 11
+M  V30 10 2 11 12
+M  V30 11 1 12 13
+M  V30 12 2 10 2
+M  V30 13 2 13 3
+M  V30 14 1 14 15 ENDPTS=(2 11 12) ATTACH=ANY
+M  V30 END BOND
+M  V30 END CTAB
+M  END
+)CTAB"_ctab;
+    REQUIRE(m);
+    {
+      MolDraw2DSVG drawer(350, 300);
+      drawer.drawMolecule(*m, "multiple variations");
+      drawer.finishDrawing();
+      auto text = drawer.getDrawingText();
+      std::ofstream outs("testPositionVariation-2.svg");
+      outs << text;
+      outs.flush();
+    }
+  }
+  SECTION("non-contiguous") {
+    auto m = R"CTAB(
+  Mrv2014 12092006102D          
+
+  0  0  0     0  0            999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 9 8 0 0 0
+M  V30 BEGIN ATOM
+M  V30 1 C -0.875 8.7484 0 0
+M  V30 2 C -2.2087 7.9784 0 0
+M  V30 3 C -2.2087 6.4383 0 0
+M  V30 4 C -0.875 5.6683 0 0
+M  V30 5 C 0.4587 6.4383 0 0
+M  V30 6 C 0.4587 7.9784 0 0
+M  V30 7 * -0.4304 6.9517 0 0
+M  V30 8 O -0.4304 4.6417 0 0
+M  V30 9 C -1.7641 3.8717 0 0
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 1 1 2
+M  V30 2 2 2 3
+M  V30 3 1 3 4
+M  V30 4 2 4 5
+M  V30 5 1 5 6
+M  V30 6 2 1 6
+M  V30 7 1 7 8 ENDPTS=(3 1 5 4) ATTACH=ANY
+M  V30 8 1 8 9
+M  V30 END BOND
+M  V30 END CTAB
+M  END
+)CTAB"_ctab;
+    REQUIRE(m);
+    {
+      MolDraw2DSVG drawer(350, 300);
+      drawer.drawMolecule(*m, "non-contiguous atoms");
+      drawer.finishDrawing();
+      auto text = drawer.getDrawingText();
+      std::ofstream outs("testPositionVariation-3.svg");
+      outs << text;
+      outs.flush();
+    }
+  }
+  SECTION("larger mol") {
+    auto m = R"CTAB(
+  Mrv2014 12092009152D          
+
+  0  0  0     0  0            999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 23 24 0 0 0
+M  V30 BEGIN ATOM
+M  V30 1 C -0.875 8.7484 0 0
+M  V30 2 C -2.2087 7.9784 0 0
+M  V30 3 C -2.2087 6.4383 0 0
+M  V30 4 C -0.875 5.6683 0 0
+M  V30 5 N 0.4587 6.4383 0 0
+M  V30 6 C 0.4587 7.9784 0 0
+M  V30 7 * -0.4304 6.9517 0 0
+M  V30 8 O -0.4304 4.6417 0 0
+M  V30 9 C -1.7641 3.8717 0 0
+M  V30 10 C -3.5423 8.7484 0 0
+M  V30 11 C -4.876 7.9784 0 0
+M  V30 12 C -4.876 6.4383 0 0
+M  V30 13 C -3.5423 5.6683 0 0
+M  V30 14 C -4.876 11.0584 0 0
+M  V30 15 C -6.2097 10.2884 0 0
+M  V30 16 C -6.2097 8.7484 0 0
+M  V30 17 C -3.5423 10.2884 0 0
+M  V30 18 C -6.2097 13.3685 0 0
+M  V30 19 C -7.5433 12.5985 0 0
+M  V30 20 C -7.5433 11.0584 0 0
+M  V30 21 C -4.876 12.5985 0 0
+M  V30 22 * -5.5428 9.1334 0 0
+M  V30 23 C -7.3712 7.7304 0 0
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 1 1 2
+M  V30 2 2 2 3
+M  V30 3 1 3 4
+M  V30 4 2 4 5
+M  V30 5 1 5 6
+M  V30 6 2 1 6
+M  V30 7 1 7 8 ENDPTS=(3 1 4 5) ATTACH=ANY
+M  V30 8 1 8 9
+M  V30 9 2 10 11
+M  V30 10 1 11 12
+M  V30 11 2 12 13
+M  V30 12 1 10 2
+M  V30 13 1 13 3
+M  V30 14 1 14 15
+M  V30 15 2 15 16
+M  V30 16 2 14 17
+M  V30 17 1 10 17
+M  V30 18 1 16 11
+M  V30 19 1 18 19
+M  V30 20 2 19 20
+M  V30 21 2 18 21
+M  V30 22 1 14 21
+M  V30 23 1 20 15
+M  V30 24 1 22 23 ENDPTS=(2 15 11) ATTACH=ANY
+M  V30 END BOND
+M  V30 END CTAB
+M  END
+)CTAB"_ctab;
+    REQUIRE(m);
+    {
+      MolDraw2DSVG drawer(250, 200);
+      drawer.drawMolecule(*m, "smaller molecule");
+      drawer.finishDrawing();
+      auto text = drawer.getDrawingText();
+      std::ofstream outs("testPositionVariation-4.svg");
+      outs << text;
+      outs.flush();
+    }
+  }
+}

--- a/Code/GraphMol/MolDraw2D/catch_tests.cpp
+++ b/Code/GraphMol/MolDraw2D/catch_tests.cpp
@@ -1480,6 +1480,16 @@ M  END
       outs << text;
       outs.flush();
     }
+    {  // make sure comic mode doesn't screw this up
+      MolDraw2DSVG drawer(350, 300);
+      drawer.drawOptions().comicMode = true;
+      drawer.drawMolecule(*m, "comic variations");
+      drawer.finishDrawing();
+      auto text = drawer.getDrawingText();
+      std::ofstream outs("testPositionVariation-1b.svg");
+      outs << text;
+      outs.flush();
+    }
   }
   SECTION("multiple") {
     auto m = R"CTAB(

--- a/Code/GraphMol/MolDraw2D/catch_tests.cpp
+++ b/Code/GraphMol/MolDraw2D/catch_tests.cpp
@@ -1641,7 +1641,7 @@ M  END
     REQUIRE(m);
     {
       MolDraw2DSVG drawer(250, 200);
-      drawer.drawMolecule(*m, "smaller molecule");
+      drawer.drawMolecule(*m, "smaller");
       drawer.finishDrawing();
       auto text = drawer.getDrawingText();
       std::ofstream outs("testPositionVariation-4.svg");


### PR DESCRIPTION
Examples of what these look like:
![image](https://user-images.githubusercontent.com/540511/101629814-35275000-3a22-11eb-939d-48f199cb5f5a.png)

![image](https://user-images.githubusercontent.com/540511/101629836-3bb5c780-3a22-11eb-81e8-47ce60b2dca7.png)

Note that the coordinate generation still won't do anything sensible with these (the examples are all read in from mol blocks), that's one for another day (and another PR)