### PR TITLE
add configuration option to disable atom symbols in the rendering

### DIFF
--- a/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
@@ -3173,10 +3173,12 @@ pair<string, OrientType> MolDraw2D::getAtomSymbolAndOrientation(
 // ****************************************************************************
 string MolDraw2D::getAtomSymbol(const RDKit::Atom &atom,
                                 OrientType orientation) const {
+  if (drawOptions().noAtomLabels) {
+    return "";
+  }
   // adds XML-like annotation for super- and sub-script, in the same manner
   // as MolDrawing.py. My first thought was for a LaTeX-like system,
   // obviously...
-
   string symbol;
   bool literal_symbol = true;
   unsigned int iso = atom.getIsotope();

--- a/Code/GraphMol/MolDraw2D/MolDraw2D.h
+++ b/Code/GraphMol/MolDraw2D/MolDraw2D.h
@@ -234,6 +234,8 @@ struct RDKIT_MOLDRAW2D_EXPORT MolDrawOptions {
                                             // around atom labels. Expressed as
                                             // a fraction of the font size.
   std::map<int, std::string> atomLabels;    // replacement labels for atoms
+  bool noAtomLabels =
+      false;  // disables inclusion of atom labels in the rendering
   std::vector<std::vector<int>> atomRegions;  // regions
   DrawColour symbolColour{
       0, 0, 0};  // color to be used for the symbols and arrows in reactions

--- a/Code/GraphMol/MolDraw2D/MolDraw2DUtils.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DUtils.cpp
@@ -143,6 +143,7 @@ void updateDrawerParamsFromJSON(MolDraw2D &drawer, const std::string &json) {
   PT_OPT_GET(multipleBondOffset);
   PT_OPT_GET(padding);
   PT_OPT_GET(additionalAtomLabelPadding);
+  PT_OPT_GET(noAtomLabels);
   PT_OPT_GET(bondLineWidth);
   PT_OPT_GET(scaleBondWidth);
   PT_OPT_GET(scaleHighlightBondWidth);

--- a/Code/GraphMol/MolDraw2D/Wrap/rdMolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/Wrap/rdMolDraw2D.cpp
@@ -670,6 +670,8 @@ BOOST_PYTHON_MODULE(rdMolDraw2D) {
                      &RDKit::MolDrawOptions::additionalAtomLabelPadding,
                      "additional padding to leave around atom labels. "
                      "Expressed as a fraction of the font size.")
+      .def_readwrite("noAtomLabels", &RDKit::MolDrawOptions::noAtomLabels,
+                     "disables inclusion of atom labels in the rendering")
       .def_readwrite("explicitMethyl", &RDKit::MolDrawOptions::explicitMethyl,
                      "Draw terminal methyls explictly.  Default is false.")
       .def_readwrite(

--- a/Code/GraphMol/MolDraw2D/catch_tests.cpp
+++ b/Code/GraphMol/MolDraw2D/catch_tests.cpp
@@ -1437,3 +1437,20 @@ TEST_CASE("github #3543: Error adding PNG metadata when kekulize=False",
   }
 }
 #endif
+
+TEST_CASE("disable atom labels", "[feature]") {
+  SECTION("basics") {
+    auto m = "NCC(=O)O"_smiles;
+    MolDraw2DSVG drawer(350, 300);
+    MolDraw2DUtils::prepareMolForDrawing(*m);
+    drawer.drawOptions().noAtomLabels = true;
+    drawer.drawMolecule(*m);
+    drawer.finishDrawing();
+    auto text = drawer.getDrawingText();
+    std::ofstream outs("testNoAtomLabels-1.svg");
+    outs << text;
+    outs.flush();
+    CHECK(text.find("atom-0") == std::string::npos);
+    CHECK(text.find("atom-3") == std::string::npos);
+  }
+}


### PR DESCRIPTION
This is a simple one to allow structures to be rendered without atomic symbols (yet still with colors, so you get renderings like this):
![image](https://user-images.githubusercontent.com/540511/101807586-90863a80-3b15-11eb-9e49-43b781d9283f.png)

It's been possible to do this all along by setting the `_displayLabel` property to `""`. This just makes that easier