### PR TITLE
Fix #3631

### DIFF
--- a/Code/GraphMol/Chirality.cpp
+++ b/Code/GraphMol/Chirality.cpp
@@ -888,7 +888,7 @@ void iterateCIPRanks(const ROMol &mol, const DOUBLE_VECT &invars,
 
   unsigned int numAtoms = mol.getNumAtoms();
   CIP_ENTRY_VECT cipEntries(numAtoms);
-  for (auto& vec : cipEntries) {
+  for (auto &vec : cipEntries) {
     vec.reserve(16);
   }
 #ifdef VERBOSE_CANON
@@ -994,7 +994,7 @@ void iterateCIPRanks(const ROMol &mol, const DOUBLE_VECT &invars,
                     return ranks[idx1] > ranks[idx2];
                   });
       }
-      auto& cipEntry = cipEntries[index];
+      auto &cipEntry = cipEntries[index];
       for (auto nbrIdx : updatedNbrIdxs) {
         unsigned int count = counts[nbrIdx];
         cipEntry.insert(cipEntry.end(), count, ranks[nbrIdx] + 1);
@@ -1182,6 +1182,7 @@ void findAtomNeighborsHelper(const ROMol &mol, const Atom *atom,
 //   3) four ring neighbors with three different ranks
 //   4) three ring neighbors with two different ranks
 //     example for this last one: C[C@H]1CC2CCCC3CCCC(C1)[C@@H]23
+// Note that N atoms are only candidates if they are in a 3-ring
 bool atomIsCandidateForRingStereochem(const ROMol &mol, const Atom *atom) {
   PRECONDITION(atom, "bad atom");
   bool res = false;
@@ -1189,6 +1190,10 @@ bool atomIsCandidateForRingStereochem(const ROMol &mol, const Atom *atom) {
   if (!atom->getPropIfPresent(common_properties::_ringStereochemCand, res)) {
     const RingInfo *ringInfo = mol.getRingInfo();
     if (ringInfo->isInitialized() && ringInfo->numAtomRings(atom->getIdx())) {
+      if (atom->getAtomicNum() == 7 &&
+          !ringInfo->isAtomInRingOfSize(atom->getIdx(), 3)) {
+        return false;
+      }
       ROMol::OEDGE_ITER beg, end;
       boost::tie(beg, end) = mol.getAtomBonds(atom);
       std::vector<const Atom *> nonRingNbrs;
@@ -1393,56 +1398,66 @@ std::pair<bool, bool> isAtomPotentialChiralCenter(
     // we only know tetrahedral chirality
     legalCenter = false;
   } else {
-    boost::dynamic_bitset<> codesSeen(mol.getNumAtoms());
-    ROMol::OEDGE_ITER beg, end;
-    boost::tie(beg, end) = mol.getAtomBonds(atom);
-    while (beg != end) {
-      unsigned int otherIdx = mol[*beg]->getOtherAtom(atom)->getIdx();
-      CHECK_INVARIANT(ranks[otherIdx] < mol.getNumAtoms(),
-                      "CIP rank higher than the number of atoms.");
-      // watch for neighbors with duplicate ranks, which would mean
-      // that we cannot be chiral:
-      if (codesSeen[ranks[otherIdx]]) {
-        // we've already seen this code, it's a dupe
-        hasDupes = true;
-        break;
+    // cases we can exclude immediately without having to look at neighbors
+    // ranks:
+    if (atom->getTotalDegree() < 3) {
+      legalCenter = false;
+    } else if (atom->getDegree() == 3 && atom->getAtomicNum() == 7 &&
+               !mol.getRingInfo()->isAtomInRingOfSize(atom->getIdx(), 3)) {
+      legalCenter = false;
+    } else {
+      boost::dynamic_bitset<> codesSeen(mol.getNumAtoms());
+      ROMol::OEDGE_ITER beg, end;
+      boost::tie(beg, end) = mol.getAtomBonds(atom);
+      while (beg != end) {
+        unsigned int otherIdx = mol[*beg]->getOtherAtom(atom)->getIdx();
+        CHECK_INVARIANT(ranks[otherIdx] < mol.getNumAtoms(),
+                        "CIP rank higher than the number of atoms.");
+        // watch for neighbors with duplicate ranks, which would mean
+        // that we cannot be chiral:
+        if (codesSeen[ranks[otherIdx]]) {
+          // we've already seen this code, it's a dupe
+          hasDupes = true;
+          break;
+        }
+        codesSeen[ranks[otherIdx]] = 1;
+        nbrs.push_back(std::make_pair(ranks[otherIdx], mol[*beg]->getIdx()));
+        ++beg;
       }
-      codesSeen[ranks[otherIdx]] = 1;
-      nbrs.push_back(std::make_pair(ranks[otherIdx], mol[*beg]->getIdx()));
-      ++beg;
-    }
 
-    // figure out if this is a legal chiral center or not:
-    if (!hasDupes) {
-      if (nbrs.size() < 3 &&
-          (atom->getAtomicNum() != 15 && atom->getAtomicNum() != 33)) {
-        // less than three neighbors is never stereogenic
-        // unless it is a phosphine/arsine with implicit H
-        legalCenter = false;
-      } else if (atom->getAtomicNum() == 15 || atom->getAtomicNum() == 33) {
-        // from logical flow: nbrs.size is 3 or 4, or 2 (implicit H)
-        // Since InChI Software v. 1.02-standard (2009), phosphines and arsines
-        // are always treated as stereogenic even with H atom neighbors.
-        // Accept automatically.
-        legalCenter = true;
-      } else if (nbrs.size() == 3) {
-        // three-coordinate with a single H we'll accept automatically:
-        if (atom->getTotalNumHs() != 1) {
-          // otherwise we default to not being a legal center
+      // figure out if this is a legal chiral center or not:
+      if (!hasDupes) {
+        if (nbrs.size() < 3 &&
+            (atom->getAtomicNum() != 15 && atom->getAtomicNum() != 33)) {
+          // less than three neighbors is never stereogenic
+          // unless it is a phosphine/arsine with implicit H
           legalCenter = false;
-          // but there are a few special cases we'll accept
-          // sulfur or selenium with either a positive charge or a double
-          // bond:
-          if ((atom->getAtomicNum() == 16 || atom->getAtomicNum() == 34) &&
-              (atom->getExplicitValence() == 4 ||
-               (atom->getExplicitValence() == 3 &&
-                atom->getFormalCharge() == 1))) {
-            legalCenter = true;
-          } else if (atom->getAtomicNum() == 7 &&
-                     mol.getRingInfo()->isAtomInRingOfSize(atom->getIdx(), 3)) {
-            // N in a three-membered ring is another one of the InChI special
-            // cases
-            legalCenter = true;
+        } else if (atom->getAtomicNum() == 15 || atom->getAtomicNum() == 33) {
+          // from logical flow: nbrs.size is 3 or 4, or 2 (implicit H)
+          // Since InChI Software v. 1.02-standard (2009), phosphines and
+          // arsines are always treated as stereogenic even with H atom
+          // neighbors. Accept automatically.
+          legalCenter = true;
+        } else if (nbrs.size() == 3) {
+          // three-coordinate with a single H we'll accept automatically:
+          if (atom->getTotalNumHs() != 1) {
+            // otherwise we default to not being a legal center
+            legalCenter = false;
+            // but there are a few special cases we'll accept
+            // sulfur or selenium with either a positive charge or a double
+            // bond:
+            if ((atom->getAtomicNum() == 16 || atom->getAtomicNum() == 34) &&
+                (atom->getExplicitValence() == 4 ||
+                 (atom->getExplicitValence() == 3 &&
+                  atom->getFormalCharge() == 1))) {
+              legalCenter = true;
+            } else if (atom->getAtomicNum() == 7 &&
+                       mol.getRingInfo()->isAtomInRingOfSize(atom->getIdx(),
+                                                             3)) {
+              // N in a three-membered ring is another one of the InChI special
+              // cases
+              legalCenter = true;
+            }
           }
         }
       }

--- a/Code/GraphMol/SmilesParse/test.cpp
+++ b/Code/GraphMol/SmilesParse/test.cpp
@@ -4275,24 +4275,29 @@ void testGithub1028() {
   BOOST_LOG(rdInfoLog) << "Testing github issue #1028: Alternating canonical "
                           "SMILES for ring with chiral N"
                        << std::endl;
-
+  // note that due to the changes made for #3631, the N's originally used in
+  // these tests are no longer considered to be chiral. I switched to using P
+  // (and verified that P was also a problem before #1028 was fixed)
   {
-    const std::string smi = "O[C@H]1CC2CCC(C1)[N@@]2C";
-    const std::string ref = "C[N@]1C2CCC1C[C@H](O)C2";
+    std::string smi = "O[C@H]1CC2CCC(C1)[P@@]2C";
+    const std::string ref = "C[P@]1C2CCC1C[C@H](O)C2";
     for (int i = 0; i < 3; ++i) {
       const auto mol = std::unique_ptr<ROMol>(SmilesToMol(smi));
       TEST_ASSERT(mol);
       const std::string out = MolToSmiles(*mol);
       TEST_ASSERT(out == ref);
+      smi = out;
     }
 
     {
-      const std::string smi = "C[N@]1C[C@@H](O)C1";
+      std::string smi = "C[P@]1C[C@@H](O)C1";
+      const std::string ref = smi;
       for (int i = 0; i < 3; ++i) {
         const auto mol = std::unique_ptr<ROMol>(SmilesToMol(smi));
         TEST_ASSERT(mol);
         const std::string out = MolToSmiles(*mol);
-        TEST_ASSERT(out == smi);
+        TEST_ASSERT(out == ref);
+        smi = out;
       }
     }
   }

--- a/Code/GraphMol/catch_chirality.cpp
+++ b/Code/GraphMol/catch_chirality.cpp
@@ -1200,3 +1200,81 @@ TEST_CASE("ring stereo finding is overly aggressive", "[chirality][bug]") {
     CHECK(stereoInfo.size() == 2);
   }
 }
+
+TEST_CASE(
+    "github #3631: Ring stereochemistry not properly removed from N atoms",
+    "[chirality][bug]") {
+  SECTION("basics") {
+    SmilesParserParams ps;
+    ps.sanitize = false;
+    ps.removeHs = false;
+    std::unique_ptr<RWMol> mol{SmilesToMol("C[N@]1C[C@@](F)(Cl)C1", ps)};
+    REQUIRE(mol);
+    MolOps::sanitizeMol(*mol);
+
+    CHECK(mol->getAtomWithIdx(1)->getChiralTag() !=
+          Atom::ChiralType::CHI_UNSPECIFIED);
+    CHECK(mol->getAtomWithIdx(3)->getChiralTag() !=
+          Atom::ChiralType::CHI_UNSPECIFIED);
+    bool cleanIt = true;
+    bool flagPossible = true;
+    bool force = true;
+    {
+      auto stereoInfo =
+          Chirality::findPotentialStereo(*mol, cleanIt, flagPossible);
+      CHECK(stereoInfo.size() == 0);
+    }
+    {
+      MolOps::assignStereochemistry(*mol, cleanIt, force, flagPossible);
+      CHECK(mol->getAtomWithIdx(1)->getChiralTag() ==
+            Atom::ChiralType::CHI_UNSPECIFIED);
+      CHECK(mol->getAtomWithIdx(3)->getChiralTag() ==
+            Atom::ChiralType::CHI_UNSPECIFIED);
+    }
+  }
+  SECTION("default behavior") {
+    auto mol = "C[N@]1C[C@@](F)(Cl)C1"_smiles;
+    REQUIRE(mol);
+    auto smiles = MolToSmiles(*mol);
+    CHECK(smiles == "CN1CC(F)(Cl)C1");
+    bool cleanIt = true;
+    bool flagPossible = true;
+    bool force = true;
+    CHECK(mol->getAtomWithIdx(1)->getChiralTag() ==
+          Atom::ChiralType::CHI_UNSPECIFIED);
+    CHECK(mol->getAtomWithIdx(3)->getChiralTag() ==
+          Atom::ChiralType::CHI_UNSPECIFIED);
+    {
+      auto stereoInfo =
+          Chirality::findPotentialStereo(*mol, cleanIt, flagPossible);
+      CHECK(stereoInfo.size() == 0);
+    }
+    {
+      MolOps::assignStereochemistry(*mol, cleanIt, force);
+      CHECK(mol->getAtomWithIdx(1)->getChiralTag() ==
+            Atom::ChiralType::CHI_UNSPECIFIED);
+      CHECK(mol->getAtomWithIdx(3)->getChiralTag() ==
+            Atom::ChiralType::CHI_UNSPECIFIED);
+    }
+  }
+  SECTION("don't overcorrect") {
+    auto mol = "C[N@]1O[C@@](F)(Cl)C1"_smiles;
+    REQUIRE(mol);
+    bool cleanIt = true;
+    bool flagPossible = true;
+    bool force = true;
+    {
+      auto stereoInfo =
+          Chirality::findPotentialStereo(*mol, cleanIt, flagPossible);
+      CHECK(stereoInfo.size() == 1);
+      CHECK(stereoInfo[0].centeredOn == 3);
+    }
+    {
+      MolOps::assignStereochemistry(*mol, cleanIt, force);
+      CHECK(mol->getAtomWithIdx(1)->getChiralTag() ==
+            Atom::ChiralType::CHI_UNSPECIFIED);
+      CHECK(mol->getAtomWithIdx(3)->getChiralTag() !=
+            Atom::ChiralType::CHI_UNSPECIFIED);
+    }
+  }
+}

--- a/Code/GraphMol/catch_chirality.cpp
+++ b/Code/GraphMol/catch_chirality.cpp
@@ -1220,15 +1220,17 @@ TEST_CASE(
     bool flagPossible = true;
     bool force = true;
     {
+      RWMol mol2(*mol);
       auto stereoInfo =
-          Chirality::findPotentialStereo(*mol, cleanIt, flagPossible);
+          Chirality::findPotentialStereo(mol2, cleanIt, flagPossible);
       CHECK(stereoInfo.size() == 0);
     }
     {
-      MolOps::assignStereochemistry(*mol, cleanIt, force, flagPossible);
-      CHECK(mol->getAtomWithIdx(1)->getChiralTag() ==
+      RWMol mol2(*mol);
+      MolOps::assignStereochemistry(mol2, cleanIt, force, flagPossible);
+      CHECK(mol2.getAtomWithIdx(1)->getChiralTag() ==
             Atom::ChiralType::CHI_UNSPECIFIED);
-      CHECK(mol->getAtomWithIdx(3)->getChiralTag() ==
+      CHECK(mol2.getAtomWithIdx(3)->getChiralTag() ==
             Atom::ChiralType::CHI_UNSPECIFIED);
     }
   }
@@ -1245,15 +1247,17 @@ TEST_CASE(
     CHECK(mol->getAtomWithIdx(3)->getChiralTag() ==
           Atom::ChiralType::CHI_UNSPECIFIED);
     {
+      RWMol mol2(*mol);
       auto stereoInfo =
-          Chirality::findPotentialStereo(*mol, cleanIt, flagPossible);
+          Chirality::findPotentialStereo(mol2, cleanIt, flagPossible);
       CHECK(stereoInfo.size() == 0);
     }
     {
-      MolOps::assignStereochemistry(*mol, cleanIt, force);
-      CHECK(mol->getAtomWithIdx(1)->getChiralTag() ==
+      RWMol mol2(*mol);
+      MolOps::assignStereochemistry(mol2, cleanIt, force, flagPossible);
+      CHECK(mol2.getAtomWithIdx(1)->getChiralTag() ==
             Atom::ChiralType::CHI_UNSPECIFIED);
-      CHECK(mol->getAtomWithIdx(3)->getChiralTag() ==
+      CHECK(mol2.getAtomWithIdx(3)->getChiralTag() ==
             Atom::ChiralType::CHI_UNSPECIFIED);
     }
   }
@@ -1264,16 +1268,18 @@ TEST_CASE(
     bool flagPossible = true;
     bool force = true;
     {
+      RWMol mol2(*mol);
       auto stereoInfo =
-          Chirality::findPotentialStereo(*mol, cleanIt, flagPossible);
+          Chirality::findPotentialStereo(mol2, cleanIt, flagPossible);
       CHECK(stereoInfo.size() == 1);
       CHECK(stereoInfo[0].centeredOn == 3);
     }
     {
-      MolOps::assignStereochemistry(*mol, cleanIt, force);
-      CHECK(mol->getAtomWithIdx(1)->getChiralTag() ==
+      RWMol mol2(*mol);
+      MolOps::assignStereochemistry(mol2, cleanIt, force, flagPossible);
+      CHECK(mol2.getAtomWithIdx(1)->getChiralTag() ==
             Atom::ChiralType::CHI_UNSPECIFIED);
-      CHECK(mol->getAtomWithIdx(3)->getChiralTag() !=
+      CHECK(mol2.getAtomWithIdx(3)->getChiralTag() !=
             Atom::ChiralType::CHI_UNSPECIFIED);
     }
   }

--- a/Code/GraphMol/molopstest.cpp
+++ b/Code/GraphMol/molopstest.cpp
@@ -2536,12 +2536,13 @@ void testSFIssue1719053() {
   TEST_ASSERT(m->getAtomWithIdx(1)->getChiralTag() == Atom::CHI_UNSPECIFIED);
   TEST_ASSERT(m->getAtomWithIdx(4)->getChiralTag() == Atom::CHI_UNSPECIFIED);
 
+  // N in rings that aren't 3 rings is not chiral
   delete m;
   smi = "C[N@@]1CC[C@@H](C)CC1";
   m = SmilesToMol(smi);
   TEST_ASSERT(m);
-  TEST_ASSERT(m->getAtomWithIdx(1)->getChiralTag() != Atom::CHI_UNSPECIFIED);
-  TEST_ASSERT(m->getAtomWithIdx(4)->getChiralTag() != Atom::CHI_UNSPECIFIED);
+  TEST_ASSERT(m->getAtomWithIdx(1)->getChiralTag() == Atom::CHI_UNSPECIFIED);
+  TEST_ASSERT(m->getAtomWithIdx(4)->getChiralTag() == Atom::CHI_UNSPECIFIED);
 
   delete m;
   BOOST_LOG(rdInfoLog) << "Finished" << std::endl;


### PR DESCRIPTION
Fixes the logic problem that was causing too many atoms to be considered for potential ring-stereo involvement.

Also does a minor bit of refactoring/cleanup of `isAtomPotentialChiralCenter()`, which was just too much of a mess.