### PR TITLE
Bump catch2 version to allow builds on Apple M1

### DIFF
--- a/External/catch/CMakeLists.txt
+++ b/External/catch/CMakeLists.txt
@@ -12,10 +12,10 @@ elseif(EXISTS "${CATCH_DIR}/single_include/catch2/catch.hpp")
 else()
   message("-- Catch not found in ${CATCH_DIR}")
   include(RDKitUtils)
-  set(RELEASE_NO "2.12.1")
+  set(RELEASE_NO "2.12.4")
   downloadAndCheckMD5("https://github.com/catchorg/Catch2/archive/v${RELEASE_NO}.tar.gz"
         "${CMAKE_CURRENT_SOURCE_DIR}/v${RELEASE_NO}.tar.gz"
-        "05c1b743773e546db9cb65b3b9315b02")
+        "dbe4fa691e37dd51256876641a821ec8")
   execute_process(COMMAND ${CMAKE_COMMAND} -E tar zxf
     ${CMAKE_CURRENT_SOURCE_DIR}/v${RELEASE_NO}.tar.gz
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

This updates catch2 version which caused the build on Apple's M1 to fail

#### Any other comments?

Generally, builds run fine, I've both built against the official Python 3.9 with universal binaries which was just released, miniforge's python3.9 and a miniforge's 3.8 environments. 

For people trying to build this on the M1 I would recommend getting all binary dependencies with miniforge.

Code signing caused issues as well - unfortunately the fix suggested in the rdkit docs didn't work so I had to sign all `.dylibs` using an actual apple developer account (`codesign -f -s "<yourid>"  $HOME/miniconda3/lib/*/*.so`)