### PR TITLE
BondStereo info lost in FragmentOnBonds()

### DIFF
--- a/Code/GraphMol/ChemTransforms/MolFragmenter.cpp
+++ b/Code/GraphMol/ChemTransforms/MolFragmenter.cpp
@@ -409,6 +409,25 @@ void checkChiralityPostMove(const ROMol &mol, const Atom *oAt, Atom *nAt,
     nAt->invertChirality();
   }
 }
+
+std::vector<std::pair<Bond*, std::vector<int>>> getNbrBondStereo(RWMol &mol, const Bond *bnd) {
+    // loop over neighboring double bonds and remove their stereo atom
+    std::vector<std::pair<Bond*, std::vector<int>>> res;
+    Atom *bgn = bnd->getBeginAtom();
+    Atom *end = bnd->getEndAtom();
+    for(auto *atom : {bgn, end}) {
+        ROMol::OEDGE_ITER a1, a2;
+        for (boost::tie(a1, a2) = mol.getAtomBonds(atom); a1 != a2; a1++) {
+          Bond *obnd = mol[*a1];
+            if(obnd->getIdx() != bnd->getIdx()) {
+                if(obnd->getStereoAtoms().size()) {
+                    res.emplace_back(obnd, obnd->getStereoAtoms());
+                }
+            }
+        }
+    }
+    return res;
+}
 }  // namespace
 
 ROMol *fragmentOnBonds(
@@ -443,6 +462,7 @@ ROMol *fragmentOnBonds(
     Bond::BondType bT = bond->getBondType();
     Bond::BondDir bD = bond->getBondDir();
     unsigned int bondidx;
+    auto nbr_bond_stereo = getNbrBondStereo(*res, bond);
     res->removeBond(bidx, eidx);
     if (nCutsPerAtom) {
       (*nCutsPerAtom)[bidx] += 1;
@@ -476,7 +496,14 @@ ROMol *fragmentOnBonds(
       // this bond starts at the same atom, so its direction should always be
       // correct:
       res->getBondWithIdx(bondidx)->setBondDir(bD);
-
+        
+      // restore stereo atoms
+      for(auto &stereo_atoms : nbr_bond_stereo) {
+          std::replace(stereo_atoms.second.begin(), stereo_atoms.second.end(), bidx, idx1);
+          std::replace(stereo_atoms.second.begin(), stereo_atoms.second.end(), eidx, idx2);
+          stereo_atoms.first->getStereoAtoms().swap(stereo_atoms.second);
+      }
+        
       // figure out if we need to change the stereo tags on the atoms:
       if (mol.getAtomWithIdx(bidx)->getChiralTag() ==
               Atom::CHI_TETRAHEDRAL_CCW ||

--- a/Code/GraphMol/ChemTransforms/catch_tests.cpp
+++ b/Code/GraphMol/ChemTransforms/catch_tests.cpp
@@ -74,26 +74,6 @@ TEST_CASE("Github #1039", "[]") {
       }
       CHECK(received_stereo==expected_stereo_atoms);
   }
-  {
-      auto m =  "C/C(O)=N/C=C"_smiles;
-      std::vector<std::pair<unsigned int, unsigned int>> dummyLabels{{1,1}};
-      std::vector<unsigned int> bonds{2};
-      auto resa = RDKit::MolFragmenter::fragmentOnBonds(*m, bonds);
-      CHECK(MolToSmiles(*resa) == "*/C=N/C=C.[1*]O");
-      // make sure we still have stereo atoms
-      std::vector<std::vector<int>> expected_stereo_atoms {
-          {}, // 5 is the new dummy atom, it was 0 before
-          {},
-          {2,4},
-          {},
-          {},
-      };
-      std::vector<std::vector<int>> received_stereo;
-      for(auto *bond: resa->bonds()) {
-          received_stereo.push_back(bond->getStereoAtoms());
-      }
-      CHECK(received_stereo==expected_stereo_atoms);
-  }
   { // break non stereo atom bond
     auto m =  "C/C(O)=N/C=C"_smiles;
     std::vector<std::pair<unsigned int, unsigned int>> dummyLabels{{1,1}};
@@ -107,6 +87,7 @@ TEST_CASE("Github #1039", "[]") {
 							 {},
 							 {},
 							 {},
+							 {}
     };
     std::vector<std::vector<int>> received_stereo;
     for(auto *bond: resa->bonds()) {

--- a/Code/GraphMol/ChemTransforms/catch_tests.cpp
+++ b/Code/GraphMol/ChemTransforms/catch_tests.cpp
@@ -74,5 +74,39 @@ TEST_CASE("Github #1039", "[]") {
       }
       CHECK(received_stereo==expected_stereo_atoms);
   }
+  { // bond stereo should only be removed when deleting the double bond with E/Z
+    auto m =  "O/C=N/C=C"_smiles;
+    std::vector<std::pair<unsigned int, unsigned int>> dummyLabels{{1,1}};
+    std::vector<std::string> expected = {
+					 "*/C=N/C=C.[1*]O",
+					 "[1*]=NC=C.[2*]=CO", // bond stereo gone
+					 "[2*]C=C.[3*]/N=C/O",
+					 "[3*]=C.[4*]=C/N=C/O"
+    };
+    for(unsigned int i=0;i<m->getNumBonds();++i) {
+      std::vector<unsigned int> bonds{i};
+      auto resa = RDKit::MolFragmenter::fragmentOnBonds(*m, bonds);
+      auto smiles = MolToSmiles(*resa);
+      CHECK(smiles == expected[i]);
+    }
+  }
+  { // bond stereo should only be removed when deleting the double bond with E/Z
+    // chiral stereo should stay
+    auto m =  "O/C=N/[C@H](I)F"_smiles;
+    std::vector<std::pair<unsigned int, unsigned int>> dummyLabels{{1,1}};
+    std::vector<std::string> expected = {
+					 "*/C=N/[C@@H](F)I.[1*]O",
+					 "[1*]=N[C@@H](F)I.[2*]=CO", // bond stereo gone
+					 "[2*][C@@H](F)I.[3*]/N=C/O",
+					 "[3*]I.[4*][C@H](F)/N=C/O",
+					 "[3*]F.[5*][C@@H](I)/N=C/O"
+    };
+    for(unsigned int i=0;i<m->getNumBonds();++i) {
+      std::vector<unsigned int> bonds{i};
+      auto resa = RDKit::MolFragmenter::fragmentOnBonds(*m, bonds);
+      auto smiles = MolToSmiles(*resa);
+      CHECK(smiles == expected[i]);
+    }
+  }
 }
 

--- a/Code/GraphMol/ChemTransforms/catch_tests.cpp
+++ b/Code/GraphMol/ChemTransforms/catch_tests.cpp
@@ -54,5 +54,25 @@ TEST_CASE("Github #1039", "[]") {
     // conformer to do that using wedging)
     CHECK(MolToSmiles(*pieces) == "*C.[1*]C(O)(F)Cl");
   }
+  SECTION("bond stereo") {
+      auto m =  "O/C=N/C=C"_smiles;
+      std::vector<std::pair<unsigned int, unsigned int>> dummyLabels{{1,1}};
+      std::vector<unsigned int> bonds{0};
+      auto resa = RDKit::MolFragmenter::fragmentOnBonds(*m, bonds);
+      CHECK(MolToSmiles(*resa) == "*/C=N/C=C.[1*]O");
+      // make sure we still have stereo atoms
+      std::vector<std::vector<int>> expected_stereo_atoms {
+          {5,3}, // 5 is the new dummy atom, it was 0 before
+          {},
+          {},
+          {},
+          {},
+      };
+      std::vector<std::vector<int>> received_stereo;
+      for(auto *bond: resa->bonds()) {
+          received_stereo.push_back(bond->getStereoAtoms());
+      }
+      CHECK(received_stereo==expected_stereo_atoms);
+  }
 }
 

--- a/Code/GraphMol/ChemTransforms/catch_tests.cpp
+++ b/Code/GraphMol/ChemTransforms/catch_tests.cpp
@@ -74,6 +74,46 @@ TEST_CASE("Github #1039", "[]") {
       }
       CHECK(received_stereo==expected_stereo_atoms);
   }
+  {
+      auto m =  "C/C(O)=N/C=C"_smiles;
+      std::vector<std::pair<unsigned int, unsigned int>> dummyLabels{{1,1}};
+      std::vector<unsigned int> bonds{2};
+      auto resa = RDKit::MolFragmenter::fragmentOnBonds(*m, bonds);
+      CHECK(MolToSmiles(*resa) == "*/C=N/C=C.[1*]O");
+      // make sure we still have stereo atoms
+      std::vector<std::vector<int>> expected_stereo_atoms {
+          {}, // 5 is the new dummy atom, it was 0 before
+          {},
+          {2,4},
+          {},
+          {},
+      };
+      std::vector<std::vector<int>> received_stereo;
+      for(auto *bond: resa->bonds()) {
+          received_stereo.push_back(bond->getStereoAtoms());
+      }
+      CHECK(received_stereo==expected_stereo_atoms);
+  }
+  { // break non stereo atom bond
+    auto m =  "C/C(O)=N/C=C"_smiles;
+    std::vector<std::pair<unsigned int, unsigned int>> dummyLabels{{1,1}};
+    std::vector<unsigned int> bonds{0};
+    auto resa = RDKit::MolFragmenter::fragmentOnBonds(*m, bonds);
+    CHECK(MolToSmiles(*resa) == "*/C(O)=N/C=C.[1*]C");
+    // make sure we still have stereo atoms
+    std::vector<std::vector<int>> expected_stereo_atoms {
+							 {},
+							 {2,4},
+							 {},
+							 {},
+							 {},
+    };
+    std::vector<std::vector<int>> received_stereo;
+    for(auto *bond: resa->bonds()) {
+      received_stereo.push_back(bond->getStereoAtoms());
+    }
+    CHECK(received_stereo==expected_stereo_atoms);
+  }  
   { // bond stereo should only be removed when deleting the double bond with E/Z
     auto m =  "O/C=N/C=C"_smiles;
     std::vector<std::pair<unsigned int, unsigned int>> dummyLabels{{1,1}};


### PR DESCRIPTION
Unlike chirality, fragment on bonds wasn't preserving the internal bond-stereo.

This only became an issue when using the fragmented mol directly, round-tripping through smiles fixed the issue.

This PR properly updates the bond stereo atoms that were being removed when the bonds were cut.

