### PR TITLE
Fixes #3658

### DIFF
--- a/Code/GraphMol/MolDraw2D/CMakeLists.txt
+++ b/Code/GraphMol/MolDraw2D/CMakeLists.txt
@@ -46,10 +46,10 @@ if(RDK_BUILD_QT_SUPPORT)
   target_compile_definitions(MolDraw2D PUBLIC "-DRDK_BUILD_QT_SUPPORT")
   find_package(Qt5 COMPONENTS Widgets OpenGL REQUIRED)
   target_sources(MolDraw2D PRIVATE MolDraw2DQt.cpp DrawTextQt.cpp)
-  target_link_libraries(MolDraw2D PUBLIC Qt5::Widgets Qt5::OpenGL)
+  target_link_libraries(MolDraw2D PRIVATE Qt5::Widgets Qt5::OpenGL)
   rdkit_headers(MolDraw2DQt.h DrawTextQt.h DEST GraphMol/MolDraw2D)
   if(RDK_INSTALL_STATIC_LIBS)
-     target_link_libraries(MolDraw2D_static PUBLIC Qt5::Widgets Qt5::OpenGL)
+     target_link_libraries(MolDraw2D_static PRIVATE Qt5::Widgets Qt5::OpenGL)
      target_sources(MolDraw2D_static PRIVATE MolDraw2DQt.cpp DrawTextQt.cpp)
   endif()
 endif(RDK_BUILD_QT_SUPPORT)
@@ -117,7 +117,7 @@ rdkit_catch_test(moldraw2DTestCatch catch_main.cpp catch_tests.cpp LINK_LIBRARIE
 
 if(RDK_BUILD_QT_SUPPORT)
 rdkit_catch_test(moldraw2DTestQt catch_qt.cpp LINK_LIBRARIES
-  MolDraw2D )
+  MolDraw2D Qt5::Widgets Qt5::OpenGL)
 endif(RDK_BUILD_QT_SUPPORT)
 
 rdkit_test(moldraw2DRxnTest1 rxn_test1.cpp LINK_LIBRARIES

--- a/Code/GraphMol/MolDraw2D/QTDemo/CMakeLists.txt
+++ b/Code/GraphMol/MolDraw2D/QTDemo/CMakeLists.txt
@@ -30,11 +30,13 @@ set( RDKitSV_INCS MolDisplay2DWidget.H
   QTGet2Strings.H
   QT4SelectItems.H )
 
+find_package(Qt5 COMPONENTS Widgets OpenGL REQUIRED)
+
 set( LIBS Boost::program_options Boost::iostreams Boost::filesystem
   ${RDKit_THREAD_LIBS}
   FileParsers SmilesParse Depictor RDGeometryLib
   RDGeneral SubstructMatch Subgraphs GraphMol RDGeometryLib
-   z )
+   z Qt5::Widgets Qt5::OpenGL )
 
 add_executable( rdkitsv ${RDKitSV_SRCS}
   ${RDKitSV_MOC_SRCS} ${RDKitSV_INCS} )

--- a/Code/GraphMol/MolDraw2D/Wrap/CMakeLists.txt
+++ b/Code/GraphMol/MolDraw2D/Wrap/CMakeLists.txt
@@ -1,8 +1,14 @@
 remove_definitions(-DRDKIT_MOLDRAW2D_BUILD)
+
+if(RDK_BUILD_QT_SUPPORT)
+  find_package(Qt5 COMPONENTS Widgets OpenGL REQUIRED)
+  set( QtDrawingLibs Qt5::Widgets Qt5::OpenGL )
+endif(RDK_BUILD_QT_SUPPORT)
+
 rdkit_python_extension(rdMolDraw2D
                        rdMolDraw2D.cpp
                        DEST Chem/Draw
-                       LINK_LIBRARIES MolDraw2D )
+                       LINK_LIBRARIES MolDraw2D ${QtDrawingLibs} )
 
 add_pytest(pyMolDraw2D ${CMAKE_CURRENT_SOURCE_DIR}/testMolDraw2D.py)
 if(RDK_BUILD_QT_SUPPORT)


### PR DESCRIPTION
This fixes #3658 the way I suggested in the issue: by adding the Qt libraries as "private" link target to MolDraw2D and rdMolDraw2D, so that they are not propagated to other libraries linking against these two.

