### PR TITLE
Embedder callback

### DIFF
--- a/Code/GraphMol/DistGeomHelpers/Embedder.cpp
+++ b/Code/GraphMol/DistGeomHelpers/Embedder.cpp
@@ -711,9 +711,9 @@ bool embedPoints(RDGeom::PointPtrVect *positions, detail::EmbedArgs eargs,
   unsigned int iter = 0;
   while ((gotCoords == false) && (iter < embedParams.maxIterations)) {
     ++iter;
-	if(embedParams.callback) {
-		embedParams.callback();
-	}
+    if(embedParams.callback) {
+      embedParams.callback();
+    }
     gotCoords = EmbeddingOps::generateInitialCoords(positions, eargs,
                                                     embedParams, distMat, rng);
 #ifdef DEBUG_EMBEDDING

--- a/Code/GraphMol/DistGeomHelpers/Embedder.cpp
+++ b/Code/GraphMol/DistGeomHelpers/Embedder.cpp
@@ -80,7 +80,8 @@ const EmbedParameters KDG(0,        // maxIterations
                           false,    // useSmallRingTorsions
                           false,    // useMacrocycleTorsions
                           false,    // useMacrocycle14config
-                          nullptr   // CPCI
+                          nullptr,   // CPCI
+                          nullptr   // callback
 );
 
 //! Parameters corresponding to Sereina Riniker's ETDG approach
@@ -108,7 +109,8 @@ const EmbedParameters ETDG(0,        // maxIterations
                            false,    // useSmallRingTorsions
                            false,    // useMacrocycleTorsions
                            false,    // useMacrocycle14config
-                           nullptr   // CPCI
+                           nullptr,   // CPCI
+                           nullptr   // callback
 );
 //! Parameters corresponding to Sereina Riniker's ETKDG approach
 const EmbedParameters ETKDG(0,        // maxIterations
@@ -135,7 +137,8 @@ const EmbedParameters ETKDG(0,        // maxIterations
                             false,    // useSmallRingTorsions
                             false,    // useMacrocycleTorsions
                             false,    // useMacrocycle14config
-                            nullptr   // CPCI
+                            nullptr,   // CPCI
+                            nullptr   // callback
 );
 
 //! Parameters corresponding to Sereina Riniker's ETKDG approach - version 2
@@ -163,7 +166,8 @@ const EmbedParameters ETKDGv2(0,        // maxIterations
                               false,    // useSmallRingTorsions
                               false,    // useMacrocycleTorsions
                               false,    // useMacrocycle14config
-                              nullptr   // CPCI
+                              nullptr,   // CPCI
+                              nullptr   // callback
 );
 
 //! Parameters corresponding improved ETKDG by Wang, Witek, Landrum and Riniker
@@ -192,7 +196,8 @@ const EmbedParameters ETKDGv3(0,        // maxIterations
                               false,    // useSmallRingTorsions
                               true,     // useMacrocycleTorsions
                               true,     // useMacrocycle14config
-                              nullptr   // CPCI
+                              nullptr,   // CPCI
+                              nullptr   // callback
 );
 
 //! Parameters corresponding improved ETKDG by Wang, Witek, Landrum and Riniker
@@ -221,7 +226,8 @@ const EmbedParameters srETKDGv3(0,        // maxIterations
                                 true,     // useSmallRingTorsions
                                 false,    // useMacrocycleTorsions
                                 false,    // useMacrocycle14config
-                                nullptr   // CPCI
+                                nullptr,   // CPCI
+                                nullptr   // callback
 );
 
 namespace detail {
@@ -711,8 +717,8 @@ bool embedPoints(RDGeom::PointPtrVect *positions, detail::EmbedArgs eargs,
   unsigned int iter = 0;
   while ((gotCoords == false) && (iter < embedParams.maxIterations)) {
     ++iter;
-    if(embedParams.callback) {
-      embedParams.callback();
+    if(embedParams.callback != nullptr) {
+      embedParams.callback(iter);
     }
     gotCoords = EmbeddingOps::generateInitialCoords(positions, eargs,
                                                     embedParams, distMat, rng);

--- a/Code/GraphMol/DistGeomHelpers/Embedder.cpp
+++ b/Code/GraphMol/DistGeomHelpers/Embedder.cpp
@@ -711,6 +711,9 @@ bool embedPoints(RDGeom::PointPtrVect *positions, detail::EmbedArgs eargs,
   unsigned int iter = 0;
   while ((gotCoords == false) && (iter < embedParams.maxIterations)) {
     ++iter;
+	if(embedParams.callback) {
+		embedParams.callback();
+	}
     gotCoords = EmbeddingOps::generateInitialCoords(positions, eargs,
                                                     embedParams, distMat, rng);
 #ifdef DEBUG_EMBEDDING

--- a/Code/GraphMol/DistGeomHelpers/Embedder.h
+++ b/Code/GraphMol/DistGeomHelpers/Embedder.h
@@ -123,7 +123,7 @@ struct RDKIT_DISTGEOMHELPERS_EXPORT EmbedParameters {
         
         CPCI(nullptr),
 
-		callback(nullptr) {};
+        callback(nullptr) {};
   EmbedParameters(
       unsigned int maxIterations, int numThreads, int randomSeed,
       bool clearConfs, bool useRandomCoords, double boxSizeMult,
@@ -163,7 +163,7 @@ struct RDKIT_DISTGEOMHELPERS_EXPORT EmbedParameters {
         useMacrocycleTorsions(useMacrocycleTorsions),
         useMacrocycle14config(useMacrocycle14config),
         CPCI(CPCI),
-		callback(nullptr) {};
+        callback(nullptr) {};
 };
 
 //*! Embed multiple conformations for a molecule

--- a/Code/GraphMol/DistGeomHelpers/Embedder.h
+++ b/Code/GraphMol/DistGeomHelpers/Embedder.h
@@ -21,7 +21,6 @@
 namespace RDKit {
 namespace DGeomHelpers {
 
-
 //! Parameter object for controlling embedding
 /*!
   numConfs       Number of conformations to be generated
@@ -123,7 +122,7 @@ struct RDKIT_DISTGEOMHELPERS_EXPORT EmbedParameters {
         boundsMat(nullptr),
         
         CPCI(nullptr),
-		
+
 		callback(nullptr) {};
   EmbedParameters(
       unsigned int maxIterations, int numThreads, int randomSeed,

--- a/Code/GraphMol/DistGeomHelpers/Embedder.h
+++ b/Code/GraphMol/DistGeomHelpers/Embedder.h
@@ -88,7 +88,9 @@ namespace DGeomHelpers {
   macrocycles is used
 
   CPCI	custom columbic interactions between atom pairs
-  callback	void pointer
+  callback	      void pointer to a function for reporting progress,
+                  will be called with the current iteration number.
+
 */
 struct RDKIT_DISTGEOMHELPERS_EXPORT EmbedParameters {
   unsigned int maxIterations{0};
@@ -116,7 +118,7 @@ struct RDKIT_DISTGEOMHELPERS_EXPORT EmbedParameters {
   bool useMacrocycleTorsions{false};
   bool useMacrocycle14config{false};
   std::shared_ptr<std::map<std::pair<unsigned int, unsigned int>, double>> CPCI;
-  void (* callback)();
+  void (* callback)(unsigned int);
   EmbedParameters()
       : 
         boundsMat(nullptr),
@@ -137,7 +139,7 @@ struct RDKIT_DISTGEOMHELPERS_EXPORT EmbedParameters {
       bool embedFragmentsSeparately = true, bool useSmallRingTorsions = false,
       bool useMacrocycleTorsions = false, bool useMacrocycle14config = false,
       std::shared_ptr<std::map<std::pair<unsigned int, unsigned int>, double>>
-          CPCI = nullptr)
+          CPCI = nullptr, void (* callback)(unsigned int) = nullptr)
       : maxIterations(maxIterations),
         numThreads(numThreads),
         randomSeed(randomSeed),
@@ -163,7 +165,7 @@ struct RDKIT_DISTGEOMHELPERS_EXPORT EmbedParameters {
         useMacrocycleTorsions(useMacrocycleTorsions),
         useMacrocycle14config(useMacrocycle14config),
         CPCI(CPCI),
-        callback(nullptr) {};
+        callback(callback) {};
 };
 
 //*! Embed multiple conformations for a molecule

--- a/Code/GraphMol/DistGeomHelpers/Embedder.h
+++ b/Code/GraphMol/DistGeomHelpers/Embedder.h
@@ -21,6 +21,7 @@
 namespace RDKit {
 namespace DGeomHelpers {
 
+
 //! Parameter object for controlling embedding
 /*!
   numConfs       Number of conformations to be generated
@@ -88,6 +89,7 @@ namespace DGeomHelpers {
   macrocycles is used
 
   CPCI	custom columbic interactions between atom pairs
+  callback	void pointer
 */
 struct RDKIT_DISTGEOMHELPERS_EXPORT EmbedParameters {
   unsigned int maxIterations{0};
@@ -115,11 +117,14 @@ struct RDKIT_DISTGEOMHELPERS_EXPORT EmbedParameters {
   bool useMacrocycleTorsions{false};
   bool useMacrocycle14config{false};
   std::shared_ptr<std::map<std::pair<unsigned int, unsigned int>, double>> CPCI;
+  void (* callback)();
   EmbedParameters()
       : 
         boundsMat(nullptr),
         
-        CPCI(nullptr){};
+        CPCI(nullptr),
+		
+		callback(nullptr) {};
   EmbedParameters(
       unsigned int maxIterations, int numThreads, int randomSeed,
       bool clearConfs, bool useRandomCoords, double boxSizeMult,
@@ -158,7 +163,8 @@ struct RDKIT_DISTGEOMHELPERS_EXPORT EmbedParameters {
         useSmallRingTorsions(useSmallRingTorsions),
         useMacrocycleTorsions(useMacrocycleTorsions),
         useMacrocycle14config(useMacrocycle14config),
-        CPCI(CPCI){};
+        CPCI(CPCI),
+		callback(nullptr) {};
 };
 
 //*! Embed multiple conformations for a molecule

--- a/Code/GraphMol/DistGeomHelpers/testDgeomHelpers.cpp
+++ b/Code/GraphMol/DistGeomHelpers/testDgeomHelpers.cpp
@@ -2279,7 +2279,7 @@ void testGithub3019() {
 }
 
 namespace {
-void throwerror() {
+void throwerror(unsigned int notUsedHere) {
   throw ValueErrorException("embedder is abortable");
 }
 }

--- a/Code/GraphMol/DistGeomHelpers/testDgeomHelpers.cpp
+++ b/Code/GraphMol/DistGeomHelpers/testDgeomHelpers.cpp
@@ -2279,27 +2279,26 @@ void testGithub3019() {
 }
 
 namespace {
-	void throwerror() {
-		throw ValueErrorException("embedder is abortable");
-	}
+void throwerror() {
+  throw ValueErrorException("embedder is abortable");
+}
 }
 
 void testGithub3667() {
-    auto *mol = SmilesToMol("c12c3c4c5c6c1c1c7c8c9c%10c%11c(c28)c3c2c3c4c4c5c5c8c6c1c1c6c7c9c7c9c%10c%10c%11c2c2c3c3c4c4c5c5c%11c%12c(c1c85)c6c7c1c%12c5c%11c4c3c3c5c(c91)c%10c23");
-	TEST_ASSERT(mol);
+  auto *mol = SmilesToMol("c12c3c4c5c6c1c1c7c8c9c%10c%11c(c28)c3c2c3c4c4c5c5c8c6c1c1c6c7c9c7c9c%10c%10c%11c2c2c3c3c4c4c5c5c%11c%12c(c1c85)c6c7c1c%12c5c%11c4c3c3c5c(c91)c%10c23");
+  TEST_ASSERT(mol);
 
-    bool ok = false;
-    try {
-	  DGeomHelpers::EmbedParameters params;
-	  params.callback = throwerror;
-      DGeomHelpers::EmbedMolecule(*mol, params);
-      ok = false;
-    } catch (const ValueErrorException &) {
-      ok = true;
-    }
-    TEST_ASSERT(ok);
-    delete mol;
-  
+  bool ok = false;
+  try {
+    DGeomHelpers::EmbedParameters params;
+    params.callback = throwerror;
+    DGeomHelpers::EmbedMolecule(*mol, params);
+    ok = false;
+  } catch (const ValueErrorException &) {
+    ok = true;
+  }
+  TEST_ASSERT(ok);
+  delete mol;
 }
 
 

--- a/Code/GraphMol/DistGeomHelpers/testDgeomHelpers.cpp
+++ b/Code/GraphMol/DistGeomHelpers/testDgeomHelpers.cpp
@@ -2278,6 +2278,31 @@ void testGithub3019() {
   }
 }
 
+namespace {
+	void throwerror() {
+		throw ValueErrorException("embedder is abortable");
+	}
+}
+
+void testGithub3667() {
+    auto *mol = SmilesToMol("c12c3c4c5c6c1c1c7c8c9c%10c%11c(c28)c3c2c3c4c4c5c5c8c6c1c1c6c7c9c7c9c%10c%10c%11c2c2c3c3c4c4c5c5c%11c%12c(c1c85)c6c7c1c%12c5c%11c4c3c3c5c(c91)c%10c23");
+	TEST_ASSERT(mol);
+
+    bool ok = false;
+    try {
+	  DGeomHelpers::EmbedParameters params;
+	  params.callback = throwerror;
+      DGeomHelpers::EmbedMolecule(*mol, params);
+      ok = false;
+    } catch (const ValueErrorException &) {
+      ok = true;
+    }
+    TEST_ASSERT(ok);
+    delete mol;
+  
+}
+
+
 int main() {
   RDLog::InitLogs();
   BOOST_LOG(rdInfoLog)
@@ -2407,6 +2432,13 @@ int main() {
   BOOST_LOG(rdInfoLog)
       << "\t test github issue 256: handling of zero-atom molecules\n\n";
   testGithub256();
+
+
+
+  BOOST_LOG(rdInfoLog) << "\t---------------------------------\n";
+  BOOST_LOG(rdInfoLog) << "\t test embedder callback function \n";
+  
+  testGithub3667();
 
 #ifdef RDK_TEST_MULTITHREADED
   BOOST_LOG(rdInfoLog) << "\t---------------------------------\n";


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! 
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->
This implements #3667 by adding a callback function pointer to the EmbedParameters struct.  In my application the callback function queries the calling process (a Mathematica kernel) to see if a user has aborted, and if so it throws an exception and returns to top level.  This is convenient if the user asked for a 3D plot of a huge protein without realizing how long it takes to generate coordinates.

I don't know if there is an equivalent abort functionality in an interactive python session, this PR does not address the python wrappers.

#### What does this implement/fix? Explain your changes.
If the callback function is provided, it will be called prior to calling `generateInitialCoords` in each embedding attempt, with the iteration number passed as an argument.

#### Any other comments?
One could imagine extending this callback function to be called *after* generateInitialCoords returns, passing the atom positions to this function, and having it return a boolean, in much the same way that the MCSParameters and SubstructMatchParameters structs work.  In this way you could accept/reject a conformation based on some arbitrary criteria.  But I don't have a use case for this, and don't know if it would be desirable. 
