### PR TITLE
Fixes issue 1761

### DIFF
--- a/Code/GraphMol/Descriptors/Wrap/rdMolDescriptors.cpp
+++ b/Code/GraphMol/Descriptors/Wrap/rdMolDescriptors.cpp
@@ -512,7 +512,7 @@ ExplicitBitVect *GetMorganFingerprintBV(
   }
   ExplicitBitVect *res;
   res = RDKit::MorganFingerprints::getFingerprintAsBitVect(
-      mol, static_cast<unsigned int>(radius), static_cast<unsigned int>(nBits),
+      mol, radius, nBits,
       invars, froms.get(), useChirality,
       useBondTypes, false, bitInfoMap,
       includeRedundantEnvironments);

--- a/Code/GraphMol/Descriptors/Wrap/rdMolDescriptors.cpp
+++ b/Code/GraphMol/Descriptors/Wrap/rdMolDescriptors.cpp
@@ -340,7 +340,7 @@ double hkAlphaHelper(const RDKit::ROMol &mol, python::object atomContribs) {
 }
 
 RDKit::SparseIntVect<std::uint32_t> *MorganFingerprintHelper(
-    const RDKit::ROMol &mol, int radius, int nBits, python::object invariants,
+    const RDKit::ROMol &mol, unsigned int radius, unsigned int nBits, python::object invariants,
     python::object fromAtoms, bool useChirality, bool useBondTypes,
     bool useFeatures, bool useCounts, python::object bitInfo,
     bool includeRedundantEnvironments) {
@@ -461,7 +461,7 @@ struct std_pair_to_python_converter {
 #endif
 }  // namespace
 RDKit::SparseIntVect<std::uint32_t> *GetMorganFingerprint(
-    const RDKit::ROMol &mol, int radius, python::object invariants,
+    const RDKit::ROMol &mol, unsigned int radius, python::object invariants,
     python::object fromAtoms, bool useChirality, bool useBondTypes,
     bool useFeatures, bool useCounts, python::object bitInfo,
     bool includeRedundantEnvironments) {
@@ -470,7 +470,7 @@ RDKit::SparseIntVect<std::uint32_t> *GetMorganFingerprint(
       useFeatures, useCounts, bitInfo, includeRedundantEnvironments);
 }
 RDKit::SparseIntVect<std::uint32_t> *GetHashedMorganFingerprint(
-    const RDKit::ROMol &mol, int radius, int nBits, python::object invariants,
+    const RDKit::ROMol &mol, unsigned int radius, unsigned int nBits, python::object invariants,
     python::object fromAtoms, bool useChirality, bool useBondTypes,
     bool useFeatures, python::object bitInfo,
     bool includeRedundantEnvironments) {
@@ -480,7 +480,7 @@ RDKit::SparseIntVect<std::uint32_t> *GetHashedMorganFingerprint(
 }
 
 ExplicitBitVect *GetMorganFingerprintBV(
-    const RDKit::ROMol &mol, int radius, unsigned int nBits,
+    const RDKit::ROMol &mol, unsigned int radius, unsigned int nBits,
     python::object invariants, python::object fromAtoms, bool useChirality,
     bool useBondTypes, bool useFeatures, python::object bitInfo,
     bool includeRedundantEnvironments) {
@@ -512,8 +512,9 @@ ExplicitBitVect *GetMorganFingerprintBV(
   }
   ExplicitBitVect *res;
   res = RDKit::MorganFingerprints::getFingerprintAsBitVect(
-      mol, static_cast<unsigned int>(radius), nBits, invars, froms.get(),
-      useChirality, useBondTypes, false, bitInfoMap,
+      mol, static_cast<unsigned int>(radius), static_cast<unsigned int>(nBits),
+      invars, froms.get(), useChirality,
+      useBondTypes, false, bitInfoMap,
       includeRedundantEnvironments);
   if (bitInfoMap) {
     bitInfo.attr("clear")();

--- a/Code/GraphMol/Descriptors/Wrap/rdMolDescriptors.cpp
+++ b/Code/GraphMol/Descriptors/Wrap/rdMolDescriptors.cpp
@@ -340,7 +340,7 @@ double hkAlphaHelper(const RDKit::ROMol &mol, python::object atomContribs) {
 }
 
 RDKit::SparseIntVect<std::uint32_t> *MorganFingerprintHelper(
-    const RDKit::ROMol &mol, unsigned int radius, unsigned int nBits, python::object invariants,
+    const RDKit::ROMol &mol, unsigned int radius, int nBits, python::object invariants,
     python::object fromAtoms, bool useChirality, bool useBondTypes,
     bool useFeatures, bool useCounts, python::object bitInfo,
     bool includeRedundantEnvironments) {

--- a/Code/GraphMol/Descriptors/Wrap/testMolDescriptors.py
+++ b/Code/GraphMol/Descriptors/Wrap/testMolDescriptors.py
@@ -170,7 +170,7 @@ class TestCase(unittest.TestCase):
     self.assertTrue(list(fp.GetNonzeroElements().values())[0] == 2)
     fp = rdMD.GetMorganFingerprint(mol, 0, useCounts=False)
     self.assertTrue(len(fp.GetNonzeroElements()) == 1)
-    self.assertTrue(list(fp.GetNonzeroElements().values())[0] == 2)
+    self.assertTrue(list(fp.GetNonzeroElements().values())[0] == 1)
 
     mol = Chem.MolFromSmiles('CC(F)(Cl)C(F)(Cl)C')
     fp = rdMD.GetHashedMorganFingerprint(mol, 0)

--- a/Code/GraphMol/Descriptors/Wrap/testMolDescriptors.py
+++ b/Code/GraphMol/Descriptors/Wrap/testMolDescriptors.py
@@ -170,7 +170,7 @@ class TestCase(unittest.TestCase):
     self.assertTrue(list(fp.GetNonzeroElements().values())[0] == 2)
     fp = rdMD.GetMorganFingerprint(mol, 0, useCounts=False)
     self.assertTrue(len(fp.GetNonzeroElements()) == 1)
-    self.assertTrue(list(fp.GetNonzeroElements().values())[0] == 1)
+    self.assertTrue(list(fp.GetNonzeroElements().values())[0] == 2)
 
     mol = Chem.MolFromSmiles('CC(F)(Cl)C(F)(Cl)C')
     fp = rdMD.GetHashedMorganFingerprint(mol, 0)
@@ -609,6 +609,12 @@ class TestCase(unittest.TestCase):
       self.assertAlmostEqual(oTPSA, orig_tpsa[i], 2)
       nTPSA = rdMD.CalcTPSA(mol, force=True, includeSandP=True)
       self.assertAlmostEqual(nTPSA, new_tpsa[i], 2)
+
+  def testGithub1761(self):
+    mol = Chem.MolFromSmiles('CC(F)(Cl)C(F)(Cl)C')
+    self.assertRaises(OverflowError, lambda: rdMD.GetMorganFingerprint(mol, -1))
+    self.assertRaises(OverflowError, lambda: rdMD.GetHashedMorganFingerprint(mol, 0, -1))
+    self.assertRaises(ValueError, lambda: rdMD.GetHashedMorganFingerprint(mol, 0, 0))
 
   @unittest.skipIf(not haveBCUT, "BCUT descriptors not present")
   def testBCUT(self):

--- a/Code/GraphMol/Fingerprints/MorganFingerprints.cpp
+++ b/Code/GraphMol/Fingerprints/MorganFingerprints.cpp
@@ -46,6 +46,7 @@
 #include <algorithm>
 
 #include <GraphMol/Fingerprints/FingerprintUtil.h>
+#include <RDGeneral/Exceptions.h>
 
 namespace {
 class ss_matcher {
@@ -315,6 +316,9 @@ SparseIntVect<uint32_t> *getHashedFingerprint(
     std::vector<uint32_t> *invariants, const std::vector<uint32_t> *fromAtoms,
     bool useChirality, bool useBondTypes, bool onlyNonzeroInvariants,
     BitInfoMap *atomsSettingBits, bool includeRedundantEnvironments) {
+  if(nBits == 0) {
+    throw ValueErrorException("nBits can not be zero");
+  }
   SparseIntVect<uint32_t> *res;
   res = new SparseIntVect<uint32_t>(nBits);
   calcFingerprint(mol, radius, invariants, fromAtoms, useChirality,

--- a/Code/GraphMol/Fingerprints/catch_tests.cpp
+++ b/Code/GraphMol/Fingerprints/catch_tests.cpp
@@ -18,6 +18,8 @@
 #include <GraphMol/SmilesParse/SmilesParse.h>
 #include <GraphMol/FileParsers/FileParsers.h>
 #include <GraphMol/Fingerprints/Fingerprints.h>
+#include <GraphMol/Fingerprints/MorganFingerprints.h>
+#include <RDGeneral/Exceptions.h>
 #include <GraphMol/Fingerprints/RDKitFPGenerator.h>
 #include <GraphMol/Substruct/SubstructMatch.h>
 #include <DataStructs/ExplicitBitVect.h>
@@ -59,6 +61,21 @@ TEST_CASE("Github 2614", "[patternfp][bug]") {
     REQUIRE(qfp);
     CHECK(AllProbeBitsMatch(*qfp, *mfp));
   }
+}
+
+TEST_CASE("Github 1761", "[patternfp][bug]") {
+    SECTION("throw ValueErrorException") {
+        auto mol = "CCC1CC1"_smiles;
+        try
+        {
+            RDKit::MorganFingerprints::getHashedFingerprint(*mol, 0, 0);
+            FAIL("Expected ValueErrorException");
+        }
+        catch (const ValueErrorException &e)
+        {
+            REQUIRE(std::string(e.what()) == "nBits can not be zero");
+        }
+    }
 }
 
 TEST_CASE("RDKit bits per feature", "[fpgenerator][rdkit]") {


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! 
-->
#### Reference Issue
Fixes #1761


#### What does this implement/fix? Explain your changes.
- Changed the types of arguments radius and nBits from function MorganFingerprintHelper from int to unsigned int. 
- The C++ MorganFingerprint code now throws a ValueErrorException
- Implemented new test for control


#### Any other comments?
I also checked fingeprint functions `GetAtomPairFingerprint, GetHashedAtomPairFingerprint, GetHashedAtomPairFingerprintAsBitVect, GetTopologicalTorsionFingerprint, GetHashedTopologicalTorsionFingerprint, GetHashedTopologicalTorsionFingerprintAsBitVect` and `GetMorganFingerprintBV` and changed int to unsigned int when found.

However, I have a question: 
In `rdkit/Code/GraphMol/Descriptors/Wrap/rdMolDescriptors.cpp` in line 469 function `MorganFingerprintHelper` is called with `nBits = -1`. This variable is then used in line 382 to call either function `RDKit::MorganFingerprints::getFingerprint` if `nBits < 0` or function `RDKit::MorganFingerprints::getHashedFingerprint` otherwise. 

With my changes from int to unsigned int for `nBits` now `nBits` is always greater 0 and therefore function `RDKit::MorganFingerprints::getHashedFingerprint` is always used. But with this behavior parameter `useCounts` is always set to `true`.

This leads to the change in `rdkit/Code/GraphMol/Descriptors/Wrap/testMolDescriptors.py` line 173 because now parameter `useCounts` can not be set to `false`.

What should I do about this?

