### PR TITLE
Remove rdmolops link dependency on MolDraw2D

### DIFF
--- a/Code/GraphMol/Wrap/CMakeLists.txt
+++ b/Code/GraphMol/Wrap/CMakeLists.txt
@@ -9,11 +9,11 @@ rdkit_python_extension(rdchem
                        SmilesParse ChemTransforms SubstructMatch GraphMol)
 
 rdkit_python_extension(rdmolops
-                       rdmolops.cpp MolOps.cpp 
+                       rdmolops.cpp MolOps.cpp
                        ChiralityOps.cpp
                        DEST Chem
                        LINK_LIBRARIES
-                       ChemReactions MolDraw2D Depictor
+                       ChemReactions Depictor
                        FileParsers SubstructMatch Fingerprints ChemTransforms
                        Subgraphs SmilesParse MolTransforms GraphMol )
 
@@ -47,7 +47,7 @@ set(rdmolfiles_sources rdmolfiles.cpp
                        SDMolSupplier.cpp TDTMolSupplier.cpp
                        SmilesMolSupplier.cpp SmilesWriter.cpp SDWriter.cpp
                        TDTWriter.cpp
-                       PDBWriter.cpp 
+                       PDBWriter.cpp
 											 MultithreadedSmilesMolSupplier.cpp
 											 MultithreadedSDMolSupplier.cpp)
 


### PR DESCRIPTION
Even after #3659, the rdmolops Python wrapper gets linked to Qt on linux because of MolDraw2D.

To prevent this, and since rdmolops doesn't need to be linked against MolDraw2D, I'm removing the link dependency.