### PR TITLE
Addresses #3693

### DIFF
--- a/Code/GraphMol/FMCS/FMCS.cpp
+++ b/Code/GraphMol/FMCS/FMCS.cpp
@@ -111,10 +111,16 @@ void parseMCSParametersJSON(const char* json, MCSParameters* params) {
         "RingMatchesRingOnly", p.AtomCompareParameters.RingMatchesRingOnly);
     p.BondCompareParameters.RingMatchesRingOnly = pt.get<bool>(
         "RingMatchesRingOnly", p.BondCompareParameters.RingMatchesRingOnly);
-    p.AtomCompareParameters.CompleteRingsOnly = pt.get<bool>(
-        "CompleteRingsOnly", p.AtomCompareParameters.CompleteRingsOnly);
+    p.AtomCompareParameters.RingMatchesRingOnly = pt.get<bool>(
+        "AtomRingMatchesRingOnly", p.AtomCompareParameters.RingMatchesRingOnly);
+    p.BondCompareParameters.RingMatchesRingOnly = pt.get<bool>(
+        "BondRingMatchesRingOnly", p.BondCompareParameters.RingMatchesRingOnly);
     p.BondCompareParameters.CompleteRingsOnly = pt.get<bool>(
         "CompleteRingsOnly", p.BondCompareParameters.CompleteRingsOnly);
+    p.AtomCompareParameters.CompleteRingsOnly = pt.get<bool>(
+        "AtomCompleteRingsOnly", p.AtomCompareParameters.CompleteRingsOnly);
+    p.BondCompareParameters.CompleteRingsOnly = pt.get<bool>(
+        "BondCompleteRingsOnly", p.BondCompareParameters.CompleteRingsOnly);
     p.BondCompareParameters.MatchFusedRings = pt.get<bool>(
         "MatchFusedRings", p.BondCompareParameters.MatchFusedRings);
     p.BondCompareParameters.MatchFusedRingsStrict = pt.get<bool>(

--- a/Code/GraphMol/FMCS/FMCS.cpp
+++ b/Code/GraphMol/FMCS/FMCS.cpp
@@ -111,6 +111,8 @@ void parseMCSParametersJSON(const char* json, MCSParameters* params) {
         "RingMatchesRingOnly", p.AtomCompareParameters.RingMatchesRingOnly);
     p.BondCompareParameters.RingMatchesRingOnly = pt.get<bool>(
         "RingMatchesRingOnly", p.BondCompareParameters.RingMatchesRingOnly);
+    p.AtomCompareParameters.CompleteRingsOnly = pt.get<bool>(
+        "CompleteRingsOnly", p.AtomCompareParameters.CompleteRingsOnly);
     p.BondCompareParameters.CompleteRingsOnly = pt.get<bool>(
         "CompleteRingsOnly", p.BondCompareParameters.CompleteRingsOnly);
     p.BondCompareParameters.MatchFusedRings = pt.get<bool>(

--- a/Code/GraphMol/FMCS/FMCS.h
+++ b/Code/GraphMol/FMCS/FMCS.h
@@ -42,6 +42,7 @@ struct RDKIT_FMCS_EXPORT MCSAtomCompareParameters {
   bool MatchChiralTag = false;
   bool MatchFormalCharge = false;
   bool RingMatchesRingOnly = false;
+  bool CompleteRingsOnly = false;
   bool MatchIsotope = false;
 };
 

--- a/Code/GraphMol/FMCS/MaximumCommonSubgraph.cpp
+++ b/Code/GraphMol/FMCS/MaximumCommonSubgraph.cpp
@@ -569,6 +569,29 @@ bool checkIfRingsAreClosed(const Seed& fs) {
   return res;
 }
 
+bool checkNoLoneRingAtoms(const Seed& fs) {
+  if (!fs.MoleculeFragment.Atoms.size()) {
+    return true;
+  }
+
+  bool res = true;
+  const auto& om = fs.MoleculeFragment.Atoms[0]->getOwningMol();
+  const auto ri = om.getRingInfo();
+  for (const auto& ithRingAtomIndices : ri->atomRings()) {
+    size_t count = 0;
+    for (const auto atom : fs.MoleculeFragment.Atoms) {
+      if (std::find(ithRingAtomIndices.begin(), ithRingAtomIndices.end(), atom->getIdx()) != ithRingAtomIndices.end() && ++count > 1) {
+        break;
+      }
+    }
+    if (count == 1) {
+      res = false;
+      break;
+    }
+  }
+  return res;
+}
+
 }  // namespace
 bool MaximumCommonSubgraph::growSeeds() {
   bool mcsFound = false;
@@ -608,6 +631,9 @@ bool MaximumCommonSubgraph::growSeeds() {
         // #945: test here to see if the MCS actually has all rings closed
         if (possibleMCS && Parameters.BondCompareParameters.CompleteRingsOnly) {
           possibleMCS = checkIfRingsAreClosed(fs);
+        }
+        if (possibleMCS && Parameters.AtomCompareParameters.CompleteRingsOnly) {
+          possibleMCS = checkNoLoneRingAtoms(fs);
         }
         if (possibleMCS) {
           mcsFound = true;
@@ -906,6 +932,12 @@ MCSResult MaximumCommonSubgraph::find(const std::vector<ROMOL_SPTR>& src_mols) {
   }
   if (ThresholdCount > src_mols.size() - 1) {  // max all targets
     ThresholdCount = src_mols.size() - 1;
+  }
+
+  // AtomCompareParameters.CompleteRingsOnly implies
+  // BondCompareParameters.CompleteRingsOnly
+  if (Parameters.AtomCompareParameters.CompleteRingsOnly) {
+    Parameters.BondCompareParameters.CompleteRingsOnly = true;
   }
 
   // Selecting CompleteRingsOnly option also enables

--- a/Code/GraphMol/FMCS/MaximumCommonSubgraph.cpp
+++ b/Code/GraphMol/FMCS/MaximumCommonSubgraph.cpp
@@ -305,7 +305,7 @@ struct QueryRings {
 struct WeightedBond {
   const Bond* BondPtr{nullptr};
   unsigned Weight{0};
-  WeightedBond()  {}
+  WeightedBond() {}
   WeightedBond(const Bond* bond, const QueryRings& r)
       : BondPtr(bond), Weight(0) {
     // score ((bond.is_in_ring + atom1.is_in_ring + atom2.is_in_ring)
@@ -580,7 +580,9 @@ bool checkNoLoneRingAtoms(const Seed& fs) {
   for (const auto& ithRingAtomIndices : ri->atomRings()) {
     size_t count = 0;
     for (const auto atom : fs.MoleculeFragment.Atoms) {
-      if (std::find(ithRingAtomIndices.begin(), ithRingAtomIndices.end(), atom->getIdx()) != ithRingAtomIndices.end() && ++count > 1) {
+      if (std::find(ithRingAtomIndices.begin(), ithRingAtomIndices.end(),
+                    atom->getIdx()) != ithRingAtomIndices.end() &&
+          ++count > 1) {
         break;
       }
     }

--- a/Code/GraphMol/FMCS/Wrap/rdFMCS.cpp
+++ b/Code/GraphMol/FMCS/Wrap/rdFMCS.cpp
@@ -25,35 +25,37 @@ namespace python = boost::python;
 namespace RDKit {
 
 struct PyMCSAtomCompare : public boost::python::wrapper<PyMCSAtomCompare> {
-  inline bool checkAtomRingMatch(const MCSAtomCompareParameters& p,
-                                 const ROMol& mol1, unsigned int atom1,
-                                 const ROMol& mol2, unsigned int atom2) const {
+  inline bool checkAtomRingMatch(const MCSAtomCompareParameters &p,
+                                 const ROMol &mol1, unsigned int atom1,
+                                 const ROMol &mol2, unsigned int atom2) const {
     return RDKit::checkAtomRingMatch(p, mol1, atom1, mol2, atom2);
   }
-  inline bool checkAtomCharge(const MCSAtomCompareParameters& p,
-                              const ROMol& mol1, unsigned int atom1,
-                              const ROMol& mol2, unsigned int atom2) const {
+  inline bool checkAtomCharge(const MCSAtomCompareParameters &p,
+                              const ROMol &mol1, unsigned int atom1,
+                              const ROMol &mol2, unsigned int atom2) const {
     return RDKit::checkAtomCharge(p, mol1, atom1, mol2, atom2);
   }
-  inline bool checkAtomChirality(const MCSAtomCompareParameters& p,
-                                 const ROMol& mol1, unsigned int atom1,
-                                 const ROMol& mol2, unsigned int atom2) const {
+  inline bool checkAtomChirality(const MCSAtomCompareParameters &p,
+                                 const ROMol &mol1, unsigned int atom1,
+                                 const ROMol &mol2, unsigned int atom2) const {
     return RDKit::checkAtomChirality(p, mol1, atom1, mol2, atom2);
   }
-  virtual bool operator()(const MCSAtomCompareParameters&,
-                          const ROMol&, unsigned int, const ROMol&, unsigned int) {
+  virtual bool operator()(const MCSAtomCompareParameters &, const ROMol &,
+                          unsigned int, const ROMol &, unsigned int) {
     PyErr_SetString(PyExc_AttributeError,
-      "The " COMPARE_FUNC_NAME "() method "
-      "must be overridden in the rdFMCS.MCSAtomCompare subclass");
+                    "The " COMPARE_FUNC_NAME
+                    "() method "
+                    "must be overridden in the rdFMCS.MCSAtomCompare subclass");
     python::throw_error_already_set();
     return false;
   }
   // DEPRECATED: remove the following compare() method in release 2021.01
-  virtual bool compare(const MCSAtomCompareParameters&,
-                       const ROMol&, unsigned int, const ROMol&, unsigned int) {
+  virtual bool compare(const MCSAtomCompareParameters &, const ROMol &,
+                       unsigned int, const ROMol &, unsigned int) {
     PyErr_SetString(PyExc_AttributeError,
-      "The " COMPARE_DEPRECATED_FUNC_NAME "() method (DEPRECATED) "
-      "must be overridden in the rdFMCS.MCSAtomCompare subclass");
+                    "The " COMPARE_DEPRECATED_FUNC_NAME
+                    "() method (DEPRECATED) "
+                    "must be overridden in the rdFMCS.MCSAtomCompare subclass");
     python::throw_error_already_set();
     return false;
   }
@@ -64,9 +66,9 @@ struct PyMCSAtomCompare : public boost::python::wrapper<PyMCSAtomCompare> {
 };
 
 struct PyMCSBondCompare : public boost::python::wrapper<PyMCSBondCompare> {
-  inline bool checkBondStereo(const MCSBondCompareParameters& p,
-                              const ROMol& mol1, unsigned int bond1,
-                              const ROMol& mol2, unsigned int bond2) const {
+  inline bool checkBondStereo(const MCSBondCompareParameters &p,
+                              const ROMol &mol1, unsigned int bond1,
+                              const ROMol &mol2, unsigned int bond2) const {
     return RDKit::checkBondStereo(p, mol1, bond1, mol2, bond2);
   }
   inline static void updateRingMatchTables(FMCS::RingMatchTableSet &rmt,
@@ -84,31 +86,34 @@ struct PyMCSBondCompare : public boost::python::wrapper<PyMCSBondCompare> {
       rmtMols.insert(&mol2);
     }
   }
-  inline bool checkBondRingMatch(const MCSBondCompareParameters& p,
-                                 const ROMol& mol1, unsigned int bond1,
-                                 const ROMol& mol2, unsigned int bond2) {
+  inline bool checkBondRingMatch(const MCSBondCompareParameters &p,
+                                 const ROMol &mol1, unsigned int bond1,
+                                 const ROMol &mol2, unsigned int bond2) {
     updateRingMatchTables(ringMatchTables, ringMatchTablesMols, mol1, mol2,
                           *mcsParameters);
-    return RDKit::checkBondRingMatch(p, mol1, bond1, mol2, bond2, &ringMatchTables);
+    return RDKit::checkBondRingMatch(p, mol1, bond1, mol2, bond2,
+                                     &ringMatchTables);
   }
   bool hasPythonOverride(const char *attrName) {
     auto obj = get_override(attrName);
     return PyCallable_Check(obj.ptr());
   }
-  virtual bool operator()(const MCSBondCompareParameters&,
-                          const ROMol&, unsigned int, const ROMol&, unsigned int) {
+  virtual bool operator()(const MCSBondCompareParameters &, const ROMol &,
+                          unsigned int, const ROMol &, unsigned int) {
     PyErr_SetString(PyExc_AttributeError,
-      "The " COMPARE_FUNC_NAME "() method "
-      "must be overridden in the rdFMCS.MCSBondCompare subclass");
+                    "The " COMPARE_FUNC_NAME
+                    "() method "
+                    "must be overridden in the rdFMCS.MCSBondCompare subclass");
     python::throw_error_already_set();
     return false;
   }
   // DEPRECATED: remove the following compare() method in release 2021.01
-  virtual bool compare(const MCSBondCompareParameters&,
-                       const ROMol&, unsigned int, const ROMol&, unsigned int) {
+  virtual bool compare(const MCSBondCompareParameters &, const ROMol &,
+                       unsigned int, const ROMol &, unsigned int) {
     PyErr_SetString(PyExc_AttributeError,
-      "The " COMPARE_DEPRECATED_FUNC_NAME "() method (DEPRECATED) "
-      "must be overridden in the rdFMCS.MCSBondCompare subclass");
+                    "The " COMPARE_DEPRECATED_FUNC_NAME
+                    "() method (DEPRECATED) "
+                    "must be overridden in the rdFMCS.MCSBondCompare subclass");
     python::throw_error_already_set();
     return false;
   }
@@ -144,130 +149,104 @@ struct PyMCSProgress : public boost::python::wrapper<PyMCSProgress> {
     auto obj = get_override(attrName);
     return PyCallable_Check(obj.ptr());
   }
-  virtual bool operator()(const MCSProgressData&,
-                          const MCSParameters&) {
+  virtual bool operator()(const MCSProgressData &, const MCSParameters &) {
     PyErr_SetString(PyExc_AttributeError,
-      "The " CALLBACK_FUNC_NAME "() method "
-      "must be overridden in the rdFMCS.MCSProgress subclass");
+                    "The " CALLBACK_FUNC_NAME
+                    "() method "
+                    "must be overridden in the rdFMCS.MCSProgress subclass");
     python::throw_error_already_set();
     return false;
   }
   // DEPRECATED: remove the following callback() method in release 2021.01
-  virtual bool callback(const MCSProgressData&,
-                        const MCSParameters&) {
+  virtual bool callback(const MCSProgressData &, const MCSParameters &) {
     PyErr_SetString(PyExc_AttributeError,
-      "The " CALLBACK_DEPRECATED_FUNC_NAME "() method "
-      "must be overridden in the rdFMCS.MCSProgress subclass");
+                    "The " CALLBACK_DEPRECATED_FUNC_NAME
+                    "() method "
+                    "must be overridden in the rdFMCS.MCSProgress subclass");
     python::throw_error_already_set();
     return false;
   }
 };
 
 class PyMCSProgressData {
-public:
-  PyMCSProgressData() :
-    pd(new MCSProgressData()),
-    pcud(new PyProgressCallbackUserData()) {
-      pcud->mcsProgressData = pd.get();
-    }
-  PyMCSProgressData(const MCSProgressData &other) :
-    PyMCSProgressData() {
-      *pd = other;
-    }
-  unsigned int getNumAtoms() const {
-    return pd->NumAtoms;
+ public:
+  PyMCSProgressData()
+      : pd(new MCSProgressData()), pcud(new PyProgressCallbackUserData()) {
+    pcud->mcsProgressData = pd.get();
   }
-  unsigned int getNumBonds() const {
-    return pd->NumBonds;
+  PyMCSProgressData(const MCSProgressData &other) : PyMCSProgressData() {
+    *pd = other;
   }
-  unsigned int getSeedProcessed() const {
-    return pd->SeedProcessed;
-  }
-private:
+  unsigned int getNumAtoms() const { return pd->NumAtoms; }
+  unsigned int getNumBonds() const { return pd->NumBonds; }
+  unsigned int getSeedProcessed() const { return pd->SeedProcessed; }
+
+ private:
   std::unique_ptr<MCSProgressData> pd;
   std::unique_ptr<PyProgressCallbackUserData> pcud;
 };
 
 class PyMCSParameters {
-public:
-  PyMCSParameters() :
-    p(new MCSParameters()),
-    cfud(new PyCompareFunctionUserData()),
-    pcud(new PyProgressCallbackUserData()) {
-      cfud->mcsParameters = p.get();
-      pcud->mcsProgressData = nullptr;
-    }
+ public:
+  PyMCSParameters()
+      : p(new MCSParameters()),
+        cfud(new PyCompareFunctionUserData()),
+        pcud(new PyProgressCallbackUserData()) {
+    cfud->mcsParameters = p.get();
+    pcud->mcsProgressData = nullptr;
+  }
   PyMCSParameters(const MCSParameters &other,
-                  const PyProgressCallbackUserData &pcudOther) :
-    PyMCSParameters() {
-      *p = other;
-      pcud->pyMCSProgress = pcudOther.pyMCSProgress;
-      cfud->pyAtomBondCompData = pcudOther.pyAtomBondCompData;
-    }
-  const MCSParameters *get() const {
-    return p.get();
+                  const PyProgressCallbackUserData &pcudOther)
+      : PyMCSParameters() {
+    *p = other;
+    pcud->pyMCSProgress = pcudOther.pyMCSProgress;
+    cfud->pyAtomBondCompData = pcudOther.pyAtomBondCompData;
   }
-  bool getMaximizeBonds() const {
-    return p->MaximizeBonds;
-  }
-  void setMaximizeBonds(bool value) {
-    p->MaximizeBonds = value;
-  }
-  double getThreshold() const {
-    return p->Threshold;
-  }
-  void setThreshold(double value) {
-    p->Threshold = value;
-  }
-  unsigned int getTimeout() const {
-    return p->Timeout;
-  }
-  void setTimeout(unsigned int value) {
-    p->Timeout = value;
-  }
-  bool getVerbose() const {
-    return p->Verbose;
-  }
-  void setVerbose(bool value) {
-    p->Verbose = value;
-  }
-  const MCSAtomCompareParameters& getAtomCompareParameters() const {
+  const MCSParameters *get() const { return p.get(); }
+  bool getMaximizeBonds() const { return p->MaximizeBonds; }
+  void setMaximizeBonds(bool value) { p->MaximizeBonds = value; }
+  double getThreshold() const { return p->Threshold; }
+  void setThreshold(double value) { p->Threshold = value; }
+  unsigned int getTimeout() const { return p->Timeout; }
+  void setTimeout(unsigned int value) { p->Timeout = value; }
+  bool getVerbose() const { return p->Verbose; }
+  void setVerbose(bool value) { p->Verbose = value; }
+  const MCSAtomCompareParameters &getAtomCompareParameters() const {
     return p->AtomCompareParameters;
   }
   void setAtomCompareParameters(const MCSAtomCompareParameters &value) {
     p->AtomCompareParameters = value;
   }
-  const MCSBondCompareParameters& getBondCompareParameters() const {
+  const MCSBondCompareParameters &getBondCompareParameters() const {
     return p->BondCompareParameters;
   }
   void setBondCompareParameters(const MCSBondCompareParameters &value) {
     p->BondCompareParameters = value;
   }
-  std::string getInitialSeed() const {
-    return p->InitialSeed;
-  }
-  void setInitialSeed(const std::string &value) {
-    p->InitialSeed = value;
-  }
+  std::string getInitialSeed() const { return p->InitialSeed; }
+  void setInitialSeed(const std::string &value) { p->InitialSeed = value; }
   void errorNotDefined(const char *className, const char *funcName) {
-    // should never happen as the method is virtual but not pure in the C++ class
+    // should never happen as the method is virtual but not pure in the C++
+    // class
     std::stringstream ss;
-    ss << "The " << funcName << "() method must be defined "
-      "in the " << className << " subclass";
+    ss << "The " << funcName
+       << "() method must be defined "
+          "in the "
+       << className << " subclass";
     PyErr_SetString(PyExc_AttributeError, ss.str().c_str());
     python::throw_error_already_set();
   }
   void errorNotCallable(const char *className, const char *funcName) {
     std::stringstream ss;
-    ss << "The " << funcName << " attribute in the "
-      << className << " subclass is not a callable method";
+    ss << "The " << funcName << " attribute in the " << className
+       << " subclass is not a callable method";
     PyErr_SetString(PyExc_TypeError, ss.str().c_str());
     python::throw_error_already_set();
   }
   void errorNotOverridden(const char *className, const char *funcName) {
     std::stringstream ss;
     ss << "The " << funcName << " method must be overridden in the "
-      << className << " subclass";
+       << className << " subclass";
     PyErr_SetString(PyExc_TypeError, ss.str().c_str());
     python::throw_error_already_set();
   }
@@ -278,11 +257,12 @@ public:
     if (extractAtomComparator.check()) {
       AtomComparator ac(extractAtomComparator());
       p->setMCSAtomTyperFromEnum(ac);
-    }
-    else {
-      python::extract<PyMCSAtomCompare *> extractPyMCSAtomCompare(atomCompObject);
+    } else {
+      python::extract<PyMCSAtomCompare *> extractPyMCSAtomCompare(
+          atomCompObject);
       if (extractPyMCSAtomCompare.check()) {
-        PyObject *callable = PyObject_GetAttrString(atomCompObject.ptr(), COMPARE_FUNC_NAME);
+        PyObject *callable =
+            PyObject_GetAttrString(atomCompObject.ptr(), COMPARE_FUNC_NAME);
         if (!callable) {
           errorNotDefined(COMPARE_FUNC_NAME, "rdFMCS.MCSAtomCompare");
         }
@@ -291,57 +271,57 @@ public:
         }
         if (!extractPyMCSAtomCompare()->hasPythonOverride(COMPARE_FUNC_NAME)) {
           // DEPRECATED: remove from here in release 2021.01
-          callable = PyObject_GetAttrString(atomCompObject.ptr(), COMPARE_DEPRECATED_FUNC_NAME);
+          callable = PyObject_GetAttrString(atomCompObject.ptr(),
+                                            COMPARE_DEPRECATED_FUNC_NAME);
           if (!callable) {
-            errorNotDefined(COMPARE_DEPRECATED_FUNC_NAME, "rdFMCS.MCSAtomCompare");
+            errorNotDefined(COMPARE_DEPRECATED_FUNC_NAME,
+                            "rdFMCS.MCSAtomCompare");
           }
           if (!PyCallable_Check(callable)) {
-            errorNotCallable(COMPARE_DEPRECATED_FUNC_NAME, "rdFMCS.MCSAtomCompare");
+            errorNotCallable(COMPARE_DEPRECATED_FUNC_NAME,
+                             "rdFMCS.MCSAtomCompare");
           }
-          if (!extractPyMCSAtomCompare()->hasPythonOverride(COMPARE_DEPRECATED_FUNC_NAME)) {
+          if (!extractPyMCSAtomCompare()->hasPythonOverride(
+                  COMPARE_DEPRECATED_FUNC_NAME)) {
             errorNotOverridden(COMPARE_FUNC_NAME, "rdFMCS.MCSAtomCompare");
-          }
-          else {
-            cfud->pyAtomBondCompData.atomCompFuncName = COMPARE_DEPRECATED_FUNC_NAME;
+          } else {
+            cfud->pyAtomBondCompData.atomCompFuncName =
+                COMPARE_DEPRECATED_FUNC_NAME;
           }
           // DEPRECATED: remove until here in release 2021.01
           // uncomment the following line in release 2021.01
           // errorNotOverridden(COMPARE_FUNC_NAME, "rdFMCS.MCSAtomCompare");
-        }
-        else {
+        } else {
           cfud->pyAtomBondCompData.atomCompFuncName = COMPARE_FUNC_NAME;
         }
         p->CompareFunctionsUserData = cfud.get();
         p->AtomTyper = MCSAtomComparePyFunc;
         cfud->pyAtomBondCompData.pyAtomComp = atomCompObject;
         cfud->mcsParameters = p.get();
-      }
-      else {
-        PyErr_SetString(PyExc_TypeError,
-          "expected an instance of a rdFMCS.MCSAtomCompare subclass "
-          "or a member of the AtomCompare class");
+      } else {
+        PyErr_SetString(
+            PyExc_TypeError,
+            "expected an instance of a rdFMCS.MCSAtomCompare subclass "
+            "or a member of the AtomCompare class");
         python::throw_error_already_set();
       }
     }
   }
   python::object getMCSAtomTyper() {
-    static const std::map<RDKit::MCSAtomCompareFunction,
-                          RDKit::AtomComparator> atomTyperToComp = {
-      { MCSAtomCompareAny, AtomCompareAny },
-      { MCSAtomCompareElements, AtomCompareElements },
-      { MCSAtomCompareIsotopes, AtomCompareIsotopes },
-      { MCSAtomCompareAnyHeavyAtom, AtomCompareAnyHeavyAtom }
-    };
+    static const std::map<RDKit::MCSAtomCompareFunction, RDKit::AtomComparator>
+        atomTyperToComp = {
+            {MCSAtomCompareAny, AtomCompareAny},
+            {MCSAtomCompareElements, AtomCompareElements},
+            {MCSAtomCompareIsotopes, AtomCompareIsotopes},
+            {MCSAtomCompareAnyHeavyAtom, AtomCompareAnyHeavyAtom}};
     if (!cfud->pyAtomBondCompData.pyAtomComp.is_none()) {
       return cfud->pyAtomBondCompData.pyAtomComp;
     }
     python::object res;
     try {
       res = python::object(atomTyperToComp.at(p->AtomTyper));
-    }
-    catch(const std::out_of_range&) {
-      PyErr_SetString(PyExc_TypeError,
-        "Unknown AtomTyper");
+    } catch (const std::out_of_range &) {
+      PyErr_SetString(PyExc_TypeError, "Unknown AtomTyper");
       python::throw_error_already_set();
     }
     return res;
@@ -353,11 +333,12 @@ public:
     if (extractBondComparator.check()) {
       BondComparator bc(extractBondComparator());
       p->setMCSBondTyperFromEnum(bc);
-    }
-    else {
-      python::extract<PyMCSBondCompare *> extractPyMCSBondCompare(bondCompObject);
+    } else {
+      python::extract<PyMCSBondCompare *> extractPyMCSBondCompare(
+          bondCompObject);
       if (extractPyMCSBondCompare.check()) {
-        PyObject *callable = PyObject_GetAttrString(bondCompObject.ptr(), COMPARE_FUNC_NAME);
+        PyObject *callable =
+            PyObject_GetAttrString(bondCompObject.ptr(), COMPARE_FUNC_NAME);
         if (!callable) {
           errorNotDefined(COMPARE_FUNC_NAME, "rdFMCS.MCSBondCompare");
         }
@@ -366,24 +347,27 @@ public:
         }
         if (!extractPyMCSBondCompare()->hasPythonOverride(COMPARE_FUNC_NAME)) {
           // DEPRECATED: remove from here in release 2021.01
-          callable = PyObject_GetAttrString(bondCompObject.ptr(), COMPARE_DEPRECATED_FUNC_NAME);
+          callable = PyObject_GetAttrString(bondCompObject.ptr(),
+                                            COMPARE_DEPRECATED_FUNC_NAME);
           if (!callable) {
-            errorNotDefined(COMPARE_DEPRECATED_FUNC_NAME, "rdFMCS.MCSBondCompare");
+            errorNotDefined(COMPARE_DEPRECATED_FUNC_NAME,
+                            "rdFMCS.MCSBondCompare");
           }
           if (!PyCallable_Check(callable)) {
-            errorNotCallable(COMPARE_DEPRECATED_FUNC_NAME, "rdFMCS.MCSBondCompare");
+            errorNotCallable(COMPARE_DEPRECATED_FUNC_NAME,
+                             "rdFMCS.MCSBondCompare");
           }
-          if (!extractPyMCSBondCompare()->hasPythonOverride(COMPARE_DEPRECATED_FUNC_NAME)) {
+          if (!extractPyMCSBondCompare()->hasPythonOverride(
+                  COMPARE_DEPRECATED_FUNC_NAME)) {
             errorNotOverridden(COMPARE_FUNC_NAME, "rdFMCS.MCSBondCompare");
-          }
-          else {
-            cfud->pyAtomBondCompData.bondCompFuncName = COMPARE_DEPRECATED_FUNC_NAME;
+          } else {
+            cfud->pyAtomBondCompData.bondCompFuncName =
+                COMPARE_DEPRECATED_FUNC_NAME;
           }
           // DEPRECATED: remove until here in release 2021.01
           // uncomment the following line in release 2021.01
           // errorNotOverridden(COMPARE_FUNC_NAME, "rdFMCS.MCSBondCompare");
-        }
-        else {
+        } else {
           cfud->pyAtomBondCompData.bondCompFuncName = COMPARE_FUNC_NAME;
         }
         p->CompareFunctionsUserData = cfud.get();
@@ -394,32 +378,28 @@ public:
         cfud->mcsParameters = p.get();
         cfud->ringMatchTablesMols = &bc->ringMatchTablesMols;
         cfud->ringMatchTables = &bc->ringMatchTables;
-      }
-      else {
-        PyErr_SetString(PyExc_TypeError,
-          "expected an instance of a rdFMCS.MCSBondCompare subclass "
-          "or a member of the BondCompare class");
+      } else {
+        PyErr_SetString(
+            PyExc_TypeError,
+            "expected an instance of a rdFMCS.MCSBondCompare subclass "
+            "or a member of the BondCompare class");
         python::throw_error_already_set();
       }
     }
   }
   python::object getMCSBondTyper() {
-    static const std::map<RDKit::MCSBondCompareFunction,
-                          RDKit::BondComparator> bondTyperToComp = {
-      { MCSBondCompareAny, BondCompareAny },
-      { MCSBondCompareOrder, BondCompareOrder },
-      { MCSBondCompareOrderExact, BondCompareOrderExact }
-    };
+    static const std::map<RDKit::MCSBondCompareFunction, RDKit::BondComparator>
+        bondTyperToComp = {{MCSBondCompareAny, BondCompareAny},
+                           {MCSBondCompareOrder, BondCompareOrder},
+                           {MCSBondCompareOrderExact, BondCompareOrderExact}};
     if (!cfud->pyAtomBondCompData.pyBondComp.is_none()) {
       return cfud->pyAtomBondCompData.pyBondComp;
     }
     python::object res;
     try {
       res = python::object(bondTyperToComp.at(p->BondTyper));
-    }
-    catch(const std::out_of_range&) {
-      PyErr_SetString(PyExc_TypeError,
-        "Unknown BondTyper");
+    } catch (const std::out_of_range &) {
+      PyErr_SetString(PyExc_TypeError, "Unknown BondTyper");
       python::throw_error_already_set();
     }
     return res;
@@ -447,7 +427,8 @@ public:
     python::object progressObject(python::handle<>(python::borrowed(progress)));
     python::extract<PyMCSProgress *> extractMCSProgress(progressObject);
     if (extractMCSProgress.check()) {
-      PyObject *callable = PyObject_GetAttrString(progressObject.ptr(), CALLBACK_FUNC_NAME);
+      PyObject *callable =
+          PyObject_GetAttrString(progressObject.ptr(), CALLBACK_FUNC_NAME);
       if (!callable) {
         errorNotDefined(CALLBACK_FUNC_NAME, "rdFMCS.MCSProgress");
       }
@@ -456,34 +437,33 @@ public:
       }
       if (!extractMCSProgress()->hasPythonOverride(CALLBACK_FUNC_NAME)) {
         // DEPRECATED: remove from here in release 2021.01
-        callable = PyObject_GetAttrString(progressObject.ptr(), CALLBACK_DEPRECATED_FUNC_NAME);
+        callable = PyObject_GetAttrString(progressObject.ptr(),
+                                          CALLBACK_DEPRECATED_FUNC_NAME);
         if (!callable) {
           errorNotDefined(CALLBACK_DEPRECATED_FUNC_NAME, "rdFMCS.MCSProgress");
         }
         if (!PyCallable_Check(callable)) {
           errorNotCallable(CALLBACK_DEPRECATED_FUNC_NAME, "rdFMCS.MCSProgress");
         }
-        if (!extractMCSProgress()->hasPythonOverride(CALLBACK_DEPRECATED_FUNC_NAME)) {
+        if (!extractMCSProgress()->hasPythonOverride(
+                CALLBACK_DEPRECATED_FUNC_NAME)) {
           errorNotOverridden(CALLBACK_FUNC_NAME, "rdFMCS.MCSProgress");
-        }
-        else {
+        } else {
           pcud->callbackFuncName = CALLBACK_DEPRECATED_FUNC_NAME;
         }
         // DEPRECATED: remove until here in release 2021.01
         // uncomment the following line in release 2021.01
         // errorNotOverridden(COMPARE_FUNC_NAME, "rdFMCS.MCSAtomCompare");
-      }
-      else {
+      } else {
         pcud->callbackFuncName = CALLBACK_FUNC_NAME;
       }
       p->ProgressCallbackUserData = pcud.get();
       p->ProgressCallback = MCSProgressCallbackPyFunc;
       pcud->pyMCSProgress = progressObject;
       pcud->pyAtomBondCompData = cfud->pyAtomBondCompData;
-    }
-    else {
+    } else {
       PyErr_SetString(PyExc_TypeError,
-        "expected an instance of a rdFMCS.MCSProgress subclass");
+                      "expected an instance of a rdFMCS.MCSProgress subclass");
       python::throw_error_already_set();
     }
   }
@@ -501,29 +481,32 @@ public:
       cfud->ringMatchTables->clear();
     }
   }
-private:
-  static bool MCSAtomComparePyFunc(const MCSAtomCompareParameters& p,
-                                   const ROMol& mol1, unsigned int atom1,
-                                   const ROMol& mol2, unsigned int atom2,
-                                   void* userData) {
+
+ private:
+  static bool MCSAtomComparePyFunc(const MCSAtomCompareParameters &p,
+                                   const ROMol &mol1, unsigned int atom1,
+                                   const ROMol &mol2, unsigned int atom2,
+                                   void *userData) {
     PRECONDITION(userData, "userData must not be NULL");
-    PyCompareFunctionUserData *cfud = static_cast<PyCompareFunctionUserData *>(userData);
+    PyCompareFunctionUserData *cfud =
+        static_cast<PyCompareFunctionUserData *>(userData);
     bool res = false;
     {
       PyGILStateHolder h;
-      res = python::call_method<bool>(cfud->pyAtomBondCompData.pyAtomComp.ptr(),
-                                      cfud->pyAtomBondCompData.atomCompFuncName.c_str(),
-                                      boost::ref(p), boost::ref(mol1),
-                                      atom1, boost::ref(mol2), atom2);
+      res = python::call_method<bool>(
+          cfud->pyAtomBondCompData.pyAtomComp.ptr(),
+          cfud->pyAtomBondCompData.atomCompFuncName.c_str(), boost::ref(p),
+          boost::ref(mol1), atom1, boost::ref(mol2), atom2);
     }
     return res;
   }
-  static bool MCSBondComparePyFunc(const MCSBondCompareParameters& p,
-                                   const ROMol& mol1, unsigned int bond1,
-                                   const ROMol& mol2, unsigned int bond2,
-                                   void* userData) {
+  static bool MCSBondComparePyFunc(const MCSBondCompareParameters &p,
+                                   const ROMol &mol1, unsigned int bond1,
+                                   const ROMol &mol2, unsigned int bond2,
+                                   void *userData) {
     PRECONDITION(userData, "userData must not be NULL");
-    PyCompareFunctionUserData *cfud = static_cast<PyCompareFunctionUserData *>(userData);
+    PyCompareFunctionUserData *cfud =
+        static_cast<PyCompareFunctionUserData *>(userData);
     bool res = false;
     if ((p.RingMatchesRingOnly ||
          cfud->mcsParameters->AtomCompareParameters.RingMatchesRingOnly) &&
@@ -535,17 +518,19 @@ private:
           p, mol1, bond1, mol2, bond2, cfud->ringMatchTables);
     } else {
       PyGILStateHolder h;
-      res = python::call_method<bool>(cfud->pyAtomBondCompData.pyBondComp.ptr(),
-                                      cfud->pyAtomBondCompData.bondCompFuncName.c_str(),
-                                      boost::ref(p), boost::ref(mol1),
-                                      bond1, boost::ref(mol2), bond2);
+      res = python::call_method<bool>(
+          cfud->pyAtomBondCompData.pyBondComp.ptr(),
+          cfud->pyAtomBondCompData.bondCompFuncName.c_str(), boost::ref(p),
+          boost::ref(mol1), bond1, boost::ref(mol2), bond2);
     }
     return res;
   }
-  static bool MCSProgressCallbackPyFunc(const MCSProgressData& stat,
-                                        const MCSParameters& params, void* userData) {
+  static bool MCSProgressCallbackPyFunc(const MCSProgressData &stat,
+                                        const MCSParameters &params,
+                                        void *userData) {
     PRECONDITION(userData, "userData must not be NULL");
-    PyProgressCallbackUserData *pcud = static_cast<PyProgressCallbackUserData *>(userData);
+    PyProgressCallbackUserData *pcud =
+        static_cast<PyProgressCallbackUserData *>(userData);
     bool res = false;
     {
       MCSParameters paramsCopy(params);
@@ -555,7 +540,8 @@ private:
       PyMCSParameters ps(paramsCopy, *pcud);
       PyMCSProgressData pd(stat);
       PyGILStateHolder h;
-      res = python::call_method<bool>(pcud->pyMCSProgress.ptr(), pcud->callbackFuncName.c_str(),
+      res = python::call_method<bool>(pcud->pyMCSProgress.ptr(),
+                                      pcud->callbackFuncName.c_str(),
                                       boost::ref(pd), boost::ref(ps));
     }
     return res;
@@ -596,7 +582,8 @@ MCSResult *FindMCSWrapper(python::object mols, bool maximizeBonds,
   p.BondCompareParameters.RingMatchesRingOnly = ringMatchesRingOnly;
   p.BondCompareParameters.CompleteRingsOnly = completeRingsOnly;
   p.BondCompareParameters.MatchFusedRings = (ringComp != IgnoreRingFusion);
-  p.BondCompareParameters.MatchFusedRingsStrict = (ringComp == StrictRingFusion);
+  p.BondCompareParameters.MatchFusedRingsStrict =
+      (ringComp == StrictRingFusion);
 
   MCSResult *res = nullptr;
   {
@@ -697,42 +684,37 @@ BOOST_PYTHON_MODULE(rdFMCS) {
 
   python::class_<RDKit::PyMCSParameters, boost::noncopyable>(
       "MCSParameters", "Parameters controlling how the MCS is constructed")
-      .add_property("MaximizeBonds",
-                    &RDKit::PyMCSParameters::getMaximizeBonds,
+      .add_property("MaximizeBonds", &RDKit::PyMCSParameters::getMaximizeBonds,
                     &RDKit::PyMCSParameters::setMaximizeBonds,
                     "toggles maximizing the number of bonds (instead of the "
                     "number of atoms)")
-      .add_property("Threshold",
-                    &RDKit::PyMCSParameters::getThreshold,
+      .add_property("Threshold", &RDKit::PyMCSParameters::getThreshold,
                     &RDKit::PyMCSParameters::setThreshold,
                     "fraction of the dataset that must contain the MCS")
-      .add_property("Timeout",
-                    &RDKit::PyMCSParameters::getTimeout,
+      .add_property("Timeout", &RDKit::PyMCSParameters::getTimeout,
                     &RDKit::PyMCSParameters::setTimeout,
                     "timeout (in seconds) for the calculation")
-      .add_property("Verbose",
-                    &RDKit::PyMCSParameters::getVerbose,
-                    &RDKit::PyMCSParameters::setVerbose,
-                    "toggles verbose mode")
-      .add_property("AtomCompareParameters", python::make_function(
-                    &RDKit::PyMCSParameters::getAtomCompareParameters,
-                    python::return_internal_reference<>()),
+      .add_property("Verbose", &RDKit::PyMCSParameters::getVerbose,
+                    &RDKit::PyMCSParameters::setVerbose, "toggles verbose mode")
+      .add_property("AtomCompareParameters",
+                    python::make_function(
+                        &RDKit::PyMCSParameters::getAtomCompareParameters,
+                        python::return_internal_reference<>()),
                     &RDKit::PyMCSParameters::setAtomCompareParameters,
                     "parameters for comparing atoms")
-      .add_property("BondCompareParameters", python::make_function(
-                    &RDKit::PyMCSParameters::getBondCompareParameters,
-                    python::return_internal_reference<>()),
+      .add_property("BondCompareParameters",
+                    python::make_function(
+                        &RDKit::PyMCSParameters::getBondCompareParameters,
+                        python::return_internal_reference<>()),
                     &RDKit::PyMCSParameters::setBondCompareParameters,
                     "parameters for comparing bonds")
-      .add_property("AtomTyper",
-                    &RDKit::PyMCSParameters::getMCSAtomTyper,
+      .add_property("AtomTyper", &RDKit::PyMCSParameters::getMCSAtomTyper,
                     &RDKit::PyMCSParameters::setMCSAtomTyper,
                     "atom typer to be used. Must be one of the "
                     "members of the rdFMCS.AtomCompare class or "
                     "an instance of a user-defined subclass of "
                     "rdFMCS.MCSAtomCompare")
-      .add_property("BondTyper",
-                    &RDKit::PyMCSParameters::getMCSBondTyper,
+      .add_property("BondTyper", &RDKit::PyMCSParameters::getMCSBondTyper,
                     &RDKit::PyMCSParameters::setMCSBondTyper,
                     "bond typer to be used. Must be one of the "
                     "members of the rdFMCS.BondCompare class or "
@@ -743,8 +725,7 @@ BOOST_PYTHON_MODULE(rdFMCS) {
                     &RDKit::PyMCSParameters::setMCSProgressCallback,
                     "progress callback class. Must be a "
                     "user-defined subclass of rdFMCS.Progress")
-      .add_property("InitialSeed",
-                    &RDKit::PyMCSParameters::getInitialSeed,
+      .add_property("InitialSeed", &RDKit::PyMCSParameters::getInitialSeed,
                     &RDKit::PyMCSParameters::setInitialSeed,
                     "SMILES string to be used as the seed of the MCS")
       .def("SetAtomTyper", &RDKit::PyMCSParameters::setMCSAtomTyper,
@@ -791,34 +772,38 @@ BOOST_PYTHON_MODULE(rdFMCS) {
       .def_readwrite("CompleteRingsOnly",
                      &RDKit::MCSBondCompareParameters::CompleteRingsOnly,
                      "results cannot include partial rings")
-      .def_readwrite("MatchFusedRings",
-                     &RDKit::MCSBondCompareParameters::MatchFusedRings,
-                     "enforce check on ring fusion, i.e. alpha-methylnaphthalene "
-                     "won't match beta-methylnaphtalene, but decalin "
-                     "will match cyclodecane unless MatchFusedRingsStrict is True")
-      .def_readwrite("MatchFusedRingsStrict",
-                     &RDKit::MCSBondCompareParameters::MatchFusedRingsStrict,
-                     "only enforced if MatchFusedRings is True; the ring fusion "
-                     "must be the same in both query and target, i.e. decalin "
-                     "won't match cyclodecane")
+      .def_readwrite(
+          "MatchFusedRings", &RDKit::MCSBondCompareParameters::MatchFusedRings,
+          "enforce check on ring fusion, i.e. alpha-methylnaphthalene "
+          "won't match beta-methylnaphtalene, but decalin "
+          "will match cyclodecane unless MatchFusedRingsStrict is True")
+      .def_readwrite(
+          "MatchFusedRingsStrict",
+          &RDKit::MCSBondCompareParameters::MatchFusedRingsStrict,
+          "only enforced if MatchFusedRings is True; the ring fusion "
+          "must be the same in both query and target, i.e. decalin "
+          "won't match cyclodecane")
       .def_readwrite("MatchStereo",
                      &RDKit::MCSBondCompareParameters::MatchStereo,
                      "include bond stereo in the comparison");
 
   python::class_<RDKit::PyMCSProgress, boost::noncopyable>(
-      "MCSProgress", "Base class. Subclass and override "
-      "MCSProgress." CALLBACK_FUNC_NAME "() "
+      "MCSProgress",
+      "Base class. Subclass and override "
+      "MCSProgress." CALLBACK_FUNC_NAME
+      "() "
       "to define a custom callback function")
-      .def(CALLBACK_FUNC_NAME, &RDKit::PyMCSProgress::operator(),
-           (python::arg("self"), python::arg("stat"),
-              python::arg("parameters")),
-              "override to implement a custom progress callback")
+      .def(
+          CALLBACK_FUNC_NAME, &RDKit::PyMCSProgress::operator(),
+          (python::arg("self"), python::arg("stat"), python::arg("parameters")),
+          "override to implement a custom progress callback")
       // DEPRECATED: remove from here in release 2021.01
-      .def(CALLBACK_DEPRECATED_FUNC_NAME, &RDKit::PyMCSProgress::callback,
-           (python::arg("self"), python::arg("stat"),
-              python::arg("parameters")),
-              "DEPRECATED: override " CALLBACK_FUNC_NAME " instead.\n"
-              "override to implement a custom progress callback.\n")
+      .def(
+          CALLBACK_DEPRECATED_FUNC_NAME, &RDKit::PyMCSProgress::callback,
+          (python::arg("self"), python::arg("stat"), python::arg("parameters")),
+          "DEPRECATED: override " CALLBACK_FUNC_NAME
+          " instead.\n"
+          "override to implement a custom progress callback.\n")
       // DEPRECATED: remove until here in release 2021.01
       ;
 
@@ -828,69 +813,65 @@ BOOST_PYTHON_MODULE(rdFMCS) {
                     "number of atoms in MCS")
       .add_property("numBonds", &RDKit::PyMCSProgressData::getNumBonds,
                     "number of bonds in MCS")
-      .add_property("seedProcessed", &RDKit::PyMCSProgressData::getSeedProcessed,
+      .add_property("seedProcessed",
+                    &RDKit::PyMCSProgressData::getSeedProcessed,
                     "number of processed seeds");
 
   python::class_<RDKit::PyMCSAtomCompare, boost::noncopyable>(
-      "MCSAtomCompare", "Base class. Subclass and override "
-      "MCSAtomCompare." COMPARE_FUNC_NAME "() to define custom "
+      "MCSAtomCompare",
+      "Base class. Subclass and override "
+      "MCSAtomCompare." COMPARE_FUNC_NAME
+      "() to define custom "
       "atom compare functions, then set MCSParameters.AtomTyper "
       "to an instance of the subclass")
       .def("CheckAtomRingMatch", &RDKit::PyMCSAtomCompare::checkAtomRingMatch,
-           (python::arg("self"), python::arg("parameters"),
-              python::arg("mol1"), python::arg("atom1"),
-              python::arg("mol2"), python::arg("atom2")),
-              "Return True if both atoms are, or are not, in a ring")
+           (python::arg("self"), python::arg("parameters"), python::arg("mol1"),
+            python::arg("atom1"), python::arg("mol2"), python::arg("atom2")),
+           "Return True if both atoms are, or are not, in a ring")
       .def("CheckAtomCharge", &RDKit::PyMCSAtomCompare::checkAtomCharge,
-           (python::arg("self"), python::arg("parameters"),
-              python::arg("mol1"), python::arg("atom1"),
-              python::arg("mol2"), python::arg("atom2")),
-              "Return True if both atoms have the same formal charge")
+           (python::arg("self"), python::arg("parameters"), python::arg("mol1"),
+            python::arg("atom1"), python::arg("mol2"), python::arg("atom2")),
+           "Return True if both atoms have the same formal charge")
       .def("CheckAtomChirality", &RDKit::PyMCSAtomCompare::checkAtomChirality,
-           (python::arg("self"), python::arg("parameters"),
-              python::arg("mol1"), python::arg("atom1"),
-              python::arg("mol2"), python::arg("atom2")),
-              "Return True if both atoms have, or have not, a chiral tag")
+           (python::arg("self"), python::arg("parameters"), python::arg("mol1"),
+            python::arg("atom1"), python::arg("mol2"), python::arg("atom2")),
+           "Return True if both atoms have, or have not, a chiral tag")
       .def(COMPARE_FUNC_NAME, &RDKit::PyMCSAtomCompare::operator(),
-           (python::arg("self"), python::arg("parameters"),
-              python::arg("mol1"), python::arg("atom1"),
-              python::arg("mol2"), python::arg("atom2")),
-              "override to implement custom atom comparison")
+           (python::arg("self"), python::arg("parameters"), python::arg("mol1"),
+            python::arg("atom1"), python::arg("mol2"), python::arg("atom2")),
+           "override to implement custom atom comparison")
       // DEPRECATED: remove from here in release 2020.03
       .def(COMPARE_DEPRECATED_FUNC_NAME, &RDKit::PyMCSAtomCompare::compare,
-           (python::arg("self"), python::arg("parameters"),
-              python::arg("mol1"), python::arg("atom1"),
-              python::arg("mol2"), python::arg("atom2")),
-              "override to implement custom atom comparison")
+           (python::arg("self"), python::arg("parameters"), python::arg("mol1"),
+            python::arg("atom1"), python::arg("mol2"), python::arg("atom2")),
+           "override to implement custom atom comparison")
       // DEPRECATED: remove until here in release 2020.03
       ;
 
   python::class_<RDKit::PyMCSBondCompare, boost::noncopyable>(
-      "MCSBondCompare", "Base class. Subclass and override "
-      "MCSBondCompare." COMPARE_FUNC_NAME "() to define custom "
+      "MCSBondCompare",
+      "Base class. Subclass and override "
+      "MCSBondCompare." COMPARE_FUNC_NAME
+      "() to define custom "
       "bond compare functions, then set MCSParameters.BondTyper "
       "to an instance of the subclass")
       .def("CheckBondStereo", &RDKit::PyMCSBondCompare::checkBondStereo,
-           (python::arg("self"), python::arg("parameters"),
-              python::arg("mol1"), python::arg("bond1"),
-              python::arg("mol2"), python::arg("bond2")),
-              "Return True if both bonds have, or have not, a stereo descriptor")
+           (python::arg("self"), python::arg("parameters"), python::arg("mol1"),
+            python::arg("bond1"), python::arg("mol2"), python::arg("bond2")),
+           "Return True if both bonds have, or have not, a stereo descriptor")
       .def("CheckBondRingMatch", &RDKit::PyMCSBondCompare::checkBondRingMatch,
-           (python::arg("self"), python::arg("parameters"),
-              python::arg("mol1"), python::arg("bond1"),
-              python::arg("mol2"), python::arg("bond2")),
-              "Return True if both bonds are, or are not, part of a ring")
+           (python::arg("self"), python::arg("parameters"), python::arg("mol1"),
+            python::arg("bond1"), python::arg("mol2"), python::arg("bond2")),
+           "Return True if both bonds are, or are not, part of a ring")
       .def(COMPARE_FUNC_NAME, &RDKit::PyMCSBondCompare::operator(),
-           (python::arg("self"), python::arg("parameters"),
-              python::arg("mol1"), python::arg("bond1"),
-              python::arg("mol2"), python::arg("bond2")),
-              "override to implement custom bond comparison")
+           (python::arg("self"), python::arg("parameters"), python::arg("mol1"),
+            python::arg("bond1"), python::arg("mol2"), python::arg("bond2")),
+           "override to implement custom bond comparison")
       // DEPRECATED: remove from here in release 2020.03
       .def(COMPARE_DEPRECATED_FUNC_NAME, &RDKit::PyMCSBondCompare::compare,
-           (python::arg("self"), python::arg("parameters"),
-              python::arg("mol1"), python::arg("bond1"),
-              python::arg("mol2"), python::arg("bond2")),
-              "override to implement custom bond comparison")
+           (python::arg("self"), python::arg("parameters"), python::arg("mol1"),
+            python::arg("bond1"), python::arg("mol2"), python::arg("bond2")),
+           "override to implement custom bond comparison")
       // DEPRECATED: remove until here in release 2020.03
       ;
 

--- a/Code/GraphMol/FMCS/Wrap/rdFMCS.cpp
+++ b/Code/GraphMol/FMCS/Wrap/rdFMCS.cpp
@@ -775,6 +775,9 @@ BOOST_PYTHON_MODULE(rdFMCS) {
       .def_readwrite("RingMatchesRingOnly",
                      &RDKit::MCSAtomCompareParameters::RingMatchesRingOnly,
                      "ring atoms are only allowed to match other ring atoms")
+      .def_readwrite("CompleteRingsOnly",
+                     &RDKit::MCSAtomCompareParameters::CompleteRingsOnly,
+                     "results cannot include lone ring atoms")
       .def_readwrite("MatchIsotope",
                      &RDKit::MCSAtomCompareParameters::MatchIsotope,
                      "use isotope atom queries in MCSResults");

--- a/Code/GraphMol/FMCS/Wrap/testFMCS.py
+++ b/Code/GraphMol/FMCS/Wrap/testFMCS.py
@@ -1007,5 +1007,38 @@ class TestCase(unittest.TestCase):
         delattr(ProgressCallback, "callbacx")
     # DEPRECATED: remove until here in release 2021.01
 
+    def test18GitHub3693(self):
+        mols = [Chem.MolFromSmiles(smi) for smi in [
+                "Nc1ccc(O)cc1c1ccc2ccccc2c1", "Oc1cnc(NC2CCC2)c(c1)c1ccc2ccccc2c1"]]
+        params = rdFMCS.MCSParameters()
+        res = rdFMCS.FindMCS(mols, params)
+        self.assertEqual(res.numAtoms, 17)
+        self.assertEqual(res.numBonds, 18)
+        self.assertEqual(res.smartsString, "[#7]-,:[#6]:[#6](:[#6]:[#6](:[#6])-[#8])-[#6]1:[#6]:[#6]:[#6]2:[#6](:[#6]:1):[#6]:[#6]:[#6]:[#6]:2")
+
+        params = rdFMCS.MCSParameters()
+        params.BondCompareParameters.CompleteRingsOnly = True
+        res = rdFMCS.FindMCS(mols, params)
+        self.assertEqual(res.numAtoms, 11)
+        self.assertEqual(res.numBonds, 12)
+        self.assertEqual(res.smartsString, "[#6]-&!@[#6]1:&@[#6]:&@[#6]:&@[#6]2:&@[#6](:&@[#6]:&@1):&@[#6]:&@[#6]:&@[#6]:&@[#6]:&@2")
+
+        params = rdFMCS.MCSParameters()
+        params.AtomCompareParameters.CompleteRingsOnly = True
+        params.BondCompareParameters.CompleteRingsOnly = True
+        res = rdFMCS.FindMCS(mols, params)
+        self.assertEqual(res.numAtoms, 10)
+        self.assertEqual(res.numBonds, 11)
+        self.assertEqual(res.smartsString, "[#6]1:&@[#6]:&@[#6]:&@[#6]2:&@[#6](:&@[#6]:&@1):&@[#6]:&@[#6]:&@[#6]:&@[#6]:&@2")
+
+        params = rdFMCS.MCSParameters()
+        params.AtomCompareParameters.CompleteRingsOnly = True
+        # this will automatically be set to True
+        params.BondCompareParameters.CompleteRingsOnly = False
+        res = rdFMCS.FindMCS(mols, params)
+        self.assertEqual(res.numAtoms, 10)
+        self.assertEqual(res.numBonds, 11)
+        self.assertEqual(res.smartsString, "[#6]1:&@[#6]:&@[#6]:&@[#6]2:&@[#6](:&@[#6]:&@1):&@[#6]:&@[#6]:&@[#6]:&@[#6]:&@2")
+
 if __name__ == "__main__":
     unittest.main()

--- a/Code/GraphMol/FMCS/testFMCS_Unit.cpp
+++ b/Code/GraphMol/FMCS/testFMCS_Unit.cpp
@@ -922,27 +922,63 @@ void testJSONParameters() {
               pj.BondCompareParameters.MatchFusedRings == false &&
               pj.BondCompareParameters.MatchFusedRingsStrict == false);
 
-  pj = MCSParameters();
-  const char json[] =
-      "{\"MaximizeBonds\": false, \"Threshold\": 0.7, \"Timeout\": 3"
-      ", \"MatchValences\": true, \"MatchChiralTag\": true"
-      ", \"MatchStereo\": true, \"RingMatchesRingOnly\": true"
-      ", \"CompleteRingsOnly\": true"
-      ", \"MatchFusedRings\": true"
-      ", \"MatchFusedRingsStrict\": true"
-      ", \"InitialSeed\": \"CNC\""
-      "}";
-  parseMCSParametersJSON(json, &pj);
-  TEST_ASSERT(pj.MaximizeBonds == false && pj.Threshold == 0.7 &&
-              pj.Timeout == 3 &&
-              pj.AtomCompareParameters.MatchValences == true &&
-              pj.AtomCompareParameters.MatchChiralTag == true &&
-              pj.BondCompareParameters.MatchStereo == true &&
-              pj.BondCompareParameters.RingMatchesRingOnly == true &&
-              pj.BondCompareParameters.CompleteRingsOnly == true &&
-              pj.BondCompareParameters.MatchFusedRings == true &&
-              pj.BondCompareParameters.MatchFusedRingsStrict == true &&
-              0 == strcmp(pj.InitialSeed.c_str(), "CNC"));
+  {
+    pj = MCSParameters();
+    const char json[] =
+        "{\"MaximizeBonds\": false, \"Threshold\": 0.7, \"Timeout\": 3"
+        ", \"MatchValences\": true, \"MatchChiralTag\": true"
+        ", \"MatchStereo\": true, \"RingMatchesRingOnly\": true"
+        ", \"CompleteRingsOnly\": true"
+        ", \"MatchFusedRings\": true"
+        ", \"MatchFusedRingsStrict\": true"
+        ", \"InitialSeed\": \"CNC\""
+        "}";
+    parseMCSParametersJSON(json, &pj);
+    TEST_ASSERT(pj.MaximizeBonds == false && pj.Threshold == 0.7 &&
+                pj.Timeout == 3 &&
+                pj.AtomCompareParameters.MatchValences == true &&
+                pj.AtomCompareParameters.MatchChiralTag == true &&
+                pj.AtomCompareParameters.RingMatchesRingOnly == true &&
+                pj.AtomCompareParameters.CompleteRingsOnly == false &&
+                pj.BondCompareParameters.MatchStereo == true &&
+                pj.BondCompareParameters.RingMatchesRingOnly == true &&
+                pj.BondCompareParameters.CompleteRingsOnly == true &&
+                pj.BondCompareParameters.MatchFusedRings == true &&
+                pj.BondCompareParameters.MatchFusedRingsStrict == true &&
+                0 == strcmp(pj.InitialSeed.c_str(), "CNC"));
+  }
+  {
+    // Atom* and Bond* versions override simple
+    // RingMatchesRingOnly and CompleteRingsOnly
+    pj = MCSParameters();
+    const char json[] =
+        "{\"MaximizeBonds\": false, \"Threshold\": 0.7, \"Timeout\": 3"
+        ", \"MatchValences\": true, \"MatchChiralTag\": true"
+        ", \"MatchStereo\": true, \"RingMatchesRingOnly\": false"
+        ", \"AtomRingMatchesRingOnly\": true"
+        ", \"BondRingMatchesRingOnly\": true"
+        ", \"CompleteRingsOnly\": false"
+        ", \"AtomCompleteRingsOnly\": true"
+        ", \"BondCompleteRingsOnly\": true"
+        ", \"MatchFusedRings\": true"
+        ", \"MatchFusedRingsStrict\": true"
+        ", \"InitialSeed\": \"CNC\""
+        "}";
+    parseMCSParametersJSON(json, &pj);
+    TEST_ASSERT(pj.MaximizeBonds == false && pj.Threshold == 0.7 &&
+                pj.Timeout == 3 &&
+                pj.AtomCompareParameters.MatchValences == true &&
+                pj.AtomCompareParameters.MatchChiralTag == true &&
+                pj.AtomCompareParameters.RingMatchesRingOnly == true &&
+                pj.AtomCompareParameters.CompleteRingsOnly == true &&
+                pj.BondCompareParameters.MatchStereo == true &&
+                pj.BondCompareParameters.RingMatchesRingOnly == true &&
+                pj.BondCompareParameters.CompleteRingsOnly == true &&
+                pj.BondCompareParameters.MatchFusedRings == true &&
+                pj.BondCompareParameters.MatchFusedRingsStrict == true &&
+                0 == strcmp(pj.InitialSeed.c_str(), "CNC"));
+  }
+
   BOOST_LOG(rdInfoLog) << "\tdone" << std::endl;
 }
 

--- a/Code/GraphMol/FMCS/testFMCS_Unit.cpp
+++ b/Code/GraphMol/FMCS/testFMCS_Unit.cpp
@@ -2200,6 +2200,65 @@ void testGitHub3458() {
   BOOST_LOG(rdInfoLog) << "\tdone" << std::endl;
 }
 
+void testGitHub3693() {
+  BOOST_LOG(rdInfoLog) << "-------------------------------------" << std::endl;
+  BOOST_LOG(rdInfoLog) << "testGitHub3693" << std::endl;
+
+  {
+    std::vector<ROMOL_SPTR> mols = {
+      "Nc1ccc(O)cc1c1ccc2ccccc2c1"_smiles,
+      "Oc1cnc(NC2CCC2)c(c1)c1ccc2ccccc2c1"_smiles
+    };
+
+    {
+      MCSParameters p;
+      MCSResult res = findMCS(mols, &p);
+      TEST_ASSERT(res.NumAtoms == 17);
+      TEST_ASSERT(res.NumBonds == 18);
+      TEST_ASSERT(res.SmartsString == "[#7]-,:[#6]:[#6](:[#6]:[#6](:[#6])-[#8])-[#6]1:[#6]:[#6]:[#6]2:[#6](:[#6]:1):[#6]:[#6]:[#6]:[#6]:2");
+    }
+    {
+      MCSParameters p;
+      p.BondCompareParameters.CompleteRingsOnly = true;
+      MCSResult res = findMCS(mols, &p);
+      TEST_ASSERT(res.NumAtoms == 11);
+      TEST_ASSERT(res.NumBonds == 12);
+      TEST_ASSERT(res.SmartsString == "[#6]-&!@[#6]1:&@[#6]:&@[#6]:&@[#6]2:&@[#6](:&@[#6]:&@1):&@[#6]:&@[#6]:&@[#6]:&@[#6]:&@2");
+    }
+    {
+      MCSParameters p;
+      p.AtomCompareParameters.CompleteRingsOnly = true;
+      MCSResult res = findMCS(mols, &p);
+      TEST_ASSERT(res.NumAtoms == 10);
+      TEST_ASSERT(res.NumBonds == 11);
+      TEST_ASSERT(res.SmartsString == "[#6]1:&@[#6]:&@[#6]:&@[#6]2:&@[#6](:&@[#6]:&@1):&@[#6]:&@[#6]:&@[#6]:&@[#6]:&@2");
+    }
+    {
+      MCSParameters p;
+      p.AtomCompareParameters.CompleteRingsOnly = true;
+      p.BondCompareParameters.CompleteRingsOnly = true;
+      MCSResult res = findMCS(mols, &p);
+      TEST_ASSERT(res.NumAtoms == 10);
+      TEST_ASSERT(res.NumBonds == 11);
+      TEST_ASSERT(res.SmartsString == "[#6]1:&@[#6]:&@[#6]:&@[#6]2:&@[#6](:&@[#6]:&@1):&@[#6]:&@[#6]:&@[#6]:&@[#6]:&@2");
+    }
+    {
+      MCSParameters p;
+      p.AtomCompareParameters.CompleteRingsOnly = true;
+      // this will automatically be set to true
+      p.BondCompareParameters.CompleteRingsOnly = false;
+      MCSResult res = findMCS(mols, &p);
+      TEST_ASSERT(res.NumAtoms == 10);
+      TEST_ASSERT(res.NumBonds == 11);
+      TEST_ASSERT(res.SmartsString == "[#6]1:&@[#6]:&@[#6]:&@[#6]2:&@[#6](:&@[#6]:&@1):&@[#6]:&@[#6]:&@[#6]:&@[#6]:&@2");
+    }
+  }
+
+  BOOST_LOG(rdInfoLog) << "============================================"
+                       << std::endl;
+  BOOST_LOG(rdInfoLog) << "\tdone" << std::endl;
+}
+
 //====================================================================================================
 //====================================================================================================
 
@@ -2277,6 +2336,7 @@ int main(int argc, const char* argv[]) {
   testCompareNonExistent();
   testGitHub3095();
   testGitHub3458();
+  testGitHub3693();
 
   unsigned long long t1 = nanoClock();
   double sec = double(t1 - T0) / 1000000.;

--- a/Code/GraphMol/FMCS/testFMCS_Unit.cpp
+++ b/Code/GraphMol/FMCS/testFMCS_Unit.cpp
@@ -2155,17 +2155,16 @@ void testGitHub3458() {
   {
     std::vector<ROMOL_SPTR> mols;
     const char* smi[] = {
-      "Brc1cccc(Nc2ncnc3cc4ccccc4cc23)c1",
-      "CCOc1cc2ncnc(Nc3cccc(Br)c3)c2cc1OCC",
-      "CN(C)c1cc2c(Nc3cccc(Br)c3)ncnc2cn1",
-      "CNc1cc2c(Nc3cccc(Br)c3)ncnc2cn1",
-      "Brc1cccc(Nc2ncnc3cc4[nH]cnc4cc23)c1",
-      "Cn1cnc2cc3ncnc(Nc4cccc(Br)c4)c3cc21",
-      "Cn1cnc2cc3c(Nc4cccc(Br)c4)ncnc3cc21",
-      "COc1cc2ncnc(Nc3cccc(Br)c3)c2cc1OC",
-      "C#CCNC/C=C/C(=O)Nc1cc2c(Nc3ccc(F)c(Cl)c3)c(C#N)cnc2cc1OCC",
-      "C=CC(=O)Nc1ccc2ncnc(Nc3cc(Cl)c(Cl)cc3F)c2c1"
-    };
+        "Brc1cccc(Nc2ncnc3cc4ccccc4cc23)c1",
+        "CCOc1cc2ncnc(Nc3cccc(Br)c3)c2cc1OCC",
+        "CN(C)c1cc2c(Nc3cccc(Br)c3)ncnc2cn1",
+        "CNc1cc2c(Nc3cccc(Br)c3)ncnc2cn1",
+        "Brc1cccc(Nc2ncnc3cc4[nH]cnc4cc23)c1",
+        "Cn1cnc2cc3ncnc(Nc4cccc(Br)c4)c3cc21",
+        "Cn1cnc2cc3c(Nc4cccc(Br)c4)ncnc3cc21",
+        "COc1cc2ncnc(Nc3cccc(Br)c3)c2cc1OC",
+        "C#CCNC/C=C/C(=O)Nc1cc2c(Nc3ccc(F)c(Cl)c3)c(C#N)cnc2cc1OCC",
+        "C=CC(=O)Nc1ccc2ncnc(Nc3cc(Cl)c(Cl)cc3F)c2c1"};
 
     for (auto& i : smi) {
       auto m = SmilesToMol(getSmilesOnly(i));
@@ -2181,7 +2180,10 @@ void testGitHub3458() {
       MCSResult res = findMCS(mols, &p);
       TEST_ASSERT(res.NumAtoms == 17);
       TEST_ASSERT(res.NumBonds == 18);
-      TEST_ASSERT(res.SmartsString == "[#6&R]:&@[#6&R]:&@[#6&R]1:&@[#6&R](-&!@[#7&!R]-&!@[#6&R]2:&@[#6&R]:&@[#6&R]:&@[#6&R]:&@[#6&R](:&@[#6&R]:&@2)-&!@[#35&!R]):&@[#7&R]:&@[#6&R]:&@[#7&R]:&@[#6&R]:&@1:&@[#6&R]");
+      TEST_ASSERT(res.SmartsString ==
+                  "[#6&R]:&@[#6&R]:&@[#6&R]1:&@[#6&R](-&!@[#7&!R]-&!@[#6&R]2:&@"
+                  "[#6&R]:&@[#6&R]:&@[#6&R]:&@[#6&R](:&@[#6&R]:&@2)-&!@[#35&!R]"
+                  "):&@[#7&R]:&@[#6&R]:&@[#7&R]:&@[#6&R]:&@1:&@[#6&R]");
     }
     {
       MCSParameters p;
@@ -2191,7 +2193,10 @@ void testGitHub3458() {
       MCSResult res = findMCS(mols, &p);
       TEST_ASSERT(res.NumAtoms == 15);
       TEST_ASSERT(res.NumBonds == 15);
-      TEST_ASSERT(res.SmartsString == "[#6&R]:&@[#6&R]:&@[#6&R](:&@[#6&R]-&!@[#7&!R]-&!@[#6&R]1:&@[#6&R]:&@[#6&R]:&@[#6&R]:&@[#6&R]:&@[#6&R]:&@1):&@[#6&R](:&@[#7&R]:&@[#6&R]):&@[#6&R]");
+      TEST_ASSERT(res.SmartsString ==
+                  "[#6&R]:&@[#6&R]:&@[#6&R](:&@[#6&R]-&!@[#7&!R]-&!@[#6&R]1:&@["
+                  "#6&R]:&@[#6&R]:&@[#6&R]:&@[#6&R]:&@[#6&R]:&@1):&@[#6&R](:&@["
+                  "#7&R]:&@[#6&R]):&@[#6&R]");
     }
   }
 
@@ -2206,16 +2211,17 @@ void testGitHub3693() {
 
   {
     std::vector<ROMOL_SPTR> mols = {
-      "Nc1ccc(O)cc1c1ccc2ccccc2c1"_smiles,
-      "Oc1cnc(NC2CCC2)c(c1)c1ccc2ccccc2c1"_smiles
-    };
+        "Nc1ccc(O)cc1c1ccc2ccccc2c1"_smiles,
+        "Oc1cnc(NC2CCC2)c(c1)c1ccc2ccccc2c1"_smiles};
 
     {
       MCSParameters p;
       MCSResult res = findMCS(mols, &p);
       TEST_ASSERT(res.NumAtoms == 17);
       TEST_ASSERT(res.NumBonds == 18);
-      TEST_ASSERT(res.SmartsString == "[#7]-,:[#6]:[#6](:[#6]:[#6](:[#6])-[#8])-[#6]1:[#6]:[#6]:[#6]2:[#6](:[#6]:1):[#6]:[#6]:[#6]:[#6]:2");
+      TEST_ASSERT(res.SmartsString ==
+                  "[#7]-,:[#6]:[#6](:[#6]:[#6](:[#6])-[#8])-[#6]1:[#6]:[#6]:[#"
+                  "6]2:[#6](:[#6]:1):[#6]:[#6]:[#6]:[#6]:2");
     }
     {
       MCSParameters p;
@@ -2223,7 +2229,9 @@ void testGitHub3693() {
       MCSResult res = findMCS(mols, &p);
       TEST_ASSERT(res.NumAtoms == 11);
       TEST_ASSERT(res.NumBonds == 12);
-      TEST_ASSERT(res.SmartsString == "[#6]-&!@[#6]1:&@[#6]:&@[#6]:&@[#6]2:&@[#6](:&@[#6]:&@1):&@[#6]:&@[#6]:&@[#6]:&@[#6]:&@2");
+      TEST_ASSERT(res.SmartsString ==
+                  "[#6]-&!@[#6]1:&@[#6]:&@[#6]:&@[#6]2:&@[#6](:&@[#6]:&@1):&@[#"
+                  "6]:&@[#6]:&@[#6]:&@[#6]:&@2");
     }
     {
       MCSParameters p;
@@ -2231,7 +2239,9 @@ void testGitHub3693() {
       MCSResult res = findMCS(mols, &p);
       TEST_ASSERT(res.NumAtoms == 10);
       TEST_ASSERT(res.NumBonds == 11);
-      TEST_ASSERT(res.SmartsString == "[#6]1:&@[#6]:&@[#6]:&@[#6]2:&@[#6](:&@[#6]:&@1):&@[#6]:&@[#6]:&@[#6]:&@[#6]:&@2");
+      TEST_ASSERT(res.SmartsString ==
+                  "[#6]1:&@[#6]:&@[#6]:&@[#6]2:&@[#6](:&@[#6]:&@1):&@[#6]:&@[#"
+                  "6]:&@[#6]:&@[#6]:&@2");
     }
     {
       MCSParameters p;
@@ -2240,7 +2250,9 @@ void testGitHub3693() {
       MCSResult res = findMCS(mols, &p);
       TEST_ASSERT(res.NumAtoms == 10);
       TEST_ASSERT(res.NumBonds == 11);
-      TEST_ASSERT(res.SmartsString == "[#6]1:&@[#6]:&@[#6]:&@[#6]2:&@[#6](:&@[#6]:&@1):&@[#6]:&@[#6]:&@[#6]:&@[#6]:&@2");
+      TEST_ASSERT(res.SmartsString ==
+                  "[#6]1:&@[#6]:&@[#6]:&@[#6]2:&@[#6](:&@[#6]:&@1):&@[#6]:&@[#"
+                  "6]:&@[#6]:&@[#6]:&@2");
     }
     {
       MCSParameters p;
@@ -2250,7 +2262,9 @@ void testGitHub3693() {
       MCSResult res = findMCS(mols, &p);
       TEST_ASSERT(res.NumAtoms == 10);
       TEST_ASSERT(res.NumBonds == 11);
-      TEST_ASSERT(res.SmartsString == "[#6]1:&@[#6]:&@[#6]:&@[#6]2:&@[#6](:&@[#6]:&@1):&@[#6]:&@[#6]:&@[#6]:&@[#6]:&@2");
+      TEST_ASSERT(res.SmartsString ==
+                  "[#6]1:&@[#6]:&@[#6]:&@[#6]2:&@[#6](:&@[#6]:&@1):&@[#6]:&@[#"
+                  "6]:&@[#6]:&@[#6]:&@2");
     }
   }
 


### PR DESCRIPTION
@driesvr has reported that lone atoms belonging to incomplete rings can still be included in MCS results also when `CompleteRingsOnly` is set to `true` (#3693).
This is a consequence of `CompleteRingsOnly` being a `BondCompareParameters` flag only.
This PR adds `CompleteRingsOnly` also to `AtomCompareParameters` (similarly to what already happens for `RingMatchesRingOnly`), thus covering the use case reported in #3693.

Note that at the moment the `AtomCompareParameters.CompleteRingsOnly` can only be set using the `findMcs(mols, params)` overload.
Calling the `findMcs` overload with `completeRingsOnly` set to `true` still only sets `BondCompareParameters.CompleteRingsOnly` to `true`. This mirrors what happened in the past for the `ringMatchesRingOnly` parameter, that originally only set `BondCompareParameters.RingMatchesRingOnly`, and was only subsequently made to affect `AtomCompareParameters` as well.
We can decide at a later stage whether we wish to introduce a change in behavior also for `completeRingsOnly` and make it affect `AtomCompareParameters` as well (or we can introduce the change in behavior right now if people prefer so).