### PR TITLE
Support context managers for mol Suppliers and Writers

### DIFF
--- a/Code/GraphMol/FileParsers/MaeMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/MaeMolSupplier.cpp
@@ -443,6 +443,7 @@ void MaeMolSupplier::init() {}
 void MaeMolSupplier::reset() {}
 
 ROMol *MaeMolSupplier::next() {
+  PRECONDITION(dp_sInStream != nullptr, "no stream");
   if (!d_stored_exc.empty()) {
     throw FileParseException(d_stored_exc);
   } else if (atEnd()) {

--- a/Code/GraphMol/FileParsers/MolSupplier.h
+++ b/Code/GraphMol/FileParsers/MolSupplier.h
@@ -66,7 +66,7 @@ class RDKIT_FILEPARSERS_EXPORT MolSupplier {
   virtual ROMol *next() = 0;
 
   virtual void close() {
-    if (df_owner && dp_inStream) {
+    if (df_owner) {
       delete dp_inStream;
       df_owner = false;
     }

--- a/Code/GraphMol/FileParsers/MolSupplier.h
+++ b/Code/GraphMol/FileParsers/MolSupplier.h
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2002-2019 greg landrum, Rational Discovery LLC
+//  Copyright (C) 2002-2021 greg landrum, Rational Discovery LLC
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -65,6 +65,14 @@ class RDKIT_FILEPARSERS_EXPORT MolSupplier {
   virtual bool atEnd() = 0;
   virtual ROMol *next() = 0;
 
+  virtual void close() {
+    if (df_owner && dp_inStream) {
+      delete dp_inStream;
+      df_owner = false;
+    }
+    dp_inStream = nullptr;
+  }
+
  private:
   // disable automatic copy constructors and assignment operators
   // for this class and its subclasses.  They will likely be
@@ -122,13 +130,7 @@ class RDKIT_FILEPARSERS_EXPORT ForwardSDMolSupplier : public MolSupplier {
                                 bool removeHs = true,
                                 bool strictParsing = false);
 
-  virtual ~ForwardSDMolSupplier() {
-    if (df_owner && dp_inStream) {
-      delete dp_inStream;
-      df_owner = false;
-      dp_inStream = nullptr;
-    }
-  };
+  virtual ~ForwardSDMolSupplier() { close(); };
 
   virtual void init();
   virtual void reset();
@@ -184,7 +186,7 @@ class RDKIT_FILEPARSERS_EXPORT SDMolSupplier : public ForwardSDMolSupplier {
                          bool sanitize = true, bool removeHs = true,
                          bool strictParsing = true);
 
-  ~SDMolSupplier(){};
+  virtual ~SDMolSupplier() { close(); };
   void init();
   void reset();
   ROMol *next();
@@ -268,7 +270,7 @@ class RDKIT_FILEPARSERS_EXPORT SmilesMolSupplier : public MolSupplier {
                              int smilesColumn = 0, int nameColumn = 1,
                              bool titleLine = true, bool sanitize = true);
 
-  ~SmilesMolSupplier();
+  virtual ~SmilesMolSupplier() { close(); };
   void setData(const std::string &text, const std::string &delimiter = " ",
                int smilesColumn = 0, int nameColumn = 1, bool titleLine = true,
                bool sanitize = true);
@@ -340,7 +342,7 @@ class RDKIT_FILEPARSERS_EXPORT TDTMolSupplier : public MolSupplier {
                           const std::string &nameRecord = "", int confId2D = -1,
                           int confId3D = 0, bool sanitize = true);
   TDTMolSupplier();
-  ~TDTMolSupplier();
+  virtual ~TDTMolSupplier() { close(); };
   void setData(const std::string &text, const std::string &nameRecord = "",
                int confId2D = -1, int confId3D = 0, bool sanitize = true);
   void init();
@@ -385,9 +387,7 @@ class RDKIT_FILEPARSERS_EXPORT PDBMolSupplier : public MolSupplier {
                           bool removeHs = true, unsigned int flavor = 0,
                           bool proximityBonding = true);
 
-  virtual ~PDBMolSupplier() {
-    if (df_owner && dp_inStream) delete dp_inStream;
-  };
+  virtual ~PDBMolSupplier() { close(); };
 
   virtual void init();
   virtual void reset();
@@ -419,14 +419,14 @@ class RDKIT_FILEPARSERS_EXPORT MaeMolSupplier : public MolSupplier {
   explicit MaeMolSupplier(const std::string &fname, bool sanitize = true,
                           bool removeHs = true);
 
-  virtual ~MaeMolSupplier(){
-      // The dp_sInStream shared_ptr will take care of cleaning up.
-  };
+  virtual ~MaeMolSupplier(){};
 
   virtual void init();
   virtual void reset();
   virtual ROMol *next();
   virtual bool atEnd();
+
+  virtual void close() { dp_sInStream.reset(); }
 
  protected:
   bool df_sanitize, df_removeHs;

--- a/Code/GraphMol/FileParsers/MolWriters.h
+++ b/Code/GraphMol/FileParsers/MolWriters.h
@@ -89,7 +89,9 @@ class RDKIT_FILEPARSERS_EXPORT SmilesWriter : public MolWriter {
 
   //! \brief close our stream (the writer cannot be used again)
   void close() {
-    flush();
+    if (dp_ostream) {
+      flush();
+    }
     if (df_owner) {
       delete dp_ostream;
       df_owner = false;
@@ -165,7 +167,9 @@ class RDKIT_FILEPARSERS_EXPORT SDWriter : public MolWriter {
 
   //! \brief close our stream (the writer cannot be used again)
   void close() {
-    flush();
+    if (dp_ostream) {
+      flush();
+    }
     if (df_owner) {
       delete dp_ostream;
       df_owner = false;
@@ -234,11 +238,13 @@ class RDKIT_FILEPARSERS_EXPORT TDTWriter : public MolWriter {
 
   //! \brief close our stream (the writer cannot be used again)
   void close() {
-    // if we've written any mols, finish with a "|" line
-    if (dp_ostream && d_molid > 0) {
-      *dp_ostream << "|\n";
+    if (dp_ostream) {
+      // if we've written any mols, finish with a "|" line
+      if (dp_ostream && d_molid > 0) {
+        *dp_ostream << "|\n";
+      }
+      flush();
     }
-    flush();
     if (df_owner) {
       delete dp_ostream;
       df_owner = false;
@@ -300,7 +306,9 @@ class RDKIT_FILEPARSERS_EXPORT PDBWriter : public MolWriter {
 
   //! \brief close our stream (the writer cannot be used again)
   void close() {
-    flush();
+    if (dp_ostream) {
+      flush();
+    }
     if (df_owner) {
       delete dp_ostream;
       df_owner = false;

--- a/Code/GraphMol/FileParsers/MolWriters.h
+++ b/Code/GraphMol/FileParsers/MolWriters.h
@@ -240,7 +240,7 @@ class RDKIT_FILEPARSERS_EXPORT TDTWriter : public MolWriter {
   void close() {
     if (dp_ostream) {
       // if we've written any mols, finish with a "|" line
-      if (dp_ostream && d_molid > 0) {
+      if (d_molid > 0) {
         *dp_ostream << "|\n";
       }
       flush();

--- a/Code/GraphMol/FileParsers/SmilesMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/SmilesMolSupplier.cpp
@@ -68,12 +68,6 @@ SmilesMolSupplier::SmilesMolSupplier(std::istream *inStream, bool takeOwnership,
   POSTCONDITION(dp_inStream, "bad instream");
 }
 
-SmilesMolSupplier::~SmilesMolSupplier() {
-  if (df_owner && dp_inStream) {
-    delete dp_inStream;
-  }
-}
-
 void SmilesMolSupplier::init() {
   dp_inStream = nullptr;
   df_owner = true;

--- a/Code/GraphMol/FileParsers/TDTMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/TDTMolSupplier.cpp
@@ -112,11 +112,6 @@ void TDTMolSupplier::init() {
   d_last = 0;
   d_line = 0;
 }
-TDTMolSupplier::~TDTMolSupplier() {
-  if (df_owner && dp_inStream) {
-    delete dp_inStream;
-  }
-}
 
 void TDTMolSupplier::setData(const std::string &text,
                              const std::string &nameRecord, int confId2D,

--- a/Code/GraphMol/Wrap/CompressedSDMolSupplier.cpp
+++ b/Code/GraphMol/Wrap/CompressedSDMolSupplier.cpp
@@ -105,17 +105,12 @@ struct compressedsdmolsup_wrap {
     python::class_<ForwardSDMolSupplier, boost::noncopyable>(
         "_CompressedSDMolSupplier", csdMolSupplierClassDoc.c_str(),
         python::no_init)
-        .def(
-            "__iter__",
-            (ForwardSDMolSupplier * (*)(ForwardSDMolSupplier *)) & MolSupplIter,
-            python::return_internal_reference<1>())
-        .def("__enter__",
-             (ForwardSDMolSupplier * (*)(ForwardSDMolSupplier *)) & MolIOEnter,
+        .def("__iter__", &MolSupplIter<ForwardSDMolSupplier>,
+             python::return_internal_reference<1>())
+        .def("__enter__", &MolIOEnter<ForwardSDMolSupplier>,
              python::return_internal_reference<>())
-        .def("__exit__", (bool (*)(ForwardSDMolSupplier *, python::object,
-                                   python::object, python::object)) &
-                             MolIOExit)
-        .def("__next__", (ROMol * (*)(ForwardSDMolSupplier *)) & MolSupplNext,
+        .def("__exit__", &MolIOExit<ForwardSDMolSupplier>)
+        .def("__next__", &MolSupplNext<ForwardSDMolSupplier>,
              "Returns the next molecule in the file.  Raises _StopIteration_ "
              "on EOF.\n",
              python::return_value_policy<python::manage_new_object>());

--- a/Code/GraphMol/Wrap/CompressedSDMolSupplier.cpp
+++ b/Code/GraphMol/Wrap/CompressedSDMolSupplier.cpp
@@ -109,6 +109,12 @@ struct compressedsdmolsup_wrap {
             "__iter__",
             (ForwardSDMolSupplier * (*)(ForwardSDMolSupplier *)) & MolSupplIter,
             python::return_internal_reference<1>())
+        .def("__enter__",
+             (ForwardSDMolSupplier * (*)(ForwardSDMolSupplier *)) & MolIOEnter,
+             python::return_internal_reference<>())
+        .def("__exit__", (bool (*)(ForwardSDMolSupplier *, python::object,
+                                   python::object, python::object)) &
+                             MolIOExit)
         .def("__next__", (ROMol * (*)(ForwardSDMolSupplier *)) & MolSupplNext,
              "Returns the next molecule in the file.  Raises _StopIteration_ "
              "on EOF.\n",

--- a/Code/GraphMol/Wrap/ContextManagers.h
+++ b/Code/GraphMol/Wrap/ContextManagers.h
@@ -1,0 +1,31 @@
+//
+//  Copyright (C) 2021 Greg Landrum
+//
+//   @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
+//
+#include <RDGeneral/export.h>
+#ifndef RD_WRAP_CONTEXTMGR_H
+#define RD_WRAP_CONTEXTMGR_H
+//! Template functions for supporting python context managers
+
+#include <RDBoost/python.h>
+namespace python = boost::python;
+
+namespace RDKit {
+template <typename T>
+T *MolIOEnter(T *self) {
+  return self;
+}
+
+template <typename T>
+bool MolIOExit(T *self, python::object exc_type, python::object exc_val,
+               python::object traceback) {
+  self->close();
+  return false;
+}
+}  // namespace RDKit
+#endif

--- a/Code/GraphMol/Wrap/ContextManagers.h
+++ b/Code/GraphMol/Wrap/ContextManagers.h
@@ -24,6 +24,9 @@ T *MolIOEnter(T *self) {
 template <typename T>
 bool MolIOExit(T *self, python::object exc_type, python::object exc_val,
                python::object traceback) {
+  RDUNUSED_PARAM(exc_type);
+  RDUNUSED_PARAM(exc_val);
+  RDUNUSED_PARAM(traceback);
   self->close();
   return false;
 }

--- a/Code/GraphMol/Wrap/ForwardSDMolSupplier.cpp
+++ b/Code/GraphMol/Wrap/ForwardSDMolSupplier.cpp
@@ -20,6 +20,7 @@
 #include <GraphMol/FileParsers/MolSupplier.h>
 #include <GraphMol/RDKitBase.h>
 #include <RDBoost/python_streambuf.h>
+#include "ContextManagers.h"
 
 #include "MolSupplier.h"
 
@@ -114,6 +115,13 @@ struct forwardsdmolsup_wrap {
             (python::arg("filename"), python::arg("sanitize") = true,
              python::arg("removeHs") = true,
              python::arg("strictParsing") = true)))
+        .def("__enter__",
+             (LocalForwardSDMolSupplier * (*)(LocalForwardSDMolSupplier *)) &
+                 MolIOEnter,
+             python::return_internal_reference<>())
+        .def("__exit__", (bool (*)(LocalForwardSDMolSupplier *, python::object,
+                                   python::object, python::object)) &
+                             MolIOExit)
         .def("__next__",
              (ROMol * (*)(LocalForwardSDMolSupplier *)) & MolForwardSupplNext,
              "Returns the next molecule in the file.  Raises _StopIteration_ "

--- a/Code/GraphMol/Wrap/MaeMolSupplier.cpp
+++ b/Code/GraphMol/Wrap/MaeMolSupplier.cpp
@@ -117,13 +117,10 @@ struct maemolsup_wrap {
         .def(python::init<std::string, bool, bool>(
             (python::arg("filename"), python::arg("sanitize") = true,
              python::arg("removeHs") = true)))
-        .def("__enter__",
-             (LocalMaeMolSupplier * (*)(LocalMaeMolSupplier *)) & MolIOEnter,
+        .def("__enter__", &MolIOEnter<LocalMaeMolSupplier>,
              python::return_internal_reference<>())
-        .def("__exit__", (bool (*)(LocalMaeMolSupplier *, python::object,
-                                   python::object, python::object)) &
-                             MolIOExit)
-        .def("__next__", (ROMol * (*)(LocalMaeMolSupplier *)) & MolSupplNext,
+        .def("__exit__", &MolIOExit<LocalMaeMolSupplier>)
+        .def("__next__", &MolSupplNext<LocalMaeMolSupplier>,
              "Returns the next molecule in the file.  Raises _StopIteration_ "
              "on EOF.\n",
              python::return_value_policy<python::manage_new_object>())

--- a/Code/GraphMol/Wrap/MaeMolSupplier.cpp
+++ b/Code/GraphMol/Wrap/MaeMolSupplier.cpp
@@ -25,6 +25,7 @@
 #include <maeparser/Reader.hpp>
 
 #include "MolSupplier.h"
+#include "ContextManagers.h"
 
 namespace python = boost::python;
 
@@ -116,6 +117,12 @@ struct maemolsup_wrap {
         .def(python::init<std::string, bool, bool>(
             (python::arg("filename"), python::arg("sanitize") = true,
              python::arg("removeHs") = true)))
+        .def("__enter__",
+             (LocalMaeMolSupplier * (*)(LocalMaeMolSupplier *)) & MolIOEnter,
+             python::return_internal_reference<>())
+        .def("__exit__", (bool (*)(LocalMaeMolSupplier *, python::object,
+                                   python::object, python::object)) &
+                             MolIOExit)
         .def("__next__", (ROMol * (*)(LocalMaeMolSupplier *)) & MolSupplNext,
              "Returns the next molecule in the file.  Raises _StopIteration_ "
              "on EOF.\n",

--- a/Code/GraphMol/Wrap/PDBWriter.cpp
+++ b/Code/GraphMol/Wrap/PDBWriter.cpp
@@ -48,11 +48,9 @@ struct pdbwriter_wrap {
         .def(python::init<std::string, unsigned int>(
             (python::arg("fileName"), python::arg("flavor") = 0),
             pdbwDocStr.c_str()))
-        .def("__enter__", (PDBWriter * (*)(PDBWriter *)) & MolIOEnter,
+        .def("__enter__", &MolIOEnter<PDBWriter>,
              python::return_internal_reference<>())
-        .def("__exit__", (bool (*)(PDBWriter *, python::object, python::object,
-                                   python::object)) &
-                             MolIOExit)
+        .def("__exit__", &MolIOExit<PDBWriter>)
 
         .def("write", &PDBWriter::write,
              (python::arg("self"), python::arg("mol"),

--- a/Code/GraphMol/Wrap/PDBWriter.cpp
+++ b/Code/GraphMol/Wrap/PDBWriter.cpp
@@ -1,6 +1,5 @@
-// $Id$
 //
-//  Copyright (C) 2013 Greg Landrum and Rational Discovery LLC
+//  Copyright (C) 2013-2021 Greg Landrum and Rational Discovery LLC
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -16,6 +15,7 @@
 #include <GraphMol/FileParsers/MolWriters.h>
 #include <GraphMol/RDKitBase.h>
 #include "rdchem.h"
+#include "ContextManagers.h"
 #include <RDBoost/PySequenceHolder.h>
 #include <RDBoost/python_streambuf.h>
 
@@ -48,6 +48,12 @@ struct pdbwriter_wrap {
         .def(python::init<std::string, unsigned int>(
             (python::arg("fileName"), python::arg("flavor") = 0),
             pdbwDocStr.c_str()))
+        .def("__enter__", (PDBWriter * (*)(PDBWriter *)) & MolIOEnter,
+             python::return_internal_reference<>())
+        .def("__exit__", (bool (*)(PDBWriter *, python::object, python::object,
+                                   python::object)) &
+                             MolIOExit)
+
         .def("write", &PDBWriter::write,
              (python::arg("self"), python::arg("mol"),
               python::arg("confId") = -1),

--- a/Code/GraphMol/Wrap/SDMolSupplier.cpp
+++ b/Code/GraphMol/Wrap/SDMolSupplier.cpp
@@ -18,6 +18,7 @@
 #include <RDBoost/PySequenceHolder.h>
 
 #include "MolSupplier.h"
+#include "ContextManagers.h"
 
 namespace python = boost::python;
 
@@ -79,14 +80,17 @@ struct sdmolsup_wrap {
             (python::arg("fileName"), python::arg("sanitize") = true,
              python::arg("removeHs") = true,
              python::arg("strictParsing") = true)))
+        .def("__enter__", (SDMolSupplier * (*)(SDMolSupplier *)) & MolIOEnter,
+             python::return_internal_reference<>())
+        .def("__exit__", (bool (*)(SDMolSupplier *, python::object,
+                                   python::object, python::object)) &
+                             MolIOExit)
         .def("__iter__", (SDMolSupplier * (*)(SDMolSupplier *)) & MolSupplIter,
              python::return_internal_reference<1>())
-        .def(
-            "__next__",
-            (ROMol * (*)(SDMolSupplier *)) & MolSupplNext,
-            "Returns the next molecule in the file.  Raises _StopIteration_ "
-            "on EOF.\n",
-            python::return_value_policy<python::manage_new_object>())
+        .def("__next__", (ROMol * (*)(SDMolSupplier *)) & MolSupplNext,
+             "Returns the next molecule in the file.  Raises _StopIteration_ "
+             "on EOF.\n",
+             python::return_value_policy<python::manage_new_object>())
         .def("__getitem__",
              (ROMol * (*)(SDMolSupplier *, int)) & MolSupplGetItem,
              python::return_value_policy<python::manage_new_object>())

--- a/Code/GraphMol/Wrap/SDMolSupplier.cpp
+++ b/Code/GraphMol/Wrap/SDMolSupplier.cpp
@@ -80,19 +80,16 @@ struct sdmolsup_wrap {
             (python::arg("fileName"), python::arg("sanitize") = true,
              python::arg("removeHs") = true,
              python::arg("strictParsing") = true)))
-        .def("__enter__", (SDMolSupplier * (*)(SDMolSupplier *)) & MolIOEnter,
+        .def("__enter__", &MolIOEnter<SDMolSupplier>,
              python::return_internal_reference<>())
-        .def("__exit__", (bool (*)(SDMolSupplier *, python::object,
-                                   python::object, python::object)) &
-                             MolIOExit)
-        .def("__iter__", (SDMolSupplier * (*)(SDMolSupplier *)) & MolSupplIter,
+        .def("__exit__", &MolIOExit<SDMolSupplier>)
+        .def("__iter__", &MolSupplIter<SDMolSupplier>,
              python::return_internal_reference<1>())
-        .def("__next__", (ROMol * (*)(SDMolSupplier *)) & MolSupplNext,
+        .def("__next__", &MolSupplNext<SDMolSupplier>,
              "Returns the next molecule in the file.  Raises _StopIteration_ "
              "on EOF.\n",
              python::return_value_policy<python::manage_new_object>())
-        .def("__getitem__",
-             (ROMol * (*)(SDMolSupplier *, int)) & MolSupplGetItem,
+        .def("__getitem__", &MolSupplGetItem<SDMolSupplier>,
              python::return_value_policy<python::manage_new_object>())
         .def("reset", &SDMolSupplier::reset,
              "Resets our position in the file to the beginning.\n")

--- a/Code/GraphMol/Wrap/SDWriter.cpp
+++ b/Code/GraphMol/Wrap/SDWriter.cpp
@@ -85,12 +85,9 @@ struct sdwriter_wrap {
                                        "output file.\n"
                                        "   If a file-like object is provided, "
                                        "output will be sent there.\n\n"))
-        //(ROMol * (*)(SDMolSupplier *, int)) &
-        .def("__enter__", (SDWriter * (*)(SDWriter *)) & MolIOEnter,
+        .def("__enter__", &MolIOEnter<SDWriter>,
              python::return_internal_reference<>())
-        .def("__exit__", (bool (*)(SDWriter *, python::object, python::object,
-                                   python::object)) &
-                             MolIOExit)
+        .def("__exit__", &MolIOExit<SDWriter>)
         .def("SetProps", SetSDWriterProps,
              "Sets the properties to be written to the output file\n\n"
              "  ARGUMENTS:\n\n"
@@ -119,9 +116,7 @@ struct sdwriter_wrap {
              "Sets whether or not molecules are kekulized on writing.\n\n")
         .def("GetKekulize", &SDWriter::getKekulize,
              "Returns whether or not molecules are kekulized on writing.\n\n")
-        .def("GetText",
-             //(std::string(*)(const ROMol &, int, bool, bool, int))
-             getSDTextHelper,
+        .def("GetText", getSDTextHelper,
              (python::arg("mol"), python::arg("confId") = -1,
               python::arg("kekulize") = true,
               python::arg("force_v3000") = false, python::arg("molid") = -1),

--- a/Code/GraphMol/Wrap/SDWriter.cpp
+++ b/Code/GraphMol/Wrap/SDWriter.cpp
@@ -1,6 +1,5 @@
-// $Id$
 //
-//  Copyright (C) 2003-2011 Greg Landrum and Rational Discovery LLC
+//  Copyright (C) 2003-2021 Greg Landrum and Rational Discovery LLC
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -17,6 +16,7 @@
 #include <GraphMol/FileParsers/MolWriters.h>
 #include <GraphMol/RDKitBase.h>
 #include "rdchem.h"
+#include "ContextManagers.h"
 #include <RDBoost/PySequenceHolder.h>
 #include <RDBoost/python_streambuf.h>
 
@@ -85,6 +85,12 @@ struct sdwriter_wrap {
                                        "output file.\n"
                                        "   If a file-like object is provided, "
                                        "output will be sent there.\n\n"))
+        //(ROMol * (*)(SDMolSupplier *, int)) &
+        .def("__enter__", (SDWriter * (*)(SDWriter *)) & MolIOEnter,
+             python::return_internal_reference<>())
+        .def("__exit__", (bool (*)(SDWriter *, python::object, python::object,
+                                   python::object)) &
+                             MolIOExit)
         .def("SetProps", SetSDWriterProps,
              "Sets the properties to be written to the output file\n\n"
              "  ARGUMENTS:\n\n"

--- a/Code/GraphMol/Wrap/SmilesMolSupplier.cpp
+++ b/Code/GraphMol/Wrap/SmilesMolSupplier.cpp
@@ -1,6 +1,5 @@
-// $Id$
 //
-//  Copyright (C) 2003-2008  Greg Landrum and Rational Discovery LLC
+//  Copyright (C) 2003-2021  Greg Landrum and Rational Discovery LLC
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -18,6 +17,7 @@
 #include <GraphMol/RDKitBase.h>
 #include <RDGeneral/FileParseException.h>
 #include "MolSupplier.h"
+#include "ContextManagers.h"
 
 namespace python = boost::python;
 
@@ -92,6 +92,12 @@ struct smimolsup_wrap {
              python::arg("titleLine") = true, python::arg("sanitize") = true),
             smsDocStr.c_str()))
         .def(python::init<>())
+        .def("__enter__",
+             (SmilesMolSupplier * (*)(SmilesMolSupplier *)) & MolIOEnter,
+             python::return_internal_reference<>())
+        .def("__exit__", (bool (*)(SmilesMolSupplier *, python::object,
+                                   python::object, python::object)) &
+                             MolIOExit)
         .def("__iter__",
              (SmilesMolSupplier * (*)(SmilesMolSupplier *)) & MolSupplIter,
              python::return_internal_reference<1>())

--- a/Code/GraphMol/Wrap/SmilesMolSupplier.cpp
+++ b/Code/GraphMol/Wrap/SmilesMolSupplier.cpp
@@ -92,21 +92,16 @@ struct smimolsup_wrap {
              python::arg("titleLine") = true, python::arg("sanitize") = true),
             smsDocStr.c_str()))
         .def(python::init<>())
-        .def("__enter__",
-             (SmilesMolSupplier * (*)(SmilesMolSupplier *)) & MolIOEnter,
+        .def("__enter__", &MolIOEnter<SmilesMolSupplier>,
              python::return_internal_reference<>())
-        .def("__exit__", (bool (*)(SmilesMolSupplier *, python::object,
-                                   python::object, python::object)) &
-                             MolIOExit)
-        .def("__iter__",
-             (SmilesMolSupplier * (*)(SmilesMolSupplier *)) & MolSupplIter,
+        .def("__exit__", &MolIOExit<SmilesMolSupplier>)
+        .def("__iter__", &MolSupplIter<SmilesMolSupplier>,
              python::return_internal_reference<1>())
-        .def("__next__", (ROMol * (*)(SmilesMolSupplier *)) & MolSupplNext,
+        .def("__next__", &MolSupplNext<SmilesMolSupplier>,
              "Returns the next molecule in the file.  Raises _StopIteration_ "
              "on EOF.\n",
              python::return_value_policy<python::manage_new_object>())
-        .def("__getitem__",
-             (ROMol * (*)(SmilesMolSupplier *, int)) & MolSupplGetItem,
+        .def("__getitem__", &MolSupplGetItem<SmilesMolSupplier>,
              python::return_value_policy<python::manage_new_object>())
         .def("reset", &SmilesMolSupplier::reset,
              "Resets our position in the file to the beginning.\n")

--- a/Code/GraphMol/Wrap/SmilesWriter.cpp
+++ b/Code/GraphMol/Wrap/SmilesWriter.cpp
@@ -83,11 +83,9 @@ struct smiwriter_wrap {
              python::arg("isomericSmiles") = true,
              python::arg("kekuleSmiles") = false),
             swDocStr.c_str()))
-        .def("__enter__", (SmilesWriter * (*)(SmilesWriter *)) & MolIOEnter,
+        .def("__enter__", &MolIOEnter<SmilesWriter>,
              python::return_internal_reference<>())
-        .def("__exit__", (bool (*)(SmilesWriter *, python::object,
-                                   python::object, python::object)) &
-                             MolIOExit)
+        .def("__exit__", &MolIOExit<SmilesWriter>)
         .def("SetProps", SetSmiWriterProps,
              "Sets the properties to be written to the output file\n\n"
              "  ARGUMENTS:\n\n"

--- a/Code/GraphMol/Wrap/SmilesWriter.cpp
+++ b/Code/GraphMol/Wrap/SmilesWriter.cpp
@@ -1,6 +1,5 @@
-// $Id$
 //
-//  Copyright (C) 2003-2011 Greg Landrum and Rational Discovery LLC
+//  Copyright (C) 2003-2021 Greg Landrum and Rational Discovery LLC
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -16,6 +15,7 @@
 #include <GraphMol/FileParsers/MolWriters.h>
 #include <GraphMol/RDKitBase.h>
 #include "rdchem.h"
+#include "ContextManagers.h"
 #include <RDBoost/PySequenceHolder.h>
 #include <RDBoost/python_streambuf.h>
 
@@ -83,6 +83,11 @@ struct smiwriter_wrap {
              python::arg("isomericSmiles") = true,
              python::arg("kekuleSmiles") = false),
             swDocStr.c_str()))
+        .def("__enter__", (SmilesWriter * (*)(SmilesWriter *)) & MolIOEnter,
+             python::return_internal_reference<>())
+        .def("__exit__", (bool (*)(SmilesWriter *, python::object,
+                                   python::object, python::object)) &
+                             MolIOExit)
         .def("SetProps", SetSmiWriterProps,
              "Sets the properties to be written to the output file\n\n"
              "  ARGUMENTS:\n\n"

--- a/Code/GraphMol/Wrap/TDTMolSupplier.cpp
+++ b/Code/GraphMol/Wrap/TDTMolSupplier.cpp
@@ -1,6 +1,5 @@
-// $Id$
 //
-//  Copyright (C) 2005-2008 Greg Landrum and Rational Discovery LLC
+//  Copyright (C) 2005-2021 Greg Landrum and Rational Discovery LLC
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -16,6 +15,7 @@
 #include <GraphMol/FileParsers/MolSupplier.h>
 #include <GraphMol/RDKitBase.h>
 #include "MolSupplier.h"
+#include "ContextManagers.h"
 
 namespace python = boost::python;
 
@@ -58,6 +58,11 @@ struct tdtmolsup_wrap {
             (python::arg("fileName"), python::arg("nameRecord") = "",
              python::arg("confId2D") = -1, python::arg("confId3D") = -1,
              python::arg("sanitize") = true)))
+        .def("__enter__", (TDTMolSupplier * (*)(TDTMolSupplier *)) & MolIOEnter,
+             python::return_internal_reference<>())
+        .def("__exit__", (bool (*)(TDTMolSupplier *, python::object,
+                                   python::object, python::object)) &
+                             MolIOExit)
         .def("__iter__",
              (TDTMolSupplier * (*)(TDTMolSupplier *)) & MolSupplIter,
              python::return_internal_reference<1>())

--- a/Code/GraphMol/Wrap/TDTMolSupplier.cpp
+++ b/Code/GraphMol/Wrap/TDTMolSupplier.cpp
@@ -58,20 +58,16 @@ struct tdtmolsup_wrap {
             (python::arg("fileName"), python::arg("nameRecord") = "",
              python::arg("confId2D") = -1, python::arg("confId3D") = -1,
              python::arg("sanitize") = true)))
-        .def("__enter__", (TDTMolSupplier * (*)(TDTMolSupplier *)) & MolIOEnter,
+        .def("__enter__", &MolIOEnter<TDTMolSupplier>,
              python::return_internal_reference<>())
-        .def("__exit__", (bool (*)(TDTMolSupplier *, python::object,
-                                   python::object, python::object)) &
-                             MolIOExit)
-        .def("__iter__",
-             (TDTMolSupplier * (*)(TDTMolSupplier *)) & MolSupplIter,
+        .def("__exit__", &MolIOExit<TDTMolSupplier>)
+        .def("__iter__", &MolSupplIter<TDTMolSupplier>,
              python::return_internal_reference<1>())
-        .def("__next__", (ROMol * (*)(TDTMolSupplier *)) & MolSupplNext,
+        .def("__next__", &MolSupplNext<TDTMolSupplier>,
              "Returns the next molecule in the file.  Raises _StopIteration_ "
              "on EOF.\n",
              python::return_value_policy<python::manage_new_object>())
-        .def("__getitem__",
-             (ROMol * (*)(TDTMolSupplier *, int)) & MolSupplGetItem,
+        .def("__getitem__", &MolSupplGetItem<TDTMolSupplier>,
              python::return_value_policy<python::manage_new_object>())
         .def("reset", &TDTMolSupplier::reset,
              "Resets our position in the file to the beginning.\n")

--- a/Code/GraphMol/Wrap/TDTWriter.cpp
+++ b/Code/GraphMol/Wrap/TDTWriter.cpp
@@ -1,6 +1,5 @@
-// $Id$
 //
-//  Copyright (C) 2005-2010  Rational Discovery LLC
+//  Copyright (C) 2005-2021 Greg Landrum and Rational Discovery LLC
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -17,6 +16,7 @@
 #include <GraphMol/FileParsers/MolWriters.h>
 #include <GraphMol/RDKitBase.h>
 #include "rdchem.h"
+#include "ContextManagers.h"
 #include <RDBoost/PySequenceHolder.h>
 #include <RDBoost/python_streambuf.h>
 
@@ -53,6 +53,11 @@ struct tdtwriter_wrap {
         .def("__init__", python::make_constructor(&getTDTWriter))
         .def(
             python::init<std::string>(python::args("fileName"), docStr.c_str()))
+        .def("__enter__", (TDTWriter * (*)(TDTWriter *)) & MolIOEnter,
+             python::return_internal_reference<>())
+        .def("__exit__", (bool (*)(TDTWriter *, python::object, python::object,
+                                   python::object)) &
+                             MolIOExit)
         .def("SetProps", SetTDTWriterProps,
              "Sets the properties to be written to the output file\n\n"
              "  ARGUMENTS:\n\n"

--- a/Code/GraphMol/Wrap/TDTWriter.cpp
+++ b/Code/GraphMol/Wrap/TDTWriter.cpp
@@ -53,11 +53,9 @@ struct tdtwriter_wrap {
         .def("__init__", python::make_constructor(&getTDTWriter))
         .def(
             python::init<std::string>(python::args("fileName"), docStr.c_str()))
-        .def("__enter__", (TDTWriter * (*)(TDTWriter *)) & MolIOEnter,
+        .def("__enter__", &MolIOEnter<TDTWriter>,
              python::return_internal_reference<>())
-        .def("__exit__", (bool (*)(TDTWriter *, python::object, python::object,
-                                   python::object)) &
-                             MolIOExit)
+        .def("__exit__", &MolIOExit<TDTWriter>)
         .def("SetProps", SetTDTWriterProps,
              "Sets the properties to be written to the output file\n\n"
              "  ARGUMENTS:\n\n"

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -2755,12 +2755,8 @@ CAS<~>
       i += 1
     self.assertEqual(i, 16)
 
+  @unittest.skipIf(not hasattr(Chem, 'MaeMolSupplier'), "not build with MAEParser support")
   def testMaeStreamSupplier(self):
-    try:
-      MaeMolSupplier = Chem.MaeMolSupplier
-    except AttributeError:  # Built without Maestro support, return w/o testing
-      return
-
     fileN = os.path.join(RDConfig.RDBaseDir, 'Code', 'GraphMol', 'FileParsers', 'test_data',
                          'NCI_aids_few.maegz')
     molNames = [
@@ -2768,7 +2764,7 @@ CAS<~>
       "220", "229", "256"
     ]
     inf = gzip.open(fileN)
-    suppl = MaeMolSupplier(inf)
+    suppl = Chem.MaeMolSupplier(inf)
 
     i = 0
     while not suppl.atEnd():
@@ -2780,7 +2776,7 @@ CAS<~>
 
     # make sure we have object ownership preserved
     inf = gzip.open(fileN)
-    suppl = MaeMolSupplier(inf)
+    suppl = Chem.MaeMolSupplier(inf)
     inf = None
     i = 0
     while not suppl.atEnd():
@@ -2790,19 +2786,15 @@ CAS<~>
       i += 1
     self.assertEqual(i, 16)
 
+  @unittest.skipIf(not hasattr(Chem, 'MaeMolSupplier'), "not build with MAEParser support")
   def testMaeFileSupplier(self):
-    try:
-      MaeMolSupplier = Chem.MaeMolSupplier
-    except AttributeError:  # Built without Maestro support, return w/o testing
-      return
-
     fileN = os.path.join(RDConfig.RDBaseDir, 'Code', 'GraphMol', 'FileParsers', 'test_data',
                          'NCI_aids_few.mae')
     molNames = [
       "48", "78", "128", "163", "164", "170", "180", "186", "192", "203", "210", "211", "213",
       "220", "229", "256"
     ]
-    suppl = MaeMolSupplier(fileN)
+    suppl = Chem.MaeMolSupplier(fileN)
 
     i = 0
     while not suppl.atEnd():
@@ -2812,18 +2804,14 @@ CAS<~>
       i += 1
     self.assertEqual(i, 16)
 
+  @unittest.skipIf(not hasattr(Chem, 'MaeMolSupplier'), "not build with MAEParser support")
   def testMaeFileSupplierException(self):
-    try:
-      MaeMolSupplier = Chem.MaeMolSupplier
-    except AttributeError:  # Built without Maestro support, return w/o testing
-      return
-
     fileN = os.path.join(RDConfig.RDBaseDir, 'Code', 'GraphMol', 'FileParsers', 'test_data',
                          'bad_ppty.mae')
     err_msg_substr = "Bad format for property"
 
     ok = False
-    suppl = MaeMolSupplier(fileN)
+    suppl = Chem.MaeMolSupplier(fileN)
     for i in range(5):
       try:
         mol = next(suppl)

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -6264,9 +6264,8 @@ M  END
     from io import StringIO
     fileN = os.path.join(RDConfig.RDBaseDir, 'Code', 'GraphMol', 'Wrap', 'test_data',
                          'github3553.sdf')
-    # with Chem.SDMolSupplier(fileN) as suppl:
-    #  mols = [x for x in suppl if x is not None]
-    mols = [x for x in Chem.SDMolSupplier(fileN) if x is not None]
+    with Chem.SDMolSupplier(fileN) as suppl:
+      mols = [x for x in suppl if x is not None]
     sio = StringIO()
     with Chem.SDWriter(sio) as w:
       for m in mols:
@@ -6276,10 +6275,14 @@ M  END
     with self.assertRaises(RuntimeError):
       w.write(mols[0])
 
+    with Chem.ForwardSDMolSupplier(fileN) as suppl:
+      mols = [x for x in suppl if x is not None]
+
     fileN = os.path.join(RDConfig.RDBaseDir, 'Code', 'GraphMol', 'FileParsers', 'test_data',
                          'first_200.tpsa.csv')
-    suppl = Chem.SmilesMolSupplier(fileN, ",", 0, -1)
-    ms = [x for x in suppl if x is not None]
+    with Chem.SmilesMolSupplier(fileN, ",", 0, -1) as suppl:
+      ms = [x for x in suppl if x is not None]
+
     sio = StringIO()
     with Chem.SmilesWriter(sio) as w:
       for m in mols:
@@ -6301,9 +6304,9 @@ CAS<932-53-6>
 $SMI<Cc1nnc(NN)nc1O>
 CAS<~>
 |"""
-    suppl = Chem.TDTMolSupplier()
-    suppl.SetData(data, "CAS")
-    ms = [x for x in suppl if x is not None]
+    with Chem.TDTMolSupplier() as suppl:
+      suppl.SetData(data, "CAS")
+      ms = [x for x in suppl if x is not None]
     sio = StringIO()
     with Chem.TDTWriter(sio) as w:
       for m in mols:
@@ -6313,7 +6316,6 @@ CAS<~>
     with self.assertRaises(RuntimeError):
       w.write(mols[0])
 
-    RDLogger.EnableLog('rdApp.*')
     fileN = os.path.join(RDConfig.RDBaseDir, 'Code', 'GraphMol', 'FileParsers', 'test_data',
                          '1CRN.pdb')
     m = Chem.MolFromPDBFile(fileN)
@@ -6326,6 +6328,14 @@ CAS<~>
     self.assertEqual(txt.count('COMPND    CRAMBIN'), len(mols))
     with self.assertRaises(RuntimeError):
       w.write(mols[0])
+
+    if hasattr(Chem, 'MaeMolSupplier'):
+      fileN = os.path.join(RDConfig.RDBaseDir, 'Code', 'GraphMol', 'FileParsers', 'test_data',
+                           'NCI_aids_few.mae')
+      with Chem.MaeMolSupplier(fileN) as suppl:
+        ms = [x for x in suppl if x is not None]
+
+    RDLogger.EnableLog('rdApp.*')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This fixes #3703 and #2217: MolWriters and MolSuppliers can now be used in Python `with` statements
Other changes to make this work:
- Added a `close()` method to `MolSupplier()`
- Make sure `MolWriter::close()` only calls `flush()` if the stream is still valid
