### PR TITLE
Make better use of strictParsing for SGroups

### DIFF
--- a/Code/GraphMol/FileParsers/FileParsers.h
+++ b/Code/GraphMol/FileParsers/FileParsers.h
@@ -53,8 +53,8 @@ typedef std::vector<RWMOL_SPTR> RWMOL_SPTR_VECT;
  *   \param removeHs - toggles removal of Hs from the molecule. H removal
  *                     is only done if the molecule is sanitized
  *   \param line     - current line number (used for error reporting)
- *   \param strictParsing - if not set, the parser is more lax about correctness
- *                          of the contents.
+ *   \param strictParsing - if set to false, the parser is more lax about
+ * correctness of the contents.
  *
  */
 RDKIT_FILEPARSERS_EXPORT RWMol *MolDataStreamToMol(std::istream *inStream,
@@ -75,8 +75,8 @@ RDKIT_FILEPARSERS_EXPORT RWMol *MolDataStreamToMol(std::istream &inStream,
  *                     perception of the molecule
  *   \param removeHs - toggles removal of Hs from the molecule. H removal
  *                     is only done if the molecule is sanitized
- *   \param strictParsing - if set, the parser is more lax about correctness
- *                          of the contents.
+ *   \param strictParsing - if set to false, the parser is more lax about
+ * correctness of the contents.
  */
 RDKIT_FILEPARSERS_EXPORT RWMol *MolBlockToMol(const std::string &molBlock,
                                               bool sanitize = true,
@@ -90,8 +90,8 @@ RDKIT_FILEPARSERS_EXPORT RWMol *MolBlockToMol(const std::string &molBlock,
  *                     perception of the molecule
  *   \param removeHs - toggles removal of Hs from the molecule. H removal
  *                     is only done if the molecule is sanitized
- *   \param strictParsing - if set, the parser is more lax about correctness
- *                          of the contents.
+ *   \param strictParsing - if set to false, the parser is more lax about
+ * correctness of the contents.
  */
 RDKIT_FILEPARSERS_EXPORT RWMol *MolFileToMol(const std::string &fName,
                                              bool sanitize = true,

--- a/Code/GraphMol/FileParsers/MolSGroupParsing.cpp
+++ b/Code/GraphMol/FileParsers/MolSGroupParsing.cpp
@@ -14,6 +14,35 @@
 
 #include <RDGeneral/FileParseException.h>
 
+#define PARSE_SGROUP_FIELD_OR_FAIL(sgroup, ParseSGroupFunc, ...) \
+  if (!ParseSGroupFunc(__VA_ARGS__)) {                           \
+    if (sgroup) {                                                \
+      static_cast<SubstanceGroup *>(sgroup)->setIsValid(         \
+          static_cast<bool>(false));                             \
+    }                                                            \
+    return;                                                      \
+  }
+
+#define PARSE_SGROUP_INT_FIELD_OR_FAIL(sgroup, ...) \
+  PARSE_SGROUP_FIELD_OR_FAIL(sgroup, ParseSGroupIntField, __VA_ARGS__)
+
+#define PARSE_SGROUP_DOUBLE_FIELD_OR_FAIL(sgroup, ...) \
+  PARSE_SGROUP_FIELD_OR_FAIL(sgroup, ParseSGroupDoubleField, __VA_ARGS__)
+
+#define SGROUP_FAIL(sgroup, Exc, ...)                  \
+  SGroupWarnOrThrow<Exc>(__VA_ARGS__);                 \
+  if (sgroup) {                                        \
+    static_cast<SubstanceGroup *>(sgroup)->setIsValid( \
+        static_cast<bool>(false));                     \
+  }                                                    \
+  return;
+
+#define FIND_SGIDX_OR_FAIL(sgroup, ...) \
+  sgroup = FindSgIdx(__VA_ARGS__);      \
+  if (!sgroup) {                        \
+    return;                             \
+  }
+
 namespace RDKit {
 namespace SGroupParsing {
 
@@ -40,6 +69,23 @@ unsigned int ParseSGroupIntField(const std::string &text, unsigned int line,
   return fieldValue;
 }
 
+bool ParseSGroupIntField(unsigned int &var, bool strictParsing,
+                         const std::string &text, unsigned int line,
+                         unsigned int &pos, bool isFieldCounter) {
+  bool res = true;
+  try {
+    var = ParseSGroupIntField(text, line, pos, isFieldCounter);
+  } catch (const std::exception &e) {
+    if (strictParsing) {
+      throw;
+    } else {
+      res = false;
+      BOOST_LOG(rdWarningLog) << e.what() << std::endl;
+    }
+  }
+  return res;
+}
+
 double ParseSGroupDoubleField(const std::string &text, unsigned int line,
                               unsigned int &pos) {
   size_t len = 10;
@@ -60,22 +106,55 @@ double ParseSGroupDoubleField(const std::string &text, unsigned int line,
   return fieldValue;
 }
 
+bool ParseSGroupDoubleField(double &var, bool strictParsing,
+                            const std::string &text, unsigned int line,
+                            unsigned int &pos) {
+  bool res = true;
+  try {
+    var = ParseSGroupDoubleField(text, line, pos);
+  } catch (const std::exception &e) {
+    if (strictParsing) {
+      throw;
+    } else {
+      res = false;
+      BOOST_LOG(rdWarningLog) << e.what() << std::endl;
+    }
+  }
+  return res;
+}
+
+SubstanceGroup *FindSgIdx(IDX_TO_SGROUP_MAP &sGroupMap, int sgIdx,
+                          unsigned int line) {
+  auto sgIt = sGroupMap.find(sgIdx);
+  if (sgIt == sGroupMap.end()) {
+    BOOST_LOG(rdWarningLog) << "SGroup " << sgIdx << " referenced on line "
+                            << line << " not found." << std::endl;
+    return nullptr;
+  }
+  return &sgIt->second;
+}
+
 void ParseSGroupV2000STYLine(IDX_TO_SGROUP_MAP &sGroupMap, RWMol *mol,
-                             const std::string &text, unsigned int line) {
+                             const std::string &text, unsigned int line,
+                             bool strictParsing) {
   PRECONDITION(mol, "bad mol");
   PRECONDITION(text.substr(0, 6) == "M  STY", "bad STY line");
 
   unsigned int pos = 6;
-  unsigned int nent = ParseSGroupIntField(text, line, pos, true);
+  unsigned int nent;
+  PARSE_SGROUP_INT_FIELD_OR_FAIL(nullptr, nent, strictParsing, text, line, pos,
+                                 true);
 
   for (unsigned int ie = 0; ie < nent; ++ie) {
     if (text.size() < pos + 8) {
       std::ostringstream errout;
       errout << "SGroup STY line too short: '" << text << "' on line " << line;
-      throw FileParseException(errout.str());
+      SGROUP_FAIL(nullptr, FileParseException, strictParsing, errout.str());
     }
 
-    int nbr = ParseSGroupIntField(text, line, pos);
+    unsigned int nbr;
+    PARSE_SGROUP_INT_FIELD_OR_FAIL(nullptr, nbr, strictParsing, text, line,
+                                   pos);
 
     std::string typ = text.substr(pos + 1, 3);
     if (SubstanceGroupChecks::isValidType(typ)) {
@@ -83,15 +162,16 @@ void ParseSGroupV2000STYLine(IDX_TO_SGROUP_MAP &sGroupMap, RWMol *mol,
     } else {
       std::ostringstream errout;
       errout << "S group " << typ << " on line " << line;
-      throw MolFileUnhandledFeatureException(errout.str());
+      SGROUP_FAIL(nullptr, MolFileUnhandledFeatureException, strictParsing,
+                  errout.str());
     }
     pos += 4;
   }
 }
 
 void ParseSGroupV2000VectorDataLine(IDX_TO_SGROUP_MAP &sGroupMap, RWMol *mol,
-                                    const std::string &text,
-                                    unsigned int line) {
+                                    const std::string &text, unsigned int line,
+                                    bool strictParsing) {
   PRECONDITION(mol, "bad mol");
 
   std::string typ = text.substr(3, 3);
@@ -112,78 +192,95 @@ void ParseSGroupV2000VectorDataLine(IDX_TO_SGROUP_MAP &sGroupMap, RWMol *mol,
   }
 
   unsigned int pos = 6;
-  unsigned int sgIdx = ParseSGroupIntField(text, line, pos);
-  if (sGroupMap.find(sgIdx) == sGroupMap.end()) {
-    BOOST_LOG(rdWarningLog) << "SGroup " << sgIdx << " referenced on line "
-                            << line << " not found." << std::endl;
-    return;
-  }
-  unsigned int nent = ParseSGroupIntField(text, line, pos, true);
+  unsigned int sgIdx;
+  PARSE_SGROUP_INT_FIELD_OR_FAIL(nullptr, sgIdx, strictParsing, text, line,
+                                 pos);
+  SubstanceGroup *sgroup;
+  FIND_SGIDX_OR_FAIL(sgroup, sGroupMap, sgIdx, line);
+  unsigned int nent;
+  PARSE_SGROUP_INT_FIELD_OR_FAIL(sgroup, nent, strictParsing, text, line, pos,
+                                 true);
 
   for (unsigned int i = 0; i < nent; ++i) {
     if (text.size() < pos + 4) {
       std::ostringstream errout;
       errout << "SGroup line too short: '" << text << "' on line " << line;
-      throw FileParseException(errout.str());
+      SGROUP_FAIL(sgroup, FileParseException, strictParsing, errout.str());
     }
-
-    int nbr = ParseSGroupIntField(text, line, pos);
-    (sGroupMap.at(sgIdx).*sGroupAddIndexedElement)(nbr);
+    unsigned int nbr;
+    PARSE_SGROUP_INT_FIELD_OR_FAIL(sgroup, nbr, strictParsing, text, line, pos);
+    try {
+      (sgroup->*sGroupAddIndexedElement)(nbr);
+    } catch (const std::exception &e) {
+      SGROUP_FAIL(sgroup, FileParseException, strictParsing, e.what());
+    }
   }
 }
 
 void ParseSGroupV2000SDILine(IDX_TO_SGROUP_MAP &sGroupMap, RWMol *mol,
-                             const std::string &text, unsigned int line) {
+                             const std::string &text, unsigned int line,
+                             bool strictParsing) {
   PRECONDITION(mol, "bad mol");
   PRECONDITION(text.substr(0, 6) == "M  SDI", "bad SDI line");
 
   unsigned int pos = 6;
-  unsigned int sgIdx = ParseSGroupIntField(text, line, pos);
-  if (sGroupMap.find(sgIdx) == sGroupMap.end()) {
-    BOOST_LOG(rdWarningLog) << "SGroup " << sgIdx << " referenced on line "
-                            << line << " not found." << std::endl;
-    return;
-  }
+  unsigned int sgIdx;
+  PARSE_SGROUP_INT_FIELD_OR_FAIL(nullptr, sgIdx, strictParsing, text, line,
+                                 pos);
+  SubstanceGroup *sgroup;
+  FIND_SGIDX_OR_FAIL(sgroup, sGroupMap, sgIdx, line);
 
-  unsigned int nCoords = ParseSGroupIntField(text, line, pos, true);
+  unsigned int nCoords;
+  PARSE_SGROUP_INT_FIELD_OR_FAIL(sgroup, nCoords, strictParsing, text, line,
+                                 pos, true);
   if (nCoords != 4) {
     std::ostringstream errout;
     errout << "Unexpected number of coordinates for SDI on line " << line;
-    throw FileParseException(errout.str());
+    SGROUP_FAIL(sgroup, FileParseException, strictParsing, errout.str());
   }
 
   SubstanceGroup::Bracket bracket;
   for (unsigned int i = 0; i < 2; ++i) {
-    double x = ParseSGroupDoubleField(text, line, pos);
-    double y = ParseSGroupDoubleField(text, line, pos);
+    double x;
+    PARSE_SGROUP_DOUBLE_FIELD_OR_FAIL(sgroup, x, strictParsing, text, line,
+                                      pos);
+    double y;
+    PARSE_SGROUP_DOUBLE_FIELD_OR_FAIL(sgroup, y, strictParsing, text, line,
+                                      pos);
     double z = 0.;
     bracket[i] = RDGeom::Point3D(x, y, z);
   }
   bracket[2] = RDGeom::Point3D(0., 0., 0.);
-  sGroupMap.at(sgIdx).addBracket(bracket);
+  try {
+    sgroup->addBracket(bracket);
+  } catch (const std::exception &e) {
+    SGROUP_FAIL(sgroup, FileParseException, strictParsing, e.what());
+  }
 }
 
 void ParseSGroupV2000SSTLine(IDX_TO_SGROUP_MAP &sGroupMap, RWMol *mol,
-                             const std::string &text, unsigned int line) {
+                             const std::string &text, unsigned int line,
+                             bool strictParsing) {
   PRECONDITION(mol, "bad mol");
   PRECONDITION(text.substr(0, 6) == "M  SST", "bad SST line");
 
   unsigned int pos = 6;
-  unsigned int nent = ParseSGroupIntField(text, line, pos, true);
+  unsigned int nent;
+  PARSE_SGROUP_INT_FIELD_OR_FAIL(nullptr, nent, strictParsing, text, line, pos,
+                                 true);
 
   for (unsigned int ie = 0; ie < nent; ++ie) {
     if (text.size() < pos + 8) {
       std::ostringstream errout;
       errout << "SGroup SST line too short: '" << text << "' on line " << line;
-      throw FileParseException(errout.str());
+      SGROUP_FAIL(nullptr, FileParseException, strictParsing, errout.str());
     }
 
-    unsigned int sgIdx = ParseSGroupIntField(text, line, pos);
-    if (sGroupMap.find(sgIdx) == sGroupMap.end()) {
-      BOOST_LOG(rdWarningLog) << "SGroup " << sgIdx << " referenced on line "
-                              << line << " not found." << std::endl;
-      return;
-    }
+    unsigned int sgIdx;
+    PARSE_SGROUP_INT_FIELD_OR_FAIL(nullptr, sgIdx, strictParsing, text, line,
+                                   pos);
+    SubstanceGroup *sgroup;
+    FIND_SGIDX_OR_FAIL(sgroup, sGroupMap, sgIdx, line);
 
     std::string subType = text.substr(++pos, 3);
 
@@ -191,102 +288,105 @@ void ParseSGroupV2000SSTLine(IDX_TO_SGROUP_MAP &sGroupMap, RWMol *mol,
       std::ostringstream errout;
       errout << "Unsupported SGroup subtype '" << subType << "' on line "
              << line;
-      throw FileParseException(errout.str());
+      SGROUP_FAIL(sgroup, FileParseException, strictParsing, errout.str());
     }
 
-    sGroupMap.at(sgIdx).setProp("SUBTYPE", subType);
+    sgroup->setProp("SUBTYPE", subType);
     pos += 3;
   }
 }
 
 void ParseSGroupV2000SMTLine(IDX_TO_SGROUP_MAP &sGroupMap, RWMol *mol,
-                             const std::string &text, unsigned int line) {
+                             const std::string &text, unsigned int line,
+                             bool strictParsing) {
   PRECONDITION(mol, "bad mol");
   PRECONDITION(text.substr(0, 6) == "M  SMT", "bad SMT line");
 
   unsigned int pos = 6;
-  unsigned int sgIdx = ParseSGroupIntField(text, line, pos);
-  if (sGroupMap.find(sgIdx) == sGroupMap.end()) {
-    BOOST_LOG(rdWarningLog) << "SGroup " << sgIdx << " referenced on line "
-                            << line << " not found." << std::endl;
-    return;
-  }
-  auto &sgroup = sGroupMap.at(sgIdx);
+  unsigned int sgIdx;
+  PARSE_SGROUP_INT_FIELD_OR_FAIL(nullptr, sgIdx, strictParsing, text, line,
+                                 pos);
+  SubstanceGroup *sgroup;
+  FIND_SGIDX_OR_FAIL(sgroup, sGroupMap, sgIdx, line);
   ++pos;
 
   if (pos >= text.length()) {
     std::ostringstream errout;
     errout << "SGroup line too short: '" << text << "' on line " << line;
-    throw FileParseException(errout.str());
+    SGROUP_FAIL(sgroup, FileParseException, strictParsing, errout.str());
   }
   std::string label = text.substr(pos, text.length() - pos);
 
-  if (sgroup.getProp<std::string>("TYPE") ==
+  if (sgroup->getProp<std::string>("TYPE") ==
       "MUL") {  // Case of multiple groups
-    sgroup.setProp("MULT", label);
+    sgroup->setProp("MULT", label);
 
   } else {  // Case of abbreviation groups, but we might not have seen a SCL
             // line yet
-    sgroup.setProp("LABEL", label);
+    sgroup->setProp("LABEL", label);
   }
 }
 
 void ParseSGroupV2000SLBLine(IDX_TO_SGROUP_MAP &sGroupMap, RWMol *mol,
-                             const std::string &text, unsigned int line) {
+                             const std::string &text, unsigned int line,
+                             bool strictParsing) {
   PRECONDITION(mol, "bad mol");
   PRECONDITION(text.substr(0, 6) == "M  SLB", "bad SLB line");
 
   unsigned int pos = 6;
-  unsigned int nent = ParseSGroupIntField(text, line, pos, true);
+  unsigned int nent;
+  PARSE_SGROUP_INT_FIELD_OR_FAIL(nullptr, nent, strictParsing, text, line, pos,
+                                 true);
 
   for (unsigned int ie = 0; ie < nent; ++ie) {
     if (text.size() < pos + 8) {
       std::ostringstream errout;
       errout << "SGroup SLB line too short: '" << text << "' on line " << line;
-      throw FileParseException(errout.str());
+      SGROUP_FAIL(nullptr, FileParseException, strictParsing, errout.str());
     }
 
-    unsigned int sgIdx = ParseSGroupIntField(text, line, pos);
-    if (sGroupMap.find(sgIdx) == sGroupMap.end()) {
-      BOOST_LOG(rdWarningLog) << "SGroup " << sgIdx << " referenced on line "
-                              << line << " not found." << std::endl;
-      return;
-    }
-    unsigned int id = ParseSGroupIntField(text, line, pos);
-
+    unsigned int sgIdx;
+    PARSE_SGROUP_INT_FIELD_OR_FAIL(nullptr, sgIdx, strictParsing, text, line,
+                                   pos);
+    SubstanceGroup *sgroup;
+    FIND_SGIDX_OR_FAIL(sgroup, sGroupMap, sgIdx, line);
+    unsigned int id;
+    PARSE_SGROUP_INT_FIELD_OR_FAIL(sgroup, id, strictParsing, text, line, pos);
     if (id != 0 && !SubstanceGroupChecks::isSubstanceGroupIdFree(*mol, id)) {
       std::ostringstream errout;
       errout << "SGroup ID '" << id
-             << "' is assigned to more than onge SGroup, on line " << line;
-      throw FileParseException(errout.str());
+             << "' is assigned to more than one SGroup, on line " << line;
+      SGROUP_FAIL(sgroup, FileParseException, strictParsing, errout.str());
     }
 
-    sGroupMap.at(sgIdx).setProp<unsigned int>("ID", id);
+    sgroup->setProp<unsigned int>("ID", id);
   }
 }
 
 void ParseSGroupV2000SCNLine(IDX_TO_SGROUP_MAP &sGroupMap, RWMol *mol,
-                             const std::string &text, unsigned int line) {
+                             const std::string &text, unsigned int line,
+                             bool strictParsing) {
   PRECONDITION(mol, "bad mol");
   PRECONDITION(text.substr(0, 6) == "M  SCN", "bad SCN line");
 
   unsigned int pos = 6;
-  unsigned int nent = ParseSGroupIntField(text, line, pos, true);
+  unsigned int nent;
+  PARSE_SGROUP_INT_FIELD_OR_FAIL(nullptr, nent, strictParsing, text, line, pos,
+                                 true);
 
   for (unsigned int ie = 0; ie < nent; ++ie) {
     if (text.size() < pos + 7) {
       std::ostringstream errout;
       errout << "SGroup SCN line too short: '" << text << "' on line " << line;
       errout << "\n needed: " << pos + 7 << " found: " << text.size();
-      throw FileParseException(errout.str());
+      SGROUP_FAIL(nullptr, FileParseException, strictParsing, errout.str());
     }
 
-    unsigned int sgIdx = ParseSGroupIntField(text, line, pos);
-    if (sGroupMap.find(sgIdx) == sGroupMap.end()) {
-      BOOST_LOG(rdWarningLog) << "SGroup " << sgIdx << " referenced on line "
-                              << line << " not found." << std::endl;
-      return;
-    }
+    unsigned int sgIdx;
+    PARSE_SGROUP_INT_FIELD_OR_FAIL(nullptr, sgIdx, strictParsing, text, line,
+                                   pos);
+    SubstanceGroup *sgroup;
+    FIND_SGIDX_OR_FAIL(sgroup, sGroupMap, sgIdx, line);
 
     std::string connect = text.substr(++pos, 2);
 
@@ -294,80 +394,87 @@ void ParseSGroupV2000SCNLine(IDX_TO_SGROUP_MAP &sGroupMap, RWMol *mol,
       std::ostringstream errout;
       errout << "Unsupported SGroup connection type '" << connect
              << "' on line " << line;
-      throw FileParseException(errout.str());
+      SGROUP_FAIL(sgroup, FileParseException, strictParsing, errout.str());
     }
 
-    sGroupMap.at(sgIdx).setProp("CONNECT", connect);
+    sgroup->setProp("CONNECT", connect);
     pos += 3;
   }
 }
 
 void ParseSGroupV2000SDSLine(IDX_TO_SGROUP_MAP &sGroupMap, RWMol *mol,
-                             const std::string &text, unsigned int line) {
+                             const std::string &text, unsigned int line,
+                             bool strictParsing) {
   PRECONDITION(mol, "bad mol");
   PRECONDITION(text.substr(0, 10) == "M  SDS EXP", "bad SDS line");
 
   unsigned int pos = 10;
-  unsigned int nent = ParseSGroupIntField(text, line, pos, true);
+  unsigned int nent;
+  PARSE_SGROUP_INT_FIELD_OR_FAIL(nullptr, nent, strictParsing, text, line, pos,
+                                 true);
 
   for (unsigned int ie = 0; ie < nent; ++ie) {
     if (text.size() < pos + 4) {
       std::ostringstream errout;
       errout << "SGroup SDS line too short: '" << text << "' on line " << line;
-      throw FileParseException(errout.str());
+      SGROUP_FAIL(nullptr, FileParseException, strictParsing, errout.str());
     }
-    unsigned int sgIdx = ParseSGroupIntField(text, line, pos);
-    if (sGroupMap.find(sgIdx) == sGroupMap.end()) {
-      BOOST_LOG(rdWarningLog) << "SGroup " << sgIdx << " referenced on line "
-                              << line << " not found." << std::endl;
-      return;
-    }
+    unsigned int sgIdx;
+    PARSE_SGROUP_INT_FIELD_OR_FAIL(nullptr, sgIdx, strictParsing, text, line,
+                                   pos);
+    SubstanceGroup *sgroup;
+    FIND_SGIDX_OR_FAIL(sgroup, sGroupMap, sgIdx, line);
 
-    sGroupMap.at(sgIdx).setProp("ESTATE", "E");
+    sgroup->setProp("ESTATE", "E");
   }
 }
 
 void ParseSGroupV2000SBVLine(IDX_TO_SGROUP_MAP &sGroupMap, RWMol *mol,
-                             const std::string &text, unsigned int line) {
+                             const std::string &text, unsigned int line,
+                             bool strictParsing) {
   PRECONDITION(mol, "bad mol");
   PRECONDITION(text.substr(0, 6) == "M  SBV", "bad SBV line");
 
   unsigned int pos = 6;
+  unsigned int sgIdx;
+  PARSE_SGROUP_INT_FIELD_OR_FAIL(nullptr, sgIdx, strictParsing, text, line,
+                                 pos);
+  SubstanceGroup *sgroup;
+  FIND_SGIDX_OR_FAIL(sgroup, sGroupMap, sgIdx, line);
 
-  unsigned int sgIdx = ParseSGroupIntField(text, line, pos);
-  if (sGroupMap.find(sgIdx) == sGroupMap.end()) {
-    BOOST_LOG(rdWarningLog) << "SGroup " << sgIdx << " referenced on line "
-                            << line << " not found." << std::endl;
-    return;
-  }
-  auto &sgroup = sGroupMap.at(sgIdx);
-
-  unsigned int bondMark = ParseSGroupIntField(text, line, pos);
+  unsigned int bondMark;
+  PARSE_SGROUP_INT_FIELD_OR_FAIL(sgroup, bondMark, strictParsing, text, line,
+                                 pos);
   Bond *bond = mol->getUniqueBondWithBookmark(bondMark);
 
   RDGeom::Point3D vector;
-  if (sgroup.getProp<std::string>("TYPE") == "SUP") {
-    vector.x = ParseSGroupDoubleField(text, line, pos);
-    vector.y = ParseSGroupDoubleField(text, line, pos);
+  if (sgroup->getProp<std::string>("TYPE") == "SUP") {
+    PARSE_SGROUP_DOUBLE_FIELD_OR_FAIL(sgroup, vector.x, strictParsing, text,
+                                      line, pos);
+    PARSE_SGROUP_DOUBLE_FIELD_OR_FAIL(sgroup, vector.y, strictParsing, text,
+                                      line, pos);
     vector.z = 0.;
   }
 
-  sgroup.addCState(bond->getIdx(), vector);
+  try {
+    sgroup->addCState(bond->getIdx(), vector);
+  } catch (const std::exception &e) {
+    SGROUP_FAIL(sgroup, FileParseException, strictParsing, e.what());
+  }
 }
 
 void ParseSGroupV2000SDTLine(IDX_TO_SGROUP_MAP &sGroupMap, RWMol *mol,
-                             const std::string &text, unsigned int line) {
+                             const std::string &text, unsigned int line,
+                             bool strictParsing) {
   PRECONDITION(mol, "bad mol");
   PRECONDITION(text.substr(0, 6) == "M  SDT", "bad SDT line");
 
   unsigned int pos = 6;
-  unsigned int sgIdx = ParseSGroupIntField(text, line, pos);
-  auto &sgroup = sGroupMap.at(sgIdx);
-  if (sGroupMap.find(sgIdx) == sGroupMap.end()) {
-    BOOST_LOG(rdWarningLog) << "SGroup " << sgIdx << " referenced on line "
-                            << line << " not found." << std::endl;
-    return;
-  }
+  unsigned int sgIdx;
+  PARSE_SGROUP_INT_FIELD_OR_FAIL(nullptr, sgIdx, strictParsing, text, line,
+                                 pos);
+  SubstanceGroup *sgroup;
+  FIND_SGIDX_OR_FAIL(sgroup, sGroupMap, sgIdx, line);
 
   std::string fieldName;
   std::string fieldType;
@@ -396,32 +503,31 @@ void ParseSGroupV2000SDTLine(IDX_TO_SGROUP_MAP &sGroupMap, RWMol *mol,
   }
 
   if (fieldName.size()) {
-    sgroup.setProp("FIELDNAME", fieldName);
-    sgroup.setProp("FIELDTYPE", fieldType);
-    sgroup.setProp("FIELDINFO", fieldInfo);
-    sgroup.setProp("QUERYTYPE", queryType);
-    sgroup.setProp("QUERYOP", queryOp);
+    sgroup->setProp("FIELDNAME", fieldName);
+    sgroup->setProp("FIELDTYPE", fieldType);
+    sgroup->setProp("FIELDINFO", fieldInfo);
+    sgroup->setProp("QUERYTYPE", queryType);
+    sgroup->setProp("QUERYOP", queryOp);
   }
 }
 
 void ParseSGroupV2000SDDLine(IDX_TO_SGROUP_MAP &sGroupMap, RWMol *mol,
-                             const std::string &text, unsigned int line) {
+                             const std::string &text, unsigned int line,
+                             bool strictParsing) {
   PRECONDITION(mol, "bad mol");
   PRECONDITION(text.substr(0, 6) == "M  SDD", "bad SDD line");
 
   unsigned int pos = 6;
-  unsigned int sgIdx = ParseSGroupIntField(text, line, pos);
-  if (sGroupMap.find(sgIdx) == sGroupMap.end()) {
-    BOOST_LOG(rdWarningLog) << "SGroup " << sgIdx << " referenced on line "
-                            << line << " not found." << std::endl;
-    return;
-  }
+  unsigned int sgIdx;
+  PARSE_SGROUP_INT_FIELD_OR_FAIL(nullptr, sgIdx, strictParsing, text, line,
+                                 pos);
+  SubstanceGroup *sgroup;
+  FIND_SGIDX_OR_FAIL(sgroup, sGroupMap, sgIdx, line);
 
   // Store the rest of the line as is.
   ++pos;
   if (pos < text.length()) {
-    sGroupMap.at(sgIdx).setProp("FIELDDISP",
-                                text.substr(pos, text.length() - pos));
+    sgroup->setProp("FIELDDISP", text.substr(pos, text.length() - pos));
   }
 }
 
@@ -437,33 +543,30 @@ void ParseSGroupV2000SCDSEDLine(IDX_TO_SGROUP_MAP &sGroupMap,
   std::string type = text.substr(pos, 3);
   pos += 3;
 
-  unsigned int sgIdx = ParseSGroupIntField(text, line, pos);
-  if (sGroupMap.find(sgIdx) == sGroupMap.end()) {
-    BOOST_LOG(rdWarningLog) << "SGroup " << sgIdx << " referenced on line "
-                            << line << " not found." << std::endl;
-    return;
-  }
+  unsigned int sgIdx;
+  PARSE_SGROUP_INT_FIELD_OR_FAIL(nullptr, sgIdx, strictParsing, text, line,
+                                 pos);
+  SubstanceGroup *sgroup;
+  FIND_SGIDX_OR_FAIL(sgroup, sGroupMap, sgIdx, line);
 
   if (lastDataSGroup != 0 && lastDataSGroup != sgIdx) {
     std::ostringstream errout;
     errout << "Found a Data Field not matching the SGroup of the last Data "
               "Field at line "
            << line;
-    throw FileParseException(errout.str());
+    SGROUP_FAIL(sgroup, FileParseException, strictParsing, errout.str());
   } else if (lastDataSGroup == 0 && type == "SCD") {
     lastDataSGroup = sgIdx;
   } else if (type == "SED") {
     lastDataSGroup = 0;
   }
 
-  auto &sgroup = sGroupMap.at(sgIdx);
-
   // this group must already have seen an SDT line
-  if (!sgroup.hasProp("FIELDNAME")) {
+  if (!sgroup->hasProp("FIELDNAME")) {
     std::ostringstream errout;
     errout << "Found a SCD line without a previous SDT specification at line "
            << line;
-    throw FileParseException(errout.str());
+    SGROUP_FAIL(sgroup, FileParseException, strictParsing, errout.str());
   }
 
   if (strictParsing) {
@@ -490,159 +593,189 @@ void ParseSGroupV2000SCDSEDLine(IDX_TO_SGROUP_MAP &sGroupMap,
 }
 
 void ParseSGroupV2000SPLLine(IDX_TO_SGROUP_MAP &sGroupMap, RWMol *mol,
-                             const std::string &text, unsigned int line) {
+                             const std::string &text, unsigned int line,
+                             bool strictParsing) {
   PRECONDITION(mol, "bad mol");
   PRECONDITION(text.substr(0, 6) == "M  SPL", "bad SPL line");
 
   unsigned int pos = 6;
-  unsigned int nent = ParseSGroupIntField(text, line, pos, true);
+  unsigned int nent;
+  PARSE_SGROUP_INT_FIELD_OR_FAIL(nullptr, nent, strictParsing, text, line, pos,
+                                 true);
 
   for (unsigned int ie = 0; ie < nent; ++ie) {
     if (text.size() < pos + 8) {
       std::ostringstream errout;
       errout << "SGroup SPL line too short: '" << text << "' on line " << line;
-      throw FileParseException(errout.str());
+      SGROUP_FAIL(nullptr, FileParseException, strictParsing, errout.str());
     }
 
-    unsigned int sgIdx = ParseSGroupIntField(text, line, pos);
-    if (sGroupMap.find(sgIdx) == sGroupMap.end()) {
-      BOOST_LOG(rdWarningLog) << "SGroup " << sgIdx << " referenced on line "
-                              << line << " not found." << std::endl;
-      return;
-    }
+    unsigned int sgIdx;
+    PARSE_SGROUP_INT_FIELD_OR_FAIL(nullptr, sgIdx, strictParsing, text, line,
+                                   pos);
+    SubstanceGroup *sgroup;
+    FIND_SGIDX_OR_FAIL(sgroup, sGroupMap, sgIdx, line);
     unsigned int parentIdx = ParseSGroupIntField(text, line, pos);
 
-    sGroupMap.at(sgIdx).setProp<unsigned int>("PARENT", parentIdx);
+    sgroup->setProp<unsigned int>("PARENT", parentIdx);
   }
 }
 
 void ParseSGroupV2000SNCLine(IDX_TO_SGROUP_MAP &sGroupMap, RWMol *mol,
-                             const std::string &text, unsigned int line) {
+                             const std::string &text, unsigned int line,
+                             bool strictParsing) {
   PRECONDITION(mol, "bad mol");
   PRECONDITION(text.substr(0, 6) == "M  SNC", "bad SNC line");
 
   unsigned int pos = 6;
-  unsigned int nent = ParseSGroupIntField(text, line, pos, true);
+  unsigned int nent;
+  PARSE_SGROUP_INT_FIELD_OR_FAIL(nullptr, nent, strictParsing, text, line, pos,
+                                 true);
 
   for (unsigned int ie = 0; ie < nent; ++ie) {
     if (text.size() < pos + 8) {
       std::ostringstream errout;
       errout << "SGroup SNC line too short: '" << text << "' on line " << line;
-      throw FileParseException(errout.str());
+      SGROUP_FAIL(nullptr, FileParseException, strictParsing, errout.str());
     }
 
-    unsigned int sgIdx = ParseSGroupIntField(text, line, pos);
-    if (sGroupMap.find(sgIdx) == sGroupMap.end()) {
-      BOOST_LOG(rdWarningLog) << "SGroup " << sgIdx << " referenced on line "
-                              << line << " not found." << std::endl;
-      return;
-    }
+    unsigned int sgIdx;
+    PARSE_SGROUP_INT_FIELD_OR_FAIL(nullptr, sgIdx, strictParsing, text, line,
+                                   pos);
+    SubstanceGroup *sgroup;
+    FIND_SGIDX_OR_FAIL(sgroup, sGroupMap, sgIdx, line);
 
-    unsigned int compno = ParseSGroupIntField(text, line, pos);
+    unsigned int compno;
+    PARSE_SGROUP_INT_FIELD_OR_FAIL(sgroup, compno, strictParsing, text, line,
+                                   pos);
     if (compno > 256u) {
       std::ostringstream errout;
       errout << "SGroup SNC value over 256: '" << compno << "' on line "
              << line;
-      throw FileParseException(errout.str());
+      SGROUP_FAIL(sgroup, FileParseException, strictParsing, errout.str());
     }
-    sGroupMap.at(sgIdx).setProp<unsigned int>("COMPNO", compno);
+    sgroup->setProp<unsigned int>("COMPNO", compno);
   }
 }
 
 void ParseSGroupV2000SAPLine(IDX_TO_SGROUP_MAP &sGroupMap, RWMol *mol,
-                             const std::string &text, unsigned int line) {
+                             const std::string &text, unsigned int line,
+                             bool strictParsing) {
   PRECONDITION(mol, "bad mol");
   PRECONDITION(text.substr(0, 6) == "M  SAP", "bad SAP line");
 
   unsigned int pos = 6;
+  unsigned int sgIdx;
+  PARSE_SGROUP_INT_FIELD_OR_FAIL(nullptr, sgIdx, strictParsing, text, line,
+                                 pos);
+  SubstanceGroup *sgroup;
+  FIND_SGIDX_OR_FAIL(sgroup, sGroupMap, sgIdx, line);
 
-  unsigned int sgIdx = ParseSGroupIntField(text, line, pos);
-  if (sGroupMap.find(sgIdx) == sGroupMap.end()) {
-    BOOST_LOG(rdWarningLog) << "SGroup " << sgIdx << " referenced on line "
-                            << line << " not found." << std::endl;
-    return;
-  }
-
-  unsigned int nent = ParseSGroupIntField(text, line, pos, true);
+  unsigned int nent;
+  PARSE_SGROUP_INT_FIELD_OR_FAIL(sgroup, nent, strictParsing, text, line, pos,
+                                 true);
 
   for (unsigned int ie = 0; ie < nent; ++ie) {
+    int lvIdx = -1;
     if (text.size() < pos + 11) {
       std::ostringstream errout;
       errout << "SGroup SAP line too short: '" << text << "' on line " << line;
-      throw FileParseException(errout.str());
+      if (strictParsing) {
+        throw FileParseException(errout.str());
+      } else {
+        BOOST_LOG(rdWarningLog) << errout.str() << std::endl;
+        if (text.size() < pos + 4) {
+          sgroup->setIsValid(false);
+          return;
+        }
+        lvIdx = mol->getNumAtoms();
+      }
     }
 
-    unsigned int aIdxMark = ParseSGroupIntField(text, line, pos);
-    unsigned int lvIdxMark = ParseSGroupIntField(text, line, pos);
-
+    std::string id = "  ";
+    unsigned int aIdxMark;
+    PARSE_SGROUP_INT_FIELD_OR_FAIL(sgroup, aIdxMark, strictParsing, text, line,
+                                   pos);
     unsigned int aIdx = mol->getAtomWithBookmark(aIdxMark)->getIdx();
-    int lvIdx = -1;
 
-    if (lvIdxMark != 0) {
-      lvIdx = mol->getAtomWithBookmark(lvIdxMark)->getIdx();
+    if (lvIdx == -1) {
+      unsigned int lvIdxMark;
+      PARSE_SGROUP_INT_FIELD_OR_FAIL(sgroup, lvIdxMark, strictParsing, text,
+                                     line, pos);
+      if (lvIdxMark != 0) {
+        lvIdx = mol->getAtomWithBookmark(lvIdxMark)->getIdx();
+      }
+      if (text.size() >= pos + 3) {
+        id = text.substr(pos + 1, 2);
+        pos += 3;
+      }
     }
 
-    sGroupMap.at(sgIdx).addAttachPoint(aIdx, lvIdx, text.substr(pos + 1, 2));
-    pos += 3;
+    try {
+      sgroup->addAttachPoint(aIdx, lvIdx, id);
+    } catch (const std::exception &e) {
+      SGROUP_FAIL(sgroup, FileParseException, strictParsing, e.what());
+    }
   }
 }
 
 void ParseSGroupV2000SCLLine(IDX_TO_SGROUP_MAP &sGroupMap, RWMol *mol,
-                             const std::string &text, unsigned int line) {
+                             const std::string &text, unsigned int line,
+                             bool strictParsing) {
   PRECONDITION(mol, "bad mol");
   PRECONDITION(text.substr(0, 6) == "M  SCL", "bad SCL line");
 
   unsigned int pos = 6;
-
-  unsigned int sgIdx = ParseSGroupIntField(text, line, pos);
-  if (sGroupMap.find(sgIdx) == sGroupMap.end()) {
-    BOOST_LOG(rdWarningLog) << "SGroup " << sgIdx << " referenced on line "
-                            << line << " not found." << std::endl;
-    return;
-  }
+  unsigned int sgIdx;
+  PARSE_SGROUP_INT_FIELD_OR_FAIL(nullptr, sgIdx, strictParsing, text, line,
+                                 pos);
+  SubstanceGroup *sgroup;
+  FIND_SGIDX_OR_FAIL(sgroup, sGroupMap, sgIdx, line);
   if (pos + 1 >= text.length()) {
     std::ostringstream errout;
     errout << "SGroup SCL line too short: '" << text << "' on line " << line;
-    throw FileParseException(errout.str());
+    SGROUP_FAIL(sgroup, FileParseException, strictParsing, errout.str());
   }
 
   ++pos;
-  sGroupMap.at(sgIdx).setProp("CLASS", text.substr(pos, text.length() - pos));
+  sgroup->setProp("CLASS", text.substr(pos, text.length() - pos));
 }
 
 void ParseSGroupV2000SBTLine(IDX_TO_SGROUP_MAP &sGroupMap, RWMol *mol,
-                             const std::string &text, unsigned int line) {
+                             const std::string &text, unsigned int line,
+                             bool strictParsing) {
   PRECONDITION(mol, "bad mol");
   PRECONDITION(text.substr(0, 6) == "M  SBT", "bad SBT line");
 
   unsigned int pos = 6;
-  unsigned int nent = ParseSGroupIntField(text, line, pos, true);
+  unsigned int nent;
+  PARSE_SGROUP_INT_FIELD_OR_FAIL(nullptr, nent, strictParsing, text, line, pos,
+                                 true);
 
   for (unsigned int ie = 0; ie < nent; ++ie) {
     if (text.size() < pos + 8) {
       std::ostringstream errout;
       errout << "SGroup SBT line too short: '" << text << "' on line " << line;
-      throw FileParseException(errout.str());
+      SGROUP_FAIL(nullptr, FileParseException, strictParsing, errout.str());
     }
 
-    unsigned int sgIdx = ParseSGroupIntField(text, line, pos);
-    if (sGroupMap.find(sgIdx) == sGroupMap.end()) {
-      BOOST_LOG(rdWarningLog) << "SGroup " << sgIdx << " referenced on line "
-                              << line << " not found." << std::endl;
-      return;
-    }
-    unsigned int bracketType = ParseSGroupIntField(text, line, pos);
-
-    auto &sgroup = sGroupMap.at(sgIdx);
+    unsigned int sgIdx;
+    PARSE_SGROUP_INT_FIELD_OR_FAIL(nullptr, sgIdx, strictParsing, text, line,
+                                   pos);
+    SubstanceGroup *sgroup;
+    FIND_SGIDX_OR_FAIL(sgroup, sGroupMap, sgIdx, line);
+    unsigned int bracketType;
+    PARSE_SGROUP_INT_FIELD_OR_FAIL(sgroup, bracketType, strictParsing, text,
+                                   line, pos);
 
     if (bracketType == 0) {
-      sgroup.setProp("BRKTYP", "BRACKET");
+      sgroup->setProp("BRKTYP", "BRACKET");
     } else if (bracketType == 1) {
-      sgroup.setProp("BRKTYP", "PAREN");
+      sgroup->setProp("BRKTYP", "PAREN");
     } else {
       std::ostringstream errout;
       errout << "Invalid SBT value '" << bracketType << "' on line " << line;
-      throw FileParseException(errout.str());
+      SGROUP_FAIL(sgroup, FileParseException, strictParsing, errout.str());
     }
   }
 }
@@ -679,7 +812,8 @@ template std::vector<unsigned int> ParseV3000Array(std::stringstream &stream);
 template std::vector<int> ParseV3000Array(std::stringstream &stream);
 
 void ParseV3000CStateLabel(RWMol *mol, SubstanceGroup &sgroup,
-                           std::stringstream &stream, unsigned int line) {
+                           std::stringstream &stream, unsigned int line,
+                           bool strictParsing) {
   stream.get();  // discard parentheses
 
   unsigned int count;
@@ -691,7 +825,8 @@ void ParseV3000CStateLabel(RWMol *mol, SubstanceGroup &sgroup,
   if ((type != "SUP" && count != 1) || (type == "SUP" && count != 4)) {
     std::ostringstream errout;
     errout << "Unexpected number of fields for CSTATE field on line " << line;
-    throw FileParseException(errout.str());
+    SubstanceGroup *sgroupPtr = &sgroup;
+    SGROUP_FAIL(sgroupPtr, FileParseException, strictParsing, errout.str());
   }
 
   Bond *bond = mol->getUniqueBondWithBookmark(bondMark);
@@ -700,13 +835,18 @@ void ParseV3000CStateLabel(RWMol *mol, SubstanceGroup &sgroup,
   if (type == "SUP") {
     stream >> vector.x >> vector.y >> vector.z;
   }
-  sgroup.addCState(bond->getIdx(), vector);
+  try {
+    sgroup.addCState(bond->getIdx(), vector);
+  } catch (const std::exception &e) {
+    SubstanceGroup *sgroupPtr = &sgroup;
+    SGROUP_FAIL(sgroupPtr, FileParseException, strictParsing, e.what());
+  }
 
   stream.get();  // discard final parentheses
 }
 
 void ParseV3000SAPLabel(RWMol *mol, SubstanceGroup &sgroup,
-                        std::stringstream &stream) {
+                        std::stringstream &stream, bool strictParsing) {
   stream.get();  // discard parentheses
 
   unsigned int count;
@@ -731,7 +871,12 @@ void ParseV3000SAPLabel(RWMol *mol, SubstanceGroup &sgroup,
     }
   }
 
-  sgroup.addAttachPoint(aIdx, lvIdx, sapIdStr);
+  try {
+    sgroup.addAttachPoint(aIdx, lvIdx, sapIdStr);
+  } catch (const std::exception &e) {
+    SubstanceGroup *sgroupPtr = &sgroup;
+    SGROUP_FAIL(sgroupPtr, FileParseException, strictParsing, e.what());
+  }
 }
 
 std::string ParseV3000StringPropLabel(std::stringstream &stream) {
@@ -774,92 +919,100 @@ std::string ParseV3000StringPropLabel(std::stringstream &stream) {
 
 void ParseV3000ParseLabel(const std::string &label,
                           std::stringstream &lineStream, STR_VECT &dataFields,
-                          unsigned int &line, SubstanceGroup &sgroup,
-                          size_t nSgroups, RWMol *mol, bool &strictParsing) {
+                          unsigned int line, SubstanceGroup &sgroup,
+                          size_t nSgroups, RWMol *mol, bool strictParsing) {
   RDUNUSED_PARAM(nSgroups);
   // TODO: we could handle these in a more structured way
-  if (label == "XBHEAD" || label == "XBCORR") {
-    std::vector<unsigned int> bvect = ParseV3000Array<unsigned int>(lineStream);
-    std::transform(bvect.begin(), bvect.end(), bvect.begin(),
-                   [](unsigned int v) -> unsigned int { return v - 1; });
-    sgroup.setProp(label, bvect);
-  } else if (label == "ATOMS") {
-    for (auto atomIdx : ParseV3000Array<unsigned int>(lineStream)) {
-      sgroup.addAtomWithBookmark(atomIdx);
-    }
-  } else if (label == "PATOMS") {
-    for (auto patomIdx : ParseV3000Array<unsigned int>(lineStream)) {
-      sgroup.addParentAtomWithBookmark(patomIdx);
-    }
-  } else if (label == "CBONDS" || label == "XBONDS") {
-    for (auto bondIdx : ParseV3000Array<unsigned int>(lineStream)) {
-      sgroup.addBondWithBookmark(bondIdx);
-    }
-  } else if (label == "BRKXYZ") {
-    auto coords = ParseV3000Array<double>(lineStream);
-    if (coords.size() != 9) {
-      std::ostringstream errout;
-      errout << "Unexpected number of coordinates for BRKXYZ on line " << line;
-      throw FileParseException(errout.str());
-    }
+  try {
+    if (label == "XBHEAD" || label == "XBCORR") {
+      std::vector<unsigned int> bvect =
+          ParseV3000Array<unsigned int>(lineStream);
+      std::transform(bvect.begin(), bvect.end(), bvect.begin(),
+                     [](unsigned int v) -> unsigned int { return v - 1; });
+      sgroup.setProp(label, bvect);
+    } else if (label == "ATOMS") {
+      for (auto atomIdx : ParseV3000Array<unsigned int>(lineStream)) {
+        sgroup.addAtomWithBookmark(atomIdx);
+      }
+    } else if (label == "PATOMS") {
+      for (auto patomIdx : ParseV3000Array<unsigned int>(lineStream)) {
+        sgroup.addParentAtomWithBookmark(patomIdx);
+      }
+    } else if (label == "CBONDS" || label == "XBONDS") {
+      for (auto bondIdx : ParseV3000Array<unsigned int>(lineStream)) {
+        sgroup.addBondWithBookmark(bondIdx);
+      }
+    } else if (label == "BRKXYZ") {
+      auto coords = ParseV3000Array<double>(lineStream);
+      if (coords.size() != 9) {
+        std::ostringstream errout;
+        errout << "Unexpected number of coordinates for BRKXYZ on line "
+               << line;
+        throw FileParseException(errout.str());
+      }
 
-    SubstanceGroup::Bracket bracket;
-    for (unsigned int i = 0; i < 3; ++i) {
-      bracket[i] = RDGeom::Point3D(*(coords.begin() + (3 * i)),
-                                   *(coords.begin() + (3 * i) + 1),
-                                   *(coords.begin() + (3 * i) + 2));
-    }
-    sgroup.addBracket(bracket);
-  } else if (label == "CSTATE") {
-    ParseV3000CStateLabel(mol, sgroup, lineStream, line);
-  } else if (label == "SAP") {
-    ParseV3000SAPLabel(mol, sgroup, lineStream);
-  } else if (label == "PARENT") {
-    // Store relationship until all SGroups have been read
-    unsigned int parentIdx;
-    lineStream >> parentIdx;
-    sgroup.setProp<unsigned int>("PARENT", parentIdx);
-  } else if (label == "COMPNO") {
-    unsigned int compno;
-    lineStream >> compno;
-    if (compno > 256u) {
-      std::ostringstream errout;
-      errout << "SGroup SNC value over 256: '" << compno << "' on line "
-             << line;
-      throw FileParseException(errout.str());
-    }
-    sgroup.setProp<unsigned int>("COMPNO", compno);
-  } else if (label == "FIELDDATA") {
-    auto strValue = ParseV3000StringPropLabel(lineStream);
-    if (strictParsing) {
-      strValue = strValue.substr(0, 200);
-    }
-    dataFields.push_back(strValue);
+      SubstanceGroup::Bracket bracket;
+      for (unsigned int i = 0; i < 3; ++i) {
+        bracket[i] = RDGeom::Point3D(*(coords.begin() + (3 * i)),
+                                     *(coords.begin() + (3 * i) + 1),
+                                     *(coords.begin() + (3 * i) + 2));
+      }
+      sgroup.addBracket(bracket);
+    } else if (label == "CSTATE") {
+      ParseV3000CStateLabel(mol, sgroup, lineStream, line, strictParsing);
+    } else if (label == "SAP") {
+      ParseV3000SAPLabel(mol, sgroup, lineStream, strictParsing);
+    } else if (label == "PARENT") {
+      // Store relationship until all SGroups have been read
+      unsigned int parentIdx;
+      lineStream >> parentIdx;
+      sgroup.setProp<unsigned int>("PARENT", parentIdx);
+    } else if (label == "COMPNO") {
+      unsigned int compno;
+      lineStream >> compno;
+      if (compno > 256u) {
+        std::ostringstream errout;
+        errout << "SGroup SNC value over 256: '" << compno << "' on line "
+               << line;
+        throw FileParseException(errout.str());
+      }
+      sgroup.setProp<unsigned int>("COMPNO", compno);
+    } else if (label == "FIELDDATA") {
+      auto strValue = ParseV3000StringPropLabel(lineStream);
+      if (strictParsing) {
+        strValue = strValue.substr(0, 200);
+      }
+      dataFields.push_back(strValue);
 
-  } else {
-    // Parse string props
-    auto strValue = ParseV3000StringPropLabel(lineStream);
+    } else {
+      // Parse string props
+      auto strValue = ParseV3000StringPropLabel(lineStream);
 
-    if (label == "SUBTYPE" && !SubstanceGroupChecks::isValidSubType(strValue)) {
-      std::ostringstream errout;
-      errout << "Unsupported SGroup subtype '" << strValue << "' on line "
-             << line;
-      throw FileParseException(errout.str());
-    } else if (label == "CONNECT" &&
-               !SubstanceGroupChecks::isValidConnectType(strValue)) {
-      std::ostringstream errout;
-      errout << "Unsupported SGroup connection type '" << strValue
-             << "' on line " << line;
-      throw FileParseException(errout.str());
+      if (label == "SUBTYPE" &&
+          !SubstanceGroupChecks::isValidSubType(strValue)) {
+        std::ostringstream errout;
+        errout << "Unsupported SGroup subtype '" << strValue << "' on line "
+               << line;
+        throw FileParseException(errout.str());
+      } else if (label == "CONNECT" &&
+                 !SubstanceGroupChecks::isValidConnectType(strValue)) {
+        std::ostringstream errout;
+        errout << "Unsupported SGroup connection type '" << strValue
+               << "' on line " << line;
+        throw FileParseException(errout.str());
+      }
+
+      sgroup.setProp(label, strValue);
     }
-
-    sgroup.setProp(label, strValue);
+  } catch (const std::exception &e) {
+    SubstanceGroup *sgroupPtr = &sgroup;
+    SGROUP_FAIL(sgroupPtr, FileParseException, strictParsing, e.what());
   }
 }
 
-void ParseV3000SGroupsBlock(std::istream *inStream, unsigned int &line,
+void ParseV3000SGroupsBlock(std::istream *inStream, unsigned int line,
                             unsigned int nSgroups, RWMol *mol,
-                            bool &strictParsing) {
+                            bool strictParsing) {
   std::string tempStr = FileParserUtils::getV3000Line(inStream, line);
   boost::to_upper(tempStr);
   if (tempStr.length() < 12 || tempStr.substr(0, 12) != "BEGIN SGROUP") {
@@ -915,13 +1068,18 @@ void ParseV3000SGroupsBlock(std::istream *inStream, unsigned int &line,
         std::ostringstream errout;
         errout << "Existing SGroup ID '" << externalId
                << "' assigned to a second SGroup on line " << line;
-        throw FileParseException(errout.str());
+        if (strictParsing) {
+          throw FileParseException(errout.str());
+        } else {
+          BOOST_LOG(rdWarningLog) << errout.str() << std::endl;
+          sgroup.setIsValid(false);
+        }
       }
 
       sgroup.setProp<unsigned int>("ID", externalId);
     }
 
-    while (!lineStream.eof() && !lineStream.fail()) {
+    while (sgroup.getIsValid() && !lineStream.eof() && !lineStream.fail()) {
       char spacer;
       std::string label;
 
@@ -932,7 +1090,13 @@ void ParseV3000SGroupsBlock(std::istream *inStream, unsigned int &line,
         std::ostringstream errout;
         errout << "Found character '" << spacer
                << "' when expecting a separator (space) on line " << line;
-        throw FileParseException(errout.str());
+        if (strictParsing) {
+          throw FileParseException(errout.str());
+        } else {
+          BOOST_LOG(rdWarningLog) << errout.str() << std::endl;
+          sgroup.setIsValid(false);
+          continue;
+        }
       }
 
       std::getline(lineStream, label, '=');
@@ -944,7 +1108,7 @@ void ParseV3000SGroupsBlock(std::istream *inStream, unsigned int &line,
     // Process defaults
     lineStream.clear();
     lineStream.str(defaultString);
-    while (!lineStream.eof() && !lineStream.fail()) {
+    while (sgroup.getIsValid() && !lineStream.eof() && !lineStream.fail()) {
       char spacer;
       std::string label;
 
@@ -956,7 +1120,13 @@ void ParseV3000SGroupsBlock(std::istream *inStream, unsigned int &line,
         errout << "Found character '" << spacer
                << "' when expecting a separator (space) in DEFAULTS on line "
                << defaultLineNum;
-        throw FileParseException(errout.str());
+        if (strictParsing) {
+          throw FileParseException(errout.str());
+        } else {
+          BOOST_LOG(rdWarningLog) << errout.str() << std::endl;
+          sgroup.setIsValid(false);
+          continue;
+        }
       }
 
       std::getline(lineStream, label, '=');
@@ -969,7 +1139,13 @@ void ParseV3000SGroupsBlock(std::istream *inStream, unsigned int &line,
         if (spacer == ' ') {
           std::ostringstream errout;
           errout << "Found unexpected whitespace at DEFAULT label " << label;
-          throw FileParseException(errout.str());
+          if (strictParsing) {
+            throw FileParseException(errout.str());
+          } else {
+            BOOST_LOG(rdWarningLog) << errout.str() << std::endl;
+            sgroup.setIsValid(false);
+            continue;
+          }
         } else if (spacer == '(') {
           std::getline(lineStream, label, ')');
           lineStream.get(spacer);
@@ -999,7 +1175,12 @@ void ParseV3000SGroupsBlock(std::istream *inStream, unsigned int &line,
 
   // SGroups successfully parsed, now add them to the molecule
   for (const auto &sg : sGroupMap) {
-    addSubstanceGroup(*mol, sg.second);
+    if (sg.second.getIsValid()) {
+      addSubstanceGroup(*mol, sg.second);
+    } else {
+      BOOST_LOG(rdWarningLog) << "SGroup " << sg.first
+                              << " is invalid and will be ignored" << std::endl;
+    }
   }
 }
 

--- a/Code/GraphMol/FileParsers/MolSGroupParsing.h
+++ b/Code/GraphMol/FileParsers/MolSGroupParsing.h
@@ -25,40 +25,72 @@ unsigned int ParseSGroupIntField(const std::string &text, unsigned int line,
                                  unsigned int &pos,
                                  bool isFieldCounter = false);
 
+bool ParseSGroupIntField(unsigned int &var, bool strictParsing,
+                         const std::string &text, unsigned int line,
+                         unsigned int &pos, bool isFieldCounter = false);
+
 double ParseSGroupDoubleField(const std::string &text, unsigned int line,
                               unsigned int &pos);
 
+bool ParseSGroupDoubleField(double &var, bool strictParsing,
+                            const std::string &text, unsigned int line,
+                            unsigned int &pos);
+
+SubstanceGroup *FindSgIdx(IDX_TO_SGROUP_MAP &sGroupMap, int sgIdx,
+                          unsigned int line);
+
+template <class Exc>
+void SGroupWarnOrThrow(bool strictParsing, const std::string &msg) {
+  if (strictParsing) {
+    throw Exc(msg);
+  } else {
+    BOOST_LOG(rdWarningLog) << msg << std::endl;
+  }
+}
+
 void ParseSGroupV2000STYLine(IDX_TO_SGROUP_MAP &sGroupMap, RWMol *mol,
-                             const std::string &text, unsigned int line);
+                             const std::string &text, unsigned int line,
+                             bool strictParsing = true);
 
 void ParseSGroupV2000VectorDataLine(IDX_TO_SGROUP_MAP &sGroupMap, RWMol *mol,
-                                    const std::string &text, unsigned int line);
+                                    const std::string &text, unsigned int line,
+                                    bool strictParsing = true);
 
 void ParseSGroupV2000SDILine(IDX_TO_SGROUP_MAP &sGroupMap, RWMol *mol,
-                             const std::string &text, unsigned int line);
+                             const std::string &text, unsigned int line,
+                             bool strictParsing = true);
 
 void ParseSGroupV2000SSTLine(IDX_TO_SGROUP_MAP &sGroupMap, RWMol *mol,
-                             const std::string &text, unsigned int line);
+                             const std::string &text, unsigned int line,
+                             bool strictParsing = true);
 
 void ParseSGroupV2000SMTLine(IDX_TO_SGROUP_MAP &sGroupMap, RWMol *mol,
-                             const std::string &text, unsigned int line);
+                             const std::string &text, unsigned int line,
+                             bool strictParsing = true);
 
 void ParseSGroupV2000SLBLine(IDX_TO_SGROUP_MAP &sGroupMap, RWMol *mol,
-                             const std::string &text, unsigned int line);
+                             const std::string &text, unsigned int line,
+                             bool strictParsing = true);
 
 void ParseSGroupV2000SCNLine(IDX_TO_SGROUP_MAP &sGroupMap, RWMol *mol,
-                             const std::string &text, unsigned int line);
+                             const std::string &text, unsigned int line,
+                             bool strictParsing = true);
 
 void ParseSGroupV2000SDSLine(IDX_TO_SGROUP_MAP &sGroupMap, RWMol *mol,
-                             const std::string &text, unsigned int line);
+                             const std::string &text, unsigned int line,
+                             bool strictParsing = true);
+
 void ParseSGroupV2000SBVLine(IDX_TO_SGROUP_MAP &sGroupMap, RWMol *mol,
-                             const std::string &text, unsigned int line);
+                             const std::string &text, unsigned int line,
+                             bool strictParsing = true);
 
 void ParseSGroupV2000SDTLine(IDX_TO_SGROUP_MAP &sGroupMap, RWMol *mol,
-                             const std::string &text, unsigned int line);
+                             const std::string &text, unsigned int line,
+                             bool strictParsing = true);
 
 void ParseSGroupV2000SDDLine(IDX_TO_SGROUP_MAP &sGroupMap, RWMol *mol,
-                             const std::string &text, unsigned int line);
+                             const std::string &text, unsigned int line,
+                             bool strictParsing = true);
 
 void ParseSGroupV2000SCDSEDLine(IDX_TO_SGROUP_MAP &sGroupMap,
                                 IDX_TO_STR_VECT_MAP &dataFieldsMap, RWMol *mol,
@@ -68,19 +100,29 @@ void ParseSGroupV2000SCDSEDLine(IDX_TO_SGROUP_MAP &sGroupMap,
                                 std::ostringstream &currentDataField);
 
 void ParseSGroupV2000SPLLine(IDX_TO_SGROUP_MAP &sGroupMap, RWMol *mol,
-                             const std::string &text, unsigned int line);
+                             const std::string &text, unsigned int line,
+                             bool strictParsing = true);
 
 void ParseSGroupV2000SNCLine(IDX_TO_SGROUP_MAP &sGroupMap, RWMol *mol,
-                             const std::string &text, unsigned int line);
+                             const std::string &text, unsigned int line,
+                             bool strictParsing = true);
 
+//! if the SAP line is malformed and has no lvIdx and no id,
+//! lvIdx is set to mol->getNumAtoms() and id is set to "  "
+//! the user is responsible for replacing lvIdx with the correct
+//! index: if d_bonds.size() == 1, and one of the bond atom indices
+//! is aIdx, the other can be safely assigned to lvIdx
 void ParseSGroupV2000SAPLine(IDX_TO_SGROUP_MAP &sGroupMap, RWMol *mol,
-                             const std::string &text, unsigned int line);
+                             const std::string &text, unsigned int line,
+                             bool strictParsing = true);
 
 void ParseSGroupV2000SCLLine(IDX_TO_SGROUP_MAP &sGroupMap, RWMol *mol,
-                             const std::string &text, unsigned int line);
+                             const std::string &text, unsigned int line,
+                             bool strictParsing = true);
 
 void ParseSGroupV2000SBTLine(IDX_TO_SGROUP_MAP &sGroupMap, RWMol *mol,
-                             const std::string &text, unsigned int line);
+                             const std::string &text, unsigned int line,
+                             bool strictParsing = true);
 
 /* ------------------ V3000 Utils  ------------------ */
 
@@ -98,17 +140,18 @@ std::vector<T> ParseV3000Array(const std::string &s) {
   return ParseV3000Array<T>(stream);
 }
 
-void ParseV3000CStateLabel(unsigned int line, const std::string &type,
-                           SubstanceGroup *sgroup, std::stringstream &stream);
+void ParseV3000CStateLabel(RWMol *mol, SubstanceGroup &sgroup,
+                           std::stringstream &stream, unsigned int line,
+                           bool strictParsing = true);
 
-void ParseV3000SAPLabel(RWMol *mol, SubstanceGroup *sgroup,
-                        std::stringstream &stream);
+void ParseV3000SAPLabel(RWMol *mol, SubstanceGroup &sgroup,
+                        std::stringstream &stream, bool strictParsing = true);
 
 std::string ParseV3000StringPropLabel(std::stringstream &stream);
 
-void ParseV3000SGroupsBlock(std::istream *inStream, unsigned int &line,
+void ParseV3000SGroupsBlock(std::istream *inStream, unsigned int line,
                             unsigned int nSgroups, RWMol *mol,
-                            bool &strictParsing);
+                            bool strictParsing);
 
 }  // namespace SGroupParsing
 }  // namespace RDKit

--- a/Code/GraphMol/FileParsers/MolSGroupParsing.h
+++ b/Code/GraphMol/FileParsers/MolSGroupParsing.h
@@ -11,6 +11,7 @@
 
 #pragma once
 #include <GraphMol/SubstanceGroup.h>
+#include <RDGeneral/FileParseException.h>
 #include <sstream>
 
 namespace RDKit {
@@ -25,21 +26,22 @@ unsigned int ParseSGroupIntField(const std::string &text, unsigned int line,
                                  unsigned int &pos,
                                  bool isFieldCounter = false);
 
-bool ParseSGroupIntField(unsigned int &var, bool strictParsing,
-                         const std::string &text, unsigned int line,
-                         unsigned int &pos, bool isFieldCounter = false);
+unsigned int ParseSGroupIntField(bool &ok, bool strictParsing,
+                                 const std::string &text, unsigned int line,
+                                 unsigned int &pos,
+                                 bool isFieldCounter = false);
 
 double ParseSGroupDoubleField(const std::string &text, unsigned int line,
                               unsigned int &pos);
 
-bool ParseSGroupDoubleField(double &var, bool strictParsing,
-                            const std::string &text, unsigned int line,
-                            unsigned int &pos);
+double ParseSGroupDoubleField(bool &ok, bool strictParsing,
+                              const std::string &text, unsigned int line,
+                              unsigned int &pos);
 
 SubstanceGroup *FindSgIdx(IDX_TO_SGROUP_MAP &sGroupMap, int sgIdx,
                           unsigned int line);
 
-template <class Exc>
+template <class Exc = FileParseException>
 void SGroupWarnOrThrow(bool strictParsing, const std::string &msg) {
   if (strictParsing) {
     throw Exc(msg);

--- a/Code/GraphMol/FileParsers/MolSupplier.h
+++ b/Code/GraphMol/FileParsers/MolSupplier.h
@@ -173,7 +173,7 @@ class RDKIT_FILEPARSERS_EXPORT SDMolSupplier : public ForwardSDMolSupplier {
    *   \param sanitize - if true sanitize the molecule before returning it
    *   \param removeHs - if true remove Hs from the molecule before returning it
    *                     (triggers sanitization)
-   *   \param strictParsing - if not set, the parser is more lax about
+   *   \param strictParsing - if set to false, the parser is more lax about
    * correctness
    *                          of the contents.
    */

--- a/Code/GraphMol/ROMol.cpp
+++ b/Code/GraphMol/ROMol.cpp
@@ -237,7 +237,7 @@ ROMol::BOND_PTR_LIST &ROMol::getAllBondsWithBookmark(int mark) {
 // returns the unique bond with the given bookmark
 Bond *ROMol::getUniqueBondWithBookmark(int mark) {
   PRECONDITION(d_bondBookmarks.count(mark) == 1,
-               "multiple bons with same bookmark");
+               "multiple bonds with same bookmark");
   return getBondWithBookmark(mark);
 }
 

--- a/Code/GraphMol/SubstanceGroup.h
+++ b/Code/GraphMol/SubstanceGroup.h
@@ -112,6 +112,13 @@ class RDKIT_GRAPHMOL_EXPORT SubstanceGroup : public RDProps {
     return *dp_mol;
   }
 
+  //! returns whether or not this group is valid; invalid groups must be
+  //! ignored.
+  bool getIsValid() const { return d_isValid; }
+
+  //! set whether or not this group is valid; invalid groups must be ignored.
+  void setIsValid(bool isValid) { d_isValid = isValid; }
+
   //! get the index of this sgroup in dp_mol's sgroups vector
   //! (do not mistake this by the ID!)
   unsigned int getIndexInMol() const;
@@ -185,6 +192,8 @@ class RDKIT_GRAPHMOL_EXPORT SubstanceGroup : public RDProps {
 
  private:
   ROMol *dp_mol = nullptr;  // owning molecule
+
+  bool d_isValid = true;
 
   std::vector<unsigned int> d_atoms;
   std::vector<unsigned int> d_patoms;


### PR DESCRIPTION
<b>PR scope</b>
- eliminate some documentation ambiguity about the role of the `strictParsing` flag
- fix some inconsistencies between SGroup parsing function prototype declarations and implementations
- add a workaround for accepting malformed V2000 'M  SAP' entries affecting older version of MarvinJS (only if `strictParsing` is set to `false`)
- if `strictParsing` is set to `false`, malformed V2000/V3000 SGroups are ignored rather than causing the parsing to fail
- fix a couple typos in warnings

<b>PR motivation</b>
The motivation for this PR is that older versions of MarvinJS (`MJ2009`-`MJ2011`, and possibly later ones; `MJ2021` is not affected) are affected by a bug in the way the `M  SAP` entry is output.
For example, the MDL molblock generated for this molecule:
![image](https://user-images.githubusercontent.com/5244385/104003066-38893500-51a2-11eb-9706-932c202e1459.png)
is:
```

  MJ201100                      

 10 10  0  0  0  0  0  0  0  0999 V2000
   -1.7411    0.8920    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
   -2.4555    0.4795    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
   -2.4555   -0.3455    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
   -1.7411   -0.7580    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
   -1.0266   -0.3455    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
   -1.0266    0.4795    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
    0.1003    1.6065    0.0000 F   0  0  0  0  0  0  0  0  0  0  0  0
   -0.3121    0.8920    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
    0.1003    0.1775    0.0000 F   0  0  0  0  0  0  0  0  0  0  0  0
   -1.1371    0.8920    0.0000 F   0  0  0  0  0  0  0  0  0  0  0  0
  1  2  2  0  0  0  0
  2  3  1  0  0  0  0
  3  4  2  0  0  0  0
  4  5  1  0  0  0  0
  5  6  2  0  0  0  0
  6  1  1  0  0  0  0
  6  8  1  0  0  0  0
  7  8  1  0  0  0  0
  8  9  1  0  0  0  0
  8 10  1  0  0  0  0
M  STY  1   1 SUP
M  SAL   1  4   7   8   9  10
M  SMT   1 CF3
M  SBL   1  1   7
M  SAP   1  1   8
M  END
```
The `M  SAP` line according to specs should read (and it does in MarvinJS 2021):
```
M  SAP   1  1   8   6   
```
As a consequence, the RDKit chokes on this molecule and fails to read it altogether:
```
In [4]: Chem.MolFromMolBlock(molblock)
[11:30:42] SGroup SAP line too short: 'M  SAP   1  1   8' on line 29
```
Also the Indigo toolkit fails to read it.
ChemDraw reads it and displays the abbreviated CF<sub>3</sub> group without problems.
In fact, the missing `lvIdx` can be easily inferred from the single `M  SBL` entry.
So I implemented this simple workaround in the RDKit V2000 parser, such that the offending molecule can be parsed correctly with the correct SGroup in place if `strictParsing` is set to `false`:
```
In [5]: Chem.MolFromMolBlock(molblock, strictParsing=False)
[11:31:56] SGroup SAP line too short: 'M  SAP   1  1   8' on line 29
Out[5]: <rdkit.Chem.rdchem.Mol at 0x7f9a0066f4e0>
```
If `strictParsing` is set to `true`, the molecule still fails to read as it did before this PR.
```
In [6]: Chem.MolFromMolBlock(molblock, strictParsing=True)
[11:32:47] SGroup SAP line too short: 'M  SAP   1  1   8' on line 29
```
<b>PR further growth</b>
After I introduced the above workaround, I thought it was worth taking a further step, and avoiding that malformed SGroups may cause the whole parsing to fail. With the proposed changes, if `strictParsing` is set to `false`, malformed SGroups will be ignored and the molecule is still parsed with conforming SGroups in place.
If `strictParsing` is set to `true`, the molecule still fails to read as it did before this PR.
I introduced three macros which I think are useful to keep the code tidier and more concise.