### PR TITLE
Fixes #3692

### DIFF
--- a/Code/GraphMol/Abbreviations/Wrap/testAbbreviations.py
+++ b/Code/GraphMol/Abbreviations/Wrap/testAbbreviations.py
@@ -123,8 +123,16 @@ M  V30 END SGROUP
 M  V30 END CTAB
 M  END''')
     nm = rdAbbreviations.CondenseAbbreviationSubstanceGroups(m)
-    nm.RemoveAllConformers() # avoid coords in CXSMILES
+    nm.RemoveAllConformers()  # avoid coords in CXSMILES
     self.assertEqual(Chem.MolToCXSmiles(nm), '*C1CC1 |$CF3;;;$|')
+
+  def testGithub3692(self):
+    defaults = rdAbbreviations.GetDefaultAbbreviations()
+    self.assertIsNotNone(defaults[0].mol)
+    lbls = [x.label for x in defaults]
+    self.assertIn('CO2Et', lbls)
+    idx = lbls.index('CO2Et')
+    self.assertEqual(Chem.MolToSmiles(defaults[idx].mol), '*C(=O)OCC')
 
 
 if __name__ == '__main__':  # pragma: nocover

--- a/Code/GraphMol/Wrap/Mol.cpp
+++ b/Code/GraphMol/Wrap/Mol.cpp
@@ -781,6 +781,7 @@ struct mol_wrapper {
         .def("GetRingInfo", &ROMol::getRingInfo,
              python::return_value_policy<python::reference_existing_object>(),
              "Returns the number of molecule's RingInfo object.\n\n");
+    python::register_ptr_to_python<std::shared_ptr<ROMol>>();
 
     // ---------------------------------------------------------------------------------------------
     python::def("_HasSubstructMatchStr", HasSubstructMatchStr,


### PR DESCRIPTION
Does this by adding support for std::shared_ptr<ROMol> return values in the Python wrappers.

Now that we know this is possible (and easy), it's worth considering a large-scale cleanup action to ensure that all RDKit-wrapped objects support std::shared_ptr and to come up with a plan for switching to using it instead of boost::shared_ptr in the API


