### PR TITLE
Missing include in PR #3704

### DIFF
--- a/Code/GraphMol/Wrap/CompressedSDMolSupplier.cpp
+++ b/Code/GraphMol/Wrap/CompressedSDMolSupplier.cpp
@@ -23,6 +23,7 @@ namespace io = boost::iostreams;
 
 // ours
 #include <GraphMol/FileParsers/MolSupplier.h>
+#include <GraphMol/Wrap/ContextManagers.h>
 #include <GraphMol/RDKitBase.h>
 #include <RDBoost/Wrap.h>
 


### PR DESCRIPTION
I was building master on Mac, and the build failed with:

```
rdkit/Code/GraphMol/Wrap/CompressedSDMolSupplier.cpp:110:28: error: use of undeclared identifier 'MolIOEnter'
```

Apparently, this include was missing in the PR. I wonder how the CI build passed.
