### PR TITLE
PandasTools.LoadSDF -- read performance 

### DIFF
--- a/Code/GraphMol/Wrap/Mol.cpp
+++ b/Code/GraphMol/Wrap/Mol.cpp
@@ -687,7 +687,8 @@ struct mol_wrapper {
              "Removes a property from the molecule.\n\n"
              "  ARGUMENTS:\n"
              "    - key: the name of the property to clear (a string).\n")
-
+        .def("ClearProps", MolClearProps<ROMol>,
+             "Removes all properties from the molecule.\n\n")
         .def("ClearComputedProps", MolClearComputedProps<ROMol>,
              "Removes all computed properties from the molecule.\n\n")
 

--- a/Code/GraphMol/Wrap/props.hpp
+++ b/Code/GraphMol/Wrap/props.hpp
@@ -134,6 +134,11 @@ void MolClearProp(const RDOb &mol, const char *key) {
 }
 
 template <class RDOb>
+void MolClearProps(const RDOb &mol) {
+  mol.clearProps();
+}
+
+template <class RDOb>
 void MolClearComputedProps(const RDOb &mol) {
   mol.clearComputedProps();
 }

--- a/Code/RDGeneral/RDProps.h
+++ b/Code/RDGeneral/RDProps.h
@@ -141,6 +141,11 @@ class RDProps {
     d_props.clearVal(key);
   };
 
+  //! clears all \c properties
+  void clearProps() const {
+    d_props.reset();
+  };
+
   //! clears all of our \c computed \c properties
   void clearComputedProps() const {
     STR_VECT compLst;

--- a/rdkit/Chem/PandasTools.py
+++ b/rdkit/Chem/PandasTools.py
@@ -476,8 +476,7 @@ def LoadSDF(filename, idName='ID', molColName='ROMol', includeFingerprints=False
       continue
     row = dict((k, mol.GetProp(k)) for k in mol.GetPropNames())
     if molColName is not None and not embedProps:
-      for prop in mol.GetPropNames():
-        mol.ClearProp(prop)
+      mol.ClearProps()
     if mol.HasProp('_Name'):
       row[idName] = mol.GetProp('_Name')
     if smilesName is not None:


### PR DESCRIPTION
Hello!
I think that the PandasTools.LoadSDF code can be optimized to avoid iterative deletion of properties when reading the file (by default embedProps = False). Instead it will be nice to have a method that resets the entire property map.
The changes are rather small, while the speedup in reading large files can be significant (about 25% for a file with only ten thousand compounds with four properties).
I will be glad to hear your opinion on this proposal.