### PR TITLE
Addresses #3717

### DIFF
--- a/Code/GraphMol/Chirality.cpp
+++ b/Code/GraphMol/Chirality.cpp
@@ -1393,7 +1393,6 @@ std::pair<bool, bool> isAtomPotentialChiralCenter(
   // ranks:
   bool legalCenter = true;
   bool hasDupes = false;
-
   if (atom->getTotalDegree() > 4) {
     // we only know tetrahedral chirality
     legalCenter = false;
@@ -1402,10 +1401,12 @@ std::pair<bool, bool> isAtomPotentialChiralCenter(
     // ranks:
     if (atom->getTotalDegree() < 3) {
       legalCenter = false;
-    } else if (atom->getDegree() < 3 &&
-               (atom->getAtomicNum() != 15 && atom->getAtomicNum() != 33)) {
+    } else if (atom->getDegree() < 3 && atom->getAtomicNum() != 15 &&
+               atom->getAtomicNum() != 33 && atom->getAtomicNum() != 16 &&
+               atom->getAtomicNum() != 34 && atom->getAtomicNum() != 52) {
       // less than three neighbors is never stereogenic
-      // unless it is a phosphine/arsine with implicit H (this is from InChI)
+      // unless it is a trigonal pyramid with P/As/S/Se/Te as central atom
+      // with implicit H (P/As is from InChI)
       legalCenter = false;
     } else if (atom->getDegree() == 3 && atom->getTotalNumHs() != 1) {
       // assume something that's really three coordinate isn't potentially
@@ -1422,10 +1423,11 @@ std::pair<bool, bool> isAtomPotentialChiralCenter(
         // are always treated as stereogenic even with H atom neighbors.
         // (this is from InChI)
         legalCenter = true;
-      } else if (atom->getAtomicNum() == 16 || atom->getAtomicNum() == 34) {
+      } else if (atom->getAtomicNum() == 16 || atom->getAtomicNum() == 34 ||
+                 atom->getAtomicNum() == 52) {
         if (atom->getExplicitValence() == 4 ||
             (atom->getExplicitValence() == 3 && atom->getFormalCharge() == 1)) {
-          // we also accept sulfur or selenium with either a positive charge
+          // we also accept S, Se or Te with either a positive charge
           // or a double bond:
           legalCenter = true;
         }

--- a/Code/GraphMol/FindStereo.cpp
+++ b/Code/GraphMol/FindStereo.cpp
@@ -202,8 +202,9 @@ bool isBondPotentialStereoBond(const Bond *bond) {
     // check rings
     const auto ri = bond->getOwningMol().getRingInfo();
     for (const auto &bring : ri->bondRings()) {
-      if (bring.size() < 8 && std::find(bring.begin(), bring.end(),
-                                        bond->getIdx()) != bring.end()) {
+      if (bring.size() < 8 &&
+          std::find(bring.begin(), bring.end(), bond->getIdx()) !=
+              bring.end()) {
         return false;
       }
     }
@@ -227,10 +228,12 @@ bool isAtomPotentialTetrahedralCenter(const Atom *atom) {
     } else if (degree == 1) {
       // chirality is never possible with 1 nbr
       return false;
-    } else if (degree < 3 &&
-               (atom->getAtomicNum() != 15 && atom->getAtomicNum() != 33)) {
+    } else if (degree < 3 && atom->getAtomicNum() != 15 &&
+               atom->getAtomicNum() != 33 && atom->getAtomicNum() != 16 &&
+               atom->getAtomicNum() != 34 && atom->getAtomicNum() != 52) {
       // less than three neighbors is never stereogenic
-      // unless it is a phosphine/arsine with implicit H
+      // unless it is a trigonal pyramid with P/As/S/Se/Te as central atom
+      // with implicit H
       return false;
     } else if (atom->getAtomicNum() == 15 || atom->getAtomicNum() == 33) {
       // from logical flow: degree is 2 or 3 (implicit H)
@@ -246,9 +249,10 @@ bool isAtomPotentialTetrahedralCenter(const Atom *atom) {
         // otherwise we default to not being a legal center
         bool legalCenter = false;
         // but there are a few special cases we'll accept
-        // sulfur or selenium with either a positive charge or a double
+        // S, Se or Te with either a positive charge or a double
         // bond:
-        if ((atom->getAtomicNum() == 16 || atom->getAtomicNum() == 34) &&
+        if ((atom->getAtomicNum() == 16 || atom->getAtomicNum() == 34 ||
+             atom->getAtomicNum() == 52) &&
             (atom->getExplicitValence() == 4 ||
              (atom->getExplicitValence() == 3 &&
               atom->getFormalCharge() == 1))) {

--- a/Code/GraphMol/catch_graphmol.cpp
+++ b/Code/GraphMol/catch_graphmol.cpp
@@ -1225,6 +1225,97 @@ TEST_CASE("phosphine and arsine chirality", "[Chirality]") {
   }
 }
 
+TEST_CASE("S/Se/Te trigonal pyramid chirality", "[Chirality]") {
+  SECTION("chiral center recognized") {
+    auto mol1 = "C[S@](=C1CCCC1)C1=CC=CC=C1"_smiles;
+    auto mol2 = "C[Se@](=C1CCCC1)C1=CC=CC=C1"_smiles;
+    auto mol3 = "C[Te@](=C1CCCC1)C1=CC=CC=C1"_smiles;
+    REQUIRE(mol1);
+    REQUIRE(mol2);
+    REQUIRE(mol3);
+    CHECK(mol1->getAtomWithIdx(1)->getChiralTag() != Atom::CHI_UNSPECIFIED);
+    CHECK(mol2->getAtomWithIdx(1)->getChiralTag() != Atom::CHI_UNSPECIFIED);
+    CHECK(mol3->getAtomWithIdx(1)->getChiralTag() != Atom::CHI_UNSPECIFIED);
+  }
+  SECTION("chiral center selective") {
+    auto mol1 = "C[S@](C)=C1CCCCC1"_smiles;
+    auto mol2 = "C[Se@](C)=C1CCCCC1"_smiles;
+    auto mol3 = "C[Te@](C)=C1CCCCC1"_smiles;
+    REQUIRE(mol1);
+    REQUIRE(mol2);
+    REQUIRE(mol3);
+    CHECK(mol1->getAtomWithIdx(1)->getChiralTag() == Atom::CHI_UNSPECIFIED);
+    CHECK(mol2->getAtomWithIdx(1)->getChiralTag() == Atom::CHI_UNSPECIFIED);
+    CHECK(mol3->getAtomWithIdx(1)->getChiralTag() == Atom::CHI_UNSPECIFIED);
+  }
+  SECTION("chiral center specific: S") {
+    auto mol1 = "C[S@](=C1CCCC1)C1=CC=CC=C1"_smiles;
+    auto mol2 = "C[S@@](=C1CCCC1)C1=CC=CC=C1"_smiles;
+    REQUIRE(mol1);
+    REQUIRE(mol2);
+    CHECK(MolToSmiles(*mol1) != MolToSmiles(*mol2));
+  }
+  SECTION("chiral center specific: Se") {
+    auto mol1 = "C[Se@](=C1CCCC1)C1=CC=CC=C1"_smiles;
+    auto mol2 = "C[Se@@](=C1CCCC1)C1=CC=CC=C1"_smiles;
+    REQUIRE(mol1);
+    REQUIRE(mol2);
+    CHECK(MolToSmiles(*mol1) != MolToSmiles(*mol2));
+  }
+  SECTION("chiral center specific: Te") {
+    auto mol1 = "C[Te@](=C1CCCC1)C1=CC=CC=C1"_smiles;
+    auto mol2 = "C[Te@@](=C1CCCC1)C1=CC=CC=C1"_smiles;
+    REQUIRE(mol1);
+    REQUIRE(mol2);
+    CHECK(MolToSmiles(*mol1) != MolToSmiles(*mol2));
+  }
+  SECTION("chiral center, implicit H: S") {
+    auto mol1 = "C[S@H]=C1CCCCC1"_smiles;
+    auto mol2 = "C[S@@H]=C1CCCCC1"_smiles;
+    REQUIRE(mol1);
+    REQUIRE(mol2);
+    CHECK(mol1->getAtomWithIdx(1)->getChiralTag() != Atom::CHI_UNSPECIFIED);
+    CHECK(mol1->getAtomWithIdx(1)->getChiralTag() != Atom::CHI_UNSPECIFIED);
+  }
+  SECTION("chiral center, implicit H: Se") {
+    auto mol1 = "C[Se@H]=C1CCCCC1"_smiles;
+    auto mol2 = "C[Se@@H]=C1CCCCC1"_smiles;
+    REQUIRE(mol1);
+    REQUIRE(mol2);
+    CHECK(mol1->getAtomWithIdx(1)->getChiralTag() != Atom::CHI_UNSPECIFIED);
+    CHECK(mol1->getAtomWithIdx(1)->getChiralTag() != Atom::CHI_UNSPECIFIED);
+  }
+  SECTION("chiral center, implicit H: Te") {
+    auto mol1 = "C[Te@H]=C1CCCCC1"_smiles;
+    auto mol2 = "C[Te@@H]=C1CCCCC1"_smiles;
+    REQUIRE(mol1);
+    REQUIRE(mol2);
+    CHECK(mol1->getAtomWithIdx(1)->getChiralTag() != Atom::CHI_UNSPECIFIED);
+    CHECK(mol1->getAtomWithIdx(1)->getChiralTag() != Atom::CHI_UNSPECIFIED);
+  }
+  SECTION("chiral center specific, implicit H: S") {
+    auto mol1 = "C[S@H]=C1CCCCC1"_smiles;
+    auto mol2 = "C[S@@H]=C1CCCCC1"_smiles;
+    REQUIRE(mol1);
+    REQUIRE(mol2);
+    CHECK(MolToSmiles(*mol1) != MolToSmiles(*mol2));
+  }
+  SECTION("chiral center specific, implicit H: Se") {
+    auto mol1 = "C[Se@H]=C1CCCCC1"_smiles;
+    auto mol2 = "C[Se@@H]=C1CCCCC1"_smiles;
+    REQUIRE(mol1);
+    REQUIRE(mol2);
+    CHECK(MolToSmiles(*mol1) != MolToSmiles(*mol2));
+  }
+  SECTION("chiral center specific, implicit H: Te") {
+    auto mol1 = "C[Te@H]=C1CCCCC1"_smiles;
+    auto mol2 = "C[Te@@H]=C1CCCCC1"_smiles;
+    REQUIRE(mol1);
+    REQUIRE(mol2);
+    CHECK(MolToSmiles(*mol1) != MolToSmiles(*mol2));
+  }
+}
+
 TEST_CASE("github #2890", "[bug][molops][stereo]") {
   auto mol = "CC=CC"_smiles;
   REQUIRE(mol);


### PR DESCRIPTION
This resolves #3717 

This enables S/Se/Te atoms in the center of trigonal pyramids to be identified as chiral centers, in a similar way as phospine and Arsine.