### PR TITLE
Support new coordgen option to not always make bonds to metals zero-order

### DIFF
--- a/External/CoordGen/CMakeLists.txt
+++ b/External/CoordGen/CMakeLists.txt
@@ -82,24 +82,24 @@ if(RDK_BUILD_COORDGEN_SUPPORT)
     endif()
 
     if(NOT EXISTS "${COORDGEN_DIR}/sketcherMinimizer.h")
-        set(RELEASE_NO "1.4.1")
-        set(MD5 "d9a925c9569bc08e241a01669f43d639")
+        set(RELEASE_NO "1.4.2")
+        set(MD5 "47aa5fe6d8186b6c8d3b871d4400218a")
         downloadAndCheckMD5("https://github.com/schrodinger/coordgenlibs/archive/v${RELEASE_NO}.tar.gz"
               "${CMAKE_CURRENT_SOURCE_DIR}/coordgenlibs-${RELEASE_NO}.tar.gz" ${MD5})
         execute_process(COMMAND ${CMAKE_COMMAND} -E tar zxf
           ${CMAKE_CURRENT_SOURCE_DIR}/coordgenlibs-${RELEASE_NO}.tar.gz
           WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
         
-        # FIX: this is a workaround until https://github.com/schrodinger/coordgenlibs/pull/76
-        # is merged and a new coordgen release is done
         file(RENAME "coordgenlibs-${RELEASE_NO}" "${COORDGEN_DIR}")
-        set(fileToPatch "${COORDGEN_DIR}/CoordgenFragmenter.h")
-        configure_file("${fileToPatch}" "${fileToPatch}.orig" COPYONLY)
-        file(READ "${fileToPatch}" buffer)
-        string(REPLACE "class CoordgenFragmenter"
-          "#include \"CoordgenConfig.hpp\"\nclass EXPORT_COORDGEN CoordgenFragmenter" 
-          buffer "${buffer}")
-        file(WRITE "${fileToPatch}" "${buffer}")
+        # # FIX: this is a workaround until https://github.com/schrodinger/coordgenlibs/pull/76
+        # # is merged and a new coordgen release is done
+        # set(fileToPatch "${COORDGEN_DIR}/CoordgenFragmenter.h")
+        # configure_file("${fileToPatch}" "${fileToPatch}.orig" COPYONLY)
+        # file(READ "${fileToPatch}" buffer)
+        # string(REPLACE "class CoordgenFragmenter"
+        #   "#include \"CoordgenConfig.hpp\"\nclass EXPORT_COORDGEN CoordgenFragmenter" 
+        #   buffer "${buffer}")
+        # file(WRITE "${fileToPatch}" "${buffer}")
     else()
       message("-- Found coordgenlibs source in ${COORDGEN_DIR}")
     endif()

--- a/External/CoordGen/CoordGen.h
+++ b/External/CoordGen/CoordGen.h
@@ -34,10 +34,12 @@ struct CoordGenParams {
   // length of 50.
   std::string templateFileDir = "";
   float minimizerPrecision =
-      sketcherCoarsePrecision;  // controls sketch precision
-  bool dbg_useConstrained = true;   // debugging
-  bool dbg_useFixed = false;        // debugging
-  bool minimizeOnly = false;        // don't actually generate full coords
+      sketcherCoarsePrecision;     // controls sketch precision
+  bool dbg_useConstrained = true;  // debugging
+  bool dbg_useFixed = false;       // debugging
+  bool minimizeOnly = false;       // don't actually generate full coords
+  bool treatBondsToMetalAsZeroOrder =
+      false;  // set all bonds to metal atoms to be zero-order bonds
 };
 
 static CoordGenParams defaultParams;
@@ -74,6 +76,8 @@ unsigned int addCoords(T& mol, const CoordGenParams* params = nullptr) {
 
   sketcherMinimizer minimizer(params->minimizerPrecision);
   auto min_mol = new sketcherMinimizerMolecule();
+
+  minimizer.setTreatAllBondsToMetalAsZOBs(params->treatBondsToMetalAsZeroOrder);
 
   // FIX: only do this check once.
   // std::cerr << "  TEMPLATES: " << templateFileDir << std::endl;

--- a/External/CoordGen/Wrap/rdCoordGen.cpp
+++ b/External/CoordGen/Wrap/rdCoordGen.cpp
@@ -73,21 +73,26 @@ struct coordgen_wrapper {
                        "uses coordgen's force field to cleanup the 2D "
                        "coordinates of the active conformation")
         .def_readonly("sketcherBestPrecision",
-                       &CoordGen::CoordGenParams::sketcherBestPrecision,
-                       "highest quality (and slowest) precision setting")
+                      &CoordGen::CoordGenParams::sketcherBestPrecision,
+                      "highest quality (and slowest) precision setting")
         .def_readonly("sketcherStandardPrecision",
-                       &CoordGen::CoordGenParams::sketcherStandardPrecision,
-                       "standard quality precision setting, the default for the coordgen project")
+                      &CoordGen::CoordGenParams::sketcherStandardPrecision,
+                      "standard quality precision setting, the default for the "
+                      "coordgen project")
         .def_readonly("sketcherQuickPrecision",
-                       &CoordGen::CoordGenParams::sketcherQuickPrecision,
-                       "faster precision setting")
-        .def_readonly("sketcherCoarsePrecision",
-                       &CoordGen::CoordGenParams::sketcherCoarsePrecision,
-                       "\"coarse\" (fastest) precision setting, produces good-quality coordinates"
-                       " most of the time, this is the default setting for the RDKit")
+                      &CoordGen::CoordGenParams::sketcherQuickPrecision,
+                      "faster precision setting")
+        .def_readonly(
+            "sketcherCoarsePrecision",
+            &CoordGen::CoordGenParams::sketcherCoarsePrecision,
+            "\"coarse\" (fastest) precision setting, produces good-quality "
+            "coordinates"
+            " most of the time, this is the default setting for the RDKit")
         .def_readwrite("minimizerPrecision",
                        &CoordGen::CoordGenParams::minimizerPrecision,
-                       "controls sketcher precision");
+                       "controls sketcher precision")
+        .def_readwrite("treatBondsToMetalAsZOBs",
+                       &CoordGen::CoordGenParams::treatBondsToMetalAsZeroOrder);
     python::def("SetDefaultTemplateFileDir", SetDefaultTemplateFileDir);
     docString =
         "Add 2D coordinates.\n"


### PR DESCRIPTION
Coordgen's default behavior is to treat all bonds to metal atoms as zero order. In v1.4.2 an option was added to allow this behavior to be disabled.

This bumps the version of coordgen we expect from v1.4.1 to v1.4.2, allows that zero-order bond parameter to be changed, and modifies the default behavior so that bonds to metals are no longer set to zero order by default.

