### PR TITLE
Fixes #3216

### DIFF
--- a/Code/GraphMol/FileParsers/file_parsers_catch.cpp
+++ b/Code/GraphMol/FileParsers/file_parsers_catch.cpp
@@ -21,6 +21,7 @@
 #include <GraphMol/FileParsers/SequenceParsers.h>
 #include <GraphMol/FileParsers/SequenceWriters.h>
 #include <GraphMol/FileParsers/PNGParser.h>
+#include <GraphMol/FileParsers/MolFileStereochem.h>
 #include <RDGeneral/FileParseException.h>
 #include <boost/algorithm/string.hpp>
 
@@ -2931,4 +2932,43 @@ TEST_CASE("supplier close methods") {
     }
   }
 #endif
+}
+
+TEST_CASE("github #3216: WedgeMolBonds() should prefer degree-1 atoms") {
+  SECTION("basics") {
+    auto m = R"CTAB(
+  Mrv2007 06082008522D          
+ 
+  0  0  0     0  0            999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 8 7 0 0 0
+M  V30 BEGIN ATOM
+M  V30 1 C -17.7571 16.6703 0 0
+M  V30 2 C -16.4234 17.4403 0 0
+M  V30 3 C -15.0897 16.6703 0 0 CFG=1
+M  V30 4 C -13.7561 17.4403 0 0 CFG=2
+M  V30 5 Br -15.0897 15.1303 0 0
+M  V30 6 C -12.4225 16.6703 0 0
+M  V30 7 Cl -13.7561 18.9803 0 0
+M  V30 8 C -11.0888 17.4403 0 0
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 1 1 2
+M  V30 2 1 2 3
+M  V30 3 1 3 5 CFG=1
+M  V30 4 1 3 4
+M  V30 5 1 4 6
+M  V30 6 1 4 7 CFG=1
+M  V30 7 1 6 8
+M  V30 END BOND
+M  V30 END CTAB
+M  END)CTAB"_ctab;
+    REQUIRE(m);
+    WedgeMolBonds(*m, &m->getConformer());
+    CHECK(m->getBondBetweenAtoms(2, 4)->getBondDir() != Bond::BondDir::NONE);
+    CHECK(m->getBondBetweenAtoms(3, 6)->getBondDir() != Bond::BondDir::NONE);
+    CHECK(m->getBondBetweenAtoms(2, 1)->getBondDir() == Bond::BondDir::NONE);
+    CHECK(m->getBondBetweenAtoms(2, 3)->getBondDir() == Bond::BondDir::NONE);
+    CHECK(m->getBondBetweenAtoms(3, 5)->getBondDir() == Bond::BondDir::NONE);
+  }
 }

--- a/Code/GraphMol/MolDraw2D/test1.cpp
+++ b/Code/GraphMol/MolDraw2D/test1.cpp
@@ -2390,7 +2390,7 @@ void test16MoleculeMetadata() {
       outs.flush();
       TEST_ASSERT(text.find("idx=\"2\" atom-smiles=\"[NH]\" drawing-x=\"55.") !=
                   std::string::npos);
-      TEST_ASSERT(text.find("idx=\"2\" begin-atom-idx=\"3\" end-atom-idx=\"2\" "
+      TEST_ASSERT(text.find("idx=\"2\" begin-atom-idx=\"2\" end-atom-idx=\"3\" "
                             "bond-smiles=\"-\"") != std::string::npos);
     }
 


### PR DESCRIPTION
The scoring scheme which was being used to pick which bonds to wedge had the wrong relative contributions to weights, so low-degree connections to heavy atoms were not being favored as they should have been.

This fixes that.