### PR TITLE
Fix pillow error in IPythonConsole.py

### DIFF
--- a/rdkit/Chem/Draw/IPythonConsole.py
+++ b/rdkit/Chem/Draw/IPythonConsole.py
@@ -164,7 +164,7 @@ def display_pil_image(img):
   """displayhook function for PIL Images, rendered as PNG"""
   # pull metadata from the image, if there
   metadata = PngInfo()
-  for k, v in img.text.items():
+  for k, v in img.info.items():
     metadata.add_text(k, v)
   bio = BytesIO()
   img.save(bio, format='PNG', pnginfo=metadata)


### PR DESCRIPTION
Follow-up to #3690.

After importing IPythonConsole, regular PIL image rendering fails with:

```
FormatterWarning: Exception in image/png formatter: 'Image' object has no attribute 'text'
```

The current pillow [documentation](https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.Image.info) suggests that `text` should be replaced with `info`.

I've tested this with Google-internal colab; will run additional tests with Jupyter soon...