### PR TITLE
lock swig version in MacOS CI builds

### DIFF
--- a/.azure-pipelines/mac_build_java.yml
+++ b/.azure-pipelines/mac_build_java.yml
@@ -20,7 +20,7 @@ steps:
     conda create --name rdkit_build $(compiler) cmake \
         boost-cpp=$(boost_version) boost=$(boost_version) \
         py-boost=$(boost_version) libboost=$(boost_version) \
-        cairo eigen swig
+        cairo eigen swig=3
   displayName: Setup build environment
 - bash: |
     source ${CONDA}/etc/profile.d/conda.sh


### PR DESCRIPTION
SWIG 4.0 seems to be showing up in the MacOS CI builds, and the RDKit doesn't currently work there.
This locks SWIG at v3