### PR TITLE
Issue a warning when embedding a molecule with no Hs

### DIFF
--- a/Code/GraphMol/AddHs.cpp
+++ b/Code/GraphMol/AddHs.cpp
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2003-2019 Greg Landrum and Rational Discovery LLC
+//  Copyright (C) 2003-2021 Greg Landrum and Rational Discovery LLC
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -19,6 +19,7 @@
 #include <boost/algorithm/string/trim.hpp>
 #include <boost/algorithm/string/classification.hpp>
 #include <boost/dynamic_bitset.hpp>
+#include <boost/range/iterator_range.hpp>
 
 namespace RDKit {
 
@@ -1138,5 +1139,23 @@ ROMol *mergeQueryHs(const ROMol &mol, bool mergeUnmappedOnly) {
   return static_cast<ROMol *>(res);
 };
 
-};  // end of namespace MolOps
-};  // namespace RDKit
+bool needsHs(const ROMol &mol) {
+  for (const auto atom : mol.atoms()) {
+    unsigned int nHNbrs = 0;
+    for (const auto nbri :
+         boost::make_iterator_range(mol.getAtomNeighbors(atom))) {
+      const auto nbr = mol[nbri];
+      if (nbr->getAtomicNum() == 1) {
+        ++nHNbrs;
+      }
+    }
+    bool noNeighbors = false;
+    if (atom->getTotalNumHs(noNeighbors) > nHNbrs) {
+      return true;
+    }
+  }
+  return false;
+}
+
+}  // end of namespace MolOps
+}  // namespace RDKit

--- a/Code/GraphMol/DistGeomHelpers/Embedder.cpp
+++ b/Code/GraphMol/DistGeomHelpers/Embedder.cpp
@@ -80,7 +80,7 @@ const EmbedParameters KDG(0,        // maxIterations
                           false,    // useSmallRingTorsions
                           false,    // useMacrocycleTorsions
                           false,    // useMacrocycle14config
-                          nullptr,   // CPCI
+                          nullptr,  // CPCI
                           nullptr   // callback
 );
 
@@ -109,7 +109,7 @@ const EmbedParameters ETDG(0,        // maxIterations
                            false,    // useSmallRingTorsions
                            false,    // useMacrocycleTorsions
                            false,    // useMacrocycle14config
-                           nullptr,   // CPCI
+                           nullptr,  // CPCI
                            nullptr   // callback
 );
 //! Parameters corresponding to Sereina Riniker's ETKDG approach
@@ -137,7 +137,7 @@ const EmbedParameters ETKDG(0,        // maxIterations
                             false,    // useSmallRingTorsions
                             false,    // useMacrocycleTorsions
                             false,    // useMacrocycle14config
-                            nullptr,   // CPCI
+                            nullptr,  // CPCI
                             nullptr   // callback
 );
 
@@ -166,7 +166,7 @@ const EmbedParameters ETKDGv2(0,        // maxIterations
                               false,    // useSmallRingTorsions
                               false,    // useMacrocycleTorsions
                               false,    // useMacrocycle14config
-                              nullptr,   // CPCI
+                              nullptr,  // CPCI
                               nullptr   // callback
 );
 
@@ -196,7 +196,7 @@ const EmbedParameters ETKDGv3(0,        // maxIterations
                               false,    // useSmallRingTorsions
                               true,     // useMacrocycleTorsions
                               true,     // useMacrocycle14config
-                              nullptr,   // CPCI
+                              nullptr,  // CPCI
                               nullptr   // callback
 );
 
@@ -226,7 +226,7 @@ const EmbedParameters srETKDGv3(0,        // maxIterations
                                 true,     // useSmallRingTorsions
                                 false,    // useMacrocycleTorsions
                                 false,    // useMacrocycle14config
-                                nullptr,   // CPCI
+                                nullptr,  // CPCI
                                 nullptr   // callback
 );
 
@@ -717,7 +717,7 @@ bool embedPoints(RDGeom::PointPtrVect *positions, detail::EmbedArgs eargs,
   unsigned int iter = 0;
   while ((gotCoords == false) && (iter < embedParams.maxIterations)) {
     ++iter;
-    if(embedParams.callback != nullptr) {
+    if (embedParams.callback != nullptr) {
       embedParams.callback(iter);
     }
     gotCoords = EmbeddingOps::generateInitialCoords(positions, eargs,
@@ -1061,6 +1061,12 @@ void EmbedMultipleConfs(ROMol &mol, INT_VECT &res, unsigned int numConfs,
     throw ValueErrorException(
         "Only version 1 and 2 of the experimental "
         "torsion-angle preferences (ETversion) supported");
+  }
+
+  if (MolOps::needsHs(mol)) {
+    BOOST_LOG(rdWarningLog)
+        << "Molecule does not have explicit Hs. Consider calling AddHs()"
+        << std::endl;
   }
 
   // initialize the conformers we're going to be creating:

--- a/Code/GraphMol/ForceFieldHelpers/MMFF/testMMFFHelpers.cpp
+++ b/Code/GraphMol/ForceFieldHelpers/MMFF/testMMFFHelpers.cpp
@@ -948,7 +948,9 @@ void testMMFFMultiThread() {
     fut.get();
   }
 
-  for (auto *mol : mols) { delete mol; }
+  for (auto *mol : mols) {
+    delete mol;
+  }
   BOOST_LOG(rdErrorLog) << "  done" << std::endl;
 }
 
@@ -1073,6 +1075,8 @@ void testGithub224() {
 //-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
 int main() {
   RDLog::InitLogs();
+  // we get a ton of warnings here about missing Hs... disable them
+  boost::logging::disable_logs("rdApp.warning");
 #if 1
   testMMFFTyper1();
   testMMFFBuilder1();

--- a/Code/GraphMol/ForceFieldHelpers/MMFF/testMultiThread.cpp
+++ b/Code/GraphMol/ForceFieldHelpers/MMFF/testMultiThread.cpp
@@ -53,7 +53,7 @@ void testMMFFMultiThread() {
   pathName += "/Code/GraphMol/ForceFieldHelpers/MMFF/test_data";
   SDMolSupplier suppl(pathName + "/bulk.sdf");
   unsigned int count = 24;
-  std::vector<std::vector<ROMol*>> mols;
+  std::vector<std::vector<ROMol *>> mols;
   for (unsigned int i = 0; i < count; ++i) {
     mols.emplace_back();
   }
@@ -62,7 +62,7 @@ void testMMFFMultiThread() {
     ROMol *mol = nullptr;
     try {
       mol = suppl.next();
-      for(unsigned int i=0;i<count;++i) {
+      for (unsigned int i = 0; i < count; ++i) {
         if (i == 0) {
           mols[i].push_back(mol);
         } else {
@@ -86,8 +86,10 @@ void testMMFFMultiThread() {
     fut.get();
   }
   std::cerr << "done" << std::endl;
-  for(unsigned int i=0; i<count; ++i)
-    for (auto *mol : mols[i]) { delete mol; }
+  for (unsigned int i = 0; i < count; ++i)
+    for (auto *mol : mols[i]) {
+      delete mol;
+    }
 
   BOOST_LOG(rdErrorLog) << "  done" << std::endl;
 }
@@ -98,6 +100,9 @@ void testMMFFMultiThread() {
 //-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
 int main() {
   RDLog::InitLogs();
+  // we get a ton of warnings here about missing Hs... disable them
+  boost::logging::disable_logs("rdApp.warning");
+
 #ifdef RDK_TEST_MULTITHREADED
   testMMFFMultiThread();
 #endif

--- a/Code/GraphMol/ForceFieldHelpers/UFF/Builder.cpp
+++ b/Code/GraphMol/ForceFieldHelpers/UFF/Builder.cpp
@@ -699,6 +699,12 @@ ForceFields::ForceField *constructForceField(ROMol &mol,
                                              bool ignoreInterfragInteractions) {
   PRECONDITION(mol.getNumAtoms() == params.size(), "bad parameters");
 
+  if (MolOps::needsHs(mol)) {
+    BOOST_LOG(rdWarningLog)
+        << "Molecule does not have explicit Hs. Consider calling AddHs()"
+        << std::endl;
+  }
+
   auto *res = new ForceFields::ForceField();
 
   // add the atomic positions:

--- a/Code/GraphMol/ForceFieldHelpers/UFF/testUFFHelpers.cpp
+++ b/Code/GraphMol/ForceFieldHelpers/UFF/testUFFHelpers.cpp
@@ -1278,7 +1278,9 @@ void testUFFMultiThread() {
     fut.get();
   }
 
-  for (auto *mol : mols) { delete mol; }
+  for (auto *mol : mols) {
+    delete mol;
+  }
   BOOST_LOG(rdErrorLog) << "  done" << std::endl;
 }
 
@@ -1401,6 +1403,9 @@ void testGitHubIssue613() {
 //-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
 int main() {
   RDLog::InitLogs();
+  // we get a ton of warnings here about missing Hs... disable them
+  boost::logging::disable_logs("rdApp.warning");
+
 #if 1
   testUFFTyper1();
   testUFFTyper2();

--- a/Code/GraphMol/MolOps.h
+++ b/Code/GraphMol/MolOps.h
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2001-2019 Greg Landrum and Rational Discovery LLC
+//  Copyright (C) 2001-2021 Greg Landrum and Rational Discovery LLC
 //  Copyright (c) 2014, Novartis Institutes for BioMedical Research Inc.
 //
 //   @@ All Rights Reserved @@
@@ -850,69 +850,6 @@ RDKIT_GRAPHMOL_EXPORT std::list<int> getShortestPath(const ROMol &mol, int aid1,
 
 //@}
 
-#if 0
-    //! \name Canonicalization
-    //@{
-
-    //! assign a canonical ordering to a molecule's atoms
-    /*!
-      The algorithm used here is a modification of the published Daylight canonical
-      smiles algorithm (i.e. it uses atom invariants and products of primes).
-
-      \param mol               the molecule of interest
-      \param ranks             used to return the ranks
-      \param breakTies         toggles breaking of ties (see below)
-      \param includeChirality  toggles inclusion of chirality in the invariants
-      \param includeIsotopes   toggles inclusion of isotopes in the invariants
-      \param rankHistory       used to return the rank history (see below)
-
-      <b>Notes:</b>
-        - Tie breaking should be done when it's important to have a full ordering
-          of the atoms (e.g. when generating canonical traversal trees). If it's
-	        acceptable to have ties between symmetry-equivalent atoms (e.g. when
-	        generating CIP codes), tie breaking can/should be skipped.
-	      - if the \c rankHistory argument is provided, the evolution of the ranks of
-	        individual atoms will be tracked.  The \c rankHistory pointer should be
-	        to a VECT_INT_VECT that has at least \c mol.getNumAtoms() elements.
-    */
-    RDKIT_GRAPHMOL_EXPORT void rankAtoms(const ROMol &mol,std::vector<int> &ranks,
-                   bool breakTies=true,
-                   bool includeChirality=true,
-                   bool includeIsotopes=true,
-                   std::vector<std::vector<int> > *rankHistory=0);
-    //! assign a canonical ordering to a sub-molecule's atoms
-    /*!
-      The algorithm used here is a modification of the published Daylight canonical
-      smiles algorithm (i.e. it uses atom invariants and products of primes).
-
-      \param mol               the molecule of interest
-      \param atomsToUse        atoms to be included
-      \param bondsToUse        bonds to be included
-      \param atomSymbols       symbols to use for the atoms in the output (these are
-                               used in place of atomic number and isotope information)
-      \param ranks             used to return the ranks
-      \param breakTies         toggles breaking of ties (see below)
-      \param rankHistory       used to return the rank history (see below)
-
-      <b>Notes:</b>
-        - Tie breaking should be done when it's important to have a full ordering
-          of the atoms (e.g. when generating canonical traversal trees). If it's
-	        acceptable to have ties between symmetry-equivalent atoms (e.g. when
-	        generating CIP codes), tie breaking can/should be skipped.
-	      - if the \c rankHistory argument is provided, the evolution of the ranks of
-	        individual atoms will be tracked.  The \c rankHistory pointer should be
-	        to a VECT_INT_VECT that has at least \c mol.getNumAtoms() elements.
-    */
-    RDKIT_GRAPHMOL_EXPORT void rankAtomsInFragment(const ROMol &mol,std::vector<int> &ranks,
-                             const boost::dynamic_bitset<> &atomsToUse,
-                             const boost::dynamic_bitset<> &bondsToUse,
-                             const std::vector<std::string> *atomSymbols=0,
-                             const std::vector<std::string> *bondSymbols=0,
-                             bool breakTies=true,
-                             std::vector<std::vector<int> > *rankHistory=0);
-
-    // @}
-#endif
 //! \name Stereochemistry
 //@{
 
@@ -1028,8 +965,6 @@ RDKIT_GRAPHMOL_EXPORT void removeStereochemistry(ROMol &mol);
 */
 RDKIT_GRAPHMOL_EXPORT void findPotentialStereoBonds(ROMol &mol,
                                                     bool cleanIt = false);
-//@}
-
 //! \brief Uses the molParity atom property to assign ChiralType to a molecule's
 //! atoms
 /*!
@@ -1040,9 +975,14 @@ RDKIT_GRAPHMOL_EXPORT void findPotentialStereoBonds(ROMol &mol,
 RDKIT_GRAPHMOL_EXPORT void assignChiralTypesFromMolParity(
     ROMol &mol, bool replaceExistingTags = true);
 
+//@}
+
 //! returns the number of atoms which have a particular property set
 RDKIT_GRAPHMOL_EXPORT unsigned getNumAtomsWithDistinctProperty(
     const ROMol &mol, std::string prop);
+
+//! returns whether or not a molecule needs to have Hs added to it.
+RDKIT_GRAPHMOL_EXPORT bool needsHs(const ROMol &mol);
 
 };  // end of namespace MolOps
 };  // end of namespace RDKit

--- a/Code/GraphMol/catch_graphmol.cpp
+++ b/Code/GraphMol/catch_graphmol.cpp
@@ -1,6 +1,5 @@
 //
-//
-//  Copyright (C) 2018-2020 Greg Landrum and T5 Informatics GmbH
+//  Copyright (C) 2018-2021 Greg Landrum and T5 Informatics GmbH
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -1422,5 +1421,33 @@ TEST_CASE("Additional oxidation states", "[chemistry]") {
       REQUIRE(m);
       CHECK(m->getAtomWithIdx(1)->getNumRadicalElectrons() == 0);
     }
+  }
+}
+
+TEST_CASE("needsHs function", "[chemistry]") {
+  SECTION("basics") {
+    const auto m = "CC"_smiles;
+    REQUIRE(m);
+    CHECK(MolOps::needsHs(*m));
+
+    // add a single H:
+    m->addAtom(new Atom(1));
+    m->addBond(0, 2, Bond::BondType::SINGLE);
+    MolOps::sanitizeMol(*m);
+    CHECK(MolOps::needsHs(*m));
+
+    // now add all the Hs:
+    MolOps::addHs(*m);
+    CHECK(!MolOps::needsHs(*m));
+  }
+  SECTION("radical") {
+    const auto m = "[O][O]"_smiles;
+    REQUIRE(m);
+    CHECK(!MolOps::needsHs(*m));
+  }
+  SECTION("none needed") {
+    const auto m = "FF"_smiles;
+    REQUIRE(m);
+    CHECK(!MolOps::needsHs(*m));
   }
 }


### PR DESCRIPTION
A not-infrequent source of confusion/bug reports is generating 3D conformations for molecules which don't have H atoms added.

This adds a simple test to detect if a molecule has all the explicit Hs it could have, calls that as part of the embedding code, and issues a warning when appropriate.

@ptosco : think it would be sensible to do the same thing when building the MMFF and UFF force fields? If so, I will go ahead and add it to this PR