### PR TITLE
Addresses issue #3815

### DIFF
--- a/Code/GraphMol/FileParsers/MaeMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/MaeMolSupplier.cpp
@@ -149,6 +149,8 @@ void parseChiralityLabel(RWMol &mol, const std::string &stereo_prop) {
     case 'S':  // S, ANS
       nSwaps = 1;
       break;
+    case '?':  // Undefined
+      return;
     default:
       break;
   }
@@ -456,16 +458,21 @@ ROMol *MaeMolSupplier::next() {
     build_mol(*mol, *d_next_struct, df_sanitize, df_removeHs);
   } catch (...) {
     delete mol;
+    moveToNextBlock();
     throw;
   }
 
+  moveToNextBlock();
+
+  return static_cast<ROMol *>(mol);
+}
+
+void MaeMolSupplier::moveToNextBlock() {
   try {
     d_next_struct = d_reader->next(mae::CT_BLOCK);
   } catch (const mae::read_exception &e) {
     d_stored_exc = e.what();
   }
-
-  return static_cast<ROMol *>(mol);
 }
 
 bool MaeMolSupplier::atEnd() { return d_next_struct == nullptr; }

--- a/Code/GraphMol/FileParsers/MolSupplier.h
+++ b/Code/GraphMol/FileParsers/MolSupplier.h
@@ -428,6 +428,9 @@ class RDKIT_FILEPARSERS_EXPORT MaeMolSupplier : public MolSupplier {
 
   virtual void close() { dp_sInStream.reset(); }
 
+ private:
+  void moveToNextBlock();
+
  protected:
   bool df_sanitize, df_removeHs;
   std::shared_ptr<schrodinger::mae::Reader> d_reader;

--- a/Code/GraphMol/FileParsers/testMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/testMolSupplier.cpp
@@ -121,7 +121,8 @@ int testMolSup() {
     TEST_ASSERT(nmol->getProp<std::string>("s_m_entry_name") ==
                 "NCI_aids_few.1");
     TEST_ASSERT(nmol->hasProp("r_f3d_dummy"));
-    TEST_ASSERT(std::abs(nmol->getProp<double>("r_f3d_dummy") - 42.123) < 0.0001);
+    TEST_ASSERT(std::abs(nmol->getProp<double>("r_f3d_dummy") - 42.123) <
+                0.0001);
 
     // Test atom properties
     TEST_ASSERT(nmol->getNumAtoms() == 19);
@@ -144,8 +145,8 @@ int testMolSup() {
       // The real property is only defined for i >= 10
       if (i >= 10) {
         TEST_ASSERT(atom->hasProp("r_f3d_dummy"));
-        TEST_ASSERT(std::abs(atom->getProp<double>("r_f3d_dummy") - (19.1 - i)) <
-                    0.0001);
+        TEST_ASSERT(std::abs(atom->getProp<double>("r_f3d_dummy") -
+                             (19.1 - i)) < 0.0001);
       } else {
         TEST_ASSERT(!atom->hasProp("r_f3d_dummy"));
       }
@@ -212,7 +213,32 @@ int testMolSup() {
         TEST_ASSERT(!at->hasProp(common_properties::_CIPCode));
       }
     }
-
+    {  // intentionally bad chirality label, intended to
+      // make sure we can step over parse errors
+      std::unique_ptr<ROMol> nmol;
+      try {
+        nmol.reset(maesup.next());
+      } catch (const Invar::Invariant &) {
+        // just ignore this failure
+      }
+      TEST_ASSERT(!nmol);
+    }
+    {  // "Undefined" chirality label
+      std::unique_ptr<ROMol> nmol(maesup.next());
+      TEST_ASSERT(nmol);
+      {
+        Atom *at = nmol->getAtomWithIdx(2);
+        TEST_ASSERT(at);
+        TEST_ASSERT(at->getChiralTag() == Atom::CHI_UNSPECIFIED);
+        TEST_ASSERT(!at->hasProp(common_properties::_CIPCode));
+      }
+      {
+        Atom *at = nmol->getAtomWithIdx(5);
+        TEST_ASSERT(at);
+        TEST_ASSERT(at->getChiralTag() == Atom::CHI_UNSPECIFIED);
+        TEST_ASSERT(!at->hasProp(common_properties::_CIPCode));
+      }
+    }
     TEST_ASSERT(maesup.atEnd());
   }
   {  // Test loop reading

--- a/Code/GraphMol/FileParsers/test_data/stereochem.mae
+++ b/Code/GraphMol/FileParsers/test_data/stereochem.mae
@@ -190,3 +190,127 @@ f_m_ct {
  } 
 } 
 
+f_m_ct { 
+ s_m_title
+ b_sd_chiral_flag
+ i_sd_version
+ s_st_Chirality_1
+ s_st_Chirality_2
+ i_m_ct_enhanced_stereo_status
+ i_m_ct_format
+ :::
+ "intentionally bad chirality props" 
+  0
+  0
+  2_bad_chirality 
+  5_?_6_2_7 
+  0
+  2
+ m_depend[2] { 
+  # First column is dependency index #
+  i_m_depend_dependency
+  s_m_depend_property
+  :::
+  1 10 s_st_Chirality_1 
+  2 10 s_st_Chirality_2 
+  :::
+ } 
+ m_atom[7] { 
+  # First column is atom index #
+  i_m_mmod_type
+  r_m_x_coord
+  r_m_y_coord
+  r_m_z_coord
+  i_m_residue_number
+  i_m_color
+  i_m_atomic_number
+  i_sd_original_parity
+  :::
+  1 57 -1.182200 -0.023400 0.000000 900 9 17 <>
+  2 3 -0.357200 -0.023400 0.000000 900 2 6 1
+  3 56 0.055100 0.690900 0.000000 900 8 9 <>
+  4 41 0.127600 -0.690900 0.000000 900 21 1 <>
+  5 4 0.467700 -0.023400 0.000000 900 2 6 1
+  6 56 1.182200 0.389000 0.000000 900 8 9 <>
+  7 6 1.135200 -0.508400 0.000000 900 2 6 <>
+  :::
+ } 
+ m_bond[6] { 
+  # First column is bond index #
+  i_m_from
+  i_m_to
+  i_m_order
+  i_sd_original_parity
+  :::
+  1 1 2 1 <>
+  2 2 5 1 <>
+  3 2 3 1 3
+  4 2 4 1 <>
+  5 5 7 1 1
+  6 5 6 1 <>
+  :::
+ } 
+} 
+
+
+f_m_ct { 
+ s_m_title
+ b_sd_chiral_flag
+ i_sd_version
+ s_st_Chirality_1
+ s_st_Chirality_2
+ i_m_ct_enhanced_stereo_status
+ i_m_ct_format
+ :::
+ "" 
+  0
+  0
+  2_?_1_3_5_4 
+  5_?_6_2_7 
+  0
+  2
+ m_depend[2] { 
+  # First column is dependency index #
+  i_m_depend_dependency
+  s_m_depend_property
+  :::
+  1 10 s_st_Chirality_1 
+  2 10 s_st_Chirality_2 
+  :::
+ } 
+ m_atom[7] { 
+  # First column is atom index #
+  i_m_mmod_type
+  r_m_x_coord
+  r_m_y_coord
+  r_m_z_coord
+  i_m_residue_number
+  i_m_color
+  i_m_atomic_number
+  i_sd_original_parity
+  :::
+  1 57 -1.182200 -0.023400 0.000000 900 9 17 <>
+  2 3 -0.357200 -0.023400 0.000000 900 2 6 1
+  3 56 0.055100 0.690900 0.000000 900 8 9 <>
+  4 41 0.127600 -0.690900 0.000000 900 21 1 <>
+  5 4 0.467700 -0.023400 0.000000 900 2 6 1
+  6 56 1.182200 0.389000 0.000000 900 8 9 <>
+  7 6 1.135200 -0.508400 0.000000 900 2 6 <>
+  :::
+ } 
+ m_bond[6] { 
+  # First column is bond index #
+  i_m_from
+  i_m_to
+  i_m_order
+  i_sd_original_parity
+  :::
+  1 1 2 1 <>
+  2 2 5 1 <>
+  3 2 3 1 3
+  4 2 4 1 <>
+  5 5 7 1 1
+  6 5 6 1 <>
+  :::
+ } 
+} 


### PR DESCRIPTION
This adds a case to consider "undefined" chirality when parsing chiral labels (it just skips the label translation, as it is unknown), as well as attempts to skip to the next CT block in case parsing fails.

This also adds two new cases to the tests: one with a malformed chiral label (to trigger a parsing failure), and another one that exercises the "undefined" chiral labels.
