### PR TITLE
Sanitize molecules when SMILES needs to be produced in PandasTools

### DIFF
--- a/rdkit/Chem/PandasTools.py
+++ b/rdkit/Chem/PandasTools.py
@@ -469,8 +469,9 @@ def LoadSDF(filename, idName='ID', molColName='ROMol', includeFingerprints=False
     close = None  # don't close an open file that was passed in
   records = []
   indices = []
+  sanitize = bool(molColName is not None or smilesName is not None)
   for i, mol in enumerate(
-      Chem.ForwardSDMolSupplier(f, sanitize=(molColName is not None), removeHs=removeHs,
+      Chem.ForwardSDMolSupplier(f, sanitize=sanitize, removeHs=removeHs,
                                 strictParsing=strictParsing)):
     if mol is None:
       continue


### PR DESCRIPTION
When loading SDF to a Pandas dataframe and discarding of molecules and retaining SMILES, the SDMolSupplier was not sanitizing the molecules before producing of SMILES. This tiny PR addresses this issue.

Additional change to improve the performance by getting property dict in one call instead of a loop over all properties.