### PR TITLE
Remove boost::foreach from public headers

### DIFF
--- a/Code/DataStructs/MultiFPBReader.cpp
+++ b/Code/DataStructs/MultiFPBReader.cpp
@@ -18,7 +18,6 @@
 #include <future>
 #endif
 
-#include <boost/foreach.hpp>
 #include "MultiFPBReader.h"
 #include <algorithm>
 
@@ -198,7 +197,7 @@ void get_containing_nbrs(
   res.clear();
   for (unsigned int i = 0; i < d_readers.size(); ++i) {
     std::vector<unsigned int> &r_res = accum[i];
-    BOOST_FOREACH (unsigned int ri, r_res) {
+    for (auto ri : r_res) {
       res.emplace_back(ri, i);
     }
   }
@@ -210,7 +209,7 @@ void get_containing_nbrs(
 
 void MultiFPBReader::init() {
   unsigned int nBits = 0;
-  BOOST_FOREACH (FPBReader *rdr, d_readers) {
+  for (auto *rdr : d_readers) {
     rdr->init();
     if (!nBits) {
       nBits = rdr->nBits();
@@ -228,7 +227,7 @@ MultiFPBReader::MultiFPBReader(std::vector<FPBReader *> &readers,
   df_init = false;
   df_takeOwnership = takeOwnership;
   df_initOnSearch = initOnSearch;
-  BOOST_FOREACH (FPBReader *rdr, readers) {
+  for (auto *rdr : readers) {
     PRECONDITION(rdr != nullptr, "bad reader");
   }
   d_readers = readers;
@@ -305,4 +304,4 @@ MultiFPBReader::getContainingNeighbors(const ExplicitBitVect &ebv,
   return res;
 }
 
-}  // end of RDKit namespace
+}  // namespace RDKit

--- a/Code/DataStructs/MultiFPBReader.h
+++ b/Code/DataStructs/MultiFPBReader.h
@@ -22,7 +22,6 @@
 #include <DataStructs/ExplicitBitVect.h>
 #include <DataStructs/FPBReader.h>
 #include <boost/tuple/tuple.hpp>
-#include <boost/foreach.hpp>
 
 namespace RDKit {
 
@@ -79,7 +78,7 @@ class RDKIT_DATASTRUCTS_EXPORT MultiFPBReader {
   ~MultiFPBReader() {
     df_init = false;
     if (df_takeOwnership) {
-      BOOST_FOREACH (FPBReader *rdr, d_readers) { delete rdr; };
+      for (auto& rdr : d_readers) { delete rdr; };
       d_readers.clear();
     }
   };

--- a/Code/Demos/RDKit/MPI/rdkexample2.cpp
+++ b/Code/Demos/RDKit/MPI/rdkexample2.cpp
@@ -17,7 +17,6 @@
 #include <vector>
 #include <algorithm>
 #include <boost/mpi.hpp>
-#include <boost/foreach.hpp>
 #include <iostream>
 #include <cstdlib>
 #include <string>
@@ -29,7 +28,7 @@ void broadcastMols(mpi::communicator &world,
   std::vector<std::string> data;
   if (world.rank() == 0) {
     data.reserve(mols.size());
-    BOOST_FOREACH (const RDKit::ROMOL_SPTR &ptr, mols) {
+    for (const auto &ptr : mols) {
       std::string pickle;
       RDKit::MolPickler::pickleMol(*ptr, pickle);
       data.push_back(pickle);
@@ -38,7 +37,7 @@ void broadcastMols(mpi::communicator &world,
   broadcast(world, data, 0);
   if (world.rank() != 0) {
     mols.reserve(data.size());
-    BOOST_FOREACH (const std::string &pickle, data) {
+    for (const std::string &pickle : data) {
       RDKit::ROMol *mol = new RDKit::ROMol;
       RDKit::MolPickler::molFromPickle(pickle, mol);
       mols.push_back(RDKit::ROMOL_SPTR(mol));
@@ -65,7 +64,7 @@ int main(int argc, char *argv[]) {
 
   // process it:
   std::vector<unsigned int> res;
-  std::vector<std::vector<unsigned int> > allRes;
+  std::vector<std::vector<unsigned int>> allRes;
   // start by finding our chunk:
   unsigned int nProcs = world.size();
   unsigned int chunkSize = data.size() / nProcs;

--- a/Code/ForceField/ForceField.cpp
+++ b/Code/ForceField/ForceField.cpp
@@ -169,7 +169,7 @@ ForceField::ForceField(const ForceField &other)
       d_numPoints(other.d_numPoints),
       dp_distMat(nullptr) {
   d_contribs.clear();
-  for (const ContribPtr &contrib : other.d_contribs) {
+  for (const auto &contrib : other.d_contribs) {
     ForceFieldContrib *ncontrib = contrib->copy();
     ncontrib->dp_forceField = this;
     d_contribs.push_back(ContribPtr(ncontrib));

--- a/Code/ForceField/ForceField.cpp
+++ b/Code/ForceField/ForceField.cpp
@@ -169,7 +169,7 @@ ForceField::ForceField(const ForceField &other)
       d_numPoints(other.d_numPoints),
       dp_distMat(nullptr) {
   d_contribs.clear();
-  BOOST_FOREACH (const ContribPtr &contrib, other.d_contribs) {
+  for (const ContribPtr &contrib : other.d_contribs) {
     ForceFieldContrib *ncontrib = contrib->copy();
     ncontrib->dp_forceField = this;
     d_contribs.push_back(ContribPtr(ncontrib));

--- a/Code/ForceField/ForceField.h
+++ b/Code/ForceField/ForceField.h
@@ -13,7 +13,6 @@
 
 #include <vector>
 #include <boost/smart_ptr.hpp>
-#include <boost/foreach.hpp>
 #include <Geometry/point.h>
 #include <GraphMol/Trajectory/Snapshot.h>
 

--- a/Code/ForceField/MMFF/testMMFFForceField.cpp
+++ b/Code/ForceField/MMFF/testMMFFForceField.cpp
@@ -402,7 +402,7 @@ int mmffValidationSuite(int argc, char *argv[]) {
           }
           delete mmffMolProperties;
         }
-        for (ROMol *m : molVec) { delete m; }
+        for (auto m : molVec) { delete m; }
         sdfWriter->close();
         delete sdfWriter;
         rdkFStream.close();

--- a/Code/ForceField/MMFF/testMMFFForceField.cpp
+++ b/Code/ForceField/MMFF/testMMFFForceField.cpp
@@ -402,7 +402,7 @@ int mmffValidationSuite(int argc, char *argv[]) {
           }
           delete mmffMolProperties;
         }
-        BOOST_FOREACH (ROMol *m, molVec) { delete m; }
+        for (ROMol *m : molVec) { delete m; }
         sdfWriter->close();
         delete sdfWriter;
         rdkFStream.close();

--- a/Code/Geometry/point.h
+++ b/Code/Geometry/point.h
@@ -45,11 +45,11 @@ class RDKIT_RDGEOMETRYLIB_EXPORT Point {
 // typedef class Point3D Point;
 class RDKIT_RDGEOMETRYLIB_EXPORT Point3D : public Point {
  public:
-  double x{ 0.0 };
-  double y{ 0.0 }; 
-  double z{ 0.0 };
+  double x{0.0};
+  double y{0.0};
+  double z{0.0};
 
-  Point3D()  {};
+  Point3D(){};
   Point3D(double xv, double yv, double zv) : x(xv), y(yv), z(zv){};
 
   ~Point3D(){};
@@ -84,6 +84,9 @@ class RDKIT_RDGEOMETRYLIB_EXPORT Point3D : public Point {
   }
 
   Point3D &operator=(const Point3D &other) {
+    if (&other == this) {
+      return *this;
+    }
     x = other.x;
     y = other.y;
     z = other.z;
@@ -259,10 +262,10 @@ RDKIT_RDGEOMETRYLIB_EXPORT double computeSignedDihedralAngle(
 
 class RDKIT_RDGEOMETRYLIB_EXPORT Point2D : public Point {
  public:
-  double x{ 0.0 };
-  double y{ 0.0 };
+  double x{0.0};
+  double y{0.0};
 
-  Point2D()  {};
+  Point2D(){};
   Point2D(double xv, double yv) : x(xv), y(yv){};
   ~Point2D(){};
 

--- a/Code/GraphMol/AddHs.cpp
+++ b/Code/GraphMol/AddHs.cpp
@@ -14,7 +14,6 @@
 #include "MonomerInfo.h"
 #include <Geometry/Transform3D.h>
 #include <Geometry/point.h>
-#include <boost/foreach.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/tokenizer.hpp>
 #include <boost/algorithm/string/trim.hpp>

--- a/Code/GraphMol/Atom.h
+++ b/Code/GraphMol/Atom.h
@@ -18,7 +18,6 @@
 
 // Std stuff
 #include <iostream>
-#include <boost/foreach.hpp>
 
 // ours
 #include <RDGeneral/Invariant.h>

--- a/Code/GraphMol/Bond.h
+++ b/Code/GraphMol/Bond.h
@@ -20,7 +20,6 @@
 #include <RDGeneral/types.h>
 #include <RDGeneral/RDProps.h>
 #include <GraphMol/details.h>
-#include <boost/foreach.hpp>
 
 namespace RDKit {
 class ROMol;

--- a/Code/GraphMol/ChemReactions/Reaction.cpp
+++ b/Code/GraphMol/ChemReactions/Reaction.cpp
@@ -35,7 +35,6 @@
 #include <GraphMol/Substruct/SubstructMatch.h>
 #include <GraphMol/QueryOps.h>
 #include <boost/dynamic_bitset.hpp>
-#include <boost/foreach.hpp>
 #include <map>
 #include <algorithm>
 #include <GraphMol/ChemTransforms/ChemTransforms.h>

--- a/Code/GraphMol/ChemReactions/ReactionDepict.cpp
+++ b/Code/GraphMol/ChemReactions/ReactionDepict.cpp
@@ -33,7 +33,6 @@
 
 #include <GraphMol/ChemReactions/Reaction.h>
 #include <GraphMol/Depictor/RDDepictor.h>
-#include <boost/foreach.hpp>
 
 namespace RDDepict {
 void compute2DCoordsForReaction(RDKit::ChemicalReaction &rxn, double spacing,
@@ -52,13 +51,11 @@ void compute2DCoordsForReaction(RDKit::ChemicalReaction &rxn, double spacing,
     compute2DCoords(**templIt, nullptr, canonOrient, true, nFlipsPerSample,
                     nSamples, sampleSeed, permuteDeg4Nodes);
     double minX = 100., maxX = -100.;
-    BOOST_FOREACH (RDGeom::Point3D &pt,
-                   (*templIt)->getConformer().getPositions()) {
+    for (auto &pt : (*templIt)->getConformer().getPositions()) {
       minX = std::min(pt.x, minX);
     }
     xOffset += minX;
-    BOOST_FOREACH (RDGeom::Point3D &pt,
-                   (*templIt)->getConformer().getPositions()) {
+    for (auto &pt : (*templIt)->getConformer().getPositions()) {
       pt.x += xOffset;
       maxX = std::max(pt.x, maxX);
     }
@@ -74,17 +71,15 @@ void compute2DCoordsForReaction(RDKit::ChemicalReaction &rxn, double spacing,
     compute2DCoords(**templIt, nullptr, canonOrient, true, nFlipsPerSample,
                     nSamples, sampleSeed, permuteDeg4Nodes);
     double minX = 100., maxX = -100.;
-    BOOST_FOREACH (RDGeom::Point3D &pt,
-                   (*templIt)->getConformer().getPositions()) {
+    for (auto &pt : (*templIt)->getConformer().getPositions()) {
       minX = std::min(pt.x, minX);
     }
     xOffset += minX;
-    BOOST_FOREACH (RDGeom::Point3D &pt,
-                   (*templIt)->getConformer().getPositions()) {
+    for (auto &pt : (*templIt)->getConformer().getPositions()) {
       pt.x += xOffset;
       maxX = std::max(pt.x, maxX);
     }
     xOffset = maxX + spacing;
   }
 }
-}  // end of namespace RDKit
+}  // namespace RDDepict

--- a/Code/GraphMol/ChemReactions/ReactionFingerprints.cpp
+++ b/Code/GraphMol/ChemReactions/ReactionFingerprints.cpp
@@ -53,8 +53,8 @@ RDKit::SparseIntVect<std::uint32_t> *generateFingerprint(
       RDKit::SparseIntVect<std::int32_t> *tmp1 =
           RDKit::AtomPairs::getHashedAtomPairFingerprint(mol, fpSize);
       res = new RDKit::SparseIntVect<std::uint32_t>(fpSize);
-      BOOST_FOREACH (
-          RDKit::SparseIntVect<std::int32_t>::StorageType::value_type val,
+      for (
+          RDKit::SparseIntVect<std::int32_t>::StorageType::value_type val :
           tmp1->getNonzeroElements()) {
         res->setVal(static_cast<std::uint32_t>(val.first), val.second);
       }
@@ -64,8 +64,8 @@ RDKit::SparseIntVect<std::uint32_t> *generateFingerprint(
       RDKit::SparseIntVect<boost::int64_t> *tmp2 =
           RDKit::AtomPairs::getHashedTopologicalTorsionFingerprint(mol, fpSize);
       res = new RDKit::SparseIntVect<std::uint32_t>(fpSize);
-      BOOST_FOREACH (
-          RDKit::SparseIntVect<boost::int64_t>::StorageType::value_type val,
+      for (
+          RDKit::SparseIntVect<boost::int64_t>::StorageType::value_type val :
           tmp2->getNonzeroElements()) {
         res->setVal(static_cast<std::uint32_t>(val.first), val.second);
       }

--- a/Code/GraphMol/ChemReactions/ReactionFingerprints.cpp
+++ b/Code/GraphMol/ChemReactions/ReactionFingerprints.cpp
@@ -53,9 +53,7 @@ RDKit::SparseIntVect<std::uint32_t> *generateFingerprint(
       RDKit::SparseIntVect<std::int32_t> *tmp1 =
           RDKit::AtomPairs::getHashedAtomPairFingerprint(mol, fpSize);
       res = new RDKit::SparseIntVect<std::uint32_t>(fpSize);
-      for (
-          RDKit::SparseIntVect<std::int32_t>::StorageType::value_type val :
-          tmp1->getNonzeroElements()) {
+      for (auto val : tmp1->getNonzeroElements()) {
         res->setVal(static_cast<std::uint32_t>(val.first), val.second);
       }
       delete tmp1;
@@ -64,9 +62,7 @@ RDKit::SparseIntVect<std::uint32_t> *generateFingerprint(
       RDKit::SparseIntVect<boost::int64_t> *tmp2 =
           RDKit::AtomPairs::getHashedTopologicalTorsionFingerprint(mol, fpSize);
       res = new RDKit::SparseIntVect<std::uint32_t>(fpSize);
-      for (
-          RDKit::SparseIntVect<boost::int64_t>::StorageType::value_type val :
-          tmp2->getNonzeroElements()) {
+      for (auto val : tmp2->getNonzeroElements()) {
         res->setVal(static_cast<std::uint32_t>(val.first), val.second);
       }
       delete tmp2;
@@ -120,14 +116,14 @@ ExplicitBitVect *generateFingerprintAsBitVect(RDKit::ROMol &mol,
   }
   return res;
 }
-}
+}  // namespace
 
 namespace RDKit {
 
 const ReactionFingerprintParams DefaultStructuralFPParams(true, 0.2, 1, 1, 4096,
-                                                            PatternFP);
+                                                          PatternFP);
 const ReactionFingerprintParams DefaultDifferenceFPParams(true, 0.0, 10, 1,
-                                                            2048, AtomPairFP);
+                                                          2048, AtomPairFP);
 
 SparseIntVect<std::uint32_t> *generateFingerprintChemReactionAsCountVect(
     const ChemicalReaction &rxn, unsigned int fpSize, FingerprintType t,
@@ -138,8 +134,7 @@ SparseIntVect<std::uint32_t> *generateFingerprintChemReactionAsCountVect(
   auto begin = getStartIterator(rxn, mt);
   auto end = getEndIterator(rxn, mt);
   for (; begin != end; ++begin) {
-    SparseIntVect<std::uint32_t> *tmp =
-        generateFingerprint(**begin, fpSize, t);
+    SparseIntVect<std::uint32_t> *tmp = generateFingerprint(**begin, fpSize, t);
     (*result) += *tmp;
     delete tmp;
   }
@@ -230,4 +225,4 @@ SparseIntVect<std::uint32_t> *DifferenceFingerprintChemReaction(
   delete productFP;
   return res;
 }
-}
+}  // namespace RDKit

--- a/Code/GraphMol/ChemReactions/ReactionRunner.cpp
+++ b/Code/GraphMol/ChemReactions/ReactionRunner.cpp
@@ -34,7 +34,6 @@
 #include <GraphMol/Substruct/SubstructMatch.h>
 #include <GraphMol/QueryOps.h>
 #include <boost/dynamic_bitset.hpp>
-#include <boost/foreach.hpp>
 #include <map>
 #include <algorithm>
 #include <GraphMol/ChemTransforms/ChemTransforms.h>
@@ -1403,7 +1402,7 @@ std::vector<MOL_SPTR_VECT> run_Reactants(const ChemicalReaction &rxn,
         "Number of reactants provided does not match number of reactant "
         "templates.");
   }
-  BOOST_FOREACH (ROMOL_SPTR msptr, reactants) {
+  for (auto msptr : reactants) {
     CHECK_INVARIANT(msptr, "bad molecule in reactants");
     msptr->clearAllAtomBookmarks();  // we use this as scratch space
   }
@@ -1564,9 +1563,8 @@ ROMol *reduceProductToSideChains(const ROMOL_SPTR &product,
                 nbr->getProp<int>(common_properties::reactionMapNum));
           } else {
             bonds_to_product.emplace_back(
-                nbr,
-                mol->getBondBetweenAtoms(scaffold_atom->getIdx(), *nbrIdx)
-                    ->getBondType());
+                nbr, mol->getBondBetweenAtoms(scaffold_atom->getIdx(), *nbrIdx)
+                         ->getBondType());
           }
         }
 

--- a/Code/GraphMol/ChemReactions/SanitizeRxn.cpp
+++ b/Code/GraphMol/ChemReactions/SanitizeRxn.cpp
@@ -212,14 +212,14 @@ void fixRGroups(ChemicalReaction &rxn) {
       getMaxProp<unsigned int>(rxn, common_properties::_MolFileRLabel);
   int max_atom_map = getMaxProp<int>(rxn, common_properties::molAtomMapNumber);
 
-  for (AtomInfo &rat : reactantAtomsToFix) {
+  for (auto &rat : reactantAtomsToFix) {
     bool found = false;
     unsigned int bestGuess = rat.bestGuessRLabel();
     if (!bestGuess) {
       continue;
     }
 
-    for (AtomInfo &pat : productAtomsToFix) {
+    for (auto &pat : productAtomsToFix) {
       if (!pat.atom) {
         continue;
       }

--- a/Code/GraphMol/ChemReactions/SanitizeRxn.cpp
+++ b/Code/GraphMol/ChemReactions/SanitizeRxn.cpp
@@ -212,14 +212,14 @@ void fixRGroups(ChemicalReaction &rxn) {
       getMaxProp<unsigned int>(rxn, common_properties::_MolFileRLabel);
   int max_atom_map = getMaxProp<int>(rxn, common_properties::molAtomMapNumber);
 
-  BOOST_FOREACH (AtomInfo &rat, reactantAtomsToFix) {
+  for (AtomInfo &rat : reactantAtomsToFix) {
     bool found = false;
     unsigned int bestGuess = rat.bestGuessRLabel();
     if (!bestGuess) {
       continue;
     }
 
-    BOOST_FOREACH (AtomInfo &pat, productAtomsToFix) {
+    for (AtomInfo &pat : productAtomsToFix) {
       if (!pat.atom) {
         continue;
       }

--- a/Code/GraphMol/ChemTransforms/MolFragmenter.cpp
+++ b/Code/GraphMol/ChemTransforms/MolFragmenter.cpp
@@ -19,6 +19,7 @@
 #include <boost/tokenizer.hpp>
 #include <boost/algorithm/string/trim.hpp>
 #include <boost/algorithm/string.hpp>
+#include <boost/range/adaptor/reversed.hpp>
 #include <cstdint>
 #include <vector>
 #include <algorithm>
@@ -442,7 +443,7 @@ ROMol *fragmentOnBonds(
   PRECONDITION((!nCutsPerAtom || nCutsPerAtom->size() == mol.getNumAtoms()),
                "bad nCutsPerAtom vector");
   if (nCutsPerAtom) {
-    BOOST_FOREACH (unsigned int &nCuts, *nCutsPerAtom) { nCuts = 0; }
+    for (unsigned int &nCuts : *nCutsPerAtom) { nCuts = 0; }
   }
   auto *res = new RWMol(mol);
   if (!mol.getNumAtoms()) {
@@ -451,7 +452,7 @@ ROMol *fragmentOnBonds(
 
   std::vector<Bond *> bondsToRemove;
   bondsToRemove.reserve(bondIndices.size());
-  BOOST_FOREACH (unsigned int bondIdx, bondIndices) {
+  for (unsigned int bondIdx : bondIndices) {
     bondsToRemove.push_back(res->getBondWithIdx(bondIdx));
   }
   for (unsigned int i = 0; i < bondsToRemove.size(); ++i) {
@@ -564,9 +565,8 @@ ROMol *fragmentOnBonds(const ROMol &mol,
 
   boost::dynamic_bitset<> bondsUsed(mol.getNumBonds(), 0);
   // the bond definitions are organized (more or less) general -> specific, so
-  // loop
-  // over them backwards
-  BOOST_REVERSE_FOREACH(const FragmenterBondType &fbt, bondPatterns) {
+  // loop over them backwards
+  for (const FragmenterBondType &fbt : boost::adaptors::reverse(bondPatterns)) {
     if (fbt.query->getNumAtoms() != 2 || fbt.query->getNumBonds() != 1) {
       BOOST_LOG(rdErrorLog)
           << "fragmentation queries must have 2 atoms and 1 bond" << std::endl;
@@ -579,7 +579,7 @@ ROMol *fragmentOnBonds(const ROMol &mol,
     // std::cerr<<"  >>> "<<fbt.atom1Label<<" "<<fbt.atom2Label<<std::endl;
     std::vector<MatchVectType> bondMatches;
     SubstructMatch(mol, *fbt.query.get(), bondMatches);
-    BOOST_FOREACH (const MatchVectType &mv, bondMatches) {
+    for (const MatchVectType &mv : bondMatches) {
       const Bond *bond = mol.getBondBetweenAtoms(mv[0].second, mv[1].second);
       // std::cerr<<"          "<<bond->getIdx()<<std::endl;
       TEST_ASSERT(bond);

--- a/Code/GraphMol/ChemTransforms/MolFragmenter.cpp
+++ b/Code/GraphMol/ChemTransforms/MolFragmenter.cpp
@@ -411,22 +411,23 @@ void checkChiralityPostMove(const ROMol &mol, const Atom *oAt, Atom *nAt,
   }
 }
 
-std::vector<std::pair<Bond*, std::vector<int>>> getNbrBondStereo(RWMol &mol, const Bond *bnd) {
-    PRECONDITION(bnd,"null bond");
-    // loop over neighboring double bonds and remove their stereo atom
-    std::vector<std::pair<Bond*, std::vector<int>>> res;
-    const auto bgn = bnd->getBeginAtom();
-    const auto end = bnd->getEndAtom();
-    for(const auto *atom : {bgn, end}) {
-        ROMol::OEDGE_ITER a1, a2;
-        for (boost::tie(a1, a2) = mol.getAtomBonds(atom); a1 != a2; ++a1) {
-          Bond *obnd = mol[*a1];
-            if(obnd->getIdx() != bnd->getIdx() && !obnd->getStereoAtoms().empty()) {
-                res.emplace_back(obnd, obnd->getStereoAtoms());
-            }
-        }
+std::vector<std::pair<Bond *, std::vector<int>>> getNbrBondStereo(
+    RWMol &mol, const Bond *bnd) {
+  PRECONDITION(bnd, "null bond");
+  // loop over neighboring double bonds and remove their stereo atom
+  std::vector<std::pair<Bond *, std::vector<int>>> res;
+  const auto bgn = bnd->getBeginAtom();
+  const auto end = bnd->getEndAtom();
+  for (const auto *atom : {bgn, end}) {
+    ROMol::OEDGE_ITER a1, a2;
+    for (boost::tie(a1, a2) = mol.getAtomBonds(atom); a1 != a2; ++a1) {
+      Bond *obnd = mol[*a1];
+      if (obnd->getIdx() != bnd->getIdx() && !obnd->getStereoAtoms().empty()) {
+        res.emplace_back(obnd, obnd->getStereoAtoms());
+      }
     }
-    return res;
+  }
+  return res;
 }
 }  // namespace
 
@@ -443,7 +444,9 @@ ROMol *fragmentOnBonds(
   PRECONDITION((!nCutsPerAtom || nCutsPerAtom->size() == mol.getNumAtoms()),
                "bad nCutsPerAtom vector");
   if (nCutsPerAtom) {
-    for (unsigned int &nCuts : *nCutsPerAtom) { nCuts = 0; }
+    for (auto &nCuts : *nCutsPerAtom) {
+      nCuts = 0;
+    }
   }
   auto *res = new RWMol(mol);
   if (!mol.getNumAtoms()) {
@@ -452,7 +455,7 @@ ROMol *fragmentOnBonds(
 
   std::vector<Bond *> bondsToRemove;
   bondsToRemove.reserve(bondIndices.size());
-  for (unsigned int bondIdx : bondIndices) {
+  for (auto bondIdx : bondIndices) {
     bondsToRemove.push_back(res->getBondWithIdx(bondIdx));
   }
   for (unsigned int i = 0; i < bondsToRemove.size(); ++i) {
@@ -496,14 +499,16 @@ ROMol *fragmentOnBonds(
       // this bond starts at the same atom, so its direction should always be
       // correct:
       res->getBondWithIdx(bondidx)->setBondDir(bD);
-        
+
       // restore stereo atoms
-      for(auto &stereo_atoms : nbr_bond_stereo) {
-          std::replace(stereo_atoms.second.begin(), stereo_atoms.second.end(), bidx, idx1);
-          std::replace(stereo_atoms.second.begin(), stereo_atoms.second.end(), eidx, idx2);
-          stereo_atoms.first->getStereoAtoms().swap(stereo_atoms.second);
+      for (auto &stereo_atoms : nbr_bond_stereo) {
+        std::replace(stereo_atoms.second.begin(), stereo_atoms.second.end(),
+                     bidx, idx1);
+        std::replace(stereo_atoms.second.begin(), stereo_atoms.second.end(),
+                     eidx, idx2);
+        stereo_atoms.first->getStereoAtoms().swap(stereo_atoms.second);
       }
-        
+
       // figure out if we need to change the stereo tags on the atoms:
       if (mol.getAtomWithIdx(bidx)->getChiralTag() ==
               Atom::CHI_TETRAHEDRAL_CCW ||
@@ -566,7 +571,7 @@ ROMol *fragmentOnBonds(const ROMol &mol,
   boost::dynamic_bitset<> bondsUsed(mol.getNumBonds(), 0);
   // the bond definitions are organized (more or less) general -> specific, so
   // loop over them backwards
-  for (const FragmenterBondType &fbt : boost::adaptors::reverse(bondPatterns)) {
+  for (const auto &fbt : boost::adaptors::reverse(bondPatterns)) {
     if (fbt.query->getNumAtoms() != 2 || fbt.query->getNumBonds() != 1) {
       BOOST_LOG(rdErrorLog)
           << "fragmentation queries must have 2 atoms and 1 bond" << std::endl;
@@ -579,7 +584,7 @@ ROMol *fragmentOnBonds(const ROMol &mol,
     // std::cerr<<"  >>> "<<fbt.atom1Label<<" "<<fbt.atom2Label<<std::endl;
     std::vector<MatchVectType> bondMatches;
     SubstructMatch(mol, *fbt.query.get(), bondMatches);
-    for (const MatchVectType &mv : bondMatches) {
+    for (const auto &mv : bondMatches) {
       const Bond *bond = mol.getBondBetweenAtoms(mv[0].second, mv[1].second);
       // std::cerr<<"          "<<bond->getIdx()<<std::endl;
       TEST_ASSERT(bond);
@@ -620,7 +625,7 @@ ROMol *fragmentOnBRICSBonds(const ROMol &mol) {
   }
   return fragmentOnBonds(mol, bondPatterns, &(atomEnvs.get()));
 }
-} // End of MolFragmenter
+}  // namespace MolFragmenter
 
 namespace {
 const unsigned int NOLABEL = std::numeric_limits<unsigned int>::max();
@@ -628,34 +633,35 @@ const unsigned int NOLABEL = std::numeric_limits<unsigned int>::max();
 unsigned int get_label(const Atom *a, const MolzipParams &p) {
   PRECONDITION(a, "bad atom in MolZip::get_label")
   unsigned int idx = NOLABEL;
-  switch(p.label) {
-  case MolzipLabel::AtomMapNumber:
-          if(a->getAtomicNum() == 0) {
-              auto mapno = a->getAtomMapNum();
-              return mapno ? mapno : NOLABEL;
-          }
-          break;
-  case MolzipLabel::Isotope:
-          if(a->getAtomicNum() == 0) {
-              auto iso = a->getIsotope();
-              return iso ? iso : NOLABEL;
-          }
-          break;
-  case MolzipLabel::AtomType: {
-    idx = std::distance(p.atomSymbols.begin(),
-                        std::find(p.atomSymbols.begin(), p.atomSymbols.end(),
-                                  a->getSymbol()));
-    if(idx == p.atomSymbols.size()) {
-        idx = NOLABEL;
-    }
-    break;
-  case MolzipLabel::FragmentOnBonds:
-      // shouldn't ever get here
-      CHECK_INVARIANT(0, "FragmentOnBonds is not an atom label, it is an atom index");
+  switch (p.label) {
+    case MolzipLabel::AtomMapNumber:
+      if (a->getAtomicNum() == 0) {
+        auto mapno = a->getAtomMapNum();
+        return mapno ? mapno : NOLABEL;
+      }
       break;
-  default:
-      CHECK_INVARIANT(0,"bogus MolZipLabel value in MolZip::get_label");
-  }
+    case MolzipLabel::Isotope:
+      if (a->getAtomicNum() == 0) {
+        auto iso = a->getIsotope();
+        return iso ? iso : NOLABEL;
+      }
+      break;
+    case MolzipLabel::AtomType: {
+      idx = std::distance(p.atomSymbols.begin(),
+                          std::find(p.atomSymbols.begin(), p.atomSymbols.end(),
+                                    a->getSymbol()));
+      if (idx == p.atomSymbols.size()) {
+        idx = NOLABEL;
+      }
+      break;
+      case MolzipLabel::FragmentOnBonds:
+        // shouldn't ever get here
+        CHECK_INVARIANT(
+            0, "FragmentOnBonds is not an atom label, it is an atom index");
+        break;
+      default:
+        CHECK_INVARIANT(0, "bogus MolZipLabel value in MolZip::get_label");
+    }
   }
   return idx;
 }
@@ -665,275 +671,295 @@ unsigned int get_label(const Atom *a, const MolzipParams &p) {
 Atom *get_other_atom(Atom *a) {
   PRECONDITION(a, "null atom in MolZip::get_other_atom");
   auto &m = a->getOwningMol();
-  if(m.getAtomDegree(a) != 1){
+  if (m.getAtomDegree(a) != 1) {
     return nullptr;
   }
-  
+
   return m[*m.getAtomNeighbors(a).first];
 }
 
 int num_swaps_to_interconvert(std::vector<unsigned int> &orders) {
-    int nswaps = 0;
-    std::vector<bool> seen(orders.size());
-    for(size_t i=0;i<orders.size();++i) {
-        if(!seen[i]) {
-            auto j = i;
-            while(orders[j] != i) {
-                j=orders[j];
-                seen[j] = true;
-                nswaps++;
-            }
-        }
+  int nswaps = 0;
+  std::vector<bool> seen(orders.size());
+  for (size_t i = 0; i < orders.size(); ++i) {
+    if (!seen[i]) {
+      auto j = i;
+      while (orders[j] != i) {
+        j = orders[j];
+        seen[j] = true;
+        nswaps++;
+      }
     }
-    return nswaps;
+  }
+  return nswaps;
 }
 
 // Simple bookkeeping class to bond attachments and handle stereo
 struct ZipBond {
-    Atom *a;       // atom being bonded
-    Atom *a_dummy; // Labelled atom, i.e. [*:1]-C  will bond the C to something
-    Atom *b;       // atom being bonded
-    Atom *b_dummy; // Labelled atom, i.e. [*:1]-O will bond the O to something
-    
-    // Backup the original chirality mark_chirality must be called first
-    //  as it checks the datastructure for validity;
-    void mark_chirality() const {
-        PRECONDITION(a, "Must have a begin atom to bond");
-        PRECONDITION(b, "Must have an end atom to bond");
-        PRECONDITION(a_dummy, "Must have a begin dummy atom");
-        PRECONDITION(b_dummy, "Must have an end dummy atom");
-        
-        mark(a, a_dummy, b);
-        mark(b, b_dummy, a);
-    }
-    
-    // bond a<->b for now only use single bonds
-    //  XXX FIX ME take the highest bond order.
-    bool bond(RWMol &newmol) const {
-        if (!a || !b || !a_dummy || !b_dummy) {
-            BOOST_LOG(rdWarningLog) << "Incomplete atom labelling, cannot make bond" << std::endl;
-            return false;
-        }
-        if (!a->getOwningMol().getBondBetweenAtoms(a->getIdx(), b->getIdx())) {
-            CHECK_INVARIANT (&a->getOwningMol() == &newmol, "Owning mol is not the combined molecule!!");
-            auto bnd = newmol.getBondBetweenAtoms(a->getIdx(), a_dummy->getIdx());
-            CHECK_INVARIANT(bnd!=nullptr, "molzip: begin atom and specified dummy atom connection are not bonded.")
-            auto bond_type_a = bnd->getBondType();
-            bnd = newmol.getBondBetweenAtoms(b->getIdx(), b_dummy->getIdx());
-            CHECK_INVARIANT(bnd!=nullptr, "molzip: end atom and specified dummy connection atom are not bonded.")
-            auto bond_type_b = bnd->getBondType();
-            if(bond_type_a != Bond::BondType::SINGLE) {
-                newmol.addBond(a, b, bond_type_a);
-            }
-            else if (bond_type_b != Bond::BondType::SINGLE) {
-                newmol.addBond(a, b, bond_type_b);
-            } else {
-                newmol.addBond(a, b, Bond::BondType::SINGLE);
-            }
-        }
-        a_dummy->setProp("__molzip_used", true);
-        b_dummy->setProp("__molzip_used", true);
+  Atom *a;        // atom being bonded
+  Atom *a_dummy;  // Labelled atom, i.e. [*:1]-C  will bond the C to something
+  Atom *b;        // atom being bonded
+  Atom *b_dummy;  // Labelled atom, i.e. [*:1]-O will bond the O to something
 
-        return true;
+  // Backup the original chirality mark_chirality must be called first
+  //  as it checks the datastructure for validity;
+  void mark_chirality() const {
+    PRECONDITION(a, "Must have a begin atom to bond");
+    PRECONDITION(b, "Must have an end atom to bond");
+    PRECONDITION(a_dummy, "Must have a begin dummy atom");
+    PRECONDITION(b_dummy, "Must have an end dummy atom");
+
+    mark(a, a_dummy, b);
+    mark(b, b_dummy, a);
+  }
+
+  // bond a<->b for now only use single bonds
+  //  XXX FIX ME take the highest bond order.
+  bool bond(RWMol &newmol) const {
+    if (!a || !b || !a_dummy || !b_dummy) {
+      BOOST_LOG(rdWarningLog)
+          << "Incomplete atom labelling, cannot make bond" << std::endl;
+      return false;
     }
-    
-    // Restore the marked chirality (mark_chirality must be called first)
-    void restore_chirality(std::set<Atom *> &already_checked) const {
-        PRECONDITION(a, "Must have a begin atom to bond");
-        PRECONDITION(b, "Must have an end atom to bond");
-        PRECONDITION(a_dummy, "Must have a begin dummy atom");
-        PRECONDITION(b_dummy, "Must have an end dummy atom");
-        if(already_checked.find(a) == already_checked.end()) {
-            restore(a);
-            already_checked.insert(a);
+    if (!a->getOwningMol().getBondBetweenAtoms(a->getIdx(), b->getIdx())) {
+      CHECK_INVARIANT(&a->getOwningMol() == &newmol,
+                      "Owning mol is not the combined molecule!!");
+      auto bnd = newmol.getBondBetweenAtoms(a->getIdx(), a_dummy->getIdx());
+      CHECK_INVARIANT(bnd != nullptr,
+                      "molzip: begin atom and specified dummy atom connection "
+                      "are not bonded.")
+      auto bond_type_a = bnd->getBondType();
+      bnd = newmol.getBondBetweenAtoms(b->getIdx(), b_dummy->getIdx());
+      CHECK_INVARIANT(bnd != nullptr,
+                      "molzip: end atom and specified dummy connection atom "
+                      "are not bonded.")
+      auto bond_type_b = bnd->getBondType();
+      if (bond_type_a != Bond::BondType::SINGLE) {
+        newmol.addBond(a, b, bond_type_a);
+      } else if (bond_type_b != Bond::BondType::SINGLE) {
+        newmol.addBond(a, b, bond_type_b);
+      } else {
+        newmol.addBond(a, b, Bond::BondType::SINGLE);
+      }
+    }
+    a_dummy->setProp("__molzip_used", true);
+    b_dummy->setProp("__molzip_used", true);
+
+    return true;
+  }
+
+  // Restore the marked chirality (mark_chirality must be called first)
+  void restore_chirality(std::set<Atom *> &already_checked) const {
+    PRECONDITION(a, "Must have a begin atom to bond");
+    PRECONDITION(b, "Must have an end atom to bond");
+    PRECONDITION(a_dummy, "Must have a begin dummy atom");
+    PRECONDITION(b_dummy, "Must have an end dummy atom");
+    if (already_checked.find(a) == already_checked.end()) {
+      restore(a);
+      already_checked.insert(a);
+    }
+    if (already_checked.find(b) == already_checked.end()) {
+      restore(b);
+      already_checked.insert(b);
+    }
+
+    // now do bond stereo
+    std::string mark = "__molzip_bond_stereo_mark";
+    for (auto *bond : a->getOwningMol().bonds()) {
+      if (bond->hasProp(mark)) {
+        std::vector<int> atoms;
+        for (auto *atom : bond->getProp<std::vector<Atom *>>(mark)) {
+          atoms.push_back(rdcast<int>(atom->getIdx()));
         }
-        if(already_checked.find(b) == already_checked.end()) {
-            restore(b);
-            already_checked.insert(b);
-        }
-        
-        // now do bond stereo
+        bond->getStereoAtoms().swap(atoms);
+        bond->setStereo(
+            bond->getProp<Bond::BondStereo>("__molzip_bond_stereo"));
+      }
+    }
+  }
+
+ private:
+  // Mark the original order of the nbr atoms including the dummy
+  //  The goal is to copy the dummy chiral order over to the
+  //  atom being bonded
+  void mark(Atom *chiral_atom, Atom *dummy_atom, Atom *new_atom) const {
+    if (chiral_atom->getChiralTag()) {
+      std::string mark =
+          "__molzip_mark_" + std::to_string(chiral_atom->getIdx());
+      chiral_atom->setProp("__molzip_chiral_mark", mark);
+      int order = 0;
+      auto &m = chiral_atom->getOwningMol();
+      for (auto nbrIdx :
+           boost::make_iterator_range(m.getAtomNeighbors(chiral_atom))) {
+        m[nbrIdx]->setProp(mark, order);
+        ++order;
+      }
+      new_atom->setProp(mark, dummy_atom->getProp<int>(mark));
+    }
+
+    // check bond stereo
+    auto &m = chiral_atom->getOwningMol();
+    for (auto nbrIdx :
+         boost::make_iterator_range(m.getAtomNeighbors(chiral_atom))) {
+      auto bond = m.getBondBetweenAtoms(chiral_atom->getIdx(), nbrIdx);
+      if (bond->getStereo()) {
         std::string mark = "__molzip_bond_stereo_mark";
-        for(auto *bond : a->getOwningMol().bonds()) {
-            if(bond->hasProp(mark)) {
-                std::vector<int> atoms;
-                for(auto *atom : bond->getProp<std::vector<Atom*>>(mark)) {
-                    atoms.push_back(rdcast<int>(atom->getIdx()));
-                }
-                bond->getStereoAtoms().swap(atoms);
-                bond->setStereo(bond->getProp<Bond::BondStereo>("__molzip_bond_stereo"));
-            }
+        std::vector<Atom *> atoms;
+        bool has_dummy = false;
+        for (auto idx : bond->getStereoAtoms()) {
+          if (idx == dummy_atom->getIdx()) {
+            atoms.push_back(new_atom);
+            has_dummy = true;
+          } else {
+            atoms.push_back(m.getAtomWithIdx(idx));
+          }
         }
+        if (has_dummy) {
+          bond->setProp(mark, atoms);
+          bond->setProp<Bond::BondStereo>("__molzip_bond_stereo",
+                                          bond->getStereo());
+        }
+      }
     }
-    
-private:
-    // Mark the original order of the nbr atoms including the dummy
-    //  The goal is to copy the dummy chiral order over to the
-    //  atom being bonded
-    void mark(Atom *chiral_atom, Atom *dummy_atom, Atom *new_atom) const {
-        if(chiral_atom->getChiralTag()) {
-            std::string mark = "__molzip_mark_" + std::to_string(chiral_atom->getIdx());
-            chiral_atom->setProp("__molzip_chiral_mark", mark);
-            int order = 0;
-            auto &m = chiral_atom->getOwningMol();
-            for(auto nbrIdx : boost::make_iterator_range(m.getAtomNeighbors(chiral_atom))) {
-                m[nbrIdx]->setProp(mark, order);
-                ++order;
-            }
-            new_atom->setProp(mark, dummy_atom->getProp<int>(mark));
-        }
-        
-        // check bond stereo
-        auto &m = chiral_atom->getOwningMol();
-        for(auto nbrIdx : boost::make_iterator_range(m.getAtomNeighbors(chiral_atom))) {
-            auto bond  = m.getBondBetweenAtoms(chiral_atom->getIdx(), nbrIdx);
-            if(bond->getStereo()) {
-                std::string mark = "__molzip_bond_stereo_mark";
-                std::vector<Atom*> atoms;
-                bool has_dummy = false;
-                for(auto idx : bond->getStereoAtoms()) {
-                    if(idx == dummy_atom->getIdx()) {
-                        atoms.push_back(new_atom);
-                        has_dummy = true;
-                    } else {
-                        atoms.push_back(m.getAtomWithIdx(idx));
-                    }
-                }
-                if(has_dummy) {
-                    bond->setProp(mark, atoms);
-                    bond->setProp<Bond::BondStereo>("__molzip_bond_stereo", bond->getStereo());
-                }
-            }
-        }
-    }
-    
-    // Restore the atom's chirality by comparing the original order
-    //  to the current
-    void restore(Atom *chiral_atom) const {
-        if(!chiral_atom->getChiralTag()) {
-            return;
-        }
-        std::string mark = chiral_atom->getProp<std::string>("__molzip_chiral_mark");
-        //std::vector<unsigned int> orders1;
-        std::vector<unsigned int> orders2;
-        auto &m = chiral_atom->getOwningMol();
-        for(auto nbrIdx : boost::make_iterator_range(m.getAtomNeighbors(chiral_atom))) {
-            orders2.push_back(m[nbrIdx]->getProp<int>(mark));
-        }
-        if(num_swaps_to_interconvert(orders2) % 2 == 1) {
-            chiral_atom->invertChirality();
-        }
-    }
-    
+  }
 
+  // Restore the atom's chirality by comparing the original order
+  //  to the current
+  void restore(Atom *chiral_atom) const {
+    if (!chiral_atom->getChiralTag()) {
+      return;
+    }
+    std::string mark =
+        chiral_atom->getProp<std::string>("__molzip_chiral_mark");
+    // std::vector<unsigned int> orders1;
+    std::vector<unsigned int> orders2;
+    auto &m = chiral_atom->getOwningMol();
+    for (auto nbrIdx :
+         boost::make_iterator_range(m.getAtomNeighbors(chiral_atom))) {
+      orders2.push_back(m[nbrIdx]->getProp<int>(mark));
+    }
+    if (num_swaps_to_interconvert(orders2) % 2 == 1) {
+      chiral_atom->invertChirality();
+    }
+  }
 };
-}
+}  // namespace
 
-std::unique_ptr<ROMol> molzip(
-        const ROMol &a, const ROMol &b, const MolzipParams &params) {
-    RWMol *newmol;
-    if (b.getNumAtoms()) {
-        newmol = static_cast<RWMol*>(combineMols(a,b));
-    }
-    else {
-        newmol = new RWMol(a);
-    }
-        
-    std::map<unsigned int, ZipBond> mappings;
-    std::map<Atom *, std::vector<const ZipBond*>> mappings_by_atom;
-    std::vector<Atom *> deletions;
-    if(params.label == MolzipLabel::FragmentOnBonds) {
-        for(auto *atom : newmol->atoms()) {
-            if(atom->getAtomicNum() == 0) {
-                auto molno = atom->getIsotope();
-                auto attached_atom = get_other_atom(atom);
-                auto &bond = mappings[molno];
-                bond.a = attached_atom;
-                bond.a_dummy = atom;
-                bond.b = newmol->getAtomWithIdx(molno);
-                for(auto nbrIdx : boost::make_iterator_range(newmol->getAtomNeighbors(bond.b))) {
-                    auto *nbr = (*newmol)[nbrIdx];
-                    if(nbr->getAtomicNum() == 0 && nbr->getIsotope() == attached_atom->getIdx()) {
-                        bond.b_dummy = nbr;
-                        break;
-                    }
-                }
-                if(!bond.b_dummy) {
-                    BOOST_LOG(rdErrorLog) << "Cannot find atom to bond using FragmentOnBond labelling" << std::endl;
-                    return std::unique_ptr<ROMol>();
-                }
-                mappings_by_atom[atom].push_back(&bond);
-                deletions.push_back(atom);
-            }
+std::unique_ptr<ROMol> molzip(const ROMol &a, const ROMol &b,
+                              const MolzipParams &params) {
+  RWMol *newmol;
+  if (b.getNumAtoms()) {
+    newmol = static_cast<RWMol *>(combineMols(a, b));
+  } else {
+    newmol = new RWMol(a);
+  }
+
+  std::map<unsigned int, ZipBond> mappings;
+  std::map<Atom *, std::vector<const ZipBond *>> mappings_by_atom;
+  std::vector<Atom *> deletions;
+  if (params.label == MolzipLabel::FragmentOnBonds) {
+    for (auto *atom : newmol->atoms()) {
+      if (atom->getAtomicNum() == 0) {
+        auto molno = atom->getIsotope();
+        auto attached_atom = get_other_atom(atom);
+        auto &bond = mappings[molno];
+        bond.a = attached_atom;
+        bond.a_dummy = atom;
+        bond.b = newmol->getAtomWithIdx(molno);
+        for (auto nbrIdx :
+             boost::make_iterator_range(newmol->getAtomNeighbors(bond.b))) {
+          auto *nbr = (*newmol)[nbrIdx];
+          if (nbr->getAtomicNum() == 0 &&
+              nbr->getIsotope() == attached_atom->getIdx()) {
+            bond.b_dummy = nbr;
+            break;
+          }
         }
-    } else {
-        for(auto *atom : newmol->atoms()) {
-            auto molno = get_label(atom, params);
-            if(molno != NOLABEL) {
-                auto attached_atom = get_other_atom(atom);
-                if(mappings.find(molno) == mappings.end()) {
-                    auto &bond = mappings[molno];
-                    CHECK_INVARIANT(!bond.a, "molzip: bond info already setup for bgn atom with label:" +
-                                    std::to_string(molno));
-                    bond.a = attached_atom;
-                    bond.a_dummy = atom;
-                } else {
-                    auto &bond = mappings[molno];
-                    CHECK_INVARIANT(bond.a, "molzip: bond info not properly setup for bgn atom with label:" +
-                                    std::to_string(molno));
-                    CHECK_INVARIANT(!bond.b, "molzip: bond info already exists for end atom with label:" + std::to_string(molno));
-                    bond.b = attached_atom;
-                    bond.b_dummy = atom;
-                    mappings_by_atom[bond.a].push_back(&bond);
-                }
-                deletions.push_back(atom);
-            }
+        if (!bond.b_dummy) {
+          BOOST_LOG(rdErrorLog)
+              << "Cannot find atom to bond using FragmentOnBond labelling"
+              << std::endl;
+          return std::unique_ptr<ROMol>();
         }
+        mappings_by_atom[atom].push_back(&bond);
+        deletions.push_back(atom);
+      }
     }
-    for(auto &kv : mappings_by_atom) {
-        for(auto &bond : kv.second) {
-            bond->mark_chirality();
+  } else {
+    for (auto *atom : newmol->atoms()) {
+      auto molno = get_label(atom, params);
+      if (molno != NOLABEL) {
+        auto attached_atom = get_other_atom(atom);
+        if (mappings.find(molno) == mappings.end()) {
+          auto &bond = mappings[molno];
+          CHECK_INVARIANT(
+              !bond.a,
+              "molzip: bond info already setup for bgn atom with label:" +
+                  std::to_string(molno));
+          bond.a = attached_atom;
+          bond.a_dummy = atom;
+        } else {
+          auto &bond = mappings[molno];
+          CHECK_INVARIANT(
+              bond.a,
+              "molzip: bond info not properly setup for bgn atom with label:" +
+                  std::to_string(molno));
+          CHECK_INVARIANT(
+              !bond.b,
+              "molzip: bond info already exists for end atom with label:" +
+                  std::to_string(molno));
+          bond.b = attached_atom;
+          bond.b_dummy = atom;
+          mappings_by_atom[bond.a].push_back(&bond);
         }
+        deletions.push_back(atom);
+      }
     }
-    for(auto &kv : mappings) {
-        kv.second.bond(*newmol);
+  }
+  for (auto &kv : mappings_by_atom) {
+    for (auto &bond : kv.second) {
+      bond->mark_chirality();
     }
-    for(auto &atom :deletions) {
-        if(atom->hasProp("__molzip_used")) {
-            newmol->removeAtom(atom);
-        }
+  }
+  for (auto &kv : mappings) {
+    kv.second.bond(*newmol);
+  }
+  for (auto &atom : deletions) {
+    if (atom->hasProp("__molzip_used")) {
+      newmol->removeAtom(atom);
     }
-    
-    std::set<Atom *> already_checked;
-    for(auto &kv : mappings_by_atom) {
-        for(auto &bond : kv.second) {
-            bond->restore_chirality(already_checked);
-        }
+  }
+
+  std::set<Atom *> already_checked;
+  for (auto &kv : mappings_by_atom) {
+    for (auto &bond : kv.second) {
+      bond->restore_chirality(already_checked);
     }
-    // remove all molzip tags
-    for(auto *atom : newmol->atoms()) {
-        auto propnames = atom->getPropList();
-        for(auto &prop : propnames) {
-            if(prop.find("__molzip") == 0) {
-                atom->clearProp(prop);
-            }
-        }
+  }
+  // remove all molzip tags
+  for (auto *atom : newmol->atoms()) {
+    auto propnames = atom->getPropList();
+    for (auto &prop : propnames) {
+      if (prop.find("__molzip") == 0) {
+        atom->clearProp(prop);
+      }
     }
-    for(auto *bond : newmol->bonds()) {
-        auto propnames = bond->getPropList();
-        for(auto &prop : propnames) {
-            if(prop.find("__molzip") == 0) {
-                bond->clearProp(prop);
-            }
-        }
+  }
+  for (auto *bond : newmol->bonds()) {
+    auto propnames = bond->getPropList();
+    for (auto &prop : propnames) {
+      if (prop.find("__molzip") == 0) {
+        bond->clearProp(prop);
+      }
     }
-    newmol->updatePropertyCache();
-    newmol->setProp(common_properties::_StereochemDone, true);
-    return std::unique_ptr<ROMol>(newmol);
+  }
+  newmol->updatePropertyCache();
+  newmol->setProp(common_properties::_StereochemDone, true);
+  return std::unique_ptr<ROMol>(newmol);
 }
 
 std::unique_ptr<ROMol> molzip(const ROMol &a, const MolzipParams &params) {
-    const static ROMol b;
-    return molzip(a,b,params);
+  const static ROMol b;
+  return molzip(a, b, params);
 }
 }  // end of namespace RDKit

--- a/Code/GraphMol/ChemTransforms/testChemTransforms.cpp
+++ b/Code/GraphMol/ChemTransforms/testChemTransforms.cpp
@@ -1885,7 +1885,7 @@ void testGithubIssue429() {
     TEST_ASSERT(frags.size() == 2);
     std::vector<std::vector<int>> fragMap;
 
-    BOOST_FOREACH (ROMOL_SPTR romol, frags) {
+    for (ROMOL_SPTR romol : frags) {
       auto *rwmol = (RWMol *)(romol.get());
       MolOps::sanitizeMol(*rwmol);
     }

--- a/Code/GraphMol/ChemTransforms/testChemTransforms.cpp
+++ b/Code/GraphMol/ChemTransforms/testChemTransforms.cpp
@@ -1885,7 +1885,7 @@ void testGithubIssue429() {
     TEST_ASSERT(frags.size() == 2);
     std::vector<std::vector<int>> fragMap;
 
-    for (ROMOL_SPTR romol : frags) {
+    for (auto romol : frags) {
       auto *rwmol = (RWMol *)(romol.get());
       MolOps::sanitizeMol(*rwmol);
     }

--- a/Code/GraphMol/Chirality.cpp
+++ b/Code/GraphMol/Chirality.cpp
@@ -655,7 +655,7 @@ void updateDoubleBondNeighbors(ROMol &mol, Bond *dblBond, const Conformer *conf,
 
   Atom *atom1 = dblBond->getBeginAtom(), *atom2 = dblBond->getEndAtom();
   if (needsDir[bond1->getIdx()]) {
-    BOOST_FOREACH (int bidx, singleBondNbrs[bond1->getIdx()]) {
+    for (int bidx : singleBondNbrs[bond1->getIdx()]) {
       // std::cerr << "       neighbor from: " << bond1->getIdx() << " " << bidx
       //           << ": " << needsDir[bidx] << std::endl;
       if (needsDir[bidx]) {
@@ -664,7 +664,7 @@ void updateDoubleBondNeighbors(ROMol &mol, Bond *dblBond, const Conformer *conf,
     }
   }
   if (needsDir[bond2->getIdx()]) {
-    BOOST_FOREACH (int bidx, singleBondNbrs[bond2->getIdx()]) {
+    for (int bidx : singleBondNbrs[bond2->getIdx()]) {
       // std::cerr << "       neighbor from: " << bond2->getIdx() << " " << bidx
       //           << ": " << needsDir[bidx] << std::endl;
       if (needsDir[bidx]) {
@@ -720,7 +720,7 @@ void updateDoubleBondNeighbors(ROMol &mol, Bond *dblBond, const Conformer *conf,
   std::cerr << "**********************\n";
   std::cerr << "**********************\n";
 #endif
-  BOOST_FOREACH (Bond *oDblBond, followupBonds) {
+  for (Bond *oDblBond : followupBonds) {
     // std::cerr << "FOLLOWUP: " << oDblBond->getIdx() << " "
     //           << needsDir[oDblBond->getIdx()] << std::endl;
     updateDoubleBondNeighbors(mol, oDblBond, conf, needsDir, singleBondCounts,
@@ -1344,7 +1344,7 @@ void findChiralAtomSpecialCases(ROMol &mol,
       // followed ring bonds, these things are all by definition in one ring
       // system. (Q: is this true if there's a spiro center in there?)
       INT_VECT same(mol.getNumAtoms(), 0);
-      BOOST_FOREACH (int ringAtomEntry, ringStereoAtoms) {
+      for (int ringAtomEntry : ringStereoAtoms) {
         int ringAtomIdx =
             ringAtomEntry < 0 ? -ringAtomEntry - 1 : ringAtomEntry - 1;
         same[ringAtomIdx] = ringAtomEntry;

--- a/Code/GraphMol/Chirality.cpp
+++ b/Code/GraphMol/Chirality.cpp
@@ -655,7 +655,7 @@ void updateDoubleBondNeighbors(ROMol &mol, Bond *dblBond, const Conformer *conf,
 
   Atom *atom1 = dblBond->getBeginAtom(), *atom2 = dblBond->getEndAtom();
   if (needsDir[bond1->getIdx()]) {
-    for (int bidx : singleBondNbrs[bond1->getIdx()]) {
+    for (auto bidx : singleBondNbrs[bond1->getIdx()]) {
       // std::cerr << "       neighbor from: " << bond1->getIdx() << " " << bidx
       //           << ": " << needsDir[bidx] << std::endl;
       if (needsDir[bidx]) {
@@ -664,7 +664,7 @@ void updateDoubleBondNeighbors(ROMol &mol, Bond *dblBond, const Conformer *conf,
     }
   }
   if (needsDir[bond2->getIdx()]) {
-    for (int bidx : singleBondNbrs[bond2->getIdx()]) {
+    for (auto bidx : singleBondNbrs[bond2->getIdx()]) {
       // std::cerr << "       neighbor from: " << bond2->getIdx() << " " << bidx
       //           << ": " << needsDir[bidx] << std::endl;
       if (needsDir[bidx]) {
@@ -1344,7 +1344,7 @@ void findChiralAtomSpecialCases(ROMol &mol,
       // followed ring bonds, these things are all by definition in one ring
       // system. (Q: is this true if there's a spiro center in there?)
       INT_VECT same(mol.getNumAtoms(), 0);
-      for (int ringAtomEntry : ringStereoAtoms) {
+      for (auto ringAtomEntry : ringStereoAtoms) {
         int ringAtomIdx =
             ringAtomEntry < 0 ? -ringAtomEntry - 1 : ringAtomEntry - 1;
         same[ringAtomIdx] = ringAtomEntry;

--- a/Code/GraphMol/Depictor/EmbeddedFrag.cpp
+++ b/Code/GraphMol/Depictor/EmbeddedFrag.cpp
@@ -1675,7 +1675,7 @@ void EmbeddedFrag::flipAboutBond(unsigned int bondId, bool flipEnd) {
   }
   // if there are fixed atoms, look at the atoms on the "end side"
   if (nAtomsFixed) {
-    for (int endAtomId : endSideAids) {
+    for (auto endAtomId : endSideAids) {
       if (d_eatoms[endAtomId].df_fixed) {
         ++nEndAtomsFixed;
       }

--- a/Code/GraphMol/Depictor/EmbeddedFrag.cpp
+++ b/Code/GraphMol/Depictor/EmbeddedFrag.cpp
@@ -1675,7 +1675,7 @@ void EmbeddedFrag::flipAboutBond(unsigned int bondId, bool flipEnd) {
   }
   // if there are fixed atoms, look at the atoms on the "end side"
   if (nAtomsFixed) {
-    BOOST_FOREACH (int endAtomId, endSideAids) {
+    for (int endAtomId : endSideAids) {
       if (d_eatoms[endAtomId].df_fixed) {
         ++nEndAtomsFixed;
       }

--- a/Code/GraphMol/Descriptors/AtomFeat.cpp
+++ b/Code/GraphMol/Descriptors/AtomFeat.cpp
@@ -31,7 +31,6 @@
 #include <GraphMol/Atom.h>
 
 #include <GraphMol/MolOps.h>
-#include <boost/foreach.hpp>
 #include <cmath>
 #include <vector>
 

--- a/Code/GraphMol/Descriptors/ConnectivityDescriptors.cpp
+++ b/Code/GraphMol/Descriptors/ConnectivityDescriptors.cpp
@@ -172,7 +172,7 @@ double calcChiNv(const ROMol &mol, unsigned int n, bool force) {
   detail::hkDeltas(mol, hkDs, force);
   PATH_LIST ps = findAllPathsOfLengthN(mol, n + 1, false);
   double res = 0.0;
-  BOOST_FOREACH (PATH_TYPE p, ps) {
+  for (const PATH_TYPE& p : ps) {
     TEST_ASSERT(p.size() == n + 1);
     double accum = 1.0;
     for (unsigned int i = 0; i < n; ++i) {
@@ -191,7 +191,7 @@ double calcChiNn(const ROMol &mol, unsigned int n, bool force) {
   detail::nVals(mol, nVs, force);
   PATH_LIST ps = findAllPathsOfLengthN(mol, n + 1, false);
   double res = 0.0;
-  BOOST_FOREACH (PATH_TYPE p, ps) {
+  for (const PATH_TYPE& p : ps) {
     TEST_ASSERT(p.size() == n + 1);
     double accum = 1.0;
     for (unsigned int i = 0; i < n; ++i) {

--- a/Code/GraphMol/Descriptors/ConnectivityDescriptors.cpp
+++ b/Code/GraphMol/Descriptors/ConnectivityDescriptors.cpp
@@ -29,7 +29,7 @@ void hkDeltas(const ROMol &mol, std::vector<double> &deltas, bool force) {
   ROMol::VERTEX_ITER atBegin, atEnd;
   boost::tie(atBegin, atEnd) = mol.getVertices();
   while (atBegin != atEnd) {
-    const Atom* at = mol[*atBegin];
+    const Atom *at = mol[*atBegin];
     unsigned int n = at->getAtomicNum();
     if (n <= 1) {
       deltas[at->getIdx()] = 0;
@@ -58,7 +58,7 @@ void nVals(const ROMol &mol, std::vector<double> &nVs, bool force) {
   ROMol::VERTEX_ITER atBegin, atEnd;
   boost::tie(atBegin, atEnd) = mol.getVertices();
   while (atBegin != atEnd) {
-    const Atom* at = mol[*atBegin];
+    const Atom *at = mol[*atBegin];
     double v = tbl->getNouterElecs(at->getAtomicNum()) - at->getTotalNumHs();
     if (v != 0.0) {
       v = 1. / sqrt(v);
@@ -165,14 +165,14 @@ double getAlpha(const Atom &atom, bool &found) {
   }
   return res;
 }
-}  // end of detail namespace
+}  // namespace detail
 
 double calcChiNv(const ROMol &mol, unsigned int n, bool force) {
   std::vector<double> hkDs(mol.getNumAtoms());
   detail::hkDeltas(mol, hkDs, force);
   PATH_LIST ps = findAllPathsOfLengthN(mol, n + 1, false);
   double res = 0.0;
-  for (const PATH_TYPE& p : ps) {
+  for (const auto &p : ps) {
     TEST_ASSERT(p.size() == n + 1);
     double accum = 1.0;
     for (unsigned int i = 0; i < n; ++i) {
@@ -191,7 +191,7 @@ double calcChiNn(const ROMol &mol, unsigned int n, bool force) {
   detail::nVals(mol, nVs, force);
   PATH_LIST ps = findAllPathsOfLengthN(mol, n + 1, false);
   double res = 0.0;
-  for (const PATH_TYPE& p : ps) {
+  for (const auto &p : ps) {
     TEST_ASSERT(p.size() == n + 1);
     double accum = 1.0;
     for (unsigned int i = 0; i < n; ++i) {
@@ -220,7 +220,7 @@ double calcChi1v(const ROMol &mol, bool force) {
   ROMol::EDGE_ITER firstB, lastB;
   boost::tie(firstB, lastB) = mol.getEdges();
   while (firstB != lastB) {
-    const Bond* bond = mol[*firstB];
+    const Bond *bond = mol[*firstB];
     res += hkDs[bond->getBeginAtomIdx()] * hkDs[bond->getEndAtomIdx()];
     ++firstB;
   }
@@ -249,7 +249,7 @@ double calcChi1n(const ROMol &mol, bool force) {
   ROMol::EDGE_ITER firstB, lastB;
   boost::tie(firstB, lastB) = mol.getEdges();
   while (firstB != lastB) {
-    const Bond* bond = mol[*firstB];
+    const Bond *bond = mol[*firstB];
     res += nVs[bond->getBeginAtomIdx()] * nVs[bond->getEndAtomIdx()];
     ++firstB;
   }
@@ -274,7 +274,7 @@ double calcHallKierAlpha(const ROMol &mol, std::vector<double> *atomContribs) {
   ROMol::VERTEX_ITER atBegin, atEnd;
   boost::tie(atBegin, atEnd) = mol.getVertices();
   while (atBegin != atEnd) {
-    const Atom* at = mol[*atBegin];
+    const Atom *at = mol[*atBegin];
     ++atBegin;
     unsigned int n = at->getAtomicNum();
     if (!n) {
@@ -348,4 +348,4 @@ double calcKappa3(const ROMol &mol) {
   return kappa;
 }
 }  // end of namespace Descriptors
-}
+}  // namespace RDKit

--- a/Code/GraphMol/Descriptors/GETAWAY.cpp
+++ b/Code/GraphMol/Descriptors/GETAWAY.cpp
@@ -46,7 +46,6 @@
 #include <Numerics/Matrix.h>
 #include <Numerics/SquareMatrix.h>
 #include <Numerics/SymmMatrix.h>
-#include <boost/foreach.hpp>
 #include <cmath>
 #include <Eigen/Dense>
 #include <Eigen/SVD>

--- a/Code/GraphMol/Descriptors/MQN.cpp
+++ b/Code/GraphMol/Descriptors/MQN.cpp
@@ -12,7 +12,6 @@
 #include <GraphMol/RDKitBase.h>
 #include <GraphMol/Descriptors/MolDescriptors.h>
 #include <GraphMol/Descriptors/Lipinski.h>
-#include <boost/foreach.hpp>
 #include <vector>
 #include <algorithm>
 
@@ -191,7 +190,7 @@ std::vector<unsigned int> calcMQNs(const ROMol& mol, bool force) {
 
   // ---------------------------------------------------
   //  ring size counts
-  BOOST_FOREACH (const INT_VECT& iv, mol.getRingInfo()->atomRings()) {
+  for (const auto& iv : mol.getRingInfo()->atomRings()) {
     if (iv.size() < 10) {
       res[iv.size() + 29]++;
     } else {

--- a/Code/GraphMol/Descriptors/PBF.cpp
+++ b/Code/GraphMol/Descriptors/PBF.cpp
@@ -55,7 +55,6 @@
 #include <Numerics/Matrix.h>
 #include <Numerics/SquareMatrix.h>
 #include <Numerics/SymmMatrix.h>
-#include <boost/foreach.hpp>
 
 #include <Eigen/Dense>
 
@@ -152,5 +151,5 @@ double PBF(const ROMol &mol, int confId) {
   return res;
 }
 
-}  // end of Descriptors namespace
-}  // end of RDKit namespace
+}  // namespace Descriptors
+}  // namespace RDKit

--- a/Code/GraphMol/Descriptors/Property.cpp
+++ b/Code/GraphMol/Descriptors/Property.cpp
@@ -74,7 +74,7 @@ void _registerDescriptors() {
   REGISTER_DESCRIPTOR(CrippenClogP, calcClogP);
   REGISTER_DESCRIPTOR(CrippenMR, calcMR);
 };
-}
+}  // namespace
 
 void registerDescriptors() {
 #ifdef RDK_THREADSAFE_SSS
@@ -105,8 +105,7 @@ int Properties::registerProperty(PropertyFunctor *prop) {
 std::vector<std::string> Properties::getAvailableProperties() {
   registerDescriptors();
   std::vector<std::string> names;
-  for (boost::shared_ptr<PropertyFunctor> prop :
-                 Properties::registry) {
+  for (auto prop : Properties::registry) {
     names.push_back(prop->getName());
   }
   return names;
@@ -115,8 +114,7 @@ std::vector<std::string> Properties::getAvailableProperties() {
 boost::shared_ptr<PropertyFunctor> Properties::getProperty(
     const std::string &name) {
   registerDescriptors();
-  for (boost::shared_ptr<PropertyFunctor> prop :
-                 Properties::registry) {
+  for (auto prop : Properties::registry) {
     if (prop.get() && prop->getName() == name) {
       return prop;
     }
@@ -126,22 +124,21 @@ boost::shared_ptr<PropertyFunctor> Properties::getProperty(
 
 Properties::Properties() : m_properties() {
   registerDescriptors();
-  for (boost::shared_ptr<PropertyFunctor> prop :
-                 Properties::registry) {
+  for (auto prop : Properties::registry) {
     m_properties.push_back(prop);
   }
 }
 
 Properties::Properties(const std::vector<std::string> &propNames) {
   registerDescriptors();
-  for (const std::string &name : propNames) {
+  for (const auto &name : propNames) {
     m_properties.push_back(Properties::getProperty(name));
   }
 }
 
 std::vector<std::string> Properties::getPropertyNames() const {
   std::vector<std::string> names;
-  for (boost::shared_ptr<PropertyFunctor> prop : m_properties) {
+  for (auto prop : m_properties) {
     names.push_back(prop->getName());
   }
   return names;
@@ -151,7 +148,7 @@ std::vector<double> Properties::computeProperties(const RDKit::ROMol &mol,
                                                   bool annotate) const {
   std::vector<double> res;
   res.reserve(m_properties.size());
-  for (boost::shared_ptr<PropertyFunctor> prop : m_properties) {
+  for (auto prop : m_properties) {
     res.push_back((*prop)(mol));
     if (annotate) {
       mol.setProp<double>(prop->getName(), (*prop)(mol));
@@ -161,7 +158,7 @@ std::vector<double> Properties::computeProperties(const RDKit::ROMol &mol,
 }
 
 void Properties::annotateProperties(RDKit::ROMol &mol) const {
-  for (boost::shared_ptr<PropertyFunctor> prop : m_properties) {
+  for (auto prop : m_properties) {
     mol.setProp<double>(prop->getName(), (*prop)(mol));
   }
 }
@@ -172,5 +169,5 @@ PROP_RANGE_QUERY *makePropertyRangeQuery(const std::string &name, double min,
   filter->setDataFunc(Properties::getProperty(name)->d_dataFunc);
   return filter;
 }
-}
-}
+}  // namespace Descriptors
+}  // namespace RDKit

--- a/Code/GraphMol/Descriptors/Property.cpp
+++ b/Code/GraphMol/Descriptors/Property.cpp
@@ -105,7 +105,7 @@ int Properties::registerProperty(PropertyFunctor *prop) {
 std::vector<std::string> Properties::getAvailableProperties() {
   registerDescriptors();
   std::vector<std::string> names;
-  BOOST_FOREACH (boost::shared_ptr<PropertyFunctor> prop,
+  for (boost::shared_ptr<PropertyFunctor> prop :
                  Properties::registry) {
     names.push_back(prop->getName());
   }
@@ -115,7 +115,7 @@ std::vector<std::string> Properties::getAvailableProperties() {
 boost::shared_ptr<PropertyFunctor> Properties::getProperty(
     const std::string &name) {
   registerDescriptors();
-  BOOST_FOREACH (boost::shared_ptr<PropertyFunctor> prop,
+  for (boost::shared_ptr<PropertyFunctor> prop :
                  Properties::registry) {
     if (prop.get() && prop->getName() == name) {
       return prop;
@@ -126,7 +126,7 @@ boost::shared_ptr<PropertyFunctor> Properties::getProperty(
 
 Properties::Properties() : m_properties() {
   registerDescriptors();
-  BOOST_FOREACH (boost::shared_ptr<PropertyFunctor> prop,
+  for (boost::shared_ptr<PropertyFunctor> prop :
                  Properties::registry) {
     m_properties.push_back(prop);
   }
@@ -134,14 +134,14 @@ Properties::Properties() : m_properties() {
 
 Properties::Properties(const std::vector<std::string> &propNames) {
   registerDescriptors();
-  BOOST_FOREACH (const std::string &name, propNames) {
+  for (const std::string &name : propNames) {
     m_properties.push_back(Properties::getProperty(name));
   }
 }
 
 std::vector<std::string> Properties::getPropertyNames() const {
   std::vector<std::string> names;
-  BOOST_FOREACH (boost::shared_ptr<PropertyFunctor> prop, m_properties) {
+  for (boost::shared_ptr<PropertyFunctor> prop : m_properties) {
     names.push_back(prop->getName());
   }
   return names;
@@ -151,7 +151,7 @@ std::vector<double> Properties::computeProperties(const RDKit::ROMol &mol,
                                                   bool annotate) const {
   std::vector<double> res;
   res.reserve(m_properties.size());
-  BOOST_FOREACH (boost::shared_ptr<PropertyFunctor> prop, m_properties) {
+  for (boost::shared_ptr<PropertyFunctor> prop : m_properties) {
     res.push_back((*prop)(mol));
     if (annotate) {
       mol.setProp<double>(prop->getName(), (*prop)(mol));
@@ -161,7 +161,7 @@ std::vector<double> Properties::computeProperties(const RDKit::ROMol &mol,
 }
 
 void Properties::annotateProperties(RDKit::ROMol &mol) const {
-  BOOST_FOREACH (boost::shared_ptr<PropertyFunctor> prop, m_properties) {
+  for (boost::shared_ptr<PropertyFunctor> prop : m_properties) {
     mol.setProp<double>(prop->getName(), (*prop)(mol));
   }
 }

--- a/Code/GraphMol/Descriptors/USRDescriptor.cpp
+++ b/Code/GraphMol/Descriptors/USRDescriptor.cpp
@@ -35,7 +35,6 @@
 #include <GraphMol/RDKitBase.h>
 #include <GraphMol/SmilesParse/SmilesParse.h>
 #include <GraphMol/Substruct/SubstructMatch.h>
-#include <boost/foreach.hpp>
 #include "USRDescriptor.h"
 
 #include <boost/flyweight.hpp>
@@ -51,7 +50,7 @@ void calcDistances(const RDGeom::Point3DConstPtrVect &coords,
   distances.resize(coords.size());
   unsigned int i = 0;
   // loop over coordinates
-  BOOST_FOREACH (const RDGeom::Point3D *tpp, coords) {
+  for (const auto *tpp : coords) {
     distances[i++] = (*tpp - point).length();
   }
 }
@@ -62,7 +61,9 @@ void calcCentroid(const RDGeom::Point3DConstPtrVect &coords,
   // set pt to zero
   pt *= 0.0;
   // loop over coordinates
-  BOOST_FOREACH (const RDGeom::Point3D *opt, coords) { pt += *opt; }
+  for (const auto *opt : coords) {
+    pt += *opt;
+  }
   pt /= coords.size();
 }
 
@@ -164,7 +165,7 @@ void getAtomIdsForFeatures(const ROMol &mol,
                "atomIds must have be the same size as featureSmarts");
   std::vector<const ROMol *> featureMatchers;
   featureMatchers.reserve(numFeatures);
-  BOOST_FOREACH (const std::string &feature, featureSmarts) {
+  for (const auto &feature : featureSmarts) {
     const ROMol *matcher = pattern_flyweight(feature).get().getMatcher();
     featureMatchers.push_back(matcher);
   }
@@ -172,10 +173,9 @@ void getAtomIdsForFeatures(const ROMol &mol,
     std::vector<MatchVectType> matchVect;
     // to maintain thread safety, we have to copy the pattern molecules:
     SubstructMatch(mol, ROMol(*featureMatchers[i], true), matchVect);
-    BOOST_FOREACH (MatchVectType mv, matchVect) {
-      for (MatchVectType::const_iterator mIt = mv.begin(); mIt != mv.end();
-           ++mIt) {
-        atomIds[i].push_back(mIt->second);
+    for (const auto &mv : matchVect) {
+      for (auto mi : mv) {
+        atomIds[i].push_back(mi.second);
       }
     }
   }  // end loop over features
@@ -249,11 +249,11 @@ void USRCAT(const ROMol &mol, std::vector<double> &descriptor,
 
   // loop over the atom selections
   unsigned int featIdx = 12;
-  BOOST_FOREACH (std::vector<unsigned int> atomsInClass, atomIds) {
+  for (const auto &atomsInClass : atomIds) {
     // reduce the coordinates to the atoms of interest
     RDGeom::Point3DConstPtrVect reducedCoords;
     reducedCoords.reserve(atomsInClass.size());
-    BOOST_FOREACH (unsigned int idx, atomsInClass) {
+    for (const auto idx : atomsInClass) {
       reducedCoords.push_back(coords[idx]);
     }
     calcUSRDistributionsFromPoints(reducedCoords, points, distribs);

--- a/Code/GraphMol/Descriptors/Wrap/rdMolDescriptors.cpp
+++ b/Code/GraphMol/Descriptors/Wrap/rdMolDescriptors.cpp
@@ -12,7 +12,6 @@
 #include <GraphMol/GraphMol.h>
 
 #include <RDGeneral/BoostStartInclude.h>
-#include <boost/foreach.hpp>
 #include <RDGeneral/BoostEndInclude.h>
 
 #include <GraphMol/Descriptors/MolDescriptors.h>
@@ -132,7 +131,9 @@ python::list calcEEMcharges(RDKit::ROMol &mol, int confId) {
   std::vector<double> res;
   RDKit::Descriptors::EEM(mol, res, confId);
   python::list pyres;
-  BOOST_FOREACH (double iv, res) { pyres.append(iv); }
+  for (const auto iv : res) {
+    pyres.append(iv);
+  }
   return pyres;
 }
 
@@ -141,7 +142,9 @@ python::list calcWHIMs(const RDKit::ROMol &mol, int confId, double thresh,
   std::vector<double> res;
   RDKit::Descriptors::WHIM(mol, res, confId, thresh, CustomAtomProperty);
   python::list pyres;
-  BOOST_FOREACH (double iv, res) { pyres.append(iv); }
+  for (const auto iv : res) {
+    pyres.append(iv);
+  }
   return pyres;
 }
 
@@ -150,7 +153,9 @@ python::list calcGETAWAYs(const RDKit::ROMol &mol, int confId, double precision,
   std::vector<double> res;
   RDKit::Descriptors::GETAWAY(mol, res, confId, precision, CustomAtomProperty);
   python::list pyres;
-  BOOST_FOREACH (double iv, res) { pyres.append(iv); }
+  for (const auto iv : res) {
+    pyres.append(iv);
+  }
   return pyres;
 }
 
@@ -159,7 +164,9 @@ python::list calcRDFs(const RDKit::ROMol &mol, int confId,
   std::vector<double> res;
   RDKit::Descriptors::RDF(mol, res, confId, CustomAtomProperty);
   python::list pyres;
-  BOOST_FOREACH (double iv, res) { pyres.append(iv); }
+  for (const auto iv : res) {
+    pyres.append(iv);
+  }
   return pyres;
 }
 
@@ -168,7 +175,9 @@ python::list calcMORSEs(const RDKit::ROMol &mol, int confId,
   std::vector<double> res;
   RDKit::Descriptors::MORSE(mol, res, confId, CustomAtomProperty);
   python::list pyres;
-  BOOST_FOREACH (double iv, res) { pyres.append(iv); }
+  for (const auto iv : res) {
+    pyres.append(iv);
+  }
   return pyres;
 }
 
@@ -177,7 +186,9 @@ python::list calcAUTOCORR3Ds(const RDKit::ROMol &mol, int confId,
   std::vector<double> res;
   RDKit::Descriptors::AUTOCORR3D(mol, res, confId, CustomAtomProperty);
   python::list pyres;
-  BOOST_FOREACH (double iv, res) { pyres.append(iv); }
+  for (const auto iv : res) {
+    pyres.append(iv);
+  }
   return pyres;
 }
 
@@ -186,7 +197,9 @@ python::list calcAUTOCORR2Ds(const RDKit::ROMol &mol,
   std::vector<double> res;
   RDKit::Descriptors::AUTOCORR2D(mol, res, CustomAtomProperty);
   python::list pyres;
-  BOOST_FOREACH (double iv, res) { pyres.append(iv); }
+  for (const auto iv : res) {
+    pyres.append(iv);
+  }
   return pyres;
 }
 
@@ -340,9 +353,9 @@ double hkAlphaHelper(const RDKit::ROMol &mol, python::object atomContribs) {
 }
 
 RDKit::SparseIntVect<std::uint32_t> *MorganFingerprintHelper(
-    const RDKit::ROMol &mol, unsigned int radius, int nBits, python::object invariants,
-    python::object fromAtoms, bool useChirality, bool useBondTypes,
-    bool useFeatures, bool useCounts, python::object bitInfo,
+    const RDKit::ROMol &mol, unsigned int radius, int nBits,
+    python::object invariants, python::object fromAtoms, bool useChirality,
+    bool useBondTypes, bool useFeatures, bool useCounts, python::object bitInfo,
     bool includeRedundantEnvironments) {
   std::vector<boost::uint32_t> *invars = nullptr;
   if (invariants) {
@@ -470,9 +483,9 @@ RDKit::SparseIntVect<std::uint32_t> *GetMorganFingerprint(
       useFeatures, useCounts, bitInfo, includeRedundantEnvironments);
 }
 RDKit::SparseIntVect<std::uint32_t> *GetHashedMorganFingerprint(
-    const RDKit::ROMol &mol, unsigned int radius, unsigned int nBits, python::object invariants,
-    python::object fromAtoms, bool useChirality, bool useBondTypes,
-    bool useFeatures, python::object bitInfo,
+    const RDKit::ROMol &mol, unsigned int radius, unsigned int nBits,
+    python::object invariants, python::object fromAtoms, bool useChirality,
+    bool useBondTypes, bool useFeatures, python::object bitInfo,
     bool includeRedundantEnvironments) {
   return MorganFingerprintHelper(mol, radius, nBits, invariants, fromAtoms,
                                  useChirality, useBondTypes, useFeatures, true,
@@ -512,10 +525,8 @@ ExplicitBitVect *GetMorganFingerprintBV(
   }
   ExplicitBitVect *res;
   res = RDKit::MorganFingerprints::getFingerprintAsBitVect(
-      mol, radius, nBits,
-      invars, froms.get(), useChirality,
-      useBondTypes, false, bitInfoMap,
-      includeRedundantEnvironments);
+      mol, radius, nBits, invars, froms.get(), useChirality, useBondTypes,
+      false, bitInfoMap, includeRedundantEnvironments);
   if (bitInfoMap) {
     bitInfo.attr("clear")();
     for (RDKit::MorganFingerprints::BitInfoMap::const_iterator iter =
@@ -552,14 +563,18 @@ python::list GetConnectivityInvariants(const RDKit::ROMol &mol,
   RDKit::MorganFingerprints::getConnectivityInvariants(mol, invars,
                                                        includeRingMembership);
   python::list res;
-  BOOST_FOREACH (std::uint32_t iv, invars) { res.append(python::long_(iv)); }
+  for (const auto iv : invars) {
+    res.append(python::long_(iv));
+  }
   return res;
 }
 python::list GetFeatureInvariants(const RDKit::ROMol &mol) {
   std::vector<std::uint32_t> invars(mol.getNumAtoms());
   RDKit::MorganFingerprints::getFeatureInvariants(mol, invars);
   python::list res;
-  BOOST_FOREACH (std::uint32_t iv, invars) { res.append(python::long_(iv)); }
+  for (const auto iv : invars) {
+    res.append(python::long_(iv));
+  }
   return res;
 }
 
@@ -573,7 +588,9 @@ python::list GetUSR(const RDKit::ROMol &mol, int confId) {
   std::vector<double> descriptor(12);
   RDKit::Descriptors::USR(mol, descriptor, confId);
   python::list pyDescr;
-  BOOST_FOREACH (double d, descriptor) { pyDescr.append(d); }
+  for (const auto d : descriptor) {
+    pyDescr.append(d);
+  }
   return pyDescr;
 }
 
@@ -595,16 +612,22 @@ python::list GetUSRDistributions(python::object coords, python::object points) {
   if (points != python::object()) {
     // make sure the optional argument actually was a list
     python::list tmpPts = python::extract<python::list>(points);
-    BOOST_FOREACH (RDGeom::Point3D p, pts) { tmpPts.append(p); }
+    for (const auto &p : pts) {
+      tmpPts.append(p);
+    }
     points = tmpPts;
   }
   python::list pyDist;
-  BOOST_FOREACH (std::vector<double> dist, distances) {
+  for (const auto &dist : distances) {
     python::list pytmp;
-    BOOST_FOREACH (double d, dist) { pytmp.append(d); }
+    for (const auto d : dist) {
+      pytmp.append(d);
+    }
     pyDist.append(pytmp);
   }
-  BOOST_FOREACH (const RDGeom::Point3D *pt, c) { delete pt; }
+  for (const auto *pt : c) {
+    delete pt;
+  }
   return pyDist;
 }
 
@@ -632,12 +655,16 @@ python::list GetUSRDistributionsFromPoints(python::object coords,
   std::vector<std::vector<double>> distances(numPts);
   RDKit::Descriptors::calcUSRDistributionsFromPoints(c, p, distances);
   python::list pyDist;
-  BOOST_FOREACH (std::vector<double> dist, distances) {
+  for (const auto &dist : distances) {
     python::list pytmp;
-    BOOST_FOREACH (double d, dist) { pytmp.append(d); }
+    for (const auto d : dist) {
+      pytmp.append(d);
+    }
     pyDist.append(pytmp);
   }
-  BOOST_FOREACH (const RDGeom::Point3D *pt, c) { delete pt; }
+  for (const auto *pt : c) {
+    delete pt;
+  }
   return pyDist;
 }
 
@@ -663,7 +690,9 @@ python::list GetUSRFromDistributions(python::object distances) {
   std::vector<double> descriptor(12);
   RDKit::Descriptors::calcUSRFromDistributions(dist, descriptor);
   python::list pyDescr;
-  BOOST_FOREACH (double d, descriptor) { pyDescr.append(d); }
+  for (const auto d : descriptor) {
+    pyDescr.append(d);
+  }
   return pyDescr;
 }
 
@@ -731,7 +760,9 @@ python::list GetUSRCAT(const RDKit::ROMol &mol, python::object atomSelections,
   std::vector<double> descriptor(sizeDescriptor);
   RDKit::Descriptors::USRCAT(mol, descriptor, atomIds, confId);
   python::list pyDescr;
-  BOOST_FOREACH (double d, descriptor) { pyDescr.append(d); }
+  for (const auto d : descriptor) {
+    pyDescr.append(d);
+  }
   return pyDescr;
 }
 
@@ -751,7 +782,9 @@ python::list CalcSlogPVSA(const RDKit::ROMol &mol, python::object bins,
   res = RDKit::Descriptors::calcSlogP_VSA(mol, lbins, force);
 
   python::list pyres;
-  BOOST_FOREACH (double dv, res) { pyres.append(dv); }
+  for (const auto d : res) {
+    pyres.append(d);
+  }
   return pyres;
 }
 python::list CalcSMRVSA(const RDKit::ROMol &mol, python::object bins,
@@ -770,7 +803,9 @@ python::list CalcSMRVSA(const RDKit::ROMol &mol, python::object bins,
   res = RDKit::Descriptors::calcSMR_VSA(mol, lbins, force);
 
   python::list pyres;
-  BOOST_FOREACH (double dv, res) { pyres.append(dv); }
+  for (const auto d : res) {
+    pyres.append(d);
+  }
   return pyres;
 }
 python::list CalcPEOEVSA(const RDKit::ROMol &mol, python::object bins,
@@ -789,7 +824,9 @@ python::list CalcPEOEVSA(const RDKit::ROMol &mol, python::object bins,
   res = RDKit::Descriptors::calcPEOE_VSA(mol, lbins, force);
 
   python::list pyres;
-  BOOST_FOREACH (double dv, res) { pyres.append(dv); }
+  for (const auto d : res) {
+    pyres.append(d);
+  }
   return pyres;
 }
 python::list CalcCustomPropVSA(const RDKit::ROMol &mol,
@@ -805,7 +842,9 @@ python::list CalcCustomPropVSA(const RDKit::ROMol &mol,
       RDKit::Descriptors::calcCustomProp_VSA(mol, customPropName, lbins, force);
 
   python::list pyres;
-  BOOST_FOREACH (double dv, res) { pyres.append(dv); }
+  for (const auto d : res) {
+    pyres.append(d);
+  }
   return pyres;
 }
 python::list CalcMQNs(const RDKit::ROMol &mol, bool force) {
@@ -813,7 +852,9 @@ python::list CalcMQNs(const RDKit::ROMol &mol, bool force) {
   res = RDKit::Descriptors::calcMQNs(mol, force);
 
   python::list pyres;
-  BOOST_FOREACH (unsigned int iv, res) { pyres.append(iv); }
+  for (const auto d : res) {
+    pyres.append(d);
+  }
   return pyres;
 }
 
@@ -823,7 +864,9 @@ unsigned int numSpiroAtoms(const RDKit::ROMol &mol, python::object pyatoms) {
       mol, pyatoms != python::object() ? &ats : nullptr);
   if (pyatoms != python::object()) {
     python::list pyres = python::extract<python::list>(pyatoms);
-    BOOST_FOREACH (unsigned int iv, ats) { pyres.append(iv); }
+    for (const auto d : ats) {
+      pyres.append(d);
+    }
   }
   return res;
 }
@@ -834,7 +877,9 @@ unsigned int numBridgeheadAtoms(const RDKit::ROMol &mol,
       mol, pyatoms != python::object() ? &ats : nullptr);
   if (pyatoms != python::object()) {
     python::list pyres = python::extract<python::list>(pyatoms);
-    BOOST_FOREACH (unsigned int iv, ats) { pyres.append(iv); }
+    for (const auto d : ats) {
+      pyres.append(d);
+    }
   }
   return res;
 }

--- a/Code/GraphMol/Descriptors/test.cpp
+++ b/Code/GraphMol/Descriptors/test.cpp
@@ -1883,7 +1883,7 @@ void testProperties() {
     std::vector<double> props = sink.computeProperties(*mol);
 
     std::vector<double> res;
-    BOOST_FOREACH (std::string prop, all_names) {
+    for (const auto& prop : all_names) {
       std::vector<std::string> props;
       props.push_back(prop);
       Properties property(props);

--- a/Code/GraphMol/DistGeomHelpers/BoundsMatrixBuilder.cpp
+++ b/Code/GraphMol/DistGeomHelpers/BoundsMatrixBuilder.cpp
@@ -619,7 +619,7 @@ void _setInRing14Bounds(const ROMol &mol, const Bond *bnd1, const Bond *bnd2,
     if (mol.getRingInfo()->numBondRings(bid2) > 1) {
       if (mol.getRingInfo()->numBondRings(bid1) == 1 &&
           mol.getRingInfo()->numBondRings(bid3) == 1) {
-        for (const INT_VECT &br : mol.getRingInfo()->bondRings()) {
+        for (const auto &br : mol.getRingInfo()->bondRings()) {
           if (std::find(br.begin(), br.end(), bid1) != br.end()) {
             if (std::find(br.begin(), br.end(), bid3) != br.end()) {
               preferCis = true;
@@ -834,10 +834,9 @@ bool _checkAmideEster14(const Bond *bnd1, const Bond *bnd3, const Atom *atm1,
 //    1   3
 //     \ / \                                         T.S.I.Left Blank
 //      2   4  <- 2 is an oxygen/nitrogen
-bool _checkMacrocycleAllInSameRingAmideEster14(const ROMol &mol, const Bond *bnd1,
-                                  const Bond *bnd3, const Atom *atm1,
-                                  const Atom *atm2, const Atom *atm3,
-                                  const Atom *atm4) {
+bool _checkMacrocycleAllInSameRingAmideEster14(
+    const ROMol &mol, const Bond *bnd1, const Bond *bnd3, const Atom *atm1,
+    const Atom *atm2, const Atom *atm3, const Atom *atm4) {
   RDUNUSED_PARAM(bnd1);
   RDUNUSED_PARAM(bnd3);
 
@@ -857,7 +856,8 @@ bool _checkMacrocycleAllInSameRingAmideEster14(const ROMol &mol, const Bond *bnd
         if (*nbrIdx != atm1->getIdx() && *nbrIdx != atm3->getIdx()) {
           const auto &res = mol.getAtomWithIdx(*nbrIdx);
           const auto &resbnd = mol.getBondBetweenAtoms(atm2->getIdx(), *nbrIdx);
-          if ((res->getAtomicNum() != 6 && res->getAtomicNum() != 1) || //check is (methylated)amide
+          if ((res->getAtomicNum() != 6 &&
+               res->getAtomicNum() != 1) ||  // check is (methylated)amide
               resbnd->getBondType() != Bond::SINGLE) {
             return false;
           }
@@ -871,7 +871,7 @@ bool _checkMacrocycleAllInSameRingAmideEster14(const ROMol &mol, const Bond *bnd
         if (*nbrIdx != atm2->getIdx() && *nbrIdx != atm4->getIdx()) {
           const auto &res = mol.getAtomWithIdx(*nbrIdx);
           const auto &resbnd = mol.getBondBetweenAtoms(atm3->getIdx(), *nbrIdx);
-          if (res->getAtomicNum() != 8 || //check for the carbonyl oxygen
+          if (res->getAtomicNum() != 8 ||  // check for the carbonyl oxygen
               resbnd->getBondType() != Bond::DOUBLE) {
             return false;
           }
@@ -1193,23 +1193,24 @@ void _record14Path(const ROMol &mol, unsigned int bid1, unsigned int bid2,
   accumData.paths14.push_back(path14);
 }
 
-// this is adapted from `_checkAmideEster14`, with only changing 
+// this is adapted from `_checkAmideEster14`, with only changing
 // (a2Num == 7 && atm2->getTotalNumHs() == 1) into
 // (a2Num == 7).
 // This is necessary as the original function does not detect attached
 // hydrogen even when is present (possibly due to explict/implicit H-count?),
 // a new function is used (currently only for macrocycle treatment with ETKDGv3)
-// in order to not break backward compatibility (also allow recognising methylated amide)
-// here we look for something like this:
-// It's an amide or ester:
+// in order to not break backward compatibility (also allow recognising
+// methylated amide) here we look for something like this: It's an amide or
+// ester:
 //
 //        4    <- 4 is the O
 //        |    <- That's the double bond
 //    1   3
 //     \ / \                                         T.S.I.Left Blank
 //      2   5  <- 2 is an oxygen/nitrogen
-bool _checkMacrocycleTwoInSameRingAmideEster14(const Bond *bnd1, const Bond *bnd3, const Atom *atm1,
-                        const Atom *atm2, const Atom *atm3, const Atom *atm4) {
+bool _checkMacrocycleTwoInSameRingAmideEster14(
+    const Bond *bnd1, const Bond *bnd3, const Atom *atm1, const Atom *atm2,
+    const Atom *atm3, const Atom *atm4) {
   unsigned int a1Num = atm1->getAtomicNum();
   unsigned int a2Num = atm2->getAtomicNum();
   unsigned int a3Num = atm3->getAtomicNum();
@@ -1217,16 +1218,17 @@ bool _checkMacrocycleTwoInSameRingAmideEster14(const Bond *bnd1, const Bond *bnd
 
   if (a1Num != 1 && a3Num == 6 && bnd3->getBondType() == Bond::DOUBLE &&
       (a4Num == 8 || a4Num == 7) && bnd1->getBondType() == Bond::SINGLE &&
-      (a2Num == 8 || (a2Num == 7 ))) {
+      (a2Num == 8 || (a2Num == 7))) {
     return true;
   }
   return false;
 }
 
 void _setMacrocycleTwoInSameRing14Bounds(const ROMol &mol, const Bond *bnd1,
-                               const Bond *bnd2, const Bond *bnd3,
-                               ComputedData &accumData,
-                               DistGeom::BoundsMatPtr mmat, double *dmat) {
+                                         const Bond *bnd2, const Bond *bnd3,
+                                         ComputedData &accumData,
+                                         DistGeom::BoundsMatPtr mmat,
+                                         double *dmat) {
   PRECONDITION(bnd1, "");
   PRECONDITION(bnd2, "");
   PRECONDITION(bnd3, "");
@@ -1243,7 +1245,6 @@ void _setMacrocycleTwoInSameRing14Bounds(const ROMol &mol, const Bond *bnd1,
   unsigned int aid4 = bnd3->getOtherAtomIdx(atm3->getIdx());
   const Atom *atm1 = mol.getAtomWithIdx(aid1);
   const Atom *atm4 = mol.getAtomWithIdx(aid4);
-
 
   // check that this actually is a 1-4 contact:
   if (dmat[std::max(aid1, aid4) * mmat->numRows() + std::min(aid1, aid4)] <
@@ -1279,8 +1280,10 @@ void _setMacrocycleTwoInSameRing14Bounds(const ROMol &mol, const Bond *bnd1,
   path14.bid1 = bid1;
   path14.bid2 = bid2;
   path14.bid3 = bid3;
-  if ((_checkMacrocycleTwoInSameRingAmideEster14(bnd1, bnd3, atm1, atm2, atm3, atm4)) ||
-      (_checkMacrocycleTwoInSameRingAmideEster14(bnd3, bnd1, atm4, atm3, atm2, atm1))) {
+  if ((_checkMacrocycleTwoInSameRingAmideEster14(bnd1, bnd3, atm1, atm2, atm3,
+                                                 atm4)) ||
+      (_checkMacrocycleTwoInSameRingAmideEster14(bnd3, bnd1, atm4, atm3, atm2,
+                                                 atm1))) {
     dl = RDGeom::compute14DistCis(bl1, bl2, bl3, ba12, ba23);
     path14.type = Path14Configuration::CIS;
     accumData.cisPaths[bid1 * nb * nb + bid2 * nb + bid3] = 1;
@@ -1288,7 +1291,8 @@ void _setMacrocycleTwoInSameRing14Bounds(const ROMol &mol, const Bond *bnd1,
     du = dl;
     dl -= GEN_DIST_TOL;
     du += GEN_DIST_TOL;
-  } else if ((ahyb2 == Atom::SP2) && (ahyb3 == Atom::SP2)) {  // FIX: check for trans
+  } else if ((ahyb2 == Atom::SP2) &&
+             (ahyb3 == Atom::SP2)) {  // FIX: check for trans
     // here we will assume 180 degrees: basically flat ring with an external
     // substituent
     dl = RDGeom::compute14DistTrans(bl1, bl2, bl3, ba12, ba23);
@@ -1323,9 +1327,10 @@ void _setMacrocycleTwoInSameRing14Bounds(const ROMol &mol, const Bond *bnd1,
 }
 
 void _setMacrocycleAllInSameRing14Bounds(const ROMol &mol, const Bond *bnd1,
-                            const Bond *bnd2, const Bond *bnd3,
-                            ComputedData &accumData,
-                            DistGeom::BoundsMatPtr mmat, double *dmat) {
+                                         const Bond *bnd2, const Bond *bnd3,
+                                         ComputedData &accumData,
+                                         DistGeom::BoundsMatPtr mmat,
+                                         double *dmat) {
   // This is adapted from `_setChain14Bounds`, with changes on how trans amide
   // is handled
   RDUNUSED_PARAM(dmat);
@@ -1448,10 +1453,10 @@ void _setMacrocycleAllInSameRing14Bounds(const ROMol &mol, const Bond *bnd1,
         path14.type = Path14Configuration::OTHER;
         // BOOST_LOG(rdDebugLog) << "Special 9 " << aid1 << " " << aid4 <<
         // "\n";
-      } else if ((_checkMacrocycleAllInSameRingAmideEster14(mol, bnd1, bnd3, atm1, atm2,
-                                               atm3, atm4)) ||
-                 (_checkMacrocycleAllInSameRingAmideEster14(mol, bnd3, bnd1, atm4, atm3,
-                                               atm2, atm1))) {
+      } else if ((_checkMacrocycleAllInSameRingAmideEster14(
+                     mol, bnd1, bnd3, atm1, atm2, atm3, atm4)) ||
+                 (_checkMacrocycleAllInSameRingAmideEster14(
+                     mol, bnd3, bnd1, atm4, atm3, atm2, atm1))) {
         dl =
             RDGeom::compute14DistTrans(bl1, bl2, bl3, ba12, ba23) +
             0.1;  // we saw that the currently defined max distance for trans is
@@ -1615,14 +1620,14 @@ void set14Bounds(const ROMol &mol, DistGeom::BoundsMatPtr mmat,
                 // either (bid1, bid2) or (bid2, bid3) are in the
                 // same ring (note all three cannot be in the same
                 // ring; we dealt with that before)
-                if (useMacrocycle14config && bidIsMacrocycle.find(bid2) != bidIsMacrocycle.end()) {		
-                  _setMacrocycleTwoInSameRing14Bounds(mol, bnd1, (*bi), bnd3, accumData,
+                if (useMacrocycle14config &&
+                    bidIsMacrocycle.find(bid2) != bidIsMacrocycle.end()) {
+                  _setMacrocycleTwoInSameRing14Bounds(
+                      mol, bnd1, (*bi), bnd3, accumData, mmat, distMatrix);
+                } else {
+                  _setTwoInSameRing14Bounds(mol, bnd1, (*bi), bnd3, accumData,
                                             mmat, distMatrix);
                 }
-		else{
-                  _setTwoInSameRing14Bounds(mol, bnd1, (*bi), bnd3, accumData,
-                                          mmat, distMatrix);
-		}
               } else if (((rinfo->numBondRings(bid1) > 0) &&
                           (rinfo->numBondRings(bid2) > 0)) ||
                          ((rinfo->numBondRings(bid2) > 0) &&

--- a/Code/GraphMol/DistGeomHelpers/BoundsMatrixBuilder.cpp
+++ b/Code/GraphMol/DistGeomHelpers/BoundsMatrixBuilder.cpp
@@ -619,7 +619,7 @@ void _setInRing14Bounds(const ROMol &mol, const Bond *bnd1, const Bond *bnd2,
     if (mol.getRingInfo()->numBondRings(bid2) > 1) {
       if (mol.getRingInfo()->numBondRings(bid1) == 1 &&
           mol.getRingInfo()->numBondRings(bid3) == 1) {
-        BOOST_FOREACH (const INT_VECT &br, mol.getRingInfo()->bondRings()) {
+        for (const INT_VECT &br : mol.getRingInfo()->bondRings()) {
           if (std::find(br.begin(), br.end(), bid1) != br.end()) {
             if (std::find(br.begin(), br.end(), bid3) != br.end()) {
               preferCis = true;

--- a/Code/GraphMol/FileParsers/MolFileWriter.cpp
+++ b/Code/GraphMol/FileParsers/MolFileWriter.cpp
@@ -313,7 +313,7 @@ const std::string GetMolFileQueryInfo(
       } else {
         ss << " F ";
       }
-      for (int val : vals) {
+      for (auto val : vals) {
         ss << std::setw(4) << std::left
            << (PeriodicTable::getTable()->getElementSymbol(val));
       }

--- a/Code/GraphMol/FileParsers/MolFileWriter.cpp
+++ b/Code/GraphMol/FileParsers/MolFileWriter.cpp
@@ -313,7 +313,7 @@ const std::string GetMolFileQueryInfo(
       } else {
         ss << " F ";
       }
-      BOOST_FOREACH (int val, vals) {
+      for (int val : vals) {
         ss << std::setw(4) << std::left
            << (PeriodicTable::getTable()->getElementSymbol(val));
       }

--- a/Code/GraphMol/FileParsers/testMolWriter.cpp
+++ b/Code/GraphMol/FileParsers/testMolWriter.cpp
@@ -1468,7 +1468,7 @@ void testGetSDText() {
       std::string csmi2 = MolToSmiles(*mol2, true);
       TEST_ASSERT(csmi1 == csmi2);
       STR_VECT pns = mol->getPropList(false, false);
-      BOOST_FOREACH (const std::string &pn, pns) {
+      for (const std::string &pn : pns) {
         TEST_ASSERT(mol2->hasProp(pn));
         TEST_ASSERT(mol->getProp<std::string>(pn) ==
                     mol2->getProp<std::string>(pn));

--- a/Code/GraphMol/FileParsers/testMolWriter.cpp
+++ b/Code/GraphMol/FileParsers/testMolWriter.cpp
@@ -1468,7 +1468,7 @@ void testGetSDText() {
       std::string csmi2 = MolToSmiles(*mol2, true);
       TEST_ASSERT(csmi1 == csmi2);
       STR_VECT pns = mol->getPropList(false, false);
-      for (const std::string &pn : pns) {
+      for (const auto &pn : pns) {
         TEST_ASSERT(mol2->hasProp(pn));
         TEST_ASSERT(mol->getProp<std::string>(pn) ==
                     mol2->getProp<std::string>(pn));

--- a/Code/GraphMol/FilterCatalog/FilterMatchers.cpp
+++ b/Code/GraphMol/FilterCatalog/FilterMatchers.cpp
@@ -40,7 +40,7 @@ const char *SMARTS_MATCH_NAME_DEFAULT = "Unnamed SmartsMatcher";
 namespace {
 const int debugParse = 0;
 const bool mergeHs = true;
-}
+}  // namespace
 SmartsMatcher::SmartsMatcher(const ROMol &pattern, unsigned int minCount,
                              unsigned int maxCount)
     : FilterMatcherBase(SMARTS_MATCH_NAME_DEFAULT),
@@ -138,8 +138,7 @@ bool FilterHierarchyMatcher::getMatches(const ROMol &mol,
   if (result) {
     std::vector<FilterMatch> children;
 
-    for (boost::shared_ptr<FilterHierarchyMatcher> matcher :
-                   d_children) {
+    for (auto matcher : d_children) {
       matcher->getMatches(mol, children);
     }
 
@@ -152,4 +151,4 @@ bool FilterHierarchyMatcher::getMatches(const ROMol &mol,
 
   return result;
 }
-}
+}  // namespace RDKit

--- a/Code/GraphMol/FilterCatalog/FilterMatchers.cpp
+++ b/Code/GraphMol/FilterCatalog/FilterMatchers.cpp
@@ -138,7 +138,7 @@ bool FilterHierarchyMatcher::getMatches(const ROMol &mol,
   if (result) {
     std::vector<FilterMatch> children;
 
-    BOOST_FOREACH (boost::shared_ptr<FilterHierarchyMatcher> matcher,
+    for (boost::shared_ptr<FilterHierarchyMatcher> matcher :
                    d_children) {
       matcher->getMatches(mol, children);
     }

--- a/Code/GraphMol/FilterCatalog/filtercatalogtest.cpp
+++ b/Code/GraphMol/FilterCatalog/filtercatalogtest.cpp
@@ -38,7 +38,6 @@
 #include <iostream>
 #include <map>
 #include <algorithm>
-#include <boost/foreach.hpp>
 
 using namespace RDKit;
 using namespace std;
@@ -87,51 +86,24 @@ void testFilterCatalog() {
 
     FilterCatalog catalog(params);
     boost::scoped_ptr<ROMol> mol;
-    const IntPair match1[10] = {{0, 23},
-                                {1, 22},
-                                {2, 20},
-                                {3, 19},
-                                {4, 25},
-                                {5, 24},
-                                {6, 18},
-                                {7, 17},
-                                {8, 16},
-                                {9, 21}};
+    const IntPair match1[10] = {{0, 23}, {1, 22}, {2, 20}, {3, 19}, {4, 25},
+                                {5, 24}, {6, 18}, {7, 17}, {8, 16}, {9, 21}};
     MatchVectType matchvec1;
     for (auto i : match1) {
       matchvec1.push_back(std::make_pair(i.first, i.second));
     }
 
-    const IntPair match2[13] = {{0, 11},
-                                {1, 12},
-                                {2, 13},
-                                {3, 14},
-                                {4, 15},
-                                {5, 10},
-                                {6, 9},
-                                {7, 8},
-                                {8, 7},
-                                {9, 6},
-                                {10, 5},
-                                {11, 17},
-                                {12, 16}};
+    const IntPair match2[13] = {{0, 11}, {1, 12},  {2, 13}, {3, 14}, {4, 15},
+                                {5, 10}, {6, 9},   {7, 8},  {8, 7},  {9, 6},
+                                {10, 5}, {11, 17}, {12, 16}};
     MatchVectType matchvec2;
     for (auto i : match2) {
       matchvec2.push_back(std::make_pair(i.first, i.second));
     }
 
-    const IntPair match3[12] = {{0, 0},
-                                {1, 1},
-                                {2, 2},
-                                {3, 4},
-                                {4, 5},
-                                {5, 6},
-                                {6, 7},
-                                {7, 8},
-                                {8, 9},
-                                {9, 14},
-                                {10, 15},
-                                {11, 16}};
+    const IntPair match3[12] = {{0, 0}, {1, 1},  {2, 2},   {3, 4},
+                                {4, 5}, {5, 6},  {6, 7},   {7, 8},
+                                {8, 9}, {9, 14}, {10, 15}, {11, 16}};
     MatchVectType matchvec3;
     for (auto i : match3) {
       matchvec3.push_back(std::make_pair(i.first, i.second));
@@ -227,51 +199,50 @@ void testFilterCatalogEntry() {
 }
 
 void testFilterCatalogThreadedRunner() {
-    FilterCatalogParams params;
-    params.addCatalog(FilterCatalogParams::PAINS_A);
-    params.addCatalog(FilterCatalogParams::PAINS_B);
-    params.addCatalog(FilterCatalogParams::PAINS_C);
+  FilterCatalogParams params;
+  params.addCatalog(FilterCatalogParams::PAINS_A);
+  params.addCatalog(FilterCatalogParams::PAINS_B);
+  params.addCatalog(FilterCatalogParams::PAINS_C);
 
-    FilterCatalog catalog(params);
-    
-    std::string pathName = getenv("RDBASE");
-    pathName += "/Code/GraphMol/test_data/pains.smi";
+  FilterCatalog catalog(params);
 
-    std::ifstream infile(pathName);
-    std::vector<std::string> smiles;
+  std::string pathName = getenv("RDBASE");
+  pathName += "/Code/GraphMol/test_data/pains.smi";
 
-    std::string line;
-    int count=0;
-    while (std::getline(infile, line))
-    {
-      if (count) {
-	std::cerr << line << std::endl;
-	smiles.push_back(line);
-      }
-      count += 1;
+  std::ifstream infile(pathName);
+  std::vector<std::string> smiles;
+
+  std::string line;
+  int count = 0;
+  while (std::getline(infile, line)) {
+    if (count) {
+      std::cerr << line << std::endl;
+      smiles.push_back(line);
     }
-    TEST_ASSERT(smiles.size() == 3);
+    count += 1;
+  }
+  TEST_ASSERT(smiles.size() == 3);
 
-    int numThreads = 3;  // one per entry
-    auto results = RunFilterCatalog(catalog, smiles, numThreads);
-    TEST_ASSERT(results.size() == smiles.size());
-    count=0;
-    for(auto &entries : results) {
-      TEST_ASSERT(entries.size() > 0);
-      std::cerr << count << " " << entries[0]->getDescription() << std::endl;
-      switch (count) {
+  int numThreads = 3;  // one per entry
+  auto results = RunFilterCatalog(catalog, smiles, numThreads);
+  TEST_ASSERT(results.size() == smiles.size());
+  count = 0;
+  for (auto &entries : results) {
+    TEST_ASSERT(entries.size() > 0);
+    std::cerr << count << " " << entries[0]->getDescription() << std::endl;
+    switch (count) {
       case 0:
-	TEST_ASSERT(entries[0]->getDescription() == "hzone_phenol_A(479)");
-	break;
+        TEST_ASSERT(entries[0]->getDescription() == "hzone_phenol_A(479)");
+        break;
       case 1:
-	TEST_ASSERT(entries[0]->getDescription() == "cyano_imine_B(17)");
-	break;
+        TEST_ASSERT(entries[0]->getDescription() == "cyano_imine_B(17)");
+        break;
       case 2:
-	TEST_ASSERT(entries[0]->getDescription() == "keto_keto_gamma(5)");
-	break;
-      }
-      count += 1;
+        TEST_ASSERT(entries[0]->getDescription() == "keto_keto_gamma(5)");
+        break;
     }
+    count += 1;
+  }
 }
 
 int main() {

--- a/Code/GraphMol/Fingerprints/AtomPairs.cpp
+++ b/Code/GraphMol/Fingerprints/AtomPairs.cpp
@@ -15,7 +15,6 @@
 #include <RDGeneral/hash/hash.hpp>
 #include <cstdint>
 #include <boost/dynamic_bitset.hpp>
-#include <boost/foreach.hpp>
 #include <GraphMol/Fingerprints/FingerprintUtil.h>
 
 namespace RDKit {
@@ -32,8 +31,7 @@ void updateElement(ExplicitBitVect &v, T1 elem) {
 }
 
 template <typename T>
-void setAtomPairBit(std::uint32_t i, std::uint32_t j,
-                    std::uint32_t nAtoms,
+void setAtomPairBit(std::uint32_t i, std::uint32_t j, std::uint32_t nAtoms,
                     const std::vector<std::uint32_t> &atomCodes,
                     const double *dm, T *bv, unsigned int minLength,
                     unsigned int maxLength, bool includeChirality) {
@@ -113,7 +111,7 @@ SparseIntVect<std::int32_t> *getAtomPairFingerprint(
                        includeChirality);
       }
     } else {
-      BOOST_FOREACH (std::uint32_t j, *fromAtoms) {
+      for (auto j : *fromAtoms) {
         if (j != i) {
           if (ignoreAtoms && std::find(ignoreAtoms->begin(), ignoreAtoms->end(),
                                        j) != ignoreAtoms->end()) {
@@ -195,7 +193,7 @@ SparseIntVect<std::int32_t> *getHashedAtomPairFingerprint(
         }
       }
     } else {
-      BOOST_FOREACH (std::uint32_t j, *fromAtoms) {
+      for (auto j : *fromAtoms) {
         if (j != i) {
           if (ignoreAtoms && std::find(ignoreAtoms->begin(), ignoreAtoms->end(),
                                        j) != ignoreAtoms->end()) {
@@ -233,8 +231,7 @@ ExplicitBitVect *getHashedAtomPairFingerprintAsBitVect(
       atomInvariants, includeChirality, use2D, confId);
   auto *res = new ExplicitBitVect(nBits);
   if (nBitsPerEntry != 4) {
-    BOOST_FOREACH (SparseIntVect<boost::int64_t>::StorageType::value_type val,
-                   sres->getNonzeroElements()) {
+    for (auto val : sres->getNonzeroElements()) {
       for (unsigned int i = 0; i < nBitsPerEntry; ++i) {
         if (val.second > static_cast<int>(i)) {
           res->setBit(val.first * nBitsPerEntry + i);
@@ -242,8 +239,7 @@ ExplicitBitVect *getHashedAtomPairFingerprintAsBitVect(
       }
     }
   } else {
-    BOOST_FOREACH (SparseIntVect<boost::int64_t>::StorageType::value_type val,
-                   sres->getNonzeroElements()) {
+    for (auto val : sres->getNonzeroElements()) {
       for (unsigned int i = 0; i < nBitsPerEntry; ++i) {
         if (val.second >= bounds[i]) {
           res->setBit(val.first * nBitsPerEntry + i);
@@ -296,12 +292,14 @@ SparseIntVect<boost::int64_t> *getTopologicalTorsionFingerprint(
   boost::dynamic_bitset<> *fromAtomsBV = nullptr;
   if (fromAtoms) {
     fromAtomsBV = new boost::dynamic_bitset<>(lmol->getNumAtoms());
-    BOOST_FOREACH (std::uint32_t fAt, *fromAtoms) { fromAtomsBV->set(fAt); }
+    for (auto fAt : *fromAtoms) {
+      fromAtomsBV->set(fAt);
+    }
   }
   boost::dynamic_bitset<> *ignoreAtomsBV = nullptr;
   if (ignoreAtoms) {
     ignoreAtomsBV = new boost::dynamic_bitset<>(mol.getNumAtoms());
-    BOOST_FOREACH (std::uint32_t fAt, *ignoreAtoms) {
+    for (auto fAt : *ignoreAtoms) {
       ignoreAtomsBV->set(fAt);
     }
   }
@@ -322,7 +320,7 @@ SparseIntVect<boost::int64_t> *getTopologicalTorsionFingerprint(
       }
     }
     if (keepIt && ignoreAtomsBV) {
-      BOOST_FOREACH (int pElem, path) {
+      for (auto pElem : path) {
         if (ignoreAtomsBV->test(pElem)) {
           keepIt = false;
           break;
@@ -393,12 +391,14 @@ void TorsionFpCalc(T *res, const ROMol &mol, unsigned int nBits,
   boost::dynamic_bitset<> *fromAtomsBV = nullptr;
   if (fromAtoms) {
     fromAtomsBV = new boost::dynamic_bitset<>(lmol->getNumAtoms());
-    BOOST_FOREACH (std::uint32_t fAt, *fromAtoms) { fromAtomsBV->set(fAt); }
+    for (auto fAt : *fromAtoms) {
+      fromAtomsBV->set(fAt);
+    }
   }
   boost::dynamic_bitset<> *ignoreAtomsBV = nullptr;
   if (ignoreAtoms) {
     ignoreAtomsBV = new boost::dynamic_bitset<>(lmol->getNumAtoms());
-    BOOST_FOREACH (std::uint32_t fAt, *ignoreAtoms) {
+    for (auto fAt : *ignoreAtoms) {
       ignoreAtomsBV->set(fAt);
     }
   }
@@ -418,7 +418,7 @@ void TorsionFpCalc(T *res, const ROMol &mol, unsigned int nBits,
       }
     }
     if (keepIt && ignoreAtomsBV) {
-      BOOST_FOREACH (int pElem, path) {
+      for (auto pElem : path) {
         if (ignoreAtomsBV->test(pElem)) {
           keepIt = false;
           break;
@@ -472,8 +472,7 @@ ExplicitBitVect *getHashedTopologicalTorsionFingerprintAsBitVect(
   auto *res = new ExplicitBitVect(nBits);
 
   if (nBitsPerEntry != 4) {
-    BOOST_FOREACH (SparseIntVect<boost::int64_t>::StorageType::value_type val,
-                   sres->getNonzeroElements()) {
+    for (auto val : sres->getNonzeroElements()) {
       for (unsigned int i = 0; i < nBitsPerEntry; ++i) {
         if (val.second > static_cast<int>(i)) {
           res->setBit(val.first * nBitsPerEntry + i);
@@ -481,8 +480,7 @@ ExplicitBitVect *getHashedTopologicalTorsionFingerprintAsBitVect(
       }
     }
   } else {
-    BOOST_FOREACH (SparseIntVect<boost::int64_t>::StorageType::value_type val,
-                   sres->getNonzeroElements()) {
+    for (auto val : sres->getNonzeroElements()) {
       for (unsigned int i = 0; i < nBitsPerEntry; ++i) {
         if (val.second >= bounds[i]) {
           res->setBit(val.first * nBitsPerEntry + i);

--- a/Code/GraphMol/Fingerprints/FingerprintGenerator.cpp
+++ b/Code/GraphMol/Fingerprints/FingerprintGenerator.cpp
@@ -262,7 +262,7 @@ SparseBitVect *FingerprintGenerator<OutputType>::getSparseFingerprint(
 
   auto *result = new SparseBitVect(resultSize);
 
-  BOOST_FOREACH (auto val, tempResult->getNonzeroElements()) {
+  for (auto val : tempResult->getNonzeroElements()) {
     if (dp_fingerprintArguments->d_countSimulation) {
       for (unsigned int i = 0;
            i < dp_fingerprintArguments->d_countBounds.size(); ++i) {
@@ -298,7 +298,7 @@ SparseIntVect<std::uint32_t>
 
   auto *result =
       new SparseIntVect<std::uint32_t>(dp_fingerprintArguments->d_fpSize);
-  BOOST_FOREACH (auto val, tempResult->getNonzeroElements()) {
+  for (auto val : tempResult->getNonzeroElements()) {
     result->setVal(val.first, val.second);
   }
 
@@ -324,7 +324,7 @@ ExplicitBitVect *FingerprintGenerator<OutputType>::getFingerprint(
       customAtomInvariants, customBondInvariants, effectiveSize);
 
   auto *result = new ExplicitBitVect(dp_fingerprintArguments->d_fpSize);
-  BOOST_FOREACH (auto val, tempResult->getNonzeroElements()) {
+  for (auto val : tempResult->getNonzeroElements()) {
     if (dp_fingerprintArguments->d_countSimulation) {
       for (unsigned int i = 0;
            i < dp_fingerprintArguments->d_countBounds.size(); ++i) {
@@ -458,7 +458,7 @@ std::vector<SparseIntVect<std::uint64_t> *> *getSparseCountFPBulk(
   }
   auto *res = new std::vector<SparseIntVect<std::uint64_t> *>();
 
-  BOOST_FOREACH (const ROMol *mol, molVector) {
+  for (const ROMol *mol : molVector) {
     res->push_back(generator->getSparseCountFingerprint(*mol));
   }
 
@@ -494,7 +494,7 @@ std::vector<SparseBitVect *> *getSparseFPBulk(
   }
   auto *res = new std::vector<SparseBitVect *>();
 
-  BOOST_FOREACH (const ROMol *mol, molVector) {
+  for (const ROMol *mol : molVector) {
     res->push_back(generator->getSparseFingerprint(*mol));
   }
 
@@ -530,7 +530,7 @@ std::vector<SparseIntVect<std::uint32_t> *> *getCountFPBulk(
   }
   auto *res = new std::vector<SparseIntVect<std::uint32_t> *>();
 
-  BOOST_FOREACH (const ROMol *mol, molVector) {
+  for (const ROMol *mol : molVector) {
     res->push_back(generator->getCountFingerprint(*mol));
   }
 
@@ -566,7 +566,7 @@ std::vector<ExplicitBitVect *> *getFPBulk(
   }
   auto *res = new std::vector<ExplicitBitVect *>();
 
-  BOOST_FOREACH (const ROMol *mol, molVector) {
+  for (const ROMol *mol : molVector) {
     res->push_back(generator->getFingerprint(*mol));
   }
 

--- a/Code/GraphMol/Fingerprints/FingerprintGenerator.cpp
+++ b/Code/GraphMol/Fingerprints/FingerprintGenerator.cpp
@@ -458,7 +458,7 @@ std::vector<SparseIntVect<std::uint64_t> *> *getSparseCountFPBulk(
   }
   auto *res = new std::vector<SparseIntVect<std::uint64_t> *>();
 
-  for (const ROMol *mol : molVector) {
+  for (const auto *mol : molVector) {
     res->push_back(generator->getSparseCountFingerprint(*mol));
   }
 
@@ -494,7 +494,7 @@ std::vector<SparseBitVect *> *getSparseFPBulk(
   }
   auto *res = new std::vector<SparseBitVect *>();
 
-  for (const ROMol *mol : molVector) {
+  for (const auto *mol : molVector) {
     res->push_back(generator->getSparseFingerprint(*mol));
   }
 
@@ -530,7 +530,7 @@ std::vector<SparseIntVect<std::uint32_t> *> *getCountFPBulk(
   }
   auto *res = new std::vector<SparseIntVect<std::uint32_t> *>();
 
-  for (const ROMol *mol : molVector) {
+  for (const auto *mol : molVector) {
     res->push_back(generator->getCountFingerprint(*mol));
   }
 
@@ -566,7 +566,7 @@ std::vector<ExplicitBitVect *> *getFPBulk(
   }
   auto *res = new std::vector<ExplicitBitVect *>();
 
-  for (const ROMol *mol : molVector) {
+  for (const auto *mol : molVector) {
     res->push_back(generator->getFingerprint(*mol));
   }
 

--- a/Code/GraphMol/Fingerprints/FingerprintUtil.cpp
+++ b/Code/GraphMol/Fingerprints/FingerprintUtil.cpp
@@ -13,7 +13,6 @@
 #include <GraphMol/Subgraphs/Subgraphs.h>
 #include <RDGeneral/hash/hash.hpp>
 #include <boost/dynamic_bitset.hpp>
-#include <boost/foreach.hpp>
 
 #include <GraphMol/RDKitBase.h>
 #include <GraphMol/SmilesParse/SmilesParse.h>
@@ -21,7 +20,6 @@
 #include <boost/dynamic_bitset.hpp>
 #include <boost/tuple/tuple.hpp>
 #include <boost/tuple/tuple_comparison.hpp>
-#include <boost/foreach.hpp>
 #include <algorithm>
 #include <RDGeneral/BoostStartInclude.h>
 #include <boost/flyweight.hpp>
@@ -310,7 +308,7 @@ void enumerateAllPaths(const ROMol &mol, INT_PATH_LIST_MAP &allPaths,
       allPaths = findAllPathsOfLengthsMtoN(mol, minPath, maxPath, true, useHs);
     }
   } else {
-    BOOST_FOREACH (std::uint32_t aidx, *fromAtoms) {
+    for (auto aidx : *fromAtoms) {
       INT_PATH_LIST_MAP tPaths;
       if (branchedPaths) {
         tPaths =
@@ -324,7 +322,7 @@ void enumerateAllPaths(const ROMol &mol, INT_PATH_LIST_MAP &allPaths,
 #ifdef VERBOSE_FINGERPRINTING
         std::cerr << "paths from " << aidx << " size: " << tpit->first
                   << std::endl;
-        BOOST_FOREACH (PATH_TYPE path, tpit->second) {
+        for (auto path : tpit->second) {
           std::cerr << " path: ";
           std::copy(path.begin(), path.end(),
                     std::ostream_iterator<int>(std::cerr, ", "));

--- a/Code/GraphMol/Fingerprints/Fingerprints.cpp
+++ b/Code/GraphMol/Fingerprints/Fingerprints.cpp
@@ -252,7 +252,7 @@ ExplicitBitVect *RDKFingerprintMol(
   boost::dynamic_bitset<> atomsInPath(mol.getNumAtoms());
   for (INT_PATH_LIST_MAP_CI paths = allPaths.begin(); paths != allPaths.end();
        paths++) {
-    BOOST_FOREACH (const PATH_TYPE &path, paths->second) {
+    for (const PATH_TYPE &path : paths->second) {
 #ifdef REPORT_FP_STATS
       std::vector<int> atomsToUse;
 #endif
@@ -427,7 +427,7 @@ ExplicitBitVect *RDKFingerprintMol(
     for (unsigned int i = 0; i < fpSize; ++i) {
       if ((*res)[i] && (bitSmiles[i].size() > 1)) {
         std::cerr << i << "\t" << bitSmiles[i].size() << std::endl;
-        BOOST_FOREACH (std::string smi, bitSmiles[i]) {
+        for (const auto& smi : bitSmiles[i]) {
           std::cerr << "   " << smi << std::endl;
         }
       }
@@ -499,7 +499,7 @@ ExplicitBitVect *LayeredFingerprintMol(
       allPaths = findAllPathsOfLengthsMtoN(mol, minPath, maxPath, false);
     }
   } else {
-    BOOST_FOREACH (std::uint32_t aidx, *fromAtoms) {
+    for (std::uint32_t aidx : *fromAtoms) {
       INT_PATH_LIST_MAP tPaths;
       if (branchedPaths) {
         tPaths =
@@ -753,7 +753,7 @@ SparseIntVect<boost::uint64_t> *getUnfoldedRDKFingerprintMol(
   boost::dynamic_bitset<> atomsInPath(mol.getNumAtoms());
   for (INT_PATH_LIST_MAP_CI paths = allPaths.begin(); paths != allPaths.end();
        paths++) {
-    BOOST_FOREACH (const PATH_TYPE &path, paths->second) {
+    for (const PATH_TYPE &path : paths->second) {
       // the bond hashes of the path
       std::vector<unsigned int> bondHashes = RDKitFPUtils::generateBondHashes(
           mol, atomsInPath, bondCache, isQueryBond, path, useBondOrder,

--- a/Code/GraphMol/Fingerprints/Fingerprints.cpp
+++ b/Code/GraphMol/Fingerprints/Fingerprints.cpp
@@ -252,7 +252,7 @@ ExplicitBitVect *RDKFingerprintMol(
   boost::dynamic_bitset<> atomsInPath(mol.getNumAtoms());
   for (INT_PATH_LIST_MAP_CI paths = allPaths.begin(); paths != allPaths.end();
        paths++) {
-    for (const PATH_TYPE &path : paths->second) {
+    for (const auto &path : paths->second) {
 #ifdef REPORT_FP_STATS
       std::vector<int> atomsToUse;
 #endif
@@ -427,7 +427,7 @@ ExplicitBitVect *RDKFingerprintMol(
     for (unsigned int i = 0; i < fpSize; ++i) {
       if ((*res)[i] && (bitSmiles[i].size() > 1)) {
         std::cerr << i << "\t" << bitSmiles[i].size() << std::endl;
-        for (const auto& smi : bitSmiles[i]) {
+        for (const auto &smi : bitSmiles[i]) {
           std::cerr << "   " << smi << std::endl;
         }
       }
@@ -499,7 +499,7 @@ ExplicitBitVect *LayeredFingerprintMol(
       allPaths = findAllPathsOfLengthsMtoN(mol, minPath, maxPath, false);
     }
   } else {
-    for (std::uint32_t aidx : *fromAtoms) {
+    for (auto aidx : *fromAtoms) {
       INT_PATH_LIST_MAP tPaths;
       if (branchedPaths) {
         tPaths =
@@ -753,7 +753,7 @@ SparseIntVect<boost::uint64_t> *getUnfoldedRDKFingerprintMol(
   boost::dynamic_bitset<> atomsInPath(mol.getNumAtoms());
   for (INT_PATH_LIST_MAP_CI paths = allPaths.begin(); paths != allPaths.end();
        paths++) {
-    for (const PATH_TYPE &path : paths->second) {
+    for (const auto &path : paths->second) {
       // the bond hashes of the path
       std::vector<unsigned int> bondHashes = RDKitFPUtils::generateBondHashes(
           mol, atomsInPath, bondCache, isQueryBond, path, useBondOrder,

--- a/Code/GraphMol/Fingerprints/MorganFingerprints.cpp
+++ b/Code/GraphMol/Fingerprints/MorganFingerprints.cpp
@@ -42,7 +42,6 @@
 #include <boost/dynamic_bitset.hpp>
 #include <boost/tuple/tuple.hpp>
 #include <boost/tuple/tuple_comparison.hpp>
-#include <boost/foreach.hpp>
 #include <algorithm>
 
 #include <GraphMol/Fingerprints/FingerprintUtil.h>
@@ -137,7 +136,9 @@ void calcFingerprint(const ROMol &mol, unsigned int radius,
 
   boost::dynamic_bitset<> includeAtoms(nAtoms);
   if (fromAtoms) {
-    BOOST_FOREACH (uint32_t idx, *fromAtoms) { includeAtoms.set(idx, 1); }
+    for (auto idx : *fromAtoms) {
+      includeAtoms.set(idx, 1);
+    }
   } else {
     includeAtoms.set();
   }
@@ -168,7 +169,7 @@ void calcFingerprint(const ROMol &mol, unsigned int radius,
         atomNeighborhoods;
     std::vector<AccumTuple> neighborhoodsThisRound;
 
-    BOOST_FOREACH (unsigned int atomIdx, atomOrder) {
+    for (auto atomIdx : atomOrder) {
       if (!deadAtoms[atomIdx]) {
         const Atom *tAtom = lmol->getAtomWithIdx(atomIdx);
         if (!tAtom->getDegree()) {
@@ -261,7 +262,8 @@ void calcFingerprint(const ROMol &mol, unsigned int radius,
          iter != neighborhoodsThisRound.end(); ++iter) {
       // if we haven't seen this exact environment before, update the
       // fingerprint:
-      if (includeRedundantEnvironments || std::find(neighborhoods.begin(), neighborhoods.end(),
+      if (includeRedundantEnvironments ||
+          std::find(neighborhoods.begin(), neighborhoods.end(),
                     iter->get<0>()) == neighborhoods.end()) {
         if (!onlyNonzeroInvariants || invariantCpy[iter->get<2>()]) {
           if (includeAtoms[iter->get<2>()]) {
@@ -316,7 +318,7 @@ SparseIntVect<uint32_t> *getHashedFingerprint(
     std::vector<uint32_t> *invariants, const std::vector<uint32_t> *fromAtoms,
     bool useChirality, bool useBondTypes, bool onlyNonzeroInvariants,
     BitInfoMap *atomsSettingBits, bool includeRedundantEnvironments) {
-  if(nBits == 0) {
+  if (nBits == 0) {
     throw ValueErrorException("nBits can not be zero");
   }
   SparseIntVect<uint32_t> *res;
@@ -327,14 +329,11 @@ SparseIntVect<uint32_t> *getHashedFingerprint(
   return res;
 }
 
-ExplicitBitVect *getFingerprintAsBitVect(const ROMol &mol, unsigned int radius,
-                                         unsigned int nBits,
-                                         std::vector<uint32_t> *invariants,
-                                         const std::vector<uint32_t> *fromAtoms,
-                                         bool useChirality, bool useBondTypes,
-                                         bool onlyNonzeroInvariants,
-                                         BitInfoMap *atomsSettingBits,
-                                         bool includeRedundantEnvironments) {
+ExplicitBitVect *getFingerprintAsBitVect(
+    const ROMol &mol, unsigned int radius, unsigned int nBits,
+    std::vector<uint32_t> *invariants, const std::vector<uint32_t> *fromAtoms,
+    bool useChirality, bool useBondTypes, bool onlyNonzeroInvariants,
+    BitInfoMap *atomsSettingBits, bool includeRedundantEnvironments) {
   auto *res = new ExplicitBitVect(nBits);
   calcFingerprint(mol, radius, invariants, fromAtoms, useChirality,
                   useBondTypes, false, onlyNonzeroInvariants, atomsSettingBits,

--- a/Code/GraphMol/Fingerprints/MorganGenerator.cpp
+++ b/Code/GraphMol/Fingerprints/MorganGenerator.cpp
@@ -18,7 +18,6 @@
 #include <boost/dynamic_bitset.hpp>
 #include <boost/tuple/tuple.hpp>
 #include <boost/tuple/tuple_comparison.hpp>
-#include <boost/foreach.hpp>
 
 #include <GraphMol/Fingerprints/FingerprintUtil.h>
 
@@ -134,11 +133,11 @@ std::string MorganArguments<OutputType>::infoString() const {
 
 template <typename OutputType>
 OutputType MorganAtomEnv<OutputType>::getBitId(
-    FingerprintArguments<OutputType> *, // arguments
-    const std::vector<std::uint32_t> *, // atomInvariants
-    const std::vector<std::uint32_t> *, // bondInvariants
+    FingerprintArguments<OutputType> *,  // arguments
+    const std::vector<std::uint32_t> *,  // atomInvariants
+    const std::vector<std::uint32_t> *,  // bondInvariants
     const AdditionalOutput *additionalOutput,
-    const bool // hashResults
+    const bool  // hashResults
 ) const {
   if (additionalOutput) {
     // todo: set additional outputs
@@ -158,12 +157,12 @@ std::vector<AtomEnvironment<OutputType> *>
 MorganEnvGenerator<OutputType>::getEnvironments(
     const ROMol &mol, FingerprintArguments<OutputType> *arguments,
     const std::vector<std::uint32_t> *fromAtoms,
-    const std::vector<std::uint32_t> *, //ignoreAtoms
-    const int, // confId
-    const AdditionalOutput *, // additionalOutput
+    const std::vector<std::uint32_t> *,  // ignoreAtoms
+    const int,                           // confId
+    const AdditionalOutput *,            // additionalOutput
     const std::vector<std::uint32_t> *atomInvariants,
     const std::vector<std::uint32_t> *bondInvariants,
-    const bool // hashResults
+    const bool  // hashResults
 ) const {
   PRECONDITION(atomInvariants && (atomInvariants->size() >= mol.getNumAtoms()),
                "bad atom invariants size");
@@ -181,7 +180,9 @@ MorganEnvGenerator<OutputType>::getEnvironments(
 
   boost::dynamic_bitset<> includeAtoms(nAtoms);
   if (fromAtoms) {
-    BOOST_FOREACH (uint32_t idx, *fromAtoms) { includeAtoms.set(idx, 1); }
+    for (auto idx : *fromAtoms) {
+      includeAtoms.set(idx, 1);
+    }
   } else {
     includeAtoms.set();
   }
@@ -241,7 +242,7 @@ MorganEnvGenerator<OutputType>::getEnvironments(
     std::vector<boost::dynamic_bitset<>> roundAtomNeighborhoods =
         atomNeighborhoods;
     std::vector<AccumTuple> allNeighborhoodsThisRound;
-    BOOST_FOREACH (unsigned int atomIdx, atomOrder) {
+    for (auto atomIdx : atomOrder) {
       // skip atoms which will not generate unique environments (neighborhoods)
       // anymore
       if (!deadAtoms[atomIdx]) {
@@ -378,7 +379,7 @@ FingerprintGenerator<OutputType> *getMorganGenerator(
     AtomInvariantsGenerator *atomInvariantsGenerator,
     BondInvariantsGenerator *bondInvariantsGenerator,
     const std::uint32_t fpSize, const std::vector<std::uint32_t> countBounds,
-    const bool ownsAtomInvGen, const bool // ownsBondInvGen
+    const bool ownsAtomInvGen, const bool  // ownsBondInvGen
 ) {
   AtomEnvironmentGenerator<OutputType> *morganEnvGenerator =
       new MorganEnvGenerator<OutputType>();
@@ -405,23 +406,25 @@ FingerprintGenerator<OutputType> *getMorganGenerator(
       bondInvariantsGenerator, ownsAtomInvGenerator, ownsBondInvGenerator);
 }
 
-template RDKIT_FINGERPRINTS_EXPORT FingerprintGenerator<std::uint32_t> *getMorganGenerator(
-    const unsigned int radius, const bool countSimulation,
-    const bool includeChirality, const bool useBondTypes,
-    const bool onlyNonzeroInvariants,
-    AtomInvariantsGenerator *atomInvariantsGenerator,
-    BondInvariantsGenerator *bondInvariantsGenerator,
-    const std::uint32_t fpSize, const std::vector<std::uint32_t> countBounds,
-    const bool ownsAtomInvGen, const bool ownsBondInvGen);
+template RDKIT_FINGERPRINTS_EXPORT FingerprintGenerator<std::uint32_t>
+    *getMorganGenerator(const unsigned int radius, const bool countSimulation,
+                        const bool includeChirality, const bool useBondTypes,
+                        const bool onlyNonzeroInvariants,
+                        AtomInvariantsGenerator *atomInvariantsGenerator,
+                        BondInvariantsGenerator *bondInvariantsGenerator,
+                        const std::uint32_t fpSize,
+                        const std::vector<std::uint32_t> countBounds,
+                        const bool ownsAtomInvGen, const bool ownsBondInvGen);
 
-template RDKIT_FINGERPRINTS_EXPORT FingerprintGenerator<std::uint64_t> *getMorganGenerator(
-    const unsigned int radius, const bool countSimulation,
-    const bool includeChirality, const bool useBondTypes,
-    const bool onlyNonzeroInvariants,
-    AtomInvariantsGenerator *atomInvariantsGenerator,
-    BondInvariantsGenerator *bondInvariantsGenerator,
-    const std::uint32_t fpSize, const std::vector<std::uint32_t> countBounds,
-    const bool ownsAtomInvGen, const bool ownsBondInvGen);
+template RDKIT_FINGERPRINTS_EXPORT FingerprintGenerator<std::uint64_t>
+    *getMorganGenerator(const unsigned int radius, const bool countSimulation,
+                        const bool includeChirality, const bool useBondTypes,
+                        const bool onlyNonzeroInvariants,
+                        AtomInvariantsGenerator *atomInvariantsGenerator,
+                        BondInvariantsGenerator *bondInvariantsGenerator,
+                        const std::uint32_t fpSize,
+                        const std::vector<std::uint32_t> countBounds,
+                        const bool ownsAtomInvGen, const bool ownsBondInvGen);
 
 }  // namespace MorganFingerprint
 }  // namespace RDKit

--- a/Code/GraphMol/Fingerprints/RDKitFPGenerator.cpp
+++ b/Code/GraphMol/Fingerprints/RDKitFPGenerator.cpp
@@ -145,7 +145,7 @@ RDKitFPEnvGenerator<OutputType>::getEnvironments(
   boost::dynamic_bitset<> atomsInPath(mol.getNumAtoms());
   for (INT_PATH_LIST_MAP_CI paths = allPaths.begin(); paths != allPaths.end();
        paths++) {
-    BOOST_FOREACH (const PATH_TYPE &path, paths->second) {
+    for (const PATH_TYPE &path : paths->second) {
       // the bond hashes of the path
       std::vector<std::uint32_t> bondHashes = RDKitFPUtils::generateBondHashes(
           mol, atomsInPath, bondCache, isQueryBond, path,

--- a/Code/GraphMol/Fingerprints/RDKitFPGenerator.cpp
+++ b/Code/GraphMol/Fingerprints/RDKitFPGenerator.cpp
@@ -95,7 +95,7 @@ OutputType RDKitFPAtomEnv<OutputType>::getBitId(
     const std::vector<std::uint32_t> *,  // bondInvariants
     const AdditionalOutput *,            // additionalOutput
     const bool                           // hashResults
-    ) const {
+) const {
   // todo set additional outputs
   return d_bitId;
 }
@@ -121,7 +121,7 @@ RDKitFPEnvGenerator<OutputType>::getEnvironments(
     const std::vector<std::uint32_t> *atomInvariants,
     const std::vector<std::uint32_t> *,  // bondInvariants
     const bool                           // hashResults
-    ) const {
+) const {
   PRECONDITION(!atomInvariants || atomInvariants->size() >= mol.getNumAtoms(),
                "bad atomInvariants size");
 
@@ -145,7 +145,7 @@ RDKitFPEnvGenerator<OutputType>::getEnvironments(
   boost::dynamic_bitset<> atomsInPath(mol.getNumAtoms());
   for (INT_PATH_LIST_MAP_CI paths = allPaths.begin(); paths != allPaths.end();
        paths++) {
-    for (const PATH_TYPE &path : paths->second) {
+    for (const auto &path : paths->second) {
       // the bond hashes of the path
       std::vector<std::uint32_t> bondHashes = RDKitFPUtils::generateBondHashes(
           mol, atomsInPath, bondCache, isQueryBond, path,

--- a/Code/GraphMol/Fingerprints/TopologicalTorsionGenerator.cpp
+++ b/Code/GraphMol/Fingerprints/TopologicalTorsionGenerator.cpp
@@ -24,7 +24,7 @@ TopologicalTorsionArguments<OutputType>::TopologicalTorsionArguments(
     const std::uint32_t fpSize)
     : FingerprintArguments<OutputType>(countSimulation, countBounds, fpSize),
       df_includeChirality(includeChirality),
-      d_torsionAtomCount(torsionAtomCount) {};
+      d_torsionAtomCount(torsionAtomCount){};
 
 template <typename OutputType>
 OutputType TopologicalTorsionArguments<OutputType>::getResultSize() const {
@@ -41,11 +41,11 @@ std::string TopologicalTorsionArguments<OutputType>::infoString() const {
 };
 template <typename OutputType>
 OutputType TopologicalTorsionAtomEnv<OutputType>::getBitId(
-    FingerprintArguments<OutputType> *, // arguments
-    const std::vector<std::uint32_t> *, // atomInvariants
-    const std::vector<std::uint32_t> *, // bondInvariants
-    const AdditionalOutput *, // additionalOutput
-    const bool // hashResults
+    FingerprintArguments<OutputType> *,  // arguments
+    const std::vector<std::uint32_t> *,  // atomInvariants
+    const std::vector<std::uint32_t> *,  // bondInvariants
+    const AdditionalOutput *,            // additionalOutput
+    const bool                           // hashResults
 ) const {
   return d_bitId;
 };
@@ -61,10 +61,10 @@ TopologicalTorsionEnvGenerator<OutputType>::getEnvironments(
     const ROMol &mol, FingerprintArguments<OutputType> *arguments,
     const std::vector<std::uint32_t> *fromAtoms,
     const std::vector<std::uint32_t> *ignoreAtoms,
-    const int, // confId
-    const AdditionalOutput *, // additionalOutput
+    const int,                 // confId
+    const AdditionalOutput *,  // additionalOutput
     const std::vector<std::uint32_t> *atomInvariants,
-    const std::vector<std::uint32_t> *, // bondInvariants
+    const std::vector<std::uint32_t> *,  // bondInvariants
     const bool hashResults) const {
   auto *topologicalTorsionArguments =
       dynamic_cast<TopologicalTorsionArguments<OutputType> *>(arguments);
@@ -75,12 +75,14 @@ TopologicalTorsionEnvGenerator<OutputType>::getEnvironments(
   boost::dynamic_bitset<> *fromAtomsBV = nullptr;
   if (fromAtoms) {
     fromAtomsBV = new boost::dynamic_bitset<>(mol.getNumAtoms());
-    for (std::uint32_t fAt : *fromAtoms) { fromAtomsBV->set(fAt); }
+    for (auto fAt : *fromAtoms) {
+      fromAtomsBV->set(fAt);
+    }
   }
   boost::dynamic_bitset<> *ignoreAtomsBV = nullptr;
   if (ignoreAtoms) {
     ignoreAtomsBV = new boost::dynamic_bitset<>(mol.getNumAtoms());
-    for (std::uint32_t fAt : *ignoreAtoms) {
+    for (auto fAt : *ignoreAtoms) {
       ignoreAtomsBV->set(fAt);
     }
   }
@@ -176,11 +178,14 @@ FingerprintGenerator<OutputType> *getTopologicalTorsionGenerator(
 
 // Topological torsion fingerprint does not support 32 bit output yet
 
-template RDKIT_FINGERPRINTS_EXPORT FingerprintGenerator<std::uint64_t> *getTopologicalTorsionGenerator(
-    const bool includeChirality, const uint32_t torsionAtomCount,
-    AtomInvariantsGenerator *atomInvariantsGenerator,
-    const bool countSimulation, const std::vector<std::uint32_t> countBounds,
-    const std::uint32_t fpSize, const bool ownsAtomInvGen);
+template RDKIT_FINGERPRINTS_EXPORT FingerprintGenerator<std::uint64_t> *
+getTopologicalTorsionGenerator(const bool includeChirality,
+                               const uint32_t torsionAtomCount,
+                               AtomInvariantsGenerator *atomInvariantsGenerator,
+                               const bool countSimulation,
+                               const std::vector<std::uint32_t> countBounds,
+                               const std::uint32_t fpSize,
+                               const bool ownsAtomInvGen);
 
 }  // namespace TopologicalTorsion
 }  // namespace RDKit

--- a/Code/GraphMol/Fingerprints/TopologicalTorsionGenerator.cpp
+++ b/Code/GraphMol/Fingerprints/TopologicalTorsionGenerator.cpp
@@ -75,12 +75,12 @@ TopologicalTorsionEnvGenerator<OutputType>::getEnvironments(
   boost::dynamic_bitset<> *fromAtomsBV = nullptr;
   if (fromAtoms) {
     fromAtomsBV = new boost::dynamic_bitset<>(mol.getNumAtoms());
-    BOOST_FOREACH (std::uint32_t fAt, *fromAtoms) { fromAtomsBV->set(fAt); }
+    for (std::uint32_t fAt : *fromAtoms) { fromAtomsBV->set(fAt); }
   }
   boost::dynamic_bitset<> *ignoreAtomsBV = nullptr;
   if (ignoreAtoms) {
     ignoreAtomsBV = new boost::dynamic_bitset<>(mol.getNumAtoms());
-    BOOST_FOREACH (std::uint32_t fAt, *ignoreAtoms) {
+    for (std::uint32_t fAt : *ignoreAtoms) {
       ignoreAtomsBV->set(fAt);
     }
   }
@@ -102,7 +102,7 @@ TopologicalTorsionEnvGenerator<OutputType>::getEnvironments(
       }
     }
     if (keepIt && ignoreAtomsBV) {
-      BOOST_FOREACH (int pElem, path) {
+      for (int pElem : path) {
         if (ignoreAtomsBV->test(pElem)) {
           keepIt = false;
           break;

--- a/Code/GraphMol/Fingerprints/test1.cpp
+++ b/Code/GraphMol/Fingerprints/test1.cpp
@@ -25,7 +25,6 @@
 #include <RDGeneral/RDLog.h>
 #include <string>
 #include <boost/version.hpp>
-#include <boost/foreach.hpp>
 
 using namespace RDKit;
 
@@ -1404,14 +1403,12 @@ void testAtomPairs() {
   c1 = AtomPairs::getAtomCode(mol->getAtomWithIdx(0));
   c2 = AtomPairs::getAtomCode(mol->getAtomWithIdx(1));
   c3 = AtomPairs::getAtomCode(mol->getAtomWithIdx(2));
-  tgt = 1 |
-        (std::min(c1, c2) | std::max(c1, c2) << AtomPairs::codeSize)
-            << AtomPairs::numPathBits;
+  tgt = 1 | (std::min(c1, c2) | std::max(c1, c2) << AtomPairs::codeSize)
+                << AtomPairs::numPathBits;
   TEST_ASSERT(AtomPairs::getAtomPairCode(c1, c2, 1) == tgt);
   TEST_ASSERT(AtomPairs::getAtomPairCode(c2, c1, 1) == tgt);
-  tgt = 2 |
-        (std::min(c1, c3) | std::max(c1, c3) << AtomPairs::codeSize)
-            << AtomPairs::numPathBits;
+  tgt = 2 | (std::min(c1, c3) | std::max(c1, c3) << AtomPairs::codeSize)
+                << AtomPairs::numPathBits;
   TEST_ASSERT(AtomPairs::getAtomPairCode(c1, c3, 2) == tgt);
   TEST_ASSERT(AtomPairs::getAtomPairCode(c3, c1, 2) == tgt);
 
@@ -1532,9 +1529,8 @@ void testTorsions() {
   c2 = AtomPairs::getAtomCode(mol->getAtomWithIdx(1)) - 2;
   c3 = AtomPairs::getAtomCode(mol->getAtomWithIdx(2)) - 2;
   c4 = AtomPairs::getAtomCode(mol->getAtomWithIdx(3)) - 1;
-  tgt = c1 |
-        (c2 | (c3 | c4 << AtomPairs::codeSize) << AtomPairs::codeSize)
-            << AtomPairs::codeSize;
+  tgt = c1 | (c2 | (c3 | c4 << AtomPairs::codeSize) << AtomPairs::codeSize)
+                 << AtomPairs::codeSize;
   codes.clear();
   codes.push_back(static_cast<unsigned int>(c1));
   codes.push_back(static_cast<unsigned int>(c2));
@@ -2322,7 +2318,9 @@ void testMACCS() {
                               131, 139, 151, 158, 160, 161, 164};
     std::vector<unsigned int> onBits(
         _onBits, _onBits + sizeof(_onBits) / sizeof(*_onBits));
-    BOOST_FOREACH (unsigned int ob, onBits) { TEST_ASSERT((*fp1)[ob]); }
+    for (auto ob : onBits) {
+      TEST_ASSERT((*fp1)[ob]);
+    }
     delete m1;
     delete fp1;
   }
@@ -2335,7 +2333,9 @@ void testMACCS() {
     unsigned int _onBits[] = {74, 114, 149, 155, 160};
     std::vector<unsigned int> onBits(
         _onBits, _onBits + sizeof(_onBits) / sizeof(*_onBits));
-    BOOST_FOREACH (unsigned int ob, onBits) { TEST_ASSERT((*fp1)[ob]); }
+    for (auto ob : onBits) {
+      TEST_ASSERT((*fp1)[ob]);
+    }
     delete m1;
     delete fp1;
   }
@@ -2348,7 +2348,9 @@ void testMACCS() {
     unsigned int _onBits[] = {93, 139, 141, 149, 157, 160, 164, 166};
     std::vector<unsigned int> onBits(
         _onBits, _onBits + sizeof(_onBits) / sizeof(*_onBits));
-    BOOST_FOREACH (unsigned int ob, onBits) { TEST_ASSERT((*fp1)[ob]); }
+    for (auto ob : onBits) {
+      TEST_ASSERT((*fp1)[ob]);
+    }
     delete m1;
     delete fp1;
   }
@@ -3035,7 +3037,7 @@ void testMultithreadedPatternFP() {
   }
   tg.clear();
 
-  BOOST_FOREACH (const ROMol *mol, mols) {
+  for (const auto *mol : mols) {
     ExplicitBitVect *bv = PatternFingerprintMol(*mol, 2048);
     referenceData.push_back(bv);
   }

--- a/Code/GraphMol/Fingerprints/testFingerprintGenerators.cpp
+++ b/Code/GraphMol/Fingerprints/testFingerprintGenerators.cpp
@@ -174,7 +174,7 @@ void testAtomPairOld() {
     FingerprintGenerator<std::uint32_t> *atomPairGenerator =
         AtomPair::getAtomPairGenerator<std::uint32_t>();
 
-    BOOST_FOREACH (std::string sm, smis) {
+    for (const auto& sm : smis) {
       mol = SmilesToMol(sm);
       fp1 = AtomPairs::getAtomPairFingerprint(*mol);
       fpu = atomPairGenerator->getSparseCountFingerprint(*mol);
@@ -598,7 +598,7 @@ void testMorganFPOld() {
   FingerprintGenerator<std::uint32_t> *morganGenerator =
       MorganFingerprint::getMorganGenerator<std::uint32_t>(radius);
 
-  BOOST_FOREACH (std::string sm, smis) {
+  for (const auto& sm : smis) {
     mol = SmilesToMol(sm);
     fp = morganGenerator->getSparseCountFingerprint(*mol);
     fpOld = MorganFingerprints::getFingerprint(*mol, radius);
@@ -1451,7 +1451,7 @@ void testRDKitFP() {
           atomInvariantsGenerator, countSimulation, countBounds, fpSize,
           numBitsPerFeature));
 
-  BOOST_FOREACH (std::string sm, smis) {
+  for (const auto& sm : smis) {
     mol = SmilesToMol(sm);
     fp = fpGenerator->getSparseCountFingerprint(*mol);
     fpTemp = getUnfoldedRDKFingerprintMol(*mol);
@@ -1585,7 +1585,7 @@ void testTopologicalTorsionFPOld() {
   FingerprintGenerator<std::uint64_t> *fpGenerator =
       TopologicalTorsion::getTopologicalTorsionGenerator<std::uint64_t>();
 
-  BOOST_FOREACH (std::string sm, smis) {
+  for (const auto& sm : smis) {
     mol = SmilesToMol(sm);
     fp = fpGenerator->getSparseCountFingerprint(*mol);
     fpSigned = AtomPairs::getTopologicalTorsionFingerprint(*mol);
@@ -2379,7 +2379,7 @@ void testBulkFP() {
 
   std::vector<const ROMol *> molVect;
 
-  BOOST_FOREACH (std::string sm, smis) { molVect.push_back(SmilesToMol(sm)); }
+  for (const auto& sm : smis) { molVect.push_back(SmilesToMol(sm)); }
 
   testPairs.emplace_back(
       AtomPair::getAtomPairGenerator<std::uint64_t>(), FPType::AtomPairFP);
@@ -2395,13 +2395,13 @@ void testBulkFP() {
       TopologicalTorsion::getTopologicalTorsionGenerator<std::uint64_t>(),
       FPType::TopologicalTorsionFP);
 
-  BOOST_FOREACH (auto it, testPairs) {
+  for (const auto& it : testPairs) {
     std::vector<SparseIntVect<std::uint64_t> *> *results =
         getSparseCountFPBulk(molVect, it.second);
 
     std::vector<SparseIntVect<std::uint64_t> *> compareRes;
 
-    BOOST_FOREACH (auto m, molVect) {
+    for (const auto& m : molVect) {
       compareRes.push_back(it.first->getSparseCountFingerprint(*m));
     }
 
@@ -2415,8 +2415,8 @@ void testBulkFP() {
     delete results;
   }
 
-  BOOST_FOREACH (auto &&m, molVect) { delete m; }
-  BOOST_FOREACH (auto &&t, testPairs) { delete t.first; }
+  for (auto &&m : molVect) { delete m; }
+  for (auto &&t : testPairs) { delete t.first; }
 
   BOOST_LOG(rdErrorLog) << "  done" << std::endl;
 }

--- a/Code/GraphMol/ForceFieldHelpers/MMFF/testMMFFHelpers.cpp
+++ b/Code/GraphMol/ForceFieldHelpers/MMFF/testMMFFHelpers.cpp
@@ -948,7 +948,7 @@ void testMMFFMultiThread() {
     fut.get();
   }
 
-  for (ROMol *mol : mols) { delete mol; }
+  for (auto *mol : mols) { delete mol; }
   BOOST_LOG(rdErrorLog) << "  done" << std::endl;
 }
 

--- a/Code/GraphMol/ForceFieldHelpers/MMFF/testMMFFHelpers.cpp
+++ b/Code/GraphMol/ForceFieldHelpers/MMFF/testMMFFHelpers.cpp
@@ -948,7 +948,7 @@ void testMMFFMultiThread() {
     fut.get();
   }
 
-  BOOST_FOREACH (ROMol *mol, mols) { delete mol; }
+  for (ROMol *mol : mols) { delete mol; }
   BOOST_LOG(rdErrorLog) << "  done" << std::endl;
 }
 

--- a/Code/GraphMol/ForceFieldHelpers/MMFF/testMultiThread.cpp
+++ b/Code/GraphMol/ForceFieldHelpers/MMFF/testMultiThread.cpp
@@ -79,7 +79,7 @@ void testMMFFMultiThread() {
   std::cerr << "processing" << std::endl;
   for (unsigned int i = 0; i < count; ++i) {
     std::cerr << " launch :" << i << std::endl;
-    std::cerr.flush();    
+    std::cerr.flush();
     tg.emplace_back(std::async(std::launch::async, runblock_mmff, mols[i]));
   }
   for (auto &fut : tg) {
@@ -87,8 +87,8 @@ void testMMFFMultiThread() {
   }
   std::cerr << "done" << std::endl;
   for(unsigned int i=0; i<count; ++i)
-    BOOST_FOREACH (ROMol *mol, mols[i]) { delete mol; }
-  
+    for (ROMol *mol : mols[i]) { delete mol; }
+
   BOOST_LOG(rdErrorLog) << "  done" << std::endl;
 }
 

--- a/Code/GraphMol/ForceFieldHelpers/MMFF/testMultiThread.cpp
+++ b/Code/GraphMol/ForceFieldHelpers/MMFF/testMultiThread.cpp
@@ -87,7 +87,7 @@ void testMMFFMultiThread() {
   }
   std::cerr << "done" << std::endl;
   for(unsigned int i=0; i<count; ++i)
-    for (ROMol *mol : mols[i]) { delete mol; }
+    for (auto *mol : mols[i]) { delete mol; }
 
   BOOST_LOG(rdErrorLog) << "  done" << std::endl;
 }

--- a/Code/GraphMol/ForceFieldHelpers/UFF/testUFFHelpers.cpp
+++ b/Code/GraphMol/ForceFieldHelpers/UFF/testUFFHelpers.cpp
@@ -1278,7 +1278,7 @@ void testUFFMultiThread() {
     fut.get();
   }
 
-  for (ROMol *mol : mols) { delete mol; }
+  for (auto *mol : mols) { delete mol; }
   BOOST_LOG(rdErrorLog) << "  done" << std::endl;
 }
 

--- a/Code/GraphMol/ForceFieldHelpers/UFF/testUFFHelpers.cpp
+++ b/Code/GraphMol/ForceFieldHelpers/UFF/testUFFHelpers.cpp
@@ -1278,7 +1278,7 @@ void testUFFMultiThread() {
     fut.get();
   }
 
-  BOOST_FOREACH (ROMol *mol, mols) { delete mol; }
+  for (ROMol *mol : mols) { delete mol; }
   BOOST_LOG(rdErrorLog) << "  done" << std::endl;
 }
 

--- a/Code/GraphMol/Kekulize.cpp
+++ b/Code/GraphMol/Kekulize.cpp
@@ -549,8 +549,8 @@ void Kekulize(RWMol &mol, bool markAtomsBonds, unsigned int maxBackTracks) {
       MolOps::findSSSR(mol, allrings);
     }
     arings.reserve(allrings.size());
-    for (INT_VECT &ring : allrings) {
-      for (int ai : ring) {
+    for (auto &ring : allrings) {
+      for (auto ai : ring) {
         if (!dummyAts[ai]) {
           arings.push_back(ring);
           break;

--- a/Code/GraphMol/Kekulize.cpp
+++ b/Code/GraphMol/Kekulize.cpp
@@ -549,8 +549,8 @@ void Kekulize(RWMol &mol, bool markAtomsBonds, unsigned int maxBackTracks) {
       MolOps::findSSSR(mol, allrings);
     }
     arings.reserve(allrings.size());
-    BOOST_FOREACH (INT_VECT &ring, allrings) {
-      BOOST_FOREACH (int ai, ring) {
+    for (INT_VECT &ring : allrings) {
+      for (int ai : ring) {
         if (!dummyAts[ai]) {
           arings.push_back(ring);
           break;

--- a/Code/GraphMol/MMPA/MMPA.cpp
+++ b/Code/GraphMol/MMPA/MMPA.cpp
@@ -524,7 +524,7 @@ bool fragmentMol(const ROMol& mol,
                  unsigned int minCuts, unsigned int maxCuts) {
   std::vector<BondVector_t> matching_bonds;  // List of matched query's bonds
 
-  for (unsigned int i : bondsToCut) {
+  for (auto i : bondsToCut) {
     const Bond* bond = mol.getBondWithIdx(i);
     BondVector_t bonds;
     unsigned int a1 = bond->getBeginAtomIdx();

--- a/Code/GraphMol/MMPA/MMPA.cpp
+++ b/Code/GraphMol/MMPA/MMPA.cpp
@@ -524,7 +524,7 @@ bool fragmentMol(const ROMol& mol,
                  unsigned int minCuts, unsigned int maxCuts) {
   std::vector<BondVector_t> matching_bonds;  // List of matched query's bonds
 
-  BOOST_FOREACH (unsigned int i, bondsToCut) {
+  for (unsigned int i : bondsToCut) {
     const Bond* bond = mol.getBondWithIdx(i);
     BondVector_t bonds;
     unsigned int a1 = bond->getBeginAtomIdx();

--- a/Code/GraphMol/MMPA/Wrap/rdMMPA.cpp
+++ b/Code/GraphMol/MMPA/Wrap/rdMMPA.cpp
@@ -13,23 +13,20 @@
 #include <GraphMol/SmilesParse/SmilesWrite.h>
 #include <RDBoost/Wrap.h>
 #include <GraphMol/MMPA/MMPA.h>
-#include <boost/foreach.hpp>
 
 namespace python = boost::python;
 
 namespace {
-python::tuple fragmentMolHelper(const RDKit::ROMol& mol,
-                                unsigned int maxCuts,
+python::tuple fragmentMolHelper(const RDKit::ROMol& mol, unsigned int maxCuts,
                                 unsigned int maxCutBonds,
                                 const std::string& pattern,
                                 bool resultsAsMols) {
-  std::vector<std::pair<RDKit::ROMOL_SPTR, RDKit::ROMOL_SPTR> > tres;
+  std::vector<std::pair<RDKit::ROMOL_SPTR, RDKit::ROMOL_SPTR>> tres;
   bool ok = RDKit::MMPA::fragmentMol(mol, tres, maxCuts, maxCutBonds, pattern);
   python::list pyres;
   if (ok) {
-    for (std::vector<std::pair<RDKit::ROMOL_SPTR,
-                               RDKit::ROMOL_SPTR> >::const_iterator pr =
-             tres.begin();
+    for (std::vector<std::pair<RDKit::ROMOL_SPTR, RDKit::ROMOL_SPTR>>::
+             const_iterator pr = tres.begin();
          pr != tres.end(); ++pr) {
       python::list lres;
       if (resultsAsMols) {
@@ -49,20 +46,17 @@ python::tuple fragmentMolHelper(const RDKit::ROMol& mol,
   return python::tuple(pyres);
 }
 
-python::tuple fragmentMolHelper2(const RDKit::ROMol& mol,
-                                 unsigned int minCuts,
-                                 unsigned int maxCuts,
-                                 unsigned int maxCutBonds,
+python::tuple fragmentMolHelper2(const RDKit::ROMol& mol, unsigned int minCuts,
+                                 unsigned int maxCuts, unsigned int maxCutBonds,
                                  const std::string& pattern,
                                  bool resultsAsMols) {
-  std::vector<std::pair<RDKit::ROMOL_SPTR, RDKit::ROMOL_SPTR> > tres;
+  std::vector<std::pair<RDKit::ROMOL_SPTR, RDKit::ROMOL_SPTR>> tres;
   bool ok = RDKit::MMPA::fragmentMol(mol, tres, minCuts, maxCuts, maxCutBonds,
                                      pattern);
   python::list pyres;
   if (ok) {
-    for (std::vector<std::pair<RDKit::ROMOL_SPTR,
-                               RDKit::ROMOL_SPTR> >::const_iterator pr =
-             tres.begin();
+    for (std::vector<std::pair<RDKit::ROMOL_SPTR, RDKit::ROMOL_SPTR>>::
+             const_iterator pr = tres.begin();
          pr != tres.end(); ++pr) {
       python::list lres;
       if (resultsAsMols) {
@@ -82,19 +76,17 @@ python::tuple fragmentMolHelper2(const RDKit::ROMol& mol,
   return python::tuple(pyres);
 }
 
-python::tuple fragmentMolHelper3(const RDKit::ROMol& mol,
-                                 python::object ob,
-                                 unsigned int minCuts,
-                                 unsigned int maxCuts,
+python::tuple fragmentMolHelper3(const RDKit::ROMol& mol, python::object ob,
+                                 unsigned int minCuts, unsigned int maxCuts,
                                  bool resultsAsMols) {
-  std::vector<std::pair<RDKit::ROMOL_SPTR, RDKit::ROMOL_SPTR> > tres;
-  std::unique_ptr<std::vector<unsigned int> > v= pythonObjectToVect<unsigned int>(ob);
+  std::vector<std::pair<RDKit::ROMOL_SPTR, RDKit::ROMOL_SPTR>> tres;
+  std::unique_ptr<std::vector<unsigned int>> v =
+      pythonObjectToVect<unsigned int>(ob);
   bool ok = RDKit::MMPA::fragmentMol(mol, tres, *v, minCuts, maxCuts);
   python::list pyres;
   if (ok) {
-    for (std::vector<std::pair<RDKit::ROMOL_SPTR,
-                               RDKit::ROMOL_SPTR> >::const_iterator pr =
-             tres.begin();
+    for (std::vector<std::pair<RDKit::ROMOL_SPTR, RDKit::ROMOL_SPTR>>::
+             const_iterator pr = tres.begin();
          pr != tres.end(); ++pr) {
       python::list lres;
       if (resultsAsMols) {
@@ -114,7 +106,7 @@ python::tuple fragmentMolHelper3(const RDKit::ROMol& mol,
   return python::tuple(pyres);
 }
 
-}
+}  // namespace
 
 BOOST_PYTHON_MODULE(rdMMPA) {
   python::scope().attr("__doc__") =
@@ -130,21 +122,15 @@ BOOST_PYTHON_MODULE(rdMMPA) {
               docString.c_str());
 
   python::def("FragmentMol", fragmentMolHelper2,
-              (python::arg("mol"),
-               python::arg("minCuts"),
-               python::arg("maxCuts"),
-               python::arg("maxCutBonds"),
+              (python::arg("mol"), python::arg("minCuts"),
+               python::arg("maxCuts"), python::arg("maxCutBonds"),
                python::arg("pattern") = "[#6+0;!$(*=,#[!#6])]!@!=!#[*]",
                python::arg("resultsAsMols") = true),
               docString.c_str());
-  
+
   python::def("FragmentMol", fragmentMolHelper3,
-              (python::arg("mol"),
-               python::arg("bondsToCut"),
-               python::arg("minCuts")=1,
-               python::arg("maxCuts")=3,
+              (python::arg("mol"), python::arg("bondsToCut"),
+               python::arg("minCuts") = 1, python::arg("maxCuts") = 3,
                python::arg("resultsAsMols") = true),
               docString.c_str());
-
-  
 }

--- a/Code/GraphMol/MolAlign/testO3AAlign.cpp
+++ b/Code/GraphMol/MolAlign/testO3AAlign.cpp
@@ -532,7 +532,7 @@ void testMMFFO3AMultiThread() {
     fut.get();
   }
 
-  BOOST_FOREACH (auto &&mol, mols) { delete mol; }
+  for (auto &&mol : mols) { delete mol; }
   BOOST_LOG(rdErrorLog) << "  done" << std::endl;
 }
 
@@ -599,7 +599,7 @@ void testCrippenO3AMultiThread() {
     fut.get();
   }
 
-  BOOST_FOREACH (ROMol *mol, mols) { delete mol; }
+  for (ROMol *mol : mols) { delete mol; }
   BOOST_LOG(rdErrorLog) << "  done" << std::endl;
 }
 #endif
@@ -734,7 +734,7 @@ void testO3AMultiThreadBug() {
 
 #endif
   delete refMol;
-  BOOST_FOREACH (auto &&mol, mols) { delete mol; }
+  for (auto &&mol : mols) { delete mol; }
   BOOST_LOG(rdErrorLog) << "  done" << std::endl;
 }
 

--- a/Code/GraphMol/MolAlign/testO3AAlign.cpp
+++ b/Code/GraphMol/MolAlign/testO3AAlign.cpp
@@ -599,7 +599,7 @@ void testCrippenO3AMultiThread() {
     fut.get();
   }
 
-  for (ROMol *mol : mols) { delete mol; }
+  for (auto *mol : mols) { delete mol; }
   BOOST_LOG(rdErrorLog) << "  done" << std::endl;
 }
 #endif

--- a/Code/GraphMol/MolDraw2D/rxn_test1.cpp
+++ b/Code/GraphMol/MolDraw2D/rxn_test1.cpp
@@ -186,7 +186,7 @@ C3)c4cccc(c4Cl)Cl	CCc1nc(c(n1c2ccccc2)C)C(=O)NCCN3CCN(CC3)c4cccc(c4Cl)Cl\n\
     std::vector<std::string> lines;
     boost::split(lines, indata, boost::is_any_of("\n"));
     unsigned int idx = 0;
-    BOOST_FOREACH (std::string &line, lines) {
+    for (std::string &line : lines) {
       std::vector<std::string> tokens;
       boost::split(tokens, line, boost::is_any_of("\t "));
       std::cerr << tokens.size() << " " << line << std::endl;

--- a/Code/GraphMol/MolDraw2D/rxn_test1.cpp
+++ b/Code/GraphMol/MolDraw2D/rxn_test1.cpp
@@ -186,7 +186,7 @@ C3)c4cccc(c4Cl)Cl	CCc1nc(c(n1c2ccccc2)C)C(=O)NCCN3CCN(CC3)c4cccc(c4Cl)Cl\n\
     std::vector<std::string> lines;
     boost::split(lines, indata, boost::is_any_of("\n"));
     unsigned int idx = 0;
-    for (std::string &line : lines) {
+    for (auto &line : lines) {
       std::vector<std::string> tokens;
       boost::split(tokens, line, boost::is_any_of("\t "));
       std::cerr << tokens.size() << " " << line << std::endl;

--- a/Code/GraphMol/MolOps.cpp
+++ b/Code/GraphMol/MolOps.cpp
@@ -289,7 +289,7 @@ void assignRadicals(RWMol &mol) {
       const INT_VECT &valens =
           PeriodicTable::getTable()->getValenceList((*ai)->getAtomicNum());
       if (valens.size() > 1) {
-        for (int val : valens) {
+        for (auto val : valens) {
           if (val - totalValence + chg >= 0) {
             numRadicals = val - totalValence + chg;
             break;
@@ -520,7 +520,7 @@ std::vector<ROMOL_SPTR> getMolFrags(const ROMol &mol, bool sanitizeFrags,
       }
       Bond *nBond = bond->copy();
       RWMol *tmp = res[(*mapping)[nBond->getBeginAtomIdx()]].get();
-      nBond->setOwningMol( tmp );
+      nBond->setOwningMol(tmp);
       nBond->setBeginAtomIdx(ids[nBond->getBeginAtomIdx()]);
       nBond->setEndAtomIdx(ids[nBond->getEndAtomIdx()]);
       nBond->getStereoAtoms().clear();
@@ -593,14 +593,14 @@ std::vector<ROMOL_SPTR> getMolFrags(const ROMol &mol, bool sanitizeFrags,
 
   if (sanitizeFrags) {
     for (auto &re : res) {
-      sanitizeMol( *re );
+      sanitizeMol(*re);
     }
   }
 
   if (ownIt) {
     delete mapping;
   }
-  return std::vector<ROMOL_SPTR>( res.begin(), res.end() );
+  return std::vector<ROMOL_SPTR>(res.begin(), res.end());
 }
 
 unsigned int getMolFrags(const ROMol &mol, INT_VECT &mapping) {

--- a/Code/GraphMol/MolOps.cpp
+++ b/Code/GraphMol/MolOps.cpp
@@ -289,7 +289,7 @@ void assignRadicals(RWMol &mol) {
       const INT_VECT &valens =
           PeriodicTable::getTable()->getValenceList((*ai)->getAtomicNum());
       if (valens.size() > 1) {
-        BOOST_FOREACH (int val, valens) {
+        for (int val : valens) {
           if (val - totalValence + chg >= 0) {
             numRadicals = val - totalValence + chg;
             break;

--- a/Code/GraphMol/ROMol.cpp
+++ b/Code/GraphMol/ROMol.cpp
@@ -9,7 +9,6 @@
 //
 
 #include <iostream>
-#include <boost/foreach.hpp>
 
 // our stuff
 #include <RDGeneral/Invariant.h>
@@ -120,13 +119,13 @@ void ROMol::initFromOther(const ROMol &other, bool quickCopy, int confId) {
     d_props = other.d_props;
 
     // Bookmarks should be copied as well:
-    BOOST_FOREACH (ATOM_BOOKMARK_MAP::value_type abmI, other.d_atomBookmarks) {
-      BOOST_FOREACH (const Atom *aptr, abmI.second) {
+    for (auto abmI : other.d_atomBookmarks) {
+      for (const auto *aptr : abmI.second) {
         setAtomBookmark(getAtomWithIdx(aptr->getIdx()), abmI.first);
       }
     }
-    BOOST_FOREACH (BOND_BOOKMARK_MAP::value_type bbmI, other.d_bondBookmarks) {
-      BOOST_FOREACH (const Bond *bptr, bbmI.second) {
+    for (auto bbmI : other.d_bondBookmarks) {
+      for (const auto *bptr : bbmI.second) {
         setBondBookmark(getBondWithIdx(bptr->getIdx()), bbmI.first);
       }
     }
@@ -617,7 +616,7 @@ unsigned int ROMol::addConformer(Conformer *conf, bool assignId) {
                "Number of atom mismatch");
   if (assignId) {
     int maxId = -1;
-    BOOST_FOREACH (CONFORMER_SPTR cptr, d_confs) {
+    for (auto cptr : d_confs) {
       maxId = std::max((int)(cptr->getId()), maxId);
     }
     maxId++;

--- a/Code/GraphMol/RWMol.cpp
+++ b/Code/GraphMol/RWMol.cpp
@@ -8,8 +8,6 @@
 //  of the RDKit source tree.
 //
 
-#include <boost/foreach.hpp>
-
 // our stuff
 #include <RDGeneral/Invariant.h>
 #include <RDGeneral/RDLog.h>
@@ -52,7 +50,7 @@ void RWMol::insertMol(const ROMol &other) {
     // take care of atom-numbering-dependent properties:
     INT_VECT nAtoms;
     if (newAt->getPropIfPresent(common_properties::_ringStereoAtoms, nAtoms)) {
-      BOOST_FOREACH (int &val, nAtoms) {
+      for (auto &val : nAtoms) {
         if (val < 0) {
           val = -1 * (newAtomIds[(-val - 1)] + 1);
         } else {
@@ -73,7 +71,9 @@ void RWMol::insertMol(const ROMol &other) {
     bond_p->setOwningMol(this);
     bond_p->setBeginAtomIdx(idx1);
     bond_p->setEndAtomIdx(idx2);
-    BOOST_FOREACH (int &v, bond_p->getStereoAtoms()) { v = newAtomIds[v]; }
+    for (auto &v : bond_p->getStereoAtoms()) {
+      v = newAtomIds[v];
+    }
     addBond(bond_p, true);
     ++firstB;
   }
@@ -235,7 +235,7 @@ void RWMol::removeAtom(Atom *atom) {
   }
 
   // do the same with the coordinates in the conformations
-  BOOST_FOREACH (CONFORMER_SPTR conf, d_confs) {
+  for (auto conf : d_confs) {
     RDGeom::POINT3D_VECT &positions = conf->getPositions();
     auto pi = positions.begin();
     for (unsigned int i = 0; i < getNumAtoms() - 1; i++) {

--- a/Code/GraphMol/ReducedGraphs/ReducedGraphs.cpp
+++ b/Code/GraphMol/ReducedGraphs/ReducedGraphs.cpp
@@ -172,8 +172,8 @@ RDNumeric::DoubleVector *generateErGFingerprintForReducedGraph(
       if (dist < rdcast<int>(minPath) || dist > rdcast<int>(maxPath)) {
         continue;
       }
-      BOOST_FOREACH (int ti, tvs[i]) {
-        BOOST_FOREACH (int tj, tvs[j]) {
+      for (int ti : tvs[i]) {
+        for (int tj : tvs[j]) {
           int ijMin = std::min(ti, tj);
           int ijMax = std::max(ti, tj);
           int block;
@@ -224,11 +224,11 @@ ROMol *generateMolExtendedReducedGraph(
   }
 
   // start by adding dummies at the ring centroids
-  BOOST_FOREACH (const INT_VECT &ring, mol.getRingInfo()->atomRings()) {
+  for (const INT_VECT &ring : mol.getRingInfo()->atomRings()) {
     if (ring.size() < 8) {
       int nIdx = res->addAtom(new Atom(0), false, true);
       int nAromatic = 0, nSP2 = 0;
-      BOOST_FOREACH (int idx, ring) {
+      for (int idx : ring) {
         res->addBond(idx, nIdx, Bond::SINGLE);
         if (mol.getAtomWithIdx(idx)->getIsAromatic()) {
           ++nAromatic;

--- a/Code/GraphMol/ReducedGraphs/ReducedGraphs.cpp
+++ b/Code/GraphMol/ReducedGraphs/ReducedGraphs.cpp
@@ -172,8 +172,8 @@ RDNumeric::DoubleVector *generateErGFingerprintForReducedGraph(
       if (dist < rdcast<int>(minPath) || dist > rdcast<int>(maxPath)) {
         continue;
       }
-      for (int ti : tvs[i]) {
-        for (int tj : tvs[j]) {
+      for (auto ti : tvs[i]) {
+        for (auto tj : tvs[j]) {
           int ijMin = std::min(ti, tj);
           int ijMax = std::max(ti, tj);
           int block;
@@ -224,11 +224,11 @@ ROMol *generateMolExtendedReducedGraph(
   }
 
   // start by adding dummies at the ring centroids
-  for (const INT_VECT &ring : mol.getRingInfo()->atomRings()) {
+  for (const auto &ring : mol.getRingInfo()->atomRings()) {
     if (ring.size() < 8) {
       int nIdx = res->addAtom(new Atom(0), false, true);
       int nAromatic = 0, nSP2 = 0;
-      for (int idx : ring) {
+      for (auto idx : ring) {
         res->addBond(idx, nIdx, Bond::SINGLE);
         if (mol.getAtomWithIdx(idx)->getIsAromatic()) {
           ++nAromatic;

--- a/Code/GraphMol/ReducedGraphs/Wrap/rdReducedGraphs.cpp
+++ b/Code/GraphMol/ReducedGraphs/Wrap/rdReducedGraphs.cpp
@@ -15,7 +15,6 @@
 
 #include <RDBoost/Wrap.h>
 #include <GraphMol/GraphMol.h>
-#include <boost/foreach.hpp>
 #include <RDBoost/import_array.h>
 
 #include <GraphMol/ReducedGraphs/ReducedGraphs.h>
@@ -69,7 +68,7 @@ PyObject *GetErGFingerprintHelper(const RDKit::ROMol &mol,
   delete dv;
   return PyArray_Return(res);
 }
-}
+}  // namespace
 
 BOOST_PYTHON_MODULE(rdReducedGraphs) {
   python::scope().attr("__doc__") =

--- a/Code/GraphMol/Renumber.cpp
+++ b/Code/GraphMol/Renumber.cpp
@@ -12,7 +12,6 @@
 #include <RDGeneral/Exceptions.h>
 #include <GraphMol/AtomIterators.h>
 #include <GraphMol/BondIterators.h>
-#include <boost/foreach.hpp>
 
 namespace RDKit {
 namespace MolOps {
@@ -46,7 +45,7 @@ ROMol *renumberAtoms(const ROMol &mol,
     INT_VECT nAtoms;
     if (nAtom->getPropIfPresent(common_properties::_ringStereoAtoms, nAtoms)) {
       // FIX: ought to be able to avoid this copy.
-      BOOST_FOREACH (int &val, nAtoms) {
+      for (auto &val : nAtoms) {
         if (val < 0) {
           val = -1 * (revOrder[(-val - 1)] + 1);
         } else {
@@ -66,7 +65,9 @@ ROMol *renumberAtoms(const ROMol &mol,
     nBond->setEndAtomIdx(revOrder[oBond->getEndAtomIdx()]);
     res->addBond(nBond, true);
     // take care of atom-numbering-dependent properties:
-    BOOST_FOREACH (int &idx, nBond->getStereoAtoms()) { idx = revOrder[idx]; }
+    for (auto &idx : nBond->getStereoAtoms()) {
+      idx = revOrder[idx];
+    }
   }
 
   // Conformers:
@@ -83,7 +84,7 @@ ROMol *renumberAtoms(const ROMol &mol,
 
   // update the ring info:
   const RingInfo *oRings = mol.getRingInfo();
-  if (oRings && oRings->isInitialized() ) {
+  if (oRings && oRings->isInitialized()) {
     RingInfo *nRings = res->getRingInfo();
     nRings->reset();
     nRings->initialize();

--- a/Code/GraphMol/SmilesParse/CXSmilesOps.cpp
+++ b/Code/GraphMol/SmilesParse/CXSmilesOps.cpp
@@ -9,7 +9,6 @@
 //
 #include <RDGeneral/BoostStartInclude.h>
 #include <boost/algorithm/string.hpp>
-#include <boost/foreach.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/format.hpp>
 #include <RDGeneral/BoostEndInclude.h>

--- a/Code/GraphMol/SmilesParse/SmilesParse.cpp
+++ b/Code/GraphMol/SmilesParse/SmilesParse.cpp
@@ -26,7 +26,6 @@
 #include "SmilesParse.h"
 #include <RDGeneral/BoostStartInclude.h>
 #include <boost/algorithm/string.hpp>
-#include <boost/foreach.hpp>
 #include <boost/lexical_cast.hpp>
 #include <RDGeneral/BoostEndInclude.h>
 #include <GraphMol/RDKitBase.h>
@@ -239,7 +238,7 @@ RWMol *toMol(const std::string &inp,
                           << " for input: '" << origInp << "'" << std::endl;
     res = nullptr;
   }
-  BOOST_FOREACH (RDKit::RWMol *molPtr, molVect) {
+  for (auto *molPtr : molVect) {
     if (molPtr) {
       // Clean-up the bond bookmarks when not calling CloseMolRings
       SmilesParseOps::CleanupAfterParseError(molPtr);

--- a/Code/GraphMol/Subgraphs/test2.cpp
+++ b/Code/GraphMol/Subgraphs/test2.cpp
@@ -14,7 +14,6 @@
 #include <GraphMol/SmilesParse/SmartsWrite.h>
 #include <GraphMol/Subgraphs/Subgraphs.h>
 #include <GraphMol/Subgraphs/SubgraphUtils.h>
-#include <boost/foreach.hpp>
 
 #include <iostream>
 using namespace std;
@@ -36,7 +35,7 @@ void test1() {
     PATH_LIST sgs;
     sgs = findAllSubgraphsOfLengthN(*mol, 3, false, 0);
     TEST_ASSERT(sgs.size() == 3);
-    BOOST_FOREACH (PATH_TYPE tmp, sgs) {
+    for (const auto &tmp : sgs) {
       TEST_ASSERT(tmp[0] == 0);
       TEST_ASSERT(tmp.size() == 3);
       ROMol *frag = Subgraphs::pathToSubmol(*mol, tmp, false);
@@ -186,12 +185,13 @@ void testGithubIssue103() {
 
 void testGithubIssue2647() {
   std::cout << "-----------------------\n Testing github Issue103: "
-               "more stereochemistry and pathToSubmol (path needs to be in sorted order)"
+               "more stereochemistry and pathToSubmol (path needs to be in "
+               "sorted order)"
             << std::endl;
   std::string smiles = "I[C@](F)(Br)O";
   std::unique_ptr<ROMol> mol(SmilesToMol(smiles));
-  std::vector<int> path = { 0, 3, 2, 1 };
-  const bool useQuery=false;
+  std::vector<int> path = {0, 3, 2, 1};
+  const bool useQuery = false;
   std::unique_ptr<ROMol> mol2(Subgraphs::pathToSubmol(*mol, path, useQuery));
   TEST_ASSERT(MolToSmiles(*mol2) == MolToSmiles(*mol));
   std::cout << "Finished" << std::endl;

--- a/Code/GraphMol/Substruct/SubstructMatch.cpp
+++ b/Code/GraphMol/Substruct/SubstructMatch.cpp
@@ -463,7 +463,7 @@ std::vector<MatchVectType> SubstructMatch(
   }
 
   if (params.recursionPossible) {
-    for (RecursiveStructureQuery *v : locked) {
+    for (auto *v : locked) {
       v->clear();
 #ifdef RDK_THREADSAFE_SSS
       v->d_mutex.unlock();

--- a/Code/GraphMol/Substruct/SubstructMatch.cpp
+++ b/Code/GraphMol/Substruct/SubstructMatch.cpp
@@ -463,7 +463,7 @@ std::vector<MatchVectType> SubstructMatch(
   }
 
   if (params.recursionPossible) {
-    BOOST_FOREACH (RecursiveStructureQuery *v, locked) {
+    for (RecursiveStructureQuery *v : locked) {
       v->clear();
 #ifdef RDK_THREADSAFE_SSS
       v->d_mutex.unlock();

--- a/Code/GraphMol/SubstructLibrary/substructLibraryTest.cpp
+++ b/Code/GraphMol/SubstructLibrary/substructLibraryTest.cpp
@@ -54,7 +54,7 @@ boost::dynamic_bitset<> runTest(SubstructLibrary &ssslib, const ROMol &pattern,
                                  int nThreads) {
   std::vector<unsigned int> libMatches = ssslib.getMatches(pattern, nThreads);
   boost::dynamic_bitset<> hasMatch(ssslib.size());
-  for (unsigned int idx : libMatches) { hasMatch[idx] = 1; }
+  for (auto idx : libMatches) { hasMatch[idx] = 1; }
 
   for (unsigned int i = 0; i < ssslib.size(); ++i) {
     MatchVectType match;
@@ -73,7 +73,7 @@ void runTest(SubstructLibrary &ssslib,
              ) {
   std::vector<unsigned int> libMatches = ssslib.getMatches(pattern, nThreads);
   boost::dynamic_bitset<> hasMatch2(ssslib.size());
-  for (unsigned int idx : libMatches) { hasMatch2[idx] = 1; }
+  for (auto idx : libMatches) { hasMatch2[idx] = 1; }
   TEST_ASSERT(hasMatch == hasMatch2);
   
   for (unsigned int i = 0; i < ssslib.size(); ++i) {

--- a/Code/GraphMol/SubstructLibrary/substructLibraryTest.cpp
+++ b/Code/GraphMol/SubstructLibrary/substructLibraryTest.cpp
@@ -54,7 +54,7 @@ boost::dynamic_bitset<> runTest(SubstructLibrary &ssslib, const ROMol &pattern,
                                  int nThreads) {
   std::vector<unsigned int> libMatches = ssslib.getMatches(pattern, nThreads);
   boost::dynamic_bitset<> hasMatch(ssslib.size());
-  BOOST_FOREACH (unsigned int idx, libMatches) { hasMatch[idx] = 1; }
+  for (unsigned int idx : libMatches) { hasMatch[idx] = 1; }
 
   for (unsigned int i = 0; i < ssslib.size(); ++i) {
     MatchVectType match;
@@ -73,7 +73,7 @@ void runTest(SubstructLibrary &ssslib,
              ) {
   std::vector<unsigned int> libMatches = ssslib.getMatches(pattern, nThreads);
   boost::dynamic_bitset<> hasMatch2(ssslib.size());
-  BOOST_FOREACH (unsigned int idx, libMatches) { hasMatch2[idx] = 1; }
+  for (unsigned int idx : libMatches) { hasMatch2[idx] = 1; }
   TEST_ASSERT(hasMatch == hasMatch2);
   
   for (unsigned int i = 0; i < ssslib.size(); ++i) {

--- a/Code/GraphMol/Wrap/MolOps.cpp
+++ b/Code/GraphMol/Wrap/MolOps.cpp
@@ -636,7 +636,9 @@ ExplicitBitVect *wrapRDKFingerprintMol(
     auto &pyl = static_cast<python::list &>(atomBits);
     for (unsigned int i = 0; i < mol.getNumAtoms(); ++i) {
       python::list tmp;
-      BOOST_FOREACH (std::uint32_t v, (*lAtomBits)[i]) { tmp.append(v); }
+      for (auto v : (*lAtomBits)[i]) {
+        tmp.append(v);
+      }
       pyl.append(tmp);
     }
     delete lAtomBits;
@@ -692,7 +694,9 @@ SparseIntVect<boost::uint64_t> *wrapUnfoldedRDKFingerprintMol(
     auto &pyl = static_cast<python::list &>(atomBits);
     for (unsigned int i = 0; i < mol.getNumAtoms(); ++i) {
       python::list tmp;
-      BOOST_FOREACH (boost::uint64_t v, (*lAtomBits)[i]) { tmp.append(v); }
+      for (auto v : (*lAtomBits)[i]) {
+        tmp.append(v);
+      }
       pyl.append(tmp);
     }
     delete lAtomBits;

--- a/Code/GraphMol/molopstest.cpp
+++ b/Code/GraphMol/molopstest.cpp
@@ -25,7 +25,6 @@
 #include <iostream>
 #include <map>
 #include <algorithm>
-#include <boost/foreach.hpp>
 #include <random>
 
 #ifndef M_PI

--- a/Code/GraphMol/new_canon.cpp
+++ b/Code/GraphMol/new_canon.cpp
@@ -13,7 +13,6 @@
 #include <GraphMol/RDKitBase.h>
 #include <GraphMol/QueryOps.h>
 #include <cstdint>
-#include <boost/foreach.hpp>
 #include <cstring>
 #include <iostream>
 #include <cassert>

--- a/Code/GraphMol/new_canon.h
+++ b/Code/GraphMol/new_canon.h
@@ -15,7 +15,6 @@
 #include <GraphMol/RingInfo.h>
 #include <RDGeneral/BoostStartInclude.h>
 #include <cstdint>
-#include <boost/foreach.hpp>
 #include <boost/dynamic_bitset.hpp>
 #include <RDGeneral/BoostEndInclude.h>
 #include <cstring>

--- a/Code/RDGeneral/Ranking.h
+++ b/Code/RDGeneral/Ranking.h
@@ -21,7 +21,6 @@
 #include <vector>
 #include <functional>
 #include <algorithm>
-#include <boost/foreach.hpp>
 #include <cstdint>
 
 namespace Rankers {

--- a/Code/SimDivPickers/testPickers.cpp
+++ b/Code/SimDivPickers/testPickers.cpp
@@ -12,7 +12,6 @@
 #include <iostream>
 #include <RDGeneral/Invariant.h>
 #include <RDGeneral/RDLog.h>
-#include <boost/foreach.hpp>
 
 namespace {
 double dist_on_line(unsigned int i, unsigned int j) {
@@ -28,7 +27,9 @@ void testGithub1421() {
   RDKit::INT_VECT picks;
   int poolSz = 1000;
   picks = pkr.lazyPick(dist_on_line, poolSz, 10, RDKit::INT_VECT(), 2748);
-  BOOST_FOREACH (int pick, picks) { TEST_ASSERT(pick < poolSz); }
+  for (auto pick : picks) {
+    TEST_ASSERT(pick < poolSz);
+  }
   BOOST_LOG(rdErrorLog) << "Done" << std::endl;
 }
 

--- a/Contrib/ConformerParser/ConformerParser.cpp
+++ b/Contrib/ConformerParser/ConformerParser.cpp
@@ -15,7 +15,8 @@
 //       with the distribution.
 //     * Neither the name of Novartis Institutes for BioMedical Research Inc.
 //       nor the names of its contributors may be used to endorse or promote
-//       products derived from this software without specific prior written permission.
+//       products derived from this software without specific prior written
+//       permission.
 //
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
@@ -34,80 +35,83 @@
 #include <GraphMol/RDKitBase.h>
 #include <GraphMol/SmilesParse/SmilesParse.h>
 #include <RDGeneral/BadFileException.h>
-#include <boost/foreach.hpp>
 #include "ConformerParser.h"
 
 #include <fstream>
 
+namespace RDKit {
+namespace ConformerParser {
 
-namespace RDKit{
-  namespace ConformerParser {
-
-    INT_VECT addConformersFromList(ROMol &mol, const std::vector<std::vector<double> > &coords,
-                               int numConf){
-      unsigned int numAtomsPerConf = mol.getNumAtoms();
-      unsigned int numCoordPerConf = 3 * numAtomsPerConf;
-      PRECONDITION(numConf <= int(coords.size()), "numConf greater than number of conformations");
-      if (numConf < 0) {
-        numConf = coords.size();
-      }
-      // loop over the conformers
-      INT_VECT confIds;
-      for (unsigned int i = 0; i < numConf; ++i) {
-        if (coords[i].size() != numCoordPerConf) {
-          throw ValueErrorException("Wrong number of coordinates");
-        }
-        RDKit::Conformer *conf = new RDKit::Conformer(numAtomsPerConf);
-        // loop over atoms
-        for (unsigned int atom = 0; atom < numAtomsPerConf; ++atom) {
-          //RDGeom::Point3D p(coords[i][3*atom], coords[i][3*atom+1], coords[i][3*atom+2]);
-          (*conf).setAtomPos(atom, RDGeom::Point3D(coords[i][3*atom], coords[i][3*atom+1], coords[i][3*atom+2]));
-        }
-        int confId = mol.addConformer(conf, true);
-        confIds.push_back(confId);
-      }
-      return confIds;
+INT_VECT addConformersFromList(ROMol &mol,
+                               const std::vector<std::vector<double>> &coords,
+                               int numConf) {
+  unsigned int numAtomsPerConf = mol.getNumAtoms();
+  unsigned int numCoordPerConf = 3 * numAtomsPerConf;
+  PRECONDITION(numConf <= int(coords.size()),
+               "numConf greater than number of conformations");
+  if (numConf < 0) {
+    numConf = coords.size();
+  }
+  // loop over the conformers
+  INT_VECT confIds;
+  for (unsigned int i = 0; i < numConf; ++i) {
+    if (coords[i].size() != numCoordPerConf) {
+      throw ValueErrorException("Wrong number of coordinates");
     }
-
-    void readAmberTrajectory(const std::string &fName, std::vector<std::vector<double> > &coords,
-                             unsigned int numAtoms) {
-      std::ifstream inStream(fName.c_str());
-      if (!inStream || (inStream.bad()) ) {
-        std::ostringstream errout;
-        errout << "Bad input file " << fName;
-        throw BadFileException(errout.str());
-      }
-      std::string tempStr;
-      // title
-      std::getline(inStream, tempStr);
-      // read coordinates
-      std::vector<double> tmpCoords;
-      while (true) {
-        double c;
-        if (!(inStream >> c)) {
-          if (!inStream.eof()) {
-            throw ValueErrorException("Error while reading file");
-          }
-          break;
-        }
-        tmpCoords.push_back(c);
-      }
-      // convert to conformers
-      unsigned int numCoordsPerConf = 3 * numAtoms;
-      if (tmpCoords.size() % numCoordsPerConf != 0) {
-        throw ValueErrorException("Wrong number of coordinates");
-      }
-      unsigned int numConfs = tmpCoords.size() / numCoordsPerConf;
-      unsigned int c = 0;
-      for (unsigned int i = 0; i < numConfs; ++i) {
-        std::vector<double> coordConf(numCoordsPerConf);
-        for (unsigned int atom = 0; atom < numCoordsPerConf; ++atom, ++c) {
-          coordConf[atom] = tmpCoords[c];
-        }
-        coords.push_back(coordConf);
-      }
+    RDKit::Conformer *conf = new RDKit::Conformer(numAtomsPerConf);
+    // loop over atoms
+    for (unsigned int atom = 0; atom < numAtomsPerConf; ++atom) {
+      // RDGeom::Point3D p(coords[i][3*atom], coords[i][3*atom+1],
+      // coords[i][3*atom+2]);
+      (*conf).setAtomPos(
+          atom, RDGeom::Point3D(coords[i][3 * atom], coords[i][3 * atom + 1],
+                                coords[i][3 * atom + 2]));
     }
+    int confId = mol.addConformer(conf, true);
+    confIds.push_back(confId);
+  }
+  return confIds;
+}
 
+void readAmberTrajectory(const std::string &fName,
+                         std::vector<std::vector<double>> &coords,
+                         unsigned int numAtoms) {
+  std::ifstream inStream(fName.c_str());
+  if (!inStream || (inStream.bad())) {
+    std::ostringstream errout;
+    errout << "Bad input file " << fName;
+    throw BadFileException(errout.str());
+  }
+  std::string tempStr;
+  // title
+  std::getline(inStream, tempStr);
+  // read coordinates
+  std::vector<double> tmpCoords;
+  while (true) {
+    double c;
+    if (!(inStream >> c)) {
+      if (!inStream.eof()) {
+        throw ValueErrorException("Error while reading file");
+      }
+      break;
+    }
+    tmpCoords.push_back(c);
+  }
+  // convert to conformers
+  unsigned int numCoordsPerConf = 3 * numAtoms;
+  if (tmpCoords.size() % numCoordsPerConf != 0) {
+    throw ValueErrorException("Wrong number of coordinates");
+  }
+  unsigned int numConfs = tmpCoords.size() / numCoordsPerConf;
+  unsigned int c = 0;
+  for (unsigned int i = 0; i < numConfs; ++i) {
+    std::vector<double> coordConf(numCoordsPerConf);
+    for (unsigned int atom = 0; atom < numCoordsPerConf; ++atom, ++c) {
+      coordConf[atom] = tmpCoords[c];
+    }
+    coords.push_back(coordConf);
+  }
+}
 
-  } // end namespace ConformerParser
-} // end namespace RDKit
+}  // end namespace ConformerParser
+}  // end namespace RDKit

--- a/Contrib/PBF/PBFRDKit.cpp
+++ b/Contrib/PBF/PBFRDKit.cpp
@@ -3,7 +3,7 @@
 //  All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
-//modification, are permitted provided that the following conditions are
+// modification, are permitted provided that the following conditions are
 // met:
 //
 //     * Redistributions of source code must retain the above copyright
@@ -14,7 +14,8 @@
 //       with the distribution.
 //     * Neither the name of Institue of Cancer Research.
 //       nor the names of its contributors may be used to endorse or promote
-//       products derived from this software without specific prior written permission.
+//       products derived from this software without specific prior written
+//       permission.
 //
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
@@ -28,129 +29,132 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
-// For more information on the Plane of Best Fit please see http://pubs.acs.org/doi/abs/10.1021/ci300293f
+// For more information on the Plane of Best Fit please see
+// http://pubs.acs.org/doi/abs/10.1021/ci300293f
 //
 //  If this code has been useful to you, please include the reference
 //  in any work which has made use of it:
 
-//  Plane of Best Fit: A Novel Method to Characterize the Three-Dimensionality of Molecules, Nicholas C. Firth, Nathan Brown, and Julian Blagg, Journal of Chemical Information and Modeling 2012 52 (10), 2516-2525
+//  Plane of Best Fit: A Novel Method to Characterize the Three-Dimensionality
+//  of Molecules, Nicholas C. Firth, Nathan Brown, and Julian Blagg, Journal of
+//  Chemical Information and Modeling 2012 52 (10), 2516-2525
 
 //
 //
 // Created by Nicholas Firth, November 2011
-// Modified by Greg Landrum for inclusion in the RDKit distribution November 2012
+// Modified by Greg Landrum for inclusion in the RDKit distribution November
+// 2012
 //
 
 #include "PBFRDKit.h"
 #include <Numerics/Matrix.h>
 #include <Numerics/SquareMatrix.h>
 #include <Numerics/SymmMatrix.h>
-#include <boost/foreach.hpp>
 
 #include <Eigen/Dense>
 using namespace RDKit;
 
-void getSmallestEigenVector(double fSumXX,double fSumXY,double fSumXZ,
-                            double fSumYY,double fSumYZ,double fSumZZ,
-                            double &x,double &y, double &z);
+void getSmallestEigenVector(double fSumXX, double fSumXY, double fSumXZ,
+                            double fSumYY, double fSumYZ, double fSumZZ,
+                            double &x, double &y, double &z);
 
-double distanceFromAPlane(const RDGeom::Point3D &pt,const std::vector<double> &plane, double denom){
-  double numer=0.0;
-  numer = std::fabs(pt.x*plane[0]+pt.y*plane[1]+pt.z*plane[2]+plane[3]);
+double distanceFromAPlane(const RDGeom::Point3D &pt,
+                          const std::vector<double> &plane, double denom) {
+  double numer = 0.0;
+  numer =
+      std::fabs(pt.x * plane[0] + pt.y * plane[1] + pt.z * plane[2] + plane[3]);
 
-  return numer/denom;
+  return numer / denom;
 }
 
 bool getBestFitPlane(const std::vector<RDGeom::Point3D> &points,
                      std::vector<double> &plane,
                      const std::vector<double> *weights) {
-  PRECONDITION((!weights || weights->size()>=points.size()),"bad weights vector");
-  RDGeom::Point3D origin(0,0,0);
-  double wSum=0.0;
+  PRECONDITION((!weights || weights->size() >= points.size()),
+               "bad weights vector");
+  RDGeom::Point3D origin(0, 0, 0);
+  double wSum = 0.0;
 
-  for(unsigned int i=0;i<points.size();++i){
-    if(weights){
-      double w=(*weights)[i];
-      wSum+=w;
-      origin+=points[i]*w;
+  for (unsigned int i = 0; i < points.size(); ++i) {
+    if (weights) {
+      double w = (*weights)[i];
+      wSum += w;
+      origin += points[i] * w;
     } else {
-      wSum+=1;
-      origin+=points[i];
+      wSum += 1;
+      origin += points[i];
     }
   }
   origin /= wSum;
 
-  double sumXX=0,sumXY=0,sumXZ=0,sumYY=0,sumYZ=0,sumZZ=0;
-  for(unsigned int i=0;i<points.size();++i){
-    RDGeom::Point3D delta=points[i]-origin;
-    if(weights){
-      double w=(*weights)[i];
+  double sumXX = 0, sumXY = 0, sumXZ = 0, sumYY = 0, sumYZ = 0, sumZZ = 0;
+  for (unsigned int i = 0; i < points.size(); ++i) {
+    RDGeom::Point3D delta = points[i] - origin;
+    if (weights) {
+      double w = (*weights)[i];
       delta *= w;
     }
-    sumXX += delta.x*delta.x;
-    sumXY += delta.x*delta.y;
-    sumXZ += delta.x*delta.z;
-    sumYY += delta.y*delta.y;
-    sumYZ += delta.y*delta.z;
-    sumZZ += delta.z*delta.z;
+    sumXX += delta.x * delta.x;
+    sumXY += delta.x * delta.y;
+    sumXZ += delta.x * delta.z;
+    sumYY += delta.y * delta.y;
+    sumYZ += delta.y * delta.z;
+    sumZZ += delta.z * delta.z;
   }
-  sumXX/=wSum;
-  sumXY/=wSum;
-  sumXZ/=wSum;
-  sumYY/=wSum;
-  sumYZ/=wSum;
-  sumZZ/=wSum;
+  sumXX /= wSum;
+  sumXY /= wSum;
+  sumXZ /= wSum;
+  sumYY /= wSum;
+  sumYZ /= wSum;
+  sumZZ /= wSum;
 
   Eigen::Matrix3d mat;
-  mat << sumXX, sumXY, sumXZ,
-    sumXY, sumYY, sumYZ,
-    sumXZ, sumYZ, sumZZ;
+  mat << sumXX, sumXY, sumXZ, sumXY, sumYY, sumYZ, sumXZ, sumYZ, sumZZ;
   Eigen::SelfAdjointEigenSolver<Eigen::Matrix3d> eigensolver(mat);
-  if(eigensolver.info()!=Eigen::Success){
-    BOOST_LOG(rdErrorLog)<<"eigenvalue calculation did not converge"<<std::endl;
+  if (eigensolver.info() != Eigen::Success) {
+    BOOST_LOG(rdErrorLog) << "eigenvalue calculation did not converge"
+                          << std::endl;
     return 0.0;
   }
   RDGeom::Point3D normal;
-  normal.x=eigensolver.eigenvectors()(0,0);
-  normal.y=eigensolver.eigenvectors()(1,0);
-  normal.z=eigensolver.eigenvectors()(2,0);
+  normal.x = eigensolver.eigenvectors()(0, 0);
+  normal.y = eigensolver.eigenvectors()(1, 0);
+  normal.z = eigensolver.eigenvectors()(2, 0);
 
   plane[0] = normal.x;
   plane[1] = normal.y;
   plane[2] = normal.z;
-  plane[3] = -1*normal.dotProduct(origin);
-  
+  plane[3] = -1 * normal.dotProduct(origin);
 }
 
-double PBFRD(ROMol& mol,int confId){
-  PRECONDITION(mol.getNumConformers()>=1,"molecule has no conformers")
+double PBFRD(ROMol &mol, int confId) {
+  PRECONDITION(mol.getNumConformers() >= 1, "molecule has no conformers")
   int numAtoms = mol.getNumAtoms();
-  if(numAtoms<4) return 0;
+  if (numAtoms < 4) return 0;
 
   const Conformer &conf = mol.getConformer(confId);
-  if(!conf.is3D()) return 0 ;
+  if (!conf.is3D()) return 0;
 
   std::vector<RDGeom::Point3D> points;
   points.reserve(numAtoms);
-  for(unsigned int i=0; i<numAtoms; ++i){
+  for (unsigned int i = 0; i < numAtoms; ++i) {
     points.push_back(conf.getAtomPos(i));
-  } 
-    
-  std::vector<double> plane(4);
-  getBestFitPlane(points,plane,0);
-
-  double denom=0.0;
-  for(unsigned int i=0; i<3; ++i){
-    denom += plane[i]*plane[i];
   }
-  denom = pow(denom,0.5);
-    
-  double res=0.0;
-  for(unsigned int i=0; i<numAtoms; ++i){
-    res+= distanceFromAPlane(points[i], plane, denom);
+
+  std::vector<double> plane(4);
+  getBestFitPlane(points, plane, 0);
+
+  double denom = 0.0;
+  for (unsigned int i = 0; i < 3; ++i) {
+    denom += plane[i] * plane[i];
+  }
+  denom = pow(denom, 0.5);
+
+  double res = 0.0;
+  for (unsigned int i = 0; i < numAtoms; ++i) {
+    res += distanceFromAPlane(points[i], plane, denom);
   }
   res /= numAtoms;
 
   return res;
 }
-

--- a/External/INCHI-API/inchi.cpp
+++ b/External/INCHI-API/inchi.cpp
@@ -70,7 +70,6 @@
 #include <algorithm>
 
 #include <RDGeneral/BoostStartInclude.h>
-#include <boost/foreach.hpp>
 #include <boost/tuple/tuple.hpp>
 #include <RDGeneral/BoostEndInclude.h>
 #ifdef RDK_TEST_MULTITHREADED
@@ -94,12 +93,11 @@ bool assignBondDirs(RWMol& mol, INT_PAIR_VECT& zBondPairs,
                     INT_PAIR_VECT& eBondPairs) {
   // bonds to assign
   std::set<int> pending;
-  INT_PAIR pair;
-  BOOST_FOREACH (pair, zBondPairs) {
+  for (const auto pair : zBondPairs) {
     pending.insert(pair.first);
     pending.insert(pair.second);
   }
-  BOOST_FOREACH (pair, eBondPairs) {
+  for (const auto pair : eBondPairs) {
     pending.insert(pair.first);
     pending.insert(pair.second);
   }
@@ -140,7 +138,7 @@ bool assignBondDirs(RWMol& mol, INT_PAIR_VECT& zBondPairs,
         for (int _ = 0; _ < 2; _++) {
           INT_PAIR_VECT* _rules = _ == 0 ? &zBondPairs : &eBondPairs;
           Bond::BondDir _dir = _ == 0 ? dir : otherDir;
-          BOOST_FOREACH (pair, *_rules) {
+          for (const auto pair : *_rules) {
             int other = -1;
             if (pair.first == curBondIdx) {
               other = pair.second;
@@ -162,7 +160,7 @@ bool assignBondDirs(RWMol& mol, INT_PAIR_VECT& zBondPairs,
                 queue.push(std::make_pair(otherBond->getIdx(), _dir));
               }  // end if otherBond's bond direction check
             }    // end if there is a match
-          }      // end boost_foreach
+          }      // end loop over pairs in _rules
         }        // end for _ to go thru rule sets
       }          // end if this bond is assigned
     }            // end if queue is empty
@@ -875,9 +873,8 @@ bool _Valence5NCleanUpA(RWMol& mol, Atom* atom) {
     return false;
   }
 
-  MatchVectType match;
   std::stack<Bond*> bestPath;
-  BOOST_FOREACH (match, fgpMatches) {
+  for (const auto& match : fgpMatches) {
     // does the match contains the current atom?
     if (match[0].second == static_cast<int>(atom->getIdx()) ||
         match[1].second == static_cast<int>(atom->getIdx())) {
@@ -1874,9 +1871,8 @@ std::string MolToInchi(const ROMol& mol, ExtraInchiReturnValues& rv,
       }
       // std::sort(neighbors.begin(), neighbors.end());
       unsigned char nid = 0;
-      std::pair<unsigned int, unsigned int> p;
       // std::cerr<<" at: "<<atom->getIdx();
-      BOOST_FOREACH (p, neighbors) {
+      for (const auto p : neighbors) {
         stereo0D.neighbor[nid++] = p.second;
         // std::cerr<<" "<<p.second;
       }

--- a/External/INCHI-API/test.cpp
+++ b/External/INCHI-API/test.cpp
@@ -3,7 +3,6 @@
 #include <boost/algorithm/string.hpp>
 #include <boost/algorithm/string/trim.hpp>
 #include <boost/lexical_cast.hpp>
-#include <boost/foreach.hpp>
 
 #include <RDGeneral/Invariant.h>
 #include <RDGeneral/RDLog.h>
@@ -81,7 +80,7 @@ void testMultiThread() {
   std::cerr << "generating reference data" << std::endl;
   std::vector<std::string> inchis;
   std::vector<std::string> keys;
-  BOOST_FOREACH (const ROMol *mol, mols) {
+  for (const auto *mol : mols) {
     ExtraInchiReturnValues tmp;
     std::string inchi = MolToInchi(*mol, tmp);
     std::string key = InchiToInchiKey(inchi);


### PR DESCRIPTION
Working on some stuff, we hit the issue that is caused by the interference of Qt and boost's foreach, as described in https://stackoverflow.com/questions/8542591/c11-reverse-range-based-for-loop.

The issue was caused by the boost foreach include in Atom.h (which isn't used in the header at all), and while we can easily work around it, I think it is a good idea to remove boost foreach from RDkit's public headers, especially because C++11 we have range iterators in the language.

This removes the include from all public headers (Code/DataStructs/MultiFPBReader.h, Code/ForceField/ForceField.h, Code/GraphMol/Atom.h, Code/GraphMol/Bond.h, Code/GraphMol/new_canon.h, Code/RDGeneral/Ranking.h), and updates any affected files to use range iterators. In most cases, this implies just swapping out `BOOST_FOREACH (... , ...)` with `for (... : ...)`, but in some cases, `auto` type and/or references were used, and in one case `BOOST_REVERSE_FOREACH` was replaced with `for (... : boost::adaptors::reverse(...))`.

Note that there are still many instances of boost foreach in the code, but these do not happen in public headers.