### PR TITLE
Fixes #3806

### DIFF
--- a/Code/GraphMol/Descriptors/AUTOCORR2D.cpp
+++ b/Code/GraphMol/Descriptors/AUTOCORR2D.cpp
@@ -46,8 +46,8 @@ namespace {
 MolData3Ddescriptors moldata3D;
 
 // this is the Broto-Moreau 2D descriptors (centered or not)
-void get2DautocorrelationDesc(const double* dist, unsigned int numAtoms, const ROMol& mol,
-                              std::vector<double>& res) {
+void get2DautocorrelationDesc(const double* dist, unsigned int numAtoms,
+                              const ROMol& mol, std::vector<double>& res) {
   std::vector<double> wp = moldata3D.GetRelativePol(mol);
   std::vector<double> wm = moldata3D.GetRelativeMW(mol);
   std::vector<double> wv = moldata3D.GetRelativeVdW(mol);
@@ -72,20 +72,18 @@ void get2DautocorrelationDesc(const double* dist, unsigned int numAtoms, const R
     }
   }
 
-
-  std::vector<double> squaresumdiff(6,0.0);
+  std::vector<double> squaresumdiff(6, 0.0);
   for (unsigned int i = 0; i < numAtoms; i++) {
-     for (unsigned int t = 0; t < 6; ++t) {
-         squaresumdiff[t] += ( w[t * numAtoms + i]-wmean[t]) * ( w[t * numAtoms + i]-wmean[t]);
-     }
+    for (unsigned int t = 0; t < 6; ++t) {
+      squaresumdiff[t] +=
+          (w[t * numAtoms + i] - wmean[t]) * (w[t * numAtoms + i] - wmean[t]);
+    }
   }
-
 
   std::vector<double> TDBmat(48, 0.0);
   std::vector<double> TDBmatC(48, 0.0);
   std::vector<double> TDBmatM(48, 0.0);
   std::vector<double> TDBmatG(48, 0.0);
-
 
   for (unsigned int k = 0; k < 8; k++) {
     int maxkVertexPairs = 0;
@@ -93,10 +91,11 @@ void get2DautocorrelationDesc(const double* dist, unsigned int numAtoms, const R
       for (unsigned int j = i + 1; j < numAtoms; ++j) {
         if (dist[j * numAtoms + i] == k + 1) {
           for (unsigned int t = 0; t < 6; ++t) {
+            TDBmatM[t * 8 + k] += (w[t * numAtoms + i] - wmean[t]) *
+                                  (w[t * numAtoms + j] - wmean[t]);  // ATSC
 
-            TDBmatM[t * 8 + k] += (w[t * numAtoms + i]-wmean[t]) * (w[t * numAtoms + j]-wmean[t]); // ATSC
-
-            TDBmatG[t * 8 + k] += (w[t * numAtoms + i] - w[t * numAtoms + j]) * (w[t * numAtoms + i] - w[t * numAtoms + j]);
+            TDBmatG[t * 8 + k] += (w[t * numAtoms + i] - w[t * numAtoms + j]) *
+                                  (w[t * numAtoms + i] - w[t * numAtoms + j]);
 
             TDBmat[t * 8 + k] += w[t * numAtoms + i] * w[t * numAtoms + j];
             TDBmatC[t * 8 + k] += fabs(w[t * numAtoms + i] - wmean[t]) *
@@ -108,17 +107,17 @@ void get2DautocorrelationDesc(const double* dist, unsigned int numAtoms, const R
     }
 
     for (unsigned int t = 0; t < 6; ++t) {
-      if (maxkVertexPairs > 0) {
+      if (maxkVertexPairs > 0 && squaresumdiff[t] > 0) {
         TDBmat[t * 8 + k] = log1p(TDBmat[t * 8 + k]);
-        TDBmatG[t * 8 + k] = TDBmatG[t * 8 + k]/ squaresumdiff[t] / maxkVertexPairs * (numAtoms-1) / 2.0;
-        TDBmatM[t * 8 + k] = TDBmatM[t * 8 + k]/ squaresumdiff[t] / maxkVertexPairs * numAtoms ;
-
+        TDBmatG[t * 8 + k] = TDBmatG[t * 8 + k] / squaresumdiff[t] /
+                             maxkVertexPairs * (numAtoms - 1) / 2.0;
+        TDBmatM[t * 8 + k] =
+            TDBmatM[t * 8 + k] / squaresumdiff[t] / maxkVertexPairs * numAtoms;
       } else {
         TDBmat[t * 8 + k] = 0.0;
         TDBmatC[t * 8 + k] = 0.0;
-        TDBmatM[t * 8 + k] =  0.0;
-        TDBmatG[t * 8 + k] =  0.0;
-
+        TDBmatM[t * 8 + k] = 0.0;
+        TDBmatG[t * 8 + k] = 0.0;
       }
     }
   }
@@ -148,86 +147,87 @@ void get2DautocorrelationDesc(const double* dist, unsigned int numAtoms, const R
   wmean.clear();
 }
 
-    // this is the Broto-Moreau 2D descriptors (centered or not)
-    void get2DautocorrelationDescCustom(const double* dist, unsigned int numAtoms, const ROMol& mol,
-                                  std::vector<double>& res,
-                                  const std::string &customAtomPropName) {
+// this is the Broto-Moreau 2D descriptors (centered or not)
+void get2DautocorrelationDescCustom(const double* dist, unsigned int numAtoms,
+                                    const ROMol& mol, std::vector<double>& res,
+                                    const std::string& customAtomPropName) {
+  std::vector<double> wc = moldata3D.GetCustomAtomProp(mol, customAtomPropName);
+  std::vector<double> w(numAtoms, 0.0);
+  double wmean = 0.0;
 
-        std::vector<double> wc = moldata3D.GetCustomAtomProp(mol,customAtomPropName);
-      std::vector<double> w(numAtoms, 0.0);
-      double wmean=0.0;
+  for (unsigned int i = 0; i < numAtoms; i++) {
+    wmean += wc[+i] / (double)numAtoms;
+  }
 
-      for (unsigned int i = 0; i < numAtoms; i++) {
-          wmean += wc[ + i] / (double)numAtoms;
-      }
+  double squaresumdiff = 0.0;
+  for (unsigned int i = 0; i < numAtoms; i++) {
+    squaresumdiff += (wc[i] - wmean) * (wc[i] - wmean);
+  }
 
-      double squaresumdiff= 0.0;
-      for (unsigned int i = 0; i < numAtoms; i++) {
-          squaresumdiff += (wc[i]-wmean) * (wc[i]-wmean);
-      }
+  std::vector<double> TDBmat(8, 0.0);
+  std::vector<double> TDBmatC(8, 0.0);
+  std::vector<double> TDBmatM(8, 0.0);
+  std::vector<double> TDBmatG(8, 0.0);
 
-      std::vector<double> TDBmat(8, 0.0);
-      std::vector<double> TDBmatC(8, 0.0);
-      std::vector<double> TDBmatM(8, 0.0);
-      std::vector<double> TDBmatG(8, 0.0);
-
-      for (unsigned int k = 0; k < 8; k++) {
-        int maxkVertexPairs = 0;
-        for (unsigned int i = 0; i < numAtoms; ++i) {
-          for (unsigned int j = i + 1; j < numAtoms; ++j) {
-            if (dist[j * numAtoms + i] == k + 1) {
-                TDBmatM[k] += (wc[ i]-wmean) * (wc[ j]-wmean);
-                TDBmatG[k] += (wc[ i] - wc[ j]) * (wc[ i] - w[ j]);
-                TDBmat[k] += wc[ i] * wc[ j];
-                TDBmatC[k] += fabs(wc[ i] - wmean) * fabs(wc[ j] - wmean);
-                maxkVertexPairs += 1;
-            }
-          }
-        }
-
-          for (unsigned int t = 0; t < 1; ++t) {
-          if (maxkVertexPairs > 0) {
-            TDBmat[k] = log1p(TDBmat[k]);
-            TDBmatG[k] = TDBmatG[k]/ squaresumdiff / maxkVertexPairs * (numAtoms-1) / 2.0;
-            TDBmatM[k] = TDBmatM[k]/ squaresumdiff / maxkVertexPairs * numAtoms ;
-
-          } else {
-            TDBmat[k] = 0.0;
-            TDBmatC[k] = 0.0;
-            TDBmatM[k] =  0.0;
-            TDBmatG[k] =  0.0;
-          }
+  for (unsigned int k = 0; k < 8; k++) {
+    int maxkVertexPairs = 0;
+    for (unsigned int i = 0; i < numAtoms; ++i) {
+      for (unsigned int j = i + 1; j < numAtoms; ++j) {
+        if (dist[j * numAtoms + i] == k + 1) {
+          TDBmatM[k] += (wc[i] - wmean) * (wc[j] - wmean);
+          TDBmatG[k] += (wc[i] - wc[j]) * (wc[i] - w[j]);
+          TDBmat[k] += wc[i] * wc[j];
+          TDBmatC[k] += fabs(wc[i] - wmean) * fabs(wc[j] - wmean);
+          maxkVertexPairs += 1;
         }
       }
+    }
 
-      // update the Output vector!
-        for (unsigned int k = 0; k < 8; ++k) {
-          res[k] = std::round(1000 * TDBmat[k]) / 1000;
-          res[k + 8] = std::round(1000 * TDBmatC[k]) / 1000;
-          res[k + 16] = std::round(1000 * TDBmatM[k]) / 1000;
-          res[k + 24] = std::round(1000 * TDBmatG[k]) / 1000;
+    for (unsigned int t = 0; t < 1; ++t) {
+      if (maxkVertexPairs > 0) {
+        TDBmat[k] = log1p(TDBmat[k]);
+        TDBmatG[k] =
+            TDBmatG[k] / squaresumdiff / maxkVertexPairs * (numAtoms - 1) / 2.0;
+        TDBmatM[k] = TDBmatM[k] / squaresumdiff / maxkVertexPairs * numAtoms;
+
+      } else {
+        TDBmat[k] = 0.0;
+        TDBmatC[k] = 0.0;
+        TDBmatM[k] = 0.0;
+        TDBmatG[k] = 0.0;
       }
-
-      TDBmat.clear();
-      TDBmatC.clear();
-      TDBmatM.clear();
-      TDBmatG.clear();
-
-      wc.clear();
     }
+  }
 
-    void Get2Dauto(const double* dist, unsigned int numAtoms, const ROMol& mol,
-                   std::vector<double>& res) {
-      get2DautocorrelationDesc(dist, numAtoms, mol, res);
-    }
-    void Get2Dautoone(const double* dist, unsigned int numAtoms, const ROMol& mol,
-                std::vector<double>& res, const std::string &customAtomPropName) {
-      get2DautocorrelationDescCustom(dist, numAtoms, mol, res, customAtomPropName);
-    }
+  // update the Output vector!
+  for (unsigned int k = 0; k < 8; ++k) {
+    res[k] = std::round(1000 * TDBmat[k]) / 1000;
+    res[k + 8] = std::round(1000 * TDBmatC[k]) / 1000;
+    res[k + 16] = std::round(1000 * TDBmatM[k]) / 1000;
+    res[k + 24] = std::round(1000 * TDBmatG[k]) / 1000;
+  }
+
+  TDBmat.clear();
+  TDBmatC.clear();
+  TDBmatM.clear();
+  TDBmatG.clear();
+
+  wc.clear();
+}
+
+void Get2Dauto(const double* dist, unsigned int numAtoms, const ROMol& mol,
+               std::vector<double>& res) {
+  get2DautocorrelationDesc(dist, numAtoms, mol, res);
+}
+void Get2Dautoone(const double* dist, unsigned int numAtoms, const ROMol& mol,
+                  std::vector<double>& res,
+                  const std::string& customAtomPropName) {
+  get2DautocorrelationDescCustom(dist, numAtoms, mol, res, customAtomPropName);
+}
 }  // end of anonymous namespace
 
 void AUTOCORR2D(const ROMol& mol, std::vector<double>& result,
-                const std::string &customAtomPropName) {
+                const std::string& customAtomPropName) {
   unsigned int numAtoms = mol.getNumAtoms();
   double* dist = MolOps::getDistanceMat(mol, false);  // topological matrix
   if (!customAtomPropName.empty()) {
@@ -240,5 +240,5 @@ void AUTOCORR2D(const ROMol& mol, std::vector<double>& result,
     Get2Dauto(dist, numAtoms, mol, result);
   }
 }
-}  // end of Descriptors namespace
-}  // end of RDKit namespace
+}  // namespace Descriptors
+}  // namespace RDKit

--- a/Code/GraphMol/Descriptors/testAUTOCORR2D.cpp
+++ b/Code/GraphMol/Descriptors/testAUTOCORR2D.cpp
@@ -11,6 +11,7 @@
 #include <RDGeneral/Invariant.h>
 #include <GraphMol/RDKitBase.h>
 #include <GraphMol/FileParsers/MolSupplier.h>
+#include <GraphMol/SmilesParse/SmilesParse.h>
 #include <GraphMol/FileParsers/FileParsers.h>
 #include <RDGeneral/RDLog.h>
 #include <vector>
@@ -19,6 +20,7 @@
 #include <sstream>
 
 #include <GraphMol/Descriptors/AUTOCORR2D.h>
+using namespace RDKit;
 
 void testautocorrelation() {
   BOOST_LOG(rdErrorLog)
@@ -85,7 +87,25 @@ void testautocorrelation() {
   BOOST_LOG(rdErrorLog) << "  done" << std::endl;
 }
 
+void testGithub3806() {
+  BOOST_LOG(rdErrorLog) << "-------------------------------------" << std::endl;
+  BOOST_LOG(rdErrorLog)
+      << "    Test Github #3806: NaNs from AUTOCORR2D descriptor" << std::endl;
+
+  {
+    auto m = "CC"_smiles;
+    std::vector<double> vs;
+    RDKit::Descriptors::AUTOCORR2D(*m, vs);
+    TEST_ASSERT(vs.size() == 192);
+    for (unsigned i = 0; i < vs.size(); ++i) {
+      TEST_ASSERT(!std::isnan(vs[i]));
+    }
+  }
+  BOOST_LOG(rdErrorLog) << "  done" << std::endl;
+}
+
 int main() {
   RDLog::InitLogs();
   testautocorrelation();
+  testGithub3806();
 }


### PR DESCRIPTION
This was just a missing check for zero in a divisor.

Because clang-format also ran on AUTOCORR2D.cpp it looks like the changes are more extensive. The only non-formatting related change in that file is line 110