### PR TITLE
Fixes #3796

### DIFF
--- a/rdkit/Chem/Draw/UnitTestDraw.py
+++ b/rdkit/Chem/Draw/UnitTestDraw.py
@@ -218,10 +218,11 @@ class TestCase(unittest.TestCase):
     with self.assertRaises(KeyError):
       Draw.DrawMorganBit(m, 32, bi)
 
-    # Github #3796: make sure we aren't trying to generate metadata:
-    png = Draw.DrawMorganBit(m, 872, bi, useSVG=False)
-    self.assertIn(b'PNG', png)
-    self.assertIsNone(Chem.MolFromPNGString(png))
+    if hasattr(Draw, 'MolDraw2DCairo'):
+      # Github #3796: make sure we aren't trying to generate metadata:
+      png = Draw.DrawMorganBit(m, 872, bi, useSVG=False)
+      self.assertIn(b'PNG', png)
+      self.assertIsNone(Chem.MolFromPNGString(png))
 
   def testDrawRDKit(self):
     m = Chem.MolFromSmiles('c1ccccc1CC1CC1')
@@ -238,10 +239,11 @@ class TestCase(unittest.TestCase):
     with self.assertRaises(KeyError):
       Draw.DrawRDKitBit(m, 32, bi)
 
-    # Github #3796: make sure we aren't trying to generate metadata:
-    png = Draw.DrawRDKitBit(m, 1553, bi, useSVG=False)
-    self.assertIn(b'PNG', png)
-    self.assertIsNone(Chem.MolFromPNGString(png))
+    if hasattr(Draw, 'MolDraw2DCairo'):
+      # Github #3796: make sure we aren't trying to generate metadata:
+      png = Draw.DrawRDKitBit(m, 1553, bi, useSVG=False)
+      self.assertIn(b'PNG', png)
+      self.assertIsNone(Chem.MolFromPNGString(png))
 
   def testDrawReaction(self):
     # this shouldn't throw an exception...

--- a/rdkit/Chem/Draw/UnitTestDraw.py
+++ b/rdkit/Chem/Draw/UnitTestDraw.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2011-2017  greg Landrum
+#  Copyright (C) 2011-2021  greg Landrum
 #
 #   @@ All Rights Reserved @@
 #  This file is part of the RDKit.
@@ -16,6 +16,7 @@ from rdkit import Chem
 from rdkit.Chem import AllChem
 from rdkit.Chem import rdDepictor
 from rdkit.Chem import Draw
+from rdkit.Chem import rdMolDescriptors
 
 try:
   from rdkit.Chem.Draw import IPythonConsole
@@ -196,53 +197,64 @@ class TestCase(unittest.TestCase):
     from rdkit.Chem import rdMolDescriptors
     m = Chem.MolFromSmiles('c1ccccc1CC1CC1')
     bi = {}
-    fp = rdMolDescriptors.GetMorganFingerprintAsBitVect(m,radius=2,bitInfo=bi)
+    fp = rdMolDescriptors.GetMorganFingerprintAsBitVect(m, radius=2, bitInfo=bi)
     self.assertTrue(872 in bi)
 
-    svg1 = Draw.DrawMorganBit(m,872,bi)
-    aid,r = bi[872][0]
-    svg2 = Draw.DrawMorganEnv(m,aid,r)
-    self.assertEqual(svg1,svg2)
+    svg1 = Draw.DrawMorganBit(m, 872, bi)
+    aid, r = bi[872][0]
+    svg2 = Draw.DrawMorganEnv(m, aid, r)
+    self.assertEqual(svg1, svg2)
     self.assertTrue("style='fill:#CCCCCC;" in svg1)
     self.assertTrue("style='fill:#E5E533;" in svg1)
     self.assertTrue("style='fill:#9999E5;" in svg1)
 
-    svg1 = Draw.DrawMorganBit(m,872,bi,centerColor=None)
-    aid,r = bi[872][0]
-    svg2 = Draw.DrawMorganEnv(m,aid,r,centerColor=None)
-    self.assertEqual(svg1,svg2)
+    svg1 = Draw.DrawMorganBit(m, 872, bi, centerColor=None)
+    aid, r = bi[872][0]
+    svg2 = Draw.DrawMorganEnv(m, aid, r, centerColor=None)
+    self.assertEqual(svg1, svg2)
     self.assertTrue("style='fill:#CCCCCC;" in svg1)
     self.assertTrue("style='fill:#E5E533;" in svg1)
     self.assertFalse("style='fill:#9999E5;" in svg1)
     with self.assertRaises(KeyError):
-      Draw.DrawMorganBit(m,32,bi)
+      Draw.DrawMorganBit(m, 32, bi)
+
+    # Github #3796: make sure we aren't trying to generate metadata:
+    png = Draw.DrawMorganBit(m, 872, bi, useSVG=False)
+    self.assertIn(b'PNG', png)
+    self.assertIsNone(Chem.MolFromPNGString(png))
 
   def testDrawRDKit(self):
     m = Chem.MolFromSmiles('c1ccccc1CC1CC1')
     bi = {}
-    rdkfp = Chem.RDKFingerprint(m,maxPath=5,bitInfo=bi)
+    rdkfp = Chem.RDKFingerprint(m, maxPath=5, bitInfo=bi)
     self.assertTrue(1553 in bi)
-    svg1 = Draw.DrawRDKitBit(m,1553,bi)
+    svg1 = Draw.DrawRDKitBit(m, 1553, bi)
     path = bi[1553][0]
-    svg2 = Draw.DrawRDKitEnv(m,path)
-    self.assertEqual(svg1,svg2)
+    svg2 = Draw.DrawRDKitEnv(m, path)
+    self.assertEqual(svg1, svg2)
     self.assertTrue("style='fill:#E5E533;" in svg1)
     self.assertFalse("style='fill:#CCCCCC;" in svg1)
     self.assertFalse("style='fill:#9999E5;" in svg1)
     with self.assertRaises(KeyError):
-      Draw.DrawRDKitBit(m,32,bi)
+      Draw.DrawRDKitBit(m, 32, bi)
 
+    # Github #3796: make sure we aren't trying to generate metadata:
+    png = Draw.DrawRDKitBit(m, 1553, bi, useSVG=False)
+    self.assertIn(b'PNG', png)
+    self.assertIsNone(Chem.MolFromPNGString(png))
 
   def testDrawReaction(self):
     # this shouldn't throw an exception...
-    rxn = AllChem.ReactionFromSmarts("[c;H1:3]1:[c:4]:[c:5]:[c;H1:6]:[c:7]2:[nH:8]:[c:9]:[c;H1:1]:[c:2]:1:2.O=[C:10]1[#6;H2:11][#6;H2:12][N:13][#6;H2:14][#6;H2:15]1>>[#6;H2:12]3[#6;H1:11]=[C:10]([c:1]1:[c:9]:[n:8]:[c:7]2:[c:6]:[c:5]:[c:4]:[c:3]:[c:2]:1:2)[#6;H2:15][#6;H2:14][N:13]3")
+    rxn = AllChem.ReactionFromSmarts(
+      "[c;H1:3]1:[c:4]:[c:5]:[c;H1:6]:[c:7]2:[nH:8]:[c:9]:[c;H1:1]:[c:2]:1:2.O=[C:10]1[#6;H2:11][#6;H2:12][N:13][#6;H2:14][#6;H2:15]1>>[#6;H2:12]3[#6;H1:11]=[C:10]([c:1]1:[c:9]:[n:8]:[c:7]2:[c:6]:[c:5]:[c:4]:[c:3]:[c:2]:1:2)[#6;H2:15][#6;H2:14][N:13]3"
+    )
     img = Draw.ReactionToImage(rxn)
 
   def testGithub3762(self):
     m = Chem.MolFromSmiles('CC(=O)O')
-    ats = [1,2,3]
-    svg = Draw._moltoSVG(m,(250,200),ats,"",False)
-    self.assertIn('stroke:#FF7F7F;stroke-width:2',svg)
+    ats = [1, 2, 3]
+    svg = Draw._moltoSVG(m, (250, 200), ats, "", False)
+    self.assertIn('stroke:#FF7F7F;stroke-width:2', svg)
     svg = Draw._moltoSVG(m, (250, 200), ats, "", False, highlightBonds=[])
     self.assertNotIn('stroke:#FF7F7F;stroke-width:2', svg)
 

--- a/rdkit/Chem/Draw/__init__.py
+++ b/rdkit/Chem/Draw/__init__.py
@@ -830,11 +830,10 @@ def DrawMorganEnvs(envs, molsPerRow=3, subImgSize=(150, 150), baseRad=0.3, useSV
     drawer = rdMolDraw2D.MolDraw2DCairo(fullSize[0], fullSize[1], subImgSize[0], subImgSize[1])
 
   if drawOptions is None:
-    drawopt = drawer.drawOptions()
-    drawopt.continuousHighlight = False
-  else:
-    drawOptions.continuousHighlight = False
-    drawer.SetDrawOptions(drawOptions)
+    drawOptions = drawer.drawOptions()
+  drawOptions.continuousHighlight = False
+  drawOptions.includeMetadata = False
+  drawer.SetDrawOptions(drawOptions)
   drawer.DrawMolecules(submols, legends=legends, highlightAtoms=highlightAtoms,
                        highlightAtomColors=atomColors, highlightBonds=highlightBonds,
                        highlightBondColors=bondColors, highlightAtomRadii=highlightRadii, **kwargs)
@@ -856,12 +855,10 @@ def DrawMorganEnv(mol, atomId, radius, molSize=(150, 150), baseRad=0.3, useSVG=T
     drawer = rdMolDraw2D.MolDraw2DCairo(molSize[0], molSize[1])
 
   if drawOptions is None:
-    drawopt = drawer.drawOptions()
-    drawopt.continuousHighlight = False
-  else:
-    drawOptions.continuousHighlight = False
-    drawer.SetDrawOptions(drawOptions)
-
+    drawOptions = drawer.drawOptions()
+  drawOptions.continuousHighlight = False
+  drawOptions.includeMetadata = False
+  drawer.SetDrawOptions(drawOptions)
   drawer.DrawMolecule(menv.submol, highlightAtoms=menv.highlightAtoms,
                       highlightAtomColors=menv.atomColors, highlightBonds=menv.highlightBonds,
                       highlightBondColors=menv.bondColors, highlightAtomRadii=menv.highlightRadii,
@@ -975,11 +972,10 @@ def DrawRDKitEnvs(envs, molsPerRow=3, subImgSize=(150, 150), baseRad=0.3, useSVG
     drawer = rdMolDraw2D.MolDraw2DCairo(fullSize[0], fullSize[1], subImgSize[0], subImgSize[1])
 
   if drawOptions is None:
-    drawopt = drawer.drawOptions()
-    drawopt.continuousHighlight = False
-  else:
-    drawOptions.continuousHighlight = False
-    drawer.SetDrawOptions(drawOptions)
+    drawOptions = drawer.drawOptions()
+  drawOptions.continuousHighlight = False
+  drawOptions.includeMetadata = False
+  drawer.SetDrawOptions(drawOptions)
   drawer.DrawMolecules(submols, legends=legends, highlightAtoms=highlightAtoms,
                        highlightAtomColors=atomColors, highlightBonds=highlightBonds,
                        highlightBondColors=bondColors, highlightAtomRadii=highlightRadii, **kwargs)
@@ -999,12 +995,10 @@ def DrawRDKitEnv(mol, bondPath, molSize=(150, 150), baseRad=0.3, useSVG=True,
     drawer = rdMolDraw2D.MolDraw2DCairo(molSize[0], molSize[1])
 
   if drawOptions is None:
-    drawopt = drawer.drawOptions()
-    drawopt.continuousHighlight = False
-  else:
-    drawOptions.continuousHighlight = False
-    drawer.SetDrawOptions(drawOptions)
-
+    drawOptions = drawer.drawOptions()
+  drawOptions.continuousHighlight = False
+  drawOptions.includeMetadata = False
+  drawer.SetDrawOptions(drawOptions)
   drawer.DrawMolecule(menv.submol, highlightAtoms=menv.highlightAtoms,
                       highlightAtomColors=menv.atomColors, highlightBonds=menv.highlightBonds,
                       highlightBondColors=menv.bondColors, highlightAtomRadii=menv.highlightRadii,


### PR DESCRIPTION
This just disables the creation of metadata when generating the images of fingerprint bits. It doesn't make sense to be generating that partial data anyway.

