### PR TITLE
Facilities for interactive modification of molecule drawing

### DIFF
--- a/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
@@ -2891,7 +2891,9 @@ void drawDativeBond(MolDraw2D &d2d, const Bond &bond, const Point2D &cds1,
   Point2D mid = (cds1 + cds2) * 0.5;
   d2d.drawLine(cds1, mid, col1, col1);
 
-  if (split) d2d.setActiveAtmIdx(bond.getEndAtomIdx());
+  if (split) {
+    d2d.setActiveAtmIdx(bond.getEndAtomIdx());
+  }
   d2d.setColour(col2);
   bool asPolygon = true;
   double frac = 0.2;

--- a/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
@@ -3043,7 +3043,9 @@ void drawQueryBond1(MolDraw2D &d2d, const Bond &bond, bool highlight_bond,
     tdash[1] /= 1.5;
   }
   if (qry->getDescription() == "SingleOrDoubleBond") {
-    if (split) d2d.setActiveAtmIdx(bond.getBeginAtomIdx());
+    if (split) {
+      d2d.setActiveAtmIdx(bond.getBeginAtomIdx());
+    }
     {
       Point2D l1s, l1f, l2s, l2f;
       calcDoubleBondLines(bond.getOwningMol(), double_bond_offset, bond,

--- a/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
@@ -305,7 +305,9 @@ MolDraw2D::MolDraw2D(int width, int height, int panelWidth, int panelHeight)
       x_offset_(0),
       y_offset_(0),
       fill_polys_(true),
-      activeMolIdx_(-1) {}
+      activeMolIdx_(-1),
+      activeAtmIdx1_(-1),
+      activeAtmIdx2_(-1) {}
 
 // ****************************************************************************
 MolDraw2D::~MolDraw2D() {}
@@ -2780,9 +2782,18 @@ const DashPattern dashes = assign::list_of(6)(6);
 const DashPattern shortDashes = assign::list_of(2)(2);
 
 // ****************************************************************************
-void drawWedgedBond(MolDraw2D &d2d, const Point2D &cds1, const Point2D &cds2,
-                    bool draw_dashed, const DrawColour &col1,
-                    const DrawColour &col2) {
+void drawWedgedBond(MolDraw2D &d2d, const Bond &bond, bool inverted,
+                    const Point2D &cds1, const Point2D &cds2, bool draw_dashed,
+                    const DrawColour &col1, const DrawColour &col2) {
+  const auto split = d2d.drawOptions().splitBonds;
+  if (!split) {
+    if (inverted) {
+      d2d.setActiveAtmIdx(bond.getEndAtomIdx(), bond.getBeginAtomIdx());
+    } else {
+      d2d.setActiveAtmIdx(bond.getBeginAtomIdx(), bond.getEndAtomIdx());
+    }
+  }
+
   Point2D perp = calcPerpendicular(cds1, cds2);
   Point2D disp = perp * 0.15;
   // make sure the displacement isn't too large using the current scale factor
@@ -2817,11 +2828,19 @@ void drawWedgedBond(MolDraw2D &d2d, const Point2D &cds1, const Point2D &cds2,
     int tgt_lw = 1;  // use the minimum line width
     d2d.setLineWidth(tgt_lw);
 
+    if (split) {
+      d2d.setActiveAtmIdx(inverted ? bond.getEndAtomIdx()
+                                   : bond.getBeginAtomIdx());
+    }
     Point2D e1 = end1 - cds1;
     Point2D e2 = end2 - cds1;
     for (unsigned int i = 1; i < nDashes + 1; ++i) {
       if ((nDashes / 2 + 1) == i) {
         d2d.setColour(col2);
+        if (split) {
+          d2d.setActiveAtmIdx(inverted ? bond.getBeginAtomIdx()
+                                       : bond.getEndAtomIdx());
+        }
       }
       Point2D e11 = cds1 + e1 * (rdcast<double>(i) / nDashes);
       Point2D e22 = cds1 + e2 * (rdcast<double>(i) / nDashes);
@@ -2835,27 +2854,45 @@ void drawWedgedBond(MolDraw2D &d2d, const Point2D &cds1, const Point2D &cds2,
     d2d.setLineWidth(orig_lw);
   } else {
     d2d.setFillPolys(true);
-    if (col1 == col2) {
+    if (col1 == col2 && !split) {
       d2d.drawTriangle(cds1, end1, end2);
     } else {
+      if (split) {
+        d2d.setActiveAtmIdx(inverted ? bond.getEndAtomIdx()
+                                     : bond.getBeginAtomIdx());
+      }
       Point2D e1 = end1 - cds1;
       Point2D e2 = end2 - cds1;
       Point2D mid1 = cds1 + e1 * 0.5;
       Point2D mid2 = cds1 + e2 * 0.5;
       d2d.drawTriangle(cds1, mid1, mid2);
+      if (split) {
+        d2d.setActiveAtmIdx(inverted ? bond.getBeginAtomIdx()
+                                     : bond.getEndAtomIdx());
+      }
       d2d.setColour(col2);
       d2d.drawTriangle(mid1, end2, end1);
       d2d.drawTriangle(mid1, mid2, end2);
     }
   }
+  d2d.setActiveAtmIdx();
 }
 
 // ****************************************************************************
-void drawDativeBond(MolDraw2D &d2d, const Point2D &cds1, const Point2D &cds2,
-                    const DrawColour &col1, const DrawColour &col2) {
+void drawDativeBond(MolDraw2D &d2d, const Bond &bond, const Point2D &cds1,
+                    const Point2D &cds2, const DrawColour &col1,
+                    const DrawColour &col2) {
+  const auto split = d2d.drawOptions().splitBonds;
+  if (!split) {
+    d2d.setActiveAtmIdx(bond.getBeginAtomIdx(), bond.getEndAtomIdx());
+  } else {
+    d2d.setActiveAtmIdx(bond.getBeginAtomIdx());
+  }
+
   Point2D mid = (cds1 + cds2) * 0.5;
   d2d.drawLine(cds1, mid, col1, col1);
 
+  if (split) d2d.setActiveAtmIdx(bond.getEndAtomIdx());
   d2d.setColour(col2);
   bool asPolygon = true;
   double frac = 0.2;
@@ -2865,6 +2902,30 @@ void drawDativeBond(MolDraw2D &d2d, const Point2D &cds1, const Point2D &cds2,
   Point2D delta = mid - cds2;
   Point2D end = cds2 + delta * frac;
   d2d.drawArrow(mid, end, asPolygon, frac, angle);
+}
+
+void drawBondLine(MolDraw2D &d2d, const Bond &bond, const Point2D &cds1,
+                  const Point2D &cds2, const DrawColour &col1,
+                  const DrawColour &col2) {
+  if (!d2d.drawOptions().splitBonds) {
+    d2d.setActiveAtmIdx(bond.getBeginAtomIdx(), bond.getEndAtomIdx());
+    d2d.drawLine(cds1, cds2, col1, col2);
+    return;
+  }
+  Point2D mid = (cds1 + cds2) * 0.5;
+  d2d.setActiveAtmIdx(bond.getBeginAtomIdx());
+  d2d.drawLine(cds1, mid, col1, col1);
+  d2d.setActiveAtmIdx(bond.getEndAtomIdx());
+  d2d.drawLine(mid, cds2, col2, col2);
+}
+
+void drawBondWavyLine(MolDraw2D &d2d, const Bond &bond, const Point2D &cds1,
+                      const Point2D &cds2, const DrawColour &col1,
+                      const DrawColour &col2) {
+  // as splitting wavy line might cause rendering problems
+  // do not split and flag wavy bond with both atoms
+  d2d.setActiveAtmIdx(bond.getBeginAtomIdx(), bond.getEndAtomIdx());
+  d2d.drawWavyLine(cds1, cds2, col1, col2);
 }
 
 void drawNormalBond(MolDraw2D &d2d, const Bond &bond, bool highlight_bond,
@@ -2884,11 +2945,11 @@ void drawNormalBond(MolDraw2D &d2d, const Bond &bond, bool highlight_bond,
       d2d.drawOptions().scaleBondWidth =
           d2d.drawOptions().scaleHighlightBondWidth;
     }
-    d2d.drawLine(l1s, l1f, col1, col2);
+    drawBondLine(d2d, bond, l1s, l1f, col1, col2);
     if (bt == Bond::AROMATIC) {
       d2d.setDash(dashes);
     }
-    d2d.drawLine(l2s, l2f, col1, col2);
+    drawBondLine(d2d, bond, l2s, l2f, col1, col2);
     if (bt == Bond::AROMATIC) {
       d2d.setDash(noDash);
     }
@@ -2899,6 +2960,7 @@ void drawNormalBond(MolDraw2D &d2d, const Bond &bond, bool highlight_bond,
     // or if at2 does have stereochem set and the bond starts there
     auto at1 = bond.getBeginAtom();
     auto at2 = bond.getEndAtom();
+    auto inverted = false;
     if ((at1->getChiralTag() != Atom::CHI_TETRAHEDRAL_CW &&
          at1->getChiralTag() != Atom::CHI_TETRAHEDRAL_CCW) ||
         (at1->getIdx() != bond.getBeginAtomIdx() &&
@@ -2907,21 +2969,22 @@ void drawNormalBond(MolDraw2D &d2d, const Bond &bond, bool highlight_bond,
       // std::cerr << "  swap" << std::endl;
       swap(at1_cds, at2_cds);
       swap(col1, col2);
+      inverted = true;
     }
     // deliberately not scaling highlighted bond width
     if (Bond::BEGINWEDGE == bond.getBondDir()) {
-      drawWedgedBond(d2d, at1_cds, at2_cds, false, col1, col2);
+      drawWedgedBond(d2d, bond, inverted, at1_cds, at2_cds, false, col1, col2);
     } else {
-      drawWedgedBond(d2d, at1_cds, at2_cds, true, col1, col2);
+      drawWedgedBond(d2d, bond, inverted, at1_cds, at2_cds, true, col1, col2);
     }
   } else if (Bond::SINGLE == bt && Bond::UNKNOWN == bond.getBondDir()) {
     // unspecified stereo
     // deliberately not scaling highlighted bond width
-    d2d.drawWavyLine(at1_cds, at2_cds, col1, col2);
+    drawBondWavyLine(d2d, bond, at1_cds, at2_cds, col1, col2);
   } else if (Bond::DATIVE == bt || Bond::DATIVEL == bt || Bond::DATIVER == bt) {
     // deliberately not scaling highlighted bond width as I think
     // the arrowhead will look ugly.
-    drawDativeBond(d2d, at1_cds, at2_cds, col1, col2);
+    drawDativeBond(d2d, bond, at1_cds, at2_cds, col1, col2);
   } else if (Bond::ZERO == bt) {
     d2d.setDash(shortDashes);
     bool orig_slw = d2d.drawOptions().scaleBondWidth;
@@ -2929,7 +2992,7 @@ void drawNormalBond(MolDraw2D &d2d, const Bond &bond, bool highlight_bond,
       d2d.drawOptions().scaleBondWidth =
           d2d.drawOptions().scaleHighlightBondWidth;
     }
-    d2d.drawLine(at1_cds, at2_cds, col1, col2);
+    drawBondLine(d2d, bond, at1_cds, at2_cds, col1, col2);
     d2d.drawOptions().scaleBondWidth = orig_slw;
     d2d.setDash(noDash);
   } else {
@@ -2940,13 +3003,13 @@ void drawNormalBond(MolDraw2D &d2d, const Bond &bond, bool highlight_bond,
       d2d.drawOptions().scaleBondWidth =
           d2d.drawOptions().scaleHighlightBondWidth;
     }
-    d2d.drawLine(at1_cds, at2_cds, col1, col2);
+    drawBondLine(d2d, bond, at1_cds, at2_cds, col1, col2);
     if (Bond::TRIPLE == bt) {
       Point2D l1s, l1f, l2s, l2f;
       calcTripleBondLines(double_bond_offset, bond, at1_cds, at2_cds, l1s, l1f,
                           l2s, l2f);
-      d2d.drawLine(l1s, l1f, col1, col2);
-      d2d.drawLine(l2s, l2f, col1, col2);
+      drawBondLine(d2d, bond, l1s, l1f, col1, col2);
+      drawBondLine(d2d, bond, l2s, l2f, col1, col2);
     }
     d2d.drawOptions().scaleBondWidth = orig_slw;
   }
@@ -2958,6 +3021,11 @@ void drawQueryBond1(MolDraw2D &d2d, const Bond &bond, bool highlight_bond,
                     const DrawColour &col2, double double_bond_offset) {
   PRECONDITION(bond.hasQuery(), "no query");
   const auto qry = bond.getQuery();
+  const auto split = d2d.drawOptions().splitBonds;
+  if (!split) {
+    d2d.setActiveAtmIdx(bond.getBeginAtomIdx(), bond.getEndAtomIdx());
+  }
+  auto midp = (at2_cds + at1_cds) / 2.;
   auto dv = at2_cds - at1_cds;
   auto p1 = at1_cds + dv * (1. / 3.);
   auto p2 = at1_cds + dv * (2. / 3.);
@@ -2970,6 +3038,7 @@ void drawQueryBond1(MolDraw2D &d2d, const Bond &bond, bool highlight_bond,
     tdash[1] /= 1.5;
   }
   if (qry->getDescription() == "SingleOrDoubleBond") {
+    if (split) d2d.setActiveAtmIdx(bond.getBeginAtomIdx());
     {
       Point2D l1s, l1f, l2s, l2f;
       calcDoubleBondLines(bond.getOwningMol(), double_bond_offset, bond,
@@ -2978,7 +3047,13 @@ void drawQueryBond1(MolDraw2D &d2d, const Bond &bond, bool highlight_bond,
       d2d.drawLine(l1s, l1f);
       d2d.drawLine(l2s, l2f);
     }
-    d2d.drawLine(p1, p2, col1, col2);
+    if (split) {
+      d2d.drawLine(p1, midp, col1, col2);
+      d2d.setActiveAtmIdx(bond.getEndAtomIdx());
+      d2d.drawLine(midp, p2, col1, col2);
+    } else {
+      d2d.drawLine(p1, p2, col1, col2);
+    }
     {
       Point2D l1s, l1f, l2s, l2f;
       calcDoubleBondLines(bond.getOwningMol(), double_bond_offset, bond, p2,
@@ -2988,6 +3063,7 @@ void drawQueryBond1(MolDraw2D &d2d, const Bond &bond, bool highlight_bond,
       d2d.drawLine(l2s, l2f);
     }
   } else if (qry->getDescription() == "SingleOrAromaticBond") {
+    if (split) d2d.setActiveAtmIdx(bond.getBeginAtomIdx());
     {
       Point2D l1s, l1f, l2s, l2f;
       calcDoubleBondLines(bond.getOwningMol(), double_bond_offset, bond,
@@ -2998,8 +3074,13 @@ void drawQueryBond1(MolDraw2D &d2d, const Bond &bond, bool highlight_bond,
       d2d.drawLine(l2s, l2f);
       d2d.setDash(noDash);
     }
-    d2d.drawLine(p1, p2, col1, col2);
-
+    if (split) {
+      d2d.drawLine(p1, midp, col1, col2);
+      d2d.setActiveAtmIdx(bond.getEndAtomIdx());
+      d2d.drawLine(midp, p2, col1, col2);
+    } else {
+      d2d.drawLine(p1, p2, col1, col2);
+    }
     {
       Point2D l1s, l1f, l2s, l2f;
       calcDoubleBondLines(bond.getOwningMol(), double_bond_offset, bond, p2,
@@ -3011,6 +3092,7 @@ void drawQueryBond1(MolDraw2D &d2d, const Bond &bond, bool highlight_bond,
       d2d.setDash(noDash);
     }
   } else if (qry->getDescription() == "DoubleOrAromaticBond") {
+    if (split) d2d.setActiveAtmIdx(bond.getBeginAtomIdx());
     {
       Point2D l1s, l1f, l2s, l2f;
       calcDoubleBondLines(bond.getOwningMol(), double_bond_offset, bond,
@@ -3021,8 +3103,27 @@ void drawQueryBond1(MolDraw2D &d2d, const Bond &bond, bool highlight_bond,
       d2d.drawLine(l2s, l2f);
       d2d.setDash(noDash);
     }
-
-    {
+    if (split) {
+      {
+        Point2D l1s, l1f, l2s, l2f;
+        calcDoubleBondLines(bond.getOwningMol(), double_bond_offset, bond, p1,
+                            midp, at_cds, l1s, l1f, l2s, l2f);
+        d2d.setColour(col1);
+        d2d.drawLine(l1s, l1f, col1, col2);
+        d2d.drawLine(l2s, l2f, col1, col2);
+        d2d.setDash(noDash);
+      }
+      d2d.setActiveAtmIdx(bond.getEndAtomIdx());
+      {
+        Point2D l1s, l1f, l2s, l2f;
+        calcDoubleBondLines(bond.getOwningMol(), double_bond_offset, bond, midp,
+                            p2, at_cds, l1s, l1f, l2s, l2f);
+        d2d.setColour(col1);
+        d2d.drawLine(l1s, l1f, col1, col2);
+        d2d.drawLine(l2s, l2f, col1, col2);
+        d2d.setDash(noDash);
+      }
+    } else {
       Point2D l1s, l1f, l2s, l2f;
       calcDoubleBondLines(bond.getOwningMol(), double_bond_offset, bond, p1, p2,
                           at_cds, l1s, l1f, l2s, l2f);
@@ -3031,7 +3132,6 @@ void drawQueryBond1(MolDraw2D &d2d, const Bond &bond, bool highlight_bond,
       d2d.drawLine(l2s, l2f, col1, col2);
       d2d.setDash(noDash);
     }
-
     {
       Point2D l1s, l1f, l2s, l2f;
       calcDoubleBondLines(bond.getOwningMol(), double_bond_offset, bond, p2,
@@ -3049,7 +3149,14 @@ void drawQueryBond1(MolDraw2D &d2d, const Bond &bond, bool highlight_bond,
       d2d.drawOptions().scaleBondWidth =
           d2d.drawOptions().scaleHighlightBondWidth;
     }
-    d2d.drawLine(at1_cds, at2_cds, col1, col2);
+    if (split) {
+      d2d.setActiveAtmIdx(bond.getBeginAtomIdx());
+      d2d.drawLine(at1_cds, midp, col1, col1);
+      d2d.setActiveAtmIdx(bond.getEndAtomIdx());
+      d2d.drawLine(midp, at2_cds, col2, col2);
+    } else {
+      d2d.drawLine(at1_cds, at2_cds, col1, col2);
+    }
     d2d.drawOptions().scaleBondWidth = orig_slw;
     d2d.setDash(noDash);
   } else {
@@ -3059,10 +3166,18 @@ void drawQueryBond1(MolDraw2D &d2d, const Bond &bond, bool highlight_bond,
       d2d.drawOptions().scaleBondWidth =
           d2d.drawOptions().scaleHighlightBondWidth;
     }
-    d2d.drawLine(at1_cds, at2_cds, col1, col2);
+    if (split) {
+      d2d.setActiveAtmIdx(bond.getBeginAtomIdx());
+      d2d.drawLine(at1_cds, midp, col1, col1);
+      d2d.setActiveAtmIdx(bond.getEndAtomIdx());
+      d2d.drawLine(midp, at2_cds, col2, col2);
+    } else {
+      d2d.drawLine(at1_cds, at2_cds, col1, col2);
+    }
     d2d.drawOptions().scaleBondWidth = orig_slw;
     d2d.setDash(noDash);
   }
+  d2d.setActiveAtmIdx();
 }
 
 void drawQueryBond(MolDraw2D &d2d, const Bond &bond, bool highlight_bond,
@@ -3071,8 +3186,11 @@ void drawQueryBond(MolDraw2D &d2d, const Bond &bond, bool highlight_bond,
                    const DrawColour &col2, double double_bond_offset) {
   PRECONDITION(bond.hasQuery(), "no query");
   const auto qry = bond.getQuery();
-  auto dv = at2_cds - at1_cds;
-  auto midp = at1_cds + dv / 2.;
+  const auto split = d2d.drawOptions().splitBonds;
+  if (!split) {
+    d2d.setActiveAtmIdx(bond.getBeginAtomIdx(), bond.getEndAtomIdx());
+  }
+  auto midp = (at2_cds + at1_cds) / 2.;
   auto tdash = shortDashes;
   if (d2d.scale() < 10) {
     tdash[0] /= 4;
@@ -3086,7 +3204,9 @@ void drawQueryBond(MolDraw2D &d2d, const Bond &bond, bool highlight_bond,
 
   bool drawGenericQuery = false;
   if (qry->getDescription() == "SingleOrDoubleBond") {
+    if (split) d2d.setActiveAtmIdx(bond.getBeginAtomIdx());
     d2d.drawLine(at1_cds, midp);
+    if (split) d2d.setActiveAtmIdx(bond.getEndAtomIdx());
     {
       Point2D l1s, l1f, l2s, l2f;
       calcDoubleBondLines(bond.getOwningMol(), double_bond_offset, bond, midp,
@@ -3095,7 +3215,9 @@ void drawQueryBond(MolDraw2D &d2d, const Bond &bond, bool highlight_bond,
       d2d.drawLine(l2s, l2f);
     }
   } else if (qry->getDescription() == "SingleOrAromaticBond") {
+    if (split) d2d.setActiveAtmIdx(bond.getBeginAtomIdx());
     d2d.drawLine(at1_cds, midp);
+    if (split) d2d.setActiveAtmIdx(bond.getEndAtomIdx());
     {
       Point2D l1s, l1f, l2s, l2f;
       calcDoubleBondLines(bond.getOwningMol(), double_bond_offset, bond, midp,
@@ -3106,6 +3228,7 @@ void drawQueryBond(MolDraw2D &d2d, const Bond &bond, bool highlight_bond,
       d2d.setDash(noDash);
     }
   } else if (qry->getDescription() == "DoubleOrAromaticBond") {
+    if (split) d2d.setActiveAtmIdx(bond.getBeginAtomIdx());
     {
       Point2D l1s, l1f, l2s, l2f;
       calcDoubleBondLines(bond.getOwningMol(), double_bond_offset, bond,
@@ -3113,7 +3236,7 @@ void drawQueryBond(MolDraw2D &d2d, const Bond &bond, bool highlight_bond,
       d2d.drawLine(l1s, l1f);
       d2d.drawLine(l2s, l2f);
     }
-
+    if (split) d2d.setActiveAtmIdx(bond.getEndAtomIdx());
     {
       Point2D l1s, l1f, l2s, l2f;
       calcDoubleBondLines(bond.getOwningMol(), double_bond_offset, bond, midp,
@@ -3125,7 +3248,14 @@ void drawQueryBond(MolDraw2D &d2d, const Bond &bond, bool highlight_bond,
     }
   } else if (qry->getDescription() == "BondNull") {
     d2d.setDash(tdash);
-    d2d.drawLine(at1_cds, at2_cds);
+    if (split) {
+      d2d.setActiveAtmIdx(bond.getBeginAtomIdx());
+      d2d.drawLine(at1_cds, midp);
+      d2d.setActiveAtmIdx(bond.getEndAtomIdx());
+      d2d.drawLine(midp, at2_cds);
+    } else {
+      d2d.drawLine(at1_cds, at2_cds);
+    }
     d2d.setDash(noDash);
   } else if (qry->getDescription() == "BondAnd" &&
              qry->endChildren() - qry->beginChildren() == 2) {
@@ -3182,10 +3312,18 @@ void drawQueryBond(MolDraw2D &d2d, const Bond &bond, bool highlight_bond,
       d2d.drawOptions().scaleBondWidth =
           d2d.drawOptions().scaleHighlightBondWidth;
     }
-    d2d.drawLine(at1_cds, at2_cds);
+    if (split) {
+      d2d.setActiveAtmIdx(bond.getBeginAtomIdx());
+      d2d.drawLine(at1_cds, midp);
+      d2d.setActiveAtmIdx(bond.getEndAtomIdx());
+      d2d.drawLine(midp, at2_cds);
+    } else {
+      d2d.drawLine(at1_cds, at2_cds);
+    }
     d2d.drawOptions().scaleBondWidth = orig_slw;
     d2d.setDash(noDash);
   }
+  d2d.setActiveAtmIdx();
 }
 
 }  // namespace
@@ -4160,6 +4298,7 @@ void MolDraw2D::tabulaRasa() {
   x_offset_ = y_offset_ = 0;
   d_metadata.clear();
   d_numMetadataEntries = 0;
+  setActiveAtmIdx();
 }
 
 // ****************************************************************************

--- a/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
@@ -3249,7 +3249,9 @@ void drawQueryBond(MolDraw2D &d2d, const Bond &bond, bool highlight_bond,
       d2d.drawLine(l1s, l1f);
       d2d.drawLine(l2s, l2f);
     }
-    if (split) d2d.setActiveAtmIdx(bond.getEndAtomIdx());
+    if (split) {
+      d2d.setActiveAtmIdx(bond.getEndAtomIdx());
+    }
     {
       Point2D l1s, l1f, l2s, l2f;
       calcDoubleBondLines(bond.getOwningMol(), double_bond_offset, bond, midp,

--- a/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
@@ -3239,7 +3239,9 @@ void drawQueryBond(MolDraw2D &d2d, const Bond &bond, bool highlight_bond,
       d2d.setDash(noDash);
     }
   } else if (qry->getDescription() == "DoubleOrAromaticBond") {
-    if (split) d2d.setActiveAtmIdx(bond.getBeginAtomIdx());
+    if (split) {
+      d2d.setActiveAtmIdx(bond.getBeginAtomIdx());
+    }
     {
       Point2D l1s, l1f, l2s, l2f;
       calcDoubleBondLines(bond.getOwningMol(), double_bond_offset, bond,

--- a/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
@@ -3101,7 +3101,9 @@ void drawQueryBond1(MolDraw2D &d2d, const Bond &bond, bool highlight_bond,
       d2d.setDash(noDash);
     }
   } else if (qry->getDescription() == "DoubleOrAromaticBond") {
-    if (split) d2d.setActiveAtmIdx(bond.getBeginAtomIdx());
+    if (split) {
+      d2d.setActiveAtmIdx(bond.getBeginAtomIdx());
+    }
     {
       Point2D l1s, l1f, l2s, l2f;
       calcDoubleBondLines(bond.getOwningMol(), double_bond_offset, bond,

--- a/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
@@ -2785,8 +2785,7 @@ const DashPattern shortDashes = assign::list_of(2)(2);
 void drawWedgedBond(MolDraw2D &d2d, const Bond &bond, bool inverted,
                     const Point2D &cds1, const Point2D &cds2, bool draw_dashed,
                     const DrawColour &col1, const DrawColour &col2) {
-  const auto split = d2d.drawOptions().splitBonds;
-  if (!split) {
+  if (!d2d.drawOptions().splitBonds) {
     if (inverted) {
       d2d.setActiveAtmIdx(bond.getEndAtomIdx(), bond.getBeginAtomIdx());
     } else {

--- a/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
@@ -3070,7 +3070,9 @@ void drawQueryBond1(MolDraw2D &d2d, const Bond &bond, bool highlight_bond,
       d2d.drawLine(l2s, l2f);
     }
   } else if (qry->getDescription() == "SingleOrAromaticBond") {
-    if (split) d2d.setActiveAtmIdx(bond.getBeginAtomIdx());
+    if (split) {
+      d2d.setActiveAtmIdx(bond.getBeginAtomIdx());
+    }
     {
       Point2D l1s, l1f, l2s, l2f;
       calcDoubleBondLines(bond.getOwningMol(), double_bond_offset, bond,

--- a/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
@@ -3207,9 +3207,13 @@ void drawQueryBond(MolDraw2D &d2d, const Bond &bond, bool highlight_bond,
 
   bool drawGenericQuery = false;
   if (qry->getDescription() == "SingleOrDoubleBond") {
-    if (split) d2d.setActiveAtmIdx(bond.getBeginAtomIdx());
+    if (split) {
+      d2d.setActiveAtmIdx(bond.getBeginAtomIdx());
+    }
     d2d.drawLine(at1_cds, midp);
-    if (split) d2d.setActiveAtmIdx(bond.getEndAtomIdx());
+    if (split) {
+      d2d.setActiveAtmIdx(bond.getEndAtomIdx());
+    }
     {
       Point2D l1s, l1f, l2s, l2f;
       calcDoubleBondLines(bond.getOwningMol(), double_bond_offset, bond, midp,

--- a/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
@@ -3218,9 +3218,13 @@ void drawQueryBond(MolDraw2D &d2d, const Bond &bond, bool highlight_bond,
       d2d.drawLine(l2s, l2f);
     }
   } else if (qry->getDescription() == "SingleOrAromaticBond") {
-    if (split) d2d.setActiveAtmIdx(bond.getBeginAtomIdx());
+    if (split) {
+      d2d.setActiveAtmIdx(bond.getBeginAtomIdx());
+    }
     d2d.drawLine(at1_cds, midp);
-    if (split) d2d.setActiveAtmIdx(bond.getEndAtomIdx());
+    if (split) 
+      d2d.setActiveAtmIdx(bond.getEndAtomIdx());
+    }
     {
       Point2D l1s, l1f, l2s, l2f;
       calcDoubleBondLines(bond.getOwningMol(), double_bond_offset, bond, midp,

--- a/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
@@ -2902,6 +2902,7 @@ void drawDativeBond(MolDraw2D &d2d, const Bond &bond, const Point2D &cds1,
   Point2D delta = mid - cds2;
   Point2D end = cds2 + delta * frac;
   d2d.drawArrow(mid, end, asPolygon, frac, angle);
+  d2d.setActiveAtmIdx();
 }
 
 void drawBondLine(MolDraw2D &d2d, const Bond &bond, const Point2D &cds1,
@@ -2910,6 +2911,7 @@ void drawBondLine(MolDraw2D &d2d, const Bond &bond, const Point2D &cds1,
   if (!d2d.drawOptions().splitBonds) {
     d2d.setActiveAtmIdx(bond.getBeginAtomIdx(), bond.getEndAtomIdx());
     d2d.drawLine(cds1, cds2, col1, col2);
+	  d2d.setActiveAtmIdx();
     return;
   }
   Point2D mid = (cds1 + cds2) * 0.5;
@@ -2917,6 +2919,7 @@ void drawBondLine(MolDraw2D &d2d, const Bond &bond, const Point2D &cds1,
   d2d.drawLine(cds1, mid, col1, col1);
   d2d.setActiveAtmIdx(bond.getEndAtomIdx());
   d2d.drawLine(mid, cds2, col2, col2);
+  d2d.setActiveAtmIdx();
 }
 
 void drawBondWavyLine(MolDraw2D &d2d, const Bond &bond, const Point2D &cds1,
@@ -2926,6 +2929,7 @@ void drawBondWavyLine(MolDraw2D &d2d, const Bond &bond, const Point2D &cds1,
   // do not split and flag wavy bond with both atoms
   d2d.setActiveAtmIdx(bond.getBeginAtomIdx(), bond.getEndAtomIdx());
   d2d.drawWavyLine(cds1, cds2, col1, col2);
+  d2d.setActiveAtmIdx();
 }
 
 void drawNormalBond(MolDraw2D &d2d, const Bond &bond, bool highlight_bond,

--- a/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
@@ -2912,7 +2912,7 @@ void drawBondLine(MolDraw2D &d2d, const Bond &bond, const Point2D &cds1,
   if (!d2d.drawOptions().splitBonds) {
     d2d.setActiveAtmIdx(bond.getBeginAtomIdx(), bond.getEndAtomIdx());
     d2d.drawLine(cds1, cds2, col1, col2);
-	  d2d.setActiveAtmIdx();
+    d2d.setActiveAtmIdx();
     return;
   }
   Point2D mid = (cds1 + cds2) * 0.5;

--- a/Code/GraphMol/MolDraw2D/MolDraw2D.h
+++ b/Code/GraphMol/MolDraw2D/MolDraw2D.h
@@ -666,7 +666,9 @@ class RDKIT_MOLDRAW2D_EXPORT MolDraw2D {
   void setActiveAtmIdx(int at_idx1 = -1, int at_idx2 = -1) {
     at_idx1 = (at_idx1 < 0 ? -1 : at_idx1);
     at_idx2 = (at_idx2 < 0 ? -1 : at_idx2);
-    if (at_idx2 >= 0 && at_idx1 < 0) std::swap(at_idx1, at_idx2);
+    if (at_idx2 >= 0 && at_idx1 < 0) {
+      std::swap(at_idx1, at_idx2);
+    }
     activeAtmIdx1_ = at_idx1;
 	activeAtmIdx2_ = at_idx2;
   }

--- a/Code/GraphMol/MolDraw2D/MolDraw2D.h
+++ b/Code/GraphMol/MolDraw2D/MolDraw2D.h
@@ -202,6 +202,9 @@ struct RDKIT_MOLDRAW2D_EXPORT MolDrawOptions {
       false;  // toggles replacing 2H with D and 3H with T
   bool dummiesAreAttachments = false;  // draws "breaks" at dummy atoms
   bool circleAtoms = true;             // draws circles under highlighted atoms
+  bool splitBonds = false;             // split bonds into per atom segments
+                                       // most useful for dynamic manipulation of drawing
+                                       // especially for svg
   DrawColour highlightColour{1, 0.5, 0.5, 1.0};  // default highlight color
   bool continuousHighlight = true;  // highlight by drawing an outline
                                     // *underneath* the molecule
@@ -657,6 +660,17 @@ class RDKIT_MOLDRAW2D_EXPORT MolDraw2D {
   virtual bool supportsAnnotations() { return true; }
   virtual void drawAnnotation(const AnnotationType &annotation);
 
+  bool hasActiveAtmIdx() { return activeAtmIdx1_>=0; }
+  int getActiveAtmIdx1() { return activeAtmIdx1_; }
+  int getActiveAtmIdx2() { return activeAtmIdx2_; }
+  void setActiveAtmIdx(int at_idx1 = -1, int at_idx2 = -1) {
+    at_idx1 = (at_idx1 < 0 ? -1 : at_idx1);
+    at_idx2 = (at_idx2 < 0 ? -1 : at_idx2);
+    if (at_idx2 >= 0 && at_idx1 < 0) std::swap(at_idx1, at_idx2);
+    activeAtmIdx1_ = at_idx1;
+	activeAtmIdx2_ = at_idx2;
+  }
+
  protected:
   std::unique_ptr<DrawText> text_drawer_;
 
@@ -669,6 +683,8 @@ class RDKIT_MOLDRAW2D_EXPORT MolDraw2D {
   int x_offset_, y_offset_;  // translation in screen coordinates
   bool fill_polys_;
   int activeMolIdx_;
+  int activeAtmIdx1_;
+  int activeAtmIdx2_;
 
   DrawColour curr_colour_;
   DashPattern curr_dash_;

--- a/Code/GraphMol/MolDraw2D/MolDraw2DSVG.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DSVG.cpp
@@ -401,7 +401,7 @@ void MolDraw2DSVG::tagAtoms(const ROMol &mol, double radius,
            << a2pos.y << "'";
       d_os << " class='bond-selector bond-" << this_idx << " atom-" << a_idx1
            << " atom-" << a_idx2;
-      if (d_activeClass != "") {
+      if (!d_activeClass.empty()) {
         d_os << " " << d_activeClass;
       }
       d_os << "'";

--- a/Code/GraphMol/MolDraw2D/MolDraw2DSVG.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DSVG.cpp
@@ -108,6 +108,7 @@ void MolDraw2DSVG::setColour(const DrawColour &col) {
   MolDraw2D::setColour(col);
 }
 
+// ****************************************************************************
 void MolDraw2DSVG::drawWavyLine(const Point2D &cds1, const Point2D &cds2,
                                 const DrawColour &col1, const DrawColour &col2,
                                 unsigned int nSegments, double vertOffset) {
@@ -130,9 +131,7 @@ void MolDraw2DSVG::drawWavyLine(const Point2D &cds1, const Point2D &cds2,
   std::string col = DrawColourToSVG(colour());
   double width = getDrawLineWidth();
   d_os << "<path ";
-  if (d_activeClass != "") {
-    d_os << "class='" << d_activeClass << "' ";
-  }
+  outputClasses();
   d_os << "d='M" << c1.x << "," << c1.y;
   for (unsigned int i = 0; i < nSegments; ++i) {
     Point2D startpt = cds1 + delta * i;
@@ -212,9 +211,7 @@ void MolDraw2DSVG::drawLine(const Point2D &cds1, const Point2D &cds2) {
     dashString = dss.str();
   }
   d_os << "<path ";
-  if (!d_activeClass.empty()) {
-    d_os << "class='" << d_activeClass << "' ";
-  }
+  outputClasses();
   d_os << "d='M " << c1.x << "," << c1.y << " L " << c2.x << "," << c2.y
        << "' ";
   d_os << "style='fill:none;fill-rule:evenodd;stroke:" << col
@@ -232,9 +229,7 @@ void MolDraw2DSVG::drawPolygon(const std::vector<Point2D> &cds) {
   unsigned int width = getDrawLineWidth();
   std::string dashString = "";
   d_os << "<path ";
-  if (d_activeClass != "") {
-    d_os << "class='" << d_activeClass << "' ";
-  }
+  outputClasses();
   d_os << "d='M";
   Point2D c0 = getDrawCoords(cds[0]);
   d_os << " " << c0.x << "," << c0.y;
@@ -276,9 +271,7 @@ void MolDraw2DSVG::drawEllipse(const Point2D &cds1, const Point2D &cds2) {
        << " rx='" << w / 2 << "'"
        << " ry='" << h / 2 << "'";
 
-  if (d_activeClass != "") {
-    d_os << " class='" << d_activeClass << "'";
-  }
+  outputClasses();
   d_os << " style='";
   if (fillPolys()) {
     d_os << "fill:" << col << ";fill-rule:evenodd;";
@@ -366,23 +359,58 @@ void MolDraw2DSVG::tagAtoms(const ROMol &mol, double radius,
   PRECONDITION(d_os, "no output stream");
   // first bonds so that they are under the atoms
   for (const auto &bond : mol.bonds()) {
-    auto this_idx = bond->getIdx();
-    auto a1pos = getDrawCoords(atomCoords()[bond->getBeginAtomIdx()]);
-    auto a2pos = getDrawCoords(atomCoords()[bond->getEndAtomIdx()]);
-    auto width = 2 + lineWidth();
-    d_os << "<path "
-         << " d='M " << a1pos.x << "," << a1pos.y << " L " << a2pos.x << ","
-         << a2pos.y << "'";
-    d_os << " class='bond-selector bond-" << this_idx;
-    if (d_activeClass != "") {
-      d_os << " " << d_activeClass;
+    const auto this_idx = bond->getIdx();
+    const auto a_idx1 = bond->getBeginAtomIdx();
+    const auto a_idx2 = bond->getEndAtomIdx();
+    const auto a1pos = getDrawCoords(atomCoords()[bond->getBeginAtomIdx()]);
+    const auto a2pos = getDrawCoords(atomCoords()[bond->getEndAtomIdx()]);
+    const auto width = 2 + lineWidth();
+    if (drawOptions().splitBonds) {
+      const auto midp = (a1pos + a2pos) / 2;
+	    // from begin to mid
+      d_os << "<path "
+           << " d='M " << a1pos.x << "," << a1pos.y << " L " << midp.x << ","
+           << midp.y << "'";
+      d_os << " class='bond-selector bond-" << this_idx << " atom-" << a_idx1;
+      if (d_activeClass != "") {
+        d_os << " " << d_activeClass;
+      }
+      d_os << "'";
+      d_os << " style='fill:#fff;stroke:#fff;stroke-width:"
+           << boost::format("%.1f") % width
+           << "px;fill-opacity:0;"
+              "stroke-opacity:0' ";
+      d_os << "/>\n";
+	    // mid to end
+      d_os << "<path "
+           << " d='M " << midp.x << "," << midp.y << " L " << a2pos.x << ","
+           << a2pos.y << "'";
+      d_os << " class='bond-selector bond-" << this_idx << " atom-" << a_idx2;
+      if (d_activeClass != "") {
+        d_os << " " << d_activeClass;
+      }
+      d_os << "'";
+      d_os << " style='fill:#fff;stroke:#fff;stroke-width:"
+           << boost::format("%.1f") % width
+           << "px;fill-opacity:0;"
+              "stroke-opacity:0' ";
+      d_os << "/>\n";
+    } else {
+      d_os << "<path "
+           << " d='M " << a1pos.x << "," << a1pos.y << " L " << a2pos.x << ","
+           << a2pos.y << "'";
+      d_os << " class='bond-selector bond-" << this_idx << " atom-" << a_idx1
+           << " atom-" << a_idx2;
+      if (d_activeClass != "") {
+        d_os << " " << d_activeClass;
+      }
+      d_os << "'";
+      d_os << " style='fill:#fff;stroke:#fff;stroke-width:"
+           << boost::format("%.1f") % width
+           << "px;fill-opacity:0;"
+              "stroke-opacity:0' ";
+      d_os << "/>\n";
     }
-    d_os << "'";
-    d_os << " style='fill:#fff;stroke:#fff;stroke-width:"
-         << boost::format("%.1f") % width
-         << "px;fill-opacity:0;"
-            "stroke-opacity:0' ";
-    d_os << "/>\n";
   }
   for (const auto &at : mol.atoms()) {
     auto this_idx = at->getIdx();
@@ -405,5 +433,28 @@ void MolDraw2DSVG::tagAtoms(const ROMol &mol, double radius,
     }
     d_os << "/>\n";
   }
+}
+
+void MolDraw2DSVG::outputClasses() {
+  if (d_activeClass.empty() && !hasActiveAtmIdx()) return;
+
+  d_os << "class='";
+  if (!d_activeClass.empty()) {
+    d_os << d_activeClass;
+  }
+  if (!hasActiveAtmIdx()) {
+    d_os << "' ";
+    return;
+  }
+  d_os << (!d_activeClass.empty() ? " " : "");
+  const auto aidx1 = getActiveAtmIdx1();
+  if (aidx1 >= 0) {
+    d_os << "atom-" <<aidx1;
+  }
+  const auto aidx2 = getActiveAtmIdx2();
+  if (aidx2 >= 0 && aidx2 != aidx1) {
+    d_os << " atom-" <<aidx2;
+  }
+  d_os << "' ";
 }
 }  // namespace RDKit

--- a/Code/GraphMol/MolDraw2D/MolDraw2DSVG.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DSVG.cpp
@@ -269,8 +269,7 @@ void MolDraw2DSVG::drawEllipse(const Point2D &cds1, const Point2D &cds2) {
        << " cx='" << cx << "'"
        << " cy='" << cy << "'"
        << " rx='" << w / 2 << "'"
-       << " ry='" << h / 2 << "'";
-
+       << " ry='" << h / 2 << "' ";
   outputClasses();
   d_os << " style='";
   if (fillPolys()) {

--- a/Code/GraphMol/MolDraw2D/MolDraw2DSVG.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DSVG.cpp
@@ -372,7 +372,7 @@ void MolDraw2DSVG::tagAtoms(const ROMol &mol, double radius,
            << " d='M " << a1pos.x << "," << a1pos.y << " L " << midp.x << ","
            << midp.y << "'";
       d_os << " class='bond-selector bond-" << this_idx << " atom-" << a_idx1;
-      if (d_activeClass != "") {
+      if (!d_activeClass.empty()) {
         d_os << " " << d_activeClass;
       }
       d_os << "'";

--- a/Code/GraphMol/MolDraw2D/MolDraw2DSVG.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DSVG.cpp
@@ -386,7 +386,7 @@ void MolDraw2DSVG::tagAtoms(const ROMol &mol, double radius,
            << " d='M " << midp.x << "," << midp.y << " L " << a2pos.x << ","
            << a2pos.y << "'";
       d_os << " class='bond-selector bond-" << this_idx << " atom-" << a_idx2;
-      if (d_activeClass != "") {
+      if (!d_activeClass.empty()) {
         d_os << " " << d_activeClass;
       }
       d_os << "'";

--- a/Code/GraphMol/MolDraw2D/MolDraw2DSVG.h
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DSVG.h
@@ -103,6 +103,8 @@ class RDKIT_MOLDRAW2D_EXPORT MolDraw2DSVG : public MolDraw2D {
     annot.rect_ = note_rect;
     drawAnnotation(annot);
   }
+
+  virtual void outputClasses();
 };
 
 }  // namespace RDKit

--- a/Code/GraphMol/MolDraw2D/MolDraw2DUtils.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DUtils.cpp
@@ -133,6 +133,7 @@ void updateDrawerParamsFromJSON(MolDraw2D &drawer, const std::string &json) {
   PT_OPT_GET(atomLabelDeuteriumTritium);
   PT_OPT_GET(dummiesAreAttachments);
   PT_OPT_GET(circleAtoms);
+  PT_OPT_GET(splitBonds);
   PT_OPT_GET(continuousHighlight);
   PT_OPT_GET(fillHighlights);
   PT_OPT_GET(highlightRadius);

--- a/Code/GraphMol/MolDraw2D/Wrap/rdMolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/Wrap/rdMolDraw2D.cpp
@@ -603,6 +603,7 @@ BOOST_PYTHON_MODULE(rdMolDraw2D) {
       .def_readwrite("dummiesAreAttachments",
                      &RDKit::MolDrawOptions::dummiesAreAttachments)
       .def_readwrite("circleAtoms", &RDKit::MolDrawOptions::circleAtoms)
+	    .def_readwrite("splitBonds", &RDKit::MolDrawOptions::splitBonds)
       .def("getBackgroundColour", &RDKit::getBgColour,
            "method returning the background colour")
       .def("getHighlightColour", &RDKit::getHighlightColour,

--- a/Code/GraphMol/MolDraw2D/catch_tests.cpp
+++ b/Code/GraphMol/MolDraw2D/catch_tests.cpp
@@ -247,7 +247,7 @@ TEST_CASE("dative bonds", "[drawing][organometallics]") {
     outs << text;
     outs.flush();
 
-    CHECK(text.find("<path class='bond-0' d='M 126.052,100 L 85.9675,100'"
+    CHECK(text.find("<path class='bond-0 atom-0 atom-1' d='M 126.052,100 L 85.9675,100'"
                     " style='fill:none;fill-rule:evenodd;"
                     "stroke:#0000FF;") != std::string::npos);
   }
@@ -263,7 +263,7 @@ TEST_CASE("dative bonds", "[drawing][organometallics]") {
     outs << text;
     outs.flush();
 
-    CHECK(text.find("<path class='bond-7' d='M 101.307,79.424 "
+    CHECK(text.find("<path class='bond-7 atom-7 atom-8' d='M 101.307,79.424 "
                     "L 95.669,87.1848' style='fill:none;"
                     "fill-rule:evenodd;stroke:#0000FF;") != std::string::npos);
   }
@@ -281,7 +281,7 @@ TEST_CASE("dative bonds", "[drawing][organometallics]") {
     outs << text;
     outs.flush();
 
-    CHECK(text.find("<path class='bond-2' d='M 53.289,140.668"
+    CHECK(text.find("<path class='bond-2 atom-3 atom-4' d='M 53.289,140.668"
                     " L 81.0244,149.68' style='fill:none;"
                     "fill-rule:evenodd;stroke:#0000FF;") != std::string::npos);
   }
@@ -842,7 +842,7 @@ TEST_CASE("including legend in drawing results in offset drawing later",
     outs.flush();
 
     // make sure the polygon starts at a bond
-    CHECK(text.find("<path class='bond-0' d='M 321.962,140") !=
+    CHECK(text.find("<path class='bond-0 atom-0 atom-1' d='M 321.962,140") !=
           std::string::npos);
     CHECK(text.find("<path d='M 321.962,140") != std::string::npos);
   }
@@ -1856,8 +1856,8 @@ TEST_CASE("disable atom labels", "[feature]") {
     std::ofstream outs("testNoAtomLabels-1.svg");
     outs << text;
     outs.flush();
-    CHECK(text.find("atom-0") == std::string::npos);
-    CHECK(text.find("atom-3") == std::string::npos);
+    CHECK(text.find("class='atom-0") == std::string::npos);
+    CHECK(text.find("class='atom-3") == std::string::npos);
   }
 }
 

--- a/Code/GraphMol/MolDraw2D/test1.cpp
+++ b/Code/GraphMol/MolDraw2D/test1.cpp
@@ -691,7 +691,7 @@ void test6() {
     outs << txt;
     outs.close();
     // start of bond-0
-    TEST_ASSERT(txt.find("<path class='bond-0' d='M 273.606,147.528") !=
+    TEST_ASSERT(txt.find("<path class='bond-0 atom-0 atom-1' d='M 273.606,147.528") !=
                 std::string::npos);
     // start of first radical spot
     TEST_ASSERT(txt.find("<path d='M 286.51,143.528 L 286.502,143.356") !=
@@ -1397,11 +1397,11 @@ M  END";
     outs << text;
     outs.flush();
 #ifdef RDK_BUILD_FREETYPE_SUPPORT
-    TEST_ASSERT(text.find("<path class='bond-1' d='M 126.878,115.979"
+    TEST_ASSERT(text.find("<path class='bond-1 atom-2 atom-4' d='M 126.878,115.979"
                           " L 184.005,90.8113 L 177.234,79.085 Z'"
                           " style='fill:#000000;") != std::string::npos);
 #else
-    TEST_ASSERT(text.find("<path class='bond-1' d='M 126.46,111.639"
+    TEST_ASSERT(text.find("<path class='bond-1 atom-2 atom-4' d='M 126.46,111.639"
                           " L 182.698,86.8632 L 176.033,75.3193 Z'"
                           " style='fill:#000000;fill-rule:evenodd;"
                           "fill-opacity:1;stroke:#000000;") !=
@@ -1456,11 +1456,11 @@ M  END";
     outs << text;
     outs.flush();
 #ifdef RDK_BUILD_FREETYPE_SUPPORT
-    TEST_ASSERT(text.find("<path class='bond-3' d='M 103.748,117.559"
+    TEST_ASSERT(text.find("<path class='bond-3 atom-2 atom-4' d='M 103.748,117.559"
                           " L 76.8908,93.4583 L 72.3264,99.8155 Z'"
                           " style='fill:#000000;") != std::string::npos);
 #else
-    TEST_ASSERT(text.find("<path class='bond-3' d='M 105.087,114.797"
+    TEST_ASSERT(text.find("<path class='bond-3 atom-2 atom-4' d='M 105.087,114.797"
                           " L 78.5054,90.9436 L 73.9878,97.2355 Z'"
                           " style='fill:#000000;fill-rule:evenodd;"
                           "fill-opacity:1;stroke:#000000;") !=
@@ -1512,7 +1512,9 @@ void testDeuteriumTritium() {
       // be made of 2 glyphs, the superscript 2 and the H.
 #ifdef RDK_BUILD_FREETYPE_SUPPORT
       if ((line.find("atom-") != std::string::npos)) {
-        ++count;
+        if ((line.find("bond-") == std::string::npos)) {
+          ++count;
+        }
       }
 #else
       // a bit kludgy, but...
@@ -1556,7 +1558,9 @@ void testDeuteriumTritium() {
       // there are no characters to look for, but each atom should
       // be made of 2 glyphs, the superscript 3 and the H.
       if ((line.find("atom-") != std::string::npos)) {
-        ++count;
+        if ((line.find("bond-") == std::string::npos)) {
+          ++count;
+        }
       }
 #else
       if (line.find("<text x='250.507' y='152.691' class='atom-1'"
@@ -1597,7 +1601,9 @@ void testDeuteriumTritium() {
 #ifdef RDK_BUILD_FREETYPE_SUPPORT
       // there should be just 1 glyph per atom - a D
       if ((line.find("atom-") != std::string::npos)) {
-        ++count;
+        if ((line.find("bond-") == std::string::npos)) {
+          ++count;
+        }
       }
 #else
       if ((line.find("baseline-shift:super") == std::string::npos) &&
@@ -1632,7 +1638,9 @@ void testDeuteriumTritium() {
 #ifdef RDK_BUILD_FREETYPE_SUPPORT
       // there should be just 1 glyph per atom - a T
       if ((line.find("atom-") != std::string::npos)) {
-        ++count;
+        if ((line.find("bond-") == std::string::npos)) {
+          ++count;
+        }
       }
 #else
       if ((line.find("baseline-shift:super") == std::string::npos) &&
@@ -1969,12 +1977,12 @@ void test13JSONConfig() {
 #ifdef RDK_BUILD_FREETYPE_SUPPORT
     // we'll just have to assume that this pink is for the legend
     TEST_ASSERT(text.find("' fill='#FF7FFF") != std::string::npos);
-    TEST_ASSERT(text.find("<path class='bond-0' d='M 119.411,8.18182"
+    TEST_ASSERT(text.find("<path class='bond-0 atom-0 atom-1' d='M 119.411,8.18182"
                           " L 162.939,83.5752'") != std::string::npos);
 #else
     TEST_ASSERT(text.find("sans-serif;text-anchor:start;fill:#FF7FFF") !=
                 std::string::npos);
-    TEST_ASSERT(text.find("<path class='bond-0' d='M 119.755,8.18182"
+    TEST_ASSERT(text.find("<path class='bond-0 atom-0 atom-1' d='M 119.755,8.18182"
                           " L 162.102,81.5304'") != std::string::npos);
 #endif
     // these days the bond line width scales with the rest of the
@@ -2205,7 +2213,7 @@ void testGithub1322() {
       outs.flush();
 #ifdef RDK_BUILD_FREETYPE_SUPPORT
       // there should be 2 paths of class atom-3, one for the S,
-      // the other for the e.
+      // the other for the e + plus one bond = 3.
       size_t start_pos = 0;
       int count = 0;
       while (true) {
@@ -2216,7 +2224,7 @@ void testGithub1322() {
         ++count;
         ++start_pos;
       }
-      TEST_ASSERT(count == 2);
+      TEST_ASSERT(count == 3);
 #else
       TEST_ASSERT(text.find(">S</text>") != std::string::npos);
       TEST_ASSERT(text.find(">e</text>") != std::string::npos);
@@ -2234,7 +2242,7 @@ void testGithub1322() {
       outs.flush();
 #ifdef RDK_BUILD_FREETYPE_SUPPORT
       // there should be 11 paths of class atom-3, one for each letter
-      // of customlabel
+      // of customlabel + plus one bond = 12.
       size_t start_pos = 0;
       int count = 0;
       while (true) {
@@ -2245,7 +2253,7 @@ void testGithub1322() {
         ++count;
         ++start_pos;
       }
-      TEST_ASSERT(count == 11);
+      TEST_ASSERT(count == 12);
 #else
       TEST_ASSERT(text.find(">S</text>") == std::string::npos);
       TEST_ASSERT(text.find(">s</text>") != std::string::npos);
@@ -2693,11 +2701,11 @@ M  END)molb";
     outs.flush();
     TEST_ASSERT(
         text.find(
-            "<path class='bond-0' d='M 65.8823,100.884 L 134.118,79.1159'") !=
+            "<path class='bond-0 atom-0 atom-1' d='M 65.8823,100.884 L 134.118,79.1159'") !=
         std::string::npos);
     TEST_ASSERT(
         text.find(
-            "<path class='bond-1' d='M 69.6998,107.496 L 9.09091,72.5044'") !=
+            "<path class='bond-1 atom-0 atom-2' d='M 69.6998,107.496 L 9.09091,72.5044'") !=
         std::string::npos);
   }
   {
@@ -2727,11 +2735,11 @@ M  END)molb";
     outs.flush();
     TEST_ASSERT(
         text.find(
-            "<path class='bond-0' d='M 65.8823,100.884 L 134.118,79.1159'") !=
+            "<path class='bond-0 atom-0 atom-1' d='M 65.8823,100.884 L 134.118,79.1159'") !=
         std::string::npos);
     TEST_ASSERT(
         text.find(
-            "<path class='bond-1' d='M 69.6998,107.496 L 9.09091,72.5044'") !=
+            "<path class='bond-1 atom-0 atom-2' d='M 69.6998,107.496 L 9.09091,72.5044'") !=
         std::string::npos);
   }
   std::cerr << " Done" << std::endl;

--- a/Code/GraphMol/MolDraw2D/test1.cpp
+++ b/Code/GraphMol/MolDraw2D/test1.cpp
@@ -2896,12 +2896,12 @@ void testGithub2931() {
                   std::string::npos);
 #ifdef RDK_BUILD_FREETYPE_SUPPORT
       TEST_ASSERT(text.find("<ellipse cx='242.185' cy='367.491'"
-                            " rx='10.4207' ry='10.7138'"
+                            " rx='10.4207' ry='10.7138' "
                             " style='fill:none;stroke:#00FF00;") !=
                   std::string::npos);
 #else
       TEST_ASSERT(text.find("<ellipse cx='242.228' cy='313.005'"
-                            " rx='10.3633' ry='10.3633'"
+                            " rx='10.3633' ry='10.3633' "
                             " style='fill:none;stroke:#00FF00;") !=
                   std::string::npos);
 #endif
@@ -2922,12 +2922,12 @@ void testGithub2931() {
                   std::string::npos);
 #ifdef RDK_BUILD_FREETYPE_SUPPORT
       TEST_ASSERT(text.find("<ellipse cx='242.154' cy='367.046'"
-                            " rx='10.4609' ry='10.4609'"
+                            " rx='10.4609' ry='10.4609' "
                             " style='fill:none;stroke:#00FF00;") !=
                   std::string::npos);
 #else
       TEST_ASSERT(text.find("<ellipse cx='242.209' cy='312.678'"
-                            " rx='10.3875' ry='10.3875'"
+                            " rx='10.3875' ry='10.3875' "
                             " style='fill:none;stroke:#00FF00;") !=
                   std::string::npos);
 #endif


### PR DESCRIPTION
The output of MolDraw2D (especially svg) can be manipulated on-the-fly to produce hilights and many other effects without the need to do full re-draw. This is especially useful for web services which can interactively update the svg within browser and save the round trip to server enabling much more responsive user experience. 

However, in order to allow atoms to be recolored bonds need to be split into per-atom fragments and tagged with atom information. This PR implements code both to split bonds and add parent atom information to svg drawing.

Bond splitting is enabled via new drawing option "splitBonds" which forces the bond rendering to be split into per atom fragments. Bond fragments are tagged with then parent atom idx. If bonds are not split the bond elements are tagged with both begin and end atom idx.
