### PR TITLE
Fixes #3774

### DIFF
--- a/Code/GraphMol/SmilesParse/CMakeLists.txt
+++ b/Code/GraphMol/SmilesParse/CMakeLists.txt
@@ -70,4 +70,4 @@ rdkit_test(smiTest2 test2.cpp LINK_LIBRARIES SmilesParse )
 rdkit_test(cxsmilesTest cxsmiles_test.cpp LINK_LIBRARIES FileParsers SmilesParse )
 
 rdkit_test(smaTest1 smatest.cpp LINK_LIBRARIES SmilesParse SubstructMatch  )
-rdkit_catch_test(smiTestCatch catch_tests.cpp LINK_LIBRARIES FileParsers SmilesParse )
+rdkit_catch_test(smiTestCatch ../catch_main.cpp catch_tests.cpp LINK_LIBRARIES FileParsers SmilesParse )

--- a/Code/GraphMol/SmilesParse/SmartsWrite.cpp
+++ b/Code/GraphMol/SmilesParse/SmartsWrite.cpp
@@ -393,7 +393,7 @@ std::string getBondSmartsSimple(const Bond *bond,
   } else if (descrip == "BondOrder") {
     bool reverseDative =
         (atomToLeftIdx >= 0 &&
-         bond->getBeginAtomIdx() == static_cast<unsigned int>(atomToLeftIdx));
+         bond->getBeginAtomIdx() != static_cast<unsigned int>(atomToLeftIdx));
     bool doIsoSmiles =
         !bond->hasOwningMol() ||
         bond->getOwningMol().hasProp(common_properties::_doIsoSmiles);
@@ -755,7 +755,7 @@ std::string getNonQueryBondSmarts(const QueryBond *qbond, int atomToLeftIdx) {
   } else {
     bool reverseDative =
         (atomToLeftIdx >= 0 &&
-         qbond->getBeginAtomIdx() == static_cast<unsigned int>(atomToLeftIdx));
+         qbond->getBeginAtomIdx() != static_cast<unsigned int>(atomToLeftIdx));
     bool doIsoSmiles =
         !qbond->hasOwningMol() ||
         qbond->getOwningMol().hasProp(common_properties::_doIsoSmiles);

--- a/Code/GraphMol/SmilesParse/catch_tests.cpp
+++ b/Code/GraphMol/SmilesParse/catch_tests.cpp
@@ -1,6 +1,6 @@
 //
 //
-//  Copyright (C) 2018-2019 Greg Landrum and T5 Informatics GmbH
+//  Copyright (C) 2018-2021 Greg Landrum and T5 Informatics GmbH
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -9,8 +9,6 @@
 //  of the RDKit source tree.
 //
 
-#define CATCH_CONFIG_MAIN  // This tells Catch to provide a main() - only do
-                           // this in one cpp file
 #include "catch.hpp"
 
 #include <GraphMol/RDKitBase.h>
@@ -774,6 +772,34 @@ TEST_CASE("github #3320: incorrect bond properties from CXSMILES",
       REQUIRE(bnd);
       CHECK(bnd->getBondType() == Bond::BondType::DATIVE);
       CHECK(bnd->getBeginAtomIdx() == pr.first);
+    }
+  }
+}
+
+TEST_CASE("github #3774: MolToSmarts inverts direction of dative bond",
+          "[smarts][bug]") {
+  SECTION("as reported") {
+    {
+      auto m = "N->[Cu+]"_smiles;
+      REQUIRE(m);
+      CHECK(MolToSmarts(*m) == "[#7]->[Cu+]");
+    }
+    {
+      auto m = "N<-[Cu+]"_smiles;
+      REQUIRE(m);
+      CHECK(MolToSmarts(*m) == "[#7]<-[Cu+]");
+    }
+  }
+  SECTION("from smarts") {
+    {
+      auto m = "N->[Cu+]"_smarts;
+      REQUIRE(m);
+      CHECK(MolToSmarts(*m) == "N->[#29&+]");
+    }
+    {
+      auto m = "N<-[Cu+]"_smarts;
+      REQUIRE(m);
+      CHECK(MolToSmarts(*m) == "N<-[#29&+]");
     }
   }
 }

--- a/Code/GraphMol/SmilesParse/catch_tests.cpp
+++ b/Code/GraphMol/SmilesParse/catch_tests.cpp
@@ -783,11 +783,13 @@ TEST_CASE("github #3774: MolToSmarts inverts direction of dative bond",
       auto m = "N->[Cu+]"_smiles;
       REQUIRE(m);
       CHECK(MolToSmarts(*m) == "[#7]->[Cu+]");
+      CHECK(MolToSmiles(*m) == "N->[Cu+]");
     }
     {
       auto m = "N<-[Cu+]"_smiles;
       REQUIRE(m);
       CHECK(MolToSmarts(*m) == "[#7]<-[Cu+]");
+      CHECK(MolToSmiles(*m) == "N<-[Cu+]");
     }
   }
   SECTION("from smarts") {


### PR DESCRIPTION
also speeds up compiles of the SMILES catch tests by using the catch_main.cpp in GraphMol

This is a simple fix since we had the logic for writing dative bonds to SMARTS exactly backwards.
