### PR TITLE
Fixes #3844: MolEnumerator and link nodes

### DIFF
--- a/Code/GraphMol/MolEnumerator/LinkNode.cpp
+++ b/Code/GraphMol/MolEnumerator/LinkNode.cpp
@@ -33,6 +33,19 @@ void LinkNodeOp::initFromMol() {
   if (!dp_mol) {
     return;
   }
+
+  if (!dp_mol->hasProp(detail::idxPropName)) {
+    detail::preserveOrigIndices(*dp_mol);
+  }
+
+  d_atomMap.clear();
+  for (auto atom : dp_mol->atoms()) {
+    unsigned int oidx;
+    if (atom->getPropIfPresent(detail::idxPropName, oidx)) {
+      d_atomMap[oidx] = atom;
+    }
+  }
+
   std::vector<int> mapping;
   if (MolOps::getMolFrags(*dp_mol, mapping) > 1) {
     throw ValueErrorException(
@@ -40,7 +53,7 @@ void LinkNodeOp::initFromMol() {
         "fragment.");
   }
   dp_frame.reset(new RWMol(*dp_mol));
-  auto nodes = utils::getMolLinkNodes(*dp_frame);
+  auto nodes = utils::getMolLinkNodes(*dp_frame, true, &d_atomMap);
   std::string attachSmarts = "";
   std::vector<std::string> linkEnums;
   std::vector<std::string> molEnums;
@@ -50,7 +63,7 @@ void LinkNodeOp::initFromMol() {
   for (auto node : nodes) {
     if (node.nBonds != 2) {
       UNDER_CONSTRUCTION(
-        "only link nodes with 2 bonds are currently supported");
+          "only link nodes with 2 bonds are currently supported");
     }
     std::string productSmarts = "";
     d_countAtEachPoint.push_back(node.maxRep - node.minRep + 1);
@@ -59,21 +72,28 @@ void LinkNodeOp::initFromMol() {
     auto attach1 = dp_frame->getAtomWithIdx(node.bondAtoms[0].second);
     auto attach2 = dp_frame->getAtomWithIdx(node.bondAtoms[1].second);
     // save the isotope values:
-    if (d_isotopeMap.find(1000 * (node.bondAtoms[0].first+1)) == d_isotopeMap.end()) {
-      d_isotopeMap[1000 * (node.bondAtoms[0].first+1)] = varAtom->getIsotope();
+    if (d_isotopeMap.find(1000 * (node.bondAtoms[0].first + 1)) ==
+        d_isotopeMap.end()) {
+      d_isotopeMap[1000 * (node.bondAtoms[0].first + 1)] =
+          varAtom->getIsotope();
     }
-    if (d_isotopeMap.find(1000 * (node.bondAtoms[0].second+1)) == d_isotopeMap.end()) {
-      d_isotopeMap[1000 * (node.bondAtoms[0].second+1)] = attach1->getIsotope();
+    if (d_isotopeMap.find(1000 * (node.bondAtoms[0].second + 1)) ==
+        d_isotopeMap.end()) {
+      d_isotopeMap[1000 * (node.bondAtoms[0].second + 1)] =
+          attach1->getIsotope();
     }
-    if (d_isotopeMap.find(1000 * (node.bondAtoms[1].second+1)) == d_isotopeMap.end()) {
-      d_isotopeMap[1000 * (node.bondAtoms[1].second+1)] = attach2->getIsotope();
+    if (d_isotopeMap.find(1000 * (node.bondAtoms[1].second + 1)) ==
+        d_isotopeMap.end()) {
+      d_isotopeMap[1000 * (node.bondAtoms[1].second + 1)] =
+          attach2->getIsotope();
     }
-    varAtom->setIsotope(1000 * (node.bondAtoms[0].first+1));
-    attach1->setIsotope(1000 * (node.bondAtoms[0].second+1));
-    attach2->setIsotope(1000 * (node.bondAtoms[1].second+1));
+    varAtom->setIsotope(1000 * (node.bondAtoms[0].first + 1));
+    attach1->setIsotope(1000 * (node.bondAtoms[0].second + 1));
+    attach2->setIsotope(1000 * (node.bondAtoms[1].second + 1));
     d_variations.push_back(
-        std::make_tuple(1000 * (node.bondAtoms[0].first+1), 
-        1000 * (node.bondAtoms[0].second+1), 1000 * (node.bondAtoms[1].second+1)));
+        std::make_tuple(1000 * (node.bondAtoms[0].first + 1),
+                        1000 * (node.bondAtoms[0].second + 1),
+                        1000 * (node.bondAtoms[1].second + 1)));
   }
 }
 

--- a/Code/GraphMol/MolEnumerator/MolEnumerator.cpp
+++ b/Code/GraphMol/MolEnumerator/MolEnumerator.cpp
@@ -12,7 +12,6 @@
 
 namespace RDKit {
 namespace MolEnumerator {
-
 namespace {
 
 //! recursively builds the variations
@@ -44,7 +43,24 @@ void enumerateVariations(std::vector<std::vector<size_t>> &variations,
   getVariations(0, base, variations, variationCounts, params.maxToEnumerate,
                 params.doRandom);
 }
+
 }  // namespace
+
+namespace detail {
+const std::string idxPropName = "_enumeratorOrigIdx";
+void preserveOrigIndices(ROMol &mol) {
+  mol.setProp(idxPropName, 1);
+  for (auto atom : mol.atoms()) {
+    atom->setProp(idxPropName, atom->getIdx());
+  }
+}
+void removeOrigIndices(ROMol &mol) {
+  for (auto atom : mol.atoms()) {
+    atom->clearProp(idxPropName);
+  }
+  mol.clearProp(idxPropName);
+}
+}  // namespace detail
 
 MolBundle enumerate(const ROMol &mol,
                     const std::vector<MolEnumeratorParams> &paramLists) {
@@ -53,6 +69,7 @@ MolBundle enumerate(const ROMol &mol,
   }
   std::unique_ptr<MolBundle> accum{new MolBundle()};
   boost::shared_ptr<ROMol> molCpy{new ROMol(mol)};
+  detail::preserveOrigIndices(*molCpy);
   accum->addMol(molCpy);
   bool variationsFound = false;
   for (const auto &params : paramLists) {
@@ -61,8 +78,6 @@ MolBundle enumerate(const ROMol &mol,
     }
     std::unique_ptr<MolBundle> thisRound{new MolBundle()};
     for (const auto &tmol : accum->getMols()) {
-      std::cerr << "---------------------------------------" << std::endl;
-      tmol->debugMol(std::cerr);
       // copy the op since we will modify it:
       auto op = params.dp_operation->copy();
       op->initFromMol(*tmol);
@@ -85,16 +100,24 @@ MolBundle enumerate(const ROMol &mol,
   if (!variationsFound) {
     return MolBundle();
   }
+  for (auto rmol : accum->getMols()) {
+    detail::removeOrigIndices(*rmol);
+  }
   return *accum;
 }
 
 MolBundle enumerate(const ROMol &mol) {
   std::vector<MolEnumeratorParams> paramsList;
+
+  // position variation first
   MolEnumerator::MolEnumeratorParams posVariationParams;
   posVariationParams.dp_operation =
       std::shared_ptr<MolEnumerator::MolEnumeratorOp>(
           new MolEnumerator::PositionVariationOp());
   paramsList.push_back(posVariationParams);
+
+  // linknodes last because we can only enumerate mols with a single
+  // fragment
   MolEnumerator::MolEnumeratorParams linkParams;
   linkParams.dp_operation = std::shared_ptr<MolEnumerator::MolEnumeratorOp>(
       new MolEnumerator::LinkNodeOp());

--- a/Code/GraphMol/MolEnumerator/MolEnumerator.cpp
+++ b/Code/GraphMol/MolEnumerator/MolEnumerator.cpp
@@ -61,6 +61,8 @@ MolBundle enumerate(const ROMol &mol,
     }
     std::unique_ptr<MolBundle> thisRound{new MolBundle()};
     for (const auto &tmol : accum->getMols()) {
+      std::cerr << "---------------------------------------" << std::endl;
+      tmol->debugMol(std::cerr);
       // copy the op since we will modify it:
       auto op = params.dp_operation->copy();
       op->initFromMol(*tmol);

--- a/Code/GraphMol/MolEnumerator/MolEnumerator.h
+++ b/Code/GraphMol/MolEnumerator/MolEnumerator.h
@@ -23,6 +23,12 @@ namespace RDKit {
 class ChemicalReaction;
 namespace MolEnumerator {
 
+namespace detail {
+extern const std::string idxPropName;
+void preserveOrigIndices(ROMol &mol);
+void removeOrigIndices(ROMol &mol);
+}  // namespace detail
+
 //! abstract base class for the a molecule enumeration operation
 class RDKIT_MOLENUMERATOR_EXPORT MolEnumeratorOp {
  public:
@@ -107,7 +113,8 @@ class RDKIT_MOLENUMERATOR_EXPORT LinkNodeOp : public MolEnumeratorOp {
         d_countAtEachPoint(other.d_countAtEachPoint),
         d_variations(other.d_variations),
         d_pointRanges(other.d_pointRanges),
-        d_isotopeMap(other.d_isotopeMap){};
+        d_isotopeMap(other.d_isotopeMap),
+        d_atomMap(other.d_atomMap){};
   LinkNodeOp &operator=(const LinkNodeOp &other) {
     if (&other == this) {
       return *this;
@@ -118,6 +125,7 @@ class RDKIT_MOLENUMERATOR_EXPORT LinkNodeOp : public MolEnumeratorOp {
     d_variations = other.d_variations;
     d_pointRanges = other.d_pointRanges;
     d_isotopeMap = other.d_isotopeMap;
+    d_atomMap = other.d_atomMap;
     return *this;
   };
   //! \override
@@ -142,6 +150,7 @@ class RDKIT_MOLENUMERATOR_EXPORT LinkNodeOp : public MolEnumeratorOp {
   std::vector<std::tuple<unsigned, unsigned, unsigned>> d_variations;
   std::vector<std::pair<unsigned, unsigned>> d_pointRanges;
   std::map<unsigned, unsigned> d_isotopeMap;
+  std::map<unsigned, Atom *> d_atomMap;
 
   void initFromMol();
 };

--- a/Code/GraphMol/MolEnumerator/PositionVariation.cpp
+++ b/Code/GraphMol/MolEnumerator/PositionVariation.cpp
@@ -23,6 +23,9 @@ void PositionVariationOp::initFromMol() {
   if (!dp_mol) {
     return;
   }
+  if (!dp_mol->hasProp(detail::idxPropName)) {
+    detail::preserveOrigIndices(*dp_mol);
+  }
   for (const auto bond : dp_mol->bonds()) {
     std::string endpts;
     std::string attach;

--- a/Code/GraphMol/MolEnumerator/enumerator_catch.cpp
+++ b/Code/GraphMol/MolEnumerator/enumerator_catch.cpp
@@ -573,19 +573,19 @@ M  V30 END CTAB
 M  END
 )CTAB"_ctab;
   std::vector<std::string> tsmis = {
-      "Cc1cnc2c(c1)CC(O)C2",         "Cc1cnc2c(c1)CC(O)C(O)C2",
-      "Cc1cnc2c(c1)CC(O)C(O)C(O)C2", "Cc1ccc2c(n1)CC(O)C2",
-      "Cc1ccc2c(n1)CC(O)C(O)C2",     "Cc1ccc2c(n1)CC(O)C(O)C(O)C2",
-      "Cc1ccnc2c1CC(O)C2",           "Cc1ccnc2c1CC(O)C(O)C2",
-      "Cc1ccnc2c1CC(O)C(O)C(O)C2"};
+      "Cc1cn(CO)c2cc(O)ccc12", "Cc1cn(CCO)c2cc(O)ccc12",
+      "Cc1cc2ccc(O)cc2n1CO",   "Cc1cc2ccc(O)cc2n1CCO",
+      "Cc1cn(CO)c2ccc(O)cc12", "Cc1cn(CCO)c2ccc(O)cc12",
+      "Cc1cc2cc(O)ccc2n1CO",   "Cc1cc2cc(O)ccc2n1CCO",
+      "Cc1cn(CO)c2c(O)cccc12", "Cc1cn(CCO)c2c(O)cccc12",
+      "Cc1cc2cccc(O)c2n1CO",   "Cc1cc2cccc(O)c2n1CCO"};
   SECTION("test2") {
-    mol1->debugMol(std::cerr);
     auto bundle = MolEnumerator::enumerate(*mol1);
-    // CHECK(bundle.size() == tsmis.size());
+    CHECK(bundle.size() == tsmis.size());
     for (const auto &molp : bundle.getMols()) {
       auto smi = MolToSmiles(*molp);
-      std::cerr << smi << std::endl;
-      // CHECK(std::find(tsmis.begin(), tsmis.end(), smi) != tsmis.end());
+      // std::cerr << "\"" << smi << "\"," << std::endl;
+      CHECK(std::find(tsmis.begin(), tsmis.end(), smi) != tsmis.end());
     }
   }
 }

--- a/Code/GraphMol/MolEnumerator/enumerator_catch.cpp
+++ b/Code/GraphMol/MolEnumerator/enumerator_catch.cpp
@@ -527,3 +527,65 @@ M  END
     CHECK(bundle.size() == 0);
   }
 }
+
+TEST_CASE("multiple enumeration points 2", "[MolEnumerator][bug]") {
+  auto mol1 = R"CTAB(
+  Mrv2014 02182116082D          
+
+  0  0  0     0  0            999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 15 14 0 0 0
+M  V30 BEGIN ATOM
+M  V30 1 C -2.1474 10.0453 0 0
+M  V30 2 C -3.481 9.2753 0 0
+M  V30 3 C -3.481 7.7352 0 0
+M  V30 4 C -2.1474 6.9652 0 0
+M  V30 5 C -0.8137 7.7352 0 0
+M  V30 6 C -0.8137 9.2753 0 0
+M  V30 7 N 0.6334 9.802 0 0
+M  V30 8 C 0.7204 7.3118 0 0
+M  V30 9 C 1.5815 8.5885 0 0
+M  V30 10 * -3.0365 9.0186 0 0
+M  V30 11 O -3.0365 11.3286 0 0
+M  V30 12 C 1.0579 11.2824 0 0
+M  V30 13 O -0.0119 12.3901 0 0
+M  V30 14 * 1.151 7.9501 0 0
+M  V30 15 C 1.151 10.2601 0 0
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 1 1 2
+M  V30 2 2 2 3
+M  V30 3 1 3 4
+M  V30 4 2 4 5
+M  V30 5 1 5 6
+M  V30 6 2 1 6
+M  V30 7 1 7 9
+M  V30 8 1 7 6
+M  V30 9 1 5 8
+M  V30 10 2 8 9
+M  V30 11 1 10 11 ENDPTS=(3 2 3 1) ATTACH=ANY
+M  V30 12 1 7 12
+M  V30 13 1 12 13
+M  V30 14 1 14 15 ENDPTS=(2 8 9) ATTACH=ANY
+M  V30 END BOND
+M  V30 LINKNODE 1 2 2 12 7 12 13
+M  V30 END CTAB
+M  END
+)CTAB"_ctab;
+  std::vector<std::string> tsmis = {
+      "Cc1cnc2c(c1)CC(O)C2",         "Cc1cnc2c(c1)CC(O)C(O)C2",
+      "Cc1cnc2c(c1)CC(O)C(O)C(O)C2", "Cc1ccc2c(n1)CC(O)C2",
+      "Cc1ccc2c(n1)CC(O)C(O)C2",     "Cc1ccc2c(n1)CC(O)C(O)C(O)C2",
+      "Cc1ccnc2c1CC(O)C2",           "Cc1ccnc2c1CC(O)C(O)C2",
+      "Cc1ccnc2c1CC(O)C(O)C(O)C2"};
+  SECTION("test2") {
+    mol1->debugMol(std::cerr);
+    auto bundle = MolEnumerator::enumerate(*mol1);
+    // CHECK(bundle.size() == tsmis.size());
+    for (const auto &molp : bundle.getMols()) {
+      auto smi = MolToSmiles(*molp);
+      std::cerr << smi << std::endl;
+      // CHECK(std::find(tsmis.begin(), tsmis.end(), smi) != tsmis.end());
+    }
+  }
+}


### PR DESCRIPTION
Since earlier enumeration steps may change atom indices we need to keep a map between original atom IDs and the atoms themselves.
This is theoretically necessary for bonds as well, but we don't currently have any enumeration steps which work with bond indices.