### PR TITLE
Fixes #3852

### DIFF
--- a/Code/GraphMol/MolDraw2D/DrawTextJS.cpp
+++ b/Code/GraphMol/MolDraw2D/DrawTextJS.cpp
@@ -34,7 +34,7 @@ void DrawTextJS::drawChar(char c, const Point2D &cds) {
   std::string col = DrawColourToSVG(colour());
   context_.set("font", font);
   context_.set("fillStyle", col);
-  context_.call<void>("fillText", txt, std::round(cds.x), std::round(cds.y));
+  context_.call<void>("fillText", txt, cds.x, cds.y);
 }
 
 // ****************************************************************************

--- a/Code/GraphMol/MolDraw2D/MolDraw2DCairo.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DCairo.cpp
@@ -136,7 +136,7 @@ void MolDraw2DCairo::drawPolygon(const std::vector<Point2D> &cds) {
   PRECONDITION(dp_cr, "no draw context");
   PRECONDITION(cds.size() >= 3, "must have at least three points");
 
-  unsigned int width = getDrawLineWidth();
+  double width = getDrawLineWidth();
 
   cairo_line_cap_t olinecap = cairo_get_line_cap(dp_cr);
   cairo_line_join_t olinejoin = cairo_get_line_join(dp_cr);

--- a/Code/GraphMol/MolDraw2D/MolDraw2DJS.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DJS.cpp
@@ -60,7 +60,7 @@ void MolDraw2DJS::drawLine(const Point2D &cds1, const Point2D &cds2) {
   Point2D c1 = getDrawCoords(cds1);
   Point2D c2 = getDrawCoords(cds2);
   std::string col = DrawColourToSVG(colour());
-  unsigned int width = getDrawLineWidth();
+  double width = getDrawLineWidth();
   std::string dashString = "";
   const DashPattern &dashes = dash();
 
@@ -71,8 +71,8 @@ void MolDraw2DJS::drawLine(const Point2D &cds1, const Point2D &cds2) {
     d_context.call<void>("setLineDash", emscripten::typed_memory_view(
                                             dashes.size(), dashes.data()));
   }
-  d_context.call<void>("moveTo", std::round(c1.x), std::round(c1.y));
-  d_context.call<void>("lineTo", std::round(c2.x), std::round(c2.y));
+  d_context.call<void>("moveTo", c1.x, c1.y);
+  d_context.call<void>("lineTo", c2.x, c2.y);
   d_context.call<void>("stroke");
   if (dashes.size()) {
     static const DashPattern nodash;
@@ -85,7 +85,7 @@ void MolDraw2DJS::drawPolygon(const std::vector<Point2D> &cds) {
   PRECONDITION(cds.size() >= 3, "must have at least three points");
 
   std::string col = DrawColourToSVG(colour());
-  unsigned int width = getDrawLineWidth();
+  double width = getDrawLineWidth();
 
   d_context.call<void>("beginPath");
   d_context.set("lineWidth", width);
@@ -93,10 +93,10 @@ void MolDraw2DJS::drawPolygon(const std::vector<Point2D> &cds) {
   d_context.set("lineJoin", std::string("round"));
   d_context.set("strokeStyle", col);
   Point2D c0 = getDrawCoords(cds[0]);
-  d_context.call<void>("moveTo", std::round(c0.x), std::round(c0.y));
+  d_context.call<void>("moveTo", c0.x, c0.y);
   for (unsigned int i = 1; i < cds.size(); ++i) {
     Point2D ci = getDrawCoords(cds[i]);
-    d_context.call<void>("lineTo", std::round(ci.x), std::round(ci.y));
+    d_context.call<void>("lineTo", ci.x, ci.y);
   }
   if (fillPolys()) {
     d_context.call<void>("closePath");
@@ -118,7 +118,7 @@ void MolDraw2DJS::drawEllipse(const Point2D &cds1, const Point2D &cds2) {
   h = h > 0 ? h : -1 * h;
 
   std::string col = DrawColourToSVG(colour());
-  unsigned int width = getDrawLineWidth();
+  double width = getDrawLineWidth();
   d_context.call<void>("beginPath");
   d_context.set("lineWidth", width);
   d_context.set("strokeStyle", col);

--- a/Code/GraphMol/MolDraw2D/MolDraw2DSVG.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DSVG.cpp
@@ -226,7 +226,7 @@ void MolDraw2DSVG::drawPolygon(const std::vector<Point2D> &cds) {
   PRECONDITION(cds.size() >= 3, "must have at least three points");
 
   std::string col = DrawColourToSVG(colour());
-  unsigned int width = getDrawLineWidth();
+  double width = getDrawLineWidth();
   std::string dashString = "";
   d_os << "<path ";
   outputClasses();
@@ -263,7 +263,7 @@ void MolDraw2DSVG::drawEllipse(const Point2D &cds1, const Point2D &cds2) {
   h = h > 0 ? h : -1 * h;
 
   std::string col = DrawColourToSVG(colour());
-  unsigned int width = getDrawLineWidth();
+  double width = getDrawLineWidth();
   std::string dashString = "";
   d_os << "<ellipse"
        << " cx='" << cx << "'"

--- a/Code/GraphMol/MolDraw2D/test1.cpp
+++ b/Code/GraphMol/MolDraw2D/test1.cpp
@@ -2762,8 +2762,8 @@ void testGithub2151() {
       std::ofstream outs("testGithub2151_1.svg");
       outs << text;
       outs.flush();
-      TEST_ASSERT(text.find("stroke-width:2px") != std::string::npos);
-      TEST_ASSERT(text.find("stroke-width:3px") == std::string::npos);
+      TEST_ASSERT(text.find("stroke-width:2.0px") != std::string::npos);
+      TEST_ASSERT(text.find("stroke-width:3.0px") == std::string::npos);
     }
     {
       MolDraw2DSVG drawer(200, 200);


### PR DESCRIPTION
This PR addresses and fixes #3852:
- `width` should not be implicitly cast to `unsigned int` (I have also fixed the same issue in a few places in the `svg` and `cairo` drawers)
- coordinates should not be rounded ahead of using them in context, as the context will do that with interpolation/antialiasing when generating the bitmap

The differences are particularly evident for the first molecule; look in particular at the carbonyl double bond and at the benzene double bonds. The connections between lines used to have a small "angle" where there was a color change, and now they don't anymore, and all bonds are now nicely parallel, as we rely on antialiasing to do the interpolation and the smoothing rather than rounding pixels to integer upfront.

Before | After
--- | ---
![image](https://user-images.githubusercontent.com/5244385/109140770-3fbdcf80-775d-11eb-9f9d-b1380f385eb9.png) | ![image](https://user-images.githubusercontent.com/5244385/109142270-f79fac80-775e-11eb-8a86-9d33e358f7b2.png)


Before | After
--- | ---
![image](https://user-images.githubusercontent.com/5244385/109140812-49dfce00-775d-11eb-8f46-97bd7112eac2.png) | ![image](https://user-images.githubusercontent.com/5244385/109142098-c45d1d80-775e-11eb-8398-69d92f58275e.png)

