### PR TITLE
add a new mol draw option to draw wedge bonds with a single color 

### DIFF
--- a/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
@@ -2999,7 +2999,7 @@ void drawNormalBond(MolDraw2D &d2d, const Bond &bond, bool highlight_bond,
       swap(col1, col2);
       inverted = true;
     }
-    if(d2d.drawOptions().blackWedgeBonds) {
+    if(d2d.drawOptions().singleColourWedgeBonds) {
       col1 = d2d.drawOptions().symbolColour;
       col2 = d2d.drawOptions().symbolColour;
     }

--- a/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
@@ -2999,6 +2999,10 @@ void drawNormalBond(MolDraw2D &d2d, const Bond &bond, bool highlight_bond,
       swap(col1, col2);
       inverted = true;
     }
+    if(d2d.drawOptions().blackWedgeBonds) {
+      col1 = d2d.drawOptions().symbolColour;
+      col2 = d2d.drawOptions().symbolColour;
+    }
     // deliberately not scaling highlighted bond width
     if (Bond::BEGINWEDGE == bond.getBondDir()) {
       drawWedgedBond(d2d, bond, inverted, at1_cds, at2_cds, false, col1, col2);

--- a/Code/GraphMol/MolDraw2D/MolDraw2D.h
+++ b/Code/GraphMol/MolDraw2D/MolDraw2D.h
@@ -306,7 +306,7 @@ struct RDKIT_MOLDRAW2D_EXPORT MolDrawOptions {
       false;  // if all specified stereocenters are in a single StereoGroup,
               // show a molecule-level annotation instead of the individual
               // labels
-  bool blackWedgeBonds = false; // if true wedged and dashed bonds are drawn
+  bool singleColourWedgeBonds = false; // if true wedged and dashed bonds are drawn
                                 // using symbolColour rather than inheriting
                                 // their colour from the atoms
 

--- a/Code/GraphMol/MolDraw2D/MolDraw2D.h
+++ b/Code/GraphMol/MolDraw2D/MolDraw2D.h
@@ -306,6 +306,9 @@ struct RDKIT_MOLDRAW2D_EXPORT MolDrawOptions {
       false;  // if all specified stereocenters are in a single StereoGroup,
               // show a molecule-level annotation instead of the individual
               // labels
+  bool blackWedgeBonds = false; // if true wedged and dashed bonds are drawn
+                                // using symbolColour rather than inheriting
+                                // their colour from the atoms
 
   MolDrawOptions() {
     highlightColourPalette.emplace_back(

--- a/Code/GraphMol/MolDraw2D/MolDraw2DUtils.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DUtils.cpp
@@ -172,6 +172,7 @@ void updateDrawerParamsFromJSON(MolDraw2D &drawer, const std::string &json) {
   PT_OPT_GET(variableAtomRadius);
   PT_OPT_GET(includeChiralFlagLabel);
   PT_OPT_GET(simplifiedStereoGroupLabel);
+  PT_OPT_GET(singleColourWedgeBonds);
 
   get_colour_option(&pt, "highlightColour", opts.highlightColour);
   get_colour_option(&pt, "backgroundColour", opts.backgroundColour);

--- a/Code/GraphMol/MolDraw2D/Wrap/rdMolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/Wrap/rdMolDraw2D.cpp
@@ -751,8 +751,8 @@ BOOST_PYTHON_MODULE(rdMolDraw2D) {
                      "if all specified stereocenters are in a single "
                      "StereoGroup, show a molecule-level annotation instead of "
                      "the individual labels. Default is false.")
-      .def_readwrite("blackWedgeBonds",
-                     &RDKit::MolDrawOptions::blackWedgeBonds,
+      .def_readwrite("singleColourWedgeBonds",
+                     &RDKit::MolDrawOptions::singleColourWedgeBonds,
                      "if true wedged and dashed bonds are drawn using symbolColour "
                      "rather than inheriting their colour from the atoms. "
                      "Default is false.")

--- a/Code/GraphMol/MolDraw2D/Wrap/rdMolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/Wrap/rdMolDraw2D.cpp
@@ -751,6 +751,11 @@ BOOST_PYTHON_MODULE(rdMolDraw2D) {
                      "if all specified stereocenters are in a single "
                      "StereoGroup, show a molecule-level annotation instead of "
                      "the individual labels. Default is false.")
+      .def_readwrite("blackWedgeBonds",
+                     &RDKit::MolDrawOptions::blackWedgeBonds,
+                     "if true wedged and dashed bonds are drawn using symbolColour "
+                     "rather than inheriting their colour from the atoms. "
+                     "Default is false.")
       .def("getVariableAttachmentColour", &RDKit::getVariableAttachmentColour,
            "method for getting the colour of variable attachment points")
       .def("setVariableAttachmentColour", &RDKit::setVariableAttachmentColour,


### PR DESCRIPTION
In general I do like the practice of coloring bond lines to match the atoms at either end, but I find it rather distracting on wedged bonds.  For example I prefer the version on the right,

<img width="392" alt="image" src="https://user-images.githubusercontent.com/16337306/109388837-250b6800-78cf-11eb-9276-2b2668ae666c.png">


- The new option simply uses the `symbolColour` to draw the wedges, alternatively the new option could be a color itself.
- If it is kept as a boolean, perhaps the name `blackWedgeBonds` is inappropriate?  I am always keepint `symbolColour` as the default black so it works for me.
- I'm not sure I added the hook into python correctly, as I don't build the python extensions  myself (or if I do then I don't know how to use them)
- I haven't added a test.  I think a test would create an SVG on a simple molecule and test for the presence of a single triangle or three, but I have no experience with the SVG exporter. 
- Looking at the code a bit closer, the logic to apply black to both colors could be done [here](https://github.com/rdkit/rdkit/blob/44efdb25a38132a8b54feae33eedd056ed1601d7/Code/GraphMol/MolDraw2D/MolDraw2D.cpp#L573) instead. Then there is only one spot in the code that overrides the bond colors to make it black.
