### PR TITLE
Fix build error with static boost libraries (missing zlib)

### DIFF
--- a/Code/GraphMol/FileParsers/CMakeLists.txt
+++ b/Code/GraphMol/FileParsers/CMakeLists.txt
@@ -58,7 +58,7 @@ rdkit_library(FileParsers
 							MultithreadedMolSupplier.cpp
 							MultithreadedSmilesMolSupplier.cpp
 							MultithreadedSDMolSupplier.cpp
-              LINK_LIBRARIES Depictor SmilesParse GraphMol ${RDK_MAEPARSER_LIBS} ${regex_lib} ${link_iostreams})
+              LINK_LIBRARIES Depictor SmilesParse GraphMol ${RDK_MAEPARSER_LIBS} ${regex_lib} ${link_iostreams} ${zlib_lib})
 target_compile_definitions(FileParsers PRIVATE RDKIT_FILEPARSERS_BUILD)
 
 rdkit_headers(FileParsers.h


### PR DESCRIPTION
#### Reference Issue
Fixes #3865 


