### PR TITLE
Fixes #2904

### DIFF
--- a/rdkit/Chem/Draw/SimilarityMaps.py
+++ b/rdkit/Chem/Draw/SimilarityMaps.py
@@ -1,5 +1,6 @@
 #
 #  Copyright (c) 2013, Novartis Institutes for BioMedical Research Inc.
+#  Copyright (c) 2021, Greg Landrum
 #  All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -32,14 +33,16 @@
 
 import copy
 import math
+
+from numpy.lib.arraysetops import isin
 try:
   from matplotlib import cm
   from matplotlib.colors import LinearSegmentedColormap
 except ImportError:
-    cm = None
+  cm = None
 except RuntimeError:
-    cm = None
-    
+  cm = None
+
 import numpy
 
 from rdkit import Chem
@@ -52,7 +55,7 @@ from rdkit.Chem import rdMolDescriptors as rdMD
 
 
 def GetAtomicWeightsForFingerprint(refMol, probeMol, fpFunction, metric=DataStructs.DiceSimilarity):
-    """
+  """
     Calculates the atomic weights for the probe molecule
     based on a fingerprint function and a metric.
 
@@ -65,28 +68,28 @@ def GetAtomicWeightsForFingerprint(refMol, probeMol, fpFunction, metric=DataStru
     Note:
       If fpFunction needs additional parameters, use a lambda construct
     """
-    if hasattr(probeMol, '_fpInfo'):
-        delattr(probeMol, '_fpInfo')
-    if hasattr(refMol, '_fpInfo'):
-        delattr(refMol, '_fpInfo')
-    refFP = fpFunction(refMol, -1)
-    probeFP = fpFunction(probeMol, -1)
-    baseSimilarity = metric(refFP, probeFP)
-    # loop over atoms
-    weights = []
-    for atomId in range(probeMol.GetNumAtoms()):
-        newFP = fpFunction(probeMol, atomId)
-        newSimilarity = metric(refFP, newFP)
-        weights.append(baseSimilarity - newSimilarity)
-    if hasattr(probeMol, '_fpInfo'):
-        delattr(probeMol, '_fpInfo')
-    if hasattr(refMol, '_fpInfo'):
-        delattr(refMol, '_fpInfo')
-    return weights
+  if hasattr(probeMol, '_fpInfo'):
+    delattr(probeMol, '_fpInfo')
+  if hasattr(refMol, '_fpInfo'):
+    delattr(refMol, '_fpInfo')
+  refFP = fpFunction(refMol, -1)
+  probeFP = fpFunction(probeMol, -1)
+  baseSimilarity = metric(refFP, probeFP)
+  # loop over atoms
+  weights = []
+  for atomId in range(probeMol.GetNumAtoms()):
+    newFP = fpFunction(probeMol, atomId)
+    newSimilarity = metric(refFP, newFP)
+    weights.append(baseSimilarity - newSimilarity)
+  if hasattr(probeMol, '_fpInfo'):
+    delattr(probeMol, '_fpInfo')
+  if hasattr(refMol, '_fpInfo'):
+    delattr(refMol, '_fpInfo')
+  return weights
 
 
 def GetAtomicWeightsForModel(probeMol, fpFunction, predictionFunction):
-    """
+  """
     Calculates the atomic weights for the probe molecule based on
     a fingerprint function and the prediction function of a ML model.
 
@@ -95,41 +98,41 @@ def GetAtomicWeightsForModel(probeMol, fpFunction, predictionFunction):
       fpFunction -- the fingerprint function
       predictionFunction -- the prediction function of the ML model
     """
-    if hasattr(probeMol, '_fpInfo'):
-        delattr(probeMol, '_fpInfo')
-    probeFP = fpFunction(probeMol, -1)
-    baseProba = predictionFunction(probeFP)
-    # loop over atoms
-    weights = []
-    for atomId in range(probeMol.GetNumAtoms()):
-        newFP = fpFunction(probeMol, atomId)
-        newProba = predictionFunction(newFP)
-        weights.append(baseProba - newProba)
-    if hasattr(probeMol, '_fpInfo'):
-        delattr(probeMol, '_fpInfo')
-    return weights
+  if hasattr(probeMol, '_fpInfo'):
+    delattr(probeMol, '_fpInfo')
+  probeFP = fpFunction(probeMol, -1)
+  baseProba = predictionFunction(probeFP)
+  # loop over atoms
+  weights = []
+  for atomId in range(probeMol.GetNumAtoms()):
+    newFP = fpFunction(probeMol, atomId)
+    newProba = predictionFunction(newFP)
+    weights.append(baseProba - newProba)
+  if hasattr(probeMol, '_fpInfo'):
+    delattr(probeMol, '_fpInfo')
+  return weights
 
 
 def GetStandardizedWeights(weights):
-    """
+  """
     Normalizes the weights,
     such that the absolute maximum weight equals 1.0.
 
     Parameters:
       weights -- the list with the atomic weights
     """
-    tmp = [math.fabs(w) for w in weights]
-    currentMax = max(tmp)
-    if currentMax > 0:
-        return [w / currentMax for w in weights], currentMax
-    else:
-        return weights, currentMax
+  tmp = [math.fabs(w) for w in weights]
+  currentMax = max(tmp)
+  if currentMax > 0:
+    return [w / currentMax for w in weights], currentMax
+  else:
+    return weights, currentMax
 
 
-def GetSimilarityMapFromWeights(mol, weights, colorMap=None, scale=-1, size=(250, 250),
-                                sigma=None, coordScale=1.5, step=0.01, colors='k', contourLines=10,
-                                alpha=0.5, draw2d=None, **kwargs):
-    """
+def GetSimilarityMapFromWeights(mol, weights, colorMap=None, scale=-1, size=(250, 250), sigma=None,
+                                coordScale=1.5, step=0.01, colors='k', contourLines=10, alpha=0.5,
+                                draw2d=None, **kwargs):
+  """
     Generates the similarity map for a molecule given the atomic weights.
 
     Parameters:
@@ -147,81 +150,90 @@ def GetSimilarityMapFromWeights(mol, weights, colorMap=None, scale=-1, size=(250
       alpha -- the alpha blending value for the contour lines
       kwargs -- additional arguments for drawing
     """
-    if mol.GetNumAtoms() < 2:
-        raise ValueError("too few atoms")
-    if draw2d is not None:
-        mol = rdMolDraw2D.PrepareMolForDrawing(mol,addChiralHs=False)
-        if not mol.GetNumConformers():
-            rdDepictor.Compute2DCoords(mol)
-        if sigma is None:
-            if mol.GetNumBonds() > 0:
-                bond = mol.GetBondWithIdx(0)
-                idx1 = bond.GetBeginAtomIdx()
-                idx2 = bond.GetEndAtomIdx()
-                sigma = 0.3 * (mol.GetConformer().GetAtomPosition(idx1)-mol.GetConformer().GetAtomPosition(idx2)).Length()
-            else:
-                sigma = 0.3 * (mol.GetConformer().GetAtomPosition(0)-mol.GetConformer().GetAtomPosition(1)).Length()
-            sigma = round(sigma, 2)
-        sigmas = [sigma]*mol.GetNumAtoms()
-        locs=[]
-        for i in range(mol.GetNumAtoms()):
-            p = mol.GetConformer().GetAtomPosition(i)
-            locs.append(Geometry.Point2D(p.x,p.y))
-        draw2d.ClearDrawing()
-        ps = Draw.ContourParams()
-        ps.fillGrid=True
-        ps.gridResolution=0.1
-        ps.extraGridPadding = 0.5
-        Draw.ContourAndDrawGaussians(draw2d,locs,weights,sigmas,nContours=contourLines,params=ps)
-        draw2d.drawOptions().clearBackground = False
-        draw2d.DrawMolecule(mol)
-        return draw2d
-
-    fig = Draw.MolToMPL(mol, coordScale=coordScale, size=size, **kwargs)
+  if mol.GetNumAtoms() < 2:
+    raise ValueError("too few atoms")
+  if draw2d is not None:
+    mol = rdMolDraw2D.PrepareMolForDrawing(mol, addChiralHs=False)
+    if not mol.GetNumConformers():
+      rdDepictor.Compute2DCoords(mol)
     if sigma is None:
-        if mol.GetNumBonds() > 0:
-            bond = mol.GetBondWithIdx(0)
-            idx1 = bond.GetBeginAtomIdx()
-            idx2 = bond.GetEndAtomIdx()
-            sigma = 0.3 * math.sqrt(
-              sum([(mol._atomPs[idx1][i] - mol._atomPs[idx2][i])**2 for i in range(2)]))
-        else:
-            sigma = 0.3 * \
-                math.sqrt(sum([(mol._atomPs[0][i] - mol._atomPs[1][i])**2 for i in range(2)]))
-        sigma = round(sigma, 2)
-    x, y, z = Draw.calcAtomGaussians(mol, sigma, weights=weights, step=step)
-    # scaling
-    if scale <= 0.0:
-        maxScale = max(math.fabs(numpy.min(z)), math.fabs(numpy.max(z)))
-    else:
-        maxScale = scale
-    # coloring
-    if colorMap is None:
-        if cm is None:
-            raise RuntimeError("matplotlib failed to import")
-        PiYG_cmap = cm.get_cmap('PiYG', 2)
-        colorMap = LinearSegmentedColormap.from_list(
-            'PiWG', [PiYG_cmap(0), (1.0, 1.0, 1.0), PiYG_cmap(1)], N=255)
+      if mol.GetNumBonds() > 0:
+        bond = mol.GetBondWithIdx(0)
+        idx1 = bond.GetBeginAtomIdx()
+        idx2 = bond.GetEndAtomIdx()
+        sigma = 0.3 * (mol.GetConformer().GetAtomPosition(idx1) -
+                       mol.GetConformer().GetAtomPosition(idx2)).Length()
+      else:
+        sigma = 0.3 * (mol.GetConformer().GetAtomPosition(0) -
+                       mol.GetConformer().GetAtomPosition(1)).Length()
+      sigma = round(sigma, 2)
+    sigmas = [sigma] * mol.GetNumAtoms()
+    locs = []
+    for i in range(mol.GetNumAtoms()):
+      p = mol.GetConformer().GetAtomPosition(i)
+      locs.append(Geometry.Point2D(p.x, p.y))
+    draw2d.ClearDrawing()
+    ps = Draw.ContourParams()
+    ps.fillGrid = True
+    ps.gridResolution = 0.1
+    ps.extraGridPadding = 0.5
+    if colorMap is not None:
+      if cm is not None and isinstance(colorMap, type(cm.Blues)):
+        # it's a matplotlib colormap:
+        clrs = [tuple(x) for x in colorMap([0, 0.5, 1])]
+      else:
+        clrs = [colorMap[0], colorMap[1], colorMap[2]]
+      ps.setColourMap(clrs)
 
-    fig.axes[0].imshow(z, cmap=colorMap, interpolation='bilinear', origin='lower',
-                       extent=(0, 1, 0, 1), vmin=-maxScale, vmax=maxScale)
-    # contour lines
-    # only draw them when at least one weight is not zero
-    if len([w for w in weights if w != 0.0]):
-        contourset = fig.axes[0].contour(
-            x, y, z, contourLines, colors=colors, alpha=alpha, **kwargs)
-        for j, c in enumerate(contourset.collections):
-            if contourset.levels[j] == 0.0:
-                c.set_linewidth(0.0)
-            elif contourset.levels[j] < 0:
-                c.set_dashes([(0, (3.0, 3.0))])
-    fig.axes[0].set_axis_off()
-    return fig
+    Draw.ContourAndDrawGaussians(draw2d, locs, weights, sigmas, nContours=contourLines, params=ps)
+    draw2d.drawOptions().clearBackground = False
+    draw2d.DrawMolecule(mol)
+    return draw2d
+
+  fig = Draw.MolToMPL(mol, coordScale=coordScale, size=size, **kwargs)
+  if sigma is None:
+    if mol.GetNumBonds() > 0:
+      bond = mol.GetBondWithIdx(0)
+      idx1 = bond.GetBeginAtomIdx()
+      idx2 = bond.GetEndAtomIdx()
+      sigma = 0.3 * math.sqrt(
+        sum([(mol._atomPs[idx1][i] - mol._atomPs[idx2][i])**2 for i in range(2)]))
+    else:
+      sigma = 0.3 * \
+          math.sqrt(sum([(mol._atomPs[0][i] - mol._atomPs[1][i])**2 for i in range(2)]))
+    sigma = round(sigma, 2)
+  x, y, z = Draw.calcAtomGaussians(mol, sigma, weights=weights, step=step)
+  # scaling
+  if scale <= 0.0:
+    maxScale = max(math.fabs(numpy.min(z)), math.fabs(numpy.max(z)))
+  else:
+    maxScale = scale
+  # coloring
+  if colorMap is None:
+    if cm is None:
+      raise RuntimeError("matplotlib failed to import")
+    PiYG_cmap = cm.get_cmap('PiYG', 2)
+    colorMap = LinearSegmentedColormap.from_list(
+      'PiWG', [PiYG_cmap(0), (1.0, 1.0, 1.0), PiYG_cmap(1)], N=255)
+
+  fig.axes[0].imshow(z, cmap=colorMap, interpolation='bilinear', origin='lower',
+                     extent=(0, 1, 0, 1), vmin=-maxScale, vmax=maxScale)
+  # contour lines
+  # only draw them when at least one weight is not zero
+  if len([w for w in weights if w != 0.0]):
+    contourset = fig.axes[0].contour(x, y, z, contourLines, colors=colors, alpha=alpha, **kwargs)
+    for j, c in enumerate(contourset.collections):
+      if contourset.levels[j] == 0.0:
+        c.set_linewidth(0.0)
+      elif contourset.levels[j] < 0:
+        c.set_dashes([(0, (3.0, 3.0))])
+  fig.axes[0].set_axis_off()
+  return fig
 
 
 def GetSimilarityMapForFingerprint(refMol, probeMol, fpFunction, metric=DataStructs.DiceSimilarity,
                                    **kwargs):
-    """
+  """
     Generates the similarity map for a given reference and probe molecule,
     fingerprint function and similarity metric.
 
@@ -232,14 +244,14 @@ def GetSimilarityMapForFingerprint(refMol, probeMol, fpFunction, metric=DataStru
       metric -- the similarity metric.
       kwargs -- additional arguments for drawing
     """
-    weights = GetAtomicWeightsForFingerprint(refMol, probeMol, fpFunction, metric)
-    weights, maxWeight = GetStandardizedWeights(weights)
-    fig = GetSimilarityMapFromWeights(probeMol, weights, **kwargs)
-    return fig, maxWeight
+  weights = GetAtomicWeightsForFingerprint(refMol, probeMol, fpFunction, metric)
+  weights, maxWeight = GetStandardizedWeights(weights)
+  fig = GetSimilarityMapFromWeights(probeMol, weights, **kwargs)
+  return fig, maxWeight
 
 
 def GetSimilarityMapForModel(probeMol, fpFunction, predictionFunction, **kwargs):
-    """
+  """
     Generates the similarity map for a given ML model and probe molecule,
     and fingerprint function.
 
@@ -249,25 +261,26 @@ def GetSimilarityMapForModel(probeMol, fpFunction, predictionFunction, **kwargs)
       predictionFunction -- the prediction function of the ML model
       kwargs -- additional arguments for drawing
     """
-    weights = GetAtomicWeightsForModel(probeMol, fpFunction, predictionFunction)
-    weights, maxWeight = GetStandardizedWeights(weights)
-    fig = GetSimilarityMapFromWeights(probeMol, weights, **kwargs)
-    return fig, maxWeight
+  weights = GetAtomicWeightsForModel(probeMol, fpFunction, predictionFunction)
+  weights, maxWeight = GetStandardizedWeights(weights)
+  fig = GetSimilarityMapFromWeights(probeMol, weights, **kwargs)
+  return fig, maxWeight
 
 
 apDict = {}
+apDict['normal'] = lambda m, bits, minl, maxl, bpe, ia, **kwargs: rdMD.GetAtomPairFingerprint(
+  m, minLength=minl, maxLength=maxl, ignoreAtoms=ia, **kwargs)
+apDict['hashed'] = lambda m, bits, minl, maxl, bpe, ia, **kwargs: rdMD.GetHashedAtomPairFingerprint(
+  m, nBits=bits, minLength=minl, maxLength=maxl, ignoreAtoms=ia, **kwargs)
 apDict[
-  'normal'] = lambda m, bits, minl, maxl, bpe, ia, **kwargs: rdMD.GetAtomPairFingerprint(m, minLength=minl, maxLength=maxl, ignoreAtoms=ia, **kwargs)
-apDict[
-  'hashed'] = lambda m, bits, minl, maxl, bpe, ia, **kwargs: rdMD.GetHashedAtomPairFingerprint(m, nBits=bits, minLength=minl, maxLength=maxl, ignoreAtoms=ia, **kwargs)
-apDict[
-  'bv'] = lambda m, bits, minl, maxl, bpe, ia, **kwargs: rdMD.GetHashedAtomPairFingerprintAsBitVect(m, nBits=bits, minLength=minl, maxLength=maxl, nBitsPerEntry=bpe, ignoreAtoms=ia, **kwargs)
+  'bv'] = lambda m, bits, minl, maxl, bpe, ia, **kwargs: rdMD.GetHashedAtomPairFingerprintAsBitVect(
+    m, nBits=bits, minLength=minl, maxLength=maxl, nBitsPerEntry=bpe, ignoreAtoms=ia, **kwargs)
 
 
 # usage:   lambda m,i: GetAPFingerprint(m, i, fpType, nBits, minLength, maxLength, nBitsPerEntry)
 def GetAPFingerprint(mol, atomId=-1, fpType='normal', nBits=2048, minLength=1, maxLength=30,
                      nBitsPerEntry=4, **kwargs):
-    """
+  """
     Calculates the atom pairs fingerprint with the torsions of atomId removed.
 
     Parameters:
@@ -279,28 +292,30 @@ def GetAPFingerprint(mol, atomId=-1, fpType='normal', nBits=2048, minLength=1, m
       maxLength -- the maxmimum path length for an atom pair
       nBitsPerEntry -- the number of bits available for each pair
     """
-    if fpType not in ['normal', 'hashed', 'bv']:
-        raise ValueError("Unknown Atom pairs fingerprint type")
-    if atomId < 0:
-        return apDict[fpType](mol, nBits, minLength, maxLength, nBitsPerEntry, 0, **kwargs)
-    if atomId >= mol.GetNumAtoms():
-        raise ValueError("atom index greater than number of atoms")
-    return apDict[fpType](mol, nBits, minLength, maxLength, nBitsPerEntry, [atomId], **kwargs)
+  if fpType not in ['normal', 'hashed', 'bv']:
+    raise ValueError("Unknown Atom pairs fingerprint type")
+  if atomId < 0:
+    return apDict[fpType](mol, nBits, minLength, maxLength, nBitsPerEntry, 0, **kwargs)
+  if atomId >= mol.GetNumAtoms():
+    raise ValueError("atom index greater than number of atoms")
+  return apDict[fpType](mol, nBits, minLength, maxLength, nBitsPerEntry, [atomId], **kwargs)
 
 
 ttDict = {}
+ttDict['normal'] = lambda m, bits, ts, bpe, ia, **kwargs: rdMD.GetTopologicalTorsionFingerprint(
+  m, targetSize=ts, ignoreAtoms=ia, **kwargs)
 ttDict[
-  'normal'] = lambda m, bits, ts, bpe, ia, **kwargs: rdMD.GetTopologicalTorsionFingerprint(m, targetSize=ts, ignoreAtoms=ia, **kwargs)
+  'hashed'] = lambda m, bits, ts, bpe, ia, **kwargs: rdMD.GetHashedTopologicalTorsionFingerprint(
+    m, nBits=bits, targetSize=ts, ignoreAtoms=ia, **kwargs)
 ttDict[
-  'hashed'] = lambda m, bits, ts, bpe, ia, **kwargs: rdMD.GetHashedTopologicalTorsionFingerprint(m, nBits=bits, targetSize=ts, ignoreAtoms=ia, **kwargs)
-ttDict[
-  'bv'] = lambda m, bits, ts, bpe, ia, **kwargs: rdMD.GetHashedTopologicalTorsionFingerprintAsBitVect(m, nBits=bits, targetSize=ts, nBitsPerEntry=bpe, ignoreAtoms=ia, **kwargs)
+  'bv'] = lambda m, bits, ts, bpe, ia, **kwargs: rdMD.GetHashedTopologicalTorsionFingerprintAsBitVect(
+    m, nBits=bits, targetSize=ts, nBitsPerEntry=bpe, ignoreAtoms=ia, **kwargs)
 
 
 # usage:   lambda m,i: GetTTFingerprint(m, i, fpType, nBits, targetSize)
 def GetTTFingerprint(mol, atomId=-1, fpType='normal', nBits=2048, targetSize=4, nBitsPerEntry=4,
                      **kwargs):
-    """
+  """
     Calculates the topological torsion fingerprint with the pairs of atomId removed.
 
     Parameters:
@@ -315,19 +330,19 @@ def GetTTFingerprint(mol, atomId=-1, fpType='normal', nBits=2048, targetSize=4, 
     any additional keyword arguments will be passed to the fingerprinting function.
 
     """
-    if fpType not in ['normal', 'hashed', 'bv']:
-        raise ValueError("Unknown Topological torsion fingerprint type")
-    if atomId < 0:
-        return ttDict[fpType](mol, nBits, targetSize, nBitsPerEntry, 0, **kwargs)
-    if atomId >= mol.GetNumAtoms():
-        raise ValueError("atom index greater than number of atoms")
-    return ttDict[fpType](mol, nBits, targetSize, nBitsPerEntry, [atomId], **kwargs)
+  if fpType not in ['normal', 'hashed', 'bv']:
+    raise ValueError("Unknown Topological torsion fingerprint type")
+  if atomId < 0:
+    return ttDict[fpType](mol, nBits, targetSize, nBitsPerEntry, 0, **kwargs)
+  if atomId >= mol.GetNumAtoms():
+    raise ValueError("atom index greater than number of atoms")
+  return ttDict[fpType](mol, nBits, targetSize, nBitsPerEntry, [atomId], **kwargs)
 
 
 # usage:   lambda m,i: GetMorganFingerprint(m, i, radius, fpType, nBits, useFeatures)
 def GetMorganFingerprint(mol, atomId=-1, radius=2, fpType='bv', nBits=2048, useFeatures=False,
                          **kwargs):
-    """
+  """
     Calculates the Morgan fingerprint with the environments of atomId removed.
 
     Parameters:
@@ -340,61 +355,61 @@ def GetMorganFingerprint(mol, atomId=-1, radius=2, fpType='bv', nBits=2048, useF
 
     any additional keyword arguments will be passed to the fingerprinting function.
     """
-    if fpType not in ['bv', 'count']:
-        raise ValueError("Unknown Morgan fingerprint type")
-    if not hasattr(mol, '_fpInfo'):
-        info = {}
-        # get the fingerprint
-        if fpType == 'bv':
-            molFp = rdMD.GetMorganFingerprintAsBitVect(mol, radius, nBits=nBits, useFeatures=useFeatures,
-                                                       bitInfo=info, **kwargs)
-        else:
-            molFp = rdMD.GetMorganFingerprint(mol, radius, useFeatures=useFeatures, bitInfo=info,
-                                              **kwargs)
-        # construct the bit map
-        if fpType == 'bv':
-            bitmap = [DataStructs.ExplicitBitVect(nBits) for _ in range(mol.GetNumAtoms())]
-        else:
-            bitmap = [[] for _ in range(mol.GetNumAtoms())]
-        for bit, es in info.items():
-            for at1, rad in es:
-                if rad == 0:  # for radius 0
-                    if fpType == 'bv':
-                        bitmap[at1][bit] = 1
-                    else:
-                        bitmap[at1].append(bit)
-                else:  # for radii > 0
-                    env = Chem.FindAtomEnvironmentOfRadiusN(mol, rad, at1)
-                    amap = {}
-                    Chem.PathToSubmol(mol, env, atomMap=amap)
-                    for at2 in amap.keys():
-                        if fpType == 'bv':
-                            bitmap[at2][bit] = 1
-                        else:
-                            bitmap[at2].append(bit)
-        mol._fpInfo = (molFp, bitmap)
+  if fpType not in ['bv', 'count']:
+    raise ValueError("Unknown Morgan fingerprint type")
+  if not hasattr(mol, '_fpInfo'):
+    info = {}
+    # get the fingerprint
+    if fpType == 'bv':
+      molFp = rdMD.GetMorganFingerprintAsBitVect(mol, radius, nBits=nBits, useFeatures=useFeatures,
+                                                 bitInfo=info, **kwargs)
+    else:
+      molFp = rdMD.GetMorganFingerprint(mol, radius, useFeatures=useFeatures, bitInfo=info,
+                                        **kwargs)
+    # construct the bit map
+    if fpType == 'bv':
+      bitmap = [DataStructs.ExplicitBitVect(nBits) for _ in range(mol.GetNumAtoms())]
+    else:
+      bitmap = [[] for _ in range(mol.GetNumAtoms())]
+    for bit, es in info.items():
+      for at1, rad in es:
+        if rad == 0:  # for radius 0
+          if fpType == 'bv':
+            bitmap[at1][bit] = 1
+          else:
+            bitmap[at1].append(bit)
+        else:  # for radii > 0
+          env = Chem.FindAtomEnvironmentOfRadiusN(mol, rad, at1)
+          amap = {}
+          Chem.PathToSubmol(mol, env, atomMap=amap)
+          for at2 in amap.keys():
+            if fpType == 'bv':
+              bitmap[at2][bit] = 1
+            else:
+              bitmap[at2].append(bit)
+    mol._fpInfo = (molFp, bitmap)
 
-    if atomId < 0:
-        return mol._fpInfo[0]
-    else:  # remove the bits of atomId
-        if atomId >= mol.GetNumAtoms():
-            raise ValueError("atom index greater than number of atoms")
-        if len(mol._fpInfo) != 2:
-            raise ValueError("_fpInfo not set")
-        if fpType == 'bv':
-            molFp = mol._fpInfo[0] ^ mol._fpInfo[1][atomId]  # xor
-        else:  # count
-            molFp = copy.deepcopy(mol._fpInfo[0])
-            # delete the bits with atomId
-            for bit in mol._fpInfo[1][atomId]:
-                molFp[bit] -= 1
-        return molFp
+  if atomId < 0:
+    return mol._fpInfo[0]
+  else:  # remove the bits of atomId
+    if atomId >= mol.GetNumAtoms():
+      raise ValueError("atom index greater than number of atoms")
+    if len(mol._fpInfo) != 2:
+      raise ValueError("_fpInfo not set")
+    if fpType == 'bv':
+      molFp = mol._fpInfo[0] ^ mol._fpInfo[1][atomId]  # xor
+    else:  # count
+      molFp = copy.deepcopy(mol._fpInfo[0])
+      # delete the bits with atomId
+      for bit in mol._fpInfo[1][atomId]:
+        molFp[bit] -= 1
+    return molFp
 
 
 # usage:   lambda m,i: GetRDKFingerprint(m, i, fpType, nBits, minPath, maxPath, nBitsPerHash)
 def GetRDKFingerprint(mol, atomId=-1, fpType='bv', nBits=2048, minPath=1, maxPath=5, nBitsPerHash=2,
                       **kwargs):
-    """
+  """
     Calculates the RDKit fingerprint with the paths of atomId removed.
 
     Parameters:
@@ -406,23 +421,23 @@ def GetRDKFingerprint(mol, atomId=-1, fpType='bv', nBits=2048, minPath=1, maxPat
       maxPath -- maximum path length
       nBitsPerHash -- number of to set per path
     """
-    if fpType not in ['bv', '']:
-        raise ValueError("Unknown RDKit fingerprint type")
-    fpType = 'bv'
-    if not hasattr(mol, '_fpInfo'):
-        info = []  # list with bits for each atom
-        # get the fingerprint
-        molFp = Chem.RDKFingerprint(mol, fpSize=nBits, minPath=minPath, maxPath=maxPath,
-                                    nBitsPerHash=nBitsPerHash, atomBits=info, **kwargs)
-        mol._fpInfo = (molFp, info)
+  if fpType not in ['bv', '']:
+    raise ValueError("Unknown RDKit fingerprint type")
+  fpType = 'bv'
+  if not hasattr(mol, '_fpInfo'):
+    info = []  # list with bits for each atom
+    # get the fingerprint
+    molFp = Chem.RDKFingerprint(mol, fpSize=nBits, minPath=minPath, maxPath=maxPath,
+                                nBitsPerHash=nBitsPerHash, atomBits=info, **kwargs)
+    mol._fpInfo = (molFp, info)
 
-    if atomId < 0:
-        return mol._fpInfo[0]
-    else:  # remove the bits of atomId
-        if atomId >= mol.GetNumAtoms():
-            raise ValueError("atom index greater than number of atoms")
-        if len(mol._fpInfo) != 2:
-            raise ValueError("_fpInfo not set")
-        molFp = copy.deepcopy(mol._fpInfo[0])
-        molFp.UnSetBitsFromList(mol._fpInfo[1][atomId])
-        return molFp
+  if atomId < 0:
+    return mol._fpInfo[0]
+  else:  # remove the bits of atomId
+    if atomId >= mol.GetNumAtoms():
+      raise ValueError("atom index greater than number of atoms")
+    if len(mol._fpInfo) != 2:
+      raise ValueError("_fpInfo not set")
+    molFp = copy.deepcopy(mol._fpInfo[0])
+    molFp.UnSetBitsFromList(mol._fpInfo[1][atomId])
+    return molFp

--- a/rdkit/Chem/Draw/UnitTestSimilarityMaps.py
+++ b/rdkit/Chem/Draw/UnitTestSimilarityMaps.py
@@ -1,5 +1,6 @@
 #
 #  Copyright (c) 2013, Novartis Institutes for BioMedical Research Inc.
+#  Copyright (c) 2021, Greg Landrum
 #  All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -89,8 +90,8 @@ class TestCase(unittest.TestCase):
       self.mol1, self.mol2, lambda m, i: sm.GetMorganFingerprint(m, i, fpType='count'))
     self.assertTrue(weights[3] < 0)
     weights = sm.GetAtomicWeightsForFingerprint(
-      self.mol1,
-      self.mol2, lambda m, i: sm.GetMorganFingerprint(m, i, fpType='bv', useFeatures=True))
+      self.mol1, self.mol2,
+      lambda m, i: sm.GetMorganFingerprint(m, i, fpType='bv', useFeatures=True))
     self.assertTrue(weights[3] < 0)
 
     # hashed AP BV
@@ -110,8 +111,8 @@ class TestCase(unittest.TestCase):
     # hashed TT BV
     refWeights = [0.5, 0.5, -0.16666, -0.5, -0.16666, 0.5]
     weights = sm.GetAtomicWeightsForFingerprint(
-      self.mol1,
-      self.mol2, lambda m, i: sm.GetTTFingerprint(m, i, fpType='bv', nBits=1024, nBitsPerEntry=1))
+      self.mol1, self.mol2,
+      lambda m, i: sm.GetTTFingerprint(m, i, fpType='bv', nBits=1024, nBitsPerEntry=1))
     for w, r in zip(weights, refWeights):
       self.assertAlmostEqual(w, r, 4)
 
@@ -177,6 +178,31 @@ class TestCase(unittest.TestCase):
     d.FinishDrawing()
     with open('similarityMap1_out.svg', 'w+') as outf:
       outf.write(d.GetDrawingText())
+
+    # Github #2904: make sure we can provide our own colormap as a list:
+    colors = [(0, 1, 0, 0.5), (1, 1, 1), (0, 0, 1, 0.5)]
+    d = Draw.MolDraw2DSVG(400, 400)
+    d.ClearDrawing()
+    _, maxWeight = sm.GetSimilarityMapForFingerprint(
+      refmol, mol, lambda m, i: sm.GetMorganFingerprint(m, i, radius=2, fpType='bv'), draw2d=d,
+      colorMap=colors)
+    d.FinishDrawing()
+    with open('similarityMap1_out2.svg', 'w+') as outf:
+      outf.write(d.GetDrawingText())
+
+    # Github #2904: make sure we can provide our own colormap as a matplotlib colormap:
+    try:
+      from matplotlib import cm
+      d = Draw.MolDraw2DSVG(400, 400)
+      d.ClearDrawing()
+      _, maxWeight = sm.GetSimilarityMapForFingerprint(
+        refmol, mol, lambda m, i: sm.GetMorganFingerprint(m, i, radius=2, fpType='bv'), draw2d=d,
+        colorMap=cm.PiYG)
+      d.FinishDrawing()
+      with open('similarityMap1_out3.svg', 'w+') as outf:
+        outf.write(d.GetDrawingText())
+    except ImportError:
+      pass
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Allows colormaps to be provided to the similarity map code when using the C++ renderer.
Colormaps can be provided either as a list/tuple with three (r,g,b,a) (or just (r,g,b)) tuples or as a matplotlib colormap