### PR TITLE
Add basic support for hydrogen bonds

### DIFF
--- a/Code/GraphMol/Bond.cpp
+++ b/Code/GraphMol/Bond.cpp
@@ -172,6 +172,9 @@ double Bond::getBondTypeAsDouble() const {
     case DATIVE:
       return 1.0;
       break;  // FIX: again probably wrong
+    case HYDROGEN:
+      return 0.0;
+      break;
     default:
       UNDER_CONSTRUCTION("Bad bond type");
   }
@@ -233,6 +236,9 @@ double Bond::getValenceContrib(const Atom *atom) const {
       } else {
         return 0.0;
       }
+      break;
+    case HYDROGEN:
+      return 0.0;
       break;
     default:
       UNDER_CONSTRUCTION("Bad bond type");
@@ -349,6 +355,9 @@ uint8_t getTwiceBondType(const Bond &b) {
     case Bond::DATIVE:
       return 2;
       break;  // FIX: again probably wrong
+    case Bond::HYDROGEN:
+      return 0;
+      break;
     default:
       UNDER_CONSTRUCTION("Bad bond type");
   }

--- a/Code/GraphMol/DistGeomHelpers/BoundsMatrixBuilder.cpp
+++ b/Code/GraphMol/DistGeomHelpers/BoundsMatrixBuilder.cpp
@@ -220,9 +220,10 @@ void set12Bounds(const ROMol &mol, DistGeom::BoundsMatPtr mmat,
   for (bi = mol.beginBonds(); bi != mol.endBonds(); bi++) {
     begId = (*bi)->getBeginAtomIdx();
     endId = (*bi)->getEndAtomIdx();
-    if (atomParams[begId] && atomParams[endId]) {
+    auto bOrder = (*bi)->getBondTypeAsDouble();
+    if (atomParams[begId] && atomParams[endId] && bOrder > 0) {
       bl = ForceFields::UFF::Utils::calcBondRestLength(
-          (*bi)->getBondTypeAsDouble(), atomParams[begId], atomParams[endId]);
+          bOrder, atomParams[begId], atomParams[endId]);
       accumData.bondLengths[(*bi)->getIdx()] = bl;
       mmat->setUpperBound(begId, endId, bl + DIST12_DELTA);
       mmat->setLowerBound(begId, endId, bl - DIST12_DELTA);

--- a/Code/GraphMol/FileParsers/MolFileParser.cpp
+++ b/Code/GraphMol/FileParsers/MolFileParser.cpp
@@ -2479,6 +2479,9 @@ void ParseV3000BondBlock(std::istream *inStream, unsigned int &line,
       case 9:
         bond = new Bond(Bond::DATIVE);
         break;
+      case 10:
+        bond = new Bond(Bond::HYDROGEN);
+        break;
       case 0:
         bond = new Bond(Bond::UNSPECIFIED);
         BOOST_LOG(rdWarningLog)

--- a/Code/GraphMol/FileParsers/MolFileWriter.cpp
+++ b/Code/GraphMol/FileParsers/MolFileWriter.cpp
@@ -1023,6 +1023,9 @@ int GetV3000BondCode(const Bond *bond) {
       case Bond::DATIVE:
         res = 9;
         break;
+      case Bond::HYDROGEN:
+        res = 10;
+        break;
       default:
         res = 0;
         break;

--- a/Code/GraphMol/FileParsers/file_parsers_catch.cpp
+++ b/Code/GraphMol/FileParsers/file_parsers_catch.cpp
@@ -3041,3 +3041,46 @@ M  END)CTAB"_ctab;
     CHECK(m->getBondBetweenAtoms(3, 5)->getBondDir() == Bond::BondDir::NONE);
   }
 }
+
+TEST_CASE("Hydrogen bonds in CTABs") {
+  SECTION("basics") {
+    auto m = R"CTAB(
+  Mrv2014 03022114422D          
+
+  0  0  0     0  0            999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 8 8 0 0 0
+M  V30 BEGIN ATOM
+M  V30 1 C -5.4583 -0.125 0 0
+M  V30 2 C -4.1247 0.645 0 0
+M  V30 3 C -2.791 -0.125 0 0
+M  V30 4 C -1.4573 0.645 0 0
+M  V30 5 O -2.791 -1.665 0 0
+M  V30 6 C -6.792 0.645 0 0
+M  V30 7 O -5.4583 -1.665 0 0
+M  V30 8 H -4.1247 -2.435 0 0
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 1 1 2
+M  V30 2 1 2 3
+M  V30 3 1 3 4
+M  V30 4 2 3 5
+M  V30 5 1 1 6
+M  V30 6 1 1 7
+M  V30 7 1 7 8
+M  V30 8 10 5 8
+M  V30 END BOND
+M  V30 END CTAB
+M  END
+)CTAB"_ctab;
+    REQUIRE(m);
+    REQUIRE(m->getBondBetweenAtoms(4, 7));
+    CHECK(m->getBondBetweenAtoms(4, 7)->getBondType() ==
+          Bond::BondType::HYDROGEN);
+    auto mb = MolToV3KMolBlock(*m);
+    CHECK(mb.find("V30 8 10 5 8") != std::string::npos);
+    CHECK(MolToSmiles(*m) ==
+          "CC1=O~[H]OC(C)C1");  // the SMILES writer still doesn't know what to
+                                // do with it
+  }
+}

--- a/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
@@ -2908,7 +2908,7 @@ void drawDativeBond(MolDraw2D &d2d, const Bond &bond, const Point2D &cds1,
 
 void drawBondLine(MolDraw2D &d2d, const Bond &bond, const Point2D &cds1,
                   const Point2D &cds2, const DrawColour &col1,
-                  const DrawColour &col2, bool clearAIdx=true) {
+                  const DrawColour &col2, bool clearAIdx = true) {
   if (!d2d.drawOptions().splitBonds) {
     d2d.setActiveAtmIdx(bond.getBeginAtomIdx(), bond.getEndAtomIdx());
     d2d.drawLine(cds1, cds2, col1, col2);
@@ -2922,13 +2922,13 @@ void drawBondLine(MolDraw2D &d2d, const Bond &bond, const Point2D &cds1,
   d2d.drawLine(cds1, mid, col1, col1);
   d2d.setActiveAtmIdx(bond.getEndAtomIdx());
   d2d.drawLine(mid, cds2, col2, col2);
-    if (clearAIdx) {
-      d2d.setActiveAtmIdx();
-    }
+  if (clearAIdx) {
+    d2d.setActiveAtmIdx();
+  }
 }
 
 void drawBondLine(MolDraw2D &d2d, const Bond &bond, const Point2D &cds1,
-                  const Point2D &cds2, bool clearAIdx=true) {
+                  const Point2D &cds2, bool clearAIdx = true) {
   if (!d2d.drawOptions().splitBonds) {
     d2d.drawLine(cds1, cds2);
     if (clearAIdx) {
@@ -3021,6 +3021,17 @@ void drawNormalBond(MolDraw2D &d2d, const Bond &bond, bool highlight_bond,
           d2d.drawOptions().scaleHighlightBondWidth;
     }
     drawBondLine(d2d, bond, at1_cds, at2_cds, col1, col2);
+    d2d.drawOptions().scaleBondWidth = orig_slw;
+    d2d.setDash(noDash);
+  } else if (Bond::HYDROGEN == bt) {
+    d2d.setDash(dots);
+    bool orig_slw = d2d.drawOptions().scaleBondWidth;
+    if (highlight_bond) {
+      d2d.drawOptions().scaleBondWidth =
+          d2d.drawOptions().scaleHighlightBondWidth;
+    }
+    drawBondLine(d2d, bond, at1_cds, at2_cds, DrawColour(0.2, 0.2, 0.2),
+                 DrawColour(0.2, 0.2, 0.2));
     d2d.drawOptions().scaleBondWidth = orig_slw;
     d2d.setDash(noDash);
   } else {
@@ -4032,8 +4043,9 @@ string MolDraw2D::getAtomSymbol(const RDKit::Atom &atom,
       postText.push_back(h);
     }
 
-    if (0 != iso && ((drawOptions().isotopeLabels && atom.getAtomicNum() != 0) ||
-        (drawOptions().dummyIsotopeLabels && atom.getAtomicNum() == 0))) {
+    if (0 != iso &&
+        ((drawOptions().isotopeLabels && atom.getAtomicNum() != 0) ||
+         (drawOptions().dummyIsotopeLabels && atom.getAtomicNum() == 0))) {
       // isotope always comes before the symbol
       preText.push_back(std::string("<sup>") + std::to_string(iso) +
                         std::string("</sup>"));

--- a/Code/GraphMol/MolDraw2D/catch_tests.cpp
+++ b/Code/GraphMol/MolDraw2D/catch_tests.cpp
@@ -247,9 +247,11 @@ TEST_CASE("dative bonds", "[drawing][organometallics]") {
     outs << text;
     outs.flush();
 
-    CHECK(text.find("<path class='bond-0 atom-0 atom-1' d='M 126.052,100 L 85.9675,100'"
-                    " style='fill:none;fill-rule:evenodd;"
-                    "stroke:#0000FF;") != std::string::npos);
+    CHECK(
+        text.find(
+            "<path class='bond-0 atom-0 atom-1' d='M 126.052,100 L 85.9675,100'"
+            " style='fill:none;fill-rule:evenodd;"
+            "stroke:#0000FF;") != std::string::npos);
   }
   SECTION("more complex") {
     auto m1 = "N->1[C@@H]2CCCC[C@H]2N->[Pt]11OC(=O)C(=O)O1"_smiles;
@@ -2049,16 +2051,17 @@ M  V30 LINKNODE 1 3 2 1 2 1 5
 M  V30 LINKNODE 1 4 2 4 3 4 5
 M  V30 END CTAB
 M  END)CTAB"_ctab;
-    std::vector<int> rotns={0,30,60,90,120,150,180};
-    for(auto rotn : rotns){
-    MolDraw2DSVG drawer(350, 300);
-    drawer.drawOptions().rotate = (double)rotn;
-    drawer.drawMolecule(*m);
-    drawer.finishDrawing();
-    auto text = drawer.getDrawingText();
-    std::ofstream outs((boost::format("testLinkNodes-2-%d.svg")%rotn).str());
-    outs << text;
-    outs.flush();
+    std::vector<int> rotns = {0, 30, 60, 90, 120, 150, 180};
+    for (auto rotn : rotns) {
+      MolDraw2DSVG drawer(350, 300);
+      drawer.drawOptions().rotate = (double)rotn;
+      drawer.drawMolecule(*m);
+      drawer.finishDrawing();
+      auto text = drawer.getDrawingText();
+      std::ofstream outs(
+          (boost::format("testLinkNodes-2-%d.svg") % rotn).str());
+      outs << text;
+      outs.flush();
     }
   }
 }
@@ -2541,5 +2544,58 @@ TEST_CASE("test the options that toggle isotope labels", "[drawing]") {
                                    textDeuteriumTritium.end(), regex, 1),
         std::sregex_token_iterator());
     CHECK(nDeuteriumTritium == 2);
+  }
+}
+
+TEST_CASE("draw hydrogen bonds", "[drawing]") {
+  SECTION("basics") {
+    auto m = R"CTAB(
+  Mrv2014 03022114422D          
+
+  0  0  0     0  0            999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 8 8 0 0 0
+M  V30 BEGIN ATOM
+M  V30 1 C -5.4583 -0.125 0 0
+M  V30 2 C -4.1247 0.645 0 0
+M  V30 3 C -2.791 -0.125 0 0
+M  V30 4 C -1.4573 0.645 0 0
+M  V30 5 O -2.791 -1.665 0 0
+M  V30 6 C -6.792 0.645 0 0
+M  V30 7 O -5.4583 -1.665 0 0
+M  V30 8 H -4.1247 -2.435 0 0
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 1 1 2
+M  V30 2 1 2 3
+M  V30 3 1 3 4
+M  V30 4 2 3 5
+M  V30 5 1 1 6
+M  V30 6 1 1 7
+M  V30 7 1 7 8
+M  V30 8 10 5 8
+M  V30 END BOND
+M  V30 END CTAB
+M  END
+)CTAB"_ctab;
+    REQUIRE(m);
+
+    MolDraw2DSVG drawer(300, 300);
+    drawer.drawMolecule(*m);
+    drawer.finishDrawing();
+    std::ofstream outs("testHydrogenBonds1.svg");
+    outs << drawer.getDrawingText();
+    outs.flush();
+  }
+  SECTION("from CXSMILES") {
+    auto m = "CC1O[H]O=C(C)C1 |H:4.3|"_smiles;
+    REQUIRE(m);
+
+    MolDraw2DSVG drawer(300, 300);
+    drawer.drawMolecule(*m);
+    drawer.finishDrawing();
+    std::ofstream outs("testHydrogenBonds2.svg");
+    outs << drawer.getDrawingText();
+    outs.flush();
   }
 }

--- a/Code/GraphMol/SmilesParse/CXSmilesOps.cpp
+++ b/Code/GraphMol/SmilesParse/CXSmilesOps.cpp
@@ -214,8 +214,9 @@ bool parse_coords(Iterator &first, Iterator last, RDKit::RWMol &mol) {
 }
 
 template <typename Iterator>
-bool parse_coordinate_bonds(Iterator &first, Iterator last, RDKit::RWMol &mol) {
-  if (first >= last || *first != 'C') {
+bool parse_coordinate_bonds(Iterator &first, Iterator last, RDKit::RWMol &mol,
+                            Bond::BondType typ) {
+  if (first >= last || (*first != 'C' && *first != 'H')) {
     return false;
   }
   ++first;
@@ -242,7 +243,7 @@ bool parse_coordinate_bonds(Iterator &first, Iterator last, RDKit::RWMol &mol) {
                                 << " involving atom " << aidx << std::endl;
         return false;
       }
-      bnd->setBondType(Bond::DATIVE);
+      bnd->setBondType(typ);
       if (bnd->getBeginAtomIdx() != aidx) {
         unsigned int tmp = bnd->getBeginAtomIdx();
         bnd->setBeginAtomIdx(aidx);
@@ -670,7 +671,11 @@ bool parse_it(Iterator &first, Iterator last, RDKit::RWMol &mol) {
         return false;
       }
     } else if (*first == 'C') {
-      if (!parse_coordinate_bonds(first, last, mol)) {
+      if (!parse_coordinate_bonds(first, last, mol, Bond::DATIVE)) {
+        return false;
+      }
+    } else if (*first == 'H') {
+      if (!parse_coordinate_bonds(first, last, mol, Bond::HYDROGEN)) {
         return false;
       }
     } else if (*first == '^') {

--- a/Code/GraphMol/SmilesParse/catch_tests.cpp
+++ b/Code/GraphMol/SmilesParse/catch_tests.cpp
@@ -805,3 +805,13 @@ TEST_CASE("github #3774: MolToSmarts inverts direction of dative bond",
     }
   }
 }
+
+TEST_CASE("Hydrogen bonds", "[smiles]") {
+  SECTION("basics") {
+    auto m = "CC1O[H]O=C(C)C1 |H:4.3|"_smiles;
+    REQUIRE(m);
+    REQUIRE(m->getBondBetweenAtoms(3, 4));
+    CHECK(m->getBondBetweenAtoms(3, 4)->getBondType() ==
+          Bond::BondType::HYDROGEN);
+  }
+}


### PR DESCRIPTION
The goal of this basic implementation is to start to allow work with hydrogen bonds in the RDKit.

Things which are supported:
1. Reading/writing H bonds from V3000 mol files
2. Reading H bonds from CXSmiles
3. Drawing H bonds
4. Generating 2D coordinates for molecules with H bonds (no code changes needed here)
5. Generating 3D coordinate for molecules with H bonds (see below)

Clearly we should add more functionality going forward, but I figure this is better than nothing (and it's not that much code anyway)

About the integration of H bonds into the conformer generator: the bounds matrix builder has always had the ability to deal with unknown bond types - it just picks a very wide window of possible bond lengths - the change here is just to make sure that those wide bounds are used for bonds which report a bond order of zero. This will, happily, also make the conformer generator work better with both dative bonds and zero-order bonds.