### PR TITLE
Allow batch editing of molecules: removal only

### DIFF
--- a/Code/GraphMol/Abbreviations/Abbreviations.cpp
+++ b/Code/GraphMol/Abbreviations/Abbreviations.cpp
@@ -76,11 +76,13 @@ void applyMatches(RWMol& mol, const std::vector<AbbreviationMatch>& matches) {
       mol.addBond(oaidx, connectIdx, Bond::BondType::SINGLE);
     }
   }
-  for (unsigned int i = toRemove.size(); i > 0; --i) {
-    if (toRemove[i - 1]) {
-      mol.removeAtom(i - 1);
+  mol.beginBatchEdit();
+  for (unsigned int i = 0; i < toRemove.size(); ++i) {
+    if (toRemove[i]) {
+      mol.removeAtom(i);
     }
   }
+  mol.commitBatchEdit();
 }
 
 void labelMatches(RWMol& mol, const std::vector<AbbreviationMatch>& matches) {
@@ -112,7 +114,7 @@ std::vector<AbbreviationMatch> findApplicableAbbreviationMatches(
   }
 
   bool hasRings = mol.getRingInfo()->isInitialized();
-  if(!hasRings) {
+  if (!hasRings) {
     MolOps::fastFindRings(mol);
   }
 
@@ -169,10 +171,10 @@ std::vector<AbbreviationMatch> findApplicableAbbreviationMatches(
   }
 
   // if we added ring info, go ahead and remove it
-  if(!hasRings){
+  if (!hasRings) {
     mol.getRingInfo()->reset();
   }
-  
+
   return res;
 }
 

--- a/Code/GraphMol/Abbreviations/AbbreviationsUtils.cpp
+++ b/Code/GraphMol/Abbreviations/AbbreviationsUtils.cpp
@@ -163,13 +163,18 @@ ROMol *createAbbreviationMol(const std::string &txt, bool removeExtraDummies,
   unsigned int nDummies = std::count_if(smarts.begin(), smarts.end(),
                                         [](char c) { return c == '*'; });
   if (removeExtraDummies) {
-    for (unsigned int i = q->getNumAtoms() - 1; i > 0; --i) {
-      auto at = q->getAtomWithIdx(i);
+    q->beginBatchEdit();
+    for (const auto at : q->atoms()) {
+      if (!at->getIdx()) {
+        // skip the first atom
+        continue;
+      }
       if (at->hasQuery() && at->getQuery()->getDescription() == "AtomNull") {
-        q->removeAtom(i);
+        q->removeAtom(at->getIdx());
         --nDummies;
       }
     }
+    q->commitBatchEdit();
   }
   q->setProp(common_properties::numDummies, nDummies);
   return q;

--- a/Code/GraphMol/AddHs.cpp
+++ b/Code/GraphMol/AddHs.cpp
@@ -882,6 +882,8 @@ void removeHs(RWMol &mol, const RemoveHsParameters &ps, bool sanitize) {
     }
   }  // end of the loop over atoms
   // now that we know which atoms need to be removed, go ahead and remove them
+  // NOTE: there's too much complexity around stereochemistry here
+  // to be able to safely use batch editing.
   for (int idx = mol.getNumAtoms() - 1; idx >= 0; --idx) {
     if (atomsToRemove[idx]) {
       molRemoveH(mol, idx, ps.updateExplicitCount);
@@ -1122,13 +1124,11 @@ void mergeQueryHs(RWMol &mol, bool mergeUnmappedOnly) {
     }
     ++currIdx;
   }
-  std::sort(atomsToRemove.begin(), atomsToRemove.end());
-  for (std::vector<unsigned int>::const_reverse_iterator aiter =
-           atomsToRemove.rbegin();
-       aiter != atomsToRemove.rend(); ++aiter) {
-    Atom *atom = mol.getAtomWithIdx(*aiter);
-    mol.removeAtom(atom);
+  mol.beginBatchEdit();
+  for (auto aidx : atomsToRemove) {
+    mol.removeAtom(aidx);
   }
+  mol.commitBatchEdit();
 };
 ROMol *mergeQueryHs(const ROMol &mol, bool mergeUnmappedOnly) {
   auto *res = new RWMol(mol);

--- a/Code/GraphMol/ChemReactions/ReactionRunner.cpp
+++ b/Code/GraphMol/ChemReactions/ReactionRunner.cpp
@@ -1618,10 +1618,11 @@ ROMol *reduceProductToSideChains(const ROMOL_SPTR &product,
       }
     }
   }
-
+  mol->beginBatchEdit();
   for (unsigned int ai : atomsToRemove) {
     mol->removeAtom(ai);
   }
+  mol->commitBatchEdit();
   return mol;
 }
 

--- a/Code/GraphMol/ChemTransforms/MolFragmenter.cpp
+++ b/Code/GraphMol/ChemTransforms/MolFragmenter.cpp
@@ -924,11 +924,13 @@ std::unique_ptr<ROMol> molzip(const ROMol &a, const ROMol &b,
   for (auto &kv : mappings) {
     kv.second.bond(*newmol);
   }
+  newmol->beginBatchEdit();
   for (auto &atom : deletions) {
     if (atom->hasProp("__molzip_used")) {
       newmol->removeAtom(atom);
     }
   }
+  newmol->commitBatchEdit();
 
   std::set<Atom *> already_checked;
   for (auto &kv : mappings_by_atom) {

--- a/Code/GraphMol/MolEnumerator/PositionVariation.cpp
+++ b/Code/GraphMol/MolEnumerator/PositionVariation.cpp
@@ -90,12 +90,11 @@ std::unique_ptr<ROMol> PositionVariationOp::operator()(
     res->addBond(begAtomIdx, endAtomIdx, Bond::BondType::SINGLE);
   }
   // now remove the dummies:
-  std::vector<size_t> atsToRemove = d_dummiesAtEachPoint;
-  std::sort(atsToRemove.begin(), atsToRemove.end());
-  for (auto riter = atsToRemove.rbegin(); riter != atsToRemove.rend();
-       ++riter) {
-    res->removeAtom(*riter);
+  res->beginBatchEdit();
+  for (auto idx : d_dummiesAtEachPoint) {
+    res->removeAtom(idx);
   }
+  res->commitBatchEdit();
   return std::unique_ptr<ROMol>(static_cast<ROMol *>(res));
 }
 

--- a/Code/GraphMol/MolHash/hashfunctions.cpp
+++ b/Code/GraphMol/MolHash/hashfunctions.cpp
@@ -460,11 +460,11 @@ static std::string ExtendedMurckoScaffold(RWMol *mol) {
       for_deletion.push_back(aptr);
     }
   }
-
+  mol->beginBatchEdit();
   for (auto &i : for_deletion) {
     mol->removeAtom(i);
   }
-
+  mol->commitBatchEdit();
   MolOps::assignRadicals(*mol);
   std::string result;
   result = MolToSmiles(*mol);
@@ -492,9 +492,11 @@ static std::string MurckoScaffoldHash(RWMol *mol) {
         for_deletion.push_back(aptr);
       }
     }
+    mol->beginBatchEdit();
     for (auto &i : for_deletion) {
       mol->removeAtom(i);
     }
+    mol->commitBatchEdit();
   } while (!for_deletion.empty());
   MolOps::assignRadicals(*mol);
   std::string result;

--- a/Code/GraphMol/MolStandardize/Fragment.cpp
+++ b/Code/GraphMol/MolStandardize/Fragment.cpp
@@ -121,7 +121,7 @@ ROMol *FragmentRemover::remove(const ROMol &mol) {
 
   boost::dynamic_bitset<> atomsToRemove(mol.getNumAtoms());
   atomsToRemove.set();
-  // loop over remaining fragments and track atoms that need to be removed
+  // loop over remaining fragments and track atoms we aren't keeping
   for (const auto &frag : frags) {
     unsigned int fragIdx = frag.second;
     for (auto atomIdx : atomFragMapping[fragIdx]) {
@@ -130,11 +130,13 @@ ROMol *FragmentRemover::remove(const ROMol &mol) {
   }
   // remove the atoms that need to go
   auto *removed = new RWMol(mol);
-  for (int i = mol.getNumAtoms() - 1; i >= 0; --i) {
+  removed->beginBatchEdit();
+  for (unsigned int i = 0; i < mol.getNumAtoms(); ++i) {
     if (atomsToRemove[i]) {
       removed->removeAtom(i);
     }
   }
+  removed->commitBatchEdit();
   return static_cast<ROMol *>(removed);
 }
 

--- a/Code/GraphMol/RGroupDecomposition/RGroupDecomp.cpp
+++ b/Code/GraphMol/RGroupDecomposition/RGroupDecomp.cpp
@@ -260,12 +260,13 @@ int RGroupDecomposition::add(const ROMol &inmol) {
               newCoreAtm->setProp<bool>("keep", true);
             }
 
-            for (int aIdx = newCore.getNumAtoms() - 1; aIdx >= 0; --aIdx) {
-              Atom *atom = newCore.getAtomWithIdx(aIdx);
+            newCore.beginBatchEdit();
+            for (const auto atom : newCore.atoms()) {
               if (!atom->hasProp("keep")) {
                 newCore.removeAtom(atom);
               }
             }
+            newCore.commitBatchEdit();
             if (newCore.getNumAtoms()) {
               std::string newCoreSmi = MolToSmiles(newCore, true);
               // add a new core if possible

--- a/Code/GraphMol/ROMol.cpp
+++ b/Code/GraphMol/ROMol.cpp
@@ -102,6 +102,17 @@ void ROMol::initFromOther(const ROMol &other, bool quickCopy, int confId) {
     d_stereo_groups.emplace_back(otherGroup.getGroupType(), std::move(atoms));
   }
 
+  if (other.dp_delAtoms) {
+    dp_delAtoms.reset(new boost::dynamic_bitset<>(*other.dp_delAtoms));
+  } else {
+    dp_delAtoms.reset(nullptr);
+  }
+  if (other.dp_delBonds) {
+    dp_delBonds.reset(new boost::dynamic_bitset<>(*other.dp_delBonds));
+  } else {
+    dp_delBonds.reset(nullptr);
+  }
+
   if (!quickCopy) {
     // copy conformations
     for (auto ci = other.beginConformers(); ci != other.endConformers(); ++ci) {
@@ -134,6 +145,7 @@ void ROMol::initFromOther(const ROMol &other, bool quickCopy, int confId) {
     STR_VECT computed;
     d_props.setVal(RDKit::detail::computedPropName, computed);
   }
+
   // std::cerr<<"---------    done init from other: "<<this<<"
   // "<<&other<<std::endl;
 }

--- a/Code/GraphMol/ROMol.h
+++ b/Code/GraphMol/ROMol.h
@@ -15,8 +15,8 @@
 */
 
 #include <RDGeneral/export.h>
-#ifndef __RD_ROMOL_H__
-#define __RD_ROMOL_H__
+#ifndef RD_ROMOL_H
+#define RD_ROMOL_H
 
 /// Std stuff
 #include <utility>
@@ -26,6 +26,7 @@
 #include <RDGeneral/BoostStartInclude.h>
 #include <boost/graph/adjacency_list.hpp>
 #include <boost/smart_ptr.hpp>
+#include <boost/dynamic_bitset.hpp>
 #include <RDGeneral/BoostEndInclude.h>
 
 // our stuff
@@ -670,15 +671,18 @@ class RDKIT_GRAPHMOL_EXPORT ROMol : public RDProps {
   MolGraph d_graph;
   ATOM_BOOKMARK_MAP d_atomBookmarks;
   BOND_BOOKMARK_MAP d_bondBookmarks;
-  RingInfo *dp_ringInfo;
+  RingInfo *dp_ringInfo = nullptr;
   CONF_SPTR_LIST d_confs;
   std::vector<SubstanceGroup> d_sgroups;
+  std::vector<StereoGroup> d_stereo_groups;
+  std::unique_ptr<boost::dynamic_bitset<>> dp_delAtoms = nullptr;
+  std::unique_ptr<boost::dynamic_bitset<>> dp_delBonds = nullptr;
+
   friend RDKIT_GRAPHMOL_EXPORT std::vector<SubstanceGroup> &getSubstanceGroups(
       ROMol &);
   friend RDKIT_GRAPHMOL_EXPORT const std::vector<SubstanceGroup>
       &getSubstanceGroups(const ROMol &);
   void clearSubstanceGroups() { d_sgroups.clear(); }
-  std::vector<StereoGroup> d_stereo_groups;
 
   ROMol &operator=(
       const ROMol &);  // disable assignment, RWMol's support assignment

--- a/Code/GraphMol/RWMol.cpp
+++ b/Code/GraphMol/RWMol.cpp
@@ -202,6 +202,10 @@ void RWMol::removeAtom(Atom *atom) {
   unsigned int idx = atom->getIdx();
   if (dp_delAtoms) {
     // we're in a batch edit
+    // if atoms have been added since we started, resize dp_delAtoms
+    if (dp_delAtoms->size() < getNumAtoms()) {
+      dp_delAtoms->resize(getNumAtoms());
+    }
     dp_delAtoms->set(idx);
     return;
   }
@@ -355,6 +359,10 @@ void RWMol::removeBond(unsigned int aid1, unsigned int aid2) {
   unsigned int idx = bnd->getIdx();
   if (dp_delBonds) {
     // we're in a batch edit
+    // if bonds have been added since we started, resize dp_delBonds
+    if (dp_delBonds->size() < getNumBonds()) {
+      dp_delBonds->resize(getNumBonds());
+    }
     dp_delBonds->set(idx);
     return;
   }

--- a/Code/GraphMol/RWMol.cpp
+++ b/Code/GraphMol/RWMol.cpp
@@ -471,7 +471,7 @@ void RWMol::beginBatchEdit() {
     BOOST_LOG(rdWarningLog) << "batchEdit mode already enabled, ignoring "
                                "additional call to beginBatchEdit()"
                             << std::endl;
-    return;
+    throw ValueErrorException("Attempt to re-enter batchEdit mode");
   }
   dp_delAtoms.reset(new boost::dynamic_bitset<>(getNumAtoms()));
   dp_delBonds.reset(new boost::dynamic_bitset<>(getNumBonds()));

--- a/Code/GraphMol/RWMol.cpp
+++ b/Code/GraphMol/RWMol.cpp
@@ -448,4 +448,13 @@ unsigned int RWMol::finishPartialBond(unsigned int atomIdx2, int bondBookmark,
   return addBond(bsp->getBeginAtomIdx(), atomIdx2, bondType);
 }
 
+void RWMol::beginBatchEdit() {
+  if (dp_delAtoms || dp_delBonds) {
+  }
+}
+void RWMol::commitBatchEdit() {
+  dp_delAtoms.release();
+  dp_delBonds.release();
+}
+
 }  // namespace RDKit

--- a/Code/GraphMol/RWMol.cpp
+++ b/Code/GraphMol/RWMol.cpp
@@ -200,6 +200,11 @@ void RWMol::removeAtom(Atom *atom) {
   PRECONDITION(static_cast<RWMol *>(&atom->getOwningMol()) == this,
                "atom not owned by this molecule");
   unsigned int idx = atom->getIdx();
+  if (dp_delAtoms) {
+    // we're in a batch edit
+    dp_delAtoms->set(idx);
+    return;
+  }
 
   // remove any bookmarks which point to this atom:
   ATOM_BOOKMARK_MAP *marks = getAtomBookmarks();
@@ -348,6 +353,11 @@ void RWMol::removeBond(unsigned int aid1, unsigned int aid2) {
     return;
   }
   unsigned int idx = bnd->getIdx();
+  if (dp_delBonds) {
+    // we're in a batch edit
+    dp_delBonds->set(idx);
+    return;
+  }
 
   // remove any bookmarks which point to this bond:
   BOND_BOOKMARK_MAP *marks = getBondBookmarks();
@@ -450,11 +460,34 @@ unsigned int RWMol::finishPartialBond(unsigned int atomIdx2, int bondBookmark,
 
 void RWMol::beginBatchEdit() {
   if (dp_delAtoms || dp_delBonds) {
+    BOOST_LOG(rdWarningLog) << "batchEdit mode already enabled, ignoring "
+                               "additional call to beginBatchEdit()"
+                            << std::endl;
+    return;
   }
+  dp_delAtoms.reset(new boost::dynamic_bitset<>(getNumAtoms()));
+  dp_delBonds.reset(new boost::dynamic_bitset<>(getNumBonds()));
 }
 void RWMol::commitBatchEdit() {
-  dp_delAtoms.release();
+  if (!dp_delBonds || !dp_delAtoms) {
+    return;
+  }
+  auto delBonds = *dp_delBonds;
   dp_delBonds.release();
+  for (unsigned int i = getNumBonds(); i > 0; --i) {
+    if (delBonds[i - 1]) {
+      const auto bnd = getBondWithIdx(i - 1);
+      CHECK_INVARIANT(bnd, "bond not found");
+      removeBond(bnd->getBeginAtomIdx(), bnd->getEndAtomIdx());
+    }
+  }
+  auto delAtoms = *dp_delAtoms;
+  dp_delAtoms.release();
+  for (unsigned int i = getNumAtoms(); i > 0; --i) {
+    if (delAtoms[i - 1]) {
+      removeAtom(i - 1);
+    }
+  }
 }
 
 }  // namespace RDKit

--- a/Code/GraphMol/RWMol.h
+++ b/Code/GraphMol/RWMol.h
@@ -14,7 +14,6 @@
 */
 
 #include <RDGeneral/export.h>
-#include <boost/dynamic_bitset.hpp>
 
 #ifndef RD_RWMOL_H
 #define RD_RWMOL_H

--- a/Code/GraphMol/RWMol.h
+++ b/Code/GraphMol/RWMol.h
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2003-2009 Greg Landrum and Rational Discovery LLC
+//  Copyright (C) 2003-2021 Greg Landrum and Rational Discovery LLC
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -14,8 +14,10 @@
 */
 
 #include <RDGeneral/export.h>
-#ifndef __RD_RWMOL_H__
-#define __RD_RWMOL_H__
+#include <boost/dynamic_bitset.hpp>
+
+#ifndef RD_RWMOL_H
+#define RD_RWMOL_H
 
 // our stuff
 #include "ROMol.h"
@@ -211,8 +213,18 @@ class RDKIT_GRAPHMOL_EXPORT RWMol : public ROMol {
     numBonds = 0;
   };
 
+  void beginBatchEdit();
+  void abortBatchEdit(){
+    dp_delAtoms.release();
+    dp_delBonds.release();
+  };
+  void commitBatchEdit();
+  
  private:
   std::vector<Bond *> d_partialBonds;
+  std::unique_ptr<boost::dynamic_bitset<>> dp_delAtoms=nullptr;
+  std::unique_ptr<boost::dynamic_bitset<>> dp_delBonds=nullptr;
+  
   void destroy();
 };
 

--- a/Code/GraphMol/RWMol.h
+++ b/Code/GraphMol/RWMol.h
@@ -48,7 +48,7 @@ class RDKIT_GRAPHMOL_EXPORT RWMol : public ROMol {
       : ROMol(other, quickCopy, confId) {
     d_partialBonds.clear();
   };
-  RWMol(const RWMol &other) : ROMol(other){};
+  RWMol(const RWMol &other) : ROMol(other) {};
   RWMol &operator=(const RWMol &);
 
   //! insert the atoms and bonds from \c other into this molecule
@@ -214,7 +214,7 @@ class RDKIT_GRAPHMOL_EXPORT RWMol : public ROMol {
   };
 
   void beginBatchEdit();
-  void abortBatchEdit(){
+  void rollbackBatchEdit(){
     dp_delAtoms.release();
     dp_delBonds.release();
   };
@@ -222,8 +222,6 @@ class RDKIT_GRAPHMOL_EXPORT RWMol : public ROMol {
   
  private:
   std::vector<Bond *> d_partialBonds;
-  std::unique_ptr<boost::dynamic_bitset<>> dp_delAtoms=nullptr;
-  std::unique_ptr<boost::dynamic_bitset<>> dp_delBonds=nullptr;
   
   void destroy();
 };

--- a/Code/GraphMol/ReducedGraphs/ReducedGraphs.cpp
+++ b/Code/GraphMol/ReducedGraphs/ReducedGraphs.cpp
@@ -44,7 +44,7 @@ class ss_matcher {
  private:
   RDKit::ROMOL_SPTR m_matcher;
 };
-}
+}  // namespace
 
 namespace ReducedGraphs {
 // Definitions for feature points adapted from:
@@ -73,7 +73,8 @@ $([N;H0&+0]([C;!$(C(=O))])([C;!$(C(=O))])[C;!$(C(=O))])]",  // Positive
 std::vector<std::string> defaultFeatureSmarts(smartsPatterns,
                                               smartsPatterns + nFeatures);
 typedef boost::flyweight<boost::flyweights::key_value<std::string, ss_matcher>,
-                         boost::flyweights::no_tracking> pattern_flyweight;
+                         boost::flyweights::no_tracking>
+    pattern_flyweight;
 
 void getErGAtomTypes(const ROMol &mol,
                      std::vector<boost::dynamic_bitset<>> &types,
@@ -111,13 +112,13 @@ void getErGAtomTypes(const ROMol &mol,
 }  // end of getAtomTypes;
 
 RDNumeric::DoubleVector *getErGFingerprint(
-    const ROMol &mol, std::vector<boost::dynamic_bitset<> > *atomTypes,
+    const ROMol &mol, std::vector<boost::dynamic_bitset<>> *atomTypes,
     double fuzzIncrement, unsigned int minPath, unsigned int maxPath) {
   ROMol *rg = generateMolExtendedReducedGraph(mol, atomTypes);
 #ifdef VERBOSE_FINGERPRINTING
   rg->updatePropertyCache(false);
-  std::cerr << " reduced graph smiles: " << MolToSmiles(*rg, false, false, -1,
-                                                        false) << std::endl;
+  std::cerr << " reduced graph smiles: "
+            << MolToSmiles(*rg, false, false, -1, false) << std::endl;
 #endif
   RDNumeric::DoubleVector *res = generateErGFingerprintForReducedGraph(
       *rg, atomTypes, fuzzIncrement, minPath, maxPath);
@@ -126,7 +127,7 @@ RDNumeric::DoubleVector *getErGFingerprint(
 }
 
 RDNumeric::DoubleVector *generateErGFingerprintForReducedGraph(
-    const ROMol &mol, std::vector<boost::dynamic_bitset<> > *atomTypes,
+    const ROMol &mol, std::vector<boost::dynamic_bitset<>> *atomTypes,
     double fuzzIncrement, unsigned int minPath, unsigned int maxPath) {
   PRECONDITION(maxPath > minPath, "maxPath<=minPath");
   // FIX: this isn't doing the special handling for flip/flop bits
@@ -144,12 +145,12 @@ RDNumeric::DoubleVector *generateErGFingerprintForReducedGraph(
   double *dm = MolOps::getDistanceMat(mol);
 
   // cache the atom type vectors:
-  std::vector<std::vector<int> > tvs;
+  std::vector<std::vector<int>> tvs;
   tvs.reserve(mol.getNumAtoms());
   for (ROMol::ConstAtomIterator atIt = mol.beginAtoms(); atIt != mol.endAtoms();
        ++atIt) {
     const std::vector<int> &tv =
-        (*atIt)->getProp<std::vector<int> >("_ErGAtomTypes");
+        (*atIt)->getProp<std::vector<int>>("_ErGAtomTypes");
     tvs.push_back(tv);
   }
 
@@ -199,10 +200,10 @@ RDNumeric::DoubleVector *generateErGFingerprintForReducedGraph(
 }
 
 ROMol *generateMolExtendedReducedGraph(
-    const ROMol &mol, std::vector<boost::dynamic_bitset<> > *atomTypes) {
+    const ROMol &mol, std::vector<boost::dynamic_bitset<>> *atomTypes) {
   std::vector<boost::dynamic_bitset<>> *latomTypes = nullptr;
   if (!atomTypes) {
-    latomTypes = new std::vector<boost::dynamic_bitset<> >();
+    latomTypes = new std::vector<boost::dynamic_bitset<>>();
     atomTypes = latomTypes;
     getErGAtomTypes(mol, *atomTypes);
   }
@@ -247,15 +248,17 @@ ROMol *generateMolExtendedReducedGraph(
   }
 
   // now remove any degree-two ring atoms that have no features:
+  res->beginBatchEdit();
   for (int i = mol.getNumAtoms() - 1; i >= 0; --i) {
     if (mol.getRingInfo()->numAtomRings(i) &&
         mol.getAtomWithIdx(i)->getDegree() == 2 &&
         res->getAtomWithIdx(i)
-            ->getProp<std::vector<int> >("_ErGAtomTypes")
+            ->getProp<std::vector<int>>("_ErGAtomTypes")
             .empty()) {
       res->removeAtom(i);
     }
   }
+  res->commitBatchEdit();
 
   // FIX: still need to do the "highly fused rings" simplification for things
   // like adamantane

--- a/Code/GraphMol/ScaffoldNetwork/ScaffoldNetwork.cpp
+++ b/Code/GraphMol/ScaffoldNetwork/ScaffoldNetwork.cpp
@@ -77,8 +77,8 @@ ROMol *removeAttachmentPoints(const ROMol &mol,
                               const ScaffoldNetworkParams &params) {
   RDUNUSED_PARAM(params);
   RWMol *res = new RWMol(mol);
-  for (unsigned int i = 1; i <= mol.getNumAtoms(); ++i) {
-    auto atom = res->getAtomWithIdx(mol.getNumAtoms() - i);
+  res->beginBatchEdit();
+  for (const auto atom : res->atoms()) {
     if (!atom->getAtomicNum() && atom->getDegree() == 1) {
       // if we're removing a neighbor from an aromatic heteroatom,
       // don't forget to set the H count on that atom:
@@ -92,6 +92,7 @@ ROMol *removeAttachmentPoints(const ROMol &mol,
       res->removeAtom(atom);
     }
   }
+  res->commitBatchEdit();
   return static_cast<ROMol *>(res);
 }
 ROMol *pruneMol(const ROMol &mol, const ScaffoldNetworkParams &params) {

--- a/Code/GraphMol/Wrap/EditableMol.cpp
+++ b/Code/GraphMol/Wrap/EditableMol.cpp
@@ -1,6 +1,5 @@
-// $Id$
 //
-//  Copyright (C) 2007 Greg Landrum
+//  Copyright (C) 2007-2021 Greg Landrum
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -8,10 +7,6 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-// there's a compiler bug in some versions of g++ that causes this file to not
-// compile unless
-// we skip the docstrings:
-//#define BOOST_PYTHON_NO_PY_SIGNATURES
 
 #define NO_IMPORT_ARRAY
 #include <RDBoost/python.h>
@@ -59,6 +54,18 @@ class EditableMol : boost::noncopyable {
     PRECONDITION(dp_mol, "no molecule");
     PRECONDITION(bond, "bad bond");
     dp_mol->replaceBond(idx, bond, preserveProps);
+  };
+  void BeginBatchEdit() {
+    PRECONDITION(dp_mol, "no molecule");
+    dp_mol->beginBatchEdit();
+  };
+  void RollbackBatchEdit() {
+    PRECONDITION(dp_mol, "no molecule");
+    dp_mol->rollbackBatchEdit();
+  };
+  void CommitBatchEdit() {
+    PRECONDITION(dp_mol, "no molecule");
+    dp_mol->commitBatchEdit();
   };
 
   ROMol *GetMol() const {
@@ -122,6 +129,13 @@ struct EditableMol_wrapper {
              "replaces the specified bond with the provided one.\n"
              "If preserveProps is True preserve keep the existing props unless "
              "explicit set on the new bond")
+
+        .def("BeginBatchEdit", &EditableMol::BeginBatchEdit,
+             "starts batch editing")
+        .def("RollbackBatchEdit", &EditableMol::RollbackBatchEdit,
+             "cancels batch editing")
+        .def("CommitBatchEdit", &EditableMol::CommitBatchEdit,
+             "finishes batch editing and makes the actual edits")
 
         .def("GetMol", &EditableMol::GetMol,
              "Returns a Mol (a normal molecule)",

--- a/Code/GraphMol/Wrap/Mol.cpp
+++ b/Code/GraphMol/Wrap/Mol.cpp
@@ -843,6 +843,12 @@ struct mol_wrapper {
         .def("SetStereoGroups", &ReadWriteMol::SetStereoGroups,
              (python::arg("stereo_groups")), "Set the stereo groups")
 
+        .def("BeginBatchEdit", &RWMol::beginBatchEdit, "starts batch editing")
+        .def("RollbackBatchEdit", &RWMol::rollbackBatchEdit,
+             "cancels batch editing")
+        .def("CommitBatchEdit", &RWMol::commitBatchEdit,
+             "finishes batch editing and makes the actual changes")
+
         // enable pickle support
         .def_pickle(mol_pickle_suite());
   };

--- a/Code/GraphMol/Wrap/Mol.cpp
+++ b/Code/GraphMol/Wrap/Mol.cpp
@@ -228,6 +228,22 @@ class ReadWriteMol : public RWMol {
     auto *res = new ROMol(*this);
     return res;
   }
+
+  ReadWriteMol *enter() {
+    beginBatchEdit();
+    return this;
+  }
+  bool exit(python::object exc_type, python::object exc_val,
+            python::object traceback) {
+    RDUNUSED_PARAM(exc_type);
+    RDUNUSED_PARAM(exc_val);
+    RDUNUSED_PARAM(traceback);
+    commitBatchEdit();
+    return false;
+  }
+
+ private:
+  boost::shared_ptr<RWMol> dp_mol;
 };
 
 std::string molClassDoc =
@@ -810,6 +826,10 @@ struct mol_wrapper {
         .def(python::init<const ROMol &, bool, int>())
         .def("__copy__", &generic__copy__<ReadWriteMol>)
         .def("__deepcopy__", &generic__deepcopy__<ReadWriteMol>)
+        .def("__enter__", &ReadWriteMol::enter,
+             python::return_internal_reference<>())
+        .def("__exit__", &ReadWriteMol::exit)
+
         .def("RemoveAtom", &ReadWriteMol::RemoveAtom,
              "Remove the specified atom from the molecule")
         .def("RemoveBond", &ReadWriteMol::RemoveBond,

--- a/Code/GraphMol/Wrap/Mol.cpp
+++ b/Code/GraphMol/Wrap/Mol.cpp
@@ -235,10 +235,16 @@ class ReadWriteMol : public RWMol {
   }
   bool exit(python::object exc_type, python::object exc_val,
             python::object traceback) {
-    RDUNUSED_PARAM(exc_type);
     RDUNUSED_PARAM(exc_val);
     RDUNUSED_PARAM(traceback);
-    commitBatchEdit();
+    if (exc_type != python::object()) {
+      // exception thrown, abort the edits
+      rollbackBatchEdit();
+    } else {
+      commitBatchEdit();
+    }
+    // we haven't handled any possible exceptions (and shouldn't do so),
+    // so just return false;
     return false;
   }
 

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -6406,13 +6406,21 @@ CAS<~>
       self.assertEqual(Chem.MolToSmiles(nmol), "CCC.O")
 
     for rwmol in [Chem.EditableMol(mol), Chem.RWMol(mol)]:
-      rwmol = Chem.EditableMol(mol)
       rwmol.BeginBatchEdit()
       rwmol.RemoveAtom(2)
       rwmol.RemoveAtom(3)
       rwmol.RollbackBatchEdit()
       nmol = rwmol.GetMol()
       self.assertEqual(Chem.MolToSmiles(nmol), "C1CCOC1")
+
+  def testBatchEditContextManager(self):
+    mol = Chem.MolFromSmiles("C1CCCO1")
+    with Chem.RWMol(mol) as rwmol:
+      rwmol.RemoveAtom(2)
+      rwmol.RemoveAtom(3)
+      # make sure we haven't actually changed anything yet:
+      self.assertEqual(rwmol.GetNumAtoms(), mol.GetNumAtoms())
+    self.assertEqual(rwmol.GetNumAtoms(), mol.GetNumAtoms() - 2)
 
 
 if __name__ == '__main__':

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -6388,29 +6388,31 @@ CAS<~>
   def testBatchEdits(self):
     mol = Chem.MolFromSmiles("C1CCCO1")
 
-    rwmol = Chem.EditableMol(mol)
-    rwmol.BeginBatchEdit()
-    rwmol.RemoveAtom(2)
-    rwmol.RemoveAtom(3)
-    rwmol.CommitBatchEdit()
-    nmol = rwmol.GetMol()
-    self.assertEqual(Chem.MolToSmiles(nmol), "CCO")
+    for rwmol in [Chem.EditableMol(mol), Chem.RWMol(mol)]:
+      rwmol.BeginBatchEdit()
+      rwmol.RemoveAtom(2)
+      rwmol.RemoveAtom(3)
+      rwmol.CommitBatchEdit()
+      nmol = rwmol.GetMol()
+      self.assertEqual(Chem.MolToSmiles(nmol), "CCO")
 
-    rwmol = Chem.EditableMol(mol)
-    rwmol.BeginBatchEdit()
-    rwmol.RemoveAtom(3)
-    rwmol.RemoveBond(4, 0)
-    rwmol.CommitBatchEdit()
-    nmol = rwmol.GetMol()
-    self.assertEqual(Chem.MolToSmiles(nmol), "CCC.O")
+    for rwmol in [Chem.EditableMol(mol), Chem.RWMol(mol)]:
+      rwmol = Chem.EditableMol(mol)
+      rwmol.BeginBatchEdit()
+      rwmol.RemoveAtom(3)
+      rwmol.RemoveBond(4, 0)
+      rwmol.CommitBatchEdit()
+      nmol = rwmol.GetMol()
+      self.assertEqual(Chem.MolToSmiles(nmol), "CCC.O")
 
-    rwmol = Chem.EditableMol(mol)
-    rwmol.BeginBatchEdit()
-    rwmol.RemoveAtom(2)
-    rwmol.RemoveAtom(3)
-    rwmol.RollbackBatchEdit()
-    nmol = rwmol.GetMol()
-    self.assertEqual(Chem.MolToSmiles(nmol), "C1CCOC1")
+    for rwmol in [Chem.EditableMol(mol), Chem.RWMol(mol)]:
+      rwmol = Chem.EditableMol(mol)
+      rwmol.BeginBatchEdit()
+      rwmol.RemoveAtom(2)
+      rwmol.RemoveAtom(3)
+      rwmol.RollbackBatchEdit()
+      nmol = rwmol.GetMol()
+      self.assertEqual(Chem.MolToSmiles(nmol), "C1CCOC1")
 
 
 if __name__ == '__main__':

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -6422,6 +6422,15 @@ CAS<~>
       self.assertEqual(rwmol.GetNumAtoms(), mol.GetNumAtoms())
     self.assertEqual(rwmol.GetNumAtoms(), mol.GetNumAtoms() - 2)
 
+    # make sure no changes get made if we throw an exception
+    try:
+      with Chem.RWMol(mol) as rwmol:
+        rwmol.RemoveAtom(2)
+        rwmol.RemoveAtom(6)
+    except:
+      pass
+    self.assertEqual(rwmol.GetNumAtoms(), mol.GetNumAtoms())
+
 
 if __name__ == '__main__':
   if "RDTESTCASE" in os.environ:

--- a/Code/GraphMol/catch_graphmol.cpp
+++ b/Code/GraphMol/catch_graphmol.cpp
@@ -1484,17 +1484,34 @@ TEST_CASE("needsHs function", "[chemistry]") {
 }
 
 TEST_CASE("batch edits", "[editing]") {
-  SECTION("basics") {
+  SECTION("removeAtom") {
     auto m = "C1CCCO1"_smiles;
     REQUIRE(m);
     m->beginBatchEdit();
     m->removeAtom(2);
     m->removeAtom(3);
     m->commitBatchEdit();
-    CHECK(MolToSmiles(*m) == "CC.O");
+    CHECK(MolToSmiles(*m) == "CCO");
   }
-}
-TEST_CASE(
+  SECTION("removeAtom + removeBond") {
+    auto m = "C1CCCO1"_smiles;
+    REQUIRE(m);
+    m->beginBatchEdit();
+    m->removeAtom(3);
+    m->removeBond(4, 0);
+    m->commitBatchEdit();
+    CHECK(MolToSmiles(*m) == "CCC.O");
+  }
+  SECTION("rollback") {
+    auto m = "C1CCCO1"_smiles;
+    REQUIRE(m);
+    m->beginBatchEdit();
+    m->removeAtom(2);
+    m->removeAtom(3);
+    m->rollbackBatchEdit();
+    CHECK(MolToSmiles(*m) == "C1CCOC1");
+  }
+}TEST_CASE(
     "github #3330: incorrect number of radicals electrons calculated for "
     "metals",
     "[chemistry][metals]") {

--- a/Code/GraphMol/catch_graphmol.cpp
+++ b/Code/GraphMol/catch_graphmol.cpp
@@ -1483,6 +1483,17 @@ TEST_CASE("needsHs function", "[chemistry]") {
   }
 }
 
+TEST_CASE("batch edits", "[editing]") {
+  SECTION("basics") {
+    auto m = "C1CCCO1"_smiles;
+    REQUIRE(m);
+    m->beginBatchEdit();
+    m->removeAtom(2);
+    m->removeAtom(3);
+    m->commitBatchEdit();
+    CHECK(MolToSmiles(*m) == "CC.O");
+  }
+}
 TEST_CASE(
     "github #3330: incorrect number of radicals electrons calculated for "
     "metals",

--- a/Code/GraphMol/catch_graphmol.cpp
+++ b/Code/GraphMol/catch_graphmol.cpp
@@ -1759,4 +1759,22 @@ TEST_CASE("batch edits", "[editing]") {
     m->commitBatchEdit();
     CHECK(MolToSmiles(*m) == "CCC.O");
   }
+  SECTION("some details") {
+    auto m = "CCCO"_smiles;
+    REQUIRE(m);
+    m->beginBatchEdit();
+    CHECK_THROWS_AS(m->beginBatchEdit(), ValueErrorException);
+    m->removeAtom(0U);
+    // copying includes the edit status:
+    RWMol m2(*m);
+    CHECK_THROWS_AS(m2.beginBatchEdit(), ValueErrorException);
+
+    // without a commit, the mols haven't changed
+    CHECK(MolToSmiles(*m) == "CCCO");
+    CHECK(MolToSmiles(m2) == "CCCO");
+    m->commitBatchEdit();
+    CHECK(MolToSmiles(*m) == "CCO");
+    m2.commitBatchEdit();
+    CHECK(MolToSmiles(m2) == "CCO");
+  }
 }

--- a/Code/GraphMol/catch_graphmol.cpp
+++ b/Code/GraphMol/catch_graphmol.cpp
@@ -1483,35 +1483,7 @@ TEST_CASE("needsHs function", "[chemistry]") {
   }
 }
 
-TEST_CASE("batch edits", "[editing]") {
-  SECTION("removeAtom") {
-    auto m = "C1CCCO1"_smiles;
-    REQUIRE(m);
-    m->beginBatchEdit();
-    m->removeAtom(2);
-    m->removeAtom(3);
-    m->commitBatchEdit();
-    CHECK(MolToSmiles(*m) == "CCO");
-  }
-  SECTION("removeAtom + removeBond") {
-    auto m = "C1CCCO1"_smiles;
-    REQUIRE(m);
-    m->beginBatchEdit();
-    m->removeAtom(3);
-    m->removeBond(4, 0);
-    m->commitBatchEdit();
-    CHECK(MolToSmiles(*m) == "CCC.O");
-  }
-  SECTION("rollback") {
-    auto m = "C1CCCO1"_smiles;
-    REQUIRE(m);
-    m->beginBatchEdit();
-    m->removeAtom(2);
-    m->removeAtom(3);
-    m->rollbackBatchEdit();
-    CHECK(MolToSmiles(*m) == "C1CCOC1");
-  }
-}TEST_CASE(
+TEST_CASE(
     "github #3330: incorrect number of radicals electrons calculated for "
     "metals",
     "[chemistry][metals]") {
@@ -1717,5 +1689,74 @@ M  END
       CHECK(v1.dotProduct(v3) < -1e-4);
       CHECK(v1.dotProduct(v4) < -1e-4);
     }
+  }
+}
+
+TEST_CASE("batch edits", "[editing]") {
+  SECTION("removeAtom") {
+    auto m = "C1CCCO1"_smiles;
+    REQUIRE(m);
+    m->beginBatchEdit();
+    m->removeAtom(2);
+    m->removeAtom(3);
+    m->commitBatchEdit();
+    CHECK(MolToSmiles(*m) == "CCO");
+  }
+  SECTION("removeAtom + removeBond") {
+    auto m = "C1CCCO1"_smiles;
+    REQUIRE(m);
+    m->beginBatchEdit();
+    m->removeAtom(3);
+    m->removeBond(4, 0);
+    m->commitBatchEdit();
+    CHECK(MolToSmiles(*m) == "CCC.O");
+  }
+  SECTION("rollback") {
+    auto m = "C1CCCO1"_smiles;
+    REQUIRE(m);
+    m->beginBatchEdit();
+    m->removeAtom(2);
+    m->removeAtom(3);
+    m->rollbackBatchEdit();
+    CHECK(MolToSmiles(*m) == "C1CCOC1");
+  }
+  SECTION("adding atoms while in a batch") {
+    auto m = "CCCO"_smiles;
+    REQUIRE(m);
+    m->beginBatchEdit();
+    m->removeAtom(2);
+    m->addAtom(new Atom(7));
+    m->removeAtom(1);
+    m->commitBatchEdit();
+    CHECK(MolToSmiles(*m) == "C.N.O");
+  }
+  SECTION("removing added atoms while in a batch") {
+    auto m = "CCCO"_smiles;
+    REQUIRE(m);
+    m->beginBatchEdit();
+    m->removeAtom(2);
+    m->addAtom(new Atom(7));
+    m->removeAtom(4);
+    m->commitBatchEdit();
+    CHECK(MolToSmiles(*m) == "CC.O");
+  }
+  SECTION("adding bonds while in a batch") {
+    auto m = "CCCO"_smiles;
+    REQUIRE(m);
+    m->beginBatchEdit();
+    m->removeBond(2, 3);
+    m->addBond(0, 3, Bond::BondType::SINGLE);
+    m->commitBatchEdit();
+    CHECK(MolToSmiles(*m) == "CCCO");
+  }
+  SECTION("removing added bonds while in a batch") {
+    auto m = "CCCO"_smiles;
+    REQUIRE(m);
+    m->beginBatchEdit();
+    m->addBond(0, 3, Bond::BondType::SINGLE);
+    m->removeBond(2, 3);
+    m->removeBond(0, 3);
+    m->commitBatchEdit();
+    CHECK(MolToSmiles(*m) == "CCC.O");
   }
 }

--- a/Code/GraphMol/molopstest.cpp
+++ b/Code/GraphMol/molopstest.cpp
@@ -7920,6 +7920,7 @@ void testRemoveAndTrackIsotopes() {
     // 2) ...Removing all Hs including isotopes and then putting them back
     mNoH.reset(MolOps::removeHs(*static_cast<ROMol *>(mChiral.get()), ps));
     mH.reset(MolOps::addHs(*mNoH));
+
     MolOps::assignStereochemistry(*mH, true, true);
     match.clear();
     TEST_ASSERT(SubstructMatch(*mH, *mChiral, match));


### PR DESCRIPTION
The idea here is to make it simpler and less error prone to remove atoms/bonds from a molecule.

In the current code if you want to remove more than one atom you need to be sure to do the removals ordered by decreasing atom index. Code needs to use a pattern like this:
```
aidsToRemove=[]
for atom in rwmol.GetAtoms():
  if we_want_to_remove(atom):
    aidsToRemove.append(atom.GetIdx())

for aid in sorted(aidsToRemove,reverse=True):
  rwmol.RemoveAtom(aid)
```
with the new API this can be simplified to:
```
rwmol.BeginBatchEdit()
for atom in rwmol.GetAtoms():
  if we_want_to_remove(atom):
    rwmol.RemoveAtom(atom)
rwmol.CommitBatchEdit()
```
or, using a context manager:
```
with Chem.RWMol(mol) as rwmol:
  for atom in rwmol.GetAtoms():
    if we_want_to_remove(atom):
      rwmol.RemoveAtom(atom)
```

Both are simpler and, I think, less error prone.

Later we can also do some optimization work in here and make it more efficient to make these kinds of edits, but the idea with this PR is to establish the API.