### PR TITLE
ConfGen: Macrocycle torsion terms not being used with fused macrocycles

### DIFF
--- a/Code/GraphMol/DistGeomHelpers/CMakeLists.txt
+++ b/Code/GraphMol/DistGeomHelpers/CMakeLists.txt
@@ -11,6 +11,10 @@ rdkit_test(testDistGeomHelpers testDgeomHelpers.cpp
            LINK_LIBRARIES
            DistGeomHelpers MolAlign MolTransforms FileParsers SmilesParse  )
 
+rdkit_catch_test(distGeomHelpersCatch ../catch_main.cpp catch_tests.cpp 
+LINK_LIBRARIES DistGeomHelpers MolAlign MolTransforms FileParsers SmilesParse )
+
+
 if(RDK_BUILD_PYTHON_WRAPPERS)
 add_subdirectory(Wrap)
 endif()

--- a/Code/GraphMol/DistGeomHelpers/catch_tests.cpp
+++ b/Code/GraphMol/DistGeomHelpers/catch_tests.cpp
@@ -16,12 +16,13 @@
 #include <GraphMol/SmilesParse/SmilesParse.h>
 #include <GraphMol/ForceFieldHelpers/CrystalFF/TorsionPreferences.h>
 #include "Embedder.h"
+#include <tuple>
 
 using namespace RDKit;
 
 TEST_CASE("Torsions not found in fused macrocycles", "[macrocycles]") {
   RDLog::InitLogs();
-  SECTION("build ff") {
+  SECTION("reported") {
     // this is 6VY8 from the PDB
     auto mol1 =
         "CC[C@H](C)[C@@H]1NC(=O)[C@@H]2CCCN2C(=O)[C@@H]2CCCN2C(=O)[C@H]([C@@H](C)CC)NC(=O)[C@H](CO)NC(=O)[C@H](CCCC[NH3+])NC(=O)[C@H]([C@@H](C)O)NC(O)[C@@H]2CN3NNC[C@H]3C[C@H](NC1=O)C(O)N[C@@H](Cc1ccccc1)C(=O)N1CCC[C@H]1C(=O)N[C@@H](CC(=O)O)C(=O)NCC(=O)N[C@@H](CCCNC(N)=[NH2+])C(=O)N2"_smiles;
@@ -42,5 +43,37 @@ TEST_CASE("Torsions not found in fused macrocycles", "[macrocycles]") {
     rdInfoLog->ClearTee();
     auto txt = sstrm.str();
     CHECK(txt.find("{9-}") != std::string::npos);
+  }
+  SECTION("edges") {
+    std::vector<std::tuple<std::string, bool, unsigned int>> tests{
+        {"O=C1CNC(=O)C2CCC(N1)NC(=O)CNC2=O", true, 15},   // 9-9
+        {"O=C1NC2CCC(C(=O)N1)C(=O)NCC(=O)N2", true, 4},   // 9-8
+        {"O=C1NC2CCC(C(=O)N1)C(=O)NC(=O)N2", false, 0}};  // 8-8
+    for (const auto &tpl : tests) {
+      std::unique_ptr<RWMol> m{SmilesToMol(std::get<0>(tpl))};
+      REQUIRE(m);
+      MolOps::addHs(*m);
+      ForceFields::CrystalFF::CrystalFFDetails details;
+      bool useExpTorsions = true;
+      bool useSmallRingTorsions = false;
+      bool useMacrocycleTorsions = true;
+      bool useBasicKnowledge = true;
+      unsigned int version = 2;
+      bool verbose = true;
+      std::stringstream sstrm;
+      rdInfoLog->SetTee(sstrm);
+      std::cerr << "-----------" << std::endl;
+      ForceFields::CrystalFF::getExperimentalTorsions(
+          *m, details, useExpTorsions, useSmallRingTorsions,
+          useMacrocycleTorsions, useBasicKnowledge, version, verbose);
+      rdInfoLog->ClearTee();
+      auto txt = sstrm.str();
+      if (std::get<1>(tpl)) {
+        CHECK(txt.find("{9-}") != std::string::npos);
+      } else {
+        CHECK(txt.find("{9-}") == std::string::npos);
+      }
+      CHECK(details.expTorsionAngles.size() == std::get<2>(tpl));
+    }
   }
 }

--- a/Code/GraphMol/DistGeomHelpers/catch_tests.cpp
+++ b/Code/GraphMol/DistGeomHelpers/catch_tests.cpp
@@ -1,0 +1,46 @@
+//
+//  Copyright (C) 2021 Greg Landrum
+//   @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
+//
+
+#include <RDGeneral/test.h>
+#include "catch.hpp"
+
+#include <RDGeneral/RDLog.h>
+#include <GraphMol/RDKitBase.h>
+#include <GraphMol/FileParsers/FileParsers.h>
+#include <GraphMol/SmilesParse/SmilesParse.h>
+#include <GraphMol/ForceFieldHelpers/CrystalFF/TorsionPreferences.h>
+#include "Embedder.h"
+
+using namespace RDKit;
+
+TEST_CASE("Torsions not found in fused macrocycles", "[macrocycles]") {
+  RDLog::InitLogs();
+  SECTION("build ff") {
+    // this is 6VY8 from the PDB
+    auto mol1 =
+        "CC[C@H](C)[C@@H]1NC(=O)[C@@H]2CCCN2C(=O)[C@@H]2CCCN2C(=O)[C@H]([C@@H](C)CC)NC(=O)[C@H](CO)NC(=O)[C@H](CCCC[NH3+])NC(=O)[C@H]([C@@H](C)O)NC(O)[C@@H]2CN3NNC[C@H]3C[C@H](NC1=O)C(O)N[C@@H](Cc1ccccc1)C(=O)N1CCC[C@H]1C(=O)N[C@@H](CC(=O)O)C(=O)NCC(=O)N[C@@H](CCCNC(N)=[NH2+])C(=O)N2"_smiles;
+    REQUIRE(mol1);
+    MolOps::addHs(*mol1);
+    ForceFields::CrystalFF::CrystalFFDetails details;
+    bool useExpTorsions = true;
+    bool useSmallRingTorsions = false;
+    bool useMacrocycleTorsions = true;
+    bool useBasicKnowledge = true;
+    unsigned int version = 2;
+    bool verbose = true;
+    std::stringstream sstrm;
+    rdInfoLog->SetTee(sstrm);
+    ForceFields::CrystalFF::getExperimentalTorsions(
+        *mol1, details, useExpTorsions, useSmallRingTorsions,
+        useMacrocycleTorsions, useBasicKnowledge, version, verbose);
+    rdInfoLog->ClearTee();
+    auto txt = sstrm.str();
+    CHECK(txt.find("{9-}") != std::string::npos);
+  }
+}

--- a/Code/GraphMol/ForceFieldHelpers/CrystalFF/TorsionPreferences.cpp
+++ b/Code/GraphMol/ForceFieldHelpers/CrystalFF/TorsionPreferences.cpp
@@ -32,6 +32,7 @@ namespace ForceFields {
 namespace CrystalFF {
 using namespace RDKit;
 
+// the "macrocycle" patterns for ETKDGv3 use a minimum ring size of 9
 const unsigned int MIN_MACROCYCLE_SIZE = 9;
 
 /* SMARTS patterns for experimental torsion angle preferences

--- a/Code/GraphMol/ForceFieldHelpers/CrystalFF/TorsionPreferences.cpp
+++ b/Code/GraphMol/ForceFieldHelpers/CrystalFF/TorsionPreferences.cpp
@@ -220,7 +220,7 @@ void getExperimentalTorsions(const RDKit::ROMol &mol, CrystalFFDetails &details,
         // FIX: check if bond is NULL
         bid2 = mol.getBondBetweenAtoms(aid2, aid3)->getIdx();
         // check that a bond is part of maximum one ring
-        if (mol.getRingInfo()->numBondRings(bid2) > 1 ||
+        if (mol.getRingInfo()->numBondRings(bid2) > 3 ||
             excludedBonds[bid2] == 1) {
           doneBonds[bid2] = 1;
         }
@@ -234,13 +234,16 @@ void getExperimentalTorsions(const RDKit::ROMol &mol, CrystalFFDetails &details,
           details.expTorsionAtoms.push_back(atoms);
           details.expTorsionAngles.emplace_back(param.signs, param.V);
           if (verbose) {
-            BOOST_LOG(rdInfoLog) << param.smarts << ": " << aid1 << " " << aid2
-                                 << " " << aid3 << " " << aid4 << ", (";
+            // using the stringstream seems redundant, but we don't want the
+            // extra formatting provided by the logger after every entry;
+            std::stringstream sstr;
+            sstr << param.smarts << ": " << aid1 << " " << aid2 << " " << aid3
+                 << " " << aid4 << ", (";
             for (unsigned int i = 0; i < param.V.size() - 1; ++i) {
-              BOOST_LOG(rdInfoLog) << param.V[i] << ", ";
+              sstr << param.V[i] << ", ";
             }
-            BOOST_LOG(rdInfoLog)
-                << param.V[param.V.size() - 1] << ") " << std::endl;
+            sstr << param.V[param.V.size() - 1] << ") ";
+            BOOST_LOG(rdInfoLog) << sstr.str() << std::endl;
           }
         }  // if not donePaths
       }    // end loop over matches


### PR DESCRIPTION
@hjuinj noticed that the ETKDGv3 macrocycle terms were not be applied when working with [6VY8](https://www.rcsb.org/structure/6VY8).

The underlying problem is that the logic we added to exclude fused rings from consideration when using small-rings terms was being incorrectly applied to macrocycles.

Here's the new logic:
- two small rings share 2 or more bonds: all bonds in both rings excluded
- small ring shares 2 or more bonds with a macrocycle: all bonds in the small ring (this includes the overlapping bonds) are excluded
- two macrocycles share 2 or more bonds: no bonds are excluded by the fused-ring logic

