### PR TITLE
Fixes 3879: bad placement of Hs with fused rings

### DIFF
--- a/Code/GraphMol/AddHs.cpp
+++ b/Code/GraphMol/AddHs.cpp
@@ -325,65 +325,23 @@ void setHydrogenCoords(ROMol *mol, unsigned int hydIdx, unsigned int heavyIdx) {
           }
         } else {
           // we're in flatland
-          double dot12 = nbr1Vect.dotProduct(nbr2Vect);
-          double dot13 = nbr1Vect.dotProduct(nbr3Vect);
-          double dot23 = nbr2Vect.dotProduct(nbr3Vect);
-          unsigned int numNeg = 0;
-          if (dot12 < -1e-4) {
-            ++numNeg;
-          }
-          if (dot13 < -1e-4) {
-            ++numNeg;
-          }
-          if (dot23 < -1e-4) {
-            ++numNeg;
-          }
 
-          if (1) {  // numNeg < 3) {
-            // github #3879:
-            auto angle12 = nbr1Vect.angleTo(nbr2Vect);
-            auto angle13 = nbr1Vect.angleTo(nbr3Vect);
-            auto angle23 = nbr2Vect.angleTo(nbr3Vect);
-            auto accum1 = angle12 + angle13;
-            auto accum2 = angle12 + angle23;
-            auto accum3 = angle13 + angle23;
-            if (accum1 <= accum2 && accum1 <= accum3) {
-              dirVect = nbr1Vect;
-            } else if (accum2 <= accum1 && accum2 <= accum3) {
-              dirVect = nbr2Vect;
-            } else {
-              dirVect = nbr3Vect;
-            }
+          // github #3879 and #908: find the two neighbors with the largest
+          // outer angle between them and then place the H to bisect that angle
+          // This is recommendation ST-1.1.4 from the 2006 IUPAC "Graphical
+          // representation of stereochemical configuration" guideline
+          auto angle12 = nbr1Vect.angleTo(nbr2Vect);
+          auto angle13 = nbr1Vect.angleTo(nbr3Vect);
+          auto angle23 = nbr2Vect.angleTo(nbr3Vect);
+          auto accum1 = angle12 + angle13;
+          auto accum2 = angle12 + angle23;
+          auto accum3 = angle13 + angle23;
+          if (accum1 <= accum2 && accum1 <= accum3) {
+            dirVect = nbr2Vect + nbr3Vect;
+          } else if (accum2 <= accum1 && accum2 <= accum3) {
+            dirVect = nbr1Vect + nbr3Vect;
           } else {
-            // all angles > 90 degrees. this was github #908
-            // Put the H between the two neighbors that have the widest angle
-            // between them. Unless the two are opposite ends of a straight line
-            // through the heavy atom, which would make the H overlap with the
-            // heavy atom. In such case, set it on the opposite direction to the
-            // 3rd neighbor.
-            double minDot = dot12;
-            if (fabs(minDot + 1) < 1e-4) {
-              dirVect = -nbr3Vect;
-            } else {
-              dirVect = nbr1Vect + nbr2Vect;
-            }
-            if (dot23 < minDot) {
-              minDot = dot23;
-              if (fabs(minDot + 1) < 1e-4) {
-                dirVect = -nbr1Vect;
-              } else {
-                dirVect = nbr2Vect + nbr3Vect;
-              }
-            }
-            if (dot13 < minDot) {
-              minDot = dot13;
-              if (fabs(minDot + 1) < 1e-4) {
-                dirVect = -nbr2Vect;
-              } else {
-                dirVect = nbr1Vect + nbr3Vect;
-              }
-            }
-            dirVect *= -1;
+            dirVect = nbr1Vect + nbr2Vect;
           }
         }
         dirVect.normalize();

--- a/Code/GraphMol/AddHs.cpp
+++ b/Code/GraphMol/AddHs.cpp
@@ -328,9 +328,6 @@ void setHydrogenCoords(ROMol *mol, unsigned int hydIdx, unsigned int heavyIdx) {
           double dot12 = nbr1Vect.dotProduct(nbr2Vect);
           double dot13 = nbr1Vect.dotProduct(nbr3Vect);
           double dot23 = nbr2Vect.dotProduct(nbr3Vect);
-          std::cerr << "!!! " << nbr1->getIdx() << "," << nbr2->getIdx() << ","
-                    << nbr3->getIdx() << " : " << dot12 << " " << dot13 << " "
-                    << dot23 << std::endl;
           unsigned int numNeg = 0;
           if (dot12 < -1e-4) {
             ++numNeg;
@@ -342,20 +339,23 @@ void setHydrogenCoords(ROMol *mol, unsigned int hydIdx, unsigned int heavyIdx) {
             ++numNeg;
           }
 
-          if (numNeg <= 1) {
-            // github #3879: all three neighbors are on "one side" of the heavy
-            // atom; put the H on the other side, opposite the "middle" atom
-            if (dot12 > dot13 && dot12 > dot23) {
-              dirVect = nbr3Vect;
-            } else if (dot13 > dot12 && dot13 > dot23) {
+          if (1) {  // numNeg < 3) {
+            // github #3879:
+            auto angle12 = nbr1Vect.angleTo(nbr2Vect);
+            auto angle13 = nbr1Vect.angleTo(nbr3Vect);
+            auto angle23 = nbr2Vect.angleTo(nbr3Vect);
+            auto accum1 = angle12 + angle13;
+            auto accum2 = angle12 + angle23;
+            auto accum3 = angle13 + angle23;
+            if (accum1 <= accum2 && accum1 <= accum3) {
+              dirVect = nbr1Vect;
+            } else if (accum2 <= accum1 && accum2 <= accum3) {
               dirVect = nbr2Vect;
             } else {
-              dirVect = nbr1Vect;
+              dirVect = nbr3Vect;
             }
-            std::cerr << " !#!#!#" << std::endl;
-            dirVect *= -1;
           } else {
-            // this was github #908
+            // all angles > 90 degrees. this was github #908
             // Put the H between the two neighbors that have the widest angle
             // between them. Unless the two are opposite ends of a straight line
             // through the heavy atom, which would make the H overlap with the

--- a/Code/GraphMol/catch_graphmol.cpp
+++ b/Code/GraphMol/catch_graphmol.cpp
@@ -1536,7 +1536,28 @@ M  END)CTAB"_ctab;
     bool addCoords = true;
     UINT_VECT onlyOnAtoms = {3, 6};
     MolOps::addHs(*m, explicitOnly, addCoords, &onlyOnAtoms);
-    std::cerr << MolToV3KMolBlock(*m);
+    const auto &conf = m->getConformer();
+    // check that the H atoms are opposite the appropriate heavy atoms
+    {
+      REQUIRE(m->getAtomWithIdx(9)->getAtomicNum() == 1);
+      REQUIRE(m->getBondBetweenAtoms(9, 3));
+      REQUIRE(m->getBondBetweenAtoms(3, 4));
+      auto v1 = conf.getAtomPos(9) - conf.getAtomPos(3);
+      auto v2 = conf.getAtomPos(4) - conf.getAtomPos(3);
+      v1.normalize();
+      v2.normalize();
+      CHECK(fabs(v1.dotProduct(v2) + 1) < 1e-4);
+    }
+    {
+      REQUIRE(m->getAtomWithIdx(10)->getAtomicNum() == 1);
+      REQUIRE(m->getBondBetweenAtoms(10, 6));
+      REQUIRE(m->getBondBetweenAtoms(5, 6));
+      auto v1 = conf.getAtomPos(10) - conf.getAtomPos(6);
+      auto v2 = conf.getAtomPos(5) - conf.getAtomPos(6);
+      v1.normalize();
+      v2.normalize();
+      CHECK(fabs(v1.dotProduct(v2) + 1) < 1e-4);
+    }
   }
   SECTION("non-chiral version") {
     auto m = R"CTAB(
@@ -1574,6 +1595,26 @@ M  END)CTAB"_ctab;
     bool addCoords = true;
     UINT_VECT onlyOnAtoms = {3, 6};
     MolOps::addHs(*m, explicitOnly, addCoords, &onlyOnAtoms);
-    std::cerr << MolToV3KMolBlock(*m);
+    const auto &conf = m->getConformer();
+    {
+      REQUIRE(m->getAtomWithIdx(9)->getAtomicNum() == 1);
+      REQUIRE(m->getBondBetweenAtoms(9, 3));
+      REQUIRE(m->getBondBetweenAtoms(3, 4));
+      auto v1 = conf.getAtomPos(9) - conf.getAtomPos(3);
+      auto v2 = conf.getAtomPos(4) - conf.getAtomPos(3);
+      v1.normalize();
+      v2.normalize();
+      CHECK(fabs(v1.dotProduct(v2) + 1) < 1e-4);
+    }
+    {
+      REQUIRE(m->getAtomWithIdx(10)->getAtomicNum() == 1);
+      REQUIRE(m->getBondBetweenAtoms(10, 6));
+      REQUIRE(m->getBondBetweenAtoms(5, 6));
+      auto v1 = conf.getAtomPos(10) - conf.getAtomPos(6);
+      auto v2 = conf.getAtomPos(5) - conf.getAtomPos(6);
+      v1.normalize();
+      v2.normalize();
+      CHECK(fabs(v1.dotProduct(v2) + 1) < 1e-4);
+    }
   }
 }

--- a/Code/GraphMol/catch_graphmol.cpp
+++ b/Code/GraphMol/catch_graphmol.cpp
@@ -1532,31 +1532,44 @@ M  V30 10 1 9 4
 M  V30 END BOND
 M  V30 END CTAB
 M  END)CTAB"_ctab;
+    REQUIRE(m);
     bool explicitOnly = false;
     bool addCoords = true;
     UINT_VECT onlyOnAtoms = {3, 6};
     MolOps::addHs(*m, explicitOnly, addCoords, &onlyOnAtoms);
     const auto &conf = m->getConformer();
-    // check that the H atoms are opposite the appropriate heavy atoms
+    // check that the H atoms bisect the angle correctly
     {
       REQUIRE(m->getAtomWithIdx(9)->getAtomicNum() == 1);
       REQUIRE(m->getBondBetweenAtoms(9, 3));
       REQUIRE(m->getBondBetweenAtoms(3, 4));
+      REQUIRE(m->getBondBetweenAtoms(3, 2));
+      REQUIRE(m->getBondBetweenAtoms(3, 8));
       auto v1 = conf.getAtomPos(9) - conf.getAtomPos(3);
       auto v2 = conf.getAtomPos(4) - conf.getAtomPos(3);
-      v1.normalize();
-      v2.normalize();
-      CHECK(fabs(v1.dotProduct(v2) + 1) < 1e-4);
+      auto v3 = conf.getAtomPos(2) - conf.getAtomPos(3);
+      auto v4 = conf.getAtomPos(8) - conf.getAtomPos(3);
+      CHECK(v1.angleTo(v3) < v1.angleTo(v2));
+      CHECK(v1.angleTo(v4) < v1.angleTo(v2));
+      CHECK(fabs(v1.angleTo(v3) - v1.angleTo(v4)) < 1e-4);
+      CHECK(v1.dotProduct(v3) < -1e-4);
+      CHECK(v1.dotProduct(v4) < -1e-4);
     }
     {
       REQUIRE(m->getAtomWithIdx(10)->getAtomicNum() == 1);
       REQUIRE(m->getBondBetweenAtoms(10, 6));
       REQUIRE(m->getBondBetweenAtoms(5, 6));
+      REQUIRE(m->getBondBetweenAtoms(6, 1));
+      REQUIRE(m->getBondBetweenAtoms(6, 7));
       auto v1 = conf.getAtomPos(10) - conf.getAtomPos(6);
       auto v2 = conf.getAtomPos(5) - conf.getAtomPos(6);
-      v1.normalize();
-      v2.normalize();
-      CHECK(fabs(v1.dotProduct(v2) + 1) < 1e-4);
+      auto v3 = conf.getAtomPos(1) - conf.getAtomPos(6);
+      auto v4 = conf.getAtomPos(7) - conf.getAtomPos(6);
+      CHECK(v1.angleTo(v3) < v1.angleTo(v2));
+      CHECK(v1.angleTo(v4) < v1.angleTo(v2));
+      CHECK(fabs(v1.angleTo(v3) - v1.angleTo(v4)) < 1e-4);
+      CHECK(v1.dotProduct(v3) < -1e-4);
+      CHECK(v1.dotProduct(v4) < -1e-4);
     }
   }
   SECTION("non-chiral version") {
@@ -1591,6 +1604,7 @@ M  V30 10 1 9 4
 M  V30 END BOND
 M  V30 END CTAB
 M  END)CTAB"_ctab;
+    REQUIRE(m);
     bool explicitOnly = false;
     bool addCoords = true;
     UINT_VECT onlyOnAtoms = {3, 6};
@@ -1600,21 +1614,80 @@ M  END)CTAB"_ctab;
       REQUIRE(m->getAtomWithIdx(9)->getAtomicNum() == 1);
       REQUIRE(m->getBondBetweenAtoms(9, 3));
       REQUIRE(m->getBondBetweenAtoms(3, 4));
+      REQUIRE(m->getBondBetweenAtoms(3, 2));
+      REQUIRE(m->getBondBetweenAtoms(3, 8));
       auto v1 = conf.getAtomPos(9) - conf.getAtomPos(3);
       auto v2 = conf.getAtomPos(4) - conf.getAtomPos(3);
-      v1.normalize();
-      v2.normalize();
-      CHECK(fabs(v1.dotProduct(v2) + 1) < 1e-4);
+      auto v3 = conf.getAtomPos(2) - conf.getAtomPos(3);
+      auto v4 = conf.getAtomPos(8) - conf.getAtomPos(3);
+      CHECK(v1.angleTo(v3) < v1.angleTo(v2));
+      CHECK(v1.angleTo(v4) < v1.angleTo(v2));
+      CHECK(fabs(v1.angleTo(v3) - v1.angleTo(v4)) < 1e-4);
+      CHECK(v1.dotProduct(v3) < -1e-4);
+      CHECK(v1.dotProduct(v4) < -1e-4);
     }
     {
       REQUIRE(m->getAtomWithIdx(10)->getAtomicNum() == 1);
       REQUIRE(m->getBondBetweenAtoms(10, 6));
       REQUIRE(m->getBondBetweenAtoms(5, 6));
+      REQUIRE(m->getBondBetweenAtoms(6, 1));
+      REQUIRE(m->getBondBetweenAtoms(6, 7));
       auto v1 = conf.getAtomPos(10) - conf.getAtomPos(6);
       auto v2 = conf.getAtomPos(5) - conf.getAtomPos(6);
-      v1.normalize();
-      v2.normalize();
-      CHECK(fabs(v1.dotProduct(v2) + 1) < 1e-4);
+      auto v3 = conf.getAtomPos(1) - conf.getAtomPos(6);
+      auto v4 = conf.getAtomPos(7) - conf.getAtomPos(6);
+      CHECK(v1.angleTo(v3) < v1.angleTo(v2));
+      CHECK(v1.angleTo(v4) < v1.angleTo(v2));
+      CHECK(fabs(v1.angleTo(v3) - v1.angleTo(v4)) < 1e-4);
+      CHECK(v1.dotProduct(v3) < -1e-4);
+      CHECK(v1.dotProduct(v4) < -1e-4);
+    }
+  }
+  SECTION("a simpler system") {
+    auto m = R"CTAB(
+  Mrv2014 03092106042D          
+
+  0  0  0     0  0            999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 5 6 0 0 0
+M  V30 BEGIN ATOM
+M  V30 1 C -4.3533 6.6867 0 0
+M  V30 2 C -4.3533 5.1467 0 0 CFG=1
+M  V30 3 O -2.8133 6.6867 0 0
+M  V30 4 C -2.8133 5.1467 0 0 CFG=1
+M  V30 5 C -3.5833 3.813 0 0
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 1 1 3
+M  V30 2 1 2 4
+M  V30 3 1 3 4
+M  V30 4 1 2 5
+M  V30 5 1 4 5 CFG=1
+M  V30 6 1 2 1 CFG=1
+M  V30 END BOND
+M  V30 END CTAB
+M  END
+)CTAB"_ctab;
+    bool explicitOnly = false;
+    bool addCoords = true;
+    UINT_VECT onlyOnAtoms = {3, 1};
+    MolOps::addHs(*m, explicitOnly, addCoords, &onlyOnAtoms);
+    const auto &conf = m->getConformer();
+    {
+      REQUIRE(m->getAtomWithIdx(5)->getAtomicNum() == 1);
+      REQUIRE(m->getBondBetweenAtoms(5, 1));
+      REQUIRE(m->getBondBetweenAtoms(1, 3));
+      REQUIRE(m->getBondBetweenAtoms(1, 0));
+      REQUIRE(m->getBondBetweenAtoms(1, 4));
+      auto v1 = conf.getAtomPos(5) - conf.getAtomPos(1);
+      auto v2 = conf.getAtomPos(3) - conf.getAtomPos(1);
+      auto v3 = conf.getAtomPos(0) - conf.getAtomPos(1);
+      auto v4 = conf.getAtomPos(4) - conf.getAtomPos(1);
+      CHECK(v1.angleTo(v3) < v1.angleTo(v2));
+      CHECK(v1.angleTo(v4) < v1.angleTo(v2));
+      CHECK(fabs(v1.angleTo(v3) - v1.angleTo(v4)) < 1e-4);
+      CHECK(v1.dotProduct(v3) < -1e-4);
+      CHECK(v1.dotProduct(v4) < -1e-4);
     }
   }
 }

--- a/Code/GraphMol/catch_graphmol.cpp
+++ b/Code/GraphMol/catch_graphmol.cpp
@@ -1498,3 +1498,82 @@ TEST_CASE(
     }
   }
 }
+
+TEST_CASE("github #3879: bad H coordinates on fused rings", "[addhs]") {
+  SECTION("reported") {
+    auto m = R"CTAB(
+     RDKit          2D
+
+  0  0  0  0  0  0  0  0  0  0999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 9 10 0 0 0
+M  V30 BEGIN ATOM
+M  V30 1 C 1.500000 2.598076 0.000000 0
+M  V30 2 N 0.750000 1.299038 0.000000 0
+M  V30 3 C 1.500000 -0.000000 0.000000 0
+M  V30 4 C 0.750000 -1.299038 0.000000 0
+M  V30 5 C 0.382772 -0.562069 0.000000 0
+M  V30 6 C -0.295379 0.612525 0.000000 0
+M  V30 7 C -0.750000 1.299038 0.000000 0
+M  V30 8 C -1.500000 0.000000 0.000000 0
+M  V30 9 O -0.750000 -1.299038 0.000000 0
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 1 1 2
+M  V30 2 1 2 3
+M  V30 3 1 4 3 CFG=3
+M  V30 4 1 4 5
+M  V30 5 1 5 6
+M  V30 6 1 7 6 CFG=3
+M  V30 7 1 7 8
+M  V30 8 1 8 9
+M  V30 9 1 7 2
+M  V30 10 1 9 4
+M  V30 END BOND
+M  V30 END CTAB
+M  END)CTAB"_ctab;
+    bool explicitOnly = false;
+    bool addCoords = true;
+    UINT_VECT onlyOnAtoms = {3, 6};
+    MolOps::addHs(*m, explicitOnly, addCoords, &onlyOnAtoms);
+    std::cerr << MolToV3KMolBlock(*m);
+  }
+  SECTION("non-chiral version") {
+    auto m = R"CTAB(
+     RDKit          2D
+
+  0  0  0  0  0  0  0  0  0  0999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 9 10 0 0 0
+M  V30 BEGIN ATOM
+M  V30 1 C 1.500000 2.598076 0.000000 0
+M  V30 2 N 0.750000 1.299038 0.000000 0
+M  V30 3 C 1.500000 -0.000000 0.000000 0
+M  V30 4 C 0.750000 -1.299038 0.000000 0
+M  V30 5 C 0.382772 -0.562069 0.000000 0
+M  V30 6 C -0.295379 0.612525 0.000000 0
+M  V30 7 C -0.750000 1.299038 0.000000 0
+M  V30 8 C -1.500000 0.000000 0.000000 0
+M  V30 9 O -0.750000 -1.299038 0.000000 0
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 1 1 2
+M  V30 2 1 2 3
+M  V30 3 1 4 3
+M  V30 4 1 4 5
+M  V30 5 1 5 6
+M  V30 6 1 7 6
+M  V30 7 1 7 8
+M  V30 8 1 8 9
+M  V30 9 1 7 2
+M  V30 10 1 9 4
+M  V30 END BOND
+M  V30 END CTAB
+M  END)CTAB"_ctab;
+    bool explicitOnly = false;
+    bool addCoords = true;
+    UINT_VECT onlyOnAtoms = {3, 6};
+    MolOps::addHs(*m, explicitOnly, addCoords, &onlyOnAtoms);
+    std::cerr << MolToV3KMolBlock(*m);
+  }
+}


### PR DESCRIPTION
Tweaks the way that the position of the H is determined when the molecule already has coordinates
and simplifies things a bit.

Following the IUPAC guidelines, this places the H so that it bisects the largest angle:
![image](https://user-images.githubusercontent.com/540511/110576598-53a40100-8161-11eb-9046-d2f5d51abbd0.png)
