### PR TITLE
Fixes #3886

### DIFF
--- a/Code/GraphMol/FMCS/MaximumCommonSubgraph.cpp
+++ b/Code/GraphMol/FMCS/MaximumCommonSubgraph.cpp
@@ -388,7 +388,11 @@ void MaximumCommonSubgraph::makeInitialSeeds() {
         QueryMoleculeMatchedBonds = seed.getNumBonds();
       }
     }
-  } else {  // create a set of seeds from each query bond
+    if (Seeds.empty()) {
+      BOOST_LOG(rdWarningLog) << "The provided InitialSeed is not an MCS and will be ignored" << std::endl;
+    }
+  }
+  if (Seeds.empty()) {  // create a set of seeds from each query bond
     // R1 additional performance OPTIMISATION
     // if(Parameters.BondCompareParameters.CompleteRingsOnly)
     // disable all mismatched rings, and do not generate initial seeds

--- a/Code/GraphMol/FMCS/Wrap/testFMCS.py
+++ b/Code/GraphMol/FMCS/Wrap/testFMCS.py
@@ -5,27 +5,6 @@ from rdkit import Chem
 from rdkit.Chem import rdFMCS
 
 
-class GrabStderr:
-    def __init__(self):
-        self._orig_stderr = None
-        self._redir_stderr = None
-        self._stderr_data = None
-
-    def __enter__(self):
-        self._orig_stderr = sys.stderr
-        self._redir_stderr = StringIO()
-        sys.stderr = self._redir_stderr
-        return self
-
-    def __exit__(self, *args, **kwargs):
-        self._stderr_data = self._redir_stderr.getvalue()
-        self._redir_stderr.close()
-        sys.stderr = self._orig_stderr
-
-    @property
-    def stderr(self):
-        return self._stderr_data
-
 class BondMatchOrderMatrix:
     def __init__(self, ignoreAromatization):
         self.MatchMatrix = [[False]*(Chem.BondType.ZERO + 1)
@@ -578,39 +557,33 @@ class Common:
         else:
             r = rdFMCS.FindMCS(ms, seedSmarts='C1CC1')
         self.assertEqual(r.smartsString, "[#6]1-[#6]-[#6]-1")
-        Chem.WrapLogs()
-        with GrabStderr() as grab:
-            if kwargs:
-                params = Common.getParams(**kwargs)
-                params.InitialSeed = 'C1OC1'
-                r = rdFMCS.FindMCS(ms, params)
-            else:
-                r = rdFMCS.FindMCS(ms, seedSmarts='C1OC1')
-        self.assertTrue("The provided InitialSeed is not an MCS" in grab.stderr)
+        if kwargs:
+            params = Common.getParams(**kwargs)
+            params.InitialSeed = 'C1OC1'
+            r = rdFMCS.FindMCS(ms, params)
+        else:
+            r = rdFMCS.FindMCS(ms, seedSmarts='C1OC1')
         self.assertEqual(r.smartsString, "[#6]1-[#6]-[#6]-[#6]-1")
         self.assertEqual(r.numAtoms, 4)
         self.assertEqual(r.numBonds, 4)
-        with GrabStderr() as grab:
-            if kwargs:
-                params = Common.getParams(**kwargs)
-                params.InitialSeed = 'C1OC1'
-                params.AtomCompareParameters.RingMatchesRingOnly = True
-                params.BondCompareParameters.RingMatchesRingOnly = True
-                r = rdFMCS.FindMCS(ms, params)
-            else:
-                r = rdFMCS.FindMCS(ms, seedSmarts='C1OC1', ringMatchesRingOnly=True)
-        self.assertTrue("The provided InitialSeed is not an MCS" in grab.stderr)
+        if kwargs:
+            params = Common.getParams(**kwargs)
+            params.InitialSeed = 'C1OC1'
+            params.AtomCompareParameters.RingMatchesRingOnly = True
+            params.BondCompareParameters.RingMatchesRingOnly = True
+            r = rdFMCS.FindMCS(ms, params)
+        else:
+            r = rdFMCS.FindMCS(ms, seedSmarts='C1OC1', ringMatchesRingOnly=True)
         self.assertEqual(r.smartsString, "[#6&R]1-&@[#6&R]-&@[#6&R]-&@[#6&R]-&@1")
         self.assertEqual(r.numAtoms, 4)
         self.assertEqual(r.numBonds, 4)
-        with GrabStderr() as grab:
-            if kwargs:
-                params = Common.getParams(**kwargs)
-                params.InitialSeed = 'C1OC1'
-                params.BondCompareParameters.CompleteRingsOnly = True
-                r = rdFMCS.FindMCS(ms, params)
-            else:
-                r = rdFMCS.FindMCS(ms, seedSmarts='C1OC1', completeRingsOnly=True)
+        if kwargs:
+            params = Common.getParams(**kwargs)
+            params.InitialSeed = 'C1OC1'
+            params.BondCompareParameters.CompleteRingsOnly = True
+            r = rdFMCS.FindMCS(ms, params)
+        else:
+            r = rdFMCS.FindMCS(ms, seedSmarts='C1OC1', completeRingsOnly=True)
         self.assertEqual(r.smartsString, "[#6]1-&@[#6]-&@[#6]-&@[#6]-&@1")
         self.assertEqual(r.numAtoms, 4)
         self.assertEqual(r.numBonds, 4)

--- a/Code/GraphMol/FMCS/testFMCS_Unit.cpp
+++ b/Code/GraphMol/FMCS/testFMCS_Unit.cpp
@@ -2415,6 +2415,29 @@ void testGitHub3693() {
   BOOST_LOG(rdInfoLog) << "\tdone" << std::endl;
 }
 
+void testGitHub3886() {
+  BOOST_LOG(rdInfoLog) << "-------------------------------------" << std::endl;
+  BOOST_LOG(rdInfoLog) << "testGitHub3886" << std::endl;
+
+  std::vector<ROMOL_SPTR> mols = {
+      "c1cccnc1"_smiles,
+      "Fc1ccccc1"_smiles};
+
+  MCSParameters p;
+  p.InitialSeed = "c1ccc*c1";
+  std::stringstream captureLog;
+  rdWarningLog->SetTee(captureLog);
+  MCSResult res = findMCS(mols, &p);
+  rdWarningLog->ClearTee();
+  TEST_ASSERT(captureLog.str().find("The provided InitialSeed is not an MCS") != std::string::npos);
+  TEST_ASSERT(res.NumAtoms == 5);
+  TEST_ASSERT(res.NumBonds == 4);
+  TEST_ASSERT(res.SmartsString == "[#6](:[#6]:[#6]:[#6]):[#6]");
+  BOOST_LOG(rdInfoLog) << "============================================"
+                       << std::endl;
+  BOOST_LOG(rdInfoLog) << "\tdone" << std::endl;
+}
+
 //====================================================================================================
 //====================================================================================================
 
@@ -2422,6 +2445,7 @@ int main(int argc, const char* argv[]) {
   (void)argc;
   (void)argv;
   // p.Verbose = true;
+  RDLog::InitLogs();
   BOOST_LOG(rdInfoLog)
       << "*******************************************************\n";
   BOOST_LOG(rdInfoLog) << "FMCS Unit Test \n";
@@ -2495,6 +2519,7 @@ int main(int argc, const char* argv[]) {
   testGitHub3095();
   testGitHub3458();
   testGitHub3693();
+  testGitHub3886();
 
   unsigned long long t1 = nanoClock();
   double sec = double(t1 - T0) / 1000000.;


### PR DESCRIPTION
This PR fixes #3886 by ignoring the `InitialSeed` when it does not consist of a valid MCS, and issuing a warning.
Added relevant C++ test and modified existing Python tests to cope with the new behavior.