### PR TITLE
Change class to struct for forward declaration

### DIFF
--- a/Code/GraphMol/RGroupDecomposition/RGroupDecomp.h
+++ b/Code/GraphMol/RGroupDecomposition/RGroupDecomp.h
@@ -69,7 +69,7 @@ struct RDKIT_RGROUPDECOMPOSITION_EXPORT RGroupDecompositionProcessResult {
       : success(success), score(score) {}
 };
 
-class RGroupMatch;
+struct RGroupMatch;
 
 struct RDKIT_RGROUPDECOMPOSITION_EXPORT RGroupDecompositionParameters {
   unsigned int labels = AutoDetect;


### PR DESCRIPTION
Fixes a small warning here

```
Code/GraphMol/RGroupDecomposition/RGroupMatch.h:19:1: warning: 'RGroupMatch' defined as a struct here but previously declared as a class; this is valid, but may result in linker errors under the Microsoft C++ ABI [-Wmismatched-tags]
Code/GraphMol/RGroupDecomposition/RGroupDecomp.h:72:1: note: did you mean struct here?
```

