### PR TITLE
Exposes InsertMol to python RWMol

### DIFF
--- a/Code/GraphMol/Wrap/Mol.cpp
+++ b/Code/GraphMol/Wrap/Mol.cpp
@@ -843,6 +843,9 @@ struct mol_wrapper {
         .def("SetStereoGroups", &ReadWriteMol::SetStereoGroups,
              (python::arg("stereo_groups")), "Set the stereo groups")
 
+        .def("InsertMol", &ReadWriteMol::insertMol,
+	   (python::arg("mol")), "Insert (add) the given molecule into this one")
+      
         // enable pickle support
         .def_pickle(mol_pickle_suite());
   };

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -6391,7 +6391,7 @@ CAS<~>
     rwmol.InsertMol(m2)
     rwmol.InsertMol(m3)
     self.assertEqual(Chem.MolToSmiles(rwmol),
-                     Chem.CanonSmiles("CNO.c1ccccc1.C1CC1A"))
+                     Chem.CanonSmiles("CNO.c1ccccc1.C1CC1"))
     
 if __name__ == '__main__':
   if "RDTESTCASE" in os.environ:

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -6382,7 +6382,17 @@ CAS<~>
 
     RDLogger.EnableLog('rdApp.*')
 
+  def testInsertMol(self):
+    m = Chem.MolFromSmiles("CNO")
+    m2 = Chem.MolFromSmiles("c1ccccc1")
+    m3 = Chem.MolFromSmiles("C1CC1")
 
+    rwmol = Chem.RWMol(m)
+    rwmol.InsertMol(m2)
+    rwmol.InsertMol(m3)
+    self.assertEqual(Chem.MolToSmiles(rwmol),
+                     Chem.CanonSmiles("CNO.c1ccccc1.C1CC1A"))
+    
 if __name__ == '__main__':
   if "RDTESTCASE" in os.environ:
     suite = unittest.TestSuite()


### PR DESCRIPTION
Example

```
from rdkit import Chem
m = Chem.MolFromSmiles("CNO")
m2 = Chem.MolFromSmiles("c1ccccc1")
m3 = Chem.MolFromSmiles("C1CC1")

rwmol = Chem.RWMol(m)
rwmol.InsertMol(m2)
rwmol.InsertMol(m3)
assert Chem.MolToSmiles(rwmol) == Chem.CanonSMiles("CNO.c1ccccc1.C1CC1")
```