### PR TITLE
Fix #3659 regression introduced in #3832

### DIFF
--- a/Code/GraphMol/MolDraw2D/Qt/Wrap/CMakeLists.txt
+++ b/Code/GraphMol/MolDraw2D/Qt/Wrap/CMakeLists.txt
@@ -1,13 +1,10 @@
 remove_definitions(-DRDKIT_MOLDRAW2DQT_BUILD)
 
-if(RDK_BUILD_QT_SUPPORT)
-  find_package(Qt5 COMPONENTS Core OpenGL REQUIRED)
-  set( QtDrawingLibs Qt5::Core Qt5::OpenGL )
-endif(RDK_BUILD_QT_SUPPORT)
+find_package(Qt5 COMPONENTS Core OpenGL REQUIRED)
 
 rdkit_python_extension(rdMolDraw2DQt
                        rdMolDraw2DQt.cpp
                        DEST Chem/Draw
-                       LINK_LIBRARIES MolDraw2DQt ${QtDrawingLibs} )
+                       LINK_LIBRARIES MolDraw2DQt Qt5::Core Qt5::OpenGL )
 
 add_pytest(pyMolDraw2DQt ${CMAKE_CURRENT_SOURCE_DIR}/testMolDraw2DQt.py)

--- a/Code/GraphMol/MolDraw2D/Wrap/CMakeLists.txt
+++ b/Code/GraphMol/MolDraw2D/Wrap/CMakeLists.txt
@@ -1,13 +1,8 @@
 remove_definitions(-DRDKIT_MOLDRAW2D_BUILD)
 
-if(RDK_BUILD_QT_SUPPORT)
-  find_package(Qt5 COMPONENTS Widgets OpenGL REQUIRED)
-  set( QtDrawingLibs Qt5::Widgets Qt5::OpenGL )
-endif(RDK_BUILD_QT_SUPPORT)
-
 rdkit_python_extension(rdMolDraw2D
                        rdMolDraw2D.cpp
                        DEST Chem/Draw
-                       LINK_LIBRARIES MolDraw2D ${QtDrawingLibs} )
+                       LINK_LIBRARIES MolDraw2D )
 
 add_pytest(pyMolDraw2D ${CMAKE_CURRENT_SOURCE_DIR}/testMolDraw2D.py)


### PR DESCRIPTION
PR #3832 caused a partial regression on #3659: despite splitting Qt-dependent code into separate instances of the drawing libraries, it reverted the MolDraw2D Python wrappers to be linked against Qt GUI libraries, which is not desired.

Also, Code/GraphMol/MolDraw2D/Qt/Wrap/CMakeLists.txt is only used if Qt support is enabled, so no need for the extra check.