### PR TITLE
Use https for Avalon and Inchi downloads

### DIFF
--- a/Code/cmake/Modules/FindInchi.cmake
+++ b/Code/cmake/Modules/FindInchi.cmake
@@ -39,7 +39,7 @@ else(EXISTS ${CUSTOM_INCHI_PATH}/src/INCHI_BASE/src/ichican2.c)
   else (INCHI_FOUND)
     # system InChI is missing, download it
     if(NOT DEFINED INCHI_URL)
-      set(INCHI_URL "http://www.inchi-trust.org/download/105/INCHI-1-SRC.zip")
+      set(INCHI_URL "https://www.inchi-trust.org/download/105/INCHI-1-SRC.zip")
     endif()
     if(NOT DEFINED INCHI_MD5SUM)
       set(INCHI_MD5SUM "ccc497c7e6ced1521a6953d859e49af4")

--- a/External/AvalonTools/CMakeLists.txt
+++ b/External/AvalonTools/CMakeLists.txt
@@ -21,7 +21,7 @@ set(AVALON_SRC_PATH ${AVALONTOOLS_DIR}/common)
 
 if(needDownload)
   if(NOT DEFINED AVALONTOOLS_URL)
-    set(AVALONTOOLS_URL "http://sourceforge.net/projects/avalontoolkit/files/AvalonToolkit_1.2/AvalonToolkit_1.2.0.source.tar")
+    set(AVALONTOOLS_URL "https://sourceforge.net/projects/avalontoolkit/files/AvalonToolkit_1.2/AvalonToolkit_1.2.0.source.tar")
   endif()
   if(NOT DEFINED AVALONTOOLS_MD5SUM)
     set(AVALONTOOLS_MD5SUM "092a94f421873f038aa67d4a6cc8cb54")


### PR DESCRIPTION
Those URLs are available as https so no reason to stick to legacy http URLs.