### PR TITLE
RGD: fix GA delegating to exhaustive search for simple systems

### DIFF
--- a/Code/GraphMol/RGroupDecomposition/RGroupDecompData.h
+++ b/Code/GraphMol/RGroupDecomposition/RGroupDecompData.h
@@ -557,7 +557,7 @@ struct RGroupDecompData {
 
     if (params.matchingStrategy == GA) {
       RGroupGa ga(*this, params.timeout >= 0 ? &t0 : nullptr);
-      if (ga.numberPermutations() < 10000) {
+      if (ga.numberPermutations() < 100*ga.getPopsize()) {
         params.matchingStrategy = Exhaustive;
       } else {
         if (params.gaNumberRuns > 1) {

--- a/Code/GraphMol/RGroupDecomposition/RGroupGa.cpp
+++ b/Code/GraphMol/RGroupDecomposition/RGroupGa.cpp
@@ -99,12 +99,12 @@ RGroupGa::RGroupGa(const RGroupDecompData& rGroupData,
   setSelectionPressure(1.0001);
 
   const auto& matches = rGroupData.matches;
-  numPermutations = 0L;
+  numPermutations = 1L;
   auto pos = 0;
   for (auto m : matches) {
     if (m.size() == 1) continue;
     chromosomePolicy.setMax(pos, m.size());
-    unsigned long count = numPermutations = m.size();
+    unsigned long count = numPermutations * m.size();
     numPermutations = count / m.size() == numPermutations
                           ? count
                           : numeric_limits<unsigned int>::max();


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! 
-->
#### Reference Issue

Fixes #3746 
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.

Fixes RGD GA hanging when running on simple systems.

The GA hangs when in cannot construct a population of different decompositions.  This PR fixes the code that determines the number of RGD permutations.  If the number of permutations is too small to create a GA population exhaustive search will be used instead.  The example in issue #3746 now runs fine:

![Capture2](https://user-images.githubusercontent.com/24233741/111198843-a75d8280-8585-11eb-833c-627b8acd14d6.PNG)



