### PR TITLE
Fix MolDraw2DQt exports

### DIFF
--- a/Code/GraphMol/MolDraw2D/DrawText.h
+++ b/Code/GraphMol/MolDraw2D/DrawText.h
@@ -17,6 +17,7 @@
 #include <string>
 #include <vector>
 
+#include <RDGeneral/export.h>
 #include <Geometry/point.h>
 #include <GraphMol/MolDraw2D/MolDraw2D.h>
 
@@ -34,7 +35,7 @@ std::ostream &operator<<(std::ostream &oss, const TextDrawType &tdt);
 std::ostream &operator<<(std::ostream &oss, const OrientType &o);
 
 // ****************************************************************************
-class DrawText {
+class RDKIT_MOLDRAW2D_EXPORT DrawText {
  public:
   static constexpr double FONT_SIZE = 0.6;  // seems to be a good number
 
@@ -165,8 +166,9 @@ class DrawText {
 //! mode based on contents of instring from i onwards. Increments i
 //! appropriately
 //! \returns true or false depending on whether it did something or not
-bool setStringDrawMode(const std::string &instring, TextDrawType &draw_mode,
-                       size_t &i);
+RDKIT_MOLDRAW2D_EXPORT bool setStringDrawMode(const std::string &instring,
+                                              TextDrawType &draw_mode,
+                                              size_t &i);
 
 // take the label for the given atom and return the individual pieces
 // that need to be drawn for it.  So NH<sub>2</sub> will return

--- a/Code/GraphMol/MolDraw2D/DrawTextFT.h
+++ b/Code/GraphMol/MolDraw2D/DrawTextFT.h
@@ -21,6 +21,7 @@
 #include FT_BBOX_H
 #include FT_OUTLINE_H
 
+#include <RDGeneral/export.h>
 #include <GraphMol/MolDraw2D/DrawText.h>
 
 namespace RDKit {
@@ -28,7 +29,7 @@ namespace RDKit {
 struct StringRect;
 
 // ****************************************************************************
-class DrawTextFT : public DrawText {
+class RDKIT_MOLDRAW2D_EXPORT DrawTextFT : public DrawText {
  public:
   DrawTextFT(double max_fnt_sz, double min_fnt_sz,
              const std::string &font_file);

--- a/Code/GraphMol/MolDraw2D/Qt/MolDraw2DQt.h
+++ b/Code/GraphMol/MolDraw2D/Qt/MolDraw2DQt.h
@@ -23,7 +23,7 @@ class QString;
 
 namespace RDKit {
 
-class RDKIT_MOLDRAW2D_EXPORT MolDraw2DQt : public MolDraw2D {
+class RDKIT_MOLDRAW2DQT_EXPORT MolDraw2DQt : public MolDraw2D {
  public:
   MolDraw2DQt(int width, int height, QPainter *qp, int panelWidth = -1,
               int panelHeight = -1, bool noFreetype = false);


### PR DESCRIPTION
Enabling Qt support breaks the windows build: since we split off support to a separate library, some of the components of MolDraw2D now need to be exported, so that they can be used from MolDraw2DQt. Also, the export macro for `MolDraw2DQt` is wrong (in the CMakeLists file relevant to the Qt directory we define `RDKIT_MOLDRAW2DQT_BUILD`, but not `RDKIT_MOLDRAW2D_BUILD`)