### PR TITLE
Fix building JavaWrappers on Windows, dynamic linking

### DIFF
--- a/Code/JavaWrappers/Bond.i
+++ b/Code/JavaWrappers/Bond.i
@@ -46,6 +46,7 @@
 %ignore RDKit::Bond::Match(const Bond *) const;
 %ignore RDKit::Bond::setBeginAtom(Atom *at);
 %ignore RDKit::Bond::setEndAtom(Atom *at);
+%ignore RDKit::getTwiceBondType(const RDKit::Bond &b);
 
 %include <GraphMol/Bond.h>
 

--- a/Code/JavaWrappers/GenericRDKitException.h
+++ b/Code/JavaWrappers/GenericRDKitException.h
@@ -13,9 +13,19 @@
 #include <exception>
 #include <string>
 
+// RDKIT_JAVAWRAPPERS_EXPORT does not get defined in RDGeneral/export.h,
+// and we only use it here for non-windows builds, so just define it based
+// on RDKIT_RDGENERAL_EXPORT
+#if defined(RDKIT_DYN_LINK) && defined(WIN32) && defined(_MSC_VER) && \
+    defined(BOOST_HAS_DECLSPEC)
+#define RDKIT_JAVAWRAPPERS_EXPORT
+#else
+#define RDKIT_JAVAWRAPPERS_EXPORT RDKIT_RDGENERAL_EXPORT
+#endif
+
 namespace RDKit {
 
-class RDKIT_RDGENERAL_EXPORT GenericRDKitException : public std::exception {
+class RDKIT_JAVAWRAPPERS_EXPORT GenericRDKitException : public std::exception {
  public:
   GenericRDKitException(const std::string &i) : _value(i){};
   GenericRDKitException(const char *msg) : _value(msg){};

--- a/Code/JavaWrappers/MolEnumerator.i
+++ b/Code/JavaWrappers/MolEnumerator.i
@@ -23,6 +23,10 @@
 %ignore RDKit::MolEnumerator::LinkNodeOp::copy;
 #endif
 
+%ignore RDKit::MolEnumerator::detail::idxPropName;
+%ignore RDKit::MolEnumerator::detail::preserveOrigIndices;
+%ignore RDKit::MolEnumerator::detail::removeOrigIndices;
+
 %ignore RDKit::MolEnumerator::MolEnumeratorOp;
 %ignore RDKit::MolEnumerator::PositionVariationOp;
 %ignore RDKit::MolEnumerator::LinkNodeOp;


### PR DESCRIPTION
This fixes building the Java wrappers on windows when `RDK_SWIG_STATIC = OFF`:

- The export for `GenericRDKitException` isn't required on windows, and does actually cause problems. We might still need it for Linux/Mac (I remember I had trouble with this when doing the visibility patch), so define it only for those platforms.

- The things I added ignores for are mentioned in Bond.h and MolEnumerator.h, but are not DLL exported, so these can't be linked to the wrapper library. Since these look like internal details, I just ignored them in the interface files, so that they don't get wrapped.