### PR TITLE
Fixes #3924

### DIFF
--- a/Code/GraphMol/RGroupDecomposition/RGroupScore.cpp
+++ b/Code/GraphMol/RGroupDecomposition/RGroupScore.cpp
@@ -123,6 +123,10 @@ double matchScore(const std::vector<size_t> &permutation,
                   << std::endl;
 #endif
       }
+      // make sure to rescale groups like [*:1].[*:1]C otherwise this will be
+        // double counted
+        // WE SHOULD PROBABLY REJECT THESE OUTRIGHT
+      tempScore /= matchSetVect.size();
     }
 
     // overweight linkers with the same attachments points....
@@ -148,7 +152,6 @@ double matchScore(const std::vector<size_t> &permutation,
     } else {
       increment = tempScore;
     }
-
     score += increment * linkerIncrement;
 #ifdef DEBUG
     std::cerr << "Increment: " << increment

--- a/Code/GraphMol/RGroupDecomposition/RGroupScore.cpp
+++ b/Code/GraphMol/RGroupDecomposition/RGroupScore.cpp
@@ -43,11 +43,8 @@ double matchScore(const std::vector<size_t> &permutation,
   int N = 0;
   std::map<int, int> num_rgroups;
   for (size_t m = 0; m < permutation.size(); ++m) {  // for each molecule
-  for (auto l : matches[m][permutation[m]].rgroups) {
-    int count = ++num_rgroups[l.first];
-    if (N < count) {
-        N = count;
-      }
+    for (auto l : matches[m][permutation[m]].rgroups) {
+       N = std::max(N, ++num_rgroups[l.first]);
     }
   }
   // for each label (r-group)

--- a/Code/GraphMol/RGroupDecomposition/RGroupScore.cpp
+++ b/Code/GraphMol/RGroupDecomposition/RGroupScore.cpp
@@ -23,7 +23,7 @@ double matchScore(const std::vector<size_t> &permutation,
                   const std::vector<std::vector<RGroupMatch>> &matches,
                   const std::set<int> &labels) {
   double score = 0.;
-
+  const std::string EMPTY_RGROUP = "";
 #ifdef DEBUG
   std::cerr << "---------------------------------------------------"
             << std::endl;
@@ -96,12 +96,11 @@ double matchScore(const std::vector<size_t> &permutation,
     }
     
     double tempScore = 0.;
-    const std::string no_rgroup;
     for (auto &matchSet : matchSetVect) {
       // get the counts for each rgroup found and sort in reverse order
       // If we don't have as many rgroups as the largest set add a empty ones
       if( N - num_rgroups_for_label > 0) {
-          matchSet[no_rgroup] = N - num_rgroups_for_label;
+          matchSet[EMPTY_RGROUP] = N - num_rgroups_for_label;
       }
       std::vector<unsigned int> equivalentRGroupCount;
 

--- a/Code/GraphMol/RGroupDecomposition/testRGroupDecomp.cpp
+++ b/Code/GraphMol/RGroupDecomposition/testRGroupDecomp.cpp
@@ -1862,13 +1862,15 @@ void testMutipleCoreRelabellingIssues() {
       "O=C1C([*:2])([*:1])[C@@H]2N1C(C(O)=O)C([*:3])([*:4])S2",
       "O=C1C([*:2])([*:1])[C@@H]2N1C(C(O)=O)C([*:3])([*:4])O2",
       "O=C1C([*:2])([*:1])C([*:6])([*:5])N1"};
+ std::vector<RGroupScore> matchtypes{Match, FingerprintVariance};
+ for(auto match: matchtypes) {
   std::vector<ROMOL_SPTR> cores;
   for (const auto &s : smi) {
     cores.emplace_back(SmartsToMol(s));
   }
 
   RGroupDecompositionParameters params;
-  params.scoreMethod = FingerprintVariance;
+  params.scoreMethod = match;
   RGroupDecomposition decomposition(cores, params);
   for (auto &mol : molecules) {
     decomposition.add(*mol);
@@ -1880,6 +1882,7 @@ void testMutipleCoreRelabellingIssues() {
   for (auto &col : columns) {
     TEST_ASSERT(30U == col.second.size());
   }
+ }
 }
 
 void testUnprocessedMapping() {
@@ -1903,24 +1906,27 @@ void testUnprocessedMapping() {
   std::vector<std::string> coreSmi = {"N1([*:1])CCN([*:2])CC1",
                                       "C1(O[*:1])CCC(O[*:2])CC1",
                                       "C1([*:1])CCC([*:2])CC1"};
+    
+  std::vector<RGroupScore> matchtypes{Match, FingerprintVariance};
+  for(auto match: matchtypes) {
+      std::vector<ROMOL_SPTR> cores;
+      for (const auto &s : coreSmi) {
+        cores.emplace_back(SmartsToMol(s));
+      }
 
-  std::vector<ROMOL_SPTR> cores;
-  for (const auto &s : coreSmi) {
-    cores.emplace_back(SmartsToMol(s));
+      RGroupDecompositionParameters params;
+      params.scoreMethod = match;
+      RGroupDecomposition decomposition(cores, params);
+      for (auto &smi : structureSmi) {
+        auto mol = SmilesToMol(smi);
+        decomposition.add(*mol);
+        delete mol;
+      }
+
+      auto result = decomposition.processAndScore();
+      TEST_ASSERT(result.success);
+      TEST_ASSERT(result.score != -1.0);
   }
-
-  RGroupDecompositionParameters params;
-  params.scoreMethod = FingerprintVariance;
-  RGroupDecomposition decomposition(cores, params);
-  for (auto &smi : structureSmi) {
-    auto mol = SmilesToMol(smi);
-    decomposition.add(*mol);
-    delete mol;
-  }
-
-  auto result = decomposition.processAndScore();
-  TEST_ASSERT(result.success);
-  TEST_ASSERT(result.score != -1.0);
 }
 
 void testGeminalRGroups() {

--- a/Code/GraphMol/RGroupDecomposition/testRGroupInternals.cpp
+++ b/Code/GraphMol/RGroupDecomposition/testRGroupInternals.cpp
@@ -262,7 +262,7 @@ void testGeminalRGroups() {
   auto test1 = matchScore(permutation, allMatches1, labels);
   auto test2 = matchScore(permutation, allMatches2, labels);
 
-  TEST_ASSERT(test1 > test2);   // Fix Me!
+  TEST_ASSERT(test1 > test2);
 
   auto testFp1 = fingerprintVarianceScore(permutation, allMatches1, labels);
   auto testFp2 = fingerprintVarianceScore(permutation, allMatches2, labels);

--- a/Code/GraphMol/RGroupDecomposition/testRGroupInternals.cpp
+++ b/Code/GraphMol/RGroupDecomposition/testRGroupInternals.cpp
@@ -168,7 +168,7 @@ void testRingMatching3Score() {
   // expect test1 to have better score than test2 since all halogens are on R1
   // but this is not the case
 
-  TEST_ASSERT(test1 < test2); // Fix Me!
+  TEST_ASSERT(test1 > test2); 
 
   // But it is for the fingerprint score
 

--- a/Code/GraphMol/RGroupDecomposition/testRGroupInternals.cpp
+++ b/Code/GraphMol/RGroupDecomposition/testRGroupInternals.cpp
@@ -166,11 +166,8 @@ void testRingMatching3Score() {
   auto test2 = matchScore(permutation, allMatches2, labels);
 
   // expect test1 to have better score than test2 since all halogens are on R1
-  // but this is not the case
 
   TEST_ASSERT(test1 > test2); 
-
-  // But it is for the fingerprint score
 
   auto testFp1 = fingerprintVarianceScore(permutation, allMatches1, labels);
   auto testFp2 = fingerprintVarianceScore(permutation, allMatches2, labels);


### PR DESCRIPTION
The scoring function was not taking into account empty rgroups which biased certain arrangements of rgroups that didn't have an rgroup at every position.

@ptosco @jones-gareth  @greglandrum This resolves #3924 and mercifully doesn't fail any of the existing regression tests!


