### PR TITLE
Fixes #2788: kekuleSmiles=true not producing kekule SMILES

### DIFF
--- a/Code/GraphMol/Fingerprints/MHFP.cpp
+++ b/Code/GraphMol/Fingerprints/MHFP.cpp
@@ -92,13 +92,18 @@ std::vector<uint32_t> MHFPEncoder::FromArray(const std::vector<uint32_t>& vec) {
 std::vector<std::string> MHFPEncoder::CreateShingling(
     const ROMol& mol, unsigned char radius, bool rings, bool isomeric,
     bool kekulize, unsigned char min_radius) {
+  RWMol tmol(mol);
+  if (kekulize) {
+    MolOps::Kekulize(tmol);
+  }
+
   std::vector<std::string> shingling;
 
   if (rings) {
-    const VECT_INT_VECT bonds_vect = mol.getRingInfo()->bondRings();
+    const VECT_INT_VECT bonds_vect = tmol.getRingInfo()->bondRings();
 
     for (size_t i = 0; i < bonds_vect.size(); i++) {
-      std::unique_ptr<ROMol> m(Subgraphs::pathToSubmol(mol, bonds_vect[i]));
+      std::unique_ptr<ROMol> m(Subgraphs::pathToSubmol(tmol, bonds_vect[i]));
       shingling.emplace_back(MolToSmiles(*m));
     }
   }
@@ -106,7 +111,7 @@ std::vector<std::string> MHFPEncoder::CreateShingling(
   unsigned char min_radius_internal = min_radius;
 
   if (!min_radius) {
-    for (auto atom : mol.atoms()) {
+    for (auto atom : tmol.atoms()) {
       bool do_kekule = false;
       const RDKit::Bond* bond_in = nullptr;
       bool all_hs_explicit = false;
@@ -119,13 +124,13 @@ std::vector<std::string> MHFPEncoder::CreateShingling(
     min_radius_internal++;
   }
 
-  for (uint32_t index = 0; index < mol.getNumAtoms(); ++index) {
+  for (uint32_t index = 0; index < tmol.getNumAtoms(); ++index) {
     for (unsigned char r = min_radius_internal; r < radius + 1; ++r) {
-      const PATH_TYPE path = findAtomEnvironmentOfRadiusN(mol, r, index);
+      const PATH_TYPE path = findAtomEnvironmentOfRadiusN(tmol, r, index);
       INT_MAP_INT amap;
       bool use_query = false;
       std::unique_ptr<ROMol> submol(
-          Subgraphs::pathToSubmol(mol, path, use_query, amap));
+          Subgraphs::pathToSubmol(tmol, path, use_query, amap));
 
       if (amap.find(index) == amap.end()) {
         continue;
@@ -146,7 +151,7 @@ std::vector<std::string> MHFPEncoder::CreateShingling(
 std::vector<std::string> MHFPEncoder::CreateShingling(
     const std::string& smiles, unsigned char radius, bool rings, bool isomeric,
     bool kekulize, unsigned char min_radius) {
-  std::unique_ptr<ROMol> m(SmilesToMol(smiles));
+  std::unique_ptr<RWMol> m(SmilesToMol(smiles));
   PRECONDITION(m, "could not parse smiles");
   return CreateShingling(*m, radius, rings, isomeric, kekulize, min_radius);
 }

--- a/Code/GraphMol/Fingerprints/MHFP.h
+++ b/Code/GraphMol/Fingerprints/MHFP.h
@@ -91,22 +91,23 @@ public:
 
   /*!
     \brief Creates a molecular shingling based on circular substructures.
-   
+
     A molecular shingling is a vector of SMILES that were extracted from and
     represent a molecule. This method extracts substructures centered at each
     atom of the molecule with different radii. A molecule with 10 atoms will
     generate <tt>10 * 3</tt> shingles when a radius of <tt>3</tt> is chosen.
-   
+
     \param radius the maximum radius of the substructure that is generated at
           each atom. Default: <tt>3</tt>.
     \param rings whether the rings (SSSR) are extrected from the molecule and
-           added to the shingling. Given the molecule 
+           added to the shingling. Given the molecule
            <tt>"C1CCCCCC1C(=O)C"</tt>, "<tt>C1CCCCCC1"</tt> would be added
            to the shingling. Default: <tt>true</tt>.
     \param isomeric whether the SMILES added to the shingling are isomeric.
             Default: <tt>false</tt>.
     \param kekulize whether the SMILES added to the shingling are kekulized.
-            Default: <tt>true</tt>.
+            Default: <tt>true</tt>. NOTE that this will throw an exception if
+            the molecule cannot be kekulized.
     \param min_radius the minimum radius that is used to extract n-grams.
             Default: <tt>1</tt>.
 
@@ -131,22 +132,23 @@ public:
 
   /*!
     \brief Creates a MinHash vector from a molecule.
-   
+
     This methods is a wrapper around MHFPEncoder::CreateShingling and
     MHFPEncoder::FromStringArray. When a vector of molecules or SMILES is passed
     and RDKit was compiled with OpenMP, it is parallelized and will speed up by
     a factor of the number of cores.
-   
+
     \param radius the maximum radius of the substructure that is generated at
           each atom. Default: <tt>3</tt>.
     \param rings whether the rings (SSSR) are extrected from the molecule and
-           added to the shingling. Given the molecule 
+           added to the shingling. Given the molecule
            <tt>"C1CCCCCC1C(=O)C"</tt>, "<tt>C1CCCCCC1"</tt> would be added
            to the shingling. Default: <tt>true</tt>.
     \param isomeric whether the SMILES added to the shingling are isomeric.
             Default: <tt>false</tt>.
     \param kekulize whether the SMILES added to the shingling are kekulized.
-            Default: <tt>true</tt>.
+            Default: <tt>true</tt>. NOTE that this will throw an exception if
+            the molecule cannot be kekulized.
     \param min_radius the minimum radius that is used to extract n-grams.
             Default: <tt>1</tt>.
 
@@ -204,7 +206,8 @@ public:
     \param isomeric whether the SMILES added to the shingling are isomeric.
             Default: <tt>false</tt>.
     \param kekulize whether the SMILES added to the shingling are kekulized.
-            Default: <tt>true</tt>.
+            Default: <tt>true</tt>. NOTE that this will throw an exception if
+            the molecule cannot be kekulized.
     \param min_radius the minimum radius that is used to extract n-grams.
             Default: <tt>1</tt>.
     \param length the length into which the fingerprint is folded.

--- a/Code/GraphMol/Fingerprints/MHFP.h
+++ b/Code/GraphMol/Fingerprints/MHFP.h
@@ -118,7 +118,7 @@ public:
           unsigned char radius = 3,
           bool rings = true,
           bool isomeric = false,
-          bool kekulize = true,
+          bool kekulize = false,
           unsigned char min_radius = 1);
 
   //! \overload
@@ -127,7 +127,7 @@ public:
           unsigned char radius = 3,
           bool rings = true,
           bool isomeric = false,
-          bool kekulize = true,
+          bool kekulize = false,
           unsigned char min_radius = 1);
 
   /*!
@@ -159,7 +159,7 @@ public:
        unsigned char radius = 3,
        bool rings = true,
        bool isomeric = false,
-       bool kekulize = true,
+       bool kekulize = false,
        unsigned char min_radius = 1);
 
   //! \overload
@@ -168,7 +168,7 @@ public:
        unsigned char radius = 3,
        bool rings = true,
        bool isomeric = false,
-       bool kekulize = true,
+       bool kekulize = false,
        unsigned char min_radius = 1);
 
   //! \overload
@@ -177,7 +177,7 @@ public:
        unsigned char radius = 3,
        bool rings = true,
        bool isomeric = false,
-       bool kekulize = true,
+       bool kekulize = false,
        unsigned char min_radius = 1);
 
   //! \overload
@@ -186,7 +186,7 @@ public:
        unsigned char radius = 3,
        bool rings = true,
        bool isomeric = false,
-       bool kekulize = true,
+       bool kekulize = false,
        unsigned char min_radius = 1);
 
 
@@ -220,7 +220,7 @@ public:
        unsigned char radius = 3,
        bool rings = true,
        bool isomeric = false,
-       bool kekulize = true,
+       bool kekulize = false,
        unsigned char min_radius = 1,
        size_t length = 2048);
 
@@ -230,7 +230,7 @@ public:
        unsigned char radius = 3,
        bool rings = true,
        bool isomeric = false,
-       bool kekulize = true,
+       bool kekulize = false,
        unsigned char min_radius = 1,
        size_t length = 2048);
 
@@ -240,7 +240,7 @@ public:
        unsigned char radius = 3,
        bool rings = true,
        bool isomeric = false,
-       bool kekulize = true,
+       bool kekulize = false,
        unsigned char min_radius = 1,
        size_t length = 2048);
 
@@ -250,7 +250,7 @@ public:
        unsigned char radius = 3,
        bool rings = true,
        bool isomeric = false,
-       bool kekulize = true,
+       bool kekulize = false,
        unsigned char min_radius = 1,
        size_t length = 2048);
 

--- a/Code/GraphMol/Fingerprints/Wrap/MHFPWrapper.cpp
+++ b/Code/GraphMol/Fingerprints/Wrap/MHFPWrapper.cpp
@@ -198,7 +198,7 @@ BOOST_PYTHON_MODULE(rdMHFPFingerprint) {
         python::arg("radius") = 3,
         python::arg("rings") = true,
         python::arg("isomeric") = false,
-        python::arg("kekulize") = true,
+        python::arg("kekulize") = false,
         python::arg("min_radius") = 1
       ),
       "Creates a shingling (a list of circular n-grams / substructures) from a SMILES string."
@@ -209,7 +209,7 @@ BOOST_PYTHON_MODULE(rdMHFPFingerprint) {
         python::arg("radius") = 3,
         python::arg("rings") = true,
         python::arg("isomeric") = false,
-        python::arg("kekulize") = true,
+        python::arg("kekulize") = false,
         python::arg("min_radius") = 1
       ),
       "Creates a shingling (a list of circular n-grams / substructures) from a RDKit Mol instance."
@@ -220,7 +220,7 @@ BOOST_PYTHON_MODULE(rdMHFPFingerprint) {
         python::arg("radius") = 3,
         python::arg("rings") = true,
         python::arg("isomeric") = false,
-        python::arg("kekulize") = true,
+        python::arg("kekulize") = false,
         python::arg("min_radius") = 1
       ),
       "Creates a MHFP vector from a SMILES string."
@@ -231,7 +231,7 @@ BOOST_PYTHON_MODULE(rdMHFPFingerprint) {
         python::arg("radius") = 3,
         python::arg("rings") = true,
         python::arg("isomeric") = false,
-        python::arg("kekulize") = true,
+        python::arg("kekulize") = false,
         python::arg("min_radius") = 1
       ),
       "Creates a MHFP vector from an RDKit Mol instance."
@@ -242,7 +242,7 @@ BOOST_PYTHON_MODULE(rdMHFPFingerprint) {
         python::arg("radius") = 3,
         python::arg("rings") = true,
         python::arg("isomeric") = false,
-        python::arg("kekulize") = true,
+        python::arg("kekulize") = false,
         python::arg("min_radius") = 1
       ),
       "Creates a MHFP vector from a list of SMILES strings."
@@ -253,7 +253,7 @@ BOOST_PYTHON_MODULE(rdMHFPFingerprint) {
         python::arg("radius") = 3,
         python::arg("rings") = true,
         python::arg("isomeric") = false,
-        python::arg("kekulize") = true,
+        python::arg("kekulize") = false,
         python::arg("min_radius") = 1
       ),
       "Creates a MHFP vector from a list of RDKit Mol instances."
@@ -264,7 +264,7 @@ BOOST_PYTHON_MODULE(rdMHFPFingerprint) {
         python::arg("radius") = 3,
         python::arg("rings") = true,
         python::arg("isomeric") = false,
-        python::arg("kekulize") = true,
+        python::arg("kekulize") = false,
         python::arg("min_radius") = 1,
         python::arg("length") = 2048
       ),
@@ -276,7 +276,7 @@ BOOST_PYTHON_MODULE(rdMHFPFingerprint) {
         python::arg("radius") = 3,
         python::arg("rings") = true,
         python::arg("isomeric") = false,
-        python::arg("kekulize") = true,
+        python::arg("kekulize") = false,
         python::arg("min_radius") = 1,
         python::arg("length") = 2048
       ),
@@ -288,7 +288,7 @@ BOOST_PYTHON_MODULE(rdMHFPFingerprint) {
         python::arg("radius") = 3,
         python::arg("rings") = true,
         python::arg("isomeric") = false,
-        python::arg("kekulize") = true,
+        python::arg("kekulize") = false,
         python::arg("min_radius") = 1,
         python::arg("length") = 2048
       ),
@@ -300,7 +300,7 @@ BOOST_PYTHON_MODULE(rdMHFPFingerprint) {
         python::arg("radius") = 3,
         python::arg("rings") = true,
         python::arg("isomeric") = false,
-        python::arg("kekulize") = true,
+        python::arg("kekulize") = false,
         python::arg("min_radius") = 1,
         python::arg("length") = 2048
       ),

--- a/Code/GraphMol/Fingerprints/Wrap/testMHFP.py
+++ b/Code/GraphMol/Fingerprints/Wrap/testMHFP.py
@@ -13,34 +13,35 @@ import unittest
 
 
 class TestCase(unittest.TestCase):
-    def setUp(self):
-        pass
 
-    def testMHFPFingerprint(self):
-        s = "CN1C=NC2=C1C(=O)N(C(=O)N2C)C"
-        t = "Cn1cnc2c1c(=O)[nH]c(=O)n2C"
+  def setUp(self):
+    pass
 
-        m = Chem.MolFromSmiles(s)
-        enc = rdMHFPFingerprint.MHFPEncoder(128, 42)
+  def testMHFPFingerprint(self):
+    s = "CN1C=NC2=C1C(=O)N(C(=O)N2C)C"
+    t = "Cn1cnc2c1c(=O)[nH]c(=O)n2C"
 
-        self.assertEqual(len(enc.CreateShinglingFromSmiles(s, rings=False)), 42)
-        self.assertEqual(len(enc.CreateShinglingFromSmiles(s, min_radius=0)), 58)
+    m = Chem.MolFromSmiles(s)
+    enc = rdMHFPFingerprint.MHFPEncoder(128, 42)
 
-        sh_a = enc.CreateShinglingFromSmiles(s)
-        sh_b = enc.CreateShinglingFromMol(m)
+    self.assertEqual(len(enc.CreateShinglingFromSmiles(s, rings=False)), 42)
+    self.assertEqual(len(enc.CreateShinglingFromSmiles(s, min_radius=0)), 58)
 
-        self.assertEqual(len(sh_a), 44)
-        self.assertEqual(list(sh_a), list(sh_b))
+    sh_a = enc.CreateShinglingFromSmiles(s)
+    sh_b = enc.CreateShinglingFromMol(m)
 
-        fp_a = enc.EncodeSmiles(s)
-        fp_b = enc.EncodeMol(m)
+    self.assertEqual(len(sh_a), 44)
+    self.assertEqual(list(sh_a), list(sh_b))
 
-        self.assertEqual(list(fp_a), list(fp_b))
+    fp_a = enc.EncodeSmiles(s)
+    fp_b = enc.EncodeMol(m)
 
-        fp_c = enc.EncodeSmiles(t)
-        dist = rdMHFPFingerprint.MHFPEncoder.Distance(fp_a, fp_c)
-        self.assertEqual(dist, 0.2890625)
+    self.assertEqual(list(fp_a), list(fp_b))
+
+    fp_c = enc.EncodeSmiles(t)
+    dist = rdMHFPFingerprint.MHFPEncoder.Distance(fp_a, fp_c)
+    self.assertEqual(dist, 0.4609375)
 
 
 if __name__ == "__main__":
-    unittest.main()
+  unittest.main()

--- a/Code/GraphMol/SmilesParse/SmilesWrite.cpp
+++ b/Code/GraphMol/SmilesParse/SmilesWrite.cpp
@@ -303,6 +303,9 @@ std::string FragmentSmilesConstruct(
                "bad atomSymbols");
   PRECONDITION(!bondSymbols || bondSymbols->size() >= mol.getNumBonds(),
                "bad bondSymbols");
+  if (doKekule) {
+    MolOps::Kekulize(static_cast<RWMol &>(mol));
+  }
 
   Canon::MolStack molStack;
   // try to prevent excessive reallocation
@@ -503,7 +506,6 @@ std::string MolToSmiles(const ROMol &mol, bool doIsomericSmiles, bool doKekule,
       }
     }
     CHECK_INVARIANT(nextAtomIdx >= 0, "no start atom found");
-
     subSmi = SmilesWrite::FragmentSmilesConstruct(
         *tmol, nextAtomIdx, colors, ranks, doKekule, canonical,
         doIsomericSmiles, allBondsExplicit, allHsExplicit, doRandom,

--- a/Code/GraphMol/SmilesParse/SmilesWrite.h
+++ b/Code/GraphMol/SmilesParse/SmilesWrite.h
@@ -62,7 +62,10 @@ RDKIT_SMILESPARSE_EXPORT std::string GetBondSmiles(
   \param mol : the molecule in question.
   \param doIsomericSmiles : include stereochemistry and isotope information
       in the SMILES
-  \param doKekule : do Kekule smiles (i.e. don't use aromatic bonds)
+
+  \param doKekule : do Kekule smiles (i.e. don't use aromatic bonds) NOTE that
+      this will throw an exception if the molecule cannot be kekulized.
+
   \param rootedAtAtom : make sure the SMILES starts at the specified atom.
       The resulting SMILES is not, of course, canonical.
   \param canonical : if false, no attempt will be made to canonicalize the

--- a/Code/GraphMol/SmilesParse/catch_tests.cpp
+++ b/Code/GraphMol/SmilesParse/catch_tests.cpp
@@ -815,3 +815,39 @@ TEST_CASE("Hydrogen bonds", "[smiles]") {
           Bond::BondType::HYDROGEN);
   }
 }
+
+TEST_CASE("Github #2788: doKekule=true should kekulize the molecule",
+          "[smiles]") {
+  SECTION("basics1") {
+    auto m = "c1ccccc1"_smiles;
+    REQUIRE(m);
+    bool doIsomeric = true;
+    bool doKekule = true;
+    CHECK(MolToSmiles(*m, doIsomeric, doKekule) == "C1=CC=CC=C1");
+  }
+  SECTION("basics2") {
+    auto m = "c1cc[nH]c1"_smiles;
+    REQUIRE(m);
+    bool doIsomeric = true;
+    bool doKekule = true;
+    CHECK(MolToSmiles(*m, doIsomeric, doKekule) == "C1=CNC=C1");
+  }
+
+  SECTION("can thrown exceptions") {
+    int debugParse = 0;
+    bool sanitize = false;
+    std::unique_ptr<RWMol> m{SmilesToMol("c1ccnc1", debugParse, sanitize)};
+    REQUIRE(m);
+    bool doIsomeric = true;
+    bool doKekule = false;
+    {
+      RWMol tm(*m);
+      CHECK(MolToSmiles(tm, doIsomeric, doKekule) == "c1ccnc1");
+    }
+    doKekule = true;
+    {
+      RWMol tm(*m);
+      CHECK_THROWS_AS(MolToSmiles(tm, doIsomeric, doKekule), KekulizeException);
+    }
+  }
+}

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -18,7 +18,15 @@
 - There have been numerous changes to the RGroup Decomposition code which change
   the results. (#3767)
 - There have been numerous changes to `GenerateDepictionMatching2DStructure()` (#3811)
-
+- Setting the kekuleSmiles argument (doKekule in C++) to MolToSmiles will now
+  cause the molecule to be kekulized before SMILES generation. Note that this
+  can lead to an exception being thrown. Previously this argument would only
+  write kekulized SMILES if the molecule had already been kekulized (#2788)
+- Using the kekulize argument in the MHFP code will now cause the molecule to be
+  kekulized before the fingerprint is generated. Note that becaues kekulization
+  is not canonical, using this argument currently causes the results to depend
+  on the input atom numbering. Note that this can lead to an exception being
+  thrown. (#3942)
 
 # Release_2020.09.1
 (Changes relative to Release_2020.03.1)


### PR DESCRIPTION
There's more detail in the discussion of #2788, but the short form is that we now explicitly kekulize molecules in the SMILES writing code if asked to generate Kekule SMILES.

Fixing this also exposed #3942, so I fix that in this PR as well.