### PR TITLE
Remove temporary labels from RGD results

### DIFF
--- a/Code/GraphMol/RGroupDecomposition/RGroupDecompData.h
+++ b/Code/GraphMol/RGroupDecomposition/RGroupDecompData.h
@@ -328,12 +328,8 @@ struct RGroupDecompData {
     addAtoms(core, atomsToAdd);
     for (const auto &rlabels : atoms) {
       auto atom = rlabels.second;
-      if (atom->hasProp(RLABEL)) {
-        atom->clearProp(RLABEL);
-      }
-      if (atom->hasProp(RLABEL_TYPE)) {
-        atom->clearProp(RLABEL_TYPE);
-      }
+      atom->clearProp(RLABEL);
+      atom->clearProp(RLABEL_TYPE);
     }
     core.updatePropertyCache(false);  // this was github #1550
   }

--- a/Code/GraphMol/RGroupDecomposition/RGroupDecompData.h
+++ b/Code/GraphMol/RGroupDecomposition/RGroupDecompData.h
@@ -257,7 +257,7 @@ struct RGroupDecompData {
     std::vector<std::pair<Atom *, Atom *>> atomsToAdd;  // adds -R if necessary
 
     // Deal with user supplied labels
-    for (auto rlabels : atoms) {
+    for (const auto &rlabels : atoms) {
       int userLabel = rlabels.first;
       if (userLabel < 0) {
         continue;  // not a user specified label
@@ -326,6 +326,15 @@ struct RGroupDecompData {
     }
 
     addAtoms(core, atomsToAdd);
+    for (const auto &rlabels : atoms) {
+      auto atom = rlabels.second;
+      if (atom->hasProp(RLABEL)) {
+        atom->clearProp(RLABEL);
+      }
+      if (atom->hasProp(RLABEL_TYPE)) {
+        atom->clearProp(RLABEL_TYPE);
+      }
+    }
     core.updatePropertyCache(false);  // this was github #1550
   }
 
@@ -399,6 +408,10 @@ struct RGroupDecompData {
         atom->setAtomicNum(
             rLabelCoreIndexToAtomicWt[atom->getProp<int>(RLABEL_CORE_INDEX)]);
         atom->setNoImplicit(true);
+        atom->clearProp(RLABEL_CORE_INDEX);
+      }
+      if (atom->hasProp(SIDECHAIN_RLABELS)) {
+        atom->clearProp(SIDECHAIN_RLABELS);
       }
     }
 

--- a/Code/GraphMol/RGroupDecomposition/RGroupDecompData.h
+++ b/Code/GraphMol/RGroupDecomposition/RGroupDecompData.h
@@ -406,9 +406,7 @@ struct RGroupDecompData {
         atom->setNoImplicit(true);
         atom->clearProp(RLABEL_CORE_INDEX);
       }
-      if (atom->hasProp(SIDECHAIN_RLABELS)) {
-        atom->clearProp(SIDECHAIN_RLABELS);
-      }
+      atom->clearProp(SIDECHAIN_RLABELS);
     }
 
 #ifdef VERBOSE

--- a/Code/GraphMol/RGroupDecomposition/RGroupScore.cpp
+++ b/Code/GraphMol/RGroupDecomposition/RGroupScore.cpp
@@ -143,7 +143,9 @@ double matchScore(const std::vector<size_t> &permutation,
 #endif
   }
 
+#ifdef DEBUG
   BOOST_LOG(rdDebugLog) << score << std::endl;
+#endif
 
   return score;
 }

--- a/Code/GraphMol/RGroupDecomposition/testRGroupDecomp.cpp
+++ b/Code/GraphMol/RGroupDecomposition/testRGroupDecomp.cpp
@@ -2182,6 +2182,29 @@ void testUnlabelledRGroupsOnAromaticNitrogen() {
   }
 }
 
+void testNoTempLabels() {
+  BOOST_LOG(rdInfoLog)
+      << "********************************************************\n";
+  BOOST_LOG(rdInfoLog) << "Test that temp labels are removed from results"
+                       << std::endl;
+  auto core = "[1*]c1ccccc1"_smiles;
+  auto mol = "Cc1ccccc1"_smiles;
+  RGroupDecompositionParameters params;
+  RGroupDecomposition decomp(*core, params);
+  TEST_ASSERT(decomp.add(*mol) == 0);
+  TEST_ASSERT(decomp.process());
+  auto rows = decomp.getRGroupsAsRows();
+  TEST_ASSERT(rows.size() == 1);
+  const auto &res = rows.front();
+  for (const auto &pair : res) {
+    for (const auto a : pair.second->atoms()) {
+      for (const auto &propName : a->getPropList()) {
+        TEST_ASSERT(propName.find("label") == std::string::npos);
+      }
+    }
+  }
+}
+
 int main() {
   RDLog::InitLogs();
   boost::logging::disable_logs("rdApp.debug");
@@ -2225,6 +2248,7 @@ int main() {
   testNoAlignmentAndSymmetry();
   testUserMatchTypes();
   testUnlabelledRGroupsOnAromaticNitrogen();
+  testNoTempLabels();
 
   BOOST_LOG(rdInfoLog)
       << "********************************************************\n";


### PR DESCRIPTION
- remove temp labels from RGD results
- remove a debug printout in non-debug builds
