### PR TITLE
Fixes #3938

### DIFF
--- a/Code/GraphMol/FMCS/Graph.h
+++ b/Code/GraphMol/FMCS/Graph.h
@@ -11,7 +11,9 @@
 // graph topology in terms of indices in source molecule
 #include <RDGeneral/export.h>
 #pragma once
+#include <RDGeneral/BoostStartInclude.h>
 #include <boost/graph/adjacency_list.hpp>
+#include <RDGeneral/BoostEndInclude.h>
 
 namespace RDKit {
 namespace FMCS {

--- a/Code/GraphMol/FMCS/MaximumCommonSubgraph.cpp
+++ b/Code/GraphMol/FMCS/MaximumCommonSubgraph.cpp
@@ -18,7 +18,9 @@
 #include "../Substruct/SubstructMatch.h"
 #include "SubstructMatchCustom.h"
 #include "MaximumCommonSubgraph.h"
+#include <RDGeneral/BoostStartInclude.h>
 #include <boost/graph/adjacency_list.hpp>
+#include <RDGeneral/BoostEndInclude.h>
 
 namespace RDKit {
 namespace FMCS {
@@ -389,7 +391,9 @@ void MaximumCommonSubgraph::makeInitialSeeds() {
       }
     }
     if (Seeds.empty()) {
-      BOOST_LOG(rdWarningLog) << "The provided InitialSeed is not an MCS and will be ignored" << std::endl;
+      BOOST_LOG(rdWarningLog)
+          << "The provided InitialSeed is not an MCS and will be ignored"
+          << std::endl;
     }
   }
   if (Seeds.empty()) {  // create a set of seeds from each query bond

--- a/Code/RDGeneral/BoostEndInclude.h
+++ b/Code/RDGeneral/BoostEndInclude.h
@@ -32,7 +32,6 @@
 //  #include <RDGeneral/BoostStartInclude.h>
 //  # include boost stuff
 //  #include <RDGeneral/BoostEndInclude.h>
-
 #include <RDGeneral/export.h>
 #if defined(__clang__)
 /* Clang/LLVM. ---------------------------------------------- */
@@ -62,4 +61,9 @@
 #elif defined(__SUNPRO_C) || defined(__SUNPRO_CC)
 /* Oracle Solaris Studio. ----------------------------------- */
 
+#endif
+
+#ifdef RDK_ALLOW_BOOST_DEPRECATED_HEADERS
+#undef RDK_ALLOW_BOOST_DEPRECATED_HEADERS
+#undef BOOST_ALLOW_DEPRECATED_HEADERS
 #endif

--- a/Code/RDGeneral/BoostStartInclude.h
+++ b/Code/RDGeneral/BoostStartInclude.h
@@ -88,3 +88,8 @@
 /* Oracle Solaris Studio. ----------------------------------- */
 
 #endif
+
+#ifndef BOOST_ALLOW_DEPRECATED_HEADERS
+#define RDK_ALLOW_BOOST_DEPRECATED_HEADERS
+#define BOOST_ALLOW_DEPRECATED_HEADERS
+#endif

--- a/Code/RDGeneral/utils.h
+++ b/Code/RDGeneral/utils.h
@@ -15,9 +15,7 @@
 #include "types.h"
 #include <RDGeneral/Invariant.h>
 #include <RDGeneral/BoostStartInclude.h>
-#define BOOST_ALLOW_DEPRECATED_HEADERS
 #include <boost/random.hpp>
-#undef BOOST_ALLOW_DEPRECATED_HEADERS
 #include <RDGeneral/BoostEndInclude.h>
 
 namespace RDKit {


### PR DESCRIPTION
suppress boost deprecated header warnings inside `BoostStartInclude`
broaden use of BoostStartInclude
