### PR TITLE
Allow three-coordinate bridgehead N to be chiral.

### DIFF
--- a/Code/GraphMol/catch_chirality.cpp
+++ b/Code/GraphMol/catch_chirality.cpp
@@ -1284,3 +1284,38 @@ TEST_CASE(
     }
   }
 }
+
+TEST_CASE("N Chirality in rings") {
+  SECTION("basics 4 coordinate") {
+    {
+      auto mol = "CC1CC2CC[N@@+]1(C)OC2"_smiles;
+      REQUIRE(mol);
+      CHECK(mol->getAtomWithIdx(6)->getAtomicNum() == 7);
+      CHECK(mol->getAtomWithIdx(6)->getChiralTag() !=
+            Atom::ChiralType::CHI_UNSPECIFIED);
+    }
+    {
+      auto mol = "C[N@@+](F)(Cl)O"_smiles;
+      REQUIRE(mol);
+      CHECK(mol->getAtomWithIdx(1)->getAtomicNum() == 7);
+      CHECK(mol->getAtomWithIdx(1)->getChiralTag() !=
+            Atom::ChiralType::CHI_UNSPECIFIED);
+    }
+  }
+  SECTION("basics 3 coordinate") {
+    {
+      auto mol = "CC1CC2CC[N@@]1OC2"_smiles;
+      REQUIRE(mol);
+      CHECK(mol->getAtomWithIdx(6)->getAtomicNum() == 7);
+      CHECK(mol->getAtomWithIdx(6)->getChiralTag() !=
+            Atom::ChiralType::CHI_UNSPECIFIED);
+    }
+    {
+      auto mol = "C1CC[N@]2OCCCC2C1"_smiles;
+      REQUIRE(mol);
+      CHECK(mol->getAtomWithIdx(3)->getAtomicNum() == 7);
+      CHECK(mol->getAtomWithIdx(3)->getChiralTag() ==
+            Atom::ChiralType::CHI_UNSPECIFIED);
+    }
+  }
+}

--- a/Docs/Book/RDKit_Book.rst
+++ b/Docs/Book/RDKit_Book.rst
@@ -545,8 +545,10 @@ The following atom types are potential tetrahedral stereogenic atoms:
   - atoms with degree 4
   - atoms with degree 3 and one implicit H
   - P or As with degree 3 or 4
-  - N with degree 3 which is in a ring of size 3
-  - S or Se with degree 3 and a total valence of 4 or a total valence of 3 and a net charge of +1.
+  - N with degree 3 which is in a ring of size 3 or which is shared between at
+    least 3 rings (this last condition is an extension to the InChI rules) 
+  - S or Se with degree 3 and a total valence of 4 or a total valence of 3 and a
+    net charge of +1.
 
 
 Brief description of the ``findPotentialStereo()`` algorithm


### PR DESCRIPTION
This is a followup from #3632

This deviates from the idea of directly following the InChI recommendations, but I think it makes sense to allow these structures to be chiral:
![image](https://user-images.githubusercontent.com/540511/111963370-bac39d00-8af3-11eb-92ad-e4d89ec73500.png)

FWIW: this is what the RDKit did up until #3632 was merged