### PR TITLE
Fix definition of bridgehead stereo

### DIFF
--- a/Code/GraphMol/Chirality.cpp
+++ b/Code/GraphMol/Chirality.cpp
@@ -1194,7 +1194,7 @@ bool atomIsCandidateForRingStereochem(const ROMol &mol, const Atom *atom) {
       //   in a ring of size 3  (from InChI)
       // OR
       //   a bridgehead, i.e. shared by more than 2 rings (RDKit extension)
-      if (atom->getAtomicNum() == 7 &&
+      if (atom->getAtomicNum() == 7 && atom->getDegree() == 3 &&
           !ringInfo->isAtomInRingOfSize(atom->getIdx(), 3) &&
           ringInfo->numAtomRings(atom->getIdx()) <= 2) {
         return false;

--- a/Code/GraphMol/Chirality.cpp
+++ b/Code/GraphMol/Chirality.cpp
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2004-2018 Greg Landrum and Rational Discovery LLC
+//  Copyright (C) 2004-2021 Greg Landrum and Rational Discovery LLC
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -10,6 +10,7 @@
 #include <GraphMol/RDKitBase.h>
 #include <RDGeneral/Ranking.h>
 #include <GraphMol/new_canon.h>
+#include <GraphMol/QueryOps.h>
 #include <RDGeneral/types.h>
 #include <sstream>
 #include <set>
@@ -1193,10 +1194,10 @@ bool atomIsCandidateForRingStereochem(const ROMol &mol, const Atom *atom) {
       // three-coordinate N additional requirements:
       //   in a ring of size 3  (from InChI)
       // OR
-      //   a bridgehead, i.e. shared by more than 2 rings (RDKit extension)
+      //   a bridgehead (RDKit extension)
       if (atom->getAtomicNum() == 7 && atom->getDegree() == 3 &&
           !ringInfo->isAtomInRingOfSize(atom->getIdx(), 3) &&
-          ringInfo->numAtomRings(atom->getIdx()) <= 2) {
+          !queryIsAtomBridgehead(atom)) {
         return false;
       }
       ROMol::OEDGE_ITER beg, end;
@@ -1420,9 +1421,9 @@ std::pair<bool, bool> isAtomPotentialChiralCenter(
         // three-coordinate N additional requirements:
         //   in a ring of size 3  (from InChI)
         // OR
-        //   a bridgehead, i.e. shared by more than 2 rings (RDKit extension)
+        /// is a bridgehead atom (RDKit extension)
         if (mol.getRingInfo()->isAtomInRingOfSize(atom->getIdx(), 3) ||
-            mol.getRingInfo()->numAtomRings(atom->getIdx()) > 2) {
+            queryIsAtomBridgehead(atom)) {
           legalCenter = true;
         }
       } else if (atom->getAtomicNum() == 15 || atom->getAtomicNum() == 33) {

--- a/Code/GraphMol/QueryOps.cpp
+++ b/Code/GraphMol/QueryOps.cpp
@@ -34,17 +34,15 @@ int queryIsAtomBridgehead(Atom const *at) {
   if (!ri || !ri->isInitialized()) {
     return 0;
   }
-  // track which bonds involve this atom and how many ring bonds we have;
-  unsigned int nRingBonds = 0;
+  // track which bonds involve this atom
   boost::dynamic_bitset<> atomRingBonds(mol.getNumBonds());
   for (const auto &nbri : boost::make_iterator_range(mol.getAtomBonds(at))) {
     const auto &bnd = mol[nbri];
     if (ri->numBondRings(bnd->getIdx())) {
       atomRingBonds.set(bnd->getIdx());
-      ++nRingBonds;
     }
   }
-  if (nRingBonds < 3) {
+  if (atomRingBonds.count() < 3) {
     return 0;
   }
 
@@ -64,7 +62,7 @@ int queryIsAtomBridgehead(Atom const *at) {
     }
     for (unsigned int j = i + 1; j < ri->bondRings().size(); ++j) {
       unsigned int overlap = 0;
-      bool atomInRingJ;
+      bool atomInRingJ = false;
       for (const auto bidx : ri->bondRings()[j]) {
         if (atomRingBonds[bidx]) {
           atomInRingJ = true;
@@ -407,6 +405,13 @@ ATOM_EQUALS_QUERY *makeAtomMissingChiralTagQuery() {
 ATOM_EQUALS_QUERY *makeAtomInRingQuery() {
   auto *res = makeAtomSimpleQuery<ATOM_EQUALS_QUERY>(true, queryIsAtomInRing);
   res->setDescription("AtomInRing");
+  return res;
+}
+
+ATOM_EQUALS_QUERY *makeAtomIsBridgeheadQuery() {
+  auto *res =
+      makeAtomSimpleQuery<ATOM_EQUALS_QUERY>(true, queryIsAtomBridgehead);
+  res->setDescription("AtomIsBridgehead");
   return res;
 }
 

--- a/Code/GraphMol/QueryOps.h
+++ b/Code/GraphMol/QueryOps.h
@@ -293,6 +293,8 @@ static inline int queryAtomHasRingBond(Atom const *at) {
   }
   return 0;
 };
+RDKIT_GRAPHMOL_EXPORT int queryIsAtomBridgehead(Atom const *at);
+
 static inline int queryIsBondInRing(Bond const *bond) {
   return bond->getOwningMol().getRingInfo()->numBondRings(bond->getIdx()) != 0;
 };
@@ -545,8 +547,8 @@ template <class T>
 T *makeAtomInRingQuery(const std::string &descr) {
   return makeAtomSimpleQuery<T>(true, queryIsAtomInRing, descr);
 }
-RDKIT_GRAPHMOL_EXPORT ATOM_EQUALS_QUERY *makeAtomInRingQuery();
 //! \overload
+RDKIT_GRAPHMOL_EXPORT ATOM_EQUALS_QUERY *makeAtomInRingQuery();
 
 //! returns a Query for matching atoms in a particular number of rings
 template <class T>
@@ -644,6 +646,14 @@ T *makeAtomNonHydrogenDegreeQuery(int what, const std::string &descr) {
 //! \overload
 RDKIT_GRAPHMOL_EXPORT ATOM_EQUALS_QUERY *makeAtomNonHydrogenDegreeQuery(
     int what);
+
+//! returns a Query for matching bridgehead atoms
+template <class T>
+T *makeAtomIsBridgeheadQuery(const std::string &descr) {
+  return makeAtomSimpleQuery<T>(true, queryIsAtomBridgehead, descr);
+}
+//! \overload
+RDKIT_GRAPHMOL_EXPORT ATOM_EQUALS_QUERY *makeAtomIsBridgeheadQuery();
 
 //! returns a Query for matching bond orders
 RDKIT_GRAPHMOL_EXPORT BOND_EQUALS_QUERY *makeBondOrderEqualsQuery(

--- a/Code/GraphMol/catch_chirality.cpp
+++ b/Code/GraphMol/catch_chirality.cpp
@@ -1356,5 +1356,20 @@ TEST_CASE("N Chirality in rings") {
       CHECK(mol->getAtomWithIdx(4)->getChiralTag() !=
             Atom::ChiralType::CHI_UNSPECIFIED);
     }
+    {  // CHEMBL79374
+      std::cerr << "--------------------------" << std::endl;
+      auto mol = "Cn1ncc([C@]23CC[N@](CC2)C3)n1"_smiles;
+      REQUIRE(mol);
+      CHECK(mol->getAtomWithIdx(8)->getAtomicNum() == 7);
+      CHECK(mol->getAtomWithIdx(8)->getChiralTag() !=
+            Atom::ChiralType::CHI_UNSPECIFIED);
+    }
+    {  // derived from CHEMBL79374
+      auto mol = "Cn1ncc([C@]23CC[C@](CC2)C3)n1"_smiles;
+      REQUIRE(mol);
+      CHECK(mol->getAtomWithIdx(8)->getAtomicNum() == 6);
+      CHECK(mol->getAtomWithIdx(8)->getChiralTag() !=
+            Atom::ChiralType::CHI_UNSPECIFIED);
+    }
   }
 }

--- a/Code/GraphMol/catch_chirality.cpp
+++ b/Code/GraphMol/catch_chirality.cpp
@@ -1318,4 +1318,43 @@ TEST_CASE("N Chirality in rings") {
             Atom::ChiralType::CHI_UNSPECIFIED);
     }
   }
+  SECTION("ring stereo") {
+    {  // real chirality
+      auto mol = "C[C@H]1CC[N@@+](C)(O)OC1"_smiles;
+      REQUIRE(mol);
+      CHECK(mol->getAtomWithIdx(4)->getAtomicNum() == 7);
+      CHECK(mol->getAtomWithIdx(4)->getChiralTag() !=
+            Atom::ChiralType::CHI_UNSPECIFIED);
+      CHECK(mol->getAtomWithIdx(1)->getAtomicNum() == 6);
+      CHECK(mol->getAtomWithIdx(1)->getChiralTag() !=
+            Atom::ChiralType::CHI_UNSPECIFIED);
+    }
+    {  // ring stereo
+      auto mol = "C[C@H]1CC[N@@+](C)(O)CC1"_smiles;
+      REQUIRE(mol);
+      CHECK(mol->getAtomWithIdx(4)->getAtomicNum() == 7);
+      CHECK(mol->getAtomWithIdx(4)->getChiralTag() !=
+            Atom::ChiralType::CHI_UNSPECIFIED);
+      CHECK(mol->getAtomWithIdx(1)->getAtomicNum() == 6);
+      CHECK(mol->getAtomWithIdx(1)->getChiralTag() !=
+            Atom::ChiralType::CHI_UNSPECIFIED);
+    }
+    {  // ring stereo
+      auto mol = "C[C@H]1CC[N@@+](C)(O)CC1"_smiles;
+      REQUIRE(mol);
+      CHECK(mol->getAtomWithIdx(4)->getAtomicNum() == 7);
+      CHECK(mol->getAtomWithIdx(4)->getChiralTag() !=
+            Atom::ChiralType::CHI_UNSPECIFIED);
+      CHECK(mol->getAtomWithIdx(1)->getAtomicNum() == 6);
+      CHECK(mol->getAtomWithIdx(1)->getChiralTag() !=
+            Atom::ChiralType::CHI_UNSPECIFIED);
+    }
+    {  // three-ring degree-three ring stereo
+      auto mol = "C[C@H]1[C@@H](C)[N@]1C"_smiles;
+      REQUIRE(mol);
+      CHECK(mol->getAtomWithIdx(4)->getAtomicNum() == 7);
+      CHECK(mol->getAtomWithIdx(4)->getChiralTag() !=
+            Atom::ChiralType::CHI_UNSPECIFIED);
+    }
+  }
 }

--- a/Code/GraphMol/catch_chirality.cpp
+++ b/Code/GraphMol/catch_chirality.cpp
@@ -1339,16 +1339,6 @@ TEST_CASE("N Chirality in rings") {
       CHECK(mol->getAtomWithIdx(1)->getChiralTag() !=
             Atom::ChiralType::CHI_UNSPECIFIED);
     }
-    {  // ring stereo
-      auto mol = "C[C@H]1CC[N@@+](C)(O)CC1"_smiles;
-      REQUIRE(mol);
-      CHECK(mol->getAtomWithIdx(4)->getAtomicNum() == 7);
-      CHECK(mol->getAtomWithIdx(4)->getChiralTag() !=
-            Atom::ChiralType::CHI_UNSPECIFIED);
-      CHECK(mol->getAtomWithIdx(1)->getAtomicNum() == 6);
-      CHECK(mol->getAtomWithIdx(1)->getChiralTag() !=
-            Atom::ChiralType::CHI_UNSPECIFIED);
-    }
     {  // three-ring degree-three ring stereo
       auto mol = "C[C@H]1[C@@H](C)[N@]1C"_smiles;
       REQUIRE(mol);

--- a/Code/GraphMol/catch_graphmol.cpp
+++ b/Code/GraphMol/catch_graphmol.cpp
@@ -1865,3 +1865,40 @@ TEST_CASE("github #3912: cannot draw atom lists from SMARTS", "[query][bug]") {
     CHECK(vals == std::vector<int>{7, 8});
   }
 }
+
+TEST_CASE("bridgehead queries", "[query]") {
+  SECTION("basics") {
+    {
+      auto m = "CC12CCN(CC1)C2"_smiles;
+      REQUIRE(m);
+      for (const auto atom : m->atoms()) {
+        auto test = queryIsAtomBridgehead(atom);
+        if (atom->getIdx() == 1 || atom->getIdx() == 4) {
+          CHECK(test == true);
+        } else {
+          CHECK(test == false);
+        }
+      }
+    }
+    {
+      auto m = "CC12CCC(C)(CC1)CC2"_smiles;
+      REQUIRE(m);
+      for (const auto atom : m->atoms()) {
+        auto test = queryIsAtomBridgehead(atom);
+        if (atom->getIdx() == 1 || atom->getIdx() == 4) {
+          CHECK(test == true);
+        } else {
+          CHECK(test == false);
+        }
+      }
+    }
+    {  // no bridgehead
+      auto m = "C1CCC2CCCCC2C1"_smiles;
+      REQUIRE(m);
+      for (const auto atom : m->atoms()) {
+        auto test = queryIsAtomBridgehead(atom);
+        CHECK(test == false);
+      }
+    }
+  }
+}


### PR DESCRIPTION
The simple definition of bridgehead stereo used in #3958 is a bit too simple.
We required three bonds which are each in at least two rings, but this doesn't work for things like this:
![image](https://user-images.githubusercontent.com/540511/112191226-18e0a500-8c06-11eb-9588-568d2e2714c5.png)
where only two rings are found.

This PR adds a new query operation with (I think) a more reasonable definition of what a bridgehead atom is:
```
  // at least three ring bonds, at least one ring bond in a ring which shares at
  // least two bonds with another ring involving this atom
```