### PR TITLE
Do not add unnecessary R-labels (and an optimization)

### DIFF
--- a/Code/GraphMol/RGroupDecomposition/RGroupDecomp.cpp
+++ b/Code/GraphMol/RGroupDecomposition/RGroupDecomp.cpp
@@ -161,6 +161,9 @@ int RGroupDecomposition::add(const ROMol &inmol) {
         global_min_heavy_nbrs = min_heavy_nbrs;
         rcore = &core.second;
         core_idx = core.first;
+        if (global_min_heavy_nbrs == 0) {
+          break;
+        }
       }
     } else if (!tmatches_filtered.empty()) {
       rcore = &core.second;

--- a/Code/GraphMol/RGroupDecomposition/RGroupDecomp.cpp
+++ b/Code/GraphMol/RGroupDecomposition/RGroupDecomp.cpp
@@ -89,8 +89,12 @@ int RGroupDecomposition::add(const ROMol &inmol) {
   int core_idx = 0;
   const RCore *rcore = nullptr;
   std::vector<MatchVectType> tmatches;
+  std::vector<MatchVectType> tmatches_filtered;
 
-  // Find the first matching core.
+  // Find the first matching core (onlyMatchAtRGroups)
+  // or the first core that requires the smallest number
+  // of newly added labels
+  int global_min_heavy_nbrs = -1;
   for (const auto &core : data->cores) {
     {
       const bool uniquify = false;
@@ -99,62 +103,81 @@ int RGroupDecomposition::add(const ROMol &inmol) {
       SubstructMatch(mol, *core.second.core, tmatches, uniquify,
                      recursionPossible, useChirality);
     }
+    if (tmatches.empty()) {
+      continue;
+    }
 
-    if (data->params.onlyMatchAtRGroups) {
-      std::vector<MatchVectType> tmatches_filtered;
-      for (auto &mv : tmatches) {
-        bool passes_filter = true;
-        boost::dynamic_bitset<> target_match_indices(mol.getNumAtoms());
-        for (auto &match : mv) {
-          target_match_indices[match.second] = 1;
-        }
+    std::vector<int> tmatches_heavy_nbrs(tmatches.size(), 0);
+    size_t i = 0;
+    for (const auto &mv : tmatches) {
+      bool passes_filter = data->params.onlyMatchAtRGroups;
+      boost::dynamic_bitset<> target_match_indices(mol.getNumAtoms());
+      for (const auto &match : mv) {
+        target_match_indices[match.second] = 1;
+      }
 
-        for (auto &match : mv) {
-          const Atom *atm = mol.getAtomWithIdx(match.second);
-          // is this a labelled rgroup or not?
-          if (core.second.core_atoms_with_user_labels.find(match.first) ==
-              core.second.core_atoms_with_user_labels.end()) {
-            // nope... if any neighbor is not part of the substructure
-            //  make sure we are a hydrogen, otherwise, skip the match
-            for (const auto &nbri :
-                 boost::make_iterator_range(mol.getAtomNeighbors(atm))) {
-              const auto &nbr = mol[nbri];
-              if (nbr->getAtomicNum() != 1 &&
-                  !target_match_indices[nbr->getIdx()]) {
+      for (const auto &match : mv) {
+        const Atom *atm = mol.getAtomWithIdx(match.second);
+        // is this a labelled rgroup or not?
+        if (!core.second.isCoreAtomUserLabelled(match.first)) {
+          // nope... if any neighbor is not part of the substructure
+          //  make sure we are a hydrogen, otherwise, skip the match
+          for (const auto &nbri :
+               boost::make_iterator_range(mol.getAtomNeighbors(atm))) {
+            const auto &nbr = mol[nbri];
+            if (nbr->getAtomicNum() != 1 &&
+                !target_match_indices[nbr->getIdx()]) {
+              if (data->params.onlyMatchAtRGroups) {
                 passes_filter = false;
                 break;
+              } else {
+                ++tmatches_heavy_nbrs[i];
               }
             }
           }
-          if (!passes_filter) {
-            break;
-          }
         }
-
-        if (passes_filter) {
-          tmatches_filtered.push_back(mv);
+        if (!passes_filter && data->params.onlyMatchAtRGroups) {
+          break;
         }
       }
-      tmatches = tmatches_filtered;
+      if (passes_filter) {
+        tmatches_filtered.push_back(mv);
+      }
+      ++i;
     }
-
-    if (tmatches.empty()) {
-      continue;
-    } else {
-      if (tmatches.size() > 1) {
-        if (data->params.matchingStrategy == NoSymmetrization) {
-          tmatches.resize(1);
-        } else if (data->matches.size() == 0) {
-          // Greedy strategy just grabs the first match and
-          //  takes the best matches from the rest
-          if (data->params.matchingStrategy == Greedy) {
-            tmatches.resize(1);
+    if (!data->params.onlyMatchAtRGroups) {
+      int min_heavy_nbrs = *std::min_element(tmatches_heavy_nbrs.begin(),
+                                             tmatches_heavy_nbrs.end());
+      if (global_min_heavy_nbrs == -1 ||
+          min_heavy_nbrs < global_min_heavy_nbrs) {
+        i = 0;
+        tmatches_filtered.clear();
+        for (const auto heavy_nbrs : tmatches_heavy_nbrs) {
+          if (heavy_nbrs <= min_heavy_nbrs) {
+            tmatches_filtered.push_back(std::move(tmatches[i]));
           }
+          ++i;
         }
+        global_min_heavy_nbrs = min_heavy_nbrs;
+        rcore = &core.second;
+        core_idx = core.first;
       }
+    } else if (!tmatches_filtered.empty()) {
       rcore = &core.second;
       core_idx = core.first;
       break;
+    }
+  }
+  tmatches = std::move(tmatches_filtered);
+  if (tmatches.size() > 1) {
+    if (data->params.matchingStrategy == NoSymmetrization) {
+      tmatches.resize(1);
+    } else if (data->matches.size() == 0) {
+      // Greedy strategy just grabs the first match and
+      //  takes the best matches from the rest
+      if (data->params.matchingStrategy == Greedy) {
+        tmatches.resize(1);
+      }
     }
   }
 
@@ -175,7 +198,7 @@ int RGroupDecomposition::add(const ROMol &inmol) {
   std::vector<RGroupMatch> potentialMatches;
 
   std::unique_ptr<ROMol> tMol;
-  for (auto &tmatche : tmatches) {
+  for (const auto &tmatche : tmatches) {
     const bool replaceDummies = false;
     const bool labelByIndex = true;
     const bool requireDummyMatch = false;
@@ -274,8 +297,7 @@ int RGroupDecomposition::add(const ROMol &inmol) {
               int core_idx = 0;
               if (newcore == data->newCores.end()) {
                 core_idx = data->newCores[newCoreSmi] = data->newCoreLabel--;
-                data->cores[core_idx] =
-                    RCore(newCore, data->params.onlyMatchAtRGroups);
+                data->cores[core_idx] = RCore(newCore);
                 return add(inmol);
               }
             }

--- a/Code/GraphMol/RGroupDecomposition/RGroupDecomp.h
+++ b/Code/GraphMol/RGroupDecomposition/RGroupDecomp.h
@@ -130,7 +130,7 @@ class UsedLabelMap {
  public:
   UsedLabelMap(const std::map<int, int> &mapping) {
     for (const auto &rl : mapping) {
-      d_map[rl.second] = std::make_pair(false, (rl.first >= 0));
+      d_map[rl.second] = std::make_pair(false, (rl.first > 0));
     }
   }
   bool getIsUsed(int label) const { return d_map.at(label).first; }

--- a/Code/GraphMol/RGroupDecomposition/RGroupDecompData.h
+++ b/Code/GraphMol/RGroupDecomposition/RGroupDecompData.h
@@ -62,9 +62,7 @@ struct RGroupDecompData {
       RWMol *alignCore = core.first ? cores[0].core.get() : nullptr;
       CHECK_INVARIANT(params.prepareCore(*core.second.core, alignCore),
                       "Could not prepare at least one core");
-      if (params.onlyMatchAtRGroups) {
-        core.second.findIndicesWithRLabel();
-      }
+      core.second.findIndicesWithRLabel();
       core.second.countUserRGroups();
       core.second.labelledCore.reset(new RWMol(*core.second.core));
     }

--- a/Code/GraphMol/RGroupDecomposition/RGroupDecompData.h
+++ b/Code/GraphMol/RGroupDecomposition/RGroupDecompData.h
@@ -178,7 +178,7 @@ struct RGroupDecompData {
     }
 
     for (int label : labels) {
-      if (label >= 0 && !removeAllHydrogenRGroups) {
+      if (label > 0 && !removeAllHydrogenRGroups) {
         continue;
       }
       bool allH = true;
@@ -443,7 +443,7 @@ struct RGroupDecompData {
 
     for (auto &it : best) {
       for (auto &rgroup : it.rgroups) {
-        if (rgroup.first >= 0) {
+        if (rgroup.first > 0) {
           userLabels.insert(rgroup.first);
         }
         if (rgroup.first < 0 && !params.onlyMatchAtRGroups) {

--- a/Code/GraphMol/RGroupDecomposition/RGroupScore.cpp
+++ b/Code/GraphMol/RGroupDecomposition/RGroupScore.cpp
@@ -133,7 +133,7 @@ double matchScore(const std::vector<size_t> &permutation,
     //  because these belong to 2 (or more) rgroups we really want these to stay
     //  the size of the set is the number of labels that are being used
     //  ** this heuristic really should be taken care of above **
-    int maxLinkerMatches = 0;
+    unsigned int maxLinkerMatches = 0;
     for (const auto &it : linkerMatchSet) {
       if (it.first.size() > 1 || it.second > 1) {
         if (it.first.size() > maxLinkerMatches) {

--- a/Code/GraphMol/RGroupDecomposition/testRGroupDecomp.cpp
+++ b/Code/GraphMol/RGroupDecomposition/testRGroupDecomp.cpp
@@ -352,33 +352,33 @@ void testRingMatching3() {
 
   RWMol *core = SmartsToMol("*1***[*:1]1");
   // RWMol *core = SmartsToMol("*1****1");
-    
+
   std::vector<RGroupScore> matchtypes{Match, FingerprintVariance};
-  for(auto match: matchtypes) {
-      RGroupDecompositionParameters params;
-      // This test is currently failing using the default scoring method (the
-      // halogens are not all in the same group)
-      params.scoreMethod = match;
-      params.allowNonTerminalRGroups = true;
+  for (auto match : matchtypes) {
+    RGroupDecompositionParameters params;
+    // This test is currently failing using the default scoring method (the
+    // halogens are not all in the same group)
+    params.scoreMethod = match;
+    params.allowNonTerminalRGroups = true;
 
-      RGroupDecomposition decomp(*core, params);
-      for (int i = 0; i < 3; ++i) {
-        ROMol *mol = SmilesToMol(ringData3[i]);
-        int res = decomp.add(*mol);
-        delete mol;
-        TEST_ASSERT(res == i);
-      }
+    RGroupDecomposition decomp(*core, params);
+    for (int i = 0; i < 3; ++i) {
+      ROMol *mol = SmilesToMol(ringData3[i]);
+      int res = decomp.add(*mol);
+      delete mol;
+      TEST_ASSERT(res == i);
+    }
 
-      decomp.process();
-      RGroupRows rows = decomp.getRGroupsAsRows();
-      std::ostringstream str;
+    decomp.process();
+    RGroupRows rows = decomp.getRGroupsAsRows();
+    std::ostringstream str;
 
-      // All Cl's should be labeled with the same rgroup
-      int i = 0;
-      for (RGroupRows::const_iterator it = rows.begin(); it != rows.end();
-           ++it, ++i) {
-        CHECK_RGROUP(it, ringDataRes3[i]);
-      }
+    // All Cl's should be labeled with the same rgroup
+    int i = 0;
+    for (RGroupRows::const_iterator it = rows.begin(); it != rows.end();
+         ++it, ++i) {
+      CHECK_RGROUP(it, ringDataRes3[i]);
+    }
   }
   delete core;
 }
@@ -1069,9 +1069,9 @@ void testSymmetryIssues() {
   BOOST_LOG(rdInfoLog) << "Testing R-Group symmetry issues\n";
 
   auto m1 = "c1c(F)cccn1"_smiles;
-  auto m2 = "c1c(Cl)c(C)ccn1"_smiles;
+  auto m2 = "c1c(Cl)c(C)c(Br)cn1"_smiles;
   auto m3 = "c1c(O)cccn1"_smiles;
-  auto m4 = "c1cc(C)c(F)cn1"_smiles;
+  auto m4 = "c1c(Br)c(C)c(F)cn1"_smiles;
   auto core = "c1c([*:1])c([*:2])ccn1"_smiles;
   {
     RGroupDecomposition decomp(*core);
@@ -1090,16 +1090,16 @@ void testSymmetryIssues() {
         ss << MolToSmiles(*rgroup) << std::endl;
       }
     }
-    // We only want two groups added
+    // We want three groups added, fluorine as R1 and bromine as R3
 
-    TEST_ASSERT(r_labels == std::set<std::string>({"Core", "R1", "R2"}));
-    TEST_ASSERT(groups.size() == 3);
+    TEST_ASSERT(r_labels == std::set<std::string>({"Core", "R1", "R2", "R3"}));
+    TEST_ASSERT(groups.size() == 4);
 
     TEST_ASSERT(ss.str() == R"RES(Rgroup===Core
-c1cc([*:2])c([*:1])cn1
-c1cc([*:2])c([*:1])cn1
-c1cc([*:2])c([*:1])cn1
-c1cc([*:2])c([*:1])cn1
+c1ncc([*:3])c([*:2])c1[*:1]
+c1ncc([*:3])c([*:2])c1[*:1]
+c1ncc([*:3])c([*:2])c1[*:1]
+c1ncc([*:3])c([*:2])c1[*:1]
 Rgroup===R1
 F[*:1]
 Cl[*:1]
@@ -1110,9 +1110,16 @@ Rgroup===R2
 C[*:2]
 [H][*:2]
 C[*:2]
+Rgroup===R3
+[H][*:3]
+Br[*:3]
+[H][*:3]
+Br[*:3]
 )RES");
   }
   {  // repeat that without symmetrization (testing #3224)
+     // Still three groups added, but bromine and fluorine
+     // are not aligned between R1 and R3
     RGroupDecompositionParameters ps;
     ps.matchingStrategy = RDKit::NoSymmetrization;
     RGroupDecomposition decomp(*core, ps);
@@ -1143,7 +1150,7 @@ Rgroup===R1
 F[*:1]
 Cl[*:1]
 O[*:1]
-[H][*:1]
+Br[*:1]
 Rgroup===R2
 [H][*:2]
 C[*:2]
@@ -1151,7 +1158,7 @@ C[*:2]
 C[*:2]
 Rgroup===R3
 [H][*:3]
-[H][*:3]
+Br[*:3]
 [H][*:3]
 F[*:3]
 )RES");
@@ -1862,27 +1869,27 @@ void testMutipleCoreRelabellingIssues() {
       "O=C1C([*:2])([*:1])[C@@H]2N1C(C(O)=O)C([*:3])([*:4])S2",
       "O=C1C([*:2])([*:1])[C@@H]2N1C(C(O)=O)C([*:3])([*:4])O2",
       "O=C1C([*:2])([*:1])C([*:6])([*:5])N1"};
- std::vector<RGroupScore> matchtypes{Match, FingerprintVariance};
- for(auto match: matchtypes) {
-  std::vector<ROMOL_SPTR> cores;
-  for (const auto &s : smi) {
-    cores.emplace_back(SmartsToMol(s));
-  }
+  std::vector<RGroupScore> matchtypes{Match, FingerprintVariance};
+  for (auto match : matchtypes) {
+    std::vector<ROMOL_SPTR> cores;
+    for (const auto &s : smi) {
+      cores.emplace_back(SmartsToMol(s));
+    }
 
-  RGroupDecompositionParameters params;
-  params.scoreMethod = match;
-  RGroupDecomposition decomposition(cores, params);
-  for (auto &mol : molecules) {
-    decomposition.add(*mol);
-  }
+    RGroupDecompositionParameters params;
+    params.scoreMethod = match;
+    RGroupDecomposition decomposition(cores, params);
+    for (auto &mol : molecules) {
+      decomposition.add(*mol);
+    }
 
-  decomposition.process();
-  const auto &columns = decomposition.getRGroupsAsColumns();
-  TEST_ASSERT(columns.size() == 7u);
-  for (auto &col : columns) {
-    TEST_ASSERT(30U == col.second.size());
+    decomposition.process();
+    const auto &columns = decomposition.getRGroupsAsColumns();
+    TEST_ASSERT(columns.size() == 7u);
+    for (auto &col : columns) {
+      TEST_ASSERT(30U == col.second.size());
+    }
   }
- }
 }
 
 void testUnprocessedMapping() {
@@ -1906,26 +1913,26 @@ void testUnprocessedMapping() {
   std::vector<std::string> coreSmi = {"N1([*:1])CCN([*:2])CC1",
                                       "C1(O[*:1])CCC(O[*:2])CC1",
                                       "C1([*:1])CCC([*:2])CC1"};
-    
+
   std::vector<RGroupScore> matchtypes{Match, FingerprintVariance};
-  for(auto match: matchtypes) {
-      std::vector<ROMOL_SPTR> cores;
-      for (const auto &s : coreSmi) {
-        cores.emplace_back(SmartsToMol(s));
-      }
+  for (auto match : matchtypes) {
+    std::vector<ROMOL_SPTR> cores;
+    for (const auto &s : coreSmi) {
+      cores.emplace_back(SmartsToMol(s));
+    }
 
-      RGroupDecompositionParameters params;
-      params.scoreMethod = match;
-      RGroupDecomposition decomposition(cores, params);
-      for (auto &smi : structureSmi) {
-        auto mol = SmilesToMol(smi);
-        decomposition.add(*mol);
-        delete mol;
-      }
+    RGroupDecompositionParameters params;
+    params.scoreMethod = match;
+    RGroupDecomposition decomposition(cores, params);
+    for (auto &smi : structureSmi) {
+      auto mol = SmilesToMol(smi);
+      decomposition.add(*mol);
+      delete mol;
+    }
 
-      auto result = decomposition.processAndScore();
-      TEST_ASSERT(result.success);
-      TEST_ASSERT(result.score != -1.0);
+    auto result = decomposition.processAndScore();
+    TEST_ASSERT(result.success);
+    TEST_ASSERT(result.score != -1.0);
   }
 }
 
@@ -2223,27 +2230,26 @@ void testUserMatchTypes() {
     }
   };
 
-
   std::vector<RGroupScore> matchtype{Match, FingerprintVariance};
-  for(auto match : matchtype) {
-      auto mol = "C1CCCCC1(N)(O)"_smiles;
-      auto core = "C1CCCCC1[*:1]"_smiles;
-      core = "C1CCCCC1[*:1]"_smarts;
-      RGroupDecompositionParameters params;
-      params.onlyMatchAtRGroups = true;
-      params.scoreMethod = match;
-      RGroupDecomposition decomp(*core, params);
-      int res = decomp.add(*mol);
-      TEST_ASSERT(res == -1);
+  for (auto match : matchtype) {
+    auto mol = "C1CCCCC1(N)(O)"_smiles;
+    auto core = "C1CCCCC1[*:1]"_smiles;
+    core = "C1CCCCC1[*:1]"_smarts;
+    RGroupDecompositionParameters params;
+    params.onlyMatchAtRGroups = true;
+    params.scoreMethod = match;
+    RGroupDecomposition decomp(*core, params);
+    int res = decomp.add(*mol);
+    TEST_ASSERT(res == -1);
 
-      params.onlyMatchAtRGroups = false;
-      std::string expected("Core:C1CCC([*:1])([*:2])CC1 R1:O[*:1] R2:N[*:2]");
-      TestMatchType::test(*core, *mol, params, expected);
-      core = "C1CCCCC1([*:1])([*:2])"_smiles;
-      TestMatchType::test(*core, *mol, params, expected);
-      core = "C1CCCC[*:2]1[*:1]"_smiles;
-      params.allowNonTerminalRGroups = true;
-      TestMatchType::test(*core, *mol, params, expected);
+    params.onlyMatchAtRGroups = false;
+    std::string expected("Core:C1CCC([*:1])([*:2])CC1 R1:O[*:1] R2:N[*:2]");
+    TestMatchType::test(*core, *mol, params, expected);
+    core = "C1CCCCC1([*:1])([*:2])"_smiles;
+    TestMatchType::test(*core, *mol, params, expected);
+    core = "C1CCCC[*:2]1[*:1]"_smiles;
+    params.allowNonTerminalRGroups = true;
+    TestMatchType::test(*core, *mol, params, expected);
   }
 }
 
@@ -2307,6 +2313,95 @@ void testNoTempLabels() {
   }
 }
 
+void testDoNotAddUnnecessaryRLabels() {
+  BOOST_LOG(rdInfoLog)
+      << "********************************************************\n";
+  BOOST_LOG(rdInfoLog) << "Test that R labels are not added if not necessary"
+                       << std::endl;
+  {
+    auto m1 = "c1c(F)cccn1"_smiles;
+    auto m2 = "c1c(Cl)c(C)ccn1"_smiles;
+    auto m3 = "c1c(O)cccn1"_smiles;
+    auto m4 = "c1cc(C)c(F)cn1"_smiles;
+    auto core = "c1c([*:1])c([*:2])ccn1"_smiles;
+    // the test runs twice, with and without symmetrization
+    // results should be the same as do not depend on permutations
+    for (unsigned int i = 0; i < 2; ++i) {
+      RGroupDecompositionParameters ps;
+      if (i) {
+        ps.matchingStrategy = RDKit::NoSymmetrization;
+      }
+      RGroupDecomposition decomp(*core, ps);
+      TEST_ASSERT(decomp.add(*m1) == 0);
+      TEST_ASSERT(decomp.add(*m2) == 1);
+      TEST_ASSERT(decomp.add(*m3) == 2);
+      TEST_ASSERT(decomp.add(*m4) == 3);
+      decomp.process();
+      std::stringstream ss;
+      auto groups = decomp.getRGroupsAsColumns();
+      std::set<std::string> r_labels;
+      for (auto &column : groups) {
+        r_labels.insert(column.first);
+        ss << "Rgroup===" << column.first << std::endl;
+        for (auto &rgroup : column.second) {
+          ss << MolToSmiles(*rgroup) << std::endl;
+        }
+      }
+      // We only want two groups added
+
+      TEST_ASSERT(r_labels == std::set<std::string>({"Core", "R1", "R2"}));
+      TEST_ASSERT(groups.size() == 3);
+
+      TEST_ASSERT(ss.str() == R"RES(Rgroup===Core
+c1cc([*:2])c([*:1])cn1
+c1cc([*:2])c([*:1])cn1
+c1cc([*:2])c([*:1])cn1
+c1cc([*:2])c([*:1])cn1
+Rgroup===R1
+F[*:1]
+Cl[*:1]
+O[*:1]
+F[*:1]
+Rgroup===R2
+[H][*:2]
+C[*:2]
+[H][*:2]
+C[*:2]
+)RES");
+    }
+  }
+  {
+    auto cores = std::vector<ROMOL_SPTR>{"[*:1]c1ccccc1"_smiles,
+                                         "[*:1]c1c([*:2])ccc(F)c1"_smiles};
+    auto m1 = "Cc1c(Cl)ccc(F)c1"_smiles;
+    auto m2 = "Cc1c(Br)cccc1"_smiles;
+    size_t i;
+    RGroupRows rows;
+    RGroupDecomposition decomp(cores);
+    TEST_ASSERT(decomp.add(*m1) == 0);
+    decomp.process();
+    rows = decomp.getRGroupsAsRows();
+    TEST_ASSERT(rows.size() == 1);
+    std::vector<std::string> expected1{
+        "Core:Fc1ccc([*:2])c([*:1])c1 R1:C[*:1] R2:Cl[*:2]"};
+    i = 0;
+    for (RGroupRows::const_iterator it = rows.begin(); it != rows.end(); ++it) {
+      CHECK_RGROUP(it, expected1.at(i++));
+    }
+    TEST_ASSERT(decomp.add(*m2) == 1);
+    decomp.process();
+    rows = decomp.getRGroupsAsRows();
+    TEST_ASSERT(rows.size() == 2);
+    std::vector<std::string> expected2{
+        "Core:Fc1ccc([*:2])c([*:1])c1 R1:C[*:1] R2:Cl[*:2]",
+        "Core:c1ccc([*:3])c([*:1])c1 R1:C[*:1] R3:Br[*:3]"};
+    i = 0;
+    for (RGroupRows::const_iterator it = rows.begin(); it != rows.end(); ++it) {
+      CHECK_RGROUP(it, expected2.at(i++));
+    }
+  }
+}
+
 int main() {
   RDLog::InitLogs();
   boost::logging::disable_logs("rdApp.debug");
@@ -2352,6 +2447,7 @@ int main() {
   testUnlabelledRGroupsOnAromaticNitrogen();
   testAddHsDoesNotFail();
   testNoTempLabels();
+  testDoNotAddUnnecessaryRLabels();
 
   BOOST_LOG(rdInfoLog)
       << "********************************************************\n";

--- a/Code/GraphMol/RGroupDecomposition/testRGroupDecomp.cpp
+++ b/Code/GraphMol/RGroupDecomposition/testRGroupDecomp.cpp
@@ -2400,6 +2400,33 @@ C[*:2]
       CHECK_RGROUP(it, expected2.at(i++));
     }
   }
+  {
+    auto cores = std::vector<ROMOL_SPTR>{"[*:1]c1c([*:2])ccc(F)c1"_smiles,
+                                         "[*:1]c1ccccc1"_smiles,
+                                         "[*:1]c1c([*:2])cccc1"_smiles};
+    auto mols = std::vector<ROMOL_SPTR>{
+        "Cc1c(Cl)ccc(F)c1"_smiles, "Cc1c(Cl)ccc(N)c1"_smiles,
+        "Cc1ccccc1"_smiles, "Cc1c(Br)cccc1"_smiles, "Cc1cc(F)ccc1"_smiles};
+    RGroupRows rows;
+    RGroupDecomposition decomp(cores);
+    int n = 0;
+    for (const auto &m : mols) {
+      TEST_ASSERT(decomp.add(*m) == n++);
+    }
+    decomp.process();
+    rows = decomp.getRGroupsAsRows();
+    TEST_ASSERT(rows.size() == 5);
+    std::vector<std::string> expected{
+        "Core:Fc1ccc([*:2])c([*:1])c1 R1:C[*:1] R2:Cl[*:2]",
+        "Core:c1cc([*:2])c([*:1])cc1[*:3] R1:C[*:1] R2:Cl[*:2] R3:N[*:3]",
+        "Core:c1cc([*:1])cc([*:3])c1 R1:C[*:1] R3:[H][*:3]",
+        "Core:c1cc([*:2])c([*:1])cc1[*:3] R1:C[*:1] R2:Br[*:2] R3:[H][*:3]",
+        "Core:Fc1ccc([*:2])c([*:1])c1 R1:C[*:1] R2:[H][*:2]"};
+    size_t i = 0;
+    for (RGroupRows::const_iterator it = rows.begin(); it != rows.end(); ++it) {
+      CHECK_RGROUP(it, expected.at(i++));
+    }
+  }
 }
 
 int main() {

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -17,6 +17,13 @@
   (#3696)
 - There have been numerous changes to the RGroup Decomposition code which change
   the results. (#3767)
+- In RGroup Decomposition, when onlyMatchAtRGroups is set to false, each molecule
+  is now decomposed based on the first scaffold which adds/uses the least number
+  of non-user-provided R labels, rather than the first scaffold tout court.
+  Among other things, this allows the code to provide the same results for both
+  onlyMatchAtRGroups=true and onlyMatchAtRGroups=false when suitable scaffolds
+  are provided without requiring the user to get overly concerned about the
+  input ordering of the scaffolds. (#3969)
 - There have been numerous changes to `GenerateDepictionMatching2DStructure()` (#3811)
 - Setting the kekuleSmiles argument (doKekule in C++) to MolToSmiles will now
   cause the molecule to be kekulized before SMILES generation. Note that this

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -18,8 +18,9 @@
 - There have been numerous changes to the RGroup Decomposition code which change
   the results. (#3767)
 - In RGroup Decomposition, when onlyMatchAtRGroups is set to false, each molecule
-  is now decomposed based on the first scaffold which adds/uses the least number
-  of non-user-provided R labels, rather than the first scaffold tout court.
+  is now decomposed based on the first matching scaffold which adds/uses the
+  least number of non-user-provided R labels, rather than simply the first
+  matching scaffold.
   Among other things, this allows the code to provide the same results for both
   onlyMatchAtRGroups=true and onlyMatchAtRGroups=false when suitable scaffolds
   are provided without requiring the user to get overly concerned about the


### PR DESCRIPTION
- use a `boost::dynamic_bitset` rather than a `std::set` for lookups
I replaced a `std::set` which was being used for lookups with a `dynamic_bitset` as it is more efficient. We consistently use `dynamic_bitset` for this purpose all over the RGD code, but apparently we missed this one.

- do not add unnecessary R-labels
While testing the RGD code on some internal datasets I ran into two cases that I believe were yielding suboptimal results when `onlyMatchAtRGroups=false`, because unnecessary R labels were being dynamically added.
Both are addressed by the new `testDoNotAddUnnecessaryRLabels()` and I will illustrate them below.

1. There is a single core
![image](https://user-images.githubusercontent.com/5244385/112223165-d630c400-8c29-11eb-8037-0c1c42a8c589.png)
while the molecules are
![image](https://user-images.githubusercontent.com/5244385/112223228-eb0d5780-8c29-11eb-9ff0-22e3b7c91057.png)
Before this PR, the code would not make a difference between assigning a H substituent vs a heavy atom substituent to user-defined or dynamically added labels.
The scoring function, when evaluating the various permutations, would then choose the permutation which adds the smallest number of labels, and so would choose the solution that yields only R1 and R2, with zero added labels.
However, when running with `NoSymmetrization`, in the situation above you end up with three labels (R1, R2, R3), since a single permutation is retained:

```
{'Core': ['c1ncc([*:3])c([*:2])c1[*:1]',
  'c1ncc([*:3])c([*:2])c1[*:1]',
  'c1ncc([*:3])c([*:2])c1[*:1]',
  'c1ncc([*:3])c([*:2])c1[*:1]'],
 'R1': ['F[*:1]', 'Cl[*:1]', 'O[*:1]', '[H][*:1]'],
 'R2': ['[H][*:2]', 'C[*:2]', '[H][*:2]', 'C[*:2]'],
 'R3': ['[H][*:3]', '[H][*:3]', '[H][*:3]', 'F[*:3]']}
```

There is a simple fix for this, which is filtering out all degenerate matches that would require adding a label whenever there is the possibility to choose an alternative degenerate match that does not require adding a label, because it accommodates all heavy substituents into existing labels, rather than assigning one of the existing labels to H and adding another label for the other heavy substituent. This fix has a negligible impact on performance.

2. There are two cores:
![image](https://user-images.githubusercontent.com/5244385/112225205-b8189300-8c2c-11eb-89dc-04ad359d7131.png)
while the molecules are
![image](https://user-images.githubusercontent.com/5244385/112225419-0f1e6800-8c2d-11eb-80ee-451b17890695.png)
Even though the first molecule matches the first core and does not require adding any label, before this PR both molecules would be associated to the second core:

```
{'Core': ['c1cc([*:1])c([*:3])cc1[*:4]', 'c1cc([*:1])c([*:3])cc1[*:4]'],
 'R1': ['Cl[*:1]', 'Br[*:1]'],
 'R3': ['C[*:3]', 'C[*:3]'],
 'R4': ['F[*:4]', '[H][*:4]']}
```

This happens because the first core already matches (with 2 additional labels), and the second core is never even tried, thus yielding a rather unexpected result, as labels should only be added when there is no better alternative.
After this PR, the expected result is generated:

```
{'Core': ['Fc1ccc([*:2])c([*:1])c1', 'c1ccc([*:3])c([*:1])c1'],
 'R1': ['C[*:1]', 'C[*:1]'],
 'R2': ['Cl[*:2]', ''],
 'R3': ['', 'Br[*:3]']}
```

where the first molecule is associated to the first core, and a single additional label is added to the second core to accommodate the second molecule.
I do realize that this fix requires probing all available cores rather than just picking the first that matches so is more expensive, but I believe getting the expected result is preferable to getting a suboptimal result, though a bit faster.