### PR TITLE
RWMol should reset(), not release(), dp_delAtoms and dp_delBonds

### DIFF
--- a/Code/GraphMol/RWMol.cpp
+++ b/Code/GraphMol/RWMol.cpp
@@ -481,7 +481,7 @@ void RWMol::commitBatchEdit() {
     return;
   }
   auto delBonds = *dp_delBonds;
-  dp_delBonds.release();
+  dp_delBonds.reset();
   for (unsigned int i = getNumBonds(); i > 0; --i) {
     if (delBonds[i - 1]) {
       const auto bnd = getBondWithIdx(i - 1);
@@ -490,7 +490,7 @@ void RWMol::commitBatchEdit() {
     }
   }
   auto delAtoms = *dp_delAtoms;
-  dp_delAtoms.release();
+  dp_delAtoms.reset();
   for (unsigned int i = getNumAtoms(); i > 0; --i) {
     if (delAtoms[i - 1]) {
       removeAtom(i - 1);

--- a/Code/GraphMol/RWMol.h
+++ b/Code/GraphMol/RWMol.h
@@ -214,8 +214,8 @@ class RDKIT_GRAPHMOL_EXPORT RWMol : public ROMol {
 
   void beginBatchEdit();
   void rollbackBatchEdit(){
-    dp_delAtoms.release();
-    dp_delBonds.release();
+    dp_delAtoms.reset();
+    dp_delBonds.reset();
   };
   void commitBatchEdit();
   


### PR DESCRIPTION
Simple fix to use `reset()` instead of `release()`

Thanks to @rvianello for pointing this out.