### PR TITLE
Update Mol2FileParser.cpp

### DIFF
--- a/Code/GraphMol/FileParsers/Mol2FileParser.cpp
+++ b/Code/GraphMol/FileParsers/Mol2FileParser.cpp
@@ -321,7 +321,7 @@ bool cleanUpMol2Substructures(RWMol *res) {
       std::string tATT;
       nbr->getProp(common_properties::_TriposAtomType, tATT);
       // carboxylates
-      if (tATT == "C.2" || tATT == "S.o2") {
+      if (tATT == "C.2" || tATT == "S.o2" || tATT=="P.3") {
         // this should return only the bond between C.2 and O.co2
         Bond *b = res->getBondBetweenAtoms(idx, *nbrIdxIt);
         if (!isFixed[*nbrIdxIt]) {


### PR DESCRIPTION
Proper substructure support for phosphate groups when parsing .mol2 files, per:
https://www.mail-archive.com/rdkit-discuss@lists.sourceforge.net/msg02468.html

<!--
Thanks for contributing a pull request! 
-->
#### Reference Issue
Fixes #3983 


#### What does this implement/fix? Explain your changes.
See reference issue.

#### Any other comments?
See reference issue.
