### PR TITLE
A set of fixes for problems caused by bad input

### DIFF
--- a/Code/GraphMol/FileParsers/MolFileParser.cpp
+++ b/Code/GraphMol/FileParsers/MolFileParser.cpp
@@ -250,7 +250,7 @@ void ParseOldAtomList(RWMol *mol, const std::string &text, unsigned int line) {
     default:
       delete q;
       std::ostringstream errout;
-      errout << "Unrecognized atom-list query modifier: '" << text[14]
+      errout << "Unrecognized atom-list query modifier: '" << text[4]
              << "' on line " << line;
       throw FileParseException(errout.str());
   }

--- a/Code/GraphMol/MolPickler.cpp
+++ b/Code/GraphMol/MolPickler.cpp
@@ -1946,13 +1946,18 @@ void MolPickler::_addRingInfoFromPickle(std::istream &ss, ROMol *mol,
       T tmpT;
       T ringSize;
       streamRead(ss, ringSize, version);
-
+      if (ringSize < 0) {
+        throw MolPicklerException("negative ring size");
+      }
       INT_VECT atoms(static_cast<int>(ringSize));
       INT_VECT bonds(static_cast<int>(ringSize));
       for (unsigned int j = 0; j < static_cast<unsigned int>(ringSize); j++) {
         streamRead(ss, tmpT, version);
         if (directMap) {
           atoms[j] = static_cast<int>(tmpT);
+          if (atoms[j] < 0 || atoms[j] >= mol->getNumAtoms()) {
+            throw MolPicklerException("ring-atom index out of range");
+          }
         } else {
           atoms[j] = mol->getAtomWithBookmark(static_cast<int>(tmpT))->getIdx();
         }
@@ -1962,6 +1967,10 @@ void MolPickler::_addRingInfoFromPickle(std::istream &ss, ROMol *mol,
           streamRead(ss, tmpT, version);
           if (directMap) {
             bonds[j] = static_cast<int>(tmpT);
+            if (bonds[j] < 0 || bonds[j] >= mol->getNumBonds()) {
+              throw MolPicklerException("ring-bond index out of range");
+            }
+
           } else {
             bonds[j] =
                 mol->getBondWithBookmark(static_cast<int>(tmpT))->getIdx();

--- a/Code/GraphMol/RWMol.cpp
+++ b/Code/GraphMol/RWMol.cpp
@@ -146,10 +146,19 @@ void RWMol::replaceAtom(unsigned int idx, Atom *atom_pin, bool updateLabel,
     atom_p->updateProps(*d_graph[vd], replaceExistingData);
   }
   removeSubstanceGroupsReferencingAtom(*this, idx);
-  delete d_graph[vd];
+
+  const auto orig_p = d_graph[vd];
+  delete orig_p;
   d_graph[vd] = atom_p;
 
-  // FIX: do something about bookmarks
+  // handle bookmarks
+  for (auto &ab : d_atomBookmarks) {
+    for (auto &elem : ab.second) {
+      if (elem == orig_p) {
+        elem = atom_p;
+      }
+    }
+  }
 };
 
 void RWMol::replaceBond(unsigned int idx, Bond *bond_pin, bool preserveProps) {
@@ -170,11 +179,19 @@ void RWMol::replaceBond(unsigned int idx, Bond *bond_pin, bool preserveProps) {
     bond_p->updateProps(*d_graph[*(bIter.first)], replaceExistingData);
   }
 
-  delete d_graph[*(bIter.first)];
+  const auto orig_p = d_graph[*(bIter.first)];
+  delete orig_p;
   d_graph[*(bIter.first)] = bond_p;
-  // FIX: do something about bookmarks
-
   removeSubstanceGroupsReferencingBond(*this, idx);
+
+  // handle bookmarks
+  for (auto &ab : d_bondBookmarks) {
+    for (auto &elem : ab.second) {
+      if (elem == orig_p) {
+        elem = bond_p;
+      }
+    }
+  }
 };
 
 Atom *RWMol::getActiveAtom() {

--- a/Code/GraphMol/SmilesParse/SmilesParse.cpp
+++ b/Code/GraphMol/SmilesParse/SmilesParse.cpp
@@ -176,10 +176,9 @@ std::string labelRecursivePatterns(const std::string &sma) {
       state.push_back(BRANCH);
     } else if (sma[pos] == ')') {
       if (state.empty() || state.back() == BASE) {
-        std::stringstream errout;
-        errout << "SMARTS '" << sma
-               << "' has a closing parentheses which doesn't have an opener.";
-        throw SmilesParseException(errout.str());
+        // seriously bogus input. Just return the input
+        // and let the SMARTS parser itself report the error
+        return sma;
       }
       SmaState currState = state.back();
       state.pop_back();

--- a/Code/GraphMol/SmilesParse/SmilesParse.cpp
+++ b/Code/GraphMol/SmilesParse/SmilesParse.cpp
@@ -175,6 +175,12 @@ std::string labelRecursivePatterns(const std::string &sma) {
     } else if (sma[pos] == '(') {
       state.push_back(BRANCH);
     } else if (sma[pos] == ')') {
+      if (state.empty() || state.back() == BASE) {
+        std::stringstream errout;
+        errout << "SMARTS '" << sma
+               << "' has a closing parentheses which doesn't have an opener.";
+        throw SmilesParseException(errout.str());
+      }
       SmaState currState = state.back();
       state.pop_back();
       if (currState == RECURSE) {

--- a/Code/GraphMol/SmilesParse/catch_tests.cpp
+++ b/Code/GraphMol/SmilesParse/catch_tests.cpp
@@ -854,5 +854,5 @@ TEST_CASE("Github #2788: doKekule=true should kekulize the molecule",
 
 TEST_CASE("bogus recursive SMARTS", "[smarts]") {
   std::string sma = "C)foo";
-  CHECK_THROWS_AS(SmartsToMol(sma), SmilesParseException);
+  CHECK(SmartsToMol(sma) == nullptr);
 }

--- a/Code/GraphMol/SmilesParse/catch_tests.cpp
+++ b/Code/GraphMol/SmilesParse/catch_tests.cpp
@@ -851,3 +851,8 @@ TEST_CASE("Github #2788: doKekule=true should kekulize the molecule",
     }
   }
 }
+
+TEST_CASE("bogus recursive SMARTS", "[smarts]") {
+  std::string sma = "C)foo";
+  CHECK_THROWS_AS(SmartsToMol(sma), SmilesParseException);
+}


### PR DESCRIPTION
`RWMol::replaceAtom()` and `RWMol::replaceBond()` can both leave dangling pointers in the bookmarks vectors.
This clears that up.

This fix also should clear at least the following OSSFuzz issues:
- https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=27315
- https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=25906
- https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=24406

Additionally some leaks in the tests in catch_graphmol.cpp have been fixed.

I also added a couple of other small fixes connected with issues discovered by OSSFuzz:
- bogus input character referenced in error reporting in the MolFileParser
- additional defensive programming around possible malicious input to the deserialization code
- correctly fail when parsing maliciously constructed SMARTS input