### PR TITLE
Cleanup some problems found during an ASAN build

### DIFF
--- a/Code/GraphMol/ChemTransforms/MolFragmenter.cpp
+++ b/Code/GraphMol/ChemTransforms/MolFragmenter.cpp
@@ -847,11 +847,11 @@ struct ZipBond {
 
 std::unique_ptr<ROMol> molzip(const ROMol &a, const ROMol &b,
                               const MolzipParams &params) {
-  RWMol *newmol;
+  std::unique_ptr<RWMol> newmol;
   if (b.getNumAtoms()) {
-    newmol = static_cast<RWMol *>(combineMols(a, b));
+    newmol.reset(static_cast<RWMol *>(combineMols(a, b)));
   } else {
-    newmol = new RWMol(a);
+    newmol.reset(new RWMol(a));
   }
 
   std::map<unsigned int, ZipBond> mappings;
@@ -957,7 +957,7 @@ std::unique_ptr<ROMol> molzip(const ROMol &a, const ROMol &b,
   }
   newmol->updatePropertyCache();
   newmol->setProp(common_properties::_StereochemDone, true);
-  return std::unique_ptr<ROMol>(newmol);
+  return newmol;
 }
 
 std::unique_ptr<ROMol> molzip(const ROMol &a, const MolzipParams &params) {

--- a/Code/GraphMol/ChemTransforms/catch_tests.cpp
+++ b/Code/GraphMol/ChemTransforms/catch_tests.cpp
@@ -75,6 +75,7 @@ TEST_CASE("Github #1039", "[]") {
           received_stereo.push_back(bond->getStereoAtoms());
       }
       CHECK(received_stereo==expected_stereo_atoms);
+      delete resa;
   }
   { // break non stereo atom bond
     auto m =  "C/C(O)=N/C=C"_smiles;
@@ -96,7 +97,8 @@ TEST_CASE("Github #1039", "[]") {
       received_stereo.push_back(bond->getStereoAtoms());
     }
     CHECK(received_stereo==expected_stereo_atoms);
-  }  
+    delete resa;
+  }
   { // bond stereo should only be removed when deleting the double bond with E/Z
     auto m =  "O/C=N/C=C"_smiles;
     std::vector<std::pair<unsigned int, unsigned int>> dummyLabels{{1,1}};
@@ -111,6 +113,7 @@ TEST_CASE("Github #1039", "[]") {
       auto resa = RDKit::MolFragmenter::fragmentOnBonds(*m, bonds);
       auto smiles = MolToSmiles(*resa);
       CHECK(smiles == expected[i]);
+      delete resa;
     }
   }
   { // bond stereo should only be removed when deleting the double bond with E/Z
@@ -129,6 +132,7 @@ TEST_CASE("Github #1039", "[]") {
       auto resa = RDKit::MolFragmenter::fragmentOnBonds(*m, bonds);
       auto smiles = MolToSmiles(*resa);
       CHECK(smiles == expected[i]);
+      delete resa;
     }
   }
 }
@@ -228,7 +232,7 @@ TEST_CASE("molzip", "[]") {
                     MolzipParams p;
                     p.label = MolzipLabel::FragmentOnBonds;
                      CHECK(MolToSmiles(*molzip(*resa,p)) == MolToSmiles(*m));
-                    
+                    delete resa;
                     // Now try using atom labels
                     auto res = RDKit::MolFragmenter::fragmentOnBonds(*m, bonds, true, &dummyLabels);
                     for(auto *atom : res->atoms()) {
@@ -237,6 +241,7 @@ TEST_CASE("molzip", "[]") {
                         }
                     }
                     CHECK(MolToSmiles(*molzip(*res)) == MolToSmiles(*m));
+                    delete res;
                 }
             }
         }
@@ -315,7 +320,7 @@ TEST_CASE("molzip", "[]") {
           for(unsigned int i=0;i<m->getNumBonds();++i) {
             std::vector<unsigned int> bonds{i};
             {
-              auto resa = RDKit::MolFragmenter::fragmentOnBonds(*m, bonds);
+              std::unique_ptr<ROMol> resa{RDKit::MolFragmenter::fragmentOnBonds(*m, bonds)};
               auto smiles = MolToSmiles(*resa);
                 
               if (std::count(smiles.begin(), smiles.end(), '/') != 2) continue;  // we removed bond stereo in fragment to bonds!
@@ -325,7 +330,7 @@ TEST_CASE("molzip", "[]") {
             }
             {
               // Now try using atom labels
-              auto res = RDKit::MolFragmenter::fragmentOnBonds(*m, bonds, true, &dummyLabels);
+              std::unique_ptr<ROMol> res{RDKit::MolFragmenter::fragmentOnBonds(*m, bonds, true, &dummyLabels)};
               auto smiles = MolToSmiles(*res);
               
               if (std::count(smiles.begin(), smiles.end(), '/') != 2) continue;  // we removed bond stereo in fragment to bonds!

--- a/Code/GraphMol/DistGeomHelpers/catch_tests.cpp
+++ b/Code/GraphMol/DistGeomHelpers/catch_tests.cpp
@@ -165,6 +165,7 @@ TEST_CASE("update parameters from JSON") {
     "coordMap":{"0":[0,0,0],"1":[0,0,1.5],"2":[0,1.5,1.5]}})JSON";
       DGeomHelpers::updateEmbedParametersFromJSON(params, json);
       CHECK(DGeomHelpers::EmbedMolecule(*mol, params) == 0);
+      delete params.coordMap;
       auto conf = mol->getConformer();
       auto v1 = conf.getAtomPos(0) - conf.getAtomPos(1);
       auto v2 = conf.getAtomPos(2) - conf.getAtomPos(1);

--- a/Code/GraphMol/DistGeomHelpers/testDgeomHelpers.cpp
+++ b/Code/GraphMol/DistGeomHelpers/testDgeomHelpers.cpp
@@ -2349,7 +2349,9 @@ void testGithub3667() {
 void testForceTransAmides() {
   auto mol = "CC(=O)NC"_smiles;
   TEST_ASSERT(mol);
-  mol->addAtom(new Atom(1));
+  bool updateLabel = true;
+  bool takeOwnership = true;
+  mol->addAtom(new Atom(1), updateLabel, takeOwnership);
   mol->addBond(3, 5, Bond::BondType::SINGLE);
   MolOps::sanitizeMol(*mol);
   MolOps::addHs(*mol);

--- a/Code/GraphMol/FileParsers/file_parsers_catch.cpp
+++ b/Code/GraphMol/FileParsers/file_parsers_catch.cpp
@@ -3120,6 +3120,7 @@ M  END
       REQUIRE(nm);
       auto sgs = getSubstanceGroups(*nm);
       REQUIRE(sgs.size() == 1);
+      delete nm;
     }
     {
       auto outctab = MolToV3KMolBlock(*m);
@@ -3128,6 +3129,7 @@ M  END
       REQUIRE(nm);
       auto sgs = getSubstanceGroups(*nm);
       REQUIRE(sgs.size() == 1);
+      delete nm;
     }
   }
 }

--- a/Code/GraphMol/SubstructLibrary/SubstructLibrary.cpp
+++ b/Code/GraphMol/SubstructLibrary/SubstructLibrary.cpp
@@ -67,8 +67,8 @@ struct Bits {
     }
   }
 
-  Bits(const FPHolderBase *fingerprints, const TautomerQuery &m, bool recursionPossible,
-       bool useChirality, bool useQueryQueryMatches)
+  Bits(const FPHolderBase *fingerprints, const TautomerQuery &m,
+       bool recursionPossible, bool useChirality, bool useQueryQueryMatches)
       : fps(nullptr),
         recursionPossible(recursionPossible),
         useChirality(useChirality),
@@ -76,15 +76,16 @@ struct Bits {
     if (fingerprints) {
       const TautomerPatternHolder *tp =
           dynamic_cast<const TautomerPatternHolder *>(fingerprints);
-        if(!tp) {
-            BOOST_LOG(rdWarningLog) << "Pattern fingerprints for tautomersearch aren't tautomer fingerprints, ignoring..." << std::endl;
-            queryBits = nullptr;
-            fps = nullptr;
-        }
-        else {
-            fps = fingerprints;
-            queryBits = m.patternFingerprintTemplate(tp->getNumBits());
-        }
+      if (!tp) {
+        BOOST_LOG(rdWarningLog) << "Pattern fingerprints for tautomersearch "
+                                   "aren't tautomer fingerprints, ignoring..."
+                                << std::endl;
+        queryBits = nullptr;
+        fps = nullptr;
+      } else {
+        fps = fingerprints;
+        queryBits = m.patternFingerprintTemplate(tp->getNumBits());
+      }
     } else {
       queryBits = nullptr;
     }
@@ -116,10 +117,10 @@ bool query_needs_rings(const ROMol &in_query) {
       if (describeQuery(atom).find("Ring") != std::string::npos) {
         return true;
       } else if (atom->getQuery()->getDescription() == "RecursiveStructure") {
-          auto *rsq = (RecursiveStructureQuery *)atom->getQuery();
-          if (query_needs_rings(*rsq->getQueryMol())) {
-              return true;
-          }
+        auto *rsq = (RecursiveStructureQuery *)atom->getQuery();
+        if (query_needs_rings(*rsq->getQueryMol())) {
+          return true;
+        }
       }
     }
   }
@@ -233,6 +234,7 @@ int internalGetMatches(const Query &query, MolHolderBase &mols,
                      maxResultsVect[thread_group_idx],
                      idxs ? &internal_results[thread_group_idx] : nullptr));
     }
+    unsigned int maxEndIdx;
     if (maxResults > 0) {
       // If we are running with maxResults in a multi-threaded settings,
       // some threads may have screened more molecules than others.
@@ -251,8 +253,7 @@ int internalGetMatches(const Query &query, MolHolderBase &mols,
       // Find out out the max number of molecules that was screened by the most
       // productive thread and do the same in all other threads, unless the
       // max number of molecules was reached
-      unsigned int maxEndIdx =
-          *std::max_element(endIdxVect.begin(), endIdxVect.end());
+      maxEndIdx = *std::max_element(endIdxVect.begin(), endIdxVect.end());
       for (thread_group_idx = 0; thread_group_idx < numThreads;
            ++thread_group_idx) {
         if (endIdxVect[thread_group_idx] >= maxEndIdx) {

--- a/Code/GraphMol/SubstructLibrary/substructLibraryTest.cpp
+++ b/Code/GraphMol/SubstructLibrary/substructLibraryTest.cpp
@@ -692,38 +692,39 @@ void testSegFaultInHolder() {
 void testTautomerQueries() {
   BOOST_LOG(rdErrorLog) << "-------------------------------------" << std::endl;
   BOOST_LOG(rdErrorLog) << "   testTautomerQueries" << std::endl;
-    
+
   boost::shared_ptr<CachedTrustedSmilesMolHolder> mols1(
-							new CachedTrustedSmilesMolHolder());
+      new CachedTrustedSmilesMolHolder());
   mols1->addSmiles("CN1C2=C(C(=O)Nc3ccccc3)C(=O)CCN2c2ccccc21");
   SubstructLibrary sss(mols1);
   auto query = "Cc1nc2ccccc2[nH]1"_smiles;
-  //auto matches1 = sss.getMatches(*query);
-  //TEST_ASSERT(matches1.size() == 0);
-  auto tq = TautomerQuery::fromMol(*query);
+  // auto matches1 = sss.getMatches(*query);
+  // TEST_ASSERT(matches1.size() == 0);
+  std::unique_ptr<TautomerQuery> tq(TautomerQuery::fromMol(*query));
   auto matches2 = sss.getMatches(*tq);
-    TEST_ASSERT(matches2.size() == 1);
-    
-    SubstructLibrary sss2(sss);
-    addPatterns(sss, boost::make_shared<TautomerPatternHolder>());
-    matches2 = sss.getMatches(*tq);
-    TEST_ASSERT(matches2.size() == 1);
-    
-    // should work but throw logging errors
-    addPatterns(sss2);
-    matches2 = sss2.getMatches(*tq);
-    TEST_ASSERT(matches2.size() == 1);
+  TEST_ASSERT(matches2.size() == 1);
+
+  SubstructLibrary sss2(sss);
+  addPatterns(sss, boost::make_shared<TautomerPatternHolder>());
+  matches2 = sss.getMatches(*tq);
+  TEST_ASSERT(matches2.size() == 1);
+
+  // should work but throw logging errors
+  addPatterns(sss2);
+  matches2 = sss2.getMatches(*tq);
+  TEST_ASSERT(matches2.size() == 1);
 }
 
 void github3881() {
   BOOST_LOG(rdErrorLog) << "-------------------------------------" << std::endl;
-  BOOST_LOG(rdErrorLog) << "  github3881 recursive smarts with rings " << std::endl;
+  BOOST_LOG(rdErrorLog) << "  github3881 recursive smarts with rings "
+                        << std::endl;
   boost::shared_ptr<CachedTrustedSmilesMolHolder> mols(
       new CachedTrustedSmilesMolHolder());
   mols->addSmiles("c1ccccc1S(=O)(=O)Cl");
   SubstructLibrary sss(mols);
   auto pat = "[$(S-!@[#6]):2](=O)(=O)(Cl)"_smarts;
-  TEST_ASSERT(sss.getMatches(*pat).size()==1);
+  TEST_ASSERT(sss.getMatches(*pat).size() == 1);
 }
 
 int main() {

--- a/Code/GraphMol/molopstest.cpp
+++ b/Code/GraphMol/molopstest.cpp
@@ -8095,6 +8095,7 @@ void testSetTerminalAtomCoords() {
 M  END)CTAB"_ctab;
   auto atom = new Atom(0);
   auto idx = mol->addAtom(atom);
+  delete atom;
   mol->addBond(idx, 0);
   MolOps::setTerminalAtomCoords(static_cast<ROMol &>(*mol), idx, 0);
   auto &coord = mol->getConformer().getAtomPos(idx);


### PR DESCRIPTION
Fix some problems found when building with `-fsanitize-address` on linux

This is one where it's worth reviewing at the indivdual commits:
- The first two are memory leaks when exceptions are thrown (not a big deal, but still...)
- The third is a legit multi-threading bug in the SubstructLibrary
- The last one is just fixing leaks in the tests.