### PR TITLE
Avoid that lone atoms which are part of a ring in one of the molecules become part of the MCS

### DIFF
--- a/Code/GraphMol/FMCS/MaximumCommonSubgraph.cpp
+++ b/Code/GraphMol/FMCS/MaximumCommonSubgraph.cpp
@@ -956,6 +956,9 @@ MCSResult MaximumCommonSubgraph::find(const std::vector<ROMOL_SPTR>& src_mols) {
   if (Parameters.BondCompareParameters.CompleteRingsOnly) {
     Parameters.BondCompareParameters.RingMatchesRingOnly = true;
   }
+  if (Parameters.AtomCompareParameters.CompleteRingsOnly) {
+    Parameters.AtomCompareParameters.RingMatchesRingOnly = true;
+  }
 
   for (const auto& src_mol : src_mols) {
     Molecules.push_back(src_mol.get());

--- a/Code/GraphMol/FMCS/Wrap/testFMCS.py
+++ b/Code/GraphMol/FMCS/Wrap/testFMCS.py
@@ -1126,7 +1126,7 @@ class TestCase(unittest.TestCase):
         res = rdFMCS.FindMCS(mols, params)
         self.assertEqual(res.numAtoms, 10)
         self.assertEqual(res.numBonds, 11)
-        self.assertEqual(res.smartsString, "[#6]1:&@[#6]:&@[#6]:&@[#6]2:&@[#6](:&@[#6]:&@1):&@[#6]:&@[#6]:&@[#6]:&@[#6]:&@2")
+        self.assertEqual(res.smartsString, "[#6&R]1:&@[#6&R]:&@[#6&R]:&@[#6&R]2:&@[#6&R](:&@[#6&R]:&@1):&@[#6&R]:&@[#6&R]:&@[#6&R]:&@[#6&R]:&@2")
 
         params = rdFMCS.MCSParameters()
         params.AtomCompareParameters.CompleteRingsOnly = True
@@ -1135,11 +1135,28 @@ class TestCase(unittest.TestCase):
         res = rdFMCS.FindMCS(mols, params)
         self.assertEqual(res.numAtoms, 10)
         self.assertEqual(res.numBonds, 11)
-        self.assertEqual(res.smartsString, "[#6]1:&@[#6]:&@[#6]:&@[#6]2:&@[#6](:&@[#6]:&@1):&@[#6]:&@[#6]:&@[#6]:&@[#6]:&@2")
+        self.assertEqual(res.smartsString, "[#6&R]1:&@[#6&R]:&@[#6&R]:&@[#6&R]2:&@[#6&R](:&@[#6&R]:&@1):&@[#6&R]:&@[#6&R]:&@[#6&R]:&@[#6&R]:&@2")
 
     def test19MCS3d(self):
         Common.test19MCS3d(self)
 
+    def test20AtomCompareCompleteRingsOnly(self):
+        mols = [Chem.MolFromSmiles(smi) for smi in ["C1CCCC1C", "C1CCCC1C1CCCCC1"]]
+        params = rdFMCS.MCSParameters()
+        params.AtomCompareParameters.CompleteRingsOnly = True
+        res = rdFMCS.FindMCS(mols, params)
+        self.assertEqual(res.numAtoms, 5)
+        self.assertEqual(res.numBonds, 5)
+        self.assertEqual(res.smartsString, "[#6&R]1-&@[#6&R]-&@[#6&R]-&@[#6&R]-&@[#6&R]-&@1")
+
+        params = rdFMCS.MCSParameters()
+        params.AtomCompareParameters.CompleteRingsOnly = True
+        # this will automatically be set to True
+        params.BondCompareParameters.CompleteRingsOnly = False
+        res = rdFMCS.FindMCS(mols, params)
+        self.assertEqual(res.numAtoms, 5)
+        self.assertEqual(res.numBonds, 5)
+        self.assertEqual(res.smartsString, "[#6&R]1-&@[#6&R]-&@[#6&R]-&@[#6&R]-&@[#6&R]-&@1")
 
 if __name__ == "__main__":
     unittest.main()

--- a/Code/GraphMol/FMCS/testFMCS_Unit.cpp
+++ b/Code/GraphMol/FMCS/testFMCS_Unit.cpp
@@ -2382,8 +2382,8 @@ void testGitHub3693() {
       TEST_ASSERT(res.NumAtoms == 10);
       TEST_ASSERT(res.NumBonds == 11);
       TEST_ASSERT(res.SmartsString ==
-                  "[#6]1:&@[#6]:&@[#6]:&@[#6]2:&@[#6](:&@[#6]:&@1):&@[#6]:&@[#"
-                  "6]:&@[#6]:&@[#6]:&@2");
+                  "[#6&R]1:&@[#6&R]:&@[#6&R]:&@[#6&R]2:&@[#6&R](:&@[#6&R]:&@1):"
+                  "&@[#6&R]:&@[#6&R]:&@[#6&R]:&@[#6&R]:&@2");
     }
     {
       MCSParameters p;
@@ -2393,8 +2393,8 @@ void testGitHub3693() {
       TEST_ASSERT(res.NumAtoms == 10);
       TEST_ASSERT(res.NumBonds == 11);
       TEST_ASSERT(res.SmartsString ==
-                  "[#6]1:&@[#6]:&@[#6]:&@[#6]2:&@[#6](:&@[#6]:&@1):&@[#6]:&@[#"
-                  "6]:&@[#6]:&@[#6]:&@2");
+                  "[#6&R]1:&@[#6&R]:&@[#6&R]:&@[#6&R]2:&@[#6&R](:&@[#6&R]:&@1):"
+                  "&@[#6&R]:&@[#6&R]:&@[#6&R]:&@[#6&R]:&@2");
     }
     {
       MCSParameters p;
@@ -2405,11 +2405,10 @@ void testGitHub3693() {
       TEST_ASSERT(res.NumAtoms == 10);
       TEST_ASSERT(res.NumBonds == 11);
       TEST_ASSERT(res.SmartsString ==
-                  "[#6]1:&@[#6]:&@[#6]:&@[#6]2:&@[#6](:&@[#6]:&@1):&@[#6]:&@[#"
-                  "6]:&@[#6]:&@[#6]:&@2");
+                  "[#6&R]1:&@[#6&R]:&@[#6&R]:&@[#6&R]2:&@[#6&R](:&@[#6&R]:&@1):"
+                  "&@[#6&R]:&@[#6&R]:&@[#6&R]:&@[#6&R]:&@2");
     }
   }
-
   BOOST_LOG(rdInfoLog) << "============================================"
                        << std::endl;
   BOOST_LOG(rdInfoLog) << "\tdone" << std::endl;
@@ -2433,6 +2432,39 @@ void testGitHub3886() {
   TEST_ASSERT(res.NumAtoms == 5);
   TEST_ASSERT(res.NumBonds == 4);
   TEST_ASSERT(res.SmartsString == "[#6](:[#6]:[#6]:[#6]):[#6]");
+  BOOST_LOG(rdInfoLog) << "============================================"
+                       << std::endl;
+  BOOST_LOG(rdInfoLog) << "\tdone" << std::endl;
+}
+
+void testAtomCompareCompleteRingsOnly() {
+  BOOST_LOG(rdInfoLog) << "-------------------------------------" << std::endl;
+  BOOST_LOG(rdInfoLog)
+      << "When AtomCompareParameters.CompleteRingsOnly is true single atoms "
+         "which are part of a ring in one of the molecules should not be "
+         "included in MCS"
+      << std::endl;
+  std::vector<ROMOL_SPTR> mols = {"C1CCCC1C"_smiles, "C1CCCC1C1CCCCC1"_smiles};
+  {
+    MCSParameters p;
+    p.AtomCompareParameters.CompleteRingsOnly = true;
+    MCSResult res = findMCS(mols, &p);
+    TEST_ASSERT(res.NumAtoms == 5);
+    TEST_ASSERT(res.NumBonds == 5);
+    TEST_ASSERT(res.SmartsString ==
+                "[#6&R]1-&@[#6&R]-&@[#6&R]-&@[#6&R]-&@[#6&R]-&@1");
+  }
+  {
+    MCSParameters p;
+    p.AtomCompareParameters.CompleteRingsOnly = true;
+    // this will automatically be set to true
+    p.AtomCompareParameters.RingMatchesRingOnly = false;
+    MCSResult res = findMCS(mols, &p);
+    TEST_ASSERT(res.NumAtoms == 5);
+    TEST_ASSERT(res.NumBonds == 5);
+    TEST_ASSERT(res.SmartsString ==
+                "[#6&R]1-&@[#6&R]-&@[#6&R]-&@[#6&R]-&@[#6&R]-&@1");
+  }
   BOOST_LOG(rdInfoLog) << "============================================"
                        << std::endl;
   BOOST_LOG(rdInfoLog) << "\tdone" << std::endl;
@@ -2520,6 +2552,7 @@ int main(int argc, const char* argv[]) {
   testGitHub3458();
   testGitHub3693();
   testGitHub3886();
+  testAtomCompareCompleteRingsOnly();
 
   unsigned long long t1 = nanoClock();
   double sec = double(t1 - T0) / 1000000.;


### PR DESCRIPTION
While looking at some of the test cases in #4019 I have noticed that currently the MCS does not do what is expected in this case:

```
mol1 = Chem.MolFromSmiles("C1CCCC1C")
mol2 = Chem.MolFromSmiles("C1CCCC1C1CCCCC1")

MolsToGridImage((mol1, mol2))
```
![image](https://user-images.githubusercontent.com/5244385/115526902-ce982580-a290-11eb-96db-9c3e03213806.png)
```
ps = rdFMCS.MCSParameters()
ps.AtomCompareParameters.CompleteRingsOnly = True
ps.timeout = 300
res = rdFMCS.FindMCS((mol1, mol2), ps)
res.queryMol
```
![image](https://user-images.githubusercontent.com/5244385/115526974-e4a5e600-a290-11eb-9617-8217470d15f4.png)

As `AtomCompareParameters.CompleteRingsOnly` was set to `True`, atom 5 should not be part of the MCS, as we have requested that only atoms which are part of a complete ring are included, and this is not the case.
The reason why this happens is that in #3695, when I implemented the `AtomCompareParameters.CompleteRingsOnly` parameter (in addition to the already existing `BondCompareParameters.CompleteRingsOnly`), I omitted to also set the `AtomCompareParameters.RingMatchesRingOnly` flag (as already happened for its `BondCompareParameters.CompleteRingsOnly` counterpart).
In fact, as `AtomCompareParameters.CompleteRingsOnly` implies `BondCompareParameters.CompleteRingsOnly`, a non-ring atom can never be matched to a ring atom as that would imply including an incomplete ring in the MCS.

With this change, the MCS returned in the above test case is cyclopentane, as expected.
I had to tweak the results of a few unit tests that I added in #3695 as the expected result did not include atom ring specifiers in the SMARTS string, as they should have.