### PR TITLE
Added function to explicitly delete RDKit mol in JSMol.

### DIFF
--- a/Code/MinimalLib/jswrapper.cpp
+++ b/Code/MinimalLib/jswrapper.cpp
@@ -93,6 +93,7 @@ std::string draw_to_canvas_with_highlights(JSMol &self, emscripten::val canvas,
 using namespace emscripten;
 EMSCRIPTEN_BINDINGS(RDKit_minimal) {
   class_<JSMol>("Mol")
+      .function("delete_mol", &JSMol::delete_mol)
       .function("is_valid", &JSMol::is_valid)
       .function("get_smiles", &JSMol::get_smiles)
       .function("get_cxsmiles", &JSMol::get_cxsmiles)

--- a/Code/MinimalLib/minilib.h
+++ b/Code/MinimalLib/minilib.h
@@ -15,6 +15,7 @@ class JSMol {
  public:
   JSMol() : d_mol(nullptr){};
   JSMol(RDKit::RWMol *mol) : d_mol(mol){};
+  void delete_mol() { d_mol.reset(nullptr); }
   std::string get_smiles() const;
   std::string get_cxsmiles() const;
   std::string get_molblock() const;


### PR DESCRIPTION
#### Reference Issue
<!-- Example: Fixes #1234 -->
Addresses discussion point #4066

#### What does this implement/fix? Explain your changes.
This adds a delete_mol function to JSMol to free the underlying RWMol.

#### Any other comments?
I found that when processing large lists of molecules in a loop, the garbage collector didn't free the memory fast enough, and I got an OOM error.  This solved it.
Tested by building with supplied Dockerfile and run on a MacBook under Catalina, with Safari and Firefox.

