### PR TITLE
Fixes #4102

### DIFF
--- a/Code/MinimalLib/cffi_test.c
+++ b/Code/MinimalLib/cffi_test.c
@@ -420,48 +420,58 @@ void test_standardize(){
   mpkl = get_mol("[Pt]CCN(=O)=O",&mpkl_size,"{\"sanitize\":false}");
   char *smi = get_smiles(mpkl,mpkl_size,"");
   assert(!strcmp(smi,"O=N(=O)CC[Pt]"));
+  free(smi);
   assert(cleanup(&mpkl,&mpkl_size,"")>0);
   smi = get_smiles(mpkl,mpkl_size,"");
   assert(!strcmp(smi,"[CH2-]C[N+](=O)[O-].[Pt+]"));
+  free(smi);
 
   assert(fragment_parent(&mpkl,&mpkl_size,"")>0);
   smi = get_smiles(mpkl,mpkl_size,"");
   assert(!strcmp(smi,"[CH2-]C[N+](=O)[O-]"));
-
+  free(smi);
+  
   assert(charge_parent(&mpkl,&mpkl_size,"")>0);
   smi = get_smiles(mpkl,mpkl_size,"");
   assert(!strcmp(smi,"CC[N+](=O)[O-]"));
-
+  free(smi);
   free(mpkl);
+  
   mpkl = get_mol("[Pt]CCN(=O)=O",&mpkl_size,"{\"sanitize\":false}");
   assert(charge_parent(&mpkl,&mpkl_size,"")>0);
   smi = get_smiles(mpkl,mpkl_size,"");
   assert(!strcmp(smi,"CC[N+](=O)[O-]"));
-
+  free(smi);
   free(mpkl);
+
   mpkl = get_mol("[Pt]CCN(=O)=O",&mpkl_size,"{\"sanitize\":false}");
   assert(charge_parent(&mpkl,&mpkl_size,"{\"skipStandardize\":true}")>0);
   smi = get_smiles(mpkl,mpkl_size,"");
   assert(!strcmp(smi,"[CH2-]C[N+](=O)[O-].[Pt+]"));
-
+  free(smi);
   free(mpkl);
+
   mpkl = get_mol("[CH2-]CN(=O)=O",&mpkl_size,"{\"sanitize\":false}");
   assert(neutralize(&mpkl,&mpkl_size,"")>0);
   smi = get_smiles(mpkl,mpkl_size,"");
   assert(!strcmp(smi,"CCN(=O)=O"));
-
+  free(smi);
   free(mpkl);
+  
   mpkl = get_mol("[O-]c1cc(C(=O)O)ccc1",&mpkl_size,"");
   assert(reionize(&mpkl,&mpkl_size,"")>0);
   smi = get_smiles(mpkl,mpkl_size,"");
   assert(!strcmp(smi,"O=C([O-])c1cccc(O)c1"));
-
+  free(smi);
   free(mpkl);
+  
   mpkl = get_mol("OC(O)C(=N)CO",&mpkl_size,"");
   assert(canonical_tautomer(&mpkl,&mpkl_size,"")>0);
   smi = get_smiles(mpkl,mpkl_size,"");
   assert(!strcmp(smi,"NC(CO)C(=O)O"));
-
+  free(smi);
+  free(mpkl);
+  
   enable_logging();
   printf("  done\n");
   printf("--------------------------\n"); 
@@ -470,7 +480,10 @@ void test_standardize(){
 
 int main(){
   enable_logging();
-  printf("hello %s\n",version()); 
+  char *vers=version();
+  printf("hello %s\n",vers);
+  free(vers); 
+
   test_io();
   test_svg();
   test_substruct();

--- a/Code/MinimalLib/cffiwrapper.cpp
+++ b/Code/MinimalLib/cffiwrapper.cpp
@@ -265,7 +265,7 @@ extern "C" char *get_inchikey_for_inchi(const char *inchi) {
 
 extern "C" char *get_mol(const char *input, size_t *pkl_sz,
                          const char *details_json) {
-  RWMol *mol = MinimalLib::mol_from_input(input, details_json);
+  std::unique_ptr<RWMol> mol{MinimalLib::mol_from_input(input, details_json)};
   if (!mol) {
     *pkl_sz = 0;
     return NULL;
@@ -278,7 +278,7 @@ extern "C" char *get_mol(const char *input, size_t *pkl_sz,
 }
 extern "C" char *get_qmol(const char *input, size_t *pkl_sz,
                           const char *details_json) {
-  RWMol *mol = MinimalLib::qmol_from_input(input, details_json);
+  std::unique_ptr<RWMol> mol{MinimalLib::qmol_from_input(input, details_json)};
   if (!mol) {
     *pkl_sz = 0;
     return str_to_c("Error!");


### PR DESCRIPTION
switch to using `std::unique_ptr` in `get_mol()` and `get_qmol()`

also clears up some leaked memory in the C test so that it can be run in valgrind