### PR TITLE
Allow MolToQPixmap to support PySide2

### DIFF
--- a/rdkit/Chem/Draw/UnitTestDraw.py
+++ b/rdkit/Chem/Draw/UnitTestDraw.py
@@ -107,10 +107,12 @@ class TestCase(unittest.TestCase):
   def testQtImage(self):
     try:
       from PySide import QtGui
-      _ = QtGui.QApplication(sys.argv)
     except ImportError:
-      from PyQt5 import QtGui
-      _ = QtGui.QGuiApplication(sys.argv)
+      try:
+        from PyQt5 import QtGui
+      except ImportError:
+        from PySide2 import QtGui
+    _ = QtGui.QGuiApplication(sys.argv)
     img = Draw.MolToQPixmap(self.mol, size=(300, 300))
     self.assertTrue(img)
     self.assertEqual(img.size().height(), 300)

--- a/rdkit/Chem/Draw/qtCanvas.py
+++ b/rdkit/Chem/Draw/qtCanvas.py
@@ -12,7 +12,10 @@ from rdkit.Chem.Draw.canvasbase import CanvasBase
 try:
   from PySide import QtGui, QtCore
 except ImportError:
-  from PyQt5 import QtGui, QtCore
+  try:
+    from PyQt5 import QtGui, QtCore
+  except ImportError:
+    from PySide2 import QtGui, QtCore
 
 
 class Canvas(CanvasBase):


### PR DESCRIPTION
Fixes #4105

This pull request adds `PySide2` to the list of Qt/Python backend supported by `MolToQPixmap`. As `PyQt5` is already supported, support for `PySide2` can be easily extended. `PySide2` is added at the end so that the existing precedence is unchanged. Furthermore, it seems more logical to try Qt4 -> Qt5 backends instead of trying PySideN packages -> PyQtN packages and crisscrossing Qt versions in doing that.

Comments:
I could not work out how the `testQtImage` test is exercised on continuous integration. Should there be changes to how CI dependencies are set up, e.g. to add PySide2 as an installed package?

This does change the ImportError message. Previously if nothing can be found, the error message complains about PyQt5 (without mentioning having tried PySide). Now the error would complain about PySide2 (without mentioning having tried PyQt5 or PySide). I am guessing this detail is probably not a public API.