### PR TITLE
Fixes #4115

### DIFF
--- a/Code/GraphMol/Chirality.cpp
+++ b/Code/GraphMol/Chirality.cpp
@@ -2609,6 +2609,8 @@ void removeStereochemistry(ROMol &mol) {
       (*bondIt)->setBondDir(Bond::NONE);
     }
   }
+  std::vector<StereoGroup> sgs;
+  static_cast<RWMol &>(mol).setStereoGroups(std::move(sgs));
 }
 
 }  // end of namespace MolOps

--- a/Code/GraphMol/catch_chirality.cpp
+++ b/Code/GraphMol/catch_chirality.cpp
@@ -1363,3 +1363,22 @@ TEST_CASE("N Chirality in rings") {
     }
   }
 }
+
+TEST_CASE(
+    "Github #4115: RemoveStereochemistry should also remove stereogroups") {
+  SECTION("basics") {
+    auto mol = "C[C@H](O)[C@@H](C)F |o1:1,3,r|"_smiles;
+    REQUIRE(mol);
+    CHECK(mol->getAtomWithIdx(1)->getChiralTag() !=
+          Atom::ChiralType::CHI_UNSPECIFIED);
+    CHECK(mol->getAtomWithIdx(3)->getChiralTag() !=
+          Atom::ChiralType::CHI_UNSPECIFIED);
+    CHECK(mol->getStereoGroups().size() == 1);
+    MolOps::removeStereochemistry(*mol);
+    CHECK(mol->getAtomWithIdx(1)->getChiralTag() ==
+          Atom::ChiralType::CHI_UNSPECIFIED);
+    CHECK(mol->getAtomWithIdx(3)->getChiralTag() ==
+          Atom::ChiralType::CHI_UNSPECIFIED);
+    CHECK(mol->getStereoGroups().empty());
+  }
+}


### PR DESCRIPTION
simple, though a bit ugly because of the need to cast from ROMol to RWMol

We should consider moving `RWMol::setStereoGroups()` to `ROMol` since you can change stereo info in the ROMol, but that's clearly not for this PR.