### PR TITLE
Avoid that MolStandardizer segfaults on empty mols

### DIFF
--- a/Code/GraphMol/MolStandardize/Fragment.cpp
+++ b/Code/GraphMol/MolStandardize/Fragment.cpp
@@ -160,6 +160,9 @@ ROMol *LargestFragmentChooser::choose(const ROMol &mol) {
   BOOST_LOG(rdInfoLog) << "Running LargestFragmentChooser\n";
 
   std::vector<boost::shared_ptr<ROMol>> frags = MolOps::getMolFrags(mol);
+  if (frags.empty()) {
+    return new ROMol();
+  }
   LargestFragmentChooser::Largest l;
 
   for (const auto &frag : frags) {

--- a/Code/GraphMol/MolStandardize/Normalize.cpp
+++ b/Code/GraphMol/MolStandardize/Normalize.cpp
@@ -86,6 +86,9 @@ ROMol *Normalizer::normalize(const ROMol &mol) {
     ROMOL_SPTR nfrag(this->normalizeFragment(*frag, transforms));
     nfrags.push_back(nfrag);
   }
+  if (nfrags.empty()) {
+    return new ROMol();
+  }
   auto *outmol = new ROMol(*(nfrags.back()));
   nfrags.pop_back();
   for (const auto &nfrag : nfrags) {

--- a/Code/GraphMol/MolStandardize/testFragment.cpp
+++ b/Code/GraphMol/MolStandardize/testFragment.cpp
@@ -243,6 +243,17 @@ void testFragmentWithoutSmarts() {
   BOOST_LOG(rdInfoLog) << "---- Done" << std::endl;
 }
 
+void testEmptyMol() {
+  BOOST_LOG(rdInfoLog)
+      << "-----------------------\n Test that "
+         "LargestFragmentChooser does not crash on an empty mol"
+      << std::endl;
+  LargestFragmentChooser lfragchooser;
+  std::unique_ptr<ROMol> emptyMol(new ROMol());
+  std::unique_ptr<ROMol> largestMol(lfragchooser.choose(*emptyMol));
+  TEST_ASSERT(!largestMol->getNumAtoms());
+}
+
 int main() {
   // may want to enable this for debugging
   // RDLog::InitLogs();
@@ -250,5 +261,6 @@ int main() {
   test_largest_fragment();
   testWhiteSpaceInSmarts();
   testFragmentWithoutSmarts();
+  testEmptyMol();
   return 0;
 }

--- a/Code/GraphMol/MolStandardize/testNormalize.cpp
+++ b/Code/GraphMol/MolStandardize/testNormalize.cpp
@@ -471,6 +471,16 @@ void testGithub3460() {
   BOOST_LOG(rdInfoLog) << "Finished" << std::endl;
 }
 
+void testEmptyMol() {
+  BOOST_LOG(rdInfoLog) << "-----------------------\n Test that Normalizer "
+                          "does not crash on an empty mol"
+                       << std::endl;
+  Normalizer nn;
+  std::unique_ptr<ROMol> emptyMol(new ROMol());
+  std::unique_ptr<ROMol> normalized(nn.normalize(*emptyMol));
+  TEST_ASSERT(!normalized->getNumAtoms());
+}
+
 int main() {
   RDLog::InitLogs();
 #if 1
@@ -480,5 +490,6 @@ int main() {
   testGithub2414();
   testNormalizeMultipleAltSmarts();
   testGithub3460();
+  testEmptyMol();
   return 0;
 }


### PR DESCRIPTION
I have just verified the the `MolStandardizer` segfaults on empty mols due to a couple of attempts to access items of an empty vector.