### PR TITLE
Fixes #4138

### DIFF
--- a/Code/GraphMol/Substruct/CMakeLists.txt
+++ b/Code/GraphMol/Substruct/CMakeLists.txt
@@ -9,4 +9,4 @@ rdkit_headers(SubstructMatch.h
 
 rdkit_test(testSubstructMatch test1.cpp LINK_LIBRARIES FileParsers SmilesParse SubstructMatch)
 
-rdkit_catch_test(substructTestCatch catch_tests.cpp LINK_LIBRARIES FileParsers SmilesParse SubstructMatch)
+rdkit_catch_test(substructTestCatch ../catch_main.cpp catch_tests.cpp LINK_LIBRARIES FileParsers SmilesParse SubstructMatch)

--- a/Code/GraphMol/Substruct/SubstructMatch.cpp
+++ b/Code/GraphMol/Substruct/SubstructMatch.cpp
@@ -415,6 +415,10 @@ void ResSubstructMatchHelper_(const ResSubstructMatchHelperArgs_ &args,
 std::vector<MatchVectType> SubstructMatch(
     const ROMol &mol, const ROMol &query,
     const SubstructMatchParameters &params) {
+  std::vector<MatchVectType> matches;
+  if (!mol.getNumAtoms() || !query.getNumAtoms()) {
+    return matches;
+  }
   std::vector<RecursiveStructureQuery *> locked;
 #ifdef RDK_THREADSAFE_SSS
   locked.reserve(query.getNumAtoms());
@@ -444,7 +448,6 @@ std::vector<MatchVectType> SubstructMatch(
       boost::vf2_all(query.getTopology(), mol.getTopology(), atomLabeler,
                      bondLabeler, matchChecker, pms, params.maxMatches);
 #endif
-  std::vector<MatchVectType> matches;
   if (found) {
     unsigned int nQueryAtoms = query.getNumAtoms();
     matches.reserve(pms.size());

--- a/Code/GraphMol/Substruct/catch_tests.cpp
+++ b/Code/GraphMol/Substruct/catch_tests.cpp
@@ -10,7 +10,6 @@
 // Tests of substructure searching
 //
 
-#define CATCH_CONFIG_MAIN
 #include "catch.hpp"
 
 #include <tuple>
@@ -267,5 +266,47 @@ TEST_CASE("Enhanced stereochemistry", "[substruct][StereoGroup]") {
     CHECK_THAT(*mol_or_partial, IsSubstructOf(*mol_or_long, ps));
     CHECK_THAT(*mol_or_partial, IsSubstructOf(*mol_and_long, ps));
     CHECK_THAT(*mol_and_partial, !IsSubstructOf(*mol_or_long, ps));
+  }
+}
+
+TEST_CASE("Github #4138: empty query produces non-empty results",
+          "[substruct][bug]") {
+  auto mol = "C1CCCCO1"_smiles;
+  auto emol = ""_smiles;
+  auto qry = "C"_smarts;
+  auto eqry = ""_smarts;
+  REQUIRE(mol);
+  REQUIRE(qry);
+  SECTION("empty query") {
+    {
+      auto matches = SubstructMatch(*mol, *eqry);
+      CHECK(matches.empty());
+    }
+    {
+      std::vector<MatchVectType> matches;
+      CHECK(SubstructMatch(*mol, *eqry, matches) == false);
+      CHECK(matches.empty());
+    }
+    {
+      MatchVectType match;
+      CHECK(SubstructMatch(*mol, *eqry, match) == false);
+      CHECK(match.empty());
+    }
+  }
+  SECTION("empty mol") {
+    {
+      auto matches = SubstructMatch(*emol, *qry);
+      CHECK(matches.empty());
+    }
+    {
+      std::vector<MatchVectType> matches;
+      CHECK(SubstructMatch(*emol, *qry, matches) == false);
+      CHECK(matches.empty());
+    }
+    {
+      MatchVectType match;
+      CHECK(SubstructMatch(*emol, *qry, match) == false);
+      CHECK(match.empty());
+    }
   }
 }

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -6547,6 +6547,19 @@ CAS<~>
       pass
     self.assertEqual(rwmol.GetNumAtoms(), mol.GetNumAtoms())
 
+  def testGithub4138(self):
+    m = Chem.MolFromSmiles('C1CCCO1')
+    q = Chem.MolFromSmarts('')
+    self.assertFalse(m.HasSubstructMatch(q))
+    self.assertEqual(m.GetSubstructMatch(q), ())
+    self.assertEqual(m.GetSubstructMatches(q), ())
+
+    m = Chem.MolFromSmiles('')
+    q = Chem.MolFromSmarts('C')
+    self.assertFalse(m.HasSubstructMatch(q))
+    self.assertEqual(m.GetSubstructMatch(q), ())
+    self.assertEqual(m.GetSubstructMatches(q), ())
+
 
 if __name__ == '__main__':
   if "RDTESTCASE" in os.environ:


### PR DESCRIPTION
adds a short-circuit test to the substructure matching so that it immediately returns an empty result set if either the molecule or the query is empty

