### PR TITLE
Fixes #4162

### DIFF
--- a/Code/GraphMol/ChemReactions/Reaction.h
+++ b/Code/GraphMol/ChemReactions/Reaction.h
@@ -126,17 +126,17 @@ class RDKIT_CHEMREACTIONS_EXPORT ChemicalReaction : public RDProps {
     df_implicitProperties = other.df_implicitProperties;
     for (MOL_SPTR_VECT::const_iterator iter = other.beginReactantTemplates();
          iter != other.endReactantTemplates(); ++iter) {
-      ROMol *reactant = new ROMol(**iter);
+      RWMol *reactant = new RWMol(**iter);
       m_reactantTemplates.push_back(ROMOL_SPTR(reactant));
     }
     for (MOL_SPTR_VECT::const_iterator iter = other.beginProductTemplates();
          iter != other.endProductTemplates(); ++iter) {
-      ROMol *product = new ROMol(**iter);
+      RWMol *product = new RWMol(**iter);
       m_productTemplates.push_back(ROMOL_SPTR(product));
     }
     for (MOL_SPTR_VECT::const_iterator iter = other.beginAgentTemplates();
          iter != other.endAgentTemplates(); ++iter) {
-      ROMol *agent = new ROMol(**iter);
+      RWMol *agent = new RWMol(**iter);
       m_agentTemplates.push_back(ROMOL_SPTR(agent));
     }
     d_props = other.d_props;

--- a/Code/GraphMol/ChemReactions/ReactionPickler.cpp
+++ b/Code/GraphMol/ChemReactions/ReactionPickler.cpp
@@ -220,7 +220,7 @@ void ReactionPickler::_depickle(std::istream &ss, ChemicalReaction *rxn,
         "Bad pickle format: BEGINREACTANTS tag not found.");
   }
   for (unsigned int i = 0; i < numReactants; ++i) {
-    auto *mol = new ROMol();
+    auto *mol = new RWMol();
     MolPickler::molFromPickle(ss, mol);
     rxn->addReactantTemplate(ROMOL_SPTR(mol));
   }
@@ -235,7 +235,7 @@ void ReactionPickler::_depickle(std::istream &ss, ChemicalReaction *rxn,
         "Bad pickle format: BEGINPRODUCTS tag not found.");
   }
   for (unsigned int i = 0; i < numProducts; ++i) {
-    auto *mol = new ROMol();
+    auto *mol = new RWMol();
     MolPickler::molFromPickle(ss, mol);
     rxn->addProductTemplate(ROMOL_SPTR(mol));
   }
@@ -251,7 +251,7 @@ void ReactionPickler::_depickle(std::istream &ss, ChemicalReaction *rxn,
           "Bad pickle format: BEGINAGENTS tag not found.");
     }
     for (unsigned int i = 0; i < numAgents; ++i) {
-      auto *mol = new ROMol();
+      auto *mol = new RWMol();
       MolPickler::molFromPickle(ss, mol);
       rxn->addAgentTemplate(ROMOL_SPTR(mol));
     }

--- a/Code/GraphMol/ChemReactions/Wrap/testSanitize.py
+++ b/Code/GraphMol/ChemReactions/Wrap/testSanitize.py
@@ -32,7 +32,6 @@
 
 import unittest
 import os,sys
-
 import pickle
 
 from rdkit import rdBase
@@ -325,6 +324,25 @@ class TestCase(unittest.TestCase) :
         
         groups = rxn.RunReactants([Chem.MolFromSmiles("c1ccccc1")])
         self.assertTrue(len(groups[0]))
+
+    def test_github_4162(self):
+        rxn = rdChemReactions.ReactionFromSmarts(
+            "[C:1](=[O:2])-[OD1].[N!H0:3]>>[C:1](=[O:2])[N:3]")
+        rxn_copy = rdChemReactions.ChemicalReaction(rxn)
+        rdChemReactions.SanitizeRxn(rxn)
+        rdChemReactions.SanitizeRxn(rxn_copy)
+        pkl = rxn.ToBinary()
+        rxn_from_pickle = rdChemReactions.ChemicalReaction(pkl)
+        rdChemReactions.SanitizeRxn(rxn_from_pickle)
+        pkl = pickle.dumps(rxn)
+        rxn_from_pickle = pickle.loads(pkl)
+        rdChemReactions.SanitizeRxn(rxn_from_pickle)
+        pkl = rxn_from_pickle.ToBinary()
+        rxn_from_pickle = rdChemReactions.ChemicalReaction(pkl)
+        rdChemReactions.SanitizeRxn(rxn_from_pickle)
+        pkl = pickle.dumps(rxn_from_pickle)
+        rxn_from_pickle = pickle.loads(pkl)
+        rdChemReactions.SanitizeRxn(rxn_from_pickle)
         
 
         

--- a/Code/GraphMol/ChemReactions/testReaction.cpp
+++ b/Code/GraphMol/ChemReactions/testReaction.cpp
@@ -7523,6 +7523,22 @@ void testGithub3078() {
   TEST_ASSERT(!bond->hasProp("_UnknownStereoRxnBond"));
 }
 
+void testGithub4162() {
+  const std::string reaction(
+      R"([C:1](=[O:2])-[OD1].[N!H0:3]>>[C:1](=[O:2])[N:3])");
+  std::unique_ptr<ChemicalReaction> rxn(RxnSmartsToChemicalReaction(reaction));
+  std::unique_ptr<ChemicalReaction> rxnCopy(new ChemicalReaction(*rxn));
+  RxnOps::sanitizeRxn(*rxn);
+  RxnOps::sanitizeRxn(*rxnCopy);
+  std::string pkl;
+  ReactionPickler::pickleReaction(*rxn, pkl);
+  std::unique_ptr<ChemicalReaction> rxnFromPickle(new ChemicalReaction(pkl));
+  RxnOps::sanitizeRxn(*rxnFromPickle);
+  ReactionPickler::pickleReaction(*rxnFromPickle, pkl);
+  rxnFromPickle.reset(new ChemicalReaction(pkl));
+  RxnOps::sanitizeRxn(*rxnFromPickle);
+}
+
 int main() {
   RDLog::InitLogs();
 
@@ -7616,6 +7632,7 @@ int main() {
   testDblBondCrash();
   testRxnBlockRemoveHs();
   testGithub3078();
+  testGithub4162();
 
   BOOST_LOG(rdInfoLog)
       << "*******************************************************\n";


### PR DESCRIPTION
The `ChemicalReaction` copy constructor and the `ReactionPickler` `_depickler ` create `ROMol`s, while `constructMolFromString` creates `RWMol`s which are then cast to `ROMol`s. This is why the `dynamic_cast` performed by `RxnOps::sanitizeRxn` failed with the copy constructor and the depickler, while it succeeded on the reaction created directly from SMARTS.
This PR sets the copy constructor and the depickler to create `RWMol`s and adds relevant C++ and Python tests.