### PR TITLE
Fixes #4144

### DIFF
--- a/Code/GraphMol/Wrap/Mol.cpp
+++ b/Code/GraphMol/Wrap/Mol.cpp
@@ -33,6 +33,10 @@ namespace python = boost::python;
 
 namespace RDKit {
 
+void MolClearComputedPropsHelper(const ROMol &mol, bool includeRings) {
+  mol.clearComputedProps(includeRings);
+}
+
 python::object MolToBinary(const ROMol &self) {
   std::string res;
   {
@@ -712,7 +716,8 @@ struct mol_wrapper {
              "  ARGUMENTS:\n"
              "    - key: the name of the property to clear (a string).\n")
 
-        .def("ClearComputedProps", MolClearComputedProps<ROMol>,
+        .def("ClearComputedProps", MolClearComputedPropsHelper,
+             (python::arg("self"), python::arg("includeRings") = true),
              "Removes all computed properties from the molecule.\n\n")
 
         .def("UpdatePropertyCache", &ROMol::updatePropertyCache,

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -6560,6 +6560,19 @@ CAS<~>
     self.assertEqual(m.GetSubstructMatch(q), ())
     self.assertEqual(m.GetSubstructMatches(q), ())
 
+  def testGithub4144(self):
+    ''' the underlying problem with #4144 was that the 
+    includeRings argument could not be passed to ClearComputedProps() 
+    from Python. Make sure that's fixed
+    '''
+    m = Chem.MolFromSmiles('c1ccccc1')
+    self.assertEqual(m.GetRingInfo().NumRings(), 1)
+    m.ClearComputedProps(includeRings=False)
+    self.assertEqual(m.GetRingInfo().NumRings(), 1)
+    m.ClearComputedProps()
+    with self.assertRaises(RuntimeError):
+      m.GetRingInfo().NumRings()
+
 
 if __name__ == '__main__':
   if "RDTESTCASE" in os.environ:

--- a/rdkit/Chem/EnumerateStereoisomers.py
+++ b/rdkit/Chem/EnumerateStereoisomers.py
@@ -324,7 +324,7 @@ def EnumerateStereoisomers(m, options=StereoEnumerationOptions(), verbose=False)
       flippers[i].flip(flag)
     isomer = Chem.Mol(tm)
     Chem.SetDoubleBondNeighborDirections(isomer)
-    isomer.ClearComputedProps()
+    isomer.ClearComputedProps(includeRings=False)
 
     Chem.AssignStereochemistry(isomer, cleanIt=True, force=True, flagPossibleStereoCenters=True)
     if options.unique:

--- a/rdkit/Chem/UnitTestChem.py
+++ b/rdkit/Chem/UnitTestChem.py
@@ -1,5 +1,4 @@
-
-#  Copyright (C) 2001-2018  greg Landrum
+#  Copyright (C) 2001-2021  greg Landrum
 #
 #   @@ All Rights Reserved @@
 #  This file is part of the RDKit.
@@ -142,18 +141,17 @@ class TestCase(unittest.TestCase):
         assert not at.IsInRingSize(4), 'atom %d improperly in ring' % (i)
       else:
         assert at.IsInRingSize(4), 'atom %d not in ring of size 4' % (i)
-  @unittest.skipIf(not hasattr(Chem,"MolToJSON"),
-                     "MolInterchange support not enabled")
+
+  @unittest.skipIf(not hasattr(Chem, "MolToJSON"), "MolInterchange support not enabled")
   def testJSON1(self):
     """ JSON test1 """
     for smi in self.bigSmiList:
       m = Chem.MolFromSmiles(smi)
       json = Chem.MolToJSON(m)
       nm = Chem.JSONToMols(json)[0]
-      self.assertEqual(Chem.MolToSmiles(m),Chem.MolToSmiles(nm))
+      self.assertEqual(Chem.MolToSmiles(m), Chem.MolToSmiles(nm))
 
-  @unittest.skipIf(not hasattr(Chem,"MolToJSON"),
-                     "MolInterchange support not enabled")
+  @unittest.skipIf(not hasattr(Chem, "MolToJSON"), "MolInterchange support not enabled")
   def testJSON2(self):
     """ JSON test2 """
     ms = [Chem.MolFromSmiles(smi) for smi in self.bigSmiList]
@@ -161,16 +159,27 @@ class TestCase(unittest.TestCase):
     nms = Chem.JSONToMols(json)
     #for nm in nms:
     #  Chem.SanitizeMol(nm)
-    self.assertEqual(len(ms),len(nms))
+    self.assertEqual(len(ms), len(nms))
     smis1 = [Chem.MolToSmiles(x) for x in ms]
     smis2 = [Chem.MolToSmiles(x) for x in nms]
-    for i,(smi1,smi2) in enumerate(zip(smis1,smis2)):
+    for i, (smi1, smi2) in enumerate(zip(smis1, smis2)):
       if smi1 != smi2:
         print(self.bigSmiList[i])
         print(smi1)
         print(smi2)
         print("-------")
-    self.assertEqual(smis1,smis2)
+    self.assertEqual(smis1, smis2)
+
+  def testGithub4144(self):
+    """ github4144: EnumerateStereiosomers clearing ring info """
+    from rdkit.Chem import EnumerateStereoisomers
+    m = Chem.MolFromSmiles('CSCc1cnc(C=Nn2c(C)nc3sc4c(c3c2=O)CCCCC4)s1')
+    sssr = [list(x) for x in Chem.GetSymmSSSR(m)]
+    sms = EnumerateStereoisomers.EnumerateStereoisomers(m)
+    for sm in sms:
+      sssr2 = [list(x) for x in Chem.GetSymmSSSR(sm)]
+      self.assertEqual(sssr, sssr2)
+
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
Fixing this sensibly requires exposing the "new" `includeRings` argument to `clearComputedProps()` to Python, but we should have done that already anyway.
