### PR TITLE
fixes #4128

### DIFF
--- a/Code/GraphMol/Conformer.h
+++ b/Code/GraphMol/Conformer.h
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2001-2008 Greg Landrum and Rational Discovery LLC
+//  Copyright (C) 2001-2021 Greg Landrum and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -15,6 +15,7 @@
 #include <RDGeneral/types.h>
 #include <boost/smart_ptr.hpp>
 #include <RDGeneral/RDProps.h>
+#include <limits>
 
 namespace RDKit {
 class ROMol;
@@ -104,7 +105,9 @@ class RDKIT_GRAPHMOL_EXPORT Conformer : public RDProps {
 
   //! Set the position of the specified atom
   inline void setAtomPos(unsigned int atomId, const RDGeom::Point3D &position) {
-    // RANGE_CHECK(0,atomId,d_positions.size()-1);
+    if (atomId == std::numeric_limits<unsigned int>::max()) {
+      throw ValueErrorException("atom index overflow");
+    }
     if (atomId >= d_positions.size()) {
       d_positions.resize(atomId + 1, RDGeom::Point3D(0.0, 0.0, 0.0));
     }

--- a/Code/GraphMol/catch_graphmol.cpp
+++ b/Code/GraphMol/catch_graphmol.cpp
@@ -19,6 +19,7 @@
 #include <GraphMol/SmilesParse/SmilesWrite.h>
 #include <GraphMol/SmilesParse/SmartsWrite.h>
 #include <boost/format.hpp>
+#include <limits>
 
 using namespace RDKit;
 #if 1
@@ -2034,4 +2035,14 @@ TEST_CASE("github #4127: SEGV in ROMol::getAtomDegree if atom is not in graph",
     takeOwnership = false;
     CHECK(mol3->addBond(mol2->getBondWithIdx(0), takeOwnership) == 1);
   }
+}
+
+TEST_CASE(
+    "github #4128: SEGV from unsigned integer overflow in "
+    "Conformer::setAtomPos",
+    "[graphmol]") {
+  Conformer conf;
+  RDGeom::Point3D pt(0, 0, 0);
+  CHECK_THROWS_AS(conf.setAtomPos(std::numeric_limits<unsigned>::max(), pt),
+                  ValueErrorException);
 }


### PR DESCRIPTION
adds a check for the possible overflow in `Conformer::setAtomPos()` and throws a ValueError on overflow.

Maybe it should be a PRECONDITION instead to be consistent? Seems like a ValueError though.