### PR TITLE
Fix python to C++ pointer conversion issue in moldrawFromQPainter

### DIFF
--- a/Code/GraphMol/MolDraw2D/Qt/Wrap/rdMolDraw2DQt.cpp
+++ b/Code/GraphMol/MolDraw2D/Qt/Wrap/rdMolDraw2DQt.cpp
@@ -20,7 +20,7 @@
 namespace python = boost::python;
 
 namespace RDKit {
-MolDraw2DQt *moldrawFromQPainter(int width, int height, unsigned long ptr,
+MolDraw2DQt *moldrawFromQPainter(int width, int height, size_t ptr,
                                  int panelWidth, int panelHeight) {
   if (!ptr) {
     throw_value_error("QPainter pointer is null");


### PR DESCRIPTION
On 64-bit windows, I noticed that the value of `ptr`/`pointer_to_QPainter` can exceed the maximum `unsigned long int` value. In some cases, this caused an OverflowError when using `MolDraw2DFromQPainter` to make a PNG. I think that changing the `ptr` type to `size_t` should prevent this issue on all platforms, but there might be a better approach.

Here is the traceback I was getting:
```
    drawer = MolDraw2DFromQPainter(cpp_qp, options.width, options.height)
...\rdkit\Chem\Draw\__init__.py:177: in MolDraw2DFromQPainter
    d2d = rdMolDraw2DQt.MolDraw2DFromQPainter_(width, height, ptr, panelWidth, panelWidth)
E   OverflowError: Python int too large to convert to C unsigned long
--------------------- Captured stdout call -----------------------------
QPainter address: <PyQt5.QtGui.QPainter object at 0x000002A0856282E0>
```

