### PR TITLE
fixes #3967

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@
 #- Eclipse files
 /.project
 /.pydevproject
+/.cproject
+/.settings/
 
 #- CLion files
 /cmake-build-*

--- a/Code/GraphMol/SmilesParse/test.cpp
+++ b/Code/GraphMol/SmilesParse/test.cpp
@@ -4339,6 +4339,31 @@ void testOSSFuzzFailures() {
   BOOST_LOG(rdInfoLog) << "done" << std::endl;
 }
 
+void testGithub3967() {
+  RWMol *mol;
+  std::string smi;
+
+  BOOST_LOG(rdInfoLog) << "-------------------------------------" << std::endl;
+  BOOST_LOG(rdInfoLog) << "Testing Github Issue 3967: Double bond stereo gets flipped by SMILES reader/writer"
+                       << std::endl;
+
+  smi = "C=c1s/c2n(c1=O)CCCCCCC\\N=2";
+  mol = SmilesToMol(smi, 1);
+  TEST_ASSERT(mol);
+  smi = MolToSmiles(*mol);
+  TEST_ASSERT(smi == "C=c1s/c2n(c1=O)CCCCCCC\\N=2");
+  delete mol;
+
+  smi = "C1=C\\C/C=C2C3=C/C/C=C\\C=C/C\\3C\\2\\C=C/1";
+  mol = SmilesToMol(smi, 1);
+  TEST_ASSERT(mol);
+  smi = MolToSmiles(*mol);
+  TEST_ASSERT(smi == "C1=C\\C/C=C2C3=C/C/C=C\\C=C/C\\3C\\2\\C=C/1");
+  delete mol;
+
+  BOOST_LOG(rdInfoLog) << "\tdone" << std::endl;
+}
+
 int main(int argc, char *argv[]) {
   (void)argc;
   (void)argv;
@@ -4417,6 +4442,7 @@ int main(int argc, char *argv[]) {
   testdoRandomSmileGeneration();
   testGithub1028();
   testGithub3139();
+  testGithub3967();
 #endif
   testOSSFuzzFailures();
 }


### PR DESCRIPTION
Reference Issue
fixes #3967

What does this implement/fix? Explain your changes.

Seems like the two reported smiles issues are caused by two different bugs.

For "C=c1s/c2n(c1=O)CCCCCCC\\N=2" the bug seems like it's cause by the ring closure happening on the double bond. This condition is checked on line 384 in Canon.cpp

I struggled quite a bit figuring out exactly why "C1=C\\C/C=C2C3=C/C/C=C\\C=C/C\\3C\\2\\C=C/1" isn't working. It seems like it's a similar issue to the first one, but only because "secondFromAtom1" is not aromatic and is closing the ring. The condition for checking this is on lines 385-387 in Canon.cpp

I wanted to refactor this line into an inline function since it is use many times, but I didn't want to make this PR too big.
atom2Dir = (atom2Dir == Bond::ENDUPRIGHT) ? Bond::ENDDOWNRIGHT
                                                : Bond::ENDUPRIGHT;

