### PR TITLE
RWMol cleanup

### DIFF
--- a/Code/GraphMol/RWMol.cpp
+++ b/Code/GraphMol/RWMol.cpp
@@ -19,16 +19,10 @@
 #include "SubstanceGroup.h"
 
 namespace RDKit {
-void RWMol::destroy() {
-  ROMol::destroy();
-  d_partialBonds.clear();
-  d_partialBonds.resize(0);
-};
 
 RWMol &RWMol::operator=(const RWMol &other) {
   if (this != &other) {
     this->clear();
-    d_partialBonds.clear();
     numBonds = 0;
     initFromOther(other, false, -1);
   }

--- a/Code/GraphMol/RWMol.h
+++ b/Code/GraphMol/RWMol.h
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2003-2021 Greg Landrum and Rational Discovery LLC
+//  Copyright (C) 2003-2021 Greg Landrum and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -31,8 +31,7 @@ namespace RDKit {
  */
 class RDKIT_GRAPHMOL_EXPORT RWMol : public ROMol {
  public:
-  RWMol() : ROMol() { d_partialBonds.clear(); }
-
+  RWMol() : ROMol() {};
   //! copy constructor with a twist
   /*!
     \param other     the molecule to be copied
@@ -44,9 +43,7 @@ class RDKIT_GRAPHMOL_EXPORT RWMol : public ROMol {
          the specified conformer from \c other.
   */
   RWMol(const ROMol &other, bool quickCopy = false, int confId = -1)
-      : ROMol(other, quickCopy, confId) {
-    d_partialBonds.clear();
-  };
+      : ROMol(other, quickCopy, confId) {};
   RWMol(const RWMol &other) : ROMol(other) {};
   RWMol &operator=(const RWMol &);
 
@@ -219,10 +216,6 @@ class RDKIT_GRAPHMOL_EXPORT RWMol : public ROMol {
   };
   void commitBatchEdit();
   
- private:
-  std::vector<Bond *> d_partialBonds;
-  
-  void destroy();
 };
 
 typedef boost::shared_ptr<RWMol> RWMOL_SPTR;


### PR DESCRIPTION
- remove d_partialBonds private data member - never used in any code
- remove RWMol::destroy()  - redundant with ROMol::destroy()

There was a bit of discussion of this connected with #4171, and it turned out that the required changes were easy