### PR TITLE
Add low level functions to bulk-update Substance Group atoms & bonds

### DIFF
--- a/Code/GraphMol/SubstanceGroup.h
+++ b/Code/GraphMol/SubstanceGroup.h
@@ -141,9 +141,9 @@ class RDKIT_GRAPHMOL_EXPORT SubstanceGroup : public RDProps {
   const std::vector<unsigned int> &getParentAtoms() const { return d_patoms; }
   const std::vector<unsigned int> &getBonds() const { return d_bonds; }
 
-  void setAtoms(const std::vector<unsigned int> & atoms) { d_atoms = atoms; }
-  void setParentAtoms(const std::vector<unsigned int> & patoms) { d_patoms = patoms; }
-  void setBonds(const std::vector<unsigned int> &bonds) { d_bonds = bonds; }
+  void setAtoms(std::vector<unsigned int> atoms) { d_atoms = std::move(atoms); }
+  void setParentAtoms(std::vector<unsigned int> patoms) { d_patoms = std::move(patoms); }
+  void setBonds(std::vector<unsigned int> bonds) { d_bonds = std::move(bonds); }
 
   const std::vector<Bracket> &getBrackets() const { return d_brackets; }
   const std::vector<CState> &getCStates() const { return d_cstates; }

--- a/Code/GraphMol/SubstanceGroup.h
+++ b/Code/GraphMol/SubstanceGroup.h
@@ -141,6 +141,10 @@ class RDKIT_GRAPHMOL_EXPORT SubstanceGroup : public RDProps {
   const std::vector<unsigned int> &getParentAtoms() const { return d_patoms; }
   const std::vector<unsigned int> &getBonds() const { return d_bonds; }
 
+  void setAtoms(const std::vector<unsigned int> & atoms) { d_atoms = atoms; }
+  void setParentAtoms(const std::vector<unsigned int> & patoms) { d_patoms = patoms; }
+  void setBonds(const std::vector<unsigned int> &bonds) { d_bonds = bonds; }
+
   const std::vector<Bracket> &getBrackets() const { return d_brackets; }
   const std::vector<CState> &getCStates() const { return d_cstates; }
   const std::vector<AttachPoint> &getAttachPoints() const { return d_saps; }

--- a/Code/GraphMol/Wrap/SubstanceGroup.cpp
+++ b/Code/GraphMol/Wrap/SubstanceGroup.cpp
@@ -17,6 +17,7 @@
 // ours
 #include <GraphMol/RDKitBase.h>
 #include <GraphMol/SubstanceGroup.h>
+#include <RDBoost/Wrap.h>
 #include "props.hpp"
 
 namespace python = boost::python;
@@ -24,15 +25,6 @@ namespace python = boost::python;
 namespace RDKit {
 
 namespace {
-
-  template< typename T >
-  inline
-  std::vector< T > to_std_vector( const python::object& iterable )
-  {
-    return std::vector< T >( python::stl_input_iterator< T >( iterable ),
-                             python::stl_input_iterator< T >( ) );
-  }
-
 
 SubstanceGroup *getMolSubstanceGroupWithIdx(ROMol &mol, unsigned int idx) {
   auto &sgs = getSubstanceGroups(mol);
@@ -100,19 +92,24 @@ python::tuple getAttachPointsHelper(const SubstanceGroup &self) {
   return python::tuple(res);
 }
 
-
-void SetAtomsHelper(SubstanceGroup &self, const python::object& iterable) {
-  self.setAtoms(to_std_vector<unsigned int>(iterable));
+void SetAtomsHelper(SubstanceGroup &self, const python::object &iterable) {
+  std::vector<unsigned int> atoms;
+  pythonObjectToVect(iterable, atoms);
+  self.setAtoms(atoms);
 }
 
-void SetParentAtomsHelper(SubstanceGroup &self, const python::object& iterable) {
-  self.setParentAtoms(to_std_vector<unsigned int>(iterable));
+void SetParentAtomsHelper(SubstanceGroup &self,
+                          const python::object &iterable) {
+  std::vector<unsigned int> patoms;
+  pythonObjectToVect(iterable, patoms);
+  self.setParentAtoms(patoms);
 }
 
-void SetBondsHelper(SubstanceGroup &self, const python::object& iterable) {
-  self.setBonds(to_std_vector<unsigned int>(iterable));
+void SetBondsHelper(SubstanceGroup &self, const python::object &iterable) {
+  std::vector<unsigned int> bonds;
+  pythonObjectToVect(iterable, bonds);
+  self.setBonds(bonds);
 }
-
 
 }  // namespace
 

--- a/Code/GraphMol/Wrap/SubstanceGroup.cpp
+++ b/Code/GraphMol/Wrap/SubstanceGroup.cpp
@@ -10,7 +10,6 @@
 
 #define NO_IMPORT_ARRAY
 #include <boost/python.hpp>
-#include <boost/python/stl_iterator.hpp>
 #include <boost/python/suite/indexing/vector_indexing_suite.hpp>
 #include <string>
 

--- a/Code/GraphMol/Wrap/SubstanceGroup.cpp
+++ b/Code/GraphMol/Wrap/SubstanceGroup.cpp
@@ -10,6 +10,7 @@
 
 #define NO_IMPORT_ARRAY
 #include <boost/python.hpp>
+#include <boost/python/stl_iterator.hpp>
 #include <boost/python/suite/indexing/vector_indexing_suite.hpp>
 #include <string>
 
@@ -23,6 +24,16 @@ namespace python = boost::python;
 namespace RDKit {
 
 namespace {
+
+  template< typename T >
+  inline
+  std::vector< T > to_std_vector( const python::object& iterable )
+  {
+    return std::vector< T >( python::stl_input_iterator< T >( iterable ),
+                             python::stl_input_iterator< T >( ) );
+  }
+
+
 SubstanceGroup *getMolSubstanceGroupWithIdx(ROMol &mol, unsigned int idx) {
   auto &sgs = getSubstanceGroups(mol);
   if (idx >= sgs.size()) {
@@ -88,6 +99,21 @@ python::tuple getAttachPointsHelper(const SubstanceGroup &self) {
   }
   return python::tuple(res);
 }
+
+
+void SetAtomsHelper(SubstanceGroup &self, const python::object& iterable) {
+  self.setAtoms(to_std_vector<unsigned int>(iterable));
+}
+
+void SetParentAtomsHelper(SubstanceGroup &self, const python::object& iterable) {
+  self.setParentAtoms(to_std_vector<unsigned int>(iterable));
+}
+
+void SetBondsHelper(SubstanceGroup &self, const python::object& iterable) {
+  self.setBonds(to_std_vector<unsigned int>(iterable));
+}
+
+
 }  // namespace
 
 std::string sGroupClassDoc =
@@ -133,6 +159,18 @@ struct sgroup_wrap {
              "returns a list of the indices of the bonds in this "
              "SubstanceGroup",
              python::return_value_policy<python::copy_const_reference>())
+        .def("SetAtoms", SetAtomsHelper,
+             "Set the list of the indices of the atoms in this "
+             "SubstanceGroup.\nNote that this does not update "
+             "properties, CStates or Attachment Points.")
+        .def("SetParentAtoms", SetParentAtomsHelper,
+             "Set the list of the indices of the parent atoms in this "
+             "SubstanceGroup.\nNote that this does not update "
+             "properties, CStates or Attachment Points.")
+        .def("SetBonds", SetBondsHelper,
+             "Set the list of the indices of the bonds in this "
+             "SubstanceGroup.\nNote that this does not update "
+             "properties, CStates or Attachment Points.")
         .def("AddAtomWithIdx", &SubstanceGroup::addAtomWithIdx)
         .def("AddBondWithIdx", &SubstanceGroup::addBondWithIdx)
         .def("AddParentAtomWithIdx", &SubstanceGroup::addParentAtomWithIdx)

--- a/Code/RDBoost/Wrap.h
+++ b/Code/RDBoost/Wrap.h
@@ -127,18 +127,13 @@ std::unique_ptr<std::vector<T>> pythonObjectToVect(const python::object &obj) {
 template <typename T>
 void pythonObjectToVect(const python::object &obj, std::vector<T> &res) {
   if (obj) {
-    res.clear();
-    python::stl_input_iterator<T> beg(obj), end;
-    while (beg != end) {
-      T v = *beg;
-      res.push_back(v);
-      ++beg;
-    }
+    res.assign(python::stl_input_iterator<T>(obj),
+               python::stl_input_iterator<T>());
   }
 }
 
-RDKIT_RDBOOST_EXPORT boost::dynamic_bitset<> pythonObjectToDynBitset(const python::object &obj,
-                                                   boost::dynamic_bitset<>::size_type maxV);
+RDKIT_RDBOOST_EXPORT boost::dynamic_bitset<> pythonObjectToDynBitset(
+    const python::object &obj, boost::dynamic_bitset<>::size_type maxV);
 
 RDKIT_RDBOOST_EXPORT std::vector<std::pair<int, int>> *translateAtomMap(
     const python::object &atomMap);
@@ -157,13 +152,11 @@ RDKIT_RDBOOST_EXPORT std::vector<unsigned int> *translateIntSeq(
 #endif
 
 class PyGILStateHolder {
-public:
-  PyGILStateHolder() :
-    d_gstate(PyGILState_Ensure()) {}
-  ~PyGILStateHolder() {
-    PyGILState_Release(d_gstate);
-  }
-private:
+ public:
+  PyGILStateHolder() : d_gstate(PyGILState_Ensure()) {}
+  ~PyGILStateHolder() { PyGILState_Release(d_gstate); }
+
+ private:
   PyGILState_STATE d_gstate;
 };
 

--- a/Code/RDBoost/Wrap.h
+++ b/Code/RDBoost/Wrap.h
@@ -99,15 +99,15 @@ std::unique_ptr<std::vector<T>> pythonObjectToVect(const python::object &obj,
   std::unique_ptr<std::vector<T>> res;
   if (obj) {
     res.reset(new std::vector<T>);
-    python::stl_input_iterator<T> beg(obj), end;
-    while (beg != end) {
-      T v = *beg;
+
+    auto check_max = [&maxV](const T &v) {
       if (v >= maxV) {
         throw_value_error("list element larger than allowed value");
       }
-      res->push_back(v);
-      ++beg;
-    }
+      return true;
+    };
+    std::copy_if(python::stl_input_iterator<T>(obj),
+                 python::stl_input_iterator<T>(), res->begin(), check_max);
   }
   return res;
 }
@@ -115,12 +115,8 @@ template <typename T>
 std::unique_ptr<std::vector<T>> pythonObjectToVect(const python::object &obj) {
   std::unique_ptr<std::vector<T>> res;
   if (obj) {
-    res.reset(new std::vector<T>);
-    unsigned int nFrom = python::extract<unsigned int>(obj.attr("__len__")());
-    for (unsigned int i = 0; i < nFrom; ++i) {
-      T v = python::extract<T>(obj[i]);
-      res->push_back(v);
-    }
+    res.reset(new std::vector<T>(python::stl_input_iterator<T>(obj),
+                                 python::stl_input_iterator<T>()));
   }
   return res;
 }

--- a/Code/RDBoost/Wrap.h
+++ b/Code/RDBoost/Wrap.h
@@ -107,7 +107,8 @@ std::unique_ptr<std::vector<T>> pythonObjectToVect(const python::object &obj,
       return true;
     };
     std::copy_if(python::stl_input_iterator<T>(obj),
-                 python::stl_input_iterator<T>(), res->begin(), check_max);
+                 python::stl_input_iterator<T>(), std::back_inserter(*res),
+                 check_max);
   }
   return res;
 }


### PR DESCRIPTION

Currently, we only have infrastructure in place to update Substance Group atoms and bonds in a one-by-one basis. This adds some low level functions to allow bulk updates to them.

These functions are not safe, and should be used carefully, since passing the wrong data to Substance Groups might invalidate them as well as the owning mol. Also, these don't update any other Substance Group features, like attachment points or c-states. Still, they are the base to implement further code to update Substance Groups to accommodate operations like splitting fragments or running reactions on molecules.

