### PR TITLE
allow more recoverable V3000 parsing errors when strictParsing=false

### DIFF
--- a/Code/GraphMol/FileParsers/MolSGroupParsing.h
+++ b/Code/GraphMol/FileParsers/MolSGroupParsing.h
@@ -152,9 +152,10 @@ void ParseV3000SAPLabel(RWMol *mol, SubstanceGroup &sgroup,
 
 std::string ParseV3000StringPropLabel(std::stringstream &stream);
 
-void ParseV3000SGroupsBlock(std::istream *inStream, unsigned int line,
-                            unsigned int nSgroups, RWMol *mol,
-                            bool strictParsing);
+// returns the last line read in the SGroups block
+std::string ParseV3000SGroupsBlock(std::istream *inStream, unsigned int line,
+                                   unsigned int nSgroups, RWMol *mol,
+                                   bool strictParsing);
 
 }  // namespace SGroupParsing
 }  // namespace RDKit


### PR DESCRIPTION
Allows a couple of additional problems with v3000 mol files to be ignored when strictParsing=false:
- missing SGroup section
- mssing END SGROUP
- missing BEGIN/END OBJ3D (no tests for this, but we don't have any tests for OBJ3D anyway)

Additionally: if there aren't enough SGroups we'll now generate an error unless strictParsing is false