### PR TITLE
Fixes #4222

### DIFF
--- a/Code/GraphMol/MolHash/catch_tests.cpp
+++ b/Code/GraphMol/MolHash/catch_tests.cpp
@@ -219,3 +219,14 @@ TEST_CASE("Molecular formula with fragments", "[molhash]") {
     CHECK(hsh == "C6H15NO2");
   }
 }
+
+TEST_CASE("Github issues", "[molhash]") {
+  SECTION("Issue #4222: MolHash fails on non-standard valences") {
+    SmilesParserParams p;
+    p.sanitize = false;
+    std::unique_ptr<RWMol> mol(SmilesToMol("C[Cl]C", p));
+    REQUIRE(mol);
+    auto hsh = MolHash::MolHash(mol.get(), MolHash::HashFunction::MolFormula);
+    CHECK(hsh == "C2H6Cl");
+  }
+}

--- a/Code/GraphMol/MolHash/hashfunctions.cpp
+++ b/Code/GraphMol/MolHash/hashfunctions.cpp
@@ -105,7 +105,10 @@ void NMRDKitSanitizeHydrogens(RDKit::RWMol *mol) {
     unsigned int hcount = aptr->getTotalNumHs();
     aptr->setNoImplicit(true);
     aptr->setNumExplicitHs(hcount);
-    aptr->updatePropertyCache();  // or else the valence is reported incorrectly
+
+    bool strict = false;
+    aptr->updatePropertyCache(
+        strict);  // or else the valence is reported incorrectly
   }
 }
 


### PR DESCRIPTION
This fixes #4222. Just as suspected, a call to `updatePropertyCache()` requiring strict valences.