### PR TITLE
Shift `Trajectory` and `Snapshot` constructors to methods on classes

### DIFF
--- a/Code/GraphMol/Wrap/Trajectory.cpp
+++ b/Code/GraphMol/Wrap/Trajectory.cpp
@@ -56,6 +56,20 @@ struct Trajectory_wrapper {
   static void wrap() {
     python::class_<Trajectory>(
         "Trajectory", "A class which allows storing Snapshots from a trajectory", python::no_init)
+        .def("__init__",
+             python::make_constructor(
+                 &constructTrajectory_wrap, python::default_call_policies(),
+                 (python::arg("dimension"), python::arg("numPoints"),
+                  python::arg("snapshotList") = python::list())),
+             "Constructor;\n"
+             "dimension:    dimensionality of this Trajectory's coordinate tuples;\n"
+             "numPoints:    number of coordinate tuples associated to each Snapshot;\n"
+             "snapshotList: list of Snapshot objects used to initialize the Trajectory (optional; defaults to []).\n")
+        .def("__init__",
+             python::make_constructor(
+                 &copyConstructTrajectory_wrap, python::default_call_policies(),
+                 python::arg("other")),
+             "Copy constructor")
         .def("Dimension", &Trajectory::dimension, (python::arg("self")),
              "returns the dimensionality of this Trajectory's coordinate tuples")
         .def("NumPoints", &Trajectory::numPoints, (python::arg("self")),
@@ -91,19 +105,21 @@ struct Trajectory_wrapper {
              "defaults to -1 (first available)\n"
              "to is the last Snapshot that will be added as a Conformer; "
              "defaults to -1 (all)\n");
-    python::def("Trajectory", constructTrajectory_wrap,
-        (python::arg("dimension"), python::arg("numPoints"),
-        python::arg("snapshotList") = python::list()),
-        "Constructor;\n"
-        "dimension:    dimensionality of this Trajectory's coordinate tuples;\n"
-        "numPoints:    number of coordinate tuples associated to each Snapshot;\n"
-        "snapshotList: list of Snapshot objects used to initialize the Trajectory (optional; defaults to []).\n",
-        python::return_value_policy<python::manage_new_object>());
-    python::def("Trajectory", copyConstructTrajectory_wrap, (python::arg("other")),
-        "Copy constructor", python::return_value_policy<python::manage_new_object>());
 
     python::class_<Snapshot>(
         "Snapshot", "A class which allows storing coordinates from a trajectory", python::no_init)
+        .def("__init__",
+             python::make_constructor(
+                 &constructSnapshot_wrap, python::default_call_policies(),
+                 (python::arg("coordList"), python::arg("energy") = 0.0)),
+             "Constructor;\n"
+             "coordList: list of floats containing the coordinates for this Snapshot;\n"
+             "energy:    the energy for this Snapshot.\n")
+        .def("__init__",
+             python::make_constructor(
+                 &copyConstructSnapshot_wrap, python::default_call_policies(),
+                 python::arg("other")),
+             "Copy constructor")
         .def("GetPoint2D", &Snapshot::getPoint2D, (python::arg("self"), python::arg("pointNum")),
              "return the coordinates at pointNum as a Point2D object; "
              "requires the Trajectory dimension to be == 2")
@@ -114,14 +130,6 @@ struct Trajectory_wrapper {
              "returns the energy for this Snapshot")
         .def("SetEnergy", &Snapshot::setEnergy, (python::arg("self"), python::arg("energy")),
              "sets the energy for this Snapshot");
-    python::def("Snapshot", constructSnapshot_wrap,
-        (python::arg("coordList"), python::arg("energy") = 0.0),
-        "Constructor;\n"
-        "coordList: list of floats containing the coordinates for this Snapshot;\n"
-        "energy:    the energy for this Snapshot.\n",
-        python::return_value_policy<python::manage_new_object>());
-    python::def("Snapshot", copyConstructSnapshot_wrap, (python::arg("other")),
-        "Copy constructor", python::return_value_policy<python::manage_new_object>());
     python::def("ReadAmberTrajectory", &readAmberTrajectory,
         (python::arg("fName"), python::arg("traj")),
         "reads coordinates from an AMBER trajectory file into the Trajectory object; "


### PR DESCRIPTION
Description: Shift `Trajectory` and `Snapshot` class constructors to methods on the classes themselves to prevent shadowing of class names in the Python wrapper module

<!--
Thanks for contributing a pull request! 
-->
#### Reference Issue
Discussion https://github.com/rdkit/rdkit/discussions/4053


#### What does this implement/fix? Explain your changes.
 - The `rdkit.Chem.rdtrajectory.Trajectory` and `rdkit.Chem.rdtrajectory.Snapshot` classes were originally shadowed by identically-named functions acting as constructors in the Python wrapper module `rdkit.Chem.rdtrajectory`
 - This PR shifts the class constructors to methods on the classes themselves, removing the identically-named functions acting as constructors
 - It is also expected that, after the un-shadowing, the documentation at https://www.rdkit.org/docs/source/rdkit.Chem.rdtrajectory.html will be populated with the classes `rdkit.Chem.rdtrajectory.Trajectory` and `rdkit.Chem.rdtrajectory.Snapshot` and their methods, rather than just the current barebones class constructor functions
