### PR TITLE
Issue 4232: MolFromSmiles shouldn't throw

### DIFF
--- a/Code/GraphMol/Wrap/rdmolfiles.cpp
+++ b/Code/GraphMol/Wrap/rdmolfiles.cpp
@@ -376,7 +376,11 @@ ROMol *MolFromSmilesHelper(python::object ismiles,
                            const SmilesParserParams &params) {
   std::string smiles = pyObjectToString(ismiles);
 
-  return SmilesToMol(smiles, params);
+  try {
+    return SmilesToMol(smiles, params);
+  } catch (...) {
+    return nullptr;
+  }
 }
 
 python::list MolToRandomSmilesHelper(const ROMol &mol, unsigned int numSmiles,
@@ -458,7 +462,7 @@ python::object addMetadataToPNGFileHelper(python::dict pymetadata, python::objec
   for (unsigned int i = 0;
        i < python::extract<unsigned int>(pymetadata.keys().attr("__len__")());
        ++i) {
-    std::string key = python::extract<std::string>(pymetadata.keys()[i]); 
+    std::string key = python::extract<std::string>(pymetadata.keys()[i]);
     std::string val = python::extract<std::string>(pymetadata.values()[i]);
     metadata.push_back(std::make_pair(key,val));
   }
@@ -477,7 +481,7 @@ python::object addMetadataToPNGStringHelper(python::dict pymetadata, python::obj
   for (unsigned int i = 0;
        i < python::extract<unsigned int>(pymetadata.keys().attr("__len__")());
        ++i) {
-    std::string key = python::extract<std::string>(pymetadata.keys()[i]); 
+    std::string key = python::extract<std::string>(pymetadata.keys()[i]);
     std::string val = python::extract<std::string>(pymetadata.values()[i]);
     metadata.push_back(std::make_pair(key,val));
   }
@@ -1745,7 +1749,7 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
 
      ARGUMENTS:
 
-       - metadata: dict with the metadata to be written 
+       - metadata: dict with the metadata to be written
                    (keys and values should be strings)
 
        - filename: the PNG filename
@@ -1762,7 +1766,7 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
 
      ARGUMENTS:
 
-       - metadata: dict with the metadata to be written 
+       - metadata: dict with the metadata to be written
                    (keys and values should be strings)
 
        - png: the PNG string

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -5531,7 +5531,7 @@ C1C(Cl)CCCC duff2
     self.assertTrue(l[6] is None)
 
     sdf = b"""
-  Mrv1810 06051911332D          
+  Mrv1810 06051911332D
 
   3  2  0  0  0  0            999 V2000
   -13.3985    4.9850    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
@@ -5542,7 +5542,7 @@ C1C(Cl)CCCC duff2
 M  END
 $$$$
 
-  Mrv1810 06051911332D          
+  Mrv1810 06051911332D
 
   3  2  0  0  0  0            999 V2000
   -10.3083    4.8496    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
@@ -5553,7 +5553,7 @@ $$$$
 M  END
 $$$$
 
-  Mrv1810 06051911332D          
+  Mrv1810 06051911332D
 
   3  2  0  0  0  0            999 V2000
   -10.3083    4.8496    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
@@ -5574,7 +5574,7 @@ $$$$
     self.assertTrue(l[2] is None)
 
     sdf = b"""
-  Mrv1810 06051911332D          
+  Mrv1810 06051911332D
 
   3  2  0  0  0  0            999 V2000
   -13.3985    4.9850    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
@@ -5583,12 +5583,12 @@ $$$$
   1  2  1  0  0  0  0
   2  3  1  0  0  0  0
 M  END
->  <pval>  (1) 
+>  <pval>  (1)
 [1,2,]
 
 $$$$
 
-  Mrv1810 06051911332D          
+  Mrv1810 06051911332D
 
   3  2  0  0  0  0            999 V2000
   -10.3083    4.8496    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
@@ -5597,7 +5597,7 @@ $$$$
   1  2  1  0  0  0  0
   2  3  1  0  0  0  0
 M  END
->  <pval>  (1) 
+>  <pval>  (1)
 [1,2,]
 """
     suppl3 = Chem.SDMolSupplier()
@@ -5750,6 +5750,15 @@ H      0.635000    0.635000    0.635000
     with self.assertRaises(ValueError):
       Chem.SanitizeMol(Chem.MolFromSmiles('c1cc1', sanitize=False))
 
+  def testNoExceptionSmilesParserParams(self):
+    """
+    MolFromSmiles should catch exceptions even when SmilesParserParams
+    is provided.
+    """
+    smiles_params = Chem.SmilesParserParams()
+    mol = Chem.MolFromSmiles("C1CC", smiles_params)
+    self.assertIsNone(mol)
+
   def testDetectChemistryProblems(self):
     m = Chem.MolFromSmiles('CFCc1cc1FC', sanitize=False)
     ps = Chem.DetectChemistryProblems(m)
@@ -5803,7 +5812,7 @@ H      0.635000    0.635000    0.635000
   def testSetBondStereoFromDirections(self):
     m1 = Chem.MolFromMolBlock(
       '''
-  Mrv1810 10141909482D          
+  Mrv1810 10141909482D
 
   4  3  0  0  0  0            999 V2000
     3.3412   -2.9968    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
@@ -5822,7 +5831,7 @@ M  END
 
     m2 = Chem.MolFromMolBlock(
       '''
-  Mrv1810 10141909542D          
+  Mrv1810 10141909542D
 
   4  3  0  0  0  0            999 V2000
     3.4745   -5.2424    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0


### PR DESCRIPTION
#### Reference Issue
Fixes https://github.com/rdkit/rdkit/issues/4232

#### What does this implement/fix? Explain your changes.
MolFromSmiles shouldn't throw even when using SmilesParserParams.
See attached test which failed before this commit.

#### Any other comments?
Sorry about the trailing whitespace removal in the diffs.
