### PR TITLE
catch an exception via reference

### DIFF
--- a/Code/RDGeneral/testRDValue.cpp
+++ b/Code/RDGeneral/testRDValue.cpp
@@ -276,36 +276,36 @@ void testIntConversions() {
     try {
         p.getProp<std::int8_t>("foo"); // should fail
         TEST_ASSERT(0);
-    } catch (boost::numeric::positive_overflow) {
+    } catch (boost::numeric::positive_overflow&) {
     }
     try {
         p.getProp<std::uint8_t>("foo"); // should fail
         TEST_ASSERT(0);
-    } catch (boost::numeric::positive_overflow) {
+    } catch (boost::numeric::positive_overflow&) {
     }
     try {
         p.getProp<std::int16_t>("foo"); // should fail
         TEST_ASSERT(0);
-    } catch (boost::numeric::positive_overflow) {
+    } catch (boost::numeric::positive_overflow&) {
     }
     try {
         p.getProp<std::uint16_t>("foo"); // should fail
         TEST_ASSERT(0);
-    } catch (boost::numeric::positive_overflow) {
+    } catch (boost::numeric::positive_overflow&) {
     }
     
     p.setProp<int>("foo", -1);
     try {
         p.getProp<std::uint8_t>("foo"); // should fail
         TEST_ASSERT(0);
-    } catch (boost::numeric::positive_overflow) {
+    } catch (boost::numeric::positive_overflow&) {
     }
     
     p.getProp<std::int16_t>("foo"); // should pass
     try {
         p.getProp<std::uint16_t>("foo"); // should fail
         TEST_ASSERT(0);
-    } catch (boost::numeric::negative_overflow) {
+    } catch (boost::numeric::negative_overflow&) {
     }
 
 }


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! 
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.

Exceptions `boost::numeric::(positive|negative)_overflow`, subclasses of `std::exception`, should be caught via reference.

```
../Code/RDGeneral/testRDValue.cpp:279:30: warning: catching polymorphic type ‘class boost::numeric::positive_overflow’ by value [-Wcatch-value=]
     } catch (boost::numeric::positive_overflow) {
                              ^~~~~~~~~~~~~~~~~
../Code/RDGeneral/testRDValue.cpp:284:30: warning: catching polymorphic type ‘class boost::numeric::positive_overflow’ by value [-Wcatch-value=]
     } catch (boost::numeric::positive_overflow) {
                              ^~~~~~~~~~~~~~~~~
../Code/RDGeneral/testRDValue.cpp:289:30: warning: catching polymorphic type ‘class boost::numeric::positive_overflow’ by value [-Wcatch-value=]
     } catch (boost::numeric::positive_overflow) {
                              ^~~~~~~~~~~~~~~~~
../Code/RDGeneral/testRDValue.cpp:294:30: warning: catching polymorphic type ‘class boost::numeric::positive_overflow’ by value [-Wcatch-value=]
     } catch (boost::numeric::positive_overflow) {
                              ^~~~~~~~~~~~~~~~~
../Code/RDGeneral/testRDValue.cpp:301:30: warning: catching polymorphic type ‘class boost::numeric::positive_overflow’ by value [-Wcatch-value=]
     } catch (boost::numeric::positive_overflow) {
                              ^~~~~~~~~~~~~~~~~
../Code/RDGeneral/testRDValue.cpp:308:30: warning: catching polymorphic type ‘class boost::numeric::negative_overflow’ by value [-Wcatch-value=]
     } catch (boost::numeric::negative_overflow) {
                              ^~~~~~~~~~~~~~~~~
```

#### Any other comments?

