### PR TITLE
double bonds now have EITHER stereo if no coordinates are present

### DIFF
--- a/Code/Geometry/point.h
+++ b/Code/Geometry/point.h
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2003-2008 Greg Landrum and Rational Discovery LLC
+// Copyright (C) 2003-2021 Greg Landrum and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -167,17 +167,18 @@ class RDKIT_RDGEOMETRYLIB_EXPORT Point3D : public Point {
    *   be between 0 and M_PI
    */
   double angleTo(const Point3D &other) const {
-    Point3D t1, t2;
-    t1 = *this;
-    t2 = other;
-    t1.normalize();
-    t2.normalize();
-    double dotProd = t1.dotProduct(t2);
+    double lsq = lengthSq() * other.lengthSq();
+    double dotProd = dotProduct(other);
+    dotProd /= sqrt(lsq);
+
     // watch for roundoff error:
-    if (dotProd < -1.0)
-      dotProd = -1.0;
-    else if (dotProd > 1.0)
-      dotProd = 1.0;
+    if (dotProd <= -1.0) {
+      return M_PI;
+    }
+    if (dotProd >= 1.0) {
+      return 0.0;
+    }
+
     return acos(dotProd);
   }
 

--- a/Code/GraphMol/Chirality.cpp
+++ b/Code/GraphMol/Chirality.cpp
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2004-2021 Greg Landrum and Rational Discovery LLC
+//  Copyright (C) 2004-2021 Greg Landrum and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -404,10 +404,19 @@ void setBondDirRelativeToAtom(Bond *bond, Atom *atom, Bond::BondDir dir,
   bond->setBondDir(dir);
 }
 
-bool isLinearArrangement(const RDGeom::Point3D &v1, const RDGeom::Point3D &v2,
-                         double tol = 0.035) {  // tolerance of 2 degrees
-  return fabs(v2.angleTo(v1) - M_PI) < tol;
+bool isLinearArrangement(const RDGeom::Point3D &v1, const RDGeom::Point3D &v2) {
+  double lsq = v1.lengthSq() * v2.lengthSq();
+
+  // treat zero length vectors as linear
+  if (lsq < 1.0e-6) return true;
+
+  double dotProd = v1.dotProduct(v2);
+
+  double cos178 =
+      -0.999388;  // == cos(M_PI-0.035), corresponds to a tolerance of 2 degrees
+  return dotProd < cos178 * sqrt(lsq);
 }
+
 void updateDoubleBondNeighbors(ROMol &mol, Bond *dblBond, const Conformer *conf,
                                boost::dynamic_bitset<> &needsDir,
                                std::vector<unsigned int> &singleBondCounts,

--- a/Code/GraphMol/FileParsers/file_parsers_catch.cpp
+++ b/Code/GraphMol/FileParsers/file_parsers_catch.cpp
@@ -3554,3 +3554,21 @@ M  END
     CHECK(m);
   }
 }
+
+TEST_CASE("double bond stereo should not be set when the coords are all zero") {
+  auto m = R"CTAB(
+     RDKit          2D
+
+  4  3  0  0  0  0  0  0  0  0999 V2000
+    0.0000    0.0000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    0.0000    0.0000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    0.0000    0.0000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    0.0000    0.0000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+  1  2  1  0
+  2  3  2  0
+  3  4  1  0
+M  END)CTAB"_ctab;
+  REQUIRE(m);
+  REQUIRE(m->getBondBetweenAtoms(1, 2));
+  CHECK(m->getBondBetweenAtoms(1, 2)->getBondDir() == Bond::EITHERDOUBLE);
+}


### PR DESCRIPTION
Previously the code was incorrectly actually assigning stereo in these cases

This also adds a small speedup for `Point3D::angleTo()`

Thanks to Roger Sayle for the patch

