### PR TITLE
Fix EnumerateStereoisomers for EITHERDOUBLE cis/trans bonds

### DIFF
--- a/Code/GraphMol/Chirality.cpp
+++ b/Code/GraphMol/Chirality.cpp
@@ -2101,18 +2101,12 @@ void findPotentialStereoBonds(ROMol &mol, bool cleanIt) {
           !(mol.getRingInfo()->numBondRings((*bondIt)->getIdx()))) {
         // we are ignoring ring bonds here - read the FIX above
         Bond *dblBond = *bondIt;
-        // We ignore bonds flagged as EITHERDOUBLE or STEREOANY which have
-        // stereo atoms set.
-        if (dblBond->getBondDir() == Bond::EITHERDOUBLE ||
-            (dblBond->getStereo() == Bond::STEREOANY &&
-             dblBond->getStereoAtoms().size() == 2)) {
-          continue;
-        }
         // proceed only if we either want to clean the stereocode on this bond,
         // if none is set on it yet, or it is STEREOANY and we need to find
         // stereoatoms
         if (cleanIt || dblBond->getStereo() == Bond::STEREONONE ||
-            dblBond->getStereo() == Bond::STEREOANY) {
+            (dblBond->getStereo() == Bond::STEREOANY &&
+             dblBond->getStereoAtoms().size() != 2)) {
           dblBond->setStereo(Bond::STEREONONE);
           const Atom *begAtom = dblBond->getBeginAtom(),
                      *endAtom = dblBond->getEndAtom();

--- a/rdkit/Chem/EnumerateStereoisomers.py
+++ b/rdkit/Chem/EnumerateStereoisomers.py
@@ -294,6 +294,9 @@ def EnumerateStereoisomers(m, options=StereoEnumerationOptions(), verbose=False)
   tm = Chem.Mol(m)
   for atom in tm.GetAtoms():
     atom.ClearProp("_CIPCode")
+  for bond in tm.GetBonds():
+    if bond.GetBondDir() == Chem.BondDir.EITHERDOUBLE:
+      bond.SetBondDir(Chem.BondDir.NONE)
   flippers = _getFlippers(tm, options)
   nCenters = len(flippers)
   if not nCenters:

--- a/rdkit/Chem/UnitTestMol3D.py
+++ b/rdkit/Chem/UnitTestMol3D.py
@@ -433,5 +433,14 @@ class TestCase(unittest.TestCase):
       self.assertTrue(at.HasProp("_ChiralityPossible"))
 
 
+  def testEnumerateEitherDoubleStereo(self):
+    """ EnumerateStereoisomers from MOL with explicit either cis/trans bond """
+    rdbase = os.environ["RDBASE"]
+    filename = os.path.join(rdbase, 'Code/GraphMol/FileParsers/test_data/simple_either.mol')
+    mol = Chem.MolFromMolFile(filename)
+    smiles = [Chem.MolToSmiles(m) for m in AllChem.EnumerateStereoisomers(mol)]
+    self.assertEqual(set(smiles), {"C/C=C/C", "C/C=C\\C"})
+
+
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! 
-->
#### Reference Issue

Fixes #3759
See also: #2890 #3015


#### What does this implement/fix? Explain your changes.


This fixes an issue where `EnumerateStereoisomers` raises a Pre-condition Violation due to missing stereo atoms for a double bond with `EITHERDOUBLE` direction set. This typically happens with input from a MOLfile with an explicit "either" cis/trans double bond.

Here's a simple example. (Note the bond stereo value `3` in first bond line.)

```python
from rdkit import Chem
from rdkit.Chem import AllChem

mb = """
  Marvin  08270811582D          

  4  3  0  0  0  0            999 V2000
   -2.5929    1.4143    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
   -1.7679    1.4143    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
   -1.3554    2.1288    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
   -3.0054    0.6998    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
  1  2  2  3  0  0  0
  2  3  1  0  0  0  0
  1  4  1  0  0  0  0
M  END
"""
mol = Chem.MolFromMolBlock(mb)
isomers = list(AllChem.EnumerateStereoisomers(mol))
```

This currently raises:

```
****
Pre-condition Violation
Stereo atoms should be specified before specifying CIS/TRANS bond stereochemistry
Violation occurred on line 285 in file /opt/conda/conda-bld/rdkit_1623858991117/work/Code/GraphMol/Bond.h
Failed Expression: what <= STEREOE || getStereoAtoms().size() == 2
****

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/opt/conda/lib/python3.7/site-packages/rdkit/Chem/EnumerateStereoisomers.py", line 324, in EnumerateStereoisomers
    flippers[i].flip(flag)
  File "/opt/conda/lib/python3.7/site-packages/rdkit/Chem/EnumerateStereoisomers.py", line 48, in flip
    self.bond.SetStereo(Chem.BondStereo.STEREOTRANS)
RuntimeError: Pre-condition Violation
        Stereo atoms should be specified before specifying CIS/TRANS bond stereochemistry
        Violation occurred on line 285 in file Code/GraphMol/Bond.h
        Failed Expression: what <= STEREOE || getStereoAtoms().size() == 2
        RDKIT: 2021.03.3
        BOOST: 1_74
```

There is an extended discussion in https://github.com/rdkit/rdkit/issues/3759 about why this happens. To summarise:

- It is fine to set a bond as `STEREOANY` without specifying stereo atoms (as explained in `setStereo()` in `bond.h`).
- `EnumerateStereoisomers` flips these bonds to `STEREOCIS` and `STEREOTRANS` without first assigning stereo atoms, causing the error.
- `findPotentialStereoBonds` is called early on in `EnumerateStereoisomers` - historically this just identified potential stereo bonds that were currently `STEREONONE` and set them to `STEREOANY` *and* set the stereo atoms. Bonds that were already `STEREOANY` were ignored, leaving stereo atoms unset if they weren't already set.
- https://github.com/rdkit/rdkit/pull/3015 provided a partial fix by updating `findPotentialStereoBonds` to ensure stereo atoms are assigned on all potential stereo bonds, even if they are already flagged as `STEREOANY`. However, some pre-existing logic in `findPotentialStereoBonds` means that potential stereo bonds are still skipped if they also have an `EITHERDOUBLE` direction.
- In addition to all this, the `EITHERDOUBLE` bond direction remains on bonds in the isomers output by `EnumerateStereoisomers`, which is incorrect. In particular, this causes the SMILES writer to omit the stereo given by the `STEREOCIS` and `STEREOTRANS` bond stereo flag, which importantly breaks the functionality of the `unique` parameter.

This fix does two things:

- Remove special handling where `EITHERDOUBLE` bonds are skipped in `findPotentialStereoBonds`. This now consistently assigns stereo atoms to pre-existing `STEREOANY` bonds, even if they also have an `EITHERDOUBLE` direction.
- Strip `EITHERDOUBLE` from all bonds in `EnumerateStereoisomers`, so they aren't present in the output.

Ultimately, a better fix may be to see if we can remove the `EITHERDOUBLE` bond direction altogether, but that's probably a discussion for another day...