### PR TITLE
Make sure that ResonanceMolSupplier substructure matches are uniquified consistently

### DIFF
--- a/Code/GraphMol/Atom.cpp
+++ b/Code/GraphMol/Atom.cpp
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2001-2019 Greg Landrum and Rational Discovery LLC
+//  Copyright (C) 2001-2021 Greg Landrum and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -213,11 +213,10 @@ int Atom::calcExplicitValence(bool strict) {
   // FIX: contributions of bonds to valence are being done at best
   // approximately
   double accum = 0;
-  ROMol::OEDGE_ITER beg, end;
-  boost::tie(beg, end) = getOwningMol().getAtomBonds(this);
-  while (beg != end) {
-    accum += getOwningMol()[*beg]->getValenceContrib(this);
-    ++beg;
+  for (const auto &nbri :
+       boost::make_iterator_range(getOwningMol().getAtomBonds(this))) {
+    const auto bnd = getOwningMol()[nbri];
+    accum += bnd->getValenceContrib(this);
   }
   accum += getNumExplicitHs();
 
@@ -333,6 +332,14 @@ int Atom::calcImplicitValence(bool strict) {
   if (d_atomicNum == 0) {
     d_implicitValence = 0;
     return 0;
+  }
+  for (const auto &nbri :
+       boost::make_iterator_range(getOwningMol().getAtomBonds(this))) {
+    const auto bnd = getOwningMol()[nbri];
+    if (QueryOps::hasComplexBondTypeQuery(*bnd)) {
+      d_implicitValence = 0;
+      return 0;
+    }
   }
   if (d_explicitValence == 0 && d_atomicNum == 1 &&
       d_numRadicalElectrons == 0) {

--- a/Code/GraphMol/Bond.cpp
+++ b/Code/GraphMol/Bond.cpp
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2001-2017 Greg Landrum and Rational Discovery LLC
+//  Copyright (C) 2001-2021 Greg Landrum and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -124,125 +124,74 @@ Atom *Bond::getOtherAtom(Atom const *what) const {
 };
 
 double Bond::getBondTypeAsDouble() const {
+  double res;
   switch (getBondType()) {
     case UNSPECIFIED:
     case IONIC:
     case ZERO:
-      return 0;
+      res = 0;
       break;
     case SINGLE:
-      return 1;
+      res = 1;
       break;
     case DOUBLE:
-      return 2;
+      res = 2;
       break;
     case TRIPLE:
-      return 3;
+      res = 3;
       break;
     case QUADRUPLE:
-      return 4;
+      res = 4;
       break;
     case QUINTUPLE:
-      return 5;
+      res = 5;
       break;
     case HEXTUPLE:
-      return 6;
+      res = 6;
       break;
     case ONEANDAHALF:
-      return 1.5;
+      res = 1.5;
       break;
     case TWOANDAHALF:
-      return 2.5;
+      res = 2.5;
       break;
     case THREEANDAHALF:
-      return 3.5;
+      res = 3.5;
       break;
     case FOURANDAHALF:
-      return 4.5;
+      res = 4.5;
       break;
     case FIVEANDAHALF:
-      return 5.5;
+      res = 5.5;
       break;
     case AROMATIC:
-      return 1.5;
+      res = 1.5;
       break;
     case DATIVEONE:
-      return 1.0;
+      res = 1.0;
       break;  // FIX: this should probably be different
     case DATIVE:
-      return 1.0;
+      res = 1.0;
       break;  // FIX: again probably wrong
     case HYDROGEN:
-      return 0.0;
+      res = 0.0;
       break;
     default:
       UNDER_CONSTRUCTION("Bad bond type");
   }
+  return res;
 }
 
 double Bond::getValenceContrib(const Atom *atom) const {
-  switch (getBondType()) {
-    case UNSPECIFIED:
-    case IONIC:
-    case ZERO:
-      return 0;
-      break;
-    case SINGLE:
-      return 1;
-      break;
-    case DOUBLE:
-      return 2;
-      break;
-    case TRIPLE:
-      return 3;
-      break;
-    case QUADRUPLE:
-      return 4;
-      break;
-    case QUINTUPLE:
-      return 5;
-      break;
-    case HEXTUPLE:
-      return 6;
-      break;
-    case ONEANDAHALF:
-      return 1.5;
-      break;
-    case TWOANDAHALF:
-      return 2.5;
-      break;
-    case THREEANDAHALF:
-      return 3.5;
-      break;
-    case FOURANDAHALF:
-      return 4.5;
-      break;
-    case FIVEANDAHALF:
-      return 5.5;
-      break;
-    case AROMATIC:
-      return 1.5;
-      break;
-    case DATIVEONE:
-      if (atom->getIdx() == getEndAtomIdx()) {
-        return 1.0;
-      } else {
-        return 0.0;
-      }
-      break;
-    case DATIVE:
-      if (atom->getIdx() == getEndAtomIdx()) {
-        return 1.0;
-      } else {
-        return 0.0;
-      }
-      break;
-    case HYDROGEN:
-      return 0.0;
-      break;
-    default:
-      UNDER_CONSTRUCTION("Bad bond type");
+  double res;
+  if ((getBondType() == DATIVE || getBondType() == DATIVEONE) &&
+      atom->getIdx() != getEndAtomIdx()) {
+    res = 0.0;
+  } else {
+    res = getBondTypeAsDouble();
   }
+
+  return res;
 }
 
 void Bond::setQuery(QUERYBOND_QUERY *what) {
@@ -362,7 +311,6 @@ uint8_t getTwiceBondType(const Bond &b) {
       UNDER_CONSTRUCTION("Bad bond type");
   }
 }
-
 };  // namespace RDKit
 
 std::ostream &operator<<(std::ostream &target, const RDKit::Bond &bond) {

--- a/Code/GraphMol/Bond.h
+++ b/Code/GraphMol/Bond.h
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2001-2017 Greg Landrum and Rational Discovery LLC
+//  Copyright (C) 2001-2021 Greg Landrum and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -129,7 +129,7 @@ class RDKIT_GRAPHMOL_EXPORT Bond : public RDProps {
     <b>Notes:</b>
       - requires an owning molecule
   */
-  double getValenceContrib(const Atom *at) const;
+  virtual double getValenceContrib(const Atom *at) const;
 
   //! sets our \c isAromatic flag
   void setIsAromatic(bool what) { df_isAromatic = what; }

--- a/Code/GraphMol/QueryBond.cpp
+++ b/Code/GraphMol/QueryBond.cpp
@@ -1,6 +1,5 @@
-// $Id$
 //
-//  Copyright (C) 2001-2006 Greg Landrum and Rational Discovery LLC
+//  Copyright (C) 2001-2021 Greg Landrum and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -219,4 +218,10 @@ bool QueryBond::QueryMatch(QueryBond const *what) const {
   }
 }
 
+double QueryBond::getValenceContrib(const Atom *atom) const {
+  if (!hasQuery() || !QueryOps::hasComplexBondTypeQuery(*getQuery())) {
+    return Bond::getValenceContrib(atom);
+  }
+  return 0;
+}
 }  // namespace RDKit

--- a/Code/GraphMol/QueryBond.h
+++ b/Code/GraphMol/QueryBond.h
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2001-2017 Greg Landrum and Rational Discovery LLC
+//  Copyright (C) 2001-2021 Greg Landrum and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -93,6 +93,13 @@ class RDKIT_GRAPHMOL_EXPORT QueryBond : public Bond {
   void expandQuery(QUERYBOND_QUERY *what,
                    Queries::CompositeQueryType how = Queries::COMPOSITE_AND,
                    bool maintainOrder = true) override;
+
+  //! returns our contribution to the explicit valence of an Atom
+  /*!
+    <b>Notes:</b>
+      - requires an owning molecule
+  */
+  double getValenceContrib(const Atom *at) const override;
 
  protected:
   QUERYBOND_QUERY *dp_query{nullptr};

--- a/Code/GraphMol/QueryOps.h
+++ b/Code/GraphMol/QueryOps.h
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2003-2017 Greg Landrum and Rational Discovery LLC
+//  Copyright (C) 2003-2021 Greg Landrum and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -668,6 +668,7 @@ RDKIT_GRAPHMOL_EXPORT BOND_EQUALS_QUERY *makeSingleOrDoubleBondQuery();
 //! returns a Query for tautomeric bonds
 RDKIT_GRAPHMOL_EXPORT BOND_EQUALS_QUERY *
 makeSingleOrDoubleOrAromaticBondQuery();
+
 //! returns a Query for matching bond directions
 RDKIT_GRAPHMOL_EXPORT BOND_EQUALS_QUERY *makeBondDirEqualsQuery(
     Bond::BondDir what);
@@ -1087,6 +1088,23 @@ RDKIT_GRAPHMOL_EXPORT void finalizeQueryFromDescription(
     Queries::Query<int, Atom const *, true> *query, Atom const *owner);
 RDKIT_GRAPHMOL_EXPORT void finalizeQueryFromDescription(
     Queries::Query<int, Bond const *, true> *query, Bond const *owner);
+
+RDKIT_GRAPHMOL_EXPORT bool hasBondTypeQuery(
+    const Queries::Query<int, Bond const *, true> &qry);
+inline bool hasBondTypeQuery(const Bond &bond) {
+  if (!bond.hasQuery()) {
+    return false;
+  }
+  return hasBondTypeQuery(*bond.getQuery());
+}
+RDKIT_GRAPHMOL_EXPORT bool hasComplexBondTypeQuery(
+    const Queries::Query<int, Bond const *, true> &qry);
+inline bool hasComplexBondTypeQuery(const Bond &bond) {
+  if (!bond.hasQuery()) {
+    return false;
+  }
+  return hasComplexBondTypeQuery(*bond.getQuery());
+}
 
 }  // namespace QueryOps
 }  // namespace RDKit

--- a/Code/GraphMol/RGroupDecomposition/RGroupCore.cpp
+++ b/Code/GraphMol/RGroupDecomposition/RGroupCore.cpp
@@ -1,4 +1,13 @@
-
+//
+//  Copyright (c) 2017-2021, Novartis Institutes for BioMedical Research Inc.
+//  and other RDKit contributors
+//
+//   @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
+//
 #include "RGroupCore.h"
 #include <GraphMol/Substruct/SubstructUtils.h>
 
@@ -193,7 +202,8 @@ void RCore::buildMatchingMol() {
 // Given a matching molecule substructure match to a target molecule, return
 // core matches with terminal user R groups matched
 std::vector<MatchVectType> RCore::matchTerminalUserRGroups(
-    const RWMol &target, MatchVectType match) const {
+    const RWMol &target, MatchVectType match,
+    const SubstructMatchParameters &sssParams) const {
   // Transform match indexed by matching molecule atoms to a map
   // indexed by core atoms
   std::transform(match.begin(), match.end(), match.begin(),
@@ -224,9 +234,6 @@ std::vector<MatchVectType> RCore::matchTerminalUserRGroups(
   // target atoms that the R group can map to
   std::vector<std::vector<int>> availableMappingsForDummy;
 
-  SubstructMatchParameters ssParameters;
-  ssParameters.useChirality = true;
-
   // Loop over all the user terminal R groups and see if they can be included
   // in the match and, if so, record the target atoms that the R group can
   // be mapped to.
@@ -246,7 +253,7 @@ std::vector<MatchVectType> RCore::matchTerminalUserRGroups(
       if (mappedTargetIdx.find(*nbrIter) == mappedTargetIdx.end()) {
         const auto targetBond = target.getBondBetweenAtoms(targetIdx, *nbrIter);
         // check for bond compatibility
-        if (bondCompat(coreBond, targetBond, ssParameters)) {
+        if (bondCompat(coreBond, targetBond, sssParams)) {
           available.push_back(*nbrIter);
         }
       }
@@ -285,7 +292,7 @@ std::vector<MatchVectType> RCore::matchTerminalUserRGroups(
     targetIndices[position] = pair.second;
   }
 
-  MolMatchFinalCheckFunctor molMatchFunctor(*core, target, ssParameters);
+  MolMatchFinalCheckFunctor molMatchFunctor(*core, target, sssParams);
   boost::dynamic_bitset<> targetBondsPresent(target.getNumBonds());
 
   // Filter all available mappings removing those that contain duplicates,
@@ -324,8 +331,8 @@ std::vector<MatchVectType> RCore::matchTerminalUserRGroups(
     }
   }
 
-  delete [] queryIndices;
-  delete [] targetIndices;
+  delete[] queryIndices;
+  delete[] targetIndices;
   return allMappings;
 }
 

--- a/Code/GraphMol/RGroupDecomposition/RGroupCore.h
+++ b/Code/GraphMol/RGroupDecomposition/RGroupCore.h
@@ -1,5 +1,6 @@
 //
-//  Copyright (C) 2020 Novartis Institutes for BioMedical Research
+//  Copyright (C) 2020-2021 Novartis Institutes for BioMedical Research and
+//  other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -60,7 +61,8 @@ struct RCore {
   RWMOL_SPTR coreWithMatches(const ROMol &coreReplacedAtoms) const;
 
   std::vector<MatchVectType> matchTerminalUserRGroups(
-      const RWMol &target, MatchVectType match) const;
+      const RWMol &target, MatchVectType match,
+      const SubstructMatchParameters &sssParams) const;
 
   inline bool isTerminalRGroupWithUserLabel(const int idx) const {
     return terminalRGroupAtomsWithUserLabels.find(idx) !=

--- a/Code/GraphMol/RGroupDecomposition/RGroupDecomp.cpp
+++ b/Code/GraphMol/RGroupDecomposition/RGroupDecomp.cpp
@@ -1,4 +1,7 @@
-//  Copyright (c) 2017, Novartis Institutes for BioMedical Research Inc.
+//
+//  Copyright (c) 2017-2021, Novartis Institutes for BioMedical Research Inc.
+//  and other RDKit contributors
+//
 //  All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -95,25 +98,25 @@ int RGroupDecomposition::add(const ROMol &inmol) {
   // or the first core that requires the smallest number
   // of newly added labels
   int global_min_heavy_nbrs = -1;
+  SubstructMatchParameters sssparams(params().substructmatchParams);
+  sssparams.uniquify = false;
+  sssparams.recursionPossible = true;
   for (const auto &core : data->cores) {
     {
-      const bool uniquify = false;
-      const bool recursionPossible = true;
-      const bool useChirality = true;
       // matching the core to the molecule is a two step process
       // First match to a reduced representation (the core minus terminal
       // R-groups). Next, match the R-groups. We do this as the core may not be
       // a substructure match for the molecule if a single molecule atom matches
       // 2 RGroup attachments (see https://github.com/rdkit/rdkit/pull/4002)
-      std::vector<MatchVectType> baseMatches;
-      // match reduced representation
-      SubstructMatch(mol, *core.second.matchingMol, baseMatches, uniquify,
-                     recursionPossible, useChirality);
+
+      // match the reduced represenation:
+      std::vector<MatchVectType> baseMatches =
+          SubstructMatch(mol, *core.second.matchingMol, sssparams);
       tmatches.clear();
       for (const auto &baseMatch : baseMatches) {
         // Match the R Groups
         auto matchesWithDummy =
-            core.second.matchTerminalUserRGroups(mol, baseMatch);
+            core.second.matchTerminalUserRGroups(mol, baseMatch, sssparams);
         tmatches.insert(tmatches.end(), matchesWithDummy.cbegin(),
                         matchesWithDummy.cend());
       }

--- a/Code/GraphMol/RGroupDecomposition/RGroupDecomp.h
+++ b/Code/GraphMol/RGroupDecomposition/RGroupDecomp.h
@@ -1,5 +1,6 @@
 //
-//  Copyright (C) 2017 Novartis Institutes for BioMedical Research
+//  Copyright (c) 2017-2021, Novartis Institutes for BioMedical Research Inc.
+//  and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -114,6 +115,10 @@ struct RDKIT_RGROUPDECOMPOSITION_EXPORT RGroupDecompositionParameters {
   int gaNumberRuns = 1;
   // Sequential or parallel runs?
   bool gaParallelRuns = true;
+  // Controls the way substructure matching with the core is done
+  SubstructMatchParameters substructmatchParams;
+
+  RGroupDecompositionParameters() { substructmatchParams.useChirality = true; }
 
  private:
   int indexOffset{-1};

--- a/Code/GraphMol/RGroupDecomposition/RGroupDecompParams.cpp
+++ b/Code/GraphMol/RGroupDecomposition/RGroupDecompParams.cpp
@@ -1,5 +1,6 @@
 //
-//  Copyright (C) 2017 Novartis Institutes for BioMedical Research
+//  Copyright (c) 2017-2021, Novartis Institutes for BioMedical Research Inc.
+//  and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -135,6 +136,22 @@ bool RGroupDecompositionParameters::prepareCore(RWMol &core,
     }
   } else if (!onlyMatchAtRGroups) {
     autoLabels |= AtomIndexLabels;
+  }
+
+  // if we aren't doing stereochem matches, remove that info from the core
+  if (!substructmatchParams.useChirality) {
+    for (auto atom : core.atoms()) {
+      atom->setChiralTag(Atom::ChiralType::CHI_UNSPECIFIED);
+    }
+    for (auto bond : core.bonds()) {
+      bond->setStereo(Bond::BondStereo::STEREONONE);
+    }
+  }
+  // remove enhanced stereo info if not being used
+  // or if chirality isn't being used
+  if (!substructmatchParams.useChirality ||
+      !substructmatchParams.useEnhancedStereo) {
+    core.setStereoGroups(std::vector<StereoGroup>());
   }
 
   int maxLabel = 1;
@@ -273,7 +290,7 @@ bool RGroupDecompositionParameters::prepareCore(RWMol &core,
   }
 
   return true;
-}
+}  // namespace RDKit
 
 void RGroupDecompositionParameters::checkNonTerminal(const Atom &atom) const {
   if (allowNonTerminalRGroups || atom.getDegree() == 1) {

--- a/Code/GraphMol/RGroupDecomposition/Wrap/rdRGroupComposition.cpp
+++ b/Code/GraphMol/RGroupDecomposition/Wrap/rdRGroupComposition.cpp
@@ -1,4 +1,6 @@
-//  Copyright (c) 2017, Novartis Institutes for BioMedical Research Inc.
+//  Copyright (c) 2017-2021, Novartis Institutes for BioMedical Research Inc.
+//  and other RDKit contributors
+//
 //  All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -312,7 +314,10 @@ struct rgroupdecomp_wrapper {
             &RDKit::RGroupDecompositionParameters::allowNonTerminalRGroups)
         .def_readwrite("removeAllHydrogenRGroupsAndLabels",
                        &RDKit::RGroupDecompositionParameters::
-                           removeAllHydrogenRGroupsAndLabels);
+                           removeAllHydrogenRGroupsAndLabels)
+        .def_readonly(
+            "substructMatchParams",
+            &RDKit::RGroupDecompositionParameters::substructmatchParams);
 
     python::class_<RDKit::RGroupDecompositionHelper, boost::noncopyable>(
         "RGroupDecomposition", docString.c_str(),

--- a/Code/GraphMol/RGroupDecomposition/Wrap/test_rgroups.py
+++ b/Code/GraphMol/RGroupDecomposition/Wrap/test_rgroups.py
@@ -1,4 +1,5 @@
-#  Copyright (c) 2018, Novartis Institutes for BioMedical Research Inc.
+#  Copyright (c) 2018-2021, Novartis Institutes for BioMedical Research Inc.
+#   and other RDKit contributors
 #  All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -36,8 +37,8 @@ import pickle
 
 from rdkit import rdBase
 from rdkit import Chem
-from rdkit.Chem.rdRGroupDecomposition import (RGroupDecompose,
-                                              RGroupDecomposition, RGroupDecompositionParameters, RGroupLabels,
+from rdkit.Chem.rdRGroupDecomposition import (RGroupDecompose, RGroupDecomposition,
+                                              RGroupDecompositionParameters, RGroupLabels,
                                               RGroupCoreAlignment)
 from collections import OrderedDict
 
@@ -49,55 +50,55 @@ RDLogger.DisableLog("rdApp.warning")
 
 class TestCase(unittest.TestCase):
 
-    def test_multicores(self):
-        cores_smi_easy = OrderedDict()
-        cores_smi_hard = OrderedDict()
+  def test_multicores(self):
+    cores_smi_easy = OrderedDict()
+    cores_smi_hard = OrderedDict()
 
-        # cores_smi_easy['cephem'] = Chem.MolFromSmiles('O=C1C([1*])[C@@H]2N1C(C(O)=O)=C([3*])CS2')
-        cores_smi_easy['cephem'] = Chem.MolFromSmarts('O=C1C([*:1])C2N1C(C(O)=O)=C([*:3])CS2')
-        cores_smi_hard['cephem'] = Chem.MolFromSmarts('O=C1C([2*])([1*])[C@@H]2N1C(C(O)=O)=C([3*])CS2')
+    # cores_smi_easy['cephem'] = Chem.MolFromSmiles('O=C1C([1*])[C@@H]2N1C(C(O)=O)=C([3*])CS2')
+    cores_smi_easy['cephem'] = Chem.MolFromSmarts('O=C1C([*:1])C2N1C(C(O)=O)=C([*:3])CS2')
+    cores_smi_hard['cephem'] = Chem.MolFromSmarts('O=C1C([2*])([1*])[C@@H]2N1C(C(O)=O)=C([3*])CS2')
 
-        # cores_smi_easy['carbacephem'] = Chem.MolFromSmiles('O=C1C([1*])[C@@H]2N1C(C(O)=O)=C([3*])CC2')
-        cores_smi_easy['carbacephem'] = Chem.MolFromSmarts('O=C1C([1*])C2N1C(C(O)=O)=C([3*])CC2')
-        cores_smi_hard['carbacephem'] = Chem.MolFromSmarts(
-            'O=C1C([2*])([1*])[C@@H]2N1C(C(O)=O)=C([3*])CC2')
+    # cores_smi_easy['carbacephem'] = Chem.MolFromSmiles('O=C1C([1*])[C@@H]2N1C(C(O)=O)=C([3*])CC2')
+    cores_smi_easy['carbacephem'] = Chem.MolFromSmarts('O=C1C([1*])C2N1C(C(O)=O)=C([3*])CC2')
+    cores_smi_hard['carbacephem'] = Chem.MolFromSmarts(
+      'O=C1C([2*])([1*])[C@@H]2N1C(C(O)=O)=C([3*])CC2')
 
-        # cores_smi_easy['oxacephem'] = Chem.MolFromSmiles('O=C1C([1*])[C@@H]2N1C(C(O)=O)=C([3*])CO2')
-        cores_smi_easy['oxacephem'] = Chem.MolFromSmarts('O=C1C([1*])C2N1C(C(O)=O)=C([3*])CO2')
-        cores_smi_hard['oxacephem'] = Chem.MolFromSmarts(
-            'O=C1C([2*])([1*])[C@@H]2N1C(C(O)=O)=C([3*])CO2')
+    # cores_smi_easy['oxacephem'] = Chem.MolFromSmiles('O=C1C([1*])[C@@H]2N1C(C(O)=O)=C([3*])CO2')
+    cores_smi_easy['oxacephem'] = Chem.MolFromSmarts('O=C1C([1*])C2N1C(C(O)=O)=C([3*])CO2')
+    cores_smi_hard['oxacephem'] = Chem.MolFromSmarts(
+      'O=C1C([2*])([1*])[C@@H]2N1C(C(O)=O)=C([3*])CO2')
 
-        # cores_smi_easy['carbapenem'] = Chem.MolFromSmiles('O=C1C([1*])[C@@H]2N1C(C(O)=O)=C([3*])C2')
-        cores_smi_easy['carbapenem'] = Chem.MolFromSmarts('O=C1C([1*])C2N1C(C(O)=O)=C([3*])C2')
-        cores_smi_hard['carbapenem'] = Chem.MolFromSmarts(
-            'O=C1C([2*])([1*])[C@@H]2N1C(C(O)=O)=C([3*])C2')
+    # cores_smi_easy['carbapenem'] = Chem.MolFromSmiles('O=C1C([1*])[C@@H]2N1C(C(O)=O)=C([3*])C2')
+    cores_smi_easy['carbapenem'] = Chem.MolFromSmarts('O=C1C([1*])C2N1C(C(O)=O)=C([3*])C2')
+    cores_smi_hard['carbapenem'] = Chem.MolFromSmarts(
+      'O=C1C([2*])([1*])[C@@H]2N1C(C(O)=O)=C([3*])C2')
 
-        # cores_smi_easy['carbapenam'] = Chem.MolFromSmiles('O=C1C([1*])[C@@H]2N1C(C(O)=O)C([3*])([4*])C2')
-        cores_smi_easy['carbapenam'] = Chem.MolFromSmarts('O=C1C([1*])C2N1C(C(O)=O)C([3*])([4*])C2')
-        cores_smi_hard['carbapenam'] = Chem.MolFromSmarts(
-            'O=C1C([2*])([1*])[C@@H]2N1C(C(O)=O)C([3*])([4*])C2')
+    # cores_smi_easy['carbapenam'] = Chem.MolFromSmiles('O=C1C([1*])[C@@H]2N1C(C(O)=O)C([3*])([4*])C2')
+    cores_smi_easy['carbapenam'] = Chem.MolFromSmarts('O=C1C([1*])C2N1C(C(O)=O)C([3*])([4*])C2')
+    cores_smi_hard['carbapenam'] = Chem.MolFromSmarts(
+      'O=C1C([2*])([1*])[C@@H]2N1C(C(O)=O)C([3*])([4*])C2')
 
-        # cores_smi_easy['penem'] = Chem.MolFromSmiles('O=C1C([1*])[C@@H]2N1C(C(O)=O)=C([3*])S2')
-        cores_smi_easy['penem'] = Chem.MolFromSmarts('O=C1C([1*])C2N1C(C(O)=O)=C([3*])S2')
-        cores_smi_hard['penem'] = Chem.MolFromSmarts('O=C1C([2*])([1*])[C@@H]2N1C(C(O)=O)=C([3*])S2')
+    # cores_smi_easy['penem'] = Chem.MolFromSmiles('O=C1C([1*])[C@@H]2N1C(C(O)=O)=C([3*])S2')
+    cores_smi_easy['penem'] = Chem.MolFromSmarts('O=C1C([1*])C2N1C(C(O)=O)=C([3*])S2')
+    cores_smi_hard['penem'] = Chem.MolFromSmarts('O=C1C([2*])([1*])[C@@H]2N1C(C(O)=O)=C([3*])S2')
 
-        # cores_smi_easy['penam'] = Chem.MolFromSmiles('O=C1C([1*])[C@@H]2N1C(C(O)=O)C([3*])([4*])S2')
-        cores_smi_easy['penam'] = Chem.MolFromSmarts('O=C1C([*:1])C2N1C(C(O)=O)C([*:3])([*:4])S2')
-        cores_smi_hard['penam'] = Chem.MolFromSmarts(
-            'O=C1C([*:2])([*:1])[C@@H]2N1C(C(O)=O)C([*:3])([*:4])S2')
+    # cores_smi_easy['penam'] = Chem.MolFromSmiles('O=C1C([1*])[C@@H]2N1C(C(O)=O)C([3*])([4*])S2')
+    cores_smi_easy['penam'] = Chem.MolFromSmarts('O=C1C([*:1])C2N1C(C(O)=O)C([*:3])([*:4])S2')
+    cores_smi_hard['penam'] = Chem.MolFromSmarts(
+      'O=C1C([*:2])([*:1])[C@@H]2N1C(C(O)=O)C([*:3])([*:4])S2')
 
-        # cores_smi_easy['oxapenam'] = Chem.MolFromSmiles('O=C1C([1*])[C@@H]2N1C(C(O)=O)C([3*])([4*])O2')
-        cores_smi_easy['oxapenam'] = Chem.MolFromSmarts('O=C1C([1*])C2N1C(C(O)=O)C([3*])([4*])O2')
-        cores_smi_hard['oxapenam'] = Chem.MolFromSmarts(
-            'O=C1C([2*])([1*])[C@@H]2N1C(C(O)=O)C([3*])([4*])O2')
+    # cores_smi_easy['oxapenam'] = Chem.MolFromSmiles('O=C1C([1*])[C@@H]2N1C(C(O)=O)C([3*])([4*])O2')
+    cores_smi_easy['oxapenam'] = Chem.MolFromSmarts('O=C1C([1*])C2N1C(C(O)=O)C([3*])([4*])O2')
+    cores_smi_hard['oxapenam'] = Chem.MolFromSmarts(
+      'O=C1C([2*])([1*])[C@@H]2N1C(C(O)=O)C([3*])([4*])O2')
 
-        cores_smi_easy['monobactam'] = Chem.MolFromSmarts('O=C1C([1*])C([5*])N1')
-        cores_smi_hard['monobactam'] = Chem.MolFromSmarts('O=C1C([2*])([1*])C([6*])([5*])N1')
-        rg_easy = RGroupDecomposition(cores_smi_easy.values())
-        rg_stereo = RGroupDecomposition(cores_smi_hard.values())
+    cores_smi_easy['monobactam'] = Chem.MolFromSmarts('O=C1C([1*])C([5*])N1')
+    cores_smi_hard['monobactam'] = Chem.MolFromSmarts('O=C1C([2*])([1*])C([6*])([5*])N1')
+    rg_easy = RGroupDecomposition(cores_smi_easy.values())
+    rg_stereo = RGroupDecomposition(cores_smi_hard.values())
 
-    def test_stereo(self):
-        smiles = """C1CCO[C@@H](N)1
+  def test_stereo(self):
+    smiles = """C1CCO[C@@H](N)1
 C1CCO[C@H](N)1
 C1CCO[C@@](N)(O)1
 C1CCO[C@@](N)(P)1
@@ -118,175 +119,175 @@ C1CCO[C@@](S)(N)1
 C1CCO[C@@](S)(O)1
 C1CCO[C@@](S)(P)1
 """
-        mols = []
-        for smi in smiles.split():
-            m = Chem.MolFromSmiles(smi)
-            assert m, smi
-            mols.append(m)
-        core = Chem.MolFromSmarts("C1CCOC1")
-        rgroups = RGroupDecomposition(core)
-        for m in mols:
-            rgroups.Add(m)
-        rgroups.Process()
-        columns = rgroups.GetRGroupsAsColumns()
-        data = {}
-        for k, v in columns.items():
-            data[k] = [Chem.MolToSmiles(m, True) for m in v]
+    mols = []
+    for smi in smiles.split():
+      m = Chem.MolFromSmiles(smi)
+      assert m, smi
+      mols.append(m)
+    core = Chem.MolFromSmarts("C1CCOC1")
+    rgroups = RGroupDecomposition(core)
+    for m in mols:
+      rgroups.Add(m)
+    rgroups.Process()
+    columns = rgroups.GetRGroupsAsColumns()
+    data = {}
+    for k, v in columns.items():
+      data[k] = [Chem.MolToSmiles(m, True) for m in v]
 
-        rgroups2, unmatched = RGroupDecompose([core], mols)
-        columns2, unmatched = RGroupDecompose([core], mols, asRows=False)
-        data2 = {}
-        for k, v in columns2.items():
-            data2[k] = [Chem.MolToSmiles(m, True) for m in v]
+    rgroups2, unmatched = RGroupDecompose([core], mols)
+    columns2, unmatched = RGroupDecompose([core], mols, asRows=False)
+    data2 = {}
+    for k, v in columns2.items():
+      data2[k] = [Chem.MolToSmiles(m, True) for m in v]
 
-        self.assertEqual(data, data2)
-        columns3, unmatched = RGroupDecompose([core], mols, asRows=False, asSmiles=True)
-        self.assertEqual(data, columns3)
+    self.assertEqual(data, data2)
+    columns3, unmatched = RGroupDecompose([core], mols, asRows=False, asSmiles=True)
+    self.assertEqual(data, columns3)
 
-    def test_h_options(self):
-        core = Chem.MolFromSmiles("O=c1oc2ccccc2cc1")
-        smiles = ("O=c1cc(Cn2ccnc2)c2ccc(Oc3ccccc3)cc2o1", "O=c1oc2ccccc2c(Cn2ccnc2)c1-c1ccccc1",
-                  "COc1ccc2c(Cn3cncn3)cc(=O)oc2c1")
-        params = RGroupDecompositionParameters()
-        rgd = RGroupDecomposition(core, params)
-        for smi in smiles:
-            m = Chem.MolFromSmiles(smi)
-            rgd.Add(m)
-        rgd.Process()
-        columns = rgd.GetRGroupsAsColumns()
-        self.assertEqual(columns['R2'][0].GetNumAtoms(), 7)
+  def test_h_options(self):
+    core = Chem.MolFromSmiles("O=c1oc2ccccc2cc1")
+    smiles = ("O=c1cc(Cn2ccnc2)c2ccc(Oc3ccccc3)cc2o1", "O=c1oc2ccccc2c(Cn2ccnc2)c1-c1ccccc1",
+              "COc1ccc2c(Cn3cncn3)cc(=O)oc2c1")
+    params = RGroupDecompositionParameters()
+    rgd = RGroupDecomposition(core, params)
+    for smi in smiles:
+      m = Chem.MolFromSmiles(smi)
+      rgd.Add(m)
+    rgd.Process()
+    columns = rgd.GetRGroupsAsColumns()
+    self.assertEqual(columns['R2'][0].GetNumAtoms(), 7)
 
-        params.removeHydrogensPostMatch = False
-        rgd = RGroupDecomposition(core, params)
-        for smi in smiles:
-            m = Chem.MolFromSmiles(smi)
-            rgd.Add(m)
-        rgd.Process()
-        columns = rgd.GetRGroupsAsColumns()
-        self.assertEqual(columns['R2'][0].GetNumAtoms(), 12)
+    params.removeHydrogensPostMatch = False
+    rgd = RGroupDecomposition(core, params)
+    for smi in smiles:
+      m = Chem.MolFromSmiles(smi)
+      rgd.Add(m)
+    rgd.Process()
+    columns = rgd.GetRGroupsAsColumns()
+    self.assertEqual(columns['R2'][0].GetNumAtoms(), 12)
 
-    def test_unmatched(self):
-        cores = [Chem.MolFromSmiles("N")]
-        mols = [
-            Chem.MolFromSmiles("CC"),
-            Chem.MolFromSmiles("CC"),
-            Chem.MolFromSmiles("CC"),
-            Chem.MolFromSmiles("N"),
-            Chem.MolFromSmiles("CC")
-        ]
+  def test_unmatched(self):
+    cores = [Chem.MolFromSmiles("N")]
+    mols = [
+      Chem.MolFromSmiles("CC"),
+      Chem.MolFromSmiles("CC"),
+      Chem.MolFromSmiles("CC"),
+      Chem.MolFromSmiles("N"),
+      Chem.MolFromSmiles("CC")
+    ]
 
-        res, unmatched = RGroupDecompose(cores, mols)
-        self.assertEqual(len(res), 1)
-        self.assertEqual(unmatched, [0, 1, 2, 4])
+    res, unmatched = RGroupDecompose(cores, mols)
+    self.assertEqual(len(res), 1)
+    self.assertEqual(unmatched, [0, 1, 2, 4])
 
-    def test_userlabels(self):
-        smis = ["C(Cl)N(N)O(O)"]
-        mols = [Chem.MolFromSmiles(smi) for smi in smis]
-        smarts = 'C([*:1])N([*:5])O([*:6])'
-        core = Chem.MolFromSmarts(smarts)
-        rg = RGroupDecomposition(core)
-        for m in mols:
-            rg.Add(m)
-        rg.Process()
-        self.assertEqual(rg.GetRGroupsAsColumns(asSmiles=True), {
-            'Core': ['C(N(O[*:6])[*:5])[*:1]'],
-            'R1': ['Cl[*:1]'],
-            'R5': ['N[*:5]'],
-            'R6': ['O[*:6]']
-        })
+  def test_userlabels(self):
+    smis = ["C(Cl)N(N)O(O)"]
+    mols = [Chem.MolFromSmiles(smi) for smi in smis]
+    smarts = 'C([*:1])N([*:5])O([*:6])'
+    core = Chem.MolFromSmarts(smarts)
+    rg = RGroupDecomposition(core)
+    for m in mols:
+      rg.Add(m)
+    rg.Process()
+    self.assertEqual(rg.GetRGroupsAsColumns(asSmiles=True), {
+      'Core': ['C(N(O[*:6])[*:5])[*:1]'],
+      'R1': ['Cl[*:1]'],
+      'R5': ['N[*:5]'],
+      'R6': ['O[*:6]']
+    })
 
-        smarts = 'C([*:4])N([*:5])O([*:6])'
+    smarts = 'C([*:4])N([*:5])O([*:6])'
 
-        core = Chem.MolFromSmarts(smarts)
-        rg = RGroupDecomposition(core)
-        for m in mols:
-            rg.Add(m)
-        rg.Process()
-        self.assertEqual(rg.GetRGroupsAsColumns(asSmiles=True), {
-            'Core': ['C(N(O[*:6])[*:5])[*:4]'],
-            'R4': ['Cl[*:4]'],
-            'R5': ['N[*:5]'],
-            'R6': ['O[*:6]']
-        })
+    core = Chem.MolFromSmarts(smarts)
+    rg = RGroupDecomposition(core)
+    for m in mols:
+      rg.Add(m)
+    rg.Process()
+    self.assertEqual(rg.GetRGroupsAsColumns(asSmiles=True), {
+      'Core': ['C(N(O[*:6])[*:5])[*:4]'],
+      'R4': ['Cl[*:4]'],
+      'R5': ['N[*:5]'],
+      'R6': ['O[*:6]']
+    })
 
-    def test_match_only_at_rgroups(self):
-        smiles = ['c1ccccc1']  # , 'c1(Cl)ccccc1', 'c1(Cl)cc(Br)ccc1']
-        mols = [Chem.MolFromSmiles(smi) for smi in smiles]
+  def test_match_only_at_rgroups(self):
+    smiles = ['c1ccccc1']  # , 'c1(Cl)ccccc1', 'c1(Cl)cc(Br)ccc1']
+    mols = [Chem.MolFromSmiles(smi) for smi in smiles]
 
-        core1 = Chem.MolFromSmiles("c1([*:5])cc([*:6])ccc1")
-        params = RGroupDecompositionParameters()
-        params.onlyMatchAtRGroups = True
-        rg = RGroupDecomposition(core1, params)
-        for smi, m in zip(smiles, mols):
-            self.assertTrue(rg.Add(m) != -1, smi)
+    core1 = Chem.MolFromSmiles("c1([*:5])cc([*:6])ccc1")
+    params = RGroupDecompositionParameters()
+    params.onlyMatchAtRGroups = True
+    rg = RGroupDecomposition(core1, params)
+    for smi, m in zip(smiles, mols):
+      self.assertTrue(rg.Add(m) != -1, smi)
 
-    def test_incorrect_multiple_rlabels(self):
-        mols = [Chem.MolFromSmiles(smi) for smi in (
-            "C1NC(Cl)CC1",
-            "C1OC(Cl)CC1",
-            "C1(Cl)OCCC1",
-        )]
+  def test_incorrect_multiple_rlabels(self):
+    mols = [Chem.MolFromSmiles(smi) for smi in (
+      "C1NC(Cl)CC1",
+      "C1OC(Cl)CC1",
+      "C1(Cl)OCCC1",
+    )]
 
-        scaffolds = [Chem.MolFromSmarts(x) for x in ("C1NCCC1",)]
-        groups, unmatched = RGroupDecompose(scaffolds, mols, asSmiles=True, asRows=False)
+    scaffolds = [Chem.MolFromSmarts(x) for x in ("C1NCCC1", )]
+    groups, unmatched = RGroupDecompose(scaffolds, mols, asSmiles=True, asRows=False)
 
-        self.assertEqual(groups, {'Core': ['C1CNC([*:1])C1'], 'R1': ['Cl[*:1]']})
+    self.assertEqual(groups, {'Core': ['C1CNC([*:1])C1'], 'R1': ['Cl[*:1]']})
 
-        scaffolds = [Chem.MolFromSmarts(x) for x in ("C1OCCC1",)]
-        groups, unmatched = RGroupDecompose(scaffolds, mols, asSmiles=True, asRows=False)
-        self.assertEqual(groups, {
-            'Core': ['C1COC([*:1])C1', 'C1COC([*:1])C1'],
-            'R1': ['Cl[*:1]', 'Cl[*:1]']
-        })
-        scaffolds = [Chem.MolFromSmarts(x) for x in ("C1NCCC1", "C1OCCC1")]
-        groups, unmatched = RGroupDecompose(scaffolds, mols, asSmiles=True, asRows=False)
-        self.assertEqual(
-            groups, {
-                'Core': ['C1CNC([*:1])C1', 'C1COC([*:1])C1', 'C1COC([*:1])C1'],
-                'R1': ['Cl[*:1]', 'Cl[*:1]', 'Cl[*:1]']
-            })
+    scaffolds = [Chem.MolFromSmarts(x) for x in ("C1OCCC1", )]
+    groups, unmatched = RGroupDecompose(scaffolds, mols, asSmiles=True, asRows=False)
+    self.assertEqual(groups, {
+      'Core': ['C1COC([*:1])C1', 'C1COC([*:1])C1'],
+      'R1': ['Cl[*:1]', 'Cl[*:1]']
+    })
+    scaffolds = [Chem.MolFromSmarts(x) for x in ("C1NCCC1", "C1OCCC1")]
+    groups, unmatched = RGroupDecompose(scaffolds, mols, asSmiles=True, asRows=False)
+    self.assertEqual(
+      groups, {
+        'Core': ['C1CNC([*:1])C1', 'C1COC([*:1])C1', 'C1COC([*:1])C1'],
+        'R1': ['Cl[*:1]', 'Cl[*:1]', 'Cl[*:1]']
+      })
 
-    def test_aligned_cores(self):
-        scaffolds = [Chem.MolFromSmarts(x) for x in ("C1NC1OC", "C1NC1NC")]
-        mols = [Chem.MolFromSmiles(smi) for smi in ("C1NC1OCCC", "C1NC1NCCC")]
-        groups, unmatched = RGroupDecompose(scaffolds, mols, asSmiles=True, asRows=True)
-        # print("test_aligned_Cores")
-        # print("groups:", groups)
-        self.assertEqual(groups, [{
-            'Core': 'C1NC1OC[*:1]',
-            'R1': 'CC[*:1]'
-        }, {
-            'Core': 'C1NC1NC[*:2]',
-            'R2': 'CC[*:2]'
-        }])
+  def test_aligned_cores(self):
+    scaffolds = [Chem.MolFromSmarts(x) for x in ("C1NC1OC", "C1NC1NC")]
+    mols = [Chem.MolFromSmiles(smi) for smi in ("C1NC1OCCC", "C1NC1NCCC")]
+    groups, unmatched = RGroupDecompose(scaffolds, mols, asSmiles=True, asRows=True)
+    # print("test_aligned_Cores")
+    # print("groups:", groups)
+    self.assertEqual(groups, [{
+      'Core': 'C1NC1OC[*:1]',
+      'R1': 'CC[*:1]'
+    }, {
+      'Core': 'C1NC1NC[*:2]',
+      'R2': 'CC[*:2]'
+    }])
 
-    def test_aligned_cores2(self):
-        scaffolds = [Chem.MolFromSmarts(x) for x in ("C1NCC1", "C1SCC1")]
-        mols = [Chem.MolFromSmiles(smi) for smi in ("C1N(P)CC1", "C1S(P)CC1")]
-        # print("test_aligned_Cores2")
-        groups, unmatched = RGroupDecompose(scaffolds, mols, asSmiles=True, asRows=True)
-        # print("groups: ", groups)
-        self.assertEqual(groups, [{
-            'Core': 'C1CN([*:1])C1',
-            'R1': 'P[*:1]'
-        }, {
-            'Core': 'C1C[SH]([*:2])C1',
-            'R2': 'P[*:2]'
-        }])
+  def test_aligned_cores2(self):
+    scaffolds = [Chem.MolFromSmarts(x) for x in ("C1NCC1", "C1SCC1")]
+    mols = [Chem.MolFromSmiles(smi) for smi in ("C1N(P)CC1", "C1S(P)CC1")]
+    # print("test_aligned_Cores2")
+    groups, unmatched = RGroupDecompose(scaffolds, mols, asSmiles=True, asRows=True)
+    # print("groups: ", groups)
+    self.assertEqual(groups, [{
+      'Core': 'C1CN([*:1])C1',
+      'R1': 'P[*:1]'
+    }, {
+      'Core': 'C1C[SH]([*:2])C1',
+      'R2': 'P[*:2]'
+    }])
 
-    def test_getrgrouplabels(self):
-        smis = ["C(Cl)N(N)O(O)"]
-        mols = [Chem.MolFromSmiles(smi) for smi in smis]
-        smarts = 'C([*:1])N([*:5])O([*:6])'
-        core = Chem.MolFromSmarts(smarts)
-        rg = RGroupDecomposition(core)
-        for m in mols:
-            rg.Add(m)
-        rg.Process()
-        self.assertEqual(set(rg.GetRGroupLabels()), set(rg.GetRGroupsAsColumns()))
+  def test_getrgrouplabels(self):
+    smis = ["C(Cl)N(N)O(O)"]
+    mols = [Chem.MolFromSmiles(smi) for smi in smis]
+    smarts = 'C([*:1])N([*:5])O([*:6])'
+    core = Chem.MolFromSmarts(smarts)
+    rg = RGroupDecomposition(core)
+    for m in mols:
+      rg.Add(m)
+    rg.Process()
+    self.assertEqual(set(rg.GetRGroupLabels()), set(rg.GetRGroupsAsColumns()))
 
-    def test_timeout(self):
-        smis = '''CN(C)Cc1cccc(Oc2cc(N3CCN(Cc4ccccc4-c4ccc(Cl)cc4)CC3)ccc2C(=O)NS(=O)(=O)c2ccc(NCC3CCOCC3)c([N+](=O)[O-])c2)c1
+  def test_timeout(self):
+    smis = '''CN(C)Cc1cccc(Oc2cc(N3CCN(Cc4ccccc4-c4ccc(Cl)cc4)CC3)ccc2C(=O)NS(=O)(=O)c2ccc(NCC3CCOCC3)c([N+](=O)[O-])c2)c1
 CNc1cccc(Oc2cc(N3CCN(Cc4ccccc4-c4ccc(Cl)cc4)CC3)ccc2C(=O)NS(=O)(=O)c2ccc(NCC3CCOCC3)c([N+](=O)[O-])c2)c1
 Cc1cc2cc(Oc3cc(N4CCN(CC5=C(c6ccc(Cl)cc6)CC(C)(C)CC5)CC4)ccc3C(=O)NS(=O)(=O)c3ccc(NC4CCN(C)CC4)c([N+](=O)[O-])c3)ccc2[nH]1
 Cc1cc2cc(Oc3cc(N4CCN(CC5=C(c6ccc(Cl)cc6)CC(C)(C)CC5)CC4)ccc3C(=O)NS(=O)(=O)c3ccc(NCCCN4CCOCC4)c([N+](=O)[O-])c3)ccc2[nH]1
@@ -386,43 +387,46 @@ O=C(NS(=O)(=O)c1ccc(NCCCN2CCOCC2)c([N+](=O)[O-])c1)c1ccc(N2CCN(Cc3ccccc3-c3ccc(C
 O=C(NS(=O)(=O)c1ccc(NCCCN2CCOCC2)c([N+](=O)[O-])c1)c1ccc(N2CCN(Cc3ccccc3-c3ccc(Cl)cc3)CC2)cc1Oc1ccc(-c2cccnc2)cc1
 CN(C)C(=O)COc1ccc(Oc2cc(N3CCN(Cc4ccccc4-c4ccc(Cl)cc4)CC3)ccc2C(=O)NS(=O)(=O)c2ccc(NCC3CCOCC3)c([N+](=O)[O-])c2)cc1
 Cn1cnc2cc(Oc3cc(N4CCN(Cc5ccccc5-c5ccc(Cl)cc5)CC4)ccc3C(=O)NS(=O)(=O)c3ccc(NCCCN4CCOCC4)c([N+](=O)[O-])c3)ccc21'''
-        mols = [Chem.MolFromSmiles(x) for x in smis.split('\n')]
+    mols = [Chem.MolFromSmiles(x) for x in smis.split('\n')]
 
-        core = Chem.MolFromSmarts('O=C(NS(=O)(=O)c1ccccc1)c1ccccc1Oc1ccccc1')
-        ps = RGroupDecompositionParameters()
-        ps.timeout = 1.0
-        with self.assertRaises(RuntimeError):
-            rg = RGroupDecomposition(core, ps)
-            for m in mols:
-                rg.Add(m)
+    core = Chem.MolFromSmarts('O=C(NS(=O)(=O)c1ccccc1)c1ccccc1Oc1ccccc1')
+    ps = RGroupDecompositionParameters()
+    ps.timeout = 1.0
+    with self.assertRaises(RuntimeError):
+      rg = RGroupDecomposition(core, ps)
+      for m in mols:
+        rg.Add(m)
 
-        with self.assertRaises(RuntimeError):
-            columns2, unmatched = RGroupDecompose([core], mols, asRows=False, options=ps)
+    with self.assertRaises(RuntimeError):
+      columns2, unmatched = RGroupDecompose([core], mols, asRows=False, options=ps)
 
-    def test_github3402(self):
-        core1 = "[$(C-!@[a])](=O)(Cl)"
-        sma = Chem.MolFromSmarts(core1)
-        m = Chem.MolFromSmiles("c1ccccc1C(=O)Cl")
-        self.assertEqual(RGroupDecompose(sma, [m], asSmiles=True),
-                         ([{'Core': 'O=C(Cl)[*:1]', 'R1': 'c1ccc([*:1])cc1'}], []))
+  def test_github3402(self):
+    core1 = "[$(C-!@[a])](=O)(Cl)"
+    sma = Chem.MolFromSmarts(core1)
+    m = Chem.MolFromSmiles("c1ccccc1C(=O)Cl")
+    self.assertEqual(RGroupDecompose(sma, [m], asSmiles=True), ([{
+      'Core': 'O=C(Cl)[*:1]',
+      'R1': 'c1ccc([*:1])cc1'
+    }], []))
 
-    def test_multicore_prelabelled(self):
-        def multicorergd_test(cores, params, expected_rows, expected_items):
-            mols = [Chem.MolFromSmiles(smi) for smi in ("CNC(=O)C1=CN=CN1CC", "Fc1ccc2ccc(Br)nc2n1")]
-            params.removeHydrogensPostMatch = True
-            params.onlyMatchAtRGroups = True
-            decomp = RGroupDecomposition(cores, params)
-            i = 0
-            for i, m in enumerate(mols):
-                res = decomp.Add(m)
-                self.assertEqual(res, i)
-            self.assertTrue(decomp.Process())
-            rows = decomp.GetRGroupsAsRows(asSmiles=True)
-            self.assertEqual(rows, expected_rows)
-            items = decomp.GetRGroupsAsColumns(asSmiles=True)
-            self.assertEqual(items, expected_items)
+  def test_multicore_prelabelled(self):
 
-        sdcores = """
+    def multicorergd_test(cores, params, expected_rows, expected_items):
+      mols = [Chem.MolFromSmiles(smi) for smi in ("CNC(=O)C1=CN=CN1CC", "Fc1ccc2ccc(Br)nc2n1")]
+      params.removeHydrogensPostMatch = True
+      params.onlyMatchAtRGroups = True
+      decomp = RGroupDecomposition(cores, params)
+      i = 0
+      for i, m in enumerate(mols):
+        res = decomp.Add(m)
+        self.assertEqual(res, i)
+      self.assertTrue(decomp.Process())
+      rows = decomp.GetRGroupsAsRows(asSmiles=True)
+      self.assertEqual(rows, expected_rows)
+      items = decomp.GetRGroupsAsColumns(asSmiles=True)
+      self.assertEqual(items, expected_items)
+
+    sdcores = """
      RDKit          2D
 
   9  9  0  0  0  0  0  0  0  0999 V2000
@@ -484,149 +488,171 @@ V   12 *
 M  END
 $$$$
 """
-        sdsup = Chem.SDMolSupplier()
-        sdsup.SetData(sdcores)
-        cores = [c for c in sdsup]
+    sdsup = Chem.SDMolSupplier()
+    sdsup.SetData(sdcores)
+    cores = [c for c in sdsup]
 
-        expected_rows = [
-            {'Core': 'O=C(c1cncn1[*:2])[*:1]', 'R1': 'CN[*:1]', 'R2': 'CC[*:2]'},
-            {'Core': 'c1cc2ccc([*:2])nc2nc1[*:1]', 'R1': 'F[*:1]', 'R2': 'Br[*:2]'}
-        ]
+    expected_rows = [{
+      'Core': 'O=C(c1cncn1[*:2])[*:1]',
+      'R1': 'CN[*:1]',
+      'R2': 'CC[*:2]'
+    }, {
+      'Core': 'c1cc2ccc([*:2])nc2nc1[*:1]',
+      'R1': 'F[*:1]',
+      'R2': 'Br[*:2]'
+    }]
 
-        expected_items = {
-            'Core': ['O=C(c1cncn1[*:2])[*:1]', 'c1cc2ccc([*:2])nc2nc1[*:1]'],
-            'R1': ['CN[*:1]', 'F[*:1]'],
-            'R2': ['CC[*:2]', 'Br[*:2]']
-        }
+    expected_items = {
+      'Core': ['O=C(c1cncn1[*:2])[*:1]', 'c1cc2ccc([*:2])nc2nc1[*:1]'],
+      'R1': ['CN[*:1]', 'F[*:1]'],
+      'R2': ['CC[*:2]', 'Br[*:2]']
+    }
 
-        params = RGroupDecompositionParameters()
+    params = RGroupDecompositionParameters()
 
-        # test pre-labelled with MDL R-group labels, autodetect
-        params.labels = RGroupLabels.AutoDetect
-        params.alignment = RGroupCoreAlignment.MCS
-        multicorergd_test(cores, params, expected_rows,
-                          expected_items)
-        # test pre-labelled with MDL R-group labels, no autodetect
-        params.labels = RGroupLabels.MDLRGroupLabels | RGroupLabels.RelabelDuplicateLabels
-        params.alignment = RGroupCoreAlignment.MCS
-        multicorergd_test(cores, params, expected_rows,
-                          expected_items)
-        # test pre-labelled with MDL R-group labels, autodetect, no MCS alignment
-        params.labels = RGroupLabels.AutoDetect
-        params.alignment = RGroupCoreAlignment.NoAlignment
-        multicorergd_test(cores, params, expected_rows,
-                          expected_items)
+    # test pre-labelled with MDL R-group labels, autodetect
+    params.labels = RGroupLabels.AutoDetect
+    params.alignment = RGroupCoreAlignment.MCS
+    multicorergd_test(cores, params, expected_rows, expected_items)
+    # test pre-labelled with MDL R-group labels, no autodetect
+    params.labels = RGroupLabels.MDLRGroupLabels | RGroupLabels.RelabelDuplicateLabels
+    params.alignment = RGroupCoreAlignment.MCS
+    multicorergd_test(cores, params, expected_rows, expected_items)
+    # test pre-labelled with MDL R-group labels, autodetect, no MCS alignment
+    params.labels = RGroupLabels.AutoDetect
+    params.alignment = RGroupCoreAlignment.NoAlignment
+    multicorergd_test(cores, params, expected_rows, expected_items)
 
-        # Reading from a MDL molblock also sets isotopic labels, so no need
-        # to set them again; we only clear MDL R-group labels
-        for core in cores:
-            for a in core.GetAtoms():
-                if a.HasProp("_MolFileRLabel"):
-                    a.ClearProp("_MolFileRLabel")
-        # test pre-labelled with isotopic labels, autodetect
-        params.labels = RGroupLabels.AutoDetect
-        params.alignment = RGroupCoreAlignment.MCS
-        multicorergd_test(cores, params, expected_rows,
-                          expected_items)
-        # test pre-labelled with isotopic labels, no autodetect
-        params.labels = RGroupLabels.IsotopeLabels | RGroupLabels.RelabelDuplicateLabels
-        params.alignment = RGroupCoreAlignment.MCS
-        multicorergd_test(cores, params, expected_rows,
-                          expected_items)
-        # test pre-labelled with isotopic labels, autodetect, no MCS alignment
-        params.labels = RGroupLabels.AutoDetect
-        params.alignment = RGroupCoreAlignment.NoAlignment
-        multicorergd_test(cores, params, expected_rows,
-                          expected_items)
+    # Reading from a MDL molblock also sets isotopic labels, so no need
+    # to set them again; we only clear MDL R-group labels
+    for core in cores:
+      for a in core.GetAtoms():
+        if a.HasProp("_MolFileRLabel"):
+          a.ClearProp("_MolFileRLabel")
+    # test pre-labelled with isotopic labels, autodetect
+    params.labels = RGroupLabels.AutoDetect
+    params.alignment = RGroupCoreAlignment.MCS
+    multicorergd_test(cores, params, expected_rows, expected_items)
+    # test pre-labelled with isotopic labels, no autodetect
+    params.labels = RGroupLabels.IsotopeLabels | RGroupLabels.RelabelDuplicateLabels
+    params.alignment = RGroupCoreAlignment.MCS
+    multicorergd_test(cores, params, expected_rows, expected_items)
+    # test pre-labelled with isotopic labels, autodetect, no MCS alignment
+    params.labels = RGroupLabels.AutoDetect
+    params.alignment = RGroupCoreAlignment.NoAlignment
+    multicorergd_test(cores, params, expected_rows, expected_items)
 
-        for core in cores:
-            for a in core.GetAtoms():
-                iso = a.GetIsotope()
-                if iso:
-                    a.SetAtomMapNum(iso)
-                    a.SetIsotope(0)
-        # test pre-labelled with atom map labels, autodetect
-        params.labels = RGroupLabels.AutoDetect
-        params.alignment = RGroupCoreAlignment.MCS
-        multicorergd_test(cores, params, expected_rows,
-                          expected_items)
-        # test pre-labelled with atom map labels, no autodetect
-        params.labels = RGroupLabels.AtomMapLabels | RGroupLabels.RelabelDuplicateLabels
-        params.alignment = RGroupCoreAlignment.MCS
-        multicorergd_test(cores, params, expected_rows,
-                          expected_items)
-        # test pre-labelled with atom map labels, autodetect, no MCS alignment
-        params.labels = RGroupLabels.AutoDetect
-        params.alignment = RGroupCoreAlignment.NoAlignment
-        multicorergd_test(cores, params, expected_rows,
-                          expected_items)
+    for core in cores:
+      for a in core.GetAtoms():
+        iso = a.GetIsotope()
+        if iso:
+          a.SetAtomMapNum(iso)
+          a.SetIsotope(0)
+    # test pre-labelled with atom map labels, autodetect
+    params.labels = RGroupLabels.AutoDetect
+    params.alignment = RGroupCoreAlignment.MCS
+    multicorergd_test(cores, params, expected_rows, expected_items)
+    # test pre-labelled with atom map labels, no autodetect
+    params.labels = RGroupLabels.AtomMapLabels | RGroupLabels.RelabelDuplicateLabels
+    params.alignment = RGroupCoreAlignment.MCS
+    multicorergd_test(cores, params, expected_rows, expected_items)
+    # test pre-labelled with atom map labels, autodetect, no MCS alignment
+    params.labels = RGroupLabels.AutoDetect
+    params.alignment = RGroupCoreAlignment.NoAlignment
+    multicorergd_test(cores, params, expected_rows, expected_items)
 
-        for core in cores:
-            for a in core.GetAtoms():
-                if a.GetAtomMapNum():
-                    a.SetAtomMapNum(0)
-        # test pre-labelled with dummy atom labels, autodetect
+    for core in cores:
+      for a in core.GetAtoms():
+        if a.GetAtomMapNum():
+          a.SetAtomMapNum(0)
+    # test pre-labelled with dummy atom labels, autodetect
 
-        expected_rows = [{'Core': 'O=C(c1cncn1[*:2])[*:1]', 'R1': 'CN[*:1]', 'R2': 'CC[*:2]'},
-                         {'Core': 'c1cc2ccc([*:2])nc2nc1[*:1]', 'R1': 'Br[*:1]', 'R2': 'F[*:2]'}]
+    expected_rows = [{
+      'Core': 'O=C(c1cncn1[*:2])[*:1]',
+      'R1': 'CN[*:1]',
+      'R2': 'CC[*:2]'
+    }, {
+      'Core': 'c1cc2ccc([*:2])nc2nc1[*:1]',
+      'R1': 'Br[*:1]',
+      'R2': 'F[*:2]'
+    }]
 
-        expected_items = {'Core': ['O=C(c1cncn1[*:2])[*:1]', 'c1cc2ccc([*:2])nc2nc1[*:1]'],
-                          'R1': ['CN[*:1]', 'Br[*:1]'],
-                          'R2': ['CC[*:2]', 'F[*:2]']}
+    expected_items = {
+      'Core': ['O=C(c1cncn1[*:2])[*:1]', 'c1cc2ccc([*:2])nc2nc1[*:1]'],
+      'R1': ['CN[*:1]', 'Br[*:1]'],
+      'R2': ['CC[*:2]', 'F[*:2]']
+    }
 
-        params.labels = RGroupLabels.AutoDetect
-        params.alignment = RGroupCoreAlignment.MCS
-        multicorergd_test(cores, params, expected_rows,
-                          expected_items)
-        # test pre-labelled with dummy atom labels, no autodetect
-        # in this case there is no difference from autodetect as the RGD code
-        # cannot tell the difference between query atoms and dummy R-groups
-        params.labels = RGroupLabels.DummyAtomLabels | RGroupLabels.RelabelDuplicateLabels
-        params.alignment = RGroupCoreAlignment.MCS
-        multicorergd_test(cores, params, expected_rows,
-                          expected_items)
+    params.labels = RGroupLabels.AutoDetect
+    params.alignment = RGroupCoreAlignment.MCS
+    multicorergd_test(cores, params, expected_rows, expected_items)
+    # test pre-labelled with dummy atom labels, no autodetect
+    # in this case there is no difference from autodetect as the RGD code
+    # cannot tell the difference between query atoms and dummy R-groups
+    params.labels = RGroupLabels.DummyAtomLabels | RGroupLabels.RelabelDuplicateLabels
+    params.alignment = RGroupCoreAlignment.MCS
+    multicorergd_test(cores, params, expected_rows, expected_items)
 
-    def testRemoveAllHydrogenFlags(self):
-        core = Chem.MolFromSmiles("[1*]c1ccc([2*])cn1")
-        mol = Chem.MolFromSmiles("Fc1ccccn1")
+  def testRemoveAllHydrogenFlags(self):
+    core = Chem.MolFromSmiles("[1*]c1ccc([2*])cn1")
+    mol = Chem.MolFromSmiles("Fc1ccccn1")
 
-        params = RGroupDecompositionParameters()
-        rgd = RGroupDecomposition(core, params)
-        self.assertEqual(rgd.Add(mol), 0)
-        self.assertTrue(rgd.Process())
-        res = rgd.GetRGroupsAsColumns(asSmiles=True)
-        self.assertEqual(res, {'Core': ['c1ccc([*:1])nc1'], 'R1': ['F[*:1]']})
+    params = RGroupDecompositionParameters()
+    rgd = RGroupDecomposition(core, params)
+    self.assertEqual(rgd.Add(mol), 0)
+    self.assertTrue(rgd.Process())
+    res = rgd.GetRGroupsAsColumns(asSmiles=True)
+    self.assertEqual(res, {'Core': ['c1ccc([*:1])nc1'], 'R1': ['F[*:1]']})
 
-        # no change, as removeAllHydrogenRGroupsAndLabels is True
-        params = RGroupDecompositionParameters()
-        params.removeAllHydrogenRGroups = False
-        rgd = RGroupDecomposition(core, params)
-        self.assertEqual(rgd.Add(mol), 0)
-        self.assertTrue(rgd.Process())
-        res = rgd.GetRGroupsAsColumns(asSmiles=True)
-        self.assertEqual(res, {'Core': ['c1ccc([*:1])nc1'], 'R1': ['F[*:1]']})
+    # no change, as removeAllHydrogenRGroupsAndLabels is True
+    params = RGroupDecompositionParameters()
+    params.removeAllHydrogenRGroups = False
+    rgd = RGroupDecomposition(core, params)
+    self.assertEqual(rgd.Add(mol), 0)
+    self.assertTrue(rgd.Process())
+    res = rgd.GetRGroupsAsColumns(asSmiles=True)
+    self.assertEqual(res, {'Core': ['c1ccc([*:1])nc1'], 'R1': ['F[*:1]']})
 
-        # Unused user-defined labels retained on core
-        # R groups still retained as removeAllHydrogenRGroups is True
-        params = RGroupDecompositionParameters()
-        params.removeAllHydrogenRGroupsAndLabels = False
-        rgd = RGroupDecomposition(core, params)
-        self.assertEqual(rgd.Add(mol), 0)
-        self.assertTrue(rgd.Process())
-        res = rgd.GetRGroupsAsColumns(asSmiles=True)
-        self.assertEqual(res, {'Core': ['c1cc([*:1])ncc1[*:2]'], 'R1': ['F[*:1]']})
+    # Unused user-defined labels retained on core
+    # R groups still retained as removeAllHydrogenRGroups is True
+    params = RGroupDecompositionParameters()
+    params.removeAllHydrogenRGroupsAndLabels = False
+    rgd = RGroupDecomposition(core, params)
+    self.assertEqual(rgd.Add(mol), 0)
+    self.assertTrue(rgd.Process())
+    res = rgd.GetRGroupsAsColumns(asSmiles=True)
+    self.assertEqual(res, {'Core': ['c1cc([*:1])ncc1[*:2]'], 'R1': ['F[*:1]']})
 
-        # Unused user-defined labels retained on core and in R groups
-        params = RGroupDecompositionParameters()
-        params.removeAllHydrogenRGroups = False
-        params.removeAllHydrogenRGroupsAndLabels = False
-        rgd = RGroupDecomposition(core, params)
-        self.assertEqual(rgd.Add(mol), 0)
-        self.assertTrue(rgd.Process())
-        res = rgd.GetRGroupsAsColumns(asSmiles=True)
-        self.assertEqual(res, {'Core': ['c1cc([*:1])ncc1[*:2]'], 'R1': ['F[*:1]'], 'R2': ['[H][*:2]']})
+    # Unused user-defined labels retained on core and in R groups
+    params = RGroupDecompositionParameters()
+    params.removeAllHydrogenRGroups = False
+    params.removeAllHydrogenRGroupsAndLabels = False
+    rgd = RGroupDecomposition(core, params)
+    self.assertEqual(rgd.Add(mol), 0)
+    self.assertTrue(rgd.Process())
+    res = rgd.GetRGroupsAsColumns(asSmiles=True)
+    self.assertEqual(res, {'Core': ['c1cc([*:1])ncc1[*:2]'], 'R1': ['F[*:1]'], 'R2': ['[H][*:2]']})
+
+  def testSubstructMatchParameters(self):
+    mols = [
+      Chem.MolFromSmiles(x) for x in ("C1CN[C@H]1F", "C1CN[C@]1(O)F", "C1CN[C@@H]1F", "C1CN[CH]1F")
+    ]
+    cores = [Chem.MolFromSmiles('C1CNC1[*:1]')]
+    chiral_cores = [Chem.MolFromSmiles('C1CN[C@H]1[*:1]')]
+
+    rgroups, unmatched = RGroupDecompose(cores, mols)
+    self.assertEqual(unmatched, [])
+    rgroups, unmatched = RGroupDecompose(chiral_cores, mols)
+    self.assertEqual(unmatched, [3])
+
+    params = RGroupDecompositionParameters()
+    params.substructMatchParams.useChirality = False
+    rgroups, unmatched = RGroupDecompose(cores, mols, options=params)
+    self.assertEqual(unmatched, [])
+    rgroups, unmatched = RGroupDecompose(chiral_cores, mols, options=params)
+    self.assertEqual(unmatched, [])
 
 
 if __name__ == '__main__':
-    rdBase.DisableLog("rdApp.debug")
-    unittest.main()
+  rdBase.DisableLog("rdApp.debug")
+  unittest.main()

--- a/Code/GraphMol/Substruct/SubstructMatch.cpp
+++ b/Code/GraphMol/Substruct/SubstructMatch.cpp
@@ -130,16 +130,59 @@ void MatchSubqueries(const ROMol &mol, QueryAtom::QUERYATOM_QUERY *q,
                      SUBQUERY_MAP &subqueryMap,
                      std::vector<RecursiveStructureQuery *> &locked);
 
-bool matchCompare(const std::pair<int, int> &a, const std::pair<int, int> &b);
-bool matchVectCompare(const MatchVectType &a, const MatchVectType &b);
-bool isToBeAddedToVector(std::vector<MatchVectType> &matches,
-                         const MatchVectType &m);
-void mergeMatchVect(std::vector<MatchVectType> &matches,
-                    const std::vector<MatchVectType> &matchesTmp,
-                    const ResSubstructMatchHelperArgs_ &args);
+inline int getSecondPairElement(const std::pair<int, int> &p) {
+  return p.second;
+}
+
+bool insertIfNeeded(std::set<MatchVectType> &matches, const MatchVectType &m) {
+  bool shouldInsert = true;
+  std::unordered_set<int> matchAsSet;
+  std::transform(m.begin(), m.end(),
+                 std::inserter(matchAsSet, matchAsSet.begin()),
+                 getSecondPairElement);
+  for (auto it = matches.begin(); it != matches.end(); ++it) {
+    std::unordered_set<int> existingMatchAsSet;
+    std::transform(
+        it->begin(), it->end(),
+        std::inserter(existingMatchAsSet, existingMatchAsSet.begin()),
+        getSecondPairElement);
+    if (matchAsSet == existingMatchAsSet) {
+      if (m < *it) {
+        matches.erase(it);
+      } else {
+        shouldInsert = false;
+      }
+      break;
+    }
+  }
+  if (shouldInsert) {
+    matches.insert(m);
+  }
+  return shouldInsert;
+}
+
+template <
+    typename Container,
+    typename std::enable_if<
+        std::is_same<MatchVectType, typename Container::value_type>::value,
+        int>::type = 0>
+void mergeMatchVect(std::set<MatchVectType> &matches,
+                    const Container &matchesTmp,
+                    const ResSubstructMatchHelperArgs_ &args) {
+  for (auto it = matchesTmp.begin();
+       (matches.size() < args.params.maxMatches) && (it != matchesTmp.end());
+       ++it) {
+    if (!args.params.uniquify) {
+      matches.insert(*it);
+    } else {
+      insertIfNeeded(matches, *it);
+    }
+  }
+}
+
 void ResSubstructMatchHelper_(const ResSubstructMatchHelperArgs_ &args,
-                              std::vector<MatchVectType> *matches,
-                              unsigned int bi, unsigned int ei);
+                              std::set<MatchVectType> *matches, unsigned int bi,
+                              unsigned int ei);
 
 typedef std::list<
     std::pair<MolGraph::vertex_descriptor, MolGraph::vertex_descriptor>>
@@ -162,9 +205,8 @@ MolMatchFinalCheckFunctor::MolMatchFinalCheckFunctor(
   }
 }
 
-bool MolMatchFinalCheckFunctor::operator()(
-    const std::uint32_t q_c[],
-    const std::uint32_t m_c[]) const {
+bool MolMatchFinalCheckFunctor::operator()(const std::uint32_t q_c[],
+                                           const std::uint32_t m_c[]) const {
   if (d_params.extraFinalCheck) {
     // EFF: we can no-doubt do better than this
     std::vector<unsigned int> aids(m_c, m_c + d_query.getNumAtoms());
@@ -379,21 +421,9 @@ class BondLabelFunctor {
   const ROMol &d_mol;
   const SubstructMatchParameters &d_params;
 };
-void mergeMatchVect(std::vector<MatchVectType> &matches,
-                    const std::vector<MatchVectType> &matchesTmp,
-                    const ResSubstructMatchHelperArgs_ &args) {
-  for (auto it = matchesTmp.begin();
-       (matches.size() < args.params.maxMatches) && (it != matchesTmp.end());
-       ++it) {
-    if ((std::find(matches.begin(), matches.end(), *it) == matches.end()) &&
-        (!args.params.uniquify || isToBeAddedToVector(matches, *it))) {
-      matches.push_back(*it);
-    }
-  }
-};
 void ResSubstructMatchHelper_(const ResSubstructMatchHelperArgs_ &args,
-                              std::vector<MatchVectType> *matches,
-                              unsigned int bi, unsigned int ei) {
+                              std::set<MatchVectType> *matches, unsigned int bi,
+                              unsigned int ei) {
   for (unsigned int i = bi;
        (matches->size() < args.params.maxMatches) && (i < ei); ++i) {
     ROMol *mol = args.resMolSupplier[i];
@@ -512,7 +542,7 @@ std::vector<MatchVectType> SubstructMatch(
 std::vector<MatchVectType> SubstructMatch(
     ResonanceMolSupplier &resMolSupplier, const ROMol &query,
     const SubstructMatchParameters &params) {
-  std::vector<MatchVectType> matches;
+  std::set<MatchVectType> matches;
   detail::ResSubstructMatchHelperArgs_ args = {resMolSupplier, query, params};
   unsigned int nt =
       std::min(resMolSupplier.length(), getNumThreadsToUse(params.numThreads));
@@ -523,13 +553,13 @@ std::vector<MatchVectType> SubstructMatch(
 #ifdef RDK_THREADSAFE_SSS
   else {
     std::vector<std::future<void>> tg;
-    std::vector<std::vector<MatchVectType> *> matchesThread(nt);
+    std::vector<std::set<MatchVectType> *> matchesThread(nt);
     unsigned int ei = 0;
     double dpt =
         static_cast<double>(resMolSupplier.length()) / static_cast<double>(nt);
     double dc = 0.0;
     for (unsigned int ti = 0; ti < nt; ++ti) {
-      matchesThread[ti] = new std::vector<MatchVectType>();
+      matchesThread[ti] = new std::set<MatchVectType>();
       unsigned int bi = ei;
       dc += dpt;
       ei = static_cast<unsigned int>(floor(dc));
@@ -541,19 +571,13 @@ std::vector<MatchVectType> SubstructMatch(
       fut.get();
     }
 
-    unsigned int matchSize = 0;
     for (unsigned int ti = 0; ti < nt; ++ti) {
-      matchSize += matchesThread[ti]->size();
-    }
-    matches.reserve(matchSize);
-    for (unsigned int ti = 0; ti < nt; ++ti) {
-      mergeMatchVect(matches, *(matchesThread[ti]), args);
+      mergeMatchVect(matches, *matchesThread[ti], args);
       delete matchesThread[ti];
     }
   }
 #endif
-  std::sort(matches.begin(), matches.end(), detail::matchVectCompare);
-  return matches;
+  return std::vector<MatchVectType>(matches.begin(), matches.end());
 }
 
 namespace detail {
@@ -677,45 +701,5 @@ void MatchSubqueries(const ROMol &mol, QueryAtom::QUERYATOM_QUERY *query,
   // std::cout << "<<- back " << (int)query << std::endl;
 }
 
-bool matchCompare(const std::pair<int, int> &a, const std::pair<int, int> &b) {
-  return (a.second < b.second);
-}
-
-bool matchVectCompare(const MatchVectType &a, const MatchVectType &b) {
-  for (unsigned int i = 0; i < std::min(a.size(), b.size()); ++i) {
-    if (a[i].second != b[i].second) {
-      return (a[i].second < b[i].second);
-    }
-  }
-  return (a.size() < b.size());
-}
-
-bool isToBeAddedToVector(std::vector<MatchVectType> &matches,
-                         const MatchVectType &m) {
-  bool isToBeAdded = true;
-  MatchVectType mCopy = m;
-  std::sort(mCopy.begin(), mCopy.end(), matchCompare);
-  for (auto it = matches.end(); isToBeAdded && it != matches.begin();) {
-    --it;
-    isToBeAdded = (it->size() != mCopy.size());
-    if (!isToBeAdded) {
-      MatchVectType matchCopy = *it;
-      std::sort(matchCopy.begin(), matchCopy.end(), matchCompare);
-      for (unsigned int i = 0; !isToBeAdded && (i < matchCopy.size()); ++i) {
-        isToBeAdded = (mCopy[i].second != matchCopy[i].second);
-      }
-      if (!isToBeAdded) {
-        for (unsigned int i = 0; !isToBeAdded && (i < m.size()); ++i) {
-          isToBeAdded = (m[i].second < (*it)[i].second);
-        }
-        if (isToBeAdded) {
-          matches.erase(it);
-          break;
-        }
-      }
-    }
-  }
-  return isToBeAdded;
-}
 }  // end of namespace detail
 }  // namespace RDKit

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -3978,7 +3978,7 @@ CAS<~>
                                (125, 124, 126, 123), (126, 124, 125, 123)))
     matches = resMolSupplST.GetSubstructMatches(guanidiniumQuery, uniquify=True)
     self.assertEqual(len(matches), 2)
-    self.assertEqual(matches, ((66, 67, 69, 68), (123, 124, 126, 125)))
+    self.assertEqual(matches, ((66, 67, 68, 69), (123, 124, 125, 126)))
     btList2ST = getBtList2(resMolSupplST)
     self.assertTrue(btList2ST)
     resMolSupplMT = Chem.ResonanceMolSupplier(crambin)
@@ -4005,7 +4005,7 @@ CAS<~>
                                  (125, 124, 126, 123), (126, 124, 125, 123)))
       matches = suppl.GetSubstructMatches(guanidiniumQuery, uniquify=True, numThreads=0)
       self.assertEqual(len(matches), 2)
-      self.assertEqual(matches, ((66, 67, 69, 68), (123, 124, 126, 125)))
+      self.assertEqual(matches, ((66, 67, 68, 69), (123, 124, 125, 126)))
 
   def testGitHub1166(self):
     mol = Chem.MolFromSmiles('NC(=[NH2+])c1ccc(cc1)C(=O)[O-]')

--- a/Code/GraphMol/catch_graphmol.cpp
+++ b/Code/GraphMol/catch_graphmol.cpp
@@ -2092,3 +2092,33 @@ TEST_CASE(
     CHECK(m->getRingInfo()->numRings() == m2.getRingInfo()->numRings());
   }
 }
+
+TEST_CASE("QueryBond valence contribs") {
+  {
+    auto m = "CO"_smarts;
+    REQUIRE(m);
+    CHECK(m->getBondWithIdx(0)->getValenceContrib(m->getAtomWithIdx(0)) == 0.0);
+    CHECK(m->getBondWithIdx(0)->getValenceContrib(m->getAtomWithIdx(1)) == 0.0);
+  }
+  {
+    auto m = "C-O"_smarts;
+    REQUIRE(m);
+    CHECK(m->getBondWithIdx(0)->getValenceContrib(m->getAtomWithIdx(0)) == 1.0);
+    CHECK(m->getBondWithIdx(0)->getValenceContrib(m->getAtomWithIdx(1)) == 1.0);
+  }
+}
+
+TEST_CASE(
+    "github #4311: unreasonable calculation of implicit valence for atoms with "
+    "query bonds",
+    "[graphmol]") {
+  SECTION("basics") {
+    auto m = "C-,=O"_smarts;
+    REQUIRE(m);
+    m->updatePropertyCache();
+    CHECK(m->getAtomWithIdx(0)->getTotalNumHs() == 0);
+    CHECK(m->getAtomWithIdx(1)->getTotalNumHs() == 0);
+    CHECK(MolToSmiles(*m) == "CO");
+    CHECK(MolToSmarts(*m) == "C-,=O");
+  }
+}

--- a/Code/GraphMol/molopstest.cpp
+++ b/Code/GraphMol/molopstest.cpp
@@ -1,5 +1,5 @@
 //
-//   Copyright (C) 2002-2018 Greg Landrum and Rational Discovery LLC
+//   Copyright (C) 2002-2021 Greg Landrum and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -658,7 +658,7 @@ void test8() {
   delete m2;
 
   std::string sma;
-  smi = "CC";
+  smi = "C-C";
   m = SmartsToMol(smi);
   MolOps::sanitizeMol(*((RWMol *)m));
   TEST_ASSERT(m);

--- a/Code/GraphMol/querytest.cpp
+++ b/Code/GraphMol/querytest.cpp
@@ -1,5 +1,5 @@
 //
-//   Copyright (C) 2002-2017 Rational Discovery LLC and Greg Landrum
+//   Copyright (C) 2002-2021 Greg Landrum and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -878,6 +878,41 @@ void testGithub2471() {
   BOOST_LOG(rdErrorLog) << "Done!" << std::endl;
 }
 
+void testHasBondTypeQuery() {
+  BOOST_LOG(rdErrorLog) << "---------------------- Testing hasBondTypeQuery() "
+                           "and hasComplexBondTypeQuery()"
+                        << std::endl;
+
+  {
+    auto m = "C-C-@C@-C@CC-,=C!-C"_smarts;
+    TEST_ASSERT(m);
+    for (const auto bond : m->bonds()) {
+      bool hasQ = QueryOps::hasBondTypeQuery(*bond);
+      if (bond->getIdx() != 3) {
+        TEST_ASSERT(hasQ);
+      } else {
+        TEST_ASSERT(!hasQ);
+      }
+    }
+    for (const auto bond : m->bonds()) {
+      bool hasQ = QueryOps::hasComplexBondTypeQuery(*bond);
+      if (bond->getIdx() < 4) {
+        TEST_ASSERT(!hasQ);
+      } else {
+        TEST_ASSERT(hasQ);
+      }
+    }
+  }
+  {
+    auto m = "CC-C"_smiles;
+    TEST_ASSERT(m);
+    for (const auto bond : m->bonds()) {
+      TEST_ASSERT(!QueryOps::hasBondTypeQuery(*bond));
+    }
+  }
+  BOOST_LOG(rdErrorLog) << "Done!" << std::endl;
+}
+
 int main() {
   RDLog::InitLogs();
 #if 1
@@ -900,5 +935,6 @@ int main() {
   testNumHeteroatomNeighborQueries();
   testAtomTypeQueries();
   testGithub2471();
+  testHasBondTypeQuery();
   return 0;
 }


### PR DESCRIPTION
Today I have built the RDKit with GCC 9.3.0 on a machine with 40 CPU cores and I had a failure in `testCrambin` (`Code/GraphMol/Wrap/rough_test.py`). Upon investigation this turned out to be caused by the algorithm that only keeps unique substructure matches not being deterministic, and hence liable to returning different matches depending on the substructure match concurrency.
This PR implements a robust solution, which I believe is also more elegant and computationally efficient compared to the one that was in place before.
Now match uniquification always returns the match vector with indices in the minimum sorted order across all the possible permutations. I have adjusted `testCrambin` results accordingly.
I am surprised that the test has not failed before.