### PR TITLE
Fixes to integer conversions and their tests

### DIFF
--- a/Code/RDGeneral/RDValue-taggedunion.h
+++ b/Code/RDGeneral/RDValue-taggedunion.h
@@ -443,7 +443,7 @@ inline unsigned int rdvalue_cast<unsigned int>(RDValue_cast_t v) {
 
 template <>
 inline std::uint8_t rdvalue_cast<std::uint8_t>(RDValue_cast_t v) {
-  if (rdvalue_is<int>(v)) return boost::numeric_cast<std::uint8_t>(v.value.u);
+  if (rdvalue_is<int>(v)) return boost::numeric_cast<std::uint8_t>(v.value.i);
   if (rdvalue_is<unsigned int>(v))
     return boost::numeric_cast<std::uint8_t>(v.value.u);
   throw boost::bad_any_cast();
@@ -451,9 +451,9 @@ inline std::uint8_t rdvalue_cast<std::uint8_t>(RDValue_cast_t v) {
 
 template <>
 inline std::uint16_t rdvalue_cast<std::uint16_t>(RDValue_cast_t v) {
-  if (rdvalue_is<int>(v)) return boost::numeric_cast<std::uint8_t>(v.value.i);
+  if (rdvalue_is<int>(v)) return boost::numeric_cast<std::uint16_t>(v.value.i);
   if (rdvalue_is<unsigned int>(v))
-    return boost::numeric_cast<std::uint8_t>(v.value.u);
+    return boost::numeric_cast<std::uint16_t>(v.value.u);
   throw boost::bad_any_cast();
 }
 

--- a/Code/RDGeneral/testRDValue.cpp
+++ b/Code/RDGeneral/testRDValue.cpp
@@ -271,6 +271,29 @@ void testIntConversions() {
     
     p.getProp<std::int16_t>("foo");
     
+	// Test that min/max values of smaller types do not under/overflow
+	p.setProp<unsigned int>("foo", 0);
+    p.getProp<std::uint8_t>("foo");
+    p.getProp<std::uint16_t>("foo");
+
+	p.setProp<unsigned int>("foo", 255);
+    p.getProp<std::uint8_t>("foo");
+
+	p.setProp<unsigned int>("foo", 65535);
+    p.getProp<std::uint16_t>("foo");
+
+	p.setProp<int>("foo", -128);
+    p.getProp<std::int8_t>("foo");
+
+	p.setProp<int>("foo", -32768);
+    p.getProp<std::int16_t>("foo");
+
+	p.setProp<int>("foo", 127);
+    p.getProp<std::int8_t>("foo");
+
+    p.setProp<int>("foo", 32767);
+    p.getProp<std::int16_t>("foo");
+    
     // Test some overflows
     p.setProp<int>("foo", 32767+1);
     try {
@@ -288,6 +311,7 @@ void testIntConversions() {
         TEST_ASSERT(0);
     } catch (boost::numeric::positive_overflow&) {
     }
+    p.setProp<int>("foo", 65535 + 1);
     try {
         p.getProp<std::uint16_t>("foo"); // should fail
         TEST_ASSERT(0);
@@ -298,7 +322,7 @@ void testIntConversions() {
     try {
         p.getProp<std::uint8_t>("foo"); // should fail
         TEST_ASSERT(0);
-    } catch (boost::numeric::positive_overflow&) {
+    } catch (boost::numeric::negative_overflow&) {
     }
     
     p.getProp<std::int16_t>("foo"); // should pass


### PR DESCRIPTION
#### Fix prop integer conversions to smaller types


#### What does this implement/fix? Explain your changes.
Two issues were found in rdvalue_cast functions:
- casting to uint16_t was actually casting to uint8_t
- casting to uint8_t was casting from the unsigned value of the union, if the value was typed as signed

#### Any other comments?
There was two issues in the tests as well, which is why the above issues were not caught. In addition, conversions of all min/max numeric limits of the smaller types i.e. (u)int8/16 are now explicitly tested.

This cleans up changes made in #4194 
