### PR TITLE
Turn MRV_COORDINATE_BOND_TYPE data Substance Groups into coordinate bonds

### DIFF
--- a/Code/GraphMol/FileParsers/file_parsers_catch.cpp
+++ b/Code/GraphMol/FileParsers/file_parsers_catch.cpp
@@ -3572,3 +3572,58 @@ M  END)CTAB"_ctab;
   REQUIRE(m->getBondBetweenAtoms(1, 2));
   CHECK(m->getBondBetweenAtoms(1, 2)->getBondDir() == Bond::EITHERDOUBLE);
 }
+
+TEST_CASE(
+    "Convert SDF V200 MRV_COORDINATE_BOND_TYPE data Substance Groups "
+    "into coordinate bonds") {
+  auto m = R"CTAB(
+  Mrv2111 06302118332D          
+
+  9  9  0  0  0  0            999 V2000
+   -2.9465    0.7804    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -3.6609    0.3679    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -3.6609   -0.4572    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -2.9465   -0.8697    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -2.2320   -0.4572    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -2.2320    0.3679    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -1.5175    0.7804    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -2.9465   -1.6947    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -4.3754    0.7804    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+  1  2  2  0  0  0  0
+  2  3  1  0  0  0  0
+  3  4  2  0  0  0  0
+  4  5  1  0  0  0  0
+  5  6  2  0  0  0  0
+  6  1  1  0  0  0  0
+  6  7  8  0  0  0  0
+  4  8  8  0  0  0  0
+  2  9  8  0  0  0  0
+M  STY  3   1 DAT   2 DAT   3 DAT
+M  SAL   1  2   6   7
+M  SDT   1 MRV_COORDINATE_BOND_TYPE                              
+M  SDD   1     0.0000    0.0000    DR    ALL  0       0  
+M  SED   1 7
+M  SAL   2  2   4   8
+M  SDT   2 MRV_COORDINATE_BOND_TYPE                              
+M  SDD   2     0.0000    0.0000    DR    ALL  0       0  
+M  SED   2 8
+M  SAL   3  2   2   9
+M  SDT   3 MRV_COORDINATE_BOND_TYPE                              
+M  SDD   3     0.0000    0.0000    DR    ALL  0       0  
+M  SED   3 9
+M  END
+)CTAB"_ctab;
+  REQUIRE(m);
+
+  std::vector<std::pair<unsigned, unsigned>> coordinate_bonds{
+      {5, 6}, {3, 7}, {1, 8}};
+
+  for (const auto &bond_atoms : coordinate_bonds) {
+    auto bnd = m->getBondBetweenAtoms(bond_atoms.first, bond_atoms.second);
+    REQUIRE(bnd);
+    CHECK(bnd->getBondType() == Bond::BondType::DATIVE);
+    CHECK(typeid(*bnd) == typeid(Bond));
+  }
+
+  CHECK(getSubstanceGroups(*m).empty());
+}

--- a/Code/GraphMol/RWMol.cpp
+++ b/Code/GraphMol/RWMol.cpp
@@ -155,7 +155,8 @@ void RWMol::replaceAtom(unsigned int idx, Atom *atom_pin, bool updateLabel,
   }
 };
 
-void RWMol::replaceBond(unsigned int idx, Bond *bond_pin, bool preserveProps) {
+void RWMol::replaceBond(unsigned int idx, Bond *bond_pin, bool preserveProps,
+                        bool keepSGroups) {
   PRECONDITION(bond_pin, "bad bond passed to replaceBond");
   URANGE_CHECK(idx, getNumBonds());
   BOND_ITER_PAIR bIter = getEdges();
@@ -176,7 +177,10 @@ void RWMol::replaceBond(unsigned int idx, Bond *bond_pin, bool preserveProps) {
   const auto orig_p = d_graph[*(bIter.first)];
   delete orig_p;
   d_graph[*(bIter.first)] = bond_p;
-  removeSubstanceGroupsReferencingBond(*this, idx);
+
+  if (!keepSGroups) {
+    removeSubstanceGroupsReferencingBond(*this, idx);
+  }
 
   // handle bookmarks
   for (auto &ab : d_bondBookmarks) {

--- a/Code/GraphMol/RWMol.h
+++ b/Code/GraphMol/RWMol.h
@@ -184,9 +184,11 @@ class RDKIT_GRAPHMOL_EXPORT RWMol : public ROMol {
     \param idx          the index of the Bond to replace
     \param bond         the new bond, which will be copied.
     \param preserveProps if true preserve the original bond property data
+    \param keepSGroups if true, keep Substance groups referencing the bond
 
   */
-  void replaceBond(unsigned int idx, Bond *bond, bool preserveProps = false);
+  void replaceBond(unsigned int idx, Bond *bond, bool preserveProps = false,
+                   bool keepSGroups = false);
 
   //@}
 

--- a/Code/GraphMol/Wrap/Mol.cpp
+++ b/Code/GraphMol/Wrap/Mol.cpp
@@ -871,7 +871,8 @@ struct mol_wrapper {
               python::arg("keepSGroups") = false),
              "replaces the specified bond with the provided one.\n"
              "If preserveProps is True preserve keep the existing props unless "
-             "explicit set on the new bond")
+             "explicit set on the new bond. If keepSGroups is False, all"
+             "Substance Groups referencing the bond will be dropped.")
         .def("GetMol", &ReadWriteMol::GetMol,
              "Returns a Mol (a normal molecule)",
              python::return_value_policy<python::manage_new_object>())

--- a/Code/GraphMol/Wrap/Mol.cpp
+++ b/Code/GraphMol/Wrap/Mol.cpp
@@ -208,9 +208,10 @@ class ReadWriteMol : public RWMol {
     PRECONDITION(atom, "bad atom");
     replaceAtom(idx, atom, updateLabel, preserveProps);
   };
-  void ReplaceBond(unsigned int idx, Bond *bond, bool preserveProps) {
+  void ReplaceBond(unsigned int idx, Bond *bond, bool preserveProps,
+                   bool keepSGroups) {
     PRECONDITION(bond, "bad bond");
-    replaceBond(idx, bond, preserveProps);
+    replaceBond(idx, bond, preserveProps, keepSGroups);
   };
   void SetStereoGroups(python::list &stereo_groups) {
     std::vector<StereoGroup> groups;
@@ -866,7 +867,8 @@ struct mol_wrapper {
              "explicit set on the new atom")
         .def("ReplaceBond", &ReadWriteMol::ReplaceBond,
              (python::arg("index"), python::arg("newBond"),
-              python::arg("preserveProps") = false),
+              python::arg("preserveProps") = false,
+              python::arg("keepSGroups") = false),
              "replaces the specified bond with the provided one.\n"
              "If preserveProps is True preserve keep the existing props unless "
              "explicit set on the new bond")


### PR DESCRIPTION
The MDL v2000 format does not have native support for coordinate bonds, so these are typically encoded as "query" bonds (type "8") and adding a data Substance Group with the field name "MRV_COORDINATE_BOND_TYPE" and the coordinate atom as data.

When RDKit finds one of those, it takes it literally and adds a `QueryBond` and a Substance Group to the mol. This patch fixes this behavior, turning the `QueryBond` into a regular dative `Bond` and dropping the Substance Group.

I think we could remove the call to `removeSubstanceGroupsReferencingBond()` from `replaceBond()` (the bond gets replaced, not removed, and we can always remove the Substance Group manually), but I chose the conservative approach, and made it optional by adding an extra argument to the function.
