### PR TITLE
Fixes github #4311

### DIFF
--- a/Code/GraphMol/Atom.cpp
+++ b/Code/GraphMol/Atom.cpp
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2001-2019 Greg Landrum and Rational Discovery LLC
+//  Copyright (C) 2001-2021 Greg Landrum and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -213,11 +213,10 @@ int Atom::calcExplicitValence(bool strict) {
   // FIX: contributions of bonds to valence are being done at best
   // approximately
   double accum = 0;
-  ROMol::OEDGE_ITER beg, end;
-  boost::tie(beg, end) = getOwningMol().getAtomBonds(this);
-  while (beg != end) {
-    accum += getOwningMol()[*beg]->getValenceContrib(this);
-    ++beg;
+  for (const auto &nbri :
+       boost::make_iterator_range(getOwningMol().getAtomBonds(this))) {
+    const auto bnd = getOwningMol()[nbri];
+    accum += bnd->getValenceContrib(this);
   }
   accum += getNumExplicitHs();
 

--- a/Code/GraphMol/Atom.cpp
+++ b/Code/GraphMol/Atom.cpp
@@ -333,6 +333,14 @@ int Atom::calcImplicitValence(bool strict) {
     d_implicitValence = 0;
     return 0;
   }
+  for (const auto &nbri :
+       boost::make_iterator_range(getOwningMol().getAtomBonds(this))) {
+    const auto bnd = getOwningMol()[nbri];
+    if (QueryOps::hasComplexBondTypeQuery(*bnd)) {
+      d_implicitValence = 0;
+      return 0;
+    }
+  }
   if (d_explicitValence == 0 && d_atomicNum == 1 &&
       d_numRadicalElectrons == 0) {
     if (d_formalCharge == 1 || d_formalCharge == -1) {

--- a/Code/GraphMol/Bond.cpp
+++ b/Code/GraphMol/Bond.cpp
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2001-2017 Greg Landrum and Rational Discovery LLC
+//  Copyright (C) 2001-2021 Greg Landrum and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -124,125 +124,74 @@ Atom *Bond::getOtherAtom(Atom const *what) const {
 };
 
 double Bond::getBondTypeAsDouble() const {
+  double res;
   switch (getBondType()) {
     case UNSPECIFIED:
     case IONIC:
     case ZERO:
-      return 0;
+      res = 0;
       break;
     case SINGLE:
-      return 1;
+      res = 1;
       break;
     case DOUBLE:
-      return 2;
+      res = 2;
       break;
     case TRIPLE:
-      return 3;
+      res = 3;
       break;
     case QUADRUPLE:
-      return 4;
+      res = 4;
       break;
     case QUINTUPLE:
-      return 5;
+      res = 5;
       break;
     case HEXTUPLE:
-      return 6;
+      res = 6;
       break;
     case ONEANDAHALF:
-      return 1.5;
+      res = 1.5;
       break;
     case TWOANDAHALF:
-      return 2.5;
+      res = 2.5;
       break;
     case THREEANDAHALF:
-      return 3.5;
+      res = 3.5;
       break;
     case FOURANDAHALF:
-      return 4.5;
+      res = 4.5;
       break;
     case FIVEANDAHALF:
-      return 5.5;
+      res = 5.5;
       break;
     case AROMATIC:
-      return 1.5;
+      res = 1.5;
       break;
     case DATIVEONE:
-      return 1.0;
+      res = 1.0;
       break;  // FIX: this should probably be different
     case DATIVE:
-      return 1.0;
+      res = 1.0;
       break;  // FIX: again probably wrong
     case HYDROGEN:
-      return 0.0;
+      res = 0.0;
       break;
     default:
       UNDER_CONSTRUCTION("Bad bond type");
   }
+  return res;
 }
 
 double Bond::getValenceContrib(const Atom *atom) const {
-  switch (getBondType()) {
-    case UNSPECIFIED:
-    case IONIC:
-    case ZERO:
-      return 0;
-      break;
-    case SINGLE:
-      return 1;
-      break;
-    case DOUBLE:
-      return 2;
-      break;
-    case TRIPLE:
-      return 3;
-      break;
-    case QUADRUPLE:
-      return 4;
-      break;
-    case QUINTUPLE:
-      return 5;
-      break;
-    case HEXTUPLE:
-      return 6;
-      break;
-    case ONEANDAHALF:
-      return 1.5;
-      break;
-    case TWOANDAHALF:
-      return 2.5;
-      break;
-    case THREEANDAHALF:
-      return 3.5;
-      break;
-    case FOURANDAHALF:
-      return 4.5;
-      break;
-    case FIVEANDAHALF:
-      return 5.5;
-      break;
-    case AROMATIC:
-      return 1.5;
-      break;
-    case DATIVEONE:
-      if (atom->getIdx() == getEndAtomIdx()) {
-        return 1.0;
-      } else {
-        return 0.0;
-      }
-      break;
-    case DATIVE:
-      if (atom->getIdx() == getEndAtomIdx()) {
-        return 1.0;
-      } else {
-        return 0.0;
-      }
-      break;
-    case HYDROGEN:
-      return 0.0;
-      break;
-    default:
-      UNDER_CONSTRUCTION("Bad bond type");
+  double res;
+  if ((getBondType() == DATIVE || getBondType() == DATIVEONE) &&
+      atom->getIdx() != getEndAtomIdx()) {
+    res = 0.0;
+  } else {
+    res = getBondTypeAsDouble();
   }
+
+  return res;
 }
 
 void Bond::setQuery(QUERYBOND_QUERY *what) {
@@ -362,7 +311,6 @@ uint8_t getTwiceBondType(const Bond &b) {
       UNDER_CONSTRUCTION("Bad bond type");
   }
 }
-
 };  // namespace RDKit
 
 std::ostream &operator<<(std::ostream &target, const RDKit::Bond &bond) {

--- a/Code/GraphMol/Bond.h
+++ b/Code/GraphMol/Bond.h
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2001-2017 Greg Landrum and Rational Discovery LLC
+//  Copyright (C) 2001-2021 Greg Landrum and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -129,7 +129,7 @@ class RDKIT_GRAPHMOL_EXPORT Bond : public RDProps {
     <b>Notes:</b>
       - requires an owning molecule
   */
-  double getValenceContrib(const Atom *at) const;
+  virtual double getValenceContrib(const Atom *at) const;
 
   //! sets our \c isAromatic flag
   void setIsAromatic(bool what) { df_isAromatic = what; }

--- a/Code/GraphMol/QueryBond.cpp
+++ b/Code/GraphMol/QueryBond.cpp
@@ -1,6 +1,5 @@
-// $Id$
 //
-//  Copyright (C) 2001-2006 Greg Landrum and Rational Discovery LLC
+//  Copyright (C) 2001-2021 Greg Landrum and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -219,4 +218,10 @@ bool QueryBond::QueryMatch(QueryBond const *what) const {
   }
 }
 
+double QueryBond::getValenceContrib(const Atom *atom) const {
+  if (!hasQuery() || !QueryOps::hasComplexBondTypeQuery(*getQuery())) {
+    return Bond::getValenceContrib(atom);
+  }
+  return 0;
+}
 }  // namespace RDKit

--- a/Code/GraphMol/QueryBond.h
+++ b/Code/GraphMol/QueryBond.h
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2001-2017 Greg Landrum and Rational Discovery LLC
+//  Copyright (C) 2001-2021 Greg Landrum and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -93,6 +93,13 @@ class RDKIT_GRAPHMOL_EXPORT QueryBond : public Bond {
   void expandQuery(QUERYBOND_QUERY *what,
                    Queries::CompositeQueryType how = Queries::COMPOSITE_AND,
                    bool maintainOrder = true) override;
+
+  //! returns our contribution to the explicit valence of an Atom
+  /*!
+    <b>Notes:</b>
+      - requires an owning molecule
+  */
+  double getValenceContrib(const Atom *at) const override;
 
  protected:
   QUERYBOND_QUERY *dp_query{nullptr};

--- a/Code/GraphMol/QueryOps.h
+++ b/Code/GraphMol/QueryOps.h
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2003-2017 Greg Landrum and Rational Discovery LLC
+//  Copyright (C) 2003-2021 Greg Landrum and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -668,6 +668,7 @@ RDKIT_GRAPHMOL_EXPORT BOND_EQUALS_QUERY *makeSingleOrDoubleBondQuery();
 //! returns a Query for tautomeric bonds
 RDKIT_GRAPHMOL_EXPORT BOND_EQUALS_QUERY *
 makeSingleOrDoubleOrAromaticBondQuery();
+
 //! returns a Query for matching bond directions
 RDKIT_GRAPHMOL_EXPORT BOND_EQUALS_QUERY *makeBondDirEqualsQuery(
     Bond::BondDir what);
@@ -1087,6 +1088,23 @@ RDKIT_GRAPHMOL_EXPORT void finalizeQueryFromDescription(
     Queries::Query<int, Atom const *, true> *query, Atom const *owner);
 RDKIT_GRAPHMOL_EXPORT void finalizeQueryFromDescription(
     Queries::Query<int, Bond const *, true> *query, Bond const *owner);
+
+RDKIT_GRAPHMOL_EXPORT bool hasBondTypeQuery(
+    const Queries::Query<int, Bond const *, true> &qry);
+inline bool hasBondTypeQuery(const Bond &bond) {
+  if (!bond.hasQuery()) {
+    return false;
+  }
+  return hasBondTypeQuery(*bond.getQuery());
+}
+RDKIT_GRAPHMOL_EXPORT bool hasComplexBondTypeQuery(
+    const Queries::Query<int, Bond const *, true> &qry);
+inline bool hasComplexBondTypeQuery(const Bond &bond) {
+  if (!bond.hasQuery()) {
+    return false;
+  }
+  return hasComplexBondTypeQuery(*bond.getQuery());
+}
 
 }  // namespace QueryOps
 }  // namespace RDKit

--- a/Code/GraphMol/catch_graphmol.cpp
+++ b/Code/GraphMol/catch_graphmol.cpp
@@ -2092,3 +2092,33 @@ TEST_CASE(
     CHECK(m->getRingInfo()->numRings() == m2.getRingInfo()->numRings());
   }
 }
+
+TEST_CASE("QueryBond valence contribs") {
+  {
+    auto m = "CO"_smarts;
+    REQUIRE(m);
+    CHECK(m->getBondWithIdx(0)->getValenceContrib(m->getAtomWithIdx(0)) == 0.0);
+    CHECK(m->getBondWithIdx(0)->getValenceContrib(m->getAtomWithIdx(1)) == 0.0);
+  }
+  {
+    auto m = "C-O"_smarts;
+    REQUIRE(m);
+    CHECK(m->getBondWithIdx(0)->getValenceContrib(m->getAtomWithIdx(0)) == 1.0);
+    CHECK(m->getBondWithIdx(0)->getValenceContrib(m->getAtomWithIdx(1)) == 1.0);
+  }
+}
+
+TEST_CASE(
+    "github #4311: unreasonable calculation of implicit valence for atoms with "
+    "query bonds",
+    "[graphmol]") {
+  SECTION("basics") {
+    auto m = "C-,=O"_smarts;
+    REQUIRE(m);
+    m->updatePropertyCache();
+    CHECK(m->getAtomWithIdx(0)->getTotalNumHs() == 0);
+    CHECK(m->getAtomWithIdx(1)->getTotalNumHs() == 0);
+    CHECK(MolToSmiles(*m) == "CO");
+    CHECK(MolToSmarts(*m) == "C-,=O");
+  }
+}

--- a/Code/GraphMol/molopstest.cpp
+++ b/Code/GraphMol/molopstest.cpp
@@ -1,5 +1,5 @@
 //
-//   Copyright (C) 2002-2018 Greg Landrum and Rational Discovery LLC
+//   Copyright (C) 2002-2021 Greg Landrum and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -658,7 +658,7 @@ void test8() {
   delete m2;
 
   std::string sma;
-  smi = "CC";
+  smi = "C-C";
   m = SmartsToMol(smi);
   MolOps::sanitizeMol(*((RWMol *)m));
   TEST_ASSERT(m);

--- a/Code/GraphMol/querytest.cpp
+++ b/Code/GraphMol/querytest.cpp
@@ -1,5 +1,5 @@
 //
-//   Copyright (C) 2002-2017 Rational Discovery LLC and Greg Landrum
+//   Copyright (C) 2002-2021 Greg Landrum and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -878,6 +878,41 @@ void testGithub2471() {
   BOOST_LOG(rdErrorLog) << "Done!" << std::endl;
 }
 
+void testHasBondTypeQuery() {
+  BOOST_LOG(rdErrorLog) << "---------------------- Testing hasBondTypeQuery() "
+                           "and hasComplexBondTypeQuery()"
+                        << std::endl;
+
+  {
+    auto m = "C-C-@C@-C@CC-,=C"_smarts;
+    TEST_ASSERT(m);
+    for (const auto bond : m->bonds()) {
+      bool hasQ = QueryOps::hasBondTypeQuery(*bond);
+      if (bond->getIdx() != 3) {
+        TEST_ASSERT(hasQ);
+      } else {
+        TEST_ASSERT(!hasQ);
+      }
+    }
+    for (const auto bond : m->bonds()) {
+      bool hasQ = QueryOps::hasComplexBondTypeQuery(*bond);
+      if (bond->getIdx() < 4) {
+        TEST_ASSERT(!hasQ);
+      } else {
+        TEST_ASSERT(hasQ);
+      }
+    }
+  }
+  {
+    auto m = "CC-C"_smiles;
+    TEST_ASSERT(m);
+    for (const auto bond : m->bonds()) {
+      TEST_ASSERT(!QueryOps::hasBondTypeQuery(*bond));
+    }
+  }
+  BOOST_LOG(rdErrorLog) << "Done!" << std::endl;
+}
+
 int main() {
   RDLog::InitLogs();
 #if 1
@@ -900,5 +935,6 @@ int main() {
   testNumHeteroatomNeighborQueries();
   testAtomTypeQueries();
   testGithub2471();
+  testHasBondTypeQuery();
   return 0;
 }

--- a/Code/GraphMol/querytest.cpp
+++ b/Code/GraphMol/querytest.cpp
@@ -884,7 +884,7 @@ void testHasBondTypeQuery() {
                         << std::endl;
 
   {
-    auto m = "C-C-@C@-C@CC-,=C"_smarts;
+    auto m = "C-C-@C@-C@CC-,=C!-C"_smarts;
     TEST_ASSERT(m);
     for (const auto bond : m->bonds()) {
       bool hasQ = QueryOps::hasBondTypeQuery(*bond);


### PR DESCRIPTION
- adds getValenceContrib() to QueryBond
- adds hasBondTypeQuery() and hasComplexBondTypeQuery() to QueryOps namespace
- atoms with complex bond type queries now have explict and implicit valences of 0
- adds tests for the above
- some duplicated code removal in Bond.cpp
