### PR TITLE
Support using SubstructMatchParameters in RGD

### DIFF
--- a/Code/GraphMol/RGroupDecomposition/RGroupCore.cpp
+++ b/Code/GraphMol/RGroupDecomposition/RGroupCore.cpp
@@ -1,4 +1,13 @@
-
+//
+//  Copyright (c) 2017-2021, Novartis Institutes for BioMedical Research Inc.
+//  and other RDKit contributors
+//
+//   @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
+//
 #include "RGroupCore.h"
 #include <GraphMol/Substruct/SubstructUtils.h>
 
@@ -193,7 +202,8 @@ void RCore::buildMatchingMol() {
 // Given a matching molecule substructure match to a target molecule, return
 // core matches with terminal user R groups matched
 std::vector<MatchVectType> RCore::matchTerminalUserRGroups(
-    const RWMol &target, MatchVectType match) const {
+    const RWMol &target, MatchVectType match,
+    const SubstructMatchParameters &sssParams) const {
   // Transform match indexed by matching molecule atoms to a map
   // indexed by core atoms
   std::transform(match.begin(), match.end(), match.begin(),
@@ -224,9 +234,6 @@ std::vector<MatchVectType> RCore::matchTerminalUserRGroups(
   // target atoms that the R group can map to
   std::vector<std::vector<int>> availableMappingsForDummy;
 
-  SubstructMatchParameters ssParameters;
-  ssParameters.useChirality = true;
-
   // Loop over all the user terminal R groups and see if they can be included
   // in the match and, if so, record the target atoms that the R group can
   // be mapped to.
@@ -246,7 +253,7 @@ std::vector<MatchVectType> RCore::matchTerminalUserRGroups(
       if (mappedTargetIdx.find(*nbrIter) == mappedTargetIdx.end()) {
         const auto targetBond = target.getBondBetweenAtoms(targetIdx, *nbrIter);
         // check for bond compatibility
-        if (bondCompat(coreBond, targetBond, ssParameters)) {
+        if (bondCompat(coreBond, targetBond, sssParams)) {
           available.push_back(*nbrIter);
         }
       }
@@ -285,7 +292,7 @@ std::vector<MatchVectType> RCore::matchTerminalUserRGroups(
     targetIndices[position] = pair.second;
   }
 
-  MolMatchFinalCheckFunctor molMatchFunctor(*core, target, ssParameters);
+  MolMatchFinalCheckFunctor molMatchFunctor(*core, target, sssParams);
   boost::dynamic_bitset<> targetBondsPresent(target.getNumBonds());
 
   // Filter all available mappings removing those that contain duplicates,
@@ -324,8 +331,8 @@ std::vector<MatchVectType> RCore::matchTerminalUserRGroups(
     }
   }
 
-  delete [] queryIndices;
-  delete [] targetIndices;
+  delete[] queryIndices;
+  delete[] targetIndices;
   return allMappings;
 }
 

--- a/Code/GraphMol/RGroupDecomposition/RGroupCore.h
+++ b/Code/GraphMol/RGroupDecomposition/RGroupCore.h
@@ -1,5 +1,6 @@
 //
-//  Copyright (C) 2020 Novartis Institutes for BioMedical Research
+//  Copyright (C) 2020-2021 Novartis Institutes for BioMedical Research and
+//  other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -60,7 +61,8 @@ struct RCore {
   RWMOL_SPTR coreWithMatches(const ROMol &coreReplacedAtoms) const;
 
   std::vector<MatchVectType> matchTerminalUserRGroups(
-      const RWMol &target, MatchVectType match) const;
+      const RWMol &target, MatchVectType match,
+      const SubstructMatchParameters &sssParams) const;
 
   inline bool isTerminalRGroupWithUserLabel(const int idx) const {
     return terminalRGroupAtomsWithUserLabels.find(idx) !=

--- a/Code/GraphMol/RGroupDecomposition/RGroupDecomp.cpp
+++ b/Code/GraphMol/RGroupDecomposition/RGroupDecomp.cpp
@@ -1,4 +1,7 @@
-//  Copyright (c) 2017, Novartis Institutes for BioMedical Research Inc.
+//
+//  Copyright (c) 2017-2021, Novartis Institutes for BioMedical Research Inc.
+//  and other RDKit contributors
+//
 //  All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -95,25 +98,25 @@ int RGroupDecomposition::add(const ROMol &inmol) {
   // or the first core that requires the smallest number
   // of newly added labels
   int global_min_heavy_nbrs = -1;
+  SubstructMatchParameters sssparams(params().substructmatchParams);
+  sssparams.uniquify = false;
+  sssparams.recursionPossible = true;
   for (const auto &core : data->cores) {
     {
-      const bool uniquify = false;
-      const bool recursionPossible = true;
-      const bool useChirality = true;
       // matching the core to the molecule is a two step process
       // First match to a reduced representation (the core minus terminal
       // R-groups). Next, match the R-groups. We do this as the core may not be
       // a substructure match for the molecule if a single molecule atom matches
       // 2 RGroup attachments (see https://github.com/rdkit/rdkit/pull/4002)
-      std::vector<MatchVectType> baseMatches;
-      // match reduced representation
-      SubstructMatch(mol, *core.second.matchingMol, baseMatches, uniquify,
-                     recursionPossible, useChirality);
+
+      // match the reduced represenation:
+      std::vector<MatchVectType> baseMatches =
+          SubstructMatch(mol, *core.second.matchingMol, sssparams);
       tmatches.clear();
       for (const auto &baseMatch : baseMatches) {
         // Match the R Groups
         auto matchesWithDummy =
-            core.second.matchTerminalUserRGroups(mol, baseMatch);
+            core.second.matchTerminalUserRGroups(mol, baseMatch, sssparams);
         tmatches.insert(tmatches.end(), matchesWithDummy.cbegin(),
                         matchesWithDummy.cend());
       }

--- a/Code/GraphMol/RGroupDecomposition/RGroupDecomp.h
+++ b/Code/GraphMol/RGroupDecomposition/RGroupDecomp.h
@@ -1,5 +1,6 @@
 //
-//  Copyright (C) 2017 Novartis Institutes for BioMedical Research
+//  Copyright (c) 2017-2021, Novartis Institutes for BioMedical Research Inc.
+//  and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -114,6 +115,10 @@ struct RDKIT_RGROUPDECOMPOSITION_EXPORT RGroupDecompositionParameters {
   int gaNumberRuns = 1;
   // Sequential or parallel runs?
   bool gaParallelRuns = true;
+  // Controls the way substructure matching with the core is done
+  SubstructMatchParameters substructmatchParams;
+
+  RGroupDecompositionParameters() { substructmatchParams.useChirality = true; }
 
  private:
   int indexOffset{-1};

--- a/Code/GraphMol/RGroupDecomposition/RGroupDecompParams.cpp
+++ b/Code/GraphMol/RGroupDecomposition/RGroupDecompParams.cpp
@@ -1,5 +1,6 @@
 //
-//  Copyright (C) 2017 Novartis Institutes for BioMedical Research
+//  Copyright (c) 2017-2021, Novartis Institutes for BioMedical Research Inc.
+//  and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -135,6 +136,22 @@ bool RGroupDecompositionParameters::prepareCore(RWMol &core,
     }
   } else if (!onlyMatchAtRGroups) {
     autoLabels |= AtomIndexLabels;
+  }
+
+  // if we aren't doing stereochem matches, remove that info from the core
+  if (!substructmatchParams.useChirality) {
+    for (auto atom : core.atoms()) {
+      atom->setChiralTag(Atom::ChiralType::CHI_UNSPECIFIED);
+    }
+    for (auto bond : core.bonds()) {
+      bond->setStereo(Bond::BondStereo::STEREONONE);
+    }
+  }
+  // remove enhanced stereo info if not being used
+  // or if chirality isn't being used
+  if (!substructmatchParams.useChirality ||
+      !substructmatchParams.useEnhancedStereo) {
+    core.setStereoGroups(std::vector<StereoGroup>());
   }
 
   int maxLabel = 1;
@@ -273,7 +290,7 @@ bool RGroupDecompositionParameters::prepareCore(RWMol &core,
   }
 
   return true;
-}
+}  // namespace RDKit
 
 void RGroupDecompositionParameters::checkNonTerminal(const Atom &atom) const {
   if (allowNonTerminalRGroups || atom.getDegree() == 1) {

--- a/Code/GraphMol/RGroupDecomposition/Wrap/rdRGroupComposition.cpp
+++ b/Code/GraphMol/RGroupDecomposition/Wrap/rdRGroupComposition.cpp
@@ -1,4 +1,6 @@
-//  Copyright (c) 2017, Novartis Institutes for BioMedical Research Inc.
+//  Copyright (c) 2017-2021, Novartis Institutes for BioMedical Research Inc.
+//  and other RDKit contributors
+//
 //  All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -312,7 +314,10 @@ struct rgroupdecomp_wrapper {
             &RDKit::RGroupDecompositionParameters::allowNonTerminalRGroups)
         .def_readwrite("removeAllHydrogenRGroupsAndLabels",
                        &RDKit::RGroupDecompositionParameters::
-                           removeAllHydrogenRGroupsAndLabels);
+                           removeAllHydrogenRGroupsAndLabels)
+        .def_readonly(
+            "substructMatchParams",
+            &RDKit::RGroupDecompositionParameters::substructmatchParams);
 
     python::class_<RDKit::RGroupDecompositionHelper, boost::noncopyable>(
         "RGroupDecomposition", docString.c_str(),

--- a/Code/GraphMol/RGroupDecomposition/Wrap/test_rgroups.py
+++ b/Code/GraphMol/RGroupDecomposition/Wrap/test_rgroups.py
@@ -1,4 +1,5 @@
-#  Copyright (c) 2018, Novartis Institutes for BioMedical Research Inc.
+#  Copyright (c) 2018-2021, Novartis Institutes for BioMedical Research Inc.
+#   and other RDKit contributors
 #  All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -36,8 +37,8 @@ import pickle
 
 from rdkit import rdBase
 from rdkit import Chem
-from rdkit.Chem.rdRGroupDecomposition import (RGroupDecompose,
-                                              RGroupDecomposition, RGroupDecompositionParameters, RGroupLabels,
+from rdkit.Chem.rdRGroupDecomposition import (RGroupDecompose, RGroupDecomposition,
+                                              RGroupDecompositionParameters, RGroupLabels,
                                               RGroupCoreAlignment)
 from collections import OrderedDict
 
@@ -49,55 +50,55 @@ RDLogger.DisableLog("rdApp.warning")
 
 class TestCase(unittest.TestCase):
 
-    def test_multicores(self):
-        cores_smi_easy = OrderedDict()
-        cores_smi_hard = OrderedDict()
+  def test_multicores(self):
+    cores_smi_easy = OrderedDict()
+    cores_smi_hard = OrderedDict()
 
-        # cores_smi_easy['cephem'] = Chem.MolFromSmiles('O=C1C([1*])[C@@H]2N1C(C(O)=O)=C([3*])CS2')
-        cores_smi_easy['cephem'] = Chem.MolFromSmarts('O=C1C([*:1])C2N1C(C(O)=O)=C([*:3])CS2')
-        cores_smi_hard['cephem'] = Chem.MolFromSmarts('O=C1C([2*])([1*])[C@@H]2N1C(C(O)=O)=C([3*])CS2')
+    # cores_smi_easy['cephem'] = Chem.MolFromSmiles('O=C1C([1*])[C@@H]2N1C(C(O)=O)=C([3*])CS2')
+    cores_smi_easy['cephem'] = Chem.MolFromSmarts('O=C1C([*:1])C2N1C(C(O)=O)=C([*:3])CS2')
+    cores_smi_hard['cephem'] = Chem.MolFromSmarts('O=C1C([2*])([1*])[C@@H]2N1C(C(O)=O)=C([3*])CS2')
 
-        # cores_smi_easy['carbacephem'] = Chem.MolFromSmiles('O=C1C([1*])[C@@H]2N1C(C(O)=O)=C([3*])CC2')
-        cores_smi_easy['carbacephem'] = Chem.MolFromSmarts('O=C1C([1*])C2N1C(C(O)=O)=C([3*])CC2')
-        cores_smi_hard['carbacephem'] = Chem.MolFromSmarts(
-            'O=C1C([2*])([1*])[C@@H]2N1C(C(O)=O)=C([3*])CC2')
+    # cores_smi_easy['carbacephem'] = Chem.MolFromSmiles('O=C1C([1*])[C@@H]2N1C(C(O)=O)=C([3*])CC2')
+    cores_smi_easy['carbacephem'] = Chem.MolFromSmarts('O=C1C([1*])C2N1C(C(O)=O)=C([3*])CC2')
+    cores_smi_hard['carbacephem'] = Chem.MolFromSmarts(
+      'O=C1C([2*])([1*])[C@@H]2N1C(C(O)=O)=C([3*])CC2')
 
-        # cores_smi_easy['oxacephem'] = Chem.MolFromSmiles('O=C1C([1*])[C@@H]2N1C(C(O)=O)=C([3*])CO2')
-        cores_smi_easy['oxacephem'] = Chem.MolFromSmarts('O=C1C([1*])C2N1C(C(O)=O)=C([3*])CO2')
-        cores_smi_hard['oxacephem'] = Chem.MolFromSmarts(
-            'O=C1C([2*])([1*])[C@@H]2N1C(C(O)=O)=C([3*])CO2')
+    # cores_smi_easy['oxacephem'] = Chem.MolFromSmiles('O=C1C([1*])[C@@H]2N1C(C(O)=O)=C([3*])CO2')
+    cores_smi_easy['oxacephem'] = Chem.MolFromSmarts('O=C1C([1*])C2N1C(C(O)=O)=C([3*])CO2')
+    cores_smi_hard['oxacephem'] = Chem.MolFromSmarts(
+      'O=C1C([2*])([1*])[C@@H]2N1C(C(O)=O)=C([3*])CO2')
 
-        # cores_smi_easy['carbapenem'] = Chem.MolFromSmiles('O=C1C([1*])[C@@H]2N1C(C(O)=O)=C([3*])C2')
-        cores_smi_easy['carbapenem'] = Chem.MolFromSmarts('O=C1C([1*])C2N1C(C(O)=O)=C([3*])C2')
-        cores_smi_hard['carbapenem'] = Chem.MolFromSmarts(
-            'O=C1C([2*])([1*])[C@@H]2N1C(C(O)=O)=C([3*])C2')
+    # cores_smi_easy['carbapenem'] = Chem.MolFromSmiles('O=C1C([1*])[C@@H]2N1C(C(O)=O)=C([3*])C2')
+    cores_smi_easy['carbapenem'] = Chem.MolFromSmarts('O=C1C([1*])C2N1C(C(O)=O)=C([3*])C2')
+    cores_smi_hard['carbapenem'] = Chem.MolFromSmarts(
+      'O=C1C([2*])([1*])[C@@H]2N1C(C(O)=O)=C([3*])C2')
 
-        # cores_smi_easy['carbapenam'] = Chem.MolFromSmiles('O=C1C([1*])[C@@H]2N1C(C(O)=O)C([3*])([4*])C2')
-        cores_smi_easy['carbapenam'] = Chem.MolFromSmarts('O=C1C([1*])C2N1C(C(O)=O)C([3*])([4*])C2')
-        cores_smi_hard['carbapenam'] = Chem.MolFromSmarts(
-            'O=C1C([2*])([1*])[C@@H]2N1C(C(O)=O)C([3*])([4*])C2')
+    # cores_smi_easy['carbapenam'] = Chem.MolFromSmiles('O=C1C([1*])[C@@H]2N1C(C(O)=O)C([3*])([4*])C2')
+    cores_smi_easy['carbapenam'] = Chem.MolFromSmarts('O=C1C([1*])C2N1C(C(O)=O)C([3*])([4*])C2')
+    cores_smi_hard['carbapenam'] = Chem.MolFromSmarts(
+      'O=C1C([2*])([1*])[C@@H]2N1C(C(O)=O)C([3*])([4*])C2')
 
-        # cores_smi_easy['penem'] = Chem.MolFromSmiles('O=C1C([1*])[C@@H]2N1C(C(O)=O)=C([3*])S2')
-        cores_smi_easy['penem'] = Chem.MolFromSmarts('O=C1C([1*])C2N1C(C(O)=O)=C([3*])S2')
-        cores_smi_hard['penem'] = Chem.MolFromSmarts('O=C1C([2*])([1*])[C@@H]2N1C(C(O)=O)=C([3*])S2')
+    # cores_smi_easy['penem'] = Chem.MolFromSmiles('O=C1C([1*])[C@@H]2N1C(C(O)=O)=C([3*])S2')
+    cores_smi_easy['penem'] = Chem.MolFromSmarts('O=C1C([1*])C2N1C(C(O)=O)=C([3*])S2')
+    cores_smi_hard['penem'] = Chem.MolFromSmarts('O=C1C([2*])([1*])[C@@H]2N1C(C(O)=O)=C([3*])S2')
 
-        # cores_smi_easy['penam'] = Chem.MolFromSmiles('O=C1C([1*])[C@@H]2N1C(C(O)=O)C([3*])([4*])S2')
-        cores_smi_easy['penam'] = Chem.MolFromSmarts('O=C1C([*:1])C2N1C(C(O)=O)C([*:3])([*:4])S2')
-        cores_smi_hard['penam'] = Chem.MolFromSmarts(
-            'O=C1C([*:2])([*:1])[C@@H]2N1C(C(O)=O)C([*:3])([*:4])S2')
+    # cores_smi_easy['penam'] = Chem.MolFromSmiles('O=C1C([1*])[C@@H]2N1C(C(O)=O)C([3*])([4*])S2')
+    cores_smi_easy['penam'] = Chem.MolFromSmarts('O=C1C([*:1])C2N1C(C(O)=O)C([*:3])([*:4])S2')
+    cores_smi_hard['penam'] = Chem.MolFromSmarts(
+      'O=C1C([*:2])([*:1])[C@@H]2N1C(C(O)=O)C([*:3])([*:4])S2')
 
-        # cores_smi_easy['oxapenam'] = Chem.MolFromSmiles('O=C1C([1*])[C@@H]2N1C(C(O)=O)C([3*])([4*])O2')
-        cores_smi_easy['oxapenam'] = Chem.MolFromSmarts('O=C1C([1*])C2N1C(C(O)=O)C([3*])([4*])O2')
-        cores_smi_hard['oxapenam'] = Chem.MolFromSmarts(
-            'O=C1C([2*])([1*])[C@@H]2N1C(C(O)=O)C([3*])([4*])O2')
+    # cores_smi_easy['oxapenam'] = Chem.MolFromSmiles('O=C1C([1*])[C@@H]2N1C(C(O)=O)C([3*])([4*])O2')
+    cores_smi_easy['oxapenam'] = Chem.MolFromSmarts('O=C1C([1*])C2N1C(C(O)=O)C([3*])([4*])O2')
+    cores_smi_hard['oxapenam'] = Chem.MolFromSmarts(
+      'O=C1C([2*])([1*])[C@@H]2N1C(C(O)=O)C([3*])([4*])O2')
 
-        cores_smi_easy['monobactam'] = Chem.MolFromSmarts('O=C1C([1*])C([5*])N1')
-        cores_smi_hard['monobactam'] = Chem.MolFromSmarts('O=C1C([2*])([1*])C([6*])([5*])N1')
-        rg_easy = RGroupDecomposition(cores_smi_easy.values())
-        rg_stereo = RGroupDecomposition(cores_smi_hard.values())
+    cores_smi_easy['monobactam'] = Chem.MolFromSmarts('O=C1C([1*])C([5*])N1')
+    cores_smi_hard['monobactam'] = Chem.MolFromSmarts('O=C1C([2*])([1*])C([6*])([5*])N1')
+    rg_easy = RGroupDecomposition(cores_smi_easy.values())
+    rg_stereo = RGroupDecomposition(cores_smi_hard.values())
 
-    def test_stereo(self):
-        smiles = """C1CCO[C@@H](N)1
+  def test_stereo(self):
+    smiles = """C1CCO[C@@H](N)1
 C1CCO[C@H](N)1
 C1CCO[C@@](N)(O)1
 C1CCO[C@@](N)(P)1
@@ -118,175 +119,175 @@ C1CCO[C@@](S)(N)1
 C1CCO[C@@](S)(O)1
 C1CCO[C@@](S)(P)1
 """
-        mols = []
-        for smi in smiles.split():
-            m = Chem.MolFromSmiles(smi)
-            assert m, smi
-            mols.append(m)
-        core = Chem.MolFromSmarts("C1CCOC1")
-        rgroups = RGroupDecomposition(core)
-        for m in mols:
-            rgroups.Add(m)
-        rgroups.Process()
-        columns = rgroups.GetRGroupsAsColumns()
-        data = {}
-        for k, v in columns.items():
-            data[k] = [Chem.MolToSmiles(m, True) for m in v]
+    mols = []
+    for smi in smiles.split():
+      m = Chem.MolFromSmiles(smi)
+      assert m, smi
+      mols.append(m)
+    core = Chem.MolFromSmarts("C1CCOC1")
+    rgroups = RGroupDecomposition(core)
+    for m in mols:
+      rgroups.Add(m)
+    rgroups.Process()
+    columns = rgroups.GetRGroupsAsColumns()
+    data = {}
+    for k, v in columns.items():
+      data[k] = [Chem.MolToSmiles(m, True) for m in v]
 
-        rgroups2, unmatched = RGroupDecompose([core], mols)
-        columns2, unmatched = RGroupDecompose([core], mols, asRows=False)
-        data2 = {}
-        for k, v in columns2.items():
-            data2[k] = [Chem.MolToSmiles(m, True) for m in v]
+    rgroups2, unmatched = RGroupDecompose([core], mols)
+    columns2, unmatched = RGroupDecompose([core], mols, asRows=False)
+    data2 = {}
+    for k, v in columns2.items():
+      data2[k] = [Chem.MolToSmiles(m, True) for m in v]
 
-        self.assertEqual(data, data2)
-        columns3, unmatched = RGroupDecompose([core], mols, asRows=False, asSmiles=True)
-        self.assertEqual(data, columns3)
+    self.assertEqual(data, data2)
+    columns3, unmatched = RGroupDecompose([core], mols, asRows=False, asSmiles=True)
+    self.assertEqual(data, columns3)
 
-    def test_h_options(self):
-        core = Chem.MolFromSmiles("O=c1oc2ccccc2cc1")
-        smiles = ("O=c1cc(Cn2ccnc2)c2ccc(Oc3ccccc3)cc2o1", "O=c1oc2ccccc2c(Cn2ccnc2)c1-c1ccccc1",
-                  "COc1ccc2c(Cn3cncn3)cc(=O)oc2c1")
-        params = RGroupDecompositionParameters()
-        rgd = RGroupDecomposition(core, params)
-        for smi in smiles:
-            m = Chem.MolFromSmiles(smi)
-            rgd.Add(m)
-        rgd.Process()
-        columns = rgd.GetRGroupsAsColumns()
-        self.assertEqual(columns['R2'][0].GetNumAtoms(), 7)
+  def test_h_options(self):
+    core = Chem.MolFromSmiles("O=c1oc2ccccc2cc1")
+    smiles = ("O=c1cc(Cn2ccnc2)c2ccc(Oc3ccccc3)cc2o1", "O=c1oc2ccccc2c(Cn2ccnc2)c1-c1ccccc1",
+              "COc1ccc2c(Cn3cncn3)cc(=O)oc2c1")
+    params = RGroupDecompositionParameters()
+    rgd = RGroupDecomposition(core, params)
+    for smi in smiles:
+      m = Chem.MolFromSmiles(smi)
+      rgd.Add(m)
+    rgd.Process()
+    columns = rgd.GetRGroupsAsColumns()
+    self.assertEqual(columns['R2'][0].GetNumAtoms(), 7)
 
-        params.removeHydrogensPostMatch = False
-        rgd = RGroupDecomposition(core, params)
-        for smi in smiles:
-            m = Chem.MolFromSmiles(smi)
-            rgd.Add(m)
-        rgd.Process()
-        columns = rgd.GetRGroupsAsColumns()
-        self.assertEqual(columns['R2'][0].GetNumAtoms(), 12)
+    params.removeHydrogensPostMatch = False
+    rgd = RGroupDecomposition(core, params)
+    for smi in smiles:
+      m = Chem.MolFromSmiles(smi)
+      rgd.Add(m)
+    rgd.Process()
+    columns = rgd.GetRGroupsAsColumns()
+    self.assertEqual(columns['R2'][0].GetNumAtoms(), 12)
 
-    def test_unmatched(self):
-        cores = [Chem.MolFromSmiles("N")]
-        mols = [
-            Chem.MolFromSmiles("CC"),
-            Chem.MolFromSmiles("CC"),
-            Chem.MolFromSmiles("CC"),
-            Chem.MolFromSmiles("N"),
-            Chem.MolFromSmiles("CC")
-        ]
+  def test_unmatched(self):
+    cores = [Chem.MolFromSmiles("N")]
+    mols = [
+      Chem.MolFromSmiles("CC"),
+      Chem.MolFromSmiles("CC"),
+      Chem.MolFromSmiles("CC"),
+      Chem.MolFromSmiles("N"),
+      Chem.MolFromSmiles("CC")
+    ]
 
-        res, unmatched = RGroupDecompose(cores, mols)
-        self.assertEqual(len(res), 1)
-        self.assertEqual(unmatched, [0, 1, 2, 4])
+    res, unmatched = RGroupDecompose(cores, mols)
+    self.assertEqual(len(res), 1)
+    self.assertEqual(unmatched, [0, 1, 2, 4])
 
-    def test_userlabels(self):
-        smis = ["C(Cl)N(N)O(O)"]
-        mols = [Chem.MolFromSmiles(smi) for smi in smis]
-        smarts = 'C([*:1])N([*:5])O([*:6])'
-        core = Chem.MolFromSmarts(smarts)
-        rg = RGroupDecomposition(core)
-        for m in mols:
-            rg.Add(m)
-        rg.Process()
-        self.assertEqual(rg.GetRGroupsAsColumns(asSmiles=True), {
-            'Core': ['C(N(O[*:6])[*:5])[*:1]'],
-            'R1': ['Cl[*:1]'],
-            'R5': ['N[*:5]'],
-            'R6': ['O[*:6]']
-        })
+  def test_userlabels(self):
+    smis = ["C(Cl)N(N)O(O)"]
+    mols = [Chem.MolFromSmiles(smi) for smi in smis]
+    smarts = 'C([*:1])N([*:5])O([*:6])'
+    core = Chem.MolFromSmarts(smarts)
+    rg = RGroupDecomposition(core)
+    for m in mols:
+      rg.Add(m)
+    rg.Process()
+    self.assertEqual(rg.GetRGroupsAsColumns(asSmiles=True), {
+      'Core': ['C(N(O[*:6])[*:5])[*:1]'],
+      'R1': ['Cl[*:1]'],
+      'R5': ['N[*:5]'],
+      'R6': ['O[*:6]']
+    })
 
-        smarts = 'C([*:4])N([*:5])O([*:6])'
+    smarts = 'C([*:4])N([*:5])O([*:6])'
 
-        core = Chem.MolFromSmarts(smarts)
-        rg = RGroupDecomposition(core)
-        for m in mols:
-            rg.Add(m)
-        rg.Process()
-        self.assertEqual(rg.GetRGroupsAsColumns(asSmiles=True), {
-            'Core': ['C(N(O[*:6])[*:5])[*:4]'],
-            'R4': ['Cl[*:4]'],
-            'R5': ['N[*:5]'],
-            'R6': ['O[*:6]']
-        })
+    core = Chem.MolFromSmarts(smarts)
+    rg = RGroupDecomposition(core)
+    for m in mols:
+      rg.Add(m)
+    rg.Process()
+    self.assertEqual(rg.GetRGroupsAsColumns(asSmiles=True), {
+      'Core': ['C(N(O[*:6])[*:5])[*:4]'],
+      'R4': ['Cl[*:4]'],
+      'R5': ['N[*:5]'],
+      'R6': ['O[*:6]']
+    })
 
-    def test_match_only_at_rgroups(self):
-        smiles = ['c1ccccc1']  # , 'c1(Cl)ccccc1', 'c1(Cl)cc(Br)ccc1']
-        mols = [Chem.MolFromSmiles(smi) for smi in smiles]
+  def test_match_only_at_rgroups(self):
+    smiles = ['c1ccccc1']  # , 'c1(Cl)ccccc1', 'c1(Cl)cc(Br)ccc1']
+    mols = [Chem.MolFromSmiles(smi) for smi in smiles]
 
-        core1 = Chem.MolFromSmiles("c1([*:5])cc([*:6])ccc1")
-        params = RGroupDecompositionParameters()
-        params.onlyMatchAtRGroups = True
-        rg = RGroupDecomposition(core1, params)
-        for smi, m in zip(smiles, mols):
-            self.assertTrue(rg.Add(m) != -1, smi)
+    core1 = Chem.MolFromSmiles("c1([*:5])cc([*:6])ccc1")
+    params = RGroupDecompositionParameters()
+    params.onlyMatchAtRGroups = True
+    rg = RGroupDecomposition(core1, params)
+    for smi, m in zip(smiles, mols):
+      self.assertTrue(rg.Add(m) != -1, smi)
 
-    def test_incorrect_multiple_rlabels(self):
-        mols = [Chem.MolFromSmiles(smi) for smi in (
-            "C1NC(Cl)CC1",
-            "C1OC(Cl)CC1",
-            "C1(Cl)OCCC1",
-        )]
+  def test_incorrect_multiple_rlabels(self):
+    mols = [Chem.MolFromSmiles(smi) for smi in (
+      "C1NC(Cl)CC1",
+      "C1OC(Cl)CC1",
+      "C1(Cl)OCCC1",
+    )]
 
-        scaffolds = [Chem.MolFromSmarts(x) for x in ("C1NCCC1",)]
-        groups, unmatched = RGroupDecompose(scaffolds, mols, asSmiles=True, asRows=False)
+    scaffolds = [Chem.MolFromSmarts(x) for x in ("C1NCCC1", )]
+    groups, unmatched = RGroupDecompose(scaffolds, mols, asSmiles=True, asRows=False)
 
-        self.assertEqual(groups, {'Core': ['C1CNC([*:1])C1'], 'R1': ['Cl[*:1]']})
+    self.assertEqual(groups, {'Core': ['C1CNC([*:1])C1'], 'R1': ['Cl[*:1]']})
 
-        scaffolds = [Chem.MolFromSmarts(x) for x in ("C1OCCC1",)]
-        groups, unmatched = RGroupDecompose(scaffolds, mols, asSmiles=True, asRows=False)
-        self.assertEqual(groups, {
-            'Core': ['C1COC([*:1])C1', 'C1COC([*:1])C1'],
-            'R1': ['Cl[*:1]', 'Cl[*:1]']
-        })
-        scaffolds = [Chem.MolFromSmarts(x) for x in ("C1NCCC1", "C1OCCC1")]
-        groups, unmatched = RGroupDecompose(scaffolds, mols, asSmiles=True, asRows=False)
-        self.assertEqual(
-            groups, {
-                'Core': ['C1CNC([*:1])C1', 'C1COC([*:1])C1', 'C1COC([*:1])C1'],
-                'R1': ['Cl[*:1]', 'Cl[*:1]', 'Cl[*:1]']
-            })
+    scaffolds = [Chem.MolFromSmarts(x) for x in ("C1OCCC1", )]
+    groups, unmatched = RGroupDecompose(scaffolds, mols, asSmiles=True, asRows=False)
+    self.assertEqual(groups, {
+      'Core': ['C1COC([*:1])C1', 'C1COC([*:1])C1'],
+      'R1': ['Cl[*:1]', 'Cl[*:1]']
+    })
+    scaffolds = [Chem.MolFromSmarts(x) for x in ("C1NCCC1", "C1OCCC1")]
+    groups, unmatched = RGroupDecompose(scaffolds, mols, asSmiles=True, asRows=False)
+    self.assertEqual(
+      groups, {
+        'Core': ['C1CNC([*:1])C1', 'C1COC([*:1])C1', 'C1COC([*:1])C1'],
+        'R1': ['Cl[*:1]', 'Cl[*:1]', 'Cl[*:1]']
+      })
 
-    def test_aligned_cores(self):
-        scaffolds = [Chem.MolFromSmarts(x) for x in ("C1NC1OC", "C1NC1NC")]
-        mols = [Chem.MolFromSmiles(smi) for smi in ("C1NC1OCCC", "C1NC1NCCC")]
-        groups, unmatched = RGroupDecompose(scaffolds, mols, asSmiles=True, asRows=True)
-        # print("test_aligned_Cores")
-        # print("groups:", groups)
-        self.assertEqual(groups, [{
-            'Core': 'C1NC1OC[*:1]',
-            'R1': 'CC[*:1]'
-        }, {
-            'Core': 'C1NC1NC[*:2]',
-            'R2': 'CC[*:2]'
-        }])
+  def test_aligned_cores(self):
+    scaffolds = [Chem.MolFromSmarts(x) for x in ("C1NC1OC", "C1NC1NC")]
+    mols = [Chem.MolFromSmiles(smi) for smi in ("C1NC1OCCC", "C1NC1NCCC")]
+    groups, unmatched = RGroupDecompose(scaffolds, mols, asSmiles=True, asRows=True)
+    # print("test_aligned_Cores")
+    # print("groups:", groups)
+    self.assertEqual(groups, [{
+      'Core': 'C1NC1OC[*:1]',
+      'R1': 'CC[*:1]'
+    }, {
+      'Core': 'C1NC1NC[*:2]',
+      'R2': 'CC[*:2]'
+    }])
 
-    def test_aligned_cores2(self):
-        scaffolds = [Chem.MolFromSmarts(x) for x in ("C1NCC1", "C1SCC1")]
-        mols = [Chem.MolFromSmiles(smi) for smi in ("C1N(P)CC1", "C1S(P)CC1")]
-        # print("test_aligned_Cores2")
-        groups, unmatched = RGroupDecompose(scaffolds, mols, asSmiles=True, asRows=True)
-        # print("groups: ", groups)
-        self.assertEqual(groups, [{
-            'Core': 'C1CN([*:1])C1',
-            'R1': 'P[*:1]'
-        }, {
-            'Core': 'C1C[SH]([*:2])C1',
-            'R2': 'P[*:2]'
-        }])
+  def test_aligned_cores2(self):
+    scaffolds = [Chem.MolFromSmarts(x) for x in ("C1NCC1", "C1SCC1")]
+    mols = [Chem.MolFromSmiles(smi) for smi in ("C1N(P)CC1", "C1S(P)CC1")]
+    # print("test_aligned_Cores2")
+    groups, unmatched = RGroupDecompose(scaffolds, mols, asSmiles=True, asRows=True)
+    # print("groups: ", groups)
+    self.assertEqual(groups, [{
+      'Core': 'C1CN([*:1])C1',
+      'R1': 'P[*:1]'
+    }, {
+      'Core': 'C1C[SH]([*:2])C1',
+      'R2': 'P[*:2]'
+    }])
 
-    def test_getrgrouplabels(self):
-        smis = ["C(Cl)N(N)O(O)"]
-        mols = [Chem.MolFromSmiles(smi) for smi in smis]
-        smarts = 'C([*:1])N([*:5])O([*:6])'
-        core = Chem.MolFromSmarts(smarts)
-        rg = RGroupDecomposition(core)
-        for m in mols:
-            rg.Add(m)
-        rg.Process()
-        self.assertEqual(set(rg.GetRGroupLabels()), set(rg.GetRGroupsAsColumns()))
+  def test_getrgrouplabels(self):
+    smis = ["C(Cl)N(N)O(O)"]
+    mols = [Chem.MolFromSmiles(smi) for smi in smis]
+    smarts = 'C([*:1])N([*:5])O([*:6])'
+    core = Chem.MolFromSmarts(smarts)
+    rg = RGroupDecomposition(core)
+    for m in mols:
+      rg.Add(m)
+    rg.Process()
+    self.assertEqual(set(rg.GetRGroupLabels()), set(rg.GetRGroupsAsColumns()))
 
-    def test_timeout(self):
-        smis = '''CN(C)Cc1cccc(Oc2cc(N3CCN(Cc4ccccc4-c4ccc(Cl)cc4)CC3)ccc2C(=O)NS(=O)(=O)c2ccc(NCC3CCOCC3)c([N+](=O)[O-])c2)c1
+  def test_timeout(self):
+    smis = '''CN(C)Cc1cccc(Oc2cc(N3CCN(Cc4ccccc4-c4ccc(Cl)cc4)CC3)ccc2C(=O)NS(=O)(=O)c2ccc(NCC3CCOCC3)c([N+](=O)[O-])c2)c1
 CNc1cccc(Oc2cc(N3CCN(Cc4ccccc4-c4ccc(Cl)cc4)CC3)ccc2C(=O)NS(=O)(=O)c2ccc(NCC3CCOCC3)c([N+](=O)[O-])c2)c1
 Cc1cc2cc(Oc3cc(N4CCN(CC5=C(c6ccc(Cl)cc6)CC(C)(C)CC5)CC4)ccc3C(=O)NS(=O)(=O)c3ccc(NC4CCN(C)CC4)c([N+](=O)[O-])c3)ccc2[nH]1
 Cc1cc2cc(Oc3cc(N4CCN(CC5=C(c6ccc(Cl)cc6)CC(C)(C)CC5)CC4)ccc3C(=O)NS(=O)(=O)c3ccc(NCCCN4CCOCC4)c([N+](=O)[O-])c3)ccc2[nH]1
@@ -386,43 +387,46 @@ O=C(NS(=O)(=O)c1ccc(NCCCN2CCOCC2)c([N+](=O)[O-])c1)c1ccc(N2CCN(Cc3ccccc3-c3ccc(C
 O=C(NS(=O)(=O)c1ccc(NCCCN2CCOCC2)c([N+](=O)[O-])c1)c1ccc(N2CCN(Cc3ccccc3-c3ccc(Cl)cc3)CC2)cc1Oc1ccc(-c2cccnc2)cc1
 CN(C)C(=O)COc1ccc(Oc2cc(N3CCN(Cc4ccccc4-c4ccc(Cl)cc4)CC3)ccc2C(=O)NS(=O)(=O)c2ccc(NCC3CCOCC3)c([N+](=O)[O-])c2)cc1
 Cn1cnc2cc(Oc3cc(N4CCN(Cc5ccccc5-c5ccc(Cl)cc5)CC4)ccc3C(=O)NS(=O)(=O)c3ccc(NCCCN4CCOCC4)c([N+](=O)[O-])c3)ccc21'''
-        mols = [Chem.MolFromSmiles(x) for x in smis.split('\n')]
+    mols = [Chem.MolFromSmiles(x) for x in smis.split('\n')]
 
-        core = Chem.MolFromSmarts('O=C(NS(=O)(=O)c1ccccc1)c1ccccc1Oc1ccccc1')
-        ps = RGroupDecompositionParameters()
-        ps.timeout = 1.0
-        with self.assertRaises(RuntimeError):
-            rg = RGroupDecomposition(core, ps)
-            for m in mols:
-                rg.Add(m)
+    core = Chem.MolFromSmarts('O=C(NS(=O)(=O)c1ccccc1)c1ccccc1Oc1ccccc1')
+    ps = RGroupDecompositionParameters()
+    ps.timeout = 1.0
+    with self.assertRaises(RuntimeError):
+      rg = RGroupDecomposition(core, ps)
+      for m in mols:
+        rg.Add(m)
 
-        with self.assertRaises(RuntimeError):
-            columns2, unmatched = RGroupDecompose([core], mols, asRows=False, options=ps)
+    with self.assertRaises(RuntimeError):
+      columns2, unmatched = RGroupDecompose([core], mols, asRows=False, options=ps)
 
-    def test_github3402(self):
-        core1 = "[$(C-!@[a])](=O)(Cl)"
-        sma = Chem.MolFromSmarts(core1)
-        m = Chem.MolFromSmiles("c1ccccc1C(=O)Cl")
-        self.assertEqual(RGroupDecompose(sma, [m], asSmiles=True),
-                         ([{'Core': 'O=C(Cl)[*:1]', 'R1': 'c1ccc([*:1])cc1'}], []))
+  def test_github3402(self):
+    core1 = "[$(C-!@[a])](=O)(Cl)"
+    sma = Chem.MolFromSmarts(core1)
+    m = Chem.MolFromSmiles("c1ccccc1C(=O)Cl")
+    self.assertEqual(RGroupDecompose(sma, [m], asSmiles=True), ([{
+      'Core': 'O=C(Cl)[*:1]',
+      'R1': 'c1ccc([*:1])cc1'
+    }], []))
 
-    def test_multicore_prelabelled(self):
-        def multicorergd_test(cores, params, expected_rows, expected_items):
-            mols = [Chem.MolFromSmiles(smi) for smi in ("CNC(=O)C1=CN=CN1CC", "Fc1ccc2ccc(Br)nc2n1")]
-            params.removeHydrogensPostMatch = True
-            params.onlyMatchAtRGroups = True
-            decomp = RGroupDecomposition(cores, params)
-            i = 0
-            for i, m in enumerate(mols):
-                res = decomp.Add(m)
-                self.assertEqual(res, i)
-            self.assertTrue(decomp.Process())
-            rows = decomp.GetRGroupsAsRows(asSmiles=True)
-            self.assertEqual(rows, expected_rows)
-            items = decomp.GetRGroupsAsColumns(asSmiles=True)
-            self.assertEqual(items, expected_items)
+  def test_multicore_prelabelled(self):
 
-        sdcores = """
+    def multicorergd_test(cores, params, expected_rows, expected_items):
+      mols = [Chem.MolFromSmiles(smi) for smi in ("CNC(=O)C1=CN=CN1CC", "Fc1ccc2ccc(Br)nc2n1")]
+      params.removeHydrogensPostMatch = True
+      params.onlyMatchAtRGroups = True
+      decomp = RGroupDecomposition(cores, params)
+      i = 0
+      for i, m in enumerate(mols):
+        res = decomp.Add(m)
+        self.assertEqual(res, i)
+      self.assertTrue(decomp.Process())
+      rows = decomp.GetRGroupsAsRows(asSmiles=True)
+      self.assertEqual(rows, expected_rows)
+      items = decomp.GetRGroupsAsColumns(asSmiles=True)
+      self.assertEqual(items, expected_items)
+
+    sdcores = """
      RDKit          2D
 
   9  9  0  0  0  0  0  0  0  0999 V2000
@@ -484,149 +488,171 @@ V   12 *
 M  END
 $$$$
 """
-        sdsup = Chem.SDMolSupplier()
-        sdsup.SetData(sdcores)
-        cores = [c for c in sdsup]
+    sdsup = Chem.SDMolSupplier()
+    sdsup.SetData(sdcores)
+    cores = [c for c in sdsup]
 
-        expected_rows = [
-            {'Core': 'O=C(c1cncn1[*:2])[*:1]', 'R1': 'CN[*:1]', 'R2': 'CC[*:2]'},
-            {'Core': 'c1cc2ccc([*:2])nc2nc1[*:1]', 'R1': 'F[*:1]', 'R2': 'Br[*:2]'}
-        ]
+    expected_rows = [{
+      'Core': 'O=C(c1cncn1[*:2])[*:1]',
+      'R1': 'CN[*:1]',
+      'R2': 'CC[*:2]'
+    }, {
+      'Core': 'c1cc2ccc([*:2])nc2nc1[*:1]',
+      'R1': 'F[*:1]',
+      'R2': 'Br[*:2]'
+    }]
 
-        expected_items = {
-            'Core': ['O=C(c1cncn1[*:2])[*:1]', 'c1cc2ccc([*:2])nc2nc1[*:1]'],
-            'R1': ['CN[*:1]', 'F[*:1]'],
-            'R2': ['CC[*:2]', 'Br[*:2]']
-        }
+    expected_items = {
+      'Core': ['O=C(c1cncn1[*:2])[*:1]', 'c1cc2ccc([*:2])nc2nc1[*:1]'],
+      'R1': ['CN[*:1]', 'F[*:1]'],
+      'R2': ['CC[*:2]', 'Br[*:2]']
+    }
 
-        params = RGroupDecompositionParameters()
+    params = RGroupDecompositionParameters()
 
-        # test pre-labelled with MDL R-group labels, autodetect
-        params.labels = RGroupLabels.AutoDetect
-        params.alignment = RGroupCoreAlignment.MCS
-        multicorergd_test(cores, params, expected_rows,
-                          expected_items)
-        # test pre-labelled with MDL R-group labels, no autodetect
-        params.labels = RGroupLabels.MDLRGroupLabels | RGroupLabels.RelabelDuplicateLabels
-        params.alignment = RGroupCoreAlignment.MCS
-        multicorergd_test(cores, params, expected_rows,
-                          expected_items)
-        # test pre-labelled with MDL R-group labels, autodetect, no MCS alignment
-        params.labels = RGroupLabels.AutoDetect
-        params.alignment = RGroupCoreAlignment.NoAlignment
-        multicorergd_test(cores, params, expected_rows,
-                          expected_items)
+    # test pre-labelled with MDL R-group labels, autodetect
+    params.labels = RGroupLabels.AutoDetect
+    params.alignment = RGroupCoreAlignment.MCS
+    multicorergd_test(cores, params, expected_rows, expected_items)
+    # test pre-labelled with MDL R-group labels, no autodetect
+    params.labels = RGroupLabels.MDLRGroupLabels | RGroupLabels.RelabelDuplicateLabels
+    params.alignment = RGroupCoreAlignment.MCS
+    multicorergd_test(cores, params, expected_rows, expected_items)
+    # test pre-labelled with MDL R-group labels, autodetect, no MCS alignment
+    params.labels = RGroupLabels.AutoDetect
+    params.alignment = RGroupCoreAlignment.NoAlignment
+    multicorergd_test(cores, params, expected_rows, expected_items)
 
-        # Reading from a MDL molblock also sets isotopic labels, so no need
-        # to set them again; we only clear MDL R-group labels
-        for core in cores:
-            for a in core.GetAtoms():
-                if a.HasProp("_MolFileRLabel"):
-                    a.ClearProp("_MolFileRLabel")
-        # test pre-labelled with isotopic labels, autodetect
-        params.labels = RGroupLabels.AutoDetect
-        params.alignment = RGroupCoreAlignment.MCS
-        multicorergd_test(cores, params, expected_rows,
-                          expected_items)
-        # test pre-labelled with isotopic labels, no autodetect
-        params.labels = RGroupLabels.IsotopeLabels | RGroupLabels.RelabelDuplicateLabels
-        params.alignment = RGroupCoreAlignment.MCS
-        multicorergd_test(cores, params, expected_rows,
-                          expected_items)
-        # test pre-labelled with isotopic labels, autodetect, no MCS alignment
-        params.labels = RGroupLabels.AutoDetect
-        params.alignment = RGroupCoreAlignment.NoAlignment
-        multicorergd_test(cores, params, expected_rows,
-                          expected_items)
+    # Reading from a MDL molblock also sets isotopic labels, so no need
+    # to set them again; we only clear MDL R-group labels
+    for core in cores:
+      for a in core.GetAtoms():
+        if a.HasProp("_MolFileRLabel"):
+          a.ClearProp("_MolFileRLabel")
+    # test pre-labelled with isotopic labels, autodetect
+    params.labels = RGroupLabels.AutoDetect
+    params.alignment = RGroupCoreAlignment.MCS
+    multicorergd_test(cores, params, expected_rows, expected_items)
+    # test pre-labelled with isotopic labels, no autodetect
+    params.labels = RGroupLabels.IsotopeLabels | RGroupLabels.RelabelDuplicateLabels
+    params.alignment = RGroupCoreAlignment.MCS
+    multicorergd_test(cores, params, expected_rows, expected_items)
+    # test pre-labelled with isotopic labels, autodetect, no MCS alignment
+    params.labels = RGroupLabels.AutoDetect
+    params.alignment = RGroupCoreAlignment.NoAlignment
+    multicorergd_test(cores, params, expected_rows, expected_items)
 
-        for core in cores:
-            for a in core.GetAtoms():
-                iso = a.GetIsotope()
-                if iso:
-                    a.SetAtomMapNum(iso)
-                    a.SetIsotope(0)
-        # test pre-labelled with atom map labels, autodetect
-        params.labels = RGroupLabels.AutoDetect
-        params.alignment = RGroupCoreAlignment.MCS
-        multicorergd_test(cores, params, expected_rows,
-                          expected_items)
-        # test pre-labelled with atom map labels, no autodetect
-        params.labels = RGroupLabels.AtomMapLabels | RGroupLabels.RelabelDuplicateLabels
-        params.alignment = RGroupCoreAlignment.MCS
-        multicorergd_test(cores, params, expected_rows,
-                          expected_items)
-        # test pre-labelled with atom map labels, autodetect, no MCS alignment
-        params.labels = RGroupLabels.AutoDetect
-        params.alignment = RGroupCoreAlignment.NoAlignment
-        multicorergd_test(cores, params, expected_rows,
-                          expected_items)
+    for core in cores:
+      for a in core.GetAtoms():
+        iso = a.GetIsotope()
+        if iso:
+          a.SetAtomMapNum(iso)
+          a.SetIsotope(0)
+    # test pre-labelled with atom map labels, autodetect
+    params.labels = RGroupLabels.AutoDetect
+    params.alignment = RGroupCoreAlignment.MCS
+    multicorergd_test(cores, params, expected_rows, expected_items)
+    # test pre-labelled with atom map labels, no autodetect
+    params.labels = RGroupLabels.AtomMapLabels | RGroupLabels.RelabelDuplicateLabels
+    params.alignment = RGroupCoreAlignment.MCS
+    multicorergd_test(cores, params, expected_rows, expected_items)
+    # test pre-labelled with atom map labels, autodetect, no MCS alignment
+    params.labels = RGroupLabels.AutoDetect
+    params.alignment = RGroupCoreAlignment.NoAlignment
+    multicorergd_test(cores, params, expected_rows, expected_items)
 
-        for core in cores:
-            for a in core.GetAtoms():
-                if a.GetAtomMapNum():
-                    a.SetAtomMapNum(0)
-        # test pre-labelled with dummy atom labels, autodetect
+    for core in cores:
+      for a in core.GetAtoms():
+        if a.GetAtomMapNum():
+          a.SetAtomMapNum(0)
+    # test pre-labelled with dummy atom labels, autodetect
 
-        expected_rows = [{'Core': 'O=C(c1cncn1[*:2])[*:1]', 'R1': 'CN[*:1]', 'R2': 'CC[*:2]'},
-                         {'Core': 'c1cc2ccc([*:2])nc2nc1[*:1]', 'R1': 'Br[*:1]', 'R2': 'F[*:2]'}]
+    expected_rows = [{
+      'Core': 'O=C(c1cncn1[*:2])[*:1]',
+      'R1': 'CN[*:1]',
+      'R2': 'CC[*:2]'
+    }, {
+      'Core': 'c1cc2ccc([*:2])nc2nc1[*:1]',
+      'R1': 'Br[*:1]',
+      'R2': 'F[*:2]'
+    }]
 
-        expected_items = {'Core': ['O=C(c1cncn1[*:2])[*:1]', 'c1cc2ccc([*:2])nc2nc1[*:1]'],
-                          'R1': ['CN[*:1]', 'Br[*:1]'],
-                          'R2': ['CC[*:2]', 'F[*:2]']}
+    expected_items = {
+      'Core': ['O=C(c1cncn1[*:2])[*:1]', 'c1cc2ccc([*:2])nc2nc1[*:1]'],
+      'R1': ['CN[*:1]', 'Br[*:1]'],
+      'R2': ['CC[*:2]', 'F[*:2]']
+    }
 
-        params.labels = RGroupLabels.AutoDetect
-        params.alignment = RGroupCoreAlignment.MCS
-        multicorergd_test(cores, params, expected_rows,
-                          expected_items)
-        # test pre-labelled with dummy atom labels, no autodetect
-        # in this case there is no difference from autodetect as the RGD code
-        # cannot tell the difference between query atoms and dummy R-groups
-        params.labels = RGroupLabels.DummyAtomLabels | RGroupLabels.RelabelDuplicateLabels
-        params.alignment = RGroupCoreAlignment.MCS
-        multicorergd_test(cores, params, expected_rows,
-                          expected_items)
+    params.labels = RGroupLabels.AutoDetect
+    params.alignment = RGroupCoreAlignment.MCS
+    multicorergd_test(cores, params, expected_rows, expected_items)
+    # test pre-labelled with dummy atom labels, no autodetect
+    # in this case there is no difference from autodetect as the RGD code
+    # cannot tell the difference between query atoms and dummy R-groups
+    params.labels = RGroupLabels.DummyAtomLabels | RGroupLabels.RelabelDuplicateLabels
+    params.alignment = RGroupCoreAlignment.MCS
+    multicorergd_test(cores, params, expected_rows, expected_items)
 
-    def testRemoveAllHydrogenFlags(self):
-        core = Chem.MolFromSmiles("[1*]c1ccc([2*])cn1")
-        mol = Chem.MolFromSmiles("Fc1ccccn1")
+  def testRemoveAllHydrogenFlags(self):
+    core = Chem.MolFromSmiles("[1*]c1ccc([2*])cn1")
+    mol = Chem.MolFromSmiles("Fc1ccccn1")
 
-        params = RGroupDecompositionParameters()
-        rgd = RGroupDecomposition(core, params)
-        self.assertEqual(rgd.Add(mol), 0)
-        self.assertTrue(rgd.Process())
-        res = rgd.GetRGroupsAsColumns(asSmiles=True)
-        self.assertEqual(res, {'Core': ['c1ccc([*:1])nc1'], 'R1': ['F[*:1]']})
+    params = RGroupDecompositionParameters()
+    rgd = RGroupDecomposition(core, params)
+    self.assertEqual(rgd.Add(mol), 0)
+    self.assertTrue(rgd.Process())
+    res = rgd.GetRGroupsAsColumns(asSmiles=True)
+    self.assertEqual(res, {'Core': ['c1ccc([*:1])nc1'], 'R1': ['F[*:1]']})
 
-        # no change, as removeAllHydrogenRGroupsAndLabels is True
-        params = RGroupDecompositionParameters()
-        params.removeAllHydrogenRGroups = False
-        rgd = RGroupDecomposition(core, params)
-        self.assertEqual(rgd.Add(mol), 0)
-        self.assertTrue(rgd.Process())
-        res = rgd.GetRGroupsAsColumns(asSmiles=True)
-        self.assertEqual(res, {'Core': ['c1ccc([*:1])nc1'], 'R1': ['F[*:1]']})
+    # no change, as removeAllHydrogenRGroupsAndLabels is True
+    params = RGroupDecompositionParameters()
+    params.removeAllHydrogenRGroups = False
+    rgd = RGroupDecomposition(core, params)
+    self.assertEqual(rgd.Add(mol), 0)
+    self.assertTrue(rgd.Process())
+    res = rgd.GetRGroupsAsColumns(asSmiles=True)
+    self.assertEqual(res, {'Core': ['c1ccc([*:1])nc1'], 'R1': ['F[*:1]']})
 
-        # Unused user-defined labels retained on core
-        # R groups still retained as removeAllHydrogenRGroups is True
-        params = RGroupDecompositionParameters()
-        params.removeAllHydrogenRGroupsAndLabels = False
-        rgd = RGroupDecomposition(core, params)
-        self.assertEqual(rgd.Add(mol), 0)
-        self.assertTrue(rgd.Process())
-        res = rgd.GetRGroupsAsColumns(asSmiles=True)
-        self.assertEqual(res, {'Core': ['c1cc([*:1])ncc1[*:2]'], 'R1': ['F[*:1]']})
+    # Unused user-defined labels retained on core
+    # R groups still retained as removeAllHydrogenRGroups is True
+    params = RGroupDecompositionParameters()
+    params.removeAllHydrogenRGroupsAndLabels = False
+    rgd = RGroupDecomposition(core, params)
+    self.assertEqual(rgd.Add(mol), 0)
+    self.assertTrue(rgd.Process())
+    res = rgd.GetRGroupsAsColumns(asSmiles=True)
+    self.assertEqual(res, {'Core': ['c1cc([*:1])ncc1[*:2]'], 'R1': ['F[*:1]']})
 
-        # Unused user-defined labels retained on core and in R groups
-        params = RGroupDecompositionParameters()
-        params.removeAllHydrogenRGroups = False
-        params.removeAllHydrogenRGroupsAndLabels = False
-        rgd = RGroupDecomposition(core, params)
-        self.assertEqual(rgd.Add(mol), 0)
-        self.assertTrue(rgd.Process())
-        res = rgd.GetRGroupsAsColumns(asSmiles=True)
-        self.assertEqual(res, {'Core': ['c1cc([*:1])ncc1[*:2]'], 'R1': ['F[*:1]'], 'R2': ['[H][*:2]']})
+    # Unused user-defined labels retained on core and in R groups
+    params = RGroupDecompositionParameters()
+    params.removeAllHydrogenRGroups = False
+    params.removeAllHydrogenRGroupsAndLabels = False
+    rgd = RGroupDecomposition(core, params)
+    self.assertEqual(rgd.Add(mol), 0)
+    self.assertTrue(rgd.Process())
+    res = rgd.GetRGroupsAsColumns(asSmiles=True)
+    self.assertEqual(res, {'Core': ['c1cc([*:1])ncc1[*:2]'], 'R1': ['F[*:1]'], 'R2': ['[H][*:2]']})
+
+  def testSubstructMatchParameters(self):
+    mols = [
+      Chem.MolFromSmiles(x) for x in ("C1CN[C@H]1F", "C1CN[C@]1(O)F", "C1CN[C@@H]1F", "C1CN[CH]1F")
+    ]
+    cores = [Chem.MolFromSmiles('C1CNC1[*:1]')]
+    chiral_cores = [Chem.MolFromSmiles('C1CN[C@H]1[*:1]')]
+
+    rgroups, unmatched = RGroupDecompose(cores, mols)
+    self.assertEqual(unmatched, [])
+    rgroups, unmatched = RGroupDecompose(chiral_cores, mols)
+    self.assertEqual(unmatched, [3])
+
+    params = RGroupDecompositionParameters()
+    params.substructMatchParams.useChirality = False
+    rgroups, unmatched = RGroupDecompose(cores, mols, options=params)
+    self.assertEqual(unmatched, [])
+    rgroups, unmatched = RGroupDecompose(chiral_cores, mols, options=params)
+    self.assertEqual(unmatched, [])
 
 
 if __name__ == '__main__':
-    rdBase.DisableLog("rdApp.debug")
-    unittest.main()
+  rdBase.DisableLog("rdApp.debug")
+  unittest.main()

--- a/Code/GraphMol/RGroupDecomposition/catch_rgd.cpp
+++ b/Code/GraphMol/RGroupDecomposition/catch_rgd.cpp
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2021 Greg Landrum
+//  Copyright (C) 2021 Greg Landrum and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -282,5 +282,154 @@ TEST_CASE("jm200186n Snippet") {
     CHECK(flatten_whitespace(toJSON(rows)) ==
           flatten_whitespace(
               readReferenceData(testDataDir + "jm200186n.excerpt.out1.json")));
+  }
+}
+
+std::vector<ROMOL_SPTR> smisToMols(const std::vector<std::string> &smis) {
+  std::vector<ROMOL_SPTR> mols;
+  for (const auto &smi : smis) {
+    auto m = SmilesToMol(smi);
+    assert(m);
+    mols.emplace_back(m);
+  }
+  return mols;
+}
+
+TEST_CASE("substructure parameters and RGD: chirality") {
+  std::vector<std::string> smis = {"C1CN[C@H]1F", "C1CN[C@]1(O)F",
+                                   "C1CN[C@@H]1F", "C1CN[CH]1F"};
+  auto mols = smisToMols(smis);
+  std::vector<std::string> csmis = {"C1CNC1[*:1]"};
+  auto cores = smisToMols(csmis);
+  std::vector<std::string> csmis2 = {"C1CN[C@H]1[*:1]"};
+  auto chiral_cores = smisToMols(csmis2);
+  SECTION("defaults") {
+    RGroupRows rows;
+    std::vector<unsigned> unmatched;
+    RGroupDecompositionParameters params;
+    {
+      auto n = RGroupDecompose(cores, mols, rows, &unmatched, params);
+      CHECK(n == mols.size());
+      CHECK(rows.size() == n);
+      CHECK(unmatched.empty());
+      CHECK(flatten_whitespace(toJSON(rows)) == flatten_whitespace(R"JSON(
+[
+  {
+    "Core":"C1CC([*:1])([*:2])N1",
+    "R1":"F[*:1]",
+    "R2":"[H][*:2]"
+  },
+  {
+    "Core":"C1CC([*:1])([*:2])N1",
+    "R1":"F[*:1]",
+    "R2":"O[*:2]"
+  },
+  {
+    "Core":"C1CC([*:1])([*:2])N1",
+    "R1":"F[*:1]",
+    "R2":"[H][*:2]"
+  },
+  {
+    "Core":"C1CC([*:1])([*:2])N1",
+    "R1":"F[*:1]",
+    "R2":"[H][*:2]"
+  }
+]
+    )JSON"));
+    }
+    {
+      auto n = RGroupDecompose(chiral_cores, mols, rows, &unmatched, params);
+      CHECK(n == mols.size() - 1);
+      CHECK(rows.size() == n);
+      CHECK(unmatched.size() == 1);
+      CHECK(flatten_whitespace(toJSON(rows)) == flatten_whitespace(R"JSON(
+[
+  {
+    "Core":"C1C[C@@]([*:1])([*:2])N1",
+    "R1":"F[*:1]",
+    "R2":"[H][*:2]"
+  },
+  {
+    "Core":"C1C[C@@]([*:1])([*:2])N1",
+    "R1":"O[*:1]",
+    "R2":"F[*:2]"
+  },
+  {
+    "Core":"C1C[C@@]([*:1])([*:2])N1",
+    "R1":"[H][*:1]",
+    "R2":"F[*:2]"
+  }
+]
+    )JSON"));
+    }
+  }
+
+  SECTION("not using chirality") {
+    // this time both cores return the same thing and stereo information is
+    // removed from the chiral cores
+    RGroupRows rows;
+    std::vector<unsigned> unmatched;
+    RGroupDecompositionParameters params;
+    params.substructmatchParams.useChirality = false;
+    {
+      auto n = RGroupDecompose(cores, mols, rows, &unmatched, params);
+      CHECK(n == mols.size());
+      CHECK(rows.size() == n);
+      CHECK(unmatched.empty());
+      CHECK(flatten_whitespace(toJSON(rows)) == flatten_whitespace(R"JSON(
+[
+  {
+    "Core":"C1CC([*:1])([*:2])N1",
+    "R1":"F[*:1]",
+    "R2":"[H][*:2]"
+  },
+  {
+    "Core":"C1CC([*:1])([*:2])N1",
+    "R1":"F[*:1]",
+    "R2":"O[*:2]"
+  },
+  {
+    "Core":"C1CC([*:1])([*:2])N1",
+    "R1":"F[*:1]",
+    "R2":"[H][*:2]"
+  },
+  {
+    "Core":"C1CC([*:1])([*:2])N1",
+    "R1":"F[*:1]",
+    "R2":"[H][*:2]"
+  }
+]
+    )JSON"));
+    }
+    {
+      auto n = RGroupDecompose(chiral_cores, mols, rows, &unmatched, params);
+      CHECK(n == mols.size());
+      CHECK(rows.size() == n);
+      CHECK(unmatched.empty());
+      CHECK(flatten_whitespace(toJSON(rows)) == flatten_whitespace(R"JSON(
+[
+  {
+    "Core":"C1CC([*:1])([*:2])N1",
+    "R1":"F[*:1]",
+    "R2":"[H][*:2]"
+  },
+  {
+    "Core":"C1CC([*:1])([*:2])N1",
+    "R1":"F[*:1]",
+    "R2":"O[*:2]"
+  },
+  {
+    "Core":"C1CC([*:1])([*:2])N1",
+    "R1":"F[*:1]",
+    "R2":"[H][*:2]"
+  },
+  {
+    "Core":"C1CC([*:1])([*:2])N1",
+    "R1":"F[*:1]",
+    "R2":"[H][*:2]"
+  }
+]
+    )JSON"));
+    }
   }
 }

--- a/Code/GraphMol/RGroupDecomposition/catch_rgd.cpp
+++ b/Code/GraphMol/RGroupDecomposition/catch_rgd.cpp
@@ -433,3 +433,155 @@ TEST_CASE("substructure parameters and RGD: chirality") {
     }
   }
 }
+
+TEST_CASE("substructure parameters and RGD: enhanced stereo") {
+  std::vector<std::string> smis = {"F[C@H]1CCN1 |&1:1|", "C1CN[C@]1(O)F |&1:3|",
+                                   "C1CN[C@@H]1F |&1:3|", "Cl[C@H]1CCN1 |o1:1|",
+                                   "C1CN[CH]1F"};
+  auto mols = smisToMols(smis);
+  std::vector<std::string> csmis = {"C1CN[C@H]1[*:1] |&1:3|"};
+  auto cores = smisToMols(csmis);
+  std::vector<std::string> csmis2 = {"C1CN[C@H]1[*:1] |o1:3|"};
+  auto cores2 = smisToMols(csmis2);
+  SECTION("defaults: no enhanced stereo") {
+    RGroupRows rows;
+    std::vector<unsigned> unmatched;
+    RGroupDecompositionParameters params;
+    {
+      auto n = RGroupDecompose(cores, mols, rows, &unmatched, params);
+      CHECK(n == mols.size() - 1);
+      CHECK(rows.size() == n);
+      CHECK(unmatched.size() == mols.size() - n);
+      std::cerr << toJSON(rows) << std::endl;
+
+      // the core output here is SMARTS because the CXSMILES parser replaces the
+      // dummy atom with a query
+      CHECK(flatten_whitespace(toJSON(rows)) == flatten_whitespace(R"JSON(
+[
+  {
+    "Core":"[#6]1-[#6]-[#7]-[#6@]-1(-[!#1:1])-[#0:2]",
+    "R1":"F[*:1]",
+    "R2":"[H][*:2]"
+  },
+  {
+    "Core":"[#6]1-[#6]-[#7]-[#6@]-1(-[!#1:1])-[#0:2]",
+    "R1":"O[*:1]",
+    "R2":"F[*:2]"
+  },
+  {
+    "Core":"[#6]1-[#6]-[#7]-[#6@]-1(-[!#1:1])-[#0:2]",
+    "R1":"[H][*:1]",
+    "R2":"F[*:2]"
+  },
+  {
+    "Core":"[#6]1-[#6]-[#7]-[#6@]-1(-[!#1:1])-[#0:2]",
+    "R1":"Cl[*:1]",
+    "R2":"[H][*:2]"
+  }
+]
+    )JSON"));
+    }
+    {
+      auto n = RGroupDecompose(cores2, mols, rows, &unmatched, params);
+      CHECK(n == mols.size() - 1);
+      CHECK(rows.size() == n);
+      CHECK(unmatched.size() == 1);
+      std::cerr << toJSON(rows) << std::endl;
+
+      // the core output here is SMARTS because the CXSMILES parser replaces the
+      // dummy atom with a query
+      CHECK(flatten_whitespace(toJSON(rows)) == flatten_whitespace(R"JSON(
+[
+  {
+    "Core":"[#6]1-[#6]-[#7]-[#6@]-1(-[!#1:1])-[#0:2]",
+    "R1":"F[*:1]",
+    "R2":"[H][*:2]"
+  },
+  {
+    "Core":"[#6]1-[#6]-[#7]-[#6@]-1(-[!#1:1])-[#0:2]",
+    "R1":"O[*:1]",
+    "R2":"F[*:2]"
+  },
+  {
+    "Core":"[#6]1-[#6]-[#7]-[#6@]-1(-[!#1:1])-[#0:2]",
+    "R1":"[H][*:1]",
+    "R2":"F[*:2]"
+  },
+  {
+    "Core":"[#6]1-[#6]-[#7]-[#6@]-1(-[!#1:1])-[#0:2]",
+    "R1":"Cl[*:1]",
+    "R2":"[H][*:2]"
+  }
+]
+    )JSON"));
+    }
+  }
+
+  SECTION("using enhanced stereo") {
+    RGroupRows rows;
+    std::vector<unsigned> unmatched;
+    RGroupDecompositionParameters params;
+    params.substructmatchParams.useEnhancedStereo = true;
+    {
+      auto n = RGroupDecompose(cores, mols, rows, &unmatched, params);
+      CHECK(n == mols.size() - 2);
+      CHECK(rows.size() == n);
+      CHECK(unmatched.size() == mols.size() - n);
+      std::cerr << toJSON(rows) << std::endl;
+      // the core output here is SMARTS because the CXSMILES parser replaces the
+      // dummy atom with a query
+      CHECK(flatten_whitespace(toJSON(rows)) == flatten_whitespace(R"JSON(
+[
+  {
+    "Core":"[#6]1-[#6]-[#7]-[#6@]-1(-[!#1:1])-[#0:2]",
+    "R1":"F[*:1]",
+    "R2":"[H][*:2]"
+  },
+  {
+    "Core":"[#6]1-[#6]-[#7]-[#6@]-1(-[!#1:1])-[#0:2]",
+    "R1":"F[*:1]",
+    "R2":"O[*:2]"
+  },
+  {
+    "Core":"[#6]1-[#6]-[#7]-[#6@]-1(-[!#1:1])-[#0:2]",
+    "R1":"F[*:1]",
+    "R2":"[H][*:2]"
+  }
+]
+    )JSON"));
+    }
+    {
+      auto n = RGroupDecompose(cores2, mols, rows, &unmatched, params);
+      CHECK(n == mols.size() - 1);
+      CHECK(rows.size() == n);
+      CHECK(unmatched.size() == 1);
+      std::cerr << toJSON(rows) << std::endl;
+      // the core output here is SMARTS because the CXSMILES parser replaces the
+      // dummy atom with a query
+      CHECK(flatten_whitespace(toJSON(rows)) == flatten_whitespace(R"JSON(
+[
+  {
+    "Core":"[#6]1-[#6]-[#7]-[#6@]-1(-[!#1:1])-[#0:2]",
+    "R1":"F[*:1]",
+    "R2":"[H][*:2]"
+  },
+  {
+    "Core":"[#6]1-[#6]-[#7]-[#6@]-1(-[!#1:1])-[#0:2]",
+    "R1":"F[*:1]",
+    "R2":"O[*:2]"
+  },
+  {
+    "Core":"[#6]1-[#6]-[#7]-[#6@]-1(-[!#1:1])-[#0:2]",
+    "R1":"F[*:1]",
+    "R2":"[H][*:2]"
+  },
+  {
+    "Core":"[#6]1-[#6]-[#7]-[#6@]-1(-[!#1:1])-[#0:2]",
+    "R1":"Cl[*:1]",
+    "R2":"[H][*:2]"
+  }
+]
+    )JSON"));
+    }
+  }
+}


### PR DESCRIPTION
Since the RGD code uses substructure matching to do most of its work, it makes sense to allow some control over how that matching is done. This PR adds an additional `SubstructMatchParameters` member to `RGroupDecompositionParameters`.

I still need to add the code to expose this to Python and a few tests for that, so I'm going to mark this as a draft until I've added that.