### PR TITLE
FindMCS takes a long time when CompleteRingsOnly is set to True

### DIFF
--- a/Code/GraphMol/FMCS/MaximumCommonSubgraph.h
+++ b/Code/GraphMol/FMCS/MaximumCommonSubgraph.h
@@ -86,6 +86,8 @@ class RDKIT_FMCS_EXPORT MaximumCommonSubgraph {
   unsigned getMaxNumberAtoms() const { return McsIdx.AtomsIdx.size(); }
   // internal:
   bool checkIfMatchAndAppend(Seed& seed);
+  bool checkIfAtomsShareRing(const ROMol& qmol, unsigned int srcAtomIdx, const std::vector<unsigned int>& neighborsInSeed) const;
+  bool canCompleteRings(const Seed& s);
 
  private:
   void clear() {

--- a/Code/GraphMol/FMCS/Wrap/testFMCS.py
+++ b/Code/GraphMol/FMCS/Wrap/testFMCS.py
@@ -1158,5 +1158,23 @@ class TestCase(unittest.TestCase):
         self.assertEqual(res.numBonds, 5)
         self.assertEqual(res.smartsString, "[#6&R]1-&@[#6&R]-&@[#6&R]-&@[#6&R]-&@[#6&R]-&@1")
 
+    def testGithub3965(self):
+        ref = Chem.MolFromSmiles(
+            'CC(C)CNC(=O)[C@H](C(C)C)C[C@H](O)[C@@H](NC1=O)COCc(ccc2)cc2[C@@H](c3ccccc3)NC(=O)c(cc14)cc(c4)N(C)S(=O)(=O)C'
+        )
+        lig = Chem.MolFromSmiles(
+            'CC(C)CNC(=O)[C@H](C(C)C)C[C@H](O)[C@@H](NC(=O)c(cc12)nc(c1)N(C)S(=O)(=O)C)COCc3cc(ccc3)[C@H](NC2=O)c4ccccc4'
+        )
+
+        params = rdFMCS.MCSParameters()
+        params.BondCompareParameters.CompleteRingsOnly = True
+        params.Timeout = 5
+        result = rdFMCS.FindMCS([ref, lig], params)
+        self.assertEqual(result.canceled, False)
+        self.assertEqual(
+            result.smartsString,
+            "[#6]-&!@[#6](-&!@[#6])-&!@[#6]-&!@[#7]-&!@[#6](=&!@[#8])-&!@[#6](-&!@[#6](-&!@[#6])-&!@[#6])-&!@[#6]-&!@[#6](-&!@[#8])-&!@[#6]1-&@[#7]-&@[#6](=&!@[#8])-&@[#6]:&@[#6]:&@[#6]-&@[#6](-&@[#7]-&@[#6](-&@[#6]2:&@[#6]:&@[#6](-&@[#6]-&@[#8]-&@[#6]-&@1):&@[#6]:&@[#6]:&@[#6]:&@2)-&!@[#6]1:&@[#6]:&@[#6]:&@[#6]:&@[#6]:&@[#6]:&@1)=&!@[#8]"
+        )
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
#### Reference Issue
Partially addresses #3965.  It seems like the MCS algorithm is stuck in a long (possibly infinite?) loop in certain queries where `BondCompareParameters.CompleteRingsOnly` is set to `True`. Interestingly, the algorithm does find the correct answer to the problem addressed in that issue after ~7s, but never completes the search. When `BondCompareParameters.CompleteRingsOnly` is set to `False`, the optimal solution is found in <1s.

#### What does this implement/fix? Explain your changes.
I think part of the problem is that the algorithm isn’t terminating the ‘growing’ process of seeds that cannot become an MCS due to incomplete rings in `MaximumCommonSubgraph::growSeeds`.  These changes are my attempt to address this issue by only growing seeds that could potentially close incomplete rings. After this commit, the optimal MCS for the example given in #3965 is found in ~.9s. However, this causes quite a few other tests to fail so I think I am either missing something or this is not a good approach.

#### Any other comments?
I'm curious if anyone who is more familiar with this code has any alternate suggestions on how to approach this problem.