### PR TITLE
Expose atomColourPalette as JSON drawOption

### DIFF
--- a/Code/GraphMol/MolDraw2D/MolDraw2DUtils.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DUtils.cpp
@@ -104,6 +104,20 @@ void updateDrawerParamsFromJSON(MolDraw2D &drawer, const char *json) {
 };
 #define PT_OPT_GET(opt) opts.opt = pt.get(#opt, opts.opt)
 
+void get_rgba(const boost::property_tree::ptree &node, DrawColour &colour) {
+  boost::property_tree::ptree::const_iterator itm = node.begin();
+  colour.r = itm->second.get_value<float>();
+  ++itm;
+  colour.g = itm->second.get_value<float>();
+  ++itm;
+  colour.b = itm->second.get_value<float>();
+  ++itm;
+  if (itm != node.end()) {
+    colour.a = itm->second.get_value<float>();
+    ++itm;
+  }
+}
+
 void get_colour_option(boost::property_tree::ptree *pt, const char *pnm,
                        DrawColour &colour) {
   PRECONDITION(pnm && strlen(pnm), "bad property name");
@@ -111,16 +125,22 @@ void get_colour_option(boost::property_tree::ptree *pt, const char *pnm,
     return;
   }
 
-  boost::property_tree::ptree::const_iterator itm = pt->get_child(pnm).begin();
-  colour.r = itm->second.get_value<float>();
-  ++itm;
-  colour.g = itm->second.get_value<float>();
-  ++itm;
-  colour.b = itm->second.get_value<float>();
-  ++itm;
-  if (itm != pt->get_child(pnm).end()) {
-    colour.a = itm->second.get_value<float>();
-    ++itm;
+  const auto &node = pt->get_child(pnm);
+  get_rgba(node, colour);
+}
+
+void get_colour_palette_option(boost::property_tree::ptree *pt, const char *pnm,
+                               ColourPalette &palette) {
+  PRECONDITION(pnm && strlen(pnm), "bad property name");
+  if (pt->find(pnm) == pt->not_found()) {
+    return;
+  }
+
+  for (const auto &atomicNumNodeIt : pt->get_child(pnm)) {
+    int atomicNum = boost::lexical_cast<int>(atomicNumNodeIt.first);
+    DrawColour colour;
+    get_rgba(atomicNumNodeIt.second, colour);
+    palette[atomicNum] = colour;
   }
 }
 
@@ -184,6 +204,8 @@ void updateDrawerParamsFromJSON(MolDraw2D &drawer, const std::string &json) {
   get_colour_option(&pt, "annotationColour", opts.annotationColour);
   get_colour_option(&pt, "variableAttachmentColour",
                     opts.variableAttachmentColour);
+  get_colour_palette_option(&pt, "atomColourPalette",
+                    opts.atomColourPalette);
   if (pt.find("atomLabels") != pt.not_found()) {
     for (const auto &item : pt.get_child("atomLabels")) {
       opts.atomLabels[boost::lexical_cast<int>(item.first)] =

--- a/Code/GraphMol/MolDraw2D/MolDraw2DUtils.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DUtils.cpp
@@ -204,8 +204,7 @@ void updateDrawerParamsFromJSON(MolDraw2D &drawer, const std::string &json) {
   get_colour_option(&pt, "annotationColour", opts.annotationColour);
   get_colour_option(&pt, "variableAttachmentColour",
                     opts.variableAttachmentColour);
-  get_colour_palette_option(&pt, "atomColourPalette",
-                    opts.atomColourPalette);
+  get_colour_palette_option(&pt, "atomColourPalette", opts.atomColourPalette);
   if (pt.find("atomLabels") != pt.not_found()) {
     for (const auto &item : pt.get_child("atomLabels")) {
       opts.atomLabels[boost::lexical_cast<int>(item.first)] =

--- a/Code/GraphMol/MolDraw2D/test1.cpp
+++ b/Code/GraphMol/MolDraw2D/test1.cpp
@@ -147,6 +147,7 @@ static const std::map<std::string, std::hash_result_t> SVG_HASHES = {
     {"test21_2.svg", 2346906091U},
     {"test22_1.svg", 3352529761U},
     {"test22_2.svg", 3623180832U},
+    {"test23_1.svg", 1474697688U},
     {"testGithub3112_1.svg", 4164182512U},
     {"testGithub3112_2.svg", 1727510065U},
     {"testGithub3112_3.svg", 1355264573U},
@@ -264,6 +265,7 @@ static const std::map<std::string, std::hash_result_t> SVG_HASHES = {
     {"test20_4.svg", 1948583366U},
     {"test22_1.svg", 3352529761U},
     {"test22_2.svg", 2183584384U},
+    {"test23_1.svg", 1655940990U},
     {"testGithub3112_1.svg", 2694789798U},
     {"testGithub3112_2.svg", 1912964589U},
     {"testGithub3112_3.svg", 1042493059U},
@@ -347,7 +349,7 @@ std::hash_result_t hash_file(const std::string &filename) {
 
 void check_file_hash(const std::string &filename,
                      std::hash_result_t exp_hash=0U) {
-//    std::cout << filename << " : " << hash_file(filename) << "U" << std::endl;
+    std::cout << filename << " : " << hash_file(filename) << "U" << std::endl;
 
   std::map<std::string, std::hash_result_t>::const_iterator it;
   if (filename.substr(filename.length() - 4) == ".svg") {
@@ -4170,6 +4172,36 @@ void testGithub4156() {
   std::cerr << " Done" << std::endl;
 }
 
+void test23JSONAtomColourPalette() {
+  std::cerr << " ----------------- Test JSON atomColourPalette" << std::endl;
+  {
+    auto m = "c1cncs1"_smiles;
+    TEST_ASSERT(m);
+    MolDraw2DUtils::prepareMolForDrawing(*m);
+    MolDraw2DSVG drawer(250, 200);
+    const char *json =
+        "{\"atomColourPalette\": {\"7\": [0.2, 0.4, 0.9], \"16\": [0.9, 0.6, 0.0]}, "
+        "\"rotate\": 90, "
+        "\"bondLineWidth\": 5}";
+    MolDraw2DUtils::updateDrawerParamsFromJSON(drawer, json);
+    drawer.drawMolecule(*m);
+    drawer.finishDrawing();
+    std::string text = drawer.getDrawingText();
+    std::ofstream outs("test23_1.svg");
+    outs << text;
+    outs.close();
+    check_file_hash("test23_1.svg");
+#ifdef RDK_BUILD_FREETYPE_SUPPORT
+    TEST_ASSERT(text.find("' fill='#3366E5") != std::string::npos);
+    TEST_ASSERT(text.find("' fill='#E59900") != std::string::npos);
+#else
+    TEST_ASSERT(text.find("fill:#3366E5") != std::string::npos);
+    TEST_ASSERT(text.find("fill:#E59900") != std::string::npos);
+#endif
+  }
+  std::cerr << " Done" << std::endl;
+}
+
 int main() {
 #ifdef RDK_BUILD_COORDGEN_SUPPORT
   RDDepict::preferCoordGen = false;
@@ -4224,5 +4256,6 @@ int main() {
   testGithub3305();
   testGithub3391();
   testGithub4156();
+  test23JSONAtomColourPalette();
 #endif
 }

--- a/Code/GraphMol/MolDraw2D/test1.cpp
+++ b/Code/GraphMol/MolDraw2D/test1.cpp
@@ -348,8 +348,8 @@ std::hash_result_t hash_file(const std::string &filename) {
 }
 
 void check_file_hash(const std::string &filename,
-                     std::hash_result_t exp_hash=0U) {
-    std::cout << filename << " : " << hash_file(filename) << "U" << std::endl;
+                     std::hash_result_t exp_hash = 0U) {
+  std::cout << filename << " : " << hash_file(filename) << "U" << std::endl;
 
   std::map<std::string, std::hash_result_t>::const_iterator it;
   if (filename.substr(filename.length() - 4) == ".svg") {
@@ -1960,8 +1960,8 @@ void testDeuteriumTritium() {
       if (!ok) {
         continue;
       }
-      // there are no characters to look for, but each atom should
-      // be made of 2 glyphs, the superscript 2 and the H.
+        // there are no characters to look for, but each atom should
+        // be made of 2 glyphs, the superscript 2 and the H.
 #ifdef RDK_BUILD_FREETYPE_SUPPORT
       if ((line.find("atom-") != std::string::npos)) {
         if ((line.find("bond-") == std::string::npos)) {
@@ -4180,9 +4180,8 @@ void test23JSONAtomColourPalette() {
     MolDraw2DUtils::prepareMolForDrawing(*m);
     MolDraw2DSVG drawer(250, 200);
     const char *json =
-        "{\"atomColourPalette\": {\"7\": [0.2, 0.4, 0.9], \"16\": [0.9, 0.6, 0.0]}, "
-        "\"rotate\": 90, "
-        "\"bondLineWidth\": 5}";
+        R"JSON({"atomColourPalette": {"7": [0.2, 0.4, 0.9], "16": [0.9, 0.6, 0.0]},
+ "rotate": 90, "bondLineWidth": 5})JSON";
     MolDraw2DUtils::updateDrawerParamsFromJSON(drawer, json);
     drawer.drawMolecule(*m);
     drawer.finishDrawing();


### PR DESCRIPTION
Small PR to expose and test `atomColourPalette` as one of the `drawOptions` that can be set from JSON.
