### PR TITLE
Fixes #4330

### DIFF
--- a/External/AvalonTools/CMakeLists.txt
+++ b/External/AvalonTools/CMakeLists.txt
@@ -98,7 +98,7 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 include_directories(${AVALON_SRC_PATH})
 
 rdkit_library(AvalonLib AvalonTools.cpp SHARED 
-     LINK_LIBRARIES avalon_clib FileParsers SmilesParse GraphMol DataStructs  )
+     LINK_LIBRARIES avalon_clib SubstructMatch FileParsers SmilesParse GraphMol DataStructs  )
 target_compile_definitions(AvalonLib PRIVATE RDKIT_AVALONLIB_BUILD)
 rdkit_headers(AvalonTools.h DEST GraphMol)
 rdkit_test(testAvalonLib1 test1.cpp

--- a/External/AvalonTools/test1.cpp
+++ b/External/AvalonTools/test1.cpp
@@ -498,6 +498,15 @@ void testGithub4330() {
     AvalonTools::set2DCoords(*mol);
     TEST_ASSERT(mol->getNumConformers() == 1);
   }
+  {  // example with the explicit Hs already in the graph
+    SmilesParserParams params;
+    params.removeHs = false;
+    std::unique_ptr<RWMol> mol(SmilesToMol("F[C@]([H])(OOF)Br", params));
+    TEST_ASSERT(mol);
+    TEST_ASSERT(mol->getNumAtoms() == 7);
+    AvalonTools::set2DCoords(*mol);
+    TEST_ASSERT(mol->getNumConformers() == 1);
+  }
   {
     auto mol = "CC"_smiles;
     TEST_ASSERT(mol);

--- a/External/AvalonTools/test1.cpp
+++ b/External/AvalonTools/test1.cpp
@@ -1,4 +1,12 @@
-// $Id$
+//
+//  Copyright (C) 2008-2021 Greg Landrum and other RDKit contributors
+//
+//   @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
+//
 //
 //  Created by Greg Landrum, July 2008
 //
@@ -476,6 +484,32 @@ void testGithub4075() {
   }
   BOOST_LOG(rdInfoLog) << "done" << std::endl;
 }
+
+void testGithub4330() {
+  BOOST_LOG(rdInfoLog) << "testing Github #4330: AvalonTools::set2DCoords "
+                          "failing for molecules which have Hs"
+                       << std::endl;
+  {
+    auto mol = "F[C@H](OOF)Br"_smiles;
+    TEST_ASSERT(mol);
+    AvalonTools::set2DCoords(*mol);
+    TEST_ASSERT(mol->getNumConformers() == 1);
+    MolOps::addHs(*mol);
+    AvalonTools::set2DCoords(*mol);
+    TEST_ASSERT(mol->getNumConformers() == 1);
+  }
+  {
+    auto mol = "CC"_smiles;
+    TEST_ASSERT(mol);
+    AvalonTools::set2DCoords(*mol);
+    TEST_ASSERT(mol->getNumConformers() == 1);
+    MolOps::addHs(*mol);
+    AvalonTools::set2DCoords(*mol);
+    TEST_ASSERT(mol->getNumConformers() == 1);
+  }
+  BOOST_LOG(rdInfoLog) << "done" << std::endl;
+}
+
 int main() {
   RDLog::InitLogs();
 #if 1
@@ -491,9 +525,10 @@ int main() {
   testSmilesSegFault();
   testGithub336();
   testCountFps();
-#endif
   testInitStruChk();
+#endif
   testGithub4075();
+  testGithub4330();
 
   return 0;
 }


### PR DESCRIPTION
The problem was caused by the avalon toolkit's (potential) addition of hydrogens and atom renumbering.
The fix for #4075 introduced in #4079 wasn't particularly robust.

When the number of atoms returned by the avalon code is larger than what we started with, or in cases where the input molecule already has Hs, this does an explicit substructure match between the mol returned from the avalon code and the input molecule rather than using heuristics.
