### PR TITLE
Addresses #4329

### DIFF
--- a/Code/MinimalLib/jswrapper.cpp
+++ b/Code/MinimalLib/jswrapper.cpp
@@ -18,17 +18,16 @@
 
 using namespace RDKit;
 
-
-
-
 namespace RDKit {
-namespace MinimalLib{
-extern std::string process_details(const std::string &details, unsigned int &width,
-                            unsigned int &height, int &offsetx, int &offsety,
-                            std::string &legend, std::vector<int> &atomIds,
-                            std::vector<int> &bondIds);
+namespace MinimalLib {
+extern std::string process_details(const std::string &details,
+                                   unsigned int &width, unsigned int &height,
+                                   int &offsetx, int &offsety,
+                                   std::string &legend,
+                                   std::vector<int> &atomIds,
+                                   std::vector<int> &bondIds);
 }
-}
+}  // namespace RDKit
 
 namespace {
 std::string draw_to_canvas_with_offset(JSMol &self, emscripten::val canvas,
@@ -70,8 +69,8 @@ std::string draw_to_canvas_with_highlights(JSMol &self, emscripten::val canvas,
   int offsetx = 0;
   int offsety = 0;
   std::string legend = "";
-  auto problems = MinimalLib::process_details(details, w, h, offsetx, offsety, legend,
-                                  atomIds, bondIds);
+  auto problems = MinimalLib::process_details(details, w, h, offsetx, offsety,
+                                              legend, atomIds, bondIds);
   if (!problems.empty()) {
     return problems;
   }
@@ -92,9 +91,12 @@ JSMol *get_mol_no_details(const std::string &input) {
   return get_mol(input, std::string());
 }
 
-emscripten::val get_morgan_fp_as_uint8array(const JSMol &self, unsigned int radius, unsigned int fplen) {
+emscripten::val get_morgan_fp_as_uint8array(const JSMol &self,
+                                            unsigned int radius,
+                                            unsigned int fplen) {
   std::string fp = self.get_morgan_fp_as_binary_text(radius, fplen);
-  emscripten::val view(emscripten::typed_memory_view(fp.size(), reinterpret_cast<const unsigned char *>(fp.c_str())));
+  emscripten::val view(emscripten::typed_memory_view(
+      fp.size(), reinterpret_cast<const unsigned char *>(fp.c_str())));
   auto res = emscripten::val::global("Uint8Array").new_(fp.size());
   res.call<void>("set", view);
   return res;
@@ -128,9 +130,11 @@ EMSCRIPTEN_BINDINGS(RDKit_minimal) {
       .function("draw_to_canvas_with_highlights",
                 &draw_to_canvas_with_highlights)
       .function("get_morgan_fp_as_uint8array",
-                select_overload<emscripten::val(const JSMol&)>(get_morgan_fp_as_uint8array))
+                select_overload<emscripten::val(const JSMol &)>(
+                    get_morgan_fp_as_uint8array))
       .function("get_morgan_fp_as_uint8array",
-                select_overload<emscripten::val(const JSMol&, unsigned int, unsigned int)>(
+                select_overload<emscripten::val(const JSMol &, unsigned int,
+                                                unsigned int)>(
                     get_morgan_fp_as_uint8array))
 #endif
       .function("get_substruct_match", &JSMol::get_substruct_match)

--- a/Code/MinimalLib/minilib.cpp
+++ b/Code/MinimalLib/minilib.cpp
@@ -131,6 +131,15 @@ std::string JSMol::get_morgan_fp(unsigned int radius,
   return res;
 }
 
+std::string JSMol::get_morgan_fp_as_binary_text(unsigned int radius,
+                                 unsigned int fplen) const {
+  if (!d_mol) return "";
+  auto fp = MorganFingerprints::getFingerprintAsBitVect(*d_mol, radius, fplen);
+  std::string res = BitVectToBinaryText(*fp);
+  delete fp;
+  return res;
+}
+
 std::string JSMol::get_stereo_tags() const {
   if (!d_mol) return "{}";
   rj::Document doc;

--- a/Code/MinimalLib/minilib.cpp
+++ b/Code/MinimalLib/minilib.cpp
@@ -132,7 +132,7 @@ std::string JSMol::get_morgan_fp(unsigned int radius,
 }
 
 std::string JSMol::get_morgan_fp_as_binary_text(unsigned int radius,
-                                 unsigned int fplen) const {
+                                                unsigned int fplen) const {
   if (!d_mol) return "";
   auto fp = MorganFingerprints::getFingerprintAsBitVect(*d_mol, radius, fplen);
   std::string res = BitVectToBinaryText(*fp);
@@ -295,8 +295,7 @@ std::string JSMol::condense_abbreviations_from_defs(
 }
 
 std::string JSMol::generate_aligned_coords(const JSMol &templateMol,
-                                           bool useCoordGen,
-                                           bool allowRGroups,
+                                           bool useCoordGen, bool allowRGroups,
                                            bool acceptFailure) {
   std::string res;
   if (!d_mol || !templateMol.d_mol || !templateMol.d_mol->getNumConformers())

--- a/Code/MinimalLib/minilib.h
+++ b/Code/MinimalLib/minilib.h
@@ -31,6 +31,8 @@ class JSMol {
   std::string get_descriptors() const;
   std::string get_morgan_fp(unsigned int radius, unsigned int len) const;
   std::string get_morgan_fp() const { return get_morgan_fp(2, 2048); }
+  std::string get_morgan_fp_as_binary_text(unsigned int radius, unsigned int len) const;
+  std::string get_morgan_fp_as_binary_text() const { return get_morgan_fp(2, 2048); }
   std::string condense_abbreviations(double maxCoverage, bool useLinkers);
   std::string condense_abbreviations() {
     return condense_abbreviations(0.4, false);

--- a/Code/MinimalLib/minilib.h
+++ b/Code/MinimalLib/minilib.h
@@ -31,8 +31,11 @@ class JSMol {
   std::string get_descriptors() const;
   std::string get_morgan_fp(unsigned int radius, unsigned int len) const;
   std::string get_morgan_fp() const { return get_morgan_fp(2, 2048); }
-  std::string get_morgan_fp_as_binary_text(unsigned int radius, unsigned int len) const;
-  std::string get_morgan_fp_as_binary_text() const { return get_morgan_fp(2, 2048); }
+  std::string get_morgan_fp_as_binary_text(unsigned int radius,
+                                           unsigned int len) const;
+  std::string get_morgan_fp_as_binary_text() const {
+    return get_morgan_fp(2, 2048);
+  }
   std::string condense_abbreviations(double maxCoverage, bool useLinkers);
   std::string condense_abbreviations() {
     return condense_abbreviations(0.4, false);

--- a/Code/MinimalLib/tests/tests.js
+++ b/Code/MinimalLib/tests/tests.js
@@ -41,12 +41,29 @@ function test_basics() {
     assert.equal(descrs.NumRings,1);
     assert.equal(descrs.amw,94.11299);
 
+    var checkStringBinaryFpIdentity = (stringFp, binaryFp) => {
+        assert.equal(binaryFp.length, stringFp.length / 8);
+        for (var i = 0, c = 0; i < binaryFp.length; ++i) {
+            var byte = 0;
+            for (var j = 0; j < 8; ++j, ++c) {
+                if (stringFp[c] === "1") {
+                    byte |= (1 << j);
+                }
+            }
+            assert.equal(byte, binaryFp[i]);
+        }
+    };
+
     var fp1 = mol.get_morgan_fp();
     assert.equal(fp1.length,2048);
     assert.equal((fp1.match(/1/g)||[]).length,11);
+    var fp1Uint8Array = mol.get_morgan_fp_as_uint8array();
+    checkStringBinaryFpIdentity(fp1, fp1Uint8Array);
     var fp2 = mol.get_morgan_fp(0,512);
     assert.equal(fp2.length,512);
     assert.equal((fp2.match(/1/g)||[]).length,3);
+    var fp2Uint8Array = mol.get_morgan_fp_as_uint8array(0, 512);
+    checkStringBinaryFpIdentity(fp2, fp2Uint8Array);
     
     var svg = mol.get_svg();
     assert(svg.search("svg")>0);


### PR DESCRIPTION
This PR addressed #4329 by implementing `get_morgan_fp_as_uint8array()`, which returns the Morgan bit vector to JS as a more useful `Uint8Array`.
