### PR TITLE
Improved sgroup output

### DIFF
--- a/Code/GraphMol/FileParsers/MolSGroupWriting.cpp
+++ b/Code/GraphMol/FileParsers/MolSGroupWriting.cpp
@@ -643,25 +643,20 @@ void addBlockToSGroupString(std::string block, std::string &currentLine,
     currentLine += block;
   } else {
     os << currentLine << " -\n";
-    if (block.length() < 73) {
-      os << "M  V30" << block << " -\n";
-      currentLine = "M  V30";
-    } else {
-      unsigned int length = block.size();
-      unsigned int start = 0;
-      os << "M  V30" << block.substr(start, 72) << "-\n";
+    unsigned int length = block.size();
+    unsigned int start = 0;
+    while (length - start >= 73) {
+      os << "M  V30";
+      os << block.substr(start, 72);
       start += 72;
-      while (length - start >= 73) {
-        os << "M  V30 " << block.substr(start, 72);
-        start += 72;
-        if (start < length) {
-          // need to write more, so add another "-"
-          os << "-\n";
-        }
-      }
       if (start < length) {
-        currentLine = "M  V30 " + block.substr(start, 73);
+        // need to write more, so add another "-"
+        os << "-\n";
       }
+    }
+    if (start < length) {
+      currentLine =
+          "M  V30" + std::string(start ? " " : "") + block.substr(start, 73);
     }
   }
 }
@@ -721,7 +716,7 @@ const std::string GetV3000MolFileSGroupLines(const unsigned int idx,
                          currLine, os);
   std::string res;
   if (!currLine.empty() && currLine != "M  V30") {
-    os << currLine << std::endl;
+    os << currLine << "\n";
     res = os.str();
   } else {
     // there's an extra " -" at the end that we need to remove

--- a/Code/GraphMol/FileParsers/MolSGroupWriting.cpp
+++ b/Code/GraphMol/FileParsers/MolSGroupWriting.cpp
@@ -636,6 +636,37 @@ std::string FormatV3000AttachPointBlock(
   return ret.str();
 }
 
+namespace {
+void addBlockToSGroupString(std::string block, std::string &currentLine,
+                            std::ostringstream &os) {
+  if (currentLine.length() + block.length() < 80) {
+    currentLine += block;
+  } else {
+    os << currentLine << " -\n";
+    if (block.length() < 73) {
+      os << "M  V30" << block << " -\n";
+      currentLine = "M  V30";
+    } else {
+      unsigned int length = block.size();
+      unsigned int start = 0;
+      os << "M  V30" << block.substr(start, 72) << "-\n";
+      start += 72;
+      while (length - start > 73) {
+        os << "M  V30 " << block.substr(start, 72);
+        start += 72;
+        if (start < length) {
+          // need to write more, so add another "-"
+          os << "-\n";
+        }
+      }
+      if (start < length) {
+        currentLine = "M  V30 " + block.substr(start, 73);
+      }
+    }
+  }
+}
+}  // namespace
+
 //! Write a SGroup line. The order of the labels is defined in the spec.
 const std::string GetV3000MolFileSGroupLines(const unsigned int idx,
                                              const SubstanceGroup &sgroup) {
@@ -644,44 +675,60 @@ const std::string GetV3000MolFileSGroupLines(const unsigned int idx,
   unsigned int id = 0;
   sgroup.getPropIfPresent("ID", id);
 
-  os << idx << ' ' << sgroup.getProp<std::string>("TYPE") << ' ' << id;
-
-  os << BuildV3000IdxVectorDataBlock("ATOMS", sgroup.getAtoms());
+  std::string currLine = (boost::format("M  V30 %d %s %d") % idx %
+                          sgroup.getProp<std::string>("TYPE") % id)
+                             .str();
+  addBlockToSGroupString(
+      BuildV3000IdxVectorDataBlock("ATOMS", sgroup.getAtoms()), currLine, os);
   // also writes XBHEAD and XBCORR
-  os << BuildV3000BondsBlock(sgroup);
-  os << BuildV3000IdxVectorDataBlock("PATOMS", sgroup.getParentAtoms());
-  os << FormatV3000StringPropertyBlock("SUBTYPE", sgroup);
-  os << FormatV3000StringPropertyBlock("MULT", sgroup);
-  os << FormatV3000StringPropertyBlock("CONNECT", sgroup);
-  os << FormatV3000ParentBlock(sgroup);
-  os << FormatV3000CompNoBlock(sgroup);
-  os << FormatV3000StringPropertyBlock("LABEL", sgroup);
-  os << FormatV3000BracketBlock(sgroup.getBrackets());
-  os << FormatV3000StringPropertyBlock("ESTATE", sgroup);
-  os << FormatV3000CStateBlock(sgroup);
-  os << FormatV3000StringPropertyBlock("FIELDNAME", sgroup);
-  os << FormatV3000StringPropertyBlock("FIELDINFO", sgroup);
-  os << FormatV3000StringPropertyBlock("FIELDDISP", sgroup);
-  os << FormatV3000StringPropertyBlock("QUERYTYPE", sgroup);
-  os << FormatV3000StringPropertyBlock("QUERYOP", sgroup);
-  os << FormatV3000FieldDataBlock(sgroup);
-  os << FormatV3000StringPropertyBlock("CLASS", sgroup);
-  os << FormatV3000AttachPointBlock(sgroup.getAttachPoints());
-  os << FormatV3000StringPropertyBlock("BRKTYP", sgroup);
-  os << FormatV3000StringPropertyBlock("SEQID", sgroup);
-
-  std::string sGroupBlock = os.str();
-  unsigned int length = sGroupBlock.size();
-  os.str("");
-
-  unsigned int start = 0;
-  while (length - start > 73) {
-    os << "M  V30 " << sGroupBlock.substr(start, 72) << '-' << std::endl;
-    start += 72;
+  addBlockToSGroupString(BuildV3000BondsBlock(sgroup), currLine, os);
+  addBlockToSGroupString(
+      BuildV3000IdxVectorDataBlock("PATOMS", sgroup.getParentAtoms()), currLine,
+      os);
+  addBlockToSGroupString(FormatV3000StringPropertyBlock("SUBTYPE", sgroup),
+                         currLine, os);
+  addBlockToSGroupString(FormatV3000StringPropertyBlock("MULT", sgroup),
+                         currLine, os);
+  addBlockToSGroupString(FormatV3000StringPropertyBlock("CONNECT", sgroup),
+                         currLine, os);
+  addBlockToSGroupString(FormatV3000ParentBlock(sgroup), currLine, os);
+  addBlockToSGroupString(FormatV3000CompNoBlock(sgroup), currLine, os);
+  addBlockToSGroupString(FormatV3000StringPropertyBlock("LABEL", sgroup),
+                         currLine, os);
+  addBlockToSGroupString(FormatV3000BracketBlock(sgroup.getBrackets()),
+                         currLine, os);
+  addBlockToSGroupString(FormatV3000StringPropertyBlock("ESTATE", sgroup),
+                         currLine, os);
+  addBlockToSGroupString(FormatV3000CStateBlock(sgroup), currLine, os);
+  addBlockToSGroupString(FormatV3000StringPropertyBlock("FIELDNAME", sgroup),
+                         currLine, os);
+  addBlockToSGroupString(FormatV3000StringPropertyBlock("FIELDINFO", sgroup),
+                         currLine, os);
+  addBlockToSGroupString(FormatV3000StringPropertyBlock("FIELDDISP", sgroup),
+                         currLine, os);
+  addBlockToSGroupString(FormatV3000StringPropertyBlock("QUERYTYPE", sgroup),
+                         currLine, os);
+  addBlockToSGroupString(FormatV3000StringPropertyBlock("QUERYOP", sgroup),
+                         currLine, os);
+  addBlockToSGroupString(FormatV3000FieldDataBlock(sgroup), currLine, os);
+  addBlockToSGroupString(FormatV3000StringPropertyBlock("CLASS", sgroup),
+                         currLine, os);
+  addBlockToSGroupString(FormatV3000AttachPointBlock(sgroup.getAttachPoints()),
+                         currLine, os);
+  addBlockToSGroupString(FormatV3000StringPropertyBlock("BRKTYP", sgroup),
+                         currLine, os);
+  addBlockToSGroupString(FormatV3000StringPropertyBlock("SEQID", sgroup),
+                         currLine, os);
+  std::string res;
+  if (!currLine.empty()) {
+    os << currLine << std::endl;
+    res = os.str();
+  } else {
+    // there's an extra " -" at the end that we need to remove
+    res = os.str();
+    res = res.substr(0, res.length() - 3) + "\n";
   }
-  os << "M  V30 " << sGroupBlock.substr(start, 73) << std::endl;
-
-  return os.str();
+  return res;
 }
 
 }  // namespace SGroupWriting

--- a/Code/GraphMol/FileParsers/MolSGroupWriting.cpp
+++ b/Code/GraphMol/FileParsers/MolSGroupWriting.cpp
@@ -639,7 +639,7 @@ std::string FormatV3000AttachPointBlock(
 namespace {
 void addBlockToSGroupString(std::string block, std::string &currentLine,
                             std::ostringstream &os) {
-  if (currentLine.length() + block.length() < 80) {
+  if (currentLine.length() + block.length() < 78) {
     currentLine += block;
   } else {
     os << currentLine << " -\n";
@@ -651,7 +651,7 @@ void addBlockToSGroupString(std::string block, std::string &currentLine,
       unsigned int start = 0;
       os << "M  V30" << block.substr(start, 72) << "-\n";
       start += 72;
-      while (length - start > 73) {
+      while (length - start >= 73) {
         os << "M  V30 " << block.substr(start, 72);
         start += 72;
         if (start < length) {
@@ -720,7 +720,7 @@ const std::string GetV3000MolFileSGroupLines(const unsigned int idx,
   addBlockToSGroupString(FormatV3000StringPropertyBlock("SEQID", sgroup),
                          currLine, os);
   std::string res;
-  if (!currLine.empty()) {
+  if (!currLine.empty() && currLine != "M  V30") {
     os << currLine << std::endl;
     res = os.str();
   } else {

--- a/Code/GraphMol/FileParsers/file_parsers_catch.cpp
+++ b/Code/GraphMol/FileParsers/file_parsers_catch.cpp
@@ -3719,12 +3719,12 @@ M  END)CTAB"_ctab;
     CHECK(getSubstanceGroups(*m2).size() == 1);
   }
   SECTION("long data elements") {
-    auto m = R"CTAB(query
+    auto m = R"CTAB(query with bogus sgroups
   Mrv2108 07152116102D          
 
   0  0  0     0  0            999 V3000
 M  V30 BEGIN CTAB
-M  V30 COUNTS 2 1 2 0 0
+M  V30 COUNTS 2 1 5 0 0
 M  V30 BEGIN ATOM
 M  V30 1 C 3.5417 -5.875 0 0
 M  V30 2 C 4.8753 -5.105 0 0
@@ -3744,14 +3744,32 @@ M  V30 QUERYTYPE=SMARTSQ QUERYOP== -
 M  V30 FIELDDATA="quite long piece of text that needs to be broken -
 M  V30 across more than two lines because we really want to be sure -
 M  V30 that we are doing this right"
+M  V30 3 DAT 0 ATOMS=(1 1) -
+M  V30 FIELDDISP="    0.0000    0.0000    DR    ALL  0       0" -
+M  V30 QUERYTYPE=SMARTSQ QUERYOP== -
+M  V30 FIELDDATA="quite long piece of text that needs to be broken -
+M  V30 across exactly two lines so that we can check the edge case -
+M  V30 11111111111111111111"
+M  V30 4 DAT 0 ATOMS=(1 1) -
+M  V30 FIELDDISP="    0.0000    0.0000    DR    ALL  0       0" -
+M  V30 QUERYTYPE=SMARTSQ QUERYOP== -
+M  V30 FIELDDATA="quite long piece of text that needs to be broken -
+M  V30 across more than two lines because we really want to be sure -
+M  V30 that we are doing this right" SEQID=1
+M  V30 5 DAT 0 ATOMS=(1 1) -
+M  V30 FIELDDISP="    0.0000    0.0000    DR    ALL  0       0" -
+M  V30 QUERYTYPE=SMARTSQ QUERYOP== -
+M  V30 FIELDDATA="quite long piece of text that needs to be broken -
+M  V30 across exactly two lines so that we can check the edge case -
+M  V30 11111111111111111111" SEQID=2
 M  V30 END SGROUP
 M  V30 END CTAB
 M  END)CTAB"_ctab;
     REQUIRE(m);
-    CHECK(getSubstanceGroups(*m).size() == 2);
+    CHECK(getSubstanceGroups(*m).size() == 5);
     auto mb = MolToV3KMolBlock(*m);
     std::unique_ptr<RWMol> m2(MolBlockToMol(mb));
     REQUIRE(m2);
-    CHECK(getSubstanceGroups(*m2).size() == 2);
+    CHECK(getSubstanceGroups(*m2).size() == 5);
   }
 }

--- a/Code/GraphMol/FileParsers/file_parsers_catch.cpp
+++ b/Code/GraphMol/FileParsers/file_parsers_catch.cpp
@@ -3688,3 +3688,70 @@ M  END
 )CTAB";
   }
 }
+
+TEST_CASE("Long lines in V3000 mol blocks") {
+  SECTION("basics") {
+    auto m = R"CTAB(query
+  Mrv2108 07152116102D          
+
+  0  0  0     0  0            999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 2 1 1 0 0
+M  V30 BEGIN ATOM
+M  V30 1 C 3.5417 -5.875 0 0
+M  V30 2 C 4.8753 -5.105 0 0
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 1 1 2
+M  V30 END BOND
+M  V30 BEGIN SGROUP
+M  V30 1 DAT 0 ATOMS=(1 2) -
+M  V30 FIELDDISP="    4.8753   -5.1050    DA    ALL  0       0" -
+M  V30 QUERYTYPE=SMARTSQ QUERYOP== FIELDDATA=[#6;R]
+M  V30 END SGROUP
+M  V30 END CTAB
+M  END)CTAB"_ctab;
+    REQUIRE(m);
+    CHECK(getSubstanceGroups(*m).size() == 1);
+    auto mb = MolToV3KMolBlock(*m);
+    std::unique_ptr<RWMol> m2(MolBlockToMol(mb));
+    REQUIRE(m2);
+    CHECK(getSubstanceGroups(*m2).size() == 1);
+  }
+  SECTION("long data elements") {
+    auto m = R"CTAB(query
+  Mrv2108 07152116102D          
+
+  0  0  0     0  0            999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 2 1 2 0 0
+M  V30 BEGIN ATOM
+M  V30 1 C 3.5417 -5.875 0 0
+M  V30 2 C 4.8753 -5.105 0 0
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 1 1 2
+M  V30 END BOND
+M  V30 BEGIN SGROUP
+M  V30 1 DAT 0 ATOMS=(1 2) -
+M  V30 FIELDDISP="    0.0000    0.0000    DR    ALL  0       0" -
+M  V30 QUERYTYPE=SMARTSQ QUERYOP== -
+M  V30 FIELDDATA="quite long piece of text that needs to be broken -
+M  V30 across two lines"
+M  V30 2 DAT 0 ATOMS=(1 1) -
+M  V30 FIELDDISP="    0.0000    0.0000    DR    ALL  0       0" -
+M  V30 QUERYTYPE=SMARTSQ QUERYOP== -
+M  V30 FIELDDATA="quite long piece of text that needs to be broken -
+M  V30 across more than two lines because we really want to be sure -
+M  V30 that we are doing this right"
+M  V30 END SGROUP
+M  V30 END CTAB
+M  END)CTAB"_ctab;
+    REQUIRE(m);
+    CHECK(getSubstanceGroups(*m).size() == 2);
+    auto mb = MolToV3KMolBlock(*m);
+    std::unique_ptr<RWMol> m2(MolBlockToMol(mb));
+    REQUIRE(m2);
+    CHECK(getSubstanceGroups(*m2).size() == 2);
+  }
+}


### PR DESCRIPTION
The current SGroup writer is correct and efficient in terms of the number of output lines that it uses, but the output can be fairly ugly since it unnecessarily breaks elements across multiple lines.
Here's an example output from the current master:
```
query
     RDKit          2D

  0  0  0  0  0  0  0  0  0  0999 V3000
M  V30 BEGIN CTAB
M  V30 COUNTS 2 1 1 0 0
M  V30 BEGIN ATOM
M  V30 1 C 3.541700 -5.875000 0.000000 0
M  V30 2 C 4.875300 -5.105000 0.000000 0
M  V30 END ATOM
M  V30 BEGIN BOND
M  V30 1 1 1 2
M  V30 END BOND
M  V30 BEGIN SGROUP
M  V30 1 DAT 0 ATOMS=(1 2) FIELDDISP="    4.8753   -5.1050    DA    ALL  0     -
M  V30   0" QUERYTYPE=SMARTSQ QUERYOP== FIELDDATA="[#6;R]"
M  V30 END SGROUP
M  V30 END CTAB
M  END
```
And with this PR:
```
query
     RDKit          2D

  0  0  0  0  0  0  0  0  0  0999 V3000
M  V30 BEGIN CTAB
M  V30 COUNTS 2 1 1 0 0
M  V30 BEGIN ATOM
M  V30 1 C 3.541700 -5.875000 0.000000 0
M  V30 2 C 4.875300 -5.105000 0.000000 0
M  V30 END ATOM
M  V30 BEGIN BOND
M  V30 1 1 1 2
M  V30 END BOND
M  V30 BEGIN SGROUP
M  V30 1 DAT 0 ATOMS=(1 2) -
M  V30 FIELDDISP="    4.8753   -5.1050    DA    ALL  0       0" -
M  V30 QUERYTYPE=SMARTSQ QUERYOP== FIELDDATA="[#6;R]"
M  V30 END SGROUP
M  V30 END CTAB
M  END
```