### PR TITLE
Two MinGW build fixes and one MSVC build fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -234,6 +234,9 @@ endif(MSVC)
 if(MSVC)
   # FIX: do we still need this?
   target_compile_definitions(rdkit_base INTERFACE "-DBOOST_ALL_NO_LIB")
+  if(RDK_INSTALL_DLLS_MSVC)
+    target_compile_definitions(rdkit_base INTERFACE "-DBOOST_ALL_DYN_LINK")
+  endif(RDK_INSTALL_DLLS_MSVC)
 endif(MSVC)
 
 if(RDK_BUILD_INCHI_SUPPORT)

--- a/Code/GraphMol/FMCS/Test/testFMCS.cpp
+++ b/Code/GraphMol/FMCS/Test/testFMCS.cpp
@@ -53,6 +53,10 @@
 #include "../FMCS.h"
 #include "../DebugTrace.h"  //#ifdef VERBOSE_STATISTICS_ON
 
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
 using namespace RDKit;
 
 unsigned long long T0;
@@ -117,10 +121,10 @@ std::string getSmilesOnlyChEMBL(
 
 MCSParameters p;
 
-void testFileMCSB(
-    const char* test, unsigned timeout = 30,
-    std::vector<unsigned> test_N = std::vector<
-        unsigned>()) {  // optional list of some tests for investigation
+void testFileMCSB(const char* test, unsigned timeout = 30,
+                  std::vector<unsigned> test_N =
+                      std::vector<unsigned>()) {  // optional list of some tests
+                                                  // for investigation
   p.Verbose = false;
 
   std::vector<ROMOL_SPTR> mols;  // IT CAN OCCUPY A LOT OF MEMORY. store SMILES
@@ -129,7 +133,7 @@ void testFileMCSB(
   std::string molFile, id;
   std::map<std::string, size_t> molIdMap;
   std::vector<std::string> smilesList;
-  std::list<std::vector<std::string> > testCase;
+  std::list<std::vector<std::string>> testCase;
   std::string referenceOutFile(test);
   referenceOutFile += ".REF.out";
   std::string outFile(test);
@@ -235,9 +239,9 @@ void testFileMCSB(
         *c = '\0';
       }
       std::string sm = getSmilesOnly(str, &id);
-      smilesList.push_back(sm);                     // without Id and LineFeed
+      smilesList.push_back(sm);            // without Id and LineFeed
       mols.emplace_back(SmilesToMol(sm));  // SmartsToMol ???
-      molIdMap[id] = mols.size() - 1;               // index in mols
+      molIdMap[id] = mols.size() - 1;      // index in mols
     }
   }
   fclose(f);
@@ -270,8 +274,8 @@ void testFileMCSB(
   fprintf(f, "#software RDKit C++ FMCS \n#options  timeout=%u threshold=%g\n",
           p.Timeout, p.Threshold);
   std::cout << "Perform test cases ... \n";
-  for (std::list<std::vector<std::string> >::const_iterator
-           tc = testCase.begin();
+  for (std::list<std::vector<std::string>>::const_iterator tc =
+           testCase.begin();
        tc != testCase.end(); tc++, n++) {
     if (!test_N.empty() &&
         test_N.end() == std::find(test_N.begin(), test_N.end(), n + 1)) {
@@ -340,14 +344,13 @@ void testFileMCSB(
                   referenceResults[n].NumBonds,
                   referenceResults[n].SmartsString.c_str());
         } else {
-          fprintf(
-              f, "# %u REFCMP: res  %s %s %u %u %s.\n", n + 1, "FAILED",
-              /*referenceResults[n].NumAtoms > res.NumAtoms ||*/ referenceResults
-                          [n].NumBonds > res.NumBonds
-                  ? "MISSING"
-                  : "GREATER",
-              referenceResults[n].NumAtoms, referenceResults[n].NumBonds,
-              referenceResults[n].SmartsString.c_str());
+          fprintf(f, "# %u REFCMP: res  %s %s %u %u %s.\n", n + 1, "FAILED",
+                  /*referenceResults[n].NumAtoms > res.NumAtoms ||*/
+                          referenceResults[n].NumBonds > res.NumBonds
+                      ? "MISSING"
+                      : "GREATER",
+                  referenceResults[n].NumAtoms, referenceResults[n].NumBonds,
+                  referenceResults[n].SmartsString.c_str());
         }
 
         if (referenceResults[n].Canceled ||
@@ -378,18 +381,20 @@ void testFileMCSB(
     }
 #ifdef xxVERBOSE_STATISTICS_ON
     if (ft)  // statistic details
-      fprintf(
-          ft, "%u; %s; %d; %d; %.2f; %.2f; %u; %u; %u; %u\n", n + 1,
-          !res.Canceled ? "ok" : referenceResults[n].Canceled ? "bad"
-                                                              : "TIMEOUT",
-          referenceResults[n].Canceled ? 0 : res.NumAtoms -
-                                                 referenceResults[n].NumAtoms,
-          referenceResults[n].Canceled ? 0 : res.NumBonds -
-                                                 referenceResults[n].NumBonds,
-          sec, referenceResultsTime[n], stat.Seed - curStat.Seed,
-          stat.MatchCall - curStat.MatchCall,
-          stat.AtomCompareCalls - curStat.AtomCompareCalls,
-          stat.BondCompareCalls - curStat.BondCompareCalls);
+      fprintf(ft, "%u; %s; %d; %d; %.2f; %.2f; %u; %u; %u; %u\n", n + 1,
+              !res.Canceled                  ? "ok"
+              : referenceResults[n].Canceled ? "bad"
+                                             : "TIMEOUT",
+              referenceResults[n].Canceled
+                  ? 0
+                  : res.NumAtoms - referenceResults[n].NumAtoms,
+              referenceResults[n].Canceled
+                  ? 0
+                  : res.NumBonds - referenceResults[n].NumBonds,
+              sec, referenceResultsTime[n], stat.Seed - curStat.Seed,
+              stat.MatchCall - curStat.MatchCall,
+              stat.AtomCompareCalls - curStat.AtomCompareCalls,
+              stat.BondCompareCalls - curStat.BondCompareCalls);
     stat.AtomCompareCalls =
         0;  // 32 bit counter with very big value -> possible overflow
     stat.BondCompareCalls = 0;
@@ -421,8 +426,9 @@ void testFileMCSB(
       ,
       stat.Seed, stat.Seed / n, stat.RemainingSizeRejected,
       stat.RemainingSizeRejected / n,
-      0 == stat.Seed ? 0 : int((double)stat.RemainingSizeRejected /
-                               (double)stat.Seed * 100.),
+      0 == stat.Seed
+          ? 0
+          : int((double)stat.RemainingSizeRejected / (double)stat.Seed * 100.),
       stat.MatchCall, stat.MatchCall / n, stat.MatchCallTrue,
       stat.MatchCallTrue / n,
       int((double)stat.MatchCallTrue / (double)stat.MatchCall * 100.)
@@ -432,14 +438,15 @@ void testFileMCSB(
       ,
       stat.FindHashInCache, stat.FindHashInCache / n, stat.HashKeyFoundInCache,
       stat.HashKeyFoundInCache / n,
-      0 == stat.FindHashInCache ? 0 : int((double)stat.HashKeyFoundInCache /
-                                          (double)stat.FindHashInCache * 100.)
+      0 == stat.FindHashInCache ? 0
+                                : int((double)stat.HashKeyFoundInCache /
+                                      (double)stat.FindHashInCache * 100.)
 
           ,
       stat.ExactMatchCall, stat.ExactMatchCall / n, stat.ExactMatchCallTrue,
       stat.ExactMatchCallTrue / n
 #endif
-      );
+  );
 #endif
   if (f) {
     fclose(f);
@@ -1078,8 +1085,8 @@ void testChEMBLdatALL(double th = 1.0) {
   };
   for (auto& i : test) {
     testChEMBLdat(
-        (std::string("benchmarking_platform-master/compounds/ChEMBL/") +
-         i).c_str(),
+        (std::string("benchmarking_platform-master/compounds/ChEMBL/") + i)
+            .c_str(),
         th);
   }
 }
@@ -1286,8 +1293,9 @@ void testFileSDF_RandomSet(const char* test = "chembl13-10000-random-pairs.sdf",
     return;
   }
   // commands for prepare Python test:
-  fprintf(fcmd, "DEL %s\n", (std::string(path) + "_" + test + ".P.csv")
-                                .c_str());  // clear before append results
+  fprintf(fcmd, "DEL %s\n",
+          (std::string(path) + "_" + test + ".P.csv")
+              .c_str());  // clear before append results
   fprintf(fcmd, "SET PATH=%%PATH%%;C:/LIB\n");
   fprintf(fcmd, "SET PYTHONPATH=C:/Projects/RDKit/RDKit_2013_09_1\n");
   fprintf(
@@ -1443,8 +1451,9 @@ void testFileSDF_RandomSet(const char* test = "chembl13-10000-random-pairs.sdf",
           "nAtoms;E nBonds;E C++ MCS\n");
 
   const unsigned n1 = n;
-  fprintf(fcmd, "DEL %s\n", (std::string(path) + "_" + test + ".BIG_MCS.P.csv")
-                                .c_str());  // clear before append results
+  fprintf(fcmd, "DEL %s\n",
+          (std::string(path) + "_" + test + ".BIG_MCS.P.csv")
+              .c_str());  // clear before append results
   fprintf(fcmd, "SET PATH=%%PATH%%;C:/LIB\n");
   fprintf(fcmd, "SET PYTHONPATH=C:/Projects/RDKit/RDKit_2013_09_1\n");
   fprintf(
@@ -1624,8 +1633,8 @@ void testGregSDFFileSetFiltered() {
 int main(int argc, const char* argv[]) {
   p.Verbose = true;
 
-// use maximum CPU resources to increase time measuring accuracy and stability in
-// multi process environment
+// use maximum CPU resources to increase time measuring accuracy and stability
+// in multi process environment
 #ifdef WIN32
   //    SetPriorityClass (GetCurrentProcess(), REALTIME_PRIORITY_CLASS );
   SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_HIGHEST);
@@ -1651,27 +1660,29 @@ int main(int argc, const char* argv[]) {
   testFileSDF_RandomSet("chembl13_threshold_90.smi");
   ////    testFileSDF_RandomSet("");
   return 0;
-//------------------------
-/*
-//    p.BondTyper = MCSBondCompareOrderExact;
-    testChEMBL_Txt("chembl_II_sets/Target_no_10980_51302.txt"); // 271 sec  SLOW
-!!!
-//    return 0;
+  //------------------------
+  /*
+  //    p.BondTyper = MCSBondCompareOrderExact;
+      testChEMBL_Txt("chembl_II_sets/Target_no_10980_51302.txt"); // 271 sec
+  SLOW
+  !!!
+  //    return 0;
 
- //   testChEMBL_TxtALL_chembl_II_sets();
- //   testTarget_no_10188_30149();
-//    return 0;
-    // SLOW tests
-    test330();
-    testChEMBL_Txt("chembl_II_sets/Target_no_10980_52937.txt");
-    testChEMBL_Txt("chembl_II_sets/Target_no_11489_37339.txt");
-    testChEMBL_Txt("chembl_II_sets/Target_no_10260_54285.txt");
-    testChEMBL_Txt("chembl_II_sets/Target_no_10980_51302.txt"); // 271 sec  SLOW
-!!!
-*/
+   //   testChEMBL_TxtALL_chembl_II_sets();
+   //   testTarget_no_10188_30149();
+  //    return 0;
+      // SLOW tests
+      test330();
+      testChEMBL_Txt("chembl_II_sets/Target_no_10980_52937.txt");
+      testChEMBL_Txt("chembl_II_sets/Target_no_11489_37339.txt");
+      testChEMBL_Txt("chembl_II_sets/Target_no_10260_54285.txt");
+      testChEMBL_Txt("chembl_II_sets/Target_no_10980_51302.txt"); // 271 sec
+  SLOW
+  !!!
+  */
 
 #ifdef xxWIN32  // brief test set for testing and issue investigation
-#ifdef _DEBUG   // check memory leaks
+#ifdef _DEBUG  // check memory leaks
   _CrtMemState _ms;
   _CrtMemCheckpoint(&_ms);
 #endif

--- a/Code/GraphMol/FMCS/testFMCS_Unit.cpp
+++ b/Code/GraphMol/FMCS/testFMCS_Unit.cpp
@@ -56,6 +56,10 @@
 
 #include "../Substruct/SubstructMatch.h"
 
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
 using namespace RDKit;
 
 unsigned long long T0;

--- a/Code/GraphMol/FileParsers/GeneralFileReader.h
+++ b/Code/GraphMol/FileParsers/GeneralFileReader.h
@@ -104,7 +104,7 @@ std::unique_ptr<MolSupplier> getSupplier(const std::string& path,
 
   std::istream* strm;
   if (compressionFormat.empty()) {
-    strm = new std::ifstream(path.c_str());
+    strm = new std::ifstream(path.c_str(), std::ios::in | std::ios::binary);
   } else {
     strm = new gzstream(path);
   }

--- a/Code/GraphMol/FileParsers/MolSGroupParsing.h
+++ b/Code/GraphMol/FileParsers/MolSGroupParsing.h
@@ -131,7 +131,7 @@ void ParseSGroupV2000SBTLine(IDX_TO_SGROUP_MAP &sGroupMap, RWMol *mol,
 template <class T>
 RDKIT_FILEPARSERS_EXPORT std::vector<T> ParseV3000Array(
     std::stringstream &stream);
-#if defined(WIN32) && defined(RDKIT_DYN_LINK)
+#if defined(_MSC_VER) && defined(RDKIT_DYN_LINK)
 template RDKIT_FILEPARSERS_EXPORT std::vector<int> ParseV3000Array(
     std::stringstream &);
 template RDKIT_FILEPARSERS_EXPORT std::vector<unsigned int> ParseV3000Array(

--- a/Code/RDGeneral/RDExportMacros.h
+++ b/Code/RDGeneral/RDExportMacros.h
@@ -20,7 +20,7 @@
 
 // RDKit export macro definitions
 #ifdef RDKIT_DYN_LINK
-#if defined(WIN32) && defined(_MSC_VER) && defined(BOOST_HAS_DECLSPEC)
+#if defined(WIN32) && defined(BOOST_HAS_DECLSPEC)
 #define RDKIT_EXPORT_API __declspec(dllexport)
 #define RDKIT_IMPORT_API __declspec(dllimport)
 #elif __GNUC__ >= 4 || defined(__clang__)

--- a/Code/cmake/Modules/RDKitUtils.cmake
+++ b/Code/cmake/Modules/RDKitUtils.cmake
@@ -274,7 +274,7 @@ function(createExportTestHeaders)
   " * templates), but make sure it is visible for *nix\n"
   " */\n"
   "// RDKIT_QUERY_EXPORT definitions\n"
-  "#if defined(RDKIT_DYN_LINK) && defined(WIN32) && defined(_MSC_VER) && defined(BOOST_HAS_DECLSPEC)\n"
+  "#if defined(RDKIT_DYN_LINK) && defined(WIN32) && defined(BOOST_HAS_DECLSPEC)\n"
   "#define RDKIT_QUERY_EXPORT\n"
   "#else\n"
   "#define RDKIT_QUERY_EXPORT RDKIT_GRAPHMOL_EXPORT\n"


### PR DESCRIPTION
- fixes MinGW build. Some pre-processor directives were (relatively) recently
  changed and caused the MinGW build to break. This PR fixes the problem
- make sure that supplier `istream` is opened in binary mode or `istream::tellg()` will
  report wrong offsets on MinGW builds (MSVC will make no difference) and cause
  `SmilesMolSupplier` read faillures
- avoid that in MSVC conda DLL builds the `libboost_*.lib` static
  libraries are picked by `cmake` instead of the `boost_*.lib` import libraries
  as they live in the same directory by defining `BOOST_ALL_DYN_LINK`
  I have noticed this in a Python 3.9 build against the latest Boost 1.73
  available in conda.

You may ignore the huge diff in the two FMCS tests; they are due to having applied `clang-format`. The only relevant change in each of the files is:
```
#ifdef _WIN32
#include <windows.h>
#endif
```