### PR TITLE
Fixes #4319: allow CXSMILES extensions for SMARTS

### DIFF
--- a/Code/GraphMol/SmilesParse/SmartsWrite.h
+++ b/Code/GraphMol/SmilesParse/SmartsWrite.h
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2004-2020 Greg Landrum and Rational Discovery LLC
+//  Copyright (C) 2004-2021 Greg Landrum and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -31,6 +31,14 @@ RDKIT_SMILESPARSE_EXPORT std::string MolToSmarts(const ROMol &mol,
                                                  bool doIsomericSmarts = true);
 
 RDKIT_SMILESPARSE_EXPORT std::string MolFragmentToSmarts(
+    const ROMol &mol, const std::vector<int> &atomsToUse,
+    const std::vector<int> *bondsToUse = nullptr, bool doIsomericSmarts = true);
+
+//! returns the CXSMARTS for a molecule
+RDKIT_SMILESPARSE_EXPORT std::string MolToCXSmarts(
+    const ROMol &mol, bool doIsomericSmarts = true);
+
+RDKIT_SMILESPARSE_EXPORT std::string MolFragmentToCXSmarts(
     const ROMol &mol, const std::vector<int> &atomsToUse,
     const std::vector<int> *bondsToUse = nullptr, bool doIsomericSmarts = true);
 };  // namespace RDKit

--- a/Code/GraphMol/SmilesParse/SmilesParse.h
+++ b/Code/GraphMol/SmilesParse/SmilesParse.h
@@ -91,8 +91,6 @@ struct RDKIT_SMILESPARSE_EXPORT SmartsParserParams {
   bool parseName = false; /**< parse (and set) the molecule name as well */
   bool mergeHs =
       true; /**< toggles merging H atoms in the SMARTS into neighboring atoms*/
-  bool useLegacyStereo =
-      true; /**< use the legacy stereochemistry perception code */
 };
 RDKIT_SMILESPARSE_EXPORT RWMol *SmartsToMol(const std::string &sma,
                                             const SmartsParserParams &ps);

--- a/Code/GraphMol/SmilesParse/SmilesParse.h
+++ b/Code/GraphMol/SmilesParse/SmilesParse.h
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2001-2020 Greg Landrum and Rational Discovery LLC
+//  Copyright (C) 2001-2021 Greg Landrum and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -81,6 +81,22 @@ inline RWMol *SmilesToMol(
   return SmilesToMol(smi, params);
 };
 
+struct RDKIT_SMILESPARSE_EXPORT SmartsParserParams {
+  int debugParse = 0; /**< enable debugging in the SMARTS parser*/
+  std::map<std::string, std::string> *replacements =
+      nullptr;               /**< allows SMARTS "macros" */
+  bool allowCXSMILES = true; /**< recognize and parse CXSMILES extensions */
+  bool strictCXSMILES =
+      true; /**< throw an exception if the CXSMILES parsing fails */
+  bool parseName = false; /**< parse (and set) the molecule name as well */
+  bool mergeHs =
+      true; /**< toggles merging H atoms in the SMARTS into neighboring atoms*/
+  bool useLegacyStereo =
+      true; /**< use the legacy stereochemistry perception code */
+};
+RDKIT_SMILESPARSE_EXPORT RWMol *SmartsToMol(const std::string &sma,
+                                            const SmartsParserParams &ps);
+
 //! Construct a molecule from a SMARTS string
 /*!
  \param sma           the SMARTS to convert
@@ -93,9 +109,15 @@ inline RWMol *SmilesToMol(
  \return a pointer to the new molecule; the caller is responsible for free'ing
  this.
  */
-RDKIT_SMILESPARSE_EXPORT RWMol *SmartsToMol(
+inline RWMol *SmartsToMol(
     const std::string &sma, int debugParse = 0, bool mergeHs = false,
-    std::map<std::string, std::string> *replacements = nullptr);
+    std::map<std::string, std::string> *replacements = nullptr) {
+  SmartsParserParams ps;
+  ps.debugParse = debugParse;
+  ps.mergeHs = mergeHs;
+  ps.replacements = replacements;
+  return SmartsToMol(sma, ps);
+};
 
 RDKIT_SMILESPARSE_EXPORT Atom *SmartsToAtom(const std::string &sma);
 RDKIT_SMILESPARSE_EXPORT Bond *SmartsToBond(const std::string &sma);

--- a/Code/GraphMol/SmilesParse/catch_tests.cpp
+++ b/Code/GraphMol/SmilesParse/catch_tests.cpp
@@ -1,5 +1,4 @@
 //
-//
 //  Copyright (C) 2018-2021 Greg Landrum and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
@@ -941,5 +940,30 @@ TEST_CASE("Github #4319 add CXSMARTS support") {
     REQUIRE(mol->getNumAtoms() == 4);
     CHECK(MolToSmarts(*mol) == "CCCO");
     CHECK(MolToCXSmarts(*mol) == "CCCO |$foo;;bar;$|");
+  }
+
+  SECTION("parser, confirm enhanced stereo working") {
+    auto mol = "[#6][C@]([#8])(F)Cl |&1:1|"_smarts;
+    REQUIRE(mol);
+    REQUIRE(mol->getNumAtoms() == 5);
+    CHECK(MolToSmarts(*mol) == "[#6][C@](-,:[#8])(-,:F)Cl");
+    CHECK(MolToCXSmarts(*mol) == "[#6][C@](-,:[#8])(-,:F)Cl |&1:1|");
+
+    {
+      auto smol = "C[C@](O)(F)Cl |&1:1|"_smiles;
+      REQUIRE(smol);
+      SubstructMatchParameters sssparams;
+      sssparams.useEnhancedStereo = true;
+      sssparams.useChirality = true;
+      CHECK(SubstructMatch(*smol, *mol, sssparams).size() == 1);
+    }
+    {
+      auto smol = "C[C@](O)(F)Cl |o1:1|"_smiles;
+      REQUIRE(smol);
+      SubstructMatchParameters sssparams;
+      sssparams.useEnhancedStereo = true;
+      sssparams.useChirality = true;
+      CHECK(SubstructMatch(*smol, *mol, sssparams).empty());
+    }
   }
 }

--- a/Code/GraphMol/SmilesParse/catch_tests.cpp
+++ b/Code/GraphMol/SmilesParse/catch_tests.cpp
@@ -1,6 +1,6 @@
 //
 //
-//  Copyright (C) 2018-2021 Greg Landrum and T5 Informatics GmbH
+//  Copyright (C) 2018-2021 Greg Landrum and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -882,5 +882,64 @@ TEST_CASE(
     std::string smi = MolFragmentToSmiles(*mol, ats, nullptr, nullptr, nullptr,
                                           doIsomericSmiles, doKekule);
     CHECK(smi == "C:CC");
+  }
+}
+
+TEST_CASE("Github #4319 add CXSMARTS support") {
+  // note: the CXSMARTS support uses exactly the same code as the CXSMILES
+  // parser/writer. We aren't testing that here since it's tested already with
+  // the CXSMILES tests. The goal here is just to make sure that it's being
+  // called by default and that we can control its behavior with the
+  // SmartsParseParams structure
+  SECTION("defaults") {
+    auto mol = "CCC |$foo;;bar$|"_smarts;
+    REQUIRE(mol);
+    REQUIRE(mol->getNumAtoms() == 3);
+    CHECK(mol->getAtomWithIdx(0)->getProp<std::string>(
+              common_properties::atomLabel) == "foo");
+    CHECK(mol->getAtomWithIdx(2)->getProp<std::string>(
+              common_properties::atomLabel) == "bar");
+    CHECK(!mol->getAtomWithIdx(1)->hasProp(common_properties::atomLabel));
+  }
+  SECTION("params") {
+    std::string sma = "CCC |$foo;;bar$|";
+    SmartsParserParams ps;
+    const std::unique_ptr<RWMol> mol(SmartsToMol(sma, ps));
+    REQUIRE(mol);
+    REQUIRE(mol->getNumAtoms() == 3);
+    CHECK(mol->getAtomWithIdx(0)->getProp<std::string>(
+              common_properties::atomLabel) == "foo");
+    CHECK(mol->getAtomWithIdx(2)->getProp<std::string>(
+              common_properties::atomLabel) == "bar");
+    CHECK(!mol->getAtomWithIdx(1)->hasProp(common_properties::atomLabel));
+  }
+  SECTION("no cxsmarts") {
+    std::string sma = "CCC |$foo;;bar$|";
+    SmartsParserParams ps;
+    ps.allowCXSMILES = false;
+    const std::unique_ptr<RWMol> mol(SmartsToMol(sma, ps));
+    REQUIRE(!mol);
+  }
+  SECTION("name") {
+    std::string sma = "CCC foobar";
+    SmartsParserParams ps;
+    ps.parseName = true;
+    const std::unique_ptr<RWMol> mol(SmartsToMol(sma, ps));
+    REQUIRE(mol);
+    REQUIRE(mol->getProp<std::string>(common_properties::_Name) == "foobar");
+  }
+  SECTION("writer") {
+    auto mol = "CCC |$foo;;bar$|"_smarts;
+    REQUIRE(mol);
+    REQUIRE(mol->getNumAtoms() == 3);
+    CHECK(MolToSmarts(*mol) == "CCC");
+    CHECK(MolToCXSmarts(*mol) == "CCC |$foo;;bar$|");
+  }
+  SECTION("writer, check reordering") {
+    auto mol = "CC1.OC1 |$foo;;;bar$|"_smarts;
+    REQUIRE(mol);
+    REQUIRE(mol->getNumAtoms() == 4);
+    CHECK(MolToSmarts(*mol) == "CCCO");
+    CHECK(MolToCXSmarts(*mol) == "CCCO |$foo;;bar;$|");
   }
 }

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2003-2021  Greg Landrum and Rational Discovery LLC
+#  Copyright (C) 2003-2021  Greg Landrum and other RDKit contributors
 #         All Rights Reserved
 #
 """ This is a rough coverage test of the python wrapper
@@ -6627,6 +6627,24 @@ CAS<~>
       m2, addWhenImpossible=Chem.StereoBondThresholds.DBL_BOND_SPECIFIED_STEREO)
     self.assertEqual(m2.GetBondWithIdx(3).GetStereo(), Chem.BondStereo.STEREONONE)
     self.assertEqual(m2.GetBondWithIdx(2).GetBondDir(), Chem.BondDir.UNKNOWN)
+
+  def testSmartsParseParams(self):
+    smi = "CCC |$foo;;bar$| ourname"
+    m = Chem.MolFromSmarts(smi)
+    self.assertTrue(m is not None)
+    ps = Chem.SmartsParserParams()
+    ps.allowCXSMILES = False
+    m = Chem.MolFromSmarts(smi, ps)
+    self.assertTrue(m is None)
+    ps.allowCXSMILES = True
+    ps.parseName = True
+    m = Chem.MolFromSmarts(smi, ps)
+    self.assertTrue(m is not None)
+    self.assertTrue(m.GetAtomWithIdx(0).HasProp('atomLabel'))
+    self.assertEqual(m.GetAtomWithIdx(0).GetProp('atomLabel'), "foo")
+    self.assertTrue(m.HasProp('_Name'))
+    self.assertEqual(m.GetProp('_Name'), "ourname")
+    self.assertEqual(m.GetProp("_CXSMILES_Data"), "|$foo;;bar$|")
 
 
 if __name__ == '__main__':

--- a/Docs/Book/RDKit_Book.rst
+++ b/Docs/Book/RDKit_Book.rst
@@ -224,10 +224,10 @@ Specifying atoms by atomic number
 The ``[#6]`` construct from SMARTS is supported in SMILES.
 
 
-CXSMILES extensions
--------------------
+CXSMILES/CXSMARTS extensions
+----------------------------
 
-The RDKit supports parsing and writing a subset of the extended SMILES functionality introduced by ChemAxon [#cxsmiles]_.
+The RDKit supports parsing and writing a subset of the extended SMILES/SMARTS functionality introduced by ChemAxon [#cxsmiles]_.
 
 The features which are parsed include:
 
@@ -245,8 +245,9 @@ The features which are parsed include:
 - non-hydrogen substitution count specifications ``s``
 - unsaturation specification ``u``
 
-The features which are written by :py:func:`rdkit.Chem.rdmolfiles.MolToCXSmiles`
-(note the specialized writer function) include:
+The features which are written by :py:func:`rdkit.Chem.rdmolfiles.MolToCXSmiles` and
+:py:func:`rdkit.Chem.rdmolfiles.MolToCXSmarts` 
+(note the specialized writer functions) include:
 
 - atomic coordinates
 - atomic values


### PR DESCRIPTION
Parse/write CXSMILES extensions as part of dealing with SMARTS.

As far as I can tell from the CXSMILES/CXSMARTS documentation the extensions (the CX part) are the same for both SMILES and SMARTS.