### PR TITLE
Removed spurious dllexport on enums

### DIFF
--- a/Code/GraphMol/ChemTransforms/MolFragmenter.h
+++ b/Code/GraphMol/ChemTransforms/MolFragmenter.h
@@ -101,7 +101,7 @@ RDKIT_CHEMTRANSFORMS_EXPORT void constructBRICSBondTypes(
     std::vector<FragmenterBondType> &defs);
 }  // namespace MolFragmenter
 
-enum class RDKIT_CHEMTRANSFORMS_EXPORT MolzipLabel {
+enum class MolzipLabel {
   AtomMapNumber,
   Isotope,
   FragmentOnBonds,

--- a/Code/GraphMol/MolHash/nmmolhash.h
+++ b/Code/GraphMol/MolHash/nmmolhash.h
@@ -22,7 +22,7 @@
 namespace RDKit {
 class RWMol;
 namespace MolHash {
-enum class RDKIT_MOLHASH_EXPORT HashFunction {
+enum class HashFunction {
   AnonymousGraph = 1,
   ElementGraph = 2,
   CanonicalSmiles = 3,
@@ -44,7 +44,7 @@ enum class RDKIT_MOLHASH_EXPORT HashFunction {
 
 RDKIT_MOLHASH_EXPORT std::string MolHash(RWMol *mol, HashFunction func);
 
-enum class RDKIT_MOLHASH_EXPORT StripType {
+enum class StripType {
   AtomStereo = 1,
   BondStereo = 2,
   Isotope = 4,

--- a/Code/GraphMol/ScaffoldNetwork/ScaffoldNetwork.h
+++ b/Code/GraphMol/ScaffoldNetwork/ScaffoldNetwork.h
@@ -64,7 +64,7 @@ struct RDKIT_SCAFFOLDNETWORK_EXPORT ScaffoldNetworkParams {
   ScaffoldNetworkParams(const std::vector<std::string> &bondBreakersSmarts);
 };
 
-enum class RDKIT_SCAFFOLDNETWORK_EXPORT EdgeType {
+enum class EdgeType {
   Fragment = 1,     ///< molecule -> fragment
   Generic = 2,      ///< molecule -> generic molecule (all atoms are dummies)
   GenericBond = 3,  ///< molecule -> generic bond molecule (all bonds single)


### PR DESCRIPTION
This is not necessary and raises annoying warnings during compilation.