### PR TITLE
CXSMILES improvements

### DIFF
--- a/Code/GraphMol/SmilesParse/CXSmilesOps.cpp
+++ b/Code/GraphMol/SmilesParse/CXSmilesOps.cpp
@@ -761,7 +761,7 @@ bool parse_polymer_sgroup(Iterator &first, Iterator last, RDKit::RWMol &mol) {
     }
     if (first != last && *first == ':') {
       ++first;
-      std::string superscript = read_text_to(first, last, ":|");
+      std::string superscript = read_text_to(first, last, ":|,");
       if (!superscript.empty()) {
         sgroup.setProp("CONNECT", superscript);
       }
@@ -1283,10 +1283,11 @@ std::string get_sgroup_polymer_block(
       }
       res << ":";
     }
+    res << ",";
   }
 
   std::string resStr = res.str();
-  if (!resStr.empty() && resStr.back() == ',') {
+  while (!resStr.empty() && resStr.back() == ',') {
     resStr.pop_back();
   }
   return resStr;

--- a/Code/GraphMol/SmilesParse/SmartsWrite.cpp
+++ b/Code/GraphMol/SmilesParse/SmartsWrite.cpp
@@ -604,6 +604,7 @@ std::string FragmentSmartsConstruct(
     ROMol &mol, unsigned int atomIdx, std::vector<Canon::AtomColors> &colors,
     UINT_VECT &ranks, bool doIsomericSmiles,
     std::vector<unsigned int> &atomOrdering,
+    std::vector<unsigned int> &bondOrdering,
     const boost::dynamic_bitset<> *bondsInPlay) {
   Canon::MolStack molStack;
   molStack.reserve(mol.getNumAtoms() + mol.getNumBonds());
@@ -652,6 +653,7 @@ std::string FragmentSmartsConstruct(
       case Canon::MOL_STACK_BOND: {
         auto *qbnd = static_cast<QueryBond *>(msCI.obj.bond);
         res << SmartsWrite::GetBondSmarts(qbnd, msCI.number);
+        bondOrdering.push_back(qbnd->getIdx());
         break;
       }
       case Canon::MOL_STACK_RING: {
@@ -785,6 +787,7 @@ std::string molToSmarts(const ROMol &inmol, bool doIsomericSmiles,
     mol.setProp(common_properties::_doIsoSmiles, 1);
   }
   std::vector<unsigned int> atomOrdering;
+  std::vector<unsigned int> bondOrdering;
 
   std::string res;
   auto colorIt = std::find(colors.begin(), colors.end(), Canon::WHITE_NODE);
@@ -799,9 +802,9 @@ std::string molToSmarts(const ROMol &inmol, bool doIsomericSmiles,
         nextAtomIdx = i;
       }
     }
-    subSmi =
-        FragmentSmartsConstruct(mol, nextAtomIdx, colors, ranks,
-                                doIsomericSmiles, atomOrdering, bondsInPlay);
+    subSmi = FragmentSmartsConstruct(mol, nextAtomIdx, colors, ranks,
+                                     doIsomericSmiles, atomOrdering,
+                                     bondOrdering, bondsInPlay);
     res += subSmi;
 
     colorIt = std::find(colors.begin(), colors.end(), Canon::WHITE_NODE);
@@ -810,6 +813,7 @@ std::string molToSmarts(const ROMol &inmol, bool doIsomericSmiles,
     }
   }
   inmol.setProp(common_properties::_smilesAtomOutputOrder, atomOrdering, true);
+  inmol.setProp(common_properties::_smilesBondOutputOrder, bondOrdering, true);
   return res;
 }
 

--- a/Code/GraphMol/SmilesParse/catch_tests.cpp
+++ b/Code/GraphMol/SmilesParse/catch_tests.cpp
@@ -1040,5 +1040,4 @@ TEST_CASE("Github #4233: data groups in CXSMILES neither parsed nor written") {
             std::vector<std::string>{"Ring2"});
     }
   }
-  SECTION("more") {}
 }

--- a/Code/GraphMol/SmilesParse/catch_tests.cpp
+++ b/Code/GraphMol/SmilesParse/catch_tests.cpp
@@ -1102,11 +1102,11 @@ TEST_CASE("polymer SGroups") {
       const auto &sgs = getSubstanceGroups(*mol);
       REQUIRE(sgs.size() == 1);
       CHECK(sgs[0].getAtoms() == std::vector<unsigned int>{1, 2, 3});
-      std::vector<unsigned int> bonds = {0, 3};
-      CHECK(sgs[0].getBonds() == bonds);
-      CHECK(sgs[0].getProp<std::vector<unsigned int>>("XBCORR") == bonds);
-      bonds = {0};
-      CHECK(sgs[0].getProp<std::vector<unsigned int>>("XBHEAD") == bonds);
+      CHECK(sgs[0].getBonds() == std::vector<unsigned int>{0, 3});
+      CHECK(sgs[0].getProp<std::vector<unsigned int>>("XBCORR") ==
+            sgs[0].getBonds());
+      CHECK(sgs[0].getProp<std::vector<unsigned int>>("XBHEAD") ==
+            std::vector<unsigned int>{0});
       CHECK(sgs[0].getProp<std::string>("TYPE") == "SRU");
       CHECK(sgs[0].getProp<std::string>("CONNECT") == "EU");
       auto smi = MolToCXSmiles(*mol);
@@ -1118,11 +1118,11 @@ TEST_CASE("polymer SGroups") {
       const auto &sgs = getSubstanceGroups(*mol);
       REQUIRE(sgs.size() == 1);
       CHECK(sgs[0].getAtoms() == std::vector<unsigned int>{1});
-      std::vector<unsigned int> bonds = {0, 1};
-      CHECK(sgs[0].getBonds() == bonds);
-      CHECK(sgs[0].getProp<std::vector<unsigned int>>("XBCORR") == bonds);
-      bonds = {0};
-      CHECK(sgs[0].getProp<std::vector<unsigned int>>("XBHEAD") == bonds);
+      CHECK(sgs[0].getBonds() == std::vector<unsigned int>{0, 1});
+      CHECK(sgs[0].getProp<std::vector<unsigned int>>("XBCORR") ==
+            sgs[0].getBonds());
+      CHECK(sgs[0].getProp<std::vector<unsigned int>>("XBHEAD") ==
+            std::vector<unsigned int>{0});
       CHECK(sgs[0].getProp<std::string>("TYPE") == "SRU");
       CHECK(sgs[0].getProp<std::string>("CONNECT") == "HT");
       auto smi = MolToCXSmiles(*mol);

--- a/Code/GraphMol/SmilesParse/catch_tests.cpp
+++ b/Code/GraphMol/SmilesParse/catch_tests.cpp
@@ -1070,6 +1070,8 @@ TEST_CASE("polymer SGroups") {
             std::vector<unsigned int>{6, 4, 0, 2});
       CHECK(sgs[0].getProp<std::string>("TYPE") == "SRU");
       CHECK(sgs[0].getProp<std::string>("CONNECT") == "HT");
+      CHECK(sgs[0].getProp<unsigned int>("index") == 1);
+
       auto smi = MolToCXSmiles(*mol);
       CHECK(smi ==
             "*CC(*)C(*)N* "
@@ -1091,6 +1093,8 @@ TEST_CASE("polymer SGroups") {
             std::vector<unsigned int>{6, 2, 0, 4});
       CHECK(sgs[0].getProp<std::string>("TYPE") == "SRU");
       CHECK(sgs[0].getProp<std::string>("CONNECT") == "HH");
+      CHECK(sgs[0].getProp<unsigned int>("index") == 1);
+
       auto smi = MolToCXSmiles(*mol);
       CHECK(smi ==
             "*CC(*)C(*)N* "
@@ -1109,6 +1113,8 @@ TEST_CASE("polymer SGroups") {
             std::vector<unsigned int>{0});
       CHECK(sgs[0].getProp<std::string>("TYPE") == "SRU");
       CHECK(sgs[0].getProp<std::string>("CONNECT") == "EU");
+      CHECK(sgs[0].getProp<unsigned int>("index") == 1);
+
       auto smi = MolToCXSmiles(*mol);
       CHECK(smi == "*CCO* |$star_e;;;;star_e$,Sg:n:1,2,3::eu:::|");
     }
@@ -1125,6 +1131,8 @@ TEST_CASE("polymer SGroups") {
             std::vector<unsigned int>{0});
       CHECK(sgs[0].getProp<std::string>("TYPE") == "SRU");
       CHECK(sgs[0].getProp<std::string>("CONNECT") == "HT");
+      CHECK(sgs[0].getProp<unsigned int>("index") == 1);
+
       auto smi = MolToCXSmiles(*mol);
       CHECK(smi == "*C* |$star_e;;star_e$,Sg:n:1::ht:::|");
     }
@@ -1144,6 +1152,8 @@ TEST_CASE("polymer SGroups") {
             std::vector<unsigned int>{0});
       CHECK(sgs[0].getProp<std::string>("TYPE") == "SRU");
       CHECK(sgs[0].getProp<std::string>("CONNECT") == "HT");
+      CHECK(sgs[0].getProp<unsigned int>("index") == 1);
+
       CHECK(sgs[1].getAtoms() == std::vector<unsigned int>{3, 4});
       CHECK(sgs[1].getBonds() == std::vector<unsigned int>{2, 4});
       CHECK(sgs[1].getProp<std::vector<unsigned int>>("XBCORR") ==
@@ -1152,6 +1162,8 @@ TEST_CASE("polymer SGroups") {
             std::vector<unsigned int>{2});
       CHECK(sgs[1].getProp<std::string>("TYPE") == "ANY");
       CHECK(sgs[1].getProp<std::string>("CONNECT") == "HH");
+      CHECK(sgs[1].getProp<unsigned int>("index") == 2);
+
       auto smi = MolToCXSmiles(*mol);
       CHECK(smi ==
             "*NCCO* |$star_e;;;;;star_e$,,,Sg:n:1,2::ht:::,Sg:any:3,4::hh:::|");
@@ -1169,6 +1181,8 @@ TEST_CASE("polymer SGroups") {
       CHECK(sgs[0].getProp<std::string>("FIELDNAME") == "atomdata");
       CHECK(sgs[0].getProp<std::vector<std::string>>("DATAFIELDS") ==
             std::vector<std::string>{"val"});
+      CHECK(sgs[0].getProp<unsigned int>("index") == 1);
+
       CHECK(sgs[1].getAtoms() == std::vector<unsigned int>{2, 3});
       CHECK(sgs[1].getBonds() == std::vector<unsigned int>{1, 3});
       CHECK(sgs[1].getProp<std::vector<unsigned int>>("XBCORR") ==
@@ -1177,6 +1191,8 @@ TEST_CASE("polymer SGroups") {
             std::vector<unsigned int>{1});
       CHECK(sgs[1].getProp<std::string>("TYPE") == "SRU");
       CHECK(sgs[1].getProp<std::string>("CONNECT") == "HT");
+      CHECK(sgs[1].getProp<unsigned int>("index") == 2);
+
       CHECK(sgs[2].getAtoms() == std::vector<unsigned int>{4, 5});
       CHECK(sgs[2].getBonds() == std::vector<unsigned int>{3, 5});
       CHECK(sgs[2].getProp<std::vector<unsigned int>>("XBCORR") ==
@@ -1185,6 +1201,8 @@ TEST_CASE("polymer SGroups") {
             std::vector<unsigned int>{3});
       CHECK(sgs[2].getProp<std::string>("TYPE") == "ANY");
       CHECK(sgs[2].getProp<std::string>("CONNECT") == "HH");
+      CHECK(sgs[2].getProp<unsigned int>("index") == 3);
+
       auto smi = MolToCXSmiles(*mol);
       CHECK(smi ==
             "*OCCNCC "
@@ -1194,17 +1212,51 @@ TEST_CASE("polymer SGroups") {
   }
 }
 
-// TEST_CASE("SGroup hierarchy") {
-//   SECTION("basics") {
-//     auto mol =
-//         "*-CNC(C-*)O-* "
-//         "|$star_e;;;;;star_e;;star_e$,Sg:any:2,1::ht,Sg:any:4,3,2,1,0,6::ht,"
-//         "SgH:1:0|"_smiles;
-//     REQUIRE(mol);
-//     const auto &sgs = getSubstanceGroups(*mol);
-//     REQUIRE(sgs.size() == 2);
-//   }
-// }
+TEST_CASE("SGroup hierarchy") {
+  SECTION("basics") {
+    auto mol =
+        "*-CNC(C-*)O-* "
+        "|$star_e;;;;;star_e;;star_e$,Sg:any:2,1::ht,Sg:any:4,3,2,1,0,6::ht,"
+        "SgH:1:0|"_smiles;
+    REQUIRE(mol);
+    const auto &sgs = getSubstanceGroups(*mol);
+    REQUIRE(sgs.size() == 2);
+    CHECK(sgs[0].getAtoms() == std::vector<unsigned int>{2, 1});
+    CHECK(sgs[0].getProp<std::string>("TYPE") == "ANY");
+    CHECK(sgs[0].getProp<unsigned int>("PARENT") == 2);
+    CHECK(sgs[0].getProp<unsigned int>("index") == 1);
+    CHECK(sgs[1].getAtoms() == std::vector<unsigned int>{4, 3, 2, 1, 0, 6});
+    CHECK(sgs[1].getProp<std::string>("TYPE") == "ANY");
+    CHECK(sgs[1].getProp<unsigned int>("index") == 2);
+    CHECK(!sgs[1].hasProp("PARENT"));
+    CHECK(MolToCXSmiles(*mol) ==
+          "*CNC(C*)O* "
+          "|$star_e;;;;;star_e;;star_e$,,,Sg:any:2,1::ht:::,Sg:any:4,3,2,1,0,6:"
+          ":ht:::,SgH:1:0|");
+  }
+
+  SECTION("nested") {
+    auto mol =
+        "*-CNC(CC(-*)C-*)O-* "
+        "|$star_e;;;;;;star_e;;star_e;;star_e$,"
+        "SgD:4:internal data:val::::,SgD:7:atom value:value2::::,"
+        "Sg:n:7::ht,Sg:n:2::ht,Sg:any:5,7,8,4,3,2,1,0,9::ht,"
+        "SgH:4:2.3.0,2:1|"_smiles;
+    REQUIRE(mol);
+    const auto &sgs = getSubstanceGroups(*mol);
+    REQUIRE(sgs.size() == 5);
+    CHECK(sgs[0].getProp<unsigned int>("PARENT") == 5);
+    CHECK(sgs[2].getProp<unsigned int>("PARENT") == 5);
+    CHECK(sgs[3].getProp<unsigned int>("PARENT") == 5);
+    CHECK(sgs[1].getProp<unsigned int>("PARENT") == 3);
+    CHECK(
+        MolToCXSmiles(*mol) ==
+        "*CNC(CC(*)C*)O* |$star_e;;;;;;star_e;;star_e;;star_e$,SgD:4:internal "
+        "data:val::::,SgD:7:atom "
+        "value:value2::::,,,,,,Sg:n:7::ht:::,Sg:n:2::ht:::,Sg:any:5,7,8,4,3,2,"
+        "1,0,9::ht:::,SgH:2:1,4:0.2.3|");
+  }
+}
 
 TEST_CASE("smilesBondOutputOrder") {
   SECTION("basics") {

--- a/Code/GraphMol/SmilesParse/catch_tests.cpp
+++ b/Code/GraphMol/SmilesParse/catch_tests.cpp
@@ -1258,6 +1258,30 @@ TEST_CASE("SGroup hierarchy") {
   }
 }
 
+TEST_CASE("Linknode writing") {
+  SECTION("single") {
+    auto mol = "OC1CCC(F)C1 |LN:1:1.3.2.6|"_smiles;
+    REQUIRE(mol);
+    std::string lns;
+    CHECK(mol->getPropIfPresent(common_properties::molFileLinkNodes, lns));
+    CHECK(lns == "1 3 2 2 3 2 7");
+    CHECK(MolToCXSmiles(*mol) == "OC1CCC(F)C1 |LN:1:1.3.2.6|");
+  }
+  SECTION("multiple") {
+    auto mol = "FC1CCC(O)C1 |LN:1:1.3.2.6,4:1.4.3.6|"_smiles;
+    REQUIRE(mol);
+    std::string lns;
+    CHECK(mol->getPropIfPresent(common_properties::molFileLinkNodes, lns));
+    CHECK(lns == "1 3 2 2 3 2 7|1 4 2 5 4 5 7");
+    CHECK(MolToCXSmiles(*mol) == "OC1CCC(F)C1 |LN:4:1.3.3.6,1:1.4.2.6|");
+  }
+  SECTION("two-coordinate") {
+    auto mol = "C1OCCC1C |LN:0:1.5,1:1.3|"_smiles;
+    REQUIRE(mol);
+    CHECK(MolToCXSmiles(*mol) == "CC1CCOC1 |LN:5:1.5,4:1.3|");
+  }
+}
+
 TEST_CASE("smilesBondOutputOrder") {
   SECTION("basics") {
     auto m = "OCCN.CCO"_smiles;

--- a/Code/GraphMol/SmilesParse/catch_tests.cpp
+++ b/Code/GraphMol/SmilesParse/catch_tests.cpp
@@ -1058,6 +1058,10 @@ TEST_CASE("polymer SGroups") {
             std::vector<unsigned int>{6, 4, 0, 2});
       CHECK(sgs[0].getProp<std::string>("TYPE") == "SRU");
       CHECK(sgs[0].getProp<std::string>("CONNECT") == "HT");
+      auto smi = MolToCXSmiles(*mol);
+      CHECK(smi ==
+            "*CC(*)C(*)N* "
+            "|$star_e;;;star_e;;star_e;;star_e$,Sg:n:6,1,2,4::ht:6,0:4,2:|");
       // auto mb = MolToV3KMolBlock(*mol);
       // std::cerr << mb << std::endl;
     }
@@ -1075,6 +1079,10 @@ TEST_CASE("polymer SGroups") {
             std::vector<unsigned int>{6, 2, 0, 4});
       CHECK(sgs[0].getProp<std::string>("TYPE") == "SRU");
       CHECK(sgs[0].getProp<std::string>("CONNECT") == "HH");
+      auto smi = MolToCXSmiles(*mol);
+      CHECK(smi ==
+            "*CC(*)C(*)N* "
+            "|$star_e;;;star_e;;star_e;;star_e$,Sg:n:6,1,2,4::hh:6,0:2,4:|");
     }
     {  // minimal
       auto mol = "*-CCO-* |$star_e;;;;star_e$,Sg:n:1,2,3|"_smiles;
@@ -1089,6 +1097,8 @@ TEST_CASE("polymer SGroups") {
       CHECK(sgs[0].getProp<std::vector<unsigned int>>("XBHEAD") == bonds);
       CHECK(sgs[0].getProp<std::string>("TYPE") == "SRU");
       CHECK(sgs[0].getProp<std::string>("CONNECT") == "EU");
+      auto smi = MolToCXSmiles(*mol);
+      CHECK(smi == "*CCO* |$star_e;;;;star_e$,Sg:n:1,2,3::eu:::|");
     }
     {  // single atom
       auto mol = "*-C-* |$star_e;;star_e$,Sg:n:1::ht|"_smiles;
@@ -1103,6 +1113,8 @@ TEST_CASE("polymer SGroups") {
       CHECK(sgs[0].getProp<std::vector<unsigned int>>("XBHEAD") == bonds);
       CHECK(sgs[0].getProp<std::string>("TYPE") == "SRU");
       CHECK(sgs[0].getProp<std::string>("CONNECT") == "HT");
+      auto smi = MolToCXSmiles(*mol);
+      CHECK(smi == "*C* |$star_e;;star_e$,Sg:n:1::ht:::|");
     }
   }
 }

--- a/Code/GraphMol/SmilesParse/catch_tests.cpp
+++ b/Code/GraphMol/SmilesParse/catch_tests.cpp
@@ -999,6 +999,18 @@ TEST_CASE("Github #4233: data groups in CXSMILES neither parsed nor written") {
       CHECK(MolToCXSmiles(*mol) ==
             "C/C=C/C |SgD:2,1:FIELD:foo:like:info:tag:|");
     }
+    {  // data on a dummy atom
+      auto mol = "CC-* |$;;star_e$,SgD:2:querydata:val::::|"_smiles;
+      REQUIRE(mol);
+      const auto &sgs = getSubstanceGroups(*mol);
+      REQUIRE(sgs.size() == 1);
+      CHECK(sgs[0].getAtoms().size() == 1);
+      CHECK(sgs[0].getAtoms()[0] == 2);
+      CHECK(sgs[0].getProp<std::string>("TYPE") == "DAT");
+      CHECK(sgs[0].getProp<std::vector<std::string>>("DATAFIELDS") ==
+            std::vector<std::string>{"val"});
+      CHECK(MolToCXSmiles(*mol) == "*CC |$star_e;;$,SgD:0:querydata:val::::|");
+    }
     {
       auto mol =
           "C1=CC=C(C=C1)C1=CC=CC=C1 |c:0,2,4,9,11,t:7,SgD:8,9,11,10,7,6:PieceName:Ring1::::,SgD:1,2,3,4,5,0:PieceName:Ring2::::|"_smiles;

--- a/Code/GraphMol/SmilesParse/catch_tests.cpp
+++ b/Code/GraphMol/SmilesParse/catch_tests.cpp
@@ -1129,7 +1129,82 @@ TEST_CASE("polymer SGroups") {
       CHECK(smi == "*C* |$star_e;;star_e$,Sg:n:1::ht:::|");
     }
   }
+  SECTION("multiple s groups") {
+    {
+      auto mol =
+          "*-NCCO-* |$star_e;;;;;star_e$,Sg:n:1,2::ht,Sg:any:3,4::hh|"_smiles;
+      REQUIRE(mol);
+      const auto &sgs = getSubstanceGroups(*mol);
+      REQUIRE(sgs.size() == 2);
+      CHECK(sgs[0].getAtoms() == std::vector<unsigned int>{1, 2});
+      CHECK(sgs[0].getBonds() == std::vector<unsigned int>{0, 2});
+      CHECK(sgs[0].getProp<std::vector<unsigned int>>("XBCORR") ==
+            sgs[0].getBonds());
+      CHECK(sgs[0].getProp<std::vector<unsigned int>>("XBHEAD") ==
+            std::vector<unsigned int>{0});
+      CHECK(sgs[0].getProp<std::string>("TYPE") == "SRU");
+      CHECK(sgs[0].getProp<std::string>("CONNECT") == "HT");
+      CHECK(sgs[1].getAtoms() == std::vector<unsigned int>{3, 4});
+      CHECK(sgs[1].getBonds() == std::vector<unsigned int>{2, 4});
+      CHECK(sgs[1].getProp<std::vector<unsigned int>>("XBCORR") ==
+            sgs[1].getBonds());
+      CHECK(sgs[1].getProp<std::vector<unsigned int>>("XBHEAD") ==
+            std::vector<unsigned int>{2});
+      CHECK(sgs[1].getProp<std::string>("TYPE") == "ANY");
+      CHECK(sgs[1].getProp<std::string>("CONNECT") == "HH");
+      auto smi = MolToCXSmiles(*mol);
+      CHECK(smi ==
+            "*NCCO* |$star_e;;;;;star_e$,,,Sg:n:1,2::ht:::,Sg:any:3,4::hh:::|");
+    }
+
+    {  // multiple s groups + data
+      auto mol =
+          "CCNCCO-* "
+          "|$;;;;;;star_e$,SgD:1:atomdata:val::::,Sg:n:2,3::ht,Sg:any:4,5::hh|"_smiles;
+      REQUIRE(mol);
+      const auto &sgs = getSubstanceGroups(*mol);
+      REQUIRE(sgs.size() == 3);
+      CHECK(sgs[0].getAtoms() == std::vector<unsigned int>{1});
+      CHECK(sgs[0].getProp<std::string>("TYPE") == "DAT");
+      CHECK(sgs[0].getProp<std::string>("FIELDNAME") == "atomdata");
+      CHECK(sgs[0].getProp<std::vector<std::string>>("DATAFIELDS") ==
+            std::vector<std::string>{"val"});
+      CHECK(sgs[1].getAtoms() == std::vector<unsigned int>{2, 3});
+      CHECK(sgs[1].getBonds() == std::vector<unsigned int>{1, 3});
+      CHECK(sgs[1].getProp<std::vector<unsigned int>>("XBCORR") ==
+            sgs[1].getBonds());
+      CHECK(sgs[1].getProp<std::vector<unsigned int>>("XBHEAD") ==
+            std::vector<unsigned int>{1});
+      CHECK(sgs[1].getProp<std::string>("TYPE") == "SRU");
+      CHECK(sgs[1].getProp<std::string>("CONNECT") == "HT");
+      CHECK(sgs[2].getAtoms() == std::vector<unsigned int>{4, 5});
+      CHECK(sgs[2].getBonds() == std::vector<unsigned int>{3, 5});
+      CHECK(sgs[2].getProp<std::vector<unsigned int>>("XBCORR") ==
+            sgs[2].getBonds());
+      CHECK(sgs[2].getProp<std::vector<unsigned int>>("XBHEAD") ==
+            std::vector<unsigned int>{3});
+      CHECK(sgs[2].getProp<std::string>("TYPE") == "ANY");
+      CHECK(sgs[2].getProp<std::string>("CONNECT") == "HH");
+      auto smi = MolToCXSmiles(*mol);
+      CHECK(smi ==
+            "*OCCNCC "
+            "|$star_e;;;;;;$,SgD:5:atomdata:val::::,,,,Sg:n:4,3::ht:::,Sg:any:"
+            "2,1::hh:::|");
+    }
+  }
 }
+
+// TEST_CASE("SGroup hierarchy") {
+//   SECTION("basics") {
+//     auto mol =
+//         "*-CNC(C-*)O-* "
+//         "|$star_e;;;;;star_e;;star_e$,Sg:any:2,1::ht,Sg:any:4,3,2,1,0,6::ht,"
+//         "SgH:1:0|"_smiles;
+//     REQUIRE(mol);
+//     const auto &sgs = getSubstanceGroups(*mol);
+//     REQUIRE(sgs.size() == 2);
+//   }
+// }
 
 TEST_CASE("smilesBondOutputOrder") {
   SECTION("basics") {

--- a/Code/GraphMol/SmilesParse/catch_tests.cpp
+++ b/Code/GraphMol/SmilesParse/catch_tests.cpp
@@ -1041,3 +1041,27 @@ TEST_CASE("Github #4233: data groups in CXSMILES neither parsed nor written") {
     }
   }
 }
+
+TEST_CASE("polymer SGroups") {
+  SECTION("basics") {
+    {
+      auto mol =
+          "*CC(*)C(*)N* |$star_e;;;star_e;;star_e;;star_e$,Sg:n:6,1,2,4::hh&#44;f:6,0,:4,2,|"_smiles;
+      REQUIRE(mol);
+      const auto &sgs = getSubstanceGroups(*mol);
+      REQUIRE(sgs.size() == 1);
+      CHECK(sgs[0].getAtoms() == std::vector<unsigned int>{6, 1, 2, 4});
+      CHECK(sgs[0].getProp<std::string>("TYPE") == "SRU");
+      // CHECK(MolToCXSmiles(*mol) == "C/C=C/C |SgD:2,1:FIELD:info::::|");
+    }
+    {  // minimal
+      auto mol = "*-CCCN-* |$star_e;;;;;star_e$,Sg:n:4,1,2,3|"_smiles;
+      REQUIRE(mol);
+      const auto &sgs = getSubstanceGroups(*mol);
+      REQUIRE(sgs.size() == 1);
+      CHECK(sgs[0].getAtoms() == std::vector<unsigned int>{4, 1, 2, 3});
+      CHECK(sgs[0].getProp<std::string>("TYPE") == "SRU");
+      // CHECK(MolToCXSmiles(*mol) == "C/C=C/C |SgD:2,1:FIELD:info::::|");
+    }
+  }
+}

--- a/Code/GraphMol/SmilesParse/catch_tests.cpp
+++ b/Code/GraphMol/SmilesParse/catch_tests.cpp
@@ -1058,8 +1058,8 @@ TEST_CASE("polymer SGroups") {
             std::vector<unsigned int>{6, 4, 0, 2});
       CHECK(sgs[0].getProp<std::string>("TYPE") == "SRU");
       CHECK(sgs[0].getProp<std::string>("CONNECT") == "HT");
-      auto mb = MolToV3KMolBlock(*mol);
-      std::cerr << mb << std::endl;
+      // auto mb = MolToV3KMolBlock(*mol);
+      // std::cerr << mb << std::endl;
     }
     {
       auto mol =
@@ -1104,5 +1104,18 @@ TEST_CASE("polymer SGroups") {
       CHECK(sgs[0].getProp<std::string>("TYPE") == "SRU");
       CHECK(sgs[0].getProp<std::string>("CONNECT") == "HT");
     }
+  }
+}
+
+TEST_CASE("smilesBondOutputOrder") {
+  SECTION("basics") {
+    auto m = "OCCN.CCO"_smiles;
+    REQUIRE(m);
+    CHECK(MolToSmiles(*m) == "CCO.NCCO");
+    std::vector<unsigned int> order;
+    m->getProp(common_properties::_smilesAtomOutputOrder, order);
+    CHECK(order == std::vector<unsigned int>{4, 5, 6, 3, 2, 1, 0});
+    m->getProp(common_properties::_smilesBondOutputOrder, order);
+    CHECK(order == std::vector<unsigned int>{3, 4, 2, 1, 0});
   }
 }

--- a/Code/GraphMol/SmilesParse/catch_tests.cpp
+++ b/Code/GraphMol/SmilesParse/catch_tests.cpp
@@ -1046,22 +1046,63 @@ TEST_CASE("polymer SGroups") {
   SECTION("basics") {
     {
       auto mol =
+          "*CC(*)C(*)N* |$star_e;;;star_e;;star_e;;star_e$,Sg:n:6,1,2,4::ht:6,0,:4,2,|"_smiles;
+      REQUIRE(mol);
+      const auto &sgs = getSubstanceGroups(*mol);
+      REQUIRE(sgs.size() == 1);
+      CHECK(sgs[0].getAtoms() == std::vector<unsigned int>{6, 1, 2, 4});
+      CHECK(sgs[0].getBonds() == std::vector<unsigned int>{6, 0, 4, 2});
+      CHECK(sgs[0].getProp<std::vector<unsigned int>>("XBHEAD") ==
+            std::vector<unsigned int>{6, 0});
+      CHECK(sgs[0].getProp<std::vector<unsigned int>>("XBCORR") ==
+            std::vector<unsigned int>{6, 4, 0, 2});
+      CHECK(sgs[0].getProp<std::string>("TYPE") == "SRU");
+      CHECK(sgs[0].getProp<std::string>("CONNECT") == "HT");
+      auto mb = MolToV3KMolBlock(*mol);
+      std::cerr << mb << std::endl;
+    }
+    {
+      auto mol =
           "*CC(*)C(*)N* |$star_e;;;star_e;;star_e;;star_e$,Sg:n:6,1,2,4::hh&#44;f:6,0,:4,2,|"_smiles;
       REQUIRE(mol);
       const auto &sgs = getSubstanceGroups(*mol);
       REQUIRE(sgs.size() == 1);
       CHECK(sgs[0].getAtoms() == std::vector<unsigned int>{6, 1, 2, 4});
+      CHECK(sgs[0].getBonds() == std::vector<unsigned int>{6, 0, 4, 2});
+      CHECK(sgs[0].getProp<std::vector<unsigned int>>("XBHEAD") ==
+            std::vector<unsigned int>{6, 0});
+      CHECK(sgs[0].getProp<std::vector<unsigned int>>("XBCORR") ==
+            std::vector<unsigned int>{6, 2, 0, 4});
       CHECK(sgs[0].getProp<std::string>("TYPE") == "SRU");
-      // CHECK(MolToCXSmiles(*mol) == "C/C=C/C |SgD:2,1:FIELD:info::::|");
+      CHECK(sgs[0].getProp<std::string>("CONNECT") == "HH");
     }
     {  // minimal
-      auto mol = "*-CCCN-* |$star_e;;;;;star_e$,Sg:n:4,1,2,3|"_smiles;
+      auto mol = "*-CCO-* |$star_e;;;;star_e$,Sg:n:1,2,3|"_smiles;
       REQUIRE(mol);
       const auto &sgs = getSubstanceGroups(*mol);
       REQUIRE(sgs.size() == 1);
-      CHECK(sgs[0].getAtoms() == std::vector<unsigned int>{4, 1, 2, 3});
+      CHECK(sgs[0].getAtoms() == std::vector<unsigned int>{1, 2, 3});
+      std::vector<unsigned int> bonds = {0, 3};
+      CHECK(sgs[0].getBonds() == bonds);
+      CHECK(sgs[0].getProp<std::vector<unsigned int>>("XBCORR") == bonds);
+      bonds = {0};
+      CHECK(sgs[0].getProp<std::vector<unsigned int>>("XBHEAD") == bonds);
       CHECK(sgs[0].getProp<std::string>("TYPE") == "SRU");
-      // CHECK(MolToCXSmiles(*mol) == "C/C=C/C |SgD:2,1:FIELD:info::::|");
+      CHECK(sgs[0].getProp<std::string>("CONNECT") == "EU");
+    }
+    {  // single atom
+      auto mol = "*-C-* |$star_e;;star_e$,Sg:n:1::ht|"_smiles;
+      REQUIRE(mol);
+      const auto &sgs = getSubstanceGroups(*mol);
+      REQUIRE(sgs.size() == 1);
+      CHECK(sgs[0].getAtoms() == std::vector<unsigned int>{1});
+      std::vector<unsigned int> bonds = {0, 1};
+      CHECK(sgs[0].getBonds() == bonds);
+      CHECK(sgs[0].getProp<std::vector<unsigned int>>("XBCORR") == bonds);
+      bonds = {0};
+      CHECK(sgs[0].getProp<std::vector<unsigned int>>("XBHEAD") == bonds);
+      CHECK(sgs[0].getProp<std::string>("TYPE") == "SRU");
+      CHECK(sgs[0].getProp<std::string>("CONNECT") == "HT");
     }
   }
 }

--- a/Code/RDGeneral/types.cpp
+++ b/Code/RDGeneral/types.cpp
@@ -1,5 +1,5 @@
 //
-//  Copyright 2001-2018 Greg Landrum and Rational Discovery LLC
+//  Copyright 2001-2021 Greg Landrum and other RDKit contributors
 //
 //  @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -86,6 +86,7 @@ const std::string _ringStereoAtoms = "_ringStereoAtoms";
 const std::string _ringStereoWarning = "_ringStereoWarning";
 const std::string _ringStereochemCand = "_ringStereochemCand";
 const std::string _smilesAtomOutputOrder = "_smilesAtomOutputOrder";
+const std::string _smilesBondOutputOrder = "_smilesBondOutputOrder";
 const std::string _starred = "_starred";
 const std::string _supplementalSmilesLabel = "_supplementalSmilesLabel";
 const std::string _tpsa = "_tpsa";

--- a/Code/RDGeneral/types.h
+++ b/Code/RDGeneral/types.h
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2001-2018 Greg Landrum and Rational Discovery LLC
+//  Copyright 2001-2021 Greg Landrum and other RDKit contributors
 //
 //  @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -64,6 +64,8 @@ RDKIT_RDGENERAL_EXPORT extern const std::string
 RDKIT_RDGENERAL_EXPORT extern const std::string extraRings;  // vec<vec<int> >
 RDKIT_RDGENERAL_EXPORT extern const std::string
     _smilesAtomOutputOrder;  // vec<int> computed
+RDKIT_RDGENERAL_EXPORT extern const std::string
+    _smilesBondOutputOrder;  // vec<int> computed
 RDKIT_RDGENERAL_EXPORT extern const std::string _StereochemDone;  // int
 RDKIT_RDGENERAL_EXPORT extern const std::string _NeedsQueryScan;  // int (bool)
 RDKIT_RDGENERAL_EXPORT extern const std::string _fragSMARTS;      // std::string

--- a/Docs/Book/RDKit_Book.rst
+++ b/Docs/Book/RDKit_Book.rst
@@ -246,6 +246,7 @@ The features which are parsed include:
 - unsaturation specification ``u``
 - SGroup Data ``SgD``
 - polymer SGroups ``Sg``
+- SGroup Hierarchy ``SgH``
 
 The features which are written by :py:func:`rdkit.Chem.rdmolfiles.MolToCXSmiles` and
 :py:func:`rdkit.Chem.rdmolfiles.MolToCXSmarts` 
@@ -259,6 +260,7 @@ The features which are written by :py:func:`rdkit.Chem.rdmolfiles.MolToCXSmiles`
 - enhanced stereo
 - SGroup Data ``SgD``
 - polymer SGroups ``Sg``
+- SGroup Hierarchy ``SgH``
 
 .. doctest::
 

--- a/Docs/Book/RDKit_Book.rst
+++ b/Docs/Book/RDKit_Book.rst
@@ -244,6 +244,7 @@ The features which are parsed include:
 - ring bond count specifications ``rb``
 - non-hydrogen substitution count specifications ``s``
 - unsaturation specification ``u``
+- SGroup Data ``SgD``
 
 The features which are written by :py:func:`rdkit.Chem.rdmolfiles.MolToCXSmiles` and
 :py:func:`rdkit.Chem.rdmolfiles.MolToCXSmarts` 

--- a/Docs/Book/RDKit_Book.rst
+++ b/Docs/Book/RDKit_Book.rst
@@ -258,9 +258,10 @@ The features which are written by :py:func:`rdkit.Chem.rdmolfiles.MolToCXSmiles`
 - atomic properties
 - radicals
 - enhanced stereo
-- SGroup Data ``SgD``
-- polymer SGroups ``Sg``
-- SGroup Hierarchy ``SgH``
+- linknodes 
+- SGroup Data
+- polymer SGroups
+- SGroup Hierarchy
 
 .. doctest::
 

--- a/Docs/Book/RDKit_Book.rst
+++ b/Docs/Book/RDKit_Book.rst
@@ -256,6 +256,7 @@ The features which are written by :py:func:`rdkit.Chem.rdmolfiles.MolToCXSmiles`
 - atomic properties
 - radicals
 - enhanced stereo
+- SGroup Data ``SgD``
 
 .. doctest::
 

--- a/Docs/Book/RDKit_Book.rst
+++ b/Docs/Book/RDKit_Book.rst
@@ -1199,6 +1199,8 @@ ROMol  (Mol in Python)
 +------------------------+---------------------------------------------------+
 | _smilesAtomOutputOrder |   The order in which atoms were written to SMILES |
 +------------------------+---------------------------------------------------+
+| _smilesBondOutputOrder |   The order in which bonds were written to SMILES |
++------------------------+---------------------------------------------------+
 
 Atom
 ----

--- a/Docs/Book/RDKit_Book.rst
+++ b/Docs/Book/RDKit_Book.rst
@@ -245,6 +245,7 @@ The features which are parsed include:
 - non-hydrogen substitution count specifications ``s``
 - unsaturation specification ``u``
 - SGroup Data ``SgD``
+- polymer SGroups ``Sg``
 
 The features which are written by :py:func:`rdkit.Chem.rdmolfiles.MolToCXSmiles` and
 :py:func:`rdkit.Chem.rdmolfiles.MolToCXSmarts` 
@@ -257,6 +258,7 @@ The features which are written by :py:func:`rdkit.Chem.rdmolfiles.MolToCXSmiles`
 - radicals
 - enhanced stereo
 - SGroup Data ``SgD``
+- polymer SGroups ``Sg``
 
 .. doctest::
 


### PR DESCRIPTION
This is a another collection of improvements to reading/writing of CXSMILES, along with a couple of other small connected changes. Since the "CXSMARTS" support uses the same code as CXSMILES this affects that as well.

Changes here:
- generating SMILES or SMARTS for a molecule will now add a property `_smilesBondOutputOrder` which includes the order in which the molecule's bonds were written to the SMILES or SMARTS. This is directly analagous to the `_smilesAtomOutputOrder` property, which has been around forever.
- Polymer SGroups can now be read from/written to CXSMILES. (This also fixes a bug where they caused the CXSMILES parser to fail)
- SGroup hierarchy can now be read from/written to CXSMILES. (This also fixes a bug where this caused the CXSMILES parser to fail)
- Link nodes can now be written to CXSMILES. They were parsed before but not written
