### PR TITLE
Fixes #4410

### DIFF
--- a/Code/GraphMol/ChemReactions/ReactionRunner.cpp
+++ b/Code/GraphMol/ChemReactions/ReactionRunner.cpp
@@ -607,7 +607,16 @@ void translateProductStereoBondDirections(Bond *pBond, const Bond *start,
 
   pBond->setStereoAtoms(pStartAnchorIdx, pEndAnchorIdx);
 
-  if (start->getBondDir() == end->getBondDir()) {
+  bool sameDir = start->getBondDir() == end->getBondDir();
+
+  if (start->getBeginAtom() == pBond->getBeginAtom()) {
+    sameDir = !sameDir;
+  }
+  if (end->getBeginAtom() != pBond->getEndAtom()) {
+    sameDir = !sameDir;
+  }
+
+  if (sameDir) {
     pBond->setStereo(Bond::BondStereo::STEREOTRANS);
   } else {
     pBond->setStereo(Bond::BondStereo::STEREOCIS);

--- a/Code/GraphMol/ChemReactions/testReaction.cpp
+++ b/Code/GraphMol/ChemReactions/testReaction.cpp
@@ -7608,9 +7608,10 @@ void testGithub4114() {
 
 void testGithub4183() {
   BOOST_LOG(rdInfoLog) << "-------------------------------------" << std::endl;
-  BOOST_LOG(rdInfoLog) << "Testing Github #4183: Reading a rxn file in v3000 format that contains agents"
+  BOOST_LOG(rdInfoLog) << "Testing Github #4183: Reading a rxn file in v3000 "
+                          "format that contains agents"
                        << std::endl;
-  
+
   std::string rdbase = getenv("RDBASE");
   std::string fName;
   fName = rdbase + "/Code/GraphMol/ChemReactions/testData/v3k_with_agents.rxn";
@@ -7622,6 +7623,29 @@ void testGithub4183() {
   TEST_ASSERT(rxn->getNumAgentTemplates() == 3);
 
   delete rxn;
+}
+
+void testGithub4410() {
+  BOOST_LOG(rdInfoLog) << "--------------------------------------" << std::endl;
+  BOOST_LOG(rdInfoLog) << "Github #4410: wrong double bond stereochemistry"
+                       << std::endl;
+
+  const std::string reaction(
+      R"([N:4][C:6](/[Cl:9])=[C:7](\[Cl:10])[C:11]>>[Br:4][CX3:6](\[Cl:9])=[CX3:7](/[Cl:10])[C:11])");
+  std::unique_ptr<ChemicalReaction> rxn(RxnSmartsToChemicalReaction(reaction));
+  TEST_ASSERT(rxn);
+  rxn->initReactantMatchers();
+
+  std::vector<ROMOL_SPTR> mol{R"(C\C(Cl)=C(\N)Cl)"_smiles};
+  auto prods = rxn->runReactants(mol);
+  TEST_ASSERT(prods.size() == 1);
+  TEST_ASSERT(prods[0].size() == 1);
+
+  auto dblBnd = prods[0][0]->getBondBetweenAtoms(1, 3);
+
+  TEST_ASSERT(dblBnd->getBondType() == Bond::DOUBLE);
+  TEST_ASSERT(dblBnd->getStereoAtoms() == std::vector<int>({2, 4}));
+  TEST_ASSERT(dblBnd->getStereo() == Bond::STEREOTRANS);
 }
 
 int main() {
@@ -7720,7 +7744,8 @@ int main() {
   testGithub4162();
   testGithub4114();
   testGithub4183();
-  
+  testGithub4410();
+
   BOOST_LOG(rdInfoLog)
       << "*******************************************************\n";
   return (0);

--- a/Code/GraphMol/ChemReactions/testReaction.cpp
+++ b/Code/GraphMol/ChemReactions/testReaction.cpp
@@ -7646,6 +7646,8 @@ void testGithub4410() {
   TEST_ASSERT(dblBnd->getBondType() == Bond::DOUBLE);
   TEST_ASSERT(dblBnd->getStereoAtoms() == std::vector<int>({2, 4}));
   TEST_ASSERT(dblBnd->getStereo() == Bond::STEREOTRANS);
+
+  TEST_ASSERT(MolToSmiles(*prods[0][0]) == R"(C/C(Cl)=C(\Cl)Br)");
 }
 
 int main() {


### PR DESCRIPTION
Fixes #4410

A simple fix for a silly mistake: in the reaction code, the part that calculates stereochemistry from product bond directions did not consider the possibility of reversed bonds, which effectively "flips" the direction.

This had been hidden from some time, until the stereo refactoring in 19bdd21de1c90f01f630b28ff72b3af9176d886f started recalculating bond directions even for bonds that already had them.