### PR TITLE
Addresses #4425

### DIFF
--- a/Code/GraphMol/Abbreviations/Wrap/rdAbbreviations.cpp
+++ b/Code/GraphMol/Abbreviations/Wrap/rdAbbreviations.cpp
@@ -9,7 +9,6 @@
 //
 
 #include <RDBoost/python.h>
-#include <boost/python/suite/indexing/vector_indexing_suite.hpp>
 #include <GraphMol/GraphMol.h>
 #include <RDBoost/Wrap.h>
 
@@ -84,7 +83,8 @@ BOOST_PYTHON_MODULE(rdAbbreviations) {
       (python::arg("mol"), python::arg("abbrevs"),
        python::arg("maxCoverage") = 0.4, python::arg("sanitize") = true),
       python::return_value_policy<python::manage_new_object>(),
-      "Finds and replaces abbreviations in a molecule. The result is not sanitized.");
+      "Finds and replaces abbreviations in a molecule. The result is not "
+      "sanitized.");
   python::def("LabelMolAbbreviations", &labelMolAbbreviationsHelper,
               (python::arg("mol"), python::arg("abbrevs"),
                python::arg("maxCoverage") = 0.4),

--- a/Code/GraphMol/ChemReactions/Wrap/Enumerate.cpp
+++ b/Code/GraphMol/ChemReactions/Wrap/Enumerate.cpp
@@ -14,7 +14,8 @@
 //       with the distribution.
 //     * Neither the name of Novartis Institutues for BioMedical Research Inc.
 //       nor the names of its contributors may be used to endorse or promote
-//       products derived from this software without specific prior written permission.
+//       products derived from this software without specific prior written
+//       permission.
 //
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
@@ -39,19 +40,18 @@
 
 namespace python = boost::python;
 
-
 namespace RDKit {
 
-template<class T>
+template <class T>
 std::vector<RDKit::MOL_SPTR_VECT> ConvertToVect(T bbs) {
   std::vector<RDKit::MOL_SPTR_VECT> vect;
   size_t num_bbs = python::extract<unsigned int>(bbs.attr("__len__")());
   vect.resize(num_bbs);
-  for(size_t i=0; i<num_bbs; ++i) {
+  for (size_t i = 0; i < num_bbs; ++i) {
     unsigned int len1 = python::extract<unsigned int>(bbs[i].attr("__len__")());
     RDKit::MOL_SPTR_VECT &reacts = vect[i];
     reacts.reserve(len1);
-    for(unsigned int j=0;j<len1;++j){
+    for (unsigned int j = 0; j < len1; ++j) {
       RDKit::ROMOL_SPTR mol = python::extract<RDKit::ROMOL_SPTR>(bbs[i][j]);
       if (mol) {
         reacts.push_back(mol);
@@ -63,7 +63,6 @@ std::vector<RDKit::MOL_SPTR_VECT> ConvertToVect(T bbs) {
   return vect;
 }
 
-
 bool EnumerateLibraryBase__nonzero__(RDKit::EnumerateLibraryBase *base) {
   return static_cast<bool>(*base);
 }
@@ -71,7 +70,7 @@ bool EnumerationStrategyBase__nonzero__(RDKit::EnumerationStrategyBase *base) {
   return static_cast<bool>(*base);
 }
 
-inline python::object pass_through(python::object const& o) { return o; }
+inline python::object pass_through(python::object const &o) { return o; }
 
 PyObject *EnumerateLibraryBase__next__(RDKit::EnumerateLibraryBase *base) {
   if (!static_cast<bool>(*base)) {
@@ -83,15 +82,15 @@ PyObject *EnumerateLibraryBase__next__(RDKit::EnumerateLibraryBase *base) {
     NOGIL gil;
     mols = base->next();
   }
-  PyObject *res=PyTuple_New(mols.size());
+  PyObject *res = PyTuple_New(mols.size());
 
-  for(unsigned int i=0;i<mols.size();++i){
-    PyObject *lTpl =PyTuple_New(mols[i].size());
-    for(unsigned int j=0;j<mols[i].size();++j){
-      PyTuple_SetItem(lTpl,j,
+  for (unsigned int i = 0; i < mols.size(); ++i) {
+    PyObject *lTpl = PyTuple_New(mols[i].size());
+    for (unsigned int j = 0; j < mols[i].size(); ++j) {
+      PyTuple_SetItem(lTpl, j,
                       python::converter::shared_ptr_to_python(mols[i][j]));
     }
-    PyTuple_SetItem(res,i,lTpl);
+    PyTuple_SetItem(res, i, lTpl);
   }
   return res;
 }
@@ -104,65 +103,48 @@ python::object EnumerateLibraryBase_Serialize(const EnumerateLibraryBase &en) {
 }
 
 class EnumerateLibraryWrap : public RDKit::EnumerateLibrary {
-public:
+ public:
   ~EnumerateLibraryWrap() override {}
   EnumerateLibraryWrap() : RDKit::EnumerateLibrary() {}
   EnumerateLibraryWrap(const RDKit::ChemicalReaction &rxn, python::list ob,
-                       const EnumerationParams & params = EnumerationParams()
-                       ) :
-      RDKit::EnumerateLibrary(rxn, ConvertToVect(ob), params) {
-  }
+                       const EnumerationParams &params = EnumerationParams())
+      : RDKit::EnumerateLibrary(rxn, ConvertToVect(ob), params) {}
 
   EnumerateLibraryWrap(const RDKit::ChemicalReaction &rxn, python::tuple ob,
-                       const EnumerationParams & params = EnumerationParams()
-                       ) :
-      RDKit::EnumerateLibrary(rxn, ConvertToVect(ob), params) {
-  }
+                       const EnumerationParams &params = EnumerationParams())
+      : RDKit::EnumerateLibrary(rxn, ConvertToVect(ob), params) {}
 
   EnumerateLibraryWrap(const RDKit::ChemicalReaction &rxn, python::list ob,
                        const EnumerationStrategyBase &enumerator,
-                       const EnumerationParams & params = EnumerationParams()
-                       ) :
-      RDKit::EnumerateLibrary(rxn, ConvertToVect(ob), enumerator, params) {
-  }
+                       const EnumerationParams &params = EnumerationParams())
+      : RDKit::EnumerateLibrary(rxn, ConvertToVect(ob), enumerator, params) {}
 
   EnumerateLibraryWrap(const RDKit::ChemicalReaction &rxn, python::tuple ob,
                        const EnumerationStrategyBase &enumerator,
-                       const EnumerationParams & params = EnumerationParams()) :
-      RDKit::EnumerateLibrary(rxn, ConvertToVect(ob), enumerator, params) {
-  }
-
+                       const EnumerationParams &params = EnumerationParams())
+      : RDKit::EnumerateLibrary(rxn, ConvertToVect(ob), enumerator, params) {}
 };
 
 namespace {
-  template< typename T >
-  inline
-  std::vector< T > to_std_vector( const python::object& iterable )
-  {
-    return std::vector< T >( python::stl_input_iterator< T >( iterable ),
-                             python::stl_input_iterator< T >( ) );
-  }
+template <typename T>
+inline std::vector<T> to_std_vector(const python::object &iterable) {
+  return std::vector<T>(python::stl_input_iterator<T>(iterable),
+                        python::stl_input_iterator<T>());
 }
+}  // namespace
 
-void ToBBS(EnumerationStrategyBase &rgroup, ChemicalReaction &rxn, python::list ob) {
+void ToBBS(EnumerationStrategyBase &rgroup, ChemicalReaction &rxn,
+           python::list ob) {
   rgroup.initialize(rxn, ConvertToVect(ob));
 }
-
-typedef std::vector<boost::uint64_t> VectSizeT;
-typedef std::vector<std::vector<std::string> > VectStringVect;
-typedef std::vector<MOL_SPTR_VECT > VectMolVect;
 
 struct enumeration_wrapper {
   static void wrap() {
     std::string docString;
-    python::class_<VectStringVect>("VectorOfStringVectors")
-      .def(python::vector_indexing_suite<VectStringVect, false>() );
 
-    python::class_<VectSizeT>("VectSizeT")
-      .def(python::vector_indexing_suite<VectSizeT, false>() );
-
-    python::class_<VectMolVect>("VectMolVect")
-      .def(python::vector_indexing_suite<VectMolVect, false>() );
+    RegisterVectorConverter<std::vector<std::string>>("VectorOfStringVectors");
+    RegisterVectorConverter<boost::uint64_t>("VectSizeT");
+    RegisterVectorConverter<MOL_SPTR_VECT>("VectMolVect");
 
     python::class_<RDKit::EnumerateLibraryBase, RDKit::EnumerateLibraryBase *,
                    RDKit::EnumerateLibraryBase &, boost::noncopyable>(
@@ -178,34 +160,40 @@ struct enumeration_wrapper {
              "Return the next smiles string from the enumeration.")
         .def("Serialize", &EnumerateLibraryBase_Serialize,
              "Serialize the library to a binary string.\n"
-             "Note that the position in the library is serialized as well.  Care should\n"
-             "be taken when serializing.  See GetState/SetState for position manipulation.")
+             "Note that the position in the library is serialized as well.  "
+             "Care should\n"
+             "be taken when serializing.  See GetState/SetState for position "
+             "manipulation.")
         .def("InitFromString", &RDKit::EnumerateLibraryBase::initFromString,
              python::arg("data"),
              "Inititialize the library from a binary string")
-        .def("GetPosition", &RDKit::EnumerateLibraryBase::getPosition,
-             "Returns the current enumeration position into the reagent vectors",
-             python::return_internal_reference<
-             1, python::with_custodian_and_ward_postcall<0, 1> >())
-        .def("GetState", &RDKit::EnumerateLibraryBase::getState,
-             "Returns the current enumeration state (position) of the library.\n"
-             "This position can be used to restart the library from a known position")
+        .def(
+            "GetPosition", &RDKit::EnumerateLibraryBase::getPosition,
+            "Returns the current enumeration position into the reagent vectors",
+            python::return_internal_reference<
+                1, python::with_custodian_and_ward_postcall<0, 1>>())
+        .def(
+            "GetState", &RDKit::EnumerateLibraryBase::getState,
+            "Returns the current enumeration state (position) of the library.\n"
+            "This position can be used to restart the library from a known "
+            "position")
         .def("SetState", &RDKit::EnumerateLibraryBase::setState,
              python::arg("state"),
              "Sets the enumeration state (position) of the library.")
         .def("ResetState", &RDKit::EnumerateLibraryBase::resetState,
-             "Returns the current enumeration state (position) of the library to the start.")
+             "Returns the current enumeration state (position) of the library "
+             "to the start.")
         .def("GetReaction", &RDKit::EnumerateLibraryBase::getReaction,
              "Returns the chemical reaction for this library",
              python::return_internal_reference<
-             1, python::with_custodian_and_ward_postcall<0, 1> >())
+                 1, python::with_custodian_and_ward_postcall<0, 1>>())
         .def("GetEnumerator", &RDKit::EnumerateLibraryBase::getEnumerator,
              "Returns the enumation strategy for the current library",
              python::return_internal_reference<
-             1, python::with_custodian_and_ward_postcall<0, 1> >());
+                 1, python::with_custodian_and_ward_postcall<0, 1>>());
 
-    docString = \
-"EnumerationParams\n\
+    docString =
+        "EnumerationParams\n\
 Controls some aspects of how the enumeration is performed.\n\
 Options:\n\
   reagentMaxMatchCount [ default Infinite ]\n\
@@ -217,18 +205,16 @@ Options:\n\
      does not pass sanitization, then none of the products will.\n\
 ";
 
-    python::class_<RDKit::EnumerationParams,
-                   RDKit::EnumerationParams*,
-                   RDKit::EnumerationParams&>("EnumerationParams",
-                                              docString.c_str(),
-                                              python::init<>())
+    python::class_<RDKit::EnumerationParams, RDKit::EnumerationParams *,
+                   RDKit::EnumerationParams &>(
+        "EnumerationParams", docString.c_str(), python::init<>())
         .def_readwrite("reagentMaxMatchCount",
-                    &RDKit::EnumerationParams::reagentMaxMatchCount)
+                       &RDKit::EnumerationParams::reagentMaxMatchCount)
         .def_readwrite("sanePartialProducts",
-                    &RDKit::EnumerationParams::sanePartialProducts);
+                       &RDKit::EnumerationParams::sanePartialProducts);
 
-    docString = \
-"EnumerateLibrary\n\
+    docString =
+        "EnumerateLibrary\n\
 This class allows easy enumeration of reactions.  Simply provide a reaction\n\
 and a set of reagents and you are off the races.\n\
 \n\
@@ -295,40 +281,30 @@ for result in itertools.islice(libary2, 1000):\n\
     # do something with the next 1000 samples\n\
 ";
     python::class_<EnumerateLibraryWrap, boost::noncopyable,
-                   python::bases<RDKit::EnumerateLibraryBase> >(
-                       "EnumerateLibrary", docString.c_str(),
-                       python::init<>())
-      .def(python::init<
-           const RDKit::ChemicalReaction &,
-           python::list,
-           python::optional<const RDKit::EnumerationParams&>
-           >(python::args("rxn", "reagents", "params")))
-      .def(python::init<
-           const RDKit::ChemicalReaction &,
-           python::tuple,
-           python::optional<const RDKit::EnumerationParams&>
-           >(python::args("rxn", "reagents", "params")))
+                   python::bases<RDKit::EnumerateLibraryBase>>(
+        "EnumerateLibrary", docString.c_str(), python::init<>())
+        .def(python::init<const RDKit::ChemicalReaction &, python::list,
+                          python::optional<const RDKit::EnumerationParams &>>(
+            python::args("rxn", "reagents", "params")))
+        .def(python::init<const RDKit::ChemicalReaction &, python::tuple,
+                          python::optional<const RDKit::EnumerationParams &>>(
+            python::args("rxn", "reagents", "params")))
 
-      .def(python::init<const RDKit::ChemicalReaction &,
-           python::list,
-           const RDKit::EnumerationStrategyBase &,
-           python::optional<const RDKit::EnumerationParams&>
-           >(python::args(
-               "rxn", "reagents", "enumerator", "params")))
-      .def(python::init<const RDKit::ChemicalReaction &,
-           python::tuple,
-           const RDKit::EnumerationStrategyBase &,
-           python::optional<const RDKit::EnumerationParams&>
-           >(python::args(
-               "rxn", "reagents", "enumerator", "params")))
+        .def(python::init<const RDKit::ChemicalReaction &, python::list,
+                          const RDKit::EnumerationStrategyBase &,
+                          python::optional<const RDKit::EnumerationParams &>>(
+            python::args("rxn", "reagents", "enumerator", "params")))
+        .def(python::init<const RDKit::ChemicalReaction &, python::tuple,
+                          const RDKit::EnumerationStrategyBase &,
+                          python::optional<const RDKit::EnumerationParams &>>(
+            python::args("rxn", "reagents", "enumerator", "params")))
 
-      .def("GetReagents", &RDKit::EnumerateLibrary::getReagents,
-           "Return the reagents used in this library.",
-           python::return_internal_reference<
-           1, python::with_custodian_and_ward_postcall<0, 1> >())
-      ;
+        .def("GetReagents", &RDKit::EnumerateLibrary::getReagents,
+             "Return the reagents used in this library.",
+             python::return_internal_reference<
+                 1, python::with_custodian_and_ward_postcall<0, 1>>());
 
-    //iterator_wrappers<EnumerateLibrary>().wrap("EnumerateLibraryIterator");
+    // iterator_wrappers<EnumerateLibrary>().wrap("EnumerateLibraryIterator");
 
     python::class_<RDKit::EnumerationStrategyBase,
                    RDKit::EnumerationStrategyBase *,
@@ -338,8 +314,7 @@ for result in itertools.islice(libary2, 1000):\n\
         .def("__bool__", &EnumerationStrategyBase__nonzero__)
         .def("Type", &EnumerationStrategyBase::type,
              "Returns the enumeration strategy type as a string.")
-        .def("Skip", &EnumerationStrategyBase::skip,
-             python::args("skipCount"),
+        .def("Skip", &EnumerationStrategyBase::skip, python::args("skipCount"),
              "Skip the next Nth results. note: this may be an expensive "
              "operation\n"
              "depending on the enumeration strategy used. It is recommended to "
@@ -348,63 +323,63 @@ for result in itertools.islice(libary2, 1000):\n\
         .def("__copy__", python::pure_virtual(&EnumerationStrategyBase::copy),
              python::return_value_policy<python::manage_new_object>())
         .def("GetNumPermutations", &EnumerationStrategyBase::getNumPermutations,
-             "Returns the total number of results for this enumeration strategy.\n"
+             "Returns the total number of results for this enumeration "
+             "strategy.\n"
              "Note that some strategies are effectively infinite.")
         .def("GetPosition", &EnumerationStrategyBase::getPosition,
              "Return the current indices into the arrays of reagents",
              python::return_internal_reference<
-                 1, python::with_custodian_and_ward_postcall<0, 1> >())
+                 1, python::with_custodian_and_ward_postcall<0, 1>>())
         .def("next", python::pure_virtual(&EnumerationStrategyBase::next),
              "Return the next indices into the arrays of reagents",
              python::return_internal_reference<
-                 1, python::with_custodian_and_ward_postcall<0, 1> >())
+                 1, python::with_custodian_and_ward_postcall<0, 1>>())
         .def("__next__", python::pure_virtual(&EnumerationStrategyBase::next),
              "Return the next indices into the arrays of reagents",
              python::return_internal_reference<
-                 1, python::with_custodian_and_ward_postcall<0, 1> >())
+                 1, python::with_custodian_and_ward_postcall<0, 1>>())
         .def("Initialize", ToBBS);
 
-    docString = "CartesianProductStrategy produces a standard walk through all possible\n"
+    docString =
+        "CartesianProductStrategy produces a standard walk through all "
+        "possible\n"
         "reagent combinations:\n"
         "\n"
         "(0,0,0), (1,0,0), (2,0,0) ...\n";
 
     python::class_<RDKit::CartesianProductStrategy,
-                   RDKit::CartesianProductStrategy*,
-                   RDKit::CartesianProductStrategy&,
-                   python::bases<EnumerationStrategyBase> >("CartesianProductStrategy",
-                                                            docString.c_str(),
-                                                            python::init<>())
+                   RDKit::CartesianProductStrategy *,
+                   RDKit::CartesianProductStrategy &,
+                   python::bases<EnumerationStrategyBase>>(
+        "CartesianProductStrategy", docString.c_str(), python::init<>())
         .def("__copy__", &RDKit::CartesianProductStrategy::copy,
-             python::return_value_policy<python::manage_new_object>())
-      ;
+             python::return_value_policy<python::manage_new_object>());
 
-    docString = "RandomSampleStrategy simply randomly samples from the reagent sets.\n"
+    docString =
+        "RandomSampleStrategy simply randomly samples from the reagent sets.\n"
         "Note that this strategy never halts and can produce duplicates.";
-    python::class_<RDKit::RandomSampleStrategy,
-                   RDKit::RandomSampleStrategy*,
-                   RDKit::RandomSampleStrategy&,
-                   python::bases<EnumerationStrategyBase> >("RandomSampleStrategy",
-                                                            docString.c_str(),
-                                                            python::init<>())
+    python::class_<RDKit::RandomSampleStrategy, RDKit::RandomSampleStrategy *,
+                   RDKit::RandomSampleStrategy &,
+                   python::bases<EnumerationStrategyBase>>(
+        "RandomSampleStrategy", docString.c_str(), python::init<>())
         .def("__copy__", &RDKit::RandomSampleStrategy::copy,
-             python::return_value_policy<python::manage_new_object>())
-      ;
+             python::return_value_policy<python::manage_new_object>());
 
-    docString = "RandomSampleAllBBsStrategy randomly samples from the reagent sets\n"
-        "with the constraint that all building blocks are samples as early as possible.\n"
+    docString =
+        "RandomSampleAllBBsStrategy randomly samples from the reagent sets\n"
+        "with the constraint that all building blocks are samples as early as "
+        "possible.\n"
         "Note that this strategy never halts and can produce duplicates.";
     python::class_<RDKit::RandomSampleAllBBsStrategy,
-                   RDKit::RandomSampleAllBBsStrategy*,
-                   RDKit::RandomSampleAllBBsStrategy&,
-                   python::bases<EnumerationStrategyBase> >("RandomSampleAllBBsStrategy",
-                                                            docString.c_str(),
-                                                            python::init<>())
+                   RDKit::RandomSampleAllBBsStrategy *,
+                   RDKit::RandomSampleAllBBsStrategy &,
+                   python::bases<EnumerationStrategyBase>>(
+        "RandomSampleAllBBsStrategy", docString.c_str(), python::init<>())
         .def("__copy__", &RDKit::RandomSampleAllBBsStrategy::copy,
-             python::return_value_policy<python::manage_new_object>())
-      ;
+             python::return_value_policy<python::manage_new_object>());
 
-    docString = "Randomly sample Pairs evenly from a collection of building blocks\n"
+    docString =
+        "Randomly sample Pairs evenly from a collection of building blocks\n"
         "This is a good strategy for choosing a relatively small selection\n"
         "of building blocks from a larger set.  As the amount of work needed\n"
         "to retrieve the next evenly sample building block grows with the\n"
@@ -413,26 +388,22 @@ for result in itertools.islice(libary2, 1000):\n\
         "See EnumerationStrategyBase for more details.\n";
 
     python::class_<RDKit::EvenSamplePairsStrategy,
-                   RDKit::EvenSamplePairsStrategy*,
-                   RDKit::EvenSamplePairsStrategy&,
-                   python::bases<EnumerationStrategyBase> >("EvenSamplePairsStrategy",
-                                                            docString.c_str(),
-                                                            python::init<>())
+                   RDKit::EvenSamplePairsStrategy *,
+                   RDKit::EvenSamplePairsStrategy &,
+                   python::bases<EnumerationStrategyBase>>(
+        "EvenSamplePairsStrategy", docString.c_str(), python::init<>())
         .def("__copy__", &RDKit::EvenSamplePairsStrategy::copy,
              python::return_value_policy<python::manage_new_object>())
         .def("Stats", &RDKit::EvenSamplePairsStrategy::stats,
-             "Return the statistics log of the pairs used in the current enumeration.")
-      ;
+             "Return the statistics log of the pairs used in the current "
+             "enumeration.");
 
     python::def("EnumerateLibraryCanSerialize", EnumerateLibraryCanSerialize,
                 "Returns True if the EnumerateLibrary is serializable "
                 "(requires boost serialization");
-
   }
 };
 
-}// end of namespace
+}  // namespace RDKit
 
-void wrap_enumeration() {
-  RDKit::enumeration_wrapper::wrap();
-}
+void wrap_enumeration() { RDKit::enumeration_wrapper::wrap(); }

--- a/Code/GraphMol/ChemReactions/Wrap/rdChemReactions.cpp
+++ b/Code/GraphMol/ChemReactions/Wrap/rdChemReactions.cpp
@@ -482,15 +482,8 @@ Sample Usage:
   'CN(C)C=O'
 )DOC";
 
-  // logic from https://stackoverflow.com/a/13017303
-  boost::python::type_info info =
-      boost::python::type_id<RDKit::MOL_SPTR_VECT>();
-  const boost::python::converter::registration *reg =
-      boost::python::converter::registry::query(info);
-  if (reg == nullptr || (*reg).m_to_python == nullptr) {
-    python::class_<RDKit::MOL_SPTR_VECT>("MOL_SPTR_VECT")
-        .def(python::vector_indexing_suite<RDKit::MOL_SPTR_VECT, true>());
-  }
+  bool noproxy = true;
+  RegisterVectorConverter<RDKit::ROMOL_SPTR>("MOL_SPTR_VECT", noproxy);
 
   python::class_<RDKit::ChemicalReaction>(
       "ChemicalReaction", docString.c_str(),

--- a/Code/GraphMol/ChemReactions/Wrap/rdChemReactions.cpp
+++ b/Code/GraphMol/ChemReactions/Wrap/rdChemReactions.cpp
@@ -48,7 +48,6 @@
 #include <RDGeneral/FileParseException.h>
 #include <GraphMol/ChemReactions/ReactionFingerprints.h>
 #include <GraphMol/ChemReactions/ReactionUtils.h>
-#include <boost/python/suite/indexing/vector_indexing_suite.hpp>
 
 namespace python = boost::python;
 

--- a/Code/GraphMol/Deprotect/Wrap/DeprotectWrap.cpp
+++ b/Code/GraphMol/Deprotect/Wrap/DeprotectWrap.cpp
@@ -34,7 +34,9 @@ boost::shared_ptr<ROMol> DeprotectWrap(const ROMol &mol) {
 }
 
 //! Make a copy so we don't try and change a const vector
-std::vector<Deprotect::DeprotectData> GetDeprotectionsWrap() { return Deprotect::getDeprotections(); }
+std::vector<Deprotect::DeprotectData> GetDeprotectionsWrap() {
+  return Deprotect::getDeprotections();
+}
 }  // namespace RDKit
 
 struct deprotect_wrap {
@@ -64,9 +66,8 @@ struct deprotect_wrap {
         "\n"
         "\n";
 
-    python::class_<std::vector<RDKit::Deprotect::DeprotectData>>("DeprotectDataVect")
-        .def(
-	     python::vector_indexing_suite<std::vector<RDKit::Deprotect::DeprotectData>>());
+    RegisterVectorConverter<RDKit::Deprotect::DeprotectData>(
+        "DeprotectDataVect");
 
     python::class_<RDKit::Deprotect::DeprotectData>(
         "DeprotectData", deprotect_doc_string,
@@ -75,8 +76,10 @@ struct deprotect_wrap {
         .def_readonly("deprotection_class",
                       &RDKit::Deprotect::DeprotectData::deprotection_class)
         .def_readonly("full_name", &RDKit::Deprotect::DeprotectData::full_name)
-        .def_readonly("abbreviation", &RDKit::Deprotect::DeprotectData::abbreviation)
-        .def_readonly("reaction_smarts", &RDKit::Deprotect::DeprotectData::reaction_smarts)
+        .def_readonly("abbreviation",
+                      &RDKit::Deprotect::DeprotectData::abbreviation)
+        .def_readonly("reaction_smarts",
+                      &RDKit::Deprotect::DeprotectData::reaction_smarts)
         .def_readonly("example", &RDKit::Deprotect::DeprotectData::example)
         .def("isValid", &RDKit::Deprotect::DeprotectData::isValid,
              "Returns True if the DeprotectData has a valid reaction");

--- a/Code/GraphMol/FilterCatalog/Wrap/FilterCatalog.cpp
+++ b/Code/GraphMol/FilterCatalog/Wrap/FilterCatalog.cpp
@@ -68,7 +68,7 @@ void SetOffPatterns(ExclusionList &fc, boost::python::object list) {
   python::stl_input_iterator<FilterMatcherBase *> begin(list);
   python::stl_input_iterator<FilterMatcherBase *> end;
 
-  std::vector<boost::shared_ptr<FilterMatcherBase> > temp;
+  std::vector<boost::shared_ptr<FilterMatcherBase>> temp;
 
   for (; begin != end; ++begin) {
     temp.push_back((*begin)->copy());
@@ -301,23 +301,21 @@ python::dict GetFlattenedFunctionalGroupHierarchyHelper(bool normalize) {
 }
 struct filtercat_wrapper {
   static void wrap() {
-    python::class_<std::pair<int, int> >("IntPair")
+    python::class_<std::pair<int, int>>("IntPair")
         .def(python::init<const int &, const int &>())
         .def_readwrite("query", &std::pair<int, int>::first)
         .def_readwrite("target", &std::pair<int, int>::second)
         .def("__getitem__", &GetMatchVectItem);
 
-    python::class_<MatchVectType>("MatchTypeVect")
-        .def(python::vector_indexing_suite<MatchVectType>());
+    RegisterVectorConverter<std::pair<int, int>>("MatchTypeVect");
 
-    python::class_<FilterMatch, FilterMatch *, boost::shared_ptr<FilterMatch> >(
+    python::class_<FilterMatch, FilterMatch *, boost::shared_ptr<FilterMatch>>(
         "FilterMatch", FilterMatchDoc,
         python::init<boost::shared_ptr<FilterMatcherBase>, MatchVectType>())
         .def_readonly("filterMatch", &FilterMatch::filterMatch)
         .def_readonly("atomPairs", &FilterMatch::atomPairs);
 
-    python::class_<std::vector<FilterMatch> >("VectFilterMatch")
-        .def(python::vector_indexing_suite<std::vector<FilterMatch> >());
+    RegisterVectorConverter<FilterMatch>("VectFilterMatch");
 
     python::class_<FilterMatcherBase, FilterMatcherBase *,
                    boost::shared_ptr<FilterMatcherBase>, boost::noncopyable>(
@@ -332,10 +330,10 @@ struct filtercat_wrapper {
         .def("GetName", &FilterMatcherBase::getName)
         .def("__str__", &FilterMatcherBase::getName);
 
-    python::register_ptr_to_python<boost::shared_ptr<FilterMatcherBase> >();
+    python::register_ptr_to_python<boost::shared_ptr<FilterMatcherBase>>();
 
     python::class_<SmartsMatcher, SmartsMatcher *,
-                   python::bases<FilterMatcherBase> >(
+                   python::bases<FilterMatcherBase>>(
         "SmartsMatcher", SmartsMatcherDoc, python::init<const std::string &>())
         .def(python::init<const ROMol &>("Construct from a molecule"))
         .def(python::init<const std::string &, const ROMol &>(
@@ -359,11 +357,13 @@ struct filtercat_wrapper {
 
         .def("IsValid", &SmartsMatcher::isValid,
              "Returns True if the SmartsMatcher is valid")
-        .def("SetPattern", (void (SmartsMatcher::*)(const ROMol &)) &
-                               SmartsMatcher::setPattern,
+        .def("SetPattern",
+             (void (SmartsMatcher::*)(const ROMol &)) &
+                 SmartsMatcher::setPattern,
              "Set the pattern molecule for the SmartsMatcher")
-        .def("SetPattern", (void (SmartsMatcher::*)(const std::string &)) &
-                               SmartsMatcher::setPattern,
+        .def("SetPattern",
+             (void (SmartsMatcher::*)(const std::string &)) &
+                 SmartsMatcher::setPattern,
              "Set the smarts pattern for the Smarts Matcher (warning: "
              "MinimumCount is not reset)")
         .def("GetPattern", &SmartsMatcher::getPattern,
@@ -381,8 +381,8 @@ struct filtercat_wrapper {
             "Set the maximum times pattern can appear for the filter to match");
 
     python::class_<ExclusionList, ExclusionList *,
-                   python::bases<FilterMatcherBase> >("ExclusionList",
-                                                      python::init<>())
+                   python::bases<FilterMatcherBase>>("ExclusionList",
+                                                     python::init<>())
         .def("SetExclusionPatterns", &SetOffPatterns,
              "Set a list of FilterMatcherBases that should not appear in a "
              "molecule")
@@ -390,7 +390,7 @@ struct filtercat_wrapper {
              "Add a FilterMatcherBase that should not appear in a molecule");
 
     python::class_<FilterHierarchyMatcher, FilterHierarchyMatcher *,
-                   python::bases<FilterMatcherBase> >(
+                   python::bases<FilterMatcherBase>>(
         "FilterHierarchyMatcher", FilterHierarchyMatcherDoc, python::init<>())
         .def(python::init<const FilterMatcherBase &>(
             "Construct from a filtermatcher"))
@@ -401,16 +401,14 @@ struct filtercat_wrapper {
         .def("AddChild", &FilterHierarchyMatcher::addChild,
              "Add a child node to this hierarchy.");
 
-    python::register_ptr_to_python<
-        boost::shared_ptr<FilterHierarchyMatcher> >();
+    python::register_ptr_to_python<boost::shared_ptr<FilterHierarchyMatcher>>();
 
-    python::class_<std::vector<RDKit::ROMol *> >("MolList").def(
-        python::vector_indexing_suite<std::vector<ROMol *>, true>());
+    bool noproxy = true;
+    RegisterVectorConverter<RDKit::ROMol *>("MolList", noproxy);
 
-    python::class_<FilterCatalogEntry,
-		   FilterCatalogEntry *,
+    python::class_<FilterCatalogEntry, FilterCatalogEntry *,
                    const FilterCatalogEntry *,
-		   boost::shared_ptr<const FilterCatalogEntry>>(
+                   boost::shared_ptr<const FilterCatalogEntry>>(
         "FilterCatalogEntry", FilterCatalogEntryDoc, python::init<>())
         .def(python::init<const std::string &, FilterMatcherBase &>())
         .def("IsValid", &FilterCatalogEntry::isValid)
@@ -434,13 +432,14 @@ struct filtercat_wrapper {
              (void (FilterCatalogEntry::*)(const std::string &, std::string)) &
                  FilterCatalogEntry::setProp<std::string>)
         .def("GetProp",
-             (std::string (FilterCatalogEntry::*)(const std::string &) const) &
+             (std::string(FilterCatalogEntry::*)(const std::string &) const) &
                  FilterCatalogEntry::getProp<std::string>)
         .def("ClearProp", (void (FilterCatalogEntry::*)(const std::string &)) &
                               FilterCatalogEntry::clearProp);
 
-    python::register_ptr_to_python<boost::shared_ptr<FilterCatalogEntry> >();    
-    python::register_ptr_to_python<boost::shared_ptr<const FilterCatalogEntry> >();
+    python::register_ptr_to_python<boost::shared_ptr<FilterCatalogEntry>>();
+    python::register_ptr_to_python<
+        boost::shared_ptr<const FilterCatalogEntry>>();
     python::def(
         "GetFunctionalGroupHierarchy", GetFunctionalGroupHierarchy,
         "Returns the functional group hierarchy filter catalog",
@@ -448,24 +447,23 @@ struct filtercat_wrapper {
     python::def(
         "GetFlattenedFunctionalGroupHierarchy",
         GetFlattenedFunctionalGroupHierarchyHelper,
-        (python::args("normalized")=false),
+        (python::args("normalized") = false),
         "Returns the flattened functional group hierarchy as a dictionary "
         " of name:ROMOL_SPTR substructure items");
 
-    python::register_ptr_to_python<
-        boost::shared_ptr<const FilterCatalogEntry> >();
-    python::class_<std::vector<boost::shared_ptr<FilterCatalogEntry const> > >(
-        "FilterCatalogEntryList")
-        .def(python::vector_indexing_suite<
-             std::vector<boost::shared_ptr<FilterCatalogEntry const> >,
-             true>());
-    
-    python::class_<
-      std::vector<
-	std::vector<boost::shared_ptr<FilterCatalogEntry const>>>>(
-			   "FilterCatalogListOfEntryList")
-      .def(python::vector_indexing_suite<
-	   std::vector<std::vector<boost::shared_ptr<FilterCatalogEntry const> > > >());
+    if (!is_python_converter_registered<
+            boost::shared_ptr<const FilterCatalogEntry>>()) {
+      python::register_ptr_to_python<
+          boost::shared_ptr<const FilterCatalogEntry>>();
+    }
+
+    noproxy = true;
+    RegisterVectorConverter<boost::shared_ptr<FilterCatalogEntry const>>(
+        "FilterCatalogEntryList", noproxy);
+
+    RegisterVectorConverter<
+        std::vector<boost::shared_ptr<FilterCatalogEntry const>>>(
+        "FilterCatalogListOfEntryList");
 
     {
       python::scope in_FilterCatalogParams =
@@ -517,21 +515,24 @@ struct filtercat_wrapper {
         // enable pickle support
         .def_pickle(filtercatalog_pickle_suite());
 
-    python::class_<PythonFilterMatch, python::bases<FilterMatcherBase> >(
+    python::class_<PythonFilterMatch, python::bases<FilterMatcherBase>>(
         "PythonFilterMatcher", python::init<PyObject *>());
 
     python::def("FilterCatalogCanSerialize", FilterCatalogCanSerialize,
                 "Returns True if the FilterCatalog is serializable "
                 "(requires boost serialization");
-    
+
     python::def("RunFilterCatalog", RunFilterCatalog,
-		(python::arg("filterCatalog"),
-		 python::arg("smiles"),
-		 python::arg("numThreads") = 1),
-                "Run the filter catalog on the input list of smiles strings.\nUse numThreads=0 to use all available processors. "
-		"Returns a vector of vectors.  For each input smiles, a vector of FilterCatalogEntry objects are "
-		"returned for each matched filter.  If a molecule matches no filter, the vector will be empty. "
-		"If a smiles string can't be parsed, a 'Bad smiles' entry is returned.");
+                (python::arg("filterCatalog"), python::arg("smiles"),
+                 python::arg("numThreads") = 1),
+                "Run the filter catalog on the input list of smiles "
+                "strings.\nUse numThreads=0 to use all available processors. "
+                "Returns a vector of vectors.  For each input smiles, a vector "
+                "of FilterCatalogEntry objects are "
+                "returned for each matched filter.  If a molecule matches no "
+                "filter, the vector will be empty. "
+                "If a smiles string can't be parsed, a 'Bad smiles' entry is "
+                "returned.");
 
     std::string nested_name = python::extract<std::string>(
         python::scope().attr("__name__") + ".FilterMatchOps");
@@ -541,21 +542,19 @@ struct filtercat_wrapper {
     python::scope parent = nested_module;
 
     python::class_<FilterMatchOps::And, FilterMatchOps::And *,
-                   python::bases<FilterMatcherBase> >(
+                   python::bases<FilterMatcherBase>>(
         "And", python::init<FilterMatcherBase &, FilterMatcherBase &>());
 
     python::class_<FilterMatchOps::Or, FilterMatchOps::Or *,
-                   python::bases<FilterMatcherBase> >(
+                   python::bases<FilterMatcherBase>>(
         "Or", python::init<FilterMatcherBase &, FilterMatcherBase &>());
 
     python::class_<FilterMatchOps::Not, FilterMatchOps::Not *,
-                   python::bases<FilterMatcherBase> >(
+                   python::bases<FilterMatcherBase>>(
         "Not", python::init<FilterMatcherBase &>());
-
-    
   };
 };
 
-}  // end of namespace
+}  // namespace RDKit
 
 void wrap_filtercat() { RDKit::filtercat_wrapper::wrap(); }

--- a/Code/GraphMol/MolChemicalFeatures/Wrap/rdMolChemicalFeatures.cpp
+++ b/Code/GraphMol/MolChemicalFeatures/Wrap/rdMolChemicalFeatures.cpp
@@ -11,7 +11,6 @@
 #include <RDBoost/Wrap.h>
 #include <GraphMol/MolChemicalFeatures/MolChemicalFeature.h>
 #include <GraphMol/MolChemicalFeatures/MolChemicalFeatureFactory.h>
-#include <boost/python/register_ptr_to_python.hpp>
 #include <fstream>
 #include <sstream>
 #include <iostream>

--- a/Code/GraphMol/MolDraw2D/Qt/Wrap/rdMolDraw2DQt.cpp
+++ b/Code/GraphMol/MolDraw2D/Qt/Wrap/rdMolDraw2DQt.cpp
@@ -13,7 +13,6 @@
 #include <GraphMol/ROMol.h>
 #include <GraphMol/MolDraw2D/MolDraw2D.h>
 
-#include <boost/python/suite/indexing/map_indexing_suite.hpp>
 #include <GraphMol/MolDraw2D/Qt/MolDraw2DQt.h>
 #include <QPainter>
 

--- a/Code/GraphMol/MolDraw2D/Wrap/rdMolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/Wrap/rdMolDraw2D.cpp
@@ -595,8 +595,10 @@ BOOST_PYTHON_MODULE(rdMolDraw2D) {
 
   rdkit_import_array();
 
-  python::class_<std::map<int, std::string>>("IntStringMap")
-      .def(python::map_indexing_suite<std::map<int, std::string>, true>());
+  if (!is_python_converter_registered<std::map<int, std::string>>()) {
+    python::class_<std::map<int, std::string>>("IntStringMap")
+        .def(python::map_indexing_suite<std::map<int, std::string>, true>());
+  }
 
   std::string docString = "Drawing options";
   python::class_<RDKit::MolDrawOptions, boost::noncopyable>("MolDrawOptions",

--- a/Code/GraphMol/RGroupDecomposition/Wrap/rdRGroupComposition.cpp
+++ b/Code/GraphMol/RGroupDecomposition/Wrap/rdRGroupComposition.cpp
@@ -173,15 +173,8 @@ python::object RGroupDecomp(python::object cores, python::object mols,
 
 struct rgroupdecomp_wrapper {
   static void wrap() {
-    // logic from https://stackoverflow.com/a/13017303
-    boost::python::type_info info =
-        boost::python::type_id<RDKit::MOL_SPTR_VECT>();
-    const boost::python::converter::registration *reg =
-        boost::python::converter::registry::query(info);
-    if (reg == nullptr || (*reg).m_to_python == nullptr) {
-      python::class_<RDKit::MOL_SPTR_VECT>("MOL_SPTR_VECT")
-          .def(python::vector_indexing_suite<RDKit::MOL_SPTR_VECT, true>());
-    }
+    bool noproxy = true;
+    RegisterVectorConverter<RDKit::ROMOL_SPTR>("MOL_SPTR_VECT", noproxy);
 
     std::string docString = "";
     python::enum_<RDKit::RGroupLabels>("RGroupLabels")

--- a/Code/GraphMol/RGroupDecomposition/Wrap/rdRGroupComposition.cpp
+++ b/Code/GraphMol/RGroupDecomposition/Wrap/rdRGroupComposition.cpp
@@ -35,8 +35,6 @@
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 #include <numpy/arrayobject.h>
 #include <boost/python/list.hpp>
-#include <boost/python/suite/indexing/map_indexing_suite.hpp>
-#include <boost/python/suite/indexing/vector_indexing_suite.hpp>
 #include <string>
 #include <cmath>
 #include <chrono>

--- a/Code/GraphMol/ScaffoldNetwork/Wrap/rdScaffoldNetwork.cpp
+++ b/Code/GraphMol/ScaffoldNetwork/Wrap/rdScaffoldNetwork.cpp
@@ -75,17 +75,7 @@ BOOST_PYTHON_MODULE(rdScaffoldNetwork) {
 
   // register the vector_indexing_suite for NetworkEdges
   // if it hasn't already been done.
-  // logic from https://stackoverflow.com/a/13017303
-  boost::python::type_info info =
-      boost::python::type_id<std::vector<ScaffoldNetwork::NetworkEdge>>();
-  const boost::python::converter::registration *reg =
-      boost::python::converter::registry::query(info);
-  if (reg == nullptr || (*reg).m_to_python == nullptr) {
-    python::class_<std::vector<ScaffoldNetwork::NetworkEdge>>(
-        "NetworkEdge_VECT")
-        .def(python::vector_indexing_suite<
-             std::vector<ScaffoldNetwork::NetworkEdge>>());
-  }
+  RegisterVectorConverter<ScaffoldNetwork::NetworkEdge>("NetworkEdge_VECT");
 
   iterable_converter().from_python<std::vector<std::string>>();
 

--- a/Code/GraphMol/ScaffoldNetwork/Wrap/rdScaffoldNetwork.cpp
+++ b/Code/GraphMol/ScaffoldNetwork/Wrap/rdScaffoldNetwork.cpp
@@ -9,7 +9,6 @@
 //
 
 #include <RDBoost/python.h>
-#include <boost/python/suite/indexing/vector_indexing_suite.hpp>
 #include <GraphMol/GraphMol.h>
 #include <RDBoost/Wrap.h>
 
@@ -73,8 +72,6 @@ BOOST_PYTHON_MODULE(rdScaffoldNetwork) {
   python::scope().attr("__doc__") =
       "Module containing functions for creating a Scaffold Network";
 
-  // register the vector_indexing_suite for NetworkEdges
-  // if it hasn't already been done.
   RegisterVectorConverter<ScaffoldNetwork::NetworkEdge>("NetworkEdge_VECT");
 
   iterable_converter().from_python<std::vector<std::string>>();

--- a/Code/GraphMol/SubstructLibrary/Wrap/SubstructLibraryWrap.cpp
+++ b/Code/GraphMol/SubstructLibrary/Wrap/SubstructLibraryWrap.cpp
@@ -98,7 +98,8 @@ const char *PatternHolderDoc =
     "Holds fingerprints with optional, user-defined number of bits (default: "
     "2048) used for filtering of molecules.";
 const char *TautomerPatternHolderDoc =
-    "Holds tautomeric fingerprints with optional, user-defined number of bits (default: "
+    "Holds tautomeric fingerprints with optional, user-defined number of bits "
+    "(default: "
     "2048) used for filtering of molecules.\n"
     "These fingerprints are designed to be used with TautomerQueries.";
 
@@ -216,33 +217,27 @@ void toStream(const SubstructLibrary &cat, python::object &fileobj) {
   cat.toStream(ost);
 }
 
-  void initFromStream(SubstructLibrary &cat, python::object &fileobj) {
-  streambuf ss(fileobj, 'b'); // python StringIO can't seek, so need binary data
+void initFromStream(SubstructLibrary &cat, python::object &fileobj) {
+  streambuf ss(fileobj,
+               'b');  // python StringIO can't seek, so need binary data
   streambuf::istream is(ss);
   cat.initFromStream(is);
 }
 
-boost::shared_ptr<MolHolderBase> GetMolHolder(SubstructLibrary &sslib)
-{
+boost::shared_ptr<MolHolderBase> GetMolHolder(SubstructLibrary &sslib) {
   // need to convert from a ref to a real shared_ptr
   return sslib.getMolHolder();
 }
 
-boost::shared_ptr<FPHolderBase> GetFpHolder(SubstructLibrary &sslib)
-{
+boost::shared_ptr<FPHolderBase> GetFpHolder(SubstructLibrary &sslib) {
   // need to convert from a ref to a real shared_ptr
   return sslib.getFpHolder();
 }
 
 struct substructlibrary_wrapper {
   static void wrap() {
-    // n.b. there can only be one of these in all wrappings
-    // python::class_<std::vector<unsigned int> >("UIntVect").def(
-    //  python::vector_indexing_suite<std::vector<unsigned int>, true>());
-
     python::class_<MolHolderBase, boost::shared_ptr<MolHolderBase>,
-		   boost::noncopyable>("MolHolderBase", "",
-				       python::no_init)
+                   boost::noncopyable>("MolHolderBase", "", python::no_init)
         .def("__len__", &MolHolderBase::size)
         .def("AddMol", &MolHolderBase::addMol,
              "Adds molecule to the molecule holder")
@@ -250,7 +245,8 @@ struct substructlibrary_wrapper {
              "Returns a particular molecule in the molecule holder\n\n"
              "  ARGUMENTS:\n"
              "    - idx: which molecule to return\n\n"
-             "    - sanitize: if sanitize is False, return the internal molecule state [default True]\n\n"
+             "    - sanitize: if sanitize is False, return the internal "
+             "molecule state [default True]\n\n"
              "  NOTE: molecule indices start at 0\n")
         .def("__len__", &MolHolderBase::size);
 
@@ -313,11 +309,12 @@ struct substructlibrary_wrapper {
         "PatternHolder", PatternHolderDoc, python::init<>())
         .def(python::init<unsigned int>());
 
-    python::class_<TautomerPatternHolder, boost::shared_ptr<TautomerPatternHolder>,
+    python::class_<TautomerPatternHolder,
+                   boost::shared_ptr<TautomerPatternHolder>,
                    python::bases<FPHolderBase>>(
         "TautomerPatternHolder", TautomerPatternHolderDoc, python::init<>())
         .def(python::init<unsigned int>());
-      
+
     python::class_<SubstructLibrary, SubstructLibrary *,
                    const SubstructLibrary *>(
         "SubstructLibrary", SubstructLibraryDoc, python::init<>())
@@ -423,101 +420,100 @@ struct substructlibrary_wrapper {
              "  - startIdx:   index to search from\n"
              "  - endIdx:     index (non-inclusize) to search to\n"
              "  - numThreads: number of threads to use, -1 means all threads\n")
-      // =========================================================================
-      // TautomerQueries
-      .def("GetMatches",
-           (std::vector<unsigned int>(SubstructLibrary::*)(
-               const TautomerQuery &, bool, bool, bool, int, int) const) &
-               SubstructLibrary::getMatches,
-           (python::arg("query"), python::arg("recursionPossible") = true,
-            python::arg("useChirality") = true,
-            python::arg("useQueryQueryMatches") = false,
-            python::arg("numThreads") = -1, python::arg("maxResults") = 1000),
-           "Get the matches for the query.\n\n"
-           " Arguments:\n"
-           "  - query:      tautomer query\n"
-           "  - numThreads: number of threads to use, -1 means all threads\n"
-           "  - maxResults: maximum number of results to return")
+        // =========================================================================
+        // TautomerQueries
+        .def("GetMatches",
+             (std::vector<unsigned int>(SubstructLibrary::*)(
+                 const TautomerQuery &, bool, bool, bool, int, int) const) &
+                 SubstructLibrary::getMatches,
+             (python::arg("query"), python::arg("recursionPossible") = true,
+              python::arg("useChirality") = true,
+              python::arg("useQueryQueryMatches") = false,
+              python::arg("numThreads") = -1, python::arg("maxResults") = 1000),
+             "Get the matches for the query.\n\n"
+             " Arguments:\n"
+             "  - query:      tautomer query\n"
+             "  - numThreads: number of threads to use, -1 means all threads\n"
+             "  - maxResults: maximum number of results to return")
 
-      .def("GetMatches",
-           (std::vector<unsigned int>(SubstructLibrary::*)(
-               const TautomerQuery &, unsigned int, unsigned int, bool, bool, bool,
-               int, int) const) &
-               SubstructLibrary::getMatches,
-           (python::arg("query"), python::arg("startIdx"),
-            python::arg("endIdx"), python::arg("recursionPossible") = true,
-            python::arg("useChirality") = true,
-            python::arg("useQueryQueryMatches") = false,
-            python::arg("numThreads") = -1, python::arg("maxResults") = 1000),
-           "Get the matches for the query.\n\n"
-           " Arguments:\n"
-           "  - query:      tautomer query\n"
-           "  - startIdx:   index to search from\n"
-           "  - endIdx:     index (non-inclusize) to search to\n"
-           "  - numThreads: number of threads to use, -1 means all threads\n"
-           "  - maxResults: maximum number of results to return")
+        .def("GetMatches",
+             (std::vector<unsigned int>(SubstructLibrary::*)(
+                 const TautomerQuery &, unsigned int, unsigned int, bool, bool,
+                 bool, int, int) const) &
+                 SubstructLibrary::getMatches,
+             (python::arg("query"), python::arg("startIdx"),
+              python::arg("endIdx"), python::arg("recursionPossible") = true,
+              python::arg("useChirality") = true,
+              python::arg("useQueryQueryMatches") = false,
+              python::arg("numThreads") = -1, python::arg("maxResults") = 1000),
+             "Get the matches for the query.\n\n"
+             " Arguments:\n"
+             "  - query:      tautomer query\n"
+             "  - startIdx:   index to search from\n"
+             "  - endIdx:     index (non-inclusize) to search to\n"
+             "  - numThreads: number of threads to use, -1 means all threads\n"
+             "  - maxResults: maximum number of results to return")
 
-      .def("CountMatches",
-           (unsigned int (SubstructLibrary::*)(const TautomerQuery &, bool, bool,
-                                               bool, int) const) &
-               SubstructLibrary::countMatches,
-           (python::arg("query"), python::arg("recursionPossible") = true,
-            python::arg("useChirality") = true,
-            python::arg("useQueryQueryMatches") = false,
-            python::arg("numThreads") = -1),
-           "Get the matches for the query.\n\n"
-           " Arguments:\n"
-           "  - query:      tautomer query\n"
-           "  - numThreads: number of threads to use, -1 means all threads\n")
+        .def("CountMatches",
+             (unsigned int (SubstructLibrary::*)(const TautomerQuery &, bool,
+                                                 bool, bool, int) const) &
+                 SubstructLibrary::countMatches,
+             (python::arg("query"), python::arg("recursionPossible") = true,
+              python::arg("useChirality") = true,
+              python::arg("useQueryQueryMatches") = false,
+              python::arg("numThreads") = -1),
+             "Get the matches for the query.\n\n"
+             " Arguments:\n"
+             "  - query:      tautomer query\n"
+             "  - numThreads: number of threads to use, -1 means all threads\n")
 
-      .def("CountMatches",
-           (unsigned int (SubstructLibrary::*)(const TautomerQuery &, unsigned int,
-                                               unsigned int, bool, bool, bool,
-                                               int) const) &
-               SubstructLibrary::countMatches,
-           (python::arg("query"), python::arg("startIdx"),
-            python::arg("endIdx"), python::arg("recursionPossible") = true,
-            python::arg("useChirality") = true,
-            python::arg("useQueryQueryMatches") = false,
-            python::arg("numThreads") = -1),
-           "Get the matches for the query.\n\n"
-           " Arguments:\n"
-           "  - query:      tautomer query\n"
-           "  - startIdx:   index to search from\n"
-           "  - endIdx:     index (non-inclusize) to search to\n"
-           "  - numThreads: number of threads to use, -1 means all threads\n")
+        .def("CountMatches",
+             (unsigned int (SubstructLibrary::*)(const TautomerQuery &,
+                                                 unsigned int, unsigned int,
+                                                 bool, bool, bool, int) const) &
+                 SubstructLibrary::countMatches,
+             (python::arg("query"), python::arg("startIdx"),
+              python::arg("endIdx"), python::arg("recursionPossible") = true,
+              python::arg("useChirality") = true,
+              python::arg("useQueryQueryMatches") = false,
+              python::arg("numThreads") = -1),
+             "Get the matches for the query.\n\n"
+             " Arguments:\n"
+             "  - query:      tautomer query\n"
+             "  - startIdx:   index to search from\n"
+             "  - endIdx:     index (non-inclusize) to search to\n"
+             "  - numThreads: number of threads to use, -1 means all threads\n")
 
-      .def("HasMatch",
-           (bool (SubstructLibrary::*)(const TautomerQuery &, bool, bool, bool, int)
-                const) &
-               SubstructLibrary::hasMatch,
-           (python::arg("query"), python::arg("recursionPossible") = true,
-            python::arg("useChirality") = true,
-            python::arg("useQueryQueryMatches") = false,
-            python::arg("numThreads") = -1),
-           "Get the matches for the query.\n\n"
-           " Arguments:\n"
-           "  - query:      tautomer query\n"
-           "  - numThreads: number of threads to use, -1 means all threads\n")
+        .def("HasMatch",
+             (bool (SubstructLibrary::*)(const TautomerQuery &, bool, bool,
+                                         bool, int) const) &
+                 SubstructLibrary::hasMatch,
+             (python::arg("query"), python::arg("recursionPossible") = true,
+              python::arg("useChirality") = true,
+              python::arg("useQueryQueryMatches") = false,
+              python::arg("numThreads") = -1),
+             "Get the matches for the query.\n\n"
+             " Arguments:\n"
+             "  - query:      tautomer query\n"
+             "  - numThreads: number of threads to use, -1 means all threads\n")
 
-      .def("HasMatch",
-           (bool (SubstructLibrary::*)(const TautomerQuery &, unsigned int,
-                                       unsigned int, bool, bool, bool, int)
-                const) &
-               SubstructLibrary::hasMatch,
-           (python::arg("query"), python::arg("startIdx"),
-            python::arg("endIdx"), python::arg("recursionPossible") = true,
-            python::arg("useChirality") = true,
-            python::arg("useQueryQueryMatches") = false,
-            python::arg("numThreads") = -1),
-           "Get the matches for the query.\n\n"
-           " Arguments:\n"
-           "  - query:      tautomer query\n"
-           "  - startIdx:   index to search from\n"
-           "  - endIdx:     index (non-inclusize) to search to\n"
-           "  - numThreads: number of threads to use, -1 means all threads\n")
+        .def("HasMatch",
+             (bool (SubstructLibrary::*)(const TautomerQuery &, unsigned int,
+                                         unsigned int, bool, bool, bool, int)
+                  const) &
+                 SubstructLibrary::hasMatch,
+             (python::arg("query"), python::arg("startIdx"),
+              python::arg("endIdx"), python::arg("recursionPossible") = true,
+              python::arg("useChirality") = true,
+              python::arg("useQueryQueryMatches") = false,
+              python::arg("numThreads") = -1),
+             "Get the matches for the query.\n\n"
+             " Arguments:\n"
+             "  - query:      tautomer query\n"
+             "  - startIdx:   index to search from\n"
+             "  - endIdx:     index (non-inclusize) to search to\n"
+             "  - numThreads: number of threads to use, -1 means all threads\n")
 
-      
         .def("GetMol", &SubstructLibrary::getMol,
              "Returns a particular molecule in the molecule holder\n\n"
              "  ARGUMENTS:\n"
@@ -569,17 +565,21 @@ struct substructlibrary_wrapper {
                 "(requires boost serialization");
 
     python::def("AddPatterns",
-		(void (*)(SubstructLibrary&, int))&addPatterns,
-		"Add pattern fingerprints to the given library, use numThreads=-1 to use all available cores",
-		(python::arg("sslib"), python::arg("numThreads")=1));
+                (void (*)(SubstructLibrary &, int)) & addPatterns,
+                "Add pattern fingerprints to the given library, use "
+                "numThreads=-1 to use all available cores",
+                (python::arg("sslib"), python::arg("numThreads") = 1));
 
-    python::def("AddPatterns",
-		(void (*)(SubstructLibrary&, boost::shared_ptr<FPHolderBase>, int))&addPatterns,
-		"Add pattern fingerprints to the given library, use numThreads=-1 to use all available cores",
-		(python::arg("sslib"), python::arg("patterns"), python::arg("numThreads")=1));
-
+    python::def(
+        "AddPatterns",
+        (void (*)(SubstructLibrary &, boost::shared_ptr<FPHolderBase>, int)) &
+            addPatterns,
+        "Add pattern fingerprints to the given library, use numThreads=-1 to "
+        "use all available cores",
+        (python::arg("sslib"), python::arg("patterns"),
+         python::arg("numThreads") = 1));
   }
 };
-}
+}  // namespace RDKit
 
 void wrap_substructlibrary() { RDKit::substructlibrary_wrapper::wrap(); }

--- a/Code/GraphMol/TautomerQuery/Wrap/rdTautomerQuery.cpp
+++ b/Code/GraphMol/TautomerQuery/Wrap/rdTautomerQuery.cpp
@@ -10,7 +10,6 @@
 
 #include <RDBoost/Wrap.h>
 #include <RDBoost/python.h>
-#include <boost/python/suite/indexing/vector_indexing_suite.hpp>
 #include <GraphMol/TautomerQuery/TautomerQuery.h>
 #include <GraphMol/Wrap/substructmethods.h>
 

--- a/Code/GraphMol/TautomerQuery/Wrap/rdTautomerQuery.cpp
+++ b/Code/GraphMol/TautomerQuery/Wrap/rdTautomerQuery.cpp
@@ -8,8 +8,6 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 
-
-
 #include <RDBoost/Wrap.h>
 #include <RDBoost/python.h>
 #include <boost/python/suite/indexing/vector_indexing_suite.hpp>
@@ -36,8 +34,8 @@ bool tautomerIsSubstructOf(const TautomerQuery &self, const ROMol &target,
 }
 
 bool tautomerIsSubstructOfWithParams(const TautomerQuery &self,
-                                    const ROMol &target,
-                                    const SubstructMatchParameters &params) {
+                                     const ROMol &target,
+                                     const SubstructMatchParameters &params) {
   return helpHasSubstructMatch(target, self, params);
 }
 
@@ -48,15 +46,15 @@ PyObject *tautomerGetSubstructMatch(const TautomerQuery &self,
   return GetSubstructMatch(target, self, useChirality, useQueryQueryMatches);
 }
 
-PyObject *tautomerGetSubstructMatchWithParams(const TautomerQuery &self,
-                                    const ROMol &target,
-                                    const SubstructMatchParameters &params) {
+PyObject *tautomerGetSubstructMatchWithParams(
+    const TautomerQuery &self, const ROMol &target,
+    const SubstructMatchParameters &params) {
   return helpGetSubstructMatch(target, self, params);
 }
 
-PyObject *tautomerGetSubstructMatchesWithParams(const TautomerQuery &self,
-                                    const ROMol &target,
-                                    const SubstructMatchParameters &params) {
+PyObject *tautomerGetSubstructMatchesWithParams(
+    const TautomerQuery &self, const ROMol &target,
+    const SubstructMatchParameters &params) {
   return helpGetSubstructMatches(target, self, params);
 }
 
@@ -139,6 +137,7 @@ PyObject *tautomerGetSubstructMatchesWithTautomers(
 struct TautomerQuery_wrapper {
   static void wrap() {
     RegisterVectorConverter<size_t>("UnsignedLong_Vect");
+
     auto docString =
         "The Tautomer Query Class.\n\
   Creates a query that enables structure search accounting for matching of\n\
@@ -153,25 +152,25 @@ struct TautomerQuery_wrapper {
               python::arg("recursionPossible") = true,
               python::arg("useChirality") = false,
               python::arg("useQueryQueryMatches") = false))
-        .def("IsSubstructOf", tautomerIsSubstructOfWithParams,
-             (python::arg("self"), python::arg("target"),
-             python::arg("params")))
+        .def(
+            "IsSubstructOf", tautomerIsSubstructOfWithParams,
+            (python::arg("self"), python::arg("target"), python::arg("params")))
         .def("GetSubstructMatch", tautomerGetSubstructMatch,
              (python::arg("self"), python::arg("target"),
               python::arg("useChirality") = false,
               python::arg("useQueryQueryMatches") = false))
-        .def("GetSubstructMatch", tautomerGetSubstructMatchWithParams,
-             (python::arg("self"), python::arg("target"),
-             python::arg("params")))
+        .def(
+            "GetSubstructMatch", tautomerGetSubstructMatchWithParams,
+            (python::arg("self"), python::arg("target"), python::arg("params")))
         .def("GetSubstructMatches", tautomerGetSubstructMatches,
              (python::arg("self"), python::arg("target"),
               python::arg("uniquify") = true,
               python::arg("useChirality") = false,
               python::arg("useQueryQueryMatches") = false,
               python::arg("maxMatches") = 1000))
-        .def("GetSubstructMatches", tautomerGetSubstructMatchesWithParams,
-             (python::arg("self"), python::arg("target"),
-             python::arg("params")))
+        .def(
+            "GetSubstructMatches", tautomerGetSubstructMatchesWithParams,
+            (python::arg("self"), python::arg("target"), python::arg("params")))
         .def("GetSubstructMatchesWithTautomers",
              tautomerGetSubstructMatchesWithTautomers,
              (python::arg("self"), python::arg("target"),

--- a/Code/GraphMol/Wrap/Mol.cpp
+++ b/Code/GraphMol/Wrap/Mol.cpp
@@ -9,7 +9,6 @@
 //
 #define NO_IMPORT_ARRAY
 #include <RDBoost/python.h>
-#include <boost/python/suite/indexing/vector_indexing_suite.hpp>
 #include <string>
 
 #include "rdchem.h"

--- a/Code/GraphMol/Wrap/SubstanceGroup.cpp
+++ b/Code/GraphMol/Wrap/SubstanceGroup.cpp
@@ -10,7 +10,6 @@
 
 #define NO_IMPORT_ARRAY
 #include <boost/python.hpp>
-#include <boost/python/suite/indexing/vector_indexing_suite.hpp>
 #include <string>
 
 // ours

--- a/External/FreeSASA/Wrap/rdFreeSASA.cpp
+++ b/External/FreeSASA/Wrap/rdFreeSASA.cpp
@@ -33,9 +33,6 @@
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 #include <numpy/arrayobject.h>
 #include <boost/python/list.hpp>
-//#include <boost/python/suite/indexing/map_indexing_suite.hpp>
-//#include <boost/python/suite/indexing/vector_indexing_suite.hpp>
-//#include <string>
 #include <cmath>
 
 #include <RDGeneral/Exceptions.h>
@@ -81,7 +78,7 @@ double calcSASAHelper(const RDKit::ROMol &mol, python::object radii,
 
   return FreeSASA::calcSASA(mol, vradii, confIdx, atom, opts);
 }
-}
+}  // namespace
 
 struct freesasa_wrapper {
   static void wrap() {
@@ -109,11 +106,10 @@ struct freesasa_wrapper {
         .def(python::init<FreeSASA::SASAOpts::Algorithm,
                           FreeSASA::SASAOpts::Classifier>())
         .def(python::init<FreeSASA::SASAOpts::Algorithm,
-                          FreeSASA::SASAOpts::Classifier,double>())
+                          FreeSASA::SASAOpts::Classifier, double>())
         .def_readwrite("algorithm", &FreeSASA::SASAOpts::algorithm)
         .def_readwrite("classifier", &FreeSASA::SASAOpts::classifier)
-        .def_readwrite("probeRadius", &FreeSASA::SASAOpts::probeRadius)
-        ;
+        .def_readwrite("probeRadius", &FreeSASA::SASAOpts::probeRadius);
 
     docString =
         "Classify the atoms in the molecule returning their radii if "
@@ -181,7 +177,7 @@ struct freesasa_wrapper {
         "and SASAClassName set to the POLAR class.  (see classifyAtoms)");
   }
 };
-}
+}  // namespace RDKit
 
 BOOST_PYTHON_MODULE(rdFreeSASA) {
   python::scope().attr("__doc__") =


### PR DESCRIPTION
Closes #4425 

It took me a while to find the converters responsible of triggering the warnings. And while looking for them, I made some refactoring:

- added a templated function to Wrap.h that makes the check to see if a converter for a specific type has already been set up.
- added a check based on this function to `RegisterVectorConverter()`
- also added checks to other converter registrations for types that look like generic enough as to be potentially used somewhere else.
- Replaced several definitions of converters for vectors of different types with `RegisterVectorConverter()`, to benefit for the check and reduce redundant code.
- remove some unused boost::python headers.

And I think that's all I did. The rest is clang-format getting over excited about code that apparently hasn't been formatted in a while...