### PR TITLE
Fixes a test failure on Windows

### DIFF
--- a/Code/GraphMol/SmilesParse/SmilesWrite.h
+++ b/Code/GraphMol/SmilesParse/SmilesWrite.h
@@ -39,7 +39,7 @@ struct RDKIT_SMILESPARSE_EXPORT SmilesWriteParams {
 };
 namespace SmilesWrite {
 
-typedef enum {
+enum CXSmilesFields : uint32_t {
   CX_NONE = 0,
   CX_ATOM_LABELS = 1 << 0,
   CX_MOLFILE_VALUES = 1 << 1,
@@ -50,13 +50,16 @@ typedef enum {
   CX_ENHANCEDSTEREO = 1 << 6,
   CX_SGROUPS = 1 << 7,
   CX_POLYMER = 1 << 8,
-  CX_ALL = std::numeric_limits<std::uint32_t>::max()
-} CXSmilesFields;
+  // NB: std::int32_t is intentional as a non-scoped enum is implicitly cast to int
+  // so numbers larger than std::numeric_limits<std::int32_t>::max() will be
+  // negative
+  CX_ALL = std::numeric_limits<std::int32_t>::max()
+};
 
 //! \brief returns the cxsmiles data for a molecule
 RDKIT_SMILESPARSE_EXPORT std::string getCXExtensions(
     const ROMol &mol,
-    std::uint32_t flags = std::numeric_limits<uint32_t>::max());
+    std::uint32_t flags = CXSmilesFields::CX_ALL);
 
 //! \brief returns true if the atom number is in the SMILES organic subset
 RDKIT_SMILESPARSE_EXPORT bool inOrganicSubset(int atomicNumber);
@@ -202,7 +205,7 @@ inline std::string MolFragmentToSmiles(
 //! \brief returns canonical CXSMILES for a molecule
 RDKIT_SMILESPARSE_EXPORT std::string MolToCXSmiles(
     const ROMol &mol, const SmilesWriteParams &ps,
-    std::uint32_t flags = std::numeric_limits<uint32_t>::max());
+    std::uint32_t flags = SmilesWrite::CXSmilesFields::CX_ALL);
 
 //! \brief returns canonical CXSMILES for a molecule
 /*!

--- a/Code/GraphMol/Wrap/rdmolfiles.cpp
+++ b/Code/GraphMol/Wrap/rdmolfiles.cpp
@@ -1323,7 +1323,7 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
                               std::uint32_t))RDKit::MolToCXSmiles,
               (python::arg("mol"), python::arg("params"),
                python::arg("flags") =
-                   (unsigned)RDKit::SmilesWrite::CXSmilesFields::CX_ALL),
+                   RDKit::SmilesWrite::CXSmilesFields::CX_ALL),
               "Returns the CXSMILES string for a molecule");
 
   docString =


### PR DESCRIPTION
Fixes a test failure on Windows due to a `CXSmilesFields` `enum` value overflowing the max `int32` limit.
The problem does not show up on other platforms as the `enum` casting done by the compiler is implementation-dependent.

According to the standard, unscoped enums are implicitly converted to `int` (https://docs.microsoft.com/en-us/cpp/cpp/enumerations-cpp?view=msvc-160), so a value exceeding the maximum `int32` integer will be converted to a negative value, which is exactly what happens with the `CX_ALL` `enum` value which is converted to `-1` causing one of the Python tests to fail:
```
2021-08-19T14:53:05.5899376Z ERROR: testCXSmilesOptions (__main__.TestCase)
2021-08-19T14:53:05.5900940Z ----------------------------------------------------------------------
2021-08-19T14:53:05.5902000Z Traceback (most recent call last):
2021-08-19T14:53:05.5903667Z   File "D:/a/1/s/Code/GraphMol/Wrap/rough_test.py", line 6663, in testCXSmilesOptions
2021-08-19T14:53:05.5905176Z     Chem.MolToCXSmiles(m, ps, (Chem.CXSmilesFields.CX_ALL ^ Chem.CXSmilesFields.CX_LINKNODES)),
2021-08-19T14:53:05.5906870Z OverflowError: can't convert negative value to unsigned int
```
A better fix would be to convert the unscoped `CXSmilesFields` `enum` to a strongly typed scoped `enum class`. This would prevent the implicit cast to `int`. However, this also means that all bit operations on `enum` members would require an explicit `static_cast<uint32_t>`, making the code unnecessary complicated.

So I propose to stick to the unscoped `enum`, and simply doing without the most significant bit in the `enum`. Doing so, we can replace `std::numeric_limits<uint32_t>::max)()` with `std::numeric_limits<int32_t>::max)()` and avoid the sign issue.