### PR TITLE
cleanup the use of lambdas in the code

### DIFF
--- a/Code/GraphMol/Abbreviations/Abbreviations.cpp
+++ b/Code/GraphMol/Abbreviations/Abbreviations.cpp
@@ -63,7 +63,7 @@ void applyMatches(RWMol& mol, const std::vector<AbbreviationMatch>& matches) {
           auto nbrIdx = nbr->getIdx();
           // if this neighbor isn't in the match:
           if (!std::any_of(amatch.match.begin(), amatch.match.end(),
-                           [&](const std::pair<int, int>& tpr) {
+                           [nbrIdx](const std::pair<int, int>& tpr) {
                              return tpr.second == rdcast<int>(nbrIdx);
                            })) {
             mol.addBond(nbrIdx, connectIdx, Bond::BondType::SINGLE);

--- a/Code/GraphMol/ChemReactions/ReactionRunner.cpp
+++ b/Code/GraphMol/ChemReactions/ReactionRunner.cpp
@@ -108,7 +108,7 @@ class StereoBondEndCap {
     const auto nbrIdxItr = mol.getAtomNeighbors(atom);
     const unsigned otherIdx = otherDblBndAtom->getIdx();
 
-    auto isNonAnchor = [&otherIdx, &stereoAtomIdx](const unsigned &nbrIdx) {
+    auto isNonAnchor = [otherIdx, stereoAtomIdx](const unsigned &nbrIdx) {
       return nbrIdx != otherIdx && nbrIdx != stereoAtomIdx;
     };
 
@@ -466,7 +466,7 @@ unsigned reactProdMapAnchorIdx(Atom *atom, const RDKit::UINT_VECT &pMatches) {
   const auto &pMol = atom->getOwningMol();
   const unsigned atomIdx = atom->getIdx();
 
-  auto areAtomsBonded = [&pMol, &atomIdx](const unsigned &pAnchor) {
+  auto areAtomsBonded = [&pMol, atomIdx](const unsigned &pAnchor) {
     return pMol.getBondBetweenAtoms(atomIdx, pAnchor) != nullptr;
   };
 

--- a/Code/GraphMol/Chirality.cpp
+++ b/Code/GraphMol/Chirality.cpp
@@ -2334,9 +2334,9 @@ void assignChiralTypesFromMolParity(ROMol &mol, bool replaceExistingTags) {
     INT_LIST nbrBondIdxList;
     std::transform(
         nbrBonds.first, nbrBonds.second, std::back_inserter(nbrBondIdxList),
-        [mol](const ROMol::edge_descriptor &e) { return mol[e]->getIdx(); });
+        [&mol](const ROMol::edge_descriptor &e) { return mol[e]->getIdx(); });
     unsigned int atomIdx = atom->getIdx();
-    nbrBondIdxList.sort([mol, atomIdx](const int ai, const int bi) {
+    nbrBondIdxList.sort([&mol, atomIdx](const int ai, const int bi) {
       return (mol.getBondWithIdx(ai)->getOtherAtomIdx(atomIdx) <
               mol.getBondWithIdx(bi)->getOtherAtomIdx(atomIdx));
     });

--- a/Code/GraphMol/Descriptors/GETAWAY.cpp
+++ b/Code/GraphMol/Descriptors/GETAWAY.cpp
@@ -265,7 +265,7 @@ std::vector<double> GetGeodesicMatrix(const double* dist, int lag,
   std::vector<double> Geodesic;
   Geodesic.reserve(sizeArray);
   std::transform(dist, dist + sizeArray, Geodesic.begin(),
-                 [&lag](const double& dist) { return int(dist == lag); });
+                 [lag](double dist) { return int(dist == lag); });
 
   return Geodesic;
 }

--- a/Code/GraphMol/MolStandardize/Metal.cpp
+++ b/Code/GraphMol/MolStandardize/Metal.cpp
@@ -157,7 +157,7 @@ void MetalDisconnector::disconnect(RWMol &mol) {
     }
     std::sort(it->second.boundMetalIndices.begin(),
               it->second.boundMetalIndices.end(),
-              [metalChargeExcess](int a, int b) {
+              [&metalChargeExcess](int a, int b) {
                 return (metalChargeExcess.at(a) < metalChargeExcess.at(b));
               });
     fcAfterCut += loneElectrons;

--- a/Code/GraphMol/StereoGroup.cpp
+++ b/Code/GraphMol/StereoGroup.cpp
@@ -25,7 +25,7 @@ void removeGroupsWithAtom(const Atom *atom, std::vector<StereoGroup> &groups) {
 
 void removeGroupsWithAtoms(const std::vector<Atom *> &atoms,
                            std::vector<StereoGroup> &groups) {
-  auto containsAnyAtom = [atoms](const StereoGroup &group) {
+  auto containsAnyAtom = [&atoms](const StereoGroup &group) {
     for (auto atom : atoms) {
       if (std::find(group.getAtoms().cbegin(), group.getAtoms().cend(), atom) !=
           group.getAtoms().cend()) {

--- a/Code/GraphMol/SubstanceGroup.cpp
+++ b/Code/GraphMol/SubstanceGroup.cpp
@@ -269,7 +269,7 @@ bool SubstanceGroupChecks::isValidConnectType(const std::string &type) {
 
 bool SubstanceGroupChecks::isSubstanceGroupIdFree(const ROMol &mol,
                                                   unsigned int id) {
-  auto match_sgroup = [&](const SubstanceGroup &sg) {
+  auto match_sgroup = [id](const SubstanceGroup &sg) {
     unsigned int storedId;
     return sg.getPropIfPresent("ID", storedId) && id == storedId;
   };


### PR DESCRIPTION
Relatively small set of changes to try and ensure lambdas are being used cleanly and efficiently.
1. For lambdas being used locally: capture things which are cheap to copy and which the lambda doesn't need to change by value, Capture others by reference
2. Get rid of default captures which aren't needed

