### PR TITLE
Swap from RDUNUSED_PARAM to unnamed parameters

### DIFF
--- a/Code/ForceField/MMFF/Nonbonded.cpp
+++ b/Code/ForceField/MMFF/Nonbonded.cpp
@@ -78,10 +78,8 @@ void scaleVdWParams(double &R_star_ij, double &wellDepth,
   }
 }
 
-double calcEleEnergy(unsigned int idx1, unsigned int idx2, double dist,
-                     double chargeTerm, std::uint8_t dielModel, bool is1_4) {
-  RDUNUSED_PARAM(idx1);
-  RDUNUSED_PARAM(idx2);
+double calcEleEnergy(unsigned int, unsigned int, double dist, double chargeTerm,
+                     std::uint8_t dielModel, bool is1_4) {
   double corr_dist = dist + 0.05;
   double const diel = 332.0716;
   double const sc1_4 = 0.75;
@@ -90,7 +88,7 @@ double calcEleEnergy(unsigned int idx1, unsigned int idx2, double dist,
   }
   return (diel * chargeTerm / corr_dist * (is1_4 ? sc1_4 : 1.0));
 }
-}  // end of namespace utils
+}  // namespace Utils
 
 VdWContrib::VdWContrib(ForceField *owner, unsigned int idx1, unsigned int idx2,
                        const MMFFVdWRijstarEps *mmffVdWConstants) {
@@ -150,8 +148,7 @@ void VdWContrib::getGrad(double *pos, double *grad) const {
 }
 
 EleContrib::EleContrib(ForceField *owner, unsigned int idx1, unsigned int idx2,
-                       double chargeTerm, std::uint8_t dielModel,
-                       bool is1_4) {
+                       double chargeTerm, std::uint8_t dielModel, bool is1_4) {
   PRECONDITION(owner, "bad owner");
   URANGE_CHECK(idx1, owner->positions().size());
   URANGE_CHECK(idx2, owner->positions().size());
@@ -196,5 +193,5 @@ void EleContrib::getGrad(double *pos, double *grad) const {
     g2[i] -= dGrad;
   }
 }
-}
-}
+}  // namespace MMFF
+}  // namespace ForceFields

--- a/Code/ForceField/MMFF/Nonbonded.h
+++ b/Code/ForceField/MMFF/Nonbonded.h
@@ -93,6 +93,7 @@ RDKIT_FORCEFIELD_EXPORT double calcVdWEnergy(const double dist,
                                              const double R_star_ij,
                                              const double wellDepth);
 //! calculates and returns the electrostatic MMFF energy
+// FIX: idx1 and idx2 are not used
 RDKIT_FORCEFIELD_EXPORT double calcEleEnergy(unsigned int idx1,
                                              unsigned int idx2, double dist,
                                              double chargeTerm,

--- a/Code/GraphMol/Aromaticity.cpp
+++ b/Code/GraphMol/Aromaticity.cpp
@@ -169,12 +169,13 @@ static void applyHuckelToFused(
     const VECT_EDON_TYPE &edon,  // electron donor state for each atom
     INT_INT_VECT_MAP &ringNeighs,
     int &narom,  // number of aromatic ring so far
-    unsigned int maxNumFusedRings, const std::vector<Bond*>& bondsByIdx, unsigned int minRingSize= 0);
+    unsigned int maxNumFusedRings, const std::vector<Bond *> &bondsByIdx,
+    unsigned int minRingSize = 0);
 
 void markAtomsBondsArom(ROMol &mol, const VECT_INT_VECT &srings,
                         const VECT_INT_VECT &brings, const INT_VECT &ringIds,
                         std::set<unsigned int> &doneBonds,
-                        const std::vector<Bond*>& bondsByIdx) {
+                        const std::vector<Bond *> &bondsByIdx) {
   INT_VECT aring, bring;
   INT_VECT_CI ri, ai, bi;
 
@@ -304,9 +305,8 @@ bool incidentMultipleBond(const Atom *at) {
   return at->getExplicitValence() != static_cast<int>(deg);
 }
 
-bool applyHuckel(ROMol &mol, const INT_VECT &ring, const VECT_EDON_TYPE &edon,
+bool applyHuckel(ROMol &, const INT_VECT &ring, const VECT_EDON_TYPE &edon,
                  unsigned int minRingSize) {
-  RDUNUSED_PARAM(mol);
   if (ring.size() < minRingSize) {
     return false;
   }
@@ -347,8 +347,7 @@ void applyHuckelToFused(
     const VECT_EDON_TYPE &edon,  // electron donor state for each atom
     INT_INT_VECT_MAP &ringNeighs,  // list of neighbors for each candidate ring
     int &narom,                    // number of aromatic ring so far
-    unsigned int maxNumFusedRings,
-    const std::vector<Bond*>& bondsByIdx,
+    unsigned int maxNumFusedRings, const std::vector<Bond *> &bondsByIdx,
     unsigned int minRingSize) {
   // this function check huckel rule on a fused system it starts
   // with the individual rings in the system and then proceeds to
@@ -370,8 +369,8 @@ void applyHuckelToFused(
   size_t nRingBonds;
   {
     boost::dynamic_bitset<> fusedBonds(mol.getNumBonds());
-    for (auto ridx: fused) {
-      for (auto bidx: brings[ridx]) {
+    for (auto ridx : fused) {
+      for (auto bidx : brings[ridx]) {
         fusedBonds[bidx] = true;
       }
     }
@@ -388,7 +387,8 @@ void applyHuckelToFused(
       // fused system that we will try. The number of combinations
       // can obviously be quite large when the number of rings in
       // the fused system is large
-      if (curSize > std::min(nrings, maxNumFusedRings) || doneBonds.size() >= nRingBonds) {
+      if (curSize > std::min(nrings, maxNumFusedRings) ||
+          doneBonds.size() >= nRingBonds) {
         break;
       }
       comb.resize(curSize);
@@ -424,10 +424,10 @@ void applyHuckelToFused(
     }
     INT_VECT unon;
     for (i = 0; i < atsInRingSystem.size(); ++i) {
-      // condition for inclusion of an atom in the aromaticity of a fused ring system
-      // is that it's present in one or two of the rings.
-      // this was #2895: the central atom in acepentalene was being included in
-      // the count of aromatic atoms
+      // condition for inclusion of an atom in the aromaticity of a fused ring
+      // system is that it's present in one or two of the rings. this was #2895:
+      // the central atom in acepentalene was being included in the count of
+      // aromatic atoms
       if (atsInRingSystem[i] == 1 || atsInRingSystem[i] == 2) {
         unon.push_back(i);
       }
@@ -767,9 +767,9 @@ int mdlAromaticityHelper(RWMol &mol, const VECT_INT_VECT &srings) {
   boost::dynamic_bitset<> fusDone(cnrs);
   INT_VECT fused;
 
-  std::vector<Bond*> bondsByIdx;
+  std::vector<Bond *> bondsByIdx;
   bondsByIdx.reserve(mol.getNumBonds());
-  for (auto b: mol.bonds()) {
+  for (auto b : mol.bonds()) {
     bondsByIdx.push_back(b);
   }
 
@@ -858,10 +858,9 @@ int aromaticityHelper(RWMol &mol, const VECT_INT_VECT &srings,
   VECT_INT_VECT brings;
   RingUtils::convertToBonds(cRings, brings, mol);
 
-
-  std::vector<Bond*> bondsByIdx;
+  std::vector<Bond *> bondsByIdx;
   bondsByIdx.reserve(mol.getNumBonds());
-  for (auto b: mol.bonds()) {
+  for (auto b : mol.bonds()) {
     bondsByIdx.push_back(b);
   }
 
@@ -883,7 +882,8 @@ int aromaticityHelper(RWMol &mol, const VECT_INT_VECT &srings,
     // shares at least one bond
     // useful to figure out fused systems
     INT_INT_VECT_MAP neighMap;
-    RingUtils::makeRingNeighborMap(brings, neighMap, maxFusedAromaticRingSize, 1);
+    RingUtils::makeRingNeighborMap(brings, neighMap, maxFusedAromaticRingSize,
+                                   1);
 
     // now loop over all the candidate rings and check the
     // huckel rule - of course paying attention to fused systems.
@@ -895,7 +895,8 @@ int aromaticityHelper(RWMol &mol, const VECT_INT_VECT &srings,
     while (curr < cnrs) {
       fused.resize(0);
       RingUtils::pickFusedRings(curr, neighMap, fused, fusDone);
-      applyHuckelToFused(mol, cRings, brings, fused, edon, neighMap, narom, 6, bondsByIdx);
+      applyHuckelToFused(mol, cRings, brings, fused, edon, neighMap, narom, 6,
+                         bondsByIdx);
 
       int rix;
       for (rix = 0; rix < cnrs; rix++) {

--- a/Code/GraphMol/Atom.cpp
+++ b/Code/GraphMol/Atom.cpp
@@ -509,17 +509,13 @@ double Atom::getMass() const {
   }
 }
 
-void Atom::setQuery(Atom::QUERYATOM_QUERY *what) {
-  RDUNUSED_PARAM(what);
+void Atom::setQuery(Atom::QUERYATOM_QUERY *) {
   //  Atoms don't have complex queries so this has to fail
   PRECONDITION(0, "plain atoms have no Query");
 }
 Atom::QUERYATOM_QUERY *Atom::getQuery() const { return nullptr; };
-void Atom::expandQuery(Atom::QUERYATOM_QUERY *what,
-                       Queries::CompositeQueryType how, bool maintainOrder) {
-  RDUNUSED_PARAM(what);
-  RDUNUSED_PARAM(how);
-  RDUNUSED_PARAM(maintainOrder);
+void Atom::expandQuery(Atom::QUERYATOM_QUERY *, Queries::CompositeQueryType,
+                       bool) {
   PRECONDITION(0, "plain atoms have no Query");
 }
 

--- a/Code/GraphMol/Bond.cpp
+++ b/Code/GraphMol/Bond.cpp
@@ -194,13 +194,12 @@ double Bond::getValenceContrib(const Atom *atom) const {
   return res;
 }
 
-void Bond::setQuery(QUERYBOND_QUERY *what) {
+void Bond::setQuery(QUERYBOND_QUERY *) {
   //  Bonds don't have queries at the moment because I have not
   //  yet figured out what a good base query should be.
   //  It would be nice to be able to do substructure searches
   //  using molecules alone, so it'd be nice if we got this
   //  issue resolved ASAP.
-  RDUNUSED_PARAM(what);
   PRECONDITION(0, "plain bonds have no Query");
 }
 
@@ -220,11 +219,8 @@ bool Bond::Match(Bond const *what) const {
   return res;
 };
 
-void Bond::expandQuery(Bond::QUERYBOND_QUERY *what,
-                       Queries::CompositeQueryType how, bool maintainOrder) {
-  RDUNUSED_PARAM(what);
-  RDUNUSED_PARAM(how);
-  RDUNUSED_PARAM(maintainOrder);
+void Bond::expandQuery(Bond::QUERYBOND_QUERY *, Queries::CompositeQueryType,
+                       bool) {
   PRECONDITION(0, "plain bonds have no query");
 };
 

--- a/Code/GraphMol/Canon.cpp
+++ b/Code/GraphMol/Canon.cpp
@@ -346,7 +346,7 @@ void canonicalizeDoubleBond(Bond *dblBond, UINT_VECT &bondVisitOrders,
       atom2Dir = atom1Dir;
     } else if (dblBond->getStereo() == Bond::STEREOZ ||
                dblBond->getStereo() == Bond::STEREOCIS) {
-      atom2Dir = flipBondDir(atom1Dir); 
+      atom2Dir = flipBondDir(atom1Dir);
     }
     CHECK_INVARIANT(atom2Dir != Bond::NONE, "stereo not set");
 
@@ -360,8 +360,7 @@ void canonicalizeDoubleBond(Bond *dblBond, UINT_VECT &bondVisitOrders,
       }
       auto beginIdx = bond->getBeginAtomIdx();
       auto endIdx = bond->getEndAtomIdx();
-      return beginIdx > endIdx && 
-             beginIdx - endIdx > 1 &&
+      return beginIdx > endIdx && beginIdx - endIdx > 1 &&
              bond->hasProp(common_properties::_TraversalRingClosureBond);
     };
 
@@ -382,14 +381,12 @@ void canonicalizeDoubleBond(Bond *dblBond, UINT_VECT &bondVisitOrders,
                       atom2->getIdx()))) == stereoAtoms.end()) {
       isFlipped = true;
       atom2Dir = flipBondDir(atom2Dir);
-    } 
-    
-    if (!isFlipped && 
-          (isClosingRingBond(dblBond) ||
-          (isClosingRingBond(secondFromAtom1) && 
-            !secondFromAtom1->getIsAromatic() && 
-            secondFromAtom1->getBondDir() != Bond::NONE))
-        ) {
+    }
+
+    if (!isFlipped && (isClosingRingBond(dblBond) ||
+                       (isClosingRingBond(secondFromAtom1) &&
+                        !secondFromAtom1->getIsAromatic() &&
+                        secondFromAtom1->getBondDir() != Bond::NONE))) {
       atom2Dir = flipBondDir(atom2Dir);
     }
     // std::cerr<<" 1 set bond 2: "<<firstFromAtom2->getIdx()<<"
@@ -913,8 +910,7 @@ bool canHaveDirection(const Bond *bond) {
 
 void clearBondDirs(ROMol &mol, Bond *refBond, const Atom *fromAtom,
                    UINT_VECT &bondDirCounts, UINT_VECT &atomDirCounts,
-                   const UINT_VECT &bondVisitOrders) {
-  RDUNUSED_PARAM(bondVisitOrders);
+                   const UINT_VECT &) {
   PRECONDITION(bondDirCounts.size() >= mol.getNumBonds(), "bad dirCount size");
   PRECONDITION(refBond, "bad bond");
   PRECONDITION(&refBond->getOwningMol() == &mol, "bad bond");

--- a/Code/GraphMol/Chirality.cpp
+++ b/Code/GraphMol/Chirality.cpp
@@ -379,13 +379,12 @@ Bond::BondDir getOppositeBondDir(Bond::BondDir dir) {
 }
 
 void setBondDirRelativeToAtom(Bond *bond, Atom *atom, Bond::BondDir dir,
-                              bool reverse, boost::dynamic_bitset<> &needsDir) {
+                              bool reverse, boost::dynamic_bitset<> &) {
   PRECONDITION(bond, "bad bond");
   PRECONDITION(atom, "bad atom");
   PRECONDITION(dir == Bond::ENDUPRIGHT || dir == Bond::ENDDOWNRIGHT, "bad dir");
   PRECONDITION(atom == bond->getBeginAtom() || atom == bond->getEndAtom(),
                "atom doesn't belong to bond");
-  RDUNUSED_PARAM(needsDir);
 
   if (bond->getBeginAtom() != atom) {
     reverse = !reverse;

--- a/Code/GraphMol/Depictor/RDDepictor.cpp
+++ b/Code/GraphMol/Depictor/RDDepictor.cpp
@@ -422,9 +422,7 @@ unsigned int compute2DCoords(RDKit::ROMol &mol,
 unsigned int compute2DCoordsMimicDistMat(
     RDKit::ROMol &mol, const DOUBLE_SMART_PTR *dmat, bool canonOrient,
     bool clearConfs, double weightDistMat, unsigned int nFlipsPerSample,
-    unsigned int nSamples, int sampleSeed, bool permuteDeg4Nodes,
-    bool forceRDKit) {
-  RDUNUSED_PARAM(forceRDKit);
+    unsigned int nSamples, int sampleSeed, bool permuteDeg4Nodes, bool) {
   // storage for pieces of a molecule/s that are embedded in 2D
   std::list<EmbeddedFrag> efrags;
   computeInitialCoords(mol, nullptr, efrags);

--- a/Code/GraphMol/Descriptors/GETAWAY.cpp
+++ b/Code/GraphMol/Descriptors/GETAWAY.cpp
@@ -111,8 +111,7 @@ int countZeros(std::string ta) {
   return nbzero;
 }
 
-bool IsClose2(double a, double b, unsigned int precision) {
-  RDUNUSED_PARAM(precision);
+bool IsClose2(double a, double b, unsigned int) {
   bool isclose = false;
 
   std::string sa, sb;
@@ -150,8 +149,7 @@ bool IsClose2(double a, double b, unsigned int precision) {
   return isclose;
 }
 
-bool IsClose3(double a, double b, unsigned int precision) {
-  RDUNUSED_PARAM(precision);
+bool IsClose3(double a, double b, unsigned int) {
   bool isclose = false;
   std::string sa, sb;
   std::string ta, tb;

--- a/Code/GraphMol/Descriptors/MQN.cpp
+++ b/Code/GraphMol/Descriptors/MQN.cpp
@@ -17,8 +17,7 @@
 
 namespace RDKit {
 namespace Descriptors {
-std::vector<unsigned int> calcMQNs(const ROMol& mol, bool force) {
-  RDUNUSED_PARAM(force);
+std::vector<unsigned int> calcMQNs(const ROMol& mol, bool) {
   // FIX: use force value to enable caching
   std::vector<unsigned int> res(42, 0);
 

--- a/Code/GraphMol/DistGeomHelpers/BoundsMatrixBuilder.cpp
+++ b/Code/GraphMol/DistGeomHelpers/BoundsMatrixBuilder.cpp
@@ -242,9 +242,8 @@ void set12Bounds(const ROMol &mol, DistGeom::BoundsMatPtr mmat,
   }
 }
 
-void setLowerBoundVDW(const ROMol &mol, DistGeom::BoundsMatPtr mmat,
-                      bool useTopolScaling, double *dmat) {
-  RDUNUSED_PARAM(useTopolScaling);
+void setLowerBoundVDW(const ROMol &mol, DistGeom::BoundsMatPtr mmat, bool,
+                      double *dmat) {
   unsigned int npt = mmat->numRows();
   PRECONDITION(npt == mol.getNumAtoms(), "Wrong size metric matrix");
   unsigned int i, j;
@@ -823,9 +822,8 @@ bool _checkNhChChNh(const Atom *atm1, const Atom *atm2, const Atom *atm3,
 //    1   3
 //     \ / \                                         T.S.I.Left Blank
 //      2   5  <- 2 is an oxygen/nitrogen
-bool _checkAmideEster14(const Bond *bnd1, const Bond *bnd3, const Atom *atm1,
+bool _checkAmideEster14(const Bond *bnd1, const Bond *bnd3, const Atom *,
                         const Atom *atm2, const Atom *atm3, const Atom *atm4) {
-  RDUNUSED_PARAM(atm1);
   unsigned int a2Num = atm2->getAtomicNum();
   unsigned int a3Num = atm3->getAtomicNum();
   unsigned int a4Num = atm4->getAtomicNum();
@@ -857,12 +855,11 @@ bool _checkAmideEster14(const Bond *bnd1, const Bond *bnd3, const Atom *atm1,
 //    1   3
 //     \ / \                                         T.S.I.Left Blank
 //      2   4  <- 2 is an oxygen/nitrogen
-bool _checkMacrocycleAllInSameRingAmideEster14(
-    const ROMol &mol, const Bond *bnd1, const Bond *bnd3, const Atom *atm1,
-    const Atom *atm2, const Atom *atm3, const Atom *atm4) {
-  RDUNUSED_PARAM(bnd1);
-  RDUNUSED_PARAM(bnd3);
-
+bool _checkMacrocycleAllInSameRingAmideEster14(const ROMol &mol, const Bond *,
+                                               const Bond *, const Atom *atm1,
+                                               const Atom *atm2,
+                                               const Atom *atm3,
+                                               const Atom *atm4) {
   //   This is a re-write of `_checkAmideEster14` with more explicit logic on
   //   the checks It is interesting that we find with this function we get
   //   better macrocycle sampling than `_checkAmideEster14`
@@ -928,10 +925,8 @@ bool _isCarbonyl(const ROMol &mol, const Atom *at) {
 }
 
 bool _checkAmideEster15(const ROMol &mol, const Bond *bnd1, const Bond *bnd3,
-                        const Atom *atm1, const Atom *atm2, const Atom *atm3,
-                        const Atom *atm4) {
-  RDUNUSED_PARAM(atm1);
-  RDUNUSED_PARAM(atm4);
+                        const Atom *, const Atom *atm2, const Atom *atm3,
+                        const Atom *) {
   unsigned int a2Num = atm2->getAtomicNum();
   if ((a2Num == 8) || ((a2Num == 7) && (atm2->getTotalNumHs(true) == 1))) {
     if ((bnd1->getBondType() == Bond::SINGLE)) {
@@ -946,9 +941,8 @@ bool _checkAmideEster15(const ROMol &mol, const Bond *bnd1, const Bond *bnd3,
 
 void _setChain14Bounds(const ROMol &mol, const Bond *bnd1, const Bond *bnd2,
                        const Bond *bnd3, ComputedData &accumData,
-                       DistGeom::BoundsMatPtr mmat, double *dmat,
+                       DistGeom::BoundsMatPtr mmat, double *,
                        bool forceTransAmides) {
-  RDUNUSED_PARAM(dmat);
   PRECONDITION(bnd1, "");
   PRECONDITION(bnd2, "");
   PRECONDITION(bnd3, "");
@@ -1351,10 +1345,9 @@ void _setMacrocycleAllInSameRing14Bounds(const ROMol &mol, const Bond *bnd1,
                                          const Bond *bnd2, const Bond *bnd3,
                                          ComputedData &accumData,
                                          DistGeom::BoundsMatPtr mmat,
-                                         double *dmat) {
+                                         double *) {
   // This is adapted from `_setChain14Bounds`, with changes on how trans amide
   // is handled
-  RDUNUSED_PARAM(dmat);
   PRECONDITION(bnd1, "");
   PRECONDITION(bnd2, "");
   PRECONDITION(bnd3, "");

--- a/Code/GraphMol/DistGeomHelpers/Embedder.cpp
+++ b/Code/GraphMol/DistGeomHelpers/Embedder.cpp
@@ -483,8 +483,7 @@ bool firstMinimization(RDGeom::PointPtrVect *positions,
 
 bool checkTetrahedralCenters(const RDGeom::PointPtrVect *positions,
                              const detail::EmbedArgs &eargs,
-                             const EmbedParameters &embedParams) {
-  RDUNUSED_PARAM(embedParams);
+                             const EmbedParameters &) {
   // for each of the atoms in the "tetrahedralCarbons" list, make sure
   // that there is a minimum volume around them and that they are inside
   // that volume. (this is part of github #971)
@@ -509,8 +508,7 @@ bool checkTetrahedralCenters(const RDGeom::PointPtrVect *positions,
 }
 bool checkChiralCenters(const RDGeom::PointPtrVect *positions,
                         const detail::EmbedArgs &eargs,
-                        const EmbedParameters &embedParams) {
-  RDUNUSED_PARAM(embedParams);
+                        const EmbedParameters &) {
   // check the chiral volume:
   for (const auto &chiralSet : *eargs.chiralCenters) {
     double vol = DistGeom::ChiralViolationContrib::calcChiralVolume(
@@ -644,8 +642,7 @@ bool minimizeWithExpTorsions(RDGeom::PointPtrVect &positions,
 
 bool finalChiralChecks(RDGeom::PointPtrVect *positions,
                        const detail::EmbedArgs &eargs,
-                       const EmbedParameters &embedParams) {
-  RDUNUSED_PARAM(embedParams);
+                       const EmbedParameters &) {
   // "distance matrix" chirality test
   std::set<int> atoms;
   for (const auto &chiralSet : *eargs.chiralCenters) {
@@ -796,13 +793,10 @@ void findChiralSets(const ROMol &mol, DistGeom::VECT_CHIRALSET &chiralCenters,
         // if we have less than 4 heavy atoms as neighbors,
         // we need to include the chiral center into the mix
         // we should at least have 3 though
-        bool includeSelf = false;
-        RDUNUSED_PARAM(includeSelf);
         CHECK_INVARIANT(nbrs.size() >= 3, "Cannot be a chiral center");
 
         if (nbrs.size() < 4) {
           nbrs.insert(nbrs.end(), atom->getIdx());
-          includeSelf = true;
         }
 
         // now create a chiral set and set the upper and lower bound on the
@@ -839,9 +833,8 @@ void findChiralSets(const ROMol &mol, DistGeom::VECT_CHIRALSET &chiralCenters,
 }  // end of _findChiralSets
 
 void adjustBoundsMatFromCoordMap(
-    DistGeom::BoundsMatPtr mmat, unsigned int nAtoms,
+    DistGeom::BoundsMatPtr mmat, unsigned int,
     const std::map<int, RDGeom::Point3D> *coordMap) {
-  RDUNUSED_PARAM(nAtoms);
   for (auto iIt = coordMap->begin(); iIt != coordMap->end(); ++iIt) {
     unsigned int iIdx = iIt->first;
     const RDGeom::Point3D &iPoint = iIt->second;
@@ -927,9 +920,7 @@ bool setupInitialBoundsMatrix(
 }  // namespace EmbeddingOps
 
 void _fillAtomPositions(RDGeom::Point3DConstPtrVect &pts, const Conformer &conf,
-                        const ROMol &mol,
-                        const std::vector<unsigned int> &match) {
-  RDUNUSED_PARAM(mol);
+                        const ROMol &, const std::vector<unsigned int> &match) {
   PRECONDITION(pts.size() == match.size(), "bad pts size");
   for (unsigned int i = 0; i < match.size(); i++) {
     pts[i] = &conf.getAtomPos(match[i]);

--- a/Code/GraphMol/DistGeomHelpers/testDgeomHelpers.cpp
+++ b/Code/GraphMol/DistGeomHelpers/testDgeomHelpers.cpp
@@ -2320,8 +2320,7 @@ void testGithub3019() {
 }
 
 namespace {
-void throwerror(unsigned int notUsedHere) {
-  RDUNUSED_PARAM(notUsedHere);
+void throwerror(unsigned int) {
   throw ValueErrorException("embedder is abortable");
 }
 }  // namespace

--- a/Code/GraphMol/FMCS/FMCS.cpp
+++ b/Code/GraphMol/FMCS/FMCS.cpp
@@ -43,18 +43,16 @@ void MCSParameters::setMCSAtomTyperFromEnum(AtomComparator atomComp) {
   }
 }
 
-void MCSParameters::setMCSAtomTyperFromConstChar(const char *atomComp) {
+void MCSParameters::setMCSAtomTyperFromConstChar(const char* atomComp) {
   PRECONDITION(atomComp, "atomComp must not be NULL");
-  static const std::map<const char *, AtomComparator> atomCompStringToEnum = {
-    { "Any", AtomCompareAny },
-    { "Elements", AtomCompareElements },
-    { "Isotopes", AtomCompareIsotopes },
-    { "AnyHeavy", AtomCompareAnyHeavyAtom }
-  };
+  static const std::map<const char*, AtomComparator> atomCompStringToEnum = {
+      {"Any", AtomCompareAny},
+      {"Elements", AtomCompareElements},
+      {"Isotopes", AtomCompareIsotopes},
+      {"AnyHeavy", AtomCompareAnyHeavyAtom}};
   try {
     setMCSAtomTyperFromEnum(atomCompStringToEnum.at(atomComp));
-  }
-  catch(const std::out_of_range&) {
+  } catch (const std::out_of_range&) {
     // we accept "def" as a no-op
   }
 }
@@ -75,17 +73,15 @@ void MCSParameters::setMCSBondTyperFromEnum(BondComparator bondComp) {
   }
 }
 
-void MCSParameters::setMCSBondTyperFromConstChar(const char *bondComp) {
+void MCSParameters::setMCSBondTyperFromConstChar(const char* bondComp) {
   PRECONDITION(bondComp, "bondComp must not be NULL");
-  static const std::map<const char *, BondComparator> bondCompStringToEnum = {
-    { "Any", BondCompareAny },
-    { "Order", BondCompareOrder },
-    { "OrderExact", BondCompareOrderExact }
-  };
+  static const std::map<const char*, BondComparator> bondCompStringToEnum = {
+      {"Any", BondCompareAny},
+      {"Order", BondCompareOrder},
+      {"OrderExact", BondCompareOrderExact}};
   try {
     setMCSBondTyperFromEnum(bondCompStringToEnum.at(bondComp));
-  }
-  catch(const std::out_of_range&) {
+  } catch (const std::out_of_range&) {
     // we accept "def" as a no-op
   }
 }
@@ -109,8 +105,8 @@ void parseMCSParametersJSON(const char* json, MCSParameters* params) {
         "MatchFormalCharge", p.AtomCompareParameters.MatchFormalCharge);
     p.AtomCompareParameters.RingMatchesRingOnly = pt.get<bool>(
         "RingMatchesRingOnly", p.AtomCompareParameters.RingMatchesRingOnly);
-    p.AtomCompareParameters.MaxDistance = pt.get<double>(
-        "MaxDistance", p.AtomCompareParameters.MaxDistance);
+    p.AtomCompareParameters.MaxDistance =
+        pt.get<double>("MaxDistance", p.AtomCompareParameters.MaxDistance);
     p.BondCompareParameters.RingMatchesRingOnly = pt.get<bool>(
         "RingMatchesRingOnly", p.BondCompareParameters.RingMatchesRingOnly);
     p.AtomCompareParameters.RingMatchesRingOnly = pt.get<bool>(
@@ -130,8 +126,10 @@ void parseMCSParametersJSON(const char* json, MCSParameters* params) {
     p.BondCompareParameters.MatchStereo =
         pt.get<bool>("MatchStereo", p.BondCompareParameters.MatchStereo);
 
-    p.setMCSAtomTyperFromConstChar(pt.get<std::string>("AtomCompare", "def").c_str());
-    p.setMCSBondTyperFromConstChar(pt.get<std::string>("BondCompare", "def").c_str());
+    p.setMCSAtomTyperFromConstChar(
+        pt.get<std::string>("AtomCompare", "def").c_str());
+    p.setMCSBondTyperFromConstChar(
+        pt.get<std::string>("BondCompare", "def").c_str());
 
     p.InitialSeed = pt.get<std::string>("InitialSeed", "");
   }
@@ -190,9 +188,8 @@ MCSResult findMCS(const std::vector<ROMOL_SPTR>& mols, bool maximizeBonds,
   return res;
 }
 
-bool MCSProgressCallbackTimeout(const MCSProgressData& stat,
+bool MCSProgressCallbackTimeout(const MCSProgressData&,
                                 const MCSParameters& params, void* userData) {
-  RDUNUSED_PARAM(stat);
   PRECONDITION(userData, "userData must not be NULL");
   auto* t0 = (unsigned long long*)userData;
   unsigned long long t = nanoClock();
@@ -214,19 +211,17 @@ bool checkAtomRingMatch(const MCSAtomCompareParameters& p, const ROMol& mol1,
   }
 }
 
-bool checkAtomCharge(const MCSAtomCompareParameters& p,
-                     const ROMol& mol1, unsigned int atom1,
-                     const ROMol& mol2, unsigned int atom2) {
-  RDUNUSED_PARAM(p);
+bool checkAtomCharge(const MCSAtomCompareParameters&, const ROMol& mol1,
+                     unsigned int atom1, const ROMol& mol2,
+                     unsigned int atom2) {
   const Atom& a1 = *mol1.getAtomWithIdx(atom1);
   const Atom& a2 = *mol2.getAtomWithIdx(atom2);
   return a1.getFormalCharge() == a2.getFormalCharge();
 }
 
-bool checkAtomChirality(const MCSAtomCompareParameters& p,
-                        const ROMol& mol1, unsigned int atom1,
-                        const ROMol& mol2, unsigned int atom2) {
-  RDUNUSED_PARAM(p);
+bool checkAtomChirality(const MCSAtomCompareParameters&, const ROMol& mol1,
+                        unsigned int atom1, const ROMol& mol2,
+                        unsigned int atom2) {
   const Atom& a1 = *mol1.getAtomWithIdx(atom1);
   const Atom& a2 = *mol2.getAtomWithIdx(atom2);
   Atom::ChiralType ac1 = a1.getChiralTag();
@@ -238,13 +233,13 @@ bool checkAtomChirality(const MCSAtomCompareParameters& p,
   return true;
 }
 
-bool checkAtomDistance(const MCSAtomCompareParameters& p,
-                       const ROMol& mol1, unsigned int atom1,
-                       const ROMol& mol2, unsigned int atom2){
-  const Conformer &ci1 = mol1.getConformer(-1);
-  const Conformer &ci2 = mol2.getConformer(-1);
-  const RDGeom::Point3D &pos1 = ci1.getAtomPos(atom1);
-  const RDGeom::Point3D &pos2 = ci2.getAtomPos(atom2);
+bool checkAtomDistance(const MCSAtomCompareParameters& p, const ROMol& mol1,
+                       unsigned int atom1, const ROMol& mol2,
+                       unsigned int atom2) {
+  const Conformer& ci1 = mol1.getConformer(-1);
+  const Conformer& ci2 = mol2.getConformer(-1);
+  const RDGeom::Point3D& pos1 = ci1.getAtomPos(atom1);
+  const RDGeom::Point3D& pos2 = ci2.getAtomPos(atom2);
   bool withinRange = (pos1 - pos2).length() <= p.MaxDistance;
   return withinRange;
 }
@@ -258,7 +253,7 @@ bool MCSAtomCompareAny(const MCSAtomCompareParameters& p, const ROMol& mol1,
   if (p.MatchFormalCharge && !checkAtomCharge(p, mol1, atom1, mol2, atom2)) {
     return false;
   }
-  if (p.MaxDistance > 0 && !checkAtomDistance(p, mol1, atom1, mol2, atom2)){
+  if (p.MaxDistance > 0 && !checkAtomDistance(p, mol1, atom1, mol2, atom2)) {
     return false;
   }
   if (p.RingMatchesRingOnly) {
@@ -285,7 +280,7 @@ bool MCSAtomCompareElements(const MCSAtomCompareParameters& p,
   if (p.MatchFormalCharge && !checkAtomCharge(p, mol1, atom1, mol2, atom2)) {
     return false;
   }
-  if (p.MaxDistance > 0 && !checkAtomDistance(p, mol1, atom1, mol2, atom2)){
+  if (p.MaxDistance > 0 && !checkAtomDistance(p, mol1, atom1, mol2, atom2)) {
     return false;
   }
   if (p.RingMatchesRingOnly) {
@@ -296,8 +291,7 @@ bool MCSAtomCompareElements(const MCSAtomCompareParameters& p,
 
 bool MCSAtomCompareIsotopes(const MCSAtomCompareParameters& p,
                             const ROMol& mol1, unsigned int atom1,
-                            const ROMol& mol2, unsigned int atom2, void* ud) {
-  RDUNUSED_PARAM(ud);
+                            const ROMol& mol2, unsigned int atom2, void*) {
   // ignore everything except isotope information:
   // if( ! MCSAtomCompareElements (p, mol1, atom1, mol2, atom2, ud))
   //    return false;
@@ -312,7 +306,7 @@ bool MCSAtomCompareIsotopes(const MCSAtomCompareParameters& p,
   if (p.MatchFormalCharge && !checkAtomCharge(p, mol1, atom1, mol2, atom2)) {
     return false;
   }
-  if (p.MaxDistance > 0 && !checkAtomDistance(p, mol1, atom1, mol2, atom2)){
+  if (p.MaxDistance > 0 && !checkAtomDistance(p, mol1, atom1, mol2, atom2)) {
     return false;
   }
   if (p.RingMatchesRingOnly) {
@@ -370,10 +364,9 @@ class BondMatchOrderMatrix {
   }
 };
 
-bool checkBondStereo(const MCSBondCompareParameters& p,
-                     const ROMol& mol1, unsigned int bond1,
-                     const ROMol& mol2, unsigned int bond2) {
-  RDUNUSED_PARAM(p);
+bool checkBondStereo(const MCSBondCompareParameters&, const ROMol& mol1,
+                     unsigned int bond1, const ROMol& mol2,
+                     unsigned int bond2) {
   const Bond* b1 = mol1.getBondWithIdx(bond1);
   const Bond* b2 = mol2.getBondWithIdx(bond2);
   Bond::BondStereo bs1 = b1->getStereo();
@@ -387,8 +380,8 @@ bool checkBondStereo(const MCSBondCompareParameters& p,
 }
 
 bool checkBondRingMatch(const MCSBondCompareParameters&, const ROMol&,
-                               unsigned int bond1, const ROMol& mol2,
-                               unsigned int bond2, void* v_ringMatchMatrixSet) {
+                        unsigned int bond1, const ROMol& mol2,
+                        unsigned int bond2, void* v_ringMatchMatrixSet) {
   if (!v_ringMatchMatrixSet) {
     throw "v_ringMatchMatrixSet is NULL";  // never
   }
@@ -459,10 +452,9 @@ bool MCSBondCompareOrderExact(const MCSBondCompareParameters& p,
 }
 
 //=== RING COMPARE ========================================================
-inline bool ringFusionCheck(const std::uint32_t c1[],
-                            const std::uint32_t c2[], const ROMol& mol1,
-                            const FMCS::Graph& query, const ROMol& mol2,
-                            const FMCS::Graph& target,
+inline bool ringFusionCheck(const std::uint32_t c1[], const std::uint32_t c2[],
+                            const ROMol& mol1, const FMCS::Graph& query,
+                            const ROMol& mol2, const FMCS::Graph& target,
                             const MCSParameters* p) {
   PRECONDITION(p, "p must not be NULL");
   const RingInfo* ri2 = mol2.getRingInfo();
@@ -816,8 +808,7 @@ bool FinalChiralityCheckFunction_1(const short unsigned c1[],
                                    const short unsigned c2[], const ROMol& mol1,
                                    const FMCS::Graph& query, const ROMol& mol2,
                                    const FMCS::Graph& target,
-                                   const MCSParameters* p) {
-  RDUNUSED_PARAM(p);
+                                   const MCSParameters*) {
   const unsigned int qna = boost::num_vertices(query);  // getNumAtoms()
   // check chiral atoms:
   for (unsigned int i = 0; i < qna; ++i) {
@@ -833,13 +824,13 @@ bool FinalChiralityCheckFunction_1(const short unsigned c1[],
           ac2 == Atom::CHI_TETRAHEDRAL_CCW)) {
       continue;  // skip non chiral center TARGET atoms even if query atom is
     }
-                 // chiral
-                 ////                return false;
+    // chiral
+    ////                return false;
     // both atoms are chiral:
     const unsigned a1Degree =
         boost::out_degree(c1[i], query);  // a1.getDegree();
     if (a1Degree != a2.getDegree()) {  // number of all connected atoms in seed
-      return false;                  // ???
+      return false;                    // ???
     }
     INT_LIST qOrder;
     for (unsigned int j = 0; j < qna && qOrder.size() != a1Degree; ++j) {

--- a/Code/GraphMol/FMCS/MaximumCommonSubgraph.cpp
+++ b/Code/GraphMol/FMCS/MaximumCommonSubgraph.cpp
@@ -1141,8 +1141,6 @@ bool MaximumCommonSubgraph::checkIfMatchAndAppend(Seed& seed) {
 #ifdef FAST_SUBSTRUCT_CACHE
   SubstructureCache::HashKey cacheKey;
   SubstructureCache::TIndexEntry* cacheEntry = nullptr;
-  bool cacheEntryIsValid = false;
-  RDUNUSED_PARAM(cacheEntryIsValid);  // unused var
 #endif
 
   bool foundInCache = false;
@@ -1170,7 +1168,6 @@ bool MaximumCommonSubgraph::checkIfMatchAndAppend(Seed& seed) {
 #endif
       cacheEntry =
           HashCache.find(seed, QueryAtomLabels, QueryBondLabels, cacheKey);
-      cacheEntryIsValid = true;
       if (cacheEntry) {  // possibly found. check for hash collision
 #ifdef VERBOSE_STATISTICS_ON
         ++VerboseStatistics.HashKeyFoundInCache;

--- a/Code/GraphMol/FMCS/SubstructMatchCustom.cpp
+++ b/Code/GraphMol/FMCS/SubstructMatchCustom.cpp
@@ -172,10 +172,8 @@ bool SubstructMatchCustom(
     const ROMol& querySrc  // seed and full source query molecule
     ,
     MCSAtomCompareFunction atomCompare, MCSBondCompareFunction bondCompare,
-    MCSFinalMatchCheckFunction finalCompare,
-    const MCSAtomCompareParameters& acp, const MCSBondCompareParameters& bcp,
-    void* ud, match_V_t* match) {
-  RDUNUSED_PARAM(finalCompare);
+    MCSFinalMatchCheckFunction, const MCSAtomCompareParameters& acp,
+    const MCSBondCompareParameters& bcp, void* ud, match_V_t* match) {
   MolMatchFinalCheckFunctor matchChecker(query, target, querySrc, mol, nullptr);
   AtomLabelFunctor atomLabeler(query, target, querySrc, mol, atomCompare, acp,
                                ud);
@@ -189,5 +187,5 @@ bool SubstructMatchCustom(
   return boost::vf2(query, target, atomLabeler, bondLabeler, matchChecker,
                     *match);
 }
-}
-}
+}  // namespace FMCS
+}  // namespace RDKit

--- a/Code/GraphMol/FileParsers/Mol2FileParser.cpp
+++ b/Code/GraphMol/FileParsers/Mol2FileParser.cpp
@@ -800,8 +800,7 @@ void ParseMol2BondBlock(std::istream *inStream, RWMol *res, unsigned int nBonds,
 //
 //------------------------------------------------
 RWMol *Mol2DataStreamToMol(std::istream *inStream, bool sanitize, bool removeHs,
-                           Mol2Type variant, bool cleanupSubstructures) {
-  RDUNUSED_PARAM(variant);
+                           Mol2Type, bool cleanupSubstructures) {
   PRECONDITION(inStream, "no stream");
   std::string tempStr, lineBeg;
   typedef boost::tokenizer<boost::char_separator<char>> tokenizer;
@@ -985,7 +984,6 @@ RWMol *Mol2DataStreamToMol(std::istream *inStream, bool sanitize, bool removeHs,
 
 RWMol *Mol2DataStreamToMol(std::istream &inStream, bool sanitize, bool removeHs,
                            Mol2Type variant, bool cleanupSubstructures) {
-  RDUNUSED_PARAM(variant);
   return Mol2DataStreamToMol(&inStream, sanitize, removeHs, variant,
                              cleanupSubstructures);
 };
@@ -996,7 +994,6 @@ RWMol *Mol2DataStreamToMol(std::istream &inStream, bool sanitize, bool removeHs,
 //------------------------------------------------
 RWMol *Mol2BlockToMol(const std::string &molBlock, bool sanitize, bool removeHs,
                       Mol2Type variant, bool cleanupSubstructures) {
-  RDUNUSED_PARAM(variant);
   std::istringstream inStream(molBlock);
   return Mol2DataStreamToMol(inStream, sanitize, removeHs, variant,
                              cleanupSubstructures);
@@ -1012,7 +1009,6 @@ RWMol *Mol2FileToMol(const std::string &fName, bool sanitize, bool removeHs,
   // FIX: this binary mode of opening file is here because of a bug in VC++ 6.0
   // the function "tellg" does not work correctly if we do not open it this way
   //   Jan 2009: Confirmed that this is still the case in visual studio 2008
-  RDUNUSED_PARAM(variant);
   std::ifstream inStream(fName.c_str(), std::ios_base::binary);
   if (!inStream || (inStream.bad())) {
     std::ostringstream errout;

--- a/Code/GraphMol/FileParsers/MolFileParser.cpp
+++ b/Code/GraphMol/FileParsers/MolFileParser.cpp
@@ -3039,7 +3039,6 @@ bool ParseV2000CTAB(std::istream *inStream, unsigned int &line, RWMol *mol,
                     Conformer *&conf, bool &chiralityPossible,
                     unsigned int &nAtoms, unsigned int &nBonds,
                     bool strictParsing) {
-  RDUNUSED_PARAM(strictParsing);
   conf = new Conformer(nAtoms);
   if (nAtoms == 0) {
     conf->set3D(false);

--- a/Code/GraphMol/FileParsers/MolFileWriter.cpp
+++ b/Code/GraphMol/FileParsers/MolFileWriter.cpp
@@ -1333,7 +1333,6 @@ std::string outputMolToMolBlock(const RWMol &tmol, int confId,
 
 std::string MolToMolBlock(const ROMol &mol, bool includeStereo, int confId,
                           bool kekulize, bool forceV3000) {
-  RDUNUSED_PARAM(includeStereo);
   RDKit::Utils::LocaleSwitcher switcher;
   RWMol trwmol(mol);
   // NOTE: kekulize the molecule before writing it out

--- a/Code/GraphMol/FileParsers/MolSGroupParsing.cpp
+++ b/Code/GraphMol/FileParsers/MolSGroupParsing.cpp
@@ -1061,9 +1061,8 @@ std::string ParseV3000StringPropLabel(std::stringstream &stream) {
 
 void ParseV3000ParseLabel(const std::string &label,
                           std::stringstream &lineStream, STR_VECT &dataFields,
-                          unsigned int line, SubstanceGroup &sgroup,
-                          size_t nSgroups, RWMol *mol, bool strictParsing) {
-  RDUNUSED_PARAM(nSgroups);
+                          unsigned int line, SubstanceGroup &sgroup, size_t,
+                          RWMol *mol, bool strictParsing) {
   // TODO: we could handle these in a more structured way
   try {
     if (label == "XBHEAD" || label == "XBCORR") {

--- a/Code/GraphMol/FileParsers/SmilesWriter.cpp
+++ b/Code/GraphMol/FileParsers/SmilesWriter.cpp
@@ -110,8 +110,7 @@ SmilesWriter::~SmilesWriter() {
   }
 }
 
-void SmilesWriter::write(const ROMol &mol, int confId) {
-  RDUNUSED_PARAM(confId);
+void SmilesWriter::write(const ROMol &mol, int) {
   CHECK_INVARIANT(dp_ostream, "no output stream");
   if (d_molid <= 0 && df_includeHeader) {
     dumpHeader();

--- a/Code/GraphMol/FileParsers/TplFileWriter.cpp
+++ b/Code/GraphMol/FileParsers/TplFileWriter.cpp
@@ -52,8 +52,7 @@ void writeAtom(const ROMol &mol, unsigned int atomId,
 }
 
 void writeBond(const ROMol &mol, unsigned int bondId,
-               ROMol::ConstConformerIterator confIt, std::ostringstream &dest) {
-  RDUNUSED_PARAM(confIt);
+               std::ostringstream &dest) {
   const Bond *bond = mol.getBondWithIdx(bondId);
   dest << bondId + 1;
   std::string bondLabel;
@@ -132,7 +131,7 @@ std::string MolToTPLText(const ROMol &mol, const std::string &partialChargeProp,
 
   // write the bonds:
   for (unsigned int i = 0; i < mol.getNumBonds(); ++i) {
-    TPLWriter::writeBond(mol, i, confIt, res);
+    TPLWriter::writeBond(mol, i, res);
   }
 
   // write the additional conformations:

--- a/Code/GraphMol/FilterCatalog/FilterCatalog.cpp
+++ b/Code/GraphMol/FilterCatalog/FilterCatalog.cpp
@@ -65,22 +65,24 @@ void FilterCatalogParams::fillCatalog(FilterCatalog &catalog) const {
     // XXX Fix Me -> these should probably be shared to save memory
     const FilterProperty_t *props = GetFilterProperties(catalogToAdd);
     CHECK_INVARIANT(props, "No filter properties for catalog");
-    
+
     for (unsigned int i = 0; i < entries; ++i) {
       const FilterData_t &data = GetFilterData(catalogToAdd)[i];
       FilterCatalogEntry *entry =
           MakeFilterCatalogEntry(data, propEntries, props);
 
       if (entry) {
-	catalog.addEntry(entry);  // catalog owns entry
+        catalog.addEntry(entry);  // catalog owns entry
       } else {
-	std::string catalog_name = "Unnamed internal catalog";
-	for(unsigned int i=0; i<propEntries; ++i) {
-	  if (std::string("FilterSet") == props[i].key) {
-	    catalog_name = props[i].value;
-	  }
-	}
-	throw ValueErrorException(std::string("Bad entry in built-in filter catalog: ") + catalog_name);
+        std::string catalog_name = "Unnamed internal catalog";
+        for (unsigned int i = 0; i < propEntries; ++i) {
+          if (std::string("FilterSet") == props[i].key) {
+            catalog_name = props[i].value;
+          }
+        }
+        throw ValueErrorException(
+            std::string("Bad entry in built-in filter catalog: ") +
+            catalog_name);
       }
     }
   }
@@ -142,13 +144,11 @@ std::string FilterCatalog::Serialize() const {
 #endif
 }
 
-unsigned int FilterCatalog::addEntry(entryType_t *entry, bool updateFPLength) {
-  RDUNUSED_PARAM(updateFPLength);
+unsigned int FilterCatalog::addEntry(entryType_t *entry, bool) {
   return addEntry(boost::shared_ptr<entryType_t>(entry));
 }
 
-unsigned int FilterCatalog::addEntry(SENTRY entry, bool updateFPLength) {
-  RDUNUSED_PARAM(updateFPLength);
+unsigned int FilterCatalog::addEntry(SENTRY entry, bool) {
   d_entries.push_back(entry);
   return static_cast<unsigned int>(d_entries.size() - 1);
 }
@@ -251,4 +251,4 @@ bool FilterCatalogCanSerialize() {
   return false;
 #endif
 }
-}
+}  // namespace RDKit

--- a/Code/GraphMol/FindRings.cpp
+++ b/Code/GraphMol/FindRings.cpp
@@ -29,8 +29,7 @@ const size_t MAX_BFSQ_SIZE = 200000;  // arbitrary huge value
 
 using namespace RDKit;
 
-std::uint32_t computeRingInvariant(INT_VECT ring, unsigned int nAtoms) {
-  RDUNUSED_PARAM(nAtoms);
+std::uint32_t computeRingInvariant(INT_VECT ring, unsigned int) {
   std::sort(ring.begin(), ring.end());
   std::uint32_t res = gboost::hash_range(ring.begin(), ring.end());
   return res;
@@ -209,9 +208,7 @@ struct compRingSize : public std::binary_function<INT_VECT, INT_VECT, bool> {
   }
 };
 
-void removeExtraRings(VECT_INT_VECT &res, unsigned int nexpt,
-                      const ROMol &mol) {
-  RDUNUSED_PARAM(nexpt);
+void removeExtraRings(VECT_INT_VECT &res, unsigned int, const ROMol &mol) {
   // sort on size
   std::sort(res.begin(), res.end(), compRingSize());
 
@@ -414,9 +411,8 @@ void findRingsD2nodes(const ROMol &tMol, VECT_INT_VECT &res,
 }
 
 void findRingsD3Node(const ROMol &tMol, VECT_INT_VECT &res,
-                     RINGINVAR_SET &invars, int cand, INT_VECT &atomDegrees,
+                     RINGINVAR_SET &invars, int cand, INT_VECT &,
                      boost::dynamic_bitset<> activeBonds) {
-  RDUNUSED_PARAM(atomDegrees);
   // this is brutal - we have no degree 2 nodes - find the first possible degree
   // 3 node
   int nsmall;

--- a/Code/GraphMol/Fingerprints/MorganFingerprints.cpp
+++ b/Code/GraphMol/Fingerprints/MorganFingerprints.cpp
@@ -81,9 +81,7 @@ uint32_t updateElement(SparseIntVect<uint32_t> &v, unsigned int elem,
   }
   return bit;
 }
-uint32_t updateElement(ExplicitBitVect &v, unsigned int elem,
-                       bool counting = false) {
-  RDUNUSED_PARAM(counting);
+uint32_t updateElement(ExplicitBitVect &v, unsigned int elem, bool) {
   uint32_t bit = elem % v.getNumBits();
   v.setBit(bit);
   return bit;

--- a/Code/GraphMol/ForceFieldHelpers/MMFF/AtomTyper.cpp
+++ b/Code/GraphMol/ForceFieldHelpers/MMFF/AtomTyper.cpp
@@ -2740,9 +2740,8 @@ MMFFMolProperties::getMMFFTorsionType(const ROMol &mol, const unsigned int idx1,
 // tabulated parameters could not be found. The returned
 // pointer to a MMFFBond object must be freed by the caller
 const ForceFields::MMFF::MMFFBond *
-MMFFMolProperties::getMMFFBondStretchEmpiricalRuleParams(const ROMol &mol,
+MMFFMolProperties::getMMFFBondStretchEmpiricalRuleParams(const ROMol &,
                                                          const Bond *bond) {
-  RDUNUSED_PARAM(mol);
   PRECONDITION(this->isValid(), "missing atom types - invalid force-field");
 
   const MMFFBond *mmffBndkParams;

--- a/Code/GraphMol/ForceFieldHelpers/UFF/AtomTyper.cpp
+++ b/Code/GraphMol/ForceFieldHelpers/UFF/AtomTyper.cpp
@@ -391,8 +391,7 @@ std::string getAtomLabel(const Atom *atom) {
 
 // ---------------------------------------------------------------
 std::pair<AtomicParamVect, bool> getAtomTypes(const ROMol &mol,
-                                              const std::string &paramData) {
-  RDUNUSED_PARAM(paramData);
+                                              const std::string &) {
   bool foundAll = true;
   ParamCollection *params = ParamCollection::getParams();
 
@@ -591,7 +590,7 @@ bool getUFFInversionParams(const ROMol &mol, unsigned int idx1,
     isBoundToSP2O = (isBoundToSP2O && (at2AtomicNum == 6));
     boost::tuple<double, double, double, double> invCoeffForceCon =
         UFF::Utils::calcInversionCoefficientsAndForceConstant(at2AtomicNum,
-                                                         isBoundToSP2O);
+                                                              isBoundToSP2O);
     uffInversionParams.K = boost::tuples::get<0>(invCoeffForceCon);
   }
   return res;
@@ -611,10 +610,12 @@ bool getUFFVdWParams(const ROMol &mol, unsigned int idx1, unsigned int idx2,
     res = (paramVect[i] ? true : false);
   }
   if (res) {
-    uffVdWParams.x_ij = UFF::Utils::calcNonbondedMinimum(paramVect[0], paramVect[1]);
-    uffVdWParams.D_ij = UFF::Utils::calcNonbondedDepth(paramVect[0], paramVect[1]);
+    uffVdWParams.x_ij =
+        UFF::Utils::calcNonbondedMinimum(paramVect[0], paramVect[1]);
+    uffVdWParams.D_ij =
+        UFF::Utils::calcNonbondedDepth(paramVect[0], paramVect[1]);
   }
   return res;
 }
-}
-}
+}  // namespace UFF
+}  // namespace RDKit

--- a/Code/GraphMol/Kekulize.cpp
+++ b/Code/GraphMol/Kekulize.cpp
@@ -20,11 +20,9 @@ namespace RDKit {
 // Local utility namespace
 namespace {
 
-void backTrack(RWMol &mol, INT_INT_DEQ_MAP &options, int lastOpt,
-               INT_VECT &done, INT_DEQUE &aqueue,
-               boost::dynamic_bitset<> &dBndCands,
+void backTrack(RWMol &mol, INT_INT_DEQ_MAP &, int lastOpt, INT_VECT &done,
+               INT_DEQUE &aqueue, boost::dynamic_bitset<> &dBndCands,
                boost::dynamic_bitset<> &dBndAdds) {
-  RDUNUSED_PARAM(options);
   // so we made a wrong turn at the lastOpt
   // remove on done list that comes after the lastOpt including itself
 

--- a/Code/GraphMol/MMPA/MMPA.cpp
+++ b/Code/GraphMol/MMPA/MMPA.cpp
@@ -75,8 +75,7 @@ static inline unsigned long long computeMorganCodeHash(const ROMol& mol) {
 
 static inline void convertMatchingToBondVect(
     std::vector<BondVector_t>& matching_bonds,
-    const std::vector<MatchVectType>& matching_atoms, const ROMol& mol) {
-  RDUNUSED_PARAM(mol);
+    const std::vector<MatchVectType>& matching_atoms) {
   for (const auto& matching_atom : matching_atoms) {
     matching_bonds.emplace_back();
     BondVector_t& mb = matching_bonds.back();  // current match
@@ -504,7 +503,7 @@ bool fragmentMol(const ROMol& mol,
 #endif
 
   std::vector<BondVector_t> matching_bonds;  // List of matched query's bonds
-  convertMatchingToBondVect(matching_bonds, matching_atoms, mol);
+  convertMatchingToBondVect(matching_bonds, matching_atoms);
   if (matching_bonds.size() > maxCutBonds) {
     return false;
   }

--- a/Code/GraphMol/MolCatalog/MolCatalogParams.cpp
+++ b/Code/GraphMol/MolCatalog/MolCatalogParams.cpp
@@ -1,6 +1,5 @@
-// $Id$
 //
-//  Copyright (C) 2006 Greg Landrum
+//  Copyright (C) 2006-2021 Greg Landrum and other RDKit contributors
 //
 //
 #include "MolCatalogParams.h"
@@ -16,8 +15,7 @@ MolCatalogParams::MolCatalogParams(const std::string &pickle) {
 
 MolCatalogParams::~MolCatalogParams() {}
 
-void MolCatalogParams::toStream(std::ostream &ss) const {
-  RDUNUSED_PARAM(ss);
+void MolCatalogParams::toStream(std::ostream &) const {
   // at the moment this is a no-op
 }
 std::string MolCatalogParams::Serialize() const {
@@ -31,8 +29,7 @@ void MolCatalogParams::initFromString(const std::string &text) {
   initFromStream(ss);
 }
 
-void MolCatalogParams::initFromStream(std::istream &ss) {
-  RDUNUSED_PARAM(ss);
+void MolCatalogParams::initFromStream(std::istream &) {
   // at the moment this is a no-op
 }
-}
+}  // namespace RDKit

--- a/Code/GraphMol/MolChemicalFeatures/MolChemicalFeature.cpp
+++ b/Code/GraphMol/MolChemicalFeatures/MolChemicalFeature.cpp
@@ -49,11 +49,6 @@ RDGeom::Point3D MolChemicalFeature::getPos(int confId) const {
   // --------------
   // Nope, we have to figure it out on our own:
   RDGeom::Point3D res(0, 0, 0);
-  bool setNeg1 = false;
-  RDUNUSED_PARAM(setNeg1);
-  if (confId == -1) {
-    setNeg1 = true;
-  }
 
   if (d_atoms.size() == 1) {
     res = dp_mol->getConformer(confId).getAtomPos((*d_atoms.begin())->getIdx());
@@ -75,4 +70,4 @@ RDGeom::Point3D MolChemicalFeature::getPos(int confId) const {
 
   return res;
 }
-}
+}  // namespace RDKit

--- a/Code/GraphMol/MolDiscriminators.cpp
+++ b/Code/GraphMol/MolDiscriminators.cpp
@@ -55,9 +55,8 @@ double computeBalabanJ(double *distMat, int nb, int nAts) {
   return nActive / ((mu + 1) * accum);
 }
 
-double computeBalabanJ(const ROMol &mol, bool useBO, bool force,
+double computeBalabanJ(const ROMol &mol, bool, bool force,
                        const std::vector<int> *bondPath, bool cacheIt) {
-  RDUNUSED_PARAM(useBO);
   double res = 0.0;
   if (!force && mol.hasProp(common_properties::BalabanJ)) {
     mol.getProp(common_properties::BalabanJ, res);

--- a/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
@@ -1952,9 +1952,8 @@ void MolDraw2D::calcLabelEllipse(int atom_idx,
 }
 
 // ****************************************************************************
-StringRect MolDraw2D::calcAnnotationPosition(const ROMol &mol,
+StringRect MolDraw2D::calcAnnotationPosition(const ROMol &,
                                              const std::string &note) {
-  RDUNUSED_PARAM(mol);
   StringRect note_rect;
   if (note.empty()) {
     note_rect.width_ = -1.0;  // so we know it's not valid.
@@ -3040,7 +3039,7 @@ void drawNormalBond(MolDraw2D &d2d, const Bond &bond, bool highlight_bond,
       swap(col1, col2);
       inverted = true;
     }
-    if(d2d.drawOptions().singleColourWedgeBonds) {
+    if (d2d.drawOptions().singleColourWedgeBonds) {
       col1 = d2d.drawOptions().symbolColour;
       col2 = d2d.drawOptions().symbolColour;
     }
@@ -3245,11 +3244,8 @@ void drawQueryBond1(MolDraw2D &d2d, const Bond &bond, bool highlight_bond,
 
 void drawQueryBond(MolDraw2D &d2d, const Bond &bond, bool highlight_bond,
                    const Point2D &at1_cds, const Point2D &at2_cds,
-                   const std::vector<Point2D> &at_cds, const DrawColour &col1,
-                   const DrawColour &col2, double double_bond_offset) {
-  RDUNUSED_PARAM(col1);
-  RDUNUSED_PARAM(col2);
-
+                   const std::vector<Point2D> &at_cds,
+                   double double_bond_offset) {
   PRECONDITION(bond.hasQuery(), "no query");
   const auto qry = bond.getQuery();
   if (!d2d.drawOptions().splitBonds) {
@@ -3393,17 +3389,13 @@ void drawQueryBond(MolDraw2D &d2d, const Bond &bond, bool highlight_bond,
 
 // ****************************************************************************
 void MolDraw2D::drawBond(
-    const ROMol &mol, const Bond *bond, int at1_idx, int at2_idx,
-    const vector<int> *highlight_atoms,
-    const map<int, DrawColour> *highlight_atom_map,
+    const ROMol &, const Bond *bond, int at1_idx, int at2_idx,
+    const vector<int> *, const map<int, DrawColour> *,
     const vector<int> *highlight_bonds,
     const map<int, DrawColour> *highlight_bond_map,
     const std::vector<std::pair<DrawColour, DrawColour>> *bond_colours) {
   PRECONDITION(bond, "no bond");
   PRECONDITION(activeMolIdx_ >= 0, "bad mol idx");
-  RDUNUSED_PARAM(highlight_atoms);
-  RDUNUSED_PARAM(highlight_atom_map);
-  RDUNUSED_PARAM(mol);
 
   if (static_cast<unsigned int>(at1_idx) != bond->getBeginAtomIdx()) {
     std::swap(at1_idx, at2_idx);
@@ -3460,7 +3452,7 @@ void MolDraw2D::drawBond(
     if (bond->getQuery()->getNegation() || descr != "BondOrder") {
       isComplex = true;
       drawQueryBond(*this, *bond, highlight_bond, at1_cds, at2_cds,
-                    at_cds_[activeMolIdx_], col1, col2, double_bond_offset);
+                    at_cds_[activeMolIdx_], double_bond_offset);
     }
   }
 
@@ -4414,9 +4406,7 @@ void MolDraw2D::drawRect(const Point2D &cds1, const Point2D &cds2) {
 
 void MolDraw2D::drawWavyLine(const Point2D &cds1, const Point2D &cds2,
                              const DrawColour &col1, const DrawColour &col2,
-                             unsigned int nSegments, double vertOffset) {
-  RDUNUSED_PARAM(nSegments);
-  RDUNUSED_PARAM(vertOffset);
+                             unsigned int, double) {
   drawLine(cds1, cds2, col1, col2);
 }
 

--- a/Code/GraphMol/MolDraw2D/MolDraw2DCairo.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DCairo.cpp
@@ -94,12 +94,10 @@ void MolDraw2DCairo::drawLine(const Point2D &cds1, const Point2D &cds2) {
 }
 
 void MolDraw2DCairo::drawWavyLine(const Point2D &cds1, const Point2D &cds2,
-                                  const DrawColour &col1,
-                                  const DrawColour &col2,
+                                  const DrawColour &col1, const DrawColour &,
                                   unsigned int nSegments, double vertOffset) {
   PRECONDITION(dp_cr, "no draw context");
   PRECONDITION(nSegments > 1, "too few segments");
-  RDUNUSED_PARAM(col2);
 
   if (nSegments % 2) {
     ++nSegments;  // we're going to assume an even number of segments

--- a/Code/GraphMol/MolDraw2D/MolDraw2DSVG.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DSVG.cpp
@@ -44,9 +44,7 @@ void outputTagClasses(const t_obj *obj, std::ostream &d_os,
 }
 
 template <class t_obj>
-void outputMetaData(const t_obj *obj, std::ostream &d_os,
-                    const std::string &d_activeClass) {
-  RDUNUSED_PARAM(d_activeClass);
+void outputMetaData(const t_obj *obj, std::ostream &d_os) {
   std::string value;
   for (const auto &prop : obj->getPropList()) {
     if (prop.length() < 11 || prop.rfind("_metaData-", 0) != 0) {
@@ -155,10 +153,9 @@ void MolDraw2DSVG::setColour(const DrawColour &col) {
 
 // ****************************************************************************
 void MolDraw2DSVG::drawWavyLine(const Point2D &cds1, const Point2D &cds2,
-                                const DrawColour &col1, const DrawColour &col2,
+                                const DrawColour &col1, const DrawColour &,
                                 unsigned int nSegments, double vertOffset) {
   PRECONDITION(nSegments > 1, "too few segments");
-  RDUNUSED_PARAM(col2);
 
   if (nSegments % 2) {
     ++nSegments;  // we're going to assume an even number of segments
@@ -379,7 +376,7 @@ void MolDraw2DSVG::addMoleculeMetadata(const ROMol &mol, int confId) const {
          << " y=\"" << pos.y << "\""
          << " z=\"" << pos.z << "\"";
 
-    outputMetaData(atom, d_os, d_activeClass);
+    outputMetaData(atom, d_os);
 
     d_os << " />" << std::endl;
   }
@@ -392,7 +389,7 @@ void MolDraw2DSVG::addMoleculeMetadata(const ROMol &mol, int confId) const {
          << SmilesWrite::GetBondSmiles(bond, -1, doKekule, allBondsExplicit)
          << "\"";
 
-    outputMetaData(bond, d_os, d_activeClass);
+    outputMetaData(bond, d_os);
 
     d_os << " />" << std::endl;
   }

--- a/Code/GraphMol/MolDraw2D/Wrap/rdMolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/Wrap/rdMolDraw2D.cpp
@@ -575,6 +575,7 @@ std::string molToSVG(const ROMol &mol, unsigned int width, unsigned int height,
                      python::object pyHighlightAtoms, bool kekulize,
                      unsigned int lineWidthMult, bool includeAtomCircles,
                      int confId) {
+  // FIX: we really should be using kekulize here
   RDUNUSED_PARAM(kekulize);
   std::unique_ptr<std::vector<int>> highlightAtoms =
       pythonObjectToVect(pyHighlightAtoms, static_cast<int>(mol.getNumAtoms()));
@@ -582,6 +583,7 @@ std::string molToSVG(const ROMol &mol, unsigned int width, unsigned int height,
   MolDraw2DSVG drawer(width, height, outs);
   drawer.setLineWidth(drawer.lineWidth() * lineWidthMult);
   drawer.drawOptions().circleAtoms = includeAtomCircles;
+  drawer.drawOptions().prepareMolsBeforeDrawing = false;
   drawer.drawMolecule(mol, highlightAtoms.get(), nullptr, nullptr, confId);
   drawer.finishDrawing();
   return outs.str();

--- a/Code/GraphMol/MolInterchange/Parser.cpp
+++ b/Code/GraphMol/MolInterchange/Parser.cpp
@@ -261,8 +261,7 @@ void readConformer(Conformer *conf, const rj::Value &confVal) {
 }
 
 void readPartialCharges(RWMol *mol, const rj::Value &repVal,
-                        const JSONParseParameters &params) {
-  RDUNUSED_PARAM(params);
+                        const JSONParseParameters &) {
   PRECONDITION(mol, "no molecule");
   PRECONDITION(repVal["name"].GetString() == std::string("partialCharges"),
                "bad charges");
@@ -312,10 +311,9 @@ Query<int, Bond const *, true> *readQuery(Bond const *owner,
 template <class T>
 Query<int, T const *, true> *readBaseQuery(T const *owner,
                                            const rj::Value &repVal,
-                                           const JSONParseParameters &params) {
+                                           const JSONParseParameters &) {
   PRECONDITION(owner, "no query");
   PRECONDITION(repVal.HasMember("tag"), "no tag");
-  RDUNUSED_PARAM(params);
   int tag = repVal["tag"].GetInt();
   if (!repVal.HasMember("descr")) {
     throw FileParseException("Bad Format: missing query description");

--- a/Code/GraphMol/MolPickler.cpp
+++ b/Code/GraphMol/MolPickler.cpp
@@ -754,7 +754,7 @@ void MolPickler::pickleMol(const ROMol *mol, std::ostream &ss,
 #else
     _pickleV1(mol, ss);
 #endif
-  } catch (const std::ios_base::failure &e) {
+  } catch (const std::ios_base::failure &) {
     if (ss.eof()) {
       throw MolPicklerException(
           "Bad pickle format: unexpected End-of-File while writing");
@@ -857,7 +857,7 @@ void MolPickler::molFromPickle(std::istream &ss, ROMol *mol,
       // FIX for issue 220 - probably better to change the pickle format later
       MolOps::assignStereochemistry(*mol, true);
     }
-  } catch (const std::ios_base::failure &e) {
+  } catch (const std::ios_base::failure &) {
     if (ss.eof()) {
       throw MolPicklerException(
           "Bad pickle format: unexpected End-of-File while reading");
@@ -1525,9 +1525,7 @@ Conformer *MolPickler::_conformerFromPickle(std::istream &ss, int version) {
 
 template <typename T>
 Atom *MolPickler::_addAtomFromPickle(std::istream &ss, ROMol *mol,
-                                     RDGeom::Point3D &pos, int version,
-                                     bool directMap) {
-  RDUNUSED_PARAM(directMap);
+                                     RDGeom::Point3D &pos, int version, bool) {
   PRECONDITION(mol, "empty molecule");
   float x, y, z;
   char tmpChar;
@@ -1929,7 +1927,8 @@ void MolPickler::_addRingInfoFromPickle(std::istream &ss, ROMol *mol,
         streamRead(ss, tmpT, version);
         if (directMap) {
           atoms[j] = static_cast<int>(tmpT);
-          if (atoms[j] < 0 || atoms[j] >= mol->getNumAtoms()) {
+          if (atoms[j] < 0 ||
+              static_cast<unsigned int>(atoms[j]) >= mol->getNumAtoms()) {
             throw MolPicklerException("ring-atom index out of range");
           }
         } else {
@@ -1941,7 +1940,8 @@ void MolPickler::_addRingInfoFromPickle(std::istream &ss, ROMol *mol,
           streamRead(ss, tmpT, version);
           if (directMap) {
             bonds[j] = static_cast<int>(tmpT);
-            if (bonds[j] < 0 || bonds[j] >= mol->getNumBonds()) {
+            if (bonds[j] < 0 ||
+                static_cast<unsigned int>(bonds[j]) >= mol->getNumBonds()) {
               throw MolPicklerException("ring-bond index out of range");
             }
 

--- a/Code/GraphMol/MolStandardize/AcidBaseCatalog/AcidBaseCatalogParams.cpp
+++ b/Code/GraphMol/MolStandardize/AcidBaseCatalog/AcidBaseCatalogParams.cpp
@@ -73,13 +73,11 @@ std::string AcidBaseCatalogParams::Serialize() const {
   return ss.str();
 }
 
-void AcidBaseCatalogParams::initFromStream(std::istream &ss) {
-  RDUNUSED_PARAM(ss);
+void AcidBaseCatalogParams::initFromStream(std::istream &) {
   UNDER_CONSTRUCTION("not implemented");
 }
 
-void AcidBaseCatalogParams::initFromString(const std::string &text) {
-  RDUNUSED_PARAM(text);
+void AcidBaseCatalogParams::initFromString(const std::string &) {
   UNDER_CONSTRUCTION("not implemented");
 }
 

--- a/Code/GraphMol/MolStandardize/FragmentCatalog/FragmentCatalogParams.cpp
+++ b/Code/GraphMol/MolStandardize/FragmentCatalog/FragmentCatalogParams.cpp
@@ -80,13 +80,11 @@ std::string FragmentCatalogParams::Serialize() const {
   return ss.str();
 }
 
-void FragmentCatalogParams::initFromStream(std::istream &ss) {
-  RDUNUSED_PARAM(ss);
+void FragmentCatalogParams::initFromStream(std::istream &) {
   UNDER_CONSTRUCTION("not implemented");
 }
 
-void FragmentCatalogParams::initFromString(const std::string &text) {
-  RDUNUSED_PARAM(text);
+void FragmentCatalogParams::initFromString(const std::string &) {
   UNDER_CONSTRUCTION("not implemented");
 }
 

--- a/Code/GraphMol/MolStandardize/TautomerCatalog/TautomerCatalogParams.cpp
+++ b/Code/GraphMol/MolStandardize/TautomerCatalog/TautomerCatalogParams.cpp
@@ -66,13 +66,11 @@ std::string TautomerCatalogParams::Serialize() const {
   return ss.str();
 }
 
-void TautomerCatalogParams::initFromStream(std::istream &ss) {
-  RDUNUSED_PARAM(ss);
+void TautomerCatalogParams::initFromStream(std::istream &) {
   UNDER_CONSTRUCTION("not implemented");
 }
 
-void TautomerCatalogParams::initFromString(const std::string &text) {
-  RDUNUSED_PARAM(text);
+void TautomerCatalogParams::initFromString(const std::string &) {
   UNDER_CONSTRUCTION("not implemented");
 }
 

--- a/Code/GraphMol/MolStandardize/TransformCatalog/TransformCatalogParams.cpp
+++ b/Code/GraphMol/MolStandardize/TransformCatalog/TransformCatalogParams.cpp
@@ -75,13 +75,11 @@ std::string TransformCatalogParams::Serialize() const {
   return ss.str();
 }
 
-void TransformCatalogParams::initFromStream(std::istream &ss) {
-  RDUNUSED_PARAM(ss);
+void TransformCatalogParams::initFromStream(std::istream &) {
   UNDER_CONSTRUCTION("not implemented");
 }
 
-void TransformCatalogParams::initFromString(const std::string &text) {
-  RDUNUSED_PARAM(text);
+void TransformCatalogParams::initFromString(const std::string &) {
   UNDER_CONSTRUCTION("not implemented");
 }
 

--- a/Code/GraphMol/MolStandardize/Validate.cpp
+++ b/Code/GraphMol/MolStandardize/Validate.cpp
@@ -57,9 +57,8 @@ std::vector<ValidationErrorInfo> RDKitValidation::validate(
   return errors;
 }
 
-void NoAtomValidation::run(const ROMol &mol, bool reportAllFailures,
+void NoAtomValidation::run(const ROMol &mol, bool,
                            std::vector<ValidationErrorInfo> &errors) const {
-  RDUNUSED_PARAM(reportAllFailures);
   unsigned int na = mol.getNumAtoms();
 
   if (!na) {
@@ -127,9 +126,8 @@ void FragmentValidation::run(const ROMol &mol, bool reportAllFailures,
   }
 }
 
-void NeutralValidation::run(const ROMol &mol, bool reportAllFailures,
+void NeutralValidation::run(const ROMol &mol, bool,
                             std::vector<ValidationErrorInfo> &errors) const {
-  RDUNUSED_PARAM(reportAllFailures);
   int charge = RDKit::MolOps::getFormalCharge(mol);
   if (charge != 0) {
     std::string charge_str;

--- a/Code/GraphMol/QueryOps.cpp
+++ b/Code/GraphMol/QueryOps.cpp
@@ -984,9 +984,8 @@ Atom *replaceAtomWithQueryAtom(RWMol *mol, Atom *atom) {
 }
 
 void finalizeQueryFromDescription(
-    Queries::Query<int, Atom const *, true> *query, Atom const *owner) {
+    Queries::Query<int, Atom const *, true> *query, Atom const *) {
   std::string descr = query->getDescription();
-  RDUNUSED_PARAM(owner);
 
   if (boost::starts_with(descr, "range_")) {
     descr = descr.substr(6);
@@ -1074,8 +1073,7 @@ void finalizeQueryFromDescription(
 }
 
 void finalizeQueryFromDescription(
-    Queries::Query<int, Bond const *, true> *query, Bond const *owner) {
-  RDUNUSED_PARAM(owner);
+    Queries::Query<int, Bond const *, true> *query, Bond const *) {
   std::string descr = query->getDescription();
   Queries::Query<int, Bond const *, true> *tmpQuery;
   if (descr == "BondRingSize") {

--- a/Code/GraphMol/RWMol.cpp
+++ b/Code/GraphMol/RWMol.cpp
@@ -126,9 +126,8 @@ unsigned int RWMol::addAtom(bool updateLabel) {
   return rdcast<unsigned int>(which);
 }
 
-void RWMol::replaceAtom(unsigned int idx, Atom *atom_pin, bool updateLabel,
+void RWMol::replaceAtom(unsigned int idx, Atom *atom_pin, bool,
                         bool preserveProps) {
-  RDUNUSED_PARAM(updateLabel);
   PRECONDITION(atom_pin, "bad atom passed to replaceAtom");
   URANGE_CHECK(idx, getNumAtoms());
   Atom *atom_p = atom_pin->copy();

--- a/Code/GraphMol/SLNParse/SLNParse.cpp
+++ b/Code/GraphMol/SLNParse/SLNParse.cpp
@@ -114,8 +114,7 @@ void finalizeQueryMol(ROMol *mol, bool mergeHs) {
   }
 }
 
-std::string replaceSLNMacroAtoms(std::string inp, int debugParse) {
-  RDUNUSED_PARAM(debugParse);
+std::string replaceSLNMacroAtoms(std::string inp) {
   const std::regex defn("\\{(.+?):(.+?)\\}");
   const char *empty = "";
 
@@ -151,7 +150,7 @@ std::string replaceSLNMacroAtoms(std::string inp, int debugParse) {
 
 RWMol *toMol(std::string inp, bool doQueries, int debugParse) {
   boost::trim_if(inp, boost::is_any_of(" \t\r\n"));
-  inp = replaceSLNMacroAtoms(inp, debugParse);
+  inp = replaceSLNMacroAtoms(inp);
   if (debugParse) {
     std::cerr << "****** PARSING SLN: ->" << inp << "<-" << std::endl;
   }

--- a/Code/GraphMol/ScaffoldNetwork/ScaffoldNetwork.cpp
+++ b/Code/GraphMol/ScaffoldNetwork/ScaffoldNetwork.cpp
@@ -50,10 +50,7 @@ ScaffoldNetworkParams::ScaffoldNetworkParams(
 
 namespace detail {
 
-void updateMolProps(RWMol &mol, const ScaffoldNetworkParams &params) {
-  RDUNUSED_PARAM(params);
-  MolOps::sanitizeMol(mol);
-}
+void updateMolProps(RWMol &mol) { MolOps::sanitizeMol(mol); }
 
 ROMol *makeScaffoldGeneric(const ROMol &mol, bool doAtoms, bool doBonds) {
   RWMol *res = new RWMol(mol);
@@ -73,9 +70,7 @@ ROMol *makeScaffoldGeneric(const ROMol &mol, bool doAtoms, bool doBonds) {
   }
   return static_cast<ROMol *>(res);
 }
-ROMol *removeAttachmentPoints(const ROMol &mol,
-                              const ScaffoldNetworkParams &params) {
-  RDUNUSED_PARAM(params);
+ROMol *removeAttachmentPoints(const ROMol &mol, const ScaffoldNetworkParams &) {
   RWMol *res = new RWMol(mol);
   res->beginBatchEdit();
   for (const auto atom : res->atoms()) {
@@ -95,8 +90,7 @@ ROMol *removeAttachmentPoints(const ROMol &mol,
   res->commitBatchEdit();
   return static_cast<ROMol *>(res);
 }
-ROMol *pruneMol(const ROMol &mol, const ScaffoldNetworkParams &params) {
-  RDUNUSED_PARAM(params);
+ROMol *pruneMol(const ROMol &mol, const ScaffoldNetworkParams &) {
   ROMol *res = MurckoDecompose(mol);
   res->updatePropertyCache();
   MolOps::fastFindRings(*res);
@@ -154,7 +148,7 @@ std::vector<std::pair<std::string, ROMOL_SPTR>> getMolFragments(
           p[0].reset(removeAttachmentPoints(*p[0], params));
         }
 
-        updateMolProps(*static_cast<RWMol *>(p[0].get()), params);
+        updateMolProps(*static_cast<RWMol *>(p[0].get()));
         auto tsmi0 = MolToSmiles(*p[0]);
         if (std::find(seen.begin(), seen.end(), tsmi0) == seen.end()) {
           stack.push_back(p[0]);
@@ -167,7 +161,7 @@ std::vector<std::pair<std::string, ROMOL_SPTR>> getMolFragments(
             // go ahead and remove attachment points here
             p[1].reset(removeAttachmentPoints(*p[1], params));
           }
-          updateMolProps(*static_cast<RWMol *>(p[1].get()), params);
+          updateMolProps(*static_cast<RWMol *>(p[1].get()));
           auto tsmi1 = MolToSmiles(*p[1]);
           if (std::find(seen.begin(), seen.end(), tsmi1) == seen.end()) {
             stack.push_back(p[1]);

--- a/Code/GraphMol/SmilesParse/SmartsWrite.cpp
+++ b/Code/GraphMol/SmilesParse/SmartsWrite.cpp
@@ -751,7 +751,6 @@ std::string getNonQueryAtomSmarts(const QueryAtom *qatom) {
 std::string getNonQueryBondSmarts(const QueryBond *qbond, int atomToLeftIdx) {
   PRECONDITION(qbond, "bad bond");
   PRECONDITION(!qbond->hasQuery(), "bond should not have query");
-  RDUNUSED_PARAM(atomToLeftIdx);
   std::string res;
 
   if (qbond->getIsAromatic()) {

--- a/Code/GraphMol/SmilesParse/SmilesWrite.cpp
+++ b/Code/GraphMol/SmilesParse/SmilesWrite.cpp
@@ -38,9 +38,8 @@ bool inOrganicSubset(int atomicNumber) {
   return false;
 }
 
-std::string GetAtomSmiles(const Atom *atom, bool doKekule, const Bond *bondIn,
+std::string GetAtomSmiles(const Atom *atom, bool doKekule, const Bond *,
                           bool allHsExplicit, bool isomericSmiles) {
-  RDUNUSED_PARAM(bondIn);
   PRECONDITION(atom, "bad atom");
   std::string res;
   int fc = atom->getFormalCharge();

--- a/Code/GraphMol/StructChecker/StructCheckerOptions.cpp
+++ b/Code/GraphMol/StructChecker/StructCheckerOptions.cpp
@@ -661,21 +661,6 @@ void StructCheckerOptions::parseTautomerData(
 }
 //--------------------------------------------------------------------------
 
-bool loadChargeDataTables(const std::string &path) {
-  // TODO: !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-  RDUNUSED_PARAM(path);
-  /*
-      double Elneg0; // elneg_table[0].value;
-      std::map<unsigned, double> ElnegTable;   // AtomicNumber -> eleng
-      std::vector<inc_entry_t> AtomAcidity;    //atom_acidity_table[]
-      std::vector<inc_entry_t> charge_inc_table;  // std::map AtomicNumber ->
-     ...
-      double Alpha, Beta;
-      std::vector<path_entry_t> alpha_path_table, beta_path_table;
-  */
-  return true;
-}
-
 StructCheckerOptions::StructCheckerOptions()
     : AcidityLimit(0.0),
       RemoveMinorFragments(false),

--- a/Code/GraphMol/Wrap/MolOps.cpp
+++ b/Code/GraphMol/Wrap/MolOps.cpp
@@ -184,16 +184,14 @@ ROMol *renumberAtomsHelper(const ROMol &mol, python::object &pyNewOrder) {
 }
 
 namespace {
-std::string getResidue(const ROMol &m, const Atom *at) {
-  RDUNUSED_PARAM(m);
+std::string getResidue(const ROMol &, const Atom *at) {
   if (at->getMonomerInfo()->getMonomerType() != AtomMonomerInfo::PDBRESIDUE) {
     return "";
   }
   return static_cast<const AtomPDBResidueInfo *>(at->getMonomerInfo())
       ->getResidueName();
 }
-std::string getChainId(const ROMol &m, const Atom *at) {
-  RDUNUSED_PARAM(m);
+std::string getChainId(const ROMol &, const Atom *at) {
   if (at->getMonomerInfo()->getMonomerType() != AtomMonomerInfo::PDBRESIDUE) {
     return "";
   }

--- a/Code/GraphMol/Wrap/rdchem.cpp
+++ b/Code/GraphMol/Wrap/rdchem.cpp
@@ -31,8 +31,7 @@ namespace RDKit {
 void tossit() { throw IndexErrorException(1); }
 }  // namespace RDKit
 
-void rdExceptionTranslator(RDKit::ConformerException const &x) {
-  RDUNUSED_PARAM(x);
+void rdExceptionTranslator(RDKit::ConformerException const &) {
   PyErr_SetString(PyExc_ValueError, "Bad Conformer Id");
 }
 

--- a/Code/GraphMol/new_canon.cpp
+++ b/Code/GraphMol/new_canon.cpp
@@ -442,8 +442,7 @@ void basicInitCanonAtom(const ROMol &mol, Canon::canon_atom &atom,
 }
 
 void advancedInitCanonAtom(const ROMol &mol, Canon::canon_atom &atom,
-                           const int &idx) {
-  RDUNUSED_PARAM(idx);
+                           const int &) {
   atom.totalNumHs = atom.atom->getTotalNumHs();
   atom.isRingStereoAtom =
       (atom.atom->getChiralTag() == Atom::CHI_TETRAHEDRAL_CW ||

--- a/Code/ML/InfoTheory/Wrap/InfoBitRanker.cpp
+++ b/Code/ML/InfoTheory/Wrap/InfoBitRanker.cpp
@@ -71,8 +71,7 @@ void SetMaskBits(InfoBitRanker *ranker, python::object maskBits) {
   ranker->setMaskBits(cList);
 }
 
-void tester(InfoBitRanker *ranker, python::object bitVect) {
-  RDUNUSED_PARAM(ranker);
+void tester(InfoBitRanker *, python::object bitVect) {
   python::extract<SparseBitVect> sbvWorks(bitVect);
   if (sbvWorks.check()) {
     SparseBitVect sv = python::extract<SparseBitVect>(bitVect);

--- a/Code/MinimalLib/cffiwrapper.cpp
+++ b/Code/MinimalLib/cffiwrapper.cpp
@@ -167,9 +167,7 @@ extern "C" char *get_smiles(const char *pkl, size_t pkl_sz,
   auto data = smiles_helper(pkl, pkl_sz, details_json);
   return str_to_c(data);
 }
-extern "C" char *get_smarts(const char *pkl, size_t pkl_sz,
-                            const char *details_json) {
-  RDUNUSED_PARAM(details_json);
+extern "C" char *get_smarts(const char *pkl, size_t pkl_sz, const char *) {
   if (!pkl || !pkl_sz) {
     return nullptr;
   }
@@ -192,9 +190,7 @@ extern "C" char *get_v3kmolblock(const char *pkl, size_t pkl_sz,
   auto data = molblock_helper(pkl, pkl_sz, details_json, true);
   return str_to_c(data);
 }
-extern "C" char *get_json(const char *pkl, size_t pkl_sz,
-                          const char *details_json) {
-  RDUNUSED_PARAM(details_json);
+extern "C" char *get_json(const char *pkl, size_t pkl_sz, const char *) {
   if (!pkl || !pkl_sz) {
     return nullptr;
   }


### PR DESCRIPTION
We've been using the `RDUNUSED_PARAM()` macro to remove warnings about unused function parameters. One of the C++ Core Guideline recommendations is [Unused parameters should be unnamed](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rf-unused). That seems like a simpler solution and has the advantage that it can't be inaccurate (we had a couple instances where a parameter was marked `RDUNUSED_PARAM()` but was used anyway).

This PR gets rid of most uses of `RDUNUSED_PARAM()` by making the corresponding parameters unnamed.

There are also a couple of places where incorrect instances of `RDUNUSED_PARAM()` were removed.