### PR TITLE
Addresses #4449

### DIFF
--- a/Code/cmake/Modules/RDKitUtils.cmake
+++ b/Code/cmake/Modules/RDKitUtils.cmake
@@ -55,13 +55,24 @@ macro(rdkit_library)
       add_library(${RDKLIB_NAME}_static ${RDKLIB_SOURCES})
 
       foreach(linkLib ${RDKLIB_LINK_LIBRARIES})
-        if(${linkLib} MATCHES "^(Boost)|(Thread)|(boost)|^(optimized)|^(debug)|(libz)")
-          set(rdk_static_link_libraries "${rdk_static_link_libraries}${linkLib};")
-        else()
-          set(rdk_static_link_libraries "${rdk_static_link_libraries}${linkLib}_static;")
+        if(TARGET "${linkLib}")
+          get_target_property(linkLib_IMPORTED "${linkLib}" IMPORTED)
+          if (linkLib_IMPORTED)
+            # linkLib is an imported target: use it as-is
+            target_link_libraries(${RDKLIB_NAME}_static PUBLIC "${linkLib}")
+            continue()
+          endif()
+        elseif(EXISTS "${linkLib}")
+          # linkLib is a file, so keep it as-is
+          target_link_libraries(${RDKLIB_NAME}_static PUBLIC "${linkLib}")
+          continue()
         endif()
+
+        # We haven't seen linkLib yet. This probably means it is a target
+        # we will be creating at some point (if not, then we are missing a find_package).
+        # Add the "_static" suffix to link against its static variant
+        target_link_libraries(${RDKLIB_NAME}_static PUBLIC "${linkLib}_static")
       endforeach()
-      target_link_libraries(${RDKLIB_NAME}_static PUBLIC ${rdk_static_link_libraries})
       target_link_libraries(${RDKLIB_NAME}_static PUBLIC rdkit_base)
       if(RDK_INSTALL_DEV_COMPONENT)
         INSTALL(TARGETS ${RDKLIB_NAME}_static EXPORT ${RDKit_EXPORTED_TARGETS}


### PR DESCRIPTION
Fixes #4449 

Currently, we use a list of hardcoded patterns to distinguish which link dependencies shouldn't get the "_static" suffix added. This list doesn't contain any patterns matching maeparser or coordgen. The simplest solution would be to add them, but I think we can do better than this.

In my changes, I replace this mechanism with a different check: if a link dependency is an explicit file path or a target imported from a CMake package (`find_package()` sets the `IMPORTED` property to `TRUE`), then we use it as is. In any other case, we add the "_static" suffix.

The more intuitive approach, which is checking whether RDKit created the target is not possible: we do not create the targets in sequence, so that when we specify link dependencies we might not yet have defined the targets we are linking against, so we can't check anything about them.

Also, directly using `target_link_libraries()` to add the dependencies instead of creating a `rdk_static_link_libraries` list avoids adding redundant/unrequired dependencies to some libraries: macros work in the same scope of the file that invokes  them, so if we call `rdkit_library()` twice in the same CMakeLists.txt, the second one will find `rdk_static_link_libraries` as the first left it, because we never clean it up.