### PR TITLE
Force import of wrapped exceptions

### DIFF
--- a/rdkit/__init__.py
+++ b/rdkit/__init__.py
@@ -1,3 +1,6 @@
+# Need to import rdBase to properly wrap exceptions                                                                                                         #  otherwise they will leak memory 
+from . import rdBase
+
 try:
   from .rdBase import rdkitVersion as __version__
 except ImportError:


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! 
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->
Fixes #4465

#### What does this implement/fix? Explain your changes.
When importing any rdkit module, first importing rdBase, this defines the proper exceptions and prevents them from leaking.