### PR TITLE
Add ToList method to Sparse/ExplicitBitVector

### DIFF
--- a/Code/DataStructs/Wrap/SparseIntVect.cpp
+++ b/Code/DataStructs/Wrap/SparseIntVect.cpp
@@ -57,6 +57,17 @@ python::dict pyGetNonzeroElements(SparseIntVect<IndexType> &vect) {
   return res;
 }
 
+template <typename IndexType>
+python::list pyToList(SparseIntVect<IndexType> &vect) {
+  python::list res;
+  res.append(0);
+  res *= vect.getLength();
+  for(auto iter: vect.getNonzeroElements()) {
+    res[iter.first] = iter.second;
+  }
+  return res;
+}
+
 template <typename T>
 python::list BulkDice(const T &siv1, python::list sivs, bool returnDistance) {
   python::list res;
@@ -167,6 +178,8 @@ struct sparseIntVec_wrapper {
              "update the vector based on the values in the list or tuple")
         .def("GetNonzeroElements", &pyGetNonzeroElements<IndexType>,
              "returns a dictionary of the nonzero elements")
+        .def("ToList", pyToList<IndexType>,
+	   "Return the Intvector as a python list (faster than list(vect))")
         .def_pickle(siv_pickle_suite<IndexType>());
 
     python::def(

--- a/Code/DataStructs/Wrap/SparseIntVect.cpp
+++ b/Code/DataStructs/Wrap/SparseIntVect.cpp
@@ -179,7 +179,7 @@ struct sparseIntVec_wrapper {
         .def("GetNonzeroElements", &pyGetNonzeroElements<IndexType>,
              "returns a dictionary of the nonzero elements")
         .def("ToList", pyToList<IndexType>,
-	   "Return the Intvector as a python list (faster than list(vect))")
+	   "Return the SparseIntVect as a python list")
         .def_pickle(siv_pickle_suite<IndexType>());
 
     python::def(

--- a/Code/DataStructs/Wrap/testBV.py
+++ b/Code/DataStructs/Wrap/testBV.py
@@ -341,16 +341,17 @@ class TestCase(unittest.TestCase):
     def test12ToList(self):
         l = [0]*2048
         nbits = 2048
-        bv = DataStructs.ExplicitBitVect(nbits)
-        for j in range(nbits):
-            x = random.randrange(0, nbits)
-            l[x] = 1
-            bv.SetBit(x)
+        for cls in [DataStructs.ExplicitBitVect, DataStructs.SparseBitVect]:
+            bv = cls(nbits)
+            for j in range(nbits):
+                x = random.randrange(0, nbits)
+                l[x] = 1
+                bv.SetBit(x)
 
-        l2 = list(bv)
-        l3 = bv.ToList()
-        self.assertEqual(l, l2)
-        self.assertEqual(l, l3)
+            l2 = list(bv)
+            l3 = bv.ToList()
+            self.assertEqual(l, l2)
+            self.assertEqual(l, l3)
             
 if __name__ == '__main__':
     unittest.main()

--- a/Code/DataStructs/Wrap/testBV.py
+++ b/Code/DataStructs/Wrap/testBV.py
@@ -339,10 +339,10 @@ class TestCase(unittest.TestCase):
             self.assertEqual(tgts,nbrs)
 
     def test12ToList(self):
-        l = [0]*2048
         nbits = 2048
         for cls in [DataStructs.ExplicitBitVect, DataStructs.SparseBitVect]:
             bv = cls(nbits)
+            l = [0]*2048
             for j in range(nbits):
                 x = random.randrange(0, nbits)
                 l[x] = 1

--- a/Code/DataStructs/Wrap/testBV.py
+++ b/Code/DataStructs/Wrap/testBV.py
@@ -338,6 +338,19 @@ class TestCase(unittest.TestCase):
             nbrs = nbrSim(qs,db)
             self.assertEqual(tgts,nbrs)
 
+    def test12ToList(self):
+        l = [0]*2048
+        nbits = 2048
+        bv = DataStructs.ExplicitBitVect(nbits)
+        for j in range(nbits):
+            x = random.randrange(0, nbits)
+            l[x] = 1
+            bv.SetBit(x)
 
+        l2 = list(bv)
+        l3 = bv.ToList()
+        self.assertEqual(l, l2)
+        self.assertEqual(l, l3)
+            
 if __name__ == '__main__':
     unittest.main()

--- a/Code/DataStructs/Wrap/testSparseIntVect.py
+++ b/Code/DataStructs/Wrap/testSparseIntVect.py
@@ -214,12 +214,12 @@ class TestCase(unittest.TestCase):
 
   def test7ToList(self):
     l = [0]*2048
-    nbits =	2048
-    bv = ds.SparseBitVect(nbits)
+    nbits = 2048
+    bv = ds.IntSparseIntVect(nbits)
     for j in range(nbits):
       x = random.randrange(0, nbits)
-      l[x] = 1
-      bv.SetBit(x)
+      l[x] = x
+      bv[x] = x
 
     l2 = list(bv)
     l3 = bv.ToList()

--- a/Code/DataStructs/Wrap/testSparseIntVect.py
+++ b/Code/DataStructs/Wrap/testSparseIntVect.py
@@ -10,7 +10,7 @@ import unittest
 import pickle
 from rdkit import RDConfig
 from rdkit import DataStructs as ds
-
+import random
 
 def feq(v1, v2, tol=1e-4):
   return abs(v1 - v2) < tol
@@ -212,6 +212,19 @@ class TestCase(unittest.TestCase):
     for i in range(len(bulkDs)):
       self.assertTrue(feq(bulkDs[i], taniDs[i]))
 
+  def test7ToList(self):
+    l = [0]*2048
+    nbits =	2048
+    bv = ds.SparseBitVect(nbits)
+    for j in range(nbits):
+      x = random.randrange(0, nbits)
+      l[x] = 1
+      bv.SetBit(x)
+
+    l2 = list(bv)
+    l3 = bv.ToList()
+    self.assertEqual(l, l2)
+    self.assertEqual(l, l3)
 
 if __name__ == '__main__':
   unittest.main()

--- a/Code/DataStructs/Wrap/wrap_ExplicitBV.cpp
+++ b/Code/DataStructs/Wrap/wrap_ExplicitBV.cpp
@@ -25,6 +25,24 @@ struct ebv_pickle_suite : python::pickle_suite {
   };
 };
 
+python::list ExplicitToList(const ExplicitBitVect& sv) {
+  python::list l;
+  if (!sv.dp_bits)
+    return l;
+  
+  auto count = sv.getNumBits();
+  if(count) {
+    l.append(0);
+    l *= count;
+    auto pos = sv.dp_bits->find_first();
+    l[pos] = 1;
+    while((pos = sv.dp_bits->find_next(pos)) != boost::dynamic_bitset<>::npos) {
+      l[pos] = 1;
+    }
+  }
+  return l;
+}
+
 std::string ebvClassDoc =
     "A class to store explicit bit vectors.\n\
 \n\
@@ -84,7 +102,9 @@ struct EBV_wrapper {
         .def("ToBase64", (std::string (*)(EBV &))ToBase64,
              "Converts the vector to a base64 string (the base64 encoded "
              "version of the results of ToString()).\n")
-        .def(python::self & python::self)
+        .def("ToList", (python::list (*)(const EBV&))ExplicitToList,
+             "Return the Bitvector as a python list (faster than list(vect))")
+         .def(python::self & python::self)
         .def(python::self | python::self)
         .def(python::self ^ python::self)
         .def(python::self + python::self)

--- a/Code/DataStructs/Wrap/wrap_SparseBV.cpp
+++ b/Code/DataStructs/Wrap/wrap_SparseBV.cpp
@@ -97,7 +97,7 @@ struct SBV_wrapper {
              "Converts the vector to a base64 string (the base64 encoded "
              "version of the results of ToString()).\n")
         .def("ToList", (python::list (*)(const SBV&))SparseToList,
-             "Return the Bitvector as a python list (faster than list(vect))")
+             "Return the BitVector as a python list")
         .def(python::self & python::self)
         .def(python::self | python::self)
         .def(python::self ^ python::self)

--- a/Code/DataStructs/Wrap/wrap_SparseBV.cpp
+++ b/Code/DataStructs/Wrap/wrap_SparseBV.cpp
@@ -96,8 +96,8 @@ struct SBV_wrapper {
         .def("ToBase64", (std::string(*)(SBV &))ToBase64,
              "Converts the vector to a base64 string (the base64 encoded "
              "version of the results of ToString()).\n")
-        .def("ToList", (python::list *(const SBV&)SparseToList,
-			"Return the Bitvector as a python list (faster than list(vect))"))      
+        .def("ToList", (python::list (*)(const SBV&))SparseToList,
+             "Return the Bitvector as a python list (faster than list(vect))")
         .def(python::self & python::self)
         .def(python::self | python::self)
         .def(python::self ^ python::self)

--- a/Code/DataStructs/Wrap/wrap_SparseBV.cpp
+++ b/Code/DataStructs/Wrap/wrap_SparseBV.cpp
@@ -27,15 +27,15 @@ struct sbv_pickle_suite : python::pickle_suite {
 };
 
 python::list SparseToList(const SparseBitVect& sv) {
-  python::list l;
-  if(sv.getNumBits()) {
-    l.append(0);
-    l *= sv.getNumBits();
-    for(int i: *sv.getBitSet()) {
-      l[i] = 1;
-    }
-  }
-  return l;
+   python::list l;
+   if(sv.getNumBits()) {
+     l.append(0);
+     l *= sv.getNumBits();
+     for(int i: *sv.getBitSet()) {
+       l[i] = 1;
+     }
+   }
+   return l;
 }
 
 std::string sbvClassDoc =
@@ -59,8 +59,8 @@ or by indexing (i.e. bv[i] = 1 or if bv[i]).\n\
 \n";
 struct SBV_wrapper {
   static void wrap() {
-    python::class_<SparseBitVect>("SparseBitVect", sbvClassDoc.c_str(),
-                                  python::init<unsigned int>())
+    python::class_<SparseBitVect, boost::shared_ptr<SparseBitVect>>(
+        "SparseBitVect", sbvClassDoc.c_str(), python::init<unsigned int>())
         .def(python::init<std::string>())
         .def("SetBit", (bool (SBV::*)(unsigned int)) & SBV::setBit,
              "Turns on a particular bit.  Returns the original state of the "
@@ -87,17 +87,17 @@ struct SBV_wrapper {
              "Returns the number of off bits.\n")
         .def("__getitem__", (int (*)(const SBV &, int))get_VectItem)
         .def("__setitem__", (int (*)(SBV &, int, int))set_VectItem)
-        .def("GetOnBits", (IntVect (*)(const SBV &))GetOnBits,
+        .def("GetOnBits", (IntVect(*)(const SBV &))GetOnBits,
              "Returns a tuple containing IDs of the on bits.\n")
-        .def("ToBinary", (python::object (*)(const SBV &))BVToBinary,
+        .def("ToBinary", (python::object(*)(const SBV &))BVToBinary,
              "Returns an internal binary representation of the vector.\n")
         .def("FromBase64", (void (*)(SBV &, const std::string &))InitFromBase64,
              "Initializes the vector from a base64 encoded binary string.\n")
-        .def("ToBase64", (std::string (*)(SBV &))ToBase64,
+        .def("ToBase64", (std::string(*)(SBV &))ToBase64,
              "Converts the vector to a base64 string (the base64 encoded "
              "version of the results of ToString()).\n")
-        .def("ToList", (python::list (*)(const SBV&))SparseToList,
-	     "Return the Bitvector as a python list (faster than list(vect))")
+        .def("ToList", (python::list *(const SBV&)BVToList,
+			"Return the Bitvector as a python list (faster than list(vect))"))      
         .def(python::self & python::self)
         .def(python::self | python::self)
         .def(python::self ^ python::self)

--- a/Code/DataStructs/Wrap/wrap_SparseBV.cpp
+++ b/Code/DataStructs/Wrap/wrap_SparseBV.cpp
@@ -26,6 +26,18 @@ struct sbv_pickle_suite : python::pickle_suite {
   };
 };
 
+python::list SparseToList(const SparseBitVect& sv) {
+  python::list l;
+  if(sv.getNumBits()) {
+    l.append(0);
+    l *= sv.getNumBits();
+    for(int i: *sv.getBitSet()) {
+      l[i] = 1;
+    }
+  }
+  return l;
+}
+
 std::string sbvClassDoc =
     "A class to store sparse bit vectors.\n\
 \n\
@@ -47,8 +59,8 @@ or by indexing (i.e. bv[i] = 1 or if bv[i]).\n\
 \n";
 struct SBV_wrapper {
   static void wrap() {
-    python::class_<SparseBitVect, boost::shared_ptr<SparseBitVect>>(
-        "SparseBitVect", sbvClassDoc.c_str(), python::init<unsigned int>())
+    python::class_<SparseBitVect>("SparseBitVect", sbvClassDoc.c_str(),
+                                  python::init<unsigned int>())
         .def(python::init<std::string>())
         .def("SetBit", (bool (SBV::*)(unsigned int)) & SBV::setBit,
              "Turns on a particular bit.  Returns the original state of the "
@@ -75,15 +87,17 @@ struct SBV_wrapper {
              "Returns the number of off bits.\n")
         .def("__getitem__", (int (*)(const SBV &, int))get_VectItem)
         .def("__setitem__", (int (*)(SBV &, int, int))set_VectItem)
-        .def("GetOnBits", (IntVect(*)(const SBV &))GetOnBits,
+        .def("GetOnBits", (IntVect (*)(const SBV &))GetOnBits,
              "Returns a tuple containing IDs of the on bits.\n")
-        .def("ToBinary", (python::object(*)(const SBV &))BVToBinary,
+        .def("ToBinary", (python::object (*)(const SBV &))BVToBinary,
              "Returns an internal binary representation of the vector.\n")
         .def("FromBase64", (void (*)(SBV &, const std::string &))InitFromBase64,
              "Initializes the vector from a base64 encoded binary string.\n")
-        .def("ToBase64", (std::string(*)(SBV &))ToBase64,
+        .def("ToBase64", (std::string (*)(SBV &))ToBase64,
              "Converts the vector to a base64 string (the base64 encoded "
              "version of the results of ToString()).\n")
+        .def("ToList", (python::list (*)(const SBV&))SparseToList,
+	     "Return the Bitvector as a python list (faster than list(vect))")
         .def(python::self & python::self)
         .def(python::self | python::self)
         .def(python::self ^ python::self)

--- a/Code/DataStructs/Wrap/wrap_SparseBV.cpp
+++ b/Code/DataStructs/Wrap/wrap_SparseBV.cpp
@@ -96,7 +96,7 @@ struct SBV_wrapper {
         .def("ToBase64", (std::string(*)(SBV &))ToBase64,
              "Converts the vector to a base64 string (the base64 encoded "
              "version of the results of ToString()).\n")
-        .def("ToList", (python::list *(const SBV&)BVToList,
+        .def("ToList", (python::list *(const SBV&)SparseToList,
 			"Return the Bitvector as a python list (faster than list(vect))"))      
         .def(python::self & python::self)
         .def(python::self | python::self)


### PR DESCRIPTION
Adds ToList methods to SparseIntVector and ExplicitBitVector

```
bv.ToList()
```

Is about 30x faster than

```
list(bv)
```

