### PR TITLE
Fixes #4468 and #4476

### DIFF
--- a/Code/GraphMol/FileParsers/MolFileParser.cpp
+++ b/Code/GraphMol/FileParsers/MolFileParser.cpp
@@ -2767,8 +2767,12 @@ void processSMARTSQ(RWMol &mol, const SubstanceGroup &sg) {
       mol.replaceAtom(oidx, &qAt);
       at = mol.getAtomWithIdx(oidx);
     }
-    QueryAtom::QUERYATOM_QUERY *query =
-        m->getAtomWithIdx(0)->getQuery()->copy();
+    QueryAtom::QUERYATOM_QUERY *query = nullptr;
+    if (m->getNumAtoms() == 1) {
+      query = m->getAtomWithIdx(0)->getQuery()->copy();
+    } else {
+      query = new RecursiveStructureQuery(m.release());
+    }
     at->setQuery(query);
     at->setProp(common_properties::_MolFileAtomQuery, 1);
   }
@@ -2836,7 +2840,8 @@ void processSGroups(RWMol *mol) {
           continue;
         }
       }
-      if (sg.getPropIfPresent("QUERYTYPE", field) && field == "SMARTSQ") {
+      if (sg.getPropIfPresent("QUERYTYPE", field) &&
+          (field == "SMARTSQ" || field == "SQ")) {
         processSMARTSQ(*mol, sg);
         sgsToRemove.push_back(sgIdx);
         continue;

--- a/Code/GraphMol/FileParsers/MolFileParser.cpp
+++ b/Code/GraphMol/FileParsers/MolFileParser.cpp
@@ -2742,7 +2742,7 @@ void processSMARTSQ(RWMol &mol, const SubstanceGroup &sg) {
         << "multiple FIELDDATA values for SMARTSQ. Taking the first."
         << std::endl;
   }
-  std::string sma = dataFields[0];
+  const std::string& sma = dataFields[0];
   if (sma.empty()) {
     BOOST_LOG(rdWarningLog)
         << "Skipping empty SMARTS value for SMARTSQ." << std::endl;

--- a/Code/GraphMol/FileParsers/MolFileParser.cpp
+++ b/Code/GraphMol/FileParsers/MolFileParser.cpp
@@ -2724,6 +2724,56 @@ void processMrvCoordinateBond(RWMol &mol, const SubstanceGroup &sg) {
   }
 }
 
+void processSMARTSQ(RWMol &mol, const SubstanceGroup &sg) {
+  std::string field;
+  if (sg.getPropIfPresent("QUERYOP", field) && field != "=") {
+    BOOST_LOG(rdWarningLog) << "unrecognized QUERYOP '" << field
+                            << "' for SMARTSQ. Query ignored." << std::endl;
+    return;
+  }
+  std::vector<std::string> dataFields;
+  if (!sg.getPropIfPresent("DATAFIELDS", dataFields) || dataFields.empty()) {
+    BOOST_LOG(rdWarningLog)
+        << "empty FIELDDATA for SMARTSQ. Query ignored." << std::endl;
+    return;
+  }
+  if (dataFields.size() > 1) {
+    BOOST_LOG(rdWarningLog)
+        << "multiple FIELDDATA values for SMARTSQ. Taking the first."
+        << std::endl;
+  }
+  std::string sma = dataFields[0];
+
+  for (auto aidx : sg.getAtoms()) {
+    auto at = mol.getAtomWithIdx(aidx);
+
+    std::unique_ptr<RWMol> m;
+    try {
+      m.reset(SmartsToMol(sma));
+    } catch (...) {
+      // Is this every used?
+    }
+
+    if (!m || !m->getNumAtoms()) {
+      BOOST_LOG(rdWarningLog)
+          << "SMARTS for SMARTSQ '" << sma
+          << "' could not be parsed or has no atoms. Ignoring it." << std::endl;
+      return;
+    }
+
+    if (!at->hasQuery()) {
+      QueryAtom qAt(*at);
+      int oidx = at->getIdx();
+      mol.replaceAtom(oidx, &qAt);
+      at = mol.getAtomWithIdx(oidx);
+    }
+    QueryAtom::QUERYATOM_QUERY *query =
+        m->getAtomWithIdx(0)->getQuery()->copy();
+    at->setQuery(query);
+    at->setProp(common_properties::_MolFileAtomQuery, 1);
+  }
+}
+
 void processMrvImplicitH(RWMol &mol, const SubstanceGroup &sg) {
   std::vector<std::string> dataFields;
   if (sg.getPropIfPresent("DATAFIELDS", dataFields)) {
@@ -2772,17 +2822,24 @@ void processSGroups(RWMol *mol) {
   unsigned int sgIdx = 0;
   for (auto &sg : getSubstanceGroups(*mol)) {
     if (sg.getProp<std::string>("TYPE") == "DAT") {
-      std::string fieldn;
-      if (sg.getPropIfPresent("FIELDNAME", fieldn)) {
-        if (fieldn == "MRV_COORDINATE_BOND_TYPE") {
+      std::string field;
+      if (sg.getPropIfPresent("FIELDNAME", field)) {
+        if (field == "MRV_COORDINATE_BOND_TYPE") {
           // V2000 support for coordinate bonds
           processMrvCoordinateBond(*mol, sg);
           sgsToRemove.push_back(sgIdx);
-        } else if (fieldn == "MRV_IMPLICIT_H") {
+          continue;
+        } else if (field == "MRV_IMPLICIT_H") {
           // CXN extension to specify implicit Hs, used for aromatic rings
           processMrvImplicitH(*mol, sg);
           sgsToRemove.push_back(sgIdx);
+          continue;
         }
+      }
+      if (sg.getPropIfPresent("QUERYTYPE", field) && field == "SMARTSQ") {
+        processSMARTSQ(*mol, sg);
+        sgsToRemove.push_back(sgIdx);
+        continue;
       }
     }
     ++sgIdx;

--- a/Code/GraphMol/FileParsers/MolFileParser.cpp
+++ b/Code/GraphMol/FileParsers/MolFileParser.cpp
@@ -839,7 +839,7 @@ void ParseMarvinSmartsLine(RWMol *mol, const std::string &text,
   try {
     m = SmartsToMol(sma);
   } catch (...) {
-    // Is this every used?
+    // Is this ever used?
   }
 
   if (m) {
@@ -2743,6 +2743,11 @@ void processSMARTSQ(RWMol &mol, const SubstanceGroup &sg) {
         << std::endl;
   }
   std::string sma = dataFields[0];
+  if (sma.empty()) {
+    BOOST_LOG(rdWarningLog)
+        << "Skipping empty SMARTS value for SMARTSQ." << std::endl;
+    return;
+  }
 
   for (auto aidx : sg.getAtoms()) {
     auto at = mol.getAtomWithIdx(aidx);
@@ -2751,7 +2756,7 @@ void processSMARTSQ(RWMol &mol, const SubstanceGroup &sg) {
     try {
       m.reset(SmartsToMol(sma));
     } catch (...) {
-      // Is this every used?
+      // Is this ever used?
     }
 
     if (!m || !m->getNumAtoms()) {

--- a/Code/GraphMol/FileParsers/MolSGroupParsing.cpp
+++ b/Code/GraphMol/FileParsers/MolSGroupParsing.cpp
@@ -576,6 +576,7 @@ void ParseSGroupV2000SDTLine(IDX_TO_SGROUP_MAP &sGroupMap, RWMol *mol,
     // making the code super complicated
   }
 
+  // only add entries for the remaining properties if they aren't blank
   if (!fieldName.empty()) {
     sgroup->setProp("FIELDNAME", fieldName);
   }

--- a/Code/GraphMol/FileParsers/MolSGroupParsing.cpp
+++ b/Code/GraphMol/FileParsers/MolSGroupParsing.cpp
@@ -576,11 +576,19 @@ void ParseSGroupV2000SDTLine(IDX_TO_SGROUP_MAP &sGroupMap, RWMol *mol,
     // making the code super complicated
   }
 
-  if (fieldName.size()) {
+  if (!fieldName.empty()) {
     sgroup->setProp("FIELDNAME", fieldName);
+  }
+  if (!fieldType.empty()) {
     sgroup->setProp("FIELDTYPE", fieldType);
+  }
+  if (!fieldInfo.empty()) {
     sgroup->setProp("FIELDINFO", fieldInfo);
+  }
+  if (!queryType.empty()) {
     sgroup->setProp("QUERYTYPE", queryType);
+  }
+  if (!queryOp.empty()) {
     sgroup->setProp("QUERYOP", queryOp);
   }
 }

--- a/Code/GraphMol/FileParsers/catch_main.cpp
+++ b/Code/GraphMol/FileParsers/catch_main.cpp
@@ -7,6 +7,14 @@
 //  of the RDKit source tree.
 //
 
-#define CATCH_CONFIG_MAIN  // This tells Catch to provide a main() - only do
-                           // this in one cpp file
+#define CATCH_CONFIG_RUNNER
 #include "catch.hpp"
+#include <RDGeneral/RDLog.h>
+
+int main(int argc, char* argv[]) {
+  RDLog::InitLogs();
+
+  int result = Catch::Session().run(argc, argv);
+
+  return result;
+}

--- a/Code/GraphMol/FileParsers/file_parsers_catch.cpp
+++ b/Code/GraphMol/FileParsers/file_parsers_catch.cpp
@@ -3908,6 +3908,56 @@ M  END)CTAB"_ctab;
     REQUIRE(!m->getAtomWithIdx(1)->hasQuery());
     CHECK(getSubstanceGroups(*m).empty());
   }
+  SECTION("empty SMARTS") {
+    auto m = R"CTAB(query
+  Mrv2108 07152116012D          
+
+  0  0  0     0  0            999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 2 1 1 0 0
+M  V30 BEGIN ATOM
+M  V30 1 C -0.8333 4.5421 0 0
+M  V30 2 C 0.5003 5.3121 0 0
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 1 1 2
+M  V30 END BOND
+M  V30 BEGIN SGROUP
+M  V30 1 DAT 0 ATOMS=(1 2) -
+M  V30 FIELDDISP="    0.0000    0.0000    DR    ALL  0       0" -
+M  V30 QUERYTYPE=SMARTSQ QUERYOP== FIELDDATA=
+M  V30 END SGROUP
+M  V30 END CTAB
+M  END)CTAB"_ctab;
+    REQUIRE(m);
+    REQUIRE(!m->getAtomWithIdx(1)->hasQuery());
+    CHECK(getSubstanceGroups(*m).empty());
+  }
+  SECTION("bad operator") {
+    auto m = R"CTAB(query
+  Mrv2108 07152116012D          
+
+  0  0  0     0  0            999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 2 1 1 0 0
+M  V30 BEGIN ATOM
+M  V30 1 C -0.8333 4.5421 0 0
+M  V30 2 C 0.5003 5.3121 0 0
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 1 1 2
+M  V30 END BOND
+M  V30 BEGIN SGROUP
+M  V30 1 DAT 0 ATOMS=(1 2) -
+M  V30 FIELDDISP="    0.0000    0.0000    DR    ALL  0       0" -
+M  V30 QUERYTYPE=SMARTSQ QUERYOP=> FIELDDATA=[#6;R]
+M  V30 END SGROUP
+M  V30 END CTAB
+M  END)CTAB"_ctab;
+    REQUIRE(m);
+    REQUIRE(!m->getAtomWithIdx(1)->hasQuery());
+    CHECK(getSubstanceGroups(*m).empty());
+  }
   SECTION("SMARTS with multiple atoms become recursive") {
     auto m = R"CTAB(query
   Mrv2108 07152116012D          

--- a/Code/GraphMol/FileParsers/file_parsers_catch.cpp
+++ b/Code/GraphMol/FileParsers/file_parsers_catch.cpp
@@ -3735,30 +3735,30 @@ M  V30 END BOND
 M  V30 BEGIN SGROUP
 M  V30 1 DAT 0 ATOMS=(1 2) -
 M  V30 FIELDDISP="    0.0000    0.0000    DR    ALL  0       0" -
-M  V30 QUERYTYPE=SMARTSQ QUERYOP== -
+M  V30 QUERYTYPE=SMARTSR QUERYOP== -
 M  V30 FIELDDATA="quite long piece of text that needs to be broken -
 M  V30 across two lines"
 M  V30 2 DAT 0 ATOMS=(1 1) -
 M  V30 FIELDDISP="    0.0000    0.0000    DR    ALL  0       0" -
-M  V30 QUERYTYPE=SMARTSQ QUERYOP== -
+M  V30 QUERYTYPE=SMARTSR QUERYOP== -
 M  V30 FIELDDATA="quite long piece of text that needs to be broken -
 M  V30 across more than two lines because we really want to be sure -
 M  V30 that we are doing this right"
 M  V30 3 DAT 0 ATOMS=(1 1) -
 M  V30 FIELDDISP="    0.0000    0.0000    DR    ALL  0       0" -
-M  V30 QUERYTYPE=SMARTSQ QUERYOP== -
+M  V30 QUERYTYPE=SMARTSR QUERYOP== -
 M  V30 FIELDDATA="quite long piece of text that needs to be broken -
 M  V30 across exactly two lines so that we can check the edge case -
 M  V30 11111111111111111111"
 M  V30 4 DAT 0 ATOMS=(1 1) -
 M  V30 FIELDDISP="    0.0000    0.0000    DR    ALL  0       0" -
-M  V30 QUERYTYPE=SMARTSQ QUERYOP== -
+M  V30 QUERYTYPE=SMARTSR QUERYOP== -
 M  V30 FIELDDATA="quite long piece of text that needs to be broken -
 M  V30 across more than two lines because we really want to be sure -
 M  V30 that we are doing this right" SEQID=1
 M  V30 5 DAT 0 ATOMS=(1 1) -
 M  V30 FIELDDISP="    0.0000    0.0000    DR    ALL  0       0" -
-M  V30 QUERYTYPE=SMARTSQ QUERYOP== -
+M  V30 QUERYTYPE=SMARTSR QUERYOP== -
 M  V30 FIELDDATA="quite long piece of text that needs to be broken -
 M  V30 across exactly two lines so that we can check the edge case -
 M  V30 11111111111111111111" SEQID=2
@@ -3824,5 +3824,35 @@ TEST_CASE("github #4345: non-stereo bonds written with unspecified parity") {
     CHECK(mb.find("CFG=2") == std::string::npos);
     mb = MolToMolBlock(*m);
     CHECK(mb.find("  2  3  2  3") == std::string::npos);
+  }
+}
+
+TEST_CASE("github #4468: encode/decode SMARTS in SGroups") {
+  SECTION("parsing") {
+    auto m = R"CTAB(query
+  Mrv2108 07152116012D          
+
+  0  0  0     0  0            999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 2 1 1 0 0
+M  V30 BEGIN ATOM
+M  V30 1 C -0.8333 4.5421 0 0
+M  V30 2 C 0.5003 5.3121 0 0
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 1 1 2
+M  V30 END BOND
+M  V30 BEGIN SGROUP
+M  V30 1 DAT 0 ATOMS=(1 2) -
+M  V30 FIELDDISP="    0.0000    0.0000    DR    ALL  0       0" -
+M  V30 QUERYTYPE=SMARTSQ QUERYOP== FIELDDATA=[#6;R]
+M  V30 END SGROUP
+M  V30 END CTAB
+M  END)CTAB"_ctab;
+    REQUIRE(m);
+    REQUIRE(m->getAtomWithIdx(1)->hasQuery());
+    CHECK(SmartsWrite::GetAtomSmarts(
+              static_cast<QueryAtom *>(m->getAtomWithIdx(1))) == "[#6&R]");
+    CHECK(getSubstanceGroups(*m).empty());
   }
 }

--- a/Code/GraphMol/RWMol.cpp
+++ b/Code/GraphMol/RWMol.cpp
@@ -138,7 +138,6 @@ void RWMol::replaceAtom(unsigned int idx, Atom *atom_pin, bool,
     const bool replaceExistingData = false;
     atom_p->updateProps(*d_graph[vd], replaceExistingData);
   }
-  removeSubstanceGroupsReferencingAtom(*this, idx);
 
   const auto orig_p = d_graph[vd];
   delete orig_p;

--- a/Code/GraphMol/RWMol.h
+++ b/Code/GraphMol/RWMol.h
@@ -188,7 +188,7 @@ class RDKIT_GRAPHMOL_EXPORT RWMol : public ROMol {
 
   */
   void replaceBond(unsigned int idx, Bond *bond, bool preserveProps = false,
-                   bool keepSGroups = false);
+                   bool keepSGroups = true);
 
   //@}
 

--- a/Code/GraphMol/Wrap/Mol.cpp
+++ b/Code/GraphMol/Wrap/Mol.cpp
@@ -867,7 +867,7 @@ struct mol_wrapper {
         .def("ReplaceBond", &ReadWriteMol::ReplaceBond,
              (python::arg("index"), python::arg("newBond"),
               python::arg("preserveProps") = false,
-              python::arg("keepSGroups") = false),
+              python::arg("keepSGroups") = true),
              "replaces the specified bond with the provided one.\n"
              "If preserveProps is True preserve keep the existing props unless "
              "explicit set on the new bond. If keepSGroups is False, all"

--- a/Code/GraphMol/Wrap/testSGroups.py
+++ b/Code/GraphMol/Wrap/testSGroups.py
@@ -62,6 +62,53 @@ M  SDD   2     0.0000    0.0000    DR    ALL  1       6
 M  SED   2 E/Z unknown
 M  END"""
     self.m1 = Chem.MolFromMolBlock(mb)
+    mb3000 = '''
+  Mrv2102 09042105562D          
+
+  0  0  0     0  0            999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 13 13 2 0 0
+M  V30 BEGIN ATOM
+M  V30 1 C 5.8858 -5.0042 0 0
+M  V30 2 C 8.5487 -5.0035 0 0
+M  V30 3 C 5.8858 -6.5508 0 0
+M  V30 4 C 7.2232 -7.3127 0 0
+M  V30 5 C 7.2198 -2.6945 0 0
+M  V30 6 C 8.5534 -1.9244 0 0
+M  V30 7 C 5.8862 -1.9244 0 0
+M  V30 8 C 7.2198 -4.2345 0 0
+M  V30 9 C 9.8757 -7.31 0 0
+M  V30 10 O 9.8757 -8.85 0 0
+M  V30 11 O 11.2094 -6.5401 0 0
+M  V30 12 C 8.5487 -6.5439 0 0
+M  V30 13 C 4.5525 -2.6945 0 0
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 2 3 4
+M  V30 2 1 1 3
+M  V30 3 1 5 8
+M  V30 4 2 5 7
+M  V30 5 1 5 6
+M  V30 6 2 1 8
+M  V30 7 1 2 8
+M  V30 8 1 9 12
+M  V30 9 2 9 11
+M  V30 10 1 9 10
+M  V30 11 1 4 12
+M  V30 12 2 2 12
+M  V30 13 1 7 13
+M  V30 END BOND
+M  V30 BEGIN SGROUP
+M  V30 1 DAT 0 ATOMS=(1 10) FIELDNAME=pH -
+M  V30 FIELDDISP="    0.0000    0.0000    DR    ALL  1       6" FIELDDATA=4.6
+M  V30 2 DAT 0 ATOMS=(2 5 7) FIELDNAME=Stereo -
+M  V30 FIELDDISP="    0.0000    0.0000    DR    ALL  1       6" -
+M  V30 FIELDDATA="E/Z unknown"
+M  V30 END SGROUP
+M  V30 END CTAB
+M  END
+'''
+    self.m2 = Chem.MolFromMolBlock(mb3000)
 
   def testBasics(self):
     self.assertTrue(self.m1 is not None)
@@ -76,8 +123,8 @@ M  END"""
     self.assertEqual(sgs[0].GetProp("FIELDNAME"), "pH")
 
     self.assertEqual(sorted(sgs[0].GetPropNames()), [
-      'DATAFIELDS', 'FIELDDISP', 'FIELDINFO', 'FIELDNAME', 'FIELDTYPE', 'ID', 'QUERYOP',
-      'QUERYTYPE', 'TYPE', 'index'
+      'DATAFIELDS', 'FIELDDISP', 'FIELDNAME', 'ID', 
+      'TYPE', 'index'
     ])
     dd = sgs[0].GetPropsAsDict()
     self.assertTrue("TYPE" in dd)
@@ -87,6 +134,31 @@ M  END"""
 
     Chem.ClearMolSubstanceGroups(self.m1)
     self.assertEqual(len(Chem.GetMolSubstanceGroups(self.m1)), 0)
+
+  def testBasics3000(self):
+    self.assertTrue(self.m2 is not None)
+    sgs = Chem.GetMolSubstanceGroups(self.m2)
+    self.assertEqual(len(sgs), 2)
+    self.assertTrue(sgs[0].HasProp("TYPE"))
+    self.assertTrue(sgs[1].HasProp("TYPE"))
+    self.assertEqual(sgs[0].GetProp("TYPE"), "DAT")
+    self.assertEqual(sgs[1].GetProp("TYPE"), "DAT")
+
+    self.assertTrue(sgs[0].HasProp("FIELDNAME"))
+    self.assertEqual(sgs[0].GetProp("FIELDNAME"), "pH")
+
+    self.assertEqual(sorted(sgs[0].GetPropNames()), [
+      'DATAFIELDS', 'FIELDDISP', 'FIELDNAME',  
+      'TYPE', 'index'
+    ])
+    dd = sgs[0].GetPropsAsDict()
+    self.assertTrue("TYPE" in dd)
+    self.assertEqual(dd["TYPE"], "DAT")
+    self.assertTrue("FIELDNAME" in dd)
+    self.assertEqual(dd["FIELDNAME"], "pH")
+
+    Chem.ClearMolSubstanceGroups(self.m2)
+    self.assertEqual(len(Chem.GetMolSubstanceGroups(self.m2)), 0)
 
   def testLifetime(self):
     self.assertTrue(self.m1 is not None)

--- a/Code/GraphMol/testSGroup.cpp
+++ b/Code/GraphMol/testSGroup.cpp
@@ -1,6 +1,6 @@
 //
 //
-//  Copyright (C) 2018-2020 Greg Landrum and T5 Informatics GmbH
+//  Copyright (C) 2018-2021 Greg Landrum and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -494,7 +494,7 @@ void testModifyMol() {
     TEST_ASSERT(sgroups.size() == 3);
   }
   {
-    // replacing an atom will drop SubstanceGroups that include that atom
+    // replacing an atom does not drop SubstanceGroups that include that atom
     mol_copy = mol;
 
     const auto &sgroups = getSubstanceGroups(mol_copy);
@@ -503,10 +503,10 @@ void testModifyMol() {
     auto new_atom = Atom();
     mol_copy.replaceAtom(1, &new_atom);
 
-    TEST_ASSERT(sgroups.size() == 1);
+    TEST_ASSERT(sgroups.size() == 3);
   }
   {
-    // replacing a bond will drop SubstanceGroups that include that bond
+    // replacing a bond does not drop SubstanceGroups that include that bond
     mol_copy = mol;
 
     const auto &sgroups = getSubstanceGroups(mol_copy);
@@ -515,7 +515,7 @@ void testModifyMol() {
     auto new_bond = Bond(Bond::SINGLE);
     mol_copy.replaceBond(1, &new_bond);
 
-    TEST_ASSERT(sgroups.size() == 1);
+    TEST_ASSERT(sgroups.size() == 3);
   }
   {
     // removing an atom will drop SubstanceGroups that include that atom

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,6 +1,11 @@
 # Release_2021.09.1
 (Changes relative to Release_2021.03.1)
 
+## Backwards incompatible changes
+- `RWMol.replaceAtom()` no longer removes `SubstanceGroups` which reference that atom.
+- The `keepSGroups` argument to `RWMol.replaceBond()` now defaults to true.
+
+
 ## Deprecated code (to be removed in a future release):
 - The `useCountSimulation` keyword argument for
   `rdFingerprintGenerator.GetMorganGenerator` and


### PR DESCRIPTION
Changes here:
- #4468: support reading SMARTS queries on atoms from SGroups in V2000 and V3000 mol blocks. These are indicated using   `QUERYTYPE=SMARTSQ` or `QUERYTYPE=SQ`.
- #4476: read Data SGroup (i.e. SDT) properties from V2000 mol blocks even if the FIELDNAME is empty
- Changes the behavior of `RWMol.replaceAtom()` to not remove SubstanceGroups involving the changed atom. This isn't necessary and doesn't really make sense.

