### PR TITLE
be more tolerant when kekulizing

### DIFF
--- a/Code/GraphMol/Kekulize.cpp
+++ b/Code/GraphMol/Kekulize.cpp
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2001-2017 Greg Landrum and Rational Discovery LLC
+//  Copyright (C) 2001-2021 Greg Landrum and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -170,6 +170,18 @@ void markDbondCands(RWMol &mol, const INT_VECT &allAtms,
         ++vi;
       }
 
+      // Kekulize aromatic N-oxides, such as O=n1ccccc1
+      // These only reach here if SANITIZE_CLEANUP is disabled.
+      if (tbo == 5 && sbo == 4 && dv == 3 && totalDegree == 3 &&
+          nRadicals == 0 && chrg == 0 && at->getTotalNumHs() == 0) {
+        switch (at->getAtomicNum()) {
+          case 7:   // N
+          case 15:  // P
+          case 33:  // As
+            dv = 5;
+            break;
+        }
+      }
       // std::cerr << "  kek: " << at->getIdx() << " tbo:" << tbo << " sbo:" <<
       // sbo
       //           << "  dv : " << dv << " totalDegree : " << totalDegree

--- a/Code/GraphMol/catch_graphmol.cpp
+++ b/Code/GraphMol/catch_graphmol.cpp
@@ -2122,3 +2122,35 @@ TEST_CASE(
     CHECK(MolToSmarts(*m) == "C-,=O");
   }
 }
+
+TEST_CASE("allow 5 valent N/P/As to kekulize", "[kekulization]") {
+  std::vector<std::pair<std::string, std::string>> tests = {
+      {"O=n1ccccc1", "O=N1=CC=CC=C1"},
+      {"O=p1ccccc1", "O=P1=CC=CC=C1"},
+      {"O=[as]1ccccc1", "O=[As]1=CC=CC=C1"}};
+  SmilesParserParams ps;
+  ps.sanitize = false;
+  SECTION("kekulization") {
+    for (const auto &pr : tests) {
+      std::unique_ptr<RWMol> m{SmilesToMol(pr.first, ps)};
+      REQUIRE(m);
+      m->updatePropertyCache(false);
+      MolOps::Kekulize(*m);
+      CHECK(MolToSmiles(*m) == pr.second);
+    }
+  }
+  SECTION("sanitization") {
+    for (const auto &pr : tests) {
+      std::unique_ptr<RWMol> m{SmilesToMol(pr.first, ps)};
+      REQUIRE(m);
+      m->updatePropertyCache(false);
+      unsigned int failed;
+      unsigned int flags = MolOps::SanitizeFlags::SANITIZE_ALL ^
+                           MolOps::SanitizeFlags::SANITIZE_CLEANUP ^
+                           MolOps::SanitizeFlags::SANITIZE_PROPERTIES;
+      MolOps::sanitizeMol(*m, failed, flags);
+      CHECK(!failed);
+      CHECK(MolToSmiles(*m) == pr.second);
+    }
+  }
+}


### PR DESCRIPTION
Modifies the sanitization code so that `O=n1ccccc1` can be kekulized. This will only happen if the other sanitization options are set up so that neither the cleanup nor the valence-check steps happen.

It seems reasonable that the kekulization code doesn't need to continue to enforce valence constraints; those should be (and are) done elsewhere.

The idea and patch are from Roger Sayle

