### PR TITLE
Fixes #4498

### DIFF
--- a/Code/GraphMol/FMCS/MaximumCommonSubgraph.cpp
+++ b/Code/GraphMol/FMCS/MaximumCommonSubgraph.cpp
@@ -964,8 +964,7 @@ MCSResult MaximumCommonSubgraph::find(const std::vector<ROMOL_SPTR>& src_mols) {
   }
 
   unsigned i = 0;
-  boost::dynamic_bitset<> faked_ring_info;
-  faked_ring_info.resize(src_mols.size());
+  boost::dynamic_bitset<> faked_ring_info(src_mols.size());
   for (const auto& src_mol : src_mols) {
     Molecules.push_back(src_mol.get());
     if (!Molecules.back()->getRingInfo()->isInitialized()) {

--- a/Code/GraphMol/FMCS/MaximumCommonSubgraph.cpp
+++ b/Code/GraphMol/FMCS/MaximumCommonSubgraph.cpp
@@ -470,18 +470,21 @@ void MaximumCommonSubgraph::makeInitialSeeds() {
             if (!QueryMoleculeSingleMatchedAtom) {
               QueryMoleculeSingleMatchedAtom = queryMolAtom;
             } else {
-              QueryMoleculeSingleMatchedAtom = (std::max)(
-                  queryMolAtom, QueryMoleculeSingleMatchedAtom,
-                  [](const Atom* a, const Atom* b) {
-                    if (a->getDegree() != b->getDegree()) {
-                      return (a->getDegree() < b->getDegree());
-                    } else if (a->getFormalCharge() != b->getFormalCharge()) {
-                      return (a->getFormalCharge() < b->getFormalCharge());
-                    } else if (a->getAtomicNum() != b->getAtomicNum()) {
-                      return (a->getAtomicNum() < b->getAtomicNum());
-                    }
-                    return (a->getIdx() < b->getIdx());
-                  });
+              QueryMoleculeSingleMatchedAtom =
+                  (std::max)(queryMolAtom, QueryMoleculeSingleMatchedAtom,
+                             [](const Atom* a, const Atom* b) {
+                               if (a->getDegree() != b->getDegree()) {
+                                 return (a->getDegree() < b->getDegree());
+                               } else if (a->getFormalCharge() !=
+                                          b->getFormalCharge()) {
+                                 return (a->getFormalCharge() <
+                                         b->getFormalCharge());
+                               } else if (a->getAtomicNum() !=
+                                          b->getAtomicNum()) {
+                                 return (a->getAtomicNum() < b->getAtomicNum());
+                               }
+                               return (a->getIdx() < b->getIdx());
+                             });
             }
           }
           break;
@@ -961,6 +964,7 @@ MCSResult MaximumCommonSubgraph::find(const std::vector<ROMOL_SPTR>& src_mols) {
   }
 
   unsigned i = 0;
+  boost::dynamic_bitset<> faked_ring_info;
   faked_ring_info.resize(src_mols.size());
   for (const auto& src_mol : src_mols) {
     Molecules.push_back(src_mol.get());
@@ -1133,6 +1137,12 @@ MCSResult MaximumCommonSubgraph::find(const std::vector<ROMOL_SPTR>& src_mols) {
 #endif
   }
 #endif
+
+  auto pos = faked_ring_info.find_first();
+  while (pos != boost::dynamic_bitset<>::npos) {
+    src_mols[pos]->getRingInfo()->reset();
+    pos = faked_ring_info.find_next(pos);
+  }
 
   clear();
   return res;

--- a/Code/GraphMol/FMCS/MaximumCommonSubgraph.cpp
+++ b/Code/GraphMol/FMCS/MaximumCommonSubgraph.cpp
@@ -960,11 +960,15 @@ MCSResult MaximumCommonSubgraph::find(const std::vector<ROMOL_SPTR>& src_mols) {
     Parameters.AtomCompareParameters.RingMatchesRingOnly = true;
   }
 
+  unsigned i = 0;
+  faked_ring_info.resize(src_mols.size());
   for (const auto& src_mol : src_mols) {
     Molecules.push_back(src_mol.get());
     if (!Molecules.back()->getRingInfo()->isInitialized()) {
       Molecules.back()->getRingInfo()->initialize();  // but do not fill out !!!
+      faked_ring_info.set(i);
     }
+    ++i;
   }
 
   // sort source set of molecules by their 'size' and assume the smallest

--- a/Code/GraphMol/FMCS/MaximumCommonSubgraph.h
+++ b/Code/GraphMol/FMCS/MaximumCommonSubgraph.h
@@ -90,13 +90,7 @@ class RDKIT_FMCS_EXPORT MaximumCommonSubgraph {
  private:
   void clear() {
     Targets.clear();
-    auto pos = faked_ring_info.find_first();
-    while (pos != boost::dynamic_bitset<>::npos) {
-      Molecules[pos]->getRingInfo()->reset();
-      pos = faked_ring_info.find_next(pos);
-    }
     Molecules.clear();
-    faked_ring_info.clear();
     To = nanoClock();
   }
   void init();
@@ -109,8 +103,6 @@ class RDKIT_FMCS_EXPORT MaximumCommonSubgraph {
 
   bool match(Seed& seed);
   bool matchIncrementalFast(Seed& seed, unsigned itarget);
-
-  boost::dynamic_bitset<> faked_ring_info;
 };
 }  // namespace FMCS
 }  // namespace RDKit

--- a/Code/GraphMol/FMCS/MaximumCommonSubgraph.h
+++ b/Code/GraphMol/FMCS/MaximumCommonSubgraph.h
@@ -90,7 +90,13 @@ class RDKIT_FMCS_EXPORT MaximumCommonSubgraph {
  private:
   void clear() {
     Targets.clear();
+    auto pos = faked_ring_info.find_first();
+    while (pos != boost::dynamic_bitset<>::npos) {
+      Molecules[pos]->getRingInfo()->reset();
+      pos = faked_ring_info.find_next(pos);
+    }
     Molecules.clear();
+    faked_ring_info.clear();
     To = nanoClock();
   }
   void init();
@@ -103,6 +109,8 @@ class RDKIT_FMCS_EXPORT MaximumCommonSubgraph {
 
   bool match(Seed& seed);
   bool matchIncrementalFast(Seed& seed, unsigned itarget);
+
+  boost::dynamic_bitset<> faked_ring_info;
 };
 }  // namespace FMCS
 }  // namespace RDKit

--- a/Code/GraphMol/FMCS/testFMCS_Unit.cpp
+++ b/Code/GraphMol/FMCS/testFMCS_Unit.cpp
@@ -2473,6 +2473,53 @@ void testAtomCompareCompleteRingsOnly() {
   BOOST_LOG(rdInfoLog) << "\tdone" << std::endl;
 }
 
+void testGitHub4498() {
+  BOOST_LOG(rdInfoLog) << "-------------------------------------" << std::endl;
+  BOOST_LOG(rdInfoLog) << "GitHub Issue #4498: FindMCS may leave mols with "
+                          "fake (empty) ring info"
+                       << std::endl;
+  {
+    // Test with rings
+    std::vector<ROMOL_SPTR> mols = {"NC1=CC(N)=C(N)C=C1"_smiles,
+                                    "NC1=CC(N)=C(N)C=C1"_smiles};
+
+    TEST_ASSERT(mols[0]);
+    TEST_ASSERT(mols[1]);
+
+    mols[1]->getRingInfo()->reset();
+    TEST_ASSERT(mols[0]->getRingInfo()->isInitialized() == true);
+    TEST_ASSERT(mols[1]->getRingInfo()->isInitialized() == false);
+
+    MCSResult res = findMCS(mols);
+    TEST_ASSERT(res.NumAtoms == 9);
+
+    TEST_ASSERT(mols[0]->getRingInfo()->isInitialized() == true);
+    TEST_ASSERT(mols[0]->getRingInfo()->numRings() == 1);
+
+    TEST_ASSERT(mols[1]->getRingInfo()->isInitialized() == false);
+  }
+  {
+    // Test without rings
+    std::vector<ROMOL_SPTR> mols = {"NC=CC(N)=C(N)C=C"_smiles,
+                                    "NC=CC(N)=C(N)C=C"_smiles};
+
+    TEST_ASSERT(mols[0]);
+    TEST_ASSERT(mols[1]);
+
+    mols[1]->getRingInfo()->reset();
+    TEST_ASSERT(mols[0]->getRingInfo()->isInitialized() == true);
+    TEST_ASSERT(mols[1]->getRingInfo()->isInitialized() == false);
+
+    MCSResult res = findMCS(mols);
+    TEST_ASSERT(res.NumAtoms == 9);
+
+    TEST_ASSERT(mols[0]->getRingInfo()->isInitialized() == true);
+    TEST_ASSERT(mols[0]->getRingInfo()->numRings() == 0);
+
+    TEST_ASSERT(mols[1]->getRingInfo()->isInitialized() == false);
+  }
+}
+
 //====================================================================================================
 //====================================================================================================
 
@@ -2556,6 +2603,7 @@ int main(int argc, const char* argv[]) {
   testGitHub3693();
   testGitHub3886();
   testAtomCompareCompleteRingsOnly();
+  testGitHub4498();
 
   unsigned long long t1 = nanoClock();
   double sec = double(t1 - T0) / 1000000.;


### PR DESCRIPTION
Fixes #4498

Addresses the issue by remembering which ones of the input mols were initialized with bogus ring info, and resets them at cleanup.
