### PR TITLE
Fixes #4503

### DIFF
--- a/Code/GraphMol/SmilesParse/CXSmilesOps.cpp
+++ b/Code/GraphMol/SmilesParse/CXSmilesOps.cpp
@@ -1163,8 +1163,12 @@ bool parse_it(Iterator &first, Iterator last, RDKit::RWMol &mol) {
 void parseCXExtensions(RDKit::RWMol &mol, const std::string &extText,
                        std::string::const_iterator &first) {
   // BOOST_LOG(rdWarningLog) << "parseCXNExtensions: " << extText << std::endl;
-  if (extText.empty() || extText[0] != '|') {
+  if (extText.empty()) {
     return;
+  }
+  if (extText[0] != '|') {
+    throw RDKit::SmilesParseException(
+        "CXSMILES extension does not start with |");
   }
   first = extText.begin();
   bool ok = parser::parse_it(first, extText.end(), mol);

--- a/Code/GraphMol/SmilesParse/SmilesParse.cpp
+++ b/Code/GraphMol/SmilesParse/SmilesParse.cpp
@@ -300,13 +300,13 @@ template <typename T>
 void preprocessSmiles(const std::string &smiles, const T &params,
                       std::string &lsmiles, std::string &name,
                       std::string &cxPart) {
+  cxPart = "";
+  name = "";
   if (params.parseName && !params.allowCXSMILES) {
-    std::vector<std::string> tokens;
-    boost::split(tokens, smiles, boost::is_any_of(" \t"),
-                 boost::token_compress_on);
-    lsmiles = tokens[0];
-    if (tokens.size() > 1) {
-      name = tokens[1];
+    size_t sidx = smiles.find_first_of(" \t");
+    if (sidx != std::string::npos && sidx != 0) {
+      lsmiles = smiles.substr(0, sidx);
+      name = boost::trim_copy(smiles.substr(sidx, smiles.size() - sidx));
     }
   } else if (params.allowCXSMILES) {
     size_t sidx = smiles.find_first_of(" \t");

--- a/Code/GraphMol/SmilesParse/SmilesParse.h
+++ b/Code/GraphMol/SmilesParse/SmilesParse.h
@@ -27,8 +27,8 @@ struct RDKIT_SMILESPARSE_EXPORT SmilesParserParams {
   bool allowCXSMILES = true; /**< recognize and parse CXSMILES*/
   bool strictCXSMILES =
       true; /**< throw an exception if the CXSMILES parsing fails */
-  bool parseName = false; /**< parse (and set) the molecule name as well */
-  bool removeHs = true;   /**< remove Hs after constructing the molecule */
+  bool parseName = true; /**< parse (and set) the molecule name as well */
+  bool removeHs = true;  /**< remove Hs after constructing the molecule */
   bool useLegacyStereo =
       true; /**< use the legacy stereochemistry perception code */
 };
@@ -88,7 +88,7 @@ struct RDKIT_SMILESPARSE_EXPORT SmartsParserParams {
   bool allowCXSMILES = true; /**< recognize and parse CXSMILES extensions */
   bool strictCXSMILES =
       true; /**< throw an exception if the CXSMILES parsing fails */
-  bool parseName = false; /**< parse (and set) the molecule name as well */
+  bool parseName = true; /**< parse (and set) the molecule name as well */
   bool mergeHs =
       true; /**< toggles merging H atoms in the SMARTS into neighboring atoms*/
 };

--- a/Code/GraphMol/SmilesParse/catch_tests.cpp
+++ b/Code/GraphMol/SmilesParse/catch_tests.cpp
@@ -917,6 +917,7 @@ TEST_CASE("Github #4319 add CXSMARTS support") {
     std::string sma = "CCC |$foo;;bar$|";
     SmartsParserParams ps;
     ps.allowCXSMILES = false;
+    ps.parseName = false;
     const std::unique_ptr<RWMol> mol(SmartsToMol(sma, ps));
     REQUIRE(!mol);
   }
@@ -1425,5 +1426,141 @@ TEST_CASE("Github #4320: Support toggling components of CXSMILES output") {
                       SmilesWrite::CXSmilesFields::CX_ALL ^
                           SmilesWrite::CXSmilesFields::CX_MOLFILE_VALUES);
     CHECK(cxsmi == "CCOC");
+  }
+}
+
+TEST_CASE(
+    "Github #4503: MolFromSmiles and MolFromSmarts incorrectly accepting input "
+    "with spaces") {
+  SECTION("SMILES defaults") {
+    std::unique_ptr<RWMol> m{SmilesToMol("NON sense")};
+    CHECK(m);
+    CHECK(m->hasProp("_Name"));
+    CHECK_THROWS_AS(SmilesToMol("NON |sense|"), SmilesParseException);
+  }
+  SECTION("SMARTS defaults") {
+    std::unique_ptr<RWMol> m{SmilesToMol("NON sense")};
+    CHECK(m);
+    CHECK_THROWS_AS(SmartsToMol("NON |sense|"), SmilesParseException);
+  }
+  SECTION("SMILES no names") {
+    SmilesParserParams ps;
+    ps.parseName = false;
+    CHECK_THROWS_AS(SmilesToMol("NON sense", ps), SmilesParseException);
+  }
+  SECTION("SMARTS no names") {
+    SmartsParserParams ps;
+    ps.parseName = false;
+    CHECK_THROWS_AS(SmartsToMol("NON sense", ps), SmilesParseException);
+  }
+  SECTION("SMILES not strict") {
+    SmilesParserParams ps;
+    ps.strictCXSMILES = false;
+    {
+      std::unique_ptr<RWMol> m{SmilesToMol("NON sense", ps)};
+      CHECK(m);
+      CHECK(m->hasProp("_Name"));
+    }
+    {
+      std::unique_ptr<RWMol> m{SmilesToMol("NON |sense|", ps)};
+      CHECK(m);
+      CHECK(!m->hasProp("_Name"));
+    }
+    ps.parseName = false;
+    {
+      std::unique_ptr<RWMol> m{SmilesToMol("NON sense", ps)};
+      CHECK(m);
+      CHECK(!m->hasProp("_Name"));
+    }
+    {
+      std::unique_ptr<RWMol> m{SmilesToMol("NON |sense|", ps)};
+      CHECK(m);
+      CHECK(!m->hasProp("_Name"));
+    }
+  }
+  SECTION("SMARTS not strict") {
+    SmartsParserParams ps;
+    ps.strictCXSMILES = false;
+    {
+      std::unique_ptr<RWMol> m{SmartsToMol("NON sense", ps)};
+      CHECK(m);
+      CHECK(m->hasProp("_Name"));
+    }
+    {
+      std::unique_ptr<RWMol> m{SmartsToMol("NON |sense|", ps)};
+      CHECK(m);
+      CHECK(!m->hasProp("_Name"));
+    }
+    ps.parseName = false;
+    {
+      std::unique_ptr<RWMol> m{SmartsToMol("NON sense", ps)};
+      CHECK(m);
+      CHECK(!m->hasProp("_Name"));
+    }
+    {
+      std::unique_ptr<RWMol> m{SmartsToMol("NON |sense|", ps)};
+      CHECK(m);
+      CHECK(!m->hasProp("_Name"));
+    }
+  }
+  SECTION("SMARTS CXExtensions + names") {
+    SmartsParserParams ps;
+    ps.strictCXSMILES = false;
+    {  // CXSMILES + name
+      std::unique_ptr<RWMol> m{SmartsToMol("NON |$_AV:bar;;foo$| name", ps)};
+      CHECK(m->hasProp("_Name"));
+      CHECK(m->getProp<std::string>("_Name") == "name");
+    }
+    {  // CXSMILES fails, so we don't read the name
+      std::unique_ptr<RWMol> m{SmartsToMol("NON |sense| name", ps)};
+      CHECK(m);
+      CHECK(!m->hasProp("_Name"));
+    }
+    ps.parseName = false;
+    {  // CXSMILES, skip the name
+      std::unique_ptr<RWMol> m{SmartsToMol("NON |$_AV:bar;;foo$| name", ps)};
+      CHECK(m);
+      CHECK(!m->hasProp("_Name"));
+    }
+    ps.parseName = true;
+    ps.allowCXSMILES = false;
+    ps.strictCXSMILES = true;
+    {  // CXSMILES + name, but not parsing the CXSMILES, so we read it as the
+       // name
+      std::unique_ptr<RWMol> m{SmartsToMol("NON |$_AV:bar;;foo$| name", ps)};
+      CHECK(m);
+      CHECK(m->hasProp("_Name"));
+      CHECK(m->getProp<std::string>("_Name") == "|$_AV:bar;;foo$|");
+    }
+  }
+  SECTION("SMILES CXExtensions + names") {
+    SmilesParserParams ps;
+    ps.strictCXSMILES = false;
+    {  // CXSMILES + name
+      std::unique_ptr<RWMol> m{SmilesToMol("NON |$_AV:bar;;foo$| name", ps)};
+      CHECK(m->hasProp("_Name"));
+      CHECK(m->getProp<std::string>("_Name") == "name");
+    }
+    {  // CXSMILES fails, so we don't read the name
+      std::unique_ptr<RWMol> m{SmilesToMol("NON |sense| name", ps)};
+      CHECK(m);
+      CHECK(!m->hasProp("_Name"));
+    }
+    ps.parseName = false;
+    {  // CXSMILES, skip the name
+      std::unique_ptr<RWMol> m{SmilesToMol("NON |$_AV:bar;;foo$| name", ps)};
+      CHECK(m);
+      CHECK(!m->hasProp("_Name"));
+    }
+    ps.parseName = true;
+    ps.allowCXSMILES = false;
+    ps.strictCXSMILES = true;
+    {  // CXSMILES + name, but not parsing the CXSMILES, so we read it as the
+       // name
+      std::unique_ptr<RWMol> m{SmilesToMol("NON |$_AV:bar;;foo$| name", ps)};
+      CHECK(m);
+      CHECK(m->hasProp("_Name"));
+      CHECK(m->getProp<std::string>("_Name") == "|$_AV:bar;;foo$|");
+    }
   }
 }

--- a/Code/GraphMol/SmilesParse/test.cpp
+++ b/Code/GraphMol/SmilesParse/test.cpp
@@ -145,7 +145,8 @@ void testFail() {
   // parsing
   // on good input:
   string smis[] = {
-      "CC=(CO)C",    "CC(=CO)C", "C1CC",  "C1CC1", "Ccc",   "CCC",
+      "CC=(CO)C",    "CC(=CO)C", "C1CC",
+      "C1CC1",       "Ccc",      "CCC",
       "fff",  // tests the situation where the parser cannot do anything at all
       "CCC",
       "N(=O)(=O)=O",  // bad sanitization failure
@@ -157,9 +158,9 @@ void testFail() {
       "C-0",  // part of sf.net issue 2525792
       "C1CC1",
       "C+0",  // part of sf.net issue 2525792
-      "C1CC1",       "[H2H]",    "C1CC1", "[HH2]", "C1CC1", 
-      "[555555555555555555C]", "C1CC1",
-      "EOS"};
+      "C1CC1",       "[H2H]",    "C1CC1",
+      "[HH2]",       "C1CC1",    "[555555555555555555C]",
+      "C1CC1",       "EOS"};
 
   // turn off the error log temporarily:
   while (smis[i] != "EOS") {
@@ -4013,22 +4014,24 @@ void testSmilesParseParams() {
     ROMol *m = SmilesToMol(smiles);
     TEST_ASSERT(m);
     delete m;
-    {  // it's ignored
+    {  // it's parsed:
       SmilesParserParams params;
+      params.allowCXSMILES = false;
       m = SmilesToMol(smiles, params);
       TEST_ASSERT(m);
-      TEST_ASSERT(!m->hasProp(common_properties::_Name));
+      TEST_ASSERT(m->hasProp(common_properties::_Name));
+      TEST_ASSERT(m->getProp<std::string>(common_properties::_Name) ==
+                  "the_name");
       delete m;
     }
     {
       SmilesParserParams params;
-      params.parseName = true;
+      params.strictCXSMILES = false;
+      params.parseName = false;
       m = SmilesToMol(smiles, params);
       TEST_ASSERT(m);
       TEST_ASSERT(m->getNumAtoms() == 4);
-      TEST_ASSERT(m->hasProp(common_properties::_Name));
-      TEST_ASSERT(m->getProp<std::string>(common_properties::_Name) ==
-                  "the_name");
+      TEST_ASSERT(!m->hasProp(common_properties::_Name));
       delete m;
     }
   }

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -4629,6 +4629,7 @@ $$$$
     self.assertTrue(m is not None)
     ps = Chem.SmilesParserParams()
     ps.allowCXSMILES = False
+    ps.parseName = False
     m = Chem.MolFromSmiles(smi, ps)
     self.assertTrue(m is None)
     ps.allowCXSMILES = True
@@ -6634,6 +6635,7 @@ CAS<~>
     self.assertTrue(m is not None)
     ps = Chem.SmartsParserParams()
     ps.allowCXSMILES = False
+    ps.parseName = False
     m = Chem.MolFromSmarts(smi, ps)
     self.assertTrue(m is None)
     ps.allowCXSMILES = True

--- a/Docs/Book/RDKit_Book.rst
+++ b/Docs/Book/RDKit_Book.rst
@@ -283,6 +283,60 @@ The features which are written by :py:func:`rdkit.Chem.rdmolfiles.MolToCXSmiles`
   >>> Chem.MolToCXSmiles(m)
   'CO |$C2;O1$,atomProp:0.p1.5:0.p2.A1:1.p1.2|'
 
+Reading molecule names
+----------------------
+
+If the SMILES/SMARTS and the optional CXSMILES extensions are followed by whitespace and another string, the SMILES/SMARTS parsers will interpret this as the molecule name:
+
+.. doctest::
+
+  >>> m = Chem.MolFromSmiles('CO carbon monoxide')
+  >>> m.GetProp('_Name')
+  'carbon monoxide'
+  >>> m2 = Chem.MolFromSmiles('CO |$C2;O1$| carbon monoxide')
+  >>> m2.GetAtomWithIdx(0).GetProp('atomLabel')
+  'C2'
+  >>> m2.GetProp('_Name')
+  'carbon monoxide'
+
+This can be disabled while still parsing the CXSMILES:
+
+.. doctest::
+
+  >>> ps = Chem.SmilesParserParams()
+  >>> ps.parseName = False
+  >>> m3 = Chem.MolFromSmiles('CO |$C2;O1$| carbon monoxide',ps)
+  >>> m3.HasProp('_Name')
+  0
+  >>> m3.GetAtomWithIdx(0).GetProp('atomLabel')
+  'C2'
+
+
+Note that if you disable CXSMILES parsing but pass in a string which includes CXSMILES it will be interpreted as (part of) the name:
+
+.. doctest::
+
+  >>> ps = Chem.SmilesParserParams()
+  >>> ps.allowCXSMILES = False
+  >>> m4 = Chem.MolFromSmiles('CO |$C2;O1$| carbon monoxide',ps)
+  >>> m4.GetProp('_Name')
+  '|$C2;O1$| carbon monoxide'
+
+
+Finally, if you disable parsing of both CXSMILES and names, then extra text in the SMILES/SMARTS string will result in errors:
+.. doctest::
+
+  >>> ps = Chem.SmilesParserParams()
+  >>> ps.allowCXSMILES = False
+  >>> ps.parseName = False
+  >>> m5 = Chem.MolFromSmiles('CO |$C2;O1$| carbon monoxide',ps)
+  >>> m5 is None
+  True
+  >>> m5 = Chem.MolFromSmiles('CO carbon monoxide',ps)
+  >>> m5 is None
+  True
+
+The examples in this sectin all used the SMILES parser, but the SMARTS parser behaves the same way.
 
 SMARTS Support and Extensions
 =============================

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -4,6 +4,11 @@
 ## Backwards incompatible changes
 - `RWMol.replaceAtom()` no longer removes `SubstanceGroups` which reference that atom.
 - The `keepSGroups` argument to `RWMol.replaceBond()` now defaults to true.
+- The SMARTS parser now by default accepts CXSMILES extensions and molecule
+  names. SMARTS which previously failed to parse like `CCC fail` will now return
+  valid molecules.
+- Molecule names in SMILES and SMARTS are now parsed by default. Previously they
+  were ignored.
 
 
 ## Deprecated code (to be removed in a future release):


### PR DESCRIPTION
The major change here is to change the default parameters for the SMILES and SMARTS parsers to parse molecule names by default.
This shouldn't break any existing code unless someone has written code which depends on SMILES including whitespace being parsed without having a `_Name` property set, but that seems unlikely.
Regardless, this is flagged as a backwards-incompatible change.
There's also a bit of refactoring in there.