### PR TITLE
Fixes #4514

### DIFF
--- a/Code/GraphMol/Wrap/SubstanceGroup.cpp
+++ b/Code/GraphMol/Wrap/SubstanceGroup.cpp
@@ -257,7 +257,9 @@ struct sgroup_wrap {
               python::arg("includeComputed") = true),
              "Returns a dictionary of the properties set on the "
              "SubstanceGroup.\n"
-             " n.b. some properties cannot be converted to python types.\n");
+             " n.b. some properties cannot be converted to python types.\n")
+        .def("ClearProp", (void (RDProps::*)(const std::string &) const) &SubstanceGroup::clearProp,
+             "Removes a particular property (does nothing if not set).\n\n");
 
     python::def("GetMolSubstanceGroups", &getMolSubstanceGroups,
                 "returns a copy of the molecule's SubstanceGroups (if any)",

--- a/Code/GraphMol/Wrap/testSGroups.py
+++ b/Code/GraphMol/Wrap/testSGroups.py
@@ -132,6 +132,13 @@ M  END
     self.assertTrue("FIELDNAME" in dd)
     self.assertEqual(dd["FIELDNAME"], "pH")
 
+    sgs[0].ClearProp("FIELDNAME")
+    self.assertFalse(sgs[0].HasProp("FIELDNAME"))
+
+    # The property doesn't exist anymore, but this should not fail
+    sgs[0].ClearProp("FIELDNAME")
+    self.assertFalse(sgs[0].HasProp("FIELDNAME"))
+
     Chem.ClearMolSubstanceGroups(self.m1)
     self.assertEqual(len(Chem.GetMolSubstanceGroups(self.m1)), 0)
 
@@ -148,7 +155,7 @@ M  END
     self.assertEqual(sgs[0].GetProp("FIELDNAME"), "pH")
 
     self.assertEqual(sorted(sgs[0].GetPropNames()), [
-      'DATAFIELDS', 'FIELDDISP', 'FIELDNAME',  
+      'DATAFIELDS', 'FIELDDISP', 'FIELDNAME',
       'TYPE', 'index'
     ])
     dd = sgs[0].GetPropsAsDict()


### PR DESCRIPTION
Fixes #4514

This just exposes the `ClearProp` method in Python.