### PR TITLE
Additions to the jupyter integration

### DIFF
--- a/rdkit/Chem/Draw/IPythonConsole.py
+++ b/rdkit/Chem/Draw/IPythonConsole.py
@@ -40,6 +40,7 @@ kekulizeStructures = True
 highlightByReactant = False
 ipython_useSVG = False
 ipython_showProperties = True
+ipython_maxProperties = 10
 ipython_3d = False
 molSize_3d = (400, 400)
 drawing_type_3d = 'stick'  # default drawing type for 3d structures
@@ -115,12 +116,15 @@ def _toHTML(mol):
   if not ipython_useSVG:
     png = Draw._moltoimg(mol, molSize, [], nm, returnPNG=True, drawOptions=drawOptions)
     png = base64.b64encode(png)
-    res.append(f'<tr><td colspan=2><image src="data:image/png;base64,{png.decode()}"></td></tr>')
+    res.append(f'<tr><td colspan=2 style="text-align:center"><image src="data:image/png;base64,{png.decode()}"></td></tr>')
   else:
     svg = Draw._moltoSVG(mol, molSize, [], nm, kekulize=kekulizeStructures, drawOptions=drawOptions)
-    res.append(f'<tr><td colspan=2>{svg}</td></tr>')
+    res.append(f'<tr><td colspan=2 style="text-align:center">{svg}</td></tr>')
 
-  for pn, pv in props.items():
+  for i,(pn, pv) in enumerate(props.items()):
+    if ipython_maxProperties>=0 and i>= ipython_maxProperties:
+      res.append('<tr><td colspan=2 style="text-align:center">Property list truncated.<br />Increase IPythonConsole.ipython_maxProperties (or set it to -1) to see more properties.</td></tr>')
+      break
     res.append(
       f'<tr><th style="text-align:right">{pn}</th><td style="text-align:left">{pv}</td></tr>')
   res = "\n".join(res)

--- a/rdkit/Chem/Draw/UnitTestIPython.py
+++ b/rdkit/Chem/Draw/UnitTestIPython.py
@@ -82,6 +82,29 @@ class TestCase(unittest.TestCase):
     self.assertNotIn('_hiddenprop', html)
     self.assertNotIn('computedprop', html)
 
+    for i in range(10):
+      m.SetIntProp(f'prop-{i}',i)
+    IPythonConsole.ipython_showProperties = True
+    IPythonConsole.ipython_maxProperties = 5
+    html = m._repr_html_()
+    self.assertIn('publicprop', html)
+    self.assertIn('prop-1', html)
+    self.assertNotIn('prop-8', html)
+
+    IPythonConsole.ipython_maxProperties = -1
+    html = m._repr_html_()
+    self.assertIn('publicprop', html)
+    self.assertIn('prop-1', html)
+    self.assertIn('prop-8', html)
+
+    IPythonConsole.ipython_maxProperties = 10
+    html = m._repr_html_()
+    self.assertIn('publicprop', html)
+    self.assertIn('prop-1', html)
+    self.assertNotIn('prop-8', html)
+
+
+
 
 if __name__ == '__main__':
   unittest.main()

--- a/rdkit/Chem/Draw/UnitTestIPython.py
+++ b/rdkit/Chem/Draw/UnitTestIPython.py
@@ -58,5 +58,30 @@ class TestCase(unittest.TestCase):
     res = Draw.MolsToGridImage((m, m), drawOptions=dopts)
     self.assertNotIn('class="note"', res.data)
 
+  @unittest.skipIf(IPythonConsole is None, 'IPython not available')
+  def testMolPropertyRendering(self):
+    m = Chem.MolFromSmiles('CCCC')
+    self.assertTrue(hasattr(m, '_repr_html_'))
+
+    m.SetProp('_Name', 'testm')
+    m.SetProp('_hiddenprop', 'hpvalue')
+    m.SetProp('computedprop', 'cpvalue', computed=True)
+    m.SetDoubleProp('foo', 12.3)
+    m.SetProp('publicprop', 'ppropval')
+
+    IPythonConsole.ipython_showProperties = True
+    html = m._repr_html_()
+    self.assertIn('publicprop', html)
+    self.assertNotIn('testm', html)
+    self.assertNotIn('_hiddenprop', html)
+    self.assertNotIn('computedprop', html)
+
+    IPythonConsole.ipython_showProperties = False
+    html = m._repr_html_()
+    self.assertNotIn('publicprop', html)
+    self.assertNotIn('_hiddenprop', html)
+    self.assertNotIn('computedprop', html)
+
+
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
The changes here:
1. The molecules in a `MolBundle` are now rendered as a molecule grid
2. If molecules have non-private, non-computed properties, they will be displayed with the molecule in the notebook. To do this the molecule+properties are rendered in a small HTML table

Example MolBundle rendering:
![image](https://user-images.githubusercontent.com/540511/134132241-3043e6b1-3446-4171-9378-2c5768bf673e.png)

Example molecule + property rendering:
![image](https://user-images.githubusercontent.com/540511/134132366-1106806e-cc6f-4a25-8d1a-928dc667d4ac.png)
