### PR TITLE
Expose get_smarts to JS

### DIFF
--- a/Code/MinimalLib/jswrapper.cpp
+++ b/Code/MinimalLib/jswrapper.cpp
@@ -114,6 +114,7 @@ EMSCRIPTEN_BINDINGS(RDKit_minimal) {
       .function("is_valid", &JSMol::is_valid)
       .function("get_smiles", &JSMol::get_smiles)
       .function("get_cxsmiles", &JSMol::get_cxsmiles)
+      .function("get_smarts", &JSMol::get_smarts)
       .function("get_molblock", &JSMol::get_molblock)
       .function("get_v3Kmolblock", &JSMol::get_v3Kmolblock)
       .function("get_inchi", &JSMol::get_inchi)

--- a/Code/MinimalLib/jswrapper.cpp
+++ b/Code/MinimalLib/jswrapper.cpp
@@ -115,6 +115,7 @@ EMSCRIPTEN_BINDINGS(RDKit_minimal) {
       .function("get_smiles", &JSMol::get_smiles)
       .function("get_cxsmiles", &JSMol::get_cxsmiles)
       .function("get_smarts", &JSMol::get_smarts)
+      .function("get_cxsmarts", &JSMol::get_cxsmarts)
       .function("get_molblock", &JSMol::get_molblock)
       .function("get_v3Kmolblock", &JSMol::get_v3Kmolblock)
       .function("get_inchi", &JSMol::get_inchi)

--- a/Code/MinimalLib/minilib.cpp
+++ b/Code/MinimalLib/minilib.cpp
@@ -55,6 +55,10 @@ std::string JSMol::get_smarts() const {
   if (!d_mol) return "";
   return MolToSmarts(*d_mol);
 }
+std::string JSMol::get_cxsmarts() const {
+  if (!d_mol) return "";
+  return MolToCXSmarts(*d_mol);
+}
 std::string JSMol::get_svg(unsigned int w, unsigned int h) const {
   if (!d_mol) return "";
   return MinimalLib::mol_to_svg(*d_mol, w, h);

--- a/Code/MinimalLib/minilib.cpp
+++ b/Code/MinimalLib/minilib.cpp
@@ -17,6 +17,7 @@
 #include <GraphMol/RDKitBase.h>
 #include <GraphMol/MolPickler.h>
 #include <GraphMol/SmilesParse/SmilesParse.h>
+#include <GraphMol/SmilesParse/SmartsWrite.h>
 #include <GraphMol/FileParsers/FileParsers.h>
 #include <GraphMol/MolDraw2D/MolDraw2D.h>
 #include <GraphMol/MolDraw2D/MolDraw2DSVG.h>
@@ -49,6 +50,10 @@ std::string JSMol::get_smiles() const {
 std::string JSMol::get_cxsmiles() const {
   if (!d_mol) return "";
   return MolToCXSmiles(*d_mol);
+}
+std::string JSMol::get_smarts() const {
+  if (!d_mol) return "";
+  return MolToSmarts(*d_mol);
 }
 std::string JSMol::get_svg(unsigned int w, unsigned int h) const {
   if (!d_mol) return "";

--- a/Code/MinimalLib/minilib.h
+++ b/Code/MinimalLib/minilib.h
@@ -19,6 +19,7 @@ class JSMol {
   std::string get_smiles() const;
   std::string get_cxsmiles() const;
   std::string get_smarts() const;
+  std::string get_cxsmarts() const;
   std::string get_molblock() const;
   std::string get_v3Kmolblock() const;
   std::string get_inchi() const;

--- a/Code/MinimalLib/minilib.h
+++ b/Code/MinimalLib/minilib.h
@@ -18,6 +18,7 @@ class JSMol {
   JSMol(RDKit::RWMol *mol) : d_mol(mol) {}
   std::string get_smiles() const;
   std::string get_cxsmiles() const;
+  std::string get_smarts() const;
   std::string get_molblock() const;
   std::string get_v3Kmolblock() const;
   std::string get_inchi() const;

--- a/Code/MinimalLib/tests/tests.js
+++ b/Code/MinimalLib/tests/tests.js
@@ -426,6 +426,36 @@ function test_get_mol_no_kekulize() {
 }
 
 
+function test_get_smarts() {
+    var mol = RDKitModule.get_mol(`
+  MJ201100                      
+
+  8  8  0  0  0  0  0  0  0  0999 V2000
+   -1.0491    1.5839    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -1.7635    1.1714    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -1.7635    0.3463    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -1.0491   -0.0661    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -0.3346    0.3463    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -0.3346    1.1714    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    0.3798    1.5839    0.0000 R#  0  0  0  0  0  0  0  0  0  0  0  0
+    0.3798   -0.0661    0.0000 R#  0  0  0  0  0  0  0  0  0  0  0  0
+  1  2  2  0  0  0  0
+  2  3  1  0  0  0  0
+  3  4  2  0  0  0  0
+  4  5  1  0  0  0  0
+  5  6  2  0  0  0  0
+  6  1  1  0  0  0  0
+  6  7  1  0  0  2  0
+  5  8  1  0  0  2  0
+M  RGP  2   7   1   8   2
+M  END
+`);
+    assert(mol.is_valid());
+    smarts = mol.get_smarts();
+    assert(smarts == "[#6]1:[#6]:[#6]:[#6]:[#6](:[#6]:1-&!@*)-&!@*");
+}
+
+
 initRDKitModule().then(function(instance) {
     var done = {};
     const waitAllTestsFinished = () => {
@@ -456,6 +486,7 @@ initRDKitModule().then(function(instance) {
     test_generate_aligned_coords_allow_rgroups();
     test_accept_failure();
     test_get_mol_no_kekulize();
+    test_get_smarts();
     waitAllTestsFinished().then(() =>
         console.log("Tests finished successfully")
     );

--- a/Code/MinimalLib/tests/tests.js
+++ b/Code/MinimalLib/tests/tests.js
@@ -456,6 +456,39 @@ M  END
 }
 
 
+function test_get_cxsmarts() {
+    var mol = RDKitModule.get_mol(`
+  MJ201100                      
+
+  8  8  0  0  0  0  0  0  0  0999 V2000
+   -1.0491    1.5839    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -1.7635    1.1714    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -1.7635    0.3463    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -1.0491   -0.0661    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -0.3346    0.3463    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -0.3346    1.1714    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    0.3798    1.5839    0.0000 R#  0  0  0  0  0  0  0  0  0  0  0  0
+    0.3798   -0.0661    0.0000 R#  0  0  0  0  0  0  0  0  0  0  0  0
+  1  2  2  0  0  0  0
+  2  3  1  0  0  0  0
+  3  4  2  0  0  0  0
+  4  5  1  0  0  0  0
+  5  6  2  0  0  0  0
+  6  1  1  0  0  0  0
+  6  7  1  0  0  2  0
+  5  8  1  0  0  2  0
+M  RGP  2   7   1   8   2
+M  END
+`);
+    assert(mol.is_valid());
+    cxsmarts = mol.get_cxsmarts();
+    assert(cxsmarts == "[#6]1:[#6]:[#6]:[#6]:[#6](:[#6]:1-&!@*)-&!@* |" +
+        "(-1.0491,1.5839,;-1.7635,1.1714,;-1.7635,0.3463,;-1.0491,-0.0661,;" +
+        "-0.3346,0.3463,;-0.3346,1.1714,;0.3798,1.5839,;0.3798,-0.0661,)," +
+        "atomProp:6.dummyLabel.R1:7.dummyLabel.R2|");
+}
+
+
 initRDKitModule().then(function(instance) {
     var done = {};
     const waitAllTestsFinished = () => {
@@ -487,6 +520,7 @@ initRDKitModule().then(function(instance) {
     test_accept_failure();
     test_get_mol_no_kekulize();
     test_get_smarts();
+    test_get_cxsmarts();
     waitAllTestsFinished().then(() =>
         console.log("Tests finished successfully")
     );


### PR DESCRIPTION
This small PR exposes `get_smarts()` functionality to JS. This is very hand, for example, to convert MDL queries to SMARTS strings.
