### PR TITLE
fix a thread-safety bug in the UFF parameter loading

### DIFF
--- a/Code/ForceField/UFF/Params.cpp
+++ b/Code/ForceField/UFF/Params.cpp
@@ -1,6 +1,5 @@
-// $Id$
 //
-//  Copyright (C) 2004-2006 Rational Discovery LLC
+//  Copyright (C) 2004-2021 Greg Landrum and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -21,20 +20,28 @@
 #include <boost/tokenizer.hpp>
 #include <Geometry/point.h>
 
-typedef boost::tokenizer<boost::char_separator<char> > tokenizer;
+typedef boost::tokenizer<boost::char_separator<char>> tokenizer;
+
+#include <RDGeneral/BoostStartInclude.h>
+#include <boost/flyweight.hpp>
+#include <boost/flyweight/key_value.hpp>
+#include <boost/flyweight/no_tracking.hpp>
+#include <RDGeneral/BoostEndInclude.h>
 
 namespace ForceFields {
 namespace UFF {
 
-class std::unique_ptr<ParamCollection> ParamCollection::ds_instance = nullptr;
-
 extern const std::string defaultParamData;
 
-ParamCollection *ParamCollection::getParams(const std::string &paramData) {
-  if (ds_instance == nullptr || !paramData.empty()) {
-    ds_instance.reset(new ParamCollection(paramData));
-  }
-  return ds_instance.get();
+typedef boost::flyweight<
+    boost::flyweights::key_value<std::string, ParamCollection>,
+    boost::flyweights::no_tracking>
+    param_flyweight;
+
+const ParamCollection *ParamCollection::getParams(
+    const std::string &paramData) {
+  const ParamCollection *res = &(param_flyweight(paramData).get());
+  return res;
 }
 
 ParamCollection::ParamCollection(std::string paramData) {
@@ -83,6 +90,8 @@ ParamCollection::ParamCollection(std::string paramData) {
     inLine = RDKit::getLine(inStream);
   }
 }
+
+// clang-format off
 const std::string defaultParamData =
     "#Atom	r1	theta0	x1	D1	zeta	Z1	Vi	Uj	"
     "Xi	Hard	Radius\n"
@@ -340,5 +349,7 @@ const std::string defaultParamData =
     "3.475	3.175	1.9\n"
     "Lw6+3	1.698	90	3.236	0.011	12	3.9	0	0	"
     "3.5	3.2	1.9\n";
+// clang-format on
+
 }  // end of namespace UFF
 }  // end of namespace ForceFields

--- a/Code/ForceField/UFF/Params.h
+++ b/Code/ForceField/UFF/Params.h
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2004-2006 Rational Discovery LLC
+//  Copyright (C) 2004-2021 Greg Landrum and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -8,8 +8,8 @@
 //  of the RDKit source tree.
 //
 #include <RDGeneral/export.h>
-#ifndef __RD_UFFPARAMS_H__
-#define __RD_UFFPARAMS_H__
+#ifndef RD_UFFPARAMS_H
+#define RD_UFFPARAMS_H
 
 #include <memory>
 #include <string>
@@ -129,7 +129,7 @@ class RDKIT_FORCEFIELD_EXPORT ParamCollection {
       - if \c paramData is supplied, a new singleton will be instantiated.
         The current instantiation (if there is one) will be deleted.
   */
-  static ParamCollection *getParams(const std::string &paramData = "");
+  static const ParamCollection *getParams(const std::string &paramData = "");
   //! Looks up the parameters for a particular UFF key and returns them.
   /*!
     \return a pointer to the AtomicParams object, NULL on failure.
@@ -143,10 +143,9 @@ class RDKIT_FORCEFIELD_EXPORT ParamCollection {
     return nullptr;
   }
 
- private:
-  //! to force this to be a singleton, the constructor must be private
   ParamCollection(std::string paramData);
-  static class std::unique_ptr<ParamCollection> ds_instance;  //!< the singleton
+
+ private:
   std::map<std::string, AtomicParams> d_params;  //!< the parameter map
 };
 }  // namespace UFF

--- a/Code/ForceField/UFF/testUFFForceField.cpp
+++ b/Code/ForceField/UFF/testUFFForceField.cpp
@@ -1,6 +1,5 @@
-// $Id$
 //
-// Copyright (C)  2004-2008 Greg Landrum and Rational Discovery LLC
+// Copyright (C)  2004-2021 Greg Landrum and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -936,8 +935,7 @@ void testUFFParams() {
   std::cerr << "-------------------------------------" << std::endl;
   std::cerr << " Test UFF Parameter objects" << std::endl;
 
-  ForceFields::UFF::ParamCollection *params =
-      ForceFields::UFF::ParamCollection::getParams();
+  auto params = ForceFields::UFF::ParamCollection::getParams();
   TEST_ASSERT(params);
 
   const ForceFields::UFF::AtomicParams *ptr;
@@ -975,8 +973,7 @@ void testUFF8() {
   ps.push_back(&p5);
   ps.push_back(&p6);
 
-  ForceFields::UFF::ParamCollection *params =
-      ForceFields::UFF::ParamCollection::getParams();
+  auto params = ForceFields::UFF::ParamCollection::getParams();
   const ForceFields::UFF::AtomicParams *param1, *param2;
 
   // C_2 (sp2 carbon):
@@ -1116,8 +1113,7 @@ void testUFFTorsionConflict() {
   ps.push_back(&p6);
   ps.push_back(&p7);
 
-  ForceFields::UFF::ParamCollection *params =
-      ForceFields::UFF::ParamCollection::getParams();
+  auto params = ForceFields::UFF::ParamCollection::getParams();
   const ForceFields::UFF::AtomicParams *param1, *param2, *param3;
 
   // C_2 (sp2 carbon):

--- a/Code/GraphMol/ForceFieldHelpers/UFF/AtomTyper.cpp
+++ b/Code/GraphMol/ForceFieldHelpers/UFF/AtomTyper.cpp
@@ -1,6 +1,5 @@
-// $Id$
 //
-//  Copyright (C) 2004-2006 Rational Discovery LLC
+//  Copyright (C) 2004-2021 Greg Landrum and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -393,7 +392,7 @@ std::string getAtomLabel(const Atom *atom) {
 std::pair<AtomicParamVect, bool> getAtomTypes(const ROMol &mol,
                                               const std::string &) {
   bool foundAll = true;
-  ParamCollection *params = ParamCollection::getParams();
+  auto params = ParamCollection::getParams();
 
   AtomicParamVect paramVect;
   paramVect.resize(mol.getNumAtoms());
@@ -420,7 +419,7 @@ std::pair<AtomicParamVect, bool> getAtomTypes(const ROMol &mol,
 
 bool getUFFBondStretchParams(const ROMol &mol, unsigned int idx1,
                              unsigned int idx2, UFFBond &uffBondStretchParams) {
-  ParamCollection *params = ParamCollection::getParams();
+  auto params = ParamCollection::getParams();
   unsigned int idx[2] = {idx1, idx2};
   AtomicParamVect paramVect(2);
   unsigned int i;
@@ -445,7 +444,7 @@ bool getUFFBondStretchParams(const ROMol &mol, unsigned int idx1,
 bool getUFFAngleBendParams(const ROMol &mol, unsigned int idx1,
                            unsigned int idx2, unsigned int idx3,
                            UFFAngle &uffAngleBendParams) {
-  ParamCollection *params = ParamCollection::getParams();
+  auto params = ParamCollection::getParams();
   unsigned int idx[3] = {idx1, idx2, idx3};
   AtomicParamVect paramVect(3);
   unsigned int i;
@@ -477,7 +476,7 @@ bool getUFFAngleBendParams(const ROMol &mol, unsigned int idx1,
 bool getUFFTorsionParams(const ROMol &mol, unsigned int idx1, unsigned int idx2,
                          unsigned int idx3, unsigned int idx4,
                          UFFTor &uffTorsionParams) {
-  ParamCollection *params = ParamCollection::getParams();
+  auto params = ParamCollection::getParams();
   unsigned int idx[4] = {idx1, idx2, idx3, idx4};
   AtomicParamVect paramVect(2);
   unsigned int i;
@@ -599,7 +598,7 @@ bool getUFFInversionParams(const ROMol &mol, unsigned int idx1,
 bool getUFFVdWParams(const ROMol &mol, unsigned int idx1, unsigned int idx2,
                      UFFVdW &uffVdWParams) {
   bool res = true;
-  ParamCollection *params = ParamCollection::getParams();
+  auto params = ParamCollection::getParams();
   unsigned int idx[2] = {idx1, idx2};
   AtomicParamVect paramVect(2);
   unsigned int i;

--- a/Code/GraphMol/ForceFieldHelpers/UFF/testUFFHelpers.cpp
+++ b/Code/GraphMol/ForceFieldHelpers/UFF/testUFFHelpers.cpp
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2004-2018 Greg Landrum and Rational Discovery LLC
+//  Copyright (C) 2004-2021 Greg Landrum and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -1387,8 +1387,7 @@ void testGitHubIssue613() {
     TEST_ASSERT(foundAll);
     TEST_ASSERT(types.size() == mol->getNumAtoms());
 
-    ForceFields::UFF::ParamCollection *params =
-        ForceFields::UFF::ParamCollection::getParams();
+    auto params = ForceFields::UFF::ParamCollection::getParams();
     const ForceFields::UFF::AtomicParams *ap = (*params)("Eu6+3");
     TEST_ASSERT(ap);
     TEST_ASSERT(ap->r1 == types[0]->r1);

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -9,6 +9,9 @@
   valid molecules.
 - Molecule names in SMILES and SMARTS are now parsed by default. Previously they
   were ignored.
+- The `getParams()` function for retrieving UFF parameters now returns a const
+  pointer instead of a standard pointer. This shouldn't affect the functionality
+  of any code since the only method of the class is also const.
 
 
 ## Deprecated code (to be removed in a future release):


### PR DESCRIPTION
The way we were using the singleton here was, I think, not particularly threadsafe. This might have been leading to a Heisenbug in the KNIME nodes.

The changes here outsource worrying about thread-safe initialization to boost::flyweight (yay!).

I didn't add any new tests because we're already doing current multi-threaded UFF and conformer generation (this also uses UFF parameters) tests. Those weren't showing any problem and I didn't manage to come up with anything that would reproducibly show the problem.