### PR TITLE
Fixes a couple build warnings in QueryOps.h

### DIFF
--- a/Code/GraphMol/QueryOps.h
+++ b/Code/GraphMol/QueryOps.h
@@ -84,7 +84,7 @@ static inline int queryAtomTotalDegree(Atom const *at) {
 //! D and T are treated as "non-hydrogen" here
 static inline int queryAtomNonHydrogenDegree(Atom const *at) {
   int res = 0;
-  for (const auto &nbri :
+  for (const auto nbri :
        boost::make_iterator_range(at->getOwningMol().getAtomNeighbors(at))) {
     const auto nbr = at->getOwningMol()[nbri];
     if (nbr->getAtomicNum() != 1 || nbr->getIsotope() > 1) {
@@ -97,7 +97,7 @@ static inline int queryAtomNonHydrogenDegree(Atom const *at) {
 //! D and T are not treated as heavy atoms here
 static inline int queryAtomHeavyAtomDegree(Atom const *at) {
   int heavyDegree = 0;
-  for (const auto &nbri :
+  for (const auto nbri :
        boost::make_iterator_range(at->getOwningMol().getAtomNeighbors(at))) {
     const auto nbr = at->getOwningMol()[nbri];
     if (nbr->getAtomicNum() > 1) {


### PR DESCRIPTION
This fixes these annoying warnings I've been seeing for some time when using clang 12 to build a project that uses rdkit:
```
In file included from ../../../rdkit/include/rdkit/GraphMol/QueryAtom.h:16:
../../../rdkit/include/rdkit/GraphMol/QueryOps.h:87:20: warning: loop variable 'nbri' is always a copy because the range of type 
'iterator_range<typename range_iterator<const pair<adjacency_iterator<adjacency_list<vecS, vecS, undirectedS, Atom *, Bond *, 
no_property, listS>, unsigned long, out_edge_iter<__wrap_iter<stored_edge_iter<unsigned long, __list_iterator<list_edge<unsigned 
long, Bond *>, void *>, Bond *> *>, unsigned long, edge_desc_impl<undirected_tag, unsigned long>, long>, long>, adjacency_iterator<
adjacency_list<vecS, vecS, undirectedS, Atom *, Bond *, no_property, listS>, unsigned long, out_edge_iter<__wrap_iter<
stored_edge_iter<unsigned long, __list_iterator<list_edge<unsigned long, Bond *>, void *>, Bond *> *>, unsigned long, edge_desc_impl
<undirected_tag, unsigned long>, long>, long> > >::type>' (aka 'iterator_range<boost::adjacency_iterator<boost::adjacency_list<
boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom *, RDKit::Bond *, boost::no_property, boost::listS>, unsigned long, 
boost::detail::out_edge_iter<std::__1::__wrap_iter<boost::detail::stored_edge_iter<unsigned long, std::__1::__list_iterator<
boost::list_edge<unsigned long, RDKit::Bond *>, void *>, RDKit::Bond *> *>, unsigned long, boost::detail::edge_desc_impl<
boost::undirected_tag, unsigned long>, long>, long> >') does not return a reference [-Wrange-loop-analysis]
  for (const auto &nbri :
                   ^
../../../rdkit/include/rdkit/GraphMol/QueryOps.h:87:8: note: use non-reference type 'unsigned long'
  for (const auto &nbri :
       ^~~~~~~~~~~~~~~~~~
../../../rdkit/include/rdkit/GraphMol/QueryOps.h:100:20: warning: loop variable 'nbri' is always a copy because the range of type 
'iterator_range<typename range_iterator<const pair<adjacency_iterator<adjacency_list<vecS, vecS, undirectedS, Atom *, Bond *, 
no_property, listS>, unsigned long, out_edge_iter<__wrap_iter<stored_edge_iter<unsigned long, __list_iterator<list_edge<unsigned 
long, Bond *>, void *>, Bond *> *>, unsigned long, edge_desc_impl<undirected_tag, unsigned long>, long>, long>, adjacency_iterator<
adjacency_list<vecS, vecS, undirectedS, Atom *, Bond *, no_property, listS>, unsigned long, out_edge_iter<__wrap_iter<
stored_edge_iter<unsigned long, __list_iterator<list_edge<unsigned long, Bond *>, void *>, Bond *> *>, unsigned long, edge_desc_impl
<undirected_tag, unsigned long>, long>, long> > >::type>' (aka 'iterator_range<boost::adjacency_iterator<boost::adjacency_list<
boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom *, RDKit::Bond *, boost::no_property, boost::listS>, unsigned long, 
boost::detail::out_edge_iter<std::__1::__wrap_iter<boost::detail::stored_edge_iter<unsigned long, std::__1::__list_iterator<
boost::list_edge<unsigned long, RDKit::Bond *>, void *>, RDKit::Bond *> *>, unsigned long, boost::detail::edge_desc_impl<
boost::undirected_tag, unsigned long>, long>, long> >') does not return a reference [-Wrange-loop-analysis]
  for (const auto &nbri :
                   ^
../../../rdkit/include/rdkit/GraphMol/QueryOps.h:100:8: note: use non-reference type 'unsigned long'
  for (const auto &nbri :
       ^~~~~~~~~~~~~~~~~~
2 warnings generated.```
