### PR TITLE
Fixes #4558

### DIFF
--- a/Code/GraphMol/Substruct/vf2.hpp
+++ b/Code/GraphMol/Substruct/vf2.hpp
@@ -23,7 +23,7 @@
 namespace boost {
 namespace detail {
 typedef std::uint32_t node_id;
-const node_id NULL_NODE = 0xFFFF;
+const node_id NULL_NODE = 0xFFFFFFFF;
 struct NodeInfo {
   node_id id;
   node_id in;


### PR DESCRIPTION
Closes #4558

I was debugging the issue when I noticed the value of `NULL_NODE` was weird: being a `uint32_t`, setting a value of 32767 felt weird, especially since `NULL_NODE` is involved in some checks as in `IsFeasiblePair()` and the value 32767 is not too high and can easily be reached in cases as the one in the description.

Updating the value to its maximum capacity (`0xFFFFFFFF`) did actually solve the issue, and the script presented in the case now prints the following:
```
num atoms: 84525
56350
indexes: [0]
deltas : []
all equal: True

indexes: [1]
deltas : []
all equal: True

indexes: [2]
deltas : []
all equal: True

indexes: [3]
deltas : []
all equal: True

indexes: [4]
deltas : []
all equal: True

indexes: [5]
deltas : []
all equal: True

indexes: [6]
deltas : []
all equal: True

indexes: [7]
deltas : []
all equal: True

indexes: [8]
deltas : []
all equal: True

indexes: [9]
deltas : []
all equal: True

indexes: [10]
deltas : []
all equal: True

indexes: [11]
deltas : []
all equal: True

indexes: [12]
deltas : []
all equal: True

indexes: [13]
deltas : []
all equal: True

indexes: [14]
deltas : []
all equal: True

indexes: [15]
deltas : []
all equal: True

indexes: [16]
deltas : []
all equal: True

indexes: [17]
deltas : []
all equal: True

indexes: [18]
deltas : []
all equal: True

indexes: [19]
deltas : []
all equal: True

indexes: [20]
deltas : []
all equal: True

```

Which means we now get the expected number of matches, and all of them are "unique" (each mol is reported twice, but with different ordering of the atoms).