### PR TITLE
Improve performance of removing substruct/tautomer duplicates

### DIFF
--- a/Code/GraphMol/Substruct/SubstructUtils.cpp
+++ b/Code/GraphMol/Substruct/SubstructUtils.cpp
@@ -8,6 +8,7 @@
 //  of the RDKit source tree.
 //
 #include "SubstructUtils.h"
+#include <set>
 #include <RDGeneral/utils.h>
 #include <GraphMol/RDKitBase.h>
 #include <GraphMol/RDKitQueries.h>
@@ -182,7 +183,7 @@ void removeDuplicates(std::vector<MatchVectType> &matches,
   //  that the 4 paths are equivalent in the semantics of the query.
   //  Also, OELib returns the same results
   //
-  std::list<boost::dynamic_bitset<>> seen;
+  std::set<boost::dynamic_bitset<>> seen;
   std::vector<MatchVectType> res;
   res.reserve(matches.size());
   for (auto &&match : matches) {
@@ -190,12 +191,12 @@ void removeDuplicates(std::vector<MatchVectType> &matches,
     for (const auto &ci : match) {
       val.set(ci.second);
     }
-    auto pos = std::lower_bound(seen.begin(), seen.end(), val);
-    if (*pos != val) {
+    if (seen.find(val) == seen.end()) {
       res.push_back(std::move(match));
-      seen.insert(pos, val);
+      seen.insert(val);
     }
   }
+  res.shrink_to_fit();
   matches = std::move(res);
 }
 

--- a/Code/GraphMol/Substruct/SubstructUtils.cpp
+++ b/Code/GraphMol/Substruct/SubstructUtils.cpp
@@ -169,7 +169,8 @@ bool bondCompat(const Bond *b1, const Bond *b2,
   return res;
 }
 
-void removeDuplicates(std::vector<MatchVectType> &v, unsigned int nAtoms) {
+void removeDuplicates(std::vector<MatchVectType> &matches,
+                      unsigned int nAtoms) {
   //
   //  This works by tracking the indices of the atoms in each match vector.
   //  This can lead to unexpected behavior when looking at rings and queries
@@ -181,21 +182,21 @@ void removeDuplicates(std::vector<MatchVectType> &v, unsigned int nAtoms) {
   //  that the 4 paths are equivalent in the semantics of the query.
   //  Also, OELib returns the same results
   //
-  std::vector<boost::dynamic_bitset<>> seen;
+  std::list<boost::dynamic_bitset<>> seen;
   std::vector<MatchVectType> res;
-  for (std::vector<MatchVectType>::const_iterator i = v.begin(); i != v.end();
-       ++i) {
+  res.reserve(matches.size());
+  for (auto &&match : matches) {
     boost::dynamic_bitset<> val(nAtoms);
-    for (const auto &ci : *i) {
+    for (const auto &ci : match) {
       val.set(ci.second);
     }
-    if (std::find(seen.begin(), seen.end(), val) == seen.end()) {
-      // it's something new
-      res.push_back(*i);
-      seen.push_back(val);
+    auto pos = std::lower_bound(seen.begin(), seen.end(), val);
+    if (*pos != val) {
+      res.push_back(std::move(match));
+      seen.insert(pos, val);
     }
   }
-  v = res;
+  matches = std::move(res);
 }
 
 const MatchVectType &getMostSubstitutedCoreMatch(

--- a/Code/GraphMol/TautomerQuery/TautomerQuery.cpp
+++ b/Code/GraphMol/TautomerQuery/TautomerQuery.cpp
@@ -9,8 +9,8 @@
 //  of the RDKit source tree.
 
 #include "TautomerQuery.h"
-#include <boost/smart_ptr.hpp>
 #include <functional>
+#include <set>
 #include <utility>
 #include <GraphMol/RDKitBase.h>
 #include <GraphMol/MolStandardize/Tautomer.h>
@@ -20,7 +20,6 @@
 #include <GraphMol/QueryBond.h>
 #include <GraphMol/Substruct/SubstructUtils.h>
 #include <GraphMol/Fingerprints/Fingerprints.h>
-
 // #define VERBOSE
 
 #ifdef VERBOSE
@@ -47,7 +46,7 @@ void removeTautomerDuplicates(std::vector<MatchVectType> &matches,
   //  Also, OELib returns the same results
   //
 
-  std::list<boost::dynamic_bitset<>> seen;
+  std::set<boost::dynamic_bitset<>> seen;
   std::vector<MatchVectType> res;
   res.reserve(matches.size());
   for (auto &&match : matches) {
@@ -55,16 +54,15 @@ void removeTautomerDuplicates(std::vector<MatchVectType> &matches,
     for (const auto &ci : match) {
       val.set(ci.second);
     }
-    auto pos = std::lower_bound(seen.begin(), seen.end(), val);
-    if (*pos != val) {
+    if (seen.find(val) == seen.end()) {
       res.push_back(std::move(match));
-      seen.insert(pos, val);
+      seen.insert(val);
     } else if (matchingTautomers) {
       auto position = res.size();
       matchingTautomers->erase(matchingTautomers->begin() + position);
     }
   }
-
+  res.shrink_to_fit();
   matches = std::move(res);
 }
 

--- a/Code/GraphMol/TautomerQuery/TautomerQuery.cpp
+++ b/Code/GraphMol/TautomerQuery/TautomerQuery.cpp
@@ -47,25 +47,25 @@ void removeTautomerDuplicates(std::vector<MatchVectType> &matches,
   //  Also, OELib returns the same results
   //
 
-  std::vector<boost::dynamic_bitset<>> seen;
+  std::list<boost::dynamic_bitset<>> seen;
   std::vector<MatchVectType> res;
-  for (size_t i = 0; i < matches.size(); i++) {
-    auto match = matches[i];
+  res.reserve(matches.size());
+  for (auto &&match : matches) {
     boost::dynamic_bitset<> val(nAtoms);
     for (const auto &ci : match) {
       val.set(ci.second);
     }
-    if (std::find(seen.begin(), seen.end(), val) == seen.end()) {
-      // it's something new
-      res.push_back(match);
-      seen.push_back(val);
+    auto pos = std::lower_bound(seen.begin(), seen.end(), val);
+    if (*pos != val) {
+      res.push_back(std::move(match));
+      seen.insert(pos, val);
     } else if (matchingTautomers) {
-      int position = res.size();
+      auto position = res.size();
       matchingTautomers->erase(matchingTautomers->begin() + position);
     }
   }
 
-  matches = res;
+  matches = std::move(res);
 }
 
 }  // namespace


### PR DESCRIPTION
~This leverages `std::lower_bound()` and sorting to reduce the number of searches to determine duplicates, and `std::list` and `std::list::insert()`  to reduce the number of vector reallocations to improve performance. It also use `std::move()` to avoid copies, although this seems to have a smaller effect.~

The result of these changes is that the my test script for issue #4558 (56350 matches in total, half of them, 28175, are unique) went from taking ~4 minutes to uniquify results, all  the way down to 15 seconds.

I haven't tested the Tautomer one, I just copied over the changes from the one for Substructure matching.
