### PR TITLE
Improve performance of removing substruct/tautomer duplicates (one final touch)

### DIFF
--- a/Code/GraphMol/Substruct/SubstructUtils.cpp
+++ b/Code/GraphMol/Substruct/SubstructUtils.cpp
@@ -191,9 +191,10 @@ void removeDuplicates(std::vector<MatchVectType> &matches,
     for (const auto &ci : match) {
       val.set(ci.second);
     }
-    if (seen.find(val) == seen.end()) {
+    auto pos = seen.lower_bound(val);
+    if (pos == seen.end() || *pos != val) {
       res.push_back(std::move(match));
-      seen.insert(val);
+      seen.insert(pos, std::move(val));
     }
   }
   res.shrink_to_fit();

--- a/Code/GraphMol/TautomerQuery/TautomerQuery.cpp
+++ b/Code/GraphMol/TautomerQuery/TautomerQuery.cpp
@@ -54,9 +54,10 @@ void removeTautomerDuplicates(std::vector<MatchVectType> &matches,
     for (const auto &ci : match) {
       val.set(ci.second);
     }
-    if (seen.find(val) == seen.end()) {
+    auto pos = seen.lower_bound(val);
+    if (pos == seen.end() || *pos != val) {
       res.push_back(std::move(match));
-      seen.insert(val);
+      seen.insert(pos, std::move(val));
     } else if (matchingTautomers) {
       auto position = res.size();
       matchingTautomers->erase(matchingTautomers->begin() + position);


### PR DESCRIPTION
One final touch to my previous commit: after it was merged I noticed that we can hint `std::set` where to insert the new elements, saving us one search in the set, and giving performance another small push: now I can match 750k atoms in ~60 seconds (that's about 33% less than my previous commit).