### PR TITLE
Fixes #4567

### DIFF
--- a/rdkit/Chem/Descriptors.py
+++ b/rdkit/Chem/Descriptors.py
@@ -201,7 +201,10 @@ def _FingerprintDensity(mol, func, *args, **kwargs):
     val = fp.GetNumOnBits()
   else:
     val = len(fp.GetNonzeroElements())
-  return float(val) / mol.GetNumHeavyAtoms()
+  num_heavy_atoms = mol.GetNumHeavyAtoms()
+  if num_heavy_atoms == 0:
+    return 0
+  return float(val) / num_heavy_atoms
 
 
 def FpDensityMorgan1(x):

--- a/rdkit/Chem/UnitTestDescriptors.py
+++ b/rdkit/Chem/UnitTestDescriptors.py
@@ -191,6 +191,14 @@ class TestCase(unittest.TestCase):
     names = set(["AUTOCORR2D_%s" % str(i + 1) for i in range(192)])
     self.assertEqual(descriptors2.intersection(names), names)
 
+  def test_issue_4567(self):
+    """
+      Github issue #4567:
+      Requesting "density" fingerprint Hydrogen molecule fails with exception
+      """
+    mol = AllChem.MolFromSmiles('[HH]')
+    self.assertEqual(Descriptors.FpDensityMorgan1(mol), 0)
+
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
Closes #4567

As suggested, we just return 0 if there aren't any heavy atoms in the mol.