### PR TITLE
Fix (new?) warnings

### DIFF
--- a/Code/GraphMol/catch_chirality.cpp
+++ b/Code/GraphMol/catch_chirality.cpp
@@ -1712,10 +1712,11 @@ TEST_CASE(
 TEST_CASE("StereoInfo comparisons") {
   Chirality::StereoInfo si1;
   si1.centeredOn = 3;
-  si1.type == Chirality::StereoType::Atom_Tetrahedral;
+  CHECK(si1.type == Chirality::StereoType::Unspecified);
+  si1.type = Chirality::StereoType::Atom_Tetrahedral;
   Chirality::StereoInfo si2;
   si2.centeredOn = 3;
-  si2.type == Chirality::StereoType::Atom_Tetrahedral;
+  si2.type = Chirality::StereoType::Atom_Tetrahedral;
   CHECK(si1 == si2);
   si2.descriptor = Chirality::StereoDescriptor::Tet_CCW;
   CHECK(si1 != si2);

--- a/Code/GraphMol/molopstest.cpp
+++ b/Code/GraphMol/molopstest.cpp
@@ -7839,7 +7839,8 @@ void testRemoveAndTrackIsotopes() {
   // shuffle atoms before adding Hs; result should not change
   std::vector<unsigned int> randomOrder(mNoH->getNumAtoms());
   std::iota(randomOrder.begin(), randomOrder.end(), 0U);
-  std::random_shuffle(randomOrder.begin(), randomOrder.end());
+  std::shuffle(randomOrder.begin(), randomOrder.end(),
+               std::default_random_engine());
   std::unique_ptr<ROMol> mNoHRen(MolOps::renumberAtoms(*mNoH, randomOrder));
   mH.reset(MolOps::addHs(*mNoHRen));
   mH_isotopicHsPerHeavy.reset(new IsotopicHsCount(*mH));


### PR DESCRIPTION
I noticed some warnings during the build. This addresses them:

- In catch_chirality.cpp, clang compiled about unused comparison results. I think these were meant to be assignments. I added an extra check to make sure we don't set tetrahedral stereo by default. I think this was introduced in #4536.
- In molopstest.cpp, `std::random_shuffle` is deprecated since C++. I replaced it with `std::shuffle`. This seems to have been introduced earlier, but I hadn't noticed it until now.