### PR TITLE
add ROMol::atomNeighbors() and ROMol::atomBonds()

### DIFF
--- a/Code/GraphMol/Abbreviations/Abbreviations.cpp
+++ b/Code/GraphMol/Abbreviations/Abbreviations.cpp
@@ -57,10 +57,8 @@ void applyMatches(RWMol& mol, const std::vector<AbbreviationMatch>& matches) {
       if (amatch.abbrev.mol &&
           mol.getAtomWithIdx(pr.second)->getDegree() >
               amatch.abbrev.mol->getAtomWithIdx(pr.first)->getDegree()) {
-        for (const auto& nbri : boost::make_iterator_range(
+        for (auto nbrIdx : boost::make_iterator_range(
                  mol.getAtomNeighbors(mol.getAtomWithIdx(pr.second)))) {
-          const auto& nbr = mol[nbri];
-          auto nbrIdx = nbr->getIdx();
           // if this neighbor isn't in the match:
           if (!std::any_of(amatch.match.begin(), amatch.match.end(),
                            [nbrIdx](const std::pair<int, int>& tpr) {

--- a/Code/GraphMol/Atom.cpp
+++ b/Code/GraphMol/Atom.cpp
@@ -166,15 +166,10 @@ unsigned int Atom::getTotalNumHs(bool includeNeighbors) const {
                "valence not defined for atoms not associated with molecules")
   int res = getNumExplicitHs() + getNumImplicitHs();
   if (includeNeighbors) {
-    ROMol::ADJ_ITER begin, end;
-    const ROMol *parent = &getOwningMol();
-    boost::tie(begin, end) = parent->getAtomNeighbors(this);
-    while (begin != end) {
-      const Atom *at = parent->getAtomWithIdx(*begin);
-      if (at->getAtomicNum() == 1) {
-        res++;
+    for (auto nbr : getOwningMol().atomNeighbors(this)) {
+      if (nbr->getAtomicNum() == 1) {
+        ++res;
       }
-      ++begin;
     }
   }
   return res;

--- a/Code/GraphMol/CMakeLists.txt
+++ b/Code/GraphMol/CMakeLists.txt
@@ -163,3 +163,5 @@ rdkit_catch_test(graphmolAdjustQueryCatch catch_adjustquery.cpp catch_main.cpp
 rdkit_catch_test(chiralityTestsCatch catch_chirality.cpp catch_main.cpp
            LINK_LIBRARIES FileParsers SmilesParse GraphMol )
 
+rdkit_catch_test(moliteratorTestsCatch catch_moliterators.cpp catch_main.cpp
+           LINK_LIBRARIES SubstructMatch SmilesParse GraphMol )

--- a/Code/GraphMol/ChemReactions/ReactionRunner.cpp
+++ b/Code/GraphMol/ChemReactions/ReactionRunner.cpp
@@ -1096,7 +1096,7 @@ void checkAndCorrectChiralityOfMatchingAtomsInProduct(
         // there's a reactant bond that hasn't yet been accounted for:
         int unmatchedBond = -1;
 
-        for (const auto &rBond : reactant.atomBonds(&reactantAtom)) {
+        for (const auto rBond : reactant.atomBonds(&reactantAtom)) {
           if (std::find(pOrder.begin(), pOrder.end(), rBond->getIdx()) ==
               pOrder.end()) {
             unmatchedBond = rBond->getIdx();

--- a/Code/GraphMol/ChemReactions/ReactionRunner.cpp
+++ b/Code/GraphMol/ChemReactions/ReactionRunner.cpp
@@ -308,20 +308,21 @@ bool updatePropsFromImplicitProps(Atom *templateAtom, Atom *atom) {
     atom->setFormalCharge(val);
     res = true;
   }
-  if (templateAtom->getPropIfPresent(common_properties::_QueryHCount, val)) {
-    if (!atom->getNoImplicit() || atom->getNumExplicitHs() != val) {
-      atom->setNumExplicitHs(val);
+  unsigned int uval;
+  if (templateAtom->getPropIfPresent(common_properties::_QueryHCount, uval)) {
+    if (!atom->getNoImplicit() || atom->getNumExplicitHs() != uval) {
+      atom->setNumExplicitHs(uval);
       atom->setNoImplicit(true);  // this was github #1544
       res = true;
     }
   }
-  if (templateAtom->getPropIfPresent(common_properties::_QueryMass, val)) {
+  if (templateAtom->getPropIfPresent(common_properties::_QueryMass, uval)) {
     // FIX: technically should do something with this
     // atom->setMass(val);
   }
-  if (templateAtom->getPropIfPresent(common_properties::_QueryIsotope, val) &&
-      val != atom->getIsotope()) {
-    atom->setIsotope(val);
+  if (templateAtom->getPropIfPresent(common_properties::_QueryIsotope, uval) &&
+      uval != atom->getIsotope()) {
+    atom->setIsotope(uval);
     res = true;
   }
   return res;
@@ -1437,7 +1438,7 @@ generateOneProductSet(const ChemicalReaction &rxn,
   return res;
 }
 void identifyAtomsInReactantTemplateNotProductTemplate(
-    const ROMol &reactant, const ROMol &product, boost::dynamic_bitset<> &atoms,
+    const ROMol &reactant, boost::dynamic_bitset<> &atoms,
     std::map<unsigned int, unsigned int> &reactantProductMap,
     const MatchVectType &reactantMatch) {
   for (const auto atom : reactant.atoms()) {
@@ -1768,8 +1769,7 @@ bool run_Reactant(const ChemicalReaction &rxn, RWMol &reactant) {
   boost::dynamic_bitset<> atomsToRemove(reactant.getNumAtoms());
   // finds atoms in the reactantTemplate which aren't in the productTemplate
   ReactionRunnerUtils::identifyAtomsInReactantTemplateNotProductTemplate(
-      *reactantTemplate, *productTemplate, atomsToRemove, reactantProductMap,
-      match);
+      *reactantTemplate, atomsToRemove, reactantProductMap, match);
   // identify atoms which should be removed from the molecule
   ReactionRunnerUtils::traverseToFindAtomsToRemove(reactant, *reactantTemplate,
                                                    atomsToRemove, match);

--- a/Code/GraphMol/ChemReactions/ReactionUtils.cpp
+++ b/Code/GraphMol/ChemReactions/ReactionUtils.cpp
@@ -193,9 +193,7 @@ std::pair<unsigned int, std::vector<int>> getNbrOrder(const Atom *atom1,
   std::vector<int> order;
   order.reserve(atom1->getDegree());
   unsigned nUnmapped = 0;
-  for (const auto &nbri : boost::make_iterator_range(
-           atom1->getOwningMol().getAtomNeighbors(atom1))) {
-    const auto &nbrAtom = atom1->getOwningMol()[nbri];
+  for (const auto nbrAtom : atom1->getOwningMol().atomNeighbors(atom1)) {
     if (nbrAtom->getAtomMapNum() > 0) {
       order.push_back(nbrAtom->getAtomMapNum());
     } else {

--- a/Code/GraphMol/ChemTransforms/ChemTransforms.cpp
+++ b/Code/GraphMol/ChemTransforms/ChemTransforms.cpp
@@ -399,7 +399,8 @@ ROMol *replaceCore(const ROMol &mol, const ROMol &core,
             coreAtom->getDegree() == 1,
             "Multiple core atoms match a mol atom, but one of the core "
             "atoms has degree > 1 ");
-        auto coreNeighborIdx = core[*core.getAtomNeighbors(coreAtom).first]->getIdx();
+        auto coreNeighborIdx =
+            core[*core.getAtomNeighbors(coreAtom).first]->getIdx();
         auto molNeighborIdx =
             std::find_if(matchV.cbegin(), matchV.cend(),
                          [coreNeighborIdx](std::pair<int, int> p) {
@@ -409,7 +410,8 @@ ROMol *replaceCore(const ROMol &mol, const ROMol &core,
         if (molNeighborIdx > -1) {
           auto connectingBond =
               mol.getBondBetweenAtoms(mappingInfo.molIndex, molNeighborIdx);
-          CHECK_INVARIANT(connectingBond,"expected bond in molecule not found");
+          CHECK_INVARIANT(connectingBond,
+                          "expected bond in molecule not found");
           multipleOwnedBonds.set(connectingBond->getIdx());
         }
       }
@@ -675,10 +677,7 @@ ROMol *MurckoDecompose(const ROMol &mol) {
       bool removeIt = true;
 
       // check if the atom has a neighboring keeper:
-      ROMol::ADJ_ITER nbrIdx, endNbrs;
-      boost::tie(nbrIdx, endNbrs) = res->getAtomNeighbors(atom);
-      while (nbrIdx != endNbrs) {
-        Atom *nbr = (*res)[*nbrIdx];
+      for (auto nbr : res->atomNeighbors(atom)) {
         if (keepAtoms[nbr->getIdx()]) {
           if (res->getBondBetweenAtoms(atom->getIdx(), nbr->getIdx())
                   ->getBondType() == Bond::DOUBLE) {
@@ -698,7 +697,6 @@ ROMol *MurckoDecompose(const ROMol &mol) {
             nbr->setChiralTag(Atom::CHI_UNSPECIFIED);
           }
         }
-        ++nbrIdx;
       }
 
       if (removeIt) {

--- a/Code/GraphMol/Chirality.cpp
+++ b/Code/GraphMol/Chirality.cpp
@@ -757,9 +757,7 @@ const Atom *findHighestCIPNeighbor(const Atom *atom, const Atom *skipAtom) {
   const Atom *bestCipRankedAtom = nullptr;
   const auto &mol = atom->getOwningMol();
 
-  for (const auto &index :
-       boost::make_iterator_range(mol.getAtomNeighbors(atom))) {
-    const auto neighbor = mol[index];
+  for (const auto neighbor : mol.atomNeighbors(atom)) {
     if (neighbor == skipAtom) {
       continue;
     }
@@ -1884,8 +1882,8 @@ void assignStereochemistry(ROMol &mol, bool cleanIt, bool force,
     if (cleanIt) {
       // enforce no stereo on small rings
       if (((*bondIt)->getBondType() == Bond::DOUBLE ||
-           (*bondIt)->getBondType() == Bond::AROMATIC) && 
-           !shouldDetectDoubleBondStereo(*bondIt)) {
+           (*bondIt)->getBondType() == Bond::AROMATIC) &&
+          !shouldDetectDoubleBondStereo(*bondIt)) {
         if ((*bondIt)->getBondDir() == Bond::EITHERDOUBLE) {
           (*bondIt)->setBondDir(Bond::NONE);
         }

--- a/Code/GraphMol/Depictor/DepictUtils.cpp
+++ b/Code/GraphMol/Depictor/DepictUtils.cpp
@@ -364,16 +364,11 @@ void getNbrAtomAndBondIds(unsigned int aid, const RDKit::ROMol *mol,
   unsigned int na = mol->getNumAtoms();
   URANGE_CHECK(aid, na);
 
-  RDKit::ROMol::ADJ_ITER nbrIdx, endNbrs;
-  boost::tie(nbrIdx, endNbrs) = mol->getAtomNeighbors(mol->getAtomWithIdx(aid));
-
-  unsigned int ai, bi;
-  while (nbrIdx != endNbrs) {
-    ai = (*nbrIdx);
-    bi = mol->getBondBetweenAtoms(aid, ai)->getIdx();
+  for (auto ai : boost::make_iterator_range(
+           mol->getAtomNeighbors(mol->getAtomWithIdx(aid)))) {
+    auto bi = mol->getBondBetweenAtoms(aid, ai)->getIdx();
     aids.push_back(ai);
     bids.push_back(bi);
-    nbrIdx++;
   }
 }
 

--- a/Code/GraphMol/DistGeomHelpers/BoundsMatrixBuilder.cpp
+++ b/Code/GraphMol/DistGeomHelpers/BoundsMatrixBuilder.cpp
@@ -868,14 +868,13 @@ bool _checkMacrocycleAllInSameRingAmideEster14(const ROMol &mol, const Bond *,
 
   if (a3Num != 6) return false;
 
-  ROMol::ADJ_ITER nbrIdx, endNbrs;
   if (a2Num == 7 || a2Num == 8) {
     if (mol.getAtomDegree(atm2) == 3 && mol.getAtomDegree(atm3) == 3) {
-      boost::tie(nbrIdx, endNbrs) = mol.getAtomNeighbors(atm2);
-      while (nbrIdx != endNbrs) {
-        if (*nbrIdx != atm1->getIdx() && *nbrIdx != atm3->getIdx()) {
-          const auto &res = mol.getAtomWithIdx(*nbrIdx);
-          const auto &resbnd = mol.getBondBetweenAtoms(atm2->getIdx(), *nbrIdx);
+      for (auto nbrIdx :
+           boost::make_iterator_range(mol.getAtomNeighbors(atm2))) {
+        if (nbrIdx != atm1->getIdx() && nbrIdx != atm3->getIdx()) {
+          const auto &res = mol.getAtomWithIdx(nbrIdx);
+          const auto &resbnd = mol.getBondBetweenAtoms(atm2->getIdx(), nbrIdx);
           if ((res->getAtomicNum() != 6 &&
                res->getAtomicNum() != 1) ||  // check is (methylated)amide
               resbnd->getBondType() != Bond::SINGLE) {
@@ -883,21 +882,19 @@ bool _checkMacrocycleAllInSameRingAmideEster14(const ROMol &mol, const Bond *,
           }
           break;
         }
-        ++nbrIdx;
       }
 
-      boost::tie(nbrIdx, endNbrs) = mol.getAtomNeighbors(atm3);
-      while (nbrIdx != endNbrs) {
-        if (*nbrIdx != atm2->getIdx() && *nbrIdx != atm4->getIdx()) {
-          const auto &res = mol.getAtomWithIdx(*nbrIdx);
-          const auto &resbnd = mol.getBondBetweenAtoms(atm3->getIdx(), *nbrIdx);
+      for (auto nbrIdx :
+           boost::make_iterator_range(mol.getAtomNeighbors(atm3))) {
+        if (nbrIdx != atm2->getIdx() && nbrIdx != atm4->getIdx()) {
+          const auto &res = mol.getAtomWithIdx(nbrIdx);
+          const auto &resbnd = mol.getBondBetweenAtoms(atm3->getIdx(), nbrIdx);
           if (res->getAtomicNum() != 8 ||  // check for the carbonyl oxygen
               resbnd->getBondType() != Bond::DOUBLE) {
             return false;
           }
           break;
         }
-        ++nbrIdx;
       }
 
       return true;
@@ -909,16 +906,13 @@ bool _checkMacrocycleAllInSameRingAmideEster14(const ROMol &mol, const Bond *,
 bool _isCarbonyl(const ROMol &mol, const Atom *at) {
   PRECONDITION(at, "bad atom");
   if (at->getAtomicNum() == 6 && at->getDegree() > 2) {
-    ROMol::ADJ_ITER nbrIdx, endNbrs;
-    boost::tie(nbrIdx, endNbrs) = mol.getAtomNeighbors(at);
-    while (nbrIdx != endNbrs) {
-      unsigned int atNum = mol.getAtomWithIdx(*nbrIdx)->getAtomicNum();
+    for (const auto nbr : mol.atomNeighbors(at)) {
+      unsigned int atNum = nbr->getAtomicNum();
       if ((atNum == 8 || atNum == 7) &&
-          mol.getBondBetweenAtoms(at->getIdx(), *nbrIdx)->getBondType() ==
+          mol.getBondBetweenAtoms(at->getIdx(), nbr->getIdx())->getBondType() ==
               Bond::DOUBLE) {
         return true;
       }
-      ++nbrIdx;
     }
   }
   return false;

--- a/Code/GraphMol/FindRings.cpp
+++ b/Code/GraphMol/FindRings.cpp
@@ -1239,10 +1239,7 @@ void _DFS(const ROMol &mol, const Atom *atom, INT_VECT &atomColors,
   atomColors[atom->getIdx()] = 1;
   traversalOrder.push_back(atom);
 
-  ROMol::ADJ_ITER nbrIter, endNbrs;
-  boost::tie(nbrIter, endNbrs) = mol.getAtomNeighbors(atom);
-  while (nbrIter != endNbrs) {
-    const Atom *nbr = mol[*nbrIter];
+  for (const auto nbr : mol.atomNeighbors(atom)) {
     unsigned int nbrIdx = nbr->getIdx();
     // std::cerr<<"   "<<atom->getIdx()<<"       consider: "<<nbrIdx<<"
     // "<<atomColors[nbrIdx]<<std::endl;
@@ -1270,7 +1267,6 @@ void _DFS(const ROMol &mol, const Atom *atom, INT_VECT &atomColors,
         // std::cerr<<std::endl;
       }
     }
-    ++nbrIter;
   }
   atomColors[atom->getIdx()] = 2;
   traversalOrder.pop_back();

--- a/Code/GraphMol/MolOps.cpp
+++ b/Code/GraphMol/MolOps.cpp
@@ -74,31 +74,26 @@ void nitrogenCleanup(RWMol &mol, Atom *atom) {
   // the sanitization process):
   if (atom->calcExplicitValence(false) == 5) {
     unsigned int aid = atom->getIdx();
-    RWMol::ADJ_ITER nid1, end1;
-    boost::tie(nid1, end1) = mol.getAtomNeighbors(atom);
-    while (nid1 != end1) {
-      if ((mol.getAtomWithIdx(*nid1)->getAtomicNum() == 8) &&
-          (mol.getAtomWithIdx(*nid1)->getFormalCharge() == 0) &&
-          (mol.getBondBetweenAtoms(aid, *nid1)->getBondType() ==
+    for (const auto nbr : mol.atomNeighbors(atom)) {
+      if ((nbr->getAtomicNum() == 8) && (nbr->getFormalCharge() == 0) &&
+          (mol.getBondBetweenAtoms(aid, nbr->getIdx())->getBondType() ==
            Bond::DOUBLE)) {
         // here's the double bonded oxygen
-        Bond *b = mol.getBondBetweenAtoms(aid, *nid1);
+        auto b = mol.getBondBetweenAtoms(aid, nbr->getIdx());
         b->setBondType(Bond::SINGLE);
         atom->setFormalCharge(1);
-        mol.getAtomWithIdx(*nid1)->setFormalCharge(-1);
+        nbr->setFormalCharge(-1);
         break;
-      } else if ((mol.getAtomWithIdx(*nid1)->getAtomicNum() == 7) &&
-                 (mol.getAtomWithIdx(*nid1)->getFormalCharge() == 0) &&
-                 (mol.getBondBetweenAtoms(aid, *nid1)->getBondType() ==
+      } else if ((nbr->getAtomicNum() == 7) && (nbr->getFormalCharge() == 0) &&
+                 (mol.getBondBetweenAtoms(aid, nbr->getIdx())->getBondType() ==
                   Bond::TRIPLE)) {
         // here's the triple bonded nitrogen
-        Bond *b = mol.getBondBetweenAtoms(aid, *nid1);
+        auto b = mol.getBondBetweenAtoms(aid, nbr->getIdx());
         b->setBondType(Bond::DOUBLE);
         atom->setFormalCharge(1);
-        mol.getAtomWithIdx(*nid1)->setFormalCharge(-1);
+        nbr->setFormalCharge(-1);
         break;
       }
-      ++nid1;
     }  // end of loop over the first neigh
   }    // if this atom is 5 coordinate nitrogen
   // force a recalculation of the explicit valence here
@@ -127,24 +122,19 @@ void phosphorusCleanup(RWMol &mol, Atom *atom) {
     Bond *dbl_to_O = nullptr;
     Atom *O_atom = nullptr;
     bool hasDoubleToCorN = false;
-    RWMol::ADJ_ITER nid1, end1;
-    boost::tie(nid1, end1) = mol.getAtomNeighbors(atom);
-    while (nid1 != end1) {
-      if ((mol.getAtomWithIdx(*nid1)->getAtomicNum() == 8) &&
-          (mol.getAtomWithIdx(*nid1)->getFormalCharge() == 0) &&
-          (mol.getBondBetweenAtoms(aid, *nid1)->getBondType() ==
+    for (const auto nbr : mol.atomNeighbors(atom)) {
+      if ((nbr->getAtomicNum() == 8) && (nbr->getFormalCharge() == 0) &&
+          (mol.getBondBetweenAtoms(aid, nbr->getIdx())->getBondType() ==
            Bond::DOUBLE)) {
         // here's the double bonded oxygen
-        dbl_to_O = mol.getBondBetweenAtoms(aid, *nid1);
-        O_atom = mol.getAtomWithIdx(*nid1);
-      } else if ((mol.getAtomWithIdx(*nid1)->getAtomicNum() == 6 ||
-                  mol.getAtomWithIdx(*nid1)->getAtomicNum() == 7) &&
-                 (mol.getAtomWithIdx(*nid1)->getDegree() >= 2) &&
-                 (mol.getBondBetweenAtoms(aid, *nid1)->getBondType() ==
+        dbl_to_O = mol.getBondBetweenAtoms(aid, nbr->getIdx());
+        O_atom = nbr;
+      } else if ((nbr->getAtomicNum() == 6 || nbr->getAtomicNum() == 7) &&
+                 (nbr->getDegree() >= 2) &&
+                 (mol.getBondBetweenAtoms(aid, nbr->getIdx())->getBondType() ==
                   Bond::DOUBLE)) {
         hasDoubleToCorN = true;
       }
-      ++nid1;
     }  // end of loop over the first neigh
     if (hasDoubleToCorN && dbl_to_O != nullptr) {
       TEST_ASSERT(O_atom != nullptr);
@@ -165,30 +155,23 @@ void halogenCleanup(RWMol &mol, Atom *atom) {
   //    X(=O)O -> [X+]([O-])O
   int ev = atom->calcExplicitValence(false);
   if (atom->getFormalCharge() == 0 && (ev == 7 || ev == 5 || ev == 3)) {
-    unsigned int aid = atom->getIdx();
     bool neighborsAllO = true;
-    RWMol::ADJ_ITER nid1, end1;
-    boost::tie(nid1, end1) = mol.getAtomNeighbors(atom);
-    while (nid1 != end1) {
-      if (mol.getAtomWithIdx(*nid1)->getAtomicNum() != 8) {
+    for (const auto nbr : mol.atomNeighbors(atom)) {
+      if (nbr->getAtomicNum() != 8) {
         neighborsAllO = false;
         break;
       }
-      ++nid1;
     }
     if (neighborsAllO) {
       int formalCharge = 0;
-      boost::tie(nid1, end1) = mol.getAtomNeighbors(atom);
-      while (nid1 != end1) {
-        Bond *b = mol.getBondBetweenAtoms(aid, *nid1);
-        if (b->getBondType() == Bond::DOUBLE) {
-          b->setBondType(Bond::SINGLE);
-          Atom *otherAtom = mol.getAtomWithIdx(*nid1);
+      for (auto bond : mol.atomBonds(atom)) {
+        if (bond->getBondType() == Bond::DOUBLE) {
+          bond->setBondType(Bond::SINGLE);
+          auto otherAtom = bond->getOtherAtom(atom);
           formalCharge++;
           otherAtom->setFormalCharge(-1);
           otherAtom->calcExplicitValence(false);
         }
-        ++nid1;
       }
       atom->setFormalCharge(formalCharge);
       atom->calcExplicitValence(false);
@@ -490,13 +473,11 @@ std::vector<ROMOL_SPTR> getMolFrags(const ROMol &mol, bool sanitizeFrags,
       }
       // loop over neighbors and add bonds in the fragment to all atoms
       // that are already in the same fragment
-      ROMol::ADJ_ITER nbrIdx, endNbrs;
-      boost::tie(nbrIdx, endNbrs) = mol.getAtomNeighbors(oAtm);
-      while (nbrIdx != endNbrs) {
-        if (copiedAtoms[*nbrIdx]) {
-          copiedBonds[mol.getBondBetweenAtoms(idx, *nbrIdx)->getIdx()] = 1;
+      for (const auto nbr : mol.atomNeighbors(oAtm)) {
+        if (copiedAtoms[nbr->getIdx()]) {
+          copiedBonds[mol.getBondBetweenAtoms(idx, nbr->getIdx())->getIdx()] =
+              1;
         }
-        ++nbrIdx;
       }
     }
     // update ring stereochemistry information

--- a/Code/GraphMol/ROMol.h
+++ b/Code/GraphMol/ROMol.h
@@ -103,17 +103,17 @@ RDKIT_GRAPHMOL_EXPORT extern const int ci_ATOM_HOLDER;
 
 //! \name C++11 Iterators
 
-template <class Graph, class Vertex>
+template <class Graph, class Vertex, class Iterator>
 struct CXXAtomIterator {
   Graph *graph;
-  typename Graph::vertex_iterator vstart, vend;
+  Iterator vstart, vend;
 
   struct CXXAtomIter {
     Graph *graph;
-    typename Graph::vertex_iterator pos;
+    Iterator pos;
     Atom *current;
 
-    CXXAtomIter(Graph *graph, typename Graph::vertex_iterator pos)
+    CXXAtomIter(Graph *graph, Iterator pos)
         : graph(graph), pos(pos), current(nullptr) {}
 
     Vertex &operator*() {
@@ -132,21 +132,23 @@ struct CXXAtomIterator {
     vstart = vs.first;
     vend = vs.second;
   }
+  CXXAtomIterator(Graph *graph, Iterator start, Iterator end)
+      : graph(graph), vstart(start), vend(end){};
   CXXAtomIter begin() { return {graph, vstart}; }
   CXXAtomIter end() { return {graph, vend}; }
 };
 
-template <class Graph, class Edge>
+template <class Graph, class Edge, class Iterator>
 struct CXXBondIterator {
   Graph *graph;
-  typename Graph::edge_iterator vstart, vend;
+  Iterator vstart, vend;
 
   struct CXXBondIter {
     Graph *graph;
-    typename Graph::edge_iterator pos;
+    Iterator pos;
     Bond *current;
 
-    CXXBondIter(Graph *graph, typename Graph::edge_iterator pos)
+    CXXBondIter(Graph *graph, Iterator pos)
         : graph(graph), pos(pos), current(nullptr) {}
 
     Edge &operator*() {
@@ -165,6 +167,8 @@ struct CXXBondIterator {
     vstart = vs.first;
     vend = vs.second;
   }
+  CXXBondIterator(Graph *graph, Iterator start, Iterator end)
+      : graph(graph), vstart(start), vend(end){};
   CXXBondIter begin() { return {graph, vstart}; }
   CXXBondIter end() { return {graph, vend}; }
 };
@@ -247,10 +251,37 @@ class RDKIT_GRAPHMOL_EXPORT ROMol : public RDProps {
     \endcode
    */
 
-  CXXAtomIterator<MolGraph, Atom *> atoms() { return {&d_graph}; }
-
-  CXXAtomIterator<const MolGraph, Atom *const> atoms() const {
+  CXXAtomIterator<MolGraph, Atom *, MolGraph::vertex_iterator> atoms() {
     return {&d_graph};
+  }
+
+  CXXAtomIterator<const MolGraph, Atom *const, MolGraph::vertex_iterator>
+  atoms() const {
+    return {&d_graph};
+  }
+
+  CXXAtomIterator<const MolGraph, Atom *const, MolGraph::adjacency_iterator>
+  atomNeighbors(Atom const *at) const {
+    auto pr = getAtomNeighbors(at);
+    return {&d_graph, pr.first, pr.second};
+  }
+
+  CXXAtomIterator<MolGraph, Atom *, MolGraph::adjacency_iterator> atomNeighbors(
+      Atom const *at) {
+    auto pr = getAtomNeighbors(at);
+    return {&d_graph, pr.first, pr.second};
+  }
+
+  CXXBondIterator<const MolGraph, Bond *const, MolGraph::out_edge_iterator>
+  atomBonds(Atom const *at) const {
+    auto pr = getAtomBonds(at);
+    return {&d_graph, pr.first, pr.second};
+  }
+
+  CXXBondIterator<MolGraph, Bond *, MolGraph::out_edge_iterator> atomBonds(
+      Atom const *at) {
+    auto pr = getAtomBonds(at);
+    return {&d_graph, pr.first, pr.second};
   }
 
   /*!
@@ -262,9 +293,12 @@ class RDKIT_GRAPHMOL_EXPORT ROMol : public RDProps {
   \endcode
  */
 
-  CXXBondIterator<MolGraph, Bond *> bonds() { return {&d_graph}; }
+  CXXBondIterator<MolGraph, Bond *, MolGraph::edge_iterator> bonds() {
+    return {&d_graph};
+  }
 
-  CXXBondIterator<const MolGraph, Bond *const> bonds() const {
+  CXXBondIterator<const MolGraph, Bond *const, MolGraph::edge_iterator> bonds()
+      const {
     return {&d_graph};
   }
 

--- a/Code/GraphMol/ROMol.h
+++ b/Code/GraphMol/ROMol.h
@@ -103,7 +103,8 @@ RDKIT_GRAPHMOL_EXPORT extern const int ci_ATOM_HOLDER;
 
 //! \name C++11 Iterators
 
-template <class Graph, class Vertex, class Iterator>
+template <class Graph, class Vertex,
+          class Iterator = typename Graph::vertex_iterator>
 struct CXXAtomIterator {
   Graph *graph;
   Iterator vstart, vend;
@@ -138,7 +139,8 @@ struct CXXAtomIterator {
   CXXAtomIter end() { return {graph, vend}; }
 };
 
-template <class Graph, class Edge, class Iterator>
+template <class Graph, class Edge,
+          class Iterator = typename Graph::edge_iterator>
 struct CXXBondIterator {
   Graph *graph;
   Iterator vstart, vend;
@@ -251,12 +253,9 @@ class RDKIT_GRAPHMOL_EXPORT ROMol : public RDProps {
     \endcode
    */
 
-  CXXAtomIterator<MolGraph, Atom *, MolGraph::vertex_iterator> atoms() {
-    return {&d_graph};
-  }
+  CXXAtomIterator<MolGraph, Atom *> atoms() { return {&d_graph}; }
 
-  CXXAtomIterator<const MolGraph, Atom *const, MolGraph::vertex_iterator>
-  atoms() const {
+  CXXAtomIterator<const MolGraph, Atom *const> atoms() const {
     return {&d_graph};
   }
 
@@ -293,12 +292,9 @@ class RDKIT_GRAPHMOL_EXPORT ROMol : public RDProps {
   \endcode
  */
 
-  CXXBondIterator<MolGraph, Bond *, MolGraph::edge_iterator> bonds() {
-    return {&d_graph};
-  }
+  CXXBondIterator<MolGraph, Bond *> bonds() { return {&d_graph}; }
 
-  CXXBondIterator<const MolGraph, Bond *const, MolGraph::edge_iterator> bonds()
-      const {
+  CXXBondIterator<const MolGraph, Bond *const> bonds() const {
     return {&d_graph};
   }
 

--- a/Code/GraphMol/Resonance.cpp
+++ b/Code/GraphMol/Resonance.cpp
@@ -1580,7 +1580,7 @@ void ResonanceMolSupplier::buildCEMap(CEMap &ceMap, unsigned int conjGrpIdx) {
       boost::tie(nbrIdx, endNbrs) =
           d_mol->getAtomNeighbors(ae[BEGIN_POS]->atom());
       for (; nbrIdx != endNbrs; ++nbrIdx) {
-        unsigned int aiNbr = (*d_mol)[*nbrIdx]->getIdx();
+        unsigned int aiNbr = *nbrIdx;
         // if this neighbor is not part of the conjugated group,
         // ignore it
         if (ce->parent()->getAtomConjGrpIdx(aiNbr) !=

--- a/Code/GraphMol/Wrap/Atom.cpp
+++ b/Code/GraphMol/Wrap/Atom.cpp
@@ -62,25 +62,16 @@ void AtomClearProp(const Atom *atom, const char *key) {
 
 python::tuple AtomGetNeighbors(Atom *atom) {
   python::list res;
-  const ROMol *parent = &atom->getOwningMol();
-  ROMol::ADJ_ITER begin, end;
-  boost::tie(begin, end) = parent->getAtomNeighbors(atom);
-  while (begin != end) {
-    res.append(python::ptr(parent->getAtomWithIdx(*begin)));
-    begin++;
+  for (auto nbr : atom->getOwningMol().atomNeighbors(atom)) {
+    res.append(python::ptr(nbr));
   }
   return python::tuple(res);
 }
 
 python::tuple AtomGetBonds(Atom *atom) {
   python::list res;
-  const ROMol *parent = &atom->getOwningMol();
-  ROMol::OEDGE_ITER begin, end;
-  boost::tie(begin, end) = parent->getAtomBonds(atom);
-  while (begin != end) {
-    const Bond *tmpB = (*parent)[*begin];
-    res.append(python::ptr(tmpB));
-    begin++;
+  for (auto bond : atom->getOwningMol().atomBonds(atom)) {
+    res.append(python::ptr(bond));
   }
   return python::tuple(res);
 }

--- a/Code/GraphMol/catch_moliterators.cpp
+++ b/Code/GraphMol/catch_moliterators.cpp
@@ -1,0 +1,60 @@
+//
+//  Copyright (C) 2021 Greg Landrum and other RDKit contributors
+//
+//   @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
+//
+
+#include "catch.hpp"
+
+#include <GraphMol/RDKitBase.h>
+#include <GraphMol/SmilesParse/SmilesParse.h>
+#include <GraphMol/SmilesParse/SmilesWrite.h>
+#include <algorithm>
+
+using namespace RDKit;
+
+TEST_CASE("mol.atoms()") {
+  const auto m = "CC(C)CO"_smiles;
+  REQUIRE(m);
+  unsigned int ccount = 0;
+  for (const auto atom : m->atoms()) {
+    if (atom->getAtomicNum() == 6) {
+      ++ccount;
+    }
+  }
+  CHECK(ccount == 4);
+}
+
+TEST_CASE("mol.atomNeighbors()") {
+  const auto m = "CC(C)CO"_smiles;
+  REQUIRE(m);
+  unsigned int count = 0;
+  for (const auto atom : m->atomNeighbors(m->getAtomWithIdx(1))) {
+    count += atom->getDegree();
+  }
+  CHECK(count == 4);
+  for (auto atom : m->atomNeighbors(m->getAtomWithIdx(1))) {
+    atom->setAtomicNum(7);
+  }
+  MolOps::sanitizeMol(*m);
+  CHECK(MolToSmiles(*m) == "NC(N)NO");
+}
+
+TEST_CASE("mol.atomBonds()") {
+  const auto m = "CC(=C)CO"_smiles;
+  REQUIRE(m);
+  double count = 0;
+  for (const auto bond : m->atomBonds(m->getAtomWithIdx(1))) {
+    count += bond->getBondTypeAsDouble();
+  }
+  CHECK(count == 4);
+  for (auto bond : m->atomBonds(m->getAtomWithIdx(1))) {
+    bond->setBondType(Bond::BondType::SINGLE);
+  }
+  MolOps::sanitizeMol(*m);
+  CHECK(MolToSmiles(*m) == "CC(C)CO");
+}

--- a/Code/GraphMol/new_canon.cpp
+++ b/Code/GraphMol/new_canon.cpp
@@ -309,11 +309,7 @@ void rankWithFunctor(T &ftor, bool breakTies, int *order,
 namespace {
 bool hasRingNbr(const ROMol &mol, const Atom *at) {
   PRECONDITION(at, "bad pointer");
-  ROMol::ADJ_ITER beg, end;
-  boost::tie(beg, end) = mol.getAtomNeighbors(at);
-  while (beg != end) {
-    const Atom *nbr = mol[*beg];
-    ++beg;
+  for (const auto nbr : mol.atomNeighbors(at)) {
     if ((nbr->getChiralTag() == Atom::CHI_TETRAHEDRAL_CW ||
          nbr->getChiralTag() == Atom::CHI_TETRAHEDRAL_CCW) &&
         nbr->hasProp(common_properties::_ringStereoAtoms)) {
@@ -326,16 +322,11 @@ bool hasRingNbr(const ROMol &mol, const Atom *at) {
 void getNbrs(const ROMol &mol, const Atom *at, int *ids) {
   PRECONDITION(at, "bad pointer");
   PRECONDITION(ids, "bad pointer");
-  ROMol::OEDGE_ITER beg, end;
-  boost::tie(beg, end) = mol.getAtomBonds(at);
+  ROMol::ADJ_ITER beg, end;
+  boost::tie(beg, end) = mol.getAtomNeighbors(at);
   unsigned int idx = 0;
-
   while (beg != end) {
-    const Bond *bond = (mol)[*beg];
-    ++beg;
-    unsigned int nbrIdx = bond->getOtherAtomIdx(at->getIdx());
-    ids[idx] = nbrIdx;
-    ++idx;
+    ids[idx++] = static_cast<int>(*beg++);
   }
 }
 

--- a/Code/JavaWrappers/ROMol.i
+++ b/Code/JavaWrappers/ROMol.i
@@ -1,7 +1,7 @@
 /*
-* $Id$
 *
-*  Copyright (c) 2010, Novartis Institutes for BioMedical Research Inc.
+*  Copyright (c) 2010-2021, Novartis Institutes for BioMedical Research Inc.
+*   and other RDKit contributors
 *  All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without
@@ -16,7 +16,8 @@
 *       with the distribution.
 *     * Neither the name of Novartis Institutes for BioMedical Research Inc.
 *       nor the names of its contributors may be used to endorse or promote
-*       products derived from this software without specific prior written permission.
+*       products derived from this software without specific prior written
+        permission.
 *
 * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
@@ -69,6 +70,13 @@
 %template(ROMol_Vect_Vect) std::vector< std::vector< boost::shared_ptr<RDKit::ROMol> > >;
 %template(Atom_Vect) std::vector<RDKit::Atom*>;
 %template(StereoGroup_Vect) std::vector<RDKit::StereoGroup>;
+// %template(CXXAtomIter_V) RDKit::CXXAtomIterator<RDKit::MolGraph,RDKit::Atom *,MolGraph::vertex_iterator>;
+// %template(CXXAtomIter_Vconst) RDKit::CXXAtomIterator<const RDKit::MolGraph,RDKit::Atom const*,MolGraph::vertex_iterator>;
+// %template(CXXAtomIter_A) RDKit::CXXAtomIterator<RDKit::MolGraph,RDKit::Atom *,MolGraph::adjacency_iterator>;
+// %template(CXXAtomIter_Aconst) RDKit::CXXAtomIterator<const RDKit::MolGraph,RDKit::Atom const*,MolGraph::adjacency_iterator>;
+// %template(CXXBondIter_E) RDKit::CXXBondIterator<RDKit::MolGraph,RDKit::Bond *,MolGraph::out_edge_iterator>;
+// %template(CXXBondIter_Econst) RDKit::CXXBondIterator<const RDKit::MolGraph,RDKit::Bond *const,MolGraph::out_edge_iterator>;
+
 
 // These prevent duplicate definitions in Java code
 %ignore RDKit::ROMol::hasProp(std::string const) const ;
@@ -78,6 +86,15 @@
 %ignore RDKit::ROMol::getBondBetweenAtoms(unsigned int,unsigned int) const ;
 %ignore RDKit::ROMol::getAtomNeighbors(Atom const *at) const;
 %ignore RDKit::ROMol::getAtomBonds(Atom const *at) const;
+%ignore RDKit::ROMol::atomNeighbors(Atom const *at) const;
+%ignore RDKit::ROMol::atomBonds(Atom const *at) const;
+%ignore RDKit::ROMol::atomNeighbors(Atom const *at);
+%ignore RDKit::ROMol::atomBonds(Atom const *at);
+%ignore RDKit::ROMol::atoms();
+%ignore RDKit::ROMol::atoms() const;
+%ignore RDKit::ROMol::bonds();
+%ignore RDKit::ROMol::bonds() const;
+
 %ignore RDKit::ROMol::getVertices() ;
 %ignore RDKit::ROMol::getVertices() const ;
 %ignore RDKit::ROMol::getEdges() ;

--- a/Code/JavaWrappers/ROMol.i
+++ b/Code/JavaWrappers/ROMol.i
@@ -70,13 +70,6 @@
 %template(ROMol_Vect_Vect) std::vector< std::vector< boost::shared_ptr<RDKit::ROMol> > >;
 %template(Atom_Vect) std::vector<RDKit::Atom*>;
 %template(StereoGroup_Vect) std::vector<RDKit::StereoGroup>;
-// %template(CXXAtomIter_V) RDKit::CXXAtomIterator<RDKit::MolGraph,RDKit::Atom *,MolGraph::vertex_iterator>;
-// %template(CXXAtomIter_Vconst) RDKit::CXXAtomIterator<const RDKit::MolGraph,RDKit::Atom const*,MolGraph::vertex_iterator>;
-// %template(CXXAtomIter_A) RDKit::CXXAtomIterator<RDKit::MolGraph,RDKit::Atom *,MolGraph::adjacency_iterator>;
-// %template(CXXAtomIter_Aconst) RDKit::CXXAtomIterator<const RDKit::MolGraph,RDKit::Atom const*,MolGraph::adjacency_iterator>;
-// %template(CXXBondIter_E) RDKit::CXXBondIterator<RDKit::MolGraph,RDKit::Bond *,MolGraph::out_edge_iterator>;
-// %template(CXXBondIter_Econst) RDKit::CXXBondIterator<const RDKit::MolGraph,RDKit::Bond *const,MolGraph::out_edge_iterator>;
-
 
 // These prevent duplicate definitions in Java code
 %ignore RDKit::ROMol::hasProp(std::string const) const ;


### PR DESCRIPTION
The idea is to make looping over atom neighbors or bonds even simpler:
```
  for(const auto nbr : mol.atomNeighbors(atom)){
     // do something with nbr, which is a const Atom *
  }
  for(const auto bnd : mol.atomBonds(atom)){
     // do something with bnd, which is a const Bond *
  }
```

I should have done these a long time ago!

There are still times when the older style `mol.getAtomNeighbors()` and `mol.getBondNeighbors()` are useful, so those have not been removed or deprecated and will continue to show up in code.

*NOTES FOR REVIEWERS*: 
In addition to adding this new code and tests for it, I also started to translate some of the existing RDKit code to use this pattern. I wanted to do some in order to get a feeling for what using this pattern is like, but I didn't want to make the review impossible. Once this is merged I will "port" more of the existing code to this pattern in a separate PR.

While I was in there I also simplified some other places where iterators are being used in the code. This makes the review a bit more complex if you're looking at everything, but that's really not necessary. Still: sorry.

The only substantive changes here are in `ROMol.h`. The rest is really just applying the new pattern to existing code.