### PR TITLE
migrate the MHFP implementation to use boost::random

### DIFF
--- a/Code/GraphMol/Fingerprints/CMakeLists.txt
+++ b/Code/GraphMol/Fingerprints/CMakeLists.txt
@@ -1,6 +1,3 @@
-# boost::random is used in MHFP.cpp to favor the portability across
-# compiler and STL implementations
-find_package(Boost ${RDK_BOOST_VERSION} COMPONENTS random REQUIRED)
 
 rdkit_library(Fingerprints
               Fingerprints.cpp PatternFingerprints.cpp MorganFingerprints.cpp


### PR DESCRIPTION
#### Reference Issue
Fixes #4244

#### What does this implement/fix? Explain your changes.
This PR migrates the MHFP encoder implementation to use boost::random in place of the C++ standard library, to prevent portability issues across different compilers, due to the partial standardization of the distribution functions.

#### Any other comments?
At this time (maybe unsurprisingly) the boost::random behavior is similar to most compilers in use, and no changes are introduced in the computed hash values (to the extent that this is covered by the available tests).
