### PR TITLE
Fix EnumerateStereoisomers with tryEmbedding

### DIFF
--- a/rdkit/Chem/EnumerateStereoisomers.py
+++ b/rdkit/Chem/EnumerateStereoisomers.py
@@ -339,7 +339,8 @@ def EnumerateStereoisomers(m, options=StereoEnumerationOptions(), verbose=False)
 
     if options.tryEmbedding:
       ntm = Chem.AddHs(isomer)
-      cid = EmbedMolecule(ntm, randomSeed=bitflag)
+      # mask bitflag to fit within C++ int.
+      cid = EmbedMolecule(ntm, randomSeed=(bitflag & 0x7fffffff))
       if cid >= 0:
         conf = Chem.Conformer(isomer.GetNumAtoms())
         for aid in range(isomer.GetNumAtoms()):

--- a/rdkit/Chem/UnitTestMol3D.py
+++ b/rdkit/Chem/UnitTestMol3D.py
@@ -442,5 +442,11 @@ class TestCase(unittest.TestCase):
     self.assertEqual(set(smiles), {"C/C=C/C", "C/C=C\\C"})
 
 
+  def testTryEmbeddingManyChirals(self):
+    smiles = "C1" + "C(Cl)(Br)" * 40 + "C1"  
+    mol = Chem.MolFromSmiles(smiles)
+    opts = AllChem.StereoEnumerationOptions(tryEmbedding=True, maxIsomers=2)
+    self.assertEqual(len(list(AllChem.EnumerateStereoisomers(mol, options=opts))), 2)
+
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

Calling `EnumerateStereoisomers` with tryEmbedding=True raises `OverflowError` when molecular having many chiral centers. This PR fixes it.
`EmbedMolecule`'s `randomSeed` argument should be within C++ int but it can be exceeded.

#### Any other comments?

A cyclic molecule is used to test because big liner molecules tend to fail `EmbedMolecule`.
