### PR TITLE
Fix clang warning `-Wabsolute-value`

### DIFF
--- a/Code/GraphMol/FileParsers/testGeneralFileReader.cpp
+++ b/Code/GraphMol/FileParsers/testGeneralFileReader.cpp
@@ -182,7 +182,7 @@ void testMae() {
   TEST_ASSERT(nmol->hasProp("s_m_entry_name"));
   TEST_ASSERT(nmol->getProp<std::string>("s_m_entry_name") == "NCI_aids_few.1");
   TEST_ASSERT(nmol->hasProp("r_f3d_dummy"));
-  TEST_ASSERT(abs(nmol->getProp<double>("r_f3d_dummy") - 42.123) < 0.0001);
+  TEST_ASSERT(std::abs(nmol->getProp<double>("r_f3d_dummy") - 42.123) < 0.0001);
 
   //! Test atom properties
   TEST_ASSERT(nmol->getNumAtoms() == 19);
@@ -204,7 +204,7 @@ void testMae() {
     //! The real property is only defined for i >= 10
     if (i >= 10) {
       TEST_ASSERT(atom->hasProp("r_f3d_dummy"));
-      TEST_ASSERT(abs(atom->getProp<double>("r_f3d_dummy") - (19.1 - i)) <
+      TEST_ASSERT(std::abs(atom->getProp<double>("r_f3d_dummy") - (19.1 - i)) <
                   0.0001);
     } else {
       TEST_ASSERT(!atom->hasProp("r_f3d_dummy"));

--- a/External/GA/ga/LinkedPopLinearSel.h
+++ b/External/GA/ga/LinkedPopLinearSel.h
@@ -138,7 +138,7 @@ LinkedPopLinearSel<Chromosome, PopulationPolicy>::LinkedPopLinearSel(
                           << " predictTotalScaledFitness "
                           << predictTotalScaledFitness;
 #endif
-  assert(abs(totalScaledFitness - predictTotalScaledFitness) < 1.0e-5);
+  assert(std::abs(totalScaledFitness - predictTotalScaledFitness) < 1.0e-5);
 
   double predictEndFitness = SELECT_START + (popsize - 1.0) * scaledFitnessStep;
   (void)predictEndFitness;  // suppress warnings when building with
@@ -147,7 +147,7 @@ LinkedPopLinearSel<Chromosome, PopulationPolicy>::LinkedPopLinearSel(
   REPORT(Reporter::TRACE) << "endFitness " << endFitness
                           << " predictEndFitness " << predictEndFitness;
 #endif
-  assert(abs(endFitness - predictEndFitness) < 1.0e-10);
+  assert(std::abs(endFitness - predictEndFitness) < 1.0e-10);
 
   freeChromosomes.reserve(10);
 }
@@ -206,7 +206,7 @@ LinkedPopLinearSel<Chromosome, PopulationPolicy>::selectParent() {
     ++iterator;
   }
   // may get here because of numeric errors
-  assert(abs(sum - totalScaledFitness) < (0.000001 * scaledFitnessStep));
+  assert(std::abs(sum - totalScaledFitness) < (0.000001 * scaledFitnessStep));
   iterator = population.end();
   --iterator;
   return iterator->second;


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! 

#### Reference Issue
Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.
```console
$ ninja Code/GraphMol/FileParsers/CMakeFiles/testGeneralFileReader.dir/testGeneralFileReader.cpp.o
../Code/GraphMol/FileParsers/testGeneralFileReader.cpp:185:15: warning: using integer absolute value function 'abs' when argument is of floating point type [-Wabsolute-value]
  TEST_ASSERT(abs(nmol->getProp<double>("r_f3d_dummy") - 42.123) < 0.0001);
              ^
../Code/GraphMol/FileParsers/testGeneralFileReader.cpp:185:15: note: use function 'std::abs' instead
  TEST_ASSERT(abs(nmol->getProp<double>("r_f3d_dummy") - 42.123) < 0.0001);
              ^~~
              std::abs
../Code/RDGeneral/Invariant.h:153:9: note: expanded from macro 'TEST_ASSERT'
  if (!(expr)) {                                                      \
        ^
../Code/GraphMol/FileParsers/testGeneralFileReader.cpp:207:19: warning: using integer absolute value function 'abs' when argument is of floating point type [-Wabsolute-value]
      TEST_ASSERT(abs(atom->getProp<double>("r_f3d_dummy") - (19.1 - i)) <
                  ^
../Code/GraphMol/FileParsers/testGeneralFileReader.cpp:207:19: note: use function 'std::abs' instead
      TEST_ASSERT(abs(atom->getProp<double>("r_f3d_dummy") - (19.1 - i)) <
                  ^~~
                  std::abs
../Code/RDGeneral/Invariant.h:153:9: note: expanded from macro 'TEST_ASSERT'
  if (!(expr)) {                                                      \
        ^
2 warnings generated.
```

<!--
#### Any other comments?
-->
