### PR TITLE
fix parsing beyond the end of the input string in findMCSsmiles

### DIFF
--- a/Code/PgSQL/rdkit/adapter.cpp
+++ b/Code/PgSQL/rdkit/adapter.cpp
@@ -2082,20 +2082,18 @@ extern "C" char *findMCSsmiles(char *smiles, char *params) {
 
   char *str = smiles;
   char *s = str;
-  int len, nmols = 0;
+  char *s_end = str + strlen(str);
+  int len = 0;
   std::vector<RDKit::ROMOL_SPTR> molecules;
   while (*s && *s <= ' ') {
     s++;
   }
-  while (*s > ' ') {
+  while (s < s_end && *s > ' ') {
     len = 0;
     while (s[len] > ' ') {
       len++;
     }
     s[len] = '\0';
-    if (0 == strlen(s)) {
-      continue;
-    }
     ROMol *molptr = nullptr;
     try {
       molptr = RDKit::SmilesToMol(s);


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
This PR addresses an issue in how the input smiles data are processed in the implementation of `fmcs_smiles`. In `findMCSSmiles` a while loop identifies the smiles in the space-separated input, but it may continue beyond the end of the input string if characters `> ' '` follow.

This issue may cause the cartridge fmcs test to fail (apparently, in a systematic way with gcc11), and the access outside the allocated space is confirmed by valgrind.

(the changes also include the removal of an unused `nmol` variable, and of an if-block at adapter.cpp:2096 that is never executed)
