### PR TITLE
Update coordgenlibs to v3.0.0

### DIFF
--- a/External/CoordGen/CMakeLists.txt
+++ b/External/CoordGen/CMakeLists.txt
@@ -82,8 +82,8 @@ if(RDK_BUILD_COORDGEN_SUPPORT)
     endif()
 
     if(NOT EXISTS "${COORDGEN_DIR}/sketcherMinimizer.h")
-        set(RELEASE_NO "2.0.3")
-        set(MD5 "e5541909e4283c67ef4934d2ad271aa3")
+        set(RELEASE_NO "3.0.0")
+        set(MD5 "5b4c5b91e412c03438b31b4a4c871026")
         downloadAndCheckMD5("https://github.com/schrodinger/coordgenlibs/archive/v${RELEASE_NO}.tar.gz"
               "${CMAKE_CURRENT_SOURCE_DIR}/coordgenlibs-${RELEASE_NO}.tar.gz" ${MD5})
         execute_process(COMMAND ${CMAKE_COMMAND} -E tar zxf


### PR DESCRIPTION
This bumps the default coordgenlibs version that RDKit will download if sources or compiled libs aren't available and the feature is enabled.

The new version should improve the rendering for some molecules, and should also be somewhat more performant than the current one because of a new stopping condition.

For more details: https://github.com/schrodinger/coordgenlibs/releases/tag/v3.0.0
