### PR TITLE
Recursive Substructure Search Deadlock

### DIFF
--- a/Code/GraphMol/ChemReactions/Wrap/testReactionWrapper.py
+++ b/Code/GraphMol/ChemReactions/Wrap/testReactionWrapper.py
@@ -1057,23 +1057,17 @@ M  END
 
 
     product = reaction_fwd.RunReactants((mol_sulfonylchloride, mol_amine))[0][0]
-    print("reaction_fwd", Chem.MolToSmiles(product))
 
     reagent_sulfonylchloride, reagent_amine = reaction_reverse.RunReactants((mol_sulfonamide,))[0]
 
     # trigger bug
-    print("trigger bug and mess up reaction_fwd object")
-    try:
-        product = reaction_fwd.RunReactants((reagent_sulfonylchloride, reagent_amine))[0]
-    except RuntimeError as e:
-        print(e)
+    with self.assertRaises(RuntimeError):
+      reaction_fwd.RunReactants((reagent_sulfonylchloride, reagent_amine))
 
-    print("call messed up reaction_fwd, this will inf loop")
-    # this used to deadlock
-    try:
-      product = reaction_fwd.RunReactants((mol_sulfonylchloride, mol_amine))
-    except RuntimeError as e:
-      pass # this is ok
+    # The second call used to deadlock
+    with self.assertRaises(RuntimeError):
+      reaction_fwd.RunReactants((reagent_sulfonylchloride, reagent_amine))
+
 
 if __name__ == '__main__':
   unittest.main(verbosity=True)

--- a/Code/GraphMol/ChemReactions/Wrap/testReactionWrapper.py
+++ b/Code/GraphMol/ChemReactions/Wrap/testReactionWrapper.py
@@ -43,8 +43,6 @@ from rdkit import Geometry
 from rdkit import RDConfig
 from rdkit.Chem.SimpleEnum import Enumerator
 
-import signal
-
 def feq(v1, v2, tol2=1e-4):
   return abs(v1 - v2) <= tol2
 

--- a/Code/GraphMol/Substruct/SubstructMatch.cpp
+++ b/Code/GraphMol/Substruct/SubstructMatch.cpp
@@ -430,7 +430,7 @@ void ResSubstructMatchHelper_(const ResSubstructMatchHelperArgs_ &args,
 
 struct RecursiveLocker {
   std::vector<RecursiveStructureQuery *> locked;
-  RecursiveLocker(const ROMol &query, const bool recursionPossible) : locked() {
+  RecursiveLocker(const ROMol &query, const bool recursionPossible) {
     if (recursionPossible) {
       locked.reserve(query.getNumAtoms());
     }

--- a/Code/GraphMol/Substruct/SubstructMatch.cpp
+++ b/Code/GraphMol/Substruct/SubstructMatch.cpp
@@ -430,9 +430,8 @@ void ResSubstructMatchHelper_(const ResSubstructMatchHelperArgs_ &args,
 
 struct RecursiveLocker {
   std::vector<RecursiveStructureQuery *> locked;
-  RecursiveLocker(const ROMol &query, const bool recursionPossible) :
-    locked() {
-    if(recursionPossible) {
+  RecursiveLocker(const ROMol &query, const bool recursionPossible) : locked() {
+    if (recursionPossible) {
       locked.reserve(query.getNumAtoms());
     }
   }
@@ -441,7 +440,7 @@ struct RecursiveLocker {
     for (auto v : locked) {
       v->clear();
 #ifdef RDK_THREADSAFE_SSS
-      v->d_mutex.unlock();  
+      v->d_mutex.unlock();
 #endif
     }
   }
@@ -466,35 +465,35 @@ std::vector<MatchVectType> SubstructMatch(
     ROMol::ConstAtomIterator atIt;
     for (atIt = query.beginAtoms(); atIt != query.endAtoms(); atIt++) {
       if ((*atIt)->getQuery()) {
-	// std::cerr<<"recurse from atom "<<(*atIt)->getIdx()<<std::endl;
-	detail::MatchSubqueries(mol, (*atIt)->getQuery(), params, subqueryMap,
-				locker.locked);
+        // std::cerr<<"recurse from atom "<<(*atIt)->getIdx()<<std::endl;
+        detail::MatchSubqueries(mol, (*atIt)->getQuery(), params, subqueryMap,
+                                locker.locked);
       }
     }
   }
-  
+
   detail::AtomLabelFunctor atomLabeler(query, mol, params);
   detail::BondLabelFunctor bondLabeler(query, mol, params);
   MolMatchFinalCheckFunctor matchChecker(query, mol, params);
-  
+
   std::list<detail::ssPairType> pms;
 #if 0
   bool found=boost::ullmann_all(query.getTopology(),mol.getTopology(),
 				atomLabeler,bondLabeler,pms);
 #else
   bool found =
-    boost::vf2_all(query.getTopology(), mol.getTopology(), atomLabeler,
-		   bondLabeler, matchChecker, pms, params.maxMatches);
+      boost::vf2_all(query.getTopology(), mol.getTopology(), atomLabeler,
+                     bondLabeler, matchChecker, pms, params.maxMatches);
 #endif
   if (found) {
     unsigned int nQueryAtoms = query.getNumAtoms();
     matches.reserve(pms.size());
     for (std::list<detail::ssPairType>::const_iterator iter1 = pms.begin();
-	 iter1 != pms.end(); ++iter1) {
+         iter1 != pms.end(); ++iter1) {
       MatchVectType matchVect;
       matchVect.resize(nQueryAtoms);
       for (const auto &iter2 : *iter1) {
-	matchVect[iter2.first] = std::pair<int, int>(iter2.first, iter2.second);
+        matchVect[iter2.first] = std::pair<int, int>(iter2.first, iter2.second);
       }
       matches.push_back(matchVect);
     }

--- a/Code/GraphMol/Substruct/SubstructMatch.cpp
+++ b/Code/GraphMol/Substruct/SubstructMatch.cpp
@@ -427,6 +427,25 @@ void ResSubstructMatchHelper_(const ResSubstructMatchHelperArgs_ &args,
     delete mol;
   }
 };
+
+struct RecursiveLocker {
+  std::vector<RecursiveStructureQuery *> locked;
+  RecursiveLocker(const ROMol &query, const bool recursionPossible) :
+    locked() {
+    if(recursionPossible) {
+      locked.reserve(query.getNumAtoms());
+    }
+  }
+
+  ~RecursiveLocker() {
+    for (auto v : locked) {
+      v->clear();
+#ifdef RDK_THREADSAFE_SSS
+      v->d_mutex.unlock();  
+#endif
+    }
+  }
+};
 }  // namespace detail
 
 // ----------------------------------------------
@@ -439,71 +458,48 @@ std::vector<MatchVectType> SubstructMatch(
   if (!mol.getNumAtoms() || !query.getNumAtoms()) {
     return matches;
   }
-  std::vector<RecursiveStructureQuery *> locked;
-  locked.reserve(query.getNumAtoms());
 
-  try {
-    if (params.recursionPossible) {
-      detail::SUBQUERY_MAP subqueryMap;
-      ROMol::ConstAtomIterator atIt;
-      for (atIt = query.beginAtoms(); atIt != query.endAtoms(); atIt++) {
-	if ((*atIt)->getQuery()) {
-	  // std::cerr<<"recurse from atom "<<(*atIt)->getIdx()<<std::endl;
-	  detail::MatchSubqueries(mol, (*atIt)->getQuery(), params, subqueryMap,
-				  locked);
-	}
+  detail::RecursiveLocker locker(query, params.recursionPossible);
+
+  if (params.recursionPossible) {
+    detail::SUBQUERY_MAP subqueryMap;
+    ROMol::ConstAtomIterator atIt;
+    for (atIt = query.beginAtoms(); atIt != query.endAtoms(); atIt++) {
+      if ((*atIt)->getQuery()) {
+	// std::cerr<<"recurse from atom "<<(*atIt)->getIdx()<<std::endl;
+	detail::MatchSubqueries(mol, (*atIt)->getQuery(), params, subqueryMap,
+				locker.locked);
       }
     }
-
-    detail::AtomLabelFunctor atomLabeler(query, mol, params);
-    detail::BondLabelFunctor bondLabeler(query, mol, params);
-    MolMatchFinalCheckFunctor matchChecker(query, mol, params);
-
-    std::list<detail::ssPairType> pms;
-#if 0
-    bool found=boost::ullmann_all(query.getTopology(),mol.getTopology(),
-                                  atomLabeler,bondLabeler,pms);
-#else
-    bool found =
-      boost::vf2_all(query.getTopology(), mol.getTopology(), atomLabeler,
-                     bondLabeler, matchChecker, pms, params.maxMatches);
-#endif
-    if (found) {
-      unsigned int nQueryAtoms = query.getNumAtoms();
-      matches.reserve(pms.size());
-      for (std::list<detail::ssPairType>::const_iterator iter1 = pms.begin();
-	   iter1 != pms.end(); ++iter1) {
-	MatchVectType matchVect;
-	matchVect.resize(nQueryAtoms);
-	for (const auto &iter2 : *iter1) {
-	  matchVect[iter2.first] = std::pair<int, int>(iter2.first, iter2.second);
-	}
-	matches.push_back(matchVect);
-      }
-      if (params.uniquify) {
-	removeDuplicates(matches, mol.getNumAtoms());
-      }
-    }
-  } catch (...) {
-    // In case of internal exception, this can happen for various reasons
-    //  no rings, implicitValenceError etc we need to release all locks
-    if (params.recursionPossible) {
-      for (auto v : locked) {
-	v->clear();
-#ifdef RDK_THREADSAFE_SSS
-	v->d_mutex.unlock();
-#endif
-      }
-    }
-    throw;
   }
   
-  if (params.recursionPossible) {
-    for (auto v : locked) {
-      v->clear();
-#ifdef RDK_THREADSAFE_SSS
-      v->d_mutex.unlock();
+  detail::AtomLabelFunctor atomLabeler(query, mol, params);
+  detail::BondLabelFunctor bondLabeler(query, mol, params);
+  MolMatchFinalCheckFunctor matchChecker(query, mol, params);
+  
+  std::list<detail::ssPairType> pms;
+#if 0
+  bool found=boost::ullmann_all(query.getTopology(),mol.getTopology(),
+				atomLabeler,bondLabeler,pms);
+#else
+  bool found =
+    boost::vf2_all(query.getTopology(), mol.getTopology(), atomLabeler,
+		   bondLabeler, matchChecker, pms, params.maxMatches);
 #endif
+  if (found) {
+    unsigned int nQueryAtoms = query.getNumAtoms();
+    matches.reserve(pms.size());
+    for (std::list<detail::ssPairType>::const_iterator iter1 = pms.begin();
+	 iter1 != pms.end(); ++iter1) {
+      MatchVectType matchVect;
+      matchVect.resize(nQueryAtoms);
+      for (const auto &iter2 : *iter1) {
+	matchVect[iter2.first] = std::pair<int, int>(iter2.first, iter2.second);
+      }
+      matches.push_back(matchVect);
+    }
+    if (params.uniquify) {
+      removeDuplicates(matches, mol.getNumAtoms());
     }
   }
   return matches;


### PR DESCRIPTION
Fixes #4651 

This is a simple fix to a nasty issue.   If an exception is thrown in the recursive bowels of a substructure search, the mutexes are not cleared.  This creates a deadlock on the second call.