### PR TITLE
Fix some compile-time warnings in the postgres cartridge code

### DIFF
--- a/Code/PgSQL/rdkit/adapter.cpp
+++ b/Code/PgSQL/rdkit/adapter.cpp
@@ -1069,8 +1069,8 @@ extern "C" double calcSparseDiceSml(CSfp a, CSfp b) {
   return res;
 }
 
-extern "C" double calcSparseStringDiceSml(const char *a, unsigned int sza,
-                                          const char *b, unsigned int szb) {
+extern "C" double calcSparseStringDiceSml(const char *a, unsigned int,
+                                          const char *b, unsigned int) {
   const auto *t1 = (const unsigned char *)a;
   const auto *t2 = (const unsigned char *)b;
 
@@ -1182,7 +1182,7 @@ extern "C" double calcSparseStringDiceSml(const char *a, unsigned int sza,
   return res;
 }
 
-extern "C" bool calcSparseStringAllValsGT(const char *a, unsigned int sza,
+extern "C" bool calcSparseStringAllValsGT(const char *a, unsigned int,
                                           int tgt) {
   const auto *t1 = (const unsigned char *)a;
 
@@ -1222,7 +1222,7 @@ extern "C" bool calcSparseStringAllValsGT(const char *a, unsigned int sza,
   }
   return true;
 }
-extern "C" bool calcSparseStringAllValsLT(const char *a, unsigned int sza,
+extern "C" bool calcSparseStringAllValsLT(const char *a, unsigned int,
                                           int tgt) {
   const auto *t1 = (const unsigned char *)a;
 
@@ -1975,7 +1975,6 @@ extern "C" CSfp makeReactionDifferenceSFP(CChemicalReaction data, int size,
     if (fpType > 3 || fpType < 1) {
       elog(ERROR, "makeReactionDifferenceSFP: Unknown Fingerprint type");
     }
-    auto fp = static_cast<RDKit::FingerprintType>(fpType);
     RDKit::ReactionFingerprintParams params;
     params.fpType = static_cast<FingerprintType>(fpType);
     params.fpSize = size;
@@ -1997,7 +1996,6 @@ extern "C" CBfp makeReactionBFP(CChemicalReaction data, int size, int fpType) {
     if (fpType > 5 || fpType < 1) {
       elog(ERROR, "makeReactionBFP: Unknown Fingerprint type");
     }
-    auto fp = static_cast<RDKit::FingerprintType>(fpType);
     RDKit::ReactionFingerprintParams params;
     params.fpType = static_cast<FingerprintType>(fpType);
     params.fpSize = size;

--- a/Code/PgSQL/rdkit/expected/fmcs.out
+++ b/Code/PgSQL/rdkit/expected/fmcs.out
@@ -5,6 +5,12 @@ select fmcs(m::text) from pgmol where m@>'c1ncccc1';
  [#6]1:,-[#7]:,-[#6]:,-[#6]:,-[#6]:,-[#6]:,-1
 (1 row)
 
+select fmcs(m) from pgmol where m@>'c1ncccc1';
+                     fmcs                     
+----------------------------------------------
+ [#6]1:,-[#6]:,-[#6]:,-[#6]:,-[#6]:,-[#7]:,-1
+(1 row)
+
 -- github #3687 : crash on bogus fmcs input
 select fmcs('q');
 ERROR:  findMCS: could not create molecule from SMILES 'q'

--- a/Code/PgSQL/rdkit/low_gist.c
+++ b/Code/PgSQL/rdkit/low_gist.c
@@ -36,6 +36,7 @@
 #include <utils/memutils.h>
 
 #include "rdkit.h"
+#include "cache.h"
 
 #define GETENTRY(vec,pos) ((bytea *) DatumGetPointer((vec)->vector[(pos)].key))
 

--- a/Code/PgSQL/rdkit/mol_op.c
+++ b/Code/PgSQL/rdkit/mol_op.c
@@ -441,11 +441,11 @@ Datum fmcs_mol2s_transition(PG_FUNCTION_ARGS) {
   }
   if (PG_ARGISNULL(0) && !PG_ARGISNULL(1)) {  // first call
     /// elog(WARNING, "fmcs_mol2s_transition() called first time");
-    CROMol mol = PG_GETARG_DATUM(1);
+    CROMol mol;
     int len, ts_size;
     char *smiles;
-    elog(WARNING, "mol=%p, fcinfo: %p, %p", mol, fcinfo->flinfo->fn_extra,
-         fcinfo->flinfo->fn_mcxt);
+    // elog(WARNING, "mol=%p, fcinfo: %p, %p", mol, fcinfo->flinfo->fn_extra,
+    //      fcinfo->flinfo->fn_mcxt);
     fcinfo->flinfo->fn_extra =
         searchMolCache(fcinfo->flinfo->fn_extra, fcinfo->flinfo->fn_mcxt,
                        PG_GETARG_DATUM(1), NULL, &mol, NULL);
@@ -469,10 +469,10 @@ Datum fmcs_mol2s_transition(PG_FUNCTION_ARGS) {
     // elog(WARNING, VARDATA(t0));
 
     // mol_to_smiles():
-    CROMol mol = PG_GETARG_DATUM(1);
+    CROMol mol;
     int len;
-    elog(WARNING, "mol=%p, fcinfo: %p, %p", mol, fcinfo->flinfo->fn_extra,
-         fcinfo->flinfo->fn_mcxt);
+    // elog(WARNING, "mol=%p, fcinfo: %p, %p", mol, fcinfo->flinfo->fn_extra,
+    //      fcinfo->flinfo->fn_mcxt);
     fcinfo->flinfo->fn_extra =
         searchMolCache(fcinfo->flinfo->fn_extra, fcinfo->flinfo->fn_mcxt,
                        PG_GETARG_DATUM(1), NULL, &mol, NULL);
@@ -537,18 +537,18 @@ Datum fmcs_mol_transition(PG_FUNCTION_ARGS) {
   if (PG_ARGISNULL(0) && !PG_ARGISNULL(1)) {  // first call
     // elog(WARNING, "fmcs_mol_transition() called first time");
     void *lst = NULL;
-    CROMol mol = PG_GETARG_DATUM(1);
+    Mol *mol = PG_GETARG_MOL_P(1);
     lst = addMol2list(NULL, mol);
     // char t[256];
     // sprintf(t,"mol=%p, lst=%p, fcinfo: %p, %p", mol, lst,
     // fcinfo->flinfo->fn_extra, fcinfo->flinfo->fn_mcxt);
     // elog(WARNING, t);
     // fcinfo->flinfo->fn_extra = lst;
-    PG_RETURN_INT32((int32)lst);
+    PG_RETURN_POINTER(lst);
   } else if (!PG_ARGISNULL(0) &&
              !PG_ARGISNULL(1)) {  // Called in aggregate context...
     // elog(WARNING, "fmcs_mol_transition(): next iteration in the same run");
-    CROMol mol = PG_GETARG_DATUM(1);
+    Mol *mol = PG_GETARG_MOL_P(1);
     void *lst = addMol2list(PG_GETARG_POINTER(0), mol);
     // char t[256];
     // sprintf(t,"mol=%p, lst=%p, fcinfo: %p, %p", mol, lst,

--- a/Code/PgSQL/rdkit/sql/fmcs.sql
+++ b/Code/PgSQL/rdkit/sql/fmcs.sql
@@ -1,6 +1,6 @@
-
 -- github #3687 : crash on bogus fmcs input
 select fmcs(m::text) from pgmol where m@>'c1ncccc1';
+select fmcs(m) from pgmol where m@>'c1ncccc1';
 
 -- github #3687 : crash on bogus fmcs input
 select fmcs('q');


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
This pull request is intended to address a few warnings in the cartridge code, due to some unused variables, one missing inclusion directive and a few integer-to/from-pointer conversions in the fmcs code.

#### Any other comments?
In the process I added a test case exercising the overloaded fmcs aggregator for mol values.