### PR TITLE
Fix docstring of ConstrainedEmbed

### DIFF
--- a/rdkit/Chem/AllChem.py
+++ b/rdkit/Chem/AllChem.py
@@ -284,17 +284,17 @@ def ConstrainedEmbed(mol, core, useTethers=True, coreConfId=-1, randomseed=2342,
     >>> mol = AllChem.MolFromSmiles("c1nn(Cc2ccccc2)cc1-c3ccccc3")
 
     Now do the constrained embedding
-    >>> AllChem.ConstrainedEmbed(mol, template)
+    >>> mol = AllChem.ConstrainedEmbed(mol, template)
 
     Demonstrate that the positions are nearly the same with template:
 
     >>> import math
-    >>> molp=mol.GetConformer().GetAtomPosition(0)
-    >>> templatep=template.GetConformer().GetAtomPosition(0)
+    >>> molp = mol.GetConformer().GetAtomPosition(0)
+    >>> templatep = template.GetConformer().GetAtomPosition(0)
     >>> all(math.isclose(v, 0.0, abs_tol=0.01) for v in molp-templatep)
     True
-    >>> molp=mol.GetConformer().GetAtomPosition(1)
-    >>> templatep=template.GetConformer().GetAtomPosition(1)
+    >>> molp = mol.GetConformer().GetAtomPosition(1)
+    >>> templatep = template.GetConformer().GetAtomPosition(1)
     >>> all(math.isclose(v, 0.0, abs_tol=0.01) for v in molp-templatep)
     True
 

--- a/rdkit/Chem/AllChem.py
+++ b/rdkit/Chem/AllChem.py
@@ -284,17 +284,18 @@ def ConstrainedEmbed(mol, core, useTethers=True, coreConfId=-1, randomseed=2342,
     >>> mol = AllChem.MolFromSmiles("c1nn(Cc2ccccc2)cc1-c3ccccc3")
 
     Now do the constrained embedding
-    >>> newmol=AllChem.ConstrainedEmbed(mol, template)
+    >>> AllChem.ConstrainedEmbed(mol, template)
 
-    Demonstrate that the positions are the same:
+    Demonstrate that the positions are nearly the same with template:
 
-    >>> newp=newmol.GetConformer().GetAtomPosition(0)
+    >>> import math
     >>> molp=mol.GetConformer().GetAtomPosition(0)
-    >>> list(newp-molp)==[0.0,0.0,0.0]
+    >>> templatep=template.GetConformer().GetAtomPosition(0)
+    >>> all(math.isclose(v, 0.0, abs_tol=0.01) for v in molp-templatep)
     True
-    >>> newp=newmol.GetConformer().GetAtomPosition(1)
     >>> molp=mol.GetConformer().GetAtomPosition(1)
-    >>> list(newp-molp)==[0.0,0.0,0.0]
+    >>> templatep=template.GetConformer().GetAtomPosition(1)
+    >>> all(math.isclose(v, 0.0, abs_tol=0.01) for v in molp-templatep)
     True
 
     """


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

This PR fixes useless docstring of ConstrainedEmbed.
`AllChem.ConstrainedEmbed` returns the same object with `mol`, ie, the code below always prints `True`.

```python
newmol=AllChem.ConstrainedEmbed(mol, template)
print(newmol is mol)
```

Therefore, the following explanations are useless. I believe that points should be compared with `template`'s ones.

