### PR TITLE
Add some new color palettes to MolDraw2D

### DIFF
--- a/Code/GraphMol/MolDraw2D/MolDraw2D.h
+++ b/Code/GraphMol/MolDraw2D/MolDraw2D.h
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2014-2020 David Cosgrove and Greg Landrum
+//  Copyright (C) 2014-2021 David Cosgrove and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -177,6 +177,7 @@ struct AnnotationType {
 typedef std::map<int, DrawColour> ColourPalette;
 typedef std::vector<double> DashPattern;
 
+//! use the RDKit's default palette r
 inline void assignDefaultPalette(ColourPalette &palette) {
   palette.clear();
   palette[-1] = DrawColour(0, 0, 0);
@@ -184,6 +185,58 @@ inline void assignDefaultPalette(ColourPalette &palette) {
   palette[1] = palette[6] = DrawColour(0.0, 0.0, 0.0);
   palette[7] = DrawColour(0.0, 0.0, 1.0);
   palette[8] = DrawColour(1.0, 0.0, 0.0);
+  palette[9] = DrawColour(0.2, 0.8, 0.8);
+  palette[15] = DrawColour(1.0, 0.5, 0.0);
+  palette[16] = DrawColour(0.8, 0.8, 0.0);
+  palette[17] = DrawColour(0.0, 0.802, 0.0);
+  palette[35] = DrawColour(0.5, 0.3, 0.1);
+  palette[53] = DrawColour(0.63, 0.12, 0.94);
+};
+
+//! use the color palette from the Avalon renderer
+inline void assignAvalonPalette(ColourPalette &palette) {
+  palette.clear();
+  palette[-1] = DrawColour(0, 0, 0);
+  palette[0] = DrawColour(0.1, 0.1, 0.1);
+  palette[1] = palette[6] = DrawColour(0.0, 0.0, 0.0);
+  palette[7] = DrawColour(0.0, 0.0, 1.0);
+  palette[8] = DrawColour(1.0, 0.0, 0.0);
+  palette[9] = DrawColour(0.0, 0.498, 0.0);
+  palette[15] = DrawColour(0.498, 0.0, 0.498);
+  palette[16] = DrawColour(0.498, 0.247, 0.0);
+  palette[17] = DrawColour(0.0, 0.498, 0.0);
+  palette[35] = DrawColour(0.0, 0.498, 0.0);
+  palette[53] = DrawColour(0.247, 0.0, 0.498);
+};
+
+//! use (part of) the CDK color palette
+/*!
+  data source:
+  https://github.com/cdk/cdk/blob/master/display/render/src/main/java/org/openscience/cdk/renderer/color/CDK2DAtomColors.java
+*/
+inline void assignCDKPalette(ColourPalette &palette) {
+  palette.clear();
+  palette[-1] = DrawColour(0, 0, 0);
+  palette[0] = DrawColour(0.1, 0.1, 0.1);
+  palette[1] = palette[6] = DrawColour(0.0, 0.0, 0.0);
+  palette[7] = DrawColour(0.188, 0.314, 0.972);
+  palette[8] = DrawColour(1.0, 0.051, 0.051);
+  palette[9] = DrawColour(0.565, 0.878, 0.314);
+  palette[15] = DrawColour(1.0, 0.5, 0.0);
+  palette[16] = DrawColour(0.776, 0.776, 0.173);
+  palette[17] = DrawColour(0.122, 0.498, 0.122);
+  palette[35] = DrawColour(0.651, 0.161, 0.161);
+  palette[53] = DrawColour(0.580, 0.0, 0.580);
+  palette[5] = DrawColour(1.000, 0.710, 0.710);
+};
+
+inline void assignDarkModePalette(ColourPalette &palette) {
+  palette.clear();
+  palette[-1] = DrawColour(0.8, 0.8, 0.8);
+  palette[0] = DrawColour(0.9, 0.9, 0.9);
+  palette[1] = palette[6] = DrawColour(0.9, 0.9, 0.9);
+  palette[7] = DrawColour(0.2, 0.2, 1.0);
+  palette[8] = DrawColour(1.0, 0.2, 0.2);
   palette[9] = DrawColour(0.2, 0.8, 0.8);
   palette[15] = DrawColour(1.0, 0.5, 0.0);
   palette[16] = DrawColour(0.8, 0.8, 0.0);
@@ -925,7 +978,29 @@ RDKIT_MOLDRAW2D_EXPORT bool doesLineIntersectLabel(const Point2D &ls,
                                                    const Point2D &lf,
                                                    const StringRect &lab_rect,
                                                    double padding = 0.0);
-
+inline void setDarkMode(MolDrawOptions &opts) {
+  assignDarkModePalette(opts.atomColourPalette);
+  opts.backgroundColour = DrawColour{0, 0, 0, 1};
+  opts.annotationColour = DrawColour{0.9, 0.9, 0.9, 1};
+  opts.legendColour = DrawColour{0.9, 0.9, 0.9, 1};
+  opts.symbolColour = DrawColour{0.9, 0.9, 0.9, 1};
+  opts.variableAttachmentColour = DrawColour{0.3, 0.3, 0.3, 1};
+}
+inline void setDarkMode(MolDraw2D &d2d) { setDarkMode(d2d.drawOptions()); }
+inline void setMonochromeMode(MolDrawOptions &opts, const DrawColour &fgColour,
+                              const DrawColour &bgColour) {
+  opts.atomColourPalette.clear();
+  opts.atomColourPalette[-1] = fgColour;
+  opts.backgroundColour = bgColour;
+  opts.annotationColour = fgColour;
+  opts.legendColour = fgColour;
+  opts.symbolColour = fgColour;
+  opts.variableAttachmentColour = fgColour;
+}
+inline void setMonochromeMode(MolDraw2D &opts, const DrawColour &fgColour,
+                              const DrawColour &bgColour) {
+  setMonochromeMode(opts.drawOptions(), fgColour, bgColour);
+}
 }  // namespace RDKit
 
 #endif  // RDKITMOLDRAW2D_H

--- a/Code/GraphMol/MolDraw2D/Wrap/rdMolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/Wrap/rdMolDraw2D.cpp
@@ -442,6 +442,12 @@ void useDefaultAtomPalette(RDKit::MolDrawOptions &self) {
 void useBWAtomPalette(RDKit::MolDrawOptions &self) {
   assignBWPalette(self.atomColourPalette);
 }
+void useAvalonAtomPalette(RDKit::MolDrawOptions &self) {
+  assignAvalonPalette(self.atomColourPalette);
+}
+void useCDKAtomPalette(RDKit::MolDrawOptions &self) {
+  assignCDKPalette(self.atomColourPalette);
+}
 void updateAtomPalette(RDKit::MolDrawOptions &self, python::object cmap) {
   pyDictToColourMap(cmap, self.atomColourPalette);
 }
@@ -632,8 +638,10 @@ BOOST_PYTHON_MODULE(rdMolDraw2D) {
 
       .def("useDefaultAtomPalette", &RDKit::useDefaultAtomPalette,
            "use the default colour palette for atoms and bonds")
-      .def("useBWAtomPalette", &RDKit::useBWAtomPalette,
-           "use the black & white palette for atoms and bonds")
+      .def("useAvalonAtomPalette", &RDKit::useAvalonAtomPalette,
+           "use the Avalon renderer palette for atoms and bonds")
+      .def("useCDKAtomPalette", &RDKit::useCDKAtomPalette,
+           "use the CDK palette for atoms and bonds")
       .def("updateAtomPalette", &RDKit::updateAtomPalette,
            "updates the palette for atoms and bonds from a dictionary mapping "
            "ints to 3-tuples")
@@ -845,7 +853,7 @@ BOOST_PYTHON_MODULE(rdMolDraw2D) {
       .def("FillPolys", &RDKit::MolDraw2D::fillPolys,
            "returns whether or not polygons are being filled")
       .def("DrawLine",
-           (void (RDKit::MolDraw2D::*)(const Point2D &, const Point2D &)) &
+           (void(RDKit::MolDraw2D::*)(const Point2D &, const Point2D &)) &
                RDKit::MolDraw2D::drawLine,
            (python::arg("self"), python::arg("cds1"), python::arg("cds2")),
            "draws a line with the current drawing style. The coordinates "
@@ -889,15 +897,15 @@ BOOST_PYTHON_MODULE(rdMolDraw2D) {
            "draw a line indicating the presence of an attachment point "
            "(normally a squiggle line perpendicular to a bond)")
       .def("DrawString",
-           (void (RDKit::MolDraw2D::*)(const std::string &,
-                                       const RDGeom::Point2D &)) &
+           (void(RDKit::MolDraw2D::*)(const std::string &,
+                                      const RDGeom::Point2D &)) &
                RDKit::MolDraw2D::drawString,
            (python::arg("self"), python::arg("string"), python::arg("pos")),
            "add text to the canvas")
       .def("DrawString",
-           (void (RDKit::MolDraw2D::*)(const std::string &,
-                                       const RDGeom::Point2D &,
-                                       RDKit::TextAlignType)) &
+           (void(RDKit::MolDraw2D::*)(const std::string &,
+                                      const RDGeom::Point2D &,
+                                      RDKit::TextAlignType)) &
                RDKit::MolDraw2D::drawString,
            (python::arg("self"), python::arg("string"), python::arg("pos"),
             python::arg("align")),
@@ -937,7 +945,7 @@ BOOST_PYTHON_MODULE(rdMolDraw2D) {
       .def("FinishDrawing", &RDKit::MolDraw2DSVG::finishDrawing,
            "add the last bits of SVG to finish the drawing")
       .def("AddMoleculeMetadata",
-           (void (RDKit::MolDraw2DSVG::*)(const RDKit::ROMol &, int) const) &
+           (void(RDKit::MolDraw2DSVG::*)(const RDKit::ROMol &, int) const) &
                RDKit::MolDraw2DSVG::addMoleculeMetadata,
            (python::arg("mol"), python::arg("confId") = -1),
            "add RDKit-specific information to the bottom of the drawing")
@@ -1100,4 +1108,11 @@ BOOST_PYTHON_MODULE(rdMolDraw2D) {
        python::arg("kekulize") = true, python::arg("lineWidthMult") = 1,
        python::arg("fontSize") = 12, python::arg("includeAtomCircles") = true),
       docString.c_str());
+
+  python::def("SetDarkMode",
+              (void (*)(RDKit::MolDrawOptions &)) & RDKit::setDarkMode,
+              "set dark mode for a MolDrawOptions object");
+  python::def("SetDarkMode",
+              (void (*)(RDKit::MolDraw2D &)) & RDKit::setDarkMode,
+              "set dark mode for a MolDraw2D object");
 }

--- a/Code/GraphMol/MolDraw2D/Wrap/rdMolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/Wrap/rdMolDraw2D.cpp
@@ -456,6 +456,20 @@ void setAtomPalette(RDKit::MolDrawOptions &self, python::object cmap) {
   updateAtomPalette(self, cmap);
 }
 
+void setMonochromeMode_helper1(RDKit::MolDrawOptions &options, python::tuple fg,
+                               python::tuple bg) {
+  auto fgc = pyTupleToDrawColour(fg);
+  auto bgc = pyTupleToDrawColour(bg);
+  RDKit::setMonochromeMode(options, fgc, bgc);
+}
+
+void setMonochromeMode_helper2(RDKit::MolDraw2D &d2d, python::tuple fg,
+                               python::tuple bg) {
+  auto fgc = pyTupleToDrawColour(fg);
+  auto bgc = pyTupleToDrawColour(bg);
+  RDKit::setMonochromeMode(d2d, fgc, bgc);
+}
+
 void contourAndDrawGaussiansHelper(
     RDKit::MolDraw2D &drawer, python::object pylocs, python::object pyheights,
     python::object pywidths, unsigned int nContours, python::object pylevels,
@@ -638,6 +652,8 @@ BOOST_PYTHON_MODULE(rdMolDraw2D) {
 
       .def("useDefaultAtomPalette", &RDKit::useDefaultAtomPalette,
            "use the default colour palette for atoms and bonds")
+      .def("useBWAtomPalette", &RDKit::useBWAtomPalette,
+           "use a black and white palette for atoms and bonds")
       .def("useAvalonAtomPalette", &RDKit::useAvalonAtomPalette,
            "use the Avalon renderer palette for atoms and bonds")
       .def("useCDKAtomPalette", &RDKit::useCDKAtomPalette,
@@ -1115,4 +1131,12 @@ BOOST_PYTHON_MODULE(rdMolDraw2D) {
   python::def("SetDarkMode",
               (void (*)(RDKit::MolDraw2D &)) & RDKit::setDarkMode,
               "set dark mode for a MolDraw2D object");
+  python::def("SetMonochromeMode", RDKit::setMonochromeMode_helper1,
+              (python::arg("options"), python::arg("fgColour"),
+               python::arg("bgColour")),
+              "set monochrome mode for a MolDrawOptions object");
+  python::def(
+      "SetMonochromeMode", RDKit::setMonochromeMode_helper2,
+      (python::arg("drawer"), python::arg("fgColour"), python::arg("bgColour")),
+      "set monochrome mode for a MolDraw2D object");
 }

--- a/Code/GraphMol/MolDraw2D/Wrap/testMolDraw2D.py
+++ b/Code/GraphMol/MolDraw2D/Wrap/testMolDraw2D.py
@@ -681,15 +681,39 @@ M  END''')
     nDeuteriumTritium = len(deuteriumTritiumRegex.findall(textDeuteriumTritium))
     self.assertEqual(nDeuteriumTritium, 2)
 
-  def testDarkMode(self):
+  def testNewDrawingModes(self):
     m = Chem.MolFromSmiles("CS(=O)(=O)COC(=N)c1cc(Cl)cnc1[NH3+] |SgD:7:note:some extra text:=:::|")
 
     d2d = Draw.MolDraw2DSVG(300, 300)
-    rdMolDraw2D.SetDarkMode(d2d);
+    rdMolDraw2D.SetDarkMode(d2d)
     d2d.DrawMolecule(m)
     d2d.FinishDrawing()
     text = d2d.GetDrawingText()
     self.assertIn("<rect style='opacity:1.0;fill:#000000;stroke:none'",text)
+
+    d2d = Draw.MolDraw2DSVG(300, 300)
+    rdMolDraw2D.SetMonochromeMode(d2d,(1,1,1),(.5,.5,.5))
+    d2d.DrawMolecule(m)
+    d2d.FinishDrawing()
+    text = d2d.GetDrawingText()
+    self.assertIn("<rect style='opacity:1.0;fill:#7F7F7F;stroke:none'",text)
+    self.assertIn("stroke:#FFFFFF;stroke-width:2",text)
+
+    d2d = Draw.MolDraw2DSVG(300, 300)
+    d2d.drawOptions().useAvalonAtomPalette()
+    d2d.DrawMolecule(m)
+    d2d.FinishDrawing()
+    text = d2d.GetDrawingText()
+    self.assertIn("<rect style='opacity:1.0;fill:#FFFFFF;stroke:none'",text)
+    self.assertIn("stroke:#007E00;stroke-width:2",text)
+
+    d2d = Draw.MolDraw2DSVG(300, 300)
+    d2d.drawOptions().useCDKAtomPalette()
+    d2d.DrawMolecule(m)
+    d2d.FinishDrawing()
+    text = d2d.GetDrawingText()
+    self.assertIn("<rect style='opacity:1.0;fill:#FFFFFF;stroke:none'",text)
+    self.assertIn("stroke:#2F50F7;stroke-width:2",text)
 
 if __name__ == "__main__":
   unittest.main()

--- a/Code/GraphMol/MolDraw2D/Wrap/testMolDraw2D.py
+++ b/Code/GraphMol/MolDraw2D/Wrap/testMolDraw2D.py
@@ -681,6 +681,15 @@ M  END''')
     nDeuteriumTritium = len(deuteriumTritiumRegex.findall(textDeuteriumTritium))
     self.assertEqual(nDeuteriumTritium, 2)
 
+  def testDarkMode(self):
+    m = Chem.MolFromSmiles("CS(=O)(=O)COC(=N)c1cc(Cl)cnc1[NH3+] |SgD:7:note:some extra text:=:::|")
+
+    d2d = Draw.MolDraw2DSVG(300, 300)
+    rdMolDraw2D.SetDarkMode(d2d);
+    d2d.DrawMolecule(m)
+    d2d.FinishDrawing()
+    text = d2d.GetDrawingText()
+    self.assertIn("<rect style='opacity:1.0;fill:#000000;stroke:none'",text)
 
 if __name__ == "__main__":
   unittest.main()

--- a/Code/GraphMol/MolDraw2D/catch_tests.cpp
+++ b/Code/GraphMol/MolDraw2D/catch_tests.cpp
@@ -157,6 +157,11 @@ static const std::map<std::string, std::hash_result_t> SVG_HASHES = {
     {"testGithub4508_2.svg", 2202600652U},
     {"testGithub4508_2b.svg", 145414660U},
     {"testGithub4538.svg", 2784641879U},
+    {"testDarkMode.1.svg", 2696431144U},
+    {"testMonochrome.1.svg", 491478930U},
+    {"testMonochrome.2.svg", 1722291679U},
+    {"testAvalon.1.svg", 3576514243U},
+    {"testCDK.1.svg", 2509805825U},
 };
 
 // These PNG hashes aren't completely reliable due to floating point cruft,
@@ -3435,5 +3440,81 @@ TEST_CASE("Github #4538 drawMolecules crash") {
     outs << text;
     outs.flush();
     check_file_hash("testGithub4538.svg");
+  }
+}
+
+TEST_CASE("dark mode mol drawing") {
+  SECTION("Basics") {
+    auto m =
+        "CS(=O)(=O)COC(=N)c1cc(Cl)cnc1[NH3+] |SgD:7:note:some extra text:=:::|"_smiles;
+    REQUIRE(m);
+    MolDraw2DSVG drawer(350, 300);
+    setDarkMode(drawer);
+    drawer.drawMolecule(*m, "dark mode!");
+    drawer.finishDrawing();
+    auto text = drawer.getDrawingText();
+    std::ofstream outs("testDarkMode.1.svg");
+    outs << text;
+    outs.flush();
+    check_file_hash("testDarkMode.1.svg");
+  }
+}
+TEST_CASE("monochrome mol drawing") {
+  SECTION("Basics") {
+    auto m =
+        "CS(=O)(=O)COC(=N)c1cc(Cl)cnc1[NH3+] |SgD:7:note:some extra text:=:::|"_smiles;
+    REQUIRE(m);
+    MolDraw2DSVG drawer(350, 300);
+    setMonochromeMode(drawer, DrawColour{0.1, 0.1, 0.6},
+                      DrawColour{0.75, 0.75, 0.75});
+    drawer.drawMolecule(*m, "monochrome");
+    drawer.finishDrawing();
+    auto text = drawer.getDrawingText();
+    std::ofstream outs("testMonochrome.1.svg");
+    outs << text;
+    outs.flush();
+    check_file_hash("testMonochrome.1.svg");
+  }
+  SECTION("Basics inverted") {
+    auto m =
+        "CS(=O)(=O)COC(=N)c1cc(Cl)cnc1[NH3+] |SgD:7:note:some extra text:=:::|"_smiles;
+    REQUIRE(m);
+    MolDraw2DSVG drawer(350, 300);
+    setMonochromeMode(drawer, DrawColour{0.75, 0.75, 0.75},
+                      DrawColour{0.1, 0.1, 0.6});
+    drawer.drawMolecule(*m, "monochrome");
+    drawer.finishDrawing();
+    auto text = drawer.getDrawingText();
+    std::ofstream outs("testMonochrome.2.svg");
+    outs << text;
+    outs.flush();
+    check_file_hash("testMonochrome.2.svg");
+  }
+}
+TEST_CASE("other palettes") {
+  auto m =
+      "CS(=O)(=O)COC(=N)c1c(I)c(Cl)c(Br)nc1[NH2+]CP(=O) |SgD:7:note:some extra text:=:::|"_smiles;
+  REQUIRE(m);
+  SECTION("Avalon") {
+    MolDraw2DSVG drawer(350, 300);
+    assignAvalonPalette(drawer.drawOptions().atomColourPalette);
+    drawer.drawMolecule(*m, "monochrome");
+    drawer.finishDrawing();
+    auto text = drawer.getDrawingText();
+    std::ofstream outs("testAvalon.1.svg");
+    outs << text;
+    outs.flush();
+    check_file_hash("testAvalon.1.svg");
+  }
+  SECTION("CDK") {
+    MolDraw2DSVG drawer(350, 300);
+    assignCDKPalette(drawer.drawOptions().atomColourPalette);
+    drawer.drawMolecule(*m, "monochrome");
+    drawer.finishDrawing();
+    auto text = drawer.getDrawingText();
+    std::ofstream outs("testCDK.1.svg");
+    outs << text;
+    outs.flush();
+    check_file_hash("testCDK.1.svg");
   }
 }

--- a/Code/GraphMol/MolDraw2D/catch_tests.cpp
+++ b/Code/GraphMol/MolDraw2D/catch_tests.cpp
@@ -160,8 +160,8 @@ static const std::map<std::string, std::hash_result_t> SVG_HASHES = {
     {"testDarkMode.1.svg", 2696431144U},
     {"testMonochrome.1.svg", 491478930U},
     {"testMonochrome.2.svg", 1722291679U},
-    {"testAvalon.1.svg", 3576514243U},
-    {"testCDK.1.svg", 2509805825U},
+    {"testAvalon.1.svg", 332535300U},
+    {"testCDK.1.svg", 3928121594U},
 };
 
 // These PNG hashes aren't completely reliable due to floating point cruft,
@@ -3498,7 +3498,7 @@ TEST_CASE("other palettes") {
   SECTION("Avalon") {
     MolDraw2DSVG drawer(350, 300);
     assignAvalonPalette(drawer.drawOptions().atomColourPalette);
-    drawer.drawMolecule(*m, "monochrome");
+    drawer.drawMolecule(*m, "Avalon");
     drawer.finishDrawing();
     auto text = drawer.getDrawingText();
     std::ofstream outs("testAvalon.1.svg");
@@ -3509,7 +3509,7 @@ TEST_CASE("other palettes") {
   SECTION("CDK") {
     MolDraw2DSVG drawer(350, 300);
     assignCDKPalette(drawer.drawOptions().atomColourPalette);
-    drawer.drawMolecule(*m, "monochrome");
+    drawer.drawMolecule(*m, "CDK");
     drawer.finishDrawing();
     auto text = drawer.getDrawingText();
     std::ofstream outs("testCDK.1.svg");


### PR DESCRIPTION
This adds three new atom color palettes:
- avalon
- CDK
- dark mode

and two new drawing modes:
- dark mode
- monochrome (= provide just foreground and background colors)

The modes set all colors (except highlighting... I didn't figure out a reasonable way to automate that), not just the atom palette.

Here are some examples:

Dark mode:
![image](https://user-images.githubusercontent.com/540511/140029932-a0afd9c9-123f-4c06-b563-451864da6f77.png)

Avalon mode:
![image](https://user-images.githubusercontent.com/540511/140030498-61e2e9c8-fe22-43ec-ba6a-c2c0dc3baad2.png)

CDK mode:
![image](https://user-images.githubusercontent.com/540511/140030530-60d78dc1-641f-41ae-94ba-9b8804779c46.png)

And monochrome, with an "arbitrary" choice of fg/bg colors:
![image](https://user-images.githubusercontent.com/540511/140030637-136fb266-8825-4f0f-adda-39a22fc34eb5.png)



