### PR TITLE
fix TopologicalTorsion fingerprint in ReactionFingerprints' generateFingerprintAsBitVect

### DIFF
--- a/Code/GraphMol/ChemReactions/ReactionFingerprints.cpp
+++ b/Code/GraphMol/ChemReactions/ReactionFingerprints.cpp
@@ -97,7 +97,7 @@ ExplicitBitVect *generateFingerprintAsBitVect(RDKit::ROMol &mol,
       break;
     case RDKit::TopologicalTorsion:
       res = RDKit::AtomPairs::getHashedTopologicalTorsionFingerprintAsBitVect(
-          mol);
+          mol, fpSize);
       break;
     case RDKit::MorganFP: {
       if (!mol.getRingInfo()->isInitialized()) {

--- a/Code/PgSQL/rdkit/expected/reaction.out
+++ b/Code/PgSQL/rdkit/expected/reaction.out
@@ -587,9 +587,9 @@ SELECT tanimoto_sml(reaction_structural_bfp('c1ccccc1>>c1ccncc1',2), reaction_st
 (1 row)
 
 SELECT tanimoto_sml(reaction_structural_bfp('c1ccccc1>>c1ccncc1',2), reaction_structural_bfp('c1ncccc1>>c1ncncc1',2));
-   tanimoto_sml    
--------------------
- 0.461538461538462
+ tanimoto_sml 
+--------------
+          0.4
 (1 row)
 
 SELECT tanimoto_sml(reaction_structural_bfp('c1ccccc1>CC(=O)O.[Na+]>c1ccncc1',2), reaction_structural_bfp('c1ccccc1>CC(=O)O.[Na+]>c1ccncc1',2));
@@ -599,9 +599,9 @@ SELECT tanimoto_sml(reaction_structural_bfp('c1ccccc1>CC(=O)O.[Na+]>c1ccncc1',2)
 (1 row)
 
 SELECT tanimoto_sml(reaction_structural_bfp('c1ccccc1>CC(=O)O.[Na+]>c1ccncc1',2), reaction_structural_bfp('c1ncccc1>[Na+]>c1ncncc1',2));
-   tanimoto_sml    
--------------------
- 0.461538461538462
+ tanimoto_sml 
+--------------
+          0.4
 (1 row)
 
 SELECT tanimoto_sml(reaction_structural_bfp('c1ccccc1>>c1ccncc1',3), reaction_structural_bfp('c1ccccc1>>c1ccncc1',3));
@@ -782,9 +782,9 @@ SELECT tanimoto_sml(reaction_structural_bfp('c1ccccc1>>c1ccncc1',2), reaction_st
 (1 row)
 
 SELECT tanimoto_sml(reaction_structural_bfp('c1ccccc1>>c1ccncc1',2), reaction_structural_bfp('c1ncccc1>>c1ncncc1',2));
-   tanimoto_sml    
--------------------
- 0.444444444444444
+ tanimoto_sml 
+--------------
+          0.4
 (1 row)
 
 SELECT tanimoto_sml(reaction_structural_bfp('c1ccccc1>CC(=O)O.[Na+]>c1ccncc1',2), reaction_structural_bfp('c1ccccc1>CC(=O)O.[Na+]>c1ccncc1',2));
@@ -794,9 +794,9 @@ SELECT tanimoto_sml(reaction_structural_bfp('c1ccccc1>CC(=O)O.[Na+]>c1ccncc1',2)
 (1 row)
 
 SELECT tanimoto_sml(reaction_structural_bfp('c1ccccc1>CC(=O)O.[Na+]>c1ccncc1',2), reaction_structural_bfp('c1ncccc1>[Na+]>c1ncncc1',2));
-   tanimoto_sml    
--------------------
- 0.444444444444444
+ tanimoto_sml 
+--------------
+          0.4
 (1 row)
 
 SELECT tanimoto_sml(reaction_structural_bfp('c1ccccc1>>c1ccncc1',3), reaction_structural_bfp('c1ccccc1>>c1ccncc1',3));


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! 
-->
#### Reference Issue
Fixes #4631

#### What does this implement/fix? Explain your changes.
The call to `getHashedTopologicalTorsionFingerprintAsBitVect` in `generateFingerprintAsBitVect` is modified to pass the `fpSize` argument, that was previously omitted and resulting in a fixed fingerprint size of 2048 bits.

#### Any other comments?
I assumed the missing argument was simply due to an oversight, just let me know if it was for some reason intended.
The implemented change in general affects the computation of reaction fingerprints of type TopologicalTorsion, and it's not limited in scope to the postgres cartridge.
