### PR TITLE
RGD:  fix for cores with MOL  block atom lists

### DIFF
--- a/Code/GraphMol/RGroupDecomposition/RGroupCore.cpp
+++ b/Code/GraphMol/RGroupDecomposition/RGroupCore.cpp
@@ -56,7 +56,7 @@ void RCore::findIndicesWithRLabel() {
 
 // Return a copy of core where dummy atoms are replaced by
 // the respective matching atom in mol, while other atoms have
-// their aromatic flag and formal charge copied from from
+// their aromatic flag and formal charge copied from 
 // the respective matching atom in mol
 ROMOL_SPTR RCore::replaceCoreAtomsWithMolMatches(
     bool &hasCoreDummies, const ROMol &mol, const MatchVectType &match) const {
@@ -106,7 +106,7 @@ void RCore::replaceCoreAtom(RWMol &mol, Atom &atom, const Atom &other) const {
   auto atomicNumber = other.getAtomicNum();
   auto targetAtom = &atom;
   bool wasDummy = (atom.getAtomicNum() == 0);
-  if (wasDummy) {
+  if (wasDummy || atom.hasQuery()) {
     if (atom.hasQuery()) {
       Atom newAtom(atomicNumber);
       auto atomIdx = atom.getIdx();

--- a/Code/GraphMol/RGroupDecomposition/testRGroupDecomp.cpp
+++ b/Code/GraphMol/RGroupDecomposition/testRGroupDecomp.cpp
@@ -2458,6 +2458,54 @@ C[*:2]
   }
 }
 
+void testCoreWithAlsRecords() {
+  auto core = R"CTAB(
+  Mrv2008 11112113312D
+
+  6  6  6  0  0  0            999 V2000
+  -13.7277    2.6107    0.0000 L   0  0  0  0  0  0  0  0  0  0  0  0
+  -14.4421    2.1982    0.0000 L   0  0  0  0  0  0  0  0  0  0  0  0
+  -14.4421    1.3732    0.0000 L   0  0  0  0  0  0  0  0  0  0  0  0
+  -13.7277    0.9607    0.0000 L   0  0  0  0  0  0  0  0  0  0  0  0
+  -13.0132    1.3732    0.0000 L   0  0  0  0  0  0  0  0  0  0  0  0
+  -13.0132    2.1982    0.0000 L   0  0  0  0  0  0  0  0  0  0  0  0
+  1  2  1  0  0  0  0
+  2  3  2  0  0  0  0
+  3  4  1  0  0  0  0
+  4  5  2  0  0  0  0
+  5  6  1  0  0  0  0
+  1  6  2  0  0  0  0
+  1 F    2   6   7
+  2 F    2   6   7
+  3 F    2   6   7
+  4 F    2   6   7
+  5 F    2   6   7
+  6 F    2   6   7
+M  ALS   1  2 F C   N   
+M  ALS   2  2 F C   N   
+M  ALS   3  2 F C   N   
+M  ALS   4  2 F C   N   
+M  ALS   5  2 F C   N   
+M  ALS   6  2 F C   N   
+M  END
+
+)CTAB"_ctab;
+  TEST_ASSERT(core);
+
+  auto structure = "ClC1=CN=C(C=C1)N1CCCC1"_smiles;
+  RGroupDecomposition decomp(*core);
+  TEST_ASSERT(decomp.add(*structure) == 0);
+  decomp.process();
+  auto rows = decomp.getRGroupsAsRows();
+  auto core_out = rows[0]["Core"];
+  auto core_mol_block = MolToMolBlock(*rows[0]["Core"]);
+  auto pos = core_mol_block.find("ALS");
+  TEST_ASSERT(pos == std::string::npos);
+  std::string expected("Core:c1cc([*:2])ncc1[*:1] R1:Cl[*:1] R2:C1CCN([*:2])C1");
+  RGroupRows::const_iterator it = rows.begin();
+  CHECK_RGROUP(it, expected);
+}
+
 int main() {
   RDLog::InitLogs();
   boost::logging::disable_logs("rdApp.debug");
@@ -2505,6 +2553,7 @@ int main() {
   testNoTempLabels();
   testNoSideChains();
   testDoNotAddUnnecessaryRLabels();
+  testCoreWithAlsRecords();
   BOOST_LOG(rdInfoLog)
       << "********************************************************\n";
   return 0;


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! 
-->

#### What does this implement/fix? Explain your changes.

If  you have a core that contains atom list records (`M ALS` in the MOL block) those query atoms do not get assigned to the matching structure atoms during decomposition.  The ALS record is retained in the matching core and the atom type in the core atom is always the first atom type in the list- so if you output to smiles you may get the wrong atom type.

For example:


![Screenshot 2021-11-14 193447](https://user-images.githubusercontent.com/24233741/141713318-bd4fccba-6e7a-4c4a-987d-f91ff5026937.png)


Anyway, the fix is trivial and I've included a test.


