### PR TITLE
Fixes #4700: changes default tautomer enumeration rules

### DIFF
--- a/Code/GraphMol/MolStandardize/Tautomer.cpp
+++ b/Code/GraphMol/MolStandardize/Tautomer.cpp
@@ -467,10 +467,11 @@ TautomerEnumeratorResult TautomerEnumerator::enumerate(const ROMol &mol) const {
                     << ", kek: " << MolToSmiles(*kekulized_product, true, true)
                     << std::endl;
 #endif
-          BOOST_LOG(rdInfoLog)
-              << "Tautomer transform "
-              << transform.Mol->getProp<std::string>(common_properties::_Name)
-              << " produced tautomer " << tsmiles << std::endl;
+          // BOOST_LOG(rdInfoLog)
+          //     << "Tautomer transform "
+          //     <<
+          //     transform.Mol->getProp<std::string>(common_properties::_Name)
+          //     << " produced tautomer " << tsmiles << std::endl;
           res.d_tautomers[tsmiles] = Tautomer(
               std::move(product), std::move(kekulized_product),
               res.d_modifiedAtoms.count(), res.d_modifiedBonds.count());

--- a/Code/GraphMol/MolStandardize/Tautomer.cpp
+++ b/Code/GraphMol/MolStandardize/Tautomer.cpp
@@ -467,6 +467,10 @@ TautomerEnumeratorResult TautomerEnumerator::enumerate(const ROMol &mol) const {
                     << ", kek: " << MolToSmiles(*kekulized_product, true, true)
                     << std::endl;
 #endif
+          BOOST_LOG(rdInfoLog)
+              << "Tautomer transform "
+              << transform.Mol->getProp<std::string>(common_properties::_Name)
+              << " produced tautomer " << tsmiles << std::endl;
           res.d_tautomers[tsmiles] = Tautomer(
               std::move(product), std::move(kekulized_product),
               res.d_modifiedAtoms.count(), res.d_modifiedBonds.count());

--- a/Code/GraphMol/MolStandardize/Tautomer.h
+++ b/Code/GraphMol/MolStandardize/Tautomer.h
@@ -323,9 +323,9 @@ class RDKIT_MOLSTANDARDIZE_EXPORT TautomerEnumerator {
 
   //! Deprecated, please use the form returning a \c TautomerEnumeratorResult
   //! instead
-  [[deprecated(
-      "please use the form returning a TautomerEnumeratorResult "
-      "instead")]] std::vector<ROMOL_SPTR>
+  [
+      [deprecated("please use the form returning a TautomerEnumeratorResult "
+                  "instead")]] std::vector<ROMOL_SPTR>
   enumerate(const ROMol &mol, boost::dynamic_bitset<> *modifiedAtoms,
             boost::dynamic_bitset<> *modifiedBonds = nullptr) const;
 
@@ -412,6 +412,12 @@ class RDKIT_MOLSTANDARDIZE_EXPORT TautomerEnumerator {
 inline TautomerEnumerator *tautomerEnumeratorFromParams(
     const CleanupParameters &params) {
   return new TautomerEnumerator(params);
+}
+// caller owns the pointer
+inline TautomerEnumerator *getV1TautomerEnumerator() {
+  TautomerCatalogParams tparms(
+      MolStandardize::defaults::defaultTautomerTransformsv1);
+  return new TautomerEnumerator(new TautomerCatalog(&tparms));
 }
 
 }  // namespace MolStandardize

--- a/Code/GraphMol/MolStandardize/TautomerCatalog/TautomerCatalogParams.cpp
+++ b/Code/GraphMol/MolStandardize/TautomerCatalog/TautomerCatalogParams.cpp
@@ -16,6 +16,7 @@ namespace RDKit {
 namespace MolStandardize {
 
 #include "tautomerTransforms.in"
+#include "tautomerTransforms.v1.in"
 
 TautomerCatalogParams::TautomerCatalogParams(const std::string &tautomerFile) {
   d_transforms.clear();
@@ -26,8 +27,7 @@ TautomerCatalogParams::TautomerCatalogParams(const std::string &tautomerFile) {
   }
 }
 TautomerCatalogParams::TautomerCatalogParams(
-    const std::vector<
-        std::tuple<std::string, std::string, std::string, std::string>> &data) {
+    const TautomerTransformDefs &data) {
   d_transforms.clear();
   d_transforms = readTautomers(data);
 }

--- a/Code/GraphMol/MolStandardize/TautomerCatalog/TautomerCatalogParams.h
+++ b/Code/GraphMol/MolStandardize/TautomerCatalog/TautomerCatalogParams.h
@@ -24,6 +24,13 @@ class ROMol;
 namespace MolStandardize {
 class TautomerTransform;
 
+using TautomerTransformDefs =
+    std::vector<std::tuple<std::string, std::string, std::string, std::string>>;
+
+namespace defaults {
+extern const TautomerTransformDefs defaultTautomerTransforms;
+extern const TautomerTransformDefs defaultTautomerTransformsv1;
+}  // namespace defaults
 class RDKIT_MOLSTANDARDIZE_EXPORT TautomerCatalogParams
     : public RDCatalog::CatalogParams {
  public:
@@ -33,9 +40,7 @@ class RDKIT_MOLSTANDARDIZE_EXPORT TautomerCatalogParams
   }
 
   TautomerCatalogParams(const std::string &tautomerFile);
-  TautomerCatalogParams(
-      const std::vector<std::tuple<std::string, std::string, std::string,
-                                   std::string>> &data);
+  TautomerCatalogParams(const TautomerTransformDefs &data);
   // copy constructor
   TautomerCatalogParams(const TautomerCatalogParams &other);
 

--- a/Code/GraphMol/MolStandardize/TautomerCatalog/TautomerCatalogParams.h
+++ b/Code/GraphMol/MolStandardize/TautomerCatalog/TautomerCatalogParams.h
@@ -28,8 +28,10 @@ using TautomerTransformDefs =
     std::vector<std::tuple<std::string, std::string, std::string, std::string>>;
 
 namespace defaults {
-extern const TautomerTransformDefs defaultTautomerTransforms;
-extern const TautomerTransformDefs defaultTautomerTransformsv1;
+RDKIT_MOLSTANDARDIZE_EXPORT extern const TautomerTransformDefs
+    defaultTautomerTransforms;
+RDKIT_MOLSTANDARDIZE_EXPORT extern const TautomerTransformDefs
+    defaultTautomerTransformsv1;
 }  // namespace defaults
 class RDKIT_MOLSTANDARDIZE_EXPORT TautomerCatalogParams
     : public RDCatalog::CatalogParams {

--- a/Code/GraphMol/MolStandardize/TautomerCatalog/TautomerCatalogUtils.cpp
+++ b/Code/GraphMol/MolStandardize/TautomerCatalog/TautomerCatalogUtils.cpp
@@ -169,8 +169,7 @@ std::vector<TautomerTransform> readTautomers(std::istream& inStream,
 }
 
 std::vector<TautomerTransform> readTautomers(
-    const std::vector<
-        std::tuple<std::string, std::string, std::string, std::string>>& data) {
+    const TautomerTransformDefs& data) {
   std::vector<TautomerTransform> tautomers;
   for (const auto& tpl : data) {
     auto transform = getTautomer(std::get<0>(tpl), std::get<1>(tpl),

--- a/Code/GraphMol/MolStandardize/TautomerCatalog/tautomerTransforms.in
+++ b/Code/GraphMol/MolStandardize/TautomerCatalog/tautomerTransforms.in
@@ -23,10 +23,10 @@ const std::vector<
                         std::string(""), std::string("")),
         std::make_tuple(
             std::string("1,5 (thio)keto/enol f"),
-            std::string("[CX4,NX3;!H0]-[C]=[C][CH0]=[O,S,Se,Te;X1]"),
+            std::string("[CX4z0,NX3;!H0]-[C]=[C][Cz1H0]=[O,S,Se,Te;X1]"),
             std::string(""), std::string("")),
         std::make_tuple(std::string("1,5 (thio)keto/enol r"),
-                        std::string("[O,S,Se,Te;X2!H0]-[CH0]=[C]-[C]=[C,N]"),
+                        std::string("[O,S,Se,Te;X2!H0]-[Cz1H0]=[C]-[C]=[Cz0,N]"),
                         std::string(""), std::string("")),
         std::make_tuple(std::string("aliphatic imine f"),
                         std::string("[CX4!H0]-[C]=[NX2]"), std::string(""),

--- a/Code/GraphMol/MolStandardize/TautomerCatalog/tautomerTransforms.in
+++ b/Code/GraphMol/MolStandardize/TautomerCatalog/tautomerTransforms.in
@@ -16,10 +16,10 @@ const std::vector<
     std::tuple<std::string, std::string, std::string, std::string>>
     defaultTautomerTransforms{
         std::make_tuple(std::string("1,3 (thio)keto/enol f"),
-                        std::string("[CX4!H0]-[C]=[O,S,Se,Te;X1]"),
+                        std::string("[CX4!H0R{0-2}]-[C;z{1-2}]=[O,S,Se,Te;X1]"),
                         std::string(""), std::string("")),
         std::make_tuple(std::string("1,3 (thio)keto/enol r"),
-                        std::string("[O,S,Se,Te;X2!H0]-[C]=[C]"),
+                        std::string("[O,S,Se,Te;X2!H0]-[#6;z{1-2}]=[C,cz{0-1}R{0-1}]"),
                         std::string(""), std::string("")),
         std::make_tuple(
             std::string("1,5 (thio)keto/enol f"),
@@ -29,16 +29,16 @@ const std::vector<
                         std::string("[O,S,Se,Te;X2!H0]-[Cz1H0]=[C]-[C]=[Cz0,N]"),
                         std::string(""), std::string("")),
         std::make_tuple(std::string("aliphatic imine f"),
-                        std::string("[CX4!H0]-[C]=[NX2]"), std::string(""),
+                        std::string("[CX4R{0-2}!H0]-[Cz1]=[NX2]"), std::string(""),
                         std::string("")),
         std::make_tuple(std::string("aliphatic imine r"),
-                        std::string("[NX3!H0]-[C]=[CX3]"), std::string(""),
+                        std::string("[NX3!H0]-[C;z{1-2}]=[CX3]"), std::string(""),
                         std::string("")),
         std::make_tuple(std::string("special imine f"),
-                        std::string("[N!H0]-[C]=[CX3R0]"), std::string(""),
+                        std::string("[Nz0!H0]-[C]=[Cz0X3R0]"), std::string(""),
                         std::string("")),
         std::make_tuple(std::string("special imine r"),
-                        std::string("[CX4!H0]-[c]=[n]"), std::string(""),
+                        std::string("[Cz0R0X4!H0]-[c]=[nz0]"), std::string(""),
                         std::string("")),
         std::make_tuple(std::string("1,3 aromatic heteroatom H shift f"),
                         std::string("[#7+0!H0]-[#6R1]=[O,#7X2+0]"),
@@ -67,11 +67,11 @@ const std::vector<
         std::make_tuple(
             std::string("1,7 aromatic heteroatom H shift f"),
             std::string("[#7+0,#8,#16,Se,Te;!H0]-[#6,#7X2]=[#6,#"
-                        "7X2]-[#6,#7X2]=[#6]-[#6,#7X2]=[#7X2+0,S,O,Se,Te,CX3]"),
+                        "7X2]-[#6,#7X2]=[#6]-[#6,#7X2]=[#7X2+0,S,O,Se,Te,Cz0X3]"),
             std::string(""), std::string("")),
         std::make_tuple(
             std::string("1,7 aromatic heteroatom H shift r"),
-            std::string("[#7+0,S,O,Se,Te,CX4;!H0]-[#6,#7X2]=[#6]-[#"
+            std::string("[#7+0,S,O,Se,Te,Cz0X4;!H0]-[#6,#7X2]=[#6]-[#"
                         "6,#7X2]=[#6,#7X2]-[#6,#7X2]=[NX2,S,O,Se,Te]"),
             std::string(""), std::string("")),
         std::make_tuple(
@@ -86,11 +86,11 @@ const std::vector<
                         std::string(""), std::string("")),
         std::make_tuple(
             std::string("furanone f"),
-            std::string("[O,S,N;!H0]-[#6r5]=[#6X3r5;$([#6]([#6r5])=[#6r5])]"),
+            std::string("[O,S,N;!H0]-[#6z2r5]=,:[#6X3r5;$([#6]([#6;r5])=,:[#6X3r5])]"),
             std::string(""), std::string("")),
         std::make_tuple(
             std::string("furanone r"),
-            std::string("[#6r5!H0;$([#6]([#6r5])[#6r5])]-[#6r5]=[O,S,N]"),
+            std::string("[#6r5!H0;$([#6]([#6r5])[#6r5])][#6z2r5]=[O,S,N]"),
             std::string(""), std::string("")),
         std::make_tuple(std::string("keten/ynol f"),
                         std::string("[C!H0]=[C]=[O,S,Se,Te;X1]"),
@@ -105,16 +105,16 @@ const std::vector<
                         std::string("[O!H0]-[N+;$([N][O-])]=[C]"),
                         std::string(""), std::string("")),
         std::make_tuple(std::string("oxim/nitroso f"),
-                        std::string("[O!H0]-[N]=[C]"), std::string(""),
+                        std::string("[O!H0]-[Nz1]=[C]"), std::string(""),
                         std::string("")),
         std::make_tuple(std::string("oxim/nitroso r"),
-                        std::string("[C!H0]-[N]=[O]"), std::string(""),
+                        std::string("[C!H0]-[Nz1]=[O]"), std::string(""),
                         std::string("")),
         std::make_tuple(std::string("oxim/nitroso via phenol f"),
                         std::string("[O!H0]-[N]=[C]-[C]=[C]-[C]=[OH0]"),
                         std::string(""), std::string("")),
         std::make_tuple(std::string("oxim/nitroso via phenol r"),
-                        std::string("[O!H0]-[c]=[c]-[c]=[c]-[N]=[OH0]"),
+                        std::string("[O!H0]-[c]=,:[c][c]=,:[c]-[N]=[OH0]"),
                         std::string(""), std::string("")),
         std::make_tuple(std::string("cyano/iso-cyanic acid f"),
                         std::string("[O!H0]-[C]#[N]"), std::string("=="),

--- a/Code/GraphMol/MolStandardize/TautomerCatalog/tautomerTransforms.v1.in
+++ b/Code/GraphMol/MolStandardize/TautomerCatalog/tautomerTransforms.v1.in
@@ -1,0 +1,145 @@
+//
+//  Copyright (C) 2021 Greg Landrum
+//
+//   @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
+//
+
+// ------------------------
+// Distributed with v2021.09 and previous versions
+namespace defaults {
+// Derived from the transforms in Sitzmann et al.
+// https://doi.org/10.1007/s10822-010-9346-4
+//	Name	SMARTS	Bonds	Charges
+const std::vector<
+    std::tuple<std::string, std::string, std::string, std::string>>
+    defaultTautomerTransformsv1{
+        std::make_tuple(std::string("1,3 (thio)keto/enol f"),
+                        std::string("[CX4!H0]-[C]=[O,S,Se,Te;X1]"),
+                        std::string(""), std::string("")),
+        std::make_tuple(std::string("1,3 (thio)keto/enol r"),
+                        std::string("[O,S,Se,Te;X2!H0]-[C]=[C]"),
+                        std::string(""), std::string("")),
+        std::make_tuple(
+            std::string("1,5 (thio)keto/enol f"),
+            std::string("[CX4,NX3;!H0]-[C]=[C][CH0]=[O,S,Se,Te;X1]"),
+            std::string(""), std::string("")),
+        std::make_tuple(std::string("1,5 (thio)keto/enol r"),
+                        std::string("[O,S,Se,Te;X2!H0]-[CH0]=[C]-[C]=[C,N]"),
+                        std::string(""), std::string("")),
+        std::make_tuple(std::string("aliphatic imine f"),
+                        std::string("[CX4!H0]-[C]=[NX2]"), std::string(""),
+                        std::string("")),
+        std::make_tuple(std::string("aliphatic imine r"),
+                        std::string("[NX3!H0]-[C]=[CX3]"), std::string(""),
+                        std::string("")),
+        std::make_tuple(std::string("special imine f"),
+                        std::string("[N!H0]-[C]=[CX3R0]"), std::string(""),
+                        std::string("")),
+        std::make_tuple(std::string("special imine r"),
+                        std::string("[CX4!H0]-[c]=[n]"), std::string(""),
+                        std::string("")),
+        std::make_tuple(std::string("1,3 aromatic heteroatom H shift f"),
+                        std::string("[#7+0!H0]-[#6R1]=[O,#7X2+0]"),
+                        std::string(""), std::string("")),
+        std::make_tuple(std::string("1,3 aromatic heteroatom H shift "),
+                        std::string("[O,#7+0;!H0]-[#6R1]=[#7+0X2]"),
+                        std::string(""), std::string("")),
+        std::make_tuple(
+            std::string("1,3 heteroatom H shift"),
+            std::string(
+                "[#7+0,S,O,Se,Te;!H0]-[#7X2,#6,#15]=[#7+0,#16,#8,Se,Te]"),
+            std::string(""), std::string("")),
+        std::make_tuple(
+            std::string("1,5 aromatic heteroatom H shift"),
+            std::string(
+                "[#7+0,#16,#8;!H0]-[#6,#7]=[#6]-[#6,#7]=[#7+0,#16,#8;H0]"),
+            std::string(""), std::string("")),
+        std::make_tuple(std::string("1,5 aromatic heteroatom H shift "),
+                        std::string("[#7+0,#16,#8,Se,Te;!H0]-[#6,nX2]=[#6,nX2]-"
+                                    "[#6,#7X2]=[#7X2+0,S,O,Se,Te]"),
+                        std::string(""), std::string("")),
+        std::make_tuple(std::string("1,5 aromatic heteroatom H shift r"),
+                        std::string("[#7+0,S,O,Se,Te;!H0]-[#6,#7X2]=[#6,nX2]-[#"
+                                    "6,nX2]=[#7+0,#16,#8,Se,Te]"),
+                        std::string(""), std::string("")),
+        std::make_tuple(
+            std::string("1,7 aromatic heteroatom H shift f"),
+            std::string("[#7+0,#8,#16,Se,Te;!H0]-[#6,#7X2]=[#6,#"
+                        "7X2]-[#6,#7X2]=[#6]-[#6,#7X2]=[#7X2+0,S,O,Se,Te,CX3]"),
+            std::string(""), std::string("")),
+        std::make_tuple(
+            std::string("1,7 aromatic heteroatom H shift r"),
+            std::string("[#7+0,S,O,Se,Te,CX4;!H0]-[#6,#7X2]=[#6]-[#"
+                        "6,#7X2]=[#6,#7X2]-[#6,#7X2]=[NX2,S,O,Se,Te]"),
+            std::string(""), std::string("")),
+        std::make_tuple(
+            std::string("1,9 aromatic heteroatom H shift f"),
+            std::string("[#7+0,O;!H0]-[#6,#7X2]=[#6,#7X2]-[#6,#7X2]"
+                        "=[#6,#7X2]-[#6,#7X2]=[#6,#7X2]-[#6,#7X2]=[#7+0,O]"),
+            std::string(""), std::string("")),
+        std::make_tuple(std::string("1,11 aromatic heteroatom H shift f"),
+                        std::string("[#7+0,O;!H0]-[#6,nX2]=[#6,nX2]-[#6,nX2]=[#"
+                                    "6,nX2]-[#6,nX2]=[#6,nX2]-[#6,nX2]=[#6,nX2]"
+                                    "-[#6,nX2]=[#7X2+0,O]"),
+                        std::string(""), std::string("")),
+        std::make_tuple(
+            std::string("furanone f"),
+            std::string("[O,S,N;!H0]-[#6r5]=[#6X3r5;$([#6]([#6r5])=[#6r5])]"),
+            std::string(""), std::string("")),
+        std::make_tuple(
+            std::string("furanone r"),
+            std::string("[#6r5!H0;$([#6]([#6r5])[#6r5])]-[#6r5]=[O,S,N]"),
+            std::string(""), std::string("")),
+        std::make_tuple(std::string("keten/ynol f"),
+                        std::string("[C!H0]=[C]=[O,S,Se,Te;X1]"),
+                        std::string("#-"), std::string("")),
+        std::make_tuple(std::string("keten/ynol r"),
+                        std::string("[O,S,Se,Te;!H0X2]-[C]#[C]"),
+                        std::string("=="), std::string("")),
+        std::make_tuple(std::string("ionic nitro/aci-nitro f"),
+                        std::string("[C!H0]-[N+;$([N][O-])]=[O]"),
+                        std::string(""), std::string("")),
+        std::make_tuple(std::string("ionic nitro/aci-nitro r"),
+                        std::string("[O!H0]-[N+;$([N][O-])]=[C]"),
+                        std::string(""), std::string("")),
+        std::make_tuple(std::string("oxim/nitroso f"),
+                        std::string("[O!H0]-[N]=[C]"), std::string(""),
+                        std::string("")),
+        std::make_tuple(std::string("oxim/nitroso r"),
+                        std::string("[C!H0]-[N]=[O]"), std::string(""),
+                        std::string("")),
+        std::make_tuple(std::string("oxim/nitroso via phenol f"),
+                        std::string("[O!H0]-[N]=[C]-[C]=[C]-[C]=[OH0]"),
+                        std::string(""), std::string("")),
+        std::make_tuple(std::string("oxim/nitroso via phenol r"),
+                        std::string("[O!H0]-[c]=[c]-[c]=[c]-[N]=[OH0]"),
+                        std::string(""), std::string("")),
+        std::make_tuple(std::string("cyano/iso-cyanic acid f"),
+                        std::string("[O!H0]-[C]#[N]"), std::string("=="),
+                        std::string("")),
+        std::make_tuple(std::string("cyano/iso-cyanic acid r"),
+                        std::string("[N!H0]=[C]=[O]"), std::string("#-"),
+                        std::string("")),
+        std::make_tuple(std::string("formamidinesulfinic acid f"),
+                        std::string("[O,N;!H0]-[C]=[S,Se,Te;v6]=[O]"),
+                        std::string("=--"), std::string("")),
+        std::make_tuple(std::string("formamidinesulfinic acid r"),
+                        std::string("[O!H0]-[S,Se,Te;v4]-[C]=[O,N]"),
+                        std::string("==-"), std::string("")),
+        std::make_tuple(std::string("isocyanide f"),
+                        std::string("[C-0!H0]#[N+0]"), std::string("#"),
+                        std::string("-+")),
+        std::make_tuple(std::string("isocyanide r"),
+                        std::string("[N+!H0]#[C-]"), std::string("#"),
+                        std::string("-+")),
+        std::make_tuple(std::string("phosphonic acid f"),
+                        std::string("[OH]-[PH0]"), std::string("="),
+                        std::string("")),
+        std::make_tuple(std::string("phosphonic acid r"),
+                        std::string("[PH]=[O]"), std::string("-"),
+                        std::string(""))};
+}  // namespace defaults

--- a/Code/GraphMol/MolStandardize/Wrap/Tautomer.cpp
+++ b/Code/GraphMol/MolStandardize/Wrap/Tautomer.cpp
@@ -478,6 +478,10 @@ struct tautomer_wrapper {
         .def_readonly(
             "tautomerScoreVersion",
             MolStandardize::TautomerScoringFunctions::tautomerScoringVersion);
+    python::def("GetV1TautomerEnumerator",
+                MolStandardize::getV1TautomerEnumerator,
+                "return a TautomerEnumerator using v1 of the enumeration rules",
+                python::return_value_policy<python::manage_new_object>());
   }
 };
 

--- a/Code/GraphMol/MolStandardize/Wrap/testMolStandardize.py
+++ b/Code/GraphMol/MolStandardize/Wrap/testMolStandardize.py
@@ -365,7 +365,7 @@ chlorine	[Cl]
 
     enumerator = rdMolStandardize.TautomerEnumerator()
     res68 = enumerator.Enumerate(m68)
-    self.assertEqual(len(res68), 292)
+    self.assertEqual(len(res68), 252)
     self.assertEqual(len(res68.tautomers), len(res68))
     self.assertEqual(res68.status, rdMolStandardize.TautomerEnumeratorStatus.MaxTransformsReached)
 
@@ -550,9 +550,9 @@ chlorine	[Cl]
     res68 = enumerator.Enumerate(m68)
     # either the enumeration completed
     # or it ran very slowly and was canceled due to timeout
-    hasReachedTimeout = (len(res68.tautomers) < 375
+    hasReachedTimeout = (len(res68.tautomers) < 295
                          and res68.status == rdMolStandardize.TautomerEnumeratorStatus.Canceled)
-    hasCompleted = (len(res68.tautomers) == 375
+    hasCompleted = (len(res68.tautomers) == 295
                     and res68.status == rdMolStandardize.TautomerEnumeratorStatus.Completed)
     if hasReachedTimeout:
       print("Enumeration was canceled due to timeout (10 s)", file=sys.stderr)

--- a/Code/GraphMol/MolStandardize/Wrap/testMolStandardize.py
+++ b/Code/GraphMol/MolStandardize/Wrap/testMolStandardize.py
@@ -369,6 +369,12 @@ chlorine	[Cl]
     self.assertEqual(len(res68.tautomers), len(res68))
     self.assertEqual(res68.status, rdMolStandardize.TautomerEnumeratorStatus.MaxTransformsReached)
 
+    enumerator = rdMolStandardize.GetV1TautomerEnumerator()
+    res68 = enumerator.Enumerate(m68)
+    self.assertEqual(len(res68), 292)
+    self.assertEqual(len(res68.tautomers), len(res68))
+    self.assertEqual(res68.status, rdMolStandardize.TautomerEnumeratorStatus.MaxTransformsReached)
+
     params = rdMolStandardize.CleanupParameters()
     params.maxTautomers = 50
     enumerator = rdMolStandardize.TautomerEnumerator(params)

--- a/Code/GraphMol/MolStandardize/testTautomer.cpp
+++ b/Code/GraphMol/MolStandardize/testTautomer.cpp
@@ -384,6 +384,13 @@ void testEnumeratorParams() {
                 TautomerEnumeratorStatus::MaxTransformsReached);
     TEST_ASSERT(res68.size() == 252);
   }
+  {  // test v1 of the tautomerization parameters
+    std::unique_ptr<TautomerEnumerator> te(getV1TautomerEnumerator());
+    TautomerEnumeratorResult res68 = te->enumerate(*m68);
+    TEST_ASSERT(res68.status() ==
+                TautomerEnumeratorStatus::MaxTransformsReached);
+    TEST_ASSERT(res68.size() == 292);
+  }
   {
     CleanupParameters params;
     params.maxTautomers = 50;

--- a/Code/GraphMol/MolStandardize/testTautomer.cpp
+++ b/Code/GraphMol/MolStandardize/testTautomer.cpp
@@ -380,9 +380,9 @@ void testEnumeratorParams() {
   {
     TautomerEnumerator te;
     TautomerEnumeratorResult res68 = te.enumerate(*m68);
-    TEST_ASSERT(res68.size() == 292);
     TEST_ASSERT(res68.status() ==
                 TautomerEnumeratorStatus::MaxTransformsReached);
+    TEST_ASSERT(res68.size() == 252);
   }
   {
     CleanupParameters params;
@@ -595,12 +595,13 @@ void testEnumeratorCallback() {
     TautomerEnumerator te(params);
     te.setCallback(new MyTautomerEnumeratorCallback(10000.0));
     TautomerEnumeratorResult res68 = te.enumerate(*m68);
+    std::cerr << res68.size() << std::endl;
     // either the enumeration completed
     // or it ran very slowly and was canceled due to timeout
     bool hasReachedTimeout =
-        (res68.size() < 375 &&
+        (res68.size() < 295 &&
          res68.status() == TautomerEnumeratorStatus::Canceled);
-    bool hasCompleted = (res68.size() == 375 &&
+    bool hasCompleted = (res68.size() == 295 &&
                          res68.status() == TautomerEnumeratorStatus::Completed);
     if (hasReachedTimeout) {
       std::cerr << "Enumeration was canceled due to timeout (10 s)"
@@ -1240,7 +1241,7 @@ void testTautomerEnumeratorResult_const_iterator() {
   TautomerEnumerator te;
   auto res = te.enumerate(*mol);
   TEST_ASSERT(res.status() == TautomerEnumeratorStatus::Completed);
-  TEST_ASSERT(res.size() == 12);
+  TEST_ASSERT(res.size() == 6);
   auto it = res.begin();
   auto it2 = res.begin();
   // Test semantic requirements of bidirectional_iterator
@@ -1339,6 +1340,7 @@ void testGithub3430() {
                    [](const ROMOL_SPTR &m) {
                      return TautomerScoringFunctions::scoreTautomer(*m);
                    });
+
     std::sort(scores.begin(), scores.end(), std::greater<int>());
     TEST_ASSERT(scores[1] < scores[0]);
   }


### PR DESCRIPTION
The rules the tautomer enumeration code was using are derived from the ones in https://doi.org/10.1007/s10822-010-9346-4 but didn't use some of the cactvs SMARTS extensions that the rules in the paper use. Since the RDKit now supports most of those extensions (the one which is unsupported is `e`, but that only shows up in one rule), this updates the definitions.

For people who want to continue to use the old definitions: I added a new parameter object with those. This is easily accessible from C++ and Python.