### PR TITLE
Remove dead code

### DIFF
--- a/Code/GraphMol/TautomerQuery/TautomerQuery.cpp
+++ b/Code/GraphMol/TautomerQuery/TautomerQuery.cpp
@@ -122,10 +122,6 @@ TautomerQuery::TautomerQuery(std::vector<ROMOL_SPTR> tautomers,
 
 TautomerQuery *TautomerQuery::fromMol(
     const ROMol &query, const std::string &tautomerTransformFile) {
-  auto tautomerFile = !tautomerTransformFile.empty()
-                          ? tautomerTransformFile
-                          : std::string(getenv("RDBASE")) +
-                                "/Data/MolStandardize/tautomerTransforms.in";
   auto tautomerParams = std::unique_ptr<MolStandardize::TautomerCatalogParams>(
       new MolStandardize::TautomerCatalogParams(tautomerTransformFile));
   MolStandardize::TautomerEnumerator tautomerEnumerator(


### PR DESCRIPTION
I was wondering how could the tests pass given `Data/MolStandardize/tautomerTransforms.in` does not exist anymore, and then I realized that's because `tautomerFile` was defined but actually never used. So I thought we might as well get rid of it :-)