### PR TITLE
Refactor the memory management of the postgres cartridge cache module

### DIFF
--- a/Code/PgSQL/rdkit/cache.c
+++ b/Code/PgSQL/rdkit/cache.c
@@ -301,7 +301,7 @@ createCache(void *cache, struct MemoryContextData * ctx)
 
   if (cache != NULL) {
     ac = (ValueCache*)cache;
-    if (ac->ctx != ctx) {
+    if (ac->magickNumber != MAGICKNUMBER || ac->ctx != ctx) {
       elog(ERROR, "We can't use our approach with cache :(");
     }
   }
@@ -530,7 +530,7 @@ SearchValueCache(void *cache, struct MemoryContextData * ctx,
     ac->entries[0]
       = ac->head
       = ac->tail
-      = MemoryContextAllocZero(ctx, sizeof(ValueCacheEntry));
+      = MemoryContextAllocZero(ac->ctx, sizeof(ValueCacheEntry));
     ac->nentries = 1;
     makeEntry(ac, ac->head, a, kind);
     fetchData(ac, ac->head, detoasted, internal, sign);
@@ -580,7 +580,7 @@ SearchValueCache(void *cache, struct MemoryContextData * ctx,
      */
     entry
       = ac->entries[ac->nentries]
-      = MemoryContextAllocZero(ctx, sizeof(ValueCacheEntry));
+      = MemoryContextAllocZero(ac->ctx, sizeof(ValueCacheEntry));
 
     /* install first */
     entry->next = ac->head;

--- a/Code/PgSQL/rdkit/cache.c
+++ b/Code/PgSQL/rdkit/cache.c
@@ -386,30 +386,30 @@ fetchData(ValueCache *ac, ValueCacheEntry *entry,
   case MolKind:
     if (detoasted) {
       if (entry->detoasted.mol.value == NULL) {
-	Mol *detoastedMol;
-	
-	detoastedMol = DatumGetMolP(entry->toastedValue);
-	entry->detoasted.mol.value
-	  = MemoryContextAlloc( ac->ctx, VARSIZE(detoastedMol));
-	memcpy(entry->detoasted.mol.value, detoastedMol, VARSIZE(detoastedMol));
+        Mol *detoastedMol;
+
+        detoastedMol = DatumGetMolP(entry->toastedValue);
+        entry->detoasted.mol.value
+          = MemoryContextAlloc( ac->ctx, VARSIZE(detoastedMol));
+        memcpy(entry->detoasted.mol.value, detoastedMol, VARSIZE(detoastedMol));
       }
       *detoasted = entry->detoasted.mol.value;
     }
 
     if (internal) {
       if (entry->detoasted.mol.mol == NULL) {
-	fetchData(ac, entry, &_tmp, NULL, NULL);
-	entry->detoasted.mol.mol = constructROMol(entry->detoasted.mol.value);
+        fetchData(ac, entry, &_tmp, NULL, NULL);
+        entry->detoasted.mol.mol = constructROMol(entry->detoasted.mol.value);
       }
       *internal = entry->detoasted.mol.mol;
     }
 
     if (sign) {
       if (entry->detoasted.mol.sign == NULL) {
-	fetchData(ac, entry, NULL, &_tmp, NULL);
-	old = MemoryContextSwitchTo( ac->ctx );
-	entry->detoasted.mol.sign = makeMolSignature(entry->detoasted.mol.mol);
-	MemoryContextSwitchTo(old);
+        fetchData(ac, entry, NULL, &_tmp, NULL);
+        old = MemoryContextSwitchTo( ac->ctx );
+        entry->detoasted.mol.sign = makeMolSignature(entry->detoasted.mol.mol);
+        MemoryContextSwitchTo(old);
       }
       *sign = entry->detoasted.mol.sign;
     }
@@ -417,32 +417,32 @@ fetchData(ValueCache *ac, ValueCacheEntry *entry,
   case BfpKind:
     if (detoasted) {
       if (entry->detoasted.bfp.value == NULL) {
-	Bfp *detoastedFP;
-	
-	detoastedFP = DatumGetBfpP(entry->toastedValue);
-	entry->detoasted.bfp.value
-	  = MemoryContextAlloc( ac->ctx, VARSIZE(detoastedFP));
-	memcpy(entry->detoasted.bfp.value, detoastedFP, VARSIZE(detoastedFP));
+        Bfp *detoastedFP;
+
+        detoastedFP = DatumGetBfpP(entry->toastedValue);
+        entry->detoasted.bfp.value
+          = MemoryContextAlloc( ac->ctx, VARSIZE(detoastedFP));
+        memcpy(entry->detoasted.bfp.value, detoastedFP, VARSIZE(detoastedFP));
       }
       *detoasted = entry->detoasted.bfp.value;
     }
 
     if (internal) {
       if (entry->detoasted.bfp.fp == NULL) {
-	fetchData(ac, entry, &_tmp, NULL, NULL);
-	entry->detoasted.bfp.fp
-	  = constructCBfp(entry->detoasted.bfp.value);
+        fetchData(ac, entry, &_tmp, NULL, NULL);
+        entry->detoasted.bfp.fp
+          = constructCBfp(entry->detoasted.bfp.value);
       }
       *internal = entry->detoasted.bfp.fp;
     }
 
     if (sign) {
       if (entry->detoasted.bfp.sign == NULL) {
-	fetchData(ac, entry, NULL, &_tmp, NULL);
-	old = MemoryContextSwitchTo( ac->ctx );
-	entry->detoasted.bfp.sign
-	  = makeBfpSignature(entry->detoasted.bfp.fp);
-	MemoryContextSwitchTo(old);
+        fetchData(ac, entry, NULL, &_tmp, NULL);
+        old = MemoryContextSwitchTo( ac->ctx );
+        entry->detoasted.bfp.sign
+          = makeBfpSignature(entry->detoasted.bfp.fp);
+        MemoryContextSwitchTo(old);
       }
       *sign = entry->detoasted.bfp.sign;
     }
@@ -450,32 +450,32 @@ fetchData(ValueCache *ac, ValueCacheEntry *entry,
   case SfpKind:
     if (detoasted) { 
       if (entry->detoasted.sfp.value == NULL) {
-	Sfp *detoastedFP;
-	
-	detoastedFP = DatumGetSfpP(entry->toastedValue);
-	entry->detoasted.sfp.value
-	  = MemoryContextAlloc( ac->ctx, VARSIZE(detoastedFP));
-	memcpy(entry->detoasted.sfp.value, detoastedFP, VARSIZE(detoastedFP));
+        Sfp *detoastedFP;
+
+        detoastedFP = DatumGetSfpP(entry->toastedValue);
+        entry->detoasted.sfp.value
+          = MemoryContextAlloc( ac->ctx, VARSIZE(detoastedFP));
+        memcpy(entry->detoasted.sfp.value, detoastedFP, VARSIZE(detoastedFP));
       }
       *detoasted = entry->detoasted.sfp.value;
     }
 
     if (internal) {
       if (entry->detoasted.sfp.fp == NULL) {
-	fetchData(ac, entry, &_tmp, NULL, NULL);
-	entry->detoasted.sfp.fp
-	  = constructCSfp(entry->detoasted.sfp.value);
+        fetchData(ac, entry, &_tmp, NULL, NULL);
+        entry->detoasted.sfp.fp
+          = constructCSfp(entry->detoasted.sfp.value);
       }
       *internal = entry->detoasted.sfp.fp;
     }
 
     if (sign) {
       if (entry->detoasted.sfp.sign == NULL) {
-	fetchData(ac, entry, NULL, &_tmp, NULL);
-	old = MemoryContextSwitchTo( ac->ctx );
-	entry->detoasted.sfp.sign
-	  = makeSfpSignature(entry->detoasted.sfp.fp, NUMBITS);
-	MemoryContextSwitchTo(old);
+        fetchData(ac, entry, NULL, &_tmp, NULL);
+        old = MemoryContextSwitchTo( ac->ctx );
+        entry->detoasted.sfp.sign
+          = makeSfpSignature(entry->detoasted.sfp.fp, NUMBITS);
+        MemoryContextSwitchTo(old);
       }
       *sign = entry->detoasted.sfp.sign;
     }
@@ -483,33 +483,33 @@ fetchData(ValueCache *ac, ValueCacheEntry *entry,
   case ReactionKind:
     if (detoasted) {
       if (entry->detoasted.reaction.value == NULL) {
-	Reaction *detoastedRxn;
-	
-	detoastedRxn = DatumGetReactionP(entry->toastedValue);
-	entry->detoasted.reaction.value
-	  = MemoryContextAlloc( ac->ctx, VARSIZE(detoastedRxn));
-	memcpy(entry->detoasted.reaction.value, detoastedRxn,
-	       VARSIZE(detoastedRxn));
+        Reaction *detoastedRxn;
+
+        detoastedRxn = DatumGetReactionP(entry->toastedValue);
+        entry->detoasted.reaction.value
+          = MemoryContextAlloc( ac->ctx, VARSIZE(detoastedRxn));
+        memcpy(entry->detoasted.reaction.value, detoastedRxn,
+                VARSIZE(detoastedRxn));
       }
       *detoasted = entry->detoasted.reaction.value;
     }
     
     if (internal) {
       if (entry->detoasted.reaction.rxn == NULL) {
-	fetchData(ac, entry, &_tmp, NULL, NULL);
-	entry->detoasted.reaction.rxn
-	  = constructChemReact(entry->detoasted.reaction.value);
+        fetchData(ac, entry, &_tmp, NULL, NULL);
+        entry->detoasted.reaction.rxn
+          = constructChemReact(entry->detoasted.reaction.value);
       }
       *internal = entry->detoasted.reaction.rxn;
     }
     
     if (sign) {
       if (entry->detoasted.reaction.sign == NULL) {
-	fetchData(ac, entry, NULL, &_tmp, NULL);
-	old = MemoryContextSwitchTo( ac->ctx );
-	entry->detoasted.reaction.sign
-	  = makeReactionSign(entry->detoasted.reaction.rxn);
-	MemoryContextSwitchTo(old);
+        fetchData(ac, entry, NULL, &_tmp, NULL);
+        old = MemoryContextSwitchTo( ac->ctx );
+        entry->detoasted.reaction.sign
+          = makeReactionSign(entry->detoasted.reaction.rxn);
+        MemoryContextSwitchTo(old);
       }
       *sign = entry->detoasted.reaction.sign;
     }

--- a/Code/PgSQL/rdkit/cache.c
+++ b/Code/PgSQL/rdkit/cache.c
@@ -286,6 +286,9 @@ cleanupRDKitCache(void * ptr)
       p->next = h->next;
       h = p->next;
     }
+
+    /* the target context was cleared, exit */
+    break;
   }
 }
 

--- a/Code/PgSQL/rdkit/cache.h
+++ b/Code/PgSQL/rdkit/cache.h
@@ -39,24 +39,25 @@ extern "C" {
 #endif
 
 /*
- *  Cache subsystem. Molecules and fingerprints I/O is extremely expensive.
+ * Cache subsystem. Molecules and fingerprints I/O is extremely expensive.
  *
  * This module provides support for caching the toasted data values that
  * functions receive as argument, together with their detoasted,
- * deserialized, or indexed representations. This may help saving the time
+ * deserialized, or signature representations. This may help saving the time
  * that would be otherwise required to some queries to process the same
  * argument values multiple times (for example repeatedly unpickling the
  * same RDKit molecule).
  * 
  * This cache mechanism also provides the functions code with a high level
- * API that encapsulates the details of the conversion between the different
- * representations for the supported value types.
+ * API that encapsulates the details of the conversion from the toasted
+ * PostgreSQL Datum and the different representations of the supported
+ * value types.
  * 
- * A cache instance is associated to a memory context where the
+ * A cache instance is associated with a memory context where the
  * cached values are allocated, and it's therefore automatically cleared
  * when the same context is reset or destroyed. For this reason the client
- * code doesn't usually create/use this cache within the "current" memory
- * context, but rather in the longer-living context that is made available
+ * code doesn't usually create/use this cache with the "current" memory
+ * context, but rather with the longer-living context that is available
  * to the function as fcinfo->flinfo->fn_mcxt.
  */
 

--- a/Code/PgSQL/rdkit/cache.h
+++ b/Code/PgSQL/rdkit/cache.h
@@ -40,7 +40,26 @@ extern "C" {
 
 /*
  *  Cache subsystem. Molecules and fingerprints I/O is extremely expensive.
+ *
+ * This module provides support for caching the toasted data values that
+ * functions receive as argument, together with their detoasted,
+ * deserialized, or indexed representations. This may help saving the time
+ * that would be otherwise required to some queries to process the same
+ * argument values multiple times (for example repeatedly unpickling the
+ * same RDKit molecule).
+ * 
+ * This cache mechanism also provides the functions code with a high level
+ * API that encapsulates the details of the conversion between the different
+ * representations for the supported value types.
+ * 
+ * A cache instance is associated to a memory context where the
+ * cached values are allocated, and it's therefore automatically cleared
+ * when the same context is reset or destroyed. For this reason the client
+ * code doesn't usually create/use this cache within the "current" memory
+ * context, but rather in the longer-living context that is made available
+ * to the function as fcinfo->flinfo->fn_mcxt.
  */
+
 struct MemoryContextData; /* forward declaration to prevent conflicts with C++
                            */
 


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
The proposed changes mainly replace the existing mechanism for deallocating the cache resources with a similar functionality based on the memory context callback api (available in postgres 9.5 and later). Also, the allocation of the cache holder instances, previously using direct calls to malloc/free, is now delegated to the associated memory context.

#### Any other comments?
So far, I only tested this with postgres 14.1, and verified that the regression tests were unaffected in my development environment. Running some queries under valgrind didn't report any leaks (some memory is reported to be in use at exit, but I think this might be in general expected).
