### PR TITLE
Fix GenericGroups installation typos

### DIFF
--- a/Code/GraphMol/GenericGroups/CMakeLists.txt
+++ b/Code/GraphMol/GenericGroups/CMakeLists.txt
@@ -4,6 +4,6 @@ rdkit_library(GenericGroups
               LINK_LIBRARIES GraphMol RDGeneral)
 target_compile_definitions(GenericGroups PRIVATE RDKIT_GENERICGROUPS_BUILD)
 
-rdkit_headers(GenericsGroups.h DEST GraphMol/GenericGroups)
+rdkit_headers(GenericGroups.h DEST GraphMol/GenericGroups)
 
 rdkit_catch_test(testGenericGroups ../catch_main.cpp generic_tests.cpp LINK_LIBRARIES GenericGroups FileParsers SmilesParse SubstructMatch)

--- a/Code/GraphMol/Substruct/CMakeLists.txt
+++ b/Code/GraphMol/Substruct/CMakeLists.txt
@@ -5,7 +5,7 @@ rdkit_library(SubstructMatch
 target_compile_definitions(SubstructMatch PRIVATE RDKIT_SUBSTRUCTMATCH_BUILD)
 
 rdkit_headers(SubstructMatch.h
-              SubstructUtils.h Generics.h DEST GraphMol/Substruct)
+              SubstructUtils.h DEST GraphMol/Substruct)
 
 rdkit_test(testSubstructMatch test1.cpp LINK_LIBRARIES FileParsers SmilesParse SubstructMatch)
 


### PR DESCRIPTION
This fixes a couple of typos found by @ptosco in the CMakeLists.txt files associated with GenericGroups that were added in #4673.