### PR TITLE
Fixes crashing bug with finalSubstructChecks

### DIFF
--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -6097,10 +6097,18 @@ M  END
 
     ps.setExtraFinalCheck(accept_none)
     self.assertEqual(len(m.GetSubstructMatches(p, ps)), 0)
+    self.assertEqual(len(m.GetSubstructMatch(p, ps)), 0)
+    self.assertFalse(m.HasSubstructMatch(p, ps))
+
     ps.setExtraFinalCheck(accept_all)
     self.assertEqual(len(m.GetSubstructMatches(p, ps)), 2)
+    self.assertEqual(len(m.GetSubstructMatch(p, ps)), 3)
+    self.assertTrue(m.HasSubstructMatch(p, ps))
+
     ps.setExtraFinalCheck(accept_large)
     self.assertEqual(len(m.GetSubstructMatches(p, ps)), 1)
+    self.assertEqual(len(m.GetSubstructMatch(p, ps)), 3)
+    self.assertTrue(m.HasSubstructMatch(p, ps))
 
   def testMostSubstitutedCoreMatch(self):
     core = Chem.MolFromSmarts("[*:1]c1cc([*:2])ccc1[*:3]")

--- a/Code/GraphMol/Wrap/substructmethods.h
+++ b/Code/GraphMol/Wrap/substructmethods.h
@@ -67,26 +67,36 @@ PyObject *GetSubstructMatches(T1 &mol, T2 &query, bool uniquify = true,
 }
 
 template <typename T1, typename T2>
+void pySubstructHelper(T1 &mol, T2 &query,
+                       const SubstructMatchParameters &params,
+                       std::vector<MatchVectType> &matches) {
+  if (params.extraFinalCheck) {
+    // NOTE: Because we are going into/out of python here, we can't
+    // run with NOGIL
+    matches = SubstructMatch(mol, query, params);
+  } else {
+    NOGIL gil;
+    matches = SubstructMatch(mol, query, params);
+  }
+}
+
+template <typename T1, typename T2>
 bool helpHasSubstructMatch(T1 &mol, T2 &query,
                            const SubstructMatchParameters &params) {
-  NOGIL gil;
-  std::vector<MatchVectType> res;
   SubstructMatchParameters ps = params;
   ps.maxMatches = 1;
-  res = SubstructMatch(mol, query, ps);
-  return res.size() != 0;
+  std::vector<MatchVectType> matches;
+  pySubstructHelper(mol, query, params, matches);
+  return matches.size() != 0;
 }
 
 template <typename T1, typename T2>
 PyObject *helpGetSubstructMatch(T1 &mol, T2 &query,
                                 const SubstructMatchParameters &params) {
+  SubstructMatchParameters ps = params;
+  ps.maxMatches = 1;
   std::vector<MatchVectType> matches;
-  {
-    NOGIL gil;
-    SubstructMatchParameters ps = params;
-    ps.maxMatches = 1;
-    matches = SubstructMatch(mol, query, ps);
-  }
+  pySubstructHelper(mol, query, params, matches);
   MatchVectType match;
   if (matches.size()) match = matches[0];
   return convertMatches(match);
@@ -96,14 +106,7 @@ template <typename T1, typename T2>
 PyObject *helpGetSubstructMatches(T1 &mol, T2 &query,
                                   const SubstructMatchParameters &params) {
   std::vector<MatchVectType> matches;
-  if (params.extraFinalCheck) {
-    // NOTE: Because we are going into/out of python here, we can't
-    // run with NOGIL
-    matches = SubstructMatch(mol, query, params);
-  } else {
-    NOGIL gil;
-    matches = SubstructMatch(mol, query, params);
-  }
+  pySubstructHelper(mol, query, params, matches);
   PyObject *res = PyTuple_New(matches.size());
   for (size_t idx = 0; idx < matches.size(); idx++) {
     PyTuple_SetItem(res, idx, convertMatches(matches[idx]));


### PR DESCRIPTION
`mol.GetSubstructMatch()` and `mol.HasSubstructMatch()` were running in NOGIL mode when `extraFinalCheck` (which requires a callback into Python) was set. This led to crashes.

This PR fixes that and does a minor bit of refactoring so that the three substructmatch helper functions all use another helper to actually do the substruct search. This way any future tweaks only have to happen in one place.

This also adds an additional test to the GenericGroups code, just to be sure that they are compatible with extraFinalChecks.