### PR TITLE
Fixes #4789

### DIFF
--- a/Code/GraphMol/AdjustQuery.cpp
+++ b/Code/GraphMol/AdjustQuery.cpp
@@ -61,7 +61,7 @@ unsigned int parseWhichString(const std::string &txt) {
   }
   return res;
 }
-
+constexpr const char *conjugatedOrAromatic = "_conjugatedOrAromatic";
 void adjustConjugatedFiveRings(RWMol &mol) {
   /*
    The idea here is to allow conjugated five-rings to match either aromatic or
@@ -100,6 +100,8 @@ void adjustConjugatedFiveRings(RWMol &mol) {
     qb.setQuery(makeSingleOrDoubleOrAromaticBondQuery());
     for (auto bi : ring) {
       const auto bond = mol.getBondWithIdx(bi);
+      bond->getBeginAtom()->setProp(conjugatedOrAromatic, 1, true);
+      bond->getEndAtom()->setProp(conjugatedOrAromatic, 1, true);
       if (std::find(bondTypesToModify.begin(), bondTypesToModify.end(),
                     bond->getBondType()) != bondTypesToModify.end()) {
         if (bond->hasQuery()) {
@@ -112,6 +114,10 @@ void adjustConjugatedFiveRings(RWMol &mol) {
       }
     }
   }
+}
+
+bool isAromaticOrConjugated(const Atom &atom) {
+  return atom.getIsAromatic() || atom.hasProp(conjugatedOrAromatic);
 }
 void adjustSingleBondsFromAromaticAtoms(RWMol &mol, bool toDegreeOneNeighbors,
                                         bool betweenAromaticAtoms) {
@@ -134,16 +140,16 @@ void adjustSingleBondsFromAromaticAtoms(RWMol &mol, bool toDegreeOneNeighbors,
   for (auto bond : mol.bonds()) {
     const auto bAt = bond->getBeginAtom();
     const auto eAt = bond->getEndAtom();
-    if (!bond->hasQuery() && bond->getBondType() == Bond::BondType::SINGLE &&
-        (bAt->getIsAromatic() || eAt->getIsAromatic())) {
-      if (toDegreeOneNeighbors &&
-          (bAt->getIsAromatic() ^ eAt->getIsAromatic())) {
-        if ((bAt->getIsAromatic() && eAt->getDegree() == 1) ||
-            (eAt->getIsAromatic() && bAt->getDegree() == 1)) {
+    if (!bond->hasQuery() && bond->getBondType() == Bond::BondType::SINGLE) {
+      auto bAtIsAromatic = isAromaticOrConjugated(*bAt);
+      auto eAtIsAromatic = isAromaticOrConjugated(*eAt);
+
+      if (toDegreeOneNeighbors && (bAtIsAromatic ^ eAtIsAromatic)) {
+        if ((bAtIsAromatic && eAt->getDegree() == 1) ||
+            (eAtIsAromatic && bAt->getDegree() == 1)) {
           mol.replaceBond(bond->getIdx(), &qb);
         }
-      } else if (betweenAromaticAtoms && bAt->getIsAromatic() &&
-                 eAt->getIsAromatic()) {
+      } else if (betweenAromaticAtoms && bAtIsAromatic && eAtIsAromatic) {
         mol.replaceBond(bond->getIdx(), &qb);
       }
     }
@@ -522,6 +528,11 @@ void adjustQueryProperties(RWMol &mol, const AdjustQueryParameters *inParams) {
     adjustSingleBondsFromAromaticAtoms(
         mol, params.adjustSingleBondsToDegreeOneNeighbors,
         params.adjustSingleBondsBetweenAromaticAtoms);
+  }
+  if (params.setMDLFiveRingAromaticity) {
+    for (auto atom : mol.atoms()) {
+      atom->clearProp(conjugatedOrAromatic);
+    }
   }
 }
 }  // namespace MolOps

--- a/Code/GraphMol/MolOps.h
+++ b/Code/GraphMol/MolOps.h
@@ -362,12 +362,12 @@ struct RDKIT_GRAPHMOL_EXPORT AdjustQueryParameters {
                 software as documented in the Chemical Representation Guide */
 
   bool adjustSingleBondsToDegreeOneNeighbors =
-      false; /**<  sets single bonds between aromatic atoms and degree one
-                neighbors to SINGLE|AROMATIC */
+      false; /**<  sets single bonds between aromatic or conjugated atoms and
+                degree one neighbors to SINGLE|AROMATIC */
 
   bool adjustSingleBondsBetweenAromaticAtoms =
-      false; /**<  sets non-ring single bonds between two aromatic atoms to
-                SINGLE|AROMATIC */
+      false; /**<  sets non-ring single bonds between two aromatic or conjugated
+                atoms to SINGLE|AROMATIC */
   //! \brief returns an AdjustQueryParameters object with all adjustments
   //! disabled
   static AdjustQueryParameters noAdjustments() {

--- a/Code/GraphMol/Wrap/MolOps.cpp
+++ b/Code/GraphMol/Wrap/MolOps.cpp
@@ -2635,13 +2635,13 @@ A note on the flags controlling which atoms/bonds are modified:
         .def_readwrite("adjustSingleBondsToDegreeOneNeighbors",
                        &MolOps::AdjustQueryParameters::
                            adjustSingleBondsToDegreeOneNeighbors,
-                       "set single bonds bewteen aromatic atoms and degree-one "
-                       "neighbors to SINGLE|AROMATIC")
+                       "set single bonds bewteen aromatic or conjugated atoms "
+                       "and degree-one neighbors to SINGLE|AROMATIC")
         .def_readwrite("adjustSingleBondsBetweenAromaticAtoms",
                        &MolOps::AdjustQueryParameters::
                            adjustSingleBondsBetweenAromaticAtoms,
-                       "sets non-ring single bonds between two aromatic atoms "
-                       "to SINGLE|AROMATIC")
+                       "sets non-ring single bonds between two aromatic or "
+                       "conjugated atoms to SINGLE|AROMATIC")
         .def("NoAdjustments", &MolOps::AdjustQueryParameters::noAdjustments,
              "Returns an AdjustQueryParameters object with all parameters set "
              "to false")

--- a/Code/GraphMol/catch_adjustquery.cpp
+++ b/Code/GraphMol/catch_adjustquery.cpp
@@ -785,3 +785,32 @@ TEST_CASE("other edges") {
     CHECK(!m->getAtomWithIdx(1)->hasQuery());
   }
 }
+
+TEST_CASE(
+    "Github #4789: AdjustQueryProperties() is inconsistent when "
+    "adjustConjugatedFiveRings is set") {
+  SECTION("degree one neighbors") {
+    auto mol = "C1=CC=CC1C"_smiles;
+    REQUIRE(mol);
+    MolOps::AdjustQueryParameters ps =
+        MolOps::AdjustQueryParameters::noAdjustments();
+    ps.adjustConjugatedFiveRings = true;
+    ps.adjustSingleBondsToDegreeOneNeighbors = true;
+    MolOps::adjustQueryProperties(*mol, &ps);
+    CHECK(MolToSmarts(*mol) ==
+          "[#6]1-,=,:[#6]-,=,:[#6]-,=,:[#6]-,=,:[#6]-,=,:1[#6]");
+  }
+  SECTION("between aromatic atoms") {
+    auto mol = "C1=CC=CC1C1=CC=CC1"_smiles;
+    REQUIRE(mol);
+    MolOps::AdjustQueryParameters ps =
+        MolOps::AdjustQueryParameters::noAdjustments();
+    ps.adjustConjugatedFiveRings = true;
+    ps.adjustSingleBondsBetweenAromaticAtoms = true;
+    MolOps::adjustQueryProperties(*mol, &ps);
+    // clang-format off
+    CHECK(MolToSmarts(*mol) ==
+          "[#6]1-,=,:[#6]-,=,:[#6]-,=,:[#6]-,=,:[#6]-,=,:1[#6]1-,=,:[#6]-,=,:[#6]-,=,:[#6]-,=,:[#6]-,=,:1");
+    // clang-format on
+  }
+}


### PR DESCRIPTION
The fix is straightforward: mark the atoms involved in bonds which are modified in 5-membered rings and then look for those tags when figuring out whether or not to adjust single bonds later.

