### PR TITLE
Fix `_moltoSVG` to avoid kekulization failure

### DIFF
--- a/rdkit/Chem/Draw/__init__.py
+++ b/rdkit/Chem/Draw/__init__.py
@@ -504,7 +504,8 @@ def _moltoSVG(mol, sz, highlights, legend, kekulize, drawOptions=None, **kwargs)
   d2d = rdMolDraw2D.MolDraw2DSVG(sz[0], sz[1])
   if drawOptions is not None:
     d2d.SetDrawOptions(drawOptions)
-
+  # we already prepared the molecule:
+  d2d.drawOptions().prepareMolsBeforeDrawing = False
   bondHighlights = kwargs.get('highlightBonds', None)
   if bondHighlights is not None:
     d2d.DrawMolecule(mc, legend=legend or "", highlightAtoms=highlights or [],


### PR DESCRIPTION
Fix `_moltoSVG` like the fix to `_moltoimg` by d2422dac6d7e79b0a12253fac0a44c02e03bd64c in #3034.

<!--
Thanks for contributing a pull request! 
-->
#### Reference Issue
Fixes #4792


