### PR TITLE
Fix similaritymaps

### DIFF
--- a/rdkit/Chem/Draw/SimilarityMaps.py
+++ b/rdkit/Chem/Draw/SimilarityMaps.py
@@ -183,8 +183,8 @@ def GetSimilarityMapFromWeights(mol, weights, colorMap=None, scale=-1, size=(250
         clrs = [tuple(x) for x in colorMap([0, 0.5, 1])]
       else:
         # assume it's a matplotlib colormap ID:
-        customCmap = cm.get_cmap(colorMap, 2)
-        clrs = [customCmap(0), (1, 1, 1), customCmap(1)]
+        customCmap = cm.get_cmap(colorMap, 3)
+        clrs = [customCmap(0), customCmap(1), customCmap(2)]
 
       ps.setColourMap(clrs)
 

--- a/rdkit/Chem/Draw/SimilarityMaps.py
+++ b/rdkit/Chem/Draw/SimilarityMaps.py
@@ -182,7 +182,7 @@ def GetSimilarityMapFromWeights(mol, weights, colorMap=None, scale=-1, size=(250
         # it's a matplotlib colormap:
         clrs = [tuple(x) for x in colorMap([0, 0.5, 1])]
       else:
-        # assume it's a matplotlib colormap scheme:
+        # assume it's a matplotlib colormap ID:
         customCmap = cm.get_cmap(colorMap, 2)
         clrs = [customCmap(0), (1, 1, 1), customCmap(1)]
 

--- a/rdkit/Chem/Draw/SimilarityMaps.py
+++ b/rdkit/Chem/Draw/SimilarityMaps.py
@@ -182,7 +182,7 @@ def GetSimilarityMapFromWeights(mol, weights, colorMap=None, scale=-1, size=(250
         # it's a matplotlib colormap:
         clrs = [tuple(x) for x in colorMap([0, 0.5, 1])]
       else:
-        # assume it's a matplotlib colormap ID:
+        # assume it's a matplotlib colormap ID
         customCmap = cm.get_cmap(colorMap, 3)
         clrs = [customCmap(0), customCmap(1), customCmap(2)]
 

--- a/rdkit/Chem/Draw/SimilarityMaps.py
+++ b/rdkit/Chem/Draw/SimilarityMaps.py
@@ -182,7 +182,10 @@ def GetSimilarityMapFromWeights(mol, weights, colorMap=None, scale=-1, size=(250
         # it's a matplotlib colormap:
         clrs = [tuple(x) for x in colorMap([0, 0.5, 1])]
       else:
-        clrs = [colorMap[0], colorMap[1], colorMap[2]]
+        # assume it's a matplotlib colormap scheme:
+        customCmap = cm.get_cmap(colorMap, 2)
+        clrs = [customCmap(0), (1, 1, 1), customCmap(1)]
+
       ps.setColourMap(clrs)
 
     Draw.ContourAndDrawGaussians(draw2d, locs, weights, sigmas, nContours=contourLines, params=ps)

--- a/rdkit/Chem/Draw/SimilarityMaps.py
+++ b/rdkit/Chem/Draw/SimilarityMaps.py
@@ -181,7 +181,7 @@ def GetSimilarityMapFromWeights(mol, weights, colorMap=None, scale=-1, size=(250
       if cm is not None and isinstance(colorMap, type(cm.Blues)):
         # it's a matplotlib colormap:
         clrs = [tuple(x) for x in colorMap([0, 0.5, 1])]
-      elif cm is not None and isinstance(colorMap, list):
+      elif isinstance(colorMap, list):
         # assume it's a passed in list of colors
         clrs = [colorMap[0], colorMap[1], colorMap[2]]
       else:

--- a/rdkit/Chem/Draw/SimilarityMaps.py
+++ b/rdkit/Chem/Draw/SimilarityMaps.py
@@ -181,6 +181,9 @@ def GetSimilarityMapFromWeights(mol, weights, colorMap=None, scale=-1, size=(250
       if cm is not None and isinstance(colorMap, type(cm.Blues)):
         # it's a matplotlib colormap:
         clrs = [tuple(x) for x in colorMap([0, 0.5, 1])]
+      elif cm is not None and isinstance(colorMap, list):
+        # assume it's a passed in list of colors
+        clrs = [colorMap[0], colorMap[1], colorMap[2]]
       else:
         # assume it's a matplotlib colormap ID
         customCmap = cm.get_cmap(colorMap, 3)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! 
-->
#### Reference Issue
<!-- Example: Fixes #4763 -->

My first commit to any project ever, so if I did something crazy, please let me know (and apologies!)

#### What does this implement/fix? Explain your changes.
This standardizes the input argument "colorMap" for GetSimilarityMapFromWeights. Currently, providing an argument for "draw2d" to GetSimilarityMapFromWeights changes the expected input of colorMap: If draw2d is not provided, a matplotlib colormap id (e.g., "coolwarm") is accepted as well as a LinearSegmentedColormap object. If draw2d is provided as an argument, however, the colormap id is no longer an acceptable input, and a LinearSegmentedColormap object can be passed in or a list of colors. This change modifies the behavior such that whether you pass the argument dra2d or not, the colormaps arguments expected shouldn't change.

fix summary: the "colorMap" argument from  GetSimilarityMapFromWeights now accepts a matplotlib colormap id (such as "coolwarm") whether the "draw2d" argument is provided or not.

#### Any other comments?
This does change the current behavior of the colorMap input besides allowing the matplotlib id to be specified; before, it allowed a list of colors to be passed in, but only when "draw2d" was not specified. I believe that was probably in error. This fix removes that option so that the coloMap argument is standardized, and accepts the same input whether draw2d is specified or not. I imagine this is okay, as any arbitrary color list can be converted into a matplotlib colormap before being passed into the colorMap argument if its desired, but I do worry about compatibility with and code currently written to circumvent the current input weirdness.
