### PR TITLE
Fixes #4785: aromatic bonds no longer set aromatic flags on atoms

### DIFF
--- a/Code/GraphMol/Atom.cpp
+++ b/Code/GraphMol/Atom.cpp
@@ -23,8 +23,7 @@
 
 namespace RDKit {
 
-namespace {
-bool isAtomAromatic(Atom &atom) {
+bool isAromaticAtom(const Atom &atom) {
   if (atom.getIsAromatic()) {
     return true;
   }
@@ -38,7 +37,6 @@ bool isAtomAromatic(Atom &atom) {
   }
   return false;
 }
-}  // namespace
 
 // Determine whether or not a molecule is to the left of Carbon
 bool isEarlyAtom(int atomicNum) {
@@ -242,7 +240,7 @@ int Atom::calcExplicitValence(bool strict) {
   if (d_atomicNum == 6 && chr > 0) {
     chr = -chr;
   }
-  if (accum > (dv + chr) && isAtomAromatic(*this)) {
+  if (accum > (dv + chr) && isAromaticAtom(*this)) {
     // this needs some explanation : if the atom is aromatic and
     // accum > (dv + chr) we assume that no hydrogen can be added
     // to this atom.  We set x = (v + chr) such that x is the
@@ -444,7 +442,7 @@ int Atom::calcImplicitValence(bool strict) {
   }
 
   // if we have an aromatic case treat it differently
-  if (isAtomAromatic(*this)) {
+  if (isAromaticAtom(*this)) {
     if (explicitPlusRadV <= (static_cast<int>(dv) + chg)) {
       res = dv + chg - explicitPlusRadV;
     } else {

--- a/Code/GraphMol/Atom.h
+++ b/Code/GraphMol/Atom.h
@@ -433,7 +433,10 @@ RDKIT_GRAPHMOL_EXPORT std::ostream &operator<<(std::ostream &target,
                                                const RDKit::Atom &at);
 
 namespace RDKit {
-//! returns whether or not the atom is to the left of C
+//! returns true if the atom is to the left of C
 RDKIT_GRAPHMOL_EXPORT bool isEarlyAtom(int atomicNum);
+//! returns true if the atom is aromatic or has an aromatic bond
+RDKIT_GRAPHMOL_EXPORT bool isAromaticAtom(const Atom &atom);
+
 }  // namespace RDKit
 #endif

--- a/Code/GraphMol/FileParsers/MolFileParser.cpp
+++ b/Code/GraphMol/FileParsers/MolFileParser.cpp
@@ -1792,8 +1792,6 @@ void ParseMolBlockBonds(std::istream *inStream, unsigned int &line,
     // atoms
     if (bond->getBondType() == Bond::AROMATIC) {
       bond->setIsAromatic(true);
-      mol->getAtomWithIdx(bond->getBeginAtomIdx())->setIsAromatic(true);
-      mol->getAtomWithIdx(bond->getEndAtomIdx())->setIsAromatic(true);
     }
     // if the bond might have chirality info associated with it, set a flag:
     if (bond->getBondDir() != Bond::NONE &&

--- a/Code/GraphMol/FileParsers/MolFileParser.cpp
+++ b/Code/GraphMol/FileParsers/MolFileParser.cpp
@@ -2634,10 +2634,10 @@ void ParseV3000BondBlock(std::istream *inStream, unsigned int &line,
     bond->setBeginAtomIdx(mol->getAtomWithBookmark(a1Idx)->getIdx());
     bond->setEndAtomIdx(mol->getAtomWithBookmark(a2Idx)->getIdx());
     mol->addBond(bond, true);
-    if (bond->getIsAromatic()) {
-      mol->getAtomWithIdx(bond->getBeginAtomIdx())->setIsAromatic(true);
-      mol->getAtomWithIdx(bond->getEndAtomIdx())->setIsAromatic(true);
-    }
+    // if (bond->getIsAromatic()) {
+    //   mol->getAtomWithIdx(bond->getBeginAtomIdx())->setIsAromatic(true);
+    //   mol->getAtomWithIdx(bond->getEndAtomIdx())->setIsAromatic(true);
+    // }
     mol->setBondBookmark(bond, bondIdx);
 
     // set the stereoCare property on the bond if it's not set already and both

--- a/Code/GraphMol/FileParsers/MolFileParser.cpp
+++ b/Code/GraphMol/FileParsers/MolFileParser.cpp
@@ -2634,10 +2634,6 @@ void ParseV3000BondBlock(std::istream *inStream, unsigned int &line,
     bond->setBeginAtomIdx(mol->getAtomWithBookmark(a1Idx)->getIdx());
     bond->setEndAtomIdx(mol->getAtomWithBookmark(a2Idx)->getIdx());
     mol->addBond(bond, true);
-    // if (bond->getIsAromatic()) {
-    //   mol->getAtomWithIdx(bond->getBeginAtomIdx())->setIsAromatic(true);
-    //   mol->getAtomWithIdx(bond->getEndAtomIdx())->setIsAromatic(true);
-    // }
     mol->setBondBookmark(bond, bondIdx);
 
     // set the stereoCare property on the bond if it's not set already and both

--- a/Code/GraphMol/FileParsers/file_parsers_catch.cpp
+++ b/Code/GraphMol/FileParsers/file_parsers_catch.cpp
@@ -4285,6 +4285,8 @@ M  V30 END CTAB
 M  END
 )CTAB"_ctab;
     REQUIRE(mol);
+    CHECK(mol->getAtomWithIdx(0)->getIsAromatic());
+    CHECK(mol->getBondWithIdx(0)->getIsAromatic());
   }
   SECTION("non-kekulizeable") {
     auto mol = R"CTAB(

--- a/Code/GraphMol/FileParsers/file_parsers_catch.cpp
+++ b/Code/GraphMol/FileParsers/file_parsers_catch.cpp
@@ -4314,4 +4314,47 @@ M  END
 )CTAB"_ctab;
     REQUIRE(!mol);
   }
+  SECTION("as reported1") {
+    auto mol = R"CTAB(
+  MJ201100                      
+
+  2  1  0  0  0  0  0  0  0  0999 V2000
+   -0.3538    0.6163    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -1.0668    0.2012    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+  1  2  4  0  0  1  0
+M  MRV SMA   1 [#6;a;a]
+M  MRV SMA   2 [#6;a;a]
+M  END)CTAB"_ctab;
+    REQUIRE(mol);
+  }
+  SECTION("as reported2") {
+    auto mol = R"CTAB(
+  MJ201100                      
+
+  2  1  0  0  0  0  0  0  0  0999 V2000
+   -0.3538    0.6163    0.0000 A   0  0  0  0  0  0  0  0  0  0  0  0
+   -1.0668    0.2012    0.0000 A   0  0  0  0  0  0  0  0  0  0  0  0
+  1  2  4  0  0  1  0
+M  END)CTAB"_ctab;
+    REQUIRE(mol);
+  }
+  SECTION("as reported3") {
+    auto mol = R"CTAB(
+     RDKit          2D
+
+  0  0  0  0  0  0  0  0  0  0999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 2 1 0 0 0
+M  V30 BEGIN ATOM
+M  V30 1 A -0.353800 0.616300 0.000000 0
+M  V30 2 A -1.066800 0.201200 0.000000 0
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 4 1 2 TOPO=1
+M  V30 END BOND
+M  V30 END CTAB
+M  END
+)CTAB"_ctab;
+    REQUIRE(mol);
+  }
 }

--- a/Code/GraphMol/FileParsers/file_parsers_catch.cpp
+++ b/Code/GraphMol/FileParsers/file_parsers_catch.cpp
@@ -4254,3 +4254,62 @@ M  END
     CHECK(mol1->hasProp(common_properties::molFileLinkNodes));
   }
 }
+
+TEST_CASE(
+    "Github #4785: MDL query with aromatic bond sets aromatic flag on atoms "
+    "even though they are not in an aromatic ring") {
+  SECTION("benzene") {
+    auto mol = R"CTAB(
+  Mrv2108 12102110572D          
+
+  0  0  0     0  0            999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 6 6 0 0 0
+M  V30 BEGIN ATOM
+M  V30 1 C 128.125 -103.585 0 0
+M  V30 2 C 126.7913 -104.355 0 0
+M  V30 3 C 126.7913 -105.895 0 0
+M  V30 4 C 128.125 -106.665 0 0
+M  V30 5 C 129.4587 -105.895 0 0
+M  V30 6 C 129.4587 -104.355 0 0
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 4 1 2
+M  V30 2 4 2 3
+M  V30 3 4 3 4
+M  V30 4 4 4 5
+M  V30 5 4 5 6
+M  V30 6 4 1 6
+M  V30 END BOND
+M  V30 END CTAB
+M  END
+)CTAB"_ctab;
+    REQUIRE(mol);
+  }
+  SECTION("non-kekulizeable") {
+    auto mol = R"CTAB(
+  Mrv2108 12102110572D          
+
+  0  0  0     0  0            999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 5 5 0 0 0
+M  V30 BEGIN ATOM
+M  V30 1 C 128.125 -103.585 0 0
+M  V30 2 C 126.7913 -104.355 0 0
+M  V30 3 C 126.7913 -105.895 0 0
+M  V30 4 C 128.125 -106.665 0 0
+M  V30 5 C 129.4587 -105.895 0 0
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 4 1 2
+M  V30 2 4 2 3
+M  V30 3 4 3 4
+M  V30 4 4 4 5
+M  V30 5 4 5 1
+M  V30 END BOND
+M  V30 END CTAB
+M  END
+)CTAB"_ctab;
+    REQUIRE(!mol);
+  }
+}

--- a/Code/GraphMol/Kekulize.cpp
+++ b/Code/GraphMol/Kekulize.cpp
@@ -622,7 +622,7 @@ void KekulizeFragment(RWMol &mol, const boost::dynamic_bitset<> &atomsToUse,
       }
     }
     for (auto atom : mol.atoms()) {
-      if (atomsToUse[atom->getIdx()] && isAromaticAtom(*atom)) {
+      if (atomsToUse[atom->getIdx()] && atom->getIsAromatic()) {
         // if we're doing the full molecule and there are aromatic atoms not in
         // a ring, throw an exception
         if (atomsToUse.all() && bondsToUse.all() &&

--- a/Code/GraphMol/Kekulize.cpp
+++ b/Code/GraphMol/Kekulize.cpp
@@ -72,8 +72,8 @@ void markDbondCands(RWMol &mol, const INT_VECT &allAtms,
 
   bool hasAromaticOrDummyAtom = false;
   for (int allAtm : allAtms) {
-    if (mol.getAtomWithIdx(allAtm)->getIsAromatic() ||
-        !mol.getAtomWithIdx(allAtm)->getAtomicNum()) {
+    if (!mol.getAtomWithIdx(allAtm)->getAtomicNum() ||
+        isAromaticAtom(*mol.getAtomWithIdx(allAtm))) {
       hasAromaticOrDummyAtom = true;
       break;
     }
@@ -90,23 +90,8 @@ void markDbondCands(RWMol &mol, const INT_VECT &allAtms,
   for (int allAtm : allAtms) {
     Atom *at = mol.getAtomWithIdx(allAtm);
 
-    if (!at->getIsAromatic() && at->getAtomicNum()) {
+    if (at->getAtomicNum() && !isAromaticAtom(*at)) {
       done.push_back(allAtm);
-      // make sure all the bonds on this atom are also non aromatic
-      // i.e. can't have aromatic bond onto a non-aromatic atom
-      RWMol::OEDGE_ITER beg, end;
-      boost::tie(beg, end) = mol.getAtomBonds(at);
-      while (beg != end) {
-        // ok we can't have an aromatic atom
-        if (mol[*beg]->getIsAromatic()) {
-          std::ostringstream errout;
-          errout << "Aromatic bonds on non aromatic atom " << at->getIdx();
-          std::string msg = errout.str();
-          BOOST_LOG(rdErrorLog) << msg << std::endl;
-          throw AtomKekulizeException(msg, at->getIdx());
-        }
-        ++beg;
-      }
       continue;
     }
 
@@ -535,7 +520,7 @@ void KekulizeFragment(RWMol &mol, const boost::dynamic_bitset<> &atomsToUse,
     }
     atom->calcImplicitValence(false);
     valences[atom->getIdx()] = atom->getTotalValence();
-    if (atom->getIsAromatic()) {
+    if (isAromaticAtom(*atom)) {
       foundAromatic = true;
     }
     if (!atom->getAtomicNum()) {
@@ -637,7 +622,7 @@ void KekulizeFragment(RWMol &mol, const boost::dynamic_bitset<> &atomsToUse,
       }
     }
     for (auto atom : mol.atoms()) {
-      if (atomsToUse[atom->getIdx()] && atom->getIsAromatic()) {
+      if (atomsToUse[atom->getIdx()] && isAromaticAtom(*atom)) {
         // if we're doing the full molecule and there are aromatic atoms not in
         // a ring, throw an exception
         if (atomsToUse.all() && bondsToUse.all() &&
@@ -697,8 +682,8 @@ bool KekulizeIfPossible(RWMol &mol, bool markAtomsBonds,
     }
   }
   boost::dynamic_bitset<> aromaticAtoms(mol.getNumAtoms());
-  for (const auto &atom : mol.atoms()) {
-    if (atom->getIsAromatic()) {
+  for (const auto atom : mol.atoms()) {
+    if (isAromaticAtom(*atom)) {
       aromaticAtoms.set(atom->getIdx());
     }
   }

--- a/Code/GraphMol/QueryOps.cpp
+++ b/Code/GraphMol/QueryOps.cpp
@@ -902,7 +902,7 @@ bool isAtomAromatic(const Atom *a) {
   PRECONDITION(a, "bad atom");
   bool res = false;
   if (!a->hasQuery()) {
-    res = a->getIsAromatic();
+    res = isAromaticAtom(*a);
   } else {
     std::string descr = a->getQuery()->getDescription();
     if (descr == "AtomAtomicNum") {

--- a/Code/GraphMol/catch_graphmol.cpp
+++ b/Code/GraphMol/catch_graphmol.cpp
@@ -2463,3 +2463,32 @@ TEST_CASE("Github #4535: operator<< for AtomPDBResidue", "[PDB]") {
     CHECK(oss.str() == tgt);
   }
 }
+
+TEST_CASE("isAromaticAtom") {
+  SECTION("basics") {
+    SmilesParserParams ps;
+    ps.sanitize = false;
+    std::unique_ptr<RWMol> mol(SmilesToMol("C:C:C", ps));
+    REQUIRE(mol);
+    CHECK(!mol->getAtomWithIdx(0)->getIsAromatic());
+    CHECK(mol->getBondWithIdx(0)->getIsAromatic());
+    CHECK(isAromaticAtom(*mol->getAtomWithIdx(0)));
+  }
+}
+
+TEST_CASE(
+    "Github #4785: aromatic bonds no longer set aromatic flags on atoms") {
+  SECTION("basics1") {
+    auto m = "C1:C:C:C:1"_smiles;
+    REQUIRE(m);
+    CHECK(MolToSmiles(*m) == "C1=CC=C1");
+  }
+  SECTION("basics2") {
+    auto m = "C1:C:C:C:C:C:1"_smiles;
+    REQUIRE(m);
+    CHECK(MolToSmiles(*m) == "c1ccccc1");
+  }
+  SECTION("can still get kekulization errors") {
+    CHECK_THROWS_AS(SmilesToMol("C1:C:C:C:C:1"), KekulizeException);
+  }
+}

--- a/Code/GraphMol/catch_graphmol.cpp
+++ b/Code/GraphMol/catch_graphmol.cpp
@@ -367,7 +367,8 @@ TEST_CASE("Specialized exceptions for sanitization errors", "[molops]") {
   }
   SECTION("AtomKekulizeException") {
     std::vector<std::pair<std::string, unsigned int>> smiles = {
-        {"CCcc", 2}, {"C1:c:CC1", 0}};
+        {"CCcc", 2},
+    };
     for (auto pr : smiles) {
       CHECK_THROWS_AS(SmilesToMol(pr.first), AtomKekulizeException);
       try {
@@ -381,7 +382,9 @@ TEST_CASE("Specialized exceptions for sanitization errors", "[molops]") {
   }
   SECTION("KekulizeException") {
     std::vector<std::pair<std::string, std::vector<unsigned int>>> smiles = {
-        {"c1cccc1", {0, 1, 2, 3, 4}}, {"Cc1cc1", {1, 2, 3}}};
+        {"c1cccc1", {0, 1, 2, 3, 4}},
+        {"Cc1cc1", {1, 2, 3}},
+        {"C1:c:CC1", {0, 1, 2}}};
     for (auto pr : smiles) {
       CHECK_THROWS_AS(SmilesToMol(pr.first), KekulizeException);
       try {

--- a/Code/PgSQL/rdkit/expected/reaction.out
+++ b/Code/PgSQL/rdkit/expected/reaction.out
@@ -201,9 +201,9 @@ $MOL
   5  6  4  0                                                         
   6  1  4  0                                                         
 M  END');
- reaction_from_ctab 
---------------------
- c1ccccc1>>c1ccncc1
+       reaction_from_ctab       
+--------------------------------
+ C1:C:C:C:C:C:1>>C1:C:C:N:C:C:1
 (1 row)
 
 CREATE TABLE tmp (id integer, tmprxn text);


### PR DESCRIPTION
This also adds a new function: `RDKit::isAromaticAtom()`, which returns true for atoms which either have their aromatic flag set or which have an aromatic bond to them.
