### PR TITLE
Fixes #4764

### DIFF
--- a/Code/GraphMol/MolDraw2D/Qt/MolDraw2DQt.cpp
+++ b/Code/GraphMol/MolDraw2D/Qt/MolDraw2DQt.cpp
@@ -92,7 +92,7 @@ void MolDraw2DQt::drawLine(const Point2D &cds1, const Point2D &cds2) {
   } else {
     pen.setStyle(Qt::SolidLine);
   }
-  pen.setWidth(lineWidth());
+  pen.setWidth(getDrawLineWidth());
   d_qp->setPen(pen);
   d_qp->drawLine(QPointF(c1.x, c1.y), QPointF(c2.x, c2.y));
 }

--- a/Code/GraphMol/MolDraw2D/Qt/catch_qt.cpp
+++ b/Code/GraphMol/MolDraw2D/Qt/catch_qt.cpp
@@ -48,6 +48,35 @@ TEST_CASE("basic generate PNGs", "[drawing][Qt]") {
   }
 }
 
+TEST_CASE("Github #4764") {
+  SECTION("basics") {
+    auto mol = "c1ccccc1-C1CCCCC1"_smiles;
+    REQUIRE(mol);
+    std::vector<int> highlights{6, 7, 8, 9, 10, 11};
+    {
+      QImage qimg(200, 150, QImage::Format_RGB32);
+      QPainter qpt(&qimg);
+      MolDraw2DQt drawer(qimg.width(), qimg.height(), &qpt);
+      drawer.drawMolecule(*mol, "highlight", &highlights);
+      qimg.save("testGithub4764.qt.sz1.png");
+    }
+    {
+      QImage qimg(400, 350, QImage::Format_RGB32);
+      QPainter qpt(&qimg);
+      MolDraw2DQt drawer(qimg.width(), qimg.height(), &qpt);
+      drawer.drawMolecule(*mol, "highlight", &highlights);
+      qimg.save("testGithub4764.qt.sz2.png");
+    }
+    {
+      QImage qimg(800, 700, QImage::Format_RGB32);
+      QPainter qpt(&qimg);
+      MolDraw2DQt drawer(qimg.width(), qimg.height(), &qpt);
+      drawer.drawMolecule(*mol, "highlight", &highlights);
+      qimg.save("testGithub4764.qt.sz3.png");
+    }
+  }
+}
+
 int main(int argc, char* argv[]) {
   QGuiApplication app(argc, argv);
 

--- a/Code/GraphMol/MolDraw2D/catch_tests.cpp
+++ b/Code/GraphMol/MolDraw2D/catch_tests.cpp
@@ -178,6 +178,9 @@ static const std::map<std::string, std::hash_result_t> SVG_HASHES = {
     {"testFlexiCanvas.4a.svg", 1976270997U},
     {"testFlexiCanvas.4b.svg", 1353149014U},
     {"testFlexiCanvas.4c.svg", 684218292U},
+    {"testGithub4764.sz1.svg", 1410356032U},
+    {"testGithub4764.sz2.svg", 2935799920U},
+    {"testGithub4764.sz3.svg", 2544100175U},
 };
 
 // These PNG hashes aren't completely reliable due to floating point cruft,
@@ -202,6 +205,9 @@ static const std::map<std::string, std::hash_result_t> PNG_HASHES = {
     {"testGithub4323_3.png", 1026038713U},
     {"testFlexiCanvas.2a.png", 3464661434U},
     {"testFlexiCanvas.2b.png", 3432369109U},
+    {"testGithub4764.sz1.png", 998569406U},
+    {"testGithub4764.sz2.png", 630175977U},
+    {"testGithub4764.sz3.png", 3924927459U},
 };
 
 std::hash_result_t hash_file(const std::string &filename) {
@@ -3946,5 +3952,67 @@ M  END)CTAB"_ctab;
       outs.flush();
       check_file_hash("testFlexiCanvas.4c.svg");
     }
+  }
+}
+
+TEST_CASE("Github #4764") {
+  SECTION("basics") {
+    auto mol = "c1ccccc1-C1CCCCC1"_smiles;
+    REQUIRE(mol);
+    std::vector<int> highlights{6, 7, 8, 9, 10, 11};
+    {
+      MolDraw2DSVG drawer(200, 150);
+      drawer.drawMolecule(*mol, "highlight", &highlights);
+      drawer.finishDrawing();
+      auto text = drawer.getDrawingText();
+      std::ofstream outs("testGithub4764.sz1.svg");
+      outs << text;
+      outs.flush();
+      check_file_hash("testGithub4764.sz1.svg");
+    }
+    {
+      MolDraw2DSVG drawer(400, 350);
+      drawer.drawMolecule(*mol, "highlight", &highlights);
+      drawer.finishDrawing();
+      auto text = drawer.getDrawingText();
+      std::ofstream outs("testGithub4764.sz2.svg");
+      outs << text;
+      outs.flush();
+      check_file_hash("testGithub4764.sz2.svg");
+    }
+    {
+      MolDraw2DSVG drawer(800, 700);
+      drawer.drawMolecule(*mol, "highlight", &highlights);
+      drawer.finishDrawing();
+      auto text = drawer.getDrawingText();
+      std::ofstream outs("testGithub4764.sz3.svg");
+      outs << text;
+      outs.flush();
+      check_file_hash("testGithub4764.sz3.svg");
+    }
+#ifdef RDK_BUILD_CAIRO_SUPPORT
+    {
+      MolDraw2DCairo drawer(200, 150);
+      drawer.drawMolecule(*mol, "highlight", &highlights);
+      drawer.finishDrawing();
+      drawer.writeDrawingText("testGithub4764.sz1.png");
+      check_file_hash("testGithub4764.sz1.png");
+    }
+    {
+      MolDraw2DCairo drawer(400, 350);
+      drawer.drawMolecule(*mol, "highlight", &highlights);
+      drawer.finishDrawing();
+      drawer.writeDrawingText("testGithub4764.sz2.png");
+      check_file_hash("testGithub4764.sz2.png");
+    }
+    {
+      MolDraw2DCairo drawer(800, 700);
+      drawer.drawMolecule(*mol, "highlight", &highlights);
+      drawer.finishDrawing();
+      drawer.writeDrawingText("testGithub4764.sz3.png");
+      check_file_hash("testGithub4764.sz3.png");
+    }
+#endif
+    // check_file_hash("testGithub4538.svg");
   }
 }


### PR DESCRIPTION
Simple change to use `getDrawLineWidth()` instead of `lineWidth()`, like all the other drawers do.

I checked the output PNGs from the new Qt tests and they look fine.
![testGithub4764 qt sz1](https://user-images.githubusercontent.com/540511/146417200-a28138f8-2ab9-4815-8552-ab8961688a0a.png)
![testGithub4764 qt sz2](https://user-images.githubusercontent.com/540511/146417217-c66b6618-26fb-4d68-b5e6-39e8e310e52b.png)
![testGithub4764 qt sz3](https://user-images.githubusercontent.com/540511/146417259-63c5f4c9-3758-4e04-9fbc-e3efc3167d1f.png)

