### PR TITLE
Fix a number of crashing bugs in the python wrappers

### DIFF
--- a/Code/GraphMol/Abbreviations/Wrap/rdAbbreviations.cpp
+++ b/Code/GraphMol/Abbreviations/Wrap/rdAbbreviations.cpp
@@ -25,8 +25,10 @@ ROMol *condenseMolAbbreviationsHelper(const ROMol *mol,
   RWMol *res = new RWMol(*mol);
   auto abbrevs =
       pythonObjectToVect<Abbreviations::AbbreviationDefinition>(pyabbrevs);
-  Abbreviations::condenseMolAbbreviations(*res, *abbrevs, maxCoverage,
-                                          sanitize);
+  if (abbrevs) {
+    Abbreviations::condenseMolAbbreviations(*res, *abbrevs, maxCoverage,
+                                            sanitize);
+  }
   return rdcast<ROMol *>(res);
 }
 
@@ -41,7 +43,9 @@ ROMol *labelMolAbbreviationsHelper(const ROMol *mol, python::object pyabbrevs,
   RWMol *res = new RWMol(*mol);
   auto abbrevs =
       pythonObjectToVect<Abbreviations::AbbreviationDefinition>(pyabbrevs);
-  Abbreviations::labelMolAbbreviations(*res, *abbrevs, maxCoverage);
+  if (abbrevs) {
+    Abbreviations::labelMolAbbreviations(*res, *abbrevs, maxCoverage);
+  }
   return rdcast<ROMol *>(res);
 }
 }  // namespace

--- a/Code/GraphMol/MMPA/Wrap/rdMMPA.cpp
+++ b/Code/GraphMol/MMPA/Wrap/rdMMPA.cpp
@@ -82,6 +82,9 @@ python::tuple fragmentMolHelper3(const RDKit::ROMol& mol, python::object ob,
   std::vector<std::pair<RDKit::ROMOL_SPTR, RDKit::ROMOL_SPTR>> tres;
   std::unique_ptr<std::vector<unsigned int>> v =
       pythonObjectToVect<unsigned int>(ob);
+  if (!v) {
+    throw_value_error("invalid value for bondsToCut");
+  }
   bool ok = RDKit::MMPA::fragmentMol(mol, tres, *v, minCuts, maxCuts);
   python::list pyres;
   if (ok) {

--- a/Code/GraphMol/MMPA/Wrap/rdMMPA.cpp
+++ b/Code/GraphMol/MMPA/Wrap/rdMMPA.cpp
@@ -83,7 +83,7 @@ python::tuple fragmentMolHelper3(const RDKit::ROMol& mol, python::object ob,
   std::unique_ptr<std::vector<unsigned int>> v =
       pythonObjectToVect<unsigned int>(ob);
   if (!v) {
-    throw_value_error("invalid value for bondsToCut");
+    throw_value_error("bondsToCut must be non-empty");
   }
   bool ok = RDKit::MMPA::fragmentMol(mol, tres, *v, minCuts, maxCuts);
   python::list pyres;

--- a/Code/GraphMol/MolDraw2D/Wrap/rdMolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/Wrap/rdMolDraw2D.cpp
@@ -476,10 +476,19 @@ void contourAndDrawGaussiansHelper(
     const MolDraw2DUtils::ContourParams &params, python::object mol) {
   std::unique_ptr<std::vector<RDGeom::Point2D>> locs =
       pythonObjectToVect<RDGeom::Point2D>(pylocs);
+  if (!locs) {
+    throw_value_error("invalid value for locs");
+  }
   std::unique_ptr<std::vector<double>> heights =
       pythonObjectToVect<double>(pyheights);
+  if (!heights) {
+    throw_value_error("invalid value for heights");
+  }
   std::unique_ptr<std::vector<double>> widths =
       pythonObjectToVect<double>(pywidths);
+  if (!widths) {
+    throw_value_error("invalid value for widths");
+  }
   std::unique_ptr<std::vector<double>> levels;
   if (pylevels) {
     levels = pythonObjectToVect<double>(pylevels);
@@ -511,8 +520,14 @@ void contourAndDrawGridHelper(RDKit::MolDraw2D &drawer, python::object &data,
 
   std::unique_ptr<std::vector<double>> xcoords =
       pythonObjectToVect<double>(pyxcoords);
+  if (!xcoords) {
+    throw_value_error("invalid value for xcoords");
+  }
   std::unique_ptr<std::vector<double>> ycoords =
       pythonObjectToVect<double>(pyycoords);
+  if (!ycoords) {
+    throw_value_error("invalid value for ycoords");
+  }
   std::unique_ptr<std::vector<double>> levels;
   if (pylevels) {
     levels = pythonObjectToVect<double>(pylevels);
@@ -559,6 +574,9 @@ void setContourColour(RDKit::MolDraw2DUtils::ContourParams &params,
 void drawPolygonHelper(RDKit::MolDraw2D &self, python::object py_cds) {
   std::unique_ptr<std::vector<RDGeom::Point2D>> cds =
       pythonObjectToVect<RDGeom::Point2D>(py_cds);
+  if (!cds) {
+    throw_value_error("invalid value for cds");
+  }
 
   self.drawPolygon(*cds);
 }
@@ -869,7 +887,7 @@ BOOST_PYTHON_MODULE(rdMolDraw2D) {
       .def("FillPolys", &RDKit::MolDraw2D::fillPolys,
            "returns whether or not polygons are being filled")
       .def("DrawLine",
-           (void(RDKit::MolDraw2D::*)(const Point2D &, const Point2D &)) &
+           (void (RDKit::MolDraw2D::*)(const Point2D &, const Point2D &)) &
                RDKit::MolDraw2D::drawLine,
            (python::arg("self"), python::arg("cds1"), python::arg("cds2")),
            "draws a line with the current drawing style. The coordinates "
@@ -913,15 +931,15 @@ BOOST_PYTHON_MODULE(rdMolDraw2D) {
            "draw a line indicating the presence of an attachment point "
            "(normally a squiggle line perpendicular to a bond)")
       .def("DrawString",
-           (void(RDKit::MolDraw2D::*)(const std::string &,
-                                      const RDGeom::Point2D &)) &
+           (void (RDKit::MolDraw2D::*)(const std::string &,
+                                       const RDGeom::Point2D &)) &
                RDKit::MolDraw2D::drawString,
            (python::arg("self"), python::arg("string"), python::arg("pos")),
            "add text to the canvas")
       .def("DrawString",
-           (void(RDKit::MolDraw2D::*)(const std::string &,
-                                      const RDGeom::Point2D &,
-                                      RDKit::TextAlignType)) &
+           (void (RDKit::MolDraw2D::*)(const std::string &,
+                                       const RDGeom::Point2D &,
+                                       RDKit::TextAlignType)) &
                RDKit::MolDraw2D::drawString,
            (python::arg("self"), python::arg("string"), python::arg("pos"),
             python::arg("align")),
@@ -961,7 +979,7 @@ BOOST_PYTHON_MODULE(rdMolDraw2D) {
       .def("FinishDrawing", &RDKit::MolDraw2DSVG::finishDrawing,
            "add the last bits of SVG to finish the drawing")
       .def("AddMoleculeMetadata",
-           (void(RDKit::MolDraw2DSVG::*)(const RDKit::ROMol &, int) const) &
+           (void (RDKit::MolDraw2DSVG::*)(const RDKit::ROMol &, int) const) &
                RDKit::MolDraw2DSVG::addMoleculeMetadata,
            (python::arg("mol"), python::arg("confId") = -1),
            "add RDKit-specific information to the bottom of the drawing")

--- a/Code/GraphMol/MolDraw2D/Wrap/rdMolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/Wrap/rdMolDraw2D.cpp
@@ -477,17 +477,17 @@ void contourAndDrawGaussiansHelper(
   std::unique_ptr<std::vector<RDGeom::Point2D>> locs =
       pythonObjectToVect<RDGeom::Point2D>(pylocs);
   if (!locs) {
-    throw_value_error("invalid value for locs");
+    throw_value_error("locs argument must be non-empty");
   }
   std::unique_ptr<std::vector<double>> heights =
       pythonObjectToVect<double>(pyheights);
   if (!heights) {
-    throw_value_error("invalid value for heights");
+    throw_value_error("heights argument must be non-empty");
   }
   std::unique_ptr<std::vector<double>> widths =
       pythonObjectToVect<double>(pywidths);
   if (!widths) {
-    throw_value_error("invalid value for widths");
+    throw_value_error("widths argument must be non-empty");
   }
   std::unique_ptr<std::vector<double>> levels;
   if (pylevels) {
@@ -521,12 +521,12 @@ void contourAndDrawGridHelper(RDKit::MolDraw2D &drawer, python::object &data,
   std::unique_ptr<std::vector<double>> xcoords =
       pythonObjectToVect<double>(pyxcoords);
   if (!xcoords) {
-    throw_value_error("invalid value for xcoords");
+    throw_value_error("xcoords argument must be non-empty");
   }
   std::unique_ptr<std::vector<double>> ycoords =
       pythonObjectToVect<double>(pyycoords);
   if (!ycoords) {
-    throw_value_error("invalid value for ycoords");
+    throw_value_error("ycoords argument must be non-empty");
   }
   std::unique_ptr<std::vector<double>> levels;
   if (pylevels) {
@@ -575,7 +575,7 @@ void drawPolygonHelper(RDKit::MolDraw2D &self, python::object py_cds) {
   std::unique_ptr<std::vector<RDGeom::Point2D>> cds =
       pythonObjectToVect<RDGeom::Point2D>(py_cds);
   if (!cds) {
-    throw_value_error("invalid value for cds");
+    throw_value_error("cds argument must be non-empty");
   }
 
   self.drawPolygon(*cds);

--- a/Code/GraphMol/MolInterchange/Wrap/rdMolInterchange.cpp
+++ b/Code/GraphMol/MolInterchange/Wrap/rdMolInterchange.cpp
@@ -35,6 +35,9 @@ python::tuple JSONToMols(const std::string &jsonBlock,
 
 std::string MolsToJSON(const python::object &mols) {
   auto pymols = pythonObjectToVect<const RDKit::ROMol *>(mols);
+  if (!pymols) {
+    return "";
+  }
   return RDKit::MolInterchange::MolsToJSONData(*pymols);
 }
 }  // namespace

--- a/Code/GraphMol/MolStandardize/Wrap/Validate.cpp
+++ b/Code/GraphMol/MolStandardize/Wrap/Validate.cpp
@@ -33,11 +33,12 @@ MolStandardize::MolVSValidation *getMolVSValidation(
     python::object validations) {
   std::vector<boost::shared_ptr<MolStandardize::MolVSValidations>> vs;
 
-  std::unique_ptr<
-      std::vector<boost::shared_ptr<MolStandardize::MolVSValidations>>>
-      pvect = pythonObjectToVect<
-          boost::shared_ptr<MolStandardize::MolVSValidations>>(validations);
-
+  auto pvect =
+      pythonObjectToVect<boost::shared_ptr<MolStandardize::MolVSValidations>>(
+          validations);
+  if (!pvect) {
+    throw_value_error("bad value for validations");
+  }
   for (auto v : *pvect) {
     vs.push_back(v->copy());
   }
@@ -57,8 +58,10 @@ python::list molVSvalidateHelper(MolStandardize::MolVSValidation &self,
 
 MolStandardize::AllowedAtomsValidation *getAllowedAtomsValidation(
     python::object atoms) {
-  std::unique_ptr<std::vector<Atom *>> p_atomList =
-      pythonObjectToVect<Atom *>(atoms);
+  auto p_atomList = pythonObjectToVect<Atom *>(atoms);
+  if (!p_atomList) {
+    throw_value_error("bad value for allowed atoms");
+  }
   std::vector<std::shared_ptr<Atom>> satoms;
   for (auto ap : *p_atomList) {
     satoms.push_back(std::shared_ptr<Atom>(ap->copy()));
@@ -81,8 +84,10 @@ python::list allowedAtomsValidate(MolStandardize::AllowedAtomsValidation &self,
 
 MolStandardize::DisallowedAtomsValidation *getDisallowedAtomsValidation(
     python::object atoms) {
-  std::unique_ptr<std::vector<Atom *>> p_atomList =
-      pythonObjectToVect<Atom *>(atoms);
+  auto p_atomList = pythonObjectToVect<Atom *>(atoms);
+  if (!p_atomList) {
+    throw_value_error("bad value for disallowed atoms");
+  }
   std::vector<std::shared_ptr<Atom>> satoms;
   for (auto ap : *p_atomList) {
     satoms.push_back(std::shared_ptr<Atom>(ap->copy()));

--- a/Code/GraphMol/MolStandardize/Wrap/Validate.cpp
+++ b/Code/GraphMol/MolStandardize/Wrap/Validate.cpp
@@ -37,7 +37,7 @@ MolStandardize::MolVSValidation *getMolVSValidation(
       pythonObjectToVect<boost::shared_ptr<MolStandardize::MolVSValidations>>(
           validations);
   if (!pvect) {
-    throw_value_error("bad value for validations");
+    throw_value_error("validations argument must be non-empty");
   }
   for (auto v : *pvect) {
     vs.push_back(v->copy());
@@ -60,7 +60,7 @@ MolStandardize::AllowedAtomsValidation *getAllowedAtomsValidation(
     python::object atoms) {
   auto p_atomList = pythonObjectToVect<Atom *>(atoms);
   if (!p_atomList) {
-    throw_value_error("bad value for allowed atoms");
+    throw_value_error("allowedAtoms argument must be non-empty");
   }
   std::vector<std::shared_ptr<Atom>> satoms;
   for (auto ap : *p_atomList) {
@@ -86,7 +86,7 @@ MolStandardize::DisallowedAtomsValidation *getDisallowedAtomsValidation(
     python::object atoms) {
   auto p_atomList = pythonObjectToVect<Atom *>(atoms);
   if (!p_atomList) {
-    throw_value_error("bad value for disallowed atoms");
+    throw_value_error("disallowedAtoms must be non-empty");
   }
   std::vector<std::shared_ptr<Atom>> satoms;
   for (auto ap : *p_atomList) {

--- a/Code/GraphMol/ScaffoldNetwork/Wrap/rdScaffoldNetwork.cpp
+++ b/Code/GraphMol/ScaffoldNetwork/Wrap/rdScaffoldNetwork.cpp
@@ -23,7 +23,7 @@ ScaffoldNetwork::ScaffoldNetwork *createNetworkHelper(
     const ScaffoldNetwork::ScaffoldNetworkParams &params) {
   auto mols = pythonObjectToVect<ROMOL_SPTR>(pmols);
   ScaffoldNetwork::ScaffoldNetwork *res = new ScaffoldNetwork::ScaffoldNetwork;
-  {
+  if (mols) {
     NOGIL gil;
 
     updateScaffoldNetwork(*mols, *res, params);
@@ -34,7 +34,7 @@ void updateNetworkHelper(python::object pmols,
                          ScaffoldNetwork::ScaffoldNetwork &net,
                          const ScaffoldNetwork::ScaffoldNetworkParams &params) {
   auto mols = pythonObjectToVect<ROMOL_SPTR>(pmols);
-  {
+  if (mols) {
     NOGIL gil;
     updateScaffoldNetwork(*mols, net, params);
   }

--- a/Code/GraphMol/SubstructLibrary/Wrap/SubstructLibraryWrap.cpp
+++ b/Code/GraphMol/SubstructLibrary/Wrap/SubstructLibraryWrap.cpp
@@ -185,14 +185,15 @@ const char *SubstructLibraryDoc =
     ">>> import csv\n"
     ">>> molholder = rdSubstructLibrary.CachedSmilesMolHolder()\n"
     ">>> pattern_holder = rdSubstructLibrary.PatternHolder()\n"
-    ">>> for i, row in "
-    "enumerate(csv.reader(open(os.path.join(RDConfig.RDDataDir, \n"
-    "...                               'NCI', 'first_200.tpsa.csv')))):\n"
-    "...   if i:\n"
-    "...     idx = molholder.AddSmiles(row[0])\n"
-    "...     idx2 = pattern_holder.AddFingerprint(\n"
-    "...         pattern_holder.MakeFingerprint(Chem.MolFromSmiles(row[0])))\n"
-    "...     assert idx==idx2\n"
+    ">>> with open(os.path.join(RDConfig.RDDataDir, 'NCI', "
+    "'first_200.tpsa.csv')) as inf:\n"
+    "...   for i, row in enumerate(csv.reader(inf)):\n"
+    "...     if i:\n"
+    "...       idx = molholder.AddSmiles(row[0])\n"
+    "...       idx2 = pattern_holder.AddFingerprint(\n"
+    "...           "
+    "pattern_holder.MakeFingerprint(Chem.MolFromSmiles(row[0])))\n"
+    "...       assert idx==idx2\n"
     ">>> library = "
     "rdSubstructLibrary.SubstructLibrary(molholder,pattern_holder)\n"
     ">>> indices = library.GetMatches(core)\n"
@@ -270,7 +271,11 @@ python::tuple getSearchOrderHelper(const SubstructLibrary &sslib) {
 void setSearchOrderHelper(SubstructLibrary &sslib, const python::object &seq) {
   std::unique_ptr<std::vector<unsigned int>> sorder =
       pythonObjectToVect<unsigned int>(seq);
-  sslib.setSearchOrder(*sorder);
+  if (sorder) {
+    sslib.setSearchOrder(*sorder);
+  } else {
+    sslib.getSearchOrder().clear();
+  }
 }
 
 #define LARGE_DEF(_tname_)                                                     \

--- a/Code/GraphMol/SubstructLibrary/Wrap/rough_test.py
+++ b/Code/GraphMol/SubstructLibrary/Wrap/rough_test.py
@@ -79,7 +79,7 @@ class TestCase(unittest.TestCase):
                        rdSubstructLibrary.CachedSmilesMolHolder()]:
           if fpholderCls: fpholder = fpholderCls()
           else: fpholder = None
-          if keyholderCls: 
+          if keyholderCls:
             keyholder = keyholderCls()
             self.assertEqual(keyholder.GetPropName(), "_Name")
           else: keyholder = None
@@ -126,7 +126,7 @@ class TestCase(unittest.TestCase):
                        rdSubstructLibrary.CachedSmilesMolHolder()]:
           if fpholderCls: fpholder = fpholderCls()
           else: fpholder = None
-          if keyholderCls: 
+          if keyholderCls:
             keyholder = keyholderCls()
             self.assertEqual(keyholder.GetPropName(), "_Name")
           else: keyholder = None
@@ -567,18 +567,28 @@ class TestCase(unittest.TestCase):
         self.assertEqual(keyholder.GetPropName(), "_Name")
         self.assertEqual(list(ssl.GetKeyHolder().GetKeys(ssl.GetMatches(qm,maxResults=2))),['3','2'])
 
+      # make sure we can clear the search order:
+      ssl.SetSearchOrder(None)
+      self.assertEqual(ssl.GetSearchOrder(),())
+
+      ssl.SetSearchOrder((3, 2, 0, 1, 4))
+      self.assertEqual(ssl.GetSearchOrder(), (3, 2, 0, 1, 4))
+
+      ssl.SetSearchOrder([])
+      self.assertEqual(ssl.GetSearchOrder(),())
+
 
   def testSearchOrder2(self):
     ssl = rdSubstructLibrary.SubstructLibrary()
     for smi in ("CCCOC", "CCCCOCC", "CCOC", "COC", "CCCCCOC"):
       ssl.AddMol(Chem.MolFromSmiles(smi))
-    
+
     def setSearchSmallestFirst(sslib):
       searchOrder = list(range(len(sslib)))
       holder = sslib.GetMolHolder()
       searchOrder.sort(key=lambda x,holder=holder:holder.GetMol(x).GetNumAtoms())
       sslib.SetSearchOrder(searchOrder)
-    
+
     setSearchSmallestFirst(ssl)
     qm = Chem.MolFromSmiles('COC')
     self.assertEqual(list(ssl.GetMatches(qm)),[3, 2, 0, 1, 4])

--- a/Code/GraphMol/Wrap/MolOps.cpp
+++ b/Code/GraphMol/Wrap/MolOps.cpp
@@ -45,8 +45,7 @@ python::tuple fragmentOnSomeBondsHelper(const ROMol &mol,
                                         python::object pyDummyLabels,
                                         python::object pyBondTypes,
                                         bool returnCutsPerAtom) {
-  std::unique_ptr<std::vector<unsigned int>> bondIndices =
-      pythonObjectToVect(pyBondIndices, mol.getNumBonds());
+  auto bondIndices = pythonObjectToVect(pyBondIndices, mol.getNumBonds());
   if (!bondIndices.get()) {
     throw_value_error("empty bond indices");
   }
@@ -120,8 +119,7 @@ ROMol *fragmentOnBondsHelper(const ROMol &mol, python::object pyBondIndices,
                              bool addDummies, python::object pyDummyLabels,
                              python::object pyBondTypes,
                              python::list pyCutsPerAtom) {
-  std::unique_ptr<std::vector<unsigned int>> bondIndices =
-      pythonObjectToVect(pyBondIndices, mol.getNumBonds());
+  auto bondIndices = pythonObjectToVect(pyBondIndices, mol.getNumBonds());
   if (!bondIndices.get()) {
     throw_value_error("empty bond indices");
   }
@@ -178,8 +176,10 @@ ROMol *renumberAtomsHelper(const ROMol &mol, python::object &pyNewOrder) {
       mol.getNumAtoms()) {
     throw_value_error("atomCounts shorter than the number of atoms");
   }
-  std::unique_ptr<std::vector<unsigned int>> newOrder =
-      pythonObjectToVect(pyNewOrder, mol.getNumAtoms());
+  auto newOrder = pythonObjectToVect(pyNewOrder, mol.getNumAtoms());
+  if (!newOrder) {
+    throw_value_error("invalid value for new order");
+  }
   ROMol *res = MolOps::renumberAtoms(mol, *newOrder);
   return res;
 }

--- a/Code/GraphMol/Wrap/MolOps.cpp
+++ b/Code/GraphMol/Wrap/MolOps.cpp
@@ -178,7 +178,7 @@ ROMol *renumberAtomsHelper(const ROMol &mol, python::object &pyNewOrder) {
   }
   auto newOrder = pythonObjectToVect(pyNewOrder, mol.getNumAtoms());
   if (!newOrder) {
-    throw_value_error("invalid value for new order");
+    throw_value_error("newOrder argument must be non-empty");
   }
   ROMol *res = MolOps::renumberAtoms(mol, *newOrder);
   return res;

--- a/Code/GraphMol/Wrap/rdmolfiles.cpp
+++ b/Code/GraphMol/Wrap/rdmolfiles.cpp
@@ -254,7 +254,7 @@ std::string molFragmentToSmarts(const ROMol &mol, python::object atomsToUse,
   auto atomIndices =
       pythonObjectToVect(atomsToUse, static_cast<int>(mol.getNumAtoms()));
   if (!atomIndices) {
-    throw_value_error("invalid value for atom indices");
+    throw_value_error("atomsToUse argument must be non-empty");
   }
   auto bondIndices =
       pythonObjectToVect(bondsToUse, static_cast<int>(mol.getNumBonds()));
@@ -268,7 +268,7 @@ std::string molFragmentToCXSmarts(const ROMol &mol, python::object atomsToUse,
   auto atomIndices =
       pythonObjectToVect(atomsToUse, static_cast<int>(mol.getNumAtoms()));
   if (!atomIndices) {
-    throw_value_error("invalid value for atom indices");
+    throw_value_error("atomsToUse argument must be non-empty");
   }
   auto bondIndices =
       pythonObjectToVect(bondsToUse, static_cast<int>(mol.getNumBonds()));

--- a/Code/GraphMol/Wrap/rdmolfiles.cpp
+++ b/Code/GraphMol/Wrap/rdmolfiles.cpp
@@ -253,6 +253,9 @@ std::string molFragmentToSmarts(const ROMol &mol, python::object atomsToUse,
                                 bool doIsomericSmarts = true) {
   auto atomIndices =
       pythonObjectToVect(atomsToUse, static_cast<int>(mol.getNumAtoms()));
+  if (!atomIndices) {
+    throw_value_error("invalid value for atom indices");
+  }
   auto bondIndices =
       pythonObjectToVect(bondsToUse, static_cast<int>(mol.getNumBonds()));
   return RDKit::MolFragmentToSmarts(mol, *atomIndices, bondIndices.get(),
@@ -264,6 +267,9 @@ std::string molFragmentToCXSmarts(const ROMol &mol, python::object atomsToUse,
                                   bool doIsomericSmarts = true) {
   auto atomIndices =
       pythonObjectToVect(atomsToUse, static_cast<int>(mol.getNumAtoms()));
+  if (!atomIndices) {
+    throw_value_error("invalid value for atom indices");
+  }
   auto bondIndices =
       pythonObjectToVect(bondsToUse, static_cast<int>(mol.getNumBonds()));
   return RDKit::MolFragmentToCXSmarts(mol, *atomIndices, bondIndices.get(),

--- a/Code/RDBoost/Wrap.h
+++ b/Code/RDBoost/Wrap.h
@@ -112,6 +112,7 @@ void RegisterListConverter(bool noproxy = false) {
   }
 }
 
+//! NOTE: this returns a nullptr if obj is None or empty
 template <typename T>
 std::unique_ptr<std::vector<T>> pythonObjectToVect(const python::object &obj,
                                                    T maxV) {
@@ -131,6 +132,7 @@ std::unique_ptr<std::vector<T>> pythonObjectToVect(const python::object &obj,
   }
   return res;
 }
+//! NOTE: this returns a nullptr if obj is None or empty
 template <typename T>
 std::unique_ptr<std::vector<T>> pythonObjectToVect(const python::object &obj) {
   std::unique_ptr<std::vector<T>> res;
@@ -140,11 +142,14 @@ std::unique_ptr<std::vector<T>> pythonObjectToVect(const python::object &obj) {
   }
   return res;
 }
+//! NOTE: \c res will be cleared if obj is None or empty
 template <typename T>
 void pythonObjectToVect(const python::object &obj, std::vector<T> &res) {
   if (obj) {
     res.assign(python::stl_input_iterator<T>(obj),
                python::stl_input_iterator<T>());
+  } else {
+    res.clear();
   }
 }
 


### PR DESCRIPTION
The function `pythonObjectToVect()` returns, by design, a `nullptr` when it's called with either `None` or an empty sequence.

However, there are a bunch of spots in the code where the results of `pythonObjectToVect()` are de-referenced without being checked.

This fixes all of those.