### PR TITLE
correctly tag unspecified branch-begin bonds in SMARTS

### DIFF
--- a/Code/GraphMol/SmilesParse/SmilesParseOps.cpp
+++ b/Code/GraphMol/SmilesParse/SmilesParseOps.cpp
@@ -146,8 +146,7 @@ void AddFragToMol(RWMol *mol, RWMol *frag, Bond::BondType bondOrder,
       // SMARTS semantics: unspecified bonds can be single or aromatic
       if (bondOrder == Bond::UNSPECIFIED) {
         auto *newB = new QueryBond(Bond::SINGLE);
-        newB->expandQuery(makeBondOrderEqualsQuery(Bond::AROMATIC),
-                          Queries::COMPOSITE_OR, true);
+        newB->setQuery(makeSingleOrAromaticBondQuery());
         newB->setOwningMol(mol);
         newB->setBeginAtomIdx(atomIdx1);
         newB->setEndAtomIdx(atomIdx2);

--- a/Code/GraphMol/SmilesParse/catch_tests.cpp
+++ b/Code/GraphMol/SmilesParse/catch_tests.cpp
@@ -948,8 +948,8 @@ TEST_CASE("Github #4319 add CXSMARTS support") {
     auto mol = "[#6][C@]([#8])(F)Cl |&1:1|"_smarts;
     REQUIRE(mol);
     REQUIRE(mol->getNumAtoms() == 5);
-    CHECK(MolToSmarts(*mol) == "[#6][C@](-,:[#8])(-,:F)Cl");
-    CHECK(MolToCXSmarts(*mol) == "[#6][C@](-,:[#8])(-,:F)Cl |&1:1|");
+    CHECK(MolToSmarts(*mol) == "[#6][C@]([#8])(F)Cl");
+    CHECK(MolToCXSmarts(*mol) == "[#6][C@]([#8])(F)Cl |&1:1|");
 
     {
       auto smol = "C[C@](O)(F)Cl |&1:1|"_smiles;
@@ -974,19 +974,17 @@ TEST_CASE("Github #4319 add CXSMARTS support") {
       auto mol = "C[C@H]([F,Cl,Br])[C@H](C)[C@@H](C)Br"_smarts;
       REQUIRE(mol);
       CHECK(mol->getAtomWithIdx(2)->getQuery()->getDescription() == "AtomOr");
-      CHECK(MolToSmarts(*mol) ==
-            "C[C@&H1](-,:[F,Cl,Br])[C@&H1](-,:C)[C@@&H1](-,:C)Br");
+      CHECK(MolToSmarts(*mol) == "C[C@&H1]([F,Cl,Br])[C@&H1](C)[C@@&H1](C)Br");
       CHECK(MolToCXSmarts(*mol) ==
-            "C[C@&H1](-,:[F,Cl,Br])[C@&H1](-,:C)[C@@&H1](-,:C)Br");
+            "C[C@&H1]([F,Cl,Br])[C@&H1](C)[C@@&H1](C)Br");
     }
     {  // make sure that doesn't break anything
       auto mol = "C[C@H]([F,Cl,Br])[C@H](C)[C@@H](C)Br |a:1,o1:4,5|"_smarts;
       REQUIRE(mol);
       CHECK(mol->getAtomWithIdx(2)->getQuery()->getDescription() == "AtomOr");
-      CHECK(MolToSmarts(*mol) ==
-            "C[C@&H1](-,:[F,Cl,Br])[C@&H1](-,:C)[C@@&H1](-,:C)Br");
+      CHECK(MolToSmarts(*mol) == "C[C@&H1]([F,Cl,Br])[C@&H1](C)[C@@&H1](C)Br");
       CHECK(MolToCXSmarts(*mol) ==
-            "C[C@&H1](-,:[F,Cl,Br])[C@&H1](-,:C)[C@@&H1](-,:C)Br |a:1,o1:4,5|");
+            "C[C@&H1]([F,Cl,Br])[C@&H1](C)[C@@&H1](C)Br |a:1,o1:4,5|");
     }
   }
 }
@@ -1846,4 +1844,14 @@ M  END)CTAB"_ctab;
         "C[C@H]2[C@@]3(CC[C@]2(C)C[C@H]2[C@@H]1C(=O)C[C@@]2(C)O)O[C@@H](C=C(C)"
         "C)C[C@@H]3C)C(=O)O");
   }
+}
+
+TEST_CASE(
+    "unspecified bonds at beginning of branch in SMARTS not properly tagged") {
+  auto m = "C(C)C"_smarts;
+  REQUIRE(m);
+  CHECK(m->getBondWithIdx(0)->getQuery()->getDescription() ==
+        "SingleOrAromaticBond");
+  CHECK(m->getBondWithIdx(1)->getQuery()->getDescription() ==
+        "SingleOrAromaticBond");
 }

--- a/Code/GraphMol/SmilesParse/smatest.cpp
+++ b/Code/GraphMol/SmilesParse/smatest.cpp
@@ -2681,7 +2681,7 @@ void testGithub2142() {
     std::unique_ptr<ROMol> m1(SmartsToMol(smarts));
     TEST_ASSERT(m1);
     auto csma1 = MolToSmarts(*m1);
-    TEST_ASSERT(csma1 == "[C;H1&$(C(-,:[#6])[#6]),H2&$(C[#6])]");
+    TEST_ASSERT(csma1 == "[C;H1&$(C([#6])[#6]),H2&$(C[#6])]");
   }
 
   {  // a second one from the issue

--- a/Code/PgSQL/rdkit/expected/rdkit-91.out
+++ b/Code/PgSQL/rdkit/expected/rdkit-91.out
@@ -1333,9 +1333,9 @@ select mol_to_smarts(mol_adjust_query_properties('*c1ncc(*)cc1'::mol));
 (1 row)
 
 select mol_to_smarts(mol_adjust_query_properties('*c1ncc(*)cc1'::qmol));
-                 mol_to_smarts                 
------------------------------------------------
- *[c&D3]1[n&D2][c&D2][c&D3](-,:*)[c&D2][c&D2]1
+               mol_to_smarts                
+--------------------------------------------
+ *[c&D3]1[n&D2][c&D2][c&D3](*)[c&D2][c&D2]1
 (1 row)
 
 -- CXSmiles
@@ -1358,9 +1358,9 @@ SELECT mol_to_cxsmarts(mol_from_smiles('C[C@H](F)[C@H](C)[C@@H](C)Br |a:1,o1:4,5
 (1 row)
 
 SELECT mol_to_cxsmarts(qmol_from_smarts('C[C@H]([F,Cl,Br])[C@H](C)[C@@H](C)Br |a:1,o1:4,5|'));
-                         mol_to_cxsmarts                          
-------------------------------------------------------------------
- C[C@&H1](-,:[F,Cl,Br])[C@&H1](-,:C)[C@@&H1](-,:C)Br |a:1,o1:4,5|
+                     mol_to_cxsmarts                     
+---------------------------------------------------------
+ C[C@&H1]([F,Cl,Br])[C@&H1](C)[C@@&H1](C)Br |a:1,o1:4,5|
 (1 row)
 
 -- CXSmiles from mol_out


### PR DESCRIPTION
These weren't being correctly assigned the SingleOrAromatic shorthand

This has no impact on correctness, just the verbosity of the output SMARTS.

Here's a demonstration of the problem.

Before this PR:
```
In [3]: Chem.MolToSmarts(Chem.MolFromSmarts('C(C)C'))
Out[3]: 'C(-,:C)C'
```

After this PR:
```
In [2]: Chem.MolToSmarts(Chem.MolFromSmarts('C(C)C'))
Out[2]: 'C(C)C'
```