### PR TITLE
WIP: MMCIF Parser

### DIFF
--- a/Code/GraphMol/FileParsers/FileParsers.h
+++ b/Code/GraphMol/FileParsers/FileParsers.h
@@ -308,6 +308,12 @@ RDKIT_FILEPARSERS_EXPORT RWMol *PDBFileToMol(const std::string &fname,
                                              unsigned int flavor = 0,
                                              bool proximityBonding = true);
 
+RDKIT_FILEPARSERS_EXPORT RWMol *MMCifFileToMol(const std::string &fname,
+                                               bool sanitize = true,
+                                               bool removeHs = true,
+                                               unsigned int flavor = 0,
+                                               bool proximityBonding = true);
+
 // \brief generates an PDB block for a molecule
 /*!
  *   \param mol           - the molecule in question

--- a/Code/GraphMol/FileParsers/FileParsers.h
+++ b/Code/GraphMol/FileParsers/FileParsers.h
@@ -308,7 +308,7 @@ RDKIT_FILEPARSERS_EXPORT RWMol *PDBFileToMol(const std::string &fname,
                                              unsigned int flavor = 0,
                                              bool proximityBonding = true);
 
-RDKIT_FILEPARSERS_EXPORT RWMol *MMCifFileToMol(const std::string &fname,
+RDKIT_FILEPARSERS_EXPORT RWMol *mmcifFileToMol(const std::string &fname,
                                                bool sanitize = true,
                                                bool removeHs = true,
                                                unsigned int flavor = 0,

--- a/Code/GraphMol/FileParsers/PDBParser.cpp
+++ b/Code/GraphMol/FileParsers/PDBParser.cpp
@@ -796,7 +796,7 @@ void parseMmcifAtoms(std::istream &ifs, const std::array<int, N_ATTRS> &name2col
         atomnum = 0;
 
         if ((flavor & 2) == 0) {
-          conf = new Conformer();
+          conf = new Conformer(mol->getNumAtoms());
           conf->set3D(true);
           conf->setId(mol->getNumConformers());
           mol->addConformer(conf, false);

--- a/Code/GraphMol/FileParsers/PDBParser.cpp
+++ b/Code/GraphMol/FileParsers/PDBParser.cpp
@@ -895,32 +895,20 @@ void parseMmcifAtoms(std::istream &ifs, const std::array<int, N_ATTRS> &name2col
     if (conf) {
       RDGeom::Point3D pos = {0.0, 0.0, 0.0};
 
-      if (name2column[CARTNX] != NOT_PRESENT) {
-        try {
+      try {
+        if (name2column[CARTNX] != NOT_PRESENT) {
           pos.x = FileParserUtils::toDouble(tokens[name2column[CARTNX]]);
-        } catch (boost::bad_lexical_cast &) {
-          std::ostringstream errout;
-          errout << "Problem with coordinates for PDB atom #" << a->getIdx();
-          throw FileParseException(errout.str());
         }
-      }
-      if (name2column[CARTNY] != NOT_PRESENT) {
-        try {
+        if (name2column[CARTNY] != NOT_PRESENT) {
           pos.y = FileParserUtils::toDouble(tokens[name2column[CARTNY]]);
-        } catch (boost::bad_lexical_cast &) {
-          std::ostringstream errout;
-          errout << "Problem with coordinates for PDB atom #" << a->getIdx();
-          throw FileParseException(errout.str());
         }
-      }
-      if (name2column[CARTNZ] != NOT_PRESENT) {
-        try {
+        if (name2column[CARTNZ] != NOT_PRESENT) {
           pos.z = FileParserUtils::toDouble(tokens[name2column[CARTNZ]]);
-        } catch (boost::bad_lexical_cast &) {
-          std::ostringstream errout;
-          errout << "Problem with coordinates for PDB atom #" << a->getIdx();
-          throw FileParseException(errout.str());
         }
+      } catch (boost::bad_lexical_cast &) {
+        std::ostringstream errout;
+        errout << "Problem with coordinates for PDB atom #" << a->getIdx();
+        throw FileParseException(errout.str());
       }
 
       conf->setAtomPos(a->getIdx(), pos);

--- a/Code/GraphMol/FileParsers/PDBParser.cpp
+++ b/Code/GraphMol/FileParsers/PDBParser.cpp
@@ -770,14 +770,12 @@ void parseMmcifAtoms(std::istream &ifs, const std::array<int, N_ATTRS> &name2col
       continue;
     }
 
-    Atom *a = nullptr;
-
     std::string tmp = tokens[name2column[TYPE_SYMBOL]];
     // BR -> Br etc
     for (unsigned int i=1; i<tmp.length(); ++i) {
       tmp[i] = tolower(tmp[i]);
     }
-    a = PDBAtomFromSymbol(tmp.c_str());
+    auto a = PDBAtomFromSymbol(tmp.c_str());
 
     if (!a) {
       std::ostringstream errout;
@@ -1011,7 +1009,10 @@ void parseMMCifFile(RWMol *&mol,
     }
 
     // slurp all rows from atom_site section
-    parseMmcifAtoms(ifs, name2column, mol, flavor);
+    {
+      Utils::LocaleSwitcher ls;
+      parseMmcifAtoms(ifs, name2column, mol, flavor);
+    }
   }
   if (!mol) {
     return;

--- a/Code/GraphMol/FileParsers/PDBParser.cpp
+++ b/Code/GraphMol/FileParsers/PDBParser.cpp
@@ -738,8 +738,17 @@ constexpr size_t GROUP_PDB=0, ATOMID=1, TYPE_SYMBOL=2, ATOMNAME=3, ALT_ID=4, \
 constexpr size_t N_ATTRS=16;
 constexpr int NOT_PRESENT = -1;
 
-bool is_quotation(char c) {
+static inline bool is_quotation(char c) {
   return c == '"';
+}
+
+// mmcif uses either '.' or '?' for blank values, change to ' ' to match PDB
+static inline void coerce_blank_values(std::string &value) {
+  if (value == ".") {
+    value = " ";
+  } else if (value == "?") {
+    value = " ";
+  }
 }
 
 void parseMmcifAtoms(std::istream &ifs, const std::array<int, N_ATTRS> &name2column,
@@ -851,21 +860,15 @@ void parseMmcifAtoms(std::istream &ifs, const std::array<int, N_ATTRS> &name2col
     info->setResidueName(tmp);
 
     tmp = name2column[ALT_ID] != NOT_PRESENT ? tokens[name2column[ALT_ID]] : " ";
-    if (tmp == ".") { // "." used as non value instead of " "
-      tmp = " ";
-    }
+    coerce_blank_values(tmp);
     info->setAltLoc(tmp);
 
     tmp = name2column[CHAINID] != NOT_PRESENT ? tokens[name2column[CHAINID]] : " ";
-    if (tmp == ".") {
-      tmp = " ";
-    }
+    coerce_blank_values(tmp);
     info->setChainId(tmp);
 
     tmp = name2column[INSCODE] != NOT_PRESENT ? tokens[name2column[INSCODE]] : " ";
-    if (tmp == ".") {
-      tmp = " ";
-    }
+    coerce_blank_values(tmp);
     info->setInsertionCode(tmp);
 
     double occup = 1.0;

--- a/Code/GraphMol/FileParsers/ProximityBonds.cpp
+++ b/Code/GraphMol/FileParsers/ProximityBonds.cpp
@@ -291,15 +291,24 @@ static bool StandardPDBDoubleBond(unsigned int rescode, unsigned int atm1,
       if (atm1 == BCATM(' ', 'C', ' ', ' ') &&
           atm2 == BCATM(' ', 'O', ' ', ' ')) {
         return true;
+      } else if (atm1 == BCATM('C', ' ', ' ', ' ') &&
+                 atm2 == BCATM('O', ' ', ' ', ' ')) {
+        return true;
       }
       break;
     case BCNAM('A', 'R', 'G'):
       if (atm1 == BCATM(' ', 'C', ' ', ' ') &&
           atm2 == BCATM(' ', 'O', ' ', ' ')) {
         return true;
+      } else if (atm1 == BCATM('C', ' ', ' ', ' ') &&
+                 atm2 == BCATM('O', ' ', ' ', ' ')) {
+        return true;
       }
       if (atm1 == BCATM(' ', 'C', 'Z', ' ') &&
           atm2 == BCATM(' ', 'N', 'H', '2')) {
+        return true;
+      } else if (atm1 == BCATM('C', 'Z', ' ', ' ') &&
+                 atm2 == BCATM('N', 'H', '2', ' ')) {
         return true;
       }
       break;
@@ -308,9 +317,15 @@ static bool StandardPDBDoubleBond(unsigned int rescode, unsigned int atm1,
       if (atm1 == BCATM(' ', 'C', ' ', ' ') &&
           atm2 == BCATM(' ', 'O', ' ', ' ')) {
         return true;
+      } else if (atm1 == BCATM('C', ' ', ' ', ' ') &&
+                 atm2 == BCATM('O', ' ', ' ', ' ')) {
+        return true;
       }
       if (atm1 == BCATM(' ', 'C', 'G', ' ') &&
           atm2 == BCATM(' ', 'O', 'D', '1')) {
+        return true;
+      } else if (atm1 == BCATM('C', 'G', ' ', ' ') &&
+                 atm2 == BCATM('O', 'D', '1', ' ')) {
         return true;
       }
       break;
@@ -319,9 +334,15 @@ static bool StandardPDBDoubleBond(unsigned int rescode, unsigned int atm1,
       if (atm1 == BCATM(' ', 'C', ' ', ' ') &&
           atm2 == BCATM(' ', 'O', ' ', ' ')) {
         return true;
+      } else if (atm1 == BCATM('C', ' ', ' ', ' ') &&
+                 atm2 == BCATM('O', ' ', ' ', ' ')) {
+        return true;
       }
       if (atm1 == BCATM(' ', 'C', 'D', ' ') &&
           atm2 == BCATM(' ', 'O', 'E', '1')) {
+        return true;
+      } else if (atm1 == BCATM('C', 'D', ' ', ' ') &&
+                 atm2 == BCATM('O', 'E', '1', ' ')) {
         return true;
       }
       break;
@@ -329,13 +350,21 @@ static bool StandardPDBDoubleBond(unsigned int rescode, unsigned int atm1,
       if (atm1 == BCATM(' ', 'C', ' ', ' ') &&
           atm2 == BCATM(' ', 'O', ' ', ' ')) {
         return true;
+      } else if (atm1 == BCATM('C', ' ', ' ', ' ') &&
+                 atm2 == BCATM('O', ' ', ' ', ' ')) {
+        return true;
       }
       if (atm1 == BCATM(' ', 'C', 'D', '2') &&
           atm2 == BCATM(' ', 'C', 'G', ' ')) {
         return true;
-      }
+      } else if (atm1 == BCATM('C', 'D', '2', ' ') &&
+                 atm2 == BCATM('C', 'G', ' ', ' '))
+        return true;
       if (atm1 == BCATM(' ', 'C', 'E', '1') &&
           atm2 == BCATM(' ', 'N', 'D', '1')) {
+        return true;
+      } else if (atm1 == BCATM('C', 'E', '1', ' ') &&
+                 atm2 == BCATM('N', 'D', '1', ' ')) {
         return true;
       }
       break;
@@ -344,17 +373,29 @@ static bool StandardPDBDoubleBond(unsigned int rescode, unsigned int atm1,
       if (atm1 == BCATM(' ', 'C', ' ', ' ') &&
           atm2 == BCATM(' ', 'O', ' ', ' ')) {
         return true;
+      } else if (atm1 == BCATM('C', ' ', ' ', ' ') &&
+                 atm2 == BCATM('O', ' ', ' ', ' ')) {
+        return true;
       }
       if (atm1 == BCATM(' ', 'C', 'D', '1') &&
           atm2 == BCATM(' ', 'C', 'G', ' ')) {
+        return true;
+      } else if (atm1 == BCATM('C', 'D', '1', ' ') &&
+                 atm2 == BCATM('C', 'G', ' ', ' ')) {
         return true;
       }
       if (atm1 == BCATM(' ', 'C', 'D', '2') &&
           atm2 == BCATM(' ', 'C', 'E', '2')) {
         return true;
+      } else if (atm1 == BCATM('C', 'D', '2', ' ') &&
+                 atm2 == BCATM('C', 'E', '2', ' ')) {
+        return true;
       }
       if (atm1 == BCATM(' ', 'C', 'E', '1') &&
           atm2 == BCATM(' ', 'C', 'Z', ' ')) {
+        return true;
+      } else if (atm1 == BCATM('C', 'E', '1', ' ') &&
+                 atm2 == BCATM('C', 'Z', ' ', ' ')) {
         return true;
       }
       break;
@@ -362,67 +403,116 @@ static bool StandardPDBDoubleBond(unsigned int rescode, unsigned int atm1,
       if (atm1 == BCATM(' ', 'C', ' ', ' ') &&
           atm2 == BCATM(' ', 'O', ' ', ' ')) {
         return true;
+      } else if (atm1 == BCATM('C', ' ', ' ', ' ') &&
+                 atm2 == BCATM('O', ' ', ' ', ' ')) {
+        return true;
       }
       if (atm1 == BCATM(' ', 'C', 'D', '1') &&
           atm2 == BCATM(' ', 'C', 'G', ' ')) {
+        return true;
+      } else if (atm1 == BCATM('C', 'D', '1', ' ') &&
+                 atm2 == BCATM('C', 'G', ' ', ' ')) {
         return true;
       }
       if (atm1 == BCATM(' ', 'C', 'D', '2') &&
           atm2 == BCATM(' ', 'C', 'E', '2')) {
         return true;
+      } else if (atm1 == BCATM('C', 'D', '2', ' ') &&
+                 atm2 == BCATM('C', 'E', '2', ' ')) {
+        return true;
       }
       if (atm1 == BCATM(' ', 'C', 'E', '3') &&
           atm2 == BCATM(' ', 'C', 'Z', '3')) {
+        return true;
+      } else if (atm1 == BCATM('C', 'E', '3', ' ') &&
+                 atm2 == BCATM('C', 'Z', '3', ' ')) {
         return true;
       }
       if (atm1 == BCATM(' ', 'C', 'H', '2') &&
           atm2 == BCATM(' ', 'C', 'Z', '2')) {
         return true;
+      } else if (atm1 == BCATM('C', 'H', '2', ' ') &&
+                 atm2 == BCATM('C', 'Z', '2', ' ')) {
+        return true;
       }
       break;
     case BCNAM(' ', ' ', 'A'):
     case BCNAM(' ', 'D', 'A'):
+    case BCNAM('A', ' ', ' '):
+    case BCNAM('D', 'A', ' '):
       if (atm1 == BCATM(' ', 'C', '6', ' ') &&
           atm2 == BCATM(' ', 'N', '1', ' ')) {
+        return true;
+      } else if (atm1 == BCATM('C', '6', ' ', ' ') &&
+                 atm2 == BCATM('N', '1', ' ', ' ')) {
         return true;
       }
       if (atm1 == BCATM(' ', 'C', '2', ' ') &&
           atm2 == BCATM(' ', 'N', '3', ' ')) {
         return true;
+      } else if (atm1 == BCATM('C', '2', ' ', ' ') &&
+                 atm2 == BCATM('N', '3', ' ', ' ')) {
+        return true;
       }
       if (atm1 == BCATM(' ', 'C', '4', ' ') &&
           atm2 == BCATM(' ', 'C', '5', ' ')) {
+        return true;
+      } else if (atm1 == BCATM('C', '4', ' ', ' ') &&
+                 atm2 == BCATM('C', '5', ' ', ' ')) {
         return true;
       }
       if (atm1 == BCATM(' ', 'C', '8', ' ') &&
           atm2 == BCATM(' ', 'N', '7', ' ')) {
         return true;
+      } else if (atm1 == BCATM('C', '8', ' ', ' ') &&
+                 atm2 == BCATM('N', '7', ' ', ' ')) {
+        return true;
       }
       if (atm1 == BCATM(' ', 'O', 'P', '1') &&
           atm2 == BCATM(' ', 'P', ' ', ' ')) {
+        return true;
+      } else if (atm1 == BCATM('O', 'P', '1', ' ') &&
+                 atm2 == BCATM('P', ' ', ' ', ' ')) {
         return true;
       }
       break;
     case BCNAM(' ', ' ', 'G'):
     case BCNAM(' ', 'D', 'G'):
+    case BCNAM('G', ' ', ' '):
+    case BCNAM('D', 'G', ' '):
       if (atm1 == BCATM(' ', 'C', '6', ' ') &&
           atm2 == BCATM(' ', 'O', '6', ' ')) {
+        return true;
+      } else if (atm1 == BCATM('C', '6', ' ', ' ') &&
+                 atm2 == BCATM('O', '6', ' ', ' ')) {
         return true;
       }
       if (atm1 == BCATM(' ', 'C', '2', ' ') &&
           atm2 == BCATM(' ', 'N', '3', ' ')) {
         return true;
+      } else if (atm1 == BCATM('C', '2', ' ', ' ') &&
+                 atm2 == BCATM('N', '3', ' ', ' ')) {
+        return true;
       }
       if (atm1 == BCATM(' ', 'C', '4', ' ') &&
           atm2 == BCATM(' ', 'C', '5', ' ')) {
+        return true;
+      } else if (atm1 == BCATM('C', '4', ' ', ' ') &&
+                 atm2 == BCATM('C', '5', ' ', ' ')) {
         return true;
       }
       if (atm1 == BCATM(' ', 'C', '8', ' ') &&
           atm2 == BCATM(' ', 'N', '7', ' ')) {
         return true;
+      } else if (atm1 == BCATM('C', '8', ' ', ' ') &&
+                 atm2 == BCATM('N', '7', ' ', ' ')) {
+        return true;
       }
       if (atm1 == BCATM(' ', 'O', 'P', '1') &&
           atm2 == BCATM(' ', 'P', ' ', ' ')) {
+        return true;
+      } else if (atm1 == BCATM('O', 'P', '1', ' ') &&
+                 atm2 == BCATM('P', ' ', ' ', ' ')) {
         return true;
       }
       break;
@@ -445,6 +535,17 @@ static bool StandardPDBDoubleBond(unsigned int rescode, unsigned int atm1,
         return true;
       }
       break;
+    case BCNAM('C', ' ', ' '):
+    case BCNAM('D', 'C', ' '):
+      if (atm1 == BCATM('C', '2', ' ', ' ') &&
+          atm2 == BCATM('O', '2', ' ', ' ')) {
+        return true;
+      }
+      if (atm1 == BCATM('C', '4', ' ', ' ') &&
+          atm2 == BCATM('N', '3', ' ', ' ')) {
+        return true;
+      }
+      break;
     case BCNAM(' ', ' ', 'T'):
     case BCNAM(' ', 'D', 'T'):
     case BCNAM(' ', ' ', 'U'):
@@ -463,6 +564,27 @@ static bool StandardPDBDoubleBond(unsigned int rescode, unsigned int atm1,
       }
       if (atm1 == BCATM(' ', 'O', 'P', '1') &&
           atm2 == BCATM(' ', 'P', ' ', ' ')) {
+        return true;
+      }
+      break;
+    case BCNAM('T', ' ', ' '):
+    case BCNAM('D', 'T', ' '):
+    case BCNAM('U', ' ', ' '):
+    case BCNAM('D', 'U', ' '):
+      if (atm1 == BCATM('C', '2', ' ', ' ') &&
+          atm2 == BCATM( 'O', '2', ' ', ' ')) {
+        return true;
+      }
+      if (atm1 == BCATM( 'C', '4', ' ', ' ') &&
+          atm2 == BCATM( 'O', '4', ' ', ' ')) {
+        return true;
+      }
+      if (atm1 == BCATM( 'C', '5', ' ', ' ') &&
+          atm2 == BCATM( 'C', '6', ' ', ' ')) {
+        return true;
+      }
+      if (atm1 == BCATM( 'O', 'P', '1', ' ') &&
+          atm2 == BCATM( 'P', ' ', ' ', ' ')) {
         return true;
       }
       break;

--- a/Code/GraphMol/FileParsers/file_parsers_catch.cpp
+++ b/Code/GraphMol/FileParsers/file_parsers_catch.cpp
@@ -4447,5 +4447,28 @@ TEST_CASE("MMCIF PARSING") {
                 m->getAtomWithIdx(2292)->getMonomerInfo())
                 ->getResidueName() == "LIA");
 
+    delete m;
+  }
+  
+  SECTION("4BNA") {
+    std::string fName;
+    fName = rdbase + "4bna.cif";
+    ROMol *m = mmcifFileToMol(fName);
+    REQUIRE(m);
+    REQUIRE(m->getNumHeavyAtoms() == 602);
+    REQUIRE(m->getAtomWithIdx(0)->getMonomerInfo());
+    REQUIRE(m->getAtomWithIdx(0)->getMonomerInfo()->getMonomerType() ==
+                AtomMonomerInfo::PDBRESIDUE);
+    REQUIRE(static_cast<AtomPDBResidueInfo *>(
+                m->getAtomWithIdx(0)->getMonomerInfo())
+                ->getSerialNumber() == 1);
+    REQUIRE(static_cast<AtomPDBResidueInfo *>(
+                m->getAtomWithIdx(1)->getMonomerInfo())
+                    ->getResidueName() == "DC");
+    REQUIRE(static_cast<AtomPDBResidueInfo *>(
+                    m->getAtomWithIdx(57)->getMonomerInfo())
+                    ->getResidueName() == "DG");
+    std::string mb = MolToPDBBlock(*m);
+    delete m;
   }
 }

--- a/Code/GraphMol/FileParsers/file_parsers_catch.cpp
+++ b/Code/GraphMol/FileParsers/file_parsers_catch.cpp
@@ -4364,18 +4364,18 @@ TEST_CASE("MMCIF PARSING") {
   std::string rdbase = getenv("RDBASE");
   rdbase += "/Code/GraphMol/FileParsers/test_data/";
   std::string fname;
-  
+
   SECTION("1CRN") {
     fname = rdbase + "1crn.cif";
-    
+
     ROMol *m = mmcifFileToMol(fname);
-    
+
     REQUIRE(m);
     REQUIRE(m->getNumAtoms() == 327);
     REQUIRE(m->getNumBonds() == 337);
     REQUIRE(m->getAtomWithIdx(0)->getMonomerInfo());
     REQUIRE(m->getAtomWithIdx(0)->getMonomerInfo()->getMonomerType() ==
-                AtomMonomerInfo::PDBRESIDUE);
+            AtomMonomerInfo::PDBRESIDUE);
 
     REQUIRE(static_cast<AtomPDBResidueInfo *>(
                 m->getAtomWithIdx(0)->getMonomerInfo())
@@ -4401,7 +4401,7 @@ TEST_CASE("MMCIF PARSING") {
 
     delete m;
   }
-  
+
   SECTION("2FVD") {
     fname = rdbase + "2fvd.cif";
     ROMol *m = mmcifFileToMol(fname);
@@ -4410,7 +4410,7 @@ TEST_CASE("MMCIF PARSING") {
     REQUIRE(m->getNumBonds() == 2383);
     REQUIRE(m->getAtomWithIdx(0)->getMonomerInfo());
     REQUIRE(m->getAtomWithIdx(0)->getMonomerInfo()->getMonomerType() ==
-                AtomMonomerInfo::PDBRESIDUE);
+            AtomMonomerInfo::PDBRESIDUE);
     REQUIRE(static_cast<AtomPDBResidueInfo *>(
                 m->getAtomWithIdx(0)->getMonomerInfo())
                 ->getSerialNumber() == 1);
@@ -4449,7 +4449,7 @@ TEST_CASE("MMCIF PARSING") {
 
     delete m;
   }
-  
+
   SECTION("4BNA") {
     std::string fName;
     fName = rdbase + "4bna.cif";
@@ -4458,17 +4458,50 @@ TEST_CASE("MMCIF PARSING") {
     REQUIRE(m->getNumHeavyAtoms() == 602);
     REQUIRE(m->getAtomWithIdx(0)->getMonomerInfo());
     REQUIRE(m->getAtomWithIdx(0)->getMonomerInfo()->getMonomerType() ==
-                AtomMonomerInfo::PDBRESIDUE);
+            AtomMonomerInfo::PDBRESIDUE);
     REQUIRE(static_cast<AtomPDBResidueInfo *>(
                 m->getAtomWithIdx(0)->getMonomerInfo())
                 ->getSerialNumber() == 1);
     REQUIRE(static_cast<AtomPDBResidueInfo *>(
                 m->getAtomWithIdx(1)->getMonomerInfo())
-                    ->getResidueName() == "DC");
+                ->getResidueName() == "DC");
     REQUIRE(static_cast<AtomPDBResidueInfo *>(
-                    m->getAtomWithIdx(57)->getMonomerInfo())
-                    ->getResidueName() == "DG");
+                m->getAtomWithIdx(57)->getMonomerInfo())
+                ->getResidueName() == "DG");
     std::string mb = MolToPDBBlock(*m);
+    delete m;
+  }
+
+  SECTION("4TNA") {
+    std::string fName;
+    fName = rdbase + "4tna.cif";
+    ROMol *m = mmcifFileToMol(fName);
+    REQUIRE(m);
+    REQUIRE(m->getNumHeavyAtoms() == 1656);
+    REQUIRE(m->getAtomWithIdx(0)->getMonomerInfo());
+    REQUIRE(m->getAtomWithIdx(0)->getMonomerInfo()->getMonomerType() ==
+            AtomMonomerInfo::PDBRESIDUE);
+    REQUIRE(
+        static_cast<AtomPDBResidueInfo *>(m->getAtomWithIdx(0)->getMonomerInfo())
+            ->getSerialNumber() == 1);
+    REQUIRE(
+        static_cast<AtomPDBResidueInfo *>(m->getAtomWithIdx(1)->getMonomerInfo())
+            ->getResidueName() == "G");
+    REQUIRE(
+        static_cast<AtomPDBResidueInfo *>(m->getAtomWithIdx(90)->getMonomerInfo())
+            ->getResidueName() == "A");
+    REQUIRE(static_cast<AtomPDBResidueInfo *>(
+                m->getAtomWithIdx(197)->getMonomerInfo())
+                ->getResidueName() == "2MG");
+    REQUIRE(static_cast<AtomPDBResidueInfo *>(
+                m->getAtomWithIdx(197)->getMonomerInfo())
+                ->getIsHeteroAtom());
+    REQUIRE(m->getBondBetweenAtoms(104, 103)->getBondType() ==
+            Bond::AROMATIC);
+    REQUIRE(m->getBondBetweenAtoms(60, 61)->getBondType() == Bond::DOUBLE);
+    REQUIRE(m->getBondBetweenAtoms(38, 37)->getBondType() == Bond::DOUBLE);
+    REQUIRE(m->getBondBetweenAtoms(148, 149)->getBondType() == Bond::DOUBLE);
+  
     delete m;
   }
 }

--- a/Code/GraphMol/FileParsers/file_parsers_catch.cpp
+++ b/Code/GraphMol/FileParsers/file_parsers_catch.cpp
@@ -4412,39 +4412,40 @@ TEST_CASE("MMCIF PARSING") {
     REQUIRE(m->getAtomWithIdx(0)->getMonomerInfo()->getMonomerType() ==
                 AtomMonomerInfo::PDBRESIDUE);
     REQUIRE(static_cast<AtomPDBResidueInfo *>(
-                    m->getAtomWithIdx(0)->getMonomerInfo())
-                    ->getSerialNumber() == 1);
+                m->getAtomWithIdx(0)->getMonomerInfo())
+                ->getSerialNumber() == 1);
     REQUIRE(static_cast<AtomPDBResidueInfo *>(
-                    m->getAtomWithIdx(0)->getMonomerInfo())
-                    ->getResidueNumber() == 1);
+                m->getAtomWithIdx(0)->getMonomerInfo())
+                ->getResidueNumber() == 1);
     REQUIRE(static_cast<AtomPDBResidueInfo *>(
-                    m->getAtomWithIdx(0)->getMonomerInfo())
-                    ->getIsHeteroAtom() == 0);
+                m->getAtomWithIdx(0)->getMonomerInfo())
+                ->getIsHeteroAtom() == 0);
+    // different to PDB file as there is no TER record
     REQUIRE(static_cast<AtomPDBResidueInfo *>(
-                    m->getAtomWithIdx(2292)->getMonomerInfo())
-                    ->getSerialNumber() == 2294);
+                m->getAtomWithIdx(2292)->getMonomerInfo())
+                ->getSerialNumber() == 2293);
     REQUIRE(static_cast<AtomPDBResidueInfo *>(
-                    m->getAtomWithIdx(2292)->getMonomerInfo())
-                    ->getResidueNumber() == 299);
+                m->getAtomWithIdx(2292)->getMonomerInfo())
+                ->getResidueNumber() == 299);
     REQUIRE(static_cast<AtomPDBResidueInfo *>(
-                    m->getAtomWithIdx(2292)->getMonomerInfo())
-                    ->getIsHeteroAtom() == 1);
+                m->getAtomWithIdx(2292)->getMonomerInfo())
+                ->getIsHeteroAtom() == 1);
     REQUIRE(static_cast<AtomPDBResidueInfo *>(
-                    m->getAtomWithIdx(2292)->getMonomerInfo())
-                    ->getChainId() == "A");
-    
+                m->getAtomWithIdx(2292)->getMonomerInfo())
+                ->getChainId() == "B");  // different from PDB
+
     REQUIRE(static_cast<AtomPDBResidueInfo *>(
-                    m->getAtomWithIdx(1)->getMonomerInfo())
-                    ->getName() == " CA ");
+                m->getAtomWithIdx(1)->getMonomerInfo())
+                ->getName() == "CA");
     REQUIRE(static_cast<AtomPDBResidueInfo *>(
-                    m->getAtomWithIdx(1)->getMonomerInfo())
-                    ->getResidueName() == "MET");
+                m->getAtomWithIdx(1)->getMonomerInfo())
+                ->getResidueName() == "MET");
     REQUIRE(static_cast<AtomPDBResidueInfo *>(
-                    m->getAtomWithIdx(2292)->getMonomerInfo())
-                    ->getName() == " N1 ");
+                m->getAtomWithIdx(2292)->getMonomerInfo())
+                ->getName() == "N1");
     REQUIRE(static_cast<AtomPDBResidueInfo *>(
-                    m->getAtomWithIdx(2292)->getMonomerInfo())
-                    ->getResidueName() == "LIA");
+                m->getAtomWithIdx(2292)->getMonomerInfo())
+                ->getResidueName() == "LIA");
 
   }
 }

--- a/Code/GraphMol/FileParsers/file_parsers_catch.cpp
+++ b/Code/GraphMol/FileParsers/file_parsers_catch.cpp
@@ -4504,4 +4504,34 @@ TEST_CASE("MMCIF PARSING") {
   
     delete m;
   }
+
+  SECTION("1DOY") {
+    std::string fname;
+    fname = rdbase + "1doy.cif";
+
+    ROMol *m = mmcifFileToMol(fname);
+
+    REQUIRE(m);
+    REQUIRE(m->getNumConformers() == 3);
+
+    auto c = m->getConformer(0);
+    auto p = c.getAtomPos(0);
+    REQUIRE(p.x == 15.15);
+    REQUIRE(p.y == -7.438);
+    REQUIRE(p.z == -7.235);
+
+    c = m->getConformer(1);
+    p = c.getAtomPos(0);
+    REQUIRE(p.x == 5.499);
+    REQUIRE(p.y == -6.831);
+    REQUIRE(p.z == -8.405);
+
+    c = m->getConformer(2);
+    p = c.getAtomPos(0);
+    REQUIRE(p.x == 12.843);
+    REQUIRE(p.y == -9.022);
+    REQUIRE(p.z == -7.588);
+
+    delete m;
+  }
 }

--- a/Code/GraphMol/FileParsers/file_parsers_catch.cpp
+++ b/Code/GraphMol/FileParsers/file_parsers_catch.cpp
@@ -9,6 +9,7 @@
 
 #include "RDGeneral/test.h"
 #include "catch.hpp"
+#include "GraphMol/MonomerInfo.h"
 #include <RDGeneral/Invariant.h>
 #include <GraphMol/RDKitBase.h>
 #include <GraphMol/QueryAtom.h>
@@ -4356,5 +4357,94 @@ M  V30 END CTAB
 M  END
 )CTAB"_ctab;
     REQUIRE(mol);
+  }
+}
+
+TEST_CASE("MMCIF PARSING") {
+  std::string rdbase = getenv("RDBASE");
+  rdbase += "/Code/GraphMol/FileParsers/test_data/";
+  std::string fname;
+  
+  SECTION("1CRN") {
+    fname = rdbase + "1crn.cif";
+    
+    ROMol *m = mmcifFileToMol(fname);
+    
+    REQUIRE(m);
+    REQUIRE(m->getNumAtoms() == 327);
+    REQUIRE(m->getNumBonds() == 337);
+    REQUIRE(m->getAtomWithIdx(0)->getMonomerInfo());
+    REQUIRE(m->getAtomWithIdx(0)->getMonomerInfo()->getMonomerType() ==
+                AtomMonomerInfo::PDBRESIDUE);
+
+    REQUIRE(static_cast<AtomPDBResidueInfo *>(
+                m->getAtomWithIdx(0)->getMonomerInfo())
+                ->getResidueNumber() == 1);
+    REQUIRE(static_cast<AtomPDBResidueInfo *>(
+                m->getAtomWithIdx(9)->getMonomerInfo())
+                ->getResidueNumber() == 2);
+
+    REQUIRE(static_cast<AtomPDBResidueInfo *>(
+                m->getAtomWithIdx(0)->getMonomerInfo())
+                ->getName() == "N");
+    REQUIRE(static_cast<AtomPDBResidueInfo *>(
+                m->getAtomWithIdx(0)->getMonomerInfo())
+                ->getResidueName() == "THR");
+    REQUIRE(feq(static_cast<AtomPDBResidueInfo *>(
+                    m->getAtomWithIdx(0)->getMonomerInfo())
+                    ->getTempFactor(),
+                13.79));
+    REQUIRE(m->getNumConformers() == 1);
+    REQUIRE(feq(m->getConformer().getAtomPos(0).x, 17.047));
+    REQUIRE(feq(m->getConformer().getAtomPos(0).y, 14.099));
+    REQUIRE(feq(m->getConformer().getAtomPos(0).z, 3.625));
+
+    delete m;
+  }
+  
+  SECTION("2FVD") {
+    fname = rdbase + "2fvd.cif";
+    ROMol *m = mmcifFileToMol(fname);
+    REQUIRE(m);
+    REQUIRE(m->getNumAtoms() == 2501);
+    REQUIRE(m->getNumBonds() == 2383);
+    REQUIRE(m->getAtomWithIdx(0)->getMonomerInfo());
+    REQUIRE(m->getAtomWithIdx(0)->getMonomerInfo()->getMonomerType() ==
+                AtomMonomerInfo::PDBRESIDUE);
+    REQUIRE(static_cast<AtomPDBResidueInfo *>(
+                    m->getAtomWithIdx(0)->getMonomerInfo())
+                    ->getSerialNumber() == 1);
+    REQUIRE(static_cast<AtomPDBResidueInfo *>(
+                    m->getAtomWithIdx(0)->getMonomerInfo())
+                    ->getResidueNumber() == 1);
+    REQUIRE(static_cast<AtomPDBResidueInfo *>(
+                    m->getAtomWithIdx(0)->getMonomerInfo())
+                    ->getIsHeteroAtom() == 0);
+    REQUIRE(static_cast<AtomPDBResidueInfo *>(
+                    m->getAtomWithIdx(2292)->getMonomerInfo())
+                    ->getSerialNumber() == 2294);
+    REQUIRE(static_cast<AtomPDBResidueInfo *>(
+                    m->getAtomWithIdx(2292)->getMonomerInfo())
+                    ->getResidueNumber() == 299);
+    REQUIRE(static_cast<AtomPDBResidueInfo *>(
+                    m->getAtomWithIdx(2292)->getMonomerInfo())
+                    ->getIsHeteroAtom() == 1);
+    REQUIRE(static_cast<AtomPDBResidueInfo *>(
+                    m->getAtomWithIdx(2292)->getMonomerInfo())
+                    ->getChainId() == "A");
+    
+    REQUIRE(static_cast<AtomPDBResidueInfo *>(
+                    m->getAtomWithIdx(1)->getMonomerInfo())
+                    ->getName() == " CA ");
+    REQUIRE(static_cast<AtomPDBResidueInfo *>(
+                    m->getAtomWithIdx(1)->getMonomerInfo())
+                    ->getResidueName() == "MET");
+    REQUIRE(static_cast<AtomPDBResidueInfo *>(
+                    m->getAtomWithIdx(2292)->getMonomerInfo())
+                    ->getName() == " N1 ");
+    REQUIRE(static_cast<AtomPDBResidueInfo *>(
+                    m->getAtomWithIdx(2292)->getMonomerInfo())
+                    ->getResidueName() == "LIA");
+
   }
 }

--- a/Code/GraphMol/FileParsers/test1.cpp
+++ b/Code/GraphMol/FileParsers/test1.cpp
@@ -4001,6 +4001,54 @@ void testPDBFile() {
   BOOST_LOG(rdInfoLog) << "done" << std::endl;
 }
 
+void testMMCifFile() {
+  BOOST_LOG(rdInfoLog) << "testing reading mmcif files" << std::endl;
+
+  std::string rdbase = getenv("RDBASE");
+  rdbase += "/Code/GraphMol/FileParsers/test_data/";
+
+  {
+    std::string fname;
+
+    fname = rdbase + "1crn.cif";
+
+    ROMol *m = MMCifFileToMol(fname);
+
+    TEST_ASSERT(m);
+    TEST_ASSERT(m->getNumAtoms() == 327);
+    TEST_ASSERT(m->getNumBonds() == 337);
+    TEST_ASSERT(m->getAtomWithIdx(0)->getMonomerInfo());
+    TEST_ASSERT(m->getAtomWithIdx(0)->getMonomerInfo()->getMonomerType() ==
+                AtomMonomerInfo::PDBRESIDUE);
+
+    TEST_ASSERT(static_cast<AtomPDBResidueInfo *>(
+                    m->getAtomWithIdx(0)->getMonomerInfo())
+                    ->getResidueNumber() == 1);
+    TEST_ASSERT(static_cast<AtomPDBResidueInfo *>(
+                    m->getAtomWithIdx(9)->getMonomerInfo())
+                    ->getResidueNumber() == 2);
+
+    TEST_ASSERT(static_cast<AtomPDBResidueInfo *>(
+                    m->getAtomWithIdx(0)->getMonomerInfo())
+                    ->getName() == "N");
+    TEST_ASSERT(static_cast<AtomPDBResidueInfo *>(
+                    m->getAtomWithIdx(0)->getMonomerInfo())
+                    ->getResidueName() == "THR");
+    TEST_ASSERT(feq(static_cast<AtomPDBResidueInfo *>(
+                        m->getAtomWithIdx(0)->getMonomerInfo())
+                        ->getTempFactor(),
+                    13.79));
+    TEST_ASSERT(m->getNumConformers() == 1);
+    TEST_ASSERT(feq(m->getConformer().getAtomPos(0).x, 17.047));
+    TEST_ASSERT(feq(m->getConformer().getAtomPos(0).y, 14.099));
+    TEST_ASSERT(feq(m->getConformer().getAtomPos(0).z, 3.625));
+
+    delete m;
+  }
+
+  BOOST_LOG(rdInfoLog) << "done" << std::endl;
+}
+
 void testSequences() {
   BOOST_LOG(rdInfoLog) << "testing reading sequences" << std::endl;
   {
@@ -5377,6 +5425,7 @@ void RunTests() {
   testGithub1023();
   testGithub1049();
   testPDBFile();
+  testMMCifFile();
   testSequences();
 
   // testSequenceReaders();

--- a/Code/GraphMol/FileParsers/test1.cpp
+++ b/Code/GraphMol/FileParsers/test1.cpp
@@ -4012,11 +4012,11 @@ void testMMCifFile() {
 
     fname = rdbase + "1crn.cif";
 
-    ROMol *m = MMCifFileToMol(fname);
+    ROMol *m = mmcifFileToMol(fname);
 
     TEST_ASSERT(m);
     TEST_ASSERT(m->getNumAtoms() == 327);
-    TEST_ASSERT(m->getNumBonds() == 337);
+    //TEST_ASSERT(m->getNumBonds() == 337);
     TEST_ASSERT(m->getAtomWithIdx(0)->getMonomerInfo());
     TEST_ASSERT(m->getAtomWithIdx(0)->getMonomerInfo()->getMonomerType() ==
                 AtomMonomerInfo::PDBRESIDUE);

--- a/Code/GraphMol/FileParsers/test1.cpp
+++ b/Code/GraphMol/FileParsers/test1.cpp
@@ -4016,7 +4016,7 @@ void testMMCifFile() {
 
     TEST_ASSERT(m);
     TEST_ASSERT(m->getNumAtoms() == 327);
-    //TEST_ASSERT(m->getNumBonds() == 337);
+    TEST_ASSERT(m->getNumBonds() == 337);
     TEST_ASSERT(m->getAtomWithIdx(0)->getMonomerInfo());
     TEST_ASSERT(m->getAtomWithIdx(0)->getMonomerInfo()->getMonomerType() ==
                 AtomMonomerInfo::PDBRESIDUE);

--- a/Code/GraphMol/FileParsers/test_data/1crn.cif
+++ b/Code/GraphMol/FileParsers/test_data/1crn.cif
@@ -1,0 +1,1049 @@
+data_1CRN
+# 
+_entry.id   1CRN 
+# 
+_audit_conform.dict_name       mmcif_pdbx.dic 
+_audit_conform.dict_version    5.287 
+_audit_conform.dict_location   http://mmcif.pdb.org/dictionaries/ascii/mmcif_pdbx.dic 
+# 
+loop_
+_database_2.database_id 
+_database_2.database_code 
+PDB   1CRN         
+WWPDB D_1000172485 
+# 
+_pdbx_database_status.status_code                     REL 
+_pdbx_database_status.entry_id                        1CRN 
+_pdbx_database_status.recvd_initial_deposition_date   1981-04-30 
+_pdbx_database_status.deposit_site                    ? 
+_pdbx_database_status.process_site                    BNL 
+_pdbx_database_status.SG_entry                        . 
+_pdbx_database_status.status_code_sf                  ? 
+_pdbx_database_status.status_code_mr                  ? 
+_pdbx_database_status.status_code_cs                  ? 
+_pdbx_database_status.methods_development_category    ? 
+_pdbx_database_status.pdb_format_compatible           Y 
+# 
+loop_
+_audit_author.name 
+_audit_author.pdbx_ordinal 
+'Hendrickson, W.A.' 1 
+'Teeter, M.M.'      2 
+# 
+loop_
+_citation.id 
+_citation.title 
+_citation.journal_abbrev 
+_citation.journal_volume 
+_citation.page_first 
+_citation.page_last 
+_citation.year 
+_citation.journal_id_ASTM 
+_citation.country 
+_citation.journal_id_ISSN 
+_citation.journal_id_CSD 
+_citation.book_publisher 
+_citation.pdbx_database_id_PubMed 
+_citation.pdbx_database_id_DOI 
+primary 'Water structure of a hydrophobic protein at atomic resolution: Pentagon rings of water molecules in crystals of crambin.' 
+Proc.Natl.Acad.Sci.Usa 81  6014 6018 1984 PNASA6 US 0027-8424 0040 ? 16593516 10.1073/pnas.81.19.6014 
+1       'Structure of the Hydrophobic Protein Crambin Determined Directly from the Anomalous Scattering of Sulphur'                
+Nature                 290 107  ?    1981 NATUAS UK 0028-0836 0006 ? ?        ?                       
+2       'Highly Ordered Crystals of the Plant Seed Protein Crambin'                                                                
+J.Mol.Biol.            127 219  ?    1979 JMOBAK UK 0022-2836 0070 ? ?        ?                       
+# 
+loop_
+_citation_author.citation_id 
+_citation_author.name 
+_citation_author.ordinal 
+primary 'Teeter, M.M.'      1 
+1       'Hendrickson, W.A.' 2 
+1       'Teeter, M.M.'      3 
+2       'Teeter, M.M.'      4 
+2       'Hendrickson, W.A.' 5 
+# 
+_cell.entry_id           1CRN 
+_cell.length_a           40.960 
+_cell.length_b           18.650 
+_cell.length_c           22.520 
+_cell.angle_alpha        90.00 
+_cell.angle_beta         90.77 
+_cell.angle_gamma        90.00 
+_cell.Z_PDB              2 
+_cell.pdbx_unique_axis   ? 
+_cell.length_a_esd       ? 
+_cell.length_b_esd       ? 
+_cell.length_c_esd       ? 
+_cell.angle_alpha_esd    ? 
+_cell.angle_beta_esd     ? 
+_cell.angle_gamma_esd    ? 
+# 
+_symmetry.entry_id                         1CRN 
+_symmetry.space_group_name_H-M             'P 1 21 1' 
+_symmetry.pdbx_full_space_group_name_H-M   ? 
+_symmetry.cell_setting                     ? 
+_symmetry.Int_Tables_number                4 
+_symmetry.space_group_name_Hall            ? 
+# 
+_entity.id                         1 
+_entity.type                       polymer 
+_entity.src_method                 man 
+_entity.pdbx_description           CRAMBIN 
+_entity.formula_weight             4738.447 
+_entity.pdbx_number_of_molecules   1 
+_entity.pdbx_ec                    ? 
+_entity.pdbx_mutation              ? 
+_entity.pdbx_fragment              ? 
+_entity.details                    ? 
+# 
+_entity_poly.entity_id                      1 
+_entity_poly.type                           'polypeptide(L)' 
+_entity_poly.nstd_linkage                   no 
+_entity_poly.nstd_monomer                   no 
+_entity_poly.pdbx_seq_one_letter_code       TTCCPSIVARSNFNVCRLPGTPEAICATYTGCIIIPGATCPGDYAN 
+_entity_poly.pdbx_seq_one_letter_code_can   TTCCPSIVARSNFNVCRLPGTPEAICATYTGCIIIPGATCPGDYAN 
+_entity_poly.pdbx_strand_id                 A 
+_entity_poly.pdbx_target_identifier         ? 
+# 
+loop_
+_entity_poly_seq.entity_id 
+_entity_poly_seq.num 
+_entity_poly_seq.mon_id 
+_entity_poly_seq.hetero 
+1 1  THR n 
+1 2  THR n 
+1 3  CYS n 
+1 4  CYS n 
+1 5  PRO n 
+1 6  SER n 
+1 7  ILE n 
+1 8  VAL n 
+1 9  ALA n 
+1 10 ARG n 
+1 11 SER n 
+1 12 ASN n 
+1 13 PHE n 
+1 14 ASN n 
+1 15 VAL n 
+1 16 CYS n 
+1 17 ARG n 
+1 18 LEU n 
+1 19 PRO n 
+1 20 GLY n 
+1 21 THR n 
+1 22 PRO n 
+1 23 GLU n 
+1 24 ALA n 
+1 25 ILE n 
+1 26 CYS n 
+1 27 ALA n 
+1 28 THR n 
+1 29 TYR n 
+1 30 THR n 
+1 31 GLY n 
+1 32 CYS n 
+1 33 ILE n 
+1 34 ILE n 
+1 35 ILE n 
+1 36 PRO n 
+1 37 GLY n 
+1 38 ALA n 
+1 39 THR n 
+1 40 CYS n 
+1 41 PRO n 
+1 42 GLY n 
+1 43 ASP n 
+1 44 TYR n 
+1 45 ALA n 
+1 46 ASN n 
+# 
+_entity_src_gen.entity_id                          1 
+_entity_src_gen.pdbx_src_id                        1 
+_entity_src_gen.pdbx_alt_source_flag               sample 
+_entity_src_gen.pdbx_seq_type                      ? 
+_entity_src_gen.pdbx_beg_seq_num                   ? 
+_entity_src_gen.pdbx_end_seq_num                   ? 
+_entity_src_gen.gene_src_common_name               ? 
+_entity_src_gen.gene_src_genus                     Crambe 
+_entity_src_gen.pdbx_gene_src_gene                 ? 
+_entity_src_gen.gene_src_species                   'Crambe hispanica' 
+_entity_src_gen.gene_src_strain                    'subsp. abyssinica' 
+_entity_src_gen.gene_src_tissue                    ? 
+_entity_src_gen.gene_src_tissue_fraction           ? 
+_entity_src_gen.gene_src_details                   ? 
+_entity_src_gen.pdbx_gene_src_fragment             ? 
+_entity_src_gen.pdbx_gene_src_scientific_name      'Crambe hispanica subsp. abyssinica' 
+_entity_src_gen.pdbx_gene_src_ncbi_taxonomy_id     3721 
+_entity_src_gen.pdbx_gene_src_variant              ? 
+_entity_src_gen.pdbx_gene_src_cell_line            ? 
+_entity_src_gen.pdbx_gene_src_atcc                 ? 
+_entity_src_gen.pdbx_gene_src_organ                ? 
+_entity_src_gen.pdbx_gene_src_organelle            ? 
+_entity_src_gen.pdbx_gene_src_cell                 ? 
+_entity_src_gen.pdbx_gene_src_cellular_location    ? 
+_entity_src_gen.host_org_common_name               ? 
+_entity_src_gen.pdbx_host_org_scientific_name      ? 
+_entity_src_gen.pdbx_host_org_ncbi_taxonomy_id     ? 
+_entity_src_gen.host_org_genus                     ? 
+_entity_src_gen.pdbx_host_org_gene                 ? 
+_entity_src_gen.pdbx_host_org_organ                ? 
+_entity_src_gen.host_org_species                   ? 
+_entity_src_gen.pdbx_host_org_tissue               ? 
+_entity_src_gen.pdbx_host_org_tissue_fraction      ? 
+_entity_src_gen.pdbx_host_org_strain               ? 
+_entity_src_gen.pdbx_host_org_variant              ? 
+_entity_src_gen.pdbx_host_org_cell_line            ? 
+_entity_src_gen.pdbx_host_org_atcc                 ? 
+_entity_src_gen.pdbx_host_org_culture_collection   ? 
+_entity_src_gen.pdbx_host_org_cell                 ? 
+_entity_src_gen.pdbx_host_org_organelle            ? 
+_entity_src_gen.pdbx_host_org_cellular_location    ? 
+_entity_src_gen.pdbx_host_org_vector_type          ? 
+_entity_src_gen.pdbx_host_org_vector               ? 
+_entity_src_gen.host_org_details                   ? 
+_entity_src_gen.expression_system_id               ? 
+_entity_src_gen.plasmid_name                       ? 
+_entity_src_gen.plasmid_details                    ? 
+_entity_src_gen.pdbx_description                   ? 
+# 
+_struct_ref.id                         1 
+_struct_ref.db_name                    UNP 
+_struct_ref.db_code                    CRAM_CRAAB 
+_struct_ref.entity_id                  1 
+_struct_ref.pdbx_db_accession          P01542 
+_struct_ref.pdbx_align_begin           1 
+_struct_ref.pdbx_seq_one_letter_code   TTCCPSIVARSNFNVCRLPGTPEAICATYTGCIIIPGATCPGDYAN 
+_struct_ref.pdbx_db_isoform            ? 
+# 
+_struct_ref_seq.align_id                      1 
+_struct_ref_seq.ref_id                        1 
+_struct_ref_seq.pdbx_PDB_id_code              1CRN 
+_struct_ref_seq.pdbx_strand_id                A 
+_struct_ref_seq.seq_align_beg                 1 
+_struct_ref_seq.pdbx_seq_align_beg_ins_code   ? 
+_struct_ref_seq.seq_align_end                 46 
+_struct_ref_seq.pdbx_seq_align_end_ins_code   ? 
+_struct_ref_seq.pdbx_db_accession             P01542 
+_struct_ref_seq.db_align_beg                  1 
+_struct_ref_seq.pdbx_db_align_beg_ins_code    ? 
+_struct_ref_seq.db_align_end                  46 
+_struct_ref_seq.pdbx_db_align_end_ins_code    ? 
+_struct_ref_seq.pdbx_auth_seq_align_beg       1 
+_struct_ref_seq.pdbx_auth_seq_align_end       46 
+# 
+loop_
+_chem_comp.id 
+_chem_comp.type 
+_chem_comp.mon_nstd_flag 
+_chem_comp.name 
+_chem_comp.pdbx_synonyms 
+_chem_comp.formula 
+_chem_comp.formula_weight 
+ALA 'L-peptide linking' y ALANINE         ? 'C3 H7 N O2'     89.093  
+ARG 'L-peptide linking' y ARGININE        ? 'C6 H15 N4 O2 1' 175.209 
+ASN 'L-peptide linking' y ASPARAGINE      ? 'C4 H8 N2 O3'    132.118 
+ASP 'L-peptide linking' y 'ASPARTIC ACID' ? 'C4 H7 N O4'     133.103 
+CYS 'L-peptide linking' y CYSTEINE        ? 'C3 H7 N O2 S'   121.158 
+GLU 'L-peptide linking' y 'GLUTAMIC ACID' ? 'C5 H9 N O4'     147.129 
+GLY 'peptide linking'   y GLYCINE         ? 'C2 H5 N O2'     75.067  
+ILE 'L-peptide linking' y ISOLEUCINE      ? 'C6 H13 N O2'    131.173 
+LEU 'L-peptide linking' y LEUCINE         ? 'C6 H13 N O2'    131.173 
+PHE 'L-peptide linking' y PHENYLALANINE   ? 'C9 H11 N O2'    165.189 
+PRO 'L-peptide linking' y PROLINE         ? 'C5 H9 N O2'     115.130 
+SER 'L-peptide linking' y SERINE          ? 'C3 H7 N O3'     105.093 
+THR 'L-peptide linking' y THREONINE       ? 'C4 H9 N O3'     119.119 
+TYR 'L-peptide linking' y TYROSINE        ? 'C9 H11 N O3'    181.189 
+VAL 'L-peptide linking' y VALINE          ? 'C5 H11 N O2'    117.146 
+# 
+_exptl.entry_id          1CRN 
+_exptl.method            'X-RAY DIFFRACTION' 
+_exptl.crystals_number   ? 
+# 
+_exptl_crystal.id                    1 
+_exptl_crystal.density_meas          ? 
+_exptl_crystal.density_Matthews      1.81 
+_exptl_crystal.density_percent_sol   32.16 
+_exptl_crystal.description           ? 
+_exptl_crystal.F_000                 ? 
+_exptl_crystal.preparation           ? 
+# 
+_diffrn.id                     1 
+_diffrn.ambient_temp           ? 
+_diffrn.ambient_temp_details   ? 
+_diffrn.crystal_id             1 
+# 
+_diffrn_radiation.diffrn_id                        1 
+_diffrn_radiation.wavelength_id                    1 
+_diffrn_radiation.pdbx_monochromatic_or_laue_m_l   ? 
+_diffrn_radiation.monochromator                    ? 
+_diffrn_radiation.pdbx_diffrn_protocol             ? 
+_diffrn_radiation.pdbx_scattering_type             x-ray 
+# 
+_diffrn_radiation_wavelength.id           1 
+_diffrn_radiation_wavelength.wavelength   . 
+_diffrn_radiation_wavelength.wt           1.0 
+# 
+_refine.entry_id                                 1CRN 
+_refine.ls_number_reflns_obs                     ? 
+_refine.ls_number_reflns_all                     ? 
+_refine.pdbx_ls_sigma_I                          ? 
+_refine.pdbx_ls_sigma_F                          ? 
+_refine.pdbx_data_cutoff_high_absF               ? 
+_refine.pdbx_data_cutoff_low_absF                ? 
+_refine.pdbx_data_cutoff_high_rms_absF           ? 
+_refine.ls_d_res_low                             ? 
+_refine.ls_d_res_high                            1.5 
+_refine.ls_percent_reflns_obs                    ? 
+_refine.ls_R_factor_obs                          ? 
+_refine.ls_R_factor_all                          ? 
+_refine.ls_R_factor_R_work                       ? 
+_refine.ls_R_factor_R_free                       ? 
+_refine.ls_R_factor_R_free_error                 ? 
+_refine.ls_R_factor_R_free_error_details         ? 
+_refine.ls_percent_reflns_R_free                 ? 
+_refine.ls_number_reflns_R_free                  ? 
+_refine.ls_number_parameters                     ? 
+_refine.ls_number_restraints                     ? 
+_refine.occupancy_min                            ? 
+_refine.occupancy_max                            ? 
+_refine.B_iso_mean                               ? 
+_refine.aniso_B[1][1]                            ? 
+_refine.aniso_B[2][2]                            ? 
+_refine.aniso_B[3][3]                            ? 
+_refine.aniso_B[1][2]                            ? 
+_refine.aniso_B[1][3]                            ? 
+_refine.aniso_B[2][3]                            ? 
+_refine.solvent_model_details                    ? 
+_refine.solvent_model_param_ksol                 ? 
+_refine.solvent_model_param_bsol                 ? 
+_refine.pdbx_ls_cross_valid_method               ? 
+_refine.details                                  ? 
+_refine.pdbx_starting_model                      ? 
+_refine.pdbx_method_to_determine_struct          ? 
+_refine.pdbx_isotropic_thermal_model             ? 
+_refine.pdbx_stereochemistry_target_values       ? 
+_refine.pdbx_stereochem_target_val_spec_case     ? 
+_refine.pdbx_R_Free_selection_details            ? 
+_refine.pdbx_overall_ESU_R                       ? 
+_refine.pdbx_overall_ESU_R_Free                  ? 
+_refine.overall_SU_ML                            ? 
+_refine.overall_SU_B                             ? 
+_refine.pdbx_refine_id                           'X-RAY DIFFRACTION' 
+_refine.pdbx_diffrn_id                           1 
+_refine.ls_redundancy_reflns_obs                 ? 
+_refine.pdbx_overall_phase_error                 ? 
+_refine.B_iso_min                                ? 
+_refine.B_iso_max                                ? 
+_refine.correlation_coeff_Fo_to_Fc               ? 
+_refine.correlation_coeff_Fo_to_Fc_free          ? 
+_refine.pdbx_solvent_vdw_probe_radii             ? 
+_refine.pdbx_solvent_ion_probe_radii             ? 
+_refine.pdbx_solvent_shrinkage_radii             ? 
+_refine.overall_SU_R_Cruickshank_DPI             ? 
+_refine.overall_SU_R_free                        ? 
+_refine.ls_wR_factor_R_free                      ? 
+_refine.ls_wR_factor_R_work                      ? 
+_refine.overall_FOM_free_R_set                   ? 
+_refine.overall_FOM_work_R_set                   ? 
+_refine.pdbx_TLS_residual_ADP_flag               ? 
+_refine.pdbx_overall_SU_R_free_Cruickshank_DPI   ? 
+_refine.pdbx_overall_SU_R_Blow_DPI               ? 
+_refine.pdbx_overall_SU_R_free_Blow_DPI          ? 
+# 
+_refine_hist.pdbx_refine_id                   'X-RAY DIFFRACTION' 
+_refine_hist.cycle_id                         LAST 
+_refine_hist.pdbx_number_atoms_protein        327 
+_refine_hist.pdbx_number_atoms_nucleic_acid   0 
+_refine_hist.pdbx_number_atoms_ligand         0 
+_refine_hist.number_atoms_solvent             0 
+_refine_hist.number_atoms_total               327 
+_refine_hist.d_res_high                       1.5 
+_refine_hist.d_res_low                        . 
+# 
+_struct.entry_id                  1CRN 
+_struct.title                     
+'WATER STRUCTURE OF A HYDROPHOBIC PROTEIN AT ATOMIC RESOLUTION. PENTAGON RINGS OF WATER MOLECULES IN CRYSTALS OF CRAMBIN' 
+_struct.pdbx_descriptor           CRAMBIN 
+_struct.pdbx_model_details        ? 
+_struct.pdbx_CASP_flag            ? 
+_struct.pdbx_model_type_details   ? 
+# 
+_struct_keywords.entry_id        1CRN 
+_struct_keywords.pdbx_keywords   'PLANT PROTEIN' 
+_struct_keywords.text            'PLANT SEED PROTEIN, PLANT PROTEIN' 
+# 
+_struct_asym.id                            A 
+_struct_asym.pdbx_blank_PDB_chainid_flag   N 
+_struct_asym.pdbx_modified                 N 
+_struct_asym.entity_id                     1 
+_struct_asym.details                       ? 
+# 
+_struct_biol.id        1 
+_struct_biol.details   ? 
+# 
+loop_
+_struct_conf.conf_type_id 
+_struct_conf.id 
+_struct_conf.pdbx_PDB_helix_id 
+_struct_conf.beg_label_comp_id 
+_struct_conf.beg_label_asym_id 
+_struct_conf.beg_label_seq_id 
+_struct_conf.pdbx_beg_PDB_ins_code 
+_struct_conf.end_label_comp_id 
+_struct_conf.end_label_asym_id 
+_struct_conf.end_label_seq_id 
+_struct_conf.pdbx_end_PDB_ins_code 
+_struct_conf.beg_auth_comp_id 
+_struct_conf.beg_auth_asym_id 
+_struct_conf.beg_auth_seq_id 
+_struct_conf.end_auth_comp_id 
+_struct_conf.end_auth_asym_id 
+_struct_conf.end_auth_seq_id 
+_struct_conf.pdbx_PDB_helix_class 
+_struct_conf.details 
+_struct_conf.pdbx_PDB_helix_length 
+HELX_P HELX_P1 H1 ILE A 7  ? PRO A 19 ? ILE A 7  PRO A 19 1 '3/10 CONFORMATION RES 17,19' 13 
+HELX_P HELX_P2 H2 GLU A 23 ? THR A 30 ? GLU A 23 THR A 30 1 'DISTORTED 3/10 AT RES 30'    8  
+# 
+_struct_conf_type.id          HELX_P 
+_struct_conf_type.criteria    ? 
+_struct_conf_type.reference   ? 
+# 
+loop_
+_struct_conn.id 
+_struct_conn.conn_type_id 
+_struct_conn.pdbx_leaving_atom_flag 
+_struct_conn.pdbx_PDB_id 
+_struct_conn.ptnr1_label_asym_id 
+_struct_conn.ptnr1_label_comp_id 
+_struct_conn.ptnr1_label_seq_id 
+_struct_conn.ptnr1_label_atom_id 
+_struct_conn.pdbx_ptnr1_label_alt_id 
+_struct_conn.pdbx_ptnr1_PDB_ins_code 
+_struct_conn.pdbx_ptnr1_standard_comp_id 
+_struct_conn.ptnr1_symmetry 
+_struct_conn.ptnr2_label_asym_id 
+_struct_conn.ptnr2_label_comp_id 
+_struct_conn.ptnr2_label_seq_id 
+_struct_conn.ptnr2_label_atom_id 
+_struct_conn.pdbx_ptnr2_label_alt_id 
+_struct_conn.pdbx_ptnr2_PDB_ins_code 
+_struct_conn.ptnr1_auth_asym_id 
+_struct_conn.ptnr1_auth_comp_id 
+_struct_conn.ptnr1_auth_seq_id 
+_struct_conn.ptnr2_auth_asym_id 
+_struct_conn.ptnr2_auth_comp_id 
+_struct_conn.ptnr2_auth_seq_id 
+_struct_conn.ptnr2_symmetry 
+_struct_conn.pdbx_ptnr3_label_atom_id 
+_struct_conn.pdbx_ptnr3_label_seq_id 
+_struct_conn.pdbx_ptnr3_label_comp_id 
+_struct_conn.pdbx_ptnr3_label_asym_id 
+_struct_conn.pdbx_ptnr3_label_alt_id 
+_struct_conn.pdbx_ptnr3_PDB_ins_code 
+_struct_conn.details 
+_struct_conn.pdbx_dist_value 
+_struct_conn.pdbx_value_order 
+disulf1 disulf ? ? A CYS 3  SG ? ? ? 1_555 A CYS 40 SG ? ? A CYS 3  A CYS 40 1_555 ? ? ? ? ? ? ? 2.004 ? 
+disulf2 disulf ? ? A CYS 4  SG ? ? ? 1_555 A CYS 32 SG ? ? A CYS 4  A CYS 32 1_555 ? ? ? ? ? ? ? 2.035 ? 
+disulf3 disulf ? ? A CYS 16 SG ? ? ? 1_555 A CYS 26 SG ? ? A CYS 16 A CYS 26 1_555 ? ? ? ? ? ? ? 2.051 ? 
+# 
+_struct_conn_type.id          disulf 
+_struct_conn_type.criteria    ? 
+_struct_conn_type.reference   ? 
+# 
+_struct_sheet.id               S1 
+_struct_sheet.type             ? 
+_struct_sheet.number_strands   2 
+_struct_sheet.details          ? 
+# 
+_struct_sheet_order.sheet_id     S1 
+_struct_sheet_order.range_id_1   1 
+_struct_sheet_order.range_id_2   2 
+_struct_sheet_order.offset       ? 
+_struct_sheet_order.sense        anti-parallel 
+# 
+loop_
+_struct_sheet_range.sheet_id 
+_struct_sheet_range.id 
+_struct_sheet_range.beg_label_comp_id 
+_struct_sheet_range.beg_label_asym_id 
+_struct_sheet_range.beg_label_seq_id 
+_struct_sheet_range.pdbx_beg_PDB_ins_code 
+_struct_sheet_range.end_label_comp_id 
+_struct_sheet_range.end_label_asym_id 
+_struct_sheet_range.end_label_seq_id 
+_struct_sheet_range.pdbx_end_PDB_ins_code 
+_struct_sheet_range.beg_auth_comp_id 
+_struct_sheet_range.beg_auth_asym_id 
+_struct_sheet_range.beg_auth_seq_id 
+_struct_sheet_range.end_auth_comp_id 
+_struct_sheet_range.end_auth_asym_id 
+_struct_sheet_range.end_auth_seq_id 
+S1 1 THR A 1  ? CYS A 4  ? THR A 1  CYS A 4  
+S1 2 CYS A 32 ? ILE A 35 ? CYS A 32 ILE A 35 
+# 
+_database_PDB_matrix.entry_id          1CRN 
+_database_PDB_matrix.origx[1][1]       1.000000 
+_database_PDB_matrix.origx[1][2]       0.000000 
+_database_PDB_matrix.origx[1][3]       0.000000 
+_database_PDB_matrix.origx[2][1]       0.000000 
+_database_PDB_matrix.origx[2][2]       1.000000 
+_database_PDB_matrix.origx[2][3]       0.000000 
+_database_PDB_matrix.origx[3][1]       0.000000 
+_database_PDB_matrix.origx[3][2]       0.000000 
+_database_PDB_matrix.origx[3][3]       1.000000 
+_database_PDB_matrix.origx_vector[1]   0.00000 
+_database_PDB_matrix.origx_vector[2]   0.00000 
+_database_PDB_matrix.origx_vector[3]   0.00000 
+# 
+_atom_sites.entry_id                    1CRN 
+_atom_sites.fract_transf_matrix[1][1]   0.024414 
+_atom_sites.fract_transf_matrix[1][2]   0.000000 
+_atom_sites.fract_transf_matrix[1][3]   0.000328 
+_atom_sites.fract_transf_matrix[2][1]   0.000000 
+_atom_sites.fract_transf_matrix[2][2]   0.053619 
+_atom_sites.fract_transf_matrix[2][3]   0.000000 
+_atom_sites.fract_transf_matrix[3][1]   0.000000 
+_atom_sites.fract_transf_matrix[3][2]   0.000000 
+_atom_sites.fract_transf_matrix[3][3]   0.044409 
+_atom_sites.fract_transf_vector[1]      0.00000 
+_atom_sites.fract_transf_vector[2]      0.00000 
+_atom_sites.fract_transf_vector[3]      0.00000 
+# 
+loop_
+_atom_type.symbol 
+C 
+N 
+O 
+S 
+# 
+loop_
+_atom_site.group_PDB 
+_atom_site.id 
+_atom_site.type_symbol 
+_atom_site.label_atom_id 
+_atom_site.label_alt_id 
+_atom_site.label_comp_id 
+_atom_site.label_asym_id 
+_atom_site.label_entity_id 
+_atom_site.label_seq_id 
+_atom_site.pdbx_PDB_ins_code 
+_atom_site.Cartn_x 
+_atom_site.Cartn_y 
+_atom_site.Cartn_z 
+_atom_site.occupancy 
+_atom_site.B_iso_or_equiv 
+_atom_site.pdbx_formal_charge 
+_atom_site.auth_seq_id 
+_atom_site.auth_comp_id 
+_atom_site.auth_asym_id 
+_atom_site.auth_atom_id 
+_atom_site.pdbx_PDB_model_num 
+ATOM 1   N N   . THR A 1 1  ? 17.047 14.099 3.625  1.00 13.79 ? 1  THR A N   1 
+ATOM 2   C CA  . THR A 1 1  ? 16.967 12.784 4.338  1.00 10.80 ? 1  THR A CA  1 
+ATOM 3   C C   . THR A 1 1  ? 15.685 12.755 5.133  1.00 9.19  ? 1  THR A C   1 
+ATOM 4   O O   . THR A 1 1  ? 15.268 13.825 5.594  1.00 9.85  ? 1  THR A O   1 
+ATOM 5   C CB  . THR A 1 1  ? 18.170 12.703 5.337  1.00 13.02 ? 1  THR A CB  1 
+ATOM 6   O OG1 . THR A 1 1  ? 19.334 12.829 4.463  1.00 15.06 ? 1  THR A OG1 1 
+ATOM 7   C CG2 . THR A 1 1  ? 18.150 11.546 6.304  1.00 14.23 ? 1  THR A CG2 1 
+ATOM 8   N N   . THR A 1 2  ? 15.115 11.555 5.265  1.00 7.81  ? 2  THR A N   1 
+ATOM 9   C CA  . THR A 1 2  ? 13.856 11.469 6.066  1.00 8.31  ? 2  THR A CA  1 
+ATOM 10  C C   . THR A 1 2  ? 14.164 10.785 7.379  1.00 5.80  ? 2  THR A C   1 
+ATOM 11  O O   . THR A 1 2  ? 14.993 9.862  7.443  1.00 6.94  ? 2  THR A O   1 
+ATOM 12  C CB  . THR A 1 2  ? 12.732 10.711 5.261  1.00 10.32 ? 2  THR A CB  1 
+ATOM 13  O OG1 . THR A 1 2  ? 13.308 9.439  4.926  1.00 12.81 ? 2  THR A OG1 1 
+ATOM 14  C CG2 . THR A 1 2  ? 12.484 11.442 3.895  1.00 11.90 ? 2  THR A CG2 1 
+ATOM 15  N N   . CYS A 1 3  ? 13.488 11.241 8.417  1.00 5.24  ? 3  CYS A N   1 
+ATOM 16  C CA  . CYS A 1 3  ? 13.660 10.707 9.787  1.00 5.39  ? 3  CYS A CA  1 
+ATOM 17  C C   . CYS A 1 3  ? 12.269 10.431 10.323 1.00 4.45  ? 3  CYS A C   1 
+ATOM 18  O O   . CYS A 1 3  ? 11.393 11.308 10.185 1.00 6.54  ? 3  CYS A O   1 
+ATOM 19  C CB  . CYS A 1 3  ? 14.368 11.748 10.691 1.00 5.99  ? 3  CYS A CB  1 
+ATOM 20  S SG  . CYS A 1 3  ? 15.885 12.426 10.016 1.00 7.01  ? 3  CYS A SG  1 
+ATOM 21  N N   . CYS A 1 4  ? 12.019 9.272  10.928 1.00 3.90  ? 4  CYS A N   1 
+ATOM 22  C CA  . CYS A 1 4  ? 10.646 8.991  11.408 1.00 4.24  ? 4  CYS A CA  1 
+ATOM 23  C C   . CYS A 1 4  ? 10.654 8.793  12.919 1.00 3.72  ? 4  CYS A C   1 
+ATOM 24  O O   . CYS A 1 4  ? 11.659 8.296  13.491 1.00 5.30  ? 4  CYS A O   1 
+ATOM 25  C CB  . CYS A 1 4  ? 10.057 7.752  10.682 1.00 4.41  ? 4  CYS A CB  1 
+ATOM 26  S SG  . CYS A 1 4  ? 9.837  8.018  8.904  1.00 4.72  ? 4  CYS A SG  1 
+ATOM 27  N N   . PRO A 1 5  ? 9.561  9.108  13.563 1.00 3.96  ? 5  PRO A N   1 
+ATOM 28  C CA  . PRO A 1 5  ? 9.448  9.034  15.012 1.00 4.25  ? 5  PRO A CA  1 
+ATOM 29  C C   . PRO A 1 5  ? 9.288  7.670  15.606 1.00 4.96  ? 5  PRO A C   1 
+ATOM 30  O O   . PRO A 1 5  ? 9.490  7.519  16.819 1.00 7.44  ? 5  PRO A O   1 
+ATOM 31  C CB  . PRO A 1 5  ? 8.230  9.957  15.345 1.00 5.11  ? 5  PRO A CB  1 
+ATOM 32  C CG  . PRO A 1 5  ? 7.338  9.786  14.114 1.00 5.24  ? 5  PRO A CG  1 
+ATOM 33  C CD  . PRO A 1 5  ? 8.366  9.804  12.958 1.00 5.20  ? 5  PRO A CD  1 
+ATOM 34  N N   . SER A 1 6  ? 8.875  6.686  14.796 1.00 4.83  ? 6  SER A N   1 
+ATOM 35  C CA  . SER A 1 6  ? 8.673  5.314  15.279 1.00 4.45  ? 6  SER A CA  1 
+ATOM 36  C C   . SER A 1 6  ? 8.753  4.376  14.083 1.00 4.99  ? 6  SER A C   1 
+ATOM 37  O O   . SER A 1 6  ? 8.726  4.858  12.923 1.00 4.61  ? 6  SER A O   1 
+ATOM 38  C CB  . SER A 1 6  ? 7.340  5.121  15.996 1.00 5.05  ? 6  SER A CB  1 
+ATOM 39  O OG  . SER A 1 6  ? 6.274  5.220  15.031 1.00 6.39  ? 6  SER A OG  1 
+ATOM 40  N N   . ILE A 1 7  ? 8.881  3.075  14.358 1.00 4.94  ? 7  ILE A N   1 
+ATOM 41  C CA  . ILE A 1 7  ? 8.912  2.083  13.258 1.00 6.33  ? 7  ILE A CA  1 
+ATOM 42  C C   . ILE A 1 7  ? 7.581  2.090  12.506 1.00 5.32  ? 7  ILE A C   1 
+ATOM 43  O O   . ILE A 1 7  ? 7.670  2.031  11.245 1.00 6.85  ? 7  ILE A O   1 
+ATOM 44  C CB  . ILE A 1 7  ? 9.207  0.677  13.924 1.00 8.43  ? 7  ILE A CB  1 
+ATOM 45  C CG1 . ILE A 1 7  ? 10.714 0.702  14.312 1.00 9.78  ? 7  ILE A CG1 1 
+ATOM 46  C CG2 . ILE A 1 7  ? 8.811  -0.477 12.969 1.00 11.70 ? 7  ILE A CG2 1 
+ATOM 47  C CD1 . ILE A 1 7  ? 11.185 -0.516 15.142 1.00 9.92  ? 7  ILE A CD1 1 
+ATOM 48  N N   . VAL A 1 8  ? 6.458  2.162  13.159 1.00 5.02  ? 8  VAL A N   1 
+ATOM 49  C CA  . VAL A 1 8  ? 5.145  2.209  12.453 1.00 6.93  ? 8  VAL A CA  1 
+ATOM 50  C C   . VAL A 1 8  ? 5.115  3.379  11.461 1.00 5.39  ? 8  VAL A C   1 
+ATOM 51  O O   . VAL A 1 8  ? 4.664  3.268  10.343 1.00 6.30  ? 8  VAL A O   1 
+ATOM 52  C CB  . VAL A 1 8  ? 3.995  2.354  13.478 1.00 9.64  ? 8  VAL A CB  1 
+ATOM 53  C CG1 . VAL A 1 8  ? 2.716  2.891  12.869 1.00 13.85 ? 8  VAL A CG1 1 
+ATOM 54  C CG2 . VAL A 1 8  ? 3.758  1.032  14.208 1.00 11.97 ? 8  VAL A CG2 1 
+ATOM 55  N N   . ALA A 1 9  ? 5.606  4.546  11.941 1.00 3.73  ? 9  ALA A N   1 
+ATOM 56  C CA  . ALA A 1 9  ? 5.598  5.767  11.082 1.00 3.56  ? 9  ALA A CA  1 
+ATOM 57  C C   . ALA A 1 9  ? 6.441  5.527  9.850  1.00 4.13  ? 9  ALA A C   1 
+ATOM 58  O O   . ALA A 1 9  ? 6.052  5.933  8.744  1.00 4.36  ? 9  ALA A O   1 
+ATOM 59  C CB  . ALA A 1 9  ? 6.022  6.977  11.891 1.00 4.80  ? 9  ALA A CB  1 
+ATOM 60  N N   . ARG A 1 10 ? 7.647  4.909  10.005 1.00 3.73  ? 10 ARG A N   1 
+ATOM 61  C CA  . ARG A 1 10 ? 8.496  4.609  8.837  1.00 3.38  ? 10 ARG A CA  1 
+ATOM 62  C C   . ARG A 1 10 ? 7.798  3.609  7.876  1.00 3.47  ? 10 ARG A C   1 
+ATOM 63  O O   . ARG A 1 10 ? 7.878  3.778  6.651  1.00 4.67  ? 10 ARG A O   1 
+ATOM 64  C CB  . ARG A 1 10 ? 9.847  4.020  9.305  1.00 3.95  ? 10 ARG A CB  1 
+ATOM 65  C CG  . ARG A 1 10 ? 10.752 3.607  8.149  1.00 4.55  ? 10 ARG A CG  1 
+ATOM 66  C CD  . ARG A 1 10 ? 11.226 4.699  7.244  1.00 5.89  ? 10 ARG A CD  1 
+ATOM 67  N NE  . ARG A 1 10 ? 12.143 5.571  8.035  1.00 6.20  ? 10 ARG A NE  1 
+ATOM 68  C CZ  . ARG A 1 10 ? 12.758 6.609  7.443  1.00 7.52  ? 10 ARG A CZ  1 
+ATOM 69  N NH1 . ARG A 1 10 ? 12.539 6.932  6.158  1.00 10.68 ? 10 ARG A NH1 1 
+ATOM 70  N NH2 . ARG A 1 10 ? 13.601 7.322  8.202  1.00 9.48  ? 10 ARG A NH2 1 
+ATOM 71  N N   . SER A 1 11 ? 7.186  2.582  8.445  1.00 5.19  ? 11 SER A N   1 
+ATOM 72  C CA  . SER A 1 11 ? 6.500  1.584  7.565  1.00 4.60  ? 11 SER A CA  1 
+ATOM 73  C C   . SER A 1 11 ? 5.382  2.313  6.773  1.00 4.84  ? 11 SER A C   1 
+ATOM 74  O O   . SER A 1 11 ? 5.213  2.016  5.557  1.00 5.84  ? 11 SER A O   1 
+ATOM 75  C CB  . SER A 1 11 ? 5.908  0.462  8.400  1.00 5.91  ? 11 SER A CB  1 
+ATOM 76  O OG  . SER A 1 11 ? 6.990  -0.272 9.012  1.00 8.38  ? 11 SER A OG  1 
+ATOM 77  N N   . ASN A 1 12 ? 4.648  3.182  7.446  1.00 3.54  ? 12 ASN A N   1 
+ATOM 78  C CA  . ASN A 1 12 ? 3.545  3.935  6.751  1.00 4.57  ? 12 ASN A CA  1 
+ATOM 79  C C   . ASN A 1 12 ? 4.107  4.851  5.691  1.00 4.14  ? 12 ASN A C   1 
+ATOM 80  O O   . ASN A 1 12 ? 3.536  5.001  4.617  1.00 5.52  ? 12 ASN A O   1 
+ATOM 81  C CB  . ASN A 1 12 ? 2.663  4.677  7.748  1.00 6.42  ? 12 ASN A CB  1 
+ATOM 82  C CG  . ASN A 1 12 ? 1.802  3.735  8.610  1.00 8.25  ? 12 ASN A CG  1 
+ATOM 83  O OD1 . ASN A 1 12 ? 1.567  2.613  8.165  1.00 12.72 ? 12 ASN A OD1 1 
+ATOM 84  N ND2 . ASN A 1 12 ? 1.394  4.252  9.767  1.00 9.92  ? 12 ASN A ND2 1 
+ATOM 85  N N   . PHE A 1 13 ? 5.259  5.498  6.005  1.00 3.43  ? 13 PHE A N   1 
+ATOM 86  C CA  . PHE A 1 13 ? 5.929  6.358  5.055  1.00 3.49  ? 13 PHE A CA  1 
+ATOM 87  C C   . PHE A 1 13 ? 6.304  5.578  3.799  1.00 3.40  ? 13 PHE A C   1 
+ATOM 88  O O   . PHE A 1 13 ? 6.136  6.072  2.653  1.00 4.07  ? 13 PHE A O   1 
+ATOM 89  C CB  . PHE A 1 13 ? 7.183  6.994  5.754  1.00 5.48  ? 13 PHE A CB  1 
+ATOM 90  C CG  . PHE A 1 13 ? 7.884  8.006  4.883  1.00 5.57  ? 13 PHE A CG  1 
+ATOM 91  C CD1 . PHE A 1 13 ? 8.906  7.586  4.027  1.00 6.99  ? 13 PHE A CD1 1 
+ATOM 92  C CD2 . PHE A 1 13 ? 7.532  9.373  4.983  1.00 6.52  ? 13 PHE A CD2 1 
+ATOM 93  C CE1 . PHE A 1 13 ? 9.560  8.539  3.194  1.00 8.20  ? 13 PHE A CE1 1 
+ATOM 94  C CE2 . PHE A 1 13 ? 8.176  10.281 4.145  1.00 6.34  ? 13 PHE A CE2 1 
+ATOM 95  C CZ  . PHE A 1 13 ? 9.141  9.845  3.292  1.00 6.84  ? 13 PHE A CZ  1 
+ATOM 96  N N   . ASN A 1 14 ? 6.900  4.390  3.989  1.00 3.64  ? 14 ASN A N   1 
+ATOM 97  C CA  . ASN A 1 14 ? 7.331  3.607  2.791  1.00 4.31  ? 14 ASN A CA  1 
+ATOM 98  C C   . ASN A 1 14 ? 6.116  3.210  1.915  1.00 3.98  ? 14 ASN A C   1 
+ATOM 99  O O   . ASN A 1 14 ? 6.240  3.144  0.684  1.00 6.22  ? 14 ASN A O   1 
+ATOM 100 C CB  . ASN A 1 14 ? 8.145  2.404  3.240  1.00 5.81  ? 14 ASN A CB  1 
+ATOM 101 C CG  . ASN A 1 14 ? 9.555  2.856  3.730  1.00 6.82  ? 14 ASN A CG  1 
+ATOM 102 O OD1 . ASN A 1 14 ? 10.013 3.895  3.323  1.00 9.43  ? 14 ASN A OD1 1 
+ATOM 103 N ND2 . ASN A 1 14 ? 10.120 1.956  4.539  1.00 8.21  ? 14 ASN A ND2 1 
+ATOM 104 N N   . VAL A 1 15 ? 4.993  2.927  2.571  1.00 3.76  ? 15 VAL A N   1 
+ATOM 105 C CA  . VAL A 1 15 ? 3.782  2.599  1.742  1.00 3.98  ? 15 VAL A CA  1 
+ATOM 106 C C   . VAL A 1 15 ? 3.296  3.871  1.004  1.00 3.80  ? 15 VAL A C   1 
+ATOM 107 O O   . VAL A 1 15 ? 2.947  3.817  -0.189 1.00 4.85  ? 15 VAL A O   1 
+ATOM 108 C CB  . VAL A 1 15 ? 2.698  1.953  2.608  1.00 4.71  ? 15 VAL A CB  1 
+ATOM 109 C CG1 . VAL A 1 15 ? 1.384  1.826  1.806  1.00 6.67  ? 15 VAL A CG1 1 
+ATOM 110 C CG2 . VAL A 1 15 ? 3.174  0.533  3.005  1.00 6.26  ? 15 VAL A CG2 1 
+ATOM 111 N N   . CYS A 1 16 ? 3.321  4.987  1.720  1.00 3.79  ? 16 CYS A N   1 
+ATOM 112 C CA  . CYS A 1 16 ? 2.890  6.285  1.126  1.00 3.54  ? 16 CYS A CA  1 
+ATOM 113 C C   . CYS A 1 16 ? 3.687  6.597  -0.111 1.00 3.48  ? 16 CYS A C   1 
+ATOM 114 O O   . CYS A 1 16 ? 3.200  7.147  -1.103 1.00 4.63  ? 16 CYS A O   1 
+ATOM 115 C CB  . CYS A 1 16 ? 3.039  7.369  2.240  1.00 4.58  ? 16 CYS A CB  1 
+ATOM 116 S SG  . CYS A 1 16 ? 2.559  9.014  1.649  1.00 5.66  ? 16 CYS A SG  1 
+ATOM 117 N N   . ARG A 1 17 ? 4.997  6.227  -0.100 1.00 3.99  ? 17 ARG A N   1 
+ATOM 118 C CA  . ARG A 1 17 ? 5.895  6.489  -1.213 1.00 3.83  ? 17 ARG A CA  1 
+ATOM 119 C C   . ARG A 1 17 ? 5.738  5.560  -2.409 1.00 3.79  ? 17 ARG A C   1 
+ATOM 120 O O   . ARG A 1 17 ? 6.228  5.901  -3.507 1.00 5.39  ? 17 ARG A O   1 
+ATOM 121 C CB  . ARG A 1 17 ? 7.370  6.507  -0.731 1.00 4.11  ? 17 ARG A CB  1 
+ATOM 122 C CG  . ARG A 1 17 ? 7.717  7.687  0.206  1.00 4.69  ? 17 ARG A CG  1 
+ATOM 123 C CD  . ARG A 1 17 ? 7.949  8.947  -0.615 1.00 5.10  ? 17 ARG A CD  1 
+ATOM 124 N NE  . ARG A 1 17 ? 9.212  8.856  -1.337 1.00 4.71  ? 17 ARG A NE  1 
+ATOM 125 C CZ  . ARG A 1 17 ? 9.537  9.533  -2.431 1.00 5.28  ? 17 ARG A CZ  1 
+ATOM 126 N NH1 . ARG A 1 17 ? 8.659  10.350 -3.032 1.00 6.67  ? 17 ARG A NH1 1 
+ATOM 127 N NH2 . ARG A 1 17 ? 10.793 9.491  -2.899 1.00 6.41  ? 17 ARG A NH2 1 
+ATOM 128 N N   . LEU A 1 18 ? 5.051  4.411  -2.204 1.00 4.70  ? 18 LEU A N   1 
+ATOM 129 C CA  . LEU A 1 18 ? 4.933  3.431  -3.326 1.00 5.46  ? 18 LEU A CA  1 
+ATOM 130 C C   . LEU A 1 18 ? 4.397  4.014  -4.620 1.00 5.13  ? 18 LEU A C   1 
+ATOM 131 O O   . LEU A 1 18 ? 4.988  3.755  -5.687 1.00 5.55  ? 18 LEU A O   1 
+ATOM 132 C CB  . LEU A 1 18 ? 4.196  2.184  -2.863 1.00 6.47  ? 18 LEU A CB  1 
+ATOM 133 C CG  . LEU A 1 18 ? 4.960  1.178  -1.991 1.00 7.43  ? 18 LEU A CG  1 
+ATOM 134 C CD1 . LEU A 1 18 ? 3.907  0.097  -1.634 1.00 8.70  ? 18 LEU A CD1 1 
+ATOM 135 C CD2 . LEU A 1 18 ? 6.129  0.606  -2.768 1.00 9.39  ? 18 LEU A CD2 1 
+ATOM 136 N N   . PRO A 1 19 ? 3.329  4.795  -4.543 1.00 4.28  ? 19 PRO A N   1 
+ATOM 137 C CA  . PRO A 1 19 ? 2.792  5.376  -5.797 1.00 5.38  ? 19 PRO A CA  1 
+ATOM 138 C C   . PRO A 1 19 ? 3.573  6.540  -6.322 1.00 6.30  ? 19 PRO A C   1 
+ATOM 139 O O   . PRO A 1 19 ? 3.260  7.045  -7.422 1.00 9.62  ? 19 PRO A O   1 
+ATOM 140 C CB  . PRO A 1 19 ? 1.358  5.766  -5.472 1.00 5.87  ? 19 PRO A CB  1 
+ATOM 141 C CG  . PRO A 1 19 ? 1.223  5.694  -3.993 1.00 6.47  ? 19 PRO A CG  1 
+ATOM 142 C CD  . PRO A 1 19 ? 2.421  4.941  -3.408 1.00 6.45  ? 19 PRO A CD  1 
+ATOM 143 N N   . GLY A 1 20 ? 4.565  7.047  -5.559 1.00 4.94  ? 20 GLY A N   1 
+ATOM 144 C CA  . GLY A 1 20 ? 5.366  8.191  -6.018 1.00 5.39  ? 20 GLY A CA  1 
+ATOM 145 C C   . GLY A 1 20 ? 5.007  9.481  -5.280 1.00 5.03  ? 20 GLY A C   1 
+ATOM 146 O O   . GLY A 1 20 ? 5.535  10.510 -5.730 1.00 7.34  ? 20 GLY A O   1 
+ATOM 147 N N   . THR A 1 21 ? 4.181  9.438  -4.262 1.00 4.10  ? 21 THR A N   1 
+ATOM 148 C CA  . THR A 1 21 ? 3.767  10.609 -3.513 1.00 3.94  ? 21 THR A CA  1 
+ATOM 149 C C   . THR A 1 21 ? 5.017  11.397 -3.042 1.00 3.96  ? 21 THR A C   1 
+ATOM 150 O O   . THR A 1 21 ? 5.947  10.757 -2.523 1.00 5.82  ? 21 THR A O   1 
+ATOM 151 C CB  . THR A 1 21 ? 2.992  10.188 -2.225 1.00 4.13  ? 21 THR A CB  1 
+ATOM 152 O OG1 . THR A 1 21 ? 2.051  9.144  -2.623 1.00 5.45  ? 21 THR A OG1 1 
+ATOM 153 C CG2 . THR A 1 21 ? 2.260  11.349 -1.551 1.00 5.41  ? 21 THR A CG2 1 
+ATOM 154 N N   . PRO A 1 22 ? 4.971  12.703 -3.176 1.00 5.04  ? 22 PRO A N   1 
+ATOM 155 C CA  . PRO A 1 22 ? 6.143  13.513 -2.696 1.00 4.69  ? 22 PRO A CA  1 
+ATOM 156 C C   . PRO A 1 22 ? 6.400  13.233 -1.225 1.00 4.19  ? 22 PRO A C   1 
+ATOM 157 O O   . PRO A 1 22 ? 5.485  13.061 -0.382 1.00 4.47  ? 22 PRO A O   1 
+ATOM 158 C CB  . PRO A 1 22 ? 5.703  14.969 -2.920 1.00 7.12  ? 22 PRO A CB  1 
+ATOM 159 C CG  . PRO A 1 22 ? 4.676  14.893 -3.996 1.00 7.03  ? 22 PRO A CG  1 
+ATOM 160 C CD  . PRO A 1 22 ? 3.964  13.567 -3.811 1.00 4.90  ? 22 PRO A CD  1 
+ATOM 161 N N   . GLU A 1 23 ? 7.728  13.297 -0.921 1.00 5.16  ? 23 GLU A N   1 
+ATOM 162 C CA  . GLU A 1 23 ? 8.114  13.103 0.500  1.00 5.31  ? 23 GLU A CA  1 
+ATOM 163 C C   . GLU A 1 23 ? 7.427  14.073 1.410  1.00 4.11  ? 23 GLU A C   1 
+ATOM 164 O O   . GLU A 1 23 ? 7.036  13.682 2.540  1.00 5.11  ? 23 GLU A O   1 
+ATOM 165 C CB  . GLU A 1 23 ? 9.648  13.285 0.660  1.00 6.16  ? 23 GLU A CB  1 
+ATOM 166 C CG  . GLU A 1 23 ? 10.440 12.093 0.063  1.00 7.48  ? 23 GLU A CG  1 
+ATOM 167 C CD  . GLU A 1 23 ? 11.941 12.170 0.391  1.00 9.40  ? 23 GLU A CD  1 
+ATOM 168 O OE1 . GLU A 1 23 ? 12.416 13.225 0.681  1.00 10.40 ? 23 GLU A OE1 1 
+ATOM 169 O OE2 . GLU A 1 23 ? 12.539 11.070 0.292  1.00 13.32 ? 23 GLU A OE2 1 
+ATOM 170 N N   . ALA A 1 24 ? 7.212  15.334 0.966  1.00 4.56  ? 24 ALA A N   1 
+ATOM 171 C CA  . ALA A 1 24 ? 6.614  16.317 1.913  1.00 4.49  ? 24 ALA A CA  1 
+ATOM 172 C C   . ALA A 1 24 ? 5.212  15.936 2.350  1.00 4.10  ? 24 ALA A C   1 
+ATOM 173 O O   . ALA A 1 24 ? 4.782  16.166 3.495  1.00 5.64  ? 24 ALA A O   1 
+ATOM 174 C CB  . ALA A 1 24 ? 6.605  17.695 1.246  1.00 5.80  ? 24 ALA A CB  1 
+ATOM 175 N N   . ILE A 1 25 ? 4.445  15.318 1.405  1.00 4.37  ? 25 ILE A N   1 
+ATOM 176 C CA  . ILE A 1 25 ? 3.074  14.894 1.756  1.00 5.44  ? 25 ILE A CA  1 
+ATOM 177 C C   . ILE A 1 25 ? 3.085  13.643 2.645  1.00 4.32  ? 25 ILE A C   1 
+ATOM 178 O O   . ILE A 1 25 ? 2.315  13.523 3.578  1.00 4.72  ? 25 ILE A O   1 
+ATOM 179 C CB  . ILE A 1 25 ? 2.204  14.637 0.462  1.00 6.42  ? 25 ILE A CB  1 
+ATOM 180 C CG1 . ILE A 1 25 ? 1.815  16.048 -0.129 1.00 7.50  ? 25 ILE A CG1 1 
+ATOM 181 C CG2 . ILE A 1 25 ? 0.903  13.864 0.811  1.00 7.65  ? 25 ILE A CG2 1 
+ATOM 182 C CD1 . ILE A 1 25 ? 0.756  16.761 0.757  1.00 7.80  ? 25 ILE A CD1 1 
+ATOM 183 N N   . CYS A 1 26 ? 4.032  12.764 2.313  1.00 3.92  ? 26 CYS A N   1 
+ATOM 184 C CA  . CYS A 1 26 ? 4.180  11.549 3.187  1.00 4.37  ? 26 CYS A CA  1 
+ATOM 185 C C   . CYS A 1 26 ? 4.632  11.944 4.596  1.00 3.95  ? 26 CYS A C   1 
+ATOM 186 O O   . CYS A 1 26 ? 4.227  11.252 5.547  1.00 4.74  ? 26 CYS A O   1 
+ATOM 187 C CB  . CYS A 1 26 ? 5.038  10.518 2.539  1.00 4.63  ? 26 CYS A CB  1 
+ATOM 188 S SG  . CYS A 1 26 ? 4.349  9.794  1.022  1.00 5.61  ? 26 CYS A SG  1 
+ATOM 189 N N   . ALA A 1 27 ? 5.408  13.012 4.694  1.00 3.89  ? 27 ALA A N   1 
+ATOM 190 C CA  . ALA A 1 27 ? 5.879  13.502 6.026  1.00 4.43  ? 27 ALA A CA  1 
+ATOM 191 C C   . ALA A 1 27 ? 4.696  13.908 6.882  1.00 4.26  ? 27 ALA A C   1 
+ATOM 192 O O   . ALA A 1 27 ? 4.528  13.422 8.025  1.00 5.44  ? 27 ALA A O   1 
+ATOM 193 C CB  . ALA A 1 27 ? 6.880  14.615 5.830  1.00 5.36  ? 27 ALA A CB  1 
+ATOM 194 N N   . THR A 1 28 ? 3.827  14.802 6.358  1.00 4.53  ? 28 THR A N   1 
+ATOM 195 C CA  . THR A 1 28 ? 2.691  15.221 7.194  1.00 5.08  ? 28 THR A CA  1 
+ATOM 196 C C   . THR A 1 28 ? 1.672  14.132 7.434  1.00 4.62  ? 28 THR A C   1 
+ATOM 197 O O   . THR A 1 28 ? 0.947  14.112 8.468  1.00 7.80  ? 28 THR A O   1 
+ATOM 198 C CB  . THR A 1 28 ? 1.986  16.520 6.614  1.00 6.03  ? 28 THR A CB  1 
+ATOM 199 O OG1 . THR A 1 28 ? 1.664  16.221 5.230  1.00 7.19  ? 28 THR A OG1 1 
+ATOM 200 C CG2 . THR A 1 28 ? 2.914  17.739 6.700  1.00 7.34  ? 28 THR A CG2 1 
+ATOM 201 N N   . TYR A 1 29 ? 1.621  13.190 6.511  1.00 5.01  ? 29 TYR A N   1 
+ATOM 202 C CA  . TYR A 1 29 ? 0.715  12.045 6.657  1.00 6.60  ? 29 TYR A CA  1 
+ATOM 203 C C   . TYR A 1 29 ? 1.125  11.125 7.815  1.00 4.92  ? 29 TYR A C   1 
+ATOM 204 O O   . TYR A 1 29 ? 0.286  10.632 8.545  1.00 7.13  ? 29 TYR A O   1 
+ATOM 205 C CB  . TYR A 1 29 ? 0.755  11.229 5.322  1.00 9.66  ? 29 TYR A CB  1 
+ATOM 206 C CG  . TYR A 1 29 ? -0.203 10.044 5.354  1.00 11.56 ? 29 TYR A CG  1 
+ATOM 207 C CD1 . TYR A 1 29 ? -1.547 10.337 5.645  1.00 12.85 ? 29 TYR A CD1 1 
+ATOM 208 C CD2 . TYR A 1 29 ? 0.193  8.750  5.100  1.00 14.44 ? 29 TYR A CD2 1 
+ATOM 209 C CE1 . TYR A 1 29 ? -2.496 9.329  5.673  1.00 16.61 ? 29 TYR A CE1 1 
+ATOM 210 C CE2 . TYR A 1 29 ? -0.801 7.705  5.156  1.00 17.11 ? 29 TYR A CE2 1 
+ATOM 211 C CZ  . TYR A 1 29 ? -2.079 8.031  5.430  1.00 19.99 ? 29 TYR A CZ  1 
+ATOM 212 O OH  . TYR A 1 29 ? -3.097 7.057  5.458  1.00 28.98 ? 29 TYR A OH  1 
+ATOM 213 N N   . THR A 1 30 ? 2.470  10.984 7.995  1.00 5.31  ? 30 THR A N   1 
+ATOM 214 C CA  . THR A 1 30 ? 2.986  9.994  8.950  1.00 5.70  ? 30 THR A CA  1 
+ATOM 215 C C   . THR A 1 30 ? 3.609  10.505 10.230 1.00 6.28  ? 30 THR A C   1 
+ATOM 216 O O   . THR A 1 30 ? 3.766  9.715  11.186 1.00 8.77  ? 30 THR A O   1 
+ATOM 217 C CB  . THR A 1 30 ? 4.076  9.103  8.225  1.00 6.55  ? 30 THR A CB  1 
+ATOM 218 O OG1 . THR A 1 30 ? 5.125  10.027 7.824  1.00 6.57  ? 30 THR A OG1 1 
+ATOM 219 C CG2 . THR A 1 30 ? 3.493  8.324  7.035  1.00 7.29  ? 30 THR A CG2 1 
+ATOM 220 N N   . GLY A 1 31 ? 3.984  11.764 10.241 1.00 4.99  ? 31 GLY A N   1 
+ATOM 221 C CA  . GLY A 1 31 ? 4.769  12.336 11.360 1.00 5.50  ? 31 GLY A CA  1 
+ATOM 222 C C   . GLY A 1 31 ? 6.255  12.243 11.106 1.00 4.19  ? 31 GLY A C   1 
+ATOM 223 O O   . GLY A 1 31 ? 7.037  12.750 11.954 1.00 6.12  ? 31 GLY A O   1 
+ATOM 224 N N   . CYS A 1 32 ? 6.710  11.631 9.992  1.00 4.30  ? 32 CYS A N   1 
+ATOM 225 C CA  . CYS A 1 32 ? 8.140  11.694 9.635  1.00 4.89  ? 32 CYS A CA  1 
+ATOM 226 C C   . CYS A 1 32 ? 8.500  13.141 9.206  1.00 5.50  ? 32 CYS A C   1 
+ATOM 227 O O   . CYS A 1 32 ? 7.581  13.949 8.944  1.00 5.82  ? 32 CYS A O   1 
+ATOM 228 C CB  . CYS A 1 32 ? 8.504  10.686 8.530  1.00 4.66  ? 32 CYS A CB  1 
+ATOM 229 S SG  . CYS A 1 32 ? 8.048  8.987  8.881  1.00 5.33  ? 32 CYS A SG  1 
+ATOM 230 N N   . ILE A 1 33 ? 9.793  13.410 9.173  1.00 6.02  ? 33 ILE A N   1 
+ATOM 231 C CA  . ILE A 1 33 ? 10.280 14.760 8.823  1.00 5.24  ? 33 ILE A CA  1 
+ATOM 232 C C   . ILE A 1 33 ? 11.346 14.658 7.743  1.00 5.16  ? 33 ILE A C   1 
+ATOM 233 O O   . ILE A 1 33 ? 11.971 13.583 7.552  1.00 7.19  ? 33 ILE A O   1 
+ATOM 234 C CB  . ILE A 1 33 ? 10.790 15.535 10.085 1.00 5.49  ? 33 ILE A CB  1 
+ATOM 235 C CG1 . ILE A 1 33 ? 12.059 14.803 10.671 1.00 6.85  ? 33 ILE A CG1 1 
+ATOM 236 C CG2 . ILE A 1 33 ? 9.684  15.686 11.138 1.00 6.45  ? 33 ILE A CG2 1 
+ATOM 237 C CD1 . ILE A 1 33 ? 12.733 15.676 11.781 1.00 8.94  ? 33 ILE A CD1 1 
+ATOM 238 N N   . ILE A 1 34 ? 11.490 15.773 7.038  1.00 5.52  ? 34 ILE A N   1 
+ATOM 239 C CA  . ILE A 1 34 ? 12.552 15.877 6.036  1.00 6.82  ? 34 ILE A CA  1 
+ATOM 240 C C   . ILE A 1 34 ? 13.590 16.917 6.560  1.00 6.92  ? 34 ILE A C   1 
+ATOM 241 O O   . ILE A 1 34 ? 13.168 18.006 6.945  1.00 9.22  ? 34 ILE A O   1 
+ATOM 242 C CB  . ILE A 1 34 ? 11.987 16.360 4.681  1.00 8.11  ? 34 ILE A CB  1 
+ATOM 243 C CG1 . ILE A 1 34 ? 10.914 15.338 4.163  1.00 9.59  ? 34 ILE A CG1 1 
+ATOM 244 C CG2 . ILE A 1 34 ? 13.131 16.517 3.629  1.00 9.73  ? 34 ILE A CG2 1 
+ATOM 245 C CD1 . ILE A 1 34 ? 10.151 16.024 2.938  1.00 13.41 ? 34 ILE A CD1 1 
+ATOM 246 N N   . ILE A 1 35 ? 14.856 16.493 6.536  1.00 7.06  ? 35 ILE A N   1 
+ATOM 247 C CA  . ILE A 1 35 ? 15.930 17.454 6.941  1.00 7.52  ? 35 ILE A CA  1 
+ATOM 248 C C   . ILE A 1 35 ? 16.913 17.550 5.819  1.00 6.63  ? 35 ILE A C   1 
+ATOM 249 O O   . ILE A 1 35 ? 17.097 16.660 4.970  1.00 7.90  ? 35 ILE A O   1 
+ATOM 250 C CB  . ILE A 1 35 ? 16.622 16.995 8.285  1.00 8.07  ? 35 ILE A CB  1 
+ATOM 251 C CG1 . ILE A 1 35 ? 17.360 15.651 8.067  1.00 9.41  ? 35 ILE A CG1 1 
+ATOM 252 C CG2 . ILE A 1 35 ? 15.592 16.974 9.434  1.00 9.46  ? 35 ILE A CG2 1 
+ATOM 253 C CD1 . ILE A 1 35 ? 18.298 15.206 9.219  1.00 9.85  ? 35 ILE A CD1 1 
+ATOM 254 N N   . PRO A 1 36 ? 17.664 18.669 5.806  1.00 8.07  ? 36 PRO A N   1 
+ATOM 255 C CA  . PRO A 1 36 ? 18.635 18.861 4.738  1.00 8.78  ? 36 PRO A CA  1 
+ATOM 256 C C   . PRO A 1 36 ? 19.925 18.042 4.949  1.00 8.31  ? 36 PRO A C   1 
+ATOM 257 O O   . PRO A 1 36 ? 20.593 17.742 3.945  1.00 9.09  ? 36 PRO A O   1 
+ATOM 258 C CB  . PRO A 1 36 ? 18.945 20.364 4.783  1.00 9.67  ? 36 PRO A CB  1 
+ATOM 259 C CG  . PRO A 1 36 ? 18.238 20.937 5.908  1.00 10.15 ? 36 PRO A CG  1 
+ATOM 260 C CD  . PRO A 1 36 ? 17.371 19.900 6.596  1.00 9.53  ? 36 PRO A CD  1 
+ATOM 261 N N   . GLY A 1 37 ? 20.172 17.730 6.217  1.00 8.48  ? 37 GLY A N   1 
+ATOM 262 C CA  . GLY A 1 37 ? 21.452 16.969 6.513  1.00 9.20  ? 37 GLY A CA  1 
+ATOM 263 C C   . GLY A 1 37 ? 21.143 15.478 6.427  1.00 10.41 ? 37 GLY A C   1 
+ATOM 264 O O   . GLY A 1 37 ? 20.138 15.023 5.878  1.00 12.06 ? 37 GLY A O   1 
+ATOM 265 N N   . ALA A 1 38 ? 22.055 14.701 7.032  1.00 9.24  ? 38 ALA A N   1 
+ATOM 266 C CA  . ALA A 1 38 ? 22.019 13.242 7.020  1.00 9.24  ? 38 ALA A CA  1 
+ATOM 267 C C   . ALA A 1 38 ? 21.944 12.628 8.396  1.00 9.60  ? 38 ALA A C   1 
+ATOM 268 O O   . ALA A 1 38 ? 21.869 11.387 8.435  1.00 13.65 ? 38 ALA A O   1 
+ATOM 269 C CB  . ALA A 1 38 ? 23.246 12.697 6.275  1.00 10.43 ? 38 ALA A CB  1 
+ATOM 270 N N   . THR A 1 39 ? 21.894 13.435 9.436  1.00 8.70  ? 39 THR A N   1 
+ATOM 271 C CA  . THR A 1 39 ? 21.936 12.911 10.809 1.00 9.46  ? 39 THR A CA  1 
+ATOM 272 C C   . THR A 1 39 ? 20.615 13.191 11.521 1.00 8.32  ? 39 THR A C   1 
+ATOM 273 O O   . THR A 1 39 ? 20.357 14.317 11.948 1.00 9.89  ? 39 THR A O   1 
+ATOM 274 C CB  . THR A 1 39 ? 23.131 13.601 11.593 1.00 10.72 ? 39 THR A CB  1 
+ATOM 275 O OG1 . THR A 1 39 ? 24.284 13.401 10.709 1.00 11.66 ? 39 THR A OG1 1 
+ATOM 276 C CG2 . THR A 1 39 ? 23.340 12.935 12.962 1.00 11.81 ? 39 THR A CG2 1 
+ATOM 277 N N   . CYS A 1 40 ? 19.827 12.110 11.642 1.00 7.64  ? 40 CYS A N   1 
+ATOM 278 C CA  . CYS A 1 40 ? 18.504 12.312 12.298 1.00 8.05  ? 40 CYS A CA  1 
+ATOM 279 C C   . CYS A 1 40 ? 18.684 12.451 13.784 1.00 7.63  ? 40 CYS A C   1 
+ATOM 280 O O   . CYS A 1 40 ? 19.533 11.718 14.362 1.00 9.64  ? 40 CYS A O   1 
+ATOM 281 C CB  . CYS A 1 40 ? 17.582 11.117 11.996 1.00 7.80  ? 40 CYS A CB  1 
+ATOM 282 S SG  . CYS A 1 40 ? 17.199 10.929 10.237 1.00 7.30  ? 40 CYS A SG  1 
+ATOM 283 N N   . PRO A 1 41 ? 17.880 13.266 14.426 1.00 8.00  ? 41 PRO A N   1 
+ATOM 284 C CA  . PRO A 1 41 ? 17.924 13.421 15.877 1.00 8.96  ? 41 PRO A CA  1 
+ATOM 285 C C   . PRO A 1 41 ? 17.392 12.206 16.594 1.00 9.06  ? 41 PRO A C   1 
+ATOM 286 O O   . PRO A 1 41 ? 16.652 11.368 16.033 1.00 8.82  ? 41 PRO A O   1 
+ATOM 287 C CB  . PRO A 1 41 ? 17.076 14.658 16.145 1.00 10.39 ? 41 PRO A CB  1 
+ATOM 288 C CG  . PRO A 1 41 ? 16.098 14.689 14.997 1.00 10.99 ? 41 PRO A CG  1 
+ATOM 289 C CD  . PRO A 1 41 ? 16.859 14.150 13.779 1.00 10.49 ? 41 PRO A CD  1 
+ATOM 290 N N   . GLY A 1 42 ? 17.728 12.124 17.884 1.00 7.55  ? 42 GLY A N   1 
+ATOM 291 C CA  . GLY A 1 42 ? 17.334 10.956 18.691 1.00 8.00  ? 42 GLY A CA  1 
+ATOM 292 C C   . GLY A 1 42 ? 15.875 10.688 18.871 1.00 7.22  ? 42 GLY A C   1 
+ATOM 293 O O   . GLY A 1 42 ? 15.434 9.550  19.166 1.00 8.41  ? 42 GLY A O   1 
+ATOM 294 N N   . ASP A 1 43 ? 15.036 11.747 18.715 1.00 5.54  ? 43 ASP A N   1 
+ATOM 295 C CA  . ASP A 1 43 ? 13.564 11.573 18.836 1.00 5.85  ? 43 ASP A CA  1 
+ATOM 296 C C   . ASP A 1 43 ? 12.936 11.227 17.470 1.00 5.87  ? 43 ASP A C   1 
+ATOM 297 O O   . ASP A 1 43 ? 11.720 11.040 17.428 1.00 7.29  ? 43 ASP A O   1 
+ATOM 298 C CB  . ASP A 1 43 ? 12.933 12.737 19.580 1.00 6.72  ? 43 ASP A CB  1 
+ATOM 299 C CG  . ASP A 1 43 ? 13.140 14.094 18.958 1.00 8.59  ? 43 ASP A CG  1 
+ATOM 300 O OD1 . ASP A 1 43 ? 14.109 14.303 18.212 1.00 9.59  ? 43 ASP A OD1 1 
+ATOM 301 O OD2 . ASP A 1 43 ? 12.267 14.963 19.265 1.00 11.45 ? 43 ASP A OD2 1 
+ATOM 302 N N   . TYR A 1 44 ? 13.725 11.174 16.425 1.00 5.22  ? 44 TYR A N   1 
+ATOM 303 C CA  . TYR A 1 44 ? 13.257 10.745 15.081 1.00 5.56  ? 44 TYR A CA  1 
+ATOM 304 C C   . TYR A 1 44 ? 14.275 9.687  14.612 1.00 4.61  ? 44 TYR A C   1 
+ATOM 305 O O   . TYR A 1 44 ? 14.930 9.862  13.568 1.00 6.04  ? 44 TYR A O   1 
+ATOM 306 C CB  . TYR A 1 44 ? 13.200 11.914 14.071 1.00 5.41  ? 44 TYR A CB  1 
+ATOM 307 C CG  . TYR A 1 44 ? 12.000 12.819 14.399 1.00 5.34  ? 44 TYR A CG  1 
+ATOM 308 C CD1 . TYR A 1 44 ? 12.119 13.853 15.332 1.00 6.59  ? 44 TYR A CD1 1 
+ATOM 309 C CD2 . TYR A 1 44 ? 10.775 12.617 13.762 1.00 5.94  ? 44 TYR A CD2 1 
+ATOM 310 C CE1 . TYR A 1 44 ? 11.045 14.675 15.610 1.00 5.97  ? 44 TYR A CE1 1 
+ATOM 311 C CE2 . TYR A 1 44 ? 9.676  13.433 14.048 1.00 5.17  ? 44 TYR A CE2 1 
+ATOM 312 C CZ  . TYR A 1 44 ? 9.802  14.456 14.996 1.00 5.96  ? 44 TYR A CZ  1 
+ATOM 313 O OH  . TYR A 1 44 ? 8.740  15.265 15.269 1.00 8.60  ? 44 TYR A OH  1 
+ATOM 314 N N   . ALA A 1 45 ? 14.342 8.640  15.422 1.00 4.76  ? 45 ALA A N   1 
+ATOM 315 C CA  . ALA A 1 45 ? 15.445 7.667  15.246 1.00 5.89  ? 45 ALA A CA  1 
+ATOM 316 C C   . ALA A 1 45 ? 15.171 6.533  14.280 1.00 6.67  ? 45 ALA A C   1 
+ATOM 317 O O   . ALA A 1 45 ? 16.093 5.705  14.039 1.00 7.56  ? 45 ALA A O   1 
+ATOM 318 C CB  . ALA A 1 45 ? 15.680 7.099  16.682 1.00 6.82  ? 45 ALA A CB  1 
+ATOM 319 N N   . ASN A 1 46 ? 13.966 6.502  13.739 1.00 5.80  ? 46 ASN A N   1 
+ATOM 320 C CA  . ASN A 1 46 ? 13.512 5.395  12.878 1.00 6.15  ? 46 ASN A CA  1 
+ATOM 321 C C   . ASN A 1 46 ? 13.311 5.853  11.455 1.00 6.61  ? 46 ASN A C   1 
+ATOM 322 O O   . ASN A 1 46 ? 13.733 6.929  11.026 1.00 7.18  ? 46 ASN A O   1 
+ATOM 323 C CB  . ASN A 1 46 ? 12.266 4.769  13.501 1.00 7.27  ? 46 ASN A CB  1 
+ATOM 324 C CG  . ASN A 1 46 ? 12.538 4.304  14.922 1.00 7.98  ? 46 ASN A CG  1 
+ATOM 325 O OD1 . ASN A 1 46 ? 11.982 4.849  15.886 1.00 11.00 ? 46 ASN A OD1 1 
+ATOM 326 N ND2 . ASN A 1 46 ? 13.407 3.298  15.015 1.00 10.32 ? 46 ASN A ND2 1 
+ATOM 327 O OXT . ASN A 1 46 ? 12.703 4.973  10.746 1.00 7.86  ? 46 ASN A OXT 1 
+# 
+loop_
+_pdbx_poly_seq_scheme.asym_id 
+_pdbx_poly_seq_scheme.entity_id 
+_pdbx_poly_seq_scheme.seq_id 
+_pdbx_poly_seq_scheme.mon_id 
+_pdbx_poly_seq_scheme.ndb_seq_num 
+_pdbx_poly_seq_scheme.pdb_seq_num 
+_pdbx_poly_seq_scheme.auth_seq_num 
+_pdbx_poly_seq_scheme.pdb_mon_id 
+_pdbx_poly_seq_scheme.auth_mon_id 
+_pdbx_poly_seq_scheme.pdb_strand_id 
+_pdbx_poly_seq_scheme.pdb_ins_code 
+_pdbx_poly_seq_scheme.hetero 
+A 1 1  THR 1  1  1  THR THR A . n 
+A 1 2  THR 2  2  2  THR THR A . n 
+A 1 3  CYS 3  3  3  CYS CYS A . n 
+A 1 4  CYS 4  4  4  CYS CYS A . n 
+A 1 5  PRO 5  5  5  PRO PRO A . n 
+A 1 6  SER 6  6  6  SER SER A . n 
+A 1 7  ILE 7  7  7  ILE ILE A . n 
+A 1 8  VAL 8  8  8  VAL VAL A . n 
+A 1 9  ALA 9  9  9  ALA ALA A . n 
+A 1 10 ARG 10 10 10 ARG ARG A . n 
+A 1 11 SER 11 11 11 SER SER A . n 
+A 1 12 ASN 12 12 12 ASN ASN A . n 
+A 1 13 PHE 13 13 13 PHE PHE A . n 
+A 1 14 ASN 14 14 14 ASN ASN A . n 
+A 1 15 VAL 15 15 15 VAL VAL A . n 
+A 1 16 CYS 16 16 16 CYS CYS A . n 
+A 1 17 ARG 17 17 17 ARG ARG A . n 
+A 1 18 LEU 18 18 18 LEU LEU A . n 
+A 1 19 PRO 19 19 19 PRO PRO A . n 
+A 1 20 GLY 20 20 20 GLY GLY A . n 
+A 1 21 THR 21 21 21 THR THR A . n 
+A 1 22 PRO 22 22 22 PRO PRO A . n 
+A 1 23 GLU 23 23 23 GLU GLU A . n 
+A 1 24 ALA 24 24 24 ALA ALA A . n 
+A 1 25 ILE 25 25 25 ILE ILE A . n 
+A 1 26 CYS 26 26 26 CYS CYS A . n 
+A 1 27 ALA 27 27 27 ALA ALA A . n 
+A 1 28 THR 28 28 28 THR THR A . n 
+A 1 29 TYR 29 29 29 TYR TYR A . n 
+A 1 30 THR 30 30 30 THR THR A . n 
+A 1 31 GLY 31 31 31 GLY GLY A . n 
+A 1 32 CYS 32 32 32 CYS CYS A . n 
+A 1 33 ILE 33 33 33 ILE ILE A . n 
+A 1 34 ILE 34 34 34 ILE ILE A . n 
+A 1 35 ILE 35 35 35 ILE ILE A . n 
+A 1 36 PRO 36 36 36 PRO PRO A . n 
+A 1 37 GLY 37 37 37 GLY GLY A . n 
+A 1 38 ALA 38 38 38 ALA ALA A . n 
+A 1 39 THR 39 39 39 THR THR A . n 
+A 1 40 CYS 40 40 40 CYS CYS A . n 
+A 1 41 PRO 41 41 41 PRO PRO A . n 
+A 1 42 GLY 42 42 42 GLY GLY A . n 
+A 1 43 ASP 43 43 43 ASP ASP A . n 
+A 1 44 TYR 44 44 44 TYR TYR A . n 
+A 1 45 ALA 45 45 45 ALA ALA A . n 
+A 1 46 ASN 46 46 46 ASN ASN A . n 
+# 
+_pdbx_struct_assembly.id                   1 
+_pdbx_struct_assembly.details              author_defined_assembly 
+_pdbx_struct_assembly.method_details       ? 
+_pdbx_struct_assembly.oligomeric_details   monomeric 
+_pdbx_struct_assembly.oligomeric_count     1 
+# 
+_pdbx_struct_assembly_gen.assembly_id       1 
+_pdbx_struct_assembly_gen.oper_expression   1 
+_pdbx_struct_assembly_gen.asym_id_list      A 
+# 
+_pdbx_struct_oper_list.id                   1 
+_pdbx_struct_oper_list.type                 'identity operation' 
+_pdbx_struct_oper_list.name                 1_555 
+_pdbx_struct_oper_list.symmetry_operation   x,y,z 
+_pdbx_struct_oper_list.matrix[1][1]         1.0000000000 
+_pdbx_struct_oper_list.matrix[1][2]         0.0000000000 
+_pdbx_struct_oper_list.matrix[1][3]         0.0000000000 
+_pdbx_struct_oper_list.vector[1]            0.0000000000 
+_pdbx_struct_oper_list.matrix[2][1]         0.0000000000 
+_pdbx_struct_oper_list.matrix[2][2]         1.0000000000 
+_pdbx_struct_oper_list.matrix[2][3]         0.0000000000 
+_pdbx_struct_oper_list.vector[2]            0.0000000000 
+_pdbx_struct_oper_list.matrix[3][1]         0.0000000000 
+_pdbx_struct_oper_list.matrix[3][2]         0.0000000000 
+_pdbx_struct_oper_list.matrix[3][3]         1.0000000000 
+_pdbx_struct_oper_list.vector[3]            0.0000000000 
+# 
+loop_
+_pdbx_audit_revision_history.ordinal 
+_pdbx_audit_revision_history.data_content_type 
+_pdbx_audit_revision_history.major_revision 
+_pdbx_audit_revision_history.minor_revision 
+_pdbx_audit_revision_history.revision_date 
+1 'Structure model' 1 0 1981-07-28 
+2 'Structure model' 1 1 2008-03-24 
+3 'Structure model' 1 2 2011-07-13 
+4 'Structure model' 1 3 2012-07-11 
+5 'Structure model' 1 4 2017-11-29 
+# 
+_pdbx_audit_revision_details.ordinal             1 
+_pdbx_audit_revision_details.revision_ordinal    1 
+_pdbx_audit_revision_details.data_content_type   'Structure model' 
+_pdbx_audit_revision_details.provider            repository 
+_pdbx_audit_revision_details.type                'Initial release' 
+_pdbx_audit_revision_details.description         ? 
+# 
+loop_
+_pdbx_audit_revision_group.ordinal 
+_pdbx_audit_revision_group.revision_ordinal 
+_pdbx_audit_revision_group.data_content_type 
+_pdbx_audit_revision_group.group 
+1 2 'Structure model' 'Version format compliance' 
+2 3 'Structure model' 'Version format compliance' 
+3 4 'Structure model' Other                       
+4 5 'Structure model' 'Derived calculations'      
+5 5 'Structure model' Other                       
+# 
+loop_
+_pdbx_audit_revision_category.ordinal 
+_pdbx_audit_revision_category.revision_ordinal 
+_pdbx_audit_revision_category.data_content_type 
+_pdbx_audit_revision_category.category 
+1 5 'Structure model' pdbx_database_status 
+2 5 'Structure model' struct_conf          
+3 5 'Structure model' struct_conf_type     
+# 
+_pdbx_audit_revision_item.ordinal             1 
+_pdbx_audit_revision_item.revision_ordinal    5 
+_pdbx_audit_revision_item.data_content_type   'Structure model' 
+_pdbx_audit_revision_item.item                '_pdbx_database_status.process_site' 
+# 
+_software.name             PROLSQ 
+_software.classification   refinement 
+_software.version          . 
+_software.citation_id      ? 
+_software.pdbx_ordinal     1 
+# 
+_pdbx_entry_details.entry_id             1CRN 
+_pdbx_entry_details.compound_details     
+;THE SECONDARY STRUCTURE SPECIFICATIONS ARE THOSE DEFINED
+IN REFERENCE 1 ABOVE AND DEPEND ON PARTICULAR DEFINITIONS
+THAT MAY AFFECT THE DETERMINATION OF END POINTS.  PLEASE
+CONSULT THE PRIMARY REFERENCE AND EXAMINE STRUCTURAL
+DETAILS SUCH AS HYDROGEN BONDING AND CONFORMATION ANGLES
+WHEN MAKING USE OF THE SPECIFICATIONS.
+;
+_pdbx_entry_details.source_details       ? 
+_pdbx_entry_details.nonpolymer_details   ? 
+_pdbx_entry_details.sequence_details     ? 
+# 
+loop_
+_pdbx_validate_rmsd_angle.id 
+_pdbx_validate_rmsd_angle.PDB_model_num 
+_pdbx_validate_rmsd_angle.auth_atom_id_1 
+_pdbx_validate_rmsd_angle.auth_asym_id_1 
+_pdbx_validate_rmsd_angle.auth_comp_id_1 
+_pdbx_validate_rmsd_angle.auth_seq_id_1 
+_pdbx_validate_rmsd_angle.PDB_ins_code_1 
+_pdbx_validate_rmsd_angle.label_alt_id_1 
+_pdbx_validate_rmsd_angle.auth_atom_id_2 
+_pdbx_validate_rmsd_angle.auth_asym_id_2 
+_pdbx_validate_rmsd_angle.auth_comp_id_2 
+_pdbx_validate_rmsd_angle.auth_seq_id_2 
+_pdbx_validate_rmsd_angle.PDB_ins_code_2 
+_pdbx_validate_rmsd_angle.label_alt_id_2 
+_pdbx_validate_rmsd_angle.auth_atom_id_3 
+_pdbx_validate_rmsd_angle.auth_asym_id_3 
+_pdbx_validate_rmsd_angle.auth_comp_id_3 
+_pdbx_validate_rmsd_angle.auth_seq_id_3 
+_pdbx_validate_rmsd_angle.PDB_ins_code_3 
+_pdbx_validate_rmsd_angle.label_alt_id_3 
+_pdbx_validate_rmsd_angle.angle_value 
+_pdbx_validate_rmsd_angle.angle_target_value 
+_pdbx_validate_rmsd_angle.angle_deviation 
+_pdbx_validate_rmsd_angle.angle_standard_deviation 
+_pdbx_validate_rmsd_angle.linker_flag 
+1 1 NE A ARG 10 ? ? CZ A ARG 10 ? ? NH2 A ARG 10 ? ? 116.71 120.30 -3.59 0.50 N 
+2 1 CB A TYR 29 ? ? CG A TYR 29 ? ? CD1 A TYR 29 ? ? 116.31 121.00 -4.69 0.60 N 
+# 

--- a/Code/GraphMol/FileParsers/test_data/1doy.cif
+++ b/Code/GraphMol/FileParsers/test_data/1doy.cif
@@ -1,0 +1,5030 @@
+data_1DOY
+# 
+_entry.id   1DOY 
+# 
+_audit_conform.dict_name       mmcif_pdbx.dic 
+_audit_conform.dict_version    5.279 
+_audit_conform.dict_location   http://mmcif.pdb.org/dictionaries/ascii/mmcif_pdbx.dic 
+# 
+loop_
+_database_2.database_id 
+_database_2.database_code 
+PDB   1DOY         
+WWPDB D_1000172881 
+# 
+_pdbx_database_status.status_code                     REL 
+_pdbx_database_status.entry_id                        1DOY 
+_pdbx_database_status.recvd_initial_deposition_date   1995-09-14 
+_pdbx_database_status.deposit_site                    ? 
+_pdbx_database_status.process_site                    ? 
+_pdbx_database_status.SG_entry                        . 
+_pdbx_database_status.pdb_format_compatible           Y 
+_pdbx_database_status.status_code_mr                  ? 
+_pdbx_database_status.status_code_sf                  ? 
+_pdbx_database_status.status_code_cs                  ? 
+# 
+loop_
+_audit_author.name 
+_audit_author.pdbx_ordinal 
+'Lelong, C.'    1 
+'Setif, P.'     2 
+'Bottin, H.'    3 
+'Andre, F.'     4 
+'Neumann, J.M.' 5 
+# 
+loop_
+_citation.id 
+_citation.title 
+_citation.journal_abbrev 
+_citation.journal_volume 
+_citation.page_first 
+_citation.page_last 
+_citation.year 
+_citation.journal_id_ASTM 
+_citation.country 
+_citation.journal_id_ISSN 
+_citation.journal_id_CSD 
+_citation.book_publisher 
+_citation.pdbx_database_id_PubMed 
+_citation.pdbx_database_id_DOI 
+primary 
+;1H and 15N NMR sequential assignment, secondary structure, and tertiary fold of [2Fe-2S] ferredoxin from Synechocystis sp. PCC 6803.
+;
+Biochemistry         34   14462 14473 1995 BICHAW US 0006-2960 0033 ? 7578051 10.1021/bi00044a024 
+1       'Ferredoxin and Flavodoxin from the Cyanobacterium Synechocystis Sp. Pcc 6803' Biochim.Biophys.Acta 1101 48    ?     1992 
+BBACAQ NE 0006-3002 0113 ? ?       ?                   
+# 
+loop_
+_citation_author.citation_id 
+_citation_author.name 
+_citation_author.ordinal 
+primary 'Lelong, C.'    1 
+primary 'Setif, P.'     2 
+primary 'Bottin, H.'    3 
+primary 'Andre, F.'     4 
+primary 'Neumann, J.M.' 5 
+1       'Bottin, H.'    6 
+1       'Lagoutte, B.'  7 
+# 
+_cell.entry_id           1DOY 
+_cell.length_a           1.000 
+_cell.length_b           1.000 
+_cell.length_c           1.000 
+_cell.angle_alpha        90.00 
+_cell.angle_beta         90.00 
+_cell.angle_gamma        90.00 
+_cell.Z_PDB              1 
+_cell.pdbx_unique_axis   ? 
+# 
+_symmetry.entry_id                         1DOY 
+_symmetry.space_group_name_H-M             'P 1' 
+_symmetry.pdbx_full_space_group_name_H-M   ? 
+_symmetry.cell_setting                     ? 
+_symmetry.Int_Tables_number                1 
+# 
+loop_
+_entity.id 
+_entity.type 
+_entity.src_method 
+_entity.pdbx_description 
+_entity.formula_weight 
+_entity.pdbx_number_of_molecules 
+_entity.pdbx_ec 
+_entity.pdbx_mutation 
+_entity.pdbx_fragment 
+_entity.details 
+1 polymer     nat 'FERREDOXIN [2FE-2S]'        10237.038 1 ? ? ? 'PLANT TYPE FERREDOXIN, WITH DISULFIDE BOND' 
+2 non-polymer syn 'FE2/S2 (INORGANIC) CLUSTER' 175.820   1 ? ? ? ?                                            
+# 
+_entity_poly.entity_id                      1 
+_entity_poly.type                           'polypeptide(L)' 
+_entity_poly.nstd_linkage                   no 
+_entity_poly.nstd_monomer                   no 
+_entity_poly.pdbx_seq_one_letter_code       
+;ASYTVKLITPDGESSIECSDDTYILDAAEEAGLDLPYSCRAGACSTCAGKITAGSVDQSDQSFLDDDQIEAGYVLTCVAY
+PTSDCTIETHKEEDLY
+;
+_entity_poly.pdbx_seq_one_letter_code_can   
+;ASYTVKLITPDGESSIECSDDTYILDAAEEAGLDLPYSCRAGACSTCAGKITAGSVDQSDQSFLDDDQIEAGYVLTCVAY
+PTSDCTIETHKEEDLY
+;
+_entity_poly.pdbx_strand_id                 A 
+_entity_poly.pdbx_target_identifier         ? 
+# 
+loop_
+_entity_poly_seq.entity_id 
+_entity_poly_seq.num 
+_entity_poly_seq.mon_id 
+_entity_poly_seq.hetero 
+1 1  ALA n 
+1 2  SER n 
+1 3  TYR n 
+1 4  THR n 
+1 5  VAL n 
+1 6  LYS n 
+1 7  LEU n 
+1 8  ILE n 
+1 9  THR n 
+1 10 PRO n 
+1 11 ASP n 
+1 12 GLY n 
+1 13 GLU n 
+1 14 SER n 
+1 15 SER n 
+1 16 ILE n 
+1 17 GLU n 
+1 18 CYS n 
+1 19 SER n 
+1 20 ASP n 
+1 21 ASP n 
+1 22 THR n 
+1 23 TYR n 
+1 24 ILE n 
+1 25 LEU n 
+1 26 ASP n 
+1 27 ALA n 
+1 28 ALA n 
+1 29 GLU n 
+1 30 GLU n 
+1 31 ALA n 
+1 32 GLY n 
+1 33 LEU n 
+1 34 ASP n 
+1 35 LEU n 
+1 36 PRO n 
+1 37 TYR n 
+1 38 SER n 
+1 39 CYS n 
+1 40 ARG n 
+1 41 ALA n 
+1 42 GLY n 
+1 43 ALA n 
+1 44 CYS n 
+1 45 SER n 
+1 46 THR n 
+1 47 CYS n 
+1 48 ALA n 
+1 49 GLY n 
+1 50 LYS n 
+1 51 ILE n 
+1 52 THR n 
+1 53 ALA n 
+1 54 GLY n 
+1 55 SER n 
+1 56 VAL n 
+1 57 ASP n 
+1 58 GLN n 
+1 59 SER n 
+1 60 ASP n 
+1 61 GLN n 
+1 62 SER n 
+1 63 PHE n 
+1 64 LEU n 
+1 65 ASP n 
+1 66 ASP n 
+1 67 ASP n 
+1 68 GLN n 
+1 69 ILE n 
+1 70 GLU n 
+1 71 ALA n 
+1 72 GLY n 
+1 73 TYR n 
+1 74 VAL n 
+1 75 LEU n 
+1 76 THR n 
+1 77 CYS n 
+1 78 VAL n 
+1 79 ALA n 
+1 80 TYR n 
+1 81 PRO n 
+1 82 THR n 
+1 83 SER n 
+1 84 ASP n 
+1 85 CYS n 
+1 86 THR n 
+1 87 ILE n 
+1 88 GLU n 
+1 89 THR n 
+1 90 HIS n 
+1 91 LYS n 
+1 92 GLU n 
+1 93 GLU n 
+1 94 ASP n 
+1 95 LEU n 
+1 96 TYR n 
+# 
+_entity_src_nat.entity_id                  1 
+_entity_src_nat.pdbx_src_id                1 
+_entity_src_nat.pdbx_alt_source_flag       sample 
+_entity_src_nat.pdbx_beg_seq_num           ? 
+_entity_src_nat.pdbx_end_seq_num           ? 
+_entity_src_nat.common_name                ? 
+_entity_src_nat.pdbx_organism_scientific   'Synechocystis sp.' 
+_entity_src_nat.pdbx_ncbi_taxonomy_id      1148 
+_entity_src_nat.genus                      Synechocystis 
+_entity_src_nat.species                    ? 
+_entity_src_nat.strain                     'PCC 6803' 
+_entity_src_nat.tissue                     ? 
+_entity_src_nat.tissue_fraction            ? 
+_entity_src_nat.pdbx_secretion             ? 
+_entity_src_nat.pdbx_fragment              ? 
+_entity_src_nat.pdbx_variant               ? 
+_entity_src_nat.pdbx_cell_line             ? 
+_entity_src_nat.pdbx_atcc                  ? 
+_entity_src_nat.pdbx_cellular_location     ? 
+_entity_src_nat.pdbx_organ                 ? 
+_entity_src_nat.pdbx_organelle             ? 
+_entity_src_nat.pdbx_cell                  ? 
+_entity_src_nat.pdbx_plasmid_name          ? 
+_entity_src_nat.pdbx_plasmid_details       ? 
+_entity_src_nat.details                    ? 
+# 
+_struct_ref.id                         1 
+_struct_ref.db_name                    UNP 
+_struct_ref.db_code                    FER_SYNY3 
+_struct_ref.entity_id                  1 
+_struct_ref.pdbx_db_accession          P27320 
+_struct_ref.pdbx_align_begin           1 
+_struct_ref.pdbx_seq_one_letter_code   
+;ASYTVKLITPDGESSIECSDDTYILDAAEEAGLDLPYSCRAGACSTCAGKITAGSVDQSDQSFLDDDQIEAGYVLTCVAY
+PTSDCTIETHKEEDLY
+;
+_struct_ref.pdbx_db_isoform            ? 
+# 
+_struct_ref_seq.align_id                      1 
+_struct_ref_seq.ref_id                        1 
+_struct_ref_seq.pdbx_PDB_id_code              1DOY 
+_struct_ref_seq.pdbx_strand_id                A 
+_struct_ref_seq.seq_align_beg                 1 
+_struct_ref_seq.pdbx_seq_align_beg_ins_code   ? 
+_struct_ref_seq.seq_align_end                 96 
+_struct_ref_seq.pdbx_seq_align_end_ins_code   ? 
+_struct_ref_seq.pdbx_db_accession             P27320 
+_struct_ref_seq.db_align_beg                  1 
+_struct_ref_seq.pdbx_db_align_beg_ins_code    ? 
+_struct_ref_seq.db_align_end                  96 
+_struct_ref_seq.pdbx_db_align_end_ins_code    ? 
+_struct_ref_seq.pdbx_auth_seq_align_beg       1 
+_struct_ref_seq.pdbx_auth_seq_align_end       96 
+# 
+loop_
+_chem_comp.id 
+_chem_comp.type 
+_chem_comp.mon_nstd_flag 
+_chem_comp.name 
+_chem_comp.pdbx_synonyms 
+_chem_comp.formula 
+_chem_comp.formula_weight 
+ALA 'L-peptide linking' y ALANINE                      ? 'C3 H7 N O2'     89.093  
+ARG 'L-peptide linking' y ARGININE                     ? 'C6 H15 N4 O2 1' 175.209 
+ASP 'L-peptide linking' y 'ASPARTIC ACID'              ? 'C4 H7 N O4'     133.103 
+CYS 'L-peptide linking' y CYSTEINE                     ? 'C3 H7 N O2 S'   121.158 
+FES non-polymer         . 'FE2/S2 (INORGANIC) CLUSTER' ? 'Fe2 S2'         175.820 
+GLN 'L-peptide linking' y GLUTAMINE                    ? 'C5 H10 N2 O3'   146.144 
+GLU 'L-peptide linking' y 'GLUTAMIC ACID'              ? 'C5 H9 N O4'     147.129 
+GLY 'peptide linking'   y GLYCINE                      ? 'C2 H5 N O2'     75.067  
+HIS 'L-peptide linking' y HISTIDINE                    ? 'C6 H10 N3 O2 1' 156.162 
+ILE 'L-peptide linking' y ISOLEUCINE                   ? 'C6 H13 N O2'    131.173 
+LEU 'L-peptide linking' y LEUCINE                      ? 'C6 H13 N O2'    131.173 
+LYS 'L-peptide linking' y LYSINE                       ? 'C6 H15 N2 O2 1' 147.195 
+PHE 'L-peptide linking' y PHENYLALANINE                ? 'C9 H11 N O2'    165.189 
+PRO 'L-peptide linking' y PROLINE                      ? 'C5 H9 N O2'     115.130 
+SER 'L-peptide linking' y SERINE                       ? 'C3 H7 N O3'     105.093 
+THR 'L-peptide linking' y THREONINE                    ? 'C4 H9 N O3'     119.119 
+TYR 'L-peptide linking' y TYROSINE                     ? 'C9 H11 N O3'    181.189 
+VAL 'L-peptide linking' y VALINE                       ? 'C5 H11 N O2'    117.146 
+# 
+_pdbx_nmr_ensemble.entry_id                             1DOY 
+_pdbx_nmr_ensemble.conformers_calculated_total_number   ? 
+_pdbx_nmr_ensemble.conformers_submitted_total_number    3 
+_pdbx_nmr_ensemble.conformer_selection_criteria         ? 
+# 
+_pdbx_nmr_software.classification   refinement 
+_pdbx_nmr_software.name             X-PLOR 
+_pdbx_nmr_software.version          3.0 
+_pdbx_nmr_software.authors          BRUNGER 
+_pdbx_nmr_software.ordinal          1 
+# 
+_exptl.entry_id          1DOY 
+_exptl.method            'SOLUTION NMR' 
+_exptl.crystals_number   ? 
+# 
+_struct.entry_id                  1DOY 
+_struct.title                     
+'1H AND 15N SEQUENTIAL ASSIGNMENT, SECONDARY STRUCTURE AND TERTIARY FOLD OF [2FE-2S] FERREDOXIN FROM SYNECHOCYSTIS SP. PCC 6803' 
+_struct.pdbx_descriptor           'FERREDOXIN [2FE-2S], FE2/S2 (INORGANIC) CLUSTER' 
+_struct.pdbx_model_details        ? 
+_struct.pdbx_CASP_flag            ? 
+_struct.pdbx_model_type_details   ? 
+# 
+_struct_keywords.entry_id        1DOY 
+_struct_keywords.pdbx_keywords   'ELECTRON TRANSPORT' 
+_struct_keywords.text            'IRON-SULFUR PROTEIN, ELECTRON TRANSPORT' 
+# 
+loop_
+_struct_asym.id 
+_struct_asym.pdbx_blank_PDB_chainid_flag 
+_struct_asym.pdbx_modified 
+_struct_asym.entity_id 
+_struct_asym.details 
+A Y N 1 ? 
+B N N 2 ? 
+# 
+_struct_biol.id   1 
+# 
+loop_
+_struct_conf.conf_type_id 
+_struct_conf.id 
+_struct_conf.pdbx_PDB_helix_id 
+_struct_conf.beg_label_comp_id 
+_struct_conf.beg_label_asym_id 
+_struct_conf.beg_label_seq_id 
+_struct_conf.pdbx_beg_PDB_ins_code 
+_struct_conf.end_label_comp_id 
+_struct_conf.end_label_asym_id 
+_struct_conf.end_label_seq_id 
+_struct_conf.pdbx_end_PDB_ins_code 
+_struct_conf.beg_auth_comp_id 
+_struct_conf.beg_auth_asym_id 
+_struct_conf.beg_auth_seq_id 
+_struct_conf.end_auth_comp_id 
+_struct_conf.end_auth_asym_id 
+_struct_conf.end_auth_seq_id 
+_struct_conf.pdbx_PDB_helix_class 
+_struct_conf.details 
+_struct_conf.pdbx_PDB_helix_length 
+HELX_P HELX_P1 1 ASP A 26 ? ASP A 34 ? ASP A 26 ASP A 34 1 ? 9 
+HELX_P HELX_P2 2 ASP A 66 ? GLU A 70 ? ASP A 66 GLU A 70 1 ? 5 
+HELX_P HELX_P3 3 GLU A 93 ? TYR A 96 ? GLU A 93 TYR A 96 1 ? 4 
+# 
+_struct_conf_type.id          HELX_P 
+_struct_conf_type.criteria    ? 
+_struct_conf_type.reference   ? 
+# 
+loop_
+_struct_conn.id 
+_struct_conn.conn_type_id 
+_struct_conn.pdbx_leaving_atom_flag 
+_struct_conn.pdbx_PDB_id 
+_struct_conn.ptnr1_label_asym_id 
+_struct_conn.ptnr1_label_comp_id 
+_struct_conn.ptnr1_label_seq_id 
+_struct_conn.ptnr1_label_atom_id 
+_struct_conn.pdbx_ptnr1_label_alt_id 
+_struct_conn.pdbx_ptnr1_PDB_ins_code 
+_struct_conn.pdbx_ptnr1_standard_comp_id 
+_struct_conn.ptnr1_symmetry 
+_struct_conn.ptnr2_label_asym_id 
+_struct_conn.ptnr2_label_comp_id 
+_struct_conn.ptnr2_label_seq_id 
+_struct_conn.ptnr2_label_atom_id 
+_struct_conn.pdbx_ptnr2_label_alt_id 
+_struct_conn.pdbx_ptnr2_PDB_ins_code 
+_struct_conn.ptnr1_auth_asym_id 
+_struct_conn.ptnr1_auth_comp_id 
+_struct_conn.ptnr1_auth_seq_id 
+_struct_conn.ptnr2_auth_asym_id 
+_struct_conn.ptnr2_auth_comp_id 
+_struct_conn.ptnr2_auth_seq_id 
+_struct_conn.ptnr2_symmetry 
+_struct_conn.pdbx_ptnr3_label_atom_id 
+_struct_conn.pdbx_ptnr3_label_seq_id 
+_struct_conn.pdbx_ptnr3_label_comp_id 
+_struct_conn.pdbx_ptnr3_label_asym_id 
+_struct_conn.pdbx_ptnr3_label_alt_id 
+_struct_conn.pdbx_ptnr3_PDB_ins_code 
+_struct_conn.details 
+_struct_conn.pdbx_dist_value 
+_struct_conn.pdbx_value_order 
+disulf1 disulf ? ? A CYS 18 SG ? ? ? 1_555 A CYS 85 SG  ? ? A CYS 18 A CYS 85 1_555 ? ? ? ? ? ? ? 2.018 ? 
+metalc1 metalc ? ? A CYS 39 SG ? ? ? 1_555 B FES .  FE1 ? ? A CYS 39 A FES 97 1_555 ? ? ? ? ? ? ? 2.282 ? 
+metalc2 metalc ? ? A CYS 44 SG ? ? ? 1_555 B FES .  FE1 ? ? A CYS 44 A FES 97 1_555 ? ? ? ? ? ? ? 2.283 ? 
+metalc3 metalc ? ? A CYS 47 SG ? ? ? 1_555 B FES .  FE2 ? ? A CYS 47 A FES 97 1_555 ? ? ? ? ? ? ? 2.352 ? 
+metalc4 metalc ? ? A CYS 77 SG ? ? ? 1_555 B FES .  FE2 ? ? A CYS 77 A FES 97 1_555 ? ? ? ? ? ? ? 2.260 ? 
+# 
+loop_
+_struct_conn_type.id 
+_struct_conn_type.criteria 
+_struct_conn_type.reference 
+disulf ? ? 
+metalc ? ? 
+# 
+_struct_sheet.id               A 
+_struct_sheet.type             ? 
+_struct_sheet.number_strands   2 
+_struct_sheet.details          ? 
+# 
+_struct_sheet_order.sheet_id     A 
+_struct_sheet_order.range_id_1   1 
+_struct_sheet_order.range_id_2   2 
+_struct_sheet_order.offset       ? 
+_struct_sheet_order.sense        anti-parallel 
+# 
+loop_
+_struct_sheet_range.sheet_id 
+_struct_sheet_range.id 
+_struct_sheet_range.beg_label_comp_id 
+_struct_sheet_range.beg_label_asym_id 
+_struct_sheet_range.beg_label_seq_id 
+_struct_sheet_range.pdbx_beg_PDB_ins_code 
+_struct_sheet_range.end_label_comp_id 
+_struct_sheet_range.end_label_asym_id 
+_struct_sheet_range.end_label_seq_id 
+_struct_sheet_range.pdbx_end_PDB_ins_code 
+_struct_sheet_range.beg_auth_comp_id 
+_struct_sheet_range.beg_auth_asym_id 
+_struct_sheet_range.beg_auth_seq_id 
+_struct_sheet_range.end_auth_comp_id 
+_struct_sheet_range.end_auth_asym_id 
+_struct_sheet_range.end_auth_seq_id 
+A 1 LYS A 6  ? ILE A 8  ? LYS A 6  ILE A 8  
+A 2 GLU A 13 ? SER A 15 ? GLU A 13 SER A 15 
+# 
+_pdbx_struct_sheet_hbond.sheet_id                A 
+_pdbx_struct_sheet_hbond.range_id_1              1 
+_pdbx_struct_sheet_hbond.range_id_2              2 
+_pdbx_struct_sheet_hbond.range_1_label_atom_id   O 
+_pdbx_struct_sheet_hbond.range_1_label_comp_id   LEU 
+_pdbx_struct_sheet_hbond.range_1_label_asym_id   A 
+_pdbx_struct_sheet_hbond.range_1_label_seq_id    7 
+_pdbx_struct_sheet_hbond.range_1_PDB_ins_code    ? 
+_pdbx_struct_sheet_hbond.range_1_auth_atom_id    O 
+_pdbx_struct_sheet_hbond.range_1_auth_comp_id    LEU 
+_pdbx_struct_sheet_hbond.range_1_auth_asym_id    A 
+_pdbx_struct_sheet_hbond.range_1_auth_seq_id     7 
+_pdbx_struct_sheet_hbond.range_2_label_atom_id   N 
+_pdbx_struct_sheet_hbond.range_2_label_comp_id   SER 
+_pdbx_struct_sheet_hbond.range_2_label_asym_id   A 
+_pdbx_struct_sheet_hbond.range_2_label_seq_id    14 
+_pdbx_struct_sheet_hbond.range_2_PDB_ins_code    ? 
+_pdbx_struct_sheet_hbond.range_2_auth_atom_id    N 
+_pdbx_struct_sheet_hbond.range_2_auth_comp_id    SER 
+_pdbx_struct_sheet_hbond.range_2_auth_asym_id    A 
+_pdbx_struct_sheet_hbond.range_2_auth_seq_id     14 
+# 
+loop_
+_struct_site.id 
+_struct_site.pdbx_evidence_code 
+_struct_site.pdbx_auth_asym_id 
+_struct_site.pdbx_auth_comp_id 
+_struct_site.pdbx_auth_seq_id 
+_struct_site.pdbx_auth_ins_code 
+_struct_site.pdbx_num_residues 
+_struct_site.details 
+S2  Unknown  ? ? ? ? 4 ?                                   
+AC1 Software ? ? ? ? 6 'BINDING SITE FOR RESIDUE FES A 97' 
+# 
+loop_
+_struct_site_gen.id 
+_struct_site_gen.site_id 
+_struct_site_gen.pdbx_num_res 
+_struct_site_gen.label_comp_id 
+_struct_site_gen.label_asym_id 
+_struct_site_gen.label_seq_id 
+_struct_site_gen.pdbx_auth_ins_code 
+_struct_site_gen.auth_comp_id 
+_struct_site_gen.auth_asym_id 
+_struct_site_gen.auth_seq_id 
+_struct_site_gen.label_atom_id 
+_struct_site_gen.label_alt_id 
+_struct_site_gen.symmetry 
+_struct_site_gen.details 
+1  S2  4 CYS A 39 ? CYS A 39 . ? 1_555 ? 
+2  S2  4 CYS A 44 ? CYS A 44 . ? 1_555 ? 
+3  S2  4 CYS A 47 ? CYS A 47 . ? 1_555 ? 
+4  S2  4 CYS A 77 ? CYS A 77 . ? 1_555 ? 
+5  AC1 6 CYS A 39 ? CYS A 39 . ? 1_555 ? 
+6  AC1 6 ARG A 40 ? ARG A 40 . ? 1_555 ? 
+7  AC1 6 CYS A 44 ? CYS A 44 . ? 1_555 ? 
+8  AC1 6 CYS A 47 ? CYS A 47 . ? 1_555 ? 
+9  AC1 6 LEU A 75 ? LEU A 75 . ? 1_555 ? 
+10 AC1 6 CYS A 77 ? CYS A 77 . ? 1_555 ? 
+# 
+_database_PDB_matrix.entry_id          1DOY 
+_database_PDB_matrix.origx[1][1]       1.000000 
+_database_PDB_matrix.origx[1][2]       0.000000 
+_database_PDB_matrix.origx[1][3]       0.000000 
+_database_PDB_matrix.origx[2][1]       0.000000 
+_database_PDB_matrix.origx[2][2]       1.000000 
+_database_PDB_matrix.origx[2][3]       0.000000 
+_database_PDB_matrix.origx[3][1]       0.000000 
+_database_PDB_matrix.origx[3][2]       0.000000 
+_database_PDB_matrix.origx[3][3]       1.000000 
+_database_PDB_matrix.origx_vector[1]   0.00000 
+_database_PDB_matrix.origx_vector[2]   0.00000 
+_database_PDB_matrix.origx_vector[3]   0.00000 
+# 
+_atom_sites.entry_id                    1DOY 
+_atom_sites.fract_transf_matrix[1][1]   1.000000 
+_atom_sites.fract_transf_matrix[1][2]   0.000000 
+_atom_sites.fract_transf_matrix[1][3]   0.000000 
+_atom_sites.fract_transf_matrix[2][1]   0.000000 
+_atom_sites.fract_transf_matrix[2][2]   1.000000 
+_atom_sites.fract_transf_matrix[2][3]   0.000000 
+_atom_sites.fract_transf_matrix[3][1]   0.000000 
+_atom_sites.fract_transf_matrix[3][2]   0.000000 
+_atom_sites.fract_transf_matrix[3][3]   1.000000 
+_atom_sites.fract_transf_vector[1]      0.00000 
+_atom_sites.fract_transf_vector[2]      0.00000 
+_atom_sites.fract_transf_vector[3]      0.00000 
+# 
+loop_
+_atom_type.symbol 
+C  
+FE 
+H  
+N  
+O  
+S  
+# 
+loop_
+_atom_site.group_PDB 
+_atom_site.id 
+_atom_site.type_symbol 
+_atom_site.label_atom_id 
+_atom_site.label_alt_id 
+_atom_site.label_comp_id 
+_atom_site.label_asym_id 
+_atom_site.label_entity_id 
+_atom_site.label_seq_id 
+_atom_site.pdbx_PDB_ins_code 
+_atom_site.Cartn_x 
+_atom_site.Cartn_y 
+_atom_site.Cartn_z 
+_atom_site.occupancy 
+_atom_site.B_iso_or_equiv 
+_atom_site.pdbx_formal_charge 
+_atom_site.auth_seq_id 
+_atom_site.auth_comp_id 
+_atom_site.auth_asym_id 
+_atom_site.auth_atom_id 
+_atom_site.pdbx_PDB_model_num 
+ATOM   1    N  N    . ALA A 1 1  ? 15.150  -7.438  -7.235  1.00 0.00 ? 1  ALA A N    1 
+ATOM   2    C  CA   . ALA A 1 1  ? 14.588  -7.258  -5.865  1.00 0.00 ? 1  ALA A CA   1 
+ATOM   3    C  C    . ALA A 1 1  ? 13.427  -6.264  -5.915  1.00 0.00 ? 1  ALA A C    1 
+ATOM   4    O  O    . ALA A 1 1  ? 12.989  -5.856  -6.972  1.00 0.00 ? 1  ALA A O    1 
+ATOM   5    C  CB   . ALA A 1 1  ? 15.677  -6.722  -4.933  1.00 0.00 ? 1  ALA A CB   1 
+ATOM   6    H  H1   . ALA A 1 1  ? 15.339  -6.506  -7.657  1.00 0.00 ? 1  ALA A H1   1 
+ATOM   7    H  H2   . ALA A 1 1  ? 16.037  -7.976  -7.178  1.00 0.00 ? 1  ALA A H2   1 
+ATOM   8    H  H3   . ALA A 1 1  ? 14.466  -7.955  -7.825  1.00 0.00 ? 1  ALA A H3   1 
+ATOM   9    H  HA   . ALA A 1 1  ? 14.233  -8.208  -5.495  1.00 0.00 ? 1  ALA A HA   1 
+ATOM   10   H  HB1  . ALA A 1 1  ? 16.641  -6.825  -5.409  1.00 0.00 ? 1  ALA A HB1  1 
+ATOM   11   H  HB2  . ALA A 1 1  ? 15.488  -5.681  -4.722  1.00 0.00 ? 1  ALA A HB2  1 
+ATOM   12   H  HB3  . ALA A 1 1  ? 15.669  -7.283  -4.010  1.00 0.00 ? 1  ALA A HB3  1 
+ATOM   13   N  N    . SER A 1 2  ? 12.926  -5.871  -4.776  1.00 0.00 ? 2  SER A N    1 
+ATOM   14   C  CA   . SER A 1 2  ? 11.795  -4.904  -4.752  1.00 0.00 ? 2  SER A CA   1 
+ATOM   15   C  C    . SER A 1 2  ? 10.611  -5.481  -5.534  1.00 0.00 ? 2  SER A C    1 
+ATOM   16   O  O    . SER A 1 2  ? 10.741  -6.463  -6.237  1.00 0.00 ? 2  SER A O    1 
+ATOM   17   C  CB   . SER A 1 2  ? 12.238  -3.586  -5.388  1.00 0.00 ? 2  SER A CB   1 
+ATOM   18   O  OG   . SER A 1 2  ? 11.126  -2.704  -5.465  1.00 0.00 ? 2  SER A OG   1 
+ATOM   19   H  H    . SER A 1 2  ? 13.295  -6.212  -3.936  1.00 0.00 ? 2  SER A H    1 
+ATOM   20   H  HA   . SER A 1 2  ? 11.497  -4.727  -3.730  1.00 0.00 ? 2  SER A HA   1 
+ATOM   21   H  HB2  . SER A 1 2  ? 13.007  -3.134  -4.785  1.00 0.00 ? 2  SER A HB2  1 
+ATOM   22   H  HB3  . SER A 1 2  ? 12.628  -3.779  -6.380  1.00 0.00 ? 2  SER A HB3  1 
+ATOM   23   H  HG   . SER A 1 2  ? 11.223  -2.044  -4.776  1.00 0.00 ? 2  SER A HG   1 
+ATOM   24   N  N    . TYR A 1 3  ? 9.463   -4.869  -5.421  1.00 0.00 ? 3  TYR A N    1 
+ATOM   25   C  CA   . TYR A 1 3  ? 8.264   -5.358  -6.157  1.00 0.00 ? 3  TYR A CA   1 
+ATOM   26   C  C    . TYR A 1 3  ? 8.222   -6.899  -6.220  1.00 0.00 ? 3  TYR A C    1 
+ATOM   27   O  O    . TYR A 1 3  ? 8.563   -7.484  -7.227  1.00 0.00 ? 3  TYR A O    1 
+ATOM   28   C  CB   . TYR A 1 3  ? 8.282   -4.791  -7.572  1.00 0.00 ? 3  TYR A CB   1 
+ATOM   29   C  CG   . TYR A 1 3  ? 9.118   -3.536  -7.603  1.00 0.00 ? 3  TYR A CG   1 
+ATOM   30   C  CD1  . TYR A 1 3  ? 8.605   -2.346  -7.075  1.00 0.00 ? 3  TYR A CD1  1 
+ATOM   31   C  CD2  . TYR A 1 3  ? 10.402  -3.566  -8.152  1.00 0.00 ? 3  TYR A CD2  1 
+ATOM   32   C  CE1  . TYR A 1 3  ? 9.381   -1.181  -7.097  1.00 0.00 ? 3  TYR A CE1  1 
+ATOM   33   C  CE2  . TYR A 1 3  ? 11.179  -2.402  -8.176  1.00 0.00 ? 3  TYR A CE2  1 
+ATOM   34   C  CZ   . TYR A 1 3  ? 10.668  -1.209  -7.649  1.00 0.00 ? 3  TYR A CZ   1 
+ATOM   35   O  OH   . TYR A 1 3  ? 11.433  -0.061  -7.672  1.00 0.00 ? 3  TYR A OH   1 
+ATOM   36   H  H    . TYR A 1 3  ? 9.385   -4.062  -4.860  1.00 0.00 ? 3  TYR A H    1 
+ATOM   37   H  HA   . TYR A 1 3  ? 7.384   -4.999  -5.658  1.00 0.00 ? 3  TYR A HA   1 
+ATOM   38   H  HB2  . TYR A 1 3  ? 8.695   -5.520  -8.254  1.00 0.00 ? 3  TYR A HB2  1 
+ATOM   39   H  HB3  . TYR A 1 3  ? 7.277   -4.552  -7.863  1.00 0.00 ? 3  TYR A HB3  1 
+ATOM   40   H  HD1  . TYR A 1 3  ? 7.613   -2.330  -6.644  1.00 0.00 ? 3  TYR A HD1  1 
+ATOM   41   H  HD2  . TYR A 1 3  ? 10.794  -4.489  -8.554  1.00 0.00 ? 3  TYR A HD2  1 
+ATOM   42   H  HE1  . TYR A 1 3  ? 8.986   -0.262  -6.690  1.00 0.00 ? 3  TYR A HE1  1 
+ATOM   43   H  HE2  . TYR A 1 3  ? 12.172  -2.423  -8.601  1.00 0.00 ? 3  TYR A HE2  1 
+ATOM   44   H  HH   . TYR A 1 3  ? 11.093  0.509   -8.365  1.00 0.00 ? 3  TYR A HH   1 
+ATOM   45   N  N    . THR A 1 4  ? 7.796   -7.570  -5.167  1.00 0.00 ? 4  THR A N    1 
+ATOM   46   C  CA   . THR A 1 4  ? 7.734   -9.048  -5.221  1.00 0.00 ? 4  THR A CA   1 
+ATOM   47   C  C    . THR A 1 4  ? 6.899   -9.620  -4.058  1.00 0.00 ? 4  THR A C    1 
+ATOM   48   O  O    . THR A 1 4  ? 6.238   -10.609 -4.220  1.00 0.00 ? 4  THR A O    1 
+ATOM   49   C  CB   . THR A 1 4  ? 9.157   -9.612  -5.153  1.00 0.00 ? 4  THR A CB   1 
+ATOM   50   O  OG1  . THR A 1 4  ? 9.822   -9.357  -6.383  1.00 0.00 ? 4  THR A OG1  1 
+ATOM   51   C  CG2  . THR A 1 4  ? 9.106   -11.119 -4.902  1.00 0.00 ? 4  THR A CG2  1 
+ATOM   52   H  H    . THR A 1 4  ? 7.520   -7.118  -4.371  1.00 0.00 ? 4  THR A H    1 
+ATOM   53   H  HA   . THR A 1 4  ? 7.287   -9.339  -6.150  1.00 0.00 ? 4  THR A HA   1 
+ATOM   54   H  HB   . THR A 1 4  ? 9.695   -9.135  -4.347  1.00 0.00 ? 4  THR A HB   1 
+ATOM   55   H  HG1  . THR A 1 4  ? 10.373  -8.580  -6.267  1.00 0.00 ? 4  THR A HG1  1 
+ATOM   56   H  HG21 . THR A 1 4  ? 8.572   -11.314 -3.984  1.00 0.00 ? 4  THR A HG21 1 
+ATOM   57   H  HG22 . THR A 1 4  ? 8.599   -11.605 -5.723  1.00 0.00 ? 4  THR A HG22 1 
+ATOM   58   H  HG23 . THR A 1 4  ? 10.113  -11.505 -4.822  1.00 0.00 ? 4  THR A HG23 1 
+ATOM   59   N  N    . VAL A 1 5  ? 6.945   -9.033  -2.887  1.00 0.00 ? 5  VAL A N    1 
+ATOM   60   C  CA   . VAL A 1 5  ? 6.178   -9.613  -1.723  1.00 0.00 ? 5  VAL A CA   1 
+ATOM   61   C  C    . VAL A 1 5  ? 4.700   -9.862  -2.075  1.00 0.00 ? 5  VAL A C    1 
+ATOM   62   O  O    . VAL A 1 5  ? 4.388   -10.478 -3.069  1.00 0.00 ? 5  VAL A O    1 
+ATOM   63   C  CB   . VAL A 1 5  ? 6.273   -8.725  -0.471  1.00 0.00 ? 5  VAL A CB   1 
+ATOM   64   C  CG1  . VAL A 1 5  ? 5.928   -9.566  0.754   1.00 0.00 ? 5  VAL A CG1  1 
+ATOM   65   C  CG2  . VAL A 1 5  ? 7.695   -8.170  -0.303  1.00 0.00 ? 5  VAL A CG2  1 
+ATOM   66   H  H    . VAL A 1 5  ? 7.495   -8.248  -2.770  1.00 0.00 ? 5  VAL A H    1 
+ATOM   67   H  HA   . VAL A 1 5  ? 6.626   -10.566 -1.489  1.00 0.00 ? 5  VAL A HA   1 
+ATOM   68   H  HB   . VAL A 1 5  ? 5.567   -7.914  -0.547  1.00 0.00 ? 5  VAL A HB   1 
+ATOM   69   H  HG11 . VAL A 1 5  ? 5.215   -10.327 0.477   1.00 0.00 ? 5  VAL A HG11 1 
+ATOM   70   H  HG12 . VAL A 1 5  ? 6.825   -10.032 1.134   1.00 0.00 ? 5  VAL A HG12 1 
+ATOM   71   H  HG13 . VAL A 1 5  ? 5.500   -8.931  1.515   1.00 0.00 ? 5  VAL A HG13 1 
+ATOM   72   H  HG21 . VAL A 1 5  ? 8.113   -7.928  -1.263  1.00 0.00 ? 5  VAL A HG21 1 
+ATOM   73   H  HG22 . VAL A 1 5  ? 7.664   -7.279  0.306   1.00 0.00 ? 5  VAL A HG22 1 
+ATOM   74   H  HG23 . VAL A 1 5  ? 8.315   -8.909  0.179   1.00 0.00 ? 5  VAL A HG23 1 
+ATOM   75   N  N    . LYS A 1 6  ? 3.767   -9.445  -1.252  1.00 0.00 ? 6  LYS A N    1 
+ATOM   76   C  CA   . LYS A 1 6  ? 2.349   -9.758  -1.587  1.00 0.00 ? 6  LYS A CA   1 
+ATOM   77   C  C    . LYS A 1 6  ? 1.408   -8.560  -1.403  1.00 0.00 ? 6  LYS A C    1 
+ATOM   78   O  O    . LYS A 1 6  ? 1.541   -7.747  -0.503  1.00 0.00 ? 6  LYS A O    1 
+ATOM   79   C  CB   . LYS A 1 6  ? 1.872   -10.905 -0.695  1.00 0.00 ? 6  LYS A CB   1 
+ATOM   80   C  CG   . LYS A 1 6  ? 2.712   -12.153 -0.979  1.00 0.00 ? 6  LYS A CG   1 
+ATOM   81   C  CD   . LYS A 1 6  ? 3.144   -12.795 0.341   1.00 0.00 ? 6  LYS A CD   1 
+ATOM   82   C  CE   . LYS A 1 6  ? 4.344   -13.710 0.096   1.00 0.00 ? 6  LYS A CE   1 
+ATOM   83   N  NZ   . LYS A 1 6  ? 4.381   -14.770 1.143   1.00 0.00 ? 6  LYS A NZ   1 
+ATOM   84   H  H    . LYS A 1 6  ? 3.994   -8.982  -0.420  1.00 0.00 ? 6  LYS A H    1 
+ATOM   85   H  HA   . LYS A 1 6  ? 2.299   -10.082 -2.614  1.00 0.00 ? 6  LYS A HA   1 
+ATOM   86   H  HB2  . LYS A 1 6  ? 1.982   -10.623 0.343   1.00 0.00 ? 6  LYS A HB2  1 
+ATOM   87   H  HB3  . LYS A 1 6  ? 0.834   -11.116 -0.903  1.00 0.00 ? 6  LYS A HB3  1 
+ATOM   88   H  HG2  . LYS A 1 6  ? 2.124   -12.860 -1.548  1.00 0.00 ? 6  LYS A HG2  1 
+ATOM   89   H  HG3  . LYS A 1 6  ? 3.588   -11.875 -1.546  1.00 0.00 ? 6  LYS A HG3  1 
+ATOM   90   H  HD2  . LYS A 1 6  ? 3.418   -12.021 1.044   1.00 0.00 ? 6  LYS A HD2  1 
+ATOM   91   H  HD3  . LYS A 1 6  ? 2.328   -13.375 0.744   1.00 0.00 ? 6  LYS A HD3  1 
+ATOM   92   H  HE2  . LYS A 1 6  ? 4.256   -14.169 -0.877  1.00 0.00 ? 6  LYS A HE2  1 
+ATOM   93   H  HE3  . LYS A 1 6  ? 5.254   -13.130 0.141   1.00 0.00 ? 6  LYS A HE3  1 
+ATOM   94   H  HZ1  . LYS A 1 6  ? 3.483   -15.294 1.138   1.00 0.00 ? 6  LYS A HZ1  1 
+ATOM   95   H  HZ2  . LYS A 1 6  ? 5.163   -15.425 0.948   1.00 0.00 ? 6  LYS A HZ2  1 
+ATOM   96   H  HZ3  . LYS A 1 6  ? 4.521   -14.329 2.075   1.00 0.00 ? 6  LYS A HZ3  1 
+ATOM   97   N  N    . LEU A 1 7  ? 0.431   -8.492  -2.263  1.00 0.00 ? 7  LEU A N    1 
+ATOM   98   C  CA   . LEU A 1 7  ? -0.594  -7.410  -2.202  1.00 0.00 ? 7  LEU A CA   1 
+ATOM   99   C  C    . LEU A 1 7  ? -1.920  -8.032  -2.651  1.00 0.00 ? 7  LEU A C    1 
+ATOM   100  O  O    . LEU A 1 7  ? -2.028  -9.234  -2.741  1.00 0.00 ? 7  LEU A O    1 
+ATOM   101  C  CB   . LEU A 1 7  ? -0.200  -6.283  -3.159  1.00 0.00 ? 7  LEU A CB   1 
+ATOM   102  C  CG   . LEU A 1 7  ? -0.551  -4.926  -2.550  1.00 0.00 ? 7  LEU A CG   1 
+ATOM   103  C  CD1  . LEU A 1 7  ? 0.672   -4.013  -2.609  1.00 0.00 ? 7  LEU A CD1  1 
+ATOM   104  C  CD2  . LEU A 1 7  ? -1.695  -4.297  -3.349  1.00 0.00 ? 7  LEU A CD2  1 
+ATOM   105  H  H    . LEU A 1 7  ? 0.360   -9.183  -2.958  1.00 0.00 ? 7  LEU A H    1 
+ATOM   106  H  HA   . LEU A 1 7  ? -0.681  -7.035  -1.193  1.00 0.00 ? 7  LEU A HA   1 
+ATOM   107  H  HB2  . LEU A 1 7  ? 0.860   -6.329  -3.345  1.00 0.00 ? 7  LEU A HB2  1 
+ATOM   108  H  HB3  . LEU A 1 7  ? -0.734  -6.401  -4.087  1.00 0.00 ? 7  LEU A HB3  1 
+ATOM   109  H  HG   . LEU A 1 7  ? -0.851  -5.056  -1.524  1.00 0.00 ? 7  LEU A HG   1 
+ATOM   110  H  HD11 . LEU A 1 7  ? 1.186   -4.163  -3.547  1.00 0.00 ? 7  LEU A HD11 1 
+ATOM   111  H  HD12 . LEU A 1 7  ? 0.356   -2.983  -2.532  1.00 0.00 ? 7  LEU A HD12 1 
+ATOM   112  H  HD13 . LEU A 1 7  ? 1.336   -4.250  -1.792  1.00 0.00 ? 7  LEU A HD13 1 
+ATOM   113  H  HD21 . LEU A 1 7  ? -1.835  -4.848  -4.268  1.00 0.00 ? 7  LEU A HD21 1 
+ATOM   114  H  HD22 . LEU A 1 7  ? -2.602  -4.334  -2.767  1.00 0.00 ? 7  LEU A HD22 1 
+ATOM   115  H  HD23 . LEU A 1 7  ? -1.454  -3.271  -3.577  1.00 0.00 ? 7  LEU A HD23 1 
+ATOM   116  N  N    . ILE A 1 8  ? -2.914  -7.248  -2.974  1.00 0.00 ? 8  ILE A N    1 
+ATOM   117  C  CA   . ILE A 1 8  ? -4.196  -7.849  -3.456  1.00 0.00 ? 8  ILE A CA   1 
+ATOM   118  C  C    . ILE A 1 8  ? -5.134  -6.751  -3.917  1.00 0.00 ? 8  ILE A C    1 
+ATOM   119  O  O    . ILE A 1 8  ? -5.692  -6.015  -3.122  1.00 0.00 ? 8  ILE A O    1 
+ATOM   120  C  CB   . ILE A 1 8  ? -4.885  -8.707  -2.381  1.00 0.00 ? 8  ILE A CB   1 
+ATOM   121  C  CG1  . ILE A 1 8  ? -4.407  -10.152 -2.524  1.00 0.00 ? 8  ILE A CG1  1 
+ATOM   122  C  CG2  . ILE A 1 8  ? -6.409  -8.685  -2.592  1.00 0.00 ? 8  ILE A CG2  1 
+ATOM   123  C  CD1  . ILE A 1 8  ? -3.706  -10.598 -1.240  1.00 0.00 ? 8  ILE A CD1  1 
+ATOM   124  H  H    . ILE A 1 8  ? -2.811  -6.273  -2.936  1.00 0.00 ? 8  ILE A H    1 
+ATOM   125  H  HA   . ILE A 1 8  ? -3.975  -8.472  -4.297  1.00 0.00 ? 8  ILE A HA   1 
+ATOM   126  H  HB   . ILE A 1 8  ? -4.643  -8.337  -1.399  1.00 0.00 ? 8  ILE A HB   1 
+ATOM   127  H  HG12 . ILE A 1 8  ? -5.259  -10.791 -2.714  1.00 0.00 ? 8  ILE A HG12 1 
+ATOM   128  H  HG13 . ILE A 1 8  ? -3.722  -10.221 -3.354  1.00 0.00 ? 8  ILE A HG13 1 
+ATOM   129  H  HG21 . ILE A 1 8  ? -6.637  -9.014  -3.596  1.00 0.00 ? 8  ILE A HG21 1 
+ATOM   130  H  HG22 . ILE A 1 8  ? -6.883  -9.343  -1.882  1.00 0.00 ? 8  ILE A HG22 1 
+ATOM   131  H  HG23 . ILE A 1 8  ? -6.777  -7.678  -2.454  1.00 0.00 ? 8  ILE A HG23 1 
+ATOM   132  H  HD11 . ILE A 1 8  ? -3.820  -9.834  -0.484  1.00 0.00 ? 8  ILE A HD11 1 
+ATOM   133  H  HD12 . ILE A 1 8  ? -4.148  -11.518 -0.890  1.00 0.00 ? 8  ILE A HD12 1 
+ATOM   134  H  HD13 . ILE A 1 8  ? -2.656  -10.755 -1.438  1.00 0.00 ? 8  ILE A HD13 1 
+ATOM   135  N  N    . THR A 1 9  ? -5.318  -6.661  -5.198  1.00 0.00 ? 9  THR A N    1 
+ATOM   136  C  CA   . THR A 1 9  ? -6.221  -5.640  -5.764  1.00 0.00 ? 9  THR A CA   1 
+ATOM   137  C  C    . THR A 1 9  ? -7.222  -6.390  -6.644  1.00 0.00 ? 9  THR A C    1 
+ATOM   138  O  O    . THR A 1 9  ? -7.334  -7.596  -6.504  1.00 0.00 ? 9  THR A O    1 
+ATOM   139  C  CB   . THR A 1 9  ? -5.361  -4.684  -6.583  1.00 0.00 ? 9  THR A CB   1 
+ATOM   140  O  OG1  . THR A 1 9  ? -5.203  -5.193  -7.899  1.00 0.00 ? 9  THR A OG1  1 
+ATOM   141  C  CG2  . THR A 1 9  ? -3.985  -4.535  -5.930  1.00 0.00 ? 9  THR A CG2  1 
+ATOM   142  H  H    . THR A 1 9  ? -4.853  -7.289  -5.812  1.00 0.00 ? 9  THR A H    1 
+ATOM   143  H  HA   . THR A 1 9  ? -6.733  -5.109  -4.974  1.00 0.00 ? 9  THR A HA   1 
+ATOM   144  H  HB   . THR A 1 9  ? -5.836  -3.732  -6.615  1.00 0.00 ? 9  THR A HB   1 
+ATOM   145  H  HG1  . THR A 1 9  ? -4.775  -6.052  -7.837  1.00 0.00 ? 9  THR A HG1  1 
+ATOM   146  H  HG21 . THR A 1 9  ? -4.096  -4.517  -4.856  1.00 0.00 ? 9  THR A HG21 1 
+ATOM   147  H  HG22 . THR A 1 9  ? -3.363  -5.370  -6.213  1.00 0.00 ? 9  THR A HG22 1 
+ATOM   148  H  HG23 . THR A 1 9  ? -3.529  -3.615  -6.261  1.00 0.00 ? 9  THR A HG23 1 
+ATOM   149  N  N    . PRO A 1 10 ? -7.901  -5.730  -7.569  1.00 0.00 ? 10 PRO A N    1 
+ATOM   150  C  CA   . PRO A 1 10 ? -8.808  -6.457  -8.443  1.00 0.00 ? 10 PRO A CA   1 
+ATOM   151  C  C    . PRO A 1 10 ? -8.056  -7.675  -8.990  1.00 0.00 ? 10 PRO A C    1 
+ATOM   152  O  O    . PRO A 1 10 ? -8.640  -8.654  -9.412  1.00 0.00 ? 10 PRO A O    1 
+ATOM   153  C  CB   . PRO A 1 10 ? -9.196  -5.459  -9.537  1.00 0.00 ? 10 PRO A CB   1 
+ATOM   154  C  CG   . PRO A 1 10 ? -8.720  -4.069  -9.065  1.00 0.00 ? 10 PRO A CG   1 
+ATOM   155  C  CD   . PRO A 1 10 ? -7.845  -4.283  -7.823  1.00 0.00 ? 10 PRO A CD   1 
+ATOM   156  H  HA   . PRO A 1 10 ? -9.672  -6.751  -7.889  1.00 0.00 ? 10 PRO A HA   1 
+ATOM   157  H  HB2  . PRO A 1 10 ? -8.714  -5.725  -10.468 1.00 0.00 ? 10 PRO A HB2  1 
+ATOM   158  H  HB3  . PRO A 1 10 ? -10.264 -5.450  -9.661  1.00 0.00 ? 10 PRO A HB3  1 
+ATOM   159  H  HG2  . PRO A 1 10 ? -8.144  -3.594  -9.847  1.00 0.00 ? 10 PRO A HG2  1 
+ATOM   160  H  HG3  . PRO A 1 10 ? -9.571  -3.455  -8.810  1.00 0.00 ? 10 PRO A HG3  1 
+ATOM   161  H  HD2  . PRO A 1 10 ? -6.851  -3.971  -8.043  1.00 0.00 ? 10 PRO A HD2  1 
+ATOM   162  H  HD3  . PRO A 1 10 ? -8.250  -3.746  -6.983  1.00 0.00 ? 10 PRO A HD3  1 
+ATOM   163  N  N    . ASP A 1 11 ? -6.746  -7.625  -8.919  1.00 0.00 ? 11 ASP A N    1 
+ATOM   164  C  CA   . ASP A 1 11 ? -5.907  -8.754  -9.349  1.00 0.00 ? 11 ASP A CA   1 
+ATOM   165  C  C    . ASP A 1 11 ? -5.278  -9.318  -8.078  1.00 0.00 ? 11 ASP A C    1 
+ATOM   166  O  O    . ASP A 1 11 ? -4.109  -9.153  -7.833  1.00 0.00 ? 11 ASP A O    1 
+ATOM   167  C  CB   . ASP A 1 11 ? -4.819  -8.252  -10.295 1.00 0.00 ? 11 ASP A CB   1 
+ATOM   168  C  CG   . ASP A 1 11 ? -4.262  -9.423  -11.106 1.00 0.00 ? 11 ASP A CG   1 
+ATOM   169  O  OD1  . ASP A 1 11 ? -5.049  -10.261 -11.517 1.00 0.00 ? 11 ASP A OD1  1 
+ATOM   170  O  OD2  . ASP A 1 11 ? -3.058  -9.465  -11.303 1.00 0.00 ? 11 ASP A OD2  1 
+ATOM   171  H  H    . ASP A 1 11 ? -6.308  -6.846  -8.535  1.00 0.00 ? 11 ASP A H    1 
+ATOM   172  H  HA   . ASP A 1 11 ? -6.512  -9.507  -9.834  1.00 0.00 ? 11 ASP A HA   1 
+ATOM   173  H  HB2  . ASP A 1 11 ? -5.239  -7.515  -10.963 1.00 0.00 ? 11 ASP A HB2  1 
+ATOM   174  H  HB3  . ASP A 1 11 ? -4.024  -7.804  -9.719  1.00 0.00 ? 11 ASP A HB3  1 
+ATOM   175  N  N    . GLY A 1 12 ? -6.101  -9.927  -7.265  1.00 0.00 ? 12 GLY A N    1 
+ATOM   176  C  CA   . GLY A 1 12 ? -5.692  -10.522 -5.947  1.00 0.00 ? 12 GLY A CA   1 
+ATOM   177  C  C    . GLY A 1 12 ? -4.183  -10.453 -5.653  1.00 0.00 ? 12 GLY A C    1 
+ATOM   178  O  O    . GLY A 1 12 ? -3.521  -9.457  -5.850  1.00 0.00 ? 12 GLY A O    1 
+ATOM   179  H  H    . GLY A 1 12 ? -7.045  -9.969  -7.516  1.00 0.00 ? 12 GLY A H    1 
+ATOM   180  H  HA2  . GLY A 1 12 ? -6.215  -10.003 -5.160  1.00 0.00 ? 12 GLY A HA2  1 
+ATOM   181  H  HA3  . GLY A 1 12 ? -5.998  -11.559 -5.933  1.00 0.00 ? 12 GLY A HA3  1 
+ATOM   182  N  N    . GLU A 1 13 ? -3.660  -11.515 -5.111  1.00 0.00 ? 13 GLU A N    1 
+ATOM   183  C  CA   . GLU A 1 13 ? -2.223  -11.553 -4.719  1.00 0.00 ? 13 GLU A CA   1 
+ATOM   184  C  C    . GLU A 1 13 ? -1.321  -10.881 -5.757  1.00 0.00 ? 13 GLU A C    1 
+ATOM   185  O  O    . GLU A 1 13 ? -1.134  -11.376 -6.850  1.00 0.00 ? 13 GLU A O    1 
+ATOM   186  C  CB   . GLU A 1 13 ? -1.789  -13.009 -4.547  1.00 0.00 ? 13 GLU A CB   1 
+ATOM   187  C  CG   . GLU A 1 13 ? -1.429  -13.270 -3.084  1.00 0.00 ? 13 GLU A CG   1 
+ATOM   188  C  CD   . GLU A 1 13 ? -2.710  -13.398 -2.257  1.00 0.00 ? 13 GLU A CD   1 
+ATOM   189  O  OE1  . GLU A 1 13 ? -3.741  -13.695 -2.841  1.00 0.00 ? 13 GLU A OE1  1 
+ATOM   190  O  OE2  . GLU A 1 13 ? -2.639  -13.201 -1.056  1.00 0.00 ? 13 GLU A OE2  1 
+ATOM   191  H  H    . GLU A 1 13 ? -4.231  -12.289 -4.921  1.00 0.00 ? 13 GLU A H    1 
+ATOM   192  H  HA   . GLU A 1 13 ? -2.107  -11.043 -3.776  1.00 0.00 ? 13 GLU A HA   1 
+ATOM   193  H  HB2  . GLU A 1 13 ? -2.599  -13.661 -4.841  1.00 0.00 ? 13 GLU A HB2  1 
+ATOM   194  H  HB3  . GLU A 1 13 ? -0.928  -13.205 -5.168  1.00 0.00 ? 13 GLU A HB3  1 
+ATOM   195  H  HG2  . GLU A 1 13 ? -0.860  -14.185 -3.012  1.00 0.00 ? 13 GLU A HG2  1 
+ATOM   196  H  HG3  . GLU A 1 13 ? -0.840  -12.449 -2.705  1.00 0.00 ? 13 GLU A HG3  1 
+ATOM   197  N  N    . SER A 1 14 ? -0.723  -9.773  -5.396  1.00 0.00 ? 14 SER A N    1 
+ATOM   198  C  CA   . SER A 1 14 ? 0.211   -9.087  -6.329  1.00 0.00 ? 14 SER A CA   1 
+ATOM   199  C  C    . SER A 1 14 ? 1.609   -9.133  -5.697  1.00 0.00 ? 14 SER A C    1 
+ATOM   200  O  O    . SER A 1 14 ? 1.744   -9.319  -4.505  1.00 0.00 ? 14 SER A O    1 
+ATOM   201  C  CB   . SER A 1 14 ? -0.237  -7.638  -6.534  1.00 0.00 ? 14 SER A CB   1 
+ATOM   202  O  OG   . SER A 1 14 ? 0.902   -6.821  -6.765  1.00 0.00 ? 14 SER A OG   1 
+ATOM   203  H  H    . SER A 1 14 ? -0.865  -9.407  -4.496  1.00 0.00 ? 14 SER A H    1 
+ATOM   204  H  HA   . SER A 1 14 ? 0.223   -9.606  -7.277  1.00 0.00 ? 14 SER A HA   1 
+ATOM   205  H  HB2  . SER A 1 14 ? -0.892  -7.581  -7.387  1.00 0.00 ? 14 SER A HB2  1 
+ATOM   206  H  HB3  . SER A 1 14 ? -0.766  -7.299  -5.655  1.00 0.00 ? 14 SER A HB3  1 
+ATOM   207  H  HG   . SER A 1 14 ? 0.831   -6.459  -7.653  1.00 0.00 ? 14 SER A HG   1 
+ATOM   208  N  N    . SER A 1 15 ? 2.650   -8.998  -6.469  1.00 0.00 ? 15 SER A N    1 
+ATOM   209  C  CA   . SER A 1 15 ? 4.018   -9.073  -5.878  1.00 0.00 ? 15 SER A CA   1 
+ATOM   210  C  C    . SER A 1 15 ? 4.582   -7.670  -5.626  1.00 0.00 ? 15 SER A C    1 
+ATOM   211  O  O    . SER A 1 15 ? 4.619   -6.837  -6.509  1.00 0.00 ? 15 SER A O    1 
+ATOM   212  C  CB   . SER A 1 15 ? 4.916   -9.831  -6.841  1.00 0.00 ? 15 SER A CB   1 
+ATOM   213  O  OG   . SER A 1 15 ? 5.770   -8.918  -7.519  1.00 0.00 ? 15 SER A OG   1 
+ATOM   214  H  H    . SER A 1 15 ? 2.539   -8.873  -7.433  1.00 0.00 ? 15 SER A H    1 
+ATOM   215  H  HA   . SER A 1 15 ? 3.971   -9.610  -4.942  1.00 0.00 ? 15 SER A HA   1 
+ATOM   216  H  HB2  . SER A 1 15 ? 5.507   -10.538 -6.291  1.00 0.00 ? 15 SER A HB2  1 
+ATOM   217  H  HB3  . SER A 1 15 ? 4.299   -10.362 -7.554  1.00 0.00 ? 15 SER A HB3  1 
+ATOM   218  H  HG   . SER A 1 15 ? 6.169   -9.380  -8.261  1.00 0.00 ? 15 SER A HG   1 
+ATOM   219  N  N    . ILE A 1 16 ? 5.021   -7.407  -4.417  1.00 0.00 ? 16 ILE A N    1 
+ATOM   220  C  CA   . ILE A 1 16 ? 5.576   -6.061  -4.090  1.00 0.00 ? 16 ILE A CA   1 
+ATOM   221  C  C    . ILE A 1 16 ? 6.587   -6.159  -2.944  1.00 0.00 ? 16 ILE A C    1 
+ATOM   222  O  O    . ILE A 1 16 ? 6.322   -6.742  -1.948  1.00 0.00 ? 16 ILE A O    1 
+ATOM   223  C  CB   . ILE A 1 16 ? 4.478   -5.111  -3.665  1.00 0.00 ? 16 ILE A CB   1 
+ATOM   224  C  CG1  . ILE A 1 16 ? 3.164   -5.875  -3.571  1.00 0.00 ? 16 ILE A CG1  1 
+ATOM   225  C  CG2  . ILE A 1 16 ? 4.374   -3.964  -4.670  1.00 0.00 ? 16 ILE A CG2  1 
+ATOM   226  C  CD1  . ILE A 1 16 ? 2.490   -5.948  -4.941  1.00 0.00 ? 16 ILE A CD1  1 
+ATOM   227  H  H    . ILE A 1 16 ? 4.980   -8.090  -3.728  1.00 0.00 ? 16 ILE A H    1 
+ATOM   228  H  HA   . ILE A 1 16 ? 6.039   -5.679  -4.951  1.00 0.00 ? 16 ILE A HA   1 
+ATOM   229  H  HB   . ILE A 1 16 ? 4.729   -4.711  -2.701  1.00 0.00 ? 16 ILE A HB   1 
+ATOM   230  H  HG12 . ILE A 1 16 ? 3.365   -6.875  -3.220  1.00 0.00 ? 16 ILE A HG12 1 
+ATOM   231  H  HG13 . ILE A 1 16 ? 2.527   -5.383  -2.882  1.00 0.00 ? 16 ILE A HG13 1 
+ATOM   232  H  HG21 . ILE A 1 16 ? 5.321   -3.447  -4.723  1.00 0.00 ? 16 ILE A HG21 1 
+ATOM   233  H  HG22 . ILE A 1 16 ? 4.126   -4.363  -5.643  1.00 0.00 ? 16 ILE A HG22 1 
+ATOM   234  H  HG23 . ILE A 1 16 ? 3.604   -3.279  -4.353  1.00 0.00 ? 16 ILE A HG23 1 
+ATOM   235  H  HD11 . ILE A 1 16 ? 3.180   -5.619  -5.701  1.00 0.00 ? 16 ILE A HD11 1 
+ATOM   236  H  HD12 . ILE A 1 16 ? 2.199   -6.965  -5.137  1.00 0.00 ? 16 ILE A HD12 1 
+ATOM   237  H  HD13 . ILE A 1 16 ? 1.620   -5.313  -4.947  1.00 0.00 ? 16 ILE A HD13 1 
+ATOM   238  N  N    . GLU A 1 17 ? 7.760   -5.610  -3.098  1.00 0.00 ? 17 GLU A N    1 
+ATOM   239  C  CA   . GLU A 1 17 ? 8.788   -5.689  -2.025  1.00 0.00 ? 17 GLU A CA   1 
+ATOM   240  C  C    . GLU A 1 17 ? 9.303   -4.282  -1.729  1.00 0.00 ? 17 GLU A C    1 
+ATOM   241  O  O    . GLU A 1 17 ? 9.923   -4.036  -0.714  1.00 0.00 ? 17 GLU A O    1 
+ATOM   242  C  CB   . GLU A 1 17 ? 9.943   -6.591  -2.461  1.00 0.00 ? 17 GLU A CB   1 
+ATOM   243  C  CG   . GLU A 1 17 ? 10.986  -6.660  -1.344  1.00 0.00 ? 17 GLU A CG   1 
+ATOM   244  C  CD   . GLU A 1 17 ? 11.535  -8.084  -1.243  1.00 0.00 ? 17 GLU A CD   1 
+ATOM   245  O  OE1  . GLU A 1 17 ? 11.405  -8.818  -2.209  1.00 0.00 ? 17 GLU A OE1  1 
+ATOM   246  O  OE2  . GLU A 1 17 ? 12.077  -8.417  -0.202  1.00 0.00 ? 17 GLU A OE2  1 
+ATOM   247  H  H    . GLU A 1 17 ? 7.966   -5.164  -3.917  1.00 0.00 ? 17 GLU A H    1 
+ATOM   248  H  HA   . GLU A 1 17 ? 8.330   -6.089  -1.144  1.00 0.00 ? 17 GLU A HA   1 
+ATOM   249  H  HB2  . GLU A 1 17 ? 9.567   -7.584  -2.665  1.00 0.00 ? 17 GLU A HB2  1 
+ATOM   250  H  HB3  . GLU A 1 17 ? 10.397  -6.190  -3.350  1.00 0.00 ? 17 GLU A HB3  1 
+ATOM   251  H  HG2  . GLU A 1 17 ? 11.794  -5.976  -1.565  1.00 0.00 ? 17 GLU A HG2  1 
+ATOM   252  H  HG3  . GLU A 1 17 ? 10.528  -6.386  -0.406  1.00 0.00 ? 17 GLU A HG3  1 
+ATOM   253  N  N    . CYS A 1 18 ? 8.978   -3.359  -2.599  1.00 0.00 ? 18 CYS A N    1 
+ATOM   254  C  CA   . CYS A 1 18 ? 9.339   -1.935  -2.428  1.00 0.00 ? 18 CYS A CA   1 
+ATOM   255  C  C    . CYS A 1 18 ? 10.528  -1.754  -1.489  1.00 0.00 ? 18 CYS A C    1 
+ATOM   256  O  O    . CYS A 1 18 ? 10.465  -1.014  -0.531  1.00 0.00 ? 18 CYS A O    1 
+ATOM   257  C  CB   . CYS A 1 18 ? 8.113   -1.204  -1.877  1.00 0.00 ? 18 CYS A CB   1 
+ATOM   258  S  SG   . CYS A 1 18 ? 6.596   -2.028  -2.441  1.00 0.00 ? 18 CYS A SG   1 
+ATOM   259  H  H    . CYS A 1 18 ? 8.436   -3.595  -3.365  1.00 0.00 ? 18 CYS A H    1 
+ATOM   260  H  HA   . CYS A 1 18 ? 9.585   -1.518  -3.391  1.00 0.00 ? 18 CYS A HA   1 
+ATOM   261  H  HB2  . CYS A 1 18 ? 8.141   -1.217  -0.802  1.00 0.00 ? 18 CYS A HB2  1 
+ATOM   262  H  HB3  . CYS A 1 18 ? 8.118   -0.187  -2.227  1.00 0.00 ? 18 CYS A HB3  1 
+ATOM   263  N  N    . SER A 1 19 ? 11.631  -2.381  -1.782  1.00 0.00 ? 19 SER A N    1 
+ATOM   264  C  CA   . SER A 1 19 ? 12.835  -2.191  -0.930  1.00 0.00 ? 19 SER A CA   1 
+ATOM   265  C  C    . SER A 1 19 ? 13.601  -0.999  -1.501  1.00 0.00 ? 19 SER A C    1 
+ATOM   266  O  O    . SER A 1 19 ? 14.814  -0.996  -1.585  1.00 0.00 ? 19 SER A O    1 
+ATOM   267  C  CB   . SER A 1 19 ? 13.710  -3.445  -0.976  1.00 0.00 ? 19 SER A CB   1 
+ATOM   268  O  OG   . SER A 1 19 ? 14.780  -3.304  -0.051  1.00 0.00 ? 19 SER A OG   1 
+ATOM   269  H  H    . SER A 1 19 ? 11.678  -2.945  -2.580  1.00 0.00 ? 19 SER A H    1 
+ATOM   270  H  HA   . SER A 1 19 ? 12.537  -1.983  0.088   1.00 0.00 ? 19 SER A HA   1 
+ATOM   271  H  HB2  . SER A 1 19 ? 13.122  -4.306  -0.707  1.00 0.00 ? 19 SER A HB2  1 
+ATOM   272  H  HB3  . SER A 1 19 ? 14.101  -3.574  -1.977  1.00 0.00 ? 19 SER A HB3  1 
+ATOM   273  H  HG   . SER A 1 19 ? 15.601  -3.467  -0.520  1.00 0.00 ? 19 SER A HG   1 
+ATOM   274  N  N    . ASP A 1 20 ? 12.878  0.005   -1.923  1.00 0.00 ? 20 ASP A N    1 
+ATOM   275  C  CA   . ASP A 1 20 ? 13.505  1.202   -2.526  1.00 0.00 ? 20 ASP A CA   1 
+ATOM   276  C  C    . ASP A 1 20 ? 12.462  2.321   -2.565  1.00 0.00 ? 20 ASP A C    1 
+ATOM   277  O  O    . ASP A 1 20 ? 12.381  3.081   -3.509  1.00 0.00 ? 20 ASP A O    1 
+ATOM   278  C  CB   . ASP A 1 20 ? 13.933  0.853   -3.954  1.00 0.00 ? 20 ASP A CB   1 
+ATOM   279  C  CG   . ASP A 1 20 ? 15.098  1.749   -4.376  1.00 0.00 ? 20 ASP A CG   1 
+ATOM   280  O  OD1  . ASP A 1 20 ? 15.695  2.362   -3.506  1.00 0.00 ? 20 ASP A OD1  1 
+ATOM   281  O  OD2  . ASP A 1 20 ? 15.377  1.807   -5.563  1.00 0.00 ? 20 ASP A OD2  1 
+ATOM   282  H  H    . ASP A 1 20 ? 11.907  -0.038  -1.858  1.00 0.00 ? 20 ASP A H    1 
+ATOM   283  H  HA   . ASP A 1 20 ? 14.359  1.509   -1.941  1.00 0.00 ? 20 ASP A HA   1 
+ATOM   284  H  HB2  . ASP A 1 20 ? 14.236  -0.187  -3.992  1.00 0.00 ? 20 ASP A HB2  1 
+ATOM   285  H  HB3  . ASP A 1 20 ? 13.097  1.003   -4.625  1.00 0.00 ? 20 ASP A HB3  1 
+ATOM   286  N  N    . ASP A 1 21 ? 11.650  2.407   -1.547  1.00 0.00 ? 21 ASP A N    1 
+ATOM   287  C  CA   . ASP A 1 21 ? 10.588  3.455   -1.516  1.00 0.00 ? 21 ASP A CA   1 
+ATOM   288  C  C    . ASP A 1 21 ? 9.513   3.093   -2.545  1.00 0.00 ? 21 ASP A C    1 
+ATOM   289  O  O    . ASP A 1 21 ? 9.744   2.272   -3.407  1.00 0.00 ? 21 ASP A O    1 
+ATOM   290  C  CB   . ASP A 1 21 ? 11.199  4.812   -1.878  1.00 0.00 ? 21 ASP A CB   1 
+ATOM   291  C  CG   . ASP A 1 21 ? 10.977  5.799   -0.730  1.00 0.00 ? 21 ASP A CG   1 
+ATOM   292  O  OD1  . ASP A 1 21 ? 9.909   6.386   -0.678  1.00 0.00 ? 21 ASP A OD1  1 
+ATOM   293  O  OD2  . ASP A 1 21 ? 11.881  5.952   0.076   1.00 0.00 ? 21 ASP A OD2  1 
+ATOM   294  H  H    . ASP A 1 21 ? 11.734  1.770   -0.808  1.00 0.00 ? 21 ASP A H    1 
+ATOM   295  H  HA   . ASP A 1 21 ? 10.148  3.503   -0.528  1.00 0.00 ? 21 ASP A HA   1 
+ATOM   296  H  HB2  . ASP A 1 21 ? 12.259  4.694   -2.052  1.00 0.00 ? 21 ASP A HB2  1 
+ATOM   297  H  HB3  . ASP A 1 21 ? 10.728  5.192   -2.771  1.00 0.00 ? 21 ASP A HB3  1 
+ATOM   298  N  N    . THR A 1 22 ? 8.349   3.709   -2.453  1.00 0.00 ? 22 THR A N    1 
+ATOM   299  C  CA   . THR A 1 22 ? 7.232   3.434   -3.426  1.00 0.00 ? 22 THR A CA   1 
+ATOM   300  C  C    . THR A 1 22 ? 6.164   2.531   -2.785  1.00 0.00 ? 22 THR A C    1 
+ATOM   301  O  O    . THR A 1 22 ? 5.608   2.882   -1.764  1.00 0.00 ? 22 THR A O    1 
+ATOM   302  C  CB   . THR A 1 22 ? 7.760   2.798   -4.719  1.00 0.00 ? 22 THR A CB   1 
+ATOM   303  O  OG1  . THR A 1 22 ? 8.891   3.528   -5.175  1.00 0.00 ? 22 THR A OG1  1 
+ATOM   304  C  CG2  . THR A 1 22 ? 6.667   2.829   -5.788  1.00 0.00 ? 22 THR A CG2  1 
+ATOM   305  H  H    . THR A 1 22 ? 8.208   4.369   -1.735  1.00 0.00 ? 22 THR A H    1 
+ATOM   306  H  HA   . THR A 1 22 ? 6.766   4.378   -3.676  1.00 0.00 ? 22 THR A HA   1 
+ATOM   307  H  HB   . THR A 1 22 ? 8.044   1.775   -4.528  1.00 0.00 ? 22 THR A HB   1 
+ATOM   308  H  HG1  . THR A 1 22 ? 8.792   4.439   -4.888  1.00 0.00 ? 22 THR A HG1  1 
+ATOM   309  H  HG21 . THR A 1 22 ? 5.727   2.530   -5.349  1.00 0.00 ? 22 THR A HG21 1 
+ATOM   310  H  HG22 . THR A 1 22 ? 6.579   3.830   -6.184  1.00 0.00 ? 22 THR A HG22 1 
+ATOM   311  H  HG23 . THR A 1 22 ? 6.924   2.148   -6.586  1.00 0.00 ? 22 THR A HG23 1 
+ATOM   312  N  N    . TYR A 1 23 ? 5.854   1.390   -3.390  1.00 0.00 ? 23 TYR A N    1 
+ATOM   313  C  CA   . TYR A 1 23 ? 4.798   0.469   -2.847  1.00 0.00 ? 23 TYR A CA   1 
+ATOM   314  C  C    . TYR A 1 23 ? 3.416   0.969   -3.279  1.00 0.00 ? 23 TYR A C    1 
+ATOM   315  O  O    . TYR A 1 23 ? 2.598   0.202   -3.730  1.00 0.00 ? 23 TYR A O    1 
+ATOM   316  C  CB   . TYR A 1 23 ? 4.882   0.369   -1.303  1.00 0.00 ? 23 TYR A CB   1 
+ATOM   317  C  CG   . TYR A 1 23 ? 3.507   0.489   -0.682  1.00 0.00 ? 23 TYR A CG   1 
+ATOM   318  C  CD1  . TYR A 1 23 ? 2.579   -0.544  -0.853  1.00 0.00 ? 23 TYR A CD1  1 
+ATOM   319  C  CD2  . TYR A 1 23 ? 3.158   1.632   0.044   1.00 0.00 ? 23 TYR A CD2  1 
+ATOM   320  C  CE1  . TYR A 1 23 ? 1.300   -0.435  -0.299  1.00 0.00 ? 23 TYR A CE1  1 
+ATOM   321  C  CE2  . TYR A 1 23 ? 1.879   1.741   0.602   1.00 0.00 ? 23 TYR A CE2  1 
+ATOM   322  C  CZ   . TYR A 1 23 ? 0.949   0.707   0.430   1.00 0.00 ? 23 TYR A CZ   1 
+ATOM   323  O  OH   . TYR A 1 23 ? -0.315  0.813   0.973   1.00 0.00 ? 23 TYR A OH   1 
+ATOM   324  H  H    . TYR A 1 23 ? 6.310   1.141   -4.220  1.00 0.00 ? 23 TYR A H    1 
+ATOM   325  H  HA   . TYR A 1 23 ? 4.940   -0.508  -3.274  1.00 0.00 ? 23 TYR A HA   1 
+ATOM   326  H  HB2  . TYR A 1 23 ? 5.295   -0.584  -1.034  1.00 0.00 ? 23 TYR A HB2  1 
+ATOM   327  H  HB3  . TYR A 1 23 ? 5.518   1.144   -0.922  1.00 0.00 ? 23 TYR A HB3  1 
+ATOM   328  H  HD1  . TYR A 1 23 ? 2.850   -1.425  -1.414  1.00 0.00 ? 23 TYR A HD1  1 
+ATOM   329  H  HD2  . TYR A 1 23 ? 3.875   2.429   0.177   1.00 0.00 ? 23 TYR A HD2  1 
+ATOM   330  H  HE1  . TYR A 1 23 ? 0.584   -1.232  -0.431  1.00 0.00 ? 23 TYR A HE1  1 
+ATOM   331  H  HE2  . TYR A 1 23 ? 1.611   2.622   1.164   1.00 0.00 ? 23 TYR A HE2  1 
+ATOM   332  H  HH   . TYR A 1 23 ? -0.953  0.663   0.272   1.00 0.00 ? 23 TYR A HH   1 
+ATOM   333  N  N    . ILE A 1 24 ? 3.184   2.243   -3.114  1.00 0.00 ? 24 ILE A N    1 
+ATOM   334  C  CA   . ILE A 1 24 ? 1.886   2.902   -3.454  1.00 0.00 ? 24 ILE A CA   1 
+ATOM   335  C  C    . ILE A 1 24 ? 0.971   2.038   -4.335  1.00 0.00 ? 24 ILE A C    1 
+ATOM   336  O  O    . ILE A 1 24 ? 1.378   1.107   -5.008  1.00 0.00 ? 24 ILE A O    1 
+ATOM   337  C  CB   . ILE A 1 24 ? 2.212   4.194   -4.214  1.00 0.00 ? 24 ILE A CB   1 
+ATOM   338  C  CG1  . ILE A 1 24 ? 3.178   5.050   -3.386  1.00 0.00 ? 24 ILE A CG1  1 
+ATOM   339  C  CG2  . ILE A 1 24 ? 0.930   4.980   -4.472  1.00 0.00 ? 24 ILE A CG2  1 
+ATOM   340  C  CD1  . ILE A 1 24 ? 3.481   6.348   -4.134  1.00 0.00 ? 24 ILE A CD1  1 
+ATOM   341  H  H    . ILE A 1 24 ? 3.884   2.793   -2.731  1.00 0.00 ? 24 ILE A H    1 
+ATOM   342  H  HA   . ILE A 1 24 ? 1.366   3.159   -2.545  1.00 0.00 ? 24 ILE A HA   1 
+ATOM   343  H  HB   . ILE A 1 24 ? 2.673   3.945   -5.158  1.00 0.00 ? 24 ILE A HB   1 
+ATOM   344  H  HG12 . ILE A 1 24 ? 2.729   5.280   -2.431  1.00 0.00 ? 24 ILE A HG12 1 
+ATOM   345  H  HG13 . ILE A 1 24 ? 4.098   4.509   -3.231  1.00 0.00 ? 24 ILE A HG13 1 
+ATOM   346  H  HG21 . ILE A 1 24 ? 0.209   4.738   -3.712  1.00 0.00 ? 24 ILE A HG21 1 
+ATOM   347  H  HG22 . ILE A 1 24 ? 1.145   6.039   -4.442  1.00 0.00 ? 24 ILE A HG22 1 
+ATOM   348  H  HG23 . ILE A 1 24 ? 0.536   4.719   -5.441  1.00 0.00 ? 24 ILE A HG23 1 
+ATOM   349  H  HD11 . ILE A 1 24 ? 2.554   6.825   -4.412  1.00 0.00 ? 24 ILE A HD11 1 
+ATOM   350  H  HD12 . ILE A 1 24 ? 4.046   7.008   -3.495  1.00 0.00 ? 24 ILE A HD12 1 
+ATOM   351  H  HD13 . ILE A 1 24 ? 4.054   6.127   -5.022  1.00 0.00 ? 24 ILE A HD13 1 
+ATOM   352  N  N    . LEU A 1 25 ? -0.287  2.370   -4.371  1.00 0.00 ? 25 LEU A N    1 
+ATOM   353  C  CA   . LEU A 1 25 ? -1.209  1.601   -5.232  1.00 0.00 ? 25 LEU A CA   1 
+ATOM   354  C  C    . LEU A 1 25 ? -0.536  1.433   -6.590  1.00 0.00 ? 25 LEU A C    1 
+ATOM   355  O  O    . LEU A 1 25 ? -0.798  0.502   -7.319  1.00 0.00 ? 25 LEU A O    1 
+ATOM   356  C  CB   . LEU A 1 25 ? -2.530  2.346   -5.363  1.00 0.00 ? 25 LEU A CB   1 
+ATOM   357  C  CG   . LEU A 1 25 ? -3.563  1.617   -4.511  1.00 0.00 ? 25 LEU A CG   1 
+ATOM   358  C  CD1  . LEU A 1 25 ? -3.148  1.696   -3.042  1.00 0.00 ? 25 LEU A CD1  1 
+ATOM   359  C  CD2  . LEU A 1 25 ? -4.935  2.268   -4.690  1.00 0.00 ? 25 LEU A CD2  1 
+ATOM   360  H  H    . LEU A 1 25 ? -0.616  3.133   -3.854  1.00 0.00 ? 25 LEU A H    1 
+ATOM   361  H  HA   . LEU A 1 25 ? -1.382  0.628   -4.794  1.00 0.00 ? 25 LEU A HA   1 
+ATOM   362  H  HB2  . LEU A 1 25 ? -2.414  3.362   -5.012  1.00 0.00 ? 25 LEU A HB2  1 
+ATOM   363  H  HB3  . LEU A 1 25 ? -2.849  2.348   -6.395  1.00 0.00 ? 25 LEU A HB3  1 
+ATOM   364  H  HG   . LEU A 1 25 ? -3.602  0.580   -4.816  1.00 0.00 ? 25 LEU A HG   1 
+ATOM   365  H  HD11 . LEU A 1 25 ? -2.180  2.167   -2.966  1.00 0.00 ? 25 LEU A HD11 1 
+ATOM   366  H  HD12 . LEU A 1 25 ? -3.874  2.276   -2.493  1.00 0.00 ? 25 LEU A HD12 1 
+ATOM   367  H  HD13 . LEU A 1 25 ? -3.098  0.699   -2.629  1.00 0.00 ? 25 LEU A HD13 1 
+ATOM   368  H  HD21 . LEU A 1 25 ? -4.906  2.949   -5.527  1.00 0.00 ? 25 LEU A HD21 1 
+ATOM   369  H  HD22 . LEU A 1 25 ? -5.675  1.504   -4.873  1.00 0.00 ? 25 LEU A HD22 1 
+ATOM   370  H  HD23 . LEU A 1 25 ? -5.194  2.812   -3.793  1.00 0.00 ? 25 LEU A HD23 1 
+ATOM   371  N  N    . ASP A 1 26 ? 0.373   2.319   -6.904  1.00 0.00 ? 26 ASP A N    1 
+ATOM   372  C  CA   . ASP A 1 26 ? 1.116   2.207   -8.175  1.00 0.00 ? 26 ASP A CA   1 
+ATOM   373  C  C    . ASP A 1 26 ? 1.796   0.832   -8.230  1.00 0.00 ? 26 ASP A C    1 
+ATOM   374  O  O    . ASP A 1 26 ? 1.647   0.095   -9.183  1.00 0.00 ? 26 ASP A O    1 
+ATOM   375  C  CB   . ASP A 1 26 ? 2.178   3.304   -8.247  1.00 0.00 ? 26 ASP A CB   1 
+ATOM   376  C  CG   . ASP A 1 26 ? 2.070   4.034   -9.588  1.00 0.00 ? 26 ASP A CG   1 
+ATOM   377  O  OD1  . ASP A 1 26 ? 2.509   3.477   -10.580 1.00 0.00 ? 26 ASP A OD1  1 
+ATOM   378  O  OD2  . ASP A 1 26 ? 1.548   5.137   -9.600  1.00 0.00 ? 26 ASP A OD2  1 
+ATOM   379  H  H    . ASP A 1 26 ? 0.584   3.047   -6.286  1.00 0.00 ? 26 ASP A H    1 
+ATOM   380  H  HA   . ASP A 1 26 ? 0.431   2.312   -8.999  1.00 0.00 ? 26 ASP A HA   1 
+ATOM   381  H  HB2  . ASP A 1 26 ? 2.025   4.006   -7.441  1.00 0.00 ? 26 ASP A HB2  1 
+ATOM   382  H  HB3  . ASP A 1 26 ? 3.159   2.863   -8.159  1.00 0.00 ? 26 ASP A HB3  1 
+ATOM   383  N  N    . ALA A 1 27 ? 2.539   0.451   -7.219  1.00 0.00 ? 27 ALA A N    1 
+ATOM   384  C  CA   . ALA A 1 27 ? 3.179   -0.875  -7.285  1.00 0.00 ? 27 ALA A CA   1 
+ATOM   385  C  C    . ALA A 1 27 ? 2.122   -1.920  -7.624  1.00 0.00 ? 27 ALA A C    1 
+ATOM   386  O  O    . ALA A 1 27 ? 2.244   -2.658  -8.586  1.00 0.00 ? 27 ALA A O    1 
+ATOM   387  C  CB   . ALA A 1 27 ? 3.818   -1.204  -5.934  1.00 0.00 ? 27 ALA A CB   1 
+ATOM   388  H  H    . ALA A 1 27 ? 2.671   1.021   -6.426  1.00 0.00 ? 27 ALA A H    1 
+ATOM   389  H  HA   . ALA A 1 27 ? 3.936   -0.872  -8.049  1.00 0.00 ? 27 ALA A HA   1 
+ATOM   390  H  HB1  . ALA A 1 27 ? 4.077   -0.286  -5.426  1.00 0.00 ? 27 ALA A HB1  1 
+ATOM   391  H  HB2  . ALA A 1 27 ? 3.116   -1.762  -5.331  1.00 0.00 ? 27 ALA A HB2  1 
+ATOM   392  H  HB3  . ALA A 1 27 ? 4.708   -1.794  -6.090  1.00 0.00 ? 27 ALA A HB3  1 
+ATOM   393  N  N    . ALA A 1 28 ? 1.083   -2.004  -6.847  1.00 0.00 ? 28 ALA A N    1 
+ATOM   394  C  CA   . ALA A 1 28 ? 0.055   -3.039  -7.137  1.00 0.00 ? 28 ALA A CA   1 
+ATOM   395  C  C    . ALA A 1 28 ? -1.109  -2.470  -7.950  1.00 0.00 ? 28 ALA A C    1 
+ATOM   396  O  O    . ALA A 1 28 ? -1.269  -2.751  -9.125  1.00 0.00 ? 28 ALA A O    1 
+ATOM   397  C  CB   . ALA A 1 28 ? -0.478  -3.605  -5.819  1.00 0.00 ? 28 ALA A CB   1 
+ATOM   398  H  H    . ALA A 1 28 ? 0.985   -1.405  -6.075  1.00 0.00 ? 28 ALA A H    1 
+ATOM   399  H  HA   . ALA A 1 28 ? 0.520   -3.827  -7.690  1.00 0.00 ? 28 ALA A HA   1 
+ATOM   400  H  HB1  . ALA A 1 28 ? 0.047   -3.148  -4.993  1.00 0.00 ? 28 ALA A HB1  1 
+ATOM   401  H  HB2  . ALA A 1 28 ? -1.533  -3.392  -5.737  1.00 0.00 ? 28 ALA A HB2  1 
+ATOM   402  H  HB3  . ALA A 1 28 ? -0.323  -4.673  -5.799  1.00 0.00 ? 28 ALA A HB3  1 
+ATOM   403  N  N    . GLU A 1 29 ? -1.936  -1.701  -7.315  1.00 0.00 ? 29 GLU A N    1 
+ATOM   404  C  CA   . GLU A 1 29 ? -3.126  -1.121  -7.992  1.00 0.00 ? 29 GLU A CA   1 
+ATOM   405  C  C    . GLU A 1 29 ? -2.770  -0.528  -9.378  1.00 0.00 ? 29 GLU A C    1 
+ATOM   406  O  O    . GLU A 1 29 ? -3.639  -0.295  -10.193 1.00 0.00 ? 29 GLU A O    1 
+ATOM   407  C  CB   . GLU A 1 29 ? -3.723  -0.076  -7.046  1.00 0.00 ? 29 GLU A CB   1 
+ATOM   408  C  CG   . GLU A 1 29 ? -4.601  0.932   -7.793  1.00 0.00 ? 29 GLU A CG   1 
+ATOM   409  C  CD   . GLU A 1 29 ? -5.992  0.970   -7.157  1.00 0.00 ? 29 GLU A CD   1 
+ATOM   410  O  OE1  . GLU A 1 29 ? -6.613  -0.077  -7.073  1.00 0.00 ? 29 GLU A OE1  1 
+ATOM   411  O  OE2  . GLU A 1 29 ? -6.417  2.047   -6.770  1.00 0.00 ? 29 GLU A OE2  1 
+ATOM   412  H  H    . GLU A 1 29 ? -1.787  -1.518  -6.365  1.00 0.00 ? 29 GLU A H    1 
+ATOM   413  H  HA   . GLU A 1 29 ? -3.851  -1.908  -8.135  1.00 0.00 ? 29 GLU A HA   1 
+ATOM   414  H  HB2  . GLU A 1 29 ? -4.321  -0.584  -6.300  1.00 0.00 ? 29 GLU A HB2  1 
+ATOM   415  H  HB3  . GLU A 1 29 ? -2.919  0.442   -6.554  1.00 0.00 ? 29 GLU A HB3  1 
+ATOM   416  H  HG2  . GLU A 1 29 ? -4.152  1.909   -7.729  1.00 0.00 ? 29 GLU A HG2  1 
+ATOM   417  H  HG3  . GLU A 1 29 ? -4.695  0.645   -8.823  1.00 0.00 ? 29 GLU A HG3  1 
+ATOM   418  N  N    . GLU A 1 30 ? -1.518  -0.322  -9.699  1.00 0.00 ? 30 GLU A N    1 
+ATOM   419  C  CA   . GLU A 1 30 ? -1.210  0.192   -11.055 1.00 0.00 ? 30 GLU A CA   1 
+ATOM   420  C  C    . GLU A 1 30 ? -0.574  -0.934  -11.858 1.00 0.00 ? 30 GLU A C    1 
+ATOM   421  O  O    . GLU A 1 30 ? -0.741  -1.026  -13.058 1.00 0.00 ? 30 GLU A O    1 
+ATOM   422  C  CB   . GLU A 1 30 ? -0.270  1.394   -11.009 1.00 0.00 ? 30 GLU A CB   1 
+ATOM   423  C  CG   . GLU A 1 30 ? 0.223   1.696   -12.424 1.00 0.00 ? 30 GLU A CG   1 
+ATOM   424  C  CD   . GLU A 1 30 ? 0.163   3.203   -12.679 1.00 0.00 ? 30 GLU A CD   1 
+ATOM   425  O  OE1  . GLU A 1 30 ? -0.746  3.835   -12.166 1.00 0.00 ? 30 GLU A OE1  1 
+ATOM   426  O  OE2  . GLU A 1 30 ? 1.027   3.698   -13.382 1.00 0.00 ? 30 GLU A OE2  1 
+ATOM   427  H  H    . GLU A 1 30 ? -0.800  -0.535  -9.088  1.00 0.00 ? 30 GLU A H    1 
+ATOM   428  H  HA   . GLU A 1 30 ? -2.124  0.479   -11.522 1.00 0.00 ? 30 GLU A HA   1 
+ATOM   429  H  HB2  . GLU A 1 30 ? -0.797  2.252   -10.617 1.00 0.00 ? 30 GLU A HB2  1 
+ATOM   430  H  HB3  . GLU A 1 30 ? 0.570   1.172   -10.386 1.00 0.00 ? 30 GLU A HB3  1 
+ATOM   431  H  HG2  . GLU A 1 30 ? 1.237   1.352   -12.525 1.00 0.00 ? 30 GLU A HG2  1 
+ATOM   432  H  HG3  . GLU A 1 30 ? -0.399  1.186   -13.141 1.00 0.00 ? 30 GLU A HG3  1 
+ATOM   433  N  N    . ALA A 1 31 ? 0.145   -1.808  -11.203 1.00 0.00 ? 31 ALA A N    1 
+ATOM   434  C  CA   . ALA A 1 31 ? 0.768   -2.931  -11.930 1.00 0.00 ? 31 ALA A CA   1 
+ATOM   435  C  C    . ALA A 1 31 ? -0.294  -3.614  -12.793 1.00 0.00 ? 31 ALA A C    1 
+ATOM   436  O  O    . ALA A 1 31 ? 0.016   -4.285  -13.759 1.00 0.00 ? 31 ALA A O    1 
+ATOM   437  C  CB   . ALA A 1 31 ? 1.328   -3.930  -10.919 1.00 0.00 ? 31 ALA A CB   1 
+ATOM   438  H  H    . ALA A 1 31 ? 0.266   -1.731  -10.232 1.00 0.00 ? 31 ALA A H    1 
+ATOM   439  H  HA   . ALA A 1 31 ? 1.564   -2.560  -12.554 1.00 0.00 ? 31 ALA A HA   1 
+ATOM   440  H  HB1  . ALA A 1 31 ? 0.757   -3.871  -10.004 1.00 0.00 ? 31 ALA A HB1  1 
+ATOM   441  H  HB2  . ALA A 1 31 ? 1.261   -4.928  -11.323 1.00 0.00 ? 31 ALA A HB2  1 
+ATOM   442  H  HB3  . ALA A 1 31 ? 2.362   -3.692  -10.714 1.00 0.00 ? 31 ALA A HB3  1 
+ATOM   443  N  N    . GLY A 1 32 ? -1.550  -3.463  -12.448 1.00 0.00 ? 32 GLY A N    1 
+ATOM   444  C  CA   . GLY A 1 32 ? -2.615  -4.130  -13.261 1.00 0.00 ? 32 GLY A CA   1 
+ATOM   445  C  C    . GLY A 1 32 ? -3.876  -3.254  -13.396 1.00 0.00 ? 32 GLY A C    1 
+ATOM   446  O  O    . GLY A 1 32 ? -4.714  -3.508  -14.238 1.00 0.00 ? 32 GLY A O    1 
+ATOM   447  H  H    . GLY A 1 32 ? -1.782  -2.929  -11.656 1.00 0.00 ? 32 GLY A H    1 
+ATOM   448  H  HA2  . GLY A 1 32 ? -2.225  -4.337  -14.246 1.00 0.00 ? 32 GLY A HA2  1 
+ATOM   449  H  HA3  . GLY A 1 32 ? -2.885  -5.064  -12.788 1.00 0.00 ? 32 GLY A HA3  1 
+ATOM   450  N  N    . LEU A 1 33 ? -4.037  -2.243  -12.583 1.00 0.00 ? 33 LEU A N    1 
+ATOM   451  C  CA   . LEU A 1 33 ? -5.255  -1.397  -12.690 1.00 0.00 ? 33 LEU A CA   1 
+ATOM   452  C  C    . LEU A 1 33 ? -4.869  0.084   -12.746 1.00 0.00 ? 33 LEU A C    1 
+ATOM   453  O  O    . LEU A 1 33 ? -5.684  0.954   -12.525 1.00 0.00 ? 33 LEU A O    1 
+ATOM   454  C  CB   . LEU A 1 33 ? -6.179  -1.647  -11.495 1.00 0.00 ? 33 LEU A CB   1 
+ATOM   455  C  CG   . LEU A 1 33 ? -5.434  -2.389  -10.386 1.00 0.00 ? 33 LEU A CG   1 
+ATOM   456  C  CD1  . LEU A 1 33 ? -6.002  -1.979  -9.026  1.00 0.00 ? 33 LEU A CD1  1 
+ATOM   457  C  CD2  . LEU A 1 33 ? -5.608  -3.897  -10.578 1.00 0.00 ? 33 LEU A CD2  1 
+ATOM   458  H  H    . LEU A 1 33 ? -3.379  -2.047  -11.910 1.00 0.00 ? 33 LEU A H    1 
+ATOM   459  H  HA   . LEU A 1 33 ? -5.767  -1.659  -13.592 1.00 0.00 ? 33 LEU A HA   1 
+ATOM   460  H  HB2  . LEU A 1 33 ? -6.538  -0.703  -11.116 1.00 0.00 ? 33 LEU A HB2  1 
+ATOM   461  H  HB3  . LEU A 1 33 ? -7.013  -2.243  -11.819 1.00 0.00 ? 33 LEU A HB3  1 
+ATOM   462  H  HG   . LEU A 1 33 ? -4.385  -2.139  -10.433 1.00 0.00 ? 33 LEU A HG   1 
+ATOM   463  H  HD11 . LEU A 1 33 ? -7.075  -2.093  -9.036  1.00 0.00 ? 33 LEU A HD11 1 
+ATOM   464  H  HD12 . LEU A 1 33 ? -5.580  -2.608  -8.256  1.00 0.00 ? 33 LEU A HD12 1 
+ATOM   465  H  HD13 . LEU A 1 33 ? -5.750  -0.948  -8.827  1.00 0.00 ? 33 LEU A HD13 1 
+ATOM   466  H  HD21 . LEU A 1 33 ? -6.157  -4.083  -11.490 1.00 0.00 ? 33 LEU A HD21 1 
+ATOM   467  H  HD22 . LEU A 1 33 ? -4.638  -4.367  -10.641 1.00 0.00 ? 33 LEU A HD22 1 
+ATOM   468  H  HD23 . LEU A 1 33 ? -6.153  -4.306  -9.741  1.00 0.00 ? 33 LEU A HD23 1 
+ATOM   469  N  N    . ASP A 1 34 ? -3.637  0.346   -13.079 1.00 0.00 ? 34 ASP A N    1 
+ATOM   470  C  CA   . ASP A 1 34 ? -3.110  1.737   -13.220 1.00 0.00 ? 34 ASP A CA   1 
+ATOM   471  C  C    . ASP A 1 34 ? -3.924  2.773   -12.428 1.00 0.00 ? 34 ASP A C    1 
+ATOM   472  O  O    . ASP A 1 34 ? -5.040  3.113   -12.770 1.00 0.00 ? 34 ASP A O    1 
+ATOM   473  C  CB   . ASP A 1 34 ? -3.115  2.058   -14.706 1.00 0.00 ? 34 ASP A CB   1 
+ATOM   474  C  CG   . ASP A 1 34 ? -3.087  3.573   -14.935 1.00 0.00 ? 34 ASP A CG   1 
+ATOM   475  O  OD1  . ASP A 1 34 ? -2.045  4.168   -14.709 1.00 0.00 ? 34 ASP A OD1  1 
+ATOM   476  O  OD2  . ASP A 1 34 ? -4.107  4.111   -15.332 1.00 0.00 ? 34 ASP A OD2  1 
+ATOM   477  H  H    . ASP A 1 34 ? -3.042  -0.392  -13.276 1.00 0.00 ? 34 ASP A H    1 
+ATOM   478  H  HA   . ASP A 1 34 ? -2.093  1.760   -12.868 1.00 0.00 ? 34 ASP A HA   1 
+ATOM   479  H  HB2  . ASP A 1 34 ? -2.248  1.603   -15.159 1.00 0.00 ? 34 ASP A HB2  1 
+ATOM   480  H  HB3  . ASP A 1 34 ? -4.003  1.637   -15.145 1.00 0.00 ? 34 ASP A HB3  1 
+ATOM   481  N  N    . LEU A 1 35 ? -3.339  3.296   -11.382 1.00 0.00 ? 35 LEU A N    1 
+ATOM   482  C  CA   . LEU A 1 35 ? -4.024  4.328   -10.555 1.00 0.00 ? 35 LEU A CA   1 
+ATOM   483  C  C    . LEU A 1 35 ? -2.965  5.114   -9.775  1.00 0.00 ? 35 LEU A C    1 
+ATOM   484  O  O    . LEU A 1 35 ? -2.586  4.729   -8.687  1.00 0.00 ? 35 LEU A O    1 
+ATOM   485  C  CB   . LEU A 1 35 ? -4.982  3.641   -9.585  1.00 0.00 ? 35 LEU A CB   1 
+ATOM   486  C  CG   . LEU A 1 35 ? -6.351  3.472   -10.247 1.00 0.00 ? 35 LEU A CG   1 
+ATOM   487  C  CD1  . LEU A 1 35 ? -7.338  2.897   -9.232  1.00 0.00 ? 35 LEU A CD1  1 
+ATOM   488  C  CD2  . LEU A 1 35 ? -6.856  4.832   -10.735 1.00 0.00 ? 35 LEU A CD2  1 
+ATOM   489  H  H    . LEU A 1 35 ? -2.429  3.016   -11.149 1.00 0.00 ? 35 LEU A H    1 
+ATOM   490  H  HA   . LEU A 1 35 ? -4.575  5.005   -11.190 1.00 0.00 ? 35 LEU A HA   1 
+ATOM   491  H  HB2  . LEU A 1 35 ? -4.589  2.671   -9.329  1.00 0.00 ? 35 LEU A HB2  1 
+ATOM   492  H  HB3  . LEU A 1 35 ? -5.085  4.239   -8.692  1.00 0.00 ? 35 LEU A HB3  1 
+ATOM   493  H  HG   . LEU A 1 35 ? -6.260  2.796   -11.086 1.00 0.00 ? 35 LEU A HG   1 
+ATOM   494  H  HD11 . LEU A 1 35 ? -7.182  3.366   -8.272  1.00 0.00 ? 35 LEU A HD11 1 
+ATOM   495  H  HD12 . LEU A 1 35 ? -8.348  3.084   -9.565  1.00 0.00 ? 35 LEU A HD12 1 
+ATOM   496  H  HD13 . LEU A 1 35 ? -7.181  1.831   -9.140  1.00 0.00 ? 35 LEU A HD13 1 
+ATOM   497  H  HD21 . LEU A 1 35 ? -6.552  5.600   -10.038 1.00 0.00 ? 35 LEU A HD21 1 
+ATOM   498  H  HD22 . LEU A 1 35 ? -6.439  5.044   -11.708 1.00 0.00 ? 35 LEU A HD22 1 
+ATOM   499  H  HD23 . LEU A 1 35 ? -7.934  4.812   -10.802 1.00 0.00 ? 35 LEU A HD23 1 
+ATOM   500  N  N    . PRO A 1 36 ? -2.505  6.189   -10.370 1.00 0.00 ? 36 PRO A N    1 
+ATOM   501  C  CA   . PRO A 1 36 ? -1.471  7.044   -9.762  1.00 0.00 ? 36 PRO A CA   1 
+ATOM   502  C  C    . PRO A 1 36 ? -1.913  7.523   -8.377  1.00 0.00 ? 36 PRO A C    1 
+ATOM   503  O  O    . PRO A 1 36 ? -3.071  7.447   -8.019  1.00 0.00 ? 36 PRO A O    1 
+ATOM   504  C  CB   . PRO A 1 36 ? -1.318  8.224   -10.732 1.00 0.00 ? 36 PRO A CB   1 
+ATOM   505  C  CG   . PRO A 1 36 ? -2.232  7.951   -11.954 1.00 0.00 ? 36 PRO A CG   1 
+ATOM   506  C  CD   . PRO A 1 36 ? -2.984  6.638   -11.690 1.00 0.00 ? 36 PRO A CD   1 
+ATOM   507  H  HA   . PRO A 1 36 ? -0.538  6.508   -9.691  1.00 0.00 ? 36 PRO A HA   1 
+ATOM   508  H  HB2  . PRO A 1 36 ? -1.618  9.140   -10.243 1.00 0.00 ? 36 PRO A HB2  1 
+ATOM   509  H  HB3  . PRO A 1 36 ? -0.293  8.301   -11.058 1.00 0.00 ? 36 PRO A HB3  1 
+ATOM   510  H  HG2  . PRO A 1 36 ? -2.937  8.762   -12.072 1.00 0.00 ? 36 PRO A HG2  1 
+ATOM   511  H  HG3  . PRO A 1 36 ? -1.632  7.852   -12.845 1.00 0.00 ? 36 PRO A HG3  1 
+ATOM   512  H  HD2  . PRO A 1 36 ? -4.050  6.814   -11.667 1.00 0.00 ? 36 PRO A HD2  1 
+ATOM   513  H  HD3  . PRO A 1 36 ? -2.738  5.905   -12.443 1.00 0.00 ? 36 PRO A HD3  1 
+ATOM   514  N  N    . TYR A 1 37 ? -0.989  8.007   -7.592  1.00 0.00 ? 37 TYR A N    1 
+ATOM   515  C  CA   . TYR A 1 37 ? -1.339  8.483   -6.224  1.00 0.00 ? 37 TYR A CA   1 
+ATOM   516  C  C    . TYR A 1 37 ? -1.182  10.002  -6.149  1.00 0.00 ? 37 TYR A C    1 
+ATOM   517  O  O    . TYR A 1 37 ? -0.117  10.537  -6.388  1.00 0.00 ? 37 TYR A O    1 
+ATOM   518  C  CB   . TYR A 1 37 ? -0.401  7.828   -5.217  1.00 0.00 ? 37 TYR A CB   1 
+ATOM   519  C  CG   . TYR A 1 37 ? 1.029   8.124   -5.596  1.00 0.00 ? 37 TYR A CG   1 
+ATOM   520  C  CD1  . TYR A 1 37 ? 1.691   7.306   -6.521  1.00 0.00 ? 37 TYR A CD1  1 
+ATOM   521  C  CD2  . TYR A 1 37 ? 1.696   9.212   -5.021  1.00 0.00 ? 37 TYR A CD2  1 
+ATOM   522  C  CE1  . TYR A 1 37 ? 3.020   7.577   -6.869  1.00 0.00 ? 37 TYR A CE1  1 
+ATOM   523  C  CE2  . TYR A 1 37 ? 3.025   9.484   -5.371  1.00 0.00 ? 37 TYR A CE2  1 
+ATOM   524  C  CZ   . TYR A 1 37 ? 3.685   8.667   -6.295  1.00 0.00 ? 37 TYR A CZ   1 
+ATOM   525  O  OH   . TYR A 1 37 ? 4.995   8.933   -6.639  1.00 0.00 ? 37 TYR A OH   1 
+ATOM   526  H  H    . TYR A 1 37 ? -0.060  8.052   -7.900  1.00 0.00 ? 37 TYR A H    1 
+ATOM   527  H  HA   . TYR A 1 37 ? -2.359  8.213   -5.995  1.00 0.00 ? 37 TYR A HA   1 
+ATOM   528  H  HB2  . TYR A 1 37 ? -0.601  8.217   -4.229  1.00 0.00 ? 37 TYR A HB2  1 
+ATOM   529  H  HB3  . TYR A 1 37 ? -0.560  6.760   -5.224  1.00 0.00 ? 37 TYR A HB3  1 
+ATOM   530  H  HD1  . TYR A 1 37 ? 1.177   6.465   -6.963  1.00 0.00 ? 37 TYR A HD1  1 
+ATOM   531  H  HD2  . TYR A 1 37 ? 1.186   9.842   -4.309  1.00 0.00 ? 37 TYR A HD2  1 
+ATOM   532  H  HE1  . TYR A 1 37 ? 3.531   6.947   -7.583  1.00 0.00 ? 37 TYR A HE1  1 
+ATOM   533  H  HE2  . TYR A 1 37 ? 3.538   10.324  -4.927  1.00 0.00 ? 37 TYR A HE2  1 
+ATOM   534  H  HH   . TYR A 1 37 ? 5.414   8.104   -6.881  1.00 0.00 ? 37 TYR A HH   1 
+ATOM   535  N  N    . SER A 1 38 ? -2.234  10.701  -5.825  1.00 0.00 ? 38 SER A N    1 
+ATOM   536  C  CA   . SER A 1 38 ? -2.143  12.184  -5.743  1.00 0.00 ? 38 SER A CA   1 
+ATOM   537  C  C    . SER A 1 38 ? -3.352  12.746  -4.987  1.00 0.00 ? 38 SER A C    1 
+ATOM   538  O  O    . SER A 1 38 ? -3.221  13.619  -4.153  1.00 0.00 ? 38 SER A O    1 
+ATOM   539  C  CB   . SER A 1 38 ? -2.110  12.767  -7.156  1.00 0.00 ? 38 SER A CB   1 
+ATOM   540  O  OG   . SER A 1 38 ? -1.788  14.150  -7.085  1.00 0.00 ? 38 SER A OG   1 
+ATOM   541  H  H    . SER A 1 38 ? -3.085  10.250  -5.641  1.00 0.00 ? 38 SER A H    1 
+ATOM   542  H  HA   . SER A 1 38 ? -1.238  12.459  -5.223  1.00 0.00 ? 38 SER A HA   1 
+ATOM   543  H  HB2  . SER A 1 38 ? -1.361  12.258  -7.740  1.00 0.00 ? 38 SER A HB2  1 
+ATOM   544  H  HB3  . SER A 1 38 ? -3.077  12.635  -7.622  1.00 0.00 ? 38 SER A HB3  1 
+ATOM   545  H  HG   . SER A 1 38 ? -1.260  14.371  -7.856  1.00 0.00 ? 38 SER A HG   1 
+ATOM   546  N  N    . CYS A 1 39 ? -4.529  12.274  -5.311  1.00 0.00 ? 39 CYS A N    1 
+ATOM   547  C  CA   . CYS A 1 39 ? -5.771  12.791  -4.660  1.00 0.00 ? 39 CYS A CA   1 
+ATOM   548  C  C    . CYS A 1 39 ? -5.519  13.145  -3.183  1.00 0.00 ? 39 CYS A C    1 
+ATOM   549  O  O    . CYS A 1 39 ? -6.139  14.038  -2.641  1.00 0.00 ? 39 CYS A O    1 
+ATOM   550  C  CB   . CYS A 1 39 ? -6.907  11.753  -4.825  1.00 0.00 ? 39 CYS A CB   1 
+ATOM   551  S  SG   . CYS A 1 39 ? -7.300  10.904  -3.268  1.00 0.00 ? 39 CYS A SG   1 
+ATOM   552  H  H    . CYS A 1 39 ? -4.599  11.591  -6.011  1.00 0.00 ? 39 CYS A H    1 
+ATOM   553  H  HA   . CYS A 1 39 ? -6.063  13.697  -5.174  1.00 0.00 ? 39 CYS A HA   1 
+ATOM   554  H  HB2  . CYS A 1 39 ? -7.793  12.257  -5.179  1.00 0.00 ? 39 CYS A HB2  1 
+ATOM   555  H  HB3  . CYS A 1 39 ? -6.606  11.021  -5.561  1.00 0.00 ? 39 CYS A HB3  1 
+ATOM   556  N  N    . ARG A 1 40 ? -4.612  12.471  -2.532  1.00 0.00 ? 40 ARG A N    1 
+ATOM   557  C  CA   . ARG A 1 40 ? -4.328  12.798  -1.102  1.00 0.00 ? 40 ARG A CA   1 
+ATOM   558  C  C    . ARG A 1 40 ? -5.514  12.388  -0.221  1.00 0.00 ? 40 ARG A C    1 
+ATOM   559  O  O    . ARG A 1 40 ? -6.602  12.146  -0.698  1.00 0.00 ? 40 ARG A O    1 
+ATOM   560  C  CB   . ARG A 1 40 ? -4.087  14.302  -0.963  1.00 0.00 ? 40 ARG A CB   1 
+ATOM   561  C  CG   . ARG A 1 40 ? -2.962  14.546  0.043   1.00 0.00 ? 40 ARG A CG   1 
+ATOM   562  C  CD   . ARG A 1 40 ? -1.737  15.100  -0.686  1.00 0.00 ? 40 ARG A CD   1 
+ATOM   563  N  NE   . ARG A 1 40 ? -0.499  14.587  -0.032  1.00 0.00 ? 40 ARG A NE   1 
+ATOM   564  C  CZ   . ARG A 1 40 ? 0.654   14.685  -0.640  1.00 0.00 ? 40 ARG A CZ   1 
+ATOM   565  N  NH1  . ARG A 1 40 ? 0.731   15.238  -1.819  1.00 0.00 ? 40 ARG A NH1  1 
+ATOM   566  N  NH2  . ARG A 1 40 ? 1.733   14.227  -0.064  1.00 0.00 ? 40 ARG A NH2  1 
+ATOM   567  H  H    . ARG A 1 40 ? -4.111  11.759  -2.983  1.00 0.00 ? 40 ARG A H    1 
+ATOM   568  H  HA   . ARG A 1 40 ? -3.445  12.264  -0.783  1.00 0.00 ? 40 ARG A HA   1 
+ATOM   569  H  HB2  . ARG A 1 40 ? -3.810  14.713  -1.922  1.00 0.00 ? 40 ARG A HB2  1 
+ATOM   570  H  HB3  . ARG A 1 40 ? -4.990  14.781  -0.613  1.00 0.00 ? 40 ARG A HB3  1 
+ATOM   571  H  HG2  . ARG A 1 40 ? -3.291  15.256  0.788   1.00 0.00 ? 40 ARG A HG2  1 
+ATOM   572  H  HG3  . ARG A 1 40 ? -2.701  13.615  0.524   1.00 0.00 ? 40 ARG A HG3  1 
+ATOM   573  H  HD2  . ARG A 1 40 ? -1.757  14.782  -1.718  1.00 0.00 ? 40 ARG A HD2  1 
+ATOM   574  H  HD3  . ARG A 1 40 ? -1.747  16.179  -0.640  1.00 0.00 ? 40 ARG A HD3  1 
+ATOM   575  H  HE   . ARG A 1 40 ? -0.551  14.172  0.854   1.00 0.00 ? 40 ARG A HE   1 
+ATOM   576  H  HH11 . ARG A 1 40 ? -0.093  15.591  -2.263  1.00 0.00 ? 40 ARG A HH11 1 
+ATOM   577  H  HH12 . ARG A 1 40 ? 1.616   15.311  -2.280  1.00 0.00 ? 40 ARG A HH12 1 
+ATOM   578  H  HH21 . ARG A 1 40 ? 1.675   13.804  0.840   1.00 0.00 ? 40 ARG A HH21 1 
+ATOM   579  H  HH22 . ARG A 1 40 ? 2.616   14.299  -0.527  1.00 0.00 ? 40 ARG A HH22 1 
+ATOM   580  N  N    . ALA A 1 41 ? -5.301  12.295  1.064   1.00 0.00 ? 41 ALA A N    1 
+ATOM   581  C  CA   . ALA A 1 41 ? -6.406  11.888  1.978   1.00 0.00 ? 41 ALA A CA   1 
+ATOM   582  C  C    . ALA A 1 41 ? -7.604  12.824  1.802   1.00 0.00 ? 41 ALA A C    1 
+ATOM   583  O  O    . ALA A 1 41 ? -7.461  13.971  1.429   1.00 0.00 ? 41 ALA A O    1 
+ATOM   584  C  CB   . ALA A 1 41 ? -5.920  11.955  3.428   1.00 0.00 ? 41 ALA A CB   1 
+ATOM   585  H  H    . ALA A 1 41 ? -4.412  12.485  1.427   1.00 0.00 ? 41 ALA A H    1 
+ATOM   586  H  HA   . ALA A 1 41 ? -6.708  10.877  1.750   1.00 0.00 ? 41 ALA A HA   1 
+ATOM   587  H  HB1  . ALA A 1 41 ? -4.956  11.476  3.507   1.00 0.00 ? 41 ALA A HB1  1 
+ATOM   588  H  HB2  . ALA A 1 41 ? -5.836  12.988  3.732   1.00 0.00 ? 41 ALA A HB2  1 
+ATOM   589  H  HB3  . ALA A 1 41 ? -6.628  11.449  4.068   1.00 0.00 ? 41 ALA A HB3  1 
+ATOM   590  N  N    . GLY A 1 42 ? -8.785  12.341  2.078   1.00 0.00 ? 42 GLY A N    1 
+ATOM   591  C  CA   . GLY A 1 42 ? -9.997  13.197  1.937   1.00 0.00 ? 42 GLY A CA   1 
+ATOM   592  C  C    . GLY A 1 42 ? -10.288 13.448  0.457   1.00 0.00 ? 42 GLY A C    1 
+ATOM   593  O  O    . GLY A 1 42 ? -10.956 14.400  0.104   1.00 0.00 ? 42 GLY A O    1 
+ATOM   594  H  H    . GLY A 1 42 ? -8.875  11.414  2.383   1.00 0.00 ? 42 GLY A H    1 
+ATOM   595  H  HA2  . GLY A 1 42 ? -10.841 12.698  2.392   1.00 0.00 ? 42 GLY A HA2  1 
+ATOM   596  H  HA3  . GLY A 1 42 ? -9.827  14.141  2.432   1.00 0.00 ? 42 GLY A HA3  1 
+ATOM   597  N  N    . ALA A 1 43 ? -9.798  12.608  -0.417  1.00 0.00 ? 43 ALA A N    1 
+ATOM   598  C  CA   . ALA A 1 43 ? -10.061 12.824  -1.868  1.00 0.00 ? 43 ALA A CA   1 
+ATOM   599  C  C    . ALA A 1 43 ? -10.461 11.505  -2.545  1.00 0.00 ? 43 ALA A C    1 
+ATOM   600  O  O    . ALA A 1 43 ? -11.110 11.509  -3.573  1.00 0.00 ? 43 ALA A O    1 
+ATOM   601  C  CB   . ALA A 1 43 ? -8.806  13.381  -2.543  1.00 0.00 ? 43 ALA A CB   1 
+ATOM   602  H  H    . ALA A 1 43 ? -9.260  11.847  -0.118  1.00 0.00 ? 43 ALA A H    1 
+ATOM   603  H  HA   . ALA A 1 43 ? -10.867 13.535  -1.979  1.00 0.00 ? 43 ALA A HA   1 
+ATOM   604  H  HB1  . ALA A 1 43 ? -7.930  13.020  -2.030  1.00 0.00 ? 43 ALA A HB1  1 
+ATOM   605  H  HB2  . ALA A 1 43 ? -8.778  13.059  -3.573  1.00 0.00 ? 43 ALA A HB2  1 
+ATOM   606  H  HB3  . ALA A 1 43 ? -8.827  14.461  -2.504  1.00 0.00 ? 43 ALA A HB3  1 
+ATOM   607  N  N    . CYS A 1 44 ? -10.090 10.377  -1.995  1.00 0.00 ? 44 CYS A N    1 
+ATOM   608  C  CA   . CYS A 1 44 ? -10.475 9.092   -2.646  1.00 0.00 ? 44 CYS A CA   1 
+ATOM   609  C  C    . CYS A 1 44 ? -10.584 7.967   -1.618  1.00 0.00 ? 44 CYS A C    1 
+ATOM   610  O  O    . CYS A 1 44 ? -10.334 8.142   -0.442  1.00 0.00 ? 44 CYS A O    1 
+ATOM   611  C  CB   . CYS A 1 44 ? -9.431  8.708   -3.703  1.00 0.00 ? 44 CYS A CB   1 
+ATOM   612  S  SG   . CYS A 1 44 ? -7.984  7.958   -2.903  1.00 0.00 ? 44 CYS A SG   1 
+ATOM   613  H  H    . CYS A 1 44 ? -9.567  10.375  -1.166  1.00 0.00 ? 44 CYS A H    1 
+ATOM   614  H  HA   . CYS A 1 44 ? -11.432 9.218   -3.130  1.00 0.00 ? 44 CYS A HA   1 
+ATOM   615  H  HB2  . CYS A 1 44 ? -9.866  7.996   -4.390  1.00 0.00 ? 44 CYS A HB2  1 
+ATOM   616  H  HB3  . CYS A 1 44 ? -9.131  9.587   -4.250  1.00 0.00 ? 44 CYS A HB3  1 
+ATOM   617  N  N    . SER A 1 45 ? -10.930 6.803   -2.085  1.00 0.00 ? 45 SER A N    1 
+ATOM   618  C  CA   . SER A 1 45 ? -11.035 5.619   -1.196  1.00 0.00 ? 45 SER A CA   1 
+ATOM   619  C  C    . SER A 1 45 ? -10.403 4.429   -1.922  1.00 0.00 ? 45 SER A C    1 
+ATOM   620  O  O    . SER A 1 45 ? -10.545 3.292   -1.521  1.00 0.00 ? 45 SER A O    1 
+ATOM   621  C  CB   . SER A 1 45 ? -12.506 5.324   -0.899  1.00 0.00 ? 45 SER A CB   1 
+ATOM   622  O  OG   . SER A 1 45 ? -13.235 6.544   -0.875  1.00 0.00 ? 45 SER A OG   1 
+ATOM   623  H  H    . SER A 1 45 ? -11.100 6.700   -3.044  1.00 0.00 ? 45 SER A H    1 
+ATOM   624  H  HA   . SER A 1 45 ? -10.505 5.807   -0.274  1.00 0.00 ? 45 SER A HA   1 
+ATOM   625  H  HB2  . SER A 1 45 ? -12.910 4.686   -1.668  1.00 0.00 ? 45 SER A HB2  1 
+ATOM   626  H  HB3  . SER A 1 45 ? -12.587 4.826   0.058   1.00 0.00 ? 45 SER A HB3  1 
+ATOM   627  H  HG   . SER A 1 45 ? -12.912 7.068   -0.137  1.00 0.00 ? 45 SER A HG   1 
+ATOM   628  N  N    . THR A 1 46 ? -9.705  4.695   -3.001  1.00 0.00 ? 46 THR A N    1 
+ATOM   629  C  CA   . THR A 1 46 ? -9.059  3.597   -3.771  1.00 0.00 ? 46 THR A CA   1 
+ATOM   630  C  C    . THR A 1 46 ? -7.836  3.091   -3.008  1.00 0.00 ? 46 THR A C    1 
+ATOM   631  O  O    . THR A 1 46 ? -7.463  1.939   -3.114  1.00 0.00 ? 46 THR A O    1 
+ATOM   632  C  CB   . THR A 1 46 ? -8.621  4.123   -5.141  1.00 0.00 ? 46 THR A CB   1 
+ATOM   633  O  OG1  . THR A 1 46 ? -8.284  5.499   -5.032  1.00 0.00 ? 46 THR A OG1  1 
+ATOM   634  C  CG2  . THR A 1 46 ? -9.761  3.953   -6.145  1.00 0.00 ? 46 THR A CG2  1 
+ATOM   635  H  H    . THR A 1 46 ? -9.607  5.619   -3.306  1.00 0.00 ? 46 THR A H    1 
+ATOM   636  H  HA   . THR A 1 46 ? -9.760  2.790   -3.905  1.00 0.00 ? 46 THR A HA   1 
+ATOM   637  H  HB   . THR A 1 46 ? -7.761  3.567   -5.483  1.00 0.00 ? 46 THR A HB   1 
+ATOM   638  H  HG1  . THR A 1 46 ? -7.411  5.560   -4.640  1.00 0.00 ? 46 THR A HG1  1 
+ATOM   639  H  HG21 . THR A 1 46 ? -10.096 2.926   -6.141  1.00 0.00 ? 46 THR A HG21 1 
+ATOM   640  H  HG22 . THR A 1 46 ? -10.581 4.601   -5.872  1.00 0.00 ? 46 THR A HG22 1 
+ATOM   641  H  HG23 . THR A 1 46 ? -9.412  4.213   -7.134  1.00 0.00 ? 46 THR A HG23 1 
+ATOM   642  N  N    . CYS A 1 47 ? -7.206  3.935   -2.234  1.00 0.00 ? 47 CYS A N    1 
+ATOM   643  C  CA   . CYS A 1 47 ? -6.013  3.470   -1.471  1.00 0.00 ? 47 CYS A CA   1 
+ATOM   644  C  C    . CYS A 1 47 ? -6.407  3.086   -0.044  1.00 0.00 ? 47 CYS A C    1 
+ATOM   645  O  O    . CYS A 1 47 ? -5.963  3.683   0.917   1.00 0.00 ? 47 CYS A O    1 
+ATOM   646  C  CB   . CYS A 1 47 ? -4.905  4.536   -1.427  1.00 0.00 ? 47 CYS A CB   1 
+ATOM   647  S  SG   . CYS A 1 47 ? -5.553  6.224   -1.600  1.00 0.00 ? 47 CYS A SG   1 
+ATOM   648  H  H    . CYS A 1 47 ? -7.522  4.858   -2.153  1.00 0.00 ? 47 CYS A H    1 
+ATOM   649  H  HA   . CYS A 1 47 ? -5.623  2.591   -1.962  1.00 0.00 ? 47 CYS A HA   1 
+ATOM   650  H  HB2  . CYS A 1 47 ? -4.386  4.461   -0.484  1.00 0.00 ? 47 CYS A HB2  1 
+ATOM   651  H  HB3  . CYS A 1 47 ? -4.203  4.342   -2.226  1.00 0.00 ? 47 CYS A HB3  1 
+ATOM   652  N  N    . ALA A 1 48 ? -7.217  2.073   0.103   1.00 0.00 ? 48 ALA A N    1 
+ATOM   653  C  CA   . ALA A 1 48 ? -7.620  1.626   1.466   1.00 0.00 ? 48 ALA A CA   1 
+ATOM   654  C  C    . ALA A 1 48 ? -6.752  0.429   1.865   1.00 0.00 ? 48 ALA A C    1 
+ATOM   655  O  O    . ALA A 1 48 ? -7.243  -0.579  2.333   1.00 0.00 ? 48 ALA A O    1 
+ATOM   656  C  CB   . ALA A 1 48 ? -9.092  1.213   1.457   1.00 0.00 ? 48 ALA A CB   1 
+ATOM   657  H  H    . ALA A 1 48 ? -7.548  1.594   -0.686  1.00 0.00 ? 48 ALA A H    1 
+ATOM   658  H  HA   . ALA A 1 48 ? -7.472  2.433   2.170   1.00 0.00 ? 48 ALA A HA   1 
+ATOM   659  H  HB1  . ALA A 1 48 ? -9.597  1.695   0.634   1.00 0.00 ? 48 ALA A HB1  1 
+ATOM   660  H  HB2  . ALA A 1 48 ? -9.164  0.141   1.345   1.00 0.00 ? 48 ALA A HB2  1 
+ATOM   661  H  HB3  . ALA A 1 48 ? -9.555  1.509   2.387   1.00 0.00 ? 48 ALA A HB3  1 
+ATOM   662  N  N    . GLY A 1 49 ? -5.465  0.542   1.668   1.00 0.00 ? 49 GLY A N    1 
+ATOM   663  C  CA   . GLY A 1 49 ? -4.528  -0.571  2.011   1.00 0.00 ? 49 GLY A CA   1 
+ATOM   664  C  C    . GLY A 1 49 ? -4.996  -1.317  3.262   1.00 0.00 ? 49 GLY A C    1 
+ATOM   665  O  O    . GLY A 1 49 ? -5.079  -0.754  4.335   1.00 0.00 ? 49 GLY A O    1 
+ATOM   666  H  H    . GLY A 1 49 ? -5.108  1.368   1.280   1.00 0.00 ? 49 GLY A H    1 
+ATOM   667  H  HA2  . GLY A 1 49 ? -4.467  -1.263  1.185   1.00 0.00 ? 49 GLY A HA2  1 
+ATOM   668  H  HA3  . GLY A 1 49 ? -3.549  -0.157  2.199   1.00 0.00 ? 49 GLY A HA3  1 
+ATOM   669  N  N    . LYS A 1 50 ? -5.288  -2.588  3.141   1.00 0.00 ? 50 LYS A N    1 
+ATOM   670  C  CA   . LYS A 1 50 ? -5.729  -3.356  4.335   1.00 0.00 ? 50 LYS A CA   1 
+ATOM   671  C  C    . LYS A 1 50 ? -4.511  -4.030  4.968   1.00 0.00 ? 50 LYS A C    1 
+ATOM   672  O  O    . LYS A 1 50 ? -4.165  -5.145  4.635   1.00 0.00 ? 50 LYS A O    1 
+ATOM   673  C  CB   . LYS A 1 50 ? -6.752  -4.416  3.921   1.00 0.00 ? 50 LYS A CB   1 
+ATOM   674  C  CG   . LYS A 1 50 ? -7.938  -4.388  4.888   1.00 0.00 ? 50 LYS A CG   1 
+ATOM   675  C  CD   . LYS A 1 50 ? -7.750  -5.459  5.964   1.00 0.00 ? 50 LYS A CD   1 
+ATOM   676  C  CE   . LYS A 1 50 ? -7.896  -6.847  5.338   1.00 0.00 ? 50 LYS A CE   1 
+ATOM   677  N  NZ   . LYS A 1 50 ? -6.829  -7.744  5.866   1.00 0.00 ? 50 LYS A NZ   1 
+ATOM   678  H  H    . LYS A 1 50 ? -5.208  -3.041  2.270   1.00 0.00 ? 50 LYS A H    1 
+ATOM   679  H  HA   . LYS A 1 50 ? -6.178  -2.681  5.049   1.00 0.00 ? 50 LYS A HA   1 
+ATOM   680  H  HB2  . LYS A 1 50 ? -7.099  -4.208  2.920   1.00 0.00 ? 50 LYS A HB2  1 
+ATOM   681  H  HB3  . LYS A 1 50 ? -6.292  -5.392  3.949   1.00 0.00 ? 50 LYS A HB3  1 
+ATOM   682  H  HG2  . LYS A 1 50 ? -7.997  -3.415  5.355   1.00 0.00 ? 50 LYS A HG2  1 
+ATOM   683  H  HG3  . LYS A 1 50 ? -8.850  -4.582  4.345   1.00 0.00 ? 50 LYS A HG3  1 
+ATOM   684  H  HD2  . LYS A 1 50 ? -6.766  -5.362  6.398   1.00 0.00 ? 50 LYS A HD2  1 
+ATOM   685  H  HD3  . LYS A 1 50 ? -8.497  -5.332  6.733   1.00 0.00 ? 50 LYS A HD3  1 
+ATOM   686  H  HE2  . LYS A 1 50 ? -8.866  -7.255  5.587   1.00 0.00 ? 50 LYS A HE2  1 
+ATOM   687  H  HE3  . LYS A 1 50 ? -7.804  -6.770  4.264   1.00 0.00 ? 50 LYS A HE3  1 
+ATOM   688  H  HZ1  . LYS A 1 50 ? -6.850  -7.734  6.905   1.00 0.00 ? 50 LYS A HZ1  1 
+ATOM   689  H  HZ2  . LYS A 1 50 ? -6.990  -8.714  5.524   1.00 0.00 ? 50 LYS A HZ2  1 
+ATOM   690  H  HZ3  . LYS A 1 50 ? -5.902  -7.408  5.537   1.00 0.00 ? 50 LYS A HZ3  1 
+ATOM   691  N  N    . ILE A 1 51 ? -3.866  -3.352  5.882   1.00 0.00 ? 51 ILE A N    1 
+ATOM   692  C  CA   . ILE A 1 51 ? -2.671  -3.921  6.570   1.00 0.00 ? 51 ILE A CA   1 
+ATOM   693  C  C    . ILE A 1 51 ? -1.449  -3.924  5.644   1.00 0.00 ? 51 ILE A C    1 
+ATOM   694  O  O    . ILE A 1 51 ? -0.837  -4.950  5.420   1.00 0.00 ? 51 ILE A O    1 
+ATOM   695  C  CB   . ILE A 1 51 ? -2.973  -5.347  7.022   1.00 0.00 ? 51 ILE A CB   1 
+ATOM   696  C  CG1  . ILE A 1 51 ? -4.245  -5.359  7.876   1.00 0.00 ? 51 ILE A CG1  1 
+ATOM   697  C  CG2  . ILE A 1 51 ? -1.801  -5.882  7.847   1.00 0.00 ? 51 ILE A CG2  1 
+ATOM   698  C  CD1  . ILE A 1 51 ? -4.220  -4.191  8.864   1.00 0.00 ? 51 ILE A CD1  1 
+ATOM   699  H  H    . ILE A 1 51 ? -4.176  -2.463  6.124   1.00 0.00 ? 51 ILE A H    1 
+ATOM   700  H  HA   . ILE A 1 51 ? -2.449  -3.318  7.437   1.00 0.00 ? 51 ILE A HA   1 
+ATOM   701  H  HB   . ILE A 1 51 ? -3.115  -5.968  6.157   1.00 0.00 ? 51 ILE A HB   1 
+ATOM   702  H  HG12 . ILE A 1 51 ? -5.108  -5.268  7.234   1.00 0.00 ? 51 ILE A HG12 1 
+ATOM   703  H  HG13 . ILE A 1 51 ? -4.301  -6.288  8.423   1.00 0.00 ? 51 ILE A HG13 1 
+ATOM   704  H  HG21 . ILE A 1 51 ? -1.386  -5.084  8.445   1.00 0.00 ? 51 ILE A HG21 1 
+ATOM   705  H  HG22 . ILE A 1 51 ? -2.148  -6.673  8.495   1.00 0.00 ? 51 ILE A HG22 1 
+ATOM   706  H  HG23 . ILE A 1 51 ? -1.040  -6.267  7.183   1.00 0.00 ? 51 ILE A HG23 1 
+ATOM   707  H  HD11 . ILE A 1 51 ? -3.286  -4.198  9.407   1.00 0.00 ? 51 ILE A HD11 1 
+ATOM   708  H  HD12 . ILE A 1 51 ? -4.315  -3.260  8.323   1.00 0.00 ? 51 ILE A HD12 1 
+ATOM   709  H  HD13 . ILE A 1 51 ? -5.040  -4.289  9.558   1.00 0.00 ? 51 ILE A HD13 1 
+ATOM   710  N  N    . THR A 1 52 ? -1.066  -2.781  5.132   1.00 0.00 ? 52 THR A N    1 
+ATOM   711  C  CA   . THR A 1 52 ? 0.146   -2.723  4.255   1.00 0.00 ? 52 THR A CA   1 
+ATOM   712  C  C    . THR A 1 52 ? 1.243   -3.534  4.937   1.00 0.00 ? 52 THR A C    1 
+ATOM   713  O  O    . THR A 1 52 ? 2.039   -4.193  4.304   1.00 0.00 ? 52 THR A O    1 
+ATOM   714  C  CB   . THR A 1 52 ? 0.608   -1.264  4.096   1.00 0.00 ? 52 THR A CB   1 
+ATOM   715  O  OG1  . THR A 1 52 ? -0.130  -0.642  3.055   1.00 0.00 ? 52 THR A OG1  1 
+ATOM   716  C  CG2  . THR A 1 52 ? 2.098   -1.217  3.746   1.00 0.00 ? 52 THR A CG2  1 
+ATOM   717  H  H    . THR A 1 52 ? -1.557  -1.965  5.347   1.00 0.00 ? 52 THR A H    1 
+ATOM   718  H  HA   . THR A 1 52 ? -0.075  -3.145  3.287   1.00 0.00 ? 52 THR A HA   1 
+ATOM   719  H  HB   . THR A 1 52 ? 0.444   -0.732  5.020   1.00 0.00 ? 52 THR A HB   1 
+ATOM   720  H  HG1  . THR A 1 52 ? 0.407   -0.655  2.260   1.00 0.00 ? 52 THR A HG1  1 
+ATOM   721  H  HG21 . THR A 1 52 ? 2.422   -2.194  3.420   1.00 0.00 ? 52 THR A HG21 1 
+ATOM   722  H  HG22 . THR A 1 52 ? 2.255   -0.502  2.954   1.00 0.00 ? 52 THR A HG22 1 
+ATOM   723  H  HG23 . THR A 1 52 ? 2.664   -0.921  4.616   1.00 0.00 ? 52 THR A HG23 1 
+ATOM   724  N  N    . ALA A 1 53 ? 1.259   -3.471  6.236   1.00 0.00 ? 53 ALA A N    1 
+ATOM   725  C  CA   . ALA A 1 53 ? 2.266   -4.217  7.049   1.00 0.00 ? 53 ALA A CA   1 
+ATOM   726  C  C    . ALA A 1 53 ? 3.609   -4.309  6.319   1.00 0.00 ? 53 ALA A C    1 
+ATOM   727  O  O    . ALA A 1 53 ? 4.349   -5.255  6.499   1.00 0.00 ? 53 ALA A O    1 
+ATOM   728  C  CB   . ALA A 1 53 ? 1.746   -5.629  7.325   1.00 0.00 ? 53 ALA A CB   1 
+ATOM   729  H  H    . ALA A 1 53 ? 0.585   -2.922  6.686   1.00 0.00 ? 53 ALA A H    1 
+ATOM   730  H  HA   . ALA A 1 53 ? 2.410   -3.707  7.989   1.00 0.00 ? 53 ALA A HA   1 
+ATOM   731  H  HB1  . ALA A 1 53 ? 0.785   -5.760  6.849   1.00 0.00 ? 53 ALA A HB1  1 
+ATOM   732  H  HB2  . ALA A 1 53 ? 2.444   -6.354  6.932   1.00 0.00 ? 53 ALA A HB2  1 
+ATOM   733  H  HB3  . ALA A 1 53 ? 1.641   -5.773  8.390   1.00 0.00 ? 53 ALA A HB3  1 
+ATOM   734  N  N    . GLY A 1 54 ? 3.939   -3.349  5.499   1.00 0.00 ? 54 GLY A N    1 
+ATOM   735  C  CA   . GLY A 1 54 ? 5.237   -3.425  4.781   1.00 0.00 ? 54 GLY A CA   1 
+ATOM   736  C  C    . GLY A 1 54 ? 5.810   -2.022  4.573   1.00 0.00 ? 54 GLY A C    1 
+ATOM   737  O  O    . GLY A 1 54 ? 6.506   -1.491  5.414   1.00 0.00 ? 54 GLY A O    1 
+ATOM   738  H  H    . GLY A 1 54 ? 3.338   -2.590  5.351   1.00 0.00 ? 54 GLY A H    1 
+ATOM   739  H  HA2  . GLY A 1 54 ? 5.933   -4.014  5.363   1.00 0.00 ? 54 GLY A HA2  1 
+ATOM   740  H  HA3  . GLY A 1 54 ? 5.088   -3.894  3.821   1.00 0.00 ? 54 GLY A HA3  1 
+ATOM   741  N  N    . SER A 1 55 ? 5.535   -1.430  3.445   1.00 0.00 ? 55 SER A N    1 
+ATOM   742  C  CA   . SER A 1 55 ? 6.074   -0.073  3.157   1.00 0.00 ? 55 SER A CA   1 
+ATOM   743  C  C    . SER A 1 55 ? 5.911   0.843   4.372   1.00 0.00 ? 55 SER A C    1 
+ATOM   744  O  O    . SER A 1 55 ? 4.812   1.142   4.796   1.00 0.00 ? 55 SER A O    1 
+ATOM   745  C  CB   . SER A 1 55 ? 5.325   0.534   1.972   1.00 0.00 ? 55 SER A CB   1 
+ATOM   746  O  OG   . SER A 1 55 ? 3.929   0.466   2.213   1.00 0.00 ? 55 SER A OG   1 
+ATOM   747  H  H    . SER A 1 55 ? 4.983   -1.888  2.776   1.00 0.00 ? 55 SER A H    1 
+ATOM   748  H  HA   . SER A 1 55 ? 7.120   -0.154  2.909   1.00 0.00 ? 55 SER A HA   1 
+ATOM   749  H  HB2  . SER A 1 55 ? 5.612   1.565   1.855   1.00 0.00 ? 55 SER A HB2  1 
+ATOM   750  H  HB3  . SER A 1 55 ? 5.573   -0.012  1.073   1.00 0.00 ? 55 SER A HB3  1 
+ATOM   751  H  HG   . SER A 1 55 ? 3.552   -0.169  1.600   1.00 0.00 ? 55 SER A HG   1 
+ATOM   752  N  N    . VAL A 1 56 ? 7.000   1.311   4.920   1.00 0.00 ? 56 VAL A N    1 
+ATOM   753  C  CA   . VAL A 1 56 ? 6.916   2.225   6.079   1.00 0.00 ? 56 VAL A CA   1 
+ATOM   754  C  C    . VAL A 1 56 ? 6.858   3.661   5.561   1.00 0.00 ? 56 VAL A C    1 
+ATOM   755  O  O    . VAL A 1 56 ? 7.833   4.198   5.074   1.00 0.00 ? 56 VAL A O    1 
+ATOM   756  C  CB   . VAL A 1 56 ? 8.129   2.039   7.001   1.00 0.00 ? 56 VAL A CB   1 
+ATOM   757  C  CG1  . VAL A 1 56 ? 8.049   0.670   7.679   1.00 0.00 ? 56 VAL A CG1  1 
+ATOM   758  C  CG2  . VAL A 1 56 ? 9.427   2.125   6.195   1.00 0.00 ? 56 VAL A CG2  1 
+ATOM   759  H  H    . VAL A 1 56 ? 7.863   1.074   4.557   1.00 0.00 ? 56 VAL A H    1 
+ATOM   760  H  HA   . VAL A 1 56 ? 6.022   2.007   6.617   1.00 0.00 ? 56 VAL A HA   1 
+ATOM   761  H  HB   . VAL A 1 56 ? 8.124   2.812   7.756   1.00 0.00 ? 56 VAL A HB   1 
+ATOM   762  H  HG11 . VAL A 1 56 ? 7.871   -0.091  6.934   1.00 0.00 ? 56 VAL A HG11 1 
+ATOM   763  H  HG12 . VAL A 1 56 ? 8.978   0.466   8.189   1.00 0.00 ? 56 VAL A HG12 1 
+ATOM   764  H  HG13 . VAL A 1 56 ? 7.238   0.670   8.393   1.00 0.00 ? 56 VAL A HG13 1 
+ATOM   765  H  HG21 . VAL A 1 56 ? 9.438   1.354   5.440   1.00 0.00 ? 56 VAL A HG21 1 
+ATOM   766  H  HG22 . VAL A 1 56 ? 9.493   3.094   5.723   1.00 0.00 ? 56 VAL A HG22 1 
+ATOM   767  H  HG23 . VAL A 1 56 ? 10.270  1.991   6.856   1.00 0.00 ? 56 VAL A HG23 1 
+ATOM   768  N  N    . ASP A 1 57 ? 5.710   4.276   5.635   1.00 0.00 ? 57 ASP A N    1 
+ATOM   769  C  CA   . ASP A 1 57 ? 5.573   5.657   5.120   1.00 0.00 ? 57 ASP A CA   1 
+ATOM   770  C  C    . ASP A 1 57 ? 6.609   6.568   5.775   1.00 0.00 ? 57 ASP A C    1 
+ATOM   771  O  O    . ASP A 1 57 ? 7.432   7.137   5.103   1.00 0.00 ? 57 ASP A O    1 
+ATOM   772  C  CB   . ASP A 1 57 ? 4.130   6.160   5.357   1.00 0.00 ? 57 ASP A CB   1 
+ATOM   773  C  CG   . ASP A 1 57 ? 4.085   7.280   6.403   1.00 0.00 ? 57 ASP A CG   1 
+ATOM   774  O  OD1  . ASP A 1 57 ? 4.415   8.401   6.054   1.00 0.00 ? 57 ASP A OD1  1 
+ATOM   775  O  OD2  . ASP A 1 57 ? 3.723   6.995   7.533   1.00 0.00 ? 57 ASP A OD2  1 
+ATOM   776  H  H    . ASP A 1 57 ? 4.938   3.821   6.010   1.00 0.00 ? 57 ASP A H    1 
+ATOM   777  H  HA   . ASP A 1 57 ? 5.762   5.640   4.068   1.00 0.00 ? 57 ASP A HA   1 
+ATOM   778  H  HB2  . ASP A 1 57 ? 3.732   6.533   4.424   1.00 0.00 ? 57 ASP A HB2  1 
+ATOM   779  H  HB3  . ASP A 1 57 ? 3.520   5.334   5.693   1.00 0.00 ? 57 ASP A HB3  1 
+ATOM   780  N  N    . GLN A 1 58 ? 6.565   6.710   7.069   1.00 0.00 ? 58 GLN A N    1 
+ATOM   781  C  CA   . GLN A 1 58 ? 7.544   7.594   7.764   1.00 0.00 ? 58 GLN A CA   1 
+ATOM   782  C  C    . GLN A 1 58 ? 7.070   9.046   7.667   1.00 0.00 ? 58 GLN A C    1 
+ATOM   783  O  O    . GLN A 1 58 ? 6.887   9.714   8.665   1.00 0.00 ? 58 GLN A O    1 
+ATOM   784  C  CB   . GLN A 1 58 ? 8.926   7.460   7.120   1.00 0.00 ? 58 GLN A CB   1 
+ATOM   785  C  CG   . GLN A 1 58 ? 9.994   7.942   8.101   1.00 0.00 ? 58 GLN A CG   1 
+ATOM   786  C  CD   . GLN A 1 58 ? 10.297  6.831   9.108   1.00 0.00 ? 58 GLN A CD   1 
+ATOM   787  O  OE1  . GLN A 1 58 ? 11.182  6.027   8.894   1.00 0.00 ? 58 GLN A OE1  1 
+ATOM   788  N  NE2  . GLN A 1 58 ? 9.593   6.751   10.203  1.00 0.00 ? 58 GLN A NE2  1 
+ATOM   789  H  H    . GLN A 1 58 ? 5.880   6.239   7.583   1.00 0.00 ? 58 GLN A H    1 
+ATOM   790  H  HA   . GLN A 1 58 ? 7.605   7.311   8.804   1.00 0.00 ? 58 GLN A HA   1 
+ATOM   791  H  HB2  . GLN A 1 58 ? 9.105   6.424   6.871   1.00 0.00 ? 58 GLN A HB2  1 
+ATOM   792  H  HB3  . GLN A 1 58 ? 8.964   8.060   6.223   1.00 0.00 ? 58 GLN A HB3  1 
+ATOM   793  H  HG2  . GLN A 1 58 ? 10.892  8.194   7.559   1.00 0.00 ? 58 GLN A HG2  1 
+ATOM   794  H  HG3  . GLN A 1 58 ? 9.633   8.813   8.628   1.00 0.00 ? 58 GLN A HG3  1 
+ATOM   795  H  HE21 . GLN A 1 58 ? 8.878   7.399   10.375  1.00 0.00 ? 58 GLN A HE21 1 
+ATOM   796  H  HE22 . GLN A 1 58 ? 9.779   6.042   10.854  1.00 0.00 ? 58 GLN A HE22 1 
+ATOM   797  N  N    . SER A 1 59 ? 6.863   9.545   6.477   1.00 0.00 ? 59 SER A N    1 
+ATOM   798  C  CA   . SER A 1 59 ? 6.398   10.951  6.339   1.00 0.00 ? 59 SER A CA   1 
+ATOM   799  C  C    . SER A 1 59 ? 4.871   11.002  6.462   1.00 0.00 ? 59 SER A C    1 
+ATOM   800  O  O    . SER A 1 59 ? 4.197   11.614  5.657   1.00 0.00 ? 59 SER A O    1 
+ATOM   801  C  CB   . SER A 1 59 ? 6.819   11.493  4.973   1.00 0.00 ? 59 SER A CB   1 
+ATOM   802  O  OG   . SER A 1 59 ? 7.110   10.404  4.108   1.00 0.00 ? 59 SER A OG   1 
+ATOM   803  H  H    . SER A 1 59 ? 7.015   8.996   5.674   1.00 0.00 ? 59 SER A H    1 
+ATOM   804  H  HA   . SER A 1 59 ? 6.841   11.554  7.117   1.00 0.00 ? 59 SER A HA   1 
+ATOM   805  H  HB2  . SER A 1 59 ? 6.017   12.075  4.552   1.00 0.00 ? 59 SER A HB2  1 
+ATOM   806  H  HB3  . SER A 1 59 ? 7.693   12.119  5.090   1.00 0.00 ? 59 SER A HB3  1 
+ATOM   807  H  HG   . SER A 1 59 ? 7.306   10.761  3.238   1.00 0.00 ? 59 SER A HG   1 
+ATOM   808  N  N    . ASP A 1 60 ? 4.316   10.363  7.460   1.00 0.00 ? 60 ASP A N    1 
+ATOM   809  C  CA   . ASP A 1 60 ? 2.835   10.381  7.618   1.00 0.00 ? 60 ASP A CA   1 
+ATOM   810  C  C    . ASP A 1 60 ? 2.372   11.810  7.901   1.00 0.00 ? 60 ASP A C    1 
+ATOM   811  O  O    . ASP A 1 60 ? 1.535   12.350  7.205   1.00 0.00 ? 60 ASP A O    1 
+ATOM   812  C  CB   . ASP A 1 60 ? 2.430   9.470   8.781   1.00 0.00 ? 60 ASP A CB   1 
+ATOM   813  C  CG   . ASP A 1 60 ? 3.409   9.651   9.944   1.00 0.00 ? 60 ASP A CG   1 
+ATOM   814  O  OD1  . ASP A 1 60 ? 4.428   8.981   9.945   1.00 0.00 ? 60 ASP A OD1  1 
+ATOM   815  O  OD2  . ASP A 1 60 ? 3.118   10.452  10.817  1.00 0.00 ? 60 ASP A OD2  1 
+ATOM   816  H  H    . ASP A 1 60 ? 4.871   9.871   8.102   1.00 0.00 ? 60 ASP A H    1 
+ATOM   817  H  HA   . ASP A 1 60 ? 2.372   10.028  6.709   1.00 0.00 ? 60 ASP A HA   1 
+ATOM   818  H  HB2  . ASP A 1 60 ? 1.432   9.724   9.106   1.00 0.00 ? 60 ASP A HB2  1 
+ATOM   819  H  HB3  . ASP A 1 60 ? 2.451   8.440   8.454   1.00 0.00 ? 60 ASP A HB3  1 
+ATOM   820  N  N    . GLN A 1 61 ? 2.914   12.429  8.917   1.00 0.00 ? 61 GLN A N    1 
+ATOM   821  C  CA   . GLN A 1 61 ? 2.509   13.826  9.244   1.00 0.00 ? 61 GLN A CA   1 
+ATOM   822  C  C    . GLN A 1 61 ? 0.991   13.967  9.112   1.00 0.00 ? 61 GLN A C    1 
+ATOM   823  O  O    . GLN A 1 61 ? 0.248   13.033  9.343   1.00 0.00 ? 61 GLN A O    1 
+ATOM   824  C  CB   . GLN A 1 61 ? 3.197   14.793  8.279   1.00 0.00 ? 61 GLN A CB   1 
+ATOM   825  C  CG   . GLN A 1 61 ? 4.692   14.471  8.218   1.00 0.00 ? 61 GLN A CG   1 
+ATOM   826  C  CD   . GLN A 1 61 ? 5.119   14.300  6.759   1.00 0.00 ? 61 GLN A CD   1 
+ATOM   827  O  OE1  . GLN A 1 61 ? 4.355   14.573  5.854   1.00 0.00 ? 61 GLN A OE1  1 
+ATOM   828  N  NE2  . GLN A 1 61 ? 6.318   13.859  6.490   1.00 0.00 ? 61 GLN A NE2  1 
+ATOM   829  H  H    . GLN A 1 61 ? 3.590   11.976  9.461   1.00 0.00 ? 61 GLN A H    1 
+ATOM   830  H  HA   . GLN A 1 61 ? 2.804   14.059  10.256  1.00 0.00 ? 61 GLN A HA   1 
+ATOM   831  H  HB2  . GLN A 1 61 ? 2.764   14.686  7.294   1.00 0.00 ? 61 GLN A HB2  1 
+ATOM   832  H  HB3  . GLN A 1 61 ? 3.064   15.806  8.625   1.00 0.00 ? 61 GLN A HB3  1 
+ATOM   833  H  HG2  . GLN A 1 61 ? 5.252   15.278  8.667   1.00 0.00 ? 61 GLN A HG2  1 
+ATOM   834  H  HG3  . GLN A 1 61 ? 4.885   13.555  8.756   1.00 0.00 ? 61 GLN A HG3  1 
+ATOM   835  H  HE21 . GLN A 1 61 ? 6.934   13.639  7.220   1.00 0.00 ? 61 GLN A HE21 1 
+ATOM   836  H  HE22 . GLN A 1 61 ? 6.600   13.745  5.559   1.00 0.00 ? 61 GLN A HE22 1 
+ATOM   837  N  N    . SER A 1 62 ? 0.524   15.128  8.742   1.00 0.00 ? 62 SER A N    1 
+ATOM   838  C  CA   . SER A 1 62 ? -0.945  15.330  8.595   1.00 0.00 ? 62 SER A CA   1 
+ATOM   839  C  C    . SER A 1 62 ? -1.473  14.436  7.470   1.00 0.00 ? 62 SER A C    1 
+ATOM   840  O  O    . SER A 1 62 ? -2.533  13.852  7.575   1.00 0.00 ? 62 SER A O    1 
+ATOM   841  C  CB   . SER A 1 62 ? -1.225  16.795  8.256   1.00 0.00 ? 62 SER A CB   1 
+ATOM   842  O  OG   . SER A 1 62 ? -2.615  16.966  8.017   1.00 0.00 ? 62 SER A OG   1 
+ATOM   843  H  H    . SER A 1 62 ? 1.139   15.869  8.560   1.00 0.00 ? 62 SER A H    1 
+ATOM   844  H  HA   . SER A 1 62 ? -1.439  15.074  9.521   1.00 0.00 ? 62 SER A HA   1 
+ATOM   845  H  HB2  . SER A 1 62 ? -0.928  17.421  9.082   1.00 0.00 ? 62 SER A HB2  1 
+ATOM   846  H  HB3  . SER A 1 62 ? -0.661  17.073  7.376   1.00 0.00 ? 62 SER A HB3  1 
+ATOM   847  H  HG   . SER A 1 62 ? -2.826  17.894  8.143   1.00 0.00 ? 62 SER A HG   1 
+ATOM   848  N  N    . PHE A 1 63 ? -0.741  14.323  6.395   1.00 0.00 ? 63 PHE A N    1 
+ATOM   849  C  CA   . PHE A 1 63 ? -1.200  13.466  5.266   1.00 0.00 ? 63 PHE A CA   1 
+ATOM   850  C  C    . PHE A 1 63 ? -1.383  12.030  5.755   1.00 0.00 ? 63 PHE A C    1 
+ATOM   851  O  O    . PHE A 1 63 ? -0.678  11.566  6.629   1.00 0.00 ? 63 PHE A O    1 
+ATOM   852  C  CB   . PHE A 1 63 ? -0.156  13.489  4.148   1.00 0.00 ? 63 PHE A CB   1 
+ATOM   853  C  CG   . PHE A 1 63 ? -0.013  14.894  3.615   1.00 0.00 ? 63 PHE A CG   1 
+ATOM   854  C  CD1  . PHE A 1 63 ? -1.119  15.554  3.067   1.00 0.00 ? 63 PHE A CD1  1 
+ATOM   855  C  CD2  . PHE A 1 63 ? 1.230   15.537  3.669   1.00 0.00 ? 63 PHE A CD2  1 
+ATOM   856  C  CE1  . PHE A 1 63 ? -0.983  16.857  2.571   1.00 0.00 ? 63 PHE A CE1  1 
+ATOM   857  C  CE2  . PHE A 1 63 ? 1.366   16.839  3.173   1.00 0.00 ? 63 PHE A CE2  1 
+ATOM   858  C  CZ   . PHE A 1 63 ? 0.260   17.499  2.625   1.00 0.00 ? 63 PHE A CZ   1 
+ATOM   859  H  H    . PHE A 1 63 ? 0.112   14.803  6.332   1.00 0.00 ? 63 PHE A H    1 
+ATOM   860  H  HA   . PHE A 1 63 ? -2.140  13.842  4.888   1.00 0.00 ? 63 PHE A HA   1 
+ATOM   861  H  HB2  . PHE A 1 63 ? 0.794   13.152  4.537   1.00 0.00 ? 63 PHE A HB2  1 
+ATOM   862  H  HB3  . PHE A 1 63 ? -0.470  12.833  3.350   1.00 0.00 ? 63 PHE A HB3  1 
+ATOM   863  H  HD1  . PHE A 1 63 ? -2.078  15.057  3.026   1.00 0.00 ? 63 PHE A HD1  1 
+ATOM   864  H  HD2  . PHE A 1 63 ? 2.083   15.028  4.091   1.00 0.00 ? 63 PHE A HD2  1 
+ATOM   865  H  HE1  . PHE A 1 63 ? -1.837  17.366  2.149   1.00 0.00 ? 63 PHE A HE1  1 
+ATOM   866  H  HE2  . PHE A 1 63 ? 2.324   17.334  3.214   1.00 0.00 ? 63 PHE A HE2  1 
+ATOM   867  H  HZ   . PHE A 1 63 ? 0.365   18.504  2.243   1.00 0.00 ? 63 PHE A HZ   1 
+ATOM   868  N  N    . LEU A 1 64 ? -2.321  11.318  5.193   1.00 0.00 ? 64 LEU A N    1 
+ATOM   869  C  CA   . LEU A 1 64 ? -2.542  9.908   5.621   1.00 0.00 ? 64 LEU A CA   1 
+ATOM   870  C  C    . LEU A 1 64 ? -1.450  9.023   5.021   1.00 0.00 ? 64 LEU A C    1 
+ATOM   871  O  O    . LEU A 1 64 ? -0.853  9.356   4.017   1.00 0.00 ? 64 LEU A O    1 
+ATOM   872  C  CB   . LEU A 1 64 ? -3.912  9.436   5.130   1.00 0.00 ? 64 LEU A CB   1 
+ATOM   873  C  CG   . LEU A 1 64 ? -4.994  9.921   6.095   1.00 0.00 ? 64 LEU A CG   1 
+ATOM   874  C  CD1  . LEU A 1 64 ? -6.373  9.621   5.507   1.00 0.00 ? 64 LEU A CD1  1 
+ATOM   875  C  CD2  . LEU A 1 64 ? -4.843  9.198   7.435   1.00 0.00 ? 64 LEU A CD2  1 
+ATOM   876  H  H    . LEU A 1 64 ? -2.875  11.708  4.486   1.00 0.00 ? 64 LEU A H    1 
+ATOM   877  H  HA   . LEU A 1 64 ? -2.505  9.848   6.698   1.00 0.00 ? 64 LEU A HA   1 
+ATOM   878  H  HB2  . LEU A 1 64 ? -4.098  9.838   4.145   1.00 0.00 ? 64 LEU A HB2  1 
+ATOM   879  H  HB3  . LEU A 1 64 ? -3.927  8.357   5.088   1.00 0.00 ? 64 LEU A HB3  1 
+ATOM   880  H  HG   . LEU A 1 64 ? -4.891  10.987  6.244   1.00 0.00 ? 64 LEU A HG   1 
+ATOM   881  H  HD11 . LEU A 1 64 ? -6.300  9.562   4.431   1.00 0.00 ? 64 LEU A HD11 1 
+ATOM   882  H  HD12 . LEU A 1 64 ? -6.733  8.679   5.895   1.00 0.00 ? 64 LEU A HD12 1 
+ATOM   883  H  HD13 . LEU A 1 64 ? -7.060  10.408  5.779   1.00 0.00 ? 64 LEU A HD13 1 
+ATOM   884  H  HD21 . LEU A 1 64 ? -3.939  8.607   7.426   1.00 0.00 ? 64 LEU A HD21 1 
+ATOM   885  H  HD22 . LEU A 1 64 ? -4.789  9.924   8.233   1.00 0.00 ? 64 LEU A HD22 1 
+ATOM   886  H  HD23 . LEU A 1 64 ? -5.694  8.551   7.594   1.00 0.00 ? 64 LEU A HD23 1 
+ATOM   887  N  N    . ASP A 1 65 ? -1.175  7.900   5.626   1.00 0.00 ? 65 ASP A N    1 
+ATOM   888  C  CA   . ASP A 1 65 ? -0.115  7.009   5.081   1.00 0.00 ? 65 ASP A CA   1 
+ATOM   889  C  C    . ASP A 1 65 ? -0.213  5.626   5.725   1.00 0.00 ? 65 ASP A C    1 
+ATOM   890  O  O    . ASP A 1 65 ? -0.659  4.674   5.115   1.00 0.00 ? 65 ASP A O    1 
+ATOM   891  C  CB   . ASP A 1 65 ? 1.256   7.606   5.388   1.00 0.00 ? 65 ASP A CB   1 
+ATOM   892  C  CG   . ASP A 1 65 ? 1.901   8.104   4.094   1.00 0.00 ? 65 ASP A CG   1 
+ATOM   893  O  OD1  . ASP A 1 65 ? 2.040   7.308   3.179   1.00 0.00 ? 65 ASP A OD1  1 
+ATOM   894  O  OD2  . ASP A 1 65 ? 2.244   9.274   4.038   1.00 0.00 ? 65 ASP A OD2  1 
+ATOM   895  H  H    . ASP A 1 65 ? -1.663  7.647   6.438   1.00 0.00 ? 65 ASP A H    1 
+ATOM   896  H  HA   . ASP A 1 65 ? -0.235  6.920   4.014   1.00 0.00 ? 65 ASP A HA   1 
+ATOM   897  H  HB2  . ASP A 1 65 ? 1.144   8.430   6.078   1.00 0.00 ? 65 ASP A HB2  1 
+ATOM   898  H  HB3  . ASP A 1 65 ? 1.883   6.848   5.831   1.00 0.00 ? 65 ASP A HB3  1 
+ATOM   899  N  N    . ASP A 1 66 ? 0.206   5.511   6.954   1.00 0.00 ? 66 ASP A N    1 
+ATOM   900  C  CA   . ASP A 1 66 ? 0.152   4.204   7.645   1.00 0.00 ? 66 ASP A CA   1 
+ATOM   901  C  C    . ASP A 1 66 ? -0.165  4.425   9.120   1.00 0.00 ? 66 ASP A C    1 
+ATOM   902  O  O    . ASP A 1 66 ? 0.092   3.582   9.955   1.00 0.00 ? 66 ASP A O    1 
+ATOM   903  C  CB   . ASP A 1 66 ? 1.502   3.501   7.507   1.00 0.00 ? 66 ASP A CB   1 
+ATOM   904  C  CG   . ASP A 1 66 ? 1.525   2.694   6.208   1.00 0.00 ? 66 ASP A CG   1 
+ATOM   905  O  OD1  . ASP A 1 66 ? 0.459   2.440   5.673   1.00 0.00 ? 66 ASP A OD1  1 
+ATOM   906  O  OD2  . ASP A 1 66 ? 2.609   2.343   5.771   1.00 0.00 ? 66 ASP A OD2  1 
+ATOM   907  H  H    . ASP A 1 66 ? 0.560   6.283   7.420   1.00 0.00 ? 66 ASP A H    1 
+ATOM   908  H  HA   . ASP A 1 66 ? -0.609  3.607   7.205   1.00 0.00 ? 66 ASP A HA   1 
+ATOM   909  H  HB2  . ASP A 1 66 ? 2.290   4.240   7.488   1.00 0.00 ? 66 ASP A HB2  1 
+ATOM   910  H  HB3  . ASP A 1 66 ? 1.649   2.839   8.344   1.00 0.00 ? 66 ASP A HB3  1 
+ATOM   911  N  N    . ASP A 1 67 ? -0.709  5.569   9.439   1.00 0.00 ? 67 ASP A N    1 
+ATOM   912  C  CA   . ASP A 1 67 ? -1.038  5.896   10.853  1.00 0.00 ? 67 ASP A CA   1 
+ATOM   913  C  C    . ASP A 1 67 ? 0.231   6.407   11.538  1.00 0.00 ? 67 ASP A C    1 
+ATOM   914  O  O    . ASP A 1 67 ? 0.211   7.404   12.233  1.00 0.00 ? 67 ASP A O    1 
+ATOM   915  C  CB   . ASP A 1 67 ? -1.579  4.662   11.580  1.00 0.00 ? 67 ASP A CB   1 
+ATOM   916  C  CG   . ASP A 1 67 ? -2.906  5.014   12.255  1.00 0.00 ? 67 ASP A CG   1 
+ATOM   917  O  OD1  . ASP A 1 67 ? -2.869  5.678   13.278  1.00 0.00 ? 67 ASP A OD1  1 
+ATOM   918  O  OD2  . ASP A 1 67 ? -3.936  4.616   11.736  1.00 0.00 ? 67 ASP A OD2  1 
+ATOM   919  H  H    . ASP A 1 67 ? -0.889  6.225   8.740   1.00 0.00 ? 67 ASP A H    1 
+ATOM   920  H  HA   . ASP A 1 67 ? -1.786  6.677   10.870  1.00 0.00 ? 67 ASP A HA   1 
+ATOM   921  H  HB2  . ASP A 1 67 ? -1.739  3.864   10.870  1.00 0.00 ? 67 ASP A HB2  1 
+ATOM   922  H  HB3  . ASP A 1 67 ? -0.873  4.346   12.328  1.00 0.00 ? 67 ASP A HB3  1 
+ATOM   923  N  N    . GLN A 1 68 ? 1.345   5.750   11.332  1.00 0.00 ? 68 GLN A N    1 
+ATOM   924  C  CA   . GLN A 1 68 ? 2.610   6.228   11.956  1.00 0.00 ? 68 GLN A CA   1 
+ATOM   925  C  C    . GLN A 1 68 ? 3.812   5.640   11.210  1.00 0.00 ? 68 GLN A C    1 
+ATOM   926  O  O    . GLN A 1 68 ? 4.805   6.309   11.011  1.00 0.00 ? 68 GLN A O    1 
+ATOM   927  C  CB   . GLN A 1 68 ? 2.657   5.812   13.432  1.00 0.00 ? 68 GLN A CB   1 
+ATOM   928  C  CG   . GLN A 1 68 ? 2.597   4.286   13.553  1.00 0.00 ? 68 GLN A CG   1 
+ATOM   929  C  CD   . GLN A 1 68 ? 1.163   3.808   13.314  1.00 0.00 ? 68 GLN A CD   1 
+ATOM   930  O  OE1  . GLN A 1 68 ? 0.271   4.124   14.076  1.00 0.00 ? 68 GLN A OE1  1 
+ATOM   931  N  NE2  . GLN A 1 68 ? 0.901   3.051   12.282  1.00 0.00 ? 68 GLN A NE2  1 
+ATOM   932  H  H    . GLN A 1 68 ? 1.352   4.954   10.759  1.00 0.00 ? 68 GLN A H    1 
+ATOM   933  H  HA   . GLN A 1 68 ? 2.653   7.308   11.887  1.00 0.00 ? 68 GLN A HA   1 
+ATOM   934  H  HB2  . GLN A 1 68 ? 3.576   6.172   13.876  1.00 0.00 ? 68 GLN A HB2  1 
+ATOM   935  H  HB3  . GLN A 1 68 ? 1.816   6.245   13.953  1.00 0.00 ? 68 GLN A HB3  1 
+ATOM   936  H  HG2  . GLN A 1 68 ? 3.254   3.841   12.822  1.00 0.00 ? 68 GLN A HG2  1 
+ATOM   937  H  HG3  . GLN A 1 68 ? 2.910   3.993   14.544  1.00 0.00 ? 68 GLN A HG3  1 
+ATOM   938  H  HE21 . GLN A 1 68 ? 1.619   2.796   11.668  1.00 0.00 ? 68 GLN A HE21 1 
+ATOM   939  H  HE22 . GLN A 1 68 ? -0.012  2.735   12.125  1.00 0.00 ? 68 GLN A HE22 1 
+ATOM   940  N  N    . ILE A 1 69 ? 3.727   4.404   10.787  1.00 0.00 ? 69 ILE A N    1 
+ATOM   941  C  CA   . ILE A 1 69 ? 4.874   3.778   10.051  1.00 0.00 ? 69 ILE A CA   1 
+ATOM   942  C  C    . ILE A 1 69 ? 4.615   2.282   9.829   1.00 0.00 ? 69 ILE A C    1 
+ATOM   943  O  O    . ILE A 1 69 ? 5.538   1.503   9.704   1.00 0.00 ? 69 ILE A O    1 
+ATOM   944  C  CB   . ILE A 1 69 ? 6.166   3.936   10.866  1.00 0.00 ? 69 ILE A CB   1 
+ATOM   945  C  CG1  . ILE A 1 69 ? 7.366   3.602   9.980   1.00 0.00 ? 69 ILE A CG1  1 
+ATOM   946  C  CG2  . ILE A 1 69 ? 6.141   2.983   12.064  1.00 0.00 ? 69 ILE A CG2  1 
+ATOM   947  C  CD1  . ILE A 1 69 ? 7.804   4.857   9.224   1.00 0.00 ? 69 ILE A CD1  1 
+ATOM   948  H  H    . ILE A 1 69 ? 2.908   3.892   10.949  1.00 0.00 ? 69 ILE A H    1 
+ATOM   949  H  HA   . ILE A 1 69 ? 4.991   4.264   9.094   1.00 0.00 ? 69 ILE A HA   1 
+ATOM   950  H  HB   . ILE A 1 69 ? 6.254   4.950   11.220  1.00 0.00 ? 69 ILE A HB   1 
+ATOM   951  H  HG12 . ILE A 1 69 ? 8.182   3.249   10.596  1.00 0.00 ? 69 ILE A HG12 1 
+ATOM   952  H  HG13 . ILE A 1 69 ? 7.090   2.836   9.274   1.00 0.00 ? 69 ILE A HG13 1 
+ATOM   953  H  HG21 . ILE A 1 69 ? 5.125   2.675   12.257  1.00 0.00 ? 69 ILE A HG21 1 
+ATOM   954  H  HG22 . ILE A 1 69 ? 6.746   2.116   11.845  1.00 0.00 ? 69 ILE A HG22 1 
+ATOM   955  H  HG23 . ILE A 1 69 ? 6.536   3.487   12.933  1.00 0.00 ? 69 ILE A HG23 1 
+ATOM   956  H  HD11 . ILE A 1 69 ? 7.482   5.733   9.767   1.00 0.00 ? 69 ILE A HD11 1 
+ATOM   957  H  HD12 . ILE A 1 69 ? 8.879   4.865   9.129   1.00 0.00 ? 69 ILE A HD12 1 
+ATOM   958  H  HD13 . ILE A 1 69 ? 7.356   4.859   8.240   1.00 0.00 ? 69 ILE A HD13 1 
+ATOM   959  N  N    . GLU A 1 70 ? 3.378   1.875   9.773   1.00 0.00 ? 70 GLU A N    1 
+ATOM   960  C  CA   . GLU A 1 70 ? 3.069   0.439   9.557   1.00 0.00 ? 70 GLU A CA   1 
+ATOM   961  C  C    . GLU A 1 70 ? 1.559   0.241   9.652   1.00 0.00 ? 70 GLU A C    1 
+ATOM   962  O  O    . GLU A 1 70 ? 1.054   -0.291  10.620  1.00 0.00 ? 70 GLU A O    1 
+ATOM   963  C  CB   . GLU A 1 70 ? 3.756   -0.416  10.626  1.00 0.00 ? 70 GLU A CB   1 
+ATOM   964  C  CG   . GLU A 1 70 ? 3.737   -1.883  10.193  1.00 0.00 ? 70 GLU A CG   1 
+ATOM   965  C  CD   . GLU A 1 70 ? 4.699   -2.687  11.070  1.00 0.00 ? 70 GLU A CD   1 
+ATOM   966  O  OE1  . GLU A 1 70 ? 4.328   -2.998  12.189  1.00 0.00 ? 70 GLU A OE1  1 
+ATOM   967  O  OE2  . GLU A 1 70 ? 5.790   -2.977  10.607  1.00 0.00 ? 70 GLU A OE2  1 
+ATOM   968  H  H    . GLU A 1 70 ? 2.649   2.513   9.865   1.00 0.00 ? 70 GLU A H    1 
+ATOM   969  H  HA   . GLU A 1 70 ? 3.410   0.144   8.580   1.00 0.00 ? 70 GLU A HA   1 
+ATOM   970  H  HB2  . GLU A 1 70 ? 4.777   -0.091  10.751  1.00 0.00 ? 70 GLU A HB2  1 
+ATOM   971  H  HB3  . GLU A 1 70 ? 3.230   -0.314  11.563  1.00 0.00 ? 70 GLU A HB3  1 
+ATOM   972  H  HG2  . GLU A 1 70 ? 2.736   -2.277  10.298  1.00 0.00 ? 70 GLU A HG2  1 
+ATOM   973  H  HG3  . GLU A 1 70 ? 4.048   -1.957  9.160   1.00 0.00 ? 70 GLU A HG3  1 
+ATOM   974  N  N    . ALA A 1 71 ? 0.832   0.665   8.659   1.00 0.00 ? 71 ALA A N    1 
+ATOM   975  C  CA   . ALA A 1 71 ? -0.638  0.498   8.702   1.00 0.00 ? 71 ALA A CA   1 
+ATOM   976  C  C    . ALA A 1 71 ? -1.250  0.877   7.352   1.00 0.00 ? 71 ALA A C    1 
+ATOM   977  O  O    . ALA A 1 71 ? -1.819  1.939   7.201   1.00 0.00 ? 71 ALA A O    1 
+ATOM   978  C  CB   . ALA A 1 71 ? -1.222  1.392   9.799   1.00 0.00 ? 71 ALA A CB   1 
+ATOM   979  H  H    . ALA A 1 71 ? 1.252   1.089   7.889   1.00 0.00 ? 71 ALA A H    1 
+ATOM   980  H  HA   . ALA A 1 71 ? -0.860  -0.521  8.924   1.00 0.00 ? 71 ALA A HA   1 
+ATOM   981  H  HB1  . ALA A 1 71 ? -0.455  1.617   10.525  1.00 0.00 ? 71 ALA A HB1  1 
+ATOM   982  H  HB2  . ALA A 1 71 ? -1.583  2.310   9.359   1.00 0.00 ? 71 ALA A HB2  1 
+ATOM   983  H  HB3  . ALA A 1 71 ? -2.038  0.879   10.284  1.00 0.00 ? 71 ALA A HB3  1 
+ATOM   984  N  N    . GLY A 1 72 ? -1.150  0.024   6.364   1.00 0.00 ? 72 GLY A N    1 
+ATOM   985  C  CA   . GLY A 1 72 ? -1.737  0.367   5.038   1.00 0.00 ? 72 GLY A CA   1 
+ATOM   986  C  C    . GLY A 1 72 ? -3.193  0.806   5.214   1.00 0.00 ? 72 GLY A C    1 
+ATOM   987  O  O    . GLY A 1 72 ? -3.765  1.451   4.359   1.00 0.00 ? 72 GLY A O    1 
+ATOM   988  H  H    . GLY A 1 72 ? -0.692  -0.837  6.492   1.00 0.00 ? 72 GLY A H    1 
+ATOM   989  H  HA2  . GLY A 1 72 ? -1.167  1.165   4.601   1.00 0.00 ? 72 GLY A HA2  1 
+ATOM   990  H  HA3  . GLY A 1 72 ? -1.704  -0.493  4.390   1.00 0.00 ? 72 GLY A HA3  1 
+ATOM   991  N  N    . TYR A 1 73 ? -3.793  0.445   6.315   1.00 0.00 ? 73 TYR A N    1 
+ATOM   992  C  CA   . TYR A 1 73 ? -5.218  0.815   6.573   1.00 0.00 ? 73 TYR A CA   1 
+ATOM   993  C  C    . TYR A 1 73 ? -5.534  2.217   6.028   1.00 0.00 ? 73 TYR A C    1 
+ATOM   994  O  O    . TYR A 1 73 ? -6.583  2.443   5.461   1.00 0.00 ? 73 TYR A O    1 
+ATOM   995  C  CB   . TYR A 1 73 ? -5.473  0.794   8.081   1.00 0.00 ? 73 TYR A CB   1 
+ATOM   996  C  CG   . TYR A 1 73 ? -6.625  -0.132  8.391   1.00 0.00 ? 73 TYR A CG   1 
+ATOM   997  C  CD1  . TYR A 1 73 ? -6.688  -1.397  7.795   1.00 0.00 ? 73 TYR A CD1  1 
+ATOM   998  C  CD2  . TYR A 1 73 ? -7.630  0.274   9.278   1.00 0.00 ? 73 TYR A CD2  1 
+ATOM   999  C  CE1  . TYR A 1 73 ? -7.755  -2.256  8.083   1.00 0.00 ? 73 TYR A CE1  1 
+ATOM   1000 C  CE2  . TYR A 1 73 ? -8.697  -0.585  9.567   1.00 0.00 ? 73 TYR A CE2  1 
+ATOM   1001 C  CZ   . TYR A 1 73 ? -8.760  -1.850  8.970   1.00 0.00 ? 73 TYR A CZ   1 
+ATOM   1002 O  OH   . TYR A 1 73 ? -9.812  -2.697  9.256   1.00 0.00 ? 73 TYR A OH   1 
+ATOM   1003 H  H    . TYR A 1 73 ? -3.305  -0.088  6.978   1.00 0.00 ? 73 TYR A H    1 
+ATOM   1004 H  HA   . TYR A 1 73 ? -5.865  0.094   6.095   1.00 0.00 ? 73 TYR A HA   1 
+ATOM   1005 H  HB2  . TYR A 1 73 ? -4.586  0.447   8.591   1.00 0.00 ? 73 TYR A HB2  1 
+ATOM   1006 H  HB3  . TYR A 1 73 ? -5.714  1.791   8.419   1.00 0.00 ? 73 TYR A HB3  1 
+ATOM   1007 H  HD1  . TYR A 1 73 ? -5.913  -1.710  7.110   1.00 0.00 ? 73 TYR A HD1  1 
+ATOM   1008 H  HD2  . TYR A 1 73 ? -7.583  1.250   9.739   1.00 0.00 ? 73 TYR A HD2  1 
+ATOM   1009 H  HE1  . TYR A 1 73 ? -7.804  -3.232  7.623   1.00 0.00 ? 73 TYR A HE1  1 
+ATOM   1010 H  HE2  . TYR A 1 73 ? -9.472  -0.272  10.252  1.00 0.00 ? 73 TYR A HE2  1 
+ATOM   1011 H  HH   . TYR A 1 73 ? -10.554 -2.445  8.700   1.00 0.00 ? 73 TYR A HH   1 
+ATOM   1012 N  N    . VAL A 1 74 ? -4.649  3.162   6.204   1.00 0.00 ? 74 VAL A N    1 
+ATOM   1013 C  CA   . VAL A 1 74 ? -4.931  4.544   5.702   1.00 0.00 ? 74 VAL A CA   1 
+ATOM   1014 C  C    . VAL A 1 74 ? -4.366  4.724   4.291   1.00 0.00 ? 74 VAL A C    1 
+ATOM   1015 O  O    . VAL A 1 74 ? -3.777  3.823   3.727   1.00 0.00 ? 74 VAL A O    1 
+ATOM   1016 C  CB   . VAL A 1 74 ? -4.294  5.573   6.639   1.00 0.00 ? 74 VAL A CB   1 
+ATOM   1017 C  CG1  . VAL A 1 74 ? -5.198  5.785   7.854   1.00 0.00 ? 74 VAL A CG1  1 
+ATOM   1018 C  CG2  . VAL A 1 74 ? -2.924  5.071   7.105   1.00 0.00 ? 74 VAL A CG2  1 
+ATOM   1019 H  H    . VAL A 1 74 ? -3.812  2.969   6.674   1.00 0.00 ? 74 VAL A H    1 
+ATOM   1020 H  HA   . VAL A 1 74 ? -5.999  4.700   5.679   1.00 0.00 ? 74 VAL A HA   1 
+ATOM   1021 H  HB   . VAL A 1 74 ? -4.175  6.511   6.114   1.00 0.00 ? 74 VAL A HB   1 
+ATOM   1022 H  HG11 . VAL A 1 74 ? -6.230  5.675   7.557   1.00 0.00 ? 74 VAL A HG11 1 
+ATOM   1023 H  HG12 . VAL A 1 74 ? -4.961  5.051   8.611   1.00 0.00 ? 74 VAL A HG12 1 
+ATOM   1024 H  HG13 . VAL A 1 74 ? -5.040  6.775   8.253   1.00 0.00 ? 74 VAL A HG13 1 
+ATOM   1025 H  HG21 . VAL A 1 74 ? -2.499  4.428   6.347   1.00 0.00 ? 74 VAL A HG21 1 
+ATOM   1026 H  HG22 . VAL A 1 74 ? -2.269  5.913   7.270   1.00 0.00 ? 74 VAL A HG22 1 
+ATOM   1027 H  HG23 . VAL A 1 74 ? -3.038  4.517   8.025   1.00 0.00 ? 74 VAL A HG23 1 
+ATOM   1028 N  N    . LEU A 1 75 ? -4.539  5.888   3.718   1.00 0.00 ? 75 LEU A N    1 
+ATOM   1029 C  CA   . LEU A 1 75 ? -4.009  6.134   2.345   1.00 0.00 ? 75 LEU A CA   1 
+ATOM   1030 C  C    . LEU A 1 75 ? -2.483  6.081   2.390   1.00 0.00 ? 75 LEU A C    1 
+ATOM   1031 O  O    . LEU A 1 75 ? -1.823  7.059   2.678   1.00 0.00 ? 75 LEU A O    1 
+ATOM   1032 C  CB   . LEU A 1 75 ? -4.470  7.508   1.853   1.00 0.00 ? 75 LEU A CB   1 
+ATOM   1033 C  CG   . LEU A 1 75 ? -5.964  7.457   1.525   1.00 0.00 ? 75 LEU A CG   1 
+ATOM   1034 C  CD1  . LEU A 1 75 ? -6.766  7.302   2.818   1.00 0.00 ? 75 LEU A CD1  1 
+ATOM   1035 C  CD2  . LEU A 1 75 ? -6.376  8.751   0.823   1.00 0.00 ? 75 LEU A CD2  1 
+ATOM   1036 H  H    . LEU A 1 75 ? -5.015  6.602   4.193   1.00 0.00 ? 75 LEU A H    1 
+ATOM   1037 H  HA   . LEU A 1 75 ? -4.375  5.368   1.676   1.00 0.00 ? 75 LEU A HA   1 
+ATOM   1038 H  HB2  . LEU A 1 75 ? -4.295  8.244   2.623   1.00 0.00 ? 75 LEU A HB2  1 
+ATOM   1039 H  HB3  . LEU A 1 75 ? -3.918  7.776   0.964   1.00 0.00 ? 75 LEU A HB3  1 
+ATOM   1040 H  HG   . LEU A 1 75 ? -6.162  6.615   0.877   1.00 0.00 ? 75 LEU A HG   1 
+ATOM   1041 H  HD11 . LEU A 1 75 ? -6.288  7.866   3.606   1.00 0.00 ? 75 LEU A HD11 1 
+ATOM   1042 H  HD12 . LEU A 1 75 ? -7.768  7.674   2.666   1.00 0.00 ? 75 LEU A HD12 1 
+ATOM   1043 H  HD13 . LEU A 1 75 ? -6.804  6.260   3.095   1.00 0.00 ? 75 LEU A HD13 1 
+ATOM   1044 H  HD21 . LEU A 1 75 ? -5.648  9.521   1.030   1.00 0.00 ? 75 LEU A HD21 1 
+ATOM   1045 H  HD22 . LEU A 1 75 ? -6.427  8.581   -0.243  1.00 0.00 ? 75 LEU A HD22 1 
+ATOM   1046 H  HD23 . LEU A 1 75 ? -7.344  9.065   1.184   1.00 0.00 ? 75 LEU A HD23 1 
+ATOM   1047 N  N    . THR A 1 76 ? -1.929  4.933   2.130   1.00 0.00 ? 76 THR A N    1 
+ATOM   1048 C  CA   . THR A 1 76 ? -0.448  4.768   2.179   1.00 0.00 ? 76 THR A CA   1 
+ATOM   1049 C  C    . THR A 1 76 ? 0.174   4.982   0.797   1.00 0.00 ? 76 THR A C    1 
+ATOM   1050 O  O    . THR A 1 76 ? 1.319   4.643   0.572   1.00 0.00 ? 76 THR A O    1 
+ATOM   1051 C  CB   . THR A 1 76 ? -0.128  3.360   2.671   1.00 0.00 ? 76 THR A CB   1 
+ATOM   1052 O  OG1  . THR A 1 76 ? -1.135  2.949   3.581   1.00 0.00 ? 76 THR A OG1  1 
+ATOM   1053 C  CG2  . THR A 1 76 ? 1.231   3.356   3.372   1.00 0.00 ? 76 THR A CG2  1 
+ATOM   1054 H  H    . THR A 1 76 ? -2.494  4.161   1.920   1.00 0.00 ? 76 THR A H    1 
+ATOM   1055 H  HA   . THR A 1 76 ? -0.033  5.485   2.869   1.00 0.00 ? 76 THR A HA   1 
+ATOM   1056 H  HB   . THR A 1 76 ? -0.101  2.685   1.834   1.00 0.00 ? 76 THR A HB   1 
+ATOM   1057 H  HG1  . THR A 1 76 ? -1.875  2.611   3.072   1.00 0.00 ? 76 THR A HG1  1 
+ATOM   1058 H  HG21 . THR A 1 76 ? 1.211   4.048   4.200   1.00 0.00 ? 76 THR A HG21 1 
+ATOM   1059 H  HG22 . THR A 1 76 ? 1.444   2.361   3.739   1.00 0.00 ? 76 THR A HG22 1 
+ATOM   1060 H  HG23 . THR A 1 76 ? 1.998   3.653   2.673   1.00 0.00 ? 76 THR A HG23 1 
+ATOM   1061 N  N    . CYS A 1 77 ? -0.556  5.528   -0.140  1.00 0.00 ? 77 CYS A N    1 
+ATOM   1062 C  CA   . CYS A 1 77 ? 0.024   5.734   -1.503  1.00 0.00 ? 77 CYS A CA   1 
+ATOM   1063 C  C    . CYS A 1 77 ? 1.176   6.760   -1.480  1.00 0.00 ? 77 CYS A C    1 
+ATOM   1064 O  O    . CYS A 1 77 ? 1.677   7.148   -2.515  1.00 0.00 ? 77 CYS A O    1 
+ATOM   1065 C  CB   . CYS A 1 77 ? -1.053  6.199   -2.467  1.00 0.00 ? 77 CYS A CB   1 
+ATOM   1066 S  SG   . CYS A 1 77 ? -1.797  7.718   -1.866  1.00 0.00 ? 77 CYS A SG   1 
+ATOM   1067 H  H    . CYS A 1 77 ? -1.482  5.791   0.046   1.00 0.00 ? 77 CYS A H    1 
+ATOM   1068 H  HA   . CYS A 1 77 ? 0.416   4.790   -1.853  1.00 0.00 ? 77 CYS A HA   1 
+ATOM   1069 H  HB2  . CYS A 1 77 ? -0.614  6.375   -3.432  1.00 0.00 ? 77 CYS A HB2  1 
+ATOM   1070 H  HB3  . CYS A 1 77 ? -1.813  5.436   -2.551  1.00 0.00 ? 77 CYS A HB3  1 
+ATOM   1071 N  N    . VAL A 1 78 ? 1.613   7.196   -0.326  1.00 0.00 ? 78 VAL A N    1 
+ATOM   1072 C  CA   . VAL A 1 78 ? 2.740   8.171   -0.273  1.00 0.00 ? 78 VAL A CA   1 
+ATOM   1073 C  C    . VAL A 1 78 ? 3.661   7.794   0.893   1.00 0.00 ? 78 VAL A C    1 
+ATOM   1074 O  O    . VAL A 1 78 ? 3.791   8.524   1.855   1.00 0.00 ? 78 VAL A O    1 
+ATOM   1075 C  CB   . VAL A 1 78 ? 2.191   9.583   -0.063  1.00 0.00 ? 78 VAL A CB   1 
+ATOM   1076 C  CG1  . VAL A 1 78 ? 1.471   9.660   1.283   1.00 0.00 ? 78 VAL A CG1  1 
+ATOM   1077 C  CG2  . VAL A 1 78 ? 3.348   10.586  -0.079  1.00 0.00 ? 78 VAL A CG2  1 
+ATOM   1078 H  H    . VAL A 1 78 ? 1.214   6.880   0.503   1.00 0.00 ? 78 VAL A H    1 
+ATOM   1079 H  HA   . VAL A 1 78 ? 3.296   8.131   -1.199  1.00 0.00 ? 78 VAL A HA   1 
+ATOM   1080 H  HB   . VAL A 1 78 ? 1.497   9.821   -0.857  1.00 0.00 ? 78 VAL A HB   1 
+ATOM   1081 H  HG11 . VAL A 1 78 ? 1.073   8.688   1.534   1.00 0.00 ? 78 VAL A HG11 1 
+ATOM   1082 H  HG12 . VAL A 1 78 ? 2.167   9.972   2.047   1.00 0.00 ? 78 VAL A HG12 1 
+ATOM   1083 H  HG13 . VAL A 1 78 ? 0.663   10.375  1.219   1.00 0.00 ? 78 VAL A HG13 1 
+ATOM   1084 H  HG21 . VAL A 1 78 ? 4.120   10.256  0.600   1.00 0.00 ? 78 VAL A HG21 1 
+ATOM   1085 H  HG22 . VAL A 1 78 ? 3.752   10.653  -1.079  1.00 0.00 ? 78 VAL A HG22 1 
+ATOM   1086 H  HG23 . VAL A 1 78 ? 2.988   11.556  0.230   1.00 0.00 ? 78 VAL A HG23 1 
+ATOM   1087 N  N    . ALA A 1 79 ? 4.284   6.644   0.824   1.00 0.00 ? 79 ALA A N    1 
+ATOM   1088 C  CA   . ALA A 1 79 ? 5.175   6.206   1.936   1.00 0.00 ? 79 ALA A CA   1 
+ATOM   1089 C  C    . ALA A 1 79 ? 6.604   6.701   1.714   1.00 0.00 ? 79 ALA A C    1 
+ATOM   1090 O  O    . ALA A 1 79 ? 6.863   7.516   0.852   1.00 0.00 ? 79 ALA A O    1 
+ATOM   1091 C  CB   . ALA A 1 79 ? 5.175   4.678   2.014   1.00 0.00 ? 79 ALA A CB   1 
+ATOM   1092 H  H    . ALA A 1 79 ? 4.150   6.063   0.048   1.00 0.00 ? 79 ALA A H    1 
+ATOM   1093 H  HA   . ALA A 1 79 ? 4.805   6.606   2.859   1.00 0.00 ? 79 ALA A HA   1 
+ATOM   1094 H  HB1  . ALA A 1 79 ? 4.733   4.272   1.117   1.00 0.00 ? 79 ALA A HB1  1 
+ATOM   1095 H  HB2  . ALA A 1 79 ? 6.191   4.323   2.107   1.00 0.00 ? 79 ALA A HB2  1 
+ATOM   1096 H  HB3  . ALA A 1 79 ? 4.603   4.362   2.874   1.00 0.00 ? 79 ALA A HB3  1 
+ATOM   1097 N  N    . TYR A 1 80 ? 7.545   6.198   2.477   1.00 0.00 ? 80 TYR A N    1 
+ATOM   1098 C  CA   . TYR A 1 80 ? 8.946   6.623   2.293   1.00 0.00 ? 80 TYR A CA   1 
+ATOM   1099 C  C    . TYR A 1 80 ? 9.845   5.363   2.363   1.00 0.00 ? 80 TYR A C    1 
+ATOM   1100 O  O    . TYR A 1 80 ? 9.968   4.701   1.353   1.00 0.00 ? 80 TYR A O    1 
+ATOM   1101 C  CB   . TYR A 1 80 ? 9.296   7.735   3.292   1.00 0.00 ? 80 TYR A CB   1 
+ATOM   1102 C  CG   . TYR A 1 80 ? 10.707  8.225   3.047   1.00 0.00 ? 80 TYR A CG   1 
+ATOM   1103 C  CD1  . TYR A 1 80 ? 11.282  8.100   1.777   1.00 0.00 ? 80 TYR A CD1  1 
+ATOM   1104 C  CD2  . TYR A 1 80 ? 11.437  8.807   4.092   1.00 0.00 ? 80 TYR A CD2  1 
+ATOM   1105 C  CE1  . TYR A 1 80 ? 12.587  8.554   1.551   1.00 0.00 ? 80 TYR A CE1  1 
+ATOM   1106 C  CE2  . TYR A 1 80 ? 12.742  9.261   3.865   1.00 0.00 ? 80 TYR A CE2  1 
+ATOM   1107 C  CZ   . TYR A 1 80 ? 13.316  9.135   2.595   1.00 0.00 ? 80 TYR A CZ   1 
+ATOM   1108 O  OH   . TYR A 1 80 ? 14.602  9.583   2.372   1.00 0.00 ? 80 TYR A OH   1 
+ATOM   1109 H  H    . TYR A 1 80 ? 7.329   5.524   3.150   1.00 0.00 ? 80 TYR A H    1 
+ATOM   1110 H  HA   . TYR A 1 80 ? 9.019   7.020   1.306   1.00 0.00 ? 80 TYR A HA   1 
+ATOM   1111 H  HB2  . TYR A 1 80 ? 8.607   8.555   3.150   1.00 0.00 ? 80 TYR A HB2  1 
+ATOM   1112 H  HB3  . TYR A 1 80 ? 9.200   7.381   4.294   1.00 0.00 ? 80 TYR A HB3  1 
+ATOM   1113 H  HD1  . TYR A 1 80 ? 10.721  7.653   0.970   1.00 0.00 ? 80 TYR A HD1  1 
+ATOM   1114 H  HD2  . TYR A 1 80 ? 10.995  8.903   5.072   1.00 0.00 ? 80 TYR A HD2  1 
+ATOM   1115 H  HE1  . TYR A 1 80 ? 13.030  8.457   0.571   1.00 0.00 ? 80 TYR A HE1  1 
+ATOM   1116 H  HE2  . TYR A 1 80 ? 13.305  9.709   4.670   1.00 0.00 ? 80 TYR A HE2  1 
+ATOM   1117 H  HH   . TYR A 1 80 ? 15.134  9.350   3.136   1.00 0.00 ? 80 TYR A HH   1 
+ATOM   1118 N  N    . PRO A 1 81 ? 10.411  4.981   3.501   1.00 0.00 ? 81 PRO A N    1 
+ATOM   1119 C  CA   . PRO A 1 81 ? 11.191  3.741   3.526   1.00 0.00 ? 81 PRO A CA   1 
+ATOM   1120 C  C    . PRO A 1 81 ? 10.198  2.609   3.287   1.00 0.00 ? 81 PRO A C    1 
+ATOM   1121 O  O    . PRO A 1 81 ? 9.067   2.685   3.724   1.00 0.00 ? 81 PRO A O    1 
+ATOM   1122 C  CB   . PRO A 1 81 ? 11.784  3.656   4.937   1.00 0.00 ? 81 PRO A CB   1 
+ATOM   1123 C  CG   . PRO A 1 81 ? 11.174  4.813   5.761   1.00 0.00 ? 81 PRO A CG   1 
+ATOM   1124 C  CD   . PRO A 1 81 ? 10.346  5.679   4.799   1.00 0.00 ? 81 PRO A CD   1 
+ATOM   1125 H  HA   . PRO A 1 81 ? 11.969  3.750   2.777   1.00 0.00 ? 81 PRO A HA   1 
+ATOM   1126 H  HB2  . PRO A 1 81 ? 11.531  2.706   5.385   1.00 0.00 ? 81 PRO A HB2  1 
+ATOM   1127 H  HB3  . PRO A 1 81 ? 12.856  3.769   4.895   1.00 0.00 ? 81 PRO A HB3  1 
+ATOM   1128 H  HG2  . PRO A 1 81 ? 10.539  4.413   6.540   1.00 0.00 ? 81 PRO A HG2  1 
+ATOM   1129 H  HG3  . PRO A 1 81 ? 11.961  5.409   6.198   1.00 0.00 ? 81 PRO A HG3  1 
+ATOM   1130 H  HD2  . PRO A 1 81 ? 9.323   5.748   5.143   1.00 0.00 ? 81 PRO A HD2  1 
+ATOM   1131 H  HD3  . PRO A 1 81 ? 10.788  6.655   4.719   1.00 0.00 ? 81 PRO A HD3  1 
+ATOM   1132 N  N    . THR A 1 82 ? 10.560  1.577   2.597   1.00 0.00 ? 82 THR A N    1 
+ATOM   1133 C  CA   . THR A 1 82 ? 9.562   0.513   2.372   1.00 0.00 ? 82 THR A CA   1 
+ATOM   1134 C  C    . THR A 1 82 ? 10.190  -0.846  2.634   1.00 0.00 ? 82 THR A C    1 
+ATOM   1135 O  O    . THR A 1 82 ? 10.672  -1.503  1.736   1.00 0.00 ? 82 THR A O    1 
+ATOM   1136 C  CB   . THR A 1 82 ? 9.044   0.585   0.942   1.00 0.00 ? 82 THR A CB   1 
+ATOM   1137 O  OG1  . THR A 1 82 ? 10.032  1.168   0.111   1.00 0.00 ? 82 THR A OG1  1 
+ATOM   1138 C  CG2  . THR A 1 82 ? 7.776   1.435   0.901   1.00 0.00 ? 82 THR A CG2  1 
+ATOM   1139 H  H    . THR A 1 82 ? 11.459  1.503   2.224   1.00 0.00 ? 82 THR A H    1 
+ATOM   1140 H  HA   . THR A 1 82 ? 8.741   0.662   3.050   1.00 0.00 ? 82 THR A HA   1 
+ATOM   1141 H  HB   . THR A 1 82 ? 8.819   -0.408  0.598   1.00 0.00 ? 82 THR A HB   1 
+ATOM   1142 H  HG1  . THR A 1 82 ? 9.597   1.502   -0.676  1.00 0.00 ? 82 THR A HG1  1 
+ATOM   1143 H  HG21 . THR A 1 82 ? 7.441   1.625   1.909   1.00 0.00 ? 82 THR A HG21 1 
+ATOM   1144 H  HG22 . THR A 1 82 ? 7.988   2.373   0.410   1.00 0.00 ? 82 THR A HG22 1 
+ATOM   1145 H  HG23 . THR A 1 82 ? 7.007   0.908   0.356   1.00 0.00 ? 82 THR A HG23 1 
+ATOM   1146 N  N    . SER A 1 83 ? 10.183  -1.267  3.864   1.00 0.00 ? 83 SER A N    1 
+ATOM   1147 C  CA   . SER A 1 83 ? 10.766  -2.585  4.207   1.00 0.00 ? 83 SER A CA   1 
+ATOM   1148 C  C    . SER A 1 83 ? 9.771   -3.685  3.828   1.00 0.00 ? 83 SER A C    1 
+ATOM   1149 O  O    . SER A 1 83 ? 9.121   -4.263  4.675   1.00 0.00 ? 83 SER A O    1 
+ATOM   1150 C  CB   . SER A 1 83 ? 11.052  -2.650  5.708   1.00 0.00 ? 83 SER A CB   1 
+ATOM   1151 O  OG   . SER A 1 83 ? 11.872  -3.779  5.982   1.00 0.00 ? 83 SER A OG   1 
+ATOM   1152 H  H    . SER A 1 83 ? 9.793   -0.712  4.563   1.00 0.00 ? 83 SER A H    1 
+ATOM   1153 H  HA   . SER A 1 83 ? 11.679  -2.717  3.660   1.00 0.00 ? 83 SER A HA   1 
+ATOM   1154 H  HB2  . SER A 1 83 ? 11.566  -1.756  6.018   1.00 0.00 ? 83 SER A HB2  1 
+ATOM   1155 H  HB3  . SER A 1 83 ? 10.118  -2.732  6.247   1.00 0.00 ? 83 SER A HB3  1 
+ATOM   1156 H  HG   . SER A 1 83 ? 12.357  -3.604  6.791   1.00 0.00 ? 83 SER A HG   1 
+ATOM   1157 N  N    . ASP A 1 84 ? 9.638   -3.963  2.556   1.00 0.00 ? 84 ASP A N    1 
+ATOM   1158 C  CA   . ASP A 1 84 ? 8.675   -5.014  2.107   1.00 0.00 ? 84 ASP A CA   1 
+ATOM   1159 C  C    . ASP A 1 84 ? 7.269   -4.412  2.063   1.00 0.00 ? 84 ASP A C    1 
+ATOM   1160 O  O    . ASP A 1 84 ? 6.926   -3.570  2.863   1.00 0.00 ? 84 ASP A O    1 
+ATOM   1161 C  CB   . ASP A 1 84 ? 8.699   -6.198  3.077   1.00 0.00 ? 84 ASP A CB   1 
+ATOM   1162 C  CG   . ASP A 1 84 ? 10.140  -6.472  3.513   1.00 0.00 ? 84 ASP A CG   1 
+ATOM   1163 O  OD1  . ASP A 1 84 ? 11.019  -6.385  2.672   1.00 0.00 ? 84 ASP A OD1  1 
+ATOM   1164 O  OD2  . ASP A 1 84 ? 10.339  -6.763  4.681   1.00 0.00 ? 84 ASP A OD2  1 
+ATOM   1165 H  H    . ASP A 1 84 ? 10.168  -3.468  1.895   1.00 0.00 ? 84 ASP A H    1 
+ATOM   1166 H  HA   . ASP A 1 84 ? 8.949   -5.351  1.118   1.00 0.00 ? 84 ASP A HA   1 
+ATOM   1167 H  HB2  . ASP A 1 84 ? 8.097   -5.966  3.943   1.00 0.00 ? 84 ASP A HB2  1 
+ATOM   1168 H  HB3  . ASP A 1 84 ? 8.301   -7.073  2.586   1.00 0.00 ? 84 ASP A HB3  1 
+ATOM   1169 N  N    . CYS A 1 85 ? 6.465   -4.809  1.114   1.00 0.00 ? 85 CYS A N    1 
+ATOM   1170 C  CA   . CYS A 1 85 ? 5.103   -4.235  1.002   1.00 0.00 ? 85 CYS A CA   1 
+ATOM   1171 C  C    . CYS A 1 85 ? 4.055   -5.338  1.220   1.00 0.00 ? 85 CYS A C    1 
+ATOM   1172 O  O    . CYS A 1 85 ? 4.179   -6.431  0.703   1.00 0.00 ? 85 CYS A O    1 
+ATOM   1173 C  CB   . CYS A 1 85 ? 4.933   -3.602  -0.394  1.00 0.00 ? 85 CYS A CB   1 
+ATOM   1174 S  SG   . CYS A 1 85 ? 6.489   -3.704  -1.322  1.00 0.00 ? 85 CYS A SG   1 
+ATOM   1175 H  H    . CYS A 1 85 ? 6.761   -5.458  0.456   1.00 0.00 ? 85 CYS A H    1 
+ATOM   1176 H  HA   . CYS A 1 85 ? 4.987   -3.481  1.751   1.00 0.00 ? 85 CYS A HA   1 
+ATOM   1177 H  HB2  . CYS A 1 85 ? 4.162   -4.125  -0.936  1.00 0.00 ? 85 CYS A HB2  1 
+ATOM   1178 H  HB3  . CYS A 1 85 ? 4.657   -2.572  -0.281  1.00 0.00 ? 85 CYS A HB3  1 
+ATOM   1179 N  N    . THR A 1 86 ? 3.025   -5.067  1.990   1.00 0.00 ? 86 THR A N    1 
+ATOM   1180 C  CA   . THR A 1 86 ? 1.984   -6.111  2.245   1.00 0.00 ? 86 THR A CA   1 
+ATOM   1181 C  C    . THR A 1 86 ? 0.596   -5.475  2.247   1.00 0.00 ? 86 THR A C    1 
+ATOM   1182 O  O    . THR A 1 86 ? 0.051   -5.191  3.293   1.00 0.00 ? 86 THR A O    1 
+ATOM   1183 C  CB   . THR A 1 86 ? 2.217   -6.739  3.621   1.00 0.00 ? 86 THR A CB   1 
+ATOM   1184 O  OG1  . THR A 1 86 ? 3.602   -6.699  3.934   1.00 0.00 ? 86 THR A OG1  1 
+ATOM   1185 C  CG2  . THR A 1 86 ? 1.733   -8.190  3.610   1.00 0.00 ? 86 THR A CG2  1 
+ATOM   1186 H  H    . THR A 1 86 ? 2.941   -4.183  2.408   1.00 0.00 ? 86 THR A H    1 
+ATOM   1187 H  HA   . THR A 1 86 ? 2.037   -6.874  1.485   1.00 0.00 ? 86 THR A HA   1 
+ATOM   1188 H  HB   . THR A 1 86 ? 1.658   -6.183  4.369   1.00 0.00 ? 86 THR A HB   1 
+ATOM   1189 H  HG1  . THR A 1 86 ? 3.703   -6.259  4.779   1.00 0.00 ? 86 THR A HG1  1 
+ATOM   1190 H  HG21 . THR A 1 86 ? 1.284   -8.412  2.652   1.00 0.00 ? 86 THR A HG21 1 
+ATOM   1191 H  HG22 . THR A 1 86 ? 2.570   -8.850  3.777   1.00 0.00 ? 86 THR A HG22 1 
+ATOM   1192 H  HG23 . THR A 1 86 ? 1.001   -8.330  4.391   1.00 0.00 ? 86 THR A HG23 1 
+ATOM   1193 N  N    . ILE A 1 87 ? 0.004   -5.254  1.107   1.00 0.00 ? 87 ILE A N    1 
+ATOM   1194 C  CA   . ILE A 1 87 ? -1.348  -4.640  1.113   1.00 0.00 ? 87 ILE A CA   1 
+ATOM   1195 C  C    . ILE A 1 87 ? -2.376  -5.647  0.601   1.00 0.00 ? 87 ILE A C    1 
+ATOM   1196 O  O    . ILE A 1 87 ? -2.391  -6.011  -0.556  1.00 0.00 ? 87 ILE A O    1 
+ATOM   1197 C  CB   . ILE A 1 87 ? -1.340  -3.369  0.252   1.00 0.00 ? 87 ILE A CB   1 
+ATOM   1198 C  CG1  . ILE A 1 87 ? -1.020  -2.182  1.156   1.00 0.00 ? 87 ILE A CG1  1 
+ATOM   1199 C  CG2  . ILE A 1 87 ? -2.710  -3.141  -0.397  1.00 0.00 ? 87 ILE A CG2  1 
+ATOM   1200 C  CD1  . ILE A 1 87 ? -2.083  -2.097  2.254   1.00 0.00 ? 87 ILE A CD1  1 
+ATOM   1201 H  H    . ILE A 1 87 ? 0.437   -5.491  0.260   1.00 0.00 ? 87 ILE A H    1 
+ATOM   1202 H  HA   . ILE A 1 87 ? -1.604  -4.375  2.128   1.00 0.00 ? 87 ILE A HA   1 
+ATOM   1203 H  HB   . ILE A 1 87 ? -0.584  -3.454  -0.514  1.00 0.00 ? 87 ILE A HB   1 
+ATOM   1204 H  HG12 . ILE A 1 87 ? -0.046  -2.323  1.601   1.00 0.00 ? 87 ILE A HG12 1 
+ATOM   1205 H  HG13 . ILE A 1 87 ? -1.027  -1.272  0.576   1.00 0.00 ? 87 ILE A HG13 1 
+ATOM   1206 H  HG21 . ILE A 1 87 ? -2.985  -4.014  -0.970  1.00 0.00 ? 87 ILE A HG21 1 
+ATOM   1207 H  HG22 . ILE A 1 87 ? -3.449  -2.968  0.373   1.00 0.00 ? 87 ILE A HG22 1 
+ATOM   1208 H  HG23 . ILE A 1 87 ? -2.661  -2.282  -1.050  1.00 0.00 ? 87 ILE A HG23 1 
+ATOM   1209 H  HD11 . ILE A 1 87 ? -3.047  -2.342  1.838   1.00 0.00 ? 87 ILE A HD11 1 
+ATOM   1210 H  HD12 . ILE A 1 87 ? -1.847  -2.793  3.043   1.00 0.00 ? 87 ILE A HD12 1 
+ATOM   1211 H  HD13 . ILE A 1 87 ? -2.107  -1.097  2.655   1.00 0.00 ? 87 ILE A HD13 1 
+ATOM   1212 N  N    . GLU A 1 88 ? -3.242  -6.089  1.461   1.00 0.00 ? 88 GLU A N    1 
+ATOM   1213 C  CA   . GLU A 1 88 ? -4.274  -7.061  1.028   1.00 0.00 ? 88 GLU A CA   1 
+ATOM   1214 C  C    . GLU A 1 88 ? -5.619  -6.346  0.919   1.00 0.00 ? 88 GLU A C    1 
+ATOM   1215 O  O    . GLU A 1 88 ? -5.966  -5.529  1.753   1.00 0.00 ? 88 GLU A O    1 
+ATOM   1216 C  CB   . GLU A 1 88 ? -4.376  -8.193  2.052   1.00 0.00 ? 88 GLU A CB   1 
+ATOM   1217 C  CG   . GLU A 1 88 ? -3.104  -9.044  1.999   1.00 0.00 ? 88 GLU A CG   1 
+ATOM   1218 C  CD   . GLU A 1 88 ? -2.006  -8.373  2.827   1.00 0.00 ? 88 GLU A CD   1 
+ATOM   1219 O  OE1  . GLU A 1 88 ? -2.338  -7.531  3.645   1.00 0.00 ? 88 GLU A OE1  1 
+ATOM   1220 O  OE2  . GLU A 1 88 ? -0.852  -8.713  2.629   1.00 0.00 ? 88 GLU A OE2  1 
+ATOM   1221 H  H    . GLU A 1 88 ? -3.217  -5.775  2.393   1.00 0.00 ? 88 GLU A H    1 
+ATOM   1222 H  HA   . GLU A 1 88 ? -4.001  -7.467  0.067   1.00 0.00 ? 88 GLU A HA   1 
+ATOM   1223 H  HB2  . GLU A 1 88 ? -4.490  -7.776  3.041   1.00 0.00 ? 88 GLU A HB2  1 
+ATOM   1224 H  HB3  . GLU A 1 88 ? -5.229  -8.813  1.820   1.00 0.00 ? 88 GLU A HB3  1 
+ATOM   1225 H  HG2  . GLU A 1 88 ? -3.311  -10.025 2.402   1.00 0.00 ? 88 GLU A HG2  1 
+ATOM   1226 H  HG3  . GLU A 1 88 ? -2.775  -9.136  0.975   1.00 0.00 ? 88 GLU A HG3  1 
+ATOM   1227 N  N    . THR A 1 89 ? -6.372  -6.628  -0.110  1.00 0.00 ? 89 THR A N    1 
+ATOM   1228 C  CA   . THR A 1 89 ? -7.688  -5.957  -0.263  1.00 0.00 ? 89 THR A CA   1 
+ATOM   1229 C  C    . THR A 1 89 ? -7.479  -4.450  -0.183  1.00 0.00 ? 89 THR A C    1 
+ATOM   1230 O  O    . THR A 1 89 ? -8.277  -3.730  0.385   1.00 0.00 ? 89 THR A O    1 
+ATOM   1231 C  CB   . THR A 1 89 ? -8.629  -6.407  0.857   1.00 0.00 ? 89 THR A CB   1 
+ATOM   1232 O  OG1  . THR A 1 89 ? -8.341  -5.671  2.038   1.00 0.00 ? 89 THR A OG1  1 
+ATOM   1233 C  CG2  . THR A 1 89 ? -8.429  -7.900  1.125   1.00 0.00 ? 89 THR A CG2  1 
+ATOM   1234 H  H    . THR A 1 89 ? -6.068  -7.271  -0.785  1.00 0.00 ? 89 THR A H    1 
+ATOM   1235 H  HA   . THR A 1 89 ? -8.118  -6.213  -1.221  1.00 0.00 ? 89 THR A HA   1 
+ATOM   1236 H  HB   . THR A 1 89 ? -9.652  -6.232  0.563   1.00 0.00 ? 89 THR A HB   1 
+ATOM   1237 H  HG1  . THR A 1 89 ? -9.010  -4.989  2.133   1.00 0.00 ? 89 THR A HG1  1 
+ATOM   1238 H  HG21 . THR A 1 89 ? -8.279  -8.417  0.187   1.00 0.00 ? 89 THR A HG21 1 
+ATOM   1239 H  HG22 . THR A 1 89 ? -7.564  -8.041  1.756   1.00 0.00 ? 89 THR A HG22 1 
+ATOM   1240 H  HG23 . THR A 1 89 ? -9.304  -8.298  1.618   1.00 0.00 ? 89 THR A HG23 1 
+ATOM   1241 N  N    . HIS A 1 90 ? -6.406  -3.973  -0.753  1.00 0.00 ? 90 HIS A N    1 
+ATOM   1242 C  CA   . HIS A 1 90 ? -6.128  -2.514  -0.725  1.00 0.00 ? 90 HIS A CA   1 
+ATOM   1243 C  C    . HIS A 1 90 ? -7.439  -1.754  -0.989  1.00 0.00 ? 90 HIS A C    1 
+ATOM   1244 O  O    . HIS A 1 90 ? -7.630  -0.643  -0.537  1.00 0.00 ? 90 HIS A O    1 
+ATOM   1245 C  CB   . HIS A 1 90 ? -5.059  -2.197  -1.787  1.00 0.00 ? 90 HIS A CB   1 
+ATOM   1246 C  CG   . HIS A 1 90 ? -5.707  -1.818  -3.094  1.00 0.00 ? 90 HIS A CG   1 
+ATOM   1247 N  ND1  . HIS A 1 90 ? -6.242  -0.559  -3.314  1.00 0.00 ? 90 HIS A ND1  1 
+ATOM   1248 C  CD2  . HIS A 1 90 ? -5.919  -2.522  -4.252  1.00 0.00 ? 90 HIS A CD2  1 
+ATOM   1249 C  CE1  . HIS A 1 90 ? -6.747  -0.546  -4.559  1.00 0.00 ? 90 HIS A CE1  1 
+ATOM   1250 N  NE2  . HIS A 1 90 ? -6.577  -1.718  -5.176  1.00 0.00 ? 90 HIS A NE2  1 
+ATOM   1251 H  H    . HIS A 1 90 ? -5.783  -4.580  -1.204  1.00 0.00 ? 90 HIS A H    1 
+ATOM   1252 H  HA   . HIS A 1 90 ? -5.753  -2.245  0.252   1.00 0.00 ? 90 HIS A HA   1 
+ATOM   1253 H  HB2  . HIS A 1 90 ? -4.437  -1.384  -1.442  1.00 0.00 ? 90 HIS A HB2  1 
+ATOM   1254 H  HB3  . HIS A 1 90 ? -4.440  -3.073  -1.939  1.00 0.00 ? 90 HIS A HB3  1 
+ATOM   1255 H  HD1  . HIS A 1 90 ? -6.250  0.187   -2.678  1.00 0.00 ? 90 HIS A HD1  1 
+ATOM   1256 H  HD2  . HIS A 1 90 ? -5.622  -3.547  -4.418  1.00 0.00 ? 90 HIS A HD2  1 
+ATOM   1257 H  HE1  . HIS A 1 90 ? -7.229  0.310   -5.009  1.00 0.00 ? 90 HIS A HE1  1 
+ATOM   1258 N  N    . LYS A 1 91 ? -8.350  -2.367  -1.704  1.00 0.00 ? 91 LYS A N    1 
+ATOM   1259 C  CA   . LYS A 1 91 ? -9.661  -1.713  -1.988  1.00 0.00 ? 91 LYS A CA   1 
+ATOM   1260 C  C    . LYS A 1 91 ? -10.503 -2.636  -2.872  1.00 0.00 ? 91 LYS A C    1 
+ATOM   1261 O  O    . LYS A 1 91 ? -10.413 -2.604  -4.082  1.00 0.00 ? 91 LYS A O    1 
+ATOM   1262 C  CB   . LYS A 1 91 ? -9.441  -0.383  -2.708  1.00 0.00 ? 91 LYS A CB   1 
+ATOM   1263 C  CG   . LYS A 1 91 ? -10.789 0.323   -2.880  1.00 0.00 ? 91 LYS A CG   1 
+ATOM   1264 C  CD   . LYS A 1 91 ? -11.541 0.325   -1.547  1.00 0.00 ? 91 LYS A CD   1 
+ATOM   1265 C  CE   . LYS A 1 91 ? -12.764 1.240   -1.652  1.00 0.00 ? 91 LYS A CE   1 
+ATOM   1266 N  NZ   . LYS A 1 91 ? -13.918 0.609   -0.949  1.00 0.00 ? 91 LYS A NZ   1 
+ATOM   1267 H  H    . LYS A 1 91 ? -8.175  -3.269  -2.044  1.00 0.00 ? 91 LYS A H    1 
+ATOM   1268 H  HA   . LYS A 1 91 ? -10.181 -1.537  -1.057  1.00 0.00 ? 91 LYS A HA   1 
+ATOM   1269 H  HB2  . LYS A 1 91 ? -8.778  0.240   -2.124  1.00 0.00 ? 91 LYS A HB2  1 
+ATOM   1270 H  HB3  . LYS A 1 91 ? -9.006  -0.564  -3.679  1.00 0.00 ? 91 LYS A HB3  1 
+ATOM   1271 H  HG2  . LYS A 1 91 ? -10.625 1.339   -3.202  1.00 0.00 ? 91 LYS A HG2  1 
+ATOM   1272 H  HG3  . LYS A 1 91 ? -11.377 -0.199  -3.620  1.00 0.00 ? 91 LYS A HG3  1 
+ATOM   1273 H  HD2  . LYS A 1 91 ? -11.860 -0.681  -1.313  1.00 0.00 ? 91 LYS A HD2  1 
+ATOM   1274 H  HD3  . LYS A 1 91 ? -10.889 0.688   -0.766  1.00 0.00 ? 91 LYS A HD3  1 
+ATOM   1275 H  HE2  . LYS A 1 91 ? -12.541 2.192   -1.194  1.00 0.00 ? 91 LYS A HE2  1 
+ATOM   1276 H  HE3  . LYS A 1 91 ? -13.014 1.389   -2.692  1.00 0.00 ? 91 LYS A HE3  1 
+ATOM   1277 H  HZ1  . LYS A 1 91 ? -13.914 -0.415  -1.125  1.00 0.00 ? 91 LYS A HZ1  1 
+ATOM   1278 H  HZ2  . LYS A 1 91 ? -13.839 0.787   0.073   1.00 0.00 ? 91 LYS A HZ2  1 
+ATOM   1279 H  HZ3  . LYS A 1 91 ? -14.805 1.016   -1.305  1.00 0.00 ? 91 LYS A HZ3  1 
+ATOM   1280 N  N    . GLU A 1 92 ? -11.321 -3.464  -2.277  1.00 0.00 ? 92 GLU A N    1 
+ATOM   1281 C  CA   . GLU A 1 92 ? -12.164 -4.391  -3.085  1.00 0.00 ? 92 GLU A CA   1 
+ATOM   1282 C  C    . GLU A 1 92 ? -13.345 -3.627  -3.690  1.00 0.00 ? 92 GLU A C    1 
+ATOM   1283 O  O    . GLU A 1 92 ? -14.172 -4.190  -4.378  1.00 0.00 ? 92 GLU A O    1 
+ATOM   1284 C  CB   . GLU A 1 92 ? -12.693 -5.512  -2.186  1.00 0.00 ? 92 GLU A CB   1 
+ATOM   1285 C  CG   . GLU A 1 92 ? -11.550 -6.464  -1.829  1.00 0.00 ? 92 GLU A CG   1 
+ATOM   1286 C  CD   . GLU A 1 92 ? -11.672 -7.743  -2.659  1.00 0.00 ? 92 GLU A CD   1 
+ATOM   1287 O  OE1  . GLU A 1 92 ? -12.488 -7.762  -3.567  1.00 0.00 ? 92 GLU A OE1  1 
+ATOM   1288 O  OE2  . GLU A 1 92 ? -10.948 -8.682  -2.374  1.00 0.00 ? 92 GLU A OE2  1 
+ATOM   1289 H  H    . GLU A 1 92 ? -11.378 -3.477  -1.298  1.00 0.00 ? 92 GLU A H    1 
+ATOM   1290 H  HA   . GLU A 1 92 ? -11.568 -4.819  -3.878  1.00 0.00 ? 92 GLU A HA   1 
+ATOM   1291 H  HB2  . GLU A 1 92 ? -13.103 -5.083  -1.282  1.00 0.00 ? 92 GLU A HB2  1 
+ATOM   1292 H  HB3  . GLU A 1 92 ? -13.464 -6.058  -2.709  1.00 0.00 ? 92 GLU A HB3  1 
+ATOM   1293 H  HG2  . GLU A 1 92 ? -10.604 -5.986  -2.039  1.00 0.00 ? 92 GLU A HG2  1 
+ATOM   1294 H  HG3  . GLU A 1 92 ? -11.603 -6.712  -0.779  1.00 0.00 ? 92 GLU A HG3  1 
+ATOM   1295 N  N    . GLU A 1 93 ? -13.431 -2.349  -3.441  1.00 0.00 ? 93 GLU A N    1 
+ATOM   1296 C  CA   . GLU A 1 93 ? -14.561 -1.556  -4.004  1.00 0.00 ? 93 GLU A CA   1 
+ATOM   1297 C  C    . GLU A 1 93 ? -15.868 -1.987  -3.334  1.00 0.00 ? 93 GLU A C    1 
+ATOM   1298 O  O    . GLU A 1 93 ? -16.941 -1.812  -3.877  1.00 0.00 ? 93 GLU A O    1 
+ATOM   1299 C  CB   . GLU A 1 93 ? -14.655 -1.801  -5.512  1.00 0.00 ? 93 GLU A CB   1 
+ATOM   1300 C  CG   . GLU A 1 93 ? -14.800 -0.462  -6.239  1.00 0.00 ? 93 GLU A CG   1 
+ATOM   1301 C  CD   . GLU A 1 93 ? -15.197 -0.710  -7.696  1.00 0.00 ? 93 GLU A CD   1 
+ATOM   1302 O  OE1  . GLU A 1 93 ? -16.159 -1.426  -7.914  1.00 0.00 ? 93 GLU A OE1  1 
+ATOM   1303 O  OE2  . GLU A 1 93 ? -14.531 -0.176  -8.569  1.00 0.00 ? 93 GLU A OE2  1 
+ATOM   1304 H  H    . GLU A 1 93 ? -12.755 -1.911  -2.883  1.00 0.00 ? 93 GLU A H    1 
+ATOM   1305 H  HA   . GLU A 1 93 ? -14.391 -0.506  -3.820  1.00 0.00 ? 93 GLU A HA   1 
+ATOM   1306 H  HB2  . GLU A 1 93 ? -13.760 -2.300  -5.852  1.00 0.00 ? 93 GLU A HB2  1 
+ATOM   1307 H  HB3  . GLU A 1 93 ? -15.516 -2.417  -5.724  1.00 0.00 ? 93 GLU A HB3  1 
+ATOM   1308 H  HG2  . GLU A 1 93 ? -15.562 0.131   -5.754  1.00 0.00 ? 93 GLU A HG2  1 
+ATOM   1309 H  HG3  . GLU A 1 93 ? -13.859 0.067   -6.209  1.00 0.00 ? 93 GLU A HG3  1 
+ATOM   1310 N  N    . ASP A 1 94 ? -15.786 -2.550  -2.159  1.00 0.00 ? 94 ASP A N    1 
+ATOM   1311 C  CA   . ASP A 1 94 ? -17.013 -2.989  -1.457  1.00 0.00 ? 94 ASP A CA   1 
+ATOM   1312 C  C    . ASP A 1 94 ? -16.825 -2.841  0.053   1.00 0.00 ? 94 ASP A C    1 
+ATOM   1313 O  O    . ASP A 1 94 ? -17.691 -2.354  0.752   1.00 0.00 ? 94 ASP A O    1 
+ATOM   1314 C  CB   . ASP A 1 94 ? -17.293 -4.452  -1.798  1.00 0.00 ? 94 ASP A CB   1 
+ATOM   1315 C  CG   . ASP A 1 94 ? -18.633 -4.558  -2.528  1.00 0.00 ? 94 ASP A CG   1 
+ATOM   1316 O  OD1  . ASP A 1 94 ? -19.643 -4.249  -1.919  1.00 0.00 ? 94 ASP A OD1  1 
+ATOM   1317 O  OD2  . ASP A 1 94 ? -18.626 -4.948  -3.684  1.00 0.00 ? 94 ASP A OD2  1 
+ATOM   1318 H  H    . ASP A 1 94 ? -14.922 -2.682  -1.741  1.00 0.00 ? 94 ASP A H    1 
+ATOM   1319 H  HA   . ASP A 1 94 ? -17.831 -2.381  -1.777  1.00 0.00 ? 94 ASP A HA   1 
+ATOM   1320 H  HB2  . ASP A 1 94 ? -16.503 -4.827  -2.432  1.00 0.00 ? 94 ASP A HB2  1 
+ATOM   1321 H  HB3  . ASP A 1 94 ? -17.333 -5.033  -0.889  1.00 0.00 ? 94 ASP A HB3  1 
+ATOM   1322 N  N    . LEU A 1 95 ? -15.699 -3.258  0.559   1.00 0.00 ? 95 LEU A N    1 
+ATOM   1323 C  CA   . LEU A 1 95 ? -15.452 -3.144  2.025   1.00 0.00 ? 95 LEU A CA   1 
+ATOM   1324 C  C    . LEU A 1 95 ? -16.247 -4.223  2.763   1.00 0.00 ? 95 LEU A C    1 
+ATOM   1325 O  O    . LEU A 1 95 ? -16.963 -3.945  3.705   1.00 0.00 ? 95 LEU A O    1 
+ATOM   1326 C  CB   . LEU A 1 95 ? -15.895 -1.763  2.511   1.00 0.00 ? 95 LEU A CB   1 
+ATOM   1327 C  CG   . LEU A 1 95 ? -14.956 -1.286  3.619   1.00 0.00 ? 95 LEU A CG   1 
+ATOM   1328 C  CD1  . LEU A 1 95 ? -14.061 -0.168  3.082   1.00 0.00 ? 95 LEU A CD1  1 
+ATOM   1329 C  CD2  . LEU A 1 95 ? -15.780 -0.758  4.795   1.00 0.00 ? 95 LEU A CD2  1 
+ATOM   1330 H  H    . LEU A 1 95 ? -15.016 -3.648  -0.025  1.00 0.00 ? 95 LEU A H    1 
+ATOM   1331 H  HA   . LEU A 1 95 ? -14.398 -3.274  2.223   1.00 0.00 ? 95 LEU A HA   1 
+ATOM   1332 H  HB2  . LEU A 1 95 ? -15.865 -1.065  1.686   1.00 0.00 ? 95 LEU A HB2  1 
+ATOM   1333 H  HB3  . LEU A 1 95 ? -16.902 -1.822  2.896   1.00 0.00 ? 95 LEU A HB3  1 
+ATOM   1334 H  HG   . LEU A 1 95 ? -14.341 -2.112  3.949   1.00 0.00 ? 95 LEU A HG   1 
+ATOM   1335 H  HD11 . LEU A 1 95 ? -14.031 -0.219  2.004   1.00 0.00 ? 95 LEU A HD11 1 
+ATOM   1336 H  HD12 . LEU A 1 95 ? -14.460 0.789   3.387   1.00 0.00 ? 95 LEU A HD12 1 
+ATOM   1337 H  HD13 . LEU A 1 95 ? -13.063 -0.284  3.477   1.00 0.00 ? 95 LEU A HD13 1 
+ATOM   1338 H  HD21 . LEU A 1 95 ? -16.790 -0.561  4.467   1.00 0.00 ? 95 LEU A HD21 1 
+ATOM   1339 H  HD22 . LEU A 1 95 ? -15.796 -1.497  5.584   1.00 0.00 ? 95 LEU A HD22 1 
+ATOM   1340 H  HD23 . LEU A 1 95 ? -15.337 0.154   5.166   1.00 0.00 ? 95 LEU A HD23 1 
+ATOM   1341 N  N    . TYR A 1 96 ? -16.127 -5.453  2.346   1.00 0.00 ? 96 TYR A N    1 
+ATOM   1342 C  CA   . TYR A 1 96 ? -16.872 -6.545  3.019   1.00 0.00 ? 96 TYR A CA   1 
+ATOM   1343 C  C    . TYR A 1 96 ? -16.764 -6.381  4.537   1.00 0.00 ? 96 TYR A C    1 
+ATOM   1344 O  O    . TYR A 1 96 ? -15.753 -5.868  4.987   1.00 0.00 ? 96 TYR A O    1 
+ATOM   1345 C  CB   . TYR A 1 96 ? -16.271 -7.887  2.602   1.00 0.00 ? 96 TYR A CB   1 
+ATOM   1346 C  CG   . TYR A 1 96 ? -14.804 -7.910  2.932   1.00 0.00 ? 96 TYR A CG   1 
+ATOM   1347 C  CD1  . TYR A 1 96 ? -14.387 -8.075  4.255   1.00 0.00 ? 96 TYR A CD1  1 
+ATOM   1348 C  CD2  . TYR A 1 96 ? -13.860 -7.768  1.911   1.00 0.00 ? 96 TYR A CD2  1 
+ATOM   1349 C  CE1  . TYR A 1 96 ? -13.024 -8.100  4.560   1.00 0.00 ? 96 TYR A CE1  1 
+ATOM   1350 C  CE2  . TYR A 1 96 ? -12.496 -7.792  2.212   1.00 0.00 ? 96 TYR A CE2  1 
+ATOM   1351 C  CZ   . TYR A 1 96 ? -12.076 -7.958  3.538   1.00 0.00 ? 96 TYR A CZ   1 
+ATOM   1352 O  OH   . TYR A 1 96 ? -10.729 -7.982  3.838   1.00 0.00 ? 96 TYR A OH   1 
+ATOM   1353 O  OXT  . TYR A 1 96 ? -17.695 -6.771  5.223   1.00 0.00 ? 96 TYR A OXT  1 
+ATOM   1354 H  H    . TYR A 1 96 ? -15.548 -5.661  1.588   1.00 0.00 ? 96 TYR A H    1 
+ATOM   1355 H  HA   . TYR A 1 96 ? -17.907 -6.507  2.723   1.00 0.00 ? 96 TYR A HA   1 
+ATOM   1356 H  HB2  . TYR A 1 96 ? -16.767 -8.680  3.131   1.00 0.00 ? 96 TYR A HB2  1 
+ATOM   1357 H  HB3  . TYR A 1 96 ? -16.400 -8.025  1.540   1.00 0.00 ? 96 TYR A HB3  1 
+ATOM   1358 H  HD1  . TYR A 1 96 ? -15.119 -8.185  5.043   1.00 0.00 ? 96 TYR A HD1  1 
+ATOM   1359 H  HD2  . TYR A 1 96 ? -14.185 -7.640  0.889   1.00 0.00 ? 96 TYR A HD2  1 
+ATOM   1360 H  HE1  . TYR A 1 96 ? -12.704 -8.229  5.582   1.00 0.00 ? 96 TYR A HE1  1 
+ATOM   1361 H  HE2  . TYR A 1 96 ? -11.769 -7.683  1.423   1.00 0.00 ? 96 TYR A HE2  1 
+ATOM   1362 H  HH   . TYR A 1 96 ? -10.400 -7.081  3.797   1.00 0.00 ? 96 TYR A HH   1 
+HETATM 1363 FE FE1  . FES B 2 .  ? -6.067  9.136   -2.518  1.00 0.00 ? 97 FES A FE1  1 
+HETATM 1364 FE FE2  . FES B 2 .  ? -4.037  7.972   -2.024  1.00 0.00 ? 97 FES A FE2  1 
+ATOM   1365 N  N    . ALA A 1 1  ? 5.499   -6.831  -8.405  1.00 0.00 ? 1  ALA A N    2 
+ATOM   1366 C  CA   . ALA A 1 1  ? 6.316   -5.721  -8.970  1.00 0.00 ? 1  ALA A CA   2 
+ATOM   1367 C  C    . ALA A 1 1  ? 7.695   -5.715  -8.306  1.00 0.00 ? 1  ALA A C    2 
+ATOM   1368 O  O    . ALA A 1 1  ? 8.688   -6.054  -8.919  1.00 0.00 ? 1  ALA A O    2 
+ATOM   1369 C  CB   . ALA A 1 1  ? 5.616   -4.387  -8.710  1.00 0.00 ? 1  ALA A CB   2 
+ATOM   1370 H  H1   . ALA A 1 1  ? 5.951   -7.190  -7.540  1.00 0.00 ? 1  ALA A H1   2 
+ATOM   1371 H  H2   . ALA A 1 1  ? 4.547   -6.481  -8.177  1.00 0.00 ? 1  ALA A H2   2 
+ATOM   1372 H  H3   . ALA A 1 1  ? 5.429   -7.600  -9.104  1.00 0.00 ? 1  ALA A H3   2 
+ATOM   1373 H  HA   . ALA A 1 1  ? 6.430   -5.866  -10.034 1.00 0.00 ? 1  ALA A HA   2 
+ATOM   1374 H  HB1  . ALA A 1 1  ? 4.548   -4.514  -8.820  1.00 0.00 ? 1  ALA A HB1  2 
+ATOM   1375 H  HB2  . ALA A 1 1  ? 5.836   -4.054  -7.707  1.00 0.00 ? 1  ALA A HB2  2 
+ATOM   1376 H  HB3  . ALA A 1 1  ? 5.966   -3.653  -9.419  1.00 0.00 ? 1  ALA A HB3  2 
+ATOM   1377 N  N    . SER A 1 2  ? 7.769   -5.333  -7.058  1.00 0.00 ? 2  SER A N    2 
+ATOM   1378 C  CA   . SER A 1 2  ? 9.089   -5.311  -6.369  1.00 0.00 ? 2  SER A CA   2 
+ATOM   1379 C  C    . SER A 1 2  ? 9.385   -6.693  -5.779  1.00 0.00 ? 2  SER A C    2 
+ATOM   1380 O  O    . SER A 1 2  ? 9.791   -7.595  -6.485  1.00 0.00 ? 2  SER A O    2 
+ATOM   1381 C  CB   . SER A 1 2  ? 9.076   -4.264  -5.255  1.00 0.00 ? 2  SER A CB   2 
+ATOM   1382 O  OG   . SER A 1 2  ? 9.500   -3.013  -5.780  1.00 0.00 ? 2  SER A OG   2 
+ATOM   1383 H  H    . SER A 1 2  ? 6.960   -5.063  -6.577  1.00 0.00 ? 2  SER A H    2 
+ATOM   1384 H  HA   . SER A 1 2  ? 9.859   -5.058  -7.084  1.00 0.00 ? 2  SER A HA   2 
+ATOM   1385 H  HB2  . SER A 1 2  ? 8.078   -4.164  -4.864  1.00 0.00 ? 2  SER A HB2  2 
+ATOM   1386 H  HB3  . SER A 1 2  ? 9.745   -4.579  -4.462  1.00 0.00 ? 2  SER A HB3  2 
+ATOM   1387 H  HG   . SER A 1 2  ? 10.460  -3.005  -5.783  1.00 0.00 ? 2  SER A HG   2 
+ATOM   1388 N  N    . TYR A 1 3  ? 9.209   -6.872  -4.493  1.00 0.00 ? 3  TYR A N    2 
+ATOM   1389 C  CA   . TYR A 1 3  ? 9.523   -8.223  -3.904  1.00 0.00 ? 3  TYR A CA   2 
+ATOM   1390 C  C    . TYR A 1 3  ? 8.338   -9.214  -4.049  1.00 0.00 ? 3  TYR A C    2 
+ATOM   1391 O  O    . TYR A 1 3  ? 8.226   -9.875  -5.064  1.00 0.00 ? 3  TYR A O    2 
+ATOM   1392 C  CB   . TYR A 1 3  ? 9.953   -8.066  -2.446  1.00 0.00 ? 3  TYR A CB   2 
+ATOM   1393 C  CG   . TYR A 1 3  ? 11.458  -8.067  -2.375  1.00 0.00 ? 3  TYR A CG   2 
+ATOM   1394 C  CD1  . TYR A 1 3  ? 12.205  -7.537  -3.434  1.00 0.00 ? 3  TYR A CD1  2 
+ATOM   1395 C  CD2  . TYR A 1 3  ? 12.108  -8.585  -1.250  1.00 0.00 ? 3  TYR A CD2  2 
+ATOM   1396 C  CE1  . TYR A 1 3  ? 13.601  -7.524  -3.368  1.00 0.00 ? 3  TYR A CE1  2 
+ATOM   1397 C  CE2  . TYR A 1 3  ? 13.505  -8.574  -1.185  1.00 0.00 ? 3  TYR A CE2  2 
+ATOM   1398 C  CZ   . TYR A 1 3  ? 14.253  -8.043  -2.244  1.00 0.00 ? 3  TYR A CZ   2 
+ATOM   1399 O  OH   . TYR A 1 3  ? 15.631  -8.030  -2.179  1.00 0.00 ? 3  TYR A OH   2 
+ATOM   1400 H  H    . TYR A 1 3  ? 8.895   -6.119  -3.918  1.00 0.00 ? 3  TYR A H    2 
+ATOM   1401 H  HA   . TYR A 1 3  ? 10.355  -8.634  -4.453  1.00 0.00 ? 3  TYR A HA   2 
+ATOM   1402 H  HB2  . TYR A 1 3  ? 9.593   -7.127  -2.068  1.00 0.00 ? 3  TYR A HB2  2 
+ATOM   1403 H  HB3  . TYR A 1 3  ? 9.559   -8.878  -1.855  1.00 0.00 ? 3  TYR A HB3  2 
+ATOM   1404 H  HD1  . TYR A 1 3  ? 11.701  -7.137  -4.302  1.00 0.00 ? 3  TYR A HD1  2 
+ATOM   1405 H  HD2  . TYR A 1 3  ? 11.531  -8.995  -0.434  1.00 0.00 ? 3  TYR A HD2  2 
+ATOM   1406 H  HE1  . TYR A 1 3  ? 14.175  -7.113  -4.186  1.00 0.00 ? 3  TYR A HE1  2 
+ATOM   1407 H  HE2  . TYR A 1 3  ? 14.006  -8.972  -0.318  1.00 0.00 ? 3  TYR A HE2  2 
+ATOM   1408 H  HH   . TYR A 1 3  ? 15.956  -7.454  -2.875  1.00 0.00 ? 3  TYR A HH   2 
+ATOM   1409 N  N    . THR A 1 4  ? 7.456   -9.360  -3.071  1.00 0.00 ? 4  THR A N    2 
+ATOM   1410 C  CA   . THR A 1 4  ? 6.347   -10.339 -3.250  1.00 0.00 ? 4  THR A CA   2 
+ATOM   1411 C  C    . THR A 1 4  ? 5.025   -9.947  -2.531  1.00 0.00 ? 4  THR A C    2 
+ATOM   1412 O  O    . THR A 1 4  ? 4.139   -10.756 -2.495  1.00 0.00 ? 4  THR A O    2 
+ATOM   1413 C  CB   . THR A 1 4  ? 6.806   -11.703 -2.728  1.00 0.00 ? 4  THR A CB   2 
+ATOM   1414 O  OG1  . THR A 1 4  ? 5.674   -12.542 -2.543  1.00 0.00 ? 4  THR A OG1  2 
+ATOM   1415 C  CG2  . THR A 1 4  ? 7.533   -11.522 -1.396  1.00 0.00 ? 4  THR A CG2  2 
+ATOM   1416 H  H    . THR A 1 4  ? 7.530   -8.857  -2.257  1.00 0.00 ? 4  THR A H    2 
+ATOM   1417 H  HA   . THR A 1 4  ? 6.151   -10.426 -4.298  1.00 0.00 ? 4  THR A HA   2 
+ATOM   1418 H  HB   . THR A 1 4  ? 7.478   -12.154 -3.442  1.00 0.00 ? 4  THR A HB   2 
+ATOM   1419 H  HG1  . THR A 1 4  ? 5.344   -12.402 -1.653  1.00 0.00 ? 4  THR A HG1  2 
+ATOM   1420 H  HG21 . THR A 1 4  ? 7.030   -10.766 -0.810  1.00 0.00 ? 4  THR A HG21 2 
+ATOM   1421 H  HG22 . THR A 1 4  ? 7.530   -12.457 -0.855  1.00 0.00 ? 4  THR A HG22 2 
+ATOM   1422 H  HG23 . THR A 1 4  ? 8.552   -11.217 -1.581  1.00 0.00 ? 4  THR A HG23 2 
+ATOM   1423 N  N    . VAL A 1 5  ? 4.888   -8.753  -1.963  1.00 0.00 ? 5  VAL A N    2 
+ATOM   1424 C  CA   . VAL A 1 5  ? 3.601   -8.336  -1.240  1.00 0.00 ? 5  VAL A CA   2 
+ATOM   1425 C  C    . VAL A 1 5  ? 2.528   -9.383  -1.354  1.00 0.00 ? 5  VAL A C    2 
+ATOM   1426 O  O    . VAL A 1 5  ? 2.203   -9.840  -2.419  1.00 0.00 ? 5  VAL A O    2 
+ATOM   1427 C  CB   . VAL A 1 5  ? 2.997   -7.023  -1.797  1.00 0.00 ? 5  VAL A CB   2 
+ATOM   1428 C  CG1  . VAL A 1 5  ? 1.494   -7.166  -2.076  1.00 0.00 ? 5  VAL A CG1  2 
+ATOM   1429 C  CG2  . VAL A 1 5  ? 3.169   -5.929  -0.762  1.00 0.00 ? 5  VAL A CG2  2 
+ATOM   1430 H  H    . VAL A 1 5  ? 5.628   -8.139  -1.995  1.00 0.00 ? 5  VAL A H    2 
+ATOM   1431 H  HA   . VAL A 1 5  ? 3.820   -8.188  -0.199  1.00 0.00 ? 5  VAL A HA   2 
+ATOM   1432 H  HB   . VAL A 1 5  ? 3.492   -6.750  -2.708  1.00 0.00 ? 5  VAL A HB   2 
+ATOM   1433 H  HG11 . VAL A 1 5  ? 0.997   -7.522  -1.185  1.00 0.00 ? 5  VAL A HG11 2 
+ATOM   1434 H  HG12 . VAL A 1 5  ? 1.090   -6.207  -2.358  1.00 0.00 ? 5  VAL A HG12 2 
+ATOM   1435 H  HG13 . VAL A 1 5  ? 1.346   -7.872  -2.878  1.00 0.00 ? 5  VAL A HG13 2 
+ATOM   1436 H  HG21 . VAL A 1 5  ? 4.020   -6.158  -0.142  1.00 0.00 ? 5  VAL A HG21 2 
+ATOM   1437 H  HG22 . VAL A 1 5  ? 3.327   -4.986  -1.261  1.00 0.00 ? 5  VAL A HG22 2 
+ATOM   1438 H  HG23 . VAL A 1 5  ? 2.282   -5.869  -0.151  1.00 0.00 ? 5  VAL A HG23 2 
+ATOM   1439 N  N    . LYS A 1 6  ? 1.926   -9.715  -0.284  1.00 0.00 ? 6  LYS A N    2 
+ATOM   1440 C  CA   . LYS A 1 6  ? 0.842   -10.699 -0.387  1.00 0.00 ? 6  LYS A CA   2 
+ATOM   1441 C  C    . LYS A 1 6  ? -0.502  -10.066 -0.038  1.00 0.00 ? 6  LYS A C    2 
+ATOM   1442 O  O    . LYS A 1 6  ? -0.623  -9.344  0.945   1.00 0.00 ? 6  LYS A O    2 
+ATOM   1443 C  CB   . LYS A 1 6  ? 1.127   -11.850 0.574   1.00 0.00 ? 6  LYS A CB   2 
+ATOM   1444 C  CG   . LYS A 1 6  ? 2.143   -12.803 -0.057  1.00 0.00 ? 6  LYS A CG   2 
+ATOM   1445 C  CD   . LYS A 1 6  ? 3.072   -13.349 1.030   1.00 0.00 ? 6  LYS A CD   2 
+ATOM   1446 C  CE   . LYS A 1 6  ? 3.282   -14.848 0.819   1.00 0.00 ? 6  LYS A CE   2 
+ATOM   1447 N  NZ   . LYS A 1 6  ? 4.262   -15.357 1.820   1.00 0.00 ? 6  LYS A NZ   2 
+ATOM   1448 H  H    . LYS A 1 6  ? 2.163   -9.295  0.576   1.00 0.00 ? 6  LYS A H    2 
+ATOM   1449 H  HA   . LYS A 1 6  ? 0.804   -11.083 -1.395  1.00 0.00 ? 6  LYS A HA   2 
+ATOM   1450 H  HB2  . LYS A 1 6  ? 1.526   -11.455 1.496   1.00 0.00 ? 6  LYS A HB2  2 
+ATOM   1451 H  HB3  . LYS A 1 6  ? 0.212   -12.384 0.774   1.00 0.00 ? 6  LYS A HB3  2 
+ATOM   1452 H  HG2  . LYS A 1 6  ? 1.621   -13.622 -0.531  1.00 0.00 ? 6  LYS A HG2  2 
+ATOM   1453 H  HG3  . LYS A 1 6  ? 2.726   -12.272 -0.793  1.00 0.00 ? 6  LYS A HG3  2 
+ATOM   1454 H  HD2  . LYS A 1 6  ? 4.024   -12.839 0.976   1.00 0.00 ? 6  LYS A HD2  2 
+ATOM   1455 H  HD3  . LYS A 1 6  ? 2.629   -13.182 2.000   1.00 0.00 ? 6  LYS A HD3  2 
+ATOM   1456 H  HE2  . LYS A 1 6  ? 2.342   -15.365 0.942   1.00 0.00 ? 6  LYS A HE2  2 
+ATOM   1457 H  HE3  . LYS A 1 6  ? 3.662   -15.023 -0.176  1.00 0.00 ? 6  LYS A HE3  2 
+ATOM   1458 H  HZ1  . LYS A 1 6  ? 4.060   -14.934 2.748   1.00 0.00 ? 6  LYS A HZ1  2 
+ATOM   1459 H  HZ2  . LYS A 1 6  ? 4.183   -16.393 1.886   1.00 0.00 ? 6  LYS A HZ2  2 
+ATOM   1460 H  HZ3  . LYS A 1 6  ? 5.225   -15.100 1.526   1.00 0.00 ? 6  LYS A HZ3  2 
+ATOM   1461 N  N    . LEU A 1 7  ? -1.515  -10.390 -0.822  1.00 0.00 ? 7  LEU A N    2 
+ATOM   1462 C  CA   . LEU A 1 7  ? -2.932  -9.900  -0.521  1.00 0.00 ? 7  LEU A CA   2 
+ATOM   1463 C  C    . LEU A 1 7  ? -3.789  -9.555  -1.764  1.00 0.00 ? 7  LEU A C    2 
+ATOM   1464 O  O    . LEU A 1 7  ? -4.330  -10.433 -2.406  1.00 0.00 ? 7  LEU A O    2 
+ATOM   1465 C  CB   . LEU A 1 7  ? -2.920  -8.693  0.414   1.00 0.00 ? 7  LEU A CB   2 
+ATOM   1466 C  CG   . LEU A 1 7  ? -3.000  -9.123  1.900   1.00 0.00 ? 7  LEU A CG   2 
+ATOM   1467 C  CD1  . LEU A 1 7  ? -2.553  -10.580 2.133   1.00 0.00 ? 7  LEU A CD1  2 
+ATOM   1468 C  CD2  . LEU A 1 7  ? -2.116  -8.196  2.735   1.00 0.00 ? 7  LEU A CD2  2 
+ATOM   1469 H  H    . LEU A 1 7  ? -1.338  -11.002 -1.584  1.00 0.00 ? 7  LEU A H    2 
+ATOM   1470 H  HA   . LEU A 1 7  ? -3.441  -10.701 -0.006  1.00 0.00 ? 7  LEU A HA   2 
+ATOM   1471 H  HB2  . LEU A 1 7  ? -2.028  -8.111  0.248   1.00 0.00 ? 7  LEU A HB2  2 
+ATOM   1472 H  HB3  . LEU A 1 7  ? -3.777  -8.090  0.190   1.00 0.00 ? 7  LEU A HB3  2 
+ATOM   1473 H  HG   . LEU A 1 7  ? -4.019  -9.021  2.228   1.00 0.00 ? 7  LEU A HG   2 
+ATOM   1474 H  HD11 . LEU A 1 7  ? -2.097  -10.983 1.249   1.00 0.00 ? 7  LEU A HD11 2 
+ATOM   1475 H  HD12 . LEU A 1 7  ? -1.843  -10.610 2.944   1.00 0.00 ? 7  LEU A HD12 2 
+ATOM   1476 H  HD13 . LEU A 1 7  ? -3.414  -11.178 2.393   1.00 0.00 ? 7  LEU A HD13 2 
+ATOM   1477 H  HD21 . LEU A 1 7  ? -1.338  -7.784  2.113   1.00 0.00 ? 7  LEU A HD21 2 
+ATOM   1478 H  HD22 . LEU A 1 7  ? -2.716  -7.395  3.139   1.00 0.00 ? 7  LEU A HD22 2 
+ATOM   1479 H  HD23 . LEU A 1 7  ? -1.670  -8.755  3.544   1.00 0.00 ? 7  LEU A HD23 2 
+ATOM   1480 N  N    . ILE A 1 8  ? -3.978  -8.288  -2.072  1.00 0.00 ? 8  ILE A N    2 
+ATOM   1481 C  CA   . ILE A 1 8  ? -4.860  -7.921  -3.224  1.00 0.00 ? 8  ILE A CA   2 
+ATOM   1482 C  C    . ILE A 1 8  ? -6.234  -8.572  -2.997  1.00 0.00 ? 8  ILE A C    2 
+ATOM   1483 O  O    . ILE A 1 8  ? -7.014  -8.056  -2.230  1.00 0.00 ? 8  ILE A O    2 
+ATOM   1484 C  CB   . ILE A 1 8  ? -4.249  -8.371  -4.560  1.00 0.00 ? 8  ILE A CB   2 
+ATOM   1485 C  CG1  . ILE A 1 8  ? -3.160  -7.375  -4.980  1.00 0.00 ? 8  ILE A CG1  2 
+ATOM   1486 C  CG2  . ILE A 1 8  ? -5.330  -8.405  -5.646  1.00 0.00 ? 8  ILE A CG2  2 
+ATOM   1487 C  CD1  . ILE A 1 8  ? -3.794  -6.073  -5.482  1.00 0.00 ? 8  ILE A CD1  2 
+ATOM   1488 H  H    . ILE A 1 8  ? -3.576  -7.579  -1.527  1.00 0.00 ? 8  ILE A H    2 
+ATOM   1489 H  HA   . ILE A 1 8  ? -4.986  -6.846  -3.235  1.00 0.00 ? 8  ILE A HA   2 
+ATOM   1490 H  HB   . ILE A 1 8  ? -3.817  -9.355  -4.448  1.00 0.00 ? 8  ILE A HB   2 
+ATOM   1491 H  HG12 . ILE A 1 8  ? -2.532  -7.153  -4.134  1.00 0.00 ? 8  ILE A HG12 2 
+ATOM   1492 H  HG13 . ILE A 1 8  ? -2.562  -7.807  -5.769  1.00 0.00 ? 8  ILE A HG13 2 
+ATOM   1493 H  HG21 . ILE A 1 8  ? -6.250  -7.997  -5.253  1.00 0.00 ? 8  ILE A HG21 2 
+ATOM   1494 H  HG22 . ILE A 1 8  ? -5.008  -7.817  -6.492  1.00 0.00 ? 8  ILE A HG22 2 
+ATOM   1495 H  HG23 . ILE A 1 8  ? -5.494  -9.426  -5.959  1.00 0.00 ? 8  ILE A HG23 2 
+ATOM   1496 H  HD11 . ILE A 1 8  ? -4.612  -6.295  -6.149  1.00 0.00 ? 8  ILE A HD11 2 
+ATOM   1497 H  HD12 . ILE A 1 8  ? -4.159  -5.505  -4.639  1.00 0.00 ? 8  ILE A HD12 2 
+ATOM   1498 H  HD13 . ILE A 1 8  ? -3.053  -5.495  -6.009  1.00 0.00 ? 8  ILE A HD13 2 
+ATOM   1499 N  N    . THR A 1 9  ? -6.511  -9.699  -3.643  1.00 0.00 ? 9  THR A N    2 
+ATOM   1500 C  CA   . THR A 1 9  ? -7.822  -10.434 -3.488  1.00 0.00 ? 9  THR A CA   2 
+ATOM   1501 C  C    . THR A 1 9  ? -8.541  -10.469 -4.843  1.00 0.00 ? 9  THR A C    2 
+ATOM   1502 O  O    . THR A 1 9  ? -8.545  -11.501 -5.490  1.00 0.00 ? 9  THR A O    2 
+ATOM   1503 C  CB   . THR A 1 9  ? -8.726  -9.832  -2.402  1.00 0.00 ? 9  THR A CB   2 
+ATOM   1504 O  OG1  . THR A 1 9  ? -8.238  -10.216 -1.124  1.00 0.00 ? 9  THR A OG1  2 
+ATOM   1505 C  CG2  . THR A 1 9  ? -10.153 -10.355 -2.580  1.00 0.00 ? 9  THR A CG2  2 
+ATOM   1506 H  H    . THR A 1 9  ? -5.832  -10.087 -4.245  1.00 0.00 ? 9  THR A H    2 
+ATOM   1507 H  HA   . THR A 1 9  ? -7.595  -11.451 -3.214  1.00 0.00 ? 9  THR A HA   2 
+ATOM   1508 H  HB   . THR A 1 9  ? -8.729  -8.768  -2.473  1.00 0.00 ? 9  THR A HB   2 
+ATOM   1509 H  HG1  . THR A 1 9  ? -7.304  -10.426 -1.214  1.00 0.00 ? 9  THR A HG1  2 
+ATOM   1510 H  HG21 . THR A 1 9  ? -10.122 -11.407 -2.820  1.00 0.00 ? 9  THR A HG21 2 
+ATOM   1511 H  HG22 . THR A 1 9  ? -10.706 -10.210 -1.665  1.00 0.00 ? 9  THR A HG22 2 
+ATOM   1512 H  HG23 . THR A 1 9  ? -10.635 -9.817  -3.383  1.00 0.00 ? 9  THR A HG23 2 
+ATOM   1513 N  N    . PRO A 1 10 ? -9.095  -9.352  -5.281  1.00 0.00 ? 10 PRO A N    2 
+ATOM   1514 C  CA   . PRO A 1 10 ? -9.752  -9.302  -6.580  1.00 0.00 ? 10 PRO A CA   2 
+ATOM   1515 C  C    . PRO A 1 10 ? -8.816  -9.995  -7.553  1.00 0.00 ? 10 PRO A C    2 
+ATOM   1516 O  O    . PRO A 1 10 ? -9.215  -10.656 -8.492  1.00 0.00 ? 10 PRO A O    2 
+ATOM   1517 C  CB   . PRO A 1 10 ? -9.907  -7.808  -6.884  1.00 0.00 ? 10 PRO A CB   2 
+ATOM   1518 C  CG   . PRO A 1 10 ? -9.515  -7.041  -5.599  1.00 0.00 ? 10 PRO A CG   2 
+ATOM   1519 C  CD   . PRO A 1 10 ? -9.099  -8.087  -4.556  1.00 0.00 ? 10 PRO A CD   2 
+ATOM   1520 H  HA   . PRO A 1 10 ? -10.708 -9.783  -6.531  1.00 0.00 ? 10 PRO A HA   2 
+ATOM   1521 H  HB2  . PRO A 1 10 ? -9.251  -7.529  -7.695  1.00 0.00 ? 10 PRO A HB2  2 
+ATOM   1522 H  HB3  . PRO A 1 10 ? -10.930 -7.586  -7.138  1.00 0.00 ? 10 PRO A HB3  2 
+ATOM   1523 H  HG2  . PRO A 1 10 ? -8.689  -6.375  -5.807  1.00 0.00 ? 10 PRO A HG2  2 
+ATOM   1524 H  HG3  . PRO A 1 10 ? -10.359 -6.479  -5.233  1.00 0.00 ? 10 PRO A HG3  2 
+ATOM   1525 H  HD2  . PRO A 1 10 ? -8.119  -7.873  -4.176  1.00 0.00 ? 10 PRO A HD2  2 
+ATOM   1526 H  HD3  . PRO A 1 10 ? -9.825  -8.128  -3.763  1.00 0.00 ? 10 PRO A HD3  2 
+ATOM   1527 N  N    . ASP A 1 11 ? -7.554  -9.882  -7.256  1.00 0.00 ? 11 ASP A N    2 
+ATOM   1528 C  CA   . ASP A 1 11 ? -6.514  -10.550 -8.046  1.00 0.00 ? 11 ASP A CA   2 
+ATOM   1529 C  C    . ASP A 1 11 ? -5.872  -11.590 -7.124  1.00 0.00 ? 11 ASP A C    2 
+ATOM   1530 O  O    . ASP A 1 11 ? -4.821  -11.362 -6.554  1.00 0.00 ? 11 ASP A O    2 
+ATOM   1531 C  CB   . ASP A 1 11 ? -5.476  -9.521  -8.487  1.00 0.00 ? 11 ASP A CB   2 
+ATOM   1532 C  CG   . ASP A 1 11 ? -4.730  -10.032 -9.719  1.00 0.00 ? 11 ASP A CG   2 
+ATOM   1533 O  OD1  . ASP A 1 11 ? -5.359  -10.671 -10.546 1.00 0.00 ? 11 ASP A OD1  2 
+ATOM   1534 O  OD2  . ASP A 1 11 ? -3.541  -9.775  -9.817  1.00 0.00 ? 11 ASP A OD2  2 
+ATOM   1535 H  H    . ASP A 1 11 ? -7.287  -9.375  -6.465  1.00 0.00 ? 11 ASP A H    2 
+ATOM   1536 H  HA   . ASP A 1 11 ? -6.953  -11.034 -8.907  1.00 0.00 ? 11 ASP A HA   2 
+ATOM   1537 H  HB2  . ASP A 1 11 ? -5.973  -8.591  -8.724  1.00 0.00 ? 11 ASP A HB2  2 
+ATOM   1538 H  HB3  . ASP A 1 11 ? -4.776  -9.357  -7.685  1.00 0.00 ? 11 ASP A HB3  2 
+ATOM   1539 N  N    . GLY A 1 12 ? -6.536  -12.707 -6.947  1.00 0.00 ? 12 GLY A N    2 
+ATOM   1540 C  CA   . GLY A 1 12 ? -6.022  -13.793 -6.053  1.00 0.00 ? 12 GLY A CA   2 
+ATOM   1541 C  C    . GLY A 1 12 ? -5.171  -13.216 -4.923  1.00 0.00 ? 12 GLY A C    2 
+ATOM   1542 O  O    . GLY A 1 12 ? -5.667  -12.564 -4.026  1.00 0.00 ? 12 GLY A O    2 
+ATOM   1543 H  H    . GLY A 1 12 ? -7.402  -12.824 -7.390  1.00 0.00 ? 12 GLY A H    2 
+ATOM   1544 H  HA2  . GLY A 1 12 ? -6.860  -14.328 -5.629  1.00 0.00 ? 12 GLY A HA2  2 
+ATOM   1545 H  HA3  . GLY A 1 12 ? -5.422  -14.477 -6.634  1.00 0.00 ? 12 GLY A HA3  2 
+ATOM   1546 N  N    . GLU A 1 13 ? -3.890  -13.462 -4.956  1.00 0.00 ? 13 GLU A N    2 
+ATOM   1547 C  CA   . GLU A 1 13 ? -3.003  -12.942 -3.880  1.00 0.00 ? 13 GLU A CA   2 
+ATOM   1548 C  C    . GLU A 1 13 ? -2.071  -11.866 -4.442  1.00 0.00 ? 13 GLU A C    2 
+ATOM   1549 O  O    . GLU A 1 13 ? -1.522  -11.995 -5.518  1.00 0.00 ? 13 GLU A O    2 
+ATOM   1550 C  CB   . GLU A 1 13 ? -2.169  -14.095 -3.317  1.00 0.00 ? 13 GLU A CB   2 
+ATOM   1551 C  CG   . GLU A 1 13 ? -1.031  -13.539 -2.457  1.00 0.00 ? 13 GLU A CG   2 
+ATOM   1552 C  CD   . GLU A 1 13 ? -0.130  -14.687 -2.001  1.00 0.00 ? 13 GLU A CD   2 
+ATOM   1553 O  OE1  . GLU A 1 13 ? -0.617  -15.550 -1.290  1.00 0.00 ? 13 GLU A OE1  2 
+ATOM   1554 O  OE2  . GLU A 1 13 ? 1.033   -14.684 -2.373  1.00 0.00 ? 13 GLU A OE2  2 
+ATOM   1555 H  H    . GLU A 1 13 ? -3.513  -13.998 -5.685  1.00 0.00 ? 13 GLU A H    2 
+ATOM   1556 H  HA   . GLU A 1 13 ? -3.607  -12.519 -3.092  1.00 0.00 ? 13 GLU A HA   2 
+ATOM   1557 H  HB2  . GLU A 1 13 ? -2.798  -14.732 -2.712  1.00 0.00 ? 13 GLU A HB2  2 
+ATOM   1558 H  HB3  . GLU A 1 13 ? -1.753  -14.669 -4.131  1.00 0.00 ? 13 GLU A HB3  2 
+ATOM   1559 H  HG2  . GLU A 1 13 ? -0.454  -12.835 -3.038  1.00 0.00 ? 13 GLU A HG2  2 
+ATOM   1560 H  HG3  . GLU A 1 13 ? -1.444  -13.041 -1.592  1.00 0.00 ? 13 GLU A HG3  2 
+ATOM   1561 N  N    . SER A 1 14 ? -1.882  -10.810 -3.703  1.00 0.00 ? 14 SER A N    2 
+ATOM   1562 C  CA   . SER A 1 14 ? -0.978  -9.717  -4.156  1.00 0.00 ? 14 SER A CA   2 
+ATOM   1563 C  C    . SER A 1 14 ? 0.439   -10.245 -4.200  1.00 0.00 ? 14 SER A C    2 
+ATOM   1564 O  O    . SER A 1 14 ? 0.757   -11.192 -3.504  1.00 0.00 ? 14 SER A O    2 
+ATOM   1565 C  CB   . SER A 1 14 ? -1.014  -8.563  -3.160  1.00 0.00 ? 14 SER A CB   2 
+ATOM   1566 O  OG   . SER A 1 14 ? -0.483  -7.397  -3.778  1.00 0.00 ? 14 SER A OG   2 
+ATOM   1567 H  H    . SER A 1 14 ? -2.327  -10.743 -2.842  1.00 0.00 ? 14 SER A H    2 
+ATOM   1568 H  HA   . SER A 1 14 ? -1.274  -9.370  -5.134  1.00 0.00 ? 14 SER A HA   2 
+ATOM   1569 H  HB2  . SER A 1 14 ? -2.024  -8.376  -2.860  1.00 0.00 ? 14 SER A HB2  2 
+ATOM   1570 H  HB3  . SER A 1 14 ? -0.423  -8.820  -2.291  1.00 0.00 ? 14 SER A HB3  2 
+ATOM   1571 H  HG   . SER A 1 14 ? -0.855  -6.631  -3.335  1.00 0.00 ? 14 SER A HG   2 
+ATOM   1572 N  N    . SER A 1 15 ? 1.283   -9.623  -4.996  1.00 0.00 ? 15 SER A N    2 
+ATOM   1573 C  CA   . SER A 1 15 ? 2.711   -10.053 -5.107  1.00 0.00 ? 15 SER A CA   2 
+ATOM   1574 C  C    . SER A 1 15 ? 3.616   -8.843  -5.459  1.00 0.00 ? 15 SER A C    2 
+ATOM   1575 O  O    . SER A 1 15 ? 3.960   -8.624  -6.604  1.00 0.00 ? 15 SER A O    2 
+ATOM   1576 C  CB   . SER A 1 15 ? 2.818   -11.113 -6.197  1.00 0.00 ? 15 SER A CB   2 
+ATOM   1577 O  OG   . SER A 1 15 ? 4.178   -11.257 -6.588  1.00 0.00 ? 15 SER A OG   2 
+ATOM   1578 H  H    . SER A 1 15 ? 0.969   -8.862  -5.519  1.00 0.00 ? 15 SER A H    2 
+ATOM   1579 H  HA   . SER A 1 15 ? 3.024   -10.476 -4.170  1.00 0.00 ? 15 SER A HA   2 
+ATOM   1580 H  HB2  . SER A 1 15 ? 2.455   -12.053 -5.817  1.00 0.00 ? 15 SER A HB2  2 
+ATOM   1581 H  HB3  . SER A 1 15 ? 2.216   -10.816 -7.045  1.00 0.00 ? 15 SER A HB3  2 
+ATOM   1582 H  HG   . SER A 1 15 ? 4.720   -11.228 -5.796  1.00 0.00 ? 15 SER A HG   2 
+ATOM   1583 N  N    . ILE A 1 16 ? 3.987   -8.056  -4.472  1.00 0.00 ? 16 ILE A N    2 
+ATOM   1584 C  CA   . ILE A 1 16 ? 4.855   -6.839  -4.705  1.00 0.00 ? 16 ILE A CA   2 
+ATOM   1585 C  C    . ILE A 1 16 ? 5.885   -6.685  -3.563  1.00 0.00 ? 16 ILE A C    2 
+ATOM   1586 O  O    . ILE A 1 16 ? 6.982   -7.142  -3.679  1.00 0.00 ? 16 ILE A O    2 
+ATOM   1587 C  CB   . ILE A 1 16 ? 3.994   -5.586  -4.786  1.00 0.00 ? 16 ILE A CB   2 
+ATOM   1588 C  CG1  . ILE A 1 16 ? 2.530   -5.996  -4.882  1.00 0.00 ? 16 ILE A CG1  2 
+ATOM   1589 C  CG2  . ILE A 1 16 ? 4.390   -4.787  -6.022  1.00 0.00 ? 16 ILE A CG2  2 
+ATOM   1590 C  CD1  . ILE A 1 16 ? 2.214   -6.473  -6.298  1.00 0.00 ? 16 ILE A CD1  2 
+ATOM   1591 H  H    . ILE A 1 16 ? 3.681   -8.255  -3.588  1.00 0.00 ? 16 ILE A H    2 
+ATOM   1592 H  HA   . ILE A 1 16 ? 5.362   -6.967  -5.628  1.00 0.00 ? 16 ILE A HA   2 
+ATOM   1593 H  HB   . ILE A 1 16 ? 4.143   -4.977  -3.910  1.00 0.00 ? 16 ILE A HB   2 
+ATOM   1594 H  HG12 . ILE A 1 16 ? 2.342   -6.796  -4.187  1.00 0.00 ? 16 ILE A HG12 2 
+ATOM   1595 H  HG13 . ILE A 1 16 ? 1.922   -5.164  -4.633  1.00 0.00 ? 16 ILE A HG13 2 
+ATOM   1596 H  HG21 . ILE A 1 16 ? 4.955   -5.421  -6.691  1.00 0.00 ? 16 ILE A HG21 2 
+ATOM   1597 H  HG22 . ILE A 1 16 ? 3.501   -4.436  -6.522  1.00 0.00 ? 16 ILE A HG22 2 
+ATOM   1598 H  HG23 . ILE A 1 16 ? 4.997   -3.945  -5.725  1.00 0.00 ? 16 ILE A HG23 2 
+ATOM   1599 H  HD11 . ILE A 1 16 ? 3.133   -6.723  -6.804  1.00 0.00 ? 16 ILE A HD11 2 
+ATOM   1600 H  HD12 . ILE A 1 16 ? 1.582   -7.342  -6.251  1.00 0.00 ? 16 ILE A HD12 2 
+ATOM   1601 H  HD13 . ILE A 1 16 ? 1.708   -5.690  -6.838  1.00 0.00 ? 16 ILE A HD13 2 
+ATOM   1602 N  N    . GLU A 1 17 ? 5.517   -6.048  -2.461  1.00 0.00 ? 17 GLU A N    2 
+ATOM   1603 C  CA   . GLU A 1 17 ? 6.416   -5.878  -1.258  1.00 0.00 ? 17 GLU A CA   2 
+ATOM   1604 C  C    . GLU A 1 17 ? 7.160   -4.567  -1.304  1.00 0.00 ? 17 GLU A C    2 
+ATOM   1605 O  O    . GLU A 1 17 ? 7.462   -4.000  -0.278  1.00 0.00 ? 17 GLU A O    2 
+ATOM   1606 C  CB   . GLU A 1 17 ? 7.434   -6.998  -1.122  1.00 0.00 ? 17 GLU A CB   2 
+ATOM   1607 C  CG   . GLU A 1 17 ? 8.438   -6.647  -0.022  1.00 0.00 ? 17 GLU A CG   2 
+ATOM   1608 C  CD   . GLU A 1 17 ? 8.646   -7.861  0.886   1.00 0.00 ? 17 GLU A CD   2 
+ATOM   1609 O  OE1  . GLU A 1 17 ? 8.359   -8.961  0.443   1.00 0.00 ? 17 GLU A OE1  2 
+ATOM   1610 O  OE2  . GLU A 1 17 ? 9.086   -7.670  2.006   1.00 0.00 ? 17 GLU A OE2  2 
+ATOM   1611 H  H    . GLU A 1 17 ? 4.632   -5.676  -2.417  1.00 0.00 ? 17 GLU A H    2 
+ATOM   1612 H  HA   . GLU A 1 17 ? 5.803   -5.890  -0.374  1.00 0.00 ? 17 GLU A HA   2 
+ATOM   1613 H  HB2  . GLU A 1 17 ? 6.927   -7.913  -0.852  1.00 0.00 ? 17 GLU A HB2  2 
+ATOM   1614 H  HB3  . GLU A 1 17 ? 7.944   -7.123  -2.045  1.00 0.00 ? 17 GLU A HB3  2 
+ATOM   1615 H  HG2  . GLU A 1 17 ? 9.380   -6.360  -0.466  1.00 0.00 ? 17 GLU A HG2  2 
+ATOM   1616 H  HG3  . GLU A 1 17 ? 8.052   -5.828  0.558   1.00 0.00 ? 17 GLU A HG3  2 
+ATOM   1617 N  N    . CYS A 1 18 ? 7.462   -4.079  -2.465  1.00 0.00 ? 18 CYS A N    2 
+ATOM   1618 C  CA   . CYS A 1 18 ? 8.194   -2.823  -2.563  1.00 0.00 ? 18 CYS A CA   2 
+ATOM   1619 C  C    . CYS A 1 18 ? 9.667   -3.082  -2.208  1.00 0.00 ? 18 CYS A C    2 
+ATOM   1620 O  O    . CYS A 1 18 ? 10.524  -3.099  -3.070  1.00 0.00 ? 18 CYS A O    2 
+ATOM   1621 C  CB   . CYS A 1 18 ? 7.572   -1.830  -1.609  1.00 0.00 ? 18 CYS A CB   2 
+ATOM   1622 S  SG   . CYS A 1 18 ? 5.759   -2.008  -1.567  1.00 0.00 ? 18 CYS A SG   2 
+ATOM   1623 H  H    . CYS A 1 18 ? 7.208   -4.532  -3.263  1.00 0.00 ? 18 CYS A H    2 
+ATOM   1624 H  HA   . CYS A 1 18 ? 8.128   -2.448  -3.568  1.00 0.00 ? 18 CYS A HA   2 
+ATOM   1625 H  HB2  . CYS A 1 18 ? 7.965   -1.997  -0.634  1.00 0.00 ? 18 CYS A HB2  2 
+ATOM   1626 H  HB3  . CYS A 1 18 ? 7.825   -0.856  -1.941  1.00 0.00 ? 18 CYS A HB3  2 
+ATOM   1627 N  N    . SER A 1 19 ? 9.972   -3.294  -0.953  1.00 0.00 ? 19 SER A N    2 
+ATOM   1628 C  CA   . SER A 1 19 ? 11.387  -3.563  -0.561  1.00 0.00 ? 19 SER A CA   2 
+ATOM   1629 C  C    . SER A 1 19 ? 12.280  -2.538  -1.242  1.00 0.00 ? 19 SER A C    2 
+ATOM   1630 O  O    . SER A 1 19 ? 13.438  -2.781  -1.523  1.00 0.00 ? 19 SER A O    2 
+ATOM   1631 C  CB   . SER A 1 19 ? 11.786  -4.970  -1.008  1.00 0.00 ? 19 SER A CB   2 
+ATOM   1632 O  OG   . SER A 1 19 ? 11.682  -5.861  0.095   1.00 0.00 ? 19 SER A OG   2 
+ATOM   1633 H  H    . SER A 1 19 ? 9.276   -3.279  -0.275  1.00 0.00 ? 19 SER A H    2 
+ATOM   1634 H  HA   . SER A 1 19 ? 11.489  -3.479  0.511   1.00 0.00 ? 19 SER A HA   2 
+ATOM   1635 H  HB2  . SER A 1 19 ? 11.128  -5.301  -1.795  1.00 0.00 ? 19 SER A HB2  2 
+ATOM   1636 H  HB3  . SER A 1 19 ? 12.803  -4.954  -1.377  1.00 0.00 ? 19 SER A HB3  2 
+ATOM   1637 H  HG   . SER A 1 19 ? 12.390  -5.655  0.710   1.00 0.00 ? 19 SER A HG   2 
+ATOM   1638 N  N    . ASP A 1 20 ? 11.733  -1.396  -1.518  1.00 0.00 ? 20 ASP A N    2 
+ATOM   1639 C  CA   . ASP A 1 20 ? 12.506  -0.328  -2.193  1.00 0.00 ? 20 ASP A CA   2 
+ATOM   1640 C  C    . ASP A 1 20 ? 11.562  0.846   -2.413  1.00 0.00 ? 20 ASP A C    2 
+ATOM   1641 O  O    . ASP A 1 20 ? 11.158  1.141   -3.520  1.00 0.00 ? 20 ASP A O    2 
+ATOM   1642 C  CB   . ASP A 1 20 ? 13.009  -0.854  -3.540  1.00 0.00 ? 20 ASP A CB   2 
+ATOM   1643 C  CG   . ASP A 1 20 ? 14.112  0.062   -4.070  1.00 0.00 ? 20 ASP A CG   2 
+ATOM   1644 O  OD1  . ASP A 1 20 ? 14.506  0.962   -3.347  1.00 0.00 ? 20 ASP A OD1  2 
+ATOM   1645 O  OD2  . ASP A 1 20 ? 14.546  -0.152  -5.190  1.00 0.00 ? 20 ASP A OD2  2 
+ATOM   1646 H  H    . ASP A 1 20 ? 10.794  -1.240  -1.284  1.00 0.00 ? 20 ASP A H    2 
+ATOM   1647 H  HA   . ASP A 1 20 ? 13.337  -0.025  -1.570  1.00 0.00 ? 20 ASP A HA   2 
+ATOM   1648 H  HB2  . ASP A 1 20 ? 13.395  -1.857  -3.411  1.00 0.00 ? 20 ASP A HB2  2 
+ATOM   1649 H  HB3  . ASP A 1 20 ? 12.188  -0.877  -4.244  1.00 0.00 ? 20 ASP A HB3  2 
+ATOM   1650 N  N    . ASP A 1 21 ? 11.169  1.482   -1.351  1.00 0.00 ? 21 ASP A N    2 
+ATOM   1651 C  CA   . ASP A 1 21 ? 10.203  2.602   -1.471  1.00 0.00 ? 21 ASP A CA   2 
+ATOM   1652 C  C    . ASP A 1 21 ? 8.841   1.975   -1.752  1.00 0.00 ? 21 ASP A C    2 
+ATOM   1653 O  O    . ASP A 1 21 ? 8.563   1.566   -2.860  1.00 0.00 ? 21 ASP A O    2 
+ATOM   1654 C  CB   . ASP A 1 21 ? 10.606  3.520   -2.626  1.00 0.00 ? 21 ASP A CB   2 
+ATOM   1655 C  CG   . ASP A 1 21 ? 12.133  3.592   -2.712  1.00 0.00 ? 21 ASP A CG   2 
+ATOM   1656 O  OD1  . ASP A 1 21 ? 12.725  4.218   -1.849  1.00 0.00 ? 21 ASP A OD1  2 
+ATOM   1657 O  OD2  . ASP A 1 21 ? 12.683  3.018   -3.638  1.00 0.00 ? 21 ASP A OD2  2 
+ATOM   1658 H  H    . ASP A 1 21 ? 11.481  1.197   -0.472  1.00 0.00 ? 21 ASP A H    2 
+ATOM   1659 H  HA   . ASP A 1 21 ? 10.168  3.160   -0.544  1.00 0.00 ? 21 ASP A HA   2 
+ATOM   1660 H  HB2  . ASP A 1 21 ? 10.211  3.130   -3.553  1.00 0.00 ? 21 ASP A HB2  2 
+ATOM   1661 H  HB3  . ASP A 1 21 ? 10.211  4.510   -2.455  1.00 0.00 ? 21 ASP A HB3  2 
+ATOM   1662 N  N    . THR A 1 22 ? 8.011   1.867   -0.747  1.00 0.00 ? 22 THR A N    2 
+ATOM   1663 C  CA   . THR A 1 22 ? 6.673   1.232   -0.931  1.00 0.00 ? 22 THR A CA   2 
+ATOM   1664 C  C    . THR A 1 22 ? 6.112   1.566   -2.310  1.00 0.00 ? 22 THR A C    2 
+ATOM   1665 O  O    . THR A 1 22 ? 5.449   2.571   -2.478  1.00 0.00 ? 22 THR A O    2 
+ATOM   1666 C  CB   . THR A 1 22 ? 5.720   1.758   0.145   1.00 0.00 ? 22 THR A CB   2 
+ATOM   1667 O  OG1  . THR A 1 22 ? 4.387   1.401   -0.191  1.00 0.00 ? 22 THR A OG1  2 
+ATOM   1668 C  CG2  . THR A 1 22 ? 5.837   3.280   0.234   1.00 0.00 ? 22 THR A CG2  2 
+ATOM   1669 H  H    . THR A 1 22 ? 8.275   2.188   0.141   1.00 0.00 ? 22 THR A H    2 
+ATOM   1670 H  HA   . THR A 1 22 ? 6.764   0.167   -0.828  1.00 0.00 ? 22 THR A HA   2 
+ATOM   1671 H  HB   . THR A 1 22 ? 5.980   1.326   1.098   1.00 0.00 ? 22 THR A HB   2 
+ATOM   1672 H  HG1  . THR A 1 22 ? 3.983   2.149   -0.638  1.00 0.00 ? 22 THR A HG1  2 
+ATOM   1673 H  HG21 . THR A 1 22 ? 6.190   3.670   -0.710  1.00 0.00 ? 22 THR A HG21 2 
+ATOM   1674 H  HG22 . THR A 1 22 ? 4.870   3.703   0.461   1.00 0.00 ? 22 THR A HG22 2 
+ATOM   1675 H  HG23 . THR A 1 22 ? 6.536   3.541   1.015   1.00 0.00 ? 22 THR A HG23 2 
+ATOM   1676 N  N    . TYR A 1 23 ? 6.345   0.746   -3.314  1.00 0.00 ? 23 TYR A N    2 
+ATOM   1677 C  CA   . TYR A 1 23 ? 5.774   1.099   -4.629  1.00 0.00 ? 23 TYR A CA   2 
+ATOM   1678 C  C    . TYR A 1 23 ? 4.274   1.287   -4.424  1.00 0.00 ? 23 TYR A C    2 
+ATOM   1679 O  O    . TYR A 1 23 ? 3.541   0.336   -4.307  1.00 0.00 ? 23 TYR A O    2 
+ATOM   1680 C  CB   . TYR A 1 23 ? 6.054   -0.003  -5.651  1.00 0.00 ? 23 TYR A CB   2 
+ATOM   1681 C  CG   . TYR A 1 23 ? 7.459   0.156   -6.181  1.00 0.00 ? 23 TYR A CG   2 
+ATOM   1682 C  CD1  . TYR A 1 23 ? 8.541   -0.381  -5.476  1.00 0.00 ? 23 TYR A CD1  2 
+ATOM   1683 C  CD2  . TYR A 1 23 ? 7.678   0.840   -7.383  1.00 0.00 ? 23 TYR A CD2  2 
+ATOM   1684 C  CE1  . TYR A 1 23 ? 9.842   -0.232  -5.970  1.00 0.00 ? 23 TYR A CE1  2 
+ATOM   1685 C  CE2  . TYR A 1 23 ? 8.979   0.989   -7.878  1.00 0.00 ? 23 TYR A CE2  2 
+ATOM   1686 C  CZ   . TYR A 1 23 ? 10.061  0.452   -7.172  1.00 0.00 ? 23 TYR A CZ   2 
+ATOM   1687 O  OH   . TYR A 1 23 ? 11.343  0.596   -7.660  1.00 0.00 ? 23 TYR A OH   2 
+ATOM   1688 H  H    . TYR A 1 23 ? 6.872   -0.083  -3.201  1.00 0.00 ? 23 TYR A H    2 
+ATOM   1689 H  HA   . TYR A 1 23 ? 6.211   2.024   -4.963  1.00 0.00 ? 23 TYR A HA   2 
+ATOM   1690 H  HB2  . TYR A 1 23 ? 5.950   -0.970  -5.182  1.00 0.00 ? 23 TYR A HB2  2 
+ATOM   1691 H  HB3  . TYR A 1 23 ? 5.356   0.082   -6.469  1.00 0.00 ? 23 TYR A HB3  2 
+ATOM   1692 H  HD1  . TYR A 1 23 ? 8.372   -0.906  -4.549  1.00 0.00 ? 23 TYR A HD1  2 
+ATOM   1693 H  HD2  . TYR A 1 23 ? 6.843   1.254   -7.928  1.00 0.00 ? 23 TYR A HD2  2 
+ATOM   1694 H  HE1  . TYR A 1 23 ? 10.677  -0.647  -5.425  1.00 0.00 ? 23 TYR A HE1  2 
+ATOM   1695 H  HE2  . TYR A 1 23 ? 9.148   1.517   -8.804  1.00 0.00 ? 23 TYR A HE2  2 
+ATOM   1696 H  HH   . TYR A 1 23 ? 11.605  -0.239  -8.054  1.00 0.00 ? 23 TYR A HH   2 
+ATOM   1697 N  N    . ILE A 1 24 ? 3.855   2.524   -4.326  1.00 0.00 ? 24 ILE A N    2 
+ATOM   1698 C  CA   . ILE A 1 24 ? 2.414   2.890   -4.071  1.00 0.00 ? 24 ILE A CA   2 
+ATOM   1699 C  C    . ILE A 1 24 ? 1.428   1.744   -4.354  1.00 0.00 ? 24 ILE A C    2 
+ATOM   1700 O  O    . ILE A 1 24 ? 1.727   0.755   -5.002  1.00 0.00 ? 24 ILE A O    2 
+ATOM   1701 C  CB   . ILE A 1 24 ? 2.038   4.076   -4.966  1.00 0.00 ? 24 ILE A CB   2 
+ATOM   1702 C  CG1  . ILE A 1 24 ? 3.233   5.023   -5.108  1.00 0.00 ? 24 ILE A CG1  2 
+ATOM   1703 C  CG2  . ILE A 1 24 ? 0.868   4.831   -4.342  1.00 0.00 ? 24 ILE A CG2  2 
+ATOM   1704 C  CD1  . ILE A 1 24 ? 4.080   4.599   -6.308  1.00 0.00 ? 24 ILE A CD1  2 
+ATOM   1705 H  H    . ILE A 1 24 ? 4.516   3.244   -4.388  1.00 0.00 ? 24 ILE A H    2 
+ATOM   1706 H  HA   . ILE A 1 24 ? 2.310   3.193   -3.041  1.00 0.00 ? 24 ILE A HA   2 
+ATOM   1707 H  HB   . ILE A 1 24 ? 1.749   3.710   -5.940  1.00 0.00 ? 24 ILE A HB   2 
+ATOM   1708 H  HG12 . ILE A 1 24 ? 2.876   6.032   -5.256  1.00 0.00 ? 24 ILE A HG12 2 
+ATOM   1709 H  HG13 . ILE A 1 24 ? 3.835   4.980   -4.212  1.00 0.00 ? 24 ILE A HG13 2 
+ATOM   1710 H  HG21 . ILE A 1 24 ? 0.655   4.418   -3.369  1.00 0.00 ? 24 ILE A HG21 2 
+ATOM   1711 H  HG22 . ILE A 1 24 ? 1.126   5.875   -4.241  1.00 0.00 ? 24 ILE A HG22 2 
+ATOM   1712 H  HG23 . ILE A 1 24 ? -0.003  4.735   -4.973  1.00 0.00 ? 24 ILE A HG23 2 
+ATOM   1713 H  HD11 . ILE A 1 24 ? 4.112   3.521   -6.367  1.00 0.00 ? 24 ILE A HD11 2 
+ATOM   1714 H  HD12 . ILE A 1 24 ? 3.645   4.995   -7.215  1.00 0.00 ? 24 ILE A HD12 2 
+ATOM   1715 H  HD13 . ILE A 1 24 ? 5.084   4.983   -6.195  1.00 0.00 ? 24 ILE A HD13 2 
+ATOM   1716 N  N    . LEU A 1 25 ? 0.209   1.893   -3.904  1.00 0.00 ? 25 LEU A N    2 
+ATOM   1717 C  CA   . LEU A 1 25 ? -0.800  0.840   -4.185  1.00 0.00 ? 25 LEU A CA   2 
+ATOM   1718 C  C    . LEU A 1 25 ? -0.654  0.446   -5.654  1.00 0.00 ? 25 LEU A C    2 
+ATOM   1719 O  O    . LEU A 1 25 ? -0.947  -0.660  -6.050  1.00 0.00 ? 25 LEU A O    2 
+ATOM   1720 C  CB   . LEU A 1 25 ? -2.204  1.378   -3.908  1.00 0.00 ? 25 LEU A CB   2 
+ATOM   1721 C  CG   . LEU A 1 25 ? -2.748  0.715   -2.642  1.00 0.00 ? 25 LEU A CG   2 
+ATOM   1722 C  CD1  . LEU A 1 25 ? -2.305  1.515   -1.416  1.00 0.00 ? 25 LEU A CD1  2 
+ATOM   1723 C  CD2  . LEU A 1 25 ? -4.275  0.676   -2.696  1.00 0.00 ? 25 LEU A CD2  2 
+ATOM   1724 H  H    . LEU A 1 25 ? -0.043  2.701   -3.414  1.00 0.00 ? 25 LEU A H    2 
+ATOM   1725 H  HA   . LEU A 1 25 ? -0.608  -0.021  -3.559  1.00 0.00 ? 25 LEU A HA   2 
+ATOM   1726 H  HB2  . LEU A 1 25 ? -2.157  2.449   -3.767  1.00 0.00 ? 25 LEU A HB2  2 
+ATOM   1727 H  HB3  . LEU A 1 25 ? -2.851  1.151   -4.741  1.00 0.00 ? 25 LEU A HB3  2 
+ATOM   1728 H  HG   . LEU A 1 25 ? -2.363  -0.292  -2.571  1.00 0.00 ? 25 LEU A HG   2 
+ATOM   1729 H  HD11 . LEU A 1 25 ? -1.444  2.115   -1.670  1.00 0.00 ? 25 LEU A HD11 2 
+ATOM   1730 H  HD12 . LEU A 1 25 ? -3.110  2.157   -1.094  1.00 0.00 ? 25 LEU A HD12 2 
+ATOM   1731 H  HD13 . LEU A 1 25 ? -2.046  0.835   -0.618  1.00 0.00 ? 25 LEU A HD13 2 
+ATOM   1732 H  HD21 . LEU A 1 25 ? -4.621  1.288   -3.516  1.00 0.00 ? 25 LEU A HD21 2 
+ATOM   1733 H  HD22 . LEU A 1 25 ? -4.605  -0.341  -2.840  1.00 0.00 ? 25 LEU A HD22 2 
+ATOM   1734 H  HD23 . LEU A 1 25 ? -4.677  1.056   -1.768  1.00 0.00 ? 25 LEU A HD23 2 
+ATOM   1735 N  N    . ASP A 1 26 ? -0.147  1.345   -6.458  1.00 0.00 ? 26 ASP A N    2 
+ATOM   1736 C  CA   . ASP A 1 26 ? 0.074   1.014   -7.883  1.00 0.00 ? 26 ASP A CA   2 
+ATOM   1737 C  C    . ASP A 1 26 ? 0.828   -0.317  -7.956  1.00 0.00 ? 26 ASP A C    2 
+ATOM   1738 O  O    . ASP A 1 26 ? 0.363   -1.263  -8.547  1.00 0.00 ? 26 ASP A O    2 
+ATOM   1739 C  CB   . ASP A 1 26 ? 0.907   2.114   -8.545  1.00 0.00 ? 26 ASP A CB   2 
+ATOM   1740 C  CG   . ASP A 1 26 ? 0.837   1.962   -10.065 1.00 0.00 ? 26 ASP A CG   2 
+ATOM   1741 O  OD1  . ASP A 1 26 ? 0.024   1.177   -10.525 1.00 0.00 ? 26 ASP A OD1  2 
+ATOM   1742 O  OD2  . ASP A 1 26 ? 1.598   2.631   -10.742 1.00 0.00 ? 26 ASP A OD2  2 
+ATOM   1743 H  H    . ASP A 1 26 ? 0.111   2.224   -6.118  1.00 0.00 ? 26 ASP A H    2 
+ATOM   1744 H  HA   . ASP A 1 26 ? -0.875  0.925   -8.385  1.00 0.00 ? 26 ASP A HA   2 
+ATOM   1745 H  HB2  . ASP A 1 26 ? 0.515   3.081   -8.260  1.00 0.00 ? 26 ASP A HB2  2 
+ATOM   1746 H  HB3  . ASP A 1 26 ? 1.934   2.034   -8.223  1.00 0.00 ? 26 ASP A HB3  2 
+ATOM   1747 N  N    . ALA A 1 27 ? 1.981   -0.424  -7.347  1.00 0.00 ? 27 ALA A N    2 
+ATOM   1748 C  CA   . ALA A 1 27 ? 2.697   -1.725  -7.407  1.00 0.00 ? 27 ALA A CA   2 
+ATOM   1749 C  C    . ALA A 1 27 ? 1.734   -2.833  -7.002  1.00 0.00 ? 27 ALA A C    2 
+ATOM   1750 O  O    . ALA A 1 27 ? 1.549   -3.807  -7.708  1.00 0.00 ? 27 ALA A O    2 
+ATOM   1751 C  CB   . ALA A 1 27 ? 3.880   -1.716  -6.435  1.00 0.00 ? 27 ALA A CB   2 
+ATOM   1752 H  H    . ALA A 1 27 ? 2.365   0.330   -6.843  1.00 0.00 ? 27 ALA A H    2 
+ATOM   1753 H  HA   . ALA A 1 27 ? 3.050   -1.899  -8.409  1.00 0.00 ? 27 ALA A HA   2 
+ATOM   1754 H  HB1  . ALA A 1 27 ? 3.884   -0.793  -5.890  1.00 0.00 ? 27 ALA A HB1  2 
+ATOM   1755 H  HB2  . ALA A 1 27 ? 3.786   -2.539  -5.741  1.00 0.00 ? 27 ALA A HB2  2 
+ATOM   1756 H  HB3  . ALA A 1 27 ? 4.807   -1.814  -6.984  1.00 0.00 ? 27 ALA A HB3  2 
+ATOM   1757 N  N    . ALA A 1 28 ? 1.133   -2.702  -5.854  1.00 0.00 ? 28 ALA A N    2 
+ATOM   1758 C  CA   . ALA A 1 28 ? 0.209   -3.769  -5.380  1.00 0.00 ? 28 ALA A CA   2 
+ATOM   1759 C  C    . ALA A 1 28 ? -1.215  -3.571  -5.902  1.00 0.00 ? 28 ALA A C    2 
+ATOM   1760 O  O    . ALA A 1 28 ? -1.646  -4.220  -6.837  1.00 0.00 ? 28 ALA A O    2 
+ATOM   1761 C  CB   . ALA A 1 28 ? 0.186   -3.778  -3.850  1.00 0.00 ? 28 ALA A CB   2 
+ATOM   1762 H  H    . ALA A 1 28 ? 1.309   -1.917  -5.297  1.00 0.00 ? 28 ALA A H    2 
+ATOM   1763 H  HA   . ALA A 1 28 ? 0.576   -4.710  -5.727  1.00 0.00 ? 28 ALA A HA   2 
+ATOM   1764 H  HB1  . ALA A 1 28 ? 0.848   -3.011  -3.475  1.00 0.00 ? 28 ALA A HB1  2 
+ATOM   1765 H  HB2  . ALA A 1 28 ? -0.819  -3.588  -3.504  1.00 0.00 ? 28 ALA A HB2  2 
+ATOM   1766 H  HB3  . ALA A 1 28 ? 0.512   -4.743  -3.490  1.00 0.00 ? 28 ALA A HB3  2 
+ATOM   1767 N  N    . GLU A 1 29 ? -1.960  -2.716  -5.274  1.00 0.00 ? 29 GLU A N    2 
+ATOM   1768 C  CA   . GLU A 1 29 ? -3.369  -2.502  -5.690  1.00 0.00 ? 29 GLU A CA   2 
+ATOM   1769 C  C    . GLU A 1 29 ? -3.506  -2.485  -7.224  1.00 0.00 ? 29 GLU A C    2 
+ATOM   1770 O  O    . GLU A 1 29 ? -4.564  -2.768  -7.738  1.00 0.00 ? 29 GLU A O    2 
+ATOM   1771 C  CB   . GLU A 1 29 ? -3.888  -1.201  -5.040  1.00 0.00 ? 29 GLU A CB   2 
+ATOM   1772 C  CG   . GLU A 1 29 ? -4.483  -0.217  -6.067  1.00 0.00 ? 29 GLU A CG   2 
+ATOM   1773 C  CD   . GLU A 1 29 ? -5.677  0.505   -5.439  1.00 0.00 ? 29 GLU A CD   2 
+ATOM   1774 O  OE1  . GLU A 1 29 ? -6.119  0.073   -4.387  1.00 0.00 ? 29 GLU A OE1  2 
+ATOM   1775 O  OE2  . GLU A 1 29 ? -6.130  1.478   -6.020  1.00 0.00 ? 29 GLU A OE2  2 
+ATOM   1776 H  H    . GLU A 1 29 ? -1.601  -2.229  -4.504  1.00 0.00 ? 29 GLU A H    2 
+ATOM   1777 H  HA   . GLU A 1 29 ? -3.955  -3.326  -5.311  1.00 0.00 ? 29 GLU A HA   2 
+ATOM   1778 H  HB2  . GLU A 1 29 ? -4.650  -1.457  -4.320  1.00 0.00 ? 29 GLU A HB2  2 
+ATOM   1779 H  HB3  . GLU A 1 29 ? -3.069  -0.722  -4.523  1.00 0.00 ? 29 GLU A HB3  2 
+ATOM   1780 H  HG2  . GLU A 1 29 ? -3.733  0.506   -6.350  1.00 0.00 ? 29 GLU A HG2  2 
+ATOM   1781 H  HG3  . GLU A 1 29 ? -4.816  -0.749  -6.941  1.00 0.00 ? 29 GLU A HG3  2 
+ATOM   1782 N  N    . GLU A 1 30 ? -2.470  -2.181  -7.967  1.00 0.00 ? 30 GLU A N    2 
+ATOM   1783 C  CA   . GLU A 1 30 ? -2.622  -2.188  -9.449  1.00 0.00 ? 30 GLU A CA   2 
+ATOM   1784 C  C    . GLU A 1 30 ? -2.383  -3.597  -9.925  1.00 0.00 ? 30 GLU A C    2 
+ATOM   1785 O  O    . GLU A 1 30 ? -3.086  -4.116  -10.768 1.00 0.00 ? 30 GLU A O    2 
+ATOM   1786 C  CB   . GLU A 1 30 ? -1.614  -1.255  -10.118 1.00 0.00 ? 30 GLU A CB   2 
+ATOM   1787 C  CG   . GLU A 1 30 ? -2.125  -0.851  -11.502 1.00 0.00 ? 30 GLU A CG   2 
+ATOM   1788 C  CD   . GLU A 1 30 ? -1.635  -1.856  -12.545 1.00 0.00 ? 30 GLU A CD   2 
+ATOM   1789 O  OE1  . GLU A 1 30 ? -0.437  -2.080  -12.606 1.00 0.00 ? 30 GLU A OE1  2 
+ATOM   1790 O  OE2  . GLU A 1 30 ? -2.466  -2.384  -13.265 1.00 0.00 ? 30 GLU A OE2  2 
+ATOM   1791 H  H    . GLU A 1 30 ? -1.613  -1.975  -7.564  1.00 0.00 ? 30 GLU A H    2 
+ATOM   1792 H  HA   . GLU A 1 30 ? -3.617  -1.891  -9.698  1.00 0.00 ? 30 GLU A HA   2 
+ATOM   1793 H  HB2  . GLU A 1 30 ? -1.479  -0.374  -9.512  1.00 0.00 ? 30 GLU A HB2  2 
+ATOM   1794 H  HB3  . GLU A 1 30 ? -0.671  -1.767  -10.228 1.00 0.00 ? 30 GLU A HB3  2 
+ATOM   1795 H  HG2  . GLU A 1 30 ? -3.205  -0.836  -11.499 1.00 0.00 ? 30 GLU A HG2  2 
+ATOM   1796 H  HG3  . GLU A 1 30 ? -1.752  0.129   -11.749 1.00 0.00 ? 30 GLU A HG3  2 
+ATOM   1797 N  N    . ALA A 1 31 ? -1.401  -4.225  -9.350  1.00 0.00 ? 31 ALA A N    2 
+ATOM   1798 C  CA   . ALA A 1 31 ? -1.092  -5.627  -9.697  1.00 0.00 ? 31 ALA A CA   2 
+ATOM   1799 C  C    . ALA A 1 31 ? -2.405  -6.376  -9.878  1.00 0.00 ? 31 ALA A C    2 
+ATOM   1800 O  O    . ALA A 1 31 ? -2.509  -7.312  -10.646 1.00 0.00 ? 31 ALA A O    2 
+ATOM   1801 C  CB   . ALA A 1 31 ? -0.316  -6.236  -8.539  1.00 0.00 ? 31 ALA A CB   2 
+ATOM   1802 H  H    . ALA A 1 31 ? -0.876  -3.771  -8.663  1.00 0.00 ? 31 ALA A H    2 
+ATOM   1803 H  HA   . ALA A 1 31 ? -0.507  -5.667  -10.601 1.00 0.00 ? 31 ALA A HA   2 
+ATOM   1804 H  HB1  . ALA A 1 31 ? 0.043   -5.443  -7.897  1.00 0.00 ? 31 ALA A HB1  2 
+ATOM   1805 H  HB2  . ALA A 1 31 ? -0.970  -6.885  -7.975  1.00 0.00 ? 31 ALA A HB2  2 
+ATOM   1806 H  HB3  . ALA A 1 31 ? 0.518   -6.798  -8.920  1.00 0.00 ? 31 ALA A HB3  2 
+ATOM   1807 N  N    . GLY A 1 32 ? -3.420  -5.946  -9.176  1.00 0.00 ? 32 GLY A N    2 
+ATOM   1808 C  CA   . GLY A 1 32 ? -4.739  -6.603  -9.303  1.00 0.00 ? 32 GLY A CA   2 
+ATOM   1809 C  C    . GLY A 1 32 ? -5.552  -5.898  -10.390 1.00 0.00 ? 32 GLY A C    2 
+ATOM   1810 O  O    . GLY A 1 32 ? -5.839  -6.470  -11.422 1.00 0.00 ? 32 GLY A O    2 
+ATOM   1811 H  H    . GLY A 1 32 ? -3.312  -5.182  -8.569  1.00 0.00 ? 32 GLY A H    2 
+ATOM   1812 H  HA2  . GLY A 1 32 ? -4.599  -7.641  -9.571  1.00 0.00 ? 32 GLY A HA2  2 
+ATOM   1813 H  HA3  . GLY A 1 32 ? -5.267  -6.539  -8.364  1.00 0.00 ? 32 GLY A HA3  2 
+ATOM   1814 N  N    . LEU A 1 33 ? -5.958  -4.674  -10.161 1.00 0.00 ? 33 LEU A N    2 
+ATOM   1815 C  CA   . LEU A 1 33 ? -6.778  -3.983  -11.175 1.00 0.00 ? 33 LEU A CA   2 
+ATOM   1816 C  C    . LEU A 1 33 ? -7.079  -2.514  -10.803 1.00 0.00 ? 33 LEU A C    2 
+ATOM   1817 O  O    . LEU A 1 33 ? -7.921  -1.887  -11.416 1.00 0.00 ? 33 LEU A O    2 
+ATOM   1818 C  CB   . LEU A 1 33 ? -8.090  -4.734  -11.271 1.00 0.00 ? 33 LEU A CB   2 
+ATOM   1819 C  CG   . LEU A 1 33 ? -8.466  -5.304  -9.898  1.00 0.00 ? 33 LEU A CG   2 
+ATOM   1820 C  CD1  . LEU A 1 33 ? -9.961  -5.117  -9.653  1.00 0.00 ? 33 LEU A CD1  2 
+ATOM   1821 C  CD2  . LEU A 1 33 ? -8.126  -6.797  -9.851  1.00 0.00 ? 33 LEU A CD2  2 
+ATOM   1822 H  H    . LEU A 1 33 ? -5.758  -4.241  -9.336  1.00 0.00 ? 33 LEU A H    2 
+ATOM   1823 H  HA   . LEU A 1 33 ? -6.277  -4.021  -12.122 1.00 0.00 ? 33 LEU A HA   2 
+ATOM   1824 H  HB2  . LEU A 1 33 ? -8.850  -4.054  -11.591 1.00 0.00 ? 33 LEU A HB2  2 
+ATOM   1825 H  HB3  . LEU A 1 33 ? -7.989  -5.536  -11.976 1.00 0.00 ? 33 LEU A HB3  2 
+ATOM   1826 H  HG   . LEU A 1 33 ? -7.911  -4.784  -9.131  1.00 0.00 ? 33 LEU A HG   2 
+ATOM   1827 H  HD11 . LEU A 1 33 ? -10.274 -4.166  -10.057 1.00 0.00 ? 33 LEU A HD11 2 
+ATOM   1828 H  HD12 . LEU A 1 33 ? -10.506 -5.912  -10.137 1.00 0.00 ? 33 LEU A HD12 2 
+ATOM   1829 H  HD13 . LEU A 1 33 ? -10.156 -5.139  -8.591  1.00 0.00 ? 33 LEU A HD13 2 
+ATOM   1830 H  HD21 . LEU A 1 33 ? -7.780  -7.118  -10.822 1.00 0.00 ? 33 LEU A HD21 2 
+ATOM   1831 H  HD22 . LEU A 1 33 ? -7.347  -6.965  -9.120  1.00 0.00 ? 33 LEU A HD22 2 
+ATOM   1832 H  HD23 . LEU A 1 33 ? -9.005  -7.359  -9.576  1.00 0.00 ? 33 LEU A HD23 2 
+ATOM   1833 N  N    . ASP A 1 34 ? -6.437  -1.954  -9.812  1.00 0.00 ? 34 ASP A N    2 
+ATOM   1834 C  CA   . ASP A 1 34 ? -6.733  -0.552  -9.434  1.00 0.00 ? 34 ASP A CA   2 
+ATOM   1835 C  C    . ASP A 1 34 ? -5.437  0.275   -9.419  1.00 0.00 ? 34 ASP A C    2 
+ATOM   1836 O  O    . ASP A 1 34 ? -4.468  -0.087  -10.043 1.00 0.00 ? 34 ASP A O    2 
+ATOM   1837 C  CB   . ASP A 1 34 ? -7.366  -0.565  -8.050  1.00 0.00 ? 34 ASP A CB   2 
+ATOM   1838 C  CG   . ASP A 1 34 ? -8.260  0.664   -7.870  1.00 0.00 ? 34 ASP A CG   2 
+ATOM   1839 O  OD1  . ASP A 1 34 ? -8.454  1.379   -8.841  1.00 0.00 ? 34 ASP A OD1  2 
+ATOM   1840 O  OD2  . ASP A 1 34 ? -8.735  0.871   -6.767  1.00 0.00 ? 34 ASP A OD2  2 
+ATOM   1841 H  H    . ASP A 1 34 ? -5.783  -2.445  -9.312  1.00 0.00 ? 34 ASP A H    2 
+ATOM   1842 H  HA   . ASP A 1 34 ? -7.420  -0.138  -10.141 1.00 0.00 ? 34 ASP A HA   2 
+ATOM   1843 H  HB2  . ASP A 1 34 ? -7.956  -1.462  -7.941  1.00 0.00 ? 34 ASP A HB2  2 
+ATOM   1844 H  HB3  . ASP A 1 34 ? -6.587  -0.561  -7.309  1.00 0.00 ? 34 ASP A HB3  2 
+ATOM   1845 N  N    . LEU A 1 35 ? -5.415  1.384   -8.710  1.00 0.00 ? 35 LEU A N    2 
+ATOM   1846 C  CA   . LEU A 1 35 ? -4.177  2.230   -8.657  1.00 0.00 ? 35 LEU A CA   2 
+ATOM   1847 C  C    . LEU A 1 35 ? -4.542  3.675   -8.290  1.00 0.00 ? 35 LEU A C    2 
+ATOM   1848 O  O    . LEU A 1 35 ? -5.068  4.401   -9.110  1.00 0.00 ? 35 LEU A O    2 
+ATOM   1849 C  CB   . LEU A 1 35 ? -3.482  2.239   -10.025 1.00 0.00 ? 35 LEU A CB   2 
+ATOM   1850 C  CG   . LEU A 1 35 ? -4.526  2.405   -11.131 1.00 0.00 ? 35 LEU A CG   2 
+ATOM   1851 C  CD1  . LEU A 1 35 ? -4.443  3.822   -11.698 1.00 0.00 ? 35 LEU A CD1  2 
+ATOM   1852 C  CD2  . LEU A 1 35 ? -4.255  1.391   -12.246 1.00 0.00 ? 35 LEU A CD2  2 
+ATOM   1853 H  H    . LEU A 1 35 ? -6.210  1.660   -8.214  1.00 0.00 ? 35 LEU A H    2 
+ATOM   1854 H  HA   . LEU A 1 35 ? -3.500  1.835   -7.915  1.00 0.00 ? 35 LEU A HA   2 
+ATOM   1855 H  HB2  . LEU A 1 35 ? -2.783  3.061   -10.065 1.00 0.00 ? 35 LEU A HB2  2 
+ATOM   1856 H  HB3  . LEU A 1 35 ? -2.951  1.311   -10.167 1.00 0.00 ? 35 LEU A HB3  2 
+ATOM   1857 H  HG   . LEU A 1 35 ? -5.513  2.240   -10.724 1.00 0.00 ? 35 LEU A HG   2 
+ATOM   1858 H  HD11 . LEU A 1 35 ? -3.726  4.395   -11.128 1.00 0.00 ? 35 LEU A HD11 2 
+ATOM   1859 H  HD12 . LEU A 1 35 ? -4.130  3.780   -12.731 1.00 0.00 ? 35 LEU A HD12 2 
+ATOM   1860 H  HD13 . LEU A 1 35 ? -5.411  4.294   -11.633 1.00 0.00 ? 35 LEU A HD13 2 
+ATOM   1861 H  HD21 . LEU A 1 35 ? -3.197  1.183   -12.295 1.00 0.00 ? 35 LEU A HD21 2 
+ATOM   1862 H  HD22 . LEU A 1 35 ? -4.793  0.478   -12.041 1.00 0.00 ? 35 LEU A HD22 2 
+ATOM   1863 H  HD23 . LEU A 1 35 ? -4.585  1.798   -13.191 1.00 0.00 ? 35 LEU A HD23 2 
+ATOM   1864 N  N    . PRO A 1 36 ? -4.237  4.057   -7.072  1.00 0.00 ? 36 PRO A N    2 
+ATOM   1865 C  CA   . PRO A 1 36 ? -4.511  5.420   -6.591  1.00 0.00 ? 36 PRO A CA   2 
+ATOM   1866 C  C    . PRO A 1 36 ? -3.528  6.390   -7.257  1.00 0.00 ? 36 PRO A C    2 
+ATOM   1867 O  O    . PRO A 1 36 ? -3.818  6.970   -8.284  1.00 0.00 ? 36 PRO A O    2 
+ATOM   1868 C  CB   . PRO A 1 36 ? -4.262  5.353   -5.078  1.00 0.00 ? 36 PRO A CB   2 
+ATOM   1869 C  CG   . PRO A 1 36 ? -3.588  3.990   -4.782  1.00 0.00 ? 36 PRO A CG   2 
+ATOM   1870 C  CD   . PRO A 1 36 ? -3.607  3.169   -6.080  1.00 0.00 ? 36 PRO A CD   2 
+ATOM   1871 H  HA   . PRO A 1 36 ? -5.532  5.704   -6.792  1.00 0.00 ? 36 PRO A HA   2 
+ATOM   1872 H  HB2  . PRO A 1 36 ? -3.616  6.164   -4.772  1.00 0.00 ? 36 PRO A HB2  2 
+ATOM   1873 H  HB3  . PRO A 1 36 ? -5.200  5.411   -4.549  1.00 0.00 ? 36 PRO A HB3  2 
+ATOM   1874 H  HG2  . PRO A 1 36 ? -2.568  4.148   -4.460  1.00 0.00 ? 36 PRO A HG2  2 
+ATOM   1875 H  HG3  . PRO A 1 36 ? -4.138  3.468   -4.015  1.00 0.00 ? 36 PRO A HG3  2 
+ATOM   1876 H  HD2  . PRO A 1 36 ? -2.597  2.921   -6.382  1.00 0.00 ? 36 PRO A HD2  2 
+ATOM   1877 H  HD3  . PRO A 1 36 ? -4.196  2.275   -5.954  1.00 0.00 ? 36 PRO A HD3  2 
+ATOM   1878 N  N    . TYR A 1 37 ? -2.359  6.543   -6.680  1.00 0.00 ? 37 TYR A N    2 
+ATOM   1879 C  CA   . TYR A 1 37 ? -1.321  7.450   -7.263  1.00 0.00 ? 37 TYR A CA   2 
+ATOM   1880 C  C    . TYR A 1 37 ? -1.981  8.642   -7.954  1.00 0.00 ? 37 TYR A C    2 
+ATOM   1881 O  O    . TYR A 1 37 ? -1.605  9.023   -9.045  1.00 0.00 ? 37 TYR A O    2 
+ATOM   1882 C  CB   . TYR A 1 37 ? -0.489  6.671   -8.284  1.00 0.00 ? 37 TYR A CB   2 
+ATOM   1883 C  CG   . TYR A 1 37 ? 0.791   7.416   -8.566  1.00 0.00 ? 37 TYR A CG   2 
+ATOM   1884 C  CD1  . TYR A 1 37 ? 1.733   7.604   -7.546  1.00 0.00 ? 37 TYR A CD1  2 
+ATOM   1885 C  CD2  . TYR A 1 37 ? 1.040   7.918   -9.849  1.00 0.00 ? 37 TYR A CD2  2 
+ATOM   1886 C  CE1  . TYR A 1 37 ? 2.922   8.294   -7.810  1.00 0.00 ? 37 TYR A CE1  2 
+ATOM   1887 C  CE2  . TYR A 1 37 ? 2.230   8.608   -10.113 1.00 0.00 ? 37 TYR A CE2  2 
+ATOM   1888 C  CZ   . TYR A 1 37 ? 3.170   8.796   -9.093  1.00 0.00 ? 37 TYR A CZ   2 
+ATOM   1889 O  OH   . TYR A 1 37 ? 4.344   9.474   -9.354  1.00 0.00 ? 37 TYR A OH   2 
+ATOM   1890 H  H    . TYR A 1 37 ? -2.154  6.044   -5.863  1.00 0.00 ? 37 TYR A H    2 
+ATOM   1891 H  HA   . TYR A 1 37 ? -0.674  7.806   -6.475  1.00 0.00 ? 37 TYR A HA   2 
+ATOM   1892 H  HB2  . TYR A 1 37 ? -0.257  5.693   -7.886  1.00 0.00 ? 37 TYR A HB2  2 
+ATOM   1893 H  HB3  . TYR A 1 37 ? -1.052  6.562   -9.199  1.00 0.00 ? 37 TYR A HB3  2 
+ATOM   1894 H  HD1  . TYR A 1 37 ? 1.541   7.216   -6.557  1.00 0.00 ? 37 TYR A HD1  2 
+ATOM   1895 H  HD2  . TYR A 1 37 ? 0.315   7.773   -10.636 1.00 0.00 ? 37 TYR A HD2  2 
+ATOM   1896 H  HE1  . TYR A 1 37 ? 3.648   8.438   -7.023  1.00 0.00 ? 37 TYR A HE1  2 
+ATOM   1897 H  HE2  . TYR A 1 37 ? 2.421   8.996   -11.102 1.00 0.00 ? 37 TYR A HE2  2 
+ATOM   1898 H  HH   . TYR A 1 37 ? 4.237   10.378  -9.051  1.00 0.00 ? 37 TYR A HH   2 
+ATOM   1899 N  N    . SER A 1 38 ? -2.961  9.234   -7.334  1.00 0.00 ? 38 SER A N    2 
+ATOM   1900 C  CA   . SER A 1 38 ? -3.635  10.397  -7.969  1.00 0.00 ? 38 SER A CA   2 
+ATOM   1901 C  C    . SER A 1 38 ? -3.877  11.488  -6.925  1.00 0.00 ? 38 SER A C    2 
+ATOM   1902 O  O    . SER A 1 38 ? -3.602  12.648  -7.156  1.00 0.00 ? 38 SER A O    2 
+ATOM   1903 C  CB   . SER A 1 38 ? -4.972  9.951   -8.562  1.00 0.00 ? 38 SER A CB   2 
+ATOM   1904 O  OG   . SER A 1 38 ? -5.158  10.581  -9.823  1.00 0.00 ? 38 SER A OG   2 
+ATOM   1905 H  H    . SER A 1 38 ? -3.254  8.913   -6.456  1.00 0.00 ? 38 SER A H    2 
+ATOM   1906 H  HA   . SER A 1 38 ? -3.007  10.787  -8.755  1.00 0.00 ? 38 SER A HA   2 
+ATOM   1907 H  HB2  . SER A 1 38 ? -4.970  8.882   -8.696  1.00 0.00 ? 38 SER A HB2  2 
+ATOM   1908 H  HB3  . SER A 1 38 ? -5.774  10.226  -7.888  1.00 0.00 ? 38 SER A HB3  2 
+ATOM   1909 H  HG   . SER A 1 38 ? -5.941  11.132  -9.767  1.00 0.00 ? 38 SER A HG   2 
+ATOM   1910 N  N    . CYS A 1 39 ? -4.399  11.134  -5.781  1.00 0.00 ? 39 CYS A N    2 
+ATOM   1911 C  CA   . CYS A 1 39 ? -4.663  12.170  -4.746  1.00 0.00 ? 39 CYS A CA   2 
+ATOM   1912 C  C    . CYS A 1 39 ? -3.455  12.258  -3.797  1.00 0.00 ? 39 CYS A C    2 
+ATOM   1913 O  O    . CYS A 1 39 ? -3.329  13.189  -3.027  1.00 0.00 ? 39 CYS A O    2 
+ATOM   1914 C  CB   . CYS A 1 39 ? -5.975  11.816  -4.000  1.00 0.00 ? 39 CYS A CB   2 
+ATOM   1915 S  SG   . CYS A 1 39 ? -5.689  11.261  -2.292  1.00 0.00 ? 39 CYS A SG   2 
+ATOM   1916 H  H    . CYS A 1 39 ? -4.626  10.196  -5.611  1.00 0.00 ? 39 CYS A H    2 
+ATOM   1917 H  HA   . CYS A 1 39 ? -4.787  13.124  -5.237  1.00 0.00 ? 39 CYS A HA   2 
+ATOM   1918 H  HB2  . CYS A 1 39 ? -6.608  12.689  -3.977  1.00 0.00 ? 39 CYS A HB2  2 
+ATOM   1919 H  HB3  . CYS A 1 39 ? -6.484  11.033  -4.546  1.00 0.00 ? 39 CYS A HB3  2 
+ATOM   1920 N  N    . ARG A 1 40 ? -2.563  11.303  -3.869  1.00 0.00 ? 40 ARG A N    2 
+ATOM   1921 C  CA   . ARG A 1 40 ? -1.349  11.321  -2.994  1.00 0.00 ? 40 ARG A CA   2 
+ATOM   1922 C  C    . ARG A 1 40 ? -1.702  11.836  -1.592  1.00 0.00 ? 40 ARG A C    2 
+ATOM   1923 O  O    . ARG A 1 40 ? -2.850  11.857  -1.196  1.00 0.00 ? 40 ARG A O    2 
+ATOM   1924 C  CB   . ARG A 1 40 ? -0.288  12.231  -3.621  1.00 0.00 ? 40 ARG A CB   2 
+ATOM   1925 C  CG   . ARG A 1 40 ? -0.842  13.650  -3.761  1.00 0.00 ? 40 ARG A CG   2 
+ATOM   1926 C  CD   . ARG A 1 40 ? 0.307   14.618  -4.052  1.00 0.00 ? 40 ARG A CD   2 
+ATOM   1927 N  NE   . ARG A 1 40 ? 0.510   14.718  -5.526  1.00 0.00 ? 40 ARG A NE   2 
+ATOM   1928 C  CZ   . ARG A 1 40 ? 1.244   15.677  -6.025  1.00 0.00 ? 40 ARG A CZ   2 
+ATOM   1929 N  NH1  . ARG A 1 40 ? 1.807   16.552  -5.234  1.00 0.00 ? 40 ARG A NH1  2 
+ATOM   1930 N  NH2  . ARG A 1 40 ? 1.415   15.760  -7.315  1.00 0.00 ? 40 ARG A NH2  2 
+ATOM   1931 H  H    . ARG A 1 40 ? -2.687  10.575  -4.513  1.00 0.00 ? 40 ARG A H    2 
+ATOM   1932 H  HA   . ARG A 1 40 ? -0.953  10.319  -2.917  1.00 0.00 ? 40 ARG A HA   2 
+ATOM   1933 H  HB2  . ARG A 1 40 ? 0.589   12.247  -2.993  1.00 0.00 ? 40 ARG A HB2  2 
+ATOM   1934 H  HB3  . ARG A 1 40 ? -0.023  11.854  -4.598  1.00 0.00 ? 40 ARG A HB3  2 
+ATOM   1935 H  HG2  . ARG A 1 40 ? -1.554  13.680  -4.574  1.00 0.00 ? 40 ARG A HG2  2 
+ATOM   1936 H  HG3  . ARG A 1 40 ? -1.330  13.940  -2.843  1.00 0.00 ? 40 ARG A HG3  2 
+ATOM   1937 H  HD2  . ARG A 1 40 ? 0.068   15.593  -3.657  1.00 0.00 ? 40 ARG A HD2  2 
+ATOM   1938 H  HD3  . ARG A 1 40 ? 1.211   14.254  -3.585  1.00 0.00 ? 40 ARG A HD3  2 
+ATOM   1939 H  HE   . ARG A 1 40 ? 0.092   14.062  -6.122  1.00 0.00 ? 40 ARG A HE   2 
+ATOM   1940 H  HH11 . ARG A 1 40 ? 1.680   16.489  -4.245  1.00 0.00 ? 40 ARG A HH11 2 
+ATOM   1941 H  HH12 . ARG A 1 40 ? 2.368   17.285  -5.620  1.00 0.00 ? 40 ARG A HH12 2 
+ATOM   1942 H  HH21 . ARG A 1 40 ? 0.987   15.089  -7.920  1.00 0.00 ? 40 ARG A HH21 2 
+ATOM   1943 H  HH22 . ARG A 1 40 ? 1.976   16.493  -7.699  1.00 0.00 ? 40 ARG A HH22 2 
+ATOM   1944 N  N    . ALA A 1 41 ? -0.714  12.248  -0.841  1.00 0.00 ? 41 ALA A N    2 
+ATOM   1945 C  CA   . ALA A 1 41 ? -0.973  12.767  0.535   1.00 0.00 ? 41 ALA A CA   2 
+ATOM   1946 C  C    . ALA A 1 41 ? -1.973  11.854  1.260   1.00 0.00 ? 41 ALA A C    2 
+ATOM   1947 O  O    . ALA A 1 41 ? -1.729  10.677  1.432   1.00 0.00 ? 41 ALA A O    2 
+ATOM   1948 C  CB   . ALA A 1 41 ? -1.525  14.192  0.436   1.00 0.00 ? 41 ALA A CB   2 
+ATOM   1949 H  H    . ALA A 1 41 ? 0.203   12.218  -1.182  1.00 0.00 ? 41 ALA A H    2 
+ATOM   1950 H  HA   . ALA A 1 41 ? -0.045  12.784  1.087   1.00 0.00 ? 41 ALA A HA   2 
+ATOM   1951 H  HB1  . ALA A 1 41 ? -2.417  14.190  -0.172  1.00 0.00 ? 41 ALA A HB1  2 
+ATOM   1952 H  HB2  . ALA A 1 41 ? -1.764  14.554  1.426   1.00 0.00 ? 41 ALA A HB2  2 
+ATOM   1953 H  HB3  . ALA A 1 41 ? -0.784  14.835  -0.013  1.00 0.00 ? 41 ALA A HB3  2 
+ATOM   1954 N  N    . GLY A 1 42 ? -3.092  12.380  1.697   1.00 0.00 ? 42 GLY A N    2 
+ATOM   1955 C  CA   . GLY A 1 42 ? -4.088  11.531  2.412   1.00 0.00 ? 42 GLY A CA   2 
+ATOM   1956 C  C    . GLY A 1 42 ? -5.471  12.172  2.297   1.00 0.00 ? 42 GLY A C    2 
+ATOM   1957 O  O    . GLY A 1 42 ? -5.927  12.848  3.197   1.00 0.00 ? 42 GLY A O    2 
+ATOM   1958 H  H    . GLY A 1 42 ? -3.277  13.330  1.560   1.00 0.00 ? 42 GLY A H    2 
+ATOM   1959 H  HA2  . GLY A 1 42 ? -4.105  10.545  1.972   1.00 0.00 ? 42 GLY A HA2  2 
+ATOM   1960 H  HA3  . GLY A 1 42 ? -3.816  11.456  3.454   1.00 0.00 ? 42 GLY A HA3  2 
+ATOM   1961 N  N    . ALA A 1 43 ? -6.144  11.972  1.195   1.00 0.00 ? 43 ALA A N    2 
+ATOM   1962 C  CA   . ALA A 1 43 ? -7.495  12.581  1.033   1.00 0.00 ? 43 ALA A CA   2 
+ATOM   1963 C  C    . ALA A 1 43 ? -8.358  11.720  0.105   1.00 0.00 ? 43 ALA A C    2 
+ATOM   1964 O  O    . ALA A 1 43 ? -9.349  12.178  -0.428  1.00 0.00 ? 43 ALA A O    2 
+ATOM   1965 C  CB   . ALA A 1 43 ? -7.352  13.983  0.437   1.00 0.00 ? 43 ALA A CB   2 
+ATOM   1966 H  H    . ALA A 1 43 ? -5.762  11.427  0.475   1.00 0.00 ? 43 ALA A H    2 
+ATOM   1967 H  HA   . ALA A 1 43 ? -7.973  12.652  1.999   1.00 0.00 ? 43 ALA A HA   2 
+ATOM   1968 H  HB1  . ALA A 1 43 ? -6.723  13.939  -0.440  1.00 0.00 ? 43 ALA A HB1  2 
+ATOM   1969 H  HB2  . ALA A 1 43 ? -8.327  14.359  0.163   1.00 0.00 ? 43 ALA A HB2  2 
+ATOM   1970 H  HB3  . ALA A 1 43 ? -6.906  14.641  1.168   1.00 0.00 ? 43 ALA A HB3  2 
+ATOM   1971 N  N    . CYS A 1 44 ? -8.005  10.478  -0.094  1.00 0.00 ? 44 CYS A N    2 
+ATOM   1972 C  CA   . CYS A 1 44 ? -8.834  9.618   -0.986  1.00 0.00 ? 44 CYS A CA   2 
+ATOM   1973 C  C    . CYS A 1 44 ? -8.811  8.171   -0.495  1.00 0.00 ? 44 CYS A C    2 
+ATOM   1974 O  O    . CYS A 1 44 ? -8.006  7.794   0.332   1.00 0.00 ? 44 CYS A O    2 
+ATOM   1975 C  CB   . CYS A 1 44 ? -8.306  9.689   -2.427  1.00 0.00 ? 44 CYS A CB   2 
+ATOM   1976 S  SG   . CYS A 1 44 ? -6.835  8.641   -2.619  1.00 0.00 ? 44 CYS A SG   2 
+ATOM   1977 H  H    . CYS A 1 44 ? -7.208  10.114  0.344   1.00 0.00 ? 44 CYS A H    2 
+ATOM   1978 H  HA   . CYS A 1 44 ? -9.853  9.976   -0.968  1.00 0.00 ? 44 CYS A HA   2 
+ATOM   1979 H  HB2  . CYS A 1 44 ? -9.077  9.346   -3.101  1.00 0.00 ? 44 CYS A HB2  2 
+ATOM   1980 H  HB3  . CYS A 1 44 ? -8.059  10.711  -2.666  1.00 0.00 ? 44 CYS A HB3  2 
+ATOM   1981 N  N    . SER A 1 45 ? -9.689  7.358   -1.013  1.00 0.00 ? 45 SER A N    2 
+ATOM   1982 C  CA   . SER A 1 45 ? -9.726  5.930   -0.597  1.00 0.00 ? 45 SER A CA   2 
+ATOM   1983 C  C    . SER A 1 45 ? -9.157  5.069   -1.724  1.00 0.00 ? 45 SER A C    2 
+ATOM   1984 O  O    . SER A 1 45 ? -8.921  3.888   -1.556  1.00 0.00 ? 45 SER A O    2 
+ATOM   1985 C  CB   . SER A 1 45 ? -11.171 5.517   -0.314  1.00 0.00 ? 45 SER A CB   2 
+ATOM   1986 O  OG   . SER A 1 45 ? -11.320 5.260   1.076   1.00 0.00 ? 45 SER A OG   2 
+ATOM   1987 H  H    . SER A 1 45 ? -10.323 7.687   -1.684  1.00 0.00 ? 45 SER A H    2 
+ATOM   1988 H  HA   . SER A 1 45 ? -9.131  5.798   0.295   1.00 0.00 ? 45 SER A HA   2 
+ATOM   1989 H  HB2  . SER A 1 45 ? -11.837 6.313   -0.602  1.00 0.00 ? 45 SER A HB2  2 
+ATOM   1990 H  HB3  . SER A 1 45 ? -11.408 4.628   -0.883  1.00 0.00 ? 45 SER A HB3  2 
+ATOM   1991 H  HG   . SER A 1 45 ? -11.139 6.076   1.549   1.00 0.00 ? 45 SER A HG   2 
+ATOM   1992 N  N    . THR A 1 46 ? -8.933  5.650   -2.873  1.00 0.00 ? 46 THR A N    2 
+ATOM   1993 C  CA   . THR A 1 46 ? -8.376  4.865   -4.010  1.00 0.00 ? 46 THR A CA   2 
+ATOM   1994 C  C    . THR A 1 46 ? -7.245  3.976   -3.494  1.00 0.00 ? 46 THR A C    2 
+ATOM   1995 O  O    . THR A 1 46 ? -7.017  2.891   -3.992  1.00 0.00 ? 46 THR A O    2 
+ATOM   1996 C  CB   . THR A 1 46 ? -7.839  5.820   -5.078  1.00 0.00 ? 46 THR A CB   2 
+ATOM   1997 O  OG1  . THR A 1 46 ? -6.853  6.665   -4.505  1.00 0.00 ? 46 THR A OG1  2 
+ATOM   1998 C  CG2  . THR A 1 46 ? -8.985  6.671   -5.625  1.00 0.00 ? 46 THR A CG2  2 
+ATOM   1999 H  H    . THR A 1 46 ? -9.128  6.604   -2.987  1.00 0.00 ? 46 THR A H    2 
+ATOM   2000 H  HA   . THR A 1 46 ? -9.154  4.248   -4.434  1.00 0.00 ? 46 THR A HA   2 
+ATOM   2001 H  HB   . THR A 1 46 ? -7.403  5.252   -5.884  1.00 0.00 ? 46 THR A HB   2 
+ATOM   2002 H  HG1  . THR A 1 46 ? -6.930  7.532   -4.911  1.00 0.00 ? 46 THR A HG1  2 
+ATOM   2003 H  HG21 . THR A 1 46 ? -9.469  7.190   -4.809  1.00 0.00 ? 46 THR A HG21 2 
+ATOM   2004 H  HG22 . THR A 1 46 ? -8.595  7.391   -6.328  1.00 0.00 ? 46 THR A HG22 2 
+ATOM   2005 H  HG23 . THR A 1 46 ? -9.702  6.035   -6.122  1.00 0.00 ? 46 THR A HG23 2 
+ATOM   2006 N  N    . CYS A 1 47 ? -6.547  4.418   -2.484  1.00 0.00 ? 47 CYS A N    2 
+ATOM   2007 C  CA   . CYS A 1 47 ? -5.447  3.582   -1.923  1.00 0.00 ? 47 CYS A CA   2 
+ATOM   2008 C  C    . CYS A 1 47 ? -5.927  2.922   -0.630  1.00 0.00 ? 47 CYS A C    2 
+ATOM   2009 O  O    . CYS A 1 47 ? -5.426  3.195   0.443   1.00 0.00 ? 47 CYS A O    2 
+ATOM   2010 C  CB   . CYS A 1 47 ? -4.190  4.417   -1.630  1.00 0.00 ? 47 CYS A CB   2 
+ATOM   2011 S  SG   . CYS A 1 47 ? -4.602  6.152   -1.296  1.00 0.00 ? 47 CYS A SG   2 
+ATOM   2012 H  H    . CYS A 1 47 ? -6.760  5.286   -2.086  1.00 0.00 ? 47 CYS A H    2 
+ATOM   2013 H  HA   . CYS A 1 47 ? -5.200  2.812   -2.636  1.00 0.00 ? 47 CYS A HA   2 
+ATOM   2014 H  HB2  . CYS A 1 47 ? -3.686  4.005   -0.771  1.00 0.00 ? 47 CYS A HB2  2 
+ATOM   2015 H  HB3  . CYS A 1 47 ? -3.528  4.368   -2.483  1.00 0.00 ? 47 CYS A HB3  2 
+ATOM   2016 N  N    . ALA A 1 48 ? -6.904  2.061   -0.724  1.00 0.00 ? 48 ALA A N    2 
+ATOM   2017 C  CA   . ALA A 1 48 ? -7.429  1.388   0.498   1.00 0.00 ? 48 ALA A CA   2 
+ATOM   2018 C  C    . ALA A 1 48 ? -6.561  0.176   0.849   1.00 0.00 ? 48 ALA A C    2 
+ATOM   2019 O  O    . ALA A 1 48 ? -6.745  -0.905  0.326   1.00 0.00 ? 48 ALA A O    2 
+ATOM   2020 C  CB   . ALA A 1 48 ? -8.865  0.924   0.245   1.00 0.00 ? 48 ALA A CB   2 
+ATOM   2021 H  H    . ALA A 1 48 ? -7.297  1.861   -1.598  1.00 0.00 ? 48 ALA A H    2 
+ATOM   2022 H  HA   . ALA A 1 48 ? -7.420  2.086   1.322   1.00 0.00 ? 48 ALA A HA   2 
+ATOM   2023 H  HB1  . ALA A 1 48 ? -8.899  0.329   -0.656  1.00 0.00 ? 48 ALA A HB1  2 
+ATOM   2024 H  HB2  . ALA A 1 48 ? -9.204  0.332   1.080   1.00 0.00 ? 48 ALA A HB2  2 
+ATOM   2025 H  HB3  . ALA A 1 48 ? -9.507  1.786   0.130   1.00 0.00 ? 48 ALA A HB3  2 
+ATOM   2026 N  N    . GLY A 1 49 ? -5.624  0.344   1.744   1.00 0.00 ? 49 GLY A N    2 
+ATOM   2027 C  CA   . GLY A 1 49 ? -4.755  -0.801  2.145   1.00 0.00 ? 49 GLY A CA   2 
+ATOM   2028 C  C    . GLY A 1 49 ? -5.360  -1.470  3.380   1.00 0.00 ? 49 GLY A C    2 
+ATOM   2029 O  O    . GLY A 1 49 ? -5.244  -0.975  4.484   1.00 0.00 ? 49 GLY A O    2 
+ATOM   2030 H  H    . GLY A 1 49 ? -5.501  1.221   2.163   1.00 0.00 ? 49 GLY A H    2 
+ATOM   2031 H  HA2  . GLY A 1 49 ? -4.699  -1.515  1.336   1.00 0.00 ? 49 GLY A HA2  2 
+ATOM   2032 H  HA3  . GLY A 1 49 ? -3.765  -0.441  2.383   1.00 0.00 ? 49 GLY A HA3  2 
+ATOM   2033 N  N    . LYS A 1 50 ? -6.017  -2.583  3.205   1.00 0.00 ? 50 LYS A N    2 
+ATOM   2034 C  CA   . LYS A 1 50 ? -6.640  -3.268  4.370   1.00 0.00 ? 50 LYS A CA   2 
+ATOM   2035 C  C    . LYS A 1 50 ? -5.558  -3.763  5.330   1.00 0.00 ? 50 LYS A C    2 
+ATOM   2036 O  O    . LYS A 1 50 ? -5.012  -4.831  5.148   1.00 0.00 ? 50 LYS A O    2 
+ATOM   2037 C  CB   . LYS A 1 50 ? -7.463  -4.456  3.879   1.00 0.00 ? 50 LYS A CB   2 
+ATOM   2038 C  CG   . LYS A 1 50 ? -8.417  -4.917  4.983   1.00 0.00 ? 50 LYS A CG   2 
+ATOM   2039 C  CD   . LYS A 1 50 ? -9.230  -3.722  5.488   1.00 0.00 ? 50 LYS A CD   2 
+ATOM   2040 C  CE   . LYS A 1 50 ? -10.533 -4.219  6.119   1.00 0.00 ? 50 LYS A CE   2 
+ATOM   2041 N  NZ   . LYS A 1 50 ? -11.691 -3.687  5.346   1.00 0.00 ? 50 LYS A NZ   2 
+ATOM   2042 H  H    . LYS A 1 50 ? -6.110  -2.965  2.304   1.00 0.00 ? 50 LYS A H    2 
+ATOM   2043 H  HA   . LYS A 1 50 ? -7.287  -2.576  4.887   1.00 0.00 ? 50 LYS A HA   2 
+ATOM   2044 H  HB2  . LYS A 1 50 ? -8.032  -4.162  3.009   1.00 0.00 ? 50 LYS A HB2  2 
+ATOM   2045 H  HB3  . LYS A 1 50 ? -6.801  -5.264  3.619   1.00 0.00 ? 50 LYS A HB3  2 
+ATOM   2046 H  HG2  . LYS A 1 50 ? -9.086  -5.667  4.589   1.00 0.00 ? 50 LYS A HG2  2 
+ATOM   2047 H  HG3  . LYS A 1 50 ? -7.848  -5.333  5.800   1.00 0.00 ? 50 LYS A HG3  2 
+ATOM   2048 H  HD2  . LYS A 1 50 ? -8.655  -3.182  6.225   1.00 0.00 ? 50 LYS A HD2  2 
+ATOM   2049 H  HD3  . LYS A 1 50 ? -9.459  -3.068  4.660   1.00 0.00 ? 50 LYS A HD3  2 
+ATOM   2050 H  HE2  . LYS A 1 50 ? -10.553 -5.298  6.101   1.00 0.00 ? 50 LYS A HE2  2 
+ATOM   2051 H  HE3  . LYS A 1 50 ? -10.592 -3.873  7.140   1.00 0.00 ? 50 LYS A HE3  2 
+ATOM   2052 H  HZ1  . LYS A 1 50 ? -11.419 -2.798  4.881   1.00 0.00 ? 50 LYS A HZ1  2 
+ATOM   2053 H  HZ2  . LYS A 1 50 ? -11.974 -4.379  4.625   1.00 0.00 ? 50 LYS A HZ2  2 
+ATOM   2054 H  HZ3  . LYS A 1 50 ? -12.487 -3.513  5.992   1.00 0.00 ? 50 LYS A HZ3  2 
+ATOM   2055 N  N    . ILE A 1 51 ? -5.274  -2.971  6.345   1.00 0.00 ? 51 ILE A N    2 
+ATOM   2056 C  CA   . ILE A 1 51 ? -4.246  -3.306  7.389   1.00 0.00 ? 51 ILE A CA   2 
+ATOM   2057 C  C    . ILE A 1 51 ? -3.407  -4.531  7.012   1.00 0.00 ? 51 ILE A C    2 
+ATOM   2058 O  O    . ILE A 1 51 ? -3.886  -5.645  6.974   1.00 0.00 ? 51 ILE A O    2 
+ATOM   2059 C  CB   . ILE A 1 51 ? -4.954  -3.555  8.727   1.00 0.00 ? 51 ILE A CB   2 
+ATOM   2060 C  CG1  . ILE A 1 51 ? -3.943  -3.453  9.876   1.00 0.00 ? 51 ILE A CG1  2 
+ATOM   2061 C  CG2  . ILE A 1 51 ? -5.591  -4.945  8.732   1.00 0.00 ? 51 ILE A CG2  2 
+ATOM   2062 C  CD1  . ILE A 1 51 ? -2.917  -4.583  9.765   1.00 0.00 ? 51 ILE A CD1  2 
+ATOM   2063 H  H    . ILE A 1 51 ? -5.758  -2.126  6.425   1.00 0.00 ? 51 ILE A H    2 
+ATOM   2064 H  HA   . ILE A 1 51 ? -3.582  -2.461  7.503   1.00 0.00 ? 51 ILE A HA   2 
+ATOM   2065 H  HB   . ILE A 1 51 ? -5.726  -2.810  8.863   1.00 0.00 ? 51 ILE A HB   2 
+ATOM   2066 H  HG12 . ILE A 1 51 ? -3.435  -2.500  9.824   1.00 0.00 ? 51 ILE A HG12 2 
+ATOM   2067 H  HG13 . ILE A 1 51 ? -4.463  -3.533  10.819  1.00 0.00 ? 51 ILE A HG13 2 
+ATOM   2068 H  HG21 . ILE A 1 51 ? -5.824  -5.237  7.719   1.00 0.00 ? 51 ILE A HG21 2 
+ATOM   2069 H  HG22 . ILE A 1 51 ? -4.902  -5.656  9.162   1.00 0.00 ? 51 ILE A HG22 2 
+ATOM   2070 H  HG23 . ILE A 1 51 ? -6.498  -4.924  9.318   1.00 0.00 ? 51 ILE A HG23 2 
+ATOM   2071 H  HD11 . ILE A 1 51 ? -3.371  -5.434  9.281   1.00 0.00 ? 51 ILE A HD11 2 
+ATOM   2072 H  HD12 . ILE A 1 51 ? -2.071  -4.246  9.184   1.00 0.00 ? 51 ILE A HD12 2 
+ATOM   2073 H  HD13 . ILE A 1 51 ? -2.586  -4.866  10.753  1.00 0.00 ? 51 ILE A HD13 2 
+ATOM   2074 N  N    . THR A 1 52 ? -2.145  -4.316  6.761   1.00 0.00 ? 52 THR A N    2 
+ATOM   2075 C  CA   . THR A 1 52 ? -1.224  -5.437  6.404   1.00 0.00 ? 52 THR A CA   2 
+ATOM   2076 C  C    . THR A 1 52 ? -0.016  -4.874  5.650   1.00 0.00 ? 52 THR A C    2 
+ATOM   2077 O  O    . THR A 1 52 ? 0.984   -5.537  5.505   1.00 0.00 ? 52 THR A O    2 
+ATOM   2078 C  CB   . THR A 1 52 ? -1.933  -6.467  5.516   1.00 0.00 ? 52 THR A CB   2 
+ATOM   2079 O  OG1  . THR A 1 52 ? -3.014  -5.852  4.837   1.00 0.00 ? 52 THR A OG1  2 
+ATOM   2080 C  CG2  . THR A 1 52 ? -2.446  -7.627  6.375   1.00 0.00 ? 52 THR A CG2  2 
+ATOM   2081 H  H    . THR A 1 52 ? -1.795  -3.404  6.826   1.00 0.00 ? 52 THR A H    2 
+ATOM   2082 H  HA   . THR A 1 52 ? -0.883  -5.920  7.310   1.00 0.00 ? 52 THR A HA   2 
+ATOM   2083 H  HB   . THR A 1 52 ? -1.237  -6.853  4.793   1.00 0.00 ? 52 THR A HB   2 
+ATOM   2084 H  HG1  . THR A 1 52 ? -3.741  -6.477  4.810   1.00 0.00 ? 52 THR A HG1  2 
+ATOM   2085 H  HG21 . THR A 1 52 ? -2.590  -7.287  7.390   1.00 0.00 ? 52 THR A HG21 2 
+ATOM   2086 H  HG22 . THR A 1 52 ? -3.387  -7.981  5.977   1.00 0.00 ? 52 THR A HG22 2 
+ATOM   2087 H  HG23 . THR A 1 52 ? -1.725  -8.430  6.363   1.00 0.00 ? 52 THR A HG23 2 
+ATOM   2088 N  N    . ALA A 1 53 ? -0.107  -3.658  5.170   1.00 0.00 ? 53 ALA A N    2 
+ATOM   2089 C  CA   . ALA A 1 53 ? 1.024   -3.046  4.426   1.00 0.00 ? 53 ALA A CA   2 
+ATOM   2090 C  C    . ALA A 1 53 ? 2.073   -2.553  5.419   1.00 0.00 ? 53 ALA A C    2 
+ATOM   2091 O  O    . ALA A 1 53 ? 2.253   -1.369  5.623   1.00 0.00 ? 53 ALA A O    2 
+ATOM   2092 C  CB   . ALA A 1 53 ? 0.517   -1.872  3.587   1.00 0.00 ? 53 ALA A CB   2 
+ATOM   2093 H  H    . ALA A 1 53 ? -0.915  -3.150  5.296   1.00 0.00 ? 53 ALA A H    2 
+ATOM   2094 H  HA   . ALA A 1 53 ? 1.457   -3.787  3.782   1.00 0.00 ? 53 ALA A HA   2 
+ATOM   2095 H  HB1  . ALA A 1 53 ? -0.559  -1.838  3.633   1.00 0.00 ? 53 ALA A HB1  2 
+ATOM   2096 H  HB2  . ALA A 1 53 ? 0.926   -0.951  3.974   1.00 0.00 ? 53 ALA A HB2  2 
+ATOM   2097 H  HB3  . ALA A 1 53 ? 0.830   -2.003  2.561   1.00 0.00 ? 53 ALA A HB3  2 
+ATOM   2098 N  N    . GLY A 1 54 ? 2.754   -3.464  6.035   1.00 0.00 ? 54 GLY A N    2 
+ATOM   2099 C  CA   . GLY A 1 54 ? 3.798   -3.094  7.029   1.00 0.00 ? 54 GLY A CA   2 
+ATOM   2100 C  C    . GLY A 1 54 ? 4.706   -2.018  6.444   1.00 0.00 ? 54 GLY A C    2 
+ATOM   2101 O  O    . GLY A 1 54 ? 4.478   -0.837  6.619   1.00 0.00 ? 54 GLY A O    2 
+ATOM   2102 H  H    . GLY A 1 54 ? 2.573   -4.399  5.844   1.00 0.00 ? 54 GLY A H    2 
+ATOM   2103 H  HA2  . GLY A 1 54 ? 3.326   -2.721  7.924   1.00 0.00 ? 54 GLY A HA2  2 
+ATOM   2104 H  HA3  . GLY A 1 54 ? 4.391   -3.965  7.269   1.00 0.00 ? 54 GLY A HA3  2 
+ATOM   2105 N  N    . SER A 1 55 ? 5.739   -2.413  5.756   1.00 0.00 ? 55 SER A N    2 
+ATOM   2106 C  CA   . SER A 1 55 ? 6.660   -1.405  5.172   1.00 0.00 ? 55 SER A CA   2 
+ATOM   2107 C  C    . SER A 1 55 ? 7.079   -0.436  6.271   1.00 0.00 ? 55 SER A C    2 
+ATOM   2108 O  O    . SER A 1 55 ? 6.856   -0.675  7.441   1.00 0.00 ? 55 SER A O    2 
+ATOM   2109 C  CB   . SER A 1 55 ? 5.947   -0.637  4.057   1.00 0.00 ? 55 SER A CB   2 
+ATOM   2110 O  OG   . SER A 1 55 ? 4.542   -0.803  4.193   1.00 0.00 ? 55 SER A OG   2 
+ATOM   2111 H  H    . SER A 1 55 ? 5.910   -3.369  5.632   1.00 0.00 ? 55 SER A H    2 
+ATOM   2112 H  HA   . SER A 1 55 ? 7.535   -1.895  4.773   1.00 0.00 ? 55 SER A HA   2 
+ATOM   2113 H  HB2  . SER A 1 55 ? 6.188   0.410   4.128   1.00 0.00 ? 55 SER A HB2  2 
+ATOM   2114 H  HB3  . SER A 1 55 ? 6.273   -1.013  3.097   1.00 0.00 ? 55 SER A HB3  2 
+ATOM   2115 H  HG   . SER A 1 55 ? 4.111   -0.109  3.688   1.00 0.00 ? 55 SER A HG   2 
+ATOM   2116 N  N    . VAL A 1 56 ? 7.677   0.658   5.910   1.00 0.00 ? 56 VAL A N    2 
+ATOM   2117 C  CA   . VAL A 1 56 ? 8.100   1.637   6.935   1.00 0.00 ? 56 VAL A CA   2 
+ATOM   2118 C  C    . VAL A 1 56 ? 8.057   3.044   6.343   1.00 0.00 ? 56 VAL A C    2 
+ATOM   2119 O  O    . VAL A 1 56 ? 8.930   3.433   5.599   1.00 0.00 ? 56 VAL A O    2 
+ATOM   2120 C  CB   . VAL A 1 56 ? 9.523   1.318   7.399   1.00 0.00 ? 56 VAL A CB   2 
+ATOM   2121 C  CG1  . VAL A 1 56 ? 9.528   -0.005  8.167   1.00 0.00 ? 56 VAL A CG1  2 
+ATOM   2122 C  CG2  . VAL A 1 56 ? 10.440  1.199   6.180   1.00 0.00 ? 56 VAL A CG2  2 
+ATOM   2123 H  H    . VAL A 1 56 ? 7.844   0.837   4.971   1.00 0.00 ? 56 VAL A H    2 
+ATOM   2124 H  HA   . VAL A 1 56 ? 7.427   1.578   7.762   1.00 0.00 ? 56 VAL A HA   2 
+ATOM   2125 H  HB   . VAL A 1 56 ? 9.877   2.110   8.043   1.00 0.00 ? 56 VAL A HB   2 
+ATOM   2126 H  HG11 . VAL A 1 56 ? 8.554   -0.175  8.599   1.00 0.00 ? 56 VAL A HG11 2 
+ATOM   2127 H  HG12 . VAL A 1 56 ? 9.767   -0.812  7.491   1.00 0.00 ? 56 VAL A HG12 2 
+ATOM   2128 H  HG13 . VAL A 1 56 ? 10.268  0.038   8.952   1.00 0.00 ? 56 VAL A HG13 2 
+ATOM   2129 H  HG21 . VAL A 1 56 ? 9.845   1.016   5.298   1.00 0.00 ? 56 VAL A HG21 2 
+ATOM   2130 H  HG22 . VAL A 1 56 ? 10.996  2.117   6.056   1.00 0.00 ? 56 VAL A HG22 2 
+ATOM   2131 H  HG23 . VAL A 1 56 ? 11.127  0.379   6.326   1.00 0.00 ? 56 VAL A HG23 2 
+ATOM   2132 N  N    . ASP A 1 57 ? 7.052   3.814   6.668   1.00 0.00 ? 57 ASP A N    2 
+ATOM   2133 C  CA   . ASP A 1 57 ? 6.976   5.195   6.116   1.00 0.00 ? 57 ASP A CA   2 
+ATOM   2134 C  C    . ASP A 1 57 ? 8.117   6.025   6.693   1.00 0.00 ? 57 ASP A C    2 
+ATOM   2135 O  O    . ASP A 1 57 ? 8.726   6.817   6.004   1.00 0.00 ? 57 ASP A O    2 
+ATOM   2136 C  CB   . ASP A 1 57 ? 5.632   5.832   6.471   1.00 0.00 ? 57 ASP A CB   2 
+ATOM   2137 C  CG   . ASP A 1 57 ? 5.566   6.087   7.978   1.00 0.00 ? 57 ASP A CG   2 
+ATOM   2138 O  OD1  . ASP A 1 57 ? 6.252   6.987   8.437   1.00 0.00 ? 57 ASP A OD1  2 
+ATOM   2139 O  OD2  . ASP A 1 57 ? 4.834   5.377   8.648   1.00 0.00 ? 57 ASP A OD2  2 
+ATOM   2140 H  H    . ASP A 1 57 ? 6.353   3.485   7.273   1.00 0.00 ? 57 ASP A H    2 
+ATOM   2141 H  HA   . ASP A 1 57 ? 7.077   5.158   5.051   1.00 0.00 ? 57 ASP A HA   2 
+ATOM   2142 H  HB2  . ASP A 1 57 ? 5.530   6.769   5.939   1.00 0.00 ? 57 ASP A HB2  2 
+ATOM   2143 H  HB3  . ASP A 1 57 ? 4.832   5.167   6.180   1.00 0.00 ? 57 ASP A HB3  2 
+ATOM   2144 N  N    . GLN A 1 58 ? 8.409   5.838   7.952   1.00 0.00 ? 58 GLN A N    2 
+ATOM   2145 C  CA   . GLN A 1 58 ? 9.512   6.598   8.602   1.00 0.00 ? 58 GLN A CA   2 
+ATOM   2146 C  C    . GLN A 1 58 ? 9.003   7.980   9.001   1.00 0.00 ? 58 GLN A C    2 
+ATOM   2147 O  O    . GLN A 1 58 ? 8.981   8.333   10.162  1.00 0.00 ? 58 GLN A O    2 
+ATOM   2148 C  CB   . GLN A 1 58 ? 10.687  6.745   7.635   1.00 0.00 ? 58 GLN A CB   2 
+ATOM   2149 C  CG   . GLN A 1 58 ? 11.993  6.806   8.428   1.00 0.00 ? 58 GLN A CG   2 
+ATOM   2150 C  CD   . GLN A 1 58 ? 12.174  5.504   9.212   1.00 0.00 ? 58 GLN A CD   2 
+ATOM   2151 O  OE1  . GLN A 1 58 ? 12.629  5.518   10.340  1.00 0.00 ? 58 GLN A OE1  2 
+ATOM   2152 N  NE2  . GLN A 1 58 ? 11.836  4.372   8.659   1.00 0.00 ? 58 GLN A NE2  2 
+ATOM   2153 H  H    . GLN A 1 58 ? 7.898   5.191   8.471   1.00 0.00 ? 58 GLN A H    2 
+ATOM   2154 H  HA   . GLN A 1 58 ? 9.838   6.068   9.484   1.00 0.00 ? 58 GLN A HA   2 
+ATOM   2155 H  HB2  . GLN A 1 58 ? 10.710  5.897   6.964   1.00 0.00 ? 58 GLN A HB2  2 
+ATOM   2156 H  HB3  . GLN A 1 58 ? 10.572  7.654   7.064   1.00 0.00 ? 58 GLN A HB3  2 
+ATOM   2157 H  HG2  . GLN A 1 58 ? 12.822  6.937   7.748   1.00 0.00 ? 58 GLN A HG2  2 
+ATOM   2158 H  HG3  . GLN A 1 58 ? 11.958  7.636   9.118   1.00 0.00 ? 58 GLN A HG3  2 
+ATOM   2159 H  HE21 . GLN A 1 58 ? 11.470  4.361   7.750   1.00 0.00 ? 58 GLN A HE21 2 
+ATOM   2160 H  HE22 . GLN A 1 58 ? 11.950  3.533   9.153   1.00 0.00 ? 58 GLN A HE22 2 
+ATOM   2161 N  N    . SER A 1 59 ? 8.591   8.763   8.047   1.00 0.00 ? 59 SER A N    2 
+ATOM   2162 C  CA   . SER A 1 59 ? 8.079   10.122  8.374   1.00 0.00 ? 59 SER A CA   2 
+ATOM   2163 C  C    . SER A 1 59 ? 6.557   10.148  8.227   1.00 0.00 ? 59 SER A C    2 
+ATOM   2164 O  O    . SER A 1 59 ? 6.031   10.599  7.228   1.00 0.00 ? 59 SER A O    2 
+ATOM   2165 C  CB   . SER A 1 59 ? 8.702   11.146  7.426   1.00 0.00 ? 59 SER A CB   2 
+ATOM   2166 O  OG   . SER A 1 59 ? 10.089  11.270  7.713   1.00 0.00 ? 59 SER A OG   2 
+ATOM   2167 H  H    . SER A 1 59 ? 8.616   8.455   7.114   1.00 0.00 ? 59 SER A H    2 
+ATOM   2168 H  HA   . SER A 1 59 ? 8.344   10.368  9.392   1.00 0.00 ? 59 SER A HA   2 
+ATOM   2169 H  HB2  . SER A 1 59 ? 8.578   10.818  6.407   1.00 0.00 ? 59 SER A HB2  2 
+ATOM   2170 H  HB3  . SER A 1 59 ? 8.209   12.102  7.556   1.00 0.00 ? 59 SER A HB3  2 
+ATOM   2171 H  HG   . SER A 1 59 ? 10.563  10.645  7.161   1.00 0.00 ? 59 SER A HG   2 
+ATOM   2172 N  N    . ASP A 1 60 ? 5.844   9.669   9.213   1.00 0.00 ? 60 ASP A N    2 
+ATOM   2173 C  CA   . ASP A 1 60 ? 4.355   9.671   9.129   1.00 0.00 ? 60 ASP A CA   2 
+ATOM   2174 C  C    . ASP A 1 60 ? 3.879   11.005  8.550   1.00 0.00 ? 60 ASP A C    2 
+ATOM   2175 O  O    . ASP A 1 60 ? 2.838   11.089  7.930   1.00 0.00 ? 60 ASP A O    2 
+ATOM   2176 C  CB   . ASP A 1 60 ? 3.766   9.480   10.529  1.00 0.00 ? 60 ASP A CB   2 
+ATOM   2177 C  CG   . ASP A 1 60 ? 4.670   10.156  11.562  1.00 0.00 ? 60 ASP A CG   2 
+ATOM   2178 O  OD1  . ASP A 1 60 ? 5.597   9.510   12.021  1.00 0.00 ? 60 ASP A OD1  2 
+ATOM   2179 O  OD2  . ASP A 1 60 ? 4.419   11.308  11.874  1.00 0.00 ? 60 ASP A OD2  2 
+ATOM   2180 H  H    . ASP A 1 60 ? 6.287   9.310   10.011  1.00 0.00 ? 60 ASP A H    2 
+ATOM   2181 H  HA   . ASP A 1 60 ? 4.030   8.865   8.488   1.00 0.00 ? 60 ASP A HA   2 
+ATOM   2182 H  HB2  . ASP A 1 60 ? 2.780   9.921   10.568  1.00 0.00 ? 60 ASP A HB2  2 
+ATOM   2183 H  HB3  . ASP A 1 60 ? 3.697   8.425   10.750  1.00 0.00 ? 60 ASP A HB3  2 
+ATOM   2184 N  N    . GLN A 1 61 ? 4.640   12.049  8.741   1.00 0.00 ? 61 GLN A N    2 
+ATOM   2185 C  CA   . GLN A 1 61 ? 4.237   13.376  8.194   1.00 0.00 ? 61 GLN A CA   2 
+ATOM   2186 C  C    . GLN A 1 61 ? 2.787   13.677  8.579   1.00 0.00 ? 61 GLN A C    2 
+ATOM   2187 O  O    . GLN A 1 61 ? 2.162   12.938  9.314   1.00 0.00 ? 61 GLN A O    2 
+ATOM   2188 C  CB   . GLN A 1 61 ? 4.363   13.355  6.669   1.00 0.00 ? 61 GLN A CB   2 
+ATOM   2189 C  CG   . GLN A 1 61 ? 5.415   14.373  6.228   1.00 0.00 ? 61 GLN A CG   2 
+ATOM   2190 C  CD   . GLN A 1 61 ? 6.766   13.674  6.077   1.00 0.00 ? 61 GLN A CD   2 
+ATOM   2191 O  OE1  . GLN A 1 61 ? 7.721   14.020  6.744   1.00 0.00 ? 61 GLN A OE1  2 
+ATOM   2192 N  NE2  . GLN A 1 61 ? 6.888   12.694  5.224   1.00 0.00 ? 61 GLN A NE2  2 
+ATOM   2193 H  H    . GLN A 1 61 ? 5.479   11.958  9.239   1.00 0.00 ? 61 GLN A H    2 
+ATOM   2194 H  HA   . GLN A 1 61 ? 4.883   14.141  8.597   1.00 0.00 ? 61 GLN A HA   2 
+ATOM   2195 H  HB2  . GLN A 1 61 ? 4.660   12.368  6.346   1.00 0.00 ? 61 GLN A HB2  2 
+ATOM   2196 H  HB3  . GLN A 1 61 ? 3.411   13.609  6.226   1.00 0.00 ? 61 GLN A HB3  2 
+ATOM   2197 H  HG2  . GLN A 1 61 ? 5.124   14.804  5.281   1.00 0.00 ? 61 GLN A HG2  2 
+ATOM   2198 H  HG3  . GLN A 1 61 ? 5.496   15.152  6.970   1.00 0.00 ? 61 GLN A HG3  2 
+ATOM   2199 H  HE21 . GLN A 1 61 ? 6.118   12.414  4.687   1.00 0.00 ? 61 GLN A HE21 2 
+ATOM   2200 H  HE22 . GLN A 1 61 ? 7.749   12.239  5.119   1.00 0.00 ? 61 GLN A HE22 2 
+ATOM   2201 N  N    . SER A 1 62 ? 2.249   14.757  8.084   1.00 0.00 ? 62 SER A N    2 
+ATOM   2202 C  CA   . SER A 1 62 ? 0.840   15.112  8.415   1.00 0.00 ? 62 SER A CA   2 
+ATOM   2203 C  C    . SER A 1 62 ? -0.056  14.795  7.217   1.00 0.00 ? 62 SER A C    2 
+ATOM   2204 O  O    . SER A 1 62 ? -0.978  15.525  6.908   1.00 0.00 ? 62 SER A O    2 
+ATOM   2205 C  CB   . SER A 1 62 ? 0.756   16.605  8.736   1.00 0.00 ? 62 SER A CB   2 
+ATOM   2206 O  OG   . SER A 1 62 ? -0.602  17.021  8.686   1.00 0.00 ? 62 SER A OG   2 
+ATOM   2207 H  H    . SER A 1 62 ? 2.773   15.337  7.493   1.00 0.00 ? 62 SER A H    2 
+ATOM   2208 H  HA   . SER A 1 62 ? 0.515   14.539  9.271   1.00 0.00 ? 62 SER A HA   2 
+ATOM   2209 H  HB2  . SER A 1 62 ? 1.146   16.786  9.723   1.00 0.00 ? 62 SER A HB2  2 
+ATOM   2210 H  HB3  . SER A 1 62 ? 1.340   17.161  8.013   1.00 0.00 ? 62 SER A HB3  2 
+ATOM   2211 H  HG   . SER A 1 62 ? -0.819  17.426  9.529   1.00 0.00 ? 62 SER A HG   2 
+ATOM   2212 N  N    . PHE A 1 63 ? 0.208   13.713  6.535   1.00 0.00 ? 63 PHE A N    2 
+ATOM   2213 C  CA   . PHE A 1 63 ? -0.628  13.353  5.355   1.00 0.00 ? 63 PHE A CA   2 
+ATOM   2214 C  C    . PHE A 1 63 ? -0.893  11.844  5.354   1.00 0.00 ? 63 PHE A C    2 
+ATOM   2215 O  O    . PHE A 1 63 ? -1.102  11.240  4.321   1.00 0.00 ? 63 PHE A O    2 
+ATOM   2216 C  CB   . PHE A 1 63 ? 0.104   13.754  4.073   1.00 0.00 ? 63 PHE A CB   2 
+ATOM   2217 C  CG   . PHE A 1 63 ? 0.414   15.232  4.117   1.00 0.00 ? 63 PHE A CG   2 
+ATOM   2218 C  CD1  . PHE A 1 63 ? -0.626  16.160  4.259   1.00 0.00 ? 63 PHE A CD1  2 
+ATOM   2219 C  CD2  . PHE A 1 63 ? 1.739   15.675  4.023   1.00 0.00 ? 63 PHE A CD2  2 
+ATOM   2220 C  CE1  . PHE A 1 63 ? -0.341  17.530  4.304   1.00 0.00 ? 63 PHE A CE1  2 
+ATOM   2221 C  CE2  . PHE A 1 63 ? 2.023   17.046  4.069   1.00 0.00 ? 63 PHE A CE2  2 
+ATOM   2222 C  CZ   . PHE A 1 63 ? 0.984   17.973  4.210   1.00 0.00 ? 63 PHE A CZ   2 
+ATOM   2223 H  H    . PHE A 1 63 ? 0.957   13.139  6.799   1.00 0.00 ? 63 PHE A H    2 
+ATOM   2224 H  HA   . PHE A 1 63 ? -1.569  13.881  5.410   1.00 0.00 ? 63 PHE A HA   2 
+ATOM   2225 H  HB2  . PHE A 1 63 ? 1.025   13.195  3.993   1.00 0.00 ? 63 PHE A HB2  2 
+ATOM   2226 H  HB3  . PHE A 1 63 ? -0.522  13.543  3.219   1.00 0.00 ? 63 PHE A HB3  2 
+ATOM   2227 H  HD1  . PHE A 1 63 ? -1.648  15.818  4.331   1.00 0.00 ? 63 PHE A HD1  2 
+ATOM   2228 H  HD2  . PHE A 1 63 ? 2.541   14.961  3.913   1.00 0.00 ? 63 PHE A HD2  2 
+ATOM   2229 H  HE1  . PHE A 1 63 ? -1.142  18.245  4.413   1.00 0.00 ? 63 PHE A HE1  2 
+ATOM   2230 H  HE2  . PHE A 1 63 ? 3.045   17.387  3.995   1.00 0.00 ? 63 PHE A HE2  2 
+ATOM   2231 H  HZ   . PHE A 1 63 ? 1.204   19.029  4.247   1.00 0.00 ? 63 PHE A HZ   2 
+ATOM   2232 N  N    . LEU A 1 64 ? -0.894  11.235  6.509   1.00 0.00 ? 64 LEU A N    2 
+ATOM   2233 C  CA   . LEU A 1 64 ? -1.155  9.767   6.586   1.00 0.00 ? 64 LEU A CA   2 
+ATOM   2234 C  C    . LEU A 1 64 ? -0.074  8.997   5.824   1.00 0.00 ? 64 LEU A C    2 
+ATOM   2235 O  O    . LEU A 1 64 ? 0.483   9.475   4.855   1.00 0.00 ? 64 LEU A O    2 
+ATOM   2236 C  CB   . LEU A 1 64 ? -2.524  9.461   5.977   1.00 0.00 ? 64 LEU A CB   2 
+ATOM   2237 C  CG   . LEU A 1 64 ? -3.617  9.755   7.007   1.00 0.00 ? 64 LEU A CG   2 
+ATOM   2238 C  CD1  . LEU A 1 64 ? -4.851  10.313  6.296   1.00 0.00 ? 64 LEU A CD1  2 
+ATOM   2239 C  CD2  . LEU A 1 64 ? -3.991  8.463   7.736   1.00 0.00 ? 64 LEU A CD2  2 
+ATOM   2240 H  H    . LEU A 1 64 ? -0.729  11.745  7.329   1.00 0.00 ? 64 LEU A H    2 
+ATOM   2241 H  HA   . LEU A 1 64 ? -1.149  9.458   7.620   1.00 0.00 ? 64 LEU A HA   2 
+ATOM   2242 H  HB2  . LEU A 1 64 ? -2.675  10.078  5.103   1.00 0.00 ? 64 LEU A HB2  2 
+ATOM   2243 H  HB3  . LEU A 1 64 ? -2.568  8.419   5.695   1.00 0.00 ? 64 LEU A HB3  2 
+ATOM   2244 H  HG   . LEU A 1 64 ? -3.253  10.481  7.719   1.00 0.00 ? 64 LEU A HG   2 
+ATOM   2245 H  HD11 . LEU A 1 64 ? -4.554  10.765  5.360   1.00 0.00 ? 64 LEU A HD11 2 
+ATOM   2246 H  HD12 . LEU A 1 64 ? -5.549  9.513   6.104   1.00 0.00 ? 64 LEU A HD12 2 
+ATOM   2247 H  HD13 . LEU A 1 64 ? -5.320  11.058  6.922   1.00 0.00 ? 64 LEU A HD13 2 
+ATOM   2248 H  HD21 . LEU A 1 64 ? -3.094  7.959   8.060   1.00 0.00 ? 64 LEU A HD21 2 
+ATOM   2249 H  HD22 . LEU A 1 64 ? -4.602  8.700   8.596   1.00 0.00 ? 64 LEU A HD22 2 
+ATOM   2250 H  HD23 . LEU A 1 64 ? -4.545  7.819   7.068   1.00 0.00 ? 64 LEU A HD23 2 
+ATOM   2251 N  N    . ASP A 1 65 ? 0.217   7.799   6.256   1.00 0.00 ? 65 ASP A N    2 
+ATOM   2252 C  CA   . ASP A 1 65 ? 1.252   6.975   5.569   1.00 0.00 ? 65 ASP A CA   2 
+ATOM   2253 C  C    . ASP A 1 65 ? 1.041   5.507   5.948   1.00 0.00 ? 65 ASP A C    2 
+ATOM   2254 O  O    . ASP A 1 65 ? 0.725   4.679   5.117   1.00 0.00 ? 65 ASP A O    2 
+ATOM   2255 C  CB   . ASP A 1 65 ? 2.646   7.427   6.011   1.00 0.00 ? 65 ASP A CB   2 
+ATOM   2256 C  CG   . ASP A 1 65 ? 2.957   8.796   5.402   1.00 0.00 ? 65 ASP A CG   2 
+ATOM   2257 O  OD1  . ASP A 1 65 ? 2.742   8.955   4.212   1.00 0.00 ? 65 ASP A OD1  2 
+ATOM   2258 O  OD2  . ASP A 1 65 ? 3.403   9.661   6.137   1.00 0.00 ? 65 ASP A OD2  2 
+ATOM   2259 H  H    . ASP A 1 65 ? -0.252  7.438   7.036   1.00 0.00 ? 65 ASP A H    2 
+ATOM   2260 H  HA   . ASP A 1 65 ? 1.155   7.090   4.499   1.00 0.00 ? 65 ASP A HA   2 
+ATOM   2261 H  HB2  . ASP A 1 65 ? 2.678   7.495   7.089   1.00 0.00 ? 65 ASP A HB2  2 
+ATOM   2262 H  HB3  . ASP A 1 65 ? 3.380   6.711   5.674   1.00 0.00 ? 65 ASP A HB3  2 
+ATOM   2263 N  N    . ASP A 1 66 ? 1.199   5.183   7.202   1.00 0.00 ? 66 ASP A N    2 
+ATOM   2264 C  CA   . ASP A 1 66 ? 0.992   3.783   7.646   1.00 0.00 ? 66 ASP A CA   2 
+ATOM   2265 C  C    . ASP A 1 66 ? 0.599   3.772   9.127   1.00 0.00 ? 66 ASP A C    2 
+ATOM   2266 O  O    . ASP A 1 66 ? 0.683   2.757   9.790   1.00 0.00 ? 66 ASP A O    2 
+ATOM   2267 C  CB   . ASP A 1 66 ? 2.284   2.984   7.452   1.00 0.00 ? 66 ASP A CB   2 
+ATOM   2268 C  CG   . ASP A 1 66 ? 2.151   2.077   6.228   1.00 0.00 ? 66 ASP A CG   2 
+ATOM   2269 O  OD1  . ASP A 1 66 ? 1.214   1.296   6.191   1.00 0.00 ? 66 ASP A OD1  2 
+ATOM   2270 O  OD2  . ASP A 1 66 ? 2.989   2.178   5.347   1.00 0.00 ? 66 ASP A OD2  2 
+ATOM   2271 H  H    . ASP A 1 66 ? 1.441   5.861   7.851   1.00 0.00 ? 66 ASP A H    2 
+ATOM   2272 H  HA   . ASP A 1 66 ? 0.206   3.347   7.063   1.00 0.00 ? 66 ASP A HA   2 
+ATOM   2273 H  HB2  . ASP A 1 66 ? 3.110   3.665   7.309   1.00 0.00 ? 66 ASP A HB2  2 
+ATOM   2274 H  HB3  . ASP A 1 66 ? 2.465   2.379   8.327   1.00 0.00 ? 66 ASP A HB3  2 
+ATOM   2275 N  N    . ASP A 1 67 ? 0.174   4.899   9.646   1.00 0.00 ? 67 ASP A N    2 
+ATOM   2276 C  CA   . ASP A 1 67 ? -0.222  4.987   11.081  1.00 0.00 ? 67 ASP A CA   2 
+ATOM   2277 C  C    . ASP A 1 67 ? 1.030   5.200   11.938  1.00 0.00 ? 67 ASP A C    2 
+ATOM   2278 O  O    . ASP A 1 67 ? 1.047   6.021   12.832  1.00 0.00 ? 67 ASP A O    2 
+ATOM   2279 C  CB   . ASP A 1 67 ? -0.935  3.704   11.515  1.00 0.00 ? 67 ASP A CB   2 
+ATOM   2280 C  CG   . ASP A 1 67 ? -1.755  3.979   12.777  1.00 0.00 ? 67 ASP A CG   2 
+ATOM   2281 O  OD1  . ASP A 1 67 ? -1.477  4.968   13.436  1.00 0.00 ? 67 ASP A OD1  2 
+ATOM   2282 O  OD2  . ASP A 1 67 ? -2.646  3.196   13.065  1.00 0.00 ? 67 ASP A OD2  2 
+ATOM   2283 H  H    . ASP A 1 67 ? 0.122   5.695   9.086   1.00 0.00 ? 67 ASP A H    2 
+ATOM   2284 H  HA   . ASP A 1 67 ? -0.888  5.828   11.214  1.00 0.00 ? 67 ASP A HA   2 
+ATOM   2285 H  HB2  . ASP A 1 67 ? -1.592  3.371   10.723  1.00 0.00 ? 67 ASP A HB2  2 
+ATOM   2286 H  HB3  . ASP A 1 67 ? -0.206  2.939   11.723  1.00 0.00 ? 67 ASP A HB3  2 
+ATOM   2287 N  N    . GLN A 1 68 ? 2.078   4.471   11.664  1.00 0.00 ? 68 GLN A N    2 
+ATOM   2288 C  CA   . GLN A 1 68 ? 3.332   4.630   12.453  1.00 0.00 ? 68 GLN A CA   2 
+ATOM   2289 C  C    . GLN A 1 68 ? 4.368   3.615   11.964  1.00 0.00 ? 68 GLN A C    2 
+ATOM   2290 O  O    . GLN A 1 68 ? 5.135   3.082   12.740  1.00 0.00 ? 68 GLN A O    2 
+ATOM   2291 C  CB   . GLN A 1 68 ? 3.044   4.399   13.942  1.00 0.00 ? 68 GLN A CB   2 
+ATOM   2292 C  CG   . GLN A 1 68 ? 2.739   2.920   14.200  1.00 0.00 ? 68 GLN A CG   2 
+ATOM   2293 C  CD   . GLN A 1 68 ? 1.582   2.463   13.310  1.00 0.00 ? 68 GLN A CD   2 
+ATOM   2294 O  OE1  . GLN A 1 68 ? 0.433   2.538   13.699  1.00 0.00 ? 68 GLN A OE1  2 
+ATOM   2295 N  NE2  . GLN A 1 68 ? 1.840   1.992   12.121  1.00 0.00 ? 68 GLN A NE2  2 
+ATOM   2296 H  H    . GLN A 1 68 ? 2.044   3.820   10.936  1.00 0.00 ? 68 GLN A H    2 
+ATOM   2297 H  HA   . GLN A 1 68 ? 3.718   5.630   12.312  1.00 0.00 ? 68 GLN A HA   2 
+ATOM   2298 H  HB2  . GLN A 1 68 ? 3.909   4.691   14.521  1.00 0.00 ? 68 GLN A HB2  2 
+ATOM   2299 H  HB3  . GLN A 1 68 ? 2.196   4.996   14.242  1.00 0.00 ? 68 GLN A HB3  2 
+ATOM   2300 H  HG2  . GLN A 1 68 ? 3.616   2.328   13.982  1.00 0.00 ? 68 GLN A HG2  2 
+ATOM   2301 H  HG3  . GLN A 1 68 ? 2.465   2.787   15.237  1.00 0.00 ? 68 GLN A HG3  2 
+ATOM   2302 H  HE21 . GLN A 1 68 ? 2.765   1.936   11.810  1.00 0.00 ? 68 GLN A HE21 2 
+ATOM   2303 H  HE22 . GLN A 1 68 ? 1.112   1.688   11.544  1.00 0.00 ? 68 GLN A HE22 2 
+ATOM   2304 N  N    . ILE A 1 69 ? 4.389   3.355   10.678  1.00 0.00 ? 69 ILE A N    2 
+ATOM   2305 C  CA   . ILE A 1 69 ? 5.370   2.380   10.100  1.00 0.00 ? 69 ILE A CA   2 
+ATOM   2306 C  C    . ILE A 1 69 ? 4.822   0.958   10.200  1.00 0.00 ? 69 ILE A C    2 
+ATOM   2307 O  O    . ILE A 1 69 ? 5.567   0.008   10.338  1.00 0.00 ? 69 ILE A O    2 
+ATOM   2308 C  CB   . ILE A 1 69 ? 6.702   2.467   10.849  1.00 0.00 ? 69 ILE A CB   2 
+ATOM   2309 C  CG1  . ILE A 1 69 ? 7.073   3.934   11.061  1.00 0.00 ? 69 ILE A CG1  2 
+ATOM   2310 C  CG2  . ILE A 1 69 ? 7.797   1.778   10.037  1.00 0.00 ? 69 ILE A CG2  2 
+ATOM   2311 C  CD1  . ILE A 1 69 ? 7.460   4.152   12.523  1.00 0.00 ? 69 ILE A CD1  2 
+ATOM   2312 H  H    . ILE A 1 69 ? 3.753   3.807   10.084  1.00 0.00 ? 69 ILE A H    2 
+ATOM   2313 H  HA   . ILE A 1 69 ? 5.528   2.618   9.059   1.00 0.00 ? 69 ILE A HA   2 
+ATOM   2314 H  HB   . ILE A 1 69 ? 6.610   1.975   11.805  1.00 0.00 ? 69 ILE A HB   2 
+ATOM   2315 H  HG12 . ILE A 1 69 ? 7.908   4.191   10.424  1.00 0.00 ? 69 ILE A HG12 2 
+ATOM   2316 H  HG13 . ILE A 1 69 ? 6.227   4.559   10.817  1.00 0.00 ? 69 ILE A HG13 2 
+ATOM   2317 H  HG21 . ILE A 1 69 ? 7.379   0.929   9.519   1.00 0.00 ? 69 ILE A HG21 2 
+ATOM   2318 H  HG22 . ILE A 1 69 ? 8.204   2.474   9.317   1.00 0.00 ? 69 ILE A HG22 2 
+ATOM   2319 H  HG23 . ILE A 1 69 ? 8.583   1.444   10.699  1.00 0.00 ? 69 ILE A HG23 2 
+ATOM   2320 H  HD11 . ILE A 1 69 ? 7.529   3.197   13.022  1.00 0.00 ? 69 ILE A HD11 2 
+ATOM   2321 H  HD12 . ILE A 1 69 ? 8.415   4.654   12.572  1.00 0.00 ? 69 ILE A HD12 2 
+ATOM   2322 H  HD13 . ILE A 1 69 ? 6.709   4.759   13.008  1.00 0.00 ? 69 ILE A HD13 2 
+ATOM   2323 N  N    . GLU A 1 70 ? 3.531   0.800   10.113  1.00 0.00 ? 70 GLU A N    2 
+ATOM   2324 C  CA   . GLU A 1 70 ? 2.936   -0.561  10.187  1.00 0.00 ? 70 GLU A CA   2 
+ATOM   2325 C  C    . GLU A 1 70 ? 1.412   -0.456  10.194  1.00 0.00 ? 70 GLU A C    2 
+ATOM   2326 O  O    . GLU A 1 70 ? 0.779   -0.585  11.222  1.00 0.00 ? 70 GLU A O    2 
+ATOM   2327 C  CB   . GLU A 1 70 ? 3.391   -1.266  11.468  1.00 0.00 ? 70 GLU A CB   2 
+ATOM   2328 C  CG   . GLU A 1 70 ? 3.393   -2.778  11.239  1.00 0.00 ? 70 GLU A CG   2 
+ATOM   2329 C  CD   . GLU A 1 70 ? 2.964   -3.492  12.522  1.00 0.00 ? 70 GLU A CD   2 
+ATOM   2330 O  OE1  . GLU A 1 70 ? 1.775   -3.511  12.797  1.00 0.00 ? 70 GLU A OE1  2 
+ATOM   2331 O  OE2  . GLU A 1 70 ? 3.831   -4.009  13.206  1.00 0.00 ? 70 GLU A OE2  2 
+ATOM   2332 H  H    . GLU A 1 70 ? 2.952   1.577   9.985   1.00 0.00 ? 70 GLU A H    2 
+ATOM   2333 H  HA   . GLU A 1 70 ? 3.251   -1.130  9.331   1.00 0.00 ? 70 GLU A HA   2 
+ATOM   2334 H  HB2  . GLU A 1 70 ? 4.384   -0.938  11.732  1.00 0.00 ? 70 GLU A HB2  2 
+ATOM   2335 H  HB3  . GLU A 1 70 ? 2.709   -1.028  12.270  1.00 0.00 ? 70 GLU A HB3  2 
+ATOM   2336 H  HG2  . GLU A 1 70 ? 2.703   -3.022  10.443  1.00 0.00 ? 70 GLU A HG2  2 
+ATOM   2337 H  HG3  . GLU A 1 70 ? 4.386   -3.101  10.965  1.00 0.00 ? 70 GLU A HG3  2 
+ATOM   2338 N  N    . ALA A 1 71 ? 0.812   -0.236  9.055   1.00 0.00 ? 71 ALA A N    2 
+ATOM   2339 C  CA   . ALA A 1 71 ? -0.673  -0.140  9.017   1.00 0.00 ? 71 ALA A CA   2 
+ATOM   2340 C  C    . ALA A 1 71 ? -1.153  0.192   7.603   1.00 0.00 ? 71 ALA A C    2 
+ATOM   2341 O  O    . ALA A 1 71 ? -1.463  1.327   7.298   1.00 0.00 ? 71 ALA A O    2 
+ATOM   2342 C  CB   . ALA A 1 71 ? -1.147  0.954   9.976   1.00 0.00 ? 71 ALA A CB   2 
+ATOM   2343 H  H    . ALA A 1 71 ? 1.333   -0.147  8.233   1.00 0.00 ? 71 ALA A H    2 
+ATOM   2344 H  HA   . ALA A 1 71 ? -1.089  -1.082  9.320   1.00 0.00 ? 71 ALA A HA   2 
+ATOM   2345 H  HB1  . ALA A 1 71 ? -0.450  1.046   10.793  1.00 0.00 ? 71 ALA A HB1  2 
+ATOM   2346 H  HB2  . ALA A 1 71 ? -1.209  1.894   9.448   1.00 0.00 ? 71 ALA A HB2  2 
+ATOM   2347 H  HB3  . ALA A 1 71 ? -2.122  0.695   10.362  1.00 0.00 ? 71 ALA A HB3  2 
+ATOM   2348 N  N    . GLY A 1 72 ? -1.234  -0.784  6.738   1.00 0.00 ? 72 GLY A N    2 
+ATOM   2349 C  CA   . GLY A 1 72 ? -1.715  -0.505  5.360   1.00 0.00 ? 72 GLY A CA   2 
+ATOM   2350 C  C    . GLY A 1 72 ? -3.020  0.287   5.441   1.00 0.00 ? 72 GLY A C    2 
+ATOM   2351 O  O    . GLY A 1 72 ? -3.383  1.005   4.532   1.00 0.00 ? 72 GLY A O    2 
+ATOM   2352 H  H    . GLY A 1 72 ? -0.991  -1.696  6.997   1.00 0.00 ? 72 GLY A H    2 
+ATOM   2353 H  HA2  . GLY A 1 72 ? -0.970  0.066   4.831   1.00 0.00 ? 72 GLY A HA2  2 
+ATOM   2354 H  HA3  . GLY A 1 72 ? -1.894  -1.435  4.845   1.00 0.00 ? 72 GLY A HA3  2 
+ATOM   2355 N  N    . TYR A 1 73 ? -3.724  0.146   6.535   1.00 0.00 ? 73 TYR A N    2 
+ATOM   2356 C  CA   . TYR A 1 73 ? -5.019  0.869   6.722   1.00 0.00 ? 73 TYR A CA   2 
+ATOM   2357 C  C    . TYR A 1 73 ? -4.962  2.254   6.065   1.00 0.00 ? 73 TYR A C    2 
+ATOM   2358 O  O    . TYR A 1 73 ? -5.684  2.533   5.129   1.00 0.00 ? 73 TYR A O    2 
+ATOM   2359 C  CB   . TYR A 1 73 ? -5.284  1.029   8.220   1.00 0.00 ? 73 TYR A CB   2 
+ATOM   2360 C  CG   . TYR A 1 73 ? -6.738  1.361   8.448   1.00 0.00 ? 73 TYR A CG   2 
+ATOM   2361 C  CD1  . TYR A 1 73 ? -7.708  0.358   8.353   1.00 0.00 ? 73 TYR A CD1  2 
+ATOM   2362 C  CD2  . TYR A 1 73 ? -7.116  2.673   8.759   1.00 0.00 ? 73 TYR A CD2  2 
+ATOM   2363 C  CE1  . TYR A 1 73 ? -9.057  0.665   8.567   1.00 0.00 ? 73 TYR A CE1  2 
+ATOM   2364 C  CE2  . TYR A 1 73 ? -8.464  2.981   8.975   1.00 0.00 ? 73 TYR A CE2  2 
+ATOM   2365 C  CZ   . TYR A 1 73 ? -9.435  1.977   8.878   1.00 0.00 ? 73 TYR A CZ   2 
+ATOM   2366 O  OH   . TYR A 1 73 ? -10.764 2.280   9.092   1.00 0.00 ? 73 TYR A OH   2 
+ATOM   2367 H  H    . TYR A 1 73 ? -3.400  -0.450  7.241   1.00 0.00 ? 73 TYR A H    2 
+ATOM   2368 H  HA   . TYR A 1 73 ? -5.817  0.295   6.277   1.00 0.00 ? 73 TYR A HA   2 
+ATOM   2369 H  HB2  . TYR A 1 73 ? -5.044  0.105   8.726   1.00 0.00 ? 73 TYR A HB2  2 
+ATOM   2370 H  HB3  . TYR A 1 73 ? -4.668  1.825   8.611   1.00 0.00 ? 73 TYR A HB3  2 
+ATOM   2371 H  HD1  . TYR A 1 73 ? -7.418  -0.654  8.112   1.00 0.00 ? 73 TYR A HD1  2 
+ATOM   2372 H  HD2  . TYR A 1 73 ? -6.366  3.448   8.832   1.00 0.00 ? 73 TYR A HD2  2 
+ATOM   2373 H  HE1  . TYR A 1 73 ? -9.806  -0.109  8.494   1.00 0.00 ? 73 TYR A HE1  2 
+ATOM   2374 H  HE2  . TYR A 1 73 ? -8.754  3.993   9.215   1.00 0.00 ? 73 TYR A HE2  2 
+ATOM   2375 H  HH   . TYR A 1 73 ? -10.815 3.183   9.411   1.00 0.00 ? 73 TYR A HH   2 
+ATOM   2376 N  N    . VAL A 1 74 ? -4.119  3.125   6.550   1.00 0.00 ? 74 VAL A N    2 
+ATOM   2377 C  CA   . VAL A 1 74 ? -4.034  4.487   5.950   1.00 0.00 ? 74 VAL A CA   2 
+ATOM   2378 C  C    . VAL A 1 74 ? -3.552  4.383   4.502   1.00 0.00 ? 74 VAL A C    2 
+ATOM   2379 O  O    . VAL A 1 74 ? -3.809  3.411   3.820   1.00 0.00 ? 74 VAL A O    2 
+ATOM   2380 C  CB   . VAL A 1 74 ? -3.053  5.343   6.752   1.00 0.00 ? 74 VAL A CB   2 
+ATOM   2381 C  CG1  . VAL A 1 74 ? -3.387  5.247   8.241   1.00 0.00 ? 74 VAL A CG1  2 
+ATOM   2382 C  CG2  . VAL A 1 74 ? -1.628  4.838   6.518   1.00 0.00 ? 74 VAL A CG2  2 
+ATOM   2383 H  H    . VAL A 1 74 ? -3.548  2.886   7.309   1.00 0.00 ? 74 VAL A H    2 
+ATOM   2384 H  HA   . VAL A 1 74 ? -5.011  4.949   5.969   1.00 0.00 ? 74 VAL A HA   2 
+ATOM   2385 H  HB   . VAL A 1 74 ? -3.129  6.372   6.432   1.00 0.00 ? 74 VAL A HB   2 
+ATOM   2386 H  HG11 . VAL A 1 74 ? -4.251  4.612   8.376   1.00 0.00 ? 74 VAL A HG11 2 
+ATOM   2387 H  HG12 . VAL A 1 74 ? -2.546  4.829   8.773   1.00 0.00 ? 74 VAL A HG12 2 
+ATOM   2388 H  HG13 . VAL A 1 74 ? -3.604  6.233   8.626   1.00 0.00 ? 74 VAL A HG13 2 
+ATOM   2389 H  HG21 . VAL A 1 74 ? -1.632  3.759   6.466   1.00 0.00 ? 74 VAL A HG21 2 
+ATOM   2390 H  HG22 . VAL A 1 74 ? -1.251  5.242   5.590   1.00 0.00 ? 74 VAL A HG22 2 
+ATOM   2391 H  HG23 . VAL A 1 74 ? -0.995  5.157   7.333   1.00 0.00 ? 74 VAL A HG23 2 
+ATOM   2392 N  N    . LEU A 1 75 ? -2.856  5.380   4.025   1.00 0.00 ? 75 LEU A N    2 
+ATOM   2393 C  CA   . LEU A 1 75 ? -2.362  5.340   2.620   1.00 0.00 ? 75 LEU A CA   2 
+ATOM   2394 C  C    . LEU A 1 75 ? -0.861  5.035   2.612   1.00 0.00 ? 75 LEU A C    2 
+ATOM   2395 O  O    . LEU A 1 75 ? -0.069  5.743   3.201   1.00 0.00 ? 75 LEU A O    2 
+ATOM   2396 C  CB   . LEU A 1 75 ? -2.612  6.695   1.947   1.00 0.00 ? 75 LEU A CB   2 
+ATOM   2397 C  CG   . LEU A 1 75 ? -4.109  7.040   1.972   1.00 0.00 ? 75 LEU A CG   2 
+ATOM   2398 C  CD1  . LEU A 1 75 ? -4.951  5.777   1.765   1.00 0.00 ? 75 LEU A CD1  2 
+ATOM   2399 C  CD2  . LEU A 1 75 ? -4.465  7.671   3.321   1.00 0.00 ? 75 LEU A CD2  2 
+ATOM   2400 H  H    . LEU A 1 75 ? -2.661  6.157   4.591   1.00 0.00 ? 75 LEU A H    2 
+ATOM   2401 H  HA   . LEU A 1 75 ? -2.887  4.568   2.077   1.00 0.00 ? 75 LEU A HA   2 
+ATOM   2402 H  HB2  . LEU A 1 75 ? -2.060  7.461   2.473   1.00 0.00 ? 75 LEU A HB2  2 
+ATOM   2403 H  HB3  . LEU A 1 75 ? -2.274  6.652   0.922   1.00 0.00 ? 75 LEU A HB3  2 
+ATOM   2404 H  HG   . LEU A 1 75 ? -4.324  7.744   1.182   1.00 0.00 ? 75 LEU A HG   2 
+ATOM   2405 H  HD11 . LEU A 1 75 ? -4.431  5.102   1.102   1.00 0.00 ? 75 LEU A HD11 2 
+ATOM   2406 H  HD12 . LEU A 1 75 ? -5.114  5.292   2.716   1.00 0.00 ? 75 LEU A HD12 2 
+ATOM   2407 H  HD13 . LEU A 1 75 ? -5.903  6.046   1.331   1.00 0.00 ? 75 LEU A HD13 2 
+ATOM   2408 H  HD21 . LEU A 1 75 ? -3.767  8.465   3.541   1.00 0.00 ? 75 LEU A HD21 2 
+ATOM   2409 H  HD22 . LEU A 1 75 ? -5.466  8.075   3.277   1.00 0.00 ? 75 LEU A HD22 2 
+ATOM   2410 H  HD23 . LEU A 1 75 ? -4.413  6.921   4.096   1.00 0.00 ? 75 LEU A HD23 2 
+ATOM   2411 N  N    . THR A 1 76 ? -0.467  3.986   1.944   1.00 0.00 ? 76 THR A N    2 
+ATOM   2412 C  CA   . THR A 1 76 ? 0.979   3.626   1.889   1.00 0.00 ? 76 THR A CA   2 
+ATOM   2413 C  C    . THR A 1 76 ? 1.613   4.245   0.639   1.00 0.00 ? 76 THR A C    2 
+ATOM   2414 O  O    . THR A 1 76 ? 2.718   3.912   0.260   1.00 0.00 ? 76 THR A O    2 
+ATOM   2415 C  CB   . THR A 1 76 ? 1.125   2.101   1.837   1.00 0.00 ? 76 THR A CB   2 
+ATOM   2416 O  OG1  . THR A 1 76 ? 2.470   1.746   2.120   1.00 0.00 ? 76 THR A OG1  2 
+ATOM   2417 C  CG2  . THR A 1 76 ? 0.742   1.593   0.445   1.00 0.00 ? 76 THR A CG2  2 
+ATOM   2418 H  H    . THR A 1 76 ? -1.125  3.431   1.475   1.00 0.00 ? 76 THR A H    2 
+ATOM   2419 H  HA   . THR A 1 76 ? 1.477   4.005   2.770   1.00 0.00 ? 76 THR A HA   2 
+ATOM   2420 H  HB   . THR A 1 76 ? 0.471   1.653   2.571   1.00 0.00 ? 76 THR A HB   2 
+ATOM   2421 H  HG1  . THR A 1 76 ? 2.829   2.400   2.725   1.00 0.00 ? 76 THR A HG1  2 
+ATOM   2422 H  HG21 . THR A 1 76 ? 0.297   2.396   -0.122  1.00 0.00 ? 76 THR A HG21 2 
+ATOM   2423 H  HG22 . THR A 1 76 ? 1.626   1.239   -0.064  1.00 0.00 ? 76 THR A HG22 2 
+ATOM   2424 H  HG23 . THR A 1 76 ? 0.033   0.783   0.540   1.00 0.00 ? 76 THR A HG23 2 
+ATOM   2425 N  N    . CYS A 1 77 ? 0.912   5.134   -0.012  1.00 0.00 ? 77 CYS A N    2 
+ATOM   2426 C  CA   . CYS A 1 77 ? 1.456   5.767   -1.251  1.00 0.00 ? 77 CYS A CA   2 
+ATOM   2427 C  C    . CYS A 1 77 ? 2.506   6.844   -0.916  1.00 0.00 ? 77 CYS A C    2 
+ATOM   2428 O  O    . CYS A 1 77 ? 2.836   7.667   -1.746  1.00 0.00 ? 77 CYS A O    2 
+ATOM   2429 C  CB   . CYS A 1 77 ? 0.307   6.408   -2.033  1.00 0.00 ? 77 CYS A CB   2 
+ATOM   2430 S  SG   . CYS A 1 77 ? -0.667  7.438   -0.919  1.00 0.00 ? 77 CYS A SG   2 
+ATOM   2431 H  H    . CYS A 1 77 ? 0.018   5.375   0.308   1.00 0.00 ? 77 CYS A H    2 
+ATOM   2432 H  HA   . CYS A 1 77 ? 1.915   5.005   -1.865  1.00 0.00 ? 77 CYS A HA   2 
+ATOM   2433 H  HB2  . CYS A 1 77 ? 0.707   7.017   -2.830  1.00 0.00 ? 77 CYS A HB2  2 
+ATOM   2434 H  HB3  . CYS A 1 77 ? -0.323  5.636   -2.448  1.00 0.00 ? 77 CYS A HB3  2 
+ATOM   2435 N  N    . VAL A 1 78 ? 3.044   6.848   0.279   1.00 0.00 ? 78 VAL A N    2 
+ATOM   2436 C  CA   . VAL A 1 78 ? 4.074   7.874   0.630   1.00 0.00 ? 78 VAL A CA   2 
+ATOM   2437 C  C    . VAL A 1 78 ? 4.829   7.431   1.888   1.00 0.00 ? 78 VAL A C    2 
+ATOM   2438 O  O    . VAL A 1 78 ? 4.747   8.057   2.926   1.00 0.00 ? 78 VAL A O    2 
+ATOM   2439 C  CB   . VAL A 1 78 ? 3.393   9.219   0.890   1.00 0.00 ? 78 VAL A CB   2 
+ATOM   2440 C  CG1  . VAL A 1 78 ? 3.186   9.952   -0.438  1.00 0.00 ? 78 VAL A CG1  2 
+ATOM   2441 C  CG2  . VAL A 1 78 ? 2.036   8.981   1.557   1.00 0.00 ? 78 VAL A CG2  2 
+ATOM   2442 H  H    . VAL A 1 78 ? 2.779   6.180   0.941   1.00 0.00 ? 78 VAL A H    2 
+ATOM   2443 H  HA   . VAL A 1 78 ? 4.770   7.977   -0.190  1.00 0.00 ? 78 VAL A HA   2 
+ATOM   2444 H  HB   . VAL A 1 78 ? 4.016   9.818   1.537   1.00 0.00 ? 78 VAL A HB   2 
+ATOM   2445 H  HG11 . VAL A 1 78 ? 4.029   9.766   -1.087  1.00 0.00 ? 78 VAL A HG11 2 
+ATOM   2446 H  HG12 . VAL A 1 78 ? 2.282   9.595   -0.910  1.00 0.00 ? 78 VAL A HG12 2 
+ATOM   2447 H  HG13 . VAL A 1 78 ? 3.101   11.014  -0.254  1.00 0.00 ? 78 VAL A HG13 2 
+ATOM   2448 H  HG21 . VAL A 1 78 ? 2.034   8.010   2.029   1.00 0.00 ? 78 VAL A HG21 2 
+ATOM   2449 H  HG22 . VAL A 1 78 ? 1.864   9.744   2.303   1.00 0.00 ? 78 VAL A HG22 2 
+ATOM   2450 H  HG23 . VAL A 1 78 ? 1.255   9.022   0.813   1.00 0.00 ? 78 VAL A HG23 2 
+ATOM   2451 N  N    . ALA A 1 79 ? 5.553   6.346   1.805   1.00 0.00 ? 79 ALA A N    2 
+ATOM   2452 C  CA   . ALA A 1 79 ? 6.299   5.844   2.992   1.00 0.00 ? 79 ALA A CA   2 
+ATOM   2453 C  C    . ALA A 1 79 ? 7.815   6.012   2.792   1.00 0.00 ? 79 ALA A C    2 
+ATOM   2454 O  O    . ALA A 1 79 ? 8.271   6.898   2.096   1.00 0.00 ? 79 ALA A O    2 
+ATOM   2455 C  CB   . ALA A 1 79 ? 5.973   4.360   3.181   1.00 0.00 ? 79 ALA A CB   2 
+ATOM   2456 H  H    . ALA A 1 79 ? 5.592   5.851   0.966   1.00 0.00 ? 79 ALA A H    2 
+ATOM   2457 H  HA   . ALA A 1 79 ? 5.991   6.390   3.867   1.00 0.00 ? 79 ALA A HA   2 
+ATOM   2458 H  HB1  . ALA A 1 79 ? 5.112   4.103   2.582   1.00 0.00 ? 79 ALA A HB1  2 
+ATOM   2459 H  HB2  . ALA A 1 79 ? 6.818   3.763   2.870   1.00 0.00 ? 79 ALA A HB2  2 
+ATOM   2460 H  HB3  . ALA A 1 79 ? 5.758   4.165   4.221   1.00 0.00 ? 79 ALA A HB3  2 
+ATOM   2461 N  N    . TYR A 1 80 ? 8.587   5.147   3.395   1.00 0.00 ? 80 TYR A N    2 
+ATOM   2462 C  CA   . TYR A 1 80 ? 10.062  5.193   3.266   1.00 0.00 ? 80 TYR A CA   2 
+ATOM   2463 C  C    . TYR A 1 80 ? 10.441  4.010   2.353   1.00 0.00 ? 80 TYR A C    2 
+ATOM   2464 O  O    . TYR A 1 80 ? 9.583   3.549   1.626   1.00 0.00 ? 80 TYR A O    2 
+ATOM   2465 C  CB   . TYR A 1 80 ? 10.667  5.060   4.668   1.00 0.00 ? 80 TYR A CB   2 
+ATOM   2466 C  CG   . TYR A 1 80 ? 11.802  6.051   4.846   1.00 0.00 ? 80 TYR A CG   2 
+ATOM   2467 C  CD1  . TYR A 1 80 ? 11.706  7.337   4.295   1.00 0.00 ? 80 TYR A CD1  2 
+ATOM   2468 C  CD2  . TYR A 1 80 ? 12.947  5.689   5.571   1.00 0.00 ? 80 TYR A CD2  2 
+ATOM   2469 C  CE1  . TYR A 1 80 ? 12.751  8.254   4.467   1.00 0.00 ? 80 TYR A CE1  2 
+ATOM   2470 C  CE2  . TYR A 1 80 ? 13.989  6.606   5.741   1.00 0.00 ? 80 TYR A CE2  2 
+ATOM   2471 C  CZ   . TYR A 1 80 ? 13.892  7.888   5.190   1.00 0.00 ? 80 TYR A CZ   2 
+ATOM   2472 O  OH   . TYR A 1 80 ? 14.921  8.793   5.359   1.00 0.00 ? 80 TYR A OH   2 
+ATOM   2473 H  H    . TYR A 1 80 ? 8.193   4.444   3.926   1.00 0.00 ? 80 TYR A H    2 
+ATOM   2474 H  HA   . TYR A 1 80 ? 10.346  6.123   2.822   1.00 0.00 ? 80 TYR A HA   2 
+ATOM   2475 H  HB2  . TYR A 1 80 ? 9.905   5.265   5.399   1.00 0.00 ? 80 TYR A HB2  2 
+ATOM   2476 H  HB3  . TYR A 1 80 ? 11.028  4.058   4.813   1.00 0.00 ? 80 TYR A HB3  2 
+ATOM   2477 H  HD1  . TYR A 1 80 ? 10.827  7.623   3.738   1.00 0.00 ? 80 TYR A HD1  2 
+ATOM   2478 H  HD2  . TYR A 1 80 ? 13.023  4.698   5.996   1.00 0.00 ? 80 TYR A HD2  2 
+ATOM   2479 H  HE1  . TYR A 1 80 ? 12.675  9.244   4.043   1.00 0.00 ? 80 TYR A HE1  2 
+ATOM   2480 H  HE2  . TYR A 1 80 ? 14.871  6.324   6.298   1.00 0.00 ? 80 TYR A HE2  2 
+ATOM   2481 H  HH   . TYR A 1 80 ? 15.021  8.957   6.299   1.00 0.00 ? 80 TYR A HH   2 
+ATOM   2482 N  N    . PRO A 1 81 ? 11.662  3.501   2.384   1.00 0.00 ? 81 PRO A N    2 
+ATOM   2483 C  CA   . PRO A 1 81 ? 11.977  2.360   1.518   1.00 0.00 ? 81 PRO A CA   2 
+ATOM   2484 C  C    . PRO A 1 81 ? 10.892  1.292   1.733   1.00 0.00 ? 81 PRO A C    2 
+ATOM   2485 O  O    . PRO A 1 81 ? 9.913   1.292   1.022   1.00 0.00 ? 81 PRO A O    2 
+ATOM   2486 C  CB   . PRO A 1 81 ? 13.380  1.909   1.947   1.00 0.00 ? 81 PRO A CB   2 
+ATOM   2487 C  CG   . PRO A 1 81 ? 13.949  3.021   2.866   1.00 0.00 ? 81 PRO A CG   2 
+ATOM   2488 C  CD   . PRO A 1 81 ? 12.787  3.968   3.222   1.00 0.00 ? 81 PRO A CD   2 
+ATOM   2489 H  HA   . PRO A 1 81 ? 11.991  2.675   0.486   1.00 0.00 ? 81 PRO A HA   2 
+ATOM   2490 H  HB2  . PRO A 1 81 ? 13.325  0.973   2.484   1.00 0.00 ? 81 PRO A HB2  2 
+ATOM   2491 H  HB3  . PRO A 1 81 ? 14.013  1.799   1.081   1.00 0.00 ? 81 PRO A HB3  2 
+ATOM   2492 H  HG2  . PRO A 1 81 ? 14.356  2.581   3.767   1.00 0.00 ? 81 PRO A HG2  2 
+ATOM   2493 H  HG3  . PRO A 1 81 ? 14.718  3.571   2.346   1.00 0.00 ? 81 PRO A HG3  2 
+ATOM   2494 H  HD2  . PRO A 1 81 ? 12.561  3.862   4.265   1.00 0.00 ? 81 PRO A HD2  2 
+ATOM   2495 H  HD3  . PRO A 1 81 ? 13.039  4.991   2.985   1.00 0.00 ? 81 PRO A HD3  2 
+ATOM   2496 N  N    . THR A 1 82 ? 11.033  0.430   2.721   1.00 0.00 ? 82 THR A N    2 
+ATOM   2497 C  CA   . THR A 1 82 ? 9.982   -0.604  3.019   1.00 0.00 ? 82 THR A CA   2 
+ATOM   2498 C  C    . THR A 1 82 ? 10.629  -1.949  3.337   1.00 0.00 ? 82 THR A C    2 
+ATOM   2499 O  O    . THR A 1 82 ? 11.215  -2.588  2.485   1.00 0.00 ? 82 THR A O    2 
+ATOM   2500 C  CB   . THR A 1 82 ? 9.011   -0.797  1.840   1.00 0.00 ? 82 THR A CB   2 
+ATOM   2501 O  OG1  . THR A 1 82 ? 8.044   0.247   1.850   1.00 0.00 ? 82 THR A OG1  2 
+ATOM   2502 C  CG2  . THR A 1 82 ? 8.293   -2.146  1.966   1.00 0.00 ? 82 THR A CG2  2 
+ATOM   2503 H  H    . THR A 1 82 ? 11.818  0.479   3.294   1.00 0.00 ? 82 THR A H    2 
+ATOM   2504 H  HA   . THR A 1 82 ? 9.418   -0.281  3.882   1.00 0.00 ? 82 THR A HA   2 
+ATOM   2505 H  HB   . THR A 1 82 ? 9.561   -0.771  0.912   1.00 0.00 ? 82 THR A HB   2 
+ATOM   2506 H  HG1  . THR A 1 82 ? 7.948   0.554   2.753   1.00 0.00 ? 82 THR A HG1  2 
+ATOM   2507 H  HG21 . THR A 1 82 ? 9.020   -2.943  1.984   1.00 0.00 ? 82 THR A HG21 2 
+ATOM   2508 H  HG22 . THR A 1 82 ? 7.717   -2.165  2.879   1.00 0.00 ? 82 THR A HG22 2 
+ATOM   2509 H  HG23 . THR A 1 82 ? 7.637   -2.283  1.126   1.00 0.00 ? 82 THR A HG23 2 
+ATOM   2510 N  N    . SER A 1 83 ? 10.476  -2.409  4.543   1.00 0.00 ? 83 SER A N    2 
+ATOM   2511 C  CA   . SER A 1 83 ? 11.021  -3.735  4.895   1.00 0.00 ? 83 SER A CA   2 
+ATOM   2512 C  C    . SER A 1 83 ? 10.107  -4.798  4.272   1.00 0.00 ? 83 SER A C    2 
+ATOM   2513 O  O    . SER A 1 83 ? 10.457  -5.956  4.168   1.00 0.00 ? 83 SER A O    2 
+ATOM   2514 C  CB   . SER A 1 83 ? 11.048  -3.898  6.416   1.00 0.00 ? 83 SER A CB   2 
+ATOM   2515 O  OG   . SER A 1 83 ? 12.368  -3.660  6.891   1.00 0.00 ? 83 SER A OG   2 
+ATOM   2516 H  H    . SER A 1 83 ? 9.972   -1.901  5.199   1.00 0.00 ? 83 SER A H    2 
+ATOM   2517 H  HA   . SER A 1 83 ? 12.014  -3.825  4.499   1.00 0.00 ? 83 SER A HA   2 
+ATOM   2518 H  HB2  . SER A 1 83 ? 10.375  -3.189  6.869   1.00 0.00 ? 83 SER A HB2  2 
+ATOM   2519 H  HB3  . SER A 1 83 ? 10.738  -4.902  6.674   1.00 0.00 ? 83 SER A HB3  2 
+ATOM   2520 H  HG   . SER A 1 83 ? 12.928  -4.376  6.583   1.00 0.00 ? 83 SER A HG   2 
+ATOM   2521 N  N    . ASP A 1 84 ? 8.929   -4.393  3.850   1.00 0.00 ? 84 ASP A N    2 
+ATOM   2522 C  CA   . ASP A 1 84 ? 7.969   -5.351  3.222   1.00 0.00 ? 84 ASP A CA   2 
+ATOM   2523 C  C    . ASP A 1 84 ? 6.629   -4.638  2.981   1.00 0.00 ? 84 ASP A C    2 
+ATOM   2524 O  O    . ASP A 1 84 ? 6.334   -3.646  3.616   1.00 0.00 ? 84 ASP A O    2 
+ATOM   2525 C  CB   . ASP A 1 84 ? 7.748   -6.541  4.158   1.00 0.00 ? 84 ASP A CB   2 
+ATOM   2526 C  CG   . ASP A 1 84 ? 7.350   -6.034  5.546   1.00 0.00 ? 84 ASP A CG   2 
+ATOM   2527 O  OD1  . ASP A 1 84 ? 7.482   -4.845  5.781   1.00 0.00 ? 84 ASP A OD1  2 
+ATOM   2528 O  OD2  . ASP A 1 84 ? 6.920   -6.845  6.350   1.00 0.00 ? 84 ASP A OD2  2 
+ATOM   2529 H  H    . ASP A 1 84 ? 8.677   -3.449  3.944   1.00 0.00 ? 84 ASP A H    2 
+ATOM   2530 H  HA   . ASP A 1 84 ? 8.372   -5.700  2.286   1.00 0.00 ? 84 ASP A HA   2 
+ATOM   2531 H  HB2  . ASP A 1 84 ? 6.959   -7.166  3.764   1.00 0.00 ? 84 ASP A HB2  2 
+ATOM   2532 H  HB3  . ASP A 1 84 ? 8.658   -7.116  4.234   1.00 0.00 ? 84 ASP A HB3  2 
+ATOM   2533 N  N    . CYS A 1 85 ? 5.801   -5.131  2.090   1.00 0.00 ? 85 CYS A N    2 
+ATOM   2534 C  CA   . CYS A 1 85 ? 4.497   -4.478  1.858   1.00 0.00 ? 85 CYS A CA   2 
+ATOM   2535 C  C    . CYS A 1 85 ? 3.406   -5.553  2.002   1.00 0.00 ? 85 CYS A C    2 
+ATOM   2536 O  O    . CYS A 1 85 ? 3.706   -6.719  2.172   1.00 0.00 ? 85 CYS A O    2 
+ATOM   2537 C  CB   . CYS A 1 85 ? 4.453   -3.866  0.452   1.00 0.00 ? 85 CYS A CB   2 
+ATOM   2538 S  SG   . CYS A 1 85 ? 5.289   -2.258  0.395   1.00 0.00 ? 85 CYS A SG   2 
+ATOM   2539 H  H    . CYS A 1 85 ? 6.020   -5.935  1.588   1.00 0.00 ? 85 CYS A H    2 
+ATOM   2540 H  HA   . CYS A 1 85 ? 4.353   -3.716  2.595   1.00 0.00 ? 85 CYS A HA   2 
+ATOM   2541 H  HB2  . CYS A 1 85 ? 4.934   -4.526  -0.234  1.00 0.00 ? 85 CYS A HB2  2 
+ATOM   2542 H  HB3  . CYS A 1 85 ? 3.432   -3.752  0.158   1.00 0.00 ? 85 CYS A HB3  2 
+ATOM   2543 N  N    . THR A 1 86 ? 2.149   -5.189  1.935   1.00 0.00 ? 86 THR A N    2 
+ATOM   2544 C  CA   . THR A 1 86 ? 1.057   -6.188  2.072   1.00 0.00 ? 86 THR A CA   2 
+ATOM   2545 C  C    . THR A 1 86 ? -0.255  -5.411  2.112   1.00 0.00 ? 86 THR A C    2 
+ATOM   2546 O  O    . THR A 1 86 ? -0.401  -4.467  2.859   1.00 0.00 ? 86 THR A O    2 
+ATOM   2547 C  CB   . THR A 1 86 ? 1.214   -6.994  3.370   1.00 0.00 ? 86 THR A CB   2 
+ATOM   2548 O  OG1  . THR A 1 86 ? 2.398   -6.602  4.053   1.00 0.00 ? 86 THR A OG1  2 
+ATOM   2549 C  CG2  . THR A 1 86 ? 1.285   -8.484  3.038   1.00 0.00 ? 86 THR A CG2  2 
+ATOM   2550 H  H    . THR A 1 86 ? 1.912   -4.258  1.786   1.00 0.00 ? 86 THR A H    2 
+ATOM   2551 H  HA   . THR A 1 86 ? 1.062   -6.855  1.220   1.00 0.00 ? 86 THR A HA   2 
+ATOM   2552 H  HB   . THR A 1 86 ? 0.362   -6.813  4.003   1.00 0.00 ? 86 THR A HB   2 
+ATOM   2553 H  HG1  . THR A 1 86 ? 2.430   -7.081  4.885   1.00 0.00 ? 86 THR A HG1  2 
+ATOM   2554 H  HG21 . THR A 1 86 ? 1.116   -8.627  1.981   1.00 0.00 ? 86 THR A HG21 2 
+ATOM   2555 H  HG22 . THR A 1 86 ? 2.261   -8.865  3.301   1.00 0.00 ? 86 THR A HG22 2 
+ATOM   2556 H  HG23 . THR A 1 86 ? 0.530   -9.014  3.598   1.00 0.00 ? 86 THR A HG23 2 
+ATOM   2557 N  N    . ILE A 1 87 ? -1.200  -5.769  1.301   1.00 0.00 ? 87 ILE A N    2 
+ATOM   2558 C  CA   . ILE A 1 87 ? -2.487  -4.987  1.302   1.00 0.00 ? 87 ILE A CA   2 
+ATOM   2559 C  C    . ILE A 1 87 ? -3.692  -5.898  1.058   1.00 0.00 ? 87 ILE A C    2 
+ATOM   2560 O  O    . ILE A 1 87 ? -4.048  -6.167  -0.071  1.00 0.00 ? 87 ILE A O    2 
+ATOM   2561 C  CB   . ILE A 1 87 ? -2.428  -3.931  0.196   1.00 0.00 ? 87 ILE A CB   2 
+ATOM   2562 C  CG1  . ILE A 1 87 ? -1.389  -2.861  0.566   1.00 0.00 ? 87 ILE A CG1  2 
+ATOM   2563 C  CG2  . ILE A 1 87 ? -3.808  -3.288  0.022   1.00 0.00 ? 87 ILE A CG2  2 
+ATOM   2564 C  CD1  . ILE A 1 87 ? -1.997  -1.844  1.537   1.00 0.00 ? 87 ILE A CD1  2 
+ATOM   2565 H  H    . ILE A 1 87 ? -1.057  -6.524  0.686   1.00 0.00 ? 87 ILE A H    2 
+ATOM   2566 H  HA   . ILE A 1 87 ? -2.602  -4.493  2.255   1.00 0.00 ? 87 ILE A HA   2 
+ATOM   2567 H  HB   . ILE A 1 87 ? -2.139  -4.405  -0.732  1.00 0.00 ? 87 ILE A HB   2 
+ATOM   2568 H  HG12 . ILE A 1 87 ? -0.539  -3.335  1.032   1.00 0.00 ? 87 ILE A HG12 2 
+ATOM   2569 H  HG13 . ILE A 1 87 ? -1.067  -2.351  -0.330  1.00 0.00 ? 87 ILE A HG13 2 
+ATOM   2570 H  HG21 . ILE A 1 87 ? -4.392  -3.441  0.918   1.00 0.00 ? 87 ILE A HG21 2 
+ATOM   2571 H  HG22 . ILE A 1 87 ? -3.693  -2.230  -0.157  1.00 0.00 ? 87 ILE A HG22 2 
+ATOM   2572 H  HG23 . ILE A 1 87 ? -4.313  -3.742  -0.818  1.00 0.00 ? 87 ILE A HG23 2 
+ATOM   2573 H  HD11 . ILE A 1 87 ? -2.543  -2.364  2.310   1.00 0.00 ? 87 ILE A HD11 2 
+ATOM   2574 H  HD12 . ILE A 1 87 ? -1.208  -1.258  1.985   1.00 0.00 ? 87 ILE A HD12 2 
+ATOM   2575 H  HD13 . ILE A 1 87 ? -2.668  -1.190  1.000   1.00 0.00 ? 87 ILE A HD13 2 
+ATOM   2576 N  N    . GLU A 1 88 ? -4.343  -6.351  2.104   1.00 0.00 ? 88 GLU A N    2 
+ATOM   2577 C  CA   . GLU A 1 88 ? -5.533  -7.236  1.915   1.00 0.00 ? 88 GLU A CA   2 
+ATOM   2578 C  C    . GLU A 1 88 ? -6.678  -6.451  1.275   1.00 0.00 ? 88 GLU A C    2 
+ATOM   2579 O  O    . GLU A 1 88 ? -6.852  -5.272  1.521   1.00 0.00 ? 88 GLU A O    2 
+ATOM   2580 C  CB   . GLU A 1 88 ? -5.983  -7.788  3.271   1.00 0.00 ? 88 GLU A CB   2 
+ATOM   2581 C  CG   . GLU A 1 88 ? -6.697  -9.125  3.066   1.00 0.00 ? 88 GLU A CG   2 
+ATOM   2582 C  CD   . GLU A 1 88 ? -7.945  -9.177  3.950   1.00 0.00 ? 88 GLU A CD   2 
+ATOM   2583 O  OE1  . GLU A 1 88 ? -8.853  -8.399  3.706   1.00 0.00 ? 88 GLU A OE1  2 
+ATOM   2584 O  OE2  . GLU A 1 88 ? -7.971  -9.993  4.856   1.00 0.00 ? 88 GLU A OE2  2 
+ATOM   2585 H  H    . GLU A 1 88 ? -4.058  -6.099  3.012   1.00 0.00 ? 88 GLU A H    2 
+ATOM   2586 H  HA   . GLU A 1 88 ? -5.267  -8.058  1.269   1.00 0.00 ? 88 GLU A HA   2 
+ATOM   2587 H  HB2  . GLU A 1 88 ? -5.121  -7.932  3.905   1.00 0.00 ? 88 GLU A HB2  2 
+ATOM   2588 H  HB3  . GLU A 1 88 ? -6.660  -7.090  3.738   1.00 0.00 ? 88 GLU A HB3  2 
+ATOM   2589 H  HG2  . GLU A 1 88 ? -6.985  -9.224  2.029   1.00 0.00 ? 88 GLU A HG2  2 
+ATOM   2590 H  HG3  . GLU A 1 88 ? -6.033  -9.932  3.335   1.00 0.00 ? 88 GLU A HG3  2 
+ATOM   2591 N  N    . THR A 1 89 ? -7.457  -7.105  0.453   1.00 0.00 ? 89 THR A N    2 
+ATOM   2592 C  CA   . THR A 1 89 ? -8.600  -6.423  -0.216  1.00 0.00 ? 89 THR A CA   2 
+ATOM   2593 C  C    . THR A 1 89 ? -8.188  -5.015  -0.644  1.00 0.00 ? 89 THR A C    2 
+ATOM   2594 O  O    . THR A 1 89 ? -8.649  -4.031  -0.103  1.00 0.00 ? 89 THR A O    2 
+ATOM   2595 C  CB   . THR A 1 89 ? -9.784  -6.336  0.750   1.00 0.00 ? 89 THR A CB   2 
+ATOM   2596 O  OG1  . THR A 1 89 ? -9.303  -6.123  2.070   1.00 0.00 ? 89 THR A OG1  2 
+ATOM   2597 C  CG2  . THR A 1 89 ? -10.583 -7.639  0.699   1.00 0.00 ? 89 THR A CG2  2 
+ATOM   2598 H  H    . THR A 1 89 ? -7.287  -8.054  0.277   1.00 0.00 ? 89 THR A H    2 
+ATOM   2599 H  HA   . THR A 1 89 ? -8.893  -6.989  -1.087  1.00 0.00 ? 89 THR A HA   2 
+ATOM   2600 H  HB   . THR A 1 89 ? -10.424 -5.515  0.463   1.00 0.00 ? 89 THR A HB   2 
+ATOM   2601 H  HG1  . THR A 1 89 ? -10.051 -5.886  2.624   1.00 0.00 ? 89 THR A HG1  2 
+ATOM   2602 H  HG21 . THR A 1 89 ? -10.886 -7.835  -0.320  1.00 0.00 ? 89 THR A HG21 2 
+ATOM   2603 H  HG22 . THR A 1 89 ? -9.967  -8.452  1.053   1.00 0.00 ? 89 THR A HG22 2 
+ATOM   2604 H  HG23 . THR A 1 89 ? -11.458 -7.551  1.324   1.00 0.00 ? 89 THR A HG23 2 
+ATOM   2605 N  N    . HIS A 1 90 ? -7.322  -4.910  -1.614  1.00 0.00 ? 90 HIS A N    2 
+ATOM   2606 C  CA   . HIS A 1 90 ? -6.887  -3.563  -2.071  1.00 0.00 ? 90 HIS A CA   2 
+ATOM   2607 C  C    . HIS A 1 90 ? -8.052  -2.882  -2.808  1.00 0.00 ? 90 HIS A C    2 
+ATOM   2608 O  O    . HIS A 1 90 ? -8.245  -3.043  -3.995  1.00 0.00 ? 90 HIS A O    2 
+ATOM   2609 C  CB   . HIS A 1 90 ? -5.661  -3.710  -2.987  1.00 0.00 ? 90 HIS A CB   2 
+ATOM   2610 C  CG   . HIS A 1 90 ? -6.081  -4.189  -4.351  1.00 0.00 ? 90 HIS A CG   2 
+ATOM   2611 N  ND1  . HIS A 1 90 ? -6.126  -3.343  -5.450  1.00 0.00 ? 90 HIS A ND1  2 
+ATOM   2612 C  CD2  . HIS A 1 90 ? -6.486  -5.417  -4.809  1.00 0.00 ? 90 HIS A CD2  2 
+ATOM   2613 C  CE1  . HIS A 1 90 ? -6.543  -4.068  -6.504  1.00 0.00 ? 90 HIS A CE1  2 
+ATOM   2614 N  NE2  . HIS A 1 90 ? -6.777  -5.339  -6.169  1.00 0.00 ? 90 HIS A NE2  2 
+ATOM   2615 H  H    . HIS A 1 90 ? -6.960  -5.715  -2.040  1.00 0.00 ? 90 HIS A H    2 
+ATOM   2616 H  HA   . HIS A 1 90 ? -6.618  -2.969  -1.210  1.00 0.00 ? 90 HIS A HA   2 
+ATOM   2617 H  HB2  . HIS A 1 90 ? -5.163  -2.757  -3.078  1.00 0.00 ? 90 HIS A HB2  2 
+ATOM   2618 H  HB3  . HIS A 1 90 ? -4.977  -4.428  -2.552  1.00 0.00 ? 90 HIS A HB3  2 
+ATOM   2619 H  HD1  . HIS A 1 90 ? -5.893  -2.390  -5.458  1.00 0.00 ? 90 HIS A HD1  2 
+ATOM   2620 H  HD2  . HIS A 1 90 ? -6.567  -6.310  -4.206  1.00 0.00 ? 90 HIS A HD2  2 
+ATOM   2621 H  HE1  . HIS A 1 90 ? -6.671  -3.671  -7.499  1.00 0.00 ? 90 HIS A HE1  2 
+ATOM   2622 N  N    . LYS A 1 91 ? -8.848  -2.126  -2.100  1.00 0.00 ? 91 LYS A N    2 
+ATOM   2623 C  CA   . LYS A 1 91 ? -10.004 -1.453  -2.757  1.00 0.00 ? 91 LYS A CA   2 
+ATOM   2624 C  C    . LYS A 1 91 ? -10.726 -2.460  -3.653  1.00 0.00 ? 91 LYS A C    2 
+ATOM   2625 O  O    . LYS A 1 91 ? -10.612 -2.426  -4.862  1.00 0.00 ? 91 LYS A O    2 
+ATOM   2626 C  CB   . LYS A 1 91 ? -9.502  -0.280  -3.602  1.00 0.00 ? 91 LYS A CB   2 
+ATOM   2627 C  CG   . LYS A 1 91 ? -10.695 0.522   -4.124  1.00 0.00 ? 91 LYS A CG   2 
+ATOM   2628 C  CD   . LYS A 1 91 ? -10.490 2.006   -3.812  1.00 0.00 ? 91 LYS A CD   2 
+ATOM   2629 C  CE   . LYS A 1 91 ? -11.836 2.731   -3.863  1.00 0.00 ? 91 LYS A CE   2 
+ATOM   2630 N  NZ   . LYS A 1 91 ? -12.576 2.323   -5.092  1.00 0.00 ? 91 LYS A NZ   2 
+ATOM   2631 H  H    . LYS A 1 91 ? -8.693  -2.011  -1.140  1.00 0.00 ? 91 LYS A H    2 
+ATOM   2632 H  HA   . LYS A 1 91 ? -10.687 -1.088  -2.002  1.00 0.00 ? 91 LYS A HA   2 
+ATOM   2633 H  HB2  . LYS A 1 91 ? -8.876  0.360   -2.995  1.00 0.00 ? 91 LYS A HB2  2 
+ATOM   2634 H  HB3  . LYS A 1 91 ? -8.930  -0.656  -4.437  1.00 0.00 ? 91 LYS A HB3  2 
+ATOM   2635 H  HG2  . LYS A 1 91 ? -10.781 0.386   -5.192  1.00 0.00 ? 91 LYS A HG2  2 
+ATOM   2636 H  HG3  . LYS A 1 91 ? -11.598 0.177   -3.643  1.00 0.00 ? 91 LYS A HG3  2 
+ATOM   2637 H  HD2  . LYS A 1 91 ? -10.062 2.110   -2.825  1.00 0.00 ? 91 LYS A HD2  2 
+ATOM   2638 H  HD3  . LYS A 1 91 ? -9.823  2.437   -4.541  1.00 0.00 ? 91 LYS A HD3  2 
+ATOM   2639 H  HE2  . LYS A 1 91 ? -12.418 2.474   -2.991  1.00 0.00 ? 91 LYS A HE2  2 
+ATOM   2640 H  HE3  . LYS A 1 91 ? -11.669 3.798   -3.882  1.00 0.00 ? 91 LYS A HE3  2 
+ATOM   2641 H  HZ1  . LYS A 1 91 ? -11.909 2.230   -5.883  1.00 0.00 ? 91 LYS A HZ1  2 
+ATOM   2642 H  HZ2  . LYS A 1 91 ? -13.046 1.411   -4.928  1.00 0.00 ? 91 LYS A HZ2  2 
+ATOM   2643 H  HZ3  . LYS A 1 91 ? -13.289 3.046   -5.321  1.00 0.00 ? 91 LYS A HZ3  2 
+ATOM   2644 N  N    . GLU A 1 92 ? -11.468 -3.361  -3.066  1.00 0.00 ? 92 GLU A N    2 
+ATOM   2645 C  CA   . GLU A 1 92 ? -12.197 -4.377  -3.877  1.00 0.00 ? 92 GLU A CA   2 
+ATOM   2646 C  C    . GLU A 1 92 ? -13.244 -3.689  -4.753  1.00 0.00 ? 92 GLU A C    2 
+ATOM   2647 O  O    . GLU A 1 92 ? -13.846 -4.303  -5.612  1.00 0.00 ? 92 GLU A O    2 
+ATOM   2648 C  CB   . GLU A 1 92 ? -12.898 -5.366  -2.945  1.00 0.00 ? 92 GLU A CB   2 
+ATOM   2649 C  CG   . GLU A 1 92 ? -11.961 -6.536  -2.639  1.00 0.00 ? 92 GLU A CG   2 
+ATOM   2650 C  CD   . GLU A 1 92 ? -12.698 -7.856  -2.876  1.00 0.00 ? 92 GLU A CD   2 
+ATOM   2651 O  OE1  . GLU A 1 92 ? -13.451 -8.255  -2.005  1.00 0.00 ? 92 GLU A OE1  2 
+ATOM   2652 O  OE2  . GLU A 1 92 ? -12.495 -8.444  -3.926  1.00 0.00 ? 92 GLU A OE2  2 
+ATOM   2653 H  H    . GLU A 1 92 ? -11.543 -3.371  -2.089  1.00 0.00 ? 92 GLU A H    2 
+ATOM   2654 H  HA   . GLU A 1 92 ? -11.495 -4.909  -4.503  1.00 0.00 ? 92 GLU A HA   2 
+ATOM   2655 H  HB2  . GLU A 1 92 ? -13.166 -4.866  -2.024  1.00 0.00 ? 92 GLU A HB2  2 
+ATOM   2656 H  HB3  . GLU A 1 92 ? -13.791 -5.739  -3.424  1.00 0.00 ? 92 GLU A HB3  2 
+ATOM   2657 H  HG2  . GLU A 1 92 ? -11.097 -6.483  -3.286  1.00 0.00 ? 92 GLU A HG2  2 
+ATOM   2658 H  HG3  . GLU A 1 92 ? -11.643 -6.484  -1.608  1.00 0.00 ? 92 GLU A HG3  2 
+ATOM   2659 N  N    . GLU A 1 93 ? -13.479 -2.425  -4.539  1.00 0.00 ? 93 GLU A N    2 
+ATOM   2660 C  CA   . GLU A 1 93 ? -14.500 -1.714  -5.357  1.00 0.00 ? 93 GLU A CA   2 
+ATOM   2661 C  C    . GLU A 1 93 ? -15.890 -2.163  -4.908  1.00 0.00 ? 93 GLU A C    2 
+ATOM   2662 O  O    . GLU A 1 93 ? -16.877 -1.931  -5.579  1.00 0.00 ? 93 GLU A O    2 
+ATOM   2663 C  CB   . GLU A 1 93 ? -14.302 -2.059  -6.834  1.00 0.00 ? 93 GLU A CB   2 
+ATOM   2664 C  CG   . GLU A 1 93 ? -14.934 -0.968  -7.702  1.00 0.00 ? 93 GLU A CG   2 
+ATOM   2665 C  CD   . GLU A 1 93 ? -13.879 0.085   -8.044  1.00 0.00 ? 93 GLU A CD   2 
+ATOM   2666 O  OE1  . GLU A 1 93 ? -12.748 -0.296  -8.294  1.00 0.00 ? 93 GLU A OE1  2 
+ATOM   2667 O  OE2  . GLU A 1 93 ? -14.220 1.257   -8.050  1.00 0.00 ? 93 GLU A OE2  2 
+ATOM   2668 H  H    . GLU A 1 93 ? -12.992 -1.946  -3.836  1.00 0.00 ? 93 GLU A H    2 
+ATOM   2669 H  HA   . GLU A 1 93 ? -14.399 -0.648  -5.216  1.00 0.00 ? 93 GLU A HA   2 
+ATOM   2670 H  HB2  . GLU A 1 93 ? -13.245 -2.125  -7.051  1.00 0.00 ? 93 GLU A HB2  2 
+ATOM   2671 H  HB3  . GLU A 1 93 ? -14.774 -3.006  -7.050  1.00 0.00 ? 93 GLU A HB3  2 
+ATOM   2672 H  HG2  . GLU A 1 93 ? -15.315 -1.409  -8.613  1.00 0.00 ? 93 GLU A HG2  2 
+ATOM   2673 H  HG3  . GLU A 1 93 ? -15.743 -0.503  -7.160  1.00 0.00 ? 93 GLU A HG3  2 
+ATOM   2674 N  N    . ASP A 1 94 ? -15.974 -2.805  -3.774  1.00 0.00 ? 94 ASP A N    2 
+ATOM   2675 C  CA   . ASP A 1 94 ? -17.284 -3.273  -3.272  1.00 0.00 ? 94 ASP A CA   2 
+ATOM   2676 C  C    . ASP A 1 94 ? -17.384 -2.983  -1.774  1.00 0.00 ? 94 ASP A C    2 
+ATOM   2677 O  O    . ASP A 1 94 ? -18.382 -2.485  -1.292  1.00 0.00 ? 94 ASP A O    2 
+ATOM   2678 C  CB   . ASP A 1 94 ? -17.420 -4.777  -3.516  1.00 0.00 ? 94 ASP A CB   2 
+ATOM   2679 C  CG   . ASP A 1 94 ? -18.731 -5.062  -4.252  1.00 0.00 ? 94 ASP A CG   2 
+ATOM   2680 O  OD1  . ASP A 1 94 ? -18.804 -4.761  -5.432  1.00 0.00 ? 94 ASP A OD1  2 
+ATOM   2681 O  OD2  . ASP A 1 94 ? -19.640 -5.580  -3.622  1.00 0.00 ? 94 ASP A OD2  2 
+ATOM   2682 H  H    . ASP A 1 94 ? -15.173 -2.977  -3.255  1.00 0.00 ? 94 ASP A H    2 
+ATOM   2683 H  HA   . ASP A 1 94 ? -18.059 -2.751  -3.790  1.00 0.00 ? 94 ASP A HA   2 
+ATOM   2684 H  HB2  . ASP A 1 94 ? -16.588 -5.120  -4.113  1.00 0.00 ? 94 ASP A HB2  2 
+ATOM   2685 H  HB3  . ASP A 1 94 ? -17.421 -5.296  -2.569  1.00 0.00 ? 94 ASP A HB3  2 
+ATOM   2686 N  N    . LEU A 1 95 ? -16.354 -3.288  -1.037  1.00 0.00 ? 95 LEU A N    2 
+ATOM   2687 C  CA   . LEU A 1 95 ? -16.382 -3.027  0.431   1.00 0.00 ? 95 LEU A CA   2 
+ATOM   2688 C  C    . LEU A 1 95 ? -15.065 -2.373  0.856   1.00 0.00 ? 95 LEU A C    2 
+ATOM   2689 O  O    . LEU A 1 95 ? -14.524 -2.667  1.904   1.00 0.00 ? 95 LEU A O    2 
+ATOM   2690 C  CB   . LEU A 1 95 ? -16.564 -4.346  1.188   1.00 0.00 ? 95 LEU A CB   2 
+ATOM   2691 C  CG   . LEU A 1 95 ? -16.602 -4.068  2.692   1.00 0.00 ? 95 LEU A CG   2 
+ATOM   2692 C  CD1  . LEU A 1 95 ? -17.972 -4.458  3.251   1.00 0.00 ? 95 LEU A CD1  2 
+ATOM   2693 C  CD2  . LEU A 1 95 ? -15.517 -4.891  3.390   1.00 0.00 ? 95 LEU A CD2  2 
+ATOM   2694 H  H    . LEU A 1 95 ? -15.559 -3.686  -1.449  1.00 0.00 ? 95 LEU A H    2 
+ATOM   2695 H  HA   . LEU A 1 95 ? -17.203 -2.364  0.662   1.00 0.00 ? 95 LEU A HA   2 
+ATOM   2696 H  HB2  . LEU A 1 95 ? -17.490 -4.811  0.883   1.00 0.00 ? 95 LEU A HB2  2 
+ATOM   2697 H  HB3  . LEU A 1 95 ? -15.738 -5.005  0.967   1.00 0.00 ? 95 LEU A HB3  2 
+ATOM   2698 H  HG   . LEU A 1 95 ? -16.429 -3.016  2.868   1.00 0.00 ? 95 LEU A HG   2 
+ATOM   2699 H  HD11 . LEU A 1 95 ? -18.516 -5.021  2.508   1.00 0.00 ? 95 LEU A HD11 2 
+ATOM   2700 H  HD12 . LEU A 1 95 ? -17.840 -5.062  4.136   1.00 0.00 ? 95 LEU A HD12 2 
+ATOM   2701 H  HD13 . LEU A 1 95 ? -18.525 -3.565  3.503   1.00 0.00 ? 95 LEU A HD13 2 
+ATOM   2702 H  HD21 . LEU A 1 95 ? -15.036 -5.537  2.670   1.00 0.00 ? 95 LEU A HD21 2 
+ATOM   2703 H  HD22 . LEU A 1 95 ? -14.784 -4.226  3.824   1.00 0.00 ? 95 LEU A HD22 2 
+ATOM   2704 H  HD23 . LEU A 1 95 ? -15.965 -5.490  4.168   1.00 0.00 ? 95 LEU A HD23 2 
+ATOM   2705 N  N    . TYR A 1 96 ? -14.544 -1.487  0.050   1.00 0.00 ? 96 TYR A N    2 
+ATOM   2706 C  CA   . TYR A 1 96 ? -13.268 -0.816  0.402   1.00 0.00 ? 96 TYR A CA   2 
+ATOM   2707 C  C    . TYR A 1 96 ? -13.289 -0.411  1.876   1.00 0.00 ? 96 TYR A C    2 
+ATOM   2708 O  O    . TYR A 1 96 ? -14.347 -0.029  2.350   1.00 0.00 ? 96 TYR A O    2 
+ATOM   2709 C  CB   . TYR A 1 96 ? -13.106 0.428   -0.470  1.00 0.00 ? 96 TYR A CB   2 
+ATOM   2710 C  CG   . TYR A 1 96 ? -14.382 1.223   -0.450  1.00 0.00 ? 96 TYR A CG   2 
+ATOM   2711 C  CD1  . TYR A 1 96 ? -14.593 2.174   0.552   1.00 0.00 ? 96 TYR A CD1  2 
+ATOM   2712 C  CD2  . TYR A 1 96 ? -15.351 1.012   -1.433  1.00 0.00 ? 96 TYR A CD2  2 
+ATOM   2713 C  CE1  . TYR A 1 96 ? -15.777 2.916   0.572   1.00 0.00 ? 96 TYR A CE1  2 
+ATOM   2714 C  CE2  . TYR A 1 96 ? -16.536 1.751   -1.416  1.00 0.00 ? 96 TYR A CE2  2 
+ATOM   2715 C  CZ   . TYR A 1 96 ? -16.751 2.705   -0.412  1.00 0.00 ? 96 TYR A CZ   2 
+ATOM   2716 O  OH   . TYR A 1 96 ? -17.920 3.435   -0.394  1.00 0.00 ? 96 TYR A OH   2 
+ATOM   2717 O  OXT  . TYR A 1 96 ? -12.248 -0.488  2.507   1.00 0.00 ? 96 TYR A OXT  2 
+ATOM   2718 H  H    . TYR A 1 96 ? -14.991 -1.262  -0.788  1.00 0.00 ? 96 TYR A H    2 
+ATOM   2719 H  HA   . TYR A 1 96 ? -12.445 -1.489  0.222   1.00 0.00 ? 96 TYR A HA   2 
+ATOM   2720 H  HB2  . TYR A 1 96 ? -12.304 1.032   -0.089  1.00 0.00 ? 96 TYR A HB2  2 
+ATOM   2721 H  HB3  . TYR A 1 96 ? -12.888 0.133   -1.486  1.00 0.00 ? 96 TYR A HB3  2 
+ATOM   2722 H  HD1  . TYR A 1 96 ? -13.840 2.337   1.311   1.00 0.00 ? 96 TYR A HD1  2 
+ATOM   2723 H  HD2  . TYR A 1 96 ? -15.184 0.276   -2.206  1.00 0.00 ? 96 TYR A HD2  2 
+ATOM   2724 H  HE1  . TYR A 1 96 ? -15.938 3.649   1.346   1.00 0.00 ? 96 TYR A HE1  2 
+ATOM   2725 H  HE2  . TYR A 1 96 ? -17.283 1.587   -2.175  1.00 0.00 ? 96 TYR A HE2  2 
+ATOM   2726 H  HH   . TYR A 1 96 ? -18.643 2.843   -0.614  1.00 0.00 ? 96 TYR A HH   2 
+HETATM 2727 FE FE1  . FES B 2 .  ? -4.794  9.224   -1.752  1.00 0.00 ? 97 FES A FE1  2 
+HETATM 2728 FE FE2  . FES B 2 .  ? -2.899  7.776   -1.257  1.00 0.00 ? 97 FES A FE2  2 
+ATOM   2729 N  N    . ALA A 1 1  ? 12.843  -9.022  -7.588  1.00 0.00 ? 1  ALA A N    3 
+ATOM   2730 C  CA   . ALA A 1 1  ? 11.535  -9.676  -7.875  1.00 0.00 ? 1  ALA A CA   3 
+ATOM   2731 C  C    . ALA A 1 1  ? 10.399  -8.787  -7.364  1.00 0.00 ? 1  ALA A C    3 
+ATOM   2732 O  O    . ALA A 1 1  ? 9.541   -9.224  -6.624  1.00 0.00 ? 1  ALA A O    3 
+ATOM   2733 C  CB   . ALA A 1 1  ? 11.477  -11.033 -7.170  1.00 0.00 ? 1  ALA A CB   3 
+ATOM   2734 H  H1   . ALA A 1 1  ? 12.684  -8.037  -7.297  1.00 0.00 ? 1  ALA A H1   3 
+ATOM   2735 H  H2   . ALA A 1 1  ? 13.326  -9.534  -6.823  1.00 0.00 ? 1  ALA A H2   3 
+ATOM   2736 H  H3   . ALA A 1 1  ? 13.434  -9.041  -8.446  1.00 0.00 ? 1  ALA A H3   3 
+ATOM   2737 H  HA   . ALA A 1 1  ? 11.429  -9.818  -8.939  1.00 0.00 ? 1  ALA A HA   3 
+ATOM   2738 H  HB1  . ALA A 1 1  ? 12.481  -11.396 -7.004  1.00 0.00 ? 1  ALA A HB1  3 
+ATOM   2739 H  HB2  . ALA A 1 1  ? 10.972  -10.926 -6.222  1.00 0.00 ? 1  ALA A HB2  3 
+ATOM   2740 H  HB3  . ALA A 1 1  ? 10.938  -11.736 -7.788  1.00 0.00 ? 1  ALA A HB3  3 
+ATOM   2741 N  N    . SER A 1 2  ? 10.387  -7.541  -7.754  1.00 0.00 ? 2  SER A N    3 
+ATOM   2742 C  CA   . SER A 1 2  ? 9.307   -6.626  -7.293  1.00 0.00 ? 2  SER A CA   3 
+ATOM   2743 C  C    . SER A 1 2  ? 7.947   -7.253  -7.604  1.00 0.00 ? 2  SER A C    3 
+ATOM   2744 O  O    . SER A 1 2  ? 7.852   -8.209  -8.347  1.00 0.00 ? 2  SER A O    3 
+ATOM   2745 C  CB   . SER A 1 2  ? 9.432   -5.288  -8.024  1.00 0.00 ? 2  SER A CB   3 
+ATOM   2746 O  OG   . SER A 1 2  ? 10.086  -5.492  -9.269  1.00 0.00 ? 2  SER A OG   3 
+ATOM   2747 H  H    . SER A 1 2  ? 11.087  -7.209  -8.352  1.00 0.00 ? 2  SER A H    3 
+ATOM   2748 H  HA   . SER A 1 2  ? 9.398   -6.467  -6.229  1.00 0.00 ? 2  SER A HA   3 
+ATOM   2749 H  HB2  . SER A 1 2  ? 8.452   -4.881  -8.202  1.00 0.00 ? 2  SER A HB2  3 
+ATOM   2750 H  HB3  . SER A 1 2  ? 10.001  -4.599  -7.414  1.00 0.00 ? 2  SER A HB3  3 
+ATOM   2751 H  HG   . SER A 1 2  ? 10.624  -4.718  -9.453  1.00 0.00 ? 2  SER A HG   3 
+ATOM   2752 N  N    . TYR A 1 3  ? 6.893   -6.728  -7.042  1.00 0.00 ? 3  TYR A N    3 
+ATOM   2753 C  CA   . TYR A 1 3  ? 5.547   -7.297  -7.307  1.00 0.00 ? 3  TYR A CA   3 
+ATOM   2754 C  C    . TYR A 1 3  ? 5.556   -8.818  -7.115  1.00 0.00 ? 3  TYR A C    3 
+ATOM   2755 O  O    . TYR A 1 3  ? 5.688   -9.574  -8.057  1.00 0.00 ? 3  TYR A O    3 
+ATOM   2756 C  CB   . TYR A 1 3  ? 5.098   -6.948  -8.721  1.00 0.00 ? 3  TYR A CB   3 
+ATOM   2757 C  CG   . TYR A 1 3  ? 6.119   -6.062  -9.388  1.00 0.00 ? 3  TYR A CG   3 
+ATOM   2758 C  CD1  . TYR A 1 3  ? 6.099   -4.683  -9.159  1.00 0.00 ? 3  TYR A CD1  3 
+ATOM   2759 C  CD2  . TYR A 1 3  ? 7.084   -6.623  -10.227 1.00 0.00 ? 3  TYR A CD2  3 
+ATOM   2760 C  CE1  . TYR A 1 3  ? 7.047   -3.860  -9.778  1.00 0.00 ? 3  TYR A CE1  3 
+ATOM   2761 C  CE2  . TYR A 1 3  ? 8.033   -5.802  -10.846 1.00 0.00 ? 3  TYR A CE2  3 
+ATOM   2762 C  CZ   . TYR A 1 3  ? 8.015   -4.420  -10.622 1.00 0.00 ? 3  TYR A CZ   3 
+ATOM   2763 O  OH   . TYR A 1 3  ? 8.950   -3.609  -11.235 1.00 0.00 ? 3  TYR A OH   3 
+ATOM   2764 H  H    . TYR A 1 3  ? 6.979   -5.954  -6.439  1.00 0.00 ? 3  TYR A H    3 
+ATOM   2765 H  HA   . TYR A 1 3  ? 4.855   -6.866  -6.610  1.00 0.00 ? 3  TYR A HA   3 
+ATOM   2766 H  HB2  . TYR A 1 3  ? 4.975   -7.854  -9.293  1.00 0.00 ? 3  TYR A HB2  3 
+ATOM   2767 H  HB3  . TYR A 1 3  ? 4.158   -6.425  -8.665  1.00 0.00 ? 3  TYR A HB3  3 
+ATOM   2768 H  HD1  . TYR A 1 3  ? 5.352   -4.256  -8.503  1.00 0.00 ? 3  TYR A HD1  3 
+ATOM   2769 H  HD2  . TYR A 1 3  ? 7.098   -7.690  -10.392 1.00 0.00 ? 3  TYR A HD2  3 
+ATOM   2770 H  HE1  . TYR A 1 3  ? 7.034   -2.794  -9.603  1.00 0.00 ? 3  TYR A HE1  3 
+ATOM   2771 H  HE2  . TYR A 1 3  ? 8.779   -6.235  -11.497 1.00 0.00 ? 3  TYR A HE2  3 
+ATOM   2772 H  HH   . TYR A 1 3  ? 8.942   -2.759  -10.790 1.00 0.00 ? 3  TYR A HH   3 
+ATOM   2773 N  N    . THR A 1 4  ? 5.394   -9.268  -5.894  1.00 0.00 ? 4  THR A N    3 
+ATOM   2774 C  CA   . THR A 1 4  ? 5.365   -10.706 -5.612  1.00 0.00 ? 4  THR A CA   3 
+ATOM   2775 C  C    . THR A 1 4  ? 4.829   -10.906 -4.191  1.00 0.00 ? 4  THR A C    3 
+ATOM   2776 O  O    . THR A 1 4  ? 4.116   -11.834 -3.935  1.00 0.00 ? 4  THR A O    3 
+ATOM   2777 C  CB   . THR A 1 4  ? 6.773   -11.300 -5.739  1.00 0.00 ? 4  THR A CB   3 
+ATOM   2778 O  OG1  . THR A 1 4  ? 6.735   -12.682 -5.409  1.00 0.00 ? 4  THR A OG1  3 
+ATOM   2779 C  CG2  . THR A 1 4  ? 7.733   -10.575 -4.796  1.00 0.00 ? 4  THR A CG2  3 
+ATOM   2780 H  H    . THR A 1 4  ? 5.274   -8.660  -5.161  1.00 0.00 ? 4  THR A H    3 
+ATOM   2781 H  HA   . THR A 1 4  ? 4.707   -11.188 -6.311  1.00 0.00 ? 4  THR A HA   3 
+ATOM   2782 H  HB   . THR A 1 4  ? 7.120   -11.184 -6.754  1.00 0.00 ? 4  THR A HB   3 
+ATOM   2783 H  HG1  . THR A 1 4  ? 6.300   -12.772 -4.559  1.00 0.00 ? 4  THR A HG1  3 
+ATOM   2784 H  HG21 . THR A 1 4  ? 7.244   -10.397 -3.850  1.00 0.00 ? 4  THR A HG21 3 
+ATOM   2785 H  HG22 . THR A 1 4  ? 8.611   -11.184 -4.638  1.00 0.00 ? 4  THR A HG22 3 
+ATOM   2786 H  HG23 . THR A 1 4  ? 8.022   -9.633  -5.234  1.00 0.00 ? 4  THR A HG23 3 
+ATOM   2787 N  N    . VAL A 1 5  ? 5.157   -10.038 -3.261  1.00 0.00 ? 5  VAL A N    3 
+ATOM   2788 C  CA   . VAL A 1 5  ? 4.650   -10.226 -1.860  1.00 0.00 ? 5  VAL A CA   3 
+ATOM   2789 C  C    . VAL A 1 5  ? 3.141   -10.526 -1.849  1.00 0.00 ? 5  VAL A C    3 
+ATOM   2790 O  O    . VAL A 1 5  ? 2.539   -10.830 -2.849  1.00 0.00 ? 5  VAL A O    3 
+ATOM   2791 C  CB   . VAL A 1 5  ? 4.985   -9.006  -0.992  1.00 0.00 ? 5  VAL A CB   3 
+ATOM   2792 C  CG1  . VAL A 1 5  ? 3.756   -8.124  -0.794  1.00 0.00 ? 5  VAL A CG1  3 
+ATOM   2793 C  CG2  . VAL A 1 5  ? 5.486   -9.486  0.368   1.00 0.00 ? 5  VAL A CG2  3 
+ATOM   2794 H  H    . VAL A 1 5  ? 5.733   -9.273  -3.479  1.00 0.00 ? 5  VAL A H    3 
+ATOM   2795 H  HA   . VAL A 1 5  ? 5.150   -11.069 -1.439  1.00 0.00 ? 5  VAL A HA   3 
+ATOM   2796 H  HB   . VAL A 1 5  ? 5.764   -8.443  -1.466  1.00 0.00 ? 5  VAL A HB   3 
+ATOM   2797 H  HG11 . VAL A 1 5  ? 3.133   -8.185  -1.674  1.00 0.00 ? 5  VAL A HG11 3 
+ATOM   2798 H  HG12 . VAL A 1 5  ? 3.206   -8.466  0.063   1.00 0.00 ? 5  VAL A HG12 3 
+ATOM   2799 H  HG13 . VAL A 1 5  ? 4.068   -7.105  -0.639  1.00 0.00 ? 5  VAL A HG13 3 
+ATOM   2800 H  HG21 . VAL A 1 5  ? 6.233   -10.253 0.226   1.00 0.00 ? 5  VAL A HG21 3 
+ATOM   2801 H  HG22 . VAL A 1 5  ? 5.921   -8.655  0.904   1.00 0.00 ? 5  VAL A HG22 3 
+ATOM   2802 H  HG23 . VAL A 1 5  ? 4.659   -9.886  0.935   1.00 0.00 ? 5  VAL A HG23 3 
+ATOM   2803 N  N    . LYS A 1 6  ? 2.524   -10.459 -0.712  1.00 0.00 ? 6  LYS A N    3 
+ATOM   2804 C  CA   . LYS A 1 6  ? 1.063   -10.773 -0.660  1.00 0.00 ? 6  LYS A CA   3 
+ATOM   2805 C  C    . LYS A 1 6  ? 0.255   -9.514  -0.366  1.00 0.00 ? 6  LYS A C    3 
+ATOM   2806 O  O    . LYS A 1 6  ? 0.455   -8.869  0.636   1.00 0.00 ? 6  LYS A O    3 
+ATOM   2807 C  CB   . LYS A 1 6  ? 0.807   -11.803 0.442   1.00 0.00 ? 6  LYS A CB   3 
+ATOM   2808 C  CG   . LYS A 1 6  ? 1.851   -12.918 0.352   1.00 0.00 ? 6  LYS A CG   3 
+ATOM   2809 C  CD   . LYS A 1 6  ? 1.440   -13.917 -0.732  1.00 0.00 ? 6  LYS A CD   3 
+ATOM   2810 C  CE   . LYS A 1 6  ? 2.085   -15.275 -0.448  1.00 0.00 ? 6  LYS A CE   3 
+ATOM   2811 N  NZ   . LYS A 1 6  ? 1.409   -15.909 0.719   1.00 0.00 ? 6  LYS A NZ   3 
+ATOM   2812 H  H    . LYS A 1 6  ? 3.020   -10.211 0.102   1.00 0.00 ? 6  LYS A H    3 
+ATOM   2813 H  HA   . LYS A 1 6  ? 0.752   -11.183 -1.609  1.00 0.00 ? 6  LYS A HA   3 
+ATOM   2814 H  HB2  . LYS A 1 6  ? 0.875   -11.322 1.407   1.00 0.00 ? 6  LYS A HB2  3 
+ATOM   2815 H  HB3  . LYS A 1 6  ? -0.179  -12.226 0.318   1.00 0.00 ? 6  LYS A HB3  3 
+ATOM   2816 H  HG2  . LYS A 1 6  ? 2.811   -12.491 0.104   1.00 0.00 ? 6  LYS A HG2  3 
+ATOM   2817 H  HG3  . LYS A 1 6  ? 1.917   -13.427 1.302   1.00 0.00 ? 6  LYS A HG3  3 
+ATOM   2818 H  HD2  . LYS A 1 6  ? 0.364   -14.022 -0.736  1.00 0.00 ? 6  LYS A HD2  3 
+ATOM   2819 H  HD3  . LYS A 1 6  ? 1.769   -13.560 -1.696  1.00 0.00 ? 6  LYS A HD3  3 
+ATOM   2820 H  HE2  . LYS A 1 6  ? 1.979   -15.913 -1.314  1.00 0.00 ? 6  LYS A HE2  3 
+ATOM   2821 H  HE3  . LYS A 1 6  ? 3.132   -15.138 -0.226  1.00 0.00 ? 6  LYS A HE3  3 
+ATOM   2822 H  HZ1  . LYS A 1 6  ? 0.547   -15.376 0.952   1.00 0.00 ? 6  LYS A HZ1  3 
+ATOM   2823 H  HZ2  . LYS A 1 6  ? 1.158   -16.891 0.483   1.00 0.00 ? 6  LYS A HZ2  3 
+ATOM   2824 H  HZ3  . LYS A 1 6  ? 2.050   -15.900 1.537   1.00 0.00 ? 6  LYS A HZ3  3 
+ATOM   2825 N  N    . LEU A 1 7  ? -0.667  -9.159  -1.223  1.00 0.00 ? 7  LEU A N    3 
+ATOM   2826 C  CA   . LEU A 1 7  ? -1.479  -7.936  -0.948  1.00 0.00 ? 7  LEU A CA   3 
+ATOM   2827 C  C    . LEU A 1 7  ? -2.960  -8.278  -0.823  1.00 0.00 ? 7  LEU A C    3 
+ATOM   2828 O  O    . LEU A 1 7  ? -3.351  -9.427  -0.760  1.00 0.00 ? 7  LEU A O    3 
+ATOM   2829 C  CB   . LEU A 1 7  ? -1.330  -6.922  -2.072  1.00 0.00 ? 7  LEU A CB   3 
+ATOM   2830 C  CG   . LEU A 1 7  ? -0.942  -5.573  -1.484  1.00 0.00 ? 7  LEU A CG   3 
+ATOM   2831 C  CD1  . LEU A 1 7  ? 0.300   -5.741  -0.611  1.00 0.00 ? 7  LEU A CD1  3 
+ATOM   2832 C  CD2  . LEU A 1 7  ? -0.654  -4.599  -2.624  1.00 0.00 ? 7  LEU A CD2  3 
+ATOM   2833 H  H    . LEU A 1 7  ? -0.825  -9.694  -2.034  1.00 0.00 ? 7  LEU A H    3 
+ATOM   2834 H  HA   . LEU A 1 7  ? -1.141  -7.490  -0.025  1.00 0.00 ? 7  LEU A HA   3 
+ATOM   2835 H  HB2  . LEU A 1 7  ? -0.574  -7.253  -2.767  1.00 0.00 ? 7  LEU A HB2  3 
+ATOM   2836 H  HB3  . LEU A 1 7  ? -2.273  -6.820  -2.580  1.00 0.00 ? 7  LEU A HB3  3 
+ATOM   2837 H  HG   . LEU A 1 7  ? -1.756  -5.195  -0.883  1.00 0.00 ? 7  LEU A HG   3 
+ATOM   2838 H  HD11 . LEU A 1 7  ? 0.569   -6.786  -0.568  1.00 0.00 ? 7  LEU A HD11 3 
+ATOM   2839 H  HD12 . LEU A 1 7  ? 1.117   -5.177  -1.033  1.00 0.00 ? 7  LEU A HD12 3 
+ATOM   2840 H  HD13 . LEU A 1 7  ? 0.090   -5.383  0.386   1.00 0.00 ? 7  LEU A HD13 3 
+ATOM   2841 H  HD21 . LEU A 1 7  ? -0.928  -5.057  -3.563  1.00 0.00 ? 7  LEU A HD21 3 
+ATOM   2842 H  HD22 . LEU A 1 7  ? -1.237  -3.701  -2.483  1.00 0.00 ? 7  LEU A HD22 3 
+ATOM   2843 H  HD23 . LEU A 1 7  ? 0.395   -4.354  -2.634  1.00 0.00 ? 7  LEU A HD23 3 
+ATOM   2844 N  N    . ILE A 1 8  ? -3.777  -7.261  -0.794  1.00 0.00 ? 8  ILE A N    3 
+ATOM   2845 C  CA   . ILE A 1 8  ? -5.249  -7.460  -0.664  1.00 0.00 ? 8  ILE A CA   3 
+ATOM   2846 C  C    . ILE A 1 8  ? -5.541  -8.308  0.578   1.00 0.00 ? 8  ILE A C    3 
+ATOM   2847 O  O    . ILE A 1 8  ? -4.948  -8.103  1.620   1.00 0.00 ? 8  ILE A O    3 
+ATOM   2848 C  CB   . ILE A 1 8  ? -5.802  -8.146  -1.909  1.00 0.00 ? 8  ILE A CB   3 
+ATOM   2849 C  CG1  . ILE A 1 8  ? -5.011  -7.698  -3.139  1.00 0.00 ? 8  ILE A CG1  3 
+ATOM   2850 C  CG2  . ILE A 1 8  ? -7.273  -7.770  -2.081  1.00 0.00 ? 8  ILE A CG2  3 
+ATOM   2851 C  CD1  . ILE A 1 8  ? -4.851  -6.176  -3.124  1.00 0.00 ? 8  ILE A CD1  3 
+ATOM   2852 H  H    . ILE A 1 8  ? -3.410  -6.351  -0.856  1.00 0.00 ? 8  ILE A H    3 
+ATOM   2853 H  HA   . ILE A 1 8  ? -5.724  -6.497  -0.551  1.00 0.00 ? 8  ILE A HA   3 
+ATOM   2854 H  HB   . ILE A 1 8  ? -5.716  -9.210  -1.792  1.00 0.00 ? 8  ILE A HB   3 
+ATOM   2855 H  HG12 . ILE A 1 8  ? -4.038  -8.163  -3.128  1.00 0.00 ? 8  ILE A HG12 3 
+ATOM   2856 H  HG13 . ILE A 1 8  ? -5.542  -7.993  -4.032  1.00 0.00 ? 8  ILE A HG13 3 
+ATOM   2857 H  HG21 . ILE A 1 8  ? -7.476  -6.855  -1.543  1.00 0.00 ? 8  ILE A HG21 3 
+ATOM   2858 H  HG22 . ILE A 1 8  ? -7.490  -7.626  -3.129  1.00 0.00 ? 8  ILE A HG22 3 
+ATOM   2859 H  HG23 . ILE A 1 8  ? -7.895  -8.559  -1.692  1.00 0.00 ? 8  ILE A HG23 3 
+ATOM   2860 H  HD11 . ILE A 1 8  ? -5.707  -5.728  -2.640  1.00 0.00 ? 8  ILE A HD11 3 
+ATOM   2861 H  HD12 . ILE A 1 8  ? -3.954  -5.913  -2.584  1.00 0.00 ? 8  ILE A HD12 3 
+ATOM   2862 H  HD13 . ILE A 1 8  ? -4.779  -5.811  -4.138  1.00 0.00 ? 8  ILE A HD13 3 
+ATOM   2863 N  N    . THR A 1 9  ? -6.468  -9.234  0.505   1.00 0.00 ? 9  THR A N    3 
+ATOM   2864 C  CA   . THR A 1 9  ? -6.786  -10.036 1.709   1.00 0.00 ? 9  THR A CA   3 
+ATOM   2865 C  C    . THR A 1 9  ? -7.243  -11.431 1.274   1.00 0.00 ? 9  THR A C    3 
+ATOM   2866 O  O    . THR A 1 9  ? -7.193  -11.737 0.094   1.00 0.00 ? 9  THR A O    3 
+ATOM   2867 C  CB   . THR A 1 9  ? -7.906  -9.324  2.460   1.00 0.00 ? 9  THR A CB   3 
+ATOM   2868 O  OG1  . THR A 1 9  ? -9.139  -9.979  2.226   1.00 0.00 ? 9  THR A OG1  3 
+ATOM   2869 C  CG2  . THR A 1 9  ? -8.021  -7.861  2.015   1.00 0.00 ? 9  THR A CG2  3 
+ATOM   2870 H  H    . THR A 1 9  ? -6.979  -9.380  -0.321  1.00 0.00 ? 9  THR A H    3 
+ATOM   2871 H  HA   . THR A 1 9  ? -5.914  -10.115 2.340   1.00 0.00 ? 9  THR A HA   3 
+ATOM   2872 H  HB   . THR A 1 9  ? -7.678  -9.356  3.494   1.00 0.00 ? 9  THR A HB   3 
+ATOM   2873 H  HG1  . THR A 1 9  ? -9.422  -9.768  1.333   1.00 0.00 ? 9  THR A HG1  3 
+ATOM   2874 H  HG21 . THR A 1 9  ? -8.071  -7.816  0.936   1.00 0.00 ? 9  THR A HG21 3 
+ATOM   2875 H  HG22 . THR A 1 9  ? -8.918  -7.429  2.432   1.00 0.00 ? 9  THR A HG22 3 
+ATOM   2876 H  HG23 . THR A 1 9  ? -7.160  -7.309  2.359   1.00 0.00 ? 9  THR A HG23 3 
+ATOM   2877 N  N    . PRO A 1 10 ? -7.716  -12.254 2.207   1.00 0.00 ? 10 PRO A N    3 
+ATOM   2878 C  CA   . PRO A 1 10 ? -8.197  -13.581 1.846   1.00 0.00 ? 10 PRO A CA   3 
+ATOM   2879 C  C    . PRO A 1 10 ? -9.006  -13.441 0.564   1.00 0.00 ? 10 PRO A C    3 
+ATOM   2880 O  O    . PRO A 1 10 ? -9.033  -14.308 -0.286  1.00 0.00 ? 10 PRO A O    3 
+ATOM   2881 C  CB   . PRO A 1 10 ? -9.037  -14.036 3.041   1.00 0.00 ? 10 PRO A CB   3 
+ATOM   2882 C  CG   . PRO A 1 10 ? -8.704  -13.081 4.210   1.00 0.00 ? 10 PRO A CG   3 
+ATOM   2883 C  CD   . PRO A 1 10 ? -7.819  -11.956 3.646   1.00 0.00 ? 10 PRO A CD   3 
+ATOM   2884 H  HA   . PRO A 1 10 ? -7.362  -14.229 1.712   1.00 0.00 ? 10 PRO A HA   3 
+ATOM   2885 H  HB2  . PRO A 1 10 ? -10.088 -13.976 2.796   1.00 0.00 ? 10 PRO A HB2  3 
+ATOM   2886 H  HB3  . PRO A 1 10 ? -8.773  -15.042 3.313   1.00 0.00 ? 10 PRO A HB3  3 
+ATOM   2887 H  HG2  . PRO A 1 10 ? -9.616  -12.665 4.615   1.00 0.00 ? 10 PRO A HG2  3 
+ATOM   2888 H  HG3  . PRO A 1 10 ? -8.167  -13.614 4.979   1.00 0.00 ? 10 PRO A HG3  3 
+ATOM   2889 H  HD2  . PRO A 1 10 ? -8.292  -11.017 3.813   1.00 0.00 ? 10 PRO A HD2  3 
+ATOM   2890 H  HD3  . PRO A 1 10 ? -6.843  -11.987 4.099   1.00 0.00 ? 10 PRO A HD3  3 
+ATOM   2891 N  N    . ASP A 1 11 ? -9.586  -12.287 0.402   1.00 0.00 ? 11 ASP A N    3 
+ATOM   2892 C  CA   . ASP A 1 11 ? -10.316 -11.969 -0.830  1.00 0.00 ? 11 ASP A CA   3 
+ATOM   2893 C  C    . ASP A 1 11 ? -9.358  -11.115 -1.664  1.00 0.00 ? 11 ASP A C    3 
+ATOM   2894 O  O    . ASP A 1 11 ? -9.458  -9.905  -1.720  1.00 0.00 ? 11 ASP A O    3 
+ATOM   2895 C  CB   . ASP A 1 11 ? -11.583 -11.176 -0.503  1.00 0.00 ? 11 ASP A CB   3 
+ATOM   2896 C  CG   . ASP A 1 11 ? -12.510 -11.169 -1.719  1.00 0.00 ? 11 ASP A CG   3 
+ATOM   2897 O  OD1  . ASP A 1 11 ? -12.032 -11.454 -2.806  1.00 0.00 ? 11 ASP A OD1  3 
+ATOM   2898 O  OD2  . ASP A 1 11 ? -13.682 -10.878 -1.545  1.00 0.00 ? 11 ASP A OD2  3 
+ATOM   2899 H  H    . ASP A 1 11 ? -9.485  -11.599 1.080   1.00 0.00 ? 11 ASP A H    3 
+ATOM   2900 H  HA   . ASP A 1 11 ? -10.564 -12.877 -1.362  1.00 0.00 ? 11 ASP A HA   3 
+ATOM   2901 H  HB2  . ASP A 1 11 ? -12.088 -11.637 0.334   1.00 0.00 ? 11 ASP A HB2  3 
+ATOM   2902 H  HB3  . ASP A 1 11 ? -11.317 -10.161 -0.249  1.00 0.00 ? 11 ASP A HB3  3 
+ATOM   2903 N  N    . GLY A 1 12 ? -8.390  -11.737 -2.264  1.00 0.00 ? 12 GLY A N    3 
+ATOM   2904 C  CA   . GLY A 1 12 ? -7.410  -10.984 -3.064  1.00 0.00 ? 12 GLY A CA   3 
+ATOM   2905 C  C    . GLY A 1 12 ? -5.984  -11.331 -2.633  1.00 0.00 ? 12 GLY A C    3 
+ATOM   2906 O  O    . GLY A 1 12 ? -5.620  -11.218 -1.480  1.00 0.00 ? 12 GLY A O    3 
+ATOM   2907 H  H    . GLY A 1 12 ? -8.293  -12.690 -2.162  1.00 0.00 ? 12 GLY A H    3 
+ATOM   2908 H  HA2  . GLY A 1 12 ? -7.540  -11.226 -4.110  1.00 0.00 ? 12 GLY A HA2  3 
+ATOM   2909 H  HA3  . GLY A 1 12 ? -7.579  -9.937  -2.916  1.00 0.00 ? 12 GLY A HA3  3 
+ATOM   2910 N  N    . GLU A 1 13 ? -5.169  -11.724 -3.564  1.00 0.00 ? 13 GLU A N    3 
+ATOM   2911 C  CA   . GLU A 1 13 ? -3.754  -12.048 -3.245  1.00 0.00 ? 13 GLU A CA   3 
+ATOM   2912 C  C    . GLU A 1 13 ? -2.896  -11.367 -4.303  1.00 0.00 ? 13 GLU A C    3 
+ATOM   2913 O  O    . GLU A 1 13 ? -2.539  -11.960 -5.302  1.00 0.00 ? 13 GLU A O    3 
+ATOM   2914 C  CB   . GLU A 1 13 ? -3.544  -13.562 -3.293  1.00 0.00 ? 13 GLU A CB   3 
+ATOM   2915 C  CG   . GLU A 1 13 ? -3.406  -14.106 -1.868  1.00 0.00 ? 13 GLU A CG   3 
+ATOM   2916 C  CD   . GLU A 1 13 ? -1.936  -14.076 -1.446  1.00 0.00 ? 13 GLU A CD   3 
+ATOM   2917 O  OE1  . GLU A 1 13 ? -1.129  -13.580 -2.214  1.00 0.00 ? 13 GLU A OE1  3 
+ATOM   2918 O  OE2  . GLU A 1 13 ? -1.643  -14.552 -0.362  1.00 0.00 ? 13 GLU A OE2  3 
+ATOM   2919 H  H    . GLU A 1 13 ? -5.482  -11.786 -4.489  1.00 0.00 ? 13 GLU A H    3 
+ATOM   2920 H  HA   . GLU A 1 13 ? -3.501  -11.668 -2.265  1.00 0.00 ? 13 GLU A HA   3 
+ATOM   2921 H  HB2  . GLU A 1 13 ? -4.392  -14.028 -3.775  1.00 0.00 ? 13 GLU A HB2  3 
+ATOM   2922 H  HB3  . GLU A 1 13 ? -2.647  -13.784 -3.850  1.00 0.00 ? 13 GLU A HB3  3 
+ATOM   2923 H  HG2  . GLU A 1 13 ? -3.988  -13.495 -1.193  1.00 0.00 ? 13 GLU A HG2  3 
+ATOM   2924 H  HG3  . GLU A 1 13 ? -3.767  -15.124 -1.836  1.00 0.00 ? 13 GLU A HG3  3 
+ATOM   2925 N  N    . SER A 1 14 ? -2.596  -10.108 -4.121  1.00 0.00 ? 14 SER A N    3 
+ATOM   2926 C  CA   . SER A 1 14 ? -1.803  -9.390  -5.156  1.00 0.00 ? 14 SER A CA   3 
+ATOM   2927 C  C    . SER A 1 14 ? -0.305  -9.540  -4.887  1.00 0.00 ? 14 SER A C    3 
+ATOM   2928 O  O    . SER A 1 14 ? 0.174   -9.264  -3.807  1.00 0.00 ? 14 SER A O    3 
+ATOM   2929 C  CB   . SER A 1 14 ? -2.201  -7.913  -5.143  1.00 0.00 ? 14 SER A CB   3 
+ATOM   2930 O  OG   . SER A 1 14 ? -1.271  -7.161  -5.909  1.00 0.00 ? 14 SER A OG   3 
+ATOM   2931 H  H    . SER A 1 14 ? -2.917  -9.626  -3.317  1.00 0.00 ? 14 SER A H    3 
+ATOM   2932 H  HA   . SER A 1 14 ? -2.030  -9.808  -6.127  1.00 0.00 ? 14 SER A HA   3 
+ATOM   2933 H  HB2  . SER A 1 14 ? -3.182  -7.802  -5.573  1.00 0.00 ? 14 SER A HB2  3 
+ATOM   2934 H  HB3  . SER A 1 14 ? -2.220  -7.557  -4.122  1.00 0.00 ? 14 SER A HB3  3 
+ATOM   2935 H  HG   . SER A 1 14 ? -1.120  -7.628  -6.735  1.00 0.00 ? 14 SER A HG   3 
+ATOM   2936 N  N    . SER A 1 15 ? 0.438   -9.967  -5.874  1.00 0.00 ? 15 SER A N    3 
+ATOM   2937 C  CA   . SER A 1 15 ? 1.910   -10.130 -5.695  1.00 0.00 ? 15 SER A CA   3 
+ATOM   2938 C  C    . SER A 1 15 ? 2.555   -8.742  -5.639  1.00 0.00 ? 15 SER A C    3 
+ATOM   2939 O  O    . SER A 1 15 ? 2.390   -7.943  -6.539  1.00 0.00 ? 15 SER A O    3 
+ATOM   2940 C  CB   . SER A 1 15 ? 2.463   -10.931 -6.867  1.00 0.00 ? 15 SER A CB   3 
+ATOM   2941 O  OG   . SER A 1 15 ? 3.406   -10.145 -7.587  1.00 0.00 ? 15 SER A OG   3 
+ATOM   2942 H  H    . SER A 1 15 ? 0.026   -10.177 -6.738  1.00 0.00 ? 15 SER A H    3 
+ATOM   2943 H  HA   . SER A 1 15 ? 2.102   -10.655 -4.779  1.00 0.00 ? 15 SER A HA   3 
+ATOM   2944 H  HB2  . SER A 1 15 ? 2.948   -11.817 -6.495  1.00 0.00 ? 15 SER A HB2  3 
+ATOM   2945 H  HB3  . SER A 1 15 ? 1.646   -11.217 -7.516  1.00 0.00 ? 15 SER A HB3  3 
+ATOM   2946 H  HG   . SER A 1 15 ? 3.725   -10.668 -8.326  1.00 0.00 ? 15 SER A HG   3 
+ATOM   2947 N  N    . ILE A 1 16 ? 3.237   -8.414  -4.570  1.00 0.00 ? 16 ILE A N    3 
+ATOM   2948 C  CA   . ILE A 1 16 ? 3.811   -7.039  -4.472  1.00 0.00 ? 16 ILE A CA   3 
+ATOM   2949 C  C    . ILE A 1 16 ? 5.306   -7.025  -4.076  1.00 0.00 ? 16 ILE A C    3 
+ATOM   2950 O  O    . ILE A 1 16 ? 6.169   -7.075  -4.903  1.00 0.00 ? 16 ILE A O    3 
+ATOM   2951 C  CB   . ILE A 1 16 ? 3.013   -6.270  -3.456  1.00 0.00 ? 16 ILE A CB   3 
+ATOM   2952 C  CG1  . ILE A 1 16 ? 1.585   -6.782  -3.484  1.00 0.00 ? 16 ILE A CG1  3 
+ATOM   2953 C  CG2  . ILE A 1 16 ? 3.036   -4.784  -3.801  1.00 0.00 ? 16 ILE A CG2  3 
+ATOM   2954 C  CD1  . ILE A 1 16 ? 0.996   -6.542  -4.873  1.00 0.00 ? 16 ILE A CD1  3 
+ATOM   2955 H  H    . ILE A 1 16 ? 3.319   -9.036  -3.832  1.00 0.00 ? 16 ILE A H    3 
+ATOM   2956 H  HA   . ILE A 1 16 ? 3.688   -6.566  -5.413  1.00 0.00 ? 16 ILE A HA   3 
+ATOM   2957 H  HB   . ILE A 1 16 ? 3.436   -6.426  -2.495  1.00 0.00 ? 16 ILE A HB   3 
+ATOM   2958 H  HG12 . ILE A 1 16 ? 1.585   -7.839  -3.270  1.00 0.00 ? 16 ILE A HG12 3 
+ATOM   2959 H  HG13 . ILE A 1 16 ? 1.007   -6.270  -2.753  1.00 0.00 ? 16 ILE A HG13 3 
+ATOM   2960 H  HG21 . ILE A 1 16 ? 2.670   -4.644  -4.806  1.00 0.00 ? 16 ILE A HG21 3 
+ATOM   2961 H  HG22 . ILE A 1 16 ? 2.407   -4.246  -3.108  1.00 0.00 ? 16 ILE A HG22 3 
+ATOM   2962 H  HG23 . ILE A 1 16 ? 4.049   -4.416  -3.730  1.00 0.00 ? 16 ILE A HG23 3 
+ATOM   2963 H  HD11 . ILE A 1 16 ? 1.753   -6.114  -5.513  1.00 0.00 ? 16 ILE A HD11 3 
+ATOM   2964 H  HD12 . ILE A 1 16 ? 0.666   -7.480  -5.287  1.00 0.00 ? 16 ILE A HD12 3 
+ATOM   2965 H  HD13 . ILE A 1 16 ? 0.161   -5.867  -4.800  1.00 0.00 ? 16 ILE A HD13 3 
+ATOM   2966 N  N    . GLU A 1 17 ? 5.648   -6.922  -2.841  1.00 0.00 ? 17 GLU A N    3 
+ATOM   2967 C  CA   . GLU A 1 17 ? 7.092   -6.877  -2.516  1.00 0.00 ? 17 GLU A CA   3 
+ATOM   2968 C  C    . GLU A 1 17 ? 7.671   -5.644  -3.199  1.00 0.00 ? 17 GLU A C    3 
+ATOM   2969 O  O    . GLU A 1 17 ? 8.871   -5.502  -3.324  1.00 0.00 ? 17 GLU A O    3 
+ATOM   2970 C  CB   . GLU A 1 17 ? 7.796   -8.140  -3.020  1.00 0.00 ? 17 GLU A CB   3 
+ATOM   2971 C  CG   . GLU A 1 17 ? 9.264   -8.113  -2.587  1.00 0.00 ? 17 GLU A CG   3 
+ATOM   2972 C  CD   . GLU A 1 17 ? 9.521   -9.239  -1.584  1.00 0.00 ? 17 GLU A CD   3 
+ATOM   2973 O  OE1  . GLU A 1 17 ? 9.122   -10.357 -1.864  1.00 0.00 ? 17 GLU A OE1  3 
+ATOM   2974 O  OE2  . GLU A 1 17 ? 10.113  -8.964  -0.554  1.00 0.00 ? 17 GLU A OE2  3 
+ATOM   2975 H  H    . GLU A 1 17 ? 4.989   -6.848  -2.143  1.00 0.00 ? 17 GLU A H    3 
+ATOM   2976 H  HA   . GLU A 1 17 ? 7.218   -6.796  -1.447  1.00 0.00 ? 17 GLU A HA   3 
+ATOM   2977 H  HB2  . GLU A 1 17 ? 7.316   -9.010  -2.598  1.00 0.00 ? 17 GLU A HB2  3 
+ATOM   2978 H  HB3  . GLU A 1 17 ? 7.741   -8.182  -4.096  1.00 0.00 ? 17 GLU A HB3  3 
+ATOM   2979 H  HG2  . GLU A 1 17 ? 9.897   -8.247  -3.452  1.00 0.00 ? 17 GLU A HG2  3 
+ATOM   2980 H  HG3  . GLU A 1 17 ? 9.485   -7.163  -2.123  1.00 0.00 ? 17 GLU A HG3  3 
+ATOM   2981 N  N    . CYS A 1 18 ? 6.797   -4.747  -3.607  1.00 0.00 ? 18 CYS A N    3 
+ATOM   2982 C  CA   . CYS A 1 18 ? 7.191   -3.471  -4.256  1.00 0.00 ? 18 CYS A CA   3 
+ATOM   2983 C  C    . CYS A 1 18 ? 8.688   -3.199  -4.086  1.00 0.00 ? 18 CYS A C    3 
+ATOM   2984 O  O    . CYS A 1 18 ? 9.114   -2.597  -3.128  1.00 0.00 ? 18 CYS A O    3 
+ATOM   2985 C  CB   . CYS A 1 18 ? 6.368   -2.359  -3.594  1.00 0.00 ? 18 CYS A CB   3 
+ATOM   2986 S  SG   . CYS A 1 18 ? 6.024   -2.772  -1.848  1.00 0.00 ? 18 CYS A SG   3 
+ATOM   2987 H  H    . CYS A 1 18 ? 5.843   -4.901  -3.458  1.00 0.00 ? 18 CYS A H    3 
+ATOM   2988 H  HA   . CYS A 1 18 ? 6.950   -3.512  -5.307  1.00 0.00 ? 18 CYS A HA   3 
+ATOM   2989 H  HB2  . CYS A 1 18 ? 6.911   -1.437  -3.642  1.00 0.00 ? 18 CYS A HB2  3 
+ATOM   2990 H  HB3  . CYS A 1 18 ? 5.440   -2.254  -4.122  1.00 0.00 ? 18 CYS A HB3  3 
+ATOM   2991 N  N    . SER A 1 19 ? 9.492   -3.652  -5.012  1.00 0.00 ? 19 SER A N    3 
+ATOM   2992 C  CA   . SER A 1 19 ? 10.962  -3.431  -4.900  1.00 0.00 ? 19 SER A CA   3 
+ATOM   2993 C  C    . SER A 1 19 ? 11.469  -2.739  -6.164  1.00 0.00 ? 19 SER A C    3 
+ATOM   2994 O  O    . SER A 1 19 ? 12.048  -3.357  -7.034  1.00 0.00 ? 19 SER A O    3 
+ATOM   2995 C  CB   . SER A 1 19 ? 11.669  -4.778  -4.737  1.00 0.00 ? 19 SER A CB   3 
+ATOM   2996 O  OG   . SER A 1 19 ? 11.967  -4.989  -3.362  1.00 0.00 ? 19 SER A OG   3 
+ATOM   2997 H  H    . SER A 1 19 ? 9.128   -4.141  -5.779  1.00 0.00 ? 19 SER A H    3 
+ATOM   2998 H  HA   . SER A 1 19 ? 11.169  -2.810  -4.042  1.00 0.00 ? 19 SER A HA   3 
+ATOM   2999 H  HB2  . SER A 1 19 ? 11.025  -5.569  -5.084  1.00 0.00 ? 19 SER A HB2  3 
+ATOM   3000 H  HB3  . SER A 1 19 ? 12.581  -4.778  -5.318  1.00 0.00 ? 19 SER A HB3  3 
+ATOM   3001 H  HG   . SER A 1 19 ? 11.254  -4.610  -2.843  1.00 0.00 ? 19 SER A HG   3 
+ATOM   3002 N  N    . ASP A 1 20 ? 11.248  -1.458  -6.268  1.00 0.00 ? 20 ASP A N    3 
+ATOM   3003 C  CA   . ASP A 1 20 ? 11.702  -0.708  -7.471  1.00 0.00 ? 20 ASP A CA   3 
+ATOM   3004 C  C    . ASP A 1 20 ? 11.064  0.682   -7.444  1.00 0.00 ? 20 ASP A C    3 
+ATOM   3005 O  O    . ASP A 1 20 ? 11.580  1.602   -6.842  1.00 0.00 ? 20 ASP A O    3 
+ATOM   3006 C  CB   . ASP A 1 20 ? 11.257  -1.455  -8.732  1.00 0.00 ? 20 ASP A CB   3 
+ATOM   3007 C  CG   . ASP A 1 20 ? 11.454  -0.558  -9.955  1.00 0.00 ? 20 ASP A CG   3 
+ATOM   3008 O  OD1  . ASP A 1 20 ? 12.562  -0.083  -10.144 1.00 0.00 ? 20 ASP A OD1  3 
+ATOM   3009 O  OD2  . ASP A 1 20 ? 10.493  -0.361  -10.680 1.00 0.00 ? 20 ASP A OD2  3 
+ATOM   3010 H  H    . ASP A 1 20 ? 10.774  -0.986  -5.552  1.00 0.00 ? 20 ASP A H    3 
+ATOM   3011 H  HA   . ASP A 1 20 ? 12.777  -0.616  -7.457  1.00 0.00 ? 20 ASP A HA   3 
+ATOM   3012 H  HB2  . ASP A 1 20 ? 11.844  -2.356  -8.845  1.00 0.00 ? 20 ASP A HB2  3 
+ATOM   3013 H  HB3  . ASP A 1 20 ? 10.212  -1.718  -8.644  1.00 0.00 ? 20 ASP A HB3  3 
+ATOM   3014 N  N    . ASP A 1 21 ? 9.929   0.831   -8.066  1.00 0.00 ? 21 ASP A N    3 
+ATOM   3015 C  CA   . ASP A 1 21 ? 9.234   2.136   -8.054  1.00 0.00 ? 21 ASP A CA   3 
+ATOM   3016 C  C    . ASP A 1 21 ? 8.022   2.018   -7.137  1.00 0.00 ? 21 ASP A C    3 
+ATOM   3017 O  O    . ASP A 1 21 ? 7.130   2.842   -7.149  1.00 0.00 ? 21 ASP A O    3 
+ATOM   3018 C  CB   . ASP A 1 21 ? 8.788   2.503   -9.471  1.00 0.00 ? 21 ASP A CB   3 
+ATOM   3019 C  CG   . ASP A 1 21 ? 7.882   1.399   -10.019 1.00 0.00 ? 21 ASP A CG   3 
+ATOM   3020 O  OD1  . ASP A 1 21 ? 7.319   0.672   -9.219  1.00 0.00 ? 21 ASP A OD1  3 
+ATOM   3021 O  OD2  . ASP A 1 21 ? 7.768   1.299   -11.230 1.00 0.00 ? 21 ASP A OD2  3 
+ATOM   3022 H  H    . ASP A 1 21 ? 9.521   0.078   -8.519  1.00 0.00 ? 21 ASP A H    3 
+ATOM   3023 H  HA   . ASP A 1 21 ? 9.897   2.885   -7.671  1.00 0.00 ? 21 ASP A HA   3 
+ATOM   3024 H  HB2  . ASP A 1 21 ? 8.245   3.438   -9.448  1.00 0.00 ? 21 ASP A HB2  3 
+ATOM   3025 H  HB3  . ASP A 1 21 ? 9.654   2.605   -10.107 1.00 0.00 ? 21 ASP A HB3  3 
+ATOM   3026 N  N    . THR A 1 22 ? 7.996   0.989   -6.334  1.00 0.00 ? 22 THR A N    3 
+ATOM   3027 C  CA   . THR A 1 22 ? 6.865   0.793   -5.398  1.00 0.00 ? 22 THR A CA   3 
+ATOM   3028 C  C    . THR A 1 22 ? 5.657   0.217   -6.134  1.00 0.00 ? 22 THR A C    3 
+ATOM   3029 O  O    . THR A 1 22 ? 5.489   0.391   -7.325  1.00 0.00 ? 22 THR A O    3 
+ATOM   3030 C  CB   . THR A 1 22 ? 6.483   2.132   -4.767  1.00 0.00 ? 22 THR A CB   3 
+ATOM   3031 O  OG1  . THR A 1 22 ? 7.611   2.994   -4.767  1.00 0.00 ? 22 THR A OG1  3 
+ATOM   3032 C  CG2  . THR A 1 22 ? 6.013   1.898   -3.334  1.00 0.00 ? 22 THR A CG2  3 
+ATOM   3033 H  H    . THR A 1 22 ? 8.734   0.345   -6.342  1.00 0.00 ? 22 THR A H    3 
+ATOM   3034 H  HA   . THR A 1 22 ? 7.165   0.110   -4.619  1.00 0.00 ? 22 THR A HA   3 
+ATOM   3035 H  HB   . THR A 1 22 ? 5.683   2.582   -5.335  1.00 0.00 ? 22 THR A HB   3 
+ATOM   3036 H  HG1  . THR A 1 22 ? 8.402   2.450   -4.737  1.00 0.00 ? 22 THR A HG1  3 
+ATOM   3037 H  HG21 . THR A 1 22 ? 5.997   0.838   -3.128  1.00 0.00 ? 22 THR A HG21 3 
+ATOM   3038 H  HG22 . THR A 1 22 ? 6.689   2.387   -2.649  1.00 0.00 ? 22 THR A HG22 3 
+ATOM   3039 H  HG23 . THR A 1 22 ? 5.019   2.304   -3.211  1.00 0.00 ? 22 THR A HG23 3 
+ATOM   3040 N  N    . TYR A 1 23 ? 4.822   -0.472  -5.413  1.00 0.00 ? 23 TYR A N    3 
+ATOM   3041 C  CA   . TYR A 1 23 ? 3.603   -1.085  -6.002  1.00 0.00 ? 23 TYR A CA   3 
+ATOM   3042 C  C    . TYR A 1 23 ? 2.488   -0.044  -6.147  1.00 0.00 ? 23 TYR A C    3 
+ATOM   3043 O  O    . TYR A 1 23 ? 1.339   -0.352  -5.915  1.00 0.00 ? 23 TYR A O    3 
+ATOM   3044 C  CB   . TYR A 1 23 ? 3.112   -2.211  -5.082  1.00 0.00 ? 23 TYR A CB   3 
+ATOM   3045 C  CG   . TYR A 1 23 ? 2.415   -1.644  -3.854  1.00 0.00 ? 23 TYR A CG   3 
+ATOM   3046 C  CD1  . TYR A 1 23 ? 2.951   -0.547  -3.156  1.00 0.00 ? 23 TYR A CD1  3 
+ATOM   3047 C  CD2  . TYR A 1 23 ? 1.234   -2.242  -3.398  1.00 0.00 ? 23 TYR A CD2  3 
+ATOM   3048 C  CE1  . TYR A 1 23 ? 2.306   -0.058  -2.018  1.00 0.00 ? 23 TYR A CE1  3 
+ATOM   3049 C  CE2  . TYR A 1 23 ? 0.593   -1.749  -2.254  1.00 0.00 ? 23 TYR A CE2  3 
+ATOM   3050 C  CZ   . TYR A 1 23 ? 1.130   -0.658  -1.565  1.00 0.00 ? 23 TYR A CZ   3 
+ATOM   3051 O  OH   . TYR A 1 23 ? 0.497   -0.173  -0.440  1.00 0.00 ? 23 TYR A OH   3 
+ATOM   3052 H  H    . TYR A 1 23 ? 5.005   -0.592  -4.474  1.00 0.00 ? 23 TYR A H    3 
+ATOM   3053 H  HA   . TYR A 1 23 ? 3.846   -1.493  -6.963  1.00 0.00 ? 23 TYR A HA   3 
+ATOM   3054 H  HB2  . TYR A 1 23 ? 2.421   -2.831  -5.620  1.00 0.00 ? 23 TYR A HB2  3 
+ATOM   3055 H  HB3  . TYR A 1 23 ? 3.947   -2.811  -4.770  1.00 0.00 ? 23 TYR A HB3  3 
+ATOM   3056 H  HD1  . TYR A 1 23 ? 3.849   -0.073  -3.494  1.00 0.00 ? 23 TYR A HD1  3 
+ATOM   3057 H  HD2  . TYR A 1 23 ? 0.818   -3.085  -3.928  1.00 0.00 ? 23 TYR A HD2  3 
+ATOM   3058 H  HE1  . TYR A 1 23 ? 2.724   0.781   -1.484  1.00 0.00 ? 23 TYR A HE1  3 
+ATOM   3059 H  HE2  . TYR A 1 23 ? -0.317  -2.210  -1.904  1.00 0.00 ? 23 TYR A HE2  3 
+ATOM   3060 H  HH   . TYR A 1 23 ? 1.170   0.156   0.159   1.00 0.00 ? 23 TYR A HH   3 
+ATOM   3061 N  N    . ILE A 1 24 ? 2.835   1.172   -6.517  1.00 0.00 ? 24 ILE A N    3 
+ATOM   3062 C  CA   . ILE A 1 24 ? 1.838   2.288   -6.679  1.00 0.00 ? 24 ILE A CA   3 
+ATOM   3063 C  C    . ILE A 1 24 ? 0.404   1.777   -6.848  1.00 0.00 ? 24 ILE A C    3 
+ATOM   3064 O  O    . ILE A 1 24 ? 0.174   0.691   -7.319  1.00 0.00 ? 24 ILE A O    3 
+ATOM   3065 C  CB   . ILE A 1 24 ? 2.205   3.124   -7.906  1.00 0.00 ? 24 ILE A CB   3 
+ATOM   3066 C  CG1  . ILE A 1 24 ? 2.912   2.246   -8.941  1.00 0.00 ? 24 ILE A CG1  3 
+ATOM   3067 C  CG2  . ILE A 1 24 ? 3.134   4.261   -7.488  1.00 0.00 ? 24 ILE A CG2  3 
+ATOM   3068 C  CD1  . ILE A 1 24 ? 2.973   2.987   -10.277 1.00 0.00 ? 24 ILE A CD1  3 
+ATOM   3069 H  H    . ILE A 1 24 ? 3.775   1.364   -6.686  1.00 0.00 ? 24 ILE A H    3 
+ATOM   3070 H  HA   . ILE A 1 24 ? 1.882   2.919   -5.808  1.00 0.00 ? 24 ILE A HA   3 
+ATOM   3071 H  HB   . ILE A 1 24 ? 1.305   3.538   -8.339  1.00 0.00 ? 24 ILE A HB   3 
+ATOM   3072 H  HG12 . ILE A 1 24 ? 3.915   2.027   -8.603  1.00 0.00 ? 24 ILE A HG12 3 
+ATOM   3073 H  HG13 . ILE A 1 24 ? 2.364   1.324   -9.068  1.00 0.00 ? 24 ILE A HG13 3 
+ATOM   3074 H  HG21 . ILE A 1 24 ? 3.506   4.074   -6.492  1.00 0.00 ? 24 ILE A HG21 3 
+ATOM   3075 H  HG22 . ILE A 1 24 ? 3.964   4.319   -8.178  1.00 0.00 ? 24 ILE A HG22 3 
+ATOM   3076 H  HG23 . ILE A 1 24 ? 2.591   5.194   -7.501  1.00 0.00 ? 24 ILE A HG23 3 
+ATOM   3077 H  HD11 . ILE A 1 24 ? 2.599   3.993   -10.148 1.00 0.00 ? 24 ILE A HD11 3 
+ATOM   3078 H  HD12 . ILE A 1 24 ? 3.996   3.025   -10.623 1.00 0.00 ? 24 ILE A HD12 3 
+ATOM   3079 H  HD13 . ILE A 1 24 ? 2.366   2.468   -11.004 1.00 0.00 ? 24 ILE A HD13 3 
+ATOM   3080 N  N    . LEU A 1 25 ? -0.547  2.599   -6.472  1.00 0.00 ? 25 LEU A N    3 
+ATOM   3081 C  CA   . LEU A 1 25 ? -2.004  2.252   -6.577  1.00 0.00 ? 25 LEU A CA   3 
+ATOM   3082 C  C    . LEU A 1 25 ? -2.230  1.041   -7.485  1.00 0.00 ? 25 LEU A C    3 
+ATOM   3083 O  O    . LEU A 1 25 ? -2.862  0.081   -7.093  1.00 0.00 ? 25 LEU A O    3 
+ATOM   3084 C  CB   . LEU A 1 25 ? -2.743  3.456   -7.165  1.00 0.00 ? 25 LEU A CB   3 
+ATOM   3085 C  CG   . LEU A 1 25 ? -1.884  4.085   -8.262  1.00 0.00 ? 25 LEU A CG   3 
+ATOM   3086 C  CD1  . LEU A 1 25 ? -2.645  4.058   -9.589  1.00 0.00 ? 25 LEU A CD1  3 
+ATOM   3087 C  CD2  . LEU A 1 25 ? -1.563  5.534   -7.890  1.00 0.00 ? 25 LEU A CD2  3 
+ATOM   3088 H  H    . LEU A 1 25 ? -0.296  3.472   -6.114  1.00 0.00 ? 25 LEU A H    3 
+ATOM   3089 H  HA   . LEU A 1 25 ? -2.396  2.044   -5.594  1.00 0.00 ? 25 LEU A HA   3 
+ATOM   3090 H  HB2  . LEU A 1 25 ? -3.687  3.133   -7.581  1.00 0.00 ? 25 LEU A HB2  3 
+ATOM   3091 H  HB3  . LEU A 1 25 ? -2.920  4.184   -6.389  1.00 0.00 ? 25 LEU A HB3  3 
+ATOM   3092 H  HG   . LEU A 1 25 ? -0.964  3.525   -8.362  1.00 0.00 ? 25 LEU A HG   3 
+ATOM   3093 H  HD11 . LEU A 1 25 ? -3.672  3.778   -9.411  1.00 0.00 ? 25 LEU A HD11 3 
+ATOM   3094 H  HD12 . LEU A 1 25 ? -2.613  5.039   -10.042 1.00 0.00 ? 25 LEU A HD12 3 
+ATOM   3095 H  HD13 . LEU A 1 25 ? -2.186  3.341   -10.253 1.00 0.00 ? 25 LEU A HD13 3 
+ATOM   3096 H  HD21 . LEU A 1 25 ? -1.467  5.618   -6.819  1.00 0.00 ? 25 LEU A HD21 3 
+ATOM   3097 H  HD22 . LEU A 1 25 ? -0.635  5.828   -8.359  1.00 0.00 ? 25 LEU A HD22 3 
+ATOM   3098 H  HD23 . LEU A 1 25 ? -2.359  6.179   -8.233  1.00 0.00 ? 25 LEU A HD23 3 
+ATOM   3099 N  N    . ASP A 1 26 ? -1.706  1.077   -8.684  1.00 0.00 ? 26 ASP A N    3 
+ATOM   3100 C  CA   . ASP A 1 26 ? -1.869  -0.067  -9.621  1.00 0.00 ? 26 ASP A CA   3 
+ATOM   3101 C  C    . ASP A 1 26 ? -1.758  -1.394  -8.860  1.00 0.00 ? 26 ASP A C    3 
+ATOM   3102 O  O    . ASP A 1 26 ? -2.700  -2.155  -8.779  1.00 0.00 ? 26 ASP A O    3 
+ATOM   3103 C  CB   . ASP A 1 26 ? -0.772  -0.008  -10.686 1.00 0.00 ? 26 ASP A CB   3 
+ATOM   3104 C  CG   . ASP A 1 26 ? -1.280  -0.652  -11.980 1.00 0.00 ? 26 ASP A CG   3 
+ATOM   3105 O  OD1  . ASP A 1 26 ? -2.101  -1.549  -11.890 1.00 0.00 ? 26 ASP A OD1  3 
+ATOM   3106 O  OD2  . ASP A 1 26 ? -0.837  -0.237  -13.038 1.00 0.00 ? 26 ASP A OD2  3 
+ATOM   3107 H  H    . ASP A 1 26 ? -1.193  1.859   -8.966  1.00 0.00 ? 26 ASP A H    3 
+ATOM   3108 H  HA   . ASP A 1 26 ? -2.833  -0.005  -10.102 1.00 0.00 ? 26 ASP A HA   3 
+ATOM   3109 H  HB2  . ASP A 1 26 ? -0.509  1.022   -10.875 1.00 0.00 ? 26 ASP A HB2  3 
+ATOM   3110 H  HB3  . ASP A 1 26 ? 0.097   -0.544  -10.338 1.00 0.00 ? 26 ASP A HB3  3 
+ATOM   3111 N  N    . ALA A 1 27 ? -0.624  -1.691  -8.294  1.00 0.00 ? 27 ALA A N    3 
+ATOM   3112 C  CA   . ALA A 1 27 ? -0.507  -2.974  -7.566  1.00 0.00 ? 27 ALA A CA   3 
+ATOM   3113 C  C    . ALA A 1 27 ? -1.257  -2.871  -6.247  1.00 0.00 ? 27 ALA A C    3 
+ATOM   3114 O  O    . ALA A 1 27 ? -1.929  -3.794  -5.824  1.00 0.00 ? 27 ALA A O    3 
+ATOM   3115 C  CB   . ALA A 1 27 ? 0.968   -3.264  -7.285  1.00 0.00 ? 27 ALA A CB   3 
+ATOM   3116 H  H    . ALA A 1 27 ? 0.144   -1.077  -8.341  1.00 0.00 ? 27 ALA A H    3 
+ATOM   3117 H  HA   . ALA A 1 27 ? -0.926  -3.770  -8.160  1.00 0.00 ? 27 ALA A HA   3 
+ATOM   3118 H  HB1  . ALA A 1 27 ? 1.503   -2.332  -7.170  1.00 0.00 ? 27 ALA A HB1  3 
+ATOM   3119 H  HB2  . ALA A 1 27 ? 1.055   -3.840  -6.374  1.00 0.00 ? 27 ALA A HB2  3 
+ATOM   3120 H  HB3  . ALA A 1 27 ? 1.392   -3.822  -8.105  1.00 0.00 ? 27 ALA A HB3  3 
+ATOM   3121 N  N    . ALA A 1 28 ? -1.147  -1.751  -5.598  1.00 0.00 ? 28 ALA A N    3 
+ATOM   3122 C  CA   . ALA A 1 28 ? -1.822  -1.577  -4.298  1.00 0.00 ? 28 ALA A CA   3 
+ATOM   3123 C  C    . ALA A 1 28 ? -3.259  -2.076  -4.367  1.00 0.00 ? 28 ALA A C    3 
+ATOM   3124 O  O    . ALA A 1 28 ? -3.537  -3.250  -4.195  1.00 0.00 ? 28 ALA A O    3 
+ATOM   3125 C  CB   . ALA A 1 28 ? -1.802  -0.097  -3.910  1.00 0.00 ? 28 ALA A CB   3 
+ATOM   3126 H  H    . ALA A 1 28 ? -0.613  -1.020  -5.967  1.00 0.00 ? 28 ALA A H    3 
+ATOM   3127 H  HA   . ALA A 1 28 ? -1.291  -2.141  -3.551  1.00 0.00 ? 28 ALA A HA   3 
+ATOM   3128 H  HB1  . ALA A 1 28 ? -1.721  0.506   -4.801  1.00 0.00 ? 28 ALA A HB1  3 
+ATOM   3129 H  HB2  . ALA A 1 28 ? -2.714  0.151   -3.388  1.00 0.00 ? 28 ALA A HB2  3 
+ATOM   3130 H  HB3  . ALA A 1 28 ? -0.955  0.094   -3.268  1.00 0.00 ? 28 ALA A HB3  3 
+ATOM   3131 N  N    . GLU A 1 29 ? -4.186  -1.202  -4.596  1.00 0.00 ? 29 GLU A N    3 
+ATOM   3132 C  CA   . GLU A 1 29 ? -5.598  -1.656  -4.633  1.00 0.00 ? 29 GLU A CA   3 
+ATOM   3133 C  C    . GLU A 1 29 ? -6.093  -1.829  -6.068  1.00 0.00 ? 29 GLU A C    3 
+ATOM   3134 O  O    . GLU A 1 29 ? -7.203  -2.274  -6.291  1.00 0.00 ? 29 GLU A O    3 
+ATOM   3135 C  CB   . GLU A 1 29 ? -6.488  -0.679  -3.871  1.00 0.00 ? 29 GLU A CB   3 
+ATOM   3136 C  CG   . GLU A 1 29 ? -5.928  0.738   -3.965  1.00 0.00 ? 29 GLU A CG   3 
+ATOM   3137 C  CD   . GLU A 1 29 ? -4.977  0.984   -2.792  1.00 0.00 ? 29 GLU A CD   3 
+ATOM   3138 O  OE1  . GLU A 1 29 ? -4.471  0.014   -2.255  1.00 0.00 ? 29 GLU A OE1  3 
+ATOM   3139 O  OE2  . GLU A 1 29 ? -4.780  2.137   -2.445  1.00 0.00 ? 29 GLU A OE2  3 
+ATOM   3140 H  H    . GLU A 1 29 ? -3.953  -0.258  -4.731  1.00 0.00 ? 29 GLU A H    3 
+ATOM   3141 H  HA   . GLU A 1 29 ? -5.654  -2.617  -4.142  1.00 0.00 ? 29 GLU A HA   3 
+ATOM   3142 H  HB2  . GLU A 1 29 ? -7.474  -0.706  -4.289  1.00 0.00 ? 29 GLU A HB2  3 
+ATOM   3143 H  HB3  . GLU A 1 29 ? -6.530  -0.977  -2.832  1.00 0.00 ? 29 GLU A HB3  3 
+ATOM   3144 H  HG2  . GLU A 1 29 ? -5.399  0.858   -4.899  1.00 0.00 ? 29 GLU A HG2  3 
+ATOM   3145 H  HG3  . GLU A 1 29 ? -6.740  1.448   -3.919  1.00 0.00 ? 29 GLU A HG3  3 
+ATOM   3146 N  N    . GLU A 1 30 ? -5.280  -1.566  -7.054  1.00 0.00 ? 30 GLU A N    3 
+ATOM   3147 C  CA   . GLU A 1 30 ? -5.748  -1.814  -8.425  1.00 0.00 ? 30 GLU A CA   3 
+ATOM   3148 C  C    . GLU A 1 30 ? -5.676  -3.318  -8.561  1.00 0.00 ? 30 GLU A C    3 
+ATOM   3149 O  O    . GLU A 1 30 ? -6.473  -3.952  -9.225  1.00 0.00 ? 30 GLU A O    3 
+ATOM   3150 C  CB   . GLU A 1 30 ? -4.854  -1.110  -9.442  1.00 0.00 ? 30 GLU A CB   3 
+ATOM   3151 C  CG   . GLU A 1 30 ? -5.684  -0.103  -10.237 1.00 0.00 ? 30 GLU A CG   3 
+ATOM   3152 C  CD   . GLU A 1 30 ? -4.832  0.484   -11.364 1.00 0.00 ? 30 GLU A CD   3 
+ATOM   3153 O  OE1  . GLU A 1 30 ? -4.776  -0.129  -12.417 1.00 0.00 ? 30 GLU A OE1  3 
+ATOM   3154 O  OE2  . GLU A 1 30 ? -4.251  1.536   -11.156 1.00 0.00 ? 30 GLU A OE2  3 
+ATOM   3155 H  H    . GLU A 1 30 ? -4.366  -1.283  -6.892  1.00 0.00 ? 30 GLU A H    3 
+ATOM   3156 H  HA   . GLU A 1 30 ? -6.765  -1.482  -8.520  1.00 0.00 ? 30 GLU A HA   3 
+ATOM   3157 H  HB2  . GLU A 1 30 ? -4.066  -0.592  -8.917  1.00 0.00 ? 30 GLU A HB2  3 
+ATOM   3158 H  HB3  . GLU A 1 30 ? -4.426  -1.837  -10.115 1.00 0.00 ? 30 GLU A HB3  3 
+ATOM   3159 H  HG2  . GLU A 1 30 ? -6.547  -0.600  -10.656 1.00 0.00 ? 30 GLU A HG2  3 
+ATOM   3160 H  HG3  . GLU A 1 30 ? -6.007  0.691   -9.581  1.00 0.00 ? 30 GLU A HG3  3 
+ATOM   3161 N  N    . ALA A 1 31 ? -4.751  -3.894  -7.837  1.00 0.00 ? 31 ALA A N    3 
+ATOM   3162 C  CA   . ALA A 1 31 ? -4.626  -5.345  -7.788  1.00 0.00 ? 31 ALA A CA   3 
+ATOM   3163 C  C    . ALA A 1 31 ? -5.665  -5.804  -6.769  1.00 0.00 ? 31 ALA A C    3 
+ATOM   3164 O  O    . ALA A 1 31 ? -6.224  -6.879  -6.856  1.00 0.00 ? 31 ALA A O    3 
+ATOM   3165 C  CB   . ALA A 1 31 ? -3.222  -5.693  -7.309  1.00 0.00 ? 31 ALA A CB   3 
+ATOM   3166 H  H    . ALA A 1 31 ? -4.167  -3.356  -7.268  1.00 0.00 ? 31 ALA A H    3 
+ATOM   3167 H  HA   . ALA A 1 31 ? -4.820  -5.767  -8.754  1.00 0.00 ? 31 ALA A HA   3 
+ATOM   3168 H  HB1  . ALA A 1 31 ? -2.540  -4.913  -7.616  1.00 0.00 ? 31 ALA A HB1  3 
+ATOM   3169 H  HB2  . ALA A 1 31 ? -3.222  -5.765  -6.232  1.00 0.00 ? 31 ALA A HB2  3 
+ATOM   3170 H  HB3  . ALA A 1 31 ? -2.917  -6.631  -7.738  1.00 0.00 ? 31 ALA A HB3  3 
+ATOM   3171 N  N    . GLY A 1 32 ? -5.941  -4.948  -5.808  1.00 0.00 ? 32 GLY A N    3 
+ATOM   3172 C  CA   . GLY A 1 32 ? -6.962  -5.262  -4.772  1.00 0.00 ? 32 GLY A CA   3 
+ATOM   3173 C  C    . GLY A 1 32 ? -8.334  -4.805  -5.278  1.00 0.00 ? 32 GLY A C    3 
+ATOM   3174 O  O    . GLY A 1 32 ? -9.285  -4.699  -4.526  1.00 0.00 ? 32 GLY A O    3 
+ATOM   3175 H  H    . GLY A 1 32 ? -5.478  -4.080  -5.782  1.00 0.00 ? 32 GLY A H    3 
+ATOM   3176 H  HA2  . GLY A 1 32 ? -6.977  -6.329  -4.590  1.00 0.00 ? 32 GLY A HA2  3 
+ATOM   3177 H  HA3  . GLY A 1 32 ? -6.726  -4.740  -3.857  1.00 0.00 ? 32 GLY A HA3  3 
+ATOM   3178 N  N    . LEU A 1 33 ? -8.437  -4.553  -6.565  1.00 0.00 ? 33 LEU A N    3 
+ATOM   3179 C  CA   . LEU A 1 33 ? -9.703  -4.131  -7.217  1.00 0.00 ? 33 LEU A CA   3 
+ATOM   3180 C  C    . LEU A 1 33 ? -10.154 -2.750  -6.740  1.00 0.00 ? 33 LEU A C    3 
+ATOM   3181 O  O    . LEU A 1 33 ? -11.017 -2.133  -7.330  1.00 0.00 ? 33 LEU A O    3 
+ATOM   3182 C  CB   . LEU A 1 33 ? -10.788 -5.150  -6.935  1.00 0.00 ? 33 LEU A CB   3 
+ATOM   3183 C  CG   . LEU A 1 33 ? -10.192 -6.491  -6.508  1.00 0.00 ? 33 LEU A CG   3 
+ATOM   3184 C  CD1  . LEU A 1 33 ? -11.294 -7.548  -6.432  1.00 0.00 ? 33 LEU A CD1  3 
+ATOM   3185 C  CD2  . LEU A 1 33 ? -9.128  -6.937  -7.515  1.00 0.00 ? 33 LEU A CD2  3 
+ATOM   3186 H  H    . LEU A 1 33 ? -7.678  -4.661  -7.115  1.00 0.00 ? 33 LEU A H    3 
+ATOM   3187 H  HA   . LEU A 1 33 ? -9.540  -4.093  -8.281  1.00 0.00 ? 33 LEU A HA   3 
+ATOM   3188 H  HB2  . LEU A 1 33 ? -11.407 -4.776  -6.151  1.00 0.00 ? 33 LEU A HB2  3 
+ATOM   3189 H  HB3  . LEU A 1 33 ? -11.365 -5.289  -7.824  1.00 0.00 ? 33 LEU A HB3  3 
+ATOM   3190 H  HG   . LEU A 1 33 ? -9.747  -6.374  -5.538  1.00 0.00 ? 33 LEU A HG   3 
+ATOM   3191 H  HD11 . LEU A 1 33 ? -11.942 -7.454  -7.290  1.00 0.00 ? 33 LEU A HD11 3 
+ATOM   3192 H  HD12 . LEU A 1 33 ? -10.848 -8.531  -6.424  1.00 0.00 ? 33 LEU A HD12 3 
+ATOM   3193 H  HD13 . LEU A 1 33 ? -11.869 -7.407  -5.529  1.00 0.00 ? 33 LEU A HD13 3 
+ATOM   3194 H  HD21 . LEU A 1 33 ? -8.827  -6.096  -8.122  1.00 0.00 ? 33 LEU A HD21 3 
+ATOM   3195 H  HD22 . LEU A 1 33 ? -8.269  -7.323  -6.984  1.00 0.00 ? 33 LEU A HD22 3 
+ATOM   3196 H  HD23 . LEU A 1 33 ? -9.534  -7.711  -8.149  1.00 0.00 ? 33 LEU A HD23 3 
+ATOM   3197 N  N    . ASP A 1 34 ? -9.593  -2.268  -5.680  1.00 0.00 ? 34 ASP A N    3 
+ATOM   3198 C  CA   . ASP A 1 34 ? -9.999  -0.937  -5.163  1.00 0.00 ? 34 ASP A CA   3 
+ATOM   3199 C  C    . ASP A 1 34 ? -9.057  0.155   -5.694  1.00 0.00 ? 34 ASP A C    3 
+ATOM   3200 O  O    . ASP A 1 34 ? -8.146  -0.112  -6.453  1.00 0.00 ? 34 ASP A O    3 
+ATOM   3201 C  CB   . ASP A 1 34 ? -9.962  -0.966  -3.634  1.00 0.00 ? 34 ASP A CB   3 
+ATOM   3202 C  CG   . ASP A 1 34 ? -10.893 0.112   -3.074  1.00 0.00 ? 34 ASP A CG   3 
+ATOM   3203 O  OD1  . ASP A 1 34 ? -12.030 0.171   -3.513  1.00 0.00 ? 34 ASP A OD1  3 
+ATOM   3204 O  OD2  . ASP A 1 34 ? -10.454 0.857   -2.215  1.00 0.00 ? 34 ASP A OD2  3 
+ATOM   3205 H  H    . ASP A 1 34 ? -8.919  -2.782  -5.221  1.00 0.00 ? 34 ASP A H    3 
+ATOM   3206 H  HA   . ASP A 1 34 ? -10.999 -0.735  -5.489  1.00 0.00 ? 34 ASP A HA   3 
+ATOM   3207 H  HB2  . ASP A 1 34 ? -10.286 -1.936  -3.287  1.00 0.00 ? 34 ASP A HB2  3 
+ATOM   3208 H  HB3  . ASP A 1 34 ? -8.957  -0.784  -3.295  1.00 0.00 ? 34 ASP A HB3  3 
+ATOM   3209 N  N    . LEU A 1 35 ? -9.273  1.387   -5.301  1.00 0.00 ? 35 LEU A N    3 
+ATOM   3210 C  CA   . LEU A 1 35 ? -8.399  2.506   -5.780  1.00 0.00 ? 35 LEU A CA   3 
+ATOM   3211 C  C    . LEU A 1 35 ? -9.039  3.844   -5.414  1.00 0.00 ? 35 LEU A C    3 
+ATOM   3212 O  O    . LEU A 1 35 ? -9.418  4.610   -6.279  1.00 0.00 ? 35 LEU A O    3 
+ATOM   3213 C  CB   . LEU A 1 35 ? -8.227  2.412   -7.299  1.00 0.00 ? 35 LEU A CB   3 
+ATOM   3214 C  CG   . LEU A 1 35 ? -9.571  2.085   -7.957  1.00 0.00 ? 35 LEU A CG   3 
+ATOM   3215 C  CD1  . LEU A 1 35 ? -10.209 3.370   -8.490  1.00 0.00 ? 35 LEU A CD1  3 
+ATOM   3216 C  CD2  . LEU A 1 35 ? -9.342  1.111   -9.115  1.00 0.00 ? 35 LEU A CD2  3 
+ATOM   3217 H  H    . LEU A 1 35 ? -10.018 1.578   -4.694  1.00 0.00 ? 35 LEU A H    3 
+ATOM   3218 H  HA   . LEU A 1 35 ? -7.425  2.451   -5.301  1.00 0.00 ? 35 LEU A HA   3 
+ATOM   3219 H  HB2  . LEU A 1 35 ? -7.862  3.356   -7.679  1.00 0.00 ? 35 LEU A HB2  3 
+ATOM   3220 H  HB3  . LEU A 1 35 ? -7.516  1.633   -7.533  1.00 0.00 ? 35 LEU A HB3  3 
+ATOM   3221 H  HG   . LEU A 1 35 ? -10.229 1.631   -7.231  1.00 0.00 ? 35 LEU A HG   3 
+ATOM   3222 H  HD11 . LEU A 1 35 ? -9.526  4.195   -8.355  1.00 0.00 ? 35 LEU A HD11 3 
+ATOM   3223 H  HD12 . LEU A 1 35 ? -10.429 3.254   -9.542  1.00 0.00 ? 35 LEU A HD12 3 
+ATOM   3224 H  HD13 . LEU A 1 35 ? -11.124 3.568   -7.952  1.00 0.00 ? 35 LEU A HD13 3 
+ATOM   3225 H  HD21 . LEU A 1 35 ? -8.280  0.983   -9.273  1.00 0.00 ? 35 LEU A HD21 3 
+ATOM   3226 H  HD22 . LEU A 1 35 ? -9.788  0.157   -8.877  1.00 0.00 ? 35 LEU A HD22 3 
+ATOM   3227 H  HD23 . LEU A 1 35 ? -9.794  1.506   -10.013 1.00 0.00 ? 35 LEU A HD23 3 
+ATOM   3228 N  N    . PRO A 1 36 ? -9.121  4.089   -4.130  1.00 0.00 ? 36 PRO A N    3 
+ATOM   3229 C  CA   . PRO A 1 36 ? -9.692  5.338   -3.603  1.00 0.00 ? 36 PRO A CA   3 
+ATOM   3230 C  C    . PRO A 1 36 ? -8.784  6.508   -3.987  1.00 0.00 ? 36 PRO A C    3 
+ATOM   3231 O  O    . PRO A 1 36 ? -9.130  7.661   -3.822  1.00 0.00 ? 36 PRO A O    3 
+ATOM   3232 C  CB   . PRO A 1 36 ? -9.700  5.149   -2.079  1.00 0.00 ? 36 PRO A CB   3 
+ATOM   3233 C  CG   . PRO A 1 36 ? -8.998  3.801   -1.769  1.00 0.00 ? 36 PRO A CG   3 
+ATOM   3234 C  CD   . PRO A 1 36 ? -8.654  3.137   -3.106  1.00 0.00 ? 36 PRO A CD   3 
+ATOM   3235 H  HA   . PRO A 1 36 ? -10.695 5.489   -3.968  1.00 0.00 ? 36 PRO A HA   3 
+ATOM   3236 H  HB2  . PRO A 1 36 ? -9.166  5.962   -1.607  1.00 0.00 ? 36 PRO A HB2  3 
+ATOM   3237 H  HB3  . PRO A 1 36 ? -10.716 5.118   -1.718  1.00 0.00 ? 36 PRO A HB3  3 
+ATOM   3238 H  HG2  . PRO A 1 36 ? -8.092  3.979   -1.209  1.00 0.00 ? 36 PRO A HG2  3 
+ATOM   3239 H  HG3  . PRO A 1 36 ? -9.660  3.162   -1.206  1.00 0.00 ? 36 PRO A HG3  3 
+ATOM   3240 H  HD2  . PRO A 1 36 ? -7.584  2.991   -3.186  1.00 0.00 ? 36 PRO A HD2  3 
+ATOM   3241 H  HD3  . PRO A 1 36 ? -9.172  2.198   -3.203  1.00 0.00 ? 36 PRO A HD3  3 
+ATOM   3242 N  N    . TYR A 1 37 ? -7.615  6.210   -4.493  1.00 0.00 ? 37 TYR A N    3 
+ATOM   3243 C  CA   . TYR A 1 37 ? -6.666  7.286   -4.886  1.00 0.00 ? 37 TYR A CA   3 
+ATOM   3244 C  C    . TYR A 1 37 ? -7.422  8.418   -5.579  1.00 0.00 ? 37 TYR A C    3 
+ATOM   3245 O  O    . TYR A 1 37 ? -7.716  8.360   -6.757  1.00 0.00 ? 37 TYR A O    3 
+ATOM   3246 C  CB   . TYR A 1 37 ? -5.616  6.710   -5.834  1.00 0.00 ? 37 TYR A CB   3 
+ATOM   3247 C  CG   . TYR A 1 37 ? -4.769  5.714   -5.081  1.00 0.00 ? 37 TYR A CG   3 
+ATOM   3248 C  CD1  . TYR A 1 37 ? -3.793  6.164   -4.184  1.00 0.00 ? 37 TYR A CD1  3 
+ATOM   3249 C  CD2  . TYR A 1 37 ? -4.961  4.341   -5.275  1.00 0.00 ? 37 TYR A CD2  3 
+ATOM   3250 C  CE1  . TYR A 1 37 ? -3.010  5.241   -3.481  1.00 0.00 ? 37 TYR A CE1  3 
+ATOM   3251 C  CE2  . TYR A 1 37 ? -4.175  3.419   -4.574  1.00 0.00 ? 37 TYR A CE2  3 
+ATOM   3252 C  CZ   . TYR A 1 37 ? -3.200  3.870   -3.676  1.00 0.00 ? 37 TYR A CZ   3 
+ATOM   3253 O  OH   . TYR A 1 37 ? -2.430  2.961   -2.981  1.00 0.00 ? 37 TYR A OH   3 
+ATOM   3254 H  H    . TYR A 1 37 ? -7.358  5.272   -4.609  1.00 0.00 ? 37 TYR A H    3 
+ATOM   3255 H  HA   . TYR A 1 37 ? -6.177  7.671   -4.003  1.00 0.00 ? 37 TYR A HA   3 
+ATOM   3256 H  HB2  . TYR A 1 37 ? -6.106  6.218   -6.661  1.00 0.00 ? 37 TYR A HB2  3 
+ATOM   3257 H  HB3  . TYR A 1 37 ? -4.989  7.507   -6.206  1.00 0.00 ? 37 TYR A HB3  3 
+ATOM   3258 H  HD1  . TYR A 1 37 ? -3.645  7.223   -4.034  1.00 0.00 ? 37 TYR A HD1  3 
+ATOM   3259 H  HD2  . TYR A 1 37 ? -5.713  3.994   -5.968  1.00 0.00 ? 37 TYR A HD2  3 
+ATOM   3260 H  HE1  . TYR A 1 37 ? -2.257  5.589   -2.789  1.00 0.00 ? 37 TYR A HE1  3 
+ATOM   3261 H  HE2  . TYR A 1 37 ? -4.321  2.361   -4.724  1.00 0.00 ? 37 TYR A HE2  3 
+ATOM   3262 H  HH   . TYR A 1 37 ? -2.457  2.125   -3.454  1.00 0.00 ? 37 TYR A HH   3 
+ATOM   3263 N  N    . SER A 1 38 ? -7.730  9.451   -4.850  1.00 0.00 ? 38 SER A N    3 
+ATOM   3264 C  CA   . SER A 1 38 ? -8.457  10.605  -5.441  1.00 0.00 ? 38 SER A CA   3 
+ATOM   3265 C  C    . SER A 1 38 ? -7.709  11.885  -5.077  1.00 0.00 ? 38 SER A C    3 
+ATOM   3266 O  O    . SER A 1 38 ? -7.479  12.743  -5.905  1.00 0.00 ? 38 SER A O    3 
+ATOM   3267 C  CB   . SER A 1 38 ? -9.879  10.663  -4.881  1.00 0.00 ? 38 SER A CB   3 
+ATOM   3268 O  OG   . SER A 1 38 ? -10.808 10.658  -5.957  1.00 0.00 ? 38 SER A OG   3 
+ATOM   3269 H  H    . SER A 1 38 ? -7.474  9.471   -3.904  1.00 0.00 ? 38 SER A H    3 
+ATOM   3270 H  HA   . SER A 1 38 ? -8.493  10.499  -6.516  1.00 0.00 ? 38 SER A HA   3 
+ATOM   3271 H  HB2  . SER A 1 38 ? -10.057 9.805   -4.255  1.00 0.00 ? 38 SER A HB2  3 
+ATOM   3272 H  HB3  . SER A 1 38 ? -9.996  11.565  -4.294  1.00 0.00 ? 38 SER A HB3  3 
+ATOM   3273 H  HG   . SER A 1 38 ? -11.194 11.534  -6.020  1.00 0.00 ? 38 SER A HG   3 
+ATOM   3274 N  N    . CYS A 1 39 ? -7.328  12.015  -3.835  1.00 0.00 ? 39 CYS A N    3 
+ATOM   3275 C  CA   . CYS A 1 39 ? -6.595  13.232  -3.399  1.00 0.00 ? 39 CYS A CA   3 
+ATOM   3276 C  C    . CYS A 1 39 ? -5.168  13.200  -3.969  1.00 0.00 ? 39 CYS A C    3 
+ATOM   3277 O  O    . CYS A 1 39 ? -4.391  14.114  -3.774  1.00 0.00 ? 39 CYS A O    3 
+ATOM   3278 C  CB   . CYS A 1 39 ? -6.601  13.290  -1.848  1.00 0.00 ? 39 CYS A CB   3 
+ATOM   3279 S  SG   . CYS A 1 39 ? -4.974  12.912  -1.118  1.00 0.00 ? 39 CYS A SG   3 
+ATOM   3280 H  H    . CYS A 1 39 ? -7.527  11.306  -3.186  1.00 0.00 ? 39 CYS A H    3 
+ATOM   3281 H  HA   . CYS A 1 39 ? -7.105  14.104  -3.785  1.00 0.00 ? 39 CYS A HA   3 
+ATOM   3282 H  HB2  . CYS A 1 39 ? -6.895  14.280  -1.538  1.00 0.00 ? 39 CYS A HB2  3 
+ATOM   3283 H  HB3  . CYS A 1 39 ? -7.328  12.580  -1.476  1.00 0.00 ? 39 CYS A HB3  3 
+ATOM   3284 N  N    . ARG A 1 40 ? -4.821  12.155  -4.676  1.00 0.00 ? 40 ARG A N    3 
+ATOM   3285 C  CA   . ARG A 1 40 ? -3.454  12.066  -5.261  1.00 0.00 ? 40 ARG A CA   3 
+ATOM   3286 C  C    . ARG A 1 40 ? -2.412  12.281  -4.163  1.00 0.00 ? 40 ARG A C    3 
+ATOM   3287 O  O    . ARG A 1 40 ? -2.677  12.082  -2.993  1.00 0.00 ? 40 ARG A O    3 
+ATOM   3288 C  CB   . ARG A 1 40 ? -3.288  13.140  -6.340  1.00 0.00 ? 40 ARG A CB   3 
+ATOM   3289 C  CG   . ARG A 1 40 ? -4.621  13.350  -7.063  1.00 0.00 ? 40 ARG A CG   3 
+ATOM   3290 C  CD   . ARG A 1 40 ? -4.460  14.445  -8.119  1.00 0.00 ? 40 ARG A CD   3 
+ATOM   3291 N  NE   . ARG A 1 40 ? -4.327  13.820  -9.466  1.00 0.00 ? 40 ARG A NE   3 
+ATOM   3292 C  CZ   . ARG A 1 40 ? -4.461  14.547  -10.544 1.00 0.00 ? 40 ARG A CZ   3 
+ATOM   3293 N  NH1  . ARG A 1 40 ? -4.710  15.825  -10.446 1.00 0.00 ? 40 ARG A NH1  3 
+ATOM   3294 N  NH2  . ARG A 1 40 ? -4.343  13.995  -11.720 1.00 0.00 ? 40 ARG A NH2  3 
+ATOM   3295 H  H    . ARG A 1 40 ? -5.460  11.429  -4.823  1.00 0.00 ? 40 ARG A H    3 
+ATOM   3296 H  HA   . ARG A 1 40 ? -3.316  11.090  -5.701  1.00 0.00 ? 40 ARG A HA   3 
+ATOM   3297 H  HB2  . ARG A 1 40 ? -2.976  14.066  -5.881  1.00 0.00 ? 40 ARG A HB2  3 
+ATOM   3298 H  HB3  . ARG A 1 40 ? -2.542  12.821  -7.052  1.00 0.00 ? 40 ARG A HB3  3 
+ATOM   3299 H  HG2  . ARG A 1 40 ? -4.920  12.429  -7.541  1.00 0.00 ? 40 ARG A HG2  3 
+ATOM   3300 H  HG3  . ARG A 1 40 ? -5.375  13.648  -6.350  1.00 0.00 ? 40 ARG A HG3  3 
+ATOM   3301 H  HD2  . ARG A 1 40 ? -5.327  15.090  -8.106  1.00 0.00 ? 40 ARG A HD2  3 
+ATOM   3302 H  HD3  . ARG A 1 40 ? -3.577  15.028  -7.903  1.00 0.00 ? 40 ARG A HD3  3 
+ATOM   3303 H  HE   . ARG A 1 40 ? -4.140  12.861  -9.544  1.00 0.00 ? 40 ARG A HE   3 
+ATOM   3304 H  HH11 . ARG A 1 40 ? -4.799  16.251  -9.546  1.00 0.00 ? 40 ARG A HH11 3 
+ATOM   3305 H  HH12 . ARG A 1 40 ? -4.811  16.379  -11.272 1.00 0.00 ? 40 ARG A HH12 3 
+ATOM   3306 H  HH21 . ARG A 1 40 ? -4.152  13.017  -11.797 1.00 0.00 ? 40 ARG A HH21 3 
+ATOM   3307 H  HH22 . ARG A 1 40 ? -4.446  14.551  -12.545 1.00 0.00 ? 40 ARG A HH22 3 
+ATOM   3308 N  N    . ALA A 1 41 ? -1.229  12.687  -4.529  1.00 0.00 ? 41 ALA A N    3 
+ATOM   3309 C  CA   . ALA A 1 41 ? -0.169  12.913  -3.509  1.00 0.00 ? 41 ALA A CA   3 
+ATOM   3310 C  C    . ALA A 1 41 ? -0.524  14.142  -2.670  1.00 0.00 ? 41 ALA A C    3 
+ATOM   3311 O  O    . ALA A 1 41 ? -0.086  15.242  -2.944  1.00 0.00 ? 41 ALA A O    3 
+ATOM   3312 C  CB   . ALA A 1 41 ? 1.172   13.143  -4.207  1.00 0.00 ? 41 ALA A CB   3 
+ATOM   3313 H  H    . ALA A 1 41 ? -1.036  12.841  -5.478  1.00 0.00 ? 41 ALA A H    3 
+ATOM   3314 H  HA   . ALA A 1 41 ? -0.096  12.048  -2.866  1.00 0.00 ? 41 ALA A HA   3 
+ATOM   3315 H  HB1  . ALA A 1 41 ? 1.161   12.663  -5.173  1.00 0.00 ? 41 ALA A HB1  3 
+ATOM   3316 H  HB2  . ALA A 1 41 ? 1.333   14.203  -4.334  1.00 0.00 ? 41 ALA A HB2  3 
+ATOM   3317 H  HB3  . ALA A 1 41 ? 1.968   12.727  -3.606  1.00 0.00 ? 41 ALA A HB3  3 
+ATOM   3318 N  N    . GLY A 1 42 ? -1.315  13.962  -1.649  1.00 0.00 ? 42 GLY A N    3 
+ATOM   3319 C  CA   . GLY A 1 42 ? -1.700  15.116  -0.791  1.00 0.00 ? 42 GLY A CA   3 
+ATOM   3320 C  C    . GLY A 1 42 ? -1.769  14.658  0.666   1.00 0.00 ? 42 GLY A C    3 
+ATOM   3321 O  O    . GLY A 1 42 ? -0.780  14.267  1.251   1.00 0.00 ? 42 GLY A O    3 
+ATOM   3322 H  H    . GLY A 1 42 ? -1.656  13.067  -1.446  1.00 0.00 ? 42 GLY A H    3 
+ATOM   3323 H  HA2  . GLY A 1 42 ? -0.963  15.902  -0.888  1.00 0.00 ? 42 GLY A HA2  3 
+ATOM   3324 H  HA3  . GLY A 1 42 ? -2.667  15.487  -1.095  1.00 0.00 ? 42 GLY A HA3  3 
+ATOM   3325 N  N    . ALA A 1 43 ? -2.930  14.701  1.258   1.00 0.00 ? 43 ALA A N    3 
+ATOM   3326 C  CA   . ALA A 1 43 ? -3.055  14.264  2.675   1.00 0.00 ? 43 ALA A CA   3 
+ATOM   3327 C  C    . ALA A 1 43 ? -4.448  13.677  2.911   1.00 0.00 ? 43 ALA A C    3 
+ATOM   3328 O  O    . ALA A 1 43 ? -5.182  14.126  3.769   1.00 0.00 ? 43 ALA A O    3 
+ATOM   3329 C  CB   . ALA A 1 43 ? -2.844  15.467  3.598   1.00 0.00 ? 43 ALA A CB   3 
+ATOM   3330 H  H    . ALA A 1 43 ? -3.720  15.017  0.770   1.00 0.00 ? 43 ALA A H    3 
+ATOM   3331 H  HA   . ALA A 1 43 ? -2.308  13.513  2.887   1.00 0.00 ? 43 ALA A HA   3 
+ATOM   3332 H  HB1  . ALA A 1 43 ? -2.402  16.278  3.037   1.00 0.00 ? 43 ALA A HB1  3 
+ATOM   3333 H  HB2  . ALA A 1 43 ? -3.794  15.783  4.001   1.00 0.00 ? 43 ALA A HB2  3 
+ATOM   3334 H  HB3  . ALA A 1 43 ? -2.184  15.189  4.407   1.00 0.00 ? 43 ALA A HB3  3 
+ATOM   3335 N  N    . CYS A 1 44 ? -4.823  12.676  2.158   1.00 0.00 ? 44 CYS A N    3 
+ATOM   3336 C  CA   . CYS A 1 44 ? -6.172  12.073  2.354   1.00 0.00 ? 44 CYS A CA   3 
+ATOM   3337 C  C    . CYS A 1 44 ? -6.035  10.646  2.878   1.00 0.00 ? 44 CYS A C    3 
+ATOM   3338 O  O    . CYS A 1 44 ? -4.974  10.056  2.841   1.00 0.00 ? 44 CYS A O    3 
+ATOM   3339 C  CB   . CYS A 1 44 ? -6.939  12.062  1.019   1.00 0.00 ? 44 CYS A CB   3 
+ATOM   3340 S  SG   . CYS A 1 44 ? -6.311  10.751  -0.078  1.00 0.00 ? 44 CYS A SG   3 
+ATOM   3341 H  H    . CYS A 1 44 ? -4.220  12.324  1.470   1.00 0.00 ? 44 CYS A H    3 
+ATOM   3342 H  HA   . CYS A 1 44 ? -6.722  12.663  3.072   1.00 0.00 ? 44 CYS A HA   3 
+ATOM   3343 H  HB2  . CYS A 1 44 ? -7.986  11.887  1.215   1.00 0.00 ? 44 CYS A HB2  3 
+ATOM   3344 H  HB3  . CYS A 1 44 ? -6.827  13.021  0.537   1.00 0.00 ? 44 CYS A HB3  3 
+ATOM   3345 N  N    . SER A 1 45 ? -7.109  10.087  3.357   1.00 0.00 ? 45 SER A N    3 
+ATOM   3346 C  CA   . SER A 1 45 ? -7.055  8.695   3.878   1.00 0.00 ? 45 SER A CA   3 
+ATOM   3347 C  C    . SER A 1 45 ? -7.682  7.756   2.847   1.00 0.00 ? 45 SER A C    3 
+ATOM   3348 O  O    . SER A 1 45 ? -7.616  6.549   2.974   1.00 0.00 ? 45 SER A O    3 
+ATOM   3349 C  CB   . SER A 1 45 ? -7.833  8.609   5.191   1.00 0.00 ? 45 SER A CB   3 
+ATOM   3350 O  OG   . SER A 1 45 ? -7.040  9.151   6.239   1.00 0.00 ? 45 SER A OG   3 
+ATOM   3351 H  H    . SER A 1 45 ? -7.954  10.581  3.370   1.00 0.00 ? 45 SER A H    3 
+ATOM   3352 H  HA   . SER A 1 45 ? -6.027  8.411   4.046   1.00 0.00 ? 45 SER A HA   3 
+ATOM   3353 H  HB2  . SER A 1 45 ? -8.748  9.173   5.110   1.00 0.00 ? 45 SER A HB2  3 
+ATOM   3354 H  HB3  . SER A 1 45 ? -8.068  7.574   5.402   1.00 0.00 ? 45 SER A HB3  3 
+ATOM   3355 H  HG   . SER A 1 45 ? -7.151  10.104  6.231   1.00 0.00 ? 45 SER A HG   3 
+ATOM   3356 N  N    . THR A 1 46 ? -8.287  8.302   1.823   1.00 0.00 ? 46 THR A N    3 
+ATOM   3357 C  CA   . THR A 1 46 ? -8.911  7.441   0.781   1.00 0.00 ? 46 THR A CA   3 
+ATOM   3358 C  C    . THR A 1 46 ? -7.954  6.296   0.451   1.00 0.00 ? 46 THR A C    3 
+ATOM   3359 O  O    . THR A 1 46 ? -8.337  5.146   0.447   1.00 0.00 ? 46 THR A O    3 
+ATOM   3360 C  CB   . THR A 1 46 ? -9.182  8.269   -0.479  1.00 0.00 ? 46 THR A CB   3 
+ATOM   3361 O  OG1  . THR A 1 46 ? -7.954  8.540   -1.138  1.00 0.00 ? 46 THR A OG1  3 
+ATOM   3362 C  CG2  . THR A 1 46 ? -9.859  9.587   -0.093  1.00 0.00 ? 46 THR A CG2  3 
+ATOM   3363 H  H    . THR A 1 46 ? -8.326  9.277   1.738   1.00 0.00 ? 46 THR A H    3 
+ATOM   3364 H  HA   . THR A 1 46 ? -9.840  7.037   1.156   1.00 0.00 ? 46 THR A HA   3 
+ATOM   3365 H  HB   . THR A 1 46 ? -9.833  7.717   -1.140  1.00 0.00 ? 46 THR A HB   3 
+ATOM   3366 H  HG1  . THR A 1 46 ? -8.041  9.380   -1.594  1.00 0.00 ? 46 THR A HG1  3 
+ATOM   3367 H  HG21 . THR A 1 46 ? -10.342 9.475   0.868   1.00 0.00 ? 46 THR A HG21 3 
+ATOM   3368 H  HG22 . THR A 1 46 ? -9.116  10.368  -0.034  1.00 0.00 ? 46 THR A HG22 3 
+ATOM   3369 H  HG23 . THR A 1 46 ? -10.597 9.845   -0.838  1.00 0.00 ? 46 THR A HG23 3 
+ATOM   3370 N  N    . CYS A 1 47 ? -6.709  6.605   0.191   1.00 0.00 ? 47 CYS A N    3 
+ATOM   3371 C  CA   . CYS A 1 47 ? -5.721  5.528   -0.122  1.00 0.00 ? 47 CYS A CA   3 
+ATOM   3372 C  C    . CYS A 1 47 ? -5.194  4.929   1.186   1.00 0.00 ? 47 CYS A C    3 
+ATOM   3373 O  O    . CYS A 1 47 ? -4.029  5.049   1.508   1.00 0.00 ? 47 CYS A O    3 
+ATOM   3374 C  CB   . CYS A 1 47 ? -4.546  6.081   -0.929  1.00 0.00 ? 47 CYS A CB   3 
+ATOM   3375 S  SG   . CYS A 1 47 ? -4.002  7.674   -0.263  1.00 0.00 ? 47 CYS A SG   3 
+ATOM   3376 H  H    . CYS A 1 47 ? -6.426  7.541   0.212   1.00 0.00 ? 47 CYS A H    3 
+ATOM   3377 H  HA   . CYS A 1 47 ? -6.212  4.753   -0.694  1.00 0.00 ? 47 CYS A HA   3 
+ATOM   3378 H  HB2  . CYS A 1 47 ? -3.725  5.380   -0.887  1.00 0.00 ? 47 CYS A HB2  3 
+ATOM   3379 H  HB3  . CYS A 1 47 ? -4.850  6.210   -1.957  1.00 0.00 ? 47 CYS A HB3  3 
+ATOM   3380 N  N    . ALA A 1 48 ? -6.044  4.287   1.945   1.00 0.00 ? 48 ALA A N    3 
+ATOM   3381 C  CA   . ALA A 1 48 ? -5.595  3.681   3.231   1.00 0.00 ? 48 ALA A CA   3 
+ATOM   3382 C  C    . ALA A 1 48 ? -5.799  2.163   3.176   1.00 0.00 ? 48 ALA A C    3 
+ATOM   3383 O  O    . ALA A 1 48 ? -6.900  1.684   2.989   1.00 0.00 ? 48 ALA A O    3 
+ATOM   3384 C  CB   . ALA A 1 48 ? -6.414  4.267   4.381   1.00 0.00 ? 48 ALA A CB   3 
+ATOM   3385 H  H    . ALA A 1 48 ? -6.978  4.202   1.670   1.00 0.00 ? 48 ALA A H    3 
+ATOM   3386 H  HA   . ALA A 1 48 ? -4.548  3.899   3.387   1.00 0.00 ? 48 ALA A HA   3 
+ATOM   3387 H  HB1  . ALA A 1 48 ? -6.289  5.339   4.403   1.00 0.00 ? 48 ALA A HB1  3 
+ATOM   3388 H  HB2  . ALA A 1 48 ? -7.458  4.029   4.237   1.00 0.00 ? 48 ALA A HB2  3 
+ATOM   3389 H  HB3  . ALA A 1 48 ? -6.075  3.844   5.316   1.00 0.00 ? 48 ALA A HB3  3 
+ATOM   3390 N  N    . GLY A 1 49 ? -4.750  1.404   3.335   1.00 0.00 ? 49 GLY A N    3 
+ATOM   3391 C  CA   . GLY A 1 49 ? -4.892  -0.080  3.289   1.00 0.00 ? 49 GLY A CA   3 
+ATOM   3392 C  C    . GLY A 1 49 ? -4.600  -0.661  4.671   1.00 0.00 ? 49 GLY A C    3 
+ATOM   3393 O  O    . GLY A 1 49 ? -4.695  0.019   5.674   1.00 0.00 ? 49 GLY A O    3 
+ATOM   3394 H  H    . GLY A 1 49 ? -3.869  1.808   3.484   1.00 0.00 ? 49 GLY A H    3 
+ATOM   3395 H  HA2  . GLY A 1 49 ? -5.899  -0.336  2.993   1.00 0.00 ? 49 GLY A HA2  3 
+ATOM   3396 H  HA3  . GLY A 1 49 ? -4.191  -0.488  2.575   1.00 0.00 ? 49 GLY A HA3  3 
+ATOM   3397 N  N    . LYS A 1 50 ? -4.240  -1.914  4.736   1.00 0.00 ? 50 LYS A N    3 
+ATOM   3398 C  CA   . LYS A 1 50 ? -3.937  -2.532  6.052   1.00 0.00 ? 50 LYS A CA   3 
+ATOM   3399 C  C    . LYS A 1 50 ? -2.485  -3.001  6.056   1.00 0.00 ? 50 LYS A C    3 
+ATOM   3400 O  O    . LYS A 1 50 ? -2.185  -4.144  5.764   1.00 0.00 ? 50 LYS A O    3 
+ATOM   3401 C  CB   . LYS A 1 50 ? -4.861  -3.725  6.277   1.00 0.00 ? 50 LYS A CB   3 
+ATOM   3402 C  CG   . LYS A 1 50 ? -5.078  -3.930  7.779   1.00 0.00 ? 50 LYS A CG   3 
+ATOM   3403 C  CD   . LYS A 1 50 ? -6.444  -3.370  8.182   1.00 0.00 ? 50 LYS A CD   3 
+ATOM   3404 C  CE   . LYS A 1 50 ? -6.586  -3.417  9.705   1.00 0.00 ? 50 LYS A CE   3 
+ATOM   3405 N  NZ   . LYS A 1 50 ? -6.038  -2.161  10.293  1.00 0.00 ? 50 LYS A NZ   3 
+ATOM   3406 H  H    . LYS A 1 50 ? -4.164  -2.448  3.918   1.00 0.00 ? 50 LYS A H    3 
+ATOM   3407 H  HA   . LYS A 1 50 ? -4.086  -1.806  6.837   1.00 0.00 ? 50 LYS A HA   3 
+ATOM   3408 H  HB2  . LYS A 1 50 ? -5.809  -3.537  5.796   1.00 0.00 ? 50 LYS A HB2  3 
+ATOM   3409 H  HB3  . LYS A 1 50 ? -4.411  -4.610  5.855   1.00 0.00 ? 50 LYS A HB3  3 
+ATOM   3410 H  HG2  . LYS A 1 50 ? -5.040  -4.985  8.007   1.00 0.00 ? 50 LYS A HG2  3 
+ATOM   3411 H  HG3  . LYS A 1 50 ? -4.304  -3.414  8.327   1.00 0.00 ? 50 LYS A HG3  3 
+ATOM   3412 H  HD2  . LYS A 1 50 ? -6.529  -2.347  7.843   1.00 0.00 ? 50 LYS A HD2  3 
+ATOM   3413 H  HD3  . LYS A 1 50 ? -7.225  -3.964  7.732   1.00 0.00 ? 50 LYS A HD3  3 
+ATOM   3414 H  HE2  . LYS A 1 50 ? -7.629  -3.512  9.967   1.00 0.00 ? 50 LYS A HE2  3 
+ATOM   3415 H  HE3  . LYS A 1 50 ? -6.038  -4.264  10.091  1.00 0.00 ? 50 LYS A HE3  3 
+ATOM   3416 H  HZ1  . LYS A 1 50 ? -6.271  -1.358  9.675   1.00 0.00 ? 50 LYS A HZ1  3 
+ATOM   3417 H  HZ2  . LYS A 1 50 ? -6.456  -2.007  11.232  1.00 0.00 ? 50 LYS A HZ2  3 
+ATOM   3418 H  HZ3  . LYS A 1 50 ? -5.004  -2.243  10.382  1.00 0.00 ? 50 LYS A HZ3  3 
+ATOM   3419 N  N    . ILE A 1 51 ? -1.584  -2.118  6.380   1.00 0.00 ? 51 ILE A N    3 
+ATOM   3420 C  CA   . ILE A 1 51 ? -0.142  -2.483  6.408   1.00 0.00 ? 51 ILE A CA   3 
+ATOM   3421 C  C    . ILE A 1 51 ? 0.307   -2.925  5.019   1.00 0.00 ? 51 ILE A C    3 
+ATOM   3422 O  O    . ILE A 1 51 ? 1.375   -3.461  4.836   1.00 0.00 ? 51 ILE A O    3 
+ATOM   3423 C  CB   . ILE A 1 51 ? 0.078   -3.596  7.446   1.00 0.00 ? 51 ILE A CB   3 
+ATOM   3424 C  CG1  . ILE A 1 51 ? -0.211  -3.051  8.847   1.00 0.00 ? 51 ILE A CG1  3 
+ATOM   3425 C  CG2  . ILE A 1 51 ? 1.525   -4.096  7.400   1.00 0.00 ? 51 ILE A CG2  3 
+ATOM   3426 C  CD1  . ILE A 1 51 ? -1.720  -2.870  9.024   1.00 0.00 ? 51 ILE A CD1  3 
+ATOM   3427 H  H    . ILE A 1 51 ? -1.857  -1.205  6.605   1.00 0.00 ? 51 ILE A H    3 
+ATOM   3428 H  HA   . ILE A 1 51 ? 0.421   -1.621  6.675   1.00 0.00 ? 51 ILE A HA   3 
+ATOM   3429 H  HB   . ILE A 1 51 ? -0.592  -4.414  7.238   1.00 0.00 ? 51 ILE A HB   3 
+ATOM   3430 H  HG12 . ILE A 1 51 ? 0.156   -3.749  9.586   1.00 0.00 ? 51 ILE A HG12 3 
+ATOM   3431 H  HG13 . ILE A 1 51 ? 0.283   -2.101  8.973   1.00 0.00 ? 51 ILE A HG13 3 
+ATOM   3432 H  HG21 . ILE A 1 51 ? 2.101   -3.480  6.736   1.00 0.00 ? 51 ILE A HG21 3 
+ATOM   3433 H  HG22 . ILE A 1 51 ? 1.952   -4.049  8.391   1.00 0.00 ? 51 ILE A HG22 3 
+ATOM   3434 H  HG23 . ILE A 1 51 ? 1.547   -5.114  7.050   1.00 0.00 ? 51 ILE A HG23 3 
+ATOM   3435 H  HD11 . ILE A 1 51 ? -2.239  -3.691  8.552   1.00 0.00 ? 51 ILE A HD11 3 
+ATOM   3436 H  HD12 . ILE A 1 51 ? -1.959  -2.850  10.077  1.00 0.00 ? 51 ILE A HD12 3 
+ATOM   3437 H  HD13 . ILE A 1 51 ? -2.026  -1.940  8.569   1.00 0.00 ? 51 ILE A HD13 3 
+ATOM   3438 N  N    . THR A 1 52 ? -0.485  -2.644  4.032   1.00 0.00 ? 52 THR A N    3 
+ATOM   3439 C  CA   . THR A 1 52 ? -0.109  -3.010  2.626   1.00 0.00 ? 52 THR A CA   3 
+ATOM   3440 C  C    . THR A 1 52 ? 0.998   -2.096  2.129   1.00 0.00 ? 52 THR A C    3 
+ATOM   3441 O  O    . THR A 1 52 ? 1.378   -2.136  0.975   1.00 0.00 ? 52 THR A O    3 
+ATOM   3442 C  CB   . THR A 1 52 ? -1.304  -2.841  1.690   1.00 0.00 ? 52 THR A CB   3 
+ATOM   3443 O  OG1  . THR A 1 52 ? -0.833  -2.676  0.359   1.00 0.00 ? 52 THR A OG1  3 
+ATOM   3444 C  CG2  . THR A 1 52 ? -2.116  -1.609  2.096   1.00 0.00 ? 52 THR A CG2  3 
+ATOM   3445 H  H    . THR A 1 52 ? -1.312  -2.163  4.216   1.00 0.00 ? 52 THR A H    3 
+ATOM   3446 H  HA   . THR A 1 52 ? 0.227   -4.032  2.595   1.00 0.00 ? 52 THR A HA   3 
+ATOM   3447 H  HB   . THR A 1 52 ? -1.922  -3.713  1.739   1.00 0.00 ? 52 THR A HB   3 
+ATOM   3448 H  HG1  . THR A 1 52 ? -1.051  -3.470  -0.133  1.00 0.00 ? 52 THR A HG1  3 
+ATOM   3449 H  HG21 . THR A 1 52 ? -1.449  -0.777  2.266   1.00 0.00 ? 52 THR A HG21 3 
+ATOM   3450 H  HG22 . THR A 1 52 ? -2.809  -1.358  1.305   1.00 0.00 ? 52 THR A HG22 3 
+ATOM   3451 H  HG23 . THR A 1 52 ? -2.666  -1.821  3.001   1.00 0.00 ? 52 THR A HG23 3 
+ATOM   3452 N  N    . ALA A 1 53 ? 1.499   -1.255  2.970   1.00 0.00 ? 53 ALA A N    3 
+ATOM   3453 C  CA   . ALA A 1 53 ? 2.552   -0.328  2.527   1.00 0.00 ? 53 ALA A CA   3 
+ATOM   3454 C  C    . ALA A 1 53 ? 3.931   -0.912  2.810   1.00 0.00 ? 53 ALA A C    3 
+ATOM   3455 O  O    . ALA A 1 53 ? 4.847   -0.716  2.044   1.00 0.00 ? 53 ALA A O    3 
+ATOM   3456 C  CB   . ALA A 1 53 ? 2.395   1.007   3.253   1.00 0.00 ? 53 ALA A CB   3 
+ATOM   3457 H  H    . ALA A 1 53 ? 1.173   -1.220  3.882   1.00 0.00 ? 53 ALA A H    3 
+ATOM   3458 H  HA   . ALA A 1 53 ? 2.445   -0.170  1.476   1.00 0.00 ? 53 ALA A HA   3 
+ATOM   3459 H  HB1  . ALA A 1 53 ? 1.890   0.845   4.193   1.00 0.00 ? 53 ALA A HB1  3 
+ATOM   3460 H  HB2  . ALA A 1 53 ? 3.369   1.432   3.435   1.00 0.00 ? 53 ALA A HB2  3 
+ATOM   3461 H  HB3  . ALA A 1 53 ? 1.814   1.682   2.643   1.00 0.00 ? 53 ALA A HB3  3 
+ATOM   3462 N  N    . GLY A 1 54 ? 4.093   -1.617  3.902   1.00 0.00 ? 54 GLY A N    3 
+ATOM   3463 C  CA   . GLY A 1 54 ? 5.435   -2.190  4.227   1.00 0.00 ? 54 GLY A CA   3 
+ATOM   3464 C  C    . GLY A 1 54 ? 6.476   -1.099  3.993   1.00 0.00 ? 54 GLY A C    3 
+ATOM   3465 O  O    . GLY A 1 54 ? 6.752   -0.292  4.852   1.00 0.00 ? 54 GLY A O    3 
+ATOM   3466 H  H    . GLY A 1 54 ? 3.338   -1.758  4.506   1.00 0.00 ? 54 GLY A H    3 
+ATOM   3467 H  HA2  . GLY A 1 54 ? 5.457   -2.506  5.262   1.00 0.00 ? 54 GLY A HA2  3 
+ATOM   3468 H  HA3  . GLY A 1 54 ? 5.641   -3.031  3.582   1.00 0.00 ? 54 GLY A HA3  3 
+ATOM   3469 N  N    . SER A 1 55 ? 7.008   -1.039  2.811   1.00 0.00 ? 55 SER A N    3 
+ATOM   3470 C  CA   . SER A 1 55 ? 7.974   0.031   2.471   1.00 0.00 ? 55 SER A CA   3 
+ATOM   3471 C  C    . SER A 1 55 ? 7.364   0.804   1.301   1.00 0.00 ? 55 SER A C    3 
+ATOM   3472 O  O    . SER A 1 55 ? 6.586   0.251   0.558   1.00 0.00 ? 55 SER A O    3 
+ATOM   3473 C  CB   . SER A 1 55 ? 9.312   -0.582  2.059   1.00 0.00 ? 55 SER A CB   3 
+ATOM   3474 O  OG   . SER A 1 55 ? 9.105   -1.925  1.645   1.00 0.00 ? 55 SER A OG   3 
+ATOM   3475 H  H    . SER A 1 55 ? 6.732   -1.678  2.125   1.00 0.00 ? 55 SER A H    3 
+ATOM   3476 H  HA   . SER A 1 55 ? 8.109   0.686   3.314   1.00 0.00 ? 55 SER A HA   3 
+ATOM   3477 H  HB2  . SER A 1 55 ? 9.729   -0.017  1.244   1.00 0.00 ? 55 SER A HB2  3 
+ATOM   3478 H  HB3  . SER A 1 55 ? 9.993   -0.553  2.900   1.00 0.00 ? 55 SER A HB3  3 
+ATOM   3479 H  HG   . SER A 1 55 ? 8.805   -2.427  2.407   1.00 0.00 ? 55 SER A HG   3 
+ATOM   3480 N  N    . VAL A 1 56 ? 7.686   2.061   1.131   1.00 0.00 ? 56 VAL A N    3 
+ATOM   3481 C  CA   . VAL A 1 56 ? 7.094   2.838   -0.006  1.00 0.00 ? 56 VAL A CA   3 
+ATOM   3482 C  C    . VAL A 1 56 ? 7.153   4.337   0.315   1.00 0.00 ? 56 VAL A C    3 
+ATOM   3483 O  O    . VAL A 1 56 ? 7.401   4.729   1.438   1.00 0.00 ? 56 VAL A O    3 
+ATOM   3484 C  CB   . VAL A 1 56 ? 5.623   2.432   -0.211  1.00 0.00 ? 56 VAL A CB   3 
+ATOM   3485 C  CG1  . VAL A 1 56 ? 4.940   2.301   1.150   1.00 0.00 ? 56 VAL A CG1  3 
+ATOM   3486 C  CG2  . VAL A 1 56 ? 4.880   3.492   -1.034  1.00 0.00 ? 56 VAL A CG2  3 
+ATOM   3487 H  H    . VAL A 1 56 ? 8.311   2.494   1.747   1.00 0.00 ? 56 VAL A H    3 
+ATOM   3488 H  HA   . VAL A 1 56 ? 7.659   2.628   -0.907  1.00 0.00 ? 56 VAL A HA   3 
+ATOM   3489 H  HB   . VAL A 1 56 ? 5.579   1.484   -0.728  1.00 0.00 ? 56 VAL A HB   3 
+ATOM   3490 H  HG11 . VAL A 1 56 ? 5.383   3.002   1.843   1.00 0.00 ? 56 VAL A HG11 3 
+ATOM   3491 H  HG12 . VAL A 1 56 ? 3.886   2.516   1.047   1.00 0.00 ? 56 VAL A HG12 3 
+ATOM   3492 H  HG13 . VAL A 1 56 ? 5.066   1.298   1.524   1.00 0.00 ? 56 VAL A HG13 3 
+ATOM   3493 H  HG21 . VAL A 1 56 ? 5.394   3.653   -1.969  1.00 0.00 ? 56 VAL A HG21 3 
+ATOM   3494 H  HG22 . VAL A 1 56 ? 3.875   3.153   -1.234  1.00 0.00 ? 56 VAL A HG22 3 
+ATOM   3495 H  HG23 . VAL A 1 56 ? 4.843   4.418   -0.479  1.00 0.00 ? 56 VAL A HG23 3 
+ATOM   3496 N  N    . ASP A 1 57 ? 6.908   5.179   -0.656  1.00 0.00 ? 57 ASP A N    3 
+ATOM   3497 C  CA   . ASP A 1 57 ? 6.934   6.643   -0.393  1.00 0.00 ? 57 ASP A CA   3 
+ATOM   3498 C  C    . ASP A 1 57 ? 8.193   6.978   0.402   1.00 0.00 ? 57 ASP A C    3 
+ATOM   3499 O  O    . ASP A 1 57 ? 8.198   7.848   1.250   1.00 0.00 ? 57 ASP A O    3 
+ATOM   3500 C  CB   . ASP A 1 57 ? 5.696   7.029   0.411   1.00 0.00 ? 57 ASP A CB   3 
+ATOM   3501 C  CG   . ASP A 1 57 ? 5.736   8.525   0.728   1.00 0.00 ? 57 ASP A CG   3 
+ATOM   3502 O  OD1  . ASP A 1 57 ? 5.355   9.302   -0.131  1.00 0.00 ? 57 ASP A OD1  3 
+ATOM   3503 O  OD2  . ASP A 1 57 ? 6.148   8.867   1.825   1.00 0.00 ? 57 ASP A OD2  3 
+ATOM   3504 H  H    . ASP A 1 57 ? 6.702   4.848   -1.554  1.00 0.00 ? 57 ASP A H    3 
+ATOM   3505 H  HA   . ASP A 1 57 ? 6.938   7.182   -1.328  1.00 0.00 ? 57 ASP A HA   3 
+ATOM   3506 H  HB2  . ASP A 1 57 ? 4.812   6.805   -0.169  1.00 0.00 ? 57 ASP A HB2  3 
+ATOM   3507 H  HB3  . ASP A 1 57 ? 5.676   6.467   1.331   1.00 0.00 ? 57 ASP A HB3  3 
+ATOM   3508 N  N    . GLN A 1 58 ? 9.259   6.277   0.136   1.00 0.00 ? 58 GLN A N    3 
+ATOM   3509 C  CA   . GLN A 1 58 ? 10.524  6.523   0.873   1.00 0.00 ? 58 GLN A CA   3 
+ATOM   3510 C  C    . GLN A 1 58 ? 10.835  8.024   0.908   1.00 0.00 ? 58 GLN A C    3 
+ATOM   3511 O  O    . GLN A 1 58 ? 11.578  8.489   1.750   1.00 0.00 ? 58 GLN A O    3 
+ATOM   3512 C  CB   . GLN A 1 58 ? 11.669  5.780   0.181   1.00 0.00 ? 58 GLN A CB   3 
+ATOM   3513 C  CG   . GLN A 1 58 ? 12.342  4.835   1.178   1.00 0.00 ? 58 GLN A CG   3 
+ATOM   3514 C  CD   . GLN A 1 58 ? 11.276  3.980   1.867   1.00 0.00 ? 58 GLN A CD   3 
+ATOM   3515 O  OE1  . GLN A 1 58 ? 10.204  3.777   1.331   1.00 0.00 ? 58 GLN A OE1  3 
+ATOM   3516 N  NE2  . GLN A 1 58 ? 11.524  3.468   3.041   1.00 0.00 ? 58 GLN A NE2  3 
+ATOM   3517 H  H    . GLN A 1 58 ? 9.222   5.575   -0.540  1.00 0.00 ? 58 GLN A H    3 
+ATOM   3518 H  HA   . GLN A 1 58 ? 10.416  6.153   1.873   1.00 0.00 ? 58 GLN A HA   3 
+ATOM   3519 H  HB2  . GLN A 1 58 ? 11.278  5.211   -0.651  1.00 0.00 ? 58 GLN A HB2  3 
+ATOM   3520 H  HB3  . GLN A 1 58 ? 12.395  6.493   -0.181  1.00 0.00 ? 58 GLN A HB3  3 
+ATOM   3521 H  HG2  . GLN A 1 58 ? 13.035  4.192   0.653   1.00 0.00 ? 58 GLN A HG2  3 
+ATOM   3522 H  HG3  . GLN A 1 58 ? 12.874  5.411   1.920   1.00 0.00 ? 58 GLN A HG3  3 
+ATOM   3523 H  HE21 . GLN A 1 58 ? 12.388  3.631   3.475   1.00 0.00 ? 58 GLN A HE21 3 
+ATOM   3524 H  HE22 . GLN A 1 58 ? 10.846  2.920   3.491   1.00 0.00 ? 58 GLN A HE22 3 
+ATOM   3525 N  N    . SER A 1 59 ? 10.284  8.782   -0.004  1.00 0.00 ? 59 SER A N    3 
+ATOM   3526 C  CA   . SER A 1 59 ? 10.555  10.251  -0.030  1.00 0.00 ? 59 SER A CA   3 
+ATOM   3527 C  C    . SER A 1 59 ? 10.585  10.809  1.396   1.00 0.00 ? 59 SER A C    3 
+ATOM   3528 O  O    . SER A 1 59 ? 11.397  11.652  1.723   1.00 0.00 ? 59 SER A O    3 
+ATOM   3529 C  CB   . SER A 1 59 ? 9.458   10.959  -0.830  1.00 0.00 ? 59 SER A CB   3 
+ATOM   3530 O  OG   . SER A 1 59 ? 9.881   12.280  -1.155  1.00 0.00 ? 59 SER A OG   3 
+ATOM   3531 H  H    . SER A 1 59 ? 9.696   8.384   -0.679  1.00 0.00 ? 59 SER A H    3 
+ATOM   3532 H  HA   . SER A 1 59 ? 11.511  10.428  -0.503  1.00 0.00 ? 59 SER A HA   3 
+ATOM   3533 H  HB2  . SER A 1 59 ? 9.265   10.415  -1.740  1.00 0.00 ? 59 SER A HB2  3 
+ATOM   3534 H  HB3  . SER A 1 59 ? 8.552   10.996  -0.238  1.00 0.00 ? 59 SER A HB3  3 
+ATOM   3535 H  HG   . SER A 1 59 ? 10.677  12.474  -0.652  1.00 0.00 ? 59 SER A HG   3 
+ATOM   3536 N  N    . ASP A 1 60 ? 9.708   10.353  2.247   1.00 0.00 ? 60 ASP A N    3 
+ATOM   3537 C  CA   . ASP A 1 60 ? 9.696   10.868  3.645   1.00 0.00 ? 60 ASP A CA   3 
+ATOM   3538 C  C    . ASP A 1 60 ? 9.118   12.285  3.657   1.00 0.00 ? 60 ASP A C    3 
+ATOM   3539 O  O    . ASP A 1 60 ? 9.290   13.030  4.602   1.00 0.00 ? 60 ASP A O    3 
+ATOM   3540 C  CB   . ASP A 1 60 ? 11.127  10.897  4.190   1.00 0.00 ? 60 ASP A CB   3 
+ATOM   3541 C  CG   . ASP A 1 60 ? 11.124  10.482  5.663   1.00 0.00 ? 60 ASP A CG   3 
+ATOM   3542 O  OD1  . ASP A 1 60 ? 10.094  10.019  6.125   1.00 0.00 ? 60 ASP A OD1  3 
+ATOM   3543 O  OD2  . ASP A 1 60 ? 12.152  10.634  6.302   1.00 0.00 ? 60 ASP A OD2  3 
+ATOM   3544 H  H    . ASP A 1 60 ? 9.059   9.674   1.968   1.00 0.00 ? 60 ASP A H    3 
+ATOM   3545 H  HA   . ASP A 1 60 ? 9.088   10.224  4.262   1.00 0.00 ? 60 ASP A HA   3 
+ATOM   3546 H  HB2  . ASP A 1 60 ? 11.741  10.211  3.624   1.00 0.00 ? 60 ASP A HB2  3 
+ATOM   3547 H  HB3  . ASP A 1 60 ? 11.527  11.896  4.099   1.00 0.00 ? 60 ASP A HB3  3 
+ATOM   3548 N  N    . GLN A 1 61 ? 8.435   12.662  2.611   1.00 0.00 ? 61 GLN A N    3 
+ATOM   3549 C  CA   . GLN A 1 61 ? 7.848   14.031  2.556   1.00 0.00 ? 61 GLN A CA   3 
+ATOM   3550 C  C    . GLN A 1 61 ? 6.569   14.075  3.397   1.00 0.00 ? 61 GLN A C    3 
+ATOM   3551 O  O    . GLN A 1 61 ? 6.315   13.204  4.205   1.00 0.00 ? 61 GLN A O    3 
+ATOM   3552 C  CB   . GLN A 1 61 ? 7.517   14.383  1.104   1.00 0.00 ? 61 GLN A CB   3 
+ATOM   3553 C  CG   . GLN A 1 61 ? 6.525   13.362  0.544   1.00 0.00 ? 61 GLN A CG   3 
+ATOM   3554 C  CD   . GLN A 1 61 ? 6.774   13.177  -0.954  1.00 0.00 ? 61 GLN A CD   3 
+ATOM   3555 O  OE1  . GLN A 1 61 ? 7.225   14.085  -1.623  1.00 0.00 ? 61 GLN A OE1  3 
+ATOM   3556 N  NE2  . GLN A 1 61 ? 6.497   12.030  -1.513  1.00 0.00 ? 61 GLN A NE2  3 
+ATOM   3557 H  H    . GLN A 1 61 ? 8.311   12.046  1.860   1.00 0.00 ? 61 GLN A H    3 
+ATOM   3558 H  HA   . GLN A 1 61 ? 8.559   14.743  2.945   1.00 0.00 ? 61 GLN A HA   3 
+ATOM   3559 H  HB2  . GLN A 1 61 ? 7.079   15.370  1.065   1.00 0.00 ? 61 GLN A HB2  3 
+ATOM   3560 H  HB3  . GLN A 1 61 ? 8.420   14.365  0.514   1.00 0.00 ? 61 GLN A HB3  3 
+ATOM   3561 H  HG2  . GLN A 1 61 ? 6.657   12.416  1.051   1.00 0.00 ? 61 GLN A HG2  3 
+ATOM   3562 H  HG3  . GLN A 1 61 ? 5.516   13.716  0.698   1.00 0.00 ? 61 GLN A HG3  3 
+ATOM   3563 H  HE21 . GLN A 1 61 ? 6.133   11.298  -0.974  1.00 0.00 ? 61 GLN A HE21 3 
+ATOM   3564 H  HE22 . GLN A 1 61 ? 6.653   11.903  -2.473  1.00 0.00 ? 61 GLN A HE22 3 
+ATOM   3565 N  N    . SER A 1 62 ? 5.760   15.084  3.212   1.00 0.00 ? 62 SER A N    3 
+ATOM   3566 C  CA   . SER A 1 62 ? 4.499   15.180  3.999   1.00 0.00 ? 62 SER A CA   3 
+ATOM   3567 C  C    . SER A 1 62 ? 3.552   14.054  3.578   1.00 0.00 ? 62 SER A C    3 
+ATOM   3568 O  O    . SER A 1 62 ? 3.979   12.968  3.237   1.00 0.00 ? 62 SER A O    3 
+ATOM   3569 C  CB   . SER A 1 62 ? 3.835   16.533  3.740   1.00 0.00 ? 62 SER A CB   3 
+ATOM   3570 O  OG   . SER A 1 62 ? 4.822   17.471  3.332   1.00 0.00 ? 62 SER A OG   3 
+ATOM   3571 H  H    . SER A 1 62 ? 5.981   15.775  2.554   1.00 0.00 ? 62 SER A H    3 
+ATOM   3572 H  HA   . SER A 1 62 ? 4.724   15.085  5.052   1.00 0.00 ? 62 SER A HA   3 
+ATOM   3573 H  HB2  . SER A 1 62 ? 3.098   16.432  2.960   1.00 0.00 ? 62 SER A HB2  3 
+ATOM   3574 H  HB3  . SER A 1 62 ? 3.351   16.875  4.646   1.00 0.00 ? 62 SER A HB3  3 
+ATOM   3575 H  HG   . SER A 1 62 ? 4.505   18.349  3.553   1.00 0.00 ? 62 SER A HG   3 
+ATOM   3576 N  N    . PHE A 1 63 ? 2.269   14.298  3.600   1.00 0.00 ? 63 PHE A N    3 
+ATOM   3577 C  CA   . PHE A 1 63 ? 1.303   13.236  3.203   1.00 0.00 ? 63 PHE A CA   3 
+ATOM   3578 C  C    . PHE A 1 63 ? 1.307   12.125  4.255   1.00 0.00 ? 63 PHE A C    3 
+ATOM   3579 O  O    . PHE A 1 63 ? 2.180   11.280  4.274   1.00 0.00 ? 63 PHE A O    3 
+ATOM   3580 C  CB   . PHE A 1 63 ? 1.712   12.650  1.849   1.00 0.00 ? 63 PHE A CB   3 
+ATOM   3581 C  CG   . PHE A 1 63 ? 2.259   13.741  0.959   1.00 0.00 ? 63 PHE A CG   3 
+ATOM   3582 C  CD1  . PHE A 1 63 ? 1.786   15.055  1.079   1.00 0.00 ? 63 PHE A CD1  3 
+ATOM   3583 C  CD2  . PHE A 1 63 ? 3.238   13.435  0.006   1.00 0.00 ? 63 PHE A CD2  3 
+ATOM   3584 C  CE1  . PHE A 1 63 ? 2.293   16.060  0.246   1.00 0.00 ? 63 PHE A CE1  3 
+ATOM   3585 C  CE2  . PHE A 1 63 ? 3.744   14.441  -0.826  1.00 0.00 ? 63 PHE A CE2  3 
+ATOM   3586 C  CZ   . PHE A 1 63 ? 3.272   15.753  -0.707  1.00 0.00 ? 63 PHE A CZ   3 
+ATOM   3587 H  H    . PHE A 1 63 ? 1.942   15.179  3.879   1.00 0.00 ? 63 PHE A H    3 
+ATOM   3588 H  HA   . PHE A 1 63 ? 0.313   13.659  3.128   1.00 0.00 ? 63 PHE A HA   3 
+ATOM   3589 H  HB2  . PHE A 1 63 ? 2.471   11.897  2.000   1.00 0.00 ? 63 PHE A HB2  3 
+ATOM   3590 H  HB3  . PHE A 1 63 ? 0.850   12.202  1.379   1.00 0.00 ? 63 PHE A HB3  3 
+ATOM   3591 H  HD1  . PHE A 1 63 ? 1.030   15.292  1.814   1.00 0.00 ? 63 PHE A HD1  3 
+ATOM   3592 H  HD2  . PHE A 1 63 ? 3.604   12.423  -0.087  1.00 0.00 ? 63 PHE A HD2  3 
+ATOM   3593 H  HE1  . PHE A 1 63 ? 1.929   17.073  0.338   1.00 0.00 ? 63 PHE A HE1  3 
+ATOM   3594 H  HE2  . PHE A 1 63 ? 4.499   14.203  -1.561  1.00 0.00 ? 63 PHE A HE2  3 
+ATOM   3595 H  HZ   . PHE A 1 63 ? 3.663   16.528  -1.350  1.00 0.00 ? 63 PHE A HZ   3 
+ATOM   3596 N  N    . LEU A 1 64 ? 0.338   12.115  5.129   1.00 0.00 ? 64 LEU A N    3 
+ATOM   3597 C  CA   . LEU A 1 64 ? 0.293   11.053  6.174   1.00 0.00 ? 64 LEU A CA   3 
+ATOM   3598 C  C    . LEU A 1 64 ? 0.303   9.681   5.496   1.00 0.00 ? 64 LEU A C    3 
+ATOM   3599 O  O    . LEU A 1 64 ? 0.414   9.579   4.290   1.00 0.00 ? 64 LEU A O    3 
+ATOM   3600 C  CB   . LEU A 1 64 ? -0.978  11.210  7.010   1.00 0.00 ? 64 LEU A CB   3 
+ATOM   3601 C  CG   . LEU A 1 64 ? -0.630  11.088  8.496   1.00 0.00 ? 64 LEU A CG   3 
+ATOM   3602 C  CD1  . LEU A 1 64 ? 0.480   12.081  8.845   1.00 0.00 ? 64 LEU A CD1  3 
+ATOM   3603 C  CD2  . LEU A 1 64 ? -1.869  11.400  9.336   1.00 0.00 ? 64 LEU A CD2  3 
+ATOM   3604 H  H    . LEU A 1 64 ? -0.360  12.803  5.097   1.00 0.00 ? 64 LEU A H    3 
+ATOM   3605 H  HA   . LEU A 1 64 ? 1.159   11.143  6.811   1.00 0.00 ? 64 LEU A HA   3 
+ATOM   3606 H  HB2  . LEU A 1 64 ? -1.417  12.179  6.820   1.00 0.00 ? 64 LEU A HB2  3 
+ATOM   3607 H  HB3  . LEU A 1 64 ? -1.683  10.437  6.743   1.00 0.00 ? 64 LEU A HB3  3 
+ATOM   3608 H  HG   . LEU A 1 64 ? -0.293  10.083  8.705   1.00 0.00 ? 64 LEU A HG   3 
+ATOM   3609 H  HD11 . LEU A 1 64 ? 0.743   12.653  7.967   1.00 0.00 ? 64 LEU A HD11 3 
+ATOM   3610 H  HD12 . LEU A 1 64 ? 0.135   12.749  9.620   1.00 0.00 ? 64 LEU A HD12 3 
+ATOM   3611 H  HD13 . LEU A 1 64 ? 1.348   11.542  9.195   1.00 0.00 ? 64 LEU A HD13 3 
+ATOM   3612 H  HD21 . LEU A 1 64 ? -2.340  12.297  8.962   1.00 0.00 ? 64 LEU A HD21 3 
+ATOM   3613 H  HD22 . LEU A 1 64 ? -2.564  10.576  9.273   1.00 0.00 ? 64 LEU A HD22 3 
+ATOM   3614 H  HD23 . LEU A 1 64 ? -1.577  11.550  10.365  1.00 0.00 ? 64 LEU A HD23 3 
+ATOM   3615 N  N    . ASP A 1 65 ? 0.197   8.625   6.256   1.00 0.00 ? 65 ASP A N    3 
+ATOM   3616 C  CA   . ASP A 1 65 ? 0.212   7.268   5.638   1.00 0.00 ? 65 ASP A CA   3 
+ATOM   3617 C  C    . ASP A 1 65 ? 1.563   7.054   4.953   1.00 0.00 ? 65 ASP A C    3 
+ATOM   3618 O  O    . ASP A 1 65 ? 2.067   7.931   4.279   1.00 0.00 ? 65 ASP A O    3 
+ATOM   3619 C  CB   . ASP A 1 65 ? -0.908  7.170   4.601   1.00 0.00 ? 65 ASP A CB   3 
+ATOM   3620 C  CG   . ASP A 1 65 ? -2.222  7.650   5.220   1.00 0.00 ? 65 ASP A CG   3 
+ATOM   3621 O  OD1  . ASP A 1 65 ? -2.254  7.836   6.424   1.00 0.00 ? 65 ASP A OD1  3 
+ATOM   3622 O  OD2  . ASP A 1 65 ? -3.175  7.823   4.477   1.00 0.00 ? 65 ASP A OD2  3 
+ATOM   3623 H  H    . ASP A 1 65 ? 0.113   8.723   7.228   1.00 0.00 ? 65 ASP A H    3 
+ATOM   3624 H  HA   . ASP A 1 65 ? 0.068   6.518   6.402   1.00 0.00 ? 65 ASP A HA   3 
+ATOM   3625 H  HB2  . ASP A 1 65 ? -0.664  7.789   3.751   1.00 0.00 ? 65 ASP A HB2  3 
+ATOM   3626 H  HB3  . ASP A 1 65 ? -1.015  6.144   4.282   1.00 0.00 ? 65 ASP A HB3  3 
+ATOM   3627 N  N    . ASP A 1 66 ? 2.166   5.908   5.124   1.00 0.00 ? 66 ASP A N    3 
+ATOM   3628 C  CA   . ASP A 1 66 ? 3.488   5.675   4.482   1.00 0.00 ? 66 ASP A CA   3 
+ATOM   3629 C  C    . ASP A 1 66 ? 4.473   6.714   5.012   1.00 0.00 ? 66 ASP A C    3 
+ATOM   3630 O  O    . ASP A 1 66 ? 5.505   6.969   4.425   1.00 0.00 ? 66 ASP A O    3 
+ATOM   3631 C  CB   . ASP A 1 66 ? 3.354   5.827   2.965   1.00 0.00 ? 66 ASP A CB   3 
+ATOM   3632 C  CG   . ASP A 1 66 ? 3.027   4.469   2.342   1.00 0.00 ? 66 ASP A CG   3 
+ATOM   3633 O  OD1  . ASP A 1 66 ? 3.184   3.473   3.026   1.00 0.00 ? 66 ASP A OD1  3 
+ATOM   3634 O  OD2  . ASP A 1 66 ? 2.626   4.450   1.189   1.00 0.00 ? 66 ASP A OD2  3 
+ATOM   3635 H  H    . ASP A 1 66 ? 1.760   5.209   5.679   1.00 0.00 ? 66 ASP A H    3 
+ATOM   3636 H  HA   . ASP A 1 66 ? 3.840   4.682   4.720   1.00 0.00 ? 66 ASP A HA   3 
+ATOM   3637 H  HB2  . ASP A 1 66 ? 2.560   6.526   2.743   1.00 0.00 ? 66 ASP A HB2  3 
+ATOM   3638 H  HB3  . ASP A 1 66 ? 4.282   6.195   2.556   1.00 0.00 ? 66 ASP A HB3  3 
+ATOM   3639 N  N    . ASP A 1 67 ? 4.149   7.322   6.120   1.00 0.00 ? 67 ASP A N    3 
+ATOM   3640 C  CA   . ASP A 1 67 ? 5.044   8.357   6.701   1.00 0.00 ? 67 ASP A CA   3 
+ATOM   3641 C  C    . ASP A 1 67 ? 6.501   7.911   6.597   1.00 0.00 ? 67 ASP A C    3 
+ATOM   3642 O  O    . ASP A 1 67 ? 7.399   8.727   6.530   1.00 0.00 ? 67 ASP A O    3 
+ATOM   3643 C  CB   . ASP A 1 67 ? 4.682   8.577   8.171   1.00 0.00 ? 67 ASP A CB   3 
+ATOM   3644 C  CG   . ASP A 1 67 ? 5.621   9.620   8.777   1.00 0.00 ? 67 ASP A CG   3 
+ATOM   3645 O  OD1  . ASP A 1 67 ? 5.904   10.596  8.102   1.00 0.00 ? 67 ASP A OD1  3 
+ATOM   3646 O  OD2  . ASP A 1 67 ? 6.044   9.425   9.904   1.00 0.00 ? 67 ASP A OD2  3 
+ATOM   3647 H  H    . ASP A 1 67 ? 3.306   7.102   6.568   1.00 0.00 ? 67 ASP A H    3 
+ATOM   3648 H  HA   . ASP A 1 67 ? 4.915   9.284   6.161   1.00 0.00 ? 67 ASP A HA   3 
+ATOM   3649 H  HB2  . ASP A 1 67 ? 3.661   8.924   8.242   1.00 0.00 ? 67 ASP A HB2  3 
+ATOM   3650 H  HB3  . ASP A 1 67 ? 4.785   7.646   8.709   1.00 0.00 ? 67 ASP A HB3  3 
+ATOM   3651 N  N    . GLN A 1 68 ? 6.758   6.630   6.589   1.00 0.00 ? 68 GLN A N    3 
+ATOM   3652 C  CA   . GLN A 1 68 ? 8.175   6.180   6.493   1.00 0.00 ? 68 GLN A CA   3 
+ATOM   3653 C  C    . GLN A 1 68 ? 8.263   4.715   6.058   1.00 0.00 ? 68 GLN A C    3 
+ATOM   3654 O  O    . GLN A 1 68 ? 9.212   4.322   5.408   1.00 0.00 ? 68 GLN A O    3 
+ATOM   3655 C  CB   . GLN A 1 68 ? 8.851   6.343   7.856   1.00 0.00 ? 68 GLN A CB   3 
+ATOM   3656 C  CG   . GLN A 1 68 ? 8.272   5.324   8.839   1.00 0.00 ? 68 GLN A CG   3 
+ATOM   3657 C  CD   . GLN A 1 68 ? 6.847   5.731   9.210   1.00 0.00 ? 68 GLN A CD   3 
+ATOM   3658 O  OE1  . GLN A 1 68 ? 6.593   6.878   9.522   1.00 0.00 ? 68 GLN A OE1  3 
+ATOM   3659 N  NE2  . GLN A 1 68 ? 5.899   4.836   9.191   1.00 0.00 ? 68 GLN A NE2  3 
+ATOM   3660 H  H    . GLN A 1 68 ? 6.030   5.974   6.648   1.00 0.00 ? 68 GLN A H    3 
+ATOM   3661 H  HA   . GLN A 1 68 ? 8.691   6.793   5.768   1.00 0.00 ? 68 GLN A HA   3 
+ATOM   3662 H  HB2  . GLN A 1 68 ? 9.914   6.180   7.752   1.00 0.00 ? 68 GLN A HB2  3 
+ATOM   3663 H  HB3  . GLN A 1 68 ? 8.675   7.340   8.230   1.00 0.00 ? 68 GLN A HB3  3 
+ATOM   3664 H  HG2  . GLN A 1 68 ? 8.260   4.346   8.377   1.00 0.00 ? 68 GLN A HG2  3 
+ATOM   3665 H  HG3  . GLN A 1 68 ? 8.881   5.295   9.730   1.00 0.00 ? 68 GLN A HG3  3 
+ATOM   3666 H  HE21 . GLN A 1 68 ? 6.103   3.911   8.938   1.00 0.00 ? 68 GLN A HE21 3 
+ATOM   3667 H  HE22 . GLN A 1 68 ? 4.982   5.088   9.427   1.00 0.00 ? 68 GLN A HE22 3 
+ATOM   3668 N  N    . ILE A 1 69 ? 7.310   3.888   6.405   1.00 0.00 ? 69 ILE A N    3 
+ATOM   3669 C  CA   . ILE A 1 69 ? 7.419   2.460   5.984   1.00 0.00 ? 69 ILE A CA   3 
+ATOM   3670 C  C    . ILE A 1 69 ? 6.216   1.637   6.458   1.00 0.00 ? 69 ILE A C    3 
+ATOM   3671 O  O    . ILE A 1 69 ? 6.178   1.180   7.582   1.00 0.00 ? 69 ILE A O    3 
+ATOM   3672 C  CB   . ILE A 1 69 ? 8.694   1.864   6.587   1.00 0.00 ? 69 ILE A CB   3 
+ATOM   3673 C  CG1  . ILE A 1 69 ? 8.852   0.411   6.133   1.00 0.00 ? 69 ILE A CG1  3 
+ATOM   3674 C  CG2  . ILE A 1 69 ? 8.605   1.904   8.114   1.00 0.00 ? 69 ILE A CG2  3 
+ATOM   3675 C  CD1  . ILE A 1 69 ? 10.173  -0.149  6.664   1.00 0.00 ? 69 ILE A CD1  3 
+ATOM   3676 H  H    . ILE A 1 69 ? 6.544   4.198   6.936   1.00 0.00 ? 69 ILE A H    3 
+ATOM   3677 H  HA   . ILE A 1 69 ? 7.483   2.410   4.909   1.00 0.00 ? 69 ILE A HA   3 
+ATOM   3678 H  HB   . ILE A 1 69 ? 9.549   2.439   6.263   1.00 0.00 ? 69 ILE A HB   3 
+ATOM   3679 H  HG12 . ILE A 1 69 ? 8.031   -0.176  6.516   1.00 0.00 ? 69 ILE A HG12 3 
+ATOM   3680 H  HG13 . ILE A 1 69 ? 8.853   0.370   5.054   1.00 0.00 ? 69 ILE A HG13 3 
+ATOM   3681 H  HG21 . ILE A 1 69 ? 7.780   2.535   8.409   1.00 0.00 ? 69 ILE A HG21 3 
+ATOM   3682 H  HG22 . ILE A 1 69 ? 8.447   0.905   8.492   1.00 0.00 ? 69 ILE A HG22 3 
+ATOM   3683 H  HG23 . ILE A 1 69 ? 9.525   2.302   8.518   1.00 0.00 ? 69 ILE A HG23 3 
+ATOM   3684 H  HD11 . ILE A 1 69 ? 10.905  0.643   6.714   1.00 0.00 ? 69 ILE A HD11 3 
+ATOM   3685 H  HD12 . ILE A 1 69 ? 10.018  -0.559  7.652   1.00 0.00 ? 69 ILE A HD12 3 
+ATOM   3686 H  HD13 . ILE A 1 69 ? 10.526  -0.926  6.003   1.00 0.00 ? 69 ILE A HD13 3 
+ATOM   3687 N  N    . GLU A 1 70 ? 5.256   1.426   5.590   1.00 0.00 ? 70 GLU A N    3 
+ATOM   3688 C  CA   . GLU A 1 70 ? 4.060   0.602   5.937   1.00 0.00 ? 70 GLU A CA   3 
+ATOM   3689 C  C    . GLU A 1 70 ? 3.036   1.454   6.666   1.00 0.00 ? 70 GLU A C    3 
+ATOM   3690 O  O    . GLU A 1 70 ? 1.980   1.770   6.155   1.00 0.00 ? 70 GLU A O    3 
+ATOM   3691 C  CB   . GLU A 1 70 ? 4.479   -0.562  6.838   1.00 0.00 ? 70 GLU A CB   3 
+ATOM   3692 C  CG   . GLU A 1 70 ? 3.342   -1.574  6.915   1.00 0.00 ? 70 GLU A CG   3 
+ATOM   3693 C  CD   . GLU A 1 70 ? 3.176   -2.041  8.362   1.00 0.00 ? 70 GLU A CD   3 
+ATOM   3694 O  OE1  . GLU A 1 70 ? 3.861   -2.976  8.744   1.00 0.00 ? 70 GLU A OE1  3 
+ATOM   3695 O  OE2  . GLU A 1 70 ? 2.368   -1.456  9.064   1.00 0.00 ? 70 GLU A OE2  3 
+ATOM   3696 H  H    . GLU A 1 70 ? 5.333   1.796   4.695   1.00 0.00 ? 70 GLU A H    3 
+ATOM   3697 H  HA   . GLU A 1 70 ? 3.622   0.210   5.034   1.00 0.00 ? 70 GLU A HA   3 
+ATOM   3698 H  HB2  . GLU A 1 70 ? 5.359   -1.037  6.430   1.00 0.00 ? 70 GLU A HB2  3 
+ATOM   3699 H  HB3  . GLU A 1 70 ? 4.693   -0.197  7.830   1.00 0.00 ? 70 GLU A HB3  3 
+ATOM   3700 H  HG2  . GLU A 1 70 ? 2.425   -1.111  6.577   1.00 0.00 ? 70 GLU A HG2  3 
+ATOM   3701 H  HG3  . GLU A 1 70 ? 3.571   -2.421  6.288   1.00 0.00 ? 70 GLU A HG3  3 
+ATOM   3702 N  N    . ALA A 1 71 ? 3.355   1.822   7.858   1.00 0.00 ? 71 ALA A N    3 
+ATOM   3703 C  CA   . ALA A 1 71 ? 2.433   2.659   8.670   1.00 0.00 ? 71 ALA A CA   3 
+ATOM   3704 C  C    . ALA A 1 71 ? 1.018   2.059   8.690   1.00 0.00 ? 71 ALA A C    3 
+ATOM   3705 O  O    . ALA A 1 71 ? 0.071   2.733   9.045   1.00 0.00 ? 71 ALA A O    3 
+ATOM   3706 C  CB   . ALA A 1 71 ? 2.374   4.065   8.071   1.00 0.00 ? 71 ALA A CB   3 
+ATOM   3707 H  H    . ALA A 1 71 ? 4.220   1.548   8.220   1.00 0.00 ? 71 ALA A H    3 
+ATOM   3708 H  HA   . ALA A 1 71 ? 2.808   2.721   9.680   1.00 0.00 ? 71 ALA A HA   3 
+ATOM   3709 H  HB1  . ALA A 1 71 ? 3.377   4.419   7.886   1.00 0.00 ? 71 ALA A HB1  3 
+ATOM   3710 H  HB2  . ALA A 1 71 ? 1.824   4.037   7.143   1.00 0.00 ? 71 ALA A HB2  3 
+ATOM   3711 H  HB3  . ALA A 1 71 ? 1.880   4.729   8.764   1.00 0.00 ? 71 ALA A HB3  3 
+ATOM   3712 N  N    . GLY A 1 72 ? 0.840   0.811   8.320   1.00 0.00 ? 72 GLY A N    3 
+ATOM   3713 C  CA   . GLY A 1 72 ? -0.533  0.241   8.346   1.00 0.00 ? 72 GLY A CA   3 
+ATOM   3714 C  C    . GLY A 1 72 ? -1.436  1.096   7.465   1.00 0.00 ? 72 GLY A C    3 
+ATOM   3715 O  O    . GLY A 1 72 ? -2.498  1.528   7.868   1.00 0.00 ? 72 GLY A O    3 
+ATOM   3716 H  H    . GLY A 1 72 ? 1.594   0.256   8.029   1.00 0.00 ? 72 GLY A H    3 
+ATOM   3717 H  HA2  . GLY A 1 72 ? -0.515  -0.773  7.976   1.00 0.00 ? 72 GLY A HA2  3 
+ATOM   3718 H  HA3  . GLY A 1 72 ? -0.902  0.252   9.353   1.00 0.00 ? 72 GLY A HA3  3 
+ATOM   3719 N  N    . TYR A 1 73 ? -1.006  1.350   6.266   1.00 0.00 ? 73 TYR A N    3 
+ATOM   3720 C  CA   . TYR A 1 73 ? -1.807  2.187   5.336   1.00 0.00 ? 73 TYR A CA   3 
+ATOM   3721 C  C    . TYR A 1 73 ? -1.503  1.767   3.896   1.00 0.00 ? 73 TYR A C    3 
+ATOM   3722 O  O    . TYR A 1 73 ? -0.920  0.730   3.653   1.00 0.00 ? 73 TYR A O    3 
+ATOM   3723 C  CB   . TYR A 1 73 ? -1.408  3.650   5.528   1.00 0.00 ? 73 TYR A CB   3 
+ATOM   3724 C  CG   . TYR A 1 73 ? -2.500  4.391   6.259   1.00 0.00 ? 73 TYR A CG   3 
+ATOM   3725 C  CD1  . TYR A 1 73 ? -2.507  4.420   7.659   1.00 0.00 ? 73 TYR A CD1  3 
+ATOM   3726 C  CD2  . TYR A 1 73 ? -3.502  5.055   5.541   1.00 0.00 ? 73 TYR A CD2  3 
+ATOM   3727 C  CE1  . TYR A 1 73 ? -3.517  5.110   8.341   1.00 0.00 ? 73 TYR A CE1  3 
+ATOM   3728 C  CE2  . TYR A 1 73 ? -4.511  5.747   6.223   1.00 0.00 ? 73 TYR A CE2  3 
+ATOM   3729 C  CZ   . TYR A 1 73 ? -4.518  5.774   7.623   1.00 0.00 ? 73 TYR A CZ   3 
+ATOM   3730 O  OH   . TYR A 1 73 ? -5.513  6.455   8.297   1.00 0.00 ? 73 TYR A OH   3 
+ATOM   3731 H  H    . TYR A 1 73 ? -0.143  0.995   5.978   1.00 0.00 ? 73 TYR A H    3 
+ATOM   3732 H  HA   . TYR A 1 73 ? -2.859  2.064   5.543   1.00 0.00 ? 73 TYR A HA   3 
+ATOM   3733 H  HB2  . TYR A 1 73 ? -0.494  3.696   6.103   1.00 0.00 ? 73 TYR A HB2  3 
+ATOM   3734 H  HB3  . TYR A 1 73 ? -1.247  4.102   4.564   1.00 0.00 ? 73 TYR A HB3  3 
+ATOM   3735 H  HD1  . TYR A 1 73 ? -1.735  3.908   8.213   1.00 0.00 ? 73 TYR A HD1  3 
+ATOM   3736 H  HD2  . TYR A 1 73 ? -3.496  5.032   4.461   1.00 0.00 ? 73 TYR A HD2  3 
+ATOM   3737 H  HE1  . TYR A 1 73 ? -3.521  5.132   9.420   1.00 0.00 ? 73 TYR A HE1  3 
+ATOM   3738 H  HE2  . TYR A 1 73 ? -5.283  6.260   5.669   1.00 0.00 ? 73 TYR A HE2  3 
+ATOM   3739 H  HH   . TYR A 1 73 ? -5.652  7.294   7.852   1.00 0.00 ? 73 TYR A HH   3 
+ATOM   3740 N  N    . VAL A 1 74 ? -1.879  2.572   2.939   1.00 0.00 ? 74 VAL A N    3 
+ATOM   3741 C  CA   . VAL A 1 74 ? -1.595  2.222   1.518   1.00 0.00 ? 74 VAL A CA   3 
+ATOM   3742 C  C    . VAL A 1 74 ? -1.400  3.498   0.707   1.00 0.00 ? 74 VAL A C    3 
+ATOM   3743 O  O    . VAL A 1 74 ? -1.954  3.658   -0.363  1.00 0.00 ? 74 VAL A O    3 
+ATOM   3744 C  CB   . VAL A 1 74 ? -2.756  1.413   0.933   1.00 0.00 ? 74 VAL A CB   3 
+ATOM   3745 C  CG1  . VAL A 1 74 ? -4.003  2.292   0.856   1.00 0.00 ? 74 VAL A CG1  3 
+ATOM   3746 C  CG2  . VAL A 1 74 ? -2.382  0.938   -0.474  1.00 0.00 ? 74 VAL A CG2  3 
+ATOM   3747 H  H    . VAL A 1 74 ? -2.339  3.410   3.155   1.00 0.00 ? 74 VAL A H    3 
+ATOM   3748 H  HA   . VAL A 1 74 ? -0.692  1.638   1.470   1.00 0.00 ? 74 VAL A HA   3 
+ATOM   3749 H  HB   . VAL A 1 74 ? -2.954  0.559   1.564   1.00 0.00 ? 74 VAL A HB   3 
+ATOM   3750 H  HG11 . VAL A 1 74 ? -4.010  2.973   1.690   1.00 0.00 ? 74 VAL A HG11 3 
+ATOM   3751 H  HG12 . VAL A 1 74 ? -3.992  2.852   -0.068  1.00 0.00 ? 74 VAL A HG12 3 
+ATOM   3752 H  HG13 . VAL A 1 74 ? -4.885  1.670   0.891   1.00 0.00 ? 74 VAL A HG13 3 
+ATOM   3753 H  HG21 . VAL A 1 74 ? -1.364  1.226   -0.692  1.00 0.00 ? 74 VAL A HG21 3 
+ATOM   3754 H  HG22 . VAL A 1 74 ? -2.470  -0.138  -0.526  1.00 0.00 ? 74 VAL A HG22 3 
+ATOM   3755 H  HG23 . VAL A 1 74 ? -3.046  1.389   -1.195  1.00 0.00 ? 74 VAL A HG23 3 
+ATOM   3756 N  N    . LEU A 1 75 ? -0.606  4.406   1.201   1.00 0.00 ? 75 LEU A N    3 
+ATOM   3757 C  CA   . LEU A 1 75 ? -0.366  5.663   0.447   1.00 0.00 ? 75 LEU A CA   3 
+ATOM   3758 C  C    . LEU A 1 75 ? 0.797   5.441   -0.517  1.00 0.00 ? 75 LEU A C    3 
+ATOM   3759 O  O    . LEU A 1 75 ? 1.801   6.125   -0.470  1.00 0.00 ? 75 LEU A O    3 
+ATOM   3760 C  CB   . LEU A 1 75 ? -0.016  6.785   1.424   1.00 0.00 ? 75 LEU A CB   3 
+ATOM   3761 C  CG   . LEU A 1 75 ? -0.583  8.108   0.910   1.00 0.00 ? 75 LEU A CG   3 
+ATOM   3762 C  CD1  . LEU A 1 75 ? -1.865  8.447   1.673   1.00 0.00 ? 75 LEU A CD1  3 
+ATOM   3763 C  CD2  . LEU A 1 75 ? 0.444   9.220   1.125   1.00 0.00 ? 75 LEU A CD2  3 
+ATOM   3764 H  H    . LEU A 1 75 ? -0.160  4.255   2.060   1.00 0.00 ? 75 LEU A H    3 
+ATOM   3765 H  HA   . LEU A 1 75 ? -1.253  5.929   -0.110  1.00 0.00 ? 75 LEU A HA   3 
+ATOM   3766 H  HB2  . LEU A 1 75 ? -0.440  6.561   2.391   1.00 0.00 ? 75 LEU A HB2  3 
+ATOM   3767 H  HB3  . LEU A 1 75 ? 1.057   6.865   1.511   1.00 0.00 ? 75 LEU A HB3  3 
+ATOM   3768 H  HG   . LEU A 1 75 ? -0.805  8.019   -0.144  1.00 0.00 ? 75 LEU A HG   3 
+ATOM   3769 H  HD11 . LEU A 1 75 ? -2.421  7.541   1.863   1.00 0.00 ? 75 LEU A HD11 3 
+ATOM   3770 H  HD12 . LEU A 1 75 ? -1.612  8.917   2.611   1.00 0.00 ? 75 LEU A HD12 3 
+ATOM   3771 H  HD13 . LEU A 1 75 ? -2.466  9.123   1.084   1.00 0.00 ? 75 LEU A HD13 3 
+ATOM   3772 H  HD21 . LEU A 1 75 ? 1.180   8.895   1.846   1.00 0.00 ? 75 LEU A HD21 3 
+ATOM   3773 H  HD22 . LEU A 1 75 ? 0.933   9.445   0.189   1.00 0.00 ? 75 LEU A HD22 3 
+ATOM   3774 H  HD23 . LEU A 1 75 ? -0.055  10.104  1.493   1.00 0.00 ? 75 LEU A HD23 3 
+ATOM   3775 N  N    . THR A 1 76 ? 0.665   4.487   -1.395  1.00 0.00 ? 76 THR A N    3 
+ATOM   3776 C  CA   . THR A 1 76 ? 1.753   4.209   -2.370  1.00 0.00 ? 76 THR A CA   3 
+ATOM   3777 C  C    . THR A 1 76 ? 1.544   5.074   -3.611  1.00 0.00 ? 76 THR A C    3 
+ATOM   3778 O  O    . THR A 1 76 ? 2.240   4.945   -4.600  1.00 0.00 ? 76 THR A O    3 
+ATOM   3779 C  CB   . THR A 1 76 ? 1.711   2.729   -2.751  1.00 0.00 ? 76 THR A CB   3 
+ATOM   3780 O  OG1  . THR A 1 76 ? 2.924   2.368   -3.395  1.00 0.00 ? 76 THR A OG1  3 
+ATOM   3781 C  CG2  . THR A 1 76 ? 0.533   2.468   -3.690  1.00 0.00 ? 76 THR A CG2  3 
+ATOM   3782 H  H    . THR A 1 76 ? -0.156  3.951   -1.414  1.00 0.00 ? 76 THR A H    3 
+ATOM   3783 H  HA   . THR A 1 76 ? 2.708   4.441   -1.924  1.00 0.00 ? 76 THR A HA   3 
+ATOM   3784 H  HB   . THR A 1 76 ? 1.585   2.140   -1.859  1.00 0.00 ? 76 THR A HB   3 
+ATOM   3785 H  HG1  . THR A 1 76 ? 3.015   2.909   -4.182  1.00 0.00 ? 76 THR A HG1  3 
+ATOM   3786 H  HG21 . THR A 1 76 ? 0.571   3.159   -4.516  1.00 0.00 ? 76 THR A HG21 3 
+ATOM   3787 H  HG22 . THR A 1 76 ? 0.587   1.456   -4.064  1.00 0.00 ? 76 THR A HG22 3 
+ATOM   3788 H  HG23 . THR A 1 76 ? -0.391  2.602   -3.151  1.00 0.00 ? 76 THR A HG23 3 
+ATOM   3789 N  N    . CYS A 1 77 ? 0.586   5.955   -3.563  1.00 0.00 ? 77 CYS A N    3 
+ATOM   3790 C  CA   . CYS A 1 77 ? 0.316   6.837   -4.732  1.00 0.00 ? 77 CYS A CA   3 
+ATOM   3791 C  C    . CYS A 1 77 ? 1.570   7.664   -5.080  1.00 0.00 ? 77 CYS A C    3 
+ATOM   3792 O  O    . CYS A 1 77 ? 1.610   8.323   -6.099  1.00 0.00 ? 77 CYS A O    3 
+ATOM   3793 C  CB   . CYS A 1 77 ? -0.846  7.782   -4.416  1.00 0.00 ? 77 CYS A CB   3 
+ATOM   3794 S  SG   . CYS A 1 77 ? -0.725  8.343   -2.702  1.00 0.00 ? 77 CYS A SG   3 
+ATOM   3795 H  H    . CYS A 1 77 ? 0.039   6.031   -2.758  1.00 0.00 ? 77 CYS A H    3 
+ATOM   3796 H  HA   . CYS A 1 77 ? 0.051   6.224   -5.582  1.00 0.00 ? 77 CYS A HA   3 
+ATOM   3797 H  HB2  . CYS A 1 77 ? -0.805  8.635   -5.077  1.00 0.00 ? 77 CYS A HB2  3 
+ATOM   3798 H  HB3  . CYS A 1 77 ? -1.781  7.264   -4.559  1.00 0.00 ? 77 CYS A HB3  3 
+ATOM   3799 N  N    . VAL A 1 78 ? 2.592   7.647   -4.254  1.00 0.00 ? 78 VAL A N    3 
+ATOM   3800 C  CA   . VAL A 1 78 ? 3.815   8.448   -4.578  1.00 0.00 ? 78 VAL A CA   3 
+ATOM   3801 C  C    . VAL A 1 78 ? 4.954   7.522   -5.034  1.00 0.00 ? 78 VAL A C    3 
+ATOM   3802 O  O    . VAL A 1 78 ? 5.894   7.953   -5.669  1.00 0.00 ? 78 VAL A O    3 
+ATOM   3803 C  CB   . VAL A 1 78 ? 4.259   9.221   -3.336  1.00 0.00 ? 78 VAL A CB   3 
+ATOM   3804 C  CG1  . VAL A 1 78 ? 5.460   10.102  -3.685  1.00 0.00 ? 78 VAL A CG1  3 
+ATOM   3805 C  CG2  . VAL A 1 78 ? 3.107   10.103  -2.850  1.00 0.00 ? 78 VAL A CG2  3 
+ATOM   3806 H  H    . VAL A 1 78 ? 2.556   7.120   -3.429  1.00 0.00 ? 78 VAL A H    3 
+ATOM   3807 H  HA   . VAL A 1 78 ? 3.584   9.146   -5.368  1.00 0.00 ? 78 VAL A HA   3 
+ATOM   3808 H  HB   . VAL A 1 78 ? 4.536   8.525   -2.558  1.00 0.00 ? 78 VAL A HB   3 
+ATOM   3809 H  HG11 . VAL A 1 78 ? 5.807   9.859   -4.678  1.00 0.00 ? 78 VAL A HG11 3 
+ATOM   3810 H  HG12 . VAL A 1 78 ? 5.168   11.140  -3.648  1.00 0.00 ? 78 VAL A HG12 3 
+ATOM   3811 H  HG13 . VAL A 1 78 ? 6.253   9.925   -2.974  1.00 0.00 ? 78 VAL A HG13 3 
+ATOM   3812 H  HG21 . VAL A 1 78 ? 2.217   9.877   -3.419  1.00 0.00 ? 78 VAL A HG21 3 
+ATOM   3813 H  HG22 . VAL A 1 78 ? 2.924   9.910   -1.803  1.00 0.00 ? 78 VAL A HG22 3 
+ATOM   3814 H  HG23 . VAL A 1 78 ? 3.367   11.142  -2.986  1.00 0.00 ? 78 VAL A HG23 3 
+ATOM   3815 N  N    . ALA A 1 79 ? 4.857   6.255   -4.736  1.00 0.00 ? 79 ALA A N    3 
+ATOM   3816 C  CA   . ALA A 1 79 ? 5.910   5.278   -5.167  1.00 0.00 ? 79 ALA A CA   3 
+ATOM   3817 C  C    . ALA A 1 79 ? 7.334   5.828   -4.963  1.00 0.00 ? 79 ALA A C    3 
+ATOM   3818 O  O    . ALA A 1 79 ? 7.805   6.660   -5.712  1.00 0.00 ? 79 ALA A O    3 
+ATOM   3819 C  CB   . ALA A 1 79 ? 5.716   4.958   -6.649  1.00 0.00 ? 79 ALA A CB   3 
+ATOM   3820 H  H    . ALA A 1 79 ? 4.077   5.935   -4.238  1.00 0.00 ? 79 ALA A H    3 
+ATOM   3821 H  HA   . ALA A 1 79 ? 5.800   4.368   -4.596  1.00 0.00 ? 79 ALA A HA   3 
+ATOM   3822 H  HB1  . ALA A 1 79 ? 4.989   5.635   -7.071  1.00 0.00 ? 79 ALA A HB1  3 
+ATOM   3823 H  HB2  . ALA A 1 79 ? 6.656   5.071   -7.168  1.00 0.00 ? 79 ALA A HB2  3 
+ATOM   3824 H  HB3  . ALA A 1 79 ? 5.365   3.941   -6.755  1.00 0.00 ? 79 ALA A HB3  3 
+ATOM   3825 N  N    . TYR A 1 80 ? 8.036   5.323   -3.980  1.00 0.00 ? 80 TYR A N    3 
+ATOM   3826 C  CA   . TYR A 1 80 ? 9.434   5.752   -3.732  1.00 0.00 ? 80 TYR A CA   3 
+ATOM   3827 C  C    . TYR A 1 80 ? 10.220  4.492   -3.355  1.00 0.00 ? 80 TYR A C    3 
+ATOM   3828 O  O    . TYR A 1 80 ? 9.632   3.434   -3.256  1.00 0.00 ? 80 TYR A O    3 
+ATOM   3829 C  CB   . TYR A 1 80 ? 9.458   6.763   -2.582  1.00 0.00 ? 80 TYR A CB   3 
+ATOM   3830 C  CG   . TYR A 1 80 ? 9.733   8.146   -3.122  1.00 0.00 ? 80 TYR A CG   3 
+ATOM   3831 C  CD1  . TYR A 1 80 ? 8.835   8.737   -4.018  1.00 0.00 ? 80 TYR A CD1  3 
+ATOM   3832 C  CD2  . TYR A 1 80 ? 10.884  8.841   -2.726  1.00 0.00 ? 80 TYR A CD2  3 
+ATOM   3833 C  CE1  . TYR A 1 80 ? 9.084   10.020  -4.518  1.00 0.00 ? 80 TYR A CE1  3 
+ATOM   3834 C  CE2  . TYR A 1 80 ? 11.134  10.125  -3.228  1.00 0.00 ? 80 TYR A CE2  3 
+ATOM   3835 C  CZ   . TYR A 1 80 ? 10.233  10.714  -4.124  1.00 0.00 ? 80 TYR A CZ   3 
+ATOM   3836 O  OH   . TYR A 1 80 ? 10.479  11.979  -4.618  1.00 0.00 ? 80 TYR A OH   3 
+ATOM   3837 H  H    . TYR A 1 80 ? 7.655   4.633   -3.414  1.00 0.00 ? 80 TYR A H    3 
+ATOM   3838 H  HA   . TYR A 1 80 ? 9.838   6.186   -4.623  1.00 0.00 ? 80 TYR A HA   3 
+ATOM   3839 H  HB2  . TYR A 1 80 ? 8.502   6.759   -2.093  1.00 0.00 ? 80 TYR A HB2  3 
+ATOM   3840 H  HB3  . TYR A 1 80 ? 10.221  6.490   -1.871  1.00 0.00 ? 80 TYR A HB3  3 
+ATOM   3841 H  HD1  . TYR A 1 80 ? 7.947   8.204   -4.320  1.00 0.00 ? 80 TYR A HD1  3 
+ATOM   3842 H  HD2  . TYR A 1 80 ? 11.578  8.388   -2.035  1.00 0.00 ? 80 TYR A HD2  3 
+ATOM   3843 H  HE1  . TYR A 1 80 ? 8.391   10.475  -5.209  1.00 0.00 ? 80 TYR A HE1  3 
+ATOM   3844 H  HE2  . TYR A 1 80 ? 12.021  10.660  -2.923  1.00 0.00 ? 80 TYR A HE2  3 
+ATOM   3845 H  HH   . TYR A 1 80 ? 9.941   12.099  -5.404  1.00 0.00 ? 80 TYR A HH   3 
+ATOM   3846 N  N    . PRO A 1 81 ? 11.507  4.606   -3.137  1.00 0.00 ? 81 PRO A N    3 
+ATOM   3847 C  CA   . PRO A 1 81 ? 12.307  3.434   -2.756  1.00 0.00 ? 81 PRO A CA   3 
+ATOM   3848 C  C    . PRO A 1 81 ? 11.522  2.627   -1.718  1.00 0.00 ? 81 PRO A C    3 
+ATOM   3849 O  O    . PRO A 1 81 ? 11.281  3.078   -0.616  1.00 0.00 ? 81 PRO A O    3 
+ATOM   3850 C  CB   . PRO A 1 81 ? 13.603  4.029   -2.190  1.00 0.00 ? 81 PRO A CB   3 
+ATOM   3851 C  CG   . PRO A 1 81 ? 13.628  5.531   -2.591  1.00 0.00 ? 81 PRO A CG   3 
+ATOM   3852 C  CD   . PRO A 1 81 ? 12.266  5.865   -3.232  1.00 0.00 ? 81 PRO A CD   3 
+ATOM   3853 H  HA   . PRO A 1 81 ? 12.524  2.827   -3.622  1.00 0.00 ? 81 PRO A HA   3 
+ATOM   3854 H  HB2  . PRO A 1 81 ? 13.612  3.931   -1.112  1.00 0.00 ? 81 PRO A HB2  3 
+ATOM   3855 H  HB3  . PRO A 1 81 ? 14.457  3.527   -2.615  1.00 0.00 ? 81 PRO A HB3  3 
+ATOM   3856 H  HG2  . PRO A 1 81 ? 13.783  6.143   -1.712  1.00 0.00 ? 81 PRO A HG2  3 
+ATOM   3857 H  HG3  . PRO A 1 81 ? 14.417  5.707   -3.305  1.00 0.00 ? 81 PRO A HG3  3 
+ATOM   3858 H  HD2  . PRO A 1 81 ? 11.779  6.655   -2.683  1.00 0.00 ? 81 PRO A HD2  3 
+ATOM   3859 H  HD3  . PRO A 1 81 ? 12.394  6.147   -4.266  1.00 0.00 ? 81 PRO A HD3  3 
+ATOM   3860 N  N    . THR A 1 82 ? 11.075  1.453   -2.086  1.00 0.00 ? 82 THR A N    3 
+ATOM   3861 C  CA   . THR A 1 82 ? 10.260  0.636   -1.167  1.00 0.00 ? 82 THR A CA   3 
+ATOM   3862 C  C    . THR A 1 82 ? 11.126  -0.473  -0.550  1.00 0.00 ? 82 THR A C    3 
+ATOM   3863 O  O    . THR A 1 82 ? 12.032  -0.203  0.212   1.00 0.00 ? 82 THR A O    3 
+ATOM   3864 C  CB   . THR A 1 82 ? 9.109   0.053   -1.998  1.00 0.00 ? 82 THR A CB   3 
+ATOM   3865 O  OG1  . THR A 1 82 ? 8.373   1.115   -2.588  1.00 0.00 ? 82 THR A OG1  3 
+ATOM   3866 C  CG2  . THR A 1 82 ? 8.179   -0.779  -1.124  1.00 0.00 ? 82 THR A CG2  3 
+ATOM   3867 H  H    . THR A 1 82 ? 11.247  1.116   -2.986  1.00 0.00 ? 82 THR A H    3 
+ATOM   3868 H  HA   . THR A 1 82 ? 9.857   1.263   -0.386  1.00 0.00 ? 82 THR A HA   3 
+ATOM   3869 H  HB   . THR A 1 82 ? 9.516   -0.573  -2.777  1.00 0.00 ? 82 THR A HB   3 
+ATOM   3870 H  HG1  . THR A 1 82 ? 8.399   1.000   -3.540  1.00 0.00 ? 82 THR A HG1  3 
+ATOM   3871 H  HG21 . THR A 1 82 ? 8.460   -0.669  -0.091  1.00 0.00 ? 82 THR A HG21 3 
+ATOM   3872 H  HG22 . THR A 1 82 ? 7.163   -0.445  -1.264  1.00 0.00 ? 82 THR A HG22 3 
+ATOM   3873 H  HG23 . THR A 1 82 ? 8.256   -1.814  -1.408  1.00 0.00 ? 82 THR A HG23 3 
+ATOM   3874 N  N    . SER A 1 83 ? 10.844  -1.709  -0.877  1.00 0.00 ? 83 SER A N    3 
+ATOM   3875 C  CA   . SER A 1 83 ? 11.619  -2.864  -0.328  1.00 0.00 ? 83 SER A CA   3 
+ATOM   3876 C  C    . SER A 1 83 ? 10.681  -4.070  -0.237  1.00 0.00 ? 83 SER A C    3 
+ATOM   3877 O  O    . SER A 1 83 ? 11.109  -5.207  -0.210  1.00 0.00 ? 83 SER A O    3 
+ATOM   3878 C  CB   . SER A 1 83 ? 12.144  -2.540  1.074   1.00 0.00 ? 83 SER A CB   3 
+ATOM   3879 O  OG   . SER A 1 83 ? 13.483  -2.061  0.985   1.00 0.00 ? 83 SER A OG   3 
+ATOM   3880 H  H    . SER A 1 83 ? 10.114  -1.883  -1.492  1.00 0.00 ? 83 SER A H    3 
+ATOM   3881 H  HA   . SER A 1 83 ? 12.445  -3.094  -0.984  1.00 0.00 ? 83 SER A HA   3 
+ATOM   3882 H  HB2  . SER A 1 83 ? 11.525  -1.781  1.524   1.00 0.00 ? 83 SER A HB2  3 
+ATOM   3883 H  HB3  . SER A 1 83 ? 12.112  -3.434  1.683   1.00 0.00 ? 83 SER A HB3  3 
+ATOM   3884 H  HG   . SER A 1 83 ? 13.704  -1.955  0.056   1.00 0.00 ? 83 SER A HG   3 
+ATOM   3885 N  N    . ASP A 1 84 ? 9.398   -3.820  -0.192  1.00 0.00 ? 84 ASP A N    3 
+ATOM   3886 C  CA   . ASP A 1 84 ? 8.411   -4.952  -0.101  1.00 0.00 ? 84 ASP A CA   3 
+ATOM   3887 C  C    . ASP A 1 84 ? 7.054   -4.422  0.381   1.00 0.00 ? 84 ASP A C    3 
+ATOM   3888 O  O    . ASP A 1 84 ? 7.004   -3.471  1.132   1.00 0.00 ? 84 ASP A O    3 
+ATOM   3889 C  CB   . ASP A 1 84 ? 8.927   -5.996  0.893   1.00 0.00 ? 84 ASP A CB   3 
+ATOM   3890 C  CG   . ASP A 1 84 ? 9.587   -5.292  2.079   1.00 0.00 ? 84 ASP A CG   3 
+ATOM   3891 O  OD1  . ASP A 1 84 ? 8.865   -4.733  2.888   1.00 0.00 ? 84 ASP A OD1  3 
+ATOM   3892 O  OD2  . ASP A 1 84 ? 10.804  -5.323  2.157   1.00 0.00 ? 84 ASP A OD2  3 
+ATOM   3893 H  H    . ASP A 1 84 ? 9.086   -2.880  -0.218  1.00 0.00 ? 84 ASP A H    3 
+ATOM   3894 H  HA   . ASP A 1 84 ? 8.300   -5.404  -1.066  1.00 0.00 ? 84 ASP A HA   3 
+ATOM   3895 H  HB2  . ASP A 1 84 ? 8.100   -6.597  1.244   1.00 0.00 ? 84 ASP A HB2  3 
+ATOM   3896 H  HB3  . ASP A 1 84 ? 9.651   -6.630  0.404   1.00 0.00 ? 84 ASP A HB3  3 
+ATOM   3897 N  N    . CYS A 1 85 ? 5.940   -5.006  -0.027  1.00 0.00 ? 85 CYS A N    3 
+ATOM   3898 C  CA   . CYS A 1 85 ? 4.644   -4.468  0.453   1.00 0.00 ? 85 CYS A CA   3 
+ATOM   3899 C  C    . CYS A 1 85 ? 4.108   -5.379  1.567   1.00 0.00 ? 85 CYS A C    3 
+ATOM   3900 O  O    . CYS A 1 85 ? 4.816   -6.255  2.026   1.00 0.00 ? 85 CYS A O    3 
+ATOM   3901 C  CB   . CYS A 1 85 ? 3.678   -4.400  -0.717  1.00 0.00 ? 85 CYS A CB   3 
+ATOM   3902 S  SG   . CYS A 1 85 ? 4.005   -2.909  -1.706  1.00 0.00 ? 85 CYS A SG   3 
+ATOM   3903 H  H    . CYS A 1 85 ? 5.946   -5.786  -0.642  1.00 0.00 ? 85 CYS A H    3 
+ATOM   3904 H  HA   . CYS A 1 85 ? 4.807   -3.484  0.841   1.00 0.00 ? 85 CYS A HA   3 
+ATOM   3905 H  HB2  . CYS A 1 85 ? 3.814   -5.270  -1.329  1.00 0.00 ? 85 CYS A HB2  3 
+ATOM   3906 H  HB3  . CYS A 1 85 ? 2.670   -4.375  -0.347  1.00 0.00 ? 85 CYS A HB3  3 
+ATOM   3907 N  N    . THR A 1 86 ? 2.895   -5.193  2.047   1.00 0.00 ? 86 THR A N    3 
+ATOM   3908 C  CA   . THR A 1 86 ? 2.448   -6.096  3.155   1.00 0.00 ? 86 THR A CA   3 
+ATOM   3909 C  C    . THR A 1 86 ? 0.924   -6.078  3.415   1.00 0.00 ? 86 THR A C    3 
+ATOM   3910 O  O    . THR A 1 86 ? 0.443   -5.374  4.268   1.00 0.00 ? 86 THR A O    3 
+ATOM   3911 C  CB   . THR A 1 86 ? 3.181   -5.680  4.439   1.00 0.00 ? 86 THR A CB   3 
+ATOM   3912 O  OG1  . THR A 1 86 ? 4.294   -4.865  4.098   1.00 0.00 ? 86 THR A OG1  3 
+ATOM   3913 C  CG2  . THR A 1 86 ? 3.672   -6.930  5.172   1.00 0.00 ? 86 THR A CG2  3 
+ATOM   3914 H  H    . THR A 1 86 ? 2.315   -4.478  1.707   1.00 0.00 ? 86 THR A H    3 
+ATOM   3915 H  HA   . THR A 1 86 ? 2.742   -7.106  2.912   1.00 0.00 ? 86 THR A HA   3 
+ATOM   3916 H  HB   . THR A 1 86 ? 2.514   -5.124  5.087   1.00 0.00 ? 86 THR A HB   3 
+ATOM   3917 H  HG1  . THR A 1 86 ? 4.768   -4.653  4.907   1.00 0.00 ? 86 THR A HG1  3 
+ATOM   3918 H  HG21 . THR A 1 86 ? 4.277   -7.524  4.503   1.00 0.00 ? 86 THR A HG21 3 
+ATOM   3919 H  HG22 . THR A 1 86 ? 4.264   -6.637  6.027   1.00 0.00 ? 86 THR A HG22 3 
+ATOM   3920 H  HG23 . THR A 1 86 ? 2.825   -7.511  5.502   1.00 0.00 ? 86 THR A HG23 3 
+ATOM   3921 N  N    . ILE A 1 87 ? 0.177   -6.921  2.748   1.00 0.00 ? 87 ILE A N    3 
+ATOM   3922 C  CA   . ILE A 1 87 ? -1.293  -7.036  3.028   1.00 0.00 ? 87 ILE A CA   3 
+ATOM   3923 C  C    . ILE A 1 87 ? -2.135  -5.961  2.306   1.00 0.00 ? 87 ILE A C    3 
+ATOM   3924 O  O    . ILE A 1 87 ? -1.949  -5.711  1.132   1.00 0.00 ? 87 ILE A O    3 
+ATOM   3925 C  CB   . ILE A 1 87 ? -1.519  -6.966  4.545   1.00 0.00 ? 87 ILE A CB   3 
+ATOM   3926 C  CG1  . ILE A 1 87 ? -0.403  -7.721  5.277   1.00 0.00 ? 87 ILE A CG1  3 
+ATOM   3927 C  CG2  . ILE A 1 87 ? -2.856  -7.617  4.889   1.00 0.00 ? 87 ILE A CG2  3 
+ATOM   3928 C  CD1  . ILE A 1 87 ? 0.193   -6.824  6.357   1.00 0.00 ? 87 ILE A CD1  3 
+ATOM   3929 H  H    . ILE A 1 87 ? 0.590   -7.528  2.111   1.00 0.00 ? 87 ILE A H    3 
+ATOM   3930 H  HA   . ILE A 1 87 ? -1.624  -8.004  2.685   1.00 0.00 ? 87 ILE A HA   3 
+ATOM   3931 H  HB   . ILE A 1 87 ? -1.528  -5.934  4.862   1.00 0.00 ? 87 ILE A HB   3 
+ATOM   3932 H  HG12 . ILE A 1 87 ? -0.813  -8.607  5.735   1.00 0.00 ? 87 ILE A HG12 3 
+ATOM   3933 H  HG13 . ILE A 1 87 ? 0.370   -8.005  4.581   1.00 0.00 ? 87 ILE A HG13 3 
+ATOM   3934 H  HG21 . ILE A 1 87 ? -3.558  -7.440  4.088   1.00 0.00 ? 87 ILE A HG21 3 
+ATOM   3935 H  HG22 . ILE A 1 87 ? -2.713  -8.679  5.016   1.00 0.00 ? 87 ILE A HG22 3 
+ATOM   3936 H  HG23 . ILE A 1 87 ? -3.237  -7.191  5.805   1.00 0.00 ? 87 ILE A HG23 3 
+ATOM   3937 H  HD11 . ILE A 1 87 ? -0.148  -5.812  6.208   1.00 0.00 ? 87 ILE A HD11 3 
+ATOM   3938 H  HD12 . ILE A 1 87 ? -0.121  -7.169  7.329   1.00 0.00 ? 87 ILE A HD12 3 
+ATOM   3939 H  HD13 . ILE A 1 87 ? 1.270   -6.851  6.296   1.00 0.00 ? 87 ILE A HD13 3 
+ATOM   3940 N  N    . GLU A 1 88 ? -3.093  -5.366  3.000   1.00 0.00 ? 88 GLU A N    3 
+ATOM   3941 C  CA   . GLU A 1 88 ? -4.000  -4.352  2.387   1.00 0.00 ? 88 GLU A CA   3 
+ATOM   3942 C  C    . GLU A 1 88 ? -5.316  -4.351  3.168   1.00 0.00 ? 88 GLU A C    3 
+ATOM   3943 O  O    . GLU A 1 88 ? -5.944  -3.329  3.365   1.00 0.00 ? 88 GLU A O    3 
+ATOM   3944 C  CB   . GLU A 1 88 ? -4.271  -4.727  0.931   1.00 0.00 ? 88 GLU A CB   3 
+ATOM   3945 C  CG   . GLU A 1 88 ? -5.504  -3.978  0.426   1.00 0.00 ? 88 GLU A CG   3 
+ATOM   3946 C  CD   . GLU A 1 88 ? -5.239  -3.444  -0.983  1.00 0.00 ? 88 GLU A CD   3 
+ATOM   3947 O  OE1  . GLU A 1 88 ? -4.285  -2.701  -1.144  1.00 0.00 ? 88 GLU A OE1  3 
+ATOM   3948 O  OE2  . GLU A 1 88 ? -5.994  -3.787  -1.878  1.00 0.00 ? 88 GLU A OE2  3 
+ATOM   3949 H  H    . GLU A 1 88 ? -3.236  -5.606  3.927   1.00 0.00 ? 88 GLU A H    3 
+ATOM   3950 H  HA   . GLU A 1 88 ? -3.550  -3.377  2.439   1.00 0.00 ? 88 GLU A HA   3 
+ATOM   3951 H  HB2  . GLU A 1 88 ? -3.414  -4.461  0.331   1.00 0.00 ? 88 GLU A HB2  3 
+ATOM   3952 H  HB3  . GLU A 1 88 ? -4.444  -5.791  0.864   1.00 0.00 ? 88 GLU A HB3  3 
+ATOM   3953 H  HG2  . GLU A 1 88 ? -6.349  -4.651  0.405   1.00 0.00 ? 88 GLU A HG2  3 
+ATOM   3954 H  HG3  . GLU A 1 88 ? -5.718  -3.152  1.088   1.00 0.00 ? 88 GLU A HG3  3 
+ATOM   3955 N  N    . THR A 1 89 ? -5.734  -5.501  3.612   1.00 0.00 ? 89 THR A N    3 
+ATOM   3956 C  CA   . THR A 1 89 ? -7.002  -5.599  4.387   1.00 0.00 ? 89 THR A CA   3 
+ATOM   3957 C  C    . THR A 1 89 ? -7.156  -7.039  4.867   1.00 0.00 ? 89 THR A C    3 
+ATOM   3958 O  O    . THR A 1 89 ? -8.232  -7.602  4.864   1.00 0.00 ? 89 THR A O    3 
+ATOM   3959 C  CB   . THR A 1 89 ? -8.183  -5.217  3.493   1.00 0.00 ? 89 THR A CB   3 
+ATOM   3960 O  OG1  . THR A 1 89 ? -7.741  -5.119  2.146   1.00 0.00 ? 89 THR A OG1  3 
+ATOM   3961 C  CG2  . THR A 1 89 ? -8.751  -3.872  3.945   1.00 0.00 ? 89 THR A CG2  3 
+ATOM   3962 H  H    . THR A 1 89 ? -5.206  -6.311  3.435   1.00 0.00 ? 89 THR A H    3 
+ATOM   3963 H  HA   . THR A 1 89 ? -6.958  -4.934  5.238   1.00 0.00 ? 89 THR A HA   3 
+ATOM   3964 H  HB   . THR A 1 89 ? -8.951  -5.970  3.569   1.00 0.00 ? 89 THR A HB   3 
+ATOM   3965 H  HG1  . THR A 1 89 ? -8.395  -5.545  1.587   1.00 0.00 ? 89 THR A HG1  3 
+ATOM   3966 H  HG21 . THR A 1 89 ? -8.399  -3.648  4.940   1.00 0.00 ? 89 THR A HG21 3 
+ATOM   3967 H  HG22 . THR A 1 89 ? -8.427  -3.097  3.265   1.00 0.00 ? 89 THR A HG22 3 
+ATOM   3968 H  HG23 . THR A 1 89 ? -9.830  -3.920  3.948   1.00 0.00 ? 89 THR A HG23 3 
+ATOM   3969 N  N    . HIS A 1 90 ? -6.068  -7.640  5.262   1.00 0.00 ? 90 HIS A N    3 
+ATOM   3970 C  CA   . HIS A 1 90 ? -6.109  -9.051  5.731   1.00 0.00 ? 90 HIS A CA   3 
+ATOM   3971 C  C    . HIS A 1 90 ? -6.341  -9.094  7.244   1.00 0.00 ? 90 HIS A C    3 
+ATOM   3972 O  O    . HIS A 1 90 ? -6.937  -10.018 7.762   1.00 0.00 ? 90 HIS A O    3 
+ATOM   3973 C  CB   . HIS A 1 90 ? -4.770  -9.712  5.397   1.00 0.00 ? 90 HIS A CB   3 
+ATOM   3974 C  CG   . HIS A 1 90 ? -4.916  -11.210 5.435   1.00 0.00 ? 90 HIS A CG   3 
+ATOM   3975 N  ND1  . HIS A 1 90 ? -4.509  -12.019 4.386   1.00 0.00 ? 90 HIS A ND1  3 
+ATOM   3976 C  CD2  . HIS A 1 90 ? -5.422  -12.059 6.388   1.00 0.00 ? 90 HIS A CD2  3 
+ATOM   3977 C  CE1  . HIS A 1 90 ? -4.774  -13.294 4.731   1.00 0.00 ? 90 HIS A CE1  3 
+ATOM   3978 N  NE2  . HIS A 1 90 ? -5.331  -13.373 5.941   1.00 0.00 ? 90 HIS A NE2  3 
+ATOM   3979 H  H    . HIS A 1 90 ? -5.214  -7.162  5.240   1.00 0.00 ? 90 HIS A H    3 
+ATOM   3980 H  HA   . HIS A 1 90 ? -6.906  -9.577  5.227   1.00 0.00 ? 90 HIS A HA   3 
+ATOM   3981 H  HB2  . HIS A 1 90 ? -4.455  -9.405  4.409   1.00 0.00 ? 90 HIS A HB2  3 
+ATOM   3982 H  HB3  . HIS A 1 90 ? -4.027  -9.404  6.119   1.00 0.00 ? 90 HIS A HB3  3 
+ATOM   3983 H  HD1  . HIS A 1 90 ? -4.101  -11.719 3.547   1.00 0.00 ? 90 HIS A HD1  3 
+ATOM   3984 H  HD2  . HIS A 1 90 ? -5.825  -11.753 7.342   1.00 0.00 ? 90 HIS A HD2  3 
+ATOM   3985 H  HE1  . HIS A 1 90 ? -4.559  -14.148 4.105   1.00 0.00 ? 90 HIS A HE1  3 
+ATOM   3986 N  N    . LYS A 1 91 ? -5.874  -8.108  7.961   1.00 0.00 ? 91 LYS A N    3 
+ATOM   3987 C  CA   . LYS A 1 91 ? -6.069  -8.108  9.438   1.00 0.00 ? 91 LYS A CA   3 
+ATOM   3988 C  C    . LYS A 1 91 ? -7.486  -7.662  9.775   1.00 0.00 ? 91 LYS A C    3 
+ATOM   3989 O  O    . LYS A 1 91 ? -7.864  -7.593  10.928  1.00 0.00 ? 91 LYS A O    3 
+ATOM   3990 C  CB   . LYS A 1 91 ? -5.061  -7.157  10.090  1.00 0.00 ? 91 LYS A CB   3 
+ATOM   3991 C  CG   . LYS A 1 91 ? -4.481  -7.810  11.345  1.00 0.00 ? 91 LYS A CG   3 
+ATOM   3992 C  CD   . LYS A 1 91 ? -3.170  -7.116  11.723  1.00 0.00 ? 91 LYS A CD   3 
+ATOM   3993 C  CE   . LYS A 1 91 ? -2.461  -7.921  12.814  1.00 0.00 ? 91 LYS A CE   3 
+ATOM   3994 N  NZ   . LYS A 1 91 ? -1.372  -7.097  13.410  1.00 0.00 ? 91 LYS A NZ   3 
+ATOM   3995 H  H    . LYS A 1 91 ? -5.392  -7.372  7.528   1.00 0.00 ? 91 LYS A H    3 
+ATOM   3996 H  HA   . LYS A 1 91 ? -5.922  -9.107  9.821   1.00 0.00 ? 91 LYS A HA   3 
+ATOM   3997 H  HB2  . LYS A 1 91 ? -4.264  -6.944  9.391   1.00 0.00 ? 91 LYS A HB2  3 
+ATOM   3998 H  HB3  . LYS A 1 91 ? -5.557  -6.238  10.361  1.00 0.00 ? 91 LYS A HB3  3 
+ATOM   3999 H  HG2  . LYS A 1 91 ? -5.188  -7.716  12.157  1.00 0.00 ? 91 LYS A HG2  3 
+ATOM   4000 H  HG3  . LYS A 1 91 ? -4.290  -8.856  11.153  1.00 0.00 ? 91 LYS A HG3  3 
+ATOM   4001 H  HD2  . LYS A 1 91 ? -2.534  -7.050  10.853  1.00 0.00 ? 91 LYS A HD2  3 
+ATOM   4002 H  HD3  . LYS A 1 91 ? -3.383  -6.125  12.092  1.00 0.00 ? 91 LYS A HD3  3 
+ATOM   4003 H  HE2  . LYS A 1 91 ? -3.171  -8.189  13.583  1.00 0.00 ? 91 LYS A HE2  3 
+ATOM   4004 H  HE3  . LYS A 1 91 ? -2.041  -8.819  12.385  1.00 0.00 ? 91 LYS A HE3  3 
+ATOM   4005 H  HZ1  . LYS A 1 91 ? -1.737  -6.152  13.639  1.00 0.00 ? 91 LYS A HZ1  3 
+ATOM   4006 H  HZ2  . LYS A 1 91 ? -1.025  -7.556  14.277  1.00 0.00 ? 91 LYS A HZ2  3 
+ATOM   4007 H  HZ3  . LYS A 1 91 ? -0.592  -7.009  12.729  1.00 0.00 ? 91 LYS A HZ3  3 
+ATOM   4008 N  N    . GLU A 1 92 ? -8.285  -7.373  8.789   1.00 0.00 ? 92 GLU A N    3 
+ATOM   4009 C  CA   . GLU A 1 92 ? -9.675  -6.956  9.090   1.00 0.00 ? 92 GLU A CA   3 
+ATOM   4010 C  C    . GLU A 1 92 ? -10.575 -8.183  9.068   1.00 0.00 ? 92 GLU A C    3 
+ATOM   4011 O  O    . GLU A 1 92 ? -11.778 -8.076  8.935   1.00 0.00 ? 92 GLU A O    3 
+ATOM   4012 C  CB   . GLU A 1 92 ? -10.179 -5.950  8.064   1.00 0.00 ? 92 GLU A CB   3 
+ATOM   4013 C  CG   . GLU A 1 92 ? -9.922  -6.483  6.653   1.00 0.00 ? 92 GLU A CG   3 
+ATOM   4014 C  CD   . GLU A 1 92 ? -11.183 -6.313  5.804   1.00 0.00 ? 92 GLU A CD   3 
+ATOM   4015 O  OE1  . GLU A 1 92 ? -11.808 -5.272  5.907   1.00 0.00 ? 92 GLU A OE1  3 
+ATOM   4016 O  OE2  . GLU A 1 92 ? -11.501 -7.229  5.062   1.00 0.00 ? 92 GLU A OE2  3 
+ATOM   4017 H  H    . GLU A 1 92 ? -7.976  -7.444  7.863   1.00 0.00 ? 92 GLU A H    3 
+ATOM   4018 H  HA   . GLU A 1 92 ? -9.707  -6.511  10.073  1.00 0.00 ? 92 GLU A HA   3 
+ATOM   4019 H  HB2  . GLU A 1 92 ? -11.242 -5.807  8.214   1.00 0.00 ? 92 GLU A HB2  3 
+ATOM   4020 H  HB3  . GLU A 1 92 ? -9.664  -5.010  8.195   1.00 0.00 ? 92 GLU A HB3  3 
+ATOM   4021 H  HG2  . GLU A 1 92 ? -9.108  -5.932  6.205   1.00 0.00 ? 92 GLU A HG2  3 
+ATOM   4022 H  HG3  . GLU A 1 92 ? -9.663  -7.530  6.706   1.00 0.00 ? 92 GLU A HG3  3 
+ATOM   4023 N  N    . GLU A 1 93 ? -10.013 -9.356  9.222   1.00 0.00 ? 93 GLU A N    3 
+ATOM   4024 C  CA   . GLU A 1 93 ? -10.867 -10.572 9.241   1.00 0.00 ? 93 GLU A CA   3 
+ATOM   4025 C  C    . GLU A 1 93 ? -12.016 -10.286 10.198  1.00 0.00 ? 93 GLU A C    3 
+ATOM   4026 O  O    . GLU A 1 93 ? -13.103 -10.816 10.080  1.00 0.00 ? 93 GLU A O    3 
+ATOM   4027 C  CB   . GLU A 1 93 ? -10.059 -11.769 9.745   1.00 0.00 ? 93 GLU A CB   3 
+ATOM   4028 C  CG   . GLU A 1 93 ? -9.600  -12.613 8.556   1.00 0.00 ? 93 GLU A CG   3 
+ATOM   4029 C  CD   . GLU A 1 93 ? -9.746  -14.096 8.899   1.00 0.00 ? 93 GLU A CD   3 
+ATOM   4030 O  OE1  . GLU A 1 93 ? -10.858 -14.595 8.826   1.00 0.00 ? 93 GLU A OE1  3 
+ATOM   4031 O  OE2  . GLU A 1 93 ? -8.744  -14.709 9.231   1.00 0.00 ? 93 GLU A OE2  3 
+ATOM   4032 H  H    . GLU A 1 93 ? -9.044  -9.428  9.346   1.00 0.00 ? 93 GLU A H    3 
+ATOM   4033 H  HA   . GLU A 1 93 ? -11.251 -10.770 8.250   1.00 0.00 ? 93 GLU A HA   3 
+ATOM   4034 H  HB2  . GLU A 1 93 ? -9.197  -11.415 10.292  1.00 0.00 ? 93 GLU A HB2  3 
+ATOM   4035 H  HB3  . GLU A 1 93 ? -10.676 -12.371 10.394  1.00 0.00 ? 93 GLU A HB3  3 
+ATOM   4036 H  HG2  . GLU A 1 93 ? -10.208 -12.380 7.693   1.00 0.00 ? 93 GLU A HG2  3 
+ATOM   4037 H  HG3  . GLU A 1 93 ? -8.565  -12.396 8.338   1.00 0.00 ? 93 GLU A HG3  3 
+ATOM   4038 N  N    . ASP A 1 94 ? -11.767 -9.417  11.141  1.00 0.00 ? 94 ASP A N    3 
+ATOM   4039 C  CA   . ASP A 1 94 ? -12.807 -9.039  12.115  1.00 0.00 ? 94 ASP A CA   3 
+ATOM   4040 C  C    . ASP A 1 94 ? -12.584 -7.583  12.542  1.00 0.00 ? 94 ASP A C    3 
+ATOM   4041 O  O    . ASP A 1 94 ? -12.798 -7.226  13.684  1.00 0.00 ? 94 ASP A O    3 
+ATOM   4042 C  CB   . ASP A 1 94 ? -12.715 -9.954  13.335  1.00 0.00 ? 94 ASP A CB   3 
+ATOM   4043 C  CG   . ASP A 1 94 ? -13.966 -10.830 13.416  1.00 0.00 ? 94 ASP A CG   3 
+ATOM   4044 O  OD1  . ASP A 1 94 ? -14.418 -11.281 12.375  1.00 0.00 ? 94 ASP A OD1  3 
+ATOM   4045 O  OD2  . ASP A 1 94 ? -14.451 -11.036 14.516  1.00 0.00 ? 94 ASP A OD2  3 
+ATOM   4046 H  H    . ASP A 1 94 ? -10.887 -9.005  11.200  1.00 0.00 ? 94 ASP A H    3 
+ATOM   4047 H  HA   . ASP A 1 94 ? -13.769 -9.138  11.657  1.00 0.00 ? 94 ASP A HA   3 
+ATOM   4048 H  HB2  . ASP A 1 94 ? -11.839 -10.580 13.243  1.00 0.00 ? 94 ASP A HB2  3 
+ATOM   4049 H  HB3  . ASP A 1 94 ? -12.637 -9.355  14.229  1.00 0.00 ? 94 ASP A HB3  3 
+ATOM   4050 N  N    . LEU A 1 95 ? -12.150 -6.737  11.638  1.00 0.00 ? 95 LEU A N    3 
+ATOM   4051 C  CA   . LEU A 1 95 ? -11.913 -5.313  12.011  1.00 0.00 ? 95 LEU A CA   3 
+ATOM   4052 C  C    . LEU A 1 95 ? -12.047 -4.429  10.770  1.00 0.00 ? 95 LEU A C    3 
+ATOM   4053 O  O    . LEU A 1 95 ? -11.427 -3.389  10.670  1.00 0.00 ? 95 LEU A O    3 
+ATOM   4054 C  CB   . LEU A 1 95 ? -10.503 -5.167  12.589  1.00 0.00 ? 95 LEU A CB   3 
+ATOM   4055 C  CG   . LEU A 1 95 ? -10.304 -3.737  13.091  1.00 0.00 ? 95 LEU A CG   3 
+ATOM   4056 C  CD1  . LEU A 1 95 ? -10.226 -3.738  14.619  1.00 0.00 ? 95 LEU A CD1  3 
+ATOM   4057 C  CD2  . LEU A 1 95 ? -9.002  -3.171  12.518  1.00 0.00 ? 95 LEU A CD2  3 
+ATOM   4058 H  H    . LEU A 1 95 ? -11.975 -7.036  10.717  1.00 0.00 ? 95 LEU A H    3 
+ATOM   4059 H  HA   . LEU A 1 95 ? -12.638 -5.009  12.750  1.00 0.00 ? 95 LEU A HA   3 
+ATOM   4060 H  HB2  . LEU A 1 95 ? -10.377 -5.860  13.410  1.00 0.00 ? 95 LEU A HB2  3 
+ATOM   4061 H  HB3  . LEU A 1 95 ? -9.775  -5.383  11.821  1.00 0.00 ? 95 LEU A HB3  3 
+ATOM   4062 H  HG   . LEU A 1 95 ? -11.136 -3.125  12.774  1.00 0.00 ? 95 LEU A HG   3 
+ATOM   4063 H  HD11 . LEU A 1 95 ? -10.502 -4.713  14.993  1.00 0.00 ? 95 LEU A HD11 3 
+ATOM   4064 H  HD12 . LEU A 1 95 ? -9.217  -3.506  14.928  1.00 0.00 ? 95 LEU A HD12 3 
+ATOM   4065 H  HD13 . LEU A 1 95 ? -10.904 -2.995  15.015  1.00 0.00 ? 95 LEU A HD13 3 
+ATOM   4066 H  HD21 . LEU A 1 95 ? -8.775  -3.666  11.584  1.00 0.00 ? 95 LEU A HD21 3 
+ATOM   4067 H  HD22 . LEU A 1 95 ? -9.117  -2.111  12.345  1.00 0.00 ? 95 LEU A HD22 3 
+ATOM   4068 H  HD23 . LEU A 1 95 ? -8.198  -3.337  13.219  1.00 0.00 ? 95 LEU A HD23 3 
+ATOM   4069 N  N    . TYR A 1 96 ? -12.853 -4.837  9.826   1.00 0.00 ? 96 TYR A N    3 
+ATOM   4070 C  CA   . TYR A 1 96 ? -13.042 -4.034  8.590   1.00 0.00 ? 96 TYR A CA   3 
+ATOM   4071 C  C    . TYR A 1 96 ? -13.087 -2.545  8.937   1.00 0.00 ? 96 TYR A C    3 
+ATOM   4072 O  O    . TYR A 1 96 ? -13.895 -2.175  9.774   1.00 0.00 ? 96 TYR A O    3 
+ATOM   4073 C  CB   . TYR A 1 96 ? -14.361 -4.444  7.942   1.00 0.00 ? 96 TYR A CB   3 
+ATOM   4074 C  CG   . TYR A 1 96 ? -15.447 -4.452  8.983   1.00 0.00 ? 96 TYR A CG   3 
+ATOM   4075 C  CD1  . TYR A 1 96 ? -16.170 -3.285  9.244   1.00 0.00 ? 96 TYR A CD1  3 
+ATOM   4076 C  CD2  . TYR A 1 96 ? -15.729 -5.626  9.687   1.00 0.00 ? 96 TYR A CD2  3 
+ATOM   4077 C  CE1  . TYR A 1 96 ? -17.180 -3.291  10.211  1.00 0.00 ? 96 TYR A CE1  3 
+ATOM   4078 C  CE2  . TYR A 1 96 ? -16.738 -5.635  10.653  1.00 0.00 ? 96 TYR A CE2  3 
+ATOM   4079 C  CZ   . TYR A 1 96 ? -17.465 -4.467  10.917  1.00 0.00 ? 96 TYR A CZ   3 
+ATOM   4080 O  OH   . TYR A 1 96 ? -18.461 -4.475  11.872  1.00 0.00 ? 96 TYR A OH   3 
+ATOM   4081 O  OXT  . TYR A 1 96 ? -12.313 -1.798  8.360   1.00 0.00 ? 96 TYR A OXT  3 
+ATOM   4082 H  H    . TYR A 1 96 ? -13.341 -5.678  9.931   1.00 0.00 ? 96 TYR A H    3 
+ATOM   4083 H  HA   . TYR A 1 96 ? -12.229 -4.225  7.907   1.00 0.00 ? 96 TYR A HA   3 
+ATOM   4084 H  HB2  . TYR A 1 96 ? -14.614 -3.741  7.169   1.00 0.00 ? 96 TYR A HB2  3 
+ATOM   4085 H  HB3  . TYR A 1 96 ? -14.266 -5.431  7.518   1.00 0.00 ? 96 TYR A HB3  3 
+ATOM   4086 H  HD1  . TYR A 1 96 ? -15.949 -2.378  8.700   1.00 0.00 ? 96 TYR A HD1  3 
+ATOM   4087 H  HD2  . TYR A 1 96 ? -15.168 -6.527  9.483   1.00 0.00 ? 96 TYR A HD2  3 
+ATOM   4088 H  HE1  . TYR A 1 96 ? -17.737 -2.390  10.410  1.00 0.00 ? 96 TYR A HE1  3 
+ATOM   4089 H  HE2  . TYR A 1 96 ? -16.955 -6.542  11.195  1.00 0.00 ? 96 TYR A HE2  3 
+ATOM   4090 H  HH   . TYR A 1 96 ? -18.056 -4.307  12.727  1.00 0.00 ? 96 TYR A HH   3 
+HETATM 4091 FE FE1  . FES B 2 .  ? -4.159  10.772  -0.886  1.00 0.00 ? 97 FES A FE1  3 
+HETATM 4092 FE FE2  . FES B 2 .  ? -2.565  9.021   -1.535  1.00 0.00 ? 97 FES A FE2  3 
+# 
+loop_
+_pdbx_poly_seq_scheme.asym_id 
+_pdbx_poly_seq_scheme.entity_id 
+_pdbx_poly_seq_scheme.seq_id 
+_pdbx_poly_seq_scheme.mon_id 
+_pdbx_poly_seq_scheme.ndb_seq_num 
+_pdbx_poly_seq_scheme.pdb_seq_num 
+_pdbx_poly_seq_scheme.auth_seq_num 
+_pdbx_poly_seq_scheme.pdb_mon_id 
+_pdbx_poly_seq_scheme.auth_mon_id 
+_pdbx_poly_seq_scheme.pdb_strand_id 
+_pdbx_poly_seq_scheme.pdb_ins_code 
+_pdbx_poly_seq_scheme.hetero 
+A 1 1  ALA 1  1  1  ALA ALA A . n 
+A 1 2  SER 2  2  2  SER SER A . n 
+A 1 3  TYR 3  3  3  TYR TYR A . n 
+A 1 4  THR 4  4  4  THR THR A . n 
+A 1 5  VAL 5  5  5  VAL VAL A . n 
+A 1 6  LYS 6  6  6  LYS LYS A . n 
+A 1 7  LEU 7  7  7  LEU LEU A . n 
+A 1 8  ILE 8  8  8  ILE ILE A . n 
+A 1 9  THR 9  9  9  THR THR A . n 
+A 1 10 PRO 10 10 10 PRO PRO A . n 
+A 1 11 ASP 11 11 11 ASP ASP A . n 
+A 1 12 GLY 12 12 12 GLY GLY A . n 
+A 1 13 GLU 13 13 13 GLU GLU A . n 
+A 1 14 SER 14 14 14 SER SER A . n 
+A 1 15 SER 15 15 15 SER SER A . n 
+A 1 16 ILE 16 16 16 ILE ILE A . n 
+A 1 17 GLU 17 17 17 GLU GLU A . n 
+A 1 18 CYS 18 18 18 CYS CYS A . n 
+A 1 19 SER 19 19 19 SER SER A . n 
+A 1 20 ASP 20 20 20 ASP ASP A . n 
+A 1 21 ASP 21 21 21 ASP ASP A . n 
+A 1 22 THR 22 22 22 THR THR A . n 
+A 1 23 TYR 23 23 23 TYR TYR A . n 
+A 1 24 ILE 24 24 24 ILE ILE A . n 
+A 1 25 LEU 25 25 25 LEU LEU A . n 
+A 1 26 ASP 26 26 26 ASP ASP A . n 
+A 1 27 ALA 27 27 27 ALA ALA A . n 
+A 1 28 ALA 28 28 28 ALA ALA A . n 
+A 1 29 GLU 29 29 29 GLU GLU A . n 
+A 1 30 GLU 30 30 30 GLU GLU A . n 
+A 1 31 ALA 31 31 31 ALA ALA A . n 
+A 1 32 GLY 32 32 32 GLY GLY A . n 
+A 1 33 LEU 33 33 33 LEU LEU A . n 
+A 1 34 ASP 34 34 34 ASP ASP A . n 
+A 1 35 LEU 35 35 35 LEU LEU A . n 
+A 1 36 PRO 36 36 36 PRO PRO A . n 
+A 1 37 TYR 37 37 37 TYR TYR A . n 
+A 1 38 SER 38 38 38 SER SER A . n 
+A 1 39 CYS 39 39 39 CYS CYS A . n 
+A 1 40 ARG 40 40 40 ARG ARG A . n 
+A 1 41 ALA 41 41 41 ALA ALA A . n 
+A 1 42 GLY 42 42 42 GLY GLY A . n 
+A 1 43 ALA 43 43 43 ALA ALA A . n 
+A 1 44 CYS 44 44 44 CYS CYS A . n 
+A 1 45 SER 45 45 45 SER SER A . n 
+A 1 46 THR 46 46 46 THR THR A . n 
+A 1 47 CYS 47 47 47 CYS CYS A . n 
+A 1 48 ALA 48 48 48 ALA ALA A . n 
+A 1 49 GLY 49 49 49 GLY GLY A . n 
+A 1 50 LYS 50 50 50 LYS LYS A . n 
+A 1 51 ILE 51 51 51 ILE ILE A . n 
+A 1 52 THR 52 52 52 THR THR A . n 
+A 1 53 ALA 53 53 53 ALA ALA A . n 
+A 1 54 GLY 54 54 54 GLY GLY A . n 
+A 1 55 SER 55 55 55 SER SER A . n 
+A 1 56 VAL 56 56 56 VAL VAL A . n 
+A 1 57 ASP 57 57 57 ASP ASP A . n 
+A 1 58 GLN 58 58 58 GLN GLN A . n 
+A 1 59 SER 59 59 59 SER SER A . n 
+A 1 60 ASP 60 60 60 ASP ASP A . n 
+A 1 61 GLN 61 61 61 GLN GLN A . n 
+A 1 62 SER 62 62 62 SER SER A . n 
+A 1 63 PHE 63 63 63 PHE PHE A . n 
+A 1 64 LEU 64 64 64 LEU LEU A . n 
+A 1 65 ASP 65 65 65 ASP ASP A . n 
+A 1 66 ASP 66 66 66 ASP ASP A . n 
+A 1 67 ASP 67 67 67 ASP ASP A . n 
+A 1 68 GLN 68 68 68 GLN GLN A . n 
+A 1 69 ILE 69 69 69 ILE ILE A . n 
+A 1 70 GLU 70 70 70 GLU GLU A . n 
+A 1 71 ALA 71 71 71 ALA ALA A . n 
+A 1 72 GLY 72 72 72 GLY GLY A . n 
+A 1 73 TYR 73 73 73 TYR TYR A . n 
+A 1 74 VAL 74 74 74 VAL VAL A . n 
+A 1 75 LEU 75 75 75 LEU LEU A . n 
+A 1 76 THR 76 76 76 THR THR A . n 
+A 1 77 CYS 77 77 77 CYS CYS A . n 
+A 1 78 VAL 78 78 78 VAL VAL A . n 
+A 1 79 ALA 79 79 79 ALA ALA A . n 
+A 1 80 TYR 80 80 80 TYR TYR A . n 
+A 1 81 PRO 81 81 81 PRO PRO A . n 
+A 1 82 THR 82 82 82 THR THR A . n 
+A 1 83 SER 83 83 83 SER SER A . n 
+A 1 84 ASP 84 84 84 ASP ASP A . n 
+A 1 85 CYS 85 85 85 CYS CYS A . n 
+A 1 86 THR 86 86 86 THR THR A . n 
+A 1 87 ILE 87 87 87 ILE ILE A . n 
+A 1 88 GLU 88 88 88 GLU GLU A . n 
+A 1 89 THR 89 89 89 THR THR A . n 
+A 1 90 HIS 90 90 90 HIS HIS A . n 
+A 1 91 LYS 91 91 91 LYS LYS A . n 
+A 1 92 GLU 92 92 92 GLU GLU A . n 
+A 1 93 GLU 93 93 93 GLU GLU A . n 
+A 1 94 ASP 94 94 94 ASP ASP A . n 
+A 1 95 LEU 95 95 95 LEU LEU A . n 
+A 1 96 TYR 96 96 96 TYR TYR A . n 
+# 
+_pdbx_nonpoly_scheme.asym_id         B 
+_pdbx_nonpoly_scheme.entity_id       2 
+_pdbx_nonpoly_scheme.mon_id          FES 
+_pdbx_nonpoly_scheme.ndb_seq_num     1 
+_pdbx_nonpoly_scheme.pdb_seq_num     97 
+_pdbx_nonpoly_scheme.auth_seq_num    97 
+_pdbx_nonpoly_scheme.pdb_mon_id      FES 
+_pdbx_nonpoly_scheme.auth_mon_id     FES 
+_pdbx_nonpoly_scheme.pdb_strand_id   A 
+_pdbx_nonpoly_scheme.pdb_ins_code    . 
+# 
+_pdbx_struct_assembly.id                   1 
+_pdbx_struct_assembly.details              author_defined_assembly 
+_pdbx_struct_assembly.method_details       ? 
+_pdbx_struct_assembly.oligomeric_details   monomeric 
+_pdbx_struct_assembly.oligomeric_count     1 
+# 
+_pdbx_struct_assembly_gen.assembly_id       1 
+_pdbx_struct_assembly_gen.oper_expression   1 
+_pdbx_struct_assembly_gen.asym_id_list      A,B 
+# 
+_pdbx_struct_oper_list.id                   1 
+_pdbx_struct_oper_list.type                 'identity operation' 
+_pdbx_struct_oper_list.name                 1_555 
+_pdbx_struct_oper_list.symmetry_operation   x,y,z 
+_pdbx_struct_oper_list.matrix[1][1]         1.0000000000 
+_pdbx_struct_oper_list.matrix[1][2]         0.0000000000 
+_pdbx_struct_oper_list.matrix[1][3]         0.0000000000 
+_pdbx_struct_oper_list.vector[1]            0.0000000000 
+_pdbx_struct_oper_list.matrix[2][1]         0.0000000000 
+_pdbx_struct_oper_list.matrix[2][2]         1.0000000000 
+_pdbx_struct_oper_list.matrix[2][3]         0.0000000000 
+_pdbx_struct_oper_list.vector[2]            0.0000000000 
+_pdbx_struct_oper_list.matrix[3][1]         0.0000000000 
+_pdbx_struct_oper_list.matrix[3][2]         0.0000000000 
+_pdbx_struct_oper_list.matrix[3][3]         1.0000000000 
+_pdbx_struct_oper_list.vector[3]            0.0000000000 
+# 
+loop_
+_pdbx_struct_conn_angle.id 
+_pdbx_struct_conn_angle.ptnr1_label_atom_id 
+_pdbx_struct_conn_angle.ptnr1_label_alt_id 
+_pdbx_struct_conn_angle.ptnr1_label_asym_id 
+_pdbx_struct_conn_angle.ptnr1_label_comp_id 
+_pdbx_struct_conn_angle.ptnr1_label_seq_id 
+_pdbx_struct_conn_angle.ptnr1_auth_atom_id 
+_pdbx_struct_conn_angle.ptnr1_auth_asym_id 
+_pdbx_struct_conn_angle.ptnr1_auth_comp_id 
+_pdbx_struct_conn_angle.ptnr1_auth_seq_id 
+_pdbx_struct_conn_angle.ptnr1_PDB_ins_code 
+_pdbx_struct_conn_angle.ptnr1_symmetry 
+_pdbx_struct_conn_angle.ptnr2_label_atom_id 
+_pdbx_struct_conn_angle.ptnr2_label_alt_id 
+_pdbx_struct_conn_angle.ptnr2_label_asym_id 
+_pdbx_struct_conn_angle.ptnr2_label_comp_id 
+_pdbx_struct_conn_angle.ptnr2_label_seq_id 
+_pdbx_struct_conn_angle.ptnr2_auth_atom_id 
+_pdbx_struct_conn_angle.ptnr2_auth_asym_id 
+_pdbx_struct_conn_angle.ptnr2_auth_comp_id 
+_pdbx_struct_conn_angle.ptnr2_auth_seq_id 
+_pdbx_struct_conn_angle.ptnr2_PDB_ins_code 
+_pdbx_struct_conn_angle.ptnr2_symmetry 
+_pdbx_struct_conn_angle.ptnr3_label_atom_id 
+_pdbx_struct_conn_angle.ptnr3_label_alt_id 
+_pdbx_struct_conn_angle.ptnr3_label_asym_id 
+_pdbx_struct_conn_angle.ptnr3_label_comp_id 
+_pdbx_struct_conn_angle.ptnr3_label_seq_id 
+_pdbx_struct_conn_angle.ptnr3_auth_atom_id 
+_pdbx_struct_conn_angle.ptnr3_auth_asym_id 
+_pdbx_struct_conn_angle.ptnr3_auth_comp_id 
+_pdbx_struct_conn_angle.ptnr3_auth_seq_id 
+_pdbx_struct_conn_angle.ptnr3_PDB_ins_code 
+_pdbx_struct_conn_angle.ptnr3_symmetry 
+_pdbx_struct_conn_angle.value 
+_pdbx_struct_conn_angle.value_esd 
+1 SG ? A CYS 39 ? A CYS 39 ? 1_555 FE1 ? B FES . ? A FES 97 ? 1_555 SG ? A CYS 44 ? A CYS 44 ? 1_555 83.7  ? 
+2 SG ? A CYS 47 ? A CYS 47 ? 1_555 FE2 ? B FES . ? A FES 97 ? 1_555 SG ? A CYS 77 ? A CYS 77 ? 1_555 122.9 ? 
+# 
+loop_
+_pdbx_audit_revision_history.ordinal 
+_pdbx_audit_revision_history.data_content_type 
+_pdbx_audit_revision_history.major_revision 
+_pdbx_audit_revision_history.minor_revision 
+_pdbx_audit_revision_history.revision_date 
+1 'Structure model' 1 0 1996-03-08 
+2 'Structure model' 1 1 2008-03-03 
+3 'Structure model' 1 2 2011-07-13 
+# 
+_pdbx_audit_revision_details.ordinal             1 
+_pdbx_audit_revision_details.revision_ordinal    1 
+_pdbx_audit_revision_details.data_content_type   'Structure model' 
+_pdbx_audit_revision_details.provider            repository 
+_pdbx_audit_revision_details.type                'Initial release' 
+_pdbx_audit_revision_details.description         ? 
+# 
+loop_
+_pdbx_audit_revision_group.ordinal 
+_pdbx_audit_revision_group.revision_ordinal 
+_pdbx_audit_revision_group.data_content_type 
+_pdbx_audit_revision_group.group 
+1 2 'Structure model' 'Version format compliance' 
+2 3 'Structure model' 'Source and taxonomy'       
+3 3 'Structure model' 'Version format compliance' 
+# 
+loop_
+_software.name 
+_software.classification 
+_software.version 
+_software.citation_id 
+_software.pdbx_ordinal 
+X-PLOR 'model building' 3.0 ? 1 
+X-PLOR refinement       3.0 ? 2 
+X-PLOR phasing          3.0 ? 3 
+# 
+loop_
+_pdbx_validate_torsion.id 
+_pdbx_validate_torsion.PDB_model_num 
+_pdbx_validate_torsion.auth_comp_id 
+_pdbx_validate_torsion.auth_asym_id 
+_pdbx_validate_torsion.auth_seq_id 
+_pdbx_validate_torsion.PDB_ins_code 
+_pdbx_validate_torsion.label_alt_id 
+_pdbx_validate_torsion.phi 
+_pdbx_validate_torsion.psi 
+1   1 SER A 2  ? ? 58.17   168.51  
+2   1 TYR A 3  ? ? 37.11   79.61   
+3   1 THR A 4  ? ? -165.87 -35.64  
+4   1 VAL A 5  ? ? -51.84  -131.87 
+5   1 ILE A 8  ? ? -173.54 108.18  
+6   1 THR A 9  ? ? -125.86 -160.70 
+7   1 PRO A 10 ? ? -48.60  -18.99  
+8   1 ASP A 11 ? ? -111.34 69.64   
+9   1 CYS A 18 ? ? 22.10   56.14   
+10  1 SER A 19 ? ? -89.22  39.31   
+11  1 ASP A 20 ? ? -165.03 37.73   
+12  1 ASP A 21 ? ? 71.13   164.27  
+13  1 THR A 22 ? ? 103.24  -123.66 
+14  1 TYR A 23 ? ? 81.69   -47.18  
+15  1 ILE A 24 ? ? -14.53  161.89  
+16  1 ALA A 28 ? ? -96.22  -73.74  
+17  1 GLU A 29 ? ? -45.93  -14.35  
+18  1 ASP A 34 ? ? 22.92   109.89  
+19  1 SER A 38 ? ? -164.40 -45.62  
+20  1 CYS A 39 ? ? -35.15  -30.07  
+21  1 ARG A 40 ? ? 69.60   163.33  
+22  1 ALA A 48 ? ? -98.66  47.21   
+23  1 ILE A 51 ? ? 74.17   57.13   
+24  1 ALA A 53 ? ? 33.66   29.73   
+25  1 GLN A 58 ? ? 81.83   -56.79  
+26  1 SER A 59 ? ? -85.19  48.06   
+27  1 GLN A 61 ? ? 42.18   -148.64 
+28  1 ASP A 65 ? ? -165.71 -74.78  
+29  1 ASP A 66 ? ? -144.78 19.68   
+30  1 ASP A 67 ? ? 82.47   -44.80  
+31  1 GLN A 68 ? ? -160.13 -38.25  
+32  1 ILE A 69 ? ? 172.33  26.69   
+33  1 GLU A 70 ? ? 175.36  73.59   
+34  1 ALA A 71 ? ? -171.63 76.92   
+35  1 LEU A 75 ? ? -65.64  93.03   
+36  1 CYS A 77 ? ? -65.79  7.85    
+37  1 TYR A 80 ? ? -136.66 -93.76  
+38  1 ASP A 84 ? ? 81.08   144.11  
+39  1 LYS A 91 ? ? 178.34  92.27   
+40  1 ASP A 94 ? ? -147.36 -44.92  
+41  1 LEU A 95 ? ? 75.57   50.98   
+42  2 SER A 2  ? ? -86.37  -102.06 
+43  2 TYR A 3  ? ? -84.21  -94.06  
+44  2 VAL A 5  ? ? -4.27   131.99  
+45  2 LEU A 7  ? ? 143.88  -103.86 
+46  2 ILE A 8  ? ? 55.34   -99.81  
+47  2 THR A 9  ? ? 117.71  -73.63  
+48  2 ASP A 11 ? ? -114.37 78.56   
+49  2 SER A 15 ? ? -150.73 81.74   
+50  2 ILE A 16 ? ? -140.89 -85.32  
+51  2 GLU A 17 ? ? 93.94   -30.86  
+52  2 CYS A 18 ? ? 75.28   -73.41  
+53  2 SER A 19 ? ? 46.82   27.44   
+54  2 ASP A 20 ? ? 177.89  68.65   
+55  2 ASP A 21 ? ? 74.28   100.66  
+56  2 THR A 22 ? ? -35.54  92.14   
+57  2 TYR A 23 ? ? -54.99  100.40  
+58  2 ILE A 24 ? ? -17.41  166.56  
+59  2 ALA A 28 ? ? -86.84  -80.72  
+60  2 ALA A 31 ? ? -39.62  -29.44  
+61  2 LEU A 33 ? ? -175.45 11.49   
+62  2 ASP A 34 ? ? -126.20 -158.25 
+63  2 LEU A 35 ? ? 156.78  106.36  
+64  2 PRO A 36 ? ? -72.44  -85.81  
+65  2 TYR A 37 ? ? 32.91   44.26   
+66  2 SER A 38 ? ? -137.31 -47.39  
+67  2 ARG A 40 ? ? 38.22   -161.96 
+68  2 ALA A 41 ? ? 44.12   -121.52 
+69  2 ALA A 43 ? ? -151.39 18.91   
+70  2 CYS A 47 ? ? -102.50 64.59   
+71  2 LYS A 50 ? ? -65.60  95.72   
+72  2 ILE A 51 ? ? 9.99    112.84  
+73  2 THR A 52 ? ? 157.90  -15.61  
+74  2 SER A 55 ? ? 51.52   -167.28 
+75  2 GLN A 58 ? ? 81.39   -61.63  
+76  2 GLN A 61 ? ? 49.62   -174.66 
+77  2 LEU A 64 ? ? 61.99   149.84  
+78  2 ASP A 65 ? ? -160.29 -64.01  
+79  2 ASP A 66 ? ? -154.04 17.32   
+80  2 ASP A 67 ? ? 83.28   -44.28  
+81  2 GLN A 68 ? ? 177.43  36.38   
+82  2 ILE A 69 ? ? 85.42   32.15   
+83  2 GLU A 70 ? ? 174.63  78.19   
+84  2 ALA A 71 ? ? 177.05  80.68   
+85  2 VAL A 74 ? ? -63.79  -149.45 
+86  2 VAL A 78 ? ? -163.50 64.77   
+87  2 ALA A 79 ? ? -110.65 -150.61 
+88  2 TYR A 80 ? ? -106.79 -157.64 
+89  2 PRO A 81 ? ? -50.61  -85.95  
+90  2 THR A 82 ? ? 138.10  114.79  
+91  2 ASP A 84 ? ? 173.48  159.07  
+92  2 THR A 86 ? ? 173.43  128.59  
+93  2 LYS A 91 ? ? 45.74   74.87   
+94  2 ASP A 94 ? ? -136.92 -45.73  
+95  3 TYR A 3  ? ? 49.44   84.24   
+96  3 THR A 4  ? ? -166.39 -36.49  
+97  3 VAL A 5  ? ? -47.54  -167.17 
+98  3 LEU A 7  ? ? -119.00 -169.57 
+99  3 ILE A 8  ? ? 54.79   -139.28 
+100 3 ASP A 11 ? ? -100.14 76.04   
+101 3 ILE A 16 ? ? -130.58 -92.83  
+102 3 CYS A 18 ? ? -13.34  90.51   
+103 3 ASP A 20 ? ? 168.64  -92.22  
+104 3 THR A 22 ? ? 78.50   154.11  
+105 3 TYR A 23 ? ? -80.51  38.51   
+106 3 ILE A 24 ? ? -19.74  153.91  
+107 3 LEU A 25 ? ? -15.03  -52.59  
+108 3 ALA A 28 ? ? -45.88  -96.09  
+109 3 LEU A 33 ? ? 66.15   -14.41  
+110 3 LEU A 35 ? ? 168.20  65.66   
+111 3 TYR A 37 ? ? -41.35  98.34   
+112 3 ARG A 40 ? ? 53.16   -157.11 
+113 3 ALA A 41 ? ? -69.85  85.27   
+114 3 ALA A 43 ? ? -149.08 56.82   
+115 3 VAL A 56 ? ? 157.47  167.79  
+116 3 SER A 59 ? ? -39.89  -39.70  
+117 3 GLN A 61 ? ? -78.49  -164.09 
+118 3 SER A 62 ? ? -67.61  -146.75 
+119 3 PHE A 63 ? ? 69.00   100.63  
+120 3 LEU A 64 ? ? -56.04  -176.49 
+121 3 ASP A 65 ? ? 62.65   135.65  
+122 3 GLN A 68 ? ? -162.07 -31.30  
+123 3 ILE A 69 ? ? -179.34 98.25   
+124 3 GLU A 70 ? ? 83.36   -69.87  
+125 3 ALA A 71 ? ? 50.36   16.14   
+126 3 VAL A 74 ? ? -149.27 47.76   
+127 3 CYS A 77 ? ? -58.80  -9.23   
+128 3 ALA A 79 ? ? 43.05   106.87  
+129 3 THR A 82 ? ? -102.07 -113.31 
+130 3 SER A 83 ? ? 149.56  -22.05  
+131 3 ASP A 84 ? ? 162.05  148.70  
+132 3 THR A 86 ? ? -164.79 89.18   
+133 3 ILE A 87 ? ? 82.66   -136.37 
+134 3 GLU A 88 ? ? 154.00  -35.99  
+135 3 THR A 89 ? ? -175.13 38.95   
+136 3 ASP A 94 ? ? -148.70 36.07   
+137 3 LEU A 95 ? ? -154.20 29.10   
+# 
+_pdbx_entity_nonpoly.entity_id   2 
+_pdbx_entity_nonpoly.name        'FE2/S2 (INORGANIC) CLUSTER' 
+_pdbx_entity_nonpoly.comp_id     FES 
+# 

--- a/Code/GraphMol/FileParsers/test_data/2fvd.cif
+++ b/Code/GraphMol/FileParsers/test_data/2fvd.cif
@@ -1,0 +1,4176 @@
+data_2FVD
+# 
+_entry.id   2FVD 
+# 
+_audit_conform.dict_name       mmcif_pdbx.dic 
+_audit_conform.dict_version    5.279 
+_audit_conform.dict_location   http://mmcif.pdb.org/dictionaries/ascii/mmcif_pdbx.dic 
+# 
+loop_
+_database_2.database_id 
+_database_2.database_code 
+PDB   2FVD         
+RCSB  RCSB036356   
+WWPDB D_1000036356 
+# 
+_pdbx_database_status.status_code                     REL 
+_pdbx_database_status.entry_id                        2FVD 
+_pdbx_database_status.recvd_initial_deposition_date   2006-01-30 
+_pdbx_database_status.deposit_site                    RCSB 
+_pdbx_database_status.process_site                    RCSB 
+_pdbx_database_status.status_code_sf                  REL 
+_pdbx_database_status.status_code_mr                  ? 
+_pdbx_database_status.SG_entry                        ? 
+_pdbx_database_status.pdb_format_compatible           Y 
+_pdbx_database_status.status_code_cs                  ? 
+# 
+loop_
+_audit_author.name 
+_audit_author.pdbx_ordinal 
+'Crowther, R.L.' 1 
+'Lukacs, C.M.'   2 
+'Kammlott, R.U.' 3 
+# 
+_citation.id                        primary 
+_citation.title                     
+;Discovery of [4-Amino-2-(1-methanesulfonylpiperidin-4-ylamino)pyrimidin-5-yl](2,3-difluoro-6- methoxyphenyl)methanone (R547), a potent and selective cyclin-dependent kinase inhibitor with significant in vivo antitumor activity.
+;
+_citation.journal_abbrev            J.Med.Chem. 
+_citation.journal_volume            49 
+_citation.page_first                6549 
+_citation.page_last                 6560 
+_citation.year                      2006 
+_citation.journal_id_ASTM           JMCMAR 
+_citation.country                   US 
+_citation.journal_id_ISSN           0022-2623 
+_citation.journal_id_CSD            0151 
+_citation.book_publisher            ? 
+_citation.pdbx_database_id_PubMed   17064073 
+_citation.pdbx_database_id_DOI      10.1021/jm0606138 
+# 
+loop_
+_citation_author.citation_id 
+_citation_author.name 
+_citation_author.ordinal 
+primary 'Chu, X.J.'      1  
+primary 'DePinto, W.'    2  
+primary 'Bartkovitz, D.' 3  
+primary 'So, S.S.'       4  
+primary 'Vu, B.T.'       5  
+primary 'Packman, K.'    6  
+primary 'Lukacs, C.'     7  
+primary 'Ding, Q.'       8  
+primary 'Jiang, N.'      9  
+primary 'Wang, K.'       10 
+primary 'Goelzer, P.'    11 
+primary 'Yin, X.'        12 
+primary 'Smith, M.A.'    13 
+primary 'Higgins, B.X.'  14 
+primary 'Chen, Y.'       15 
+primary 'Xiang, Q.'      16 
+primary 'Moliterni, J.'  17 
+primary 'Kaplan, G.'     18 
+primary 'Graves, B.'     19 
+primary 'Lovey, A.'      20 
+primary 'Fotouhi, N.'    21 
+# 
+_cell.entry_id           2FVD 
+_cell.length_a           53.506 
+_cell.length_b           71.647 
+_cell.length_c           71.692 
+_cell.angle_alpha        90.00 
+_cell.angle_beta         90.00 
+_cell.angle_gamma        90.00 
+_cell.Z_PDB              4 
+_cell.pdbx_unique_axis   ? 
+_cell.length_a_esd       ? 
+_cell.length_b_esd       ? 
+_cell.length_c_esd       ? 
+_cell.angle_alpha_esd    ? 
+_cell.angle_beta_esd     ? 
+_cell.angle_gamma_esd    ? 
+# 
+_symmetry.entry_id                         2FVD 
+_symmetry.space_group_name_H-M             'P 21 21 21' 
+_symmetry.pdbx_full_space_group_name_H-M   ? 
+_symmetry.cell_setting                     ? 
+_symmetry.Int_Tables_number                19 
+_symmetry.space_group_name_Hall            ? 
+# 
+loop_
+_entity.id 
+_entity.type 
+_entity.src_method 
+_entity.pdbx_description 
+_entity.formula_weight 
+_entity.pdbx_number_of_molecules 
+_entity.pdbx_ec 
+_entity.pdbx_mutation 
+_entity.pdbx_fragment 
+_entity.details 
+1 polymer     man 'Cell division protein kinase 2'                                                                             
+33976.488 1   2.7.1.37 ? ? ? 
+2 non-polymer syn '(4-AMINO-2-{[1-(METHYLSULFONYL)PIPERIDIN-4-YL]AMINO}PYRIMIDIN-5-YL)(2,3-DIFLUORO-6-METHOXYPHENYL)METHANONE' 
+441.452   1   ?        ? ? ? 
+3 water       nat water                                                                                                        
+18.015    179 ?        ? ? ? 
+# 
+_entity_name_com.entity_id   1 
+_entity_name_com.name        'p33 protein kinase' 
+# 
+_entity_poly.entity_id                      1 
+_entity_poly.type                           'polypeptide(L)' 
+_entity_poly.nstd_linkage                   no 
+_entity_poly.nstd_monomer                   no 
+_entity_poly.pdbx_seq_one_letter_code       
+;MENFQKVEKIGEGTYGVVYKARNKLTGEVVALKKIRLDTETEGVPSTAIREISLLKELNHPNIVKLLDVIHTENKLYLVF
+EFLHQDLKKFMDASALTGIPLPLIKSYLFQLLQGLAFCHSHRVLHRDLKPQNLLINTEGAIKLADFGLARAFGVPVRTYT
+HEVVTLWYRAPEILLGCKYYSTAVDIWSLGCIFAEMVTRRALFPGDSEIDQLFRIFRTLGTPDEVVWPGVTSMPDYKPSF
+PKWARQDFSKVVPPLDEDGRSLLSQMLHYDPNKRISAKAALAHPFFQDVTKPVPHLRL
+;
+_entity_poly.pdbx_seq_one_letter_code_can   
+;MENFQKVEKIGEGTYGVVYKARNKLTGEVVALKKIRLDTETEGVPSTAIREISLLKELNHPNIVKLLDVIHTENKLYLVF
+EFLHQDLKKFMDASALTGIPLPLIKSYLFQLLQGLAFCHSHRVLHRDLKPQNLLINTEGAIKLADFGLARAFGVPVRTYT
+HEVVTLWYRAPEILLGCKYYSTAVDIWSLGCIFAEMVTRRALFPGDSEIDQLFRIFRTLGTPDEVVWPGVTSMPDYKPSF
+PKWARQDFSKVVPPLDEDGRSLLSQMLHYDPNKRISAKAALAHPFFQDVTKPVPHLRL
+;
+_entity_poly.pdbx_strand_id                 A 
+_entity_poly.pdbx_target_identifier         ? 
+# 
+loop_
+_entity_poly_seq.entity_id 
+_entity_poly_seq.num 
+_entity_poly_seq.mon_id 
+_entity_poly_seq.hetero 
+1 1   MET n 
+1 2   GLU n 
+1 3   ASN n 
+1 4   PHE n 
+1 5   GLN n 
+1 6   LYS n 
+1 7   VAL n 
+1 8   GLU n 
+1 9   LYS n 
+1 10  ILE n 
+1 11  GLY n 
+1 12  GLU n 
+1 13  GLY n 
+1 14  THR n 
+1 15  TYR n 
+1 16  GLY n 
+1 17  VAL n 
+1 18  VAL n 
+1 19  TYR n 
+1 20  LYS n 
+1 21  ALA n 
+1 22  ARG n 
+1 23  ASN n 
+1 24  LYS n 
+1 25  LEU n 
+1 26  THR n 
+1 27  GLY n 
+1 28  GLU n 
+1 29  VAL n 
+1 30  VAL n 
+1 31  ALA n 
+1 32  LEU n 
+1 33  LYS n 
+1 34  LYS n 
+1 35  ILE n 
+1 36  ARG n 
+1 37  LEU n 
+1 38  ASP n 
+1 39  THR n 
+1 40  GLU n 
+1 41  THR n 
+1 42  GLU n 
+1 43  GLY n 
+1 44  VAL n 
+1 45  PRO n 
+1 46  SER n 
+1 47  THR n 
+1 48  ALA n 
+1 49  ILE n 
+1 50  ARG n 
+1 51  GLU n 
+1 52  ILE n 
+1 53  SER n 
+1 54  LEU n 
+1 55  LEU n 
+1 56  LYS n 
+1 57  GLU n 
+1 58  LEU n 
+1 59  ASN n 
+1 60  HIS n 
+1 61  PRO n 
+1 62  ASN n 
+1 63  ILE n 
+1 64  VAL n 
+1 65  LYS n 
+1 66  LEU n 
+1 67  LEU n 
+1 68  ASP n 
+1 69  VAL n 
+1 70  ILE n 
+1 71  HIS n 
+1 72  THR n 
+1 73  GLU n 
+1 74  ASN n 
+1 75  LYS n 
+1 76  LEU n 
+1 77  TYR n 
+1 78  LEU n 
+1 79  VAL n 
+1 80  PHE n 
+1 81  GLU n 
+1 82  PHE n 
+1 83  LEU n 
+1 84  HIS n 
+1 85  GLN n 
+1 86  ASP n 
+1 87  LEU n 
+1 88  LYS n 
+1 89  LYS n 
+1 90  PHE n 
+1 91  MET n 
+1 92  ASP n 
+1 93  ALA n 
+1 94  SER n 
+1 95  ALA n 
+1 96  LEU n 
+1 97  THR n 
+1 98  GLY n 
+1 99  ILE n 
+1 100 PRO n 
+1 101 LEU n 
+1 102 PRO n 
+1 103 LEU n 
+1 104 ILE n 
+1 105 LYS n 
+1 106 SER n 
+1 107 TYR n 
+1 108 LEU n 
+1 109 PHE n 
+1 110 GLN n 
+1 111 LEU n 
+1 112 LEU n 
+1 113 GLN n 
+1 114 GLY n 
+1 115 LEU n 
+1 116 ALA n 
+1 117 PHE n 
+1 118 CYS n 
+1 119 HIS n 
+1 120 SER n 
+1 121 HIS n 
+1 122 ARG n 
+1 123 VAL n 
+1 124 LEU n 
+1 125 HIS n 
+1 126 ARG n 
+1 127 ASP n 
+1 128 LEU n 
+1 129 LYS n 
+1 130 PRO n 
+1 131 GLN n 
+1 132 ASN n 
+1 133 LEU n 
+1 134 LEU n 
+1 135 ILE n 
+1 136 ASN n 
+1 137 THR n 
+1 138 GLU n 
+1 139 GLY n 
+1 140 ALA n 
+1 141 ILE n 
+1 142 LYS n 
+1 143 LEU n 
+1 144 ALA n 
+1 145 ASP n 
+1 146 PHE n 
+1 147 GLY n 
+1 148 LEU n 
+1 149 ALA n 
+1 150 ARG n 
+1 151 ALA n 
+1 152 PHE n 
+1 153 GLY n 
+1 154 VAL n 
+1 155 PRO n 
+1 156 VAL n 
+1 157 ARG n 
+1 158 THR n 
+1 159 TYR n 
+1 160 THR n 
+1 161 HIS n 
+1 162 GLU n 
+1 163 VAL n 
+1 164 VAL n 
+1 165 THR n 
+1 166 LEU n 
+1 167 TRP n 
+1 168 TYR n 
+1 169 ARG n 
+1 170 ALA n 
+1 171 PRO n 
+1 172 GLU n 
+1 173 ILE n 
+1 174 LEU n 
+1 175 LEU n 
+1 176 GLY n 
+1 177 CYS n 
+1 178 LYS n 
+1 179 TYR n 
+1 180 TYR n 
+1 181 SER n 
+1 182 THR n 
+1 183 ALA n 
+1 184 VAL n 
+1 185 ASP n 
+1 186 ILE n 
+1 187 TRP n 
+1 188 SER n 
+1 189 LEU n 
+1 190 GLY n 
+1 191 CYS n 
+1 192 ILE n 
+1 193 PHE n 
+1 194 ALA n 
+1 195 GLU n 
+1 196 MET n 
+1 197 VAL n 
+1 198 THR n 
+1 199 ARG n 
+1 200 ARG n 
+1 201 ALA n 
+1 202 LEU n 
+1 203 PHE n 
+1 204 PRO n 
+1 205 GLY n 
+1 206 ASP n 
+1 207 SER n 
+1 208 GLU n 
+1 209 ILE n 
+1 210 ASP n 
+1 211 GLN n 
+1 212 LEU n 
+1 213 PHE n 
+1 214 ARG n 
+1 215 ILE n 
+1 216 PHE n 
+1 217 ARG n 
+1 218 THR n 
+1 219 LEU n 
+1 220 GLY n 
+1 221 THR n 
+1 222 PRO n 
+1 223 ASP n 
+1 224 GLU n 
+1 225 VAL n 
+1 226 VAL n 
+1 227 TRP n 
+1 228 PRO n 
+1 229 GLY n 
+1 230 VAL n 
+1 231 THR n 
+1 232 SER n 
+1 233 MET n 
+1 234 PRO n 
+1 235 ASP n 
+1 236 TYR n 
+1 237 LYS n 
+1 238 PRO n 
+1 239 SER n 
+1 240 PHE n 
+1 241 PRO n 
+1 242 LYS n 
+1 243 TRP n 
+1 244 ALA n 
+1 245 ARG n 
+1 246 GLN n 
+1 247 ASP n 
+1 248 PHE n 
+1 249 SER n 
+1 250 LYS n 
+1 251 VAL n 
+1 252 VAL n 
+1 253 PRO n 
+1 254 PRO n 
+1 255 LEU n 
+1 256 ASP n 
+1 257 GLU n 
+1 258 ASP n 
+1 259 GLY n 
+1 260 ARG n 
+1 261 SER n 
+1 262 LEU n 
+1 263 LEU n 
+1 264 SER n 
+1 265 GLN n 
+1 266 MET n 
+1 267 LEU n 
+1 268 HIS n 
+1 269 TYR n 
+1 270 ASP n 
+1 271 PRO n 
+1 272 ASN n 
+1 273 LYS n 
+1 274 ARG n 
+1 275 ILE n 
+1 276 SER n 
+1 277 ALA n 
+1 278 LYS n 
+1 279 ALA n 
+1 280 ALA n 
+1 281 LEU n 
+1 282 ALA n 
+1 283 HIS n 
+1 284 PRO n 
+1 285 PHE n 
+1 286 PHE n 
+1 287 GLN n 
+1 288 ASP n 
+1 289 VAL n 
+1 290 THR n 
+1 291 LYS n 
+1 292 PRO n 
+1 293 VAL n 
+1 294 PRO n 
+1 295 HIS n 
+1 296 LEU n 
+1 297 ARG n 
+1 298 LEU n 
+# 
+_entity_src_gen.entity_id                          1 
+_entity_src_gen.pdbx_src_id                        1 
+_entity_src_gen.pdbx_alt_source_flag               sample 
+_entity_src_gen.pdbx_seq_type                      ? 
+_entity_src_gen.pdbx_beg_seq_num                   ? 
+_entity_src_gen.pdbx_end_seq_num                   ? 
+_entity_src_gen.gene_src_common_name               human 
+_entity_src_gen.gene_src_genus                     Homo 
+_entity_src_gen.pdbx_gene_src_gene                 CDK2 
+_entity_src_gen.gene_src_species                   ? 
+_entity_src_gen.gene_src_strain                    ? 
+_entity_src_gen.gene_src_tissue                    ? 
+_entity_src_gen.gene_src_tissue_fraction           ? 
+_entity_src_gen.gene_src_details                   ? 
+_entity_src_gen.pdbx_gene_src_fragment             ? 
+_entity_src_gen.pdbx_gene_src_scientific_name      'Homo sapiens' 
+_entity_src_gen.pdbx_gene_src_ncbi_taxonomy_id     9606 
+_entity_src_gen.pdbx_gene_src_variant              ? 
+_entity_src_gen.pdbx_gene_src_cell_line            ? 
+_entity_src_gen.pdbx_gene_src_atcc                 ? 
+_entity_src_gen.pdbx_gene_src_organ                ? 
+_entity_src_gen.pdbx_gene_src_organelle            ? 
+_entity_src_gen.pdbx_gene_src_cell                 ? 
+_entity_src_gen.pdbx_gene_src_cellular_location    ? 
+_entity_src_gen.host_org_common_name               ? 
+_entity_src_gen.pdbx_host_org_scientific_name      'unidentified baculovirus' 
+_entity_src_gen.pdbx_host_org_ncbi_taxonomy_id     10469 
+_entity_src_gen.host_org_genus                     ? 
+_entity_src_gen.pdbx_host_org_gene                 ? 
+_entity_src_gen.pdbx_host_org_organ                ? 
+_entity_src_gen.host_org_species                   ? 
+_entity_src_gen.pdbx_host_org_tissue               ? 
+_entity_src_gen.pdbx_host_org_tissue_fraction      ? 
+_entity_src_gen.pdbx_host_org_strain               ? 
+_entity_src_gen.pdbx_host_org_variant              ? 
+_entity_src_gen.pdbx_host_org_cell_line            ? 
+_entity_src_gen.pdbx_host_org_atcc                 ? 
+_entity_src_gen.pdbx_host_org_culture_collection   ? 
+_entity_src_gen.pdbx_host_org_cell                 ? 
+_entity_src_gen.pdbx_host_org_organelle            ? 
+_entity_src_gen.pdbx_host_org_cellular_location    ? 
+_entity_src_gen.pdbx_host_org_vector_type          ? 
+_entity_src_gen.pdbx_host_org_vector               ? 
+_entity_src_gen.host_org_details                   ? 
+_entity_src_gen.expression_system_id               ? 
+_entity_src_gen.plasmid_name                       ? 
+_entity_src_gen.plasmid_details                    ? 
+_entity_src_gen.pdbx_description                   ? 
+# 
+_struct_ref.id                         1 
+_struct_ref.db_name                    UNP 
+_struct_ref.db_code                    CDK2_HUMAN 
+_struct_ref.pdbx_db_accession          P24941 
+_struct_ref.entity_id                  1 
+_struct_ref.pdbx_align_begin           1 
+_struct_ref.pdbx_db_isoform            ? 
+_struct_ref.pdbx_seq_one_letter_code   ? 
+# 
+_struct_ref_seq.align_id                      1 
+_struct_ref_seq.ref_id                        1 
+_struct_ref_seq.pdbx_PDB_id_code              2FVD 
+_struct_ref_seq.pdbx_strand_id                A 
+_struct_ref_seq.seq_align_beg                 1 
+_struct_ref_seq.pdbx_seq_align_beg_ins_code   ? 
+_struct_ref_seq.seq_align_end                 298 
+_struct_ref_seq.pdbx_seq_align_end_ins_code   ? 
+_struct_ref_seq.pdbx_db_accession             P24941 
+_struct_ref_seq.db_align_beg                  1 
+_struct_ref_seq.pdbx_db_align_beg_ins_code    ? 
+_struct_ref_seq.db_align_end                  298 
+_struct_ref_seq.pdbx_db_align_end_ins_code    ? 
+_struct_ref_seq.pdbx_auth_seq_align_beg       1 
+_struct_ref_seq.pdbx_auth_seq_align_end       298 
+# 
+loop_
+_chem_comp.id 
+_chem_comp.type 
+_chem_comp.mon_nstd_flag 
+_chem_comp.name 
+_chem_comp.pdbx_synonyms 
+_chem_comp.formula 
+_chem_comp.formula_weight 
+ALA 'L-peptide linking' y ALANINE ? 'C3 H7 N O2'         89.093  
+ARG 'L-peptide linking' y ARGININE ? 'C6 H15 N4 O2 1'     175.209 
+ASN 'L-peptide linking' y ASPARAGINE ? 'C4 H8 N2 O3'        132.118 
+ASP 'L-peptide linking' y 'ASPARTIC ACID' ? 'C4 H7 N O4'         133.103 
+CYS 'L-peptide linking' y CYSTEINE ? 'C3 H7 N O2 S'       121.158 
+GLN 'L-peptide linking' y GLUTAMINE ? 'C5 H10 N2 O3'       146.144 
+GLU 'L-peptide linking' y 'GLUTAMIC ACID' ? 'C5 H9 N O4'         147.129 
+GLY 'peptide linking'   y GLYCINE ? 'C2 H5 N O2'         75.067  
+HIS 'L-peptide linking' y HISTIDINE ? 'C6 H10 N3 O2 1'     156.162 
+HOH non-polymer         . WATER ? 'H2 O'               18.015  
+ILE 'L-peptide linking' y ISOLEUCINE ? 'C6 H13 N O2'        131.173 
+LEU 'L-peptide linking' y LEUCINE ? 'C6 H13 N O2'        131.173 
+LIA non-polymer         . 
+'(4-AMINO-2-{[1-(METHYLSULFONYL)PIPERIDIN-4-YL]AMINO}PYRIMIDIN-5-YL)(2,3-DIFLUORO-6-METHOXYPHENYL)METHANONE' ? 
+'C18 H21 F2 N5 O4 S' 441.452 
+LYS 'L-peptide linking' y LYSINE ? 'C6 H15 N2 O2 1'     147.195 
+MET 'L-peptide linking' y METHIONINE ? 'C5 H11 N O2 S'      149.211 
+PHE 'L-peptide linking' y PHENYLALANINE ? 'C9 H11 N O2'        165.189 
+PRO 'L-peptide linking' y PROLINE ? 'C5 H9 N O2'         115.130 
+SER 'L-peptide linking' y SERINE ? 'C3 H7 N O3'         105.093 
+THR 'L-peptide linking' y THREONINE ? 'C4 H9 N O3'         119.119 
+TRP 'L-peptide linking' y TRYPTOPHAN ? 'C11 H12 N2 O2'      204.225 
+TYR 'L-peptide linking' y TYROSINE ? 'C9 H11 N O3'        181.189 
+VAL 'L-peptide linking' y VALINE ? 'C5 H11 N O2'        117.146 
+# 
+_exptl.entry_id          2FVD 
+_exptl.method            'X-RAY DIFFRACTION' 
+_exptl.crystals_number   1 
+# 
+_exptl_crystal.id                    1 
+_exptl_crystal.density_meas          ? 
+_exptl_crystal.density_Matthews      2.03 
+_exptl_crystal.density_percent_sol   39.30 
+_exptl_crystal.description           ? 
+_exptl_crystal.F_000                 ? 
+_exptl_crystal.preparation           ? 
+# 
+_exptl_crystal_grow.crystal_id      1 
+_exptl_crystal_grow.method          'VAPOR DIFFUSION, HANGING DROP' 
+_exptl_crystal_grow.temp            277 
+_exptl_crystal_grow.temp_details    ? 
+_exptl_crystal_grow.pH              8.5 
+_exptl_crystal_grow.pdbx_details    'PEG 3000, pH 8.5, VAPOR DIFFUSION, HANGING DROP, temperature 277K' 
+_exptl_crystal_grow.pdbx_pH_range   . 
+# 
+_diffrn.id                     1 
+_diffrn.ambient_temp           100 
+_diffrn.ambient_temp_details   ? 
+_diffrn.crystal_id             1 
+# 
+_diffrn_detector.diffrn_id              1 
+_diffrn_detector.detector               CCD 
+_diffrn_detector.type                   'ADSC QUANTUM 4' 
+_diffrn_detector.pdbx_collection_date   2002-11-12 
+_diffrn_detector.details                ? 
+# 
+_diffrn_radiation.diffrn_id                        1 
+_diffrn_radiation.wavelength_id                    1 
+_diffrn_radiation.pdbx_monochromatic_or_laue_m_l   M 
+_diffrn_radiation.monochromator                    ? 
+_diffrn_radiation.pdbx_diffrn_protocol             'SINGLE WAVELENGTH' 
+_diffrn_radiation.pdbx_scattering_type             x-ray 
+# 
+_diffrn_radiation_wavelength.id           1 
+_diffrn_radiation_wavelength.wavelength   1.1 
+_diffrn_radiation_wavelength.wt           1.0 
+# 
+_diffrn_source.diffrn_id                   1 
+_diffrn_source.source                      SYNCHROTRON 
+_diffrn_source.type                        'NSLS BEAMLINE X8C' 
+_diffrn_source.pdbx_synchrotron_site       NSLS 
+_diffrn_source.pdbx_synchrotron_beamline   X8C 
+_diffrn_source.pdbx_wavelength             ? 
+_diffrn_source.pdbx_wavelength_list        1.1 
+# 
+_reflns.entry_id                     2FVD 
+_reflns.observed_criterion_sigma_I   0.0 
+_reflns.observed_criterion_sigma_F   0.0 
+_reflns.d_resolution_low             50.0 
+_reflns.d_resolution_high            1.85 
+_reflns.number_obs                   23350 
+_reflns.number_all                   ? 
+_reflns.percent_possible_obs         95.7 
+_reflns.pdbx_Rmerge_I_obs            ? 
+_reflns.pdbx_Rsym_value              0.039 
+_reflns.pdbx_netI_over_sigmaI        18.3 
+_reflns.B_iso_Wilson_estimate        8.6 
+_reflns.pdbx_redundancy              4 
+_reflns.R_free_details               ? 
+_reflns.limit_h_max                  ? 
+_reflns.limit_h_min                  ? 
+_reflns.limit_k_max                  ? 
+_reflns.limit_k_min                  ? 
+_reflns.limit_l_max                  ? 
+_reflns.limit_l_min                  ? 
+_reflns.observed_criterion_F_max     ? 
+_reflns.observed_criterion_F_min     ? 
+_reflns.pdbx_chi_squared             ? 
+_reflns.pdbx_scaling_rejects         ? 
+_reflns.pdbx_diffrn_id               1 
+_reflns.pdbx_ordinal                 1 
+# 
+_reflns_shell.d_res_high             1.85 
+_reflns_shell.d_res_low              1.92 
+_reflns_shell.percent_possible_all   75.4 
+_reflns_shell.Rmerge_I_obs           0.108 
+_reflns_shell.pdbx_Rsym_value        ? 
+_reflns_shell.meanI_over_sigI_obs    ? 
+_reflns_shell.pdbx_redundancy        ? 
+_reflns_shell.percent_possible_obs   ? 
+_reflns_shell.number_unique_all      1802 
+_reflns_shell.number_measured_all    ? 
+_reflns_shell.number_measured_obs    ? 
+_reflns_shell.number_unique_obs      ? 
+_reflns_shell.pdbx_chi_squared       ? 
+_reflns_shell.pdbx_diffrn_id         ? 
+_reflns_shell.pdbx_ordinal           1 
+# 
+_refine.entry_id                                 2FVD 
+_refine.ls_number_reflns_obs                     23187 
+_refine.ls_number_reflns_all                     23350 
+_refine.pdbx_ls_sigma_I                          ? 
+_refine.pdbx_ls_sigma_F                          0.0 
+_refine.pdbx_data_cutoff_high_absF               1621544.12 
+_refine.pdbx_data_cutoff_low_absF                0.000000 
+_refine.pdbx_data_cutoff_high_rms_absF           ? 
+_refine.ls_d_res_low                             36.79 
+_refine.ls_d_res_high                            1.85 
+_refine.ls_percent_reflns_obs                    95.9 
+_refine.ls_R_factor_obs                          ? 
+_refine.ls_R_factor_all                          ? 
+_refine.ls_R_factor_R_work                       0.207 
+_refine.ls_R_factor_R_free                       0.235 
+_refine.ls_R_factor_R_free_error                 0.007 
+_refine.ls_R_factor_R_free_error_details         ? 
+_refine.ls_percent_reflns_R_free                 5.0 
+_refine.ls_number_reflns_R_free                  1167 
+_refine.ls_number_parameters                     ? 
+_refine.ls_number_restraints                     ? 
+_refine.occupancy_min                            ? 
+_refine.occupancy_max                            ? 
+_refine.correlation_coeff_Fo_to_Fc               ? 
+_refine.correlation_coeff_Fo_to_Fc_free          ? 
+_refine.B_iso_mean                               16.7 
+_refine.aniso_B[1][1]                            1.58 
+_refine.aniso_B[2][2]                            -0.03 
+_refine.aniso_B[3][3]                            -1.56 
+_refine.aniso_B[1][2]                            0.00 
+_refine.aniso_B[1][3]                            0.00 
+_refine.aniso_B[2][3]                            0.00 
+_refine.solvent_model_details                    'FLAT MODEL' 
+_refine.solvent_model_param_ksol                 0.354944 
+_refine.solvent_model_param_bsol                 40.0518 
+_refine.pdbx_solvent_vdw_probe_radii             ? 
+_refine.pdbx_solvent_ion_probe_radii             ? 
+_refine.pdbx_solvent_shrinkage_radii             ? 
+_refine.pdbx_ls_cross_valid_method               THROUGHOUT 
+_refine.details                                  ? 
+_refine.pdbx_starting_model                      ? 
+_refine.pdbx_method_to_determine_struct          'FOURIER SYNTHESIS' 
+_refine.pdbx_isotropic_thermal_model             RESTRAINED 
+_refine.pdbx_stereochemistry_target_values       'Engh & Huber' 
+_refine.pdbx_stereochem_target_val_spec_case     ? 
+_refine.pdbx_R_Free_selection_details            RANDOM 
+_refine.pdbx_overall_ESU_R                       ? 
+_refine.pdbx_overall_ESU_R_Free                  ? 
+_refine.overall_SU_ML                            ? 
+_refine.overall_SU_B                             ? 
+_refine.ls_redundancy_reflns_obs                 ? 
+_refine.B_iso_min                                ? 
+_refine.B_iso_max                                ? 
+_refine.overall_SU_R_Cruickshank_DPI             ? 
+_refine.overall_SU_R_free                        ? 
+_refine.ls_wR_factor_R_free                      ? 
+_refine.ls_wR_factor_R_work                      ? 
+_refine.overall_FOM_free_R_set                   ? 
+_refine.overall_FOM_work_R_set                   ? 
+_refine.pdbx_refine_id                           'X-RAY DIFFRACTION' 
+_refine.pdbx_diffrn_id                           1 
+_refine.pdbx_TLS_residual_ADP_flag               ? 
+_refine.pdbx_overall_phase_error                 ? 
+_refine.pdbx_overall_SU_R_free_Cruickshank_DPI   ? 
+_refine.pdbx_overall_SU_R_Blow_DPI               ? 
+_refine.pdbx_overall_SU_R_free_Blow_DPI          ? 
+# 
+_refine_analyze.entry_id                        2FVD 
+_refine_analyze.Luzzati_coordinate_error_obs    0.21 
+_refine_analyze.Luzzati_sigma_a_obs             0.07 
+_refine_analyze.Luzzati_d_res_low_obs           5.00 
+_refine_analyze.Luzzati_coordinate_error_free   0.25 
+_refine_analyze.Luzzati_sigma_a_free            0.13 
+_refine_analyze.Luzzati_d_res_low_free          ? 
+_refine_analyze.number_disordered_residues      ? 
+_refine_analyze.occupancy_sum_hydrogen          ? 
+_refine_analyze.occupancy_sum_non_hydrogen      ? 
+_refine_analyze.pdbx_Luzzati_d_res_high_obs     ? 
+_refine_analyze.pdbx_refine_id                  'X-RAY DIFFRACTION' 
+# 
+_refine_hist.pdbx_refine_id                   'X-RAY DIFFRACTION' 
+_refine_hist.cycle_id                         LAST 
+_refine_hist.pdbx_number_atoms_protein        2292 
+_refine_hist.pdbx_number_atoms_nucleic_acid   0 
+_refine_hist.pdbx_number_atoms_ligand         30 
+_refine_hist.number_atoms_solvent             179 
+_refine_hist.number_atoms_total               2501 
+_refine_hist.d_res_high                       1.85 
+_refine_hist.d_res_low                        36.79 
+# 
+loop_
+_refine_ls_restr.type 
+_refine_ls_restr.dev_ideal 
+_refine_ls_restr.dev_ideal_target 
+_refine_ls_restr.weight 
+_refine_ls_restr.number 
+_refine_ls_restr.pdbx_refine_id 
+_refine_ls_restr.pdbx_restraint_function 
+c_bond_d           0.006 ?    ? ? 'X-RAY DIFFRACTION' ? 
+c_angle_deg        1.3   ?    ? ? 'X-RAY DIFFRACTION' ? 
+c_dihedral_angle_d 22.5  ?    ? ? 'X-RAY DIFFRACTION' ? 
+c_improper_angle_d 0.78  ?    ? ? 'X-RAY DIFFRACTION' ? 
+c_mcbond_it        0.94  1.50 ? ? 'X-RAY DIFFRACTION' ? 
+c_mcangle_it       1.55  2.00 ? ? 'X-RAY DIFFRACTION' ? 
+c_scbond_it        1.31  2.00 ? ? 'X-RAY DIFFRACTION' ? 
+c_scangle_it       2.04  2.50 ? ? 'X-RAY DIFFRACTION' ? 
+# 
+_refine_ls_shell.pdbx_total_number_of_bins_used   6 
+_refine_ls_shell.d_res_high                       1.85 
+_refine_ls_shell.d_res_low                        1.97 
+_refine_ls_shell.number_reflns_R_work             2974 
+_refine_ls_shell.R_factor_R_work                  0.206 
+_refine_ls_shell.percent_reflns_obs               79.9 
+_refine_ls_shell.R_factor_R_free                  0.262 
+_refine_ls_shell.R_factor_R_free_error            0.020 
+_refine_ls_shell.percent_reflns_R_free            5.3 
+_refine_ls_shell.number_reflns_R_free             168 
+_refine_ls_shell.number_reflns_all                ? 
+_refine_ls_shell.R_factor_all                     ? 
+_refine_ls_shell.number_reflns_obs                ? 
+_refine_ls_shell.redundancy_reflns_obs            ? 
+_refine_ls_shell.pdbx_refine_id                   'X-RAY DIFFRACTION' 
+# 
+loop_
+_pdbx_xplor_file.serial_no 
+_pdbx_xplor_file.param_file 
+_pdbx_xplor_file.topol_file 
+_pdbx_xplor_file.pdbx_refine_id 
+1 protein_rep.p protein.top 'X-RAY DIFFRACTION' 
+2 water_rep.par water.top   'X-RAY DIFFRACTION' 
+3 ion.param     ion.top     'X-RAY DIFFRACTION' 
+4 lig.par       lig.top     'X-RAY DIFFRACTION' 
+# 
+_struct.entry_id                  2FVD 
+_struct.title                     'Cyclin Dependent Kinase 2 (CDK2) with diaminopyrimidine inhibitor' 
+_struct.pdbx_descriptor           'Cell division protein kinase 2 (E.C.2.7.1.37)' 
+_struct.pdbx_model_details        ? 
+_struct.pdbx_CASP_flag            ? 
+_struct.pdbx_model_type_details   ? 
+# 
+_struct_keywords.entry_id        2FVD 
+_struct_keywords.pdbx_keywords   TRANSFERASE 
+_struct_keywords.text            'CDK2 ligand, TRANSFERASE' 
+# 
+loop_
+_struct_asym.id 
+_struct_asym.pdbx_blank_PDB_chainid_flag 
+_struct_asym.pdbx_modified 
+_struct_asym.entity_id 
+_struct_asym.details 
+A N N 1 ? 
+B N N 2 ? 
+C N N 3 ? 
+# 
+_struct_biol.id                    1 
+_struct_biol.details               'The structure is monomeric' 
+_struct_biol.pdbx_parent_biol_id   ? 
+# 
+loop_
+_struct_conf.conf_type_id 
+_struct_conf.id 
+_struct_conf.pdbx_PDB_helix_id 
+_struct_conf.beg_label_comp_id 
+_struct_conf.beg_label_asym_id 
+_struct_conf.beg_label_seq_id 
+_struct_conf.pdbx_beg_PDB_ins_code 
+_struct_conf.end_label_comp_id 
+_struct_conf.end_label_asym_id 
+_struct_conf.end_label_seq_id 
+_struct_conf.pdbx_end_PDB_ins_code 
+_struct_conf.beg_auth_comp_id 
+_struct_conf.beg_auth_asym_id 
+_struct_conf.beg_auth_seq_id 
+_struct_conf.end_auth_comp_id 
+_struct_conf.end_auth_asym_id 
+_struct_conf.end_auth_seq_id 
+_struct_conf.pdbx_PDB_helix_class 
+_struct_conf.details 
+_struct_conf.pdbx_PDB_helix_length 
+HELX_P HELX_P1  2  LEU A 87  ? SER A 94  ? LEU A 87  SER A 94  1 ? 8  
+HELX_P HELX_P2  3  PRO A 100 ? HIS A 121 ? PRO A 100 HIS A 121 1 ? 22 
+HELX_P HELX_P3  4  LYS A 129 ? GLN A 131 ? LYS A 129 GLN A 131 5 ? 3  
+HELX_P HELX_P4  5  ALA A 170 ? LEU A 175 ? ALA A 170 LEU A 175 1 ? 6  
+HELX_P HELX_P5  6  THR A 182 ? ARG A 199 ? THR A 182 ARG A 199 1 ? 18 
+HELX_P HELX_P6  7  SER A 207 ? GLY A 220 ? SER A 207 GLY A 220 1 ? 14 
+HELX_P HELX_P7  8  GLY A 229 ? MET A 233 ? GLY A 229 MET A 233 5 ? 5  
+HELX_P HELX_P8  9  ASP A 247 ? VAL A 251 ? ASP A 247 VAL A 251 5 ? 5  
+HELX_P HELX_P9  10 ASP A 256 ? LEU A 267 ? ASP A 256 LEU A 267 1 ? 12 
+HELX_P HELX_P10 11 SER A 276 ? ALA A 282 ? SER A 276 ALA A 282 1 ? 7  
+HELX_P HELX_P11 12 HIS A 283 ? GLN A 287 ? HIS A 283 GLN A 287 5 ? 5  
+# 
+_struct_conf_type.id          HELX_P 
+_struct_conf_type.criteria    ? 
+_struct_conf_type.reference   ? 
+# 
+_struct_mon_prot_cis.pdbx_id                1 
+_struct_mon_prot_cis.label_comp_id          PRO 
+_struct_mon_prot_cis.label_seq_id           253 
+_struct_mon_prot_cis.label_asym_id          A 
+_struct_mon_prot_cis.label_alt_id           . 
+_struct_mon_prot_cis.pdbx_PDB_ins_code      ? 
+_struct_mon_prot_cis.auth_comp_id           PRO 
+_struct_mon_prot_cis.auth_seq_id            253 
+_struct_mon_prot_cis.auth_asym_id           A 
+_struct_mon_prot_cis.pdbx_label_comp_id_2   PRO 
+_struct_mon_prot_cis.pdbx_label_seq_id_2    254 
+_struct_mon_prot_cis.pdbx_label_asym_id_2   A 
+_struct_mon_prot_cis.pdbx_PDB_ins_code_2    ? 
+_struct_mon_prot_cis.pdbx_auth_comp_id_2    PRO 
+_struct_mon_prot_cis.pdbx_auth_seq_id_2     254 
+_struct_mon_prot_cis.pdbx_auth_asym_id_2    A 
+_struct_mon_prot_cis.pdbx_PDB_model_num     1 
+_struct_mon_prot_cis.pdbx_omega_angle       0.11 
+# 
+loop_
+_struct_sheet.id 
+_struct_sheet.type 
+_struct_sheet.number_strands 
+_struct_sheet.details 
+A ? 5 ? 
+B ? 3 ? 
+# 
+loop_
+_struct_sheet_order.sheet_id 
+_struct_sheet_order.range_id_1 
+_struct_sheet_order.range_id_2 
+_struct_sheet_order.offset 
+_struct_sheet_order.sense 
+A 1 2 ? anti-parallel 
+A 2 3 ? anti-parallel 
+A 3 4 ? anti-parallel 
+A 4 5 ? anti-parallel 
+B 1 2 ? anti-parallel 
+B 2 3 ? anti-parallel 
+# 
+loop_
+_struct_sheet_range.sheet_id 
+_struct_sheet_range.id 
+_struct_sheet_range.beg_label_comp_id 
+_struct_sheet_range.beg_label_asym_id 
+_struct_sheet_range.beg_label_seq_id 
+_struct_sheet_range.pdbx_beg_PDB_ins_code 
+_struct_sheet_range.end_label_comp_id 
+_struct_sheet_range.end_label_asym_id 
+_struct_sheet_range.end_label_seq_id 
+_struct_sheet_range.pdbx_end_PDB_ins_code 
+_struct_sheet_range.beg_auth_comp_id 
+_struct_sheet_range.beg_auth_asym_id 
+_struct_sheet_range.beg_auth_seq_id 
+_struct_sheet_range.end_auth_comp_id 
+_struct_sheet_range.end_auth_asym_id 
+_struct_sheet_range.end_auth_seq_id 
+A 1 PHE A 4   ? GLU A 12  ? PHE A 4   GLU A 12  
+A 2 VAL A 17  ? ASN A 23  ? VAL A 17  ASN A 23  
+A 3 VAL A 29  ? ARG A 36  ? VAL A 29  ARG A 36  
+A 4 LYS A 75  ? GLU A 81  ? LYS A 75  GLU A 81  
+A 5 LEU A 66  ? THR A 72  ? LEU A 66  THR A 72  
+B 1 GLN A 85  ? ASP A 86  ? GLN A 85  ASP A 86  
+B 2 LEU A 133 ? ILE A 135 ? LEU A 133 ILE A 135 
+B 3 ILE A 141 ? LEU A 143 ? ILE A 141 LEU A 143 
+# 
+loop_
+_pdbx_struct_sheet_hbond.sheet_id 
+_pdbx_struct_sheet_hbond.range_id_1 
+_pdbx_struct_sheet_hbond.range_id_2 
+_pdbx_struct_sheet_hbond.range_1_label_atom_id 
+_pdbx_struct_sheet_hbond.range_1_label_comp_id 
+_pdbx_struct_sheet_hbond.range_1_label_asym_id 
+_pdbx_struct_sheet_hbond.range_1_label_seq_id 
+_pdbx_struct_sheet_hbond.range_1_PDB_ins_code 
+_pdbx_struct_sheet_hbond.range_1_auth_atom_id 
+_pdbx_struct_sheet_hbond.range_1_auth_comp_id 
+_pdbx_struct_sheet_hbond.range_1_auth_asym_id 
+_pdbx_struct_sheet_hbond.range_1_auth_seq_id 
+_pdbx_struct_sheet_hbond.range_2_label_atom_id 
+_pdbx_struct_sheet_hbond.range_2_label_comp_id 
+_pdbx_struct_sheet_hbond.range_2_label_asym_id 
+_pdbx_struct_sheet_hbond.range_2_label_seq_id 
+_pdbx_struct_sheet_hbond.range_2_PDB_ins_code 
+_pdbx_struct_sheet_hbond.range_2_auth_atom_id 
+_pdbx_struct_sheet_hbond.range_2_auth_comp_id 
+_pdbx_struct_sheet_hbond.range_2_auth_asym_id 
+_pdbx_struct_sheet_hbond.range_2_auth_seq_id 
+A 1 2 N VAL A 7   ? N VAL A 7   O LYS A 20  ? O LYS A 20  
+A 2 3 N TYR A 19  ? N TYR A 19  O LEU A 32  ? O LEU A 32  
+A 3 4 N ALA A 31  ? N ALA A 31  O PHE A 80  ? O PHE A 80  
+A 4 5 O VAL A 79  ? O VAL A 79  N ASP A 68  ? N ASP A 68  
+B 1 2 N GLN A 85  ? N GLN A 85  O ILE A 135 ? O ILE A 135 
+B 2 3 N LEU A 134 ? N LEU A 134 O LYS A 142 ? O LYS A 142 
+# 
+_struct_site.id                   AC1 
+_struct_site.pdbx_evidence_code   Software 
+_struct_site.pdbx_auth_asym_id    ? 
+_struct_site.pdbx_auth_comp_id    ? 
+_struct_site.pdbx_auth_seq_id     ? 
+_struct_site.pdbx_auth_ins_code   ? 
+_struct_site.pdbx_num_residues    20 
+_struct_site.details              'BINDING SITE FOR RESIDUE LIA A 299' 
+# 
+loop_
+_struct_site_gen.id 
+_struct_site_gen.site_id 
+_struct_site_gen.pdbx_num_res 
+_struct_site_gen.label_comp_id 
+_struct_site_gen.label_asym_id 
+_struct_site_gen.label_seq_id 
+_struct_site_gen.pdbx_auth_ins_code 
+_struct_site_gen.auth_comp_id 
+_struct_site_gen.auth_asym_id 
+_struct_site_gen.auth_seq_id 
+_struct_site_gen.label_atom_id 
+_struct_site_gen.label_alt_id 
+_struct_site_gen.symmetry 
+_struct_site_gen.details 
+1  AC1 20 VAL A 18  ? VAL A 18  . ? 1_555 ? 
+2  AC1 20 ALA A 31  ? ALA A 31  . ? 1_555 ? 
+3  AC1 20 LYS A 33  ? LYS A 33  . ? 1_555 ? 
+4  AC1 20 VAL A 64  ? VAL A 64  . ? 1_555 ? 
+5  AC1 20 PHE A 80  ? PHE A 80  . ? 1_555 ? 
+6  AC1 20 GLU A 81  ? GLU A 81  . ? 1_555 ? 
+7  AC1 20 PHE A 82  ? PHE A 82  . ? 1_555 ? 
+8  AC1 20 LEU A 83  ? LEU A 83  . ? 1_555 ? 
+9  AC1 20 HIS A 84  ? HIS A 84  . ? 1_555 ? 
+10 AC1 20 GLN A 85  ? GLN A 85  . ? 1_555 ? 
+11 AC1 20 ASP A 86  ? ASP A 86  . ? 1_555 ? 
+12 AC1 20 LYS A 89  ? LYS A 89  . ? 1_555 ? 
+13 AC1 20 GLN A 131 ? GLN A 131 . ? 1_555 ? 
+14 AC1 20 ASN A 132 ? ASN A 132 . ? 1_555 ? 
+15 AC1 20 LEU A 134 ? LEU A 134 . ? 1_555 ? 
+16 AC1 20 ALA A 144 ? ALA A 144 . ? 1_555 ? 
+17 AC1 20 ASP A 145 ? ASP A 145 . ? 1_555 ? 
+18 AC1 20 HOH C .   ? HOH A 341 . ? 1_555 ? 
+19 AC1 20 HOH C .   ? HOH A 386 . ? 1_555 ? 
+20 AC1 20 HOH C .   ? HOH A 389 . ? 1_555 ? 
+# 
+_database_PDB_matrix.entry_id          2FVD 
+_database_PDB_matrix.origx[1][1]       1.000000 
+_database_PDB_matrix.origx[1][2]       0.000000 
+_database_PDB_matrix.origx[1][3]       0.000000 
+_database_PDB_matrix.origx[2][1]       0.000000 
+_database_PDB_matrix.origx[2][2]       1.000000 
+_database_PDB_matrix.origx[2][3]       0.000000 
+_database_PDB_matrix.origx[3][1]       0.000000 
+_database_PDB_matrix.origx[3][2]       0.000000 
+_database_PDB_matrix.origx[3][3]       1.000000 
+_database_PDB_matrix.origx_vector[1]   0.00000 
+_database_PDB_matrix.origx_vector[2]   0.00000 
+_database_PDB_matrix.origx_vector[3]   0.00000 
+# 
+_atom_sites.entry_id                    2FVD 
+_atom_sites.fract_transf_matrix[1][1]   0.018689 
+_atom_sites.fract_transf_matrix[1][2]   0.000000 
+_atom_sites.fract_transf_matrix[1][3]   0.000000 
+_atom_sites.fract_transf_matrix[2][1]   0.000000 
+_atom_sites.fract_transf_matrix[2][2]   0.013957 
+_atom_sites.fract_transf_matrix[2][3]   0.000000 
+_atom_sites.fract_transf_matrix[3][1]   0.000000 
+_atom_sites.fract_transf_matrix[3][2]   0.000000 
+_atom_sites.fract_transf_matrix[3][3]   0.013949 
+_atom_sites.fract_transf_vector[1]      0.00000 
+_atom_sites.fract_transf_vector[2]      0.00000 
+_atom_sites.fract_transf_vector[3]      0.00000 
+# 
+loop_
+_atom_type.symbol 
+C 
+F 
+N 
+O 
+S 
+# 
+loop_
+_atom_site.group_PDB 
+_atom_site.id 
+_atom_site.type_symbol 
+_atom_site.label_atom_id 
+_atom_site.label_alt_id 
+_atom_site.label_comp_id 
+_atom_site.label_asym_id 
+_atom_site.label_entity_id 
+_atom_site.label_seq_id 
+_atom_site.pdbx_PDB_ins_code 
+_atom_site.Cartn_x 
+_atom_site.Cartn_y 
+_atom_site.Cartn_z 
+_atom_site.occupancy 
+_atom_site.B_iso_or_equiv 
+_atom_site.pdbx_formal_charge 
+_atom_site.auth_seq_id 
+_atom_site.auth_comp_id 
+_atom_site.auth_asym_id 
+_atom_site.auth_atom_id 
+_atom_site.pdbx_PDB_model_num 
+ATOM   1    N N   . MET A 1 1   ? -14.693 31.715 -2.722  1.00 37.74 ? 1   MET A N   1 
+ATOM   2    C CA  . MET A 1 1   ? -13.227 31.899 -2.908  1.00 37.59 ? 1   MET A CA  1 
+ATOM   3    C C   . MET A 1 1   ? -12.840 31.779 -4.374  1.00 37.02 ? 1   MET A C   1 
+ATOM   4    O O   . MET A 1 1   ? -11.705 31.426 -4.692  1.00 37.13 ? 1   MET A O   1 
+ATOM   5    C CB  . MET A 1 1   ? -12.447 30.852 -2.105  1.00 38.12 ? 1   MET A CB  1 
+ATOM   6    C CG  . MET A 1 1   ? -12.774 30.816 -0.623  1.00 38.70 ? 1   MET A CG  1 
+ATOM   7    S SD  . MET A 1 1   ? -12.785 32.451 0.136   1.00 37.90 ? 1   MET A SD  1 
+ATOM   8    C CE  . MET A 1 1   ? -14.533 32.784 0.100   1.00 38.98 ? 1   MET A CE  1 
+ATOM   9    N N   . GLU A 1 2   ? -13.782 32.063 -5.268  1.00 36.63 ? 2   GLU A N   1 
+ATOM   10   C CA  . GLU A 1 2   ? -13.500 31.977 -6.694  1.00 36.49 ? 2   GLU A CA  1 
+ATOM   11   C C   . GLU A 1 2   ? -12.309 32.855 -7.067  1.00 35.85 ? 2   GLU A C   1 
+ATOM   12   O O   . GLU A 1 2   ? -11.666 32.637 -8.093  1.00 35.71 ? 2   GLU A O   1 
+ATOM   13   C CB  . GLU A 1 2   ? -14.729 32.381 -7.518  1.00 37.49 ? 2   GLU A CB  1 
+ATOM   14   C CG  . GLU A 1 2   ? -15.376 33.693 -7.102  1.00 38.63 ? 2   GLU A CG  1 
+ATOM   15   C CD  . GLU A 1 2   ? -16.138 33.575 -5.796  1.00 39.51 ? 2   GLU A CD  1 
+ATOM   16   O OE1 . GLU A 1 2   ? -17.098 32.776 -5.737  1.00 38.95 ? 2   GLU A OE1 1 
+ATOM   17   O OE2 . GLU A 1 2   ? -15.776 34.280 -4.828  1.00 40.65 ? 2   GLU A OE2 1 
+ATOM   18   N N   . ASN A 1 3   ? -12.010 33.842 -6.226  1.00 35.19 ? 3   ASN A N   1 
+ATOM   19   C CA  . ASN A 1 3   ? -10.887 34.738 -6.481  1.00 34.45 ? 3   ASN A CA  1 
+ATOM   20   C C   . ASN A 1 3   ? -9.603  34.207 -5.852  1.00 33.48 ? 3   ASN A C   1 
+ATOM   21   O O   . ASN A 1 3   ? -8.599  34.915 -5.783  1.00 32.61 ? 3   ASN A O   1 
+ATOM   22   C CB  . ASN A 1 3   ? -11.182 36.135 -5.931  1.00 35.34 ? 3   ASN A CB  1 
+ATOM   23   C CG  . ASN A 1 3   ? -12.505 36.683 -6.420  1.00 36.19 ? 3   ASN A CG  1 
+ATOM   24   O OD1 . ASN A 1 3   ? -13.568 36.242 -5.987  1.00 37.67 ? 3   ASN A OD1 1 
+ATOM   25   N ND2 . ASN A 1 3   ? -12.447 37.640 -7.337  1.00 36.28 ? 3   ASN A ND2 1 
+ATOM   26   N N   . PHE A 1 4   ? -9.640  32.959 -5.395  1.00 32.30 ? 4   PHE A N   1 
+ATOM   27   C CA  . PHE A 1 4   ? -8.476  32.345 -4.771  1.00 31.75 ? 4   PHE A CA  1 
+ATOM   28   C C   . PHE A 1 4   ? -8.089  31.029 -5.428  1.00 31.66 ? 4   PHE A C   1 
+ATOM   29   O O   . PHE A 1 4   ? -8.913  30.125 -5.573  1.00 32.13 ? 4   PHE A O   1 
+ATOM   30   C CB  . PHE A 1 4   ? -8.735  32.127 -3.278  1.00 30.91 ? 4   PHE A CB  1 
+ATOM   31   C CG  . PHE A 1 4   ? -8.717  33.394 -2.473  1.00 30.16 ? 4   PHE A CG  1 
+ATOM   32   C CD1 . PHE A 1 4   ? -7.509  33.997 -2.126  1.00 30.06 ? 4   PHE A CD1 1 
+ATOM   33   C CD2 . PHE A 1 4   ? -9.906  34.002 -2.083  1.00 29.80 ? 4   PHE A CD2 1 
+ATOM   34   C CE1 . PHE A 1 4   ? -7.485  35.188 -1.404  1.00 29.63 ? 4   PHE A CE1 1 
+ATOM   35   C CE2 . PHE A 1 4   ? -9.896  35.194 -1.361  1.00 29.26 ? 4   PHE A CE2 1 
+ATOM   36   C CZ  . PHE A 1 4   ? -8.682  35.789 -1.021  1.00 29.91 ? 4   PHE A CZ  1 
+ATOM   37   N N   . GLN A 1 5   ? -6.825  30.937 -5.824  1.00 31.65 ? 5   GLN A N   1 
+ATOM   38   C CA  . GLN A 1 5   ? -6.287  29.743 -6.464  1.00 31.62 ? 5   GLN A CA  1 
+ATOM   39   C C   . GLN A 1 5   ? -5.433  28.987 -5.457  1.00 31.05 ? 5   GLN A C   1 
+ATOM   40   O O   . GLN A 1 5   ? -4.391  29.479 -5.021  1.00 30.36 ? 5   GLN A O   1 
+ATOM   41   C CB  . GLN A 1 5   ? -5.419  30.130 -7.665  1.00 32.93 ? 5   GLN A CB  1 
+ATOM   42   C CG  . GLN A 1 5   ? -4.676  28.965 -8.306  1.00 34.45 ? 5   GLN A CG  1 
+ATOM   43   C CD  . GLN A 1 5   ? -3.572  29.424 -9.246  1.00 36.11 ? 5   GLN A CD  1 
+ATOM   44   O OE1 . GLN A 1 5   ? -2.608  30.069 -8.824  1.00 36.57 ? 5   GLN A OE1 1 
+ATOM   45   N NE2 . GLN A 1 5   ? -3.708  29.095 -10.527 1.00 36.56 ? 5   GLN A NE2 1 
+ATOM   46   N N   . LYS A 1 6   ? -5.871  27.791 -5.087  1.00 30.33 ? 6   LYS A N   1 
+ATOM   47   C CA  . LYS A 1 6   ? -5.117  26.992 -4.134  1.00 30.15 ? 6   LYS A CA  1 
+ATOM   48   C C   . LYS A 1 6   ? -3.798  26.573 -4.770  1.00 28.94 ? 6   LYS A C   1 
+ATOM   49   O O   . LYS A 1 6   ? -3.754  26.179 -5.935  1.00 28.98 ? 6   LYS A O   1 
+ATOM   50   C CB  . LYS A 1 6   ? -5.922  25.756 -3.724  1.00 31.28 ? 6   LYS A CB  1 
+ATOM   51   C CG  . LYS A 1 6   ? -7.349  26.074 -3.298  1.00 33.05 ? 6   LYS A CG  1 
+ATOM   52   C CD  . LYS A 1 6   ? -7.388  27.060 -2.136  1.00 33.88 ? 6   LYS A CD  1 
+ATOM   53   C CE  . LYS A 1 6   ? -8.723  27.793 -2.081  1.00 34.57 ? 6   LYS A CE  1 
+ATOM   54   N NZ  . LYS A 1 6   ? -9.877  26.862 -1.944  1.00 36.07 ? 6   LYS A NZ  1 
+ATOM   55   N N   . VAL A 1 7   ? -2.721  26.674 -4.003  1.00 27.70 ? 7   VAL A N   1 
+ATOM   56   C CA  . VAL A 1 7   ? -1.399  26.304 -4.486  1.00 26.60 ? 7   VAL A CA  1 
+ATOM   57   C C   . VAL A 1 7   ? -1.033  24.924 -3.956  1.00 25.68 ? 7   VAL A C   1 
+ATOM   58   O O   . VAL A 1 7   ? -0.664  24.029 -4.719  1.00 25.54 ? 7   VAL A O   1 
+ATOM   59   C CB  . VAL A 1 7   ? -0.347  27.325 -4.024  1.00 26.46 ? 7   VAL A CB  1 
+ATOM   60   C CG1 . VAL A 1 7   ? 1.039   26.891 -4.471  1.00 26.97 ? 7   VAL A CG1 1 
+ATOM   61   C CG2 . VAL A 1 7   ? -0.690  28.692 -4.584  1.00 27.36 ? 7   VAL A CG2 1 
+ATOM   62   N N   . GLU A 1 8   ? -1.148  24.761 -2.642  1.00 24.36 ? 8   GLU A N   1 
+ATOM   63   C CA  . GLU A 1 8   ? -0.847  23.500 -1.978  1.00 24.07 ? 8   GLU A CA  1 
+ATOM   64   C C   . GLU A 1 8   ? -1.425  23.505 -0.572  1.00 23.06 ? 8   GLU A C   1 
+ATOM   65   O O   . GLU A 1 8   ? -1.667  24.562 0.002   1.00 21.53 ? 8   GLU A O   1 
+ATOM   66   C CB  . GLU A 1 8   ? 0.666   23.279 -1.902  1.00 25.07 ? 8   GLU A CB  1 
+ATOM   67   C CG  . GLU A 1 8   ? 1.456   24.482 -1.399  1.00 27.15 ? 8   GLU A CG  1 
+ATOM   68   C CD  . GLU A 1 8   ? 2.932   24.173 -1.218  1.00 28.29 ? 8   GLU A CD  1 
+ATOM   69   O OE1 . GLU A 1 8   ? 3.480   23.398 -2.029  1.00 29.07 ? 8   GLU A OE1 1 
+ATOM   70   O OE2 . GLU A 1 8   ? 3.549   24.716 -0.276  1.00 29.41 ? 8   GLU A OE2 1 
+ATOM   71   N N   . LYS A 1 9   ? -1.653  22.316 -0.026  1.00 22.33 ? 9   LYS A N   1 
+ATOM   72   C CA  . LYS A 1 9   ? -2.186  22.197 1.322   1.00 22.65 ? 9   LYS A CA  1 
+ATOM   73   C C   . LYS A 1 9   ? -1.013  22.348 2.288   1.00 22.57 ? 9   LYS A C   1 
+ATOM   74   O O   . LYS A 1 9   ? 0.035   21.731 2.095   1.00 21.66 ? 9   LYS A O   1 
+ATOM   75   C CB  . LYS A 1 9   ? -2.850  20.832 1.498   1.00 24.09 ? 9   LYS A CB  1 
+ATOM   76   C CG  . LYS A 1 9   ? -3.547  20.630 2.822   1.00 24.89 ? 9   LYS A CG  1 
+ATOM   77   C CD  . LYS A 1 9   ? -4.304  19.317 2.809   1.00 27.09 ? 9   LYS A CD  1 
+ATOM   78   C CE  . LYS A 1 9   ? -5.020  19.073 4.114   1.00 27.96 ? 9   LYS A CE  1 
+ATOM   79   N NZ  . LYS A 1 9   ? -5.735  17.766 4.107   1.00 30.15 ? 9   LYS A NZ  1 
+ATOM   80   N N   . ILE A 1 10  ? -1.179  23.182 3.312   1.00 21.84 ? 10  ILE A N   1 
+ATOM   81   C CA  . ILE A 1 10  ? -0.119  23.406 4.291   1.00 22.84 ? 10  ILE A CA  1 
+ATOM   82   C C   . ILE A 1 10  ? -0.249  22.469 5.485   1.00 23.80 ? 10  ILE A C   1 
+ATOM   83   O O   . ILE A 1 10  ? 0.754   21.996 6.020   1.00 24.08 ? 10  ILE A O   1 
+ATOM   84   C CB  . ILE A 1 10  ? -0.126  24.864 4.808   1.00 22.65 ? 10  ILE A CB  1 
+ATOM   85   C CG1 . ILE A 1 10  ? 0.179   25.826 3.664   1.00 22.69 ? 10  ILE A CG1 1 
+ATOM   86   C CG2 . ILE A 1 10  ? 0.907   25.030 5.916   1.00 23.38 ? 10  ILE A CG2 1 
+ATOM   87   C CD1 . ILE A 1 10  ? 0.106   27.292 4.061   1.00 21.45 ? 10  ILE A CD1 1 
+ATOM   88   N N   . GLY A 1 11  ? -1.483  22.208 5.905   1.00 24.56 ? 11  GLY A N   1 
+ATOM   89   C CA  . GLY A 1 11  ? -1.705  21.324 7.038   1.00 25.82 ? 11  GLY A CA  1 
+ATOM   90   C C   . GLY A 1 11  ? -3.158  21.272 7.470   1.00 26.49 ? 11  GLY A C   1 
+ATOM   91   O O   . GLY A 1 11  ? -4.019  21.890 6.843   1.00 26.02 ? 11  GLY A O   1 
+ATOM   92   N N   . GLU A 1 12  ? -3.428  20.523 8.537   1.00 27.76 ? 12  GLU A N   1 
+ATOM   93   C CA  . GLU A 1 12  ? -4.781  20.386 9.069   1.00 28.76 ? 12  GLU A CA  1 
+ATOM   94   C C   . GLU A 1 12  ? -4.795  20.590 10.580  1.00 28.35 ? 12  GLU A C   1 
+ATOM   95   O O   . GLU A 1 12  ? -3.951  20.050 11.297  1.00 29.19 ? 12  GLU A O   1 
+ATOM   96   C CB  . GLU A 1 12  ? -5.354  18.994 8.781   1.00 30.40 ? 12  GLU A CB  1 
+ATOM   97   C CG  . GLU A 1 12  ? -5.422  18.587 7.322   1.00 32.82 ? 12  GLU A CG  1 
+ATOM   98   C CD  . GLU A 1 12  ? -6.267  17.336 7.117   1.00 34.18 ? 12  GLU A CD  1 
+ATOM   99   O OE1 . GLU A 1 12  ? -6.073  16.353 7.864   1.00 34.28 ? 12  GLU A OE1 1 
+ATOM   100  O OE2 . GLU A 1 12  ? -7.125  17.335 6.209   1.00 35.48 ? 12  GLU A OE2 1 
+ATOM   101  N N   . GLY A 1 13  ? -5.761  21.369 11.055  1.00 27.03 ? 13  GLY A N   1 
+ATOM   102  C CA  . GLY A 1 13  ? -5.897  21.604 12.480  1.00 25.58 ? 13  GLY A CA  1 
+ATOM   103  C C   . GLY A 1 13  ? -7.088  20.789 12.945  1.00 24.93 ? 13  GLY A C   1 
+ATOM   104  O O   . GLY A 1 13  ? -7.657  20.030 12.156  1.00 24.20 ? 13  GLY A O   1 
+ATOM   105  N N   . THR A 1 14  ? -7.483  20.938 14.206  1.00 24.48 ? 14  THR A N   1 
+ATOM   106  C CA  . THR A 1 14  ? -8.619  20.180 14.723  1.00 24.55 ? 14  THR A CA  1 
+ATOM   107  C C   . THR A 1 14  ? -9.932  20.578 14.046  1.00 24.17 ? 14  THR A C   1 
+ATOM   108  O O   . THR A 1 14  ? -10.807 19.736 13.830  1.00 23.51 ? 14  THR A O   1 
+ATOM   109  C CB  . THR A 1 14  ? -8.771  20.363 16.254  1.00 24.94 ? 14  THR A CB  1 
+ATOM   110  O OG1 . THR A 1 14  ? -7.593  19.881 16.914  1.00 25.91 ? 14  THR A OG1 1 
+ATOM   111  C CG2 . THR A 1 14  ? -9.977  19.579 16.768  1.00 24.90 ? 14  THR A CG2 1 
+ATOM   112  N N   . TYR A 1 15  ? -10.063 21.855 13.699  1.00 24.05 ? 15  TYR A N   1 
+ATOM   113  C CA  . TYR A 1 15  ? -11.285 22.341 13.067  1.00 24.45 ? 15  TYR A CA  1 
+ATOM   114  C C   . TYR A 1 15  ? -11.082 23.053 11.735  1.00 24.55 ? 15  TYR A C   1 
+ATOM   115  O O   . TYR A 1 15  ? -12.035 23.590 11.170  1.00 24.63 ? 15  TYR A O   1 
+ATOM   116  C CB  . TYR A 1 15  ? -12.035 23.290 14.009  1.00 26.03 ? 15  TYR A CB  1 
+ATOM   117  C CG  . TYR A 1 15  ? -12.533 22.648 15.282  1.00 27.51 ? 15  TYR A CG  1 
+ATOM   118  C CD1 . TYR A 1 15  ? -11.718 22.560 16.412  1.00 27.99 ? 15  TYR A CD1 1 
+ATOM   119  C CD2 . TYR A 1 15  ? -13.824 22.124 15.359  1.00 28.52 ? 15  TYR A CD2 1 
+ATOM   120  C CE1 . TYR A 1 15  ? -12.180 21.968 17.588  1.00 28.81 ? 15  TYR A CE1 1 
+ATOM   121  C CE2 . TYR A 1 15  ? -14.293 21.531 16.526  1.00 28.59 ? 15  TYR A CE2 1 
+ATOM   122  C CZ  . TYR A 1 15  ? -13.468 21.457 17.636  1.00 29.09 ? 15  TYR A CZ  1 
+ATOM   123  O OH  . TYR A 1 15  ? -13.940 20.879 18.793  1.00 29.81 ? 15  TYR A OH  1 
+ATOM   124  N N   . GLY A 1 16  ? -9.854  23.070 11.228  1.00 23.69 ? 16  GLY A N   1 
+ATOM   125  C CA  . GLY A 1 16  ? -9.630  23.744 9.965   1.00 23.09 ? 16  GLY A CA  1 
+ATOM   126  C C   . GLY A 1 16  ? -8.464  23.245 9.137   1.00 22.53 ? 16  GLY A C   1 
+ATOM   127  O O   . GLY A 1 16  ? -7.445  22.801 9.671   1.00 22.33 ? 16  GLY A O   1 
+ATOM   128  N N   . VAL A 1 17  ? -8.623  23.316 7.820   1.00 20.90 ? 17  VAL A N   1 
+ATOM   129  C CA  . VAL A 1 17  ? -7.576  22.900 6.900   1.00 19.95 ? 17  VAL A CA  1 
+ATOM   130  C C   . VAL A 1 17  ? -6.918  24.180 6.388   1.00 18.34 ? 17  VAL A C   1 
+ATOM   131  O O   . VAL A 1 17  ? -7.604  25.163 6.105   1.00 18.36 ? 17  VAL A O   1 
+ATOM   132  C CB  . VAL A 1 17  ? -8.160  22.092 5.722   1.00 20.51 ? 17  VAL A CB  1 
+ATOM   133  C CG1 . VAL A 1 17  ? -9.214  22.915 4.998   1.00 22.10 ? 17  VAL A CG1 1 
+ATOM   134  C CG2 . VAL A 1 17  ? -7.048  21.673 4.781   1.00 21.07 ? 17  VAL A CG2 1 
+ATOM   135  N N   . VAL A 1 18  ? -5.593  24.169 6.283   1.00 17.07 ? 18  VAL A N   1 
+ATOM   136  C CA  . VAL A 1 18  ? -4.849  25.346 5.836   1.00 16.04 ? 18  VAL A CA  1 
+ATOM   137  C C   . VAL A 1 18  ? -4.202  25.150 4.466   1.00 15.26 ? 18  VAL A C   1 
+ATOM   138  O O   . VAL A 1 18  ? -3.544  24.138 4.220   1.00 14.99 ? 18  VAL A O   1 
+ATOM   139  C CB  . VAL A 1 18  ? -3.732  25.699 6.842   1.00 16.17 ? 18  VAL A CB  1 
+ATOM   140  C CG1 . VAL A 1 18  ? -3.196  27.101 6.562   1.00 15.88 ? 18  VAL A CG1 1 
+ATOM   141  C CG2 . VAL A 1 18  ? -4.260  25.586 8.266   1.00 16.84 ? 18  VAL A CG2 1 
+ATOM   142  N N   . TYR A 1 19  ? -4.378  26.126 3.582   1.00 14.69 ? 19  TYR A N   1 
+ATOM   143  C CA  . TYR A 1 19  ? -3.794  26.045 2.246   1.00 15.41 ? 19  TYR A CA  1 
+ATOM   144  C C   . TYR A 1 19  ? -2.989  27.283 1.891   1.00 14.57 ? 19  TYR A C   1 
+ATOM   145  O O   . TYR A 1 19  ? -3.262  28.373 2.386   1.00 14.70 ? 19  TYR A O   1 
+ATOM   146  C CB  . TYR A 1 19  ? -4.868  25.917 1.163   1.00 17.11 ? 19  TYR A CB  1 
+ATOM   147  C CG  . TYR A 1 19  ? -5.794  24.741 1.288   1.00 19.70 ? 19  TYR A CG  1 
+ATOM   148  C CD1 . TYR A 1 19  ? -6.925  24.808 2.096   1.00 21.18 ? 19  TYR A CD1 1 
+ATOM   149  C CD2 . TYR A 1 19  ? -5.555  23.565 0.577   1.00 20.79 ? 19  TYR A CD2 1 
+ATOM   150  C CE1 . TYR A 1 19  ? -7.804  23.734 2.191   1.00 22.88 ? 19  TYR A CE1 1 
+ATOM   151  C CE2 . TYR A 1 19  ? -6.426  22.482 0.668   1.00 22.36 ? 19  TYR A CE2 1 
+ATOM   152  C CZ  . TYR A 1 19  ? -7.549  22.574 1.475   1.00 23.57 ? 19  TYR A CZ  1 
+ATOM   153  O OH  . TYR A 1 19  ? -8.425  21.515 1.562   1.00 24.95 ? 19  TYR A OH  1 
+ATOM   154  N N   . LYS A 1 20  ? -1.995  27.102 1.030   1.00 12.89 ? 20  LYS A N   1 
+ATOM   155  C CA  . LYS A 1 20  ? -1.227  28.231 0.533   1.00 12.40 ? 20  LYS A CA  1 
+ATOM   156  C C   . LYS A 1 20  ? -2.039  28.509 -0.721  1.00 12.72 ? 20  LYS A C   1 
+ATOM   157  O O   . LYS A 1 20  ? -2.356  27.578 -1.466  1.00 12.68 ? 20  LYS A O   1 
+ATOM   158  C CB  . LYS A 1 20  ? 0.199   27.825 0.149   1.00 11.32 ? 20  LYS A CB  1 
+ATOM   159  C CG  . LYS A 1 20  ? 1.036   28.994 -0.394  1.00 9.82  ? 20  LYS A CG  1 
+ATOM   160  C CD  . LYS A 1 20  ? 2.458   28.564 -0.735  1.00 9.54  ? 20  LYS A CD  1 
+ATOM   161  C CE  . LYS A 1 20  ? 3.303   29.758 -1.191  1.00 8.58  ? 20  LYS A CE  1 
+ATOM   162  N NZ  . LYS A 1 20  ? 4.724   29.389 -1.427  1.00 9.73  ? 20  LYS A NZ  1 
+ATOM   163  N N   . ALA A 1 21  ? -2.407  29.762 -0.947  1.00 13.58 ? 21  ALA A N   1 
+ATOM   164  C CA  . ALA A 1 21  ? -3.206  30.089 -2.121  1.00 15.51 ? 21  ALA A CA  1 
+ATOM   165  C C   . ALA A 1 21  ? -2.804  31.416 -2.736  1.00 16.79 ? 21  ALA A C   1 
+ATOM   166  O O   . ALA A 1 21  ? -2.063  32.195 -2.138  1.00 15.96 ? 21  ALA A O   1 
+ATOM   167  C CB  . ALA A 1 21  ? -4.687  30.116 -1.750  1.00 14.86 ? 21  ALA A CB  1 
+ATOM   168  N N   . ARG A 1 22  ? -3.307  31.670 -3.937  1.00 19.31 ? 22  ARG A N   1 
+ATOM   169  C CA  . ARG A 1 22  ? -3.010  32.908 -4.634  1.00 22.02 ? 22  ARG A CA  1 
+ATOM   170  C C   . ARG A 1 22  ? -4.283  33.710 -4.890  1.00 23.11 ? 22  ARG A C   1 
+ATOM   171  O O   . ARG A 1 22  ? -5.294  33.171 -5.344  1.00 22.45 ? 22  ARG A O   1 
+ATOM   172  C CB  . ARG A 1 22  ? -2.299  32.612 -5.959  1.00 24.95 ? 22  ARG A CB  1 
+ATOM   173  C CG  . ARG A 1 22  ? -2.215  33.809 -6.894  1.00 27.65 ? 22  ARG A CG  1 
+ATOM   174  C CD  . ARG A 1 22  ? -1.346  33.535 -8.113  1.00 30.30 ? 22  ARG A CD  1 
+ATOM   175  N NE  . ARG A 1 22  ? 0.078   33.624 -7.804  1.00 32.81 ? 22  ARG A NE  1 
+ATOM   176  C CZ  . ARG A 1 22  ? 0.792   32.658 -7.235  1.00 34.13 ? 22  ARG A CZ  1 
+ATOM   177  N NH1 . ARG A 1 22  ? 0.224   31.505 -6.909  1.00 35.03 ? 22  ARG A NH1 1 
+ATOM   178  N NH2 . ARG A 1 22  ? 2.078   32.851 -6.983  1.00 35.04 ? 22  ARG A NH2 1 
+ATOM   179  N N   . ASN A 1 23  ? -4.225  34.999 -4.574  1.00 23.80 ? 23  ASN A N   1 
+ATOM   180  C CA  . ASN A 1 23  ? -5.353  35.894 -4.774  1.00 25.51 ? 23  ASN A CA  1 
+ATOM   181  C C   . ASN A 1 23  ? -5.295  36.367 -6.221  1.00 27.46 ? 23  ASN A C   1 
+ATOM   182  O O   . ASN A 1 23  ? -4.373  37.079 -6.612  1.00 27.51 ? 23  ASN A O   1 
+ATOM   183  C CB  . ASN A 1 23  ? -5.252  37.077 -3.802  1.00 24.93 ? 23  ASN A CB  1 
+ATOM   184  C CG  . ASN A 1 23  ? -6.423  38.041 -3.916  1.00 24.62 ? 23  ASN A CG  1 
+ATOM   185  O OD1 . ASN A 1 23  ? -6.779  38.714 -2.947  1.00 26.08 ? 23  ASN A OD1 1 
+ATOM   186  N ND2 . ASN A 1 23  ? -7.013  38.125 -5.098  1.00 23.31 ? 23  ASN A ND2 1 
+ATOM   187  N N   . LYS A 1 24  ? -6.277  35.952 -7.014  1.00 29.05 ? 24  LYS A N   1 
+ATOM   188  C CA  . LYS A 1 24  ? -6.340  36.314 -8.427  1.00 31.19 ? 24  LYS A CA  1 
+ATOM   189  C C   . LYS A 1 24  ? -6.516  37.814 -8.653  1.00 32.01 ? 24  LYS A C   1 
+ATOM   190  O O   . LYS A 1 24  ? -6.091  38.347 -9.678  1.00 31.98 ? 24  LYS A O   1 
+ATOM   191  C CB  . LYS A 1 24  ? -7.491  35.567 -9.102  1.00 32.14 ? 24  LYS A CB  1 
+ATOM   192  C CG  . LYS A 1 24  ? -7.411  34.056 -8.975  1.00 33.46 ? 24  LYS A CG  1 
+ATOM   193  C CD  . LYS A 1 24  ? -8.647  33.393 -9.558  1.00 33.96 ? 24  LYS A CD  1 
+ATOM   194  C CE  . LYS A 1 24  ? -8.557  31.882 -9.461  1.00 35.51 ? 24  LYS A CE  1 
+ATOM   195  N NZ  . LYS A 1 24  ? -7.362  31.359 -10.182 1.00 36.50 ? 24  LYS A NZ  1 
+ATOM   196  N N   . LEU A 1 25  ? -7.143  38.491 -7.696  1.00 32.83 ? 25  LEU A N   1 
+ATOM   197  C CA  . LEU A 1 25  ? -7.378  39.924 -7.814  1.00 33.56 ? 25  LEU A CA  1 
+ATOM   198  C C   . LEU A 1 25  ? -6.170  40.769 -7.414  1.00 33.54 ? 25  LEU A C   1 
+ATOM   199  O O   . LEU A 1 25  ? -5.995  41.880 -7.918  1.00 33.27 ? 25  LEU A O   1 
+ATOM   200  C CB  . LEU A 1 25  ? -8.594  40.333 -6.973  1.00 34.62 ? 25  LEU A CB  1 
+ATOM   201  C CG  . LEU A 1 25  ? -9.945  39.738 -7.391  1.00 35.90 ? 25  LEU A CG  1 
+ATOM   202  C CD1 . LEU A 1 25  ? -11.040 40.237 -6.455  1.00 36.18 ? 25  LEU A CD1 1 
+ATOM   203  C CD2 . LEU A 1 25  ? -10.257 40.126 -8.831  1.00 36.29 ? 25  LEU A CD2 1 
+ATOM   204  N N   . THR A 1 26  ? -5.338  40.248 -6.517  1.00 32.86 ? 26  THR A N   1 
+ATOM   205  C CA  . THR A 1 26  ? -4.159  40.986 -6.071  1.00 31.95 ? 26  THR A CA  1 
+ATOM   206  C C   . THR A 1 26  ? -2.843  40.305 -6.443  1.00 31.45 ? 26  THR A C   1 
+ATOM   207  O O   . THR A 1 26  ? -1.788  40.944 -6.428  1.00 32.00 ? 26  THR A O   1 
+ATOM   208  C CB  . THR A 1 26  ? -4.178  41.207 -4.539  1.00 31.90 ? 26  THR A CB  1 
+ATOM   209  O OG1 . THR A 1 26  ? -4.161  39.941 -3.870  1.00 31.08 ? 26  THR A OG1 1 
+ATOM   210  C CG2 . THR A 1 26  ? -5.427  41.979 -4.124  1.00 31.92 ? 26  THR A CG2 1 
+ATOM   211  N N   . GLY A 1 27  ? -2.909  39.021 -6.787  1.00 30.19 ? 27  GLY A N   1 
+ATOM   212  C CA  . GLY A 1 27  ? -1.710  38.273 -7.139  1.00 28.96 ? 27  GLY A CA  1 
+ATOM   213  C C   . GLY A 1 27  ? -0.980  37.873 -5.869  1.00 27.50 ? 27  GLY A C   1 
+ATOM   214  O O   . GLY A 1 27  ? 0.032   37.168 -5.885  1.00 27.87 ? 27  GLY A O   1 
+ATOM   215  N N   . GLU A 1 28  ? -1.530  38.334 -4.755  1.00 26.00 ? 28  GLU A N   1 
+ATOM   216  C CA  . GLU A 1 28  ? -1.000  38.088 -3.423  1.00 23.70 ? 28  GLU A CA  1 
+ATOM   217  C C   . GLU A 1 28  ? -1.006  36.598 -3.061  1.00 21.00 ? 28  GLU A C   1 
+ATOM   218  O O   . GLU A 1 28  ? -1.941  35.870 -3.396  1.00 18.83 ? 28  GLU A O   1 
+ATOM   219  C CB  . GLU A 1 28  ? -1.846  38.893 -2.435  1.00 25.87 ? 28  GLU A CB  1 
+ATOM   220  C CG  . GLU A 1 28  ? -1.352  38.995 -1.013  1.00 28.83 ? 28  GLU A CG  1 
+ATOM   221  C CD  . GLU A 1 28  ? -2.137  40.043 -0.233  1.00 31.51 ? 28  GLU A CD  1 
+ATOM   222  O OE1 . GLU A 1 28  ? -3.373  40.124 -0.424  1.00 32.05 ? 28  GLU A OE1 1 
+ATOM   223  O OE2 . GLU A 1 28  ? -1.527  40.783 0.571   1.00 32.36 ? 28  GLU A OE2 1 
+ATOM   224  N N   . VAL A 1 29  ? 0.055   36.149 -2.395  1.00 18.52 ? 29  VAL A N   1 
+ATOM   225  C CA  . VAL A 1 29  ? 0.156   34.759 -1.956  1.00 16.30 ? 29  VAL A CA  1 
+ATOM   226  C C   . VAL A 1 29  ? -0.255  34.789 -0.491  1.00 14.94 ? 29  VAL A C   1 
+ATOM   227  O O   . VAL A 1 29  ? 0.274   35.579 0.290   1.00 12.91 ? 29  VAL A O   1 
+ATOM   228  C CB  . VAL A 1 29  ? 1.595   34.218 -2.098  1.00 17.08 ? 29  VAL A CB  1 
+ATOM   229  C CG1 . VAL A 1 29  ? 1.723   32.880 -1.394  1.00 17.32 ? 29  VAL A CG1 1 
+ATOM   230  C CG2 . VAL A 1 29  ? 1.938   34.055 -3.571  1.00 17.20 ? 29  VAL A CG2 1 
+ATOM   231  N N   . VAL A 1 30  ? -1.203  33.933 -0.125  1.00 12.48 ? 30  VAL A N   1 
+ATOM   232  C CA  . VAL A 1 30  ? -1.720  33.917 1.233   1.00 10.98 ? 30  VAL A CA  1 
+ATOM   233  C C   . VAL A 1 30  ? -1.895  32.515 1.802   1.00 10.56 ? 30  VAL A C   1 
+ATOM   234  O O   . VAL A 1 30  ? -1.675  31.512 1.123   1.00 9.68  ? 30  VAL A O   1 
+ATOM   235  C CB  . VAL A 1 30  ? -3.108  34.597 1.282   1.00 10.91 ? 30  VAL A CB  1 
+ATOM   236  C CG1 . VAL A 1 30  ? -3.032  36.010 0.714   1.00 11.35 ? 30  VAL A CG1 1 
+ATOM   237  C CG2 . VAL A 1 30  ? -4.102  33.774 0.481   1.00 12.28 ? 30  VAL A CG2 1 
+ATOM   238  N N   . ALA A 1 31  ? -2.293  32.470 3.068   1.00 10.59 ? 31  ALA A N   1 
+ATOM   239  C CA  . ALA A 1 31  ? -2.573  31.215 3.743   1.00 11.44 ? 31  ALA A CA  1 
+ATOM   240  C C   . ALA A 1 31  ? -4.072  31.274 3.977   1.00 12.43 ? 31  ALA A C   1 
+ATOM   241  O O   . ALA A 1 31  ? -4.589  32.291 4.442   1.00 12.26 ? 31  ALA A O   1 
+ATOM   242  C CB  . ALA A 1 31  ? -1.842  31.139 5.070   1.00 11.75 ? 31  ALA A CB  1 
+ATOM   243  N N   . LEU A 1 32  ? -4.772  30.196 3.646   1.00 13.98 ? 32  LEU A N   1 
+ATOM   244  C CA  . LEU A 1 32  ? -6.220  30.151 3.824   1.00 15.73 ? 32  LEU A CA  1 
+ATOM   245  C C   . LEU A 1 32  ? -6.610  29.114 4.863   1.00 16.67 ? 32  LEU A C   1 
+ATOM   246  O O   . LEU A 1 32  ? -6.136  27.978 4.824   1.00 17.35 ? 32  LEU A O   1 
+ATOM   247  C CB  . LEU A 1 32  ? -6.916  29.792 2.509   1.00 17.20 ? 32  LEU A CB  1 
+ATOM   248  C CG  . LEU A 1 32  ? -6.908  30.748 1.317   1.00 18.83 ? 32  LEU A CG  1 
+ATOM   249  C CD1 . LEU A 1 32  ? -7.567  30.053 0.134   1.00 20.10 ? 32  LEU A CD1 1 
+ATOM   250  C CD2 . LEU A 1 32  ? -7.651  32.038 1.664   1.00 19.46 ? 32  LEU A CD2 1 
+ATOM   251  N N   . LYS A 1 33  ? -7.467  29.508 5.798   1.00 16.73 ? 33  LYS A N   1 
+ATOM   252  C CA  . LYS A 1 33  ? -7.943  28.581 6.814   1.00 17.34 ? 33  LYS A CA  1 
+ATOM   253  C C   . LYS A 1 33  ? -9.401  28.290 6.476   1.00 17.55 ? 33  LYS A C   1 
+ATOM   254  O O   . LYS A 1 33  ? -10.240 29.191 6.507   1.00 16.82 ? 33  LYS A O   1 
+ATOM   255  C CB  . LYS A 1 33  ? -7.847  29.194 8.216   1.00 16.91 ? 33  LYS A CB  1 
+ATOM   256  C CG  . LYS A 1 33  ? -8.320  28.253 9.321   1.00 18.10 ? 33  LYS A CG  1 
+ATOM   257  C CD  . LYS A 1 33  ? -8.116  28.846 10.705  1.00 19.88 ? 33  LYS A CD  1 
+ATOM   258  C CE  . LYS A 1 33  ? -8.411  27.815 11.787  1.00 20.81 ? 33  LYS A CE  1 
+ATOM   259  N NZ  . LYS A 1 33  ? -8.177  28.343 13.160  1.00 21.63 ? 33  LYS A NZ  1 
+ATOM   260  N N   . LYS A 1 34  ? -9.693  27.041 6.133   1.00 18.28 ? 34  LYS A N   1 
+ATOM   261  C CA  . LYS A 1 34  ? -11.056 26.645 5.789   1.00 19.74 ? 34  LYS A CA  1 
+ATOM   262  C C   . LYS A 1 34  ? -11.708 25.924 6.958   1.00 19.01 ? 34  LYS A C   1 
+ATOM   263  O O   . LYS A 1 34  ? -11.217 24.890 7.408   1.00 17.65 ? 34  LYS A O   1 
+ATOM   264  C CB  . LYS A 1 34  ? -11.069 25.701 4.582   1.00 21.91 ? 34  LYS A CB  1 
+ATOM   265  C CG  . LYS A 1 34  ? -10.498 26.264 3.300   1.00 26.52 ? 34  LYS A CG  1 
+ATOM   266  C CD  . LYS A 1 34  ? -10.762 25.304 2.145   1.00 28.10 ? 34  LYS A CD  1 
+ATOM   267  C CE  . LYS A 1 34  ? -10.212 25.837 0.833   1.00 30.04 ? 34  LYS A CE  1 
+ATOM   268  N NZ  . LYS A 1 34  ? -10.567 24.950 -0.311  1.00 31.69 ? 34  LYS A NZ  1 
+ATOM   269  N N   . ILE A 1 35  ? -12.820 26.466 7.438   1.00 19.61 ? 35  ILE A N   1 
+ATOM   270  C CA  . ILE A 1 35  ? -13.545 25.861 8.545   1.00 21.54 ? 35  ILE A CA  1 
+ATOM   271  C C   . ILE A 1 35  ? -14.956 25.494 8.101   1.00 23.25 ? 35  ILE A C   1 
+ATOM   272  O O   . ILE A 1 35  ? -15.671 26.328 7.545   1.00 23.47 ? 35  ILE A O   1 
+ATOM   273  C CB  . ILE A 1 35  ? -13.650 26.828 9.742   1.00 21.34 ? 35  ILE A CB  1 
+ATOM   274  C CG1 . ILE A 1 35  ? -12.253 27.245 10.198  1.00 21.61 ? 35  ILE A CG1 1 
+ATOM   275  C CG2 . ILE A 1 35  ? -14.398 26.156 10.883  1.00 21.80 ? 35  ILE A CG2 1 
+ATOM   276  C CD1 . ILE A 1 35  ? -12.250 28.325 11.258  1.00 21.37 ? 35  ILE A CD1 1 
+ATOM   277  N N   . ARG A 1 36  ? -15.347 24.244 8.332   1.00 25.10 ? 36  ARG A N   1 
+ATOM   278  C CA  . ARG A 1 36  ? -16.683 23.786 7.966   1.00 27.39 ? 36  ARG A CA  1 
+ATOM   279  C C   . ARG A 1 36  ? -17.637 24.129 9.099   1.00 27.73 ? 36  ARG A C   1 
+ATOM   280  O O   . ARG A 1 36  ? -17.316 23.926 10.267  1.00 27.97 ? 36  ARG A O   1 
+ATOM   281  C CB  . ARG A 1 36  ? -16.692 22.272 7.732   1.00 29.07 ? 36  ARG A CB  1 
+ATOM   282  C CG  . ARG A 1 36  ? -15.817 21.818 6.578   1.00 32.07 ? 36  ARG A CG  1 
+ATOM   283  C CD  . ARG A 1 36  ? -15.832 20.303 6.418   1.00 34.63 ? 36  ARG A CD  1 
+ATOM   284  N NE  . ARG A 1 36  ? -17.153 19.787 6.070   1.00 37.01 ? 36  ARG A NE  1 
+ATOM   285  C CZ  . ARG A 1 36  ? -17.410 18.507 5.816   1.00 38.23 ? 36  ARG A CZ  1 
+ATOM   286  N NH1 . ARG A 1 36  ? -16.436 17.607 5.871   1.00 38.59 ? 36  ARG A NH1 1 
+ATOM   287  N NH2 . ARG A 1 36  ? -18.642 18.123 5.505   1.00 38.93 ? 36  ARG A NH2 1 
+ATOM   288  N N   . LEU A 1 37  ? -18.807 24.652 8.750   1.00 28.56 ? 37  LEU A N   1 
+ATOM   289  C CA  . LEU A 1 37  ? -19.805 25.025 9.745   1.00 29.47 ? 37  LEU A CA  1 
+ATOM   290  C C   . LEU A 1 37  ? -21.007 24.092 9.681   1.00 29.79 ? 37  LEU A C   1 
+ATOM   291  O O   . LEU A 1 37  ? -20.902 22.915 10.005  1.00 31.41 ? 37  LEU A O   1 
+ATOM   292  C CB  . LEU A 1 37  ? -20.261 26.465 9.510   1.00 29.76 ? 37  LEU A CB  1 
+ATOM   293  C CG  . LEU A 1 37  ? -19.167 27.531 9.563   1.00 30.21 ? 37  LEU A CG  1 
+ATOM   294  C CD1 . LEU A 1 37  ? -19.749 28.873 9.150   1.00 31.26 ? 37  LEU A CD1 1 
+ATOM   295  C CD2 . LEU A 1 37  ? -18.586 27.599 10.967  1.00 31.13 ? 37  LEU A CD2 1 
+ATOM   296  N N   . ARG A 1 50  ? -18.325 36.683 15.248  1.00 37.05 ? 50  ARG A N   1 
+ATOM   297  C CA  . ARG A 1 50  ? -18.090 38.109 15.442  1.00 36.85 ? 50  ARG A CA  1 
+ATOM   298  C C   . ARG A 1 50  ? -16.716 38.369 16.052  1.00 37.14 ? 50  ARG A C   1 
+ATOM   299  O O   . ARG A 1 50  ? -15.977 39.232 15.580  1.00 37.10 ? 50  ARG A O   1 
+ATOM   300  C CB  . ARG A 1 50  ? -19.175 38.701 16.332  1.00 37.54 ? 50  ARG A CB  1 
+ATOM   301  N N   . GLU A 1 51  ? -16.379 37.621 17.099  1.00 36.97 ? 51  GLU A N   1 
+ATOM   302  C CA  . GLU A 1 51  ? -15.094 37.771 17.778  1.00 37.03 ? 51  GLU A CA  1 
+ATOM   303  C C   . GLU A 1 51  ? -13.957 37.782 16.756  1.00 36.76 ? 51  GLU A C   1 
+ATOM   304  O O   . GLU A 1 51  ? -12.904 38.383 16.979  1.00 35.86 ? 51  GLU A O   1 
+ATOM   305  C CB  . GLU A 1 51  ? -14.896 36.624 18.775  1.00 37.81 ? 51  GLU A CB  1 
+ATOM   306  C CG  . GLU A 1 51  ? -13.695 36.786 19.696  1.00 39.03 ? 51  GLU A CG  1 
+ATOM   307  C CD  . GLU A 1 51  ? -13.585 35.663 20.714  1.00 39.91 ? 51  GLU A CD  1 
+ATOM   308  O OE1 . GLU A 1 51  ? -12.630 35.682 21.522  1.00 40.53 ? 51  GLU A OE1 1 
+ATOM   309  O OE2 . GLU A 1 51  ? -14.452 34.762 20.707  1.00 39.91 ? 51  GLU A OE2 1 
+ATOM   310  N N   . ILE A 1 52  ? -14.189 37.119 15.629  1.00 36.95 ? 52  ILE A N   1 
+ATOM   311  C CA  . ILE A 1 52  ? -13.204 37.046 14.560  1.00 37.43 ? 52  ILE A CA  1 
+ATOM   312  C C   . ILE A 1 52  ? -13.036 38.406 13.891  1.00 37.53 ? 52  ILE A C   1 
+ATOM   313  O O   . ILE A 1 52  ? -11.921 38.808 13.555  1.00 38.04 ? 52  ILE A O   1 
+ATOM   314  C CB  . ILE A 1 52  ? -13.624 36.017 13.486  1.00 37.90 ? 52  ILE A CB  1 
+ATOM   315  C CG1 . ILE A 1 52  ? -13.815 34.640 14.127  1.00 37.66 ? 52  ILE A CG1 1 
+ATOM   316  C CG2 . ILE A 1 52  ? -12.574 35.954 12.384  1.00 38.15 ? 52  ILE A CG2 1 
+ATOM   317  C CD1 . ILE A 1 52  ? -12.582 34.100 14.818  1.00 37.91 ? 52  ILE A CD1 1 
+ATOM   318  N N   . SER A 1 53  ? -14.148 39.111 13.701  1.00 37.48 ? 53  SER A N   1 
+ATOM   319  C CA  . SER A 1 53  ? -14.122 40.424 13.068  1.00 37.14 ? 53  SER A CA  1 
+ATOM   320  C C   . SER A 1 53  ? -13.227 41.384 13.844  1.00 36.11 ? 53  SER A C   1 
+ATOM   321  O O   . SER A 1 53  ? -12.606 42.276 13.263  1.00 36.38 ? 53  SER A O   1 
+ATOM   322  C CB  . SER A 1 53  ? -15.538 41.003 12.974  1.00 38.24 ? 53  SER A CB  1 
+ATOM   323  O OG  . SER A 1 53  ? -16.060 41.303 14.258  1.00 39.41 ? 53  SER A OG  1 
+ATOM   324  N N   . LEU A 1 54  ? -13.159 41.199 15.159  1.00 34.25 ? 54  LEU A N   1 
+ATOM   325  C CA  . LEU A 1 54  ? -12.328 42.053 15.996  1.00 32.18 ? 54  LEU A CA  1 
+ATOM   326  C C   . LEU A 1 54  ? -10.845 41.773 15.751  1.00 30.70 ? 54  LEU A C   1 
+ATOM   327  O O   . LEU A 1 54  ? -10.006 42.662 15.895  1.00 29.75 ? 54  LEU A O   1 
+ATOM   328  C CB  . LEU A 1 54  ? -12.652 41.836 17.478  1.00 33.26 ? 54  LEU A CB  1 
+ATOM   329  C CG  . LEU A 1 54  ? -14.057 42.196 17.978  1.00 33.78 ? 54  LEU A CG  1 
+ATOM   330  C CD1 . LEU A 1 54  ? -14.392 43.623 17.568  1.00 33.89 ? 54  LEU A CD1 1 
+ATOM   331  C CD2 . LEU A 1 54  ? -15.081 41.223 17.410  1.00 34.38 ? 54  LEU A CD2 1 
+ATOM   332  N N   . LEU A 1 55  ? -10.527 40.534 15.383  1.00 28.32 ? 55  LEU A N   1 
+ATOM   333  C CA  . LEU A 1 55  ? -9.142  40.159 15.119  1.00 27.07 ? 55  LEU A CA  1 
+ATOM   334  C C   . LEU A 1 55  ? -8.625  40.870 13.875  1.00 26.00 ? 55  LEU A C   1 
+ATOM   335  O O   . LEU A 1 55  ? -7.425  41.099 13.734  1.00 25.20 ? 55  LEU A O   1 
+ATOM   336  C CB  . LEU A 1 55  ? -9.015  38.645 14.931  1.00 27.51 ? 55  LEU A CB  1 
+ATOM   337  C CG  . LEU A 1 55  ? -9.244  37.758 16.161  1.00 28.84 ? 55  LEU A CG  1 
+ATOM   338  C CD1 . LEU A 1 55  ? -9.056  36.298 15.770  1.00 28.84 ? 55  LEU A CD1 1 
+ATOM   339  C CD2 . LEU A 1 55  ? -8.269  38.136 17.270  1.00 29.26 ? 55  LEU A CD2 1 
+ATOM   340  N N   . LYS A 1 56  ? -9.538  41.218 12.976  1.00 25.08 ? 56  LYS A N   1 
+ATOM   341  C CA  . LYS A 1 56  ? -9.171  41.905 11.746  1.00 25.04 ? 56  LYS A CA  1 
+ATOM   342  C C   . LYS A 1 56  ? -8.647  43.308 12.071  1.00 23.91 ? 56  LYS A C   1 
+ATOM   343  O O   . LYS A 1 56  ? -8.024  43.959 11.231  1.00 23.19 ? 56  LYS A O   1 
+ATOM   344  C CB  . LYS A 1 56  ? -10.385 41.986 10.816  1.00 26.50 ? 56  LYS A CB  1 
+ATOM   345  C CG  . LYS A 1 56  ? -10.041 42.066 9.338   1.00 28.99 ? 56  LYS A CG  1 
+ATOM   346  C CD  . LYS A 1 56  ? -11.258 41.745 8.479   1.00 31.23 ? 56  LYS A CD  1 
+ATOM   347  C CE  . LYS A 1 56  ? -10.926 41.784 6.996   1.00 32.83 ? 56  LYS A CE  1 
+ATOM   348  N NZ  . LYS A 1 56  ? -12.090 41.364 6.158   1.00 34.80 ? 56  LYS A NZ  1 
+ATOM   349  N N   . GLU A 1 57  ? -8.900  43.764 13.295  1.00 22.54 ? 57  GLU A N   1 
+ATOM   350  C CA  . GLU A 1 57  ? -8.440  45.081 13.732  1.00 21.70 ? 57  GLU A CA  1 
+ATOM   351  C C   . GLU A 1 57  ? -7.197  44.972 14.615  1.00 19.82 ? 57  GLU A C   1 
+ATOM   352  O O   . GLU A 1 57  ? -6.518  45.965 14.877  1.00 18.80 ? 57  GLU A O   1 
+ATOM   353  C CB  . GLU A 1 57  ? -9.551  45.803 14.500  1.00 24.53 ? 57  GLU A CB  1 
+ATOM   354  C CG  . GLU A 1 57  ? -10.791 46.085 13.668  1.00 27.83 ? 57  GLU A CG  1 
+ATOM   355  C CD  . GLU A 1 57  ? -10.467 46.832 12.391  1.00 30.47 ? 57  GLU A CD  1 
+ATOM   356  O OE1 . GLU A 1 57  ? -9.871  47.927 12.477  1.00 32.72 ? 57  GLU A OE1 1 
+ATOM   357  O OE2 . GLU A 1 57  ? -10.807 46.327 11.299  1.00 33.04 ? 57  GLU A OE2 1 
+ATOM   358  N N   . LEU A 1 58  ? -6.906  43.758 15.070  1.00 18.25 ? 58  LEU A N   1 
+ATOM   359  C CA  . LEU A 1 58  ? -5.751  43.513 15.930  1.00 17.69 ? 58  LEU A CA  1 
+ATOM   360  C C   . LEU A 1 58  ? -4.491  43.441 15.063  1.00 16.66 ? 58  LEU A C   1 
+ATOM   361  O O   . LEU A 1 58  ? -3.905  42.375 14.898  1.00 17.11 ? 58  LEU A O   1 
+ATOM   362  C CB  . LEU A 1 58  ? -5.947  42.192 16.685  1.00 18.06 ? 58  LEU A CB  1 
+ATOM   363  C CG  . LEU A 1 58  ? -5.014  41.870 17.857  1.00 18.32 ? 58  LEU A CG  1 
+ATOM   364  C CD1 . LEU A 1 58  ? -5.312  42.801 19.021  1.00 17.71 ? 58  LEU A CD1 1 
+ATOM   365  C CD2 . LEU A 1 58  ? -5.216  40.418 18.282  1.00 18.73 ? 58  LEU A CD2 1 
+ATOM   366  N N   . ASN A 1 59  ? -4.079  44.585 14.522  1.00 15.50 ? 59  ASN A N   1 
+ATOM   367  C CA  . ASN A 1 59  ? -2.913  44.664 13.646  1.00 13.91 ? 59  ASN A CA  1 
+ATOM   368  C C   . ASN A 1 59  ? -1.625  45.079 14.364  1.00 13.43 ? 59  ASN A C   1 
+ATOM   369  O O   . ASN A 1 59  ? -1.575  46.111 15.038  1.00 12.67 ? 59  ASN A O   1 
+ATOM   370  C CB  . ASN A 1 59  ? -3.222  45.629 12.495  1.00 14.67 ? 59  ASN A CB  1 
+ATOM   371  C CG  . ASN A 1 59  ? -4.402  45.161 11.644  1.00 15.62 ? 59  ASN A CG  1 
+ATOM   372  O OD1 . ASN A 1 59  ? -5.180  45.973 11.134  1.00 17.57 ? 59  ASN A OD1 1 
+ATOM   373  N ND2 . ASN A 1 59  ? -4.533  43.848 11.483  1.00 13.35 ? 59  ASN A ND2 1 
+ATOM   374  N N   . HIS A 1 60  ? -0.580  44.270 14.194  1.00 12.14 ? 60  HIS A N   1 
+ATOM   375  C CA  . HIS A 1 60  ? 0.714   44.511 14.834  1.00 10.89 ? 60  HIS A CA  1 
+ATOM   376  C C   . HIS A 1 60  ? 1.820   43.842 14.003  1.00 10.10 ? 60  HIS A C   1 
+ATOM   377  O O   . HIS A 1 60  ? 1.594   42.800 13.386  1.00 9.94  ? 60  HIS A O   1 
+ATOM   378  C CB  . HIS A 1 60  ? 0.672   43.929 16.257  1.00 11.11 ? 60  HIS A CB  1 
+ATOM   379  C CG  . HIS A 1 60  ? 1.886   44.223 17.085  1.00 10.87 ? 60  HIS A CG  1 
+ATOM   380  N ND1 . HIS A 1 60  ? 3.087   43.570 16.908  1.00 10.87 ? 60  HIS A ND1 1 
+ATOM   381  C CD2 . HIS A 1 60  ? 2.073   45.079 18.118  1.00 10.19 ? 60  HIS A CD2 1 
+ATOM   382  C CE1 . HIS A 1 60  ? 3.959   44.007 17.799  1.00 11.31 ? 60  HIS A CE1 1 
+ATOM   383  N NE2 . HIS A 1 60  ? 3.370   44.922 18.546  1.00 10.34 ? 60  HIS A NE2 1 
+ATOM   384  N N   . PRO A 1 61  ? 3.025   44.438 13.966  1.00 9.46  ? 61  PRO A N   1 
+ATOM   385  C CA  . PRO A 1 61  ? 4.147   43.877 13.198  1.00 10.19 ? 61  PRO A CA  1 
+ATOM   386  C C   . PRO A 1 61  ? 4.477   42.431 13.560  1.00 10.23 ? 61  PRO A C   1 
+ATOM   387  O O   . PRO A 1 61  ? 5.045   41.696 12.746  1.00 7.92  ? 61  PRO A O   1 
+ATOM   388  C CB  . PRO A 1 61  ? 5.304   44.811 13.538  1.00 11.76 ? 61  PRO A CB  1 
+ATOM   389  C CG  . PRO A 1 61  ? 4.613   46.124 13.785  1.00 12.12 ? 61  PRO A CG  1 
+ATOM   390  C CD  . PRO A 1 61  ? 3.408   45.712 14.598  1.00 9.88  ? 61  PRO A CD  1 
+ATOM   391  N N   . ASN A 1 62  ? 4.114   42.027 14.776  1.00 8.97  ? 62  ASN A N   1 
+ATOM   392  C CA  . ASN A 1 62  ? 4.401   40.670 15.230  1.00 9.22  ? 62  ASN A CA  1 
+ATOM   393  C C   . ASN A 1 62  ? 3.167   39.784 15.403  1.00 8.81  ? 62  ASN A C   1 
+ATOM   394  O O   . ASN A 1 62  ? 3.153   38.869 16.227  1.00 9.31  ? 62  ASN A O   1 
+ATOM   395  C CB  . ASN A 1 62  ? 5.220   40.720 16.525  1.00 8.62  ? 62  ASN A CB  1 
+ATOM   396  C CG  . ASN A 1 62  ? 6.489   41.539 16.372  1.00 10.00 ? 62  ASN A CG  1 
+ATOM   397  O OD1 . ASN A 1 62  ? 6.548   42.692 16.787  1.00 10.82 ? 62  ASN A OD1 1 
+ATOM   398  N ND2 . ASN A 1 62  ? 7.506   40.949 15.752  1.00 9.91  ? 62  ASN A ND2 1 
+ATOM   399  N N   . ILE A 1 63  ? 2.133   40.073 14.618  1.00 8.50  ? 63  ILE A N   1 
+ATOM   400  C CA  . ILE A 1 63  ? 0.903   39.287 14.610  1.00 7.92  ? 63  ILE A CA  1 
+ATOM   401  C C   . ILE A 1 63  ? 0.624   39.038 13.131  1.00 7.99  ? 63  ILE A C   1 
+ATOM   402  O O   . ILE A 1 63  ? 0.582   39.988 12.344  1.00 6.74  ? 63  ILE A O   1 
+ATOM   403  C CB  . ILE A 1 63  ? -0.295  40.064 15.228  1.00 8.06  ? 63  ILE A CB  1 
+ATOM   404  C CG1 . ILE A 1 63  ? -0.143  40.136 16.751  1.00 8.45  ? 63  ILE A CG1 1 
+ATOM   405  C CG2 . ILE A 1 63  ? -1.614  39.375 14.866  1.00 7.71  ? 63  ILE A CG2 1 
+ATOM   406  C CD1 . ILE A 1 63  ? -1.272  40.888 17.450  1.00 7.35  ? 63  ILE A CD1 1 
+ATOM   407  N N   . VAL A 1 64  ? 0.458   37.776 12.742  1.00 8.32  ? 64  VAL A N   1 
+ATOM   408  C CA  . VAL A 1 64  ? 0.186   37.473 11.340  1.00 8.52  ? 64  VAL A CA  1 
+ATOM   409  C C   . VAL A 1 64  ? -1.077  38.236 10.952  1.00 8.91  ? 64  VAL A C   1 
+ATOM   410  O O   . VAL A 1 64  ? -2.114  38.123 11.604  1.00 8.50  ? 64  VAL A O   1 
+ATOM   411  C CB  . VAL A 1 64  ? -0.011  35.955 11.096  1.00 8.60  ? 64  VAL A CB  1 
+ATOM   412  C CG1 . VAL A 1 64  ? -1.181  35.431 11.901  1.00 10.57 ? 64  VAL A CG1 1 
+ATOM   413  C CG2 . VAL A 1 64  ? -0.250  35.695 9.613   1.00 9.86  ? 64  VAL A CG2 1 
+ATOM   414  N N   . LYS A 1 65  ? -0.985  39.030 9.897   1.00 8.62  ? 65  LYS A N   1 
+ATOM   415  C CA  . LYS A 1 65  ? -2.127  39.827 9.478   1.00 9.74  ? 65  LYS A CA  1 
+ATOM   416  C C   . LYS A 1 65  ? -3.272  39.012 8.906   1.00 11.06 ? 65  LYS A C   1 
+ATOM   417  O O   . LYS A 1 65  ? -3.071  38.170 8.033   1.00 10.74 ? 65  LYS A O   1 
+ATOM   418  C CB  . LYS A 1 65  ? -1.690  40.871 8.448   1.00 10.98 ? 65  LYS A CB  1 
+ATOM   419  C CG  . LYS A 1 65  ? -2.811  41.778 7.948   1.00 10.88 ? 65  LYS A CG  1 
+ATOM   420  C CD  . LYS A 1 65  ? -2.274  42.790 6.940   1.00 13.31 ? 65  LYS A CD  1 
+ATOM   421  C CE  . LYS A 1 65  ? -3.354  43.764 6.487   1.00 13.04 ? 65  LYS A CE  1 
+ATOM   422  N NZ  . LYS A 1 65  ? -3.927  44.520 7.642   1.00 14.17 ? 65  LYS A NZ  1 
+ATOM   423  N N   . LEU A 1 66  ? -4.467  39.258 9.435   1.00 11.10 ? 66  LEU A N   1 
+ATOM   424  C CA  . LEU A 1 66  ? -5.681  38.613 8.957   1.00 12.90 ? 66  LEU A CA  1 
+ATOM   425  C C   . LEU A 1 66  ? -6.157  39.571 7.870   1.00 14.72 ? 66  LEU A C   1 
+ATOM   426  O O   . LEU A 1 66  ? -6.655  40.665 8.159   1.00 15.49 ? 66  LEU A O   1 
+ATOM   427  C CB  . LEU A 1 66  ? -6.721  38.519 10.076  1.00 12.96 ? 66  LEU A CB  1 
+ATOM   428  C CG  . LEU A 1 66  ? -8.128  38.060 9.673   1.00 13.66 ? 66  LEU A CG  1 
+ATOM   429  C CD1 . LEU A 1 66  ? -8.076  36.681 9.019   1.00 13.31 ? 66  LEU A CD1 1 
+ATOM   430  C CD2 . LEU A 1 66  ? -9.011  38.038 10.906  1.00 14.21 ? 66  LEU A CD2 1 
+ATOM   431  N N   . LEU A 1 67  ? -5.961  39.164 6.623   1.00 15.86 ? 67  LEU A N   1 
+ATOM   432  C CA  . LEU A 1 67  ? -6.319  39.970 5.464   1.00 17.29 ? 67  LEU A CA  1 
+ATOM   433  C C   . LEU A 1 67  ? -7.814  40.053 5.208   1.00 19.47 ? 67  LEU A C   1 
+ATOM   434  O O   . LEU A 1 67  ? -8.339  41.127 4.925   1.00 19.39 ? 67  LEU A O   1 
+ATOM   435  C CB  . LEU A 1 67  ? -5.627  39.408 4.224   1.00 16.70 ? 67  LEU A CB  1 
+ATOM   436  C CG  . LEU A 1 67  ? -4.100  39.377 4.310   1.00 16.93 ? 67  LEU A CG  1 
+ATOM   437  C CD1 . LEU A 1 67  ? -3.532  38.559 3.168   1.00 15.87 ? 67  LEU A CD1 1 
+ATOM   438  C CD2 . LEU A 1 67  ? -3.564  40.801 4.282   1.00 17.46 ? 67  LEU A CD2 1 
+ATOM   439  N N   . ASP A 1 68  ? -8.496  38.918 5.300   1.00 21.75 ? 68  ASP A N   1 
+ATOM   440  C CA  . ASP A 1 68  ? -9.930  38.883 5.046   1.00 24.43 ? 68  ASP A CA  1 
+ATOM   441  C C   . ASP A 1 68  ? -10.623 37.725 5.744   1.00 25.25 ? 68  ASP A C   1 
+ATOM   442  O O   . ASP A 1 68  ? -10.006 36.705 6.057   1.00 23.94 ? 68  ASP A O   1 
+ATOM   443  C CB  . ASP A 1 68  ? -10.189 38.779 3.540   1.00 26.78 ? 68  ASP A CB  1 
+ATOM   444  C CG  . ASP A 1 68  ? -9.689  39.987 2.770   1.00 29.45 ? 68  ASP A CG  1 
+ATOM   445  O OD1 . ASP A 1 68  ? -10.263 41.084 2.946   1.00 29.94 ? 68  ASP A OD1 1 
+ATOM   446  O OD2 . ASP A 1 68  ? -8.719  39.838 1.989   1.00 30.68 ? 68  ASP A OD2 1 
+ATOM   447  N N   . VAL A 1 69  ? -11.920 37.896 5.975   1.00 27.00 ? 69  VAL A N   1 
+ATOM   448  C CA  . VAL A 1 69  ? -12.751 36.884 6.614   1.00 28.80 ? 69  VAL A CA  1 
+ATOM   449  C C   . VAL A 1 69  ? -13.968 36.704 5.714   1.00 30.34 ? 69  VAL A C   1 
+ATOM   450  O O   . VAL A 1 69  ? -14.752 37.637 5.536   1.00 30.34 ? 69  VAL A O   1 
+ATOM   451  C CB  . VAL A 1 69  ? -13.226 37.341 8.010   1.00 28.94 ? 69  VAL A CB  1 
+ATOM   452  C CG1 . VAL A 1 69  ? -14.139 36.289 8.624   1.00 28.63 ? 69  VAL A CG1 1 
+ATOM   453  C CG2 . VAL A 1 69  ? -12.027 37.596 8.909   1.00 29.24 ? 69  VAL A CG2 1 
+ATOM   454  N N   . ILE A 1 70  ? -14.125 35.516 5.140   1.00 31.45 ? 70  ILE A N   1 
+ATOM   455  C CA  . ILE A 1 70  ? -15.254 35.274 4.253   1.00 32.66 ? 70  ILE A CA  1 
+ATOM   456  C C   . ILE A 1 70  ? -16.166 34.141 4.704   1.00 33.86 ? 70  ILE A C   1 
+ATOM   457  O O   . ILE A 1 70  ? -15.730 33.004 4.893   1.00 33.67 ? 70  ILE A O   1 
+ATOM   458  C CB  . ILE A 1 70  ? -14.778 34.981 2.821   1.00 32.42 ? 70  ILE A CB  1 
+ATOM   459  C CG1 . ILE A 1 70  ? -13.804 36.073 2.367   1.00 32.15 ? 70  ILE A CG1 1 
+ATOM   460  C CG2 . ILE A 1 70  ? -15.979 34.932 1.883   1.00 32.91 ? 70  ILE A CG2 1 
+ATOM   461  C CD1 . ILE A 1 70  ? -13.122 35.791 1.046   1.00 31.75 ? 70  ILE A CD1 1 
+ATOM   462  N N   . HIS A 1 71  ? -17.441 34.473 4.870   1.00 35.18 ? 71  HIS A N   1 
+ATOM   463  C CA  . HIS A 1 71  ? -18.449 33.511 5.289   1.00 36.64 ? 71  HIS A CA  1 
+ATOM   464  C C   . HIS A 1 71  ? -19.394 33.263 4.124   1.00 37.84 ? 71  HIS A C   1 
+ATOM   465  O O   . HIS A 1 71  ? -20.142 34.156 3.726   1.00 37.96 ? 71  HIS A O   1 
+ATOM   466  C CB  . HIS A 1 71  ? -19.243 34.059 6.476   1.00 36.45 ? 71  HIS A CB  1 
+ATOM   467  C CG  . HIS A 1 71  ? -20.273 33.110 7.002   1.00 37.00 ? 71  HIS A CG  1 
+ATOM   468  N ND1 . HIS A 1 71  ? -21.188 33.468 7.969   1.00 37.34 ? 71  HIS A ND1 1 
+ATOM   469  C CD2 . HIS A 1 71  ? -20.525 31.812 6.708   1.00 37.27 ? 71  HIS A CD2 1 
+ATOM   470  C CE1 . HIS A 1 71  ? -21.958 32.431 8.248   1.00 37.70 ? 71  HIS A CE1 1 
+ATOM   471  N NE2 . HIS A 1 71  ? -21.577 31.414 7.497   1.00 37.77 ? 71  HIS A NE2 1 
+ATOM   472  N N   . THR A 1 72  ? -19.352 32.053 3.574   1.00 38.96 ? 72  THR A N   1 
+ATOM   473  C CA  . THR A 1 72  ? -20.213 31.694 2.453   1.00 40.07 ? 72  THR A CA  1 
+ATOM   474  C C   . THR A 1 72  ? -20.539 30.204 2.455   1.00 40.16 ? 72  THR A C   1 
+ATOM   475  O O   . THR A 1 72  ? -19.652 29.366 2.621   1.00 40.60 ? 72  THR A O   1 
+ATOM   476  C CB  . THR A 1 72  ? -19.555 32.037 1.100   1.00 40.66 ? 72  THR A CB  1 
+ATOM   477  O OG1 . THR A 1 72  ? -18.337 31.296 0.960   1.00 41.89 ? 72  THR A OG1 1 
+ATOM   478  C CG2 . THR A 1 72  ? -19.252 33.529 1.010   1.00 41.17 ? 72  THR A CG2 1 
+ATOM   479  N N   . GLU A 1 73  ? -21.818 29.888 2.272   1.00 40.23 ? 73  GLU A N   1 
+ATOM   480  C CA  . GLU A 1 73  ? -22.292 28.507 2.234   1.00 40.25 ? 73  GLU A CA  1 
+ATOM   481  C C   . GLU A 1 73  ? -21.653 27.580 3.262   1.00 39.69 ? 73  GLU A C   1 
+ATOM   482  O O   . GLU A 1 73  ? -20.757 26.802 2.933   1.00 39.33 ? 73  GLU A O   1 
+ATOM   483  C CB  . GLU A 1 73  ? -22.085 27.923 0.834   1.00 41.27 ? 73  GLU A CB  1 
+ATOM   484  C CG  . GLU A 1 73  ? -23.034 28.479 -0.210  1.00 42.56 ? 73  GLU A CG  1 
+ATOM   485  C CD  . GLU A 1 73  ? -22.938 27.739 -1.526  1.00 43.21 ? 73  GLU A CD  1 
+ATOM   486  O OE1 . GLU A 1 73  ? -21.904 27.876 -2.214  1.00 44.22 ? 73  GLU A OE1 1 
+ATOM   487  O OE2 . GLU A 1 73  ? -23.896 27.013 -1.869  1.00 43.66 ? 73  GLU A OE2 1 
+ATOM   488  N N   . ASN A 1 74  ? -22.135 27.660 4.500   1.00 38.83 ? 74  ASN A N   1 
+ATOM   489  C CA  . ASN A 1 74  ? -21.641 26.838 5.603   1.00 38.15 ? 74  ASN A CA  1 
+ATOM   490  C C   . ASN A 1 74  ? -20.125 26.643 5.626   1.00 36.73 ? 74  ASN A C   1 
+ATOM   491  O O   . ASN A 1 74  ? -19.627 25.615 6.088   1.00 36.14 ? 74  ASN A O   1 
+ATOM   492  C CB  . ASN A 1 74  ? -22.348 25.473 5.603   1.00 39.39 ? 74  ASN A CB  1 
+ATOM   493  C CG  . ASN A 1 74  ? -22.244 24.752 4.269   1.00 40.82 ? 74  ASN A CG  1 
+ATOM   494  O OD1 . ASN A 1 74  ? -21.151 24.409 3.813   1.00 41.03 ? 74  ASN A OD1 1 
+ATOM   495  N ND2 . ASN A 1 74  ? -23.392 24.515 3.635   1.00 41.80 ? 74  ASN A ND2 1 
+ATOM   496  N N   . LYS A 1 75  ? -19.396 27.637 5.130   1.00 35.19 ? 75  LYS A N   1 
+ATOM   497  C CA  . LYS A 1 75  ? -17.938 27.586 5.111   1.00 34.04 ? 75  LYS A CA  1 
+ATOM   498  C C   . LYS A 1 75  ? -17.394 28.933 5.572   1.00 32.11 ? 75  LYS A C   1 
+ATOM   499  O O   . LYS A 1 75  ? -17.891 29.984 5.162   1.00 31.92 ? 75  LYS A O   1 
+ATOM   500  C CB  . LYS A 1 75  ? -17.420 27.300 3.697   1.00 35.28 ? 75  LYS A CB  1 
+ATOM   501  C CG  . LYS A 1 75  ? -17.991 26.056 3.033   1.00 37.13 ? 75  LYS A CG  1 
+ATOM   502  C CD  . LYS A 1 75  ? -17.580 24.776 3.740   1.00 38.62 ? 75  LYS A CD  1 
+ATOM   503  C CE  . LYS A 1 75  ? -18.136 23.560 3.004   1.00 39.40 ? 75  LYS A CE  1 
+ATOM   504  N NZ  . LYS A 1 75  ? -17.733 22.267 3.626   1.00 40.21 ? 75  LYS A NZ  1 
+ATOM   505  N N   . LEU A 1 76  ? -16.383 28.899 6.431   1.00 29.49 ? 76  LEU A N   1 
+ATOM   506  C CA  . LEU A 1 76  ? -15.768 30.124 6.921   1.00 27.08 ? 76  LEU A CA  1 
+ATOM   507  C C   . LEU A 1 76  ? -14.304 30.112 6.516   1.00 25.49 ? 76  LEU A C   1 
+ATOM   508  O O   . LEU A 1 76  ? -13.565 29.194 6.869   1.00 24.92 ? 76  LEU A O   1 
+ATOM   509  C CB  . LEU A 1 76  ? -15.885 30.223 8.445   1.00 27.58 ? 76  LEU A CB  1 
+ATOM   510  C CG  . LEU A 1 76  ? -15.281 31.493 9.056   1.00 27.69 ? 76  LEU A CG  1 
+ATOM   511  C CD1 . LEU A 1 76  ? -15.898 32.724 8.398   1.00 27.97 ? 76  LEU A CD1 1 
+ATOM   512  C CD2 . LEU A 1 76  ? -15.523 31.512 10.558  1.00 27.74 ? 76  LEU A CD2 1 
+ATOM   513  N N   . TYR A 1 77  ? -13.897 31.132 5.765   1.00 23.70 ? 77  TYR A N   1 
+ATOM   514  C CA  . TYR A 1 77  ? -12.521 31.251 5.297   1.00 22.07 ? 77  TYR A CA  1 
+ATOM   515  C C   . TYR A 1 77  ? -11.819 32.435 5.948   1.00 20.31 ? 77  TYR A C   1 
+ATOM   516  O O   . TYR A 1 77  ? -12.369 33.536 6.011   1.00 19.83 ? 77  TYR A O   1 
+ATOM   517  C CB  . TYR A 1 77  ? -12.493 31.452 3.781   1.00 23.12 ? 77  TYR A CB  1 
+ATOM   518  C CG  . TYR A 1 77  ? -13.082 30.314 2.979   1.00 25.70 ? 77  TYR A CG  1 
+ATOM   519  C CD1 . TYR A 1 77  ? -12.308 29.214 2.620   1.00 26.12 ? 77  TYR A CD1 1 
+ATOM   520  C CD2 . TYR A 1 77  ? -14.414 30.344 2.571   1.00 26.54 ? 77  TYR A CD2 1 
+ATOM   521  C CE1 . TYR A 1 77  ? -12.846 28.169 1.870   1.00 27.34 ? 77  TYR A CE1 1 
+ATOM   522  C CE2 . TYR A 1 77  ? -14.963 29.304 1.823   1.00 27.74 ? 77  TYR A CE2 1 
+ATOM   523  C CZ  . TYR A 1 77  ? -14.172 28.221 1.476   1.00 28.03 ? 77  TYR A CZ  1 
+ATOM   524  O OH  . TYR A 1 77  ? -14.705 27.191 0.731   1.00 30.21 ? 77  TYR A OH  1 
+ATOM   525  N N   . LEU A 1 78  ? -10.609 32.199 6.441   1.00 18.13 ? 78  LEU A N   1 
+ATOM   526  C CA  . LEU A 1 78  ? -9.805  33.255 7.042   1.00 16.69 ? 78  LEU A CA  1 
+ATOM   527  C C   . LEU A 1 78  ? -8.574  33.375 6.152   1.00 14.96 ? 78  LEU A C   1 
+ATOM   528  O O   . LEU A 1 78  ? -7.856  32.399 5.937   1.00 15.01 ? 78  LEU A O   1 
+ATOM   529  C CB  . LEU A 1 78  ? -9.396  32.892 8.471   1.00 16.69 ? 78  LEU A CB  1 
+ATOM   530  C CG  . LEU A 1 78  ? -10.533 32.618 9.464   1.00 18.76 ? 78  LEU A CG  1 
+ATOM   531  C CD1 . LEU A 1 78  ? -9.956  32.461 10.865  1.00 19.44 ? 78  LEU A CD1 1 
+ATOM   532  C CD2 . LEU A 1 78  ? -11.531 33.758 9.433   1.00 19.18 ? 78  LEU A CD2 1 
+ATOM   533  N N   . VAL A 1 79  ? -8.343  34.570 5.625   1.00 13.54 ? 79  VAL A N   1 
+ATOM   534  C CA  . VAL A 1 79  ? -7.217  34.803 4.739   1.00 12.60 ? 79  VAL A CA  1 
+ATOM   535  C C   . VAL A 1 79  ? -6.110  35.519 5.497   1.00 12.14 ? 79  VAL A C   1 
+ATOM   536  O O   . VAL A 1 79  ? -6.278  36.660 5.921   1.00 12.17 ? 79  VAL A O   1 
+ATOM   537  C CB  . VAL A 1 79  ? -7.648  35.656 3.529   1.00 12.36 ? 79  VAL A CB  1 
+ATOM   538  C CG1 . VAL A 1 79  ? -6.501  35.782 2.539   1.00 12.98 ? 79  VAL A CG1 1 
+ATOM   539  C CG2 . VAL A 1 79  ? -8.858  35.027 2.869   1.00 11.35 ? 79  VAL A CG2 1 
+ATOM   540  N N   . PHE A 1 80  ? -4.978  34.841 5.660   1.00 10.94 ? 80  PHE A N   1 
+ATOM   541  C CA  . PHE A 1 80  ? -3.844  35.400 6.385   1.00 9.63  ? 80  PHE A CA  1 
+ATOM   542  C C   . PHE A 1 80  ? -2.646  35.689 5.492   1.00 10.11 ? 80  PHE A C   1 
+ATOM   543  O O   . PHE A 1 80  ? -2.479  35.070 4.443   1.00 9.74  ? 80  PHE A O   1 
+ATOM   544  C CB  . PHE A 1 80  ? -3.397  34.419 7.476   1.00 9.21  ? 80  PHE A CB  1 
+ATOM   545  C CG  . PHE A 1 80  ? -4.390  34.240 8.585   1.00 9.12  ? 80  PHE A CG  1 
+ATOM   546  C CD1 . PHE A 1 80  ? -4.521  35.206 9.580   1.00 9.12  ? 80  PHE A CD1 1 
+ATOM   547  C CD2 . PHE A 1 80  ? -5.173  33.090 8.656   1.00 10.32 ? 80  PHE A CD2 1 
+ATOM   548  C CE1 . PHE A 1 80  ? -5.413  35.029 10.634  1.00 10.24 ? 80  PHE A CE1 1 
+ATOM   549  C CE2 . PHE A 1 80  ? -6.071  32.901 9.708   1.00 10.39 ? 80  PHE A CE2 1 
+ATOM   550  C CZ  . PHE A 1 80  ? -6.190  33.871 10.700  1.00 10.32 ? 80  PHE A CZ  1 
+ATOM   551  N N   . GLU A 1 81  ? -1.812  36.635 5.913   1.00 9.20  ? 81  GLU A N   1 
+ATOM   552  C CA  . GLU A 1 81  ? -0.602  36.935 5.164   1.00 10.07 ? 81  GLU A CA  1 
+ATOM   553  C C   . GLU A 1 81  ? 0.236   35.657 5.261   1.00 10.02 ? 81  GLU A C   1 
+ATOM   554  O O   . GLU A 1 81  ? 0.249   34.991 6.298   1.00 9.11  ? 81  GLU A O   1 
+ATOM   555  C CB  . GLU A 1 81  ? 0.159   38.103 5.804   1.00 13.15 ? 81  GLU A CB  1 
+ATOM   556  C CG  . GLU A 1 81  ? 0.745   37.771 7.159   1.00 15.59 ? 81  GLU A CG  1 
+ATOM   557  C CD  . GLU A 1 81  ? 1.653   38.857 7.708   1.00 15.63 ? 81  GLU A CD  1 
+ATOM   558  O OE1 . GLU A 1 81  ? 2.643   39.213 7.036   1.00 19.56 ? 81  GLU A OE1 1 
+ATOM   559  O OE2 . GLU A 1 81  ? 1.382   39.348 8.818   1.00 15.40 ? 81  GLU A OE2 1 
+ATOM   560  N N   . PHE A 1 82  ? 0.936   35.320 4.187   1.00 8.53  ? 82  PHE A N   1 
+ATOM   561  C CA  . PHE A 1 82  ? 1.753   34.112 4.152   1.00 8.93  ? 82  PHE A CA  1 
+ATOM   562  C C   . PHE A 1 82  ? 3.191   34.304 4.629   1.00 8.68  ? 82  PHE A C   1 
+ATOM   563  O O   . PHE A 1 82  ? 3.825   35.302 4.301   1.00 9.41  ? 82  PHE A O   1 
+ATOM   564  C CB  . PHE A 1 82  ? 1.770   33.560 2.720   1.00 8.09  ? 82  PHE A CB  1 
+ATOM   565  C CG  . PHE A 1 82  ? 2.578   32.305 2.559   1.00 8.61  ? 82  PHE A CG  1 
+ATOM   566  C CD1 . PHE A 1 82  ? 3.910   32.360 2.163   1.00 7.52  ? 82  PHE A CD1 1 
+ATOM   567  C CD2 . PHE A 1 82  ? 2.011   31.065 2.833   1.00 7.53  ? 82  PHE A CD2 1 
+ATOM   568  C CE1 . PHE A 1 82  ? 4.664   31.196 2.044   1.00 8.45  ? 82  PHE A CE1 1 
+ATOM   569  C CE2 . PHE A 1 82  ? 2.759   29.896 2.718   1.00 8.91  ? 82  PHE A CE2 1 
+ATOM   570  C CZ  . PHE A 1 82  ? 4.085   29.961 2.324   1.00 8.48  ? 82  PHE A CZ  1 
+ATOM   571  N N   . LEU A 1 83  ? 3.683   33.360 5.430   1.00 8.65  ? 83  LEU A N   1 
+ATOM   572  C CA  . LEU A 1 83  ? 5.082   33.368 5.876   1.00 8.32  ? 83  LEU A CA  1 
+ATOM   573  C C   . LEU A 1 83  ? 5.615   31.978 5.531   1.00 8.08  ? 83  LEU A C   1 
+ATOM   574  O O   . LEU A 1 83  ? 4.885   30.992 5.623   1.00 8.82  ? 83  LEU A O   1 
+ATOM   575  C CB  . LEU A 1 83  ? 5.227   33.661 7.373   1.00 8.19  ? 83  LEU A CB  1 
+ATOM   576  C CG  . LEU A 1 83  ? 5.026   35.138 7.720   1.00 10.76 ? 83  LEU A CG  1 
+ATOM   577  C CD1 . LEU A 1 83  ? 3.567   35.366 8.083   1.00 10.42 ? 83  LEU A CD1 1 
+ATOM   578  C CD2 . LEU A 1 83  ? 5.927   35.540 8.892   1.00 11.49 ? 83  LEU A CD2 1 
+ATOM   579  N N   . HIS A 1 84  ? 6.881   31.900 5.135   1.00 7.63  ? 84  HIS A N   1 
+ATOM   580  C CA  . HIS A 1 84  ? 7.461   30.634 4.687   1.00 8.67  ? 84  HIS A CA  1 
+ATOM   581  C C   . HIS A 1 84  ? 7.893   29.572 5.683   1.00 9.57  ? 84  HIS A C   1 
+ATOM   582  O O   . HIS A 1 84  ? 8.102   28.423 5.294   1.00 9.49  ? 84  HIS A O   1 
+ATOM   583  C CB  . HIS A 1 84  ? 8.647   30.911 3.756   1.00 9.04  ? 84  HIS A CB  1 
+ATOM   584  C CG  . HIS A 1 84  ? 8.263   31.552 2.460   1.00 9.38  ? 84  HIS A CG  1 
+ATOM   585  N ND1 . HIS A 1 84  ? 7.991   32.898 2.345   1.00 9.99  ? 84  HIS A ND1 1 
+ATOM   586  C CD2 . HIS A 1 84  ? 8.064   31.021 1.229   1.00 9.87  ? 84  HIS A CD2 1 
+ATOM   587  C CE1 . HIS A 1 84  ? 7.637   33.170 1.102   1.00 9.31  ? 84  HIS A CE1 1 
+ATOM   588  N NE2 . HIS A 1 84  ? 7.673   32.048 0.404   1.00 9.77  ? 84  HIS A NE2 1 
+ATOM   589  N N   . GLN A 1 85  ? 8.019   29.915 6.957   1.00 9.60  ? 85  GLN A N   1 
+ATOM   590  C CA  . GLN A 1 85  ? 8.493   28.910 7.905   1.00 9.82  ? 85  GLN A CA  1 
+ATOM   591  C C   . GLN A 1 85  ? 8.011   29.176 9.326   1.00 9.90  ? 85  GLN A C   1 
+ATOM   592  O O   . GLN A 1 85  ? 7.689   30.314 9.673   1.00 9.44  ? 85  GLN A O   1 
+ATOM   593  C CB  . GLN A 1 85  ? 10.026  28.892 7.855   1.00 9.21  ? 85  GLN A CB  1 
+ATOM   594  C CG  . GLN A 1 85  ? 10.708  27.706 8.527   1.00 9.92  ? 85  GLN A CG  1 
+ATOM   595  C CD  . GLN A 1 85  ? 12.149  27.539 8.051   1.00 10.97 ? 85  GLN A CD  1 
+ATOM   596  O OE1 . GLN A 1 85  ? 12.403  27.265 6.868   1.00 11.82 ? 85  GLN A OE1 1 
+ATOM   597  N NE2 . GLN A 1 85  ? 13.096  27.714 8.961   1.00 7.52  ? 85  GLN A NE2 1 
+ATOM   598  N N   . ASP A 1 86  ? 7.936   28.123 10.140  1.00 9.53  ? 86  ASP A N   1 
+ATOM   599  C CA  . ASP A 1 86  ? 7.525   28.299 11.528  1.00 9.58  ? 86  ASP A CA  1 
+ATOM   600  C C   . ASP A 1 86  ? 8.717   28.025 12.438  1.00 9.79  ? 86  ASP A C   1 
+ATOM   601  O O   . ASP A 1 86  ? 9.727   27.460 12.003  1.00 9.92  ? 86  ASP A O   1 
+ATOM   602  C CB  . ASP A 1 86  ? 6.314   27.415 11.896  1.00 8.73  ? 86  ASP A CB  1 
+ATOM   603  C CG  . ASP A 1 86  ? 6.584   25.925 11.757  1.00 8.86  ? 86  ASP A CG  1 
+ATOM   604  O OD1 . ASP A 1 86  ? 7.677   25.460 12.142  1.00 11.36 ? 86  ASP A OD1 1 
+ATOM   605  O OD2 . ASP A 1 86  ? 5.675   25.211 11.282  1.00 9.76  ? 86  ASP A OD2 1 
+ATOM   606  N N   . LEU A 1 87  ? 8.614   28.444 13.693  1.00 10.03 ? 87  LEU A N   1 
+ATOM   607  C CA  . LEU A 1 87  ? 9.716   28.281 14.632  1.00 10.42 ? 87  LEU A CA  1 
+ATOM   608  C C   . LEU A 1 87  ? 10.107  26.832 14.860  1.00 11.56 ? 87  LEU A C   1 
+ATOM   609  O O   . LEU A 1 87  ? 11.283  26.528 15.074  1.00 12.66 ? 87  LEU A O   1 
+ATOM   610  C CB  . LEU A 1 87  ? 9.376   28.938 15.971  1.00 9.27  ? 87  LEU A CB  1 
+ATOM   611  C CG  . LEU A 1 87  ? 10.499  28.905 17.012  1.00 9.28  ? 87  LEU A CG  1 
+ATOM   612  C CD1 . LEU A 1 87  ? 11.721  29.667 16.492  1.00 9.07  ? 87  LEU A CD1 1 
+ATOM   613  C CD2 . LEU A 1 87  ? 10.002  29.533 18.312  1.00 8.23  ? 87  LEU A CD2 1 
+ATOM   614  N N   . LYS A 1 88  ? 9.124   25.943 14.813  1.00 12.22 ? 88  LYS A N   1 
+ATOM   615  C CA  . LYS A 1 88  ? 9.381   24.525 15.014  1.00 13.37 ? 88  LYS A CA  1 
+ATOM   616  C C   . LYS A 1 88  ? 10.388  24.014 13.991  1.00 13.06 ? 88  LYS A C   1 
+ATOM   617  O O   . LYS A 1 88  ? 11.380  23.377 14.348  1.00 13.64 ? 88  LYS A O   1 
+ATOM   618  C CB  . LYS A 1 88  ? 8.077   23.737 14.906  1.00 14.66 ? 88  LYS A CB  1 
+ATOM   619  C CG  . LYS A 1 88  ? 8.218   22.270 15.245  1.00 16.94 ? 88  LYS A CG  1 
+ATOM   620  C CD  . LYS A 1 88  ? 6.854   21.622 15.377  1.00 19.24 ? 88  LYS A CD  1 
+ATOM   621  C CE  . LYS A 1 88  ? 6.977   20.180 15.833  1.00 19.93 ? 88  LYS A CE  1 
+ATOM   622  N NZ  . LYS A 1 88  ? 5.658   19.637 16.221  1.00 20.71 ? 88  LYS A NZ  1 
+ATOM   623  N N   . LYS A 1 89  ? 10.139  24.304 12.716  1.00 12.88 ? 89  LYS A N   1 
+ATOM   624  C CA  . LYS A 1 89  ? 11.033  23.866 11.648  1.00 11.86 ? 89  LYS A CA  1 
+ATOM   625  C C   . LYS A 1 89  ? 12.424  24.476 11.773  1.00 11.67 ? 89  LYS A C   1 
+ATOM   626  O O   . LYS A 1 89  ? 13.433  23.813 11.508  1.00 10.56 ? 89  LYS A O   1 
+ATOM   627  C CB  . LYS A 1 89  ? 10.439  24.222 10.279  1.00 11.19 ? 89  LYS A CB  1 
+ATOM   628  C CG  . LYS A 1 89  ? 11.325  23.837 9.097   1.00 11.30 ? 89  LYS A CG  1 
+ATOM   629  C CD  . LYS A 1 89  ? 10.591  24.023 7.765   1.00 11.34 ? 89  LYS A CD  1 
+ATOM   630  C CE  . LYS A 1 89  ? 11.469  23.627 6.583   1.00 12.23 ? 89  LYS A CE  1 
+ATOM   631  N NZ  . LYS A 1 89  ? 10.754  23.794 5.282   1.00 11.92 ? 89  LYS A NZ  1 
+ATOM   632  N N   . PHE A 1 90  ? 12.477  25.741 12.177  1.00 11.31 ? 90  PHE A N   1 
+ATOM   633  C CA  . PHE A 1 90  ? 13.743  26.442 12.327  1.00 12.24 ? 90  PHE A CA  1 
+ATOM   634  C C   . PHE A 1 90  ? 14.567  25.848 13.473  1.00 13.67 ? 90  PHE A C   1 
+ATOM   635  O O   . PHE A 1 90  ? 15.781  25.687 13.357  1.00 13.57 ? 90  PHE A O   1 
+ATOM   636  C CB  . PHE A 1 90  ? 13.481  27.931 12.573  1.00 12.33 ? 90  PHE A CB  1 
+ATOM   637  C CG  . PHE A 1 90  ? 14.727  28.758 12.685  1.00 13.34 ? 90  PHE A CG  1 
+ATOM   638  C CD1 . PHE A 1 90  ? 15.668  28.771 11.659  1.00 13.56 ? 90  PHE A CD1 1 
+ATOM   639  C CD2 . PHE A 1 90  ? 14.956  29.538 13.815  1.00 14.00 ? 90  PHE A CD2 1 
+ATOM   640  C CE1 . PHE A 1 90  ? 16.825  29.550 11.754  1.00 14.22 ? 90  PHE A CE1 1 
+ATOM   641  C CE2 . PHE A 1 90  ? 16.109  30.322 13.923  1.00 14.52 ? 90  PHE A CE2 1 
+ATOM   642  C CZ  . PHE A 1 90  ? 17.047  30.328 12.889  1.00 14.06 ? 90  PHE A CZ  1 
+ATOM   643  N N   . MET A 1 91  ? 13.910  25.528 14.581  1.00 15.69 ? 91  MET A N   1 
+ATOM   644  C CA  . MET A 1 91  ? 14.622  24.938 15.711  1.00 17.30 ? 91  MET A CA  1 
+ATOM   645  C C   . MET A 1 91  ? 15.203  23.589 15.324  1.00 17.95 ? 91  MET A C   1 
+ATOM   646  O O   . MET A 1 91  ? 16.344  23.281 15.670  1.00 18.21 ? 91  MET A O   1 
+ATOM   647  C CB  . MET A 1 91  ? 13.698  24.766 16.915  1.00 17.80 ? 91  MET A CB  1 
+ATOM   648  C CG  . MET A 1 91  ? 13.417  26.052 17.663  1.00 18.23 ? 91  MET A CG  1 
+ATOM   649  S SD  . MET A 1 91  ? 12.729  25.724 19.286  1.00 23.11 ? 91  MET A SD  1 
+ATOM   650  C CE  . MET A 1 91  ? 11.015  25.417 18.854  1.00 15.88 ? 91  MET A CE  1 
+ATOM   651  N N   . ASP A 1 92  ? 14.420  22.787 14.606  1.00 19.65 ? 92  ASP A N   1 
+ATOM   652  C CA  . ASP A 1 92  ? 14.884  21.474 14.170  1.00 21.10 ? 92  ASP A CA  1 
+ATOM   653  C C   . ASP A 1 92  ? 16.093  21.615 13.258  1.00 21.69 ? 92  ASP A C   1 
+ATOM   654  O O   . ASP A 1 92  ? 17.021  20.810 13.313  1.00 21.96 ? 92  ASP A O   1 
+ATOM   655  C CB  . ASP A 1 92  ? 13.779  20.717 13.428  1.00 22.65 ? 92  ASP A CB  1 
+ATOM   656  C CG  . ASP A 1 92  ? 12.615  20.358 14.322  1.00 24.90 ? 92  ASP A CG  1 
+ATOM   657  O OD1 . ASP A 1 92  ? 12.846  20.073 15.516  1.00 26.73 ? 92  ASP A OD1 1 
+ATOM   658  O OD2 . ASP A 1 92  ? 11.467  20.348 13.831  1.00 26.87 ? 92  ASP A OD2 1 
+ATOM   659  N N   . ALA A 1 93  ? 16.079  22.635 12.407  1.00 22.15 ? 93  ALA A N   1 
+ATOM   660  C CA  . ALA A 1 93  ? 17.191  22.869 11.496  1.00 21.97 ? 93  ALA A CA  1 
+ATOM   661  C C   . ALA A 1 93  ? 18.385  23.408 12.278  1.00 22.89 ? 93  ALA A C   1 
+ATOM   662  O O   . ALA A 1 93  ? 19.522  23.371 11.805  1.00 22.72 ? 93  ALA A O   1 
+ATOM   663  C CB  . ALA A 1 93  ? 16.783  23.858 10.415  1.00 21.98 ? 93  ALA A CB  1 
+ATOM   664  N N   . SER A 1 94  ? 18.115  23.900 13.483  1.00 23.18 ? 94  SER A N   1 
+ATOM   665  C CA  . SER A 1 94  ? 19.152  24.457 14.343  1.00 24.43 ? 94  SER A CA  1 
+ATOM   666  C C   . SER A 1 94  ? 19.426  23.562 15.550  1.00 25.35 ? 94  SER A C   1 
+ATOM   667  O O   . SER A 1 94  ? 20.159  23.949 16.452  1.00 25.20 ? 94  SER A O   1 
+ATOM   668  C CB  . SER A 1 94  ? 18.730  25.846 14.841  1.00 22.60 ? 94  SER A CB  1 
+ATOM   669  O OG  . SER A 1 94  ? 18.461  26.731 13.766  1.00 21.54 ? 94  SER A OG  1 
+ATOM   670  N N   . ALA A 1 95  ? 18.841  22.368 15.562  1.00 27.27 ? 95  ALA A N   1 
+ATOM   671  C CA  . ALA A 1 95  ? 19.012  21.440 16.678  1.00 28.88 ? 95  ALA A CA  1 
+ATOM   672  C C   . ALA A 1 95  ? 20.470  21.061 16.920  1.00 29.80 ? 95  ALA A C   1 
+ATOM   673  O O   . ALA A 1 95  ? 20.933  21.021 18.062  1.00 30.48 ? 95  ALA A O   1 
+ATOM   674  C CB  . ALA A 1 95  ? 18.182  20.183 16.438  1.00 29.17 ? 95  ALA A CB  1 
+ATOM   675  N N   . LEU A 1 96  ? 21.187  20.787 15.838  1.00 30.68 ? 96  LEU A N   1 
+ATOM   676  C CA  . LEU A 1 96  ? 22.591  20.399 15.909  1.00 30.55 ? 96  LEU A CA  1 
+ATOM   677  C C   . LEU A 1 96  ? 23.502  21.453 16.532  1.00 29.57 ? 96  LEU A C   1 
+ATOM   678  O O   . LEU A 1 96  ? 24.443  21.125 17.259  1.00 29.13 ? 96  LEU A O   1 
+ATOM   679  C CB  . LEU A 1 96  ? 23.099  20.044 14.504  1.00 31.86 ? 96  LEU A CB  1 
+ATOM   680  C CG  . LEU A 1 96  ? 22.335  20.593 13.286  1.00 32.75 ? 96  LEU A CG  1 
+ATOM   681  C CD1 . LEU A 1 96  ? 22.243  22.112 13.335  1.00 32.38 ? 96  LEU A CD1 1 
+ATOM   682  C CD2 . LEU A 1 96  ? 23.039  20.146 12.014  1.00 32.19 ? 96  LEU A CD2 1 
+ATOM   683  N N   . THR A 1 97  ? 23.214  22.719 16.259  1.00 28.40 ? 97  THR A N   1 
+ATOM   684  C CA  . THR A 1 97  ? 24.030  23.815 16.768  1.00 27.15 ? 97  THR A CA  1 
+ATOM   685  C C   . THR A 1 97  ? 23.339  24.703 17.798  1.00 25.56 ? 97  THR A C   1 
+ATOM   686  O O   . THR A 1 97  ? 23.988  25.268 18.679  1.00 25.93 ? 97  THR A O   1 
+ATOM   687  C CB  . THR A 1 97  ? 24.498  24.709 15.610  1.00 28.58 ? 97  THR A CB  1 
+ATOM   688  O OG1 . THR A 1 97  ? 25.098  25.900 16.136  1.00 30.53 ? 97  THR A OG1 1 
+ATOM   689  C CG2 . THR A 1 97  ? 23.315  25.078 14.722  1.00 28.44 ? 97  THR A CG2 1 
+ATOM   690  N N   . GLY A 1 98  ? 22.024  24.834 17.675  1.00 22.61 ? 98  GLY A N   1 
+ATOM   691  C CA  . GLY A 1 98  ? 21.276  25.669 18.592  1.00 20.03 ? 98  GLY A CA  1 
+ATOM   692  C C   . GLY A 1 98  ? 21.143  27.080 18.053  1.00 18.74 ? 98  GLY A C   1 
+ATOM   693  O O   . GLY A 1 98  ? 22.077  27.617 17.451  1.00 18.73 ? 98  GLY A O   1 
+ATOM   694  N N   . ILE A 1 99  ? 19.977  27.684 18.250  1.00 15.96 ? 99  ILE A N   1 
+ATOM   695  C CA  . ILE A 1 99  ? 19.755  29.049 17.790  1.00 14.64 ? 99  ILE A CA  1 
+ATOM   696  C C   . ILE A 1 99  ? 20.655  29.963 18.620  1.00 13.98 ? 99  ILE A C   1 
+ATOM   697  O O   . ILE A 1 99  ? 20.691  29.861 19.847  1.00 12.88 ? 99  ILE A O   1 
+ATOM   698  C CB  . ILE A 1 99  ? 18.283  29.487 17.995  1.00 14.18 ? 99  ILE A CB  1 
+ATOM   699  C CG1 . ILE A 1 99  ? 17.343  28.562 17.219  1.00 15.20 ? 99  ILE A CG1 1 
+ATOM   700  C CG2 . ILE A 1 99  ? 18.096  30.929 17.529  1.00 13.65 ? 99  ILE A CG2 1 
+ATOM   701  C CD1 . ILE A 1 99  ? 15.869  28.911 17.376  1.00 14.39 ? 99  ILE A CD1 1 
+ATOM   702  N N   . PRO A 1 100 ? 21.407  30.859 17.962  1.00 13.45 ? 100 PRO A N   1 
+ATOM   703  C CA  . PRO A 1 100 ? 22.289  31.765 18.707  1.00 13.92 ? 100 PRO A CA  1 
+ATOM   704  C C   . PRO A 1 100 ? 21.491  32.607 19.704  1.00 13.63 ? 100 PRO A C   1 
+ATOM   705  O O   . PRO A 1 100 ? 20.407  33.096 19.379  1.00 13.24 ? 100 PRO A O   1 
+ATOM   706  C CB  . PRO A 1 100 ? 22.922  32.610 17.605  1.00 13.85 ? 100 PRO A CB  1 
+ATOM   707  C CG  . PRO A 1 100 ? 22.951  31.665 16.434  1.00 14.51 ? 100 PRO A CG  1 
+ATOM   708  C CD  . PRO A 1 100 ? 21.582  31.029 16.510  1.00 13.78 ? 100 PRO A CD  1 
+ATOM   709  N N   . LEU A 1 101 ? 22.030  32.783 20.908  1.00 13.50 ? 101 LEU A N   1 
+ATOM   710  C CA  . LEU A 1 101 ? 21.343  33.557 21.944  1.00 12.97 ? 101 LEU A CA  1 
+ATOM   711  C C   . LEU A 1 101 ? 20.784  34.892 21.449  1.00 12.42 ? 101 LEU A C   1 
+ATOM   712  O O   . LEU A 1 101 ? 19.645  35.243 21.759  1.00 10.96 ? 101 LEU A O   1 
+ATOM   713  C CB  . LEU A 1 101 ? 22.277  33.811 23.133  1.00 13.42 ? 101 LEU A CB  1 
+ATOM   714  C CG  . LEU A 1 101 ? 21.703  34.615 24.308  1.00 14.65 ? 101 LEU A CG  1 
+ATOM   715  C CD1 . LEU A 1 101 ? 20.489  33.898 24.899  1.00 14.98 ? 101 LEU A CD1 1 
+ATOM   716  C CD2 . LEU A 1 101 ? 22.783  34.793 25.371  1.00 15.90 ? 101 LEU A CD2 1 
+ATOM   717  N N   . PRO A 1 102 ? 21.577  35.659 20.682  1.00 12.47 ? 102 PRO A N   1 
+ATOM   718  C CA  . PRO A 1 102 ? 21.080  36.947 20.188  1.00 11.85 ? 102 PRO A CA  1 
+ATOM   719  C C   . PRO A 1 102 ? 19.746  36.826 19.448  1.00 11.17 ? 102 PRO A C   1 
+ATOM   720  O O   . PRO A 1 102 ? 18.862  37.675 19.601  1.00 9.84  ? 102 PRO A O   1 
+ATOM   721  C CB  . PRO A 1 102 ? 22.211  37.422 19.278  1.00 13.13 ? 102 PRO A CB  1 
+ATOM   722  C CG  . PRO A 1 102 ? 23.428  36.861 19.956  1.00 12.58 ? 102 PRO A CG  1 
+ATOM   723  C CD  . PRO A 1 102 ? 22.983  35.457 20.287  1.00 13.02 ? 102 PRO A CD  1 
+ATOM   724  N N   . LEU A 1 103 ? 19.609  35.772 18.646  1.00 9.72  ? 103 LEU A N   1 
+ATOM   725  C CA  . LEU A 1 103 ? 18.381  35.549 17.886  1.00 8.97  ? 103 LEU A CA  1 
+ATOM   726  C C   . LEU A 1 103 ? 17.265  35.077 18.815  1.00 8.99  ? 103 LEU A C   1 
+ATOM   727  O O   . LEU A 1 103 ? 16.110  35.484 18.669  1.00 8.86  ? 103 LEU A O   1 
+ATOM   728  C CB  . LEU A 1 103 ? 18.618  34.517 16.779  1.00 8.87  ? 103 LEU A CB  1 
+ATOM   729  C CG  . LEU A 1 103 ? 17.461  34.335 15.792  1.00 8.90  ? 103 LEU A CG  1 
+ATOM   730  C CD1 . LEU A 1 103 ? 17.061  35.698 15.207  1.00 9.88  ? 103 LEU A CD1 1 
+ATOM   731  C CD2 . LEU A 1 103 ? 17.882  33.380 14.685  1.00 9.50  ? 103 LEU A CD2 1 
+ATOM   732  N N   . ILE A 1 104 ? 17.607  34.215 19.769  1.00 8.29  ? 104 ILE A N   1 
+ATOM   733  C CA  . ILE A 1 104 ? 16.611  33.741 20.728  1.00 8.66  ? 104 ILE A CA  1 
+ATOM   734  C C   . ILE A 1 104 ? 16.041  34.964 21.442  1.00 8.61  ? 104 ILE A C   1 
+ATOM   735  O O   . ILE A 1 104 ? 14.834  35.096 21.602  1.00 8.07  ? 104 ILE A O   1 
+ATOM   736  C CB  . ILE A 1 104 ? 17.229  32.808 21.796  1.00 8.83  ? 104 ILE A CB  1 
+ATOM   737  C CG1 . ILE A 1 104 ? 17.688  31.499 21.152  1.00 10.23 ? 104 ILE A CG1 1 
+ATOM   738  C CG2 . ILE A 1 104 ? 16.210  32.542 22.907  1.00 9.45  ? 104 ILE A CG2 1 
+ATOM   739  C CD1 . ILE A 1 104 ? 18.350  30.526 22.134  1.00 9.47  ? 104 ILE A CD1 1 
+ATOM   740  N N   . LYS A 1 105 ? 16.931  35.859 21.863  1.00 8.09  ? 105 LYS A N   1 
+ATOM   741  C CA  . LYS A 1 105 ? 16.540  37.072 22.569  1.00 7.59  ? 105 LYS A CA  1 
+ATOM   742  C C   . LYS A 1 105 ? 15.661  37.958 21.686  1.00 8.00  ? 105 LYS A C   1 
+ATOM   743  O O   . LYS A 1 105 ? 14.634  38.485 22.137  1.00 7.27  ? 105 LYS A O   1 
+ATOM   744  C CB  . LYS A 1 105 ? 17.802  37.824 23.020  1.00 9.22  ? 105 LYS A CB  1 
+ATOM   745  C CG  . LYS A 1 105 ? 17.554  39.062 23.884  1.00 9.44  ? 105 LYS A CG  1 
+ATOM   746  C CD  . LYS A 1 105 ? 18.861  39.568 24.509  1.00 11.04 ? 105 LYS A CD  1 
+ATOM   747  C CE  . LYS A 1 105 ? 19.484  38.502 25.404  1.00 11.81 ? 105 LYS A CE  1 
+ATOM   748  N NZ  . LYS A 1 105 ? 20.713  38.964 26.106  1.00 12.83 ? 105 LYS A NZ  1 
+ATOM   749  N N   . SER A 1 106 ? 16.050  38.113 20.424  1.00 7.43  ? 106 SER A N   1 
+ATOM   750  C CA  . SER A 1 106 ? 15.266  38.931 19.504  1.00 7.50  ? 106 SER A CA  1 
+ATOM   751  C C   . SER A 1 106 ? 13.854  38.376 19.328  1.00 7.01  ? 106 SER A C   1 
+ATOM   752  O O   . SER A 1 106 ? 12.877  39.120 19.364  1.00 6.79  ? 106 SER A O   1 
+ATOM   753  C CB  . SER A 1 106 ? 15.946  39.008 18.139  1.00 8.30  ? 106 SER A CB  1 
+ATOM   754  O OG  . SER A 1 106 ? 15.129  39.721 17.230  1.00 8.07  ? 106 SER A OG  1 
+ATOM   755  N N   . TYR A 1 107 ? 13.750  37.068 19.126  1.00 6.48  ? 107 TYR A N   1 
+ATOM   756  C CA  . TYR A 1 107 ? 12.443  36.442 18.950  1.00 6.74  ? 107 TYR A CA  1 
+ATOM   757  C C   . TYR A 1 107 ? 11.589  36.586 20.209  1.00 6.55  ? 107 TYR A C   1 
+ATOM   758  O O   . TYR A 1 107 ? 10.396  36.872 20.130  1.00 5.06  ? 107 TYR A O   1 
+ATOM   759  C CB  . TYR A 1 107 ? 12.599  34.956 18.608  1.00 5.79  ? 107 TYR A CB  1 
+ATOM   760  C CG  . TYR A 1 107 ? 12.999  34.670 17.172  1.00 7.98  ? 107 TYR A CG  1 
+ATOM   761  C CD1 . TYR A 1 107 ? 12.879  35.647 16.177  1.00 8.39  ? 107 TYR A CD1 1 
+ATOM   762  C CD2 . TYR A 1 107 ? 13.453  33.405 16.801  1.00 7.38  ? 107 TYR A CD2 1 
+ATOM   763  C CE1 . TYR A 1 107 ? 13.202  35.364 14.846  1.00 8.10  ? 107 TYR A CE1 1 
+ATOM   764  C CE2 . TYR A 1 107 ? 13.776  33.111 15.474  1.00 7.47  ? 107 TYR A CE2 1 
+ATOM   765  C CZ  . TYR A 1 107 ? 13.648  34.090 14.506  1.00 8.13  ? 107 TYR A CZ  1 
+ATOM   766  O OH  . TYR A 1 107 ? 13.949  33.783 13.199  1.00 6.24  ? 107 TYR A OH  1 
+ATOM   767  N N   . LEU A 1 108 ? 12.199  36.373 21.373  1.00 6.06  ? 108 LEU A N   1 
+ATOM   768  C CA  . LEU A 1 108 ? 11.465  36.488 22.629  1.00 6.64  ? 108 LEU A CA  1 
+ATOM   769  C C   . LEU A 1 108 ? 10.940  37.911 22.814  1.00 6.82  ? 108 LEU A C   1 
+ATOM   770  O O   . LEU A 1 108 ? 9.785   38.116 23.191  1.00 4.88  ? 108 LEU A O   1 
+ATOM   771  C CB  . LEU A 1 108 ? 12.368  36.106 23.812  1.00 6.27  ? 108 LEU A CB  1 
+ATOM   772  C CG  . LEU A 1 108 ? 11.700  36.079 25.194  1.00 6.90  ? 108 LEU A CG  1 
+ATOM   773  C CD1 . LEU A 1 108 ? 10.579  35.044 25.202  1.00 5.82  ? 108 LEU A CD1 1 
+ATOM   774  C CD2 . LEU A 1 108 ? 12.729  35.750 26.264  1.00 5.42  ? 108 LEU A CD2 1 
+ATOM   775  N N   . PHE A 1 109 ? 11.801  38.889 22.549  1.00 7.06  ? 109 PHE A N   1 
+ATOM   776  C CA  . PHE A 1 109 ? 11.441  40.297 22.684  1.00 7.72  ? 109 PHE A CA  1 
+ATOM   777  C C   . PHE A 1 109 ? 10.272  40.653 21.761  1.00 7.64  ? 109 PHE A C   1 
+ATOM   778  O O   . PHE A 1 109 ? 9.296   41.269 22.194  1.00 6.20  ? 109 PHE A O   1 
+ATOM   779  C CB  . PHE A 1 109 ? 12.655  41.178 22.354  1.00 8.36  ? 109 PHE A CB  1 
+ATOM   780  C CG  . PHE A 1 109 ? 12.468  42.637 22.703  1.00 9.69  ? 109 PHE A CG  1 
+ATOM   781  C CD1 . PHE A 1 109 ? 12.536  43.066 24.028  1.00 9.63  ? 109 PHE A CD1 1 
+ATOM   782  C CD2 . PHE A 1 109 ? 12.212  43.577 21.708  1.00 10.26 ? 109 PHE A CD2 1 
+ATOM   783  C CE1 . PHE A 1 109 ? 12.351  44.412 24.355  1.00 11.07 ? 109 PHE A CE1 1 
+ATOM   784  C CE2 . PHE A 1 109 ? 12.024  44.925 22.025  1.00 10.22 ? 109 PHE A CE2 1 
+ATOM   785  C CZ  . PHE A 1 109 ? 12.094  45.342 23.350  1.00 11.07 ? 109 PHE A CZ  1 
+ATOM   786  N N   . GLN A 1 110 ? 10.370  40.261 20.492  1.00 7.03  ? 110 GLN A N   1 
+ATOM   787  C CA  . GLN A 1 110 ? 9.309   40.556 19.523  1.00 6.81  ? 110 GLN A CA  1 
+ATOM   788  C C   . GLN A 1 110 ? 7.961   39.959 19.932  1.00 7.03  ? 110 GLN A C   1 
+ATOM   789  O O   . GLN A 1 110 ? 6.916   40.613 19.825  1.00 5.71  ? 110 GLN A O   1 
+ATOM   790  C CB  . GLN A 1 110 ? 9.693   40.030 18.135  1.00 7.47  ? 110 GLN A CB  1 
+ATOM   791  C CG  . GLN A 1 110 ? 10.879  40.739 17.490  1.00 6.67  ? 110 GLN A CG  1 
+ATOM   792  C CD  . GLN A 1 110 ? 11.182  40.210 16.100  1.00 6.57  ? 110 GLN A CD  1 
+ATOM   793  O OE1 . GLN A 1 110 ? 10.358  40.319 15.186  1.00 5.57  ? 110 GLN A OE1 1 
+ATOM   794  N NE2 . GLN A 1 110 ? 12.362  39.629 15.933  1.00 5.22  ? 110 GLN A NE2 1 
+ATOM   795  N N   . LEU A 1 111 ? 7.982   38.715 20.401  1.00 6.12  ? 111 LEU A N   1 
+ATOM   796  C CA  . LEU A 1 111 ? 6.748   38.063 20.807  1.00 6.74  ? 111 LEU A CA  1 
+ATOM   797  C C   . LEU A 1 111 ? 6.185   38.724 22.059  1.00 6.64  ? 111 LEU A C   1 
+ATOM   798  O O   . LEU A 1 111 ? 4.965   38.844 22.214  1.00 7.37  ? 111 LEU A O   1 
+ATOM   799  C CB  . LEU A 1 111 ? 6.987   36.562 21.012  1.00 7.73  ? 111 LEU A CB  1 
+ATOM   800  C CG  . LEU A 1 111 ? 7.390   35.879 19.694  1.00 9.14  ? 111 LEU A CG  1 
+ATOM   801  C CD1 . LEU A 1 111 ? 7.746   34.418 19.931  1.00 8.34  ? 111 LEU A CD1 1 
+ATOM   802  C CD2 . LEU A 1 111 ? 6.244   35.999 18.693  1.00 8.77  ? 111 LEU A CD2 1 
+ATOM   803  N N   . LEU A 1 112 ? 7.065   39.172 22.949  1.00 6.03  ? 112 LEU A N   1 
+ATOM   804  C CA  . LEU A 1 112 ? 6.601   39.857 24.149  1.00 6.13  ? 112 LEU A CA  1 
+ATOM   805  C C   . LEU A 1 112 ? 5.940   41.171 23.735  1.00 6.48  ? 112 LEU A C   1 
+ATOM   806  O O   . LEU A 1 112 ? 4.983   41.620 24.366  1.00 6.63  ? 112 LEU A O   1 
+ATOM   807  C CB  . LEU A 1 112 ? 7.766   40.117 25.107  1.00 5.78  ? 112 LEU A CB  1 
+ATOM   808  C CG  . LEU A 1 112 ? 8.171   38.868 25.908  1.00 5.73  ? 112 LEU A CG  1 
+ATOM   809  C CD1 . LEU A 1 112 ? 9.467   39.126 26.670  1.00 5.08  ? 112 LEU A CD1 1 
+ATOM   810  C CD2 . LEU A 1 112 ? 7.036   38.496 26.872  1.00 5.62  ? 112 LEU A CD2 1 
+ATOM   811  N N   . GLN A 1 113 ? 6.457   41.793 22.679  1.00 6.87  ? 113 GLN A N   1 
+ATOM   812  C CA  . GLN A 1 113 ? 5.870   43.035 22.186  1.00 7.19  ? 113 GLN A CA  1 
+ATOM   813  C C   . GLN A 1 113 ? 4.489   42.723 21.619  1.00 7.23  ? 113 GLN A C   1 
+ATOM   814  O O   . GLN A 1 113 ? 3.523   43.443 21.882  1.00 6.57  ? 113 GLN A O   1 
+ATOM   815  C CB  . GLN A 1 113 ? 6.744   43.648 21.092  1.00 8.50  ? 113 GLN A CB  1 
+ATOM   816  C CG  . GLN A 1 113 ? 8.044   44.242 21.597  1.00 11.29 ? 113 GLN A CG  1 
+ATOM   817  C CD  . GLN A 1 113 ? 8.831   44.901 20.487  1.00 13.60 ? 113 GLN A CD  1 
+ATOM   818  O OE1 . GLN A 1 113 ? 9.267   44.236 19.546  1.00 14.59 ? 113 GLN A OE1 1 
+ATOM   819  N NE2 . GLN A 1 113 ? 9.008   46.219 20.583  1.00 13.74 ? 113 GLN A NE2 1 
+ATOM   820  N N   . GLY A 1 114 ? 4.403   41.643 20.844  1.00 6.92  ? 114 GLY A N   1 
+ATOM   821  C CA  . GLY A 1 114 ? 3.130   41.243 20.267  1.00 5.77  ? 114 GLY A CA  1 
+ATOM   822  C C   . GLY A 1 114 ? 2.092   40.954 21.341  1.00 6.81  ? 114 GLY A C   1 
+ATOM   823  O O   . GLY A 1 114 ? 0.923   41.351 21.226  1.00 4.97  ? 114 GLY A O   1 
+ATOM   824  N N   . LEU A 1 115 ? 2.513   40.257 22.392  1.00 6.03  ? 115 LEU A N   1 
+ATOM   825  C CA  . LEU A 1 115 ? 1.609   39.935 23.490  1.00 7.10  ? 115 LEU A CA  1 
+ATOM   826  C C   . LEU A 1 115 ? 1.247   41.176 24.303  1.00 6.74  ? 115 LEU A C   1 
+ATOM   827  O O   . LEU A 1 115 ? 0.098   41.339 24.713  1.00 7.55  ? 115 LEU A O   1 
+ATOM   828  C CB  . LEU A 1 115 ? 2.232   38.884 24.411  1.00 6.54  ? 115 LEU A CB  1 
+ATOM   829  C CG  . LEU A 1 115 ? 2.397   37.493 23.788  1.00 7.10  ? 115 LEU A CG  1 
+ATOM   830  C CD1 . LEU A 1 115 ? 3.067   36.559 24.790  1.00 6.70  ? 115 LEU A CD1 1 
+ATOM   831  C CD2 . LEU A 1 115 ? 1.028   36.956 23.371  1.00 7.06  ? 115 LEU A CD2 1 
+ATOM   832  N N   . ALA A 1 116 ? 2.223   42.048 24.547  1.00 7.17  ? 116 ALA A N   1 
+ATOM   833  C CA  . ALA A 1 116 ? 1.945   43.260 25.310  1.00 7.80  ? 116 ALA A CA  1 
+ATOM   834  C C   . ALA A 1 116 ? 0.822   43.994 24.583  1.00 8.52  ? 116 ALA A C   1 
+ATOM   835  O O   . ALA A 1 116 ? -0.091  44.535 25.206  1.00 7.46  ? 116 ALA A O   1 
+ATOM   836  C CB  . ALA A 1 116 ? 3.197   44.144 25.395  1.00 8.01  ? 116 ALA A CB  1 
+ATOM   837  N N   . PHE A 1 117 ? 0.888   43.975 23.256  1.00 9.12  ? 117 PHE A N   1 
+ATOM   838  C CA  . PHE A 1 117 ? -0.116  44.623 22.415  1.00 9.28  ? 117 PHE A CA  1 
+ATOM   839  C C   . PHE A 1 117 ? -1.499  43.971 22.508  1.00 9.50  ? 117 PHE A C   1 
+ATOM   840  O O   . PHE A 1 117 ? -2.476  44.624 22.881  1.00 9.59  ? 117 PHE A O   1 
+ATOM   841  C CB  . PHE A 1 117 ? 0.347   44.618 20.955  1.00 9.46  ? 117 PHE A CB  1 
+ATOM   842  C CG  . PHE A 1 117 ? -0.666  45.181 19.995  1.00 10.16 ? 117 PHE A CG  1 
+ATOM   843  C CD1 . PHE A 1 117 ? -0.855  46.555 19.885  1.00 11.68 ? 117 PHE A CD1 1 
+ATOM   844  C CD2 . PHE A 1 117 ? -1.424  44.333 19.193  1.00 10.89 ? 117 PHE A CD2 1 
+ATOM   845  C CE1 . PHE A 1 117 ? -1.783  47.079 18.988  1.00 11.24 ? 117 PHE A CE1 1 
+ATOM   846  C CE2 . PHE A 1 117 ? -2.356  44.846 18.293  1.00 12.84 ? 117 PHE A CE2 1 
+ATOM   847  C CZ  . PHE A 1 117 ? -2.535  46.223 18.190  1.00 12.75 ? 117 PHE A CZ  1 
+ATOM   848  N N   . CYS A 1 118 ? -1.598  42.686 22.177  1.00 10.83 ? 118 CYS A N   1 
+ATOM   849  C CA  . CYS A 1 118 ? -2.907  42.040 22.220  1.00 10.77 ? 118 CYS A CA  1 
+ATOM   850  C C   . CYS A 1 118 ? -3.496  41.997 23.627  1.00 10.40 ? 118 CYS A C   1 
+ATOM   851  O O   . CYS A 1 118 ? -4.701  42.163 23.800  1.00 10.26 ? 118 CYS A O   1 
+ATOM   852  C CB  . CYS A 1 118 ? -2.854  40.634 21.583  1.00 12.33 ? 118 CYS A CB  1 
+ATOM   853  S SG  . CYS A 1 118 ? -1.876  39.378 22.397  1.00 13.77 ? 118 CYS A SG  1 
+ATOM   854  N N   . HIS A 1 119 ? -2.654  41.800 24.637  1.00 9.81  ? 119 HIS A N   1 
+ATOM   855  C CA  . HIS A 1 119 ? -3.144  41.767 26.009  1.00 11.14 ? 119 HIS A CA  1 
+ATOM   856  C C   . HIS A 1 119 ? -3.674  43.134 26.443  1.00 11.94 ? 119 HIS A C   1 
+ATOM   857  O O   . HIS A 1 119 ? -4.612  43.209 27.239  1.00 12.30 ? 119 HIS A O   1 
+ATOM   858  C CB  . HIS A 1 119 ? -2.037  41.311 26.962  1.00 9.82  ? 119 HIS A CB  1 
+ATOM   859  C CG  . HIS A 1 119 ? -1.666  39.870 26.804  1.00 9.53  ? 119 HIS A CG  1 
+ATOM   860  N ND1 . HIS A 1 119 ? -0.579  39.306 27.439  1.00 9.69  ? 119 HIS A ND1 1 
+ATOM   861  C CD2 . HIS A 1 119 ? -2.244  38.873 26.091  1.00 8.75  ? 119 HIS A CD2 1 
+ATOM   862  C CE1 . HIS A 1 119 ? -0.504  38.024 27.125  1.00 9.12  ? 119 HIS A CE1 1 
+ATOM   863  N NE2 . HIS A 1 119 ? -1.503  37.735 26.309  1.00 8.95  ? 119 HIS A NE2 1 
+ATOM   864  N N   . SER A 1 120 ? -3.084  44.211 25.926  1.00 11.52 ? 120 SER A N   1 
+ATOM   865  C CA  . SER A 1 120 ? -3.549  45.549 26.287  1.00 12.77 ? 120 SER A CA  1 
+ATOM   866  C C   . SER A 1 120 ? -4.953  45.769 25.726  1.00 13.55 ? 120 SER A C   1 
+ATOM   867  O O   . SER A 1 120 ? -5.710  46.602 26.230  1.00 14.02 ? 120 SER A O   1 
+ATOM   868  C CB  . SER A 1 120 ? -2.592  46.634 25.762  1.00 11.85 ? 120 SER A CB  1 
+ATOM   869  O OG  . SER A 1 120 ? -2.664  46.779 24.351  1.00 12.95 ? 120 SER A OG  1 
+ATOM   870  N N   . HIS A 1 121 ? -5.299  45.012 24.688  1.00 14.41 ? 121 HIS A N   1 
+ATOM   871  C CA  . HIS A 1 121 ? -6.617  45.116 24.068  1.00 14.77 ? 121 HIS A CA  1 
+ATOM   872  C C   . HIS A 1 121 ? -7.534  43.985 24.506  1.00 15.06 ? 121 HIS A C   1 
+ATOM   873  O O   . HIS A 1 121 ? -8.539  43.686 23.852  1.00 13.76 ? 121 HIS A O   1 
+ATOM   874  C CB  . HIS A 1 121 ? -6.490  45.152 22.543  1.00 16.09 ? 121 HIS A CB  1 
+ATOM   875  C CG  . HIS A 1 121 ? -5.811  46.385 22.038  1.00 18.04 ? 121 HIS A CG  1 
+ATOM   876  N ND1 . HIS A 1 121 ? -4.624  46.351 21.338  1.00 19.61 ? 121 HIS A ND1 1 
+ATOM   877  C CD2 . HIS A 1 121 ? -6.124  47.694 22.184  1.00 18.75 ? 121 HIS A CD2 1 
+ATOM   878  C CE1 . HIS A 1 121 ? -4.235  47.587 21.077  1.00 19.30 ? 121 HIS A CE1 1 
+ATOM   879  N NE2 . HIS A 1 121 ? -5.127  48.420 21.580  1.00 19.73 ? 121 HIS A NE2 1 
+ATOM   880  N N   . ARG A 1 122 ? -7.166  43.358 25.620  1.00 15.01 ? 122 ARG A N   1 
+ATOM   881  C CA  . ARG A 1 122 ? -7.947  42.281 26.215  1.00 16.47 ? 122 ARG A CA  1 
+ATOM   882  C C   . ARG A 1 122 ? -8.125  41.057 25.322  1.00 15.69 ? 122 ARG A C   1 
+ATOM   883  O O   . ARG A 1 122 ? -9.146  40.370 25.390  1.00 16.01 ? 122 ARG A O   1 
+ATOM   884  C CB  . ARG A 1 122 ? -9.316  42.830 26.632  1.00 19.59 ? 122 ARG A CB  1 
+ATOM   885  C CG  . ARG A 1 122 ? -9.216  44.125 27.423  1.00 23.71 ? 122 ARG A CG  1 
+ATOM   886  C CD  . ARG A 1 122 ? -10.575 44.790 27.592  1.00 28.02 ? 122 ARG A CD  1 
+ATOM   887  N NE  . ARG A 1 122 ? -11.472 44.000 28.430  1.00 31.21 ? 122 ARG A NE  1 
+ATOM   888  C CZ  . ARG A 1 122 ? -12.717 44.354 28.732  1.00 33.13 ? 122 ARG A CZ  1 
+ATOM   889  N NH1 . ARG A 1 122 ? -13.221 45.490 28.263  1.00 33.76 ? 122 ARG A NH1 1 
+ATOM   890  N NH2 . ARG A 1 122 ? -13.459 43.573 29.508  1.00 34.13 ? 122 ARG A NH2 1 
+ATOM   891  N N   . VAL A 1 123 ? -7.127  40.781 24.493  1.00 13.26 ? 123 VAL A N   1 
+ATOM   892  C CA  . VAL A 1 123 ? -7.184  39.630 23.605  1.00 12.24 ? 123 VAL A CA  1 
+ATOM   893  C C   . VAL A 1 123 ? -6.118  38.635 24.033  1.00 11.37 ? 123 VAL A C   1 
+ATOM   894  O O   . VAL A 1 123 ? -4.948  38.997 24.150  1.00 10.58 ? 123 VAL A O   1 
+ATOM   895  C CB  . VAL A 1 123 ? -6.915  40.035 22.136  1.00 12.36 ? 123 VAL A CB  1 
+ATOM   896  C CG1 . VAL A 1 123 ? -6.801  38.788 21.254  1.00 11.74 ? 123 VAL A CG1 1 
+ATOM   897  C CG2 . VAL A 1 123 ? -8.028  40.945 21.643  1.00 13.08 ? 123 VAL A CG2 1 
+ATOM   898  N N   . LEU A 1 124 ? -6.528  37.395 24.290  1.00 10.49 ? 124 LEU A N   1 
+ATOM   899  C CA  . LEU A 1 124 ? -5.583  36.351 24.680  1.00 10.11 ? 124 LEU A CA  1 
+ATOM   900  C C   . LEU A 1 124 ? -5.348  35.473 23.458  1.00 10.15 ? 124 LEU A C   1 
+ATOM   901  O O   . LEU A 1 124 ? -6.218  35.357 22.597  1.00 8.98  ? 124 LEU A O   1 
+ATOM   902  C CB  . LEU A 1 124 ? -6.142  35.462 25.797  1.00 11.20 ? 124 LEU A CB  1 
+ATOM   903  C CG  . LEU A 1 124 ? -7.081  35.936 26.908  1.00 13.77 ? 124 LEU A CG  1 
+ATOM   904  C CD1 . LEU A 1 124 ? -6.992  34.914 28.042  1.00 13.80 ? 124 LEU A CD1 1 
+ATOM   905  C CD2 . LEU A 1 124 ? -6.722  37.317 27.412  1.00 14.06 ? 124 LEU A CD2 1 
+ATOM   906  N N   . HIS A 1 125 ? -4.178  34.854 23.369  1.00 8.60  ? 125 HIS A N   1 
+ATOM   907  C CA  . HIS A 1 125 ? -3.913  33.972 22.242  1.00 9.10  ? 125 HIS A CA  1 
+ATOM   908  C C   . HIS A 1 125 ? -4.479  32.601 22.603  1.00 8.86  ? 125 HIS A C   1 
+ATOM   909  O O   . HIS A 1 125 ? -5.260  32.017 21.842  1.00 9.13  ? 125 HIS A O   1 
+ATOM   910  C CB  . HIS A 1 125 ? -2.410  33.880 21.962  1.00 7.82  ? 125 HIS A CB  1 
+ATOM   911  C CG  . HIS A 1 125 ? -2.083  33.068 20.751  1.00 7.74  ? 125 HIS A CG  1 
+ATOM   912  N ND1 . HIS A 1 125 ? -2.192  31.695 20.726  1.00 6.94  ? 125 HIS A ND1 1 
+ATOM   913  C CD2 . HIS A 1 125 ? -1.730  33.441 19.498  1.00 7.73  ? 125 HIS A CD2 1 
+ATOM   914  C CE1 . HIS A 1 125 ? -1.923  31.257 19.510  1.00 8.14  ? 125 HIS A CE1 1 
+ATOM   915  N NE2 . HIS A 1 125 ? -1.641  32.297 18.745  1.00 7.76  ? 125 HIS A NE2 1 
+ATOM   916  N N   . ARG A 1 126 ? -4.081  32.105 23.774  1.00 9.10  ? 126 ARG A N   1 
+ATOM   917  C CA  . ARG A 1 126 ? -4.541  30.828 24.323  1.00 9.51  ? 126 ARG A CA  1 
+ATOM   918  C C   . ARG A 1 126 ? -3.815  29.559 23.876  1.00 9.35  ? 126 ARG A C   1 
+ATOM   919  O O   . ARG A 1 126 ? -3.906  28.534 24.548  1.00 9.36  ? 126 ARG A O   1 
+ATOM   920  C CB  . ARG A 1 126 ? -6.045  30.644 24.063  1.00 11.68 ? 126 ARG A CB  1 
+ATOM   921  C CG  . ARG A 1 126 ? -6.931  31.788 24.559  1.00 13.85 ? 126 ARG A CG  1 
+ATOM   922  C CD  . ARG A 1 126 ? -8.359  31.631 24.034  1.00 16.65 ? 126 ARG A CD  1 
+ATOM   923  N NE  . ARG A 1 126 ? -9.169  32.832 24.246  1.00 19.44 ? 126 ARG A NE  1 
+ATOM   924  C CZ  . ARG A 1 126 ? -9.647  33.210 25.425  1.00 20.67 ? 126 ARG A CZ  1 
+ATOM   925  N NH1 . ARG A 1 126 ? -9.404  32.480 26.504  1.00 22.23 ? 126 ARG A NH1 1 
+ATOM   926  N NH2 . ARG A 1 126 ? -10.362 34.325 25.529  1.00 20.78 ? 126 ARG A NH2 1 
+ATOM   927  N N   . ASP A 1 127 ? -3.095  29.602 22.763  1.00 8.75  ? 127 ASP A N   1 
+ATOM   928  C CA  . ASP A 1 127 ? -2.432  28.383 22.315  1.00 9.12  ? 127 ASP A CA  1 
+ATOM   929  C C   . ASP A 1 127 ? -1.074  28.608 21.669  1.00 8.64  ? 127 ASP A C   1 
+ATOM   930  O O   . ASP A 1 127 ? -0.806  28.114 20.570  1.00 8.44  ? 127 ASP A O   1 
+ATOM   931  C CB  . ASP A 1 127 ? -3.366  27.620 21.363  1.00 9.63  ? 127 ASP A CB  1 
+ATOM   932  C CG  . ASP A 1 127 ? -2.922  26.183 21.123  1.00 11.31 ? 127 ASP A CG  1 
+ATOM   933  O OD1 . ASP A 1 127 ? -2.302  25.586 22.029  1.00 10.17 ? 127 ASP A OD1 1 
+ATOM   934  O OD2 . ASP A 1 127 ? -3.214  25.641 20.031  1.00 11.35 ? 127 ASP A OD2 1 
+ATOM   935  N N   . LEU A 1 128 ? -0.216  29.364 22.346  1.00 8.91  ? 128 LEU A N   1 
+ATOM   936  C CA  . LEU A 1 128 ? 1.114   29.604 21.816  1.00 8.73  ? 128 LEU A CA  1 
+ATOM   937  C C   . LEU A 1 128 ? 1.921   28.312 21.832  1.00 7.72  ? 128 LEU A C   1 
+ATOM   938  O O   . LEU A 1 128 ? 1.863   27.540 22.791  1.00 7.29  ? 128 LEU A O   1 
+ATOM   939  C CB  . LEU A 1 128 ? 1.858   30.662 22.637  1.00 10.89 ? 128 LEU A CB  1 
+ATOM   940  C CG  . LEU A 1 128 ? 1.395   32.110 22.494  1.00 11.84 ? 128 LEU A CG  1 
+ATOM   941  C CD1 . LEU A 1 128 ? 2.384   33.024 23.205  1.00 14.45 ? 128 LEU A CD1 1 
+ATOM   942  C CD2 . LEU A 1 128 ? 1.308   32.474 21.021  1.00 14.00 ? 128 LEU A CD2 1 
+ATOM   943  N N   . LYS A 1 129 ? 2.653   28.086 20.750  1.00 6.26  ? 129 LYS A N   1 
+ATOM   944  C CA  . LYS A 1 129 ? 3.522   26.927 20.589  1.00 6.67  ? 129 LYS A CA  1 
+ATOM   945  C C   . LYS A 1 129 ? 4.383   27.221 19.364  1.00 6.57  ? 129 LYS A C   1 
+ATOM   946  O O   . LYS A 1 129 ? 4.024   28.056 18.533  1.00 6.34  ? 129 LYS A O   1 
+ATOM   947  C CB  . LYS A 1 129 ? 2.710   25.635 20.402  1.00 6.98  ? 129 LYS A CB  1 
+ATOM   948  C CG  . LYS A 1 129 ? 1.588   25.711 19.384  1.00 9.42  ? 129 LYS A CG  1 
+ATOM   949  C CD  . LYS A 1 129 ? 0.795   24.404 19.373  1.00 9.12  ? 129 LYS A CD  1 
+ATOM   950  C CE  . LYS A 1 129 ? -0.436  24.509 18.485  1.00 9.74  ? 129 LYS A CE  1 
+ATOM   951  N NZ  . LYS A 1 129 ? -1.192  23.227 18.474  1.00 8.81  ? 129 LYS A NZ  1 
+ATOM   952  N N   . PRO A 1 130 ? 5.533   26.547 19.238  1.00 6.21  ? 130 PRO A N   1 
+ATOM   953  C CA  . PRO A 1 130 ? 6.446   26.752 18.108  1.00 5.76  ? 130 PRO A CA  1 
+ATOM   954  C C   . PRO A 1 130 ? 5.806   26.819 16.724  1.00 6.23  ? 130 PRO A C   1 
+ATOM   955  O O   . PRO A 1 130 ? 6.158   27.674 15.908  1.00 5.51  ? 130 PRO A O   1 
+ATOM   956  C CB  . PRO A 1 130 ? 7.412   25.579 18.240  1.00 5.47  ? 130 PRO A CB  1 
+ATOM   957  C CG  . PRO A 1 130 ? 7.511   25.435 19.740  1.00 6.09  ? 130 PRO A CG  1 
+ATOM   958  C CD  . PRO A 1 130 ? 6.059   25.515 20.151  1.00 5.94  ? 130 PRO A CD  1 
+ATOM   959  N N   . GLN A 1 131 ? 4.869   25.916 16.456  1.00 6.33  ? 131 GLN A N   1 
+ATOM   960  C CA  . GLN A 1 131 ? 4.224   25.891 15.149  1.00 7.76  ? 131 GLN A CA  1 
+ATOM   961  C C   . GLN A 1 131 ? 3.290   27.077 14.927  1.00 7.46  ? 131 GLN A C   1 
+ATOM   962  O O   . GLN A 1 131 ? 2.880   27.331 13.797  1.00 7.35  ? 131 GLN A O   1 
+ATOM   963  C CB  . GLN A 1 131 ? 3.458   24.583 14.960  1.00 9.67  ? 131 GLN A CB  1 
+ATOM   964  C CG  . GLN A 1 131 ? 2.210   24.476 15.803  1.00 13.46 ? 131 GLN A CG  1 
+ATOM   965  C CD  . GLN A 1 131 ? 1.718   23.045 15.914  1.00 16.54 ? 131 GLN A CD  1 
+ATOM   966  O OE1 . GLN A 1 131 ? 2.365   22.205 16.543  1.00 17.18 ? 131 GLN A OE1 1 
+ATOM   967  N NE2 . GLN A 1 131 ? 0.575   22.758 15.293  1.00 16.71 ? 131 GLN A NE2 1 
+ATOM   968  N N   . ASN A 1 132 ? 2.945   27.792 15.994  1.00 8.11  ? 132 ASN A N   1 
+ATOM   969  C CA  . ASN A 1 132 ? 2.086   28.968 15.853  1.00 7.52  ? 132 ASN A CA  1 
+ATOM   970  C C   . ASN A 1 132 ? 2.902   30.260 15.843  1.00 7.12  ? 132 ASN A C   1 
+ATOM   971  O O   . ASN A 1 132 ? 2.362   31.356 16.024  1.00 6.67  ? 132 ASN A O   1 
+ATOM   972  C CB  . ASN A 1 132 ? 1.028   29.017 16.961  1.00 7.72  ? 132 ASN A CB  1 
+ATOM   973  C CG  . ASN A 1 132 ? -0.132  28.081 16.691  1.00 9.88  ? 132 ASN A CG  1 
+ATOM   974  O OD1 . ASN A 1 132 ? -0.338  27.652 15.555  1.00 10.05 ? 132 ASN A OD1 1 
+ATOM   975  N ND2 . ASN A 1 132 ? -0.907  27.771 17.727  1.00 9.41  ? 132 ASN A ND2 1 
+ATOM   976  N N   . LEU A 1 133 ? 4.208   30.118 15.638  1.00 6.84  ? 133 LEU A N   1 
+ATOM   977  C CA  . LEU A 1 133 ? 5.118   31.254 15.568  1.00 5.83  ? 133 LEU A CA  1 
+ATOM   978  C C   . LEU A 1 133 ? 5.779   31.200 14.188  1.00 6.81  ? 133 LEU A C   1 
+ATOM   979  O O   . LEU A 1 133 ? 6.566   30.295 13.889  1.00 6.67  ? 133 LEU A O   1 
+ATOM   980  C CB  . LEU A 1 133 ? 6.163   31.173 16.689  1.00 5.60  ? 133 LEU A CB  1 
+ATOM   981  C CG  . LEU A 1 133 ? 5.578   31.150 18.109  1.00 4.79  ? 133 LEU A CG  1 
+ATOM   982  C CD1 . LEU A 1 133 ? 6.696   31.043 19.148  1.00 6.68  ? 133 LEU A CD1 1 
+ATOM   983  C CD2 . LEU A 1 133 ? 4.754   32.410 18.348  1.00 3.51  ? 133 LEU A CD2 1 
+ATOM   984  N N   . LEU A 1 134 ? 5.447   32.174 13.347  1.00 6.30  ? 134 LEU A N   1 
+ATOM   985  C CA  . LEU A 1 134 ? 5.961   32.215 11.987  1.00 7.02  ? 134 LEU A CA  1 
+ATOM   986  C C   . LEU A 1 134 ? 7.093   33.203 11.822  1.00 6.31  ? 134 LEU A C   1 
+ATOM   987  O O   . LEU A 1 134 ? 7.079   34.282 12.409  1.00 6.66  ? 134 LEU A O   1 
+ATOM   988  C CB  . LEU A 1 134 ? 4.821   32.543 11.024  1.00 7.11  ? 134 LEU A CB  1 
+ATOM   989  C CG  . LEU A 1 134 ? 3.641   31.576 11.182  1.00 7.95  ? 134 LEU A CG  1 
+ATOM   990  C CD1 . LEU A 1 134 ? 2.569   31.929 10.176  1.00 7.99  ? 134 LEU A CD1 1 
+ATOM   991  C CD2 . LEU A 1 134 ? 4.108   30.142 10.987  1.00 6.50  ? 134 LEU A CD2 1 
+ATOM   992  N N   . ILE A 1 135 ? 8.074   32.828 11.010  1.00 6.98  ? 135 ILE A N   1 
+ATOM   993  C CA  . ILE A 1 135 ? 9.243   33.673 10.805  1.00 6.49  ? 135 ILE A CA  1 
+ATOM   994  C C   . ILE A 1 135 ? 9.539   33.960 9.338   1.00 8.05  ? 135 ILE A C   1 
+ATOM   995  O O   . ILE A 1 135 ? 9.113   33.223 8.452   1.00 8.79  ? 135 ILE A O   1 
+ATOM   996  C CB  . ILE A 1 135 ? 10.490  33.014 11.425  1.00 6.15  ? 135 ILE A CB  1 
+ATOM   997  C CG1 . ILE A 1 135 ? 10.741  31.649 10.764  1.00 6.75  ? 135 ILE A CG1 1 
+ATOM   998  C CG2 . ILE A 1 135 ? 10.293  32.856 12.930  1.00 6.06  ? 135 ILE A CG2 1 
+ATOM   999  C CD1 . ILE A 1 135 ? 12.040  30.961 11.204  1.00 6.63  ? 135 ILE A CD1 1 
+ATOM   1000 N N   . ASN A 1 136 ? 10.255  35.051 9.087   1.00 8.59  ? 136 ASN A N   1 
+ATOM   1001 C CA  . ASN A 1 136 ? 10.626  35.391 7.724   1.00 9.45  ? 136 ASN A CA  1 
+ATOM   1002 C C   . ASN A 1 136 ? 12.119  35.679 7.642   1.00 11.22 ? 136 ASN A C   1 
+ATOM   1003 O O   . ASN A 1 136 ? 12.833  35.630 8.645   1.00 11.38 ? 136 ASN A O   1 
+ATOM   1004 C CB  . ASN A 1 136 ? 9.809   36.578 7.182   1.00 8.41  ? 136 ASN A CB  1 
+ATOM   1005 C CG  . ASN A 1 136 ? 10.012  37.868 7.972   1.00 7.13  ? 136 ASN A CG  1 
+ATOM   1006 O OD1 . ASN A 1 136 ? 11.038  38.074 8.615   1.00 6.95  ? 136 ASN A OD1 1 
+ATOM   1007 N ND2 . ASN A 1 136 ? 9.024   38.752 7.903   1.00 8.20  ? 136 ASN A ND2 1 
+ATOM   1008 N N   . THR A 1 137 ? 12.584  35.968 6.434   1.00 12.17 ? 137 THR A N   1 
+ATOM   1009 C CA  . THR A 1 137 ? 13.991  36.242 6.184   1.00 13.23 ? 137 THR A CA  1 
+ATOM   1010 C C   . THR A 1 137 ? 14.446  37.588 6.732   1.00 14.44 ? 137 THR A C   1 
+ATOM   1011 O O   . THR A 1 137 ? 15.643  37.882 6.761   1.00 14.99 ? 137 THR A O   1 
+ATOM   1012 C CB  . THR A 1 137 ? 14.264  36.213 4.677   1.00 12.74 ? 137 THR A CB  1 
+ATOM   1013 O OG1 . THR A 1 137 ? 13.334  37.082 4.016   1.00 13.97 ? 137 THR A OG1 1 
+ATOM   1014 C CG2 . THR A 1 137 ? 14.097  34.804 4.136   1.00 13.34 ? 137 THR A CG2 1 
+ATOM   1015 N N   . GLU A 1 138 ? 13.486  38.402 7.156   1.00 15.16 ? 138 GLU A N   1 
+ATOM   1016 C CA  . GLU A 1 138 ? 13.769  39.726 7.689   1.00 15.35 ? 138 GLU A CA  1 
+ATOM   1017 C C   . GLU A 1 138 ? 14.057  39.706 9.187   1.00 15.00 ? 138 GLU A C   1 
+ATOM   1018 O O   . GLU A 1 138 ? 14.257  40.756 9.799   1.00 14.66 ? 138 GLU A O   1 
+ATOM   1019 C CB  . GLU A 1 138 ? 12.588  40.661 7.416   1.00 16.86 ? 138 GLU A CB  1 
+ATOM   1020 C CG  . GLU A 1 138 ? 12.378  41.029 5.954   1.00 20.31 ? 138 GLU A CG  1 
+ATOM   1021 C CD  . GLU A 1 138 ? 13.510  41.862 5.394   1.00 22.70 ? 138 GLU A CD  1 
+ATOM   1022 O OE1 . GLU A 1 138 ? 14.450  41.282 4.811   1.00 23.96 ? 138 GLU A OE1 1 
+ATOM   1023 O OE2 . GLU A 1 138 ? 13.464  43.102 5.553   1.00 24.49 ? 138 GLU A OE2 1 
+ATOM   1024 N N   . GLY A 1 139 ? 14.070  38.514 9.775   1.00 12.70 ? 139 GLY A N   1 
+ATOM   1025 C CA  . GLY A 1 139 ? 14.339  38.401 11.195  1.00 11.12 ? 139 GLY A CA  1 
+ATOM   1026 C C   . GLY A 1 139 ? 13.122  38.636 12.070  1.00 10.51 ? 139 GLY A C   1 
+ATOM   1027 O O   . GLY A 1 139 ? 13.247  38.745 13.288  1.00 10.94 ? 139 GLY A O   1 
+ATOM   1028 N N   . ALA A 1 140 ? 11.945  38.717 11.459  1.00 8.17  ? 140 ALA A N   1 
+ATOM   1029 C CA  . ALA A 1 140 ? 10.723  38.933 12.228  1.00 9.45  ? 140 ALA A CA  1 
+ATOM   1030 C C   . ALA A 1 140 ? 10.096  37.599 12.623  1.00 8.45  ? 140 ALA A C   1 
+ATOM   1031 O O   . ALA A 1 140 ? 10.304  36.584 11.960  1.00 8.33  ? 140 ALA A O   1 
+ATOM   1032 C CB  . ALA A 1 140 ? 9.719   39.754 11.409  1.00 8.15  ? 140 ALA A CB  1 
+ATOM   1033 N N   . ILE A 1 141 ? 9.355   37.605 13.725  1.00 8.16  ? 141 ILE A N   1 
+ATOM   1034 C CA  . ILE A 1 141 ? 8.645   36.417 14.180  1.00 6.92  ? 141 ILE A CA  1 
+ATOM   1035 C C   . ILE A 1 141 ? 7.247   36.923 14.535  1.00 7.08  ? 141 ILE A C   1 
+ATOM   1036 O O   . ILE A 1 141 ? 7.098   37.998 15.129  1.00 6.90  ? 141 ILE A O   1 
+ATOM   1037 C CB  . ILE A 1 141 ? 9.341   35.744 15.392  1.00 6.99  ? 141 ILE A CB  1 
+ATOM   1038 C CG1 . ILE A 1 141 ? 8.645   34.417 15.707  1.00 6.59  ? 141 ILE A CG1 1 
+ATOM   1039 C CG2 . ILE A 1 141 ? 9.336   36.672 16.607  1.00 7.16  ? 141 ILE A CG2 1 
+ATOM   1040 C CD1 . ILE A 1 141 ? 9.510   33.431 16.510  1.00 6.59  ? 141 ILE A CD1 1 
+ATOM   1041 N N   . LYS A 1 142 ? 6.224   36.163 14.157  1.00 7.33  ? 142 LYS A N   1 
+ATOM   1042 C CA  . LYS A 1 142 ? 4.846   36.592 14.385  1.00 6.99  ? 142 LYS A CA  1 
+ATOM   1043 C C   . LYS A 1 142 ? 3.923   35.549 15.002  1.00 7.43  ? 142 LYS A C   1 
+ATOM   1044 O O   . LYS A 1 142 ? 4.033   34.352 14.726  1.00 7.77  ? 142 LYS A O   1 
+ATOM   1045 C CB  . LYS A 1 142 ? 4.241   37.071 13.053  1.00 7.88  ? 142 LYS A CB  1 
+ATOM   1046 C CG  . LYS A 1 142 ? 5.129   38.055 12.293  1.00 8.16  ? 142 LYS A CG  1 
+ATOM   1047 C CD  . LYS A 1 142 ? 4.384   38.727 11.134  1.00 10.12 ? 142 LYS A CD  1 
+ATOM   1048 C CE  . LYS A 1 142 ? 5.294   39.688 10.374  1.00 10.58 ? 142 LYS A CE  1 
+ATOM   1049 N NZ  . LYS A 1 142 ? 4.533   40.542 9.417   1.00 10.72 ? 142 LYS A NZ  1 
+ATOM   1050 N N   . LEU A 1 143 ? 2.997   36.031 15.827  1.00 7.23  ? 143 LEU A N   1 
+ATOM   1051 C CA  . LEU A 1 143 ? 2.005   35.194 16.493  1.00 7.54  ? 143 LEU A CA  1 
+ATOM   1052 C C   . LEU A 1 143 ? 0.930   34.825 15.477  1.00 8.12  ? 143 LEU A C   1 
+ATOM   1053 O O   . LEU A 1 143 ? 0.373   35.698 14.805  1.00 6.99  ? 143 LEU A O   1 
+ATOM   1054 C CB  . LEU A 1 143 ? 1.362   35.967 17.650  1.00 7.54  ? 143 LEU A CB  1 
+ATOM   1055 C CG  . LEU A 1 143 ? 2.321   36.438 18.747  1.00 8.86  ? 143 LEU A CG  1 
+ATOM   1056 C CD1 . LEU A 1 143 ? 1.682   37.569 19.564  1.00 9.17  ? 143 LEU A CD1 1 
+ATOM   1057 C CD2 . LEU A 1 143 ? 2.686   35.260 19.641  1.00 7.91  ? 143 LEU A CD2 1 
+ATOM   1058 N N   . ALA A 1 144 ? 0.634   33.534 15.377  1.00 7.84  ? 144 ALA A N   1 
+ATOM   1059 C CA  . ALA A 1 144 ? -0.362  33.053 14.430  1.00 9.02  ? 144 ALA A CA  1 
+ATOM   1060 C C   . ALA A 1 144 ? -1.400  32.149 15.078  1.00 9.77  ? 144 ALA A C   1 
+ATOM   1061 O O   . ALA A 1 144 ? -1.184  31.607 16.164  1.00 9.62  ? 144 ALA A O   1 
+ATOM   1062 C CB  . ALA A 1 144 ? 0.321   32.311 13.298  1.00 9.31  ? 144 ALA A CB  1 
+ATOM   1063 N N   . ASP A 1 145 ? -2.521  31.992 14.379  1.00 9.94  ? 145 ASP A N   1 
+ATOM   1064 C CA  . ASP A 1 145 ? -3.639  31.163 14.816  1.00 11.62 ? 145 ASP A CA  1 
+ATOM   1065 C C   . ASP A 1 145 ? -4.178  31.502 16.201  1.00 12.23 ? 145 ASP A C   1 
+ATOM   1066 O O   . ASP A 1 145 ? -4.253  30.639 17.077  1.00 11.90 ? 145 ASP A O   1 
+ATOM   1067 C CB  . ASP A 1 145 ? -3.271  29.673 14.759  1.00 13.63 ? 145 ASP A CB  1 
+ATOM   1068 C CG  . ASP A 1 145 ? -4.505  28.770 14.679  1.00 14.92 ? 145 ASP A CG  1 
+ATOM   1069 O OD1 . ASP A 1 145 ? -5.474  29.155 14.001  1.00 13.74 ? 145 ASP A OD1 1 
+ATOM   1070 O OD2 . ASP A 1 145 ? -4.506  27.672 15.273  1.00 18.18 ? 145 ASP A OD2 1 
+ATOM   1071 N N   . PHE A 1 146 ? -4.552  32.761 16.397  1.00 12.40 ? 146 PHE A N   1 
+ATOM   1072 C CA  . PHE A 1 146 ? -5.121  33.174 17.672  1.00 13.84 ? 146 PHE A CA  1 
+ATOM   1073 C C   . PHE A 1 146 ? -6.356  32.316 17.918  1.00 15.66 ? 146 PHE A C   1 
+ATOM   1074 O O   . PHE A 1 146 ? -7.142  32.079 16.998  1.00 15.51 ? 146 PHE A O   1 
+ATOM   1075 C CB  . PHE A 1 146 ? -5.519  34.653 17.639  1.00 11.93 ? 146 PHE A CB  1 
+ATOM   1076 C CG  . PHE A 1 146 ? -4.411  35.585 18.030  1.00 9.64  ? 146 PHE A CG  1 
+ATOM   1077 C CD1 . PHE A 1 146 ? -3.340  35.812 17.180  1.00 8.90  ? 146 PHE A CD1 1 
+ATOM   1078 C CD2 . PHE A 1 146 ? -4.429  36.217 19.273  1.00 9.72  ? 146 PHE A CD2 1 
+ATOM   1079 C CE1 . PHE A 1 146 ? -2.292  36.659 17.561  1.00 6.82  ? 146 PHE A CE1 1 
+ATOM   1080 C CE2 . PHE A 1 146 ? -3.392  37.062 19.665  1.00 7.48  ? 146 PHE A CE2 1 
+ATOM   1081 C CZ  . PHE A 1 146 ? -2.320  37.283 18.805  1.00 8.14  ? 146 PHE A CZ  1 
+ATOM   1082 N N   . GLY A 1 147 ? -6.517  31.846 19.150  1.00 17.99 ? 147 GLY A N   1 
+ATOM   1083 C CA  . GLY A 1 147 ? -7.658  31.009 19.473  1.00 20.95 ? 147 GLY A CA  1 
+ATOM   1084 C C   . GLY A 1 147 ? -8.787  31.732 20.184  1.00 23.30 ? 147 GLY A C   1 
+ATOM   1085 O O   . GLY A 1 147 ? -8.560  32.709 20.900  1.00 23.45 ? 147 GLY A O   1 
+ATOM   1086 N N   . LEU A 1 148 ? -10.007 31.239 19.988  1.00 25.32 ? 148 LEU A N   1 
+ATOM   1087 C CA  . LEU A 1 148 ? -11.194 31.826 20.603  1.00 26.61 ? 148 LEU A CA  1 
+ATOM   1088 C C   . LEU A 1 148 ? -11.482 31.234 21.978  1.00 27.83 ? 148 LEU A C   1 
+ATOM   1089 O O   . LEU A 1 148 ? -10.930 30.196 22.349  1.00 28.08 ? 148 LEU A O   1 
+ATOM   1090 C CB  . LEU A 1 148 ? -12.415 31.612 19.705  1.00 27.38 ? 148 LEU A CB  1 
+ATOM   1091 C CG  . LEU A 1 148 ? -12.368 32.197 18.293  1.00 28.08 ? 148 LEU A CG  1 
+ATOM   1092 C CD1 . LEU A 1 148 ? -13.720 31.992 17.617  1.00 27.91 ? 148 LEU A CD1 1 
+ATOM   1093 C CD2 . LEU A 1 148 ? -12.028 33.681 18.353  1.00 28.40 ? 148 LEU A CD2 1 
+ATOM   1094 N N   . ALA A 1 149 ? -12.359 31.899 22.725  1.00 28.60 ? 149 ALA A N   1 
+ATOM   1095 C CA  . ALA A 1 149 ? -12.734 31.442 24.056  1.00 29.57 ? 149 ALA A CA  1 
+ATOM   1096 C C   . ALA A 1 149 ? -13.668 30.239 23.960  1.00 29.88 ? 149 ALA A C   1 
+ATOM   1097 O O   . ALA A 1 149 ? -13.312 29.130 24.352  1.00 30.44 ? 149 ALA A O   1 
+ATOM   1098 C CB  . ALA A 1 149 ? -13.410 32.573 24.824  1.00 29.65 ? 149 ALA A CB  1 
+ATOM   1099 N N   . PHE A 1 152 ? -15.485 26.182 17.404  1.00 33.20 ? 152 PHE A N   1 
+ATOM   1100 C CA  . PHE A 1 152 ? -16.698 26.014 16.606  1.00 32.98 ? 152 PHE A CA  1 
+ATOM   1101 C C   . PHE A 1 152 ? -16.380 25.370 15.255  1.00 32.75 ? 152 PHE A C   1 
+ATOM   1102 O O   . PHE A 1 152 ? -15.249 25.441 14.773  1.00 33.07 ? 152 PHE A O   1 
+ATOM   1103 C CB  . PHE A 1 152 ? -17.380 27.375 16.398  1.00 33.66 ? 152 PHE A CB  1 
+ATOM   1104 C CG  . PHE A 1 152 ? -16.641 28.301 15.462  1.00 33.88 ? 152 PHE A CG  1 
+ATOM   1105 C CD1 . PHE A 1 152 ? -16.807 28.200 14.083  1.00 34.44 ? 152 PHE A CD1 1 
+ATOM   1106 C CD2 . PHE A 1 152 ? -15.771 29.267 15.960  1.00 34.02 ? 152 PHE A CD2 1 
+ATOM   1107 C CE1 . PHE A 1 152 ? -16.119 29.047 13.214  1.00 34.17 ? 152 PHE A CE1 1 
+ATOM   1108 C CE2 . PHE A 1 152 ? -15.079 30.117 15.098  1.00 34.06 ? 152 PHE A CE2 1 
+ATOM   1109 C CZ  . PHE A 1 152 ? -15.254 30.005 13.722  1.00 34.02 ? 152 PHE A CZ  1 
+ATOM   1110 N N   . GLY A 1 153 ? -17.379 24.739 14.647  1.00 31.69 ? 153 GLY A N   1 
+ATOM   1111 C CA  . GLY A 1 153 ? -17.163 24.112 13.358  1.00 30.91 ? 153 GLY A CA  1 
+ATOM   1112 C C   . GLY A 1 153 ? -17.113 22.601 13.426  1.00 30.28 ? 153 GLY A C   1 
+ATOM   1113 O O   . GLY A 1 153 ? -17.125 22.012 14.511  1.00 29.80 ? 153 GLY A O   1 
+ATOM   1114 N N   . VAL A 1 154 ? -17.056 21.973 12.256  1.00 29.31 ? 154 VAL A N   1 
+ATOM   1115 C CA  . VAL A 1 154 ? -17.004 20.520 12.165  1.00 28.79 ? 154 VAL A CA  1 
+ATOM   1116 C C   . VAL A 1 154 ? -15.571 20.009 12.273  1.00 27.66 ? 154 VAL A C   1 
+ATOM   1117 O O   . VAL A 1 154 ? -14.708 20.378 11.471  1.00 27.25 ? 154 VAL A O   1 
+ATOM   1118 C CB  . VAL A 1 154 ? -17.596 20.031 10.829  1.00 29.42 ? 154 VAL A CB  1 
+ATOM   1119 C CG1 . VAL A 1 154 ? -17.542 18.507 10.764  1.00 30.17 ? 154 VAL A CG1 1 
+ATOM   1120 C CG2 . VAL A 1 154 ? -19.026 20.520 10.683  1.00 30.16 ? 154 VAL A CG2 1 
+ATOM   1121 N N   . PRO A 1 155 ? -15.298 19.152 13.270  1.00 26.57 ? 155 PRO A N   1 
+ATOM   1122 C CA  . PRO A 1 155 ? -13.955 18.600 13.461  1.00 25.29 ? 155 PRO A CA  1 
+ATOM   1123 C C   . PRO A 1 155 ? -13.454 17.912 12.194  1.00 23.89 ? 155 PRO A C   1 
+ATOM   1124 O O   . PRO A 1 155 ? -14.203 17.197 11.526  1.00 23.70 ? 155 PRO A O   1 
+ATOM   1125 C CB  . PRO A 1 155 ? -14.148 17.610 14.608  1.00 26.12 ? 155 PRO A CB  1 
+ATOM   1126 C CG  . PRO A 1 155 ? -15.241 18.240 15.407  1.00 26.89 ? 155 PRO A CG  1 
+ATOM   1127 C CD  . PRO A 1 155 ? -16.207 18.692 14.335  1.00 26.63 ? 155 PRO A CD  1 
+ATOM   1128 N N   . VAL A 1 156 ? -12.191 18.139 11.859  1.00 22.45 ? 156 VAL A N   1 
+ATOM   1129 C CA  . VAL A 1 156 ? -11.602 17.519 10.681  1.00 21.30 ? 156 VAL A CA  1 
+ATOM   1130 C C   . VAL A 1 156 ? -11.328 16.054 11.033  1.00 20.54 ? 156 VAL A C   1 
+ATOM   1131 O O   . VAL A 1 156 ? -10.475 15.767 11.873  1.00 19.63 ? 156 VAL A O   1 
+ATOM   1132 C CB  . VAL A 1 156 ? -10.279 18.220 10.300  1.00 20.71 ? 156 VAL A CB  1 
+ATOM   1133 C CG1 . VAL A 1 156 ? -9.731  17.631 9.016   1.00 20.33 ? 156 VAL A CG1 1 
+ATOM   1134 C CG2 . VAL A 1 156 ? -10.508 19.717 10.142  1.00 22.28 ? 156 VAL A CG2 1 
+ATOM   1135 N N   . ARG A 1 157 ? -12.052 15.136 10.394  1.00 20.82 ? 157 ARG A N   1 
+ATOM   1136 C CA  . ARG A 1 157 ? -11.894 13.707 10.663  1.00 21.16 ? 157 ARG A CA  1 
+ATOM   1137 C C   . ARG A 1 157 ? -10.497 13.146 10.431  1.00 20.16 ? 157 ARG A C   1 
+ATOM   1138 O O   . ARG A 1 157 ? -10.085 12.205 11.109  1.00 20.64 ? 157 ARG A O   1 
+ATOM   1139 C CB  . ARG A 1 157 ? -12.877 12.872 9.826   1.00 23.39 ? 157 ARG A CB  1 
+ATOM   1140 C CG  . ARG A 1 157 ? -14.332 12.950 10.253  1.00 26.25 ? 157 ARG A CG  1 
+ATOM   1141 C CD  . ARG A 1 157 ? -14.974 11.563 10.238  1.00 27.91 ? 157 ARG A CD  1 
+ATOM   1142 N NE  . ARG A 1 157 ? -14.766 10.850 8.977   1.00 29.64 ? 157 ARG A NE  1 
+ATOM   1143 C CZ  . ARG A 1 157 ? -15.372 11.146 7.829   1.00 31.46 ? 157 ARG A CZ  1 
+ATOM   1144 N NH1 . ARG A 1 157 ? -16.238 12.151 7.765   1.00 31.45 ? 157 ARG A NH1 1 
+ATOM   1145 N NH2 . ARG A 1 157 ? -15.115 10.431 6.742   1.00 31.91 ? 157 ARG A NH2 1 
+ATOM   1146 N N   . THR A 1 158 ? -9.771  13.712 9.474   1.00 19.12 ? 158 THR A N   1 
+ATOM   1147 C CA  . THR A 1 158 ? -8.433  13.221 9.148   1.00 18.62 ? 158 THR A CA  1 
+ATOM   1148 C C   . THR A 1 158 ? -7.290  13.832 9.953   1.00 17.88 ? 158 THR A C   1 
+ATOM   1149 O O   . THR A 1 158 ? -6.132  13.449 9.769   1.00 18.52 ? 158 THR A O   1 
+ATOM   1150 C CB  . THR A 1 158 ? -8.119  13.424 7.650   1.00 18.39 ? 158 THR A CB  1 
+ATOM   1151 O OG1 . THR A 1 158 ? -8.254  14.811 7.321   1.00 17.12 ? 158 THR A OG1 1 
+ATOM   1152 C CG2 . THR A 1 158 ? -9.074  12.604 6.784   1.00 18.82 ? 158 THR A CG2 1 
+ATOM   1153 N N   . TYR A 1 159 ? -7.601  14.772 10.841  1.00 17.26 ? 159 TYR A N   1 
+ATOM   1154 C CA  . TYR A 1 159 ? -6.566  15.414 11.652  1.00 16.86 ? 159 TYR A CA  1 
+ATOM   1155 C C   . TYR A 1 159 ? -5.734  14.404 12.442  1.00 16.73 ? 159 TYR A C   1 
+ATOM   1156 O O   . TYR A 1 159 ? -6.272  13.572 13.174  1.00 16.59 ? 159 TYR A O   1 
+ATOM   1157 C CB  . TYR A 1 159 ? -7.196  16.422 12.616  1.00 17.37 ? 159 TYR A CB  1 
+ATOM   1158 C CG  . TYR A 1 159 ? -6.237  16.955 13.655  1.00 17.73 ? 159 TYR A CG  1 
+ATOM   1159 C CD1 . TYR A 1 159 ? -6.255  16.466 14.962  1.00 18.56 ? 159 TYR A CD1 1 
+ATOM   1160 C CD2 . TYR A 1 159 ? -5.304  17.942 13.333  1.00 17.55 ? 159 TYR A CD2 1 
+ATOM   1161 C CE1 . TYR A 1 159 ? -5.372  16.946 15.922  1.00 18.15 ? 159 TYR A CE1 1 
+ATOM   1162 C CE2 . TYR A 1 159 ? -4.414  18.429 14.286  1.00 19.06 ? 159 TYR A CE2 1 
+ATOM   1163 C CZ  . TYR A 1 159 ? -4.455  17.926 15.579  1.00 19.23 ? 159 TYR A CZ  1 
+ATOM   1164 O OH  . TYR A 1 159 ? -3.581  18.399 16.527  1.00 19.92 ? 159 TYR A OH  1 
+ATOM   1165 N N   . THR A 1 160 ? -4.417  14.492 12.291  1.00 16.11 ? 160 THR A N   1 
+ATOM   1166 C CA  . THR A 1 160 ? -3.504  13.585 12.982  1.00 16.73 ? 160 THR A CA  1 
+ATOM   1167 C C   . THR A 1 160 ? -3.040  14.187 14.313  1.00 16.26 ? 160 THR A C   1 
+ATOM   1168 O O   . THR A 1 160 ? -2.634  15.349 14.376  1.00 15.69 ? 160 THR A O   1 
+ATOM   1169 C CB  . THR A 1 160 ? -2.271  13.272 12.102  1.00 17.88 ? 160 THR A CB  1 
+ATOM   1170 O OG1 . THR A 1 160 ? -2.703  12.690 10.864  1.00 19.28 ? 160 THR A OG1 1 
+ATOM   1171 C CG2 . THR A 1 160 ? -1.336  12.291 12.808  1.00 18.41 ? 160 THR A CG2 1 
+ATOM   1172 N N   . HIS A 1 161 ? -3.123  13.388 15.374  1.00 15.36 ? 161 HIS A N   1 
+ATOM   1173 C CA  . HIS A 1 161 ? -2.710  13.816 16.707  1.00 15.53 ? 161 HIS A CA  1 
+ATOM   1174 C C   . HIS A 1 161 ? -1.290  14.377 16.695  1.00 14.33 ? 161 HIS A C   1 
+ATOM   1175 O O   . HIS A 1 161 ? -0.406  13.842 16.028  1.00 13.65 ? 161 HIS A O   1 
+ATOM   1176 C CB  . HIS A 1 161 ? -2.774  12.635 17.681  1.00 15.46 ? 161 HIS A CB  1 
+ATOM   1177 C CG  . HIS A 1 161 ? -2.320  12.968 19.068  1.00 15.95 ? 161 HIS A CG  1 
+ATOM   1178 N ND1 . HIS A 1 161 ? -3.055  13.763 19.923  1.00 15.92 ? 161 HIS A ND1 1 
+ATOM   1179 C CD2 . HIS A 1 161 ? -1.196  12.629 19.743  1.00 15.95 ? 161 HIS A CD2 1 
+ATOM   1180 C CE1 . HIS A 1 161 ? -2.402  13.900 21.064  1.00 16.69 ? 161 HIS A CE1 1 
+ATOM   1181 N NE2 . HIS A 1 161 ? -1.271  13.222 20.980  1.00 16.46 ? 161 HIS A NE2 1 
+ATOM   1182 N N   . GLU A 1 162 ? -1.082  15.456 17.442  1.00 14.53 ? 162 GLU A N   1 
+ATOM   1183 C CA  . GLU A 1 162 ? 0.226   16.094 17.534  1.00 14.83 ? 162 GLU A CA  1 
+ATOM   1184 C C   . GLU A 1 162 ? 0.758   15.956 18.960  1.00 14.19 ? 162 GLU A C   1 
+ATOM   1185 O O   . GLU A 1 162 ? 0.095   16.347 19.923  1.00 13.46 ? 162 GLU A O   1 
+ATOM   1186 C CB  . GLU A 1 162 ? 0.115   17.569 17.122  1.00 16.04 ? 162 GLU A CB  1 
+ATOM   1187 C CG  . GLU A 1 162 ? -0.092  17.755 15.612  1.00 18.44 ? 162 GLU A CG  1 
+ATOM   1188 C CD  . GLU A 1 162 ? -0.479  19.175 15.216  1.00 20.61 ? 162 GLU A CD  1 
+ATOM   1189 O OE1 . GLU A 1 162 ? -0.467  19.484 14.003  1.00 22.33 ? 162 GLU A OE1 1 
+ATOM   1190 O OE2 . GLU A 1 162 ? -0.810  19.981 16.107  1.00 22.88 ? 162 GLU A OE2 1 
+ATOM   1191 N N   . VAL A 1 163 ? 1.955   15.393 19.099  1.00 13.66 ? 163 VAL A N   1 
+ATOM   1192 C CA  . VAL A 1 163 ? 2.531   15.187 20.426  1.00 13.81 ? 163 VAL A CA  1 
+ATOM   1193 C C   . VAL A 1 163 ? 2.760   16.446 21.262  1.00 12.90 ? 163 VAL A C   1 
+ATOM   1194 O O   . VAL A 1 163 ? 2.691   16.393 22.491  1.00 13.36 ? 163 VAL A O   1 
+ATOM   1195 C CB  . VAL A 1 163 ? 3.866   14.402 20.353  1.00 14.12 ? 163 VAL A CB  1 
+ATOM   1196 C CG1 . VAL A 1 163 ? 3.633   13.039 19.714  1.00 13.94 ? 163 VAL A CG1 1 
+ATOM   1197 C CG2 . VAL A 1 163 ? 4.905   15.196 19.575  1.00 14.62 ? 163 VAL A CG2 1 
+ATOM   1198 N N   . VAL A 1 164 ? 3.014   17.575 20.606  1.00 13.26 ? 164 VAL A N   1 
+ATOM   1199 C CA  . VAL A 1 164 ? 3.280   18.829 21.317  1.00 13.39 ? 164 VAL A CA  1 
+ATOM   1200 C C   . VAL A 1 164 ? 2.042   19.573 21.824  1.00 13.23 ? 164 VAL A C   1 
+ATOM   1201 O O   . VAL A 1 164 ? 2.171   20.586 22.504  1.00 12.96 ? 164 VAL A O   1 
+ATOM   1202 C CB  . VAL A 1 164 ? 4.074   19.823 20.420  1.00 13.42 ? 164 VAL A CB  1 
+ATOM   1203 C CG1 . VAL A 1 164 ? 5.266   19.117 19.773  1.00 13.51 ? 164 VAL A CG1 1 
+ATOM   1204 C CG2 . VAL A 1 164 ? 3.158   20.407 19.355  1.00 12.12 ? 164 VAL A CG2 1 
+ATOM   1205 N N   . THR A 1 165 ? 0.855   19.062 21.505  1.00 12.78 ? 165 THR A N   1 
+ATOM   1206 C CA  . THR A 1 165 ? -0.411  19.702 21.874  1.00 12.70 ? 165 THR A CA  1 
+ATOM   1207 C C   . THR A 1 165 ? -0.586  20.331 23.264  1.00 11.98 ? 165 THR A C   1 
+ATOM   1208 O O   . THR A 1 165 ? -1.125  21.434 23.375  1.00 10.61 ? 165 THR A O   1 
+ATOM   1209 C CB  . THR A 1 165 ? -1.595  18.730 21.634  1.00 13.51 ? 165 THR A CB  1 
+ATOM   1210 O OG1 . THR A 1 165 ? -1.638  18.373 20.246  1.00 14.38 ? 165 THR A OG1 1 
+ATOM   1211 C CG2 . THR A 1 165 ? -2.914  19.379 22.012  1.00 13.31 ? 165 THR A CG2 1 
+ATOM   1212 N N   . LEU A 1 166 ? -0.134  19.653 24.316  1.00 10.88 ? 166 LEU A N   1 
+ATOM   1213 C CA  . LEU A 1 166 ? -0.311  20.165 25.678  1.00 10.56 ? 166 LEU A CA  1 
+ATOM   1214 C C   . LEU A 1 166 ? 0.949   20.713 26.350  1.00 9.89  ? 166 LEU A C   1 
+ATOM   1215 O O   . LEU A 1 166 ? 0.878   21.258 27.457  1.00 9.55  ? 166 LEU A O   1 
+ATOM   1216 C CB  . LEU A 1 166 ? -0.865  19.050 26.566  1.00 11.39 ? 166 LEU A CB  1 
+ATOM   1217 C CG  . LEU A 1 166 ? -2.133  18.324 26.117  1.00 12.50 ? 166 LEU A CG  1 
+ATOM   1218 C CD1 . LEU A 1 166 ? -2.328  17.092 26.986  1.00 14.17 ? 166 LEU A CD1 1 
+ATOM   1219 C CD2 . LEU A 1 166 ? -3.335  19.260 26.206  1.00 12.42 ? 166 LEU A CD2 1 
+ATOM   1220 N N   . TRP A 1 167 ? 2.086   20.573 25.679  1.00 9.13  ? 167 TRP A N   1 
+ATOM   1221 C CA  . TRP A 1 167 ? 3.378   20.979 26.225  1.00 9.06  ? 167 TRP A CA  1 
+ATOM   1222 C C   . TRP A 1 167 ? 3.535   22.418 26.705  1.00 8.63  ? 167 TRP A C   1 
+ATOM   1223 O O   . TRP A 1 167 ? 4.383   22.695 27.560  1.00 7.78  ? 167 TRP A O   1 
+ATOM   1224 C CB  . TRP A 1 167 ? 4.478   20.681 25.203  1.00 9.78  ? 167 TRP A CB  1 
+ATOM   1225 C CG  . TRP A 1 167 ? 4.627   19.218 24.852  1.00 11.15 ? 167 TRP A CG  1 
+ATOM   1226 C CD1 . TRP A 1 167 ? 3.872   18.173 25.313  1.00 12.00 ? 167 TRP A CD1 1 
+ATOM   1227 C CD2 . TRP A 1 167 ? 5.606   18.649 23.975  1.00 11.46 ? 167 TRP A CD2 1 
+ATOM   1228 N NE1 . TRP A 1 167 ? 4.325   16.987 24.776  1.00 12.66 ? 167 TRP A NE1 1 
+ATOM   1229 C CE2 . TRP A 1 167 ? 5.388   17.253 23.951  1.00 13.36 ? 167 TRP A CE2 1 
+ATOM   1230 C CE3 . TRP A 1 167 ? 6.648   19.186 23.205  1.00 12.60 ? 167 TRP A CE3 1 
+ATOM   1231 C CZ2 . TRP A 1 167 ? 6.177   16.384 23.186  1.00 13.10 ? 167 TRP A CZ2 1 
+ATOM   1232 C CZ3 . TRP A 1 167 ? 7.434   18.320 22.444  1.00 13.52 ? 167 TRP A CZ3 1 
+ATOM   1233 C CH2 . TRP A 1 167 ? 7.192   16.935 22.443  1.00 13.19 ? 167 TRP A CH2 1 
+ATOM   1234 N N   . TYR A 1 168 ? 2.718   23.317 26.168  1.00 7.87  ? 168 TYR A N   1 
+ATOM   1235 C CA  . TYR A 1 168 ? 2.794   24.738 26.502  1.00 7.95  ? 168 TYR A CA  1 
+ATOM   1236 C C   . TYR A 1 168 ? 1.608   25.261 27.313  1.00 8.24  ? 168 TYR A C   1 
+ATOM   1237 O O   . TYR A 1 168 ? 1.480   26.467 27.524  1.00 7.20  ? 168 TYR A O   1 
+ATOM   1238 C CB  . TYR A 1 168 ? 2.929   25.523 25.192  1.00 7.07  ? 168 TYR A CB  1 
+ATOM   1239 C CG  . TYR A 1 168 ? 3.987   24.913 24.301  1.00 6.20  ? 168 TYR A CG  1 
+ATOM   1240 C CD1 . TYR A 1 168 ? 5.335   25.228 24.473  1.00 6.32  ? 168 TYR A CD1 1 
+ATOM   1241 C CD2 . TYR A 1 168 ? 3.655   23.929 23.367  1.00 6.36  ? 168 TYR A CD2 1 
+ATOM   1242 C CE1 . TYR A 1 168 ? 6.331   24.571 23.743  1.00 5.31  ? 168 TYR A CE1 1 
+ATOM   1243 C CE2 . TYR A 1 168 ? 4.645   23.262 22.640  1.00 5.68  ? 168 TYR A CE2 1 
+ATOM   1244 C CZ  . TYR A 1 168 ? 5.976   23.588 22.839  1.00 4.97  ? 168 TYR A CZ  1 
+ATOM   1245 O OH  . TYR A 1 168 ? 6.960   22.906 22.156  1.00 4.35  ? 168 TYR A OH  1 
+ATOM   1246 N N   . ARG A 1 169 ? 0.761   24.348 27.781  1.00 8.34  ? 169 ARG A N   1 
+ATOM   1247 C CA  . ARG A 1 169 ? -0.432  24.703 28.550  1.00 8.74  ? 169 ARG A CA  1 
+ATOM   1248 C C   . ARG A 1 169 ? -0.126  25.186 29.975  1.00 8.42  ? 169 ARG A C   1 
+ATOM   1249 O O   . ARG A 1 169 ? 0.568   24.510 30.735  1.00 7.27  ? 169 ARG A O   1 
+ATOM   1250 C CB  . ARG A 1 169 ? -1.373  23.493 28.608  1.00 11.74 ? 169 ARG A CB  1 
+ATOM   1251 C CG  . ARG A 1 169 ? -2.844  23.831 28.820  1.00 16.28 ? 169 ARG A CG  1 
+ATOM   1252 C CD  . ARG A 1 169 ? -3.457  24.440 27.558  1.00 18.81 ? 169 ARG A CD  1 
+ATOM   1253 N NE  . ARG A 1 169 ? -3.928  23.451 26.586  1.00 19.10 ? 169 ARG A NE  1 
+ATOM   1254 C CZ  . ARG A 1 169 ? -3.901  23.643 25.268  1.00 19.80 ? 169 ARG A CZ  1 
+ATOM   1255 N NH1 . ARG A 1 169 ? -3.417  24.776 24.781  1.00 19.79 ? 169 ARG A NH1 1 
+ATOM   1256 N NH2 . ARG A 1 169 ? -4.372  22.718 24.435  1.00 20.37 ? 169 ARG A NH2 1 
+ATOM   1257 N N   . ALA A 1 170 ? -0.654  26.353 30.340  1.00 7.30  ? 170 ALA A N   1 
+ATOM   1258 C CA  . ALA A 1 170 ? -0.435  26.889 31.686  1.00 7.15  ? 170 ALA A CA  1 
+ATOM   1259 C C   . ALA A 1 170 ? -1.115  25.979 32.710  1.00 6.74  ? 170 ALA A C   1 
+ATOM   1260 O O   . ALA A 1 170 ? -2.159  25.389 32.429  1.00 8.12  ? 170 ALA A O   1 
+ATOM   1261 C CB  . ALA A 1 170 ? -0.998  28.316 31.791  1.00 6.68  ? 170 ALA A CB  1 
+ATOM   1262 N N   . PRO A 1 171 ? -0.543  25.869 33.921  1.00 7.42  ? 171 PRO A N   1 
+ATOM   1263 C CA  . PRO A 1 171 ? -1.125  25.014 34.962  1.00 7.61  ? 171 PRO A CA  1 
+ATOM   1264 C C   . PRO A 1 171 ? -2.571  25.336 35.356  1.00 8.12  ? 171 PRO A C   1 
+ATOM   1265 O O   . PRO A 1 171 ? -3.337  24.424 35.702  1.00 7.79  ? 171 PRO A O   1 
+ATOM   1266 C CB  . PRO A 1 171 ? -0.135  25.165 36.126  1.00 8.09  ? 171 PRO A CB  1 
+ATOM   1267 C CG  . PRO A 1 171 ? 0.383   26.553 35.954  1.00 7.97  ? 171 PRO A CG  1 
+ATOM   1268 C CD  . PRO A 1 171 ? 0.597   26.641 34.450  1.00 7.39  ? 171 PRO A CD  1 
+ATOM   1269 N N   . GLU A 1 172 ? -2.964  26.607 35.289  1.00 7.65  ? 172 GLU A N   1 
+ATOM   1270 C CA  . GLU A 1 172 ? -4.334  26.965 35.660  1.00 9.95  ? 172 GLU A CA  1 
+ATOM   1271 C C   . GLU A 1 172 ? -5.348  26.389 34.675  1.00 10.11 ? 172 GLU A C   1 
+ATOM   1272 O O   . GLU A 1 172 ? -6.481  26.093 35.047  1.00 12.14 ? 172 GLU A O   1 
+ATOM   1273 C CB  . GLU A 1 172 ? -4.513  28.488 35.766  1.00 8.90  ? 172 GLU A CB  1 
+ATOM   1274 C CG  . GLU A 1 172 ? -4.127  29.262 34.526  1.00 9.16  ? 172 GLU A CG  1 
+ATOM   1275 C CD  . GLU A 1 172 ? -2.715  29.807 34.606  1.00 8.54  ? 172 GLU A CD  1 
+ATOM   1276 O OE1 . GLU A 1 172 ? -1.807  29.052 35.027  1.00 8.14  ? 172 GLU A OE1 1 
+ATOM   1277 O OE2 . GLU A 1 172 ? -2.520  30.985 34.237  1.00 7.86  ? 172 GLU A OE2 1 
+ATOM   1278 N N   . ILE A 1 173 ? -4.948  26.238 33.417  1.00 10.98 ? 173 ILE A N   1 
+ATOM   1279 C CA  . ILE A 1 173 ? -5.842  25.661 32.423  1.00 10.23 ? 173 ILE A CA  1 
+ATOM   1280 C C   . ILE A 1 173 ? -6.003  24.170 32.734  1.00 11.94 ? 173 ILE A C   1 
+ATOM   1281 O O   . ILE A 1 173 ? -7.115  23.642 32.735  1.00 12.44 ? 173 ILE A O   1 
+ATOM   1282 C CB  . ILE A 1 173 ? -5.282  25.826 30.992  1.00 10.49 ? 173 ILE A CB  1 
+ATOM   1283 C CG1 . ILE A 1 173 ? -5.269  27.312 30.616  1.00 8.72  ? 173 ILE A CG1 1 
+ATOM   1284 C CG2 . ILE A 1 173 ? -6.132  25.026 30.002  1.00 10.66 ? 173 ILE A CG2 1 
+ATOM   1285 C CD1 . ILE A 1 173 ? -4.683  27.610 29.250  1.00 9.98  ? 173 ILE A CD1 1 
+ATOM   1286 N N   . LEU A 1 174 ? -4.887  23.505 33.010  1.00 11.97 ? 174 LEU A N   1 
+ATOM   1287 C CA  . LEU A 1 174 ? -4.895  22.077 33.324  1.00 12.07 ? 174 LEU A CA  1 
+ATOM   1288 C C   . LEU A 1 174 ? -5.670  21.783 34.608  1.00 13.24 ? 174 LEU A C   1 
+ATOM   1289 O O   . LEU A 1 174 ? -6.226  20.690 34.772  1.00 12.26 ? 174 LEU A O   1 
+ATOM   1290 C CB  . LEU A 1 174 ? -3.457  21.565 33.461  1.00 12.87 ? 174 LEU A CB  1 
+ATOM   1291 C CG  . LEU A 1 174 ? -2.596  21.618 32.189  1.00 12.96 ? 174 LEU A CG  1 
+ATOM   1292 C CD1 . LEU A 1 174 ? -1.149  21.260 32.516  1.00 12.34 ? 174 LEU A CD1 1 
+ATOM   1293 C CD2 . LEU A 1 174 ? -3.158  20.658 31.155  1.00 12.72 ? 174 LEU A CD2 1 
+ATOM   1294 N N   . LEU A 1 175 ? -5.700  22.757 35.512  1.00 13.23 ? 175 LEU A N   1 
+ATOM   1295 C CA  . LEU A 1 175 ? -6.396  22.603 36.784  1.00 14.53 ? 175 LEU A CA  1 
+ATOM   1296 C C   . LEU A 1 175 ? -7.863  23.022 36.709  1.00 15.63 ? 175 LEU A C   1 
+ATOM   1297 O O   . LEU A 1 175 ? -8.538  23.137 37.735  1.00 16.03 ? 175 LEU A O   1 
+ATOM   1298 C CB  . LEU A 1 175 ? -5.675  23.393 37.880  1.00 14.32 ? 175 LEU A CB  1 
+ATOM   1299 C CG  . LEU A 1 175 ? -4.340  22.791 38.341  1.00 15.70 ? 175 LEU A CG  1 
+ATOM   1300 C CD1 . LEU A 1 175 ? -3.666  23.720 39.340  1.00 14.93 ? 175 LEU A CD1 1 
+ATOM   1301 C CD2 . LEU A 1 175 ? -4.586  21.419 38.963  1.00 15.95 ? 175 LEU A CD2 1 
+ATOM   1302 N N   . GLY A 1 176 ? -8.343  23.263 35.493  1.00 16.51 ? 176 GLY A N   1 
+ATOM   1303 C CA  . GLY A 1 176 ? -9.740  23.617 35.298  1.00 18.45 ? 176 GLY A CA  1 
+ATOM   1304 C C   . GLY A 1 176 ? -10.198 25.056 35.460  1.00 19.20 ? 176 GLY A C   1 
+ATOM   1305 O O   . GLY A 1 176 ? -11.392 25.292 35.651  1.00 18.61 ? 176 GLY A O   1 
+ATOM   1306 N N   . CYS A 1 177 ? -9.290  26.023 35.392  1.00 20.31 ? 177 CYS A N   1 
+ATOM   1307 C CA  . CYS A 1 177 ? -9.713  27.417 35.522  1.00 22.51 ? 177 CYS A CA  1 
+ATOM   1308 C C   . CYS A 1 177 ? -10.592 27.756 34.317  1.00 22.42 ? 177 CYS A C   1 
+ATOM   1309 O O   . CYS A 1 177 ? -10.181 27.585 33.171  1.00 21.23 ? 177 CYS A O   1 
+ATOM   1310 C CB  . CYS A 1 177 ? -8.507  28.360 35.566  1.00 23.41 ? 177 CYS A CB  1 
+ATOM   1311 S SG  . CYS A 1 177 ? -8.941  30.118 35.787  1.00 28.59 ? 177 CYS A SG  1 
+ATOM   1312 N N   . LYS A 1 178 ? -11.804 28.233 34.580  1.00 23.19 ? 178 LYS A N   1 
+ATOM   1313 C CA  . LYS A 1 178 ? -12.726 28.573 33.505  1.00 24.25 ? 178 LYS A CA  1 
+ATOM   1314 C C   . LYS A 1 178 ? -12.452 29.947 32.902  1.00 23.73 ? 178 LYS A C   1 
+ATOM   1315 O O   . LYS A 1 178 ? -12.602 30.142 31.698  1.00 24.02 ? 178 LYS A O   1 
+ATOM   1316 C CB  . LYS A 1 178 ? -14.172 28.517 34.016  1.00 26.10 ? 178 LYS A CB  1 
+ATOM   1317 C CG  . LYS A 1 178 ? -14.609 27.135 34.491  1.00 28.89 ? 178 LYS A CG  1 
+ATOM   1318 C CD  . LYS A 1 178 ? -14.509 26.106 33.366  1.00 30.38 ? 178 LYS A CD  1 
+ATOM   1319 C CE  . LYS A 1 178 ? -14.829 24.698 33.857  1.00 30.64 ? 178 LYS A CE  1 
+ATOM   1320 N NZ  . LYS A 1 178 ? -13.864 24.221 34.893  1.00 31.78 ? 178 LYS A NZ  1 
+ATOM   1321 N N   . TYR A 1 179 ? -12.040 30.891 33.740  1.00 23.12 ? 179 TYR A N   1 
+ATOM   1322 C CA  . TYR A 1 179 ? -11.772 32.253 33.289  1.00 23.61 ? 179 TYR A CA  1 
+ATOM   1323 C C   . TYR A 1 179 ? -10.322 32.648 33.533  1.00 22.54 ? 179 TYR A C   1 
+ATOM   1324 O O   . TYR A 1 179 ? -10.027 33.507 34.366  1.00 22.44 ? 179 TYR A O   1 
+ATOM   1325 C CB  . TYR A 1 179 ? -12.713 33.221 34.012  1.00 25.69 ? 179 TYR A CB  1 
+ATOM   1326 C CG  . TYR A 1 179 ? -14.157 32.777 33.953  1.00 27.26 ? 179 TYR A CG  1 
+ATOM   1327 C CD1 . TYR A 1 179 ? -14.886 32.864 32.768  1.00 28.35 ? 179 TYR A CD1 1 
+ATOM   1328 C CD2 . TYR A 1 179 ? -14.774 32.205 35.064  1.00 28.70 ? 179 TYR A CD2 1 
+ATOM   1329 C CE1 . TYR A 1 179 ? -16.195 32.387 32.689  1.00 29.54 ? 179 TYR A CE1 1 
+ATOM   1330 C CE2 . TYR A 1 179 ? -16.081 31.723 34.996  1.00 30.08 ? 179 TYR A CE2 1 
+ATOM   1331 C CZ  . TYR A 1 179 ? -16.783 31.816 33.807  1.00 29.95 ? 179 TYR A CZ  1 
+ATOM   1332 O OH  . TYR A 1 179 ? -18.068 31.326 33.732  1.00 31.48 ? 179 TYR A OH  1 
+ATOM   1333 N N   . TYR A 1 180 ? -9.420  32.013 32.794  1.00 21.00 ? 180 TYR A N   1 
+ATOM   1334 C CA  . TYR A 1 180 ? -8.004  32.295 32.931  1.00 19.79 ? 180 TYR A CA  1 
+ATOM   1335 C C   . TYR A 1 180 ? -7.647  33.647 32.313  1.00 18.28 ? 180 TYR A C   1 
+ATOM   1336 O O   . TYR A 1 180 ? -8.434  34.238 31.566  1.00 17.92 ? 180 TYR A O   1 
+ATOM   1337 C CB  . TYR A 1 180 ? -7.185  31.156 32.318  1.00 20.05 ? 180 TYR A CB  1 
+ATOM   1338 C CG  . TYR A 1 180 ? -7.607  30.770 30.924  1.00 21.51 ? 180 TYR A CG  1 
+ATOM   1339 C CD1 . TYR A 1 180 ? -7.170  31.499 29.821  1.00 20.80 ? 180 TYR A CD1 1 
+ATOM   1340 C CD2 . TYR A 1 180 ? -8.443  29.673 30.707  1.00 21.20 ? 180 TYR A CD2 1 
+ATOM   1341 C CE1 . TYR A 1 180 ? -7.546  31.146 28.536  1.00 21.81 ? 180 TYR A CE1 1 
+ATOM   1342 C CE2 . TYR A 1 180 ? -8.832  29.311 29.419  1.00 22.47 ? 180 TYR A CE2 1 
+ATOM   1343 C CZ  . TYR A 1 180 ? -8.376  30.054 28.338  1.00 22.47 ? 180 TYR A CZ  1 
+ATOM   1344 O OH  . TYR A 1 180 ? -8.742  29.710 27.057  1.00 23.26 ? 180 TYR A OH  1 
+ATOM   1345 N N   . SER A 1 181 ? -6.453  34.130 32.635  1.00 15.48 ? 181 SER A N   1 
+ATOM   1346 C CA  . SER A 1 181 ? -5.998  35.435 32.182  1.00 12.60 ? 181 SER A CA  1 
+ATOM   1347 C C   . SER A 1 181 ? -4.916  35.411 31.120  1.00 11.58 ? 181 SER A C   1 
+ATOM   1348 O O   . SER A 1 181 ? -4.459  34.354 30.681  1.00 9.30  ? 181 SER A O   1 
+ATOM   1349 C CB  . SER A 1 181 ? -5.449  36.205 33.372  1.00 13.46 ? 181 SER A CB  1 
+ATOM   1350 O OG  . SER A 1 181 ? -4.229  35.610 33.790  1.00 12.07 ? 181 SER A OG  1 
+ATOM   1351 N N   . THR A 1 182 ? -4.493  36.613 30.748  1.00 9.44  ? 182 THR A N   1 
+ATOM   1352 C CA  . THR A 1 182 ? -3.438  36.805 29.770  1.00 8.75  ? 182 THR A CA  1 
+ATOM   1353 C C   . THR A 1 182 ? -2.165  36.089 30.231  1.00 8.08  ? 182 THR A C   1 
+ATOM   1354 O O   . THR A 1 182 ? -1.254  35.861 29.439  1.00 7.67  ? 182 THR A O   1 
+ATOM   1355 C CB  . THR A 1 182 ? -3.131  38.300 29.604  1.00 7.97  ? 182 THR A CB  1 
+ATOM   1356 O OG1 . THR A 1 182 ? -2.890  38.879 30.893  1.00 8.66  ? 182 THR A OG1 1 
+ATOM   1357 C CG2 . THR A 1 182 ? -4.311  39.018 28.955  1.00 10.55 ? 182 THR A CG2 1 
+ATOM   1358 N N   . ALA A 1 183 ? -2.108  35.732 31.513  1.00 8.32  ? 183 ALA A N   1 
+ATOM   1359 C CA  . ALA A 1 183 ? -0.936  35.050 32.053  1.00 7.36  ? 183 ALA A CA  1 
+ATOM   1360 C C   . ALA A 1 183 ? -0.681  33.699 31.387  1.00 6.87  ? 183 ALA A C   1 
+ATOM   1361 O O   . ALA A 1 183 ? 0.449   33.212 31.391  1.00 6.33  ? 183 ALA A O   1 
+ATOM   1362 C CB  . ALA A 1 183 ? -1.080  34.860 33.566  1.00 8.60  ? 183 ALA A CB  1 
+ATOM   1363 N N   . VAL A 1 184 ? -1.720  33.082 30.832  1.00 5.95  ? 184 VAL A N   1 
+ATOM   1364 C CA  . VAL A 1 184 ? -1.524  31.789 30.193  1.00 6.16  ? 184 VAL A CA  1 
+ATOM   1365 C C   . VAL A 1 184 ? -0.567  31.912 29.011  1.00 5.51  ? 184 VAL A C   1 
+ATOM   1366 O O   . VAL A 1 184 ? 0.223   31.004 28.756  1.00 5.33  ? 184 VAL A O   1 
+ATOM   1367 C CB  . VAL A 1 184 ? -2.857  31.157 29.710  1.00 6.35  ? 184 VAL A CB  1 
+ATOM   1368 C CG1 . VAL A 1 184 ? -3.783  30.926 30.900  1.00 6.96  ? 184 VAL A CG1 1 
+ATOM   1369 C CG2 . VAL A 1 184 ? -3.525  32.049 28.658  1.00 8.01  ? 184 VAL A CG2 1 
+ATOM   1370 N N   . ASP A 1 185 ? -0.627  33.035 28.298  1.00 5.70  ? 185 ASP A N   1 
+ATOM   1371 C CA  . ASP A 1 185 ? 0.256   33.234 27.148  1.00 5.77  ? 185 ASP A CA  1 
+ATOM   1372 C C   . ASP A 1 185 ? 1.711   33.408 27.575  1.00 5.39  ? 185 ASP A C   1 
+ATOM   1373 O O   . ASP A 1 185 ? 2.629   32.968 26.876  1.00 5.42  ? 185 ASP A O   1 
+ATOM   1374 C CB  . ASP A 1 185 ? -0.192  34.447 26.320  1.00 5.56  ? 185 ASP A CB  1 
+ATOM   1375 C CG  . ASP A 1 185 ? -1.537  34.223 25.645  1.00 6.95  ? 185 ASP A CG  1 
+ATOM   1376 O OD1 . ASP A 1 185 ? -1.903  33.047 25.434  1.00 6.12  ? 185 ASP A OD1 1 
+ATOM   1377 O OD2 . ASP A 1 185 ? -2.215  35.219 25.311  1.00 6.80  ? 185 ASP A OD2 1 
+ATOM   1378 N N   . ILE A 1 186 ? 1.922   34.055 28.719  1.00 4.74  ? 186 ILE A N   1 
+ATOM   1379 C CA  . ILE A 1 186 ? 3.277   34.258 29.224  1.00 5.24  ? 186 ILE A CA  1 
+ATOM   1380 C C   . ILE A 1 186 ? 3.887   32.906 29.587  1.00 4.05  ? 186 ILE A C   1 
+ATOM   1381 O O   . ILE A 1 186 ? 5.056   32.650 29.306  1.00 3.94  ? 186 ILE A O   1 
+ATOM   1382 C CB  . ILE A 1 186 ? 3.283   35.174 30.463  1.00 5.28  ? 186 ILE A CB  1 
+ATOM   1383 C CG1 . ILE A 1 186 ? 2.770   36.562 30.072  1.00 5.71  ? 186 ILE A CG1 1 
+ATOM   1384 C CG2 . ILE A 1 186 ? 4.690   35.246 31.060  1.00 5.31  ? 186 ILE A CG2 1 
+ATOM   1385 C CD1 . ILE A 1 186 ? 3.578   37.242 28.997  1.00 8.37  ? 186 ILE A CD1 1 
+ATOM   1386 N N   . TRP A 1 187 ? 3.091   32.045 30.215  1.00 3.56  ? 187 TRP A N   1 
+ATOM   1387 C CA  . TRP A 1 187 ? 3.565   30.713 30.571  1.00 4.46  ? 187 TRP A CA  1 
+ATOM   1388 C C   . TRP A 1 187 ? 3.998   29.974 29.302  1.00 4.37  ? 187 TRP A C   1 
+ATOM   1389 O O   . TRP A 1 187 ? 5.096   29.418 29.228  1.00 4.06  ? 187 TRP A O   1 
+ATOM   1390 C CB  . TRP A 1 187 ? 2.454   29.915 31.265  1.00 4.56  ? 187 TRP A CB  1 
+ATOM   1391 C CG  . TRP A 1 187 ? 2.839   28.484 31.534  1.00 5.93  ? 187 TRP A CG  1 
+ATOM   1392 C CD1 . TRP A 1 187 ? 2.852   27.447 30.637  1.00 5.91  ? 187 TRP A CD1 1 
+ATOM   1393 C CD2 . TRP A 1 187 ? 3.332   27.955 32.764  1.00 5.44  ? 187 TRP A CD2 1 
+ATOM   1394 N NE1 . TRP A 1 187 ? 3.330   26.308 31.238  1.00 5.91  ? 187 TRP A NE1 1 
+ATOM   1395 C CE2 . TRP A 1 187 ? 3.632   26.591 32.544  1.00 6.01  ? 187 TRP A CE2 1 
+ATOM   1396 C CE3 . TRP A 1 187 ? 3.553   28.502 34.036  1.00 6.29  ? 187 TRP A CE3 1 
+ATOM   1397 C CZ2 . TRP A 1 187 ? 4.142   25.764 33.550  1.00 6.74  ? 187 TRP A CZ2 1 
+ATOM   1398 C CZ3 . TRP A 1 187 ? 4.060   27.678 35.039  1.00 8.39  ? 187 TRP A CZ3 1 
+ATOM   1399 C CH2 . TRP A 1 187 ? 4.348   26.323 34.788  1.00 7.00  ? 187 TRP A CH2 1 
+ATOM   1400 N N   . SER A 1 188 ? 3.127   29.971 28.300  1.00 4.71  ? 188 SER A N   1 
+ATOM   1401 C CA  . SER A 1 188 ? 3.422   29.281 27.047  1.00 4.74  ? 188 SER A CA  1 
+ATOM   1402 C C   . SER A 1 188 ? 4.704   29.809 26.415  1.00 5.18  ? 188 SER A C   1 
+ATOM   1403 O O   . SER A 1 188 ? 5.551   29.036 25.956  1.00 5.39  ? 188 SER A O   1 
+ATOM   1404 C CB  . SER A 1 188 ? 2.255   29.445 26.065  1.00 5.43  ? 188 SER A CB  1 
+ATOM   1405 O OG  . SER A 1 188 ? 1.049   28.934 26.615  1.00 5.33  ? 188 SER A OG  1 
+ATOM   1406 N N   . LEU A 1 189 ? 4.849   31.127 26.390  1.00 4.74  ? 189 LEU A N   1 
+ATOM   1407 C CA  . LEU A 1 189 ? 6.033   31.719 25.793  1.00 5.55  ? 189 LEU A CA  1 
+ATOM   1408 C C   . LEU A 1 189 ? 7.276   31.338 26.598  1.00 5.35  ? 189 LEU A C   1 
+ATOM   1409 O O   . LEU A 1 189 ? 8.341   31.097 26.024  1.00 5.48  ? 189 LEU A O   1 
+ATOM   1410 C CB  . LEU A 1 189 ? 5.886   33.242 25.700  1.00 4.47  ? 189 LEU A CB  1 
+ATOM   1411 C CG  . LEU A 1 189 ? 7.023   33.954 24.960  1.00 6.39  ? 189 LEU A CG  1 
+ATOM   1412 C CD1 . LEU A 1 189 ? 7.218   33.319 23.580  1.00 6.13  ? 189 LEU A CD1 1 
+ATOM   1413 C CD2 . LEU A 1 189 ? 6.697   35.437 24.826  1.00 6.61  ? 189 LEU A CD2 1 
+ATOM   1414 N N   . GLY A 1 190 ? 7.137   31.275 27.920  1.00 5.35  ? 190 GLY A N   1 
+ATOM   1415 C CA  . GLY A 1 190 ? 8.266   30.888 28.754  1.00 6.27  ? 190 GLY A CA  1 
+ATOM   1416 C C   . GLY A 1 190 ? 8.725   29.483 28.403  1.00 6.63  ? 190 GLY A C   1 
+ATOM   1417 O O   . GLY A 1 190 ? 9.927   29.192 28.348  1.00 6.27  ? 190 GLY A O   1 
+ATOM   1418 N N   . CYS A 1 191 ? 7.765   28.595 28.161  1.00 5.96  ? 191 CYS A N   1 
+ATOM   1419 C CA  . CYS A 1 191 ? 8.093   27.220 27.803  1.00 6.62  ? 191 CYS A CA  1 
+ATOM   1420 C C   . CYS A 1 191 ? 8.833   27.193 26.465  1.00 5.72  ? 191 CYS A C   1 
+ATOM   1421 O O   . CYS A 1 191 ? 9.757   26.408 26.266  1.00 5.33  ? 191 CYS A O   1 
+ATOM   1422 C CB  . CYS A 1 191 ? 6.814   26.375 27.705  1.00 7.55  ? 191 CYS A CB  1 
+ATOM   1423 S SG  . CYS A 1 191 ? 6.020   26.017 29.302  1.00 6.70  ? 191 CYS A SG  1 
+ATOM   1424 N N   . ILE A 1 192 ? 8.418   28.065 25.554  1.00 5.29  ? 192 ILE A N   1 
+ATOM   1425 C CA  . ILE A 1 192 ? 9.038   28.150 24.234  1.00 5.49  ? 192 ILE A CA  1 
+ATOM   1426 C C   . ILE A 1 192 ? 10.458  28.702 24.357  1.00 5.17  ? 192 ILE A C   1 
+ATOM   1427 O O   . ILE A 1 192 ? 11.378  28.256 23.665  1.00 7.45  ? 192 ILE A O   1 
+ATOM   1428 C CB  . ILE A 1 192 ? 8.177   29.037 23.308  1.00 4.32  ? 192 ILE A CB  1 
+ATOM   1429 C CG1 . ILE A 1 192 ? 6.848   28.320 23.032  1.00 5.75  ? 192 ILE A CG1 1 
+ATOM   1430 C CG2 . ILE A 1 192 ? 8.919   29.328 22.002  1.00 4.25  ? 192 ILE A CG2 1 
+ATOM   1431 C CD1 . ILE A 1 192 ? 5.773   29.191 22.376  1.00 5.18  ? 192 ILE A CD1 1 
+ATOM   1432 N N   . PHE A 1 193 ? 10.626  29.666 25.253  1.00 5.01  ? 193 PHE A N   1 
+ATOM   1433 C CA  . PHE A 1 193 ? 11.925  30.287 25.521  1.00 6.26  ? 193 PHE A CA  1 
+ATOM   1434 C C   . PHE A 1 193 ? 12.888  29.186 26.000  1.00 6.32  ? 193 PHE A C   1 
+ATOM   1435 O O   . PHE A 1 193 ? 13.991  29.034 25.471  1.00 5.63  ? 193 PHE A O   1 
+ATOM   1436 C CB  . PHE A 1 193 ? 11.715  31.384 26.583  1.00 6.49  ? 193 PHE A CB  1 
+ATOM   1437 C CG  . PHE A 1 193 ? 12.980  32.051 27.080  1.00 7.78  ? 193 PHE A CG  1 
+ATOM   1438 C CD1 . PHE A 1 193 ? 14.120  32.137 26.288  1.00 7.78  ? 193 PHE A CD1 1 
+ATOM   1439 C CD2 . PHE A 1 193 ? 12.998  32.639 28.345  1.00 8.17  ? 193 PHE A CD2 1 
+ATOM   1440 C CE1 . PHE A 1 193 ? 15.257  32.800 26.752  1.00 8.65  ? 193 PHE A CE1 1 
+ATOM   1441 C CE2 . PHE A 1 193 ? 14.130  33.306 28.816  1.00 7.67  ? 193 PHE A CE2 1 
+ATOM   1442 C CZ  . PHE A 1 193 ? 15.260  33.386 28.018  1.00 7.49  ? 193 PHE A CZ  1 
+ATOM   1443 N N   . ALA A 1 194 ? 12.448  28.399 26.976  1.00 6.28  ? 194 ALA A N   1 
+ATOM   1444 C CA  . ALA A 1 194 ? 13.270  27.316 27.507  1.00 6.60  ? 194 ALA A CA  1 
+ATOM   1445 C C   . ALA A 1 194 ? 13.673  26.334 26.411  1.00 6.37  ? 194 ALA A C   1 
+ATOM   1446 O O   . ALA A 1 194 ? 14.819  25.875 26.363  1.00 5.96  ? 194 ALA A O   1 
+ATOM   1447 C CB  . ALA A 1 194 ? 12.518  26.582 28.613  1.00 5.55  ? 194 ALA A CB  1 
+ATOM   1448 N N   . GLU A 1 195 ? 12.724  26.021 25.532  1.00 5.66  ? 195 GLU A N   1 
+ATOM   1449 C CA  . GLU A 1 195 ? 12.950  25.091 24.433  1.00 6.20  ? 195 GLU A CA  1 
+ATOM   1450 C C   . GLU A 1 195 ? 13.978  25.603 23.425  1.00 6.10  ? 195 GLU A C   1 
+ATOM   1451 O O   . GLU A 1 195 ? 14.786  24.827 22.911  1.00 6.12  ? 195 GLU A O   1 
+ATOM   1452 C CB  . GLU A 1 195 ? 11.622  24.792 23.722  1.00 5.69  ? 195 GLU A CB  1 
+ATOM   1453 C CG  . GLU A 1 195 ? 11.697  23.616 22.768  1.00 8.02  ? 195 GLU A CG  1 
+ATOM   1454 C CD  . GLU A 1 195 ? 10.341  23.212 22.223  1.00 9.26  ? 195 GLU A CD  1 
+ATOM   1455 O OE1 . GLU A 1 195 ? 9.329   23.371 22.942  1.00 8.91  ? 195 GLU A OE1 1 
+ATOM   1456 O OE2 . GLU A 1 195 ? 10.293  22.717 21.079  1.00 8.70  ? 195 GLU A OE2 1 
+ATOM   1457 N N   . MET A 1 196 ? 13.951  26.899 23.129  1.00 5.65  ? 196 MET A N   1 
+ATOM   1458 C CA  . MET A 1 196 ? 14.925  27.451 22.184  1.00 6.83  ? 196 MET A CA  1 
+ATOM   1459 C C   . MET A 1 196 ? 16.333  27.345 22.759  1.00 7.63  ? 196 MET A C   1 
+ATOM   1460 O O   . MET A 1 196 ? 17.294  27.040 22.046  1.00 7.27  ? 196 MET A O   1 
+ATOM   1461 C CB  . MET A 1 196 ? 14.628  28.924 21.870  1.00 6.24  ? 196 MET A CB  1 
+ATOM   1462 C CG  . MET A 1 196 ? 13.428  29.149 20.956  1.00 7.77  ? 196 MET A CG  1 
+ATOM   1463 S SD  . MET A 1 196 ? 13.340  30.850 20.311  1.00 10.62 ? 196 MET A SD  1 
+ATOM   1464 C CE  . MET A 1 196 ? 12.623  31.702 21.728  1.00 8.18  ? 196 MET A CE  1 
+ATOM   1465 N N   . VAL A 1 197 ? 16.447  27.607 24.055  1.00 7.36  ? 197 VAL A N   1 
+ATOM   1466 C CA  . VAL A 1 197 ? 17.732  27.563 24.737  1.00 9.38  ? 197 VAL A CA  1 
+ATOM   1467 C C   . VAL A 1 197 ? 18.318  26.157 24.889  1.00 10.12 ? 197 VAL A C   1 
+ATOM   1468 O O   . VAL A 1 197 ? 19.495  25.938 24.589  1.00 9.75  ? 197 VAL A O   1 
+ATOM   1469 C CB  . VAL A 1 197 ? 17.622  28.202 26.135  1.00 9.88  ? 197 VAL A CB  1 
+ATOM   1470 C CG1 . VAL A 1 197 ? 18.935  28.038 26.902  1.00 11.65 ? 197 VAL A CG1 1 
+ATOM   1471 C CG2 . VAL A 1 197 ? 17.265  29.675 25.995  1.00 10.28 ? 197 VAL A CG2 1 
+ATOM   1472 N N   . THR A 1 198 ? 17.502  25.211 25.345  1.00 9.96  ? 198 THR A N   1 
+ATOM   1473 C CA  . THR A 1 198 ? 17.963  23.841 25.573  1.00 11.11 ? 198 THR A CA  1 
+ATOM   1474 C C   . THR A 1 198 ? 17.842  22.887 24.392  1.00 11.85 ? 198 THR A C   1 
+ATOM   1475 O O   . THR A 1 198 ? 18.475  21.823 24.385  1.00 10.62 ? 198 THR A O   1 
+ATOM   1476 C CB  . THR A 1 198 ? 17.216  23.204 26.757  1.00 11.40 ? 198 THR A CB  1 
+ATOM   1477 O OG1 . THR A 1 198 ? 15.833  23.045 26.416  1.00 11.63 ? 198 THR A OG1 1 
+ATOM   1478 C CG2 . THR A 1 198 ? 17.336  24.080 27.995  1.00 10.23 ? 198 THR A CG2 1 
+ATOM   1479 N N   . ARG A 1 199 ? 17.032  23.265 23.406  1.00 12.10 ? 199 ARG A N   1 
+ATOM   1480 C CA  . ARG A 1 199 ? 16.805  22.456 22.210  1.00 13.73 ? 199 ARG A CA  1 
+ATOM   1481 C C   . ARG A 1 199 ? 15.983  21.211 22.540  1.00 14.28 ? 199 ARG A C   1 
+ATOM   1482 O O   . ARG A 1 199 ? 16.064  20.191 21.851  1.00 14.39 ? 199 ARG A O   1 
+ATOM   1483 C CB  . ARG A 1 199 ? 18.138  22.041 21.569  1.00 14.75 ? 199 ARG A CB  1 
+ATOM   1484 C CG  . ARG A 1 199 ? 19.065  23.197 21.220  1.00 16.96 ? 199 ARG A CG  1 
+ATOM   1485 C CD  . ARG A 1 199 ? 20.317  22.670 20.535  1.00 18.55 ? 199 ARG A CD  1 
+ATOM   1486 N NE  . ARG A 1 199 ? 21.532  23.167 21.163  1.00 21.10 ? 199 ARG A NE  1 
+ATOM   1487 C CZ  . ARG A 1 199 ? 22.739  22.659 20.947  1.00 22.08 ? 199 ARG A CZ  1 
+ATOM   1488 N NH1 . ARG A 1 199 ? 22.891  21.635 20.117  1.00 23.56 ? 199 ARG A NH1 1 
+ATOM   1489 N NH2 . ARG A 1 199 ? 23.793  23.172 21.564  1.00 24.98 ? 199 ARG A NH2 1 
+ATOM   1490 N N   . ARG A 1 200 ? 15.199  21.304 23.608  1.00 14.02 ? 200 ARG A N   1 
+ATOM   1491 C CA  . ARG A 1 200 ? 14.341  20.210 24.038  1.00 14.00 ? 200 ARG A CA  1 
+ATOM   1492 C C   . ARG A 1 200 ? 13.126  20.802 24.740  1.00 12.26 ? 200 ARG A C   1 
+ATOM   1493 O O   . ARG A 1 200 ? 13.245  21.798 25.452  1.00 12.41 ? 200 ARG A O   1 
+ATOM   1494 C CB  . ARG A 1 200 ? 15.091  19.289 25.001  1.00 15.31 ? 200 ARG A CB  1 
+ATOM   1495 C CG  . ARG A 1 200 ? 14.364  17.982 25.279  1.00 18.33 ? 200 ARG A CG  1 
+ATOM   1496 C CD  . ARG A 1 200 ? 15.131  17.124 26.269  1.00 21.48 ? 200 ARG A CD  1 
+ATOM   1497 N NE  . ARG A 1 200 ? 14.521  15.809 26.446  1.00 23.55 ? 200 ARG A NE  1 
+ATOM   1498 C CZ  . ARG A 1 200 ? 14.958  14.896 27.309  1.00 25.39 ? 200 ARG A CZ  1 
+ATOM   1499 N NH1 . ARG A 1 200 ? 16.006  15.158 28.078  1.00 25.77 ? 200 ARG A NH1 1 
+ATOM   1500 N NH2 . ARG A 1 200 ? 14.357  13.715 27.395  1.00 25.93 ? 200 ARG A NH2 1 
+ATOM   1501 N N   . ALA A 1 201 ? 11.959  20.200 24.533  1.00 11.09 ? 201 ALA A N   1 
+ATOM   1502 C CA  . ALA A 1 201 ? 10.741  20.690 25.164  1.00 10.39 ? 201 ALA A CA  1 
+ATOM   1503 C C   . ALA A 1 201 ? 10.930  20.674 26.674  1.00 10.83 ? 201 ALA A C   1 
+ATOM   1504 O O   . ALA A 1 201 ? 11.570  19.773 27.215  1.00 10.54 ? 201 ALA A O   1 
+ATOM   1505 C CB  . ALA A 1 201 ? 9.554   19.817 24.773  1.00 10.41 ? 201 ALA A CB  1 
+ATOM   1506 N N   . LEU A 1 202 ? 10.370  21.673 27.349  1.00 9.91  ? 202 LEU A N   1 
+ATOM   1507 C CA  . LEU A 1 202 ? 10.498  21.777 28.794  1.00 9.96  ? 202 LEU A CA  1 
+ATOM   1508 C C   . LEU A 1 202 ? 9.621   20.781 29.549  1.00 10.12 ? 202 LEU A C   1 
+ATOM   1509 O O   . LEU A 1 202 ? 10.093  20.093 30.453  1.00 10.70 ? 202 LEU A O   1 
+ATOM   1510 C CB  . LEU A 1 202 ? 10.160  23.198 29.247  1.00 9.39  ? 202 LEU A CB  1 
+ATOM   1511 C CG  . LEU A 1 202 ? 10.396  23.464 30.736  1.00 10.89 ? 202 LEU A CG  1 
+ATOM   1512 C CD1 . LEU A 1 202 ? 11.851  23.176 31.082  1.00 11.52 ? 202 LEU A CD1 1 
+ATOM   1513 C CD2 . LEU A 1 202 ? 10.029  24.903 31.067  1.00 11.33 ? 202 LEU A CD2 1 
+ATOM   1514 N N   . PHE A 1 203 ? 8.346   20.718 29.182  1.00 9.47  ? 203 PHE A N   1 
+ATOM   1515 C CA  . PHE A 1 203 ? 7.392   19.814 29.829  1.00 10.34 ? 203 PHE A CA  1 
+ATOM   1516 C C   . PHE A 1 203 ? 6.655   19.032 28.749  1.00 10.17 ? 203 PHE A C   1 
+ATOM   1517 O O   . PHE A 1 203 ? 5.533   19.376 28.378  1.00 10.54 ? 203 PHE A O   1 
+ATOM   1518 C CB  . PHE A 1 203 ? 6.380   20.623 30.647  1.00 10.03 ? 203 PHE A CB  1 
+ATOM   1519 C CG  . PHE A 1 203 ? 7.008   21.509 31.689  1.00 10.81 ? 203 PHE A CG  1 
+ATOM   1520 C CD1 . PHE A 1 203 ? 7.852   20.976 32.657  1.00 11.09 ? 203 PHE A CD1 1 
+ATOM   1521 C CD2 . PHE A 1 203 ? 6.722   22.868 31.725  1.00 10.44 ? 203 PHE A CD2 1 
+ATOM   1522 C CE1 . PHE A 1 203 ? 8.398   21.785 33.651  1.00 11.30 ? 203 PHE A CE1 1 
+ATOM   1523 C CE2 . PHE A 1 203 ? 7.264   23.687 32.717  1.00 10.32 ? 203 PHE A CE2 1 
+ATOM   1524 C CZ  . PHE A 1 203 ? 8.103   23.141 33.682  1.00 10.68 ? 203 PHE A CZ  1 
+ATOM   1525 N N   . PRO A 1 204 ? 7.278   17.966 28.228  1.00 11.18 ? 204 PRO A N   1 
+ATOM   1526 C CA  . PRO A 1 204 ? 6.660   17.154 27.177  1.00 11.58 ? 204 PRO A CA  1 
+ATOM   1527 C C   . PRO A 1 204 ? 5.682   16.084 27.662  1.00 12.83 ? 204 PRO A C   1 
+ATOM   1528 O O   . PRO A 1 204 ? 5.991   14.896 27.609  1.00 13.10 ? 204 PRO A O   1 
+ATOM   1529 C CB  . PRO A 1 204 ? 7.867   16.550 26.475  1.00 11.04 ? 204 PRO A CB  1 
+ATOM   1530 C CG  . PRO A 1 204 ? 8.786   16.276 27.629  1.00 12.14 ? 204 PRO A CG  1 
+ATOM   1531 C CD  . PRO A 1 204 ? 8.670   17.542 28.471  1.00 11.51 ? 204 PRO A CD  1 
+ATOM   1532 N N   . GLY A 1 205 ? 4.507   16.507 28.119  1.00 13.03 ? 205 GLY A N   1 
+ATOM   1533 C CA  . GLY A 1 205 ? 3.509   15.558 28.590  1.00 14.97 ? 205 GLY A CA  1 
+ATOM   1534 C C   . GLY A 1 205 ? 2.622   15.055 27.464  1.00 15.51 ? 205 GLY A C   1 
+ATOM   1535 O O   . GLY A 1 205 ? 2.366   15.781 26.503  1.00 16.13 ? 205 GLY A O   1 
+ATOM   1536 N N   . ASP A 1 206 ? 2.136   13.822 27.574  1.00 16.45 ? 206 ASP A N   1 
+ATOM   1537 C CA  . ASP A 1 206 ? 1.279   13.272 26.526  1.00 17.40 ? 206 ASP A CA  1 
+ATOM   1538 C C   . ASP A 1 206 ? -0.188  13.118 26.934  1.00 17.87 ? 206 ASP A C   1 
+ATOM   1539 O O   . ASP A 1 206 ? -0.994  12.548 26.192  1.00 19.54 ? 206 ASP A O   1 
+ATOM   1540 C CB  . ASP A 1 206 ? 1.838   11.934 26.035  1.00 17.25 ? 206 ASP A CB  1 
+ATOM   1541 C CG  . ASP A 1 206 ? 1.843   10.871 27.113  1.00 17.81 ? 206 ASP A CG  1 
+ATOM   1542 O OD1 . ASP A 1 206 ? 1.747   11.229 28.305  1.00 16.41 ? 206 ASP A OD1 1 
+ATOM   1543 O OD2 . ASP A 1 206 ? 1.956   9.675  26.761  1.00 18.00 ? 206 ASP A OD2 1 
+ATOM   1544 N N   . SER A 1 207 ? -0.527  13.623 28.114  1.00 17.33 ? 207 SER A N   1 
+ATOM   1545 C CA  . SER A 1 207 ? -1.899  13.588 28.620  1.00 17.73 ? 207 SER A CA  1 
+ATOM   1546 C C   . SER A 1 207 ? -1.996  14.727 29.624  1.00 16.83 ? 207 SER A C   1 
+ATOM   1547 O O   . SER A 1 207 ? -0.979  15.193 30.125  1.00 15.95 ? 207 SER A O   1 
+ATOM   1548 C CB  . SER A 1 207 ? -2.212  12.253 29.310  1.00 17.58 ? 207 SER A CB  1 
+ATOM   1549 O OG  . SER A 1 207 ? -1.668  12.194 30.618  1.00 19.96 ? 207 SER A OG  1 
+ATOM   1550 N N   . GLU A 1 208 ? -3.206  15.182 29.924  1.00 16.50 ? 208 GLU A N   1 
+ATOM   1551 C CA  . GLU A 1 208 ? -3.344  16.285 30.857  1.00 16.92 ? 208 GLU A CA  1 
+ATOM   1552 C C   . GLU A 1 208 ? -2.702  16.028 32.212  1.00 15.46 ? 208 GLU A C   1 
+ATOM   1553 O O   . GLU A 1 208 ? -2.033  16.908 32.756  1.00 14.90 ? 208 GLU A O   1 
+ATOM   1554 C CB  . GLU A 1 208 ? -4.815  16.661 31.032  1.00 18.39 ? 208 GLU A CB  1 
+ATOM   1555 C CG  . GLU A 1 208 ? -5.264  17.761 30.082  1.00 21.23 ? 208 GLU A CG  1 
+ATOM   1556 C CD  . GLU A 1 208 ? -6.713  18.143 30.279  1.00 23.39 ? 208 GLU A CD  1 
+ATOM   1557 O OE1 . GLU A 1 208 ? -7.593  17.395 29.810  1.00 25.58 ? 208 GLU A OE1 1 
+ATOM   1558 O OE2 . GLU A 1 208 ? -6.969  19.188 30.913  1.00 25.63 ? 208 GLU A OE2 1 
+ATOM   1559 N N   . ILE A 1 209 ? -2.882  14.831 32.755  1.00 14.15 ? 209 ILE A N   1 
+ATOM   1560 C CA  . ILE A 1 209 ? -2.297  14.544 34.056  1.00 14.43 ? 209 ILE A CA  1 
+ATOM   1561 C C   . ILE A 1 209 ? -0.776  14.401 33.965  1.00 13.65 ? 209 ILE A C   1 
+ATOM   1562 O O   . ILE A 1 209 ? -0.051  14.850 34.856  1.00 12.65 ? 209 ILE A O   1 
+ATOM   1563 C CB  . ILE A 1 209 ? -2.943  13.283 34.711  1.00 14.97 ? 209 ILE A CB  1 
+ATOM   1564 C CG1 . ILE A 1 209 ? -2.746  13.344 36.227  1.00 16.63 ? 209 ILE A CG1 1 
+ATOM   1565 C CG2 . ILE A 1 209 ? -2.327  12.007 34.169  1.00 15.75 ? 209 ILE A CG2 1 
+ATOM   1566 C CD1 . ILE A 1 209 ? -3.447  14.529 36.882  1.00 15.89 ? 209 ILE A CD1 1 
+ATOM   1567 N N   . ASP A 1 210 ? -0.288  13.802 32.882  1.00 13.39 ? 210 ASP A N   1 
+ATOM   1568 C CA  . ASP A 1 210 ? 1.150   13.643 32.703  1.00 13.09 ? 210 ASP A CA  1 
+ATOM   1569 C C   . ASP A 1 210 ? 1.785   15.021 32.560  1.00 11.70 ? 210 ASP A C   1 
+ATOM   1570 O O   . ASP A 1 210 ? 2.875   15.271 33.075  1.00 11.12 ? 210 ASP A O   1 
+ATOM   1571 C CB  . ASP A 1 210 ? 1.456   12.804 31.455  1.00 13.64 ? 210 ASP A CB  1 
+ATOM   1572 C CG  . ASP A 1 210 ? 2.941   12.509 31.298  1.00 14.80 ? 210 ASP A CG  1 
+ATOM   1573 O OD1 . ASP A 1 210 ? 3.517   11.868 32.200  1.00 15.37 ? 210 ASP A OD1 1 
+ATOM   1574 O OD2 . ASP A 1 210 ? 3.532   12.917 30.275  1.00 13.71 ? 210 ASP A OD2 1 
+ATOM   1575 N N   . GLN A 1 211 ? 1.091   15.913 31.857  1.00 11.10 ? 211 GLN A N   1 
+ATOM   1576 C CA  . GLN A 1 211 ? 1.578   17.272 31.642  1.00 9.51  ? 211 GLN A CA  1 
+ATOM   1577 C C   . GLN A 1 211 ? 1.678   17.986 32.984  1.00 9.26  ? 211 GLN A C   1 
+ATOM   1578 O O   . GLN A 1 211 ? 2.692   18.606 33.305  1.00 7.56  ? 211 GLN A O   1 
+ATOM   1579 C CB  . GLN A 1 211 ? 0.609   18.029 30.731  1.00 10.27 ? 211 GLN A CB  1 
+ATOM   1580 C CG  . GLN A 1 211 ? 1.071   19.417 30.314  1.00 10.73 ? 211 GLN A CG  1 
+ATOM   1581 C CD  . GLN A 1 211 ? 2.360   19.375 29.520  1.00 10.99 ? 211 GLN A CD  1 
+ATOM   1582 O OE1 . GLN A 1 211 ? 2.542   18.509 28.665  1.00 10.24 ? 211 GLN A OE1 1 
+ATOM   1583 N NE2 . GLN A 1 211 ? 3.258   20.314 29.791  1.00 10.47 ? 211 GLN A NE2 1 
+ATOM   1584 N N   . LEU A 1 212 ? 0.610   17.887 33.766  1.00 8.63  ? 212 LEU A N   1 
+ATOM   1585 C CA  . LEU A 1 212 ? 0.565   18.521 35.070  1.00 10.27 ? 212 LEU A CA  1 
+ATOM   1586 C C   . LEU A 1 212 ? 1.690   17.995 35.958  1.00 9.70  ? 212 LEU A C   1 
+ATOM   1587 O O   . LEU A 1 212 ? 2.435   18.769 36.555  1.00 10.42 ? 212 LEU A O   1 
+ATOM   1588 C CB  . LEU A 1 212 ? -0.790  18.253 35.726  1.00 11.03 ? 212 LEU A CB  1 
+ATOM   1589 C CG  . LEU A 1 212 ? -1.145  19.065 36.967  1.00 13.90 ? 212 LEU A CG  1 
+ATOM   1590 C CD1 . LEU A 1 212 ? -1.367  20.524 36.569  1.00 14.05 ? 212 LEU A CD1 1 
+ATOM   1591 C CD2 . LEU A 1 212 ? -2.404  18.488 37.614  1.00 14.80 ? 212 LEU A CD2 1 
+ATOM   1592 N N   . PHE A 1 213 ? 1.820   16.676 36.033  1.00 9.62  ? 213 PHE A N   1 
+ATOM   1593 C CA  . PHE A 1 213 ? 2.853   16.072 36.864  1.00 9.70  ? 213 PHE A CA  1 
+ATOM   1594 C C   . PHE A 1 213 ? 4.277   16.387 36.408  1.00 9.46  ? 213 PHE A C   1 
+ATOM   1595 O O   . PHE A 1 213 ? 5.176   16.499 37.239  1.00 9.24  ? 213 PHE A O   1 
+ATOM   1596 C CB  . PHE A 1 213 ? 2.629   14.559 36.966  1.00 10.67 ? 213 PHE A CB  1 
+ATOM   1597 C CG  . PHE A 1 213 ? 1.439   14.181 37.815  1.00 11.18 ? 213 PHE A CG  1 
+ATOM   1598 C CD1 . PHE A 1 213 ? 0.636   15.162 38.392  1.00 12.69 ? 213 PHE A CD1 1 
+ATOM   1599 C CD2 . PHE A 1 213 ? 1.125   12.846 38.040  1.00 12.90 ? 213 PHE A CD2 1 
+ATOM   1600 C CE1 . PHE A 1 213 ? -0.462  14.820 39.180  1.00 14.00 ? 213 PHE A CE1 1 
+ATOM   1601 C CE2 . PHE A 1 213 ? 0.024   12.492 38.828  1.00 12.58 ? 213 PHE A CE2 1 
+ATOM   1602 C CZ  . PHE A 1 213 ? -0.767  13.479 39.396  1.00 13.62 ? 213 PHE A CZ  1 
+ATOM   1603 N N   . ARG A 1 214 ? 4.493   16.534 35.103  1.00 9.30  ? 214 ARG A N   1 
+ATOM   1604 C CA  . ARG A 1 214 ? 5.829   16.880 34.627  1.00 9.29  ? 214 ARG A CA  1 
+ATOM   1605 C C   . ARG A 1 214 ? 6.152   18.291 35.116  1.00 8.41  ? 214 ARG A C   1 
+ATOM   1606 O O   . ARG A 1 214 ? 7.278   18.570 35.517  1.00 9.49  ? 214 ARG A O   1 
+ATOM   1607 C CB  . ARG A 1 214 ? 5.911   16.811 33.097  1.00 10.86 ? 214 ARG A CB  1 
+ATOM   1608 C CG  . ARG A 1 214 ? 6.108   15.394 32.566  1.00 12.80 ? 214 ARG A CG  1 
+ATOM   1609 C CD  . ARG A 1 214 ? 6.056   15.360 31.045  1.00 15.18 ? 214 ARG A CD  1 
+ATOM   1610 N NE  . ARG A 1 214 ? 6.227   14.017 30.489  1.00 17.21 ? 214 ARG A NE  1 
+ATOM   1611 C CZ  . ARG A 1 214 ? 7.398   13.414 30.302  1.00 18.86 ? 214 ARG A CZ  1 
+ATOM   1612 N NH1 . ARG A 1 214 ? 8.533   14.024 30.628  1.00 18.72 ? 214 ARG A NH1 1 
+ATOM   1613 N NH2 . ARG A 1 214 ? 7.436   12.200 29.764  1.00 20.09 ? 214 ARG A NH2 1 
+ATOM   1614 N N   . ILE A 1 215 ? 5.160   19.177 35.087  1.00 7.69  ? 215 ILE A N   1 
+ATOM   1615 C CA  . ILE A 1 215 ? 5.352   20.543 35.576  1.00 6.80  ? 215 ILE A CA  1 
+ATOM   1616 C C   . ILE A 1 215 ? 5.666   20.471 37.069  1.00 7.42  ? 215 ILE A C   1 
+ATOM   1617 O O   . ILE A 1 215 ? 6.618   21.082 37.544  1.00 7.81  ? 215 ILE A O   1 
+ATOM   1618 C CB  . ILE A 1 215 ? 4.074   21.400 35.399  1.00 6.52  ? 215 ILE A CB  1 
+ATOM   1619 C CG1 . ILE A 1 215 ? 3.809   21.654 33.914  1.00 4.74  ? 215 ILE A CG1 1 
+ATOM   1620 C CG2 . ILE A 1 215 ? 4.233   22.745 36.119  1.00 6.18  ? 215 ILE A CG2 1 
+ATOM   1621 C CD1 . ILE A 1 215 ? 2.474   22.325 33.647  1.00 5.36  ? 215 ILE A CD1 1 
+ATOM   1622 N N   . PHE A 1 216 ? 4.852   19.711 37.800  1.00 8.33  ? 216 PHE A N   1 
+ATOM   1623 C CA  . PHE A 1 216 ? 5.028   19.559 39.242  1.00 9.39  ? 216 PHE A CA  1 
+ATOM   1624 C C   . PHE A 1 216 ? 6.399   19.005 39.613  1.00 9.46  ? 216 PHE A C   1 
+ATOM   1625 O O   . PHE A 1 216 ? 7.006   19.445 40.586  1.00 9.75  ? 216 PHE A O   1 
+ATOM   1626 C CB  . PHE A 1 216 ? 3.959   18.624 39.825  1.00 9.17  ? 216 PHE A CB  1 
+ATOM   1627 C CG  . PHE A 1 216 ? 2.569   19.211 39.869  1.00 10.27 ? 216 PHE A CG  1 
+ATOM   1628 C CD1 . PHE A 1 216 ? 2.294   20.471 39.345  1.00 10.09 ? 216 PHE A CD1 1 
+ATOM   1629 C CD2 . PHE A 1 216 ? 1.523   18.476 40.424  1.00 10.80 ? 216 PHE A CD2 1 
+ATOM   1630 C CE1 . PHE A 1 216 ? 0.999   20.992 39.372  1.00 11.07 ? 216 PHE A CE1 1 
+ATOM   1631 C CE2 . PHE A 1 216 ? 0.223   18.986 40.458  1.00 10.68 ? 216 PHE A CE2 1 
+ATOM   1632 C CZ  . PHE A 1 216 ? -0.041  20.247 39.931  1.00 10.94 ? 216 PHE A CZ  1 
+ATOM   1633 N N   . ARG A 1 217 ? 6.874   18.029 38.845  1.00 11.38 ? 217 ARG A N   1 
+ATOM   1634 C CA  . ARG A 1 217 ? 8.167   17.400 39.110  1.00 12.79 ? 217 ARG A CA  1 
+ATOM   1635 C C   . ARG A 1 217 ? 9.319   18.392 39.055  1.00 13.07 ? 217 ARG A C   1 
+ATOM   1636 O O   . ARG A 1 217 ? 10.285  18.287 39.816  1.00 12.95 ? 217 ARG A O   1 
+ATOM   1637 C CB  . ARG A 1 217 ? 8.425   16.280 38.099  1.00 15.34 ? 217 ARG A CB  1 
+ATOM   1638 C CG  . ARG A 1 217 ? 7.471   15.103 38.212  1.00 20.23 ? 217 ARG A CG  1 
+ATOM   1639 C CD  . ARG A 1 217 ? 7.484   14.252 36.942  1.00 24.62 ? 217 ARG A CD  1 
+ATOM   1640 N NE  . ARG A 1 217 ? 6.450   13.221 36.973  1.00 27.27 ? 217 ARG A NE  1 
+ATOM   1641 C CZ  . ARG A 1 217 ? 5.950   12.623 35.896  1.00 29.42 ? 217 ARG A CZ  1 
+ATOM   1642 N NH1 . ARG A 1 217 ? 6.383   12.950 34.684  1.00 30.25 ? 217 ARG A NH1 1 
+ATOM   1643 N NH2 . ARG A 1 217 ? 5.011   11.696 36.031  1.00 30.20 ? 217 ARG A NH2 1 
+ATOM   1644 N N   . THR A 1 218 ? 9.221   19.353 38.146  1.00 12.61 ? 218 THR A N   1 
+ATOM   1645 C CA  . THR A 1 218 ? 10.270  20.349 37.989  1.00 12.51 ? 218 THR A CA  1 
+ATOM   1646 C C   . THR A 1 218 ? 10.117  21.550 38.910  1.00 11.84 ? 218 THR A C   1 
+ATOM   1647 O O   . THR A 1 218 ? 11.054  21.925 39.617  1.00 12.43 ? 218 THR A O   1 
+ATOM   1648 C CB  . THR A 1 218 ? 10.327  20.869 36.536  1.00 13.83 ? 218 THR A CB  1 
+ATOM   1649 O OG1 . THR A 1 218 ? 10.809  19.831 35.673  1.00 16.04 ? 218 THR A OG1 1 
+ATOM   1650 C CG2 . THR A 1 218 ? 11.249  22.087 36.435  1.00 13.92 ? 218 THR A CG2 1 
+ATOM   1651 N N   . LEU A 1 219 ? 8.932   22.149 38.900  1.00 10.75 ? 219 LEU A N   1 
+ATOM   1652 C CA  . LEU A 1 219 ? 8.675   23.342 39.692  1.00 10.83 ? 219 LEU A CA  1 
+ATOM   1653 C C   . LEU A 1 219 ? 8.152   23.081 41.098  1.00 10.61 ? 219 LEU A C   1 
+ATOM   1654 O O   . LEU A 1 219 ? 8.008   24.009 41.891  1.00 10.52 ? 219 LEU A O   1 
+ATOM   1655 C CB  . LEU A 1 219 ? 7.701   24.247 38.931  1.00 10.82 ? 219 LEU A CB  1 
+ATOM   1656 C CG  . LEU A 1 219 ? 8.138   24.600 37.503  1.00 10.06 ? 219 LEU A CG  1 
+ATOM   1657 C CD1 . LEU A 1 219 ? 7.094   25.491 36.844  1.00 9.63  ? 219 LEU A CD1 1 
+ATOM   1658 C CD2 . LEU A 1 219 ? 9.489   25.309 37.541  1.00 11.24 ? 219 LEU A CD2 1 
+ATOM   1659 N N   . GLY A 1 220 ? 7.891   21.816 41.405  1.00 10.03 ? 220 GLY A N   1 
+ATOM   1660 C CA  . GLY A 1 220 ? 7.381   21.464 42.714  1.00 8.94  ? 220 GLY A CA  1 
+ATOM   1661 C C   . GLY A 1 220 ? 5.868   21.477 42.687  1.00 9.80  ? 220 GLY A C   1 
+ATOM   1662 O O   . GLY A 1 220 ? 5.262   22.265 41.955  1.00 8.34  ? 220 GLY A O   1 
+ATOM   1663 N N   . THR A 1 221 ? 5.246   20.593 43.462  1.00 8.39  ? 221 THR A N   1 
+ATOM   1664 C CA  . THR A 1 221 ? 3.789   20.552 43.504  1.00 9.85  ? 221 THR A CA  1 
+ATOM   1665 C C   . THR A 1 221 ? 3.309   21.825 44.189  1.00 9.92  ? 221 THR A C   1 
+ATOM   1666 O O   . THR A 1 221 ? 3.660   22.089 45.338  1.00 10.00 ? 221 THR A O   1 
+ATOM   1667 C CB  . THR A 1 221 ? 3.291   19.332 44.293  1.00 10.17 ? 221 THR A CB  1 
+ATOM   1668 O OG1 . THR A 1 221 ? 3.712   18.137 43.628  1.00 10.40 ? 221 THR A OG1 1 
+ATOM   1669 C CG2 . THR A 1 221 ? 1.764   19.347 44.405  1.00 11.55 ? 221 THR A CG2 1 
+ATOM   1670 N N   . PRO A 1 222 ? 2.492   22.631 43.492  1.00 10.30 ? 222 PRO A N   1 
+ATOM   1671 C CA  . PRO A 1 222 ? 1.985   23.879 44.065  1.00 10.69 ? 222 PRO A CA  1 
+ATOM   1672 C C   . PRO A 1 222 ? 1.109   23.694 45.296  1.00 11.91 ? 222 PRO A C   1 
+ATOM   1673 O O   . PRO A 1 222 ? 0.420   22.688 45.437  1.00 11.58 ? 222 PRO A O   1 
+ATOM   1674 C CB  . PRO A 1 222 ? 1.224   24.509 42.896  1.00 10.30 ? 222 PRO A CB  1 
+ATOM   1675 C CG  . PRO A 1 222 ? 0.703   23.328 42.162  1.00 10.12 ? 222 PRO A CG  1 
+ATOM   1676 C CD  . PRO A 1 222 ? 1.893   22.378 42.170  1.00 10.18 ? 222 PRO A CD  1 
+ATOM   1677 N N   . ASP A 1 223 ? 1.159   24.675 46.190  1.00 12.53 ? 223 ASP A N   1 
+ATOM   1678 C CA  . ASP A 1 223 ? 0.357   24.663 47.406  1.00 13.96 ? 223 ASP A CA  1 
+ATOM   1679 C C   . ASP A 1 223 ? -0.093  26.092 47.668  1.00 13.56 ? 223 ASP A C   1 
+ATOM   1680 O O   . ASP A 1 223 ? 0.246   26.997 46.908  1.00 12.47 ? 223 ASP A O   1 
+ATOM   1681 C CB  . ASP A 1 223 ? 1.161   24.141 48.604  1.00 16.32 ? 223 ASP A CB  1 
+ATOM   1682 C CG  . ASP A 1 223 ? 2.472   24.883 48.807  1.00 17.99 ? 223 ASP A CG  1 
+ATOM   1683 O OD1 . ASP A 1 223 ? 2.556   26.077 48.458  1.00 19.40 ? 223 ASP A OD1 1 
+ATOM   1684 O OD2 . ASP A 1 223 ? 3.424   24.268 49.335  1.00 19.87 ? 223 ASP A OD2 1 
+ATOM   1685 N N   . GLU A 1 224 ? -0.851  26.293 48.742  1.00 13.52 ? 224 GLU A N   1 
+ATOM   1686 C CA  . GLU A 1 224 ? -1.343  27.623 49.084  1.00 13.87 ? 224 GLU A CA  1 
+ATOM   1687 C C   . GLU A 1 224 ? -0.229  28.636 49.348  1.00 14.02 ? 224 GLU A C   1 
+ATOM   1688 O O   . GLU A 1 224 ? -0.440  29.841 49.210  1.00 13.94 ? 224 GLU A O   1 
+ATOM   1689 C CB  . GLU A 1 224 ? -2.259  27.544 50.308  1.00 14.35 ? 224 GLU A CB  1 
+ATOM   1690 C CG  . GLU A 1 224 ? -3.583  26.846 50.060  1.00 13.91 ? 224 GLU A CG  1 
+ATOM   1691 C CD  . GLU A 1 224 ? -4.449  27.575 49.050  1.00 12.81 ? 224 GLU A CD  1 
+ATOM   1692 O OE1 . GLU A 1 224 ? -4.485  28.823 49.085  1.00 12.17 ? 224 GLU A OE1 1 
+ATOM   1693 O OE2 . GLU A 1 224 ? -5.105  26.900 48.228  1.00 14.22 ? 224 GLU A OE2 1 
+ATOM   1694 N N   . VAL A 1 225 ? 0.952   28.154 49.729  1.00 14.65 ? 225 VAL A N   1 
+ATOM   1695 C CA  . VAL A 1 225 ? 2.080   29.043 50.004  1.00 15.04 ? 225 VAL A CA  1 
+ATOM   1696 C C   . VAL A 1 225 ? 2.537   29.801 48.758  1.00 15.11 ? 225 VAL A C   1 
+ATOM   1697 O O   . VAL A 1 225 ? 2.671   31.028 48.780  1.00 15.55 ? 225 VAL A O   1 
+ATOM   1698 C CB  . VAL A 1 225 ? 3.299   28.267 50.571  1.00 16.23 ? 225 VAL A CB  1 
+ATOM   1699 C CG1 . VAL A 1 225 ? 4.496   29.208 50.716  1.00 17.76 ? 225 VAL A CG1 1 
+ATOM   1700 C CG2 . VAL A 1 225 ? 2.947   27.654 51.924  1.00 17.08 ? 225 VAL A CG2 1 
+ATOM   1701 N N   . VAL A 1 226 ? 2.776   29.072 47.674  1.00 14.31 ? 226 VAL A N   1 
+ATOM   1702 C CA  . VAL A 1 226 ? 3.235   29.698 46.441  1.00 14.20 ? 226 VAL A CA  1 
+ATOM   1703 C C   . VAL A 1 226 ? 2.102   30.106 45.505  1.00 13.72 ? 226 VAL A C   1 
+ATOM   1704 O O   . VAL A 1 226 ? 2.276   30.996 44.671  1.00 14.33 ? 226 VAL A O   1 
+ATOM   1705 C CB  . VAL A 1 226 ? 4.205   28.765 45.667  1.00 14.85 ? 226 VAL A CB  1 
+ATOM   1706 C CG1 . VAL A 1 226 ? 5.386   28.397 46.555  1.00 16.09 ? 226 VAL A CG1 1 
+ATOM   1707 C CG2 . VAL A 1 226 ? 3.475   27.512 45.192  1.00 15.04 ? 226 VAL A CG2 1 
+ATOM   1708 N N   . TRP A 1 227 ? 0.941   29.473 45.654  1.00 12.61 ? 227 TRP A N   1 
+ATOM   1709 C CA  . TRP A 1 227 ? -0.202  29.767 44.792  1.00 12.41 ? 227 TRP A CA  1 
+ATOM   1710 C C   . TRP A 1 227 ? -1.517  29.796 45.572  1.00 13.61 ? 227 TRP A C   1 
+ATOM   1711 O O   . TRP A 1 227 ? -2.262  28.810 45.590  1.00 13.75 ? 227 TRP A O   1 
+ATOM   1712 C CB  . TRP A 1 227 ? -0.289  28.708 43.685  1.00 12.02 ? 227 TRP A CB  1 
+ATOM   1713 C CG  . TRP A 1 227 ? -1.308  28.988 42.615  1.00 10.71 ? 227 TRP A CG  1 
+ATOM   1714 C CD1 . TRP A 1 227 ? -2.238  29.991 42.598  1.00 11.18 ? 227 TRP A CD1 1 
+ATOM   1715 C CD2 . TRP A 1 227 ? -1.493  28.247 41.404  1.00 10.01 ? 227 TRP A CD2 1 
+ATOM   1716 N NE1 . TRP A 1 227 ? -2.993  29.918 41.446  1.00 11.80 ? 227 TRP A NE1 1 
+ATOM   1717 C CE2 . TRP A 1 227 ? -2.555  28.857 40.696  1.00 11.13 ? 227 TRP A CE2 1 
+ATOM   1718 C CE3 . TRP A 1 227 ? -0.865  27.125 40.847  1.00 10.47 ? 227 TRP A CE3 1 
+ATOM   1719 C CZ2 . TRP A 1 227 ? -3.002  28.381 39.456  1.00 12.01 ? 227 TRP A CZ2 1 
+ATOM   1720 C CZ3 . TRP A 1 227 ? -1.310  26.650 39.611  1.00 10.93 ? 227 TRP A CZ3 1 
+ATOM   1721 C CH2 . TRP A 1 227 ? -2.368  27.280 38.931  1.00 12.16 ? 227 TRP A CH2 1 
+ATOM   1722 N N   . PRO A 1 228 ? -1.824  30.929 46.223  1.00 13.67 ? 228 PRO A N   1 
+ATOM   1723 C CA  . PRO A 1 228 ? -3.068  31.042 46.994  1.00 14.37 ? 228 PRO A CA  1 
+ATOM   1724 C C   . PRO A 1 228 ? -4.281  30.689 46.141  1.00 14.82 ? 228 PRO A C   1 
+ATOM   1725 O O   . PRO A 1 228 ? -4.431  31.195 45.025  1.00 14.57 ? 228 PRO A O   1 
+ATOM   1726 C CB  . PRO A 1 228 ? -3.076  32.507 47.422  1.00 14.26 ? 228 PRO A CB  1 
+ATOM   1727 C CG  . PRO A 1 228 ? -1.610  32.812 47.566  1.00 14.42 ? 228 PRO A CG  1 
+ATOM   1728 C CD  . PRO A 1 228 ? -1.028  32.163 46.328  1.00 13.78 ? 228 PRO A CD  1 
+ATOM   1729 N N   . GLY A 1 229 ? -5.136  29.815 46.668  1.00 15.12 ? 229 GLY A N   1 
+ATOM   1730 C CA  . GLY A 1 229 ? -6.330  29.409 45.948  1.00 14.70 ? 229 GLY A CA  1 
+ATOM   1731 C C   . GLY A 1 229 ? -6.177  28.176 45.069  1.00 15.82 ? 229 GLY A C   1 
+ATOM   1732 O O   . GLY A 1 229 ? -7.167  27.643 44.561  1.00 15.78 ? 229 GLY A O   1 
+ATOM   1733 N N   . VAL A 1 230 ? -4.949  27.703 44.885  1.00 15.02 ? 230 VAL A N   1 
+ATOM   1734 C CA  . VAL A 1 230 ? -4.741  26.539 44.034  1.00 15.19 ? 230 VAL A CA  1 
+ATOM   1735 C C   . VAL A 1 230 ? -5.509  25.294 44.490  1.00 16.07 ? 230 VAL A C   1 
+ATOM   1736 O O   . VAL A 1 230 ? -6.038  24.556 43.657  1.00 14.96 ? 230 VAL A O   1 
+ATOM   1737 C CB  . VAL A 1 230 ? -3.234  26.185 43.907  1.00 14.03 ? 230 VAL A CB  1 
+ATOM   1738 C CG1 . VAL A 1 230 ? -2.679  25.690 45.240  1.00 13.20 ? 230 VAL A CG1 1 
+ATOM   1739 C CG2 . VAL A 1 230 ? -3.045  25.138 42.824  1.00 14.40 ? 230 VAL A CG2 1 
+ATOM   1740 N N   . THR A 1 231 ? -5.592  25.071 45.801  1.00 17.76 ? 231 THR A N   1 
+ATOM   1741 C CA  . THR A 1 231 ? -6.280  23.885 46.321  1.00 18.74 ? 231 THR A CA  1 
+ATOM   1742 C C   . THR A 1 231 ? -7.796  23.907 46.149  1.00 20.00 ? 231 THR A C   1 
+ATOM   1743 O O   . THR A 1 231 ? -8.463  22.905 46.402  1.00 20.89 ? 231 THR A O   1 
+ATOM   1744 C CB  . THR A 1 231 ? -5.975  23.650 47.822  1.00 18.40 ? 231 THR A CB  1 
+ATOM   1745 O OG1 . THR A 1 231 ? -6.434  24.769 48.591  1.00 19.58 ? 231 THR A OG1 1 
+ATOM   1746 C CG2 . THR A 1 231 ? -4.483  23.454 48.045  1.00 17.67 ? 231 THR A CG2 1 
+ATOM   1747 N N   . SER A 1 232 ? -8.342  25.039 45.721  1.00 21.14 ? 232 SER A N   1 
+ATOM   1748 C CA  . SER A 1 232 ? -9.784  25.154 45.530  1.00 22.36 ? 232 SER A CA  1 
+ATOM   1749 C C   . SER A 1 232 ? -10.159 25.136 44.050  1.00 22.46 ? 232 SER A C   1 
+ATOM   1750 O O   . SER A 1 232 ? -11.332 25.268 43.690  1.00 22.64 ? 232 SER A O   1 
+ATOM   1751 C CB  . SER A 1 232 ? -10.298 26.441 46.179  1.00 23.55 ? 232 SER A CB  1 
+ATOM   1752 O OG  . SER A 1 232 ? -9.652  27.578 45.633  1.00 26.75 ? 232 SER A OG  1 
+ATOM   1753 N N   . MET A 1 233 ? -9.161  24.970 43.191  1.00 21.46 ? 233 MET A N   1 
+ATOM   1754 C CA  . MET A 1 233 ? -9.411  24.943 41.761  1.00 20.98 ? 233 MET A CA  1 
+ATOM   1755 C C   . MET A 1 233 ? -10.176 23.691 41.350  1.00 20.09 ? 233 MET A C   1 
+ATOM   1756 O O   . MET A 1 233 ? -10.015 22.630 41.950  1.00 20.14 ? 233 MET A O   1 
+ATOM   1757 C CB  . MET A 1 233 ? -8.090  25.063 41.006  1.00 22.21 ? 233 MET A CB  1 
+ATOM   1758 C CG  . MET A 1 233 ? -7.422  26.403 41.264  1.00 24.72 ? 233 MET A CG  1 
+ATOM   1759 S SD  . MET A 1 233 ? -6.027  26.722 40.198  1.00 27.21 ? 233 MET A SD  1 
+ATOM   1760 C CE  . MET A 1 233 ? -6.881  27.194 38.696  1.00 26.36 ? 233 MET A CE  1 
+ATOM   1761 N N   . PRO A 1 234 ? -11.027 23.809 40.318  1.00 19.52 ? 234 PRO A N   1 
+ATOM   1762 C CA  . PRO A 1 234 ? -11.864 22.735 39.774  1.00 18.86 ? 234 PRO A CA  1 
+ATOM   1763 C C   . PRO A 1 234 ? -11.289 21.323 39.756  1.00 18.37 ? 234 PRO A C   1 
+ATOM   1764 O O   . PRO A 1 234 ? -11.901 20.398 40.291  1.00 17.87 ? 234 PRO A O   1 
+ATOM   1765 C CB  . PRO A 1 234 ? -12.196 23.241 38.375  1.00 18.83 ? 234 PRO A CB  1 
+ATOM   1766 C CG  . PRO A 1 234 ? -12.345 24.711 38.609  1.00 19.07 ? 234 PRO A CG  1 
+ATOM   1767 C CD  . PRO A 1 234 ? -11.149 25.025 39.489  1.00 19.64 ? 234 PRO A CD  1 
+ATOM   1768 N N   . ASP A 1 235 ? -10.120 21.155 39.147  1.00 16.44 ? 235 ASP A N   1 
+ATOM   1769 C CA  . ASP A 1 235 ? -9.516  19.834 39.044  1.00 16.44 ? 235 ASP A CA  1 
+ATOM   1770 C C   . ASP A 1 235 ? -8.364  19.539 39.997  1.00 15.78 ? 235 ASP A C   1 
+ATOM   1771 O O   . ASP A 1 235 ? -7.662  18.539 39.833  1.00 16.03 ? 235 ASP A O   1 
+ATOM   1772 C CB  . ASP A 1 235 ? -9.075  19.588 37.599  1.00 16.98 ? 235 ASP A CB  1 
+ATOM   1773 C CG  . ASP A 1 235 ? -10.220 19.735 36.614  1.00 18.26 ? 235 ASP A CG  1 
+ATOM   1774 O OD1 . ASP A 1 235 ? -11.341 19.295 36.939  1.00 19.26 ? 235 ASP A OD1 1 
+ATOM   1775 O OD2 . ASP A 1 235 ? -10.001 20.282 35.516  1.00 19.19 ? 235 ASP A OD2 1 
+ATOM   1776 N N   . TYR A 1 236 ? -8.161  20.397 40.992  1.00 15.74 ? 236 TYR A N   1 
+ATOM   1777 C CA  . TYR A 1 236 ? -7.094  20.161 41.955  1.00 15.50 ? 236 TYR A CA  1 
+ATOM   1778 C C   . TYR A 1 236 ? -7.501  18.959 42.811  1.00 15.63 ? 236 TYR A C   1 
+ATOM   1779 O O   . TYR A 1 236 ? -8.672  18.795 43.134  1.00 15.78 ? 236 TYR A O   1 
+ATOM   1780 C CB  . TYR A 1 236 ? -6.893  21.373 42.864  1.00 15.94 ? 236 TYR A CB  1 
+ATOM   1781 C CG  . TYR A 1 236 ? -5.931  21.092 43.993  1.00 17.29 ? 236 TYR A CG  1 
+ATOM   1782 C CD1 . TYR A 1 236 ? -4.553  21.211 43.812  1.00 17.67 ? 236 TYR A CD1 1 
+ATOM   1783 C CD2 . TYR A 1 236 ? -6.396  20.637 45.226  1.00 17.38 ? 236 TYR A CD2 1 
+ATOM   1784 C CE1 . TYR A 1 236 ? -3.662  20.877 44.835  1.00 18.11 ? 236 TYR A CE1 1 
+ATOM   1785 C CE2 . TYR A 1 236 ? -5.521  20.300 46.248  1.00 18.61 ? 236 TYR A CE2 1 
+ATOM   1786 C CZ  . TYR A 1 236 ? -4.159  20.420 46.049  1.00 17.89 ? 236 TYR A CZ  1 
+ATOM   1787 O OH  . TYR A 1 236 ? -3.301  20.075 47.067  1.00 17.89 ? 236 TYR A OH  1 
+ATOM   1788 N N   . LYS A 1 237 ? -6.531  18.129 43.176  1.00 15.50 ? 237 LYS A N   1 
+ATOM   1789 C CA  . LYS A 1 237 ? -6.805  16.946 43.989  1.00 15.26 ? 237 LYS A CA  1 
+ATOM   1790 C C   . LYS A 1 237 ? -5.818  16.889 45.148  1.00 15.25 ? 237 LYS A C   1 
+ATOM   1791 O O   . LYS A 1 237 ? -4.606  16.933 44.935  1.00 14.43 ? 237 LYS A O   1 
+ATOM   1792 C CB  . LYS A 1 237 ? -6.650  15.674 43.147  1.00 15.65 ? 237 LYS A CB  1 
+ATOM   1793 C CG  . LYS A 1 237 ? -7.497  15.624 41.881  1.00 16.11 ? 237 LYS A CG  1 
+ATOM   1794 C CD  . LYS A 1 237 ? -8.968  15.369 42.185  1.00 17.31 ? 237 LYS A CD  1 
+ATOM   1795 C CE  . LYS A 1 237 ? -9.812  15.459 40.913  1.00 18.08 ? 237 LYS A CE  1 
+ATOM   1796 N NZ  . LYS A 1 237 ? -11.240 15.117 41.164  1.00 19.16 ? 237 LYS A NZ  1 
+ATOM   1797 N N   . PRO A 1 238 ? -6.321  16.803 46.392  1.00 15.38 ? 238 PRO A N   1 
+ATOM   1798 C CA  . PRO A 1 238 ? -5.416  16.737 47.543  1.00 14.65 ? 238 PRO A CA  1 
+ATOM   1799 C C   . PRO A 1 238 ? -4.474  15.543 47.405  1.00 14.65 ? 238 PRO A C   1 
+ATOM   1800 O O   . PRO A 1 238 ? -3.387  15.523 47.986  1.00 14.23 ? 238 PRO A O   1 
+ATOM   1801 C CB  . PRO A 1 238 ? -6.372  16.574 48.720  1.00 15.02 ? 238 PRO A CB  1 
+ATOM   1802 C CG  . PRO A 1 238 ? -7.563  17.359 48.284  1.00 15.04 ? 238 PRO A CG  1 
+ATOM   1803 C CD  . PRO A 1 238 ? -7.721  16.931 46.836  1.00 15.69 ? 238 PRO A CD  1 
+ATOM   1804 N N   . SER A 1 239 ? -4.903  14.556 46.622  1.00 13.40 ? 239 SER A N   1 
+ATOM   1805 C CA  . SER A 1 239 ? -4.117  13.347 46.404  1.00 12.79 ? 239 SER A CA  1 
+ATOM   1806 C C   . SER A 1 239 ? -2.947  13.495 45.429  1.00 13.04 ? 239 SER A C   1 
+ATOM   1807 O O   . SER A 1 239 ? -2.225  12.527 45.184  1.00 12.25 ? 239 SER A O   1 
+ATOM   1808 C CB  . SER A 1 239 ? -5.029  12.202 45.945  1.00 12.76 ? 239 SER A CB  1 
+ATOM   1809 O OG  . SER A 1 239 ? -5.807  12.563 44.815  1.00 11.84 ? 239 SER A OG  1 
+ATOM   1810 N N   . PHE A 1 240 ? -2.752  14.690 44.873  1.00 13.55 ? 240 PHE A N   1 
+ATOM   1811 C CA  . PHE A 1 240 ? -1.628  14.906 43.956  1.00 13.10 ? 240 PHE A CA  1 
+ATOM   1812 C C   . PHE A 1 240 ? -0.331  14.560 44.687  1.00 13.58 ? 240 PHE A C   1 
+ATOM   1813 O O   . PHE A 1 240 ? -0.164  14.909 45.853  1.00 12.75 ? 240 PHE A O   1 
+ATOM   1814 C CB  . PHE A 1 240 ? -1.518  16.377 43.515  1.00 13.20 ? 240 PHE A CB  1 
+ATOM   1815 C CG  . PHE A 1 240 ? -2.529  16.806 42.480  1.00 13.60 ? 240 PHE A CG  1 
+ATOM   1816 C CD1 . PHE A 1 240 ? -3.138  15.882 41.634  1.00 13.79 ? 240 PHE A CD1 1 
+ATOM   1817 C CD2 . PHE A 1 240 ? -2.827  18.159 42.320  1.00 13.53 ? 240 PHE A CD2 1 
+ATOM   1818 C CE1 . PHE A 1 240 ? -4.030  16.300 40.640  1.00 14.19 ? 240 PHE A CE1 1 
+ATOM   1819 C CE2 . PHE A 1 240 ? -3.717  18.588 41.329  1.00 13.79 ? 240 PHE A CE2 1 
+ATOM   1820 C CZ  . PHE A 1 240 ? -4.319  17.657 40.489  1.00 13.66 ? 240 PHE A CZ  1 
+ATOM   1821 N N   . PRO A 1 241 ? 0.596   13.855 44.023  1.00 13.72 ? 241 PRO A N   1 
+ATOM   1822 C CA  . PRO A 1 241 ? 1.852   13.527 44.706  1.00 14.86 ? 241 PRO A CA  1 
+ATOM   1823 C C   . PRO A 1 241 ? 2.566   14.840 45.030  1.00 15.23 ? 241 PRO A C   1 
+ATOM   1824 O O   . PRO A 1 241 ? 2.404   15.829 44.308  1.00 14.87 ? 241 PRO A O   1 
+ATOM   1825 C CB  . PRO A 1 241 ? 2.609   12.709 43.663  1.00 14.37 ? 241 PRO A CB  1 
+ATOM   1826 C CG  . PRO A 1 241 ? 1.501   12.028 42.914  1.00 15.20 ? 241 PRO A CG  1 
+ATOM   1827 C CD  . PRO A 1 241 ? 0.494   13.140 42.739  1.00 14.79 ? 241 PRO A CD  1 
+ATOM   1828 N N   . LYS A 1 242 ? 3.353   14.852 46.101  1.00 15.92 ? 242 LYS A N   1 
+ATOM   1829 C CA  . LYS A 1 242 ? 4.066   16.058 46.501  1.00 17.32 ? 242 LYS A CA  1 
+ATOM   1830 C C   . LYS A 1 242 ? 5.541   16.032 46.118  1.00 17.75 ? 242 LYS A C   1 
+ATOM   1831 O O   . LYS A 1 242 ? 6.360   15.381 46.773  1.00 17.74 ? 242 LYS A O   1 
+ATOM   1832 C CB  . LYS A 1 242 ? 3.926   16.279 48.009  1.00 19.23 ? 242 LYS A CB  1 
+ATOM   1833 C CG  . LYS A 1 242 ? 2.507   16.595 48.456  1.00 21.83 ? 242 LYS A CG  1 
+ATOM   1834 C CD  . LYS A 1 242 ? 2.416   16.704 49.968  1.00 24.76 ? 242 LYS A CD  1 
+ATOM   1835 C CE  . LYS A 1 242 ? 0.998   17.025 50.416  1.00 26.02 ? 242 LYS A CE  1 
+ATOM   1836 N NZ  . LYS A 1 242 ? 0.885   16.998 51.902  1.00 27.98 ? 242 LYS A NZ  1 
+ATOM   1837 N N   . TRP A 1 243 ? 5.866   16.739 45.041  1.00 16.68 ? 243 TRP A N   1 
+ATOM   1838 C CA  . TRP A 1 243 ? 7.236   16.841 44.554  1.00 16.74 ? 243 TRP A CA  1 
+ATOM   1839 C C   . TRP A 1 243 ? 7.822   18.159 45.047  1.00 16.20 ? 243 TRP A C   1 
+ATOM   1840 O O   . TRP A 1 243 ? 7.139   19.183 45.050  1.00 14.12 ? 243 TRP A O   1 
+ATOM   1841 C CB  . TRP A 1 243 ? 7.265   16.842 43.024  1.00 17.67 ? 243 TRP A CB  1 
+ATOM   1842 C CG  . TRP A 1 243 ? 7.105   15.498 42.369  1.00 19.84 ? 243 TRP A CG  1 
+ATOM   1843 C CD1 . TRP A 1 243 ? 8.049   14.511 42.277  1.00 21.53 ? 243 TRP A CD1 1 
+ATOM   1844 C CD2 . TRP A 1 243 ? 5.947   15.009 41.681  1.00 20.55 ? 243 TRP A CD2 1 
+ATOM   1845 N NE1 . TRP A 1 243 ? 7.551   13.440 41.570  1.00 22.04 ? 243 TRP A NE1 1 
+ATOM   1846 C CE2 . TRP A 1 243 ? 6.263   13.718 41.193  1.00 21.62 ? 243 TRP A CE2 1 
+ATOM   1847 C CE3 . TRP A 1 243 ? 4.672   15.535 41.428  1.00 19.84 ? 243 TRP A CE3 1 
+ATOM   1848 C CZ2 . TRP A 1 243 ? 5.349   12.946 40.465  1.00 21.47 ? 243 TRP A CZ2 1 
+ATOM   1849 C CZ3 . TRP A 1 243 ? 3.763   14.767 40.704  1.00 20.62 ? 243 TRP A CZ3 1 
+ATOM   1850 C CH2 . TRP A 1 243 ? 4.108   13.486 40.231  1.00 21.05 ? 243 TRP A CH2 1 
+ATOM   1851 N N   . ALA A 1 244 ? 9.083   18.131 45.466  1.00 16.20 ? 244 ALA A N   1 
+ATOM   1852 C CA  . ALA A 1 244 ? 9.758   19.340 45.924  1.00 17.32 ? 244 ALA A CA  1 
+ATOM   1853 C C   . ALA A 1 244 ? 10.374  20.000 44.690  1.00 18.05 ? 244 ALA A C   1 
+ATOM   1854 O O   . ALA A 1 244 ? 10.876  19.316 43.801  1.00 18.85 ? 244 ALA A O   1 
+ATOM   1855 C CB  . ALA A 1 244 ? 10.847  18.986 46.940  1.00 18.44 ? 244 ALA A CB  1 
+ATOM   1856 N N   . ARG A 1 245 ? 10.319  21.325 44.628  1.00 18.59 ? 245 ARG A N   1 
+ATOM   1857 C CA  . ARG A 1 245 ? 10.868  22.061 43.493  1.00 19.81 ? 245 ARG A CA  1 
+ATOM   1858 C C   . ARG A 1 245 ? 12.355  21.745 43.358  1.00 20.58 ? 245 ARG A C   1 
+ATOM   1859 O O   . ARG A 1 245 ? 13.099  21.801 44.338  1.00 19.71 ? 245 ARG A O   1 
+ATOM   1860 C CB  . ARG A 1 245 ? 10.671  23.565 43.708  1.00 19.56 ? 245 ARG A CB  1 
+ATOM   1861 C CG  . ARG A 1 245 ? 11.063  24.456 42.529  1.00 20.19 ? 245 ARG A CG  1 
+ATOM   1862 C CD  . ARG A 1 245 ? 10.919  25.925 42.924  1.00 19.85 ? 245 ARG A CD  1 
+ATOM   1863 N NE  . ARG A 1 245 ? 11.193  26.865 41.837  1.00 19.88 ? 245 ARG A NE  1 
+ATOM   1864 C CZ  . ARG A 1 245 ? 10.317  27.225 40.902  1.00 19.62 ? 245 ARG A CZ  1 
+ATOM   1865 N NH1 . ARG A 1 245 ? 9.085   26.725 40.899  1.00 18.04 ? 245 ARG A NH1 1 
+ATOM   1866 N NH2 . ARG A 1 245 ? 10.669  28.112 39.978  1.00 19.43 ? 245 ARG A NH2 1 
+ATOM   1867 N N   . GLN A 1 246 ? 12.785  21.408 42.147  1.00 21.75 ? 246 GLN A N   1 
+ATOM   1868 C CA  . GLN A 1 246 ? 14.189  21.090 41.920  1.00 23.03 ? 246 GLN A CA  1 
+ATOM   1869 C C   . GLN A 1 246 ? 15.005  22.357 41.651  1.00 22.60 ? 246 GLN A C   1 
+ATOM   1870 O O   . GLN A 1 246 ? 14.447  23.418 41.361  1.00 21.54 ? 246 GLN A O   1 
+ATOM   1871 C CB  . GLN A 1 246 ? 14.329  20.108 40.751  1.00 25.15 ? 246 GLN A CB  1 
+ATOM   1872 C CG  . GLN A 1 246 ? 14.170  20.714 39.368  1.00 28.90 ? 246 GLN A CG  1 
+ATOM   1873 C CD  . GLN A 1 246 ? 14.149  19.656 38.271  1.00 31.13 ? 246 GLN A CD  1 
+ATOM   1874 O OE1 . GLN A 1 246 ? 14.893  18.675 38.323  1.00 33.36 ? 246 GLN A OE1 1 
+ATOM   1875 N NE2 . GLN A 1 246 ? 13.301  19.858 37.268  1.00 31.60 ? 246 GLN A NE2 1 
+ATOM   1876 N N   . ASP A 1 247 ? 16.326  22.239 41.764  1.00 21.63 ? 247 ASP A N   1 
+ATOM   1877 C CA  . ASP A 1 247 ? 17.231  23.365 41.532  1.00 22.03 ? 247 ASP A CA  1 
+ATOM   1878 C C   . ASP A 1 247 ? 16.963  23.926 40.135  1.00 20.92 ? 247 ASP A C   1 
+ATOM   1879 O O   . ASP A 1 247 ? 17.082  23.203 39.150  1.00 20.65 ? 247 ASP A O   1 
+ATOM   1880 C CB  . ASP A 1 247 ? 18.683  22.887 41.621  1.00 23.29 ? 247 ASP A CB  1 
+ATOM   1881 C CG  . ASP A 1 247 ? 19.672  24.031 41.723  1.00 24.82 ? 247 ASP A CG  1 
+ATOM   1882 O OD1 . ASP A 1 247 ? 19.416  25.102 41.133  1.00 24.93 ? 247 ASP A OD1 1 
+ATOM   1883 O OD2 . ASP A 1 247 ? 20.713  23.851 42.387  1.00 25.87 ? 247 ASP A OD2 1 
+ATOM   1884 N N   . PHE A 1 248 ? 16.621  25.210 40.054  1.00 20.86 ? 248 PHE A N   1 
+ATOM   1885 C CA  . PHE A 1 248 ? 16.309  25.857 38.776  1.00 21.51 ? 248 PHE A CA  1 
+ATOM   1886 C C   . PHE A 1 248 ? 17.474  25.942 37.787  1.00 21.41 ? 248 PHE A C   1 
+ATOM   1887 O O   . PHE A 1 248 ? 17.253  26.067 36.581  1.00 21.04 ? 248 PHE A O   1 
+ATOM   1888 C CB  . PHE A 1 248 ? 15.760  27.268 39.017  1.00 21.85 ? 248 PHE A CB  1 
+ATOM   1889 C CG  . PHE A 1 248 ? 14.922  27.800 37.881  1.00 22.59 ? 248 PHE A CG  1 
+ATOM   1890 C CD1 . PHE A 1 248 ? 13.624  27.339 37.684  1.00 22.60 ? 248 PHE A CD1 1 
+ATOM   1891 C CD2 . PHE A 1 248 ? 15.431  28.757 37.006  1.00 22.69 ? 248 PHE A CD2 1 
+ATOM   1892 C CE1 . PHE A 1 248 ? 12.842  27.824 36.632  1.00 23.69 ? 248 PHE A CE1 1 
+ATOM   1893 C CE2 . PHE A 1 248 ? 14.659  29.248 35.952  1.00 22.49 ? 248 PHE A CE2 1 
+ATOM   1894 C CZ  . PHE A 1 248 ? 13.362  28.781 35.764  1.00 22.19 ? 248 PHE A CZ  1 
+ATOM   1895 N N   . SER A 1 249 ? 18.705  25.890 38.289  1.00 21.11 ? 249 SER A N   1 
+ATOM   1896 C CA  . SER A 1 249 ? 19.886  25.956 37.425  1.00 21.49 ? 249 SER A CA  1 
+ATOM   1897 C C   . SER A 1 249 ? 19.984  24.674 36.603  1.00 21.19 ? 249 SER A C   1 
+ATOM   1898 O O   . SER A 1 249 ? 20.765  24.567 35.657  1.00 21.24 ? 249 SER A O   1 
+ATOM   1899 C CB  . SER A 1 249 ? 21.150  26.125 38.274  1.00 22.38 ? 249 SER A CB  1 
+ATOM   1900 O OG  . SER A 1 249 ? 21.279  25.064 39.202  1.00 22.73 ? 249 SER A OG  1 
+ATOM   1901 N N   . LYS A 1 250 ? 19.163  23.708 36.983  1.00 20.71 ? 250 LYS A N   1 
+ATOM   1902 C CA  . LYS A 1 250 ? 19.099  22.407 36.341  1.00 21.61 ? 250 LYS A CA  1 
+ATOM   1903 C C   . LYS A 1 250 ? 18.180  22.458 35.117  1.00 21.08 ? 250 LYS A C   1 
+ATOM   1904 O O   . LYS A 1 250 ? 18.312  21.651 34.193  1.00 21.61 ? 250 LYS A O   1 
+ATOM   1905 C CB  . LYS A 1 250 ? 18.557  21.415 37.374  1.00 23.11 ? 250 LYS A CB  1 
+ATOM   1906 C CG  . LYS A 1 250 ? 18.521  19.959 36.993  1.00 25.67 ? 250 LYS A CG  1 
+ATOM   1907 C CD  . LYS A 1 250 ? 17.911  19.174 38.155  1.00 26.51 ? 250 LYS A CD  1 
+ATOM   1908 C CE  . LYS A 1 250 ? 17.958  17.682 37.929  1.00 27.81 ? 250 LYS A CE  1 
+ATOM   1909 N NZ  . LYS A 1 250 ? 19.356  17.201 37.843  1.00 28.61 ? 250 LYS A NZ  1 
+ATOM   1910 N N   . VAL A 1 251 ? 17.273  23.432 35.110  1.00 19.70 ? 251 VAL A N   1 
+ATOM   1911 C CA  . VAL A 1 251 ? 16.277  23.579 34.049  1.00 19.34 ? 251 VAL A CA  1 
+ATOM   1912 C C   . VAL A 1 251 ? 16.725  24.081 32.671  1.00 18.00 ? 251 VAL A C   1 
+ATOM   1913 O O   . VAL A 1 251 ? 16.384  23.477 31.653  1.00 17.65 ? 251 VAL A O   1 
+ATOM   1914 C CB  . VAL A 1 251 ? 15.119  24.474 34.527  1.00 19.75 ? 251 VAL A CB  1 
+ATOM   1915 C CG1 . VAL A 1 251 ? 13.953  24.368 33.559  1.00 21.46 ? 251 VAL A CG1 1 
+ATOM   1916 C CG2 . VAL A 1 251 ? 14.693  24.066 35.929  1.00 21.06 ? 251 VAL A CG2 1 
+ATOM   1917 N N   . VAL A 1 252 ? 17.468  25.181 32.616  1.00 15.87 ? 252 VAL A N   1 
+ATOM   1918 C CA  . VAL A 1 252 ? 17.892  25.691 31.317  1.00 14.77 ? 252 VAL A CA  1 
+ATOM   1919 C C   . VAL A 1 252 ? 19.380  25.988 31.158  1.00 14.22 ? 252 VAL A C   1 
+ATOM   1920 O O   . VAL A 1 252 ? 19.757  27.016 30.601  1.00 13.15 ? 252 VAL A O   1 
+ATOM   1921 C CB  . VAL A 1 252 ? 17.099  26.962 30.930  1.00 14.90 ? 252 VAL A CB  1 
+ATOM   1922 C CG1 . VAL A 1 252 ? 15.631  26.614 30.720  1.00 15.25 ? 252 VAL A CG1 1 
+ATOM   1923 C CG2 . VAL A 1 252 ? 17.245  28.021 32.010  1.00 14.45 ? 252 VAL A CG2 1 
+ATOM   1924 N N   . PRO A 1 253 ? 20.252  25.092 31.642  1.00 14.25 ? 253 PRO A N   1 
+ATOM   1925 C CA  . PRO A 1 253 ? 21.671  25.406 31.463  1.00 14.81 ? 253 PRO A CA  1 
+ATOM   1926 C C   . PRO A 1 253 ? 21.968  25.406 29.959  1.00 15.35 ? 253 PRO A C   1 
+ATOM   1927 O O   . PRO A 1 253 ? 21.329  24.674 29.201  1.00 15.59 ? 253 PRO A O   1 
+ATOM   1928 C CB  . PRO A 1 253 ? 22.369  24.266 32.201  1.00 15.11 ? 253 PRO A CB  1 
+ATOM   1929 C CG  . PRO A 1 253 ? 21.427  23.106 31.986  1.00 15.16 ? 253 PRO A CG  1 
+ATOM   1930 C CD  . PRO A 1 253 ? 20.062  23.740 32.198  1.00 14.48 ? 253 PRO A CD  1 
+ATOM   1931 N N   . PRO A 1 254 ? 22.940  26.219 29.508  1.00 15.91 ? 254 PRO A N   1 
+ATOM   1932 C CA  . PRO A 1 254 ? 23.775  27.128 30.295  1.00 15.40 ? 254 PRO A CA  1 
+ATOM   1933 C C   . PRO A 1 254 ? 23.304  28.586 30.229  1.00 15.04 ? 254 PRO A C   1 
+ATOM   1934 O O   . PRO A 1 254 ? 24.126  29.499 30.198  1.00 15.47 ? 254 PRO A O   1 
+ATOM   1935 C CB  . PRO A 1 254 ? 25.137  26.955 29.646  1.00 16.42 ? 254 PRO A CB  1 
+ATOM   1936 C CG  . PRO A 1 254 ? 24.764  26.934 28.196  1.00 15.55 ? 254 PRO A CG  1 
+ATOM   1937 C CD  . PRO A 1 254 ? 23.511  26.048 28.158  1.00 16.11 ? 254 PRO A CD  1 
+ATOM   1938 N N   . LEU A 1 255 ? 21.994  28.805 30.197  1.00 13.35 ? 255 LEU A N   1 
+ATOM   1939 C CA  . LEU A 1 255 ? 21.460  30.164 30.134  1.00 12.13 ? 255 LEU A CA  1 
+ATOM   1940 C C   . LEU A 1 255 ? 21.984  31.006 31.301  1.00 12.02 ? 255 LEU A C   1 
+ATOM   1941 O O   . LEU A 1 255 ? 22.065  30.526 32.437  1.00 10.98 ? 255 LEU A O   1 
+ATOM   1942 C CB  . LEU A 1 255 ? 19.934  30.131 30.170  1.00 11.56 ? 255 LEU A CB  1 
+ATOM   1943 C CG  . LEU A 1 255 ? 19.201  31.456 29.939  1.00 11.35 ? 255 LEU A CG  1 
+ATOM   1944 C CD1 . LEU A 1 255 ? 19.488  31.974 28.528  1.00 12.27 ? 255 LEU A CD1 1 
+ATOM   1945 C CD2 . LEU A 1 255 ? 17.707  31.242 30.137  1.00 9.99  ? 255 LEU A CD2 1 
+ATOM   1946 N N   . ASP A 1 256 ? 22.333  32.260 31.020  1.00 10.99 ? 256 ASP A N   1 
+ATOM   1947 C CA  . ASP A 1 256 ? 22.855  33.151 32.053  1.00 11.53 ? 256 ASP A CA  1 
+ATOM   1948 C C   . ASP A 1 256 ? 21.776  33.556 33.055  1.00 10.96 ? 256 ASP A C   1 
+ATOM   1949 O O   . ASP A 1 256 ? 20.585  33.381 32.802  1.00 10.26 ? 256 ASP A O   1 
+ATOM   1950 C CB  . ASP A 1 256 ? 23.484  34.397 31.413  1.00 10.77 ? 256 ASP A CB  1 
+ATOM   1951 C CG  . ASP A 1 256 ? 22.476  35.249 30.665  1.00 12.24 ? 256 ASP A CG  1 
+ATOM   1952 O OD1 . ASP A 1 256 ? 21.555  35.796 31.305  1.00 10.12 ? 256 ASP A OD1 1 
+ATOM   1953 O OD2 . ASP A 1 256 ? 22.609  35.377 29.430  1.00 12.99 ? 256 ASP A OD2 1 
+ATOM   1954 N N   . GLU A 1 257 ? 22.192  34.095 34.198  1.00 11.02 ? 257 GLU A N   1 
+ATOM   1955 C CA  . GLU A 1 257 ? 21.236  34.492 35.233  1.00 10.19 ? 257 GLU A CA  1 
+ATOM   1956 C C   . GLU A 1 257 ? 20.183  35.508 34.772  1.00 8.88  ? 257 GLU A C   1 
+ATOM   1957 O O   . GLU A 1 257 ? 19.061  35.504 35.286  1.00 8.50  ? 257 GLU A O   1 
+ATOM   1958 C CB  . GLU A 1 257 ? 21.980  35.023 36.465  1.00 11.91 ? 257 GLU A CB  1 
+ATOM   1959 C CG  . GLU A 1 257 ? 21.071  35.438 37.630  1.00 14.81 ? 257 GLU A CG  1 
+ATOM   1960 C CD  . GLU A 1 257 ? 20.260  34.289 38.232  1.00 17.42 ? 257 GLU A CD  1 
+ATOM   1961 O OE1 . GLU A 1 257 ? 20.413  33.130 37.791  1.00 18.71 ? 257 GLU A OE1 1 
+ATOM   1962 O OE2 . GLU A 1 257 ? 19.465  34.551 39.163  1.00 19.30 ? 257 GLU A OE2 1 
+ATOM   1963 N N   . ASP A 1 258 ? 20.519  36.383 33.826  1.00 7.41  ? 258 ASP A N   1 
+ATOM   1964 C CA  . ASP A 1 258 ? 19.512  37.335 33.351  1.00 7.26  ? 258 ASP A CA  1 
+ATOM   1965 C C   . ASP A 1 258 ? 18.384  36.529 32.708  1.00 7.16  ? 258 ASP A C   1 
+ATOM   1966 O O   . ASP A 1 258 ? 17.207  36.768 32.973  1.00 6.16  ? 258 ASP A O   1 
+ATOM   1967 C CB  . ASP A 1 258 ? 20.089  38.318 32.322  1.00 8.32  ? 258 ASP A CB  1 
+ATOM   1968 C CG  . ASP A 1 258 ? 20.871  39.459 32.968  1.00 9.83  ? 258 ASP A CG  1 
+ATOM   1969 O OD1 . ASP A 1 258 ? 20.405  40.007 33.985  1.00 9.69  ? 258 ASP A OD1 1 
+ATOM   1970 O OD2 . ASP A 1 258 ? 21.943  39.817 32.449  1.00 11.15 ? 258 ASP A OD2 1 
+ATOM   1971 N N   . GLY A 1 259 ? 18.756  35.555 31.882  1.00 6.64  ? 259 GLY A N   1 
+ATOM   1972 C CA  . GLY A 1 259 ? 17.759  34.725 31.221  1.00 7.38  ? 259 GLY A CA  1 
+ATOM   1973 C C   . GLY A 1 259 ? 16.975  33.854 32.190  1.00 8.06  ? 259 GLY A C   1 
+ATOM   1974 O O   . GLY A 1 259 ? 15.745  33.780 32.111  1.00 7.62  ? 259 GLY A O   1 
+ATOM   1975 N N   . ARG A 1 260 ? 17.678  33.185 33.103  1.00 8.27  ? 260 ARG A N   1 
+ATOM   1976 C CA  . ARG A 1 260 ? 17.025  32.319 34.086  1.00 9.25  ? 260 ARG A CA  1 
+ATOM   1977 C C   . ARG A 1 260 ? 16.051  33.106 34.956  1.00 8.73  ? 260 ARG A C   1 
+ATOM   1978 O O   . ARG A 1 260 ? 14.962  32.622 35.279  1.00 8.13  ? 260 ARG A O   1 
+ATOM   1979 C CB  . ARG A 1 260 ? 18.068  31.625 34.975  1.00 10.48 ? 260 ARG A CB  1 
+ATOM   1980 C CG  . ARG A 1 260 ? 18.999  30.688 34.210  1.00 14.19 ? 260 ARG A CG  1 
+ATOM   1981 C CD  . ARG A 1 260 ? 19.927  29.913 35.140  1.00 15.65 ? 260 ARG A CD  1 
+ATOM   1982 N NE  . ARG A 1 260 ? 20.761  30.795 35.950  1.00 20.03 ? 260 ARG A NE  1 
+ATOM   1983 C CZ  . ARG A 1 260 ? 21.783  30.382 36.692  1.00 21.25 ? 260 ARG A CZ  1 
+ATOM   1984 N NH1 . ARG A 1 260 ? 22.101  29.094 36.723  1.00 22.86 ? 260 ARG A NH1 1 
+ATOM   1985 N NH2 . ARG A 1 260 ? 22.483  31.253 37.409  1.00 22.56 ? 260 ARG A NH2 1 
+ATOM   1986 N N   . SER A 1 261 ? 16.448  34.318 35.331  1.00 8.58  ? 261 SER A N   1 
+ATOM   1987 C CA  . SER A 1 261 ? 15.614  35.181 36.159  1.00 8.32  ? 261 SER A CA  1 
+ATOM   1988 C C   . SER A 1 261 ? 14.304  35.477 35.432  1.00 8.24  ? 261 SER A C   1 
+ATOM   1989 O O   . SER A 1 261 ? 13.214  35.321 35.994  1.00 7.36  ? 261 SER A O   1 
+ATOM   1990 C CB  . SER A 1 261 ? 16.353  36.489 36.456  1.00 9.14  ? 261 SER A CB  1 
+ATOM   1991 O OG  . SER A 1 261 ? 15.514  37.432 37.097  1.00 11.75 ? 261 SER A OG  1 
+ATOM   1992 N N   . LEU A 1 262 ? 14.415  35.891 34.174  1.00 6.54  ? 262 LEU A N   1 
+ATOM   1993 C CA  . LEU A 1 262 ? 13.232  36.207 33.385  1.00 6.87  ? 262 LEU A CA  1 
+ATOM   1994 C C   . LEU A 1 262 ? 12.354  34.967 33.240  1.00 6.49  ? 262 LEU A C   1 
+ATOM   1995 O O   . LEU A 1 262 ? 11.142  35.032 33.442  1.00 6.43  ? 262 LEU A O   1 
+ATOM   1996 C CB  . LEU A 1 262 ? 13.630  36.724 31.997  1.00 6.89  ? 262 LEU A CB  1 
+ATOM   1997 C CG  . LEU A 1 262 ? 12.470  36.919 31.012  1.00 7.41  ? 262 LEU A CG  1 
+ATOM   1998 C CD1 . LEU A 1 262 ? 11.464  37.908 31.592  1.00 7.92  ? 262 LEU A CD1 1 
+ATOM   1999 C CD2 . LEU A 1 262 ? 13.001  37.424 29.675  1.00 8.70  ? 262 LEU A CD2 1 
+ATOM   2000 N N   . LEU A 1 263 ? 12.967  33.837 32.905  1.00 6.74  ? 263 LEU A N   1 
+ATOM   2001 C CA  . LEU A 1 263 ? 12.207  32.600 32.739  1.00 6.38  ? 263 LEU A CA  1 
+ATOM   2002 C C   . LEU A 1 263 ? 11.452  32.237 34.017  1.00 6.91  ? 263 LEU A C   1 
+ATOM   2003 O O   . LEU A 1 263 ? 10.278  31.870 33.970  1.00 6.41  ? 263 LEU A O   1 
+ATOM   2004 C CB  . LEU A 1 263 ? 13.133  31.441 32.351  1.00 5.83  ? 263 LEU A CB  1 
+ATOM   2005 C CG  . LEU A 1 263 ? 12.413  30.105 32.116  1.00 5.13  ? 263 LEU A CG  1 
+ATOM   2006 C CD1 . LEU A 1 263 ? 11.503  30.240 30.904  1.00 5.87  ? 263 LEU A CD1 1 
+ATOM   2007 C CD2 . LEU A 1 263 ? 13.426  28.984 31.895  1.00 5.27  ? 263 LEU A CD2 1 
+ATOM   2008 N N   . SER A 1 264 ? 12.120  32.339 35.161  1.00 7.40  ? 264 SER A N   1 
+ATOM   2009 C CA  . SER A 1 264 ? 11.465  32.003 36.422  1.00 8.28  ? 264 SER A CA  1 
+ATOM   2010 C C   . SER A 1 264 ? 10.231  32.871 36.637  1.00 7.61  ? 264 SER A C   1 
+ATOM   2011 O O   . SER A 1 264 ? 9.227   32.394 37.153  1.00 7.08  ? 264 SER A O   1 
+ATOM   2012 C CB  . SER A 1 264 ? 12.426  32.172 37.601  1.00 9.68  ? 264 SER A CB  1 
+ATOM   2013 O OG  . SER A 1 264 ? 12.887  33.504 37.688  1.00 15.75 ? 264 SER A OG  1 
+ATOM   2014 N N   . GLN A 1 265 ? 10.302  34.142 36.246  1.00 6.79  ? 265 GLN A N   1 
+ATOM   2015 C CA  . GLN A 1 265 ? 9.156   35.030 36.417  1.00 6.99  ? 265 GLN A CA  1 
+ATOM   2016 C C   . GLN A 1 265 ? 8.042   34.705 35.431  1.00 7.10  ? 265 GLN A C   1 
+ATOM   2017 O O   . GLN A 1 265 ? 6.868   34.956 35.703  1.00 5.92  ? 265 GLN A O   1 
+ATOM   2018 C CB  . GLN A 1 265 ? 9.574   36.495 36.274  1.00 8.78  ? 265 GLN A CB  1 
+ATOM   2019 C CG  . GLN A 1 265 ? 10.501  36.958 37.387  1.00 9.17  ? 265 GLN A CG  1 
+ATOM   2020 C CD  . GLN A 1 265 ? 10.642  38.463 37.442  1.00 9.82  ? 265 GLN A CD  1 
+ATOM   2021 O OE1 . GLN A 1 265 ? 11.167  39.082 36.519  1.00 10.82 ? 265 GLN A OE1 1 
+ATOM   2022 N NE2 . GLN A 1 265 ? 10.164  39.061 38.528  1.00 10.01 ? 265 GLN A NE2 1 
+ATOM   2023 N N   . MET A 1 266 ? 8.410   34.146 34.284  1.00 6.49  ? 266 MET A N   1 
+ATOM   2024 C CA  . MET A 1 266 ? 7.416   33.765 33.290  1.00 5.64  ? 266 MET A CA  1 
+ATOM   2025 C C   . MET A 1 266 ? 6.764   32.441 33.682  1.00 6.45  ? 266 MET A C   1 
+ATOM   2026 O O   . MET A 1 266 ? 5.673   32.121 33.208  1.00 5.52  ? 266 MET A O   1 
+ATOM   2027 C CB  . MET A 1 266 ? 8.062   33.627 31.912  1.00 6.94  ? 266 MET A CB  1 
+ATOM   2028 C CG  . MET A 1 266 ? 8.620   34.928 31.362  1.00 6.92  ? 266 MET A CG  1 
+ATOM   2029 S SD  . MET A 1 266 ? 9.411   34.657 29.764  1.00 7.65  ? 266 MET A SD  1 
+ATOM   2030 C CE  . MET A 1 266 ? 7.968   34.626 28.660  1.00 7.63  ? 266 MET A CE  1 
+ATOM   2031 N N   . LEU A 1 267 ? 7.422   31.684 34.561  1.00 5.28  ? 267 LEU A N   1 
+ATOM   2032 C CA  . LEU A 1 267 ? 6.886   30.391 34.990  1.00 6.22  ? 267 LEU A CA  1 
+ATOM   2033 C C   . LEU A 1 267 ? 6.317   30.348 36.411  1.00 7.21  ? 267 LEU A C   1 
+ATOM   2034 O O   . LEU A 1 267 ? 6.119   29.265 36.971  1.00 7.67  ? 267 LEU A O   1 
+ATOM   2035 C CB  . LEU A 1 267 ? 7.950   29.296 34.828  1.00 5.99  ? 267 LEU A CB  1 
+ATOM   2036 C CG  . LEU A 1 267 ? 8.406   29.042 33.383  1.00 7.22  ? 267 LEU A CG  1 
+ATOM   2037 C CD1 . LEU A 1 267 ? 9.416   27.909 33.341  1.00 7.22  ? 267 LEU A CD1 1 
+ATOM   2038 C CD2 . LEU A 1 267 ? 7.206   28.696 32.523  1.00 7.79  ? 267 LEU A CD2 1 
+ATOM   2039 N N   . HIS A 1 268 ? 6.047   31.510 37.002  1.00 8.45  ? 268 HIS A N   1 
+ATOM   2040 C CA  . HIS A 1 268 ? 5.468   31.526 38.346  1.00 10.29 ? 268 HIS A CA  1 
+ATOM   2041 C C   . HIS A 1 268 ? 4.113   30.823 38.293  1.00 9.74  ? 268 HIS A C   1 
+ATOM   2042 O O   . HIS A 1 268 ? 3.340   31.023 37.355  1.00 9.78  ? 268 HIS A O   1 
+ATOM   2043 C CB  . HIS A 1 268 ? 5.251   32.962 38.850  1.00 12.88 ? 268 HIS A CB  1 
+ATOM   2044 C CG  . HIS A 1 268 ? 6.484   33.609 39.399  1.00 17.21 ? 268 HIS A CG  1 
+ATOM   2045 N ND1 . HIS A 1 268 ? 7.364   32.949 40.230  1.00 18.91 ? 268 HIS A ND1 1 
+ATOM   2046 C CD2 . HIS A 1 268 ? 6.966   34.867 39.264  1.00 18.41 ? 268 HIS A CD2 1 
+ATOM   2047 C CE1 . HIS A 1 268 ? 8.336   33.772 40.582  1.00 19.10 ? 268 HIS A CE1 1 
+ATOM   2048 N NE2 . HIS A 1 268 ? 8.118   34.943 40.010  1.00 18.74 ? 268 HIS A NE2 1 
+ATOM   2049 N N   . TYR A 1 269 ? 3.829   29.996 39.296  1.00 9.45  ? 269 TYR A N   1 
+ATOM   2050 C CA  . TYR A 1 269 ? 2.554   29.288 39.352  1.00 8.32  ? 269 TYR A CA  1 
+ATOM   2051 C C   . TYR A 1 269 ? 1.376   30.253 39.464  1.00 8.38  ? 269 TYR A C   1 
+ATOM   2052 O O   . TYR A 1 269 ? 0.401   30.139 38.726  1.00 7.52  ? 269 TYR A O   1 
+ATOM   2053 C CB  . TYR A 1 269 ? 2.522   28.334 40.550  1.00 7.44  ? 269 TYR A CB  1 
+ATOM   2054 C CG  . TYR A 1 269 ? 3.080   26.953 40.278  1.00 7.49  ? 269 TYR A CG  1 
+ATOM   2055 C CD1 . TYR A 1 269 ? 2.541   26.150 39.272  1.00 7.63  ? 269 TYR A CD1 1 
+ATOM   2056 C CD2 . TYR A 1 269 ? 4.114   26.429 41.059  1.00 6.74  ? 269 TYR A CD2 1 
+ATOM   2057 C CE1 . TYR A 1 269 ? 3.013   24.853 39.050  1.00 8.11  ? 269 TYR A CE1 1 
+ATOM   2058 C CE2 . TYR A 1 269 ? 4.597   25.134 40.846  1.00 7.97  ? 269 TYR A CE2 1 
+ATOM   2059 C CZ  . TYR A 1 269 ? 4.037   24.352 39.839  1.00 7.54  ? 269 TYR A CZ  1 
+ATOM   2060 O OH  . TYR A 1 269 ? 4.496   23.075 39.626  1.00 8.09  ? 269 TYR A OH  1 
+ATOM   2061 N N   . ASP A 1 270 ? 1.464   31.193 40.400  1.00 8.49  ? 270 ASP A N   1 
+ATOM   2062 C CA  . ASP A 1 270 ? 0.388   32.160 40.609  1.00 9.59  ? 270 ASP A CA  1 
+ATOM   2063 C C   . ASP A 1 270 ? 0.263   33.112 39.424  1.00 10.34 ? 270 ASP A C   1 
+ATOM   2064 O O   . ASP A 1 270 ? 1.155   33.923 39.178  1.00 9.58  ? 270 ASP A O   1 
+ATOM   2065 C CB  . ASP A 1 270 ? 0.651   32.968 41.882  1.00 10.22 ? 270 ASP A CB  1 
+ATOM   2066 C CG  . ASP A 1 270 ? -0.540  33.821 42.295  1.00 11.52 ? 270 ASP A CG  1 
+ATOM   2067 O OD1 . ASP A 1 270 ? -1.457  34.017 41.473  1.00 12.16 ? 270 ASP A OD1 1 
+ATOM   2068 O OD2 . ASP A 1 270 ? -0.548  34.305 43.448  1.00 12.29 ? 270 ASP A OD2 1 
+ATOM   2069 N N   . PRO A 1 271 ? -0.852  33.032 38.680  1.00 11.98 ? 271 PRO A N   1 
+ATOM   2070 C CA  . PRO A 1 271 ? -1.075  33.900 37.519  1.00 13.79 ? 271 PRO A CA  1 
+ATOM   2071 C C   . PRO A 1 271 ? -0.921  35.384 37.852  1.00 15.53 ? 271 PRO A C   1 
+ATOM   2072 O O   . PRO A 1 271 ? -0.551  36.184 36.994  1.00 16.41 ? 271 PRO A O   1 
+ATOM   2073 C CB  . PRO A 1 271 ? -2.500  33.550 37.096  1.00 13.52 ? 271 PRO A CB  1 
+ATOM   2074 C CG  . PRO A 1 271 ? -2.615  32.113 37.477  1.00 14.35 ? 271 PRO A CG  1 
+ATOM   2075 C CD  . PRO A 1 271 ? -1.974  32.090 38.848  1.00 12.13 ? 271 PRO A CD  1 
+ATOM   2076 N N   . ASN A 1 272 ? -1.202  35.742 39.101  1.00 16.76 ? 272 ASN A N   1 
+ATOM   2077 C CA  . ASN A 1 272 ? -1.099  37.126 39.546  1.00 17.73 ? 272 ASN A CA  1 
+ATOM   2078 C C   . ASN A 1 272 ? 0.334   37.553 39.824  1.00 17.08 ? 272 ASN A C   1 
+ATOM   2079 O O   . ASN A 1 272 ? 0.631   38.747 39.882  1.00 18.07 ? 272 ASN A O   1 
+ATOM   2080 C CB  . ASN A 1 272 ? -1.950  37.334 40.798  1.00 20.57 ? 272 ASN A CB  1 
+ATOM   2081 C CG  . ASN A 1 272 ? -3.425  37.436 40.485  1.00 23.30 ? 272 ASN A CG  1 
+ATOM   2082 O OD1 . ASN A 1 272 ? -4.270  37.011 41.277  1.00 25.28 ? 272 ASN A OD1 1 
+ATOM   2083 N ND2 . ASN A 1 272 ? -3.748  38.017 39.333  1.00 24.46 ? 272 ASN A ND2 1 
+ATOM   2084 N N   . LYS A 1 273 ? 1.220   36.579 40.001  1.00 15.47 ? 273 LYS A N   1 
+ATOM   2085 C CA  . LYS A 1 273 ? 2.620   36.872 40.262  1.00 14.80 ? 273 LYS A CA  1 
+ATOM   2086 C C   . LYS A 1 273 ? 3.444   36.743 38.983  1.00 13.12 ? 273 LYS A C   1 
+ATOM   2087 O O   . LYS A 1 273 ? 4.514   37.337 38.864  1.00 11.91 ? 273 LYS A O   1 
+ATOM   2088 C CB  . LYS A 1 273 ? 3.171   35.924 41.330  1.00 17.04 ? 273 LYS A CB  1 
+ATOM   2089 C CG  . LYS A 1 273 ? 2.513   36.075 42.691  1.00 19.98 ? 273 LYS A CG  1 
+ATOM   2090 C CD  . LYS A 1 273 ? 2.629   37.507 43.206  1.00 23.81 ? 273 LYS A CD  1 
+ATOM   2091 C CE  . LYS A 1 273 ? 2.258   37.601 44.680  1.00 25.12 ? 273 LYS A CE  1 
+ATOM   2092 N NZ  . LYS A 1 273 ? 3.166   36.761 45.518  1.00 26.08 ? 273 LYS A NZ  1 
+ATOM   2093 N N   . ARG A 1 274 ? 2.932   35.964 38.035  1.00 10.71 ? 274 ARG A N   1 
+ATOM   2094 C CA  . ARG A 1 274 ? 3.606   35.749 36.759  1.00 9.26  ? 274 ARG A CA  1 
+ATOM   2095 C C   . ARG A 1 274 ? 3.808   37.107 36.085  1.00 9.15  ? 274 ARG A C   1 
+ATOM   2096 O O   . ARG A 1 274 ? 2.906   37.947 36.069  1.00 8.41  ? 274 ARG A O   1 
+ATOM   2097 C CB  . ARG A 1 274 ? 2.759   34.820 35.885  1.00 9.31  ? 274 ARG A CB  1 
+ATOM   2098 C CG  . ARG A 1 274 ? 3.512   34.124 34.757  1.00 8.33  ? 274 ARG A CG  1 
+ATOM   2099 C CD  . ARG A 1 274 ? 2.621   33.084 34.088  1.00 8.24  ? 274 ARG A CD  1 
+ATOM   2100 N NE  . ARG A 1 274 ? 2.150   32.067 35.033  1.00 7.64  ? 274 ARG A NE  1 
+ATOM   2101 C CZ  . ARG A 1 274 ? 1.022   31.378 34.888  1.00 9.13  ? 274 ARG A CZ  1 
+ATOM   2102 N NH1 . ARG A 1 274 ? 0.238   31.593 33.833  1.00 7.74  ? 274 ARG A NH1 1 
+ATOM   2103 N NH2 . ARG A 1 274 ? 0.665   30.480 35.802  1.00 7.63  ? 274 ARG A NH2 1 
+ATOM   2104 N N   . ILE A 1 275 ? 5.000   37.326 35.540  1.00 7.25  ? 275 ILE A N   1 
+ATOM   2105 C CA  . ILE A 1 275 ? 5.322   38.601 34.906  1.00 7.36  ? 275 ILE A CA  1 
+ATOM   2106 C C   . ILE A 1 275 ? 4.441   38.902 33.685  1.00 8.05  ? 275 ILE A C   1 
+ATOM   2107 O O   . ILE A 1 275 ? 4.062   37.997 32.942  1.00 7.84  ? 275 ILE A O   1 
+ATOM   2108 C CB  . ILE A 1 275 ? 6.816   38.625 34.504  1.00 6.98  ? 275 ILE A CB  1 
+ATOM   2109 C CG1 . ILE A 1 275 ? 7.268   40.059 34.238  1.00 6.36  ? 275 ILE A CG1 1 
+ATOM   2110 C CG2 . ILE A 1 275 ? 7.047   37.724 33.288  1.00 6.88  ? 275 ILE A CG2 1 
+ATOM   2111 C CD1 . ILE A 1 275 ? 8.761   40.193 34.066  1.00 6.53  ? 275 ILE A CD1 1 
+ATOM   2112 N N   . SER A 1 276 ? 4.092   40.172 33.499  1.00 7.20  ? 276 SER A N   1 
+ATOM   2113 C CA  . SER A 1 276 ? 3.278   40.565 32.352  1.00 8.00  ? 276 SER A CA  1 
+ATOM   2114 C C   . SER A 1 276 ? 4.227   40.781 31.178  1.00 8.27  ? 276 SER A C   1 
+ATOM   2115 O O   . SER A 1 276 ? 5.435   40.928 31.374  1.00 8.66  ? 276 SER A O   1 
+ATOM   2116 C CB  . SER A 1 276 ? 2.527   41.866 32.647  1.00 7.15  ? 276 SER A CB  1 
+ATOM   2117 O OG  . SER A 1 276 ? 3.429   42.961 32.752  1.00 6.76  ? 276 SER A OG  1 
+ATOM   2118 N N   . ALA A 1 277 ? 3.688   40.792 29.962  1.00 8.34  ? 277 ALA A N   1 
+ATOM   2119 C CA  . ALA A 1 277 ? 4.512   41.007 28.775  1.00 7.85  ? 277 ALA A CA  1 
+ATOM   2120 C C   . ALA A 1 277 ? 5.201   42.371 28.856  1.00 7.42  ? 277 ALA A C   1 
+ATOM   2121 O O   . ALA A 1 277 ? 6.397   42.500 28.596  1.00 7.00  ? 277 ALA A O   1 
+ATOM   2122 C CB  . ALA A 1 277 ? 3.647   40.931 27.519  1.00 8.00  ? 277 ALA A CB  1 
+ATOM   2123 N N   . LYS A 1 278 ? 4.427   43.383 29.232  1.00 8.47  ? 278 LYS A N   1 
+ATOM   2124 C CA  . LYS A 1 278 ? 4.912   44.753 29.355  1.00 9.64  ? 278 LYS A CA  1 
+ATOM   2125 C C   . LYS A 1 278 ? 6.113   44.859 30.297  1.00 9.52  ? 278 LYS A C   1 
+ATOM   2126 O O   . LYS A 1 278 ? 7.118   45.493 29.968  1.00 7.97  ? 278 LYS A O   1 
+ATOM   2127 C CB  . LYS A 1 278 ? 3.776   45.647 29.864  1.00 12.03 ? 278 LYS A CB  1 
+ATOM   2128 C CG  . LYS A 1 278 ? 4.074   47.139 29.857  1.00 16.90 ? 278 LYS A CG  1 
+ATOM   2129 C CD  . LYS A 1 278 ? 4.043   47.709 28.448  1.00 18.62 ? 278 LYS A CD  1 
+ATOM   2130 C CE  . LYS A 1 278 ? 3.981   49.234 28.478  1.00 20.54 ? 278 LYS A CE  1 
+ATOM   2131 N NZ  . LYS A 1 278 ? 3.716   49.798 27.126  1.00 21.08 ? 278 LYS A NZ  1 
+ATOM   2132 N N   . ALA A 1 279 ? 6.010   44.238 31.468  1.00 8.79  ? 279 ALA A N   1 
+ATOM   2133 C CA  . ALA A 1 279 ? 7.101   44.280 32.440  1.00 8.41  ? 279 ALA A CA  1 
+ATOM   2134 C C   . ALA A 1 279 ? 8.297   43.461 31.962  1.00 8.85  ? 279 ALA A C   1 
+ATOM   2135 O O   . ALA A 1 279 ? 9.449   43.830 32.200  1.00 7.34  ? 279 ALA A O   1 
+ATOM   2136 C CB  . ALA A 1 279 ? 6.618   43.762 33.795  1.00 8.27  ? 279 ALA A CB  1 
+ATOM   2137 N N   . ALA A 1 280 ? 8.023   42.349 31.284  1.00 7.57  ? 280 ALA A N   1 
+ATOM   2138 C CA  . ALA A 1 280 ? 9.093   41.493 30.786  1.00 8.08  ? 280 ALA A CA  1 
+ATOM   2139 C C   . ALA A 1 280 ? 10.004  42.248 29.820  1.00 8.14  ? 280 ALA A C   1 
+ATOM   2140 O O   . ALA A 1 280 ? 11.213  42.053 29.825  1.00 7.99  ? 280 ALA A O   1 
+ATOM   2141 C CB  . ALA A 1 280 ? 8.506   40.262 30.105  1.00 7.43  ? 280 ALA A CB  1 
+ATOM   2142 N N   . LEU A 1 281 ? 9.419   43.119 28.999  1.00 8.74  ? 281 LEU A N   1 
+ATOM   2143 C CA  . LEU A 1 281 ? 10.193  43.894 28.035  1.00 8.28  ? 281 LEU A CA  1 
+ATOM   2144 C C   . LEU A 1 281 ? 11.253  44.755 28.716  1.00 8.67  ? 281 LEU A C   1 
+ATOM   2145 O O   . LEU A 1 281 ? 12.283  45.070 28.120  1.00 9.44  ? 281 LEU A O   1 
+ATOM   2146 C CB  . LEU A 1 281 ? 9.265   44.796 27.213  1.00 7.62  ? 281 LEU A CB  1 
+ATOM   2147 C CG  . LEU A 1 281 ? 8.237   44.086 26.330  1.00 7.64  ? 281 LEU A CG  1 
+ATOM   2148 C CD1 . LEU A 1 281 ? 7.239   45.105 25.779  1.00 8.54  ? 281 LEU A CD1 1 
+ATOM   2149 C CD2 . LEU A 1 281 ? 8.949   43.356 25.203  1.00 7.18  ? 281 LEU A CD2 1 
+ATOM   2150 N N   . ALA A 1 282 ? 11.000  45.130 29.963  1.00 8.22  ? 282 ALA A N   1 
+ATOM   2151 C CA  . ALA A 1 282 ? 11.937  45.962 30.713  1.00 8.74  ? 282 ALA A CA  1 
+ATOM   2152 C C   . ALA A 1 282 ? 12.961  45.160 31.513  1.00 8.07  ? 282 ALA A C   1 
+ATOM   2153 O O   . ALA A 1 282 ? 13.810  45.738 32.193  1.00 6.87  ? 282 ALA A O   1 
+ATOM   2154 C CB  . ALA A 1 282 ? 11.164  46.893 31.651  1.00 9.20  ? 282 ALA A CB  1 
+ATOM   2155 N N   . HIS A 1 283 ? 12.889  43.835 31.437  1.00 7.48  ? 283 HIS A N   1 
+ATOM   2156 C CA  . HIS A 1 283 ? 13.810  42.990 32.190  1.00 8.14  ? 283 HIS A CA  1 
+ATOM   2157 C C   . HIS A 1 283 ? 15.239  43.171 31.687  1.00 9.14  ? 283 HIS A C   1 
+ATOM   2158 O O   . HIS A 1 283 ? 15.465  43.361 30.492  1.00 8.93  ? 283 HIS A O   1 
+ATOM   2159 C CB  . HIS A 1 283 ? 13.390  41.518 32.081  1.00 7.97  ? 283 HIS A CB  1 
+ATOM   2160 C CG  . HIS A 1 283 ? 14.107  40.611 33.033  1.00 6.96  ? 283 HIS A CG  1 
+ATOM   2161 N ND1 . HIS A 1 283 ? 15.386  40.150 32.807  1.00 8.42  ? 283 HIS A ND1 1 
+ATOM   2162 C CD2 . HIS A 1 283 ? 13.726  40.093 34.224  1.00 7.35  ? 283 HIS A CD2 1 
+ATOM   2163 C CE1 . HIS A 1 283 ? 15.761  39.385 33.817  1.00 8.11  ? 283 HIS A CE1 1 
+ATOM   2164 N NE2 . HIS A 1 283 ? 14.772  39.334 34.691  1.00 7.01  ? 283 HIS A NE2 1 
+ATOM   2165 N N   . PRO A 1 284 ? 16.222  43.130 32.603  1.00 9.45  ? 284 PRO A N   1 
+ATOM   2166 C CA  . PRO A 1 284 ? 17.638  43.292 32.250  1.00 9.23  ? 284 PRO A CA  1 
+ATOM   2167 C C   . PRO A 1 284 ? 18.121  42.375 31.124  1.00 9.85  ? 284 PRO A C   1 
+ATOM   2168 O O   . PRO A 1 284 ? 19.092  42.690 30.440  1.00 9.94  ? 284 PRO A O   1 
+ATOM   2169 C CB  . PRO A 1 284 ? 18.352  43.020 33.573  1.00 8.83  ? 284 PRO A CB  1 
+ATOM   2170 C CG  . PRO A 1 284 ? 17.383  43.607 34.581  1.00 9.42  ? 284 PRO A CG  1 
+ATOM   2171 C CD  . PRO A 1 284 ? 16.043  43.098 34.069  1.00 9.28  ? 284 PRO A CD  1 
+ATOM   2172 N N   . PHE A 1 285 ? 17.441  41.248 30.932  1.00 9.58  ? 285 PHE A N   1 
+ATOM   2173 C CA  . PHE A 1 285 ? 17.816  40.303 29.883  1.00 10.13 ? 285 PHE A CA  1 
+ATOM   2174 C C   . PHE A 1 285 ? 17.839  40.975 28.512  1.00 10.79 ? 285 PHE A C   1 
+ATOM   2175 O O   . PHE A 1 285 ? 18.618  40.588 27.649  1.00 11.14 ? 285 PHE A O   1 
+ATOM   2176 C CB  . PHE A 1 285 ? 16.835  39.120 29.859  1.00 10.44 ? 285 PHE A CB  1 
+ATOM   2177 C CG  . PHE A 1 285 ? 17.196  38.026 28.874  1.00 9.90  ? 285 PHE A CG  1 
+ATOM   2178 C CD1 . PHE A 1 285 ? 18.402  37.334 28.982  1.00 10.47 ? 285 PHE A CD1 1 
+ATOM   2179 C CD2 . PHE A 1 285 ? 16.299  37.649 27.875  1.00 9.89  ? 285 PHE A CD2 1 
+ATOM   2180 C CE1 . PHE A 1 285 ? 18.706  36.281 28.113  1.00 9.59  ? 285 PHE A CE1 1 
+ATOM   2181 C CE2 . PHE A 1 285 ? 16.591  36.596 26.998  1.00 9.23  ? 285 PHE A CE2 1 
+ATOM   2182 C CZ  . PHE A 1 285 ? 17.796  35.911 27.119  1.00 9.92  ? 285 PHE A CZ  1 
+ATOM   2183 N N   . PHE A 1 286 ? 16.998  41.988 28.320  1.00 10.78 ? 286 PHE A N   1 
+ATOM   2184 C CA  . PHE A 1 286 ? 16.923  42.674 27.030  1.00 11.05 ? 286 PHE A CA  1 
+ATOM   2185 C C   . PHE A 1 286 ? 17.756  43.950 26.928  1.00 12.74 ? 286 PHE A C   1 
+ATOM   2186 O O   . PHE A 1 286 ? 17.597  44.734 25.988  1.00 12.87 ? 286 PHE A O   1 
+ATOM   2187 C CB  . PHE A 1 286 ? 15.462  42.977 26.696  1.00 9.65  ? 286 PHE A CB  1 
+ATOM   2188 C CG  . PHE A 1 286 ? 14.604  41.745 26.597  1.00 8.24  ? 286 PHE A CG  1 
+ATOM   2189 C CD1 . PHE A 1 286 ? 14.853  40.787 25.616  1.00 7.85  ? 286 PHE A CD1 1 
+ATOM   2190 C CD2 . PHE A 1 286 ? 13.570  41.530 27.498  1.00 7.73  ? 286 PHE A CD2 1 
+ATOM   2191 C CE1 . PHE A 1 286 ? 14.079  39.624 25.536  1.00 8.27  ? 286 PHE A CE1 1 
+ATOM   2192 C CE2 . PHE A 1 286 ? 12.788  40.372 27.431  1.00 8.70  ? 286 PHE A CE2 1 
+ATOM   2193 C CZ  . PHE A 1 286 ? 13.044  39.417 26.448  1.00 8.02  ? 286 PHE A CZ  1 
+ATOM   2194 N N   . GLN A 1 287 ? 18.649  44.148 27.888  1.00 13.97 ? 287 GLN A N   1 
+ATOM   2195 C CA  . GLN A 1 287 ? 19.516  45.322 27.893  1.00 16.46 ? 287 GLN A CA  1 
+ATOM   2196 C C   . GLN A 1 287 ? 20.328  45.403 26.609  1.00 16.38 ? 287 GLN A C   1 
+ATOM   2197 O O   . GLN A 1 287 ? 20.610  46.499 26.115  1.00 16.91 ? 287 GLN A O   1 
+ATOM   2198 C CB  . GLN A 1 287 ? 20.469  45.273 29.099  1.00 19.20 ? 287 GLN A CB  1 
+ATOM   2199 C CG  . GLN A 1 287 ? 21.573  46.343 29.099  1.00 24.10 ? 287 GLN A CG  1 
+ATOM   2200 C CD  . GLN A 1 287 ? 22.748  46.007 28.174  1.00 27.57 ? 287 GLN A CD  1 
+ATOM   2201 O OE1 . GLN A 1 287 ? 23.447  45.009 28.367  1.00 29.14 ? 287 GLN A OE1 1 
+ATOM   2202 N NE2 . GLN A 1 287 ? 22.965  46.846 27.166  1.00 30.40 ? 287 GLN A NE2 1 
+ATOM   2203 N N   . ASP A 1 288 ? 20.701  44.244 26.072  1.00 15.10 ? 288 ASP A N   1 
+ATOM   2204 C CA  . ASP A 1 288 ? 21.505  44.194 24.857  1.00 16.07 ? 288 ASP A CA  1 
+ATOM   2205 C C   . ASP A 1 288 ? 20.775  43.553 23.683  1.00 14.78 ? 288 ASP A C   1 
+ATOM   2206 O O   . ASP A 1 288 ? 21.410  43.002 22.783  1.00 15.71 ? 288 ASP A O   1 
+ATOM   2207 C CB  . ASP A 1 288 ? 22.809  43.428 25.127  1.00 16.55 ? 288 ASP A CB  1 
+ATOM   2208 C CG  . ASP A 1 288 ? 22.571  41.962 25.461  1.00 17.88 ? 288 ASP A CG  1 
+ATOM   2209 O OD1 . ASP A 1 288 ? 21.398  41.566 25.620  1.00 20.37 ? 288 ASP A OD1 1 
+ATOM   2210 O OD2 . ASP A 1 288 ? 23.557  41.203 25.570  1.00 18.99 ? 288 ASP A OD2 1 
+ATOM   2211 N N   . VAL A 1 289 ? 19.449  43.636 23.682  1.00 13.78 ? 289 VAL A N   1 
+ATOM   2212 C CA  . VAL A 1 289 ? 18.677  43.040 22.603  1.00 12.81 ? 289 VAL A CA  1 
+ATOM   2213 C C   . VAL A 1 289 ? 18.974  43.717 21.268  1.00 13.01 ? 289 VAL A C   1 
+ATOM   2214 O O   . VAL A 1 289 ? 19.132  44.941 21.191  1.00 12.74 ? 289 VAL A O   1 
+ATOM   2215 C CB  . VAL A 1 289 ? 17.152  43.096 22.886  1.00 12.33 ? 289 VAL A CB  1 
+ATOM   2216 C CG1 . VAL A 1 289 ? 16.656  44.534 22.857  1.00 12.74 ? 289 VAL A CG1 1 
+ATOM   2217 C CG2 . VAL A 1 289 ? 16.407  42.244 21.868  1.00 13.04 ? 289 VAL A CG2 1 
+ATOM   2218 N N   . THR A 1 290 ? 19.070  42.896 20.227  1.00 12.05 ? 290 THR A N   1 
+ATOM   2219 C CA  . THR A 1 290 ? 19.344  43.360 18.872  1.00 12.79 ? 290 THR A CA  1 
+ATOM   2220 C C   . THR A 1 290 ? 18.426  42.583 17.941  1.00 13.25 ? 290 THR A C   1 
+ATOM   2221 O O   . THR A 1 290 ? 17.658  41.738 18.400  1.00 13.39 ? 290 THR A O   1 
+ATOM   2222 C CB  . THR A 1 290 ? 20.806  43.075 18.469  1.00 12.57 ? 290 THR A CB  1 
+ATOM   2223 O OG1 . THR A 1 290 ? 21.029  41.659 18.432  1.00 11.29 ? 290 THR A OG1 1 
+ATOM   2224 C CG2 . THR A 1 290 ? 21.761  43.703 19.466  1.00 13.31 ? 290 THR A CG2 1 
+ATOM   2225 N N   . LYS A 1 291 ? 18.498  42.860 16.642  1.00 12.96 ? 291 LYS A N   1 
+ATOM   2226 C CA  . LYS A 1 291 ? 17.653  42.141 15.691  1.00 13.56 ? 291 LYS A CA  1 
+ATOM   2227 C C   . LYS A 1 291 ? 18.481  41.432 14.624  1.00 13.01 ? 291 LYS A C   1 
+ATOM   2228 O O   . LYS A 1 291 ? 18.664  41.950 13.519  1.00 13.33 ? 291 LYS A O   1 
+ATOM   2229 C CB  . LYS A 1 291 ? 16.661  43.091 15.015  1.00 14.17 ? 291 LYS A CB  1 
+ATOM   2230 C CG  . LYS A 1 291 ? 15.620  42.365 14.170  1.00 16.09 ? 291 LYS A CG  1 
+ATOM   2231 C CD  . LYS A 1 291 ? 14.640  43.327 13.516  1.00 19.15 ? 291 LYS A CD  1 
+ATOM   2232 C CE  . LYS A 1 291 ? 13.637  42.564 12.658  1.00 20.85 ? 291 LYS A CE  1 
+ATOM   2233 N NZ  . LYS A 1 291 ? 12.637  43.463 12.018  1.00 22.87 ? 291 LYS A NZ  1 
+ATOM   2234 N N   . PRO A 1 292 ? 19.002  40.237 14.947  1.00 13.02 ? 292 PRO A N   1 
+ATOM   2235 C CA  . PRO A 1 292 ? 19.815  39.452 14.011  1.00 12.78 ? 292 PRO A CA  1 
+ATOM   2236 C C   . PRO A 1 292 ? 19.008  38.954 12.812  1.00 14.75 ? 292 PRO A C   1 
+ATOM   2237 O O   . PRO A 1 292 ? 17.778  38.864 12.865  1.00 13.22 ? 292 PRO A O   1 
+ATOM   2238 C CB  . PRO A 1 292 ? 20.309  38.284 14.867  1.00 13.15 ? 292 PRO A CB  1 
+ATOM   2239 C CG  . PRO A 1 292 ? 20.267  38.823 16.269  1.00 12.36 ? 292 PRO A CG  1 
+ATOM   2240 C CD  . PRO A 1 292 ? 18.980  39.601 16.276  1.00 11.98 ? 292 PRO A CD  1 
+ATOM   2241 N N   . VAL A 1 293 ? 19.719  38.635 11.734  1.00 15.68 ? 293 VAL A N   1 
+ATOM   2242 C CA  . VAL A 1 293 ? 19.109  38.116 10.516  1.00 18.54 ? 293 VAL A CA  1 
+ATOM   2243 C C   . VAL A 1 293 ? 19.353  36.610 10.519  1.00 18.87 ? 293 VAL A C   1 
+ATOM   2244 O O   . VAL A 1 293 ? 20.498  36.160 10.473  1.00 20.62 ? 293 VAL A O   1 
+ATOM   2245 C CB  . VAL A 1 293 ? 19.772  38.718 9.252   1.00 19.74 ? 293 VAL A CB  1 
+ATOM   2246 C CG1 . VAL A 1 293 ? 19.149  38.113 7.995   1.00 21.22 ? 293 VAL A CG1 1 
+ATOM   2247 C CG2 . VAL A 1 293 ? 19.614  40.228 9.250   1.00 20.96 ? 293 VAL A CG2 1 
+ATOM   2248 N N   . PRO A 1 294 ? 18.284  35.809 10.594  1.00 18.75 ? 294 PRO A N   1 
+ATOM   2249 C CA  . PRO A 1 294 ? 18.463  34.357 10.600  1.00 19.07 ? 294 PRO A CA  1 
+ATOM   2250 C C   . PRO A 1 294 ? 18.731  33.847 9.192   1.00 19.80 ? 294 PRO A C   1 
+ATOM   2251 O O   . PRO A 1 294 ? 18.272  34.439 8.215   1.00 18.82 ? 294 PRO A O   1 
+ATOM   2252 C CB  . PRO A 1 294 ? 17.132  33.858 11.139  1.00 18.73 ? 294 PRO A CB  1 
+ATOM   2253 C CG  . PRO A 1 294 ? 16.170  34.818 10.503  1.00 18.83 ? 294 PRO A CG  1 
+ATOM   2254 C CD  . PRO A 1 294 ? 16.857  36.161 10.710  1.00 19.03 ? 294 PRO A CD  1 
+ATOM   2255 N N   . HIS A 1 295 ? 19.492  32.764 9.086   1.00 21.20 ? 295 HIS A N   1 
+ATOM   2256 C CA  . HIS A 1 295 ? 19.766  32.180 7.784   1.00 22.11 ? 295 HIS A CA  1 
+ATOM   2257 C C   . HIS A 1 295 ? 18.726  31.083 7.608   1.00 20.54 ? 295 HIS A C   1 
+ATOM   2258 O O   . HIS A 1 295 ? 18.787  30.051 8.274   1.00 21.26 ? 295 HIS A O   1 
+ATOM   2259 C CB  . HIS A 1 295 ? 21.169  31.575 7.726   1.00 25.37 ? 295 HIS A CB  1 
+ATOM   2260 C CG  . HIS A 1 295 ? 21.605  31.222 6.338   1.00 28.71 ? 295 HIS A CG  1 
+ATOM   2261 N ND1 . HIS A 1 295 ? 20.872  30.391 5.519   1.00 30.30 ? 295 HIS A ND1 1 
+ATOM   2262 C CD2 . HIS A 1 295 ? 22.679  31.614 5.612   1.00 30.81 ? 295 HIS A CD2 1 
+ATOM   2263 C CE1 . HIS A 1 295 ? 21.474  30.288 4.347   1.00 31.58 ? 295 HIS A CE1 1 
+ATOM   2264 N NE2 . HIS A 1 295 ? 22.572  31.022 4.377   1.00 31.40 ? 295 HIS A NE2 1 
+ATOM   2265 N N   . LEU A 1 296 ? 17.763  31.315 6.722   1.00 18.55 ? 296 LEU A N   1 
+ATOM   2266 C CA  . LEU A 1 296 ? 16.705  30.340 6.496   1.00 17.50 ? 296 LEU A CA  1 
+ATOM   2267 C C   . LEU A 1 296 ? 16.835  29.621 5.164   1.00 18.08 ? 296 LEU A C   1 
+ATOM   2268 O O   . LEU A 1 296 ? 17.191  30.223 4.149   1.00 17.81 ? 296 LEU A O   1 
+ATOM   2269 C CB  . LEU A 1 296 ? 15.332  31.024 6.543   1.00 16.89 ? 296 LEU A CB  1 
+ATOM   2270 C CG  . LEU A 1 296 ? 14.943  31.814 7.794   1.00 16.00 ? 296 LEU A CG  1 
+ATOM   2271 C CD1 . LEU A 1 296 ? 13.567  32.435 7.581   1.00 16.40 ? 296 LEU A CD1 1 
+ATOM   2272 C CD2 . LEU A 1 296 ? 14.943  30.904 9.011   1.00 15.59 ? 296 LEU A CD2 1 
+ATOM   2273 N N   . ARG A 1 297 ? 16.550  28.325 5.179   1.00 18.42 ? 297 ARG A N   1 
+ATOM   2274 C CA  . ARG A 1 297 ? 16.581  27.526 3.964   1.00 20.27 ? 297 ARG A CA  1 
+ATOM   2275 C C   . ARG A 1 297 ? 15.120  27.295 3.603   1.00 19.97 ? 297 ARG A C   1 
+ATOM   2276 O O   . ARG A 1 297 ? 14.412  26.557 4.287   1.00 19.18 ? 297 ARG A O   1 
+ATOM   2277 C CB  . ARG A 1 297 ? 17.308  26.196 4.204   1.00 23.07 ? 297 ARG A CB  1 
+ATOM   2278 C CG  . ARG A 1 297 ? 16.804  25.386 5.389   1.00 27.82 ? 297 ARG A CG  1 
+ATOM   2279 C CD  . ARG A 1 297 ? 17.673  24.150 5.611   1.00 32.04 ? 297 ARG A CD  1 
+ATOM   2280 N NE  . ARG A 1 297 ? 17.198  23.321 6.717   1.00 35.64 ? 297 ARG A NE  1 
+ATOM   2281 C CZ  . ARG A 1 297 ? 17.792  22.203 7.124   1.00 37.51 ? 297 ARG A CZ  1 
+ATOM   2282 N NH1 . ARG A 1 297 ? 18.891  21.773 6.516   1.00 38.71 ? 297 ARG A NH1 1 
+ATOM   2283 N NH2 . ARG A 1 297 ? 17.286  21.509 8.137   1.00 38.47 ? 297 ARG A NH2 1 
+ATOM   2284 N N   . LEU A 1 298 ? 14.670  27.961 2.544   1.00 19.05 ? 298 LEU A N   1 
+ATOM   2285 C CA  . LEU A 1 298 ? 13.290  27.859 2.092   1.00 18.93 ? 298 LEU A CA  1 
+ATOM   2286 C C   . LEU A 1 298 ? 13.172  27.005 0.835   1.00 19.72 ? 298 LEU A C   1 
+ATOM   2287 O O   . LEU A 1 298 ? 12.151  26.305 0.708   1.00 19.66 ? 298 LEU A O   1 
+ATOM   2288 C CB  . LEU A 1 298 ? 12.723  29.253 1.816   1.00 18.75 ? 298 LEU A CB  1 
+ATOM   2289 C CG  . LEU A 1 298 ? 12.832  30.283 2.944   1.00 18.59 ? 298 LEU A CG  1 
+ATOM   2290 C CD1 . LEU A 1 298 ? 12.310  31.626 2.455   1.00 17.17 ? 298 LEU A CD1 1 
+ATOM   2291 C CD2 . LEU A 1 298 ? 12.047  29.803 4.165   1.00 18.29 ? 298 LEU A CD2 1 
+ATOM   2292 O OXT . LEU A 1 298 ? 14.086  27.066 -0.017  1.00 20.76 ? 298 LEU A OXT 1 
+HETATM 2293 N N1  . LIA B 2 .   ? 6.006   26.497 6.980   1.00 10.56 ? 299 LIA A N1  1 
+HETATM 2294 C C2  . LIA B 2 .   ? 5.228   26.235 5.737   1.00 10.69 ? 299 LIA A C2  1 
+HETATM 2295 C C3  . LIA B 2 .   ? 4.425   27.497 5.356   1.00 9.74  ? 299 LIA A C3  1 
+HETATM 2296 C C4  . LIA B 2 .   ? 3.474   27.912 6.508   1.00 10.58 ? 299 LIA A C4  1 
+HETATM 2297 C C5  . LIA B 2 .   ? 4.263   28.022 7.859   1.00 10.01 ? 299 LIA A C5  1 
+HETATM 2298 C C6  . LIA B 2 .   ? 5.084   26.743 8.129   1.00 10.74 ? 299 LIA A C6  1 
+HETATM 2299 N N7  . LIA B 2 .   ? 2.853   29.193 6.145   1.00 10.05 ? 299 LIA A N7  1 
+HETATM 2300 C C8  . LIA B 2 .   ? 1.769   29.532 6.900   1.00 9.16  ? 299 LIA A C8  1 
+HETATM 2301 N N9  . LIA B 2 .   ? 1.069   28.596 7.597   1.00 9.24  ? 299 LIA A N9  1 
+HETATM 2302 C C10 . LIA B 2 .   ? 0.049   28.949 8.317   1.00 8.76  ? 299 LIA A C10 1 
+HETATM 2303 C C11 . LIA B 2 .   ? -0.400  30.325 8.422   1.00 9.02  ? 299 LIA A C11 1 
+HETATM 2304 C C12 . LIA B 2 .   ? 0.364   31.287 7.659   1.00 8.51  ? 299 LIA A C12 1 
+HETATM 2305 N N13 . LIA B 2 .   ? 1.437   30.856 6.914   1.00 7.92  ? 299 LIA A N13 1 
+HETATM 2306 C C14 . LIA B 2 .   ? -1.543  30.655 9.260   1.00 8.90  ? 299 LIA A C14 1 
+HETATM 2307 O O15 . LIA B 2 .   ? -1.970  31.821 9.319   1.00 8.84  ? 299 LIA A O15 1 
+HETATM 2308 C C16 . LIA B 2 .   ? -2.197  29.647 10.064  1.00 10.02 ? 299 LIA A C16 1 
+HETATM 2309 C C17 . LIA B 2 .   ? -3.548  29.259 9.750   1.00 10.79 ? 299 LIA A C17 1 
+HETATM 2310 C C18 . LIA B 2 .   ? -4.212  28.257 10.524  1.00 11.95 ? 299 LIA A C18 1 
+HETATM 2311 C C19 . LIA B 2 .   ? -3.548  27.625 11.616  1.00 11.33 ? 299 LIA A C19 1 
+HETATM 2312 C C20 . LIA B 2 .   ? -2.214  27.992 11.950  1.00 10.60 ? 299 LIA A C20 1 
+HETATM 2313 C C21 . LIA B 2 .   ? -1.510  29.004 11.189  1.00 9.84  ? 299 LIA A C21 1 
+HETATM 2314 O O22 . LIA B 2 .   ? -0.188  29.401 11.490  1.00 9.06  ? 299 LIA A O22 1 
+HETATM 2315 C C23 . LIA B 2 .   ? 0.555   28.398 12.227  1.00 7.97  ? 299 LIA A C23 1 
+HETATM 2316 F F24 . LIA B 2 .   ? -4.202  29.825 8.740   1.00 12.32 ? 299 LIA A F24 1 
+HETATM 2317 F F25 . LIA B 2 .   ? -5.450  27.907 10.229  1.00 13.53 ? 299 LIA A F25 1 
+HETATM 2318 N N26 . LIA B 2 .   ? 0.083   32.603 7.639   1.00 7.78  ? 299 LIA A N26 1 
+HETATM 2319 S S27 . LIA B 2 .   ? 7.063   25.211 7.310   1.00 10.53 ? 299 LIA A S27 1 
+HETATM 2320 C C28 . LIA B 2 .   ? 6.179   23.662 7.710   1.00 11.57 ? 299 LIA A C28 1 
+HETATM 2321 O O29 . LIA B 2 .   ? 7.871   25.586 8.449   1.00 10.84 ? 299 LIA A O29 1 
+HETATM 2322 O O30 . LIA B 2 .   ? 7.911   25.002 6.168   1.00 10.25 ? 299 LIA A O30 1 
+HETATM 2323 O O   . HOH C 3 .   ? 3.368   23.588 30.184  1.00 7.60  ? 300 HOH A O   1 
+HETATM 2324 O O   . HOH C 3 .   ? 2.141   41.401 10.451  1.00 21.15 ? 301 HOH A O   1 
+HETATM 2325 O O   . HOH C 3 .   ? -0.837  30.420 24.946  1.00 7.09  ? 302 HOH A O   1 
+HETATM 2326 O O   . HOH C 3 .   ? 8.997   23.731 25.723  1.00 6.37  ? 303 HOH A O   1 
+HETATM 2327 O O   . HOH C 3 .   ? -0.355  26.139 23.831  1.00 8.22  ? 304 HOH A O   1 
+HETATM 2328 O O   . HOH C 3 .   ? 7.135   22.481 27.378  1.00 6.14  ? 305 HOH A O   1 
+HETATM 2329 O O   . HOH C 3 .   ? 4.311   41.950 35.871  1.00 16.15 ? 306 HOH A O   1 
+HETATM 2330 O O   . HOH C 3 .   ? 12.946  35.681 11.383  1.00 9.70  ? 307 HOH A O   1 
+HETATM 2331 O O   . HOH C 3 .   ? 19.882  40.166 20.526  1.00 9.89  ? 308 HOH A O   1 
+HETATM 2332 O O   . HOH C 3 .   ? -1.336  28.340 28.315  1.00 7.69  ? 309 HOH A O   1 
+HETATM 2333 O O   . HOH C 3 .   ? 16.627  33.581 39.276  1.00 21.07 ? 310 HOH A O   1 
+HETATM 2334 O O   . HOH C 3 .   ? -4.033  41.176 11.658  1.00 11.94 ? 311 HOH A O   1 
+HETATM 2335 O O   . HOH C 3 .   ? -2.008  27.069 25.874  1.00 9.74  ? 312 HOH A O   1 
+HETATM 2336 O O   . HOH C 3 .   ? 0.821   40.501 29.617  1.00 7.16  ? 313 HOH A O   1 
+HETATM 2337 O O   . HOH C 3 .   ? -4.367  37.342 13.222  1.00 19.85 ? 314 HOH A O   1 
+HETATM 2338 O O   . HOH C 3 .   ? 0.289   23.498 24.659  1.00 9.27  ? 315 HOH A O   1 
+HETATM 2339 O O   . HOH C 3 .   ? 21.650  22.644 39.650  1.00 18.70 ? 316 HOH A O   1 
+HETATM 2340 O O   . HOH C 3 .   ? -0.783  10.516 23.696  1.00 14.82 ? 317 HOH A O   1 
+HETATM 2341 O O   . HOH C 3 .   ? -4.543  32.788 34.197  1.00 10.93 ? 318 HOH A O   1 
+HETATM 2342 O O   . HOH C 3 .   ? -5.608  28.542 18.187  1.00 27.60 ? 319 HOH A O   1 
+HETATM 2343 O O   . HOH C 3 .   ? -1.222  42.074 12.100  1.00 7.91  ? 320 HOH A O   1 
+HETATM 2344 O O   . HOH C 3 .   ? 7.211   28.162 39.387  1.00 18.51 ? 321 HOH A O   1 
+HETATM 2345 O O   . HOH C 3 .   ? -0.410  39.174 31.841  1.00 9.01  ? 322 HOH A O   1 
+HETATM 2346 O O   . HOH C 3 .   ? -6.017  43.192 9.087   1.00 13.15 ? 323 HOH A O   1 
+HETATM 2347 O O   . HOH C 3 .   ? 1.453   43.234 29.536  1.00 9.47  ? 324 HOH A O   1 
+HETATM 2348 O O   . HOH C 3 .   ? 0.726   16.799 24.221  1.00 7.89  ? 325 HOH A O   1 
+HETATM 2349 O O   . HOH C 3 .   ? 0.776   37.485 2.068   1.00 11.67 ? 326 HOH A O   1 
+HETATM 2350 O O   . HOH C 3 .   ? -5.021  39.967 14.102  1.00 16.48 ? 327 HOH A O   1 
+HETATM 2351 O O   . HOH C 3 .   ? -5.947  21.354 27.648  1.00 18.14 ? 328 HOH A O   1 
+HETATM 2352 O O   . HOH C 3 .   ? 18.636  37.178 40.405  1.00 16.36 ? 329 HOH A O   1 
+HETATM 2353 O O   . HOH C 3 .   ? 6.864   25.146 43.915  1.00 18.77 ? 330 HOH A O   1 
+HETATM 2354 O O   . HOH C 3 .   ? 14.343  42.391 17.743  1.00 12.58 ? 331 HOH A O   1 
+HETATM 2355 O O   . HOH C 3 .   ? 1.169   37.426 33.226  1.00 10.58 ? 332 HOH A O   1 
+HETATM 2356 O O   . HOH C 3 .   ? 6.469   12.749 26.147  1.00 21.34 ? 333 HOH A O   1 
+HETATM 2357 O O   . HOH C 3 .   ? 22.243  39.590 29.876  1.00 24.32 ? 334 HOH A O   1 
+HETATM 2358 O O   . HOH C 3 .   ? 4.417   23.536 17.930  1.00 5.36  ? 335 HOH A O   1 
+HETATM 2359 O O   . HOH C 3 .   ? -9.350  36.742 23.721  1.00 17.27 ? 336 HOH A O   1 
+HETATM 2360 O O   . HOH C 3 .   ? -1.591  24.376 50.690  1.00 26.27 ? 337 HOH A O   1 
+HETATM 2361 O O   . HOH C 3 .   ? 5.598   24.169 45.817  1.00 25.98 ? 338 HOH A O   1 
+HETATM 2362 O O   . HOH C 3 .   ? 6.009   27.793 0.544   1.00 9.53  ? 339 HOH A O   1 
+HETATM 2363 O O   . HOH C 3 .   ? 19.772  45.147 15.649  1.00 13.76 ? 340 HOH A O   1 
+HETATM 2364 O O   . HOH C 3 .   ? 10.271  26.520 5.042   1.00 10.37 ? 341 HOH A O   1 
+HETATM 2365 O O   . HOH C 3 .   ? -0.128  44.831 27.895  1.00 10.52 ? 342 HOH A O   1 
+HETATM 2366 O O   . HOH C 3 .   ? 8.937   22.715 46.362  1.00 23.77 ? 343 HOH A O   1 
+HETATM 2367 O O   . HOH C 3 .   ? 15.698  38.856 14.742  1.00 9.76  ? 344 HOH A O   1 
+HETATM 2368 O O   . HOH C 3 .   ? 24.654  28.912 17.977  1.00 34.90 ? 345 HOH A O   1 
+HETATM 2369 O O   . HOH C 3 .   ? 23.517  40.444 17.889  1.00 18.94 ? 346 HOH A O   1 
+HETATM 2370 O O   . HOH C 3 .   ? -6.470  38.581 31.666  1.00 18.29 ? 347 HOH A O   1 
+HETATM 2371 O O   . HOH C 3 .   ? -3.929  19.682 49.517  1.00 22.34 ? 348 HOH A O   1 
+HETATM 2372 O O   . HOH C 3 .   ? 10.429  26.580 2.442   1.00 19.12 ? 349 HOH A O   1 
+HETATM 2373 O O   . HOH C 3 .   ? -4.620  34.444 13.935  1.00 15.79 ? 350 HOH A O   1 
+HETATM 2374 O O   . HOH C 3 .   ? 9.476   17.487 34.634  1.00 18.52 ? 351 HOH A O   1 
+HETATM 2375 O O   . HOH C 3 .   ? 24.876  33.689 34.674  1.00 17.47 ? 352 HOH A O   1 
+HETATM 2376 O O   . HOH C 3 .   ? 10.681  41.791 36.671  1.00 13.11 ? 353 HOH A O   1 
+HETATM 2377 O O   . HOH C 3 .   ? 25.050  37.074 23.133  1.00 30.64 ? 354 HOH A O   1 
+HETATM 2378 O O   . HOH C 3 .   ? 21.985  40.210 22.035  1.00 17.13 ? 355 HOH A O   1 
+HETATM 2379 O O   . HOH C 3 .   ? 6.492   25.325 -3.782  1.00 36.53 ? 356 HOH A O   1 
+HETATM 2380 O O   . HOH C 3 .   ? 22.225  37.639 28.137  1.00 24.19 ? 357 HOH A O   1 
+HETATM 2381 O O   . HOH C 3 .   ? 18.079  31.400 38.680  1.00 20.84 ? 358 HOH A O   1 
+HETATM 2382 O O   . HOH C 3 .   ? 15.554  27.062 7.836   1.00 19.42 ? 359 HOH A O   1 
+HETATM 2383 O O   . HOH C 3 .   ? 9.917   19.236 19.975  1.00 26.11 ? 360 HOH A O   1 
+HETATM 2384 O O   . HOH C 3 .   ? 0.422   8.494  25.211  1.00 11.66 ? 361 HOH A O   1 
+HETATM 2385 O O   . HOH C 3 .   ? -13.661 20.058 35.292  1.00 33.08 ? 362 HOH A O   1 
+HETATM 2386 O O   . HOH C 3 .   ? 8.222   44.649 17.032  1.00 34.48 ? 363 HOH A O   1 
+HETATM 2387 O O   . HOH C 3 .   ? 1.064   32.978 50.149  1.00 20.47 ? 364 HOH A O   1 
+HETATM 2388 O O   . HOH C 3 .   ? 17.740  26.289 19.548  1.00 19.56 ? 365 HOH A O   1 
+HETATM 2389 O O   . HOH C 3 .   ? 6.417   22.035 18.381  1.00 45.30 ? 366 HOH A O   1 
+HETATM 2390 O O   . HOH C 3 .   ? -6.795  16.448 38.016  1.00 25.02 ? 367 HOH A O   1 
+HETATM 2391 O O   . HOH C 3 .   ? -2.830  37.632 35.106  1.00 36.33 ? 368 HOH A O   1 
+HETATM 2392 O O   . HOH C 3 .   ? -6.068  32.590 36.258  1.00 23.95 ? 369 HOH A O   1 
+HETATM 2393 O O   . HOH C 3 .   ? 6.425   47.120 18.765  1.00 25.05 ? 370 HOH A O   1 
+HETATM 2394 O O   . HOH C 3 .   ? 22.869  32.708 28.291  1.00 20.06 ? 371 HOH A O   1 
+HETATM 2395 O O   . HOH C 3 .   ? 2.592   10.829 34.653  1.00 36.59 ? 372 HOH A O   1 
+HETATM 2396 O O   . HOH C 3 .   ? -3.320  11.581 25.000  1.00 21.03 ? 373 HOH A O   1 
+HETATM 2397 O O   . HOH C 3 .   ? -2.285  23.015 21.366  1.00 15.28 ? 374 HOH A O   1 
+HETATM 2398 O O   . HOH C 3 .   ? -3.980  9.320  26.446  1.00 25.62 ? 375 HOH A O   1 
+HETATM 2399 O O   . HOH C 3 .   ? 0.462   12.672 22.810  1.00 19.28 ? 376 HOH A O   1 
+HETATM 2400 O O   . HOH C 3 .   ? 2.729   13.984 23.702  1.00 9.10  ? 377 HOH A O   1 
+HETATM 2401 O O   . HOH C 3 .   ? 3.155   26.267 11.279  1.00 13.03 ? 378 HOH A O   1 
+HETATM 2402 O O   . HOH C 3 .   ? 15.943  36.587 39.925  1.00 12.45 ? 379 HOH A O   1 
+HETATM 2403 O O   . HOH C 3 .   ? 15.288  17.615 29.628  1.00 33.91 ? 380 HOH A O   1 
+HETATM 2404 O O   . HOH C 3 .   ? 8.405   42.671 36.997  1.00 33.32 ? 381 HOH A O   1 
+HETATM 2405 O O   . HOH C 3 .   ? 2.947   44.210 35.646  1.00 35.41 ? 382 HOH A O   1 
+HETATM 2406 O O   . HOH C 3 .   ? 4.602   46.787 20.455  1.00 15.29 ? 383 HOH A O   1 
+HETATM 2407 O O   . HOH C 3 .   ? -1.285  31.641 51.053  1.00 23.64 ? 384 HOH A O   1 
+HETATM 2408 O O   . HOH C 3 .   ? 3.936   31.581 42.337  1.00 25.08 ? 385 HOH A O   1 
+HETATM 2409 O O   . HOH C 3 .   ? 1.563   26.050 9.001   1.00 11.44 ? 386 HOH A O   1 
+HETATM 2410 O O   . HOH C 3 .   ? 15.614  28.545 -1.380  1.00 26.97 ? 387 HOH A O   1 
+HETATM 2411 O O   . HOH C 3 .   ? 17.952  27.158 8.821   1.00 23.43 ? 388 HOH A O   1 
+HETATM 2412 O O   . HOH C 3 .   ? -3.415  32.508 11.789  1.00 22.64 ? 389 HOH A O   1 
+HETATM 2413 O O   . HOH C 3 .   ? -5.856  30.953 12.181  1.00 26.81 ? 390 HOH A O   1 
+HETATM 2414 O O   . HOH C 3 .   ? -1.173  25.228 9.342   1.00 30.59 ? 391 HOH A O   1 
+HETATM 2415 O O   . HOH C 3 .   ? 4.065   26.164 1.973   1.00 24.50 ? 392 HOH A O   1 
+HETATM 2416 O O   . HOH C 3 .   ? 4.099   23.875 3.207   1.00 24.51 ? 393 HOH A O   1 
+HETATM 2417 O O   . HOH C 3 .   ? 3.365   22.622 5.836   1.00 19.43 ? 394 HOH A O   1 
+HETATM 2418 O O   . HOH C 3 .   ? 6.743   25.345 -0.813  1.00 30.38 ? 395 HOH A O   1 
+HETATM 2419 O O   . HOH C 3 .   ? 4.801   27.852 -3.649  1.00 22.83 ? 396 HOH A O   1 
+HETATM 2420 O O   . HOH C 3 .   ? 0.281   21.010 18.282  1.00 45.38 ? 397 HOH A O   1 
+HETATM 2421 O O   . HOH C 3 .   ? 3.536   17.589 17.399  1.00 19.40 ? 398 HOH A O   1 
+HETATM 2422 O O   . HOH C 3 .   ? 3.367   14.996 16.313  1.00 16.20 ? 399 HOH A O   1 
+HETATM 2423 O O   . HOH C 3 .   ? 6.801   17.404 17.330  1.00 25.61 ? 400 HOH A O   1 
+HETATM 2424 O O   . HOH C 3 .   ? -3.241  16.959 18.701  1.00 17.42 ? 401 HOH A O   1 
+HETATM 2425 O O   . HOH C 3 .   ? -2.484  20.598 18.446  1.00 29.21 ? 402 HOH A O   1 
+HETATM 2426 O O   . HOH C 3 .   ? -3.667  26.531 17.620  1.00 33.33 ? 403 HOH A O   1 
+HETATM 2427 O O   . HOH C 3 .   ? -7.120  27.354 19.933  1.00 29.76 ? 404 HOH A O   1 
+HETATM 2428 O O   . HOH C 3 .   ? -5.832  29.278 21.040  1.00 40.54 ? 405 HOH A O   1 
+HETATM 2429 O O   . HOH C 3 .   ? -7.063  32.745 14.213  1.00 23.69 ? 406 HOH A O   1 
+HETATM 2430 O O   . HOH C 3 .   ? -9.079  31.077 13.605  1.00 36.69 ? 407 HOH A O   1 
+HETATM 2431 O O   . HOH C 3 .   ? 1.842   13.946 14.579  1.00 16.01 ? 408 HOH A O   1 
+HETATM 2432 O O   . HOH C 3 .   ? 5.163   12.750 23.767  1.00 24.03 ? 409 HOH A O   1 
+HETATM 2433 O O   . HOH C 3 .   ? 22.419  37.910 23.281  1.00 19.49 ? 410 HOH A O   1 
+HETATM 2434 O O   . HOH C 3 .   ? 24.244  40.633 20.856  1.00 19.90 ? 411 HOH A O   1 
+HETATM 2435 O O   . HOH C 3 .   ? 24.036  38.394 16.441  1.00 23.25 ? 412 HOH A O   1 
+HETATM 2436 O O   . HOH C 3 .   ? 22.136  27.773 14.509  1.00 25.09 ? 413 HOH A O   1 
+HETATM 2437 O O   . HOH C 3 .   ? 20.037  29.160 13.912  1.00 23.13 ? 414 HOH A O   1 
+HETATM 2438 O O   . HOH C 3 .   ? 23.780  38.522 25.955  1.00 25.71 ? 415 HOH A O   1 
+HETATM 2439 O O   . HOH C 3 .   ? 22.589  35.729 16.031  1.00 24.52 ? 416 HOH A O   1 
+HETATM 2440 O O   . HOH C 3 .   ? 21.319  34.783 13.893  1.00 27.16 ? 417 HOH A O   1 
+HETATM 2441 O O   . HOH C 3 .   ? 22.541  38.605 11.768  1.00 12.78 ? 418 HOH A O   1 
+HETATM 2442 O O   . HOH C 3 .   ? 11.060  42.940 10.105  1.00 23.45 ? 419 HOH A O   1 
+HETATM 2443 O O   . HOH C 3 .   ? 9.121   41.470 8.552   1.00 19.77 ? 420 HOH A O   1 
+HETATM 2444 O O   . HOH C 3 .   ? 5.943   41.956 7.601   1.00 28.42 ? 421 HOH A O   1 
+HETATM 2445 O O   . HOH C 3 .   ? 6.842   38.488 6.035   1.00 16.84 ? 422 HOH A O   1 
+HETATM 2446 O O   . HOH C 3 .   ? 3.085   37.969 3.144   1.00 29.23 ? 423 HOH A O   1 
+HETATM 2447 O O   . HOH C 3 .   ? 9.315   30.341 38.738  1.00 23.07 ? 424 HOH A O   1 
+HETATM 2448 O O   . HOH C 3 .   ? 0.205   38.104 35.563  1.00 11.96 ? 425 HOH A O   1 
+HETATM 2449 O O   . HOH C 3 .   ? 3.281   40.391 37.686  1.00 29.17 ? 426 HOH A O   1 
+HETATM 2450 O O   . HOH C 3 .   ? 5.915   29.881 41.578  1.00 14.80 ? 427 HOH A O   1 
+HETATM 2451 O O   . HOH C 3 .   ? 14.167  21.379 28.108  1.00 21.13 ? 428 HOH A O   1 
+HETATM 2452 O O   . HOH C 3 .   ? 12.601  19.195 30.753  1.00 34.75 ? 429 HOH A O   1 
+HETATM 2453 O O   . HOH C 3 .   ? 8.394   21.415 19.856  1.00 27.96 ? 430 HOH A O   1 
+HETATM 2454 O O   . HOH C 3 .   ? 14.687  24.172 7.111   1.00 28.70 ? 431 HOH A O   1 
+HETATM 2455 O O   . HOH C 3 .   ? 20.221  22.800 9.249   1.00 29.69 ? 432 HOH A O   1 
+HETATM 2456 O O   . HOH C 3 .   ? 13.105  24.007 3.674   1.00 31.09 ? 433 HOH A O   1 
+HETATM 2457 O O   . HOH C 3 .   ? 8.729   21.384 5.753   1.00 26.46 ? 434 HOH A O   1 
+HETATM 2458 O O   . HOH C 3 .   ? -1.908  25.897 14.729  1.00 27.77 ? 435 HOH A O   1 
+HETATM 2459 O O   . HOH C 3 .   ? -9.830  44.378 18.172  1.00 32.81 ? 436 HOH A O   1 
+HETATM 2460 O O   . HOH C 3 .   ? -7.067  48.546 13.991  1.00 25.09 ? 437 HOH A O   1 
+HETATM 2461 O O   . HOH C 3 .   ? -2.329  43.910 29.515  1.00 23.93 ? 438 HOH A O   1 
+HETATM 2462 O O   . HOH C 3 .   ? 7.002   47.784 31.909  1.00 23.80 ? 439 HOH A O   1 
+HETATM 2463 O O   . HOH C 3 .   ? 4.860   47.289 33.608  1.00 26.58 ? 440 HOH A O   1 
+HETATM 2464 O O   . HOH C 3 .   ? 19.609  28.843 38.663  1.00 34.73 ? 441 HOH A O   1 
+HETATM 2465 O O   . HOH C 3 .   ? 21.173  41.904 28.581  1.00 20.94 ? 442 HOH A O   1 
+HETATM 2466 O O   . HOH C 3 .   ? 14.813  23.913 20.182  1.00 38.69 ? 443 HOH A O   1 
+HETATM 2467 O O   . HOH C 3 .   ? 17.131  24.094 18.114  1.00 21.07 ? 444 HOH A O   1 
+HETATM 2468 O O   . HOH C 3 .   ? -6.374  25.431 21.794  1.00 24.94 ? 445 HOH A O   1 
+HETATM 2469 O O   . HOH C 3 .   ? 2.597   23.756 8.363   1.00 33.30 ? 446 HOH A O   1 
+HETATM 2470 O O   . HOH C 3 .   ? 3.200   19.687 15.795  1.00 22.17 ? 447 HOH A O   1 
+HETATM 2471 O O   . HOH C 3 .   ? 6.478   15.057 16.103  1.00 31.86 ? 448 HOH A O   1 
+HETATM 2472 O O   . HOH C 3 .   ? -1.303  16.784 12.557  1.00 20.35 ? 449 HOH A O   1 
+HETATM 2473 O O   . HOH C 3 .   ? -3.194  16.466 10.433  1.00 23.08 ? 450 HOH A O   1 
+HETATM 2474 O O   . HOH C 3 .   ? -8.164  11.696 12.941  1.00 22.71 ? 451 HOH A O   1 
+HETATM 2475 O O   . HOH C 3 .   ? 0.144   9.888  29.891  1.00 20.26 ? 452 HOH A O   1 
+HETATM 2476 O O   . HOH C 3 .   ? 1.564   35.595 -7.330  1.00 31.74 ? 453 HOH A O   1 
+HETATM 2477 O O   . HOH C 3 .   ? -10.440 17.104 14.467  1.00 22.67 ? 454 HOH A O   1 
+HETATM 2478 O O   . HOH C 3 .   ? -13.828 22.474 9.921   1.00 25.24 ? 455 HOH A O   1 
+HETATM 2479 O O   . HOH C 3 .   ? -6.026  38.480 -0.021  1.00 25.24 ? 456 HOH A O   1 
+HETATM 2480 O O   . HOH C 3 .   ? -2.412  36.013 14.225  1.00 40.83 ? 457 HOH A O   1 
+HETATM 2481 O O   . HOH C 3 .   ? -8.187  44.333 8.512   1.00 31.91 ? 458 HOH A O   1 
+HETATM 2482 O O   . HOH C 3 .   ? -1.385  14.905 23.960  1.00 23.74 ? 459 HOH A O   1 
+HETATM 2483 O O   . HOH C 3 .   ? -1.657  7.863  26.711  1.00 26.24 ? 460 HOH A O   1 
+HETATM 2484 O O   . HOH C 3 .   ? -2.720  23.782 16.300  1.00 21.60 ? 461 HOH A O   1 
+HETATM 2485 O O   . HOH C 3 .   ? -9.299  24.988 31.996  1.00 21.67 ? 462 HOH A O   1 
+HETATM 2486 O O   . HOH C 3 .   ? -0.609  20.794 47.113  1.00 26.39 ? 463 HOH A O   1 
+HETATM 2487 O O   . HOH C 3 .   ? 5.537   25.244 48.171  1.00 34.19 ? 464 HOH A O   1 
+HETATM 2488 O O   . HOH C 3 .   ? 24.828  32.116 21.277  1.00 22.75 ? 465 HOH A O   1 
+HETATM 2489 O O   . HOH C 3 .   ? 7.263   49.286 19.834  1.00 32.16 ? 466 HOH A O   1 
+HETATM 2490 O O   . HOH C 3 .   ? 8.751   37.858 40.740  1.00 21.17 ? 467 HOH A O   1 
+HETATM 2491 O O   . HOH C 3 .   ? 18.680  26.919 34.446  1.00 17.11 ? 468 HOH A O   1 
+HETATM 2492 O O   . HOH C 3 .   ? 12.735  24.167 39.333  1.00 17.43 ? 469 HOH A O   1 
+HETATM 2493 O O   . HOH C 3 .   ? 10.854  17.043 42.107  1.00 16.20 ? 470 HOH A O   1 
+HETATM 2494 O O   . HOH C 3 .   ? 20.630  18.298 35.853  1.00 26.16 ? 471 HOH A O   1 
+HETATM 2495 O O   . HOH C 3 .   ? -0.080  47.463 28.753  1.00 28.27 ? 472 HOH A O   1 
+HETATM 2496 O O   . HOH C 3 .   ? -4.815  11.205 10.914  1.00 25.97 ? 473 HOH A O   1 
+HETATM 2497 O O   . HOH C 3 .   ? -5.223  31.461 40.517  1.00 16.27 ? 474 HOH A O   1 
+HETATM 2498 O O   . HOH C 3 .   ? -7.930  27.802 48.381  1.00 19.10 ? 475 HOH A O   1 
+HETATM 2499 O O   . HOH C 3 .   ? 1.549   34.148 45.313  1.00 21.83 ? 476 HOH A O   1 
+HETATM 2500 O O   . HOH C 3 .   ? 21.165  21.226 42.918  1.00 28.13 ? 477 HOH A O   1 
+HETATM 2501 O O   . HOH C 3 .   ? 18.591  44.359 12.366  1.00 22.19 ? 478 HOH A O   1 
+# 
+loop_
+_pdbx_poly_seq_scheme.asym_id 
+_pdbx_poly_seq_scheme.entity_id 
+_pdbx_poly_seq_scheme.seq_id 
+_pdbx_poly_seq_scheme.mon_id 
+_pdbx_poly_seq_scheme.ndb_seq_num 
+_pdbx_poly_seq_scheme.pdb_seq_num 
+_pdbx_poly_seq_scheme.auth_seq_num 
+_pdbx_poly_seq_scheme.pdb_mon_id 
+_pdbx_poly_seq_scheme.auth_mon_id 
+_pdbx_poly_seq_scheme.pdb_strand_id 
+_pdbx_poly_seq_scheme.pdb_ins_code 
+_pdbx_poly_seq_scheme.hetero 
+A 1 1   MET 1   1   1   MET MET A . n 
+A 1 2   GLU 2   2   2   GLU GLU A . n 
+A 1 3   ASN 3   3   3   ASN ASN A . n 
+A 1 4   PHE 4   4   4   PHE PHE A . n 
+A 1 5   GLN 5   5   5   GLN GLN A . n 
+A 1 6   LYS 6   6   6   LYS LYS A . n 
+A 1 7   VAL 7   7   7   VAL VAL A . n 
+A 1 8   GLU 8   8   8   GLU GLU A . n 
+A 1 9   LYS 9   9   9   LYS LYS A . n 
+A 1 10  ILE 10  10  10  ILE ILE A . n 
+A 1 11  GLY 11  11  11  GLY GLY A . n 
+A 1 12  GLU 12  12  12  GLU GLU A . n 
+A 1 13  GLY 13  13  13  GLY GLY A . n 
+A 1 14  THR 14  14  14  THR THR A . n 
+A 1 15  TYR 15  15  15  TYR TYR A . n 
+A 1 16  GLY 16  16  16  GLY GLY A . n 
+A 1 17  VAL 17  17  17  VAL VAL A . n 
+A 1 18  VAL 18  18  18  VAL VAL A . n 
+A 1 19  TYR 19  19  19  TYR TYR A . n 
+A 1 20  LYS 20  20  20  LYS LYS A . n 
+A 1 21  ALA 21  21  21  ALA ALA A . n 
+A 1 22  ARG 22  22  22  ARG ARG A . n 
+A 1 23  ASN 23  23  23  ASN ASN A . n 
+A 1 24  LYS 24  24  24  LYS LYS A . n 
+A 1 25  LEU 25  25  25  LEU LEU A . n 
+A 1 26  THR 26  26  26  THR THR A . n 
+A 1 27  GLY 27  27  27  GLY GLY A . n 
+A 1 28  GLU 28  28  28  GLU GLU A . n 
+A 1 29  VAL 29  29  29  VAL VAL A . n 
+A 1 30  VAL 30  30  30  VAL VAL A . n 
+A 1 31  ALA 31  31  31  ALA ALA A . n 
+A 1 32  LEU 32  32  32  LEU LEU A . n 
+A 1 33  LYS 33  33  33  LYS LYS A . n 
+A 1 34  LYS 34  34  34  LYS LYS A . n 
+A 1 35  ILE 35  35  35  ILE ILE A . n 
+A 1 36  ARG 36  36  36  ARG ARG A . n 
+A 1 37  LEU 37  37  37  LEU LEU A . n 
+A 1 38  ASP 38  38  ?   ?   ?   A . n 
+A 1 39  THR 39  39  ?   ?   ?   A . n 
+A 1 40  GLU 40  40  ?   ?   ?   A . n 
+A 1 41  THR 41  41  ?   ?   ?   A . n 
+A 1 42  GLU 42  42  ?   ?   ?   A . n 
+A 1 43  GLY 43  43  ?   ?   ?   A . n 
+A 1 44  VAL 44  44  ?   ?   ?   A . n 
+A 1 45  PRO 45  45  ?   ?   ?   A . n 
+A 1 46  SER 46  46  ?   ?   ?   A . n 
+A 1 47  THR 47  47  ?   ?   ?   A . n 
+A 1 48  ALA 48  48  ?   ?   ?   A . n 
+A 1 49  ILE 49  49  ?   ?   ?   A . n 
+A 1 50  ARG 50  50  50  ARG ARG A . n 
+A 1 51  GLU 51  51  51  GLU GLU A . n 
+A 1 52  ILE 52  52  52  ILE ILE A . n 
+A 1 53  SER 53  53  53  SER SER A . n 
+A 1 54  LEU 54  54  54  LEU LEU A . n 
+A 1 55  LEU 55  55  55  LEU LEU A . n 
+A 1 56  LYS 56  56  56  LYS LYS A . n 
+A 1 57  GLU 57  57  57  GLU GLU A . n 
+A 1 58  LEU 58  58  58  LEU LEU A . n 
+A 1 59  ASN 59  59  59  ASN ASN A . n 
+A 1 60  HIS 60  60  60  HIS HIS A . n 
+A 1 61  PRO 61  61  61  PRO PRO A . n 
+A 1 62  ASN 62  62  62  ASN ASN A . n 
+A 1 63  ILE 63  63  63  ILE ILE A . n 
+A 1 64  VAL 64  64  64  VAL VAL A . n 
+A 1 65  LYS 65  65  65  LYS LYS A . n 
+A 1 66  LEU 66  66  66  LEU LEU A . n 
+A 1 67  LEU 67  67  67  LEU LEU A . n 
+A 1 68  ASP 68  68  68  ASP ASP A . n 
+A 1 69  VAL 69  69  69  VAL VAL A . n 
+A 1 70  ILE 70  70  70  ILE ILE A . n 
+A 1 71  HIS 71  71  71  HIS HIS A . n 
+A 1 72  THR 72  72  72  THR THR A . n 
+A 1 73  GLU 73  73  73  GLU GLU A . n 
+A 1 74  ASN 74  74  74  ASN ASN A . n 
+A 1 75  LYS 75  75  75  LYS LYS A . n 
+A 1 76  LEU 76  76  76  LEU LEU A . n 
+A 1 77  TYR 77  77  77  TYR TYR A . n 
+A 1 78  LEU 78  78  78  LEU LEU A . n 
+A 1 79  VAL 79  79  79  VAL VAL A . n 
+A 1 80  PHE 80  80  80  PHE PHE A . n 
+A 1 81  GLU 81  81  81  GLU GLU A . n 
+A 1 82  PHE 82  82  82  PHE PHE A . n 
+A 1 83  LEU 83  83  83  LEU LEU A . n 
+A 1 84  HIS 84  84  84  HIS HIS A . n 
+A 1 85  GLN 85  85  85  GLN GLN A . n 
+A 1 86  ASP 86  86  86  ASP ASP A . n 
+A 1 87  LEU 87  87  87  LEU LEU A . n 
+A 1 88  LYS 88  88  88  LYS LYS A . n 
+A 1 89  LYS 89  89  89  LYS LYS A . n 
+A 1 90  PHE 90  90  90  PHE PHE A . n 
+A 1 91  MET 91  91  91  MET MET A . n 
+A 1 92  ASP 92  92  92  ASP ASP A . n 
+A 1 93  ALA 93  93  93  ALA ALA A . n 
+A 1 94  SER 94  94  94  SER SER A . n 
+A 1 95  ALA 95  95  95  ALA ALA A . n 
+A 1 96  LEU 96  96  96  LEU LEU A . n 
+A 1 97  THR 97  97  97  THR THR A . n 
+A 1 98  GLY 98  98  98  GLY GLY A . n 
+A 1 99  ILE 99  99  99  ILE ILE A . n 
+A 1 100 PRO 100 100 100 PRO PRO A . n 
+A 1 101 LEU 101 101 101 LEU LEU A . n 
+A 1 102 PRO 102 102 102 PRO PRO A . n 
+A 1 103 LEU 103 103 103 LEU LEU A . n 
+A 1 104 ILE 104 104 104 ILE ILE A . n 
+A 1 105 LYS 105 105 105 LYS LYS A . n 
+A 1 106 SER 106 106 106 SER SER A . n 
+A 1 107 TYR 107 107 107 TYR TYR A . n 
+A 1 108 LEU 108 108 108 LEU LEU A . n 
+A 1 109 PHE 109 109 109 PHE PHE A . n 
+A 1 110 GLN 110 110 110 GLN GLN A . n 
+A 1 111 LEU 111 111 111 LEU LEU A . n 
+A 1 112 LEU 112 112 112 LEU LEU A . n 
+A 1 113 GLN 113 113 113 GLN GLN A . n 
+A 1 114 GLY 114 114 114 GLY GLY A . n 
+A 1 115 LEU 115 115 115 LEU LEU A . n 
+A 1 116 ALA 116 116 116 ALA ALA A . n 
+A 1 117 PHE 117 117 117 PHE PHE A . n 
+A 1 118 CYS 118 118 118 CYS CYS A . n 
+A 1 119 HIS 119 119 119 HIS HIS A . n 
+A 1 120 SER 120 120 120 SER SER A . n 
+A 1 121 HIS 121 121 121 HIS HIS A . n 
+A 1 122 ARG 122 122 122 ARG ARG A . n 
+A 1 123 VAL 123 123 123 VAL VAL A . n 
+A 1 124 LEU 124 124 124 LEU LEU A . n 
+A 1 125 HIS 125 125 125 HIS HIS A . n 
+A 1 126 ARG 126 126 126 ARG ARG A . n 
+A 1 127 ASP 127 127 127 ASP ASP A . n 
+A 1 128 LEU 128 128 128 LEU LEU A . n 
+A 1 129 LYS 129 129 129 LYS LYS A . n 
+A 1 130 PRO 130 130 130 PRO PRO A . n 
+A 1 131 GLN 131 131 131 GLN GLN A . n 
+A 1 132 ASN 132 132 132 ASN ASN A . n 
+A 1 133 LEU 133 133 133 LEU LEU A . n 
+A 1 134 LEU 134 134 134 LEU LEU A . n 
+A 1 135 ILE 135 135 135 ILE ILE A . n 
+A 1 136 ASN 136 136 136 ASN ASN A . n 
+A 1 137 THR 137 137 137 THR THR A . n 
+A 1 138 GLU 138 138 138 GLU GLU A . n 
+A 1 139 GLY 139 139 139 GLY GLY A . n 
+A 1 140 ALA 140 140 140 ALA ALA A . n 
+A 1 141 ILE 141 141 141 ILE ILE A . n 
+A 1 142 LYS 142 142 142 LYS LYS A . n 
+A 1 143 LEU 143 143 143 LEU LEU A . n 
+A 1 144 ALA 144 144 144 ALA ALA A . n 
+A 1 145 ASP 145 145 145 ASP ASP A . n 
+A 1 146 PHE 146 146 146 PHE PHE A . n 
+A 1 147 GLY 147 147 147 GLY GLY A . n 
+A 1 148 LEU 148 148 148 LEU LEU A . n 
+A 1 149 ALA 149 149 149 ALA ALA A . n 
+A 1 150 ARG 150 150 ?   ?   ?   A . n 
+A 1 151 ALA 151 151 ?   ?   ?   A . n 
+A 1 152 PHE 152 152 152 PHE PHE A . n 
+A 1 153 GLY 153 153 153 GLY GLY A . n 
+A 1 154 VAL 154 154 154 VAL VAL A . n 
+A 1 155 PRO 155 155 155 PRO PRO A . n 
+A 1 156 VAL 156 156 156 VAL VAL A . n 
+A 1 157 ARG 157 157 157 ARG ARG A . n 
+A 1 158 THR 158 158 158 THR THR A . n 
+A 1 159 TYR 159 159 159 TYR TYR A . n 
+A 1 160 THR 160 160 160 THR THR A . n 
+A 1 161 HIS 161 161 161 HIS HIS A . n 
+A 1 162 GLU 162 162 162 GLU GLU A . n 
+A 1 163 VAL 163 163 163 VAL VAL A . n 
+A 1 164 VAL 164 164 164 VAL VAL A . n 
+A 1 165 THR 165 165 165 THR THR A . n 
+A 1 166 LEU 166 166 166 LEU LEU A . n 
+A 1 167 TRP 167 167 167 TRP TRP A . n 
+A 1 168 TYR 168 168 168 TYR TYR A . n 
+A 1 169 ARG 169 169 169 ARG ARG A . n 
+A 1 170 ALA 170 170 170 ALA ALA A . n 
+A 1 171 PRO 171 171 171 PRO PRO A . n 
+A 1 172 GLU 172 172 172 GLU GLU A . n 
+A 1 173 ILE 173 173 173 ILE ILE A . n 
+A 1 174 LEU 174 174 174 LEU LEU A . n 
+A 1 175 LEU 175 175 175 LEU LEU A . n 
+A 1 176 GLY 176 176 176 GLY GLY A . n 
+A 1 177 CYS 177 177 177 CYS CYS A . n 
+A 1 178 LYS 178 178 178 LYS LYS A . n 
+A 1 179 TYR 179 179 179 TYR TYR A . n 
+A 1 180 TYR 180 180 180 TYR TYR A . n 
+A 1 181 SER 181 181 181 SER SER A . n 
+A 1 182 THR 182 182 182 THR THR A . n 
+A 1 183 ALA 183 183 183 ALA ALA A . n 
+A 1 184 VAL 184 184 184 VAL VAL A . n 
+A 1 185 ASP 185 185 185 ASP ASP A . n 
+A 1 186 ILE 186 186 186 ILE ILE A . n 
+A 1 187 TRP 187 187 187 TRP TRP A . n 
+A 1 188 SER 188 188 188 SER SER A . n 
+A 1 189 LEU 189 189 189 LEU LEU A . n 
+A 1 190 GLY 190 190 190 GLY GLY A . n 
+A 1 191 CYS 191 191 191 CYS CYS A . n 
+A 1 192 ILE 192 192 192 ILE ILE A . n 
+A 1 193 PHE 193 193 193 PHE PHE A . n 
+A 1 194 ALA 194 194 194 ALA ALA A . n 
+A 1 195 GLU 195 195 195 GLU GLU A . n 
+A 1 196 MET 196 196 196 MET MET A . n 
+A 1 197 VAL 197 197 197 VAL VAL A . n 
+A 1 198 THR 198 198 198 THR THR A . n 
+A 1 199 ARG 199 199 199 ARG ARG A . n 
+A 1 200 ARG 200 200 200 ARG ARG A . n 
+A 1 201 ALA 201 201 201 ALA ALA A . n 
+A 1 202 LEU 202 202 202 LEU LEU A . n 
+A 1 203 PHE 203 203 203 PHE PHE A . n 
+A 1 204 PRO 204 204 204 PRO PRO A . n 
+A 1 205 GLY 205 205 205 GLY GLY A . n 
+A 1 206 ASP 206 206 206 ASP ASP A . n 
+A 1 207 SER 207 207 207 SER SER A . n 
+A 1 208 GLU 208 208 208 GLU GLU A . n 
+A 1 209 ILE 209 209 209 ILE ILE A . n 
+A 1 210 ASP 210 210 210 ASP ASP A . n 
+A 1 211 GLN 211 211 211 GLN GLN A . n 
+A 1 212 LEU 212 212 212 LEU LEU A . n 
+A 1 213 PHE 213 213 213 PHE PHE A . n 
+A 1 214 ARG 214 214 214 ARG ARG A . n 
+A 1 215 ILE 215 215 215 ILE ILE A . n 
+A 1 216 PHE 216 216 216 PHE PHE A . n 
+A 1 217 ARG 217 217 217 ARG ARG A . n 
+A 1 218 THR 218 218 218 THR THR A . n 
+A 1 219 LEU 219 219 219 LEU LEU A . n 
+A 1 220 GLY 220 220 220 GLY GLY A . n 
+A 1 221 THR 221 221 221 THR THR A . n 
+A 1 222 PRO 222 222 222 PRO PRO A . n 
+A 1 223 ASP 223 223 223 ASP ASP A . n 
+A 1 224 GLU 224 224 224 GLU GLU A . n 
+A 1 225 VAL 225 225 225 VAL VAL A . n 
+A 1 226 VAL 226 226 226 VAL VAL A . n 
+A 1 227 TRP 227 227 227 TRP TRP A . n 
+A 1 228 PRO 228 228 228 PRO PRO A . n 
+A 1 229 GLY 229 229 229 GLY GLY A . n 
+A 1 230 VAL 230 230 230 VAL VAL A . n 
+A 1 231 THR 231 231 231 THR THR A . n 
+A 1 232 SER 232 232 232 SER SER A . n 
+A 1 233 MET 233 233 233 MET MET A . n 
+A 1 234 PRO 234 234 234 PRO PRO A . n 
+A 1 235 ASP 235 235 235 ASP ASP A . n 
+A 1 236 TYR 236 236 236 TYR TYR A . n 
+A 1 237 LYS 237 237 237 LYS LYS A . n 
+A 1 238 PRO 238 238 238 PRO PRO A . n 
+A 1 239 SER 239 239 239 SER SER A . n 
+A 1 240 PHE 240 240 240 PHE PHE A . n 
+A 1 241 PRO 241 241 241 PRO PRO A . n 
+A 1 242 LYS 242 242 242 LYS LYS A . n 
+A 1 243 TRP 243 243 243 TRP TRP A . n 
+A 1 244 ALA 244 244 244 ALA ALA A . n 
+A 1 245 ARG 245 245 245 ARG ARG A . n 
+A 1 246 GLN 246 246 246 GLN GLN A . n 
+A 1 247 ASP 247 247 247 ASP ASP A . n 
+A 1 248 PHE 248 248 248 PHE PHE A . n 
+A 1 249 SER 249 249 249 SER SER A . n 
+A 1 250 LYS 250 250 250 LYS LYS A . n 
+A 1 251 VAL 251 251 251 VAL VAL A . n 
+A 1 252 VAL 252 252 252 VAL VAL A . n 
+A 1 253 PRO 253 253 253 PRO PRO A . n 
+A 1 254 PRO 254 254 254 PRO PRO A . n 
+A 1 255 LEU 255 255 255 LEU LEU A . n 
+A 1 256 ASP 256 256 256 ASP ASP A . n 
+A 1 257 GLU 257 257 257 GLU GLU A . n 
+A 1 258 ASP 258 258 258 ASP ASP A . n 
+A 1 259 GLY 259 259 259 GLY GLY A . n 
+A 1 260 ARG 260 260 260 ARG ARG A . n 
+A 1 261 SER 261 261 261 SER SER A . n 
+A 1 262 LEU 262 262 262 LEU LEU A . n 
+A 1 263 LEU 263 263 263 LEU LEU A . n 
+A 1 264 SER 264 264 264 SER SER A . n 
+A 1 265 GLN 265 265 265 GLN GLN A . n 
+A 1 266 MET 266 266 266 MET MET A . n 
+A 1 267 LEU 267 267 267 LEU LEU A . n 
+A 1 268 HIS 268 268 268 HIS HIS A . n 
+A 1 269 TYR 269 269 269 TYR TYR A . n 
+A 1 270 ASP 270 270 270 ASP ASP A . n 
+A 1 271 PRO 271 271 271 PRO PRO A . n 
+A 1 272 ASN 272 272 272 ASN ASN A . n 
+A 1 273 LYS 273 273 273 LYS LYS A . n 
+A 1 274 ARG 274 274 274 ARG ARG A . n 
+A 1 275 ILE 275 275 275 ILE ILE A . n 
+A 1 276 SER 276 276 276 SER SER A . n 
+A 1 277 ALA 277 277 277 ALA ALA A . n 
+A 1 278 LYS 278 278 278 LYS LYS A . n 
+A 1 279 ALA 279 279 279 ALA ALA A . n 
+A 1 280 ALA 280 280 280 ALA ALA A . n 
+A 1 281 LEU 281 281 281 LEU LEU A . n 
+A 1 282 ALA 282 282 282 ALA ALA A . n 
+A 1 283 HIS 283 283 283 HIS HIS A . n 
+A 1 284 PRO 284 284 284 PRO PRO A . n 
+A 1 285 PHE 285 285 285 PHE PHE A . n 
+A 1 286 PHE 286 286 286 PHE PHE A . n 
+A 1 287 GLN 287 287 287 GLN GLN A . n 
+A 1 288 ASP 288 288 288 ASP ASP A . n 
+A 1 289 VAL 289 289 289 VAL VAL A . n 
+A 1 290 THR 290 290 290 THR THR A . n 
+A 1 291 LYS 291 291 291 LYS LYS A . n 
+A 1 292 PRO 292 292 292 PRO PRO A . n 
+A 1 293 VAL 293 293 293 VAL VAL A . n 
+A 1 294 PRO 294 294 294 PRO PRO A . n 
+A 1 295 HIS 295 295 295 HIS HIS A . n 
+A 1 296 LEU 296 296 296 LEU LEU A . n 
+A 1 297 ARG 297 297 297 ARG ARG A . n 
+A 1 298 LEU 298 298 298 LEU LEU A . n 
+# 
+loop_
+_pdbx_nonpoly_scheme.asym_id 
+_pdbx_nonpoly_scheme.entity_id 
+_pdbx_nonpoly_scheme.mon_id 
+_pdbx_nonpoly_scheme.ndb_seq_num 
+_pdbx_nonpoly_scheme.pdb_seq_num 
+_pdbx_nonpoly_scheme.auth_seq_num 
+_pdbx_nonpoly_scheme.pdb_mon_id 
+_pdbx_nonpoly_scheme.auth_mon_id 
+_pdbx_nonpoly_scheme.pdb_strand_id 
+_pdbx_nonpoly_scheme.pdb_ins_code 
+B 2 LIA 1   299 201 LIA LIA A . 
+C 3 HOH 1   300 1   HOH HOH A . 
+C 3 HOH 2   301 2   HOH HOH A . 
+C 3 HOH 3   302 3   HOH HOH A . 
+C 3 HOH 4   303 4   HOH HOH A . 
+C 3 HOH 5   304 5   HOH HOH A . 
+C 3 HOH 6   305 6   HOH HOH A . 
+C 3 HOH 7   306 7   HOH HOH A . 
+C 3 HOH 8   307 8   HOH HOH A . 
+C 3 HOH 9   308 9   HOH HOH A . 
+C 3 HOH 10  309 10  HOH HOH A . 
+C 3 HOH 11  310 11  HOH HOH A . 
+C 3 HOH 12  311 12  HOH HOH A . 
+C 3 HOH 13  312 13  HOH HOH A . 
+C 3 HOH 14  313 14  HOH HOH A . 
+C 3 HOH 15  314 15  HOH HOH A . 
+C 3 HOH 16  315 16  HOH HOH A . 
+C 3 HOH 17  316 17  HOH HOH A . 
+C 3 HOH 18  317 18  HOH HOH A . 
+C 3 HOH 19  318 19  HOH HOH A . 
+C 3 HOH 20  319 20  HOH HOH A . 
+C 3 HOH 21  320 21  HOH HOH A . 
+C 3 HOH 22  321 22  HOH HOH A . 
+C 3 HOH 23  322 23  HOH HOH A . 
+C 3 HOH 24  323 24  HOH HOH A . 
+C 3 HOH 25  324 25  HOH HOH A . 
+C 3 HOH 26  325 26  HOH HOH A . 
+C 3 HOH 27  326 27  HOH HOH A . 
+C 3 HOH 28  327 28  HOH HOH A . 
+C 3 HOH 29  328 29  HOH HOH A . 
+C 3 HOH 30  329 30  HOH HOH A . 
+C 3 HOH 31  330 31  HOH HOH A . 
+C 3 HOH 32  331 32  HOH HOH A . 
+C 3 HOH 33  332 33  HOH HOH A . 
+C 3 HOH 34  333 34  HOH HOH A . 
+C 3 HOH 35  334 35  HOH HOH A . 
+C 3 HOH 36  335 36  HOH HOH A . 
+C 3 HOH 37  336 37  HOH HOH A . 
+C 3 HOH 38  337 38  HOH HOH A . 
+C 3 HOH 39  338 39  HOH HOH A . 
+C 3 HOH 40  339 40  HOH HOH A . 
+C 3 HOH 41  340 41  HOH HOH A . 
+C 3 HOH 42  341 42  HOH HOH A . 
+C 3 HOH 43  342 43  HOH HOH A . 
+C 3 HOH 44  343 44  HOH HOH A . 
+C 3 HOH 45  344 45  HOH HOH A . 
+C 3 HOH 46  345 46  HOH HOH A . 
+C 3 HOH 47  346 47  HOH HOH A . 
+C 3 HOH 48  347 48  HOH HOH A . 
+C 3 HOH 49  348 49  HOH HOH A . 
+C 3 HOH 50  349 50  HOH HOH A . 
+C 3 HOH 51  350 51  HOH HOH A . 
+C 3 HOH 52  351 52  HOH HOH A . 
+C 3 HOH 53  352 53  HOH HOH A . 
+C 3 HOH 54  353 54  HOH HOH A . 
+C 3 HOH 55  354 55  HOH HOH A . 
+C 3 HOH 56  355 57  HOH HOH A . 
+C 3 HOH 57  356 58  HOH HOH A . 
+C 3 HOH 58  357 59  HOH HOH A . 
+C 3 HOH 59  358 60  HOH HOH A . 
+C 3 HOH 60  359 62  HOH HOH A . 
+C 3 HOH 61  360 63  HOH HOH A . 
+C 3 HOH 62  361 64  HOH HOH A . 
+C 3 HOH 63  362 65  HOH HOH A . 
+C 3 HOH 64  363 66  HOH HOH A . 
+C 3 HOH 65  364 67  HOH HOH A . 
+C 3 HOH 66  365 68  HOH HOH A . 
+C 3 HOH 67  366 69  HOH HOH A . 
+C 3 HOH 68  367 70  HOH HOH A . 
+C 3 HOH 69  368 72  HOH HOH A . 
+C 3 HOH 70  369 73  HOH HOH A . 
+C 3 HOH 71  370 74  HOH HOH A . 
+C 3 HOH 72  371 75  HOH HOH A . 
+C 3 HOH 73  372 76  HOH HOH A . 
+C 3 HOH 74  373 77  HOH HOH A . 
+C 3 HOH 75  374 79  HOH HOH A . 
+C 3 HOH 76  375 83  HOH HOH A . 
+C 3 HOH 77  376 84  HOH HOH A . 
+C 3 HOH 78  377 85  HOH HOH A . 
+C 3 HOH 79  378 86  HOH HOH A . 
+C 3 HOH 80  379 87  HOH HOH A . 
+C 3 HOH 81  380 81  HOH HOH A . 
+C 3 HOH 82  381 88  HOH HOH A . 
+C 3 HOH 83  382 90  HOH HOH A . 
+C 3 HOH 84  383 91  HOH HOH A . 
+C 3 HOH 85  384 92  HOH HOH A . 
+C 3 HOH 86  385 93  HOH HOH A . 
+C 3 HOH 87  386 94  HOH HOH A . 
+C 3 HOH 88  387 95  HOH HOH A . 
+C 3 HOH 89  388 96  HOH HOH A . 
+C 3 HOH 90  389 97  HOH HOH A . 
+C 3 HOH 91  390 98  HOH HOH A . 
+C 3 HOH 92  391 99  HOH HOH A . 
+C 3 HOH 93  392 100 HOH HOH A . 
+C 3 HOH 94  393 101 HOH HOH A . 
+C 3 HOH 95  394 102 HOH HOH A . 
+C 3 HOH 96  395 103 HOH HOH A . 
+C 3 HOH 97  396 104 HOH HOH A . 
+C 3 HOH 98  397 105 HOH HOH A . 
+C 3 HOH 99  398 106 HOH HOH A . 
+C 3 HOH 100 399 107 HOH HOH A . 
+C 3 HOH 101 400 108 HOH HOH A . 
+C 3 HOH 102 401 110 HOH HOH A . 
+C 3 HOH 103 402 111 HOH HOH A . 
+C 3 HOH 104 403 112 HOH HOH A . 
+C 3 HOH 105 404 113 HOH HOH A . 
+C 3 HOH 106 405 114 HOH HOH A . 
+C 3 HOH 107 406 117 HOH HOH A . 
+C 3 HOH 108 407 118 HOH HOH A . 
+C 3 HOH 109 408 119 HOH HOH A . 
+C 3 HOH 110 409 120 HOH HOH A . 
+C 3 HOH 111 410 121 HOH HOH A . 
+C 3 HOH 112 411 122 HOH HOH A . 
+C 3 HOH 113 412 123 HOH HOH A . 
+C 3 HOH 114 413 124 HOH HOH A . 
+C 3 HOH 115 414 125 HOH HOH A . 
+C 3 HOH 116 415 126 HOH HOH A . 
+C 3 HOH 117 416 127 HOH HOH A . 
+C 3 HOH 118 417 128 HOH HOH A . 
+C 3 HOH 119 418 129 HOH HOH A . 
+C 3 HOH 120 419 130 HOH HOH A . 
+C 3 HOH 121 420 131 HOH HOH A . 
+C 3 HOH 122 421 132 HOH HOH A . 
+C 3 HOH 123 422 133 HOH HOH A . 
+C 3 HOH 124 423 134 HOH HOH A . 
+C 3 HOH 125 424 135 HOH HOH A . 
+C 3 HOH 126 425 136 HOH HOH A . 
+C 3 HOH 127 426 137 HOH HOH A . 
+C 3 HOH 128 427 138 HOH HOH A . 
+C 3 HOH 129 428 139 HOH HOH A . 
+C 3 HOH 130 429 140 HOH HOH A . 
+C 3 HOH 131 430 141 HOH HOH A . 
+C 3 HOH 132 431 142 HOH HOH A . 
+C 3 HOH 133 432 143 HOH HOH A . 
+C 3 HOH 134 433 144 HOH HOH A . 
+C 3 HOH 135 434 145 HOH HOH A . 
+C 3 HOH 136 435 146 HOH HOH A . 
+C 3 HOH 137 436 147 HOH HOH A . 
+C 3 HOH 138 437 148 HOH HOH A . 
+C 3 HOH 139 438 149 HOH HOH A . 
+C 3 HOH 140 439 150 HOH HOH A . 
+C 3 HOH 141 440 151 HOH HOH A . 
+C 3 HOH 142 441 152 HOH HOH A . 
+C 3 HOH 143 442 153 HOH HOH A . 
+C 3 HOH 144 443 154 HOH HOH A . 
+C 3 HOH 145 444 155 HOH HOH A . 
+C 3 HOH 146 445 156 HOH HOH A . 
+C 3 HOH 147 446 158 HOH HOH A . 
+C 3 HOH 148 447 159 HOH HOH A . 
+C 3 HOH 149 448 160 HOH HOH A . 
+C 3 HOH 150 449 161 HOH HOH A . 
+C 3 HOH 151 450 162 HOH HOH A . 
+C 3 HOH 152 451 163 HOH HOH A . 
+C 3 HOH 153 452 164 HOH HOH A . 
+C 3 HOH 154 453 165 HOH HOH A . 
+C 3 HOH 155 454 166 HOH HOH A . 
+C 3 HOH 156 455 167 HOH HOH A . 
+C 3 HOH 157 456 168 HOH HOH A . 
+C 3 HOH 158 457 169 HOH HOH A . 
+C 3 HOH 159 458 170 HOH HOH A . 
+C 3 HOH 160 459 171 HOH HOH A . 
+C 3 HOH 161 460 172 HOH HOH A . 
+C 3 HOH 162 461 173 HOH HOH A . 
+C 3 HOH 163 462 174 HOH HOH A . 
+C 3 HOH 164 463 175 HOH HOH A . 
+C 3 HOH 165 464 176 HOH HOH A . 
+C 3 HOH 166 465 177 HOH HOH A . 
+C 3 HOH 167 466 179 HOH HOH A . 
+C 3 HOH 168 467 180 HOH HOH A . 
+C 3 HOH 169 468 181 HOH HOH A . 
+C 3 HOH 170 469 182 HOH HOH A . 
+C 3 HOH 171 470 183 HOH HOH A . 
+C 3 HOH 172 471 184 HOH HOH A . 
+C 3 HOH 173 472 185 HOH HOH A . 
+C 3 HOH 174 473 186 HOH HOH A . 
+C 3 HOH 175 474 187 HOH HOH A . 
+C 3 HOH 176 475 188 HOH HOH A . 
+C 3 HOH 177 476 189 HOH HOH A . 
+C 3 HOH 178 477 191 HOH HOH A . 
+C 3 HOH 179 478 192 HOH HOH A . 
+# 
+_pdbx_struct_assembly.id                   1 
+_pdbx_struct_assembly.details              author_defined_assembly 
+_pdbx_struct_assembly.method_details       ? 
+_pdbx_struct_assembly.oligomeric_details   monomeric 
+_pdbx_struct_assembly.oligomeric_count     1 
+# 
+_pdbx_struct_assembly_gen.assembly_id       1 
+_pdbx_struct_assembly_gen.oper_expression   1 
+_pdbx_struct_assembly_gen.asym_id_list      A,B,C 
+# 
+_pdbx_struct_oper_list.id                   1 
+_pdbx_struct_oper_list.type                 'identity operation' 
+_pdbx_struct_oper_list.name                 1_555 
+_pdbx_struct_oper_list.symmetry_operation   x,y,z 
+_pdbx_struct_oper_list.matrix[1][1]         1.0000000000 
+_pdbx_struct_oper_list.matrix[1][2]         0.0000000000 
+_pdbx_struct_oper_list.matrix[1][3]         0.0000000000 
+_pdbx_struct_oper_list.vector[1]            0.0000000000 
+_pdbx_struct_oper_list.matrix[2][1]         0.0000000000 
+_pdbx_struct_oper_list.matrix[2][2]         1.0000000000 
+_pdbx_struct_oper_list.matrix[2][3]         0.0000000000 
+_pdbx_struct_oper_list.vector[2]            0.0000000000 
+_pdbx_struct_oper_list.matrix[3][1]         0.0000000000 
+_pdbx_struct_oper_list.matrix[3][2]         0.0000000000 
+_pdbx_struct_oper_list.matrix[3][3]         1.0000000000 
+_pdbx_struct_oper_list.vector[3]            0.0000000000 
+# 
+loop_
+_pdbx_audit_revision_history.ordinal 
+_pdbx_audit_revision_history.data_content_type 
+_pdbx_audit_revision_history.major_revision 
+_pdbx_audit_revision_history.minor_revision 
+_pdbx_audit_revision_history.revision_date 
+1 'Structure model' 1 0 2006-10-10 
+2 'Structure model' 1 1 2008-05-01 
+3 'Structure model' 1 2 2011-07-13 
+# 
+_pdbx_audit_revision_details.ordinal             1 
+_pdbx_audit_revision_details.revision_ordinal    1 
+_pdbx_audit_revision_details.data_content_type   'Structure model' 
+_pdbx_audit_revision_details.provider            repository 
+_pdbx_audit_revision_details.type                'Initial release' 
+_pdbx_audit_revision_details.description         ? 
+# 
+loop_
+_pdbx_audit_revision_group.ordinal 
+_pdbx_audit_revision_group.revision_ordinal 
+_pdbx_audit_revision_group.data_content_type 
+_pdbx_audit_revision_group.group 
+1 2 'Structure model' 'Version format compliance' 
+2 3 'Structure model' 'Version format compliance' 
+# 
+loop_
+_software.name 
+_software.classification 
+_software.version 
+_software.citation_id 
+_software.pdbx_ordinal 
+CNX       refinement       2002 ? 1 
+HKL-2000  'data reduction' .    ? 2 
+SCALEPACK 'data scaling'   .    ? 3 
+CNX       phasing          2002 ? 4 
+# 
+loop_
+_pdbx_validate_torsion.id 
+_pdbx_validate_torsion.PDB_model_num 
+_pdbx_validate_torsion.auth_comp_id 
+_pdbx_validate_torsion.auth_asym_id 
+_pdbx_validate_torsion.auth_seq_id 
+_pdbx_validate_torsion.PDB_ins_code 
+_pdbx_validate_torsion.label_alt_id 
+_pdbx_validate_torsion.phi 
+_pdbx_validate_torsion.psi 
+1 1 GLU A 73  ? ? 40.65   79.51  
+2 1 ARG A 126 ? ? 84.78   -19.22 
+3 1 ASP A 127 ? ? -144.19 50.22  
+4 1 TYR A 179 ? ? -119.36 68.37  
+# 
+loop_
+_pdbx_unobs_or_zero_occ_atoms.id 
+_pdbx_unobs_or_zero_occ_atoms.PDB_model_num 
+_pdbx_unobs_or_zero_occ_atoms.polymer_flag 
+_pdbx_unobs_or_zero_occ_atoms.occupancy_flag 
+_pdbx_unobs_or_zero_occ_atoms.auth_asym_id 
+_pdbx_unobs_or_zero_occ_atoms.auth_comp_id 
+_pdbx_unobs_or_zero_occ_atoms.auth_seq_id 
+_pdbx_unobs_or_zero_occ_atoms.PDB_ins_code 
+_pdbx_unobs_or_zero_occ_atoms.auth_atom_id 
+_pdbx_unobs_or_zero_occ_atoms.label_alt_id 
+_pdbx_unobs_or_zero_occ_atoms.label_asym_id 
+_pdbx_unobs_or_zero_occ_atoms.label_comp_id 
+_pdbx_unobs_or_zero_occ_atoms.label_seq_id 
+_pdbx_unobs_or_zero_occ_atoms.label_atom_id 
+1 1 Y 1 A ARG 50 ? CG  ? A ARG 50 CG  
+2 1 Y 1 A ARG 50 ? CD  ? A ARG 50 CD  
+3 1 Y 1 A ARG 50 ? NE  ? A ARG 50 NE  
+4 1 Y 1 A ARG 50 ? CZ  ? A ARG 50 CZ  
+5 1 Y 1 A ARG 50 ? NH1 ? A ARG 50 NH1 
+6 1 Y 1 A ARG 50 ? NH2 ? A ARG 50 NH2 
+# 
+loop_
+_pdbx_unobs_or_zero_occ_residues.id 
+_pdbx_unobs_or_zero_occ_residues.PDB_model_num 
+_pdbx_unobs_or_zero_occ_residues.polymer_flag 
+_pdbx_unobs_or_zero_occ_residues.occupancy_flag 
+_pdbx_unobs_or_zero_occ_residues.auth_asym_id 
+_pdbx_unobs_or_zero_occ_residues.auth_comp_id 
+_pdbx_unobs_or_zero_occ_residues.auth_seq_id 
+_pdbx_unobs_or_zero_occ_residues.PDB_ins_code 
+_pdbx_unobs_or_zero_occ_residues.label_asym_id 
+_pdbx_unobs_or_zero_occ_residues.label_comp_id 
+_pdbx_unobs_or_zero_occ_residues.label_seq_id 
+1  1 Y 1 A ASP 38  ? A ASP 38  
+2  1 Y 1 A THR 39  ? A THR 39  
+3  1 Y 1 A GLU 40  ? A GLU 40  
+4  1 Y 1 A THR 41  ? A THR 41  
+5  1 Y 1 A GLU 42  ? A GLU 42  
+6  1 Y 1 A GLY 43  ? A GLY 43  
+7  1 Y 1 A VAL 44  ? A VAL 44  
+8  1 Y 1 A PRO 45  ? A PRO 45  
+9  1 Y 1 A SER 46  ? A SER 46  
+10 1 Y 1 A THR 47  ? A THR 47  
+11 1 Y 1 A ALA 48  ? A ALA 48  
+12 1 Y 1 A ILE 49  ? A ILE 49  
+13 1 Y 1 A ARG 150 ? A ARG 150 
+14 1 Y 1 A ALA 151 ? A ALA 151 
+# 
+loop_
+_pdbx_entity_nonpoly.entity_id 
+_pdbx_entity_nonpoly.name 
+_pdbx_entity_nonpoly.comp_id 
+2 '(4-AMINO-2-{[1-(METHYLSULFONYL)PIPERIDIN-4-YL]AMINO}PYRIMIDIN-5-YL)(2,3-DIFLUORO-6-METHOXYPHENYL)METHANONE' LIA 
+3 water                                                                                                        HOH 
+# 

--- a/Code/GraphMol/FileParsers/test_data/4bna.cif
+++ b/Code/GraphMol/FileParsers/test_data/4bna.cif
@@ -1,0 +1,1626 @@
+data_4BNA
+# 
+_entry.id   4BNA 
+# 
+_audit_conform.dict_name       mmcif_pdbx.dic 
+_audit_conform.dict_version    5.279 
+_audit_conform.dict_location   http://mmcif.pdb.org/dictionaries/ascii/mmcif_pdbx.dic 
+# 
+loop_
+_database_2.database_id 
+_database_2.database_code 
+PDB   4BNA         
+RCSB  BDLB04       
+WWPDB D_1000179270 
+# 
+_pdbx_database_status.status_code                     REL 
+_pdbx_database_status.entry_id                        4BNA 
+_pdbx_database_status.recvd_initial_deposition_date   1982-02-16 
+_pdbx_database_status.deposit_site                    BNL 
+_pdbx_database_status.process_site                    BNL 
+_pdbx_database_status.status_code_sf                  REL 
+_pdbx_database_status.status_code_mr                  ? 
+_pdbx_database_status.SG_entry                        ? 
+_pdbx_database_status.pdb_format_compatible           Y 
+_pdbx_database_status.status_code_cs                  ? 
+# 
+loop_
+_audit_author.name 
+_audit_author.pdbx_ordinal 
+'Kopka, M.L.'     1 
+'Fratini, A.V.'   2 
+'Dickerson, R.E.' 3 
+# 
+loop_
+_citation.id 
+_citation.title 
+_citation.journal_abbrev 
+_citation.journal_volume 
+_citation.page_first 
+_citation.page_last 
+_citation.year 
+_citation.journal_id_ASTM 
+_citation.country 
+_citation.journal_id_ISSN 
+_citation.journal_id_CSD 
+_citation.book_publisher 
+_citation.pdbx_database_id_PubMed 
+_citation.pdbx_database_id_DOI 
+primary 'Reversible bending and helix geometry in a B-DNA dodecamer: CGCGAATTBrCGCG.'       J.Biol.Chem.           257 14686 14707 
+1982 JBCHA3 US 0021-9258 0071 ? 7174662 ? 
+1       'Ordered Water Structure around a B-DNA Dodecamer. A Quantitative Study'            J.Mol.Biol.            163 129   146   
+1983 JMOBAK UK 0022-2836 0070 ? ?       ? 
+2       'Structure of a B-DNA Dodecamer at 16 Kelvin'                                       Proc.Natl.Acad.Sci.USA 79  4040  4044  
+1982 PNASA6 US 0027-8424 0040 ? ?       ? 
+3       'Kinematic Model for B-DNA'                                                         Proc.Natl.Acad.Sci.USA 78  7318  7322  
+1981 PNASA6 US 0027-8424 0040 ? ?       ? 
+4       'Structure of a B-DNA Dodecamer. Conformation and Dynamics'                         Proc.Natl.Acad.Sci.USA 78  2179  2183  
+1981 PNASA6 US 0027-8424 0040 ? ?       ? 
+5       'Structure of a B-DNA Dodecamer. II. Influence of Base Sequence on Helix Structure' J.Mol.Biol.            149 761   786   
+1981 JMOBAK UK 0022-2836 0070 ? ?       ? 
+6       'Structure of a B-DNA Dodecamer. III. Geometry of Hydration'                        J.Mol.Biol.            151 535   556   
+1981 JMOBAK UK 0022-2836 0070 ? ?       ? 
+7       'Crystal Structure Analysis of a Complete Turn of B-DNA'                            Nature                 287 755   758   
+1980 NATUAS UK 0028-0836 0006 ? ?       ? 
+# 
+loop_
+_citation_author.citation_id 
+_citation_author.name 
+_citation_author.ordinal 
+primary 'Fratini, A.V.'   1  
+primary 'Kopka, M.L.'     2  
+primary 'Drew, H.R.'      3  
+primary 'Dickerson, R.E.' 4  
+1       'Kopka, M.L.'     5  
+1       'Fratini, A.V.'   6  
+1       'Drew, H.R.'      7  
+1       'Dickerson, R.E.' 8  
+2       'Drew, H.R.'      9  
+2       'Samson, S.'      10 
+2       'Dickerson, R.E.' 11 
+3       'Dickerson, R.E.' 12 
+3       'Drew, H.R.'      13 
+4       'Drew, H.R.'      14 
+4       'Wing, R.M.'      15 
+4       'Takano, T.'      16 
+4       'Broka, C.'       17 
+4       'Tanaka, S.'      18 
+4       'Itakura, K.'     19 
+4       'Dickerson, R.E.' 20 
+5       'Dickerson, R.E.' 21 
+5       'Drew, H.R.'      22 
+6       'Drew, H.R.'      23 
+6       'Dickerson, R.E.' 24 
+7       'Wing, R.'        25 
+7       'Drew, H.R.'      26 
+7       'Takano, T.'      27 
+7       'Broka, C.'       28 
+7       'Tanaka, S.'      29 
+7       'Itakura, K.'     30 
+7       'Dickerson, R.E.' 31 
+# 
+_cell.entry_id           4BNA 
+_cell.length_a           24.200 
+_cell.length_b           40.090 
+_cell.length_c           63.950 
+_cell.angle_alpha        90.00 
+_cell.angle_beta         90.00 
+_cell.angle_gamma        90.00 
+_cell.Z_PDB              8 
+_cell.pdbx_unique_axis   ? 
+# 
+_symmetry.entry_id                         4BNA 
+_symmetry.space_group_name_H-M             'P 21 21 21' 
+_symmetry.pdbx_full_space_group_name_H-M   ? 
+_symmetry.cell_setting                     ? 
+_symmetry.Int_Tables_number                19 
+# 
+loop_
+_entity.id 
+_entity.type 
+_entity.src_method 
+_entity.pdbx_description 
+_entity.formula_weight 
+_entity.pdbx_number_of_molecules 
+_entity.pdbx_ec 
+_entity.pdbx_mutation 
+_entity.pdbx_fragment 
+_entity.details 
+1 polymer syn 
+;DNA (5'-D(*CP*GP*CP*GP*AP*AP*TP*TP*(CBR)P*GP*CP*G)-3')
+;
+3742.288 2   ? ? ? ? 
+2 water   nat water                                                    18.015   114 ? ? ? ? 
+# 
+_entity_poly.entity_id                      1 
+_entity_poly.type                           polydeoxyribonucleotide 
+_entity_poly.nstd_linkage                   no 
+_entity_poly.nstd_monomer                   yes 
+_entity_poly.pdbx_seq_one_letter_code       '(DC)(DG)(DC)(DG)(DA)(DA)(DT)(DT)(CBR)(DG)(DC)(DG)' 
+_entity_poly.pdbx_seq_one_letter_code_can   CGCGAATTCGCG 
+_entity_poly.pdbx_strand_id                 A,B 
+_entity_poly.pdbx_target_identifier         ? 
+# 
+loop_
+_entity_poly_seq.entity_id 
+_entity_poly_seq.num 
+_entity_poly_seq.mon_id 
+_entity_poly_seq.hetero 
+1 1  DC  n 
+1 2  DG  n 
+1 3  DC  n 
+1 4  DG  n 
+1 5  DA  n 
+1 6  DA  n 
+1 7  DT  n 
+1 8  DT  n 
+1 9  CBR n 
+1 10 DG  n 
+1 11 DC  n 
+1 12 DG  n 
+# 
+_struct_ref.id                         1 
+_struct_ref.entity_id                  1 
+_struct_ref.db_name                    PDB 
+_struct_ref.db_code                    4BNA 
+_struct_ref.pdbx_db_accession          4BNA 
+_struct_ref.pdbx_db_isoform            ? 
+_struct_ref.pdbx_seq_one_letter_code   ? 
+_struct_ref.pdbx_align_begin           ? 
+# 
+loop_
+_struct_ref_seq.align_id 
+_struct_ref_seq.ref_id 
+_struct_ref_seq.pdbx_PDB_id_code 
+_struct_ref_seq.pdbx_strand_id 
+_struct_ref_seq.seq_align_beg 
+_struct_ref_seq.pdbx_seq_align_beg_ins_code 
+_struct_ref_seq.seq_align_end 
+_struct_ref_seq.pdbx_seq_align_end_ins_code 
+_struct_ref_seq.pdbx_db_accession 
+_struct_ref_seq.db_align_beg 
+_struct_ref_seq.pdbx_db_align_beg_ins_code 
+_struct_ref_seq.db_align_end 
+_struct_ref_seq.pdbx_db_align_end_ins_code 
+_struct_ref_seq.pdbx_auth_seq_align_beg 
+_struct_ref_seq.pdbx_auth_seq_align_end 
+1 1 4BNA A 1 ? 12 ? 4BNA 1  ? 12 ? 1  12 
+2 1 4BNA B 1 ? 12 ? 4BNA 13 ? 24 ? 13 24 
+# 
+loop_
+_chem_comp.id 
+_chem_comp.type 
+_chem_comp.mon_nstd_flag 
+_chem_comp.name 
+_chem_comp.pdbx_synonyms 
+_chem_comp.formula 
+_chem_comp.formula_weight 
+CBR 'DNA linking' n "5-BROMO-2'-DEOXY-CYTIDINE-5'-MONOPHOSPHATE" ? 'C9 H13 Br N3 O7 P' 386.093 
+DA  'DNA linking' y "2'-DEOXYADENOSINE-5'-MONOPHOSPHATE"         ? 'C10 H14 N5 O6 P'   331.222 
+DC  'DNA linking' y "2'-DEOXYCYTIDINE-5'-MONOPHOSPHATE"          ? 'C9 H14 N3 O7 P'    307.197 
+DG  'DNA linking' y "2'-DEOXYGUANOSINE-5'-MONOPHOSPHATE"         ? 'C10 H14 N5 O7 P'   347.221 
+DT  'DNA linking' y "THYMIDINE-5'-MONOPHOSPHATE"                 ? 'C10 H15 N2 O8 P'   322.208 
+HOH non-polymer   . WATER                                        ? 'H2 O'              18.015  
+# 
+_exptl.entry_id          4BNA 
+_exptl.method            'X-RAY DIFFRACTION' 
+_exptl.crystals_number   ? 
+# 
+_exptl_crystal.id                    1 
+_exptl_crystal.density_meas          ? 
+_exptl_crystal.density_Matthews      2.07 
+_exptl_crystal.density_percent_sol   40.65 
+_exptl_crystal.description           ? 
+# 
+_exptl_crystal_grow.crystal_id      1 
+_exptl_crystal_grow.method          'VAPOR DIFFUSION' 
+_exptl_crystal_grow.temp            280.00 
+_exptl_crystal_grow.temp_details    ? 
+_exptl_crystal_grow.pH              ? 
+_exptl_crystal_grow.pdbx_details    'VAPOR DIFFUSION, temperature 280.00K' 
+_exptl_crystal_grow.pdbx_pH_range   ? 
+# 
+loop_
+_exptl_crystal_grow_comp.crystal_id 
+_exptl_crystal_grow_comp.id 
+_exptl_crystal_grow_comp.sol_id 
+_exptl_crystal_grow_comp.name 
+_exptl_crystal_grow_comp.volume 
+_exptl_crystal_grow_comp.conc 
+_exptl_crystal_grow_comp.details 
+1 1 1 WATER    ? ? ? 
+1 2 1 MPD      ? ? ? 
+1 3 1 MG2+     ? ? ? 
+1 4 1 SPERMINE ? ? ? 
+# 
+_diffrn.id                     1 
+_diffrn.ambient_temp           280.00 
+_diffrn.ambient_temp_details   ? 
+_diffrn.crystal_id             1 
+# 
+_diffrn_detector.diffrn_id              1 
+_diffrn_detector.detector               DIFFRACTOMETER 
+_diffrn_detector.type                   ? 
+_diffrn_detector.pdbx_collection_date   ? 
+_diffrn_detector.details                ? 
+# 
+_diffrn_radiation.diffrn_id                        1 
+_diffrn_radiation.wavelength_id                    1 
+_diffrn_radiation.pdbx_monochromatic_or_laue_m_l   ? 
+_diffrn_radiation.monochromator                    ? 
+_diffrn_radiation.pdbx_diffrn_protocol             ? 
+_diffrn_radiation.pdbx_scattering_type             x-ray 
+# 
+_diffrn_radiation_wavelength.id           1 
+_diffrn_radiation_wavelength.wavelength   . 
+_diffrn_radiation_wavelength.wt           1.0 
+# 
+_diffrn_source.diffrn_id                   1 
+_diffrn_source.source                      ? 
+_diffrn_source.type                        ? 
+_diffrn_source.pdbx_synchrotron_site       ? 
+_diffrn_source.pdbx_synchrotron_beamline   ? 
+_diffrn_source.pdbx_wavelength             ? 
+_diffrn_source.pdbx_wavelength_list        ? 
+# 
+_reflns.entry_id                     4BNA 
+_reflns.observed_criterion_sigma_I   ? 
+_reflns.observed_criterion_sigma_F   ? 
+_reflns.d_resolution_low             8.000 
+_reflns.d_resolution_high            2.300 
+_reflns.number_obs                   2919 
+_reflns.number_all                   ? 
+_reflns.percent_possible_obs         ? 
+_reflns.pdbx_Rmerge_I_obs            ? 
+_reflns.pdbx_Rsym_value              ? 
+_reflns.pdbx_netI_over_sigmaI        ? 
+_reflns.B_iso_Wilson_estimate        ? 
+_reflns.pdbx_redundancy              ? 
+_reflns.pdbx_diffrn_id               1 
+_reflns.pdbx_ordinal                 1 
+# 
+_refine.entry_id                                 4BNA 
+_refine.ls_number_reflns_obs                     2919 
+_refine.ls_number_reflns_all                     ? 
+_refine.pdbx_ls_sigma_I                          ? 
+_refine.pdbx_ls_sigma_F                          ? 
+_refine.pdbx_data_cutoff_high_absF               ? 
+_refine.pdbx_data_cutoff_low_absF                ? 
+_refine.pdbx_data_cutoff_high_rms_absF           ? 
+_refine.ls_d_res_low                             8.000 
+_refine.ls_d_res_high                            2.300 
+_refine.ls_percent_reflns_obs                    ? 
+_refine.ls_R_factor_obs                          0.216 
+_refine.ls_R_factor_all                          ? 
+_refine.ls_R_factor_R_work                       ? 
+_refine.ls_R_factor_R_free                       ? 
+_refine.ls_R_factor_R_free_error                 ? 
+_refine.ls_R_factor_R_free_error_details         ? 
+_refine.ls_percent_reflns_R_free                 ? 
+_refine.ls_number_reflns_R_free                  ? 
+_refine.ls_number_parameters                     ? 
+_refine.ls_number_restraints                     ? 
+_refine.occupancy_min                            ? 
+_refine.occupancy_max                            ? 
+_refine.B_iso_mean                               ? 
+_refine.aniso_B[1][1]                            ? 
+_refine.aniso_B[2][2]                            ? 
+_refine.aniso_B[3][3]                            ? 
+_refine.aniso_B[1][2]                            ? 
+_refine.aniso_B[1][3]                            ? 
+_refine.aniso_B[2][3]                            ? 
+_refine.solvent_model_details                    ? 
+_refine.solvent_model_param_ksol                 ? 
+_refine.solvent_model_param_bsol                 ? 
+_refine.pdbx_ls_cross_valid_method               ? 
+_refine.details                                  ? 
+_refine.pdbx_starting_model                      ? 
+_refine.pdbx_method_to_determine_struct          ? 
+_refine.pdbx_isotropic_thermal_model             ? 
+_refine.pdbx_stereochemistry_target_values       ? 
+_refine.pdbx_stereochem_target_val_spec_case     ? 
+_refine.pdbx_R_Free_selection_details            ? 
+_refine.pdbx_overall_ESU_R                       ? 
+_refine.pdbx_overall_ESU_R_Free                  ? 
+_refine.overall_SU_ML                            ? 
+_refine.overall_SU_B                             ? 
+_refine.pdbx_refine_id                           'X-RAY DIFFRACTION' 
+_refine.pdbx_diffrn_id                           1 
+_refine.pdbx_TLS_residual_ADP_flag               ? 
+_refine.correlation_coeff_Fo_to_Fc               ? 
+_refine.correlation_coeff_Fo_to_Fc_free          ? 
+_refine.pdbx_solvent_vdw_probe_radii             ? 
+_refine.pdbx_solvent_ion_probe_radii             ? 
+_refine.pdbx_solvent_shrinkage_radii             ? 
+_refine.pdbx_overall_phase_error                 ? 
+_refine.overall_SU_R_Cruickshank_DPI             ? 
+_refine.pdbx_overall_SU_R_free_Cruickshank_DPI   ? 
+_refine.pdbx_overall_SU_R_Blow_DPI               ? 
+_refine.pdbx_overall_SU_R_free_Blow_DPI          ? 
+# 
+_refine_hist.pdbx_refine_id                   'X-RAY DIFFRACTION' 
+_refine_hist.cycle_id                         LAST 
+_refine_hist.pdbx_number_atoms_protein        0 
+_refine_hist.pdbx_number_atoms_nucleic_acid   486 
+_refine_hist.pdbx_number_atoms_ligand         2 
+_refine_hist.number_atoms_solvent             114 
+_refine_hist.number_atoms_total               602 
+_refine_hist.d_res_high                       2.300 
+_refine_hist.d_res_low                        8.000 
+# 
+_struct.entry_id                  4BNA 
+_struct.title                     'REVERSIBLE BENDING AND HELIX GEOMETRY IN A B-DNA DODECAMER: CGCGAATTBRCGCG' 
+_struct.pdbx_descriptor           
+;5'-D(*CP*GP*CP*GP*AP*AP*TP*TP*(CBR)P*GP*CP*G)-3', MPD, 280K
+;
+_struct.pdbx_model_details        ? 
+_struct.pdbx_CASP_flag            ? 
+_struct.pdbx_model_type_details   ? 
+# 
+_struct_keywords.entry_id        4BNA 
+_struct_keywords.pdbx_keywords   DNA 
+_struct_keywords.text            'B-DNA, DOUBLE HELIX, MODIFIED, DNA' 
+# 
+loop_
+_struct_asym.id 
+_struct_asym.pdbx_blank_PDB_chainid_flag 
+_struct_asym.pdbx_modified 
+_struct_asym.entity_id 
+_struct_asym.details 
+A N N 1 ? 
+B N N 1 ? 
+C N N 2 ? 
+D N N 2 ? 
+# 
+_struct_biol.id   1 
+# 
+loop_
+_struct_conn.id 
+_struct_conn.conn_type_id 
+_struct_conn.pdbx_leaving_atom_flag 
+_struct_conn.pdbx_PDB_id 
+_struct_conn.ptnr1_label_asym_id 
+_struct_conn.ptnr1_label_comp_id 
+_struct_conn.ptnr1_label_seq_id 
+_struct_conn.ptnr1_label_atom_id 
+_struct_conn.pdbx_ptnr1_label_alt_id 
+_struct_conn.pdbx_ptnr1_PDB_ins_code 
+_struct_conn.pdbx_ptnr1_standard_comp_id 
+_struct_conn.ptnr1_symmetry 
+_struct_conn.ptnr2_label_asym_id 
+_struct_conn.ptnr2_label_comp_id 
+_struct_conn.ptnr2_label_seq_id 
+_struct_conn.ptnr2_label_atom_id 
+_struct_conn.pdbx_ptnr2_label_alt_id 
+_struct_conn.pdbx_ptnr2_PDB_ins_code 
+_struct_conn.ptnr1_auth_asym_id 
+_struct_conn.ptnr1_auth_comp_id 
+_struct_conn.ptnr1_auth_seq_id 
+_struct_conn.ptnr2_auth_asym_id 
+_struct_conn.ptnr2_auth_comp_id 
+_struct_conn.ptnr2_auth_seq_id 
+_struct_conn.ptnr2_symmetry 
+_struct_conn.pdbx_ptnr3_label_atom_id 
+_struct_conn.pdbx_ptnr3_label_seq_id 
+_struct_conn.pdbx_ptnr3_label_comp_id 
+_struct_conn.pdbx_ptnr3_label_asym_id 
+_struct_conn.pdbx_ptnr3_label_alt_id 
+_struct_conn.pdbx_ptnr3_PDB_ins_code 
+_struct_conn.details 
+_struct_conn.pdbx_dist_value 
+_struct_conn.pdbx_value_order 
+covale1  covale ? ? A DT  8  "O3'" ? ? ? 1_555 A CBR 9  P  ? ? A DT  8  A CBR 9  1_555 ? ? ? ? ? ? ?            1.593 ? 
+covale2  covale ? ? A CBR 9  "O3'" ? ? ? 1_555 A DG  10 P  ? ? A CBR 9  A DG  10 1_555 ? ? ? ? ? ? ?            1.596 ? 
+covale3  covale ? ? B DT  8  "O3'" ? ? ? 1_555 B CBR 9  P  ? ? B DT  20 B CBR 21 1_555 ? ? ? ? ? ? ?            1.600 ? 
+covale4  covale ? ? B CBR 9  "O3'" ? ? ? 1_555 B DG  10 P  ? ? B CBR 21 B DG  22 1_555 ? ? ? ? ? ? ?            1.606 ? 
+hydrog1  hydrog ? ? A DC  1  N3    ? ? ? 1_555 B DG  12 N1 ? ? A DC  1  B DG  24 1_555 ? ? ? ? ? ? WATSON-CRICK ?     ? 
+hydrog2  hydrog ? ? A DC  1  N4    ? ? ? 1_555 B DG  12 O6 ? ? A DC  1  B DG  24 1_555 ? ? ? ? ? ? WATSON-CRICK ?     ? 
+hydrog3  hydrog ? ? A DC  1  O2    ? ? ? 1_555 B DG  12 N2 ? ? A DC  1  B DG  24 1_555 ? ? ? ? ? ? WATSON-CRICK ?     ? 
+hydrog4  hydrog ? ? A DG  2  N1    ? ? ? 1_555 B DC  11 N3 ? ? A DG  2  B DC  23 1_555 ? ? ? ? ? ? WATSON-CRICK ?     ? 
+hydrog5  hydrog ? ? A DG  2  N2    ? ? ? 1_555 B DC  11 O2 ? ? A DG  2  B DC  23 1_555 ? ? ? ? ? ? WATSON-CRICK ?     ? 
+hydrog6  hydrog ? ? A DG  2  O6    ? ? ? 1_555 B DC  11 N4 ? ? A DG  2  B DC  23 1_555 ? ? ? ? ? ? WATSON-CRICK ?     ? 
+hydrog7  hydrog ? ? A DC  3  N3    ? ? ? 1_555 B DG  10 N1 ? ? A DC  3  B DG  22 1_555 ? ? ? ? ? ? WATSON-CRICK ?     ? 
+hydrog8  hydrog ? ? A DC  3  N4    ? ? ? 1_555 B DG  10 O6 ? ? A DC  3  B DG  22 1_555 ? ? ? ? ? ? WATSON-CRICK ?     ? 
+hydrog9  hydrog ? ? A DC  3  O2    ? ? ? 1_555 B DG  10 N2 ? ? A DC  3  B DG  22 1_555 ? ? ? ? ? ? WATSON-CRICK ?     ? 
+hydrog10 hydrog ? ? A DG  4  N1    ? ? ? 1_555 B CBR 9  N3 ? ? A DG  4  B CBR 21 1_555 ? ? ? ? ? ? WATSON-CRICK ?     ? 
+hydrog11 hydrog ? ? A DG  4  N2    ? ? ? 1_555 B CBR 9  O2 ? ? A DG  4  B CBR 21 1_555 ? ? ? ? ? ? WATSON-CRICK ?     ? 
+hydrog12 hydrog ? ? A DG  4  O6    ? ? ? 1_555 B CBR 9  N4 ? ? A DG  4  B CBR 21 1_555 ? ? ? ? ? ? WATSON-CRICK ?     ? 
+hydrog13 hydrog ? ? A DA  5  N1    ? ? ? 1_555 B DT  8  N3 ? ? A DA  5  B DT  20 1_555 ? ? ? ? ? ? WATSON-CRICK ?     ? 
+hydrog14 hydrog ? ? A DA  5  N6    ? ? ? 1_555 B DT  8  O4 ? ? A DA  5  B DT  20 1_555 ? ? ? ? ? ? WATSON-CRICK ?     ? 
+hydrog15 hydrog ? ? A DA  6  N1    ? ? ? 1_555 B DT  7  N3 ? ? A DA  6  B DT  19 1_555 ? ? ? ? ? ? WATSON-CRICK ?     ? 
+hydrog16 hydrog ? ? A DA  6  N6    ? ? ? 1_555 B DT  7  O4 ? ? A DA  6  B DT  19 1_555 ? ? ? ? ? ? WATSON-CRICK ?     ? 
+hydrog17 hydrog ? ? A DT  7  N3    ? ? ? 1_555 B DA  6  N1 ? ? A DT  7  B DA  18 1_555 ? ? ? ? ? ? WATSON-CRICK ?     ? 
+hydrog18 hydrog ? ? A DT  7  O4    ? ? ? 1_555 B DA  6  N6 ? ? A DT  7  B DA  18 1_555 ? ? ? ? ? ? WATSON-CRICK ?     ? 
+hydrog19 hydrog ? ? A DT  8  N3    ? ? ? 1_555 B DA  5  N1 ? ? A DT  8  B DA  17 1_555 ? ? ? ? ? ? WATSON-CRICK ?     ? 
+hydrog20 hydrog ? ? A DT  8  O4    ? ? ? 1_555 B DA  5  N6 ? ? A DT  8  B DA  17 1_555 ? ? ? ? ? ? WATSON-CRICK ?     ? 
+hydrog21 hydrog ? ? A CBR 9  N3    ? ? ? 1_555 B DG  4  N1 ? ? A CBR 9  B DG  16 1_555 ? ? ? ? ? ? WATSON-CRICK ?     ? 
+hydrog22 hydrog ? ? A CBR 9  N4    ? ? ? 1_555 B DG  4  O6 ? ? A CBR 9  B DG  16 1_555 ? ? ? ? ? ? WATSON-CRICK ?     ? 
+hydrog23 hydrog ? ? A CBR 9  O2    ? ? ? 1_555 B DG  4  N2 ? ? A CBR 9  B DG  16 1_555 ? ? ? ? ? ? WATSON-CRICK ?     ? 
+hydrog24 hydrog ? ? A DG  10 N1    ? ? ? 1_555 B DC  3  N3 ? ? A DG  10 B DC  15 1_555 ? ? ? ? ? ? WATSON-CRICK ?     ? 
+hydrog25 hydrog ? ? A DG  10 N2    ? ? ? 1_555 B DC  3  O2 ? ? A DG  10 B DC  15 1_555 ? ? ? ? ? ? WATSON-CRICK ?     ? 
+hydrog26 hydrog ? ? A DG  10 O6    ? ? ? 1_555 B DC  3  N4 ? ? A DG  10 B DC  15 1_555 ? ? ? ? ? ? WATSON-CRICK ?     ? 
+hydrog27 hydrog ? ? A DC  11 N3    ? ? ? 1_555 B DG  2  N1 ? ? A DC  11 B DG  14 1_555 ? ? ? ? ? ? WATSON-CRICK ?     ? 
+hydrog28 hydrog ? ? A DC  11 N4    ? ? ? 1_555 B DG  2  O6 ? ? A DC  11 B DG  14 1_555 ? ? ? ? ? ? WATSON-CRICK ?     ? 
+hydrog29 hydrog ? ? A DC  11 O2    ? ? ? 1_555 B DG  2  N2 ? ? A DC  11 B DG  14 1_555 ? ? ? ? ? ? WATSON-CRICK ?     ? 
+hydrog30 hydrog ? ? A DG  12 N1    ? ? ? 1_555 B DC  1  N3 ? ? A DG  12 B DC  13 1_555 ? ? ? ? ? ? WATSON-CRICK ?     ? 
+hydrog31 hydrog ? ? A DG  12 N2    ? ? ? 1_555 B DC  1  O2 ? ? A DG  12 B DC  13 1_555 ? ? ? ? ? ? WATSON-CRICK ?     ? 
+hydrog32 hydrog ? ? A DG  12 O6    ? ? ? 1_555 B DC  1  N4 ? ? A DG  12 B DC  13 1_555 ? ? ? ? ? ? WATSON-CRICK ?     ? 
+# 
+loop_
+_struct_conn_type.id 
+_struct_conn_type.criteria 
+_struct_conn_type.reference 
+covale ? ? 
+hydrog ? ? 
+# 
+_database_PDB_matrix.entry_id          4BNA 
+_database_PDB_matrix.origx[1][1]       1.000000 
+_database_PDB_matrix.origx[1][2]       0.000000 
+_database_PDB_matrix.origx[1][3]       0.000000 
+_database_PDB_matrix.origx[2][1]       0.000000 
+_database_PDB_matrix.origx[2][2]       1.000000 
+_database_PDB_matrix.origx[2][3]       0.000000 
+_database_PDB_matrix.origx[3][1]       0.000000 
+_database_PDB_matrix.origx[3][2]       0.000000 
+_database_PDB_matrix.origx[3][3]       1.000000 
+_database_PDB_matrix.origx_vector[1]   0.00000 
+_database_PDB_matrix.origx_vector[2]   0.00000 
+_database_PDB_matrix.origx_vector[3]   0.00000 
+# 
+_atom_sites.entry_id                    4BNA 
+_atom_sites.fract_transf_matrix[1][1]   0.041322 
+_atom_sites.fract_transf_matrix[1][2]   0.000000 
+_atom_sites.fract_transf_matrix[1][3]   0.000000 
+_atom_sites.fract_transf_matrix[2][1]   0.000000 
+_atom_sites.fract_transf_matrix[2][2]   0.024944 
+_atom_sites.fract_transf_matrix[2][3]   0.000000 
+_atom_sites.fract_transf_matrix[3][1]   0.000000 
+_atom_sites.fract_transf_matrix[3][2]   0.000000 
+_atom_sites.fract_transf_matrix[3][3]   0.015637 
+_atom_sites.fract_transf_vector[1]      0.00000 
+_atom_sites.fract_transf_vector[2]      0.00000 
+_atom_sites.fract_transf_vector[3]      0.00000 
+# 
+loop_
+_atom_type.symbol 
+BR 
+C  
+N  
+O  
+P  
+# 
+loop_
+_atom_site.group_PDB 
+_atom_site.id 
+_atom_site.type_symbol 
+_atom_site.label_atom_id 
+_atom_site.label_alt_id 
+_atom_site.label_comp_id 
+_atom_site.label_asym_id 
+_atom_site.label_entity_id 
+_atom_site.label_seq_id 
+_atom_site.pdbx_PDB_ins_code 
+_atom_site.Cartn_x 
+_atom_site.Cartn_y 
+_atom_site.Cartn_z 
+_atom_site.occupancy 
+_atom_site.B_iso_or_equiv 
+_atom_site.pdbx_formal_charge 
+_atom_site.auth_seq_id 
+_atom_site.auth_comp_id 
+_atom_site.auth_asym_id 
+_atom_site.auth_atom_id 
+_atom_site.pdbx_PDB_model_num 
+ATOM   1   O  "O5'" . DC  A 1 1  ? 18.310 35.242 24.641  1.00 41.15 ? 1   DC  A "O5'" 1 
+ATOM   2   C  "C5'" . DC  A 1 1  ? 19.081 35.327 23.422  1.00 21.85 ? 1   DC  A "C5'" 1 
+ATOM   3   C  "C4'" . DC  A 1 1  ? 19.934 34.088 23.249  1.00 20.49 ? 1   DC  A "C4'" 1 
+ATOM   4   O  "O4'" . DC  A 1 1  ? 19.165 32.922 23.589  1.00 25.33 ? 1   DC  A "O4'" 1 
+ATOM   5   C  "C3'" . DC  A 1 1  ? 20.440 33.816 21.833  1.00 35.76 ? 1   DC  A "C3'" 1 
+ATOM   6   O  "O3'" . DC  A 1 1  ? 21.779 33.290 21.830  1.00 26.49 ? 1   DC  A "O3'" 1 
+ATOM   7   C  "C2'" . DC  A 1 1  ? 19.393 32.814 21.344  1.00 29.32 ? 1   DC  A "C2'" 1 
+ATOM   8   C  "C1'" . DC  A 1 1  ? 19.380 31.933 22.574  1.00 6.29  ? 1   DC  A "C1'" 1 
+ATOM   9   N  N1    . DC  A 1 1  ? 18.210 31.024 22.668  1.00 14.88 ? 1   DC  A N1    1 
+ATOM   10  C  C2    . DC  A 1 1  ? 18.403 29.730 23.042  1.00 9.95  ? 1   DC  A C2    1 
+ATOM   11  O  O2    . DC  A 1 1  ? 19.555 29.326 23.159  1.00 4.28  ? 1   DC  A O2    1 
+ATOM   12  N  N3    . DC  A 1 1  ? 17.353 28.934 23.274  1.00 13.24 ? 1   DC  A N3    1 
+ATOM   13  C  C4    . DC  A 1 1  ? 16.109 29.399 23.133  1.00 24.67 ? 1   DC  A C4    1 
+ATOM   14  N  N4    . DC  A 1 1  ? 15.045 28.580 23.374  1.00 14.13 ? 1   DC  A N4    1 
+ATOM   15  C  C5    . DC  A 1 1  ? 15.869 30.714 22.738  1.00 5.74  ? 1   DC  A C5    1 
+ATOM   16  C  C6    . DC  A 1 1  ? 16.961 31.543 22.512  1.00 13.38 ? 1   DC  A C6    1 
+ATOM   17  P  P     . DG  A 1 2  ? 22.632 33.256 20.478  1.00 32.73 ? 2   DG  A P     1 
+ATOM   18  O  OP1   . DG  A 1 2  ? 23.989 33.799 20.773  1.00 31.46 ? 2   DG  A OP1   1 
+ATOM   19  O  OP2   . DG  A 1 2  ? 21.866 33.901 19.388  1.00 35.78 ? 2   DG  A OP2   1 
+ATOM   20  O  "O5'" . DG  A 1 2  ? 22.731 31.697 20.139  1.00 6.39  ? 2   DG  A "O5'" 1 
+ATOM   21  C  "C5'" . DG  A 1 2  ? 23.526 30.830 20.963  1.00 24.24 ? 2   DG  A "C5'" 1 
+ATOM   22  C  "C4'" . DG  A 1 2  ? 23.356 29.448 20.396  1.00 34.69 ? 2   DG  A "C4'" 1 
+ATOM   23  O  "O4'" . DG  A 1 2  ? 21.988 29.093 20.598  1.00 11.57 ? 2   DG  A "O4'" 1 
+ATOM   24  C  "C3'" . DG  A 1 2  ? 23.623 29.297 18.896  1.00 31.82 ? 2   DG  A "C3'" 1 
+ATOM   25  O  "O3'" . DG  A 1 2  ? 24.667 28.329 18.625  1.00 36.94 ? 2   DG  A "O3'" 1 
+ATOM   26  C  "C2'" . DG  A 1 2  ? 22.229 28.963 18.334  1.00 12.08 ? 2   DG  A "C2'" 1 
+ATOM   27  C  "C1'" . DG  A 1 2  ? 21.595 28.248 19.516  1.00 14.11 ? 2   DG  A "C1'" 1 
+ATOM   28  N  N9    . DG  A 1 2  ? 20.102 28.317 19.505  1.00 15.33 ? 2   DG  A N9    1 
+ATOM   29  C  C8    . DG  A 1 2  ? 19.291 29.373 19.168  1.00 25.91 ? 2   DG  A C8    1 
+ATOM   30  N  N7    . DG  A 1 2  ? 17.987 29.119 19.373  1.00 9.70  ? 2   DG  A N7    1 
+ATOM   31  C  C5    . DG  A 1 2  ? 17.973 27.860 19.856  1.00 3.36  ? 2   DG  A C5    1 
+ATOM   32  C  C6    . DG  A 1 2  ? 16.868 27.053 20.271  1.00 -2.73 ? 2   DG  A C6    1 
+ATOM   33  O  O6    . DG  A 1 2  ? 15.668 27.329 20.291  1.00 5.22  ? 2   DG  A O6    1 
+ATOM   34  N  N1    . DG  A 1 2  ? 17.283 25.804 20.668  1.00 3.69  ? 2   DG  A N1    1 
+ATOM   35  C  C2    . DG  A 1 2  ? 18.567 25.339 20.711  1.00 5.81  ? 2   DG  A C2    1 
+ATOM   36  N  N2    . DG  A 1 2  ? 18.762 24.049 21.106  1.00 0.81  ? 2   DG  A N2    1 
+ATOM   37  N  N3    . DG  A 1 2  ? 19.603 26.101 20.358  1.00 17.30 ? 2   DG  A N3    1 
+ATOM   38  C  C4    . DG  A 1 2  ? 19.236 27.336 19.938  1.00 7.41  ? 2   DG  A C4    1 
+ATOM   39  P  P     . DC  A 1 3  ? 25.090 27.873 17.141  1.00 21.06 ? 3   DC  A P     1 
+ATOM   40  O  OP1   . DC  A 1 3  ? 26.553 27.613 17.142  1.00 29.66 ? 3   DC  A OP1   1 
+ATOM   41  O  OP2   . DC  A 1 3  ? 24.605 28.815 16.117  1.00 25.50 ? 3   DC  A OP2   1 
+ATOM   42  O  "O5'" . DC  A 1 3  ? 24.312 26.481 16.963  1.00 3.49  ? 3   DC  A "O5'" 1 
+ATOM   43  C  "C5'" . DC  A 1 3  ? 24.588 25.383 17.865  1.00 11.45 ? 3   DC  A "C5'" 1 
+ATOM   44  C  "C4'" . DC  A 1 3  ? 23.448 24.409 17.746  1.00 15.19 ? 3   DC  A "C4'" 1 
+ATOM   45  O  "O4'" . DC  A 1 3  ? 22.239 25.161 17.837  1.00 19.57 ? 3   DC  A "O4'" 1 
+ATOM   46  C  "C3'" . DC  A 1 3  ? 23.266 23.754 16.399  1.00 14.03 ? 3   DC  A "C3'" 1 
+ATOM   47  O  "O3'" . DC  A 1 3  ? 24.197 22.690 16.175  1.00 35.51 ? 3   DC  A "O3'" 1 
+ATOM   48  C  "C2'" . DC  A 1 3  ? 21.801 23.302 16.460  1.00 28.43 ? 3   DC  A "C2'" 1 
+ATOM   49  C  "C1'" . DC  A 1 3  ? 21.192 24.242 17.494  1.00 10.35 ? 3   DC  A "C1'" 1 
+ATOM   50  N  N1    . DC  A 1 3  ? 20.083 25.077 16.982  1.00 7.04  ? 3   DC  A N1    1 
+ATOM   51  C  C2    . DC  A 1 3  ? 18.787 24.751 17.255  1.00 7.12  ? 3   DC  A C2    1 
+ATOM   52  O  O2    . DC  A 1 3  ? 18.556 23.690 17.839  1.00 18.61 ? 3   DC  A O2    1 
+ATOM   53  N  N3    . DC  A 1 3  ? 17.809 25.608 16.936  1.00 3.17  ? 3   DC  A N3    1 
+ATOM   54  C  C4    . DC  A 1 3  ? 18.092 26.773 16.342  1.00 2.29  ? 3   DC  A C4    1 
+ATOM   55  N  N4    . DC  A 1 3  ? 17.098 27.664 16.063  1.00 5.39  ? 3   DC  A N4    1 
+ATOM   56  C  C5    . DC  A 1 3  ? 19.398 27.123 16.025  1.00 9.59  ? 3   DC  A C5    1 
+ATOM   57  C  C6    . DC  A 1 3  ? 20.413 26.240 16.366  1.00 8.83  ? 3   DC  A C6    1 
+ATOM   58  P  P     . DG  A 1 4  ? 24.073 21.751 14.886  1.00 15.68 ? 4   DG  A P     1 
+ATOM   59  O  OP1   . DG  A 1 4  ? 25.311 20.970 14.728  1.00 36.53 ? 4   DG  A OP1   1 
+ATOM   60  O  OP2   . DG  A 1 4  ? 23.637 22.547 13.725  1.00 10.28 ? 4   DG  A OP2   1 
+ATOM   61  O  "O5'" . DG  A 1 4  ? 22.904 20.735 15.252  1.00 42.16 ? 4   DG  A "O5'" 1 
+ATOM   62  C  "C5'" . DG  A 1 4  ? 23.063 19.757 16.293  1.00 33.11 ? 4   DG  A "C5'" 1 
+ATOM   63  C  "C4'" . DG  A 1 4  ? 21.793 18.941 16.320  1.00 14.16 ? 4   DG  A "C4'" 1 
+ATOM   64  O  "O4'" . DG  A 1 4  ? 20.633 19.813 16.341  1.00 19.33 ? 4   DG  A "O4'" 1 
+ATOM   65  C  "C3'" . DG  A 1 4  ? 21.541 18.009 15.150  1.00 -0.73 ? 4   DG  A "C3'" 1 
+ATOM   66  O  "O3'" . DG  A 1 4  ? 20.729 16.931 15.574  1.00 35.07 ? 4   DG  A "O3'" 1 
+ATOM   67  C  "C2'" . DG  A 1 4  ? 20.831 18.950 14.182  1.00 -2.44 ? 4   DG  A "C2'" 1 
+ATOM   68  C  "C1'" . DG  A 1 4  ? 19.847 19.595 15.142  1.00 11.92 ? 4   DG  A "C1'" 1 
+ATOM   69  N  N9    . DG  A 1 4  ? 19.422 20.931 14.628  1.00 2.85  ? 4   DG  A N9    1 
+ATOM   70  C  C8    . DG  A 1 4  ? 20.157 21.819 13.896  1.00 -0.82 ? 4   DG  A C8    1 
+ATOM   71  N  N7    . DG  A 1 4  ? 19.503 22.960 13.636  1.00 2.15  ? 4   DG  A N7    1 
+ATOM   72  C  C5    . DG  A 1 4  ? 18.298 22.783 14.209  1.00 4.74  ? 4   DG  A C5    1 
+ATOM   73  C  C6    . DG  A 1 4  ? 17.173 23.669 14.250  1.00 -3.92 ? 4   DG  A C6    1 
+ATOM   74  O  O6    . DG  A 1 4  ? 17.061 24.809 13.790  1.00 -0.80 ? 4   DG  A O6    1 
+ATOM   75  N  N1    . DG  A 1 4  ? 16.110 23.088 14.895  1.00 -6.91 ? 4   DG  A N1    1 
+ATOM   76  C  C2    . DG  A 1 4  ? 16.080 21.848 15.469  1.00 19.72 ? 4   DG  A C2    1 
+ATOM   77  N  N2    . DG  A 1 4  ? 14.908 21.453 16.043  1.00 20.59 ? 4   DG  A N2    1 
+ATOM   78  N  N3    . DG  A 1 4  ? 17.143 21.031 15.459  1.00 7.78  ? 4   DG  A N3    1 
+ATOM   79  C  C4    . DG  A 1 4  ? 18.207 21.556 14.813  1.00 17.47 ? 4   DG  A C4    1 
+ATOM   80  P  P     . DA  A 1 5  ? 20.088 15.885 14.556  1.00 31.98 ? 5   DA  A P     1 
+ATOM   81  O  OP1   . DA  A 1 5  ? 20.386 14.527 15.076  1.00 42.18 ? 5   DA  A OP1   1 
+ATOM   82  O  OP2   . DA  A 1 5  ? 20.476 16.121 13.150  1.00 50.76 ? 5   DA  A OP2   1 
+ATOM   83  O  "O5'" . DA  A 1 5  ? 18.533 16.180 14.750  1.00 19.84 ? 5   DA  A "O5'" 1 
+ATOM   84  C  "C5'" . DA  A 1 5  ? 17.946 16.084 16.074  1.00 25.46 ? 5   DA  A "C5'" 1 
+ATOM   85  C  "C4'" . DA  A 1 5  ? 16.469 16.341 15.945  1.00 13.68 ? 5   DA  A "C4'" 1 
+ATOM   86  O  "O4'" . DA  A 1 5  ? 16.315 17.632 15.305  1.00 25.98 ? 5   DA  A "O4'" 1 
+ATOM   87  C  "C3'" . DA  A 1 5  ? 15.705 15.357 15.064  1.00 16.71 ? 5   DA  A "C3'" 1 
+ATOM   88  O  "O3'" . DA  A 1 5  ? 14.369 15.121 15.540  1.00 22.14 ? 5   DA  A "O3'" 1 
+ATOM   89  C  "C2'" . DA  A 1 5  ? 15.790 16.046 13.696  1.00 14.45 ? 5   DA  A "C2'" 1 
+ATOM   90  C  "C1'" . DA  A 1 5  ? 15.510 17.471 14.122  1.00 10.80 ? 5   DA  A "C1'" 1 
+ATOM   91  N  N9    . DA  A 1 5  ? 16.013 18.481 13.159  1.00 1.65  ? 5   DA  A N9    1 
+ATOM   92  C  C8    . DA  A 1 5  ? 17.181 18.484 12.444  1.00 25.05 ? 5   DA  A C8    1 
+ATOM   93  N  N7    . DA  A 1 5  ? 17.375 19.625 11.763  1.00 24.10 ? 5   DA  A N7    1 
+ATOM   94  C  C5    . DA  A 1 5  ? 16.282 20.361 12.051  1.00 18.05 ? 5   DA  A C5    1 
+ATOM   95  C  C6    . DA  A 1 5  ? 15.881 21.674 11.657  1.00 16.15 ? 5   DA  A C6    1 
+ATOM   96  N  N6    . DA  A 1 5  ? 16.659 22.487 10.884  1.00 0.35  ? 5   DA  A N6    1 
+ATOM   97  N  N1    . DA  A 1 5  ? 14.682 22.093 12.058  1.00 5.25  ? 5   DA  A N1    1 
+ATOM   98  C  C2    . DA  A 1 5  ? 13.940 21.310 12.837  1.00 8.52  ? 5   DA  A C2    1 
+ATOM   99  N  N3    . DA  A 1 5  ? 14.220 20.098 13.312  1.00 27.34 ? 5   DA  A N3    1 
+ATOM   100 C  C4    . DA  A 1 5  ? 15.419 19.685 12.864  1.00 2.71  ? 5   DA  A C4    1 
+ATOM   101 P  P     . DA  A 1 6  ? 13.327 14.239 14.699  1.00 17.88 ? 6   DA  A P     1 
+ATOM   102 O  OP1   . DA  A 1 6  ? 12.408 13.530 15.618  1.00 25.50 ? 6   DA  A OP1   1 
+ATOM   103 O  OP2   . DA  A 1 6  ? 14.034 13.388 13.718  1.00 28.17 ? 6   DA  A OP2   1 
+ATOM   104 O  "O5'" . DA  A 1 6  ? 12.492 15.360 13.929  1.00 13.26 ? 6   DA  A "O5'" 1 
+ATOM   105 C  "C5'" . DA  A 1 6  ? 11.669 16.289 14.656  1.00 20.39 ? 6   DA  A "C5'" 1 
+ATOM   106 C  "C4'" . DA  A 1 6  ? 10.831 16.997 13.619  1.00 30.97 ? 6   DA  A "C4'" 1 
+ATOM   107 O  "O4'" . DA  A 1 6  ? 11.688 17.834 12.826  1.00 23.37 ? 6   DA  A "O4'" 1 
+ATOM   108 C  "C3'" . DA  A 1 6  ? 10.099 16.091 12.632  1.00 11.33 ? 6   DA  A "C3'" 1 
+ATOM   109 O  "O3'" . DA  A 1 6  ? 8.686  16.358 12.611  1.00 20.89 ? 6   DA  A "O3'" 1 
+ATOM   110 C  "C2'" . DA  A 1 6  ? 10.843 16.344 11.315  1.00 8.59  ? 6   DA  A "C2'" 1 
+ATOM   111 C  "C1'" . DA  A 1 6  ? 11.219 17.804 11.476  1.00 2.81  ? 6   DA  A "C1'" 1 
+ATOM   112 N  N9    . DA  A 1 6  ? 12.416 18.177 10.678  1.00 1.59  ? 6   DA  A N9    1 
+ATOM   113 C  C8    . DA  A 1 6  ? 13.581 17.475 10.485  1.00 -4.87 ? 6   DA  A C8    1 
+ATOM   114 N  N7    . DA  A 1 6  ? 14.500 18.171 9.789   1.00 10.00 ? 6   DA  A N7    1 
+ATOM   115 C  C5    . DA  A 1 6  ? 13.892 19.352 9.538   1.00 3.93  ? 6   DA  A C5    1 
+ATOM   116 C  C6    . DA  A 1 6  ? 14.323 20.533 8.855   1.00 7.29  ? 6   DA  A C6    1 
+ATOM   117 N  N6    . DA  A 1 6  ? 15.571 20.672 8.317   1.00 4.77  ? 6   DA  A N6    1 
+ATOM   118 N  N1    . DA  A 1 6  ? 13.454 21.540 8.767   1.00 7.07  ? 6   DA  A N1    1 
+ATOM   119 C  C2    . DA  A 1 6  ? 12.249 21.424 9.319   1.00 -2.44 ? 6   DA  A C2    1 
+ATOM   120 N  N3    . DA  A 1 6  ? 11.735 20.399 9.992   1.00 8.21  ? 6   DA  A N3    1 
+ATOM   121 C  C4    . DA  A 1 6  ? 12.626 19.387 10.057  1.00 5.02  ? 6   DA  A C4    1 
+ATOM   122 P  P     . DT  A 1 7  ? 7.694  15.666 11.561  1.00 10.91 ? 7   DT  A P     1 
+ATOM   123 O  OP1   . DT  A 1 7  ? 6.380  15.462 12.210  1.00 20.94 ? 7   DT  A OP1   1 
+ATOM   124 O  OP2   . DT  A 1 7  ? 8.309  14.464 10.957  1.00 21.18 ? 7   DT  A OP2   1 
+ATOM   125 O  "O5'" . DT  A 1 7  ? 7.546  16.809 10.460  1.00 16.05 ? 7   DT  A "O5'" 1 
+ATOM   126 C  "C5'" . DT  A 1 7  ? 7.182  18.149 10.855  1.00 23.18 ? 7   DT  A "C5'" 1 
+ATOM   127 C  "C4'" . DT  A 1 7  ? 7.417  18.990 9.632   1.00 5.17  ? 7   DT  A "C4'" 1 
+ATOM   128 O  "O4'" . DT  A 1 7  ? 8.768  18.777 9.223   1.00 13.96 ? 7   DT  A "O4'" 1 
+ATOM   129 C  "C3'" . DT  A 1 7  ? 6.595  18.571 8.422   1.00 24.26 ? 7   DT  A "C3'" 1 
+ATOM   130 O  "O3'" . DT  A 1 7  ? 5.453  19.424 8.231   1.00 32.63 ? 7   DT  A "O3'" 1 
+ATOM   131 C  "C2'" . DT  A 1 7  ? 7.611  18.516 7.267   1.00 0.35  ? 7   DT  A "C2'" 1 
+ATOM   132 C  "C1'" . DT  A 1 7  ? 8.792  19.242 7.883   1.00 8.06  ? 7   DT  A "C1'" 1 
+ATOM   133 N  N1    . DT  A 1 7  ? 10.120 18.880 7.316   1.00 6.40  ? 7   DT  A N1    1 
+ATOM   134 C  C2    . DT  A 1 7  ? 10.853 19.858 6.715   1.00 7.81  ? 7   DT  A C2    1 
+ATOM   135 O  O2    . DT  A 1 7  ? 10.402 21.000 6.605   1.00 4.87  ? 7   DT  A O2    1 
+ATOM   136 N  N3    . DT  A 1 7  ? 12.116 19.560 6.294   1.00 16.33 ? 7   DT  A N3    1 
+ATOM   137 C  C4    . DT  A 1 7  ? 12.671 18.327 6.465   1.00 6.26  ? 7   DT  A C4    1 
+ATOM   138 O  O4    . DT  A 1 7  ? 13.824 18.159 6.074   1.00 20.42 ? 7   DT  A O4    1 
+ATOM   139 C  C5    . DT  A 1 7  ? 11.924 17.341 7.107   1.00 5.33  ? 7   DT  A C5    1 
+ATOM   140 C  C7    . DT  A 1 7  ? 12.534 15.992 7.375   1.00 -5.15 ? 7   DT  A C7    1 
+ATOM   141 C  C6    . DT  A 1 7  ? 10.630 17.634 7.537   1.00 0.23  ? 7   DT  A C6    1 
+ATOM   142 P  P     . DT  A 1 8  ? 4.419  19.207 7.032   1.00 30.96 ? 8   DT  A P     1 
+ATOM   143 O  OP1   . DT  A 1 8  ? 3.180  19.943 7.365   1.00 25.77 ? 8   DT  A OP1   1 
+ATOM   144 O  OP2   . DT  A 1 8  ? 4.267  17.763 6.733   1.00 27.97 ? 8   DT  A OP2   1 
+ATOM   145 O  "O5'" . DT  A 1 8  ? 5.125  19.984 5.828   1.00 25.89 ? 8   DT  A "O5'" 1 
+ATOM   146 C  "C5'" . DT  A 1 8  ? 5.480  21.369 6.028   1.00 18.03 ? 8   DT  A "C5'" 1 
+ATOM   147 C  "C4'" . DT  A 1 8  ? 6.378  21.720 4.900   1.00 6.81  ? 8   DT  A "C4'" 1 
+ATOM   148 O  "O4'" . DT  A 1 8  ? 7.436  20.778 4.857   1.00 39.27 ? 8   DT  A "O4'" 1 
+ATOM   149 C  "C3'" . DT  A 1 8  ? 5.738  21.577 3.542   1.00 42.84 ? 8   DT  A "C3'" 1 
+ATOM   150 O  "O3'" . DT  A 1 8  ? 5.118  22.809 3.151   1.00 42.08 ? 8   DT  A "O3'" 1 
+ATOM   151 C  "C2'" . DT  A 1 8  ? 6.896  21.077 2.652   1.00 11.90 ? 8   DT  A "C2'" 1 
+ATOM   152 C  "C1'" . DT  A 1 8  ? 8.072  21.070 3.615   1.00 18.26 ? 8   DT  A "C1'" 1 
+ATOM   153 N  N1    . DT  A 1 8  ? 9.119  20.020 3.389   1.00 13.59 ? 8   DT  A N1    1 
+ATOM   154 C  C2    . DT  A 1 8  ? 10.338 20.375 2.885   1.00 12.87 ? 8   DT  A C2    1 
+ATOM   155 O  O2    . DT  A 1 8  ? 10.564 21.533 2.524   1.00 26.28 ? 8   DT  A O2    1 
+ATOM   156 N  N3    . DT  A 1 8  ? 11.323 19.435 2.835   1.00 6.44  ? 8   DT  A N3    1 
+ATOM   157 C  C4    . DT  A 1 8  ? 11.133 18.149 3.243   1.00 10.35 ? 8   DT  A C4    1 
+ATOM   158 O  O4    . DT  A 1 8  ? 12.090 17.374 3.164   1.00 4.79  ? 8   DT  A O4    1 
+ATOM   159 C  C5    . DT  A 1 8  ? 9.877  17.789 3.736   1.00 1.49  ? 8   DT  A C5    1 
+ATOM   160 C  C7    . DT  A 1 8  ? 9.610  16.383 4.189   1.00 -1.05 ? 8   DT  A C7    1 
+ATOM   161 C  C6    . DT  A 1 8  ? 8.871  18.750 3.820   1.00 6.87  ? 8   DT  A C6    1 
+HETATM 162 BR BR    . CBR A 1 9  ? 7.544  18.540 0.147   1.00 27.82 ? 9   CBR A BR    1 
+HETATM 163 P  P     . CBR A 1 9  ? 4.754  23.117 1.631   1.00 39.24 ? 9   CBR A P     1 
+HETATM 164 O  OP1   . CBR A 1 9  ? 3.833  24.270 1.607   1.00 26.96 ? 9   CBR A OP1   1 
+HETATM 165 O  OP2   . CBR A 1 9  ? 4.263  21.879 0.986   1.00 36.34 ? 9   CBR A OP2   1 
+HETATM 166 O  "O5'" . CBR A 1 9  ? 6.174  23.528 1.008   1.00 45.31 ? 9   CBR A "O5'" 1 
+HETATM 167 N  N1    . CBR A 1 9  ? 9.532  22.002 -0.808  1.00 25.10 ? 9   CBR A N1    1 
+HETATM 168 C  C6    . CBR A 1 9  ? 8.538  21.145 -0.461  1.00 1.88  ? 9   CBR A C6    1 
+HETATM 169 C  C2    . CBR A 1 9  ? 10.799 21.577 -1.072  1.00 23.46 ? 9   CBR A C2    1 
+HETATM 170 O  O2    . CBR A 1 9  ? 11.651 22.419 -1.363  1.00 19.53 ? 9   CBR A O2    1 
+HETATM 171 N  N3    . CBR A 1 9  ? 11.101 20.288 -0.953  1.00 11.77 ? 9   CBR A N3    1 
+HETATM 172 C  C4    . CBR A 1 9  ? 10.164 19.404 -0.596  1.00 18.33 ? 9   CBR A C4    1 
+HETATM 173 N  N4    . CBR A 1 9  ? 10.505 18.094 -0.434  1.00 11.36 ? 9   CBR A N4    1 
+HETATM 174 C  C5    . CBR A 1 9  ? 8.847  19.796 -0.365  1.00 3.77  ? 9   CBR A C5    1 
+HETATM 175 C  "C2'" . CBR A 1 9  ? 7.881  23.685 -1.403  1.00 28.11 ? 9   CBR A "C2'" 1 
+HETATM 176 C  "C5'" . CBR A 1 9  ? 6.956  24.611 1.576   1.00 33.12 ? 9   CBR A "C5'" 1 
+HETATM 177 C  "C4'" . CBR A 1 9  ? 8.103  24.878 0.637   1.00 35.32 ? 9   CBR A "C4'" 1 
+HETATM 178 O  "O4'" . CBR A 1 9  ? 8.946  23.711 0.613   1.00 31.18 ? 9   CBR A "O4'" 1 
+HETATM 179 C  "C1'" . CBR A 1 9  ? 9.224  23.431 -0.768  1.00 33.42 ? 9   CBR A "C1'" 1 
+HETATM 180 C  "C3'" . CBR A 1 9  ? 7.655  25.067 -0.808  1.00 46.10 ? 9   CBR A "C3'" 1 
+HETATM 181 O  "O3'" . CBR A 1 9  ? 8.353  26.102 -1.506  1.00 43.15 ? 9   CBR A "O3'" 1 
+ATOM   182 P  P     . DG  A 1 10 ? 7.758  26.596 -2.902  1.00 48.90 ? 10  DG  A P     1 
+ATOM   183 O  OP1   . DG  A 1 10 ? 7.798  28.063 -2.989  1.00 56.18 ? 10  DG  A OP1   1 
+ATOM   184 O  OP2   . DG  A 1 10 ? 6.413  26.016 -3.017  1.00 43.65 ? 10  DG  A OP2   1 
+ATOM   185 O  "O5'" . DG  A 1 10 ? 8.701  25.910 -4.001  1.00 51.40 ? 10  DG  A "O5'" 1 
+ATOM   186 C  "C5'" . DG  A 1 10 ? 10.051 26.360 -4.218  1.00 46.70 ? 10  DG  A "C5'" 1 
+ATOM   187 C  "C4'" . DG  A 1 10 ? 10.640 25.411 -5.225  1.00 31.84 ? 10  DG  A "C4'" 1 
+ATOM   188 O  "O4'" . DG  A 1 10 ? 10.599 24.095 -4.646  1.00 25.15 ? 10  DG  A "O4'" 1 
+ATOM   189 C  "C3'" . DG  A 1 10 ? 9.926  25.260 -6.571  1.00 33.88 ? 10  DG  A "C3'" 1 
+ATOM   190 O  "O3'" . DG  A 1 10 ? 10.863 25.137 -7.641  1.00 49.82 ? 10  DG  A "O3'" 1 
+ATOM   191 C  "C2'" . DG  A 1 10 ? 9.133  23.981 -6.350  1.00 22.71 ? 10  DG  A "C2'" 1 
+ATOM   192 C  "C1'" . DG  A 1 10 ? 10.260 23.209 -5.712  1.00 48.71 ? 10  DG  A "C1'" 1 
+ATOM   193 N  N9    . DG  A 1 10 ? 9.800  21.929 -5.138  1.00 27.81 ? 10  DG  A N9    1 
+ATOM   194 C  C8    . DG  A 1 10 ? 8.551  21.579 -4.699  1.00 23.42 ? 10  DG  A C8    1 
+ATOM   195 N  N7    . DG  A 1 10 ? 8.502  20.320 -4.237  1.00 12.79 ? 10  DG  A N7    1 
+ATOM   196 C  C5    . DG  A 1 10 ? 9.767  19.870 -4.390  1.00 6.91  ? 10  DG  A C5    1 
+ATOM   197 C  C6    . DG  A 1 10 ? 10.329 18.596 -4.062  1.00 2.67  ? 10  DG  A C6    1 
+ATOM   198 O  O6    . DG  A 1 10 ? 9.782  17.612 -3.569  1.00 10.47 ? 10  DG  A O6    1 
+ATOM   199 N  N1    . DG  A 1 10 ? 11.675 18.554 -4.337  1.00 0.59  ? 10  DG  A N1    1 
+ATOM   200 C  C2    . DG  A 1 10 ? 12.432 19.553 -4.876  1.00 7.92  ? 10  DG  A C2    1 
+ATOM   201 N  N2    . DG  A 1 10 ? 13.756 19.301 -5.077  1.00 29.97 ? 10  DG  A N2    1 
+ATOM   202 N  N3    . DG  A 1 10 ? 11.904 20.735 -5.208  1.00 10.72 ? 10  DG  A N3    1 
+ATOM   203 C  C4    . DG  A 1 10 ? 10.583 20.825 -4.926  1.00 23.82 ? 10  DG  A C4    1 
+ATOM   204 P  P     . DC  A 1 11 ? 11.370 26.440 -8.411  1.00 43.49 ? 11  DC  A P     1 
+ATOM   205 O  OP1   . DC  A 1 11 ? 11.430 27.571 -7.461  1.00 57.36 ? 11  DC  A OP1   1 
+ATOM   206 O  OP2   . DC  A 1 11 ? 10.535 26.649 -9.601  1.00 54.03 ? 11  DC  A OP2   1 
+ATOM   207 O  "O5'" . DC  A 1 11 ? 12.839 26.005 -8.871  1.00 35.15 ? 11  DC  A "O5'" 1 
+ATOM   208 C  "C5'" . DC  A 1 11 ? 13.934 25.955 -7.927  1.00 25.01 ? 11  DC  A "C5'" 1 
+ATOM   209 C  "C4'" . DC  A 1 11 ? 14.979 25.006 -8.447  1.00 55.72 ? 11  DC  A "C4'" 1 
+ATOM   210 O  "O4'" . DC  A 1 11 ? 14.615 23.735 -7.898  1.00 50.59 ? 11  DC  A "O4'" 1 
+ATOM   211 C  "C3'" . DC  A 1 11 ? 15.037 24.821 -9.959  1.00 36.84 ? 11  DC  A "C3'" 1 
+ATOM   212 O  "O3'" . DC  A 1 11 ? 16.363 24.764 -10.503 1.00 41.37 ? 11  DC  A "O3'" 1 
+ATOM   213 C  "C2'" . DC  A 1 11 ? 14.245 23.531 -10.161 1.00 15.16 ? 11  DC  A "C2'" 1 
+ATOM   214 C  "C1'" . DC  A 1 11 ? 14.638 22.756 -8.936  1.00 20.64 ? 11  DC  A "C1'" 1 
+ATOM   215 N  N1    . DC  A 1 11 ? 13.498 21.835 -8.725  1.00 21.37 ? 11  DC  A N1    1 
+ATOM   216 C  C2    . DC  A 1 11 ? 13.672 20.575 -8.231  1.00 35.95 ? 11  DC  A C2    1 
+ATOM   217 O  O2    . DC  A 1 11 ? 14.804 20.232 -7.886  1.00 38.20 ? 11  DC  A O2    1 
+ATOM   218 N  N3    . DC  A 1 11 ? 12.628 19.739 -8.152  1.00 21.15 ? 11  DC  A N3    1 
+ATOM   219 C  C4    . DC  A 1 11 ? 11.410 20.126 -8.547  1.00 17.27 ? 11  DC  A C4    1 
+ATOM   220 N  N4    . DC  A 1 11 ? 10.358 19.265 -8.466  1.00 20.81 ? 11  DC  A N4    1 
+ATOM   221 C  C5    . DC  A 1 11 ? 11.188 21.409 -9.034  1.00 10.96 ? 11  DC  A C5    1 
+ATOM   222 C  C6    . DC  A 1 11 ? 12.275 22.275 -9.131  1.00 7.42  ? 11  DC  A C6    1 
+ATOM   223 P  P     . DG  A 1 12 ? 16.559 24.424 -12.047 1.00 43.75 ? 12  DG  A P     1 
+ATOM   224 O  OP1   . DG  A 1 12 ? 17.592 25.279 -12.673 1.00 42.07 ? 12  DG  A OP1   1 
+ATOM   225 O  OP2   . DG  A 1 12 ? 15.238 24.406 -12.765 1.00 36.15 ? 12  DG  A OP2   1 
+ATOM   226 O  "O5'" . DG  A 1 12 ? 17.184 22.973 -12.074 1.00 46.00 ? 12  DG  A "O5'" 1 
+ATOM   227 C  "C5'" . DG  A 1 12 ? 18.340 22.545 -11.297 1.00 44.36 ? 12  DG  A "C5'" 1 
+ATOM   228 C  "C4'" . DG  A 1 12 ? 18.412 21.062 -11.549 1.00 45.03 ? 12  DG  A "C4'" 1 
+ATOM   229 O  "O4'" . DG  A 1 12 ? 17.111 20.595 -11.214 1.00 8.20  ? 12  DG  A "O4'" 1 
+ATOM   230 C  "C3'" . DG  A 1 12 ? 18.589 20.705 -13.015 1.00 44.44 ? 12  DG  A "C3'" 1 
+ATOM   231 O  "O3'" . DG  A 1 12 ? 19.918 20.255 -13.312 1.00 53.86 ? 12  DG  A "O3'" 1 
+ATOM   232 C  "C2'" . DG  A 1 12 ? 17.492 19.667 -13.317 1.00 -1.04 ? 12  DG  A "C2'" 1 
+ATOM   233 C  "C1'" . DG  A 1 12 ? 16.844 19.421 -11.962 1.00 0.99  ? 12  DG  A "C1'" 1 
+ATOM   234 N  N9    . DG  A 1 12 ? 15.373 19.501 -12.055 1.00 17.30 ? 12  DG  A N9    1 
+ATOM   235 C  C8    . DG  A 1 12 ? 14.619 20.608 -12.348 1.00 16.91 ? 12  DG  A C8    1 
+ATOM   236 N  N7    . DG  A 1 12 ? 13.300 20.373 -12.279 1.00 13.84 ? 12  DG  A N7    1 
+ATOM   237 C  C5    . DG  A 1 12 ? 13.232 19.076 -11.916 1.00 22.79 ? 12  DG  A C5    1 
+ATOM   238 C  C6    . DG  A 1 12 ? 12.089 18.256 -11.656 1.00 18.98 ? 12  DG  A C6    1 
+ATOM   239 O  O6    . DG  A 1 12 ? 10.897 18.550 -11.711 1.00 31.42 ? 12  DG  A O6    1 
+ATOM   240 N  N1    . DG  A 1 12 ? 12.458 16.989 -11.275 1.00 3.94  ? 12  DG  A N1    1 
+ATOM   241 C  C2    . DG  A 1 12 ? 13.726 16.499 -11.154 1.00 9.57  ? 12  DG  A C2    1 
+ATOM   242 N  N2    . DG  A 1 12 ? 13.871 15.205 -10.752 1.00 6.53  ? 12  DG  A N2    1 
+ATOM   243 N  N3    . DG  A 1 12 ? 14.799 17.251 -11.403 1.00 16.33 ? 12  DG  A N3    1 
+ATOM   244 C  C4    . DG  A 1 12 ? 14.472 18.514 -11.770 1.00 20.11 ? 12  DG  A C4    1 
+ATOM   245 O  "O5'" . DC  B 1 1  ? 6.833  9.092  -10.304 1.00 50.15 ? 13  DC  B "O5'" 1 
+ATOM   246 C  "C5'" . DC  B 1 1  ? 8.081  8.368  -10.417 1.00 45.63 ? 13  DC  B "C5'" 1 
+ATOM   247 C  "C4'" . DC  B 1 1  ? 9.209  9.226  -9.893  1.00 6.69  ? 13  DC  B "C4'" 1 
+ATOM   248 O  "O4'" . DC  B 1 1  ? 9.380  10.369 -10.754 1.00 43.46 ? 13  DC  B "O4'" 1 
+ATOM   249 C  "C3'" . DC  B 1 1  ? 9.082  9.787  -8.466  1.00 5.03  ? 13  DC  B "C3'" 1 
+ATOM   250 O  "O3'" . DC  B 1 1  ? 10.283 9.643  -7.711  1.00 37.40 ? 13  DC  B "O3'" 1 
+ATOM   251 C  "C2'" . DC  B 1 1  ? 8.804  11.236 -8.777  1.00 39.69 ? 13  DC  B "C2'" 1 
+ATOM   252 C  "C1'" . DC  B 1 1  ? 9.817  11.403 -9.884  1.00 9.32  ? 13  DC  B "C1'" 1 
+ATOM   253 N  N1    . DC  B 1 1  ? 9.600  12.711 -10.524 1.00 -3.05 ? 13  DC  B N1    1 
+ATOM   254 C  C2    . DC  B 1 1  ? 10.537 13.684 -10.355 1.00 11.31 ? 13  DC  B C2    1 
+ATOM   255 O  O2    . DC  B 1 1  ? 11.567 13.404 -9.738  1.00 23.75 ? 13  DC  B O2    1 
+ATOM   256 N  N3    . DC  B 1 1  ? 10.324 14.905 -10.857 1.00 47.45 ? 13  DC  B N3    1 
+ATOM   257 C  C4    . DC  B 1 1  ? 9.190  15.175 -11.521 1.00 38.38 ? 13  DC  B C4    1 
+ATOM   258 N  N4    . DC  B 1 1  ? 8.975  16.427 -12.021 1.00 27.06 ? 13  DC  B N4    1 
+ATOM   259 C  C5    . DC  B 1 1  ? 8.220  14.198 -11.729 1.00 35.81 ? 13  DC  B C5    1 
+ATOM   260 C  C6    . DC  B 1 1  ? 8.437  12.931 -11.200 1.00 17.34 ? 13  DC  B C6    1 
+ATOM   261 P  P     . DG  B 1 2  ? 10.404 8.420  -6.698  1.00 45.80 ? 14  DG  B P     1 
+ATOM   262 O  OP1   . DG  B 1 2  ? 10.300 7.184  -7.488  1.00 46.81 ? 14  DG  B OP1   1 
+ATOM   263 O  OP2   . DG  B 1 2  ? 9.378  8.661  -5.642  1.00 42.97 ? 14  DG  B OP2   1 
+ATOM   264 O  "O5'" . DG  B 1 2  ? 11.914 8.553  -6.176  1.00 39.92 ? 14  DG  B "O5'" 1 
+ATOM   265 C  "C5'" . DG  B 1 2  ? 13.016 8.506  -7.129  1.00 10.14 ? 14  DG  B "C5'" 1 
+ATOM   266 C  "C4'" . DG  B 1 2  ? 13.973 9.649  -6.870  1.00 23.05 ? 14  DG  B "C4'" 1 
+ATOM   267 O  "O4'" . DG  B 1 2  ? 13.424 10.876 -7.420  1.00 19.01 ? 14  DG  B "O4'" 1 
+ATOM   268 C  "C3'" . DG  B 1 2  ? 14.224 9.953  -5.391  1.00 24.52 ? 14  DG  B "C3'" 1 
+ATOM   269 O  "O3'" . DG  B 1 2  ? 15.544 10.433 -5.128  1.00 34.49 ? 14  DG  B "O3'" 1 
+ATOM   270 C  "C2'" . DG  B 1 2  ? 13.212 11.056 -5.187  1.00 37.69 ? 14  DG  B "C2'" 1 
+ATOM   271 C  "C1'" . DG  B 1 2  ? 13.601 11.868 -6.399  1.00 17.36 ? 14  DG  B "C1'" 1 
+ATOM   272 N  N9    . DG  B 1 2  ? 12.638 12.985 -6.552  1.00 20.57 ? 14  DG  B N9    1 
+ATOM   273 C  C8    . DG  B 1 2  ? 11.293 12.932 -6.300  1.00 20.12 ? 14  DG  B C8    1 
+ATOM   274 N  N7    . DG  B 1 2  ? 10.683 14.116 -6.450  1.00 38.47 ? 14  DG  B N7    1 
+ATOM   275 C  C5    . DG  B 1 2  ? 11.685 14.943 -6.804  1.00 6.54  ? 14  DG  B C5    1 
+ATOM   276 C  C6    . DG  B 1 2  ? 11.622 16.334 -7.097  1.00 24.41 ? 14  DG  B C6    1 
+ATOM   277 O  O6    . DG  B 1 2  ? 10.642 17.069 -7.067  1.00 31.10 ? 14  DG  B O6    1 
+ATOM   278 N  N1    . DG  B 1 2  ? 12.849 16.833 -7.456  1.00 2.43  ? 14  DG  B N1    1 
+ATOM   279 C  C2    . DG  B 1 2  ? 14.029 16.144 -7.510  1.00 -1.53 ? 14  DG  B C2    1 
+ATOM   280 N  N2    . DG  B 1 2  ? 15.146 16.834 -7.876  1.00 32.62 ? 14  DG  B N2    1 
+ATOM   281 N  N3    . DG  B 1 2  ? 14.095 14.840 -7.212  1.00 29.64 ? 14  DG  B N3    1 
+ATOM   282 C  C4    . DG  B 1 2  ? 12.891 14.305 -6.881  1.00 27.85 ? 14  DG  B C4    1 
+ATOM   283 P  P     . DC  B 1 3  ? 16.386 9.801  -3.924  1.00 23.60 ? 15  DC  B P     1 
+ATOM   284 O  OP1   . DC  B 1 3  ? 17.025 8.564  -4.422  1.00 39.14 ? 15  DC  B OP1   1 
+ATOM   285 O  OP2   . DC  B 1 3  ? 15.495 9.592  -2.755  1.00 35.39 ? 15  DC  B OP2   1 
+ATOM   286 O  "O5'" . DC  B 1 3  ? 17.479 10.942 -3.643  1.00 15.86 ? 15  DC  B "O5'" 1 
+ATOM   287 C  "C5'" . DC  B 1 3  ? 18.205 11.506 -4.757  1.00 4.16  ? 15  DC  B "C5'" 1 
+ATOM   288 C  "C4'" . DC  B 1 3  ? 18.068 13.002 -4.599  1.00 22.18 ? 15  DC  B "C4'" 1 
+ATOM   289 O  "O4'" . DC  B 1 3  ? 16.695 13.375 -4.764  1.00 20.69 ? 15  DC  B "O4'" 1 
+ATOM   290 C  "C3'" . DC  B 1 3  ? 18.327 13.514 -3.197  1.00 11.04 ? 15  DC  B "C3'" 1 
+ATOM   291 O  "O3'" . DC  B 1 3  ? 19.719 13.442 -2.792  1.00 22.92 ? 15  DC  B "O3'" 1 
+ATOM   292 C  "C2'" . DC  B 1 3  ? 17.730 14.927 -3.299  1.00 14.83 ? 15  DC  B "C2'" 1 
+ATOM   293 C  "C1'" . DC  B 1 3  ? 16.572 14.724 -4.291  1.00 1.91  ? 15  DC  B "C1'" 1 
+ATOM   294 N  N1    . DC  B 1 3  ? 15.177 14.878 -3.763  1.00 1.84  ? 15  DC  B N1    1 
+ATOM   295 C  C2    . DC  B 1 3  ? 14.546 16.083 -3.873  1.00 9.34  ? 15  DC  B C2    1 
+ATOM   296 O  O2    . DC  B 1 3  ? 15.173 17.027 -4.352  1.00 9.22  ? 15  DC  B O2    1 
+ATOM   297 N  N3    . DC  B 1 3  ? 13.258 16.196 -3.524  1.00 7.36  ? 15  DC  B N3    1 
+ATOM   298 C  C4    . DC  B 1 3  ? 12.582 15.146 -3.047  1.00 12.78 ? 15  DC  B C4    1 
+ATOM   299 N  N4    . DC  B 1 3  ? 11.270 15.281 -2.707  1.00 23.36 ? 15  DC  B N4    1 
+ATOM   300 C  C5    . DC  B 1 3  ? 13.193 13.906 -2.885  1.00 29.55 ? 15  DC  B C5    1 
+ATOM   301 C  C6    . DC  B 1 3  ? 14.529 13.784 -3.269  1.00 -0.53 ? 15  DC  B C6    1 
+ATOM   302 P  P     . DG  B 1 4  ? 20.211 14.038 -1.391  1.00 30.69 ? 16  DG  B P     1 
+ATOM   303 O  OP1   . DG  B 1 4  ? 21.568 13.582 -1.038  1.00 52.50 ? 16  DG  B OP1   1 
+ATOM   304 O  OP2   . DG  B 1 4  ? 19.194 13.786 -0.365  1.00 35.69 ? 16  DG  B OP2   1 
+ATOM   305 O  "O5'" . DG  B 1 4  ? 20.291 15.610 -1.575  1.00 12.98 ? 16  DG  B "O5'" 1 
+ATOM   306 C  "C5'" . DG  B 1 4  ? 21.076 16.213 -2.659  1.00 14.60 ? 16  DG  B "C5'" 1 
+ATOM   307 C  "C4'" . DG  B 1 4  ? 20.699 17.670 -2.660  1.00 37.18 ? 16  DG  B "C4'" 1 
+ATOM   308 O  "O4'" . DG  B 1 4  ? 19.269 17.764 -2.601  1.00 18.95 ? 16  DG  B "O4'" 1 
+ATOM   309 C  "C3'" . DG  B 1 4  ? 21.158 18.515 -1.493  1.00 26.30 ? 16  DG  B "C3'" 1 
+ATOM   310 O  "O3'" . DG  B 1 4  ? 21.175 19.890 -1.838  1.00 50.12 ? 16  DG  B "O3'" 1 
+ATOM   311 C  "C2'" . DG  B 1 4  ? 20.058 18.215 -0.483  1.00 21.70 ? 16  DG  B "C2'" 1 
+ATOM   312 C  "C1'" . DG  B 1 4  ? 18.904 18.528 -1.432  1.00 23.68 ? 16  DG  B "C1'" 1 
+ATOM   313 N  N9    . DG  B 1 4  ? 17.584 17.975 -1.005  1.00 3.93  ? 16  DG  B N9    1 
+ATOM   314 C  C8    . DG  B 1 4  ? 17.368 16.788 -0.361  1.00 21.20 ? 16  DG  B C8    1 
+ATOM   315 N  N7    . DG  B 1 4  ? 16.068 16.505 -0.185  1.00 12.91 ? 16  DG  B N7    1 
+ATOM   316 C  C5    . DG  B 1 4  ? 15.436 17.560 -0.734  1.00 4.07  ? 16  DG  B C5    1 
+ATOM   317 C  C6    . DG  B 1 4  ? 14.035 17.821 -0.832  1.00 -1.14 ? 16  DG  B C6    1 
+ATOM   318 O  O6    . DG  B 1 4  ? 13.096 17.129 -0.453  1.00 5.32  ? 16  DG  B O6    1 
+ATOM   319 N  N1    . DG  B 1 4  ? 13.785 19.038 -1.411  1.00 3.46  ? 16  DG  B N1    1 
+ATOM   320 C  C2    . DG  B 1 4  ? 14.711 19.926 -1.874  1.00 -3.24 ? 16  DG  B C2    1 
+ATOM   321 N  N2    . DG  B 1 4  ? 14.246 21.094 -2.397  1.00 6.21  ? 16  DG  B N2    1 
+ATOM   322 N  N3    . DG  B 1 4  ? 16.023 19.680 -1.808  1.00 13.59 ? 16  DG  B N3    1 
+ATOM   323 C  C4    . DG  B 1 4  ? 16.317 18.483 -1.234  1.00 5.08  ? 16  DG  B C4    1 
+ATOM   324 P  P     . DA  B 1 5  ? 21.878 20.979 -0.903  1.00 28.75 ? 17  DA  B P     1 
+ATOM   325 O  OP1   . DA  B 1 5  ? 23.203 21.257 -1.481  1.00 53.12 ? 17  DA  B OP1   1 
+ATOM   326 O  OP2   . DA  B 1 5  ? 21.825 20.611 0.526   1.00 53.38 ? 17  DA  B OP2   1 
+ATOM   327 O  "O5'" . DA  B 1 5  ? 20.879 22.206 -1.083  1.00 16.45 ? 17  DA  B "O5'" 1 
+ATOM   328 C  "C5'" . DA  B 1 5  ? 20.333 22.496 -2.375  1.00 49.94 ? 17  DA  B "C5'" 1 
+ATOM   329 C  "C4'" . DA  B 1 5  ? 19.120 23.343 -2.087  1.00 46.08 ? 17  DA  B "C4'" 1 
+ATOM   330 O  "O4'" . DA  B 1 5  ? 18.126 22.496 -1.487  1.00 39.84 ? 17  DA  B "O4'" 1 
+ATOM   331 C  "C3'" . DA  B 1 5  ? 19.361 24.430 -1.068  1.00 29.88 ? 17  DA  B "C3'" 1 
+ATOM   332 O  "O3'" . DA  B 1 5  ? 18.869 25.702 -1.491  1.00 43.42 ? 17  DA  B "O3'" 1 
+ATOM   333 C  "C2'" . DA  B 1 5  ? 18.740 23.893 0.221   1.00 35.20 ? 17  DA  B "C2'" 1 
+ATOM   334 C  "C1'" . DA  B 1 5  ? 17.552 23.140 -0.333  1.00 39.46 ? 17  DA  B "C1'" 1 
+ATOM   335 N  N9    . DA  B 1 5  ? 17.142 22.026 0.577   1.00 34.11 ? 17  DA  B N9    1 
+ATOM   336 C  C8    . DA  B 1 5  ? 17.961 21.105 1.186   1.00 0.05  ? 17  DA  B C8    1 
+ATOM   337 N  N7    . DA  B 1 5  ? 17.290 20.157 1.862   1.00 23.54 ? 17  DA  B N7    1 
+ATOM   338 C  C5    . DA  B 1 5  ? 15.999 20.488 1.661   1.00 21.38 ? 17  DA  B C5    1 
+ATOM   339 C  C6    . DA  B 1 5  ? 14.786 19.860 2.082   1.00 19.92 ? 17  DA  B C6    1 
+ATOM   340 N  N6    . DA  B 1 5  ? 14.771 18.712 2.823   1.00 16.31 ? 17  DA  B N6    1 
+ATOM   341 N  N1    . DA  B 1 5  ? 13.635 20.432 1.714   1.00 19.82 ? 17  DA  B N1    1 
+ATOM   342 C  C2    . DA  B 1 5  ? 13.649 21.561 1.001   1.00 9.97  ? 17  DA  B C2    1 
+ATOM   343 N  N3    . DA  B 1 5  ? 14.701 22.245 0.547   1.00 21.81 ? 17  DA  B N3    1 
+ATOM   344 C  C4    . DA  B 1 5  ? 15.861 21.638 0.916   1.00 29.63 ? 17  DA  B C4    1 
+ATOM   345 P  P     . DA  B 1 6  ? 18.968 26.931 -0.489  1.00 51.51 ? 18  DA  B P     1 
+ATOM   346 O  OP1   . DA  B 1 6  ? 19.075 28.189 -1.248  1.00 59.64 ? 18  DA  B OP1   1 
+ATOM   347 O  OP2   . DA  B 1 6  ? 20.090 26.624 0.431   1.00 51.63 ? 18  DA  B OP2   1 
+ATOM   348 O  "O5'" . DA  B 1 6  ? 17.543 26.873 0.232   1.00 40.99 ? 18  DA  B "O5'" 1 
+ATOM   349 C  "C5'" . DA  B 1 6  ? 16.318 27.004 -0.538  1.00 19.81 ? 18  DA  B "C5'" 1 
+ATOM   350 C  "C4'" . DA  B 1 6  ? 15.199 26.956 0.463   1.00 13.88 ? 18  DA  B "C4'" 1 
+ATOM   351 O  "O4'" . DA  B 1 6  ? 15.303 25.696 1.122   1.00 18.17 ? 18  DA  B "O4'" 1 
+ATOM   352 C  "C3'" . DA  B 1 6  ? 15.244 28.014 1.559   1.00 25.33 ? 18  DA  B "C3'" 1 
+ATOM   353 O  "O3'" . DA  B 1 6  ? 14.140 28.940 1.469   1.00 43.30 ? 18  DA  B "O3'" 1 
+ATOM   354 C  "C2'" . DA  B 1 6  ? 15.337 27.191 2.852   1.00 6.14  ? 18  DA  B "C2'" 1 
+ATOM   355 C  "C1'" . DA  B 1 6  ? 14.752 25.850 2.425   1.00 -3.06 ? 18  DA  B "C1'" 1 
+ATOM   356 N  N9    . DA  B 1 6  ? 15.338 24.718 3.187   1.00 7.01  ? 18  DA  B N9    1 
+ATOM   357 C  C8    . DA  B 1 6  ? 16.663 24.389 3.309   1.00 13.11 ? 18  DA  B C8    1 
+ATOM   358 N  N7    . DA  B 1 6  ? 16.854 23.237 3.976   1.00 4.22  ? 18  DA  B N7    1 
+ATOM   359 C  C5    . DA  B 1 6  ? 15.606 22.817 4.273   1.00 -6.03 ? 18  DA  B C5    1 
+ATOM   360 C  C6    . DA  B 1 6  ? 15.120 21.654 4.950   1.00 10.09 ? 18  DA  B C6    1 
+ATOM   361 N  N6    . DA  B 1 6  ? 15.950 20.706 5.469   1.00 12.00 ? 18  DA  B N6    1 
+ATOM   362 N  N1    . DA  B 1 6  ? 13.799 21.510 5.058   1.00 14.68 ? 18  DA  B N1    1 
+ATOM   363 C  C2    . DA  B 1 6  ? 12.993 22.447 4.554   1.00 4.30  ? 18  DA  B C2    1 
+ATOM   364 N  N3    . DA  B 1 6  ? 13.312 23.580 3.923   1.00 2.54  ? 18  DA  B N3    1 
+ATOM   365 C  C4    . DA  B 1 6  ? 14.655 23.699 3.818   1.00 14.24 ? 18  DA  B C4    1 
+ATOM   366 P  P     . DT  B 1 7  ? 13.968 30.155 2.501   1.00 36.54 ? 19  DT  B P     1 
+ATOM   367 O  OP1   . DT  B 1 7  ? 13.133 31.210 1.874   1.00 30.76 ? 19  DT  B OP1   1 
+ATOM   368 O  OP2   . DT  B 1 7  ? 15.293 30.639 2.954   1.00 33.56 ? 19  DT  B OP2   1 
+ATOM   369 O  "O5'" . DT  B 1 7  ? 13.155 29.457 3.695   1.00 32.67 ? 19  DT  B "O5'" 1 
+ATOM   370 C  "C5'" . DT  B 1 7  ? 11.894 28.783 3.401   1.00 24.79 ? 19  DT  B "C5'" 1 
+ATOM   371 C  "C4'" . DT  B 1 7  ? 11.491 27.941 4.574   1.00 12.60 ? 19  DT  B "C4'" 1 
+ATOM   372 O  "O4'" . DT  B 1 7  ? 12.580 27.083 4.871   1.00 22.34 ? 19  DT  B "O4'" 1 
+ATOM   373 C  "C3'" . DT  B 1 7  ? 11.196 28.668 5.883   1.00 10.60 ? 19  DT  B "C3'" 1 
+ATOM   374 O  "O3'" . DT  B 1 7  ? 9.825  29.124 5.975   1.00 35.11 ? 19  DT  B "O3'" 1 
+ATOM   375 C  "C2'" . DT  B 1 7  ? 11.630 27.637 6.941   1.00 23.19 ? 19  DT  B "C2'" 1 
+ATOM   376 C  "C1'" . DT  B 1 7  ? 12.195 26.493 6.097   1.00 -0.26 ? 19  DT  B "C1'" 1 
+ATOM   377 N  N1    . DT  B 1 7  ? 13.394 25.809 6.650   1.00 14.07 ? 19  DT  B N1    1 
+ATOM   378 C  C2    . DT  B 1 7  ? 13.204 24.635 7.312   1.00 20.50 ? 19  DT  B C2    1 
+ATOM   379 O  O2    . DT  B 1 7  ? 12.069 24.206 7.505   1.00 12.28 ? 19  DT  B O2    1 
+ATOM   380 N  N3    . DT  B 1 7  ? 14.293 23.909 7.683   1.00 15.74 ? 19  DT  B N3    1 
+ATOM   381 C  C4    . DT  B 1 7  ? 15.570 24.334 7.451   1.00 5.04  ? 19  DT  B C4    1 
+ATOM   382 O  O4    . DT  B 1 7  ? 16.494 23.615 7.828   1.00 12.48 ? 19  DT  B O4    1 
+ATOM   383 C  C5    . DT  B 1 7  ? 15.758 25.569 6.831   1.00 10.88 ? 19  DT  B C5    1 
+ATOM   384 C  C7    . DT  B 1 7  ? 17.151 26.071 6.594   1.00 9.29  ? 19  DT  B C7    1 
+ATOM   385 C  C6    . DT  B 1 7  ? 14.646 26.300 6.406   1.00 19.28 ? 19  DT  B C6    1 
+ATOM   386 P  P     . DT  B 1 8  ? 9.193  29.815 7.281   1.00 29.34 ? 20  DT  B P     1 
+ATOM   387 O  OP1   . DT  B 1 8  ? 7.840  30.272 6.904   1.00 20.30 ? 20  DT  B OP1   1 
+ATOM   388 O  OP2   . DT  B 1 8  ? 10.077 30.829 7.923   1.00 29.64 ? 20  DT  B OP2   1 
+ATOM   389 O  "O5'" . DT  B 1 8  ? 8.991  28.609 8.305   1.00 7.29  ? 20  DT  B "O5'" 1 
+ATOM   390 C  "C5'" . DT  B 1 8  ? 8.011  27.592 8.029   1.00 35.74 ? 20  DT  B "C5'" 1 
+ATOM   391 C  "C4'" . DT  B 1 8  ? 8.113  26.614 9.166   1.00 0.27  ? 20  DT  B "C4'" 1 
+ATOM   392 O  "O4'" . DT  B 1 8  ? 9.436  26.066 9.204   1.00 10.84 ? 20  DT  B "O4'" 1 
+ATOM   393 C  "C3'" . DT  B 1 8  ? 7.808  27.155 10.567  1.00 36.37 ? 20  DT  B "C3'" 1 
+ATOM   394 O  "O3'" . DT  B 1 8  ? 6.610  26.561 11.093  1.00 42.32 ? 20  DT  B "O3'" 1 
+ATOM   395 C  "C2'" . DT  B 1 8  ? 9.099  26.840 11.344  1.00 10.11 ? 20  DT  B "C2'" 1 
+ATOM   396 C  "C1'" . DT  B 1 8  ? 9.664  25.673 10.553  1.00 4.28  ? 20  DT  B "C1'" 1 
+ATOM   397 N  N1    . DT  B 1 8  ? 11.140 25.590 10.677  1.00 0.58  ? 20  DT  B N1    1 
+ATOM   398 C  C2    . DT  B 1 8  ? 11.719 24.459 11.171  1.00 6.16  ? 20  DT  B C2    1 
+ATOM   399 O  O2    . DT  B 1 8  ? 11.028 23.526 11.577  1.00 13.97 ? 20  DT  B O2    1 
+ATOM   400 N  N3    . DT  B 1 8  ? 13.079 24.361 11.144  1.00 12.83 ? 20  DT  B N3    1 
+ATOM   401 C  C4    . DT  B 1 8  ? 13.875 25.367 10.665  1.00 1.28  ? 20  DT  B C4    1 
+ATOM   402 O  O4    . DT  B 1 8  ? 15.093 25.196 10.669  1.00 24.75 ? 20  DT  B O4    1 
+ATOM   403 C  C5    . DT  B 1 8  ? 13.274 26.538 10.208  1.00 10.97 ? 20  DT  B C5    1 
+ATOM   404 C  C7    . DT  B 1 8  ? 14.133 27.640 9.668   1.00 4.45  ? 20  DT  B C7    1 
+ATOM   405 C  C6    . DT  B 1 8  ? 11.886 26.630 10.204  1.00 -8.34 ? 20  DT  B C6    1 
+HETATM 406 BR BR    . CBR B 1 9  ? 12.207 27.935 13.598  1.00 22.17 ? 21  CBR B BR    1 
+HETATM 407 P  P     . CBR B 1 9  ? 6.232  26.619 12.647  1.00 27.28 ? 21  CBR B P     1 
+HETATM 408 O  OP1   . CBR B 1 9  ? 4.776  26.382 12.774  1.00 57.90 ? 21  CBR B OP1   1 
+HETATM 409 O  OP2   . CBR B 1 9  ? 6.735  27.860 13.249  1.00 49.40 ? 21  CBR B OP2   1 
+HETATM 410 O  "O5'" . CBR B 1 9  ? 7.053  25.418 13.304  1.00 14.56 ? 21  CBR B "O5'" 1 
+HETATM 411 N  N1    . CBR B 1 9  ? 10.958 24.180 14.805  1.00 3.34  ? 21  CBR B N1    1 
+HETATM 412 C  C6    . CBR B 1 9  ? 10.933 25.470 14.365  1.00 26.08 ? 21  CBR B C6    1 
+HETATM 413 C  C2    . CBR B 1 9  ? 12.144 23.548 15.054  1.00 42.66 ? 21  CBR B C2    1 
+HETATM 414 O  O2    . CBR B 1 9  ? 12.117 22.381 15.434  1.00 32.64 ? 21  CBR B O2    1 
+HETATM 415 N  N3    . CBR B 1 9  ? 13.309 24.182 14.862  1.00 18.87 ? 21  CBR B N3    1 
+HETATM 416 C  C4    . CBR B 1 9  ? 13.332 25.448 14.430  1.00 -6.99 ? 21  CBR B C4    1 
+HETATM 417 N  N4    . CBR B 1 9  ? 14.525 26.087 14.248  1.00 -1.40 ? 21  CBR B N4    1 
+HETATM 418 C  C5    . CBR B 1 9  ? 12.148 26.140 14.171  1.00 22.44 ? 21  CBR B C5    1 
+HETATM 419 C  "C2'" . CBR B 1 9  ? 8.795  23.920 16.115  1.00 21.46 ? 21  CBR B "C2'" 1 
+HETATM 420 C  "C5'" . CBR B 1 9  ? 6.707  24.056 13.070  1.00 42.50 ? 21  CBR B "C5'" 1 
+HETATM 421 C  "C4'" . CBR B 1 9  ? 7.560  23.372 14.105  1.00 31.04 ? 21  CBR B "C4'" 1 
+HETATM 422 O  "O4'" . CBR B 1 9  ? 8.920  23.603 13.742  1.00 24.91 ? 21  CBR B "O4'" 1 
+HETATM 423 C  "C1'" . CBR B 1 9  ? 9.669  23.431 14.960  1.00 24.08 ? 21  CBR B "C1'" 1 
+HETATM 424 C  "C3'" . CBR B 1 9  ? 7.368  23.887 15.551  1.00 22.65 ? 21  CBR B "C3'" 1 
+HETATM 425 O  "O3'" . CBR B 1 9  ? 6.358  23.096 16.242  1.00 37.32 ? 21  CBR B "O3'" 1 
+ATOM   426 P  P     . DG  B 1 10 ? 6.151  22.837 17.813  1.00 40.95 ? 22  DG  B P     1 
+ATOM   427 O  OP1   . DG  B 1 10 ? 5.341  21.603 17.838  1.00 41.68 ? 22  DG  B OP1   1 
+ATOM   428 O  OP2   . DG  B 1 10 ? 5.592  24.000 18.485  1.00 29.89 ? 22  DG  B OP2   1 
+ATOM   429 O  "O5'" . DG  B 1 10 ? 7.591  22.520 18.411  1.00 40.63 ? 22  DG  B "O5'" 1 
+ATOM   430 C  "C5'" . DG  B 1 10 ? 8.203  21.223 18.226  1.00 40.07 ? 22  DG  B "C5'" 1 
+ATOM   431 C  "C4'" . DG  B 1 10 ? 9.436  21.179 19.107  1.00 21.88 ? 22  DG  B "C4'" 1 
+ATOM   432 O  "O4'" . DG  B 1 10 ? 10.446 21.994 18.486  1.00 30.68 ? 22  DG  B "O4'" 1 
+ATOM   433 C  "C3'" . DG  B 1 10 ? 9.340  21.712 20.553  1.00 36.47 ? 22  DG  B "C3'" 1 
+ATOM   434 O  "O3'" . DG  B 1 10 ? 10.330 21.121 21.410  1.00 39.73 ? 22  DG  B "O3'" 1 
+ATOM   435 C  "C2'" . DG  B 1 10 ? 9.668  23.175 20.296  1.00 34.67 ? 22  DG  B "C2'" 1 
+ATOM   436 C  "C1'" . DG  B 1 10 ? 10.914 22.885 19.502  1.00 -3.28 ? 22  DG  B "C1'" 1 
+ATOM   437 N  N9    . DG  B 1 10 ? 11.542 24.085 18.903  1.00 1.41  ? 22  DG  B N9    1 
+ATOM   438 C  C8    . DG  B 1 10 ? 10.998 25.290 18.541  1.00 -5.89 ? 22  DG  B C8    1 
+ATOM   439 N  N7    . DG  B 1 10 ? 11.912 26.126 18.021  1.00 19.04 ? 22  DG  B N7    1 
+ATOM   440 C  C5    . DG  B 1 10 ? 13.061 25.415 18.072  1.00 7.58  ? 22  DG  B C5    1 
+ATOM   441 C  C6    . DG  B 1 10 ? 14.390 25.770 17.683  1.00 15.66 ? 22  DG  B C6    1 
+ATOM   442 O  O6    . DG  B 1 10 ? 14.796 26.822 17.200  1.00 9.27  ? 22  DG  B O6    1 
+ATOM   443 N  N1    . DG  B 1 10 ? 15.284 24.754 17.941  1.00 3.61  ? 22  DG  B N1    1 
+ATOM   444 C  C2    . DG  B 1 10 ? 15.006 23.534 18.487  1.00 -3.38 ? 22  DG  B C2    1 
+ATOM   445 N  N2    . DG  B 1 10 ? 16.039 22.659 18.683  1.00 27.47 ? 22  DG  B N2    1 
+ATOM   446 N  N3    . DG  B 1 10 ? 13.768 23.207 18.843  1.00 18.84 ? 22  DG  B N3    1 
+ATOM   447 C  C4    . DG  B 1 10 ? 12.869 24.187 18.610  1.00 0.03  ? 22  DG  B C4    1 
+ATOM   448 P  P     . DC  B 1 11 ? 9.933  20.071 22.555  1.00 31.07 ? 23  DC  B P     1 
+ATOM   449 O  OP1   . DC  B 1 11 ? 9.210  18.923 21.965  1.00 34.74 ? 23  DC  B OP1   1 
+ATOM   450 O  OP2   . DC  B 1 11 ? 9.235  20.797 23.650  1.00 48.02 ? 23  DC  B OP2   1 
+ATOM   451 O  "O5'" . DC  B 1 11 ? 11.356 19.503 23.023  1.00 35.89 ? 23  DC  B "O5'" 1 
+ATOM   452 C  "C5'" . DC  B 1 11 ? 12.000 18.486 22.217  1.00 36.77 ? 23  DC  B "C5'" 1 
+ATOM   453 C  "C4'" . DC  B 1 11 ? 13.466 18.793 22.183  1.00 53.74 ? 23  DC  B "C4'" 1 
+ATOM   454 O  "O4'" . DC  B 1 11 ? 13.525 20.130 21.716  1.00 28.42 ? 23  DC  B "O4'" 1 
+ATOM   455 C  "C3'" . DC  B 1 11 ? 14.215 18.756 23.523  1.00 31.64 ? 23  DC  B "C3'" 1 
+ATOM   456 O  "O3'" . DC  B 1 11 ? 15.147 17.640 23.618  1.00 40.69 ? 23  DC  B "O3'" 1 
+ATOM   457 C  "C2'" . DC  B 1 11 ? 14.838 20.159 23.644  1.00 21.20 ? 23  DC  B "C2'" 1 
+ATOM   458 C  "C1'" . DC  B 1 11 ? 14.720 20.704 22.222  1.00 -0.25 ? 23  DC  B "C1'" 1 
+ATOM   459 N  N1    . DC  B 1 11 ? 14.414 22.147 22.176  1.00 4.59  ? 23  DC  B N1    1 
+ATOM   460 C  C2    . DC  B 1 11 ? 15.428 23.045 22.087  1.00 16.09 ? 23  DC  B C2    1 
+ATOM   461 O  O2    . DC  B 1 11 ? 16.583 22.623 22.086  1.00 18.41 ? 23  DC  B O2    1 
+ATOM   462 N  N3    . DC  B 1 11 ? 15.158 24.351 22.024  1.00 29.61 ? 23  DC  B N3    1 
+ATOM   463 C  C4    . DC  B 1 11 ? 13.895 24.788 22.032  1.00 14.26 ? 23  DC  B C4    1 
+ATOM   464 N  N4    . DC  B 1 11 ? 13.633 26.127 21.940  1.00 15.65 ? 23  DC  B N4    1 
+ATOM   465 C  C5    . DC  B 1 11 ? 12.829 23.898 22.097  1.00 13.43 ? 23  DC  B C5    1 
+ATOM   466 C  C6    . DC  B 1 11 ? 13.113 22.539 22.165  1.00 27.49 ? 23  DC  B C6    1 
+ATOM   467 P  P     . DG  B 1 12 ? 15.629 17.011 25.022  1.00 58.32 ? 24  DG  B P     1 
+ATOM   468 O  OP1   . DG  B 1 12 ? 16.328 15.734 24.753  1.00 61.17 ? 24  DG  B OP1   1 
+ATOM   469 O  OP2   . DG  B 1 12 ? 14.476 16.865 25.930  1.00 49.15 ? 24  DG  B OP2   1 
+ATOM   470 O  "O5'" . DG  B 1 12 ? 16.720 18.058 25.551  1.00 47.71 ? 24  DG  B "O5'" 1 
+ATOM   471 C  "C5'" . DG  B 1 12 ? 17.996 18.109 24.868  1.00 34.82 ? 24  DG  B "C5'" 1 
+ATOM   472 C  "C4'" . DG  B 1 12 ? 18.730 19.368 25.254  1.00 33.83 ? 24  DG  B "C4'" 1 
+ATOM   473 O  "O4'" . DG  B 1 12 ? 18.086 20.480 24.647  1.00 17.30 ? 24  DG  B "O4'" 1 
+ATOM   474 C  "C3'" . DG  B 1 12 ? 18.775 19.730 26.718  1.00 23.44 ? 24  DG  B "C3'" 1 
+ATOM   475 O  "O3'" . DG  B 1 12 ? 19.657 18.873 27.467  1.00 45.91 ? 24  DG  B "O3'" 1 
+ATOM   476 C  "C2'" . DG  B 1 12 ? 19.282 21.170 26.595  1.00 35.07 ? 24  DG  B "C2'" 1 
+ATOM   477 C  "C1'" . DG  B 1 12 ? 18.583 21.643 25.313  1.00 15.49 ? 24  DG  B "C1'" 1 
+ATOM   478 N  N9    . DG  B 1 12 ? 17.427 22.559 25.484  1.00 12.06 ? 24  DG  B N9    1 
+ATOM   479 C  C8    . DG  B 1 12 ? 16.155 22.288 25.915  1.00 1.12  ? 24  DG  B C8    1 
+ATOM   480 N  N7    . DG  B 1 12 ? 15.334 23.346 25.818  1.00 15.94 ? 24  DG  B N7    1 
+ATOM   481 C  C5    . DG  B 1 12 ? 16.121 24.311 25.303  1.00 22.02 ? 24  DG  B C5    1 
+ATOM   482 C  C6    . DG  B 1 12 ? 15.792 25.646 24.922  1.00 6.56  ? 24  DG  B C6    1 
+ATOM   483 O  O6    . DG  B 1 12 ? 14.700 26.213 24.952  1.00 19.74 ? 24  DG  B O6    1 
+ATOM   484 N  N1    . DG  B 1 12 ? 16.883 26.298 24.396  1.00 6.11  ? 24  DG  B N1    1 
+ATOM   485 C  C2    . DG  B 1 12 ? 18.148 25.799 24.245  1.00 7.73  ? 24  DG  B C2    1 
+ATOM   486 N  N2    . DG  B 1 12 ? 19.083 26.601 23.658  1.00 15.30 ? 24  DG  B N2    1 
+ATOM   487 N  N3    . DG  B 1 12 ? 18.450 24.542 24.578  1.00 10.73 ? 24  DG  B N3    1 
+ATOM   488 C  C4    . DG  B 1 12 ? 17.401 23.869 25.103  1.00 19.68 ? 24  DG  B C4    1 
+HETATM 489 O  O     . HOH C 2 .  ? 24.384 35.196 23.173  1.00 34.95 ? 25  HOH A O     1 
+HETATM 490 O  O     . HOH C 2 .  ? 14.270 29.247 19.555  1.00 13.23 ? 29  HOH A O     1 
+HETATM 491 O  O     . HOH C 2 .  ? 18.200 33.593 18.044  1.00 16.08 ? 30  HOH A O     1 
+HETATM 492 O  O     . HOH C 2 .  ? 20.282 25.369 12.056  1.00 33.09 ? 34  HOH A O     1 
+HETATM 493 O  O     . HOH C 2 .  ? 7.758  22.470 9.474   1.00 12.35 ? 35  HOH A O     1 
+HETATM 494 O  O     . HOH C 2 .  ? 8.812  23.432 7.047   1.00 13.70 ? 37  HOH A O     1 
+HETATM 495 O  O     . HOH C 2 .  ? 8.539  24.956 4.917   1.00 25.00 ? 40  HOH A O     1 
+HETATM 496 O  O     . HOH C 2 .  ? 4.428  26.842 4.663   1.00 25.95 ? 41  HOH A O     1 
+HETATM 497 O  O     . HOH C 2 .  ? 10.665 24.219 2.431   1.00 15.05 ? 42  HOH A O     1 
+HETATM 498 O  O     . HOH C 2 .  ? 12.905 24.515 -0.302  1.00 32.49 ? 45  HOH A O     1 
+HETATM 499 O  O     . HOH C 2 .  ? 13.490 25.858 -3.717  1.00 32.76 ? 46  HOH A O     1 
+HETATM 500 O  O     . HOH C 2 .  ? 5.731  23.811 -4.554  1.00 22.64 ? 47  HOH A O     1 
+HETATM 501 O  O     . HOH C 2 .  ? 1.913  21.946 -5.197  1.00 35.66 ? 49  HOH A O     1 
+HETATM 502 O  O     . HOH C 2 .  ? 3.179  28.347 -8.878  1.00 46.61 ? 50  HOH A O     1 
+HETATM 503 O  O     . HOH C 2 .  ? 18.288 35.569 27.096  1.00 38.43 ? 52  HOH A O     1 
+HETATM 504 O  O     . HOH C 2 .  ? 17.790 32.793 25.798  1.00 34.18 ? 53  HOH A O     1 
+HETATM 505 O  O     . HOH C 2 .  ? 15.144 33.683 25.825  1.00 37.91 ? 54  HOH A O     1 
+HETATM 506 O  O     . HOH C 2 .  ? 12.115 33.089 26.258  1.00 42.82 ? 55  HOH A O     1 
+HETATM 507 O  O     . HOH C 2 .  ? 13.347 29.746 25.501  1.00 34.15 ? 56  HOH A O     1 
+HETATM 508 O  O     . HOH C 2 .  ? 13.434 31.537 11.886  1.00 31.28 ? 60  HOH A O     1 
+HETATM 509 O  O     . HOH C 2 .  ? 13.860 31.584 18.511  1.00 14.40 ? 63  HOH A O     1 
+HETATM 510 O  O     . HOH C 2 .  ? 16.940 30.780 15.014  1.00 38.53 ? 68  HOH A O     1 
+HETATM 511 O  O     . HOH C 2 .  ? 24.408 32.144 15.106  1.00 35.63 ? 69  HOH A O     1 
+HETATM 512 O  O     . HOH C 2 .  ? 24.190 25.894 12.836  1.00 25.74 ? 70  HOH A O     1 
+HETATM 513 O  O     . HOH C 2 .  ? 5.100  22.924 9.633   1.00 38.11 ? 72  HOH A O     1 
+HETATM 514 O  O     . HOH C 2 .  ? 19.208 16.138 11.180  1.00 39.01 ? 73  HOH A O     1 
+HETATM 515 O  O     . HOH C 2 .  ? 25.459 37.740 21.115  1.00 34.84 ? 74  HOH A O     1 
+HETATM 516 O  O     . HOH C 2 .  ? 20.229 24.975 9.234   1.00 30.88 ? 75  HOH A O     1 
+HETATM 517 O  O     . HOH C 2 .  ? 2.220  26.569 6.687   1.00 35.22 ? 76  HOH A O     1 
+HETATM 518 O  O     . HOH C 2 .  ? 21.256 34.168 28.162  1.00 35.57 ? 77  HOH A O     1 
+HETATM 519 O  O     . HOH C 2 .  ? 3.808  18.852 -1.122  1.00 42.78 ? 81  HOH A O     1 
+HETATM 520 O  O     . HOH C 2 .  ? 2.902  25.608 -3.126  1.00 41.69 ? 84  HOH A O     1 
+HETATM 521 O  O     . HOH C 2 .  ? 7.191  30.921 -3.636  1.00 38.62 ? 85  HOH A O     1 
+HETATM 522 O  O     . HOH C 2 .  ? 2.996  26.723 -13.424 1.00 38.56 ? 87  HOH A O     1 
+HETATM 523 O  O     . HOH C 2 .  ? 15.663 29.656 14.073  1.00 32.12 ? 88  HOH A O     1 
+HETATM 524 O  O     . HOH C 2 .  ? 10.134 32.246 28.643  1.00 39.06 ? 89  HOH A O     1 
+HETATM 525 O  O     . HOH C 2 .  ? 9.974  31.724 31.603  1.00 35.09 ? 91  HOH A O     1 
+HETATM 526 O  O     . HOH C 2 .  ? 5.448  20.261 -3.092  1.00 32.84 ? 93  HOH A O     1 
+HETATM 527 O  O     . HOH C 2 .  ? 5.079  18.621 -4.631  1.00 32.70 ? 94  HOH A O     1 
+HETATM 528 O  O     . HOH C 2 .  ? 22.963 37.037 19.225  1.00 35.59 ? 95  HOH A O     1 
+HETATM 529 O  O     . HOH C 2 .  ? 5.881  26.822 -12.822 1.00 35.16 ? 98  HOH A O     1 
+HETATM 530 O  O     . HOH C 2 .  ? 21.060 12.609 14.344  1.00 33.28 ? 99  HOH A O     1 
+HETATM 531 O  O     . HOH C 2 .  ? 15.732 16.825 8.667   1.00 35.92 ? 100 HOH A O     1 
+HETATM 532 O  O     . HOH C 2 .  ? 0.452  18.455 5.899   1.00 42.87 ? 101 HOH A O     1 
+HETATM 533 O  O     . HOH C 2 .  ? 4.394  25.547 -9.966  1.00 33.16 ? 102 HOH A O     1 
+HETATM 534 O  O     . HOH C 2 .  ? 4.553  25.272 8.558   1.00 30.57 ? 105 HOH A O     1 
+HETATM 535 O  O     . HOH C 2 .  ? 17.906 13.750 11.916  1.00 38.81 ? 109 HOH A O     1 
+HETATM 536 O  O     . HOH C 2 .  ? 9.494  14.820 8.411   1.00 30.76 ? 110 HOH A O     1 
+HETATM 537 O  O     . HOH C 2 .  ? 16.172 31.238 18.557  1.00 37.24 ? 114 HOH A O     1 
+HETATM 538 O  O     . HOH C 2 .  ? 27.540 29.476 18.417  1.00 39.52 ? 115 HOH A O     1 
+HETATM 539 O  O     . HOH C 2 .  ? 4.083  20.418 10.481  1.00 38.51 ? 120 HOH A O     1 
+HETATM 540 O  O     . HOH C 2 .  ? 26.506 38.352 23.125  1.00 42.16 ? 122 HOH A O     1 
+HETATM 541 O  O     . HOH C 2 .  ? 18.862 19.589 7.504   1.00 46.96 ? 123 HOH A O     1 
+HETATM 542 O  O     . HOH C 2 .  ? 15.343 31.279 26.738  1.00 39.85 ? 126 HOH A O     1 
+HETATM 543 O  O     . HOH C 2 .  ? 4.991  24.486 -6.797  1.00 40.95 ? 127 HOH A O     1 
+HETATM 544 O  O     . HOH C 2 .  ? 19.887 25.966 6.082   1.00 42.88 ? 134 HOH A O     1 
+HETATM 545 O  O     . HOH C 2 .  ? 18.890 16.165 6.102   1.00 42.39 ? 135 HOH A O     1 
+HETATM 546 O  O     . HOH D 2 .  ? 10.848 26.569 22.387  1.00 19.12 ? 26  HOH B O     1 
+HETATM 547 O  O     . HOH D 2 .  ? 5.563  20.356 21.826  1.00 41.08 ? 27  HOH B O     1 
+HETATM 548 O  O     . HOH D 2 .  ? 7.547  24.990 19.067  1.00 22.22 ? 28  HOH B O     1 
+HETATM 549 O  O     . HOH D 2 .  ? 13.767 20.612 19.006  1.00 24.15 ? 31  HOH B O     1 
+HETATM 550 O  O     . HOH D 2 .  ? 9.949  17.053 17.843  1.00 25.61 ? 32  HOH B O     1 
+HETATM 551 O  O     . HOH D 2 .  ? 9.978  31.650 13.536  1.00 40.89 ? 33  HOH B O     1 
+HETATM 552 O  O     . HOH D 2 .  ? 18.192 29.848 7.710   1.00 28.04 ? 36  HOH B O     1 
+HETATM 553 O  O     . HOH D 2 .  ? 12.956 31.994 6.569   1.00 26.62 ? 38  HOH B O     1 
+HETATM 554 O  O     . HOH D 2 .  ? 15.464 29.284 5.946   1.00 24.81 ? 39  HOH B O     1 
+HETATM 555 O  O     . HOH D 2 .  ? 12.563 14.769 0.840   1.00 28.06 ? 43  HOH B O     1 
+HETATM 556 O  O     . HOH D 2 .  ? 23.393 23.610 0.564   1.00 35.80 ? 44  HOH B O     1 
+HETATM 557 O  O     . HOH D 2 .  ? 7.394  16.046 -6.329  1.00 18.67 ? 48  HOH B O     1 
+HETATM 558 O  O     . HOH D 2 .  ? 17.428 25.440 -4.218  1.00 36.80 ? 51  HOH B O     1 
+HETATM 559 O  O     . HOH D 2 .  ? 12.724 24.488 26.606  1.00 43.35 ? 57  HOH B O     1 
+HETATM 560 O  O     . HOH D 2 .  ? 10.821 34.208 8.290   1.00 43.93 ? 58  HOH B O     1 
+HETATM 561 O  O     . HOH D 2 .  ? 7.325  25.434 22.272  1.00 32.39 ? 59  HOH B O     1 
+HETATM 562 O  O     . HOH D 2 .  ? 13.495 15.589 19.081  1.00 34.67 ? 61  HOH B O     1 
+HETATM 563 O  O     . HOH D 2 .  ? 11.701 31.434 18.782  1.00 29.38 ? 62  HOH B O     1 
+HETATM 564 O  O     . HOH D 2 .  ? 2.844  26.497 11.377  1.00 38.13 ? 64  HOH B O     1 
+HETATM 565 O  O     . HOH D 2 .  ? 9.348  21.290 11.495  1.00 23.75 ? 65  HOH B O     1 
+HETATM 566 O  O     . HOH D 2 .  ? 8.901  18.527 16.031  1.00 33.54 ? 66  HOH B O     1 
+HETATM 567 O  O     . HOH D 2 .  ? 11.761 20.297 16.207  1.00 34.56 ? 67  HOH B O     1 
+HETATM 568 O  O     . HOH D 2 .  ? 3.000  29.613 12.879  1.00 38.83 ? 71  HOH B O     1 
+HETATM 569 O  O     . HOH D 2 .  ? 17.419 29.178 -3.603  1.00 42.93 ? 78  HOH B O     1 
+HETATM 570 O  O     . HOH D 2 .  ? 17.991 12.124 2.333   1.00 38.75 ? 79  HOH B O     1 
+HETATM 571 O  O     . HOH D 2 .  ? 17.810 9.394  0.745   1.00 26.60 ? 80  HOH B O     1 
+HETATM 572 O  O     . HOH D 2 .  ? 24.652 22.219 -2.985  1.00 37.53 ? 82  HOH B O     1 
+HETATM 573 O  O     . HOH D 2 .  ? 16.223 9.236  3.127   1.00 37.74 ? 83  HOH B O     1 
+HETATM 574 O  O     . HOH D 2 .  ? 3.174  16.962 19.663  1.00 29.72 ? 86  HOH B O     1 
+HETATM 575 O  O     . HOH D 2 .  ? 10.611 32.019 -3.494  1.00 31.34 ? 90  HOH B O     1 
+HETATM 576 O  O     . HOH D 2 .  ? 12.750 30.518 -1.256  1.00 33.94 ? 92  HOH B O     1 
+HETATM 577 O  O     . HOH D 2 .  ? 4.693  19.968 18.644  1.00 42.56 ? 96  HOH B O     1 
+HETATM 578 O  O     . HOH D 2 .  ? 6.464  27.931 18.635  1.00 39.40 ? 97  HOH B O     1 
+HETATM 579 O  O     . HOH D 2 .  ? 9.421  24.741 28.177  1.00 33.36 ? 103 HOH B O     1 
+HETATM 580 O  O     . HOH D 2 .  ? 13.586 29.913 16.859  1.00 31.88 ? 104 HOH B O     1 
+HETATM 581 O  O     . HOH D 2 .  ? 1.789  30.649 9.945   1.00 40.75 ? 106 HOH B O     1 
+HETATM 582 O  O     . HOH D 2 .  ? 3.237  25.228 16.303  1.00 29.20 ? 107 HOH B O     1 
+HETATM 583 O  O     . HOH D 2 .  ? 3.527  19.709 16.064  1.00 32.95 ? 108 HOH B O     1 
+HETATM 584 O  O     . HOH D 2 .  ? 6.110  31.919 9.458   1.00 44.34 ? 111 HOH B O     1 
+HETATM 585 O  O     . HOH D 2 .  ? 10.343 29.074 19.061  1.00 46.91 ? 112 HOH B O     1 
+HETATM 586 O  O     . HOH D 2 .  ? 14.637 17.588 18.474  1.00 41.07 ? 113 HOH B O     1 
+HETATM 587 O  O     . HOH D 2 .  ? 7.356  15.408 15.974  1.00 39.14 ? 116 HOH B O     1 
+HETATM 588 O  O     . HOH D 2 .  ? 4.956  18.920 13.796  1.00 40.45 ? 117 HOH B O     1 
+HETATM 589 O  O     . HOH D 2 .  ? 8.937  20.332 13.507  1.00 35.68 ? 118 HOH B O     1 
+HETATM 590 O  O     . HOH D 2 .  ? 3.303  23.627 13.780  1.00 36.77 ? 119 HOH B O     1 
+HETATM 591 O  O     . HOH D 2 .  ? 22.950 27.609 9.718   1.00 43.36 ? 121 HOH B O     1 
+HETATM 592 O  O     . HOH D 2 .  ? 8.177  12.708 -3.487  1.00 39.06 ? 124 HOH B O     1 
+HETATM 593 O  O     . HOH D 2 .  ? 2.876  31.748 13.374  1.00 35.33 ? 125 HOH B O     1 
+HETATM 594 O  O     . HOH D 2 .  ? 4.554  30.827 15.881  1.00 41.10 ? 128 HOH B O     1 
+HETATM 595 O  O     . HOH D 2 .  ? 11.370 28.105 16.361  1.00 33.10 ? 129 HOH B O     1 
+HETATM 596 O  O     . HOH D 2 .  ? 19.678 28.492 9.696   1.00 43.11 ? 130 HOH B O     1 
+HETATM 597 O  O     . HOH D 2 .  ? 17.383 26.809 10.606  1.00 39.81 ? 131 HOH B O     1 
+HETATM 598 O  O     . HOH D 2 .  ? 14.095 28.477 27.325  1.00 42.34 ? 132 HOH B O     1 
+HETATM 599 O  O     . HOH D 2 .  ? 7.793  29.647 15.378  1.00 46.75 ? 133 HOH B O     1 
+HETATM 600 O  O     . HOH D 2 .  ? 15.657 15.301 4.213   1.00 45.66 ? 136 HOH B O     1 
+HETATM 601 O  O     . HOH D 2 .  ? 10.571 10.120 1.317   1.00 44.44 ? 137 HOH B O     1 
+HETATM 602 O  O     . HOH D 2 .  ? 11.581 27.470 0.664   1.00 45.23 ? 138 HOH B O     1 
+# 
+loop_
+_pdbx_poly_seq_scheme.asym_id 
+_pdbx_poly_seq_scheme.entity_id 
+_pdbx_poly_seq_scheme.seq_id 
+_pdbx_poly_seq_scheme.mon_id 
+_pdbx_poly_seq_scheme.ndb_seq_num 
+_pdbx_poly_seq_scheme.pdb_seq_num 
+_pdbx_poly_seq_scheme.auth_seq_num 
+_pdbx_poly_seq_scheme.pdb_mon_id 
+_pdbx_poly_seq_scheme.auth_mon_id 
+_pdbx_poly_seq_scheme.pdb_strand_id 
+_pdbx_poly_seq_scheme.pdb_ins_code 
+_pdbx_poly_seq_scheme.hetero 
+A 1 1  DC  1  1  1  DC  C A . n 
+A 1 2  DG  2  2  2  DG  G A . n 
+A 1 3  DC  3  3  3  DC  C A . n 
+A 1 4  DG  4  4  4  DG  G A . n 
+A 1 5  DA  5  5  5  DA  A A . n 
+A 1 6  DA  6  6  6  DA  A A . n 
+A 1 7  DT  7  7  7  DT  T A . n 
+A 1 8  DT  8  8  8  DT  T A . n 
+A 1 9  CBR 9  9  9  CBR C A . n 
+A 1 10 DG  10 10 10 DG  G A . n 
+A 1 11 DC  11 11 11 DC  C A . n 
+A 1 12 DG  12 12 12 DG  G A . n 
+B 1 1  DC  1  13 13 DC  C B . n 
+B 1 2  DG  2  14 14 DG  G B . n 
+B 1 3  DC  3  15 15 DC  C B . n 
+B 1 4  DG  4  16 16 DG  G B . n 
+B 1 5  DA  5  17 17 DA  A B . n 
+B 1 6  DA  6  18 18 DA  A B . n 
+B 1 7  DT  7  19 19 DT  T B . n 
+B 1 8  DT  8  20 20 DT  T B . n 
+B 1 9  CBR 9  21 21 CBR C B . n 
+B 1 10 DG  10 22 22 DG  G B . n 
+B 1 11 DC  11 23 23 DC  C B . n 
+B 1 12 DG  12 24 24 DG  G B . n 
+# 
+loop_
+_pdbx_nonpoly_scheme.asym_id 
+_pdbx_nonpoly_scheme.entity_id 
+_pdbx_nonpoly_scheme.mon_id 
+_pdbx_nonpoly_scheme.ndb_seq_num 
+_pdbx_nonpoly_scheme.pdb_seq_num 
+_pdbx_nonpoly_scheme.auth_seq_num 
+_pdbx_nonpoly_scheme.pdb_mon_id 
+_pdbx_nonpoly_scheme.auth_mon_id 
+_pdbx_nonpoly_scheme.pdb_strand_id 
+_pdbx_nonpoly_scheme.pdb_ins_code 
+C 2 HOH 1  25  25  HOH HOH A . 
+C 2 HOH 2  29  29  HOH HOH A . 
+C 2 HOH 3  30  30  HOH HOH A . 
+C 2 HOH 4  34  34  HOH HOH A . 
+C 2 HOH 5  35  35  HOH HOH A . 
+C 2 HOH 6  37  37  HOH HOH A . 
+C 2 HOH 7  40  40  HOH HOH A . 
+C 2 HOH 8  41  41  HOH HOH A . 
+C 2 HOH 9  42  42  HOH HOH A . 
+C 2 HOH 10 45  45  HOH HOH A . 
+C 2 HOH 11 46  46  HOH HOH A . 
+C 2 HOH 12 47  47  HOH HOH A . 
+C 2 HOH 13 49  49  HOH HOH A . 
+C 2 HOH 14 50  50  HOH HOH A . 
+C 2 HOH 15 52  52  HOH HOH A . 
+C 2 HOH 16 53  53  HOH HOH A . 
+C 2 HOH 17 54  54  HOH HOH A . 
+C 2 HOH 18 55  55  HOH HOH A . 
+C 2 HOH 19 56  56  HOH HOH A . 
+C 2 HOH 20 60  60  HOH HOH A . 
+C 2 HOH 21 63  63  HOH HOH A . 
+C 2 HOH 22 68  68  HOH HOH A . 
+C 2 HOH 23 69  69  HOH HOH A . 
+C 2 HOH 24 70  70  HOH HOH A . 
+C 2 HOH 25 72  72  HOH HOH A . 
+C 2 HOH 26 73  73  HOH HOH A . 
+C 2 HOH 27 74  74  HOH HOH A . 
+C 2 HOH 28 75  75  HOH HOH A . 
+C 2 HOH 29 76  76  HOH HOH A . 
+C 2 HOH 30 77  77  HOH HOH A . 
+C 2 HOH 31 81  81  HOH HOH A . 
+C 2 HOH 32 84  84  HOH HOH A . 
+C 2 HOH 33 85  85  HOH HOH A . 
+C 2 HOH 34 87  87  HOH HOH A . 
+C 2 HOH 35 88  88  HOH HOH A . 
+C 2 HOH 36 89  89  HOH HOH A . 
+C 2 HOH 37 91  91  HOH HOH A . 
+C 2 HOH 38 93  93  HOH HOH A . 
+C 2 HOH 39 94  94  HOH HOH A . 
+C 2 HOH 40 95  95  HOH HOH A . 
+C 2 HOH 41 98  98  HOH HOH A . 
+C 2 HOH 42 99  99  HOH HOH A . 
+C 2 HOH 43 100 100 HOH HOH A . 
+C 2 HOH 44 101 101 HOH HOH A . 
+C 2 HOH 45 102 102 HOH HOH A . 
+C 2 HOH 46 105 105 HOH HOH A . 
+C 2 HOH 47 109 109 HOH HOH A . 
+C 2 HOH 48 110 110 HOH HOH A . 
+C 2 HOH 49 114 114 HOH HOH A . 
+C 2 HOH 50 115 115 HOH HOH A . 
+C 2 HOH 51 120 120 HOH HOH A . 
+C 2 HOH 52 122 122 HOH HOH A . 
+C 2 HOH 53 123 123 HOH HOH A . 
+C 2 HOH 54 126 126 HOH HOH A . 
+C 2 HOH 55 127 127 HOH HOH A . 
+C 2 HOH 56 134 134 HOH HOH A . 
+C 2 HOH 57 135 135 HOH HOH A . 
+D 2 HOH 1  26  26  HOH HOH B . 
+D 2 HOH 2  27  27  HOH HOH B . 
+D 2 HOH 3  28  28  HOH HOH B . 
+D 2 HOH 4  31  31  HOH HOH B . 
+D 2 HOH 5  32  32  HOH HOH B . 
+D 2 HOH 6  33  33  HOH HOH B . 
+D 2 HOH 7  36  36  HOH HOH B . 
+D 2 HOH 8  38  38  HOH HOH B . 
+D 2 HOH 9  39  39  HOH HOH B . 
+D 2 HOH 10 43  43  HOH HOH B . 
+D 2 HOH 11 44  44  HOH HOH B . 
+D 2 HOH 12 48  48  HOH HOH B . 
+D 2 HOH 13 51  51  HOH HOH B . 
+D 2 HOH 14 57  57  HOH HOH B . 
+D 2 HOH 15 58  58  HOH HOH B . 
+D 2 HOH 16 59  59  HOH HOH B . 
+D 2 HOH 17 61  61  HOH HOH B . 
+D 2 HOH 18 62  62  HOH HOH B . 
+D 2 HOH 19 64  64  HOH HOH B . 
+D 2 HOH 20 65  65  HOH HOH B . 
+D 2 HOH 21 66  66  HOH HOH B . 
+D 2 HOH 22 67  67  HOH HOH B . 
+D 2 HOH 23 71  71  HOH HOH B . 
+D 2 HOH 24 78  78  HOH HOH B . 
+D 2 HOH 25 79  79  HOH HOH B . 
+D 2 HOH 26 80  80  HOH HOH B . 
+D 2 HOH 27 82  82  HOH HOH B . 
+D 2 HOH 28 83  83  HOH HOH B . 
+D 2 HOH 29 86  86  HOH HOH B . 
+D 2 HOH 30 90  90  HOH HOH B . 
+D 2 HOH 31 92  92  HOH HOH B . 
+D 2 HOH 32 96  96  HOH HOH B . 
+D 2 HOH 33 97  97  HOH HOH B . 
+D 2 HOH 34 103 103 HOH HOH B . 
+D 2 HOH 35 104 104 HOH HOH B . 
+D 2 HOH 36 106 106 HOH HOH B . 
+D 2 HOH 37 107 107 HOH HOH B . 
+D 2 HOH 38 108 108 HOH HOH B . 
+D 2 HOH 39 111 111 HOH HOH B . 
+D 2 HOH 40 112 112 HOH HOH B . 
+D 2 HOH 41 113 113 HOH HOH B . 
+D 2 HOH 42 116 116 HOH HOH B . 
+D 2 HOH 43 117 117 HOH HOH B . 
+D 2 HOH 44 118 118 HOH HOH B . 
+D 2 HOH 45 119 119 HOH HOH B . 
+D 2 HOH 46 121 121 HOH HOH B . 
+D 2 HOH 47 124 124 HOH HOH B . 
+D 2 HOH 48 125 125 HOH HOH B . 
+D 2 HOH 49 128 128 HOH HOH B . 
+D 2 HOH 50 129 129 HOH HOH B . 
+D 2 HOH 51 130 130 HOH HOH B . 
+D 2 HOH 52 131 131 HOH HOH B . 
+D 2 HOH 53 132 132 HOH HOH B . 
+D 2 HOH 54 133 133 HOH HOH B . 
+D 2 HOH 55 136 136 HOH HOH B . 
+D 2 HOH 56 137 137 HOH HOH B . 
+D 2 HOH 57 138 138 HOH HOH B . 
+# 
+loop_
+_pdbx_struct_mod_residue.id 
+_pdbx_struct_mod_residue.label_asym_id 
+_pdbx_struct_mod_residue.label_comp_id 
+_pdbx_struct_mod_residue.label_seq_id 
+_pdbx_struct_mod_residue.auth_asym_id 
+_pdbx_struct_mod_residue.auth_comp_id 
+_pdbx_struct_mod_residue.auth_seq_id 
+_pdbx_struct_mod_residue.PDB_ins_code 
+_pdbx_struct_mod_residue.parent_comp_id 
+_pdbx_struct_mod_residue.details 
+1 A CBR 9 A CBR 9  ? DC ? 
+2 B CBR 9 B CBR 21 ? DC ? 
+# 
+_pdbx_struct_assembly.id                   1 
+_pdbx_struct_assembly.details              author_defined_assembly 
+_pdbx_struct_assembly.method_details       ? 
+_pdbx_struct_assembly.oligomeric_details   dimeric 
+_pdbx_struct_assembly.oligomeric_count     2 
+# 
+_pdbx_struct_assembly_gen.assembly_id       1 
+_pdbx_struct_assembly_gen.oper_expression   1 
+_pdbx_struct_assembly_gen.asym_id_list      A,B,C,D 
+# 
+_pdbx_struct_oper_list.id                   1 
+_pdbx_struct_oper_list.type                 'identity operation' 
+_pdbx_struct_oper_list.name                 1_555 
+_pdbx_struct_oper_list.symmetry_operation   x,y,z 
+_pdbx_struct_oper_list.matrix[1][1]         1.0000000000 
+_pdbx_struct_oper_list.matrix[1][2]         0.0000000000 
+_pdbx_struct_oper_list.matrix[1][3]         0.0000000000 
+_pdbx_struct_oper_list.vector[1]            0.0000000000 
+_pdbx_struct_oper_list.matrix[2][1]         0.0000000000 
+_pdbx_struct_oper_list.matrix[2][2]         1.0000000000 
+_pdbx_struct_oper_list.matrix[2][3]         0.0000000000 
+_pdbx_struct_oper_list.vector[2]            0.0000000000 
+_pdbx_struct_oper_list.matrix[3][1]         0.0000000000 
+_pdbx_struct_oper_list.matrix[3][2]         0.0000000000 
+_pdbx_struct_oper_list.matrix[3][3]         1.0000000000 
+_pdbx_struct_oper_list.vector[3]            0.0000000000 
+# 
+loop_
+_pdbx_audit_revision_history.ordinal 
+_pdbx_audit_revision_history.data_content_type 
+_pdbx_audit_revision_history.major_revision 
+_pdbx_audit_revision_history.minor_revision 
+_pdbx_audit_revision_history.revision_date 
+1 'Structure model' 1 0 1982-04-15 
+2 'Structure model' 1 1 2008-05-22 
+3 'Structure model' 1 2 2011-07-13 
+# 
+_pdbx_audit_revision_details.ordinal             1 
+_pdbx_audit_revision_details.revision_ordinal    1 
+_pdbx_audit_revision_details.data_content_type   'Structure model' 
+_pdbx_audit_revision_details.provider            repository 
+_pdbx_audit_revision_details.type                'Initial release' 
+_pdbx_audit_revision_details.description         ? 
+# 
+loop_
+_pdbx_audit_revision_group.ordinal 
+_pdbx_audit_revision_group.revision_ordinal 
+_pdbx_audit_revision_group.data_content_type 
+_pdbx_audit_revision_group.group 
+1 2 'Structure model' 'Version format compliance' 
+2 3 'Structure model' 'Version format compliance' 
+# 
+loop_
+_refine_B_iso.class 
+_refine_B_iso.details 
+_refine_B_iso.treatment 
+_refine_B_iso.pdbx_refine_id 
+'ALL ATOMS'  TR isotropic 'X-RAY DIFFRACTION' 
+'ALL WATERS' TR isotropic 'X-RAY DIFFRACTION' 
+# 
+loop_
+_refine_occupancy.class 
+_refine_occupancy.treatment 
+_refine_occupancy.pdbx_refine_id 
+'ALL ATOMS'  fix 'X-RAY DIFFRACTION' 
+'ALL WATERS' fix 'X-RAY DIFFRACTION' 
+# 
+_software.name             JACK-LEVITT 
+_software.classification   refinement 
+_software.version          . 
+_software.citation_id      ? 
+_software.pdbx_ordinal     1 
+# 
+loop_
+_pdbx_validate_close_contact.id 
+_pdbx_validate_close_contact.PDB_model_num 
+_pdbx_validate_close_contact.auth_atom_id_1 
+_pdbx_validate_close_contact.auth_asym_id_1 
+_pdbx_validate_close_contact.auth_comp_id_1 
+_pdbx_validate_close_contact.auth_seq_id_1 
+_pdbx_validate_close_contact.PDB_ins_code_1 
+_pdbx_validate_close_contact.label_alt_id_1 
+_pdbx_validate_close_contact.auth_atom_id_2 
+_pdbx_validate_close_contact.auth_asym_id_2 
+_pdbx_validate_close_contact.auth_comp_id_2 
+_pdbx_validate_close_contact.auth_seq_id_2 
+_pdbx_validate_close_contact.PDB_ins_code_2 
+_pdbx_validate_close_contact.label_alt_id_2 
+_pdbx_validate_close_contact.dist 
+1 1 OP1 B DG  22 ? ? O B HOH 96  ? ? 1.93 
+2 1 O   A HOH 68 ? ? O A HOH 88  ? ? 1.94 
+3 1 N7  A DA  6  ? ? O A HOH 100 ? ? 2.14 
+4 1 OP1 A DA  5  ? ? O A HOH 99  ? ? 2.16 
+5 1 O   A HOH 63 ? ? O B HOH 62  ? ? 2.18 
+# 
+loop_
+_pdbx_validate_rmsd_bond.id 
+_pdbx_validate_rmsd_bond.PDB_model_num 
+_pdbx_validate_rmsd_bond.auth_atom_id_1 
+_pdbx_validate_rmsd_bond.auth_asym_id_1 
+_pdbx_validate_rmsd_bond.auth_comp_id_1 
+_pdbx_validate_rmsd_bond.auth_seq_id_1 
+_pdbx_validate_rmsd_bond.PDB_ins_code_1 
+_pdbx_validate_rmsd_bond.label_alt_id_1 
+_pdbx_validate_rmsd_bond.auth_atom_id_2 
+_pdbx_validate_rmsd_bond.auth_asym_id_2 
+_pdbx_validate_rmsd_bond.auth_comp_id_2 
+_pdbx_validate_rmsd_bond.auth_seq_id_2 
+_pdbx_validate_rmsd_bond.PDB_ins_code_2 
+_pdbx_validate_rmsd_bond.label_alt_id_2 
+_pdbx_validate_rmsd_bond.bond_value 
+_pdbx_validate_rmsd_bond.bond_target_value 
+_pdbx_validate_rmsd_bond.bond_deviation 
+_pdbx_validate_rmsd_bond.bond_standard_deviation 
+_pdbx_validate_rmsd_bond.linker_flag 
+1  1 C5 A DC 1  ? ? C6 A DC 1  ? ? 1.390 1.339 0.051  0.008 N 
+2  1 C5 A DG 2  ? ? N7 A DG 2  ? ? 1.349 1.388 -0.039 0.006 N 
+3  1 N7 A DG 2  ? ? C8 A DG 2  ? ? 1.344 1.305 0.039  0.006 N 
+4  1 C5 A DC 3  ? ? C6 A DC 3  ? ? 1.388 1.339 0.049  0.008 N 
+5  1 C5 A DG 4  ? ? N7 A DG 4  ? ? 1.346 1.388 -0.042 0.006 N 
+6  1 C5 A DA 5  ? ? N7 A DA 5  ? ? 1.349 1.388 -0.039 0.006 N 
+7  1 C5 A DA 6  ? ? N7 A DA 6  ? ? 1.352 1.388 -0.036 0.006 N 
+8  1 C5 A DT 7  ? ? C6 A DT 7  ? ? 1.395 1.339 0.056  0.007 N 
+9  1 C5 A DT 8  ? ? C6 A DT 8  ? ? 1.394 1.339 0.055  0.007 N 
+10 1 C5 A DG 10 ? ? N7 A DG 10 ? ? 1.351 1.388 -0.037 0.006 N 
+11 1 N7 A DG 10 ? ? C8 A DG 10 ? ? 1.342 1.305 0.037  0.006 N 
+12 1 C5 A DC 11 ? ? C6 A DC 11 ? ? 1.393 1.339 0.054  0.008 N 
+13 1 C5 A DG 12 ? ? N7 A DG 12 ? ? 1.349 1.388 -0.039 0.006 N 
+14 1 N7 A DG 12 ? ? C8 A DG 12 ? ? 1.342 1.305 0.037  0.006 N 
+15 1 C5 B DC 13 ? ? C6 B DC 13 ? ? 1.390 1.339 0.051  0.008 N 
+16 1 C5 B DG 14 ? ? N7 B DG 14 ? ? 1.347 1.388 -0.041 0.006 N 
+17 1 C5 B DC 15 ? ? C6 B DC 15 ? ? 1.395 1.339 0.056  0.008 N 
+18 1 C5 B DG 16 ? ? N7 B DG 16 ? ? 1.347 1.388 -0.041 0.006 N 
+19 1 N7 B DG 16 ? ? C8 B DG 16 ? ? 1.342 1.305 0.037  0.006 N 
+20 1 C5 B DA 17 ? ? N7 B DA 17 ? ? 1.348 1.388 -0.040 0.006 N 
+21 1 C5 B DA 18 ? ? N7 B DA 18 ? ? 1.350 1.388 -0.038 0.006 N 
+22 1 C5 B DT 19 ? ? C6 B DT 19 ? ? 1.397 1.339 0.058  0.007 N 
+23 1 C5 B DT 20 ? ? C6 B DT 20 ? ? 1.391 1.339 0.052  0.007 N 
+24 1 N7 B DG 22 ? ? C8 B DG 22 ? ? 1.343 1.305 0.038  0.006 N 
+25 1 C5 B DC 23 ? ? C6 B DC 23 ? ? 1.390 1.339 0.051  0.008 N 
+26 1 C5 B DG 24 ? ? N7 B DG 24 ? ? 1.348 1.388 -0.040 0.006 N 
+27 1 N7 B DG 24 ? ? C8 B DG 24 ? ? 1.343 1.305 0.038  0.006 N 
+# 
+loop_
+_pdbx_validate_rmsd_angle.id 
+_pdbx_validate_rmsd_angle.PDB_model_num 
+_pdbx_validate_rmsd_angle.auth_atom_id_1 
+_pdbx_validate_rmsd_angle.auth_asym_id_1 
+_pdbx_validate_rmsd_angle.auth_comp_id_1 
+_pdbx_validate_rmsd_angle.auth_seq_id_1 
+_pdbx_validate_rmsd_angle.PDB_ins_code_1 
+_pdbx_validate_rmsd_angle.label_alt_id_1 
+_pdbx_validate_rmsd_angle.auth_atom_id_2 
+_pdbx_validate_rmsd_angle.auth_asym_id_2 
+_pdbx_validate_rmsd_angle.auth_comp_id_2 
+_pdbx_validate_rmsd_angle.auth_seq_id_2 
+_pdbx_validate_rmsd_angle.PDB_ins_code_2 
+_pdbx_validate_rmsd_angle.label_alt_id_2 
+_pdbx_validate_rmsd_angle.auth_atom_id_3 
+_pdbx_validate_rmsd_angle.auth_asym_id_3 
+_pdbx_validate_rmsd_angle.auth_comp_id_3 
+_pdbx_validate_rmsd_angle.auth_seq_id_3 
+_pdbx_validate_rmsd_angle.PDB_ins_code_3 
+_pdbx_validate_rmsd_angle.label_alt_id_3 
+_pdbx_validate_rmsd_angle.angle_value 
+_pdbx_validate_rmsd_angle.angle_target_value 
+_pdbx_validate_rmsd_angle.angle_deviation 
+_pdbx_validate_rmsd_angle.angle_standard_deviation 
+_pdbx_validate_rmsd_angle.linker_flag 
+1  1 "C3'" A DC  1  ? ? "C2'" A DC  1  ? ? "C1'" A DC 1  ? ? 97.32  102.40 -5.08 0.80 N 
+2  1 "O4'" A DC  1  ? ? "C1'" A DC  1  ? ? "C2'" A DC 1  ? ? 100.09 105.90 -5.81 0.80 N 
+3  1 "O4'" A DC  3  ? ? "C4'" A DC  3  ? ? "C3'" A DC 3  ? ? 100.58 104.50 -3.92 0.40 N 
+4  1 "O4'" A DA  6  ? ? "C1'" A DA  6  ? ? N9    A DA 6  ? ? 103.74 108.00 -4.26 0.70 N 
+5  1 "C1'" A DT  7  ? ? "O4'" A DT  7  ? ? "C4'" A DT 7  ? ? 103.75 110.10 -6.35 1.00 N 
+6  1 N1    A DT  7  ? ? C2    A DT  7  ? ? N3    A DT 7  ? ? 118.53 114.60 3.93  0.60 N 
+7  1 C2    A DT  7  ? ? N3    A DT  7  ? ? C4    A DT 7  ? ? 122.40 127.20 -4.80 0.60 N 
+8  1 C5    A DT  7  ? ? C6    A DT  7  ? ? N1    A DT 7  ? ? 119.26 123.70 -4.44 0.60 N 
+9  1 "C1'" A DT  8  ? ? "O4'" A DT  8  ? ? "C4'" A DT 8  ? ? 102.91 110.10 -7.19 1.00 N 
+10 1 N1    A DT  8  ? ? C2    A DT  8  ? ? N3    A DT 8  ? ? 118.65 114.60 4.05  0.60 N 
+11 1 C2    A DT  8  ? ? N3    A DT  8  ? ? C4    A DT 8  ? ? 122.64 127.20 -4.56 0.60 N 
+12 1 C5    A DT  8  ? ? C6    A DT  8  ? ? N1    A DT 8  ? ? 119.46 123.70 -4.24 0.60 N 
+13 1 "C3'" A DG  10 ? ? "C2'" A DG  10 ? ? "C1'" A DG 10 ? ? 95.87  102.40 -6.53 0.80 N 
+14 1 "O4'" A DG  10 ? ? "C1'" A DG  10 ? ? "C2'" A DG 10 ? ? 100.12 105.90 -5.78 0.80 N 
+15 1 "O5'" A DG  12 ? ? "C5'" A DG  12 ? ? "C4'" A DG 12 ? ? 103.77 109.40 -5.63 0.80 N 
+16 1 "O4'" A DG  12 ? ? "C1'" A DG  12 ? ? N9    A DG 12 ? ? 100.14 108.00 -7.86 0.70 N 
+17 1 "O4'" B DC  13 ? ? "C1'" B DC  13 ? ? "C2'" B DC 13 ? ? 99.33  105.90 -6.57 0.80 N 
+18 1 C5    B DC  13 ? ? C6    B DC  13 ? ? N1    B DC 13 ? ? 117.97 121.00 -3.03 0.50 N 
+19 1 "C3'" B DG  14 ? ? "C2'" B DG  14 ? ? "C1'" B DG 14 ? ? 96.41  102.40 -5.99 0.80 N 
+20 1 "O4'" B DG  14 ? ? "C1'" B DG  14 ? ? "C2'" B DG 14 ? ? 99.65  105.90 -6.25 0.80 N 
+21 1 "O4'" B DG  14 ? ? "C1'" B DG  14 ? ? N9    B DG 14 ? ? 111.55 108.30 3.25  0.30 N 
+22 1 "O4'" B DC  15 ? ? "C4'" B DC  15 ? ? "C3'" B DC 15 ? ? 100.51 104.50 -3.99 0.40 N 
+23 1 "C3'" B DG  16 ? ? "C2'" B DG  16 ? ? "C1'" B DG 16 ? ? 95.36  102.40 -7.04 0.80 N 
+24 1 "O5'" B DA  17 ? ? "C5'" B DA  17 ? ? "C4'" B DA 17 ? ? 104.37 109.40 -5.03 0.80 N 
+25 1 "O4'" B DA  18 ? ? "C1'" B DA  18 ? ? N9    B DA 18 ? ? 103.56 108.00 -4.44 0.70 N 
+26 1 "C1'" B DT  19 ? ? "O4'" B DT  19 ? ? "C4'" B DT 19 ? ? 103.00 110.10 -7.10 1.00 N 
+27 1 N1    B DT  19 ? ? C2    B DT  19 ? ? N3    B DT 19 ? ? 118.76 114.60 4.16  0.60 N 
+28 1 C2    B DT  19 ? ? N3    B DT  19 ? ? C4    B DT 19 ? ? 122.42 127.20 -4.78 0.60 N 
+29 1 C5    B DT  19 ? ? C6    B DT  19 ? ? N1    B DT 19 ? ? 119.13 123.70 -4.57 0.60 N 
+30 1 N1    B DT  20 ? ? C2    B DT  20 ? ? N3    B DT 20 ? ? 118.42 114.60 3.82  0.60 N 
+31 1 C2    B DT  20 ? ? N3    B DT  20 ? ? C4    B DT 20 ? ? 122.26 127.20 -4.94 0.60 N 
+32 1 C5    B DT  20 ? ? C6    B DT  20 ? ? N1    B DT 20 ? ? 119.61 123.70 -4.09 0.60 N 
+33 1 "C3'" B CBR 21 ? ? "O3'" B CBR 21 ? ? P     B DG 22 ? ? 129.86 119.70 10.16 1.20 Y 
+34 1 "C3'" B DG  22 ? ? "C2'" B DG  22 ? ? "C1'" B DG 22 ? ? 94.72  102.40 -7.68 0.80 N 
+35 1 "O4'" B DG  22 ? ? "C1'" B DG  22 ? ? N9    B DG 22 ? ? 110.87 108.30 2.57  0.30 N 
+36 1 "O4'" B DC  23 ? ? "C1'" B DC  23 ? ? N1    B DC 23 ? ? 102.11 108.00 -5.89 0.70 N 
+# 
+_pdbx_validate_planes.id              1 
+_pdbx_validate_planes.PDB_model_num   1 
+_pdbx_validate_planes.auth_comp_id    DA 
+_pdbx_validate_planes.auth_asym_id    A 
+_pdbx_validate_planes.auth_seq_id     5 
+_pdbx_validate_planes.PDB_ins_code    ? 
+_pdbx_validate_planes.label_alt_id    ? 
+_pdbx_validate_planes.rmsd            0.056 
+_pdbx_validate_planes.type            'SIDE CHAIN' 
+# 
+loop_
+_ndb_struct_conf_na.entry_id 
+_ndb_struct_conf_na.feature 
+4BNA 'double helix'        
+4BNA 'b-form double helix' 
+# 
+loop_
+_ndb_struct_na_base_pair.model_number 
+_ndb_struct_na_base_pair.i_label_asym_id 
+_ndb_struct_na_base_pair.i_label_comp_id 
+_ndb_struct_na_base_pair.i_label_seq_id 
+_ndb_struct_na_base_pair.i_symmetry 
+_ndb_struct_na_base_pair.j_label_asym_id 
+_ndb_struct_na_base_pair.j_label_comp_id 
+_ndb_struct_na_base_pair.j_label_seq_id 
+_ndb_struct_na_base_pair.j_symmetry 
+_ndb_struct_na_base_pair.shear 
+_ndb_struct_na_base_pair.stretch 
+_ndb_struct_na_base_pair.stagger 
+_ndb_struct_na_base_pair.buckle 
+_ndb_struct_na_base_pair.propeller 
+_ndb_struct_na_base_pair.opening 
+_ndb_struct_na_base_pair.pair_number 
+_ndb_struct_na_base_pair.pair_name 
+_ndb_struct_na_base_pair.i_auth_asym_id 
+_ndb_struct_na_base_pair.i_auth_seq_id 
+_ndb_struct_na_base_pair.i_PDB_ins_code 
+_ndb_struct_na_base_pair.j_auth_asym_id 
+_ndb_struct_na_base_pair.j_auth_seq_id 
+_ndb_struct_na_base_pair.j_PDB_ins_code 
+_ndb_struct_na_base_pair.hbond_type_28 
+_ndb_struct_na_base_pair.hbond_type_12 
+1 A DC  1  1_555 B DG  12 1_555 -0.836 -0.194 0.415  -1.873  -14.702 -1.820  1  A_DC1:DG24_B  A 1  ? B 24 ? 19 1 
+1 A DG  2  1_555 B DC  11 1_555 -0.250 -0.339 1.211  15.461  -7.843  -3.329  2  A_DG2:DC23_B  A 2  ? B 23 ? 19 1 
+1 A DC  3  1_555 B DG  10 1_555 0.447  -0.341 0.329  -4.236  -4.856  -3.758  3  A_DC3:DG22_B  A 3  ? B 22 ? 19 1 
+1 A DG  4  1_555 B CBR 9  1_555 0.438  -0.006 0.283  17.272  -12.904 -3.094  4  A_DG4:CBR21_B A 4  ? B 21 ? 19 1 
+1 A DA  5  1_555 B DT  8  1_555 0.488  0.009  0.069  10.097  -22.360 1.267   5  A_DA5:DT20_B  A 5  ? B 20 ? 20 1 
+1 A DA  6  1_555 B DT  7  1_555 -0.294 -0.226 0.455  2.762   -21.697 3.951   6  A_DA6:DT19_B  A 6  ? B 19 ? 20 1 
+1 A DT  7  1_555 B DA  6  1_555 -0.321 0.005  0.280  -2.319  -22.066 6.900   7  A_DT7:DA18_B  A 7  ? B 18 ? 20 1 
+1 A DT  8  1_555 B DA  5  1_555 0.220  -0.205 0.159  -10.118 -21.942 2.475   8  A_DT8:DA17_B  A 8  ? B 17 ? 20 1 
+1 A CBR 9  1_555 B DG  4  1_555 -0.209 -0.062 -0.090 -18.464 -12.285 -3.888  9  A_CBR9:DG16_B A 9  ? B 16 ? 19 1 
+1 A DG  10 1_555 B DC  3  1_555 0.020  -0.120 0.568  6.268   -0.093  -0.357  10 A_DG10:DC15_B A 10 ? B 15 ? 19 1 
+1 A DC  11 1_555 B DG  2  1_555 0.049  -0.167 -0.055 4.966   -21.510 -12.252 11 A_DC11:DG14_B A 11 ? B 14 ? 19 1 
+1 A DG  12 1_555 B DC  1  1_555 0.068  -0.028 0.336  16.497  21.546  -2.922  12 A_DG12:DC13_B A 12 ? B 13 ? 19 1 
+# 
+loop_
+_ndb_struct_na_base_pair_step.model_number 
+_ndb_struct_na_base_pair_step.i_label_asym_id_1 
+_ndb_struct_na_base_pair_step.i_label_comp_id_1 
+_ndb_struct_na_base_pair_step.i_label_seq_id_1 
+_ndb_struct_na_base_pair_step.i_symmetry_1 
+_ndb_struct_na_base_pair_step.j_label_asym_id_1 
+_ndb_struct_na_base_pair_step.j_label_comp_id_1 
+_ndb_struct_na_base_pair_step.j_label_seq_id_1 
+_ndb_struct_na_base_pair_step.j_symmetry_1 
+_ndb_struct_na_base_pair_step.i_label_asym_id_2 
+_ndb_struct_na_base_pair_step.i_label_comp_id_2 
+_ndb_struct_na_base_pair_step.i_label_seq_id_2 
+_ndb_struct_na_base_pair_step.i_symmetry_2 
+_ndb_struct_na_base_pair_step.j_label_asym_id_2 
+_ndb_struct_na_base_pair_step.j_label_comp_id_2 
+_ndb_struct_na_base_pair_step.j_label_seq_id_2 
+_ndb_struct_na_base_pair_step.j_symmetry_2 
+_ndb_struct_na_base_pair_step.shift 
+_ndb_struct_na_base_pair_step.slide 
+_ndb_struct_na_base_pair_step.rise 
+_ndb_struct_na_base_pair_step.tilt 
+_ndb_struct_na_base_pair_step.roll 
+_ndb_struct_na_base_pair_step.twist 
+_ndb_struct_na_base_pair_step.x_displacement 
+_ndb_struct_na_base_pair_step.y_displacement 
+_ndb_struct_na_base_pair_step.helical_rise 
+_ndb_struct_na_base_pair_step.inclination 
+_ndb_struct_na_base_pair_step.tip 
+_ndb_struct_na_base_pair_step.helical_twist 
+_ndb_struct_na_base_pair_step.step_number 
+_ndb_struct_na_base_pair_step.step_name 
+_ndb_struct_na_base_pair_step.i_auth_asym_id_1 
+_ndb_struct_na_base_pair_step.i_auth_seq_id_1 
+_ndb_struct_na_base_pair_step.i_PDB_ins_code_1 
+_ndb_struct_na_base_pair_step.j_auth_asym_id_1 
+_ndb_struct_na_base_pair_step.j_auth_seq_id_1 
+_ndb_struct_na_base_pair_step.j_PDB_ins_code_1 
+_ndb_struct_na_base_pair_step.i_auth_asym_id_2 
+_ndb_struct_na_base_pair_step.i_auth_seq_id_2 
+_ndb_struct_na_base_pair_step.i_PDB_ins_code_2 
+_ndb_struct_na_base_pair_step.j_auth_asym_id_2 
+_ndb_struct_na_base_pair_step.j_auth_seq_id_2 
+_ndb_struct_na_base_pair_step.j_PDB_ins_code_2 
+1 A DC  1  1_555 B DG  12 1_555 A DG  2  1_555 B DC  11 1_555 -0.036 -0.030 2.929 -6.495 -1.927  38.715 0.161  -0.641 2.896 -2.879 
+9.707   39.280 1  AA_DC1DG2:DC23DG24_BB   A 1  ? B 24 ? A 2  ? B 23 ? 
+1 A DG  2  1_555 B DC  11 1_555 A DC  3  1_555 B DG  10 1_555 0.828  0.048  4.003 9.947  -8.581  44.042 0.993  0.018  4.014 
+-11.151 -12.926 45.866 2  AA_DG2DC3:DG22DC23_BB   A 2  ? B 23 ? A 3  ? B 22 ? 
+1 A DC  3  1_555 B DG  10 1_555 A DG  4  1_555 B CBR 9  1_555 -0.594 0.543  2.916 1.837  2.230   28.892 0.646  1.546  2.907 4.456 
+-3.671  29.033 3  AA_DC3DG4:CBR21DG22_BB  A 3  ? B 22 ? A 4  ? B 21 ? 
+1 A DG  4  1_555 B CBR 9  1_555 A DA  5  1_555 B DT  8  1_555 0.019  -0.326 3.463 1.965  -5.708  38.664 0.244  0.223  3.472 -8.558 
+-2.946  39.115 4  AA_DG4DA5:DT20CBR21_BB  A 4  ? B 21 ? A 5  ? B 20 ? 
+1 A DA  5  1_555 B DT  8  1_555 A DA  6  1_555 B DT  7  1_555 0.377  -0.497 3.224 -1.897 3.538   35.384 -1.314 -0.886 3.138 5.799 
+3.109   35.603 5  AA_DA5DA6:DT19DT20_BB   A 5  ? B 20 ? A 6  ? B 19 ? 
+1 A DA  6  1_555 B DT  7  1_555 A DT  7  1_555 B DA  6  1_555 0.076  -0.547 3.380 1.240  -1.681  30.915 -0.688 0.106  3.404 -3.149 
+-2.324  30.984 6  AA_DA6DT7:DA18DT19_BB   A 6  ? B 19 ? A 7  ? B 18 ? 
+1 A DT  7  1_555 B DA  6  1_555 A DT  8  1_555 B DA  5  1_555 -0.091 -0.275 3.430 1.557  1.547   36.373 -0.664 0.371  3.410 2.475 
+-2.491  36.437 7  AA_DT7DT8:DA17DA18_BB   A 7  ? B 18 ? A 8  ? B 17 ? 
+1 A DT  8  1_555 B DA  5  1_555 A CBR 9  1_555 B DG  4  1_555 -0.419 0.013  3.468 1.567  -6.989  41.109 0.798  0.764  3.404 -9.863 
+-2.211  41.701 8  AA_DT8CBR9:DG16DA17_BB  A 8  ? B 17 ? A 9  ? B 16 ? 
+1 A CBR 9  1_555 B DG  4  1_555 A DG  10 1_555 B DC  3  1_555 0.711  0.537  2.914 -5.498 4.318   28.805 0.244  -2.416 2.782 8.522 
+10.850  29.624 9  AA_CBR9DG10:DC15DG16_BB A 9  ? B 16 ? A 10 ? B 15 ? 
+1 A DG  10 1_555 B DC  3  1_555 A DC  11 1_555 B DG  2  1_555 -1.339 0.493  3.533 2.730  -14.697 42.344 2.049  2.018  3.117 
+-19.628 -3.647  44.790 10 AA_DG10DC11:DG14DC15_BB A 10 ? B 15 ? A 11 ? B 14 ? 
+1 A DC  11 1_555 B DG  2  1_555 A DG  12 1_555 B DC  1  1_555 1.291  -0.061 3.517 -4.063 -11.671 35.133 1.553  -2.598 3.212 
+-18.637 6.488   37.178 11 AA_DC11DG12:DC13DG14_BB A 11 ? B 14 ? A 12 ? B 13 ? 
+# 
+_pdbx_entity_nonpoly.entity_id   2 
+_pdbx_entity_nonpoly.name        water 
+_pdbx_entity_nonpoly.comp_id     HOH 
+# 

--- a/Code/GraphMol/FileParsers/test_data/4tna.cif
+++ b/Code/GraphMol/FileParsers/test_data/4tna.cif
@@ -1,0 +1,3246 @@
+data_4TNA
+# 
+_entry.id   4TNA 
+# 
+_audit_conform.dict_name       mmcif_pdbx.dic 
+_audit_conform.dict_version    5.279 
+_audit_conform.dict_location   http://mmcif.pdb.org/dictionaries/ascii/mmcif_pdbx.dic 
+# 
+loop_
+_database_2.database_id 
+_database_2.database_code 
+PDB   4TNA         
+RCSB  TRNA10       
+WWPDB D_1000179434 
+# 
+_pdbx_database_PDB_obs_spr.id               SPRSDE 
+_pdbx_database_PDB_obs_spr.date             1978-05-17 
+_pdbx_database_PDB_obs_spr.pdb_id           4TNA 
+_pdbx_database_PDB_obs_spr.replace_pdb_id   3TNA 
+_pdbx_database_PDB_obs_spr.details          ? 
+# 
+_pdbx_database_status.status_code                     REL 
+_pdbx_database_status.entry_id                        4TNA 
+_pdbx_database_status.recvd_initial_deposition_date   1978-04-12 
+_pdbx_database_status.deposit_site                    BNL 
+_pdbx_database_status.process_site                    BNL 
+_pdbx_database_status.status_code_sf                  REL 
+_pdbx_database_status.status_code_mr                  ? 
+_pdbx_database_status.SG_entry                        ? 
+_pdbx_database_status.pdb_format_compatible           Y 
+_pdbx_database_status.status_code_cs                  ? 
+# 
+loop_
+_audit_author.name 
+_audit_author.pdbx_ordinal 
+'Hingerty, B.E.' 1 
+'Brown, R.S.'    2 
+'Jack, A.'       3 
+# 
+loop_
+_citation.id 
+_citation.title 
+_citation.journal_abbrev 
+_citation.journal_volume 
+_citation.page_first 
+_citation.page_last 
+_citation.year 
+_citation.journal_id_ASTM 
+_citation.country 
+_citation.journal_id_ISSN 
+_citation.journal_id_CSD 
+_citation.book_publisher 
+_citation.pdbx_database_id_PubMed 
+_citation.pdbx_database_id_DOI 
+primary 'Further refinement of the structure of yeast tRNAPhe.'                                       J.Mol.Biol. 124 523  534 
+1978 JMOBAK UK 0022-2836     0070 ?                                                            361973 
+'10.1016/0022-2836(78)90185-7' 
+1       'Refinement of Large Structures by Simultaneous Minimization of Energy and R Factor'          'Acta Crystallogr.,Sect.A' 
+34  931  ?   1978 ACACEQ DK 0108-7673     0621 ?                                                            ?      ? 
+2       'A Crystallographic Study of Metal-Binding to Yeast Phenylalanine Transfer RNA'               J.Mol.Biol. 111 315  ?   
+1977 JMOBAK UK 0022-2836     0070 ?                                                            ?      ? 
+3       'Crystallographic Refinement of Yeast Phenylalanine Transfer RNA at 2.5 Angstroms Resolution' J.Mol.Biol. 108 619  ?   
+1976 JMOBAK UK 0022-2836     0070 ?                                                            ?      ? 
+4       'Atomic Coordinates for Yeast Phenylalanine T-RNA'                                            'Nucleic Acids Res.' 2   
+1629 ?   1975 NARHAD UK 0305-1048     0389 ?                                                            ?      ? 
+5       'Structure of Yeast Phenylalanine T-RNA at 3 Angstroms Resolution'                            Nature 250 546  ?   1974 
+NATUAS UK 0028-0836     0006 ?                                                            ?      ?                              
+6       ?                                                                                             
+'Atlas of Protein Sequence and Structure (Data Section)' 5   347  ?   1972 ?      ?  0-912466-02-2 0435 
+'National Biomedical Research Foundation, Silver Spring,Md.' ?      ?                              
+# 
+loop_
+_citation_author.citation_id 
+_citation_author.name 
+_citation_author.ordinal 
+primary 'Hingerty, B.'   1  
+primary 'Brown, R.S.'    2  
+primary 'Jack, A.'       3  
+1       'Jack, A.'       4  
+1       'Levitt, M.'     5  
+2       'Jack, A.'       6  
+2       'Ladner, J.E.'   7  
+2       'Rhodes, D.'     8  
+2       'Brown, R.S.'    9  
+2       'Klug, A.'       10 
+3       'Jack, A.'       11 
+3       'Ladner, J.E.'   12 
+3       'Klug, A.'       13 
+4       'Ladner, J.E.'   14 
+4       'Jack, A.'       15 
+4       'Robertus, J.D.' 16 
+4       'Brown, R.S.'    17 
+4       'Rhodes, D.'     18 
+4       'Clark, B.F.C.'  19 
+4       'Klug, A.'       20 
+5       'Robertus, J.D.' 21 
+5       'Ladner, J.E.'   22 
+5       'Finch, J.T.'    23 
+5       'Rhodes, D.'     24 
+5       'Brown, R.S.'    25 
+5       'Clark, B.F.C.'  26 
+5       'Klug, A.'       27 
+# 
+_cell.entry_id           4TNA 
+_cell.length_a           56.300 
+_cell.length_b           33.400 
+_cell.length_c           63.000 
+_cell.angle_alpha        90.00 
+_cell.angle_beta         90.25 
+_cell.angle_gamma        90.00 
+_cell.Z_PDB              2 
+_cell.pdbx_unique_axis   ? 
+# 
+_symmetry.entry_id                         4TNA 
+_symmetry.space_group_name_H-M             'P 1 21 1' 
+_symmetry.pdbx_full_space_group_name_H-M   ? 
+_symmetry.cell_setting                     ? 
+_symmetry.Int_Tables_number                4 
+# 
+loop_
+_entity.id 
+_entity.type 
+_entity.src_method 
+_entity.pdbx_description 
+_entity.formula_weight 
+_entity.pdbx_number_of_molecules 
+_entity.pdbx_ec 
+_entity.pdbx_mutation 
+_entity.pdbx_fragment 
+_entity.details 
+1 polymer     nat TRNAPHE         24890.121 1 ? ? ? ? 
+2 non-polymer syn 'MAGNESIUM ION' 24.305    4 ? ? ? ? 
+# 
+_entity_poly.entity_id                      1 
+_entity_poly.type                           polyribonucleotide 
+_entity_poly.nstd_linkage                   no 
+_entity_poly.nstd_monomer                   yes 
+_entity_poly.pdbx_seq_one_letter_code       
+;GCGGAUUUA(2MG)CUCAG(H2U)(H2U)GGGAGAGC(M2G)CCAGA(OMC)U(OMG)AA(YG)A(PSU)(5MC)UGGAG
+(7MG)UC(5MC)UGUG(5MU)(PSU)CG(1MA)UCCACAGAAUUCGCACCA
+;
+_entity_poly.pdbx_seq_one_letter_code_can   GCGGAUUUAGCUCAGUUGGGAGAGCGCCAGACUGAAGAUCUGGAGGUCCUGUGUUCGAUCCACAGAAUUCGCACCA 
+_entity_poly.pdbx_strand_id                 A 
+_entity_poly.pdbx_target_identifier         ? 
+# 
+loop_
+_entity_poly_seq.entity_id 
+_entity_poly_seq.num 
+_entity_poly_seq.mon_id 
+_entity_poly_seq.hetero 
+1 1  G   n 
+1 2  C   n 
+1 3  G   n 
+1 4  G   n 
+1 5  A   n 
+1 6  U   n 
+1 7  U   n 
+1 8  U   n 
+1 9  A   n 
+1 10 2MG n 
+1 11 C   n 
+1 12 U   n 
+1 13 C   n 
+1 14 A   n 
+1 15 G   n 
+1 16 H2U n 
+1 17 H2U n 
+1 18 G   n 
+1 19 G   n 
+1 20 G   n 
+1 21 A   n 
+1 22 G   n 
+1 23 A   n 
+1 24 G   n 
+1 25 C   n 
+1 26 M2G n 
+1 27 C   n 
+1 28 C   n 
+1 29 A   n 
+1 30 G   n 
+1 31 A   n 
+1 32 OMC n 
+1 33 U   n 
+1 34 OMG n 
+1 35 A   n 
+1 36 A   n 
+1 37 YG  n 
+1 38 A   n 
+1 39 PSU n 
+1 40 5MC n 
+1 41 U   n 
+1 42 G   n 
+1 43 G   n 
+1 44 A   n 
+1 45 G   n 
+1 46 7MG n 
+1 47 U   n 
+1 48 C   n 
+1 49 5MC n 
+1 50 U   n 
+1 51 G   n 
+1 52 U   n 
+1 53 G   n 
+1 54 5MU n 
+1 55 PSU n 
+1 56 C   n 
+1 57 G   n 
+1 58 1MA n 
+1 59 U   n 
+1 60 C   n 
+1 61 C   n 
+1 62 A   n 
+1 63 C   n 
+1 64 A   n 
+1 65 G   n 
+1 66 A   n 
+1 67 A   n 
+1 68 U   n 
+1 69 U   n 
+1 70 C   n 
+1 71 G   n 
+1 72 C   n 
+1 73 A   n 
+1 74 C   n 
+1 75 C   n 
+1 76 A   n 
+# 
+_entity_src_nat.entity_id                  1 
+_entity_src_nat.pdbx_src_id                1 
+_entity_src_nat.pdbx_alt_source_flag       sample 
+_entity_src_nat.pdbx_beg_seq_num           ? 
+_entity_src_nat.pdbx_end_seq_num           ? 
+_entity_src_nat.common_name                
+;baker's yeast
+;
+_entity_src_nat.pdbx_organism_scientific   'Saccharomyces cerevisiae' 
+_entity_src_nat.pdbx_ncbi_taxonomy_id      4932 
+_entity_src_nat.genus                      ? 
+_entity_src_nat.species                    ? 
+_entity_src_nat.strain                     ? 
+_entity_src_nat.tissue                     ? 
+_entity_src_nat.tissue_fraction            ? 
+_entity_src_nat.pdbx_secretion             ? 
+_entity_src_nat.pdbx_fragment              ? 
+_entity_src_nat.pdbx_variant               ? 
+_entity_src_nat.pdbx_cell_line             ? 
+_entity_src_nat.pdbx_atcc                  ? 
+_entity_src_nat.pdbx_cellular_location     ? 
+_entity_src_nat.pdbx_organ                 ? 
+_entity_src_nat.pdbx_organelle             ? 
+_entity_src_nat.pdbx_cell                  ? 
+_entity_src_nat.pdbx_plasmid_name          ? 
+_entity_src_nat.pdbx_plasmid_details       ? 
+_entity_src_nat.details                    ? 
+# 
+_struct_ref.id                         1 
+_struct_ref.entity_id                  1 
+_struct_ref.db_name                    PDB 
+_struct_ref.db_code                    4TNA 
+_struct_ref.pdbx_db_accession          4TNA 
+_struct_ref.pdbx_db_isoform            ? 
+_struct_ref.pdbx_seq_one_letter_code   ? 
+_struct_ref.pdbx_align_begin           ? 
+# 
+_struct_ref_seq.align_id                      1 
+_struct_ref_seq.ref_id                        1 
+_struct_ref_seq.pdbx_PDB_id_code              4TNA 
+_struct_ref_seq.pdbx_strand_id                A 
+_struct_ref_seq.seq_align_beg                 1 
+_struct_ref_seq.pdbx_seq_align_beg_ins_code   ? 
+_struct_ref_seq.seq_align_end                 76 
+_struct_ref_seq.pdbx_seq_align_end_ins_code   ? 
+_struct_ref_seq.pdbx_db_accession             4TNA 
+_struct_ref_seq.db_align_beg                  1 
+_struct_ref_seq.pdbx_db_align_beg_ins_code    ? 
+_struct_ref_seq.db_align_end                  76 
+_struct_ref_seq.pdbx_db_align_end_ins_code    ? 
+_struct_ref_seq.pdbx_auth_seq_align_beg       1 
+_struct_ref_seq.pdbx_auth_seq_align_end       76 
+# 
+loop_
+_chem_comp.id 
+_chem_comp.type 
+_chem_comp.mon_nstd_flag 
+_chem_comp.name 
+_chem_comp.pdbx_synonyms 
+_chem_comp.formula 
+_chem_comp.formula_weight 
+1MA 'RNA linking' n "6-HYDRO-1-METHYLADENOSINE-5'-MONOPHOSPHATE"  ? 'C11 H16 N5 O7 P'  361.248 
+2MG 'RNA linking' n "2N-METHYLGUANOSINE-5'-MONOPHOSPHATE"         ? 'C11 H16 N5 O8 P'  377.247 
+5MC 'RNA linking' n "5-METHYLCYTIDINE-5'-MONOPHOSPHATE"           ? 'C10 H16 N3 O8 P'  337.223 
+5MU 'RNA linking' n 
+;5-METHYLURIDINE 5'-MONOPHOSPHATE
+;
+?                                                                                                                                
+'C10 H15 N2 O9 P'  338.208 
+7MG 'RNA linking' n "7N-METHYL-8-HYDROGUANOSINE-5'-MONOPHOSPHATE" ? 'C11 H18 N5 O8 P'  379.263 
+A   'RNA linking' y "ADENOSINE-5'-MONOPHOSPHATE"                  ? 'C10 H14 N5 O7 P'  347.221 
+C   'RNA linking' y "CYTIDINE-5'-MONOPHOSPHATE"                   ? 'C9 H14 N3 O8 P'   323.197 
+G   'RNA linking' y "GUANOSINE-5'-MONOPHOSPHATE"                  ? 'C10 H14 N5 O8 P'  363.221 
+H2U 'RNA linking' n "5,6-DIHYDROURIDINE-5'-MONOPHOSPHATE"         ? 'C9 H15 N2 O9 P'   326.197 
+M2G 'RNA linking' n "N2-DIMETHYLGUANOSINE-5'-MONOPHOSPHATE"       ? 'C12 H18 N5 O8 P'  391.274 
+MG  non-polymer   . 'MAGNESIUM ION'                               ? 'Mg 2'             24.305  
+OMC 'RNA linking' n "O2'-METHYLYCYTIDINE-5'-MONOPHOSPHATE"        ? 'C10 H16 N3 O8 P'  337.223 
+OMG 'RNA linking' n "O2'-METHYLGUANOSINE-5'-MONOPHOSPHATE"        ? 'C11 H16 N5 O8 P'  377.247 
+PSU 'RNA linking' n "PSEUDOURIDINE-5'-MONOPHOSPHATE"              ? 'C9 H13 N2 O9 P'   324.181 
+U   'RNA linking' y "URIDINE-5'-MONOPHOSPHATE"                    ? 'C9 H13 N2 O9 P'   324.181 
+YG  'RNA linking' n WYBUTOSINE                                    
+'Y-BASE; 1H-IMIDAZO(1,2-ALPHA)PURINE-7-BUTANOIC ACID,4,9-DIHYDRO-ALPHA-((METHOXYCARBONYL)AMINO)-4,6-DIMETHYL-9-OXO-METHYL ESTER' 
+'C21 H29 N6 O12 P' 588.462 
+# 
+_exptl.entry_id          4TNA 
+_exptl.method            'X-RAY DIFFRACTION' 
+_exptl.crystals_number   ? 
+# 
+_exptl_crystal.id                    1 
+_exptl_crystal.density_meas          ? 
+_exptl_crystal.density_Matthews      2.38 
+_exptl_crystal.density_percent_sol   48.31 
+_exptl_crystal.description           ? 
+# 
+_diffrn.id                     1 
+_diffrn.crystal_id             1 
+_diffrn.ambient_temp           ? 
+_diffrn.ambient_temp_details   ? 
+# 
+_refine.entry_id                                 4TNA 
+_refine.ls_number_reflns_obs                     ? 
+_refine.ls_number_reflns_all                     ? 
+_refine.pdbx_ls_sigma_I                          ? 
+_refine.pdbx_ls_sigma_F                          ? 
+_refine.pdbx_data_cutoff_high_absF               ? 
+_refine.pdbx_data_cutoff_low_absF                ? 
+_refine.pdbx_data_cutoff_high_rms_absF           ? 
+_refine.ls_d_res_low                             ? 
+_refine.ls_d_res_high                            2.500 
+_refine.ls_percent_reflns_obs                    ? 
+_refine.ls_R_factor_obs                          ? 
+_refine.ls_R_factor_all                          ? 
+_refine.ls_R_factor_R_work                       ? 
+_refine.ls_R_factor_R_free                       ? 
+_refine.ls_R_factor_R_free_error                 ? 
+_refine.ls_R_factor_R_free_error_details         ? 
+_refine.ls_percent_reflns_R_free                 ? 
+_refine.ls_number_reflns_R_free                  ? 
+_refine.ls_number_parameters                     ? 
+_refine.ls_number_restraints                     ? 
+_refine.occupancy_min                            ? 
+_refine.occupancy_max                            ? 
+_refine.B_iso_mean                               ? 
+_refine.aniso_B[1][1]                            ? 
+_refine.aniso_B[2][2]                            ? 
+_refine.aniso_B[3][3]                            ? 
+_refine.aniso_B[1][2]                            ? 
+_refine.aniso_B[1][3]                            ? 
+_refine.aniso_B[2][3]                            ? 
+_refine.solvent_model_details                    ? 
+_refine.solvent_model_param_ksol                 ? 
+_refine.solvent_model_param_bsol                 ? 
+_refine.pdbx_ls_cross_valid_method               ? 
+_refine.details                                  ? 
+_refine.pdbx_starting_model                      ? 
+_refine.pdbx_method_to_determine_struct          ? 
+_refine.pdbx_isotropic_thermal_model             ? 
+_refine.pdbx_stereochemistry_target_values       ? 
+_refine.pdbx_stereochem_target_val_spec_case     ? 
+_refine.pdbx_R_Free_selection_details            ? 
+_refine.pdbx_overall_ESU_R                       ? 
+_refine.pdbx_overall_ESU_R_Free                  ? 
+_refine.overall_SU_ML                            ? 
+_refine.overall_SU_B                             ? 
+_refine.pdbx_refine_id                           'X-RAY DIFFRACTION' 
+_refine.pdbx_diffrn_id                           1 
+_refine.pdbx_TLS_residual_ADP_flag               ? 
+_refine.correlation_coeff_Fo_to_Fc               ? 
+_refine.correlation_coeff_Fo_to_Fc_free          ? 
+_refine.pdbx_solvent_vdw_probe_radii             ? 
+_refine.pdbx_solvent_ion_probe_radii             ? 
+_refine.pdbx_solvent_shrinkage_radii             ? 
+_refine.pdbx_overall_phase_error                 ? 
+_refine.overall_SU_R_Cruickshank_DPI             ? 
+_refine.pdbx_overall_SU_R_free_Cruickshank_DPI   ? 
+_refine.pdbx_overall_SU_R_Blow_DPI               ? 
+_refine.pdbx_overall_SU_R_free_Blow_DPI          ? 
+# 
+_refine_hist.pdbx_refine_id                   'X-RAY DIFFRACTION' 
+_refine_hist.cycle_id                         LAST 
+_refine_hist.pdbx_number_atoms_protein        0 
+_refine_hist.pdbx_number_atoms_nucleic_acid   1652 
+_refine_hist.pdbx_number_atoms_ligand         4 
+_refine_hist.number_atoms_solvent             0 
+_refine_hist.number_atoms_total               1656 
+_refine_hist.d_res_high                       2.500 
+_refine_hist.d_res_low                        . 
+# 
+_struct.entry_id                  4TNA 
+_struct.title                     'FURTHER REFINEMENT OF THE STRUCTURE OF YEAST T-RNA-PHE' 
+_struct.pdbx_descriptor           'TRANSFER RIBO-NUCLEIC ACID (YEAST,PHE) T-RNA' 
+_struct.pdbx_model_details        ? 
+_struct.pdbx_CASP_flag            ? 
+_struct.pdbx_model_type_details   ? 
+# 
+_struct_keywords.entry_id        4TNA 
+_struct_keywords.pdbx_keywords   T-RNA 
+_struct_keywords.text            'T-RNA, SINGLE STRAND, LOOPS' 
+# 
+loop_
+_struct_asym.id 
+_struct_asym.pdbx_blank_PDB_chainid_flag 
+_struct_asym.pdbx_modified 
+_struct_asym.entity_id 
+_struct_asym.details 
+A N N 1 ? 
+B N N 2 ? 
+C N N 2 ? 
+D N N 2 ? 
+E N N 2 ? 
+# 
+_struct_biol.id   1 
+# 
+loop_
+_struct_conn.id 
+_struct_conn.conn_type_id 
+_struct_conn.pdbx_leaving_atom_flag 
+_struct_conn.pdbx_PDB_id 
+_struct_conn.ptnr1_label_asym_id 
+_struct_conn.ptnr1_label_comp_id 
+_struct_conn.ptnr1_label_seq_id 
+_struct_conn.ptnr1_label_atom_id 
+_struct_conn.pdbx_ptnr1_label_alt_id 
+_struct_conn.pdbx_ptnr1_PDB_ins_code 
+_struct_conn.pdbx_ptnr1_standard_comp_id 
+_struct_conn.ptnr1_symmetry 
+_struct_conn.ptnr2_label_asym_id 
+_struct_conn.ptnr2_label_comp_id 
+_struct_conn.ptnr2_label_seq_id 
+_struct_conn.ptnr2_label_atom_id 
+_struct_conn.pdbx_ptnr2_label_alt_id 
+_struct_conn.pdbx_ptnr2_PDB_ins_code 
+_struct_conn.ptnr1_auth_asym_id 
+_struct_conn.ptnr1_auth_comp_id 
+_struct_conn.ptnr1_auth_seq_id 
+_struct_conn.ptnr2_auth_asym_id 
+_struct_conn.ptnr2_auth_comp_id 
+_struct_conn.ptnr2_auth_seq_id 
+_struct_conn.ptnr2_symmetry 
+_struct_conn.pdbx_ptnr3_label_atom_id 
+_struct_conn.pdbx_ptnr3_label_seq_id 
+_struct_conn.pdbx_ptnr3_label_comp_id 
+_struct_conn.pdbx_ptnr3_label_asym_id 
+_struct_conn.pdbx_ptnr3_label_alt_id 
+_struct_conn.pdbx_ptnr3_PDB_ins_code 
+_struct_conn.details 
+_struct_conn.pdbx_dist_value 
+_struct_conn.pdbx_value_order 
+covale1  covale ? ? A 2MG 10 P     ? ? ? 1_555 A A   9  "O3'" ? ? A 2MG 10 A A   9  1_555 ? ? ? ? ? ? ?                       
+1.580 ? 
+covale2  covale ? ? A 2MG 10 "O3'" ? ? ? 1_555 A C   11 P     ? ? A 2MG 10 A C   11 1_555 ? ? ? ? ? ? ?                       
+1.585 ? 
+covale3  covale ? ? A H2U 16 P     ? ? ? 1_555 A G   15 "O3'" ? ? A H2U 16 A G   15 1_555 ? ? ? ? ? ? ?                       
+1.569 ? 
+covale4  covale ? ? A H2U 16 "O3'" ? ? ? 1_555 A H2U 17 P     ? ? A H2U 16 A H2U 17 1_555 ? ? ? ? ? ? ?                       
+1.570 ? 
+covale5  covale ? ? A H2U 17 "O3'" ? ? ? 1_555 A G   18 P     ? ? A H2U 17 A G   18 1_555 ? ? ? ? ? ? ?                       
+1.623 ? 
+covale6  covale ? ? A M2G 26 P     ? ? ? 1_555 A C   25 "O3'" ? ? A M2G 26 A C   25 1_555 ? ? ? ? ? ? ?                       
+1.602 ? 
+covale7  covale ? ? A M2G 26 "O3'" ? ? ? 1_555 A C   27 P     ? ? A M2G 26 A C   27 1_555 ? ? ? ? ? ? ?                       
+1.588 ? 
+covale8  covale ? ? A OMC 32 P     ? ? ? 1_555 A A   31 "O3'" ? ? A OMC 32 A A   31 1_555 ? ? ? ? ? ? ?                       
+1.603 ? 
+covale9  covale ? ? A OMC 32 "O3'" ? ? ? 1_555 A U   33 P     ? ? A OMC 32 A U   33 1_555 ? ? ? ? ? ? ?                       
+1.607 ? 
+covale10 covale ? ? A OMG 34 P     ? ? ? 1_555 A U   33 "O3'" ? ? A OMG 34 A U   33 1_555 ? ? ? ? ? ? ?                       
+1.614 ? 
+covale11 covale ? ? A OMG 34 "O3'" ? ? ? 1_555 A A   35 P     ? ? A OMG 34 A A   35 1_555 ? ? ? ? ? ? ?                       
+1.611 ? 
+covale12 covale ? ? A YG  37 P     ? ? ? 1_555 A A   36 "O3'" ? ? A YG  37 A A   36 1_555 ? ? ? ? ? ? ?                       
+1.598 ? 
+covale13 covale ? ? A YG  37 "O3'" ? ? ? 1_555 A A   38 P     ? ? A YG  37 A A   38 1_555 ? ? ? ? ? ? ?                       
+1.607 ? 
+covale14 covale ? ? A PSU 39 P     ? ? ? 1_555 A A   38 "O3'" ? ? A PSU 39 A A   38 1_555 ? ? ? ? ? ? ?                       
+1.621 ? 
+covale15 covale ? ? A PSU 39 "O3'" ? ? ? 1_555 A 5MC 40 P     ? ? A PSU 39 A 5MC 40 1_555 ? ? ? ? ? ? ?                       
+1.597 ? 
+covale16 covale ? ? A 5MC 40 "O3'" ? ? ? 1_555 A U   41 P     ? ? A 5MC 40 A U   41 1_555 ? ? ? ? ? ? ?                       
+1.639 ? 
+covale17 covale ? ? A 7MG 46 P     ? ? ? 1_555 A G   45 "O3'" ? ? A 7MG 46 A G   45 1_555 ? ? ? ? ? ? ?                       
+1.603 ? 
+covale18 covale ? ? A 7MG 46 "O3'" ? ? ? 1_555 A U   47 P     ? ? A 7MG 46 A U   47 1_555 ? ? ? ? ? ? ?                       
+1.623 ? 
+covale19 covale ? ? A 5MC 49 P     ? ? ? 1_555 A C   48 "O3'" ? ? A 5MC 49 A C   48 1_555 ? ? ? ? ? ? ?                       
+1.592 ? 
+covale20 covale ? ? A 5MC 49 "O3'" ? ? ? 1_555 A U   50 P     ? ? A 5MC 49 A U   50 1_555 ? ? ? ? ? ? ?                       
+1.597 ? 
+covale21 covale ? ? A 5MU 54 P     ? ? ? 1_555 A G   53 "O3'" ? ? A 5MU 54 A G   53 1_555 ? ? ? ? ? ? ?                       
+1.593 ? 
+covale22 covale ? ? A 5MU 54 "O3'" ? ? ? 1_555 A PSU 55 P     ? ? A 5MU 54 A PSU 55 1_555 ? ? ? ? ? ? ?                       
+1.600 ? 
+covale23 covale ? ? A PSU 55 "O3'" ? ? ? 1_555 A C   56 P     ? ? A PSU 55 A C   56 1_555 ? ? ? ? ? ? ?                       
+1.586 ? 
+covale24 covale ? ? A 1MA 58 P     ? ? ? 1_555 A G   57 "O3'" ? ? A 1MA 58 A G   57 1_555 ? ? ? ? ? ? ?                       
+1.579 ? 
+covale25 covale ? ? A 1MA 58 "O3'" ? ? ? 1_555 A U   59 P     ? ? A 1MA 58 A U   59 1_555 ? ? ? ? ? ? ?                       
+1.610 ? 
+metalc1  metalc ? ? A G   19 OP1   ? ? ? 1_555 D MG  .  MG    ? ? A G   19 A MG  79 1_555 ? ? ? ? ? ? ?                       
+2.398 ? 
+metalc2  metalc ? ? A A   21 OP2   ? ? ? 1_555 C MG  .  MG    ? ? A A   21 A MG  78 1_555 ? ? ? ? ? ? ?                       
+2.316 ? 
+hydrog1  hydrog ? ? A G   1  N1    ? ? ? 1_555 A C   72 N3    ? ? A G   1  A C   72 1_555 ? ? ? ? ? ? WATSON-CRICK            ? ? 
+hydrog2  hydrog ? ? A G   1  N2    ? ? ? 1_555 A C   72 O2    ? ? A G   1  A C   72 1_555 ? ? ? ? ? ? WATSON-CRICK            ? ? 
+hydrog3  hydrog ? ? A G   1  O6    ? ? ? 1_555 A C   72 N4    ? ? A G   1  A C   72 1_555 ? ? ? ? ? ? WATSON-CRICK            ? ? 
+hydrog4  hydrog ? ? A C   2  N3    ? ? ? 1_555 A G   71 N1    ? ? A C   2  A G   71 1_555 ? ? ? ? ? ? WATSON-CRICK            ? ? 
+hydrog5  hydrog ? ? A C   2  N4    ? ? ? 1_555 A G   71 O6    ? ? A C   2  A G   71 1_555 ? ? ? ? ? ? WATSON-CRICK            ? ? 
+hydrog6  hydrog ? ? A C   2  O2    ? ? ? 1_555 A G   71 N2    ? ? A C   2  A G   71 1_555 ? ? ? ? ? ? WATSON-CRICK            ? ? 
+hydrog7  hydrog ? ? A G   3  N1    ? ? ? 1_555 A C   70 N3    ? ? A G   3  A C   70 1_555 ? ? ? ? ? ? WATSON-CRICK            ? ? 
+hydrog8  hydrog ? ? A G   3  N2    ? ? ? 1_555 A C   70 O2    ? ? A G   3  A C   70 1_555 ? ? ? ? ? ? WATSON-CRICK            ? ? 
+hydrog9  hydrog ? ? A G   3  O6    ? ? ? 1_555 A C   70 N4    ? ? A G   3  A C   70 1_555 ? ? ? ? ? ? WATSON-CRICK            ? ? 
+hydrog10 hydrog ? ? A G   4  N1    ? ? ? 1_555 A U   69 O2    ? ? A G   4  A U   69 1_555 ? ? ? ? ? ? TYPE_28_PAIR            ? ? 
+hydrog11 hydrog ? ? A G   4  O6    ? ? ? 1_555 A U   69 N3    ? ? A G   4  A U   69 1_555 ? ? ? ? ? ? TYPE_28_PAIR            ? ? 
+hydrog12 hydrog ? ? A A   5  N1    ? ? ? 1_555 A U   68 N3    ? ? A A   5  A U   68 1_555 ? ? ? ? ? ? WATSON-CRICK            ? ? 
+hydrog13 hydrog ? ? A A   5  N6    ? ? ? 1_555 A U   68 O4    ? ? A A   5  A U   68 1_555 ? ? ? ? ? ? WATSON-CRICK            ? ? 
+hydrog14 hydrog ? ? A U   6  N3    ? ? ? 1_555 A A   67 N1    ? ? A U   6  A A   67 1_555 ? ? ? ? ? ? WATSON-CRICK            ? ? 
+hydrog15 hydrog ? ? A U   6  O4    ? ? ? 1_555 A A   67 N6    ? ? A U   6  A A   67 1_555 ? ? ? ? ? ? WATSON-CRICK            ? ? 
+hydrog16 hydrog ? ? A U   7  N3    ? ? ? 1_555 A A   66 N1    ? ? A U   7  A A   66 1_555 ? ? ? ? ? ? WATSON-CRICK            ? ? 
+hydrog17 hydrog ? ? A U   7  O4    ? ? ? 1_555 A A   66 N6    ? ? A U   7  A A   66 1_555 ? ? ? ? ? ? WATSON-CRICK            ? ? 
+hydrog18 hydrog ? ? A U   8  N3    ? ? ? 1_555 A A   14 N7    ? ? A U   8  A A   14 1_555 ? ? ? ? ? ? 'REVERSED HOOGSTEEN'    ? ? 
+hydrog19 hydrog ? ? A U   8  O2    ? ? ? 1_555 A A   14 N6    ? ? A U   8  A A   14 1_555 ? ? ? ? ? ? 'REVERSED HOOGSTEEN'    ? ? 
+hydrog20 hydrog ? ? A A   9  N6    ? ? ? 1_555 A A   23 N7    ? ? A A   9  A A   23 1_555 ? ? ? ? ? ? TYPE_2_PAIR             ? ? 
+hydrog21 hydrog ? ? A A   9  N7    ? ? ? 1_555 A A   23 N6    ? ? A A   9  A A   23 1_555 ? ? ? ? ? ? TYPE_2_PAIR             ? ? 
+hydrog22 hydrog ? ? A 2MG 10 N1    ? ? ? 1_555 A C   25 N3    ? ? A 2MG 10 A C   25 1_555 ? ? ? ? ? ? WATSON-CRICK            ? ? 
+hydrog23 hydrog ? ? A 2MG 10 N2    ? ? ? 1_555 A C   25 O2    ? ? A 2MG 10 A C   25 1_555 ? ? ? ? ? ? WATSON-CRICK            ? ? 
+hydrog24 hydrog ? ? A 2MG 10 O6    ? ? ? 1_555 A C   25 N4    ? ? A 2MG 10 A C   25 1_555 ? ? ? ? ? ? WATSON-CRICK            ? ? 
+hydrog25 hydrog ? ? A 2MG 10 O6    ? ? ? 1_555 A G   45 N2    ? ? A 2MG 10 A G   45 1_555 ? ? ? ? ? ? '2MG-G MISPAIR'         ? ? 
+hydrog26 hydrog ? ? A C   11 N3    ? ? ? 1_555 A G   24 N1    ? ? A C   11 A G   24 1_555 ? ? ? ? ? ? WATSON-CRICK            ? ? 
+hydrog27 hydrog ? ? A C   11 N4    ? ? ? 1_555 A G   24 O6    ? ? A C   11 A G   24 1_555 ? ? ? ? ? ? WATSON-CRICK            ? ? 
+hydrog28 hydrog ? ? A C   11 O2    ? ? ? 1_555 A G   24 N2    ? ? A C   11 A G   24 1_555 ? ? ? ? ? ? WATSON-CRICK            ? ? 
+hydrog29 hydrog ? ? A U   12 N3    ? ? ? 1_555 A A   23 N1    ? ? A U   12 A A   23 1_555 ? ? ? ? ? ? WATSON-CRICK            ? ? 
+hydrog30 hydrog ? ? A U   12 O4    ? ? ? 1_555 A A   23 N6    ? ? A U   12 A A   23 1_555 ? ? ? ? ? ? WATSON-CRICK            ? ? 
+hydrog31 hydrog ? ? A C   13 N3    ? ? ? 1_555 A G   22 N1    ? ? A C   13 A G   22 1_555 ? ? ? ? ? ? WATSON-CRICK            ? ? 
+hydrog32 hydrog ? ? A C   13 N4    ? ? ? 1_555 A G   22 O6    ? ? A C   13 A G   22 1_555 ? ? ? ? ? ? WATSON-CRICK            ? ? 
+hydrog33 hydrog ? ? A C   13 O2    ? ? ? 1_555 A G   22 N2    ? ? A C   13 A G   22 1_555 ? ? ? ? ? ? WATSON-CRICK            ? ? 
+hydrog34 hydrog ? ? A G   15 N1    ? ? ? 1_555 A C   48 O2    ? ? A G   15 A C   48 1_555 ? ? ? ? ? ? 'REVERSED WATSON-CRICK' ? ? 
+hydrog35 hydrog ? ? A G   15 N2    ? ? ? 1_555 A C   48 N3    ? ? A G   15 A C   48 1_555 ? ? ? ? ? ? 'REVERSED WATSON-CRICK' ? ? 
+hydrog36 hydrog ? ? A G   18 N1    ? ? ? 1_555 A PSU 55 O4    ? ? A G   18 A PSU 55 1_555 ? ? ? ? ? ? 'G-PSU MISPAIR'         ? ? 
+hydrog37 hydrog ? ? A G   19 N1    ? ? ? 1_555 A C   56 N3    ? ? A G   19 A C   56 1_555 ? ? ? ? ? ? WATSON-CRICK            ? ? 
+hydrog38 hydrog ? ? A G   19 N2    ? ? ? 1_555 A C   56 O2    ? ? A G   19 A C   56 1_555 ? ? ? ? ? ? WATSON-CRICK            ? ? 
+hydrog39 hydrog ? ? A G   19 O6    ? ? ? 1_555 A C   56 N4    ? ? A G   19 A C   56 1_555 ? ? ? ? ? ? WATSON-CRICK            ? ? 
+hydrog40 hydrog ? ? A G   22 N7    ? ? ? 1_555 A 7MG 46 N1    ? ? A G   22 A 7MG 46 1_555 ? ? ? ? ? ? TYPE_7_PAIR             ? ? 
+hydrog41 hydrog ? ? A G   22 O6    ? ? ? 1_555 A 7MG 46 N2    ? ? A G   22 A 7MG 46 1_555 ? ? ? ? ? ? TYPE_7_PAIR             ? ? 
+hydrog42 hydrog ? ? A M2G 26 N1    ? ? ? 1_555 A A   44 N1    ? ? A M2G 26 A A   44 1_555 ? ? ? ? ? ? TYPE_8_PAIR             ? ? 
+hydrog43 hydrog ? ? A M2G 26 O6    ? ? ? 1_555 A A   44 N6    ? ? A M2G 26 A A   44 1_555 ? ? ? ? ? ? TYPE_8_PAIR             ? ? 
+hydrog44 hydrog ? ? A C   27 N4    ? ? ? 1_555 A G   43 O6    ? ? A C   27 A G   43 1_555 ? ? ? ? ? ? 'C-G PAIR'              ? ? 
+hydrog45 hydrog ? ? A C   28 N3    ? ? ? 1_555 A G   42 N1    ? ? A C   28 A G   42 1_555 ? ? ? ? ? ? WATSON-CRICK            ? ? 
+hydrog46 hydrog ? ? A C   28 N4    ? ? ? 1_555 A G   42 O6    ? ? A C   28 A G   42 1_555 ? ? ? ? ? ? WATSON-CRICK            ? ? 
+hydrog47 hydrog ? ? A C   28 O2    ? ? ? 1_555 A G   42 N2    ? ? A C   28 A G   42 1_555 ? ? ? ? ? ? WATSON-CRICK            ? ? 
+hydrog48 hydrog ? ? A A   29 N1    ? ? ? 1_555 A U   41 N3    ? ? A A   29 A U   41 1_555 ? ? ? ? ? ? WATSON-CRICK            ? ? 
+hydrog49 hydrog ? ? A A   29 N6    ? ? ? 1_555 A U   41 O4    ? ? A A   29 A U   41 1_555 ? ? ? ? ? ? WATSON-CRICK            ? ? 
+hydrog50 hydrog ? ? A G   30 N1    ? ? ? 1_555 A 5MC 40 N3    ? ? A G   30 A 5MC 40 1_555 ? ? ? ? ? ? WATSON-CRICK            ? ? 
+hydrog51 hydrog ? ? A G   30 N2    ? ? ? 1_555 A 5MC 40 O2    ? ? A G   30 A 5MC 40 1_555 ? ? ? ? ? ? WATSON-CRICK            ? ? 
+hydrog52 hydrog ? ? A G   30 O6    ? ? ? 1_555 A 5MC 40 N4    ? ? A G   30 A 5MC 40 1_555 ? ? ? ? ? ? WATSON-CRICK            ? ? 
+hydrog53 hydrog ? ? A A   31 N1    ? ? ? 1_555 A PSU 39 N3    ? ? A A   31 A PSU 39 1_555 ? ? ? ? ? ? 'REVERSED WATSON-CRICK' ? ? 
+hydrog54 hydrog ? ? A A   31 N6    ? ? ? 1_555 A PSU 39 O2    ? ? A A   31 A PSU 39 1_555 ? ? ? ? ? ? 'REVERSED WATSON-CRICK' ? ? 
+hydrog55 hydrog ? ? A 5MC 49 N3    ? ? ? 1_555 A G   65 N1    ? ? A 5MC 49 A G   65 1_555 ? ? ? ? ? ? WATSON-CRICK            ? ? 
+hydrog56 hydrog ? ? A 5MC 49 N4    ? ? ? 1_555 A G   65 O6    ? ? A 5MC 49 A G   65 1_555 ? ? ? ? ? ? WATSON-CRICK            ? ? 
+hydrog57 hydrog ? ? A 5MC 49 O2    ? ? ? 1_555 A G   65 N2    ? ? A 5MC 49 A G   65 1_555 ? ? ? ? ? ? WATSON-CRICK            ? ? 
+hydrog58 hydrog ? ? A U   50 N3    ? ? ? 1_555 A A   64 N1    ? ? A U   50 A A   64 1_555 ? ? ? ? ? ? WATSON-CRICK            ? ? 
+hydrog59 hydrog ? ? A U   50 O4    ? ? ? 1_555 A A   64 N6    ? ? A U   50 A A   64 1_555 ? ? ? ? ? ? WATSON-CRICK            ? ? 
+hydrog60 hydrog ? ? A G   51 N1    ? ? ? 1_555 A C   63 N3    ? ? A G   51 A C   63 1_555 ? ? ? ? ? ? WATSON-CRICK            ? ? 
+hydrog61 hydrog ? ? A G   51 N2    ? ? ? 1_555 A C   63 O2    ? ? A G   51 A C   63 1_555 ? ? ? ? ? ? WATSON-CRICK            ? ? 
+hydrog62 hydrog ? ? A G   51 O6    ? ? ? 1_555 A C   63 N4    ? ? A G   51 A C   63 1_555 ? ? ? ? ? ? WATSON-CRICK            ? ? 
+hydrog63 hydrog ? ? A U   52 N3    ? ? ? 1_555 A A   62 N1    ? ? A U   52 A A   62 1_555 ? ? ? ? ? ? WATSON-CRICK            ? ? 
+hydrog64 hydrog ? ? A U   52 O4    ? ? ? 1_555 A A   62 N6    ? ? A U   52 A A   62 1_555 ? ? ? ? ? ? WATSON-CRICK            ? ? 
+hydrog65 hydrog ? ? A G   53 N1    ? ? ? 1_555 A C   61 N3    ? ? A G   53 A C   61 1_555 ? ? ? ? ? ? WATSON-CRICK            ? ? 
+hydrog66 hydrog ? ? A G   53 N2    ? ? ? 1_555 A C   61 O2    ? ? A G   53 A C   61 1_555 ? ? ? ? ? ? WATSON-CRICK            ? ? 
+hydrog67 hydrog ? ? A G   53 O6    ? ? ? 1_555 A C   61 N4    ? ? A G   53 A C   61 1_555 ? ? ? ? ? ? WATSON-CRICK            ? ? 
+hydrog68 hydrog ? ? A 5MU 54 N3    ? ? ? 1_555 A 1MA 58 N7    ? ? A 5MU 54 A 1MA 58 1_555 ? ? ? ? ? ? 'REVERSED HOOGSTEEN'    ? ? 
+hydrog69 hydrog ? ? A 5MU 54 O2    ? ? ? 1_555 A 1MA 58 N6    ? ? A 5MU 54 A 1MA 58 1_555 ? ? ? ? ? ? 'REVERSED HOOGSTEEN'    ? ? 
+# 
+loop_
+_struct_conn_type.id 
+_struct_conn_type.criteria 
+_struct_conn_type.reference 
+covale ? ? 
+metalc ? ? 
+hydrog ? ? 
+# 
+loop_
+_struct_site.id 
+_struct_site.pdbx_evidence_code 
+_struct_site.pdbx_auth_asym_id 
+_struct_site.pdbx_auth_comp_id 
+_struct_site.pdbx_auth_seq_id 
+_struct_site.pdbx_auth_ins_code 
+_struct_site.pdbx_num_residues 
+_struct_site.details 
+AC1 Software ? ? ? ? 2 'BINDING SITE FOR RESIDUE MG A 78' 
+AC2 Software ? ? ? ? 1 'BINDING SITE FOR RESIDUE MG A 79' 
+# 
+loop_
+_struct_site_gen.id 
+_struct_site_gen.site_id 
+_struct_site_gen.pdbx_num_res 
+_struct_site_gen.label_comp_id 
+_struct_site_gen.label_asym_id 
+_struct_site_gen.label_seq_id 
+_struct_site_gen.pdbx_auth_ins_code 
+_struct_site_gen.auth_comp_id 
+_struct_site_gen.auth_asym_id 
+_struct_site_gen.auth_seq_id 
+_struct_site_gen.label_atom_id 
+_struct_site_gen.label_alt_id 
+_struct_site_gen.symmetry 
+_struct_site_gen.details 
+1 AC1 2 G A 20 ? G A 20 . ? 1_555 ? 
+2 AC1 2 A A 21 ? A A 21 . ? 1_555 ? 
+3 AC2 1 G A 19 ? G A 19 . ? 1_555 ? 
+# 
+_database_PDB_matrix.entry_id          4TNA 
+_database_PDB_matrix.origx[1][1]       1.000000 
+_database_PDB_matrix.origx[1][2]       0.000000 
+_database_PDB_matrix.origx[1][3]       0.000000 
+_database_PDB_matrix.origx[2][1]       0.000000 
+_database_PDB_matrix.origx[2][2]       1.000000 
+_database_PDB_matrix.origx[2][3]       0.000000 
+_database_PDB_matrix.origx[3][1]       0.000000 
+_database_PDB_matrix.origx[3][2]       0.000000 
+_database_PDB_matrix.origx[3][3]       1.000000 
+_database_PDB_matrix.origx_vector[1]   0.00000 
+_database_PDB_matrix.origx_vector[2]   0.00000 
+_database_PDB_matrix.origx_vector[3]   0.00000 
+# 
+_atom_sites.entry_id                    4TNA 
+_atom_sites.fract_transf_matrix[1][1]   0.017760 
+_atom_sites.fract_transf_matrix[1][2]   0.000000 
+_atom_sites.fract_transf_matrix[1][3]   0.000000 
+_atom_sites.fract_transf_matrix[2][1]   0.000000 
+_atom_sites.fract_transf_matrix[2][2]   0.029940 
+_atom_sites.fract_transf_matrix[2][3]   0.000000 
+_atom_sites.fract_transf_matrix[3][1]   0.000070 
+_atom_sites.fract_transf_matrix[3][2]   0.000000 
+_atom_sites.fract_transf_matrix[3][3]   0.015873 
+_atom_sites.fract_transf_vector[1]      0.00000 
+_atom_sites.fract_transf_vector[2]      0.00000 
+_atom_sites.fract_transf_vector[3]      0.00000 
+# 
+loop_
+_atom_type.symbol 
+C  
+MG 
+N  
+O  
+P  
+# 
+loop_
+_atom_site.group_PDB 
+_atom_site.id 
+_atom_site.type_symbol 
+_atom_site.label_atom_id 
+_atom_site.label_alt_id 
+_atom_site.label_comp_id 
+_atom_site.label_asym_id 
+_atom_site.label_entity_id 
+_atom_site.label_seq_id 
+_atom_site.pdbx_PDB_ins_code 
+_atom_site.Cartn_x 
+_atom_site.Cartn_y 
+_atom_site.Cartn_z 
+_atom_site.occupancy 
+_atom_site.B_iso_or_equiv 
+_atom_site.pdbx_formal_charge 
+_atom_site.auth_seq_id 
+_atom_site.auth_comp_id 
+_atom_site.auth_asym_id 
+_atom_site.auth_atom_id 
+_atom_site.pdbx_PDB_model_num 
+ATOM   1    O  OP3   . G   A 1 1  ? 23.215 5.145   51.161  1.00 0.00 ? 1  G   A OP3   1 
+ATOM   2    P  P     . G   A 1 1  ? 24.650 4.594   51.620  1.00 0.00 ? 1  G   A P     1 
+ATOM   3    O  OP1   . G   A 1 1  ? 24.810 3.219   51.082  1.00 0.00 ? 1  G   A OP1   1 
+ATOM   4    O  OP2   . G   A 1 1  ? 25.707 5.598   51.344  1.00 0.00 ? 1  G   A OP2   1 
+ATOM   5    O  "O5'" . G   A 1 1  ? 24.476 4.546   53.204  1.00 0.00 ? 1  G   A "O5'" 1 
+ATOM   6    C  "C5'" . G   A 1 1  ? 25.156 5.525   53.978  1.00 0.00 ? 1  G   A "C5'" 1 
+ATOM   7    C  "C4'" . G   A 1 1  ? 25.808 4.801   55.152  1.00 0.00 ? 1  G   A "C4'" 1 
+ATOM   8    O  "O4'" . G   A 1 1  ? 24.983 3.707   55.565  1.00 0.00 ? 1  G   A "O4'" 1 
+ATOM   9    C  "C3'" . G   A 1 1  ? 27.185 4.241   54.785  1.00 0.00 ? 1  G   A "C3'" 1 
+ATOM   10   O  "O3'" . G   A 1 1  ? 28.130 5.240   55.163  1.00 0.00 ? 1  G   A "O3'" 1 
+ATOM   11   C  "C2'" . G   A 1 1  ? 27.282 3.124   55.808  1.00 0.00 ? 1  G   A "C2'" 1 
+ATOM   12   O  "O2'" . G   A 1 1  ? 27.691 3.684   57.045  1.00 0.00 ? 1  G   A "O2'" 1 
+ATOM   13   C  "C1'" . G   A 1 1  ? 25.833 2.612   55.903  1.00 0.00 ? 1  G   A "C1'" 1 
+ATOM   14   N  N9    . G   A 1 1  ? 25.681 1.623   54.832  1.00 0.00 ? 1  G   A N9    1 
+ATOM   15   C  C8    . G   A 1 1  ? 24.865 1.712   53.755  1.00 0.00 ? 1  G   A C8    1 
+ATOM   16   N  N7    . G   A 1 1  ? 25.012 0.580   52.989  1.00 0.00 ? 1  G   A N7    1 
+ATOM   17   C  C5    . G   A 1 1  ? 25.874 -0.248  53.697  1.00 0.00 ? 1  G   A C5    1 
+ATOM   18   C  C6    . G   A 1 1  ? 26.336 -1.541  53.483  1.00 0.00 ? 1  G   A C6    1 
+ATOM   19   O  O6    . G   A 1 1  ? 25.983 -2.159  52.466  1.00 0.00 ? 1  G   A O6    1 
+ATOM   20   N  N1    . G   A 1 1  ? 27.127 -2.122  54.405  1.00 0.00 ? 1  G   A N1    1 
+ATOM   21   C  C2    . G   A 1 1  ? 27.481 -1.468  55.532  1.00 0.00 ? 1  G   A C2    1 
+ATOM   22   N  N2    . G   A 1 1  ? 28.055 -2.114  56.534  1.00 0.00 ? 1  G   A N2    1 
+ATOM   23   N  N3    . G   A 1 1  ? 27.078 -0.243  55.747  1.00 0.00 ? 1  G   A N3    1 
+ATOM   24   C  C4    . G   A 1 1  ? 26.260 0.388   54.839  1.00 0.00 ? 1  G   A C4    1 
+ATOM   25   P  P     . C   A 1 2  ? 29.640 5.301   54.591  1.00 0.00 ? 2  C   A P     1 
+ATOM   26   O  OP1   . C   A 1 2  ? 30.307 6.511   55.152  1.00 0.00 ? 2  C   A OP1   1 
+ATOM   27   O  OP2   . C   A 1 2  ? 29.605 5.142   53.117  1.00 0.00 ? 2  C   A OP2   1 
+ATOM   28   O  "O5'" . C   A 1 2  ? 30.332 4.036   55.292  1.00 0.00 ? 2  C   A "O5'" 1 
+ATOM   29   C  "C5'" . C   A 1 2  ? 30.763 4.137   56.639  1.00 0.00 ? 2  C   A "C5'" 1 
+ATOM   30   C  "C4'" . C   A 1 2  ? 31.424 2.812   56.982  1.00 0.00 ? 2  C   A "C4'" 1 
+ATOM   31   O  "O4'" . C   A 1 2  ? 30.483 1.753   56.828  1.00 0.00 ? 2  C   A "O4'" 1 
+ATOM   32   C  "C3'" . C   A 1 2  ? 32.562 2.541   56.002  1.00 0.00 ? 2  C   A "C3'" 1 
+ATOM   33   O  "O3'" . C   A 1 2  ? 33.772 3.124   56.479  1.00 0.00 ? 2  C   A "O3'" 1 
+ATOM   34   C  "C2'" . C   A 1 2  ? 32.637 1.038   56.077  1.00 0.00 ? 2  C   A "C2'" 1 
+ATOM   35   O  "O2'" . C   A 1 2  ? 33.390 0.643   57.211  1.00 0.00 ? 2  C   A "O2'" 1 
+ATOM   36   C  "C1'" . C   A 1 2  ? 31.162 0.636   56.248  1.00 0.00 ? 2  C   A "C1'" 1 
+ATOM   37   N  N1    . C   A 1 2  ? 30.570 0.343   54.911  1.00 0.00 ? 2  C   A N1    1 
+ATOM   38   C  C2    . C   A 1 2  ? 30.799 -0.845  54.338  1.00 0.00 ? 2  C   A C2    1 
+ATOM   39   O  O2    . C   A 1 2  ? 31.777 -1.511  54.728  1.00 0.00 ? 2  C   A O2    1 
+ATOM   40   N  N3    . C   A 1 2  ? 30.243 -1.143  53.141  1.00 0.00 ? 2  C   A N3    1 
+ATOM   41   C  C4    . C   A 1 2  ? 29.496 -0.265  52.481  1.00 0.00 ? 2  C   A C4    1 
+ATOM   42   N  N4    . C   A 1 2  ? 28.782 -0.652  51.425  1.00 0.00 ? 2  C   A N4    1 
+ATOM   43   C  C5    . C   A 1 2  ? 29.284 0.988   53.032  1.00 0.00 ? 2  C   A C5    1 
+ATOM   44   C  C6    . C   A 1 2  ? 29.844 1.264   54.273  1.00 0.00 ? 2  C   A C6    1 
+ATOM   45   P  P     . G   A 1 3  ? 34.558 4.092   55.472  1.00 0.00 ? 3  G   A P     1 
+ATOM   46   O  OP1   . G   A 1 3  ? 35.617 4.858   56.160  1.00 0.00 ? 3  G   A OP1   1 
+ATOM   47   O  OP2   . G   A 1 3  ? 33.579 4.765   54.565  1.00 0.00 ? 3  G   A OP2   1 
+ATOM   48   O  "O5'" . G   A 1 3  ? 35.361 3.002   54.718  1.00 0.00 ? 3  G   A "O5'" 1 
+ATOM   49   C  "C5'" . G   A 1 3  ? 36.430 2.519   55.497  1.00 0.00 ? 3  G   A "C5'" 1 
+ATOM   50   C  "C4'" . G   A 1 3  ? 36.785 1.211   54.865  1.00 0.00 ? 3  G   A "C4'" 1 
+ATOM   51   O  "O4'" . G   A 1 3  ? 35.592 0.439   54.762  1.00 0.00 ? 3  G   A "O4'" 1 
+ATOM   52   C  "C3'" . G   A 1 3  ? 37.127 1.494   53.426  1.00 0.00 ? 3  G   A "C3'" 1 
+ATOM   53   O  "O3'" . G   A 1 3  ? 38.384 2.155   53.317  1.00 0.00 ? 3  G   A "O3'" 1 
+ATOM   54   C  "C2'" . G   A 1 3  ? 37.054 0.044   52.956  1.00 0.00 ? 3  G   A "C2'" 1 
+ATOM   55   O  "O2'" . G   A 1 3  ? 38.107 -0.710  53.511  1.00 0.00 ? 3  G   A "O2'" 1 
+ATOM   56   C  "C1'" . G   A 1 3  ? 35.772 -0.434  53.651  1.00 0.00 ? 3  G   A "C1'" 1 
+ATOM   57   N  N9    . G   A 1 3  ? 34.630 -0.302  52.717  1.00 0.00 ? 3  G   A N9    1 
+ATOM   58   C  C8    . G   A 1 3  ? 33.780 0.768   52.590  1.00 0.00 ? 3  G   A C8    1 
+ATOM   59   N  N7    . G   A 1 3  ? 32.895 0.502   51.557  1.00 0.00 ? 3  G   A N7    1 
+ATOM   60   C  C5    . G   A 1 3  ? 33.242 -0.757  51.063  1.00 0.00 ? 3  G   A C5    1 
+ATOM   61   C  C6    . G   A 1 3  ? 32.769 -1.512  49.984  1.00 0.00 ? 3  G   A C6    1 
+ATOM   62   O  O6    . G   A 1 3  ? 31.672 -1.220  49.480  1.00 0.00 ? 3  G   A O6    1 
+ATOM   63   N  N1    . G   A 1 3  ? 33.324 -2.722  49.729  1.00 0.00 ? 3  G   A N1    1 
+ATOM   64   C  C2    . G   A 1 3  ? 34.329 -3.222  50.500  1.00 0.00 ? 3  G   A C2    1 
+ATOM   65   N  N2    . G   A 1 3  ? 34.868 -4.421  50.223  1.00 0.00 ? 3  G   A N2    1 
+ATOM   66   N  N3    . G   A 1 3  ? 34.799 -2.523  51.531  1.00 0.00 ? 3  G   A N3    1 
+ATOM   67   C  C4    . G   A 1 3  ? 34.267 -1.271  51.817  1.00 0.00 ? 3  G   A C4    1 
+ATOM   68   P  P     . G   A 1 4  ? 38.845 2.801   51.914  1.00 0.00 ? 4  G   A P     1 
+ATOM   69   O  OP1   . G   A 1 4  ? 40.096 3.590   52.097  1.00 0.00 ? 4  G   A OP1   1 
+ATOM   70   O  OP2   . G   A 1 4  ? 37.683 3.498   51.323  1.00 0.00 ? 4  G   A OP2   1 
+ATOM   71   O  "O5'" . G   A 1 4  ? 39.194 1.500   51.045  1.00 0.00 ? 4  G   A "O5'" 1 
+ATOM   72   C  "C5'" . G   A 1 4  ? 40.265 0.666   51.450  1.00 0.00 ? 4  G   A "C5'" 1 
+ATOM   73   C  "C4'" . G   A 1 4  ? 40.197 -0.601  50.604  1.00 0.00 ? 4  G   A "C4'" 1 
+ATOM   74   O  "O4'" . G   A 1 4  ? 38.950 -1.273  50.773  1.00 0.00 ? 4  G   A "O4'" 1 
+ATOM   75   C  "C3'" . G   A 1 4  ? 40.292 -0.239  49.132  1.00 0.00 ? 4  G   A "C3'" 1 
+ATOM   76   O  "O3'" . G   A 1 4  ? 41.675 -0.135  48.828  1.00 0.00 ? 4  G   A "O3'" 1 
+ATOM   77   C  "C2'" . G   A 1 4  ? 39.663 -1.486  48.505  1.00 0.00 ? 4  G   A "C2'" 1 
+ATOM   78   O  "O2'" . G   A 1 4  ? 40.590 -2.540  48.344  1.00 0.00 ? 4  G   A "O2'" 1 
+ATOM   79   C  "C1'" . G   A 1 4  ? 38.604 -1.895  49.532  1.00 0.00 ? 4  G   A "C1'" 1 
+ATOM   80   N  N9    . G   A 1 4  ? 37.351 -1.323  49.033  1.00 0.00 ? 4  G   A N9    1 
+ATOM   81   C  C8    . G   A 1 4  ? 36.749 -0.186  49.459  1.00 0.00 ? 4  G   A C8    1 
+ATOM   82   N  N7    . G   A 1 4  ? 35.590 -0.012  48.720  1.00 0.00 ? 4  G   A N7    1 
+ATOM   83   C  C5    . G   A 1 4  ? 35.532 -1.066  47.811  1.00 0.00 ? 4  G   A C5    1 
+ATOM   84   C  C6    . G   A 1 4  ? 34.556 -1.492  46.905  1.00 0.00 ? 4  G   A C6    1 
+ATOM   85   O  O6    . G   A 1 4  ? 33.608 -0.742  46.613  1.00 0.00 ? 4  G   A O6    1 
+ATOM   86   N  N1    . G   A 1 4  ? 34.787 -2.572  46.161  1.00 0.00 ? 4  G   A N1    1 
+ATOM   87   C  C2    . G   A 1 4  ? 35.922 -3.277  46.268  1.00 0.00 ? 4  G   A C2    1 
+ATOM   88   N  N2    . G   A 1 4  ? 36.180 -4.264  45.397  1.00 0.00 ? 4  G   A N2    1 
+ATOM   89   N  N3    . G   A 1 4  ? 36.841 -2.942  47.163  1.00 0.00 ? 4  G   A N3    1 
+ATOM   90   C  C4    . G   A 1 4  ? 36.644 -1.838  47.975  1.00 0.00 ? 4  G   A C4    1 
+ATOM   91   P  P     . A   A 1 5  ? 42.128 0.884   47.695  1.00 0.00 ? 5  A   A P     1 
+ATOM   92   O  OP1   . A   A 1 5  ? 43.613 1.004   47.614  1.00 0.00 ? 5  A   A OP1   1 
+ATOM   93   O  OP2   . A   A 1 5  ? 41.299 2.111   47.812  1.00 0.00 ? 5  A   A OP2   1 
+ATOM   94   O  "O5'" . A   A 1 5  ? 41.651 0.035   46.450  1.00 0.00 ? 5  A   A "O5'" 1 
+ATOM   95   C  "C5'" . A   A 1 5  ? 42.437 -1.057  46.016  1.00 0.00 ? 5  A   A "C5'" 1 
+ATOM   96   C  "C4'" . A   A 1 5  ? 41.635 -1.650  44.871  1.00 0.00 ? 5  A   A "C4'" 1 
+ATOM   97   O  "O4'" . A   A 1 5  ? 40.311 -1.830  45.348  1.00 0.00 ? 5  A   A "O4'" 1 
+ATOM   98   C  "C3'" . A   A 1 5  ? 41.473 -0.661  43.726  1.00 0.00 ? 5  A   A "C3'" 1 
+ATOM   99   O  "O3'" . A   A 1 5  ? 42.564 -0.739  42.828  1.00 0.00 ? 5  A   A "O3'" 1 
+ATOM   100  C  "C2'" . A   A 1 5  ? 40.323 -1.357  43.061  1.00 0.00 ? 5  A   A "C2'" 1 
+ATOM   101  O  "O2'" . A   A 1 5  ? 40.843 -2.565  42.582  1.00 0.00 ? 5  A   A "O2'" 1 
+ATOM   102  C  "C1'" . A   A 1 5  ? 39.448 -1.737  44.231  1.00 0.00 ? 5  A   A "C1'" 1 
+ATOM   103  N  N9    . A   A 1 5  ? 38.420 -0.702  44.464  1.00 0.00 ? 5  A   A N9    1 
+ATOM   104  C  C8    . A   A 1 5  ? 38.423 0.272   45.424  1.00 0.00 ? 5  A   A C8    1 
+ATOM   105  N  N7    . A   A 1 5  ? 37.216 0.950   45.366  1.00 0.00 ? 5  A   A N7    1 
+ATOM   106  C  C5    . A   A 1 5  ? 36.482 0.343   44.346  1.00 0.00 ? 5  A   A C5    1 
+ATOM   107  C  C6    . A   A 1 5  ? 35.163 0.493   43.904  1.00 0.00 ? 5  A   A C6    1 
+ATOM   108  N  N6    . A   A 1 5  ? 34.295 1.168   44.636  1.00 0.00 ? 5  A   A N6    1 
+ATOM   109  N  N1    . A   A 1 5  ? 34.718 -0.263  42.892  1.00 0.00 ? 5  A   A N1    1 
+ATOM   110  C  C2    . A   A 1 5  ? 35.498 -1.178  42.310  1.00 0.00 ? 5  A   A C2    1 
+ATOM   111  N  N3    . A   A 1 5  ? 36.742 -1.384  42.721  1.00 0.00 ? 5  A   A N3    1 
+ATOM   112  C  C4    . A   A 1 5  ? 37.254 -0.626  43.760  1.00 0.00 ? 5  A   A C4    1 
+ATOM   113  P  P     . U   A 1 6  ? 42.767 0.450   41.759  1.00 0.00 ? 6  U   A P     1 
+ATOM   114  O  OP1   . U   A 1 6  ? 43.994 0.174   40.981  1.00 0.00 ? 6  U   A OP1   1 
+ATOM   115  O  OP2   . U   A 1 6  ? 42.670 1.709   42.514  1.00 0.00 ? 6  U   A OP2   1 
+ATOM   116  O  "O5'" . U   A 1 6  ? 41.522 0.371   40.752  1.00 0.00 ? 6  U   A "O5'" 1 
+ATOM   117  C  "C5'" . U   A 1 6  ? 41.479 -0.627  39.741  1.00 0.00 ? 6  U   A "C5'" 1 
+ATOM   118  C  "C4'" . U   A 1 6  ? 40.165 -0.455  38.978  1.00 0.00 ? 6  U   A "C4'" 1 
+ATOM   119  O  "O4'" . U   A 1 6  ? 39.086 -0.468  39.903  1.00 0.00 ? 6  U   A "O4'" 1 
+ATOM   120  C  "C3'" . U   A 1 6  ? 40.066 0.913   38.327  1.00 0.00 ? 6  U   A "C3'" 1 
+ATOM   121  O  "O3'" . U   A 1 6  ? 40.808 0.975   37.109  1.00 0.00 ? 6  U   A "O3'" 1 
+ATOM   122  C  "C2'" . U   A 1 6  ? 38.567 0.896   38.063  1.00 0.00 ? 6  U   A "C2'" 1 
+ATOM   123  O  "O2'" . U   A 1 6  ? 38.326 -0.025  37.025  1.00 0.00 ? 6  U   A "O2'" 1 
+ATOM   124  C  "C1'" . U   A 1 6  ? 38.007 0.277   39.351  1.00 0.00 ? 6  U   A "C1'" 1 
+ATOM   125  N  N1    . U   A 1 6  ? 37.600 1.310   40.340  1.00 0.00 ? 6  U   A N1    1 
+ATOM   126  C  C2    . U   A 1 6  ? 36.338 1.770   40.360  1.00 0.00 ? 6  U   A C2    1 
+ATOM   127  O  O2    . U   A 1 6  ? 35.478 1.251   39.625  1.00 0.00 ? 6  U   A O2    1 
+ATOM   128  N  N3    . U   A 1 6  ? 35.959 2.694   41.269  1.00 0.00 ? 6  U   A N3    1 
+ATOM   129  C  C4    . U   A 1 6  ? 36.807 3.194   42.166  1.00 0.00 ? 6  U   A C4    1 
+ATOM   130  O  O4    . U   A 1 6  ? 36.355 3.674   43.222  1.00 0.00 ? 6  U   A O4    1 
+ATOM   131  C  C5    . U   A 1 6  ? 38.121 2.762   42.132  1.00 0.00 ? 6  U   A C5    1 
+ATOM   132  C  C6    . U   A 1 6  ? 38.495 1.800   41.193  1.00 0.00 ? 6  U   A C6    1 
+ATOM   133  P  P     . U   A 1 7  ? 41.128 2.411   36.444  1.00 0.00 ? 7  U   A P     1 
+ATOM   134  O  OP1   . U   A 1 7  ? 41.982 2.228   35.251  1.00 0.00 ? 7  U   A OP1   1 
+ATOM   135  O  OP2   . U   A 1 7  ? 41.556 3.349   37.496  1.00 0.00 ? 7  U   A OP2   1 
+ATOM   136  O  "O5'" . U   A 1 7  ? 39.741 2.907   35.857  1.00 0.00 ? 7  U   A "O5'" 1 
+ATOM   137  C  "C5'" . U   A 1 7  ? 39.151 2.237   34.758  1.00 0.00 ? 7  U   A "C5'" 1 
+ATOM   138  C  "C4'" . U   A 1 7  ? 37.856 2.971   34.421  1.00 0.00 ? 7  U   A "C4'" 1 
+ATOM   139  O  "O4'" . U   A 1 7  ? 37.201 3.209   35.661  1.00 0.00 ? 7  U   A "O4'" 1 
+ATOM   140  C  "C3'" . U   A 1 7  ? 38.181 4.350   33.843  1.00 0.00 ? 7  U   A "C3'" 1 
+ATOM   141  O  "O3'" . U   A 1 7  ? 37.253 4.663   32.823  1.00 0.00 ? 7  U   A "O3'" 1 
+ATOM   142  C  "C2'" . U   A 1 7  ? 37.939 5.319   34.969  1.00 0.00 ? 7  U   A "C2'" 1 
+ATOM   143  O  "O2'" . U   A 1 7  ? 37.441 6.510   34.348  1.00 0.00 ? 7  U   A "O2'" 1 
+ATOM   144  C  "C1'" . U   A 1 7  ? 36.824 4.578   35.717  1.00 0.00 ? 7  U   A "C1'" 1 
+ATOM   145  N  N1    . U   A 1 7  ? 36.714 5.012   37.134  1.00 0.00 ? 7  U   A N1    1 
+ATOM   146  C  C2    . U   A 1 7  ? 35.568 5.559   37.594  1.00 0.00 ? 7  U   A C2    1 
+ATOM   147  O  O2    . U   A 1 7  ? 34.571 5.614   36.871  1.00 0.00 ? 7  U   A O2    1 
+ATOM   148  N  N3    . U   A 1 7  ? 35.452 5.971   38.843  1.00 0.00 ? 7  U   A N3    1 
+ATOM   149  C  C4    . U   A 1 7  ? 36.441 5.830   39.705  1.00 0.00 ? 7  U   A C4    1 
+ATOM   150  O  O4    . U   A 1 7  ? 36.233 6.062   40.903  1.00 0.00 ? 7  U   A O4    1 
+ATOM   151  C  C5    . U   A 1 7  ? 37.621 5.192   39.299  1.00 0.00 ? 7  U   A C5    1 
+ATOM   152  C  C6    . U   A 1 7  ? 37.716 4.754   37.969  1.00 0.00 ? 7  U   A C6    1 
+ATOM   153  P  P     . U   A 1 8  ? 37.555 4.171   31.327  1.00 0.00 ? 8  U   A P     1 
+ATOM   154  O  OP1   . U   A 1 8  ? 36.381 4.530   30.514  1.00 0.00 ? 8  U   A OP1   1 
+ATOM   155  O  OP2   . U   A 1 8  ? 38.033 2.778   31.309  1.00 0.00 ? 8  U   A OP2   1 
+ATOM   156  O  "O5'" . U   A 1 8  ? 38.765 5.141   30.925  1.00 0.00 ? 8  U   A "O5'" 1 
+ATOM   157  C  "C5'" . U   A 1 8  ? 38.506 6.496   30.557  1.00 0.00 ? 8  U   A "C5'" 1 
+ATOM   158  C  "C4'" . U   A 1 8  ? 39.756 7.096   29.890  1.00 0.00 ? 8  U   A "C4'" 1 
+ATOM   159  O  "O4'" . U   A 1 8  ? 40.921 6.762   30.627  1.00 0.00 ? 8  U   A "O4'" 1 
+ATOM   160  C  "C3'" . U   A 1 8  ? 40.012 6.418   28.558  1.00 0.00 ? 8  U   A "C3'" 1 
+ATOM   161  O  "O3'" . U   A 1 8  ? 39.103 6.793   27.527  1.00 0.00 ? 8  U   A "O3'" 1 
+ATOM   162  C  "C2'" . U   A 1 8  ? 41.432 6.833   28.305  1.00 0.00 ? 8  U   A "C2'" 1 
+ATOM   163  O  "O2'" . U   A 1 8  ? 41.469 8.186   27.991  1.00 0.00 ? 8  U   A "O2'" 1 
+ATOM   164  C  "C1'" . U   A 1 8  ? 42.014 6.669   29.700  1.00 0.00 ? 8  U   A "C1'" 1 
+ATOM   165  N  N1    . U   A 1 8  ? 42.516 5.302   29.862  1.00 0.00 ? 8  U   A N1    1 
+ATOM   166  C  C2    . U   A 1 8  ? 43.639 4.876   29.234  1.00 0.00 ? 8  U   A C2    1 
+ATOM   167  O  O2    . U   A 1 8  ? 44.374 5.675   28.646  1.00 0.00 ? 8  U   A O2    1 
+ATOM   168  N  N3    . U   A 1 8  ? 44.087 3.647   29.437  1.00 0.00 ? 8  U   A N3    1 
+ATOM   169  C  C4    . U   A 1 8  ? 43.467 2.812   30.258  1.00 0.00 ? 8  U   A C4    1 
+ATOM   170  O  O4    . U   A 1 8  ? 44.139 1.949   30.820  1.00 0.00 ? 8  U   A O4    1 
+ATOM   171  C  C5    . U   A 1 8  ? 42.301 3.227   30.892  1.00 0.00 ? 8  U   A C5    1 
+ATOM   172  C  C6    . U   A 1 8  ? 41.850 4.505   30.668  1.00 0.00 ? 8  U   A C6    1 
+ATOM   173  P  P     . A   A 1 9  ? 38.558 5.617   26.671  1.00 0.00 ? 9  A   A P     1 
+ATOM   174  O  OP1   . A   A 1 9  ? 37.182 5.414   26.889  1.00 0.00 ? 9  A   A OP1   1 
+ATOM   175  O  OP2   . A   A 1 9  ? 39.447 4.547   26.815  1.00 0.00 ? 9  A   A OP2   1 
+ATOM   176  O  "O5'" . A   A 1 9  ? 38.800 6.208   25.232  1.00 0.00 ? 9  A   A "O5'" 1 
+ATOM   177  C  "C5'" . A   A 1 9  ? 38.070 7.314   24.745  1.00 0.00 ? 9  A   A "C5'" 1 
+ATOM   178  C  "C4'" . A   A 1 9  ? 38.039 7.190   23.227  1.00 0.00 ? 9  A   A "C4'" 1 
+ATOM   179  O  "O4'" . A   A 1 9  ? 39.378 7.115   22.750  1.00 0.00 ? 9  A   A "O4'" 1 
+ATOM   180  C  "C3'" . A   A 1 9  ? 37.380 5.857   22.827  1.00 0.00 ? 9  A   A "C3'" 1 
+ATOM   181  O  "O3'" . A   A 1 9  ? 36.632 6.096   21.655  1.00 0.00 ? 9  A   A "O3'" 1 
+ATOM   182  C  "C2'" . A   A 1 9  ? 38.551 4.973   22.442  1.00 0.00 ? 9  A   A "C2'" 1 
+ATOM   183  O  "O2'" . A   A 1 9  ? 38.152 4.125   21.394  1.00 0.00 ? 9  A   A "O2'" 1 
+ATOM   184  C  "C1'" . A   A 1 9  ? 39.461 6.015   21.854  1.00 0.00 ? 9  A   A "C1'" 1 
+ATOM   185  N  N9    . A   A 1 9  ? 40.814 5.457   21.830  1.00 0.00 ? 9  A   A N9    1 
+ATOM   186  C  C8    . A   A 1 9  ? 41.194 4.275   22.388  1.00 0.00 ? 9  A   A C8    1 
+ATOM   187  N  N7    . A   A 1 9  ? 42.541 4.093   22.149  1.00 0.00 ? 9  A   A N7    1 
+ATOM   188  C  C5    . A   A 1 9  ? 42.958 5.198   21.414  1.00 0.00 ? 9  A   A C5    1 
+ATOM   189  C  C6    . A   A 1 9  ? 44.193 5.553   20.877  1.00 0.00 ? 9  A   A C6    1 
+ATOM   190  N  N6    . A   A 1 9  ? 45.271 4.852   21.208  1.00 0.00 ? 9  A   A N6    1 
+ATOM   191  N  N1    . A   A 1 9  ? 44.309 6.688   20.177  1.00 0.00 ? 9  A   A N1    1 
+ATOM   192  C  C2    . A   A 1 9  ? 43.255 7.491   19.989  1.00 0.00 ? 9  A   A C2    1 
+ATOM   193  N  N3    . A   A 1 9  ? 42.066 7.197   20.494  1.00 0.00 ? 9  A   A N3    1 
+ATOM   194  C  C4    . A   A 1 9  ? 41.898 6.034   21.217  1.00 0.00 ? 9  A   A C4    1 
+HETATM 195  P  P     . 2MG A 1 10 ? 35.095 6.450   21.753  1.00 0.00 ? 10 2MG A P     1 
+HETATM 196  O  OP1   . 2MG A 1 10 ? 34.668 7.135   20.522  1.00 0.00 ? 10 2MG A OP1   1 
+HETATM 197  O  OP2   . 2MG A 1 10 ? 34.778 7.058   23.064  1.00 0.00 ? 10 2MG A OP2   1 
+HETATM 198  O  "O5'" . 2MG A 1 10 ? 34.521 4.979   21.607  1.00 0.00 ? 10 2MG A "O5'" 1 
+HETATM 199  C  "C5'" . 2MG A 1 10 ? 33.115 4.830   21.622  1.00 0.00 ? 10 2MG A "C5'" 1 
+HETATM 200  C  "C4'" . 2MG A 1 10 ? 32.816 3.488   20.998  1.00 0.00 ? 10 2MG A "C4'" 1 
+HETATM 201  O  "O4'" . 2MG A 1 10 ? 33.325 3.452   19.680  1.00 0.00 ? 10 2MG A "O4'" 1 
+HETATM 202  C  "C3'" . 2MG A 1 10 ? 33.521 2.390   21.759  1.00 0.00 ? 10 2MG A "C3'" 1 
+HETATM 203  O  "O3'" . 2MG A 1 10 ? 32.635 2.052   22.821  1.00 0.00 ? 10 2MG A "O3'" 1 
+HETATM 204  C  "C2'" . 2MG A 1 10 ? 33.538 1.316   20.689  1.00 0.00 ? 10 2MG A "C2'" 1 
+HETATM 205  O  "O2'" . 2MG A 1 10 ? 32.224 0.811   20.600  1.00 0.00 ? 10 2MG A "O2'" 1 
+HETATM 206  C  "C1'" . 2MG A 1 10 ? 33.799 2.135   19.422  1.00 0.00 ? 10 2MG A "C1'" 1 
+HETATM 207  N  N9    . 2MG A 1 10 ? 35.239 2.318   19.178  1.00 0.00 ? 10 2MG A N9    1 
+HETATM 208  C  C8    . 2MG A 1 10 ? 35.845 3.518   19.010  1.00 0.00 ? 10 2MG A C8    1 
+HETATM 209  N  N7    . 2MG A 1 10 ? 37.186 3.308   18.791  1.00 0.00 ? 10 2MG A N7    1 
+HETATM 210  C  C5    . 2MG A 1 10 ? 37.354 1.927   18.736  1.00 0.00 ? 10 2MG A C5    1 
+HETATM 211  C  C6    . 2MG A 1 10 ? 38.473 1.125   18.520  1.00 0.00 ? 10 2MG A C6    1 
+HETATM 212  O  O6    . 2MG A 1 10 ? 39.522 1.644   18.124  1.00 0.00 ? 10 2MG A O6    1 
+HETATM 213  N  N1    . 2MG A 1 10 ? 38.340 -0.191  18.462  1.00 0.00 ? 10 2MG A N1    1 
+HETATM 214  C  C2    . 2MG A 1 10 ? 37.154 -0.778  18.601  1.00 0.00 ? 10 2MG A C2    1 
+HETATM 215  N  N2    . 2MG A 1 10 ? 37.107 -2.099  18.763  1.00 0.00 ? 10 2MG A N2    1 
+HETATM 216  C  CM2   . 2MG A 1 10 ? 35.812 -2.765  18.885  1.00 0.00 ? 10 2MG A CM2   1 
+HETATM 217  N  N3    . 2MG A 1 10 ? 36.061 -0.051  18.830  1.00 0.00 ? 10 2MG A N3    1 
+HETATM 218  C  C4    . 2MG A 1 10 ? 36.149 1.323   18.918  1.00 0.00 ? 10 2MG A C4    1 
+ATOM   219  P  P     . C   A 1 11 ? 33.284 1.751   24.235  1.00 0.00 ? 11 C   A P     1 
+ATOM   220  O  OP1   . C   A 1 11 ? 32.252 1.897   25.278  1.00 0.00 ? 11 C   A OP1   1 
+ATOM   221  O  OP2   . C   A 1 11 ? 34.556 2.501   24.359  1.00 0.00 ? 11 C   A OP2   1 
+ATOM   222  O  "O5'" . C   A 1 11 ? 33.680 0.227   24.076  1.00 0.00 ? 11 C   A "O5'" 1 
+ATOM   223  C  "C5'" . C   A 1 11 ? 32.731 -0.816  23.990  1.00 0.00 ? 11 C   A "C5'" 1 
+ATOM   224  C  "C4'" . C   A 1 11 ? 33.585 -2.065  23.729  1.00 0.00 ? 11 C   A "C4'" 1 
+ATOM   225  O  "O4'" . C   A 1 11 ? 34.364 -1.811  22.569  1.00 0.00 ? 11 C   A "O4'" 1 
+ATOM   226  C  "C3'" . C   A 1 11 ? 34.625 -2.318  24.833  1.00 0.00 ? 11 C   A "C3'" 1 
+ATOM   227  O  "O3'" . C   A 1 11 ? 34.085 -3.176  25.844  1.00 0.00 ? 11 C   A "O3'" 1 
+ATOM   228  C  "C2'" . C   A 1 11 ? 35.624 -3.148  24.041  1.00 0.00 ? 11 C   A "C2'" 1 
+ATOM   229  O  "O2'" . C   A 1 11 ? 35.097 -4.445  23.948  1.00 0.00 ? 11 C   A "O2'" 1 
+ATOM   230  C  "C1'" . C   A 1 11 ? 35.570 -2.576  22.635  1.00 0.00 ? 11 C   A "C1'" 1 
+ATOM   231  N  N1    . C   A 1 11 ? 36.688 -1.640  22.420  1.00 0.00 ? 11 C   A N1    1 
+ATOM   232  C  C2    . C   A 1 11 ? 37.924 -2.093  22.139  1.00 0.00 ? 11 C   A C2    1 
+ATOM   233  O  O2    . C   A 1 11 ? 38.153 -3.314  22.152  1.00 0.00 ? 11 C   A O2    1 
+ATOM   234  N  N3    . C   A 1 11 ? 38.944 -1.234  21.937  1.00 0.00 ? 11 C   A N3    1 
+ATOM   235  C  C4    . C   A 1 11 ? 38.736 0.082   21.994  1.00 0.00 ? 11 C   A C4    1 
+ATOM   236  N  N4    . C   A 1 11 ? 39.692 0.934   21.676  1.00 0.00 ? 11 C   A N4    1 
+ATOM   237  C  C5    . C   A 1 11 ? 37.464 0.561   22.239  1.00 0.00 ? 11 C   A C5    1 
+ATOM   238  C  C6    . C   A 1 11 ? 36.439 -0.347  22.433  1.00 0.00 ? 11 C   A C6    1 
+ATOM   239  P  P     . U   A 1 12 ? 34.783 -3.267  27.298  1.00 0.00 ? 12 U   A P     1 
+ATOM   240  O  OP1   . U   A 1 12 ? 34.001 -4.179  28.122  1.00 0.00 ? 12 U   A OP1   1 
+ATOM   241  O  OP2   . U   A 1 12 ? 34.934 -1.888  27.776  1.00 0.00 ? 12 U   A OP2   1 
+ATOM   242  O  "O5'" . U   A 1 12 ? 36.212 -3.940  27.034  1.00 0.00 ? 12 U   A "O5'" 1 
+ATOM   243  C  "C5'" . U   A 1 12 ? 36.395 -5.332  27.273  1.00 0.00 ? 12 U   A "C5'" 1 
+ATOM   244  C  "C4'" . U   A 1 12 ? 37.888 -5.609  27.068  1.00 0.00 ? 12 U   A "C4'" 1 
+ATOM   245  O  "O4'" . U   A 1 12 ? 38.247 -4.914  25.885  1.00 0.00 ? 12 U   A "O4'" 1 
+ATOM   246  C  "C3'" . U   A 1 12 ? 38.732 -4.877  28.107  1.00 0.00 ? 12 U   A "C3'" 1 
+ATOM   247  O  "O3'" . U   A 1 12 ? 38.938 -5.638  29.283  1.00 0.00 ? 12 U   A "O3'" 1 
+ATOM   248  C  "C2'" . U   A 1 12 ? 40.047 -4.884  27.363  1.00 0.00 ? 12 U   A "C2'" 1 
+ATOM   249  O  "O2'" . U   A 1 12 ? 40.515 -6.205  27.345  1.00 0.00 ? 12 U   A "O2'" 1 
+ATOM   250  C  "C1'" . U   A 1 12 ? 39.627 -4.594  25.946  1.00 0.00 ? 12 U   A "C1'" 1 
+ATOM   251  N  N1    . U   A 1 12 ? 39.843 -3.171  25.604  1.00 0.00 ? 12 U   A N1    1 
+ATOM   252  C  C2    . U   A 1 12 ? 41.002 -2.817  25.048  1.00 0.00 ? 12 U   A C2    1 
+ATOM   253  O  O2    . U   A 1 12 ? 41.962 -3.600  25.151  1.00 0.00 ? 12 U   A O2    1 
+ATOM   254  N  N3    . U   A 1 12 ? 41.235 -1.547  24.683  1.00 0.00 ? 12 U   A N3    1 
+ATOM   255  C  C4    . U   A 1 12 ? 40.335 -0.603  24.898  1.00 0.00 ? 12 U   A C4    1 
+ATOM   256  O  O4    . U   A 1 12 ? 40.543 0.568   24.525  1.00 0.00 ? 12 U   A O4    1 
+ATOM   257  C  C5    . U   A 1 12 ? 39.141 -0.939  25.528  1.00 0.00 ? 12 U   A C5    1 
+ATOM   258  C  C6    . U   A 1 12 ? 38.923 -2.263  25.882  1.00 0.00 ? 12 U   A C6    1 
+ATOM   259  P  P     . C   A 1 13 ? 39.176 -4.864  30.657  1.00 0.00 ? 13 C   A P     1 
+ATOM   260  O  OP1   . C   A 1 13 ? 39.427 -5.838  31.740  1.00 0.00 ? 13 C   A OP1   1 
+ATOM   261  O  OP2   . C   A 1 13 ? 38.024 -3.940  30.762  1.00 0.00 ? 13 C   A OP2   1 
+ATOM   262  O  "O5'" . C   A 1 13 ? 40.498 -4.001  30.449  1.00 0.00 ? 13 C   A "O5'" 1 
+ATOM   263  C  "C5'" . C   A 1 13 ? 41.734 -4.546  30.868  1.00 0.00 ? 13 C   A "C5'" 1 
+ATOM   264  C  "C4'" . C   A 1 13 ? 42.875 -3.866  30.117  1.00 0.00 ? 13 C   A "C4'" 1 
+ATOM   265  O  "O4'" . C   A 1 13 ? 42.391 -3.180  28.982  1.00 0.00 ? 13 C   A "O4'" 1 
+ATOM   266  C  "C3'" . C   A 1 13 ? 43.615 -2.756  30.849  1.00 0.00 ? 13 C   A "C3'" 1 
+ATOM   267  O  "O3'" . C   A 1 13 ? 44.491 -3.300  31.817  1.00 0.00 ? 13 C   A "O3'" 1 
+ATOM   268  C  "C2'" . C   A 1 13 ? 44.472 -2.320  29.664  1.00 0.00 ? 13 C   A "C2'" 1 
+ATOM   269  O  "O2'" . C   A 1 13 ? 45.453 -3.307  29.490  1.00 0.00 ? 13 C   A "O2'" 1 
+ATOM   270  C  "C1'" . C   A 1 13 ? 43.504 -2.435  28.483  1.00 0.00 ? 13 C   A "C1'" 1 
+ATOM   271  N  N1    . C   A 1 13 ? 43.017 -1.099  28.151  1.00 0.00 ? 13 C   A N1    1 
+ATOM   272  C  C2    . C   A 1 13 ? 43.798 -0.257  27.476  1.00 0.00 ? 13 C   A C2    1 
+ATOM   273  O  O2    . C   A 1 13 ? 44.959 -0.597  27.203  1.00 0.00 ? 13 C   A O2    1 
+ATOM   274  N  N3    . C   A 1 13 ? 43.373 0.964   27.144  1.00 0.00 ? 13 C   A N3    1 
+ATOM   275  C  C4    . C   A 1 13 ? 42.163 1.383   27.539  1.00 0.00 ? 13 C   A C4    1 
+ATOM   276  N  N4    . C   A 1 13 ? 41.621 2.503   27.033  1.00 0.00 ? 13 C   A N4    1 
+ATOM   277  C  C5    . C   A 1 13 ? 41.377 0.545   28.311  1.00 0.00 ? 13 C   A C5    1 
+ATOM   278  C  C6    . C   A 1 13 ? 41.847 -0.715  28.614  1.00 0.00 ? 13 C   A C6    1 
+ATOM   279  P  P     . A   A 1 14 ? 45.320 -2.380  32.826  1.00 0.00 ? 14 A   A P     1 
+ATOM   280  O  OP1   . A   A 1 14 ? 45.945 -3.316  33.790  1.00 0.00 ? 14 A   A OP1   1 
+ATOM   281  O  OP2   . A   A 1 14 ? 44.464 -1.295  33.340  1.00 0.00 ? 14 A   A OP2   1 
+ATOM   282  O  "O5'" . A   A 1 14 ? 46.448 -1.667  31.967  1.00 0.00 ? 14 A   A "O5'" 1 
+ATOM   283  C  "C5'" . A   A 1 14 ? 47.595 -2.369  31.504  1.00 0.00 ? 14 A   A "C5'" 1 
+ATOM   284  C  "C4'" . A   A 1 14 ? 48.555 -1.472  30.675  1.00 0.00 ? 14 A   A "C4'" 1 
+ATOM   285  O  "O4'" . A   A 1 14 ? 47.954 -0.806  29.579  1.00 0.00 ? 14 A   A "O4'" 1 
+ATOM   286  C  "C3'" . A   A 1 14 ? 49.181 -0.324  31.439  1.00 0.00 ? 14 A   A "C3'" 1 
+ATOM   287  O  "O3'" . A   A 1 14 ? 50.133 -0.821  32.358  1.00 0.00 ? 14 A   A "O3'" 1 
+ATOM   288  C  "C2'" . A   A 1 14 ? 49.893 0.340   30.274  1.00 0.00 ? 14 A   A "C2'" 1 
+ATOM   289  O  "O2'" . A   A 1 14 ? 51.067 -0.352  29.926  1.00 0.00 ? 14 A   A "O2'" 1 
+ATOM   290  C  "C1'" . A   A 1 14 ? 48.908 0.151   29.142  1.00 0.00 ? 14 A   A "C1'" 1 
+ATOM   291  N  N9    . A   A 1 14 ? 48.240 1.414   28.953  1.00 0.00 ? 14 A   A N9    1 
+ATOM   292  C  C8    . A   A 1 14 ? 46.966 1.665   29.277  1.00 0.00 ? 14 A   A C8    1 
+ATOM   293  N  N7    . A   A 1 14 ? 46.679 2.954   28.906  1.00 0.00 ? 14 A   A N7    1 
+ATOM   294  C  C5    . A   A 1 14 ? 47.850 3.493   28.357  1.00 0.00 ? 14 A   A C5    1 
+ATOM   295  C  C6    . A   A 1 14 ? 48.151 4.740   27.798  1.00 0.00 ? 14 A   A C6    1 
+ATOM   296  N  N6    . A   A 1 14 ? 47.226 5.695   27.752  1.00 0.00 ? 14 A   A N6    1 
+ATOM   297  N  N1    . A   A 1 14 ? 49.360 4.965   27.312  1.00 0.00 ? 14 A   A N1    1 
+ATOM   298  C  C2    . A   A 1 14 ? 50.304 4.020   27.353  1.00 0.00 ? 14 A   A C2    1 
+ATOM   299  N  N3    . A   A 1 14 ? 50.063 2.824   27.891  1.00 0.00 ? 14 A   A N3    1 
+ATOM   300  C  C4    . A   A 1 14 ? 48.817 2.543   28.409  1.00 0.00 ? 14 A   A C4    1 
+ATOM   301  P  P     . G   A 1 15 ? 50.299 -0.095  33.766  1.00 0.00 ? 15 G   A P     1 
+ATOM   302  O  OP1   . G   A 1 15 ? 51.313 -0.857  34.527  1.00 0.00 ? 15 G   A OP1   1 
+ATOM   303  O  OP2   . G   A 1 15 ? 48.941 0.101   34.347  1.00 0.00 ? 15 G   A OP2   1 
+ATOM   304  O  "O5'" . G   A 1 15 ? 50.845 1.366   33.390  1.00 0.00 ? 15 G   A "O5'" 1 
+ATOM   305  C  "C5'" . G   A 1 15 ? 52.162 1.593   32.937  1.00 0.00 ? 15 G   A "C5'" 1 
+ATOM   306  C  "C4'" . G   A 1 15 ? 52.179 2.963   32.252  1.00 0.00 ? 15 G   A "C4'" 1 
+ATOM   307  O  "O4'" . G   A 1 15 ? 51.108 3.049   31.324  1.00 0.00 ? 15 G   A "O4'" 1 
+ATOM   308  C  "C3'" . G   A 1 15 ? 51.867 4.059   33.205  1.00 0.00 ? 15 G   A "C3'" 1 
+ATOM   309  O  "O3'" . G   A 1 15 ? 52.975 4.415   33.989  1.00 0.00 ? 15 G   A "O3'" 1 
+ATOM   310  C  "C2'" . G   A 1 15 ? 51.513 5.160   32.225  1.00 0.00 ? 15 G   A "C2'" 1 
+ATOM   311  O  "O2'" . G   A 1 15 ? 52.662 5.692   31.646  1.00 0.00 ? 15 G   A "O2'" 1 
+ATOM   312  C  "C1'" . G   A 1 15 ? 50.739 4.417   31.162  1.00 0.00 ? 15 G   A "C1'" 1 
+ATOM   313  N  N9    . G   A 1 15 ? 49.312 4.566   31.523  1.00 0.00 ? 15 G   A N9    1 
+ATOM   314  C  C8    . G   A 1 15 ? 48.568 3.660   32.213  1.00 0.00 ? 15 G   A C8    1 
+ATOM   315  N  N7    . G   A 1 15 ? 47.309 4.162   32.382  1.00 0.00 ? 15 G   A N7    1 
+ATOM   316  C  C5    . G   A 1 15 ? 47.290 5.404   31.760  1.00 0.00 ? 15 G   A C5    1 
+ATOM   317  C  C6    . G   A 1 15 ? 46.293 6.359   31.607  1.00 0.00 ? 15 G   A C6    1 
+ATOM   318  O  O6    . G   A 1 15 ? 45.212 6.221   32.206  1.00 0.00 ? 15 G   A O6    1 
+ATOM   319  N  N1    . G   A 1 15 ? 46.546 7.474   30.904  1.00 0.00 ? 15 G   A N1    1 
+ATOM   320  C  C2    . G   A 1 15 ? 47.752 7.700   30.350  1.00 0.00 ? 15 G   A C2    1 
+ATOM   321  N  N2    . G   A 1 15 ? 47.843 8.608   29.402  1.00 0.00 ? 15 G   A N2    1 
+ATOM   322  N  N3    . G   A 1 15 ? 48.739 6.827   30.499  1.00 0.00 ? 15 G   A N3    1 
+ATOM   323  C  C4    . G   A 1 15 ? 48.517 5.650   31.207  1.00 0.00 ? 15 G   A C4    1 
+HETATM 324  P  P     . H2U A 1 16 ? 52.658 5.174   35.325  1.00 0.00 ? 16 H2U A P     1 
+HETATM 325  O  OP1   . H2U A 1 16 ? 52.078 4.251   36.292  1.00 0.00 ? 16 H2U A OP1   1 
+HETATM 326  O  OP2   . H2U A 1 16 ? 51.980 6.391   35.002  1.00 0.00 ? 16 H2U A OP2   1 
+HETATM 327  O  "O5'" . H2U A 1 16 ? 54.065 5.545   35.771  1.00 0.00 ? 16 H2U A "O5'" 1 
+HETATM 328  C  "C5'" . H2U A 1 16 ? 54.861 6.286   34.887  1.00 0.00 ? 16 H2U A "C5'" 1 
+HETATM 329  C  "C4'" . H2U A 1 16 ? 55.699 7.273   35.679  1.00 0.00 ? 16 H2U A "C4'" 1 
+HETATM 330  O  "O4'" . H2U A 1 16 ? 54.879 8.305   36.210  1.00 0.00 ? 16 H2U A "O4'" 1 
+HETATM 331  C  "C3'" . H2U A 1 16 ? 56.362 6.591   36.874  1.00 0.00 ? 16 H2U A "C3'" 1 
+HETATM 332  O  "O3'" . H2U A 1 16 ? 57.486 7.390   37.186  1.00 0.00 ? 16 H2U A "O3'" 1 
+HETATM 333  C  "C1'" . H2U A 1 16 ? 54.660 8.078   37.604  1.00 0.00 ? 16 H2U A "C1'" 1 
+HETATM 334  C  "C2'" . H2U A 1 16 ? 55.307 6.748   37.970  1.00 0.00 ? 16 H2U A "C2'" 1 
+HETATM 335  O  "O2'" . H2U A 1 16 ? 55.865 6.809   39.269  1.00 0.00 ? 16 H2U A "O2'" 1 
+HETATM 336  N  N1    . H2U A 1 16 ? 53.222 7.997   37.854  1.00 0.00 ? 16 H2U A N1    1 
+HETATM 337  C  C2    . H2U A 1 16 ? 52.571 9.114   38.058  1.00 0.00 ? 16 H2U A C2    1 
+HETATM 338  O  O2    . H2U A 1 16 ? 53.193 10.070  38.533  1.00 0.00 ? 16 H2U A O2    1 
+HETATM 339  N  N3    . H2U A 1 16 ? 51.255 9.093   38.204  1.00 0.00 ? 16 H2U A N3    1 
+HETATM 340  C  C4    . H2U A 1 16 ? 50.554 7.974   38.166  1.00 0.00 ? 16 H2U A C4    1 
+HETATM 341  O  O4    . H2U A 1 16 ? 49.321 8.020   38.095  1.00 0.00 ? 16 H2U A O4    1 
+HETATM 342  C  C5    . H2U A 1 16 ? 51.237 6.667   37.975  1.00 0.00 ? 16 H2U A C5    1 
+HETATM 343  C  C6    . H2U A 1 16 ? 52.678 6.774   38.429  1.00 0.00 ? 16 H2U A C6    1 
+HETATM 344  P  P     . H2U A 1 17 ? 58.783 7.380   36.302  1.00 0.00 ? 17 H2U A P     1 
+HETATM 345  O  OP1   . H2U A 1 17 ? 58.524 7.308   34.863  1.00 0.00 ? 17 H2U A OP1   1 
+HETATM 346  O  OP2   . H2U A 1 17 ? 59.677 6.443   36.958  1.00 0.00 ? 17 H2U A OP2   1 
+HETATM 347  O  "O5'" . H2U A 1 17 ? 59.225 8.856   36.605  1.00 0.00 ? 17 H2U A "O5'" 1 
+HETATM 348  C  "C5'" . H2U A 1 17 ? 59.096 9.318   37.936  1.00 0.00 ? 17 H2U A "C5'" 1 
+HETATM 349  C  "C4'" . H2U A 1 17 ? 59.075 10.841  37.981  1.00 0.00 ? 17 H2U A "C4'" 1 
+HETATM 350  O  "O4'" . H2U A 1 17 ? 60.315 11.374  37.536  1.00 0.00 ? 17 H2U A "O4'" 1 
+HETATM 351  C  "C3'" . H2U A 1 17 ? 58.006 11.343  37.039  1.00 0.00 ? 17 H2U A "C3'" 1 
+HETATM 352  O  "O3'" . H2U A 1 17 ? 57.404 12.456  37.686  1.00 0.00 ? 17 H2U A "O3'" 1 
+HETATM 353  C  "C1'" . H2U A 1 17 ? 60.124 12.192  36.389  1.00 0.00 ? 17 H2U A "C1'" 1 
+HETATM 354  C  "C2'" . H2U A 1 17 ? 58.810 11.722  35.800  1.00 0.00 ? 17 H2U A "C2'" 1 
+HETATM 355  O  "O2'" . H2U A 1 17 ? 58.176 12.781  35.127  1.00 0.00 ? 17 H2U A "O2'" 1 
+HETATM 356  N  N1    . H2U A 1 17 ? 61.280 12.038  35.466  1.00 0.00 ? 17 H2U A N1    1 
+HETATM 357  C  C2    . H2U A 1 17 ? 62.322 12.870  35.539  1.00 0.00 ? 17 H2U A C2    1 
+HETATM 358  O  O2    . H2U A 1 17 ? 62.227 13.920  36.170  1.00 0.00 ? 17 H2U A O2    1 
+HETATM 359  N  N3    . H2U A 1 17 ? 63.395 12.682  34.780  1.00 0.00 ? 17 H2U A N3    1 
+HETATM 360  C  C4    . H2U A 1 17 ? 63.503 11.629  33.992  1.00 0.00 ? 17 H2U A C4    1 
+HETATM 361  O  O4    . H2U A 1 17 ? 64.559 11.423  33.387  1.00 0.00 ? 17 H2U A O4    1 
+HETATM 362  C  C5    . H2U A 1 17 ? 62.424 10.596  33.977  1.00 0.00 ? 17 H2U A C5    1 
+HETATM 363  C  C6    . H2U A 1 17 ? 61.109 11.294  34.250  1.00 0.00 ? 17 H2U A C6    1 
+ATOM   364  P  P     . G   A 1 18 ? 56.153 12.293  38.707  1.00 0.00 ? 18 G   A P     1 
+ATOM   365  O  OP1   . G   A 1 18 ? 56.056 13.436  39.635  1.00 0.00 ? 18 G   A OP1   1 
+ATOM   366  O  OP2   . G   A 1 18 ? 56.118 10.952  39.307  1.00 0.00 ? 18 G   A OP2   1 
+ATOM   367  O  "O5'" . G   A 1 18 ? 54.999 12.483  37.624  1.00 0.00 ? 18 G   A "O5'" 1 
+ATOM   368  C  "C5'" . G   A 1 18 ? 54.165 13.626  37.748  1.00 0.00 ? 18 G   A "C5'" 1 
+ATOM   369  C  "C4'" . G   A 1 18 ? 53.964 14.366  36.416  1.00 0.00 ? 18 G   A "C4'" 1 
+ATOM   370  O  "O4'" . G   A 1 18 ? 53.364 15.610  36.763  1.00 0.00 ? 18 G   A "O4'" 1 
+ATOM   371  C  "C3'" . G   A 1 18 ? 55.328 14.792  35.868  1.00 0.00 ? 18 G   A "C3'" 1 
+ATOM   372  O  "O3'" . G   A 1 18 ? 55.145 15.448  34.623  1.00 0.00 ? 18 G   A "O3'" 1 
+ATOM   373  C  "C2'" . G   A 1 18 ? 55.767 15.871  36.845  1.00 0.00 ? 18 G   A "C2'" 1 
+ATOM   374  O  "O2'" . G   A 1 18 ? 56.648 16.753  36.148  1.00 0.00 ? 18 G   A "O2'" 1 
+ATOM   375  C  "C1'" . G   A 1 18 ? 54.414 16.537  37.011  1.00 0.00 ? 18 G   A "C1'" 1 
+ATOM   376  N  N9    . G   A 1 18 ? 54.221 17.314  38.228  1.00 0.00 ? 18 G   A N9    1 
+ATOM   377  C  C8    . G   A 1 18 ? 54.921 17.231  39.395  1.00 0.00 ? 18 G   A C8    1 
+ATOM   378  N  N7    . G   A 1 18 ? 54.414 18.198  40.267  1.00 0.00 ? 18 G   A N7    1 
+ATOM   379  C  C5    . G   A 1 18 ? 53.419 18.878  39.558  1.00 0.00 ? 18 G   A C5    1 
+ATOM   380  C  C6    . G   A 1 18 ? 52.635 20.003  39.830  1.00 0.00 ? 18 G   A C6    1 
+ATOM   381  O  O6    . G   A 1 18 ? 52.927 20.748  40.770  1.00 0.00 ? 18 G   A O6    1 
+ATOM   382  N  N1    . G   A 1 18 ? 51.786 20.442  38.911  1.00 0.00 ? 18 G   A N1    1 
+ATOM   383  C  C2    . G   A 1 18 ? 51.674 19.862  37.721  1.00 0.00 ? 18 G   A C2    1 
+ATOM   384  N  N2    . G   A 1 18 ? 50.943 20.439  36.785  1.00 0.00 ? 18 G   A N2    1 
+ATOM   385  N  N3    . G   A 1 18 ? 52.408 18.816  37.407  1.00 0.00 ? 18 G   A N3    1 
+ATOM   386  C  C4    . G   A 1 18 ? 53.303 18.310  38.324  1.00 0.00 ? 18 G   A C4    1 
+ATOM   387  P  P     . G   A 1 19 ? 55.690 14.740  33.288  1.00 0.00 ? 19 G   A P     1 
+ATOM   388  O  OP1   . G   A 1 19 ? 54.860 13.575  32.978  1.00 0.00 ? 19 G   A OP1   1 
+ATOM   389  O  OP2   . G   A 1 19 ? 57.139 14.523  33.442  1.00 0.00 ? 19 G   A OP2   1 
+ATOM   390  O  "O5'" . G   A 1 19 ? 55.497 15.908  32.203  1.00 0.00 ? 19 G   A "O5'" 1 
+ATOM   391  C  "C5'" . G   A 1 19 ? 54.260 16.030  31.526  1.00 0.00 ? 19 G   A "C5'" 1 
+ATOM   392  C  "C4'" . G   A 1 19 ? 54.276 17.280  30.652  1.00 0.00 ? 19 G   A "C4'" 1 
+ATOM   393  O  "O4'" . G   A 1 19 ? 54.936 18.283  31.412  1.00 0.00 ? 19 G   A "O4'" 1 
+ATOM   394  C  "C3'" . G   A 1 19 ? 55.116 17.088  29.391  1.00 0.00 ? 19 G   A "C3'" 1 
+ATOM   395  O  "O3'" . G   A 1 19 ? 54.489 17.842  28.392  1.00 0.00 ? 19 G   A "O3'" 1 
+ATOM   396  C  "C2'" . G   A 1 19 ? 56.447 17.785  29.688  1.00 0.00 ? 19 G   A "C2'" 1 
+ATOM   397  O  "O2'" . G   A 1 19 ? 56.888 18.463  28.534  1.00 0.00 ? 19 G   A "O2'" 1 
+ATOM   398  C  "C1'" . G   A 1 19 ? 55.995 18.853  30.642  1.00 0.00 ? 19 G   A "C1'" 1 
+ATOM   399  N  N9    . G   A 1 19 ? 57.010 19.154  31.603  1.00 0.00 ? 19 G   A N9    1 
+ATOM   400  C  C8    . G   A 1 19 ? 57.724 18.280  32.225  1.00 0.00 ? 19 G   A C8    1 
+ATOM   401  N  N7    . G   A 1 19 ? 58.383 18.918  33.213  1.00 0.00 ? 19 G   A N7    1 
+ATOM   402  C  C5    . G   A 1 19 ? 57.987 20.238  33.176  1.00 0.00 ? 19 G   A C5    1 
+ATOM   403  C  C6    . G   A 1 19 ? 58.241 21.328  33.968  1.00 0.00 ? 19 G   A C6    1 
+ATOM   404  O  O6    . G   A 1 19 ? 58.806 21.193  35.061  1.00 0.00 ? 19 G   A O6    1 
+ATOM   405  N  N1    . G   A 1 19 ? 57.689 22.437  33.693  1.00 0.00 ? 19 G   A N1    1 
+ATOM   406  C  C2    . G   A 1 19 ? 56.856 22.561  32.709  1.00 0.00 ? 19 G   A C2    1 
+ATOM   407  N  N2    . G   A 1 19 ? 56.308 23.725  32.463  1.00 0.00 ? 19 G   A N2    1 
+ATOM   408  N  N3    . G   A 1 19 ? 56.556 21.565  31.955  1.00 0.00 ? 19 G   A N3    1 
+ATOM   409  C  C4    . G   A 1 19 ? 57.153 20.369  32.176  1.00 0.00 ? 19 G   A C4    1 
+ATOM   410  P  P     . G   A 1 20 ? 53.238 17.243  27.600  1.00 0.00 ? 20 G   A P     1 
+ATOM   411  O  OP1   . G   A 1 20 ? 52.674 18.266  26.675  1.00 0.00 ? 20 G   A OP1   1 
+ATOM   412  O  OP2   . G   A 1 20 ? 52.333 16.523  28.522  1.00 0.00 ? 20 G   A OP2   1 
+ATOM   413  O  "O5'" . G   A 1 20 ? 53.964 16.230  26.644  1.00 0.00 ? 20 G   A "O5'" 1 
+ATOM   414  C  "C5'" . G   A 1 20 ? 54.362 16.802  25.409  1.00 0.00 ? 20 G   A "C5'" 1 
+ATOM   415  C  "C4'" . G   A 1 20 ? 54.456 15.707  24.338  1.00 0.00 ? 20 G   A "C4'" 1 
+ATOM   416  O  "O4'" . G   A 1 20 ? 55.331 14.674  24.748  1.00 0.00 ? 20 G   A "O4'" 1 
+ATOM   417  C  "C3'" . G   A 1 20 ? 53.106 15.085  24.140  1.00 0.00 ? 20 G   A "C3'" 1 
+ATOM   418  O  "O3'" . G   A 1 20 ? 52.438 15.809  23.122  1.00 0.00 ? 20 G   A "O3'" 1 
+ATOM   419  C  "C2'" . G   A 1 20 ? 53.523 13.769  23.571  1.00 0.00 ? 20 G   A "C2'" 1 
+ATOM   420  O  "O2'" . G   A 1 20 ? 53.886 13.988  22.243  1.00 0.00 ? 20 G   A "O2'" 1 
+ATOM   421  C  "C1'" . G   A 1 20 ? 54.777 13.434  24.350  1.00 0.00 ? 20 G   A "C1'" 1 
+ATOM   422  N  N9    . G   A 1 20 ? 54.370 12.657  25.536  1.00 0.00 ? 20 G   A N9    1 
+ATOM   423  C  C8    . G   A 1 20 ? 54.586 13.022  26.814  1.00 0.00 ? 20 G   A C8    1 
+ATOM   424  N  N7    . G   A 1 20 ? 53.997 12.106  27.630  1.00 0.00 ? 20 G   A N7    1 
+ATOM   425  C  C5    . G   A 1 20 ? 53.426 11.150  26.812  1.00 0.00 ? 20 G   A C5    1 
+ATOM   426  C  C6    . G   A 1 20 ? 52.742 9.971   27.099  1.00 0.00 ? 20 G   A C6    1 
+ATOM   427  O  O6    . G   A 1 20 ? 52.774 9.546   28.254  1.00 0.00 ? 20 G   A O6    1 
+ATOM   428  N  N1    . G   A 1 20 ? 52.289 9.192   26.113  1.00 0.00 ? 20 G   A N1    1 
+ATOM   429  C  C2    . G   A 1 20 ? 52.515 9.504   24.839  1.00 0.00 ? 20 G   A C2    1 
+ATOM   430  N  N2    . G   A 1 20 ? 52.145 8.655   23.897  1.00 0.00 ? 20 G   A N2    1 
+ATOM   431  N  N3    . G   A 1 20 ? 53.216 10.611  24.513  1.00 0.00 ? 20 G   A N3    1 
+ATOM   432  C  C4    . G   A 1 20 ? 53.693 11.455  25.518  1.00 0.00 ? 20 G   A C4    1 
+ATOM   433  P  P     . A   A 1 21 ? 50.876 16.180  23.223  1.00 0.00 ? 21 A   A P     1 
+ATOM   434  O  OP1   . A   A 1 21 ? 50.526 16.924  21.985  1.00 0.00 ? 21 A   A OP1   1 
+ATOM   435  O  OP2   . A   A 1 21 ? 50.552 16.819  24.515  1.00 0.00 ? 21 A   A OP2   1 
+ATOM   436  O  "O5'" . A   A 1 21 ? 50.099 14.800  23.226  1.00 0.00 ? 21 A   A "O5'" 1 
+ATOM   437  C  "C5'" . A   A 1 21 ? 49.678 14.188  24.436  1.00 0.00 ? 21 A   A "C5'" 1 
+ATOM   438  C  "C4'" . A   A 1 21 ? 49.738 12.673  24.233  1.00 0.00 ? 21 A   A "C4'" 1 
+ATOM   439  O  "O4'" . A   A 1 21 ? 48.811 12.110  25.164  1.00 0.00 ? 21 A   A "O4'" 1 
+ATOM   440  C  "C3'" . A   A 1 21 ? 49.240 12.344  22.824  1.00 0.00 ? 21 A   A "C3'" 1 
+ATOM   441  O  "O3'" . A   A 1 21 ? 49.644 11.025  22.477  1.00 0.00 ? 21 A   A "O3'" 1 
+ATOM   442  C  "C2'" . A   A 1 21 ? 47.752 12.300  23.088  1.00 0.00 ? 21 A   A "C2'" 1 
+ATOM   443  O  "O2'" . A   A 1 21 ? 47.116 11.494  22.122  1.00 0.00 ? 21 A   A "O2'" 1 
+ATOM   444  C  "C1'" . A   A 1 21 ? 47.724 11.590  24.428  1.00 0.00 ? 21 A   A "C1'" 1 
+ATOM   445  N  N9    . A   A 1 21 ? 46.412 11.764  25.069  1.00 0.00 ? 21 A   A N9    1 
+ATOM   446  C  C8    . A   A 1 21 ? 45.578 12.816  24.875  1.00 0.00 ? 21 A   A C8    1 
+ATOM   447  N  N7    . A   A 1 21 ? 44.369 12.526  25.464  1.00 0.00 ? 21 A   A N7    1 
+ATOM   448  C  C5    . A   A 1 21 ? 44.493 11.266  26.036  1.00 0.00 ? 21 A   A C5    1 
+ATOM   449  C  C6    . A   A 1 21 ? 43.582 10.433  26.693  1.00 0.00 ? 21 A   A C6    1 
+ATOM   450  N  N6    . A   A 1 21 ? 42.274 10.631  26.525  1.00 0.00 ? 21 A   A N6    1 
+ATOM   451  N  N1    . A   A 1 21 ? 43.986 9.258   27.149  1.00 0.00 ? 21 A   A N1    1 
+ATOM   452  C  C2    . A   A 1 21 ? 45.236 8.839   26.954  1.00 0.00 ? 21 A   A C2    1 
+ATOM   453  N  N3    . A   A 1 21 ? 46.132 9.582   26.310  1.00 0.00 ? 21 A   A N3    1 
+ATOM   454  C  C4    . A   A 1 21 ? 45.775 10.830  25.850  1.00 0.00 ? 21 A   A C4    1 
+ATOM   455  P  P     . G   A 1 22 ? 49.849 10.558  20.991  1.00 0.00 ? 22 G   A P     1 
+ATOM   456  O  OP1   . G   A 1 22 ? 51.220 10.581  20.659  1.00 0.00 ? 22 G   A OP1   1 
+ATOM   457  O  OP2   . G   A 1 22 ? 48.955 11.289  20.170  1.00 0.00 ? 22 G   A OP2   1 
+ATOM   458  O  "O5'" . G   A 1 22 ? 49.368 9.073   21.024  1.00 0.00 ? 22 G   A "O5'" 1 
+ATOM   459  C  "C5'" . G   A 1 22 ? 50.445 8.167   21.115  1.00 0.00 ? 22 G   A "C5'" 1 
+ATOM   460  C  "C4'" . G   A 1 22 ? 50.148 6.938   21.962  1.00 0.00 ? 22 G   A "C4'" 1 
+ATOM   461  O  "O4'" . G   A 1 22 ? 49.462 7.201   23.178  1.00 0.00 ? 22 G   A "O4'" 1 
+ATOM   462  C  "C3'" . G   A 1 22 ? 49.382 5.826   21.265  1.00 0.00 ? 22 G   A "C3'" 1 
+ATOM   463  O  "O3'" . G   A 1 22 ? 50.210 5.206   20.258  1.00 0.00 ? 22 G   A "O3'" 1 
+ATOM   464  C  "C2'" . G   A 1 22 ? 49.184 4.922   22.491  1.00 0.00 ? 22 G   A "C2'" 1 
+ATOM   465  O  "O2'" . G   A 1 22 ? 50.364 4.200   22.712  1.00 0.00 ? 22 G   A "O2'" 1 
+ATOM   466  C  "C1'" . G   A 1 22 ? 49.013 5.908   23.666  1.00 0.00 ? 22 G   A "C1'" 1 
+ATOM   467  N  N9    . G   A 1 22 ? 47.577 5.935   23.998  1.00 0.00 ? 22 G   A N9    1 
+ATOM   468  C  C8    . G   A 1 22 ? 46.733 6.964   23.739  1.00 0.00 ? 22 G   A C8    1 
+ATOM   469  N  N7    . G   A 1 22 ? 45.469 6.611   24.161  1.00 0.00 ? 22 G   A N7    1 
+ATOM   470  C  C5    . G   A 1 22 ? 45.551 5.316   24.656  1.00 0.00 ? 22 G   A C5    1 
+ATOM   471  C  C6    . G   A 1 22 ? 44.619 4.466   25.241  1.00 0.00 ? 22 G   A C6    1 
+ATOM   472  O  O6    . G   A 1 22 ? 43.438 4.813   25.350  1.00 0.00 ? 22 G   A O6    1 
+ATOM   473  N  N1    . G   A 1 22 ? 44.967 3.240   25.587  1.00 0.00 ? 22 G   A N1    1 
+ATOM   474  C  C2    . G   A 1 22 ? 46.219 2.809   25.422  1.00 0.00 ? 22 G   A C2    1 
+ATOM   475  N  N2    . G   A 1 22 ? 46.580 1.647   25.959  1.00 0.00 ? 22 G   A N2    1 
+ATOM   476  N  N3    . G   A 1 22 ? 47.153 3.602   24.912  1.00 0.00 ? 22 G   A N3    1 
+ATOM   477  C  C4    . G   A 1 22 ? 46.840 4.885   24.525  1.00 0.00 ? 22 G   A C4    1 
+ATOM   478  P  P     . A   A 1 23 ? 49.603 4.196   19.130  1.00 0.00 ? 23 A   A P     1 
+ATOM   479  O  OP1   . A   A 1 23 ? 50.587 4.057   18.140  1.00 0.00 ? 23 A   A OP1   1 
+ATOM   480  O  OP2   . A   A 1 23 ? 48.222 4.622   18.730  1.00 0.00 ? 23 A   A OP2   1 
+ATOM   481  O  "O5'" . A   A 1 23 ? 49.537 2.763   19.863  1.00 0.00 ? 23 A   A "O5'" 1 
+ATOM   482  C  "C5'" . A   A 1 23 ? 50.682 1.950   20.025  1.00 0.00 ? 23 A   A "C5'" 1 
+ATOM   483  C  "C4'" . A   A 1 23 ? 50.293 0.612   20.711  1.00 0.00 ? 23 A   A "C4'" 1 
+ATOM   484  O  "O4'" . A   A 1 23 ? 49.696 0.807   21.995  1.00 0.00 ? 23 A   A "O4'" 1 
+ATOM   485  C  "C3'" . A   A 1 23 ? 49.302 -0.213  19.912  1.00 0.00 ? 23 A   A "C3'" 1 
+ATOM   486  O  "O3'" . A   A 1 23 ? 50.026 -0.901  18.895  1.00 0.00 ? 23 A   A "O3'" 1 
+ATOM   487  C  "C2'" . A   A 1 23 ? 48.865 -1.159  21.021  1.00 0.00 ? 23 A   A "C2'" 1 
+ATOM   488  O  "O2'" . A   A 1 23 ? 49.895 -2.048  21.325  1.00 0.00 ? 23 A   A "O2'" 1 
+ATOM   489  C  "C1'" . A   A 1 23 ? 48.760 -0.243  22.222  1.00 0.00 ? 23 A   A "C1'" 1 
+ATOM   490  N  N9    . A   A 1 23 ? 47.450 0.399   22.274  1.00 0.00 ? 23 A   A N9    1 
+ATOM   491  C  C8    . A   A 1 23 ? 47.196 1.658   21.873  1.00 0.00 ? 23 A   A C8    1 
+ATOM   492  N  N7    . A   A 1 23 ? 45.903 1.991   22.198  1.00 0.00 ? 23 A   A N7    1 
+ATOM   493  C  C5    . A   A 1 23 ? 45.370 0.878   22.839  1.00 0.00 ? 23 A   A C5    1 
+ATOM   494  C  C6    . A   A 1 23 ? 44.087 0.603   23.320  1.00 0.00 ? 23 A   A C6    1 
+ATOM   495  N  N6    . A   A 1 23 ? 43.073 1.419   23.024  1.00 0.00 ? 23 A   A N6    1 
+ATOM   496  N  N1    . A   A 1 23 ? 43.858 -0.565  23.894  1.00 0.00 ? 23 A   A N1    1 
+ATOM   497  C  C2    . A   A 1 23 ? 44.825 -1.494  24.008  1.00 0.00 ? 23 A   A C2    1 
+ATOM   498  N  N3    . A   A 1 23 ? 46.033 -1.305  23.530  1.00 0.00 ? 23 A   A N3    1 
+ATOM   499  C  C4    . A   A 1 23 ? 46.327 -0.113  22.893  1.00 0.00 ? 23 A   A C4    1 
+ATOM   500  P  P     . G   A 1 24 ? 49.368 -1.348  17.492  1.00 0.00 ? 24 G   A P     1 
+ATOM   501  O  OP1   . G   A 1 24 ? 50.492 -1.683  16.586  1.00 0.00 ? 24 G   A OP1   1 
+ATOM   502  O  OP2   . G   A 1 24 ? 48.340 -0.373  17.007  1.00 0.00 ? 24 G   A OP2   1 
+ATOM   503  O  "O5'" . G   A 1 24 ? 48.588 -2.649  17.928  1.00 0.00 ? 24 G   A "O5'" 1 
+ATOM   504  C  "C5'" . G   A 1 24 ? 49.246 -3.821  18.384  1.00 0.00 ? 24 G   A "C5'" 1 
+ATOM   505  C  "C4'" . G   A 1 24 ? 48.107 -4.664  18.973  1.00 0.00 ? 24 G   A "C4'" 1 
+ATOM   506  O  "O4'" . G   A 1 24 ? 47.563 -3.949  20.059  1.00 0.00 ? 24 G   A "O4'" 1 
+ATOM   507  C  "C3'" . G   A 1 24 ? 46.927 -4.760  18.007  1.00 0.00 ? 24 G   A "C3'" 1 
+ATOM   508  O  "O3'" . G   A 1 24 ? 47.119 -5.843  17.131  1.00 0.00 ? 24 G   A "O3'" 1 
+ATOM   509  C  "C2'" . G   A 1 24 ? 45.807 -5.121  18.964  1.00 0.00 ? 24 G   A "C2'" 1 
+ATOM   510  O  "O2'" . G   A 1 24 ? 45.742 -6.536  19.192  1.00 0.00 ? 24 G   A "O2'" 1 
+ATOM   511  C  "C1'" . G   A 1 24 ? 46.220 -4.370  20.237  1.00 0.00 ? 24 G   A "C1'" 1 
+ATOM   512  N  N9    . G   A 1 24 ? 45.440 -3.145  20.252  1.00 0.00 ? 24 G   A N9    1 
+ATOM   513  C  C8    . G   A 1 24 ? 45.782 -1.986  19.649  1.00 0.00 ? 24 G   A C8    1 
+ATOM   514  N  N7    . G   A 1 24 ? 44.734 -1.109  19.782  1.00 0.00 ? 24 G   A N7    1 
+ATOM   515  C  C5    . G   A 1 24 ? 43.741 -1.778  20.482  1.00 0.00 ? 24 G   A C5    1 
+ATOM   516  C  C6    . G   A 1 24 ? 42.431 -1.443  20.790  1.00 0.00 ? 24 G   A C6    1 
+ATOM   517  O  O6    . G   A 1 24 ? 42.015 -0.301  20.546  1.00 0.00 ? 24 G   A O6    1 
+ATOM   518  N  N1    . G   A 1 24 ? 41.667 -2.313  21.447  1.00 0.00 ? 24 G   A N1    1 
+ATOM   519  C  C2    . G   A 1 24 ? 42.136 -3.517  21.825  1.00 0.00 ? 24 G   A C2    1 
+ATOM   520  N  N2    . G   A 1 24 ? 41.266 -4.454  22.188  1.00 0.00 ? 24 G   A N2    1 
+ATOM   521  N  N3    . G   A 1 24 ? 43.387 -3.873  21.545  1.00 0.00 ? 24 G   A N3    1 
+ATOM   522  C  C4    . G   A 1 24 ? 44.206 -3.006  20.842  1.00 0.00 ? 24 G   A C4    1 
+ATOM   523  P  P     . C   A 1 25 ? 46.480 -5.780  15.681  1.00 0.00 ? 25 C   A P     1 
+ATOM   524  O  OP1   . C   A 1 25 ? 46.946 -7.006  15.012  1.00 0.00 ? 25 C   A OP1   1 
+ATOM   525  O  OP2   . C   A 1 25 ? 46.740 -4.455  15.106  1.00 0.00 ? 25 C   A OP2   1 
+ATOM   526  O  "O5'" . C   A 1 25 ? 44.917 -5.867  15.872  1.00 0.00 ? 25 C   A "O5'" 1 
+ATOM   527  C  "C5'" . C   A 1 25 ? 44.337 -7.144  16.033  1.00 0.00 ? 25 C   A "C5'" 1 
+ATOM   528  C  "C4'" . C   A 1 25 ? 42.891 -6.952  16.492  1.00 0.00 ? 25 C   A "C4'" 1 
+ATOM   529  O  "O4'" . C   A 1 25 ? 42.873 -6.029  17.574  1.00 0.00 ? 25 C   A "O4'" 1 
+ATOM   530  C  "C3'" . C   A 1 25 ? 42.016 -6.311  15.420  1.00 0.00 ? 25 C   A "C3'" 1 
+ATOM   531  O  "O3'" . C   A 1 25 ? 41.440 -7.297  14.578  1.00 0.00 ? 25 C   A "O3'" 1 
+ATOM   532  C  "C2'" . C   A 1 25 ? 40.900 -5.794  16.298  1.00 0.00 ? 25 C   A "C2'" 1 
+ATOM   533  O  "O2'" . C   A 1 25 ? 39.865 -6.739  16.393  1.00 0.00 ? 25 C   A "O2'" 1 
+ATOM   534  C  "C1'" . C   A 1 25 ? 41.539 -5.551  17.667  1.00 0.00 ? 25 C   A "C1'" 1 
+ATOM   535  N  N1    . C   A 1 25 ? 41.639 -4.124  17.725  1.00 0.00 ? 25 C   A N1    1 
+ATOM   536  C  C2    . C   A 1 25 ? 40.638 -3.430  18.204  1.00 0.00 ? 25 C   A C2    1 
+ATOM   537  O  O2    . C   A 1 25 ? 39.532 -3.987  18.315  1.00 0.00 ? 25 C   A O2    1 
+ATOM   538  N  N3    . C   A 1 25 ? 40.693 -2.102  18.204  1.00 0.00 ? 25 C   A N3    1 
+ATOM   539  C  C4    . C   A 1 25 ? 41.714 -1.455  17.666  1.00 0.00 ? 25 C   A C4    1 
+ATOM   540  N  N4    . C   A 1 25 ? 41.840 -0.145  17.831  1.00 0.00 ? 25 C   A N4    1 
+ATOM   541  C  C5    . C   A 1 25 ? 42.749 -2.175  17.113  1.00 0.00 ? 25 C   A C5    1 
+ATOM   542  C  C6    . C   A 1 25 ? 42.675 -3.545  17.153  1.00 0.00 ? 25 C   A C6    1 
+HETATM 543  P  P     . M2G A 1 26 ? 40.942 -6.906  13.106  1.00 0.00 ? 26 M2G A P     1 
+HETATM 544  O  OP1   . M2G A 1 26 ? 40.308 -8.115  12.530  1.00 0.00 ? 26 M2G A OP1   1 
+HETATM 545  O  OP2   . M2G A 1 26 ? 42.084 -6.275  12.407  1.00 0.00 ? 26 M2G A OP2   1 
+HETATM 546  O  "O5'" . M2G A 1 26 ? 39.822 -5.804  13.322  1.00 0.00 ? 26 M2G A "O5'" 1 
+HETATM 547  C  "C5'" . M2G A 1 26 ? 38.522 -6.196  13.739  1.00 0.00 ? 26 M2G A "C5'" 1 
+HETATM 548  C  "C4'" . M2G A 1 26 ? 37.776 -4.931  14.147  1.00 0.00 ? 26 M2G A "C4'" 1 
+HETATM 549  O  "O4'" . M2G A 1 26 ? 38.698 -4.077  14.815  1.00 0.00 ? 26 M2G A "O4'" 1 
+HETATM 550  C  "C3'" . M2G A 1 26 ? 37.429 -4.102  12.925  1.00 0.00 ? 26 M2G A "C3'" 1 
+HETATM 551  O  "O3'" . M2G A 1 26 ? 36.257 -4.572  12.288  1.00 0.00 ? 26 M2G A "O3'" 1 
+HETATM 552  C  "C2'" . M2G A 1 26 ? 37.202 -2.728  13.545  1.00 0.00 ? 26 M2G A "C2'" 1 
+HETATM 553  O  "O2'" . M2G A 1 26 ? 35.878 -2.579  14.024  1.00 0.00 ? 26 M2G A "O2'" 1 
+HETATM 554  C  "C1'" . M2G A 1 26 ? 38.144 -2.767  14.736  1.00 0.00 ? 26 M2G A "C1'" 1 
+HETATM 555  N  N9    . M2G A 1 26 ? 39.210 -1.823  14.516  1.00 0.00 ? 26 M2G A N9    1 
+HETATM 556  C  C8    . M2G A 1 26 ? 40.454 -2.128  14.144  1.00 0.00 ? 26 M2G A C8    1 
+HETATM 557  N  N7    . M2G A 1 26 ? 41.194 -0.964  14.128  1.00 0.00 ? 26 M2G A N7    1 
+HETATM 558  C  C5    . M2G A 1 26 ? 40.333 0.073   14.472  1.00 0.00 ? 26 M2G A C5    1 
+HETATM 559  C  C6    . M2G A 1 26 ? 40.524 1.449   14.680  1.00 0.00 ? 26 M2G A C6    1 
+HETATM 560  O  O6    . M2G A 1 26 ? 41.674 1.915   14.761  1.00 0.00 ? 26 M2G A O6    1 
+HETATM 561  N  N1    . M2G A 1 26 ? 39.476 2.220   14.985  1.00 0.00 ? 26 M2G A N1    1 
+HETATM 562  C  C2    . M2G A 1 26 ? 38.248 1.708   15.120  1.00 0.00 ? 26 M2G A C2    1 
+HETATM 563  N  N2    . M2G A 1 26 ? 37.227 2.524   15.257  1.00 0.00 ? 26 M2G A N2    1 
+HETATM 564  N  N3    . M2G A 1 26 ? 38.021 0.385   14.963  1.00 0.00 ? 26 M2G A N3    1 
+HETATM 565  C  C4    . M2G A 1 26 ? 39.082 -0.455  14.637  1.00 0.00 ? 26 M2G A C4    1 
+HETATM 566  C  CM1   . M2G A 1 26 ? 37.418 3.967   15.049  1.00 0.00 ? 26 M2G A CM1   1 
+HETATM 567  C  CM2   . M2G A 1 26 ? 35.871 1.968   15.388  1.00 0.00 ? 26 M2G A CM2   1 
+ATOM   568  P  P     . C   A 1 27 ? 36.262 -4.476  10.703  1.00 0.00 ? 27 C   A P     1 
+ATOM   569  O  OP1   . C   A 1 27 ? 35.020 -5.061  10.165  1.00 0.00 ? 27 C   A OP1   1 
+ATOM   570  O  OP2   . C   A 1 27 ? 37.573 -4.980  10.273  1.00 0.00 ? 27 C   A OP2   1 
+ATOM   571  O  "O5'" . C   A 1 27 ? 36.167 -2.925  10.487  1.00 0.00 ? 27 C   A "O5'" 1 
+ATOM   572  C  "C5'" . C   A 1 27 ? 34.868 -2.378  10.577  1.00 0.00 ? 27 C   A "C5'" 1 
+ATOM   573  C  "C4'" . C   A 1 27 ? 34.953 -0.848  10.506  1.00 0.00 ? 27 C   A "C4'" 1 
+ATOM   574  O  "O4'" . C   A 1 27 ? 35.801 -0.340  11.528  1.00 0.00 ? 27 C   A "O4'" 1 
+ATOM   575  C  "C3'" . C   A 1 27 ? 35.574 -0.345  9.220   1.00 0.00 ? 27 C   A "C3'" 1 
+ATOM   576  O  "O3'" . C   A 1 27 ? 34.653 -0.378  8.146   1.00 0.00 ? 27 C   A "O3'" 1 
+ATOM   577  C  "C2'" . C   A 1 27 ? 35.862 1.091   9.626   1.00 0.00 ? 27 C   A "C2'" 1 
+ATOM   578  O  "O2'" . C   A 1 27 ? 34.714 1.909   9.481   1.00 0.00 ? 27 C   A "O2'" 1 
+ATOM   579  C  "C1'" . C   A 1 27 ? 36.255 0.957   11.110  1.00 0.00 ? 27 C   A "C1'" 1 
+ATOM   580  N  N1    . C   A 1 27 ? 37.722 0.919   11.160  1.00 0.00 ? 27 C   A N1    1 
+ATOM   581  C  C2    . C   A 1 27 ? 38.416 2.054   11.102  1.00 0.00 ? 27 C   A C2    1 
+ATOM   582  O  O2    . C   A 1 27 ? 37.843 3.093   10.735  1.00 0.00 ? 27 C   A O2    1 
+ATOM   583  N  N3    . C   A 1 27 ? 39.751 2.034   11.111  1.00 0.00 ? 27 C   A N3    1 
+ATOM   584  C  C4    . C   A 1 27 ? 40.429 0.890   11.133  1.00 0.00 ? 27 C   A C4    1 
+ATOM   585  N  N4    . C   A 1 27 ? 41.710 0.889   11.493  1.00 0.00 ? 27 C   A N4    1 
+ATOM   586  C  C5    . C   A 1 27 ? 39.732 -0.298  11.125  1.00 0.00 ? 27 C   A C5    1 
+ATOM   587  C  C6    . C   A 1 27 ? 38.346 -0.250  11.122  1.00 0.00 ? 27 C   A C6    1 
+ATOM   588  P  P     . C   A 1 28 ? 35.253 -0.591  6.671   1.00 0.00 ? 28 C   A P     1 
+ATOM   589  O  OP1   . C   A 1 28 ? 34.149 -0.776  5.721   1.00 0.00 ? 28 C   A OP1   1 
+ATOM   590  O  OP2   . C   A 1 28 ? 36.298 -1.634  6.798   1.00 0.00 ? 28 C   A OP2   1 
+ATOM   591  O  "O5'" . C   A 1 28 ? 36.008 0.772   6.328   1.00 0.00 ? 28 C   A "O5'" 1 
+ATOM   592  C  "C5'" . C   A 1 28 ? 35.330 1.951   5.949   1.00 0.00 ? 28 C   A "C5'" 1 
+ATOM   593  C  "C4'" . C   A 1 28 ? 36.418 2.966   5.573   1.00 0.00 ? 28 C   A "C4'" 1 
+ATOM   594  O  "O4'" . C   A 1 28 ? 37.318 3.148   6.661   1.00 0.00 ? 28 C   A "O4'" 1 
+ATOM   595  C  "C3'" . C   A 1 28 ? 37.281 2.434   4.437   1.00 0.00 ? 28 C   A "C3'" 1 
+ATOM   596  O  "O3'" . C   A 1 28 ? 36.668 2.649   3.160   1.00 0.00 ? 28 C   A "O3'" 1 
+ATOM   597  C  "C2'" . C   A 1 28 ? 38.479 3.336   4.590   1.00 0.00 ? 28 C   A "C2'" 1 
+ATOM   598  O  "O2'" . C   A 1 28 ? 38.177 4.586   3.978   1.00 0.00 ? 28 C   A "O2'" 1 
+ATOM   599  C  "C1'" . C   A 1 28 ? 38.602 3.460   6.120   1.00 0.00 ? 28 C   A "C1'" 1 
+ATOM   600  N  N1    . C   A 1 28 ? 39.571 2.482   6.676   1.00 0.00 ? 28 C   A N1    1 
+ATOM   601  C  C2    . C   A 1 28 ? 40.825 2.834   6.796   1.00 0.00 ? 28 C   A C2    1 
+ATOM   602  O  O2    . C   A 1 28 ? 41.220 3.765   6.088   1.00 0.00 ? 28 C   A O2    1 
+ATOM   603  N  N3    . C   A 1 28 ? 41.727 1.995   7.316   1.00 0.00 ? 28 C   A N3    1 
+ATOM   604  C  C4    . C   A 1 28 ? 41.395 0.778   7.711   1.00 0.00 ? 28 C   A C4    1 
+ATOM   605  N  N4    . C   A 1 28 ? 42.340 -0.123  7.954   1.00 0.00 ? 28 C   A N4    1 
+ATOM   606  C  C5    . C   A 1 28 ? 40.087 0.383   7.601   1.00 0.00 ? 28 C   A C5    1 
+ATOM   607  C  C6    . C   A 1 28 ? 39.173 1.292   7.086   1.00 0.00 ? 28 C   A C6    1 
+ATOM   608  P  P     . A   A 1 29 ? 37.039 1.595   1.972   1.00 0.00 ? 29 A   A P     1 
+ATOM   609  O  OP1   . A   A 1 29 ? 36.101 1.794   0.854   1.00 0.00 ? 29 A   A OP1   1 
+ATOM   610  O  OP2   . A   A 1 29 ? 37.136 0.242   2.592   1.00 0.00 ? 29 A   A OP2   1 
+ATOM   611  O  "O5'" . A   A 1 29 ? 38.491 2.102   1.528   1.00 0.00 ? 29 A   A "O5'" 1 
+ATOM   612  C  "C5'" . A   A 1 29 ? 38.593 3.220   0.654   1.00 0.00 ? 29 A   A "C5'" 1 
+ATOM   613  C  "C4'" . A   A 1 29 ? 40.021 3.752   0.692   1.00 0.00 ? 29 A   A "C4'" 1 
+ATOM   614  O  "O4'" . A   A 1 29 ? 40.409 3.899   2.047   1.00 0.00 ? 29 A   A "O4'" 1 
+ATOM   615  C  "C3'" . A   A 1 29 ? 41.050 2.794   0.132   1.00 0.00 ? 29 A   A "C3'" 1 
+ATOM   616  O  "O3'" . A   A 1 29 ? 41.133 2.950   -1.275  1.00 0.00 ? 29 A   A "O3'" 1 
+ATOM   617  C  "C2'" . A   A 1 29 ? 42.287 3.441   0.749   1.00 0.00 ? 29 A   A "C2'" 1 
+ATOM   618  O  "O2'" . A   A 1 29 ? 42.536 4.671   0.110   1.00 0.00 ? 29 A   A "O2'" 1 
+ATOM   619  C  "C1'" . A   A 1 29 ? 41.828 3.766   2.146   1.00 0.00 ? 29 A   A "C1'" 1 
+ATOM   620  N  N9    . A   A 1 29 ? 42.124 2.615   2.995   1.00 0.00 ? 29 A   A N9    1 
+ATOM   621  C  C8    . A   A 1 29 ? 41.235 1.681   3.402   1.00 0.00 ? 29 A   A C8    1 
+ATOM   622  N  N7    . A   A 1 29 ? 41.883 0.806   4.230   1.00 0.00 ? 29 A   A N7    1 
+ATOM   623  C  C5    . A   A 1 29 ? 43.214 1.185   4.244   1.00 0.00 ? 29 A   A C5    1 
+ATOM   624  C  C6    . A   A 1 29 ? 44.324 0.662   4.885   1.00 0.00 ? 29 A   A C6    1 
+ATOM   625  N  N6    . A   A 1 29 ? 44.279 -0.558  5.356   1.00 0.00 ? 29 A   A N6    1 
+ATOM   626  N  N1    . A   A 1 29 ? 45.506 1.189   4.636   1.00 0.00 ? 29 A   A N1    1 
+ATOM   627  C  C2    . A   A 1 29 ? 45.665 2.223   3.791   1.00 0.00 ? 29 A   A C2    1 
+ATOM   628  N  N3    . A   A 1 29 ? 44.628 2.767   3.193   1.00 0.00 ? 29 A   A N3    1 
+ATOM   629  C  C4    . A   A 1 29 ? 43.375 2.245   3.415   1.00 0.00 ? 29 A   A C4    1 
+ATOM   630  P  P     . G   A 1 30 ? 42.046 1.952   -2.141  1.00 0.00 ? 30 G   A P     1 
+ATOM   631  O  OP1   . G   A 1 30 ? 41.832 2.266   -3.575  1.00 0.00 ? 30 G   A OP1   1 
+ATOM   632  O  OP2   . G   A 1 30 ? 41.720 0.574   -1.683  1.00 0.00 ? 30 G   A OP2   1 
+ATOM   633  O  "O5'" . G   A 1 30 ? 43.576 2.294   -1.737  1.00 0.00 ? 30 G   A "O5'" 1 
+ATOM   634  C  "C5'" . G   A 1 30 ? 44.314 3.392   -2.271  1.00 0.00 ? 30 G   A "C5'" 1 
+ATOM   635  C  "C4'" . G   A 1 30 ? 45.750 3.297   -1.712  1.00 0.00 ? 30 G   A "C4'" 1 
+ATOM   636  O  "O4'" . G   A 1 30 ? 45.680 2.920   -0.335  1.00 0.00 ? 30 G   A "O4'" 1 
+ATOM   637  C  "C3'" . G   A 1 30 ? 46.550 2.164   -2.355  1.00 0.00 ? 30 G   A "C3'" 1 
+ATOM   638  O  "O3'" . G   A 1 30 ? 47.194 2.595   -3.547  1.00 0.00 ? 30 G   A "O3'" 1 
+ATOM   639  C  "C2'" . G   A 1 30 ? 47.595 1.877   -1.276  1.00 0.00 ? 30 G   A "C2'" 1 
+ATOM   640  O  "O2'" . G   A 1 30 ? 48.704 2.759   -1.364  1.00 0.00 ? 30 G   A "O2'" 1 
+ATOM   641  C  "C1'" . G   A 1 30 ? 46.846 2.165   0.014   1.00 0.00 ? 30 G   A "C1'" 1 
+ATOM   642  N  N9    . G   A 1 30 ? 46.397 0.897   0.594   1.00 0.00 ? 30 G   A N9    1 
+ATOM   643  C  C8    . G   A 1 30 ? 45.132 0.405   0.527   1.00 0.00 ? 30 G   A C8    1 
+ATOM   644  N  N7    . G   A 1 30 ? 45.075 -0.750  1.266   1.00 0.00 ? 30 G   A N7    1 
+ATOM   645  C  C5    . G   A 1 30 ? 46.354 -0.963  1.769   1.00 0.00 ? 30 G   A C5    1 
+ATOM   646  C  C6    . G   A 1 30 ? 46.860 -1.886  2.683   1.00 0.00 ? 30 G   A C6    1 
+ATOM   647  O  O6    . G   A 1 30 ? 46.146 -2.827  3.048   1.00 0.00 ? 30 G   A O6    1 
+ATOM   648  N  N1    . G   A 1 30 ? 48.162 -1.860  3.005   1.00 0.00 ? 30 G   A N1    1 
+ATOM   649  C  C2    . G   A 1 30 ? 48.991 -0.944  2.475   1.00 0.00 ? 30 G   A C2    1 
+ATOM   650  N  N2    . G   A 1 30 ? 50.296 -1.112  2.605   1.00 0.00 ? 30 G   A N2    1 
+ATOM   651  N  N3    . G   A 1 30 ? 48.536 -0.005  1.640   1.00 0.00 ? 30 G   A N3    1 
+ATOM   652  C  C4    . G   A 1 30 ? 47.192 0.009   1.288   1.00 0.00 ? 30 G   A C4    1 
+ATOM   653  P  P     . A   A 1 31 ? 47.250 1.565   -4.785  1.00 0.00 ? 31 A   A P     1 
+ATOM   654  O  OP1   . A   A 1 31 ? 47.915 2.226   -5.928  1.00 0.00 ? 31 A   A OP1   1 
+ATOM   655  O  OP2   . A   A 1 31 ? 45.880 1.037   -4.998  1.00 0.00 ? 31 A   A OP2   1 
+ATOM   656  O  "O5'" . A   A 1 31 ? 48.162 0.378   -4.203  1.00 0.00 ? 31 A   A "O5'" 1 
+ATOM   657  C  "C5'" . A   A 1 31 ? 49.550 0.597   -4.024  1.00 0.00 ? 31 A   A "C5'" 1 
+ATOM   658  C  "C4'" . A   A 1 31 ? 50.081 -0.545  -3.169  1.00 0.00 ? 31 A   A "C4'" 1 
+ATOM   659  O  "O4'" . A   A 1 31 ? 49.186 -0.799  -2.096  1.00 0.00 ? 31 A   A "O4'" 1 
+ATOM   660  C  "C3'" . A   A 1 31 ? 50.034 -1.876  -3.896  1.00 0.00 ? 31 A   A "C3'" 1 
+ATOM   661  O  "O3'" . A   A 1 31 ? 51.103 -1.986  -4.824  1.00 0.00 ? 31 A   A "O3'" 1 
+ATOM   662  C  "C2'" . A   A 1 31 ? 50.260 -2.800  -2.698  1.00 0.00 ? 31 A   A "C2'" 1 
+ATOM   663  O  "O2'" . A   A 1 31 ? 51.645 -2.919  -2.448  1.00 0.00 ? 31 A   A "O2'" 1 
+ATOM   664  C  "C1'" . A   A 1 31 ? 49.617 -2.037  -1.532  1.00 0.00 ? 31 A   A "C1'" 1 
+ATOM   665  N  N9    . A   A 1 31 ? 48.437 -2.747  -1.007  1.00 0.00 ? 31 A   A N9    1 
+ATOM   666  C  C8    . A   A 1 31 ? 47.138 -2.427  -1.296  1.00 0.00 ? 31 A   A C8    1 
+ATOM   667  N  N7    . A   A 1 31 ? 46.318 -3.303  -0.618  1.00 0.00 ? 31 A   A N7    1 
+ATOM   668  C  C5    . A   A 1 31 ? 47.154 -4.192  0.061   1.00 0.00 ? 31 A   A C5    1 
+ATOM   669  C  C6    . A   A 1 31 ? 46.883 -5.284  0.898   1.00 0.00 ? 31 A   A C6    1 
+ATOM   670  N  N6    . A   A 1 31 ? 45.609 -5.654  1.112   1.00 0.00 ? 31 A   A N6    1 
+ATOM   671  N  N1    . A   A 1 31 ? 47.905 -6.001  1.429   1.00 0.00 ? 31 A   A N1    1 
+ATOM   672  C  C2    . A   A 1 31 ? 49.191 -5.674  1.162   1.00 0.00 ? 31 A   A C2    1 
+ATOM   673  N  N3    . A   A 1 31 ? 49.487 -4.621  0.365   1.00 0.00 ? 31 A   A N3    1 
+ATOM   674  C  C4    . A   A 1 31 ? 48.463 -3.863  -0.195  1.00 0.00 ? 31 A   A C4    1 
+HETATM 675  N  N1    . OMC A 1 32 ? 47.626 -6.177  -3.315  1.00 0.00 ? 32 OMC A N1    1 
+HETATM 676  C  C2    . OMC A 1 32 ? 46.616 -6.752  -2.648  1.00 0.00 ? 32 OMC A C2    1 
+HETATM 677  N  N3    . OMC A 1 32 ? 45.390 -6.196  -2.630  1.00 0.00 ? 32 OMC A N3    1 
+HETATM 678  C  C4    . OMC A 1 32 ? 45.162 -5.035  -3.240  1.00 0.00 ? 32 OMC A C4    1 
+HETATM 679  C  C5    . OMC A 1 32 ? 46.205 -4.381  -3.886  1.00 0.00 ? 32 OMC A C5    1 
+HETATM 680  C  C6    . OMC A 1 32 ? 47.464 -4.983  -3.890  1.00 0.00 ? 32 OMC A C6    1 
+HETATM 681  O  O2    . OMC A 1 32 ? 46.848 -7.742  -1.940  1.00 0.00 ? 32 OMC A O2    1 
+HETATM 682  N  N4    . OMC A 1 32 ? 43.940 -4.520  -3.270  1.00 0.00 ? 32 OMC A N4    1 
+HETATM 683  C  "C1'" . OMC A 1 32 ? 48.963 -6.794  -3.293  1.00 0.00 ? 32 OMC A "C1'" 1 
+HETATM 684  C  "C2'" . OMC A 1 32 ? 49.186 -7.826  -4.401  1.00 0.00 ? 32 OMC A "C2'" 1 
+HETATM 685  O  "O2'" . OMC A 1 32 ? 50.015 -8.834  -3.845  1.00 0.00 ? 32 OMC A "O2'" 1 
+HETATM 686  C  CM2   . OMC A 1 32 ? 49.278 -9.542  -2.867  1.00 0.00 ? 32 OMC A CM2   1 
+HETATM 687  C  "C3'" . OMC A 1 32 ? 50.061 -7.075  -5.408  1.00 0.00 ? 32 OMC A "C3'" 1 
+HETATM 688  C  "C4'" . OMC A 1 32 ? 50.895 -6.282  -4.422  1.00 0.00 ? 32 OMC A "C4'" 1 
+HETATM 689  O  "O4'" . OMC A 1 32 ? 49.902 -5.757  -3.553  1.00 0.00 ? 32 OMC A "O4'" 1 
+HETATM 690  O  "O3'" . OMC A 1 32 ? 50.923 -7.984  -6.081  1.00 0.00 ? 32 OMC A "O3'" 1 
+HETATM 691  C  "C5'" . OMC A 1 32 ? 51.618 -5.127  -5.101  1.00 0.00 ? 32 OMC A "C5'" 1 
+HETATM 692  O  "O5'" . OMC A 1 32 ? 50.583 -4.298  -5.594  1.00 0.00 ? 32 OMC A "O5'" 1 
+HETATM 693  P  P     . OMC A 1 32 ? 50.880 -2.845  -6.159  1.00 0.00 ? 32 OMC A P     1 
+HETATM 694  O  OP1   . OMC A 1 32 ? 52.169 -2.861  -6.876  1.00 0.00 ? 32 OMC A OP1   1 
+HETATM 695  O  OP2   . OMC A 1 32 ? 49.633 -2.392  -6.859  1.00 0.00 ? 32 OMC A OP2   1 
+ATOM   696  P  P     . U   A 1 33 ? 50.521 -8.509  -7.546  1.00 0.00 ? 33 U   A P     1 
+ATOM   697  O  OP1   . U   A 1 33 ? 51.631 -9.333  -8.090  1.00 0.00 ? 33 U   A OP1   1 
+ATOM   698  O  OP2   . U   A 1 33 ? 50.028 -7.349  -8.326  1.00 0.00 ? 33 U   A OP2   1 
+ATOM   699  O  "O5'" . U   A 1 33 ? 49.273 -9.455  -7.258  1.00 0.00 ? 33 U   A "O5'" 1 
+ATOM   700  C  "C5'" . U   A 1 33 ? 49.491 -10.744 -6.714  1.00 0.00 ? 33 U   A "C5'" 1 
+ATOM   701  C  "C4'" . U   A 1 33 ? 48.112 -11.327 -6.476  1.00 0.00 ? 33 U   A "C4'" 1 
+ATOM   702  O  "O4'" . U   A 1 33 ? 47.436 -10.547 -5.490  1.00 0.00 ? 33 U   A "O4'" 1 
+ATOM   703  C  "C3'" . U   A 1 33 ? 47.259 -11.151 -7.718  1.00 0.00 ? 33 U   A "C3'" 1 
+ATOM   704  O  "O3'" . U   A 1 33 ? 47.537 -12.162 -8.662  1.00 0.00 ? 33 U   A "O3'" 1 
+ATOM   705  C  "C2'" . U   A 1 33 ? 45.933 -11.452 -7.067  1.00 0.00 ? 33 U   A "C2'" 1 
+ATOM   706  O  "O2'" . U   A 1 33 ? 45.961 -12.831 -6.768  1.00 0.00 ? 33 U   A "O2'" 1 
+ATOM   707  C  "C1'" . U   A 1 33 ? 46.038 -10.693 -5.738  1.00 0.00 ? 33 U   A "C1'" 1 
+ATOM   708  N  N1    . U   A 1 33 ? 45.447 -9.352  -5.891  1.00 0.00 ? 33 U   A N1    1 
+ATOM   709  C  C2    . U   A 1 33 ? 44.129 -9.175  -5.678  1.00 0.00 ? 33 U   A C2    1 
+ATOM   710  O  O2    . U   A 1 33 ? 43.497 -10.046 -5.069  1.00 0.00 ? 33 U   A O2    1 
+ATOM   711  N  N3    . U   A 1 33 ? 43.568 -7.978  -5.825  1.00 0.00 ? 33 U   A N3    1 
+ATOM   712  C  C4    . U   A 1 33 ? 44.300 -6.910  -6.146  1.00 0.00 ? 33 U   A C4    1 
+ATOM   713  O  O4    . U   A 1 33 ? 43.744 -5.886  -6.572  1.00 0.00 ? 33 U   A O4    1 
+ATOM   714  C  C5    . U   A 1 33 ? 45.677 -7.049  -6.296  1.00 0.00 ? 33 U   A C5    1 
+ATOM   715  C  C6    . U   A 1 33 ? 46.236 -8.313  -6.136  1.00 0.00 ? 33 U   A C6    1 
+HETATM 716  P  P     . OMG A 1 34 ? 47.219 -11.900 -10.223 1.00 0.00 ? 34 OMG A P     1 
+HETATM 717  O  OP1   . OMG A 1 34 ? 47.589 -13.154 -10.940 1.00 0.00 ? 34 OMG A OP1   1 
+HETATM 718  O  OP2   . OMG A 1 34 ? 47.895 -10.626 -10.599 1.00 0.00 ? 34 OMG A OP2   1 
+HETATM 719  O  "O5'" . OMG A 1 34 ? 45.627 -11.690 -10.292 1.00 0.00 ? 34 OMG A "O5'" 1 
+HETATM 720  C  "C5'" . OMG A 1 34 ? 45.110 -10.931 -11.373 1.00 0.00 ? 34 OMG A "C5'" 1 
+HETATM 721  C  "C4'" . OMG A 1 34 ? 43.712 -11.427 -11.663 1.00 0.00 ? 34 OMG A "C4'" 1 
+HETATM 722  O  "O4'" . OMG A 1 34 ? 43.790 -12.823 -11.892 1.00 0.00 ? 34 OMG A "O4'" 1 
+HETATM 723  C  "C3'" . OMG A 1 34 ? 42.758 -11.230 -10.493 1.00 0.00 ? 34 OMG A "C3'" 1 
+HETATM 724  O  "O3'" . OMG A 1 34 ? 42.083 -9.992  -10.665 1.00 0.00 ? 34 OMG A "O3'" 1 
+HETATM 725  C  "C2'" . OMG A 1 34 ? 41.745 -12.317 -10.759 1.00 0.00 ? 34 OMG A "C2'" 1 
+HETATM 726  O  "O2'" . OMG A 1 34 ? 40.723 -11.837 -11.621 1.00 0.00 ? 34 OMG A "O2'" 1 
+HETATM 727  C  CM2   . OMG A 1 34 ? 39.703 -12.827 -11.720 1.00 0.00 ? 34 OMG A CM2   1 
+HETATM 728  C  "C1'" . OMG A 1 34 ? 42.572 -13.404 -11.450 1.00 0.00 ? 34 OMG A "C1'" 1 
+HETATM 729  N  N9    . OMG A 1 34 ? 42.900 -14.434 -10.458 1.00 0.00 ? 34 OMG A N9    1 
+HETATM 730  C  C8    . OMG A 1 34 ? 44.140 -14.897 -10.145 1.00 0.00 ? 34 OMG A C8    1 
+HETATM 731  N  N7    . OMG A 1 34 ? 43.997 -15.922 -9.230  1.00 0.00 ? 34 OMG A N7    1 
+HETATM 732  C  C5    . OMG A 1 34 ? 42.626 -16.051 -9.001  1.00 0.00 ? 34 OMG A C5    1 
+HETATM 733  C  C6    . OMG A 1 34 ? 41.861 -17.004 -8.326  1.00 0.00 ? 34 OMG A C6    1 
+HETATM 734  O  O6    . OMG A 1 34 ? 42.417 -17.943 -7.740  1.00 0.00 ? 34 OMG A O6    1 
+HETATM 735  N  N1    . OMG A 1 34 ? 40.531 -16.873 -8.277  1.00 0.00 ? 34 OMG A N1    1 
+HETATM 736  C  C2    . OMG A 1 34 ? 39.901 -15.860 -8.905  1.00 0.00 ? 34 OMG A C2    1 
+HETATM 737  N  N2    . OMG A 1 34 ? 38.613 -15.630 -8.665  1.00 0.00 ? 34 OMG A N2    1 
+HETATM 738  N  N3    . OMG A 1 34 ? 40.590 -14.975 -9.612  1.00 0.00 ? 34 OMG A N3    1 
+HETATM 739  C  C4    . OMG A 1 34 ? 41.968 -15.076 -9.690  1.00 0.00 ? 34 OMG A C4    1 
+ATOM   740  P  P     . A   A 1 35 ? 42.263 -8.835  -9.558  1.00 0.00 ? 35 A   A P     1 
+ATOM   741  O  OP1   . A   A 1 35 ? 41.691 -7.570  -10.110 1.00 0.00 ? 35 A   A OP1   1 
+ATOM   742  O  OP2   . A   A 1 35 ? 43.662 -8.886  -9.070  1.00 0.00 ? 35 A   A OP2   1 
+ATOM   743  O  "O5'" . A   A 1 35 ? 41.303 -9.363  -8.403  1.00 0.00 ? 35 A   A "O5'" 1 
+ATOM   744  C  "C5'" . A   A 1 35 ? 39.903 -9.320  -8.611  1.00 0.00 ? 35 A   A "C5'" 1 
+ATOM   745  C  "C4'" . A   A 1 35 ? 39.250 -10.417 -7.768  1.00 0.00 ? 35 A   A "C4'" 1 
+ATOM   746  O  "O4'" . A   A 1 35 ? 39.661 -11.735 -8.146  1.00 0.00 ? 35 A   A "O4'" 1 
+ATOM   747  C  "C3'" . A   A 1 35 ? 39.523 -10.303 -6.279  1.00 0.00 ? 35 A   A "C3'" 1 
+ATOM   748  O  "O3'" . A   A 1 35 ? 38.715 -9.247  -5.755  1.00 0.00 ? 35 A   A "O3'" 1 
+ATOM   749  C  "C2'" . A   A 1 35 ? 38.947 -11.671 -5.930  1.00 0.00 ? 35 A   A "C2'" 1 
+ATOM   750  O  "O2'" . A   A 1 35 ? 37.545 -11.601 -6.168  1.00 0.00 ? 35 A   A "O2'" 1 
+ATOM   751  C  "C1'" . A   A 1 35 ? 39.525 -12.591 -7.006  1.00 0.00 ? 35 A   A "C1'" 1 
+ATOM   752  N  N9    . A   A 1 35 ? 40.901 -13.006 -6.687  1.00 0.00 ? 35 A   A N9    1 
+ATOM   753  C  C8    . A   A 1 35 ? 42.019 -12.363 -7.122  1.00 0.00 ? 35 A   A C8    1 
+ATOM   754  N  N7    . A   A 1 35 ? 43.114 -13.037 -6.688  1.00 0.00 ? 35 A   A N7    1 
+ATOM   755  C  C5    . A   A 1 35 ? 42.653 -14.167 -6.029  1.00 0.00 ? 35 A   A C5    1 
+ATOM   756  C  C6    . A   A 1 35 ? 43.323 -15.269 -5.497  1.00 0.00 ? 35 A   A C6    1 
+ATOM   757  N  N6    . A   A 1 35 ? 44.647 -15.344 -5.598  1.00 0.00 ? 35 A   A N6    1 
+ATOM   758  N  N1    . A   A 1 35 ? 42.625 -16.274 -4.961  1.00 0.00 ? 35 A   A N1    1 
+ATOM   759  C  C2    . A   A 1 35 ? 41.279 -16.251 -4.943  1.00 0.00 ? 35 A   A C2    1 
+ATOM   760  N  N3    . A   A 1 35 ? 40.593 -15.217 -5.459  1.00 0.00 ? 35 A   A N3    1 
+ATOM   761  C  C4    . A   A 1 35 ? 41.281 -14.154 -6.024  1.00 0.00 ? 35 A   A C4    1 
+ATOM   762  P  P     . A   A 1 36 ? 39.332 -8.094  -4.798  1.00 0.00 ? 36 A   A P     1 
+ATOM   763  O  OP1   . A   A 1 36 ? 38.383 -6.952  -4.877  1.00 0.00 ? 36 A   A OP1   1 
+ATOM   764  O  OP2   . A   A 1 36 ? 40.753 -7.859  -5.144  1.00 0.00 ? 36 A   A OP2   1 
+ATOM   765  O  "O5'" . A   A 1 36 ? 39.227 -8.736  -3.318  1.00 0.00 ? 36 A   A "O5'" 1 
+ATOM   766  C  "C5'" . A   A 1 36 ? 37.925 -8.819  -2.735  1.00 0.00 ? 36 A   A "C5'" 1 
+ATOM   767  C  "C4'" . A   A 1 36 ? 37.621 -10.237 -2.237  1.00 0.00 ? 36 A   A "C4'" 1 
+ATOM   768  O  "O4'" . A   A 1 36 ? 38.104 -11.210 -3.149  1.00 0.00 ? 36 A   A "O4'" 1 
+ATOM   769  C  "C3'" . A   A 1 36 ? 38.308 -10.517 -0.919  1.00 0.00 ? 36 A   A "C3'" 1 
+ATOM   770  O  "O3'" . A   A 1 36 ? 37.452 -10.013 0.095   1.00 0.00 ? 36 A   A "O3'" 1 
+ATOM   771  C  "C2'" . A   A 1 36 ? 38.372 -12.055 -0.944  1.00 0.00 ? 36 A   A "C2'" 1 
+ATOM   772  O  "O2'" . A   A 1 36 ? 37.170 -12.674 -0.514  1.00 0.00 ? 36 A   A "O2'" 1 
+ATOM   773  C  "C1'" . A   A 1 36 ? 38.585 -12.352 -2.430  1.00 0.00 ? 36 A   A "C1'" 1 
+ATOM   774  N  N9    . A   A 1 36 ? 40.025 -12.348 -2.637  1.00 0.00 ? 36 A   A N9    1 
+ATOM   775  C  C8    . A   A 1 36 ? 40.738 -11.293 -3.072  1.00 0.00 ? 36 A   A C8    1 
+ATOM   776  N  N7    . A   A 1 36 ? 42.061 -11.645 -3.113  1.00 0.00 ? 36 A   A N7    1 
+ATOM   777  C  C5    . A   A 1 36 ? 42.137 -12.948 -2.637  1.00 0.00 ? 36 A   A C5    1 
+ATOM   778  C  C6    . A   A 1 36 ? 43.207 -13.820 -2.457  1.00 0.00 ? 36 A   A C6    1 
+ATOM   779  N  N6    . A   A 1 36 ? 44.437 -13.439 -2.805  1.00 0.00 ? 36 A   A N6    1 
+ATOM   780  N  N1    . A   A 1 36 ? 42.993 -15.034 -1.942  1.00 0.00 ? 36 A   A N1    1 
+ATOM   781  C  C2    . A   A 1 36 ? 41.759 -15.435 -1.600  1.00 0.00 ? 36 A   A C2    1 
+ATOM   782  N  N3    . A   A 1 36 ? 40.703 -14.639 -1.784  1.00 0.00 ? 36 A   A N3    1 
+ATOM   783  C  C4    . A   A 1 36 ? 40.881 -13.378 -2.320  1.00 0.00 ? 36 A   A C4    1 
+HETATM 784  N  N1    . YG  A 1 37 ? 46.372 -14.527 1.026   1.00 0.00 ? 37 YG  A N1    1 
+HETATM 785  N  N2    . YG  A 1 37 ? 46.596 -16.095 2.657   1.00 0.00 ? 37 YG  A N2    1 
+HETATM 786  C  C2    . YG  A 1 37 ? 45.770 -15.207 2.030   1.00 0.00 ? 37 YG  A C2    1 
+HETATM 787  N  N3    . YG  A 1 37 ? 44.469 -14.987 2.455   1.00 0.00 ? 37 YG  A N3    1 
+HETATM 788  C  C3    . YG  A 1 37 ? 43.723 -16.080 3.095   1.00 0.00 ? 37 YG  A C3    1 
+HETATM 789  C  C4    . YG  A 1 37 ? 43.838 -13.941 1.759   1.00 0.00 ? 37 YG  A C4    1 
+HETATM 790  C  C5    . YG  A 1 37 ? 44.483 -13.219 0.750   1.00 0.00 ? 37 YG  A C5    1 
+HETATM 791  C  C6    . YG  A 1 37 ? 45.770 -13.591 0.336   1.00 0.00 ? 37 YG  A C6    1 
+HETATM 792  O  O6    . YG  A 1 37 ? 46.210 -13.216 -0.759  1.00 0.00 ? 37 YG  A O6    1 
+HETATM 793  N  N7    . YG  A 1 37 ? 43.606 -12.250 0.257   1.00 0.00 ? 37 YG  A N7    1 
+HETATM 794  C  C8    . YG  A 1 37 ? 42.419 -12.394 0.934   1.00 0.00 ? 37 YG  A C8    1 
+HETATM 795  N  N9    . YG  A 1 37 ? 42.553 -13.408 1.851   1.00 0.00 ? 37 YG  A N9    1 
+HETATM 796  C  C10   . YG  A 1 37 ? 49.079 -16.506 2.539   1.00 0.00 ? 37 YG  A C10   1 
+HETATM 797  C  C11   . YG  A 1 37 ? 47.778 -15.986 2.007   1.00 0.00 ? 37 YG  A C11   1 
+HETATM 798  C  C12   . YG  A 1 37 ? 47.640 -15.040 0.923   1.00 0.00 ? 37 YG  A C12   1 
+HETATM 799  C  C13   . YG  A 1 37 ? 48.753 -14.676 -0.034  1.00 0.00 ? 37 YG  A C13   1 
+HETATM 800  C  C14   . YG  A 1 37 ? 49.029 -15.924 -0.888  1.00 0.00 ? 37 YG  A C14   1 
+HETATM 801  C  C15   . YG  A 1 37 ? 50.510 -16.234 -1.207  1.00 0.00 ? 37 YG  A C15   1 
+HETATM 802  C  C16   . YG  A 1 37 ? 50.381 -17.342 -2.215  1.00 0.00 ? 37 YG  A C16   1 
+HETATM 803  O  O17   . YG  A 1 37 ? 49.794 -18.389 -1.891  1.00 0.00 ? 37 YG  A O17   1 
+HETATM 804  O  O18   . YG  A 1 37 ? 50.957 -17.258 -3.313  1.00 0.00 ? 37 YG  A O18   1 
+HETATM 805  C  C19   . YG  A 1 37 ? 50.725 -18.442 -4.065  1.00 0.00 ? 37 YG  A C19   1 
+HETATM 806  N  N20   . YG  A 1 37 ? 51.204 -16.761 0.017   1.00 0.00 ? 37 YG  A N20   1 
+HETATM 807  C  C21   . YG  A 1 37 ? 52.320 -17.563 0.006   1.00 0.00 ? 37 YG  A C21   1 
+HETATM 808  O  O22   . YG  A 1 37 ? 52.914 -17.835 -1.048  1.00 0.00 ? 37 YG  A O22   1 
+HETATM 809  O  O23   . YG  A 1 37 ? 52.477 -18.345 0.958   1.00 0.00 ? 37 YG  A O23   1 
+HETATM 810  C  C24   . YG  A 1 37 ? 53.613 -19.176 0.732   1.00 0.00 ? 37 YG  A C24   1 
+HETATM 811  C  "C1'" . YG  A 1 37 ? 41.462 -13.888 2.757   1.00 0.00 ? 37 YG  A "C1'" 1 
+HETATM 812  C  "C2'" . YG  A 1 37 ? 41.762 -13.454 4.204   1.00 0.00 ? 37 YG  A "C2'" 1 
+HETATM 813  O  "O2'" . YG  A 1 37 ? 41.164 -14.324 5.148   1.00 0.00 ? 37 YG  A "O2'" 1 
+HETATM 814  C  "C3'" . YG  A 1 37 ? 41.178 -12.055 4.263   1.00 0.00 ? 37 YG  A "C3'" 1 
+HETATM 815  O  "O3'" . YG  A 1 37 ? 40.641 -11.669 5.518   1.00 0.00 ? 37 YG  A "O3'" 1 
+HETATM 816  C  "C4'" . YG  A 1 37 ? 40.017 -12.138 3.311   1.00 0.00 ? 37 YG  A "C4'" 1 
+HETATM 817  O  "O4'" . YG  A 1 37 ? 40.247 -13.216 2.397   1.00 0.00 ? 37 YG  A "O4'" 1 
+HETATM 818  C  "C5'" . YG  A 1 37 ? 39.976 -10.789 2.621   1.00 0.00 ? 37 YG  A "C5'" 1 
+HETATM 819  O  "O5'" . YG  A 1 37 ? 38.819 -10.817 1.841   1.00 0.00 ? 37 YG  A "O5'" 1 
+HETATM 820  P  P     . YG  A 1 37 ? 38.123 -9.451  1.432   1.00 0.00 ? 37 YG  A P     1 
+HETATM 821  O  OP1   . YG  A 1 37 ? 37.039 -9.086  2.397   1.00 0.00 ? 37 YG  A OP1   1 
+HETATM 822  O  OP2   . YG  A 1 37 ? 39.170 -8.445  1.084   1.00 0.00 ? 37 YG  A OP2   1 
+ATOM   823  P  P     . A   A 1 38 ? 41.099 -10.250 6.116   1.00 0.00 ? 38 A   A P     1 
+ATOM   824  O  OP1   . A   A 1 38 ? 40.236 -9.917  7.275   1.00 0.00 ? 38 A   A OP1   1 
+ATOM   825  O  OP2   . A   A 1 38 ? 41.273 -9.231  5.041   1.00 0.00 ? 38 A   A OP2   1 
+ATOM   826  O  "O5'" . A   A 1 38 ? 42.532 -10.705 6.658   1.00 0.00 ? 38 A   A "O5'" 1 
+ATOM   827  C  "C5'" . A   A 1 38 ? 42.584 -11.679 7.689   1.00 0.00 ? 38 A   A "C5'" 1 
+ATOM   828  C  "C4'" . A   A 1 38 ? 43.910 -12.439 7.584   1.00 0.00 ? 38 A   A "C4'" 1 
+ATOM   829  O  "O4'" . A   A 1 38 ? 44.015 -13.044 6.294   1.00 0.00 ? 38 A   A "O4'" 1 
+ATOM   830  C  "C3'" . A   A 1 38 ? 45.138 -11.536 7.782   1.00 0.00 ? 38 A   A "C3'" 1 
+ATOM   831  O  "O3'" . A   A 1 38 ? 45.463 -11.485 9.182   1.00 0.00 ? 38 A   A "O3'" 1 
+ATOM   832  C  "C2'" . A   A 1 38 ? 46.177 -12.387 7.047   1.00 0.00 ? 38 A   A "C2'" 1 
+ATOM   833  O  "O2'" . A   A 1 38 ? 46.755 -13.334 7.921   1.00 0.00 ? 38 A   A "O2'" 1 
+ATOM   834  C  "C1'" . A   A 1 38 ? 45.401 -13.144 5.959   1.00 0.00 ? 38 A   A "C1'" 1 
+ATOM   835  N  N9    . A   A 1 38 ? 45.635 -12.407 4.701   1.00 0.00 ? 38 A   A N9    1 
+ATOM   836  C  C8    . A   A 1 38 ? 44.750 -11.572 4.088   1.00 0.00 ? 38 A   A C8    1 
+ATOM   837  N  N7    . A   A 1 38 ? 45.390 -10.978 3.018   1.00 0.00 ? 38 A   A N7    1 
+ATOM   838  C  C5    . A   A 1 38 ? 46.696 -11.472 3.000   1.00 0.00 ? 38 A   A C5    1 
+ATOM   839  C  C6    . A   A 1 38 ? 47.837 -11.096 2.283   1.00 0.00 ? 38 A   A C6    1 
+ATOM   840  N  N6    . A   A 1 38 ? 47.797 -10.015 1.494   1.00 0.00 ? 38 A   A N6    1 
+ATOM   841  N  N1    . A   A 1 38 ? 49.004 -11.730 2.502   1.00 0.00 ? 38 A   A N1    1 
+ATOM   842  C  C2    . A   A 1 38 ? 49.103 -12.701 3.429   1.00 0.00 ? 38 A   A C2    1 
+ATOM   843  N  N3    . A   A 1 38 ? 48.049 -13.050 4.181   1.00 0.00 ? 38 A   A N3    1 
+ATOM   844  C  C4    . A   A 1 38 ? 46.823 -12.416 3.988   1.00 0.00 ? 38 A   A C4    1 
+HETATM 845  N  N1    . PSU A 1 39 ? 46.862 -8.681  5.301   1.00 0.00 ? 39 PSU A N1    1 
+HETATM 846  C  C2    . PSU A 1 39 ? 47.232 -7.999  4.210   1.00 0.00 ? 39 PSU A C2    1 
+HETATM 847  N  N3    . PSU A 1 39 ? 48.499 -8.017  3.793   1.00 0.00 ? 39 PSU A N3    1 
+HETATM 848  C  C4    . PSU A 1 39 ? 49.436 -8.707  4.446   1.00 0.00 ? 39 PSU A C4    1 
+HETATM 849  C  C5    . PSU A 1 39 ? 49.090 -9.409  5.592   1.00 0.00 ? 39 PSU A C5    1 
+HETATM 850  C  C6    . PSU A 1 39 ? 47.755 -9.386  5.998   1.00 0.00 ? 39 PSU A C6    1 
+HETATM 851  O  O2    . PSU A 1 39 ? 46.361 -7.552  3.447   1.00 0.00 ? 39 PSU A O2    1 
+HETATM 852  O  O4    . PSU A 1 39 ? 50.631 -8.598  4.127   1.00 0.00 ? 39 PSU A O4    1 
+HETATM 853  C  "C1'" . PSU A 1 39 ? 50.140 -10.189 6.355   1.00 0.00 ? 39 PSU A "C1'" 1 
+HETATM 854  C  "C2'" . PSU A 1 39 ? 50.874 -9.286  7.358   1.00 0.00 ? 39 PSU A "C2'" 1 
+HETATM 855  O  "O2'" . PSU A 1 39 ? 52.269 -9.576  7.400   1.00 0.00 ? 39 PSU A "O2'" 1 
+HETATM 856  C  "C3'" . PSU A 1 39 ? 50.254 -9.658  8.681   1.00 0.00 ? 39 PSU A "C3'" 1 
+HETATM 857  C  "C4'" . PSU A 1 39 ? 49.886 -11.108 8.477   1.00 0.00 ? 39 PSU A "C4'" 1 
+HETATM 858  O  "O3'" . PSU A 1 39 ? 51.222 -9.585  9.707   1.00 0.00 ? 39 PSU A "O3'" 1 
+HETATM 859  O  "O4'" . PSU A 1 39 ? 49.518 -11.231 7.110   1.00 0.00 ? 39 PSU A "O4'" 1 
+HETATM 860  C  "C5'" . PSU A 1 39 ? 48.677 -11.391 9.379   1.00 0.00 ? 39 PSU A "C5'" 1 
+HETATM 861  O  "O5'" . PSU A 1 39 ? 47.717 -10.370 9.099   1.00 0.00 ? 39 PSU A "O5'" 1 
+HETATM 862  P  P     . PSU A 1 39 ? 46.305 -10.277 9.860   1.00 0.00 ? 39 PSU A P     1 
+HETATM 863  O  OP1   . PSU A 1 39 ? 46.569 -10.534 11.301  1.00 0.00 ? 39 PSU A OP1   1 
+HETATM 864  O  OP2   . PSU A 1 39 ? 45.625 -9.016  9.509   1.00 0.00 ? 39 PSU A OP2   1 
+HETATM 865  P  P     . 5MC A 1 40 ? 51.342 -8.221  10.528  1.00 0.00 ? 40 5MC A P     1 
+HETATM 866  O  OP1   . 5MC A 1 40 ? 52.332 -8.386  11.610  1.00 0.00 ? 40 5MC A OP1   1 
+HETATM 867  O  OP2   . 5MC A 1 40 ? 49.967 -7.819  10.898  1.00 0.00 ? 40 5MC A OP2   1 
+HETATM 868  O  "O5'" . 5MC A 1 40 ? 51.912 -7.189  9.439   1.00 0.00 ? 40 5MC A "O5'" 1 
+HETATM 869  C  "C5'" . 5MC A 1 40 ? 53.324 -6.981  9.359   1.00 0.00 ? 40 5MC A "C5'" 1 
+HETATM 870  C  "C4'" . 5MC A 1 40 ? 53.689 -6.027  8.197   1.00 0.00 ? 40 5MC A "C4'" 1 
+HETATM 871  O  "O4'" . 5MC A 1 40 ? 53.064 -6.476  6.997   1.00 0.00 ? 40 5MC A "O4'" 1 
+HETATM 872  C  "C3'" . 5MC A 1 40 ? 53.245 -4.572  8.386   1.00 0.00 ? 40 5MC A "C3'" 1 
+HETATM 873  O  "O3'" . 5MC A 1 40 ? 54.202 -3.811  9.135   1.00 0.00 ? 40 5MC A "O3'" 1 
+HETATM 874  C  "C2'" . 5MC A 1 40 ? 53.346 -4.141  6.933   1.00 0.00 ? 40 5MC A "C2'" 1 
+HETATM 875  O  "O2'" . 5MC A 1 40 ? 54.716 -3.965  6.618   1.00 0.00 ? 40 5MC A "O2'" 1 
+HETATM 876  C  "C1'" . 5MC A 1 40 ? 52.849 -5.360  6.145   1.00 0.00 ? 40 5MC A "C1'" 1 
+HETATM 877  N  N1    . 5MC A 1 40 ? 51.392 -5.234  5.862   1.00 0.00 ? 40 5MC A N1    1 
+HETATM 878  C  C2    . 5MC A 1 40 ? 50.988 -4.553  4.774   1.00 0.00 ? 40 5MC A C2    1 
+HETATM 879  O  O2    . 5MC A 1 40 ? 51.777 -3.754  4.247   1.00 0.00 ? 40 5MC A O2    1 
+HETATM 880  N  N3    . 5MC A 1 40 ? 49.681 -4.426  4.491   1.00 0.00 ? 40 5MC A N3    1 
+HETATM 881  C  C4    . 5MC A 1 40 ? 48.746 -4.957  5.273   1.00 0.00 ? 40 5MC A C4    1 
+HETATM 882  N  N4    . 5MC A 1 40 ? 47.473 -4.632  5.086   1.00 0.00 ? 40 5MC A N4    1 
+HETATM 883  C  C5    . 5MC A 1 40 ? 49.136 -5.673  6.407   1.00 0.00 ? 40 5MC A C5    1 
+HETATM 884  C  C6    . 5MC A 1 40 ? 50.500 -5.801  6.673   1.00 0.00 ? 40 5MC A C6    1 
+HETATM 885  C  CM5   . 5MC A 1 40 ? 48.124 -6.078  7.444   1.00 0.00 ? 40 5MC A CM5   1 
+ATOM   886  P  P     . U   A 1 41 ? 53.809 -2.389  9.850   1.00 0.00 ? 41 U   A P     1 
+ATOM   887  O  OP1   . U   A 1 41 ? 55.009 -1.868  10.527  1.00 0.00 ? 41 U   A OP1   1 
+ATOM   888  O  OP2   . U   A 1 41 ? 52.590 -2.564  10.659  1.00 0.00 ? 41 U   A OP2   1 
+ATOM   889  O  "O5'" . U   A 1 41 ? 53.382 -1.415  8.631   1.00 0.00 ? 41 U   A "O5'" 1 
+ATOM   890  C  "C5'" . U   A 1 41 ? 54.343 -0.818  7.770   1.00 0.00 ? 41 U   A "C5'" 1 
+ATOM   891  C  "C4'" . U   A 1 41 ? 53.593 0.039   6.736   1.00 0.00 ? 41 U   A "C4'" 1 
+ATOM   892  O  "O4'" . U   A 1 41 ? 52.552 -0.728  6.155   1.00 0.00 ? 41 U   A "O4'" 1 
+ATOM   893  C  "C3'" . U   A 1 41 ? 52.808 1.145   7.393   1.00 0.00 ? 41 U   A "C3'" 1 
+ATOM   894  O  "O3'" . U   A 1 41 ? 53.695 2.182   7.757   1.00 0.00 ? 41 U   A "O3'" 1 
+ATOM   895  C  "C2'" . U   A 1 41 ? 51.917 1.541   6.225   1.00 0.00 ? 41 U   A "C2'" 1 
+ATOM   896  O  "O2'" . U   A 1 41 ? 52.671 2.235   5.238   1.00 0.00 ? 41 U   A "O2'" 1 
+ATOM   897  C  "C1'" . U   A 1 41 ? 51.583 0.174   5.643   1.00 0.00 ? 41 U   A "C1'" 1 
+ATOM   898  N  N1    . U   A 1 41 ? 50.272 -0.322  6.090   1.00 0.00 ? 41 U   A N1    1 
+ATOM   899  C  C2    . U   A 1 41 ? 49.131 0.191   5.553   1.00 0.00 ? 41 U   A C2    1 
+ATOM   900  O  O2    . U   A 1 41 ? 49.191 1.124   4.734   1.00 0.00 ? 41 U   A O2    1 
+ATOM   901  N  N3    . U   A 1 41 ? 47.928 -0.285  5.898   1.00 0.00 ? 41 U   A N3    1 
+ATOM   902  C  C4    . U   A 1 41 ? 47.808 -1.288  6.773   1.00 0.00 ? 41 U   A C4    1 
+ATOM   903  O  O4    . U   A 1 41 ? 46.751 -1.938  6.779   1.00 0.00 ? 41 U   A O4    1 
+ATOM   904  C  C5    . U   A 1 41 ? 48.971 -1.846  7.346   1.00 0.00 ? 41 U   A C5    1 
+ATOM   905  C  C6    . U   A 1 41 ? 50.220 -1.336  6.958   1.00 0.00 ? 41 U   A C6    1 
+ATOM   906  P  P     . G   A 1 42 ? 53.365 3.056   9.075   1.00 0.00 ? 42 G   A P     1 
+ATOM   907  O  OP1   . G   A 1 42 ? 54.509 3.991   9.203   1.00 0.00 ? 42 G   A OP1   1 
+ATOM   908  O  OP2   . G   A 1 42 ? 52.947 2.165   10.213  1.00 0.00 ? 42 G   A OP2   1 
+ATOM   909  O  "O5'" . G   A 1 42 ? 52.127 3.881   8.529   1.00 0.00 ? 42 G   A "O5'" 1 
+ATOM   910  C  "C5'" . G   A 1 42 ? 52.403 4.860   7.543   1.00 0.00 ? 42 G   A "C5'" 1 
+ATOM   911  C  "C4'" . G   A 1 42 ? 51.077 5.396   7.023   1.00 0.00 ? 42 G   A "C4'" 1 
+ATOM   912  O  "O4'" . G   A 1 42 ? 50.355 4.386   6.338   1.00 0.00 ? 42 G   A "O4'" 1 
+ATOM   913  C  "C3'" . G   A 1 42 ? 50.179 5.806   8.165   1.00 0.00 ? 42 G   A "C3'" 1 
+ATOM   914  O  "O3'" . G   A 1 42 ? 50.604 7.046   8.727   1.00 0.00 ? 42 G   A "O3'" 1 
+ATOM   915  C  "C2'" . G   A 1 42 ? 48.896 5.925   7.371   1.00 0.00 ? 42 G   A "C2'" 1 
+ATOM   916  O  "O2'" . G   A 1 42 ? 48.946 7.071   6.542   1.00 0.00 ? 42 G   A "O2'" 1 
+ATOM   917  C  "C1'" . G   A 1 42 ? 48.974 4.686   6.480   1.00 0.00 ? 42 G   A "C1'" 1 
+ATOM   918  N  N9    . G   A 1 42 ? 48.278 3.580   7.167   1.00 0.00 ? 42 G   A N9    1 
+ATOM   919  C  C8    . G   A 1 42 ? 48.814 2.607   7.981   1.00 0.00 ? 42 G   A C8    1 
+ATOM   920  N  N7    . G   A 1 42 ? 47.766 1.808   8.439   1.00 0.00 ? 42 G   A N7    1 
+ATOM   921  C  C5    . G   A 1 42 ? 46.606 2.358   7.905   1.00 0.00 ? 42 G   A C5    1 
+ATOM   922  C  C6    . G   A 1 42 ? 45.269 2.030   8.038   1.00 0.00 ? 42 G   A C6    1 
+ATOM   923  O  O6    . G   A 1 42 ? 44.971 0.909   8.471   1.00 0.00 ? 42 G   A O6    1 
+ATOM   924  N  N1    . G   A 1 42 ? 44.343 2.785   7.417   1.00 0.00 ? 42 G   A N1    1 
+ATOM   925  C  C2    . G   A 1 42 ? 44.683 3.838   6.662   1.00 0.00 ? 42 G   A C2    1 
+ATOM   926  N  N2    . G   A 1 42 ? 43.761 4.501   5.998   1.00 0.00 ? 42 G   A N2    1 
+ATOM   927  N  N3    . G   A 1 42 ? 45.944 4.170   6.498   1.00 0.00 ? 42 G   A N3    1 
+ATOM   928  C  C4    . G   A 1 42 ? 46.926 3.427   7.120   1.00 0.00 ? 42 G   A C4    1 
+ATOM   929  P  P     . G   A 1 43 ? 50.051 7.500   10.169  1.00 0.00 ? 43 G   A P     1 
+ATOM   930  O  OP1   . G   A 1 43 ? 50.843 8.647   10.660  1.00 0.00 ? 43 G   A OP1   1 
+ATOM   931  O  OP2   . G   A 1 43 ? 49.913 6.296   11.052  1.00 0.00 ? 43 G   A OP2   1 
+ATOM   932  O  "O5'" . G   A 1 43 ? 48.619 8.027   9.726   1.00 0.00 ? 43 G   A "O5'" 1 
+ATOM   933  C  "C5'" . G   A 1 43 ? 48.473 9.257   9.050   1.00 0.00 ? 43 G   A "C5'" 1 
+ATOM   934  C  "C4'" . G   A 1 43 ? 46.999 9.300   8.688   1.00 0.00 ? 43 G   A "C4'" 1 
+ATOM   935  O  "O4'" . G   A 1 43 ? 46.642 7.985   8.246   1.00 0.00 ? 43 G   A "O4'" 1 
+ATOM   936  C  "C3'" . G   A 1 43 ? 46.145 9.498   9.937   1.00 0.00 ? 43 G   A "C3'" 1 
+ATOM   937  O  "O3'" . G   A 1 43 ? 46.072 10.883  10.285  1.00 0.00 ? 43 G   A "O3'" 1 
+ATOM   938  C  "C2'" . G   A 1 43 ? 44.822 8.985   9.368   1.00 0.00 ? 43 G   A "C2'" 1 
+ATOM   939  O  "O2'" . G   A 1 43 ? 44.271 9.972   8.507   1.00 0.00 ? 43 G   A "O2'" 1 
+ATOM   940  C  "C1'" . G   A 1 43 ? 45.243 7.783   8.502   1.00 0.00 ? 43 G   A "C1'" 1 
+ATOM   941  N  N9    . G   A 1 43 ? 45.101 6.525   9.271   1.00 0.00 ? 43 G   A N9    1 
+ATOM   942  C  C8    . G   A 1 43 ? 46.112 5.912   9.945   1.00 0.00 ? 43 G   A C8    1 
+ATOM   943  N  N7    . G   A 1 43 ? 45.622 4.788   10.567  1.00 0.00 ? 43 G   A N7    1 
+ATOM   944  C  C5    . G   A 1 43 ? 44.274 4.747   10.276  1.00 0.00 ? 43 G   A C5    1 
+ATOM   945  C  C6    . G   A 1 43 ? 43.296 3.850   10.658  1.00 0.00 ? 43 G   A C6    1 
+ATOM   946  O  O6    . G   A 1 43 ? 43.645 2.759   11.141  1.00 0.00 ? 43 G   A O6    1 
+ATOM   947  N  N1    . G   A 1 43 ? 42.035 4.044   10.263  1.00 0.00 ? 43 G   A N1    1 
+ATOM   948  C  C2    . G   A 1 43 ? 41.690 5.073   9.488   1.00 0.00 ? 43 G   A C2    1 
+ATOM   949  N  N2    . G   A 1 43 ? 40.398 5.283   9.260   1.00 0.00 ? 43 G   A N2    1 
+ATOM   950  N  N3    . G   A 1 43 ? 42.613 5.960   9.066   1.00 0.00 ? 43 G   A N3    1 
+ATOM   951  C  C4    . G   A 1 43 ? 43.937 5.801   9.463   1.00 0.00 ? 43 G   A C4    1 
+ATOM   952  P  P     . A   A 1 44 ? 45.632 11.343  11.777  1.00 0.00 ? 44 A   A P     1 
+ATOM   953  O  OP1   . A   A 1 44 ? 45.829 12.790  11.905  1.00 0.00 ? 44 A   A OP1   1 
+ATOM   954  O  OP2   . A   A 1 44 ? 46.243 10.413  12.782  1.00 0.00 ? 44 A   A OP2   1 
+ATOM   955  O  "O5'" . A   A 1 44 ? 44.053 11.119  11.766  1.00 0.00 ? 44 A   A "O5'" 1 
+ATOM   956  C  "C5'" . A   A 1 44 ? 43.216 11.971  10.996  1.00 0.00 ? 44 A   A "C5'" 1 
+ATOM   957  C  "C4'" . A   A 1 44 ? 41.830 11.298  10.891  1.00 0.00 ? 44 A   A "C4'" 1 
+ATOM   958  O  "O4'" . A   A 1 44 ? 42.033 9.947   10.502  1.00 0.00 ? 44 A   A "O4'" 1 
+ATOM   959  C  "C3'" . A   A 1 44 ? 41.127 11.194  12.247  1.00 0.00 ? 44 A   A "C3'" 1 
+ATOM   960  O  "O3'" . A   A 1 44 ? 40.364 12.349  12.529  1.00 0.00 ? 44 A   A "O3'" 1 
+ATOM   961  C  "C2'" . A   A 1 44 ? 40.186 10.015  12.008  1.00 0.00 ? 44 A   A "C2'" 1 
+ATOM   962  O  "O2'" . A   A 1 44 ? 39.106 10.352  11.154  1.00 0.00 ? 44 A   A "O2'" 1 
+ATOM   963  C  "C1'" . A   A 1 44 ? 41.075 9.123   11.185  1.00 0.00 ? 44 A   A "C1'" 1 
+ATOM   964  N  N9    . A   A 1 44 ? 41.772 8.182   12.070  1.00 0.00 ? 44 A   A N9    1 
+ATOM   965  C  C8    . A   A 1 44 ? 43.100 8.179   12.346  1.00 0.00 ? 44 A   A C8    1 
+ATOM   966  N  N7    . A   A 1 44 ? 43.387 7.034   13.057  1.00 0.00 ? 44 A   A N7    1 
+ATOM   967  C  C5    . A   A 1 44 ? 42.214 6.303   13.116  1.00 0.00 ? 44 A   A C5    1 
+ATOM   968  C  C6    . A   A 1 44 ? 41.953 4.992   13.493  1.00 0.00 ? 44 A   A C6    1 
+ATOM   969  N  N6    . A   A 1 44 ? 42.851 4.318   14.198  1.00 0.00 ? 44 A   A N6    1 
+ATOM   970  N  N1    . A   A 1 44 ? 40.739 4.502   13.339  1.00 0.00 ? 44 A   A N1    1 
+ATOM   971  C  C2    . A   A 1 44 ? 39.754 5.237   12.818  1.00 0.00 ? 44 A   A C2    1 
+ATOM   972  N  N3    . A   A 1 44 ? 39.956 6.475   12.432  1.00 0.00 ? 44 A   A N3    1 
+ATOM   973  C  C4    . A   A 1 44 ? 41.209 7.035   12.568  1.00 0.00 ? 44 A   A C4    1 
+ATOM   974  P  P     . G   A 1 45 ? 40.314 12.923  14.024  1.00 0.00 ? 45 G   A P     1 
+ATOM   975  O  OP1   . G   A 1 45 ? 39.241 13.968  14.100  1.00 0.00 ? 45 G   A OP1   1 
+ATOM   976  O  OP2   . G   A 1 45 ? 41.716 13.256  14.385  1.00 0.00 ? 45 G   A OP2   1 
+ATOM   977  O  "O5'" . G   A 1 45 ? 39.819 11.677  14.882  1.00 0.00 ? 45 G   A "O5'" 1 
+ATOM   978  C  "C5'" . G   A 1 45 ? 38.436 11.344  14.886  1.00 0.00 ? 45 G   A "C5'" 1 
+ATOM   979  C  "C4'" . G   A 1 45 ? 38.251 10.046  15.680  1.00 0.00 ? 45 G   A "C4'" 1 
+ATOM   980  O  "O4'" . G   A 1 45 ? 39.192 9.073   15.231  1.00 0.00 ? 45 G   A "O4'" 1 
+ATOM   981  C  "C3'" . G   A 1 45 ? 38.582 10.217  17.156  1.00 0.00 ? 45 G   A "C3'" 1 
+ATOM   982  O  "O3'" . G   A 1 45 ? 37.448 10.726  17.830  1.00 0.00 ? 45 G   A "O3'" 1 
+ATOM   983  C  "C2'" . G   A 1 45 ? 38.747 8.756   17.537  1.00 0.00 ? 45 G   A "C2'" 1 
+ATOM   984  O  "O2'" . G   A 1 45 ? 37.445 8.195   17.638  1.00 0.00 ? 45 G   A "O2'" 1 
+ATOM   985  C  "C1'" . G   A 1 45 ? 39.402 8.140   16.290  1.00 0.00 ? 45 G   A "C1'" 1 
+ATOM   986  N  N9    . G   A 1 45 ? 40.863 7.946   16.416  1.00 0.00 ? 45 G   A N9    1 
+ATOM   987  C  C8    . G   A 1 45 ? 41.809 8.836   16.018  1.00 0.00 ? 45 G   A C8    1 
+ATOM   988  N  N7    . G   A 1 45 ? 43.053 8.302   16.262  1.00 0.00 ? 45 G   A N7    1 
+ATOM   989  C  C5    . G   A 1 45 ? 42.842 7.023   16.767  1.00 0.00 ? 45 G   A C5    1 
+ATOM   990  C  C6    . G   A 1 45 ? 43.720 6.011   17.163  1.00 0.00 ? 45 G   A C6    1 
+ATOM   991  O  O6    . G   A 1 45 ? 44.944 6.218   17.201  1.00 0.00 ? 45 G   A O6    1 
+ATOM   992  N  N1    . G   A 1 45 ? 43.232 4.861   17.612  1.00 0.00 ? 45 G   A N1    1 
+ATOM   993  C  C2    . G   A 1 45 ? 41.914 4.626   17.667  1.00 0.00 ? 45 G   A C2    1 
+ATOM   994  N  N2    . G   A 1 45 ? 41.485 3.493   18.226  1.00 0.00 ? 45 G   A N2    1 
+ATOM   995  N  N3    . G   A 1 45 ? 41.028 5.562   17.278  1.00 0.00 ? 45 G   A N3    1 
+ATOM   996  C  C4    . G   A 1 45 ? 41.488 6.788   16.831  1.00 0.00 ? 45 G   A C4    1 
+HETATM 997  P  P     . 7MG A 1 46 ? 37.547 12.150  18.559  1.00 0.00 ? 46 7MG A P     1 
+HETATM 998  O  OP1   . 7MG A 1 46 ? 36.562 13.047  17.929  1.00 0.00 ? 46 7MG A OP1   1 
+HETATM 999  O  OP2   . 7MG A 1 46 ? 38.940 12.638  18.636  1.00 0.00 ? 46 7MG A OP2   1 
+HETATM 1000 O  "O5'" . 7MG A 1 46 ? 37.078 11.760  20.038  1.00 0.00 ? 46 7MG A "O5'" 1 
+HETATM 1001 C  "C5'" . 7MG A 1 46 ? 37.855 10.769  20.677  1.00 0.00 ? 46 7MG A "C5'" 1 
+HETATM 1002 C  "C4'" . 7MG A 1 46 ? 37.584 10.772  22.175  1.00 0.00 ? 46 7MG A "C4'" 1 
+HETATM 1003 O  "O4'" . 7MG A 1 46 ? 38.798 10.250  22.723  1.00 0.00 ? 46 7MG A "O4'" 1 
+HETATM 1004 C  "C3'" . 7MG A 1 46 ? 37.528 12.257  22.581  1.00 0.00 ? 46 7MG A "C3'" 1 
+HETATM 1005 O  "O3'" . 7MG A 1 46 ? 36.969 12.471  23.874  1.00 0.00 ? 46 7MG A "O3'" 1 
+HETATM 1006 C  "C2'" . 7MG A 1 46 ? 38.992 12.648  22.633  1.00 0.00 ? 46 7MG A "C2'" 1 
+HETATM 1007 O  "O2'" . 7MG A 1 46 ? 39.206 13.619  23.658  1.00 0.00 ? 46 7MG A "O2'" 1 
+HETATM 1008 C  "C1'" . 7MG A 1 46 ? 39.605 11.349  23.112  1.00 0.00 ? 46 7MG A "C1'" 1 
+HETATM 1009 N  N9    . 7MG A 1 46 ? 40.996 11.220  22.721  1.00 0.00 ? 46 7MG A N9    1 
+HETATM 1010 C  C8    . 7MG A 1 46 ? 41.724 12.149  22.057  1.00 0.00 ? 46 7MG A C8    1 
+HETATM 1011 N  N7    . 7MG A 1 46 ? 42.975 11.664  21.911  1.00 0.00 ? 46 7MG A N7    1 
+HETATM 1012 C  C5    . 7MG A 1 46 ? 43.024 10.436  22.569  1.00 0.00 ? 46 7MG A C5    1 
+HETATM 1013 C  C6    . 7MG A 1 46 ? 43.990 9.436   22.687  1.00 0.00 ? 46 7MG A C6    1 
+HETATM 1014 O  O6    . 7MG A 1 46 ? 45.178 9.705   22.489  1.00 0.00 ? 46 7MG A O6    1 
+HETATM 1015 N  N1    . 7MG A 1 46 ? 43.698 8.336   23.374  1.00 0.00 ? 46 7MG A N1    1 
+HETATM 1016 C  C2    . 7MG A 1 46 ? 42.514 8.146   23.936  1.00 0.00 ? 46 7MG A C2    1 
+HETATM 1017 N  N2    . 7MG A 1 46 ? 42.349 7.149   24.774  1.00 0.00 ? 46 7MG A N2    1 
+HETATM 1018 N  N3    . 7MG A 1 46 ? 41.564 9.038   23.810  1.00 0.00 ? 46 7MG A N3    1 
+HETATM 1019 C  C4    . 7MG A 1 46 ? 41.799 10.189  23.093  1.00 0.00 ? 46 7MG A C4    1 
+HETATM 1020 C  CM7   . 7MG A 1 46 ? 44.134 12.551  21.742  1.00 0.00 ? 46 7MG A CM7   1 
+ATOM   1021 P  P     . U   A 1 47 ? 35.389 12.461  24.245  1.00 0.00 ? 47 U   A P     1 
+ATOM   1022 O  OP1   . U   A 1 47 ? 34.996 11.216  24.927  1.00 0.00 ? 47 U   A OP1   1 
+ATOM   1023 O  OP2   . U   A 1 47 ? 34.526 12.920  23.127  1.00 0.00 ? 47 U   A OP2   1 
+ATOM   1024 O  "O5'" . U   A 1 47 ? 35.447 13.600  25.319  1.00 0.00 ? 47 U   A "O5'" 1 
+ATOM   1025 C  "C5'" . U   A 1 47 ? 36.448 13.468  26.302  1.00 0.00 ? 47 U   A "C5'" 1 
+ATOM   1026 C  "C4'" . U   A 1 47 ? 36.723 14.876  26.759  1.00 0.00 ? 47 U   A "C4'" 1 
+ATOM   1027 O  "O4'" . U   A 1 47 ? 35.507 15.611  26.687  1.00 0.00 ? 47 U   A "O4'" 1 
+ATOM   1028 C  "C3'" . U   A 1 47 ? 37.208 14.898  28.198  1.00 0.00 ? 47 U   A "C3'" 1 
+ATOM   1029 O  "O3'" . U   A 1 47 ? 38.634 14.908  28.167  1.00 0.00 ? 47 U   A "O3'" 1 
+ATOM   1030 C  "C2'" . U   A 1 47 ? 36.674 16.256  28.641  1.00 0.00 ? 47 U   A "C2'" 1 
+ATOM   1031 O  "O2'" . U   A 1 47 ? 37.602 17.301  28.341  1.00 0.00 ? 47 U   A "O2'" 1 
+ATOM   1032 C  "C1'" . U   A 1 47 ? 35.396 16.473  27.821  1.00 0.00 ? 47 U   A "C1'" 1 
+ATOM   1033 N  N1    . U   A 1 47 ? 34.142 16.111  28.546  1.00 0.00 ? 47 U   A N1    1 
+ATOM   1034 C  C2    . U   A 1 47 ? 33.917 16.537  29.812  1.00 0.00 ? 47 U   A C2    1 
+ATOM   1035 O  O2    . U   A 1 47 ? 34.656 17.404  30.314  1.00 0.00 ? 47 U   A O2    1 
+ATOM   1036 N  N3    . U   A 1 47 ? 32.761 16.239  30.434  1.00 0.00 ? 47 U   A N3    1 
+ATOM   1037 C  C4    . U   A 1 47 ? 31.795 15.552  29.814  1.00 0.00 ? 47 U   A C4    1 
+ATOM   1038 O  O4    . U   A 1 47 ? 30.776 15.202  30.431  1.00 0.00 ? 47 U   A O4    1 
+ATOM   1039 C  C5    . U   A 1 47 ? 31.984 15.137  28.506  1.00 0.00 ? 47 U   A C5    1 
+ATOM   1040 C  C6    . U   A 1 47 ? 33.188 15.449  27.883  1.00 0.00 ? 47 U   A C6    1 
+ATOM   1041 P  P     . C   A 1 48 ? 39.512 15.072  29.497  1.00 0.00 ? 48 C   A P     1 
+ATOM   1042 O  OP1   . C   A 1 48 ? 38.868 16.000  30.467  1.00 0.00 ? 48 C   A OP1   1 
+ATOM   1043 O  OP2   . C   A 1 48 ? 40.853 15.564  29.087  1.00 0.00 ? 48 C   A OP2   1 
+ATOM   1044 O  "O5'" . C   A 1 48 ? 39.706 13.594  30.141  1.00 0.00 ? 48 C   A "O5'" 1 
+ATOM   1045 C  "C5'" . C   A 1 48 ? 38.811 12.499  30.014  1.00 0.00 ? 48 C   A "C5'" 1 
+ATOM   1046 C  "C4'" . C   A 1 48 ? 39.619 11.249  30.376  1.00 0.00 ? 48 C   A "C4'" 1 
+ATOM   1047 O  "O4'" . C   A 1 48 ? 40.844 11.341  29.678  1.00 0.00 ? 48 C   A "O4'" 1 
+ATOM   1048 C  "C3'" . C   A 1 48 ? 39.995 11.224  31.870  1.00 0.00 ? 48 C   A "C3'" 1 
+ATOM   1049 O  "O3'" . C   A 1 48 ? 39.885 9.878   32.334  1.00 0.00 ? 48 C   A "O3'" 1 
+ATOM   1050 C  "C2'" . C   A 1 48 ? 41.476 11.535  31.881  1.00 0.00 ? 48 C   A "C2'" 1 
+ATOM   1051 O  "O2'" . C   A 1 48 ? 42.083 10.803  32.943  1.00 0.00 ? 48 C   A "O2'" 1 
+ATOM   1052 C  "C1'" . C   A 1 48 ? 41.869 10.902  30.554  1.00 0.00 ? 48 C   A "C1'" 1 
+ATOM   1053 N  N1    . C   A 1 48 ? 43.167 11.406  30.062  1.00 0.00 ? 48 C   A N1    1 
+ATOM   1054 C  C2    . C   A 1 48 ? 44.269 10.623  30.074  1.00 0.00 ? 48 C   A C2    1 
+ATOM   1055 O  O2    . C   A 1 48 ? 44.281 9.571   30.736  1.00 0.00 ? 48 C   A O2    1 
+ATOM   1056 N  N3    . C   A 1 48 ? 45.429 11.091  29.613  1.00 0.00 ? 48 C   A N3    1 
+ATOM   1057 C  C4    . C   A 1 48 ? 45.532 12.324  29.132  1.00 0.00 ? 48 C   A C4    1 
+ATOM   1058 N  N4    . C   A 1 48 ? 46.686 12.754  28.614  1.00 0.00 ? 48 C   A N4    1 
+ATOM   1059 C  C5    . C   A 1 48 ? 44.409 13.131  29.092  1.00 0.00 ? 48 C   A C5    1 
+ATOM   1060 C  C6    . C   A 1 48 ? 43.213 12.627  29.559  1.00 0.00 ? 48 C   A C6    1 
+HETATM 1061 P  P     . 5MC A 1 49 ? 39.469 9.595   33.844  1.00 0.00 ? 49 5MC A P     1 
+HETATM 1062 O  OP1   . 5MC A 1 49 ? 39.689 10.824  34.613  1.00 0.00 ? 49 5MC A OP1   1 
+HETATM 1063 O  OP2   . 5MC A 1 49 ? 40.132 8.383   34.349  1.00 0.00 ? 49 5MC A OP2   1 
+HETATM 1064 O  "O5'" . 5MC A 1 49 ? 37.915 9.241   33.750  1.00 0.00 ? 49 5MC A "O5'" 1 
+HETATM 1065 C  "C5'" . 5MC A 1 49 ? 37.117 9.771   32.702  1.00 0.00 ? 49 5MC A "C5'" 1 
+HETATM 1066 C  "C4'" . 5MC A 1 49 ? 35.678 10.011  33.189  1.00 0.00 ? 49 5MC A "C4'" 1 
+HETATM 1067 O  "O4'" . 5MC A 1 49 ? 35.242 9.056   34.163  1.00 0.00 ? 49 5MC A "O4'" 1 
+HETATM 1068 C  "C3'" . 5MC A 1 49 ? 35.636 11.340  33.879  1.00 0.00 ? 49 5MC A "C3'" 1 
+HETATM 1069 O  "O3'" . 5MC A 1 49 ? 35.560 12.318  32.867  1.00 0.00 ? 49 5MC A "O3'" 1 
+HETATM 1070 C  "C2'" . 5MC A 1 49 ? 34.317 11.161  34.592  1.00 0.00 ? 49 5MC A "C2'" 1 
+HETATM 1071 O  "O2'" . 5MC A 1 49 ? 33.259 11.220  33.689  1.00 0.00 ? 49 5MC A "O2'" 1 
+HETATM 1072 C  "C1'" . 5MC A 1 49 ? 34.393 9.724   35.094  1.00 0.00 ? 49 5MC A "C1'" 1 
+HETATM 1073 N  N1    . 5MC A 1 49 ? 35.074 9.739   36.407  1.00 0.00 ? 49 5MC A N1    1 
+HETATM 1074 C  C2    . 5MC A 1 49 ? 34.392 10.087  37.499  1.00 0.00 ? 49 5MC A C2    1 
+HETATM 1075 O  O2    . 5MC A 1 49 ? 33.268 10.591  37.380  1.00 0.00 ? 49 5MC A O2    1 
+HETATM 1076 N  N3    . 5MC A 1 49 ? 34.969 10.080  38.714  1.00 0.00 ? 49 5MC A N3    1 
+HETATM 1077 C  C4    . 5MC A 1 49 ? 36.236 9.754   38.864  1.00 0.00 ? 49 5MC A C4    1 
+HETATM 1078 N  N4    . 5MC A 1 49 ? 36.819 9.917   40.029  1.00 0.00 ? 49 5MC A N4    1 
+HETATM 1079 C  C5    . 5MC A 1 49 ? 36.983 9.417   37.754  1.00 0.00 ? 49 5MC A C5    1 
+HETATM 1080 C  C6    . 5MC A 1 49 ? 36.355 9.411   36.499  1.00 0.00 ? 49 5MC A C6    1 
+HETATM 1081 C  CM5   . 5MC A 1 49 ? 38.479 9.334   37.866  1.00 0.00 ? 49 5MC A CM5   1 
+ATOM   1082 P  P     . U   A 1 50 ? 36.094 13.806  33.091  1.00 0.00 ? 50 U   A P     1 
+ATOM   1083 O  OP1   . U   A 1 50 ? 36.011 14.496  31.817  1.00 0.00 ? 50 U   A OP1   1 
+ATOM   1084 O  OP2   . U   A 1 50 ? 37.423 13.721  33.731  1.00 0.00 ? 50 U   A OP2   1 
+ATOM   1085 O  "O5'" . U   A 1 50 ? 35.002 14.457  34.075  1.00 0.00 ? 50 U   A "O5'" 1 
+ATOM   1086 C  "C5'" . U   A 1 50 ? 33.676 14.729  33.633  1.00 0.00 ? 50 U   A "C5'" 1 
+ATOM   1087 C  "C4'" . U   A 1 50 ? 32.818 15.350  34.763  1.00 0.00 ? 50 U   A "C4'" 1 
+ATOM   1088 O  "O4'" . U   A 1 50 ? 32.688 14.437  35.839  1.00 0.00 ? 50 U   A "O4'" 1 
+ATOM   1089 C  "C3'" . U   A 1 50 ? 33.510 16.573  35.324  1.00 0.00 ? 50 U   A "C3'" 1 
+ATOM   1090 O  "O3'" . U   A 1 50 ? 33.176 17.742  34.577  1.00 0.00 ? 50 U   A "O3'" 1 
+ATOM   1091 C  "C2'" . U   A 1 50 ? 32.930 16.609  36.730  1.00 0.00 ? 50 U   A "C2'" 1 
+ATOM   1092 O  "O2'" . U   A 1 50 ? 31.647 17.199  36.732  1.00 0.00 ? 50 U   A "O2'" 1 
+ATOM   1093 C  "C1'" . U   A 1 50 ? 32.775 15.127  37.077  1.00 0.00 ? 50 U   A "C1'" 1 
+ATOM   1094 N  N1    . U   A 1 50 ? 33.964 14.673  37.824  1.00 0.00 ? 50 U   A N1    1 
+ATOM   1095 C  C2    . U   A 1 50 ? 34.165 15.136  39.066  1.00 0.00 ? 50 U   A C2    1 
+ATOM   1096 O  O2    . U   A 1 50 ? 33.298 15.820  39.617  1.00 0.00 ? 50 U   A O2    1 
+ATOM   1097 N  N3    . U   A 1 50 ? 35.219 14.775  39.777  1.00 0.00 ? 50 U   A N3    1 
+ATOM   1098 C  C4    . U   A 1 50 ? 36.116 13.945  39.295  1.00 0.00 ? 50 U   A C4    1 
+ATOM   1099 O  O4    . U   A 1 50 ? 36.798 13.302  40.110  1.00 0.00 ? 50 U   A O4    1 
+ATOM   1100 C  C5    . U   A 1 50 ? 35.941 13.456  37.999  1.00 0.00 ? 50 U   A C5    1 
+ATOM   1101 C  C6    . U   A 1 50 ? 34.821 13.849  37.279  1.00 0.00 ? 50 U   A C6    1 
+ATOM   1102 P  P     . G   A 1 51 ? 34.176 19.001  34.678  1.00 0.00 ? 51 G   A P     1 
+ATOM   1103 O  OP1   . G   A 1 51 ? 33.768 19.990  33.684  1.00 0.00 ? 51 G   A OP1   1 
+ATOM   1104 O  OP2   . G   A 1 51 ? 35.594 18.552  34.642  1.00 0.00 ? 51 G   A OP2   1 
+ATOM   1105 O  "O5'" . G   A 1 51 ? 33.928 19.580  36.141  1.00 0.00 ? 51 G   A "O5'" 1 
+ATOM   1106 C  "C5'" . G   A 1 51 ? 32.813 20.408  36.462  1.00 0.00 ? 51 G   A "C5'" 1 
+ATOM   1107 C  "C4'" . G   A 1 51 ? 32.897 20.769  37.954  1.00 0.00 ? 51 G   A "C4'" 1 
+ATOM   1108 O  "O4'" . G   A 1 51 ? 33.004 19.561  38.696  1.00 0.00 ? 51 G   A "O4'" 1 
+ATOM   1109 C  "C3'" . G   A 1 51 ? 34.174 21.533  38.295  1.00 0.00 ? 51 G   A "C3'" 1 
+ATOM   1110 O  "O3'" . G   A 1 51 ? 34.027 22.930  38.076  1.00 0.00 ? 51 G   A "O3'" 1 
+ATOM   1111 C  "C2'" . G   A 1 51 ? 34.286 21.237  39.777  1.00 0.00 ? 51 G   A "C2'" 1 
+ATOM   1112 O  "O2'" . G   A 1 51 ? 33.478 22.075  40.561  1.00 0.00 ? 51 G   A "O2'" 1 
+ATOM   1113 C  "C1'" . G   A 1 51 ? 33.733 19.824  39.892  1.00 0.00 ? 51 G   A "C1'" 1 
+ATOM   1114 N  N9    . G   A 1 51 ? 34.887 18.943  39.913  1.00 0.00 ? 51 G   A N9    1 
+ATOM   1115 C  C8    . G   A 1 51 ? 35.449 18.344  38.849  1.00 0.00 ? 51 G   A C8    1 
+ATOM   1116 N  N7    . G   A 1 51 ? 36.505 17.610  39.286  1.00 0.00 ? 51 G   A N7    1 
+ATOM   1117 C  C5    . G   A 1 51 ? 36.609 17.831  40.648  1.00 0.00 ? 51 G   A C5    1 
+ATOM   1118 C  C6    . G   A 1 51 ? 37.439 17.309  41.620  1.00 0.00 ? 51 G   A C6    1 
+ATOM   1119 O  O6    . G   A 1 51 ? 37.930 16.196  41.421  1.00 0.00 ? 51 G   A O6    1 
+ATOM   1120 N  N1    . G   A 1 51 ? 37.308 17.741  42.873  1.00 0.00 ? 51 G   A N1    1 
+ATOM   1121 C  C2    . G   A 1 51 ? 36.384 18.630  43.214  1.00 0.00 ? 51 G   A C2    1 
+ATOM   1122 N  N2    . G   A 1 51 ? 36.290 19.028  44.455  1.00 0.00 ? 51 G   A N2    1 
+ATOM   1123 N  N3    . G   A 1 51 ? 35.552 19.104  42.333  1.00 0.00 ? 51 G   A N3    1 
+ATOM   1124 C  C4    . G   A 1 51 ? 35.639 18.689  41.025  1.00 0.00 ? 51 G   A C4    1 
+ATOM   1125 P  P     . U   A 1 52 ? 35.343 23.812  37.825  1.00 0.00 ? 52 U   A P     1 
+ATOM   1126 O  OP1   . U   A 1 52 ? 34.957 25.168  37.391  1.00 0.00 ? 52 U   A OP1   1 
+ATOM   1127 O  OP2   . U   A 1 52 ? 36.242 22.981  36.975  1.00 0.00 ? 52 U   A OP2   1 
+ATOM   1128 O  "O5'" . U   A 1 52 ? 35.970 23.942  39.274  1.00 0.00 ? 52 U   A "O5'" 1 
+ATOM   1129 C  "C5'" . U   A 1 52 ? 35.384 24.853  40.192  1.00 0.00 ? 52 U   A "C5'" 1 
+ATOM   1130 C  "C4'" . U   A 1 52 ? 35.971 24.542  41.563  1.00 0.00 ? 52 U   A "C4'" 1 
+ATOM   1131 O  "O4'" . U   A 1 52 ? 36.054 23.119  41.679  1.00 0.00 ? 52 U   A "O4'" 1 
+ATOM   1132 C  "C3'" . U   A 1 52 ? 37.415 24.977  41.681  1.00 0.00 ? 52 U   A "C3'" 1 
+ATOM   1133 O  "O3'" . U   A 1 52 ? 37.628 26.350  42.014  1.00 0.00 ? 52 U   A "O3'" 1 
+ATOM   1134 C  "C2'" . U   A 1 52 ? 37.826 24.119  42.859  1.00 0.00 ? 52 U   A "C2'" 1 
+ATOM   1135 O  "O2'" . U   A 1 52 ? 37.434 24.764  44.060  1.00 0.00 ? 52 U   A "O2'" 1 
+ATOM   1136 C  "C1'" . U   A 1 52 ? 37.050 22.820  42.642  1.00 0.00 ? 52 U   A "C1'" 1 
+ATOM   1137 N  N1    . U   A 1 52 ? 37.949 21.815  42.063  1.00 0.00 ? 52 U   A N1    1 
+ATOM   1138 C  C2    . U   A 1 52 ? 38.798 21.157  42.858  1.00 0.00 ? 52 U   A C2    1 
+ATOM   1139 O  O2    . U   A 1 52 ? 38.849 21.426  44.072  1.00 0.00 ? 52 U   A O2    1 
+ATOM   1140 N  N3    . U   A 1 52 ? 39.649 20.268  42.358  1.00 0.00 ? 52 U   A N3    1 
+ATOM   1141 C  C4    . U   A 1 52 ? 39.674 19.979  41.068  1.00 0.00 ? 52 U   A C4    1 
+ATOM   1142 O  O4    . U   A 1 52 ? 40.329 18.996  40.679  1.00 0.00 ? 52 U   A O4    1 
+ATOM   1143 C  C5    . U   A 1 52 ? 38.771 20.614  40.211  1.00 0.00 ? 52 U   A C5    1 
+ATOM   1144 C  C6    . U   A 1 52 ? 37.893 21.544  40.756  1.00 0.00 ? 52 U   A C6    1 
+ATOM   1145 P  P     . G   A 1 53 ? 39.095 26.932  41.612  1.00 0.00 ? 53 G   A P     1 
+ATOM   1146 O  OP1   . G   A 1 53 ? 39.149 28.384  41.933  1.00 0.00 ? 53 G   A OP1   1 
+ATOM   1147 O  OP2   . G   A 1 53 ? 39.366 26.466  40.217  1.00 0.00 ? 53 G   A OP2   1 
+ATOM   1148 O  "O5'" . G   A 1 53 ? 40.171 26.166  42.523  1.00 0.00 ? 53 G   A "O5'" 1 
+ATOM   1149 C  "C5'" . G   A 1 53 ? 40.462 26.653  43.810  1.00 0.00 ? 53 G   A "C5'" 1 
+ATOM   1150 C  "C4'" . G   A 1 53 ? 41.311 25.616  44.546  1.00 0.00 ? 53 G   A "C4'" 1 
+ATOM   1151 O  "O4'" . G   A 1 53 ? 40.915 24.310  44.181  1.00 0.00 ? 53 G   A "O4'" 1 
+ATOM   1152 C  "C3'" . G   A 1 53 ? 42.761 25.642  44.180  1.00 0.00 ? 53 G   A "C3'" 1 
+ATOM   1153 O  "O3'" . G   A 1 53 ? 43.417 26.681  44.873  1.00 0.00 ? 53 G   A "O3'" 1 
+ATOM   1154 C  "C2'" . G   A 1 53 ? 43.164 24.333  44.811  1.00 0.00 ? 53 G   A "C2'" 1 
+ATOM   1155 O  "O2'" . G   A 1 53 ? 43.188 24.515  46.210  1.00 0.00 ? 53 G   A "O2'" 1 
+ATOM   1156 C  "C1'" . G   A 1 53 ? 41.994 23.437  44.448  1.00 0.00 ? 53 G   A "C1'" 1 
+ATOM   1157 N  N9    . G   A 1 53 ? 42.298 22.705  43.216  1.00 0.00 ? 53 G   A N9    1 
+ATOM   1158 C  C8    . G   A 1 53 ? 41.693 22.866  42.021  1.00 0.00 ? 53 G   A C8    1 
+ATOM   1159 N  N7    . G   A 1 53 ? 42.241 21.967  41.132  1.00 0.00 ? 53 G   A N7    1 
+ATOM   1160 C  C5    . G   A 1 53 ? 43.239 21.274  41.813  1.00 0.00 ? 53 G   A C5    1 
+ATOM   1161 C  C6    . G   A 1 53 ? 44.071 20.201  41.470  1.00 0.00 ? 53 G   A C6    1 
+ATOM   1162 O  O6    . G   A 1 53 ? 43.853 19.533  40.443  1.00 0.00 ? 53 G   A O6    1 
+ATOM   1163 N  N1    . G   A 1 53 ? 44.967 19.764  42.352  1.00 0.00 ? 53 G   A N1    1 
+ATOM   1164 C  C2    . G   A 1 53 ? 45.071 20.305  43.572  1.00 0.00 ? 53 G   A C2    1 
+ATOM   1165 N  N2    . G   A 1 53 ? 46.193 20.129  44.261  1.00 0.00 ? 53 G   A N2    1 
+ATOM   1166 N  N3    . G   A 1 53 ? 44.259 21.274  43.952  1.00 0.00 ? 53 G   A N3    1 
+ATOM   1167 C  C4    . G   A 1 53 ? 43.308 21.774  43.078  1.00 0.00 ? 53 G   A C4    1 
+HETATM 1168 N  N1    . 5MU A 1 54 ? 47.464 22.781  42.919  1.00 0.00 ? 54 5MU A N1    1 
+HETATM 1169 C  C2    . 5MU A 1 54 ? 47.858 21.757  42.128  1.00 0.00 ? 54 5MU A C2    1 
+HETATM 1170 N  N3    . 5MU A 1 54 ? 47.337 21.610  40.899  1.00 0.00 ? 54 5MU A N3    1 
+HETATM 1171 C  C4    . 5MU A 1 54 ? 46.406 22.446  40.435  1.00 0.00 ? 54 5MU A C4    1 
+HETATM 1172 C  C5    . 5MU A 1 54 ? 45.952 23.475  41.248  1.00 0.00 ? 54 5MU A C5    1 
+HETATM 1173 C  C5M   . 5MU A 1 54 ? 44.740 24.261  40.866  1.00 0.00 ? 54 5MU A C5M   1 
+HETATM 1174 C  C6    . 5MU A 1 54 ? 46.497 23.610  42.514  1.00 0.00 ? 54 5MU A C6    1 
+HETATM 1175 O  O2    . 5MU A 1 54 ? 48.583 20.847  42.595  1.00 0.00 ? 54 5MU A O2    1 
+HETATM 1176 O  O4    . 5MU A 1 54 ? 45.973 22.326  39.274  1.00 0.00 ? 54 5MU A O4    1 
+HETATM 1177 C  "C1'" . 5MU A 1 54 ? 48.031 22.920  44.291  1.00 0.00 ? 54 5MU A "C1'" 1 
+HETATM 1178 C  "C2'" . 5MU A 1 54 ? 49.186 23.907  44.295  1.00 0.00 ? 54 5MU A "C2'" 1 
+HETATM 1179 O  "O2'" . 5MU A 1 54 ? 50.055 23.620  45.369  1.00 0.00 ? 54 5MU A "O2'" 1 
+HETATM 1180 C  "C3'" . 5MU A 1 54 ? 48.514 25.226  44.614  1.00 0.00 ? 54 5MU A "C3'" 1 
+HETATM 1181 C  "C4'" . 5MU A 1 54 ? 47.481 24.755  45.624  1.00 0.00 ? 54 5MU A "C4'" 1 
+HETATM 1182 O  "O3'" . 5MU A 1 54 ? 49.487 26.030  45.241  1.00 0.00 ? 54 5MU A "O3'" 1 
+HETATM 1183 O  "O4'" . 5MU A 1 54 ? 47.030 23.493  45.149  1.00 0.00 ? 54 5MU A "O4'" 1 
+HETATM 1184 C  "C5'" . 5MU A 1 54 ? 46.317 25.741  45.779  1.00 0.00 ? 54 5MU A "C5'" 1 
+HETATM 1185 O  "O5'" . 5MU A 1 54 ? 45.763 26.027  44.507  1.00 0.00 ? 54 5MU A "O5'" 1 
+HETATM 1186 P  P     . 5MU A 1 54 ? 44.776 27.254  44.271  1.00 0.00 ? 54 5MU A P     1 
+HETATM 1187 O  OP1   . 5MU A 1 54 ? 45.165 28.396  45.104  1.00 0.00 ? 54 5MU A OP1   1 
+HETATM 1188 O  OP2   . 5MU A 1 54 ? 44.642 27.451  42.810  1.00 0.00 ? 54 5MU A OP2   1 
+HETATM 1189 N  N1    . PSU A 1 55 ? 48.050 25.876  39.887  1.00 0.00 ? 55 PSU A N1    1 
+HETATM 1190 C  C2    . PSU A 1 55 ? 47.598 25.286  38.777  1.00 0.00 ? 55 PSU A C2    1 
+HETATM 1191 N  N3    . PSU A 1 55 ? 48.283 24.281  38.221  1.00 0.00 ? 55 PSU A N3    1 
+HETATM 1192 C  C4    . PSU A 1 55 ? 49.436 23.867  38.731  1.00 0.00 ? 55 PSU A C4    1 
+HETATM 1193 C  C5    . PSU A 1 55 ? 49.942 24.469  39.863  1.00 0.00 ? 55 PSU A C5    1 
+HETATM 1194 C  C6    . PSU A 1 55 ? 49.198 25.494  40.447  1.00 0.00 ? 55 PSU A C6    1 
+HETATM 1195 O  O2    . PSU A 1 55 ? 46.732 25.866  38.100  1.00 0.00 ? 55 PSU A O2    1 
+HETATM 1196 O  O4    . PSU A 1 55 ? 50.112 23.017  38.146  1.00 0.00 ? 55 PSU A O4    1 
+HETATM 1197 C  "C1'" . PSU A 1 55 ? 51.278 24.026  40.413  1.00 0.00 ? 55 PSU A "C1'" 1 
+HETATM 1198 C  "C2'" . PSU A 1 55 ? 52.379 25.010  39.948  1.00 0.00 ? 55 PSU A "C2'" 1 
+HETATM 1199 O  "O2'" . PSU A 1 55 ? 53.613 24.339  39.942  1.00 0.00 ? 55 PSU A "O2'" 1 
+HETATM 1200 C  "C3'" . PSU A 1 55 ? 52.463 25.958  41.107  1.00 0.00 ? 55 PSU A "C3'" 1 
+HETATM 1201 C  "C4'" . PSU A 1 55 ? 52.335 24.933  42.218  1.00 0.00 ? 55 PSU A "C4'" 1 
+HETATM 1202 O  "O3'" . PSU A 1 55 ? 53.752 26.543  41.161  1.00 0.00 ? 55 PSU A "O3'" 1 
+HETATM 1203 O  "O4'" . PSU A 1 55 ? 51.250 24.110  41.829  1.00 0.00 ? 55 PSU A "O4'" 1 
+HETATM 1204 C  "C5'" . PSU A 1 55 ? 52.028 25.646  43.518  1.00 0.00 ? 55 PSU A "C5'" 1 
+HETATM 1205 O  "O5'" . PSU A 1 55 ? 50.913 26.466  43.248  1.00 0.00 ? 55 PSU A "O5'" 1 
+HETATM 1206 P  P     . PSU A 1 55 ? 50.137 27.236  44.414  1.00 0.00 ? 55 PSU A P     1 
+HETATM 1207 O  OP1   . PSU A 1 55 ? 51.105 27.968  45.281  1.00 0.00 ? 55 PSU A OP1   1 
+HETATM 1208 O  OP2   . PSU A 1 55 ? 49.044 28.028  43.770  1.00 0.00 ? 55 PSU A OP2   1 
+ATOM   1209 P  P     . C   A 1 56 ? 53.879 28.091  40.838  1.00 0.00 ? 56 C   A P     1 
+ATOM   1210 O  OP1   . C   A 1 56 ? 55.143 28.534  41.450  1.00 0.00 ? 56 C   A OP1   1 
+ATOM   1211 O  OP2   . C   A 1 56 ? 52.593 28.739  41.161  1.00 0.00 ? 56 C   A OP2   1 
+ATOM   1212 O  "O5'" . C   A 1 56 ? 54.081 28.120  39.268  1.00 0.00 ? 56 C   A "O5'" 1 
+ATOM   1213 C  "C5'" . C   A 1 56 ? 53.922 29.367  38.606  1.00 0.00 ? 56 C   A "C5'" 1 
+ATOM   1214 C  "C4'" . C   A 1 56 ? 53.985 29.094  37.113  1.00 0.00 ? 56 C   A "C4'" 1 
+ATOM   1215 O  "O4'" . C   A 1 56 ? 55.302 28.609  36.860  1.00 0.00 ? 56 C   A "O4'" 1 
+ATOM   1216 C  "C3'" . C   A 1 56 ? 53.025 27.968  36.727  1.00 0.00 ? 56 C   A "C3'" 1 
+ATOM   1217 O  "O3'" . C   A 1 56 ? 51.737 28.473  36.350  1.00 0.00 ? 56 C   A "O3'" 1 
+ATOM   1218 C  "C2'" . C   A 1 56 ? 53.740 27.517  35.464  1.00 0.00 ? 56 C   A "C2'" 1 
+ATOM   1219 O  "O2'" . C   A 1 56 ? 53.453 28.509  34.475  1.00 0.00 ? 56 C   A "O2'" 1 
+ATOM   1220 C  "C1'" . C   A 1 56 ? 55.223 27.625  35.832  1.00 0.00 ? 56 C   A "C1'" 1 
+ATOM   1221 N  N1    . C   A 1 56 ? 55.921 26.357  36.287  1.00 0.00 ? 56 C   A N1    1 
+ATOM   1222 C  C2    . C   A 1 56 ? 56.365 25.492  35.387  1.00 0.00 ? 56 C   A C2    1 
+ATOM   1223 O  O2    . C   A 1 56 ? 56.041 25.647  34.205  1.00 0.00 ? 56 C   A O2    1 
+ATOM   1224 N  N3    . C   A 1 56 ? 57.045 24.417  35.732  1.00 0.00 ? 56 C   A N3    1 
+ATOM   1225 C  C4    . C   A 1 56 ? 57.359 24.177  36.946  1.00 0.00 ? 56 C   A C4    1 
+ATOM   1226 N  N4    . C   A 1 56 ? 58.231 23.218  37.212  1.00 0.00 ? 56 C   A N4    1 
+ATOM   1227 C  C5    . C   A 1 56 ? 57.001 25.076  37.906  1.00 0.00 ? 56 C   A C5    1 
+ATOM   1228 C  C6    . C   A 1 56 ? 56.289 26.195  37.550  1.00 0.00 ? 56 C   A C6    1 
+ATOM   1229 P  P     . G   A 1 57 ? 50.439 27.548  36.613  1.00 0.00 ? 57 G   A P     1 
+ATOM   1230 O  OP1   . G   A 1 57 ? 49.193 28.099  35.983  1.00 0.00 ? 57 G   A OP1   1 
+ATOM   1231 O  OP2   . G   A 1 57 ? 50.422 27.319  38.048  1.00 0.00 ? 57 G   A OP2   1 
+ATOM   1232 O  "O5'" . G   A 1 57 ? 50.832 26.230  35.822  1.00 0.00 ? 57 G   A "O5'" 1 
+ATOM   1233 C  "C5'" . G   A 1 57 ? 50.043 25.868  34.688  1.00 0.00 ? 57 G   A "C5'" 1 
+ATOM   1234 C  "C4'" . G   A 1 57 ? 50.769 24.776  33.885  1.00 0.00 ? 57 G   A "C4'" 1 
+ATOM   1235 O  "O4'" . G   A 1 57 ? 52.143 24.795  34.204  1.00 0.00 ? 57 G   A "O4'" 1 
+ATOM   1236 C  "C3'" . G   A 1 57 ? 50.323 23.381  34.205  1.00 0.00 ? 57 G   A "C3'" 1 
+ATOM   1237 O  "O3'" . G   A 1 57 ? 49.263 23.080  33.342  1.00 0.00 ? 57 G   A "O3'" 1 
+ATOM   1238 C  "C2'" . G   A 1 57 ? 51.496 22.625  33.674  1.00 0.00 ? 57 G   A "C2'" 1 
+ATOM   1239 O  "O2'" . G   A 1 57 ? 51.386 22.686  32.284  1.00 0.00 ? 57 G   A "O2'" 1 
+ATOM   1240 C  "C1'" . G   A 1 57 ? 52.672 23.486  34.059  1.00 0.00 ? 57 G   A "C1'" 1 
+ATOM   1241 N  N9    . G   A 1 57 ? 53.226 23.103  35.366  1.00 0.00 ? 57 G   A N9    1 
+ATOM   1242 C  C8    . G   A 1 57 ? 53.130 23.837  36.491  1.00 0.00 ? 57 G   A C8    1 
+ATOM   1243 N  N7    . G   A 1 57 ? 53.842 23.210  37.476  1.00 0.00 ? 57 G   A N7    1 
+ATOM   1244 C  C5    . G   A 1 57 ? 54.387 22.068  36.919  1.00 0.00 ? 57 G   A C5    1 
+ATOM   1245 C  C6    . G   A 1 57 ? 55.295 21.123  37.393  1.00 0.00 ? 57 G   A C6    1 
+ATOM   1246 O  O6    . G   A 1 57 ? 56.019 21.401  38.355  1.00 0.00 ? 57 G   A O6    1 
+ATOM   1247 N  N1    . G   A 1 57 ? 55.631 20.112  36.610  1.00 0.00 ? 57 G   A N1    1 
+ATOM   1248 C  C2    . G   A 1 57 ? 55.159 20.008  35.371  1.00 0.00 ? 57 G   A C2    1 
+ATOM   1249 N  N2    . G   A 1 57 ? 55.333 18.894  34.704  1.00 0.00 ? 57 G   A N2    1 
+ATOM   1250 N  N3    . G   A 1 57 ? 54.361 20.908  34.873  1.00 0.00 ? 57 G   A N3    1 
+ATOM   1251 C  C4    . G   A 1 57 ? 53.957 21.978  35.639  1.00 0.00 ? 57 G   A C4    1 
+HETATM 1252 P  P     . 1MA A 1 58 ? 47.841 22.745  33.940  1.00 0.00 ? 58 1MA A P     1 
+HETATM 1253 O  OP1   . 1MA A 1 58 ? 46.802 23.335  33.071  1.00 0.00 ? 58 1MA A OP1   1 
+HETATM 1254 O  OP2   . 1MA A 1 58 ? 47.837 22.995  35.376  1.00 0.00 ? 58 1MA A OP2   1 
+HETATM 1255 O  "O5'" . 1MA A 1 58 ? 47.714 21.197  33.730  1.00 0.00 ? 58 1MA A "O5'" 1 
+HETATM 1256 C  "C5'" . 1MA A 1 58 ? 48.698 20.345  34.238  1.00 0.00 ? 58 1MA A "C5'" 1 
+HETATM 1257 C  "C4'" . 1MA A 1 58 ? 48.275 18.905  34.015  1.00 0.00 ? 58 1MA A "C4'" 1 
+HETATM 1258 O  "O4'" . 1MA A 1 58 ? 48.785 18.312  35.192  1.00 0.00 ? 58 1MA A "O4'" 1 
+HETATM 1259 C  "C3'" . 1MA A 1 58 ? 46.746 18.816  34.143  1.00 0.00 ? 58 1MA A "C3'" 1 
+HETATM 1260 O  "O3'" . 1MA A 1 58 ? 46.254 17.531  33.799  1.00 0.00 ? 58 1MA A "O3'" 1 
+HETATM 1261 C  "C2'" . 1MA A 1 58 ? 46.562 18.914  35.632  1.00 0.00 ? 58 1MA A "C2'" 1 
+HETATM 1262 O  "O2'" . 1MA A 1 58 ? 45.388 18.228  35.967  1.00 0.00 ? 58 1MA A "O2'" 1 
+HETATM 1263 C  "C1'" . 1MA A 1 58 ? 47.713 18.070  36.086  1.00 0.00 ? 58 1MA A "C1'" 1 
+HETATM 1264 N  N9    . 1MA A 1 58 ? 48.117 18.387  37.433  1.00 0.00 ? 58 1MA A N9    1 
+HETATM 1265 C  C8    . 1MA A 1 58 ? 47.686 19.455  38.151  1.00 0.00 ? 58 1MA A C8    1 
+HETATM 1266 N  N7    . 1MA A 1 58 ? 48.302 19.430  39.380  1.00 0.00 ? 58 1MA A N7    1 
+HETATM 1267 C  C5    . 1MA A 1 58 ? 49.119 18.305  39.391  1.00 0.00 ? 58 1MA A C5    1 
+HETATM 1268 C  C6    . 1MA A 1 58 ? 49.979 17.774  40.355  1.00 0.00 ? 58 1MA A C6    1 
+HETATM 1269 N  N6    . 1MA A 1 58 ? 50.083 18.352  41.541  1.00 0.00 ? 58 1MA A N6    1 
+HETATM 1270 N  N1    . 1MA A 1 58 ? 50.654 16.659  40.093  1.00 0.00 ? 58 1MA A N1    1 
+HETATM 1271 C  CM1   . 1MA A 1 58 ? 51.535 16.107  41.118  1.00 0.00 ? 58 1MA A CM1   1 
+HETATM 1272 C  C2    . 1MA A 1 58 ? 50.535 16.035  38.915  1.00 0.00 ? 58 1MA A C2    1 
+HETATM 1273 N  N3    . 1MA A 1 58 ? 49.749 16.501  37.964  1.00 0.00 ? 58 1MA A N3    1 
+HETATM 1274 C  C4    . 1MA A 1 58 ? 49.013 17.658  38.185  1.00 0.00 ? 58 1MA A C4    1 
+ATOM   1275 P  P     . U   A 1 59 ? 46.385 16.863  32.340  1.00 0.00 ? 59 U   A P     1 
+ATOM   1276 O  OP1   . U   A 1 59 ? 47.792 16.620  31.985  1.00 0.00 ? 59 U   A OP1   1 
+ATOM   1277 O  OP2   . U   A 1 59 ? 45.538 17.633  31.424  1.00 0.00 ? 59 U   A OP2   1 
+ATOM   1278 O  "O5'" . U   A 1 59 ? 45.751 15.402  32.554  1.00 0.00 ? 59 U   A "O5'" 1 
+ATOM   1279 C  "C5'" . U   A 1 59 ? 44.488 15.209  33.184  1.00 0.00 ? 59 U   A "C5'" 1 
+ATOM   1280 C  "C4'" . U   A 1 59 ? 44.403 13.727  33.555  1.00 0.00 ? 59 U   A "C4'" 1 
+ATOM   1281 O  "O4'" . U   A 1 59 ? 45.121 12.981  32.583  1.00 0.00 ? 59 U   A "O4'" 1 
+ATOM   1282 C  "C3'" . U   A 1 59 ? 45.163 13.393  34.825  1.00 0.00 ? 59 U   A "C3'" 1 
+ATOM   1283 O  "O3'" . U   A 1 59 ? 44.341 13.589  35.956  1.00 0.00 ? 59 U   A "O3'" 1 
+ATOM   1284 C  "C2'" . U   A 1 59 ? 45.301 11.901  34.651  1.00 0.00 ? 59 U   A "C2'" 1 
+ATOM   1285 O  "O2'" . U   A 1 59 ? 44.004 11.406  34.857  1.00 0.00 ? 59 U   A "O2'" 1 
+ATOM   1286 C  "C1'" . U   A 1 59 ? 45.559 11.757  33.164  1.00 0.00 ? 59 U   A "C1'" 1 
+ATOM   1287 N  N1    . U   A 1 59 ? 46.986 11.600  32.815  1.00 0.00 ? 59 U   A N1    1 
+ATOM   1288 C  C2    . U   A 1 59 ? 47.676 10.551  33.256  1.00 0.00 ? 59 U   A C2    1 
+ATOM   1289 O  O2    . U   A 1 59 ? 47.061 9.598   33.757  1.00 0.00 ? 59 U   A O2    1 
+ATOM   1290 N  N3    . U   A 1 59 ? 48.959 10.374  32.899  1.00 0.00 ? 59 U   A N3    1 
+ATOM   1291 C  C4    . U   A 1 59 ? 49.571 11.210  32.078  1.00 0.00 ? 59 U   A C4    1 
+ATOM   1292 O  O4    . U   A 1 59 ? 50.791 11.108  31.895  1.00 0.00 ? 59 U   A O4    1 
+ATOM   1293 C  C5    . U   A 1 59 ? 48.880 12.304  31.571  1.00 0.00 ? 59 U   A C5    1 
+ATOM   1294 C  C6    . U   A 1 59 ? 47.557 12.477  31.969  1.00 0.00 ? 59 U   A C6    1 
+ATOM   1295 P  P     . C   A 1 60 ? 44.981 14.487  37.100  1.00 0.00 ? 60 C   A P     1 
+ATOM   1296 O  OP1   . C   A 1 60 ? 44.054 14.679  38.202  1.00 0.00 ? 60 C   A OP1   1 
+ATOM   1297 O  OP2   . C   A 1 60 ? 45.538 15.664  36.453  1.00 0.00 ? 60 C   A OP2   1 
+ATOM   1298 O  "O5'" . C   A 1 60 ? 46.168 13.557  37.560  1.00 0.00 ? 60 C   A "O5'" 1 
+ATOM   1299 C  "C5'" . C   A 1 60 ? 45.853 12.329  38.229  1.00 0.00 ? 60 C   A "C5'" 1 
+ATOM   1300 C  "C4'" . C   A 1 60 ? 47.150 11.531  38.542  1.00 0.00 ? 60 C   A "C4'" 1 
+ATOM   1301 O  "O4'" . C   A 1 60 ? 47.866 11.432  37.307  1.00 0.00 ? 60 C   A "O4'" 1 
+ATOM   1302 C  "C3'" . C   A 1 60 ? 48.104 12.215  39.532  1.00 0.00 ? 60 C   A "C3'" 1 
+ATOM   1303 O  "O3'" . C   A 1 60 ? 48.826 11.211  40.267  1.00 0.00 ? 60 C   A "O3'" 1 
+ATOM   1304 C  "C2'" . C   A 1 60 ? 49.067 12.912  38.572  1.00 0.00 ? 60 C   A "C2'" 1 
+ATOM   1305 O  "O2'" . C   A 1 60 ? 50.367 13.088  39.112  1.00 0.00 ? 60 C   A "O2'" 1 
+ATOM   1306 C  "C1'" . C   A 1 60 ? 49.194 11.869  37.504  1.00 0.00 ? 60 C   A "C1'" 1 
+ATOM   1307 N  N1    . C   A 1 60 ? 49.667 12.546  36.319  1.00 0.00 ? 60 C   A N1    1 
+ATOM   1308 C  C2    . C   A 1 60 ? 50.660 12.040  35.620  1.00 0.00 ? 60 C   A C2    1 
+ATOM   1309 O  O2    . C   A 1 60 ? 51.247 11.051  36.068  1.00 0.00 ? 60 C   A O2    1 
+ATOM   1310 N  N3    . C   A 1 60 ? 51.127 12.678  34.530  1.00 0.00 ? 60 C   A N3    1 
+ATOM   1311 C  C4    . C   A 1 60 ? 50.575 13.835  34.121  1.00 0.00 ? 60 C   A C4    1 
+ATOM   1312 N  N4    . C   A 1 60 ? 51.260 14.663  33.341  1.00 0.00 ? 60 C   A N4    1 
+ATOM   1313 C  C5    . C   A 1 60 ? 49.496 14.338  34.811  1.00 0.00 ? 60 C   A C5    1 
+ATOM   1314 C  C6    . C   A 1 60 ? 49.052 13.651  35.922  1.00 0.00 ? 60 C   A C6    1 
+ATOM   1315 P  P     . C   A 1 61 ? 48.323 10.608  41.680  1.00 0.00 ? 61 C   A P     1 
+ATOM   1316 O  OP1   . C   A 1 61 ? 49.269 9.580   42.074  1.00 0.00 ? 61 C   A OP1   1 
+ATOM   1317 O  OP2   . C   A 1 61 ? 46.876 10.309  41.607  1.00 0.00 ? 61 C   A OP2   1 
+ATOM   1318 O  "O5'" . C   A 1 61 ? 48.487 11.843  42.713  1.00 0.00 ? 61 C   A "O5'" 1 
+ATOM   1319 C  "C5'" . C   A 1 61 ? 49.723 12.064  43.402  1.00 0.00 ? 61 C   A "C5'" 1 
+ATOM   1320 C  "C4'" . C   A 1 61 ? 49.659 13.381  44.198  1.00 0.00 ? 61 C   A "C4'" 1 
+ATOM   1321 O  "O4'" . C   A 1 61 ? 49.911 14.515  43.377  1.00 0.00 ? 61 C   A "O4'" 1 
+ATOM   1322 C  "C3'" . C   A 1 61 ? 48.303 13.615  44.854  1.00 0.00 ? 61 C   A "C3'" 1 
+ATOM   1323 O  "O3'" . C   A 1 61 ? 48.286 12.943  46.100  1.00 0.00 ? 61 C   A "O3'" 1 
+ATOM   1324 C  "C2'" . C   A 1 61 ? 48.384 15.115  45.083  1.00 0.00 ? 61 C   A "C2'" 1 
+ATOM   1325 O  "O2'" . C   A 1 61 ? 49.101 15.407  46.242  1.00 0.00 ? 61 C   A "O2'" 1 
+ATOM   1326 C  "C1'" . C   A 1 61 ? 49.151 15.625  43.871  1.00 0.00 ? 61 C   A "C1'" 1 
+ATOM   1327 N  N1    . C   A 1 61 ? 48.157 15.944  42.835  1.00 0.00 ? 61 C   A N1    1 
+ATOM   1328 C  C2    . C   A 1 61 ? 47.433 17.045  42.945  1.00 0.00 ? 61 C   A C2    1 
+ATOM   1329 O  O2    . C   A 1 61 ? 47.820 17.922  43.721  1.00 0.00 ? 61 C   A O2    1 
+ATOM   1330 N  N3    . C   A 1 61 ? 46.540 17.367  42.013  1.00 0.00 ? 61 C   A N3    1 
+ATOM   1331 C  C4    . C   A 1 61 ? 46.344 16.603  40.935  1.00 0.00 ? 61 C   A C4    1 
+ATOM   1332 N  N4    . C   A 1 61 ? 45.585 17.040  39.934  1.00 0.00 ? 61 C   A N4    1 
+ATOM   1333 C  C5    . C   A 1 61 ? 47.085 15.450  40.785  1.00 0.00 ? 61 C   A C5    1 
+ATOM   1334 C  C6    . C   A 1 61 ? 48.015 15.140  41.772  1.00 0.00 ? 61 C   A C6    1 
+ATOM   1335 P  P     . A   A 1 62 ? 46.937 12.287  46.658  1.00 0.00 ? 62 A   A P     1 
+ATOM   1336 O  OP1   . A   A 1 62 ? 47.341 11.345  47.733  1.00 0.00 ? 62 A   A OP1   1 
+ATOM   1337 O  OP2   . A   A 1 62 ? 46.122 11.799  45.546  1.00 0.00 ? 62 A   A OP2   1 
+ATOM   1338 O  "O5'" . A   A 1 62 ? 46.206 13.557  47.257  1.00 0.00 ? 62 A   A "O5'" 1 
+ATOM   1339 C  "C5'" . A   A 1 62 ? 46.735 14.221  48.400  1.00 0.00 ? 62 A   A "C5'" 1 
+ATOM   1340 C  "C4'" . A   A 1 62 ? 45.927 15.507  48.615  1.00 0.00 ? 62 A   A "C4'" 1 
+ATOM   1341 O  "O4'" . A   A 1 62 ? 46.101 16.361  47.497  1.00 0.00 ? 62 A   A "O4'" 1 
+ATOM   1342 C  "C3'" . A   A 1 62 ? 44.440 15.222  48.658  1.00 0.00 ? 62 A   A "C3'" 1 
+ATOM   1343 O  "O3'" . A   A 1 62 ? 44.076 14.829  49.970  1.00 0.00 ? 62 A   A "O3'" 1 
+ATOM   1344 C  "C2'" . A   A 1 62 ? 43.905 16.599  48.354  1.00 0.00 ? 62 A   A "C2'" 1 
+ATOM   1345 O  "O2'" . A   A 1 62 ? 43.902 17.379  49.528  1.00 0.00 ? 62 A   A "O2'" 1 
+ATOM   1346 C  "C1'" . A   A 1 62 ? 44.929 17.151  47.362  1.00 0.00 ? 62 A   A "C1'" 1 
+ATOM   1347 N  N9    . A   A 1 62 ? 44.437 16.899  46.010  1.00 0.00 ? 62 A   A N9    1 
+ATOM   1348 C  C8    . A   A 1 62 ? 44.864 15.916  45.178  1.00 0.00 ? 62 A   A C8    1 
+ATOM   1349 N  N7    . A   A 1 62 ? 44.138 15.969  44.018  1.00 0.00 ? 62 A   A N7    1 
+ATOM   1350 C  C5    . A   A 1 62 ? 43.245 17.023  44.165  1.00 0.00 ? 62 A   A C5    1 
+ATOM   1351 C  C6    . A   A 1 62 ? 42.248 17.542  43.333  1.00 0.00 ? 62 A   A C6    1 
+ATOM   1352 N  N6    . A   A 1 62 ? 42.176 17.168  42.050  1.00 0.00 ? 62 A   A N6    1 
+ATOM   1353 N  N1    . A   A 1 62 ? 41.500 18.563  43.774  1.00 0.00 ? 62 A   A N1    1 
+ATOM   1354 C  C2    . A   A 1 62 ? 41.698 19.123  44.984  1.00 0.00 ? 62 A   A C2    1 
+ATOM   1355 N  N3    . A   A 1 62 ? 42.657 18.686  45.796  1.00 0.00 ? 62 A   A N3    1 
+ATOM   1356 C  C4    . A   A 1 62 ? 43.445 17.615  45.391  1.00 0.00 ? 62 A   A C4    1 
+ATOM   1357 P  P     . C   A 1 63 ? 42.865 13.828  50.218  1.00 0.00 ? 63 C   A P     1 
+ATOM   1358 O  OP1   . C   A 1 63 ? 43.031 13.445  51.617  1.00 0.00 ? 63 C   A OP1   1 
+ATOM   1359 O  OP2   . C   A 1 63 ? 42.813 12.750  49.159  1.00 0.00 ? 63 C   A OP2   1 
+ATOM   1360 O  "O5'" . C   A 1 63 ? 41.567 14.753  50.067  1.00 0.00 ? 63 C   A "O5'" 1 
+ATOM   1361 C  "C5'" . C   A 1 63 ? 41.294 15.691  51.085  1.00 0.00 ? 63 C   A "C5'" 1 
+ATOM   1362 C  "C4'" . C   A 1 63 ? 40.245 16.666  50.566  1.00 0.00 ? 63 C   A "C4'" 1 
+ATOM   1363 O  "O4'" . C   A 1 63 ? 40.704 17.201  49.342  1.00 0.00 ? 63 C   A "O4'" 1 
+ATOM   1364 C  "C3'" . C   A 1 63 ? 38.939 15.978  50.203  1.00 0.00 ? 63 C   A "C3'" 1 
+ATOM   1365 O  "O3'" . C   A 1 63 ? 38.121 15.785  51.343  1.00 0.00 ? 63 C   A "O3'" 1 
+ATOM   1366 C  "C2'" . C   A 1 63 ? 38.345 17.063  49.339  1.00 0.00 ? 63 C   A "C2'" 1 
+ATOM   1367 O  "O2'" . C   A 1 63 ? 37.813 18.091  50.149  1.00 0.00 ? 63 C   A "O2'" 1 
+ATOM   1368 C  "C1'" . C   A 1 63 ? 39.565 17.601  48.590  1.00 0.00 ? 63 C   A "C1'" 1 
+ATOM   1369 N  N1    . C   A 1 63 ? 39.630 16.963  47.264  1.00 0.00 ? 63 C   A N1    1 
+ATOM   1370 C  C2    . C   A 1 63 ? 38.845 17.419  46.280  1.00 0.00 ? 63 C   A C2    1 
+ATOM   1371 O  O2    . C   A 1 63 ? 38.036 18.333  46.518  1.00 0.00 ? 63 C   A O2    1 
+ATOM   1372 N  N3    . C   A 1 63 ? 38.856 16.849  45.074  1.00 0.00 ? 63 C   A N3    1 
+ATOM   1373 C  C4    . C   A 1 63 ? 39.656 15.808  44.820  1.00 0.00 ? 63 C   A C4    1 
+ATOM   1374 N  N4    . C   A 1 63 ? 39.752 15.309  43.577  1.00 0.00 ? 63 C   A N4    1 
+ATOM   1375 C  C5    . C   A 1 63 ? 40.474 15.325  45.815  1.00 0.00 ? 63 C   A C5    1 
+ATOM   1376 C  C6    . C   A 1 63 ? 40.434 15.934  47.060  1.00 0.00 ? 63 C   A C6    1 
+ATOM   1377 P  P     . A   A 1 64 ? 37.121 14.548  51.290  1.00 0.00 ? 64 A   A P     1 
+ATOM   1378 O  OP1   . A   A 1 64 ? 36.531 14.280  52.624  1.00 0.00 ? 64 A   A OP1   1 
+ATOM   1379 O  OP2   . A   A 1 64 ? 37.868 13.439  50.647  1.00 0.00 ? 64 A   A OP2   1 
+ATOM   1380 O  "O5'" . A   A 1 64 ? 35.972 15.076  50.303  1.00 0.00 ? 64 A   A "O5'" 1 
+ATOM   1381 C  "C5'" . A   A 1 64 ? 35.091 16.076  50.776  1.00 0.00 ? 64 A   A "C5'" 1 
+ATOM   1382 C  "C4'" . A   A 1 64 ? 34.131 16.466  49.654  1.00 0.00 ? 64 A   A "C4'" 1 
+ATOM   1383 O  "O4'" . A   A 1 64 ? 34.777 17.142  48.573  1.00 0.00 ? 64 A   A "O4'" 1 
+ATOM   1384 C  "C3'" . A   A 1 64 ? 33.413 15.262  49.079  1.00 0.00 ? 64 A   A "C3'" 1 
+ATOM   1385 O  "O3'" . A   A 1 64 ? 32.270 14.986  49.883  1.00 0.00 ? 64 A   A "O3'" 1 
+ATOM   1386 C  "C2'" . A   A 1 64 ? 32.961 15.920  47.773  1.00 0.00 ? 64 A   A "C2'" 1 
+ATOM   1387 O  "O2'" . A   A 1 64 ? 31.937 16.861  48.054  1.00 0.00 ? 64 A   A "O2'" 1 
+ATOM   1388 C  "C1'" . A   A 1 64 ? 34.190 16.704  47.347  1.00 0.00 ? 64 A   A "C1'" 1 
+ATOM   1389 N  N9    . A   A 1 64 ? 35.111 15.792  46.623  1.00 0.00 ? 64 A   A N9    1 
+ATOM   1390 C  C8    . A   A 1 64 ? 36.188 15.136  47.142  1.00 0.00 ? 64 A   A C8    1 
+ATOM   1391 N  N7    . A   A 1 64 ? 36.797 14.425  46.129  1.00 0.00 ? 64 A   A N7    1 
+ATOM   1392 C  C5    . A   A 1 64 ? 36.078 14.688  44.963  1.00 0.00 ? 64 A   A C5    1 
+ATOM   1393 C  C6    . A   A 1 64 ? 36.348 14.461  43.602  1.00 0.00 ? 64 A   A C6    1 
+ATOM   1394 N  N6    . A   A 1 64 ? 37.295 13.600  43.227  1.00 0.00 ? 64 A   A N6    1 
+ATOM   1395 N  N1    . A   A 1 64 ? 35.484 14.874  42.700  1.00 0.00 ? 64 A   A N1    1 
+ATOM   1396 C  C2    . A   A 1 64 ? 34.390 15.556  43.046  1.00 0.00 ? 64 A   A C2    1 
+ATOM   1397 N  N3    . A   A 1 64 ? 34.139 15.877  44.304  1.00 0.00 ? 64 A   A N3    1 
+ATOM   1398 C  C4    . A   A 1 64 ? 35.008 15.478  45.292  1.00 0.00 ? 64 A   A C4    1 
+ATOM   1399 P  P     . G   A 1 65 ? 31.450 13.612  49.661  1.00 0.00 ? 65 G   A P     1 
+ATOM   1400 O  OP1   . G   A 1 65 ? 30.260 13.622  50.558  1.00 0.00 ? 65 G   A OP1   1 
+ATOM   1401 O  OP2   . G   A 1 65 ? 32.415 12.506  49.727  1.00 0.00 ? 65 G   A OP2   1 
+ATOM   1402 O  "O5'" . G   A 1 65 ? 30.958 13.669  48.152  1.00 0.00 ? 65 G   A "O5'" 1 
+ATOM   1403 C  "C5'" . G   A 1 65 ? 29.830 14.442  47.794  1.00 0.00 ? 65 G   A "C5'" 1 
+ATOM   1404 C  "C4'" . G   A 1 65 ? 29.616 14.270  46.287  1.00 0.00 ? 65 G   A "C4'" 1 
+ATOM   1405 O  "O4'" . G   A 1 65 ? 30.765 14.713  45.579  1.00 0.00 ? 65 G   A "O4'" 1 
+ATOM   1406 C  "C3'" . G   A 1 65 ? 29.470 12.813  45.874  1.00 0.00 ? 65 G   A "C3'" 1 
+ATOM   1407 O  "O3'" . G   A 1 65 ? 28.150 12.344  46.086  1.00 0.00 ? 65 G   A "O3'" 1 
+ATOM   1408 C  "C2'" . G   A 1 65 ? 29.671 12.995  44.396  1.00 0.00 ? 65 G   A "C2'" 1 
+ATOM   1409 O  "O2'" . G   A 1 65 ? 28.488 13.499  43.838  1.00 0.00 ? 65 G   A "O2'" 1 
+ATOM   1410 C  "C1'" . G   A 1 65 ? 30.763 14.045  44.324  1.00 0.00 ? 65 G   A "C1'" 1 
+ATOM   1411 N  N9    . G   A 1 65 ? 31.992 13.261  44.213  1.00 0.00 ? 65 G   A N9    1 
+ATOM   1412 C  C8    . G   A 1 65 ? 32.814 12.888  45.231  1.00 0.00 ? 65 G   A C8    1 
+ATOM   1413 N  N7    . G   A 1 65 ? 33.826 12.126  44.702  1.00 0.00 ? 65 G   A N7    1 
+ATOM   1414 C  C5    . G   A 1 65 ? 33.574 12.014  43.338  1.00 0.00 ? 65 G   A C5    1 
+ATOM   1415 C  C6    . G   A 1 65 ? 34.275 11.409  42.292  1.00 0.00 ? 65 G   A C6    1 
+ATOM   1416 O  O6    . G   A 1 65 ? 35.297 10.754  42.539  1.00 0.00 ? 65 G   A O6    1 
+ATOM   1417 N  N1    . G   A 1 65 ? 33.775 11.458  41.041  1.00 0.00 ? 65 G   A N1    1 
+ATOM   1418 C  C2    . G   A 1 65 ? 32.615 12.107  40.784  1.00 0.00 ? 65 G   A C2    1 
+ATOM   1419 N  N2    . G   A 1 65 ? 32.224 12.288  39.530  1.00 0.00 ? 65 G   A N2    1 
+ATOM   1420 N  N3    . G   A 1 65 ? 31.942 12.717  41.757  1.00 0.00 ? 65 G   A N3    1 
+ATOM   1421 C  C4    . G   A 1 65 ? 32.429 12.695  43.048  1.00 0.00 ? 65 G   A C4    1 
+ATOM   1422 P  P     . A   A 1 66 ? 27.820 10.788  45.920  1.00 0.00 ? 66 A   A P     1 
+ATOM   1423 O  OP1   . A   A 1 66 ? 26.447 10.564  46.430  1.00 0.00 ? 66 A   A OP1   1 
+ATOM   1424 O  OP2   . A   A 1 66 ? 28.950 9.981   46.463  1.00 0.00 ? 66 A   A OP2   1 
+ATOM   1425 O  "O5'" . A   A 1 66 ? 27.770 10.561  44.338  1.00 0.00 ? 66 A   A "O5'" 1 
+ATOM   1426 C  "C5'" . A   A 1 66 ? 26.561 10.663  43.612  1.00 0.00 ? 66 A   A "C5'" 1 
+ATOM   1427 C  "C4'" . A   A 1 66 ? 26.989 10.472  42.174  1.00 0.00 ? 66 A   A "C4'" 1 
+ATOM   1428 O  "O4'" . A   A 1 66 ? 28.307 10.986  42.051  1.00 0.00 ? 66 A   A "O4'" 1 
+ATOM   1429 C  "C3'" . A   A 1 66 ? 27.189 9.025   41.880  1.00 0.00 ? 66 A   A "C3'" 1 
+ATOM   1430 O  "O3'" . A   A 1 66 ? 25.919 8.448   41.652  1.00 0.00 ? 66 A   A "O3'" 1 
+ATOM   1431 C  "C2'" . A   A 1 66 ? 28.050 9.130   40.621  1.00 0.00 ? 66 A   A "C2'" 1 
+ATOM   1432 O  "O2'" . A   A 1 66 ? 27.267 9.503   39.508  1.00 0.00 ? 66 A   A "O2'" 1 
+ATOM   1433 C  "C1'" . A   A 1 66 ? 28.962 10.301  40.982  1.00 0.00 ? 66 A   A "C1'" 1 
+ATOM   1434 N  N9    . A   A 1 66 ? 30.182 9.786   41.577  1.00 0.00 ? 66 A   A N9    1 
+ATOM   1435 C  C8    . A   A 1 66 ? 30.489 9.857   42.881  1.00 0.00 ? 66 A   A C8    1 
+ATOM   1436 N  N7    . A   A 1 66 ? 31.676 9.235   43.083  1.00 0.00 ? 66 A   A N7    1 
+ATOM   1437 C  C5    . A   A 1 66 ? 32.090 8.751   41.850  1.00 0.00 ? 66 A   A C5    1 
+ATOM   1438 C  C6    . A   A 1 66 ? 33.257 8.111   41.436  1.00 0.00 ? 66 A   A C6    1 
+ATOM   1439 N  N6    . A   A 1 66 ? 34.214 7.832   42.324  1.00 0.00 ? 66 A   A N6    1 
+ATOM   1440 N  N1    . A   A 1 66 ? 33.396 7.759   40.154  1.00 0.00 ? 66 A   A N1    1 
+ATOM   1441 C  C2    . A   A 1 66 ? 32.437 8.022   39.253  1.00 0.00 ? 66 A   A C2    1 
+ATOM   1442 N  N3    . A   A 1 66 ? 31.329 8.672   39.592  1.00 0.00 ? 66 A   A N3    1 
+ATOM   1443 C  C4    . A   A 1 66 ? 31.153 9.071   40.911  1.00 0.00 ? 66 A   A C4    1 
+ATOM   1444 P  P     . A   A 1 67 ? 25.780 6.899   42.000  1.00 0.00 ? 67 A   A P     1 
+ATOM   1445 O  OP1   . A   A 1 67 ? 24.355 6.518   41.920  1.00 0.00 ? 67 A   A OP1   1 
+ATOM   1446 O  OP2   . A   A 1 67 ? 26.570 6.529   43.204  1.00 0.00 ? 67 A   A OP2   1 
+ATOM   1447 O  "O5'" . A   A 1 67 ? 26.480 6.271   40.744  1.00 0.00 ? 67 A   A "O5'" 1 
+ATOM   1448 C  "C5'" . A   A 1 67 ? 25.796 6.283   39.503  1.00 0.00 ? 67 A   A "C5'" 1 
+ATOM   1449 C  "C4'" . A   A 1 67 ? 26.762 5.597   38.556  1.00 0.00 ? 67 A   A "C4'" 1 
+ATOM   1450 O  "O4'" . A   A 1 67 ? 28.022 6.236   38.741  1.00 0.00 ? 67 A   A "O4'" 1 
+ATOM   1451 C  "C3'" . A   A 1 67 ? 26.971 4.171   39.028  1.00 0.00 ? 67 A   A "C3'" 1 
+ATOM   1452 O  "O3'" . A   A 1 67 ? 25.983 3.274   38.507  1.00 0.00 ? 67 A   A "O3'" 1 
+ATOM   1453 C  "C2'" . A   A 1 67 ? 28.334 3.926   38.411  1.00 0.00 ? 67 A   A "C2'" 1 
+ATOM   1454 O  "O2'" . A   A 1 67 ? 28.164 3.777   37.017  1.00 0.00 ? 67 A   A "O2'" 1 
+ATOM   1455 C  "C1'" . A   A 1 67 ? 29.044 5.256   38.666  1.00 0.00 ? 67 A   A "C1'" 1 
+ATOM   1456 N  N9    . A   A 1 67 ? 29.832 5.239   39.937  1.00 0.00 ? 67 A   A N9    1 
+ATOM   1457 C  C8    . A   A 1 67 ? 29.533 5.866   41.083  1.00 0.00 ? 67 A   A C8    1 
+ATOM   1458 N  N7    . A   A 1 67 ? 30.574 5.672   41.981  1.00 0.00 ? 67 A   A N7    1 
+ATOM   1459 C  C5    . A   A 1 67 ? 31.545 4.937   41.320  1.00 0.00 ? 67 A   A C5    1 
+ATOM   1460 C  C6    . A   A 1 67 ? 32.853 4.544   41.653  1.00 0.00 ? 67 A   A C6    1 
+ATOM   1461 N  N6    . A   A 1 67 ? 33.269 4.555   42.921  1.00 0.00 ? 67 A   A N6    1 
+ATOM   1462 N  N1    . A   A 1 67 ? 33.565 3.865   40.765  1.00 0.00 ? 67 A   A N1    1 
+ATOM   1463 C  C2    . A   A 1 67 ? 33.087 3.580   39.552  1.00 0.00 ? 67 A   A C2    1 
+ATOM   1464 N  N3    . A   A 1 67 ? 31.880 3.961   39.184  1.00 0.00 ? 67 A   A N3    1 
+ATOM   1465 C  C4    . A   A 1 67 ? 31.073 4.657   40.071  1.00 0.00 ? 67 A   A C4    1 
+ATOM   1466 P  P     . U   A 1 68 ? 25.802 1.843   39.236  1.00 0.00 ? 68 U   A P     1 
+ATOM   1467 O  OP1   . U   A 1 68 ? 24.612 1.146   38.716  1.00 0.00 ? 68 U   A OP1   1 
+ATOM   1468 O  OP2   . U   A 1 68 ? 25.963 2.046   40.685  1.00 0.00 ? 68 U   A OP2   1 
+ATOM   1469 O  "O5'" . U   A 1 68 ? 27.051 0.993   38.818  1.00 0.00 ? 68 U   A "O5'" 1 
+ATOM   1470 C  "C5'" . U   A 1 68 ? 27.095 0.337   37.581  1.00 0.00 ? 68 U   A "C5'" 1 
+ATOM   1471 C  "C4'" . U   A 1 68 ? 28.484 -0.269  37.566  1.00 0.00 ? 68 U   A "C4'" 1 
+ATOM   1472 O  "O4'" . U   A 1 68 ? 29.421 0.715   38.000  1.00 0.00 ? 68 U   A "O4'" 1 
+ATOM   1473 C  "C3'" . U   A 1 68 ? 28.614 -1.360  38.614  1.00 0.00 ? 68 U   A "C3'" 1 
+ATOM   1474 O  "O3'" . U   A 1 68 ? 28.025 -2.554  38.112  1.00 0.00 ? 68 U   A "O3'" 1 
+ATOM   1475 C  "C2'" . U   A 1 68 ? 30.133 -1.460  38.572  1.00 0.00 ? 68 U   A "C2'" 1 
+ATOM   1476 O  "O2'" . U   A 1 68 ? 30.493 -2.064  37.338  1.00 0.00 ? 68 U   A "O2'" 1 
+ATOM   1477 C  "C1'" . U   A 1 68 ? 30.560 0.009   38.486  1.00 0.00 ? 68 U   A "C1'" 1 
+ATOM   1478 N  N1    . U   A 1 68 ? 30.839 0.540   39.820  1.00 0.00 ? 68 U   A N1    1 
+ATOM   1479 C  C2    . U   A 1 68 ? 32.053 0.363   40.365  1.00 0.00 ? 68 U   A C2    1 
+ATOM   1480 O  O2    . U   A 1 68 ? 32.801 -0.513  39.904  1.00 0.00 ? 68 U   A O2    1 
+ATOM   1481 N  N3    . U   A 1 68 ? 32.330 0.847   41.568  1.00 0.00 ? 68 U   A N3    1 
+ATOM   1482 C  C4    . U   A 1 68 ? 31.416 1.481   42.272  1.00 0.00 ? 68 U   A C4    1 
+ATOM   1483 O  O4    . U   A 1 68 ? 31.741 2.042   43.329  1.00 0.00 ? 68 U   A O4    1 
+ATOM   1484 C  C5    . U   A 1 68 ? 30.134 1.655   41.752  1.00 0.00 ? 68 U   A C5    1 
+ATOM   1485 C  C6    . U   A 1 68 ? 29.880 1.166   40.479  1.00 0.00 ? 68 U   A C6    1 
+ATOM   1486 P  P     . U   A 1 69 ? 27.633 -3.737  39.128  1.00 0.00 ? 69 U   A P     1 
+ATOM   1487 O  OP1   . U   A 1 69 ? 27.064 -4.859  38.344  1.00 0.00 ? 69 U   A OP1   1 
+ATOM   1488 O  OP2   . U   A 1 69 ? 26.907 -3.193  40.279  1.00 0.00 ? 69 U   A OP2   1 
+ATOM   1489 O  "O5'" . U   A 1 69 ? 29.063 -4.175  39.672  1.00 0.00 ? 69 U   A "O5'" 1 
+ATOM   1490 C  "C5'" . U   A 1 69 ? 29.862 -5.049  38.890  1.00 0.00 ? 69 U   A "C5'" 1 
+ATOM   1491 C  "C4'" . U   A 1 69 ? 31.119 -5.299  39.704  1.00 0.00 ? 69 U   A "C4'" 1 
+ATOM   1492 O  "O4'" . U   A 1 69 ? 31.630 -4.030  40.099  1.00 0.00 ? 69 U   A "O4'" 1 
+ATOM   1493 C  "C3'" . U   A 1 69 ? 30.760 -5.974  41.023  1.00 0.00 ? 69 U   A "C3'" 1 
+ATOM   1494 O  "O3'" . U   A 1 69 ? 30.601 -7.387  40.860  1.00 0.00 ? 69 U   A "O3'" 1 
+ATOM   1495 C  "C2'" . U   A 1 69 ? 31.997 -5.586  41.846  1.00 0.00 ? 69 U   A "C2'" 1 
+ATOM   1496 O  "O2'" . U   A 1 69 ? 33.127 -6.344  41.429  1.00 0.00 ? 69 U   A "O2'" 1 
+ATOM   1497 C  "C1'" . U   A 1 69 ? 32.261 -4.156  41.371  1.00 0.00 ? 69 U   A "C1'" 1 
+ATOM   1498 N  N1    . U   A 1 69 ? 31.662 -3.155  42.258  1.00 0.00 ? 69 U   A N1    1 
+ATOM   1499 C  C2    . U   A 1 69 ? 32.332 -2.730  43.337  1.00 0.00 ? 69 U   A C2    1 
+ATOM   1500 O  O2    . U   A 1 69 ? 33.477 -3.145  43.554  1.00 0.00 ? 69 U   A O2    1 
+ATOM   1501 N  N3    . U   A 1 69 ? 31.815 -1.810  44.147  1.00 0.00 ? 69 U   A N3    1 
+ATOM   1502 C  C4    . U   A 1 69 ? 30.636 -1.274  43.904  1.00 0.00 ? 69 U   A C4    1 
+ATOM   1503 O  O4    . U   A 1 69 ? 30.243 -0.320  44.585  1.00 0.00 ? 69 U   A O4    1 
+ATOM   1504 C  C5    . U   A 1 69 ? 29.931 -1.665  42.786  1.00 0.00 ? 69 U   A C5    1 
+ATOM   1505 C  C6    . U   A 1 69 ? 30.491 -2.625  41.954  1.00 0.00 ? 69 U   A C6    1 
+ATOM   1506 P  P     . C   A 1 70 ? 29.732 -8.195  41.958  1.00 0.00 ? 70 C   A P     1 
+ATOM   1507 O  OP1   . C   A 1 70 ? 29.406 -9.571  41.467  1.00 0.00 ? 70 C   A OP1   1 
+ATOM   1508 O  OP2   . C   A 1 70 ? 28.618 -7.293  42.327  1.00 0.00 ? 70 C   A OP2   1 
+ATOM   1509 O  "O5'" . C   A 1 70 ? 30.704 -8.299  43.224  1.00 0.00 ? 70 C   A "O5'" 1 
+ATOM   1510 C  "C5'" . C   A 1 70 ? 31.833 -9.161  43.208  1.00 0.00 ? 70 C   A "C5'" 1 
+ATOM   1511 C  "C4'" . C   A 1 70 ? 32.758 -8.842  44.405  1.00 0.00 ? 70 C   A "C4'" 1 
+ATOM   1512 O  "O4'" . C   A 1 70 ? 33.207 -7.488  44.392  1.00 0.00 ? 70 C   A "O4'" 1 
+ATOM   1513 C  "C3'" . C   A 1 70 ? 32.108 -9.034  45.774  1.00 0.00 ? 70 C   A "C3'" 1 
+ATOM   1514 O  "O3'" . C   A 1 70 ? 32.088 -10.414 46.118  1.00 0.00 ? 70 C   A "O3'" 1 
+ATOM   1515 C  "C2'" . C   A 1 70 ? 33.171 -8.317  46.596  1.00 0.00 ? 70 C   A "C2'" 1 
+ATOM   1516 O  "O2'" . C   A 1 70 ? 34.336 -9.119  46.660  1.00 0.00 ? 70 C   A "O2'" 1 
+ATOM   1517 C  "C1'" . C   A 1 70 ? 33.498 -7.101  45.740  1.00 0.00 ? 70 C   A "C1'" 1 
+ATOM   1518 N  N1    . C   A 1 70 ? 32.621 -5.974  46.158  1.00 0.00 ? 70 C   A N1    1 
+ATOM   1519 C  C2    . C   A 1 70 ? 32.981 -5.216  47.207  1.00 0.00 ? 70 C   A C2    1 
+ATOM   1520 O  O2    . C   A 1 70 ? 34.113 -5.344  47.678  1.00 0.00 ? 70 C   A O2    1 
+ATOM   1521 N  N3    . C   A 1 70 ? 32.229 -4.184  47.608  1.00 0.00 ? 70 C   A N3    1 
+ATOM   1522 C  C4    . C   A 1 70 ? 31.102 -3.867  46.973  1.00 0.00 ? 70 C   A C4    1 
+ATOM   1523 N  N4    . C   A 1 70 ? 30.378 -2.818  47.371  1.00 0.00 ? 70 C   A N4    1 
+ATOM   1524 C  C5    . C   A 1 70 ? 30.706 -4.623  45.871  1.00 0.00 ? 70 C   A C5    1 
+ATOM   1525 C  C6    . C   A 1 70 ? 31.510 -5.688  45.475  1.00 0.00 ? 70 C   A C6    1 
+ATOM   1526 P  P     . G   A 1 71 ? 31.226 -10.948 47.370  1.00 0.00 ? 71 G   A P     1 
+ATOM   1527 O  OP1   . G   A 1 71 ? 31.537 -12.391 47.508  1.00 0.00 ? 71 G   A OP1   1 
+ATOM   1528 O  OP2   . G   A 1 71 ? 29.821 -10.501 47.254  1.00 0.00 ? 71 G   A OP2   1 
+ATOM   1529 O  "O5'" . G   A 1 71 ? 31.851 -10.222 48.650  1.00 0.00 ? 71 G   A "O5'" 1 
+ATOM   1530 C  "C5'" . G   A 1 71 ? 32.755 -11.009 49.418  1.00 0.00 ? 71 G   A "C5'" 1 
+ATOM   1531 C  "C4'" . G   A 1 71 ? 33.302 -10.171 50.560  1.00 0.00 ? 71 G   A "C4'" 1 
+ATOM   1532 O  "O4'" . G   A 1 71 ? 33.485 -8.869  50.038  1.00 0.00 ? 71 G   A "O4'" 1 
+ATOM   1533 C  "C3'" . G   A 1 71 ? 32.293 -9.967  51.686  1.00 0.00 ? 71 G   A "C3'" 1 
+ATOM   1534 O  "O3'" . G   A 1 71 ? 32.270 -11.042 52.628  1.00 0.00 ? 71 G   A "O3'" 1 
+ATOM   1535 C  "C2'" . G   A 1 71 ? 32.856 -8.700  52.328  1.00 0.00 ? 71 G   A "C2'" 1 
+ATOM   1536 O  "O2'" . G   A 1 71 ? 33.846 -8.934  53.339  1.00 0.00 ? 71 G   A "O2'" 1 
+ATOM   1537 C  "C1'" . G   A 1 71 ? 33.462 -7.964  51.136  1.00 0.00 ? 71 G   A "C1'" 1 
+ATOM   1538 N  N9    . G   A 1 71 ? 32.509 -6.906  50.816  1.00 0.00 ? 71 G   A N9    1 
+ATOM   1539 C  C8    . G   A 1 71 ? 31.621 -6.879  49.783  1.00 0.00 ? 71 G   A C8    1 
+ATOM   1540 N  N7    . G   A 1 71 ? 30.905 -5.719  49.879  1.00 0.00 ? 71 G   A N7    1 
+ATOM   1541 C  C5    . G   A 1 71 ? 31.344 -5.077  51.031  1.00 0.00 ? 71 G   A C5    1 
+ATOM   1542 C  C6    . G   A 1 71 ? 30.957 -3.906  51.671  1.00 0.00 ? 71 G   A C6    1 
+ATOM   1543 O  O6    . G   A 1 71 ? 30.058 -3.201  51.191  1.00 0.00 ? 71 G   A O6    1 
+ATOM   1544 N  N1    . G   A 1 71 ? 31.555 -3.550  52.818  1.00 0.00 ? 71 G   A N1    1 
+ATOM   1545 C  C2    . G   A 1 71 ? 32.519 -4.304  53.384  1.00 0.00 ? 71 G   A C2    1 
+ATOM   1546 N  N2    . G   A 1 71 ? 33.311 -3.761  54.317  1.00 0.00 ? 71 G   A N2    1 
+ATOM   1547 N  N3    . G   A 1 71 ? 32.898 -5.432  52.804  1.00 0.00 ? 71 G   A N3    1 
+ATOM   1548 C  C4    . G   A 1 71 ? 32.310 -5.825  51.615  1.00 0.00 ? 71 G   A C4    1 
+ATOM   1549 P  P     . C   A 1 72 ? 30.858 -11.284 53.336  1.00 0.00 ? 72 C   A P     1 
+ATOM   1550 O  OP1   . C   A 1 72 ? 30.874 -12.510 54.144  1.00 0.00 ? 72 C   A OP1   1 
+ATOM   1551 O  OP2   . C   A 1 72 ? 29.834 -11.140 52.289  1.00 0.00 ? 72 C   A OP2   1 
+ATOM   1552 O  "O5'" . C   A 1 72 ? 30.739 -10.036 54.296  1.00 0.00 ? 72 C   A "O5'" 1 
+ATOM   1553 C  "C5'" . C   A 1 72 ? 31.447 -9.996  55.526  1.00 0.00 ? 72 C   A "C5'" 1 
+ATOM   1554 C  "C4'" . C   A 1 72 ? 31.078 -8.645  56.121  1.00 0.00 ? 72 C   A "C4'" 1 
+ATOM   1555 O  "O4'" . C   A 1 72 ? 31.072 -7.733  55.032  1.00 0.00 ? 72 C   A "O4'" 1 
+ATOM   1556 C  "C3'" . C   A 1 72 ? 29.610 -8.609  56.531  1.00 0.00 ? 72 C   A "C3'" 1 
+ATOM   1557 O  "O3'" . C   A 1 72 ? 29.360 -9.194  57.805  1.00 0.00 ? 72 C   A "O3'" 1 
+ATOM   1558 C  "C2'" . C   A 1 72 ? 29.407 -7.109  56.590  1.00 0.00 ? 72 C   A "C2'" 1 
+ATOM   1559 O  "O2'" . C   A 1 72 ? 30.021 -6.553  57.749  1.00 0.00 ? 72 C   A "O2'" 1 
+ATOM   1560 C  "C1'" . C   A 1 72 ? 30.212 -6.659  55.394  1.00 0.00 ? 72 C   A "C1'" 1 
+ATOM   1561 N  N1    . C   A 1 72 ? 29.306 -6.309  54.298  1.00 0.00 ? 72 C   A N1    1 
+ATOM   1562 C  C2    . C   A 1 72 ? 28.696 -5.141  54.356  1.00 0.00 ? 72 C   A C2    1 
+ATOM   1563 O  O2    . C   A 1 72 ? 29.038 -4.348  55.240  1.00 0.00 ? 72 C   A O2    1 
+ATOM   1564 N  N3    . C   A 1 72 ? 27.886 -4.720  53.391  1.00 0.00 ? 72 C   A N3    1 
+ATOM   1565 C  C4    . C   A 1 72 ? 27.662 -5.450  52.327  1.00 0.00 ? 72 C   A C4    1 
+ATOM   1566 N  N4    . C   A 1 72 ? 27.356 -4.807  51.209  1.00 0.00 ? 72 C   A N4    1 
+ATOM   1567 C  C5    . C   A 1 72 ? 28.288 -6.700  52.236  1.00 0.00 ? 72 C   A C5    1 
+ATOM   1568 C  C6    . C   A 1 72 ? 29.141 -7.108  53.263  1.00 0.00 ? 72 C   A C6    1 
+ATOM   1569 P  P     . A   A 1 73 ? 27.846 -9.558  58.168  1.00 0.00 ? 73 A   A P     1 
+ATOM   1570 O  OP1   . A   A 1 73 ? 27.884 -10.226 59.479  1.00 0.00 ? 73 A   A OP1   1 
+ATOM   1571 O  OP2   . A   A 1 73 ? 27.214 -10.253 57.023  1.00 0.00 ? 73 A   A OP2   1 
+ATOM   1572 O  "O5'" . A   A 1 73 ? 27.114 -8.144  58.331  1.00 0.00 ? 73 A   A "O5'" 1 
+ATOM   1573 C  "C5'" . A   A 1 73 ? 27.403 -7.310  59.456  1.00 0.00 ? 73 A   A "C5'" 1 
+ATOM   1574 C  "C4'" . A   A 1 73 ? 26.663 -5.966  59.336  1.00 0.00 ? 73 A   A "C4'" 1 
+ATOM   1575 O  "O4'" . A   A 1 73 ? 27.043 -5.302  58.141  1.00 0.00 ? 73 A   A "O4'" 1 
+ATOM   1576 C  "C3'" . A   A 1 73 ? 25.157 -6.131  59.204  1.00 0.00 ? 73 A   A "C3'" 1 
+ATOM   1577 O  "O3'" . A   A 1 73 ? 24.534 -6.262  60.469  1.00 0.00 ? 73 A   A "O3'" 1 
+ATOM   1578 C  "C2'" . A   A 1 73 ? 24.810 -4.761  58.658  1.00 0.00 ? 73 A   A "C2'" 1 
+ATOM   1579 O  "O2'" . A   A 1 73 ? 24.920 -3.805  59.690  1.00 0.00 ? 73 A   A "O2'" 1 
+ATOM   1580 C  "C1'" . A   A 1 73 ? 25.933 -4.535  57.671  1.00 0.00 ? 73 A   A "C1'" 1 
+ATOM   1581 N  N9    . A   A 1 73 ? 25.497 -5.077  56.371  1.00 0.00 ? 73 A   A N9    1 
+ATOM   1582 C  C8    . A   A 1 73 ? 25.805 -6.306  55.870  1.00 0.00 ? 73 A   A C8    1 
+ATOM   1583 N  N7    . A   A 1 73 ? 25.276 -6.407  54.608  1.00 0.00 ? 73 A   A N7    1 
+ATOM   1584 C  C5    . A   A 1 73 ? 24.599 -5.215  54.355  1.00 0.00 ? 73 A   A C5    1 
+ATOM   1585 C  C6    . A   A 1 73 ? 24.019 -4.680  53.200  1.00 0.00 ? 73 A   A C6    1 
+ATOM   1586 N  N6    . A   A 1 73 ? 23.817 -5.455  52.138  1.00 0.00 ? 73 A   A N6    1 
+ATOM   1587 N  N1    . A   A 1 73 ? 23.446 -3.480  53.253  1.00 0.00 ? 73 A   A N1    1 
+ATOM   1588 C  C2    . A   A 1 73 ? 23.438 -2.752  54.383  1.00 0.00 ? 73 A   A C2    1 
+ATOM   1589 N  N3    . A   A 1 73 ? 24.045 -3.187  55.482  1.00 0.00 ? 73 A   A N3    1 
+ATOM   1590 C  C4    . A   A 1 73 ? 24.667 -4.428  55.477  1.00 0.00 ? 73 A   A C4    1 
+ATOM   1591 P  P     . C   A 1 74 ? 23.083 -6.943  60.527  1.00 0.00 ? 74 C   A P     1 
+ATOM   1592 O  OP1   . C   A 1 74 ? 22.567 -6.766  61.910  1.00 0.00 ? 74 C   A OP1   1 
+ATOM   1593 O  OP2   . C   A 1 74 ? 23.174 -8.315  59.982  1.00 0.00 ? 74 C   A OP2   1 
+ATOM   1594 O  "O5'" . C   A 1 74 ? 22.193 -6.047  59.557  1.00 0.00 ? 74 C   A "O5'" 1 
+ATOM   1595 C  "C5'" . C   A 1 74 ? 21.661 -4.861  60.114  1.00 0.00 ? 74 C   A "C5'" 1 
+ATOM   1596 C  "C4'" . C   A 1 74 ? 20.580 -4.418  59.156  1.00 0.00 ? 74 C   A "C4'" 1 
+ATOM   1597 O  "O4'" . C   A 1 74 ? 21.142 -4.300  57.857  1.00 0.00 ? 74 C   A "O4'" 1 
+ATOM   1598 C  "C3'" . C   A 1 74 ? 19.560 -5.541  59.003  1.00 0.00 ? 74 C   A "C3'" 1 
+ATOM   1599 O  "O3'" . C   A 1 74 ? 18.692 -5.581  60.139  1.00 0.00 ? 74 C   A "O3'" 1 
+ATOM   1600 C  "C2'" . C   A 1 74 ? 18.874 -5.002  57.757  1.00 0.00 ? 74 C   A "C2'" 1 
+ATOM   1601 O  "O2'" . C   A 1 74 ? 18.083 -3.909  58.157  1.00 0.00 ? 74 C   A "O2'" 1 
+ATOM   1602 C  "C1'" . C   A 1 74 ? 20.068 -4.463  56.932  1.00 0.00 ? 74 C   A "C1'" 1 
+ATOM   1603 N  N1    . C   A 1 74 ? 20.534 -5.449  55.936  1.00 0.00 ? 74 C   A N1    1 
+ATOM   1604 C  C2    . C   A 1 74 ? 19.964 -5.491  54.718  1.00 0.00 ? 74 C   A C2    1 
+ATOM   1605 O  O2    . C   A 1 74 ? 19.242 -4.543  54.357  1.00 0.00 ? 74 C   A O2    1 
+ATOM   1606 N  N3    . C   A 1 74 ? 20.374 -6.383  53.800  1.00 0.00 ? 74 C   A N3    1 
+ATOM   1607 C  C4    . C   A 1 74 ? 21.361 -7.228  54.060  1.00 0.00 ? 74 C   A C4    1 
+ATOM   1608 N  N4    . C   A 1 74 ? 21.939 -7.882  53.058  1.00 0.00 ? 74 C   A N4    1 
+ATOM   1609 C  C5    . C   A 1 74 ? 21.981 -7.192  55.308  1.00 0.00 ? 74 C   A C5    1 
+ATOM   1610 C  C6    . C   A 1 74 ? 21.544 -6.262  56.243  1.00 0.00 ? 74 C   A C6    1 
+ATOM   1611 P  P     . C   A 1 75 ? 18.015 -6.964  60.608  1.00 0.00 ? 75 C   A P     1 
+ATOM   1612 O  OP1   . C   A 1 75 ? 17.546 -6.778  61.990  1.00 0.00 ? 75 C   A OP1   1 
+ATOM   1613 O  OP2   . C   A 1 75 ? 18.940 -8.079  60.315  1.00 0.00 ? 75 C   A OP2   1 
+ATOM   1614 O  "O5'" . C   A 1 75 ? 16.716 -7.130  59.707  1.00 0.00 ? 75 C   A "O5'" 1 
+ATOM   1615 C  "C5'" . C   A 1 75 ? 15.640 -6.214  59.821  1.00 0.00 ? 75 C   A "C5'" 1 
+ATOM   1616 C  "C4'" . C   A 1 75 ? 14.855 -6.313  58.510  1.00 0.00 ? 75 C   A "C4'" 1 
+ATOM   1617 O  "O4'" . C   A 1 75 ? 15.797 -6.156  57.438  1.00 0.00 ? 75 C   A "O4'" 1 
+ATOM   1618 C  "C3'" . C   A 1 75 ? 14.211 -7.700  58.319  1.00 0.00 ? 75 C   A "C3'" 1 
+ATOM   1619 O  "O3'" . C   A 1 75 ? 12.855 -7.781  58.767  1.00 0.00 ? 75 C   A "O3'" 1 
+ATOM   1620 C  "C2'" . C   A 1 75 ? 14.147 -7.709  56.805  1.00 0.00 ? 75 C   A "C2'" 1 
+ATOM   1621 O  "O2'" . C   A 1 75 ? 13.111 -6.822  56.381  1.00 0.00 ? 75 C   A "O2'" 1 
+ATOM   1622 C  "C1'" . C   A 1 75 ? 15.473 -7.084  56.392  1.00 0.00 ? 75 C   A "C1'" 1 
+ATOM   1623 N  N1    . C   A 1 75 ? 16.612 -8.039  56.213  1.00 0.00 ? 75 C   A N1    1 
+ATOM   1624 C  C2    . C   A 1 75 ? 16.561 -9.067  55.322  1.00 0.00 ? 75 C   A C2    1 
+ATOM   1625 O  O2    . C   A 1 75 ? 15.454 -9.511  54.967  1.00 0.00 ? 75 C   A O2    1 
+ATOM   1626 N  N3    . C   A 1 75 ? 17.668 -9.832  55.092  1.00 0.00 ? 75 C   A N3    1 
+ATOM   1627 C  C4    . C   A 1 75 ? 18.822 -9.594  55.738  1.00 0.00 ? 75 C   A C4    1 
+ATOM   1628 N  N4    . C   A 1 75 ? 19.874 -10.403 55.608  1.00 0.00 ? 75 C   A N4    1 
+ATOM   1629 C  C5    . C   A 1 75 ? 18.865 -8.570  56.662  1.00 0.00 ? 75 C   A C5    1 
+ATOM   1630 C  C6    . C   A 1 75 ? 17.728 -7.797  56.867  1.00 0.00 ? 75 C   A C6    1 
+ATOM   1631 P  P     . A   A 1 76 ? 12.264 -9.231  58.970  1.00 0.00 ? 76 A   A P     1 
+ATOM   1632 O  OP1   . A   A 1 76 ? 12.790 -9.675  60.257  1.00 0.00 ? 76 A   A OP1   1 
+ATOM   1633 O  OP2   . A   A 1 76 ? 12.602 -10.105 57.867  1.00 0.00 ? 76 A   A OP2   1 
+ATOM   1634 O  "O5'" . A   A 1 76 ? 10.679 -9.104  59.055  1.00 0.00 ? 76 A   A "O5'" 1 
+ATOM   1635 C  "C5'" . A   A 1 76 ? 9.825  -9.098  57.929  1.00 0.00 ? 76 A   A "C5'" 1 
+ATOM   1636 C  "C4'" . A   A 1 76 ? 8.364  -9.348  58.370  1.00 0.00 ? 76 A   A "C4'" 1 
+ATOM   1637 O  "O4'" . A   A 1 76 ? 8.367  -9.987  59.649  1.00 0.00 ? 76 A   A "O4'" 1 
+ATOM   1638 C  "C3'" . A   A 1 76 ? 7.584  -8.037  58.555  1.00 0.00 ? 76 A   A "C3'" 1 
+ATOM   1639 O  "O3'" . A   A 1 76 ? 6.222  -8.269  58.232  1.00 0.00 ? 76 A   A "O3'" 1 
+ATOM   1640 C  "C2'" . A   A 1 76 ? 7.687  -7.749  60.045  1.00 0.00 ? 76 A   A "C2'" 1 
+ATOM   1641 O  "O2'" . A   A 1 76 ? 6.523  -7.042  60.481  1.00 0.00 ? 76 A   A "O2'" 1 
+ATOM   1642 C  "C1'" . A   A 1 76 ? 7.696  -9.164  60.618  1.00 0.00 ? 76 A   A "C1'" 1 
+ATOM   1643 N  N9    . A   A 1 76 ? 8.430  -9.185  61.902  1.00 0.00 ? 76 A   A N9    1 
+ATOM   1644 C  C8    . A   A 1 76 ? 9.781  -9.097  62.038  1.00 0.00 ? 76 A   A C8    1 
+ATOM   1645 N  N7    . A   A 1 76 ? 10.101 -9.181  63.361  1.00 0.00 ? 76 A   A N7    1 
+ATOM   1646 C  C5    . A   A 1 76 ? 8.905  -9.328  64.047  1.00 0.00 ? 76 A   A C5    1 
+ATOM   1647 C  C6    . A   A 1 76 ? 8.626  -9.568  65.392  1.00 0.00 ? 76 A   A C6    1 
+ATOM   1648 N  N6    . A   A 1 76 ? 9.540  -9.257  66.289  1.00 0.00 ? 76 A   A N6    1 
+ATOM   1649 N  N1    . A   A 1 76 ? 7.358  -9.696  65.778  1.00 0.00 ? 76 A   A N1    1 
+ATOM   1650 C  C2    . A   A 1 76 ? 6.345  -9.605  64.898  1.00 0.00 ? 76 A   A C2    1 
+ATOM   1651 N  N3    . A   A 1 76 ? 6.568  -9.405  63.599  1.00 0.00 ? 76 A   A N3    1 
+ATOM   1652 C  C4    . A   A 1 76 ? 7.870  -9.283  63.150  1.00 0.00 ? 76 A   A C4    1 
+HETATM 1653 MG MG    . MG  B 2 .  ? 36.200 1.700   27.800  1.00 0.00 ? 77 MG  A MG    1 
+HETATM 1654 MG MG    . MG  C 2 .  ? 50.300 18.900  25.500  1.00 0.00 ? 78 MG  A MG    1 
+HETATM 1655 MG MG    . MG  D 2 .  ? 54.500 11.900  31.300  1.00 0.00 ? 79 MG  A MG    1 
+HETATM 1656 MG MG    . MG  E 2 .  ? 9.200  11.800  27.500  1.00 0.00 ? 80 MG  A MG    1 
+# 
+loop_
+_pdbx_poly_seq_scheme.asym_id 
+_pdbx_poly_seq_scheme.entity_id 
+_pdbx_poly_seq_scheme.seq_id 
+_pdbx_poly_seq_scheme.mon_id 
+_pdbx_poly_seq_scheme.ndb_seq_num 
+_pdbx_poly_seq_scheme.pdb_seq_num 
+_pdbx_poly_seq_scheme.auth_seq_num 
+_pdbx_poly_seq_scheme.pdb_mon_id 
+_pdbx_poly_seq_scheme.auth_mon_id 
+_pdbx_poly_seq_scheme.pdb_strand_id 
+_pdbx_poly_seq_scheme.pdb_ins_code 
+_pdbx_poly_seq_scheme.hetero 
+A 1 1  G   1  1  1  G   G   A . n 
+A 1 2  C   2  2  2  C   C   A . n 
+A 1 3  G   3  3  3  G   G   A . n 
+A 1 4  G   4  4  4  G   G   A . n 
+A 1 5  A   5  5  5  A   A   A . n 
+A 1 6  U   6  6  6  U   U   A . n 
+A 1 7  U   7  7  7  U   U   A . n 
+A 1 8  U   8  8  8  U   U   A . n 
+A 1 9  A   9  9  9  A   A   A . n 
+A 1 10 2MG 10 10 10 2MG 2MG A . n 
+A 1 11 C   11 11 11 C   C   A . n 
+A 1 12 U   12 12 12 U   U   A . n 
+A 1 13 C   13 13 13 C   C   A . n 
+A 1 14 A   14 14 14 A   A   A . n 
+A 1 15 G   15 15 15 G   G   A . n 
+A 1 16 H2U 16 16 16 H2U H2U A . n 
+A 1 17 H2U 17 17 17 H2U H2U A . n 
+A 1 18 G   18 18 18 G   G   A . n 
+A 1 19 G   19 19 19 G   G   A . n 
+A 1 20 G   20 20 20 G   G   A . n 
+A 1 21 A   21 21 21 A   A   A . n 
+A 1 22 G   22 22 22 G   G   A . n 
+A 1 23 A   23 23 23 A   A   A . n 
+A 1 24 G   24 24 24 G   G   A . n 
+A 1 25 C   25 25 25 C   C   A . n 
+A 1 26 M2G 26 26 26 M2G M2G A . n 
+A 1 27 C   27 27 27 C   C   A . n 
+A 1 28 C   28 28 28 C   C   A . n 
+A 1 29 A   29 29 29 A   A   A . n 
+A 1 30 G   30 30 30 G   G   A . n 
+A 1 31 A   31 31 31 A   A   A . n 
+A 1 32 OMC 32 32 32 OMC OMC A . n 
+A 1 33 U   33 33 33 U   U   A . n 
+A 1 34 OMG 34 34 34 OMG OMG A . n 
+A 1 35 A   35 35 35 A   A   A . n 
+A 1 36 A   36 36 36 A   A   A . n 
+A 1 37 YG  37 37 37 YG  YG  A . n 
+A 1 38 A   38 38 38 A   A   A . n 
+A 1 39 PSU 39 39 39 PSU PSU A . n 
+A 1 40 5MC 40 40 40 5MC 5MC A . n 
+A 1 41 U   41 41 41 U   U   A . n 
+A 1 42 G   42 42 42 G   G   A . n 
+A 1 43 G   43 43 43 G   G   A . n 
+A 1 44 A   44 44 44 A   A   A . n 
+A 1 45 G   45 45 45 G   G   A . n 
+A 1 46 7MG 46 46 46 7MG 7MG A . n 
+A 1 47 U   47 47 47 U   U   A . n 
+A 1 48 C   48 48 48 C   C   A . n 
+A 1 49 5MC 49 49 49 5MC 5MC A . n 
+A 1 50 U   50 50 50 U   U   A . n 
+A 1 51 G   51 51 51 G   G   A . n 
+A 1 52 U   52 52 52 U   U   A . n 
+A 1 53 G   53 53 53 G   G   A . n 
+A 1 54 5MU 54 54 54 5MU 5MU A . n 
+A 1 55 PSU 55 55 55 PSU PSU A . n 
+A 1 56 C   56 56 56 C   C   A . n 
+A 1 57 G   57 57 57 G   G   A . n 
+A 1 58 1MA 58 58 58 1MA 1MA A . n 
+A 1 59 U   59 59 59 U   U   A . n 
+A 1 60 C   60 60 60 C   C   A . n 
+A 1 61 C   61 61 61 C   C   A . n 
+A 1 62 A   62 62 62 A   A   A . n 
+A 1 63 C   63 63 63 C   C   A . n 
+A 1 64 A   64 64 64 A   A   A . n 
+A 1 65 G   65 65 65 G   G   A . n 
+A 1 66 A   66 66 66 A   A   A . n 
+A 1 67 A   67 67 67 A   A   A . n 
+A 1 68 U   68 68 68 U   U   A . n 
+A 1 69 U   69 69 69 U   U   A . n 
+A 1 70 C   70 70 70 C   C   A . n 
+A 1 71 G   71 71 71 G   G   A . n 
+A 1 72 C   72 72 72 C   C   A . n 
+A 1 73 A   73 73 73 A   A   A . n 
+A 1 74 C   74 74 74 C   C   A . n 
+A 1 75 C   75 75 75 C   C   A . n 
+A 1 76 A   76 76 76 A   A   A . n 
+# 
+loop_
+_pdbx_nonpoly_scheme.asym_id 
+_pdbx_nonpoly_scheme.entity_id 
+_pdbx_nonpoly_scheme.mon_id 
+_pdbx_nonpoly_scheme.ndb_seq_num 
+_pdbx_nonpoly_scheme.pdb_seq_num 
+_pdbx_nonpoly_scheme.auth_seq_num 
+_pdbx_nonpoly_scheme.pdb_mon_id 
+_pdbx_nonpoly_scheme.auth_mon_id 
+_pdbx_nonpoly_scheme.pdb_strand_id 
+_pdbx_nonpoly_scheme.pdb_ins_code 
+B 2 MG 1 77 77 MG MG A . 
+C 2 MG 1 78 78 MG MG A . 
+D 2 MG 1 79 79 MG MG A . 
+E 2 MG 1 80 80 MG MG A . 
+# 
+loop_
+_pdbx_struct_mod_residue.id 
+_pdbx_struct_mod_residue.label_asym_id 
+_pdbx_struct_mod_residue.label_comp_id 
+_pdbx_struct_mod_residue.label_seq_id 
+_pdbx_struct_mod_residue.auth_asym_id 
+_pdbx_struct_mod_residue.auth_comp_id 
+_pdbx_struct_mod_residue.auth_seq_id 
+_pdbx_struct_mod_residue.PDB_ins_code 
+_pdbx_struct_mod_residue.parent_comp_id 
+_pdbx_struct_mod_residue.details 
+1  A 2MG 10 A 2MG 10 ? G "2N-METHYLGUANOSINE-5'-MONOPHOSPHATE"   
+2  A H2U 16 A H2U 16 ? U "5,6-DIHYDROURIDINE-5'-MONOPHOSPHATE"   
+3  A H2U 17 A H2U 17 ? U "5,6-DIHYDROURIDINE-5'-MONOPHOSPHATE"   
+4  A M2G 26 A M2G 26 ? G "N2-DIMETHYLGUANOSINE-5'-MONOPHOSPHATE" 
+5  A OMC 32 A OMC 32 ? C "O2'-METHYLYCYTIDINE-5'-MONOPHOSPHATE"  
+6  A OMG 34 A OMG 34 ? G "O2'-METHYLGUANOSINE-5'-MONOPHOSPHATE"  
+7  A YG  37 A YG  37 ? G WYBUTOSINE                              
+8  A PSU 39 A PSU 39 ? U "PSEUDOURIDINE-5'-MONOPHOSPHATE"        
+9  A 5MC 40 A 5MC 40 ? C "5-METHYLCYTIDINE-5'-MONOPHOSPHATE"     
+10 A 7MG 46 A 7MG 46 ? G ?                                       
+11 A 5MC 49 A 5MC 49 ? C "5-METHYLCYTIDINE-5'-MONOPHOSPHATE"     
+12 A 5MU 54 A 5MU 54 ? U 
+;5-METHYLURIDINE 5'-MONOPHOSPHATE
+;
+13 A PSU 55 A PSU 55 ? U "PSEUDOURIDINE-5'-MONOPHOSPHATE"        
+14 A 1MA 58 A 1MA 58 ? A ?                                       
+# 
+_pdbx_struct_assembly.id                   1 
+_pdbx_struct_assembly.details              author_defined_assembly 
+_pdbx_struct_assembly.method_details       ? 
+_pdbx_struct_assembly.oligomeric_details   monomeric 
+_pdbx_struct_assembly.oligomeric_count     1 
+# 
+_pdbx_struct_assembly_gen.assembly_id       1 
+_pdbx_struct_assembly_gen.oper_expression   1 
+_pdbx_struct_assembly_gen.asym_id_list      A,B,C,D,E 
+# 
+_pdbx_struct_oper_list.id                   1 
+_pdbx_struct_oper_list.type                 'identity operation' 
+_pdbx_struct_oper_list.name                 1_555 
+_pdbx_struct_oper_list.symmetry_operation   x,y,z 
+_pdbx_struct_oper_list.matrix[1][1]         1.0000000000 
+_pdbx_struct_oper_list.matrix[1][2]         0.0000000000 
+_pdbx_struct_oper_list.matrix[1][3]         0.0000000000 
+_pdbx_struct_oper_list.vector[1]            0.0000000000 
+_pdbx_struct_oper_list.matrix[2][1]         0.0000000000 
+_pdbx_struct_oper_list.matrix[2][2]         1.0000000000 
+_pdbx_struct_oper_list.matrix[2][3]         0.0000000000 
+_pdbx_struct_oper_list.vector[2]            0.0000000000 
+_pdbx_struct_oper_list.matrix[3][1]         0.0000000000 
+_pdbx_struct_oper_list.matrix[3][2]         0.0000000000 
+_pdbx_struct_oper_list.matrix[3][3]         1.0000000000 
+_pdbx_struct_oper_list.vector[3]            0.0000000000 
+# 
+loop_
+_pdbx_audit_revision_history.ordinal 
+_pdbx_audit_revision_history.data_content_type 
+_pdbx_audit_revision_history.major_revision 
+_pdbx_audit_revision_history.minor_revision 
+_pdbx_audit_revision_history.revision_date 
+1 'Structure model' 1 0 1978-04-12 
+2 'Structure model' 1 1 2008-05-22 
+3 'Structure model' 1 2 2011-07-13 
+# 
+_pdbx_audit_revision_details.ordinal             1 
+_pdbx_audit_revision_details.revision_ordinal    1 
+_pdbx_audit_revision_details.data_content_type   'Structure model' 
+_pdbx_audit_revision_details.provider            repository 
+_pdbx_audit_revision_details.type                'Initial release' 
+_pdbx_audit_revision_details.description         ? 
+# 
+loop_
+_pdbx_audit_revision_group.ordinal 
+_pdbx_audit_revision_group.revision_ordinal 
+_pdbx_audit_revision_group.data_content_type 
+_pdbx_audit_revision_group.group 
+1 2 'Structure model' 'Version format compliance' 
+2 3 'Structure model' 'Non-polymer description'   
+3 3 'Structure model' 'Version format compliance' 
+# 
+_software.name             JACK-LEVITT 
+_software.classification   refinement 
+_software.version          . 
+_software.citation_id      ? 
+_software.pdbx_ordinal     1 
+# 
+loop_
+_pdbx_validate_rmsd_bond.id 
+_pdbx_validate_rmsd_bond.PDB_model_num 
+_pdbx_validate_rmsd_bond.auth_atom_id_1 
+_pdbx_validate_rmsd_bond.auth_asym_id_1 
+_pdbx_validate_rmsd_bond.auth_comp_id_1 
+_pdbx_validate_rmsd_bond.auth_seq_id_1 
+_pdbx_validate_rmsd_bond.PDB_ins_code_1 
+_pdbx_validate_rmsd_bond.label_alt_id_1 
+_pdbx_validate_rmsd_bond.auth_atom_id_2 
+_pdbx_validate_rmsd_bond.auth_asym_id_2 
+_pdbx_validate_rmsd_bond.auth_comp_id_2 
+_pdbx_validate_rmsd_bond.auth_seq_id_2 
+_pdbx_validate_rmsd_bond.PDB_ins_code_2 
+_pdbx_validate_rmsd_bond.label_alt_id_2 
+_pdbx_validate_rmsd_bond.bond_value 
+_pdbx_validate_rmsd_bond.bond_target_value 
+_pdbx_validate_rmsd_bond.bond_deviation 
+_pdbx_validate_rmsd_bond.bond_standard_deviation 
+_pdbx_validate_rmsd_bond.linker_flag 
+1   1 C6 A G 1  ? ? N1 A G 1  ? ? 1.347 1.391 -0.044 0.007 N 
+2   1 N7 A G 1  ? ? C8 A G 1  ? ? 1.375 1.305 0.070  0.006 N 
+3   1 C5 A C 2  ? ? C6 A C 2  ? ? 1.389 1.339 0.050  0.008 N 
+4   1 N7 A G 3  ? ? C8 A G 3  ? ? 1.386 1.305 0.081  0.006 N 
+5   1 C6 A G 4  ? ? N1 A G 4  ? ? 1.332 1.391 -0.059 0.007 N 
+6   1 N7 A G 4  ? ? C8 A G 4  ? ? 1.386 1.305 0.081  0.006 N 
+7   1 N3 A A 5  ? ? C4 A A 5  ? ? 1.384 1.344 0.040  0.006 N 
+8   1 N7 A A 5  ? ? C8 A A 5  ? ? 1.386 1.311 0.075  0.007 N 
+9   1 C5 A U 6  ? ? C6 A U 6  ? ? 1.395 1.337 0.058  0.009 N 
+10  1 C2 A U 7  ? ? N3 A U 7  ? ? 1.320 1.373 -0.053 0.007 N 
+11  1 N3 A U 7  ? ? C4 A U 7  ? ? 1.319 1.380 -0.061 0.009 N 
+12  1 C5 A U 7  ? ? C6 A U 7  ? ? 1.403 1.337 0.066  0.009 N 
+13  1 N1 A U 8  ? ? C6 A U 8  ? ? 1.315 1.375 -0.060 0.009 N 
+14  1 C2 A U 8  ? ? N3 A U 8  ? ? 1.324 1.373 -0.049 0.007 N 
+15  1 N3 A U 8  ? ? C4 A U 8  ? ? 1.325 1.380 -0.055 0.009 N 
+16  1 N7 A A 9  ? ? C8 A A 9  ? ? 1.380 1.311 0.069  0.007 N 
+17  1 N1 A C 11 ? ? C6 A C 11 ? ? 1.317 1.367 -0.050 0.006 N 
+18  1 N3 A U 12 ? ? C4 A U 12 ? ? 1.322 1.380 -0.058 0.009 N 
+19  1 N1 A C 13 ? ? C2 A C 13 ? ? 1.332 1.397 -0.065 0.010 N 
+20  1 N1 A C 13 ? ? C6 A C 13 ? ? 1.316 1.367 -0.051 0.006 N 
+21  1 N7 A A 14 ? ? C8 A A 14 ? ? 1.372 1.311 0.061  0.007 N 
+22  1 C6 A G 15 ? ? N1 A G 15 ? ? 1.342 1.391 -0.049 0.007 N 
+23  1 N7 A G 15 ? ? C8 A G 15 ? ? 1.366 1.305 0.061  0.006 N 
+24  1 C6 A G 18 ? ? N1 A G 18 ? ? 1.326 1.391 -0.065 0.007 N 
+25  1 N7 A G 18 ? ? C8 A G 18 ? ? 1.397 1.305 0.092  0.006 N 
+26  1 N1 A G 19 ? ? C2 A G 19 ? ? 1.295 1.373 -0.078 0.008 N 
+27  1 C4 A G 19 ? ? C5 A G 19 ? ? 1.309 1.379 -0.070 0.007 N 
+28  1 C6 A G 19 ? ? N1 A G 19 ? ? 1.269 1.391 -0.122 0.007 N 
+29  1 N7 A G 19 ? ? C8 A G 19 ? ? 1.348 1.305 0.043  0.006 N 
+30  1 C8 A G 19 ? ? N9 A G 19 ? ? 1.289 1.374 -0.085 0.007 N 
+31  1 N3 A G 20 ? ? C4 A G 20 ? ? 1.396 1.350 0.046  0.007 N 
+32  1 C6 A G 20 ? ? N1 A G 20 ? ? 1.336 1.391 -0.055 0.007 N 
+33  1 N7 A G 20 ? ? C8 A G 20 ? ? 1.361 1.305 0.056  0.006 N 
+34  1 N7 A A 21 ? ? C8 A A 21 ? ? 1.376 1.311 0.065  0.007 N 
+35  1 C6 A G 22 ? ? N1 A G 22 ? ? 1.321 1.391 -0.070 0.007 N 
+36  1 N7 A G 22 ? ? C8 A G 22 ? ? 1.379 1.305 0.074  0.006 N 
+37  1 N3 A A 23 ? ? C4 A A 23 ? ? 1.383 1.344 0.039  0.006 N 
+38  1 N7 A A 23 ? ? C8 A A 23 ? ? 1.374 1.311 0.063  0.007 N 
+39  1 C6 A G 24 ? ? N1 A G 24 ? ? 1.331 1.391 -0.060 0.007 N 
+40  1 N7 A G 24 ? ? C8 A G 24 ? ? 1.373 1.305 0.068  0.006 N 
+41  1 N1 A C 25 ? ? C2 A C 25 ? ? 1.309 1.397 -0.088 0.010 N 
+42  1 N1 A C 25 ? ? C6 A C 25 ? ? 1.317 1.367 -0.050 0.006 N 
+43  1 C4 A C 25 ? ? C5 A C 25 ? ? 1.377 1.425 -0.048 0.008 N 
+44  1 N1 A C 27 ? ? C2 A C 27 ? ? 1.332 1.397 -0.065 0.010 N 
+45  1 N1 A C 27 ? ? C6 A C 27 ? ? 1.326 1.367 -0.041 0.006 N 
+46  1 N1 A C 28 ? ? C2 A C 28 ? ? 1.308 1.397 -0.089 0.010 N 
+47  1 N1 A C 28 ? ? C6 A C 28 ? ? 1.320 1.367 -0.047 0.006 N 
+48  1 C4 A C 28 ? ? C5 A C 28 ? ? 1.371 1.425 -0.054 0.008 N 
+49  1 C5 A C 28 ? ? C6 A C 28 ? ? 1.388 1.339 0.049  0.008 N 
+50  1 N7 A A 29 ? ? C8 A A 29 ? ? 1.368 1.311 0.057  0.007 N 
+51  1 C6 A G 30 ? ? N1 A G 30 ? ? 1.341 1.391 -0.050 0.007 N 
+52  1 N7 A G 30 ? ? C8 A G 30 ? ? 1.372 1.305 0.067  0.006 N 
+53  1 N3 A A 31 ? ? C4 A A 31 ? ? 1.392 1.344 0.048  0.006 N 
+54  1 N7 A A 31 ? ? C8 A A 31 ? ? 1.378 1.311 0.067  0.007 N 
+55  1 C2 A U 33 ? ? N3 A U 33 ? ? 1.330 1.373 -0.043 0.007 N 
+56  1 C5 A U 33 ? ? C6 A U 33 ? ? 1.391 1.337 0.054  0.009 N 
+57  1 N3 A A 35 ? ? C4 A A 35 ? ? 1.387 1.344 0.043  0.006 N 
+58  1 N7 A A 35 ? ? C8 A A 35 ? ? 1.357 1.311 0.046  0.007 N 
+59  1 N3 A A 36 ? ? C4 A A 36 ? ? 1.382 1.344 0.038  0.006 N 
+60  1 N7 A A 36 ? ? C8 A A 36 ? ? 1.370 1.311 0.059  0.007 N 
+61  1 N3 A A 38 ? ? C4 A A 38 ? ? 1.394 1.344 0.050  0.006 N 
+62  1 N7 A A 38 ? ? C8 A A 38 ? ? 1.381 1.311 0.070  0.007 N 
+63  1 C5 A U 41 ? ? C6 A U 41 ? ? 1.404 1.337 0.067  0.009 N 
+64  1 C6 A G 42 ? ? N1 A G 42 ? ? 1.347 1.391 -0.044 0.007 N 
+65  1 N7 A G 42 ? ? C8 A G 42 ? ? 1.395 1.305 0.090  0.006 N 
+66  1 C6 A G 43 ? ? N1 A G 43 ? ? 1.336 1.391 -0.055 0.007 N 
+67  1 N7 A G 43 ? ? C8 A G 43 ? ? 1.375 1.305 0.070  0.006 N 
+68  1 N7 A A 44 ? ? C8 A A 44 ? ? 1.378 1.311 0.067  0.007 N 
+69  1 C6 A G 45 ? ? N1 A G 45 ? ? 1.327 1.391 -0.064 0.007 N 
+70  1 N7 A G 45 ? ? C8 A G 45 ? ? 1.376 1.305 0.071  0.006 N 
+71  1 C5 A U 47 ? ? C6 A U 47 ? ? 1.391 1.337 0.054  0.009 N 
+72  1 N1 A C 48 ? ? C6 A C 48 ? ? 1.321 1.367 -0.046 0.006 N 
+73  1 N1 A U 50 ? ? C6 A U 50 ? ? 1.308 1.375 -0.067 0.009 N 
+74  1 C2 A U 50 ? ? N3 A U 50 ? ? 1.322 1.373 -0.051 0.007 N 
+75  1 N3 A U 50 ? ? C4 A U 50 ? ? 1.314 1.380 -0.066 0.009 N 
+76  1 C6 A G 51 ? ? N1 A G 51 ? ? 1.332 1.391 -0.059 0.007 N 
+77  1 N7 A G 51 ? ? C8 A G 51 ? ? 1.358 1.305 0.053  0.006 N 
+78  1 C2 A U 52 ? ? N3 A U 52 ? ? 1.328 1.373 -0.045 0.007 N 
+79  1 N3 A U 52 ? ? C4 A U 52 ? ? 1.322 1.380 -0.058 0.009 N 
+80  1 C6 A G 53 ? ? N1 A G 53 ? ? 1.331 1.391 -0.060 0.007 N 
+81  1 N7 A G 53 ? ? C8 A G 53 ? ? 1.378 1.305 0.073  0.006 N 
+82  1 N1 A C 56 ? ? C2 A C 56 ? ? 1.325 1.397 -0.072 0.010 N 
+83  1 N1 A C 56 ? ? C6 A C 56 ? ? 1.325 1.367 -0.042 0.006 N 
+84  1 N3 A C 56 ? ? C4 A C 56 ? ? 1.277 1.335 -0.058 0.007 N 
+85  1 C4 A C 56 ? ? C5 A C 56 ? ? 1.363 1.425 -0.062 0.008 N 
+86  1 C6 A G 57 ? ? N1 A G 57 ? ? 1.322 1.391 -0.069 0.007 N 
+87  1 N7 A G 57 ? ? C8 A G 57 ? ? 1.368 1.305 0.063  0.006 N 
+88  1 N3 A U 59 ? ? C4 A U 59 ? ? 1.322 1.380 -0.058 0.009 N 
+89  1 C5 A U 59 ? ? C6 A U 59 ? ? 1.392 1.337 0.055  0.009 N 
+90  1 N1 A C 60 ? ? C2 A C 60 ? ? 1.316 1.397 -0.081 0.010 N 
+91  1 N1 A C 60 ? ? C6 A C 60 ? ? 1.325 1.367 -0.042 0.006 N 
+92  1 C4 A C 60 ? ? C5 A C 60 ? ? 1.376 1.425 -0.049 0.008 N 
+93  1 N1 A C 61 ? ? C2 A C 61 ? ? 1.322 1.397 -0.075 0.010 N 
+94  1 C5 A C 61 ? ? C6 A C 61 ? ? 1.391 1.339 0.052  0.008 N 
+95  1 N3 A A 62 ? ? C4 A A 62 ? ? 1.390 1.344 0.046  0.006 N 
+96  1 N7 A A 62 ? ? C8 A A 62 ? ? 1.369 1.311 0.058  0.007 N 
+97  1 N1 A C 63 ? ? C6 A C 63 ? ? 1.322 1.367 -0.045 0.006 N 
+98  1 C4 A C 63 ? ? C5 A C 63 ? ? 1.376 1.425 -0.049 0.008 N 
+99  1 N7 A A 64 ? ? C8 A A 64 ? ? 1.379 1.311 0.068  0.007 N 
+100 1 C6 A G 65 ? ? N1 A G 65 ? ? 1.348 1.391 -0.043 0.007 N 
+101 1 N7 A G 65 ? ? C8 A G 65 ? ? 1.373 1.305 0.068  0.006 N 
+102 1 N3 A A 66 ? ? C4 A A 66 ? ? 1.389 1.344 0.045  0.006 N 
+103 1 N7 A A 66 ? ? C8 A A 66 ? ? 1.355 1.311 0.044  0.007 N 
+104 1 N3 A A 67 ? ? C4 A A 67 ? ? 1.387 1.344 0.043  0.006 N 
+105 1 N7 A A 67 ? ? C8 A A 67 ? ? 1.388 1.311 0.077  0.007 N 
+106 1 C2 A U 68 ? ? N3 A U 68 ? ? 1.326 1.373 -0.047 0.007 N 
+107 1 N3 A U 68 ? ? C4 A U 68 ? ? 1.316 1.380 -0.064 0.009 N 
+108 1 N1 A U 69 ? ? C6 A U 69 ? ? 1.321 1.375 -0.054 0.009 N 
+109 1 C2 A U 69 ? ? N3 A U 69 ? ? 1.330 1.373 -0.043 0.007 N 
+110 1 N3 A U 69 ? ? C4 A U 69 ? ? 1.318 1.380 -0.062 0.009 N 
+111 1 C5 A C 70 ? ? C6 A C 70 ? ? 1.392 1.339 0.053  0.008 N 
+112 1 C6 A G 71 ? ? N1 A G 71 ? ? 1.342 1.391 -0.049 0.007 N 
+113 1 N7 A G 71 ? ? C8 A G 71 ? ? 1.367 1.305 0.062  0.006 N 
+114 1 N1 A C 72 ? ? C2 A C 72 ? ? 1.319 1.397 -0.078 0.010 N 
+115 1 N1 A C 72 ? ? C6 A C 72 ? ? 1.318 1.367 -0.049 0.006 N 
+116 1 C5 A C 72 ? ? C6 A C 72 ? ? 1.396 1.339 0.057  0.008 N 
+117 1 N3 A A 73 ? ? C4 A A 73 ? ? 1.388 1.344 0.044  0.006 N 
+118 1 N7 A A 73 ? ? C8 A A 73 ? ? 1.372 1.311 0.061  0.007 N 
+119 1 C5 A C 74 ? ? C6 A C 74 ? ? 1.389 1.339 0.050  0.008 N 
+120 1 N1 A C 75 ? ? C6 A C 75 ? ? 1.316 1.367 -0.051 0.006 N 
+121 1 C5 A C 75 ? ? C6 A C 75 ? ? 1.390 1.339 0.051  0.008 N 
+122 1 N3 A A 76 ? ? C4 A A 76 ? ? 1.383 1.344 0.039  0.006 N 
+123 1 N7 A A 76 ? ? C8 A A 76 ? ? 1.364 1.311 0.053  0.007 N 
+# 
+loop_
+_pdbx_validate_rmsd_angle.id 
+_pdbx_validate_rmsd_angle.PDB_model_num 
+_pdbx_validate_rmsd_angle.auth_atom_id_1 
+_pdbx_validate_rmsd_angle.auth_asym_id_1 
+_pdbx_validate_rmsd_angle.auth_comp_id_1 
+_pdbx_validate_rmsd_angle.auth_seq_id_1 
+_pdbx_validate_rmsd_angle.PDB_ins_code_1 
+_pdbx_validate_rmsd_angle.label_alt_id_1 
+_pdbx_validate_rmsd_angle.auth_atom_id_2 
+_pdbx_validate_rmsd_angle.auth_asym_id_2 
+_pdbx_validate_rmsd_angle.auth_comp_id_2 
+_pdbx_validate_rmsd_angle.auth_seq_id_2 
+_pdbx_validate_rmsd_angle.PDB_ins_code_2 
+_pdbx_validate_rmsd_angle.label_alt_id_2 
+_pdbx_validate_rmsd_angle.auth_atom_id_3 
+_pdbx_validate_rmsd_angle.auth_asym_id_3 
+_pdbx_validate_rmsd_angle.auth_comp_id_3 
+_pdbx_validate_rmsd_angle.auth_seq_id_3 
+_pdbx_validate_rmsd_angle.PDB_ins_code_3 
+_pdbx_validate_rmsd_angle.label_alt_id_3 
+_pdbx_validate_rmsd_angle.angle_value 
+_pdbx_validate_rmsd_angle.angle_target_value 
+_pdbx_validate_rmsd_angle.angle_deviation 
+_pdbx_validate_rmsd_angle.angle_standard_deviation 
+_pdbx_validate_rmsd_angle.linker_flag 
+1   1 C6    A G 1  ? ? N1    A G 1  ? ? C2    A G 1  ? ? 121.10 125.10 -4.00  0.60 N 
+2   1 C2    A G 1  ? ? N3    A G 1  ? ? C4    A G 1  ? ? 120.31 111.90 8.41   0.50 N 
+3   1 N3    A G 1  ? ? C4    A G 1  ? ? C5    A G 1  ? ? 120.50 128.60 -8.10  0.50 N 
+4   1 C5    A G 1  ? ? C6    A G 1  ? ? N1    A G 1  ? ? 119.43 111.50 7.93   0.50 N 
+5   1 N7    A G 1  ? ? C8    A G 1  ? ? N9    A G 1  ? ? 108.94 113.10 -4.16  0.50 N 
+6   1 N3    A G 1  ? ? C4    A G 1  ? ? N9    A G 1  ? ? 132.16 126.00 6.16   0.60 N 
+7   1 C5    A G 1  ? ? C6    A G 1  ? ? O6    A G 1  ? ? 119.66 128.60 -8.94  0.60 N 
+8   1 N3    A C 2  ? ? C4    A C 2  ? ? C5    A C 2  ? ? 119.10 121.90 -2.80  0.40 N 
+9   1 "O5'" A G 3  ? ? "C5'" A G 3  ? ? "C4'" A G 3  ? ? 104.27 109.40 -5.13  0.80 N 
+10  1 "C4'" A G 3  ? ? "C3'" A G 3  ? ? "C2'" A G 3  ? ? 96.02  102.60 -6.58  1.00 N 
+11  1 C2    A G 3  ? ? N3    A G 3  ? ? C4    A G 3  ? ? 119.81 111.90 7.91   0.50 N 
+12  1 N3    A G 3  ? ? C4    A G 3  ? ? C5    A G 3  ? ? 120.67 128.60 -7.93  0.50 N 
+13  1 C5    A G 3  ? ? C6    A G 3  ? ? N1    A G 3  ? ? 119.23 111.50 7.73   0.50 N 
+14  1 N7    A G 3  ? ? C8    A G 3  ? ? N9    A G 3  ? ? 108.35 113.10 -4.75  0.50 N 
+15  1 C8    A G 3  ? ? N9    A G 3  ? ? C4    A G 3  ? ? 109.04 106.40 2.64   0.40 N 
+16  1 N3    A G 3  ? ? C4    A G 3  ? ? N9    A G 3  ? ? 132.08 126.00 6.08   0.60 N 
+17  1 C5    A G 3  ? ? C6    A G 3  ? ? O6    A G 3  ? ? 118.99 128.60 -9.61  0.60 N 
+18  1 N9    A G 4  ? ? "C1'" A G 4  ? ? "C2'" A G 4  ? ? 105.00 112.00 -7.00  1.10 N 
+19  1 C2    A G 4  ? ? N3    A G 4  ? ? C4    A G 4  ? ? 119.92 111.90 8.02   0.50 N 
+20  1 N3    A G 4  ? ? C4    A G 4  ? ? C5    A G 4  ? ? 119.80 128.60 -8.80  0.50 N 
+21  1 C5    A G 4  ? ? C6    A G 4  ? ? N1    A G 4  ? ? 119.21 111.50 7.71   0.50 N 
+22  1 N7    A G 4  ? ? C8    A G 4  ? ? N9    A G 4  ? ? 108.02 113.10 -5.08  0.50 N 
+23  1 C8    A G 4  ? ? N9    A G 4  ? ? C4    A G 4  ? ? 109.16 106.40 2.76   0.40 N 
+24  1 N3    A G 4  ? ? C4    A G 4  ? ? N9    A G 4  ? ? 132.68 126.00 6.68   0.60 N 
+25  1 C5    A G 4  ? ? C6    A G 4  ? ? O6    A G 4  ? ? 120.04 128.60 -8.56  0.60 N 
+26  1 "O5'" A A 5  ? ? "C5'" A A 5  ? ? "C4'" A A 5  ? ? 103.86 109.40 -5.54  0.80 N 
+27  1 "C4'" A A 5  ? ? "C3'" A A 5  ? ? "C2'" A A 5  ? ? 96.53  102.60 -6.07  1.00 N 
+28  1 N1    A A 5  ? ? C2    A A 5  ? ? N3    A A 5  ? ? 121.27 129.30 -8.03  0.50 N 
+29  1 C2    A A 5  ? ? N3    A A 5  ? ? C4    A A 5  ? ? 119.64 110.60 9.04   0.50 N 
+30  1 N3    A A 5  ? ? C4    A A 5  ? ? C5    A A 5  ? ? 119.98 126.80 -6.82  0.70 N 
+31  1 N7    A A 5  ? ? C8    A A 5  ? ? N9    A A 5  ? ? 108.49 113.80 -5.31  0.50 N 
+32  1 C8    A A 5  ? ? N9    A A 5  ? ? C4    A A 5  ? ? 108.93 105.80 3.13   0.40 N 
+33  1 N3    A A 5  ? ? C4    A A 5  ? ? N9    A A 5  ? ? 132.30 127.40 4.90   0.80 N 
+34  1 N1    A U 6  ? ? C2    A U 6  ? ? N3    A U 6  ? ? 120.53 114.90 5.63   0.60 N 
+35  1 C2    A U 6  ? ? N3    A U 6  ? ? C4    A U 6  ? ? 122.11 127.00 -4.89  0.60 N 
+36  1 C5    A U 6  ? ? C4    A U 6  ? ? O4    A U 6  ? ? 119.08 125.90 -6.82  0.60 N 
+37  1 N1    A U 7  ? ? C2    A U 7  ? ? N3    A U 7  ? ? 121.54 114.90 6.64   0.60 N 
+38  1 C2    A U 7  ? ? N3    A U 7  ? ? C4    A U 7  ? ? 121.25 127.00 -5.75  0.60 N 
+39  1 N3    A U 7  ? ? C4    A U 7  ? ? C5    A U 7  ? ? 119.37 114.60 4.77   0.60 N 
+40  1 C5    A U 7  ? ? C6    A U 7  ? ? N1    A U 7  ? ? 118.92 122.70 -3.78  0.50 N 
+41  1 C5    A U 7  ? ? C4    A U 7  ? ? O4    A U 7  ? ? 120.47 125.90 -5.43  0.60 N 
+42  1 N1    A U 8  ? ? C2    A U 8  ? ? N3    A U 8  ? ? 120.08 114.90 5.18   0.60 N 
+43  1 C2    A U 8  ? ? N3    A U 8  ? ? C4    A U 8  ? ? 121.45 127.00 -5.55  0.60 N 
+44  1 N3    A U 8  ? ? C4    A U 8  ? ? C5    A U 8  ? ? 119.13 114.60 4.53   0.60 N 
+45  1 C5    A U 8  ? ? C4    A U 8  ? ? O4    A U 8  ? ? 117.34 125.90 -8.56  0.60 N 
+46  1 N1    A A 9  ? ? C2    A A 9  ? ? N3    A A 9  ? ? 121.34 129.30 -7.96  0.50 N 
+47  1 C2    A A 9  ? ? N3    A A 9  ? ? C4    A A 9  ? ? 119.74 110.60 9.14   0.50 N 
+48  1 N3    A A 9  ? ? C4    A A 9  ? ? C5    A A 9  ? ? 119.84 126.80 -6.96  0.70 N 
+49  1 N7    A A 9  ? ? C8    A A 9  ? ? N9    A A 9  ? ? 108.42 113.80 -5.38  0.50 N 
+50  1 C8    A A 9  ? ? N9    A A 9  ? ? C4    A A 9  ? ? 109.13 105.80 3.33   0.40 N 
+51  1 N3    A A 9  ? ? C4    A A 9  ? ? N9    A A 9  ? ? 133.20 127.40 5.80   0.80 N 
+52  1 "O5'" A C 11 ? ? "C5'" A C 11 ? ? "C4'" A C 11 ? ? 103.73 109.40 -5.67  0.80 N 
+53  1 N1    A U 12 ? ? C2    A U 12 ? ? N3    A U 12 ? ? 121.04 114.90 6.14   0.60 N 
+54  1 C2    A U 12 ? ? N3    A U 12 ? ? C4    A U 12 ? ? 120.89 127.00 -6.11  0.60 N 
+55  1 N3    A U 12 ? ? C4    A U 12 ? ? C5    A U 12 ? ? 119.05 114.60 4.45   0.60 N 
+56  1 C5    A U 12 ? ? C6    A U 12 ? ? N1    A U 12 ? ? 119.49 122.70 -3.21  0.50 N 
+57  1 N1    A U 12 ? ? C2    A U 12 ? ? O2    A U 12 ? ? 118.00 122.80 -4.80  0.70 N 
+58  1 C5    A U 12 ? ? C4    A U 12 ? ? O4    A U 12 ? ? 120.37 125.90 -5.53  0.60 N 
+59  1 "C1'" A C 13 ? ? "O4'" A C 13 ? ? "C4'" A C 13 ? ? 105.49 109.70 -4.21  0.70 N 
+60  1 "C4'" A C 13 ? ? "C3'" A C 13 ? ? "C2'" A C 13 ? ? 96.20  102.60 -6.40  1.00 N 
+61  1 N3    A C 13 ? ? C4    A C 13 ? ? C5    A C 13 ? ? 119.20 121.90 -2.70  0.40 N 
+62  1 N1    A A 14 ? ? C2    A A 14 ? ? N3    A A 14 ? ? 121.26 129.30 -8.04  0.50 N 
+63  1 C2    A A 14 ? ? N3    A A 14 ? ? C4    A A 14 ? ? 119.86 110.60 9.26   0.50 N 
+64  1 N3    A A 14 ? ? C4    A A 14 ? ? C5    A A 14 ? ? 119.16 126.80 -7.64  0.70 N 
+65  1 C5    A A 14 ? ? N7    A A 14 ? ? C8    A A 14 ? ? 107.01 103.90 3.11   0.50 N 
+66  1 N7    A A 14 ? ? C8    A A 14 ? ? N9    A A 14 ? ? 108.06 113.80 -5.74  0.50 N 
+67  1 C8    A A 14 ? ? N9    A A 14 ? ? C4    A A 14 ? ? 109.88 105.80 4.08   0.40 N 
+68  1 N3    A A 14 ? ? C4    A A 14 ? ? N9    A A 14 ? ? 133.87 127.40 6.47   0.80 N 
+69  1 C2    A G 15 ? ? N3    A G 15 ? ? C4    A G 15 ? ? 119.69 111.90 7.79   0.50 N 
+70  1 N3    A G 15 ? ? C4    A G 15 ? ? C5    A G 15 ? ? 120.06 128.60 -8.54  0.50 N 
+71  1 C5    A G 15 ? ? C6    A G 15 ? ? N1    A G 15 ? ? 119.57 111.50 8.07   0.50 N 
+72  1 N7    A G 15 ? ? C8    A G 15 ? ? N9    A G 15 ? ? 108.79 113.10 -4.31  0.50 N 
+73  1 C8    A G 15 ? ? N9    A G 15 ? ? C4    A G 15 ? ? 108.91 106.40 2.51   0.40 N 
+74  1 N3    A G 15 ? ? C4    A G 15 ? ? N9    A G 15 ? ? 133.52 126.00 7.52   0.60 N 
+75  1 C5    A G 15 ? ? C6    A G 15 ? ? O6    A G 15 ? ? 119.64 128.60 -8.96  0.60 N 
+76  1 "O4'" A G 18 ? ? "C1'" A G 18 ? ? N9    A G 18 ? ? 113.29 108.50 4.79   0.70 N 
+77  1 C2    A G 18 ? ? N3    A G 18 ? ? C4    A G 18 ? ? 119.70 111.90 7.80   0.50 N 
+78  1 N3    A G 18 ? ? C4    A G 18 ? ? C5    A G 18 ? ? 120.31 128.60 -8.29  0.50 N 
+79  1 C5    A G 18 ? ? C6    A G 18 ? ? N1    A G 18 ? ? 119.39 111.50 7.89   0.50 N 
+80  1 N7    A G 18 ? ? C8    A G 18 ? ? N9    A G 18 ? ? 107.80 113.10 -5.30  0.50 N 
+81  1 C8    A G 18 ? ? N9    A G 18 ? ? C4    A G 18 ? ? 109.34 106.40 2.94   0.40 N 
+82  1 N9    A G 18 ? ? C4    A G 18 ? ? C5    A G 18 ? ? 108.18 105.40 2.78   0.40 N 
+83  1 N3    A G 18 ? ? C4    A G 18 ? ? N9    A G 18 ? ? 131.42 126.00 5.42   0.60 N 
+84  1 C5    A G 18 ? ? C6    A G 18 ? ? O6    A G 18 ? ? 120.08 128.60 -8.52  0.60 N 
+85  1 C2    A G 19 ? ? N3    A G 19 ? ? C4    A G 19 ? ? 119.06 111.90 7.16   0.50 N 
+86  1 N3    A G 19 ? ? C4    A G 19 ? ? C5    A G 19 ? ? 119.59 128.60 -9.01  0.50 N 
+87  1 C5    A G 19 ? ? C6    A G 19 ? ? N1    A G 19 ? ? 119.28 111.50 7.78   0.50 N 
+88  1 C4    A G 19 ? ? C5    A G 19 ? ? N7    A G 19 ? ? 107.42 110.80 -3.38  0.40 N 
+89  1 N7    A G 19 ? ? C8    A G 19 ? ? N9    A G 19 ? ? 107.67 113.10 -5.43  0.50 N 
+90  1 C8    A G 19 ? ? N9    A G 19 ? ? C4    A G 19 ? ? 110.28 106.40 3.88   0.40 N 
+91  1 N3    A G 19 ? ? C4    A G 19 ? ? N9    A G 19 ? ? 132.69 126.00 6.69   0.60 N 
+92  1 C5    A G 19 ? ? C6    A G 19 ? ? O6    A G 19 ? ? 120.53 128.60 -8.07  0.60 N 
+93  1 C6    A G 20 ? ? N1    A G 20 ? ? C2    A G 20 ? ? 120.81 125.10 -4.29  0.60 N 
+94  1 C2    A G 20 ? ? N3    A G 20 ? ? C4    A G 20 ? ? 119.94 111.90 8.04   0.50 N 
+95  1 N3    A G 20 ? ? C4    A G 20 ? ? C5    A G 20 ? ? 118.92 128.60 -9.68  0.50 N 
+96  1 C5    A G 20 ? ? C6    A G 20 ? ? N1    A G 20 ? ? 120.53 111.50 9.03   0.50 N 
+97  1 N7    A G 20 ? ? C8    A G 20 ? ? N9    A G 20 ? ? 108.50 113.10 -4.60  0.50 N 
+98  1 C8    A G 20 ? ? N9    A G 20 ? ? C4    A G 20 ? ? 109.10 106.40 2.70   0.40 N 
+99  1 N3    A G 20 ? ? C4    A G 20 ? ? N9    A G 20 ? ? 134.72 126.00 8.72   0.60 N 
+100 1 C5    A G 20 ? ? C6    A G 20 ? ? O6    A G 20 ? ? 118.21 128.60 -10.39 0.60 N 
+101 1 "O4'" A A 21 ? ? "C1'" A A 21 ? ? N9    A A 21 ? ? 114.59 108.50 6.09   0.70 N 
+102 1 N1    A A 21 ? ? C2    A A 21 ? ? N3    A A 21 ? ? 121.80 129.30 -7.50  0.50 N 
+103 1 C2    A A 21 ? ? N3    A A 21 ? ? C4    A A 21 ? ? 119.55 110.60 8.95   0.50 N 
+104 1 N3    A A 21 ? ? C4    A A 21 ? ? C5    A A 21 ? ? 119.13 126.80 -7.67  0.70 N 
+105 1 N7    A A 21 ? ? C8    A A 21 ? ? N9    A A 21 ? ? 108.40 113.80 -5.40  0.50 N 
+106 1 C8    A A 21 ? ? N9    A A 21 ? ? C4    A A 21 ? ? 108.87 105.80 3.07   0.40 N 
+107 1 N3    A A 21 ? ? C4    A A 21 ? ? N9    A A 21 ? ? 133.29 127.40 5.89   0.80 N 
+108 1 C6    A G 22 ? ? N1    A G 22 ? ? C2    A G 22 ? ? 120.98 125.10 -4.12  0.60 N 
+109 1 C2    A G 22 ? ? N3    A G 22 ? ? C4    A G 22 ? ? 120.34 111.90 8.44   0.50 N 
+110 1 N3    A G 22 ? ? C4    A G 22 ? ? C5    A G 22 ? ? 118.82 128.60 -9.78  0.50 N 
+111 1 C5    A G 22 ? ? C6    A G 22 ? ? N1    A G 22 ? ? 120.08 111.50 8.58   0.50 N 
+112 1 N7    A G 22 ? ? C8    A G 22 ? ? N9    A G 22 ? ? 108.54 113.10 -4.56  0.50 N 
+113 1 N3    A G 22 ? ? C4    A G 22 ? ? N9    A G 22 ? ? 133.78 126.00 7.78   0.60 N 
+114 1 C5    A G 22 ? ? C6    A G 22 ? ? O6    A G 22 ? ? 120.40 128.60 -8.20  0.60 N 
+115 1 N1    A A 23 ? ? C2    A A 23 ? ? N3    A A 23 ? ? 122.07 129.30 -7.23  0.50 N 
+116 1 C2    A A 23 ? ? N3    A A 23 ? ? C4    A A 23 ? ? 119.17 110.60 8.57   0.50 N 
+117 1 N3    A A 23 ? ? C4    A A 23 ? ? C5    A A 23 ? ? 119.34 126.80 -7.46  0.70 N 
+118 1 N7    A A 23 ? ? C8    A A 23 ? ? N9    A A 23 ? ? 109.50 113.80 -4.30  0.50 N 
+119 1 C8    A A 23 ? ? N9    A A 23 ? ? C4    A A 23 ? ? 109.09 105.80 3.29   0.40 N 
+120 1 N3    A A 23 ? ? C4    A A 23 ? ? N9    A A 23 ? ? 134.34 127.40 6.94   0.80 N 
+121 1 "O5'" A G 24 ? ? "C5'" A G 24 ? ? "C4'" A G 24 ? ? 103.46 109.40 -5.94  0.80 N 
+122 1 C2    A G 24 ? ? N3    A G 24 ? ? C4    A G 24 ? ? 119.71 111.90 7.81   0.50 N 
+123 1 N3    A G 24 ? ? C4    A G 24 ? ? C5    A G 24 ? ? 119.80 128.60 -8.80  0.50 N 
+124 1 C5    A G 24 ? ? C6    A G 24 ? ? N1    A G 24 ? ? 119.59 111.50 8.09   0.50 N 
+125 1 N7    A G 24 ? ? C8    A G 24 ? ? N9    A G 24 ? ? 108.16 113.10 -4.94  0.50 N 
+126 1 C8    A G 24 ? ? N9    A G 24 ? ? C4    A G 24 ? ? 109.40 106.40 3.00   0.40 N 
+127 1 N3    A G 24 ? ? C4    A G 24 ? ? N9    A G 24 ? ? 133.28 126.00 7.28   0.60 N 
+128 1 C5    A G 24 ? ? C6    A G 24 ? ? O6    A G 24 ? ? 119.72 128.60 -8.88  0.60 N 
+129 1 N1    A C 25 ? ? "C1'" A C 25 ? ? "C2'" A C 25 ? ? 102.93 112.00 -9.07  1.10 N 
+130 1 N3    A C 25 ? ? C4    A C 25 ? ? C5    A C 25 ? ? 119.19 121.90 -2.71  0.40 N 
+131 1 N3    A C 27 ? ? C4    A C 27 ? ? C5    A C 27 ? ? 118.94 121.90 -2.96  0.40 N 
+132 1 N3    A C 28 ? ? C4    A C 28 ? ? C5    A C 28 ? ? 118.75 121.90 -3.15  0.40 N 
+133 1 N1    A A 29 ? ? C2    A A 29 ? ? N3    A A 29 ? ? 120.71 129.30 -8.59  0.50 N 
+134 1 C2    A A 29 ? ? N3    A A 29 ? ? C4    A A 29 ? ? 119.21 110.60 8.61   0.50 N 
+135 1 N3    A A 29 ? ? C4    A A 29 ? ? C5    A A 29 ? ? 120.25 126.80 -6.55  0.70 N 
+136 1 N7    A A 29 ? ? C8    A A 29 ? ? N9    A A 29 ? ? 108.22 113.80 -5.58  0.50 N 
+137 1 C8    A A 29 ? ? N9    A A 29 ? ? C4    A A 29 ? ? 108.75 105.80 2.95   0.40 N 
+138 1 N3    A A 29 ? ? C4    A A 29 ? ? N9    A A 29 ? ? 132.81 127.40 5.41   0.80 N 
+139 1 C6    A G 30 ? ? N1    A G 30 ? ? C2    A G 30 ? ? 121.14 125.10 -3.96  0.60 N 
+140 1 C2    A G 30 ? ? N3    A G 30 ? ? C4    A G 30 ? ? 119.65 111.90 7.75   0.50 N 
+141 1 N3    A G 30 ? ? C4    A G 30 ? ? C5    A G 30 ? ? 119.70 128.60 -8.90  0.50 N 
+142 1 C5    A G 30 ? ? C6    A G 30 ? ? N1    A G 30 ? ? 119.79 111.50 8.29   0.50 N 
+143 1 N7    A G 30 ? ? C8    A G 30 ? ? N9    A G 30 ? ? 108.47 113.10 -4.63  0.50 N 
+144 1 C8    A G 30 ? ? N9    A G 30 ? ? C4    A G 30 ? ? 109.16 106.40 2.76   0.40 N 
+145 1 N3    A G 30 ? ? C4    A G 30 ? ? N9    A G 30 ? ? 133.75 126.00 7.75   0.60 N 
+146 1 C5    A G 30 ? ? C6    A G 30 ? ? O6    A G 30 ? ? 119.20 128.60 -9.40  0.60 N 
+147 1 "C1'" A A 31 ? ? "O4'" A A 31 ? ? "C4'" A A 31 ? ? 105.27 109.70 -4.43  0.70 N 
+148 1 N1    A A 31 ? ? C2    A A 31 ? ? N3    A A 31 ? ? 120.79 129.30 -8.51  0.50 N 
+149 1 C2    A A 31 ? ? N3    A A 31 ? ? C4    A A 31 ? ? 119.99 110.60 9.39   0.50 N 
+150 1 N3    A A 31 ? ? C4    A A 31 ? ? C5    A A 31 ? ? 119.72 126.80 -7.08  0.70 N 
+151 1 N7    A A 31 ? ? C8    A A 31 ? ? N9    A A 31 ? ? 108.19 113.80 -5.61  0.50 N 
+152 1 C8    A A 31 ? ? N9    A A 31 ? ? C4    A A 31 ? ? 109.34 105.80 3.54   0.40 N 
+153 1 N3    A A 31 ? ? C4    A A 31 ? ? N9    A A 31 ? ? 133.70 127.40 6.30   0.80 N 
+154 1 N1    A U 33 ? ? C2    A U 33 ? ? N3    A U 33 ? ? 120.90 114.90 6.00   0.60 N 
+155 1 C2    A U 33 ? ? N3    A U 33 ? ? C4    A U 33 ? ? 121.04 127.00 -5.96  0.60 N 
+156 1 N3    A U 33 ? ? C4    A U 33 ? ? C5    A U 33 ? ? 119.26 114.60 4.66   0.60 N 
+157 1 C5    A U 33 ? ? C6    A U 33 ? ? N1    A U 33 ? ? 119.57 122.70 -3.13  0.50 N 
+158 1 C5    A U 33 ? ? C4    A U 33 ? ? O4    A U 33 ? ? 119.26 125.90 -6.64  0.60 N 
+159 1 "C4'" A A 35 ? ? "C3'" A A 35 ? ? "C2'" A A 35 ? ? 95.12  102.60 -7.48  1.00 N 
+160 1 N1    A A 35 ? ? C2    A A 35 ? ? N3    A A 35 ? ? 121.22 129.30 -8.08  0.50 N 
+161 1 C2    A A 35 ? ? N3    A A 35 ? ? C4    A A 35 ? ? 119.54 110.60 8.94   0.50 N 
+162 1 N3    A A 35 ? ? C4    A A 35 ? ? C5    A A 35 ? ? 119.37 126.80 -7.43  0.70 N 
+163 1 N7    A A 35 ? ? C8    A A 35 ? ? N9    A A 35 ? ? 109.02 113.80 -4.78  0.50 N 
+164 1 C8    A A 35 ? ? N9    A A 35 ? ? C4    A A 35 ? ? 108.70 105.80 2.90   0.40 N 
+165 1 N3    A A 35 ? ? C4    A A 35 ? ? N9    A A 35 ? ? 134.22 127.40 6.82   0.80 N 
+166 1 N1    A A 36 ? ? C2    A A 36 ? ? N3    A A 36 ? ? 120.94 129.30 -8.36  0.50 N 
+167 1 C2    A A 36 ? ? N3    A A 36 ? ? C4    A A 36 ? ? 119.71 110.60 9.11   0.50 N 
+168 1 N3    A A 36 ? ? C4    A A 36 ? ? C5    A A 36 ? ? 119.75 126.80 -7.05  0.70 N 
+169 1 N7    A A 36 ? ? C8    A A 36 ? ? N9    A A 36 ? ? 108.66 113.80 -5.14  0.50 N 
+170 1 C8    A A 36 ? ? N9    A A 36 ? ? C4    A A 36 ? ? 109.37 105.80 3.57   0.40 N 
+171 1 N3    A A 36 ? ? C4    A A 36 ? ? N9    A A 36 ? ? 133.81 127.40 6.41   0.80 N 
+172 1 N1    A A 38 ? ? C2    A A 38 ? ? N3    A A 38 ? ? 121.07 129.30 -8.23  0.50 N 
+173 1 C2    A A 38 ? ? N3    A A 38 ? ? C4    A A 38 ? ? 119.69 110.60 9.09   0.50 N 
+174 1 N3    A A 38 ? ? C4    A A 38 ? ? C5    A A 38 ? ? 119.61 126.80 -7.19  0.70 N 
+175 1 C5    A A 38 ? ? N7    A A 38 ? ? C8    A A 38 ? ? 106.93 103.90 3.03   0.50 N 
+176 1 N7    A A 38 ? ? C8    A A 38 ? ? N9    A A 38 ? ? 108.13 113.80 -5.67  0.50 N 
+177 1 C8    A A 38 ? ? N9    A A 38 ? ? C4    A A 38 ? ? 109.23 105.80 3.43   0.40 N 
+178 1 N3    A A 38 ? ? C4    A A 38 ? ? N9    A A 38 ? ? 133.31 127.40 5.91   0.80 N 
+179 1 N1    A U 41 ? ? C2    A U 41 ? ? N3    A U 41 ? ? 121.16 114.90 6.26   0.60 N 
+180 1 C2    A U 41 ? ? N3    A U 41 ? ? C4    A U 41 ? ? 121.08 127.00 -5.92  0.60 N 
+181 1 N3    A U 41 ? ? C4    A U 41 ? ? C5    A U 41 ? ? 119.24 114.60 4.64   0.60 N 
+182 1 C5    A U 41 ? ? C6    A U 41 ? ? N1    A U 41 ? ? 119.34 122.70 -3.36  0.50 N 
+183 1 C5    A U 41 ? ? C4    A U 41 ? ? O4    A U 41 ? ? 119.53 125.90 -6.37  0.60 N 
+184 1 C2    A G 42 ? ? N3    A G 42 ? ? C4    A G 42 ? ? 119.38 111.90 7.48   0.50 N 
+185 1 N3    A G 42 ? ? C4    A G 42 ? ? C5    A G 42 ? ? 120.96 128.60 -7.64  0.50 N 
+186 1 C5    A G 42 ? ? C6    A G 42 ? ? N1    A G 42 ? ? 119.17 111.50 7.67   0.50 N 
+187 1 N7    A G 42 ? ? C8    A G 42 ? ? N9    A G 42 ? ? 107.84 113.10 -5.26  0.50 N 
+188 1 C8    A G 42 ? ? N9    A G 42 ? ? C4    A G 42 ? ? 109.12 106.40 2.72   0.40 N 
+189 1 N3    A G 42 ? ? C4    A G 42 ? ? N9    A G 42 ? ? 131.45 126.00 5.45   0.60 N 
+190 1 C5    A G 42 ? ? C6    A G 42 ? ? O6    A G 42 ? ? 118.75 128.60 -9.85  0.60 N 
+191 1 "O5'" A G 43 ? ? "C5'" A G 43 ? ? "C4'" A G 43 ? ? 103.85 109.40 -5.55  0.80 N 
+192 1 C2    A G 43 ? ? N3    A G 43 ? ? C4    A G 43 ? ? 119.15 111.90 7.25   0.50 N 
+193 1 N3    A G 43 ? ? C4    A G 43 ? ? C5    A G 43 ? ? 119.35 128.60 -9.25  0.50 N 
+194 1 C5    A G 43 ? ? C6    A G 43 ? ? N1    A G 43 ? ? 119.50 111.50 8.00   0.50 N 
+195 1 N7    A G 43 ? ? C8    A G 43 ? ? N9    A G 43 ? ? 109.12 113.10 -3.98  0.50 N 
+196 1 N3    A G 43 ? ? C4    A G 43 ? ? N9    A G 43 ? ? 134.50 126.00 8.50   0.60 N 
+197 1 C5    A G 43 ? ? C6    A G 43 ? ? O6    A G 43 ? ? 118.60 128.60 -10.00 0.60 N 
+198 1 N1    A A 44 ? ? C2    A A 44 ? ? N3    A A 44 ? ? 121.37 129.30 -7.93  0.50 N 
+199 1 C2    A A 44 ? ? N3    A A 44 ? ? C4    A A 44 ? ? 119.59 110.60 8.99   0.50 N 
+200 1 N3    A A 44 ? ? C4    A A 44 ? ? C5    A A 44 ? ? 119.54 126.80 -7.26  0.70 N 
+201 1 N7    A A 44 ? ? C8    A A 44 ? ? N9    A A 44 ? ? 108.10 113.80 -5.70  0.50 N 
+202 1 C8    A A 44 ? ? N9    A A 44 ? ? C4    A A 44 ? ? 109.04 105.80 3.24   0.40 N 
+203 1 N3    A A 44 ? ? C4    A A 44 ? ? N9    A A 44 ? ? 132.59 127.40 5.19   0.80 N 
+204 1 C2    A G 45 ? ? N3    A G 45 ? ? C4    A G 45 ? ? 119.38 111.90 7.48   0.50 N 
+205 1 N3    A G 45 ? ? C4    A G 45 ? ? C5    A G 45 ? ? 119.58 128.60 -9.02  0.50 N 
+206 1 C5    A G 45 ? ? C6    A G 45 ? ? N1    A G 45 ? ? 119.50 111.50 8.00   0.50 N 
+207 1 N7    A G 45 ? ? C8    A G 45 ? ? N9    A G 45 ? ? 108.87 113.10 -4.23  0.50 N 
+208 1 C8    A G 45 ? ? N9    A G 45 ? ? C4    A G 45 ? ? 108.82 106.40 2.42   0.40 N 
+209 1 N3    A G 45 ? ? C4    A G 45 ? ? N9    A G 45 ? ? 133.65 126.00 7.65   0.60 N 
+210 1 C5    A G 45 ? ? C6    A G 45 ? ? O6    A G 45 ? ? 120.48 128.60 -8.12  0.60 N 
+211 1 N1    A U 47 ? ? C2    A U 47 ? ? N3    A U 47 ? ? 120.32 114.90 5.42   0.60 N 
+212 1 C2    A U 47 ? ? N3    A U 47 ? ? C4    A U 47 ? ? 121.31 127.00 -5.69  0.60 N 
+213 1 N3    A U 47 ? ? C4    A U 47 ? ? C5    A U 47 ? ? 119.54 114.60 4.94   0.60 N 
+214 1 C5    A U 47 ? ? C4    A U 47 ? ? O4    A U 47 ? ? 119.79 125.90 -6.11  0.60 N 
+215 1 N3    A C 48 ? ? C4    A C 48 ? ? C5    A C 48 ? ? 119.29 121.90 -2.61  0.40 N 
+216 1 N1    A U 50 ? ? C2    A U 50 ? ? N3    A U 50 ? ? 121.57 114.90 6.67   0.60 N 
+217 1 C2    A U 50 ? ? N3    A U 50 ? ? C4    A U 50 ? ? 121.31 127.00 -5.69  0.60 N 
+218 1 N3    A U 50 ? ? C4    A U 50 ? ? C5    A U 50 ? ? 118.44 114.60 3.84   0.60 N 
+219 1 C5    A U 50 ? ? C6    A U 50 ? ? N1    A U 50 ? ? 119.40 122.70 -3.30  0.50 N 
+220 1 C5    A U 50 ? ? C4    A U 50 ? ? O4    A U 50 ? ? 119.77 125.90 -6.13  0.60 N 
+221 1 C2    A G 51 ? ? N3    A G 51 ? ? C4    A G 51 ? ? 119.58 111.90 7.68   0.50 N 
+222 1 N3    A G 51 ? ? C4    A G 51 ? ? C5    A G 51 ? ? 120.22 128.60 -8.38  0.50 N 
+223 1 C5    A G 51 ? ? C6    A G 51 ? ? N1    A G 51 ? ? 118.72 111.50 7.22   0.50 N 
+224 1 N7    A G 51 ? ? C8    A G 51 ? ? N9    A G 51 ? ? 108.13 113.10 -4.97  0.50 N 
+225 1 C8    A G 51 ? ? N9    A G 51 ? ? C4    A G 51 ? ? 109.35 106.40 2.95   0.40 N 
+226 1 N3    A G 51 ? ? C4    A G 51 ? ? N9    A G 51 ? ? 133.10 126.00 7.10   0.60 N 
+227 1 C5    A G 51 ? ? C6    A G 51 ? ? O6    A G 51 ? ? 117.85 128.60 -10.75 0.60 N 
+228 1 N1    A U 52 ? ? C2    A U 52 ? ? N3    A U 52 ? ? 120.84 114.90 5.94   0.60 N 
+229 1 C2    A U 52 ? ? N3    A U 52 ? ? C4    A U 52 ? ? 121.71 127.00 -5.29  0.60 N 
+230 1 N3    A U 52 ? ? C4    A U 52 ? ? C5    A U 52 ? ? 119.13 114.60 4.53   0.60 N 
+231 1 C5    A U 52 ? ? C6    A U 52 ? ? N1    A U 52 ? ? 119.52 122.70 -3.18  0.50 N 
+232 1 C5    A U 52 ? ? C4    A U 52 ? ? O4    A U 52 ? ? 120.51 125.90 -5.39  0.60 N 
+233 1 C2    A G 53 ? ? N3    A G 53 ? ? C4    A G 53 ? ? 120.38 111.90 8.48   0.50 N 
+234 1 N3    A G 53 ? ? C4    A G 53 ? ? C5    A G 53 ? ? 119.23 128.60 -9.37  0.50 N 
+235 1 C5    A G 53 ? ? C6    A G 53 ? ? N1    A G 53 ? ? 119.29 111.50 7.79   0.50 N 
+236 1 C4    A G 53 ? ? C5    A G 53 ? ? N7    A G 53 ? ? 107.92 110.80 -2.88  0.40 N 
+237 1 N7    A G 53 ? ? C8    A G 53 ? ? N9    A G 53 ? ? 108.38 113.10 -4.72  0.50 N 
+238 1 N3    A G 53 ? ? C4    A G 53 ? ? N9    A G 53 ? ? 133.06 126.00 7.06   0.60 N 
+239 1 C5    A G 53 ? ? C6    A G 53 ? ? O6    A G 53 ? ? 120.62 128.60 -7.98  0.60 N 
+240 1 N3    A C 56 ? ? C4    A C 56 ? ? C5    A C 56 ? ? 118.76 121.90 -3.14  0.40 N 
+241 1 C6    A G 57 ? ? N1    A G 57 ? ? C2    A G 57 ? ? 121.42 125.10 -3.68  0.60 N 
+242 1 C2    A G 57 ? ? N3    A G 57 ? ? C4    A G 57 ? ? 120.29 111.90 8.39   0.50 N 
+243 1 N3    A G 57 ? ? C4    A G 57 ? ? C5    A G 57 ? ? 119.00 128.60 -9.60  0.50 N 
+244 1 C5    A G 57 ? ? C6    A G 57 ? ? N1    A G 57 ? ? 118.86 111.50 7.36   0.50 N 
+245 1 C4    A G 57 ? ? C5    A G 57 ? ? N7    A G 57 ? ? 108.10 110.80 -2.70  0.40 N 
+246 1 N7    A G 57 ? ? C8    A G 57 ? ? N9    A G 57 ? ? 108.34 113.10 -4.76  0.50 N 
+247 1 N3    A G 57 ? ? C4    A G 57 ? ? N9    A G 57 ? ? 133.19 126.00 7.19   0.60 N 
+248 1 C5    A G 57 ? ? C6    A G 57 ? ? O6    A G 57 ? ? 119.60 128.60 -9.00  0.60 N 
+249 1 N1    A U 59 ? ? C2    A U 59 ? ? N3    A U 59 ? ? 120.73 114.90 5.83   0.60 N 
+250 1 C2    A U 59 ? ? N3    A U 59 ? ? C4    A U 59 ? ? 121.59 127.00 -5.41  0.60 N 
+251 1 N3    A U 59 ? ? C4    A U 59 ? ? C5    A U 59 ? ? 119.62 114.60 5.02   0.60 N 
+252 1 C5    A U 59 ? ? C4    A U 59 ? ? O4    A U 59 ? ? 120.06 125.90 -5.84  0.60 N 
+253 1 N3    A C 60 ? ? C4    A C 60 ? ? C5    A C 60 ? ? 118.92 121.90 -2.98  0.40 N 
+254 1 N3    A C 61 ? ? C4    A C 61 ? ? C5    A C 61 ? ? 119.16 121.90 -2.74  0.40 N 
+255 1 N1    A A 62 ? ? C2    A A 62 ? ? N3    A A 62 ? ? 121.15 129.30 -8.15  0.50 N 
+256 1 C2    A A 62 ? ? N3    A A 62 ? ? C4    A A 62 ? ? 118.94 110.60 8.34   0.50 N 
+257 1 N3    A A 62 ? ? C4    A A 62 ? ? C5    A A 62 ? ? 120.58 126.80 -6.22  0.70 N 
+258 1 N7    A A 62 ? ? C8    A A 62 ? ? N9    A A 62 ? ? 108.94 113.80 -4.86  0.50 N 
+259 1 C8    A A 62 ? ? N9    A A 62 ? ? C4    A A 62 ? ? 109.22 105.80 3.42   0.40 N 
+260 1 N3    A A 62 ? ? C4    A A 62 ? ? N9    A A 62 ? ? 132.92 127.40 5.52   0.80 N 
+261 1 N3    A C 63 ? ? C4    A C 63 ? ? C5    A C 63 ? ? 119.45 121.90 -2.45  0.40 N 
+262 1 N1    A A 64 ? ? C2    A A 64 ? ? N3    A A 64 ? ? 121.75 129.30 -7.55  0.50 N 
+263 1 C2    A A 64 ? ? N3    A A 64 ? ? C4    A A 64 ? ? 119.55 110.60 8.95   0.50 N 
+264 1 N3    A A 64 ? ? C4    A A 64 ? ? C5    A A 64 ? ? 119.23 126.80 -7.57  0.70 N 
+265 1 N7    A A 64 ? ? C8    A A 64 ? ? N9    A A 64 ? ? 108.49 113.80 -5.31  0.50 N 
+266 1 C8    A A 64 ? ? N9    A A 64 ? ? C4    A A 64 ? ? 108.58 105.80 2.78   0.40 N 
+267 1 N3    A A 64 ? ? C4    A A 64 ? ? N9    A A 64 ? ? 132.72 127.40 5.32   0.80 N 
+268 1 N9    A G 65 ? ? "C1'" A G 65 ? ? "C2'" A G 65 ? ? 103.75 112.00 -8.25  1.10 N 
+269 1 C6    A G 65 ? ? N1    A G 65 ? ? C2    A G 65 ? ? 120.76 125.10 -4.34  0.60 N 
+270 1 C2    A G 65 ? ? N3    A G 65 ? ? C4    A G 65 ? ? 119.88 111.90 7.98   0.50 N 
+271 1 N3    A G 65 ? ? C4    A G 65 ? ? C5    A G 65 ? ? 120.22 128.60 -8.38  0.50 N 
+272 1 C5    A G 65 ? ? C6    A G 65 ? ? N1    A G 65 ? ? 119.54 111.50 8.04   0.50 N 
+273 1 N7    A G 65 ? ? C8    A G 65 ? ? N9    A G 65 ? ? 108.01 113.10 -5.09  0.50 N 
+274 1 C8    A G 65 ? ? N9    A G 65 ? ? C4    A G 65 ? ? 109.33 106.40 2.93   0.40 N 
+275 1 N3    A G 65 ? ? C4    A G 65 ? ? N9    A G 65 ? ? 132.68 126.00 6.68   0.60 N 
+276 1 C5    A G 65 ? ? C6    A G 65 ? ? O6    A G 65 ? ? 119.58 128.60 -9.02  0.60 N 
+277 1 "O5'" A A 66 ? ? "C5'" A A 66 ? ? "C4'" A A 66 ? ? 103.72 109.40 -5.68  0.80 N 
+278 1 N1    A A 66 ? ? C2    A A 66 ? ? N3    A A 66 ? ? 121.37 129.30 -7.93  0.50 N 
+279 1 C2    A A 66 ? ? N3    A A 66 ? ? C4    A A 66 ? ? 119.24 110.60 8.64   0.50 N 
+280 1 N3    A A 66 ? ? C4    A A 66 ? ? C5    A A 66 ? ? 119.93 126.80 -6.87  0.70 N 
+281 1 N7    A A 66 ? ? C8    A A 66 ? ? N9    A A 66 ? ? 108.73 113.80 -5.07  0.50 N 
+282 1 C8    A A 66 ? ? N9    A A 66 ? ? C4    A A 66 ? ? 109.64 105.80 3.84   0.40 N 
+283 1 N3    A A 66 ? ? C4    A A 66 ? ? N9    A A 66 ? ? 134.22 127.40 6.82   0.80 N 
+284 1 "O5'" A A 67 ? ? "C5'" A A 67 ? ? "C4'" A A 67 ? ? 103.62 109.40 -5.78  0.80 N 
+285 1 N1    A A 67 ? ? C2    A A 67 ? ? N3    A A 67 ? ? 121.33 129.30 -7.97  0.50 N 
+286 1 C2    A A 67 ? ? N3    A A 67 ? ? C4    A A 67 ? ? 119.96 110.60 9.36   0.50 N 
+287 1 N3    A A 67 ? ? C4    A A 67 ? ? C5    A A 67 ? ? 119.17 126.80 -7.63  0.70 N 
+288 1 C4    A A 67 ? ? C5    A A 67 ? ? N7    A A 67 ? ? 107.65 110.70 -3.05  0.50 N 
+289 1 C5    A A 67 ? ? N7    A A 67 ? ? C8    A A 67 ? ? 106.92 103.90 3.02   0.50 N 
+290 1 N7    A A 67 ? ? C8    A A 67 ? ? N9    A A 67 ? ? 108.69 113.80 -5.11  0.50 N 
+291 1 C8    A A 67 ? ? N9    A A 67 ? ? C4    A A 67 ? ? 108.39 105.80 2.59   0.40 N 
+292 1 N9    A A 67 ? ? C4    A A 67 ? ? C5    A A 67 ? ? 108.31 105.80 2.51   0.40 N 
+293 1 N3    A A 67 ? ? C4    A A 67 ? ? N9    A A 67 ? ? 132.40 127.40 5.00   0.80 N 
+294 1 "O5'" A U 68 ? ? "C5'" A U 68 ? ? "C4'" A U 68 ? ? 102.99 109.40 -6.41  0.80 N 
+295 1 "C4'" A U 68 ? ? "C3'" A U 68 ? ? "C2'" A U 68 ? ? 96.52  102.60 -6.08  1.00 N 
+296 1 N1    A U 68 ? ? C2    A U 68 ? ? N3    A U 68 ? ? 120.60 114.90 5.70   0.60 N 
+297 1 C2    A U 68 ? ? N3    A U 68 ? ? C4    A U 68 ? ? 121.06 127.00 -5.94  0.60 N 
+298 1 N3    A U 68 ? ? C4    A U 68 ? ? C5    A U 68 ? ? 119.94 114.60 5.34   0.60 N 
+299 1 C5    A U 68 ? ? C6    A U 68 ? ? N1    A U 68 ? ? 119.46 122.70 -3.24  0.50 N 
+300 1 N3    A U 68 ? ? C2    A U 68 ? ? O2    A U 68 ? ? 117.96 122.20 -4.24  0.70 N 
+301 1 C5    A U 68 ? ? C4    A U 68 ? ? O4    A U 68 ? ? 120.16 125.90 -5.74  0.60 N 
+302 1 N1    A U 69 ? ? C2    A U 69 ? ? N3    A U 69 ? ? 121.04 114.90 6.14   0.60 N 
+303 1 C2    A U 69 ? ? N3    A U 69 ? ? C4    A U 69 ? ? 121.11 127.00 -5.89  0.60 N 
+304 1 N3    A U 69 ? ? C4    A U 69 ? ? C5    A U 69 ? ? 119.46 114.60 4.86   0.60 N 
+305 1 C5    A U 69 ? ? C4    A U 69 ? ? O4    A U 69 ? ? 120.21 125.90 -5.69  0.60 N 
+306 1 N3    A C 70 ? ? C4    A C 70 ? ? C5    A C 70 ? ? 119.23 121.90 -2.67  0.40 N 
+307 1 N9    A G 71 ? ? "C1'" A G 71 ? ? "C2'" A G 71 ? ? 105.16 112.00 -6.84  1.10 N 
+308 1 N1    A G 71 ? ? C2    A G 71 ? ? N3    A G 71 ? ? 119.82 123.90 -4.08  0.60 N 
+309 1 C2    A G 71 ? ? N3    A G 71 ? ? C4    A G 71 ? ? 119.80 111.90 7.90   0.50 N 
+310 1 N3    A G 71 ? ? C4    A G 71 ? ? C5    A G 71 ? ? 121.13 128.60 -7.47  0.50 N 
+311 1 C5    A G 71 ? ? C6    A G 71 ? ? N1    A G 71 ? ? 119.56 111.50 8.06   0.50 N 
+312 1 N7    A G 71 ? ? C8    A G 71 ? ? N9    A G 71 ? ? 107.76 113.10 -5.34  0.50 N 
+313 1 C8    A G 71 ? ? N9    A G 71 ? ? C4    A G 71 ? ? 109.55 106.40 3.15   0.40 N 
+314 1 N3    A G 71 ? ? C4    A G 71 ? ? N9    A G 71 ? ? 132.00 126.00 6.00   0.60 N 
+315 1 C5    A G 71 ? ? C6    A G 71 ? ? O6    A G 71 ? ? 120.21 128.60 -8.39  0.60 N 
+316 1 "O5'" A C 72 ? ? "C5'" A C 72 ? ? "C4'" A C 72 ? ? 104.05 109.40 -5.35  0.80 N 
+317 1 N3    A C 72 ? ? C4    A C 72 ? ? C5    A C 72 ? ? 118.27 121.90 -3.63  0.40 N 
+318 1 N1    A A 73 ? ? C2    A A 73 ? ? N3    A A 73 ? ? 121.02 129.30 -8.28  0.50 N 
+319 1 C2    A A 73 ? ? N3    A A 73 ? ? C4    A A 73 ? ? 119.63 110.60 9.03   0.50 N 
+320 1 N3    A A 73 ? ? C4    A A 73 ? ? C5    A A 73 ? ? 119.57 126.80 -7.23  0.70 N 
+321 1 C5    A A 73 ? ? N7    A A 73 ? ? C8    A A 73 ? ? 106.93 103.90 3.03   0.50 N 
+322 1 N7    A A 73 ? ? C8    A A 73 ? ? N9    A A 73 ? ? 108.51 113.80 -5.29  0.50 N 
+323 1 C8    A A 73 ? ? N9    A A 73 ? ? C4    A A 73 ? ? 108.76 105.80 2.96   0.40 N 
+324 1 N3    A A 73 ? ? C4    A A 73 ? ? N9    A A 73 ? ? 133.37 127.40 5.97   0.80 N 
+325 1 N3    A C 74 ? ? C4    A C 74 ? ? C5    A C 74 ? ? 119.37 121.90 -2.53  0.40 N 
+326 1 N3    A C 75 ? ? C4    A C 75 ? ? C5    A C 75 ? ? 118.69 121.90 -3.21  0.40 N 
+327 1 N1    A A 76 ? ? C2    A A 76 ? ? N3    A A 76 ? ? 121.45 129.30 -7.85  0.50 N 
+328 1 C2    A A 76 ? ? N3    A A 76 ? ? C4    A A 76 ? ? 119.16 110.60 8.56   0.50 N 
+329 1 N3    A A 76 ? ? C4    A A 76 ? ? C5    A A 76 ? ? 119.72 126.80 -7.08  0.70 N 
+330 1 N7    A A 76 ? ? C8    A A 76 ? ? N9    A A 76 ? ? 109.02 113.80 -4.78  0.50 N 
+331 1 C8    A A 76 ? ? N9    A A 76 ? ? C4    A A 76 ? ? 108.61 105.80 2.81   0.40 N 
+332 1 N3    A A 76 ? ? C4    A A 76 ? ? N9    A A 76 ? ? 133.34 127.40 5.94   0.80 N 
+333 1 C5    A A 76 ? ? C6    A A 76 ? ? N6    A A 76 ? ? 118.50 123.70 -5.20  0.80 N 
+# 
+loop_
+_pdbx_validate_planes.id 
+_pdbx_validate_planes.PDB_model_num 
+_pdbx_validate_planes.auth_comp_id 
+_pdbx_validate_planes.auth_asym_id 
+_pdbx_validate_planes.auth_seq_id 
+_pdbx_validate_planes.PDB_ins_code 
+_pdbx_validate_planes.label_alt_id 
+_pdbx_validate_planes.rmsd 
+_pdbx_validate_planes.type 
+1  1 G A 1  ? ? 0.070 'SIDE CHAIN' 
+2  1 C A 2  ? ? 0.115 'SIDE CHAIN' 
+3  1 G A 3  ? ? 0.063 'SIDE CHAIN' 
+4  1 A A 5  ? ? 0.121 'SIDE CHAIN' 
+5  1 U A 6  ? ? 0.117 'SIDE CHAIN' 
+6  1 U A 8  ? ? 0.144 'SIDE CHAIN' 
+7  1 U A 12 ? ? 0.091 'SIDE CHAIN' 
+8  1 C A 13 ? ? 0.077 'SIDE CHAIN' 
+9  1 G A 15 ? ? 0.094 'SIDE CHAIN' 
+10 1 G A 18 ? ? 0.101 'SIDE CHAIN' 
+11 1 G A 19 ? ? 0.099 'SIDE CHAIN' 
+12 1 G A 20 ? ? 0.065 'SIDE CHAIN' 
+13 1 A A 21 ? ? 0.149 'SIDE CHAIN' 
+14 1 A A 23 ? ? 0.065 'SIDE CHAIN' 
+15 1 G A 24 ? ? 0.099 'SIDE CHAIN' 
+16 1 C A 25 ? ? 0.104 'SIDE CHAIN' 
+17 1 C A 27 ? ? 0.122 'SIDE CHAIN' 
+18 1 C A 28 ? ? 0.113 'SIDE CHAIN' 
+19 1 A A 29 ? ? 0.080 'SIDE CHAIN' 
+20 1 G A 30 ? ? 0.095 'SIDE CHAIN' 
+21 1 U A 33 ? ? 0.122 'SIDE CHAIN' 
+22 1 A A 38 ? ? 0.127 'SIDE CHAIN' 
+23 1 U A 41 ? ? 0.100 'SIDE CHAIN' 
+24 1 G A 42 ? ? 0.068 'SIDE CHAIN' 
+25 1 G A 43 ? ? 0.072 'SIDE CHAIN' 
+26 1 A A 44 ? ? 0.090 'SIDE CHAIN' 
+27 1 U A 47 ? ? 0.070 'SIDE CHAIN' 
+28 1 U A 50 ? ? 0.113 'SIDE CHAIN' 
+29 1 G A 51 ? ? 0.136 'SIDE CHAIN' 
+30 1 G A 53 ? ? 0.135 'SIDE CHAIN' 
+31 1 C A 56 ? ? 0.062 'SIDE CHAIN' 
+32 1 G A 57 ? ? 0.145 'SIDE CHAIN' 
+33 1 U A 59 ? ? 0.079 'SIDE CHAIN' 
+34 1 C A 60 ? ? 0.114 'SIDE CHAIN' 
+35 1 C A 61 ? ? 0.092 'SIDE CHAIN' 
+36 1 A A 62 ? ? 0.053 'SIDE CHAIN' 
+37 1 A A 64 ? ? 0.076 'SIDE CHAIN' 
+38 1 U A 68 ? ? 0.093 'SIDE CHAIN' 
+39 1 G A 71 ? ? 0.071 'SIDE CHAIN' 
+40 1 C A 72 ? ? 0.148 'SIDE CHAIN' 
+41 1 A A 73 ? ? 0.075 'SIDE CHAIN' 
+42 1 C A 74 ? ? 0.097 'SIDE CHAIN' 
+43 1 C A 75 ? ? 0.094 'SIDE CHAIN' 
+44 1 A A 76 ? ? 0.079 'SIDE CHAIN' 
+# 
+loop_
+_ndb_struct_conf_na.entry_id 
+_ndb_struct_conf_na.feature 
+4TNA 'double helix'         
+4TNA 'a-form double helix'  
+4TNA 'parallel strands'     
+4TNA 'hairpin loop'         
+4TNA 'mismatched base pair' 
+4TNA 'four-way junction'    
+# 
+loop_
+_ndb_struct_na_base_pair.model_number 
+_ndb_struct_na_base_pair.i_label_asym_id 
+_ndb_struct_na_base_pair.i_label_comp_id 
+_ndb_struct_na_base_pair.i_label_seq_id 
+_ndb_struct_na_base_pair.i_symmetry 
+_ndb_struct_na_base_pair.j_label_asym_id 
+_ndb_struct_na_base_pair.j_label_comp_id 
+_ndb_struct_na_base_pair.j_label_seq_id 
+_ndb_struct_na_base_pair.j_symmetry 
+_ndb_struct_na_base_pair.shear 
+_ndb_struct_na_base_pair.stretch 
+_ndb_struct_na_base_pair.stagger 
+_ndb_struct_na_base_pair.buckle 
+_ndb_struct_na_base_pair.propeller 
+_ndb_struct_na_base_pair.opening 
+_ndb_struct_na_base_pair.pair_number 
+_ndb_struct_na_base_pair.pair_name 
+_ndb_struct_na_base_pair.i_auth_asym_id 
+_ndb_struct_na_base_pair.i_auth_seq_id 
+_ndb_struct_na_base_pair.i_PDB_ins_code 
+_ndb_struct_na_base_pair.j_auth_asym_id 
+_ndb_struct_na_base_pair.j_auth_seq_id 
+_ndb_struct_na_base_pair.j_PDB_ins_code 
+_ndb_struct_na_base_pair.hbond_type_28 
+_ndb_struct_na_base_pair.hbond_type_12 
+1 A G   1  1_555 A C   72 1_555 -0.970 -0.315 0.024  3.246   1.291   4.674    1  A_G1:C72_A      A 1  ? A 72 ? 19 1 
+1 A C   2  1_555 A G   71 1_555 1.133  -0.674 -0.121 5.689   -10.494 -2.016   2  A_C2:G71_A      A 2  ? A 71 ? 19 1 
+1 A G   3  1_555 A C   70 1_555 -0.318 -0.240 0.273  6.163   -12.127 -0.724   3  A_G3:C70_A      A 3  ? A 70 ? 19 1 
+1 A G   4  1_555 A U   69 1_555 -2.065 -0.210 -0.099 8.962   -7.946  3.752    4  A_G4:U69_A      A 4  ? A 69 ? 28 1 
+1 A A   5  1_555 A U   68 1_555 -0.175 -0.156 -0.555 3.494   -18.198 -2.778   5  A_A5:U68_A      A 5  ? A 68 ? 20 1 
+1 A U   6  1_555 A A   67 1_555 0.118  -0.178 -0.292 5.297   -20.183 7.877    6  A_U6:A67_A      A 6  ? A 67 ? 20 1 
+1 A U   7  1_555 A A   66 1_555 -0.581 0.045  -0.399 2.695   -5.520  -5.657   7  A_U7:A66_A      A 7  ? A 66 ? 20 1 
+1 A 5MC 49 1_555 A G   65 1_555 -0.028 -0.042 -0.442 10.198  -13.674 -0.594   8  A_5MC49:G65_A   A 49 ? A 65 ? 19 1 
+1 A U   50 1_555 A A   64 1_555 -0.546 0.017  0.801  -13.819 0.192   4.235    9  A_U50:A64_A     A 50 ? A 64 ? 20 1 
+1 A G   51 1_555 A C   63 1_555 0.129  -0.187 0.217  -0.092  -11.539 -1.753   10 A_G51:C63_A     A 51 ? A 63 ? 19 1 
+1 A U   52 1_555 A A   62 1_555 -0.516 -0.073 0.334  4.495   -14.271 -4.048   11 A_U52:A62_A     A 52 ? A 62 ? 20 1 
+1 A G   53 1_555 A C   61 1_555 -0.094 -0.091 0.216  -8.853  -10.830 2.377    12 A_G53:C61_A     A 53 ? A 61 ? 19 1 
+1 A 5MU 54 1_555 A 1MA 58 1_555 4.334  -2.136 0.157  1.137   3.814   -99.892  13 A_5MU54:1MA58_A A 54 ? A 58 ? 24 4 
+1 A PSU 55 1_555 A G   18 1_555 0.659  -6.013 0.479  16.601  -3.170  -93.314  14 A_PSU55:G18_A   A 55 ? A 18 ? ?  2 
+1 A PSU 39 1_555 A A   31 1_555 -1.541 0.114  0.005  18.831  -9.120  -14.147  15 A_PSU39:A31_A   A 39 ? A 31 ? 21 1 
+1 A 5MC 40 1_555 A G   30 1_555 -0.253 0.171  -1.041 13.550  -18.928 -7.011   16 A_5MC40:G30_A   A 40 ? A 30 ? 19 1 
+1 A U   41 1_555 A A   29 1_555 0.248  0.077  -0.105 -3.469  -5.056  -3.952   17 A_U41:A29_A     A 41 ? A 29 ? 20 1 
+1 A G   42 1_555 A C   28 1_555 -0.112 -0.304 0.145  -7.469  -14.810 -0.463   18 A_G42:C28_A     A 42 ? A 28 ? 19 1 
+1 A G   43 1_555 A C   27 1_555 0.413  0.048  -0.487 -14.445 -32.326 -16.394  19 A_G43:C27_A     A 43 ? A 27 ? ?  ? 
+1 A A   44 1_555 A M2G 26 1_555 0.801  1.263  -1.026 -26.519 -28.583 -26.610  20 A_A44:M2G26_A   A 44 ? A 26 ? 8  ? 
+1 A 2MG 10 1_555 A C   25 1_555 0.211  -0.047 -0.614 -11.204 -14.071 -6.024   21 A_2MG10:C25_A   A 10 ? A 25 ? 19 1 
+1 A C   11 1_555 A G   24 1_555 0.235  -0.163 0.136  -7.070  -23.274 -9.668   22 A_C11:G24_A     A 11 ? A 24 ? 19 1 
+1 A U   12 1_555 A A   23 1_555 -0.211 -0.058 -0.421 1.064   -13.120 -1.118   23 A_U12:A23_A     A 12 ? A 23 ? 20 1 
+1 A C   13 1_555 A G   22 1_555 -0.285 0.235  0.034  8.061   -8.888  0.742    24 A_C13:G22_A     A 13 ? A 22 ? 19 1 
+1 A A   14 1_555 A U   8  1_555 -4.073 -1.927 1.142  4.840   16.124  -101.713 25 A_A14:U8_A      A 14 ? A 8  ? 24 4 
+1 A G   15 1_555 A C   48 1_555 -0.359 3.719  -0.035 7.885   1.141   151.489  26 A_G15:C48_A     A 15 ? A 48 ? 22 2 
+1 A G   19 1_555 A C   56 1_555 -0.083 -0.102 0.313  -28.096 -16.158 2.537    27 A_G19:C56_A     A 19 ? A 56 ? 19 1 
+# 
+loop_
+_ndb_struct_na_base_pair_step.model_number 
+_ndb_struct_na_base_pair_step.i_label_asym_id_1 
+_ndb_struct_na_base_pair_step.i_label_comp_id_1 
+_ndb_struct_na_base_pair_step.i_label_seq_id_1 
+_ndb_struct_na_base_pair_step.i_symmetry_1 
+_ndb_struct_na_base_pair_step.j_label_asym_id_1 
+_ndb_struct_na_base_pair_step.j_label_comp_id_1 
+_ndb_struct_na_base_pair_step.j_label_seq_id_1 
+_ndb_struct_na_base_pair_step.j_symmetry_1 
+_ndb_struct_na_base_pair_step.i_label_asym_id_2 
+_ndb_struct_na_base_pair_step.i_label_comp_id_2 
+_ndb_struct_na_base_pair_step.i_label_seq_id_2 
+_ndb_struct_na_base_pair_step.i_symmetry_2 
+_ndb_struct_na_base_pair_step.j_label_asym_id_2 
+_ndb_struct_na_base_pair_step.j_label_comp_id_2 
+_ndb_struct_na_base_pair_step.j_label_seq_id_2 
+_ndb_struct_na_base_pair_step.j_symmetry_2 
+_ndb_struct_na_base_pair_step.shift 
+_ndb_struct_na_base_pair_step.slide 
+_ndb_struct_na_base_pair_step.rise 
+_ndb_struct_na_base_pair_step.tilt 
+_ndb_struct_na_base_pair_step.roll 
+_ndb_struct_na_base_pair_step.twist 
+_ndb_struct_na_base_pair_step.x_displacement 
+_ndb_struct_na_base_pair_step.y_displacement 
+_ndb_struct_na_base_pair_step.helical_rise 
+_ndb_struct_na_base_pair_step.inclination 
+_ndb_struct_na_base_pair_step.tip 
+_ndb_struct_na_base_pair_step.helical_twist 
+_ndb_struct_na_base_pair_step.step_number 
+_ndb_struct_na_base_pair_step.step_name 
+_ndb_struct_na_base_pair_step.i_auth_asym_id_1 
+_ndb_struct_na_base_pair_step.i_auth_seq_id_1 
+_ndb_struct_na_base_pair_step.i_PDB_ins_code_1 
+_ndb_struct_na_base_pair_step.j_auth_asym_id_1 
+_ndb_struct_na_base_pair_step.j_auth_seq_id_1 
+_ndb_struct_na_base_pair_step.j_PDB_ins_code_1 
+_ndb_struct_na_base_pair_step.i_auth_asym_id_2 
+_ndb_struct_na_base_pair_step.i_auth_seq_id_2 
+_ndb_struct_na_base_pair_step.i_PDB_ins_code_2 
+_ndb_struct_na_base_pair_step.j_auth_asym_id_2 
+_ndb_struct_na_base_pair_step.j_auth_seq_id_2 
+_ndb_struct_na_base_pair_step.j_PDB_ins_code_2 
+1 A G   1  1_555 A C   72 1_555 A C   2  1_555 A G   71 1_555 -1.130 -1.649 3.430 -1.480 1.767  39.694  -2.640 1.483  3.395 2.599  
+2.177   39.758  1  AA_G1C2:G71C72_AA         A 1  ? A 72 ? A 2  ? A 71 ? 
+1 A C   2  1_555 A G   71 1_555 A G   3  1_555 A C   70 1_555 0.238  -1.694 3.086 1.251  13.095 23.197  -6.474 -0.251 1.885 29.698 
+-2.838  26.623  2  AA_C2G3:C70G71_AA         A 2  ? A 71 ? A 3  ? A 70 ? 
+1 A G   3  1_555 A C   70 1_555 A G   4  1_555 A U   69 1_555 0.288  -1.702 3.059 -1.501 10.395 23.148  -6.344 -1.012 2.088 24.360 
+3.516   25.390  3  AA_G3G4:U69C70_AA         A 3  ? A 70 ? A 4  ? A 69 ? 
+1 A G   4  1_555 A U   69 1_555 A A   5  1_555 A U   68 1_555 -0.436 -1.101 3.561 1.193  11.755 38.263  -3.015 0.781  3.090 17.433 
+-1.769  39.980  4  AA_G4A5:U68U69_AA         A 4  ? A 69 ? A 5  ? A 68 ? 
+1 A A   5  1_555 A U   68 1_555 A U   6  1_555 A A   67 1_555 0.737  -1.270 3.257 0.179  2.254  34.575  -2.473 -1.211 3.174 3.788  
+-0.300  34.647  5  AA_A5U6:A67U68_AA         A 5  ? A 68 ? A 6  ? A 67 ? 
+1 A U   6  1_555 A A   67 1_555 A U   7  1_555 A A   66 1_555 -0.412 -1.379 3.372 0.805  17.827 27.192  -5.330 0.867  2.085 33.704 
+-1.522  32.432  6  AA_U6U7:A66A67_AA         A 6  ? A 67 ? A 7  ? A 66 ? 
+1 A U   7  1_555 A A   66 1_555 A 5MC 49 1_555 A G   65 1_555 0.228  -1.608 3.225 3.991  1.763  34.515  -2.953 0.214  3.147 2.956  
+-6.693  34.782  7  AA_U75MC49:G65A66_AA      A 7  ? A 66 ? A 49 ? A 65 ? 
+1 A 5MC 49 1_555 A G   65 1_555 A U   50 1_555 A A   64 1_555 -0.017 -2.106 4.031 -8.273 7.497  29.319  -5.538 -1.775 3.290 14.179 
+15.648  31.329  8  AA_5MC49U50:A64G65_AA     A 49 ? A 65 ? A 50 ? A 64 ? 
+1 A U   50 1_555 A A   64 1_555 A G   51 1_555 A C   63 1_555 -0.397 -1.533 2.698 3.930  9.808  37.279  -3.231 0.967  2.189 14.978 
+-6.001  38.696  9  AA_U50G51:C63A64_AA       A 50 ? A 64 ? A 51 ? A 63 ? 
+1 A G   51 1_555 A C   63 1_555 A U   52 1_555 A A   62 1_555 0.153  -1.726 3.252 -1.477 2.375  26.400  -4.367 -0.710 3.074 5.183  
+3.222   26.545  10 AA_G51U52:A62C63_AA       A 51 ? A 63 ? A 52 ? A 62 ? 
+1 A U   52 1_555 A A   62 1_555 A G   53 1_555 A C   61 1_555 0.893  -2.073 3.477 1.944  8.312  34.067  -4.682 -1.191 2.950 13.919 
+-3.256  35.089  11 AA_U52G53:C61A62_AA       A 52 ? A 62 ? A 53 ? A 61 ? 
+1 A G   53 1_555 A C   61 1_555 A 5MU 54 1_555 A 1MA 58 1_555 -2.201 -2.503 3.195 0.270  -3.599 93.168  -1.656 1.519  3.263 -2.476 
+-0.186  93.221  12 AA_G535MU54:1MA58C61_AA   A 53 ? A 61 ? A 54 ? A 58 ? 
+1 A 5MU 54 1_555 A 1MA 58 1_555 A PSU 55 1_555 A G   18 1_555 2.168  -1.932 3.244 9.005  4.830  40.212  -3.261 -2.073 3.388 6.891  
+-12.848 41.438  13 AA_5MU54PSU55:G181MA58_AA A 54 ? A 58 ? A 55 ? A 18 ? 
+1 A PSU 39 1_555 A A   31 1_555 A 5MC 40 1_555 A G   30 1_555 -0.475 -1.423 3.490 3.263  12.311 34.675  -3.903 1.189  2.788 19.846 
+-5.260  36.873  14 AA_PSU395MC40:G30A31_AA   A 39 ? A 31 ? A 40 ? A 30 ? 
+1 A 5MC 40 1_555 A G   30 1_555 A U   41 1_555 A A   29 1_555 0.616  -2.156 4.112 -5.892 3.884  34.590  -4.253 -2.071 3.704 6.449  
+9.783   35.281  15 AA_5MC40U41:A29G30_AA     A 40 ? A 30 ? A 41 ? A 29 ? 
+1 A U   41 1_555 A A   29 1_555 A G   42 1_555 A C   28 1_555 0.347  -1.376 3.252 0.004  10.831 29.190  -4.480 -0.647 2.589 20.617 
+-0.008  31.094  16 AA_U41G42:C28A29_AA       A 41 ? A 29 ? A 42 ? A 28 ? 
+1 A G   42 1_555 A C   28 1_555 A G   43 1_555 A C   27 1_555 -0.772 -1.661 3.644 2.957  11.687 36.967  -3.972 1.534  2.937 17.858 
+-4.518  38.817  17 AA_G42G43:C27C28_AA       A 42 ? A 28 ? A 43 ? A 27 ? 
+1 A G   43 1_555 A C   27 1_555 A A   44 1_555 A M2G 26 1_555 -0.413 -1.167 3.390 6.567  8.640  38.405  -2.701 1.357  2.962 12.825 
+-9.748  39.854  18 AA_G43A44:M2G26C27_AA     A 43 ? A 27 ? A 44 ? A 26 ? 
+1 A A   44 1_555 A M2G 26 1_555 A 2MG 10 1_555 A C   25 1_555 -3.129 -2.904 3.808 14.579 15.681 56.513  -3.637 3.810  2.208 15.942 
+-14.822 60.119  19 AA_A442MG10:C25M2G26_AA   A 44 ? A 26 ? A 10 ? A 25 ? 
+1 A 2MG 10 1_555 A C   25 1_555 A C   11 1_555 A G   24 1_555 -0.987 -1.554 3.162 -7.296 10.259 34.422  -3.794 0.636  2.749 16.660 
+11.848  36.586  20 AA_2MG10C11:G24C25_AA     A 10 ? A 25 ? A 11 ? A 24 ? 
+1 A C   11 1_555 A G   24 1_555 A U   12 1_555 A A   23 1_555 0.342  -1.081 3.055 5.366  4.090  30.895  -2.683 0.288  2.908 7.565  
+-9.924  31.606  21 AA_C11U12:A23G24_AA       A 11 ? A 24 ? A 12 ? A 23 ? 
+1 A U   12 1_555 A A   23 1_555 A C   13 1_555 A G   22 1_555 1.855  -1.660 3.222 1.385  4.861  28.341  -4.381 -3.435 2.987 9.830  
+-2.800  28.779  22 AA_U12C13:G22A23_AA       A 12 ? A 23 ? A 13 ? A 22 ? 
+1 A C   13 1_555 A G   22 1_555 A A   14 1_555 A U   8  1_555 -2.261 -0.345 3.337 0.115  -6.533 59.252  -0.011 2.282  3.351 -6.585 
+-0.116  59.579  23 AA_C13A14:U8G22_AA        A 13 ? A 22 ? A 14 ? A 8  ? 
+1 A A   14 1_555 A U   8  1_555 A G   15 1_555 A C   48 1_555 2.519  -3.309 3.559 1.575  10.324 -67.022 2.515  2.330  3.919 -9.292 
+1.418   -67.737 24 AA_A14G15:C48U8_AA        A 14 ? A 8  ? A 15 ? A 48 ? 
+# 
+_pdbx_entity_nonpoly.entity_id   2 
+_pdbx_entity_nonpoly.name        'MAGNESIUM ION' 
+_pdbx_entity_nonpoly.comp_id     MG 
+# 

--- a/Code/GraphMol/Wrap/rdmolfiles.cpp
+++ b/Code/GraphMol/Wrap/rdmolfiles.cpp
@@ -203,6 +203,21 @@ ROMol *MolFromPDBFile(const char *filename, bool sanitize, bool removeHs,
   return static_cast<ROMol *>(newM);
 }
 
+ROMol *MolFromMmcifFile(const char *filename, bool sanitize, bool removeHs,
+                        unsigned int flavor, bool proximityBonding) {
+  RWMol *newM = nullptr;
+  try {
+    newM = mmcifFileToMol(filename, sanitize, removeHs, flavor, proximityBonding);
+  } catch (RDKit::BadFileException &e) {
+    PyErr_SetString(PyExc_IOError, e.what());
+    throw python::error_already_set();
+  } catch (RDKit::FileParseException &e) {
+    BOOST_LOG(rdWarningLog) << e.what() << std::endl;
+  } catch (...) {
+  }
+  return static_cast<ROMol *>(newM);
+}
+
 ROMol *MolFromPDBBlock(python::object molBlock, bool sanitize, bool removeHs,
                        unsigned int flavor, bool proximityBonding) {
   std::istringstream inStream(pyObjectToString(molBlock));
@@ -1557,6 +1572,34 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
     a Mol object, None on failure.\n\
 \n";
   python::def("MolFromPDBFile", RDKit::MolFromPDBFile,
+              (python::arg("molFileName"), python::arg("sanitize") = true,
+               python::arg("removeHs") = true, python::arg("flavor") = 0,
+               python::arg("proximityBonding") = true),
+              docString.c_str(),
+              python::return_value_policy<python::manage_new_object>());
+
+  docString = "Construct a molecule from an mmcif file.\n\n\
+  ARGUMENTS:\n\
+\n\
+  - fileName: name of the file to read\n\
+\n\
+  - sanitize: (optional) toggles sanitization of the molecule.\n\
+    Defaults to true.\n\
+\n\
+  - removeHs: (optional) toggles removing hydrogens from the molecule.\n\
+    This only make sense when sanitization is done.\n\
+    Defaults to true.\n\
+\n\
+  - flavor: (optional) \n\
+\n\
+  - proximityBonding: (optional) toggles automatic proximity bonding\n\
+\n\
+RETURNS:\n\
+\n\
+  a Mol object, None on failure.\n\
+\n";
+
+  python::def("MolFromMmCifFile", RDKit::MolFromMmcifFile,
               (python::arg("molFileName"), python::arg("sanitize") = true,
                python::arg("removeHs") = true, python::arg("flavor") = 0,
                python::arg("proximityBonding") = true),


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! 
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->

Fixes #2054 

Currently a work in progress, just checking I'm in the right direction.

TODO:
 - [ ] multiple models
 - [x] python hookup
 - [x] cmake things (see below)
 - [ ] more tests

#### What does this implement/fix? Explain your changes.

Adds a PDBx/mmcif parser exposed as `Mol *m = MMCifFileToMol()`

#### Any other comments?

I've copied across the PDB parser test from 1CRN.  The only part not working is the atom serials - `AtomPDBResidueInfo` assumes these are ints, in the PDBx standard they can be strings.

~~This is using the [gemmi](https://github.com/project-gemmi/gemmi) library for parsing the cif file, it seemed like the best available option.  I'm assuming that this will require working in this as an optional dependency into the CMake files?~~ Easier to hack together a stream parser than play with CMake