### PR TITLE
Fixes #4809: double bond stereo can now be set after calling replaceCore()

### DIFF
--- a/Code/GraphMol/ChemTransforms/CMakeLists.txt
+++ b/Code/GraphMol/ChemTransforms/CMakeLists.txt
@@ -13,4 +13,4 @@ rdkit_headers(ChemTransforms.h
 rdkit_test(testChemTransforms testChemTransforms.cpp 
            LINK_LIBRARIES ChemTransforms FileParsers)
 
-rdkit_catch_test(chemTransformsTestCatch catch_tests.cpp LINK_LIBRARIES ChemTransforms FileParsers)
+rdkit_catch_test(chemTransformsTestCatch ../catch_main.cpp catch_tests.cpp LINK_LIBRARIES ChemTransforms FileParsers)

--- a/Code/GraphMol/ChemTransforms/ChemTransforms.cpp
+++ b/Code/GraphMol/ChemTransforms/ChemTransforms.cpp
@@ -598,11 +598,17 @@ ROMol *replaceCore(const ROMol &mol, const ROMol &core,
 
   std::vector<Atom *> delList;
   boost::dynamic_bitset<> removedAtoms(mol.getNumAtoms());
+  bool removedRingAtom = false;
   newMol->beginBatchEdit();
   for (const auto at : newMol->atoms()) {
     if (std::find(keepList.begin(), keepList.end(), at) == keepList.end()) {
       newMol->removeAtom(at);
       removedAtoms.set(at->getIdx());
+      if (!removedRingAtom && mol.getRingInfo() &&
+          mol.getRingInfo()->isInitialized() &&
+          mol.getRingInfo()->numAtomRings(at->getIdx())) {
+        removedRingAtom = true;
+      }
     }
   }
   newMol->commitBatchEdit();

--- a/Code/GraphMol/ChemTransforms/ChemTransforms.cpp
+++ b/Code/GraphMol/ChemTransforms/ChemTransforms.cpp
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2006-2020 Greg Landrum
+//  Copyright (C) 2006-2021 Greg Landrum
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -13,6 +13,7 @@
 #include <GraphMol/RDKitQueries.h>
 #include <RDGeneral/Exceptions.h>
 #include <GraphMol/RDKitBase.h>
+#include <GraphMol/Chirality.h>
 #include <GraphMol/Substruct/SubstructMatch.h>
 #include <RDGeneral/BoostStartInclude.h>
 #include <boost/dynamic_bitset.hpp>
@@ -394,6 +395,8 @@ void setSubMolBrokenRingStereo(RWMol &mol,
         if ((bond->getIsAromatic() ||
              bond->getBondType() == Bond::BondType::DOUBLE) &&
             bond->getStereo() == Bond::BondStereo::STEREONONE &&
+            mol.getRingInfo()->minBondRingSize(bond->getIdx()) <
+                Chirality::minRingSizeForDoubleBondStereo &&
             !removedAtoms[bond->getBeginAtomIdx()] &&
             !removedAtoms[bond->getEndAtomIdx()]) {
           // find the two neighboring bonds which are in the ring or to the

--- a/Code/GraphMol/ChemTransforms/catch_tests.cpp
+++ b/Code/GraphMol/ChemTransforms/catch_tests.cpp
@@ -397,4 +397,14 @@ TEST_CASE(
     auto mb = MolToV3KMolBlock(*res);
     CHECK(mb.find("CFG=2") == std::string::npos);
   }
+  SECTION("don't do larger rings") {
+    auto m = "C1C=CCCCC2=C1C=CC=N2"_smiles;
+    REQUIRE(m);
+    auto core = "c1ncccc1"_smiles;
+    REQUIRE(core);
+    std::unique_ptr<ROMol> res{replaceCore(*m, *core)};
+    REQUIRE(res);
+    auto mb = MolToV3KMolBlock(*res);
+    CHECK(mb.find("CFG=2") != std::string::npos);
+  }
 }

--- a/Code/GraphMol/ChemTransforms/catch_tests.cpp
+++ b/Code/GraphMol/ChemTransforms/catch_tests.cpp
@@ -1,5 +1,5 @@
 //
-//  Copyright (c) 2019 Greg Landrum
+//  Copyright (c) 2019-2021 Greg Landrum
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -7,8 +7,6 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 ///
-#define CATCH_CONFIG_MAIN  // This tells Catch to provide a main() - only do
-                           // this in one cpp file
 #include "catch.hpp"
 
 #include <GraphMol/RDKitBase.h>
@@ -373,5 +371,21 @@ TEST_CASE("molzip", "[]") {
       caught = true;
     }
     CHECK(caught == true);
+  }
+}
+
+TEST_CASE(
+    "Github4825: ReplaceCore should set stereo on ring bonds when it breaks "
+    "rings") {
+  SECTION("basics") {
+    auto m = "C1C=CCC2=C1C=CC=N2"_smiles;
+    REQUIRE(m);
+    auto core = "c1ncccc1"_smiles;
+    REQUIRE(core);
+    std::unique_ptr<ROMol> res{replaceCore(*m, *core)};
+    REQUIRE(res);
+    auto mb = MolToV3KMolBlock(*res);
+    std::cerr << mb << std::endl;
+    CHECK(mb.find("CFG=2") == std::string::npos);
   }
 }

--- a/Code/GraphMol/ChemTransforms/catch_tests.cpp
+++ b/Code/GraphMol/ChemTransforms/catch_tests.cpp
@@ -385,7 +385,16 @@ TEST_CASE(
     std::unique_ptr<ROMol> res{replaceCore(*m, *core)};
     REQUIRE(res);
     auto mb = MolToV3KMolBlock(*res);
-    std::cerr << mb << std::endl;
+    CHECK(mb.find("CFG=2") == std::string::npos);
+  }
+  SECTION("adjacent") {
+    auto m = "C1CC2=C(C=C1)C=CC=N2"_smiles;
+    REQUIRE(m);
+    auto core = "c1ncccc1"_smiles;
+    REQUIRE(core);
+    std::unique_ptr<ROMol> res{replaceCore(*m, *core)};
+    REQUIRE(res);
+    auto mb = MolToV3KMolBlock(*res);
     CHECK(mb.find("CFG=2") == std::string::npos);
   }
 }

--- a/Code/GraphMol/Chirality.cpp
+++ b/Code/GraphMol/Chirality.cpp
@@ -31,7 +31,8 @@ namespace {
 bool shouldDetectDoubleBondStereo(const Bond *bond) {
   const RingInfo *ri = bond->getOwningMol().getRingInfo();
   return (!ri->numBondRings(bond->getIdx()) ||
-          ri->minBondRingSize(bond->getIdx()) > 7);
+          ri->minBondRingSize(bond->getIdx()) >=
+              Chirality::minRingSizeForDoubleBondStereo);
 }
 
 // ----------------------------------- -----------------------------------

--- a/Code/GraphMol/Chirality.h
+++ b/Code/GraphMol/Chirality.h
@@ -25,6 +25,7 @@ class ROMol;
 
 namespace Chirality {
 
+//! double bond stereo will be ignored/removed for rings smaller than this:
 constexpr unsigned int minRingSizeForDoubleBondStereo = 8;
 
 /// @cond

--- a/Code/GraphMol/Chirality.h
+++ b/Code/GraphMol/Chirality.h
@@ -24,6 +24,9 @@ class Bond;
 class ROMol;
 
 namespace Chirality {
+
+constexpr unsigned int minRingSizeForDoubleBondStereo = 8;
+
 /// @cond
 /*!
   \param mol the molecule to be altered

--- a/Code/GraphMol/RGroupDecomposition/catch_rgd.cpp
+++ b/Code/GraphMol/RGroupDecomposition/catch_rgd.cpp
@@ -585,3 +585,22 @@ TEST_CASE("substructure parameters and RGD: enhanced stereo") {
     }
   }
 }
+
+TEST_CASE("github4809: ring double bonds written as crossed bonds after RGD") {
+  std::vector<std::string> smis = {"C1C=CCC2=C1C=CC=N2"};
+  auto mols = smisToMols(smis);
+  std::vector<std::string> csmis = {"c1ccnc([*:1])c1[*:2]"};
+  auto cores = smisToMols(csmis);
+  SECTION("basics") {
+    RGroupRows rows;
+    {
+      auto n = RGroupDecompose(cores, mols, rows);
+      CHECK(n == mols.size());
+      CHECK(rows.size() == n);
+      auto r1 = rows[0]["R1"];
+      auto mb = MolToV3KMolBlock(*r1);
+      std::cerr << mb << std::endl;
+      CHECK(mb.find("CFG=2") == std::string::npos);
+    }
+  }
+}

--- a/Code/GraphMol/RGroupDecomposition/catch_rgd.cpp
+++ b/Code/GraphMol/RGroupDecomposition/catch_rgd.cpp
@@ -599,7 +599,6 @@ TEST_CASE("github4809: ring double bonds written as crossed bonds after RGD") {
       CHECK(rows.size() == n);
       auto r1 = rows[0]["R1"];
       auto mb = MolToV3KMolBlock(*r1);
-      std::cerr << mb << std::endl;
       CHECK(mb.find("CFG=2") == std::string::npos);
     }
   }


### PR DESCRIPTION
When `replaceCore` breaks a small ring containing double bonds, this sets double bonds to CIS so that we don't end up with crossed bonds in mol blocks.

