### PR TITLE
Fix RunFilterCatalog() thread counts.

### DIFF
--- a/Code/GraphMol/FilterCatalog/FilterCatalogRunner.cpp
+++ b/Code/GraphMol/FilterCatalog/FilterCatalogRunner.cpp
@@ -49,14 +49,9 @@ RunFilterCatalog(const FilterCatalog &fc,
   std::vector<std::vector<FilterCatalog::CONST_SENTRY>> results(smiles.size());
 
 #ifdef RDK_THREADSAFE_SSS
-  if (numThreads == -1) {
-    numThreads = (int)getNumThreadsToUse(numThreads);
-  } else {
-    numThreads = std::min(numThreads, (int)getNumThreadsToUse(numThreads));
-  }
-
   std::vector<std::future<void>> thread_group;
-  for (int thread_group_idx = 0; thread_group_idx < numThreads + 1;
+  numThreads = (int)getNumThreadsToUse(numThreads);
+  for (int thread_group_idx = 0; thread_group_idx < numThreads;
        ++thread_group_idx) {
     // need to use std::ref otherwise things are passed by value
     thread_group.emplace_back(std::async(


### PR DESCRIPTION
I ended up diving into `RunFilterCatalog()` while debugging #4846, and noticed a couple bugs:
- The Python docs say "Use numThreads=0 to use all available processors." but that currently doesn't work (this is implemented in `getNumThreadsToUse()` so we can use the result without any extra logic).
- The function actually starts `numThreads + 1` threads, which may cause duplicate results / race conditions.

This fixes both problems.

