### PR TITLE
RGD: dummy atom in input structure is mishandled

### DIFF
--- a/Code/GraphMol/RGroupDecomposition/RGroupData.h
+++ b/Code/GraphMol/RGroupDecomposition/RGroupData.h
@@ -136,7 +136,11 @@ struct RGroupData {
   bool isMolHydrogen(ROMol &mol) {
     for (ROMol::AtomIterator atIt = mol.beginAtoms(); atIt != mol.endAtoms();
          ++atIt) {
-      if ((*atIt)->getAtomicNum() > 1) {
+      auto atom = *atIt;
+      if (atom->getAtomicNum() > 1) {
+        return false;
+      }
+      else if (atom->getAtomicNum() == 0 && ! atom->hasProp(SIDECHAIN_RLABELS)) {
         return false;
       }
     }

--- a/Code/GraphMol/RGroupDecomposition/RGroupDecomp.cpp
+++ b/Code/GraphMol/RGroupDecomposition/RGroupDecomp.cpp
@@ -93,6 +93,11 @@ int RGroupDecomposition::add(const ROMol &inmol) {
   for (auto &atom : mol.atoms()) {
     if (atom->getAtomicNum() == 0) {
       atom->setIsotope(1000U);
+      // clean any existing R group numbers
+      atom->setAtomMapNum(0);
+      if (atom->hasProp(common_properties::_MolFileRLabel)) {
+        atom->clearProp(common_properties::_MolFileRLabel);
+      }
     }
   }
   int core_idx = 0;

--- a/Code/GraphMol/RGroupDecomposition/RGroupDecomp.cpp
+++ b/Code/GraphMol/RGroupDecomposition/RGroupDecomp.cpp
@@ -89,7 +89,7 @@ int RGroupDecomposition::add(const ROMol &inmol) {
   const bool addCoords = true;
   MolOps::addHs(mol, explicitOnly, addCoords);
 
-  // mark any wildcards in inout molecule:
+  // mark any wildcards in input molecule:
   for (auto &atom : mol.atoms()) {
     if (atom->getAtomicNum() == 0) {
       atom->setIsotope(1000U);
@@ -296,6 +296,7 @@ int RGroupDecomposition::add(const ROMol &inmol) {
               }
             }
             else {
+              // restore input wildcard
               at->setIsotope(0);
             }
           }

--- a/Code/GraphMol/RGroupDecomposition/RGroupDecomp.cpp
+++ b/Code/GraphMol/RGroupDecomposition/RGroupDecomp.cpp
@@ -92,8 +92,9 @@ int RGroupDecomposition::add(const ROMol &inmol) {
   // mark any wildcards in input molecule:
   for (auto &atom : mol.atoms()) {
     if (atom->getAtomicNum() == 0) {
-      atom->setIsotope(1000U);
+      atom->setProp("INPUT_DUMMY", true);
       // clean any existing R group numbers
+      atom->setIsotope(0);
       atom->setAtomMapNum(0);
       if (atom->hasProp(common_properties::_MolFileRLabel)) {
         atom->clearProp(common_properties::_MolFileRLabel);
@@ -286,7 +287,7 @@ int RGroupDecomposition::add(const ROMol &inmol) {
             unsigned int index =
                 at->getIsotope();  // this is the index into the core
             // it messes up when there are multiple ?
-            if (index < 1000U) {
+            if (! at->hasProp("INPUT_DUMMY")) {
               int rlabel;
               auto coreAtom = rcore->core->getAtomWithIdx(index);
               coreAtomAnyMatched.insert(index);
@@ -302,7 +303,7 @@ int RGroupDecomposition::add(const ROMol &inmol) {
             }
             else {
               // restore input wildcard
-              at->setIsotope(0);
+              at->clearProp("INPUT_DUMMY");
             }
           }
         }

--- a/Code/GraphMol/RGroupDecomposition/RGroupDecomp.cpp
+++ b/Code/GraphMol/RGroupDecomposition/RGroupDecomp.cpp
@@ -93,7 +93,7 @@ int RGroupDecomposition::add(const ROMol &inmol) {
   // mark any wildcards in input molecule:
   for (auto &atom : mol.atoms()) {
     if (atom->getAtomicNum() == 0) {
-      atom->setProp("INPUT_DUMMY", true);
+      atom->setProp(inputDummy, true);
       // clean any existing R group numbers
       atom->setIsotope(0);
       atom->setAtomMapNum(0);

--- a/Code/GraphMol/RGroupDecomposition/RGroupDecomp.cpp
+++ b/Code/GraphMol/RGroupDecomposition/RGroupDecomp.cpp
@@ -82,6 +82,7 @@ RGroupDecomposition::RGroupDecomposition(
 RGroupDecomposition::~RGroupDecomposition() { delete data; }
 
 int RGroupDecomposition::add(const ROMol &inmol) {
+  constexpr const char *inputDummy = "INPUT_DUMMY";
   // get the sidechains if possible
   //  Add hs for better symmetrization
   RWMol mol(inmol);
@@ -287,7 +288,7 @@ int RGroupDecomposition::add(const ROMol &inmol) {
             unsigned int index =
                 at->getIsotope();  // this is the index into the core
             // it messes up when there are multiple ?
-            if (! at->hasProp("INPUT_DUMMY")) {
+            if (!at->hasProp(inputDummy)) {
               int rlabel;
               auto coreAtom = rcore->core->getAtomWithIdx(index);
               coreAtomAnyMatched.insert(index);
@@ -300,10 +301,9 @@ int RGroupDecomposition::add(const ROMol &inmol) {
                 data->labels.insert(rlabel);  // keep track of all labels used
                 attachments.push_back(rlabel);
               }
-            }
-            else {
+            } else {
               // restore input wildcard
-              at->clearProp("INPUT_DUMMY");
+              at->clearProp(inputDummy);
             }
           }
         }

--- a/Code/GraphMol/RGroupDecomposition/RGroupUtils.h
+++ b/Code/GraphMol/RGroupDecomposition/RGroupUtils.h
@@ -17,10 +17,10 @@
 namespace RDKit {
 
 RDKIT_RGROUPDECOMPOSITION_EXPORT extern const std::string RLABEL;
-extern const std::string RLABEL_TYPE;
-extern const std::string RLABEL_CORE_INDEX;
-extern const std::string SIDECHAIN_RLABELS;
-extern const std::string done;
+RDKIT_RGROUPDECOMPOSITION_EXPORT extern const std::string RLABEL_TYPE;
+RDKIT_RGROUPDECOMPOSITION_EXPORT extern const std::string RLABEL_CORE_INDEX;
+RDKIT_RGROUPDECOMPOSITION_EXPORT extern const std::string SIDECHAIN_RLABELS;
+RDKIT_RGROUPDECOMPOSITION_EXPORT extern const std::string done;
 
 const unsigned int EMPTY_CORE_LABEL = -100000;
 

--- a/Code/GraphMol/RGroupDecomposition/testRGroupDecomp.cpp
+++ b/Code/GraphMol/RGroupDecomposition/testRGroupDecomp.cpp
@@ -98,8 +98,8 @@ void DUMP_RGROUP(RGroupRows::const_iterator &it, std::string &result) {
 
   for (const auto &rgroups : *it) {
     // rlabel:smiles
-    str << rgroups.first << "\t" << MolToSmiles(*rgroups.second.get(), true)
-        << "\t";
+    str << rgroups.first << ":" << MolToSmiles(*rgroups.second.get(), true)
+        << " ";
   }
   std::cerr << str.str() << std::endl;
   result = str.str();
@@ -2627,6 +2627,56 @@ M  END
   }
 }
 
+void testWildcardInInput() {
+  BOOST_LOG(rdInfoLog)
+      << "********************************************************\n";
+  BOOST_LOG(rdInfoLog) << "Test that dummy atom in input molecule is handled correctly"
+                       << std::endl;
+ 
+  auto core = R"CTAB(
+Mrv2008 12012115162D          
+
+  6  6  6  0  0  0            999 V2000
+  -21.0938  -16.9652    0.0000 L   0  0  0  0  0  0  0  0  0  0  0  0
+  -21.8082  -17.3777    0.0000 L   0  0  0  0  0  0  0  0  0  0  0  0
+  -21.8082  -18.2027    0.0000 L   0  0  0  0  0  0  0  0  0  0  0  0
+  -21.0938  -18.6152    0.0000 L   0  0  0  0  0  0  0  0  0  0  0  0
+  -20.3793  -18.2027    0.0000 L   0  0  0  0  0  0  0  0  0  0  0  0
+  -20.3793  -17.3777    0.0000 L   0  0  0  0  0  0  0  0  0  0  0  0
+  1  2  6  0  0  0  0
+  2  3  7  0  0  0  0
+  3  4  6  0  0  0  0
+  4  5  7  0  0  0  0
+  5  6  6  0  0  0  0
+  1  6  7  0  0  0  0
+  1 F    2   6   7
+  2 F    2   6   7
+  3 F    2   6   7
+  4 F    2   6   7
+  5 F    2   6   7
+  6 F    2   6   7
+M  ALS   1  2 F C   N   
+M  ALS   2  2 F C   N   
+M  ALS   3  2 F C   N   
+M  ALS   4  2 F C   N   
+M  ALS   5  2 F C   N   
+M  ALS   6  2 F C   N   
+M  END
+)CTAB"_ctab;
+  auto structure = "CC1CCN(C1)C1=CC(O*)=C(Cl)C=C1C#N"_smiles; 
+  RGroupDecomposition decomp(*core);
+  TEST_ASSERT(decomp.add(*structure) == 0);
+  decomp.process();
+  
+  std::string dump;
+  auto rows = decomp.getRGroupsAsRows();
+  TEST_ASSERT(rows.size() == 1)
+  RGroupRows::const_iterator it = rows.begin();
+  std::string expected(
+      "Core:c1c([*:2])c([*:1])cc([*:4])c1[*:3] R1:Cl[*:1] R2:*O[*:2] R3:CC1CCN([*:3])C1 R4:N#C[*:4]");
+  CHECK_RGROUP(it, expected);
+}
+
 int main() {
   RDLog::InitLogs();
   boost::logging::disable_logs("rdApp.debug");
@@ -2676,6 +2726,7 @@ int main() {
   testDoNotAddUnnecessaryRLabels();
   testCoreWithAlsRecords();
   testAlignOutputCoreToMolecule();
+  testWildcardInInput();
   BOOST_LOG(rdInfoLog)
       << "********************************************************\n";
   return 0;

--- a/Code/GraphMol/RGroupDecomposition/testRGroupDecomp.cpp
+++ b/Code/GraphMol/RGroupDecomposition/testRGroupDecomp.cpp
@@ -2697,7 +2697,6 @@ int main() {
       << "********************************************************\n";
   BOOST_LOG(rdInfoLog) << "Testing R-Group Decomposition \n";
 
-  testWildcardInInput();
 #if 1
   testSymmetryMatching(FingerprintVariance);
   testSymmetryMatching();
@@ -2740,6 +2739,7 @@ int main() {
   testDoNotAddUnnecessaryRLabels();
   testCoreWithAlsRecords();
   testAlignOutputCoreToMolecule();
+  testWildcardInInput();
   BOOST_LOG(rdInfoLog)
       << "********************************************************\n";
   return 0;

--- a/Code/GraphMol/RGroupDecomposition/testRGroupDecomp.cpp
+++ b/Code/GraphMol/RGroupDecomposition/testRGroupDecomp.cpp
@@ -2630,9 +2630,10 @@ M  END
 void testWildcardInInput() {
   BOOST_LOG(rdInfoLog)
       << "********************************************************\n";
-  BOOST_LOG(rdInfoLog) << "Test that dummy atom in input molecule is handled correctly"
-                       << std::endl;
- 
+  BOOST_LOG(rdInfoLog)
+      << "Test that dummy atom in input molecule is handled correctly"
+      << std::endl;
+
   auto core = R"CTAB(
 Mrv2008 12012115162D          
 
@@ -2663,17 +2664,29 @@ M  ALS   5  2 F C   N
 M  ALS   6  2 F C   N   
 M  END
 )CTAB"_ctab;
-  auto structure = "CC1CCN(C1)C1=CC(O*)=C(Cl)C=C1C#N"_smiles; 
+
+  auto structure = "CC1CCN(C1)C1=CC(O*)=C(Cl)C=C1C#N"_smiles;
   RGroupDecomposition decomp(*core);
   TEST_ASSERT(decomp.add(*structure) == 0);
   decomp.process();
-  
-  std::string dump;
   auto rows = decomp.getRGroupsAsRows();
   TEST_ASSERT(rows.size() == 1)
   RGroupRows::const_iterator it = rows.begin();
   std::string expected(
-      "Core:c1c([*:2])c([*:1])cc([*:4])c1[*:3] R1:Cl[*:1] R2:*O[*:2] R3:CC1CCN([*:3])C1 R4:N#C[*:4]");
+      "Core:c1c([*:2])c([*:1])cc([*:4])c1[*:3] R1:Cl[*:1] R2:*O[*:2] "
+      "R3:CC1CCN([*:3])C1 R4:N#C[*:4]");
+  CHECK_RGROUP(it, expected);
+
+  structure = "CC1CCN(C1)C1=CC([*:2])=C(Cl)C=C1C#N"_smiles;
+  RGroupDecomposition decomp2(*core);
+  TEST_ASSERT(decomp2.add(*structure) == 0);
+  decomp2.process();
+  rows = decomp2.getRGroupsAsRows();
+  TEST_ASSERT(rows.size() == 1)
+  it = rows.begin();
+  expected =
+      "Core:c1c([*:2])c([*:1])cc([*:4])c1[*:3] R1:Cl[*:1] R2:*[*:2] "
+      "R3:CC1CCN([*:3])C1 R4:N#C[*:4]";
   CHECK_RGROUP(it, expected);
 }
 
@@ -2684,6 +2697,7 @@ int main() {
       << "********************************************************\n";
   BOOST_LOG(rdInfoLog) << "Testing R-Group Decomposition \n";
 
+  testWildcardInInput();
 #if 1
   testSymmetryMatching(FingerprintVariance);
   testSymmetryMatching();
@@ -2726,7 +2740,6 @@ int main() {
   testDoNotAddUnnecessaryRLabels();
   testCoreWithAlsRecords();
   testAlignOutputCoreToMolecule();
-  testWildcardInInput();
   BOOST_LOG(rdInfoLog)
       << "********************************************************\n";
   return 0;


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! 
-->

#### What does this implement/fix? Explain your changes.

Currently RGD does not decompose correctly if an input structure contains a dummy atom.  For example, if a second RGD is performed on the groups from an earlier RGD.  Just to be clear- by submitting a fix I'm not endorsing the practice!

Before
 
![Screenshot 2022-01-06 121328](https://user-images.githubusercontent.com/24233741/148438217-60f51633-760f-4aa6-93b7-73b41eb4984c.png)

After

![Screenshot 2022-01-06 120844](https://user-images.githubusercontent.com/24233741/148437681-e3c67de5-2eb6-4f67-8c9e-e28917b402ab.png)

Note: the difference in the core depiction is due to the improvements in master since the 21.09 release. The PR fixes the R2 and R4 groups.
