### PR TITLE
Fix bug with wedges being drawn backwards

### DIFF
--- a/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
@@ -473,7 +473,6 @@ void MolDraw2D::drawMolecule(const ROMol &mol,
     }
     setFillPolys(true);
   }
-
   drawBonds(draw_mol, highlight_atoms, highlight_atom_map, highlight_bonds,
             highlight_bond_map);
 
@@ -3068,21 +3067,7 @@ void drawNormalBond(MolDraw2D &d2d, const Bond &bond, bool highlight_bond,
     d2d.drawOptions().scaleBondWidth = orig_slw;
   } else if (Bond::SINGLE == bt && (Bond::BEGINWEDGE == bond.getBondDir() ||
                                     Bond::BEGINDASH == bond.getBondDir())) {
-    // swap the direction if at1 has does not have stereochem set
-    // or if at2 does have stereochem set and the bond starts there
-    auto at1 = bond.getBeginAtom();
-    auto at2 = bond.getEndAtom();
     auto inverted = false;
-    if ((at1->getChiralTag() != Atom::CHI_TETRAHEDRAL_CW &&
-         at1->getChiralTag() != Atom::CHI_TETRAHEDRAL_CCW) ||
-        (at1->getIdx() != bond.getBeginAtomIdx() &&
-         (at2->getChiralTag() == Atom::CHI_TETRAHEDRAL_CW ||
-          at2->getChiralTag() == Atom::CHI_TETRAHEDRAL_CCW))) {
-      // std::cerr << "  swap" << std::endl;
-      swap(at1_cds, at2_cds);
-      swap(col1, col2);
-      inverted = true;
-    }
     if (d2d.drawOptions().singleColourWedgeBonds) {
       col1 = d2d.drawOptions().symbolColour;
       col2 = d2d.drawOptions().symbolColour;
@@ -3465,7 +3450,6 @@ void MolDraw2D::drawBond(
                 bond->getIdx()) != highlight_bonds->end()) {
     highlight_bond = true;
   }
-
   DrawColour col1, col2;
   int orig_lw = lineWidth();
   if (bond_colours) {

--- a/Code/GraphMol/MolDraw2D/catch_tests.cpp
+++ b/Code/GraphMol/MolDraw2D/catch_tests.cpp
@@ -182,6 +182,7 @@ static const std::map<std::string, std::hash_result_t> SVG_HASHES = {
     {"testGithub4764.sz2.svg", 2935799920U},
     {"testGithub4764.sz3.svg", 2544100175U},
     {"testDrawArc1.svg", 827049291U},
+    {"testMetalWedges.svg", 4275464711U},
 };
 
 // These PNG hashes aren't completely reliable due to floating point cruft,
@@ -4061,5 +4062,42 @@ M  END)CTAB"_ctab;
       outs.flush();
       check_file_hash("testDrawArc1.svg");
     }
+  }
+}
+
+TEST_CASE("wedged bonds to metals drawn in the wrong direction") {
+  SECTION("basics") {
+    auto m = R"CTAB(
+  Mrv2108 01092205442D          
+
+  0  0  0     0  0            999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 5 4 0 0 0
+M  V30 BEGIN ATOM
+M  V30 1 F 10.6667 -0.75 0 0
+M  V30 2 Pt 10.6667 -2.29 0 0 CFG=1
+M  V30 3 Cl 12.2067 -2.29 0 0
+M  V30 4 C 10.6667 -3.83 0 0
+M  V30 5 O 9.1267 -2.29 0 0
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 1 1 2
+M  V30 2 1 2 3
+M  V30 3 1 2 4 CFG=1
+M  V30 4 1 2 5 CFG=3
+M  V30 END BOND
+M  V30 END CTAB
+M  END)CTAB"_ctab;
+    m->getBondWithIdx(2)->setBondDir(Bond::BondDir::BEGINWEDGE);
+    m->getBondWithIdx(3)->setBondDir(Bond::BondDir::BEGINDASH);
+    MolDraw2DSVG drawer(250, 200);
+    assignBWPalette(drawer.drawOptions().atomColourPalette);
+    drawer.drawMolecule(*m, "check wedges");
+    drawer.finishDrawing();
+    auto text = drawer.getDrawingText();
+    std::ofstream outs("testMetalWedges.svg");
+    outs << text;
+    outs.flush();
+    check_file_hash("testMetalWedges.svg");
   }
 }


### PR DESCRIPTION
The drawing code had some broken logic to try and fix wedged bonds drawn from non-chiral atoms. This was resulting in wedged bonds being drawn backwards if the central atom didn't have marked tetrahedral stereo.

Aside from the fact that the logic was broken, by the time we get to the drawing code we shouldn't be doing this kind of chemistry "cleanup" anymore anyway, so this just removes that logic.