### PR TITLE
update CI VMs to latest versions

### DIFF
--- a/.azure-pipelines/vs_build.yml
+++ b/.azure-pipelines/vs_build.yml
@@ -7,7 +7,8 @@ steps:
     conda create --name rdkit_build ^
         boost-cpp=$(boost_version) boost=$(boost_version) ^
         py-boost=$(boost_version) libboost=$(boost_version) ^
-        numpy matplotlib cairo pillow eigen pandas
+        numpy matplotlib cairo pillow eigen pandas ^
+        sphinx=3.1.2 recommonmark
     call activate rdkit_build
     conda install -c conda-forge cmake nbval
   displayName: Install dependencies

--- a/.azure-pipelines/vs_build.yml
+++ b/.azure-pipelines/vs_build.yml
@@ -51,7 +51,7 @@ steps:
     set PYTHONPATH=%RDBASE%;%PYTHONPATH%
     set PATH=%RDBASE%\lib;%PATH%
     cd build
-    ctest -j $(number_of_cores) --output-on-failure -T Test
+    ctest -C Release -j $(number_of_cores) --output-on-failure -T Test
   displayName: Run tests
 - script: |
     call activate rdkit_build

--- a/.azure-pipelines/vs_build.yml
+++ b/.azure-pipelines/vs_build.yml
@@ -4,7 +4,7 @@ steps:
 - script: |
     conda config --set always_yes yes --set changeps1 no
     conda info -a
-    conda create --name rdkit_build  cmake ^
+    conda create --name rdkit_build  -c conda-forge cmake ^
         boost-cpp=$(boost_version) boost=$(boost_version) ^
         py-boost=$(boost_version) libboost=$(boost_version) ^
         numpy matplotlib cairo pillow eigen pandas  ^

--- a/.azure-pipelines/vs_build.yml
+++ b/.azure-pipelines/vs_build.yml
@@ -4,7 +4,7 @@ steps:
 - script: |
     conda config --set always_yes yes --set changeps1 no
     conda info -a
-    conda create --name rdkit_build $(compiler) cmake ^
+    conda create --name rdkit_build  cmake ^
         boost-cpp=$(boost_version) boost=$(boost_version) ^
         py-boost=$(boost_version) libboost=$(boost_version) ^
         numpy matplotlib cairo pillow eigen pandas  ^
@@ -17,7 +17,7 @@ steps:
     mkdir build && cd build
     call activate rdkit_build
     cmake .. ^
-    -G "Visual Studio 15 2017 Win64" ^
+    -G "Visual Studio 17 2022" ^
     -DCMAKE_BUILD_TYPE=Release ^
     -DRDK_INSTALL_INTREE=ON ^
     -DRDK_INSTALL_STATIC_LIBS=OFF ^

--- a/.azure-pipelines/vs_build.yml
+++ b/.azure-pipelines/vs_build.yml
@@ -4,20 +4,19 @@ steps:
 - script: |
     conda config --set always_yes yes --set changeps1 no
     conda info -a
-    conda create --name rdkit_build  -c conda-forge cmake ^
+    conda create --name rdkit_build ^
         boost-cpp=$(boost_version) boost=$(boost_version) ^
         py-boost=$(boost_version) libboost=$(boost_version) ^
-        numpy matplotlib cairo pillow eigen pandas  ^
-        sphinx=3.1.2 recommonmark jupyter
-    conda activate rdkit_build
-    conda install -c conda-forge nbval
+        numpy matplotlib cairo pillow eigen pandas
+    call activate rdkit_build
+    conda install -c conda-forge cmake nbval
   displayName: Install dependencies
 - script: |
     set Boost_ROOT=
     mkdir build && cd build
     call activate rdkit_build
     cmake .. ^
-    -G "Visual Studio 17 2022" ^
+    -G "Visual Studio 16 2019" ^
     -DCMAKE_BUILD_TYPE=Release ^
     -DRDK_INSTALL_INTREE=ON ^
     -DRDK_INSTALL_STATIC_LIBS=OFF ^

--- a/.azure-pipelines/vs_build_dll.yml
+++ b/.azure-pipelines/vs_build_dll.yml
@@ -8,15 +8,15 @@ steps:
         boost-cpp=$(boost_version) boost=$(boost_version) ^
         py-boost=$(boost_version) libboost=$(boost_version) ^
         numpy matplotlib cairo pillow eigen pandas
-    conda activate rdkit_build
-    conda install -c conda-forge cmake
+    call activate rdkit_build
+    conda install -c conda-forge cmake nbval
   displayName: Install dependencies
 - script: |
     set Boost_ROOT=
     mkdir build && cd build
     call activate rdkit_build
     cmake .. ^
-    -G "Visual Studio 17 2022 Win64" ^
+    -G "Visual Studio 16 2019" ^
     -DCMAKE_BUILD_TYPE=Release ^
     -DRDK_INSTALL_INTREE=ON ^
     -DRDK_INSTALL_STATIC_LIBS=OFF ^

--- a/.azure-pipelines/vs_build_dll.yml
+++ b/.azure-pipelines/vs_build_dll.yml
@@ -50,7 +50,7 @@ steps:
     set PYTHONPATH=%RDBASE%;%PYTHONPATH%
     set PATH=%RDBASE%\lib;%PATH%
     cd build
-    ctest -j $(number_of_cores) --output-on-failure -T Test
+    ctest -C Release -j $(number_of_cores) --output-on-failure -T Test
   displayName: Run tests
 - task: PublishTestResults@2
   inputs:

--- a/.azure-pipelines/vs_build_dll.yml
+++ b/.azure-pipelines/vs_build_dll.yml
@@ -4,10 +4,12 @@ steps:
 - script: |
     conda config --set always_yes yes --set changeps1 no
     conda info -a
-    conda create --name rdkit_build -c conda-forge cmake ^
+    conda create --name rdkit_build ^
         boost-cpp=$(boost_version) boost=$(boost_version) ^
         py-boost=$(boost_version) libboost=$(boost_version) ^
         numpy matplotlib cairo pillow eigen pandas
+    conda activate rdkit_build
+    conda install -c conda-forge cmake
   displayName: Install dependencies
 - script: |
     set Boost_ROOT=

--- a/.azure-pipelines/vs_build_dll.yml
+++ b/.azure-pipelines/vs_build_dll.yml
@@ -4,7 +4,7 @@ steps:
 - script: |
     conda config --set always_yes yes --set changeps1 no
     conda info -a
-    conda create --name rdkit_build cmake ^
+    conda create --name rdkit_build -c conda-forge cmake ^
         boost-cpp=$(boost_version) boost=$(boost_version) ^
         py-boost=$(boost_version) libboost=$(boost_version) ^
         numpy matplotlib cairo pillow eigen pandas

--- a/.azure-pipelines/vs_build_dll.yml
+++ b/.azure-pipelines/vs_build_dll.yml
@@ -4,7 +4,7 @@ steps:
 - script: |
     conda config --set always_yes yes --set changeps1 no
     conda info -a
-    conda create --name rdkit_build $(compiler) cmake ^
+    conda create --name rdkit_build cmake ^
         boost-cpp=$(boost_version) boost=$(boost_version) ^
         py-boost=$(boost_version) libboost=$(boost_version) ^
         numpy matplotlib cairo pillow eigen pandas
@@ -14,7 +14,7 @@ steps:
     mkdir build && cd build
     call activate rdkit_build
     cmake .. ^
-    -G "Visual Studio 15 2017 Win64" ^
+    -G "Visual Studio 17 2022 Win64" ^
     -DCMAKE_BUILD_TYPE=Release ^
     -DRDK_INSTALL_INTREE=ON ^
     -DRDK_INSTALL_STATIC_LIBS=OFF ^

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,23 +28,21 @@ jobs:
     target_platform: 10.9
   steps:
   - template: .azure-pipelines/mac_build.yml
-- job: Windows_VS2017_x64
+- job: Windows_VS2022_x64
   timeoutInMinutes: 90
   pool:
     vmImage: windows-latest
   variables:
-    compiler: windows-latest
     boost_version: 1.67.0
     number_of_cores: '%NUMBER_OF_PROCESSORS%'
     python_name: python37
   steps:
   - template: .azure-pipelines/vs_build.yml
-- job: Windows_VS2017_x64_dll
+- job: Windows_VS2022_x64_dll
   timeoutInMinutes: 90
   pool:
     vmImage: windows-latest
   variables:
-    compiler: vs2017_win-64
     boost_version: 1.67.0
     number_of_cores: '%NUMBER_OF_PROCESSORS%'
     python_name: python37

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,10 +4,10 @@ trigger:
 - dev/*
 
 jobs:
-- job: Ubuntu_18_04_x64
+- job: Ubuntu_x64
   timeoutInMinutes: 90
   pool:
-    vmImage: ubuntu-18.04
+    vmImage: ubuntu-20.04
   variables:
     python: python=3.8
     boost_version: 1.71.0
@@ -31,9 +31,9 @@ jobs:
 - job: Windows_VS2017_x64
   timeoutInMinutes: 90
   pool:
-    vmImage: vs2017-win2016
+    vmImage: windows-latest
   variables:
-    compiler: vs2017_win-64
+    compiler: windows-latest
     boost_version: 1.67.0
     number_of_cores: '%NUMBER_OF_PROCESSORS%'
     python_name: python37
@@ -42,7 +42,7 @@ jobs:
 - job: Windows_VS2017_x64_dll
   timeoutInMinutes: 90
   pool:
-    vmImage: vs2017-win2016
+    vmImage: windows-latest
   variables:
     compiler: vs2017_win-64
     boost_version: 1.67.0
@@ -50,7 +50,7 @@ jobs:
     python_name: python37
   steps:
   - template: .azure-pipelines/vs_build_dll.yml
-- job: Ubuntu_20_04_x64_java
+- job: Ubuntu_x64_java
   timeoutInMinutes: 90
   pool:
     vmImage: ubuntu-20.04
@@ -73,7 +73,7 @@ jobs:
     target_platform: 10.9
   steps:
   - template: .azure-pipelines/mac_build_java.yml
-- job: Ubuntu_20_04_x64_cartridge
+- job: Ubuntu_x64_cartridge
   timeoutInMinutes: 90
   pool:
     vmImage: ubuntu-20.04
@@ -82,10 +82,10 @@ jobs:
     number_of_cores: nproc
   steps:
   - template: .azure-pipelines/linux_build_cartridge.yml
-- job: Ubuntu_18_04_x64_limitexternaldependencies
+- job: Ubuntu_x64_limitexternaldependencies
   timeoutInMinutes: 90
   pool:
-    vmImage: ubuntu-18.04
+    vmImage: ubuntu-20.04
   variables:
     python: python=3.8
     boost_version: 1.71.0


### PR DESCRIPTION
The windows-2016 VMS are deprecated and there's no reason to be using ubuntu-18.04 any more.