### PR TITLE
fix reentrant python to c++ to python

### DIFF
--- a/Code/GraphMol/FilterCatalog/Wrap/FilterCatalog.cpp
+++ b/Code/GraphMol/FilterCatalog/Wrap/FilterCatalog.cpp
@@ -155,25 +155,30 @@ class PythonFilterMatch : public FilterMatcherBase {
   }
 
   ~PythonFilterMatch() override {
+    PyGILStateHolder h;
     if (incref) {
       python::decref(functor);
     }
   }
   bool isValid() const override {
+    PyGILStateHolder h;
     return python::call_method<bool>(functor, "IsValid");
   }
 
   std::string getName() const override {
+    PyGILStateHolder h;
     return python::call_method<std::string>(functor, "GetName");
   }
 
   bool getMatches(const ROMol &mol,
                   std::vector<FilterMatch> &matchVect) const override {
+    PyGILStateHolder h;    
     return python::call_method<bool>(functor, "GetMatches", boost::ref(mol),
                                      boost::ref(matchVect));
   }
 
   bool hasMatch(const ROMol &mol) const override {
+    PyGILStateHolder h;    
     return python::call_method<bool>(functor, "HasMatch", boost::ref(mol));
   }
 
@@ -299,6 +304,13 @@ python::dict GetFlattenedFunctionalGroupHierarchyHelper(bool normalize) {
   }
   return dict;
 }
+
+std::vector<std::vector<boost::shared_ptr<const FilterCatalogEntry>>>
+RunFilterCatalogWrapper(const FilterCatalog &fc, const std::vector<std::string> &smiles, int numThreads) {
+  NOGIL nogil;
+  return RunFilterCatalog(fc, smiles, numThreads);
+}
+
 struct filtercat_wrapper {
   static void wrap() {
     python::class_<std::pair<int, int>>("IntPair")
@@ -517,7 +529,7 @@ struct filtercat_wrapper {
                 "Returns True if the FilterCatalog is serializable "
                 "(requires boost serialization");
 
-    python::def("RunFilterCatalog", RunFilterCatalog,
+    python::def("RunFilterCatalog", RunFilterCatalogWrapper,
                 (python::arg("filterCatalog"), python::arg("smiles"),
                  python::arg("numThreads") = 1),
                 "Run the filter catalog on the input list of smiles "

--- a/Code/GraphMol/SubstructLibrary/Wrap/rough_test.py
+++ b/Code/GraphMol/SubstructLibrary/Wrap/rough_test.py
@@ -616,6 +616,50 @@ class TestCase(unittest.TestCase):
       indices = library.GetMatches(m)
       self.assertEqual(['Z11234'], list(library.GetKeyHolder().GetKeys(indices)))
 
+  def test_bad_smiles(self):
+    # add mols
+    pdb_ligands = [
+      "&CCS(=O)(=O)c1ccc(OC)c(Nc2ncc(-c3cccc(-c4ccccn4)c3)o2)c1",
+      "&COc1ccc(S(=O)(=O)NCC2CC2)cc1Nc1ncc(-c2cccc(-c3cccnc3)c2)o1",
+      "&COc1ccc(-c2oc3ncnc(N)c3c2-c2ccc(NC(=O)Nc3cc(C(F)(F)F)ccc3F)cc2)cc1",
+      "&COC(=O)Nc1nc2ccc(Oc3ccc(NC(=O)Nc4cc(C(F)(F)F)ccc4F)cc3)cc2[nH]1",
+      "&COc1cc(Nc2ncnc(-c3cccnc3Nc3ccccc3)n2)cc(OC)c1OC",
+      "&O=C(Nc1ccc(Oc2ccccc2)cc1)c1cccnc1NCc1ccncc1",
+      "&O=C(Nc1ccc(Oc2ccccc2)cc1)c1cccnc1NCc1ccncc1",
+      "&CNC(=O)c1cc(Oc2ccc3[nH]c(Nc4ccc(Cl)c(C(F)(F)F)c4)nc3c2)ccn1",
+      "&CNC(=O)c1cc(Oc2ccc3oc(Nc4ccc(Cl)c(OCC5CCC[NH+]5C)c4)nc3c2)ccn1",
+      "&CNC(=O)c1cc(Oc2ccc3oc(Nc4ccc(Cl)c(OCC5CCC[NH+]5C)c4)nc3c2)ccn1",
+      "&COc1cc2nccc(Oc3ccc4c(c3)OCCN4C(=O)Nc3ccc(Cl)cc3)c2cc1OC",
+      "&CNC(=O)c1c(C)oc2cc(Oc3cc[nH+]c4cc(OCCN5CCOCC5)ccc34)ccc12",
+      "&COc1cc2[nH+]ccc(Oc3ccc4c(C(=O)Nc5ccc(Cl)cc5)cccc4c3)c2cc1OC",
+      "&COc1cc2[nH+]ccc(Oc3ccc4c(C(=O)Nc5ccc(Cl)cc5)cccc4c3)c2cc1OC",
+      "&COc1cc2[nH+]ccc(Oc3ccc4c(C(=O)NC5CC5)cccc4c3)c2cc1OC",
+      "&COc1cc2[nH+]ccc(Oc3ccc4c(C(=O)NC5CC5)cccc4c3)c2cc1OC",
+      "&Cc1ccc(C(=O)Nc2cc(CCC[NH+](C)C)cc(C(F)(F)F)c2)cc1Nc1ncccc1-c1ccncn1",
+      "&COc1cc(Nc2nccc(Nc3ccc4c(C)n[nH]c4c3)n2)cc(OC)c1OC",
+      "&COc1cc(Nc2nccc(N(C)c3ccc4c(C)n[nH]c4c3)n2)cc(OC)c1OC",
+      "&Cc1ccn(-c2ccc3c(c2)NCC3(C)C)c(=O)c1-c1ccc2nc(N)ncc2c1",
+      "&Cc1ccn(-c2ccc3c(c2)NCC3(C)C)c(=O)c1-c1ccc2nc(N)ncc2c1",
+      "&Cc1ccc(C(=O)NCCC2CCCC2)cc1C(=O)Nc1ccc(N)nc1",
+      "&Cc1ccc(C(=O)NCCC2CCCC2)cc1C(=O)Nc1ccc(N)nc1",
+      "&Cc1ccn(-c2cccc(C(F)(F)F)c2)c(=O)c1-c1ccc2nc(N)ncc2c1",
+      "&Cc1ccn(-c2cccc(C(F)(F)F)c2)c(=O)c1-c1ccc2nc(N)ncc2c1",
+      "&O=C(Nc1cncnc1)c1c(Cl)ccc2c(Nc3cccc(C(F)(F)F)c3)noc12",
+      "&O=C(Nc1cncnc1)c1c(Cl)ccc2c(Nc3cccc(C(F)(F)F)c3)noc12",
+      "&CC1(C)CNc2cc(NC(=O)c3cccnc3NCc3ccncc3)ccc21",
+      "&CC1(C)CNc2cc(NC(=O)c3cccnc3NCc3ccncc3)ccc21"
+    ]
+    for holder in [rdSubstructLibrary.CachedSmilesMolHolder(),
+                   rdSubstructLibrary.CachedTrustedSmilesMolHolder()]:
+      for smi in pdb_ligands:
+        holder.AddSmiles(smi)
+      lib = rdSubstructLibrary.SubstructLibrary(holder)  
+      # this should excercise the logger
+      smi = "CCS(=O)(=O)c1ccc(OC)c(Nc2ncc(-c3cccc(-c4ccccn4)c3)o2)c1"
+      self.assertEqual(0, lib.CountMatches(Chem.MolFromSmiles(smi)) )
 
+      # test add patterns
+      rdSubstructLibrary.AddPatterns(lib, -1)
+      
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
This fixes the substructlibrary and filter catalog to call into python code from C++ threads.

The FilterCatalog fix is trivial, the SubstructLibrary was a bit invasive due to the complexity of making a boost::python call_guard that releases the gil.

See the comment in the SubstructLibraryWrapper for details.

Note:  I was going to push this to @xavierholt 's branch but for some reason I couldn't, so I split it out.