### PR TITLE
Build documentation for 3 missing modules

### DIFF
--- a/Docs/Book/source/rdkit.Chem.rdCIPLabeler.rst
+++ b/Docs/Book/source/rdkit.Chem.rdCIPLabeler.rst
@@ -1,0 +1,8 @@
+rdkit.Chem.rdCIPLabeler module
+=================================
+
+.. automodule:: rdkit.Chem.rdCIPLabeler
+    :members:
+    :undoc-members:
+    :show-inheritance:
+

--- a/Docs/Book/source/rdkit.Chem.rdMolEnumerator.rst
+++ b/Docs/Book/source/rdkit.Chem.rdMolEnumerator.rst
@@ -1,0 +1,8 @@
+rdkit.Chem.rdMolEnumerator module
+=================================
+
+.. automodule:: rdkit.Chem.rdMolEnumerator
+    :members:
+    :undoc-members:
+    :show-inheritance:
+

--- a/Docs/Book/source/rdkit.Chem.rdTautomerQuery.rst
+++ b/Docs/Book/source/rdkit.Chem.rdTautomerQuery.rst
@@ -1,0 +1,8 @@
+rdkit.Chem.rdTautomerQuery module
+=================================
+
+.. automodule:: rdkit.Chem.rdTautomerQuery
+    :members:
+    :undoc-members:
+    :show-inheritance:
+

--- a/Docs/Book/source/rdkit.Chem.rst
+++ b/Docs/Book/source/rdkit.Chem.rst
@@ -104,6 +104,9 @@ Submodules
    rdkit.Chem.rdSLNParse
    rdkit.Chem.rdAbbreviations
    rdkit.Chem.rdDeprotect
+   rdkit.Chem.rdMolEnumerator.rst
+   rdkit.Chem.rdCIPLabeler.rst
+   rdkit.Chem.rdTautomerQuery.rst
 
 Module contents
 ---------------


### PR DESCRIPTION
I noticed that three modules that I have seen in the code are not actually present in the Sphinx docs:
* `rdkit.Chem.rdMolEnumerator`
* `rdkit.Chem.rdCIPLabeler`
* `rdkit.Chem.rdTautomerQuery`

If this was unintentional, this PR fixes it.