### PR TITLE
Added GetQueryType() to python query atom API

### DIFF
--- a/Code/GraphMol/Atom.h
+++ b/Code/GraphMol/Atom.h
@@ -260,6 +260,9 @@ class RDKIT_GRAPHMOL_EXPORT Atom : public RDProps {
   virtual bool hasQuery() const { return false; }
 
   //! NOT CALLABLE
+  virtual std::string getQueryType() const {return "";}
+
+  //! NOT CALLABLE
   virtual void setQuery(QUERYATOM_QUERY *what);
 
   //! NOT CALLABLE

--- a/Code/GraphMol/Atom.h
+++ b/Code/GraphMol/Atom.h
@@ -259,7 +259,6 @@ class RDKIT_GRAPHMOL_EXPORT Atom : public RDProps {
   // This method can be used to distinguish query atoms from standard atoms:
   virtual bool hasQuery() const { return false; }
 
-  //! NOT CALLABLE
   virtual std::string getQueryType() const {return "";}
 
   //! NOT CALLABLE

--- a/Code/GraphMol/QueryAtom.h
+++ b/Code/GraphMol/QueryAtom.h
@@ -73,6 +73,11 @@ class RDKIT_GRAPHMOL_EXPORT QueryAtom : public Atom {
   bool hasQuery() const override { return dp_query != nullptr; }
 
   //! replaces our current query with the value passed in
+  std::string getQueryType() const override {
+    return dp_query->getTypeLabel();
+  }
+
+  //! replaces our current query with the value passed in
   void setQuery(QUERYATOM_QUERY *what) override {
     delete dp_query;
     dp_query = what;

--- a/Code/GraphMol/Wrap/Atom.cpp
+++ b/Code/GraphMol/Wrap/Atom.cpp
@@ -215,6 +215,7 @@ struct atom_wrapper {
         .def("GetIsotope", &Atom::getIsotope)
         .def("SetNumRadicalElectrons", &Atom::setNumRadicalElectrons)
         .def("GetNumRadicalElectrons", &Atom::getNumRadicalElectrons)
+        .def("GetQueryType", &Atom::getQueryType)
 
         .def("SetChiralTag", &Atom::setChiralTag)
         .def("InvertChirality", &Atom::invertChirality)

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -5212,6 +5212,39 @@ M  END
 
     self.assertTrue(Chem.MolFromSmiles("c1ccccc1").HasSubstructMatch(pat))
 
+  def testGetQueryType(self):
+    query_a = os.path.join(RDConfig.RDBaseDir, 'Code', 'GraphMol', 'FileParsers', 'test_data',
+                      'query_A.mol')
+    m = next(Chem.SDMolSupplier(query_a))
+    self.assertTrue(m.GetAtomWithIdx(6).HasQuery())
+    self.assertTrue(m.GetAtomWithIdx(6).GetQueryType() == "A")
+
+    query_a_v3k = os.path.join(RDConfig.RDBaseDir, 'Code', 'GraphMol', 'FileParsers', 'test_data',
+                      'query_A.v3k.mol')
+    m = next(Chem.SDMolSupplier(query_a_v3k))
+    self.assertTrue(m.GetAtomWithIdx(6).HasQuery())
+    self.assertTrue(m.GetAtomWithIdx(6).GetQueryType() == "A")
+
+    query_q = os.path.join(RDConfig.RDBaseDir, 'Code', 'GraphMol', 'FileParsers', 'test_data',
+                      'query_Q.mol')
+    m = next(Chem.SDMolSupplier(query_q))
+    self.assertTrue(m.GetAtomWithIdx(6).HasQuery())
+    self.assertTrue(m.GetAtomWithIdx(6).GetQueryType() == "Q")
+
+    query_q_v3k = os.path.join(RDConfig.RDBaseDir, 'Code', 'GraphMol', 'FileParsers', 'test_data',
+                      'query_Q.v3k.mol')
+    m = next(Chem.SDMolSupplier(query_q_v3k))
+    self.assertTrue(m.GetAtomWithIdx(6).HasQuery())
+    self.assertTrue(m.GetAtomWithIdx(6).GetQueryType() == "Q")
+
+    m = Chem.MolFromSmiles("*CC")
+    params = Chem.rdmolops.AdjustQueryParameters.NoAdjustments()
+    params.makeDummiesQueries = True
+    m = Chem.rdmolops.AdjustQueryProperties(m, params)
+    self.assertTrue(m.GetAtomWithIdx(0).HasQuery())
+    self.assertTrue(m.GetAtomWithIdx(0).GetQueryType() == "")
+
+
   def testBondSetQuery(self):
     pat = Chem.MolFromSmarts('[#6]=[#6]')
     mol = Chem.MolFromSmiles("c1ccccc1")


### PR DESCRIPTION
#### Reference Issue
Addresses #4880

#### What does this implement/fix? Explain your changes.
This is exposes the `getQueryType()` query atom function to python so that atom query types/symbols (Q, QH, X, XH, etc) can be accessed. This is mostly helpful because the query symbols can now be used as a dummy label so that it will render in image generation. Here is an example of what the images will looks before and after setting dummy labels using query atom symbols:
  
<img width="834" alt="before" src="https://user-images.githubusercontent.com/39069546/149390426-033203df-ee1f-4767-a4e8-3fb1f5c758bf.png">
<img width="881" alt="Screen Shot 2022-01-07 at 4 09 50 PM" src="https://user-images.githubusercontent.com/39069546/149390505-caac8fcf-b8b9-4836-a4fa-d9ba3177ffc8.png">

#### Any other comments?
This might be something we want to automatically render
