### PR TITLE
Fixes a bug with the choice of RGD cores

### DIFF
--- a/Code/GraphMol/RGroupDecomposition/RGroupDecomp.cpp
+++ b/Code/GraphMol/RGroupDecomposition/RGroupDecomp.cpp
@@ -109,7 +109,8 @@ int RGroupDecomposition::add(const ROMol &inmol) {
 
   // Find the first matching core (onlyMatchAtRGroups)
   // or the first core that requires the smallest number
-  // of newly added labels
+  // of newly added labels and is a superstructure of
+  // the first matching core
   int global_min_heavy_nbrs = -1;
   SubstructMatchParameters sssparams(params().substructmatchParams);
   sssparams.uniquify = false;
@@ -198,8 +199,9 @@ int RGroupDecomposition::add(const ROMol &inmol) {
     if (!data->params.onlyMatchAtRGroups) {
       int min_heavy_nbrs = *std::min_element(tmatches_heavy_nbrs.begin(),
                                              tmatches_heavy_nbrs.end());
-      if (global_min_heavy_nbrs == -1 ||
-          min_heavy_nbrs < global_min_heavy_nbrs) {
+      if (!rcore || (min_heavy_nbrs < global_min_heavy_nbrs &&
+                     !SubstructMatch(*core.second.core, *rcore->core, sssparams)
+                          .empty())) {
         i = 0;
         tmatches_filtered.clear();
         for (const auto heavy_nbrs : tmatches_heavy_nbrs) {

--- a/Code/GraphMol/RGroupDecomposition/testRGroupDecomp.cpp
+++ b/Code/GraphMol/RGroupDecomposition/testRGroupDecomp.cpp
@@ -2715,7 +2715,6 @@ void testDoNotChooseUnrelatedCores() {
       RGroupDecomposition decomp(orderedCores);
       TEST_ASSERT(decomp.add(*m) == 0);
       TEST_ASSERT(decomp.process());
-      std::stringstream ss;
       auto cols = decomp.getRGroupsAsColumns();
       const auto &core = cols["Core"];
       TEST_ASSERT(core.size() == 1);

--- a/Code/GraphMol/RGroupDecomposition/testRGroupDecomp.cpp
+++ b/Code/GraphMol/RGroupDecomposition/testRGroupDecomp.cpp
@@ -2748,7 +2748,6 @@ void testDoNotChooseUnrelatedCores() {
         TEST_ASSERT(decomp.add(*m) == j++);
       }
       TEST_ASSERT(decomp.process());
-      std::stringstream ss;
       auto cols = decomp.getRGroupsAsColumns();
       const auto &core = cols["Core"];
       TEST_ASSERT(core.size() == 3);

--- a/Code/GraphMol/RGroupDecomposition/testRGroupDecomp.cpp
+++ b/Code/GraphMol/RGroupDecomposition/testRGroupDecomp.cpp
@@ -2690,6 +2690,78 @@ M  END
   CHECK_RGROUP(it, expected);
 }
 
+void testDoNotChooseUnrelatedCores() {
+  BOOST_LOG(rdInfoLog)
+      << "********************************************************\n";
+  BOOST_LOG(rdInfoLog) << "Test that later cores with more R-groups\n"
+                       << "are only chosen if superstructures of earlier\n"
+                       << "cores" << std::endl;
+  {
+    // 1st test, two unrelated cores:
+    // 1) 5 terms, 1 R-group
+    // 2) 6 terms, 3 R-groups
+    // dataset molecule can fit core 1 adding 1 non-user defined R label,
+    // and core 2 with no addition of R labels
+    ROMOL_SPTR core5Terms1RGroup = "[*:1]C1COCN1"_smiles;
+    ROMOL_SPTR core6Terms3RGroups = "[*:1]c1ccc([*:2])c([*:3])c1"_smiles;
+    std::vector<ROMOL_SPTR> cores{core5Terms1RGroup, core6Terms3RGroups};
+    auto m = "Cc1cc(ccc1F)C1NC(CO1)c1cccs1"_smiles;
+    // repeat the test twice, with cores in opposite orders
+    // in both cases core ordering should be honored and the first
+    // core (either 5-term of 6-term) should be chosen, even when adding
+    // R labels is required, as the 2 cores are not structurally related
+    for (unsigned int i = 0; i < 2; ++i) {
+      std::vector<ROMOL_SPTR> orderedCores{cores[i], cores[1 - i]};
+      RGroupDecomposition decomp(orderedCores);
+      TEST_ASSERT(decomp.add(*m) == 0);
+      TEST_ASSERT(decomp.process());
+      std::stringstream ss;
+      auto cols = decomp.getRGroupsAsColumns();
+      const auto &core = cols["Core"];
+      TEST_ASSERT(core.size() == 1);
+      TEST_ASSERT(
+          core.front()->getRingInfo()->atomRings().front().size() ==
+          orderedCores.front()->getRingInfo()->atomRings().front().size());
+    }
+  }
+  {
+    // 2nd test: two related cores:
+    // 1) 5 terms, 2 R-groups
+    // 2) 5 terms, 3 R-groups
+    // dataset molecule 1 has 1 substituent, fits both cores
+    // dataset molecule 2 has 2 substituents, fits both cores
+    // dataset molecule 3 has 3 substituents, fits core 2 with no need to add
+    // R labels
+    ROMOL_SPTR core5Terms2RGroups = "[*:1]C1COC([*:2])N1"_smiles;
+    ROMOL_SPTR core5Terms3RGroups = "[*:1]C1C([*:2])OC([*:3])N1"_smiles;
+    std::vector<ROMOL_SPTR> cores{core5Terms2RGroups, core5Terms3RGroups};
+    std::vector<ROMOL_SPTR> mols{"CC1NCCO1"_smiles, "CC1NC(F)CO1"_smiles,
+                                 "CC1NC(F)C(Cl)O1"_smiles};
+    // repeat the test twice, with cores in opposite orders
+    // Molecules (1) and (2) should always pick the first core
+    // in the order provided, though both cores could fit
+    // Molecule (3) should always pick the more specific core 2
+    for (unsigned int i = 0; i < 2; ++i) {
+      std::vector<ROMOL_SPTR> orderedCores{cores[i], cores[1 - i]};
+      RGroupDecomposition decomp(orderedCores);
+      int j = 0;
+      for (const auto &m : mols) {
+        TEST_ASSERT(decomp.add(*m) == j++);
+      }
+      TEST_ASSERT(decomp.process());
+      std::stringstream ss;
+      auto cols = decomp.getRGroupsAsColumns();
+      const auto &core = cols["Core"];
+      TEST_ASSERT(core.size() == 3);
+      TEST_ASSERT(MolToSmiles(*core.at(0)) ==
+                  MolToSmiles(*orderedCores.front()));
+      TEST_ASSERT(MolToSmiles(*core.at(1)) ==
+                  MolToSmiles(*orderedCores.front()));
+      TEST_ASSERT(MolToSmiles(*core.at(2)) == MolToSmiles(*core5Terms3RGroups));
+    }
+  }
+}
+
 int main() {
   RDLog::InitLogs();
   boost::logging::disable_logs("rdApp.debug");
@@ -2740,6 +2812,7 @@ int main() {
   testCoreWithAlsRecords();
   testAlignOutputCoreToMolecule();
   testWildcardInInput();
+  testDoNotChooseUnrelatedCores();
   BOOST_LOG(rdInfoLog)
       << "********************************************************\n";
   return 0;


### PR DESCRIPTION
I have recently realized that the "Do not add unnecessary R labels" part of a previous PR (#3969) had an oversight.

Before #3969, the first matching core in the order cores are provided to RGD was chosen to decompose each molecule.
As discussed in #3969, this may cause suboptimal cores to be chosen when `onlyMatchAtRGroups` is set to `false`, so the rule was changed as follows: the first matching core is chosen that requires the least number of non-user defined R labels to be added.
However, this should only happen when later, more specific cores are structurally related to earlier cores, i.e. when they are superstructures of earlier cores.

To better explain this point, let's take a look at these examples, taken from the newly added `testDoNotChooseUnrelatedCores()` test.

## Example 1

We have these two cores:
1. ![image](https://user-images.githubusercontent.com/5244385/149669034-ce4e6b9d-447c-4418-9bce-773b9d7c564d.png)
2. ![image](https://user-images.githubusercontent.com/5244385/149669054-64c08f7c-6e7f-4f20-9e6c-f249ac10851d.png)

We want to decompose this molecule:
![image](https://user-images.githubusercontent.com/5244385/149669094-be9e308f-99c0-4ce9-bf38-ddef3273ee5e.png)

The molecule fits both cores, requiring 1 additional label for core 1 and no additional labels for core 2.
With the current logic, the core 2 is chosen to decompose the molecule, which goes against the user preference of using a 5-term core to decompose the molecule first, and only if the 5-term core does not match the molecule, fall back to the 6-term core.
After this PR, the 5-term core is used; only if the ordering of cores is reversed is the 6-term core used.

## Example 2

We have these two cores:
1. ![image](https://user-images.githubusercontent.com/5244385/149669295-d28b582a-a607-492b-a564-5103d72c98fc.png)
2. ![image](https://user-images.githubusercontent.com/5244385/149669305-75cfa129-09bf-479d-b126-e537bdceb1a8.png)

We want to decompose these 3 molecules:
1. ![image](https://user-images.githubusercontent.com/5244385/149669353-11bad77f-bb3f-42ce-937d-58c87fdf951b.png)
2. ![image](https://user-images.githubusercontent.com/5244385/149669363-e198e2a9-66c7-493d-9b99-6fe79a03f881.png)
3. ![image](https://user-images.githubusercontent.com/5244385/149669396-ea9c7c7f-18fc-4766-8d53-90f945759c39.png)

All molecules fit both cores.
However, as all cores are structurally related (i.e., are in a substructure/superstructure relationship), in each case the core that fits the molecule requiring addition of the least number of R labels should be chosen; when there is no difference, the ordering should matter.
So the expected result is:
![image](https://user-images.githubusercontent.com/5244385/149670357-5dc030ce-dd93-4a84-be26-171faf4c6d8e.png)

If we reverse the order of cores we expect:
![image](https://user-images.githubusercontent.com/5244385/149670524-435343a2-f367-4b5f-a633-3318834763f5.png)

And this is indeed what we get.
