### PR TITLE
Clean-up Python #4815 - P1.5: Chem\FeatMaps

### DIFF
--- a/rdkit/Chem/FeatMaps/FeatMapParser.py
+++ b/rdkit/Chem/FeatMaps/FeatMapParser.py
@@ -146,9 +146,7 @@ class FeatMapParser(object):
     splitL = txt.split(',')
     if len(splitL) != 3:
       raise ValueError('Bad location string')
-    vs = [float(x) for x in splitL]
-    pt = Geometry.Point3D(vs[0], vs[1], vs[2])
-    return pt
+    return Geometry.Point3D(float(splitL[0]), float(splitL[1]), float(splitL[2]))
 
   def ParseFeatPointBlock(self):
     featLineSplitter = re.compile(r'([a-zA-Z]+) *= *')
@@ -164,27 +162,22 @@ class FeatMapParser(object):
       i = 0
       while i < len(vals):
         name = vals[i].lower()
+        if name not in ('family', 'weight', 'pos', 'dir'):
+          raise FeatMapParseError(f'FeatPoint option {name} not recognized on line {self._lineNum}')       
+        
+        i += 1
         if name == 'family':
-          i += 1
           val = vals[i].strip()
           p.SetFamily(val)
         elif name == 'weight':
-          i += 1
-          val = float(vals[i])
-          p.weight = val
+          p.weight = float(vals[i])
         elif name == 'pos':
-          i += 1
-          val = vals[i]
-          pos = self._parsePoint(val)
+          pos = self._parsePoint(vals[i])
           p.SetPos(pos)
         elif name == 'dir':
-          i += 1
-          val = vals[i]
-          pos = self._parsePoint(val)
+          pos = self._parsePoint(vals[i])
           p.featDirs.append(pos)
-        else:
-          raise FeatMapParseError('FeatPoint option %s not recognized on line %d' %
-                                  (name, self._lineNum))
+          
         i += 1
       feats.append(p)
       l = self._NextLine()

--- a/rdkit/Chem/FeatMaps/FeatMapParser.py
+++ b/rdkit/Chem/FeatMaps/FeatMapParser.py
@@ -160,25 +160,19 @@ class FeatMapParser(object):
       p = FeatMapPoint.FeatMapPoint()
 
       i = 0
-      while i < len(vals):
+      for i in range(0, len(vals), 2):
         name = vals[i].lower()
-        if name not in ('family', 'weight', 'pos', 'dir'):
-          raise FeatMapParseError(f'FeatPoint option {name} not recognized on line {self._lineNum}')       
-        
-        i += 1
         if name == 'family':
-          val = vals[i].strip()
-          p.SetFamily(val)
+          p.SetFamily(vals[i + 1].strip())
         elif name == 'weight':
-          p.weight = float(vals[i])
+          p.weight = float(vals[i + 1])
         elif name == 'pos':
-          pos = self._parsePoint(vals[i])
-          p.SetPos(pos)
+          p.SetPos(self._parsePoint(vals[i + 1]))
         elif name == 'dir':
-          pos = self._parsePoint(vals[i])
-          p.featDirs.append(pos)
-          
-        i += 1
+          p.featDirs.append(self._parsePoint(vals[i + 1]))
+        else:
+          raise FeatMapParseError(f'FeatPoint option {name} not recognized on line {self._lineNum}')
+        
       feats.append(p)
       l = self._NextLine()
     return feats

--- a/rdkit/Chem/FeatMaps/FeatMapParser.py
+++ b/rdkit/Chem/FeatMaps/FeatMapParser.py
@@ -160,14 +160,15 @@ class FeatMapParser(object):
       p = FeatMapPoint.FeatMapPoint()
       for i in range(0, len(vals), 2):
         name = vals[i].lower()
+        value = vals[i + 1]
         if name == 'family':
-          p.SetFamily(vals[i + 1].strip())
+          p.SetFamily(value.strip())
         elif name == 'weight':
-          p.weight = float(vals[i + 1])
+          p.weight = float(value)
         elif name == 'pos':
-          p.SetPos(self._parsePoint(vals[i + 1]))
+          p.SetPos(self._parsePoint(value))
         elif name == 'dir':
-          p.featDirs.append(self._parsePoint(vals[i + 1]))
+          p.featDirs.append(self._parsePoint(value))
         else:
           raise FeatMapParseError(f'FeatPoint option {name} not recognized on line {self._lineNum}')
         

--- a/rdkit/Chem/FeatMaps/FeatMapParser.py
+++ b/rdkit/Chem/FeatMaps/FeatMapParser.py
@@ -158,8 +158,6 @@ class FeatMapParser(object):
       while vals.count(''):
         vals.remove('')
       p = FeatMapPoint.FeatMapPoint()
-
-      i = 0
       for i in range(0, len(vals), 2):
         name = vals[i].lower()
         if name == 'family':

--- a/rdkit/Chem/FeatMaps/FeatMaps.py
+++ b/rdkit/Chem/FeatMaps/FeatMaps.py
@@ -122,7 +122,6 @@ class FeatMap(object):
     """ feat1 is one of our feats
         feat2 is any Feature
 
-
     """
     if typeMatch and feat1.GetFamily() != feat2.GetFamily():
       return 0.0
@@ -154,41 +153,44 @@ class FeatMap(object):
 
     return score
 
-  def ScoreFeats(self, featsToScore, mapScoreVect=[], featsScoreVect=[], featsToFeatMapIdx=[]):
+  def ScoreFeats(self, featsToScore, mapScoreVect=None, featsScoreVect=None, featsToFeatMapIdx=None):
     nFeats = len(self._feats)
-    if mapScoreVect and len(mapScoreVect) != nFeats:
-      raise ValueError('if provided, len(mapScoreVect) should equal numFeats')
-    nToScore = len(featsToScore)
-    if featsScoreVect and len(featsScoreVect) != nToScore:
-      raise ValueError('if provided, len(featsScoreVect) should equal len(featsToScore)')
-    if featsToFeatMapIdx and len(featsToFeatMapIdx) != nToScore:
-      raise ValueError('if provided, len(featsToFeatMapIdx) should equal len(featsToScore)')
-
-    if mapScoreVect:
+    if mapScoreVect is not None:
+      if len(mapScoreVect) != nFeats:
+        raise ValueError('if provided, len(mapScoreVect) should equal numFeats')
       for i in range(nFeats):
         mapScoreVect[i] = 0.0
     else:
-      mapScoreVect = [0.0] * nFeats
+        mapScoreVect = [0.0] * nFeats
 
+    nToScore = len(featsToScore)
     if self.scoreMode == FeatMapScoreMode.Closest:
       defScore = 1000.0
-    else:
+    else: 
       defScore = 0.0
-    if featsScoreVect:
+    if featsScoreVect is not None:
+      if len(featsScoreVect) != nToScore:
+        raise ValueError('if provided, len(featsScoreVect) should equal len(featsToScore)')
       for i in range(nToScore):
         featsScoreVect[i] = defScore
     else:
       featsScoreVect = [defScore] * nToScore
 
-    if not featsToFeatMapIdx:
-      featsToFeatMapIdx = [None] * nToScore
-
-    for i in range(nToScore):
+    if featsToFeatMapIdx is not None: # Initialize a 2D-empty array
+      if len(featsToFeatMapIdx) != nToScore:
+        raise ValueError('if provided, len(featsToFeatMapIdx) should equal len(featsToScore)')
       if self.scoreMode != FeatMapScoreMode.All:
-        featsToFeatMapIdx[i] = [-1]
+        for i in range(nToScore):
+          featsToFeatMapIdx[i] = [-1]
       else:
-        featsToFeatMapIdx[i] = []
-
+        for i in range(nToScore):
+          featsToFeatMapIdx[i] = []
+    else:
+      if self.scoreMode != FeatMapScoreMode.All:
+        featsToFeatMapIdx = [[-1] for _ in range(nToScore)]
+      else:
+        featsToFeatMapIdx = [[] for _ in range(nToScore)]
+    
     for oIdx, oFeat in enumerate(featsToScore):
       for sIdx, sFeat in self._loopOverMatchingFeats(oFeat):
         if self.scoreMode == FeatMapScoreMode.Closest:

--- a/rdkit/Chem/FeatMaps/FeatMaps.py
+++ b/rdkit/Chem/FeatMaps/FeatMaps.py
@@ -161,13 +161,14 @@ class FeatMap(object):
       for i in range(nFeats):
         mapScoreVect[i] = 0.0
     else:
-        mapScoreVect = [0.0] * nFeats
+      mapScoreVect = [0.0] * nFeats
 
     nToScore = len(featsToScore)
     if self.scoreMode == FeatMapScoreMode.Closest:
       defScore = 1000.0
     else: 
       defScore = 0.0
+      
     if featsScoreVect is not None:
       if len(featsScoreVect) != nToScore:
         raise ValueError('if provided, len(featsScoreVect) should equal len(featsToScore)')
@@ -179,17 +180,15 @@ class FeatMap(object):
     if featsToFeatMapIdx is not None: # Initialize a 2D-empty array
       if len(featsToFeatMapIdx) != nToScore:
         raise ValueError('if provided, len(featsToFeatMapIdx) should equal len(featsToScore)')
-      if self.scoreMode != FeatMapScoreMode.All:
-        for i in range(nToScore):
-          featsToFeatMapIdx[i] = [-1]
-      else:
-        for i in range(nToScore):
-          featsToFeatMapIdx[i] = []
     else:
-      if self.scoreMode != FeatMapScoreMode.All:
-        featsToFeatMapIdx = [[-1] for _ in range(nToScore)]
-      else:
-        featsToFeatMapIdx = [[] for _ in range(nToScore)]
+      featsToFeatMapIdx = [None] * nToScore
+    
+    if self.scoreMode != FeatMapScoreMode.All:
+      for i in range(nToScore):
+        featsToFeatMapIdx[i] = [-1]
+    else:
+      for i in range(nToScore):
+        featsToFeatMapIdx[i] = []
     
     for oIdx, oFeat in enumerate(featsToScore):
       for sIdx, sFeat in self._loopOverMatchingFeats(oFeat):

--- a/rdkit/Chem/FeatMaps/FeatMaps.py
+++ b/rdkit/Chem/FeatMaps/FeatMaps.py
@@ -140,8 +140,7 @@ class FeatMap(object):
         score = 0.0
     elif params.featProfile == FeatMapParams.FeatProfile.Box:
       score = 1.0
-    weight = feat1.weight
-    score *= weight
+    score *= feat1.weight
 
     if self.dirScoreMode != FeatDirScoreMode.Ignore:
       dirScore = feat1.GetDirMatch(feat2)
@@ -183,11 +182,10 @@ class FeatMap(object):
     else:
       featsToFeatMapIdx = [None] * nToScore
     
-    if self.scoreMode != FeatMapScoreMode.All:
-      for i in range(nToScore):
+    for i in range(nToScore):
+      if self.scoreMode != FeatMapScoreMode.All:
         featsToFeatMapIdx[i] = [-1]
-    else:
-      for i in range(nToScore):
+      else:
         featsToFeatMapIdx[i] = []
     
     for oIdx, oFeat in enumerate(featsToScore):
@@ -221,7 +219,6 @@ class FeatMap(object):
           totScore += lScore
         else:
           featsScoreVect[oIdx] = 0
-
     else:
       totScore = sum(featsScoreVect)
       if self.scoreMode == FeatMapScoreMode.Best:


### PR DESCRIPTION
This is the sub-PR breaking from the large PR 4815: https://github.com/rdkit/rdkit/pull/4815

--------------------
Updated Changes
- [New]: Cleanup `class FeatMapParser`,
- [Recall]: Function `ScoreFeats()` changed the default variables for data/memory safety. Check in PR 4815. This may cause backward incompatible
- [Recall]: Function `GetFeatFeatDistMatrix()` is optimized.