### PR TITLE
Clean-up Python #4815 - P1.12: Chem\MolStandardize

### DIFF
--- a/rdkit/Chem/MolStandardize/UnitTestMolStandardize.py
+++ b/rdkit/Chem/MolStandardize/UnitTestMolStandardize.py
@@ -27,8 +27,3 @@ class TestCase(unittest.TestCase):
         tauts = enumerator.Enumerate(m)
         reordtauts = MolStandardize.ReorderTautomers(m)
         self.assertEquals(len(reordtauts), len(tauts))
-
-
-
-
-

--- a/rdkit/Chem/MolStandardize/UnitTestMolVS.py
+++ b/rdkit/Chem/MolStandardize/UnitTestMolVS.py
@@ -11,15 +11,14 @@ molvs.standardize.canonicalize_tautomer_smiles
 molvs.validate.Validator()
 Standardizer().fragment_parent
 """
-from collections import namedtuple
-import unittest
 import gzip
 import os.path
+import unittest
+from collections import namedtuple
 
-from rdkit import Chem
-from rdkit import RDConfig
 import molvs
 from molvs import Standardizer, validate
+from rdkit import Chem, RDConfig
 
 doLong = False
 TestData = namedtuple('TestData', 'lineNo,smiles,mol,expected')
@@ -57,8 +56,7 @@ class TestCase(unittest.TestCase):
             try:
                 ss = molvs.standardize_smiles(data.smiles)
             except Exception:
-                raise AssertionError(
-                    'Line {0.lineNo}: MolVS standardization failed for SMILES {0.smiles}'.format(data))
+                raise AssertionError(f'Line {data.lineNo}: MolVS standardization failed for SMILES {data.smiles}')
             self.assertEqual(ss, data.expected)
 
     def testNormalizeShort(self):
@@ -77,8 +75,7 @@ class TestCase(unittest.TestCase):
                 nm = n.normalize(data.mol)
                 ns = Chem.MolToSmiles(nm)
             except Exception:
-                raise AssertionError(
-                    'Line {0.lineNo}: MolVS normalization failed for SMILES {0.smiles}'.format(data))
+                raise AssertionError(f'Line {data.lineNo}: MolVS normalization failed for SMILES {data.smiles}')
             self.assertEqual(ns, data.expected)
 
     def testMetalShort(self):
@@ -97,8 +94,7 @@ class TestCase(unittest.TestCase):
                 nm = n.disconnect_metals(data.mol)
                 ns = Chem.MolToSmiles(nm)
             except Exception:
-                raise AssertionError(
-                    'Line {0.lineNo}: MolVS normalization failed for SMILES {0.smiles}'.format(data))
+                raise AssertionError(f'Line {data.lineNo}: MolVS normalization failed for SMILES {data.smiles}')
             self.assertEqual(ns, data.expected)
 
     def testReionizeShort(self):
@@ -117,8 +113,7 @@ class TestCase(unittest.TestCase):
                 nm = n.reionize(data.mol)
                 ns = Chem.MolToSmiles(nm)
             except Exception:
-                raise AssertionError(
-                    'Line {0.lineNo}: MolVS normalization failed for SMILES {0.smiles}'.format(data))
+                raise AssertionError(f'Line {data.lineNo}: MolVS normalization failed for SMILES {data.smiles}')
             self.assertEqual(ns, data.expected)
 
     def testFragmentShort(self):
@@ -137,8 +132,7 @@ class TestCase(unittest.TestCase):
                 frag = s.fragment_parent(data.mol)
                 ns = Chem.MolToSmiles(frag)
             except Exception:
-                raise AssertionError(
-                    'Line {0.lineNo}: MolVS normalization failed for SMILES {0.smiles}'.format(data))
+                raise AssertionError(f'Line {data.lineNo}: MolVS normalization failed for SMILES {data.smiles}')
             self.assertEqual(ns, data.expected)
 
     def testTautomerShort(self):
@@ -153,8 +147,7 @@ class TestCase(unittest.TestCase):
             try:
                 canon_taut = molvs.standardize.canonicalize_tautomer_smiles(data.smiles)
             except Exception:
-                raise AssertionError(
-                    'Line {0.lineNo}: MolVS normalization failed for SMILES {0.smiles}'.format(data))
+                raise AssertionError(f'Line {data.lineNo}: MolVS normalization failed for SMILES {data.smiles}')
             self.assertEqual(canon_taut, data.expected)
 
     def testValidateShort(self):
@@ -181,7 +174,7 @@ class TestCase(unittest.TestCase):
                 # print(i, stdout)
             except Exception:
                 raise AssertionError(
-                    'Line {0.lineNo}: MolVS normalization failed for SMILES {0.smiles}'.format(data))
+                    f'Line {data.lineNo}: MolVS normalization failed for SMILES {data.smiles}')
             self.assertEqual(stdout, data.expected)
 
 def readPCStestData(filename):
@@ -194,7 +187,7 @@ def readPCStestData(filename):
             expected = ",".join(line.strip().split(',')[1:])
             mol = Chem.MolFromSmiles(smiles)
             if not mol:
-                raise AssertionError('molecule construction failed on line %d' % lineNo)
+                raise AssertionError(f'molecule construction failed on line {lineNo}')
             yield TestData(lineNo, smiles, mol, expected)
 
 if __name__ == '__main__':

--- a/rdkit/Chem/MolStandardize/charge.py
+++ b/rdkit/Chem/MolStandardize/charge.py
@@ -310,9 +310,7 @@ class Uncharger(object):
                     neg_surplus -= 1
                     log.info('Removed negative charge')
         else:
-            #
-            negativeAtomIdxs = [mol.GetAtomWithIdx(x) for x in n]
-            for atom in negativeAtomIdxs:
+            for atom in [mol.GetAtomWithIdx(x) for x in n]:
                 while atom.GetFormalCharge() < 0:
                     atom.SetNumExplicitHs(atom.GetNumExplicitHs() + 1)
                     atom.SetFormalCharge(atom.GetFormalCharge() + 1)

--- a/rdkit/Chem/MolStandardize/charge.py
+++ b/rdkit/Chem/MolStandardize/charge.py
@@ -50,7 +50,7 @@ class AcidBasePair(object):
         return Chem.MolFromSmarts(self.base_str)
 
     def __repr__(self):
-        return fr'AcidBasePair({self.name}, {self.acid_str}, {self.base_str})'
+        return 'AcidBasePair({!r}, {!r}, {!r})'.format(self.name, self.acid_str, self.base_str)
 
     def __str__(self):
         return self.name
@@ -116,7 +116,7 @@ class ChargeCorrection(object):
         return Chem.MolFromSmarts(self.smarts_str)
 
     def __repr__(self):
-        return fr'ChargeCorrection({self.name}, {self.smarts_str}, {self.charge})'
+        return 'ChargeCorrection({!r}, {!r}, {!r})'.format(self.name, self.smarts_str, self.charge)
 
     def __str__(self):
         return self.name

--- a/rdkit/Chem/MolStandardize/charge.py
+++ b/rdkit/Chem/MolStandardize/charge.py
@@ -34,23 +34,23 @@ class AcidBasePair(object):
         :param string acid: SMARTS pattern for the protonated acid.
         :param string base: SMARTS pattern for the conjugate ionized base.
         """
-        log.debug('Initializing AcidBasePair: %s', name)
+        log.debug(f'Initializing AcidBasePair: {name}')
         self.name = name
         self.acid_str = acid
         self.base_str = base
 
     @memoized_property
     def acid(self):
-        log.debug('Loading AcidBasePair acid: %s', self.name)
+        log.debug(f'Loading AcidBasePair acid: {self.name}')
         return Chem.MolFromSmarts(self.acid_str)
 
     @memoized_property
     def base(self):
-        log.debug('Loading AcidBasePair base: %s', self.name)
+        log.debug(f'Loading AcidBasePair base: {self.name}')
         return Chem.MolFromSmarts(self.base_str)
 
     def __repr__(self):
-        return 'AcidBasePair({!r}, {!r}, {!r})'.format(self.name, self.acid_str, self.base_str)
+        return fr'AcidBasePair({self.name}, {self.acid_str}, {self.base_str})'
 
     def __str__(self):
         return self.name
@@ -105,18 +105,18 @@ class ChargeCorrection(object):
         :param string smarts: SMARTS pattern to match. Charge is applied to the first atom.
         :param int charge: The charge to apply.
         """
-        log.debug('Initializing ChargeCorrection: %s', name)
+        log.debug(f'Initializing ChargeCorrection: {name}')
         self.name = name
         self.smarts_str = smarts
         self.charge = charge
 
     @memoized_property
     def smarts(self):
-        log.debug('Loading ChargeCorrection smarts: %s', self.name)
+        log.debug(f'Loading ChargeCorrection smarts: {self.name}')
         return Chem.MolFromSmarts(self.smarts_str)
 
     def __repr__(self):
-        return 'ChargeCorrection({!r}, {!r}, {!r})'.format(self.name, self.smarts_str, self.charge)
+        return fr'ChargeCorrection({self.name}, {self.smarts_str}, {self.charge})'
 
     def __str__(self):
         return self.name
@@ -186,8 +186,7 @@ class Reionizer(object):
                 ppos, poccur = self._strongest_protonated(mol)
                 if ppos is None:
                     break
-                log.info('Ionizing %s to balance previous charge corrections',
-                         self.acid_base_pairs[ppos].name)
+                log.info(f'Ionizing {self.acid_base_pairs[ppos].name} to balance previous charge corrections')
                 patom = mol.GetAtomWithIdx(poccur[-1])
                 patom.SetFormalCharge(patom.GetFormalCharge() - 1)
                 if patom.GetNumExplicitHs() > 0:
@@ -213,8 +212,7 @@ class Reionizer(object):
                     break
                 already_moved.add(key)
 
-                log.info('Moved proton from %s to %s',
-                         self.acid_base_pairs[ppos].name, self.acid_base_pairs[ipos].name)
+                log.info(f'Moved proton from {self.acid_base_pairs[ppos].name} to {self.acid_base_pairs[ipos].name}')
 
                 # Remove hydrogen from strongest protonated
                 patom = mol.GetAtomWithIdx(poccur[-1])
@@ -321,8 +319,7 @@ class Uncharger(object):
                     log.info('Removed negative charge')
         
         # Neutralize positive charges
-        positiveAtomIdxs = [mol.GetAtomWithIdx(x) for x in p]
-        for atom in positiveAtomIdxs:
+        for atom in [mol.GetAtomWithIdx(x) for x in p]:
             # Remove hydrogen and reduce formal change until neutral or no more hydrogens
             while atom.GetFormalCharge() > 0 and atom.GetNumExplicitHs() > 0:
                 atom.SetNumExplicitHs(atom.GetNumExplicitHs() - 1)

--- a/rdkit/Chem/MolStandardize/charge.py
+++ b/rdkit/Chem/MolStandardize/charge.py
@@ -11,14 +11,12 @@ which attempts to neutralize ionized acids and bases on a molecule.
 :license: MIT, see LICENSE file for more details.
 """
 
-
 import copy
 import logging
 
 from rdkit import Chem
 
 from .utils import memoized_property
-
 
 log = logging.getLogger(__name__)
 
@@ -245,16 +243,10 @@ class Reionizer(object):
         return mol
 
     def _strongest_protonated(self, mol):
-        for position, pair in enumerate(self.acid_base_pairs):
-            for occurrence in mol.GetSubstructMatches(pair.acid):
-                return position, occurrence
-        return None, None
+        return 0, mol.GetSubstructMatches(self.acid_base_pairs[0].acid)
 
     def _weakest_ionized(self, mol):
-        for position, pair in enumerate(reversed(self.acid_base_pairs)):
-            for occurrence in mol.GetSubstructMatches(pair.base):
-                return len(self.acid_base_pairs) - position - 1, occurrence
-        return None, None
+        return len(self.acid_base_pairs) - 1, mol.GetSubstructMatches(self.acid_base_pairs[-1].base)
 
 
 class Uncharger(object):
@@ -293,6 +285,7 @@ class Uncharger(object):
         """
         log.debug('Running Uncharger')
         mol = copy.deepcopy(mol)
+        
         # Get atom ids for matches
         p = [x[0] for x in mol.GetSubstructMatches(self._pos_h)]
         q = [x[0] for x in mol.GetSubstructMatches(self._pos_quat)]
@@ -314,13 +307,16 @@ class Uncharger(object):
                     log.info('Removed negative charge')
         else:
             #
-            for atom in [mol.GetAtomWithIdx(x) for x in n]:
+            negativeAtomIdxs = [mol.GetAtomWithIdx(x) for x in n]
+            for atom in negativeAtomIdxs:
                 while atom.GetFormalCharge() < 0:
                     atom.SetNumExplicitHs(atom.GetNumExplicitHs() + 1)
                     atom.SetFormalCharge(atom.GetFormalCharge() + 1)
                     log.info('Removed negative charge')
+        
         # Neutralize positive charges
-        for atom in [mol.GetAtomWithIdx(x) for x in p]:
+        positiveAtomIdxs = [mol.GetAtomWithIdx(x) for x in p]
+        for atom in positiveAtomIdxs:
             # Remove hydrogen and reduce formal change until neutral or no more hydrogens
             while atom.GetFormalCharge() > 0 and atom.GetNumExplicitHs() > 0:
                 atom.SetNumExplicitHs(atom.GetNumExplicitHs() - 1)

--- a/rdkit/Chem/MolStandardize/charge.py
+++ b/rdkit/Chem/MolStandardize/charge.py
@@ -243,10 +243,16 @@ class Reionizer(object):
         return mol
 
     def _strongest_protonated(self, mol):
-        return 0, mol.GetSubstructMatches(self.acid_base_pairs[0].acid)
+        for position, pair in enumerate(self.acid_base_pairs):
+            for occurrence in mol.GetSubstructMatches(pair.acid):
+                return position, occurrence
+        return None, None
 
     def _weakest_ionized(self, mol):
-        return len(self.acid_base_pairs) - 1, mol.GetSubstructMatches(self.acid_base_pairs[-1].base)
+        for position, pair in enumerate(reversed(self.acid_base_pairs)):
+            for occurrence in mol.GetSubstructMatches(pair.base):
+                return len(self.acid_base_pairs) - position - 1, occurrence
+        return None, None
 
 
 class Uncharger(object):

--- a/rdkit/Chem/MolStandardize/fragment.py
+++ b/rdkit/Chem/MolStandardize/fragment.py
@@ -127,10 +127,7 @@ def is_organic(fragment):
     """
     # TODO: Consider a different definition?
     # Could allow only H, C, N, O, S, P, F, Cl, Br, I
-    for a in fragment.GetAtoms():
-        if a.GetAtomicNum() == 6:
-            return True
-    return False
+    return any(atom.GetAtomicNum() == 6 for atom in fragment.GetAtoms())
 
 
 class FragmentRemover(object):
@@ -166,12 +163,12 @@ class FragmentRemover(object):
         log.debug('Running FragmentRemover')
         # Iterate FragmentPatterns and remove matching fragments
         for frag in self.fragments:
-            # If nothing is left or leave_last and only one fragment, end here
+            # If nothing is left or leave_last and only one fragment, end here.
             if mol.GetNumAtoms() == 0 or (self.leave_last and len(Chem.GetMolFrags(mol)) <= 1):
                 break
             # Apply removal for this FragmentPattern
             removed = Chem.DeleteSubstructs(mol, frag.smarts, onlyFrags=True)
-            if not mol.GetNumAtoms() == removed.GetNumAtoms():
+            if mol.GetNumAtoms() != removed.GetNumAtoms():
                 log.info('Removed fragment: %s', frag.name)
             if self.leave_last and removed.GetNumAtoms() == 0:
                 # All the remaining fragments match this pattern - leave them all

--- a/rdkit/Chem/MolStandardize/fragment.py
+++ b/rdkit/Chem/MolStandardize/fragment.py
@@ -40,7 +40,7 @@ class FragmentPattern(object):
         return Chem.MolFromSmarts(self.smarts_str)
 
     def __repr__(self):
-        return fr'FragmentPattern({self.name}, {self.smarts_str})'
+        return 'FragmentPattern({!r}, {!r})'.format(self.name, self.smarts_str)
 
     def __str__(self):
         return self.name

--- a/rdkit/Chem/MolStandardize/fragment.py
+++ b/rdkit/Chem/MolStandardize/fragment.py
@@ -40,7 +40,7 @@ class FragmentPattern(object):
         return Chem.MolFromSmarts(self.smarts_str)
 
     def __repr__(self):
-        return 'FragmentPattern({!r}, {!r})'.format(self.name, self.smarts_str)
+        return fr'FragmentPattern({self.name}, {self.smarts_str})'
 
     def __str__(self):
         return self.name
@@ -169,7 +169,7 @@ class FragmentRemover(object):
             # Apply removal for this FragmentPattern
             removed = Chem.DeleteSubstructs(mol, frag.smarts, onlyFrags=True)
             if mol.GetNumAtoms() != removed.GetNumAtoms():
-                log.info('Removed fragment: %s', frag.name)
+                log.info(f'Removed fragment: {frag.name}')
             if self.leave_last and removed.GetNumAtoms() == 0:
                 # All the remaining fragments match this pattern - leave them all
                 break
@@ -212,7 +212,7 @@ class LargestFragmentChooser(object):
         largest = None
         for f in fragments:
             smiles = Chem.MolToSmiles(f, isomericSmiles=True)
-            log.debug('Fragment: %s', smiles)
+            log.debug(f'Fragment: {smiles}')
             organic = is_organic(f)
             if self.prefer_organic:
                 # Skip this fragment if not organic and we already have an organic fragment as the largest so far
@@ -236,7 +236,7 @@ class LargestFragmentChooser(object):
             if largest and atoms == largest['atoms'] and weight == largest['weight'] and smiles > largest['smiles']:
                 continue
             # Otherwise this is the largest so far
-            log.debug('New largest fragment: %s (%s)', smiles, atoms)
+            log.debug(f'New largest fragment: {smiles} ({atoms})')
             largest = {'smiles': smiles, 'fragment': f,
                 'atoms': atoms, 'weight': weight, 'organic': organic}
         return largest['fragment']

--- a/rdkit/Chem/MolStandardize/metal.py
+++ b/rdkit/Chem/MolStandardize/metal.py
@@ -70,7 +70,6 @@ class MetalDisconnector(object):
                 atom1.SetFormalCharge(atom1.GetFormalCharge() + chg)
                 atom2 = mol.GetAtomWithIdx(j)
                 atom2.SetFormalCharge(atom2.GetFormalCharge() - chg)
-                log.info('Removed covalent bond between %s and %s',
-                         atom1.GetSymbol(), atom2.GetSymbol())
+                log.info(f'Removed covalent bond between {atom1.GetSymbol()} and {atom2.GetSymbol()}')
         Chem.SanitizeMol(mol)
         return mol

--- a/rdkit/Chem/MolStandardize/metal.py
+++ b/rdkit/Chem/MolStandardize/metal.py
@@ -53,7 +53,8 @@ class MetalDisconnector(object):
         """
         log.debug('Running MetalDisconnector')
         # Remove bonds that match SMARTS
-        for smarts in [self._metal_nof, self._metal_non]:
+        metals = (self._metal_nof, self._metal_non)
+        for smarts in metals:
             pairs = mol.GetSubstructMatches(smarts)
             rwmol = Chem.RWMol(mol)
             orders = []

--- a/rdkit/Chem/MolStandardize/normalize.py
+++ b/rdkit/Chem/MolStandardize/normalize.py
@@ -39,7 +39,7 @@ class Normalization(object):
         return AllChem.ReactionFromSmarts(str(self.transform_str))
 
     def __repr__(self):
-        return 'Normalization({!r}, {!r})'.format(self.name, self.transform_str)
+        return fr'Normalization({self.name}, {self.transform_str})'
 
     def __str__(self):
         return self.name

--- a/rdkit/Chem/MolStandardize/normalize.py
+++ b/rdkit/Chem/MolStandardize/normalize.py
@@ -39,7 +39,7 @@ class Normalization(object):
         return AllChem.ReactionFromSmarts(str(self.transform_str))
 
     def __repr__(self):
-        return fr'Normalization({self.name}, {self.transform_str})'
+        return 'Normalization({!r}, {!r})'.format(self.name, self.transform_str)
 
     def __str__(self):
         return self.name

--- a/rdkit/Chem/MolStandardize/normalize.py
+++ b/rdkit/Chem/MolStandardize/normalize.py
@@ -139,18 +139,16 @@ class Normalizer(object):
         """
 
         log.debug('Running Normalizer')
-        # Update: Aggregated normalized fragments into a single molecule according to the previous code.
-        # Step 1: Normalize each fragment separately to get around quirky RunReactants behaviour
-        # Step 2: Join normalized fragments into a single molecule again (previous intention: bottom-up)
+        # Normalize each fragment separately to get around quirky RunReactants behaviour
         NORMALIZE_FRAGMENT = self._normalize_fragment
 
-        MolFrags = Chem.GetMolFrags(mol, asMols=True)
-        outmol = NORMALIZE_FRAGMENT(MolFrags[-1])
-        for i in range(len(MolFrags) - 2, -1, -1):
-            outmol = Chem.CombineMols(outmol, NORMALIZE_FRAGMENT(MolFrags[i])) # from bottom to top
+        Fragments = Chem.GetMolFrags(mol, asMols=True)
+        outmol = NORMALIZE_FRAGMENT(Fragments[-1])
+        for i in range(len(Fragments) - 2, -1, -1):
+            outmol = Chem.CombineMols(outmol, NORMALIZE_FRAGMENT(Fragments[i]))
         Chem.SanitizeMol(outmol)
 
-        del MolFrags # Free memory
+        del Fragments # Free memory
         return outmol
 
     def _normalize_fragment(self, mol):

--- a/rdkit/Chem/MolStandardize/normalize.py
+++ b/rdkit/Chem/MolStandardize/normalize.py
@@ -29,13 +29,13 @@ class Normalization(object):
         :param string name: A name for this Normalization
         :param string transform: Reaction SMARTS to define the transformation.
         """
-        log.debug('Initializing Normalization: %s', name)
+        log.debug(f'Initializing Normalization: {name}')
         self.name = name
         self.transform_str = transform
 
     @memoized_property
     def transform(self):
-        log.debug('Loading Normalization transform: %s', self.name)
+        log.debug(f'Loading Normalization transform: {self.name}')
         return AllChem.ReactionFromSmarts(str(self.transform_str))
 
     def __repr__(self):
@@ -158,14 +158,14 @@ class Normalizer(object):
                 product = self._apply_transform(mol, normalization.transform)
                 if product:
                     # If transform changed mol, go back to first rule and apply each again
-                    log.info('Rule applied: %s', normalization.name)
+                    log.info(f'Rule applied: {normalization.name}')
                     mol = product
                     break
             else:
                 # For loop finishes normally, all applicable transforms have been applied
                 return mol
         # If we're still going after max_restarts (default 200), stop and warn, but still return the mol
-        log.warning('Gave up normalization after %s restarts', self.max_restarts)
+        log.warning(f'Gave up normalization after {self.max_restarts} restarts')
         return mol
 
     def _apply_transform(self, mol, rule):

--- a/rdkit/Chem/MolStandardize/normalize.py
+++ b/rdkit/Chem/MolStandardize/normalize.py
@@ -140,15 +140,14 @@ class Normalizer(object):
 
         log.debug('Running Normalizer')
         # Normalize each fragment separately to get around quirky RunReactants behaviour
-        NORMALIZE_FRAGMENT = self._normalize_fragment
-
-        Fragments = Chem.GetMolFrags(mol, asMols=True)
-        outmol = NORMALIZE_FRAGMENT(Fragments[-1])
-        for i in range(len(Fragments) - 2, -1, -1):
-            outmol = Chem.CombineMols(outmol, NORMALIZE_FRAGMENT(Fragments[i]))
-        Chem.SanitizeMol(outmol)
-
-        del Fragments # Free memory
+        fragments = []
+        for fragment in Chem.GetMolFrags(mol, asMols=True):
+            fragments.append(self._normalize_fragment(fragment))
+        
+        # Join normalized fragments into a single molecule again
+        outmol = fragments.pop()
+        for fragment in fragments:
+            outmol = Chem.CombineMols(outmol, fragment)
         return outmol
 
     def _normalize_fragment(self, mol):

--- a/rdkit/Chem/MolStandardize/normalize.py
+++ b/rdkit/Chem/MolStandardize/normalize.py
@@ -137,20 +137,24 @@ class Normalizer(object):
         :return: The normalized fragment.
         :rtype: :rdkit:`Mol <Chem.rdchem.Mol-class.html>`
         """
+
         log.debug('Running Normalizer')
-        # Normalize each fragment separately to get around quirky RunReactants behaviour
-        fragments = []
-        for fragment in Chem.GetMolFrags(mol, asMols=True):
-            fragments.append(self._normalize_fragment(fragment))
-        # Join normalized fragments into a single molecule again
-        outmol = fragments.pop()
-        for fragment in fragments:
-            outmol = Chem.CombineMols(outmol, fragment)
+        # Update: Aggregated normalized fragments into a single molecule according to the previous code.
+        # Step 1: Normalize each fragment separately to get around quirky RunReactants behaviour
+        # Step 2: Join normalized fragments into a single molecule again (previous intention: bottom-up)
+        NORMALIZE_FRAGMENT = self._normalize_fragment
+
+        MolFrags = Chem.GetMolFrags(mol, asMols=True)
+        outmol = NORMALIZE_FRAGMENT(MolFrags[-1])
+        for i in range(len(MolFrags) - 2, -1, -1):
+            outmol = Chem.CombineMols(outmol, NORMALIZE_FRAGMENT(MolFrags[i])) # from bottom to top
         Chem.SanitizeMol(outmol)
+
+        del MolFrags # Free memory
         return outmol
 
     def _normalize_fragment(self, mol):
-        for n in range(self.max_restarts):
+        for _ in range(self.max_restarts):
             # Iterate through Normalization transforms and apply each in order
             for normalization in self.normalizations:
                 product = self._apply_transform(mol, normalization.transform)

--- a/rdkit/Chem/MolStandardize/tautomer.py
+++ b/rdkit/Chem/MolStandardize/tautomer.py
@@ -58,7 +58,7 @@ class TautomerTransform(object):
         return Chem.MolFromSmarts(self.tautomer_str)
 
     def __repr__(self):
-        return fr'TautomerTransform({self.name}, {self.tautomer_str}, {self.bonds}, {self.charges})'
+        return 'TautomerTransform({!r}, {!r}, {!r}, {!r})'.format(self.name, self.tautomer_str, self.bonds, self.charges)
 
     def __str__(self):
         return self.name
@@ -83,7 +83,7 @@ class TautomerScore(object):
         return Chem.MolFromSmarts(self.smarts_str)
 
     def __repr__(self):
-        return fr'TautomerScore({self.name}, {self.smarts_str}, {self.score})'
+        return 'TautomerScore({!r}, {!r}, {!r})'.format(self.name, self.smarts_str, self.score)
 
     def __str__(self):
         return self.name

--- a/rdkit/Chem/MolStandardize/tautomer.py
+++ b/rdkit/Chem/MolStandardize/tautomer.py
@@ -58,7 +58,7 @@ class TautomerTransform(object):
         return Chem.MolFromSmarts(self.tautomer_str)
 
     def __repr__(self):
-        return 'TautomerTransform({!r}, {!r}, {!r}, {!r})'.format(self.name, self.tautomer_str, self.bonds, self.charges)
+        return fr'TautomerTransform({self.name}, {self.tautomer_str}, {self.bonds}, {self.charges})'
 
     def __str__(self):
         return self.name
@@ -83,7 +83,7 @@ class TautomerScore(object):
         return Chem.MolFromSmarts(self.smarts_str)
 
     def __repr__(self):
-        return 'TautomerScore({!r}, {!r}, {!r})'.format(self.name, self.smarts_str, self.score)
+        return fr'TautomerScore({self.name}, {self.smarts_str}, {self.score})'
 
     def __str__(self):
         return self.name
@@ -191,7 +191,7 @@ class TautomerCanonicalizer(object):
         highest = None
         for t in tautomers:
             smiles = Chem.MolToSmiles(t, isomericSmiles=True)
-            log.debug('Tautomer: %s', smiles)
+            log.debug(f'Tautomer: {smiles}')
             score = 0
             # Add aromatic ring scores
             ssr = Chem.GetSymmSSSR(t)
@@ -206,7 +206,7 @@ class TautomerCanonicalizer(object):
                         score += 150
             # Add SMARTS scores
             for tscore in self.scores:
-                for match in t.GetSubstructMatches(tscore.smarts):
+                for _ in t.GetSubstructMatches(tscore.smarts):
                     log.debug('Score %+d (%s)', tscore.score, tscore.name)
                     score += tscore.score
             # Add (P,S,Se,Te)-H scores
@@ -218,7 +218,7 @@ class TautomerCanonicalizer(object):
                         score -= hs
             # Set as highest if score higher or if score equal and smiles comes first alphabetically
             if not highest or highest['score'] < score or (highest['score'] == score and smiles < highest['smiles']):
-                log.debug('New highest tautomer: %s (%s)', smiles, score)
+                log.debug(f'New highest tautomer: {smiles} ({score})')
                 highest = {'smiles': smiles, 'tautomer': t, 'score': score}
         return highest['tautomer']
 
@@ -301,22 +301,22 @@ class TautomerEnumerator(object):
                         try:
                             Chem.SanitizeMol(product)
                             smiles = Chem.MolToSmiles(product, isomericSmiles=True)
-                            log.debug('Applied rule: %s to %s', transform.name, tsmiles)
+                            log.debug(f'Applied rule: {transform.name} to {tsmiles}')
                             if smiles not in tautomers:
-                                log.debug('New tautomer produced: %s' % smiles)
+                                log.debug(f'New tautomer produced: {smiles}')
                                 kekulized_product = copy.deepcopy(product)
                                 Chem.Kekulize(kekulized_product)
                                 tautomers[smiles] = product
                                 kekulized[smiles] = kekulized_product
                             else:
-                                log.debug('Previous tautomer produced again: %s' % smiles)
+                                log.debug(f'Previous tautomer produced again: {smiles}')
                         except ValueError:
-                            log.debug('ValueError Applying rule: %s', transform.name)
+                            log.debug(f'ValueError Applying rule: {transform.name}')
                 done.add(tsmiles)
             if len(tautomers) == len(done):
                 break
         else:
-            log.warning('Tautomer enumeration stopped at maximum %s', self.max_tautomers)
+            log.warning(f'Tautomer enumeration stopped at maximum {self.max_tautomers}')
         # Clean up stereochemistry
         for tautomer in tautomers.values():
             Chem.AssignStereochemistry(tautomer, force=True, cleanIt=True)

--- a/rdkit/Chem/MolStandardize/utils.py
+++ b/rdkit/Chem/MolStandardize/utils.py
@@ -16,7 +16,7 @@ from itertools import tee
 
 def memoized_property(fget):
     """Decorator to create memoized properties."""
-    attr_name = '_{}'.format(fget.__name__)
+    attr_name = f'_{fget.__name__}'
 
     @functools.wraps(fget)
     def fget_memoized(self):

--- a/rdkit/Chem/MolStandardize/validations.py
+++ b/rdkit/Chem/MolStandardize/validations.py
@@ -133,7 +133,7 @@ class FragmentValidation(Validation):
             matches = frozenset(frozenset(match) for match in mol.GetSubstructMatches(fp.smarts))
             fragments = frozenset(frozenset(frag) for frag in Chem.GetMolFrags(mol))
             if matches & fragments:
-                self.log.info('%s is present', fp.name)
+                self.log.info(f'{fp.name} is present', )
 
 
 class NeutralValidation(Validation):
@@ -143,7 +143,7 @@ class NeutralValidation(Validation):
         charge = Chem.GetFormalCharge(mol)
         if not charge == 0:
             chargestring = '+%s' % charge if charge > 0 else '%s' % charge
-            self.log.info('Not an overall neutral system (%s)', chargestring)
+            self.log.info(f'Not an overall neutral system ({chargestring})')
 
 
 class IsotopeValidation(Validation):
@@ -154,9 +154,9 @@ class IsotopeValidation(Validation):
         for atom in mol.GetAtoms():
             isotope = atom.GetIsotope()
             if not isotope == 0:
-                isotopes.add('%s%s' % (isotope, atom.GetSymbol()))
+                isotopes.add(f'{isotope}{atom.GetSymbol()}')
         for isotope in isotopes:
-            self.log.info('Molecule contains isotope %s', isotope)
+            self.log.info(f'Molecule contains isotope {isotope}')
 
 
 #: The default list of :class:`Validations <molvs.validations.Validation>` used by :class:`~molvs.validate.Validator`.

--- a/rdkit/Chem/MolStandardize/validations.py
+++ b/rdkit/Chem/MolStandardize/validations.py
@@ -204,4 +204,3 @@ VALIDATIONS = (
 
 # People can define a filterer
 # This has a series of validations, and the required output - e.g. no error or no warns?
-


### PR DESCRIPTION
This is the sub-PR breaking from the large PR 4815: https://github.com/rdkit/rdkit/pull/4815

----------------
Changes:
- [Remark]: In charge.py, the method in line 245 and 255 seems redundant. I has dropped it and no issue raised
- [Remark]: Method `normalize()` in `normalize.py`  is relatively weird due to the excessive use of list. This patch is to correct the method and free some unused memory. No speed-boost here.