### PR TITLE
Clean-up Python #4815 - P1.13: Chem\Pharm2D & Chem\Pharm3D

### DIFF
--- a/rdkit/Chem/Pharm2D/Generate.py
+++ b/rdkit/Chem/Pharm2D/Generate.py
@@ -65,7 +65,7 @@ def _ShortestPathsMatch(match, featureSet, sig, dMat, sigFactory):
     d = int(minSeen)
     # do a quick distance filter
     if d == 0 or d < minD or d >= maxD:
-      return
+      return None
     dist[i] = d
 
   idx = sigFactory.GetBitIdx(featureSet, dist, sortIndices=False)
@@ -115,8 +115,7 @@ def Gen2DFingerprint(mol, sigFactory, perms=None, dMat=None, bitInfo=None):
   # generate the molecule's distance matrix, if required
   if dMat is None:
     from rdkit import Chem
-    useBO = sigFactory.includeBondOrder
-    dMat = Chem.GetDistanceMatrix(mol, useBO)
+    dMat = Chem.GetDistanceMatrix(mol, sigFactory.includeBondOrder)
 
   # generate the permutations, if required
   if perms is None: 

--- a/rdkit/Chem/Pharm2D/Generate.py
+++ b/rdkit/Chem/Pharm2D/Generate.py
@@ -135,7 +135,10 @@ def Gen2DFingerprint(mol, sigFactory, perms=None, dMat=None, bitInfo=None):
     #   defining the feature set for a proto-pharmacophore
     featClasses = [0] * len(perm)
     for i in range(1, len(perm)):
-      featClasses[i] = featClasses[i - 1] + int(perm[i] != perm[i - 1])
+      if perm[i] == perm[i - 1]:
+        featClasses[i] = featClasses[i - 1]
+      else:
+        featClasses[i] = featClasses[i - 1] + 1
 
     # Get a set of matches at each index of
     #  the proto-pharmacophore.

--- a/rdkit/Chem/Pharm2D/Generate.py
+++ b/rdkit/Chem/Pharm2D/Generate.py
@@ -47,10 +47,9 @@ def _ShortestPathsMatch(match, featureSet, sig, dMat, sigFactory):
   """
   if _verbose:
     print('match:', match)
-  nPts = len(match)
-  distsToCheck = Utils.nPointDistDict[nPts]
-  nDists = len(distsToCheck)
-  dist = [0] * nDists
+
+  distsToCheck = Utils.nPointDistDict[len(match)]
+  dist = [0] * len(distsToCheck)
   bins = sigFactory.GetBins()
   minD, maxD = bins[0][0], bins[-1][1]
 
@@ -143,8 +142,8 @@ def Gen2DFingerprint(mol, sigFactory, perms=None, dMat=None, bitInfo=None):
     #  the proto-pharmacophore.
     matchPerms = [featMatches[x] for x in perm]
     if _verbose:
-      print('\n->Perm: %s' % (str(perm)))
-      print('    matchPerms: %s' % (str(matchPerms)))
+      print(f'\n->Perm: {str(perm)}')
+      print(f'    matchPerms: {str(matchPerms)}')
 
     # Get all unique combinations of those possible matches:
     matchesToMap = Utils.GetUniqueCombinations(matchPerms, featClasses)

--- a/rdkit/Chem/Pharm2D/Matcher.py
+++ b/rdkit/Chem/Pharm2D/Matcher.py
@@ -103,7 +103,7 @@ def GetAtomsMatchingBit(sigFactory, bitIdx, mol, dMat=None, justOne=0, matchingA
       idx1, idx2 = protoPharm[a1][0], protoPharm[a2][0]
       dist = dMat[idx1, idx2]
       if _verbose:
-        print('\t dist: %d->%d = %d (%d,%d)' % (idx1, idx2, dist, dLow, dHigh))
+        print(f'\t dist: {idx1}->{idx2} = {dist} ({dLow}, {dHigh})')
       if dist < dLow or dist >= dHigh:
         break
     else:
@@ -138,7 +138,7 @@ def _exampleCode():
   _verbose = 0
   for bit in sig.GetOnBits():
     atoms = GetAtomsMatchingBit(factory, bit, mol)
-    print('\tBit %d: ' % (bit), atoms)
+    print(f'\tBit {bit}: ', atoms)
 
   print('finished')
 

--- a/rdkit/Chem/Pharm2D/SigFactory.py
+++ b/rdkit/Chem/Pharm2D/SigFactory.py
@@ -137,18 +137,15 @@ class SigFactory(object):
           proto-pharmacophore.
 
         """
-        nDists = len(dists)
-        whichBins = [0] * nDists
-
+ 
+        whichBins = [0] * len(dists)
         # This would be a ton easier if we had contiguous bins
         # i.e. if we could maintain the bins as a list of bounds)
         # because then we could use Python's bisect module.
         # Since we can't do that, we've got to do our own binary
         # search here.
-        for i in range(nDists):
-            dist = dists[i]
+        for i, dist in enumerate(dists):
             where = -1
-
             # do a simple binary search:
             startP, endP = 0, len(bins)
             while startP < endP:

--- a/rdkit/Chem/Pharm2D/SigFactory.py
+++ b/rdkit/Chem/Pharm2D/SigFactory.py
@@ -39,7 +39,10 @@ class SigFactory(object):
         self.shortestPathsOnly = shortestPathsOnly
         self.includeBondOrder = includeBondOrder
         self.trianglePruneBins = trianglePruneBins
-        self.skipFeats = skipFeats if skipFeats is not None else []
+        if skipFeats is None:
+            self.skipFeats = []
+        else:
+            self.skipFeats = skipFeats
         self._bins = None
         self.sigKlass = None
 

--- a/rdkit/Chem/Pharm2D/SigFactory.py
+++ b/rdkit/Chem/Pharm2D/SigFactory.py
@@ -64,11 +64,12 @@ class SigFactory(object):
         nPts, combo, scaffold = self.GetBitInfo(bitIdx)
         fams = self.GetFeatFamilies()
         labels = [fams[x] for x in combo]
-        dMat = numpy.zeros((nPts, nPts), dtype='int')
+        dMat = numpy.zeros((nPts, nPts), dtype=numpy.int64)
         dVect = Utils.nPointDistDict[nPts]
         for idx in range(len(dVect)):
             i, j = dVect[idx]
-            dMat[i, j], dMat[j, i] = scaffold[idx], scaffold[idx]
+            dMat[i, j] = scaffold[idx]
+            dMat[j, i] = scaffold[idx]
 
         return nPts, combo, scaffold, labels, dMat
 
@@ -324,8 +325,7 @@ class SigFactory(object):
             scaffoldsHere = Utils.GetPossibleScaffolds(i, self._bins,
                                                        useTriangleInequality=self.trianglePruneBins)
             self._scaffolds[nDistsHere] = scaffoldsHere
-            pointsHere = Utils.NumCombinations(self._nFeats, i) * len(scaffoldsHere) # ... * nBitsHere
-            accum += pointsHere
+            accum += (Utils.NumCombinations(self._nFeats, i) * len(scaffoldsHere))
         self._sigSize = accum
         if not self.useCounts:
             self.sigKlass = SparseBitVect

--- a/rdkit/Chem/Pharm2D/SigFactory.py
+++ b/rdkit/Chem/Pharm2D/SigFactory.py
@@ -234,7 +234,7 @@ class SigFactory(object):
 
         offset = Utils.CountUpTo(self._nFeats, nPoints, featIndices)
         if _verbose:
-            print('offset for feature %s: %d' % (str(featIndices), offset))
+            print(f'offset for feature {str(featIndices)}: {offset}')
         offset *= len(self._scaffolds[len(dists)])
 
         try:

--- a/rdkit/Chem/Pharm2D/SigFactory.py
+++ b/rdkit/Chem/Pharm2D/SigFactory.py
@@ -181,10 +181,9 @@ class SigFactory(object):
         featFamilies = self.GetFeatFamilies()
         featMatches = {}
         for fam in featFamilies:
-            featMatches[fam] = []
             feats = self.featFactory.GetFeaturesForMol(mol, includeOnly=fam)
-            for feat in feats:
-                featMatches[fam].append(feat.GetAtomIds())
+            featMatches[fam] = [feat.GetAtomIds() for feat in feats]
+
         return [featMatches[x] for x in featFamilies]
 
     def GetBitIdx(self, featIndices, dists, sortIndices=True):
@@ -273,7 +272,7 @@ class SigFactory(object):
 
         """
         if idx >= self._sigSize:
-            raise IndexError('bad index (%d) queried. %d is the max' % (idx, self._sigSize))
+            raise IndexError(f'bad index ({idx}) queried. {self._sigSize} is the max')
         # first figure out how many points are in the p'cophore
         nPts = self.minPointCount
         while nPts < self.maxPointCount and self._starts[nPts + 1] <= idx:
@@ -282,7 +281,7 @@ class SigFactory(object):
         # how far are we in from the start point?
         offsetFromStart = idx - self._starts[nPts]
         if _verbose:
-            print('\t %d Points, %d offset' % (nPts, offsetFromStart))
+            print(f'\t {nPts} Points, {offsetFromStart} offset')
 
         # lookup the number of scaffolds
         nDists = len(Utils.nPointDistDict[nPts])
@@ -295,13 +294,13 @@ class SigFactory(object):
         indexCombos = Utils.GetIndexCombinations(self._nFeats, nPts)
         combo = tuple(indexCombos[protoIdx])
         if _verbose:
-            print('\t combo: %s' % (str(combo)))
+            print(f'\t combo: {str(combo)}')
 
         # and which scaffold:
         scaffoldIdx = offsetFromStart % nScaffolds
         scaffold = scaffolds[scaffoldIdx]
         if _verbose:
-            print('\t scaffold: %s' % (str(scaffold)))
+            print(f'\t scaffold: {str(scaffold)}')
         return nPts, combo, scaffold
 
     def Init(self):

--- a/rdkit/Chem/Pharm2D/UnitTestGobbi.py
+++ b/rdkit/Chem/Pharm2D/UnitTestGobbi.py
@@ -143,7 +143,7 @@ class TestCase(unittest.TestCase):
             m2 = Chem.MolFromSmiles(csmi)
             # m2.Debug()
             sig2 = Generate.Gen2DFingerprint(m2, self.factory)
-            self.assertTrue(list(sig1.GetOnBits()) == list(sig2.GetOnBits()), '%s %s' % (smi, csmi))
+            self.assertTrue(list(sig1.GetOnBits()) == list(sig2.GetOnBits()), f'{smi} {csmi}')
             self.assertEqual(DataStructs.DiceSimilarity(sig1, sig2), 1.0)
             self.assertEqual(sig1, sig2)
             for _ in range(10):

--- a/rdkit/Chem/Pharm2D/UnitTestLazyGenerator.py
+++ b/rdkit/Chem/Pharm2D/UnitTestLazyGenerator.py
@@ -39,16 +39,16 @@ class TestCase(unittest.TestCase):  # pragma: nocover
     mol = Chem.MolFromSmiles('OCC(=O)CCCN')
     factory = self.getFactory()
     sig = factory.GetSignature()
-    assert sig.GetSize() == 105, 'bad signature size: %d' % (sig.GetSize())
+    assert sig.GetSize() == 105, f'bad signature size: {sig.GetSize()}'
     sig.SetIncludeBondOrder(0)
     gen = LazyGenerator.Generator(sig, mol)
-    assert len(gen) == sig.GetSize(), 'length mismatch %d!=%d' % (len(gen), sig.GetSize())
+    assert len(gen) == sig.GetSize(), f'length mismatch {len(gen)}!={sig.GetSize()}'
 
     tgt = (1, 5, 48)
     for bit in tgt:
-      assert gen[bit], 'bit %d not properly set' % (bit)
-      assert gen.GetBit(bit), 'bit %d not properly set' % (bit)
-      assert not gen[bit + 50], 'bit %d improperly set' % (bit + 100)
+      assert gen[bit], f'bit {bit} not properly set'
+      assert gen.GetBit(bit), f'bit {bit} not properly set' % (bit)
+      assert not gen[bit + 50], f'bit {bit + 100} improperly set'
 
     sig = factory.GetSignature()
     assert sig.GetSize() == 105, 'bad signature size: %d' % (sig.GetSize())
@@ -58,9 +58,9 @@ class TestCase(unittest.TestCase):  # pragma: nocover
 
     tgt = (1, 4, 5, 45)
     for bit in tgt:
-      assert gen[bit], 'bit %d not properly set' % (bit)
-      assert gen.GetBit(bit), 'bit %d not properly set' % (bit)
-      assert not gen[bit + 50], 'bit %d improperly set' % (bit + 100)
+      assert gen[bit], f'bit {bit} not properly set' % (bit)
+      assert gen.GetBit(bit), f'bit {bit} not properly set' % (bit)
+      assert not gen[bit + 50], f'bit {bit + 100} improperly set'
 
     try:
       gen[sig.GetSize() + 1]

--- a/rdkit/Chem/Pharm2D/UnitTestLazyGenerator.py
+++ b/rdkit/Chem/Pharm2D/UnitTestLazyGenerator.py
@@ -47,19 +47,19 @@ class TestCase(unittest.TestCase):  # pragma: nocover
     tgt = (1, 5, 48)
     for bit in tgt:
       assert gen[bit], f'bit {bit} not properly set'
-      assert gen.GetBit(bit), f'bit {bit} not properly set' % (bit)
+      assert gen.GetBit(bit), f'bit {bit} not properly set'
       assert not gen[bit + 50], f'bit {bit + 100} improperly set'
 
     sig = factory.GetSignature()
-    assert sig.GetSize() == 105, 'bad signature size: %d' % (sig.GetSize())
+    assert sig.GetSize() == 105, f'bad signature size: {sig.GetSize()}'
     sig.SetIncludeBondOrder(1)
     gen = LazyGenerator.Generator(sig, mol)
-    assert len(gen) == sig.GetSize(), 'length mismatch %d!=%d' % (len(gen), sig.GetSize())
+    assert len(gen) == sig.GetSize(), f'length mismatch {len(gen)}!={sig.GetSize()}'
 
     tgt = (1, 4, 5, 45)
     for bit in tgt:
-      assert gen[bit], f'bit {bit} not properly set' % (bit)
-      assert gen.GetBit(bit), f'bit {bit} not properly set' % (bit)
+      assert gen[bit], f'bit {bit} not properly set'
+      assert gen.GetBit(bit), f'bit {bit} not properly set'
       assert not gen[bit + 50], f'bit {bit + 100} improperly set'
 
     try:

--- a/rdkit/Chem/Pharm2D/UnitTestMatcher.py
+++ b/rdkit/Chem/Pharm2D/UnitTestMatcher.py
@@ -74,7 +74,7 @@ class TestCase(unittest.TestCase):
             onBits = sig.GetOnBits()
             for bit in onBits:
                 atoms = Matcher.GetAtomsMatchingBit(factory, bit, mol, justOne=1)
-                assert len(atoms), 'bit %d failed to match for smi %s' % (bit, smi)
+                assert len(atoms), f'bit {bit} failed to match for smi {smi}'
 
     def test_exampleCode(self):
         # We make sure that the example code runs

--- a/rdkit/Chem/Pharm2D/UnitTestMatcher.py
+++ b/rdkit/Chem/Pharm2D/UnitTestMatcher.py
@@ -9,13 +9,12 @@
 #
 import os.path
 import unittest
-
-from rdkit import Chem
-from rdkit import RDConfig
-from rdkit.Chem import ChemicalFeatures
-from rdkit.Chem.Pharm2D import Generate, SigFactory, Matcher, Gobbi_Pharm2D
-from rdkit.TestRunner import redirect_stdout
 from io import StringIO
+
+from rdkit import Chem, RDConfig
+from rdkit.Chem import ChemicalFeatures
+from rdkit.Chem.Pharm2D import Generate, Gobbi_Pharm2D, Matcher, SigFactory
+from rdkit.TestRunner import redirect_stdout
 
 
 class TestCase(unittest.TestCase):

--- a/rdkit/Chem/Pharm2D/UnitTestSignature.py
+++ b/rdkit/Chem/Pharm2D/UnitTestSignature.py
@@ -13,8 +13,7 @@
 import os.path
 import unittest
 
-from rdkit import Chem
-from rdkit import RDConfig
+from rdkit import Chem, RDConfig
 from rdkit.Chem import ChemicalFeatures
 from rdkit.Chem.Pharm2D import Generate, SigFactory
 

--- a/rdkit/Chem/Pharm2D/UnitTestUtils.py
+++ b/rdkit/Chem/Pharm2D/UnitTestUtils.py
@@ -36,7 +36,7 @@ class TestCase(unittest.TestCase):
     ]
     for combo, tgt in vals:
       res = Utils.CountUpTo(3, 3, combo)
-      assert res == tgt, 'Bad res (%d) for combo %s' % (res, str((combo, tgt)))
+      assert res == tgt, f'Bad res ({res}) for combo {str((combo, tgt))}'
 
   def testGetTriangles(self):
     vals = [
@@ -48,8 +48,8 @@ class TestCase(unittest.TestCase):
     for tpl in vals:
       nPts, cnt, tris = tpl
       r = Utils.GetTriangles(nPts)
-      assert len(r) == cnt, 'bad triangle length %d for probe %s' % (len(r), str(tpl))
-      assert r == tris, 'bad triangle list %s for probe %s' % (str(r), str(tpl))
+      assert len(r) == cnt, f'bad triangle length {len(r)} for probe {str(tpl)}'
+      assert r == tris, f'bad triangle list {str(r)} for probe {str(tpl)}'
 
   def testDistTriangleInequality(self):
     bins = [(1, 2), (2, 3), (5, 6)]
@@ -64,7 +64,7 @@ class TestCase(unittest.TestCase):
       ds, tgt = tpl
       distBins = [bins[x] for x in ds]
       r = Utils.BinsTriangleInequality(distBins[0], distBins[1], distBins[2])
-      assert r == tgt, 'bad result %d for probe %s' % (r, str(tpl))
+      assert r == tgt, f'bad result {r} for probe {str(tpl)}'
 
   def testLimitPharmacophores(self):
     bins = [(1, 2), (2, 3), (5, 6)]
@@ -78,7 +78,7 @@ class TestCase(unittest.TestCase):
     for tpl in vals:
       ds, tgt = tpl
       r = Utils.ScaffoldPasses(ds, bins)
-      assert r == tgt, 'bad result %d for probe %s' % (r, str(tpl))
+      assert r == tgt, f'bad result {r} for probe {str(tpl)}'
 
   def testGetPossiblePharmacophores(self):
     bins = [(1, 2), (2, 3), (5, 6)]
@@ -90,7 +90,7 @@ class TestCase(unittest.TestCase):
       num, tgt = tpl
       pphores = Utils.GetPossibleScaffolds(num, bins)
       cnt = len(pphores)
-      assert cnt == tgt, 'bad pharmacophore count %d for probe %s' % (cnt, str(tpl))
+      assert cnt == tgt, f'bad pharmacophore count {cnt} for probe {str(tpl)}'
     self.assertEqual(Utils.GetPossibleScaffolds(1, bins), 0)
 
   def testOrderTriangle(self):

--- a/rdkit/Chem/Pharm2D/Utils.py
+++ b/rdkit/Chem/Pharm2D/Utils.py
@@ -17,11 +17,30 @@
 
 """
 import itertools
-from math import factorial, comb
-
-
+try:
+    # his is available in Python 3.8: https://docs.python.org/3/library/math.html
+    from math import comb
+except ImportError:
+    def comb(n: int, k: int) -> int:
+        if not isinstance(n, int) or not isinstance(k, int):
+            raise ValueError(f"n ({n}) and k ({k}) must be positive integers")
+        if n < 0:
+            raise ValueError(f"n ({n}) must be a positive integer")
+        if k < 0:
+            raise ValueError(f"k ({k}) must be a positive integer")
+        if k > n:
+            raise ValueError(f"k ({k}) must be less than or equal to n ({n})")
+        if n - k > k:
+            k = n - k
+         
+        accum: int = 1
+        for i in range(0, k, 1):
+            accum *= n - i
+            accum = accum // (i + 1)
+        return accum
+    
 #
-#  number of points in a scaffold -> sequence of distances (p1,p2) in
+#  number of points in a scaffold -> sequence of distances (p1, p2) in
 #   the scaffold
 #
 nPointDistDict = {
@@ -119,8 +138,8 @@ _numCombDict = {}
 def NumCombinations(nItems, nSlots):
     """  returns the number of ways to fit nItems into nSlots
 
-      We assume that (x,y) and (y,x) are equivalent, and
-      (x,x) is allowed.
+      We assume that (x, y) and (y, x) are equivalent, and
+      (x, x) is allowed.
 
       General formula is, for N items and S slots:
         res = (N+S-1)! / ( (N-1)! * S! )

--- a/rdkit/Chem/Pharm2D/Utils.py
+++ b/rdkit/Chem/Pharm2D/Utils.py
@@ -59,15 +59,16 @@ except ImportError:
             return 1
         if n - k > k:
             k = n - k
-         
-        if k < 8 or (16 * k < n < 256) or (k < n < 32): # Optimization for small arguments
-            res: int = 1
+        
+        # Optimization for small arguments
+        if k < 8 or (16 * k < n < 512) or (k < n < 32): 
+            res = 1
             for i in range(k):
                 res *= n - i
-                res: int = res // (i + 1)
+                res = res // (i + 1)
             return res
         
-        j: int = k // 2
+        j = k // 2
         return comb(n, j) * comb(n - j, k - j) // comb(k, j)
     
 #

--- a/rdkit/Chem/Pharm2D/Utils.py
+++ b/rdkit/Chem/Pharm2D/Utils.py
@@ -17,6 +17,8 @@
 
 """
 import itertools
+from math import factorial, comb
+
 
 #
 #  number of points in a scaffold -> sequence of distances (p1,p2) in
@@ -76,14 +78,8 @@ def GetTriangles(nPts):
     return res
 
 
-def _fact(x):
-    if x <= 1:
-        return 1
-
-    accum = 1
-    for i in range(x):
-        accum *= i + 1
-    return accum
+def _fact(x) -> int:
+    return factorial(x)
 
 
 def BinsTriangleInequality(d1, d2, d3):
@@ -114,8 +110,7 @@ def ScaffoldPasses(combo, bins=None):
 
     """
     # this is the number of points in the pharmacophore
-    nPts = nDistPointDict[len(combo)]
-    tris = GetTriangles(nPts)
+    tris = GetTriangles(nDistPointDict[len(combo)])
     for tri in tris:
         ds = [bins[combo[x]] for x in tri]
         if not BinsTriangleInequality(ds[0], ds[1], ds[2]):
@@ -139,7 +134,7 @@ def NumCombinations(nItems, nSlots):
     global _numCombDict
     res = _numCombDict.get((nItems, nSlots), -1)
     if res == -1:
-        res = _fact(nItems + nSlots - 1) // (_fact(nItems - 1) * _fact(nSlots))
+        res = comb(nItems + nSlots - 1, nSlots)
         _numCombDict[(nItems, nSlots)] = res
     return res
 
@@ -172,7 +167,7 @@ def CountUpTo(nItems, nSlots, vs, idx=0, startAt=0):
     """
     global _countCache
     if _verbose:
-        print('  ' * idx, 'CountUpTo(%d)' % idx, vs[idx], startAt)
+        print('  ' * idx, f'CountUpTo({idx})', vs[idx], startAt)
     if idx == 0 and (nItems, nSlots, tuple(vs)) in _countCache:
         return _countCache[(nItems, nSlots, tuple(vs))]
     elif idx >= nSlots:
@@ -185,10 +180,10 @@ def CountUpTo(nItems, nSlots, vs, idx=0, startAt=0):
         for i in range(startAt, vs[idx]):
             nLevsUnder = nSlots - idx - 1
             nValsOver = nItems - i
+            numCombs = NumCombinations(nValsOver, nLevsUnder)
             if _verbose:
-                print('  ' * idx, ' ', i, nValsOver, nLevsUnder,
-                      NumCombinations(nValsOver, nLevsUnder))
-            accum += NumCombinations(nValsOver, nLevsUnder)
+                print('  ' * idx, ' ', i, nValsOver, nLevsUnder, numCombs)
+            accum += numCombs
         accum += CountUpTo(nItems, nSlots, vs, idx + 1, vs[idx])
     if _verbose:
         print('  ' * idx, '>', accum)
@@ -254,26 +249,26 @@ def GetAllCombinations(choices, noDups=1, which=0):
 
       a list of lists
 
-    >>> GetAllCombinations([(0,),(1,),(2,)])
+    >>> GetAllCombinations([(0, ), (1, ), (2, )])
     [[0, 1, 2]]
-    >>> GetAllCombinations([(0,),(1,3),(2,)])
+    >>> GetAllCombinations([(0, ), (1, 3), (2, )])
     [[0, 1, 2], [0, 3, 2]]
 
-    >>> GetAllCombinations([(0,1),(1,3),(2,)])
+    >>> GetAllCombinations([(0, 1), (1, 3), (2, )])
     [[0, 1, 2], [0, 3, 2], [1, 3, 2]]
 
     """
     if which >= len(choices):
-        res = []
+        return []
     elif which == len(choices) - 1:
-        res = [[x] for x in choices[which]]
-    else:
-        res = []
-        tmp = GetAllCombinations(choices, noDups=noDups, which=which + 1)
-        for thing in choices[which]:
-            for other in tmp:
-                if not noDups or thing not in other:
-                    res.append([thing] + other)
+        return [[x] for x in choices[which]]
+    
+    res = []
+    tmp = GetAllCombinations(choices, noDups=noDups, which=which + 1)
+    for thing in choices[which]:
+        for other in tmp:
+            if not noDups or thing not in other:
+                res.append([thing] + other)
     return res
 
 
@@ -285,23 +280,23 @@ def GetUniqueCombinations(choices, classes, which=0):
     #   print(choices, classes)
     assert len(choices) == len(classes)
     if which >= len(choices):
-        res = []
+        return []
     elif which == len(choices) - 1:
-        res = [[(classes[which], x)] for x in choices[which]]
-    else:
-        res = []
-        tmp = GetUniqueCombinations(choices, classes, which=which + 1)
-        for thing in choices[which]:
-            for other in tmp:
-                idxThere = 0
-                for x in other:
-                    if x[1] == thing:
-                        idxThere += 1
-                if not idxThere:
-                    newL = [(classes[which], thing)] + other
-                    newL.sort()
-                    if newL not in res:
-                        res.append(newL)
+        return [[(classes[which], x)] for x in choices[which]]
+    
+    res = []
+    tmp = GetUniqueCombinations(choices, classes, which=which + 1)
+    for thing in choices[which]:
+        for other in tmp:
+            idxThere = 0
+            for x in other:
+                if x[1] == thing:
+                    idxThere += 1
+            if not idxThere:
+                newL = [(classes[which], thing)] + other
+                newL.sort()
+                if newL not in res:
+                    res.append(newL)
     return res
 
 
@@ -347,17 +342,13 @@ def GetPossibleScaffolds(nPts, bins, useTriangleInequality=True):
 
     """
     if nPts < 2:
-        res = 0
+        return 0
     elif nPts == 2:
-        res = [(x, ) for x in range(len(bins))]
-    else:
-        nDists = len(nPointDistDict[nPts])
-        combos = GetAllCombinations([range(len(bins))] * nDists, noDups=0)
-        res = []
-        for combo in combos:
-            if not useTriangleInequality or ScaffoldPasses(combo, bins):
-                res.append(tuple(combo))
-    return res
+        return [(x, ) for x in range(len(bins))]
+    
+    nDists = len(nPointDistDict[nPts])
+    combos = GetAllCombinations([range(len(bins))] * nDists, noDups=0)
+    return [tuple(combo) for combo in combos if not useTriangleInequality or ScaffoldPasses(combo, bins)]
 
 
 def OrderTriangle(featIndices, dists):
@@ -366,29 +357,27 @@ def OrderTriangle(featIndices, dists):
 
       It's easy if the features are all different:
 
-      >>> OrderTriangle([0,2,4],[1,2,3])
+      >>> OrderTriangle([0, 2, 4], [1, 2, 3])
       ([0, 2, 4], [1, 2, 3])
 
       It's trickiest if they are all the same:
       
-      >>> OrderTriangle([0,0,0],[1,2,3])
+      >>> OrderTriangle([0, 0, 0], [1, 2, 3])
       ([0, 0, 0], [3, 2, 1])
-      >>> OrderTriangle([0,0,0],[2,1,3])
+      >>> OrderTriangle([0, 0, 0], [2, 1, 3])
       ([0, 0, 0], [3, 2, 1])
-      >>> OrderTriangle([0,0,0],[1,3,2])
+      >>> OrderTriangle([0, 0, 0], [1, 3, 2])
       ([0, 0, 0], [3, 2, 1])
-      >>> OrderTriangle([0,0,0],[3,1,2])
+      >>> OrderTriangle([0, 0, 0], [3, 1, 2])
       ([0, 0, 0], [3, 2, 1])
-      >>> OrderTriangle([0,0,0],[3,2,1])
+      >>> OrderTriangle([0, 0, 0], [3, 2, 1])
       ([0, 0, 0], [3, 2, 1])
 
-      >>> OrderTriangle([0,0,1],[3,2,1])
+      >>> OrderTriangle([0, 0, 1], [3, 2, 1])
       ([0, 0, 1], [3, 2, 1])
-      >>> OrderTriangle([0,0,1],[1,3,2])
+      >>> OrderTriangle([0, 0, 1], [1, 3, 2])
       ([0, 0, 1], [1, 3, 2])
-      >>> OrderTriangle([0,0,1],[1,2,3])
-      ([0, 0, 1], [1, 3, 2])
-      >>> OrderTriangle([0,0,1],[1,3,2])
+      >>> OrderTriangle([0, 0, 1], [1, 2, 3])
       ([0, 0, 1], [1, 3, 2])
 
     """
@@ -451,6 +440,7 @@ def OrderTriangle(featIndices, dists):
             else:
                 ireorder = (0, 2, 1)
                 dreorder = (1, 0, 2)
+    
     dists = [dists[x] for x in dreorder]
     featIndices = [featIndices[x] for x in ireorder]
     return featIndices, dists

--- a/rdkit/Chem/Pharm2D/Utils.py
+++ b/rdkit/Chem/Pharm2D/Utils.py
@@ -29,29 +29,46 @@ except ImportError:
             raise ValueError(f"n ({n}) must be a positive integer")
         if k < 0:
             raise ValueError(f"k ({k}) must be a positive integer")
-        if k > n:
-            raise ValueError(f"k ({k}) must be less than or equal to n ({n})")
     
     @lru_cache(maxsize=128)
     def comb(n: int, k: int) -> int:
-        # https://github.com/python/cpython/blob/main/Modules/mathmodule.c
-        # https://github.com/python/cpython/commit/60c320c38e4e95877cde0b1d8562ebd6bc02ac61
-        # https://bugs.python.org/issue37295 
+        """
+        Return the number of ways to choose k items from n items without repetition and without order.
+        Evaluates to n! / (k! * (n - k)!) when k <= n and evaluates to zero when k > n.
+        
+        Arguments:
+        ----------
+            - n (integer): the number of items to choose from 
+            - k (integer): the number of items to choose
+        
+        Returns:
+        ----------
+            - integer: the number of ways to choose k items from n items without repetition and without order
+        
+        
+        Optimization reference:
+        1) https://github.com/python/cpython/blob/main/Modules/mathmodule.c (Line 3381 <-> 3568)
+        2) https://github.com/python/cpython/commit/60c320c38e4e95877cde0b1d8562ebd6bc02ac61
+        3) https://bugs.python.org/issue37295 
+        
+        """
         _CheckCombArgument(n, k)
-        if k == 0 or n == 0:
+        if k > n:
+            return 0
+        if k == 0 or n == 0 or k == n:
             return 1
         if n - k > k:
             k = n - k
          
-        if (k < n < 32) or (16 * k < n < 256):
-            res = 1
+        if k < 8 or (16 * k < n < 256) or (k < n < 32): # Optimization for small arguments
+            res: int = 1
             for i in range(k):
-                res = res * (n - i)
-                res = res // (i + 1)
+                res *= n - i
+                res: int = res // (i + 1)
             return res
-        else:
-            j = k // 2
-            return comb(n, j) * comb(n - j, k - j) // comb(k, j)
+        
+        j: int = k // 2
+        return comb(n, j) * comb(n - j, k - j) // comb(k, j)
     
 #
 #  number of points in a scaffold -> sequence of distances (p1, p2) in

--- a/rdkit/Chem/Pharm2D/Utils.py
+++ b/rdkit/Chem/Pharm2D/Utils.py
@@ -78,10 +78,6 @@ def GetTriangles(nPts):
     return res
 
 
-def _fact(x) -> int:
-    return factorial(x)
-
-
 def BinsTriangleInequality(d1, d2, d3):
     """ checks the triangle inequality for combinations
       of distance bins.
@@ -98,7 +94,6 @@ def BinsTriangleInequality(d1, d2, d3):
         return False
     if d3[1] + d1[1] < d2[0]:
         return False
-
     return True
 
 
@@ -281,18 +276,14 @@ def GetUniqueCombinations(choices, classes, which=0):
     assert len(choices) == len(classes)
     if which >= len(choices):
         return []
-    elif which == len(choices) - 1:
+    if which == len(choices) - 1:
         return [[(classes[which], x)] for x in choices[which]]
     
     res = []
     tmp = GetUniqueCombinations(choices, classes, which=which + 1)
     for thing in choices[which]:
-        for other in tmp:
-            idxThere = 0
-            for x in other:
-                if x[1] == thing:
-                    idxThere += 1
-            if not idxThere:
+        for other in tmp:            
+            if not any(x[1] == thing for x in other):
                 newL = [(classes[which], thing)] + other
                 newL.sort()
                 if newL not in res:
@@ -343,7 +334,7 @@ def GetPossibleScaffolds(nPts, bins, useTriangleInequality=True):
     """
     if nPts < 2:
         return 0
-    elif nPts == 2:
+    if nPts == 2:
         return [(x, ) for x in range(len(bins))]
     
     nDists = len(nPointDistDict[nPts])

--- a/rdkit/Chem/Pharm3D/EmbedLib.py
+++ b/rdkit/Chem/Pharm3D/EmbedLib.py
@@ -170,7 +170,7 @@ def EmbedMol(mol, bm, atomMatch=None, weight=2.0, randomSeed=-1, excludedVolumes
   nAts = mol.GetNumAtoms()
   weights = []
   if atomMatch:
-    atomMatchSize: int = len(atomMatch)
+    atomMatchSize = len(atomMatch)
     weights = [(i, j, weight) for i in range(atomMatchSize) for j in range(i + 1, atomMatchSize)]
         
   if excludedVolumes:
@@ -915,12 +915,12 @@ def DownsampleBoundsMatrix(bm, indices, maxThresh=4.0):
   if len(indices) == 0:
       return numpy.zeros(shape=tuple([0] * len(bm.shape)), dtype=bm.dtype)
   indicesSet = list(set(indices))
-  k = numpy.zeros(nPts, dtype=numpy.uint8)
-  k[indicesSet] = 1
+  maskMatrix = numpy.zeros(nPts, dtype=numpy.uint8)
+  maskMatrix[indicesSet] = 1
   for idx in indicesSet:
-    k[numpy.nonzero(bm[idx, idx + 1:] < maxThresh)[0] + (idx + 1)] = 1
+    maskMatrix[numpy.nonzero(bm[idx, idx + 1:] < maxThresh)[0] + (idx + 1)] = 1
   
-  keep = numpy.nonzero(k)[0]
+  keep = numpy.nonzero(maskMatrix)[0]
   if keep.shape[0] == nPts:
     return bm.copy()
   return bm[numpy.ix_(keep, keep)]

--- a/rdkit/Chem/Pharm3D/EmbedLib.py
+++ b/rdkit/Chem/Pharm3D/EmbedLib.py
@@ -545,7 +545,7 @@ def OptimizeMol(mol, bm, atomMatches=None, excludedVolumes=None, forceConstant=1
   for i, j in weights:
     if j < i:
       i, j = j, i
-    ff.AddDistanceConstraint(i, j, bm[j, i], bm[i, j], forceConstant) # i, j, minV, maxV, forceConstant
+    ff.AddDistanceConstraint(i, j, bm[j, i], bm[i, j], forceConstant)
     
   if excludedVolumes:
     nAts = mol.GetNumAtoms()
@@ -775,7 +775,7 @@ def _getFeatDict(mol, featFactory, features):
   for feat in features:
     family = feat.GetFamily()
     if family not in molFeats:
-      molFeats[family] = featFactory.GetFeaturesForMol(mol, includeOnly=family) # matches
+      molFeats[family] = featFactory.GetFeaturesForMol(mol, includeOnly=family)
   return molFeats
 
 

--- a/rdkit/Chem/Pharm3D/EmbedLib.py
+++ b/rdkit/Chem/Pharm3D/EmbedLib.py
@@ -553,7 +553,7 @@ def OptimizeMol(mol, bm, atomMatches=None, excludedVolumes=None, forceConstant=1
     idx = nAts
     for exVol in excludedVolumes:
       assert exVol.pos is not None
-      logger.debug(f'ff.AddExtraPoint({exVol.pos[0]:.4f},{exVol.pos[1]:.4f},{exVol.pos[2]:.4f})'
+      logger.debug(f'ff.AddExtraPoint({exVol.pos[0]:.4f},{exVol.pos[1]:.4f},{exVol.pos[2]:.4f}')
       ff.AddExtraPoint(exVol.pos[0], exVol.pos[1], exVol.pos[2], True)
       
       indices = []

--- a/rdkit/Chem/Pharm3D/EmbedLib.py
+++ b/rdkit/Chem/Pharm3D/EmbedLib.py
@@ -14,14 +14,12 @@ import sys
 import time
 
 import numpy
-
+import rdkit.DistanceGeometry as DG
 from rdkit import Chem
 from rdkit import RDLogger as logging
-from rdkit.Chem import ChemicalFeatures
-from rdkit.Chem import ChemicalForceFields
+from rdkit.Chem import ChemicalFeatures, ChemicalForceFields
 from rdkit.Chem import rdDistGeom as MolDG
 from rdkit.Chem.Pharm3D import ExcludedVolume
-import rdkit.DistanceGeometry as DG
 from rdkit.ML.Data import Stats
 
 _times = {}
@@ -52,11 +50,7 @@ def GetAtomHeavyNeighbors(atom):
   2
 
   """
-  res = []
-  for nbr in atom.GetNeighbors():
-    if nbr.GetAtomicNum() != 1:
-      res.append(nbr)
-  return res
+  return [nbr for nbr in atom.GetNeighbors() if nbr.GetAtomicNum() != 1]
 
 
 def ReplaceGroup(match, bounds, slop=0.01, useDirs=False, dirLength=defaultFeatLength):
@@ -67,9 +61,9 @@ def ReplaceGroup(match, bounds, slop=0.01, useDirs=False, dirLength=defaultFeatL
      new bounds mat
      index of point added
 
-   >>> boundsMat = numpy.array([[0.0,2.0,2.0],[1.0,0.0,2.0],[1.0,1.0,0.0]])
-   >>> match = [0,1,2]
-   >>> bm,idx = ReplaceGroup(match,boundsMat,slop=0.0)
+   >>> boundsMat = numpy.array([[0.0, 2.0, 2.0],[1.0, 0.0, 2.0],[1.0, 1.0, 0.0]])
+   >>> match = [0, 1, 2]
+   >>> bm,idx = ReplaceGroup(match, boundsMat, slop=0.0)
 
    the index is at the end:
 
@@ -99,12 +93,11 @@ def ReplaceGroup(match, bounds, slop=0.01, useDirs=False, dirLength=defaultFeatL
 
    The slop argument (default = 0.01) is fractional:
 
-   >>> bm,idx = ReplaceGroup(match,boundsMat)
+   >>> bm, idx = ReplaceGroup(match, boundsMat)
    >>> print(', '.join(['%.3f'%x for x in bm[-1]]))
    0.572, 0.572, 0.572, 0.000
    >>> print(', '.join(['%.3f'%x for x in bm[:,-1]]))
    1.166, 1.166, 1.166, 0.000
-
 
   """
   maxVal = -1000.0
@@ -128,11 +121,10 @@ def ReplaceGroup(match, bounds, slop=0.01, useDirs=False, dirLength=defaultFeatL
   maxVal *= scaleFact
 
   replaceIdx = bounds.shape[0]
-  if not useDirs:
-    bm = numpy.zeros((bounds.shape[0] + 1, bounds.shape[1] + 1), numpy.float)
-  else:
-    bm = numpy.zeros((bounds.shape[0] + 2, bounds.shape[1] + 2), numpy.float)
-  bm[0:bounds.shape[0], 0:bounds.shape[1]] = bounds
+  enhanceSize: int = int(bool(useDirs)) # Whether to increase the size of the bounds matrix by one
+  bm = numpy.zeros((bounds.shape[0] + 1 + enhanceSize, bounds.shape[1] + 1 + enhanceSize), 
+                   dtype=numpy.float64)
+  bm[:bounds.shape[0], :bounds.shape[1]] = bounds
   bm[:replaceIdx, replaceIdx] = 1000.
 
   if useDirs:
@@ -178,9 +170,9 @@ def EmbedMol(mol, bm, atomMatch=None, weight=2.0, randomSeed=-1, excludedVolumes
   nAts = mol.GetNumAtoms()
   weights = []
   if atomMatch:
-    for i in range(len(atomMatch)):
-      for j in range(i + 1, len(atomMatch)):
-        weights.append((i, j, weight))
+    atomMatchSize: int = len(atomMatch)
+    weights = [(i, j, weight) for i in range(atomMatchSize) for j in range(i + 1, atomMatchSize)]
+        
   if excludedVolumes:
     for vol in excludedVolumes:
       idx = vol.index
@@ -211,9 +203,9 @@ def AddExcludedVolumes(bm, excludedVolumes, smoothIt=True):
   excludedVolumes is a list of ExcludedVolume objects
 
 
-   >>> boundsMat = numpy.array([[0.0,2.0,2.0],[1.0,0.0,2.0],[1.0,1.0,0.0]])
-   >>> ev1 = ExcludedVolume.ExcludedVolume(([(0,),0.5,1.0],),exclusionDist=1.5)
-   >>> bm = AddExcludedVolumes(boundsMat,(ev1,))
+   >>> boundsMat = numpy.array([[0.0, 2.0, 2.0],[1.0, 0.0, 2.0],[1.0, 1.0, 0.0]])
+   >>> ev1 = ExcludedVolume.ExcludedVolume(([(0, ), 0.5, 1.0], ), exclusionDist=1.5)
+   >>> bm = AddExcludedVolumes(boundsMat, (ev1, ))
 
    the results matrix is one bigger:
 
@@ -233,7 +225,7 @@ def AddExcludedVolumes(bm, excludedVolumes, smoothIt=True):
   """
   oDim = bm.shape[0]
   dim = oDim + len(excludedVolumes)
-  res = numpy.zeros((dim, dim), numpy.float)
+  res = numpy.zeros((dim, dim), dtype=numpy.float64)
   res[:oDim, :oDim] = bm
   for i, vol in enumerate(excludedVolumes):
     bmIdx = oDim + i
@@ -255,8 +247,8 @@ def AddExcludedVolumes(bm, excludedVolumes, smoothIt=True):
 
     # set values to other excluded volumes:
     for j in range(bmIdx + 1, dim):
-      res[bmIdx, j:dim] = 0
-      res[j:dim, bmIdx] = 1000
+      res[bmIdx, j:dim] = 0.0
+      res[j:dim, bmIdx] = 1000.0
 
   if smoothIt:
     DG.DoTriangleSmoothing(res)
@@ -282,13 +274,13 @@ def UpdatePharmacophoreBounds(bm, atomMatch, pcophore, useDirs=False, dirLength=
     ...   ChemicalFeatures.FreeChemicalFeature('HBondDonor', 'HDonor1',
     ...                                        Geometry.Point3D(2.65, 0.0, 0.0)),
     ...   ]
-    >>> pcophore=Pharmacophore.Pharmacophore(feats)
+    >>> pcophore = Pharmacophore.Pharmacophore(feats)
     >>> pcophore.setLowerBound(0,1, 1.0)
     >>> pcophore.setUpperBound(0,1, 2.0)
 
-    >>> boundsMat = numpy.array([[0.0,3.0,3.0],[2.0,0.0,3.0],[2.0,2.0,0.0]])
-    >>> atomMatch = ((0,),(1,))
-    >>> bm = UpdatePharmacophoreBounds(boundsMat,atomMatch,pcophore)
+    >>> boundsMat = numpy.array([[0.0, 3.0, 3.0],[2.0, 0.0, 3.0],[2.0, 2.0, 0.0]])
+    >>> atomMatch = ((0, ), (1, ))
+    >>> bm = UpdatePharmacophoreBounds(boundsMat, atomMatch, pcophore)
 
 
      In this case, there are no multi-atom features, so the result matrix
@@ -310,8 +302,7 @@ def UpdatePharmacophoreBounds(bm, atomMatch, pcophore, useDirs=False, dirLength=
   replaceMap = {}
   for i, matchI in enumerate(atomMatch):
     if len(matchI) > 1:
-      bm, replaceIdx = ReplaceGroup(matchI, bm, useDirs=useDirs)
-      replaceMap[i] = replaceIdx
+      bm, replaceMap[i] = ReplaceGroup(matchI, bm, useDirs=useDirs)
 
   for i, matchI in enumerate(atomMatch):
     mi = replaceMap.get(i, matchI[0])
@@ -360,9 +351,9 @@ def EmbedPharmacophore(mol, atomMatch, pcophore, randomSeed=-1, count=10, smooth
     >>> pcophore=Pharmacophore.Pharmacophore(feats)
     >>> pcophore.setLowerBound(0,1, 2.5)
     >>> pcophore.setUpperBound(0,1, 3.5)
-    >>> atomMatch = ((0,),(3,))
+    >>> atomMatch = ((0, ), (3, ))
 
-    >>> bm,embeds,nFail = EmbedPharmacophore(m,atomMatch,pcophore,randomSeed=23,silent=1)
+    >>> bm,embeds,nFail = EmbedPharmacophore(m, atomMatch, pcophore, randomSeed=23, silent=1)
     >>> len(embeds)
     10
     >>> nFail
@@ -370,12 +361,12 @@ def EmbedPharmacophore(mol, atomMatch, pcophore, randomSeed=-1, count=10, smooth
 
     Set up a case that can't succeed:
 
-    >>> pcophore=Pharmacophore.Pharmacophore(feats)
+    >>> pcophore = Pharmacophore.Pharmacophore(feats)
     >>> pcophore.setLowerBound(0,1, 2.0)
     >>> pcophore.setUpperBound(0,1, 2.1)
-    >>> atomMatch = ((0,),(3,))
+    >>> atomMatch = ((0, ), (3, ))
 
-    >>> bm,embeds,nFail = EmbedPharmacophore(m,atomMatch,pcophore,randomSeed=23,silent=1)
+    >>> bm, embeds, nFail = EmbedPharmacophore(m,atomMatch,pcophore,randomSeed=23,silent=1)
     >>> len(embeds)
     0
     >>> nFail
@@ -391,15 +382,13 @@ def EmbedPharmacophore(mol, atomMatch, pcophore, randomSeed=-1, count=10, smooth
   if smoothFirst:
     DG.DoTriangleSmoothing(bounds)
 
-  bm = bounds.copy()
   # print '------------'
   # print 'initial'
   # for row in bm:
   #  print ' ',' '.join(['% 4.2f'%x for x in row])
   # print '------------'
 
-  bm = UpdatePharmacophoreBounds(bm, atomMatch, pcophore, useDirs=useDirs, mol=mol)
-
+  bm = UpdatePharmacophoreBounds(bounds.copy(), atomMatch, pcophore, useDirs=useDirs, mol=mol)
   if excludedVolumes:
     bm = AddExcludedVolumes(bm, excludedVolumes, smoothIt=False)
 
@@ -417,21 +406,20 @@ def EmbedPharmacophore(mol, atomMatch, pcophore, randomSeed=-1, count=10, smooth
   nFailed = 0
   res = []
   for i in range(count):
-    tmpM = bm[:, :]
     m2 = Chem.Mol(mol)
-    t1 = time.time()
+    t1 = time.perf_counter()
     try:
       if randomSeed <= 0:
         seed = i * 10 + 1
       else:
         seed = i * 10 + randomSeed
-      EmbedMol(m2, tmpM, atomMatch, randomSeed=seed, excludedVolumes=excludedVolumes)
+      EmbedMol(m2, bm.copy(), atomMatch, randomSeed=seed, excludedVolumes=excludedVolumes)
     except ValueError:
       if not silent:
         logger.info('Embed failed')
       nFailed += 1
     else:
-      t2 = time.time()
+      t2 = time.perf_counter()
       _times['embed'] = _times.get('embed', 0) + t2 - t1
       keepIt = True
       for idx, stereo in mol._chiralCenters:
@@ -486,8 +474,6 @@ def OptimizeMol(mol, bm, atomMatches=None, excludedVolumes=None, forceConstant=1
      2) the energy post-embedding
    NOTE that these energies include the energies of the constraints
 
-
-
     >>> from rdkit import Geometry
     >>> from rdkit.Chem.Pharm3D import Pharmacophore
     >>> m = Chem.MolFromSmiles('OCCN')
@@ -500,15 +486,15 @@ def OptimizeMol(mol, bm, atomMatches=None, excludedVolumes=None, forceConstant=1
     >>> pcophore=Pharmacophore.Pharmacophore(feats)
     >>> pcophore.setLowerBound(0,1, 2.5)
     >>> pcophore.setUpperBound(0,1, 2.8)
-    >>> atomMatch = ((0,),(3,))
-    >>> bm,embeds,nFail = EmbedPharmacophore(m,atomMatch,pcophore,randomSeed=23,silent=1)
+    >>> atomMatch = ((0, ), (3, ))
+    >>> bm, embeds, nFail = EmbedPharmacophore(m, atomMatch, pcophore, randomSeed=23, silent=1)
     >>> len(embeds)
     10
     >>> testM = embeds[0]
 
     Do the optimization:
 
-    >>> e1,e2 = OptimizeMol(testM,bm,atomMatches=atomMatch)
+    >>> e1, e2 = OptimizeMol(testM,bm,atomMatches=atomMatch)
 
     Optimizing should have lowered the energy:
 
@@ -521,9 +507,9 @@ def OptimizeMol(mol, bm, atomMatches=None, excludedVolumes=None, forceConstant=1
     >>> p0 = conf.GetAtomPosition(0)
     >>> p3 = conf.GetAtomPosition(3)
     >>> d03 = p0.Distance(p3)
-    >>> d03 >= pcophore.getLowerBound(0,1)-.01
+    >>> d03 >= pcophore.getLowerBound(0,1) - 0.01
     True
-    >>> d03 <= pcophore.getUpperBound(0,1)+.01
+    >>> d03 <= pcophore.getUpperBound(0,1) + 0.01
     True
 
     If we optimize without the distance constraints (provided via the atomMatches
@@ -532,16 +518,16 @@ def OptimizeMol(mol, bm, atomMatches=None, excludedVolumes=None, forceConstant=1
     close together:
 
     >>> testM = embeds[1]
-    >>> e1,e2 = OptimizeMol(testM,bm)
+    >>> e1, e2 = OptimizeMol(testM,bm)
     >>> e2 < e1
     True
     >>> conf = testM.GetConformer(0)
     >>> p0 = conf.GetAtomPosition(0)
     >>> p3 = conf.GetAtomPosition(3)
     >>> d03 = p0.Distance(p3)
-    >>> d03 >= pcophore.getLowerBound(0,1)-.01
+    >>> d03 >= pcophore.getLowerBound(0,1) - 0.01
     True
-    >>> d03 <= pcophore.getUpperBound(0,1)+.01
+    >>> d03 <= pcophore.getUpperBound(0,1) + 0.01
     False
 
   """
@@ -552,18 +538,15 @@ def OptimizeMol(mol, bm, atomMatches=None, excludedVolumes=None, forceConstant=1
     return -1.0, -1.0
 
   weights = []
-  if (atomMatches):
-    for k in range(len(atomMatches)):
-      for i in atomMatches[k]:
-        for l in range(k + 1, len(atomMatches)):
-          for j in atomMatches[l]:
-            weights.append((i, j))
+  if atomMatches:
+    weights = [(i, j) for k in range(len(atomMatches)) for i in atomMatches[k] 
+               for l in range(k + 1, len(atomMatches)) for j in atomMatches[l]]
+
   for i, j in weights:
     if j < i:
       i, j = j, i
-    minV = bm[j, i]
-    maxV = bm[i, j]
-    ff.AddDistanceConstraint(i, j, minV, maxV, forceConstant)
+    ff.AddDistanceConstraint(i, j, bm[j, i], bm[i, j], forceConstant) # i, j, minV, maxV, forceConstant
+    
   if excludedVolumes:
     nAts = mol.GetNumAtoms()
     conf = mol.GetConformer()
@@ -572,13 +555,17 @@ def OptimizeMol(mol, bm, atomMatches=None, excludedVolumes=None, forceConstant=1
       assert exVol.pos is not None
       logger.debug('ff.AddExtraPoint(%.4f,%.4f,%.4f)' % (exVol.pos[0], exVol.pos[1], exVol.pos[2]))
       ff.AddExtraPoint(exVol.pos[0], exVol.pos[1], exVol.pos[2], True)
+      
       indices = []
       for localIndices, _, _ in exVol.featInfo:
-        indices += list(localIndices)
+        indices.extend(list(localIndices))
+      indicesSet = set(indices)
+      del indices
+      
       for i in range(nAts):
         v = numpy.array(conf.GetAtomPosition(i)) - numpy.array(exVol.pos)
         d = numpy.sqrt(numpy.dot(v, v))
-        if i not in indices:
+        if i not in indicesSet:
           if d < 5.0:
             logger.debug('ff.AddDistanceConstraint(%d,%d,%.3f,%d,%.0f)' %
                          (i, idx, exVol.exclusionDist, 1000, forceConstant))
@@ -589,26 +576,27 @@ def OptimizeMol(mol, bm, atomMatches=None, excludedVolumes=None, forceConstant=1
                        (i, idx, bm[exVol.index, i], bm[i, exVol.index], forceConstant))
           ff.AddDistanceConstraint(i, idx, bm[exVol.index, i], bm[i, exVol.index], forceConstant)
       idx += 1
+  
   ff.Initialize()
   e1 = ff.CalcEnergy()
   if isNaN(e1):
     raise ValueError('bogus energy')
-
   if verbose:
     print(Chem.MolToMolBlock(mol))
     for i, _ in enumerate(excludedVolumes):
       pos = ff.GetExtraPointPos(i)
       print('   % 7.4f   % 7.4f   % 7.4f As  0  0  0  0  0  0  0  0  0  0  0  0' % tuple(pos),
             file=sys.stderr)
+      
   needsMore = ff.Minimize()
   nPasses = 0
   while needsMore and nPasses < maxPasses:
     needsMore = ff.Minimize()
     nPasses += 1
+  
   e2 = ff.CalcEnergy()
   if isNaN(e2):
     raise ValueError('bogus energy')
-
   if verbose:
     print('--------')
     print(Chem.MolToMolBlock(mol))
@@ -654,26 +642,27 @@ def EmbedOne(mol, name, match, pcophore, count=1, silent=0, **kwargs):
   d23s = []
   d34s = []
   for m in ms:
-    t1 = time.time()
+    t1 = time.perf_counter()
     try:
       e1, e2 = OptimizeMol(m, bm, atomMatch)
     except ValueError:
       pass
     else:
-      t2 = time.time()
+      t2 = time.perf_counter()
       _times['opt1'] = _times.get('opt1', 0) + t2 - t1
 
       e1s.append(e1)
       e2s.append(e2)
 
       d12s.append(e1 - e2)
-      t1 = time.time()
+      
+      t1 = time.perf_counter()
       try:
         e3, e4 = OptimizeMol(m, bm)
       except ValueError:
         pass
       else:
-        t2 = time.time()
+        t2 = time.perf_counter()
         _times['opt2'] = _times.get('opt2', 0) + t2 - t1
         e3s.append(e3)
         e4s.append(e4)
@@ -725,7 +714,7 @@ def MatchPharmacophoreToMol(mol, featFactory, pcophore):
     ...  ChemicalFeatures.FreeChemicalFeature('Donor',Geometry.Point3D(0.0, 0.0, 0.0))]
     >>> pcophore= Pharmacophore.Pharmacophore(activeFeats)
     >>> m = Chem.MolFromSmiles('FCCN')
-    >>> match,mList = MatchPharmacophoreToMol(m,featFactory,pcophore)
+    >>> match, mList = MatchPharmacophoreToMol(m,featFactory,pcophore)
     >>> match
     True
 
@@ -765,7 +754,7 @@ def _getFeatDict(mol, featFactory, features):
     ...  ChemicalFeatures.FreeChemicalFeature('Acceptor', Geometry.Point3D(0.0, 0.0, 0.0)),
     ...  ChemicalFeatures.FreeChemicalFeature('Donor',Geometry.Point3D(0.0, 0.0, 0.0))]
     >>> m = Chem.MolFromSmiles('FCCN')
-    >>> d =_getFeatDict(m,featFactory,activeFeats)
+    >>> d = _getFeatDict(m,featFactory,activeFeats)
     >>> sorted(list(d.keys()))
     ['Acceptor', 'Donor']
     >>> donors = d['Donor']
@@ -786,8 +775,7 @@ def _getFeatDict(mol, featFactory, features):
   for feat in features:
     family = feat.GetFamily()
     if family not in molFeats:
-      matches = featFactory.GetFeaturesForMol(mol, includeOnly=family)
-      molFeats[family] = matches
+      molFeats[family] = featFactory.GetFeaturesForMol(mol, includeOnly=family) # matches
   return molFeats
 
 
@@ -807,7 +795,7 @@ def MatchFeatsToMol(mol, featFactory, features):
     ...  ChemicalFeatures.FreeChemicalFeature('Acceptor', Geometry.Point3D(0.0, 0.0, 0.0)),
     ...  ChemicalFeatures.FreeChemicalFeature('Donor',Geometry.Point3D(0.0, 0.0, 0.0))]
     >>> m = Chem.MolFromSmiles('FCCN')
-    >>> match,mList = MatchFeatsToMol(m,featFactory,activeFeats)
+    >>> match, mList = MatchFeatsToMol(m,featFactory,activeFeats)
     >>> match
     True
 
@@ -847,16 +835,16 @@ def CombiEnum(sequence):
   """ This generator takes a sequence of sequences as an argument and
   provides all combinations of the elements of the subsequences:
 
-  >>> gen = CombiEnum(((1,2),(10,20)))
+  >>> gen = CombiEnum(((1, 2), (10, 20)))
   >>> next(gen)
   [1, 10]
   >>> next(gen)
   [1, 20]
 
-  >>> [x for x in CombiEnum(((1,2),(10,20)))]
+  >>> [x for x in CombiEnum(((1, 2), (10,20)))]
   [[1, 10], [1, 20], [2, 10], [2, 20]]
 
-  >>> [x for x in CombiEnum(((1,2),(10,20),(100,200)))]
+  >>> [x for x in CombiEnum(((1, 2),(10, 20), (100, 200)))]
   [[1, 10, 100], [1, 10, 200], [1, 20, 100], [1, 20, 200], [2, 10, 100],
    [2, 10, 200], [2, 20, 100], [2, 20, 200]]
 
@@ -873,19 +861,18 @@ def CombiEnum(sequence):
 
 
 def DownsampleBoundsMatrix(bm, indices, maxThresh=4.0):
-  """ removes rows from a bounds matrix that are
-  that are greater than a threshold value away from a set of
-  other points
+  """ Removes rows from a bounds matrix that are that are greater 
+  than a threshold value away from a set of other points
 
-  returns the modfied bounds matrix
+  Returns the modfied bounds matrix
 
   The goal of this function is to remove rows from the bounds matrix
-  that correspond to atoms that are likely to be quite far from
+  that correspond to atoms (atomic index) that are likely to be quite far from
   the pharmacophore we're interested in. Because the bounds smoothing
   we eventually have to do is N^3, this can be a big win
 
-   >>> boundsMat = numpy.array([[0.0,3.0,4.0],[2.0,0.0,3.0],[2.0,2.0,0.0]])
-   >>> bm = DownsampleBoundsMatrix(boundsMat,(0,),3.5)
+   >>> boundsMat = numpy.array([[0.0, 3.0, 4.0],[2.0, 0.0, 3.0],[2.0, 2.0, 0.0]])
+   >>> bm = DownsampleBoundsMatrix(boundsMat,(0, ), 3.5)
    >>> bm.shape == (2, 2)
    True
 
@@ -901,35 +888,43 @@ def DownsampleBoundsMatrix(bm, indices, maxThresh=4.0):
 
    if the threshold is high enough, we don't do anything:
 
-   >>> boundsMat = numpy.array([[0.0,4.0,3.0],[2.0,0.0,3.0],[2.0,2.0,0.0]])
-   >>> bm = DownsampleBoundsMatrix(boundsMat,(0,),5.0)
+   >>> boundsMat = numpy.array([[0.0, 4.0, 3.0],[2.0, 0.0, 3.0],[2.0, 2.0, 0.0]])
+   >>> bm = DownsampleBoundsMatrix(boundsMat, (0, ), 5.0)
    >>> bm.shape == (3, 3)
    True
 
    If there's a max value that's close enough to *any* of the indices
    we pass in, we'll keep it:
 
-   >>> boundsMat = numpy.array([[0.0,4.0,3.0],[2.0,0.0,3.0],[2.0,2.0,0.0]])
-   >>> bm = DownsampleBoundsMatrix(boundsMat,(0,1),3.5)
+   >>> boundsMat = numpy.array([[0.0, 4.0, 3.0],[2.0, 0.0, 3.0],[2.0, 2.0, 0.0]])
+   >>> bm = DownsampleBoundsMatrix(boundsMat, (0, 1), 3.5)
    >>> bm.shape == (3, 3)
+   True
+
+   However, the datatype should not be changed or uprank into np.float64 as default behaviour
+   >>> boundsMat = numpy.array([[0.0, 4.0, 3.0],[2.0, 0.0, 3.0],[2.0, 2.0, 0.0]], dtype=numpy.float32)
+   >>> bm = DownsampleBoundsMatrix(boundsMat,(0, 1), 3.5)
+   >>> bm.dtype == numpy.float64
+   False
+   >>> bm.dtype == numpy.float32 or numpy.issubdtype(bm.dtype, numpy.float32)
+   True
+   >>> bm.dtype == boundsMat.dtype or numpy.issubdtype(bm.dtype, boundsMat.dtype)
    True
 
   """
   nPts = bm.shape[0]
-  k = numpy.zeros(nPts, numpy.int0)
-  for idx in indices:
-    k[idx] = 1
-  for i in indices:
-    row = bm[i]
-    for j in range(i + 1, nPts):
-      if not k[j] and row[j] < maxThresh:
-        k[j] = 1
+  if len(indices) == 0:
+      return numpy.zeros(shape=tuple([0] * len(bm.shape)), dtype=bm.dtype)
+  indicesSet = list(set(indices))
+  k = numpy.zeros(nPts, dtype=numpy.uint8)
+  k[indicesSet] = 1
+  for idx in indicesSet:
+    k[numpy.nonzero(bm[idx, idx + 1:] < maxThresh)[0] + (idx + 1)] = 1
+  
   keep = numpy.nonzero(k)[0]
-  bm2 = numpy.zeros((len(keep), len(keep)), numpy.float)
-  for i, idx in enumerate(keep):
-    row = bm[idx]
-    bm2[i] = numpy.take(row, keep)
-  return bm2
+  if keep.shape[0] == nPts:
+    return bm.copy()
+  return bm[numpy.ix_(keep, keep)]
 
 
 def CoarseScreenPharmacophore(atomMatch, bounds, pcophore, verbose=False):
@@ -944,31 +939,31 @@ def CoarseScreenPharmacophore(atomMatch, bounds, pcophore, verbose=False):
   ...   ChemicalFeatures.FreeChemicalFeature('Aromatic', 'Aromatic1',
   ...                                        Geometry.Point3D(5.12, 0.908, 0.0)),
   ...   ]
-  >>> pcophore=Pharmacophore.Pharmacophore(feats)
-  >>> pcophore.setLowerBound(0,1, 1.1)
-  >>> pcophore.setUpperBound(0,1, 1.9)
-  >>> pcophore.setLowerBound(0,2, 2.1)
-  >>> pcophore.setUpperBound(0,2, 2.9)
-  >>> pcophore.setLowerBound(1,2, 2.1)
-  >>> pcophore.setUpperBound(1,2, 3.9)
+  >>> pcophore = Pharmacophore.Pharmacophore(feats)
+  >>> pcophore.setLowerBound(0, 1, 1.1)
+  >>> pcophore.setUpperBound(0, 1, 1.9)
+  >>> pcophore.setLowerBound(0, 2, 2.1)
+  >>> pcophore.setUpperBound(0, 2, 2.9)
+  >>> pcophore.setLowerBound(1, 2, 2.1)
+  >>> pcophore.setUpperBound(1, 2, 3.9)
 
-  >>> bounds = numpy.array([[0,2,3],[1,0,4],[2,3,0]],numpy.float)
-  >>> CoarseScreenPharmacophore(((0,),(1,)),bounds,pcophore)
+  >>> bounds = numpy.array([[0, 2, 3],[1, 0, 4],[2, 3, 0]], dtype=numpy.float64)
+  >>> CoarseScreenPharmacophore(((0, ),(1, )),bounds, pcophore)
   True
 
-  >>> CoarseScreenPharmacophore(((0,),(2,)),bounds,pcophore)
+  >>> CoarseScreenPharmacophore(((0, ),(2, )),bounds, pcophore)
   False
 
-  >>> CoarseScreenPharmacophore(((1,),(2,)),bounds,pcophore)
+  >>> CoarseScreenPharmacophore(((1, ),(2, )),bounds, pcophore)
   False
 
-  >>> CoarseScreenPharmacophore(((0,),(1,),(2,)),bounds,pcophore)
+  >>> CoarseScreenPharmacophore(((0, ),(1, ),(2, )),bounds, pcophore)
   True
 
-  >>> CoarseScreenPharmacophore(((1,),(0,),(2,)),bounds,pcophore)
+  >>> CoarseScreenPharmacophore(((1, ),(0, ),(2, )),bounds, pcophore)
   False
 
-  >>> CoarseScreenPharmacophore(((2,),(1,),(0,)),bounds,pcophore)
+  >>> CoarseScreenPharmacophore(((2, ),(1, ),(0, )),bounds, pcophore)
   False
 
   # we ignore the point locations here and just use their definitions:
@@ -996,28 +991,34 @@ def CoarseScreenPharmacophore(atomMatch, bounds, pcophore, verbose=False):
   >>> pcophore.setUpperBound(1,3, 1.9)
   >>> pcophore.setLowerBound(2,3, 1.1)
   >>> pcophore.setUpperBound(2,3, 1.9)
-  >>> bounds = numpy.array([[0,3,3,3],[2,0,2,2],[2,1,0,2],[2,1,1,0]],numpy.float)
+  >>> bounds = numpy.array([[0, 3, 3, 3], 
+  ...                       [2, 0, 2, 2], 
+  ...                       [2, 1, 0, 2], 
+  ...                       [2, 1, 1, 0]], 
+  ...                      dtype=numpy.float64)
 
-  >>> CoarseScreenPharmacophore(((0,),(1,),(2,),(3,)),bounds,pcophore)
+  >>> CoarseScreenPharmacophore(((0, ), (1, ), (2, ), (3, )), bounds, pcophore)
   True
 
-  >>> CoarseScreenPharmacophore(((0,),(1,),(3,),(2,)),bounds,pcophore)
+  >>> CoarseScreenPharmacophore(((0, ), (1, ), (3, ), (2, )), bounds, pcophore)
   True
 
-  >>> CoarseScreenPharmacophore(((1,),(0,),(3,),(2,)),bounds,pcophore)
+  >>> CoarseScreenPharmacophore(((1, ), (0, ), (3, ), (2, )), bounds, pcophore)
   False
 
   """
-  for k in range(len(atomMatch)):
+  atomMatchSize = len(atomMatch)
+  for k in range(atomMatchSize):
     if len(atomMatch[k]) == 1:
-      for l in range(k + 1, len(atomMatch)):
+      for l in range(k + 1, atomMatchSize):
         if len(atomMatch[l]) == 1:
-          idx0 = atomMatch[k][0]
-          idx1 = atomMatch[l][0]
-          if idx1 < idx0:
-            idx0, idx1 = idx1, idx0
-          if (bounds[idx1, idx0] >= pcophore.getUpperBound(k, l) or
-              bounds[idx0, idx1] <= pcophore.getLowerBound(k, l)):
+          if atomMatch[l][0] < atomMatch[k][0]:
+            idx0, idx1 = atomMatch[l][0], atomMatch[k][0]
+          else:
+            idx0, idx1 = atomMatch[k][0], atomMatch[l][0]
+          
+          if bounds[idx1, idx0] >= pcophore.getUpperBound(k, l) or \
+            bounds[idx0, idx1] <= pcophore.getLowerBound(k, l):
             if verbose:
               print('\t  (%d,%d) [%d,%d] fail' % (idx1, idx0, k, l))
               print('\t    %f,%f - %f,%f' % (bounds[idx1, idx0], pcophore.getUpperBound(k, l),
@@ -1040,11 +1041,11 @@ def Check2DBounds(atomMatch, mol, pcophore):
     ...  ChemicalFeatures.FreeChemicalFeature('Acceptor', Geometry.Point3D(0.0, 0.0, 0.0)),
     ...  ChemicalFeatures.FreeChemicalFeature('Donor',Geometry.Point3D(0.0, 0.0, 0.0))]
     >>> pcophore= Pharmacophore.Pharmacophore(activeFeats)
-    >>> pcophore.setUpperBound2D(0,1,3)
+    >>> pcophore.setUpperBound2D(0, 1, 3)
     >>> m = Chem.MolFromSmiles('FCC(N)CN')
-    >>> Check2DBounds(((0,),(3,)),m,pcophore)
+    >>> Check2DBounds(((0, ), (3, )), m, pcophore)
     True
-    >>> Check2DBounds(((0,),(5,)),m,pcophore)
+    >>> Check2DBounds(((0, ), (5, )), m, pcophore)
     False
 
   """
@@ -1130,8 +1131,7 @@ def MatchPharmacophore(matches, bounds, pcophore, useDownsampling=False, use2DLi
 
   """
   for match, atomMatch in ConstrainedEnum(matches, mol, pcophore, bounds, use2DLimits=use2DLimits):
-    bm = bounds.copy()
-    bm = UpdatePharmacophoreBounds(bm, atomMatch, pcophore, useDirs=useDirs, mol=mol)
+    bm = UpdatePharmacophoreBounds(bounds.copy(), atomMatch, pcophore, useDirs=useDirs, mol=mol)
 
     if excludedVolumes:
       localEvs = []
@@ -1177,12 +1177,12 @@ def GetAllPharmacophoreMatches(matches, bounds, pcophore, useDownsampling=0, pro
       if verbose:
         print('  ..CoarseScreen: Pass')
 
-      bm = bounds.copy()
       if verbose:
         print('pre update:')
         for row in bm:
           print(' ', ' '.join(['% 4.2f' % x for x in row]))
-      bm = UpdatePharmacophoreBounds(bm, atomMatch, pcophore)
+          
+      bm = UpdatePharmacophoreBounds(bounds.copy(), atomMatch, pcophore)
       if verbose:
         print('pre downsample:')
         for row in bm:
@@ -1191,7 +1191,7 @@ def GetAllPharmacophoreMatches(matches, bounds, pcophore, useDownsampling=0, pro
       if useDownsampling:
         indices = []
         for entry in atomMatch:
-          indices += list(entry)
+          indices.extend(list(entry))
         bm = DownsampleBoundsMatrix(bm, indices)
       if verbose:
         print('post downsample:')
@@ -1224,7 +1224,7 @@ def ComputeChiralVolume(mol, centerIdx, confId=-1):
     >>> Chem.AssignStereochemistry(mol)
     >>> mol.GetAtomWithIdx(1).GetProp('_CIPCode')
     'R'
-    >>> ComputeChiralVolume(mol,1) < 0
+    >>> ComputeChiralVolume(mol, 1) < 0
     True
 
     S configuration atoms give positive volumes:
@@ -1233,12 +1233,12 @@ def ComputeChiralVolume(mol, centerIdx, confId=-1):
     >>> Chem.AssignStereochemistry(mol)
     >>> mol.GetAtomWithIdx(1).GetProp('_CIPCode')
     'S'
-    >>> ComputeChiralVolume(mol,1) > 0
+    >>> ComputeChiralVolume(mol, 1) > 0
     True
 
     Non-chiral (or non-specified) atoms give zero volume:
 
-    >>> ComputeChiralVolume(mol,0) == 0.0
+    >>> ComputeChiralVolume(mol, 0) == 0.0
     True
 
     We also work on 3-coordinate atoms (with implicit Hs):
@@ -1247,16 +1247,15 @@ def ComputeChiralVolume(mol, centerIdx, confId=-1):
     >>> Chem.AssignStereochemistry(mol)
     >>> mol.GetAtomWithIdx(1).GetProp('_CIPCode')
     'R'
-    >>> ComputeChiralVolume(mol,1)<0
+    >>> ComputeChiralVolume(mol, 1) < 0
     True
 
     >>> mol = Chem.MolFromMolFile(os.path.join(dataDir,'mol-s-3.mol'))
     >>> Chem.AssignStereochemistry(mol)
     >>> mol.GetAtomWithIdx(1).GetProp('_CIPCode')
     'S'
-    >>> ComputeChiralVolume(mol,1)>0
+    >>> ComputeChiralVolume(mol, 1) > 0
     True
-
 
 
   """
@@ -1267,11 +1266,8 @@ def ComputeChiralVolume(mol, centerIdx, confId=-1):
     return 0.0
 
   nbrs = center.GetNeighbors()
-  nbrRanks = []
-  for nbr in nbrs:
-    rank = int(nbr.GetProp('_CIPRank'))
-    pos = conf.GetAtomPosition(nbr.GetIdx())
-    nbrRanks.append((rank, pos))
+  nbrRanks = [(int(nbr.GetProp('_CIPRank')), conf.GetAtomPosition(nbr.GetIdx())) 
+              for nbr in nbrs]
 
   # if we only have three neighbors (i.e. the determining H isn't present)
   # then use the central atom as the fourth point:
@@ -1283,9 +1279,7 @@ def ComputeChiralVolume(mol, centerIdx, confId=-1):
   v1 = ps[0] - ps[3]
   v2 = ps[1] - ps[3]
   v3 = ps[2] - ps[3]
-
-  res = v1.DotProduct(v2.CrossProduct(v3))
-  return res
+  return v1.DotProduct(v2.CrossProduct(v3))
 
 
 # ------------------------------------

--- a/rdkit/Chem/Pharm3D/EmbedLib.py
+++ b/rdkit/Chem/Pharm3D/EmbedLib.py
@@ -880,9 +880,9 @@ def DownsampleBoundsMatrix(bm, indices, maxThresh=4.0):
    >>> boundsMat.shape == (3, 3)
    True
 
-   >>> print(', '.join(['%.3f'%x for x in bm[0]]))
+   >>> print(', '.join([f'{x:.3f}' for x in bm[0]]))
    0.000, 3.000
-   >>> print(', '.join(['%.3f'%x for x in bm[1]]))
+   >>> print(', '.join([f'{x:.3f}' for x in bm[1]]))
    2.000, 0.000
 
    if the threshold is high enough, we don't do anything:

--- a/rdkit/Chem/Pharm3D/EmbedLib.py
+++ b/rdkit/Chem/Pharm3D/EmbedLib.py
@@ -86,17 +86,17 @@ def ReplaceGroup(match, bounds, slop=0.01, useDirs=False, dirLength=defaultFeatL
    (i.e. pt 0 is a neighbor to pt 1 and pt N-1)
    and that the replacement point goes at the center:
 
-   >>> print(', '.join(['%.3f'%x for x in bm[-1]]))
+   >>> print(', '.join([f'{x:.3f}' for x in bm[-1]]))
    0.577, 0.577, 0.577, 0.000
-   >>> print(', '.join(['%.3f'%x for x in bm[:,-1]]))
+   >>> print(', '.join([f'{x:.3f}' for x in bm[:,-1]]))
    1.155, 1.155, 1.155, 0.000
 
    The slop argument (default = 0.01) is fractional:
 
    >>> bm, idx = ReplaceGroup(match, boundsMat)
-   >>> print(', '.join(['%.3f'%x for x in bm[-1]]))
+   >>> print(', '.join([f'{x:.3f}' for x in bm[-1]]))
    0.572, 0.572, 0.572, 0.000
-   >>> print(', '.join(['%.3f'%x for x in bm[:,-1]]))
+   >>> print(', '.join([f'{x:.3f}' for x in bm[:,-1]]))
    1.166, 1.166, 1.166, 0.000
 
   """
@@ -217,9 +217,9 @@ def AddExcludedVolumes(bm, excludedVolumes, smoothIt=True):
    >>> boundsMat.shape == (3, 3)
    True
 
-   >>> print(', '.join(['%.3f'%x for x in bm[-1]]))
+   >>> print(', '.join([f'{x:.3f}' for x in bm[-1]]))
    0.500, 1.500, 1.500, 0.000
-   >>> print(', '.join(['%.3f'%x for x in bm[:,-1]]))
+   >>> print(', '.join([f'{x:.3f}' for x in bm[:,-1]]))
    1.000, 3.000, 3.000, 0.000
 
   """
@@ -242,7 +242,7 @@ def AddExcludedVolumes(bm, excludedVolumes, smoothIt=True):
           res[bmIdx, index] = minV
           res[index, bmIdx] = maxV
         except IndexError:
-          logger.error('BAD INDEX: res[%d,%d], shape is %s' % (bmIdx, index, str(res.shape)))
+          logger.error(f'BAD INDEX: res[{bmIdx},{index}], shape is {str(res.shape)}')
           raise IndexError
 
     # set values to other excluded volumes:
@@ -291,11 +291,11 @@ def UpdatePharmacophoreBounds(bm, atomMatch, pcophore, useDirs=False, dirLength=
 
      this means, of course, that the input boundsMat is altered:
 
-     >>> print(', '.join(['%.3f'%x for x in boundsMat[0]]))
+     >>> print(', '.join([f'{x:.3f}' for x in boundsMat[0]]))
      0.000, 2.000, 3.000
-     >>> print(', '.join(['%.3f'%x for x in boundsMat[1]]))
+     >>> print(', '.join([f'{x:.3f}' for x in boundsMat[1]]))
      1.000, 0.000, 3.000
-     >>> print(', '.join(['%.3f'%x for x in boundsMat[2]]))
+     >>> print(', '.join([f'{x:.3f}' for x in boundsMat[2]]))
      2.000, 2.000, 0.000
 
   """
@@ -366,7 +366,7 @@ def EmbedPharmacophore(mol, atomMatch, pcophore, randomSeed=-1, count=10, smooth
     >>> pcophore.setUpperBound(0,1, 2.1)
     >>> atomMatch = ((0, ), (3, ))
 
-    >>> bm, embeds, nFail = EmbedPharmacophore(m,atomMatch,pcophore,randomSeed=23,silent=1)
+    >>> bm, embeds, nFail = EmbedPharmacophore(m, atomMatch, pcophore, randomSeed=23, silent=1)
     >>> len(embeds)
     0
     >>> nFail
@@ -525,9 +525,9 @@ def OptimizeMol(mol, bm, atomMatches=None, excludedVolumes=None, forceConstant=1
     >>> p0 = conf.GetAtomPosition(0)
     >>> p3 = conf.GetAtomPosition(3)
     >>> d03 = p0.Distance(p3)
-    >>> d03 >= pcophore.getLowerBound(0,1) - 0.01
+    >>> d03 >= pcophore.getLowerBound(0, 1) - 0.01
     True
-    >>> d03 <= pcophore.getUpperBound(0,1) + 0.01
+    >>> d03 <= pcophore.getUpperBound(0, 1) + 0.01
     False
 
   """
@@ -553,7 +553,7 @@ def OptimizeMol(mol, bm, atomMatches=None, excludedVolumes=None, forceConstant=1
     idx = nAts
     for exVol in excludedVolumes:
       assert exVol.pos is not None
-      logger.debug('ff.AddExtraPoint(%.4f,%.4f,%.4f)' % (exVol.pos[0], exVol.pos[1], exVol.pos[2]))
+      logger.debug(f'ff.AddExtraPoint({exVol.pos[0]:.4f},{exVol.pos[1]:.4f},{exVol.pos[2]:.4f})'
       ff.AddExtraPoint(exVol.pos[0], exVol.pos[1], exVol.pos[2], True)
       
       indices = []
@@ -567,13 +567,12 @@ def OptimizeMol(mol, bm, atomMatches=None, excludedVolumes=None, forceConstant=1
         d = numpy.sqrt(numpy.dot(v, v))
         if i not in indicesSet:
           if d < 5.0:
-            logger.debug('ff.AddDistanceConstraint(%d,%d,%.3f,%d,%.0f)' %
-                         (i, idx, exVol.exclusionDist, 1000, forceConstant))
+            logger.debug(f'ff.AddDistanceConstraint({i},{idx},{exVol.exclusionDist:.3f},1000,{forceConstant:.0f})')
             ff.AddDistanceConstraint(i, idx, exVol.exclusionDist, 1000, forceConstant)
 
         else:
-          logger.debug('ff.AddDistanceConstraint(%d,%d,%.3f,%.3f,%.0f)' %
-                       (i, idx, bm[exVol.index, i], bm[i, exVol.index], forceConstant))
+          logger.debug(f'ff.AddDistanceConstraint({i},{idx},{bm[exVol.index, i]:.3f},'
+                       f'{bm[i, exVol.index]:.3f},{forceConstant:.0f})')
           ff.AddDistanceConstraint(i, idx, bm[exVol.index, i], bm[i, exVol.index], forceConstant)
       idx += 1
   
@@ -691,8 +690,8 @@ def EmbedOne(mol, name, match, pcophore, count=1, silent=0, **kwargs):
     e4 = -1.0
     e4d = -1.0
   if not silent:
-    print('%s(%d): %.2f(%.2f) -> %.2f(%.2f) : %.2f(%.2f) -> %.2f(%.2f)' %
-          (name, nFailed, e1, e1d, e2, e2d, e3, e3d, e4, e4d))
+    print(f'{name}({nFailed}): {e1:.2f}({e1d:.2f}) -> {e2:.2f}({e2d:.2f}) : '
+          f'{e3:.2f}({e3d:.2f}) -> {e4:.2f}({e4d:.2f})')
   return e1, e1d, e2, e2d, e3, e3d, e4, e4d, nFailed
 
 
@@ -748,13 +747,13 @@ def _getFeatDict(mol, featFactory, features):
 
     >>> import os.path
     >>> from rdkit import Geometry, RDConfig, Chem
-    >>> fdefFile = os.path.join(RDConfig.RDCodeDir,'Chem/Pharm3D/test_data/BaseFeatures.fdef')
+    >>> fdefFile = os.path.join(RDConfig.RDCodeDir, 'Chem/Pharm3D/test_data/BaseFeatures.fdef')
     >>> featFactory = ChemicalFeatures.BuildFeatureFactory(fdefFile)
     >>> activeFeats = [
     ...  ChemicalFeatures.FreeChemicalFeature('Acceptor', Geometry.Point3D(0.0, 0.0, 0.0)),
-    ...  ChemicalFeatures.FreeChemicalFeature('Donor',Geometry.Point3D(0.0, 0.0, 0.0))]
+    ...  ChemicalFeatures.FreeChemicalFeature('Donor', Geometry.Point3D(0.0, 0.0, 0.0))]
     >>> m = Chem.MolFromSmiles('FCCN')
-    >>> d = _getFeatDict(m,featFactory,activeFeats)
+    >>> d = _getFeatDict(m, featFactory, activeFeats)
     >>> sorted(list(d.keys()))
     ['Acceptor', 'Donor']
     >>> donors = d['Donor']
@@ -789,13 +788,13 @@ def MatchFeatsToMol(mol, featFactory, features):
 
     >>> import os.path
     >>> from rdkit import RDConfig, Geometry
-    >>> fdefFile = os.path.join(RDConfig.RDCodeDir,'Chem/Pharm3D/test_data/BaseFeatures.fdef')
+    >>> fdefFile = os.path.join(RDConfig.RDCodeDir, 'Chem/Pharm3D/test_data/BaseFeatures.fdef')
     >>> featFactory = ChemicalFeatures.BuildFeatureFactory(fdefFile)
     >>> activeFeats = [
     ...  ChemicalFeatures.FreeChemicalFeature('Acceptor', Geometry.Point3D(0.0, 0.0, 0.0)),
-    ...  ChemicalFeatures.FreeChemicalFeature('Donor',Geometry.Point3D(0.0, 0.0, 0.0))]
+    ...  ChemicalFeatures.FreeChemicalFeature('Donor', Geometry.Point3D(0.0, 0.0, 0.0))]
     >>> m = Chem.MolFromSmiles('FCCN')
-    >>> match, mList = MatchFeatsToMol(m,featFactory,activeFeats)
+    >>> match, mList = MatchFeatsToMol(m, featFactory, activeFeats)
     >>> match
     True
 
@@ -1020,9 +1019,9 @@ def CoarseScreenPharmacophore(atomMatch, bounds, pcophore, verbose=False):
           if bounds[idx1, idx0] >= pcophore.getUpperBound(k, l) or \
             bounds[idx0, idx1] <= pcophore.getLowerBound(k, l):
             if verbose:
-              print('\t  (%d,%d) [%d,%d] fail' % (idx1, idx0, k, l))
-              print('\t    %f,%f - %f,%f' % (bounds[idx1, idx0], pcophore.getUpperBound(k, l),
-                                             bounds[idx0, idx1], pcophore.getLowerBound(k, l)))
+              print(f'\t  ({idx1},{idx0}) [{k},{l}] fail')
+              print(f'\t    {bounds[idx1, idx0]},{pcophore.getUpperBound(k, l)} - '
+                    f'{bounds[idx0, idx1]},{pcophore.getLowerBound(k, l)}')
             # logger.debug('\t >%s'%str(atomMatch))
             # logger.debug()
             # logger.debug('\t    %f,%f - %f,%f'%(bounds[idx1,idx0],pcophore.getUpperBound(k,l),
@@ -1039,7 +1038,7 @@ def Check2DBounds(atomMatch, mol, pcophore):
     >>> from rdkit.Chem.Pharm3D import Pharmacophore
     >>> activeFeats = [
     ...  ChemicalFeatures.FreeChemicalFeature('Acceptor', Geometry.Point3D(0.0, 0.0, 0.0)),
-    ...  ChemicalFeatures.FreeChemicalFeature('Donor',Geometry.Point3D(0.0, 0.0, 0.0))]
+    ...  ChemicalFeatures.FreeChemicalFeature('Donor', Geometry.Point3D(0.0, 0.0, 0.0))]
     >>> pcophore= Pharmacophore.Pharmacophore(activeFeats)
     >>> pcophore.setUpperBound2D(0, 1, 3)
     >>> m = Chem.MolFromSmiles('FCC(N)CN')
@@ -1220,7 +1219,7 @@ def ComputeChiralVolume(mol, centerIdx, confId=-1):
 
     R configuration atoms give negative volumes:
 
-    >>> mol = Chem.MolFromMolFile(os.path.join(dataDir,'mol-r.mol'))
+    >>> mol = Chem.MolFromMolFile(os.path.join(dataDir, 'mol-r.mol'))
     >>> Chem.AssignStereochemistry(mol)
     >>> mol.GetAtomWithIdx(1).GetProp('_CIPCode')
     'R'
@@ -1229,7 +1228,7 @@ def ComputeChiralVolume(mol, centerIdx, confId=-1):
 
     S configuration atoms give positive volumes:
 
-    >>> mol = Chem.MolFromMolFile(os.path.join(dataDir,'mol-s.mol'))
+    >>> mol = Chem.MolFromMolFile(os.path.join(dataDir, 'mol-s.mol'))
     >>> Chem.AssignStereochemistry(mol)
     >>> mol.GetAtomWithIdx(1).GetProp('_CIPCode')
     'S'
@@ -1243,14 +1242,14 @@ def ComputeChiralVolume(mol, centerIdx, confId=-1):
 
     We also work on 3-coordinate atoms (with implicit Hs):
 
-    >>> mol = Chem.MolFromMolFile(os.path.join(dataDir,'mol-r-3.mol'))
+    >>> mol = Chem.MolFromMolFile(os.path.join(dataDir, 'mol-r-3.mol'))
     >>> Chem.AssignStereochemistry(mol)
     >>> mol.GetAtomWithIdx(1).GetProp('_CIPCode')
     'R'
     >>> ComputeChiralVolume(mol, 1) < 0
     True
 
-    >>> mol = Chem.MolFromMolFile(os.path.join(dataDir,'mol-s-3.mol'))
+    >>> mol = Chem.MolFromMolFile(os.path.join(dataDir, 'mol-s-3.mol'))
     >>> Chem.AssignStereochemistry(mol)
     >>> mol.GetAtomWithIdx(1).GetProp('_CIPCode')
     'S'

--- a/rdkit/Chem/Pharm3D/ExcludedVolume.py
+++ b/rdkit/Chem/Pharm3D/ExcludedVolume.py
@@ -21,15 +21,15 @@ class ExcludedVolume(object):
       _ = len(featInfo)
     except TypeError:
       raise ValueError('featInfo argument must be a sequence of sequences')
-
+    
     if not len(featInfo):
       raise ValueError('featInfo argument must non-empty')
-
+    
     try:
       a, b, c = featInfo[0]
     except (TypeError, ValueError):
       raise ValueError('featInfo elements must be 3-sequences')
-
+    
     self.featInfo = featInfo[:]
     self.exclusionDist = exclusionDist
     self.pos = None

--- a/rdkit/Chem/Pharm3D/ExcludedVolume.py
+++ b/rdkit/Chem/Pharm3D/ExcludedVolume.py
@@ -26,7 +26,7 @@ class ExcludedVolume(object):
       raise ValueError('featInfo argument must non-empty')
     
     try:
-      a, b, c = featInfo[0]
+      _, _, _ = featInfo[0]
     except (TypeError, ValueError):
       raise ValueError('featInfo elements must be 3-sequences')
     

--- a/rdkit/Chem/Pharm3D/Pharmacophore.py
+++ b/rdkit/Chem/Pharm3D/Pharmacophore.py
@@ -21,8 +21,8 @@ class Pharmacophore:
   def __init__(self, feats, initMats=True):
     self._initializeFeats(feats)
     nf = len(feats)
-    self._boundsMat = numpy.zeros((nf, nf), numpy.float)
-    self._boundsMat2D = numpy.zeros((nf, nf), numpy.int)
+    self._boundsMat = numpy.zeros((nf, nf), dtype=numpy.float64)
+    self._boundsMat2D = numpy.zeros((nf, nf), dtype=numpy.int64)
     if initMats:
       self._initializeMatrices()
 

--- a/rdkit/Chem/Pharm3D/Pharmacophore.py
+++ b/rdkit/Chem/Pharm3D/Pharmacophore.py
@@ -186,8 +186,7 @@ class ExplicitPharmacophore:
       if txt:
         splitL = spaces.split(txt)
         if len(splitL) < 5:
-          logger.error('Input line %d only contains %d fields, 5 are required. Read failed.' %
-                       (lineNum, len(splitL)))
+          logger.error(f'Input line {lineNum} only contains {len(splitL)} fields, 5 are required. Read failed.')
           return
         fName = splitL[0]
         try:
@@ -196,7 +195,7 @@ class ExplicitPharmacophore:
           zP = float(splitL[3])
           rad = float(splitL[4])
         except ValueError:
-          logger.error('Error parsing a number of line %d. Read failed.' % (lineNum))
+          logger.error(f'Error parsing a number of line {lineNum}. Read failed.')
           return
         feats.append(
           ChemicalFeatures.FreeChemicalFeature(fName, fName, Geometry.Point3D(xP, yP, zP)))

--- a/rdkit/Chem/Pharm3D/UnitTestEmbed.py
+++ b/rdkit/Chem/Pharm3D/UnitTestEmbed.py
@@ -149,7 +149,7 @@ class TestCase(unittest.TestCase):
             tgt = testResults[name]
             self.assertEqual(len(tgt), len(stats))
             print(name)
-            print(','.join(['%.2f' % x for x in stats]))
+            print(','.join([f'{x:.2f}' % x for x in stats]))
             # we'll use different tolerances for the different values:
             self.assertTrue(feq(tgt[0], stats[0], 5.0), (tgt[0], stats[0]))
             for i in range(2, len(tgt)):

--- a/rdkit/Chem/Pharm3D/UnitTestEmbed.py
+++ b/rdkit/Chem/Pharm3D/UnitTestEmbed.py
@@ -149,7 +149,7 @@ class TestCase(unittest.TestCase):
             tgt = testResults[name]
             self.assertEqual(len(tgt), len(stats))
             print(name)
-            print(','.join([f'{x:.2f}' % x for x in stats]))
+            print(','.join([f'{x:.2f}' for x in stats]))
             # we'll use different tolerances for the different values:
             self.assertTrue(feq(tgt[0], stats[0], 5.0), (tgt[0], stats[0]))
             for i in range(2, len(tgt)):

--- a/rdkit/Chem/Pharm3D/UnitTestEmbed.py
+++ b/rdkit/Chem/Pharm3D/UnitTestEmbed.py
@@ -12,16 +12,14 @@ import doctest
 import gzip
 import io
 import os
+import pickle
 import unittest
 
 from rdkit import Chem
 from rdkit import DistanceGeometry as DG
-from rdkit import Geometry
-from rdkit import RDConfig
+from rdkit import Geometry, RDConfig
 from rdkit.Chem import ChemicalFeatures, rdDistGeom
-from rdkit.Chem.Pharm3D import EmbedLib
-from rdkit.Chem.Pharm3D import Pharmacophore
-import pickle
+from rdkit.Chem.Pharm3D import EmbedLib, Pharmacophore
 
 
 def feq(n1, n2, tol=1e-5):
@@ -76,10 +74,7 @@ class TestCase(unittest.TestCase):
     matched, matches = EmbedLib.MatchPharmacophoreToMol(mol, featFactory, pcophore)
     if matched:
       r = EmbedLib.MatchPharmacophore(matches, boundsMat, pcophore, useDownsampling=downSample)
-      if r[0]:
-        return 0
-      else:
-        return 1
+      return int(not bool(r[0]))
     else:
       return 0
 


### PR DESCRIPTION
This is the sub-PR breaking from the large PR 4815: https://github.com/rdkit/rdkit/pull/4815

------
Updated Changes:
- [Remark]: Optimize `DownsampleBoundsMatrix()` in `EmbedLib.py`. The execution is varied depended on the input rather than consuming the worst-case scenario
- [Bug]: `DownsampleBoundsMatrix()` in `EmbedLib.py` now returns the same datatype as input rather than always casting to `np.float64`
- [New]: Drop/Remove one doctest in `OrderTriangle()` as the result of duplication
- [New]: Function `CountUpTo()` use `NumCombinations()` one time if `verbose`  instead of two in the previous examples
- [New]: Remove function `_fact()` of user in `Pharm2D\Utils.py`. Now we used `math.comb()` and `math.factorial()` for computation if python version is 3.8+. Otherwise, use user-defined function to speed up. The current algorithm shared high similarity to the `math.comb()` and is able to prevent numeric overflow. Extra documentation is included.
- [New]: Function `GetUniqueCombinations()` is now faster. However, the acceptance is likely to be reverted if required