### PR TITLE
fix some leaks in the SWIG wrappers

### DIFF
--- a/Code/JavaWrappers/MolOps.i
+++ b/Code/JavaWrappers/MolOps.i
@@ -39,6 +39,10 @@
 %newobject RDKit::MolOps::renumberAtoms;
 %newobject RDKit::MolOps::removeHs;
 %newobject RDKit::MolOps::addHs;
+%newobject RDKit::MolOps::removeAllHs;
+%newobject RDKit::MolOps::mergeQueryHs;
+%newobject RDKit::MolOps::adjustQueryProperties;
+
 %ignore RDKit::MolOps::detectChemistryProblems;
 %include <GraphMol/MolOps.h>
 %ignore RDKit::MolOps::sanitizeMol(RWMol &,unsigned int &,unsigned int &);


### PR DESCRIPTION
This is another basic one to clear up some easy-to-fix leaks due to forgotten `%newobject` calls.

