### PR TITLE
Fix SWIG wrappers for C#

### DIFF
--- a/Code/GraphMol/SmilesParse/SmilesWrite.h
+++ b/Code/GraphMol/SmilesParse/SmilesWrite.h
@@ -50,10 +50,7 @@ enum CXSmilesFields : uint32_t {
   CX_ENHANCEDSTEREO = 1 << 6,
   CX_SGROUPS = 1 << 7,
   CX_POLYMER = 1 << 8,
-  // NB: std::int32_t is intentional as a non-scoped enum is implicitly cast to
-  // int so numbers larger than std::numeric_limits<std::int32_t>::max() will be
-  // negative
-  CX_ALL = std::numeric_limits<std::int32_t>::max()
+  CX_ALL = 0x7fffffff
 };
 
 //! \brief returns the cxsmiles data for a molecule


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

`std::numeric_limits<std::int32_t>::max()` is not handled properly by SWIG for C#.  This PR fixes to use an literal integer.

#### Any other comments?

Because this enum is `uint32`, general formula is not needed. Another expression like `INT_MAX` also does not work. 
