### PR TITLE
Fixes definition of eccentricity (#4952)

### DIFF
--- a/rdkit/Chem/Descriptors3D.py
+++ b/rdkit/Chem/Descriptors3D.py
@@ -146,7 +146,7 @@ if hasattr(rdMolDescriptors, 'CalcPMI1'):
        https://doi.org/10.1002/9783527618279.ch37
 
        Definition:
-         sqrt(pm3**2 -pm1**2) / pm3**2
+         sqrt(pm3**2 -pm1**2) / pm3
 
     **Arguments**
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! 
-->
#### Reference Issue

Fixes #4952 .  

#### Implementation

The definition of eccentricity should have only `pm3` in the denominator, not `pm3**2`.   The C++ implementation is correct.


