### PR TITLE
fix CMakeLists.txt extracting link line from python LDSHARED config var

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -348,7 +348,7 @@ if(RDK_BUILD_PYTHON_WRAPPERS)
     # We strip off the first word though (which will be the compiler name).
     execute_process(
         COMMAND
-        ${PYTHON_EXECUTABLE} -c "from distutils import sysconfig; print(sysconfig.get_config_var('LDSHARED').split(' ', 1)[1])"
+        ${PYTHON_EXECUTABLE} -c "from distutils import sysconfig; print(sysconfig.get_config_var('LDSHARED').lstrip().split(' ', 1)[1])"
         OUTPUT_VARIABLE PYTHON_LDSHARED
         OUTPUT_STRIP_TRAILING_WHITESPACE
      )


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! 
-->
#### What does this implement/fix? Explain your changes.
A build using Anaconda's python 3.9 on CentOS7 was consistently failing on linking a shared object, with an error message reporting that `x86_64-conda-linux-gnu-gcc` couldn't be found.

It eventually turned out that the problem originated from a leading whitespace character in the string returned (in the conda build environment) by `sysconfig.get_config_var('LDSHARED')`. Because of this leading whitespace character, the compiler program name wasn't [removed](https://github.com/rdkit/rdkit/blob/master/CMakeLists.txt#L351) from the string by `.split(' ', 1)[1]` and it was therefore included in the `PYTHON_LDSHARED` cmake variable.

This resulted in the misplaced occurrence of `x86_64-conda-linux-gnu-gcc` in the link command generated by cmake for some shared objects.

#### Any other comments?
For reference this is the value returned by `sysconfig.get_config_var('LDSHARED')` for the same build using python 3.8:

    "x86_64-conda-linux-gnu-gcc -pthread -shared -Wl,-O2 -Wl,--sort-common -Wl,--as-needed -Wl,-z,relro -Wl,-z,now -Wl,-rpath,$PREFIX/lib -L$PREFIX/lib -Wl,-O2 -Wl,--sort-common -Wl,--as-needed -Wl,-z,relro -Wl,-z,now -Wl,-rpath,$PREFIX/lib -L$PREFIX/lib"

and (for reasons that are unknown to me) this is the string returned by python 3.9:

    " x86_64-conda-linux-gnu-gcc -pthread -shared -Wl,-O2 -Wl,--sort-common -Wl,--as-needed -Wl,-z,relro -Wl,-z,now -Wl,--disable-new-dtags -Wl,--gc-sections -Wl,-rpath,$PREFIX/lib -Wl,-rpath-link,$PREFIX/lib -L$PREFIX/lib -L$PREFIX/lib -Wl,-O2 -Wl,--sort-common -Wl,--as-needed -Wl,-z,relro -Wl,-z,now -Wl,--disable-new-dtags -Wl,--gc-sections -Wl,-rpath,$PREFIX/lib -Wl,-rpath-link,$PREFIX/lib -L$PREFIX/lib"
