### PR TITLE
fix to work tests when RDK_USE_BOOST_IOSTREAMS=OFF

### DIFF
--- a/Code/GraphMol/FileParsers/GeneralFileReader.h
+++ b/Code/GraphMol/FileParsers/GeneralFileReader.h
@@ -106,7 +106,11 @@ std::unique_ptr<MolSupplier> getSupplier(const std::string& path,
   if (compressionFormat.empty()) {
     strm = new std::ifstream(path.c_str(), std::ios::in | std::ios::binary);
   } else {
+#if RDK_USE_BOOST_IOSTREAMS 
     strm = new gzstream(path);
+#else
+    throw BadFileException("Unsupported fileFormat: " + fileFormat);
+#endif
   }
 
   //! Dispatch to the appropriate supplier

--- a/Code/GraphMol/FileParsers/testMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/testMolSupplier.cpp
@@ -296,6 +296,7 @@ int testMolSup() {
     TEST_ASSERT(ok);
   }
 
+#if RDK_USE_BOOST_IOSTREAMS
   {  // Test Maestro PDB property reading
     fname = rdbase + "/Code/GraphMol/FileParsers/test_data/1kv1.maegz";
     auto *strm = new gzstream(fname);
@@ -309,6 +310,7 @@ int testMolSup() {
     TEST_ASSERT(info->getChainId() == "A");
     TEST_ASSERT(info->getResidueNumber() == 5);
   }
+#endif
 #endif  // RDK_BUILD_MAEPARSER_SUPPORT
   return 1;
 }
@@ -2330,6 +2332,7 @@ int testForwardSDSupplier() {
     }
     TEST_ASSERT(i == 1663);
   }
+#if RDK_USE_BOOST_IOSTREAMS  
   {
     gzstream strm(maefname2);
 
@@ -2361,6 +2364,7 @@ int testForwardSDSupplier() {
     }
     TEST_ASSERT(i == 16);
   }
+#endif
 #endif  // RDK_BUILD_MAEPARSER_SUPPORT
 
   return 1;

--- a/Code/GraphMol/FileParsers/testMultithreadedMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/testMultithreadedMolSupplier.cpp
@@ -339,6 +339,7 @@ void testPerformance() {
     std::cout << "Duration for SmilesMolSupplier: " << duration.count()
               << " (milliseconds) \n";
 
+#if RDK_USE_BOOST_IOSTREAMS
     for (unsigned int i = maxThreadCount; i >= 1; --i) {
       std::istream *strm = new gzstream(rdbase + gzpath);
       start = high_resolution_clock::now();
@@ -352,6 +353,7 @@ void testPerformance() {
                 << "  writer threads: " << duration.count()
                 << " (milliseconds) \n";
     }
+#endif
   }
 #endif
 
@@ -376,6 +378,7 @@ void testPerformance() {
     std::cout << "Duration for SDMolSupplier: " << duration.count()
               << " (milliseconds) \n";
 
+#if RDK_USE_BOOST_IOSTREAMS
     for (unsigned int i = maxThreadCount; i >= 1; --i) {
       std::istream *strm = new gzstream(rdbase + gzpath);
       bool takeOwnership = true;
@@ -388,6 +391,7 @@ void testPerformance() {
                 << "  writer threads: " << duration.count()
                 << " (milliseconds) \n";
     }
+#endif
   }
 }
 


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

This PR fixes tests for `RDK_USE_BOOST_IOSTREAMS=OFF`.

#### Any other comments?

`RDK_USE_BOOST_IOSTREAMS=OFF` issue was fixed on https://github.com/rdkit/rdkit/pull/4933, but only for non-test files.
