### PR TITLE
add JavaGzStreamTests

### DIFF
--- a/Code/JavaWrappers/gmwrapper/CMakeLists.txt
+++ b/Code/JavaWrappers/gmwrapper/CMakeLists.txt
@@ -187,10 +187,6 @@ ADD_CUSTOM_TARGET(BuildJavaWrapperTests ALL
   DEPENDS ${CMAKE_JAVA_TEST_OUTDIR}/org/RDKit/WrapperTests.class GraphMolWrap
   COMMENT "building test classes"
 )
-ADD_CUSTOM_TARGET(RunJavaWrapperTests
-  DEPENDS BuildJavaWrapperTests
-  COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/runUnitTests.sh
-)
 
 # need to add boost libs for testing
 SET (CTEST_ENVIRONMENT
@@ -290,6 +286,12 @@ ADD_TEST(JavaSuppliersTests
     java -Djava.library.path=${CMAKE_CURRENT_SOURCE_DIR}
 	-cp "${JUNIT_JAR}${PATH_SEP}${CMAKE_JAVA_TEST_OUTDIR}${PATH_SEP}${CMAKE_CURRENT_SOURCE_DIR}/org.RDKit.jar"
 	org.RDKit.SuppliersTests)
+if(RDK_USE_BOOST_IOSTREAMS)
+ADD_TEST(JavaGzStreamTests
+    java -Djava.library.path=${CMAKE_CURRENT_SOURCE_DIR}
+	-cp "${JUNIT_JAR}${PATH_SEP}${CMAKE_JAVA_TEST_OUTDIR}${PATH_SEP}${CMAKE_CURRENT_SOURCE_DIR}/org.RDKit.jar"
+	org.RDKit.GzStreamTests)
+endif(RDK_USE_BOOST_IOSTREAMS)
 ADD_TEST(JavaTrajectoryTests
     java -Djava.library.path=${CMAKE_CURRENT_SOURCE_DIR}
 	-cp "${JUNIT_JAR}${PATH_SEP}${CMAKE_JAVA_TEST_OUTDIR}${PATH_SEP}${CMAKE_CURRENT_SOURCE_DIR}/org.RDKit.jar"
@@ -395,7 +397,7 @@ ADD_TEST(JavaBitOpsTests
 		-cp "${JUNIT_JAR}${PATH_SEP}${CMAKE_JAVA_TEST_OUTDIR}${PATH_SEP}${CMAKE_CURRENT_SOURCE_DIR}/org.RDKit.jar"
 		org.RDKit.BitOpsTests)
 
-    ADD_TEST(MolStandardizeTest
+ADD_TEST(MolStandardizeTest
     java -Djava.library.path=${CMAKE_CURRENT_SOURCE_DIR}
     -cp "${JUNIT_JAR}${PATH_SEP}${CMAKE_JAVA_TEST_OUTDIR}${PATH_SEP}${CMAKE_CURRENT_SOURCE_DIR}/org.RDKit.jar"
     org.RDKit.MolStandardizeTest)


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

- This PR adds `JavaGzStreamTests` test to `CMakeLists.txt`. `GzStreamTests` is introduced at https://github.com/rdkit/rdkit/pull/4933.
- `RunJavaWrapperTests` also deleted because `runUnitTests.sh` is missing.
