### PR TITLE
Fix memory safety issues found by OSS-Fuzz

### DIFF
--- a/Code/GraphMol/Chirality.cpp
+++ b/Code/GraphMol/Chirality.cpp
@@ -1038,10 +1038,12 @@ void iterateCIPRanks(const ROMol &mol, const DOUBLE_VECT &invars,
     numRanks = *std::max_element(ranks.begin(), ranks.end()) + 1;
 
     // now truncate each vector and stick the rank at the end
-    for (unsigned int i = 0; i < numAtoms; ++i) {
-      cipEntries[i][numIts + 1] = ranks[i];
-      cipEntries[i].erase(cipEntries[i].begin() + numIts + 2,
-                          cipEntries[i].end());
+    if (static_cast<unsigned int>(lastNumRanks) != numRanks) {
+      for (unsigned int i = 0; i < numAtoms; ++i) {
+        cipEntries[i][numIts + 1] = ranks[i];
+        cipEntries[i].erase(cipEntries[i].begin() + numIts + 2,
+                            cipEntries[i].end());
+      }
     }
 
     ++numIts;

--- a/Code/GraphMol/FileParsers/MolSGroupParsing.cpp
+++ b/Code/GraphMol/FileParsers/MolSGroupParsing.cpp
@@ -942,7 +942,7 @@ std::vector<T> ParseV3000Array(std::stringstream &stream, int maxV,
         << "WARNING: first character of V3000 array is not '('" << std::endl;
   }
 
-  unsigned int count;
+  unsigned int count = 0;
   stream >> count;
   std::vector<T> values;
   if (maxV >= 0 && count > static_cast<unsigned int>(maxV)) {
@@ -1009,8 +1009,8 @@ void ParseV3000SAPLabel(RWMol *mol, SubstanceGroup &sgroup,
                         std::stringstream &stream, bool strictParsing) {
   stream.get();  // discard parentheses
 
-  unsigned int count;
-  unsigned int aIdxMark;
+  unsigned int count = 0;
+  unsigned int aIdxMark = 0;
   std::string lvIdxStr;  // In V3000 this may be a string
   std::string sapIdStr;
   stream >> count >> aIdxMark >> lvIdxStr >> sapIdStr;

--- a/Code/GraphMol/RWMol.cpp
+++ b/Code/GraphMol/RWMol.cpp
@@ -151,6 +151,21 @@ void RWMol::replaceAtom(unsigned int idx, Atom *atom_pin, bool,
       }
     }
   }
+
+  // handle stereo group
+  for (auto &group : d_stereo_groups) {
+    auto atoms = group.getAtoms();
+    bool found = std::find(atoms.begin(), atoms.end(), orig_p) != atoms.end();
+    if (found) {
+      std::vector<Atom*> new_atoms = atoms;
+      for (auto &elem : new_atoms) {
+        if (elem == orig_p) {
+          elem = atom_p;
+        }
+      }
+      group = StereoGroup(group.getGroupType(), new_atoms);
+    }
+  }
 };
 
 void RWMol::replaceBond(unsigned int idx, Bond *bond_pin, bool preserveProps,

--- a/Code/GraphMol/RWMol.cpp
+++ b/Code/GraphMol/RWMol.cpp
@@ -155,15 +155,10 @@ void RWMol::replaceAtom(unsigned int idx, Atom *atom_pin, bool,
   // handle stereo group
   for (auto &group : d_stereo_groups) {
     auto atoms = group.getAtoms();
-    bool found = std::find(atoms.begin(), atoms.end(), orig_p) != atoms.end();
-    if (found) {
-      std::vector<Atom*> new_atoms = atoms;
-      for (auto &elem : new_atoms) {
-        if (elem == orig_p) {
-          elem = atom_p;
-        }
-      }
-      group = StereoGroup(group.getGroupType(), new_atoms);
+    auto aiter = std::find(atoms.begin(), atoms.end(), orig_p);
+    if (aiter != atoms.end()) {
+      *aiter = atom_p;
+      group = StereoGroup(group.getGroupType(), std::move(atoms));
     }
   }
 };

--- a/Code/GraphMol/catch_chirality.cpp
+++ b/Code/GraphMol/catch_chirality.cpp
@@ -1738,3 +1738,19 @@ TEST_CASE("StereoGroup Testing") {
     CHECK(mol->getStereoGroups().size() == 1);
   }
 }
+
+TEST_CASE("replaceAtom and StereoGroups") {
+  SECTION("basics") {
+    auto mol = "C[C@](O)(Cl)[C@H](F)Cl |o1:1,4|"_smiles;
+    REQUIRE(mol);
+    CHECK(mol->getStereoGroups().size() == 1);
+    CHECK(mol->getStereoGroups()[0].getAtoms().size() == 2);
+    CHECK(mol->getStereoGroups()[0].getAtoms()[0] == mol->getAtomWithIdx(1));
+
+    Atom acp(*mol->getAtomWithIdx(1));
+    mol->replaceAtom(1, &acp);
+    CHECK(mol->getStereoGroups().size() == 1);
+    CHECK(mol->getStereoGroups()[0].getAtoms().size() == 2);
+    CHECK(mol->getStereoGroups()[0].getAtoms()[0] == mol->getAtomWithIdx(1));
+  }
+}

--- a/Code/RDGeneral/StreamOps.h
+++ b/Code/RDGeneral/StreamOps.h
@@ -307,7 +307,7 @@ template <class T>
 void streamReadVec(std::istream &ss, T &val) {
   boost::uint64_t size;
   streamRead(ss, size);
-  val.resize(size);
+  val.resize(boost::numeric_cast<size_t>(size));
 
   for (size_t i = 0; i < size; ++i) streamRead(ss, val[i]);
 }


### PR DESCRIPTION
This PR attempts to fix most of the open security-relevant issues found by OSS-Fuzz:
- https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=36998: `RWMol::replaceAtom` needs to update references in stereo groups to avoid use-after-frees. Fixed in ae37e6eb3dabcb793b21ed679a4e4f4b4514a019
- https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=28660: `iterateCIPRanks` wrote out-of-bounds in some cases when the rank did not change in the current iteration. Fixed in a88de3ed64a5278ac25e8541cbdc347a108e1bbd with an extra bounds check.
- https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=25220 and https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=25225: A couple of functions used uninitialized variables. 14b852bcee980db6a655bdb357f2905939bddc44 initializes them.
-  https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=28034: an implicit cast on 32-bit systems would lead to allocating the wrong number of elements in `streamReadVec`, leading to an out-of-bounds write. Fixed in ace149aba1d31845c89177297f92b5c918af878e with a `numeric_cast`, which will throw an exception if the casted value is out of range.