### PR TITLE
AssignStereochemistry should remove nonchiral atoms from StereoGroups

### DIFF
--- a/Code/GraphMol/Chirality.cpp
+++ b/Code/GraphMol/Chirality.cpp
@@ -1826,6 +1826,28 @@ INT_VECT findStereoAtoms(const Bond *bond) {
   }
 }
 
+void cleanupStereoGroups(ROMol &mol) {
+  std::vector<StereoGroup> newsgs;
+  for (auto sg : mol.getStereoGroups()) {
+    std::vector<Atom *> okatoms;
+    bool keep = true;
+    for (const auto atom : sg.getAtoms()) {
+      if (atom->getChiralTag() == Atom::ChiralType::CHI_UNSPECIFIED) {
+        keep = false;
+      } else {
+        okatoms.push_back(atom);
+      }
+    }
+
+    if (keep) {
+      newsgs.push_back(sg);
+    } else if (!okatoms.empty()) {
+      newsgs.emplace_back(sg.getGroupType(), std::move(okatoms));
+    }
+  }
+  mol.setStereoGroups(std::move(newsgs));
+}
+
 }  // namespace Chirality
 
 namespace MolOps {
@@ -2075,6 +2097,7 @@ void assignStereochemistry(ROMol &mol, bool cleanIt, bool force,
       }
 #endif
     }
+    Chirality::cleanupStereoGroups(mol);
   }
   mol.setProp(common_properties::_StereochemDone, 1, true);
 

--- a/Code/GraphMol/Chirality.h
+++ b/Code/GraphMol/Chirality.h
@@ -114,6 +114,9 @@ RDKIT_GRAPHMOL_EXPORT std::vector<StereoInfo> findPotentialStereo(
 RDKIT_GRAPHMOL_EXPORT std::vector<StereoInfo> findPotentialStereo(
     const ROMol &mol);
 
+//! removes atoms without specified chirality from stereo groups
+RDKIT_GRAPHMOL_EXPORT void cleanupStereoGroups(ROMol &mol);
+
 /// @cond
 namespace detail {
 RDKIT_GRAPHMOL_EXPORT bool isAtomPotentialTetrahedralCenter(const Atom *atom);

--- a/Code/GraphMol/ROMol.h
+++ b/Code/GraphMol/ROMol.h
@@ -699,6 +699,15 @@ class RDKIT_GRAPHMOL_EXPORT ROMol : public RDProps {
     return d_stereo_groups;
   }
 
+  //! Sets groups of atoms with relative stereochemistry
+  /*!
+    \param stereo_groups the new set of stereo groups. All will be replaced.
+
+    Stereo groups are also called enhanced stereochemistry in the SDF/Mol3000
+    file format. stereo_groups should be std::move()ed into this function.
+  */
+  void setStereoGroups(std::vector<StereoGroup> stereo_groups);
+
  private:
   MolGraph d_graph;
   ATOM_BOOKMARK_MAP d_atomBookmarks;
@@ -750,14 +759,6 @@ class RDKIT_GRAPHMOL_EXPORT ROMol : public RDProps {
   */
   unsigned int addBond(Bond *bond, bool takeOwnership = false);
 
-  //! Sets groups of atoms with relative stereochemistry
-  /*!
-    \param stereo_groups the new set of stereo groups. All will be replaced.
-
-    Stereo groups are also called enhanced stereochemistry in the SDF/Mol3000
-    file format. stereo_groups should be std::move()ed into this function.
-  */
-  void setStereoGroups(std::vector<StereoGroup> stereo_groups);
   //! adds a Bond to our collection
   /*!
     \param bond          pointer to the Bond to add

--- a/Code/GraphMol/RWMol.h
+++ b/Code/GraphMol/RWMol.h
@@ -192,18 +192,7 @@ class RDKIT_GRAPHMOL_EXPORT RWMol : public ROMol {
 
   //@}
 
-  //! Sets groups of atoms with relative stereochemistry
-  /*!
-    \param stereo_groups the new set of stereo groups. All will be replaced.
-
-    Stereo groups are also called enhanced stereochemistry in the SDF/Mol3000
-    file format. stereo_groups should be std::move()ed into this function.
-  */
-  void setStereoGroups(std::vector<StereoGroup> &&stereo_groups) {
-    return ROMol::setStereoGroups(std::move(stereo_groups));
-  }
-
-  //! removes all atoms, bonds, properties, bookmarks, etc.
+    //! removes all atoms, bonds, properties, bookmarks, etc.
   void clear() {
     destroy();
     d_confs.clear();

--- a/Code/GraphMol/SmilesParse/catch_tests.cpp
+++ b/Code/GraphMol/SmilesParse/catch_tests.cpp
@@ -255,10 +255,10 @@ TEST_CASE("github #2257: writing cxsmiles", "[smiles][cxsmiles]") {
     CHECK(smi == "CN |$_AV:val1;val2$,atomProp:0.p2.v2:1.p1.v1|");
   }
   SECTION("enhanced stereo 1") {
-    auto mol = "C[C@H](F)[C@H](C)[C@@H](C)Br |a:1,o1:4,5|"_smiles;
+    auto mol = "C[C@H](F)[C@H](C)[C@@H](C)Br |a:1,o1:3,5|"_smiles;
     REQUIRE(mol);
     auto smi = MolToCXSmiles(*mol);
-    CHECK(smi == "C[C@H](F)[C@H](C)[C@@H](C)Br |a:1,o1:4,5|");
+    CHECK(smi == "C[C@H](F)[C@H](C)[C@@H](C)Br |a:1,o1:3,5|");
   }
 
   SECTION("enhanced stereo 2") {

--- a/Code/GraphMol/SmilesParse/cxsmiles_test.cpp
+++ b/Code/GraphMol/SmilesParse/cxsmiles_test.cpp
@@ -422,7 +422,7 @@ void testEnhancedStereo() {
 
   std::vector<unsigned int> atom_ref1({4, 5});
   {
-    std::string smiles = "C[C@H](F)[C@H](C)[C@@H](C)Br |a:1,o1:4,5|";
+    std::string smiles = "C[C@H](F)[C@H](C)[C@@H](C)Br |a:1,o1:3,5|";
     SmilesParserParams params;
     params.allowCXSMILES = true;
     ROMol *m = SmilesToMol(smiles, params);
@@ -445,13 +445,13 @@ void testEnhancedStereo() {
     {
       auto &atoms = stg->getAtoms();
       TEST_ASSERT(atoms.size() == 2);
-      TEST_ASSERT(atoms[0]->getIdx() == 4);
+      TEST_ASSERT(atoms[0]->getIdx() == 3);
       TEST_ASSERT(atoms[1]->getIdx() == 5);
     }
     delete m;
   }
   {
-    std::string smiles = "C[C@H](F)[C@H](C)[C@@H](C)Br |&1:4,5,a:1|";
+    std::string smiles = "C[C@H](F)[C@H](C)[C@@H](C)Br |&1:3,5,a:1|";
     SmilesParserParams params;
     params.allowCXSMILES = true;
     ROMol *m = SmilesToMol(smiles, params);
@@ -467,7 +467,7 @@ void testEnhancedStereo() {
     {
       auto &atoms = stg->getAtoms();
       TEST_ASSERT(atoms.size() == 2);
-      TEST_ASSERT(atoms[0]->getIdx() == 4);
+      TEST_ASSERT(atoms[0]->getIdx() == 3);
       TEST_ASSERT(atoms[1]->getIdx() == 5);
     }
     ++stg;

--- a/Code/GraphMol/catch_chirality.cpp
+++ b/Code/GraphMol/catch_chirality.cpp
@@ -1738,3 +1738,26 @@ TEST_CASE("StereoGroup Testing") {
     CHECK(mol->getStereoGroups().size() == 1);
   }
 }
+
+TEST_CASE("Removing stereogroups from unspecified atoms") {
+  SECTION("basics") {
+    auto mol = "C[C@](O)(Cl)F |o1:1|"_smiles;
+    REQUIRE(mol);
+    CHECK(mol->getStereoGroups().size() == 1);
+    mol->getAtomWithIdx(1)->setChiralTag(Atom::ChiralType::CHI_UNSPECIFIED);
+    Chirality::cleanupStereoGroups(*mol);
+    CHECK(mol->getStereoGroups().empty());
+  }
+  SECTION("parsing") {
+    auto mol = "C[C@](C)(Cl)F |o1:1|"_smiles;
+    REQUIRE(mol);
+    CHECK(mol->getStereoGroups().empty());
+  }
+  SECTION("partial group removal") {
+    auto mol = "C[C@](C)(Cl)[C@H](F)Cl |o1:1,4|"_smiles;
+    REQUIRE(mol);
+    CHECK(mol->getStereoGroups().size() == 1);
+    CHECK(mol->getStereoGroups()[0].getAtoms().size() == 1);
+    CHECK(mol->getStereoGroups()[0].getAtoms()[0]->getIdx() == 4);
+  }
+}

--- a/Code/PgSQL/rdkit/expected/rdkit-91.out
+++ b/Code/PgSQL/rdkit/expected/rdkit-91.out
@@ -960,37 +960,37 @@ select substruct_count('c1ccncc1'::mol,'c1ccncc1'::mol,false);
                2
 (1 row)
 
-select substruct_count('c1ccccc1C[C@@H](O)[C@@H](C)F |&1:1,3,r|'::mol,'c1ccccc1C[C@@H](O)[C@@H](C)F |o1:1,3,r|'::mol);
+select substruct_count('c1ccccc1C[C@@H](O)[C@@H](C)F |&1:7,9,r|'::mol,'c1ccccc1C[C@@H](O)[C@@H](C)F |o1:7,9,r|'::mol);
  substruct_count 
 -----------------
                1
 (1 row)
 
-select substruct_count('c1ccccc1C[C@@H](O)[C@@H](C)F |o1:1,3,r|'::mol,'c1ccccc1C[C@@H](O)[C@@H](C)F |&1:1,3,r|'::mol);
+select substruct_count('c1ccccc1C[C@@H](O)[C@@H](C)F |o1:7,9,r|'::mol,'c1ccccc1C[C@@H](O)[C@@H](C)F |&1:7,9,r|'::mol);
  substruct_count 
 -----------------
                1
 (1 row)
 
-select substruct_count_chiral('c1ccccc1C[C@@H](O)[C@@H](C)F |&1:1,3,r|'::mol,'c1ccccc1C[C@@H](O)[C@@H](C)F |o1:1,3,r|'::mol);
+select substruct_count_chiral('c1ccccc1C[C@@H](O)[C@@H](C)F |&1:7,9,r|'::mol,'c1ccccc1C[C@@H](O)[C@@H](C)F |o1:7,9,r|'::mol);
  substruct_count_chiral 
 ------------------------
                       1
 (1 row)
 
-select substruct_count_chiral('c1ccccc1C[C@@H](O)[C@@H](C)F |o1:1,3,r|'::mol,'c1ccccc1C[C@@H](O)[C@@H](C)F |&1:1,3,r|'::mol);
+select substruct_count_chiral('c1ccccc1C[C@@H](O)[C@@H](C)F |o1:7,9,r|'::mol,'c1ccccc1C[C@@H](O)[C@@H](C)F |&1:7,9,r|'::mol);
  substruct_count_chiral 
 ------------------------
                       0
 (1 row)
 
-select substruct_count_chiral('c1ccccc1C[C@@H](O)[C@@H](C)F |&1:1,3,r|'::mol,'c1ccccc1C[C@@H](O)[C@@H](C)F |o1:1,3,r|'::mol,false);
+select substruct_count_chiral('c1ccccc1C[C@@H](O)[C@@H](C)F |&1:7,9,r|'::mol,'c1ccccc1C[C@@H](O)[C@@H](C)F |o1:7,9,r|'::mol,false);
  substruct_count_chiral 
 ------------------------
                       2
 (1 row)
 
-select substruct_count_chiral('c1ccccc1C[C@@H](O)[C@@H](C)F |o1:1,3,r|'::mol,'c1ccccc1C[C@@H](O)[C@@H](C)F |&1:1,3,r|'::mol,false);
+select substruct_count_chiral('c1ccccc1C[C@@H](O)[C@@H](C)F |o1:7,9,r|'::mol,'c1ccccc1C[C@@H](O)[C@@H](C)F |&1:7,9,r|'::mol,false);
  substruct_count_chiral 
 ------------------------
                       0
@@ -1339,35 +1339,35 @@ select mol_to_smarts(mol_adjust_query_properties('*c1ncc(*)cc1'::qmol));
 (1 row)
 
 -- CXSmiles
-SELECT mol_to_smiles(mol_from_smiles('C[C@H](F)[C@H](C)[C@@H](C)Br |a:1,o1:4,5|'));
+SELECT mol_to_smiles(mol_from_smiles('C[C@H](F)[C@H](C)[C@@H](C)Br |a:1,o1:3,5|'));
         mol_to_smiles         
 ------------------------------
  C[C@H](F)[C@H](C)[C@@H](C)Br
 (1 row)
 
-SELECT mol_to_cxsmiles(mol_from_smiles('C[C@H](F)[C@H](C)[C@@H](C)Br |a:1,o1:4,5|'));
+SELECT mol_to_cxsmiles(mol_from_smiles('C[C@H](F)[C@H](C)[C@@H](C)Br |a:1,o1:3,5|'));
               mol_to_cxsmiles              
 -------------------------------------------
- C[C@H](F)[C@H](C)[C@@H](C)Br |a:1,o1:4,5|
+ C[C@H](F)[C@H](C)[C@@H](C)Br |a:1,o1:3,5|
 (1 row)
 
-SELECT mol_to_cxsmarts(mol_from_smiles('C[C@H](F)[C@H](C)[C@@H](C)Br |a:1,o1:4,5|'));
+SELECT mol_to_cxsmarts(mol_from_smiles('C[C@H](F)[C@H](C)[C@@H](C)Br |a:1,o1:3,5|'));
                           mol_to_cxsmarts                           
 --------------------------------------------------------------------
- [#6]-[#6@H](-[#9])-[#6@H](-[#6])-[#6@@H](-[#6])-[#35] |a:1,o1:4,5|
+ [#6]-[#6@H](-[#9])-[#6@H](-[#6])-[#6@@H](-[#6])-[#35] |a:1,o1:3,5|
 (1 row)
 
-SELECT mol_to_cxsmarts(qmol_from_smarts('C[C@H]([F,Cl,Br])[C@H](C)[C@@H](C)Br |a:1,o1:4,5|'));
+SELECT mol_to_cxsmarts(qmol_from_smarts('C[C@H]([F,Cl,Br])[C@H](C)[C@@H](C)Br |a:1,o1:3,5|'));
                      mol_to_cxsmarts                     
 ---------------------------------------------------------
- C[C@&H1]([F,Cl,Br])[C@&H1](C)[C@@&H1](C)Br |a:1,o1:4,5|
+ C[C@&H1]([F,Cl,Br])[C@&H1](C)[C@@&H1](C)Br |a:1,o1:3,5|
 (1 row)
 
 -- CXSmiles from mol_out
-SELECT mol_out(mol_from_smiles('C[C@H](F)[C@H](C)[C@@H](C)Br |a:1,o1:4,5|'));
+SELECT mol_out(mol_from_smiles('C[C@H](F)[C@H](C)[C@@H](C)Br |a:1,o1:3,5|'));
                   mol_out                  
 -------------------------------------------
- C[C@H](F)[C@H](C)[C@@H](C)Br |a:1,o1:4,5|
+ C[C@H](F)[C@H](C)[C@@H](C)Br |a:1,o1:3,5|
 (1 row)
 
 -- github #3688: bad input to qmol_from_ctab() crashes db

--- a/Code/PgSQL/rdkit/sql/rdkit-91.sql
+++ b/Code/PgSQL/rdkit/sql/rdkit-91.sql
@@ -297,12 +297,12 @@ select rsubstruct_chiral('C[C@@H](O)[C@@H](C)F |o1:1,3,r|'::mol,'C[C@@H](O)[C@@H
 -- substructure counts
 select substruct_count('c1ccncc1'::mol,'c1ccncc1'::mol);
 select substruct_count('c1ccncc1'::mol,'c1ccncc1'::mol,false);
-select substruct_count('c1ccccc1C[C@@H](O)[C@@H](C)F |&1:1,3,r|'::mol,'c1ccccc1C[C@@H](O)[C@@H](C)F |o1:1,3,r|'::mol);
-select substruct_count('c1ccccc1C[C@@H](O)[C@@H](C)F |o1:1,3,r|'::mol,'c1ccccc1C[C@@H](O)[C@@H](C)F |&1:1,3,r|'::mol);
-select substruct_count_chiral('c1ccccc1C[C@@H](O)[C@@H](C)F |&1:1,3,r|'::mol,'c1ccccc1C[C@@H](O)[C@@H](C)F |o1:1,3,r|'::mol);
-select substruct_count_chiral('c1ccccc1C[C@@H](O)[C@@H](C)F |o1:1,3,r|'::mol,'c1ccccc1C[C@@H](O)[C@@H](C)F |&1:1,3,r|'::mol);
-select substruct_count_chiral('c1ccccc1C[C@@H](O)[C@@H](C)F |&1:1,3,r|'::mol,'c1ccccc1C[C@@H](O)[C@@H](C)F |o1:1,3,r|'::mol,false);
-select substruct_count_chiral('c1ccccc1C[C@@H](O)[C@@H](C)F |o1:1,3,r|'::mol,'c1ccccc1C[C@@H](O)[C@@H](C)F |&1:1,3,r|'::mol,false);
+select substruct_count('c1ccccc1C[C@@H](O)[C@@H](C)F |&1:7,9,r|'::mol,'c1ccccc1C[C@@H](O)[C@@H](C)F |o1:7,9,r|'::mol);
+select substruct_count('c1ccccc1C[C@@H](O)[C@@H](C)F |o1:7,9,r|'::mol,'c1ccccc1C[C@@H](O)[C@@H](C)F |&1:7,9,r|'::mol);
+select substruct_count_chiral('c1ccccc1C[C@@H](O)[C@@H](C)F |&1:7,9,r|'::mol,'c1ccccc1C[C@@H](O)[C@@H](C)F |o1:7,9,r|'::mol);
+select substruct_count_chiral('c1ccccc1C[C@@H](O)[C@@H](C)F |o1:7,9,r|'::mol,'c1ccccc1C[C@@H](O)[C@@H](C)F |&1:7,9,r|'::mol);
+select substruct_count_chiral('c1ccccc1C[C@@H](O)[C@@H](C)F |&1:7,9,r|'::mol,'c1ccccc1C[C@@H](O)[C@@H](C)F |o1:7,9,r|'::mol,false);
+select substruct_count_chiral('c1ccccc1C[C@@H](O)[C@@H](C)F |o1:7,9,r|'::mol,'c1ccccc1C[C@@H](O)[C@@H](C)F |&1:7,9,r|'::mol,false);
 
 -- special queries
 select 'c1ccc[nH]1'::mol@>mol_from_smiles('c1cccn1[H]') as match;
@@ -459,13 +459,13 @@ select mol_to_smarts(mol_adjust_query_properties('*c1ncc(*)cc1'::qmol));
 
 
 -- CXSmiles
-SELECT mol_to_smiles(mol_from_smiles('C[C@H](F)[C@H](C)[C@@H](C)Br |a:1,o1:4,5|'));
-SELECT mol_to_cxsmiles(mol_from_smiles('C[C@H](F)[C@H](C)[C@@H](C)Br |a:1,o1:4,5|'));
-SELECT mol_to_cxsmarts(mol_from_smiles('C[C@H](F)[C@H](C)[C@@H](C)Br |a:1,o1:4,5|'));
-SELECT mol_to_cxsmarts(qmol_from_smarts('C[C@H]([F,Cl,Br])[C@H](C)[C@@H](C)Br |a:1,o1:4,5|'));
+SELECT mol_to_smiles(mol_from_smiles('C[C@H](F)[C@H](C)[C@@H](C)Br |a:1,o1:3,5|'));
+SELECT mol_to_cxsmiles(mol_from_smiles('C[C@H](F)[C@H](C)[C@@H](C)Br |a:1,o1:3,5|'));
+SELECT mol_to_cxsmarts(mol_from_smiles('C[C@H](F)[C@H](C)[C@@H](C)Br |a:1,o1:3,5|'));
+SELECT mol_to_cxsmarts(qmol_from_smarts('C[C@H]([F,Cl,Br])[C@H](C)[C@@H](C)Br |a:1,o1:3,5|'));
 
 -- CXSmiles from mol_out
-SELECT mol_out(mol_from_smiles('C[C@H](F)[C@H](C)[C@@H](C)Br |a:1,o1:4,5|'));
+SELECT mol_out(mol_from_smiles('C[C@H](F)[C@H](C)[C@@H](C)Br |a:1,o1:3,5|'));
 
 -- github #3688: bad input to qmol_from_ctab() crashes db
 select qmol_from_ctab('a'::cstring,false);


### PR DESCRIPTION
The current code doesn't do anything about `StereoGroup`s when chiral info is removed from atoms.
Example 1, here there should be no `StereoGroup`:
```
In [39]: m = Chem.MolFromSmiles('C[C@](C)(Cl)F |o1:1|')

In [40]: Chem.MolToCXSmiles(m)
Out[40]: 'CC(C)(F)Cl |o1:1|'
```
And here the nonchiral atom should be removed from the `StereoGroup`
```
In [41]: m = Chem.MolFromSmiles('C[C@](C)(Cl)[C@H](F)Cl |o1:1,4|')

In [42]: Chem.MolToCXSmiles(m)
Out[42]: 'CC(C)(Cl)[C@H](F)Cl |o1:1,4|'
```

This PR fixes the problem by adding a new function `cleanupStereoGroups()` which is called from `AssignStereochemistry()` (it's also part of the `RDKit::Chirality` public API, so it can be called elsewhere).

The other change in this PR is to move the method `ROMol::setStereoGroups()` from private to public visibility and remove `RWMol::setStereoGroups()`, which is no longer necessary. Given that `setStereoGroups()` doesn't change connectivity, there's no reason for it to be public only in RWMol and not in ROMol.

Due to this last change, I'm assigning this bug fix to the `2022_03_1` milestone.