### PR TITLE
Expose baseFontSize to Python and JSON drawOptions

### DIFF
--- a/Code/GraphMol/MolDraw2D/MolDraw2DUtils.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DUtils.cpp
@@ -164,6 +164,7 @@ void updateDrawerParamsFromJSON(MolDraw2D &drawer, const std::string &json) {
   PT_OPT_GET(includeAtomTags);
   PT_OPT_GET(clearBackground);
   PT_OPT_GET(legendFontSize);
+  PT_OPT_GET(baseFontSize);
   PT_OPT_GET(maxFontSize);
   PT_OPT_GET(minFontSize);
   PT_OPT_GET(annotationFontScale);

--- a/Code/GraphMol/MolDraw2D/Wrap/rdMolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/Wrap/rdMolDraw2D.cpp
@@ -722,6 +722,9 @@ BOOST_PYTHON_MODULE(rdMolDraw2D) {
                      "clear the background before drawing a molecule")
       .def_readwrite("legendFontSize", &RDKit::MolDrawOptions::legendFontSize,
                      "font size in pixels of the legend (if drawn)")
+      .def_readwrite("baseFontSize", &RDKit::MolDrawOptions::baseFontSize,
+                     "when > 0 this is used to set the baseFontSize used for text "
+                     "drawing, which otherwise defaults to 0.6")
       .def_readwrite("maxFontSize", &RDKit::MolDrawOptions::maxFontSize,
                      "maximum font size in pixels. default=40, -1 means no"
                      " maximum.")


### PR DESCRIPTION
With reference to discussion #4652, I thought it would be useful to expose both to Python and JSON `drawOptions` the `baseFontSize` setting that currently is exposed only to C++.

Side note: I find the naming `baseFontSize` a bit confusing since the settings seems to be a scale rather than an absolute size; @DavidACosgrove: should we consider changing the naming and deprecate the old one?

Also, the behavior of `setFontSize()` seems a bit odd:
```
drawer = rdMolDraw2D.MolDraw2DSVG(300, 300)
drawer.FontSize()
0.6
```
Again, this looks like a scale rather than a font size.
If I call `SetFontSize(0.6)` (same value as returned by the accessor) I would expect no change; instead, I get a warning and afterwards `fontSize` is set to a different value than it was before:
```
SetFontSize(0.6)
[22:41:12] The new font size 0.6 is below the current minimum (6).
drawer.FontSize()
6.0
```
Looking at the `DrawText::setFontSize()` code I can see why this happens: `setFontSize()` actually calls `setFontScale()`, which I also find a bit confusing as `setFontScale()` is itself a public function that I could have called directly (though not from Python, as it is not exposed).
Additionally, if I set `fontSize` to a quite different value, e.g.:
```
drawer.SetFontSize(30)
drawer.FontSize()
30
```
I see no difference in the size of the fonts in the molecule (while changing `baseFontSize` does change the lettering base size as one would expect).