### PR TITLE
Fixes #4996 and #4998

### DIFF
--- a/Code/GraphMol/CIPLabeler/CIPMol.cpp
+++ b/Code/GraphMol/CIPLabeler/CIPMol.cpp
@@ -62,7 +62,10 @@ int CIPMol::getBondOrder(Bond *bond) const {
   PRECONDITION(bond, "bad bond")
   if (dp_kekulized_mol == nullptr) {
     auto tmp = new RWMol(d_mol);
-    MolOps::Kekulize(*tmp);
+    try {
+      MolOps::Kekulize(*tmp);
+    } catch (const MolSanitizeException &) {
+    }
     const_cast<CIPMol *>(this)->dp_kekulized_mol.reset(tmp);
   }
 
@@ -78,6 +81,11 @@ int CIPMol::getBondOrder(Bond *bond) const {
     case Bond::DATIVER:
       return 0;
     case Bond::SINGLE:
+      return 1;
+    case Bond::AROMATIC:
+      BOOST_LOG(rdWarningLog)
+          << "non kekulizable aromatic bond being treated as bond order 1"
+          << std::endl;
       return 1;
     case Bond::DOUBLE:
       return 2;

--- a/Code/GraphMol/CIPLabeler/CMakeLists.txt
+++ b/Code/GraphMol/CIPLabeler/CMakeLists.txt
@@ -28,7 +28,7 @@ rdkit_headers(CIPLabeler.h
               TooManyNodesException.h
               DEST CIPLabeler)
 
-rdkit_catch_test(testCIPLabeler catch_tests.cpp
+rdkit_catch_test(testCIPLabeler catch_tests.cpp ../catch_main.cpp
                  CIPMol.cpp CIPLabeler.cpp
                  Mancude.cpp Digraph.cpp Node.cpp Edge.cpp Sort.cpp
                  ${configs_src} ${rules_src}

--- a/Code/GraphMol/CIPLabeler/catch_tests.cpp
+++ b/Code/GraphMol/CIPLabeler/catch_tests.cpp
@@ -511,3 +511,35 @@ TEST_CASE(
     CHECK(cip == "s");
   }
 }
+
+TEST_CASE("CIP code errors on fragments which cannot be kekulized",
+          "[accurateCIP]") {
+  SECTION("fragment not affecting the stereochem") {
+    auto m = "F[C@H](CNC)CCc(:c):c"_smarts;
+    m->getAtomWithIdx(1)->clearProp(common_properties::_CIPCode);
+    m->updatePropertyCache();
+    CIPLabeler::assignCIPLabels(*m);
+    std::string cip;
+    CHECK(m->getAtomWithIdx(1)->getPropIfPresent(common_properties::_CIPCode,
+                                                 cip));
+    CHECK(cip == "S");
+  }
+  SECTION("fragment, unique bits") {
+    auto m = "F[C@H](C(N)C)c(:c):c"_smarts;
+    m->getAtomWithIdx(1)->clearProp(common_properties::_CIPCode);
+    m->updatePropertyCache();
+    CIPLabeler::assignCIPLabels(*m);
+    std::string cip;
+    CHECK(m->getAtomWithIdx(1)->getPropIfPresent(common_properties::_CIPCode,
+                                                 cip));
+  }
+  SECTION("fragment, non-unique bits") {
+    auto m = "F[C@H]([C]([NH])[CH2])c(:n):c"_smarts;
+    m->getAtomWithIdx(1)->clearProp(common_properties::_CIPCode);
+    m->updatePropertyCache();
+    CIPLabeler::assignCIPLabels(*m);
+    std::string cip;
+    CHECK(!m->getAtomWithIdx(1)->getPropIfPresent(common_properties::_CIPCode,
+                                                  cip));
+  }
+}

--- a/Code/GraphMol/CIPLabeler/catch_tests.cpp
+++ b/Code/GraphMol/CIPLabeler/catch_tests.cpp
@@ -468,22 +468,20 @@ TEST_CASE("para-stereochemistry", "[accurateCIP]") {
 TEST_CASE(
     "Github #4996: Bad handling of dummy atoms in the CIP assignment code",
     "[accurateCIP]") {
-  // SECTION("case 0") {
-  //   auto m = "C[C@](F)(Cl)Br"_smiles;
-  //   REQUIRE(m);
-  //   m->getAtomWithIdx(1)->clearProp(common_properties::_CIPCode);
-  //   CIPLabeler::assignCIPLabels(*m);
-  //   std::string cip;
-  //   CHECK(m->getAtomWithIdx(1)->getPropIfPresent(common_properties::_CIPCode,
-  //                                                cip));
-  //   CHECK(cip == "S");
-  // }
   SECTION("case 1") {
     auto m = "*[C@](F)(Cl)Br"_smiles;
     REQUIRE(m);
+    bool cleanit = true;
+    bool force = true;
+    // original assignment:
+    MolOps::assignStereochemistry(*m, cleanit, force);
+    std::string cip;
+    CHECK(m->getAtomWithIdx(1)->getPropIfPresent(common_properties::_CIPCode,
+                                                 cip));
+    CHECK(cip == "S");
+
     m->getAtomWithIdx(1)->clearProp(common_properties::_CIPCode);
     CIPLabeler::assignCIPLabels(*m);
-    std::string cip;
     CHECK(m->getAtomWithIdx(1)->getPropIfPresent(common_properties::_CIPCode,
                                                  cip));
     CHECK(cip == "S");
@@ -491,15 +489,26 @@ TEST_CASE(
   SECTION("dummies can match dummies") {
     auto m = "*[C@](*)(Cl)Br"_smiles;
     REQUIRE(m);
-    m->getAtomWithIdx(1)->clearProp(common_properties::_CIPCode);
+    bool cleanit = true;
+    bool force = true;
+    // original assignment:
+    MolOps::assignStereochemistry(*m, cleanit, force);
+    CHECK(!m->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
+
     CIPLabeler::assignCIPLabels(*m);
     CHECK(!m->getAtomWithIdx(1)->hasProp(common_properties::_CIPCode));
   }
   SECTION("case 2") {
     auto m = "C1CC[C@](*)2CCCC[C@H]2C1"_smiles;
     REQUIRE(m);
-    m->getAtomWithIdx(3)->clearProp(common_properties::_CIPCode);
-    m->getAtomWithIdx(9)->clearProp(common_properties::_CIPCode);
+
+    bool cleanit = true;
+    bool force = true;
+    // original assignment doesn't work for these:
+    MolOps::assignStereochemistry(*m, cleanit, force);
+    CHECK(!m->getAtomWithIdx(3)->hasProp(common_properties::_CIPCode));
+    CHECK(!m->getAtomWithIdx(9)->hasProp(common_properties::_CIPCode));
+
     CIPLabeler::assignCIPLabels(*m);
     std::string cip;
     CHECK(m->getAtomWithIdx(3)->getPropIfPresent(common_properties::_CIPCode,

--- a/Code/GraphMol/CIPLabeler/rules/Rule1a.cpp
+++ b/Code/GraphMol/CIPLabeler/rules/Rule1a.cpp
@@ -20,9 +20,6 @@ Rule1a::Rule1a() = default;
 int Rule1a::compare(const Edge *a, const Edge *b) const {
   const auto afrac = a->getEnd()->getAtomicNumFraction();
   const auto bfrac = b->getEnd()->getAtomicNumFraction();
-  if (afrac.numerator() == 0 || bfrac.numerator() == 0) {
-    return 0;
-  }
 
   return three_way_comparison(afrac, bfrac);
 }

--- a/Code/GraphMol/CIPLabeler/rules/SequenceRule.cpp
+++ b/Code/GraphMol/CIPLabeler/rules/SequenceRule.cpp
@@ -49,11 +49,6 @@ const Sort *SequenceRule::getSorter() const {
 }
 
 int SequenceRule::recursiveCompare(const Edge *a, const Edge *b) const {
-  // pseudo atoms (atomic no. 0) match all
-  if (a->getEnd()->getAtomicNum() == 0 || b->getEnd()->getAtomicNum() == 0) {
-    return 0;
-  }
-
   int cmp = compare(a, b);
   if (cmp != 0) {
     return cmp;


### PR DESCRIPTION
Opening this to start a discussion about the fix for #4998 in particular.

What this is currently doing will clearly give the right answer if the non-kekulized bonds are not involved in distinguishing between ligands. If the bonds do need to be involved in setting chirality, it's not at all clear what the right answer should be.
We could pick bond order 1 (here) or bond order 0 (used for dative bonds).
It's worth discussing this.
