### PR TITLE
Make FMCS check bond stereo.

### DIFF
--- a/Code/GraphMol/FMCS/FMCS.cpp
+++ b/Code/GraphMol/FMCS/FMCS.cpp
@@ -374,6 +374,8 @@ bool checkBondStereo(const MCSBondCompareParameters&, const ROMol& mol1,
   if (b1->getBondType() == Bond::DOUBLE && b2->getBondType() == Bond::DOUBLE) {
     if (bs1 > Bond::STEREOANY && !(bs2 > Bond::STEREOANY)) {
       return false;
+    } else {
+      return bs1 == bs2;
     }
   }
   return true;

--- a/Code/GraphMol/FMCS/testFMCS_Unit.cpp
+++ b/Code/GraphMol/FMCS/testFMCS_Unit.cpp
@@ -2521,6 +2521,73 @@ void testGitHub4498() {
   }
 }
 
+void testBondStereo() {
+  BOOST_LOG(rdInfoLog) << "-------------------------------------" << std::endl;
+  BOOST_LOG(rdInfoLog) << "FindMCS should check bond stereo"
+                       << std::endl;
+  {
+    std::vector<ROMOL_SPTR> mols = {"CC\\C=C/CC"_smiles, "CC\\C=C\\CC"_smiles};
+
+    MCSParameters p;
+    p.BondCompareParameters.MatchStereo = false;
+    MCSResult mcs_resf = findMCS(mols, &p);
+    std::cout << "MCS MatchStereo false : " << mcs_resf.SmartsString << " "
+              << mcs_resf.NumAtoms << " atoms, " << mcs_resf.NumBonds
+              << " bonds\n";
+    TEST_ASSERT(mcs_resf.NumAtoms == 6);
+    TEST_ASSERT(mcs_resf.NumBonds == 5);
+
+    p.BondCompareParameters.MatchStereo = true;
+    MCSResult mcs_rest = findMCS(mols, &p);
+    std::cout << "MCS MatchStereo true  : " << mcs_rest.SmartsString << " "
+              << mcs_rest.NumAtoms << " atoms, " << mcs_rest.NumBonds
+              << " bonds\n";
+    TEST_ASSERT(mcs_rest.NumAtoms == 3);
+    TEST_ASSERT(mcs_rest.NumBonds == 2);
+    TEST_ASSERT(mcs_resf.SmartsString != mcs_rest.SmartsString);
+  }
+  {
+    std::vector<ROMOL_SPTR> mols = {"CC\\C=C/CC"_smiles, "CCC=CCC"_smiles};
+    MCSParameters p;
+    p.BondCompareParameters.MatchStereo = false;
+    MCSResult mcs_resf = findMCS(mols, &p);
+    std::cout << "MCS MatchStereo false : " << mcs_resf.SmartsString << " "
+              << mcs_resf.NumAtoms << " atoms, " << mcs_resf.NumBonds
+              << " bonds\n";
+    TEST_ASSERT(mcs_resf.NumAtoms == 6);
+    TEST_ASSERT(mcs_resf.NumBonds == 5);
+
+    p.BondCompareParameters.MatchStereo = true;
+    MCSResult mcs_rest = findMCS(mols, &p);
+    std::cout << "MCS MatchStereo true  : " << mcs_rest.SmartsString << " "
+              << mcs_rest.NumAtoms << " atoms, " << mcs_rest.NumBonds
+              << " bonds\n";
+    TEST_ASSERT(mcs_rest.NumAtoms == 3);
+    TEST_ASSERT(mcs_rest.NumBonds == 2);
+    TEST_ASSERT(mcs_resf.SmartsString != mcs_rest.SmartsString);
+  }
+  {
+    std::vector<ROMOL_SPTR> mols = {"CCC=CCC"_smiles, "CCC=CCC"_smiles};
+    MCSParameters p;
+    p.BondCompareParameters.MatchStereo = false;
+    MCSResult mcs_resf = findMCS(mols, &p);
+    std::cout << "MCS MatchStereo false : " << mcs_resf.SmartsString << " "
+              << mcs_resf.NumAtoms << " atoms, " << mcs_resf.NumBonds
+              << " bonds\n";
+    TEST_ASSERT(mcs_resf.NumAtoms == 6);
+    TEST_ASSERT(mcs_resf.NumBonds == 5);
+
+    p.BondCompareParameters.MatchStereo = true;
+    MCSResult mcs_rest = findMCS(mols, &p);
+    std::cout << "MCS MatchStereo true  : " << mcs_rest.SmartsString << " "
+              << mcs_rest.NumAtoms << " atoms, " << mcs_rest.NumBonds
+              << " bonds\n";
+    TEST_ASSERT(mcs_rest.NumAtoms == 6);
+    TEST_ASSERT(mcs_rest.NumBonds == 5);
+    TEST_ASSERT(mcs_resf.SmartsString == mcs_rest.SmartsString);
+  }
+}
+
 //====================================================================================================
 //====================================================================================================
 
@@ -2544,6 +2611,7 @@ int main(int argc, const char* argv[]) {
 
   T0 = nanoClock();
   t0 = nanoClock();
+  testBondStereo();
 
 #if 1
   testJSONParameters();
@@ -2605,6 +2673,7 @@ int main(int argc, const char* argv[]) {
   testGitHub3886();
   testAtomCompareCompleteRingsOnly();
   testGitHub4498();
+  testBondStereo();
 
   unsigned long long t1 = nanoClock();
   double sec = double(t1 - T0) / 1000000.;

--- a/Code/GraphMol/FMCS/testFMCS_Unit.cpp
+++ b/Code/GraphMol/FMCS/testFMCS_Unit.cpp
@@ -2611,7 +2611,6 @@ int main(int argc, const char* argv[]) {
 
   T0 = nanoClock();
   t0 = nanoClock();
-  testBondStereo();
 
 #if 1
   testJSONParameters();

--- a/Code/GraphMol/RGroupDecomposition/testRGroupDecomp.cpp
+++ b/Code/GraphMol/RGroupDecomposition/testRGroupDecomp.cpp
@@ -1316,9 +1316,9 @@ Cn1cnc2cc(Oc3cc(N4CCN(Cc5ccccc5-c5ccc(Cl)cc5)CC4)ccc3C(=O)NS(=O)(=O)c3ccc(NCCCN4
   {
     RGroupDecompositionParameters ps = RGroupDecompositionParameters();
 #ifdef NDEBUG
-    ps.timeout = 1.0;
-#else
     ps.timeout = 5.0;
+#else
+    ps.timeout = 25.0;
 #endif
     ps.matchingStrategy = RDKit::NoSymmetrization;
     std::cerr << "bulk, no symmetry" << std::endl;


### PR DESCRIPTION

#### Reference Issue
Fixes issue discussed in https://github.com/rdkit/rdkit/discussions/5000


#### What does this implement/fix? Explain your changes.
the RMCS checkBondStereo function only compared if the bond stereo was defined for one bond, and not for the other.  It didn't check to see that if they were both set, that they matched.  Thus CC\C=C\CC and CC\C=C/CC were deemed a match.

#### Any other comments?
Tested on macOS and C++ only.
