### PR TITLE
Fix warning when generating coordinates for ZOBs

### DIFF
--- a/External/CoordGen/CoordGen.h
+++ b/External/CoordGen/CoordGen.h
@@ -128,6 +128,9 @@ unsigned int addCoords(T& mol, const CoordGenParams* params = nullptr) {
                                    ats[obnd->getEndAtomIdx()]);
     // FIX: This is no doubt wrong
     switch (obnd->getBondType()) {
+      case Bond::ZERO:
+        bnd->bondOrder = 0;
+        break;
       case Bond::SINGLE:
         bnd->bondOrder = 1;
         break;


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
When generating coordinates for molecules with zero order bonds,
the coordgen adapter layer emitted a warning. This addresses that
warning.
