### PR TITLE
Remove extra newline from Kekulize error message.

### DIFF
--- a/Code/GraphMol/Kekulize.cpp
+++ b/Code/GraphMol/Kekulize.cpp
@@ -493,7 +493,6 @@ void kekulizeFused(RWMol &mol, const VECT_INT_VECT &arings,
         problemAtoms.push_back(i);
       }
     }
-    errout << std::endl;
     std::string msg = errout.str();
     BOOST_LOG(rdErrorLog) << msg << std::endl;
     throw KekulizeException(msg, problemAtoms);

--- a/Code/JavaWrappers/gmwrapper/src-test/org/RDKit/WrapperTests.java
+++ b/Code/JavaWrappers/gmwrapper/src-test/org/RDKit/WrapperTests.java
@@ -272,7 +272,7 @@ public class WrapperTests extends GraphMolTest {
             mol = RWMol.MolFromSmiles("c1cccc1");
             mol.sanitizeMol();
         } catch (MolSanitizeException e) {
-            assertEquals("Can't kekulize mol.  Unkekulized atoms: 0 1 2 3 4\n",
+            assertEquals("Can't kekulize mol.  Unkekulized atoms: 0 1 2 3 4",
                     e.getMessage());
         } finally {
             if (mol != null) {


### PR DESCRIPTION
The log message for a Kekulization failure had an extra newline.  This removes it.

Example of the old behavior:

```
[01:01:51] Can't kekulize mol.  Unkekulized atoms: 6 7 8 9 10

[01:01:51] Explicit valence for atom # 2 H, 2, is greater than permitted
[01:01:51] Explicit valence for atom # 2 H, 2, is greater than permitted
[01:01:51] Explicit valence for atom # 2 H, 2, is greater than permitted
[01:01:51] Can't kekulize mol.  Unkekulized atoms: 17 18 19 21 22

[01:01:51] Explicit valence for atom # 2 H, 2, is greater than permitted
[01:01:51] Can't kekulize mol.  Unkekulized atoms: 8 10 12 15 18

```