### PR TITLE
Improving atom colors for dark mode.

### DIFF
--- a/Code/GraphMol/MolDraw2D/MolDraw2DHelpers.h
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DHelpers.h
@@ -114,14 +114,14 @@ inline void assignDarkModePalette(ColourPalette &palette) {
   palette[-1] = DrawColour(0.8, 0.8, 0.8);
   palette[0] = DrawColour(0.9, 0.9, 0.9);
   palette[1] = palette[6] = DrawColour(0.9, 0.9, 0.9);
-  palette[7] = DrawColour(0.2, 0.2, 1.0);
+  palette[7] = DrawColour(0.33, 0.41, 0.92);
   palette[8] = DrawColour(1.0, 0.2, 0.2);
   palette[9] = DrawColour(0.2, 0.8, 0.8);
   palette[15] = DrawColour(1.0, 0.5, 0.0);
   palette[16] = DrawColour(0.8, 0.8, 0.0);
   palette[17] = DrawColour(0.0, 0.802, 0.0);
-  palette[35] = DrawColour(0.5, 0.3, 0.1);
-  palette[53] = DrawColour(0.63, 0.12, 0.94);
+  palette[35] = DrawColour(0.71, 0.4, 0.07);
+  palette[53] = DrawColour(0.89, 0.004, 1);
 };
 
 inline void assignBWPalette(ColourPalette &palette) {


### PR DESCRIPTION
Improving dark mode palette for N, Br and I atoms.

### Current Palette
![Current_Colors](https://user-images.githubusercontent.com/45514816/155268161-ac5160bc-75b3-48ad-9d90-b9681ce27dea.png)

### Improved Palette
![Improved_colors](https://user-images.githubusercontent.com/45514816/155268204-40770cee-956a-491d-8e12-340edf985e99.png)


