### PR TITLE
enable the multithreaded LeaderPicker on linux

### DIFF
--- a/Code/SimDivPickers/LeaderPicker.h
+++ b/Code/SimDivPickers/LeaderPicker.h
@@ -124,7 +124,7 @@ class LeaderPicker : public DistPicker {
 
 #ifdef USE_THREADED_LEADERPICKER
 // Note that this block of code currently only works on linux (which is why it's
-// disabled by default). In order to work on other platforms we need
+// disabled by default elsewhere). In order to work on other platforms we need
 // cross-platform threading primitives which support a barrier; or a rewrite.
 // Given that we will get the cross-platform threading for free with C++20, I
 // think it makes sense to just wait


### PR DESCRIPTION
This code has been there for two years, but isn't built by default since we don't have a cross-platform solution yet.

Rather than continue to wait until the cross-platform solution is found (which we'll get for "free" with C++20), this enables the multithreaded picker on linux when the RDKit is already being built with threading support.
