### PR TITLE
AtomSymbol needs to have a virtual destructor

### DIFF
--- a/Code/GraphMol/MolDraw2D/AtomSymbol.h
+++ b/Code/GraphMol/MolDraw2D/AtomSymbol.h
@@ -32,7 +32,7 @@ namespace MolDraw2D_detail {
 class AtomSymbol {
 
  public:
-  ~AtomSymbol() = default;
+  virtual ~AtomSymbol() = default;
 
   /*!
    *

--- a/Code/GraphMol/MolDraw2D/DrawShape.h
+++ b/Code/GraphMol/MolDraw2D/DrawShape.h
@@ -69,7 +69,7 @@ class DrawShapeArrow : public DrawShape {
                  double frac = 0.2, double angle = M_PI / 6);
   DrawShapeArrow(const DrawShapeArrow &) = delete;
   DrawShapeArrow(DrawShapeArrow &&) = delete;
-  virtual ~DrawShapeArrow() = default;
+  ~DrawShapeArrow() = default;
   DrawShapeArrow &operator=(const DrawShapeArrow &) = delete;
   DrawShapeArrow &operator=(DrawShapeArrow &&) = delete;
   void myDraw(MolDraw2D &drawer) const override;

--- a/Code/GraphMol/MolDraw2D/DrawTextFT.h
+++ b/Code/GraphMol/MolDraw2D/DrawTextFT.h
@@ -35,7 +35,7 @@ namespace MolDraw2D_detail {
 // ****************************************************************************
 class RDKIT_MOLDRAW2D_EXPORT DrawTextFT : public DrawText {
  public:
-  ~DrawTextFT() override;
+  virtual ~DrawTextFT() override;
   virtual int MoveToFunctionImpl(const FT_Vector *to) = 0;
   virtual int LineToFunctionImpl(const FT_Vector *to) = 0;
   virtual int ConicToFunctionImpl(const FT_Vector *control,
@@ -52,7 +52,6 @@ class RDKIT_MOLDRAW2D_EXPORT DrawTextFT : public DrawText {
   DrawTextFT &operator=(DrawTextFT &&) = delete;
 
   void drawChar(char c, const Point2D &cds) override;
-
 
   // unless over-ridden by the c'tor, this will return a hard-coded
   // file from $RDBASE.

--- a/Code/GraphMol/MolDraw2D/DrawTextFTCairo.h
+++ b/Code/GraphMol/MolDraw2D/DrawTextFTCairo.h
@@ -23,8 +23,8 @@ namespace MolDraw2D_detail {
 // ****************************************************************************
 
 class DrawTextFTCairo : public DrawTextFT {
-
  public:
+  ~DrawTextFTCairo() override = default;
   DrawTextFTCairo(double max_fnt_sz, double min_fnt_sz,
                   const std::string &font_file, cairo_t *dp_cr);
   DrawTextFTCairo(const DrawTextFTCairo &) = delete;
@@ -42,7 +42,7 @@ class DrawTextFTCairo : public DrawTextFT {
   void setCairoContext(cairo_t *cr);
 
   // adds x_trans_ and y_trans_ to coords returns x advance distance
-  virtual double extractOutline() override;
+  double extractOutline() override;
 
   cairo_t *dp_cr_;
 };

--- a/Code/GraphMol/MolDraw2D/DrawTextFTJS.h
+++ b/Code/GraphMol/MolDraw2D/DrawTextFTJS.h
@@ -23,8 +23,9 @@ class MolDraw2DJS;
 namespace MolDraw2D_detail {
 // ****************************************************************************
 class DrawTextFTJS : public DrawTextFT {
-
  public:
+  ~DrawTextFTJS() override = default;
+
   DrawTextFTJS(double max_fnt_sz, double min_fnt_sz,
                const std::string &font_file, emscripten::val &context);
   DrawTextFTJS(const DrawTextFTJS &) = delete;
@@ -41,7 +42,7 @@ class DrawTextFTJS : public DrawTextFT {
                           const FT_Vector *to) override;
 
   // adds x_trans_ and y_trans_ to coords returns x advance distance
-  virtual double extractOutline() override;
+  double extractOutline() override;
 
   emscripten::val &context_;
 };

--- a/Code/GraphMol/MolDraw2D/MolDraw2DSVG.h
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DSVG.h
@@ -82,7 +82,7 @@ class RDKIT_MOLDRAW2D_EXPORT MolDraw2DSVG : public MolDraw2D {
   void initDrawing() override;
   void initTextDrawer(bool noFreetype) override;
 
-  virtual void outputClasses();
+  void outputClasses();
 };
 
 }  // namespace RDKit

--- a/Code/GraphMol/MolDraw2D/Qt/DrawTextFTQt.h
+++ b/Code/GraphMol/MolDraw2D/Qt/DrawTextFTQt.h
@@ -41,7 +41,7 @@ class DrawTextFTQt : public DrawTextFT {
                           const FT_Vector *to) override;
 
   // adds x_trans_ and y_trans_ to coords returns x advance distance
-  virtual double extractOutline() override;
+  double extractOutline() override;
 
  private:
   QPainter *d_qp;


### PR DESCRIPTION
Simple fix for AtomSymbol, it needs a virtual destructor since it has virtual functions.