### PR TITLE
[WIP] Clean up the warning landscape

### DIFF
--- a/Code/GraphMol/Substruct/catch_tests.cpp
+++ b/Code/GraphMol/Substruct/catch_tests.cpp
@@ -315,9 +315,9 @@ TEST_CASE("Github #4138: empty query produces non-empty results",
 TEST_CASE("Github #4558: GetSubstructMatches() loops at 43690 iterations",
           "[substruct][bug]") {
   // We need LOTS of water molecules here.
-  auto num_mols = 22000;
+  auto num_mols = 22000u;
   std::stringstream smi;
-  for (int i = 1; i < num_mols; ++i) {
+  for (auto i = 1u; i < num_mols; ++i) {
     smi << "[H]O[H].";
   }
   smi << "[H]O[H]";  // last one (notice we started at 1)

--- a/External/AvalonTools/CMakeLists.txt
+++ b/External/AvalonTools/CMakeLists.txt
@@ -84,10 +84,10 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
 endif()
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wreturn-type -Wimplicit-function-declaration -Wabsolute-value -Wno-parentheses -Wno-logical-op-parentheses -Wno-dangling-else -Wno-format")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-return-type -Wno-implicit-function-declaration -Wno-absolute-value -Wno-parentheses -Wno-logical-op-parentheses -Wno-dangling-else -Wno-format")
 endif()
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wunused-result -Wformat-overflow= -Wformat= -Wformat-security -Wimplicit-function-declaration")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-unused-result -Wformat-overflow=0 -Wformat=0 -Wno-format-security -Wno-implicit-function-declaration")
 endif()
 
 

--- a/External/AvalonTools/CMakeLists.txt
+++ b/External/AvalonTools/CMakeLists.txt
@@ -84,8 +84,12 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
 endif()
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-parentheses -Wno-logical-op-parentheses -Wno-dangling-else -Wno-format")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wreturn-type -Wimplicit-function-declaration -Wabsolute-value -Wno-parentheses -Wno-logical-op-parentheses -Wno-dangling-else -Wno-format")
 endif()
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wunused-result -Wformat-overflow= -Wformat= -Wformat-security -Wimplicit-function-declaration")
+endif()
+
 
 
 rdkit_library(avalon_clib ${avalon_clib_srcs})

--- a/External/CoordGen/CMakeLists.txt
+++ b/External/CoordGen/CMakeLists.txt
@@ -52,7 +52,7 @@ if(RDK_BUILD_MAEPARSER_SUPPORT)
     file(GLOB MAESOURCES "${MAEPARSER_DIR}/*.cpp")
 
      if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-      set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wdeprecated-copy")
+      set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-deprecated-copy")
      endif()
 
     rdkit_library(maeparser ${MAESOURCES} LINK_LIBRARIES ${Boost_LIBRARIES} ${ZLIB_LIBRARIES} SHARED)

--- a/External/CoordGen/CMakeLists.txt
+++ b/External/CoordGen/CMakeLists.txt
@@ -52,7 +52,7 @@ if(RDK_BUILD_MAEPARSER_SUPPORT)
     file(GLOB MAESOURCES "${MAEPARSER_DIR}/*.cpp")
 
      if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-      set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-deprecated-copy")
+      set(CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS} -Wno-deprecated-copy")
      endif()
 
     rdkit_library(maeparser ${MAESOURCES} LINK_LIBRARIES ${Boost_LIBRARIES} ${ZLIB_LIBRARIES} SHARED)

--- a/External/CoordGen/CMakeLists.txt
+++ b/External/CoordGen/CMakeLists.txt
@@ -51,9 +51,14 @@ if(RDK_BUILD_MAEPARSER_SUPPORT)
         CACHE STRING "MaeParser Include Dir" FORCE)
     file(GLOB MAESOURCES "${MAEPARSER_DIR}/*.cpp")
 
+     if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+      set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wdeprecated-copy")
+     endif()
+
     rdkit_library(maeparser ${MAESOURCES} LINK_LIBRARIES ${Boost_LIBRARIES} ${ZLIB_LIBRARIES} SHARED)
     install(TARGETS maeparser DESTINATION ${RDKit_LibDir})
     set(maeparser_LIBRARIES maeparser ${ZLIB_LIBRARIES})
+
 
   endif(MAEPARSER_FORCE_BUILD OR (NOT maeparser_FOUND))
 

--- a/External/INCHI-API/CMakeLists.txt
+++ b/External/INCHI-API/CMakeLists.txt
@@ -71,8 +71,14 @@ if(RDK_BUILD_INCHI_SUPPORT)
   endif()
 
      if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-      set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-parentheses -Wno-logical-op-parentheses")
+      set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wcomment -Wno-parentheses -Wno-logical-op-parentheses")
      endif()
+     if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+      set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wformat-overflow= -Wformat= -Wformat-security")
+     endif()
+
+
+
   rdkit_library(RDInchiLib inchi.cpp SHARED LINK_LIBRARIES ${INCHI_LIBRARIES}
                 GraphMol RDGeneral Depictor SubstructMatch SmilesParse )
   target_compile_definitions(RDInchiLib PRIVATE RDKIT_RDINCHILIB_BUILD)

--- a/External/INCHI-API/CMakeLists.txt
+++ b/External/INCHI-API/CMakeLists.txt
@@ -71,7 +71,7 @@ if(RDK_BUILD_INCHI_SUPPORT)
   endif()
 
      if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-      set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-comment -Wno-parentheses -Wno-logical-op-parentheses")
+      set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-comment -Wno-parentheses -Wno-logical-op-parentheses -Wno-pointer-bool-conversion -Wno-unused-value -Wno-unsequenced -Wno-constant-logical-operand")
      endif()
      if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
       set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wformat-overflow=0 -Wformat=0 -Wno-format-security")

--- a/External/INCHI-API/CMakeLists.txt
+++ b/External/INCHI-API/CMakeLists.txt
@@ -71,10 +71,10 @@ if(RDK_BUILD_INCHI_SUPPORT)
   endif()
 
      if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-      set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wcomment -Wno-parentheses -Wno-logical-op-parentheses")
+      set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-comment -Wno-parentheses -Wno-logical-op-parentheses")
      endif()
      if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-      set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wformat-overflow= -Wformat= -Wformat-security")
+      set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wformat-overflow=0 -Wformat=0 -Wno-format-security")
      endif()
 
 


### PR DESCRIPTION
1. suppress a bunch of warnings from third-party code with clang and g++
2. get rid of one warning in RDKit code

I will probably add some additional suppression for MSVC++ too, but let's start with clang and g++