### PR TITLE
Exposing setting atomSymbols to python for MolzipParams

### DIFF
--- a/Code/GraphMol/ChemTransforms/MolFragmenter.cpp
+++ b/Code/GraphMol/ChemTransforms/MolFragmenter.cpp
@@ -845,6 +845,14 @@ struct ZipBond {
 };
 }  // namespace
 
+void MolzipParams::setLabel(MolzipLabel label) {
+  this->label = label;
+}
+
+void MolzipParams::setAtomSymbols(const std::vector<std::string> &atomSymbols) {
+  this->atomSymbols = atomSymbols;
+}
+
 std::unique_ptr<ROMol> molzip(const ROMol &a, const ROMol &b,
                               const MolzipParams &params) {
   std::unique_ptr<RWMol> newmol;

--- a/Code/GraphMol/ChemTransforms/MolFragmenter.h
+++ b/Code/GraphMol/ChemTransforms/MolFragmenter.h
@@ -115,11 +115,9 @@ struct RDKIT_CHEMTRANSFORMS_EXPORT MolzipParams {
     atomSymbols(atomSymbols) {
   }
   //! Set the labelling type for zipping molecules together
-  void setLabel(MolzipLabel label) { this->label = label; }
+  void setLabel(MolzipLabel label);
   //! Set the list of atom symbols to zip together when using AtomType labelling.
-  void setAtomSymbols(const std::vector<std::string> &atomSymbols) {
-    this->atomSymbols = atomSymbols;
-  }
+  void setAtomSymbols(const std::vector<std::string> &atomSymbols);
 };
 
 RDKIT_CHEMTRANSFORMS_EXPORT std::unique_ptr<ROMol> molzip(

--- a/Code/GraphMol/ChemTransforms/MolFragmenter.h
+++ b/Code/GraphMol/ChemTransforms/MolFragmenter.h
@@ -106,6 +106,20 @@ enum class MolzipLabel { AtomMapNumber, Isotope, FragmentOnBonds, AtomType };
 struct RDKIT_CHEMTRANSFORMS_EXPORT MolzipParams {
   MolzipLabel label = MolzipLabel::AtomMapNumber;
   std::vector<std::string> atomSymbols;
+
+  MolzipParams() = default;
+  MolzipParams(MolzipLabel label) : label(label), atomSymbols() {}
+  MolzipParams(MolzipLabel label,
+	       const std::vector<std::string> &atomSymbols) :
+    label(label),
+    atomSymbols(atomSymbols) {
+  }
+  //! Set the labelling type for zipping molecules together
+  void setLabel(MolzipLabel label) { this->label = label; }
+  //! Set the list of atom symbols to zip together when using AtomType labelling.
+  void setAtomSymbols(const std::vector<std::string> &atomSymbols) {
+    this->atomSymbols = atomSymbols;
+  }
 };
 
 RDKIT_CHEMTRANSFORMS_EXPORT std::unique_ptr<ROMol> molzip(

--- a/Code/GraphMol/Wrap/MolOps.cpp
+++ b/Code/GraphMol/Wrap/MolOps.cpp
@@ -887,6 +887,17 @@ void setDoubleBondNeighborDirectionsHelper(ROMol &mol, python::object confObj) {
   MolOps::setDoubleBondNeighborDirections(mol, conf);
 }
 
+void setAtomSymbolsHelper(MolzipParams &params, python::list symbols) {
+  params.atomSymbols.clear();
+  if (symbols) {
+    unsigned int nVs =
+      python::extract<unsigned int>(symbols.attr("__len__")());
+    for (unsigned int i = 0; i < nVs; ++i) {
+      params.atomSymbols.push_back(python::extract<std::string>(symbols[i]));
+    }
+  }
+}
+
 ROMol *molzip_new(const ROMol &a, const ROMol &b, const MolzipParams &p) {
   return molzip(a, b, p).release();
 }
@@ -2452,11 +2463,17 @@ EXAMPLES:\n\n\
   MolzipLabel.AtomTypes: choose the atom types to act as matching dummy atoms.\n\
     i.e.  'C[V]' and 'N[Xe]' with atoms pairs [('V', 'Xe')] results in 'CN'\n\
 ";
+    python::class_<MolzipParams>("MolzipParams", docString.c_str(), python::init<>())
+      .def(python::init<MolzipLabel>(python::arg("label")))
 
-    python::class_<MolzipParams>("MolzipParams", docString.c_str(),
-                                 python::init<>())
-        .def_readwrite("label", &MolzipParams::label,
-                       "Set the atom labelling system to zip together");
+      .def_readwrite("label", &MolzipParams::label,
+                     "Set the atom labelling system used to zip moleclues together")
+      .def("SetLabel", &MolzipParams::setLabel,
+	   "Set the atom labelling system used to zip molecules together")
+      .def("SetAtomSymbols", setAtomSymbolsHelper,
+	   (python::arg("atomSymbols")),
+	   "Set the atom symbols to zip together when using AtomType zipping")
+      ;
 
     docString =
         "molzip: zip two molecules together preserving bond and atom stereochemistry.\n\

--- a/Code/GraphMol/Wrap/MolOps.cpp
+++ b/Code/GraphMol/Wrap/MolOps.cpp
@@ -2467,7 +2467,7 @@ EXAMPLES:\n\n\
       .def(python::init<MolzipLabel>(python::arg("label")))
 
       .def_readwrite("label", &MolzipParams::label,
-                     "Set the atom labelling system used to zip moleclues together")
+                     "Set the atom labelling system used to zip molecules together")
       .def("SetLabel", &MolzipParams::setLabel,
 	   "Set the atom labelling system used to zip molecules together")
       .def("SetAtomSymbols", setAtomSymbolsHelper,

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -6482,6 +6482,19 @@ M  END
     c = Chem.molzip(a, p)
     self.assertEqual(Chem.MolToSmiles(c), 'C=C/N=C/O')
 
+    a = Chem.MolFromSmiles("[C@H]([Xe])(F)([V])")
+    b = Chem.MolFromSmiles("[Xe]N.[V]I")
+    p = Chem.MolzipParams(Chem.MolzipLabel.AtomType)
+    p.SetAtomSymbols(["Xe", "V"])
+    c = Chem.molzip(a, b, p)
+    self.assertEqual(Chem.MolToSmiles(c), 'N[C@@H](F)I')
+
+    p = Chem.MolzipParams()
+    p.SetLabel(Chem.MolzipLabel.AtomType)
+    p.SetAtomSymbols(["Xe", "V"])
+    c = Chem.molzip(a, b, p)
+    self.assertEqual(Chem.MolToSmiles(c), 'N[C@@H](F)I')
+
   def testContextManagers(self):
     from rdkit import RDLogger
     RDLogger.DisableLog('rdApp.*')

--- a/Code/JavaWrappers/ChemTransforms.i
+++ b/Code/JavaWrappers/ChemTransforms.i
@@ -82,6 +82,8 @@ RDKit::ROMol * new_molzip(
 %newobject new_molzip;
 %ignore fragmentOnBonds;
 %ignore molzip;
+%ignore RDKit::MolzipParams::setLabel;
+%ignore RDKit::MolzipParams::setAtomSymbols;
 %rename("fragmentOnBonds") fragmentMolOnBonds;
 %rename("molzip") new_molzip;
 


### PR DESCRIPTION
Expose setting molzipparams atomSymbols to python

I decided to add two setter functions to the class because I couldn't figure out how to wrap std::vector as a def_readwrite.