### PR TITLE
To INCHI conversion leaks on kekulization failure

### DIFF
--- a/External/INCHI-API/inchi.cpp
+++ b/External/INCHI-API/inchi.cpp
@@ -1757,7 +1757,7 @@ void rCleanUp(RWMol& mol) {
 
 std::string MolToInchi(const ROMol& mol, ExtraInchiReturnValues& rv,
                        const char* options) {
-  auto* m = new RWMol(mol);
+  std::unique_ptr<RWMol> m{new RWMol(mol)};
 
   // assign stereochem:
   if (mol.needsUpdatePropertyCache()) {
@@ -2095,7 +2095,7 @@ std::string MolToInchi(const ROMol& mol, ExtraInchiReturnValues& rv,
   if (stereo0Ds) {
     delete[] stereo0Ds;
   }
-  delete m;
+
   return inchi;
 }
 

--- a/External/INCHI-API/test.cpp
+++ b/External/INCHI-API/test.cpp
@@ -856,12 +856,39 @@ void testGithub3645() {
   BOOST_LOG(rdInfoLog) << "done" << std::endl;
 }
 
+void test_clean_up_on_kekulization_error() {
+  BOOST_LOG(rdErrorLog) << "-------------------------------------" << std::endl;
+  BOOST_LOG(rdInfoLog) << "To INCHI conversion leaks on kekulization failure"
+                       << std::endl;
+
+  {
+    // This will fail kekulization because of the ambiguous valence
+    // on the N atom
+    SmilesParserParams params;
+    params.sanitize = false;
+
+    std::unique_ptr<ROMol> mol{SmilesToMol("c1ccnc1", params)};
+    TEST_ASSERT(mol);
+
+    ExtraInchiReturnValues tmp;
+    bool ok = true;
+    try {
+      auto inchi = MolToInchi(*mol, tmp);
+    } catch (const std::exception &) {
+      ok = true;
+    }
+    TEST_ASSERT(ok);
+  }
+
+  BOOST_LOG(rdInfoLog) << "done" << std::endl;
+}
+
 //-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
 //
 //-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
 int main() {
   RDLog::InitLogs();
-#if 1
+
   testGithubIssue3();
   testGithubIssue8();
   testGithubIssue40();
@@ -874,8 +901,8 @@ int main() {
   testGithubIssue614();
   testGithubIssue1572();
   testMolBlockToInchi();
-#endif
   testGithubIssue562();
   testGithub3365();
   testGithub3645();
+  test_clean_up_on_kekulization_error();
 }


### PR DESCRIPTION
I noticed this while writing tests for an external project that uses RDKit.

A kekulization exception would cause `MolToInchi()` to return without cleaning up `m`. The smart pointer should now take care of cleaning it up whenever we leave the function.


