### PR TITLE
Add a CXSMILES option to the MolHash

### DIFF
--- a/Code/GraphMol/MolHash/CMakeLists.txt
+++ b/Code/GraphMol/MolHash/CMakeLists.txt
@@ -7,7 +7,7 @@ target_compile_definitions(MolHash PRIVATE RDKIT_MOLHASH_BUILD)
 rdkit_headers(MolHash.h nmmolhash.h           
               DEST GraphMol/MolHash)
 
-rdkit_catch_test(molHashCatchTest catch_tests.cpp LINK_LIBRARIES MolHash)
+rdkit_catch_test(molHashCatchTest ../catch_main.cpp catch_tests.cpp  LINK_LIBRARIES MolHash)
 
 if(RDK_BUILD_PYTHON_WRAPPERS)
 add_subdirectory(Wrap)

--- a/Code/GraphMol/MolHash/MolHash.h
+++ b/Code/GraphMol/MolHash/MolHash.h
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2020 Greg Landrum
+//  Copyright (C) 2020 Greg Landrum and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.

--- a/Code/GraphMol/MolHash/Wrap/rdMolHash.cpp
+++ b/Code/GraphMol/MolHash/Wrap/rdMolHash.cpp
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2020 Greg Landrum
+//  Copyright (C) 2020-2022 Greg Landrum and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -17,9 +17,10 @@ using namespace RDKit;
 
 namespace {
 
-std::string MolHashHelper(const ROMol &mol, MolHash::HashFunction func) {
+std::string MolHashHelper(const ROMol &mol, MolHash::HashFunction func,
+                          bool useCXSmiles) {
   RWMol cpy(mol);
-  return MolHash::MolHash(&cpy, func);
+  return MolHash::MolHash(&cpy, func, useCXSmiles);
 }
 }  // namespace
 
@@ -48,7 +49,8 @@ BOOST_PYTHON_MODULE(rdMolHash) {
              MolHash::HashFunction::ArthorSubstructureOrder);
 
   python::def("MolHash", MolHashHelper,
-              (python::arg("mol"), python::arg("func")),
+              (python::arg("mol"), python::arg("func"),
+               python::arg("useCxSmiles") = false),
               "Generate a hash for a molecule. The func argument determines "
               "which hash is generated.");
 }

--- a/Code/GraphMol/MolHash/Wrap/testMolHash.py
+++ b/Code/GraphMol/MolHash/Wrap/testMolHash.py
@@ -35,6 +35,17 @@ class TestCase(unittest.TestCase):
     self.assertEqual(rdMolHash.MolHash(m, rdMolHash.HashFunction.ArthorSubstructureOrder),
                      '000f001001000c000300005f000000')
 
+  def testCxSmiles(self):
+    m = Chem.MolFromSmiles(
+      'C[C@@H](O)[C@@H](C)[C@@H](C)C[C@H](C1=CN=CN1)C1=CNC=N1 |o1:8,5,&1:1,3,r,c:11,18,t:9,15|')
+
+    self.assertEqual(rdMolHash.MolHash(m, rdMolHash.HashFunction.HetAtomTautomer),
+                     'C[C@@H](CC([C]1[CH][N][CH][N]1)[C]1[CH][N][CH][N]1)[C@H](C)[C@@H](C)[O]_3_0')
+
+    self.assertEqual(
+      rdMolHash.MolHash(m, rdMolHash.HashFunction.HetAtomTautomer, True),
+      'C[C@@H](CC([C]1[CH][N][CH][N]1)[C]1[CH][N][CH][N]1)[C@H](C)[C@@H](C)[O]_3_0 |o1:1,&1:14,16|')
+
 
 if __name__ == "__main__":
   unittest.main()

--- a/Code/GraphMol/MolHash/catch_tests.cpp
+++ b/Code/GraphMol/MolHash/catch_tests.cpp
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2019 Greg Landrum
+//  Copyright (C) 2019-2022 Greg Landrum
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -11,6 +11,7 @@
 
 #include <GraphMol/RDKitBase.h>
 #include <GraphMol/SmilesParse/SmilesParse.h>
+#include <GraphMol/FileParsers/FileParsers.h>
 #include <GraphMol/SmilesParse/SmilesWrite.h>
 #include "MolHash.h"
 
@@ -230,7 +231,7 @@ TEST_CASE("Github issues", "[molhash]") {
 }
 
 TEST_CASE("MolHash with CX extensions", "[molhash]") {
-  SECTION("basics") {
+  SECTION("Tautomer") {
     auto mol =
         "C[C@@H](O)[C@@H](C)[C@@H](C)C[C@H](C1=CN=CN1)C1=CNC=N1 "
         "|o1:8,5,&1:1,3,r,c:11,18,t:9,15|"_smiles;
@@ -253,6 +254,154 @@ TEST_CASE("MolHash with CX extensions", "[molhash]") {
           hsh ==
           "C[C@@H](CC([C]1[CH][N][CH][N]1)[C]1[CH][N][CH][N]1)[C@H](C)[C@@H](C)"
           "[O]_3_0 |o1:1,&1:14,16|");
+    }
+  }
+  SECTION("no coordinates please") {
+    auto mol = R"CTAB(
+  Mrv2108 03032205502D          
+
+  0  0  0     0  0            999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 15 16 0 0 1
+M  V30 BEGIN ATOM
+M  V30 1 C -0.4657 -3.589 0 0 CFG=1
+M  V30 2 C -0.4657 -2.049 0 0
+M  V30 3 C 0.8679 -4.359 0 0
+M  V30 4 C 2.2016 -3.589 0 0 CFG=2
+M  V30 5 C 3.5353 -4.359 0 0
+M  V30 6 C 4.9422 -3.7327 0 0
+M  V30 7 N 5.9726 -4.8771 0 0
+M  V30 8 C 5.2026 -6.2108 0 0
+M  V30 9 N 3.6963 -5.8906 0 0
+M  V30 10 C 2.2016 -2.049 0 0
+M  V30 11 C 0.9557 -1.1438 0 0
+M  V30 12 N 1.4316 0.3208 0 0
+M  V30 13 C 2.9716 0.3208 0 0
+M  V30 14 N 3.4475 -1.1438 0 0
+M  V30 15 F -1.7994 -4.359 0 0
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 1 1 2 CFG=1
+M  V30 2 1 1 3
+M  V30 3 1 4 3 CFG=1
+M  V30 4 1 4 5
+M  V30 5 2 5 6
+M  V30 6 1 6 7
+M  V30 7 2 7 8
+M  V30 8 1 8 9
+M  V30 9 1 5 9
+M  V30 10 1 4 10
+M  V30 11 2 10 11
+M  V30 12 1 11 12
+M  V30 13 1 12 13
+M  V30 14 2 13 14
+M  V30 15 1 10 14
+M  V30 16 1 1 15
+M  V30 END BOND
+M  V30 BEGIN COLLECTION
+M  V30 MDLV30/STEREL1 ATOMS=(1 1)
+M  V30 MDLV30/STERAC1 ATOMS=(1 4)
+M  V30 END COLLECTION
+M  V30 END CTAB
+M  END
+)CTAB"_ctab;
+    REQUIRE(mol);
+
+    {
+      RWMol cp(*mol);
+      auto hsh =
+          MolHash::MolHash(&cp, MolHash::HashFunction::HetAtomTautomer, true);
+      CHECK(hsh ==
+            "C[C@H](F)CC([C]1[CH][N][CH][N]1)[C]1[CH][N][CH][N]1_2_0 |o1:1|");
+    }
+  }
+
+  SECTION("Mesomer") {
+    auto mol = "C[C@H](F)C[C@@](C([NH-])=O)C([O-])=N |o1:1,&1:4|"_smiles;
+    REQUIRE(mol);
+
+    {
+      RWMol cp(*mol);
+      auto hsh = MolHash::MolHash(&cp, MolHash::HashFunction::Mesomer);
+      CHECK(hsh == "C[C@H](F)C[C]([C]([NH])[O])[C]([NH])[O]_-2");
+    }
+    {
+      RWMol cp(*mol);
+
+      auto hsh = MolHash::MolHash(&cp, MolHash::HashFunction::Mesomer, true);
+      CHECK(hsh == "C[C@H](F)C[C]([C]([NH])[O])[C]([NH])[O]_-2 |o1:1|");
+    }
+  }
+  SECTION("Extended Murcko") {
+    auto mol =
+        "CC1=CC=CC=C1[C@@H](C[C@@H](C1CC1)C1CCC1)C1=CC=CC=C1O |o1:9,&1:7|"_smiles;
+    REQUIRE(mol);
+
+    {
+      RWMol cp(*mol);
+      auto hsh = MolHash::MolHash(&cp, MolHash::HashFunction::ExtendedMurcko);
+      CHECK(hsh == "*c1ccccc1C(C[C@H](C1CCC1)C1CC1)c1ccccc1*");
+    }
+    {
+      RWMol cp(*mol);
+
+      auto hsh =
+          MolHash::MolHash(&cp, MolHash::HashFunction::ExtendedMurcko, true);
+      CHECK(hsh == "*c1ccccc1C(C[C@H](C1CCC1)C1CC1)c1ccccc1* |o1:9|");
+    }
+  }
+  SECTION("Murcko") {
+    auto mol =
+        "CC1=CC=CC=C1[C@@H](C[C@@H](C1CC1)C1CCC1)C1=CC=CC=C1O |o1:9,&1:7|"_smiles;
+    REQUIRE(mol);
+
+    {
+      RWMol cp(*mol);
+      auto hsh = MolHash::MolHash(&cp, MolHash::HashFunction::MurckoScaffold);
+      CHECK(hsh == "c1ccc(C(C[C@H](C2CCC2)C2CC2)c2ccccc2)cc1");
+    }
+    {
+      RWMol cp(*mol);
+
+      auto hsh =
+          MolHash::MolHash(&cp, MolHash::HashFunction::MurckoScaffold, true);
+      CHECK(hsh == "c1ccc(C(C[C@H](C2CCC2)C2CC2)c2ccccc2)cc1 |o1:6|");
+    }
+  }
+  SECTION("Element") {
+    auto mol =
+        "C([C@@H](C1CC1)C1CCC1)[C@@H](C1CCCCC1)C1=CC=CC=C1 |o1:1,&1:9,c:21,23,t:19|"_smiles;
+    REQUIRE(mol);
+
+    {
+      RWMol cp(*mol);
+      auto hsh = MolHash::MolHash(&cp, MolHash::HashFunction::ElementGraph);
+      CHECK(hsh == "C1CCC(C(C[C@H](C2CCC2)C2CC2)C2CCCCC2)CC1");
+    }
+    {
+      RWMol cp(*mol);
+
+      auto hsh =
+          MolHash::MolHash(&cp, MolHash::HashFunction::ElementGraph, true);
+      CHECK(hsh == "C1CCC(C(C[C@H](C2CCC2)C2CC2)C2CCCCC2)CC1 |o1:6|");
+    }
+  }
+  SECTION("Anonymous") {
+    auto mol =
+        "C([C@@H](C1CC1)C1CCC1)[C@@H](C1CCCCC1)C1=CC=CC=N1 |o1:1,&1:9,c:21,23,t:19|"_smiles;
+    REQUIRE(mol);
+
+    {
+      RWMol cp(*mol);
+      auto hsh = MolHash::MolHash(&cp, MolHash::HashFunction::AnonymousGraph);
+      CHECK(hsh == "*1***(*(**(*2***2)*2**2)*2*****2)**1");
+    }
+    {
+      RWMol cp(*mol);
+
+      auto hsh =
+          MolHash::MolHash(&cp, MolHash::HashFunction::AnonymousGraph, true);
+      CHECK(hsh == "*1***(*(**(*2***2)*2**2)*2*****2)**1");
     }
   }
 }

--- a/Code/GraphMol/MolHash/catch_tests.cpp
+++ b/Code/GraphMol/MolHash/catch_tests.cpp
@@ -7,8 +7,6 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-#define CATCH_CONFIG_MAIN  // This tells Catch to provide a main() - only do
-                           // this in one cpp file
 #include "catch.hpp"
 
 #include <GraphMol/RDKitBase.h>
@@ -228,5 +226,33 @@ TEST_CASE("Github issues", "[molhash]") {
     REQUIRE(mol);
     auto hsh = MolHash::MolHash(mol.get(), MolHash::HashFunction::MolFormula);
     CHECK(hsh == "C2H6Cl");
+  }
+}
+
+TEST_CASE("MolHash with CX extensions", "[molhash]") {
+  SECTION("basics") {
+    auto mol =
+        "C[C@@H](O)[C@@H](C)[C@@H](C)C[C@H](C1=CN=CN1)C1=CNC=N1 "
+        "|o1:8,5,&1:1,3,r,c:11,18,t:9,15|"_smiles;
+    REQUIRE(mol);
+
+    {
+      RWMol cp(*mol);
+      auto hsh = MolHash::MolHash(&cp, MolHash::HashFunction::HetAtomTautomer);
+      CHECK(
+          hsh ==
+          "C[C@@H](CC([C]1[CH][N][CH][N]1)[C]1[CH][N][CH][N]1)[C@H](C)[C@@H](C)"
+          "[O]_3_0");
+    }
+    {
+      RWMol cp(*mol);
+
+      auto hsh =
+          MolHash::MolHash(&cp, MolHash::HashFunction::HetAtomTautomer, true);
+      CHECK(
+          hsh ==
+          "C[C@@H](CC([C]1[CH][N][CH][N]1)[C]1[CH][N][CH][N]1)[C@H](C)[C@@H](C)"
+          "[O]_3_0 |o1:1,&1:14,16|");
+    }
   }
 }

--- a/Code/GraphMol/MolHash/hashfunctions.cpp
+++ b/Code/GraphMol/MolHash/hashfunctions.cpp
@@ -1,13 +1,11 @@
-/*==============================================*/
-/* Copyright (C)  2011-2019  NextMove Software  */
-/* All rights reserved.                         */
-/*                                              */
-/* This file is part of molhash.                */
-/*                                              */
-/* The contents are covered by the terms of the */
-/* BSD license, which is included in the file   */
-/* license.txt.                                 */
-/*==============================================*/
+//
+//  Copyright (C) 2011-2022 NextMove Software and other RDKit contributors
+//
+//   @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
 #define _CRT_SECURE_NO_WARNINGS
 
 #include <cstring>

--- a/Code/GraphMol/MolHash/hashfunctions.cpp
+++ b/Code/GraphMol/MolHash/hashfunctions.cpp
@@ -126,8 +126,10 @@ void NMRDKitSanitizeHydrogens(RDKit::RWMol *mol) {
 
 namespace RDKit {
 namespace MolHash {
-static unsigned int NMDetermineComponents(RWMol *mol, unsigned int *parts,
-                                          unsigned int acount) {
+
+namespace {
+unsigned int NMDetermineComponents(RWMol *mol, unsigned int *parts,
+                                   unsigned int acount) {
   PRECONDITION(mol, "bad molecule");
   PRECONDITION(parts, "bad parts pointer");
   memset(parts, 0, acount * sizeof(unsigned int));
@@ -158,8 +160,8 @@ static unsigned int NMDetermineComponents(RWMol *mol, unsigned int *parts,
   return result;
 }
 
-static std::string NMMolecularFormula(RWMol *mol, const unsigned int *parts,
-                                      unsigned int part) {
+std::string NMMolecularFormula(RWMol *mol, const unsigned int *parts,
+                               unsigned int part) {
   PRECONDITION(mol, "bad molecule");
   PRECONDITION((!part || parts), "bad parts pointer");
   unsigned int hist[256];
@@ -212,7 +214,7 @@ static std::string NMMolecularFormula(RWMol *mol, const unsigned int *parts,
   return result;
 }
 
-static std::string NMMolecularFormula(RWMol *mol, bool sep = false) {
+std::string NMMolecularFormula(RWMol *mol, bool sep = false) {
   PRECONDITION(mol, "bad molecule");
   if (!sep) {
     return NMMolecularFormula(mol, nullptr, 0);
@@ -247,7 +249,7 @@ static std::string NMMolecularFormula(RWMol *mol, bool sep = false) {
   return result;
 }
 
-static void NormalizeHCount(Atom *aptr) {
+void NormalizeHCount(Atom *aptr) {
   PRECONDITION(aptr, "bad atom pointer");
   unsigned int hcount;
 
@@ -290,7 +292,7 @@ static void NormalizeHCount(Atom *aptr) {
   aptr->setNumExplicitHs(hcount);
 }
 
-static std::string AnonymousGraph(RWMol *mol, bool elem) {
+std::string AnonymousGraph(RWMol *mol, bool elem) {
   PRECONDITION(mol, "bad molecule");
   std::string result;
   int charge = 0;
@@ -316,7 +318,7 @@ static std::string AnonymousGraph(RWMol *mol, bool elem) {
   return result;
 }
 
-static std::string MesomerHash(RWMol *mol, bool netq, bool useCXSmiles) {
+std::string MesomerHash(RWMol *mol, bool netq, bool useCXSmiles) {
   PRECONDITION(mol, "bad molecule");
   std::string result;
   char buffer[32];
@@ -351,7 +353,7 @@ static std::string MesomerHash(RWMol *mol, bool netq, bool useCXSmiles) {
   return result;
 }
 
-static std::string TautomerHash(RWMol *mol, bool proto, bool useCXSmiles) {
+std::string TautomerHash(RWMol *mol, bool proto, bool useCXSmiles) {
   PRECONDITION(mol, "bad molecule");
   std::string result;
   char buffer[32];
@@ -399,7 +401,7 @@ static std::string TautomerHash(RWMol *mol, bool proto, bool useCXSmiles) {
   return result;
 }
 
-static bool TraverseForRing(Atom *atom, unsigned char *visit) {
+bool TraverseForRing(Atom *atom, unsigned char *visit) {
   PRECONDITION(atom, "bad atom pointer");
   PRECONDITION(visit, "bad pointer");
   visit[atom->getIdx()] = 1;
@@ -419,8 +421,7 @@ static bool TraverseForRing(Atom *atom, unsigned char *visit) {
   return false;
 }
 
-static bool DepthFirstSearchForRing(Atom *root, Atom *nbor,
-                                    unsigned int maxatomidx) {
+bool DepthFirstSearchForRing(Atom *root, Atom *nbor, unsigned int maxatomidx) {
   PRECONDITION(root, "bad atom pointer");
   PRECONDITION(nbor, "bad atom pointer");
 
@@ -449,7 +450,7 @@ bool IsInScaffold(Atom *atom, unsigned int maxatomidx) {
   return count > 1;
 }
 
-static bool HasNbrInScaffold(Atom *aptr, unsigned char *is_in_scaffold) {
+bool HasNbrInScaffold(Atom *aptr, unsigned char *is_in_scaffold) {
   PRECONDITION(aptr, "bad atom pointer");
   PRECONDITION(is_in_scaffold, "bad pointer");
   for (auto nbri : boost::make_iterator_range(
@@ -462,7 +463,7 @@ static bool HasNbrInScaffold(Atom *aptr, unsigned char *is_in_scaffold) {
   return false;
 }
 
-static std::string ExtendedMurckoScaffold(RWMol *mol, bool useCXSmiles) {
+std::string ExtendedMurckoScaffold(RWMol *mol, bool useCXSmiles) {
   PRECONDITION(mol, "bad molecule");
   RDKit::MolOps::fastFindRings(*mol);
 
@@ -501,7 +502,7 @@ static std::string ExtendedMurckoScaffold(RWMol *mol, bool useCXSmiles) {
   return result;
 }
 
-static std::string MurckoScaffoldHash(RWMol *mol, bool useCXSmiles) {
+std::string MurckoScaffoldHash(RWMol *mol, bool useCXSmiles) {
   PRECONDITION(mol, "bad molecule");
   std::vector<Atom *> for_deletion;
   do {
@@ -537,7 +538,7 @@ static std::string MurckoScaffoldHash(RWMol *mol, bool useCXSmiles) {
   return result;
 }
 
-static std::string NetChargeHash(RWMol *mol) {
+std::string NetChargeHash(RWMol *mol) {
   PRECONDITION(mol, "bad molecule");
   int totalq = 0;
 
@@ -550,7 +551,7 @@ static std::string NetChargeHash(RWMol *mol) {
   return buffer;
 }
 
-static std::string SmallWorldHash(RWMol *mol, bool brl) {
+std::string SmallWorldHash(RWMol *mol, bool brl) {
   PRECONDITION(mol, "bad molecule");
   char buffer[64];
 
@@ -572,7 +573,7 @@ static std::string SmallWorldHash(RWMol *mol, bool brl) {
   return buffer;
 }
 
-static void DegreeVector(RWMol *mol, unsigned int *v) {
+void DegreeVector(RWMol *mol, unsigned int *v) {
   memset(v, 0, 4 * sizeof(unsigned int));
   for (auto aptr : mol->atoms()) {
     switch (aptr->getDegree()) {
@@ -592,7 +593,7 @@ static void DegreeVector(RWMol *mol, unsigned int *v) {
   }
 }
 
-static bool HasDoubleBond(Atom *atom) {
+bool HasDoubleBond(Atom *atom) {
   PRECONDITION(atom, "bad atom");
   for (const auto &nbri :
        boost::make_iterator_range(atom->getOwningMol().getAtomBonds(atom))) {
@@ -611,7 +612,7 @@ static bool HasDoubleBond(Atom *atom) {
 // 2 means break, with hydrogen on beg and asterisk on end
 // 3 means break, with asterisks on both beg and end
 
-static int RegioisomerBond(Bond *bnd) {
+int RegioisomerBond(Bond *bnd) {
   PRECONDITION(bnd, "bad bond");
   if (NMRDKitBondGetOrder(bnd) != 1) {
     return -1;
@@ -649,7 +650,7 @@ static int RegioisomerBond(Bond *bnd) {
   return -1;
 }
 
-static void ClearEZStereo(Atom *atm) {
+void ClearEZStereo(Atom *atm) {
   PRECONDITION(atm, "bad atom");
   for (const auto &nbri :
        boost::make_iterator_range(atm->getOwningMol().getAtomBonds(atm))) {
@@ -660,7 +661,7 @@ static void ClearEZStereo(Atom *atm) {
   }
 }
 
-static std::string RegioisomerHash(RWMol *mol, bool useCXSmiles) {
+std::string RegioisomerHash(RWMol *mol, bool useCXSmiles) {
   PRECONDITION(mol, "bad molecule");
 
   // we need a copy of the molecule so that we can loop over the bonds of
@@ -715,7 +716,7 @@ static std::string RegioisomerHash(RWMol *mol, bool useCXSmiles) {
   return result;
 }
 
-static std::string ArthorSubOrderHash(RWMol *mol) {
+std::string ArthorSubOrderHash(RWMol *mol) {
   PRECONDITION(mol, "bad molecule");
   char buffer[256];
 
@@ -832,6 +833,7 @@ static std::string ArthorSubOrderHash(RWMol *mol) {
           pcount, ccount, ocount, zcount, rcount, qcount, icount);
   return buffer;
 }
+}  // namespace
 
 std::string MolHash(RWMol *mol, HashFunction func, bool useCXSmiles) {
   PRECONDITION(mol, "bad molecule");

--- a/Code/GraphMol/MolHash/mf.h
+++ b/Code/GraphMol/MolHash/mf.h
@@ -1,13 +1,11 @@
-/*==============================================*/
-/* Copyright (C)  2016-2019  NextMove Software  */
-/* All rights reserved.                         */
-/*                                              */
-/* This file is part of molhash.                */
-/*                                              */
-/* The contents are covered by the terms of the */
-/* BSD license, which is included in the file   */
-/* license.txt.                                 */
-/*==============================================*/
+//
+//  Copyright (C) 2016-2022 NextMove Software and other RDKit contributors
+//
+//   @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
 #ifndef NMS_MOLFORMULA_H
 #define NMS_MOLFORMULA_H
 

--- a/Code/GraphMol/MolHash/nmmolhash.h
+++ b/Code/GraphMol/MolHash/nmmolhash.h
@@ -42,7 +42,8 @@ enum class HashFunction {
   ArthorSubstructureOrder = 17
 };
 
-RDKIT_MOLHASH_EXPORT std::string MolHash(RWMol *mol, HashFunction func);
+RDKIT_MOLHASH_EXPORT std::string MolHash(RWMol *mol, HashFunction func,
+                                         bool useCXSmiles = false);
 
 enum class StripType {
   AtomStereo = 1,

--- a/Code/GraphMol/MolHash/normalize.cpp
+++ b/Code/GraphMol/MolHash/normalize.cpp
@@ -1,13 +1,11 @@
-/*==============================================*/
-/* Copyright (C)  2019       NextMove Software  */
-/* All rights reserved.                         */
-/*                                              */
-/* This file is part of molhash.                */
-/*                                              */
-/* The contents are covered by the terms of the */
-/* BSD license, which is included in the file   */
-/* license.txt.                                 */
-/*==============================================*/
+//
+//  Copyright (C) 2019-2022 NextMove Software and other RDKit contributors
+//
+//   @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
 
 #include <GraphMol/RDKitBase.h>
 #include <GraphMol/RDKitQueries.h>

--- a/Code/GraphMol/MolHash/normalize.cpp
+++ b/Code/GraphMol/MolHash/normalize.cpp
@@ -51,11 +51,9 @@ void Strip(RWMol *mol, unsigned int striptype) {
 }
 
 void SplitMolecule(RWMol *mol, std::vector<RWMol *> &molv) {
-  RDKit::MOL_SPTR_VECT mfrags = RDKit::MolOps::getMolFrags(*mol);
-  RDKit::MOL_SPTR_VECT::iterator vit;
-  for (vit = mfrags.begin(); vit != mfrags.end(); ++vit) {
-    RDKit::ROMol *wrappedmol =
-        (*vit).get();  // reach inside the shared pointer...
+  auto mfrags = RDKit::MolOps::getMolFrags(*mol);
+  for (const auto &frag : mfrags) {
+    const auto *wrappedmol = frag.get();  // reach inside the shared pointer...
     molv.push_back(new RWMol(*wrappedmol));  // ...and make a copy
   }
 }

--- a/Code/GraphMol/MolHash/normalize.cpp
+++ b/Code/GraphMol/MolHash/normalize.cpp
@@ -25,6 +25,10 @@ void Strip(RWMol *mol, unsigned int striptype) {
     for (auto aptr : mol->atoms()) {
       aptr->setChiralTag(RDKit::Atom::CHI_UNSPECIFIED);
     }
+    if (!mol->getStereoGroups().empty()) {
+      std::vector<StereoGroup> no_sgs;
+      mol->setStereoGroups(std::move(no_sgs));
+    }
   }
   if (striptype & static_cast<unsigned>(StripType::BondStereo)) {
     for (auto bptr : mol->bonds()) {

--- a/Code/GraphMol/catch_chirality.cpp
+++ b/Code/GraphMol/catch_chirality.cpp
@@ -1739,22 +1739,6 @@ TEST_CASE("StereoGroup Testing") {
   }
 }
 
-TEST_CASE("replaceAtom and StereoGroups") {
-  SECTION("basics") {
-    auto mol = "C[C@](O)(Cl)[C@H](F)Cl |o1:1,4|"_smiles;
-    REQUIRE(mol);
-    CHECK(mol->getStereoGroups().size() == 1);
-    CHECK(mol->getStereoGroups()[0].getAtoms().size() == 2);
-    CHECK(mol->getStereoGroups()[0].getAtoms()[0] == mol->getAtomWithIdx(1));
-
-    Atom acp(*mol->getAtomWithIdx(1));
-    mol->replaceAtom(1, &acp);
-    CHECK(mol->getStereoGroups().size() == 1);
-    CHECK(mol->getStereoGroups()[0].getAtoms().size() == 2);
-    CHECK(mol->getStereoGroups()[0].getAtoms()[0] == mol->getAtomWithIdx(1));
-  }
-}
-
 TEST_CASE("Removing stereogroups from unspecified atoms") {
   SECTION("basics") {
     auto mol = "C[C@](O)(Cl)F |o1:1|"_smiles;
@@ -1775,5 +1759,21 @@ TEST_CASE("Removing stereogroups from unspecified atoms") {
     CHECK(mol->getStereoGroups().size() == 1);
     CHECK(mol->getStereoGroups()[0].getAtoms().size() == 1);
     CHECK(mol->getStereoGroups()[0].getAtoms()[0]->getIdx() == 4);
+  }
+}
+
+TEST_CASE("replaceAtom and StereoGroups") {
+  SECTION("basics") {
+    auto mol = "C[C@](O)(Cl)[C@H](F)Cl |o1:1,4|"_smiles;
+    REQUIRE(mol);
+    CHECK(mol->getStereoGroups().size() == 1);
+    CHECK(mol->getStereoGroups()[0].getAtoms().size() == 2);
+    CHECK(mol->getStereoGroups()[0].getAtoms()[0] == mol->getAtomWithIdx(1));
+
+    Atom acp(*mol->getAtomWithIdx(1));
+    mol->replaceAtom(1, &acp);
+    CHECK(mol->getStereoGroups().size() == 1);
+    CHECK(mol->getStereoGroups()[0].getAtoms().size() == 2);
+    CHECK(mol->getStereoGroups()[0].getAtoms()[0] == mol->getAtomWithIdx(1));
   }
 }

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -4,6 +4,10 @@
 ## Backwards incompatible changes
 - When running in Jupyter Notebook, logs are now sent only to Python's
   standard error stream, and no longer include the `RDKit LEVEL` prefix.
+- The MolHash functions now reassign stereochemistry after modifying the
+  molecule and before calculating the hash. Previous versions would still
+  include information about atom/bond stereochemistry in the output hash even if
+  that no longer applies in the modified molecule.
 
 ## Code removed in this release:
 - The `useCountSimulation` keyword argument for


### PR DESCRIPTION
This PR adds the option to include CXSMILES extensions to the hash strings generated by MolHash. One example of when this would be useful is when the molecules being hashed include enhanced stereochemistry.

Other changes in here:
- a bug fix to make sure hashes don't include stereo information on atoms/bonds which have newly duplicate neighbors
- a bit of general cleanup of the hashing code