### PR TITLE
Python loggers set to DEBUG level by default

### DIFF
--- a/rdkit/__init__.py
+++ b/rdkit/__init__.py
@@ -28,7 +28,7 @@ except:
 # "enabling jupyter" message at the root logger.
 log_handler = logging.StreamHandler(sys.stderr)
 logger.addHandler(log_handler)
-logger.setLevel(logging.DEBUG)
+logger.setLevel(logging.WARN)
 logger.propagate = False
 
 # Uncomment this to use Python logging by default:


### PR DESCRIPTION
The logging level was set to DEBUG since #4846. This causes an excess of text to be printed when certain operations are performed. We should raise the level to WARN to reduce the amount of logs being printed to a reasonable level.

E.g., just importing `from rdkit.Chem import MolStandardize` results in this output being printed on the console:
```
Initializing Normalization: Nitro to N+(O-)=O
Initializing Normalization: Sulfone to S(=O)(=O)
Initializing Normalization: Pyridine oxide to n+O-
Initializing Normalization: Azide to N=N+=N-
Initializing Normalization: Diazo/azo to =N+=N-
Initializing Normalization: Sulfoxide to -S+(O-)-
Initializing Normalization: Phosphate to P(O-)=O
Initializing Normalization: C/S+N to C/S=N+
Initializing Normalization: P+N to P=N+
Initializing Normalization: Normalize hydrazine-diazonium
Initializing Normalization: Recombine 1,3-separated charges
Initializing Normalization: Recombine 1,3-separated charges
Initializing Normalization: Recombine 1,3-separated charges
Initializing Normalization: Recombine 1,5-separated charges
Initializing Normalization: Recombine 1,5-separated charges
Initializing Normalization: Recombine 1,5-separated charges
Initializing Normalization: Normalize 1,3 conjugated cation
Initializing Normalization: Normalize 1,3 conjugated cation
Initializing Normalization: Normalize 1,5 conjugated cation
Initializing Normalization: Normalize 1,5 conjugated cation
Initializing Normalization: Charge normalization
Initializing Normalization: Charge recombination
Initializing AcidBasePair: -OSO3H
Initializing AcidBasePair: -SO3H
Initializing AcidBasePair: -OSO2H
Initializing AcidBasePair: -SO2H
Initializing AcidBasePair: -OPO3H2
Initializing AcidBasePair: -PO3H2
Initializing AcidBasePair: -CO2H
Initializing AcidBasePair: thiophenol
Initializing AcidBasePair: (-OPO3H)-
Initializing AcidBasePair: (-PO3H)-
Initializing AcidBasePair: phthalimide
Initializing AcidBasePair: CO3H (peracetyl)
Initializing AcidBasePair: alpha-carbon-hydrogen-nitro group
Initializing AcidBasePair: -SO2NH2
Initializing AcidBasePair: -OBO2H2
Initializing AcidBasePair: -BO2H2
Initializing AcidBasePair: phenol
Initializing AcidBasePair: SH (aliphatic)
Initializing AcidBasePair: (-OBO2H)-
Initializing AcidBasePair: (-BO2H)-
Initializing AcidBasePair: cyclopentadiene
Initializing AcidBasePair: -CONH2
Initializing AcidBasePair: imidazole
Initializing AcidBasePair: -OH (aliphatic alcohol)
Initializing AcidBasePair: alpha-carbon-hydrogen-keto group
Initializing AcidBasePair: alpha-carbon-hydrogen-acetyl ester group
Initializing AcidBasePair: sp carbon hydrogen
Initializing AcidBasePair: alpha-carbon-hydrogen-sulfone group
Initializing AcidBasePair: alpha-carbon-hydrogen-sulfoxide group
Initializing AcidBasePair: -NH2
Initializing AcidBasePair: benzyl hydrogen
Initializing AcidBasePair: sp2-carbon hydrogen
Initializing AcidBasePair: sp3-carbon hydrogen
Initializing ChargeCorrection: [Li,Na,K]
Initializing ChargeCorrection: [Mg,Ca]
Initializing ChargeCorrection: [Cl]
```