### PR TITLE
Fix github 5061.

### DIFF
--- a/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
@@ -297,11 +297,17 @@ void MolDraw2D::drawReaction(
   if (delta < 5) {
     frac *= 5 / delta;
   }
-  drawArrow(arrowBeg, arrowEnd, false, frac, M_PI / 6,
-            drawOptions().symbolColour, true);
   xOffset = drawReactionPart(agents, 0, xOffset, offsets);
   xOffset = drawReactionPart(products, plusWidth, xOffset, offsets);
-
+  auto osbw = drawOptions().scaleBondWidth;
+  if (reagents.empty() && products.empty() && agents.empty()) {
+    // if it's an empty reaction, we won't have a DrawMol with a scale,
+    // so we won't be able to do a scaled bond width
+    drawOptions().scaleBondWidth = false;
+  }
+  drawArrow(arrowBeg, arrowEnd, false, frac, M_PI / 6,
+            drawOptions().symbolColour, true);
+  drawOptions().scaleBondWidth = osbw;
   if (drawOptions().includeMetadata) {
     this->updateMetadata(rxn);
   }

--- a/Code/GraphMol/MolDraw2D/catch_tests.cpp
+++ b/Code/GraphMol/MolDraw2D/catch_tests.cpp
@@ -199,6 +199,7 @@ static const std::map<std::string, std::hash_result_t> SVG_HASHES = {
     {"testVariableLegend_1.svg", 2181678815U},
     {"testVariableLegend_2.svg", 2392644674U},
     {"testVariableLegend_3.svg", 2954965314U},
+    {"testGithub_5061.svg", 632991478U},
 };
 
 // These PNG hashes aren't completely reliable due to floating point cruft,

--- a/Code/GraphMol/MolDraw2D/catch_tests.cpp
+++ b/Code/GraphMol/MolDraw2D/catch_tests.cpp
@@ -4256,6 +4256,40 @@ TEST_CASE("vary proporition of panel for legend", "[drawing]") {
   }
 }
 
+TEST_CASE("Github 5061 - draw reaction with no reagents and scaleBondWidth true") {
+  SECTION("basics") {
+    std::string data = R"RXN($RXN
+
+  Mrv16425    091201171606
+
+  0  1
+$MOL
+
+  Mrv1642509121716062D
+
+  2  1  0  0  0  0            999 V2000
+    3.5357    0.0000    0.0000 R#  0  0  0  0  0  0  0  0  0  0  0  0
+    2.7107    0.0000    0.0000 R#  0  0  0  0  0  0  0  0  0  0  0  0
+  1  2  1  0  0  0  0
+M  RGP  2   1   1   2   2
+
+
+M  END)RXN";
+    {
+      std::unique_ptr<ChemicalReaction> rxn{RxnBlockToChemicalReaction(data)};
+      MolDraw2DSVG drawer(450, 200);
+      drawer.drawOptions().scaleBondWidth = true;
+      drawer.drawReaction(*rxn);
+      drawer.finishDrawing();
+      auto text = drawer.getDrawingText();
+      std::ofstream outs("testGithub_5061.svg");
+      outs << text;
+      outs.flush();
+      check_file_hash("testGithub_5061.svg");
+    }
+  }
+}
+
 #ifdef RDK_BUILD_CAIRO_SUPPORT
 TEST_CASE("drawing doesn't destroy reaction properties", "[drawing]") {
   auto rxn = "[CH3:1][OH:2]>>[CH2:1]=[OH0:2]"_rxnsmarts;


### PR DESCRIPTION
#### Reference Issue
Fixes https://github.com/rdkit/rdkit/issues/5061


#### What does this implement/fix? Explain your changes.
When no reagents are present in the reaction, there's nothing to use to scale the line width when drawing the arrow.  Duck the problem by drawing the arrow last.

#### Any other comments?
On my macBook, I am getting what look spurious different hash codes messaged for the moldraw2DRxnTest1 SVGs. 
