### PR TITLE
Add sanitize option to molzip

### DIFF
--- a/Code/GraphMol/ChemTransforms/MolFragmenter.cpp
+++ b/Code/GraphMol/ChemTransforms/MolFragmenter.cpp
@@ -955,7 +955,7 @@ std::unique_ptr<ROMol> molzip(const ROMol &a, const ROMol &b,
       }
     }
   }
-  newmol->updatePropertyCache(params.sanitize);
+  newmol->updatePropertyCache(params.enforceValenceRules);
   newmol->setProp(common_properties::_StereochemDone, true);
   return newmol;
 }

--- a/Code/GraphMol/ChemTransforms/MolFragmenter.cpp
+++ b/Code/GraphMol/ChemTransforms/MolFragmenter.cpp
@@ -955,7 +955,7 @@ std::unique_ptr<ROMol> molzip(const ROMol &a, const ROMol &b,
       }
     }
   }
-  newmol->updatePropertyCache();
+  newmol->updatePropertyCache(params.sanitize);
   newmol->setProp(common_properties::_StereochemDone, true);
   return newmol;
 }

--- a/Code/GraphMol/ChemTransforms/MolFragmenter.h
+++ b/Code/GraphMol/ChemTransforms/MolFragmenter.h
@@ -106,7 +106,7 @@ enum class MolzipLabel { AtomMapNumber, Isotope, FragmentOnBonds, AtomType };
 struct RDKIT_CHEMTRANSFORMS_EXPORT MolzipParams {
   MolzipLabel label = MolzipLabel::AtomMapNumber;
   std::vector<std::string> atomSymbols;
-  bool sanitize=true;
+  bool enforceValenceRules=true;
 };
 
 RDKIT_CHEMTRANSFORMS_EXPORT std::unique_ptr<ROMol> molzip(

--- a/Code/GraphMol/ChemTransforms/MolFragmenter.h
+++ b/Code/GraphMol/ChemTransforms/MolFragmenter.h
@@ -106,6 +106,7 @@ enum class MolzipLabel { AtomMapNumber, Isotope, FragmentOnBonds, AtomType };
 struct RDKIT_CHEMTRANSFORMS_EXPORT MolzipParams {
   MolzipLabel label = MolzipLabel::AtomMapNumber;
   std::vector<std::string> atomSymbols;
+  bool sanitize=true;
 };
 
 RDKIT_CHEMTRANSFORMS_EXPORT std::unique_ptr<ROMol> molzip(

--- a/Code/GraphMol/ChemTransforms/catch_tests.cpp
+++ b/Code/GraphMol/ChemTransforms/catch_tests.cpp
@@ -372,6 +372,15 @@ TEST_CASE("molzip", "[]") {
     }
     CHECK(caught == true);
   }
+
+  {
+    // check to see we can make a non sanitizable zipped mol
+    MolzipParams p;
+    p.sanitize = false;
+    auto a = "CC(=[*:1])N"_smiles;
+    auto b = "[*:1]-N=C"_smiles;
+    auto mol = molzip(*a, *b, params);
+  }
 }
 
 TEST_CASE(

--- a/Code/GraphMol/ChemTransforms/catch_tests.cpp
+++ b/Code/GraphMol/ChemTransforms/catch_tests.cpp
@@ -376,7 +376,7 @@ TEST_CASE("molzip", "[]") {
   {
     // check to see we can make a non sanitizable zipped mol
     MolzipParams p;
-    p.sanitize = false;
+    p.enforceValenceRules = false;
     auto a = "CC(=[*:1])N"_smiles;
     auto b = "[*:1]-N=C"_smiles;
     auto mol = molzip(*a, *b, p);

--- a/Code/GraphMol/ChemTransforms/catch_tests.cpp
+++ b/Code/GraphMol/ChemTransforms/catch_tests.cpp
@@ -379,7 +379,7 @@ TEST_CASE("molzip", "[]") {
     p.sanitize = false;
     auto a = "CC(=[*:1])N"_smiles;
     auto b = "[*:1]-N=C"_smiles;
-    auto mol = molzip(*a, *b, params);
+    auto mol = molzip(*a, *b, p);
   }
 }
 

--- a/Code/GraphMol/Wrap/MolOps.cpp
+++ b/Code/GraphMol/Wrap/MolOps.cpp
@@ -2468,8 +2468,9 @@ EXAMPLES:\n\n\
                                  python::init<>())
         .def_readwrite("label", &MolzipParams::label,
                        "Set the atom labelling system to zip together")
-        .def_readwrite("sanitize", &MolzipParams::sanitize,
-		       "If true (default) performs simple sanitization of the output")
+        .def_readwrite("enforceValenceRules", &MolzipParams::enforceValenceRules,
+		       "If true (default) enforce valences after zipping\n\
+Setting this to false allows assembling chemically incorrect fragments.")
         .def("setAtomSymbols", &RDKit::setAtomSymbols,
              "Set the atom symbols used to zip mols together when using AtomType labeling")
       ;

--- a/Code/GraphMol/Wrap/MolOps.cpp
+++ b/Code/GraphMol/Wrap/MolOps.cpp
@@ -2468,6 +2468,8 @@ EXAMPLES:\n\n\
                                  python::init<>())
         .def_readwrite("label", &MolzipParams::label,
                        "Set the atom labelling system to zip together")
+        .def_readwrite("sanitize", &MolzipParams::sanitize,
+		       "If true (default) performs simple sanitization of the output")
         .def("setAtomSymbols", &RDKit::setAtomSymbols,
              "Set the atom symbols used to zip mols together when using AtomType labeling")
       ;

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -6493,7 +6493,7 @@ M  END
     a = Chem.MolFromSmiles("C(=[*:1])N")
     b = Chem.MolFromSmiles("[*:1]-N=C")
     p = Chem.MolzipParams()
-    p.sanitize = False
+    p.enforceValenceRules = False
     c = Chem.molzip(a, b, p)
     
 

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -6490,6 +6490,13 @@ M  END
     c = Chem.molzip(a, b, p)
     self.assertEqual(Chem.MolToSmiles(c), "N[C@@H](F)I")
 
+    a = Chem.MolFromSmiles("C(=[*:1])N")
+    b = Chem.MolFromSmiles("[*:1]-N=C")
+    p = Chem.MolzipParams()
+    p.sanitize = False
+    c = Chem.molzip(a, b, p)
+    
+
   def testContextManagers(self):
     from rdkit import RDLogger
     RDLogger.DisableLog('rdApp.*')


### PR DESCRIPTION
This code allows non sanitizable fragments to be combined.  This is useful when combining multiple fragments that may eventually become a sensible molecule.