### PR TITLE
modify the way legends are handled with the flexicanvas mode

### DIFF
--- a/Code/GraphMol/MolDraw2D/DrawMol.cpp
+++ b/Code/GraphMol/MolDraw2D/DrawMol.cpp
@@ -816,11 +816,9 @@ void DrawMol::calculateScale() {
     drawHeight_ = newScale * yRange_;
   }
   if (height_ < 0) {
+    height_ = drawHeight_;
     if (legend_.empty()) {
-      height_ = drawHeight_;
       legendHeight_ = 0;
-    } else {
-      height_ = drawHeight_;
     }
   }
 
@@ -1417,8 +1415,7 @@ void DrawMol::extractLegend() {
       relFontScale *= double(width_) / total_width;
       calc_legend_height(legend_bits, relFontScale, total_width, total_height);
     } else {
-      width_ = total_width;
-      width_ += width_ * drawOptions_.padding;
+      width_ = total_width * (1 + drawOptions_.padding);
     }
   }
 
@@ -1432,8 +1429,7 @@ void DrawMol::extractLegend() {
     }
   } else {
     height_ += total_height;
-    // REVIEW: is this factoring in the padding for the drawing bit twice?
-    height_ += height_ * drawOptions_.padding;
+    // height_ += height_ * drawOptions_.padding;
   }
 
   Point2D loc(width_ / 2 + xOffset_,

--- a/Code/GraphMol/MolDraw2D/DrawMol.cpp
+++ b/Code/GraphMol/MolDraw2D/DrawMol.cpp
@@ -60,7 +60,8 @@ DrawMol::DrawMol(
       yMax_(std::numeric_limits<double>::lowest() / 2.0),
       xRange_(std::numeric_limits<double>::max()),
       yRange_(std::numeric_limits<double>::max()),
-      flexiCanvas_(height_ < 0.0 || width_ < 0.0) {
+      flexiCanvasX_(width_ < 0.0),
+      flexiCanvasY_(height_ < 0.0) {
   if (highlight_atoms) {
     highlightAtoms_ = *highlight_atoms;
   }
@@ -1412,7 +1413,7 @@ void DrawMol::extractLegend() {
   double total_width, total_height;
   calc_legend_height(legend_bits, relFontScale, total_width, total_height);
   if (total_width >= width_) {
-    if (!flexiCanvas_) {
+    if (!flexiCanvasX_) {
       relFontScale *= double(width_) / total_width;
       calc_legend_height(legend_bits, relFontScale, total_width, total_height);
     } else {
@@ -1421,7 +1422,7 @@ void DrawMol::extractLegend() {
     }
   }
 
-  if (!flexiCanvas_) {
+  if (!flexiCanvasY_) {
     auto adjLegHt = height_ * drawOptions_.legendFraction;
     // subtract off space for the padding.
     adjLegHt -= 0.5 * drawOptions_.padding * height_;

--- a/Code/GraphMol/MolDraw2D/DrawMol.h
+++ b/Code/GraphMol/MolDraw2D/DrawMol.h
@@ -265,7 +265,8 @@ class DrawMol {
   // via MolDraw2D's activeAtmIdx[12]_ and activeBndIdx.  We don't always want
   // them to start from 0 for atom/bond 0.
   int activeAtmIdxOffset_ = 0, activeBndIdxOffset_ = 0;
-  bool flexiCanvas_ = false;
+  bool flexiCanvasX_ = false;
+  bool flexiCanvasY_ = false;
 };
 
 void centerMolForDrawing(RWMol &mol, int confId = 1);

--- a/Code/GraphMol/MolDraw2D/DrawMol.h
+++ b/Code/GraphMol/MolDraw2D/DrawMol.h
@@ -265,6 +265,7 @@ class DrawMol {
   // via MolDraw2D's activeAtmIdx[12]_ and activeBndIdx.  We don't always want
   // them to start from 0 for atom/bond 0.
   int activeAtmIdxOffset_ = 0, activeBndIdxOffset_ = 0;
+  bool flexiCanvas_ = false;
 };
 
 void centerMolForDrawing(RWMol &mol, int confId = 1);

--- a/Code/GraphMol/MolDraw2D/catch_tests.cpp
+++ b/Code/GraphMol/MolDraw2D/catch_tests.cpp
@@ -188,9 +188,13 @@ static const std::map<std::string, std::hash_result_t> SVG_HASHES = {
     {"testSemiFlexiCanvas.1c.svg", 3129493597U},
     {"testFlexiCanvas.3.svg", 1503902249U},
     {"testFlexiCanvas.4a.svg", 428287035U},
-    {"testFlexiCanvas.4b.svg", 2697900619U},
-    {"testFlexiCanvas.4c.svg", 2505619220U},
-    {"testFlexiCanvas.4d.svg", 1845451441U},
+    {"testFlexiCanvas.4b.svg", 2666113420U},
+    {"testFlexiCanvas.4c.svg", 966336388U},
+    {"testFlexiCanvas.4d.svg", 2157934249U},
+    {"testFlexiCanvas.5a.svg", 2806793427U},
+    {"testFlexiCanvas.5b.svg", 4143043529U},
+    {"testFlexiCanvas.5c.svg", 54804156U},
+    {"testFlexiCanvas.5d.svg", 2580215972U},
     {"testGithub4764.sz1.svg", 2195931596U},
     {"testGithub4764.sz2.svg", 3477099305U},
     {"testGithub4764.sz3.svg", 3324176273U},
@@ -4059,6 +4063,52 @@ M  END)CTAB"_ctab;
       check_file_hash("testFlexiCanvas.4d.svg");
     }
   }
+  SECTION("including legends") {
+    // add an atomNote so that we can compare font sizes
+    mol1->getAtomWithIdx(0)->setProp(common_properties::atomNote, "n1");
+    {
+      MolDraw2DSVG drawer(-1, -1);
+      drawer.drawMolecule(*mol1, "legend");
+      drawer.finishDrawing();
+      auto text = drawer.getDrawingText();
+      std::ofstream outs("testFlexiCanvas.5a.svg");
+      outs << text;
+      outs.flush();
+      check_file_hash("testFlexiCanvas.5a.svg");
+    }
+    {
+      MolDraw2DSVG drawer(-1, -1);
+      drawer.drawMolecule(*mol1, "legend\nwith two lines");
+      drawer.finishDrawing();
+      auto text = drawer.getDrawingText();
+      std::ofstream outs("testFlexiCanvas.5b.svg");
+      outs << text;
+      outs.flush();
+      check_file_hash("testFlexiCanvas.5b.svg");
+    }
+    {
+      MolDraw2DSVG drawer(-1, -1);
+      drawer.drawOptions().scalingFactor = 45;
+      drawer.drawMolecule(*mol1, "legend");
+      drawer.finishDrawing();
+      auto text = drawer.getDrawingText();
+      std::ofstream outs("testFlexiCanvas.5c.svg");
+      outs << text;
+      outs.flush();
+      check_file_hash("testFlexiCanvas.5c.svg");
+    }
+    {
+      MolDraw2DSVG drawer(-1, -1);
+      drawer.drawOptions().scalingFactor = 10;
+      drawer.drawMolecule(*mol1, "legend");
+      drawer.finishDrawing();
+      auto text = drawer.getDrawingText();
+      std::ofstream outs("testFlexiCanvas.5d.svg");
+      outs << text;
+      outs.flush();
+      check_file_hash("testFlexiCanvas.5d.svg");
+    }
+  }
 }
 
 TEST_CASE("Github #4764") {
@@ -4257,7 +4307,8 @@ TEST_CASE("vary proporition of panel for legend", "[drawing]") {
   }
 }
 
-TEST_CASE("Github 5061 - draw reaction with no reagents and scaleBondWidth true") {
+TEST_CASE(
+    "Github 5061 - draw reaction with no reagents and scaleBondWidth true") {
   SECTION("basics") {
     std::string data = R"RXN($RXN
 

--- a/Code/GraphMol/MolDraw2D/catch_tests.cpp
+++ b/Code/GraphMol/MolDraw2D/catch_tests.cpp
@@ -43,7 +43,7 @@ namespace {
 // The hand-drawn pictures will fail this frequently due to the use
 // of random numbers to draw the lines.  As well as all the testHandDrawn
 // files, this includes testBrackets-5a.svg and testPositionVariation-1b.svg
-static const bool DELETE_WITH_GOOD_HASH = false;
+static const bool DELETE_WITH_GOOD_HASH = true;
 // The expected hash code for a file may be included in these maps, or
 // provided in the call to check_file_hash().
 // These values are for a build with FreeType, so expect them all to be
@@ -188,21 +188,21 @@ static const std::map<std::string, std::hash_result_t> SVG_HASHES = {
     {"testSemiFlexiCanvas.1c.svg", 3129493597U},
     {"testFlexiCanvas.3.svg", 1503902249U},
     {"testFlexiCanvas.4a.svg", 428287035U},
-    {"testFlexiCanvas.4b.svg", 2666113420U},
-    {"testFlexiCanvas.4c.svg", 966336388U},
-    {"testFlexiCanvas.4d.svg", 2157934249U},
-    {"testFlexiCanvas.5a.svg", 2806793427U},
-    {"testFlexiCanvas.5b.svg", 4143043529U},
-    {"testFlexiCanvas.5c.svg", 54804156U},
-    {"testFlexiCanvas.5d.svg", 2580215972U},
+    {"testFlexiCanvas.4b.svg", 3643035210U},
+    {"testFlexiCanvas.4c.svg", 377546443U},
+    {"testFlexiCanvas.4d.svg", 2960126120U},
+    {"testFlexiCanvas.5a.svg", 948987396U},
+    {"testFlexiCanvas.5b.svg", 768214783U},
+    {"testFlexiCanvas.5c.svg", 1950949146U},
+    {"testFlexiCanvas.5d.svg", 4273629948U},
     {"testFlexiCanvas.6a.svg", 1705496796U},
     {"testFlexiCanvas.6b.svg", 1850606159U},
     {"testFlexiCanvas.6c.svg", 1705496796U},
     {"testFlexiCanvas.6d.svg", 1705496796U},
-    {"testFlexiCanvas.7a.svg", 332655605U},
-    {"testFlexiCanvas.7b.svg", 3708997766U},
-    {"testFlexiCanvas.7c.svg", 332655605U},
-    {"testFlexiCanvas.7d.svg", 332655605U},
+    {"testFlexiCanvas.7a.svg", 1790658127U},
+    {"testFlexiCanvas.7b.svg", 1178964791U},
+    {"testFlexiCanvas.7c.svg", 1790658127U},
+    {"testFlexiCanvas.7d.svg", 1790658127U},
     {"testGithub4764.sz1.svg", 2195931596U},
     {"testGithub4764.sz2.svg", 3477099305U},
     {"testGithub4764.sz3.svg", 3324176273U},

--- a/Code/GraphMol/MolDraw2D/catch_tests.cpp
+++ b/Code/GraphMol/MolDraw2D/catch_tests.cpp
@@ -43,7 +43,7 @@ namespace {
 // The hand-drawn pictures will fail this frequently due to the use
 // of random numbers to draw the lines.  As well as all the testHandDrawn
 // files, this includes testBrackets-5a.svg and testPositionVariation-1b.svg
-static const bool DELETE_WITH_GOOD_HASH = true;
+static const bool DELETE_WITH_GOOD_HASH = false;
 // The expected hash code for a file may be included in these maps, or
 // provided in the call to check_file_hash().
 // These values are for a build with FreeType, so expect them all to be
@@ -195,6 +195,14 @@ static const std::map<std::string, std::hash_result_t> SVG_HASHES = {
     {"testFlexiCanvas.5b.svg", 4143043529U},
     {"testFlexiCanvas.5c.svg", 54804156U},
     {"testFlexiCanvas.5d.svg", 2580215972U},
+    {"testFlexiCanvas.6a.svg", 1705496796U},
+    {"testFlexiCanvas.6b.svg", 1850606159U},
+    {"testFlexiCanvas.6c.svg", 1705496796U},
+    {"testFlexiCanvas.6d.svg", 1705496796U},
+    {"testFlexiCanvas.7a.svg", 332655605U},
+    {"testFlexiCanvas.7b.svg", 3708997766U},
+    {"testFlexiCanvas.7c.svg", 332655605U},
+    {"testFlexiCanvas.7d.svg", 332655605U},
     {"testGithub4764.sz1.svg", 2195931596U},
     {"testGithub4764.sz2.svg", 3477099305U},
     {"testGithub4764.sz3.svg", 3324176273U},
@@ -4107,6 +4115,100 @@ M  END)CTAB"_ctab;
       outs << text;
       outs.flush();
       check_file_hash("testFlexiCanvas.5d.svg");
+    }
+  }
+
+  SECTION("partially flexicanvas (height) + legends") {
+    // add an atomNote so that we can compare font sizes
+    mol1->getAtomWithIdx(0)->setProp(common_properties::atomNote, "n1");
+    {
+      MolDraw2DSVG drawer(-1, 200);
+      drawer.drawMolecule(*mol1, "legend");
+      drawer.finishDrawing();
+      auto text = drawer.getDrawingText();
+      std::ofstream outs("testFlexiCanvas.6a.svg");
+      outs << text;
+      outs.flush();
+      check_file_hash("testFlexiCanvas.6a.svg");
+    }
+    {
+      MolDraw2DSVG drawer(-1, 200);
+      drawer.drawMolecule(*mol1, "legend\nwith two lines");
+      drawer.finishDrawing();
+      auto text = drawer.getDrawingText();
+      std::ofstream outs("testFlexiCanvas.6b.svg");
+      outs << text;
+      outs.flush();
+      check_file_hash("testFlexiCanvas.6b.svg");
+    }
+    {
+      MolDraw2DSVG drawer(-1, 200);
+      drawer.drawOptions().scalingFactor = 45;
+      drawer.drawMolecule(*mol1, "legend");
+      drawer.finishDrawing();
+      auto text = drawer.getDrawingText();
+      std::ofstream outs("testFlexiCanvas.6c.svg");
+      outs << text;
+      outs.flush();
+      check_file_hash("testFlexiCanvas.6c.svg");
+    }
+    {
+      MolDraw2DSVG drawer(-1, 200);
+      drawer.drawOptions().scalingFactor = 10;
+      drawer.drawMolecule(*mol1, "legend");
+      drawer.finishDrawing();
+      auto text = drawer.getDrawingText();
+      std::ofstream outs("testFlexiCanvas.6d.svg");
+      outs << text;
+      outs.flush();
+      check_file_hash("testFlexiCanvas.6d.svg");
+    }
+  }
+
+  SECTION("partially flexicanvas (width) + legends") {
+    // add an atomNote so that we can compare font sizes
+    mol1->getAtomWithIdx(0)->setProp(common_properties::atomNote, "n1");
+    {
+      MolDraw2DSVG drawer(300, -1);
+      drawer.drawMolecule(*mol1, "legend");
+      drawer.finishDrawing();
+      auto text = drawer.getDrawingText();
+      std::ofstream outs("testFlexiCanvas.7a.svg");
+      outs << text;
+      outs.flush();
+      check_file_hash("testFlexiCanvas.7a.svg");
+    }
+    {
+      MolDraw2DSVG drawer(300, -1);
+      drawer.drawMolecule(*mol1, "legend\nwith two lines");
+      drawer.finishDrawing();
+      auto text = drawer.getDrawingText();
+      std::ofstream outs("testFlexiCanvas.7b.svg");
+      outs << text;
+      outs.flush();
+      check_file_hash("testFlexiCanvas.7b.svg");
+    }
+    {
+      MolDraw2DSVG drawer(300, -1);
+      drawer.drawOptions().scalingFactor = 45;
+      drawer.drawMolecule(*mol1, "legend");
+      drawer.finishDrawing();
+      auto text = drawer.getDrawingText();
+      std::ofstream outs("testFlexiCanvas.7c.svg");
+      outs << text;
+      outs.flush();
+      check_file_hash("testFlexiCanvas.7c.svg");
+    }
+    {
+      MolDraw2DSVG drawer(300, -1);
+      drawer.drawOptions().scalingFactor = 10;
+      drawer.drawMolecule(*mol1, "legend");
+      drawer.finishDrawing();
+      auto text = drawer.getDrawingText();
+      std::ofstream outs("testFlexiCanvas.7d.svg");
+      outs << text;
+      outs.flush();
+      check_file_hash("testFlexiCanvas.7d.svg");
     }
   }
 }


### PR DESCRIPTION
This changes the drawing code to directly honor the `legendFontSize` option when flexicanvas mode (this is when the canvas size is provided as -1,-1) is being used. This is now consistent with the way atom labels and other notes are handled.

Here's a comparison of what you get with master (left) and after this PR (right)
![image](https://user-images.githubusercontent.com/540511/157819865-5a720ece-218e-4498-9349-42e0ac9fa748.png)

For the first three of those the default `legendFontSize`, 16, is used. For the last I specified `legendFontSize = 32`