### PR TITLE
[ENH]: Function `FindBondEnvironmentOfRadiusN()`

### DIFF
--- a/Code/GraphMol/Subgraphs/Subgraphs.cpp
+++ b/Code/GraphMol/Subgraphs/Subgraphs.cpp
@@ -604,7 +604,7 @@ namespace {
       }
       return i;
     }
-    
+
 } // Private namespace
 
 PATH_TYPE findAtomEnvironmentOfRadiusN(
@@ -678,7 +678,7 @@ PATH_TYPE findBondEnvironmentOfRadiusN(
   // Duplicated at rooted bond is available, but we set the constraint below. 
   // Perform BFS to find the environment
   std::unordered_map<unsigned int, int> bondsInMap;
-  bondsInMap[rootedAtBond] = -1
+  bondsInMap[rootedAtBond] = -1;
   res.push_back(rootedAtBond);
   unsigned int traveledDist = findEnvironmentOfRadiusN(mol, radius, res, nbrStack, 
                                                        bondsInMap, useHs, atomMap);

--- a/Code/GraphMol/Subgraphs/Subgraphs.cpp
+++ b/Code/GraphMol/Subgraphs/Subgraphs.cpp
@@ -576,7 +576,7 @@ namespace {
           if (bondsInMap.find(bondIdx) == bondsInMap.end()) {
             // The value assigned in bondsInMap is unimportant, but
             // it can be used to indicate the minimum travel distance.
-            bondsInMap[bondIdx] = dist + 1;
+            bondsInMap[bondIdx] = i + 1;
             path.push_back(bondIdx);
 
             // add the next set of neighbors:

--- a/Code/GraphMol/Subgraphs/Subgraphs.cpp
+++ b/Code/GraphMol/Subgraphs/Subgraphs.cpp
@@ -656,7 +656,6 @@ PATH_TYPE findBondEnvironmentOfRadiusN(
     throw ValueErrorException("bad bond index");
   }
   PATH_TYPE res;
-  res.push_back(rootedAtBond);
   const Bond &rootedBond = *mol.getBondWithIdx(rootedAtBond);
   unsigned int beginAtomIdx = rootedBond.getBeginAtomIdx();
   unsigned int endAtomIdx = rootedBond.getEndAtomIdx();
@@ -676,7 +675,8 @@ PATH_TYPE findBondEnvironmentOfRadiusN(
   prepareNeighborStack(mol, beginAtomIdx, nbrStack, useHs); 
   prepareNeighborStack(mol, endAtomIdx, nbrStack, useHs); 
 
-  // I am not sure if duplication at rooted bond is needed, but it seems to work
+  // I am not sure if removing duplication at rooted bond is needed or 
+  // added any complexity, but it would keep our idea to be clear enough
   std::erase_if(nbrStack.begin(), nbrStack.end(),
                 [&rootedAtBond](const std::pair<int, int> &p) {
                   return p.second == rootedAtBond;
@@ -684,7 +684,8 @@ PATH_TYPE findBondEnvironmentOfRadiusN(
   
   // Perform BFS to find the environment
   boost::dynamic_bitset<> bondsIn(mol.getNumBonds());
-  bondsIn.set(rootAtBond);
+  res.push_back(rootedAtBond);
+  bondsIn.set(rootedAtBond);
   unsigned int maxRolledRadius = _findMaxRolledRadius(mol, radius, res, nbrStack, 
                                                       bondsIn, useHs, &atomMap);
   if (maxRolledRadius != radius && enforceSize) {

--- a/Code/GraphMol/Subgraphs/Subgraphs.cpp
+++ b/Code/GraphMol/Subgraphs/Subgraphs.cpp
@@ -656,7 +656,7 @@ PATH_TYPE findBondEnvironmentOfRadiusN(
     throw ValueErrorException("bad bond index");
   }
   PATH_TYPE res;
-  Bond *rootedBond = mol.getBondWithIdx(rootedAtBond);
+  const Bond *rootedBond = mol.getBondWithIdx(rootedAtBond);
   unsigned int beginAtomIdx = rootedBond->getBeginAtomIdx();
   unsigned int endAtomIdx = rootedBond->getEndAtomIdx();
   

--- a/Code/GraphMol/Subgraphs/Subgraphs.cpp
+++ b/Code/GraphMol/Subgraphs/Subgraphs.cpp
@@ -574,7 +574,9 @@ namespace {
           boost::tie(startAtom, bondIdx) = nbrStack.front();
           nbrStack.pop_front();
           if (bondsInMap.find(bondIdx) == bondsInMap.end()) {
-            bondsInMap[bondIdx] = -1;
+            // The value assigned in bondsInMap is unimportant, but
+            // it can be used to indicate the minimum travel distance.
+            bondsInMap[bondIdx] = dist + 1;
             path.push_back(bondIdx);
 
             // add the next set of neighbors:
@@ -676,7 +678,7 @@ PATH_TYPE findBondEnvironmentOfRadiusN(
   
   // Duplicated at rooted bond is available, but we set the constraint below. 
   std::unordered_map<unsigned int, int> bondsInMap;
-  bondsInMap[rootedAtBond] = -1;
+  bondsInMap[rootedAtBond] = 0;
   res.push_back(rootedAtBond);
   unsigned int traveledDist = findEnvironmentOfRadiusN(mol, radius, res, nbrStack, 
                                                        bondsInMap, useHs, atomMap);

--- a/Code/GraphMol/Subgraphs/Subgraphs.cpp
+++ b/Code/GraphMol/Subgraphs/Subgraphs.cpp
@@ -656,9 +656,9 @@ PATH_TYPE findBondEnvironmentOfRadiusN(
     throw ValueErrorException("bad bond index");
   }
   PATH_TYPE res;
-  const Bond &rootedBond = *mol.getBondWithIdx(rootedAtBond);
-  unsigned int beginAtomIdx = rootedBond.getBeginAtomIdx();
-  unsigned int endAtomIdx = rootedBond.getEndAtomIdx();
+  Bond *rootedBond = mol.getBondWithIdx(rootedAtBond);
+  unsigned int beginAtomIdx = rootedBond->getBeginAtomIdx();
+  unsigned int endAtomIdx = rootedBond->getEndAtomIdx();
   
   if (atomMap) {
     atomMap->clear();

--- a/Code/GraphMol/Subgraphs/Subgraphs.cpp
+++ b/Code/GraphMol/Subgraphs/Subgraphs.cpp
@@ -559,7 +559,7 @@ namespace {
   unsigned int findEnvironmentOfRadiusN(
     const ROMol &mol, unsigned int radius, PATH_TYPE &path,
     std::list<std::pair<int, int>> &nbrStack, 
-    std::unordered_map<unsigned int, int> &bondsInMap,
+    std::unordered_map<unsigned int, unsigned int> &bondMap,
     bool useHs, std::unordered_map<unsigned int, unsigned int> *atomMap) {
       // Perform BFS to find the environment
       unsigned int i;
@@ -573,10 +573,10 @@ namespace {
           int bondIdx, startAtom;
           boost::tie(startAtom, bondIdx) = nbrStack.front();
           nbrStack.pop_front();
-          if (bondsInMap.find(bondIdx) == bondsInMap.end()) {
-            // The value assigned in bondsInMap is unimportant, but
+          if (bondMap.find(bondIdx) == bondMap.end()) {
+            // The value assigned in bondMap is unimportant, but
             // it can be used to indicate the minimum travel distance.
-            bondsInMap[bondIdx] = i + 1;
+            bondMap[bondIdx] = i + 1;
             path.push_back(bondIdx);
 
             // add the next set of neighbors:
@@ -592,7 +592,7 @@ namespace {
             // this round onto the stack
             if (i < radius - 1) {
               for (const auto bond : mol.atomBonds(mol.getAtomWithIdx(oAtom))) {
-                if (bondsInMap.find(bond->getIdx()) == bondsInMap.end()) {
+                if (bondMap.find(bond->getIdx()) == bondMap.end()) {
                   if (useHs || mol.getAtomWithIdx(bond->getOtherAtomIdx(oAtom))
                                        ->getAtomicNum() != 1) {
                     nextLayer.emplace_back(oAtom, bond->getIdx());
@@ -638,7 +638,7 @@ PATH_TYPE findAtomEnvironmentOfRadiusN(
   if (bondMap) {
     traveledDist = findEnvironmentOfRadiusN(mol, radius, res, nbrStack, *bondMap, useHs, atomMap);
   } else {
-    std::unordered_map<unsigned int, int> cBondMap;
+    std::unordered_map<unsigned int, unsigned int> cBondMap;
     traveledDist = findEnvironmentOfRadiusN(mol, radius, res, nbrStack, cBondMap, useHs, atomMap);
   }
 
@@ -694,7 +694,7 @@ PATH_TYPE findBondEnvironmentOfRadiusN(
   if (bondMap) {
     traveledDist = findEnvironmentOfRadiusN(mol, radius, res, nbrStack, *bondMap, useHs, atomMap);
   } else {
-    std::unordered_map<unsigned int, int> cBondMap;
+    std::unordered_map<unsigned int, unsigned int> cBondMap;
     cBondMap[rootedAtBond] = 0;
     traveledDist = findEnvironmentOfRadiusN(mol, radius, res, nbrStack, cBondMap, useHs, atomMap);
   }

--- a/Code/GraphMol/Subgraphs/Subgraphs.cpp
+++ b/Code/GraphMol/Subgraphs/Subgraphs.cpp
@@ -558,10 +558,10 @@ namespace {
   
   unsigned int findEnvironmentOfRadiusN(
     const ROMol &mol, unsigned int radius, PATH_TYPE &path,
-    std::list<std::pair<int, int>> &nbrStack, bool useHs, 
+    std::list<std::pair<int, int>> &nbrStack, 
+    boost::dynamic_bitset<> &bondsIn, bool useHs, 
     std::unordered_map<unsigned int, unsigned int> *atomMap) {
       
-      boost::dynamic_bitset<> bondsIn(mol.getNumBonds());
       unsigned int maxRolledRadius;
       for (maxRolledRadius = 0; i < radius; ++i) {
         if (nbrStack.empty()) {
@@ -628,8 +628,9 @@ PATH_TYPE findAtomEnvironmentOfRadiusN(
   prepareNeighborStack(mol, rootedAtAtom, nbrStack, useHs);
 
   // Perform BFS to find the environment
+  boost::dynamic_bitset<> bondsIn(mol.getNumBonds());
   unsigned int maxRolledRadius = _findMaxRolledRadius(mol, radius, res, nbrStack,
-                                                      useHs, &atomMap);
+                                                      bondsIn, useHs, &atomMap);
 
   if (maxRolledRadius != radius && enforceSize) {
     // If there are no paths found with the requested radius, user can choose
@@ -680,8 +681,10 @@ PATH_TYPE findBondEnvironmentOfRadiusN(
                 });
   
   // Perform BFS to find the environment
-  unsigned int maxRolledRadius = _findMaxRolledRadius(mol, radius, res, nbrStack,
-                                                      useHs, &atomMap);
+  boost::dynamic_bitset<> bondsIn(mol.getNumBonds());
+  bondsIn.set(rootAtBond);
+  unsigned int maxRolledRadius = _findMaxRolledRadius(mol, radius, res, nbrStack, 
+                                                      bondsIn, useHs, &atomMap);
   if (maxRolledRadius != radius && enforceSize) {
     res.clear();
     res.resize(0);

--- a/Code/GraphMol/Subgraphs/Subgraphs.cpp
+++ b/Code/GraphMol/Subgraphs/Subgraphs.cpp
@@ -633,8 +633,8 @@ PATH_TYPE findAtomEnvironmentOfRadiusN(
   // Select all neighboring bonds for iteration
   std::list<std::pair<int, int>> nbrStack;
   prepareNeighborStack(mol, rootedAtAtom, nbrStack, useHs);
+  
   unsigned int traveledDist;
-
   if (bondMap) {
     traveledDist = findEnvironmentOfRadiusN(mol, radius, res, nbrStack, *bondMap, useHs, atomMap);
   } else {

--- a/Code/GraphMol/Subgraphs/Subgraphs.cpp
+++ b/Code/GraphMol/Subgraphs/Subgraphs.cpp
@@ -675,6 +675,8 @@ PATH_TYPE findBondEnvironmentOfRadiusN(
   // Select all neighboring bonds for iteration, the rooted bond is ignored
   prepareNeighborStack(mol, beginAtomIdx, nbrStack, useHs); 
   prepareNeighborStack(mol, endAtomIdx, nbrStack, useHs); 
+
+  // I am not sure if duplication at rooted bond is needed, but it seems to work
   std::erase_if(nbrStack.begin(), nbrStack.end(),
                 [&rootedAtBond](const std::pair<int, int> &p) {
                   return p.second == rootedAtBond;

--- a/Code/GraphMol/Subgraphs/Subgraphs.cpp
+++ b/Code/GraphMol/Subgraphs/Subgraphs.cpp
@@ -561,7 +561,7 @@ namespace {
     std::list<std::pair<int, int>> &nbrStack, 
     std::unordered_map<unsigned int, int> &bondsInMap,
     bool useHs, std::unordered_map<unsigned int, unsigned int> *atomMap) {
-      
+      // Perform BFS to find the environment
       unsigned int i;
       for (i = 0; i < radius; ++i) {
         if (nbrStack.empty()) {
@@ -628,7 +628,6 @@ PATH_TYPE findAtomEnvironmentOfRadiusN(
   // Select all neighboring bonds for iteration
   prepareNeighborStack(mol, rootedAtAtom, nbrStack, useHs);
 
-  // Perform BFS to find the environment
   std::unordered_map<unsigned int, int> bondsInMap;
   unsigned int traveledDist = findEnvironmentOfRadiusN(mol, radius, res, nbrStack,
                                                        bondsInMap, useHs, atomMap);
@@ -676,7 +675,6 @@ PATH_TYPE findBondEnvironmentOfRadiusN(
   prepareNeighborStack(mol, endAtomIdx, nbrStack, useHs); 
   
   // Duplicated at rooted bond is available, but we set the constraint below. 
-  // Perform BFS to find the environment
   std::unordered_map<unsigned int, int> bondsInMap;
   bondsInMap[rootedAtBond] = -1;
   res.push_back(rootedAtBond);

--- a/Code/GraphMol/Subgraphs/Subgraphs.cpp
+++ b/Code/GraphMol/Subgraphs/Subgraphs.cpp
@@ -657,6 +657,7 @@ PATH_TYPE findBondEnvironmentOfRadiusN(
     throw ValueErrorException("bad bond index");
   }
   PATH_TYPE res;
+  res.push_back(rootedAtBond);
   const Bond *rootedBond = mol.getBondWithIdx(rootedAtBond);
   unsigned int beginAtomIdx = rootedBond->getBeginAtomIdx();
   unsigned int endAtomIdx = rootedBond->getEndAtomIdx();
@@ -679,7 +680,6 @@ PATH_TYPE findBondEnvironmentOfRadiusN(
   // Duplicated at rooted bond is available, but we set the constraint below. 
   std::unordered_map<unsigned int, int> bondsInMap;
   bondsInMap[rootedAtBond] = 0;
-  res.push_back(rootedAtBond);
   unsigned int traveledDist = findEnvironmentOfRadiusN(mol, radius, res, nbrStack, 
                                                        bondsInMap, useHs, atomMap);
   if (enforceSize) {

--- a/Code/GraphMol/Subgraphs/Subgraphs.h
+++ b/Code/GraphMol/Subgraphs/Subgraphs.h
@@ -146,12 +146,17 @@ RDKIT_SUBGRAPHS_EXPORT INT_PATH_LIST_MAP findAllPathsOfLengthsMtoN(
  *   \param bondMap - Optional: If provided, it will measure the minimum 
  * distance of the bond from the connected bond (start with 1). 
  * The result is a pair of the bond ID and the distance.
+ *   \param assumeIsolatedHydro - Optional: If True, the speed-up is achievable by 
+ * assuming that all the hydrogen atoms (except the rooted atom) is located at the 
+ * final node of branch in the molecular graph (one connected bond only) and is 
+ * unable to traverse the graph. Default to False. 
  */
 RDKIT_SUBGRAPHS_EXPORT PATH_TYPE findAtomEnvironmentOfRadiusN(
     const ROMol &mol, unsigned int radius, unsigned int rootedAtAtom,
     bool useHs=false, bool enforceSize=true,
     std::unordered_map<unsigned int, unsigned int> *atomMap=nullptr, 
-    std::unordered_map<unsigned int, unsigned int> *bondMap=nullptr);
+    std::unordered_map<unsigned int, unsigned int> *bondMap=nullptr, 
+    bool assumeIsolatedHydro=false);
 
 //! \brief Find bond subgraphs of a particular radius around a bond. 
 //!        The result is a path (a vector of bond indices).
@@ -175,12 +180,17 @@ RDKIT_SUBGRAPHS_EXPORT PATH_TYPE findAtomEnvironmentOfRadiusN(
  *   \param bondMap - Optional: If provided, it will measure the minimum 
  * distance of the bond from the rooted bond (start with 0). 
  * The result is a pair of the bond ID and the distance.
+ *   \param assumeIsolatedHydro - Optional: If True, the speed-up is achievable by 
+ * assuming that all the hydrogen atoms (except the rooted atom) is located at the 
+ * final node of branch in the molecular graph (one connected bond only) and is 
+ * unable to traverse the graph. Default to False. 
  */
 RDKIT_SUBGRAPHS_EXPORT PATH_TYPE findBondEnvironmentOfRadiusN(
     const ROMol &mol, unsigned int radius, unsigned int rootedAtBond,
     bool useHs=false, bool enforceSize=true,
     std::unordered_map<unsigned int, unsigned int> *atomMap=nullptr, 
-    std::unordered_map<unsigned int, unsigned int> *bondMap=nullptr);
+    std::unordered_map<unsigned int, unsigned int> *bondMap=nullptr, 
+    bool assumeIsolatedHydro=false);
 
 }  // namespace RDKit
 

--- a/Code/GraphMol/Subgraphs/Subgraphs.h
+++ b/Code/GraphMol/Subgraphs/Subgraphs.h
@@ -141,13 +141,17 @@ RDKIT_SUBGRAPHS_EXPORT INT_PATH_LIST_MAP findAllPathsOfLengthsMtoN(
  *                        (<= radius) is collected. Otherwise, at least one bond
  *                        located at the asked radius must be found and added. 
  *   \param atomMap - Optional: If provided, it will measure the minimum
- * distance of the atom from the rooted atom (start with 0 from the rooted
- * atom). The result is a pair of the atom ID and the distance.
+ * distance of the atom from the rooted atom (start with 0). 
+ * The result is a pair of the atom ID and the distance.
+ *   \param bondMap - Optional: If provided, it will measure the minimum 
+ * distance of the bond from the connected bond (start with 1). 
+ * The result is a pair of the bond ID and the distance.
  */
 RDKIT_SUBGRAPHS_EXPORT PATH_TYPE findAtomEnvironmentOfRadiusN(
     const ROMol &mol, unsigned int radius, unsigned int rootedAtAtom,
     bool useHs=false, bool enforceSize=true,
-    std::unordered_map<unsigned int, unsigned int> *atomMap=nullptr);
+    std::unordered_map<unsigned int, unsigned int> *atomMap=nullptr, 
+    std::unordered_map<unsigned int, unsigned int> *bondMap=nullptr);
 
 //! \brief Find bond subgraphs of a particular radius around a bond. 
 //!        The result is a path (a vector of bond indices).
@@ -166,14 +170,17 @@ RDKIT_SUBGRAPHS_EXPORT PATH_TYPE findAtomEnvironmentOfRadiusN(
  *                        (<= radius) is collected. Otherwise, at least one bond
  *                        located at the asked radius must be found and added. 
  *   \param atomMap - Optional: If provided, it will measure the minimum
- * distance of the atom from the connected bond (start with 0 from the connected
- * atom). The result is a pair of the atom ID and the distance. 
+ * distance of the atom from the connected bond (start with 0). 
+ * The result is a pair of the atom ID and the distance. 
+ *   \param bondMap - Optional: If provided, it will measure the minimum 
+ * distance of the bond from the rooted bond (start with 0). 
+ * The result is a pair of the bond ID and the distance.
  */
 RDKIT_SUBGRAPHS_EXPORT PATH_TYPE findBondEnvironmentOfRadiusN(
     const ROMol &mol, unsigned int radius, unsigned int rootedAtBond,
     bool useHs=false, bool enforceSize=true,
-    std::unordered_map<unsigned int, unsigned int> *atomMap=nullptr);
-
+    std::unordered_map<unsigned int, unsigned int> *atomMap=nullptr, 
+    std::unordered_map<unsigned int, unsigned int> *bondMap=nullptr);
 
 }  // namespace RDKit
 

--- a/Code/GraphMol/Subgraphs/Subgraphs.h
+++ b/Code/GraphMol/Subgraphs/Subgraphs.h
@@ -128,6 +128,7 @@ RDKIT_SUBGRAPHS_EXPORT INT_PATH_LIST_MAP findAllPathsOfLengthsMtoN(
     bool useBonds = true, bool useHs = false, int rootedAtAtom = -1);
 
 //! \brief Find bond subgraphs of a particular radius around an atom.
+//!        The result is a path (a vector of bond indices).
 //!        Return empty result if there is no bond at the requested radius.
 /*!
  *   \param mol - the molecule to be considered
@@ -141,15 +142,15 @@ RDKIT_SUBGRAPHS_EXPORT INT_PATH_LIST_MAP findAllPathsOfLengthsMtoN(
  *                        located at the asked radius must be found and added. 
  *   \param atomMap - Optional: If provided, it will measure the minimum
  * distance of the atom from the rooted atom (start with 0 from the rooted
- * atom). The result is a pair of the atom ID and the distance. The result is a
- * path (a vector of bond indices)
+ * atom). The result is a pair of the atom ID and the distance.
  */
 RDKIT_SUBGRAPHS_EXPORT PATH_TYPE findAtomEnvironmentOfRadiusN(
     const ROMol &mol, unsigned int radius, unsigned int rootedAtAtom,
     bool useHs=false, bool enforceSize=true,
     std::unordered_map<unsigned int, unsigned int> *atomMap=nullptr);
 
-//! \brief Find bond subgraphs of a particular radius around a bond.
+//! \brief Find bond subgraphs of a particular radius around a bond. 
+//!        The result is a path (a vector of bond indices).
 //!        Return empty result if there is no bond at the requested radius.
 //!        The function is equivalent as `findAtomEnvironmentOfRadiusN` on 
 //!        two connected atoms, and uniquely aggregate together with minimal 
@@ -165,9 +166,8 @@ RDKIT_SUBGRAPHS_EXPORT PATH_TYPE findAtomEnvironmentOfRadiusN(
  *                        (<= radius) is collected. Otherwise, at least one bond
  *                        located at the asked radius must be found and added. 
  *   \param atomMap - Optional: If provided, it will measure the minimum
- * distance of the atom from the rooted bond (start with 0 from the connected
- * atom). The result is a pair of the atom ID and the distance. The result is a
- * path (a vector of bond indices)
+ * distance of the atom from the connected bond (start with 0 from the connected
+ * atom). The result is a pair of the atom ID and the distance. 
  */
 RDKIT_SUBGRAPHS_EXPORT PATH_TYPE findBondEnvironmentOfRadiusN(
     const ROMol &mol, unsigned int radius, unsigned int rootedAtBond,

--- a/Code/GraphMol/Subgraphs/Subgraphs.h
+++ b/Code/GraphMol/Subgraphs/Subgraphs.h
@@ -138,8 +138,8 @@ RDKIT_SUBGRAPHS_EXPORT INT_PATH_LIST_MAP findAllPathsOfLengthsMtoN(
  *                      Hs to the graph.
  *   \param enforceSize - If false, all the bonds within the requested radius
  *                        (<= radius) is collected. Otherwise, at least one bond
- *                        located at the requested radius must be found and
- * added. \param atomMap - Optional: If provided, it will measure the minimum
+ *                        located at the asked radius must be found and added. 
+ *   \param atomMap - Optional: If provided, it will measure the minimum
  * distance of the atom from the rooted atom (start with 0 from the rooted
  * atom). The result is a pair of the atom ID and the distance. The result is a
  * path (a vector of bond indices)
@@ -148,6 +148,32 @@ RDKIT_SUBGRAPHS_EXPORT PATH_TYPE findAtomEnvironmentOfRadiusN(
     const ROMol &mol, unsigned int radius, unsigned int rootedAtAtom,
     bool useHs=false, bool enforceSize=true,
     std::unordered_map<unsigned int, unsigned int> *atomMap=nullptr);
+
+//! \brief Find bond subgraphs of a particular radius around a bond.
+//!        Return empty result if there is no bond at the requested radius.
+//!        The function is equivalent as `findAtomEnvironmentOfRadiusN` on 
+//!        two connected atoms, and uniquely aggregate together with minimal 
+//!        bond distance.
+/*!
+ *   \param mol - the molecule to be considered
+ *   \param radius - the radius of the subgraphs to be considered
+ *   \param rootedAtBond - the bond to consider
+ *   \param useHs     - if set, hydrogens in the graph will be considered
+ *                      eligible to be in paths. NOTE: this will not add
+ *                      Hs to the graph.
+ *   \param enforceSize - If false, all the bonds within the requested radius
+ *                        (<= radius) is collected. Otherwise, at least one bond
+ *                        located at the asked radius must be found and added. 
+ *   \param atomMap - Optional: If provided, it will measure the minimum
+ * distance of the atom from the rooted bond (start with 0 from the connected
+ * atom). The result is a pair of the atom ID and the distance. The result is a
+ * path (a vector of bond indices)
+ */
+RDKIT_SUBGRAPHS_EXPORT PATH_TYPE findBondEnvironmentOfRadiusN(
+    const ROMol &mol, unsigned int radius, unsigned int rootedAtBond,
+    bool useHs=false, bool enforceSize=true,
+    std::unordered_map<unsigned int, unsigned int> *atomMap=nullptr);
+
 
 }  // namespace RDKit
 

--- a/Code/GraphMol/Subgraphs/test2.cpp
+++ b/Code/GraphMol/Subgraphs/test2.cpp
@@ -326,7 +326,7 @@ void test4() {
 
   {
     // Non-ring-membered bond;
-    std::string smiles = "S(C(CNC)(N=C)NO)S(C(CNC)(N=C)NO)"; // Non-canonical
+    std::string smiles = "C=NC(CNC)(NO)SSC(CNC)(N=C)NO" // Non-canonical "S(C(CNC)(N=C)NO)S(C(CNC)(N=C)NO)"
     unsigned int rootedAtBond = 8; // S-S bond
  
     RWMol *mol = SmilesToMol(smiles);
@@ -337,16 +337,18 @@ void test4() {
     PATH_TYPE pth;
     
     // ---------------------------------------------------------------------------------
-    // useHs = false, enforceSize = false
-    {
-      pth = findBondEnvironmentOfRadiusN(*mH, 0, rootedAtBond, false, false, &cAtomMap);
-      TEST_ASSERT(pth.size() == 1);
-      TEST_ASSERT(pth[0] == rootedAtBond);
-      TEST_ASSERT(cAtomMap.size() == 2);
-      TEST_ASSERT(cAtomMap[0] == 0);
-      TEST_ASSERT(cAtomMap[9] == 0);
-      cAtomMap.clear();
+    // Zero radius
+    pth = findBondEnvironmentOfRadiusN(*mH, 0, rootedAtBond, true, false, &cAtomMap);
+    TEST_ASSERT(pth.size() == 1);
+    TEST_ASSERT(pth[0] == rootedAtBond);
+    TEST_ASSERT(cAtomMap.size() == 2);
+    TEST_ASSERT(cAtomMap[8] == 0);
+    TEST_ASSERT(cAtomMap[9] == 0);
+    cAtomMap.clear();
 
+    // ---------------------------------------------------------------------------------
+    // useHs = false
+    {
       pth = findBondEnvironmentOfRadiusN(*mH, 1, rootedAtBond, false, false, &cAtomMap);
       TEST_ASSERT(pth.size() == 3);
       TEST_ASSERT(cAtomMap.size() == 4);
@@ -373,33 +375,15 @@ void test4() {
       TEST_ASSERT(cAtomMap.size() == 18);
       cAtomMap.clear();
 
-      pth = findBondEnvironmentOfRadiusN(*mH, 6, rootedAtBond, false, false, &cAtomMap);
-      TEST_ASSERT(pth.size() == 17);
-      TEST_ASSERT(cAtomMap.size() == 18);
-      cAtomMap.clear();
-
       pth = findBondEnvironmentOfRadiusN(*mH, 5, rootedAtBond, false, true, &cAtomMap);
-      TEST_ASSERT(pth.size() == 0);
-      TEST_ASSERT(cAtomMap.size() == 0);
-      cAtomMap.clear();
-
-      pth = findBondEnvironmentOfRadiusN(*mH, 6, rootedAtBond, false, true, &cAtomMap);
       TEST_ASSERT(pth.size() == 0);
       TEST_ASSERT(cAtomMap.size() == 0);
       cAtomMap.clear();
     }
   
     // ---------------------------------------------------------------------------------
-    // useHs = true, enforceSize = false
+    // useHs = true
     {
-      pth = findBondEnvironmentOfRadiusN(*mH, 0, rootedAtBond, true, false, &cAtomMap);
-      TEST_ASSERT(pth.size() == 1);
-      TEST_ASSERT(pth[0] == rootedAtBond);
-      TEST_ASSERT(cAtomMap.size() == 2);
-      TEST_ASSERT(cAtomMap[0] == 0);
-      TEST_ASSERT(cAtomMap[9] == 0);
-      cAtomMap.clear();
-
       pth = findBondEnvironmentOfRadiusN(*mH, 1, rootedAtBond, true, false, &cAtomMap);
       TEST_ASSERT(pth.size() == 3);
       TEST_ASSERT(cAtomMap.size() == 4);
@@ -425,6 +409,7 @@ void test4() {
       TEST_ASSERT(cAtomMap.size() == 38);
       cAtomMap.clear();
 
+      // -------------------------------------------
       pth = findBondEnvironmentOfRadiusN(*mH, 6, rootedAtBond, true, false, &cAtomMap);
       TEST_ASSERT(pth.size() == 37);
       TEST_ASSERT(cAtomMap.size() == 38);
@@ -442,8 +427,8 @@ void test4() {
 
   {
     // Ring-membered bond;
-    std::string smiles = "S1CCCCCCCS1"; 
-    unsigned int rootedAtBond = 8;
+    std::string smiles = "C1CCCSSCCC1"; 
+    unsigned int rootedAtBond = 4;
 
     RWMol *mol = SmilesToMol(smiles);
     TEST_ASSERT(mol);
@@ -453,16 +438,18 @@ void test4() {
     PATH_TYPE pth;
 
     // ---------------------------------------------------------------------------------
+    // Zero radius
+    pth = findBondEnvironmentOfRadiusN(*mH, 0, rootedAtBond, true, false, &cAtomMap);
+    TEST_ASSERT(pth.size() == 1);
+    TEST_ASSERT(pth[0] == rootedAtBond);
+    TEST_ASSERT(cAtomMap.size() == 2);
+    TEST_ASSERT(cAtomMap[4] == 0);
+    TEST_ASSERT(cAtomMap[5] == 0);
+    cAtomMap.clear();
+
+    // ---------------------------------------------------------------------------------
     // useHs = false
     {
-      pth = findBondEnvironmentOfRadiusN(*mH, 0, rootedAtBond, false, false, &cAtomMap);
-      TEST_ASSERT(pth.size() == 1);
-      TEST_ASSERT(pth[0] == rootedAtBond);
-      TEST_ASSERT(cAtomMap.size() == 2);
-      TEST_ASSERT(cAtomMap[0] == 0);
-      TEST_ASSERT(cAtomMap[8] == 0);
-      cAtomMap.clear();
-
       pth = findBondEnvironmentOfRadiusN(*mH, 1, rootedAtBond, false, false, &cAtomMap);
       TEST_ASSERT(pth.size() == 3);
       TEST_ASSERT(cAtomMap.size() == 4);
@@ -487,7 +474,8 @@ void test4() {
       TEST_ASSERT(pth.size() == 9);
       TEST_ASSERT(cAtomMap.size() == 9);
       cAtomMap.clear();
-
+      
+      // ---------------------------------------------------------------------------------
       pth = findBondEnvironmentOfRadiusN(*mH, 6, rootedAtBond, false, false, &cAtomMap);
       TEST_ASSERT(pth.size() == 9);
       TEST_ASSERT(cAtomMap.size() == 9);
@@ -502,14 +490,6 @@ void test4() {
     // ---------------------------------------------------------------------------------
     // useHs = true
     {
-      pth = findBondEnvironmentOfRadiusN(*mH, 0, rootedAtBond, true, false, &cAtomMap);
-      TEST_ASSERT(pth.size() == 1);
-      TEST_ASSERT(pth[0] == rootedAtBond);
-      TEST_ASSERT(cAtomMap.size() == 2);
-      TEST_ASSERT(cAtomMap[0] == 0);
-      TEST_ASSERT(cAtomMap[8] == 0);
-      cAtomMap.clear();
-
       pth = findBondEnvironmentOfRadiusN(*mH, 1, rootedAtBond, true, false, &cAtomMap);
       TEST_ASSERT(pth.size() == 3);
       TEST_ASSERT(cAtomMap.size() == 4);
@@ -534,7 +514,8 @@ void test4() {
       TEST_ASSERT(pth.size() == 23);
       TEST_ASSERT(cAtomMap.size() == 23);
       cAtomMap.clear();
-
+      
+      // ---------------------------------------------------------------------------------
       pth = findBondEnvironmentOfRadiusN(*mH, 6, rootedAtBond, true, false, &cAtomMap);
       TEST_ASSERT(pth.size() == 23);
       TEST_ASSERT(cAtomMap.size() == 23);
@@ -546,8 +527,6 @@ void test4() {
       cAtomMap.clear();
     }
 
-    // ---------------------------------------------------------------------------------
-    // useHs = true, enforceSize = true: This is skipped
     delete mol;
     delete mH;
   }

--- a/Code/GraphMol/Subgraphs/test2.cpp
+++ b/Code/GraphMol/Subgraphs/test2.cpp
@@ -601,6 +601,141 @@ void test4() {
   std::cout << "Finished" << std::endl;
 }
 
+void test5() {
+  std::cout << "-----------------------" << std::endl;
+  std::cout << "Test 5: Assume Isolated Hydrogen" << std::endl;
+
+  {
+    // Test on hydrogen air with `useHs` parameter.
+    std::string smiles = "[H][H]";
+    std::unordered_map<unsigned int, unsigned int> cAtomMap;
+    std::unordered_map<unsigned int, unsigned int> cBondMap;
+    RWMol *mol = SmilesToMol(smiles);
+    TEST_ASSERT(mol);
+    ROMol *mH = MolOps::addHs(static_cast<const ROMol &>(*mol));
+
+    PATH_TYPE pth = findAtomEnvironmentOfRadiusN(*mol, 1, 0, true, false, &cAtomMap, &cBondMap, true);
+    TEST_ASSERT(pth.size() == 1);
+    TEST_ASSERT(cAtomMap.size() == 2);
+    TEST_ASSERT(cBondMap.size() == 1);
+    cAtomMap.clear();
+    cBondMap.clear();
+
+    pth = findAtomEnvironmentOfRadiusN(*mol, 1, 0, true, false, &cAtomMap, &cBondMap, false);
+    TEST_ASSERT(pth.size() == 1);
+    TEST_ASSERT(cAtomMap.size() == 2);
+    TEST_ASSERT(cBondMap.size() == 1);
+    cAtomMap.clear();
+    cBondMap.clear();
+
+    pth = findAtomEnvironmentOfRadiusN(*mol, 1, 0, false, false, &cAtomMap, &cBondMap, true);
+    TEST_ASSERT(pth.size() == 0);
+    TEST_ASSERT(cAtomMap.size() == 1);
+    TEST_ASSERT(cBondMap.size() == 0);
+    cAtomMap.clear();
+    cBondMap.clear();
+
+    pth = findAtomEnvironmentOfRadiusN(*mol, 1, 0, false, false, &cAtomMap, &cBondMap, false);
+    TEST_ASSERT(pth.size() == 0);
+    TEST_ASSERT(cAtomMap.size() == 1);
+    TEST_ASSERT(cBondMap.size() == 0);
+    cAtomMap.clear();
+    cBondMap.clear();
+
+    delete mol;
+    delete mH;
+  }
+
+  {
+    // Test on methane with `useHs` parameter.
+    std::string smiles = "C";
+    std::unordered_map<unsigned int, unsigned int> cAtomMap;
+    std::unordered_map<unsigned int, unsigned int> cBondMap;
+    RWMol *mol = SmilesToMol(smiles);
+    TEST_ASSERT(mol);
+    ROMol *mH = MolOps::addHs(static_cast<const ROMol &>(*mol));
+
+    // Test on carbon atom (`radius` is independent if enforceSize=false)
+    PATH_TYPE pth = findAtomEnvironmentOfRadiusN(*mol, 1, 0, true, false, &cAtomMap, &cBondMap, true);
+    TEST_ASSERT(pth.size() == 4);
+    TEST_ASSERT(cAtomMap.size() == 5);
+    TEST_ASSERT(cBondMap.size() == 4);
+    cAtomMap.clear();
+    cBondMap.clear();
+
+    pth = findAtomEnvironmentOfRadiusN(*mol, 1, 0, true, false, &cAtomMap, &cBondMap, false);
+    TEST_ASSERT(pth.size() == 4);
+    TEST_ASSERT(cAtomMap.size() == 5);
+    TEST_ASSERT(cBondMap.size() == 4);
+    cAtomMap.clear();
+    cBondMap.clear();
+
+    // Test on hydrogen atom (`radius` is independent)
+    // useHs=true:
+    pth = findAtomEnvironmentOfRadiusN(*mol, 1, 1, true, false, &cAtomMap, &cBondMap, true);
+    TEST_ASSERT(pth.size() == 1);
+    TEST_ASSERT(cAtomMap.size() == 2);
+    TEST_ASSERT(cBondMap.size() == 1);
+    cAtomMap.clear();
+    cBondMap.clear();
+
+    pth = findAtomEnvironmentOfRadiusN(*mol, 1, 1, true, false, &cAtomMap, &cBondMap, false);
+    TEST_ASSERT(pth.size() == 1);
+    TEST_ASSERT(cAtomMap.size() == 2);
+    TEST_ASSERT(cBondMap.size() == 1);
+    cAtomMap.clear();
+    cBondMap.clear();
+
+    pth = findAtomEnvironmentOfRadiusN(*mol, 2, 1, true, false, &cAtomMap, &cBondMap, true);
+    TEST_ASSERT(pth.size() == 4);
+    TEST_ASSERT(cAtomMap.size() == 5);
+    TEST_ASSERT(cBondMap.size() == 4);
+    cAtomMap.clear();
+    cBondMap.clear();
+
+    pth = findAtomEnvironmentOfRadiusN(*mol, 2, 1, true, false, &cAtomMap, &cBondMap, false);
+    TEST_ASSERT(pth.size() == 4);
+    TEST_ASSERT(cAtomMap.size() == 5);
+    TEST_ASSERT(cBondMap.size() == 4);
+    cAtomMap.clear();
+    cBondMap.clear();
+
+    // useHs=false:
+    pth = findAtomEnvironmentOfRadiusN(*mol, 1, 1, false, false, &cAtomMap, &cBondMap, true);
+    TEST_ASSERT(pth.size() == 1);
+    TEST_ASSERT(cAtomMap.size() == 2);
+    TEST_ASSERT(cBondMap.size() == 1);
+    cAtomMap.clear();
+    cBondMap.clear();
+
+    pth = findAtomEnvironmentOfRadiusN(*mol, 2, 1, false, false, &cAtomMap, &cBondMap, true);
+    TEST_ASSERT(pth.size() == 1);
+    TEST_ASSERT(cAtomMap.size() == 2);
+    TEST_ASSERT(cBondMap.size() == 1);
+    cAtomMap.clear();
+    cBondMap.clear();
+
+
+    pth = findAtomEnvironmentOfRadiusN(*mol, 1, 1, false, false, &cAtomMap, &cBondMap, false);
+    TEST_ASSERT(pth.size() == 1);
+    TEST_ASSERT(cAtomMap.size() == 2);
+    TEST_ASSERT(cBondMap.size() == 1);
+    cAtomMap.clear();
+    cBondMap.clear();
+
+    pth = findAtomEnvironmentOfRadiusN(*mol, 2, 1, false, false, &cAtomMap, &cBondMap, false);
+    TEST_ASSERT(pth.size() == 1);
+    TEST_ASSERT(cAtomMap.size() == 2);
+    TEST_ASSERT(cBondMap.size() == 1);
+    cAtomMap.clear();
+    cBondMap.clear();
+
+    delete mol;
+    delete mH;
+  }
+
+}
+
 void testGithubIssue103() {
   std::cout << "-----------------------\n Testing github Issue103: "
                "stereochemistry and pathToSubmol"
@@ -668,6 +803,7 @@ int main() {
   test2();
   test3();
   test4();
+  test5();
   testGithubIssue103();
   testGithubIssue2647();
   return 0;

--- a/Code/GraphMol/Subgraphs/test2.cpp
+++ b/Code/GraphMol/Subgraphs/test2.cpp
@@ -366,45 +366,14 @@ void test4() {
       TEST_ASSERT(pth.size() == 17);
       TEST_ASSERT(cAtomMap.size() == 18);
       cAtomMap.clear();
-
+      
+      // -------------------------------------------
       pth = findBondEnvironmentOfRadiusN(*mH, 5, rootedAtBond, false, false, &cAtomMap);
       TEST_ASSERT(pth.size() == 17);
       TEST_ASSERT(cAtomMap.size() == 18);
       cAtomMap.clear();
 
       pth = findBondEnvironmentOfRadiusN(*mH, 6, rootedAtBond, false, false, &cAtomMap);
-      TEST_ASSERT(pth.size() == 17);
-      TEST_ASSERT(cAtomMap.size() == 18);
-      cAtomMap.clear();
-    }
-  
-    // ---------------------------------------------------------------------------------
-    // useHs = false, enforceSize = true
-    {
-      pth = findBondEnvironmentOfRadiusN(*mH, 0, rootedAtBond, false, true, &cAtomMap);
-      TEST_ASSERT(pth.size() == 1);
-      TEST_ASSERT(pth[0] == rootedAtBond);
-      TEST_ASSERT(cAtomMap.size() == 2);
-      TEST_ASSERT(cAtomMap[0] == 0);
-      TEST_ASSERT(cAtomMap[9] == 0);
-      cAtomMap.clear();
-
-      pth = findBondEnvironmentOfRadiusN(*mH, 1, rootedAtBond, false, true, &cAtomMap);
-      TEST_ASSERT(pth.size() == 3);
-      TEST_ASSERT(cAtomMap.size() == 4);
-      cAtomMap.clear();
-
-      pth = findBondEnvironmentOfRadiusN(*mH, 2, rootedAtBond, false, true, &cAtomMap);
-      TEST_ASSERT(pth.size() == 9);
-      TEST_ASSERT(cAtomMap.size() == 10);
-      cAtomMap.clear();
-
-      pth = findBondEnvironmentOfRadiusN(*mH, 3, rootedAtBond, false, true, &cAtomMap);
-      TEST_ASSERT(pth.size() == 15);
-      TEST_ASSERT(cAtomMap.size() == 16);
-      cAtomMap.clear();
-
-      pth = findBondEnvironmentOfRadiusN(*mH, 4, rootedAtBond, false, true, &cAtomMap);
       TEST_ASSERT(pth.size() == 17);
       TEST_ASSERT(cAtomMap.size() == 18);
       cAtomMap.clear();
@@ -419,7 +388,7 @@ void test4() {
       TEST_ASSERT(cAtomMap.size() == 0);
       cAtomMap.clear();
     }
-
+  
     // ---------------------------------------------------------------------------------
     // useHs = true, enforceSize = false
     {
@@ -485,7 +454,6 @@ void test4() {
 
     // ---------------------------------------------------------------------------------
     // useHs = false
-
     {
       pth = findBondEnvironmentOfRadiusN(*mH, 0, rootedAtBond, false, false, &cAtomMap);
       TEST_ASSERT(pth.size() == 1);
@@ -531,7 +499,6 @@ void test4() {
       cAtomMap.clear();
     }
 
-  
     // ---------------------------------------------------------------------------------
     // useHs = true
     {
@@ -540,7 +507,7 @@ void test4() {
       TEST_ASSERT(pth[0] == rootedAtBond);
       TEST_ASSERT(cAtomMap.size() == 2);
       TEST_ASSERT(cAtomMap[0] == 0);
-      TEST_ASSERT(cAtomMap[9] == 0);
+      TEST_ASSERT(cAtomMap[8] == 0);
       cAtomMap.clear();
 
       pth = findBondEnvironmentOfRadiusN(*mH, 1, rootedAtBond, true, false, &cAtomMap);

--- a/Code/GraphMol/Subgraphs/test2.cpp
+++ b/Code/GraphMol/Subgraphs/test2.cpp
@@ -320,6 +320,233 @@ void test3() {
   std::cout << "Finished" << std::endl;
 }
 
+void test4() {
+  std::cout << "-----------------------" << std::endl;
+  std::cout << "Test 4: Bond Environment" << std::endl;
+
+  {
+    // Non-ring-membered bond;
+    std::string smiles = "S(C(CNC)(N=C)NO)S(C(CNC)(N=C)NO)"; // Non-canonical
+    unsigned int rootedAtBond = 8; // S-S bond
+ 
+    RWMol *mol = SmilesToMol(smiles);
+    TEST_ASSERT(mol);
+    ROMol *mH = MolOps::addHs(static_cast<const ROMol &>(*mol));
+
+    std::unordered_map<unsigned int, unsigned int> cAtomMap;
+    PATH_TYPE pth;
+    
+    // ---------------------------------------------------------------------------------
+    // useHs = false, enforceSize = false
+    pth = findBondEnvironmentOfRadiusN(*mH, 0, rootedAtBond, false, false, cAtomMap)
+    TEST_ASSERT(pth.size() == 1);
+    TEST_ASSERT(pth[0] == rootedAtBond);
+    TEST_ASSERT(cAtomMap.size() == 2);
+    TEST_ASSERT(cAtomMap[0] == 0);
+    TEST_ASSERT(cAtomMap[9] == 0);
+    cAtomMap.clear();
+
+    pth = findBondEnvironmentOfRadiusN(*mH, 1, rootedAtBond, false, false, cAtomMap)
+    TEST_ASSERT(pth.size() == 3);
+    TEST_ASSERT(cAtomMap.size() == 4);
+    cAtomMap.clear();
+
+    pth = findBondEnvironmentOfRadiusN(*mH, 2, rootedAtBond, false, false, cAtomMap)
+    TEST_ASSERT(pth.size() == 9);
+    TEST_ASSERT(cAtomMap.size() == 10);
+    cAtomMap.clear();
+
+    pth = findBondEnvironmentOfRadiusN(*mH, 3, rootedAtBond, false, false, cAtomMap)
+    TEST_ASSERT(pth.size() == 15);
+    TEST_ASSERT(cAtomMap.size() == 16);
+    cAtomMap.clear();
+
+    pth = findBondEnvironmentOfRadiusN(*mH, 4, rootedAtBond, false, false, cAtomMap)
+    TEST_ASSERT(pth.size() == 18);
+    TEST_ASSERT(cAtomMap.size() == 19);
+    cAtomMap.clear();
+
+    pth = findBondEnvironmentOfRadiusN(*mH, 5, rootedAtBond, false, false, cAtomMap)
+    TEST_ASSERT(pth.size() == 19);
+    TEST_ASSERT(cAtomMap.size() == 20);
+    cAtomMap.clear();
+
+    pth = findBondEnvironmentOfRadiusN(*mH, 6, rootedAtBond, false, false, cAtomMap)
+    TEST_ASSERT(pth.size() == 20);
+    TEST_ASSERT(cAtomMap.size() == 21);
+    cAtomMap.clear();
+
+    // ---------------------------------------------------------------------------------
+    // useHs = false, enforceSize = true
+    pth = findBondEnvironmentOfRadiusN(*mH, 0, rootedAtBond, false, true, cAtomMap)
+    TEST_ASSERT(pth.size() == 1);
+    TEST_ASSERT(pth[0] == rootedAtBond);
+    TEST_ASSERT(cAtomMap.size() == 2);
+    TEST_ASSERT(cAtomMap[0] == 0);
+    TEST_ASSERT(cAtomMap[9] == 0);
+    cAtomMap.clear();
+
+    pth = findBondEnvironmentOfRadiusN(*mH, 1, rootedAtBond, false, true, cAtomMap)
+    TEST_ASSERT(pth.size() == 3);
+    TEST_ASSERT(cAtomMap.size() == 4);
+    cAtomMap.clear();
+
+    pth = findBondEnvironmentOfRadiusN(*mH, 2, rootedAtBond, false, true, cAtomMap)
+    TEST_ASSERT(pth.size() == 9);
+    TEST_ASSERT(cAtomMap.size() == 10);
+    cAtomMap.clear();
+
+    pth = findBondEnvironmentOfRadiusN(*mH, 3, rootedAtBond, false, true, cAtomMap)
+    TEST_ASSERT(pth.size() == 15);
+    TEST_ASSERT(cAtomMap.size() == 16);
+    cAtomMap.clear();
+
+    pth = findBondEnvironmentOfRadiusN(*mH, 4, rootedAtBond, false, true, cAtomMap)
+    TEST_ASSERT(pth.size() == 18);
+    TEST_ASSERT(cAtomMap.size() == 19);
+    cAtomMap.clear();
+
+    pth = findBondEnvironmentOfRadiusN(*mH, 5, rootedAtBond, false, true, cAtomMap)
+    TEST_ASSERT(pth.size() == 19);
+    TEST_ASSERT(cAtomMap.size() == 20);
+    cAtomMap.clear();
+
+    pth = findBondEnvironmentOfRadiusN(*mH, 6, rootedAtBond, false, true, cAtomMap)
+    TEST_ASSERT(pth.size() == 20);
+    TEST_ASSERT(cAtomMap.size() == 21);
+    cAtomMap.clear();
+
+    // ---------------------------------------------------------------------------------
+    // useHs = true, enforceSize = false
+    pth = findBondEnvironmentOfRadiusN(*mH, 0, rootedAtBond, true, false, cAtomMap)
+    TEST_ASSERT(pth.size() == 1);
+    TEST_ASSERT(pth[0] == rootedAtBond);
+    TEST_ASSERT(cAtomMap.size() == 2);
+    TEST_ASSERT(cAtomMap[0] == 0);
+    TEST_ASSERT(cAtomMap[9] == 0);
+    cAtomMap.clear();
+
+    pth = findBondEnvironmentOfRadiusN(*mH, 1, rootedAtBond, true, false, cAtomMap)
+    TEST_ASSERT(pth.size() == 3);
+    TEST_ASSERT(cAtomMap.size() == 4);
+    cAtomMap.clear();
+
+    pth = findBondEnvironmentOfRadiusN(*mH, 2, rootedAtBond, true, false, cAtomMap)
+    TEST_ASSERT(pth.size() == 9);
+    TEST_ASSERT(cAtomMap.size() == 10);
+    cAtomMap.clear();
+
+    pth = findBondEnvironmentOfRadiusN(*mH, 3, rootedAtBond, true, false, cAtomMap)
+    TEST_ASSERT(pth.size() == 21);
+    TEST_ASSERT(cAtomMap.size() == 22);
+    cAtomMap.clear();
+
+    pth = findBondEnvironmentOfRadiusN(*mH, 4, rootedAtBond, true, false, cAtomMap)
+    TEST_ASSERT(pth.size() == 31);
+    TEST_ASSERT(cAtomMap.size() == 32);
+    cAtomMap.clear();
+
+    // ---------------------------------------------------------------------------------
+    // useHs = true, enforceSize = true: This is skipped
+    delete mol;
+    delete mH;
+  }
+
+  {
+    // Ring-membered bond;
+    std::string smiles = "S1CCCCCCCS1"; 
+    unsigned int rootedAtBond = 8;
+    std::unordered_map<unsigned int, unsigned int> cAtomMap;
+
+    RWMol *mol = SmilesToMol(smiles);
+    TEST_ASSERT(mol);
+    ROMol *mH = MolOps::addHs(static_cast<const ROMol &>(*mol));
+
+    // ---------------------------------------------------------------------------------
+    // useHs = false
+    pth = findBondEnvironmentOfRadiusN(*mH, 0, rootedAtBond, false, false, cAtomMap)
+    TEST_ASSERT(pth.size() == 1);
+    TEST_ASSERT(pth[0] == rootedAtBond);
+    TEST_ASSERT(cAtomMap.size() == 2);
+    TEST_ASSERT(cAtomMap[0] == 0);
+    TEST_ASSERT(cAtomMap[8] == 0);
+    cAtomMap.clear();
+
+    pth = findBondEnvironmentOfRadiusN(*mH, 1, rootedAtBond, false, false, cAtomMap)
+    TEST_ASSERT(pth.size() == 3);
+    TEST_ASSERT(cAtomMap.size() == 4);
+    cAtomMap.clear();
+
+    pth = findBondEnvironmentOfRadiusN(*mH, 2, rootedAtBond, false, false, cAtomMap)
+    TEST_ASSERT(pth.size() == 5);
+    TEST_ASSERT(cAtomMap.size() == 6);
+    cAtomMap.clear();
+
+    pth = findBondEnvironmentOfRadiusN(*mH, 3, rootedAtBond, false, false, cAtomMap)
+    TEST_ASSERT(pth.size() == 7);
+    TEST_ASSERT(cAtomMap.size() == 8);
+    cAtomMap.clear();
+
+    pth = findBondEnvironmentOfRadiusN(*mH, 4, rootedAtBond, false, false, cAtomMap)
+    TEST_ASSERT(pth.size() == 9);
+    TEST_ASSERT(cAtomMap.size() == 9);
+    cAtomMap.clear();
+
+    pth = findBondEnvironmentOfRadiusN(*mH, 5, rootedAtBond, false, false, cAtomMap)
+    TEST_ASSERT(pth.size() == 9);
+    TEST_ASSERT(cAtomMap.size() == 9);
+    cAtomMap.clear();
+
+    pth = findBondEnvironmentOfRadiusN(*mH, 6, rootedAtBond, false, false, cAtomMap)
+    TEST_ASSERT(pth.size() == 9);
+    TEST_ASSERT(cAtomMap.size() == 9);
+    cAtomMap.clear();
+
+    pth = findBondEnvironmentOfRadiusN(*mH, 6, rootedAtBond, false, true, cAtomMap)
+    TEST_ASSERT(pth.size() == 0);
+    TEST_ASSERT(cAtomMap.size() == 0);
+    cAtomMap.clear();
+
+    // ---------------------------------------------------------------------------------
+    // useHs = true, enforceSize = true
+    pth = findBondEnvironmentOfRadiusN(*mH, 0, rootedAtBond, true, false, cAtomMap)
+    TEST_ASSERT(pth.size() == 1);
+    TEST_ASSERT(pth[0] == rootedAtBond);
+    TEST_ASSERT(cAtomMap.size() == 2);
+    TEST_ASSERT(cAtomMap[0] == 0);
+    TEST_ASSERT(cAtomMap[9] == 0);
+    cAtomMap.clear();
+
+    pth = findBondEnvironmentOfRadiusN(*mH, 1, rootedAtBond, true, false, cAtomMap)
+    TEST_ASSERT(pth.size() == 3);
+    TEST_ASSERT(cAtomMap.size() == 4);
+    cAtomMap.clear();
+
+    pth = findBondEnvironmentOfRadiusN(*mH, 2, rootedAtBond, true, false, cAtomMap)
+    TEST_ASSERT(pth.size() == 9);
+    TEST_ASSERT(cAtomMap.size() == 10);
+    cAtomMap.clear();
+
+    pth = findBondEnvironmentOfRadiusN(*mH, 3, rootedAtBond, true, false, cAtomMap)
+    TEST_ASSERT(pth.size() == 15);
+    TEST_ASSERT(cAtomMap.size() == 16);
+    cAtomMap.clear();
+
+    pth = findBondEnvironmentOfRadiusN(*mH, 4, rootedAtBond, true, false, cAtomMap)
+    TEST_ASSERT(pth.size() == 21);
+    TEST_ASSERT(cAtomMap.size() == 21);
+    cAtomMap.clear();
+
+    // ---------------------------------------------------------------------------------
+    // useHs = true, enforceSize = true: This is skipped
+    delete mol;
+    delete mH;
+  }
+
+  std::cout << "Finished" << std::endl;
+}
+
+
 void testGithubIssue103() {
   std::cout << "-----------------------\n Testing github Issue103: "
                "stereochemistry and pathToSubmol"
@@ -386,6 +613,7 @@ int main() {
   test1();
   test2();
   test3();
+  test4();
   testGithubIssue103();
   testGithubIssue2647();
   return 0;

--- a/Code/GraphMol/Subgraphs/test2.cpp
+++ b/Code/GraphMol/Subgraphs/test2.cpp
@@ -469,13 +469,17 @@ void test4() {
       TEST_ASSERT(pth.size() == 9);
       TEST_ASSERT(cAtomMap.size() == 9);
       cAtomMap.clear();
-
+      // ---------------------------------------------------------------------------------
       pth = findBondEnvironmentOfRadiusN(*mH, 5, rootedAtBond, false, false, &cAtomMap);
       TEST_ASSERT(pth.size() == 9);
       TEST_ASSERT(cAtomMap.size() == 9);
       cAtomMap.clear();
       
-      // ---------------------------------------------------------------------------------
+      pth = findBondEnvironmentOfRadiusN(*mH, 5, rootedAtBond, false, true, &cAtomMap);
+      TEST_ASSERT(pth.size() == 9);
+      TEST_ASSERT(cAtomMap.size() == 9);
+      cAtomMap.clear();
+      
       pth = findBondEnvironmentOfRadiusN(*mH, 6, rootedAtBond, false, false, &cAtomMap);
       TEST_ASSERT(pth.size() == 9);
       TEST_ASSERT(cAtomMap.size() == 9);

--- a/Code/GraphMol/Subgraphs/test2.cpp
+++ b/Code/GraphMol/Subgraphs/test2.cpp
@@ -326,7 +326,6 @@ void test4() {
 
   {
     // Non-ring-membered bond;
-    std::cout << "Non-ring-membered bond" << std::endl;
     std::string smiles = "C=NC(CNC)(NO)SSC(CNC)(N=C)NO"; // Non-canonical "S(C(CNC)(N=C)NO)S(C(CNC)(N=C)NO)"
     unsigned int rootedAtBond = 8; // S-S bond
  
@@ -335,96 +334,120 @@ void test4() {
     ROMol *mH = MolOps::addHs(static_cast<const ROMol &>(*mol));
 
     std::unordered_map<unsigned int, unsigned int> cAtomMap;
+    std::unordered_map<unsigned int, unsigned int> cBondMap;
     PATH_TYPE pth;
     
     // ---------------------------------------------------------------------------------
     // Zero radius
-    std::cout << "Test zero radius" << std::endl;
-    pth = findBondEnvironmentOfRadiusN(*mH, 0, rootedAtBond, true, false, &cAtomMap);
+    pth = findBondEnvironmentOfRadiusN(*mH, 0, rootedAtBond, true, false, &cAtomMap, &cBondMap);
     TEST_ASSERT(pth.size() == 1);
     TEST_ASSERT(pth[0] == rootedAtBond);
     TEST_ASSERT(cAtomMap.size() == 2);
     TEST_ASSERT(cAtomMap[8] == 0);
     TEST_ASSERT(cAtomMap[9] == 0);
     cAtomMap.clear();
+    TEST_ASSERT(pth.size() == cBondMap.size());
+    cBondMap.clear();
 
     // ---------------------------------------------------------------------------------
     // useHs = false
     {
-      std::cout << "Test useHs=false" << std::endl;
-      pth = findBondEnvironmentOfRadiusN(*mH, 1, rootedAtBond, false, false, &cAtomMap);
+      pth = findBondEnvironmentOfRadiusN(*mH, 1, rootedAtBond, false, false, &cAtomMap, &cBondMap);
       TEST_ASSERT(pth.size() == 3);
       TEST_ASSERT(cAtomMap.size() == 4);
       cAtomMap.clear();
+      TEST_ASSERT(pth.size() == cBondMap.size());
+      cBondMap.clear();
 
-      pth = findBondEnvironmentOfRadiusN(*mH, 2, rootedAtBond, false, false, &cAtomMap);
+      pth = findBondEnvironmentOfRadiusN(*mH, 2, rootedAtBond, false, false, &cAtomMap, &cBondMap);
       TEST_ASSERT(pth.size() == 9);
       TEST_ASSERT(cAtomMap.size() == 10);
       cAtomMap.clear();
+      TEST_ASSERT(pth.size() == cBondMap.size());
+      cBondMap.clear();
 
-      pth = findBondEnvironmentOfRadiusN(*mH, 3, rootedAtBond, false, false, &cAtomMap);
+      pth = findBondEnvironmentOfRadiusN(*mH, 3, rootedAtBond, false, false, &cAtomMap, &cBondMap);
       TEST_ASSERT(pth.size() == 15);
       TEST_ASSERT(cAtomMap.size() == 16);
       cAtomMap.clear();
+      TEST_ASSERT(pth.size() == cBondMap.size());
+      cBondMap.clear();
 
-      pth = findBondEnvironmentOfRadiusN(*mH, 4, rootedAtBond, false, false, &cAtomMap);
+      pth = findBondEnvironmentOfRadiusN(*mH, 4, rootedAtBond, false, false, &cAtomMap, &cBondMap);
       TEST_ASSERT(pth.size() == 17);
       TEST_ASSERT(cAtomMap.size() == 18);
       cAtomMap.clear();
+      TEST_ASSERT(pth.size() == cBondMap.size());
+      cBondMap.clear();
       
       // -------------------------------------------
-      std::cout << "Test enforceSize" << std::endl;
-      pth = findBondEnvironmentOfRadiusN(*mH, 5, rootedAtBond, false, false, &cAtomMap);
+      pth = findBondEnvironmentOfRadiusN(*mH, 5, rootedAtBond, false, false, &cAtomMap, &cBondMap);
       TEST_ASSERT(pth.size() == 17);
       TEST_ASSERT(cAtomMap.size() == 18);
       cAtomMap.clear();
+      TEST_ASSERT(pth.size() == cBondMap.size());
+      cBondMap.clear();
 
-      pth = findBondEnvironmentOfRadiusN(*mH, 5, rootedAtBond, false, true, &cAtomMap);
+      pth = findBondEnvironmentOfRadiusN(*mH, 5, rootedAtBond, false, true, &cAtomMap, &cBondMap);
       TEST_ASSERT(pth.size() == 0);
       TEST_ASSERT(cAtomMap.size() == 0);
       cAtomMap.clear();
+      TEST_ASSERT(pth.size() == cBondMap.size());
+      cBondMap.clear();
     }
   
     // ---------------------------------------------------------------------------------
     // useHs = true
     {
-      std::cout << "Test useHs=true" << std::endl;
-      pth = findBondEnvironmentOfRadiusN(*mH, 1, rootedAtBond, true, false, &cAtomMap);
+      pth = findBondEnvironmentOfRadiusN(*mH, 1, rootedAtBond, true, false, &cAtomMap, &cBondMap);
       TEST_ASSERT(pth.size() == 3);
       TEST_ASSERT(cAtomMap.size() == 4);
       cAtomMap.clear();
+      TEST_ASSERT(pth.size() == cBondMap.size());
+      cBondMap.clear();
 
-      pth = findBondEnvironmentOfRadiusN(*mH, 2, rootedAtBond, true, false, &cAtomMap);
+      pth = findBondEnvironmentOfRadiusN(*mH, 2, rootedAtBond, true, false, &cAtomMap, &cBondMap);
       TEST_ASSERT(pth.size() == 9);
       TEST_ASSERT(cAtomMap.size() == 10);
       cAtomMap.clear();
+      TEST_ASSERT(pth.size() == cBondMap.size());
+      cBondMap.clear();
 
-      pth = findBondEnvironmentOfRadiusN(*mH, 3, rootedAtBond, true, false, &cAtomMap);
+      pth = findBondEnvironmentOfRadiusN(*mH, 3, rootedAtBond, true, false, &cAtomMap, &cBondMap);
       TEST_ASSERT(pth.size() == 21);
       TEST_ASSERT(cAtomMap.size() == 22);
       cAtomMap.clear();
+      TEST_ASSERT(pth.size() == cBondMap.size());
+      cBondMap.clear();
 
-      pth = findBondEnvironmentOfRadiusN(*mH, 4, rootedAtBond, true, false, &cAtomMap);
+      pth = findBondEnvironmentOfRadiusN(*mH, 4, rootedAtBond, true, false, &cAtomMap, &cBondMap);
       TEST_ASSERT(pth.size() == 31);
       TEST_ASSERT(cAtomMap.size() == 32);
       cAtomMap.clear();
+      TEST_ASSERT(pth.size() == cBondMap.size());
+      cBondMap.clear();
 
-      pth = findBondEnvironmentOfRadiusN(*mH, 5, rootedAtBond, true, false, &cAtomMap);
+      pth = findBondEnvironmentOfRadiusN(*mH, 5, rootedAtBond, true, false, &cAtomMap, &cBondMap);
       TEST_ASSERT(pth.size() == 37);
       TEST_ASSERT(cAtomMap.size() == 38);
       cAtomMap.clear();
+      TEST_ASSERT(pth.size() == cBondMap.size());
+      cBondMap.clear();
 
       // -------------------------------------------
-      std::cout << "Test enforceSize" << std::endl;
-      pth = findBondEnvironmentOfRadiusN(*mH, 6, rootedAtBond, true, false, &cAtomMap);
+      pth = findBondEnvironmentOfRadiusN(*mH, 6, rootedAtBond, true, false, &cAtomMap, &cBondMap);
       TEST_ASSERT(pth.size() == 37);
       TEST_ASSERT(cAtomMap.size() == 38);
       cAtomMap.clear();
+      TEST_ASSERT(pth.size() == cBondMap.size());
+      cBondMap.clear();
 
-      pth = findBondEnvironmentOfRadiusN(*mH, 6, rootedAtBond, true, true, &cAtomMap);
+      pth = findBondEnvironmentOfRadiusN(*mH, 6, rootedAtBond, true, true, &cAtomMap, &cBondMap);
       TEST_ASSERT(pth.size() == 0);
       TEST_ASSERT(cAtomMap.size() == 0);
       cAtomMap.clear();
+      TEST_ASSERT(pth.size() == cBondMap.size());
+      cBondMap.clear();
     }
 
     delete mol;
@@ -433,7 +456,6 @@ void test4() {
 
   {
     // Ring-membered bond;
-    std::cout << "Ring-membered bond" << std::endl;
     std::string smiles = "C1CCCSSCCC1"; // Exceptional case of enforceSize
     unsigned int rootedAtBond = 4;
 
@@ -442,111 +464,140 @@ void test4() {
     ROMol *mH = MolOps::addHs(static_cast<const ROMol &>(*mol));
 
     std::unordered_map<unsigned int, unsigned int> cAtomMap;
+    std::unordered_map<unsigned int, unsigned int> cBondMap;
     PATH_TYPE pth;
 
     // ---------------------------------------------------------------------------------
     // Zero radius
-    std::cout << "Test zero radius" << std::endl;
-    pth = findBondEnvironmentOfRadiusN(*mH, 0, rootedAtBond, true, false, &cAtomMap);
+    pth = findBondEnvironmentOfRadiusN(*mH, 0, rootedAtBond, true, false, &cAtomMap, &cBondMap);
     TEST_ASSERT(pth.size() == 1);
     TEST_ASSERT(pth[0] == rootedAtBond);
     TEST_ASSERT(cAtomMap.size() == 2);
     TEST_ASSERT(cAtomMap[4] == 0);
     TEST_ASSERT(cAtomMap[5] == 0);
     cAtomMap.clear();
+    TEST_ASSERT(pth.size() == cBondMap.size());
+    cBondMap.clear();
 
     // ---------------------------------------------------------------------------------
     // useHs = false
     {
-      std::cout << "Test useHs=false" << std::endl;
-      pth = findBondEnvironmentOfRadiusN(*mH, 1, rootedAtBond, false, false, &cAtomMap);
+      pth = findBondEnvironmentOfRadiusN(*mH, 1, rootedAtBond, false, false, &cAtomMap, &cBondMap);
       TEST_ASSERT(pth.size() == 3);
       TEST_ASSERT(cAtomMap.size() == 4);
       cAtomMap.clear();
+      TEST_ASSERT(pth.size() == cBondMap.size());
+      cBondMap.clear();
 
-      pth = findBondEnvironmentOfRadiusN(*mH, 2, rootedAtBond, false, false, &cAtomMap);
+      pth = findBondEnvironmentOfRadiusN(*mH, 2, rootedAtBond, false, false, &cAtomMap, &cBondMap);
       TEST_ASSERT(pth.size() == 5);
       TEST_ASSERT(cAtomMap.size() == 6);
       cAtomMap.clear();
+      TEST_ASSERT(pth.size() == cBondMap.size());
+      cBondMap.clear();
 
-      pth = findBondEnvironmentOfRadiusN(*mH, 3, rootedAtBond, false, false, &cAtomMap);
+      pth = findBondEnvironmentOfRadiusN(*mH, 3, rootedAtBond, false, false, &cAtomMap, &cBondMap);
       TEST_ASSERT(pth.size() == 7);
       TEST_ASSERT(cAtomMap.size() == 8);
       cAtomMap.clear();
+      TEST_ASSERT(pth.size() == cBondMap.size());
+      cBondMap.clear();
 
-      pth = findBondEnvironmentOfRadiusN(*mH, 4, rootedAtBond, false, false, &cAtomMap);
+      pth = findBondEnvironmentOfRadiusN(*mH, 4, rootedAtBond, false, false, &cAtomMap, &cBondMap);
       TEST_ASSERT(pth.size() == 9);
       TEST_ASSERT(cAtomMap.size() == 9);
       cAtomMap.clear();
+      TEST_ASSERT(pth.size() == cBondMap.size());
+      cBondMap.clear();
+
       // ---------------------------------------------------------------------------------
-      std::cout << "Test enforceSize v1" << std::endl;
-      pth = findBondEnvironmentOfRadiusN(*mH, 5, rootedAtBond, false, false, &cAtomMap);
+      pth = findBondEnvironmentOfRadiusN(*mH, 5, rootedAtBond, false, false, &cAtomMap, &cBondMap);
       TEST_ASSERT(pth.size() == 9);
       TEST_ASSERT(cAtomMap.size() == 9);
       cAtomMap.clear();
+      TEST_ASSERT(pth.size() == cBondMap.size());
+      cBondMap.clear();
       
-      pth = findBondEnvironmentOfRadiusN(*mH, 5, rootedAtBond, false, true, &cAtomMap);
+      pth = findBondEnvironmentOfRadiusN(*mH, 5, rootedAtBond, false, true, &cAtomMap, &cBondMap);
       TEST_ASSERT(pth.size() == 9);
       TEST_ASSERT(cAtomMap.size() == 9);
       cAtomMap.clear();
+      TEST_ASSERT(pth.size() == cBondMap.size());
+      cBondMap.clear();
       
-      std::cout << "Test enforceSize v2" << std::endl;
-      pth = findBondEnvironmentOfRadiusN(*mH, 6, rootedAtBond, false, false, &cAtomMap);
+      pth = findBondEnvironmentOfRadiusN(*mH, 6, rootedAtBond, false, false, &cAtomMap, &cBondMap);
       TEST_ASSERT(pth.size() == 9);
       TEST_ASSERT(cAtomMap.size() == 9);
       cAtomMap.clear();
+      TEST_ASSERT(pth.size() == cBondMap.size());
+      cBondMap.clear();
 
-      pth = findBondEnvironmentOfRadiusN(*mH, 6, rootedAtBond, false, true, &cAtomMap);
+      pth = findBondEnvironmentOfRadiusN(*mH, 6, rootedAtBond, false, true, &cAtomMap, &cBondMap);
       TEST_ASSERT(pth.size() == 0);
       TEST_ASSERT(cAtomMap.size() == 0);
       cAtomMap.clear();
+      TEST_ASSERT(pth.size() == cBondMap.size());
+      cBondMap.clear();
     }
 
     // ---------------------------------------------------------------------------------
     // useHs = true
     {
-      std::cout << "Test useHs=true" << std::endl;
-      pth = findBondEnvironmentOfRadiusN(*mH, 1, rootedAtBond, true, false, &cAtomMap);
+      pth = findBondEnvironmentOfRadiusN(*mH, 1, rootedAtBond, true, false, &cAtomMap, &cBondMap);
       TEST_ASSERT(pth.size() == 3);
       TEST_ASSERT(cAtomMap.size() == 4);
       cAtomMap.clear();
+      TEST_ASSERT(pth.size() == cBondMap.size());
+      cBondMap.clear();
 
-      pth = findBondEnvironmentOfRadiusN(*mH, 2, rootedAtBond, true, false, &cAtomMap);
+      pth = findBondEnvironmentOfRadiusN(*mH, 2, rootedAtBond, true, false, &cAtomMap, &cBondMap);
       TEST_ASSERT(pth.size() == 9);
       TEST_ASSERT(cAtomMap.size() == 10);
       cAtomMap.clear();
+      TEST_ASSERT(pth.size() == cBondMap.size());
+      cBondMap.clear();
 
-      pth = findBondEnvironmentOfRadiusN(*mH, 3, rootedAtBond, true, false, &cAtomMap);
+      pth = findBondEnvironmentOfRadiusN(*mH, 3, rootedAtBond, true, false, &cAtomMap, &cBondMap);
       TEST_ASSERT(pth.size() == 15);
       TEST_ASSERT(cAtomMap.size() == 16);
       cAtomMap.clear();
+      TEST_ASSERT(pth.size() == cBondMap.size());
+      cBondMap.clear();
 
-      pth = findBondEnvironmentOfRadiusN(*mH, 4, rootedAtBond, true, false, &cAtomMap);
+      pth = findBondEnvironmentOfRadiusN(*mH, 4, rootedAtBond, true, false, &cAtomMap, &cBondMap);
       TEST_ASSERT(pth.size() == 21);
       TEST_ASSERT(cAtomMap.size() == 21);
       cAtomMap.clear();
+      TEST_ASSERT(pth.size() == cBondMap.size());
+      cBondMap.clear();
 
-      pth = findBondEnvironmentOfRadiusN(*mH, 5, rootedAtBond, true, false, &cAtomMap);
+      pth = findBondEnvironmentOfRadiusN(*mH, 5, rootedAtBond, true, false, &cAtomMap, &cBondMap);
       TEST_ASSERT(pth.size() == 23);
       TEST_ASSERT(cAtomMap.size() == 23);
       cAtomMap.clear();
+      TEST_ASSERT(pth.size() == cBondMap.size());
+      cBondMap.clear();
       
       // ---------------------------------------------------------------------------------
-      std::cout << "Test enforceSize" << std::endl;
-      pth = findBondEnvironmentOfRadiusN(*mH, 6, rootedAtBond, true, false, &cAtomMap);
+      pth = findBondEnvironmentOfRadiusN(*mH, 6, rootedAtBond, true, false, &cAtomMap, &cBondMap);
       TEST_ASSERT(pth.size() == 23);
       TEST_ASSERT(cAtomMap.size() == 23);
       cAtomMap.clear();
+      TEST_ASSERT(pth.size() == cBondMap.size());
+      cBondMap.clear();
 
-      pth = findBondEnvironmentOfRadiusN(*mH, 6, rootedAtBond, true, true, &cAtomMap);
+      pth = findBondEnvironmentOfRadiusN(*mH, 6, rootedAtBond, true, true, &cAtomMap, &cBondMap);
       TEST_ASSERT(pth.size() == 0);
       TEST_ASSERT(cAtomMap.size() == 0);
       cAtomMap.clear();
+      TEST_ASSERT(pth.size() == cBondMap.size());
+      cBondMap.clear();
     }
 
     delete mol;
     delete mH;
   }
+
   std::cout << "Finished" << std::endl;
 }
 

--- a/Code/GraphMol/Subgraphs/test2.cpp
+++ b/Code/GraphMol/Subgraphs/test2.cpp
@@ -464,6 +464,7 @@ void test4() {
 
     // ---------------------------------------------------------------------------------
     // useHs = false
+    PATH_TYPE pth;
     pth = findBondEnvironmentOfRadiusN(*mH, 0, rootedAtBond, false, false, &cAtomMap);
     TEST_ASSERT(pth.size() == 1);
     TEST_ASSERT(pth[0] == rootedAtBond);

--- a/Code/GraphMol/Subgraphs/test2.cpp
+++ b/Code/GraphMol/Subgraphs/test2.cpp
@@ -427,7 +427,7 @@ void test4() {
 
   {
     // Ring-membered bond;
-    std::string smiles = "C1CCCSSCCC1"; // Exceptional case
+    std::string smiles = "C1CCCSSCCC1"; // Exceptional case of enforceSize
     unsigned int rootedAtBond = 4;
 
     RWMol *mol = SmilesToMol(smiles);

--- a/Code/GraphMol/Subgraphs/test2.cpp
+++ b/Code/GraphMol/Subgraphs/test2.cpp
@@ -326,6 +326,7 @@ void test4() {
 
   {
     // Non-ring-membered bond;
+    std::cout << "Non-ring-membered bond" << std::endl;
     std::string smiles = "C=NC(CNC)(NO)SSC(CNC)(N=C)NO"; // Non-canonical "S(C(CNC)(N=C)NO)S(C(CNC)(N=C)NO)"
     unsigned int rootedAtBond = 8; // S-S bond
  
@@ -338,6 +339,7 @@ void test4() {
     
     // ---------------------------------------------------------------------------------
     // Zero radius
+    std::cout << "Test zero radius" << std::endl;
     pth = findBondEnvironmentOfRadiusN(*mH, 0, rootedAtBond, true, false, &cAtomMap);
     TEST_ASSERT(pth.size() == 1);
     TEST_ASSERT(pth[0] == rootedAtBond);
@@ -349,6 +351,7 @@ void test4() {
     // ---------------------------------------------------------------------------------
     // useHs = false
     {
+      std::cout << "Test useHs=false" << std::endl;
       pth = findBondEnvironmentOfRadiusN(*mH, 1, rootedAtBond, false, false, &cAtomMap);
       TEST_ASSERT(pth.size() == 3);
       TEST_ASSERT(cAtomMap.size() == 4);
@@ -370,6 +373,7 @@ void test4() {
       cAtomMap.clear();
       
       // -------------------------------------------
+      std::cout << "Test enforceSize" << std::endl;
       pth = findBondEnvironmentOfRadiusN(*mH, 5, rootedAtBond, false, false, &cAtomMap);
       TEST_ASSERT(pth.size() == 17);
       TEST_ASSERT(cAtomMap.size() == 18);
@@ -384,6 +388,7 @@ void test4() {
     // ---------------------------------------------------------------------------------
     // useHs = true
     {
+      std::cout << "Test useHs=true" << std::endl;
       pth = findBondEnvironmentOfRadiusN(*mH, 1, rootedAtBond, true, false, &cAtomMap);
       TEST_ASSERT(pth.size() == 3);
       TEST_ASSERT(cAtomMap.size() == 4);
@@ -410,6 +415,7 @@ void test4() {
       cAtomMap.clear();
 
       // -------------------------------------------
+      std::cout << "Test enforceSize" << std::endl;
       pth = findBondEnvironmentOfRadiusN(*mH, 6, rootedAtBond, true, false, &cAtomMap);
       TEST_ASSERT(pth.size() == 37);
       TEST_ASSERT(cAtomMap.size() == 38);
@@ -427,6 +433,7 @@ void test4() {
 
   {
     // Ring-membered bond;
+    std::cout << "Ring-membered bond" << std::endl;
     std::string smiles = "C1CCCSSCCC1"; // Exceptional case of enforceSize
     unsigned int rootedAtBond = 4;
 
@@ -439,6 +446,7 @@ void test4() {
 
     // ---------------------------------------------------------------------------------
     // Zero radius
+    std::cout << "Test zero radius" << std::endl;
     pth = findBondEnvironmentOfRadiusN(*mH, 0, rootedAtBond, true, false, &cAtomMap);
     TEST_ASSERT(pth.size() == 1);
     TEST_ASSERT(pth[0] == rootedAtBond);
@@ -450,6 +458,7 @@ void test4() {
     // ---------------------------------------------------------------------------------
     // useHs = false
     {
+      std::cout << "Test useHs=false" << std::endl;
       pth = findBondEnvironmentOfRadiusN(*mH, 1, rootedAtBond, false, false, &cAtomMap);
       TEST_ASSERT(pth.size() == 3);
       TEST_ASSERT(cAtomMap.size() == 4);
@@ -470,6 +479,7 @@ void test4() {
       TEST_ASSERT(cAtomMap.size() == 9);
       cAtomMap.clear();
       // ---------------------------------------------------------------------------------
+      std::cout << "Test enforceSize v1" << std::endl;
       pth = findBondEnvironmentOfRadiusN(*mH, 5, rootedAtBond, false, false, &cAtomMap);
       TEST_ASSERT(pth.size() == 9);
       TEST_ASSERT(cAtomMap.size() == 9);
@@ -480,6 +490,7 @@ void test4() {
       TEST_ASSERT(cAtomMap.size() == 9);
       cAtomMap.clear();
       
+      std::cout << "Test enforceSize v2" << std::endl;
       pth = findBondEnvironmentOfRadiusN(*mH, 6, rootedAtBond, false, false, &cAtomMap);
       TEST_ASSERT(pth.size() == 9);
       TEST_ASSERT(cAtomMap.size() == 9);
@@ -494,6 +505,7 @@ void test4() {
     // ---------------------------------------------------------------------------------
     // useHs = true
     {
+      std::cout << "Test useHs=true" << std::endl;
       pth = findBondEnvironmentOfRadiusN(*mH, 1, rootedAtBond, true, false, &cAtomMap);
       TEST_ASSERT(pth.size() == 3);
       TEST_ASSERT(cAtomMap.size() == 4);
@@ -520,6 +532,7 @@ void test4() {
       cAtomMap.clear();
       
       // ---------------------------------------------------------------------------------
+      std::cout << "Test enforceSize" << std::endl;
       pth = findBondEnvironmentOfRadiusN(*mH, 6, rootedAtBond, true, false, &cAtomMap);
       TEST_ASSERT(pth.size() == 23);
       TEST_ASSERT(cAtomMap.size() == 23);
@@ -534,7 +547,6 @@ void test4() {
     delete mol;
     delete mH;
   }
-
   std::cout << "Finished" << std::endl;
 }
 

--- a/Code/GraphMol/Subgraphs/test2.cpp
+++ b/Code/GraphMol/Subgraphs/test2.cpp
@@ -427,7 +427,7 @@ void test4() {
 
   {
     // Ring-membered bond;
-    std::string smiles = "C1CCCSSCCC1"; 
+    std::string smiles = "C1CCCSSCCC1"; // Exceptional case
     unsigned int rootedAtBond = 4;
 
     RWMol *mol = SmilesToMol(smiles);

--- a/Code/GraphMol/Subgraphs/test2.cpp
+++ b/Code/GraphMol/Subgraphs/test2.cpp
@@ -326,7 +326,7 @@ void test4() {
 
   {
     // Non-ring-membered bond;
-    std::string smiles = "C=NC(CNC)(NO)SSC(CNC)(N=C)NO" // Non-canonical "S(C(CNC)(N=C)NO)S(C(CNC)(N=C)NO)"
+    std::string smiles = "C=NC(CNC)(NO)SSC(CNC)(N=C)NO"; // Non-canonical "S(C(CNC)(N=C)NO)S(C(CNC)(N=C)NO)"
     unsigned int rootedAtBond = 8; // S-S bond
  
     RWMol *mol = SmilesToMol(smiles);

--- a/Code/GraphMol/Subgraphs/test2.cpp
+++ b/Code/GraphMol/Subgraphs/test2.cpp
@@ -614,28 +614,28 @@ void test5() {
     TEST_ASSERT(mol);
     ROMol *mH = MolOps::addHs(static_cast<const ROMol &>(*mol));
 
-    PATH_TYPE pth = findAtomEnvironmentOfRadiusN(*mol, 1, 0, true, false, &cAtomMap, &cBondMap, true);
+    PATH_TYPE pth = findAtomEnvironmentOfRadiusN(*mH, 1, 0, true, false, &cAtomMap, &cBondMap, true);
     TEST_ASSERT(pth.size() == 1);
     TEST_ASSERT(cAtomMap.size() == 2);
     TEST_ASSERT(cBondMap.size() == 1);
     cAtomMap.clear();
     cBondMap.clear();
 
-    pth = findAtomEnvironmentOfRadiusN(*mol, 1, 0, true, false, &cAtomMap, &cBondMap, false);
+    pth = findAtomEnvironmentOfRadiusN(*mH, 1, 0, true, false, &cAtomMap, &cBondMap, false);
     TEST_ASSERT(pth.size() == 1);
     TEST_ASSERT(cAtomMap.size() == 2);
     TEST_ASSERT(cBondMap.size() == 1);
     cAtomMap.clear();
     cBondMap.clear();
 
-    pth = findAtomEnvironmentOfRadiusN(*mol, 1, 0, false, false, &cAtomMap, &cBondMap, true);
+    pth = findAtomEnvironmentOfRadiusN(*mH, 1, 0, false, false, &cAtomMap, &cBondMap, true);
     TEST_ASSERT(pth.size() == 0);
     TEST_ASSERT(cAtomMap.size() == 1);
     TEST_ASSERT(cBondMap.size() == 0);
     cAtomMap.clear();
     cBondMap.clear();
 
-    pth = findAtomEnvironmentOfRadiusN(*mol, 1, 0, false, false, &cAtomMap, &cBondMap, false);
+    pth = findAtomEnvironmentOfRadiusN(*mH, 1, 0, false, false, &cAtomMap, &cBondMap, false);
     TEST_ASSERT(pth.size() == 0);
     TEST_ASSERT(cAtomMap.size() == 1);
     TEST_ASSERT(cBondMap.size() == 0);
@@ -656,14 +656,14 @@ void test5() {
     ROMol *mH = MolOps::addHs(static_cast<const ROMol &>(*mol));
 
     // Test on carbon atom (`radius` is independent if enforceSize=false)
-    PATH_TYPE pth = findAtomEnvironmentOfRadiusN(*mol, 1, 0, true, false, &cAtomMap, &cBondMap, true);
+    PATH_TYPE pth = findAtomEnvironmentOfRadiusN(*mH, 1, 0, true, false, &cAtomMap, &cBondMap, true);
     TEST_ASSERT(pth.size() == 4);
     TEST_ASSERT(cAtomMap.size() == 5);
     TEST_ASSERT(cBondMap.size() == 4);
     cAtomMap.clear();
     cBondMap.clear();
 
-    pth = findAtomEnvironmentOfRadiusN(*mol, 1, 0, true, false, &cAtomMap, &cBondMap, false);
+    pth = findAtomEnvironmentOfRadiusN(*mH, 1, 0, true, false, &cAtomMap, &cBondMap, false);
     TEST_ASSERT(pth.size() == 4);
     TEST_ASSERT(cAtomMap.size() == 5);
     TEST_ASSERT(cBondMap.size() == 4);
@@ -672,28 +672,28 @@ void test5() {
 
     // Test on hydrogen atom (`radius` is independent)
     // useHs=true:
-    pth = findAtomEnvironmentOfRadiusN(*mol, 1, 1, true, false, &cAtomMap, &cBondMap, true);
+    pth = findAtomEnvironmentOfRadiusN(*mH, 1, 1, true, false, &cAtomMap, &cBondMap, true);
     TEST_ASSERT(pth.size() == 1);
     TEST_ASSERT(cAtomMap.size() == 2);
     TEST_ASSERT(cBondMap.size() == 1);
     cAtomMap.clear();
     cBondMap.clear();
 
-    pth = findAtomEnvironmentOfRadiusN(*mol, 1, 1, true, false, &cAtomMap, &cBondMap, false);
+    pth = findAtomEnvironmentOfRadiusN(*mH, 1, 1, true, false, &cAtomMap, &cBondMap, false);
     TEST_ASSERT(pth.size() == 1);
     TEST_ASSERT(cAtomMap.size() == 2);
     TEST_ASSERT(cBondMap.size() == 1);
     cAtomMap.clear();
     cBondMap.clear();
 
-    pth = findAtomEnvironmentOfRadiusN(*mol, 2, 1, true, false, &cAtomMap, &cBondMap, true);
+    pth = findAtomEnvironmentOfRadiusN(*mH, 2, 1, true, false, &cAtomMap, &cBondMap, true);
     TEST_ASSERT(pth.size() == 4);
     TEST_ASSERT(cAtomMap.size() == 5);
     TEST_ASSERT(cBondMap.size() == 4);
     cAtomMap.clear();
     cBondMap.clear();
 
-    pth = findAtomEnvironmentOfRadiusN(*mol, 2, 1, true, false, &cAtomMap, &cBondMap, false);
+    pth = findAtomEnvironmentOfRadiusN(*mH, 2, 1, true, false, &cAtomMap, &cBondMap, false);
     TEST_ASSERT(pth.size() == 4);
     TEST_ASSERT(cAtomMap.size() == 5);
     TEST_ASSERT(cBondMap.size() == 4);
@@ -701,14 +701,14 @@ void test5() {
     cBondMap.clear();
 
     // useHs=false:
-    pth = findAtomEnvironmentOfRadiusN(*mol, 1, 1, false, false, &cAtomMap, &cBondMap, true);
+    pth = findAtomEnvironmentOfRadiusN(*mH, 1, 1, false, false, &cAtomMap, &cBondMap, true);
     TEST_ASSERT(pth.size() == 1);
     TEST_ASSERT(cAtomMap.size() == 2);
     TEST_ASSERT(cBondMap.size() == 1);
     cAtomMap.clear();
     cBondMap.clear();
 
-    pth = findAtomEnvironmentOfRadiusN(*mol, 2, 1, false, false, &cAtomMap, &cBondMap, true);
+    pth = findAtomEnvironmentOfRadiusN(*mH, 2, 1, false, false, &cAtomMap, &cBondMap, true);
     TEST_ASSERT(pth.size() == 1);
     TEST_ASSERT(cAtomMap.size() == 2);
     TEST_ASSERT(cBondMap.size() == 1);
@@ -716,14 +716,14 @@ void test5() {
     cBondMap.clear();
 
 
-    pth = findAtomEnvironmentOfRadiusN(*mol, 1, 1, false, false, &cAtomMap, &cBondMap, false);
+    pth = findAtomEnvironmentOfRadiusN(*mH, 1, 1, false, false, &cAtomMap, &cBondMap, false);
     TEST_ASSERT(pth.size() == 1);
     TEST_ASSERT(cAtomMap.size() == 2);
     TEST_ASSERT(cBondMap.size() == 1);
     cAtomMap.clear();
     cBondMap.clear();
 
-    pth = findAtomEnvironmentOfRadiusN(*mol, 2, 1, false, false, &cAtomMap, &cBondMap, false);
+    pth = findAtomEnvironmentOfRadiusN(*mH, 2, 1, false, false, &cAtomMap, &cBondMap, false);
     TEST_ASSERT(pth.size() == 1);
     TEST_ASSERT(cAtomMap.size() == 2);
     TEST_ASSERT(cBondMap.size() == 1);

--- a/Code/GraphMol/Subgraphs/test2.cpp
+++ b/Code/GraphMol/Subgraphs/test2.cpp
@@ -338,7 +338,7 @@ void test4() {
     
     // ---------------------------------------------------------------------------------
     // useHs = false, enforceSize = false
-    pth = findBondEnvironmentOfRadiusN(*mH, 0, rootedAtBond, false, false, cAtomMap)
+    pth = findBondEnvironmentOfRadiusN(*mH, 0, rootedAtBond, false, false, &cAtomMap)
     TEST_ASSERT(pth.size() == 1);
     TEST_ASSERT(pth[0] == rootedAtBond);
     TEST_ASSERT(cAtomMap.size() == 2);
@@ -346,39 +346,39 @@ void test4() {
     TEST_ASSERT(cAtomMap[9] == 0);
     cAtomMap.clear();
 
-    pth = findBondEnvironmentOfRadiusN(*mH, 1, rootedAtBond, false, false, cAtomMap)
+    pth = findBondEnvironmentOfRadiusN(*mH, 1, rootedAtBond, false, false, &cAtomMap)
     TEST_ASSERT(pth.size() == 3);
     TEST_ASSERT(cAtomMap.size() == 4);
     cAtomMap.clear();
 
-    pth = findBondEnvironmentOfRadiusN(*mH, 2, rootedAtBond, false, false, cAtomMap)
+    pth = findBondEnvironmentOfRadiusN(*mH, 2, rootedAtBond, false, false, &cAtomMap)
     TEST_ASSERT(pth.size() == 9);
     TEST_ASSERT(cAtomMap.size() == 10);
     cAtomMap.clear();
 
-    pth = findBondEnvironmentOfRadiusN(*mH, 3, rootedAtBond, false, false, cAtomMap)
+    pth = findBondEnvironmentOfRadiusN(*mH, 3, rootedAtBond, false, false, &cAtomMap)
     TEST_ASSERT(pth.size() == 15);
     TEST_ASSERT(cAtomMap.size() == 16);
     cAtomMap.clear();
 
-    pth = findBondEnvironmentOfRadiusN(*mH, 4, rootedAtBond, false, false, cAtomMap)
+    pth = findBondEnvironmentOfRadiusN(*mH, 4, rootedAtBond, false, false, &cAtomMap)
     TEST_ASSERT(pth.size() == 18);
     TEST_ASSERT(cAtomMap.size() == 19);
     cAtomMap.clear();
 
-    pth = findBondEnvironmentOfRadiusN(*mH, 5, rootedAtBond, false, false, cAtomMap)
+    pth = findBondEnvironmentOfRadiusN(*mH, 5, rootedAtBond, false, false, &cAtomMap)
     TEST_ASSERT(pth.size() == 19);
     TEST_ASSERT(cAtomMap.size() == 20);
     cAtomMap.clear();
 
-    pth = findBondEnvironmentOfRadiusN(*mH, 6, rootedAtBond, false, false, cAtomMap)
+    pth = findBondEnvironmentOfRadiusN(*mH, 6, rootedAtBond, false, false, &cAtomMap)
     TEST_ASSERT(pth.size() == 20);
     TEST_ASSERT(cAtomMap.size() == 21);
     cAtomMap.clear();
 
     // ---------------------------------------------------------------------------------
     // useHs = false, enforceSize = true
-    pth = findBondEnvironmentOfRadiusN(*mH, 0, rootedAtBond, false, true, cAtomMap)
+    pth = findBondEnvironmentOfRadiusN(*mH, 0, rootedAtBond, false, true, &cAtomMap)
     TEST_ASSERT(pth.size() == 1);
     TEST_ASSERT(pth[0] == rootedAtBond);
     TEST_ASSERT(cAtomMap.size() == 2);
@@ -386,39 +386,39 @@ void test4() {
     TEST_ASSERT(cAtomMap[9] == 0);
     cAtomMap.clear();
 
-    pth = findBondEnvironmentOfRadiusN(*mH, 1, rootedAtBond, false, true, cAtomMap)
+    pth = findBondEnvironmentOfRadiusN(*mH, 1, rootedAtBond, false, true, &cAtomMap)
     TEST_ASSERT(pth.size() == 3);
     TEST_ASSERT(cAtomMap.size() == 4);
     cAtomMap.clear();
 
-    pth = findBondEnvironmentOfRadiusN(*mH, 2, rootedAtBond, false, true, cAtomMap)
+    pth = findBondEnvironmentOfRadiusN(*mH, 2, rootedAtBond, false, true, &cAtomMap)
     TEST_ASSERT(pth.size() == 9);
     TEST_ASSERT(cAtomMap.size() == 10);
     cAtomMap.clear();
 
-    pth = findBondEnvironmentOfRadiusN(*mH, 3, rootedAtBond, false, true, cAtomMap)
+    pth = findBondEnvironmentOfRadiusN(*mH, 3, rootedAtBond, false, true, &cAtomMap)
     TEST_ASSERT(pth.size() == 15);
     TEST_ASSERT(cAtomMap.size() == 16);
     cAtomMap.clear();
 
-    pth = findBondEnvironmentOfRadiusN(*mH, 4, rootedAtBond, false, true, cAtomMap)
+    pth = findBondEnvironmentOfRadiusN(*mH, 4, rootedAtBond, false, true, &cAtomMap)
     TEST_ASSERT(pth.size() == 18);
     TEST_ASSERT(cAtomMap.size() == 19);
     cAtomMap.clear();
 
-    pth = findBondEnvironmentOfRadiusN(*mH, 5, rootedAtBond, false, true, cAtomMap)
+    pth = findBondEnvironmentOfRadiusN(*mH, 5, rootedAtBond, false, true, &cAtomMap)
     TEST_ASSERT(pth.size() == 19);
     TEST_ASSERT(cAtomMap.size() == 20);
     cAtomMap.clear();
 
-    pth = findBondEnvironmentOfRadiusN(*mH, 6, rootedAtBond, false, true, cAtomMap)
+    pth = findBondEnvironmentOfRadiusN(*mH, 6, rootedAtBond, false, true, &cAtomMap)
     TEST_ASSERT(pth.size() == 20);
     TEST_ASSERT(cAtomMap.size() == 21);
     cAtomMap.clear();
 
     // ---------------------------------------------------------------------------------
     // useHs = true, enforceSize = false
-    pth = findBondEnvironmentOfRadiusN(*mH, 0, rootedAtBond, true, false, cAtomMap)
+    pth = findBondEnvironmentOfRadiusN(*mH, 0, rootedAtBond, true, false, &cAtomMap)
     TEST_ASSERT(pth.size() == 1);
     TEST_ASSERT(pth[0] == rootedAtBond);
     TEST_ASSERT(cAtomMap.size() == 2);
@@ -426,22 +426,22 @@ void test4() {
     TEST_ASSERT(cAtomMap[9] == 0);
     cAtomMap.clear();
 
-    pth = findBondEnvironmentOfRadiusN(*mH, 1, rootedAtBond, true, false, cAtomMap)
+    pth = findBondEnvironmentOfRadiusN(*mH, 1, rootedAtBond, true, false, &cAtomMap)
     TEST_ASSERT(pth.size() == 3);
     TEST_ASSERT(cAtomMap.size() == 4);
     cAtomMap.clear();
 
-    pth = findBondEnvironmentOfRadiusN(*mH, 2, rootedAtBond, true, false, cAtomMap)
+    pth = findBondEnvironmentOfRadiusN(*mH, 2, rootedAtBond, true, false, &cAtomMap)
     TEST_ASSERT(pth.size() == 9);
     TEST_ASSERT(cAtomMap.size() == 10);
     cAtomMap.clear();
 
-    pth = findBondEnvironmentOfRadiusN(*mH, 3, rootedAtBond, true, false, cAtomMap)
+    pth = findBondEnvironmentOfRadiusN(*mH, 3, rootedAtBond, true, false, &cAtomMap)
     TEST_ASSERT(pth.size() == 21);
     TEST_ASSERT(cAtomMap.size() == 22);
     cAtomMap.clear();
 
-    pth = findBondEnvironmentOfRadiusN(*mH, 4, rootedAtBond, true, false, cAtomMap)
+    pth = findBondEnvironmentOfRadiusN(*mH, 4, rootedAtBond, true, false, &cAtomMap)
     TEST_ASSERT(pth.size() == 31);
     TEST_ASSERT(cAtomMap.size() == 32);
     cAtomMap.clear();
@@ -464,7 +464,7 @@ void test4() {
 
     // ---------------------------------------------------------------------------------
     // useHs = false
-    pth = findBondEnvironmentOfRadiusN(*mH, 0, rootedAtBond, false, false, cAtomMap)
+    pth = findBondEnvironmentOfRadiusN(*mH, 0, rootedAtBond, false, false, &cAtomMap)
     TEST_ASSERT(pth.size() == 1);
     TEST_ASSERT(pth[0] == rootedAtBond);
     TEST_ASSERT(cAtomMap.size() == 2);
@@ -472,44 +472,44 @@ void test4() {
     TEST_ASSERT(cAtomMap[8] == 0);
     cAtomMap.clear();
 
-    pth = findBondEnvironmentOfRadiusN(*mH, 1, rootedAtBond, false, false, cAtomMap)
+    pth = findBondEnvironmentOfRadiusN(*mH, 1, rootedAtBond, false, false, &cAtomMap)
     TEST_ASSERT(pth.size() == 3);
     TEST_ASSERT(cAtomMap.size() == 4);
     cAtomMap.clear();
 
-    pth = findBondEnvironmentOfRadiusN(*mH, 2, rootedAtBond, false, false, cAtomMap)
+    pth = findBondEnvironmentOfRadiusN(*mH, 2, rootedAtBond, false, false, &cAtomMap)
     TEST_ASSERT(pth.size() == 5);
     TEST_ASSERT(cAtomMap.size() == 6);
     cAtomMap.clear();
 
-    pth = findBondEnvironmentOfRadiusN(*mH, 3, rootedAtBond, false, false, cAtomMap)
+    pth = findBondEnvironmentOfRadiusN(*mH, 3, rootedAtBond, false, false, &cAtomMap)
     TEST_ASSERT(pth.size() == 7);
     TEST_ASSERT(cAtomMap.size() == 8);
     cAtomMap.clear();
 
-    pth = findBondEnvironmentOfRadiusN(*mH, 4, rootedAtBond, false, false, cAtomMap)
+    pth = findBondEnvironmentOfRadiusN(*mH, 4, rootedAtBond, false, false, &cAtomMap)
     TEST_ASSERT(pth.size() == 9);
     TEST_ASSERT(cAtomMap.size() == 9);
     cAtomMap.clear();
 
-    pth = findBondEnvironmentOfRadiusN(*mH, 5, rootedAtBond, false, false, cAtomMap)
+    pth = findBondEnvironmentOfRadiusN(*mH, 5, rootedAtBond, false, false, &cAtomMap)
     TEST_ASSERT(pth.size() == 9);
     TEST_ASSERT(cAtomMap.size() == 9);
     cAtomMap.clear();
 
-    pth = findBondEnvironmentOfRadiusN(*mH, 6, rootedAtBond, false, false, cAtomMap)
+    pth = findBondEnvironmentOfRadiusN(*mH, 6, rootedAtBond, false, false, &cAtomMap)
     TEST_ASSERT(pth.size() == 9);
     TEST_ASSERT(cAtomMap.size() == 9);
     cAtomMap.clear();
 
-    pth = findBondEnvironmentOfRadiusN(*mH, 6, rootedAtBond, false, true, cAtomMap)
+    pth = findBondEnvironmentOfRadiusN(*mH, 6, rootedAtBond, false, true, &cAtomMap)
     TEST_ASSERT(pth.size() == 0);
     TEST_ASSERT(cAtomMap.size() == 0);
     cAtomMap.clear();
 
     // ---------------------------------------------------------------------------------
     // useHs = true, enforceSize = true
-    pth = findBondEnvironmentOfRadiusN(*mH, 0, rootedAtBond, true, false, cAtomMap)
+    pth = findBondEnvironmentOfRadiusN(*mH, 0, rootedAtBond, true, false, &cAtomMap)
     TEST_ASSERT(pth.size() == 1);
     TEST_ASSERT(pth[0] == rootedAtBond);
     TEST_ASSERT(cAtomMap.size() == 2);
@@ -517,22 +517,22 @@ void test4() {
     TEST_ASSERT(cAtomMap[9] == 0);
     cAtomMap.clear();
 
-    pth = findBondEnvironmentOfRadiusN(*mH, 1, rootedAtBond, true, false, cAtomMap)
+    pth = findBondEnvironmentOfRadiusN(*mH, 1, rootedAtBond, true, false, &cAtomMap)
     TEST_ASSERT(pth.size() == 3);
     TEST_ASSERT(cAtomMap.size() == 4);
     cAtomMap.clear();
 
-    pth = findBondEnvironmentOfRadiusN(*mH, 2, rootedAtBond, true, false, cAtomMap)
+    pth = findBondEnvironmentOfRadiusN(*mH, 2, rootedAtBond, true, false, &cAtomMap)
     TEST_ASSERT(pth.size() == 9);
     TEST_ASSERT(cAtomMap.size() == 10);
     cAtomMap.clear();
 
-    pth = findBondEnvironmentOfRadiusN(*mH, 3, rootedAtBond, true, false, cAtomMap)
+    pth = findBondEnvironmentOfRadiusN(*mH, 3, rootedAtBond, true, false, &cAtomMap)
     TEST_ASSERT(pth.size() == 15);
     TEST_ASSERT(cAtomMap.size() == 16);
     cAtomMap.clear();
 
-    pth = findBondEnvironmentOfRadiusN(*mH, 4, rootedAtBond, true, false, cAtomMap)
+    pth = findBondEnvironmentOfRadiusN(*mH, 4, rootedAtBond, true, false, &cAtomMap)
     TEST_ASSERT(pth.size() == 21);
     TEST_ASSERT(cAtomMap.size() == 21);
     cAtomMap.clear();

--- a/Code/GraphMol/Subgraphs/test2.cpp
+++ b/Code/GraphMol/Subgraphs/test2.cpp
@@ -338,116 +338,135 @@ void test4() {
     
     // ---------------------------------------------------------------------------------
     // useHs = false, enforceSize = false
-    pth = findBondEnvironmentOfRadiusN(*mH, 0, rootedAtBond, false, false, &cAtomMap);
-    TEST_ASSERT(pth.size() == 1);
-    TEST_ASSERT(pth[0] == rootedAtBond);
-    TEST_ASSERT(cAtomMap.size() == 2);
-    TEST_ASSERT(cAtomMap[0] == 0);
-    TEST_ASSERT(cAtomMap[9] == 0);
-    cAtomMap.clear();
+    {
+      pth = findBondEnvironmentOfRadiusN(*mH, 0, rootedAtBond, false, false, &cAtomMap);
+      TEST_ASSERT(pth.size() == 1);
+      TEST_ASSERT(pth[0] == rootedAtBond);
+      TEST_ASSERT(cAtomMap.size() == 2);
+      TEST_ASSERT(cAtomMap[0] == 0);
+      TEST_ASSERT(cAtomMap[9] == 0);
+      cAtomMap.clear();
 
-    pth = findBondEnvironmentOfRadiusN(*mH, 1, rootedAtBond, false, false, &cAtomMap);
-    TEST_ASSERT(pth.size() == 3);
-    TEST_ASSERT(cAtomMap.size() == 4);
-    cAtomMap.clear();
+      pth = findBondEnvironmentOfRadiusN(*mH, 1, rootedAtBond, false, false, &cAtomMap);
+      TEST_ASSERT(pth.size() == 3);
+      TEST_ASSERT(cAtomMap.size() == 4);
+      cAtomMap.clear();
 
-    pth = findBondEnvironmentOfRadiusN(*mH, 2, rootedAtBond, false, false, &cAtomMap);
-    TEST_ASSERT(pth.size() == 9);
-    TEST_ASSERT(cAtomMap.size() == 10);
-    cAtomMap.clear();
+      pth = findBondEnvironmentOfRadiusN(*mH, 2, rootedAtBond, false, false, &cAtomMap);
+      TEST_ASSERT(pth.size() == 9);
+      TEST_ASSERT(cAtomMap.size() == 10);
+      cAtomMap.clear();
 
-    pth = findBondEnvironmentOfRadiusN(*mH, 3, rootedAtBond, false, false, &cAtomMap);
-    TEST_ASSERT(pth.size() == 15);
-    TEST_ASSERT(cAtomMap.size() == 16);
-    cAtomMap.clear();
+      pth = findBondEnvironmentOfRadiusN(*mH, 3, rootedAtBond, false, false, &cAtomMap);
+      TEST_ASSERT(pth.size() == 15);
+      TEST_ASSERT(cAtomMap.size() == 16);
+      cAtomMap.clear();
 
-    pth = findBondEnvironmentOfRadiusN(*mH, 4, rootedAtBond, false, false, &cAtomMap);
-    TEST_ASSERT(pth.size() == 18);
-    TEST_ASSERT(cAtomMap.size() == 19);
-    cAtomMap.clear();
+      pth = findBondEnvironmentOfRadiusN(*mH, 4, rootedAtBond, false, false, &cAtomMap);
+      TEST_ASSERT(pth.size() == 17);
+      TEST_ASSERT(cAtomMap.size() == 18);
+      cAtomMap.clear();
 
-    pth = findBondEnvironmentOfRadiusN(*mH, 5, rootedAtBond, false, false, &cAtomMap);
-    TEST_ASSERT(pth.size() == 19);
-    TEST_ASSERT(cAtomMap.size() == 20);
-    cAtomMap.clear();
+      pth = findBondEnvironmentOfRadiusN(*mH, 5, rootedAtBond, false, false, &cAtomMap);
+      TEST_ASSERT(pth.size() == 17);
+      TEST_ASSERT(cAtomMap.size() == 18);
+      cAtomMap.clear();
 
-    pth = findBondEnvironmentOfRadiusN(*mH, 6, rootedAtBond, false, false, &cAtomMap);
-    TEST_ASSERT(pth.size() == 20);
-    TEST_ASSERT(cAtomMap.size() == 21);
-    cAtomMap.clear();
-
+      pth = findBondEnvironmentOfRadiusN(*mH, 6, rootedAtBond, false, false, &cAtomMap);
+      TEST_ASSERT(pth.size() == 17);
+      TEST_ASSERT(cAtomMap.size() == 18);
+      cAtomMap.clear();
+    }
+  
     // ---------------------------------------------------------------------------------
     // useHs = false, enforceSize = true
-    pth = findBondEnvironmentOfRadiusN(*mH, 0, rootedAtBond, false, true, &cAtomMap);
-    TEST_ASSERT(pth.size() == 1);
-    TEST_ASSERT(pth[0] == rootedAtBond);
-    TEST_ASSERT(cAtomMap.size() == 2);
-    TEST_ASSERT(cAtomMap[0] == 0);
-    TEST_ASSERT(cAtomMap[9] == 0);
-    cAtomMap.clear();
+    {
+      pth = findBondEnvironmentOfRadiusN(*mH, 0, rootedAtBond, false, true, &cAtomMap);
+      TEST_ASSERT(pth.size() == 1);
+      TEST_ASSERT(pth[0] == rootedAtBond);
+      TEST_ASSERT(cAtomMap.size() == 2);
+      TEST_ASSERT(cAtomMap[0] == 0);
+      TEST_ASSERT(cAtomMap[9] == 0);
+      cAtomMap.clear();
 
-    pth = findBondEnvironmentOfRadiusN(*mH, 1, rootedAtBond, false, true, &cAtomMap);
-    TEST_ASSERT(pth.size() == 3);
-    TEST_ASSERT(cAtomMap.size() == 4);
-    cAtomMap.clear();
+      pth = findBondEnvironmentOfRadiusN(*mH, 1, rootedAtBond, false, true, &cAtomMap);
+      TEST_ASSERT(pth.size() == 3);
+      TEST_ASSERT(cAtomMap.size() == 4);
+      cAtomMap.clear();
 
-    pth = findBondEnvironmentOfRadiusN(*mH, 2, rootedAtBond, false, true, &cAtomMap);
-    TEST_ASSERT(pth.size() == 9);
-    TEST_ASSERT(cAtomMap.size() == 10);
-    cAtomMap.clear();
+      pth = findBondEnvironmentOfRadiusN(*mH, 2, rootedAtBond, false, true, &cAtomMap);
+      TEST_ASSERT(pth.size() == 9);
+      TEST_ASSERT(cAtomMap.size() == 10);
+      cAtomMap.clear();
 
-    pth = findBondEnvironmentOfRadiusN(*mH, 3, rootedAtBond, false, true, &cAtomMap);
-    TEST_ASSERT(pth.size() == 15);
-    TEST_ASSERT(cAtomMap.size() == 16);
-    cAtomMap.clear();
+      pth = findBondEnvironmentOfRadiusN(*mH, 3, rootedAtBond, false, true, &cAtomMap);
+      TEST_ASSERT(pth.size() == 15);
+      TEST_ASSERT(cAtomMap.size() == 16);
+      cAtomMap.clear();
 
-    pth = findBondEnvironmentOfRadiusN(*mH, 4, rootedAtBond, false, true, &cAtomMap);
-    TEST_ASSERT(pth.size() == 18);
-    TEST_ASSERT(cAtomMap.size() == 19);
-    cAtomMap.clear();
+      pth = findBondEnvironmentOfRadiusN(*mH, 4, rootedAtBond, false, true, &cAtomMap);
+      TEST_ASSERT(pth.size() == 17);
+      TEST_ASSERT(cAtomMap.size() == 18);
+      cAtomMap.clear();
 
-    pth = findBondEnvironmentOfRadiusN(*mH, 5, rootedAtBond, false, true, &cAtomMap);
-    TEST_ASSERT(pth.size() == 19);
-    TEST_ASSERT(cAtomMap.size() == 20);
-    cAtomMap.clear();
+      pth = findBondEnvironmentOfRadiusN(*mH, 5, rootedAtBond, false, true, &cAtomMap);
+      TEST_ASSERT(pth.size() == 0);
+      TEST_ASSERT(cAtomMap.size() == 0);
+      cAtomMap.clear();
 
-    pth = findBondEnvironmentOfRadiusN(*mH, 6, rootedAtBond, false, true, &cAtomMap);
-    TEST_ASSERT(pth.size() == 20);
-    TEST_ASSERT(cAtomMap.size() == 21);
-    cAtomMap.clear();
+      pth = findBondEnvironmentOfRadiusN(*mH, 6, rootedAtBond, false, true, &cAtomMap);
+      TEST_ASSERT(pth.size() == 0);
+      TEST_ASSERT(cAtomMap.size() == 0);
+      cAtomMap.clear();
+    }
 
     // ---------------------------------------------------------------------------------
     // useHs = true, enforceSize = false
-    pth = findBondEnvironmentOfRadiusN(*mH, 0, rootedAtBond, true, false, &cAtomMap);
-    TEST_ASSERT(pth.size() == 1);
-    TEST_ASSERT(pth[0] == rootedAtBond);
-    TEST_ASSERT(cAtomMap.size() == 2);
-    TEST_ASSERT(cAtomMap[0] == 0);
-    TEST_ASSERT(cAtomMap[9] == 0);
-    cAtomMap.clear();
+    {
+      pth = findBondEnvironmentOfRadiusN(*mH, 0, rootedAtBond, true, false, &cAtomMap);
+      TEST_ASSERT(pth.size() == 1);
+      TEST_ASSERT(pth[0] == rootedAtBond);
+      TEST_ASSERT(cAtomMap.size() == 2);
+      TEST_ASSERT(cAtomMap[0] == 0);
+      TEST_ASSERT(cAtomMap[9] == 0);
+      cAtomMap.clear();
 
-    pth = findBondEnvironmentOfRadiusN(*mH, 1, rootedAtBond, true, false, &cAtomMap);
-    TEST_ASSERT(pth.size() == 3);
-    TEST_ASSERT(cAtomMap.size() == 4);
-    cAtomMap.clear();
+      pth = findBondEnvironmentOfRadiusN(*mH, 1, rootedAtBond, true, false, &cAtomMap);
+      TEST_ASSERT(pth.size() == 3);
+      TEST_ASSERT(cAtomMap.size() == 4);
+      cAtomMap.clear();
 
-    pth = findBondEnvironmentOfRadiusN(*mH, 2, rootedAtBond, true, false, &cAtomMap);
-    TEST_ASSERT(pth.size() == 9);
-    TEST_ASSERT(cAtomMap.size() == 10);
-    cAtomMap.clear();
+      pth = findBondEnvironmentOfRadiusN(*mH, 2, rootedAtBond, true, false, &cAtomMap);
+      TEST_ASSERT(pth.size() == 9);
+      TEST_ASSERT(cAtomMap.size() == 10);
+      cAtomMap.clear();
 
-    pth = findBondEnvironmentOfRadiusN(*mH, 3, rootedAtBond, true, false, &cAtomMap);
-    TEST_ASSERT(pth.size() == 21);
-    TEST_ASSERT(cAtomMap.size() == 22);
-    cAtomMap.clear();
+      pth = findBondEnvironmentOfRadiusN(*mH, 3, rootedAtBond, true, false, &cAtomMap);
+      TEST_ASSERT(pth.size() == 21);
+      TEST_ASSERT(cAtomMap.size() == 22);
+      cAtomMap.clear();
 
-    pth = findBondEnvironmentOfRadiusN(*mH, 4, rootedAtBond, true, false, &cAtomMap);
-    TEST_ASSERT(pth.size() == 31);
-    TEST_ASSERT(cAtomMap.size() == 32);
-    cAtomMap.clear();
+      pth = findBondEnvironmentOfRadiusN(*mH, 4, rootedAtBond, true, false, &cAtomMap);
+      TEST_ASSERT(pth.size() == 31);
+      TEST_ASSERT(cAtomMap.size() == 32);
+      cAtomMap.clear();
 
-    // ---------------------------------------------------------------------------------
-    // useHs = true, enforceSize = true: This is skipped
+      pth = findBondEnvironmentOfRadiusN(*mH, 5, rootedAtBond, true, false, &cAtomMap);
+      TEST_ASSERT(pth.size() == 37);
+      TEST_ASSERT(cAtomMap.size() == 38);
+      cAtomMap.clear();
+
+      pth = findBondEnvironmentOfRadiusN(*mH, 6, rootedAtBond, true, false, &cAtomMap);
+      TEST_ASSERT(pth.size() == 37);
+      TEST_ASSERT(cAtomMap.size() == 38);
+      cAtomMap.clear();
+
+      pth = findBondEnvironmentOfRadiusN(*mH, 6, rootedAtBond, true, true, &cAtomMap);
+      TEST_ASSERT(pth.size() == 0);
+      TEST_ASSERT(cAtomMap.size() == 0);
+      cAtomMap.clear();
+    }
+
     delete mol;
     delete mH;
   }
@@ -456,87 +475,109 @@ void test4() {
     // Ring-membered bond;
     std::string smiles = "S1CCCCCCCS1"; 
     unsigned int rootedAtBond = 8;
-    std::unordered_map<unsigned int, unsigned int> cAtomMap;
 
     RWMol *mol = SmilesToMol(smiles);
     TEST_ASSERT(mol);
     ROMol *mH = MolOps::addHs(static_cast<const ROMol &>(*mol));
 
+    std::unordered_map<unsigned int, unsigned int> cAtomMap;
+    PATH_TYPE pth;
+
     // ---------------------------------------------------------------------------------
     // useHs = false
-    PATH_TYPE pth;
-    pth = findBondEnvironmentOfRadiusN(*mH, 0, rootedAtBond, false, false, &cAtomMap);
-    TEST_ASSERT(pth.size() == 1);
-    TEST_ASSERT(pth[0] == rootedAtBond);
-    TEST_ASSERT(cAtomMap.size() == 2);
-    TEST_ASSERT(cAtomMap[0] == 0);
-    TEST_ASSERT(cAtomMap[8] == 0);
-    cAtomMap.clear();
 
-    pth = findBondEnvironmentOfRadiusN(*mH, 1, rootedAtBond, false, false, &cAtomMap);
-    TEST_ASSERT(pth.size() == 3);
-    TEST_ASSERT(cAtomMap.size() == 4);
-    cAtomMap.clear();
+    {
+      pth = findBondEnvironmentOfRadiusN(*mH, 0, rootedAtBond, false, false, &cAtomMap);
+      TEST_ASSERT(pth.size() == 1);
+      TEST_ASSERT(pth[0] == rootedAtBond);
+      TEST_ASSERT(cAtomMap.size() == 2);
+      TEST_ASSERT(cAtomMap[0] == 0);
+      TEST_ASSERT(cAtomMap[8] == 0);
+      cAtomMap.clear();
 
-    pth = findBondEnvironmentOfRadiusN(*mH, 2, rootedAtBond, false, false, &cAtomMap);
-    TEST_ASSERT(pth.size() == 5);
-    TEST_ASSERT(cAtomMap.size() == 6);
-    cAtomMap.clear();
+      pth = findBondEnvironmentOfRadiusN(*mH, 1, rootedAtBond, false, false, &cAtomMap);
+      TEST_ASSERT(pth.size() == 3);
+      TEST_ASSERT(cAtomMap.size() == 4);
+      cAtomMap.clear();
 
-    pth = findBondEnvironmentOfRadiusN(*mH, 3, rootedAtBond, false, false, &cAtomMap);
-    TEST_ASSERT(pth.size() == 7);
-    TEST_ASSERT(cAtomMap.size() == 8);
-    cAtomMap.clear();
+      pth = findBondEnvironmentOfRadiusN(*mH, 2, rootedAtBond, false, false, &cAtomMap);
+      TEST_ASSERT(pth.size() == 5);
+      TEST_ASSERT(cAtomMap.size() == 6);
+      cAtomMap.clear();
 
-    pth = findBondEnvironmentOfRadiusN(*mH, 4, rootedAtBond, false, false, &cAtomMap);
-    TEST_ASSERT(pth.size() == 9);
-    TEST_ASSERT(cAtomMap.size() == 9);
-    cAtomMap.clear();
+      pth = findBondEnvironmentOfRadiusN(*mH, 3, rootedAtBond, false, false, &cAtomMap);
+      TEST_ASSERT(pth.size() == 7);
+      TEST_ASSERT(cAtomMap.size() == 8);
+      cAtomMap.clear();
 
-    pth = findBondEnvironmentOfRadiusN(*mH, 5, rootedAtBond, false, false, &cAtomMap);
-    TEST_ASSERT(pth.size() == 9);
-    TEST_ASSERT(cAtomMap.size() == 9);
-    cAtomMap.clear();
+      pth = findBondEnvironmentOfRadiusN(*mH, 4, rootedAtBond, false, false, &cAtomMap);
+      TEST_ASSERT(pth.size() == 9);
+      TEST_ASSERT(cAtomMap.size() == 9);
+      cAtomMap.clear();
 
-    pth = findBondEnvironmentOfRadiusN(*mH, 6, rootedAtBond, false, false, &cAtomMap);
-    TEST_ASSERT(pth.size() == 9);
-    TEST_ASSERT(cAtomMap.size() == 9);
-    cAtomMap.clear();
+      pth = findBondEnvironmentOfRadiusN(*mH, 5, rootedAtBond, false, false, &cAtomMap);
+      TEST_ASSERT(pth.size() == 9);
+      TEST_ASSERT(cAtomMap.size() == 9);
+      cAtomMap.clear();
 
-    pth = findBondEnvironmentOfRadiusN(*mH, 6, rootedAtBond, false, true, &cAtomMap);
-    TEST_ASSERT(pth.size() == 0);
-    TEST_ASSERT(cAtomMap.size() == 0);
-    cAtomMap.clear();
+      pth = findBondEnvironmentOfRadiusN(*mH, 6, rootedAtBond, false, false, &cAtomMap);
+      TEST_ASSERT(pth.size() == 9);
+      TEST_ASSERT(cAtomMap.size() == 9);
+      cAtomMap.clear();
 
+      pth = findBondEnvironmentOfRadiusN(*mH, 6, rootedAtBond, false, true, &cAtomMap);
+      TEST_ASSERT(pth.size() == 0);
+      TEST_ASSERT(cAtomMap.size() == 0);
+      cAtomMap.clear();
+    }
+
+  
     // ---------------------------------------------------------------------------------
-    // useHs = true, enforceSize = true
-    pth = findBondEnvironmentOfRadiusN(*mH, 0, rootedAtBond, true, false, &cAtomMap);
-    TEST_ASSERT(pth.size() == 1);
-    TEST_ASSERT(pth[0] == rootedAtBond);
-    TEST_ASSERT(cAtomMap.size() == 2);
-    TEST_ASSERT(cAtomMap[0] == 0);
-    TEST_ASSERT(cAtomMap[9] == 0);
-    cAtomMap.clear();
+    // useHs = true
+    {
+      pth = findBondEnvironmentOfRadiusN(*mH, 0, rootedAtBond, true, false, &cAtomMap);
+      TEST_ASSERT(pth.size() == 1);
+      TEST_ASSERT(pth[0] == rootedAtBond);
+      TEST_ASSERT(cAtomMap.size() == 2);
+      TEST_ASSERT(cAtomMap[0] == 0);
+      TEST_ASSERT(cAtomMap[9] == 0);
+      cAtomMap.clear();
 
-    pth = findBondEnvironmentOfRadiusN(*mH, 1, rootedAtBond, true, false, &cAtomMap);
-    TEST_ASSERT(pth.size() == 3);
-    TEST_ASSERT(cAtomMap.size() == 4);
-    cAtomMap.clear();
+      pth = findBondEnvironmentOfRadiusN(*mH, 1, rootedAtBond, true, false, &cAtomMap);
+      TEST_ASSERT(pth.size() == 3);
+      TEST_ASSERT(cAtomMap.size() == 4);
+      cAtomMap.clear();
 
-    pth = findBondEnvironmentOfRadiusN(*mH, 2, rootedAtBond, true, false, &cAtomMap);
-    TEST_ASSERT(pth.size() == 9);
-    TEST_ASSERT(cAtomMap.size() == 10);
-    cAtomMap.clear();
+      pth = findBondEnvironmentOfRadiusN(*mH, 2, rootedAtBond, true, false, &cAtomMap);
+      TEST_ASSERT(pth.size() == 9);
+      TEST_ASSERT(cAtomMap.size() == 10);
+      cAtomMap.clear();
 
-    pth = findBondEnvironmentOfRadiusN(*mH, 3, rootedAtBond, true, false, &cAtomMap);
-    TEST_ASSERT(pth.size() == 15);
-    TEST_ASSERT(cAtomMap.size() == 16);
-    cAtomMap.clear();
+      pth = findBondEnvironmentOfRadiusN(*mH, 3, rootedAtBond, true, false, &cAtomMap);
+      TEST_ASSERT(pth.size() == 15);
+      TEST_ASSERT(cAtomMap.size() == 16);
+      cAtomMap.clear();
 
-    pth = findBondEnvironmentOfRadiusN(*mH, 4, rootedAtBond, true, false, &cAtomMap);
-    TEST_ASSERT(pth.size() == 21);
-    TEST_ASSERT(cAtomMap.size() == 21);
-    cAtomMap.clear();
+      pth = findBondEnvironmentOfRadiusN(*mH, 4, rootedAtBond, true, false, &cAtomMap);
+      TEST_ASSERT(pth.size() == 21);
+      TEST_ASSERT(cAtomMap.size() == 21);
+      cAtomMap.clear();
+
+      pth = findBondEnvironmentOfRadiusN(*mH, 5, rootedAtBond, true, false, &cAtomMap);
+      TEST_ASSERT(pth.size() == 23);
+      TEST_ASSERT(cAtomMap.size() == 23);
+      cAtomMap.clear();
+
+      pth = findBondEnvironmentOfRadiusN(*mH, 6, rootedAtBond, true, false, &cAtomMap);
+      TEST_ASSERT(pth.size() == 23);
+      TEST_ASSERT(cAtomMap.size() == 23);
+      cAtomMap.clear();
+
+      pth = findBondEnvironmentOfRadiusN(*mH, 6, rootedAtBond, true, true, &cAtomMap);
+      TEST_ASSERT(pth.size() == 0);
+      TEST_ASSERT(cAtomMap.size() == 0);
+      cAtomMap.clear();
+    }
 
     // ---------------------------------------------------------------------------------
     // useHs = true, enforceSize = true: This is skipped

--- a/Code/GraphMol/Subgraphs/test2.cpp
+++ b/Code/GraphMol/Subgraphs/test2.cpp
@@ -338,7 +338,7 @@ void test4() {
     
     // ---------------------------------------------------------------------------------
     // useHs = false, enforceSize = false
-    pth = findBondEnvironmentOfRadiusN(*mH, 0, rootedAtBond, false, false, &cAtomMap)
+    pth = findBondEnvironmentOfRadiusN(*mH, 0, rootedAtBond, false, false, &cAtomMap);
     TEST_ASSERT(pth.size() == 1);
     TEST_ASSERT(pth[0] == rootedAtBond);
     TEST_ASSERT(cAtomMap.size() == 2);
@@ -346,39 +346,39 @@ void test4() {
     TEST_ASSERT(cAtomMap[9] == 0);
     cAtomMap.clear();
 
-    pth = findBondEnvironmentOfRadiusN(*mH, 1, rootedAtBond, false, false, &cAtomMap)
+    pth = findBondEnvironmentOfRadiusN(*mH, 1, rootedAtBond, false, false, &cAtomMap);
     TEST_ASSERT(pth.size() == 3);
     TEST_ASSERT(cAtomMap.size() == 4);
     cAtomMap.clear();
 
-    pth = findBondEnvironmentOfRadiusN(*mH, 2, rootedAtBond, false, false, &cAtomMap)
+    pth = findBondEnvironmentOfRadiusN(*mH, 2, rootedAtBond, false, false, &cAtomMap);
     TEST_ASSERT(pth.size() == 9);
     TEST_ASSERT(cAtomMap.size() == 10);
     cAtomMap.clear();
 
-    pth = findBondEnvironmentOfRadiusN(*mH, 3, rootedAtBond, false, false, &cAtomMap)
+    pth = findBondEnvironmentOfRadiusN(*mH, 3, rootedAtBond, false, false, &cAtomMap);
     TEST_ASSERT(pth.size() == 15);
     TEST_ASSERT(cAtomMap.size() == 16);
     cAtomMap.clear();
 
-    pth = findBondEnvironmentOfRadiusN(*mH, 4, rootedAtBond, false, false, &cAtomMap)
+    pth = findBondEnvironmentOfRadiusN(*mH, 4, rootedAtBond, false, false, &cAtomMap);
     TEST_ASSERT(pth.size() == 18);
     TEST_ASSERT(cAtomMap.size() == 19);
     cAtomMap.clear();
 
-    pth = findBondEnvironmentOfRadiusN(*mH, 5, rootedAtBond, false, false, &cAtomMap)
+    pth = findBondEnvironmentOfRadiusN(*mH, 5, rootedAtBond, false, false, &cAtomMap);
     TEST_ASSERT(pth.size() == 19);
     TEST_ASSERT(cAtomMap.size() == 20);
     cAtomMap.clear();
 
-    pth = findBondEnvironmentOfRadiusN(*mH, 6, rootedAtBond, false, false, &cAtomMap)
+    pth = findBondEnvironmentOfRadiusN(*mH, 6, rootedAtBond, false, false, &cAtomMap);
     TEST_ASSERT(pth.size() == 20);
     TEST_ASSERT(cAtomMap.size() == 21);
     cAtomMap.clear();
 
     // ---------------------------------------------------------------------------------
     // useHs = false, enforceSize = true
-    pth = findBondEnvironmentOfRadiusN(*mH, 0, rootedAtBond, false, true, &cAtomMap)
+    pth = findBondEnvironmentOfRadiusN(*mH, 0, rootedAtBond, false, true, &cAtomMap);
     TEST_ASSERT(pth.size() == 1);
     TEST_ASSERT(pth[0] == rootedAtBond);
     TEST_ASSERT(cAtomMap.size() == 2);
@@ -386,39 +386,39 @@ void test4() {
     TEST_ASSERT(cAtomMap[9] == 0);
     cAtomMap.clear();
 
-    pth = findBondEnvironmentOfRadiusN(*mH, 1, rootedAtBond, false, true, &cAtomMap)
+    pth = findBondEnvironmentOfRadiusN(*mH, 1, rootedAtBond, false, true, &cAtomMap);
     TEST_ASSERT(pth.size() == 3);
     TEST_ASSERT(cAtomMap.size() == 4);
     cAtomMap.clear();
 
-    pth = findBondEnvironmentOfRadiusN(*mH, 2, rootedAtBond, false, true, &cAtomMap)
+    pth = findBondEnvironmentOfRadiusN(*mH, 2, rootedAtBond, false, true, &cAtomMap);
     TEST_ASSERT(pth.size() == 9);
     TEST_ASSERT(cAtomMap.size() == 10);
     cAtomMap.clear();
 
-    pth = findBondEnvironmentOfRadiusN(*mH, 3, rootedAtBond, false, true, &cAtomMap)
+    pth = findBondEnvironmentOfRadiusN(*mH, 3, rootedAtBond, false, true, &cAtomMap);
     TEST_ASSERT(pth.size() == 15);
     TEST_ASSERT(cAtomMap.size() == 16);
     cAtomMap.clear();
 
-    pth = findBondEnvironmentOfRadiusN(*mH, 4, rootedAtBond, false, true, &cAtomMap)
+    pth = findBondEnvironmentOfRadiusN(*mH, 4, rootedAtBond, false, true, &cAtomMap);
     TEST_ASSERT(pth.size() == 18);
     TEST_ASSERT(cAtomMap.size() == 19);
     cAtomMap.clear();
 
-    pth = findBondEnvironmentOfRadiusN(*mH, 5, rootedAtBond, false, true, &cAtomMap)
+    pth = findBondEnvironmentOfRadiusN(*mH, 5, rootedAtBond, false, true, &cAtomMap);
     TEST_ASSERT(pth.size() == 19);
     TEST_ASSERT(cAtomMap.size() == 20);
     cAtomMap.clear();
 
-    pth = findBondEnvironmentOfRadiusN(*mH, 6, rootedAtBond, false, true, &cAtomMap)
+    pth = findBondEnvironmentOfRadiusN(*mH, 6, rootedAtBond, false, true, &cAtomMap);
     TEST_ASSERT(pth.size() == 20);
     TEST_ASSERT(cAtomMap.size() == 21);
     cAtomMap.clear();
 
     // ---------------------------------------------------------------------------------
     // useHs = true, enforceSize = false
-    pth = findBondEnvironmentOfRadiusN(*mH, 0, rootedAtBond, true, false, &cAtomMap)
+    pth = findBondEnvironmentOfRadiusN(*mH, 0, rootedAtBond, true, false, &cAtomMap);
     TEST_ASSERT(pth.size() == 1);
     TEST_ASSERT(pth[0] == rootedAtBond);
     TEST_ASSERT(cAtomMap.size() == 2);
@@ -426,22 +426,22 @@ void test4() {
     TEST_ASSERT(cAtomMap[9] == 0);
     cAtomMap.clear();
 
-    pth = findBondEnvironmentOfRadiusN(*mH, 1, rootedAtBond, true, false, &cAtomMap)
+    pth = findBondEnvironmentOfRadiusN(*mH, 1, rootedAtBond, true, false, &cAtomMap);
     TEST_ASSERT(pth.size() == 3);
     TEST_ASSERT(cAtomMap.size() == 4);
     cAtomMap.clear();
 
-    pth = findBondEnvironmentOfRadiusN(*mH, 2, rootedAtBond, true, false, &cAtomMap)
+    pth = findBondEnvironmentOfRadiusN(*mH, 2, rootedAtBond, true, false, &cAtomMap);
     TEST_ASSERT(pth.size() == 9);
     TEST_ASSERT(cAtomMap.size() == 10);
     cAtomMap.clear();
 
-    pth = findBondEnvironmentOfRadiusN(*mH, 3, rootedAtBond, true, false, &cAtomMap)
+    pth = findBondEnvironmentOfRadiusN(*mH, 3, rootedAtBond, true, false, &cAtomMap);
     TEST_ASSERT(pth.size() == 21);
     TEST_ASSERT(cAtomMap.size() == 22);
     cAtomMap.clear();
 
-    pth = findBondEnvironmentOfRadiusN(*mH, 4, rootedAtBond, true, false, &cAtomMap)
+    pth = findBondEnvironmentOfRadiusN(*mH, 4, rootedAtBond, true, false, &cAtomMap);
     TEST_ASSERT(pth.size() == 31);
     TEST_ASSERT(cAtomMap.size() == 32);
     cAtomMap.clear();
@@ -464,7 +464,7 @@ void test4() {
 
     // ---------------------------------------------------------------------------------
     // useHs = false
-    pth = findBondEnvironmentOfRadiusN(*mH, 0, rootedAtBond, false, false, &cAtomMap)
+    pth = findBondEnvironmentOfRadiusN(*mH, 0, rootedAtBond, false, false, &cAtomMap);
     TEST_ASSERT(pth.size() == 1);
     TEST_ASSERT(pth[0] == rootedAtBond);
     TEST_ASSERT(cAtomMap.size() == 2);
@@ -472,44 +472,44 @@ void test4() {
     TEST_ASSERT(cAtomMap[8] == 0);
     cAtomMap.clear();
 
-    pth = findBondEnvironmentOfRadiusN(*mH, 1, rootedAtBond, false, false, &cAtomMap)
+    pth = findBondEnvironmentOfRadiusN(*mH, 1, rootedAtBond, false, false, &cAtomMap);
     TEST_ASSERT(pth.size() == 3);
     TEST_ASSERT(cAtomMap.size() == 4);
     cAtomMap.clear();
 
-    pth = findBondEnvironmentOfRadiusN(*mH, 2, rootedAtBond, false, false, &cAtomMap)
+    pth = findBondEnvironmentOfRadiusN(*mH, 2, rootedAtBond, false, false, &cAtomMap);
     TEST_ASSERT(pth.size() == 5);
     TEST_ASSERT(cAtomMap.size() == 6);
     cAtomMap.clear();
 
-    pth = findBondEnvironmentOfRadiusN(*mH, 3, rootedAtBond, false, false, &cAtomMap)
+    pth = findBondEnvironmentOfRadiusN(*mH, 3, rootedAtBond, false, false, &cAtomMap);
     TEST_ASSERT(pth.size() == 7);
     TEST_ASSERT(cAtomMap.size() == 8);
     cAtomMap.clear();
 
-    pth = findBondEnvironmentOfRadiusN(*mH, 4, rootedAtBond, false, false, &cAtomMap)
+    pth = findBondEnvironmentOfRadiusN(*mH, 4, rootedAtBond, false, false, &cAtomMap);
     TEST_ASSERT(pth.size() == 9);
     TEST_ASSERT(cAtomMap.size() == 9);
     cAtomMap.clear();
 
-    pth = findBondEnvironmentOfRadiusN(*mH, 5, rootedAtBond, false, false, &cAtomMap)
+    pth = findBondEnvironmentOfRadiusN(*mH, 5, rootedAtBond, false, false, &cAtomMap);
     TEST_ASSERT(pth.size() == 9);
     TEST_ASSERT(cAtomMap.size() == 9);
     cAtomMap.clear();
 
-    pth = findBondEnvironmentOfRadiusN(*mH, 6, rootedAtBond, false, false, &cAtomMap)
+    pth = findBondEnvironmentOfRadiusN(*mH, 6, rootedAtBond, false, false, &cAtomMap);
     TEST_ASSERT(pth.size() == 9);
     TEST_ASSERT(cAtomMap.size() == 9);
     cAtomMap.clear();
 
-    pth = findBondEnvironmentOfRadiusN(*mH, 6, rootedAtBond, false, true, &cAtomMap)
+    pth = findBondEnvironmentOfRadiusN(*mH, 6, rootedAtBond, false, true, &cAtomMap);
     TEST_ASSERT(pth.size() == 0);
     TEST_ASSERT(cAtomMap.size() == 0);
     cAtomMap.clear();
 
     // ---------------------------------------------------------------------------------
     // useHs = true, enforceSize = true
-    pth = findBondEnvironmentOfRadiusN(*mH, 0, rootedAtBond, true, false, &cAtomMap)
+    pth = findBondEnvironmentOfRadiusN(*mH, 0, rootedAtBond, true, false, &cAtomMap);
     TEST_ASSERT(pth.size() == 1);
     TEST_ASSERT(pth[0] == rootedAtBond);
     TEST_ASSERT(cAtomMap.size() == 2);
@@ -517,22 +517,22 @@ void test4() {
     TEST_ASSERT(cAtomMap[9] == 0);
     cAtomMap.clear();
 
-    pth = findBondEnvironmentOfRadiusN(*mH, 1, rootedAtBond, true, false, &cAtomMap)
+    pth = findBondEnvironmentOfRadiusN(*mH, 1, rootedAtBond, true, false, &cAtomMap);
     TEST_ASSERT(pth.size() == 3);
     TEST_ASSERT(cAtomMap.size() == 4);
     cAtomMap.clear();
 
-    pth = findBondEnvironmentOfRadiusN(*mH, 2, rootedAtBond, true, false, &cAtomMap)
+    pth = findBondEnvironmentOfRadiusN(*mH, 2, rootedAtBond, true, false, &cAtomMap);
     TEST_ASSERT(pth.size() == 9);
     TEST_ASSERT(cAtomMap.size() == 10);
     cAtomMap.clear();
 
-    pth = findBondEnvironmentOfRadiusN(*mH, 3, rootedAtBond, true, false, &cAtomMap)
+    pth = findBondEnvironmentOfRadiusN(*mH, 3, rootedAtBond, true, false, &cAtomMap);
     TEST_ASSERT(pth.size() == 15);
     TEST_ASSERT(cAtomMap.size() == 16);
     cAtomMap.clear();
 
-    pth = findBondEnvironmentOfRadiusN(*mH, 4, rootedAtBond, true, false, &cAtomMap)
+    pth = findBondEnvironmentOfRadiusN(*mH, 4, rootedAtBond, true, false, &cAtomMap);
     TEST_ASSERT(pth.size() == 21);
     TEST_ASSERT(cAtomMap.size() == 21);
     cAtomMap.clear();
@@ -545,7 +545,6 @@ void test4() {
 
   std::cout << "Finished" << std::endl;
 }
-
 
 void testGithubIssue103() {
   std::cout << "-----------------------\n Testing github Issue103: "

--- a/Code/GraphMol/Wrap/MolOps.cpp
+++ b/Code/GraphMol/Wrap/MolOps.cpp
@@ -795,17 +795,17 @@ python::object findAllSubgraphsOfLengthsMtoNHelper(const ROMol &mol,
 PATH_TYPE findAtomEnvironmentOfRadiusNHelper(
   const ROMol &mol, unsigned int radius, unsigned int rootedAtAtom,
   bool useHs, bool enforceSize, python::object atomMap, 
-  python::object bondMap) {
+  python::object bondMap, bool assumeIsolatedHydro) {
   PATH_TYPE path;
   std::unordered_map<unsigned int, unsigned int> cBondMap;
 
   if (atomMap == python::object()) {
-    path = findAtomEnvironmentOfRadiusN(mol, radius, rootedAtAtom, useHs,
-                                        enforceSize, nullptr, &cBondMap);
+    path = findAtomEnvironmentOfRadiusN(mol, radius, rootedAtAtom, useHs, enforceSize, 
+                                        nullptr, &cBondMap, assumeIsolatedHydro);
   } else {
     std::unordered_map<unsigned int, unsigned int> cAtomMap;
-    path = findAtomEnvironmentOfRadiusN(mol, radius, rootedAtAtom, useHs,
-                                        enforceSize, &cAtomMap, &cBondMap);
+    path = findAtomEnvironmentOfRadiusN(mol, radius, rootedAtAtom, useHs, enforceSize, 
+                                        &cAtomMap, &cBondMap, assumeIsolatedHydro);
     // make sure the optional argument (atomMap) is actually a dictionary
     python::dict typecheck = python::extract<python::dict>(atomMap);
     atomMap.attr("clear")();
@@ -828,16 +828,16 @@ PATH_TYPE findAtomEnvironmentOfRadiusNHelper(
 PATH_TYPE findBondEnvironmentOfRadiusNHelper(
   const ROMol &mol, unsigned int radius, unsigned int rootedAtBond,
   bool useHs, bool enforceSize, python::object atomMap, 
-  python::object bondMap) {
+  python::object bondMap, bool assumeIsolatedHydro) {
   PATH_TYPE path;
   std::unordered_map<unsigned int, unsigned int> cBondMap;
   if (atomMap == python::object()) {
-    path = findBondEnvironmentOfRadiusN(mol, radius, rootedAtBond, useHs,
-                                        enforceSize);
+    path = findBondEnvironmentOfRadiusN(mol, radius, rootedAtBond, useHs, enforceSize, 
+                                        nullptr, &cBondMap, assumeIsolatedHydro);
   } else {
     std::unordered_map<unsigned int, unsigned int> cAtomMap;
-    path = findBondEnvironmentOfRadiusN(mol, radius, rootedAtBond, useHs,
-                                        enforceSize, &cAtomMap);
+    path = findBondEnvironmentOfRadiusN(mol, radius, rootedAtBond, useHs, enforceSize, 
+                                        &cAtomMap, &cBondMap, assumeIsolatedHydro);
     // make sure the optional argument (atomMap) is actually a dictionary
     python::dict typecheck = python::extract<python::dict>(atomMap);
     atomMap.attr("clear")();
@@ -1789,6 +1789,11 @@ to the terminal dummy atoms.\n\
       from the connected bond (start with 1). The result is a pair of \n\
       the bond ID and the distance. \n\
 \n\
+    - assumeIsolatedHydro: (optional) If True, the speed-up is achievable by assuming \n\
+      that all the hydrogen atoms (except the rooted atom) is located at the final node \n\
+      of branch in the molecular graph (one connected bond only) and is unable to \n\
+      traverse the graph. Default to False. \n\
+\n\
   RETURNS: a vector of bond IDs\n\
 \n";
     python::def(
@@ -1796,7 +1801,8 @@ to the terminal dummy atoms.\n\
         (python::arg("mol"), python::arg("radius"), python::arg("rootedAtAtom"),
          python::arg("useHs") = false, python::arg("enforceSize") = true,
          python::arg("atomMap") = python::object(), 
-         python::arg("bondMap") = python::object()),
+         python::arg("bondMap") = python::object(), 
+         python::arg("assumeIsolatedHydro") = false),
         docString.c_str());
 
     // ------------------------------------------------------------------------
@@ -1830,6 +1836,11 @@ to the terminal dummy atoms.\n\
       from the rooted bond (start with 0). The result is a pair of \n\
       the bond ID and the distance. \n\
 \n\
+    - assumeIsolatedHydro: (optional) If True, the speed-up is achievable by assuming \n\
+      that all the hydrogen atoms (except the rooted atom) is located at the final node \n\
+      of branch in the molecular graph (one connected bond only) and is unable to \n\
+      traverse the graph. Default to False. \n\
+\n\
   RETURNS: a vector of bond IDs\n\
 \n";
     python::def(
@@ -1837,7 +1848,8 @@ to the terminal dummy atoms.\n\
         (python::arg("mol"), python::arg("radius"), python::arg("rootedAtBond"),
          python::arg("useHs") = false, python::arg("enforceSize") = true,
          python::arg("atomMap") = python::object(), 
-         python::arg("bondMap") = python::object()),
+         python::arg("bondMap") = python::object(), 
+         python::arg("assumeIsolatedHydro") = false),
         docString.c_str());
 
     python::def("PathToSubmol", pathToSubmolHelper,


### PR DESCRIPTION
**Why does this PR:** 
I did the small project in which the properties of a particular atom inside a molecule can be predicted within a defined subgraph. The core idea worked well with `Subsgraph::findAtomEnvironmentOfRadiusN()`. But I don't like I have to write extra code to match up the `bondPath` and `radius`, so PR #4970 is introduced.

My second project is aimed on the particular bond (its property can also be predictable within a defined radius). 
In the legacy version, I have to merge the result from both connected atoms. Let's say the `bondID=5, atomIdx=(4, 5)`; thus I have to perform `Subsgraph::findAtomEnvironmentOfRadiusN()` twice and uniquely aggregating the result to run `pathToSubmol()`. Although there are zero issues arised but the time spent is relatively large `O(2 * (N*d))`. 

**What needed to be implemented** 
- Generalize the function `findAtomEnvironmentOfRadiusN()` into two smaller components which are `prepareNeighborStack()` and `findEnvironmentOfRadiusN()` into a private namespace.

**Result**
- Reduce time complexity from `2 * (N**d)` to `N**d + N`

**Future Work**
None, but if successfully, I wished the function `bond.getNeighborBonds()` or `bond.getBonds()` (by RDKit notation) can be implemented using the idea of `findBondEnvironmentOfRadiusN()`