### PR TITLE
Make the RGD code work when `rgroupLabelling` is `Isotope`

### DIFF
--- a/Code/GraphMol/RGroupDecomposition/RGroupDecomp.cpp
+++ b/Code/GraphMol/RGroupDecomposition/RGroupDecomp.cpp
@@ -454,7 +454,7 @@ RWMOL_SPTR RGroupDecomposition::outputCoreMolecule(
     if (atom->getAtomicNum()) {
       continue;
     }
-    auto label = atom->getAtomMapNum();
+    auto label = data->getRlabel(atom);
     Atom *nbrAtom = nullptr;
     for (const auto &nbri :
          boost::make_iterator_range(coreWithMatches->getAtomNeighbors(atom))) {

--- a/Code/GraphMol/RGroupDecomposition/RGroupDecompData.h
+++ b/Code/GraphMol/RGroupDecomposition/RGroupDecompData.h
@@ -77,7 +77,7 @@ struct RGroupDecompData {
   }
 
   void setRlabel(Atom *atom, int rlabel) {
-    PRECONDITION(rlabel != 0, "RLabels must be >0");
+    PRECONDITION(rlabel > 0, "RLabels must be >0");
     if (params.rgroupLabelling & AtomMap) {
       atom->setAtomMapNum(rlabel);
     }
@@ -89,8 +89,26 @@ struct RGroupDecompData {
     }
 
     if (params.rgroupLabelling & Isotope) {
-      atom->setIsotope(rlabel + 1);
+      atom->setIsotope(rlabel);
     }
+  }
+
+  int getRlabel(Atom *atom) const {
+    if (params.rgroupLabelling & AtomMap) {
+      return atom->getAtomMapNum();
+    }
+    if (params.rgroupLabelling & Isotope) {
+      return atom->getIsotope();
+    }
+
+    if (params.rgroupLabelling & MDLRGroup) {
+      unsigned int label = 0;
+      if (atom->getPropIfPresent(common_properties::_MolFileRLabel, label)) {
+        return label;
+      }
+    }
+
+    CHECK_INVARIANT(0, "no valid r label found");
   }
 
   double scoreFromPrunedData(const std::vector<size_t> &permutation,


### PR DESCRIPTION
Also fixes an off-by-one problem with the assigned isotope labels

Turns out we didn't have any tests for this so it never got caught.
