### PR TITLE
Fixes #5095

### DIFF
--- a/Code/PgSQL/rdkit/expected/props.out
+++ b/Code/PgSQL/rdkit/expected/props.out
@@ -232,7 +232,8 @@ SELECT mol_numrotatablebonds('CCCC'::mol) mol_numrotatablebonds;
                      1
 (1 row)
 
-SELECT mol_numrotatablebonds('c1ccccc1c1ccc(CCC)cc1'::mol) mol_numrotatablebonds;
+-- mol_from_smiles() shouldn't be necessary, but there's an RDKit bug
+SELECT mol_numrotatablebonds(mol_from_smiles('c1ccccc1c1ccc(CCC)cc1')) mol_numrotatablebonds;
  mol_numrotatablebonds 
 -----------------------
                      3

--- a/Code/PgSQL/rdkit/expected/rdkit-91.out
+++ b/Code/PgSQL/rdkit/expected/rdkit-91.out
@@ -111,8 +111,9 @@ SELECT mol_to_smiles(mol_from_smiles(''));
  
 (1 row)
 
-CREATE TABLE pgmol (id int, m mol);
-\copy pgmol from 'data/data'
+CREATE TABLE insmiles (id int, smiles text);
+\copy insmiles from 'data/data'
+SELECT id, mol_from_smiles(smiles::cstring) m into pgmol from insmiles;
 CREATE UNIQUE INDEX mol_ididx ON pgmol (id);
 SELECT count(*) FROM pgmol;
  count 
@@ -1398,5 +1399,52 @@ select mol_from_smiles('C=C')::qmol;
  mol_from_smiles 
 -----------------
  [#6]=[#6]
+(1 row)
+
+-- github #5095: cannot restore molecule
+select mol_in('c1cccc'::cstring);
+ERROR:  could not create molecule from SMILES 'c1cccc'
+select mol_in('c1cccc1'::cstring);
+ mol_in  
+---------
+ c1cccc1
+(1 row)
+
+select mol_in('c1co(C)cc1'::cstring);
+  mol_in  
+----------
+ Co1cccc1
+(1 row)
+
+select mol_in('c1cccc'::cstring);
+ERROR:  could not create molecule from SMILES 'c1cccc'
+select 'c1cccc1'::mol;
+   mol   
+---------
+ c1cccc1
+(1 row)
+
+select 'c1co(C)cc1'::mol;
+   mol    
+----------
+ Co1cccc1
+(1 row)
+
+select mol_in('c1cccc1'::cstring) @> '[r5]'::qmol;
+ ?column? 
+----------
+ t
+(1 row)
+
+select 'c1cccc1'::mol @> '[r5]'::qmol;
+ ?column? 
+----------
+ t
+(1 row)
+
+select mol_in('Cc1ccc2c(c1)-n1-c(=O)c=cc(=O)-n-2-c2cc(C)ccc2-1')
+                     mol_in                      
+-------------------------------------------------
+ Cc1ccc2c(c1)-n1-c(=O)c=cc(=O)-n-2-c2cc(C)ccc2-1
 (1 row)
 

--- a/Code/PgSQL/rdkit/rdkit.h
+++ b/Code/PgSQL/rdkit/rdkit.h
@@ -101,7 +101,8 @@ Mol *deconstructROMol(CROMol data);
 
 CROMol parseMolBlob(char *data, int len);
 char *makeMolBlob(CROMol data, int *len);
-CROMol parseMolText(char *data, bool asSmarts, bool warnOnFail, bool asQuery);
+/* sanitize argument is only used if asSmarts and asQuery are false */
+CROMol parseMolText(char *data, bool asSmarts, bool warnOnFail, bool asQuery, bool sanitize);
 CROMol parseMolCTAB(char *data, bool keepConformer, bool warnOnFail,
                     bool asQuery);
 char *makeMolText(CROMol data, int *len, bool asSmarts, bool cxSmiles);

--- a/Code/PgSQL/rdkit/rdkit_io.c
+++ b/Code/PgSQL/rdkit/rdkit_io.c
@@ -48,7 +48,7 @@ mol_in(PG_FUNCTION_ARGS) {
   CROMol  mol;
   Mol     *res;
 
-  mol = parseMolText(data,false,false,false);
+  mol = parseMolText(data,false,false,false,false);
   if(!mol){
     ereport(ERROR,
             (errcode(ERRCODE_DATA_EXCEPTION),
@@ -163,7 +163,7 @@ mol_from_smarts(PG_FUNCTION_ARGS) {
   CROMol  mol;
   Mol     *res;
 
-  mol = parseMolText(data,true,true,false);
+  mol = parseMolText(data,true,true,false,false);
   if (!mol) {
     PG_RETURN_NULL();
   }
@@ -181,7 +181,7 @@ mol_from_smiles(PG_FUNCTION_ARGS) {
   CROMol  mol;
   Mol     *res;
 
-  mol = parseMolText(data,false,true,false);
+  mol = parseMolText(data,false,true,false,true);
   if (!mol) {
     PG_RETURN_NULL();
   }
@@ -199,7 +199,7 @@ qmol_from_smiles(PG_FUNCTION_ARGS) {
   CROMol  mol;
   Mol     *res;
 
-  mol = parseMolText(data,false,true,true);
+  mol = parseMolText(data,false,true,true,false);
   if (!mol) {
     PG_RETURN_NULL();
   }
@@ -414,7 +414,7 @@ qmol_in(PG_FUNCTION_ARGS) {
   CROMol  mol;
   Mol     *res;
 
-  mol = parseMolText(data,true,false,false);
+  mol = parseMolText(data,true,false,false,false);
   if(!mol){
     ereport(ERROR,
             (errcode(ERRCODE_DATA_EXCEPTION),

--- a/Code/PgSQL/rdkit/sql/props.sql
+++ b/Code/PgSQL/rdkit/sql/props.sql
@@ -44,7 +44,8 @@ select mol_formula('[2H][13CH2]CO'::mol, true, false);
 --
 SELECT mol_numrotatablebonds('CCC'::mol) mol_numrotatablebonds;
 SELECT mol_numrotatablebonds('CCCC'::mol) mol_numrotatablebonds;
-SELECT mol_numrotatablebonds('c1ccccc1c1ccc(CCC)cc1'::mol) mol_numrotatablebonds;
+-- mol_from_smiles() shouldn't be necessary, but there's an RDKit bug
+SELECT mol_numrotatablebonds(mol_from_smiles('c1ccccc1c1ccc(CCC)cc1')) mol_numrotatablebonds;
 SELECT mol_numheavyatoms('CCC'::mol) val;
 SELECT mol_numatoms('CCC'::mol) val;
 SELECT mol_numheteroatoms('CCC'::mol) val;

--- a/Code/PgSQL/rdkit/sql/rdkit-91.sql
+++ b/Code/PgSQL/rdkit/sql/rdkit-91.sql
@@ -28,8 +28,9 @@ SELECT mol_from_smiles('');
 SELECT mol_to_smiles(mol_from_smiles(''));
 
 
-CREATE TABLE pgmol (id int, m mol);
-\copy pgmol from 'data/data'
+CREATE TABLE insmiles (id int, smiles text);
+\copy insmiles from 'data/data'
+SELECT id, mol_from_smiles(smiles::cstring) m into pgmol from insmiles;
 
 CREATE UNIQUE INDEX mol_ididx ON pgmol (id);
 
@@ -475,3 +476,14 @@ select qmol_from_smiles('C1C'::cstring);
 
 -- casting from mol to qmol
 select mol_from_smiles('C=C')::qmol;
+
+-- github #5095: cannot restore molecule
+select mol_in('c1cccc'::cstring);
+select mol_in('c1cccc1'::cstring);
+select mol_in('c1co(C)cc1'::cstring);
+select mol_in('c1cccc'::cstring);
+select 'c1cccc1'::mol;
+select 'c1co(C)cc1'::mol;
+select mol_in('c1cccc1'::cstring) @> '[r5]'::qmol;
+select 'c1cccc1'::mol @> '[r5]'::qmol;
+select mol_in('Cc1ccc2c(c1)-n1-c(=O)c=cc(=O)-n-2-c2cc(C)ccc2-1')

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -11,6 +11,7 @@
   molecule and before calculating the hash. Previous versions would still
   include information about atom/bond stereochemistry in the output hash even if
   that no longer applies in the modified molecule.
+- In the PostgreSQL cartridge the `::mol` typecast operator and `mol_in()` function no longer perform full sanitization of the molecule. If you want to convert text to a molecule with full sanitization, use the `mol_from_smiles()` function.
 
 ## Code removed in this release:
 - The `useCountSimulation` keyword argument for


### PR DESCRIPTION
We now treat the input smiles passed to `mol_in()` or the `::mol` cast operator as trusted SMILES and do not do full sanitization.
