### PR TITLE
Fixes #5017

### DIFF
--- a/rdkit/Chem/PandasTools.py
+++ b/rdkit/Chem/PandasTools.py
@@ -197,19 +197,19 @@ def patchPandasrepr(self, **kwargs):
   global defPandasGetAdjustment
 
   import pandas.io.formats.html
-  if not hasattr(pandas.io.formats.html.HTMLFormatter, "_rdkitpatched"):
-    defHTMLFormatter_write_cell = pd.io.formats.html.HTMLFormatter._write_cell
-    pd.io.formats.html.HTMLFormatter._write_cell = _patched_HTMLFormatter_write_cell
-    pandas.io.formats.html.HTMLFormatter._rdkitpatched = True
-  get_adjustment_attr = getAdjustmentAttr()
-  if get_adjustment_attr:
-    defPandasGetAdjustment = getattr(pd.io.formats.format, get_adjustment_attr)
-    setattr(pd.io.formats.format, get_adjustment_attr, _patched_get_adjustment)
-  res = defPandasRepr(self, **kwargs)
-  if get_adjustment_attr:
-    setattr(pd.io.formats.format, get_adjustment_attr, defPandasGetAdjustment)
-  pd.io.formats.html.HTMLFormatter._write_cell = defHTMLFormatter_write_cell
-  return res
+  defHTMLFormatter_write_cell = pd.io.formats.html.HTMLFormatter._write_cell
+  pd.io.formats.html.HTMLFormatter._write_cell = _patched_HTMLFormatter_write_cell
+  try:
+    get_adjustment_attr = getAdjustmentAttr()
+    if get_adjustment_attr:
+      defPandasGetAdjustment = getattr(pd.io.formats.format, get_adjustment_attr)
+      setattr(pd.io.formats.format, get_adjustment_attr, _patched_get_adjustment)
+    res = defPandasRepr(self, **kwargs)
+    if get_adjustment_attr:
+      setattr(pd.io.formats.format, get_adjustment_attr, defPandasGetAdjustment)
+    return res
+  finally:
+    pd.io.formats.html.HTMLFormatter._write_cell = defHTMLFormatter_write_cell
 
 
 def patchPandasHTMLrepr(self, **kwargs):


### PR DESCRIPTION
#### Reference Issue
This PR fixes #5017

#### What does this implement/fix? Explain your changes.
`patchPandasrepr()` patches `pd.io.formats.html.HTMLFormatter._write_cell()`, then it restores the original function before returning. However, while doing so, it also sets an `_rdkitpatched` attribute on `pandas.io.formats.html.HTMLFormatter`.
The next time patchPandasrepr() is called, the patch is not applied anymore due to the present of the `_rdkitpatched` attribute, even though the patch has actually been reverted.
This explains why the DataFrame displays molecules as PNG images only the first time.
The fix is removing the usage of `_rdkitpatched` attribute entirely as it is not necessary, since the patch is applied and then reverted. Instead, a `try..finally` block is used to make sure that the patch is reverted before returning even if an exception is raised.

After this PR, running the test described in #5017 yields the desired behavior:

```
from rdkit import Chem
from IPython.display import HTML
from rdkit.Chem import PandasTools
import pandas as pd

import rdkit
rdkit.__version__
'2022.03.1pre'

df = pd.DataFrame(dict(a=[1], s=['CCN']))
PandasTools.AddMoleculeColumnToFrame(df, smilesCol='s', molCol='m')
df
```
![image](https://user-images.githubusercontent.com/5244385/158797975-895b2069-e74f-4e28-95ed-8977ae7c55cd.png)
```
df
```
![image](https://user-images.githubusercontent.com/5244385/158797975-895b2069-e74f-4e28-95ed-8977ae7c55cd.png)
```
PandasTools.RenderImagesInAllDataFrames(False)
df
```
![image](https://user-images.githubusercontent.com/5244385/158798128-042f8410-85c6-43fe-8075-f58ad40e8d2a.png)
```
df
```
![image](https://user-images.githubusercontent.com/5244385/158798128-042f8410-85c6-43fe-8075-f58ad40e8d2a.png)
```
PandasTools.RenderImagesInAllDataFrames(True)
df
```
![image](https://user-images.githubusercontent.com/5244385/158797975-895b2069-e74f-4e28-95ed-8977ae7c55cd.png)
```
df
```
![image](https://user-images.githubusercontent.com/5244385/158797975-895b2069-e74f-4e28-95ed-8977ae7c55cd.png)
