### PR TITLE
Cleanup of python API documentation stubs

### DIFF
--- a/Docs/Book/source/rdkit.Chem.DSViewer.rst
+++ b/Docs/Book/source/rdkit.Chem.DSViewer.rst
@@ -1,7 +1,0 @@
-rdkit.Chem.DSViewer module
-==========================
-
-.. automodule:: rdkit.Chem.DSViewer
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/Docs/Book/source/rdkit.Chem.Draw.rdMolDraw2DQt.rst
+++ b/Docs/Book/source/rdkit.Chem.Draw.rdMolDraw2DQt.rst
@@ -1,0 +1,7 @@
+rdkit.Chem.Draw.rdMolDraw2DQt module
+====================================
+
+.. automodule:: rdkit.Chem.Draw.rdMolDraw2DQt
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/Docs/Book/source/rdkit.Chem.Draw.rst
+++ b/Docs/Book/source/rdkit.Chem.Draw.rst
@@ -10,6 +10,7 @@ Submodules
    rdkit.Chem.Draw.MolDrawing
    rdkit.Chem.Draw.SimilarityMaps
    rdkit.Chem.Draw.rdMolDraw2D
+   rdkit.Chem.Draw.rdMolDraw2DQt
    rdkit.Chem.Draw.aggCanvas
    rdkit.Chem.Draw.cairoCanvas
    rdkit.Chem.Draw.canvasbase

--- a/Docs/Book/source/rdkit.Chem.Pharm2D.LazyGenerator.rst
+++ b/Docs/Book/source/rdkit.Chem.Pharm2D.LazyGenerator.rst
@@ -1,7 +1,0 @@
-rdkit.Chem.Pharm2D.LazyGenerator module
-=======================================
-
-.. automodule:: rdkit.Chem.Pharm2D.LazyGenerator
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/Docs/Book/source/rdkit.Chem.Pharm2D.rst
+++ b/Docs/Book/source/rdkit.Chem.Pharm2D.rst
@@ -8,7 +8,6 @@ Submodules
 
    rdkit.Chem.Pharm2D.Generate
    rdkit.Chem.Pharm2D.Gobbi_Pharm2D
-   rdkit.Chem.Pharm2D.LazyGenerator
    rdkit.Chem.Pharm2D.Matcher
    rdkit.Chem.Pharm2D.SigFactory
    rdkit.Chem.Pharm2D.Utils

--- a/Docs/Book/source/rdkit.Chem.Subshape.rst
+++ b/Docs/Book/source/rdkit.Chem.Subshape.rst
@@ -10,7 +10,6 @@ Submodules
    rdkit.Chem.Subshape.SubshapeAligner
    rdkit.Chem.Subshape.SubshapeBuilder
    rdkit.Chem.Subshape.SubshapeObjects
-   rdkit.Chem.Subshape.testCombined
 
 Module contents
 ---------------

--- a/Docs/Book/source/rdkit.Chem.Subshape.testCombined.rst
+++ b/Docs/Book/source/rdkit.Chem.Subshape.testCombined.rst
@@ -1,7 +1,0 @@
-rdkit.Chem.Subshape.testCombined module
-=======================================
-
-.. automodule:: rdkit.Chem.Subshape.testCombined
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/Docs/Book/source/rdkit.Chem.rdEHTTools.rst
+++ b/Docs/Book/source/rdkit.Chem.rdEHTTools.rst
@@ -1,0 +1,8 @@
+rdkit.Chem.rdEHTTools module
+============================
+
+.. automodule:: rdkit.Chem.rdEHTTools
+    :members:
+    :undoc-members:
+    :show-inheritance:
+

--- a/Docs/Book/source/rdkit.Chem.rdStructChecker.rst
+++ b/Docs/Book/source/rdkit.Chem.rdStructChecker.rst
@@ -1,8 +1,0 @@
-rdkit.Chem.rdStructChecker module
-=================================
-
-.. automodule:: rdkit.Chem.rdStructChecker
-    :members:
-    :undoc-members:
-    :show-inheritance:
-

--- a/Docs/Book/source/rdkit.Chem.rst
+++ b/Docs/Book/source/rdkit.Chem.rst
@@ -104,9 +104,10 @@ Submodules
    rdkit.Chem.rdSLNParse
    rdkit.Chem.rdAbbreviations
    rdkit.Chem.rdDeprotect
-   rdkit.Chem.rdMolEnumerator.rst
-   rdkit.Chem.rdCIPLabeler.rst
-   rdkit.Chem.rdTautomerQuery.rst
+   rdkit.Chem.rdMolEnumerator
+   rdkit.Chem.rdCIPLabeler
+   rdkit.Chem.rdTautomerQuery
+   rdkit.Chem.rdEHTTools
 
 Module contents
 ---------------

--- a/Docs/Book/source/rdkit.DataStructs.HierarchyVis.rst
+++ b/Docs/Book/source/rdkit.DataStructs.HierarchyVis.rst
@@ -1,7 +1,0 @@
-rdkit.DataStructs.HierarchyVis module
-=====================================
-
-.. automodule:: rdkit.DataStructs.HierarchyVis
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/Docs/Book/source/rdkit.DataStructs.rst
+++ b/Docs/Book/source/rdkit.DataStructs.rst
@@ -9,7 +9,6 @@ Submodules
    rdkit.DataStructs.BitEnsemble
    rdkit.DataStructs.BitEnsembleDb
    rdkit.DataStructs.BitUtils
-   rdkit.DataStructs.HierarchyVis
    rdkit.DataStructs.LazySignature
    rdkit.DataStructs.TopNContainer
    rdkit.DataStructs.VectCollection

--- a/Docs/Book/source/rdkit.ML.Data.cQuantize.rst
+++ b/Docs/Book/source/rdkit.ML.Data.cQuantize.rst
@@ -1,0 +1,7 @@
+rdkit.ML.Data.cQuantize module
+==============================
+
+.. automodule:: rdkit.ML.Data.cQuantize
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/Docs/Book/source/rdkit.ML.Data.rst
+++ b/Docs/Book/source/rdkit.ML.Data.rst
@@ -10,6 +10,7 @@ Submodules
    rdkit.ML.Data.FindQuantBounds
    rdkit.ML.Data.MLData
    rdkit.ML.Data.Quantize
+   rdkit.ML.Data.cQuantize
    rdkit.ML.Data.SplitData
    rdkit.ML.Data.Stats
    rdkit.ML.Data.Transforms

--- a/Docs/Book/source/rdkit.ML.DecTree.randomtest.rst
+++ b/Docs/Book/source/rdkit.ML.DecTree.randomtest.rst
@@ -1,7 +1,0 @@
-rdkit.ML.DecTree.randomtest module
-==================================
-
-.. automodule:: rdkit.ML.DecTree.randomtest
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/Docs/Book/source/rdkit.ML.DecTree.rst
+++ b/Docs/Book/source/rdkit.ML.DecTree.rst
@@ -18,7 +18,6 @@ Submodules
    rdkit.ML.DecTree.Tree
    rdkit.ML.DecTree.TreeUtils
    rdkit.ML.DecTree.TreeVis
-   rdkit.ML.DecTree.randomtest
 
 Module contents
 ---------------

--- a/Docs/Book/source/rdkit.VLib.NodeLib.demo.rst
+++ b/Docs/Book/source/rdkit.VLib.NodeLib.demo.rst
@@ -1,7 +1,0 @@
-rdkit.VLib.NodeLib.demo module
-==============================
-
-.. automodule:: rdkit.VLib.NodeLib.demo
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/Docs/Book/source/rdkit.VLib.NodeLib.rst
+++ b/Docs/Book/source/rdkit.VLib.NodeLib.rst
@@ -14,7 +14,6 @@ Submodules
    rdkit.VLib.NodeLib.SmilesDupeFilter
    rdkit.VLib.NodeLib.SmilesOutput
    rdkit.VLib.NodeLib.SmilesSupply
-   rdkit.VLib.NodeLib.demo
 
 Module contents
 ---------------

--- a/Docs/Book/source/rdkit.utils.chemdraw.rst
+++ b/Docs/Book/source/rdkit.utils.chemdraw.rst
@@ -1,7 +1,0 @@
-rdkit.utils.chemdraw module
-===========================
-
-.. automodule:: rdkit.utils.chemdraw
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/Docs/Book/source/rdkit.utils.chemdraw_qax.rst
+++ b/Docs/Book/source/rdkit.utils.chemdraw_qax.rst
@@ -1,7 +1,0 @@
-rdkit.utils.chemdraw\_qax module
-================================
-
-.. automodule:: rdkit.utils.chemdraw_qax
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/Docs/Book/source/rdkit.utils.comhack.rst
+++ b/Docs/Book/source/rdkit.utils.comhack.rst
@@ -1,7 +1,0 @@
-rdkit.utils.comhack module
-==========================
-
-.. automodule:: rdkit.utils.comhack
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/Docs/Book/source/rdkit.utils.rst
+++ b/Docs/Book/source/rdkit.utils.rst
@@ -7,10 +7,7 @@ Submodules
 .. toctree::
 
    rdkit.utils.cactvs
-   rdkit.utils.chemdraw
-   rdkit.utils.chemdraw_qax
    rdkit.utils.chemutils
-   rdkit.utils.comhack
    rdkit.utils.fileutils
    rdkit.utils.listutils
    rdkit.utils.spiral


### PR DESCRIPTION
This removes files referencing modules which either no longer exist or for which the doc-generation just doesn't work and adds a couple stubs for modules which were missing.
