### PR TITLE
Add a couple of depiction helper functions and some JS bindings

### DIFF
--- a/Code/GraphMol/Depictor/RDDepictor.cpp
+++ b/Code/GraphMol/Depictor/RDDepictor.cpp
@@ -174,6 +174,11 @@ void _shiftCoords(std::list<EmbeddedFrag> &efrags) {
     ++eri;
   }
 }
+
+// we do not use std::copysign as we need a tolerance
+double copySign(double to, double from, double tol) {
+  return (from < -tol ? -fabs(to) : fabs(to));
+}
 }  // namespace DepictorLocal
 
 void computeInitialCoords(RDKit::ROMol &mol,
@@ -622,5 +627,132 @@ void generateDepictionMatching3DStructure(RDKit::ROMol &mol,
 
   RDDepict::compute2DCoordsMimicDistMat(mol, &dmat, false, true, 0.5, 3, 100,
                                         25, true, forceRDKit);
+}
+
+void straightenDepiction(RDKit::ROMol &mol, int confId, bool smallestRotation) {
+  constexpr double RAD2DEG = 180. / M_PI;
+  constexpr double DEG2RAD = M_PI / 180.;
+  constexpr double INCR_DEG = 30.;
+  constexpr double HALF_INCR_DEG = 0.5 * INCR_DEG;
+  constexpr double TOL_DEG = 5.0;
+  constexpr double ALMOST_ZERO = 1.e-5;
+  auto &conf = mol.getConformer(confId);
+  auto &pos = conf.getPositions();
+  std::unordered_map<int, std::pair<unsigned int, double>> thetaBins;
+  std::vector<double> thetaValues;
+  thetaValues.reserve(mol.getNumBonds());
+  for (const auto b : mol.bonds()) {
+    auto bi = b->getBeginAtomIdx();
+    auto ei = b->getEndAtomIdx();
+    auto bv = pos.at(bi) - pos.at(ei);
+    bv.x = (bv.x < 0.) ? std::min(-ALMOST_ZERO, bv.x)
+                       : std::max(ALMOST_ZERO, bv.x);
+    auto theta = RAD2DEG * atan(bv.y / bv.x);
+    auto d_theta = fmod(-theta, INCR_DEG);
+    if (fabs(d_theta) > HALF_INCR_DEG) {
+      d_theta -= DepictorLocal::copySign(INCR_DEG, d_theta, ALMOST_ZERO);
+    }
+    int thetaKey = static_cast<int>(
+        d_theta + DepictorLocal::copySign(0.5, d_theta, ALMOST_ZERO));
+    auto it = thetaBins.find(thetaKey);
+    if (it == thetaBins.end()) {
+      it = thetaBins.emplace(thetaKey, std::make_pair(0U, 0.0)).first;
+    }
+    ++it->second.first;
+    it->second.second += d_theta;
+    thetaValues.push_back(theta);
+  }
+  unsigned int maxCount = 0;
+  double d_thetaMin = 0.;
+  for (const auto &it : thetaBins) {
+    const auto count = it.second.first;
+    const auto d_thetaAvg = it.second.second / static_cast<double>(count);
+    if (count > maxCount ||
+        (count == maxCount && fabs(d_thetaAvg) < fabs(d_thetaMin))) {
+      maxCount = count;
+      d_thetaMin = d_thetaAvg;
+    }
+  }
+  unsigned int n30 =
+      std::count_if(thetaValues.begin(), thetaValues.end(),
+                    [d_thetaMin, INCR_DEG, TOL_DEG](double theta) {
+                      theta += d_thetaMin;
+                      return (fabs(fmod(theta, INCR_DEG)) < TOL_DEG);
+                    });
+  unsigned int n60 = std::count_if(
+      thetaValues.begin(), thetaValues.end(),
+      [d_thetaMin, INCR_DEG, TOL_DEG](double theta) {
+        theta += d_thetaMin;
+        return (fabs(fmod(theta, INCR_DEG)) < TOL_DEG &&
+                !(abs(static_cast<int>(
+                      theta / INCR_DEG +
+                      DepictorLocal::copySign(0.5, theta, ALMOST_ZERO))) %
+                  2));
+      });
+  bool shouldRotate = (n60 > n30 / 2);
+  if (shouldRotate && !smallestRotation) {
+    d_thetaMin -= DepictorLocal::copySign(INCR_DEG, d_thetaMin, ALMOST_ZERO);
+  }
+  d_thetaMin *= DEG2RAD;
+  RDGeom::Transform3D trans;
+  trans.SetRotation(d_thetaMin, RDGeom::Z_Axis);
+  MolTransforms::transformConformer(conf, trans);
+}
+
+double normalizeDepiction(RDKit::ROMol &mol, int confId, int canonicalize,
+                          double scaleFactor) {
+  auto &conf = mol.getConformer(confId);
+  if (scaleFactor < 0.0) {
+    constexpr double RDKIT_BOND_LEN = 1.5;
+    int mostCommonBondLengthInt = -1;
+    unsigned int maxCount = 0;
+    std::unordered_map<int, unsigned int> binnedBondLengths;
+    for (const auto b : mol.bonds()) {
+      int bondLength =
+          static_cast<int>(MolTransforms::getBondLength(
+                               conf, b->getBeginAtomIdx(), b->getEndAtomIdx()) *
+                               10.0 +
+                           0.5);
+      auto it = binnedBondLengths.find(bondLength);
+      if (it == binnedBondLengths.end()) {
+        it = binnedBondLengths.emplace(bondLength, 0U).first;
+      }
+      ++it->second;
+      if (it->second > maxCount) {
+        maxCount = it->second;
+        mostCommonBondLengthInt = it->first;
+      }
+    }
+    if (!binnedBondLengths.empty()) {
+      double mostCommonBondLength =
+          static_cast<double>(mostCommonBondLengthInt) * 0.1;
+      scaleFactor = RDKIT_BOND_LEN / mostCommonBondLength;
+    }
+  }
+  boost::shared_ptr<RDGeom::Transform3D> canonTrans;
+  boost::shared_ptr<RDGeom::Transform3D> trans;
+  if (canonicalize == 0 || canonicalize == 1) {
+    auto ctd = MolTransforms::computeCentroid(conf);
+    canonTrans.reset(MolTransforms::computeCanonicalTransform(conf, &ctd));
+    if (canonicalize == 1) {
+      boost::shared_ptr<RDGeom::Transform3D> rotate90(
+          new RDGeom::Transform3D());
+      rotate90->SetRotation(0., 1., RDGeom::Point3D(0., 0., 1.));
+      *canonTrans *= *rotate90;
+    }
+    trans = canonTrans;
+  }
+  if (scaleFactor > 0. && fabs(scaleFactor - 1.0) > 1.e-5) {
+    trans.reset(new RDGeom::Transform3D());
+    trans->setVal(0, 0, scaleFactor);
+    trans->setVal(1, 1, scaleFactor);
+    if (canonTrans.get()) {
+      *trans *= *canonTrans;
+    }
+  }
+  if (trans.get()) {
+    MolTransforms::transformConformer(conf, *trans);
+  }
+  return scaleFactor;
 }
 }  // namespace RDDepict

--- a/Code/GraphMol/Depictor/RDDepictor.h
+++ b/Code/GraphMol/Depictor/RDDepictor.h
@@ -236,6 +236,59 @@ RDKIT_DEPICTOR_EXPORT void generateDepictionMatching3DStructure(
     RDKit::ROMol &mol, const RDKit::ROMol &reference, int confId = -1,
     RDKit::ROMol *referencePattern = nullptr, bool acceptFailure = false,
     bool forceRDKit = false);
+
+//! \brief Rotate the 2D depiction such that the majority bonds have an angle
+//   with the X axis which is a multiple of 30 degrees.
+/*!
+  Generates a depiction for a molecule where a piece of the molecule
+  is constrained to have coordinates similar to those of a 3D reference
+  structure.
+
+  ARGUMENTS:
+  \param mol - the molecule to be rotated
+  \param confId - (optional) the id of the reference conformation to use
+  \param smallestRotation - (optional) if true, the smallest rotation that
+                            leads to the majority of bonds having an angle which
+                            is a multiple of 30 degrees will be chosen.
+                            If false, and the angle is 0, a larger rotation that
+                            leads to an angle of 30 degrees will be chosen
+*/
+
+RDKIT_DEPICTOR_EXPORT void straightenDepiction(RDKit::ROMol &mol,
+                                               int confId = -1,
+                                               bool smallestRotation = false);
+
+//! \brief Normalizes the 2D depiction.
+/*!
+  If canonicalize is >= 0, the depiction is subjected to a canonical
+  transformation. If canonicalize is 0 or 1, following the canonical
+  tranformation, the depiction is rotated by 90 degrees if needed, such that its
+  main axis is aligned along the X (0) or Y (1) axis. If scaleFactor is <0.0
+  (the default) the depiction is scaled such that bond lengths conform to RDKit
+  standards. The applied scaling factor is returned.
+
+  ARGUMENTS:
+  \param mol          - the molecule to be normalized
+  \param confId       - (optional) the id of the reference conformation to use
+  \param canonicalize - (optional) if 0 or 1, a canonical transformation is
+                        applied, If 0 (the default), the main molecule axis is
+                        aligned to the X axis.
+                        if 1, the canonical orientation is rotated by 90-degree
+                        to align the main molecule axis to the Y axis.
+                        If <0 or >1, no canonical transformation is applied.
+  \param scaleFactor  - (optional) if >0.0, the scaling factor to apply. The
+                        default (-1.0) means that the depiction is automatically
+                        scaled such that bond lengths are the standard RDKit
+                        ones.
+  RETURNS:
+
+  \return the applied scaling factor.
+*/
+
+RDKIT_DEPICTOR_EXPORT double normalizeDepiction(RDKit::ROMol &mol,
+                                                int confId = -1,
+                                                int canonicalize = 0,
+                                                double scaleFactor = -1.0);
 };  // namespace RDDepict
 
 #endif

--- a/Code/GraphMol/Depictor/Wrap/rdDepictor.cpp
+++ b/Code/GraphMol/Depictor/Wrap/rdDepictor.cpp
@@ -321,4 +321,49 @@ BOOST_PYTHON_MODULE(rdDepictor) {
        python::arg("refPatt") = python::object(),
        python::arg("acceptFailure") = false, python::arg("forceRDKit") = false),
       docString.c_str());
+
+  docString =
+      "Rotate the 2D depiction such that the majority bonds have an angle \n\
+  with the X axis which is a multiple of 30 degrees.\n\
+  ARGUMENTS: \n\n\
+  mol -    the molecule to be rotated. \n\
+  confId -       (optional) the id of the reference conformation to use \n\
+  smallestRotation -  (optional) if True, the smallest rotation that \n\
+                  leads to the majority of bonds having an angle which \n\
+                  is multiple of 30 degrees will be chosen.\n\
+                  If False, and the angle is 0, a larger rotation that \n\
+                  leads to an angle of 30 degrees will be chosen";
+
+  python::def("StraightenDepiction", RDDepict::straightenDepiction,
+              (python::arg("mol"), python::arg("confId") = -1,
+               python::arg("smallestRotation") = false),
+              docString.c_str());
+
+  docString =
+      "Normalizes the 2D depiction.\n\
+If canonicalize is >= 0, the depiction is subjected to a canonical\n\
+transformation. If canonicalize is 0 or 1, following the canonical\n\
+tranformation, the depiction is rotated by 90 degrees if needed, such that its\n\
+main axis is aligned along the X (0) or Y (1) axis. If scaleFactor is <0.0\n\
+(the default) the depiction is scaled such that bond lengths conform to RDKit\n\
+standards. The applied scaling factor is returned.\n\n\
+ARGUMENTS:\n\n\
+mol          - the molecule to be normalized\n\
+confId       - (optional) the id of the reference conformation to use\n\
+canonicalize - (optional) if 0 or 1, a canonical transformation is\n\
+               applied, If 0 (the default), the main molecule axis is aligned\n\
+               to the X axis.\n\
+               if 1, the canonical orientation is rotated by 90-degree\n\
+               to align the main molecule axis to the Y axis.\n\
+               If >1, no canonical transformation is applied.\n\
+scaleFactor  - (optional) if >0.0, the scaling factor to apply. The default\n\
+               (-1.0) means that the depiction is automatically scaled\n\
+               such that bond lengths are the standard RDKit ones.\n\n\
+RETURNS: the applied scaling factor.";
+
+  python::def(
+      "NormalizeDepiction", RDDepict::normalizeDepiction,
+      (python::arg("mol"), python::arg("confId") = -1,
+       python::arg("canonicalize") = 0, python::arg("scaleFactor") = -1.),
+      docString.c_str());
 }

--- a/Code/GraphMol/Depictor/Wrap/testDepictor.py
+++ b/Code/GraphMol/Depictor/Wrap/testDepictor.py
@@ -389,7 +389,6 @@ M  END"""
   6  1  1  0
 M  END""")
         genericRefPatternWithRGroups = Chem.MolFromSmarts("[*:3]a1a([*:1])aa([*:2])aa1")
-        pyridineRefHs = Chem.AddHs(pyridineRef)
 
         for mol in (ortho, meta, biphenyl, phenyl):
             atomMap = rdDepictor.GenerateDepictionMatching2DStructure(
@@ -401,6 +400,123 @@ M  END""")
                         mol.GetConformer().GetAtomPosition(molIdx)).LengthSq()
             msd /= len(atomMap)
             self.assertAlmostEqual(msd, 0.0)
+
+    def testNormalizeStraighten(self):
+        def computeRmsd(c1, c2):
+            self.assertEqual(c1.GetNumAtoms(), c2.GetNumAtoms())
+            msd = 0.0
+            for i in range(c1.GetNumAtoms()):
+                msd += (c1.GetAtomPosition(i) - c2.GetAtomPosition(i)).LengthSq()
+            msd /= c1.GetNumAtoms()
+            return np.sqrt(msd)
+
+        noradrenalineMJ = Chem.MolFromMolBlock("""
+  MJ201100                      
+
+ 12 12  0  0  1  0  0  0  0  0999 V2000
+    2.2687    1.0716    0.0000 N   0  0  0  0  0  0  0  0  0  0  0  0
+    1.4437    1.0716    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    1.0312    0.3572    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    1.4437   -0.3572    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
+    0.2062    0.3572    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -0.2062   -0.3572    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -1.0312   -0.3572    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -1.4437   -1.0716    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
+   -1.4437    0.3572    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -2.2687    0.3572    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
+   -1.0312    1.0716    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -0.2062    1.0716    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+  1  2  1  0  0  0  0
+  3  2  1  0  0  0  0
+  3  4  1  6  0  0  0
+  3  5  1  0  0  0  0
+  5  6  2  0  0  0  0
+  6  7  1  0  0  0  0
+  7  8  1  0  0  0  0
+  7  9  2  0  0  0  0
+  9 10  1  0  0  0  0
+  9 11  1  0  0  0  0
+ 11 12  2  0  0  0  0
+  5 12  1  0  0  0  0
+M  END)""")
+
+        noradrenalineMJCopy = Chem.Mol(noradrenalineMJ)
+        conformerCopy = Chem.Conformer(noradrenalineMJCopy.GetConformer())
+        noradrenalineMJCopy.AddConformer(conformerCopy, True)
+        self.assertAlmostEqual(computeRmsd(noradrenalineMJ.GetConformer(0), noradrenalineMJCopy.GetConformer(0)), 0., 3)
+        self.assertAlmostEqual(computeRmsd(noradrenalineMJ.GetConformer(0), noradrenalineMJCopy.GetConformer(1)), 0., 3)
+        scalingFactor = rdDepictor.NormalizeDepiction(noradrenalineMJCopy, 1)
+        self.assertAlmostEqual(computeRmsd(noradrenalineMJ.GetConformer(0), noradrenalineMJCopy.GetConformer(0)), 0.0, 3)
+        self.assertGreater(computeRmsd(noradrenalineMJ.GetConformer(0), noradrenalineMJCopy.GetConformer(1)), 0.1)
+        self.assertAlmostEqual(scalingFactor, 1.875, 3)
+        bond10_11Conf0 = noradrenalineMJCopy.GetConformer(0).GetAtomPosition(11) - noradrenalineMJCopy.GetConformer(0).GetAtomPosition(10)
+        self.assertAlmostEqual(bond10_11Conf0.x, 0.825, 3)
+        self.assertAlmostEqual(bond10_11Conf0.y, 0., 3)
+        bond10_11Conf1 = noradrenalineMJCopy.GetConformer(1).GetAtomPosition(11) - noradrenalineMJCopy.GetConformer(1).GetAtomPosition(10)
+        self.assertAlmostEqual(bond10_11Conf1.x, 1.513, 3)
+        self.assertAlmostEqual(bond10_11Conf1.y, -0.321, 3)
+        rdDepictor.StraightenDepiction(noradrenalineMJCopy, 1, True)
+        bond10_11Conf1 = noradrenalineMJCopy.GetConformer(1).GetAtomPosition(11) - noradrenalineMJCopy.GetConformer(1).GetAtomPosition(10)
+        self.assertAlmostEqual(bond10_11Conf1.x, 1.547, 3)
+        self.assertAlmostEqual(bond10_11Conf1.y, 0., 3)
+        rdDepictor.StraightenDepiction(noradrenalineMJCopy, 1, False)
+        bond10_11Conf1 = noradrenalineMJCopy.GetConformer(1).GetAtomPosition(11) - noradrenalineMJCopy.GetConformer(1).GetAtomPosition(10)
+        self.assertAlmostEqual(bond10_11Conf1.x, 1.34, 3)
+        self.assertAlmostEqual(bond10_11Conf1.y, -0.773, 3)
+        bond4_11Conf1 = noradrenalineMJCopy.GetConformer(1).GetAtomPosition(11) - noradrenalineMJCopy.GetConformer(1).GetAtomPosition(4)
+        self.assertAlmostEqual(bond4_11Conf1.x, 0., 3)
+        self.assertAlmostEqual(bond4_11Conf1.y, 1.547, 3)
+
+        noradrenalineMJCopy = Chem.Mol(noradrenalineMJ)
+        conformerCopy = Chem.Conformer(noradrenalineMJCopy.GetConformer())
+        noradrenalineMJCopy.AddConformer(conformerCopy, True)
+        self.assertAlmostEqual(computeRmsd(noradrenalineMJ.GetConformer(0), noradrenalineMJCopy.GetConformer(0)), 0., 3)
+        self.assertAlmostEqual(computeRmsd(noradrenalineMJ.GetConformer(0), noradrenalineMJCopy.GetConformer(1)), 0., 3)
+        scalingFactor = rdDepictor.NormalizeDepiction(noradrenalineMJCopy, 1, 1)
+        self.assertAlmostEqual(computeRmsd(noradrenalineMJ.GetConformer(0), noradrenalineMJCopy.GetConformer(0)), 0.0, 3)
+        self.assertGreater(computeRmsd(noradrenalineMJ.GetConformer(0), noradrenalineMJCopy.GetConformer(1)), 0.1)
+        self.assertAlmostEqual(scalingFactor, 1.875, 3)
+        bond10_11Conf0 = noradrenalineMJCopy.GetConformer(0).GetAtomPosition(11) - noradrenalineMJCopy.GetConformer(0).GetAtomPosition(10)
+        self.assertAlmostEqual(bond10_11Conf0.x, 0.825, 3)
+        self.assertAlmostEqual(bond10_11Conf0.y, 0., 3)
+        bond10_11Conf1 = noradrenalineMJCopy.GetConformer(1).GetAtomPosition(11) - noradrenalineMJCopy.GetConformer(1).GetAtomPosition(10)
+        self.assertAlmostEqual(bond10_11Conf1.x, 0.321, 3)
+        self.assertAlmostEqual(bond10_11Conf1.y, 1.513, 3)
+        rdDepictor.StraightenDepiction(noradrenalineMJCopy, 1, True)
+        bond10_11Conf1 = noradrenalineMJCopy.GetConformer(1).GetAtomPosition(11) - noradrenalineMJCopy.GetConformer(1).GetAtomPosition(10)
+        self.assertAlmostEqual(bond10_11Conf1.x, 0., 3)
+        self.assertAlmostEqual(bond10_11Conf1.y, 1.547, 3)
+        rdDepictor.StraightenDepiction(noradrenalineMJCopy, 1, False)
+        bond10_11Conf1 = noradrenalineMJCopy.GetConformer(1).GetAtomPosition(11) - noradrenalineMJCopy.GetConformer(1).GetAtomPosition(10)
+        self.assertAlmostEqual(bond10_11Conf1.x, 0., 3)
+        self.assertAlmostEqual(bond10_11Conf1.y, 1.547, 3)
+
+        noradrenalineMJCopy = Chem.Mol(noradrenalineMJ)
+        conformerCopy = Chem.Conformer(noradrenalineMJCopy.GetConformer())
+        noradrenalineMJCopy.AddConformer(conformerCopy, True)
+        self.assertAlmostEqual(computeRmsd(noradrenalineMJ.GetConformer(0), noradrenalineMJCopy.GetConformer(0)), 0., 3)
+        self.assertAlmostEqual(computeRmsd(noradrenalineMJ.GetConformer(0), noradrenalineMJCopy.GetConformer(1)), 0., 3)
+        scalingFactor = rdDepictor.NormalizeDepiction(noradrenalineMJCopy, 1, -1, 3.0)
+        self.assertAlmostEqual(computeRmsd(noradrenalineMJ.GetConformer(0), noradrenalineMJCopy.GetConformer(0)), 0.0, 3)
+        self.assertGreater(computeRmsd(noradrenalineMJ.GetConformer(0), noradrenalineMJCopy.GetConformer(1)), 0.1)
+        self.assertAlmostEqual(scalingFactor, 3., 3)
+        bond10_11Conf0 = noradrenalineMJCopy.GetConformer(0).GetAtomPosition(11) - noradrenalineMJCopy.GetConformer(0).GetAtomPosition(10)
+        self.assertAlmostEqual(bond10_11Conf0.x, 0.825, 3)
+        self.assertAlmostEqual(bond10_11Conf0.y, 0., 3)
+        bond10_11Conf1 = noradrenalineMJCopy.GetConformer(1).GetAtomPosition(11) - noradrenalineMJCopy.GetConformer(1).GetAtomPosition(10)
+        self.assertAlmostEqual(bond10_11Conf1.x, 2.475, 3)
+        self.assertAlmostEqual(bond10_11Conf1.y, 0., 3)
+        rdDepictor.StraightenDepiction(noradrenalineMJCopy, 1, True)
+        bond10_11Conf1 = noradrenalineMJCopy.GetConformer(1).GetAtomPosition(11) - noradrenalineMJCopy.GetConformer(1).GetAtomPosition(10)
+        self.assertAlmostEqual(bond10_11Conf1.x, 2.475, 3)
+        self.assertAlmostEqual(bond10_11Conf1.y, 0., 3)
+        rdDepictor.StraightenDepiction(noradrenalineMJCopy, 1, False)
+        bond10_11Conf1 = noradrenalineMJCopy.GetConformer(1).GetAtomPosition(11) - noradrenalineMJCopy.GetConformer(1).GetAtomPosition(10)
+        self.assertAlmostEqual(bond10_11Conf1.x, 2.143, 3)
+        self.assertAlmostEqual(bond10_11Conf1.y, -1.237, 3)
+        bond4_11Conf1 = noradrenalineMJCopy.GetConformer(1).GetAtomPosition(11) - noradrenalineMJCopy.GetConformer(1).GetAtomPosition(4)
+        self.assertAlmostEqual(bond4_11Conf1.x, 0., 3)
+        self.assertAlmostEqual(bond4_11Conf1.y, 2.475, 3)
 
 if __name__ == '__main__':
     rdDepictor.SetPreferCoordGen(False)

--- a/Code/GraphMol/Depictor/testDepictor.cpp
+++ b/Code/GraphMol/Depictor/testDepictor.cpp
@@ -1291,6 +1291,158 @@ M  END)RES"_ctab;
   BOOST_LOG(rdInfoLog) << "Finished" << std::endl;
 }
 
+void testNormalizeStraighten() {
+  BOOST_LOG(rdInfoLog)
+      << "-----------------------\n Test normalize and straighten depiction"
+      << std::endl;
+
+  struct Rmsd {
+    static double compute(const Conformer &c1, const Conformer &c2) {
+      TEST_ASSERT(c1.getNumAtoms() == c2.getNumAtoms());
+      double msd = 0.0;
+      for (unsigned int i = 0; i < c1.getNumAtoms(); ++i) {
+        msd += (c1.getAtomPos(i) - c2.getAtomPos(i)).lengthSq();
+      }
+      msd /= static_cast<double>(c1.getNumAtoms());
+      return sqrt(msd);
+    }
+  };
+
+  auto noradrenalineMJ = R"RES(
+  MJ201100                      
+
+ 12 12  0  0  1  0  0  0  0  0999 V2000
+    2.2687    1.0716    0.0000 N   0  0  0  0  0  0  0  0  0  0  0  0
+    1.4437    1.0716    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    1.0312    0.3572    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    1.4437   -0.3572    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
+    0.2062    0.3572    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -0.2062   -0.3572    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -1.0312   -0.3572    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -1.4437   -1.0716    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
+   -1.4437    0.3572    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -2.2687    0.3572    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
+   -1.0312    1.0716    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -0.2062    1.0716    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+  1  2  1  0  0  0  0
+  3  2  1  0  0  0  0
+  3  4  1  6  0  0  0
+  3  5  1  0  0  0  0
+  5  6  2  0  0  0  0
+  6  7  1  0  0  0  0
+  7  8  1  0  0  0  0
+  7  9  2  0  0  0  0
+  9 10  1  0  0  0  0
+  9 11  1  0  0  0  0
+ 11 12  2  0  0  0  0
+  5 12  1  0  0  0  0
+M  END)RES"_ctab;
+  {
+    auto noradrenalineMJCopy =
+        std::unique_ptr<RWMol>(new RWMol(*noradrenalineMJ));
+    auto conformerCopy = new Conformer(noradrenalineMJCopy->getConformer());
+    noradrenalineMJCopy->addConformer(conformerCopy, true);
+    TEST_ASSERT(Rmsd::compute(noradrenalineMJ->getConformer(0),
+                              noradrenalineMJCopy->getConformer(0)) < 1.e-5);
+    TEST_ASSERT(Rmsd::compute(noradrenalineMJ->getConformer(0),
+                              noradrenalineMJCopy->getConformer(1)) < 1.e-5);
+    auto scalingFactor = RDDepict::normalizeDepiction(*noradrenalineMJCopy, 1);
+    TEST_ASSERT(Rmsd::compute(noradrenalineMJ->getConformer(0),
+                              noradrenalineMJCopy->getConformer(0)) < 1.e-5);
+    TEST_ASSERT(Rmsd::compute(noradrenalineMJ->getConformer(0),
+                              noradrenalineMJCopy->getConformer(1)) > 1.e-5);
+    TEST_ASSERT(static_cast<int>(std::round(scalingFactor * 1.e3)) == 1875);
+    auto bond10_11Conf0 = noradrenalineMJCopy->getConformer(0).getAtomPos(11) -
+                          noradrenalineMJCopy->getConformer(0).getAtomPos(10);
+    TEST_ASSERT(static_cast<int>(std::round(bond10_11Conf0.x * 1.e3)) == 825);
+    TEST_ASSERT(static_cast<int>(std::round(bond10_11Conf0.y * 1.e3)) == 0);
+    auto bond10_11Conf1 = noradrenalineMJCopy->getConformer(1).getAtomPos(11) -
+                          noradrenalineMJCopy->getConformer(1).getAtomPos(10);
+    TEST_ASSERT(static_cast<int>(std::round(bond10_11Conf1.x * 1.e3)) == 1513);
+    TEST_ASSERT(static_cast<int>(std::round(bond10_11Conf1.y * 1.e3)) == -321);
+    RDDepict::straightenDepiction(*noradrenalineMJCopy, 1, true);
+    bond10_11Conf1 = noradrenalineMJCopy->getConformer(1).getAtomPos(11) -
+                     noradrenalineMJCopy->getConformer(1).getAtomPos(10);
+    TEST_ASSERT(static_cast<int>(std::round(bond10_11Conf1.x * 1.e3)) == 1547);
+    TEST_ASSERT(static_cast<int>(std::round(bond10_11Conf1.y * 1.e3)) == 0);
+    RDDepict::straightenDepiction(*noradrenalineMJCopy, 1, false);
+    bond10_11Conf1 = noradrenalineMJCopy->getConformer(1).getAtomPos(11) -
+                     noradrenalineMJCopy->getConformer(1).getAtomPos(10);
+    TEST_ASSERT(static_cast<int>(std::round(bond10_11Conf1.x * 1.e3)) == 1340);
+    TEST_ASSERT(static_cast<int>(std::round(bond10_11Conf1.y * 1.e3)) == -773);
+    auto bond4_11Conf1 = noradrenalineMJCopy->getConformer(1).getAtomPos(11) -
+                         noradrenalineMJCopy->getConformer(1).getAtomPos(4);
+    TEST_ASSERT(static_cast<int>(std::round(bond4_11Conf1.x * 1.e3)) == 0);
+    TEST_ASSERT(static_cast<int>(std::round(bond4_11Conf1.y * 1.e3)) == 1547);
+  }
+  {
+    auto noradrenalineMJCopy =
+        std::unique_ptr<RWMol>(new RWMol(*noradrenalineMJ));
+    auto conformerCopy = new Conformer(noradrenalineMJCopy->getConformer());
+    noradrenalineMJCopy->addConformer(conformerCopy, true);
+    auto scalingFactor =
+        RDDepict::normalizeDepiction(*noradrenalineMJCopy, 1, 1);
+    TEST_ASSERT(Rmsd::compute(noradrenalineMJ->getConformer(0),
+                              noradrenalineMJCopy->getConformer(0)) < 1.e-5);
+    TEST_ASSERT(Rmsd::compute(noradrenalineMJ->getConformer(0),
+                              noradrenalineMJCopy->getConformer(1)) > 1.e-5);
+    TEST_ASSERT(static_cast<int>(std::round(scalingFactor * 1.e3)) == 1875);
+    auto bond10_11Conf0 = noradrenalineMJCopy->getConformer(0).getAtomPos(11) -
+                          noradrenalineMJCopy->getConformer(0).getAtomPos(10);
+    TEST_ASSERT(static_cast<int>(std::round(bond10_11Conf0.x * 1.e3)) == 825);
+    TEST_ASSERT(static_cast<int>(std::round(bond10_11Conf0.y * 1.e3)) == 0);
+    auto bond10_11Conf1 = noradrenalineMJCopy->getConformer(1).getAtomPos(11) -
+                          noradrenalineMJCopy->getConformer(1).getAtomPos(10);
+    TEST_ASSERT(static_cast<int>(std::round(bond10_11Conf1.x * 1.e3)) == 321);
+    TEST_ASSERT(static_cast<int>(std::round(bond10_11Conf1.y * 1.e3)) == 1513);
+    RDDepict::straightenDepiction(*noradrenalineMJCopy, 1, true);
+    bond10_11Conf1 = noradrenalineMJCopy->getConformer(1).getAtomPos(11) -
+                     noradrenalineMJCopy->getConformer(1).getAtomPos(10);
+    TEST_ASSERT(static_cast<int>(std::round(bond10_11Conf1.x * 1.e3)) == 0);
+    TEST_ASSERT(static_cast<int>(std::round(bond10_11Conf1.y * 1.e3)) == 1547);
+    RDDepict::straightenDepiction(*noradrenalineMJCopy, 1, false);
+    bond10_11Conf1 = noradrenalineMJCopy->getConformer(1).getAtomPos(11) -
+                     noradrenalineMJCopy->getConformer(1).getAtomPos(10);
+    TEST_ASSERT(static_cast<int>(std::round(bond10_11Conf1.x * 1.e3)) == 0);
+    TEST_ASSERT(static_cast<int>(std::round(bond10_11Conf1.y * 1.e3)) == 1547);
+  }
+  {
+    auto noradrenalineMJCopy =
+        std::unique_ptr<RWMol>(new RWMol(*noradrenalineMJ));
+    auto conformerCopy = new Conformer(noradrenalineMJCopy->getConformer());
+    noradrenalineMJCopy->addConformer(conformerCopy, true);
+    auto scalingFactor =
+        RDDepict::normalizeDepiction(*noradrenalineMJCopy, 1, -1, 3.0);
+    TEST_ASSERT(Rmsd::compute(noradrenalineMJ->getConformer(0),
+                              noradrenalineMJCopy->getConformer(0)) < 1.e-5);
+    TEST_ASSERT(Rmsd::compute(noradrenalineMJ->getConformer(0),
+                              noradrenalineMJCopy->getConformer(1)) > 1.e-5);
+    TEST_ASSERT(static_cast<int>(std::round(scalingFactor * 1.e3)) == 3000);
+    auto bond10_11Conf0 = noradrenalineMJCopy->getConformer(0).getAtomPos(11) -
+                          noradrenalineMJCopy->getConformer(0).getAtomPos(10);
+    TEST_ASSERT(static_cast<int>(std::round(bond10_11Conf0.x * 1.e3)) == 825);
+    TEST_ASSERT(static_cast<int>(std::round(bond10_11Conf0.y * 1.e3)) == 0);
+    auto bond10_11Conf1 = noradrenalineMJCopy->getConformer(1).getAtomPos(11) -
+                          noradrenalineMJCopy->getConformer(1).getAtomPos(10);
+    TEST_ASSERT(static_cast<int>(std::round(bond10_11Conf1.x * 1.e3)) == 2475);
+    TEST_ASSERT(static_cast<int>(std::round(bond10_11Conf1.y * 1.e3)) == 0);
+    RDDepict::straightenDepiction(*noradrenalineMJCopy, 1, true);
+    bond10_11Conf1 = noradrenalineMJCopy->getConformer(1).getAtomPos(11) -
+                     noradrenalineMJCopy->getConformer(1).getAtomPos(10);
+    TEST_ASSERT(static_cast<int>(std::round(bond10_11Conf1.x * 1.e3)) == 2475);
+    TEST_ASSERT(static_cast<int>(std::round(bond10_11Conf1.y * 1.e3)) == 0);
+    RDDepict::straightenDepiction(*noradrenalineMJCopy, 1, false);
+    bond10_11Conf1 = noradrenalineMJCopy->getConformer(1).getAtomPos(11) -
+                     noradrenalineMJCopy->getConformer(1).getAtomPos(10);
+    TEST_ASSERT(static_cast<int>(std::round(bond10_11Conf1.x * 1.e3)) == 2143);
+    TEST_ASSERT(static_cast<int>(std::round(bond10_11Conf1.y * 1.e3)) == -1237);
+    auto bond4_11Conf1 = noradrenalineMJCopy->getConformer(1).getAtomPos(11) -
+                         noradrenalineMJCopy->getConformer(1).getAtomPos(4);
+    TEST_ASSERT(static_cast<int>(std::round(bond4_11Conf1.x * 1.e3)) == 0);
+    TEST_ASSERT(static_cast<int>(std::round(bond4_11Conf1.y * 1.e3)) == 2475);
+  }
+}
+
 int main() {
 #ifdef RDK_BUILD_COORDGEN_SUPPORT
   RDDepict::preferCoordGen = false;
@@ -1493,6 +1645,7 @@ int main() {
   testGithub2027();
   testGenerate2DDepictionRefPatternMatchVect();
   testGenerate2DDepictionAllowRGroups();
+  testNormalizeStraighten();
 
   return (0);
 }

--- a/Code/GraphMol/FileParsers/MolFileParser.cpp
+++ b/Code/GraphMol/FileParsers/MolFileParser.cpp
@@ -1418,7 +1418,7 @@ Atom *ParseMolFileAtomLine(const std::string text, RDGeom::Point3D &pos,
       res->setAtomicNum(0);
     }
     if (massDiff == 0 && symb[0] == 'R') {
-      if (symb.length() > 1) {
+      if (symb.length() > 1 && symb >= "R0" && symb <= "R99") {
         std::string rlabel = "";
         rlabel = symb.substr(1, symb.length() - 1);
         int rnumber;

--- a/Code/MinimalLib/common.h
+++ b/Code/MinimalLib/common.h
@@ -131,6 +131,7 @@ RWMol *mol_from_input(const std::string &input,
   }
   return res;
 }
+
 RWMol *mol_from_input(const std::string &input, const char *details_json) {
   std::string json;
   if (details_json) {
@@ -173,6 +174,7 @@ RWMol *qmol_from_input(const std::string &input,
   }
   return res;
 }
+
 RWMol *qmol_from_input(const std::string &input, const char *details_json) {
   std::string json;
   if (details_json) {
@@ -184,7 +186,7 @@ RWMol *qmol_from_input(const std::string &input, const char *details_json) {
 std::string process_details(const std::string &details, int &width, int &height,
                             int &offsetx, int &offsety, std::string &legend,
                             std::vector<int> &atomIds,
-                            std::vector<int> &bondIds) {
+                            std::vector<int> &bondIds, bool &kekulize) {
   rj::Document doc;
   doc.Parse(details.c_str());
   if (!doc.IsObject()) return "Invalid JSON";
@@ -243,6 +245,15 @@ std::string process_details(const std::string &details, int &width, int &height,
     legend = doc["legend"].GetString();
   }
 
+  if (doc.HasMember("kekulize")) {
+    if (!doc["kekulize"].IsBool()) {
+      return "JSON contains 'kekulize' field, but it is not a bool";
+    }
+    kekulize = doc["kekulize"].GetBool();
+  } else {
+    kekulize = true;
+  }
+
   return "";
 }
 
@@ -272,15 +283,28 @@ void get_sss_json(const ROMol &d_mol, const ROMol &q_mol,
   obj.AddMember("bonds", rjBonds, doc.GetAllocator());
 }
 
+void prepare_and_draw_mol(MolDraw2D &d2d, const ROMol &mol,
+                          const std::string &legend,
+                          const std::vector<int> &atomIds,
+                          const std::vector<int> &bondIds, bool kekulize) {
+  RWMol cpy(mol);
+  MolDraw2DUtils::prepareMolForDrawing(cpy, kekulize);
+  bool savedFlag = d2d.drawOptions().prepareMolsBeforeDrawing;
+  d2d.drawOptions().prepareMolsBeforeDrawing = false;
+  d2d.drawMolecule(cpy, legend, &atomIds, &bondIds);
+  d2d.drawOptions().prepareMolsBeforeDrawing = savedFlag;
+}
+
 std::string mol_to_svg(const ROMol &m, int w, int h,
                        const std::string &details = "") {
   std::vector<int> atomIds;
   std::vector<int> bondIds;
   std::string legend = "";
   int offsetx = 0, offsety = 0;
+  bool kekulize = true;
   if (!details.empty()) {
     auto problems = process_details(details, w, h, offsetx, offsety, legend,
-                                    atomIds, bondIds);
+                                    atomIds, bondIds, kekulize);
     if (!problems.empty()) {
       return problems;
     }
@@ -292,7 +316,7 @@ std::string mol_to_svg(const ROMol &m, int w, int h,
   }
   drawer.setOffset(offsetx, offsety);
 
-  MolDraw2DUtils::prepareAndDrawMolecule(drawer, m, legend, &atomIds, &bondIds);
+  prepare_and_draw_mol(drawer, m, legend, atomIds, bondIds, kekulize);
   drawer.finishDrawing();
 
   return drawer.getDrawingText();

--- a/Code/MinimalLib/jswrapper.cpp
+++ b/Code/MinimalLib/jswrapper.cpp
@@ -24,8 +24,13 @@ extern std::string process_details(const std::string &details, int &width,
                                    int &height, int &offsetx, int &offsety,
                                    std::string &legend,
                                    std::vector<int> &atomIds,
-                                   std::vector<int> &bondIds);
-}
+                                   std::vector<int> &bondIds, bool &kekulize);
+extern void prepare_and_draw_mol(MolDraw2D &d2d, const ROMol &mol,
+                                 const std::string &legend,
+                                 const std::vector<int> &atomIds,
+                                 const std::vector<int> &bondIds,
+                                 bool kekulize);
+}  // namespace MinimalLib
 }  // namespace RDKit
 
 namespace {
@@ -68,8 +73,9 @@ std::string draw_to_canvas_with_highlights(JSMol &self, emscripten::val canvas,
   int offsetx = 0;
   int offsety = 0;
   std::string legend = "";
-  auto problems = MinimalLib::process_details(details, w, h, offsetx, offsety,
-                                              legend, atomIds, bondIds);
+  bool kekulize;
+  auto problems = MinimalLib::process_details(
+      details, w, h, offsetx, offsety, legend, atomIds, bondIds, kekulize);
   if (!problems.empty()) {
     return problems;
   }
@@ -80,8 +86,8 @@ std::string draw_to_canvas_with_highlights(JSMol &self, emscripten::val canvas,
   }
   d2d->setOffset(offsetx, offsety);
 
-  MolDraw2DUtils::prepareAndDrawMolecule(*d2d, *self.d_mol, legend, &atomIds,
-                                         &bondIds);
+  MinimalLib::prepare_and_draw_mol(*d2d, *self.d_mol, legend, atomIds, bondIds,
+                                   kekulize);
   delete d2d;
   return "";
 }
@@ -90,10 +96,20 @@ JSMol *get_mol_no_details(const std::string &input) {
   return get_mol(input, std::string());
 }
 
-emscripten::val get_morgan_fp_as_uint8array(const JSMol &self,
-                                            unsigned int radius,
-                                            unsigned int fplen) {
-  std::string fp = self.get_morgan_fp_as_binary_text(radius, fplen);
+emscripten::val get_as_uint8array(const JSMol &self) {
+  auto pickle = self.get_pickle();
+  emscripten::val view(emscripten::typed_memory_view(
+      pickle.size(), reinterpret_cast<const unsigned char *>(pickle.c_str())));
+  auto res = emscripten::val::global("Uint8Array").new_(pickle.size());
+  res.call<void>("set", view);
+  return res;
+}
+
+JSMol *get_mol_from_uint8array(const emscripten::val &pickleAsUInt8Array) {
+  return get_mol_from_pickle(pickleAsUInt8Array.as<std::string>());
+}
+
+emscripten::val get_fp_as_uint8array(const std::string &fp) {
   emscripten::val view(emscripten::typed_memory_view(
       fp.size(), reinterpret_cast<const unsigned char *>(fp.c_str())));
   auto res = emscripten::val::global("Uint8Array").new_(fp.size());
@@ -101,8 +117,25 @@ emscripten::val get_morgan_fp_as_uint8array(const JSMol &self,
   return res;
 }
 
+emscripten::val get_morgan_fp_as_uint8array(const JSMol &self,
+                                            unsigned int radius,
+                                            unsigned int fplen) {
+  std::string fp = self.get_morgan_fp_as_binary_text(radius, fplen);
+  return get_fp_as_uint8array(fp);
+}
+
 emscripten::val get_morgan_fp_as_uint8array(const JSMol &self) {
   return get_morgan_fp_as_uint8array(self, 2, 2048);
+}
+
+emscripten::val get_pattern_fp_as_uint8array(const JSMol &self,
+                                             unsigned int fplen) {
+  std::string fp = self.get_pattern_fp_as_binary_text(fplen);
+  return get_fp_as_uint8array(fp);
+}
+
+emscripten::val get_pattern_fp_as_uint8array(const JSMol &self) {
+  return get_pattern_fp_as_uint8array(self, 2048);
 }
 
 }  // namespace
@@ -111,12 +144,14 @@ using namespace emscripten;
 EMSCRIPTEN_BINDINGS(RDKit_minimal) {
   class_<JSMol>("Mol")
       .function("is_valid", &JSMol::is_valid)
+      .function("has_coords", &JSMol::has_coords)
       .function("get_smiles", &JSMol::get_smiles)
       .function("get_cxsmiles", &JSMol::get_cxsmiles)
       .function("get_smarts", &JSMol::get_smarts)
       .function("get_cxsmarts", &JSMol::get_cxsmarts)
       .function("get_molblock", &JSMol::get_molblock)
       .function("get_v3Kmolblock", &JSMol::get_v3Kmolblock)
+      .function("get_as_uint8array", &get_as_uint8array)
       .function("get_inchi", &JSMol::get_inchi)
       .function("get_json", &JSMol::get_json)
       .function("get_svg",
@@ -137,6 +172,12 @@ EMSCRIPTEN_BINDINGS(RDKit_minimal) {
                 select_overload<emscripten::val(const JSMol &, unsigned int,
                                                 unsigned int)>(
                     get_morgan_fp_as_uint8array))
+      .function("get_pattern_fp_as_uint8array",
+                select_overload<emscripten::val(const JSMol &)>(
+                    get_pattern_fp_as_uint8array))
+      .function("get_pattern_fp_as_uint8array",
+                select_overload<emscripten::val(const JSMol &, unsigned int)>(
+                    get_pattern_fp_as_uint8array))
 #endif
       .function("get_substruct_match", &JSMol::get_substruct_match)
       .function("get_substruct_matches", &JSMol::get_substruct_matches)
@@ -146,13 +187,22 @@ EMSCRIPTEN_BINDINGS(RDKit_minimal) {
       .function("get_morgan_fp",
                 select_overload<std::string(unsigned int, unsigned int) const>(
                     &JSMol::get_morgan_fp))
+      .function("get_pattern_fp",
+                select_overload<std::string() const>(&JSMol::get_pattern_fp))
+      .function("get_pattern_fp",
+                select_overload<std::string(unsigned int) const>(
+                    &JSMol::get_pattern_fp))
 
       // functionality primarily useful in ketcher
       .function("get_stereo_tags", &JSMol::get_stereo_tags)
       .function("get_aromatic_form", &JSMol::get_aromatic_form)
       .function("get_kekule_form", &JSMol::get_kekule_form)
+      .function("set_new_coords",
+                select_overload<bool()>(&JSMol::set_new_coords))
       .function("get_new_coords",
                 select_overload<std::string() const>(&JSMol::get_new_coords))
+      .function("set_new_coords",
+                select_overload<bool(bool)>(&JSMol::set_new_coords))
       .function("get_new_coords", select_overload<std::string(bool) const>(
                                       &JSMol::get_new_coords))
       .function("generate_aligned_coords",
@@ -173,7 +223,17 @@ EMSCRIPTEN_BINDINGS(RDKit_minimal) {
                 select_overload<std::string(double, bool)>(
                     &JSMol::condense_abbreviations))
       .function("add_hs", &JSMol::add_hs)
-      .function("remove_hs", &JSMol::remove_hs);
+      .function("remove_hs", &JSMol::remove_hs)
+      .function("normalize_depiction",
+                select_overload<double()>(&JSMol::normalize_depiction))
+      .function("normalize_depiction",
+                select_overload<double(int)>(&JSMol::normalize_depiction))
+      .function("normalize_depiction", select_overload<double(int, double)>(
+                                           &JSMol::normalize_depiction))
+      .function("straighten_depiction",
+                select_overload<void()>(&JSMol::straighten_depiction))
+      .function("straighten_depiction",
+                select_overload<void(bool)>(&JSMol::straighten_depiction));
 
   class_<JSSubstructLibrary>("SubstructLibrary")
       .constructor<>()
@@ -204,5 +264,8 @@ EMSCRIPTEN_BINDINGS(RDKit_minimal) {
   function("get_inchikey_for_inchi", &get_inchikey_for_inchi);
   function("get_mol", &get_mol, allow_raw_pointers());
   function("get_mol", &get_mol_no_details, allow_raw_pointers());
+  function("get_mol_from_uint8array", &get_mol_from_uint8array,
+           allow_raw_pointers());
+  function("get_mol_copy", &get_mol_copy, allow_raw_pointers());
   function("get_qmol", &get_qmol, allow_raw_pointers());
 }

--- a/Code/MinimalLib/minilib.cpp
+++ b/Code/MinimalLib/minilib.cpp
@@ -31,6 +31,8 @@
 #include <GraphMol/Depictor/RDDepictor.h>
 #include <GraphMol/CIPLabeler/CIPLabeler.h>
 #include <GraphMol/Abbreviations/Abbreviations.h>
+#include <GraphMol/MolTransforms/MolTransforms.h>
+#include <Geometry/Transform3D.h>
 #include <DataStructs/BitOps.h>
 
 #include <INCHI-API/inchi.h>
@@ -89,6 +91,13 @@ std::string JSMol::get_json() const {
   return MolInterchange::MolToJSONData(*d_mol);
 }
 
+std::string JSMol::get_pickle() const {
+  if (!d_mol) return std::string();
+  std::string pickle;
+  MolPickler::pickleMol(*d_mol, pickle);
+  return pickle;
+}
+
 std::string JSMol::get_substruct_match(const JSMol &q) const {
   std::string res = "{}";
   if (!d_mol || !q.d_mol) return res;
@@ -139,18 +148,32 @@ std::string JSMol::get_descriptors() const {
 std::string JSMol::get_morgan_fp(unsigned int radius,
                                  unsigned int fplen) const {
   if (!d_mol) return "";
-  auto fp = MorganFingerprints::getFingerprintAsBitVect(*d_mol, radius, fplen);
+  std::unique_ptr<ExplicitBitVect> fp(
+      MorganFingerprints::getFingerprintAsBitVect(*d_mol, radius, fplen));
   std::string res = BitVectToText(*fp);
-  delete fp;
   return res;
 }
 
 std::string JSMol::get_morgan_fp_as_binary_text(unsigned int radius,
                                                 unsigned int fplen) const {
   if (!d_mol) return "";
-  auto fp = MorganFingerprints::getFingerprintAsBitVect(*d_mol, radius, fplen);
+  std::unique_ptr<ExplicitBitVect> fp(
+      MorganFingerprints::getFingerprintAsBitVect(*d_mol, radius, fplen));
   std::string res = BitVectToBinaryText(*fp);
-  delete fp;
+  return res;
+}
+
+std::string JSMol::get_pattern_fp(unsigned int fplen) const {
+  if (!d_mol) return "";
+  std::unique_ptr<ExplicitBitVect> fp(PatternFingerprintMol(*d_mol, fplen));
+  std::string res = BitVectToText(*fp);
+  return res;
+}
+
+std::string JSMol::get_pattern_fp_as_binary_text(unsigned int fplen) const {
+  if (!d_mol) return "";
+  std::unique_ptr<ExplicitBitVect> fp(PatternFingerprintMol(*d_mol, fplen));
+  std::string res = BitVectToBinaryText(*fp);
   return res;
 }
 
@@ -233,6 +256,21 @@ std::string JSMol::get_kekule_form() const {
   return MolToMolBlock(molCopy, includeStereo, confId, kekulize);
 }
 
+bool JSMol::set_new_coords(bool useCoordGen) {
+  if (!d_mol) return false;
+
+#ifdef RDK_BUILD_COORDGEN_SUPPORT
+  bool oprefer = RDDepict::preferCoordGen;
+  RDDepict::preferCoordGen = useCoordGen;
+#endif
+  RDDepict::compute2DCoords(*d_mol);
+#ifdef RDK_BUILD_COORDGEN_SUPPORT
+  RDDepict::preferCoordGen = oprefer;
+#endif
+
+  return true;
+}
+
 std::string JSMol::get_new_coords(bool useCoordGen) const {
   if (!d_mol) return "";
 
@@ -267,8 +305,6 @@ std::string JSMol::add_hs() const {
 
   RWMol molCopy(*d_mol);
   MolOps::addHs(molCopy);
-
-  // RDDepict::generateDepictionMatching2DStructure(molCopy, *d_mol);
 
   bool includeStereo = true;
   int confId = -1;
@@ -339,7 +375,17 @@ std::string JSMol::generate_aligned_coords(const JSMol &templateMol,
   RDDepict::preferCoordGen = oprefer;
 #endif
   return res;
-};
+}
+
+double JSMol::normalize_depiction(int canonicalize, double scaleFactor) {
+  if (!d_mol || !d_mol->getNumAtoms() || !d_mol->getNumConformers()) return -1.;
+  return RDDepict::normalizeDepiction(*d_mol, -1, canonicalize, scaleFactor);
+}
+
+void JSMol::straighten_depiction(bool smallestRotation) {
+  if (!d_mol || !d_mol->getNumAtoms() || !d_mol->getNumConformers()) return;
+  RDDepict::straightenDepiction(*d_mol, -1, smallestRotation);
+}
 
 JSSubstructLibrary::JSSubstructLibrary(unsigned int num_bits)
     : d_sslib(new SubstructLibrary(
@@ -358,11 +404,11 @@ int JSSubstructLibrary::add_trusted_smiles(const std::string &smi) {
     return -1;
   }
   mol->updatePropertyCache();
-  ExplicitBitVect *bv = PatternFingerprintMol(*mol, d_num_bits);
-  if (!bv) {
+  auto fp = PatternFingerprintMol(*mol, d_num_bits);
+  if (!fp) {
     return -1;
   }
-  d_fpHolder->addFingerprint(bv);
+  d_fpHolder->addFingerprint(fp);
   auto ret = d_molHolder->addSmiles(smi);
   return ret;
 }
@@ -419,8 +465,27 @@ std::string get_inchikey_for_inchi(const std::string &input) {
   return InchiToInchiKey(input);
 }
 
+JSMol *get_mol_copy(const JSMol &other) {
+  RWMol *mol = new RWMol(*other.d_mol);
+  return new JSMol(mol);
+}
+
 JSMol *get_mol(const std::string &input, const std::string &details_json) {
   RWMol *mol = MinimalLib::mol_from_input(input, details_json);
+  return new JSMol(mol);
+}
+
+JSMol *get_mol_from_pickle(const std::string &pickle) {
+  RWMol *mol = nullptr;
+  if (!pickle.empty()) {
+    mol = new RWMol();
+    try {
+      MolPickler::molFromPickle(pickle, mol);
+    } catch (...) {
+      delete mol;
+      mol = nullptr;
+    }
+  }
   return new JSMol(mol);
 }
 

--- a/Code/MinimalLib/minilib.h
+++ b/Code/MinimalLib/minilib.h
@@ -22,6 +22,7 @@ class JSMol {
   std::string get_cxsmarts() const;
   std::string get_molblock() const;
   std::string get_v3Kmolblock() const;
+  std::string get_pickle() const;
   std::string get_inchi() const;
   std::string get_json() const;
   std::string get_svg(int width, int height) const;
@@ -37,7 +38,13 @@ class JSMol {
   std::string get_morgan_fp_as_binary_text(unsigned int radius,
                                            unsigned int len) const;
   std::string get_morgan_fp_as_binary_text() const {
-    return get_morgan_fp(2, 2048);
+    return get_morgan_fp_as_binary_text(2, 2048);
+  }
+  std::string get_pattern_fp(unsigned int len) const;
+  std::string get_pattern_fp() const { return get_pattern_fp(2048); }
+  std::string get_pattern_fp_as_binary_text(unsigned int len) const;
+  std::string get_pattern_fp_as_binary_text() const {
+    return get_pattern_fp_as_binary_text(2048);
   }
   std::string condense_abbreviations(double maxCoverage, bool useLinkers);
   std::string condense_abbreviations() {
@@ -63,17 +70,27 @@ class JSMol {
   std::string generate_aligned_coords(const JSMol &templateMol) {
     return generate_aligned_coords(templateMol, false, false, true);
   }
-
   bool is_valid() const { return d_mol.get() != nullptr; }
+  bool has_coords() const {
+    return d_mol.get() != nullptr && d_mol->getNumConformers() != 0;
+  }
 
-  // functionality primarily useful in ketcher
   std::string get_stereo_tags() const;
   std::string get_aromatic_form() const;
   std::string get_kekule_form() const;
+  bool set_new_coords(bool useCoordGen);
+  bool set_new_coords() { return set_new_coords(false); }
   std::string get_new_coords(bool useCoordGen) const;
   std::string get_new_coords() const { return get_new_coords(false); }
   std::string remove_hs() const;
   std::string add_hs() const;
+  double normalize_depiction(int canonicalize, double scaleFactor);
+  double normalize_depiction(int canonicalize) {
+    return normalize_depiction(canonicalize, -1.);
+  }
+  double normalize_depiction() { return normalize_depiction(0, -1.); }
+  void straighten_depiction(bool smallestRotation);
+  void straighten_depiction() { return straighten_depiction(false); }
 
   std::unique_ptr<RDKit::RWMol> d_mol;
   static constexpr int d_defaultWidth = 250;
@@ -119,6 +136,8 @@ class JSSubstructLibrary {
 
 std::string get_inchikey_for_inchi(const std::string &input);
 JSMol *get_mol(const std::string &input, const std::string &details_json);
+JSMol *get_mol_from_pickle(const std::string &pickle);
+JSMol *get_mol_copy(const JSMol &other);
 JSMol *get_qmol(const std::string &input);
 std::string version();
 void prefer_coordgen(bool prefer);

--- a/Code/MinimalLib/tests/tests.js
+++ b/Code/MinimalLib/tests/tests.js
@@ -21,9 +21,13 @@ const readline = require('readline');
 // the goal here isn't to be comprehensive (the RDKit has tests for that),
 // just to make sure that the wrappers are working as expected
 function test_basics() {
-    var bmol = RDKitModule.get_mol("c1ccccc");
-    assert.equal(bmol.is_valid(),0);
-    
+    var bmol = null;
+    try {
+        bmol = RDKitModule.get_mol("c1ccccc");
+        assert.equal(bmol.is_valid(),0);
+    } catch {
+        assert(bmol === null);
+    }
     var mol = RDKitModule.get_mol("c1ccccc1O");
     assert.equal(mol.is_valid(),1);
     assert.equal(mol.get_smiles(),"Oc1ccccc1");
@@ -70,7 +74,18 @@ function test_basics() {
     assert.equal((fp2.match(/1/g)||[]).length,3);
     var fp2Uint8Array = mol.get_morgan_fp_as_uint8array(0, 512);
     checkStringBinaryFpIdentity(fp2, fp2Uint8Array);
-    
+
+    fp1 = mol.get_pattern_fp();
+    assert.equal(fp1.length,2048);
+    assert.equal((fp1.match(/1/g)||[]).length,73);
+    fp1Uint8Array = mol.get_pattern_fp_as_uint8array();
+    checkStringBinaryFpIdentity(fp1, fp1Uint8Array);
+    fp2 = mol.get_pattern_fp(256);
+    assert.equal(fp2.length,256);
+    assert.equal((fp2.match(/1/g)||[]).length,65);
+    fp2Uint8Array = mol.get_pattern_fp_as_uint8array(256);
+    checkStringBinaryFpIdentity(fp2, fp2Uint8Array);
+
     var svg = mol.get_svg();
     assert(svg.search("svg")>0);
 
@@ -156,6 +171,21 @@ M  END`;
     assert.equal(mol.is_valid(),1);
 }
 
+function test_get_aromatic_kekule_form() {
+    const aromRegExp = /  \d  \d  4  \d\n/g;
+    const kekRegExp = /  \d  \d  [12]  \d\n/g;
+    var mol = RDKitModule.get_mol("c1ccccc1");
+    var molblock = mol.get_molblock();
+    assert ([...molblock.matchAll(aromRegExp)].length === 0);
+    assert ([...molblock.matchAll(kekRegExp)].length === 6);
+    var molblock = mol.get_kekule_form();
+    assert ([...molblock.matchAll(aromRegExp)].length === 0);
+    assert ([...molblock.matchAll(kekRegExp)].length === 6);
+    molblock = mol.get_aromatic_form();
+    assert ([...molblock.matchAll(aromRegExp)].length === 6);
+    assert ([...molblock.matchAll(kekRegExp)].length === 0);
+}
+
 function test_sketcher_services() {
     var mol = RDKitModule.get_mol("C[C@](F)(Cl)/C=C/C(F)Br");
     assert.equal(mol.is_valid(),1);
@@ -179,7 +209,6 @@ function test_sketcher_services2() {
     molb2 = mol2.remove_hs();
     assert(molb2.search(" H ")<0); 
 }
-
 
 function test_abbreviations() {
     var bmol = RDKitModule.get_mol("C1CCC1C(F)(F)F");
@@ -283,7 +312,6 @@ function test_generate_aligned_coords() {
     assert.equal(mol.generate_aligned_coords(qmol, true), "");
 }
 
-
 function test_isotope_labels() {
     var mol = RDKitModule.get_mol("[1*]c1cc([2*])c([3*])c[14c]1");
     assert.equal(mol.is_valid(), 1);
@@ -305,7 +333,6 @@ function test_isotope_labels() {
     resSorted.sort((a, b) => (a - b));
     assert.ok(res.every((resItem, i) => (resItem === resSorted[i])));
 }
-
 
 function test_generate_aligned_coords_allow_rgroups() {
     var template_molblock = `
@@ -354,7 +381,6 @@ M  END`;
     assert.equal(JSON.parse(phenyl.generate_aligned_coords(
         template_ref, false, true)).atoms.length, 6);
 }
-
 
 function test_accept_failure() {
     var template_molblock = `
@@ -419,12 +445,17 @@ M  END
 }
 
 function test_get_mol_no_kekulize() {
-    var mol = RDKitModule.get_mol("c");
-    assert(!mol.is_valid());
+    var molIsValid = true;
+    try {
+        mol = RDKitModule.get_mol("c");
+        molIsValid = mol.is_valid();
+    } catch (e) {
+        molIsValid = false;
+    }
+    assert(!molIsValid);
     mol = RDKitModule.get_mol("c", JSON.stringify({kekulize: false}));
     assert(mol.is_valid());
 }
-
 
 function test_get_smarts() {
     var mol = RDKitModule.get_mol(`
@@ -454,7 +485,6 @@ M  END
     smarts = mol.get_smarts();
     assert(smarts == "[#6]1:[#6]:[#6]:[#6]:[#6](:[#6]:1-&!@*)-&!@*");
 }
-
 
 function test_get_cxsmarts() {
     var mol = RDKitModule.get_mol(`
@@ -488,6 +518,104 @@ M  END
         "atomProp:6.dummyLabel.R1:7.dummyLabel.R2|");
 }
 
+function test_normalize_depiction() {
+    var mol = RDKitModule.get_mol(`
+  MJ201100                      
+
+  9 10  0  0  0  0  0  0  0  0999 V2000
+   -1.5402    1.3161    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -2.2546    0.9036    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -2.2546    0.0785    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -1.5402   -0.3339    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -0.8257    0.0785    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -0.8257    0.9036    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -0.0411   -0.1764    0.0000 N   0  0  0  0  0  0  0  0  0  0  0  0
+    0.4438    0.4909    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -0.0410    1.1583    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+  1  2  2  0  0  0  0
+  2  3  1  0  0  0  0
+  3  4  2  0  0  0  0
+  4  5  1  0  0  0  0
+  5  6  2  0  0  0  0
+  6  1  1  0  0  0  0
+  8  9  2  0  0  0  0
+  6  9  1  0  0  0  0
+  7  8  1  0  0  0  0
+  5  7  1  0  0  0  0
+M  END
+`);
+    const scalingFactor = mol.normalize_depiction();
+    assert(scalingFactor > 1.8 && scalingFactor < 1.9);
+}
+
+function test_straighten_depiction() {
+    var mol1 = RDKitModule.get_mol(`
+  MJ201900                      
+
+  2  1  0  0  0  0  0  0  0  0999 V2000
+   -0.3904    2.1535    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -1.1049    1.7410    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+  2  1  1  0  0  0  0
+M  END
+`);
+    var mol2 = RDKitModule.get_mol(`
+  MJ201900                      
+
+  2  1  0  0  0  0  0  0  0  0999 V2000
+    0.1899    1.9526    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -0.5245    1.5401    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+  2  1  1  0  0  0  0
+M  END
+`);
+    mol1.normalize_depiction();
+    mol1.straighten_depiction();
+    mol2.normalize_depiction();
+    mol2.straighten_depiction();
+    assert(mol1.get_molblock() === mol2.get_molblock());
+}
+
+function test_has_coords() {
+    var mol = RDKitModule.get_mol('CC');
+    assert(!mol.has_coords());
+    var mol2 = RDKitModule.get_mol(mol.get_new_coords());
+    assert(mol2.has_coords());
+    assert(!mol.has_coords());
+    mol.set_new_coords();
+    assert(mol.has_coords());
+}
+
+function test_kekulize() {
+    const badAromaticSmiles = 'c1cccc1';
+    var mol = null;
+    try {
+        mol = RDKitModule.get_mol(badAromaticSmiles);
+        assert(!mol.is_valid());
+    } catch {
+        assert(mol === null);
+    }
+    mol = RDKitModule.get_mol(badAromaticSmiles, JSON.stringify({ kekulize: false }));
+    assert(mol.is_valid());
+}
+
+function test_sanitize() {
+    const badValenceSmiles = 'N(C)(C)(C)C';
+    var mol = null;
+    try {
+        mol = RDKitModule.get_mol(badValenceSmiles);
+        assert(!mol.is_valid());
+    } catch {
+        assert(mol === null);
+    }
+    try {
+        mol = RDKitModule.get_mol(badValenceSmiles, JSON.stringify({ kekulize: false }));
+        assert(!mol.is_valid());
+    } catch {
+        assert(mol === null);
+    }
+    mol = RDKitModule.get_mol(badValenceSmiles, JSON.stringify({ sanitize: false }));
+    assert(mol.is_valid());
+}
+
 function test_flexicanvas() {
     
     var mol = RDKitModule.get_mol("CCCC");
@@ -518,6 +646,7 @@ initRDKitModule().then(function(instance) {
     test_basics();
     test_molblock_nostrict();
     test_molblock_rgp();
+    test_get_aromatic_kekule_form();
     test_sketcher_services();
     test_sketcher_services2();
     test_abbreviations();
@@ -533,6 +662,11 @@ initRDKitModule().then(function(instance) {
     test_get_mol_no_kekulize();
     test_get_smarts();
     test_get_cxsmarts();
+    test_has_coords();
+    test_kekulize();
+    test_sanitize();
+    test_normalize_depiction();
+    test_straighten_depiction();
     test_flexicanvas();
     waitAllTestsFinished().then(() =>
         console.log("Tests finished successfully")


### PR DESCRIPTION
- adds `normalizeDepiction()` and Python wrappers
- adds `straightenDepiction()` and Python wrappers
- adds an early check for R-labels to be in the accepted range to avoid throwing an exception later on
- adds a `kekulize` flag to `process_details()` to enable depicting molecules which fail to kekulize from JavaScript
- adds JavaScript functions to get fingerprints as `Uint8Array`
- adds JavaScript function to generate pickled molecule as `Uint8Array`
- adds JavaScript function to restore pickled molecule from `Uint8Array`
- adds `has_coords()` JavaScript function
- adds `set_new_coords()` to set JSMol coordinates in-place
- adds `get_mol_copy()` to obtain a JSMol copy
