### PR TITLE
Fixes #5152

### DIFF
--- a/Code/GraphMol/MolPickler.cpp
+++ b/Code/GraphMol/MolPickler.cpp
@@ -35,7 +35,7 @@ namespace RDKit {
 
 const int32_t MolPickler::versionMajor = 13;
 const int32_t MolPickler::versionMinor = 0;
-const int32_t MolPickler::versionPatch = 0;
+const int32_t MolPickler::versionPatch = 1;
 const int32_t MolPickler::endianId = 0xDEADBEEF;
 
 void streamWrite(std::ostream &ss, MolPickler::Tags tag) {
@@ -512,11 +512,16 @@ Query<int, Bond const *, true> *unpickleQuery(std::istream &ss,
                                               Bond const *owner, int version) {
   PRECONDITION(owner, "no query");
   std::string descr;
+  std::string typeLabel = "";
   bool isNegated = false;
   Query<int, Bond const *, true> *res;
   streamRead(ss, descr, version);
   MolPickler::Tags tag;
   streamRead(ss, tag, version);
+  if (tag == MolPickler::QUERY_TYPELABEL) {
+    streamRead(ss, typeLabel, version);
+    streamRead(ss, tag, version);
+  }
   if (tag == MolPickler::QUERY_ISNEGATED) {
     isNegated = true;
     streamRead(ss, tag, version);

--- a/Code/GraphMol/QueryOps.cpp
+++ b/Code/GraphMol/QueryOps.cpp
@@ -589,6 +589,7 @@ BOND_EQUALS_QUERY *makeBondOrderEqualsQuery(Bond::BondType what) {
   res->setVal(what);
   res->setDataFunc(queryBondOrder);
   res->setDescription("BondOrder");
+  res->setTypeLabel("BondOrder");
   return res;
 }
 
@@ -597,6 +598,7 @@ RDKIT_GRAPHMOL_EXPORT BOND_EQUALS_QUERY *makeSingleOrAromaticBondQuery() {
   res->setVal(true);
   res->setDataFunc(queryBondIsSingleOrAromatic);
   res->setDescription("SingleOrAromaticBond");
+  res->setTypeLabel("BondOrder");
   return res;
 };
 
@@ -605,6 +607,7 @@ RDKIT_GRAPHMOL_EXPORT BOND_EQUALS_QUERY *makeDoubleOrAromaticBondQuery() {
   res->setVal(true);
   res->setDataFunc(queryBondIsDoubleOrAromatic);
   res->setDescription("DoubleOrAromaticBond");
+  res->setTypeLabel("BondOrder");
   return res;
 };
 
@@ -613,6 +616,7 @@ RDKIT_GRAPHMOL_EXPORT BOND_EQUALS_QUERY *makeSingleOrDoubleBondQuery() {
   res->setVal(true);
   res->setDataFunc(queryBondIsSingleOrDouble);
   res->setDescription("SingleOrDoubleBond");
+  res->setTypeLabel("BondOrder");
   return res;
 };
 
@@ -622,10 +626,13 @@ makeSingleOrDoubleOrAromaticBondQuery() {
   res->setVal(true);
   res->setDataFunc(queryBondIsSingleOrDoubleOrAromatic);
   res->setDescription("SingleOrDoubleOrAromaticBond");
+  res->setTypeLabel("BondOrder");
   return res;
 };
 
 namespace QueryOps {
+// we don't use these anymore but we need to keep them around for backwards
+// compatibility with pickled queries. There's no reason to update this list.
 const std::vector<std::string> bondOrderQueryFunctions{
     std::string("BondOrder"), std::string("SingleOrAromaticBond"),
     std::string("DoubleOrAromaticBond"), std::string("SingleOrDoubleBond"),
@@ -633,9 +640,12 @@ const std::vector<std::string> bondOrderQueryFunctions{
 RDKIT_GRAPHMOL_EXPORT bool hasBondTypeQuery(
     const Queries::Query<int, Bond const *, true> &qry) {
   const auto df = qry.getDescription();
+  const auto dt = qry.getTypeLabel();
   // is this a bond order query?
-  if (std::find(bondOrderQueryFunctions.begin(), bondOrderQueryFunctions.end(),
-                df) != bondOrderQueryFunctions.end()) {
+  if (dt == "BondOrder" ||
+      (dt.empty() &&
+       std::find(bondOrderQueryFunctions.begin(), bondOrderQueryFunctions.end(),
+                 df) != bondOrderQueryFunctions.end())) {
     return true;
   }
   for (const auto &child :


### PR DESCRIPTION
We needed to add a special case to the aromaticity code for bond-order queries. There's not really a perfectly correct answer for this, but the change here is to have them contribute to valence for aromaticity like a normal bond. Previously they weren't contributing to the valence for aromaticity at all.

Also adds a typeLabel to the bond order queries so that they are easier to recognize

