### PR TITLE
Very small fix to avoid an AttributeError

### DIFF
--- a/rdkit/Chem/Draw/InteractiveRenderer.py
+++ b/rdkit/Chem/Draw/InteractiveRenderer.py
@@ -131,7 +131,7 @@ def setOpts(mol, opts):
       f"{__name__}.setOpts(mol: Chem.Mol, opts: dict): no key in opts should be null")
   if opts:
     setattr(mol, _opts, opts)
-  else:
+  elif hasattr(mol, _opts):
     delattr(mol, _opts)
 
 


### PR DESCRIPTION
This PR avoids that `delattr` fails with an `AttributeError` if `_opts` is not yet set.
Thanks to Jacob Gora for reporting this.
