### PR TITLE
Add multi-template isMoleculeXOfReaction overloads

### DIFF
--- a/Code/GraphMol/ChemReactions/Reaction.cpp
+++ b/Code/GraphMol/ChemReactions/Reaction.cpp
@@ -348,6 +348,25 @@ bool isMoleculeReactantOfReaction(const ChemicalReaction &rxn, const ROMol &mol,
   }
   return false;
 }
+
+bool isMoleculeReactantOfReaction(const ChemicalReaction &rxn, const ROMol &mol,
+                                  std::vector<unsigned int> &which) {
+  if (!rxn.isInitialized()) {
+    throw ChemicalReactionException(
+        "initReactantMatchers() must be called first");
+  }
+  which.clear();
+  unsigned int reactant_template_idx = 0;
+  for (auto iter = rxn.beginReactantTemplates();
+       iter != rxn.endReactantTemplates(); ++iter, ++reactant_template_idx) {
+    MatchVectType tvect;
+    if (SubstructMatch(mol, **iter, tvect)) {
+      which.push_back(reactant_template_idx);
+    }
+  }
+  return !which.empty();
+}
+
 bool isMoleculeReactantOfReaction(const ChemicalReaction &rxn,
                                   const ROMol &mol) {
   unsigned int ignore;
@@ -370,6 +389,25 @@ bool isMoleculeProductOfReaction(const ChemicalReaction &rxn, const ROMol &mol,
   }
   return false;
 }
+
+bool isMoleculeProductOfReaction(const ChemicalReaction &rxn, const ROMol &mol,
+                                 std::vector<unsigned int> &which) {
+  if (!rxn.isInitialized()) {
+    throw ChemicalReactionException(
+        "initReactantMatchers() must be called first");
+  }
+  which.clear();
+  unsigned int product_template_idx = 0;
+  for (auto iter = rxn.beginProductTemplates();
+       iter != rxn.endProductTemplates(); ++iter, ++product_template_idx) {
+    MatchVectType tvect;
+    if (SubstructMatch(mol, **iter, tvect)) {
+      which.push_back(product_template_idx);
+    }
+  }
+  return !which.empty();
+}
+
 bool isMoleculeProductOfReaction(const ChemicalReaction &rxn,
                                  const ROMol &mol) {
   unsigned int ignore;
@@ -406,6 +444,34 @@ bool isMoleculeAgentOfReaction(const ChemicalReaction &rxn, const ROMol &mol,
     }
   }
   return false;
+}
+
+bool isMoleculeAgentOfReaction(const ChemicalReaction &rxn, const ROMol &mol,
+                               std::vector<unsigned int> &which) {
+  if (!rxn.isInitialized()) {
+    throw ChemicalReactionException(
+        "initReactantMatchers() must be called first");
+  }
+  which.clear();
+  unsigned int agent_template_idx = 0;
+  for (auto iter = rxn.beginAgentTemplates(); iter != rxn.endAgentTemplates();
+       ++iter, ++agent_template_idx) {
+    if (iter->get()->getNumHeavyAtoms() != mol.getNumHeavyAtoms()) {
+      continue;
+    }
+    if (iter->get()->getNumBonds() != mol.getNumBonds()) {
+      continue;
+    }
+    if (RDKit::Descriptors::calcAMW(*iter->get()) !=
+        RDKit::Descriptors::calcAMW(mol)) {
+      continue;
+    }
+    MatchVectType tvect;
+    if (SubstructMatch(mol, **iter, tvect)) {
+      which.push_back(agent_template_idx);
+    }
+  }
+  return !which.empty();
 }
 
 bool isMoleculeAgentOfReaction(const ChemicalReaction &rxn, const ROMol &mol) {

--- a/Code/GraphMol/ChemReactions/Reaction.h
+++ b/Code/GraphMol/ChemReactions/Reaction.h
@@ -369,6 +369,10 @@ RDKIT_CHEMREACTIONS_EXPORT bool isMoleculeReactantOfReaction(
     const ChemicalReaction &rxn, const ROMol &mol, unsigned int &which);
 //! \overload
 RDKIT_CHEMREACTIONS_EXPORT bool isMoleculeReactantOfReaction(
+    const ChemicalReaction &rxn, const ROMol &mol,
+    std::vector<unsigned int> &which);
+//! \overload
+RDKIT_CHEMREACTIONS_EXPORT bool isMoleculeReactantOfReaction(
     const ChemicalReaction &rxn, const ROMol &mol);
 
 //! tests whether or not the molecule has a substructure match
@@ -380,6 +384,10 @@ RDKIT_CHEMREACTIONS_EXPORT bool isMoleculeProductOfReaction(
     const ChemicalReaction &rxn, const ROMol &mol, unsigned int &which);
 //! \overload
 RDKIT_CHEMREACTIONS_EXPORT bool isMoleculeProductOfReaction(
+    const ChemicalReaction &rxn, const ROMol &mol,
+    std::vector<unsigned int> &which);
+//! \overload
+RDKIT_CHEMREACTIONS_EXPORT bool isMoleculeProductOfReaction(
     const ChemicalReaction &rxn, const ROMol &mol);
 
 //! tests whether or not the molecule has a substructure match
@@ -389,6 +397,10 @@ RDKIT_CHEMREACTIONS_EXPORT bool isMoleculeProductOfReaction(
 //! of agents on return
 RDKIT_CHEMREACTIONS_EXPORT bool isMoleculeAgentOfReaction(
     const ChemicalReaction &rxn, const ROMol &mol, unsigned int &which);
+//! \overload
+RDKIT_CHEMREACTIONS_EXPORT bool isMoleculeAgentOfReaction(
+    const ChemicalReaction &rxn, const ROMol &mol,
+    std::vector<unsigned int> &which);
 //! \overload
 RDKIT_CHEMREACTIONS_EXPORT bool isMoleculeAgentOfReaction(
     const ChemicalReaction &rxn, const ROMol &mol);


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
The `isMoleculeXOfReaction` functions (namely `isMoleculeReactantOfReaction`, `isMoleculeProductOfReaction` and `isMoleculeAgentOfReaction`) iterate over the `ChemicalReaction`'s corresponding `ReactantTemplate`, `ProductTemplate` or `AgentTemplate`s checking for `SubstructMatch`es between the input molecule and the template, returning upon the first encountered match. The `which` argument takes the value of the matching template's index.

However, the same molecule may map to multiple templates. In situations where it's of interest to know to which template the molecule maps to chances are one would be interested in all matches, not just the first one.

This commit adds overloads for the above functions, with the `which` argument being a `std::vector<unsigned>&` taking the value of all matching template indices instead of a single `unsigned&` index.

#### Any other comments?
Example code where a reactant matches multiple reactant templates.

```cpp
#include <GraphMol/SmilesParse/SmilesParse.h>
#include <GraphMol/ChemReactions/Reaction.h>
#include <GraphMol/ChemReactions/ReactionParser.h>
#include <iostream>

int main() {

  RDKit::ChemicalReaction* reaction = RDKit::RxnSmartsToChemicalReaction("[#6;$(C=C-[#6]),$(c:c):1][Br,I].[Cl,Br,I][c:2]>>[c:2][#6:1]");
  reaction->initReactantMatchers();
  unsigned reaction_validation_warnings = 0, reaction_validation_errors = 0;
  bool reaction_is_valid = reaction->validate(reaction_validation_warnings, reaction_validation_errors);
  assert(reaction_is_valid);

  RDKit::ROMOL_SPTR reactant (RDKit::SmilesToMol("O=C(CCCN1CCC(O)(c2ccc(Br)cc2)CC1)c1ccc(F)cc1"));

  std::vector<unsigned> reactant_template_indices;
  bool is_reactant = RDKit::isMoleculeReactantOfReaction(*reaction, *reactant, reactant_template_indices);
  assert(is_reactant);
  assert(reactant_template_indices.size() == 2);

  for (unsigned rti : reactant_template_indices) {
    std::cout << rti << " ";
  };
  std::cout << std::endl;

  delete reaction;

  return 0;
};
```
This is my first pull request so any feedback is welcome.


