### PR TITLE
More consistently check for `WIN32` instead of `MSVC` in CMake files

### DIFF
--- a/Code/GraphMol/CMakeLists.txt
+++ b/Code/GraphMol/CMakeLists.txt
@@ -13,7 +13,7 @@ rdkit_library(GraphMol
 target_compile_definitions(GraphMol PRIVATE RDKIT_GRAPHMOL_BUILD)
 if(RDK_USE_URF)
   target_link_libraries(GraphMol PUBLIC ${RDK_URF_LIBS})
-  if(NOT MSVC AND RDK_INSTALL_STATIC_LIBS)
+  if(NOT WIN32 AND RDK_INSTALL_STATIC_LIBS)
     target_link_libraries(GraphMol_static PUBLIC ${RDK_URF_LIBS}_static)
   endif()
 endif()

--- a/Code/MinimalLib/CMakeLists.txt
+++ b/Code/MinimalLib/CMakeLists.txt
@@ -21,7 +21,7 @@ endif(RDK_BUILD_MINIMAL_LIB)
 if(RDK_BUILD_CFFI_LIB)
 
     set(CMAKE_C_STANDARD 99)
-    if((NOT MSVC) OR (MSVC AND RDK_INSTALL_DLLS_MSVC))
+    if((NOT WIN32) OR (WIN32 AND RDK_INSTALL_DLLS_MSVC))
         set(LIBS_TO_USE 
             MolStandardize_static DistGeomHelpers_static ForceFieldHelpers_static DistGeometry_static
             ForceField_static Alignment_static


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

With this change I was able to cross compile for Windows by using MinGW.

#### Any other comments?

I'm not changing them, but as far as I can tell the `if`s at https://github.com/rdkit/rdkit/blob/4fafb72212163bbdaeafbb364d7f922b95a823bf/Code/MinimalLib/CMakeLists.txt#L32-L34 and https://github.com/rdkit/rdkit/blob/4fafb72212163bbdaeafbb364d7f922b95a823bf/Code/MinimalLib/CMakeLists.txt#L43-L45 are completely useless: `RDK_URF_LIBS` is always true, so these `if`s are _always_ hit, and `RingDecomposerLib` is already unconditionally added to `LIBS_TO_USE` at https://github.com/rdkit/rdkit/blob/4fafb72212163bbdaeafbb364d7f922b95a823bf/Code/MinimalLib/CMakeLists.txt#L31 and https://github.com/rdkit/rdkit/blob/4fafb72212163bbdaeafbb364d7f922b95a823bf/Code/MinimalLib/CMakeLists.txt#L42