### PR TITLE
Add test for string rectangle clashing with vector bwtween bonded atoms.

### DIFF
--- a/Code/GraphMol/MolDraw2D/DrawMol.cpp
+++ b/Code/GraphMol/MolDraw2D/DrawMol.cpp
@@ -2003,7 +2003,6 @@ void DrawMol::calcAnnotationPosition(const Atom *atom,
   PRECONDITION(atom, "no atom");
   double start_ang = getNoteStartAngle(atom);
   Point2D const &atCds = atCds_[atom->getIdx()];
-
   double radStep = 0.25;
   Point2D leastWorstPos = atCds;
   int leastWorstScore = 100;
@@ -2188,6 +2187,18 @@ int DrawMol::doesNoteClash(const DrawAnnotation &annot) const {
 
 // ****************************************************************************
 int DrawMol::doesRectClash(const StringRect &rect, double padding) const {
+
+  // see if the rectangle clashes with any of the bonds themselves, as
+  // opposed to the draw shapes derived from them.  Github 5185 shows
+  // that sometimes atom indices can just fit between the lines of a
+  // double bond.
+  for (auto bond : drawMol_->bonds()) {
+    auto at1 = bond->getBeginAtomIdx();
+    auto at2 = bond->getEndAtomIdx();
+    if (doesLineIntersect(rect, atCds_[at1], atCds_[at2], 0.0)) {
+      return 1;
+    }
+  }
   for (const auto &bond : bonds_) {
     if (bond->doesRectClash(rect, padding)) {
       return 1;

--- a/Code/GraphMol/MolDraw2D/DrawMol.cpp
+++ b/Code/GraphMol/MolDraw2D/DrawMol.cpp
@@ -2188,15 +2188,17 @@ int DrawMol::doesNoteClash(const DrawAnnotation &annot) const {
 // ****************************************************************************
 int DrawMol::doesRectClash(const StringRect &rect, double padding) const {
 
-  // see if the rectangle clashes with any of the bonds themselves, as
-  // opposed to the draw shapes derived from them.  Github 5185 shows
+  // see if the rectangle clashes with any of the double bonds themselves,
+  // as opposed to the draw shapes derived from them.  Github 5185 shows
   // that sometimes atom indices can just fit between the lines of a
   // double bond.
   for (auto bond : drawMol_->bonds()) {
-    auto at1 = bond->getBeginAtomIdx();
-    auto at2 = bond->getEndAtomIdx();
-    if (doesLineIntersect(rect, atCds_[at1], atCds_[at2], 0.0)) {
-      return 1;
+    if (bond->getBondType() == Bond::DOUBLE) {
+      auto at1 = bond->getBeginAtomIdx();
+      auto at2 = bond->getEndAtomIdx();
+      if (doesLineIntersect(rect, atCds_[at1], atCds_[at2], 0.0)) {
+        return 1;
+      }
     }
   }
   for (const auto &bond : bonds_) {

--- a/Code/GraphMol/MolDraw2D/catch_tests.cpp
+++ b/Code/GraphMol/MolDraw2D/catch_tests.cpp
@@ -4481,9 +4481,14 @@ TEST_CASE(
       std::ofstream outs("testGithub_5185.svg");
       outs << text;
       outs.flush();
+#ifdef RDK_BUILD_FREETYPE_SUPPORT
       CHECK(text.find("<path class='note' d='M 92.5 130.1")
             != std::string::npos);
       check_file_hash("testGithub_5185.svg");
+#else
+      CHECK(text.find("<text x='90.4' y='130.3' class='note' ")
+            != std::string::npos);
+#endif
     }
   }
 }

--- a/Code/GraphMol/MolDraw2D/catch_tests.cpp
+++ b/Code/GraphMol/MolDraw2D/catch_tests.cpp
@@ -212,6 +212,7 @@ static const std::map<std::string, std::hash_result_t> SVG_HASHES = {
     {"testVariableLegend_2.svg", 2392644674U},
     {"testVariableLegend_3.svg", 2954965314U},
     {"testGithub_5061.svg", 632991478U},
+    {"testGithub_5185.svg", 1652507399U},
 };
 
 // These PNG hashes aren't completely reliable due to floating point cruft,
@@ -4461,6 +4462,28 @@ M  END)RXN";
       outs << text;
       outs.flush();
       check_file_hash("testGithub_5061.svg");
+    }
+  }
+}
+
+TEST_CASE(
+    "Github 5185 - don't draw atom indices between double bond") {
+  SECTION("basics") {
+    auto m1 = "OC(=O)CCCC(=O)O"_smiles;
+    REQUIRE(m1);
+    {
+      // default legend
+      MolDraw2DSVG drawer(400, 200, -1, -1);
+      drawer.drawOptions().addAtomIndices = true;
+      MolDraw2DUtils::prepareAndDrawMolecule(drawer, *m1);
+      drawer.finishDrawing();
+      auto text = drawer.getDrawingText();
+      std::ofstream outs("testGithub_5185.svg");
+      outs << text;
+      outs.flush();
+      CHECK(text.find("<path class='note' d='M 92.5 130.1")
+            != std::string::npos);
+      check_file_hash("testGithub_5185.svg");
     }
   }
 }


### PR DESCRIPTION

#### Reference Issue
Fixes #5185 

#### What does this implement/fix? Explain your changes.
Puts an extra test to make sure the annotation doesn't lie on the vector between two bonded atoms.  With a double bond, there isn't a line exactly along that vector. 

#### Any other comments?
Tested on macOs only.

