### PR TITLE
Fixes #5169

### DIFF
--- a/Code/GraphMol/MolStandardize/Charge.cpp
+++ b/Code/GraphMol/MolStandardize/Charge.cpp
@@ -287,8 +287,8 @@ std::pair<unsigned int, std::vector<unsigned int>> *Reionizer::weakestIonized(
 }
 
 Uncharger::Uncharger()
-    : pos_h(SmartsToMol("[+,+2,+3,+4;!H0;!$(*~[-]),$(*(~[-])~[-])]")),
-      pos_noh(SmartsToMol("[+,+2,+3,+4;H0;!$(*~[-]),$(*(~[-])~[-])]")),
+    : pos_h(SmartsToMol("[+,+2,+3,+4;!h0;!$(*~[-]),$(*(~[-])~[-])]")),
+      pos_noh(SmartsToMol("[+,+2,+3,+4;h0;!$(*~[-]),$(*(~[-])~[-])]")),
       neg(SmartsToMol("[-!$(*~[+,+2,+3,+4])]")),
       neg_acid(SmartsToMol(
           // carboxylate, carbonate, sulfi(a)te,


### PR DESCRIPTION
The fix is pretty easy: change the SMARTS patterns used to determine whether not a positively charged atom has hydrogens (and can thus be neutralized by removing an H) to only recognize implicit Hs.

We might think about adding an option to allow explicit (in graph) Hs to be removed at some later point.