### PR TITLE
Fixes #5196

### DIFF
--- a/Code/GraphMol/Chirality.cpp
+++ b/Code/GraphMol/Chirality.cpp
@@ -780,6 +780,8 @@ const Atom *findHighestCIPNeighbor(const Atom *atom, const Atom *skipAtom) {
 
 }  // namespace
 
+namespace Chirality {
+namespace detail {
 bool bondAffectsAtomChirality(const Bond *bond, const Atom *atom) {
   PRECONDITION(bond, "bad bond pointer");
   PRECONDITION(atom, "bad atom pointer");
@@ -803,8 +805,8 @@ unsigned int getAtomNonzeroDegree(const Atom *atom) {
   }
   return res;
 }
+}  // namespace detail
 
-namespace Chirality {
 typedef std::pair<int, int> INT_PAIR;
 typedef std::vector<INT_PAIR> INT_PAIR_VECT;
 typedef std::vector<INT_PAIR>::iterator INT_PAIR_VECT_I;
@@ -1424,7 +1426,7 @@ std::pair<bool, bool> isAtomPotentialChiralCenter(
   bool legalCenter = true;
   bool hasDupes = false;
 
-  auto nzDegree = getAtomNonzeroDegree(atom);
+  auto nzDegree = Chirality::detail::getAtomNonzeroDegree(atom);
   auto tnzDegree = nzDegree + atom->getTotalNumHs();
   if (tnzDegree > 4) {
     // we only know tetrahedral chirality
@@ -1470,7 +1472,7 @@ std::pair<bool, bool> isAtomPotentialChiralCenter(
     if (legalCenter) {
       boost::dynamic_bitset<> codesSeen(mol.getNumAtoms());
       for (const auto bond : mol.atomBonds(atom)) {
-        if (!bondAffectsAtomChirality(bond, atom)) {
+        if (!Chirality::detail::bondAffectsAtomChirality(bond, atom)) {
           continue;
         }
         unsigned int otherIdx = bond->getOtherAtom(atom)->getIdx();
@@ -2267,7 +2269,7 @@ void assignChiralTypesFrom3D(ROMol &mol, int confId, bool replaceExistingTags) {
     }
     atom->setChiralTag(Atom::CHI_UNSPECIFIED);
     // additional reasons to skip the atom:
-    auto nzDegree = getAtomNonzeroDegree(atom);
+    auto nzDegree = Chirality::detail::getAtomNonzeroDegree(atom);
     auto tnzDegree = nzDegree + atom->getTotalNumHs();
     if (nzDegree < 3 || tnzDegree > 4) {
       // not enough explicit neighbors or too many total neighbors
@@ -2285,7 +2287,7 @@ void assignChiralTypesFrom3D(ROMol &mol, int confId, bool replaceExistingTags) {
     const RDGeom::Point3D *nbrs[3];
     unsigned int nbrIdx = 0;
     for (const auto bond : mol.atomBonds(atom)) {
-      if (!bondAffectsAtomChirality(bond, atom)) {
+      if (!Chirality::detail::bondAffectsAtomChirality(bond, atom)) {
         continue;
       }
       nbrs[nbrIdx++] = &conf.getAtomPos(bond->getOtherAtomIdx(atom->getIdx()));

--- a/Code/GraphMol/Chirality.cpp
+++ b/Code/GraphMol/Chirality.cpp
@@ -2294,9 +2294,7 @@ void assignChiralTypesFrom3D(ROMol &mol, int confId, bool replaceExistingTags) {
     mol.clearProp(common_properties::_StereochemDone);
   }
 
-  for (ROMol::AtomIterator atomIt = mol.beginAtoms(); atomIt != mol.endAtoms();
-       ++atomIt) {
-    Atom *atom = *atomIt;
+  for (auto atom : mol.atoms()) {
     // if we aren't replacing existing tags and the atom is already tagged,
     // punt:
     if (!replaceExistingTags && atom->getChiralTag() != Atom::CHI_UNSPECIFIED) {
@@ -2318,7 +2316,7 @@ void assignChiralTypesFrom3D(ROMol &mol, int confId, bool replaceExistingTags) {
         continue;
       }
     }
-    const RDGeom::Point3D &p0 = conf.getAtomPos(atom->getIdx());
+    const auto &p0 = conf.getAtomPos(atom->getIdx());
     const RDGeom::Point3D *nbrs[3];
     unsigned int nbrIdx = 0;
     for (const auto bond : mol.atomBonds(atom)) {
@@ -2330,9 +2328,9 @@ void assignChiralTypesFrom3D(ROMol &mol, int confId, bool replaceExistingTags) {
         break;
       }
     }
-    RDGeom::Point3D v1 = *nbrs[0] - p0;
-    RDGeom::Point3D v2 = *nbrs[1] - p0;
-    RDGeom::Point3D v3 = *nbrs[2] - p0;
+    auto v1 = *nbrs[0] - p0;
+    auto v2 = *nbrs[1] - p0;
+    auto v3 = *nbrs[2] - p0;
 
     double chiralVol = v1.dotProduct(v2.crossProduct(v3));
     if (chiralVol < -ZERO_VOLUME_TOL) {

--- a/Code/GraphMol/Chirality.h
+++ b/Code/GraphMol/Chirality.h
@@ -124,7 +124,9 @@ RDKIT_GRAPHMOL_EXPORT bool isAtomPotentialStereoAtom(const Atom *atom);
 RDKIT_GRAPHMOL_EXPORT bool isBondPotentialStereoBond(const Bond *bond);
 RDKIT_GRAPHMOL_EXPORT StereoInfo getStereoInfo(const Bond *bond);
 RDKIT_GRAPHMOL_EXPORT StereoInfo getStereoInfo(const Atom *atom);
-
+RDKIT_GRAPHMOL_EXPORT bool bondAffectsAtomChirality(const Bond *bond,
+                                                    const Atom *atom);
+RDKIT_GRAPHMOL_EXPORT unsigned int getAtomNonzeroDegree(const Atom *atom);
 }  // namespace detail
 /// @endcond
 

--- a/Code/GraphMol/FindStereo.cpp
+++ b/Code/GraphMol/FindStereo.cpp
@@ -216,19 +216,19 @@ bool isBondPotentialStereoBond(const Bond *bond) {
 
 bool isAtomPotentialTetrahedralCenter(const Atom *atom) {
   PRECONDITION(atom, "atom is null");
-
-  if (atom->getTotalDegree() > 4) {
+  auto nzDegree = getAtomNonzeroDegree(atom);
+  auto tnzDegree = nzDegree + atom->getTotalNumHs();
+  if (tnzDegree > 4) {
     return false;
   } else {
     const auto &mol = atom->getOwningMol();
-    auto degree = mol.getAtomDegree(atom);
-    if (degree == 4) {
+    if (nzDegree == 4) {
       // chirality is always possible with 4 nbrs
       return true;
-    } else if (degree == 1) {
+    } else if (nzDegree == 1) {
       // chirality is never possible with 1 nbr
       return false;
-    } else if (degree < 3 &&
+    } else if (nzDegree < 3 &&
                (atom->getAtomicNum() != 15 && atom->getAtomicNum() != 33)) {
       // less than three neighbors is never stereogenic
       // unless it is a phosphine/arsine with implicit H
@@ -239,7 +239,7 @@ bool isAtomPotentialTetrahedralCenter(const Atom *atom) {
       // are always treated as stereogenic even with H atom neighbors.
       // Accept automatically.
       return true;
-    } else if (degree == 3) {
+    } else if (nzDegree == 3) {
       // three-coordinate with a single H we'll accept automatically:
       if (atom->getTotalNumHs() == 1) {
         return true;

--- a/Code/GraphMol/FindStereo.cpp
+++ b/Code/GraphMol/FindStereo.cpp
@@ -350,6 +350,9 @@ std::vector<StereoInfo> findPotentialStereo(ROMol &mol, bool cleanIt,
       }
     } else {
       atomSymbols[aidx] = getAtomCompareSymbol(*atom);
+      if (cleanIt) {
+        atom->setChiralTag(Atom::ChiralType::CHI_UNSPECIFIED);
+      }
     }
   }
 

--- a/Code/GraphMol/catch_chirality.cpp
+++ b/Code/GraphMol/catch_chirality.cpp
@@ -1777,3 +1777,106 @@ TEST_CASE("replaceAtom and StereoGroups") {
     CHECK(mol->getStereoGroups()[0].getAtoms()[0] == mol->getAtomWithIdx(1));
   }
 }
+
+TEST_CASE(
+    "Github #5196: Zero & coordinate bonds are being taken into account for "
+    "chirality") {
+  auto mol = R"CTAB(
+     RDKit          3D
+
+  0  0  0  0  0  0  0  0  0  0999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 15 18 0 0 0
+M  V30 BEGIN ATOM
+M  V30 1 C -0.136359 0.025241 -0.986870 0
+M  V30 2 C 0.211183 -0.810922 0.138318 0
+M  V30 3 C -0.446638 -0.713741 1.305561 0
+M  V30 4 C -1.141107 0.914647 -0.916429 0
+M  V30 5 R -1.628248 -0.983190 -0.411960 0
+M  V30 6 H 0.392055 -0.106505 -1.920607 0
+M  V30 7 H 0.974038 -1.568492 0.017171 0
+M  V30 8 H -0.209921 -1.406535 2.084966 0
+M  V30 9 H -1.378909 1.482059 -1.807349 0
+M  V30 10 C -1.544607 0.306162 1.588191 0
+M  V30 11 C -1.946856 1.186683 0.358271 0
+M  V30 12 H -1.207983 0.944410 2.407927 0
+M  V30 13 H -2.419549 -0.225146 1.965589 0
+M  V30 14 H -3.006492 1.040978 0.144313 0
+M  V30 15 H -1.830875 2.240146 0.620809 0
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 1 2 1
+M  V30 2 2 3 2
+M  V30 3 2 4 1
+M  V30 4 0 1 5
+M  V30 5 0 2 5
+M  V30 6 0 3 5
+M  V30 7 0 4 5
+M  V30 8 1 1 6
+M  V30 9 1 2 7
+M  V30 10 1 3 8
+M  V30 11 1 4 9
+M  V30 12 1 10 3
+M  V30 13 1 11 4
+M  V30 14 1 11 10
+M  V30 15 1 12 10
+M  V30 16 1 13 10
+M  V30 17 1 14 11
+M  V30 18 1 15 11
+M  V30 END BOND
+M  V30 END CTAB
+M  END)CTAB"_ctab;
+  REQUIRE(mol);
+  SECTION("as reported") {
+    MolOps::assignStereochemistryFrom3D(*mol);
+    for (auto aidx : {0, 1, 2, 3}) {
+      CHECK(mol->getAtomWithIdx(aidx)->getChiralTag() ==
+            Atom::ChiralType::CHI_UNSPECIFIED);
+    }
+  }
+  SECTION("as reported - ZOBs") {
+    for (auto bidx : {3, 4, 5, 6}) {
+      mol->getBondWithIdx(bidx)->setBondType(Bond::BondType::ZERO);
+    }
+    MolOps::assignStereochemistryFrom3D(*mol);
+    for (auto idx : {0, 1, 2, 3}) {
+      CHECK(mol->getAtomWithIdx(idx)->getChiralTag() ==
+            Atom::ChiralType::CHI_UNSPECIFIED);
+    }
+  }
+  SECTION("as reported - datives") {
+    for (auto bidx : {3, 4, 5, 6}) {
+      mol->getBondWithIdx(bidx)->setBondType(Bond::BondType::DATIVE);
+    }
+    MolOps::assignStereochemistryFrom3D(*mol);
+    for (auto idx : {0, 1, 2, 3}) {
+      CHECK(mol->getAtomWithIdx(idx)->getChiralTag() ==
+            Atom::ChiralType::CHI_UNSPECIFIED);
+    }
+  }
+  SECTION("as reported - reversed datives") {
+    // structure is bogus, but we want to test
+    for (auto bidx : {3, 4, 5, 6}) {
+      auto bond = mol->getBondWithIdx(bidx);
+      bond->setEndAtomIdx(bond->getBeginAtomIdx());
+      bond->setBeginAtomIdx(4);
+      bond->setBondType(Bond::BondType::DATIVE);
+    }
+    MolOps::assignStereochemistryFrom3D(*mol);
+    for (auto idx : {0, 1, 2, 3}) {
+      CHECK(mol->getAtomWithIdx(idx)->getChiralTag() !=
+            Atom::ChiralType::CHI_UNSPECIFIED);
+    }
+  }
+  SECTION("as reported - singles") {
+    // structure is bogus, but we want to test
+    for (auto bidx : {3, 4, 5, 6}) {
+      mol->getBondWithIdx(bidx)->setBondType(Bond::BondType::SINGLE);
+    }
+    MolOps::assignStereochemistryFrom3D(*mol);
+    for (auto idx : {0, 1, 2, 3}) {
+      CHECK(mol->getAtomWithIdx(idx)->getChiralTag() !=
+            Atom::ChiralType::CHI_UNSPECIFIED);
+    }
+  }
+}

--- a/Code/GraphMol/catch_chirality.cpp
+++ b/Code/GraphMol/catch_chirality.cpp
@@ -1893,26 +1893,34 @@ M  END)CTAB"_ctab;
             Atom::ChiralType::CHI_UNSPECIFIED);
     }
   }
-  SECTION("assignStereochemistry - dative") {
+  SECTION("assignStereochemistry") {
     auto mol = "[Fe]C(=C)O |C:1.0|"_smiles;
     REQUIRE(mol);
-    mol->getAtomWithIdx(1)->setChiralTag(Atom::ChiralType::CHI_TETRAHEDRAL_CW);
-    bool cleanit = true;
-    bool force = true;
-    MolOps::assignStereochemistry(*mol, cleanit, force);
-    CHECK(mol->getAtomWithIdx(1)->getChiralTag() ==
-          Atom::ChiralType::CHI_UNSPECIFIED);
-  }
-  SECTION("assignStereochemistry - ZOB and unspecified") {
-    auto mol = "[Fe]C(=C)O |C:1.0|"_smiles;
-    REQUIRE(mol);
-    for (auto bt : {Bond::BondType::ZERO, Bond::BondType::UNSPECIFIED}) {
+    for (auto bt : {Bond::BondType::DATIVE, Bond::BondType::ZERO,
+                    Bond::BondType::UNSPECIFIED}) {
       mol->getAtomWithIdx(1)->setChiralTag(
           Atom::ChiralType::CHI_TETRAHEDRAL_CW);
       mol->getBondWithIdx(0)->setBondType(bt);
       bool cleanit = true;
       bool force = true;
       MolOps::assignStereochemistry(*mol, cleanit, force);
+      CHECK(mol->getAtomWithIdx(1)->getChiralTag() ==
+            Atom::ChiralType::CHI_UNSPECIFIED);
+    }
+  }
+  SECTION("isAtomPotentialTetrahedralCenter() and getStereoInfo()") {
+    auto mol = "[Fe]C(=C)O |C:1.0|"_smiles;
+    REQUIRE(mol);
+    for (auto bt : {Bond::BondType::DATIVE, Bond::BondType::ZERO,
+                    Bond::BondType::UNSPECIFIED}) {
+      mol->getAtomWithIdx(1)->setChiralTag(
+          Atom::ChiralType::CHI_TETRAHEDRAL_CW);
+      mol->getBondWithIdx(0)->setBondType(bt);
+      CHECK(!Chirality::detail::isAtomPotentialStereoAtom(
+          mol->getAtomWithIdx(1)));
+      bool cleanit = true;
+      auto sinfo = Chirality::findPotentialStereo(*mol, cleanit);
+      CHECK(sinfo.size() == 0);
       CHECK(mol->getAtomWithIdx(1)->getChiralTag() ==
             Atom::ChiralType::CHI_UNSPECIFIED);
     }

--- a/Code/GraphMol/catch_chirality.cpp
+++ b/Code/GraphMol/catch_chirality.cpp
@@ -1920,7 +1920,7 @@ M  END)CTAB"_ctab;
           mol->getAtomWithIdx(1)));
       bool cleanit = true;
       auto sinfo = Chirality::findPotentialStereo(*mol, cleanit);
-      CHECK(sinfo.size() == 0);
+      CHECK(sinfo.empty());
       CHECK(mol->getAtomWithIdx(1)->getChiralTag() ==
             Atom::ChiralType::CHI_UNSPECIFIED);
     }

--- a/Code/GraphMol/catch_chirality.cpp
+++ b/Code/GraphMol/catch_chirality.cpp
@@ -1779,6 +1779,19 @@ TEST_CASE("replaceAtom and StereoGroups") {
 }
 
 TEST_CASE(
+    "Github #5200: FindPotentialStereo does not clean stereoflags from atoms "
+    "which cannot be stereocenters") {
+  auto m = "CCF"_smiles;
+  REQUIRE(m);
+  m->getAtomWithIdx(1)->setChiralTag(Atom::ChiralType::CHI_TETRAHEDRAL_CCW);
+  bool cleanIt = true;
+  auto sinfo = Chirality::findPotentialStereo(*m, cleanIt);
+  CHECK(sinfo.empty());
+  CHECK(m->getAtomWithIdx(1)->getChiralTag() ==
+        Atom::ChiralType::CHI_UNSPECIFIED);
+}
+
+TEST_CASE(
     "Github #5196: Zero & coordinate bonds are being taken into account for "
     "chirality") {
   RDLog::LogStateSetter setter;  // disable irritating warning messages


### PR DESCRIPTION
`assignStereochemistry()` and `findPotentialStereo()` no longer take zero-order, unspecified, or dative bonds starting at an atom into account when figuring out the number of neighbors an atom has.

This doesn't do anything to the CIP assignment code. That assumes that atoms which have stereo markers should be considered for stereo, so there's no straightforward mechanism to add a "this can't be a stereo atom" check. As long as we're using either `assignStereochemistry()` or `findPotentialStereo()` to cleanup bogus stereo specifications before perceiving CIP I think everything should be fine though.

This also fixes #5200, which I discovered while working on this.