### PR TITLE
Fixes multiple definitions of symbols

### DIFF
--- a/Code/DataStructs/MultiFPBReader.cpp
+++ b/Code/DataStructs/MultiFPBReader.cpp
@@ -11,7 +11,6 @@
 #include <boost/tuple/tuple_comparison.hpp>
 
 #include <RDGeneral/Invariant.h>
-#include <RDGeneral/Ranking.h>
 #include <RDGeneral/RDThreads.h>
 #ifdef RDK_THREADSAFE_SSS
 #include <thread>

--- a/Code/GraphMol/FileParsers/MolFileStereochem.cpp
+++ b/Code/GraphMol/FileParsers/MolFileStereochem.cpp
@@ -10,12 +10,10 @@
 //
 #include <list>
 #include <RDGeneral/RDLog.h>
-#include "MolFileStereochem.h"
 #include <Geometry/point.h>
 #include <boost/dynamic_bitset.hpp>
 #include <algorithm>
 #include "MolFileStereochem.h"
-#include <RDGeneral/Ranking.h>
 
 namespace RDKit {
 typedef std::list<double> DOUBLE_LIST;
@@ -239,7 +237,9 @@ INT_MAP_INT pickBondsToWedge(const ROMol &mol) {
     // happen; I'll kick myself and do the hard solution at that point.)
     CHECK_INVARIANT(nbrScores.size(),
                     "no eligible neighbors for chiral center");
-    std::sort(nbrScores.begin(), nbrScores.end(), Rankers::pairLess);
+    std::sort(nbrScores.begin(), nbrScores.end(), [](const auto &v1, const auto &v2) {
+    return v1.first < v2.first;
+  });
     res[nbrScores[0].second] = idx;
   }
   return res;

--- a/Code/GraphMol/FileParsers/MolFileStereochem.cpp
+++ b/Code/GraphMol/FileParsers/MolFileStereochem.cpp
@@ -10,10 +10,11 @@
 //
 #include <list>
 #include <RDGeneral/RDLog.h>
+#include "MolFileStereochem.h"
 #include <Geometry/point.h>
 #include <boost/dynamic_bitset.hpp>
 #include <algorithm>
-#include "MolFileStereochem.h"
+#include <RDGeneral/Ranking.h>
 
 namespace RDKit {
 typedef std::list<double> DOUBLE_LIST;
@@ -237,9 +238,7 @@ INT_MAP_INT pickBondsToWedge(const ROMol &mol) {
     // happen; I'll kick myself and do the hard solution at that point.)
     CHECK_INVARIANT(nbrScores.size(),
                     "no eligible neighbors for chiral center");
-    std::sort(nbrScores.begin(), nbrScores.end(), [](const auto &v1, const auto &v2) {
-    return v1.first < v2.first;
-  });
+    std::sort(nbrScores.begin(), nbrScores.end(), Rankers::pairLess);
     res[nbrScores[0].second] = idx;
   }
   return res;

--- a/Code/GraphMol/FileParsers/MolFileWriter.cpp
+++ b/Code/GraphMol/FileParsers/MolFileWriter.cpp
@@ -17,6 +17,7 @@
 #include <RDGeneral/Invariant.h>
 #include <GraphMol/RDKitQueries.h>
 #include <GraphMol/SubstanceGroup.h>
+#include <RDGeneral/Ranking.h>
 #include <RDGeneral/LocaleSwitcher.h>
 
 #include <vector>
@@ -509,9 +510,7 @@ unsigned int getAtomParityFlag(const Atom *atom, const Conformer *conf) {
     vs.emplace_back(idx, v);
     ++nbrIdx;
   }
-  std::sort(vs.begin(), vs.end(), [](const auto &v1, const auto &v2) {
-    return v1.first < v2.first;
-  });
+  std::sort(vs.begin(), vs.end(), Rankers::pairLess);
   double vol;
   if (vs.size() == 4) {
     vol = vs[0].second.crossProduct(vs[1].second).dotProduct(vs[3].second);

--- a/Code/GraphMol/FileParsers/MolFileWriter.cpp
+++ b/Code/GraphMol/FileParsers/MolFileWriter.cpp
@@ -17,7 +17,6 @@
 #include <RDGeneral/Invariant.h>
 #include <GraphMol/RDKitQueries.h>
 #include <GraphMol/SubstanceGroup.h>
-#include <RDGeneral/Ranking.h>
 #include <RDGeneral/LocaleSwitcher.h>
 
 #include <vector>
@@ -510,7 +509,9 @@ unsigned int getAtomParityFlag(const Atom *atom, const Conformer *conf) {
     vs.emplace_back(idx, v);
     ++nbrIdx;
   }
-  std::sort(vs.begin(), vs.end(), Rankers::pairLess);
+  std::sort(vs.begin(), vs.end(), [](const auto &v1, const auto &v2) {
+    return v1.first < v2.first;
+  });
   double vol;
   if (vs.size() == 4) {
     vol = vs[0].second.crossProduct(vs[1].second).dotProduct(vs[3].second);

--- a/Code/GraphMol/FindStereo.cpp
+++ b/Code/GraphMol/FindStereo.cpp
@@ -8,7 +8,6 @@
 //  of the RDKit source tree.
 //
 #include <GraphMol/RDKitBase.h>
-#include <RDGeneral/Ranking.h>
 #include <GraphMol/new_canon.h>
 #include <RDGeneral/types.h>
 #include <algorithm>

--- a/Code/RDGeneral/Ranking.h
+++ b/Code/RDGeneral/Ranking.h
@@ -24,13 +24,13 @@
 #include <cstdint>
 
 namespace Rankers {
-auto pairGreater = [](const auto &v1, const auto &v2) {
+inline auto pairGreater = [](const auto &v1, const auto &v2) {
   return v1.first > v2.first;
 };
 
 //! function for implementing < on two std::pairs.  The first entries are
 /// compared.
-auto pairLess = [](const auto &v1, const auto &v2) {
+inline auto pairLess = [](const auto &v1, const auto &v2) {
   return v1.first < v2.first;
 };
 


### PR DESCRIPTION
My build (GCC 11.1.0) is currently failing due to multiple definitions of `Rankers::pairGreater` and `Rankers::pairLess`:
```
/scratch/toscopa1/.conda/envs/pyds_v0.9L/bin/../lib/gcc/x86_64-conda-linux-gnu/11.1.0/../../../../x86_64-conda-linux-gnu/bin/ld: CMakeFiles/DataStructs.dir/MultiFPBReader.cpp.o:(.bss+0x0): multiple definition of `Rankers::pairLess';
CMakeFiles/DataStructs.dir/FPBReader.cpp.o:(.bss+0x0): first defined here
/scratch/toscopa1/.conda/envs/pyds_v0.9L/bin/../lib/gcc/x86_64-conda-linux-gnu/11.1.0/../../../../x86_64-conda-linux-gnu/bin/ld: CMakeFiles/DataStructs.dir/MultiFPBReader.cpp.o:(.bss+0x1): multiple definition of `Rankers::pairGreater'; CMakeFiles/DataStructs.dir/FPBReader.cpp.o:(.bss+0x1): first defined here
```
Looking at the code, it seems that different lambdas (i.e., taking different data types as parameters) are being associated to the same variable, which I believe justifies the error.
While some clashes can be removed by removing unnecessary `#include` keywords, others can't and require copying the lambda. This seems a simpler solution than using a templated function.