### PR TITLE
Add support for Qt6

### DIFF
--- a/Code/GraphMol/MolDraw2D/CMakeLists.txt
+++ b/Code/GraphMol/MolDraw2D/CMakeLists.txt
@@ -1,5 +1,6 @@
 
 option(RDK_BUILD_QT_SUPPORT "build support for QT drawing" OFF )
+option(RDK_USE_QT6 "Use Qt6 instead of Qt5" OFF )
 option(RDK_BUILD_QT_DEMO "build the QT drawing demo" OFF )
 option(RDK_BUILD_CAIRO_SUPPORT "build support for Cairo drawing" OFF )
 option(RDK_BUILD_FREETYPE_SUPPORT "build support for FreeType font handling" ON)

--- a/Code/GraphMol/MolDraw2D/Qt/CMakeLists.txt
+++ b/Code/GraphMol/MolDraw2D/Qt/CMakeLists.txt
@@ -30,6 +30,7 @@ install(TARGETS QtDependencies EXPORT ${RDKit_EXPORTED_TARGETS} COMPONENT dev )
 rdkit_headers(MolDraw2DQt.h DEST GraphMol/MolDraw2D/Qt)
 if(RDK_INSTALL_STATIC_LIBS)
   target_link_libraries(MolDraw2DQt_static PUBLIC QtDependencies)
+  target_compile_definitions(MolDraw2DQt_static PRIVATE "-DRDK_QT_VERSION=\"${RDK_QT_VERSION_STRING}\"")
   target_sources(MolDraw2DQt_static PRIVATE MolDraw2DQt.cpp DrawTextQt.cpp)
 endif()
 

--- a/Code/GraphMol/MolDraw2D/Qt/CMakeLists.txt
+++ b/Code/GraphMol/MolDraw2D/Qt/CMakeLists.txt
@@ -9,12 +9,17 @@ add_library(QtDependencies INTERFACE)
 if (RDK_USE_QT6)
   find_package(Qt6 COMPONENTS Core Widgets OpenGL REQUIRED)
   target_link_libraries(QtDependencies INTERFACE Qt6::Core Qt6::OpenGL Qt6::Widgets)
+  set(RDK_QT_VERSION_STRING ${Qt6Core_VERSION})
 else(RDK_USE_QT6)
   find_package(Qt5 COMPONENTS Core Widgets OpenGL REQUIRED)
   target_link_libraries(QtDependencies INTERFACE Qt5::Core Qt5::OpenGL Qt5::Widgets)
+  set(RDK_QT_VERSION_STRING ${Qt5Core_VERSION})
 endif(RDK_USE_QT6)
 
 target_link_libraries(MolDraw2DQt PUBLIC QtDependencies)
+target_compile_definitions(MolDraw2DQt PRIVATE "-DRDK_QT_VERSION=\"${RDK_QT_VERSION_STRING}\"")
+
+install(TARGETS QtDependencies EXPORT ${RDKit_EXPORTED_TARGETS} COMPONENT dev )
 
 rdkit_headers(MolDraw2DQt.h DEST GraphMol/MolDraw2D/Qt)
 if(RDK_INSTALL_STATIC_LIBS)

--- a/Code/GraphMol/MolDraw2D/Qt/CMakeLists.txt
+++ b/Code/GraphMol/MolDraw2D/Qt/CMakeLists.txt
@@ -4,12 +4,21 @@ rdkit_library(MolDraw2DQt MolDraw2DQt.cpp DrawTextQt.cpp
   MolDraw2D)
 target_compile_definitions(MolDraw2DQt PRIVATE RDKIT_MOLDRAW2DQT_BUILD)
 target_compile_definitions(MolDraw2DQt PUBLIC "-DRDK_BUILD_QT_SUPPORT")
-find_package(Qt5 COMPONENTS Widgets OpenGL REQUIRED)
-target_link_libraries(MolDraw2DQt PUBLIC Qt5::Widgets Qt5::OpenGL)
+
+add_library(QtDependencies INTERFACE)
+if (RDK_USE_QT6)
+  find_package(Qt6 COMPONENTS Core Widgets OpenGL REQUIRED)
+  target_link_libraries(QtDependencies INTERFACE Qt6::Core Qt6::OpenGL Qt6::Widgets)
+else(RDK_USE_QT6)
+  find_package(Qt5 COMPONENTS Core Widgets OpenGL REQUIRED)
+  target_link_libraries(QtDependencies INTERFACE Qt5::Core Qt5::OpenGL Qt5::Widgets)
+endif(RDK_USE_QT6)
+
+target_link_libraries(MolDraw2DQt PUBLIC QtDependencies)
 
 rdkit_headers(MolDraw2DQt.h DEST GraphMol/MolDraw2D/Qt)
 if(RDK_INSTALL_STATIC_LIBS)
-  target_link_libraries(MolDraw2DQt_static PUBLIC Qt5::Widgets Qt5::OpenGL)
+  target_link_libraries(MolDraw2DQt_static PUBLIC QtDependencies)
   target_sources(MolDraw2DQt_static PRIVATE MolDraw2DQt.cpp DrawTextQt.cpp)
 endif()
 
@@ -21,7 +30,7 @@ if(RDK_BUILD_FREETYPE_SUPPORT)
     target_compile_definitions(MolDraw2DQt_static PUBLIC "-DRDK_BUILD_FREETYPE_SUPPORT")
     target_sources(MolDraw2DQt_static PRIVATE DrawTextFTQt.cpp)
   endif()
-  # I think Emscripten with Qt is nonsense, so 
+  # I think Emscripten with Qt is nonsense, so
   find_package(Freetype REQUIRED)
   target_link_libraries(MolDraw2DQt PUBLIC Freetype::Freetype)
   if(RDK_INSTALL_STATIC_LIBS)
@@ -30,8 +39,7 @@ if(RDK_BUILD_FREETYPE_SUPPORT)
 endif(RDK_BUILD_FREETYPE_SUPPORT)
 
 if(RDK_BUILD_QT_SUPPORT)
-rdkit_catch_test(moldraw2DTestQt catch_qt.cpp LINK_LIBRARIES
-  MolDraw2DQt Qt5::Widgets Qt5::OpenGL)
+  rdkit_catch_test(moldraw2DTestQt catch_qt.cpp LINK_LIBRARIES MolDraw2DQt)
 endif(RDK_BUILD_QT_SUPPORT)
 
 if(RDK_BUILD_QT_DEMO)

--- a/Code/GraphMol/MolDraw2D/Qt/CMakeLists.txt
+++ b/Code/GraphMol/MolDraw2D/Qt/CMakeLists.txt
@@ -14,7 +14,13 @@ else(RDK_USE_QT6)
   find_package(Qt5 COMPONENTS Core Widgets OpenGL REQUIRED)
   target_link_libraries(QtDependencies INTERFACE Qt5::Core Qt5::OpenGL Qt5::Widgets)
   set(RDK_QT_VERSION_STRING ${Qt5Core_VERSION})
+  if (RDK_QT_VERSION_STRING STREQUAL "")
+    # QT < 5.9 uses Qt5Core_VERSION_STRING
+    set(RDK_QT_VERSION_STRING ${Qt5Core_VERSION_STRING})
+  endif()
 endif(RDK_USE_QT6)
+
+message(STATUS "Building with Qt version ${RDK_QT_VERSION_STRING}")
 
 target_link_libraries(MolDraw2DQt PUBLIC QtDependencies)
 target_compile_definitions(MolDraw2DQt PRIVATE "-DRDK_QT_VERSION=\"${RDK_QT_VERSION_STRING}\"")

--- a/Code/GraphMol/MolDraw2D/Qt/Demo/CMakeLists.txt
+++ b/Code/GraphMol/MolDraw2D/Qt/Demo/CMakeLists.txt
@@ -34,7 +34,7 @@ set( LIBS Boost::program_options Boost::iostreams Boost::filesystem
   ${RDKit_THREAD_LIBS}
   FileParsers SmilesParse Depictor RDGeometryLib
   RDGeneral SubstructMatch Subgraphs GraphMol RDGeometryLib
-   z QtWidgetDependencies)
+   z QtDependencies)
 
 add_executable( rdkitsv ${RDKitSV_SRCS}
   ${RDKitSV_MOC_SRCS} ${RDKitSV_INCS} )

--- a/Code/GraphMol/MolDraw2D/Qt/Demo/CMakeLists.txt
+++ b/Code/GraphMol/MolDraw2D/Qt/Demo/CMakeLists.txt
@@ -30,13 +30,11 @@ set( RDKitSV_INCS MolDisplay2DWidget.H
   QTGet2Strings.H
   QT4SelectItems.H )
 
-find_package(Qt5 COMPONENTS Widgets OpenGL REQUIRED)
-
 set( LIBS Boost::program_options Boost::iostreams Boost::filesystem
   ${RDKit_THREAD_LIBS}
   FileParsers SmilesParse Depictor RDGeometryLib
   RDGeneral SubstructMatch Subgraphs GraphMol RDGeometryLib
-   z Qt5::Widgets Qt5::OpenGL )
+   z QtWidgetDependencies)
 
 add_executable( rdkitsv ${RDKitSV_SRCS}
   ${RDKitSV_MOC_SRCS} ${RDKitSV_INCS} )

--- a/Code/GraphMol/MolDraw2D/Qt/MolDraw2DQt.cpp
+++ b/Code/GraphMol/MolDraw2D/Qt/MolDraw2DQt.cpp
@@ -24,6 +24,8 @@ using namespace std;
 
 namespace RDKit {
 
+const char *rdkitQtVersion = RDK_QT_VERSION;
+
 // ****************************************************************************
 MolDraw2DQt::MolDraw2DQt(int width, int height, QPainter *qp, int panelWidth,
                          int panelHeight, bool noFreetype)

--- a/Code/GraphMol/MolDraw2D/Qt/MolDraw2DQt.h
+++ b/Code/GraphMol/MolDraw2D/Qt/MolDraw2DQt.h
@@ -23,6 +23,8 @@ class QString;
 
 namespace RDKit {
 
+RDKIT_MOLDRAW2DQT_EXPORT extern const char *rdkitQtVersion;
+
 class RDKIT_MOLDRAW2DQT_EXPORT MolDraw2DQt : public MolDraw2D {
  public:
   MolDraw2DQt(int width, int height, QPainter *qp, int panelWidth = -1,

--- a/Code/GraphMol/MolDraw2D/Qt/Wrap/CMakeLists.txt
+++ b/Code/GraphMol/MolDraw2D/Qt/Wrap/CMakeLists.txt
@@ -1,10 +1,8 @@
 remove_definitions(-DRDKIT_MOLDRAW2DQT_BUILD)
 
-find_package(Qt5 COMPONENTS Core OpenGL REQUIRED)
-
 rdkit_python_extension(rdMolDraw2DQt
                        rdMolDraw2DQt.cpp
                        DEST Chem/Draw
-                       LINK_LIBRARIES MolDraw2DQt Qt5::Core Qt5::OpenGL )
+                       LINK_LIBRARIES MolDraw2DQt)
 
 add_pytest(pyMolDraw2DQt ${CMAKE_CURRENT_SOURCE_DIR}/testMolDraw2DQt.py)

--- a/Code/GraphMol/MolDraw2D/Qt/Wrap/rdMolDraw2DQt.cpp
+++ b/Code/GraphMol/MolDraw2D/Qt/Wrap/rdMolDraw2DQt.cpp
@@ -34,6 +34,8 @@ BOOST_PYTHON_MODULE(rdMolDraw2DQt) {
   python::scope().attr("__doc__") =
       "Module containing a C++ implementation of 2D molecule drawing using Qt";
 
+  python::scope().attr("rdkitQtVersion") = RDKit::rdkitQtVersion;
+
   std::string docString = "Qt molecule drawer";
   python::class_<RDKit::MolDraw2DQt, python::bases<RDKit::MolDraw2D>,
                  boost::noncopyable>("MolDraw2DQt", docString.c_str(),

--- a/Code/GraphMol/MolDraw2D/Qt/Wrap/testMolDraw2DQt.py
+++ b/Code/GraphMol/MolDraw2D/Qt/Wrap/testMolDraw2DQt.py
@@ -10,9 +10,11 @@ from rdkit.Chem.Draw import rdMolDraw2DQt
 
 try:
   if rdMolDraw2DQt.rdkitQtVersion.startswith('6'):
-    from PyQt6.Qt import *
+    from PyQt6.QtGui import *
+    Format_RGB32 = QImage.Format.Format_RGB32
   else:
     from PyQt5.Qt import *
+    Format_RGB32 = QImage.Format_RGB32
 except ImportError:
   # If we can't find Qt, there's nothing we can do
   sip = None
@@ -41,7 +43,7 @@ class TestCase(unittest.TestCase):
   def testSIPBasics(self):
     m = Chem.MolFromSmiles('c1ccccc1O')
     Draw.PrepareMolForDrawing(m)
-    qimg = QImage(250, 200, QImage.Format_RGB32)
+    qimg = QImage(250, 200, Format_RGB32)
     with QPainter(qimg) as qptr:
       p = sip.unwrapinstance(qptr)
       d2d = rdMolDraw2DQt.MolDraw2DFromQPainter_(250, 200, p)
@@ -51,7 +53,7 @@ class TestCase(unittest.TestCase):
   def testBasics(self):
     m = Chem.MolFromSmiles('c1ccccc1O')
     Draw.PrepareMolForDrawing(m)
-    qimg = QImage(250, 200, QImage.Format_RGB32)
+    qimg = QImage(250, 200, Format_RGB32)
     with QPainter(qimg) as qptr:
       d2d = Draw.MolDraw2DFromQPainter(qptr)
       d2d.DrawMolecule(m)
@@ -62,7 +64,7 @@ class TestCase(unittest.TestCase):
     def testfunc():
       m = Chem.MolFromSmiles('c1ccccc1O')
       Draw.PrepareMolForDrawing(m)
-      qimg = QImage(250, 200, QImage.Format_RGB32)
+      qimg = QImage(250, 200, Format_RGB32)
       with QPainter(qimg) as qptr:
         p = sip.unwrapinstance(qptr)
         d2d = rdMolDraw2DQt.MolDraw2DFromQPainter_(250, 200, p, -1, -1)
@@ -76,7 +78,7 @@ class TestCase(unittest.TestCase):
     def testfunc():
       m = Chem.MolFromSmiles('c1ccccc1O')
       Draw.PrepareMolForDrawing(m)
-      qimg = QImage(250, 200, QImage.Format_RGB32)
+      qimg = QImage(250, 200, Format_RGB32)
       with QPainter(qimg) as qptr:
         d2d = Draw.MolDraw2DFromQPainter(qptr)
       raise ValueError("expected")

--- a/Code/GraphMol/MolDraw2D/Qt/Wrap/testMolDraw2DQt.py
+++ b/Code/GraphMol/MolDraw2D/Qt/Wrap/testMolDraw2DQt.py
@@ -1,19 +1,28 @@
-from rdkit import RDConfig
+import sys
 import unittest
+
 from rdkit import Chem
-from rdkit.Chem import Draw, AllChem, rdDepictor
+from rdkit import RDConfig
+from rdkit.Chem import AllChem
+from rdkit.Chem import Draw
+from rdkit.Chem import rdDepictor
 from rdkit.Chem.Draw import rdMolDraw2DQt
 
-import sys
 try:
-  from PyQt5.Qt import *
+  if rdMolDraw2DQt.rdkitQtVersion.startswith('6'):
+    from PyQt6.Qt import *
+  else:
+    from PyQt5.Qt import *
 except ImportError:
   # If we can't find Qt, there's nothing we can do
   sip = None
 else:
   try:
-    # Prefer the PyQt5-bundled sip
-    from PyQt5 import sip
+    # Prefer the PyQt-bundled sip
+    if rdMolDraw2DQt.rdkitQtVersion.startswith('6'):
+      from PyQt6 import sip
+    else:
+      from PyQt5 import sip
   except ImportError:
     # No bundled sip, try the standalone package
     try:
@@ -21,7 +30,6 @@ else:
     except ImportError:
       # No sip at all
       sip = None
-
 
 
 @unittest.skipIf(sip is None, "skipping tests because pyqt is not installed")

--- a/rdkit/Chem/Draw/UnitTestDraw.py
+++ b/rdkit/Chem/Draw/UnitTestDraw.py
@@ -14,8 +14,8 @@ import unittest
 
 from rdkit import Chem
 from rdkit.Chem import AllChem
-from rdkit.Chem import rdDepictor
 from rdkit.Chem import Draw
+from rdkit.Chem import rdDepictor
 from rdkit.Chem import rdMolDescriptors
 
 try:
@@ -105,13 +105,21 @@ class TestCase(unittest.TestCase):
 
   @unittest.skipIf(qtCanvas is None, 'Skipping Qt test')
   def testQtImage(self):
+    from rdkit.Chem.Draw.rdMolDraw2DQt import rdkitQtVersion
     try:
       from PySide import QtGui
     except ImportError:
       try:
-        from PyQt5 import QtGui
+        if rdkitQtVersion.startswith('6'):
+          from PyQt6.Qt import QtGui
+        else:
+          from PyQt5.Qt import QtGui
       except ImportError:
-        from PySide2 import QtGui
+        if rdkitQtVersion.startswith('6'):
+          # PySide version numbers leapt at Qt6
+          from PySide6 import QtGui
+        else:
+          from PySide2 import QtGui
     _ = QtGui.QGuiApplication(sys.argv)
     img = Draw.MolToQPixmap(self.mol, size=(300, 300))
     self.assertTrue(img)

--- a/rdkit/Chem/Draw/UnitTestDraw.py
+++ b/rdkit/Chem/Draw/UnitTestDraw.py
@@ -43,14 +43,14 @@ except ImportError:
 class TestCase(unittest.TestCase):
   showAllImages = False
 
-  def test_interactive(self):
-    # We avoid checking in the code with development flag set
-    self.assertFalse(self.showAllImages)
-
   def setUp(self):
     if IPythonConsole is not None and Draw.MolsToGridImage == IPythonConsole.ShowMols:
       IPythonConsole.UninstallIPythonRenderer()
     self.mol = Chem.MolFromSmiles('c1c(C[15NH3+])ccnc1[C@](Cl)(Br)[C@](Cl)(Br)F')
+
+  def test_interactive(self):
+    # We avoid checking in the code with development flag set
+    self.assertFalse(self.showAllImages)
 
   def _testMolToFile(self):
     try:
@@ -106,20 +106,22 @@ class TestCase(unittest.TestCase):
   @unittest.skipIf(qtCanvas is None, 'Skipping Qt test')
   def testQtImage(self):
     from rdkit.Chem.Draw.rdMolDraw2DQt import rdkitQtVersion
-    try:
-      from PySide import QtGui
-    except ImportError:
+    if rdkitQtVersion.startswith('6'):
       try:
-        if rdkitQtVersion.startswith('6'):
-          from PyQt6.Qt import QtGui
-        else:
-          from PyQt5.Qt import QtGui
+        from PyQt6 import QtGui
       except ImportError:
-        if rdkitQtVersion.startswith('6'):
-          # PySide version numbers leapt at Qt6
-          from PySide6 import QtGui
-        else:
+        # PySide version numbers leapt at Qt6
+        from PySide6 import QtGui
+    else:
+      try:
+        from PyQt5.Qt import QtGui
+      except ImportError:
+        try:
+          from PySide import QtGui
+        except ImportError:
+          # PySide2 supports Qt >= 5.12
           from PySide2 import QtGui
+
     _ = QtGui.QGuiApplication(sys.argv)
     img = Draw.MolToQPixmap(self.mol, size=(300, 300))
     self.assertTrue(img)

--- a/rdkit/Chem/Draw/UnitTestDraw.py
+++ b/rdkit/Chem/Draw/UnitTestDraw.py
@@ -114,7 +114,7 @@ class TestCase(unittest.TestCase):
         from PySide6 import QtGui
     else:
       try:
-        from PyQt5.Qt import QtGui
+        from PyQt5 import QtGui
       except ImportError:
         try:
           from PySide import QtGui

--- a/rdkit/Chem/Draw/__init__.py
+++ b/rdkit/Chem/Draw/__init__.py
@@ -180,7 +180,7 @@ if _sip_available():
       if rdMolDraw2DQt.rdkitQtVersion.startswith('6'):
         from PyQt6 import sip
       else:
-        from PyQt5.Qt import sip
+        from PyQt5 import sip
     except ImportError:
       # No bundled sip, try the standalone package
       import sip

--- a/rdkit/Chem/Draw/__init__.py
+++ b/rdkit/Chem/Draw/__init__.py
@@ -9,14 +9,19 @@
 #
 import os
 import warnings
+from collections import namedtuple
 from importlib.util import find_spec
+from io import BytesIO
 
-from rdkit.Chem.Draw import rdMolDraw2D
-from rdkit.Chem.Draw.MolDrawing import MolDrawing, DrawingOptions
-from rdkit.Chem.Draw.rdMolDraw2D import *
-from rdkit.Chem import rdDepictor
-from rdkit import Chem, rdBase
+import numpy
+from rdkit import Chem
 from rdkit import RDConfig
+from rdkit import rdBase
+from rdkit.Chem import rdDepictor
+from rdkit.Chem.Draw import rdMolDraw2D
+from rdkit.Chem.Draw.MolDrawing import DrawingOptions
+from rdkit.Chem.Draw.MolDrawing import MolDrawing
+from rdkit.Chem.Draw.rdMolDraw2D import *
 
 
 def _getCanvas():
@@ -150,24 +155,35 @@ def _legacyMolToImage(mol, size, kekulize, wedgeBonds, fitImage, options, canvas
 
 
 def _sip_available():
-  if find_spec('PyQt5') and find_spec('PyQt5.sip'):
+  try:
+    from rdkit.Chem.Draw.rdMolDraw2DQt import rdkitQtVersion
+  except ImportError:
+    return False
+  pyqt_pkg = f'PyQt{rdkitQtVersion[0]}'
+  if find_spec(pyqt_pkg) and find_spec(f'{pyqt_pkg}.sip'):
     return True
   elif find_spec('sip'):
     return True
   return False
 
 
-if find_spec('rdkit.Chem.Draw.rdMolDraw2DQt') and _sip_available():
+if _sip_available():
 
   def MolDraw2DFromQPainter(qpainter, width=-1, height=-1, panelWidth=-1, panelHeight=-1):
-    from PyQt5.Qt import QPainter
+    from rdkit.Chem.Draw import rdMolDraw2DQt
+    if rdMolDraw2DQt.rdkitQtVersion.startswith('6'):
+      from PyQt6.Qt import QPainter
+    else:
+      from PyQt5.Qt import QPainter
     try:
-      # Prefer the PyQt5-bundled sip
-      from PyQt5 import sip
+      # Prefer the PyQt-bundled sip
+      if rdMolDraw2DQt.rdkitQtVersion.startswith('6'):
+        from PyQt6.Qt import sip
+      else:
+        from PyQt5.Qt import sip
     except ImportError:
       # No bundled sip, try the standalone package
       import sip
-    from rdkit.Chem.Draw import rdMolDraw2DQt
 
     if not isinstance(qpainter, QPainter):
       raise ValueError("argument must be a QPainter instance")
@@ -312,6 +328,7 @@ def ShowMol(mol, size=(300, 300), kekulize=True, wedgeBonds=True, title='RDKit M
   """ Generates a picture of a molecule and displays it in a Tkinter window
   """
   import tkinter
+
   from PIL import ImageTk
 
   img = MolToImage(mol, size, kekulize, wedgeBonds, **kwargs)
@@ -359,9 +376,6 @@ def MolToMPL(mol, size=(300, 300), kekulize=True, wedgeBonds=True, imageType=Non
     omol._atomPs[k] = canvas.rescalePt(v)
   canvas._figure.set_size_inches(float(size[0]) / 100, float(size[1]) / 100)
   return canvas._figure
-
-
-import numpy
 
 
 def _bivariate_normal(X, Y, sigmax=1.0, sigmay=1.0, mux=0.0, muy=0.0, sigmaxy=0.0):
@@ -424,9 +438,6 @@ def MolsToImage(mols, subImgSize=(200, 200), legends=None, **kwargs):
   for i, mol in enumerate(mols):
     res.paste(MolToImage(mol, subImgSize, legend=legends[i], **kwargs), (i * subImgSize[0], 0))
   return res
-
-
-from io import BytesIO
 
 
 def _drawerToImage(d2d):
@@ -717,7 +728,6 @@ def DrawMorganBits(tpls, **kwargs):
 
 # adapted from the function drawFPBits._drawFPBit() from the CheTo package
 # original author Nadine Schneider
-from collections import namedtuple
 FingerprintEnv = namedtuple(
   'FingerprintEnv',
   ('submol', 'highlightAtoms', 'atomColors', 'highlightBonds', 'bondColors', 'highlightRadii'))

--- a/rdkit/Chem/Draw/__init__.py
+++ b/rdkit/Chem/Draw/__init__.py
@@ -172,13 +172,13 @@ if _sip_available():
   def MolDraw2DFromQPainter(qpainter, width=-1, height=-1, panelWidth=-1, panelHeight=-1):
     from rdkit.Chem.Draw import rdMolDraw2DQt
     if rdMolDraw2DQt.rdkitQtVersion.startswith('6'):
-      from PyQt6.Qt import QPainter
+      from PyQt6.QtGui import QPainter
     else:
       from PyQt5.Qt import QPainter
     try:
       # Prefer the PyQt-bundled sip
       if rdMolDraw2DQt.rdkitQtVersion.startswith('6'):
-        from PyQt6.Qt import sip
+        from PyQt6 import sip
       else:
         from PyQt5.Qt import sip
     except ImportError:

--- a/rdkit/Chem/Draw/qtCanvas.py
+++ b/rdkit/Chem/Draw/qtCanvas.py
@@ -11,25 +11,39 @@
 from rdkit.Chem.Draw.canvasbase import CanvasBase
 from rdkit.Chem.Draw.rdMolDraw2DQt import rdkitQtVersion
 
-try:
-  from PySide import QtCore
-  from PySide import QtGui
-except ImportError:
+if rdkitQtVersion.startswith('6'):
   try:
-    if rdkitQtVersion.startswith('6'):
-      from PyQt6 import QtCore
-      from PyQt6 import QtGui
-    else:
-      from PyQt5 import QtCore
-      from PyQt5 import QtGui
+    from PyQt6 import QtCore
+    from PyQt6 import QtGui
   except ImportError:
-    if rdkitQtVersion.startswith('6'):
-      # PySide version numbers leapt at Qt6
-      from PySide6 import QtCore
-      from PySide6 import QtGui
-    else:
+    # PySide version numbers leapt at Qt6
+    from PySide6 import QtCore
+    from PySide6 import QtGui
+
+  QPainter_Antialiasing = QtGui.QPainter.RenderHint.Antialiasing
+  QPainter_SmoothPixmapTransform = QtGui.QPainter.RenderHint.SmoothPixmapTransform
+  GlobalColor_white = QtCore.Qt.GlobalColor.white
+  PenStile_SolidLine = QtCore.Qt.PenStyle.SolidLine
+  PenStile_DashLine = QtCore.Qt.PenStyle.DashLine
+
+else:
+  try:
+    from PyQt5 import QtCore
+    from PyQt5 import QtGui
+  except ImportError:
+    try:
+      from PySide import QtCore
+      from PySide import QtGui
+    except ImportError:
+      # PySide2 supports Qt >= 5.12
       from PySide2 import QtCore
       from PySide2 import QtGui
+
+  QPainter_Antialiasing = QtGui.QPainter.Antialiasing
+  QPainter_SmoothPixmapTransform = QtGui.QPainter.SmoothPixmapTransform
+  GlobalColor_white = QtCore.Qt.white
+  PenStile_SolidLine = QtCore.Qt.SolidLine
+  PenStile_DashLine = QtCore.Qt.DashLine
 
 
 class Canvas(CanvasBase):
@@ -39,15 +53,15 @@ class Canvas(CanvasBase):
     self.qsize = QtCore.QSize(*size)
     self.pixmap = QtGui.QPixmap(self.qsize)
     self.painter = QtGui.QPainter(self.pixmap)
-    self.painter.setRenderHint(QtGui.QPainter.Antialiasing, True)
-    self.painter.setRenderHint(QtGui.QPainter.SmoothPixmapTransform, True)
-    self.painter.fillRect(0, 0, size[0], size[1], QtCore.Qt.white)
+    self.painter.setRenderHint(QPainter_Antialiasing, True)
+    self.painter.setRenderHint(QPainter_SmoothPixmapTransform, True)
+    self.painter.fillRect(0, 0, size[0], size[1], GlobalColor_white)
 
   def addCanvasLine(self, p1, p2, color=(0, 0, 0), color2=None, **kwargs):
     if 'dash' in kwargs:
-      line_type = QtCore.Qt.DashLine
+      line_type = PenStile_DashLine
     else:
-      line_type = QtCore.Qt.SolidLine
+      line_type = PenStile_SolidLine
     qp1 = QtCore.QPointF(*p1)
     qp2 = QtCore.QPointF(*p2)
     qpm = QtCore.QPointF((p1[0] + p2[0]) / 2, (p1[1] + p2[1]) / 2)
@@ -93,14 +107,14 @@ class Canvas(CanvasBase):
     for ver in ps:
       polygon.append(QtCore.QPointF(*ver))
     color = [int(c * 255) for c in color]
-    pen = QtGui.QPen(QtGui.QColor(*color), 1, QtCore.Qt.SolidLine)
+    pen = QtGui.QPen(QtGui.QColor(*color), 1, PenStile_DashLine)
     self.painter.setPen(pen)
     self.painter.setBrush(QtGui.QColor(0, 0, 0))
     self.painter.drawPolygon(polygon)
 
   def addCanvasDashedWedge(self, p1, p2, p3, dash=(2, 2), color=(0, 0, 0), color2=None, **kwargs):
     rgb = [int(c * 255) for c in color]
-    pen = QtGui.QPen(QtGui.QColor(*rgb), 1, QtCore.Qt.SolidLine)
+    pen = QtGui.QPen(QtGui.QColor(*rgb), 1, PenStile_DashLine)
     self.painter.setPen(pen)
     dash = (4, 4)
     pts1 = self._getLinePoints(p1, p2, dash)

--- a/rdkit/Chem/Draw/qtCanvas.py
+++ b/rdkit/Chem/Draw/qtCanvas.py
@@ -9,13 +9,27 @@
 #
 
 from rdkit.Chem.Draw.canvasbase import CanvasBase
+from rdkit.Chem.Draw.rdMolDraw2DQt import rdkitQtVersion
+
 try:
-  from PySide import QtGui, QtCore
+  from PySide import QtCore
+  from PySide import QtGui
 except ImportError:
   try:
-    from PyQt5 import QtGui, QtCore
+    if rdkitQtVersion.startswith('6'):
+      from PyQt6 import QtCore
+      from PyQt6 import QtGui
+    else:
+      from PyQt5 import QtCore
+      from PyQt5 import QtGui
   except ImportError:
-    from PySide2 import QtGui, QtCore
+    if rdkitQtVersion.startswith('6'):
+      # PySide version numbers leapt at Qt6
+      from PySide6 import QtCore
+      from PySide6 import QtGui
+    else:
+      from PySide2 import QtCore
+      from PySide2 import QtGui
 
 
 class Canvas(CanvasBase):


### PR DESCRIPTION
This adds support for Qt6.

By setting `RDK_USE_QT6=ON`, we will use Qt6 instead of Qt5 to build.

I added a `rdkitQtVersion` attribute to the `rdMolDraw2DQt` Python module to indicate which Qt version was used in the build. The version will be populated with the Qt version found by CMake via a macro definition.

`PySide6` may sound weird, since for Qt5 we use `PySide`/`PySide2`, but that's the right one according to https://www.qt.io/blog/qt-for-python-6-released.

We don't currently have any CI with Qt6, but I've tested this with Qt6 on Linux and Mac, and I'm currently working on Windows. So  far, everything built fine and passed tests, except a couple of Inchi ones which failed on both platforms, but I think that's not related.

I'll keep this as WIP while I run more testing and fix any potential problems I still might encounter.