### PR TITLE
Fixes array overflow in FMCS code

### DIFF
--- a/Code/GraphMol/FMCS/MaximumCommonSubgraph.cpp
+++ b/Code/GraphMol/FMCS/MaximumCommonSubgraph.cpp
@@ -114,8 +114,8 @@ void MaximumCommonSubgraph::init() {
   unsigned currentLabelValue = 1;
   std::vector<LabelDefinition> labels;
   nq = QueryMolecule->getNumAtoms();
-  QueryAtomLabels.resize(nq);
-  for (size_t ai = 0; ai < nq; ai++) {
+  QueryAtomLabels.resize(nq, NotSet);
+  for (size_t ai = 0; ai < nq; ++ai) {
     if (MCSAtomCompareAny ==
         Parameters.AtomTyper) {  // predefined functor without atom compare
                                  // parameters
@@ -157,8 +157,8 @@ void MaximumCommonSubgraph::init() {
   labels.clear();
   currentLabelValue = 1;
   nq = QueryMolecule->getNumBonds();
-  QueryBondLabels.resize(nq);
-  for (size_t aj = 0; aj < nq; aj++) {
+  QueryBondLabels.resize(nq, NotSet);
+  for (size_t aj = 0; aj < nq; ++aj) {
     const Bond* bond = QueryMolecule->getBondWithIdx(aj);
     unsigned ring = 0;
     if (!userData && (Parameters.BondCompareParameters.CompleteRingsOnly ||
@@ -201,7 +201,7 @@ void MaximumCommonSubgraph::init() {
           break;
         }
       }
-      if (NotSet == QueryAtomLabels[aj]) {  // not found -> create new label
+      if (NotSet == QueryBondLabels[aj]) {  // not found -> create new label
         QueryBondLabels[aj] = ++currentLabelValue;
         labels.emplace_back(aj, currentLabelValue);
       }

--- a/Code/GraphMol/FMCS/SubstructMatchCustom.h
+++ b/Code/GraphMol/FMCS/SubstructMatchCustom.h
@@ -9,6 +9,7 @@
 //
 #include <RDGeneral/export.h>
 #pragma once
+#include <limits>
 #include <vector>
 #include "FMCS.h"
 #include "Graph.h"
@@ -19,7 +20,7 @@ namespace FMCS {
 typedef std::vector<
     std::pair<FMCS::Graph::vertex_descriptor, FMCS::Graph::vertex_descriptor>>
     match_V_t;
-const unsigned int NotSet = (unsigned int)-1;
+const unsigned int NotSet = std::numeric_limits<unsigned int>::max();
 
 RDKIT_FMCS_EXPORT bool SubstructMatchCustomTable(
     const FMCS::Graph& target, const ROMol& target_mol,


### PR DESCRIPTION
I've been playing with address sanitization on Python tests (fortunately, asan is way faster than valgrind when working around Python).

Some Python test revealed an array overflow in line 204 of Code/GraphMol/FMCS/MaximumCommonSubgraph.cpp. I'm not familiar with the FMCS code, but this looks like a bug to me.

Sadly, I don't know how to write a test that would expose this.