### PR TITLE
Fixes #5207

### DIFF
--- a/Code/GraphMol/PeriodicTable.cpp
+++ b/Code/GraphMol/PeriodicTable.cpp
@@ -15,7 +15,7 @@ typedef boost::tokenizer<boost::char_separator<char>> tokenizer;
 #include <sstream>
 #include <locale>
 
-#ifdef RDK_BUILD_THREADSAFE_SSS
+#ifdef RDK_THREADSAFE_SSS
 #include <mutex>
 #endif
 
@@ -104,7 +104,7 @@ void PeriodicTable::initInstance() {
 }
 
 PeriodicTable *PeriodicTable::getTable() {
-#ifdef RDK_BUILD_THREADSAFE_SSS
+#ifdef RDK_THREADSAFE_SSS
   static std::once_flag pt_init_once;
   std::call_once(pt_init_once, initInstance);
 #else


### PR DESCRIPTION
Fixes #5207 by using the "correct" macro name mentioned in the CMake file (see the attached issue).

I'm adding the quotes because `RDK_THREADSAFE_SSS`, despite being the actual name of the macro we use, and being used in several other places, is apparently not the right name, or so we said in 2018:

https://github.com/rdkit/rdkit/blob/66476f01c014b4f0b81b2ff9851120227a5d548b/ReleaseNotes.md?plain=1#L2469-L2482

It's not the only macro we've messed up, though: `USE_BUILTIN_POPCOUNT` still seems to be used in some places, although it was first renamed to  and then, more recently, to `RDK_OPTIMIZE_POPCNT`, `BUILD_COORDGEN_SUPPORT` seems to be used once in one ROMol.i

I think we should fix the names at some point, but for now, I'm just renaming these to fix the periodic table.

Oh, and the Release Notes document it self seems to be messed up a bit too, since this whole block repeats again further down:
https://github.com/rdkit/rdkit/blob/66476f01c014b4f0b81b2ff9851120227a5d548b/ReleaseNotes.md?plain=1#L8971-L8984