### PR TITLE
Fix use of not thread safe function localtime() 

### DIFF
--- a/Code/RDGeneral/RDLog.cpp
+++ b/Code/RDGeneral/RDLog.cpp
@@ -152,7 +152,8 @@ void InitLogs() {
 std::ostream &toStream(std::ostream &logstrm) {
   char buffer[16];
   time_t t = time(nullptr);
-  strftime(buffer, 16, "[%T] ", localtime(&t));
+  struct tm buf;
+  strftime(buffer, 16, "[%T] ", localtime_r(&t, &buf));
   return logstrm << buffer;
 }
 }  // namespace RDLog

--- a/Code/RDGeneral/RDLog.cpp
+++ b/Code/RDGeneral/RDLog.cpp
@@ -152,8 +152,14 @@ void InitLogs() {
 std::ostream &toStream(std::ostream &logstrm) {
   char buffer[16];
   time_t t = time(nullptr);
+  struct tm *tm;
+// localtime() is thread safe on windows, but not on *nix
+#ifdef WIN32
+  strftime(buffer, 16, "[%T] ", localtime(&t));
+#else
   struct tm buf;
   strftime(buffer, 16, "[%T] ", localtime_r(&t, &buf));
+#endif
   return logstrm << buffer;
 }
 }  // namespace RDLog


### PR DESCRIPTION
`localtime()` is not thread safe (https://linux.die.net/man/3/localtime): 

> 
> The four functions asctime(), ctime(), gmtime() and localtime() return a pointer to static data and hence are not thread-safe. 
> Thread-safe versions asctime_r(), ctime_r(), gmtime_r() and localtime_r() are specified by SUSv2, and available since libc 5.2.5. 
> 

RDkit uses `localtime()` in logging, and the thread sanitizer flags its usage as a data race. Fortunately, it's easy to fix.