### PR TITLE
Fix duplicate non thread safe check in VarianceDataForLabel

### DIFF
--- a/Code/GraphMol/RGroupDecomposition/RGroupFingerprintScore.cpp
+++ b/Code/GraphMol/RGroupDecomposition/RGroupFingerprintScore.cpp
@@ -238,11 +238,13 @@ static std::mutex groupMutex;
 
 // add an rgroup structure to a bit counts array
 void VarianceDataForLabel::addRgroupData(RGroupData *rgroupData) {
+  {
 #ifdef RDK_THREADSAFE_SSS
-  const std::lock_guard<std::mutex> lock(groupMutex);
+    const std::lock_guard<std::mutex> lock(groupMutex);
 #endif
-  if (rgroupData->fingerprint == nullptr) {
-    addFingerprintToRGroupData(rgroupData);
+    if (rgroupData->fingerprint == nullptr) {
+      addFingerprintToRGroupData(rgroupData);
+    }
   }
 
   ++numberFingerprints;

--- a/Code/GraphMol/RGroupDecomposition/RGroupFingerprintScore.cpp
+++ b/Code/GraphMol/RGroupDecomposition/RGroupFingerprintScore.cpp
@@ -59,7 +59,7 @@ void addFingerprintToRGroupData(RGroupData *rgroupData) {
                            : MorganFingerprints::getFingerprintAsBitVect(
                                  mol, 2, fingerprintSize);
     fingerprint->getOnBits(rgroupData->fingerprintOnBits);
-    rgroupData->fingerprint = std::unique_ptr<ExplicitBitVect>(fingerprint);
+    rgroupData->fingerprint.reset(fingerprint);
 
 #ifdef DEBUG
     std::cerr << "Combined mol smiles " << MolToSmiles(*rgroupData->combinedMol)
@@ -238,14 +238,13 @@ static std::mutex groupMutex;
 
 // add an rgroup structure to a bit counts array
 void VarianceDataForLabel::addRgroupData(RGroupData *rgroupData) {
-  if (rgroupData->fingerprint == nullptr) {
 #ifdef RDK_THREADSAFE_SSS
-    const std::lock_guard<std::mutex> lock(groupMutex);
+  const std::lock_guard<std::mutex> lock(groupMutex);
 #endif
-    if (rgroupData->fingerprint == nullptr) {
-      addFingerprintToRGroupData(rgroupData);
-    }
+  if (rgroupData->fingerprint == nullptr) {
+    addFingerprintToRGroupData(rgroupData);
   }
+
   ++numberFingerprints;
   const auto &onBits = rgroupData->fingerprintOnBits;
   for (int b : onBits) {


### PR DESCRIPTION
Another detection flagged by the thread sanitizer.

In this case, there's a data race condition in `rgroupData->fingerprint`, which is updated inside `addFingerprintToRGroupData()`. Maybe not a big issue due to the duplicated check, but it's still good to get it fixed by removing the duplicate check outside the mutex.