### PR TITLE
Fix data race in MultithreadedMolSupplier 

### DIFF
--- a/Code/GraphMol/FileParsers/MultithreadedMolSupplier.h
+++ b/Code/GraphMol/FileParsers/MultithreadedMolSupplier.h
@@ -85,7 +85,8 @@ class RDKIT_FILEPARSERS_EXPORT MultithreadedMolSupplier : public MolSupplier {
   std::thread d_readerThread;                    //! single reader thread
 
  protected:
-  unsigned int d_lastRecordId = 0;           //! stores last extracted record id
+  std::atomic<unsigned int> d_lastRecordId =
+      0;                                     //! stores last extracted record id
   std::string d_lastItemText;                //! stores last extracted record
   const unsigned int d_numReaderThread = 1;  //! number of reader thread
   unsigned int d_numWriterThreads;           //! number of writer threads


### PR DESCRIPTION
Another thread sanitizer detection: `d_lastRecordId` is, apparently, written and read by different threads, so we need to make sure it's accessed one at a time.