### PR TITLE
Allow linking against Python 3.6

### DIFF
--- a/Code/RDBoost/Wrap/RDBase.cpp
+++ b/Code/RDBoost/Wrap/RDBase.cpp
@@ -78,11 +78,11 @@ struct PyLogStream : std::ostream, std::streambuf {
   }
 
   ~PyLogStream() {
-    #if PY_VERSION_HEX > 0x03070000
+#if PY_VERSION_HEX > 0x03070000
     if (!_Py_IsFinalizing()) {
       Py_XDECREF(logfn);
     }
-    #endif
+#endif
   }
 
   int overflow(int c) override {

--- a/Code/RDBoost/Wrap/RDBase.cpp
+++ b/Code/RDBoost/Wrap/RDBase.cpp
@@ -78,9 +78,11 @@ struct PyLogStream : std::ostream, std::streambuf {
   }
 
   ~PyLogStream() {
+    #if PY_VERSION_HEX > 0x03070000
     if (!_Py_IsFinalizing()) {
       Py_XDECREF(logfn);
     }
+    #endif
   }
 
   int overflow(int c) override {


### PR DESCRIPTION
`_Py_IsFinalizing()` was introduced in Python 3.7, so RDKit will fail to build against Python 3.6, as I realized today.
I do realize that Python 3.6 is deprecated, but I think it is a bit too early to prevent building RDKit against it.
As I understand the workaround that I propose will only cause a minor memory leak.