### PR TITLE
Fix qt build under VS2019

### DIFF
--- a/Code/GraphMol/MolDraw2D/Qt/DrawTextFTQt.cpp
+++ b/Code/GraphMol/MolDraw2D/Qt/DrawTextFTQt.cpp
@@ -20,6 +20,8 @@ DrawTextFTQt::DrawTextFTQt(double max_fnt_sz, double min_fnt_sz,
                            const std::string &font_file, QPainter *qp)
     : DrawTextFT(max_fnt_sz, min_fnt_sz, font_file), d_qp(qp) {}
 
+DrawTextFTQt::~DrawTextFTQt() = default;
+
 // ****************************************************************************
 double DrawTextFTQt::extractOutline() {
   dp_qpp.reset(new QPainterPath());

--- a/Code/GraphMol/MolDraw2D/Qt/DrawTextFTQt.h
+++ b/Code/GraphMol/MolDraw2D/Qt/DrawTextFTQt.h
@@ -12,8 +12,6 @@
 #ifndef RDKIT_DRAWTEXTFTQT_H
 #define RDKIT_DRAWTEXTFTQT_H
 
-#include <boost/noncopyable.hpp>
-
 #include <RDGeneral/export.h>
 #include <GraphMol/MolDraw2D/DrawTextFT.h>
 #include "DrawTextQt.h"
@@ -26,8 +24,7 @@ namespace RDKit {
 namespace MolDraw2D_detail {
 // ****************************************************************************
 
-class RDKIT_MOLDRAW2DQT_EXPORT DrawTextFTQt : public DrawTextFT,
-                                              public boost::noncopyable {
+class RDKIT_MOLDRAW2DQT_EXPORT DrawTextFTQt : public DrawTextFT {
  public:
   DrawTextFTQt(double max_fnt_sz, double min_fnt_sz,
                const std::string &font_file, QPainter *qp);

--- a/Code/GraphMol/MolDraw2D/Qt/DrawTextFTQt.h
+++ b/Code/GraphMol/MolDraw2D/Qt/DrawTextFTQt.h
@@ -12,6 +12,8 @@
 #ifndef RDKIT_DRAWTEXTFTQT_H
 #define RDKIT_DRAWTEXTFTQT_H
 
+#include <boost/noncopyable.hpp>
+
 #include <RDGeneral/export.h>
 #include <GraphMol/MolDraw2D/DrawTextFT.h>
 #include "DrawTextQt.h"
@@ -24,10 +26,14 @@ namespace RDKit {
 namespace MolDraw2D_detail {
 // ****************************************************************************
 
-class RDKIT_MOLDRAW2DQT_EXPORT DrawTextFTQt : public DrawTextFT {
+class RDKIT_MOLDRAW2DQT_EXPORT DrawTextFTQt : public DrawTextFT,
+                                              public boost::noncopyable {
  public:
   DrawTextFTQt(double max_fnt_sz, double min_fnt_sz,
                const std::string &font_file, QPainter *qp);
+
+  ~DrawTextFTQt();
+
   DrawTextFTQt(const DrawTextFTQt &rhs) = delete;
   DrawTextFTQt(DrawTextFTQt &&rhs) = delete;
   DrawTextFTQt &operator=(const DrawTextFTQt &rhs) = delete;


### PR DESCRIPTION
I finally managed to test the Qt6 build under Windows, which requires VS2019.

The first try failed because the compiler complained about `QPainterPath` when it tried to generate a deleter function, I assume while trying to create a default destructor on header file import:
```
MSVC\14.29.30133\include\memory(3119): error C2027: use of undefined type 'QPainterPath'
C:\build\rdkit\Code\GraphMol\MolDraw2D\Qt\DrawTextFTQt.h(20): note: see declaration of 'QPainterPath'
MSVC\14.29.30133\include\memory(3118): note: while compiling class template member function 'void std::default_delete<QPainterPath>::operator ()(_Ty *) noexcept const'
```

Declaring the destructor, and specifying it to be a default in the implementation file solved the issue.

Also, given the unique pointer member, I decided to make the class non-copyable while I was here.