### PR TITLE
Fixes #5239

### DIFF
--- a/Code/GraphMol/Atom.cpp
+++ b/Code/GraphMol/Atom.cpp
@@ -23,6 +23,19 @@
 
 namespace RDKit {
 
+unsigned int getAtomNonzeroDegree(const Atom *atom) {
+  PRECONDITION(atom, "bad pointer");
+  PRECONDITION(atom->hasOwningMol(), "no owning molecule");
+  unsigned int res = 0;
+  for (auto bond : atom->getOwningMol().atomBonds(atom)) {
+    if (!bondAffectsAtomChirality(bond, atom)) {
+      continue;
+    }
+    ++res;
+  }
+  return res;
+}
+
 bool isAromaticAtom(const Atom &atom) {
   if (atom.getIsAromatic()) {
     return true;
@@ -41,125 +54,125 @@ bool isAromaticAtom(const Atom &atom) {
 // Determine whether or not an element is to the left of carbon.
 bool isEarlyAtom(int atomicNum) {
   static const bool table[119] = {
-    false, // #0 *
-    false, // #1 H
-    false,  // #2 He
-    true,  // #3 Li
-    true,  // #4 Be
-    true,  // #5 B
-    false, // #6 C
-    false, // #7 N
-    false, // #8 O
-    false, // #9 F
-    false, // #10 Ne
-    true,  // #11 Na
-    true,  // #12 Mg
-    true,  // #13 Al
-    false, // #14 Si
-    false, // #15 P
-    false, // #16 S
-    false, // #17 Cl
-    false, // #18 Ar
-    true,  // #19 K
-    true,  // #20 Ca
-    true,  // #21 Sc
-    true,  // #22 Ti
-    false, // #23 V
-    false, // #24 Cr
-    false, // #25 Mn
-    false, // #26 Fe
-    false, // #27 Co
-    false, // #28 Ni
-    false, // #29 Cu
-    true,  // #30 Zn
-    true,  // #31 Ga
-    true,  // #32 Ge  see github #2606
-    false, // #33 As
-    false, // #34 Se
-    false, // #35 Br
-    false, // #36 Kr
-    true,  // #37 Rb
-    true,  // #38 Sr
-    true,  // #39 Y
-    true,  // #40 Zr
-    true,  // #41 Nb
-    false, // #42 Mo
-    false, // #43 Tc
-    false, // #44 Ru
-    false, // #45 Rh
-    false, // #46 Pd
-    false, // #47 Ag
-    true,  // #48 Cd
-    true,  // #49 In
-    true,  // #50 Sn  see github #2606
-    true,  // #51 Sb  see github #2775
-    false, // #52 Te
-    false, // #53 I
-    false, // #54 Xe
-    true,  // #55 Cs
-    true,  // #56 Ba
-    true,  // #57 La
-    true,  // #58 Ce
-    true,  // #59 Pr
-    true,  // #60 Nd
-    true,  // #61 Pm
-    false, // #62 Sm
-    false, // #63 Eu
-    false, // #64 Gd
-    false, // #65 Tb
-    false, // #66 Dy
-    false, // #67 Ho
-    false, // #68 Er
-    false, // #69 Tm
-    false, // #70 Yb
-    false, // #71 Lu
-    true,  // #72 Hf
-    true,  // #73 Ta
-    false, // #74 W
-    false, // #75 Re
-    false, // #76 Os
-    false, // #77 Ir
-    false, // #78 Pt
-    false, // #79 Au
-    true,  // #80 Hg
-    true,  // #81 Tl
-    true,  // #82 Pb  see github #2606
-    true,  // #83 Bi  see github #2775
-    false, // #84 Po
-    false, // #85 At
-    false, // #86 Rn
-    true,  // #87 Fr
-    true,  // #88 Ra
-    true,  // #89 Ac
-    true,  // #90 Th
-    true,  // #91 Pa
-    true,  // #92 U
-    true,  // #93 Np
-    false, // #94 Pu
-    false, // #95 Am
-    false, // #96 Cm
-    false, // #97 Bk
-    false, // #98 Cf
-    false, // #99 Es
-    false, // #100 Fm
-    false, // #101 Md
-    false, // #102 No
-    false, // #103 Lr
-    true,  // #104 Rf
-    true,  // #105 Db
-    true,  // #106 Sg
-    true,  // #107 Bh
-    true,  // #108 Hs
-    true,  // #109 Mt
-    true,  // #110 Ds
-    true,  // #111 Rg
-    true,  // #112 Cn
-    true,  // #113 Nh
-    true,  // #114 Fl
-    true,  // #115 Mc
-    true,  // #116 Lv
-    true,  // #117 Ts
-    true,  // #118 Og
+      false,  // #0 *
+      false,  // #1 H
+      false,  // #2 He
+      true,   // #3 Li
+      true,   // #4 Be
+      true,   // #5 B
+      false,  // #6 C
+      false,  // #7 N
+      false,  // #8 O
+      false,  // #9 F
+      false,  // #10 Ne
+      true,   // #11 Na
+      true,   // #12 Mg
+      true,   // #13 Al
+      false,  // #14 Si
+      false,  // #15 P
+      false,  // #16 S
+      false,  // #17 Cl
+      false,  // #18 Ar
+      true,   // #19 K
+      true,   // #20 Ca
+      true,   // #21 Sc
+      true,   // #22 Ti
+      false,  // #23 V
+      false,  // #24 Cr
+      false,  // #25 Mn
+      false,  // #26 Fe
+      false,  // #27 Co
+      false,  // #28 Ni
+      false,  // #29 Cu
+      true,   // #30 Zn
+      true,   // #31 Ga
+      true,   // #32 Ge  see github #2606
+      false,  // #33 As
+      false,  // #34 Se
+      false,  // #35 Br
+      false,  // #36 Kr
+      true,   // #37 Rb
+      true,   // #38 Sr
+      true,   // #39 Y
+      true,   // #40 Zr
+      true,   // #41 Nb
+      false,  // #42 Mo
+      false,  // #43 Tc
+      false,  // #44 Ru
+      false,  // #45 Rh
+      false,  // #46 Pd
+      false,  // #47 Ag
+      true,   // #48 Cd
+      true,   // #49 In
+      true,   // #50 Sn  see github #2606
+      true,   // #51 Sb  see github #2775
+      false,  // #52 Te
+      false,  // #53 I
+      false,  // #54 Xe
+      true,   // #55 Cs
+      true,   // #56 Ba
+      true,   // #57 La
+      true,   // #58 Ce
+      true,   // #59 Pr
+      true,   // #60 Nd
+      true,   // #61 Pm
+      false,  // #62 Sm
+      false,  // #63 Eu
+      false,  // #64 Gd
+      false,  // #65 Tb
+      false,  // #66 Dy
+      false,  // #67 Ho
+      false,  // #68 Er
+      false,  // #69 Tm
+      false,  // #70 Yb
+      false,  // #71 Lu
+      true,   // #72 Hf
+      true,   // #73 Ta
+      false,  // #74 W
+      false,  // #75 Re
+      false,  // #76 Os
+      false,  // #77 Ir
+      false,  // #78 Pt
+      false,  // #79 Au
+      true,   // #80 Hg
+      true,   // #81 Tl
+      true,   // #82 Pb  see github #2606
+      true,   // #83 Bi  see github #2775
+      false,  // #84 Po
+      false,  // #85 At
+      false,  // #86 Rn
+      true,   // #87 Fr
+      true,   // #88 Ra
+      true,   // #89 Ac
+      true,   // #90 Th
+      true,   // #91 Pa
+      true,   // #92 U
+      true,   // #93 Np
+      false,  // #94 Pu
+      false,  // #95 Am
+      false,  // #96 Cm
+      false,  // #97 Bk
+      false,  // #98 Cf
+      false,  // #99 Es
+      false,  // #100 Fm
+      false,  // #101 Md
+      false,  // #102 No
+      false,  // #103 Lr
+      true,   // #104 Rf
+      true,   // #105 Db
+      true,   // #106 Sg
+      true,   // #107 Bh
+      true,   // #108 Hs
+      true,   // #109 Mt
+      true,   // #110 Ds
+      true,   // #111 Rg
+      true,   // #112 Cn
+      true,   // #113 Nh
+      true,   // #114 Fl
+      true,   // #115 Mc
+      true,   // #116 Lv
+      true,   // #117 Ts
+      true,   // #118 Og
   };
   return ((unsigned int)atomicNum < 119) && table[atomicNum];
 }
@@ -686,11 +699,10 @@ int Atom::getPerturbationOrder(const INT_LIST &probe) const {
       dp_mol,
       "perturbation order not defined for atoms not associated with molecules")
   INT_LIST ref;
-  ROMol::OEDGE_ITER beg, end;
-  boost::tie(beg, end) = getOwningMol().getAtomBonds(this);
-  while (beg != end) {
-    ref.push_back(getOwningMol()[*beg]->getIdx());
-    ++beg;
+  for (auto bond : getOwningMol().atomBonds(this)) {
+    if (bondAffectsAtomChirality(bond, this)) {
+      ref.push_back(bond->getIdx());
+    }
   }
   int nSwaps = static_cast<int>(countSwapsToInterconvert(probe, ref));
   return nSwaps;

--- a/Code/GraphMol/Atom.h
+++ b/Code/GraphMol/Atom.h
@@ -264,7 +264,7 @@ class RDKIT_GRAPHMOL_EXPORT Atom : public RDProps {
   // This method can be used to distinguish query atoms from standard atoms:
   virtual bool hasQuery() const { return false; }
 
-  virtual std::string getQueryType() const {return "";}
+  virtual std::string getQueryType() const { return ""; }
 
   //! NOT CALLABLE
   virtual void setQuery(QUERYATOM_QUERY *what);
@@ -434,16 +434,18 @@ RDKIT_GRAPHMOL_EXPORT std::string getAtomValue(const Atom *atom);
 RDKIT_GRAPHMOL_EXPORT void setSupplementalSmilesLabel(Atom *atom,
                                                       const std::string &label);
 RDKIT_GRAPHMOL_EXPORT std::string getSupplementalSmilesLabel(const Atom *atom);
-};  // namespace RDKit
-//! allows Atom objects to be dumped to streams
-RDKIT_GRAPHMOL_EXPORT std::ostream &operator<<(std::ostream &target,
-                                               const RDKit::Atom &at);
 
-namespace RDKit {
 //! returns true if the atom is to the left of C
 RDKIT_GRAPHMOL_EXPORT bool isEarlyAtom(int atomicNum);
 //! returns true if the atom is aromatic or has an aromatic bond
 RDKIT_GRAPHMOL_EXPORT bool isAromaticAtom(const Atom &atom);
 
+unsigned int RDKIT_GRAPHMOL_EXPORT getAtomNonzeroDegree(const Atom *atom);
+
 }  // namespace RDKit
+
+//! allows Atom objects to be dumped to streams
+RDKIT_GRAPHMOL_EXPORT std::ostream &operator<<(std::ostream &target,
+                                               const RDKit::Atom &at);
+
 #endif

--- a/Code/GraphMol/Bond.cpp
+++ b/Code/GraphMol/Bond.cpp
@@ -14,6 +14,18 @@
 
 namespace RDKit {
 
+bool bondAffectsAtomChirality(const Bond *bond, const Atom *atom) {
+  PRECONDITION(bond, "bad bond pointer");
+  PRECONDITION(atom, "bad atom pointer");
+  if (bond->getBondType() == Bond::BondType::UNSPECIFIED ||
+      bond->getBondType() == Bond::BondType::ZERO ||
+      (bond->getBondType() == Bond::BondType::DATIVE &&
+       bond->getBeginAtomIdx() == atom->getIdx())) {
+    return false;
+  }
+  return true;
+}
+
 Bond::Bond() : RDProps() { initBond(); };
 
 Bond::Bond(BondType bT) : RDProps() {

--- a/Code/GraphMol/Bond.h
+++ b/Code/GraphMol/Bond.h
@@ -384,6 +384,9 @@ class RDKIT_GRAPHMOL_EXPORT Bond : public RDProps {
 //! (e.g. SINGLE->2, AROMATIC->3, etc.)
 RDKIT_GRAPHMOL_EXPORT extern uint8_t getTwiceBondType(const RDKit::Bond &b);
 
+bool RDKIT_GRAPHMOL_EXPORT bondAffectsAtomChirality(const Bond *bond,
+                                                    const Atom *atom);
+
 };  // namespace RDKit
 
 //! allows Bond objects to be dumped to streams

--- a/Code/GraphMol/Chirality.h
+++ b/Code/GraphMol/Chirality.h
@@ -124,9 +124,6 @@ RDKIT_GRAPHMOL_EXPORT bool isAtomPotentialStereoAtom(const Atom *atom);
 RDKIT_GRAPHMOL_EXPORT bool isBondPotentialStereoBond(const Bond *bond);
 RDKIT_GRAPHMOL_EXPORT StereoInfo getStereoInfo(const Bond *bond);
 RDKIT_GRAPHMOL_EXPORT StereoInfo getStereoInfo(const Atom *atom);
-RDKIT_GRAPHMOL_EXPORT bool bondAffectsAtomChirality(const Bond *bond,
-                                                    const Atom *atom);
-RDKIT_GRAPHMOL_EXPORT unsigned int getAtomNonzeroDegree(const Atom *atom);
 }  // namespace detail
 /// @endcond
 

--- a/Code/GraphMol/catch_chirality.cpp
+++ b/Code/GraphMol/catch_chirality.cpp
@@ -1926,3 +1926,37 @@ M  END)CTAB"_ctab;
     }
   }
 }
+
+TEST_CASE(
+    "Github #5239: Precondition violation on chiral Atoms with zero order "
+    "bonds") {
+  RDLog::LogStateSetter setter;  // disable irritating warning messages
+  auto molblock = R"CTAB(
+     RDKit          3D
+
+  0  0  0  0  0  0  0  0  0  0999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 5 4 0 0 0
+M  V30 BEGIN ATOM
+M  V30 1 C -0.446600 -0.713700 1.305600 0
+M  V30 2 Fe -1.628200 -0.983200 -0.412000 0
+M  V30 3 Cl -0.049300 -1.876700 2.613900 0
+M  V30 4 C -1.544600 0.306200 1.588200 0
+M  V30 5 F 0.673700 0.029200 0.993700 0
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 1 1 3
+M  V30 2 1 1 4 CFG=1
+M  V30 3 1 1 5
+M  V30 4 0 2 1
+M  V30 END BOND
+M  V30 END CTAB
+M  END)CTAB";
+  bool sanitize = false;
+  std::unique_ptr<ROMol> mol(MolBlockToMol(molblock, sanitize));
+  REQUIRE(mol);
+  MolOps::assignStereochemistryFrom3D(*mol);
+
+  CHECK(mol->getAtomWithIdx(0)->getChiralTag() !=
+        Atom::ChiralType::CHI_UNSPECIFIED);
+}


### PR DESCRIPTION
The problem was happening because, as a side effect of not considering zerp/coordinate/unspecified bonds when determining if an atom could be chiral, these bonds were also not added to the list of bonds used to calculate parity. But they still were included in the other list, the one we use as reference, which caused the precondition violation inside `Atom::getPerturbationOrder()`, which requires both lists to have the same size.

This fixes #5239  by also excluding zero/coordinate/unspecified bonds from the reference list.
