### PR TITLE
Make TautomerQuery serializable

### DIFF
--- a/Code/GraphMol/TautomerQuery/CMakeLists.txt
+++ b/Code/GraphMol/TautomerQuery/CMakeLists.txt
@@ -1,7 +1,13 @@
+if(RDK_USE_BOOST_SERIALIZATION AND Boost_SERIALIZATION_LIBRARY)
+    set(RDKit_SERIALIZATION_LIBS ${Boost_SERIALIZATION_LIBRARY})
+else()
+    message("== Making SubstructLibrary without boost Serialization support")
+    set(RDKit_SERIALIZATION_LIBS )
+endif()
 
 rdkit_library(TautomerQuery 
               TautomerQuery.cpp
-              LINK_LIBRARIES GraphMol RDGeneral MolStandardize)
+              LINK_LIBRARIES GraphMol RDGeneral MolStandardize ${RDKit_SERIALIZATION_LIBS})
 target_compile_definitions(TautomerQuery PRIVATE RDKIT_TAUTOMERQUERY_BUILD)
 
 rdkit_headers(TautomerQuery.h

--- a/Code/GraphMol/TautomerQuery/CMakeLists.txt
+++ b/Code/GraphMol/TautomerQuery/CMakeLists.txt
@@ -11,4 +11,4 @@ if(RDK_BUILD_PYTHON_WRAPPERS)
 add_subdirectory(Wrap)
 endif()
 
-rdkit_catch_test(tautomerQueryTestCatch catch_tests.cpp LINK_LIBRARIES TautomerQuery )
+rdkit_catch_test(tautomerQueryTestCatch catch_tests.cpp ../catch_main.cpp LINK_LIBRARIES TautomerQuery )

--- a/Code/GraphMol/TautomerQuery/TautomerQuery.cpp
+++ b/Code/GraphMol/TautomerQuery/TautomerQuery.cpp
@@ -22,6 +22,14 @@
 #include <GraphMol/Fingerprints/Fingerprints.h>
 // #define VERBOSE
 
+#ifdef RDK_USE_BOOST_SERIALIZATION
+#include <RDGeneral/BoostStartInclude.h>
+#include <boost/archive/text_oarchive.hpp>
+#include <boost/archive/text_iarchive.hpp>
+#include <boost/archive/archive_exception.hpp>
+#include <RDGeneral/BoostEndInclude.h>
+#endif
+
 #ifdef VERBOSE
 #include <GraphMol/SmilesParse/SmilesWrite.h>
 #endif
@@ -70,6 +78,14 @@ void removeTautomerDuplicates(std::vector<MatchVectType> &matches,
 }  // namespace
 
 namespace RDKit {
+
+bool TautomerQueryCanSerialize() {
+#ifdef RDK_USE_BOOST_SERIALIZATION
+  return true;
+#else
+  return false;
+#endif
+}
 
 class TautomerQueryMatcher {
  private:
@@ -277,6 +293,35 @@ std::vector<MatchVectType> SubstructMatch(
     const ROMol &mol, const TautomerQuery &query,
     const SubstructMatchParameters &params) {
   return query.substructOf(mol, params);
+}
+
+void TautomerQuery::toStream(std::ostream &ss) const {
+#ifndef RDK_USE_BOOST_SERIALIZATION
+  PRECONDITION(0, "Boost SERIALIZATION is not enabled")
+#else
+  boost::archive::text_oarchive ar(ss);
+  ar << *this;
+#endif
+}
+
+std::string TautomerQuery::toBinary() const {
+  std::stringstream ss;
+  toStream(ss);
+  return ss.str();
+}
+
+void TautomerQuery::initFromStream(std::istream &ss) {
+#ifndef RDK_USE_BOOST_SERIALIZATION
+  PRECONDITION(0, "Boost SERIALIZATION is not enabled")
+#else
+  boost::archive::text_iarchive ar(ss);
+  ar >> *this;
+#endif
+}
+
+void TautomerQuery::initFromString(const std::string &text) {
+  std::stringstream ss(text);
+  initFromStream(ss);
 }
 
 }  // namespace RDKit

--- a/Code/GraphMol/TautomerQuery/TautomerQuery.cpp
+++ b/Code/GraphMol/TautomerQuery/TautomerQuery.cpp
@@ -304,7 +304,7 @@ void TautomerQuery::toStream(std::ostream &ss) const {
 #endif
 }
 
-std::string TautomerQuery::toBinary() const {
+std::string TautomerQuery::serialize() const {
   std::stringstream ss;
   toStream(ss);
   return ss.str();

--- a/Code/GraphMol/TautomerQuery/TautomerQuery.h
+++ b/Code/GraphMol/TautomerQuery/TautomerQuery.h
@@ -107,7 +107,7 @@ class RDKIT_TAUTOMERQUERY_EXPORT TautomerQuery {
   //! serializes (pickles) to a stream
   void toStream(std::ostream &ss) const;
   //! returns a string with a serialized (pickled) representation
-  std::string toBinary() const;
+  std::string serialize() const;
   //! initializes from a stream pickle
   void initFromStream(std::istream &ss);
   //! initializes from a string pickle

--- a/Code/GraphMol/TautomerQuery/TautomerQuery.h
+++ b/Code/GraphMol/TautomerQuery/TautomerQuery.h
@@ -1,7 +1,7 @@
 //
 // Created by Gareth Jones on 5/7/2020.
 //
-// Copyright 2020 Schrodinger, Inc
+// Copyright 2020-2022 Schrodinger, Inc and other RDKit contributors
 //  @@ All Rights Reserved @@
 //  This file is part of the RDKit.
 //  The contents are covered by the terms of the BSD license
@@ -14,13 +14,24 @@
 #define RDKIT_TAUTOMERQUERY_H
 
 #include <GraphMol/ROMol.h>
+#include <GraphMol/MolPickler.h>
 #include <vector>
 #include <GraphMol/Substruct/SubstructMatch.h>
 #include <DataStructs/ExplicitBitVect.h>
 
+#ifdef RDK_USE_BOOST_SERIALIZATION
+#include <RDGeneral/BoostStartInclude.h>
+#include <boost/serialization/vector.hpp>
+#include <boost/serialization/shared_ptr.hpp>
+#include <boost/serialization/split_member.hpp>
+#include <RDGeneral/BoostEndInclude.h>
+#endif
+
 namespace RDKit {
 
 class RWMol;
+
+RDKIT_TAUTOMERQUERY_EXPORT bool TautomerQueryCanSerialize();
 
 class RDKIT_TAUTOMERQUERY_EXPORT TautomerQuery {
  private:
@@ -29,8 +40,8 @@ class RDKIT_TAUTOMERQUERY_EXPORT TautomerQuery {
   // Template query for substructure search
   std::unique_ptr<const ROMol> d_templateMolecule;
   // Tautomeric bonds and atoms
-  const std::vector<size_t> d_modifiedAtoms;
-  const std::vector<size_t> d_modifiedBonds;
+  std::vector<size_t> d_modifiedAtoms;
+  std::vector<size_t> d_modifiedBonds;
 
   // tests if a match to the template matches a specific tautomer
   bool matchTautomer(const ROMol &mol, const ROMol &tautomer,
@@ -56,6 +67,8 @@ class RDKIT_TAUTOMERQUERY_EXPORT TautomerQuery {
       d_tautomers.push_back(boost::make_shared<ROMol>(*taut));
     }
   }
+
+  TautomerQuery(const std::string &pickle) { initFromString(pickle); }
 
   // Factory to build TautomerQuery
   // Caller owns the memory
@@ -91,7 +104,54 @@ class RDKIT_TAUTOMERQUERY_EXPORT TautomerQuery {
 
   const std::vector<size_t> getModifiedBonds() const { return d_modifiedBonds; }
 
+  //! serializes (pickles) to a stream
+  void toStream(std::ostream &ss) const;
+  //! returns a string with a serialized (pickled) representation
+  std::string toBinary() const;
+  //! initializes from a stream pickle
+  void initFromStream(std::istream &ss);
+  //! initializes from a string pickle
+  void initFromString(const std::string &text);
+
   friend class TautomerQueryMatcher;
+
+#ifdef RDK_USE_BOOST_SERIALIZATION
+  template <class Archive>
+  void save(Archive &ar, const unsigned int version) const {
+    RDUNUSED_PARAM(version);
+    std::vector<std::string> pkls;
+    for (const auto taut : d_tautomers) {
+      std::string pkl;
+      MolPickler::pickleMol(*taut, pkl);
+      pkls.push_back(pkl);
+    }
+    ar &pkls;
+    std::string molpkl;
+    MolPickler::pickleMol(*d_templateMolecule, molpkl);
+    ar &molpkl;
+    ar &d_modifiedAtoms;
+    ar &d_modifiedBonds;
+  }
+
+  template <class Archive>
+  void load(Archive &ar, const unsigned int version) {
+    RDUNUSED_PARAM(version);
+
+    std::vector<std::string> pkls;
+    ar &pkls;
+    d_tautomers.clear();
+    for (const auto &pkl : pkls) {
+      d_tautomers.push_back(ROMOL_SPTR(new ROMol(pkl)));
+    }
+    std::string molpkl;
+    ar &molpkl;
+    d_templateMolecule.reset(new ROMol(molpkl));
+
+    ar &d_modifiedAtoms;
+    ar &d_modifiedBonds;
+  }
+  BOOST_SERIALIZATION_SPLIT_MEMBER()
+#endif
 };
 
 // so we can use the templates in Code/GraphMol/Substruct/SubstructMatch.h

--- a/Code/GraphMol/TautomerQuery/TautomerQuery.h
+++ b/Code/GraphMol/TautomerQuery/TautomerQuery.h
@@ -125,12 +125,12 @@ class RDKIT_TAUTOMERQUERY_EXPORT TautomerQuery {
       MolPickler::pickleMol(*taut, pkl);
       pkls.push_back(pkl);
     }
-    ar &pkls;
+    ar << pkls;
     std::string molpkl;
     MolPickler::pickleMol(*d_templateMolecule, molpkl);
-    ar &molpkl;
-    ar &d_modifiedAtoms;
-    ar &d_modifiedBonds;
+    ar << molpkl;
+    ar << d_modifiedAtoms;
+    ar << d_modifiedBonds;
   }
 
   template <class Archive>
@@ -138,17 +138,17 @@ class RDKIT_TAUTOMERQUERY_EXPORT TautomerQuery {
     RDUNUSED_PARAM(version);
 
     std::vector<std::string> pkls;
-    ar &pkls;
+    ar >> pkls;
     d_tautomers.clear();
     for (const auto &pkl : pkls) {
       d_tautomers.push_back(ROMOL_SPTR(new ROMol(pkl)));
     }
     std::string molpkl;
-    ar &molpkl;
+    ar >> molpkl;
     d_templateMolecule.reset(new ROMol(molpkl));
 
-    ar &d_modifiedAtoms;
-    ar &d_modifiedBonds;
+    ar >> d_modifiedAtoms;
+    ar >> d_modifiedBonds;
   }
   BOOST_SERIALIZATION_SPLIT_MEMBER()
 #endif

--- a/Code/GraphMol/TautomerQuery/Wrap/rdTautomerQuery.cpp
+++ b/Code/GraphMol/TautomerQuery/Wrap/rdTautomerQuery.cpp
@@ -1,7 +1,7 @@
 //
 // Created by Gareth Jones on 5/30/2020.
 //
-// Copyright 2020 Schrodinger, Inc
+// Copyright 2020-2022 Schrodinger, Inc and other RDKit contributors
 //  @@ All Rights Reserved @@
 //  This file is part of the RDKit.
 //  The contents are covered by the terms of the BSD license
@@ -12,10 +12,12 @@
 #include <RDBoost/python.h>
 #include <GraphMol/TautomerQuery/TautomerQuery.h>
 #include <GraphMol/Wrap/substructmethods.h>
+#include <RDBoost/python_streambuf.h>
 
 #define PY_ARRAY_UNIQUE_SYMBOL rdtautomerquery_array_API
 
 namespace python = boost::python;
+using boost_adaptbx::python::streambuf;
 using namespace RDKit;
 
 namespace {
@@ -133,6 +135,38 @@ PyObject *tautomerGetSubstructMatchesWithTautomers(
 
 }  // namespace
 
+namespace RDKit {
+struct tautomerquery_pickle_suite : python::pickle_suite {
+  static python::tuple getinitargs(const TautomerQuery &self) {
+    if (!TautomerQueryCanSerialize()) {
+      throw_runtime_error("Pickling of TautomerQuery instances is not enabled");
+    }
+    auto res = self.serialize();
+    return python::make_tuple(python::object(python::handle<>(
+        PyBytes_FromStringAndSize(res.c_str(), res.length()))));
+  };
+};
+
+void toStream(const TautomerQuery &tq, python::object &fileobj) {
+  streambuf ss(fileobj, 't');
+  streambuf::ostream ost(ss);
+  tq.toStream(ost);
+}
+
+void initFromStream(TautomerQuery &tq, python::object &fileobj) {
+  streambuf ss(fileobj,
+               'b');  // python StringIO can't seek, so need binary data
+  streambuf::istream is(ss);
+  tq.initFromStream(is);
+}
+
+python::object TQToBinary(const TautomerQuery &tq) {
+  auto res = tq.serialize();
+  return python::object(
+      python::handle<>(PyBytes_FromStringAndSize(res.c_str(), res.length())));
+}
+}  // namespace RDKit
+
 struct TautomerQuery_wrapper {
   static void wrap() {
     RegisterVectorConverter<size_t>("UnsignedLong_Vect");
@@ -146,6 +180,7 @@ struct TautomerQuery_wrapper {
         "TautomerQuery", docString, python::no_init)
         .def("__init__", python::make_constructor(createDefaultTautomerQuery))
         .def("__init__", python::make_constructor(&TautomerQuery::fromMol))
+        .def(python::init<std::string>())
         .def("IsSubstructOf", tautomerIsSubstructOf,
              (python::arg("self"), python::arg("target"),
               python::arg("recursionPossible") = true,
@@ -189,7 +224,9 @@ struct TautomerQuery_wrapper {
              python::return_internal_reference<>())
         .def("GetModifiedAtoms", &TautomerQuery::getModifiedAtoms)
         .def("GetModifiedBonds", &TautomerQuery::getModifiedBonds)
-        .def("GetTautomers", getTautomers);
+        .def("GetTautomers", getTautomers)
+        .def("ToBinary", TQToBinary)
+        .def_pickle(tautomerquery_pickle_suite());
 
     python::def("PatternFingerprintTautomerTarget",
                 &TautomerQuery::patternFingerprintTarget,

--- a/Code/GraphMol/TautomerQuery/Wrap/rdTautomerQuery.cpp
+++ b/Code/GraphMol/TautomerQuery/Wrap/rdTautomerQuery.cpp
@@ -232,6 +232,11 @@ struct TautomerQuery_wrapper {
                 &TautomerQuery::patternFingerprintTarget,
                 (python::arg("target"), python::arg("fingerprintSize") = 2048),
                 python::return_value_policy<python::manage_new_object>());
+
+    python::def(
+        "TautomerQueryCanSerialize", TautomerQueryCanSerialize,
+        "Returns True if the TautomerQuery is serializable "
+        "(requires that the RDKit was built with boost::serialization)");
   }
 };
 

--- a/Code/GraphMol/TautomerQuery/Wrap/rough_test.py
+++ b/Code/GraphMol/TautomerQuery/Wrap/rough_test.py
@@ -1,7 +1,7 @@
 #
 # Created by Gareth Jones on 5/30/2020.
 #
-# Copyright 2020 Schrodinger, Inc
+# Copyright 2020-2022 Schrodinger, Inc and other RDKit contributors
 #  @@ All Rights Reserved @@
 #  This file is part of the RDKit.
 #  The contents are covered by the terms of the BSD license
@@ -16,6 +16,7 @@ from rdkit import Chem, DataStructs
 from rdkit.Chem import rdTautomerQuery
 from unittest import TestCase, main
 import os
+import pickle
 
 
 class TautomerQueryTestCase(TestCase):
@@ -88,6 +89,20 @@ class TautomerQueryTestCase(TestCase):
     tautomers = tautomer_query.GetTautomers()
     self.assertTrue(target.HasSubstructMatch(mol))
     self.assertTrue(tautomer_query.IsSubstructOf(target))
+
+  def test_serialization(self):
+    mol = Chem.MolFromSmiles("O=C1CCCCC1")
+    base_tautomer_query = rdTautomerQuery.TautomerQuery(mol)
+    for tautomer_query in (pickle.loads(pickle.dumps(base_tautomer_query)),
+                           rdTautomerQuery.TautomerQuery(base_tautomer_query.ToBinary())):
+      self.assertEqual(2, len(tautomer_query.GetTautomers()))
+      modified_bonds = tautomer_query.GetModifiedBonds()
+      self.assertEqual(3, len(modified_bonds))
+      modified_atoms = tautomer_query.GetModifiedAtoms()
+      self.assertEqual(3, len(modified_atoms))
+
+      target = Chem.MolFromSmiles("OC1=CCCC(CC)C1")
+      self.assertTrue(target.HasSubstructMatch(tautomer_query.GetTemplateMolecule()))
 
 
 if __name__ == "__main__":

--- a/Code/GraphMol/TautomerQuery/catch_tests.cpp
+++ b/Code/GraphMol/TautomerQuery/catch_tests.cpp
@@ -345,7 +345,7 @@ TEST_CASE("Serialization") {
         std::unique_ptr<TautomerQuery>(TautomerQuery::fromMol(*mol));
     CHECK(15 == tautomerQuery->getTautomers().size());
 
-    std::string pickle = tautomerQuery->toBinary();
+    std::string pickle = tautomerQuery->serialize();
     TautomerQuery serialized(pickle);
     CHECK(serialized.getTautomers().size() ==
           tautomerQuery->getTautomers().size());

--- a/Code/GraphMol/TautomerQuery/catch_tests.cpp
+++ b/Code/GraphMol/TautomerQuery/catch_tests.cpp
@@ -1,5 +1,10 @@
-
-#define CATCH_CONFIG_MAIN
+//
+// Copyright 2020-2022 Schrodinger, Inc and other RDKit contributors
+//  @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
 
 #include "catch.hpp"
 
@@ -329,4 +334,37 @@ TEST_CASE("github #3821 check TAUTOMERQUERY_OPERATOR= does a deep copy") {
   auto tautomerQueryAssigned = *tautomerQuery;
   CHECK(&(tautomerQuery->getTemplateMolecule()) !=
         &tautomerQueryAssigned.getTemplateMolecule());
+}
+
+TEST_CASE("Serialization") {
+#ifdef RDK_USE_BOOST_SERIALIZATION
+  SECTION("basics") {
+    auto mol = "Nc1nc(=O)c2nc[nH]c2[nH]1"_smiles;
+    REQUIRE(mol);
+    auto tautomerQuery =
+        std::unique_ptr<TautomerQuery>(TautomerQuery::fromMol(*mol));
+    CHECK(15 == tautomerQuery->getTautomers().size());
+
+    std::string pickle = tautomerQuery->toBinary();
+    TautomerQuery serialized(pickle);
+    CHECK(serialized.getTautomers().size() ==
+          tautomerQuery->getTautomers().size());
+
+    auto queryFingerprint = serialized.patternFingerprintTemplate();
+    REQUIRE(queryFingerprint);
+    std::vector<std::string> targetSmis{"CCc1nc2[nH]c(=N)nc(O)c2[nH]1",
+                                        "CN1C2=NC=NC2=C(O)N=C1N"};
+    for (auto targetSmiles : targetSmis) {
+      auto target = SmilesToMol(targetSmiles);
+      REQUIRE(target);
+      CHECK(serialized.isSubstructOf(*target));
+      auto targetFingerprint = TautomerQuery::patternFingerprintTarget(*target);
+      REQUIRE(targetFingerprint);
+      CHECK(AllProbeBitsMatch(*queryFingerprint, *targetFingerprint));
+      delete targetFingerprint;
+      delete target;
+    }
+    delete queryFingerprint;
+  }
+#endif
 }


### PR DESCRIPTION
This adds boost::serialization support to the `TautomerQuery` class.
This is potentially useful by itself, but it's also a pre-req for using these in the PostgreSQL cartridge, which is what I really want to do. :-)

While implementing this I noticed that things would be a lot easier if `ROMol` supported boost::serialization; I'll do a separate PR for that.