### PR TITLE
add boost::serialization support to ROMol

### DIFF
--- a/Code/GraphMol/CMakeLists.txt
+++ b/Code/GraphMol/CMakeLists.txt
@@ -1,3 +1,9 @@
+if(RDK_USE_BOOST_SERIALIZATION AND Boost_SERIALIZATION_LIBRARY)
+    set(RDKit_SERIALIZATION_LIBS ${Boost_SERIALIZATION_LIBRARY})
+else()
+    message("== Making SubstructLibrary without boost Serialization support")
+    set(RDKit_SERIALIZATION_LIBS )
+endif()
 
 rdkit_library(GraphMol
               Atom.cpp QueryAtom.cpp QueryBond.cpp Bond.cpp
@@ -9,7 +15,7 @@ rdkit_library(GraphMol
               Renumber.cpp AdjustQuery.cpp Resonance.cpp StereoGroup.cpp
               new_canon.cpp SubstanceGroup.cpp FindStereo.cpp MonomerInfo.cpp
               SHARED
-              LINK_LIBRARIES RDGeometryLib RDGeneral  )
+              LINK_LIBRARIES RDGeometryLib RDGeneral ${RDKit_SERIALIZATION_LIBS} )
 target_compile_definitions(GraphMol PRIVATE RDKIT_GRAPHMOL_BUILD)
 if(RDK_USE_URF)
   target_link_libraries(GraphMol PUBLIC ${RDK_URF_LIBS})

--- a/Code/GraphMol/FilterCatalog/FilterMatchers.h
+++ b/Code/GraphMol/FilterCatalog/FilterMatchers.h
@@ -345,28 +345,21 @@ class RDKIT_FILTERCATALOG_EXPORT SmartsMatcher : public FilterMatcherBase {
   friend class boost::serialization::access;
   template <class Archive>
   void save(Archive &ar, const unsigned int version) const {
+    RDUNUSED_PARAM(version);
     ar &boost::serialization::base_object<FilterMatcherBase>(*this);
-    if (version < 2) {
-      std::string res;
-      MolPickler::pickleMol(*d_pattern.get(), res);
-      ar &res;
-    } else {
-      ar &d_pattern;
-    }
+    std::string res;
+    MolPickler::pickleMol(*d_pattern.get(), res);
+    ar &res;
     ar &d_min_count;
     ar &d_max_count;
   }
   template <class Archive>
   void load(Archive &ar, const unsigned int version) {
     ar &boost::serialization::base_object<FilterMatcherBase>(*this);
-    if (version < 2) {
-      std::string res;
-      ar &res;
-      d_pattern = boost::shared_ptr<ROMol>(new ROMol(res));
-    } else {
-      ar &d_pattern;
-    }
-    ar &d_pattern;
+    RDUNUSED_PARAM(version);
+    std::string res;
+    ar &res;
+    d_pattern = boost::shared_ptr<ROMol>(new ROMol(res));
     ar &d_min_count;
     ar &d_max_count;
   }
@@ -579,7 +572,7 @@ void registerFilterMatcherTypes(Archive &ar) {
 }  // namespace RDKit
 
 #ifdef RDK_USE_BOOST_SERIALIZATION
-BOOST_CLASS_VERSION(RDKit::SmartsMatcher, 2)
+BOOST_CLASS_VERSION(RDKit::SmartsMatcher, 1)
 BOOST_CLASS_VERSION(RDKit::ExclusionList, 1)
 BOOST_CLASS_VERSION(RDKit::FilterHierarchyMatcher, 1)
 #endif

--- a/Code/GraphMol/ROMol.cpp
+++ b/Code/GraphMol/ROMol.cpp
@@ -693,9 +693,9 @@ void ROMol::load(Archive &ar, const unsigned int) {
   numBonds = rdcast<unsigned int>(boost::num_edges(d_graph));
 }
 
-template void ROMol::save<boost::archive::text_oarchive>(
+template RDKIT_GRAPHMOL_EXPORT void ROMol::save<boost::archive::text_oarchive>(
     boost::archive::text_oarchive &, const unsigned int) const;
-template void ROMol::load<boost::archive::text_iarchive>(
+template RDKIT_GRAPHMOL_EXPORT void ROMol::load<boost::archive::text_iarchive>(
     boost::archive::text_iarchive &, const unsigned int);
 #endif
 

--- a/Code/GraphMol/ROMol.cpp
+++ b/Code/GraphMol/ROMol.cpp
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2003-2021 Greg Landrum and other RDKit contributors
+//  Copyright (C) 2003-2022 Greg Landrum and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -21,6 +21,13 @@
 #include "MolPickler.h"
 #include "Conformer.h"
 #include "SubstanceGroup.h"
+
+#ifdef RDK_USE_BOOST_SERIALIZATION
+#include <RDGeneral/BoostStartInclude.h>
+#include <boost/archive/text_oarchive.hpp>
+#include <boost/archive/text_iarchive.hpp>
+#include <RDGeneral/BoostEndInclude.h>
+#endif
 
 namespace RDKit {
 class QueryAtom;
@@ -666,5 +673,30 @@ unsigned int ROMol::addConformer(Conformer *conf, bool assignId) {
   d_confs.push_back(nConf);
   return conf->getId();
 }
+
+#ifdef RDK_USE_BOOST_SERIALIZATION
+template <class Archive>
+void ROMol::save(Archive &ar, const unsigned int) const {
+  std::string pkl;
+  MolPickler::pickleMol(*this, pkl, PicklerOps::AllProps);
+  ar << pkl;
+}
+
+template <class Archive>
+void ROMol::load(Archive &ar, const unsigned int) {
+  std::string pkl;
+  ar >> pkl;
+
+  initMol();
+  numBonds = 0;
+  MolPickler::molFromPickle(pkl, *this, PicklerOps::AllProps);
+  numBonds = rdcast<unsigned int>(boost::num_edges(d_graph));
+}
+
+template void ROMol::save<boost::archive::text_oarchive>(
+    boost::archive::text_oarchive &, const unsigned int) const;
+template void ROMol::load<boost::archive::text_iarchive>(
+    boost::archive::text_iarchive &, const unsigned int);
+#endif
 
 }  // namespace RDKit

--- a/Code/GraphMol/ROMol.h
+++ b/Code/GraphMol/ROMol.h
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2003-2018 Greg Landrum and Rational Discovery LLC
+//  Copyright (C) 2003-2022 Greg Landrum and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -29,6 +29,10 @@
 #include <boost/graph/adjacency_list.hpp>
 #include <boost/smart_ptr.hpp>
 #include <boost/dynamic_bitset.hpp>
+
+#ifdef RDK_USE_BOOST_SERIALIZATION
+#include <boost/serialization/split_member.hpp>
+#endif
 #include <RDGeneral/BoostEndInclude.h>
 
 // our stuff
@@ -784,6 +788,17 @@ class RDKIT_GRAPHMOL_EXPORT ROMol : public RDProps {
     file format. stereo_groups should be std::move()ed into this function.
   */
   void setStereoGroups(std::vector<StereoGroup> stereo_groups);
+
+#ifdef RDK_USE_BOOST_SERIALIZATION
+  //! \name boost::serialization support
+  //@{
+  template <class Archive>
+  void save(Archive &ar, const unsigned int version) const;
+  template <class Archive>
+  void load(Archive &ar, const unsigned int version);
+  BOOST_SERIALIZATION_SPLIT_MEMBER()
+  //@}
+#endif
 
  private:
   MolGraph d_graph;

--- a/Code/GraphMol/ROMol.h
+++ b/Code/GraphMol/ROMol.h
@@ -45,15 +45,6 @@
 #include "StereoGroup.h"
 #include "RingInfo.h"
 
-#ifdef RDK_USE_BOOST_SERIALIZATION
-namespace boost {
-namespace archive {
-class text_oarchive;
-class text_iarchive;
-}  // namespace archive
-}  // namespace boost
-#endif
-
 namespace RDKit {
 class SubstanceGroup;
 class Atom;
@@ -877,13 +868,6 @@ typedef std::vector<ROMOL_SPTR> MOL_SPTR_VECT;
 
 typedef MOL_PTR_VECT::const_iterator MOL_PTR_VECT_CI;
 typedef MOL_PTR_VECT::iterator MOL_PTR_VECT_I;
-
-#ifdef RDK_USE_BOOST_SERIALIZATION
-template RDKIT_GRAPHMOL_EXPORT void ROMol::save<boost::archive::text_oarchive>(
-    boost::archive::text_oarchive &, const unsigned int) const;
-template RDKIT_GRAPHMOL_EXPORT void ROMol::load<boost::archive::text_iarchive>(
-    boost::archive::text_iarchive &, const unsigned int);
-#endif
 
 };  // namespace RDKit
 #endif

--- a/Code/GraphMol/ROMol.h
+++ b/Code/GraphMol/ROMol.h
@@ -45,6 +45,15 @@
 #include "StereoGroup.h"
 #include "RingInfo.h"
 
+#ifdef RDK_USE_BOOST_SERIALIZATION
+namespace boost {
+namespace archive {
+class text_oarchive;
+class text_iarchive;
+}  // namespace archive
+}  // namespace boost
+#endif
+
 namespace RDKit {
 class SubstanceGroup;
 class Atom;
@@ -868,6 +877,13 @@ typedef std::vector<ROMOL_SPTR> MOL_SPTR_VECT;
 
 typedef MOL_PTR_VECT::const_iterator MOL_PTR_VECT_CI;
 typedef MOL_PTR_VECT::iterator MOL_PTR_VECT_I;
+
+#ifdef RDK_USE_BOOST_SERIALIZATION
+template RDKIT_GRAPHMOL_EXPORT void ROMol::save<boost::archive::text_oarchive>(
+    boost::archive::text_oarchive &, const unsigned int) const;
+template RDKIT_GRAPHMOL_EXPORT void ROMol::load<boost::archive::text_iarchive>(
+    boost::archive::text_iarchive &, const unsigned int);
+#endif
 
 };  // namespace RDKit
 #endif

--- a/Code/GraphMol/testPickler.cpp
+++ b/Code/GraphMol/testPickler.cpp
@@ -1773,26 +1773,52 @@ void testBoostSerialization() {
   m1->setProp("foo", 1);
   m1->getAtomWithIdx(0)->setProp("afoo", 2);
   m1->getBondWithIdx(0)->setProp("bfoo", 3);
-  std::stringstream ss;
   {
-    boost::archive::text_oarchive ar(ss);
-    ar << *m1;
+    std::stringstream ss;
+    {
+      boost::archive::text_oarchive ar(ss);
+      ar << *m1;
+    }
+    ss.seekg(0);
+    ROMol m2;
+    {
+      boost::archive::text_iarchive ar(ss);
+      ar >> m2;
+    }
+    TEST_ASSERT(m2.getNumAtoms(m1->getNumAtoms()));
+    int pval = 0;
+    TEST_ASSERT(m2.getPropIfPresent("foo", pval));
+    TEST_ASSERT(pval == 1);
+    TEST_ASSERT(m2.getAtomWithIdx(0)->getPropIfPresent("afoo", pval));
+    TEST_ASSERT(pval == 2);
+    TEST_ASSERT(m2.getBondWithIdx(0)->getPropIfPresent("bfoo", pval));
+    TEST_ASSERT(pval == 3);
   }
-  ss.seekg(0);
-  ROMol m2;
-  {
-    boost::archive::text_iarchive ar(ss);
-    ar >> m2;
+
+  {  // test RWMol
+    RWMol m3(*m1);
+    std::stringstream ss;
+    {
+      boost::archive::text_oarchive ar(ss);
+      ar << m3;
+    }
+    ss.seekg(0);
+    RWMol m2;
+    {
+      boost::archive::text_iarchive ar(ss);
+      ar >> m2;
+    }
+    TEST_ASSERT(m2.getNumAtoms(m1->getNumAtoms()));
+    int pval = 0;
+    TEST_ASSERT(m2.getPropIfPresent("foo", pval));
+    TEST_ASSERT(pval == 1);
+    TEST_ASSERT(m2.getAtomWithIdx(0)->getPropIfPresent("afoo", pval));
+    TEST_ASSERT(pval == 2);
+    TEST_ASSERT(m2.getBondWithIdx(0)->getPropIfPresent("bfoo", pval));
+    TEST_ASSERT(pval == 3);
   }
-  TEST_ASSERT(m2.getNumAtoms(m1->getNumAtoms()));
-  int pval = 0;
-  TEST_ASSERT(m2.getPropIfPresent("foo", pval));
-  TEST_ASSERT(pval == 1);
-  TEST_ASSERT(m2.getAtomWithIdx(0)->getPropIfPresent("afoo", pval));
-  TEST_ASSERT(pval == 2);
-  TEST_ASSERT(m2.getBondWithIdx(0)->getPropIfPresent("bfoo", pval));
-  TEST_ASSERT(pval == 3);
   BOOST_LOG(rdErrorLog) << "\tdone" << std::endl;
+
 #endif
 }
 int main(int argc, char *argv[]) {

--- a/Code/GraphMol/testPickler.cpp
+++ b/Code/GraphMol/testPickler.cpp
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2004-2021 Greg Landrum and other RDKit contributors
+//  Copyright (C) 2004-2022 Greg Landrum and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -20,6 +20,14 @@
 #include <GraphMol/SmilesParse/SmilesWrite.h>
 #include <GraphMol/SmilesParse/SmartsWrite.h>
 #include <GraphMol/Substruct/SubstructMatch.h>
+
+#ifdef RDK_USE_BOOST_SERIALIZATION
+#include <RDGeneral/BoostStartInclude.h>
+#include <boost/archive/text_oarchive.hpp>
+#include <boost/archive/text_iarchive.hpp>
+#include <boost/archive/archive_exception.hpp>
+#include <RDGeneral/BoostEndInclude.h>
+#endif
 
 #include <RDGeneral/RDLog.h>
 
@@ -1755,6 +1763,38 @@ void testAdditionalQueryPickling() {
   BOOST_LOG(rdErrorLog) << "\tdone" << std::endl;
 }
 
+void testBoostSerialization() {
+#ifdef RDK_USE_BOOST_SERIALIZATION
+  BOOST_LOG(rdErrorLog) << "-------------------------------------" << std::endl;
+  BOOST_LOG(rdErrorLog) << "Testing boost::serialization integration"
+                        << std::endl;
+  auto m1 = "CCC"_smiles;
+  TEST_ASSERT(m1);
+  m1->setProp("foo", 1);
+  m1->getAtomWithIdx(0)->setProp("afoo", 2);
+  m1->getBondWithIdx(0)->setProp("bfoo", 3);
+  std::stringstream ss;
+  {
+    boost::archive::text_oarchive ar(ss);
+    ar << *m1;
+  }
+  ss.seekg(0);
+  ROMol m2;
+  {
+    boost::archive::text_iarchive ar(ss);
+    ar >> m2;
+  }
+  TEST_ASSERT(m2.getNumAtoms(m1->getNumAtoms()));
+  int pval = 0;
+  TEST_ASSERT(m2.getPropIfPresent("foo", pval));
+  TEST_ASSERT(pval == 1);
+  TEST_ASSERT(m2.getAtomWithIdx(0)->getPropIfPresent("afoo", pval));
+  TEST_ASSERT(pval == 2);
+  TEST_ASSERT(m2.getBondWithIdx(0)->getPropIfPresent("bfoo", pval));
+  TEST_ASSERT(pval == 3);
+  BOOST_LOG(rdErrorLog) << "\tdone" << std::endl;
+#endif
+}
 int main(int argc, char *argv[]) {
   RDLog::InitLogs();
   bool doLong = false;
@@ -1799,4 +1839,5 @@ int main(int argc, char *argv[]) {
   testConformerOptions();
   testPropertyOptions();
   testAdditionalQueryPickling();
+  testBoostSerialization();
 }


### PR DESCRIPTION
This isn't really intended for use on its own (though that's possible of course); it's mainly there to allow other classes which include ROMols to be serialized more easily