### PR TITLE
fix doxygen comments

### DIFF
--- a/Code/ForceField/MMFF/Params.h
+++ b/Code/ForceField/MMFF/Params.h
@@ -323,10 +323,10 @@ class RDKIT_FORCEFIELD_EXPORT MMFFChgCollection {
            std::map<const unsigned int, std::map<const unsigned int, MMFFChg>>>
       d_params;  //!< the parameter 3D-map
 #else
-  std::vector<MMFFChg> d_params;          //! the parameter vector
-  std::vector<std::uint8_t> d_iAtomType;  //! atom type vector for atom i
-  std::vector<std::uint8_t> d_jAtomType;  //! atom type vector for atom j
-  std::vector<std::uint8_t> d_bondType;   //! bond type vector for bond i-j
+  std::vector<MMFFChg> d_params;          //!< the parameter vector
+  std::vector<std::uint8_t> d_iAtomType;  //!< atom type vector for atom i
+  std::vector<std::uint8_t> d_jAtomType;  //!< atom type vector for atom j
+  std::vector<std::uint8_t> d_bondType;   //!< bond type vector for bond i-j
 #endif
 };
 
@@ -397,9 +397,9 @@ class RDKIT_FORCEFIELD_EXPORT MMFFBondCollection {
       d_params;  //!< the parameter 3D-map
 #else
   std::vector<MMFFBond> d_params;         //!< the parameter vector
-  std::vector<std::uint8_t> d_iAtomType;  //! atom type vector for atom i
-  std::vector<std::uint8_t> d_jAtomType;  //! atom type vector for atom j
-  std::vector<std::uint8_t> d_bondType;   //! bond type vector for bond i-j
+  std::vector<std::uint8_t> d_iAtomType;  //!< atom type vector for atom i
+  std::vector<std::uint8_t> d_jAtomType;  //!< atom type vector for atom j
+  std::vector<std::uint8_t> d_bondType;   //!< bond type vector for bond i-j
 #endif
 };
 
@@ -455,8 +455,8 @@ class RDKIT_FORCEFIELD_EXPORT MMFFBndkCollection {
       d_params;  //!< the parameter 2D-map
 #else
   std::vector<MMFFBond> d_params;          //!< the parameter vector
-  std::vector<std::uint8_t> d_iAtomicNum;  //! atomic number vector for atom i
-  std::vector<std::uint8_t> d_jAtomicNum;  //! atomic number vector for atom j
+  std::vector<std::uint8_t> d_iAtomicNum;  //!< atomic number vector for atom i
+  std::vector<std::uint8_t> d_jAtomicNum;  //!< atomic number vector for atom j
 #endif
 };
 
@@ -512,8 +512,8 @@ class RDKIT_FORCEFIELD_EXPORT MMFFHerschbachLaurieCollection {
       d_params;  //!< the parameter 2D-map
 #else
   std::vector<MMFFHerschbachLaurie> d_params;  //!< the parameter vector
-  std::vector<std::uint8_t> d_iRow;  //! periodic row number vector for atom i
-  std::vector<std::uint8_t> d_jRow;  //! periodic row number vector for atom j
+  std::vector<std::uint8_t> d_iRow;  //!< periodic row number vector for atom i
+  std::vector<std::uint8_t> d_jRow;  //!< periodic row number vector for atom j
 #endif
 };
 
@@ -658,10 +658,10 @@ class RDKIT_FORCEFIELD_EXPORT MMFFAngleCollection {
       d_params;  //!< the parameter 4D-map
 #else
   std::vector<MMFFAngle> d_params;        //!< the parameter vector
-  std::vector<std::uint8_t> d_iAtomType;  //! atom type vector for atom i
-  std::vector<std::uint8_t> d_jAtomType;  //! atom type vector for atom j
-  std::vector<std::uint8_t> d_kAtomType;  //! atom type vector for atom k
-  std::vector<std::uint8_t> d_angleType;  //! angle type vector for angle i-j-k
+  std::vector<std::uint8_t> d_iAtomType;  //!< atom type vector for atom i
+  std::vector<std::uint8_t> d_jAtomType;  //!< atom type vector for atom j
+  std::vector<std::uint8_t> d_kAtomType;  //!< atom type vector for atom k
+  std::vector<std::uint8_t> d_angleType;  //!< angle type vector for angle i-j-k
 #endif
 };
 
@@ -757,11 +757,11 @@ class RDKIT_FORCEFIELD_EXPORT MMFFStbnCollection {
       d_params;  //!< the parameter 4D-map
 #else
   std::vector<MMFFStbn> d_params;         //!< the parameter vector
-  std::vector<std::uint8_t> d_iAtomType;  //! atom type vector for atom i
-  std::vector<std::uint8_t> d_jAtomType;  //! atom type vector for atom j
-  std::vector<std::uint8_t> d_kAtomType;  //! atom type vector for atom k
+  std::vector<std::uint8_t> d_iAtomType;  //!< atom type vector for atom i
+  std::vector<std::uint8_t> d_jAtomType;  //!< atom type vector for atom j
+  std::vector<std::uint8_t> d_kAtomType;  //!< atom type vector for atom k
   std::vector<std::uint8_t>
-      d_stretchBendType;  //! stretch-bend type vector for angle i-j-k
+      d_stretchBendType;  //!< stretch-bend type vector for angle i-j-k
 #endif
 };
 
@@ -914,10 +914,10 @@ class RDKIT_FORCEFIELD_EXPORT MMFFOopCollection {
       d_params;  //!< the parameter 4D-map
 #else
   std::vector<MMFFOop> d_params;          //!< the parameter vector
-  std::vector<std::uint8_t> d_iAtomType;  //! atom type vector for atom i
-  std::vector<std::uint8_t> d_jAtomType;  //! atom type vector for atom j
-  std::vector<std::uint8_t> d_kAtomType;  //! atom type vector for atom k
-  std::vector<std::uint8_t> d_lAtomType;  //! atom type vector for atom l
+  std::vector<std::uint8_t> d_iAtomType;  //!< atom type vector for atom i
+  std::vector<std::uint8_t> d_jAtomType;  //!< atom type vector for atom j
+  std::vector<std::uint8_t> d_kAtomType;  //!< atom type vector for atom k
+  std::vector<std::uint8_t> d_lAtomType;  //!< atom type vector for atom l
 #endif
 };
 
@@ -1081,12 +1081,12 @@ class RDKIT_FORCEFIELD_EXPORT MMFFTorCollection {
       d_params;  //!< the parameter 5D-map
 #else
   std::vector<MMFFTor> d_params;          //!< the parameter vector
-  std::vector<std::uint8_t> d_iAtomType;  //! atom type vector for atom i
-  std::vector<std::uint8_t> d_jAtomType;  //! atom type vector for atom j
-  std::vector<std::uint8_t> d_kAtomType;  //! atom type vector for atom k
-  std::vector<std::uint8_t> d_lAtomType;  //! atom type vector for atom l
+  std::vector<std::uint8_t> d_iAtomType;  //!< atom type vector for atom i
+  std::vector<std::uint8_t> d_jAtomType;  //!< atom type vector for atom j
+  std::vector<std::uint8_t> d_kAtomType;  //!< atom type vector for atom k
+  std::vector<std::uint8_t> d_lAtomType;  //!< atom type vector for atom l
   std::vector<std::uint8_t>
-      d_torType;  //! torsion type vector for angle i-j-k-l
+      d_torType;  //!< torsion type vector for angle i-j-k-l
 #endif
 };
 
@@ -1125,7 +1125,7 @@ class RDKIT_FORCEFIELD_EXPORT MMFFVdWCollection {
   std::map<const unsigned int, MMFFVdW> d_params;  //!< the parameter map
 #else
   std::vector<MMFFVdW> d_params;         //!< the parameter vector
-  std::vector<std::uint8_t> d_atomType;  //! atom type vector
+  std::vector<std::uint8_t> d_atomType;  //!< atom type vector
 #endif
 };
 }  // namespace MMFF

--- a/Code/Geometry/UniformGrid3D.h
+++ b/Code/Geometry/UniformGrid3D.h
@@ -188,12 +188,13 @@ class RDKIT_RDGEOMETRYLIB_EXPORT UniformGrid3D : public Grid3D {
                 RDKit::DiscreteValueVect::DiscreteValueType valType,
                 const RDGeom::Point3D &offSet,
                 RDKit::DiscreteValueVect *data = nullptr);
-  unsigned int d_numX, d_numY,
-      d_numZ;        //! number of grid points along x, y, z axes
-  double d_spacing;  //! grid spacing
-  Point3D d_offSet;  //! the grid offset (from the origin)
+  unsigned int d_numX;  //!< number of grid points along x axis
+  unsigned int d_numY;  //!< number of grid points along y axis
+  unsigned int d_numZ;  //!< number of grid points along z axis
+  double d_spacing;  //!< grid spacing
+  Point3D d_offSet;  //!< the grid offset (from the origin)
   RDKit::DiscreteValueVect
-      *dp_storage;  //! storage for values at each grid point
+      *dp_storage;  //!< storage for values at each grid point
 
   //! \brief construct from a pickle
   void initFromText(const char *pkl, const unsigned int length);

--- a/Code/GraphMol/Abbreviations/Abbreviations.h
+++ b/Code/GraphMol/Abbreviations/Abbreviations.h
@@ -26,8 +26,8 @@ struct RDKIT_ABBREVIATIONS_EXPORT AbbreviationDefinition {
   std::string displayLabel;
   std::string displayLabelW;
   std::string smarts;
-  std::shared_ptr<ROMol> mol;                  //! optional
-  std::vector<unsigned int> extraAttachAtoms;  //! optional
+  std::shared_ptr<ROMol> mol;                  //!< optional
+  std::vector<unsigned int> extraAttachAtoms;  //!< optional
   bool operator==(const AbbreviationDefinition& other) const {
     return label == other.label && displayLabel == other.displayLabel &&
            displayLabelW == other.displayLabelW && smarts == other.smarts;

--- a/Code/GraphMol/Atom.h
+++ b/Code/GraphMol/Atom.h
@@ -94,11 +94,11 @@ class RDKIT_GRAPHMOL_EXPORT Atom : public RDProps {
     CHI_TETRAHEDRAL_CCW,  //!< tetrahedral: counter-clockwise rotation (SMILES
                           //\@)
     CHI_OTHER,            //!< some unrecognized type of chirality
-    CHI_TETRAHEDRAL,      //! tetrahedral, use permutation flag
-    CHI_ALLENE,           //! allene, use permutation flag
-    CHI_SQUAREPLANAR,     //! square planar, use permutation flag
-    CHI_TRIGONALBIPYRAMIDAL,  //! trigonal bipyramidal, use permutation flag
-    CHI_OCTAHEDRAL            //! octahedral, use permutation flag
+    CHI_TETRAHEDRAL,      //!< tetrahedral, use permutation flag
+    CHI_ALLENE,           //!< allene, use permutation flag
+    CHI_SQUAREPLANAR,     //!< square planar, use permutation flag
+    CHI_TRIGONALBIPYRAMIDAL,  //!< trigonal bipyramidal, use permutation flag
+    CHI_OCTAHEDRAL            //!< octahedral, use permutation flag
   } ChiralType;
 
   Atom();

--- a/Code/GraphMol/Canon.h
+++ b/Code/GraphMol/Canon.h
@@ -28,9 +28,9 @@ const int MAX_BONDTYPE = 32;  //!< used in the canonical traversal code
 
 //! used in traversals of the molecule
 typedef enum {
-  WHITE_NODE = 0,  //! not visited
-  GREY_NODE,       //! visited, but not finished
-  BLACK_NODE,      //! visited and finished
+  WHITE_NODE = 0,  //!< not visited
+  GREY_NODE,       //!< visited, but not finished
+  BLACK_NODE,      //!< visited and finished
 } AtomColors;
 
 //! used to indicate types of entries in the molecular stack:

--- a/Code/GraphMol/ChemReactions/ReactionParser.h
+++ b/Code/GraphMol/ChemReactions/ReactionParser.h
@@ -67,7 +67,7 @@ class RDKIT_CHEMREACTIONS_EXPORT ChemicalReactionParserException
 
 //---------------------------------------------------------------------------
 //! \name Reaction SMARTS/SMILES Support
-//@{
+//! @{
 
 //! Parse a string containing "Reaction SMARTS" into a ChemicalReaction
 /*!
@@ -98,11 +98,11 @@ RDKIT_CHEMREACTIONS_EXPORT std::string ChemicalReactionToRxnSmarts(
 //! returns the reaction SMILES for a reaction
 RDKIT_CHEMREACTIONS_EXPORT std::string ChemicalReactionToRxnSmiles(
     const ChemicalReaction &rxn, bool canonical = true);
-//@}
+//! @}
 
 //---------------------------------------------------------------------------
 //! \name Reaction Mol Support
-//@{
+//! @{
 
 //! Parse a ROMol into a ChemicalReaction, RXN role must be set before
 /*!
@@ -118,11 +118,11 @@ RDKIT_CHEMREACTIONS_EXPORT ChemicalReaction *RxnMolToChemicalReaction(
 //! returns a ROMol with RXN roles used to describe the reaction
 RDKIT_CHEMREACTIONS_EXPORT ROMol *ChemicalReactionToRxnMol(
     const ChemicalReaction &rxn);
-//@}
+//! @}
 
 //---------------------------------------------------------------------------
 //! \name MDL rxn Support
-//@{
+//! @{
 
 //! Parse a text block in MDL rxn format into a ChemicalReaction
 RDKIT_CHEMREACTIONS_EXPORT ChemicalReaction *RxnBlockToChemicalReaction(
@@ -161,11 +161,11 @@ RDKIT_CHEMREACTIONS_EXPORT std::string ChemicalReactionToRxnBlock(
 RDKIT_CHEMREACTIONS_EXPORT std::string ChemicalReactionToV3KRxnBlock(
     const ChemicalReaction &rxn, bool separateAgents = false);
 
-//@}
+//! @}
 
 //---------------------------------------------------------------------------
 //! \name PNG Support
-//@{
+//! @{
 
 //! Tags used for PNG metadata
 namespace PNGData {
@@ -244,7 +244,7 @@ inline std::string addChemicalReactionToPNGFile(const ChemicalReaction &rxn,
   return addChemicalReactionToPNGStream(
       rxn, inStream, includePkl, includeSmiles, includeSmarts, includeRxn);
 }
-//@}
+//! @}
 
 inline std::unique_ptr<ChemicalReaction> operator"" _rxnsmarts(const char *text,
                                                                size_t len) {

--- a/Code/GraphMol/ChemReactions/ReactionPickler.h
+++ b/Code/GraphMol/ChemReactions/ReactionPickler.h
@@ -43,7 +43,7 @@ class RDKIT_CHEMREACTIONS_EXPORT ReactionPickler {
   static const std::int32_t versionMajor;  //!< mark the pickle version
   static const std::int32_t versionMinor;  //!< mark the pickle version
   static const std::int32_t versionPatch;  //!< mark the pickle version
-  static const std::int32_t endianId;  //! mark the endian-ness of the pickle
+  static const std::int32_t endianId;  //!< mark the endian-ness of the pickle
 
   //! the pickle format is tagged using these tags:
   //! NOTE: if you add to this list, be sure to put new entries AT THE BOTTOM,

--- a/Code/GraphMol/Chirality.h
+++ b/Code/GraphMol/Chirality.h
@@ -158,7 +158,7 @@ RDKIT_GRAPHMOL_EXPORT unsigned int getAtomNonzeroDegree(const Atom *atom);
 RDKIT_GRAPHMOL_EXPORT INT_VECT findStereoAtoms(const Bond *bond);
 
 //! \name Non-tetrahedral stereochemistry
-//@{
+//! @{
 RDKIT_GRAPHMOL_EXPORT bool hasNonTetrahedralStereo(const Atom *center);
 RDKIT_GRAPHMOL_EXPORT Bond *getChiralAcrossBond(const Atom *center,
                                                 const Bond *qry);
@@ -168,14 +168,14 @@ RDKIT_GRAPHMOL_EXPORT Atom *getChiralAcrossAtom(const Atom *center,
                                                 const Bond *qry);
 RDKIT_GRAPHMOL_EXPORT Atom *getChiralAcrossAtom(const Atom *center,
                                                 const Atom *qry);
-// \param which: if this is -1 then the second axial bond will be returned,
-// otherwise the first
+//! \param which: if this is -1 then the second axial bond will be returned,
+//! otherwise the first
 RDKIT_GRAPHMOL_EXPORT Bond *getTrigonalBipyramidalAxialBond(const Atom *center,
                                                             int which = 0);
 RDKIT_GRAPHMOL_EXPORT Atom *getTrigonalBipyramidalAxialAtom(const Atom *center,
                                                             int which = 0);
 
-// \returns 1 if it's the first axial atom, -1 if it's the second
+//! \returns 1 if it's the first axial atom, -1 if it's the second
 RDKIT_GRAPHMOL_EXPORT int isTrigonalBipyramidalAxialBond(const Atom *center,
                                                          const Bond *qry);
 RDKIT_GRAPHMOL_EXPORT int isTrigonalBipyramidalAxialAtom(const Atom *center,
@@ -187,7 +187,7 @@ RDKIT_GRAPHMOL_EXPORT double getIdealAngleBetweenLigands(const Atom *center,
 
 RDKIT_GRAPHMOL_EXPORT unsigned int getChiralPermutation(const Atom *center,
                                                         const INT_LIST &probe);
-//@}
+//! @}
 
 }  // namespace Chirality
 }  // namespace RDKit

--- a/Code/GraphMol/DistGeomHelpers/Embedder.h
+++ b/Code/GraphMol/DistGeomHelpers/Embedder.h
@@ -173,11 +173,11 @@ struct RDKIT_DISTGEOMHELPERS_EXPORT EmbedParameters {
         callback(callback) {}
 };
 
-//*! update parameters from a JSON string
+//! update parameters from a JSON string
 RDKIT_DISTGEOMHELPERS_EXPORT void updateEmbedParametersFromJSON(
     EmbedParameters &params, const std::string &json);
 
-//*! Embed multiple conformations for a molecule
+//! Embed multiple conformations for a molecule
 RDKIT_DISTGEOMHELPERS_EXPORT void EmbedMultipleConfs(
     ROMol &mol, INT_VECT &res, unsigned int numConfs,
     const EmbedParameters &params);

--- a/Code/GraphMol/FileParsers/FileParsers.h
+++ b/Code/GraphMol/FileParsers/FileParsers.h
@@ -234,7 +234,7 @@ RDKIT_FILEPARSERS_EXPORT void MolToTPLFile(
 //-----
 
 typedef enum {
-  CORINA = 0  //! supports output from Corina and some dbtranslate output
+  CORINA = 0  //!< supports output from Corina and some dbtranslate output
 } Mol2Type;
 
 // \brief construct a molecule from a Tripos mol2 file

--- a/Code/GraphMol/FileParsers/MultithreadedMolSupplier.h
+++ b/Code/GraphMol/FileParsers/MultithreadedMolSupplier.h
@@ -80,23 +80,23 @@ class RDKIT_FILEPARSERS_EXPORT MultithreadedMolSupplier : public MolSupplier {
                                        unsigned int lineNum) = 0;
 
  private:
-  std::atomic<unsigned int> d_threadCounter{1};  //! thread counter
-  std::vector<std::thread> d_writerThreads;      //! vector writer threads
-  std::thread d_readerThread;                    //! single reader thread
+  std::atomic<unsigned int> d_threadCounter{1};  //!< thread counter
+  std::vector<std::thread> d_writerThreads;      //!< vector writer threads
+  std::thread d_readerThread;                    //!< single reader thread
 
  protected:
   std::atomic<unsigned int> d_lastRecordId =
-      0;                                     //! stores last extracted record id
-  std::string d_lastItemText;                //! stores last extracted record
-  const unsigned int d_numReaderThread = 1;  //! number of reader thread
-  unsigned int d_numWriterThreads;           //! number of writer threads
-  size_t d_sizeInputQueue;                   //! size of input queue
-  size_t d_sizeOutputQueue;                  //! size of output queue
+      0;                       //!< stores last extracted record id
+  std::string d_lastItemText;  //!< stores last extracted record
+  const unsigned int d_numReaderThread = 1;  //!< number of reader thread
+  unsigned int d_numWriterThreads;           //!< number of writer threads
+  size_t d_sizeInputQueue;                   //!< size of input queue
+  size_t d_sizeOutputQueue;                  //!< size of output queue
 
   ConcurrentQueue<std::tuple<std::string, unsigned int, unsigned int>>
-      *d_inputQueue;  //! concurrent input queue
+      *d_inputQueue;  //!< concurrent input queue
   ConcurrentQueue<std::tuple<ROMol *, std::string, unsigned int>>
-      *d_outputQueue;  //! concurrent output queue
+      *d_outputQueue;  //!< concurrent output queue
 };
 }  // namespace RDKit
 #endif

--- a/Code/GraphMol/FileParsers/MultithreadedSDMolSupplier.h
+++ b/Code/GraphMol/FileParsers/MultithreadedSDMolSupplier.h
@@ -53,12 +53,12 @@ class RDKIT_FILEPARSERS_EXPORT MultithreadedSDMolSupplier
                         size_t sizeInputQueue, size_t sizeOutputQueue);
 
  private:
-  bool df_end = false;  //! have we reached the end of the file?
-  int d_line = 0;       //! line number we are currently on
+  bool df_end = false;  //!< have we reached the end of the file?
+  int d_line = 0;       //!< line number we are currently on
   bool df_sanitize = true, df_removeHs = true, df_strictParsing = true;
   bool df_processPropertyLists = true;
   bool df_eofHitOnRead = false;
-  unsigned int d_currentRecordId = 1;  //! current record id
+  unsigned int d_currentRecordId = 1;  //!< current record id
 };
 }  // namespace RDKit
 #endif

--- a/Code/GraphMol/FileParsers/MultithreadedSmilesMolSupplier.h
+++ b/Code/GraphMol/FileParsers/MultithreadedSmilesMolSupplier.h
@@ -51,15 +51,15 @@ class RDKIT_FILEPARSERS_EXPORT MultithreadedSmilesMolSupplier
                         size_t sizeInputQueue, size_t sizeOutputQueue);
 
  private:
-  bool df_end = false;      //! have we reached the end of the file?
-  int d_line = 0;           //! line number we are currently on
-  std::string d_delim;      //! the delimiter string
-  bool df_sanitize = true;  //! sanitize molecules before returning them?
-  STR_VECT d_props;         //! vector of property names
-  bool df_title = true;     //! do we have a title line?
-  int d_smi = 0;            //! column id for the smile string
-  int d_name = 1;           //! column id for the name
-  unsigned int d_currentRecordId = 1;  //! current record id
+  bool df_end = false;      //!< have we reached the end of the file?
+  int d_line = 0;           //!< line number we are currently on
+  std::string d_delim;      //!< the delimiter string
+  bool df_sanitize = true;  //!< sanitize molecules before returning them?
+  STR_VECT d_props;         //!< vector of property names
+  bool df_title = true;     //!< do we have a title line?
+  int d_smi = 0;            //!< column id for the smile string
+  int d_name = 1;           //!< column id for the name
+  unsigned int d_currentRecordId = 1;  //!< current record id
 };
 }  // namespace RDKit
 #endif

--- a/Code/GraphMol/FileParsers/PNGParser.h
+++ b/Code/GraphMol/FileParsers/PNGParser.h
@@ -33,7 +33,7 @@ RDKIT_FILEPARSERS_EXPORT extern const std::string pklTag;
 }  // namespace PNGData
 
 //! \name metadata to/from PNG
-//@{
+//! @{
 
 //! \brief returns the metadata (tEXt and zTXt chunks) from PNG data
 RDKIT_FILEPARSERS_EXPORT std::vector<std::pair<std::string, std::string>>
@@ -88,10 +88,10 @@ inline std::string addMetadataToPNGFile(
   std::ifstream inStream(fname.c_str(), std::ios::binary);
   return addMetadataToPNGStream(inStream, metadata, compressed);
 }
-//@}
+//! @}
 
 //! \name molecules to/from PNG
-//@{
+//! @{
 
 //! \brief constructs an ROMol from the metadata in a PNG stream
 /*!
@@ -196,7 +196,7 @@ inline std::string addMolToPNGFile(const ROMol &mol, const std::string &fname,
   return addMolToPNGStream(mol, inStream, includePkl, includeSmiles,
                            includeMol);
 }
-//@}
+//! @}
 
 }  // namespace RDKit
 

--- a/Code/GraphMol/FilterCatalog/FilterCatalogEntry.h
+++ b/Code/GraphMol/FilterCatalog/FilterCatalogEntry.h
@@ -97,7 +97,7 @@ class RDKIT_FILTERCATALOG_EXPORT FilterCatalogEntry
   void setDescription(const std::string &description);
 
   //! \name Properties
-  //@{
+  //! @{
 
   //! returns a list with the names of our \c properties
   STR_VECT getPropList() const { return d_props.keys(); }

--- a/Code/GraphMol/MolDraw2D/MolDraw2D.h
+++ b/Code/GraphMol/MolDraw2D/MolDraw2D.h
@@ -216,7 +216,7 @@ class RDKIT_MOLDRAW2D_EXPORT MolDraw2D {
   //! into canvas coords.
   virtual void drawPolygon(const std::vector<Point2D> &cds,
                            bool rawCoords = false) = 0;
-  //@}
+  //! @}
 
   //! A Whole bunch of drawing primitives.  They may be over-ridden
   //! by different renderers, or they may be implemented in terms of
@@ -277,7 +277,7 @@ class RDKIT_MOLDRAW2D_EXPORT MolDraw2D {
                           bool rawCoords = false);
 
   //! \name Transformations
-  //@{
+  //! @{
   // transform a set of coords in the molecule's coordinate system
   // to drawing system coordinates and vice versa. Note that the coordinates
   // have
@@ -304,7 +304,7 @@ class RDKIT_MOLDRAW2D_EXPORT MolDraw2D {
   //! returns the molecular coordinates of a particular atom.  at_num refers
   //! to the atom in activeMolIdx_.
   virtual Point2D getAtomCoords(int at_num) const;
-  //@}
+  //! @}
   //! returns the coordinates of the atoms of the activeMolIdx_ molecule in
   //! molecular coordinates.
   const std::vector<Point2D> &atomCoords() const;
@@ -421,7 +421,7 @@ class RDKIT_MOLDRAW2D_EXPORT MolDraw2D {
 
  private:
   //! \name Methods that must be provided by child classes
-  //@{
+  //! @{
   virtual void initDrawing() = 0;
   virtual void initTextDrawer(bool noFreetype) = 0;
 

--- a/Code/GraphMol/MolEnumerator/MolEnumerator.h
+++ b/Code/GraphMol/MolEnumerator/MolEnumerator.h
@@ -213,8 +213,8 @@ class RDKIT_MOLENUMERATOR_EXPORT RepeatUnitOp : public MolEnumeratorOp {
   }
 
   size_t d_defaultRepeatCount =
-      4;  //! from mol files we typically don't know the repeat count. This is
-          //! what we use instead
+      4;  //!< from mol files we typically don't know the repeat count. This is
+          //!< what we use instead
  private:
   std::shared_ptr<ROMol> dp_mol{nullptr};
   std::shared_ptr<RWMol> dp_frame{nullptr};

--- a/Code/GraphMol/MolInterchange/MolInterchange.h
+++ b/Code/GraphMol/MolInterchange/MolInterchange.h
@@ -38,15 +38,15 @@ namespace MolInterchange {
 // \brief parameters controlling parsing of MolJSON
 struct RDKIT_MOLINTERCHANGE_EXPORT JSONParseParameters {
   bool setAromaticBonds =
-      true; /*! toggles setting the BondType of aromatic bonds to Aromatic */
+      true; /*!< toggles setting the BondType of aromatic bonds to Aromatic */
   bool strictValenceCheck =
-      false; /*! toggles doing reasonable valence checks */
+      false; /*!< toggles doing reasonable valence checks */
   bool parseProperties =
-      true; /*! toggles extracting molecular properties from the JSON block */
+      true; /*!< toggles extracting molecular properties from the JSON block */
   bool parseConformers =
-      true; /*! toggles extracting conformers from the JSON block */
+      true; /*!< toggles extracting conformers from the JSON block */
   bool useHCounts =
-      true; /*! toggles using the implicit H counts for atoms from the JSON
+      true; /*!< toggles using the implicit H counts for atoms from the JSON
                block. You may want to set this to false when parsing queries. */
 };
 static JSONParseParameters defaultJSONParseParameters;

--- a/Code/GraphMol/MolOps.h
+++ b/Code/GraphMol/MolOps.h
@@ -419,7 +419,7 @@ RDKIT_GRAPHMOL_EXPORT void adjustQueryProperties(
 RDKIT_GRAPHMOL_EXPORT ROMol *renumberAtoms(
     const ROMol &mol, const std::vector<unsigned int> &newOrder);
 
-//@}
+//! @}
 
 //! \name Sanitization
 /// {
@@ -651,10 +651,10 @@ RDKIT_GRAPHMOL_EXPORT void setConjugation(ROMol &mol);
 //! calculates and sets the hybridization of all a molecule's Stoms
 RDKIT_GRAPHMOL_EXPORT void setHybridization(ROMol &mol);
 
-// @}
+//!  @}
 
 //! \name Ring finding and SSSR
-//@{
+//! @{
 
 //! finds a molecule's Smallest Set of Smallest Rings
 /*!
@@ -745,10 +745,10 @@ RDKIT_GRAPHMOL_EXPORT int symmetrizeSSSR(ROMol &mol,
 //! \overload
 RDKIT_GRAPHMOL_EXPORT int symmetrizeSSSR(ROMol &mol);
 
-//@}
+//! @}
 
 //! \name Shortest paths and other matrices
-//@{
+//! @{
 
 //! returns a molecule's adjacency matrix
 /*!
@@ -869,10 +869,10 @@ RDKIT_GRAPHMOL_EXPORT double *get3DDistanceMat(
 RDKIT_GRAPHMOL_EXPORT std::list<int> getShortestPath(const ROMol &mol, int aid1,
                                                      int aid2);
 
-//@}
+//! @}
 
 //! \name Stereochemistry
-//@{
+//! @{
 
 //! removes bogus chirality markers (those on non-sp3 centers):
 RDKIT_GRAPHMOL_EXPORT void cleanupChirality(RWMol &mol);
@@ -1002,7 +1002,7 @@ RDKIT_GRAPHMOL_EXPORT void findPotentialStereoBonds(ROMol &mol,
 RDKIT_GRAPHMOL_EXPORT void assignChiralTypesFromMolParity(
     ROMol &mol, bool replaceExistingTags = true);
 
-//@}
+//! @}
 
 //! returns the number of atoms which have a particular property set
 RDKIT_GRAPHMOL_EXPORT unsigned getNumAtomsWithDistinctProperty(

--- a/Code/GraphMol/MolPickler.h
+++ b/Code/GraphMol/MolPickler.h
@@ -70,7 +70,7 @@ class RDKIT_GRAPHMOL_EXPORT MolPickler {
   static const std::int32_t versionMajor;  //!< mark the pickle major version
   static const std::int32_t versionMinor;  //!< mark the pickle minor version
   static const std::int32_t versionPatch;  //!< mark the pickle patch version
-  static const std::int32_t endianId;  //! mark the endian-ness of the pickle
+  static const std::int32_t endianId;  //!< mark the endian-ness of the pickle
 
   //! the pickle format is tagged using these tags:
   //! NOTE: if you add to this list, be sure to put new entries AT THE BOTTOM,

--- a/Code/GraphMol/MolStandardize/MolStandardize.h
+++ b/Code/GraphMol/MolStandardize/MolStandardize.h
@@ -48,34 +48,34 @@ struct RDKIT_MOLSTANDARDIZE_EXPORT CleanupParameters {
   std::string acidbaseFile;
   std::string fragmentFile;
   std::string tautomerTransforms;
-  int maxRestarts{200};  //! The maximum number of times to attempt to apply the
-                         //! series of normalizations (default 200).
-  bool preferOrganic{false};  //! Whether to prioritize organic fragments when
-                              //! choosing fragment parent (default False).
-  bool doCanonical{true};     //! Whether to apply normalizations in a
-                              //! canonical order
-  int maxTautomers{1000};     //! The maximum number of tautomers to enumerate
-                              //! (default 1000).
-  int maxTransforms{1000};    //! The maximum number of tautomer transformations
-                              //! to apply (default 1000).
+  int maxRestarts{200};  //!< The maximum number of times to attempt to apply
+                         //!< the series of normalizations (default 200).
+  bool preferOrganic{false};  //!< Whether to prioritize organic fragments when
+                              //!< choosing fragment parent (default False).
+  bool doCanonical{true};     //!< Whether to apply normalizations in a
+                              //!< canonical order
+  int maxTautomers{1000};     //!< The maximum number of tautomers to enumerate
+                              //!< (default 1000).
+  int maxTransforms{1000};    //!< The maximum number of tautomer
+                              //!< transformations to apply (default 1000).
   bool tautomerRemoveSp3Stereo{
-      true};  //! Whether to remove stereochemistry from sp3
-              //! centers involved in tautomerism (defaults to true)
+      true};  //!< Whether to remove stereochemistry from sp3 centers involved
+              //!< in tautomerism (defaults to true)
   bool tautomerRemoveBondStereo{
-      true};  //! Whether to remove stereochemistry from double
-              //! bonds involved in tautomerism (defaults to true)
+      true};  //!< Whether to remove stereochemistry from double bonds involved
+              //!< in tautomerism (defaults to true)
   bool tautomerRemoveIsotopicHs{
-      true};  //! Whether to remove isotopic Hs from centers
-              //! involved in tautomerism (defaults to true)
+      true};  //!< Whether to remove isotopic Hs from centers involved in
+              //!< tautomerism (defaults to true)
   bool tautomerReassignStereo{
-      true};  //! Whether enumerate() should call assignStereochemistry
-              //! on all generated tautomers (defaults to true)
+      true};  //!< Whether enumerate() should call assignStereochemistry on all
+              //!< generated tautomers (defaults to true)
   bool largestFragmentChooserUseAtomCount{
-      true};  //! Whether LargestFragmentChooser should use atom
-              //! count as main criterion before MW (defaults to true)
+      true};  //!< Whether LargestFragmentChooser should use atom count as main
+              //!< criterion before MW (defaults to true)
   bool largestFragmentChooserCountHeavyAtomsOnly{
-      false};  //! Whether LargestFragmentChooser should only count
-               //! heavy atoms (defaults to false)
+      false};  //!< Whether LargestFragmentChooser should only count heavy atoms
+               //!< (defaults to false)
   std::vector<std::pair<std::string, std::string>> normalizationData;
   std::vector<std::pair<std::string, std::string>> fragmentData;
   std::vector<std::tuple<std::string, std::string, std::string>> acidbaseData;

--- a/Code/GraphMol/ROMol.h
+++ b/Code/GraphMol/ROMol.h
@@ -202,7 +202,7 @@ class RDKIT_GRAPHMOL_EXPORT ROMol : public RDProps {
   //! \cond TYPEDEFS
 
   //! \name typedefs
-  //@{
+  //! @{
   typedef MolGraph::vertex_descriptor vertex_descriptor;
   typedef MolGraph::edge_descriptor edge_descriptor;
 
@@ -259,7 +259,7 @@ class RDKIT_GRAPHMOL_EXPORT ROMol : public RDProps {
   typedef CONF_SPTR_LIST_I ConformerIterator;
   typedef CONF_SPTR_LIST_CI ConstConformerIterator;
 
-  //@}
+  //! @}
   //! \endcond
 
   //! C++11 Range iterator
@@ -405,9 +405,9 @@ class RDKIT_GRAPHMOL_EXPORT ROMol : public RDProps {
 
   virtual ~ROMol() { destroy(); }
 
-  //@}
+  //! @}
   //! \name Atoms
-  //@{
+  //! @{
 
   //! returns our number of atoms
   inline unsigned int getNumAtoms() const {
@@ -432,10 +432,10 @@ class RDKIT_GRAPHMOL_EXPORT ROMol : public RDProps {
   }
   //! returns the degree (number of neighbors) of an Atom in the graph
   unsigned int getAtomDegree(const Atom *at) const;
-  //@}
+  //! @}
 
   //! \name Bonds
-  //@{
+  //! @{
 
   //! returns our number of Bonds
   unsigned int getNumBonds(bool onlyHeavy = 1) const;
@@ -470,10 +470,10 @@ class RDKIT_GRAPHMOL_EXPORT ROMol : public RDProps {
                                rdcast<unsigned int>(idx2));
   }
 
-  //@}
+  //! @}
 
   //! \name Bookmarks
-  //@{
+  //! @{
 
   //! associates an Atom pointer with a bookmark
   void setAtomBookmark(Atom *at, int mark) {
@@ -526,10 +526,10 @@ class RDKIT_GRAPHMOL_EXPORT ROMol : public RDProps {
   //! returns a pointer to all of our bond \c bookmarks
   BOND_BOOKMARK_MAP *getBondBookmarks() { return &d_bondBookmarks; }
 
-  //@}
+  //! @}
 
   //! \name Conformers
-  //@{
+  //! @{
 
   //! return the conformer with a specified ID
   //! if the ID is negative the first conformation will be returned
@@ -562,7 +562,7 @@ class RDKIT_GRAPHMOL_EXPORT ROMol : public RDProps {
   }
 
   //! \name Topology
-  //@{
+  //! @{
 
   //! returns a pointer to our RingInfo structure
   //! <b>Note:</b> the client should not delete this.
@@ -670,10 +670,10 @@ class RDKIT_GRAPHMOL_EXPORT ROMol : public RDProps {
       \endcode
    */
   MolGraph const &getTopology() const { return d_graph; }
-  //@}
+  //! @}
 
   //! \name Iterators
-  //@{
+  //! @{
 
   //! get an AtomIterator pointing at our first Atom
   AtomIterator beginAtoms();
@@ -739,10 +739,10 @@ class RDKIT_GRAPHMOL_EXPORT ROMol : public RDProps {
 
   inline ConstConformerIterator endConformers() const { return d_confs.end(); }
 
-  //@}
+  //! @}
 
   //! \name Properties
-  //@{
+  //! @{
 
   //! clears all of our \c computed \c properties
   void clearComputedProps(bool includeRings = true) const;
@@ -755,13 +755,13 @@ class RDKIT_GRAPHMOL_EXPORT ROMol : public RDProps {
 
   bool needsUpdatePropertyCache() const;
 
-  //@}
+  //! @}
 
   //! \name Misc
-  //@{
+  //! @{
   //! sends some debugging info to a stream
   void debugMol(std::ostream &str) const;
-  //@}
+  //! @}
 
   Atom *operator[](const vertex_descriptor &v) { return d_graph[v]; }
   const Atom *operator[](const vertex_descriptor &v) const {
@@ -791,13 +791,13 @@ class RDKIT_GRAPHMOL_EXPORT ROMol : public RDProps {
 
 #ifdef RDK_USE_BOOST_SERIALIZATION
   //! \name boost::serialization support
-  //@{
+  //! @{
   template <class Archive>
   void save(Archive &ar, const unsigned int version) const;
   template <class Archive>
   void load(Archive &ar, const unsigned int version);
   BOOST_SERIALIZATION_SPLIT_MEMBER()
-  //@}
+  //! @}
 #endif
 
  private:

--- a/Code/GraphMol/RWMol.h
+++ b/Code/GraphMol/RWMol.h
@@ -57,7 +57,7 @@ class RDKIT_GRAPHMOL_EXPORT RWMol : public ROMol {
   void insertMol(const ROMol &other);
 
   //! \name Atoms
-  //@{
+  //! @{
 
   //! adds an empty Atom to our collection
   /*!
@@ -115,10 +115,10 @@ class RDKIT_GRAPHMOL_EXPORT RWMol : public ROMol {
   //! \overload
   void removeAtom(Atom *atom);
 
-  //@}
+  //! @}
 
   //! \name Bonds
-  //@{
+  //! @{
 
   //! adds a Bond between the indicated Atoms
   /*!
@@ -196,7 +196,7 @@ class RDKIT_GRAPHMOL_EXPORT RWMol : public ROMol {
   void replaceBond(unsigned int idx, Bond *bond, bool preserveProps = false,
                    bool keepSGroups = true);
 
-  //@}
+  //! @}
 
     //! removes all atoms, bonds, properties, bookmarks, etc.
   void clear() {

--- a/Code/GraphMol/RingInfo.h
+++ b/Code/GraphMol/RingInfo.h
@@ -63,7 +63,7 @@ class RDKIT_GRAPHMOL_EXPORT RingInfo {
                        const INT_VECT &bondIndices);
 
   //! \name Atom information
-  //@{
+  //! @{
 
   //! returns a vector with sizes of the rings that atom with index \c idx is
   //! in.
@@ -128,10 +128,10 @@ class RDKIT_GRAPHMOL_EXPORT RingInfo {
   bool areAtomsInSameRingOfSize(unsigned int idx1, unsigned int idx2,
                                 unsigned int size) const;
 
-  //@}
+  //! @}
 
   //! \name Bond information
-  //@{
+  //! @{
 
   //! returns a vector with sizes of the rings that bond with index \c idx is
   //! in.
@@ -254,7 +254,7 @@ class RDKIT_GRAPHMOL_EXPORT RingInfo {
   bool areRingFamiliesInitialized() const { return dp_urfData != nullptr; }
 #endif
 
-  //@}
+  //! @}
 
  private:
   //! pre-allocates some memory to save time later

--- a/Code/GraphMol/SubstanceGroup.h
+++ b/Code/GraphMol/SubstanceGroup.h
@@ -258,7 +258,7 @@ RDKIT_GRAPHMOL_EXPORT bool isSubstanceGroupIdFree(const ROMol &mol,
 }  // namespace SubstanceGroupChecks
 
 //! \name SubstanceGroups and molecules
-//@{
+//! @{
 
 RDKIT_GRAPHMOL_EXPORT std::vector<SubstanceGroup> &getSubstanceGroups(
     ROMol &mol);
@@ -287,7 +287,7 @@ RDKIT_GRAPHMOL_EXPORT void removeSubstanceGroupsReferencingAtom(
 */
 RDKIT_GRAPHMOL_EXPORT void removeSubstanceGroupsReferencingBond(
     RWMol &mol, unsigned int idx);
-//@}
+//! @}
 
 }  // namespace RDKit
 

--- a/Code/Numerics/Vector.h
+++ b/Code/Numerics/Vector.h
@@ -288,7 +288,7 @@ class Vector {
   }
 
  private:
-  unsigned int d_size;  //! < our length
+  unsigned int d_size;  //!< our length
   DATA_SPTR d_data;
   Vector<TYPE> &operator=(const Vector<TYPE> &other);
 };


### PR DESCRIPTION
For example,
```cpp
int x;  //! comment for x
int y;
```
is equivalent to
```cpp
int x;
//! comment for x
int y;
```
i.e. that is a Doxygen comment for *y*; it should be
```cpp
int x;  //!< comment for x
int y;
```

https://www.doxygen.nl/manual/docblocks.html#memberdoc