### PR TITLE
Update __init__.py

### DIFF
--- a/rdkit/Chem/Draw/__init__.py
+++ b/rdkit/Chem/Draw/__init__.py
@@ -758,7 +758,11 @@ def _getMorganEnv(mol, atomId, radius, baseRad, aromaticColor, ringColor, center
 
   # set the coordinates of the submol based on the coordinates of the original molecule
   amap = {}
-  submol = Chem.PathToSubmol(mol, enlargedEnv, atomMap=amap)
+  if enlargedEnv:
+    submol = Chem.PathToSubmol(mol, enlargedEnv, atomMap=amap)
+  else:
+    # generate submol from fragments with no bonds
+    submol = Chem.MolFromSmiles(Chem.MolFragmentToSmiles(mol, atomsToUse=atomsToUse))
   Chem.FastFindRings(submol)
   conf = Chem.Conformer(submol.GetNumAtoms())
   confOri = mol.GetConformer(0)


### PR DESCRIPTION
#### Reference Issue

Fixes #4242

#### What does this implement/fix? Explain your changes.

Detect the cases when `enlargedEnv` is empty and manually create a one-atom molecule instead of calling `PathToSubmol()` (see https://github.com/rdkit/rdkit/issues/4242#issuecomment-1080544357)

#### Any other comments?

Tested on a variety of cases. Fingerprints with no bonds are now displayed correctly. E.g.:

<img width="873" alt="Screenshot 2022-03-29 at 00 16 19" src="https://user-images.githubusercontent.com/24247667/160496691-ab248e4b-2b36-497c-b4e1-89ae9666cf85.png">
