### PR TITLE
Allow the compiler to generate default ChemicalReaction copy assignment operator

### DIFF
--- a/Code/GraphMol/ChemReactions/Reaction.h
+++ b/Code/GraphMol/ChemReactions/Reaction.h
@@ -357,7 +357,6 @@ class RDKIT_CHEMREACTIONS_EXPORT ChemicalReaction : public RDProps {
   bool df_needsInit{true};
   bool df_implicitProperties{false};
   MOL_SPTR_VECT m_reactantTemplates, m_productTemplates, m_agentTemplates;
-  ChemicalReaction &operator=(const ChemicalReaction &);  // disable assignment
 };
 
 //! tests whether or not the molecule has a substructure match


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
I've noticed that the `ChemicalReaction` copy assignment operator has been purposefully hidden by making its declaration `private`.

https://github.com/rdkit/rdkit/blob/8a4c208a19c41a0c5a9fb2d5d2ed49349f61b59b/Code/GraphMol/ChemReactions/Reaction.h#L356-L360

As far as I can tell `ChemicalReaction` could be copied and assigned trivially. The base class `RDProps` is copy assignable, and so are all member variables of `ChemicalReaction`. In fact, removing the above declaration allows the compiler to generate a copy assignment operator which seems to work as expected.

Why was this operator disabled? If it should remain disabled I think it would be clearer to use the C++11 `delete` keyword as opposed to making the function declaration `private`.

```cpp
ChemicalReaction &operator=(const ChemicalReaction &) = delete;  // disable assignment
```