### PR TITLE
add ACE caps double bonds

### DIFF
--- a/Code/GraphMol/FileParsers/ProximityBonds.cpp
+++ b/Code/GraphMol/FileParsers/ProximityBonds.cpp
@@ -273,6 +273,7 @@ static bool StandardPDBDoubleBond(unsigned int rescode, unsigned int atm1,
   }
 
   switch (rescode) {
+    case BCNAM('A', 'C', 'E'):
     case BCNAM('A', 'L', 'A'):
     case BCNAM('C', 'Y', 'S'):
     case BCNAM('G', 'L', 'Y'):

--- a/Code/GraphMol/FileParsers/file_parsers_catch.cpp
+++ b/Code/GraphMol/FileParsers/file_parsers_catch.cpp
@@ -4625,6 +4625,7 @@ TEST_CASE(
     CHECK(groups[1].getGroupType() == RDKit::StereoGroupType::STEREO_AND);
   }
 }
+
 TEST_CASE("POL atoms in CTABS") {
   SECTION("V3000") {
     auto mol = R"CTAB(
@@ -4680,4 +4681,41 @@ M  END
     auto smi = MolToCXSmiles(*mol);
     CHECK(smi == "*CC |$Mod_p;;$|");
   }
+}
+
+
+TEST_CASE("PDB ACE caps bond order") {
+  auto mol = R"DATA(HEADER TEST
+ATOM      1  H1  ACE     1      25.950  25.179  24.582  1.00  0.00           H
+ATOM      2  CH3 ACE     1      25.986  26.176  24.145  1.00  0.00           C
+ATOM      3  H2  ACE     1      25.332  26.843  24.703  1.00  0.00           H
+ATOM      4  H3  ACE     1      25.673  26.131  23.104  1.00  0.00           H
+ATOM      5  C   ACE     1      27.405  26.691  24.218  1.00  0.00           C
+ATOM      6  O   ACE     1      28.285  25.999  24.713  1.00  0.00           O
+ATOM      7  N   ALA     2      27.621  27.909  23.728  1.00  0.00           N
+ATOM      8  H   ALA     2      26.838  28.435  23.370  1.00  0.00           H
+ATOM      9  CA  ALA     2      28.916  28.589  23.730  1.00  0.00           C
+ATOM     10  HA  ALA     2      29.471  28.288  24.620  1.00  0.00           H
+ATOM     11  CB  ALA     2      29.710  28.153  22.489  1.00  0.00           C
+ATOM     12  HB1 ALA     2      29.172  28.440  21.584  1.00  0.00           H
+ATOM     13  HB2 ALA     2      30.691  28.627  22.488  1.00  0.00           H
+ATOM     14  HB3 ALA     2      29.844  27.070  22.499  1.00  0.00           H
+ATOM     15  C   ALA     2      28.737  30.119  23.778  1.00  0.00           C
+ATOM     16  O   ALA     2      27.675  30.634  23.429  1.00  0.00           O
+ATOM     17  N   NME     3      29.784  30.841  24.197  1.00  0.00           N
+ATOM     18  H   NME     3      30.622  30.348  24.461  1.00  0.00           H
+ATOM     19  CH3 NME     3      29.784  32.300  24.293  1.00  0.00           C
+ATOM     20 HH31 NME     3      28.951  32.628  24.918  1.00  0.00           H
+ATOM     21 HH32 NME     3      30.720  32.652  24.729  1.00  0.00           H
+ATOM     22 HH33 NME     3      29.663  32.734  23.299  1.00  0.00           H
+TER      23      NME     3
+END
+)DATA"_pdb;
+  REQUIRE(mol);
+  // Oxygen in ACE (3rd heavy atom in mol) should be C=O, i.e. not OH
+  CHECK(mol->getAtomWithIdx(2)->getTotalNumHs() == 0);
+  CHECK(mol->getAtomWithIdx(2)->getTotalDegree() == 1);
+  auto bond = mol->getBondBetweenAtoms(1, 2);
+  REQUIRE(bond);
+  CHECK(bond->getBondType() == Bond::BondType::DOUBLE);
 }


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! 
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.

Acetyl caps are fairly common, but currently their bond order isn't properly inferred.

#### Any other comments?

Adding support for this would be pretty ACE.