### PR TITLE
Fix bad layout of atom notes with highlights.

### DIFF
--- a/Code/GraphMol/MolDraw2D/DrawMol.cpp
+++ b/Code/GraphMol/MolDraw2D/DrawMol.cpp
@@ -2192,6 +2192,8 @@ int DrawMol::doesRectClash(const StringRect &rect, double padding) const {
   // as opposed to the draw shapes derived from them.  Github 5185 shows
   // that sometimes atom indices can just fit between the lines of a
   // double bond.
+  // Also, no longer check if it clashes with highlights.  This frequently
+  // results in bad pictures and things look ok on top of highlights.
   for (auto bond : drawMol_->bonds()) {
     if (bond->getBondType() == Bond::DOUBLE) {
       auto at1 = bond->getBeginAtomIdx();
@@ -2214,11 +2216,6 @@ int DrawMol::doesRectClash(const StringRect &rect, double padding) const {
   for (const auto &a : annotations_) {
     if (a->doesRectClash(rect, padding)) {
       return 3;
-    }
-  }
-  for (const auto &hl : highlights_) {
-    if (hl->doesRectClash(rect, padding)) {
-      return 4;
     }
   }
   return 0;


### PR DESCRIPTION
#### Reference Issue
Fixes 5296, discussed in https://github.com/rdkit/rdkit/discussions/5195

#### What does this implement/fix? Explain your changes.
When placing the atom annotations, it ignores the highlights.

#### Any other comments?
Tested on macOS only.
