### PR TITLE
Add ChemicalReaction copy assignment implementation

### DIFF
--- a/Code/GraphMol/ChemReactions/Reaction.h
+++ b/Code/GraphMol/ChemReactions/Reaction.h
@@ -121,30 +121,41 @@ class RDKIT_CHEMREACTIONS_EXPORT ChemicalReactionException
 class RDKIT_CHEMREACTIONS_EXPORT ChemicalReaction : public RDProps {
   friend class ReactionPickler;
 
- public:
-  ChemicalReaction() : RDProps() {}
-  ChemicalReaction(const ChemicalReaction &other) : RDProps() {
+ private:
+  void copy(const ChemicalReaction &other) {
+    RDProps::operator=(other);
     df_needsInit = other.df_needsInit;
     df_implicitProperties = other.df_implicitProperties;
-    for (MOL_SPTR_VECT::const_iterator iter = other.beginReactantTemplates();
-         iter != other.endReactantTemplates(); ++iter) {
-      RWMol *reactant = new RWMol(**iter);
-      m_reactantTemplates.push_back(ROMOL_SPTR(reactant));
+    m_reactantTemplates.clear();
+    m_reactantTemplates.reserve(other.m_reactantTemplates.size());
+    for (ROMOL_SPTR reactant_template : other.m_reactantTemplates) {
+      m_reactantTemplates.emplace_back(new RWMol(*reactant_template));
     }
-    for (MOL_SPTR_VECT::const_iterator iter = other.beginProductTemplates();
-         iter != other.endProductTemplates(); ++iter) {
-      RWMol *product = new RWMol(**iter);
-      m_productTemplates.push_back(ROMOL_SPTR(product));
+    m_productTemplates.clear();
+    m_productTemplates.reserve(other.m_productTemplates.size());
+    for (ROMOL_SPTR product_template : other.m_productTemplates) {
+      m_productTemplates.emplace_back(new RWMol(*product_template));
     }
-    for (MOL_SPTR_VECT::const_iterator iter = other.beginAgentTemplates();
-         iter != other.endAgentTemplates(); ++iter) {
-      RWMol *agent = new RWMol(**iter);
-      m_agentTemplates.push_back(ROMOL_SPTR(agent));
+    m_agentTemplates.clear();
+    m_agentTemplates.reserve(other.m_agentTemplates.size());
+    for (ROMOL_SPTR agent_template : other.m_agentTemplates) {
+      m_agentTemplates.emplace_back(new RWMol(*agent_template));
     }
-    d_props = other.d_props;
   }
+
+ public:
+  ChemicalReaction() : RDProps() {}
   //! construct a reaction from a pickle string
   ChemicalReaction(const std::string &binStr);
+  ChemicalReaction(const ChemicalReaction &other) : RDProps() {
+    copy(other);
+  }
+  ChemicalReaction &operator=(const ChemicalReaction &other) {
+    if (this != &other) {
+      copy(other);
+    }
+    return *this;
+  }
 
   //! Adds a new reactant template
   /*!

--- a/Code/GraphMol/ChemReactions/testReaction.cpp
+++ b/Code/GraphMol/ChemReactions/testReaction.cpp
@@ -7719,7 +7719,7 @@ void testChemicalReactionCopyAssignment() {
 
   std::string rxn_smarts1 =
     "[C;$(C=O):1][OH1].[N;$(N[#6]);!$(N=*);!$([N-]);!$(N#*);!$([ND3]);!$([ND4]);!$(N[O,N]);!$(N[C,S]=[S,O,N]):2]>>[C:1][N+0:2]";
-  RDKit::ChemicalReaction* rxn1 = RDKit::RxnSmartsToChemicalReaction(rxn_smarts1);
+  ChemicalReaction* rxn1 = RxnSmartsToChemicalReaction(rxn_smarts1);
   rxn1->setImplicitPropertiesFlag(true);
   rxn1->initReactantMatchers();
   unsigned int nWarn, nError;
@@ -7727,36 +7727,49 @@ void testChemicalReactionCopyAssignment() {
   TEST_ASSERT(nWarn == 0 && nError == 0);
 
   std::string rxn_smarts2 = "[O:1]>>[N:1]";
-  RDKit::ChemicalReaction* rxn2 = RDKit::RxnSmartsToChemicalReaction(rxn_smarts2);
+  ChemicalReaction* rxn2 = RxnSmartsToChemicalReaction(rxn_smarts2);
 
   *rxn2 = *rxn1;
 
+  // Check we copied the base class members
+  TEST_ASSERT(rxn2->getPropList() == rxn1->getPropList());
+
+  // Check we copied the flags
   TEST_ASSERT(rxn2->getImplicitPropertiesFlag());
   TEST_ASSERT(rxn2->isInitialized());
 
-  RDKit::MOL_SPTR_VECT::const_iterator it1 = rxn1->beginReactantTemplates();
-  RDKit::MOL_SPTR_VECT::const_iterator it2 = rxn2->beginReactantTemplates();
-  RDKit::MOL_SPTR_VECT::const_iterator end_it1 = rxn1->endReactantTemplates();
+  // Check we copied the reactant/product templates
+  TEST_ASSERT(rxn2->getNumReactantTemplates() == 2);
+  TEST_ASSERT(rxn2->getNumProductTemplates() == 1);
+  MOL_SPTR_VECT::const_iterator it1 = rxn1->beginReactantTemplates();
+  MOL_SPTR_VECT::const_iterator it2 = rxn2->beginReactantTemplates();
+  MOL_SPTR_VECT::const_iterator end_it1 = rxn1->endReactantTemplates();
   while (it1 != end_it1) {
-    TEST_ASSERT(RDKit::MolToSmiles(**it1) == RDKit::MolToSmiles(**it2));
+    TEST_ASSERT(MolToSmiles(**it1) == MolToSmiles(**it2));
     ++it1;
     ++it2;
   }
-
   it1 = rxn1->beginProductTemplates();
   it2 = rxn2->beginProductTemplates();
   end_it1 = rxn1->endProductTemplates();
   while (it1 != end_it1) {
-    TEST_ASSERT(RDKit::MolToSmiles(**it1) == RDKit::MolToSmiles(**it2));
+    TEST_ASSERT(MolToSmiles(**it1) == MolToSmiles(**it2));
     ++it1;
     ++it2;
   }
 
-  RDKit::MOL_SPTR_VECT reactants;
-  reactants.emplace_back(RDKit::SmilesToMol("CC(=O)O"));
-  reactants.emplace_back(RDKit::SmilesToMol("CCN"));
-  std::vector<RDKit::MOL_SPTR_VECT> products = rxn1->runReactants(reactants);
-  TEST_ASSERT(RDKit::MolToSmiles(*products[0][0]) == "CCNC(C)=O");
+  // Check that the reactions don't share resources
+  const RWMol& rxn1_reactant = *rxn1->getReactants().at(0);
+  const_cast<RWMol&>(rxn1_reactant).clear();
+  ROMOL_SPTR rxn2_reactant = rxn2->getReactants().at(0);
+  TEST_ASSERT(rxn2_reactant->getNumAtoms() > 0);
+
+  // Check the reaction works
+  MOL_SPTR_VECT reactants;
+  reactants.emplace_back(SmilesToMol("CC(=O)O"));
+  reactants.emplace_back(SmilesToMol("CCN"));
+  std::vector<MOL_SPTR_VECT> products = rxn2->runReactants(reactants);
+  TEST_ASSERT(MolToSmiles(*products[0][0]) == "CCNC(C)=O");
 
   delete rxn1;
   delete rxn2;


### PR DESCRIPTION
#### Reference Issue
Addresses the issues of PR #5265.

#### What does this implement/fix? Explain your changes.
The default `ChemicalReaction` copy assignment operator introduced with PR #5265 copied pointers to reactant/agent/product templates as opposed to the underlying molecules. As noted by @bp-kelley, this can have unintended consequences when modifying the template molecules. This PR provides an implementation for the copy assignment operator that copies the underlying resources.