### PR TITLE
Fixes #5298

### DIFF
--- a/Code/GraphMol/MolDraw2D/Wrap/rdMolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/Wrap/rdMolDraw2D.cpp
@@ -383,6 +383,7 @@ python::object getCairoDrawingText(const RDKit::MolDraw2DCairo &self) {
 #endif
 ROMol *prepMolForDrawing(const ROMol *m, bool kekulize, bool addChiralHs,
                          bool wedgeBonds, bool forceCoords, bool wavyBonds) {
+  PRECONDITION(m, "molecule must not be None");
   auto *res = new RWMol(*m);
   MolDraw2DUtils::prepareMolForDrawing(*res, kekulize, addChiralHs, wedgeBonds,
                                        forceCoords, wavyBonds);

--- a/Code/GraphMol/MolDraw2D/Wrap/testMolDraw2D.py
+++ b/Code/GraphMol/MolDraw2D/Wrap/testMolDraw2D.py
@@ -738,5 +738,10 @@ M  END''')
     with self.assertRaises(ValueError):
       d2d.DrawString("fail", Geometry.Point2D(1, 4), 3)
 
+  def testGithub5298(self):
+    with self.assertRaises(RuntimeError):
+      rdMolDraw2D.PrepareMolForDrawing(None)
+
+
 if __name__ == "__main__":
   unittest.main()


### PR DESCRIPTION
Avoids a segfault in case a `None` molecule is passed to `rdMolDraw2D.PrepareMolForDrawing()`.