### PR TITLE
Add a global feature flag to enable the "new" stereo perception code

### DIFF
--- a/Code/GraphMol/Chirality.cpp
+++ b/Code/GraphMol/Chirality.cpp
@@ -24,7 +24,6 @@
 #include "Chirality.h"
 
 #include <cstdlib>
-#include <stdlib.h>
 
 // #define VERBOSE_CANON 1
 

--- a/Code/GraphMol/Chirality.cpp
+++ b/Code/GraphMol/Chirality.cpp
@@ -768,6 +768,7 @@ const Atom *findHighestCIPNeighbor(const Atom *atom, const Atom *skipAtom) {
 
 namespace Chirality {
 bool allowNontetrahedralChirality = true;
+bool useLegacyStereoPerception = true;
 
 namespace detail {
 bool bondAffectsAtomChirality(const Bond *bond, const Atom *atom) {
@@ -1837,6 +1838,11 @@ namespace MolOps {
 void assignStereochemistry(ROMol &mol, bool cleanIt, bool force,
                            bool flagPossibleStereoCenters) {
   if (!force && mol.hasProp(common_properties::_StereochemDone)) {
+    return;
+  }
+
+  if (!Chirality::useLegacyStereoPerception) {
+    Chirality::findPotentialStereo(mol, cleanIt, flagPossibleStereoCenters);
     return;
   }
 

--- a/Code/GraphMol/Chirality.h
+++ b/Code/GraphMol/Chirality.h
@@ -27,9 +27,20 @@ namespace Chirality {
 
 //! double bond stereo will be ignored/removed for rings smaller than this:
 constexpr unsigned int minRingSizeForDoubleBondStereo = 8;
-RDKIT_GRAPHMOL_EXPORT extern bool
-    allowNontetrahedralChirality;  //!< Toggle perception of
-                                   //!< nontetrahedral chirality from 3D
+
+constexpr auto nonTetrahedralStereoEnvVar = "RDK_ENABLE_NONTETRAHEDRAL_STEREO";
+constexpr auto useLegacyStereoEnvVar = "RDK_USE_LEGACY_STEREO_PERCEPTION";
+constexpr bool nonTetrahedralStereoDefaultVal =
+    true;  //!< whether or not nontetrahedral stereo is perceived by default
+constexpr bool useLegacyStereoDefaultVal =
+    true;  //!< whether or not the legacy stereo perception code is used by
+           //!< default
+
+RDKIT_GRAPHMOL_EXPORT extern void setAllowNontetrahedralChirality(bool val);
+RDKIT_GRAPHMOL_EXPORT extern bool getAllowNontetrahedralChirality();
+
+RDKIT_GRAPHMOL_EXPORT extern void setUseLegacyStereoPerception(bool val);
+RDKIT_GRAPHMOL_EXPORT extern bool getUseLegacyStereoPerception();
 
 RDKIT_GRAPHMOL_EXPORT extern bool
     useLegacyStereoPerception;  //!< Toggle usage of the legacy stereo

--- a/Code/GraphMol/Chirality.h
+++ b/Code/GraphMol/Chirality.h
@@ -31,6 +31,10 @@ RDKIT_GRAPHMOL_EXPORT extern bool
     allowNontetrahedralChirality;  //!< Toggle perception of
                                    //!< nontetrahedral chirality from 3D
 
+RDKIT_GRAPHMOL_EXPORT extern bool
+    useLegacyStereoPerception;  //!< Toggle usage of the legacy stereo
+                                //!< perception code
+
 /// @cond
 /*!
   \param mol the molecule to be altered

--- a/Code/GraphMol/Wrap/MolOps.cpp
+++ b/Code/GraphMol/Wrap/MolOps.cpp
@@ -21,6 +21,7 @@
 #include <GraphMol/MolBundle.h>
 #include <GraphMol/RDKitQueries.h>
 #include <GraphMol/MonomerInfo.h>
+#include <GraphMol/Chirality.h>
 #include <GraphMol/Substruct/SubstructMatch.h>
 #include <GraphMol/Substruct/SubstructUtils.h>
 #include <GraphMol/Wrap/substructmethods.h>
@@ -44,6 +45,7 @@ namespace RDKit {
 void setAllowNontetrahedral(bool val) {
   RDKit::Chirality::allowNontetrahedralChirality = val;
 }
+void setLegacyStereo(bool val) { Chirality::useLegacyStereoPerception = val; }
 
 python::tuple fragmentOnSomeBondsHelper(const ROMol &mol,
                                         python::object pyBondIndices,
@@ -2732,6 +2734,8 @@ A note on the flags controlling which atoms/bonds are modified:
     python::def(
         "SetAllowNontetrahedralChirality", setAllowNontetrahedral,
         "toggles recognition of non-tetrahedral chirality from 3D structures");
+    python::def("SetLegacyStereoPerception", setLegacyStereo,
+                "toggles usage of the legacy stereo perception code");
   }
 };
 }  // namespace RDKit

--- a/Code/GraphMol/Wrap/MolOps.cpp
+++ b/Code/GraphMol/Wrap/MolOps.cpp
@@ -42,15 +42,6 @@ using boost_adaptbx::python::streambuf;
 
 namespace RDKit {
 
-void setAllowNontetrahedral(bool val) {
-  RDKit::Chirality::allowNontetrahedralChirality = val;
-}
-bool getAllowNontetrahedral() {
-  return RDKit::Chirality::allowNontetrahedralChirality;
-}
-void setLegacyStereo(bool val) { Chirality::useLegacyStereoPerception = val; }
-bool getLegacyStereo() { return Chirality::useLegacyStereoPerception; }
-
 python::tuple fragmentOnSomeBondsHelper(const ROMol &mol,
                                         python::object pyBondIndices,
                                         unsigned int nToBreak, bool addDummies,
@@ -2736,14 +2727,18 @@ A note on the flags controlling which atoms/bonds are modified:
                 GenericGroups::convertGenericQueriesToSubstanceGroups,
                 python::arg("mol"), "documentation");
     python::def(
-        "SetAllowNontetrahedralChirality", setAllowNontetrahedral,
+        "SetAllowNontetrahedralChirality",
+        Chirality::setAllowNontetrahedralChirality,
         "toggles recognition of non-tetrahedral chirality from 3D structures");
-    python::def("GetAllowNontetrahedralChirality", getAllowNontetrahedral,
+    python::def("GetAllowNontetrahedralChirality",
+                Chirality::getAllowNontetrahedralChirality,
                 "returns whether or not recognition of non-tetrahedral "
                 "chirality from 3D structures is enabled");
-    python::def("SetLegacyStereoPerception", setLegacyStereo,
+    python::def("SetUseLegacyStereoPerception",
+                Chirality::setUseLegacyStereoPerception,
                 "toggles usage of the legacy stereo perception code");
-    python::def("GetLegacyStereoPerception", getLegacyStereo,
+    python::def("GetUseLegacyStereoPerception",
+                Chirality::getUseLegacyStereoPerception,
                 "returns whether or not the legacy stereo perception code is "
                 "being used");
   }

--- a/Code/GraphMol/Wrap/MolOps.cpp
+++ b/Code/GraphMol/Wrap/MolOps.cpp
@@ -45,7 +45,11 @@ namespace RDKit {
 void setAllowNontetrahedral(bool val) {
   RDKit::Chirality::allowNontetrahedralChirality = val;
 }
+bool getAllowNontetrahedral() {
+  return RDKit::Chirality::allowNontetrahedralChirality;
+}
 void setLegacyStereo(bool val) { Chirality::useLegacyStereoPerception = val; }
+bool getLegacyStereo() { return Chirality::useLegacyStereoPerception; }
 
 python::tuple fragmentOnSomeBondsHelper(const ROMol &mol,
                                         python::object pyBondIndices,
@@ -2734,8 +2738,14 @@ A note on the flags controlling which atoms/bonds are modified:
     python::def(
         "SetAllowNontetrahedralChirality", setAllowNontetrahedral,
         "toggles recognition of non-tetrahedral chirality from 3D structures");
+    python::def("GetAllowNontetrahedralChirality", getAllowNontetrahedral,
+                "returns whether or not recognition of non-tetrahedral "
+                "chirality from 3D structures is enabled");
     python::def("SetLegacyStereoPerception", setLegacyStereo,
                 "toggles usage of the legacy stereo perception code");
+    python::def("GetLegacyStereoPerception", getLegacyStereo,
+                "returns whether or not the legacy stereo perception code is "
+                "being used");
   }
 };
 }  // namespace RDKit

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -6896,18 +6896,18 @@ CAS<~>
     Chem.SetAllowNontetrahedralChirality(origVal)
 
   def test_legacyStereochemGlobal(self):
-    origVal = Chem.GetLegacyStereoPerception()
-    Chem.SetLegacyStereoPerception(True)
+    origVal = Chem.GetUseLegacyStereoPerception()
+    Chem.SetUseLegacyStereoPerception(True)
     m = Chem.MolFromSmiles("C[C@H]1CCC2(CC1)CC[C@H](C)C(C)C2")
     self.assertEqual(m.GetAtomWithIdx(1).GetChiralTag(), Chem.ChiralType.CHI_UNSPECIFIED)
     self.assertNotEqual(m.GetAtomWithIdx(9).GetChiralTag(), Chem.ChiralType.CHI_UNSPECIFIED)
 
-    Chem.SetLegacyStereoPerception(False)
+    Chem.SetUseLegacyStereoPerception(False)
     m = Chem.MolFromSmiles("C[C@H]1CCC2(CC1)CC[C@H](C)C(C)C2")
     self.assertNotEqual(m.GetAtomWithIdx(1).GetChiralTag(), Chem.ChiralType.CHI_UNSPECIFIED)
     self.assertNotEqual(m.GetAtomWithIdx(9).GetChiralTag(), Chem.ChiralType.CHI_UNSPECIFIED)
 
-    Chem.SetLegacyStereoPerception(origVal)
+    Chem.SetUseLegacyStereoPerception(origVal)
 
 
 if __name__ == '__main__':

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -6866,32 +6866,37 @@ CAS<~>
       log_stream.truncate(0)
 
   def testDisableNontetrahedralStereo(self):
-    fileN = os.path.join(RDConfig.RDBaseDir, 'Code', 'GraphMol', 'test_data', 'nontetrahedral_3d.sdf')
+    fileN = os.path.join(RDConfig.RDBaseDir, 'Code', 'GraphMol', 'test_data',
+                         'nontetrahedral_3d.sdf')
+    origVal = Chem.GetAllowNontetrahedralChirality()
+    Chem.SetAllowNontetrahedralChirality(True)
     suppl = Chem.SDMolSupplier(fileN, sanitize=False)
     for mol in suppl:
       Chem.AssignStereochemistryFrom3D(mol)
       ct = mol.GetProp("ChiralType")
       at = mol.GetAtomWithIdx(0)
-      if ct=="SP":
-        self.assertEqual(at.GetChiralTag(),Chem.ChiralType.CHI_SQUAREPLANAR)
-      elif ct=="TB":
-        self.assertEqual(at.GetChiralTag(),Chem.ChiralType.CHI_TRIGONALBIPYRAMIDAL)
-      elif ct=="OH":
-        self.assertEqual(at.GetChiralTag(),Chem.ChiralType.CHI_OCTAHEDRAL)
-      elif ct=="TH":
-        self.assertEqual(at.GetChiralTag(),Chem.ChiralType.CHI_TETRAHEDRAL)
+      if ct == "SP":
+        self.assertEqual(at.GetChiralTag(), Chem.ChiralType.CHI_SQUAREPLANAR)
+      elif ct == "TB":
+        self.assertEqual(at.GetChiralTag(), Chem.ChiralType.CHI_TRIGONALBIPYRAMIDAL)
+      elif ct == "OH":
+        self.assertEqual(at.GetChiralTag(), Chem.ChiralType.CHI_OCTAHEDRAL)
+      elif ct == "TH":
+        self.assertEqual(at.GetChiralTag(), Chem.ChiralType.CHI_TETRAHEDRAL)
     Chem.SetAllowNontetrahedralChirality(False)
     suppl = Chem.SDMolSupplier(fileN, sanitize=False)
     for mol in suppl:
       Chem.AssignStereochemistryFrom3D(mol)
       ct = mol.GetProp("ChiralType")
       at = mol.GetAtomWithIdx(0)
-      if ct=="TH":
-        self.assertEqual(at.GetChiralTag(),Chem.ChiralType.CHI_TETRAHEDRAL)
+      if ct == "TH":
+        self.assertEqual(at.GetChiralTag(), Chem.ChiralType.CHI_TETRAHEDRAL)
       else:
-        self.assertEqual(at.GetChiralTag(),Chem.ChiralType.CHI_UNSPECIFIED)
+        self.assertEqual(at.GetChiralTag(), Chem.ChiralType.CHI_UNSPECIFIED)
+    Chem.SetAllowNontetrahedralChirality(origVal)
 
   def test_legacyStereochemGlobal(self):
+    origVal = Chem.GetLegacyStereoPerception()
     Chem.SetLegacyStereoPerception(True)
     m = Chem.MolFromSmiles("C[C@H]1CCC2(CC1)CC[C@H](C)C(C)C2")
     self.assertEqual(m.GetAtomWithIdx(1).GetChiralTag(), Chem.ChiralType.CHI_UNSPECIFIED)
@@ -6901,6 +6906,8 @@ CAS<~>
     m = Chem.MolFromSmiles("C[C@H]1CCC2(CC1)CC[C@H](C)C(C)C2")
     self.assertNotEqual(m.GetAtomWithIdx(1).GetChiralTag(), Chem.ChiralType.CHI_UNSPECIFIED)
     self.assertNotEqual(m.GetAtomWithIdx(9).GetChiralTag(), Chem.ChiralType.CHI_UNSPECIFIED)
+
+    Chem.SetLegacyStereoPerception(origVal)
 
 
 if __name__ == '__main__':

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -6891,6 +6891,16 @@ CAS<~>
       else:
         self.assertEqual(at.GetChiralTag(),Chem.ChiralType.CHI_UNSPECIFIED)
 
+  def test_legacyStereochemGlobal(self):
+    Chem.SetLegacyStereoPerception(True)
+    m = Chem.MolFromSmiles("C[C@H]1CCC2(CC1)CC[C@H](C)C(C)C2")
+    self.assertEqual(m.GetAtomWithIdx(1).GetChiralTag(), Chem.ChiralType.CHI_UNSPECIFIED)
+    self.assertNotEqual(m.GetAtomWithIdx(9).GetChiralTag(), Chem.ChiralType.CHI_UNSPECIFIED)
+
+    Chem.SetLegacyStereoPerception(False)
+    m = Chem.MolFromSmiles("C[C@H]1CCC2(CC1)CC[C@H](C)C(C)C2")
+    self.assertNotEqual(m.GetAtomWithIdx(1).GetChiralTag(), Chem.ChiralType.CHI_UNSPECIFIED)
+    self.assertNotEqual(m.GetAtomWithIdx(9).GetChiralTag(), Chem.ChiralType.CHI_UNSPECIFIED)
 
 
 if __name__ == '__main__':

--- a/Code/GraphMol/catch_chirality.cpp
+++ b/Code/GraphMol/catch_chirality.cpp
@@ -1990,7 +1990,7 @@ TEST_CASE("nontetrahedral stereo from 3D", "[nontetrahedral]") {
     }
   }
   SECTION("disable nontetrahedral stereo") {
-    Chirality::allowNontetrahedralChirality = false;
+    Chirality::setAllowNontetrahedralChirality(false);
     SDMolSupplier suppl(pathName);
     while (!suppl.atEnd()) {
       std::unique_ptr<ROMol> m{suppl.next()};
@@ -2005,7 +2005,7 @@ TEST_CASE("nontetrahedral stereo from 3D", "[nontetrahedral]") {
         CHECK(atom->getChiralTag() == Atom::ChiralType::CHI_UNSPECIFIED);
       }
     }
-    Chirality::allowNontetrahedralChirality = true;
+    Chirality::setAllowNontetrahedralChirality(true);
   }
 }
 
@@ -2385,14 +2385,14 @@ TEST_CASE("nontetrahedral StereoInfo", "[nontetrahedral]") {
 }
 TEST_CASE("useLegacyStereoPerception feature flag") {
   SECTION("original failing example") {
-    Chirality::useLegacyStereoPerception = true;
+    Chirality::setUseLegacyStereoPerception(true);
     auto m = "C[C@H]1CCC2(CC1)CC[C@H](C)C(C)C2"_smiles;
     REQUIRE(m);
     CHECK(m->getAtomWithIdx(1)->getChiralTag() == Atom::CHI_UNSPECIFIED);
     CHECK(m->getAtomWithIdx(9)->getChiralTag() != Atom::CHI_UNSPECIFIED);
   }
   SECTION("use new code") {
-    Chirality::useLegacyStereoPerception = false;
+    Chirality::setUseLegacyStereoPerception(false);
     auto m = "C[C@H]1CCC2(CC1)CC[C@H](C)C(C)C2"_smiles;
     REQUIRE(m);
     CHECK(m->getAtomWithIdx(1)->getChiralTag() != Atom::CHI_UNSPECIFIED);
@@ -2441,13 +2441,13 @@ M  V30 END CTAB
 M  END
 )CTAB";
   SECTION("original example, from mol block") {
-    Chirality::useLegacyStereoPerception = true;
+    Chirality::setUseLegacyStereoPerception(true);
     std::unique_ptr<RWMol> m{MolBlockToMol(molblock)};
     CHECK(m->getAtomWithIdx(3)->getChiralTag() != Atom::CHI_UNSPECIFIED);
     CHECK(m->getAtomWithIdx(8)->getChiralTag() == Atom::CHI_UNSPECIFIED);
   }
   SECTION("original example, from mol block, new code") {
-    Chirality::useLegacyStereoPerception = false;
+    Chirality::setUseLegacyStereoPerception(false);
     std::unique_ptr<RWMol> m{MolBlockToMol(molblock)};
     CHECK(m->getAtomWithIdx(3)->getChiralTag() != Atom::CHI_UNSPECIFIED);
     CHECK(m->getAtomWithIdx(8)->getChiralTag() != Atom::CHI_UNSPECIFIED);

--- a/Code/MinimalLib/jswrapper.cpp
+++ b/Code/MinimalLib/jswrapper.cpp
@@ -249,6 +249,7 @@ EMSCRIPTEN_BINDINGS(RDKit_minimal) {
 
   function("version", &version);
   function("prefer_coordgen", &prefer_coordgen);
+  function("use_legacy_stereo_perception", &use_legacy_stereo_perception);
   function("get_inchikey_for_inchi", &get_inchikey_for_inchi);
   function("get_mol", &get_mol, allow_raw_pointers());
   function("get_mol", &get_mol_no_details, allow_raw_pointers());

--- a/Code/MinimalLib/minilib.cpp
+++ b/Code/MinimalLib/minilib.cpp
@@ -535,5 +535,5 @@ void prefer_coordgen(bool useCoordGen) {
 }
 
 void use_legacy_stereo_perception(bool value) {
-  Chirality::useLegacyStereoPerception = value;
+  Chirality::setUseLegacyStereoPerception(value);
 }

--- a/Code/MinimalLib/minilib.cpp
+++ b/Code/MinimalLib/minilib.cpp
@@ -16,6 +16,7 @@
 #include <RDGeneral/versions.h>
 #include <GraphMol/RDKitBase.h>
 #include <GraphMol/MolPickler.h>
+#include <GraphMol/Chirality.h>
 #include <GraphMol/SmilesParse/SmilesParse.h>
 #include <GraphMol/SmilesParse/SmartsWrite.h>
 #include <GraphMol/FileParsers/FileParsers.h>
@@ -531,4 +532,8 @@ void prefer_coordgen(bool useCoordGen) {
 #ifdef RDK_BUILD_COORDGEN_SUPPORT
   RDDepict::preferCoordGen = useCoordGen;
 #endif
+}
+
+void use_legacy_stereo_perception(bool value) {
+  Chirality::useLegacyStereoPerception = value;
 }

--- a/Code/MinimalLib/minilib.h
+++ b/Code/MinimalLib/minilib.h
@@ -140,3 +140,4 @@ JSMol *get_mol_copy(const JSMol &other);
 JSMol *get_qmol(const std::string &input);
 std::string version();
 void prefer_coordgen(bool prefer);
+void use_legacy_stereo_perception(bool value);

--- a/Code/MinimalLib/tests/tests.js
+++ b/Code/MinimalLib/tests/tests.js
@@ -635,6 +635,18 @@ function test_flexicanvas() {
     assert(svg.search("height='21px'")>0);
 }
 
+function test_legacy_stereochem() {
+    RDKitModule.use_legacy_stereo_perception(true);
+    var mol = RDKitModule.get_mol("C[C@H]1CCC2(CC1)CC[C@H](C)C(C)C2");
+    assert.equal(mol.is_valid(),1);
+    assert.equal(mol.get_smiles(),"CC1CCC2(CC1)CC[C@H](C)C(C)C2");
+    
+    RDKitModule.use_legacy_stereo_perception(false);
+    mol = RDKitModule.get_mol("C[C@H]1CCC2(CC1)CC[C@H](C)C(C)C2");
+    assert.equal(mol.is_valid(),1);
+    assert.equal(mol.get_smiles(),"CC1CC2(CC[C@H](C)CC2)CC[C@@H]1C");
+}
+
 
 
 initRDKitModule().then(function(instance) {
@@ -676,6 +688,7 @@ initRDKitModule().then(function(instance) {
     test_normalize_depiction();
     test_straighten_depiction();
     test_flexicanvas();
+    test_legacy_stereochem();
     waitAllTestsFinished().then(() =>
         console.log("Tests finished successfully")
     );

--- a/Docs/Book/RDKit_Book.rst
+++ b/Docs/Book/RDKit_Book.rst
@@ -658,7 +658,7 @@ Brief description of the ``findPotentialStereo()`` algorithm
 Support for non-tetrahedral atomic stereochemistry
 ==================================================
 
-Starting with the 2022.03 release, the RDKit has partial, but evolving, support
+Starting with the 2022.09 release, the RDKit has partial, but evolving, support
 for non-tetrahedral stereochemistry. The status of this work is being tracked in
 this github issue: https://github.com/rdkit/rdkit/issues/4851
 
@@ -666,7 +666,7 @@ This code is being released in a preliminary state in order to get feedback as
 soon as we can and to start to gather experience working with these systems.
 
 
-Status as of 2022.03.1 release
+Status as of 2022.09.1 release
 ------------------------------
 
 "Complete"
@@ -2248,6 +2248,45 @@ The idea of the fingerprint is generate features using the same subgraph (or
 path) enumeration algorithm used in the RDKit fingerprint. After a subgraph has
 been generated, it is used to set multiple bits based on different atom and bond
 type definitions.
+
+
+Feature Flags: global variables affecting RDKit behavior
+********************************************************
+
+The RDKit uses a number of "feature flags": global variables which affect its
+behavior. These have generally been added to maintain backwards compatibility
+when introducing new algorithms which yield different results.
+
+Here's are the current feature flags:
+
+  - ``preferCoordGen``: when this is ``true`` Schrodinger's open-source Coordgen
+    library will be used to generate 2D coordinates of molecules. The default
+    value is ``false``. This can be set from C++ using the variable
+    ``RDKit::RDDepict::preferCoordGen`` or from Python using the function
+    ``rdDepictor.SetPreferCoordGen()``. Added in the 2018.03 release.
+
+  - ``allowNontetrahedralChirality``: when this is ``true`` non-tetrahedral
+    chirality will be perceived from 3D coordinates. The default value is
+    ``true`` unless the environment variable
+    ``RDK_ENABLE_NONTETRAHEDRAL_STEREO`` is set to ``"0"``. Can set/checked from
+    C++ using the functions
+    ``RDKit::Chirality::setAllowNontetrahedralChirality()`` /
+    ``RDKit::Chirality::getAllowNontetrahedralChirality()`` or from Python using
+    the functions ``Chem.SetAllowNontetrahedralChirality()`` /
+    ``Chem.GetAllowNontetrahedralChirality()``. Added in the 2022.09 release.
+
+  - ``useLegacyStereoPerception``: when this is ``true`` the legacy
+    implementation for perceiving stereochemistry will be used. 
+    The default value is ``true`` unless the environment variable
+    ``RDK_USE_LEGACY_STEREO_PERCEPTION`` is set to ``"0"``. Can set/checked from
+    C++ using the functions
+    ``RDKit::Chirality::setUseLegacyStereoPerception()`` /
+    ``RDKit::Chirality::getUseLegacyStereoPerception()`` or from Python using
+    the functions ``Chem.SetUseLegacyStereoPerception()`` /
+    ``Chem.GetUseLegacyStereoPerception()``. Added in the 2022.09 release.
+
+
+
 
 
 .. rubric:: Footnotes


### PR DESCRIPTION
This currently defaults to true, but when it is set then the new stereo code is used when calling `AssignStereochemistry()`