### PR TITLE
Support conjugated terminal groups in GetBestRMS()

### DIFF
--- a/Code/GraphMol/MolAlign/AlignMolecules.h
+++ b/Code/GraphMol/MolAlign/AlignMolecules.h
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2001-2006 Rational Discovery LLC
+//  Copyright (C) 2001-2022 Greg Landrum and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -122,6 +122,9 @@ RDKIT_MOLALIGN_EXPORT double alignMol(
                     substructure search.
   \param maxMatches (optional) if map is empty, this will be the max number of
                     matches found in a SubstructMatch().
+  \param symmetrizeConjugatedTerminalGroups (optional) if set, conjugated
+  terminal functional groups (like nitro or carboxylate) will be considered
+  symmetrically
 
   <b>Returns</b>
   Best RMSD value found
@@ -129,7 +132,7 @@ RDKIT_MOLALIGN_EXPORT double alignMol(
 RDKIT_MOLALIGN_EXPORT double getBestRMS(
     ROMol &probeMol, ROMol &refMol, int probeId = -1, int refId = -1,
     const std::vector<MatchVectType> &map = std::vector<MatchVectType>(),
-    int maxMatches = 1e6);
+    int maxMatches = 1e6, bool symmetrizeConjugatedTerminalGroups = true);
 
 //! Returns the RMS between two molecules, taking symmetry into account.
 /*!

--- a/Code/GraphMol/MolAlign/CMakeLists.txt
+++ b/Code/GraphMol/MolAlign/CMakeLists.txt
@@ -1,6 +1,6 @@
 
 rdkit_library(MolAlign AlignMolecules.cpp 
-              LINK_LIBRARIES MolTransforms SubstructMatch Alignment GraphMol RDGeneral)
+              LINK_LIBRARIES MolTransforms SmilesParse SubstructMatch Alignment GraphMol RDGeneral)
 target_compile_definitions(MolAlign PRIVATE RDKIT_MOLALIGN_BUILD)
 
 rdkit_library(O3AAlign O3AAlignMolecules.cpp
@@ -16,6 +16,10 @@ FileParsers DistGeomHelpers SmilesParse)
 rdkit_test(testO3AAlign testO3AAlign.cpp
            LINK_LIBRARIES O3AAlign Descriptors
 FileParsers DistGeomHelpers SmilesParse)
+
+rdkit_catch_test(molAlignCatchTest catch_tests.cpp 
+           LINK_LIBRARIES MolAlign SmilesParse FileParsers )
+
 
 if(RDK_BUILD_PYTHON_WRAPPERS)
 add_subdirectory(Wrap)

--- a/Code/GraphMol/MolAlign/Wrap/rdMolAlign.cpp
+++ b/Code/GraphMol/MolAlign/Wrap/rdMolAlign.cpp
@@ -152,7 +152,8 @@ double AlignMolecule(ROMol &prbMol, const ROMol &refMol, int prbCid = -1,
 }
 
 double GetBestRMS(ROMol &prbMol, ROMol &refMol, int prbId, int refId,
-                  python::object map, int maxMatches) {
+                  python::object map, int maxMatches,
+                  bool symmetrizeTerminalGroups) {
   std::vector<MatchVectType> aMapVec;
   if (map != python::object()) {
     aMapVec = translateAtomMapSeq(map);
@@ -161,8 +162,8 @@ double GetBestRMS(ROMol &prbMol, ROMol &refMol, int prbId, int refId,
   double rmsd;
   {
     NOGIL gil;
-    rmsd =
-        MolAlign::getBestRMS(prbMol, refMol, prbId, refId, aMapVec, maxMatches);
+    rmsd = MolAlign::getBestRMS(prbMol, refMol, prbId, refId, aMapVec,
+                                maxMatches, symmetrizeTerminalGroups);
   }
   return rmsd;
 }
@@ -646,6 +647,9 @@ BOOST_PYTHON_MODULE(rdMolAlign) {
                        using a substructure search.\n\
         - maxMatches:  (optional) if map isn't specified, this will be\n\
                        the max number of matches found in a SubstructMatch()\n\
+        - symmetrizeConjugatedTerminalGroups:  (optional) if set, conjugated\n\
+                       terminal functional groups (like nitro or carboxylate)\n\
+                       will be considered symmetrically\n\
        \n\
       RETURNS\n\
       The best RMSD found\n\
@@ -654,7 +658,8 @@ BOOST_PYTHON_MODULE(rdMolAlign) {
       "GetBestRMS", RDKit::GetBestRMS,
       (python::arg("prbMol"), python::arg("refMol"), python::arg("prbId") = -1,
        python::arg("refId") = -1, python::arg("map") = python::object(),
-       python::arg("maxMatches") = 1000000),
+       python::arg("maxMatches") = 1000000,
+       python::arg("symmetrizeConjugatedTerminalGroups") = true),
       docString.c_str());
 
   docString =

--- a/Code/GraphMol/MolAlign/Wrap/testMolAlign.py
+++ b/Code/GraphMol/MolAlign/Wrap/testMolAlign.py
@@ -459,16 +459,17 @@ class TestCase(unittest.TestCase):
 
     for i, m in enumerate(bzr_ms):
       #prbParams = ChemicalForceFields.MMFFGetMoleculeProperties(m)
-      algs = rdMolAlign.GetO3AForProbeConfs(m,
-                                            bzr_ms_o[0],
-                                            numThreads=4  #,prbPyMMFFMolProperties=prbParams,
-                                            #refPyMMFFMolProperties=refParams
-                                            )
+      algs = rdMolAlign.GetO3AForProbeConfs(
+        m,
+        bzr_ms_o[0],
+        numThreads=4  #,prbPyMMFFMolProperties=prbParams,
+        #refPyMMFFMolProperties=refParams
+      )
       self.failUnlessEqual(len(algs), nConfs)
 
   def test17GetBestRMS(self):
-    sdf = os.path.join(RDConfig.RDBaseDir, 'Code', 'GraphMol', 'MolAlign',
-                       'test_data', 'probe_mol.sdf')
+    sdf = os.path.join(RDConfig.RDBaseDir, 'Code', 'GraphMol', 'MolAlign', 'test_data',
+                       'probe_mol.sdf')
     molS = Chem.SDMolSupplier(sdf, True, False)
     mol1 = molS[1]
     mol2 = molS[2]
@@ -478,6 +479,19 @@ class TestCase(unittest.TestCase):
     rmsd = rdMolAlign.GetBestRMS(mol1, mol2)
 
     self.failUnlessAlmostEqual(rmsd, 2.43449209)
+
+  def test18GetBestRMSAndConjugatedGroups(self):
+    mol = Chem.MolFromSmiles(
+      "CC(=O)[O-] |(-0.65,-0.05,-0.10;0.82,0.02,0.11;1.48,-0.99,0.42;1.51,1.21,-0.02)|")
+    qry = Chem.MolFromSmiles(
+      "CC([O-])=O |(-0.65,-0.05,-0.10;0.82,0.02,0.11;1.48,-0.99,0.42;1.51,1.21,-0.02)|")
+
+    rmsd = rdMolAlign.GetBestRMS(qry, mol)
+    self.failUnlessAlmostEqual(rmsd, 0, 3)
+
+    rmsd = rdMolAlign.GetBestRMS(qry, mol, symmetrizeConjugatedTerminalGroups=False)
+    self.failUnlessAlmostEqual(rmsd, 0.077, 3)
+
 
 if __name__ == '__main__':
   print("Testing MolAlign Wrappers")

--- a/Code/GraphMol/MolAlign/Wrap/testMolAlign.py
+++ b/Code/GraphMol/MolAlign/Wrap/testMolAlign.py
@@ -482,15 +482,17 @@ class TestCase(unittest.TestCase):
 
   def test18GetBestRMSAndConjugatedGroups(self):
     mol = Chem.MolFromSmiles(
-      "CC(=O)[O-] |(-0.65,-0.05,-0.10;0.82,0.02,0.11;1.48,-0.99,0.42;1.51,1.21,-0.02)|")
+      "CCC(=O)[O-] |(-1.11,0.08,-0.29;0.08,-0.18,0.58;1.34,0.03,-0.16;1.74,1.22,-0.32;2.06,-1.04,-0.66)|"
+    )
     qry = Chem.MolFromSmiles(
-      "CC([O-])=O |(-0.65,-0.05,-0.10;0.82,0.02,0.11;1.48,-0.99,0.42;1.51,1.21,-0.02)|")
+      "CCC([O-])=O |(-1.11,0.08,-0.29;0.08,-0.18,0.58;1.34,0.03,-0.16;1.74,1.22,-0.32;2.06,-1.04,-0.66)|"
+    )
 
     rmsd = rdMolAlign.GetBestRMS(qry, mol)
     self.failUnlessAlmostEqual(rmsd, 0, 3)
 
     rmsd = rdMolAlign.GetBestRMS(qry, mol, symmetrizeConjugatedTerminalGroups=False)
-    self.failUnlessAlmostEqual(rmsd, 0.077, 3)
+    self.failUnlessAlmostEqual(rmsd, 0.747, 3)
 
 
 if __name__ == '__main__':

--- a/Code/GraphMol/MolAlign/catch_tests.cpp
+++ b/Code/GraphMol/MolAlign/catch_tests.cpp
@@ -1,0 +1,106 @@
+//
+//  Copyright (C) 2022 Greg Landrum and other RDKit contributors
+//
+//   @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
+//
+#include "catch.hpp"
+#include "AlignMolecules.h"
+#include <GraphMol/FileParsers/FileParsers.h>
+#include <GraphMol/ROMol.h>
+#include <GraphMol/Conformer.h>
+#include <GraphMol/SmilesParse/SmilesParse.h>
+#include <GraphMol/MolTransforms/MolTransforms.h>
+
+using namespace RDKit;
+
+TEST_CASE("symmetric functional groups") {
+  SECTION("basics") {
+    auto m1 =
+        "CC(=O)[O-] "
+        "|(-0.65,-0.05,-0.10;0.82,0.02,0.11;1.48,-0.99,0.42;1.51,1.21,-0.02)|"_smiles;
+    REQUIRE(m1);
+
+    // swap the bond orders to the Os
+    RWMol m2(*m1);
+    m2.getAtomWithIdx(2)->setFormalCharge(-1);
+    m2.getAtomWithIdx(3)->setFormalCharge(0);
+    m2.getBondBetweenAtoms(1, 2)->setBondType(Bond::BondType::SINGLE);
+    m2.getBondBetweenAtoms(1, 3)->setBondType(Bond::BondType::DOUBLE);
+
+    {
+      auto rmsd = MolAlign::getBestRMS(m2, *m1);
+      CHECK(rmsd == Approx(0.0).margin(1e-3));
+    }
+    {
+      // previous behavior
+      int probeId = -1;
+      int refId = -1;
+      std::vector<MatchVectType> mp;
+      int maxMatches = 1e6;
+      bool symmetrize = false;
+      auto rmsd = MolAlign::getBestRMS(m2, *m1, probeId, refId, mp, maxMatches,
+                                       symmetrize);
+      CHECK(rmsd == Approx(0.076).margin(1e-3));
+    }
+  }
+  SECTION("terminal sulfate1") {
+    auto m1 =
+        "CS(=O)(=O)[O-] |(-0.93,-0.06,-0.04;0.82,0.07,0.13;1.27,-0.04,1.54;1.21,1.40,-0.48;1.53,-1.11,-0.82)|"_smiles;
+    REQUIRE(m1);
+
+    // swap the bond orders to the Os
+    RWMol m2(*m1);
+    m2.getAtomWithIdx(2)->setFormalCharge(-1);
+    m2.getAtomWithIdx(4)->setFormalCharge(0);
+    m2.getBondBetweenAtoms(1, 2)->setBondType(Bond::BondType::SINGLE);
+    m2.getBondBetweenAtoms(1, 4)->setBondType(Bond::BondType::DOUBLE);
+
+    {
+      auto rmsd = MolAlign::getBestRMS(m2, *m1);
+      CHECK(rmsd == Approx(0.0).margin(1e-3));
+    }
+    {
+      // previous behavior
+      int probeId = -1;
+      int refId = -1;
+      std::vector<MatchVectType> mp;
+      int maxMatches = 1e6;
+      bool symmetrize = false;
+      auto rmsd = MolAlign::getBestRMS(m2, *m1, probeId, refId, mp, maxMatches,
+                                       symmetrize);
+      CHECK(rmsd == Approx(0.097).margin(1e-3));
+    }
+  }
+  SECTION("terminal sulfate2") {
+    auto m1 =
+        "CS(=O)(=O)[O-] |(-0.93,-0.06,-0.04;0.82,0.07,0.13;1.27,-0.04,1.54;1.21,1.40,-0.48;1.53,-1.11,-0.82)|"_smiles;
+    REQUIRE(m1);
+
+    // swap the bond orders to the Os
+    RWMol m2(*m1);
+    m2.getAtomWithIdx(3)->setFormalCharge(-1);
+    m2.getAtomWithIdx(4)->setFormalCharge(0);
+    m2.getBondBetweenAtoms(1, 3)->setBondType(Bond::BondType::SINGLE);
+    m2.getBondBetweenAtoms(1, 4)->setBondType(Bond::BondType::DOUBLE);
+
+    {
+      auto rmsd = MolAlign::getBestRMS(m2, *m1);
+      CHECK(rmsd == Approx(0.0).margin(1e-3));
+    }
+    {
+      // previous behavior
+      int probeId = -1;
+      int refId = -1;
+      std::vector<MatchVectType> mp;
+      int maxMatches = 1e6;
+      bool symmetrize = false;
+      auto rmsd = MolAlign::getBestRMS(m2, *m1, probeId, refId, mp, maxMatches,
+                                       symmetrize);
+      CHECK(rmsd == Approx(0.097).margin(1e-3));
+    }
+  }
+}

--- a/Code/GraphMol/MolAlign/catch_tests.cpp
+++ b/Code/GraphMol/MolAlign/catch_tests.cpp
@@ -20,16 +20,16 @@ using namespace RDKit;
 TEST_CASE("symmetric functional groups") {
   SECTION("basics") {
     auto m1 =
-        "CC(=O)[O-] "
-        "|(-0.65,-0.05,-0.10;0.82,0.02,0.11;1.48,-0.99,0.42;1.51,1.21,-0.02)|"_smiles;
+        "CCC(=O)[O-] "
+        "|(-1.11,0.08,-0.29;0.08,-0.18,0.58;1.34,0.03,-0.16;1.74,1.22,-0.32;2.06,-1.04,-0.66)|"_smiles;
     REQUIRE(m1);
 
     // swap the bond orders to the Os
     RWMol m2(*m1);
-    m2.getAtomWithIdx(2)->setFormalCharge(-1);
-    m2.getAtomWithIdx(3)->setFormalCharge(0);
-    m2.getBondBetweenAtoms(1, 2)->setBondType(Bond::BondType::SINGLE);
-    m2.getBondBetweenAtoms(1, 3)->setBondType(Bond::BondType::DOUBLE);
+    m2.getAtomWithIdx(3)->setFormalCharge(-1);
+    m2.getAtomWithIdx(4)->setFormalCharge(0);
+    m2.getBondBetweenAtoms(2, 3)->setBondType(Bond::BondType::SINGLE);
+    m2.getBondBetweenAtoms(2, 4)->setBondType(Bond::BondType::DOUBLE);
 
     {
       auto rmsd = MolAlign::getBestRMS(m2, *m1);
@@ -44,7 +44,7 @@ TEST_CASE("symmetric functional groups") {
       bool symmetrize = false;
       auto rmsd = MolAlign::getBestRMS(m2, *m1, probeId, refId, mp, maxMatches,
                                        symmetrize);
-      CHECK(rmsd == Approx(0.076).margin(1e-3));
+      CHECK(rmsd == Approx(0.747).margin(1e-3));
     }
   }
   SECTION("terminal sulfate1") {

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -2,6 +2,15 @@
 (Changes relative to Release_2022.03.1)
 
 ## Backwards incompatible changes
+- `GetBestRMS()` by default now treats terminal conjugated functional groups
+  like carboxylate and nitro symmetrically. For example, the group
+  `C(=[O:1])[O-:2]` can match in either orientation. The SMARTS pattern which is
+  used to recognize affected groups is:
+  `[{atomP};$([{atomP}]-[*]=[{atomP}]),$([{atomP}]=[*]-[{atomP}])]~[*]` where
+  `{atomP}` is `O,N;D1`. The previous behavior can be restored using by setting
+  the `symmetrizeConjugatedTerminalGroups` argument to false when calling
+  `GetBestRMS()`
+
 
 ## Code removed in this release:
 - The C++ class `RDLog::BlockLogs` has been removed. Please use the class `RDLog::LogStateSetter`. The Python class rdBase.BlockLogs() is still available and supported.


### PR DESCRIPTION
Here's a demonstration of the problem this fixes; take two conformers of deprotonated propionic acid which just differ by swapping the two carboxylate O atoms:
```
In [4]: mol = Chem.MolFromSmiles("CCC(=O)[O-] |(-1.11,0.08,-0.29;0.08,-0.18,0.58;1.34,0.03,-0.16;1.74,1.22,-0.32;2.06,-1.04,-0.66)|")

In [5]: qry = Chem.MolFromSmiles("CCC([O-])=O |(-1.11,0.08,-0.29;0.08,-0.18,0.58;1.34,0.03,-0.16;1.74,1.22,-0.32;2.06,-1.04,-0.66)|")
```

The current version of `GetBestRMS()` produces this alignment since it assumes that the two O atoms are not equivalent to each other:
![image](https://user-images.githubusercontent.com/540511/169818350-135fae0f-b9cf-4e74-a0ad-4714e6703dfd.png)

This PR adds allows those O atoms to be considered to be equivalent to each other, which gives a perfect alignment here:
```
In [7]: rdMolAlign.GetBestRMS(qry, mol, symmetrizeConjugatedTerminalGroups=True)
Out[7]: 0.0
```
They can, of course, still be treated as distinct:
```
In [6]: rdMolAlign.GetBestRMS(qry, mol, symmetrizeConjugatedTerminalGroups=False)
Out[6]: 0.7474002006331917
```

The SMARTS pattern which is used to recognize affected groups is:
```
[{atomP};$([{atomP}]-[*]=[{atomP}]),$([{atomP}]=[*]-[{atomP}])]~[*]
``` 
where `{atomP}` is `O,N;D1`.

This PR makes the new behavior the default since I believe that's more correct than the old way, but we can change this if others disagree.

Thanks to Evan Bolton and Zhi Sun in the Pubchem group at NCBI for pointing out the issue and helping beta test the suggested changes.