### PR TITLE
revert #5251, document the problem

### DIFF
--- a/Code/GraphMol/SmilesParse/SmilesWrite.cpp
+++ b/Code/GraphMol/SmilesParse/SmilesWrite.cpp
@@ -23,22 +23,9 @@
 #include <map>
 #include <list>
 
-#ifdef RDK_THREADSAFE_SSS
-#include <mutex>
-#endif
-
 //#define VERBOSE_CANON 1
 
 namespace RDKit {
-
-#ifdef RDK_THREADSAFE_SSS
-namespace {
-std::mutex & smiles_setprop_locker() {
-    static std::mutex locker;
-    return locker;
-}
-}
-#endif //RDK_THREADSAFE_SSS
 
 namespace SmilesWrite {
 const int atomicSmiles[] = {0, 5, 6, 7, 8, 9, 15, 16, 17, 35, 53, -1};
@@ -631,15 +618,10 @@ std::string MolToSmiles(const ROMol &mol, const SmilesWriteParams &params) {
       }
     }
   }
-  {
-#ifdef RDK_THREADSAFE_SSS
-      std::scoped_lock locker(smiles_setprop_locker());
-#endif
-      mol.setProp(common_properties::_smilesAtomOutputOrder, flattenedAtomOrdering,
-                  true);
-      mol.setProp(common_properties::_smilesBondOutputOrder, flattenedBondOrdering,
-                  true);
-  }
+  mol.setProp(common_properties::_smilesAtomOutputOrder, flattenedAtomOrdering,
+              true);
+  mol.setProp(common_properties::_smilesBondOutputOrder, flattenedBondOrdering,
+              true);
   return result;
 }  // end of MolToSmiles()
 
@@ -839,14 +821,10 @@ std::string MolFragmentToSmiles(const ROMol &mol,
       res += ".";
     }
   }
-    
-  {
-#ifdef RDK_THREADSAFE_SSS
-      std::scoped_lock locker(smiles_setprop_locker());
-#endif
-      mol.setProp(common_properties::_smilesAtomOutputOrder, atomOrdering, true);
-      mol.setProp(common_properties::_smilesBondOutputOrder, bondOrdering, true);
-  }
+
+  mol.setProp(common_properties::_smilesAtomOutputOrder, atomOrdering, true);
+  mol.setProp(common_properties::_smilesBondOutputOrder, bondOrdering, true);
+
   return res;
 }  // end of MolFragmentToSmiles()
 

--- a/Code/GraphMol/SmilesParse/catch_tests.cpp
+++ b/Code/GraphMol/SmilesParse/catch_tests.cpp
@@ -1921,28 +1921,6 @@ TEST_CASE("Github #4981: Invalid SMARTS for negated single-atoms", "[smarts]") {
   }
 }
 
-#ifdef RDK_THREADSAFE_SSS
-namespace {
-void runblock(const ROMol *mol) { MolToSmiles(*mol); }
-}  // namespace
-
-TEST_CASE("Github #5245: Multithreaded smiles testing") {
-  SECTION("smiles from the same molecule") {
-    auto mol = "CCCCCCCCC"_smiles;
-    REQUIRE(mol);
-    std::vector<std::future<void>> tg;
-    unsigned int count = 100;
-    for (unsigned int i = 0; i < count; ++i) {
-      tg.emplace_back(std::async(std::launch::async, runblock, mol.get()));
-    }
-    for (auto &fut : tg) {
-      fut.get();
-    }
-    tg.clear();
-  }
-}
-#endif
-
 TEST_CASE("Pol and Mod atoms in CXSMILES", "[cxsmiles]") {
   SECTION("Pol basics") {
     auto mol = "CC* |$;;Pol_p$|"_smiles;

--- a/Docs/Book/RDKit_Book.rst
+++ b/Docs/Book/RDKit_Book.rst
@@ -1665,7 +1665,7 @@ What has been tested
 --------------------
 
   - Reading molecules from SMILES/SMARTS/Mol blocks
-  - Writing molecules to SMILES/SMARTS/Mol blocks
+  - Writing molecules to SMILES/SMARTS/Mol blocks (see below)
   - Generating 2D coordinates
   - Generating 3D conformations with the distance geometry code
   - Optimizing molecules with UFF or MMFF
@@ -1694,6 +1694,8 @@ Known Problems
     ``RDK_BUILD_THREADSAFE_SSS`` argument (the default for the binaries
     we provide), a mutex is used to ensure that only one thread is
     using a given recursive query at a time.
+  - Calling MolToSmiles() on the same molecule from multiple threads can lead to
+    data races with the calculated properties on the molecule.
 
 Implementation of the TPSA Descriptor
 =====================================


### PR DESCRIPTION
The changes in #5251 didn't actually fix the thread-safety problem and the test was leading to intermittent test failures

This reverts the changes to #5251.
