### PR TITLE
Fix segfault in mol zip

### DIFF
--- a/Code/GraphMol/ChemTransforms/MolFragmenter.cpp
+++ b/Code/GraphMol/ChemTransforms/MolFragmenter.cpp
@@ -686,7 +686,7 @@ int num_swaps_to_interconvert(std::vector<unsigned int> &orders) {
       auto j = i;
       while (orders[j] != i) {
         j = orders[j];
-        CHECK_INVARIANT(j < orders.size(), "Bond index outside of number of bonds for atom")
+        CHECK_INVARIANT(j < orders.size(), "molzip: bond index outside of number of bonds for atom")
         seen[j] = true;
         nswaps++;
       }

--- a/Code/GraphMol/ChemTransforms/MolFragmenter.cpp
+++ b/Code/GraphMol/ChemTransforms/MolFragmenter.cpp
@@ -686,6 +686,7 @@ int num_swaps_to_interconvert(std::vector<unsigned int> &orders) {
       auto j = i;
       while (orders[j] != i) {
         j = orders[j];
+        CHECK_INVARIANT(j < orders.size(), "Bond index outside of number of bonds for atom")
         seen[j] = true;
         nswaps++;
       }
@@ -715,12 +716,22 @@ struct ZipBond {
 
   // bond a<->b for now only use single bonds
   //  XXX FIX ME take the highest bond order.
-  bool bond(RWMol &newmol) const {
+  bool bond(RWMol &newmol, const MolzipParams &params) const {
     if (!a || !b || !a_dummy || !b_dummy) {
       BOOST_LOG(rdWarningLog)
           << "Incomplete atom labelling, cannot make bond" << std::endl;
       return false;
     }
+    
+    // Fragment on bonds allows multiple links to the same atom
+    // i.e. C.[1C].[1C]
+    //  otherwise throw an invariant error
+    if (!(params.label == MolzipLabel::FragmentOnBonds) &&  a->getOwningMol().getBondBetweenAtoms(a->getIdx(), b->getIdx())) {
+      CHECK_INVARIANT(!a->getOwningMol().getBondBetweenAtoms(a->getIdx(), b->getIdx()),
+                      "molzip: zipped Bond already exists, perhaps labels are duplicated");
+    }
+
+    
     if (!a->getOwningMol().getBondBetweenAtoms(a->getIdx(), b->getIdx())) {
       CHECK_INVARIANT(&a->getOwningMol() == &newmol,
                       "Owning mol is not the combined molecule!!");
@@ -922,7 +933,7 @@ std::unique_ptr<ROMol> molzip(const ROMol &a, const ROMol &b,
     }
   }
   for (auto &kv : mappings) {
-    kv.second.bond(*newmol);
+    kv.second.bond(*newmol, params);
   }
   newmol->beginBatchEdit();
   for (auto &atom : deletions) {

--- a/Code/GraphMol/ChemTransforms/MolFragmenter.cpp
+++ b/Code/GraphMol/ChemTransforms/MolFragmenter.cpp
@@ -726,10 +726,9 @@ struct ZipBond {
     // Fragment on bonds allows multiple links to the same atom
     // i.e. C.[1C].[1C]
     //  otherwise throw an invariant error
-    if (!(params.label == MolzipLabel::FragmentOnBonds) &&  a->getOwningMol().getBondBetweenAtoms(a->getIdx(), b->getIdx())) {
-      CHECK_INVARIANT(!a->getOwningMol().getBondBetweenAtoms(a->getIdx(), b->getIdx()),
-                      "molzip: zipped Bond already exists, perhaps labels are duplicated");
-    }
+    CHECK_INVARIANT(params.label == MolzipLabel::FragmentOnBonds || !a->getOwningMol().getBondBetweenAtoms(a->getIdx(), b->getIdx()),
+                  "molzip: zipped Bond already exists, perhaps labels are duplicated");
+
 
     
     if (!a->getOwningMol().getBondBetweenAtoms(a->getIdx(), b->getIdx())) {

--- a/Code/GraphMol/ChemTransforms/catch_tests.cpp
+++ b/Code/GraphMol/ChemTransforms/catch_tests.cpp
@@ -227,6 +227,8 @@ TEST_CASE("molzip", "[]") {
         if (i != j) {
           std::vector<unsigned int> bonds{i, j};
           auto resa = RDKit::MolFragmenter::fragmentOnBonds(*m, bonds);
+          auto smiles = MolToSmiles(*resa);
+            std::cout << smiles << std::endl;
           MolzipParams p;
           p.label = MolzipLabel::FragmentOnBonds;
           CHECK(MolToSmiles(*molzip(*resa, p)) == MolToSmiles(*m));
@@ -327,6 +329,7 @@ TEST_CASE("molzip", "[]") {
         }
         MolzipParams p;
         p.label = MolzipLabel::FragmentOnBonds;
+          std::cout << smiles << std::endl;
         CHECK(MolToSmiles(*molzip(*resa, p)) == MolToSmiles(*m));
       }
       {
@@ -417,5 +420,24 @@ TEST_CASE(
     REQUIRE(res);
     auto mb = MolToV3KMolBlock(*res);
     CHECK(mb.find("CFG=2") != std::string::npos);
+  }
+}
+
+TEST_CASE(
+    "Github5335: ReplaceCore should set stereo on ring bonds when it breaks "
+    "rings") {
+  SECTION("segfault") {
+    auto a = "C([*:1])[*:2].[C@@H](Cl)([1*:1])[2*:2]"_smiles;
+    bool caught = false;
+    try {
+        auto mol = molzip(*a);
+        CHECK(false);
+    } catch (Invar::Invariant &e) {
+        CHECK(e.toUserString().find(
+                  "molzip: zipped Bond already exists, perhaps labels are duplicated") !=
+              std::string::npos);
+        caught = true;
+    }
+    CHECK(caught);
   }
 }

--- a/Code/GraphMol/ChemTransforms/catch_tests.cpp
+++ b/Code/GraphMol/ChemTransforms/catch_tests.cpp
@@ -424,7 +424,7 @@ TEST_CASE(
 }
 
 TEST_CASE(
-    "Github5335: ReplaceCore should set stereo on ring bonds when it breaks "
+    "Github5334: ReplaceCore should set stereo on ring bonds when it breaks "
     "rings") {
   SECTION("segfault") {
     auto a = "C([*:1])[*:2].[C@@H](Cl)([1*:1])[2*:2]"_smiles;

--- a/Code/GraphMol/ChemTransforms/catch_tests.cpp
+++ b/Code/GraphMol/ChemTransforms/catch_tests.cpp
@@ -227,8 +227,6 @@ TEST_CASE("molzip", "[]") {
         if (i != j) {
           std::vector<unsigned int> bonds{i, j};
           auto resa = RDKit::MolFragmenter::fragmentOnBonds(*m, bonds);
-          auto smiles = MolToSmiles(*resa);
-            std::cout << smiles << std::endl;
           MolzipParams p;
           p.label = MolzipLabel::FragmentOnBonds;
           CHECK(MolToSmiles(*molzip(*resa, p)) == MolToSmiles(*m));
@@ -329,7 +327,6 @@ TEST_CASE("molzip", "[]") {
         }
         MolzipParams p;
         p.label = MolzipLabel::FragmentOnBonds;
-          std::cout << smiles << std::endl;
         CHECK(MolToSmiles(*molzip(*resa, p)) == MolToSmiles(*m));
       }
       {


### PR DESCRIPTION
Fixes #5334 

FragmentOnBonds allows multiple links with the same label, everything else does not.  This caused issues when looking at the ordering for chirality.

This fixes both issues.