### PR TITLE
Minimallib NPM release fixes - wrong node bin command in Dockerfile and prepublish npm script command replacement

### DIFF
--- a/Code/MinimalLib/docker/Dockerfile
+++ b/Code/MinimalLib/docker/Dockerfile
@@ -65,7 +65,7 @@ RUN make -j2 RDKit_minimal && \
 
 # run the tests
 WORKDIR /src/rdkit/Code/MinimalLib/tests
-RUN nodejs tests.js
+RUN node tests.js
 
 # Copy js and wasm rdkit files to use in browser
 # This feature requires the BuildKit backend

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "Code/MinimalLib/dist/RDKit_minimal.js",
   "scripts": {
     "build": "bash Code/MinimalLib/scripts/build_rdkitjs.sh",
-    "prepublish": "bash Code/MinimalLib/scripts/npm_prepublish.sh",
+    "prepublishOnly": "bash Code/MinimalLib/scripts/npm_prepublish.sh",
     "postpublish": "bash Code/MinimalLib/scripts/npm_postpublish.sh",
     "resetVersion": "jq '.version = \"PLACEHOLDER\"' package.json > temp && mv temp package.json",
     "test": "echo \"Tests are run during the docker build. See https://github.com/rdkit/rdkit/blob/master/Code/MinimalLib/docker/Dockerfile .\" && exit 1"


### PR DESCRIPTION
#### Reference Issue
ref https://github.com/rdkit/rdkit/issues/5346#issuecomment-1144941460

#### What does this implement/fix? Explain your changes.

- replace prepublish script with prepublishOnly script ref: https://docs.npmjs.com/cli/v8/using-npm/scripts\#prepare-and-prepublish

- fix bin command for node in minimallib Dockerfile

#### Any other comments?

check context in issue ref https://github.com/rdkit/rdkit/issues/5346#issuecomment-1144941460

cc @greglandrum @ptosco 

-----------------------------

TLDR;

1. the npm `prepublish` script which runs automatically when you run `npm publish` [has been renamed to `prepublishOnly` in recent npm versions
](https://docs.npmjs.com/cli/v8/using-npm/scripts\#prepare-and-prepublish
)
2. the node bin command that gets installed is now named `node` and not `nodejs`