### PR TITLE
Fixes #5324

### DIFF
--- a/Code/GraphMol/ChemReactions/catch_tests.cpp
+++ b/Code/GraphMol/ChemReactions/catch_tests.cpp
@@ -1211,6 +1211,7 @@ TEST_CASE("V3K rxn blocks") {
     std::unique_ptr<ChemicalReaction> rxn(RxnSmartsToChemicalReaction(
       				          ">>C-1-C-C-C-C-O-1 |Sg:n:4:n:ht|"));
     auto rxnb = ChemicalReactionToV3KRxnBlock(*rxn);
+    CHECK(rxnb.find("ATOMS=(1 5) XBONDS=(2 4 5) XBHEAD=(1 4) XBCORR=(2 4 5)")!=std::string::npos);
   }
 }
 

--- a/Code/GraphMol/ChemReactions/catch_tests.cpp
+++ b/Code/GraphMol/ChemReactions/catch_tests.cpp
@@ -1203,7 +1203,8 @@ TEST_CASE("V3K rxn blocks") {
     CHECK(rxn->getNumProductTemplates()==rxn2->getNumProductTemplates());   
   }
      
-  SECTION("githubXXXX") {
+  SECTION("github5324") {
+    // Test sgroup in a ring - this example failed with improperr tail crossings
     auto mol = "C-1-C-C-C-C-O-1 |Sg:n:4:n:ht|"_smarts;
     MolOps::findSSSR(*mol);
     auto mbk = FileParserUtils::getV3000CTAB(*mol, -1);

--- a/Code/GraphMol/ChemReactions/catch_tests.cpp
+++ b/Code/GraphMol/ChemReactions/catch_tests.cpp
@@ -13,6 +13,8 @@
 #include <GraphMol/QueryOps.h>
 #include <GraphMol/QueryAtom.h>
 #include <GraphMol/MonomerInfo.h>
+#include <GraphMol/FileParsers/FileParsers.h>
+#include <GraphMol/FileParsers/MolSupplier.h>
 #include <GraphMol/SmilesParse/SmilesParse.h>
 #include <GraphMol/SmilesParse/SmilesWrite.h>
 #include <GraphMol/FileParsers/SequenceParsers.h>
@@ -21,6 +23,7 @@
 #include <GraphMol/ChemReactions/ReactionRunner.h>
 #include <GraphMol/ChemReactions/ReactionUtils.h>
 #include <GraphMol/FileParsers/PNGParser.h>
+#include <GraphMol/FileParsers/FileParserUtils.h>
 
 using namespace RDKit;
 using std::unique_ptr;
@@ -1180,6 +1183,7 @@ TEST_CASE("CXSMILES for reactions", "[cxsmiles]") {
 }
 
 TEST_CASE("V3K rxn blocks") {
+    
   SECTION("writing basics") {
     // clang-format off
     auto rxn =
@@ -1198,5 +1202,14 @@ TEST_CASE("V3K rxn blocks") {
     CHECK(rxn->getNumReactantTemplates()==rxn2->getNumReactantTemplates());
     CHECK(rxn->getNumProductTemplates()==rxn2->getNumProductTemplates());   
   }
-
+     
+  SECTION("githubXXXX") {
+    auto mol = "C-1-C-C-C-C-O-1 |Sg:n:4:n:ht|"_smarts;
+    MolOps::findSSSR(*mol);
+    auto mbk = FileParserUtils::getV3000CTAB(*mol, -1);
+    std::unique_ptr<ChemicalReaction> rxn(RxnSmartsToChemicalReaction(
+      				          ">>C-1-C-C-C-C-O-1 |Sg:n:4:n:ht|"));
+    auto rxnb = ChemicalReactionToV3KRxnBlock(*rxn);
+  }
 }
+

--- a/Code/GraphMol/ChemReactions/catch_tests.cpp
+++ b/Code/GraphMol/ChemReactions/catch_tests.cpp
@@ -1208,6 +1208,7 @@ TEST_CASE("V3K rxn blocks") {
     auto mol = "C-1-C-C-C-C-O-1 |Sg:n:4:n:ht|"_smarts;
     MolOps::findSSSR(*mol);
     auto mbk = FileParserUtils::getV3000CTAB(*mol, -1);
+    CHECK(mbk.find("ATOMS=(1 5) XBONDS=(2 4 5) XBHEAD=(1 4) XBCORR=(2 4 5)")!=std::string::npos);
     std::unique_ptr<ChemicalReaction> rxn(RxnSmartsToChemicalReaction(
       				          ">>C-1-C-C-C-C-O-1 |Sg:n:4:n:ht|"));
     auto rxnb = ChemicalReactionToV3KRxnBlock(*rxn);

--- a/Code/GraphMol/SmilesParse/CXSmilesOps.cpp
+++ b/Code/GraphMol/SmilesParse/CXSmilesOps.cpp
@@ -281,27 +281,21 @@ void finalizePolymerSGroup(RWMol &mol, SubstanceGroup &sgroup) {
       bondIndexMap[smilesIdx] = bond->getIdx();
     }
   }
-  for (auto &smilesIdx : headCrossings) {
-    int bondIdx = bondIndexMap[smilesIdx];
+  for (auto &bondIdx : headCrossings) {
     if (bondIdx < 0) {
       throw RDKit::SmilesParseException(
           "could not find SGroup bond index in molecule");
     }
     sgroup.addBondWithIdx(bondIdx);
-    // and replace the original value
-    smilesIdx = bondIdx;
   }
   sgroup.setProp("XBHEAD", headCrossings);
 
-  for (auto &smilesIdx : tailCrossings) {
-    int bondIdx = bondIndexMap[smilesIdx];
+  for (auto &bondIdx : tailCrossings) {
     if (bondIdx < 0) {
       throw RDKit::SmilesParseException(
           "could not find SGroup bond index in molecule");
     }
     sgroup.addBondWithIdx(bondIdx);
-    // and replace the original value
-    smilesIdx = bondIdx;
   }
 
   // now we can setup XBCORR

--- a/Code/GraphMol/SmilesParse/CXSmilesOps.cpp
+++ b/Code/GraphMol/SmilesParse/CXSmilesOps.cpp
@@ -272,29 +272,13 @@ void finalizePolymerSGroup(RWMol &mol, SubstanceGroup &sgroup) {
     // we tried... nothing more we can do
     return;
   }
-  // bondIndexMap uses the position in the vector for the SMILES index and
-  // the value in that position as the actual bond index.
-  std::vector<int> bondIndexMap(mol.getNumBonds(), -1);
-  for (const auto bond : mol.bonds()) {
-    unsigned int smilesIdx;
-    if (bond->getPropIfPresent("_cxsmilesBondIdx", smilesIdx)) {
-      bondIndexMap[smilesIdx] = bond->getIdx();
-    }
-  }
+
   for (auto &bondIdx : headCrossings) {
-    if (bondIdx < 0) {
-      throw RDKit::SmilesParseException(
-          "could not find SGroup bond index in molecule");
-    }
     sgroup.addBondWithIdx(bondIdx);
   }
   sgroup.setProp("XBHEAD", headCrossings);
 
   for (auto &bondIdx : tailCrossings) {
-    if (bondIdx < 0) {
-      throw RDKit::SmilesParseException(
-          "could not find SGroup bond index in molecule");
-    }
     sgroup.addBondWithIdx(bondIdx);
   }
 


### PR DESCRIPTION
I believe this fixes the sgroup writing issue.

It appears that the headCrossing and tailCrossing were being filled with proper bond indices from getBondBetweenAtoms, but then looking these up in the bondIndexMap as if they were the index of the bond order when being parsed.   This was causing bad lookups when trying to get the bondType.
