### PR TITLE
Fixes #1812

### DIFF
--- a/Docs/Book/Install.md
+++ b/Docs/Book/Install.md
@@ -2,9 +2,9 @@
 
 Below a number of installation recipes is presented, with varying degree of complexity.
 
-## Cross-platform under anaconda python (fastest install)
+## Cross-platform using Conda
 
-### Introduction to anaconda
+### Introduction to Conda
 
 Conda is an open-source, cross-platform, software package manager. It supports the packaging and distribution of software components, and manages their installation inside isolated execution environments. It has several analogies with pip and virtualenv, but it is designed to be more "python-agnostic" and more suitable for the distribution of binary packages and their dependencies.
 
@@ -160,6 +160,18 @@ psql my_rdkit_db
 ```
 
 If you are trying to use multiple installations of PostgreSQL in different environments, you will need to setup different pid files, unix sockets and ports by [editing the PostgreSQL config files](https://opensourcedbms.com/dbms/running-multiple-postgresql-9-2-instances-on-one-server-in-centos-6rhel-6fedora/). With the above configurations these files can be found in /folder/where/data/should/be/stored.
+
+## Cross-platform using PIP
+
+Linux, Windows, and macOS RDKit platform wheels are available at the [rdkit ](https://pypi.org/project/rdkit/) PyPi repository for all major Python versions. You can install RDKit using pip.
+
+```sh
+pip install rdkit
+```
+
+Build information and details can be found at the [https://github.com/kuelumbus/rdkit-pypi](https://github.com/kuelumbus/rdkit-pypi) GitHub page. Please open an issue directly at this Github page if you find something not working as expected.
+
+Note: Older versions of RDKit might be available at the [`rdkit-pypi`](https://pypi.org/project/rdkit-pypi/) PyPi repository. `rdkit-pypi` is the old name of RDKit at PyPi.
 
 ## Linux and OS X
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Installation instructions are available in [Docs/Book/Install.md](https://github
   * [homebrew](https://github.com/rdkit/homebrew-rdkit) formula for building on the Mac. Contributed by Eddie Cao.
   * [recipes](https://github.com/rdkit/conda-rdkit) for building using the excellent conda package manager. Contributed by Riccardo Vianello.
   * [APKs](https://github.com/daverona/alpine-rdkit) for Alpine Linux. Contributed by da Verona
+  * [Wheels](https://pypi.org/project/rdkit/) at PyPi for all major platforms and python versions. Contributed by Christopher Kuenneth
 
 ## Projects using RDKit
 


### PR DESCRIPTION
RDKit platform wheels are now available at PyPI and can be installed using 
```sh
pip install rdkit
``` 
This PR updates the documentation. Fixes #1812 