### PR TITLE
Fixes #5372

### DIFF
--- a/Code/GraphMol/SmilesParse/SmilesWrite.cpp
+++ b/Code/GraphMol/SmilesParse/SmilesWrite.cpp
@@ -507,7 +507,7 @@ std::string MolToSmiles(const ROMol &mol, const SmilesWriteParams &params) {
     if (params.doRandom && rootedAtAtom == -1) {
       // need to find a random atom id between 0 and mol.getNumAtoms()
       // exclusively
-      rootedAtAtom = getRandomGenerator()() % mol.getNumAtoms();
+      rootedAtAtom = getRandomGenerator()() % tmol->getNumAtoms();
     }
 
     std::string res;

--- a/Code/GraphMol/SmilesParse/catch_tests.cpp
+++ b/Code/GraphMol/SmilesParse/catch_tests.cpp
@@ -1947,8 +1947,8 @@ TEST_CASE("Pol and Mod atoms in CXSMILES", "[cxsmiles]") {
 TEST_CASE("empty atom label block", "[cxsmiles]") {
   SECTION("basics") {
     auto m = R"CTAB(
-  MJ201100                      
-
+  MJ201100
+                        
   8  8  0  0  0  0  0  0  0  0999 V2000
    -1.0491    1.5839    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
    -1.7635    1.1714    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
@@ -1972,5 +1972,16 @@ M  END)CTAB"_ctab;
     m->clearConformers();
     auto smi = MolToCXSmiles(*m);
     CHECK(smi.find("$") == std::string::npos);
+  }
+}
+
+TEST_CASE("Github #5372: errors with fragments and doRandom=True") {
+  SECTION("basics") {
+    auto m = "C.C"_smiles;
+    REQUIRE(m);
+    SmilesWriteParams ps;
+    ps.doRandom = true;
+    auto smi = MolToSmiles(*m, ps);
+    CHECK(smi == "C.C");
   }
 }


### PR DESCRIPTION
This was a very simple oversight.
Note that with this fix the ordering of the fragments is always the same. If that's a problem then we need to do a bit more work here, but given the use case for these things I don't think it's critical.
