### PR TITLE
Drop usage of CIP information from the canonicalization code

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -47,6 +47,7 @@ Standard:        Cpp11
 IndentWidth:     2
 TabWidth:        8
 UseTab:          Never
+BreakStringLiterals: false
 BreakBeforeBraces: Attach
 SpacesInParentheses: false
 SpacesInSquareBrackets: false

--- a/Code/GraphMol/CMakeLists.txt
+++ b/Code/GraphMol/CMakeLists.txt
@@ -174,5 +174,8 @@ rdkit_catch_test(graphmolAdjustQueryCatch catch_adjustquery.cpp
 rdkit_catch_test(chiralityTestsCatch catch_chirality.cpp 
            LINK_LIBRARIES FileParsers SmilesParse GraphMol )
 
+rdkit_catch_test(canonTestsCatch catch_canon.cpp 
+           LINK_LIBRARIES FileParsers SmilesParse GraphMol )
+
 rdkit_catch_test(moliteratorTestsCatch catch_moliterators.cpp 
            LINK_LIBRARIES SubstructMatch SmilesParse GraphMol )

--- a/Code/GraphMol/ChemReactions/testReaction.cpp
+++ b/Code/GraphMol/ChemReactions/testReaction.cpp
@@ -5155,7 +5155,7 @@ void test54RedundantProductMappingNumbersAndRSChirality() {
     TEST_ASSERT(prods[0].size() == 1);
 
     std::cout << MolToSmiles(*prods[0][0], true) << std::endl;
-    smi = "F[C@@](Cl)(Br)ONO[C@@](F)(Cl)Br";
+    smi = "F[C@](Cl)(Br)ONO[C@](F)(Cl)Br";
     TEST_ASSERT(MolToSmiles(*prods[0][0], true) == smi);
 
     ROMOL_SPTR prod = prods[0][0];
@@ -5248,7 +5248,7 @@ void test54RedundantProductMappingNumbersAndRSChirality() {
     TEST_ASSERT(prods[0].size() == 1);
 
     std::cout << MolToSmiles(*prods[0][0], true) << std::endl;
-    smi = "F[C@@](Cl)(Br)ONO[C@@](F)(Cl)Br";
+    smi = "F[C@](Cl)(Br)ONO[C@](F)(Cl)Br";
     TEST_ASSERT(MolToSmiles(*prods[0][0], true) == smi);
 
     ROMOL_SPTR prod = prods[0][0];
@@ -5340,7 +5340,7 @@ void test54RedundantProductMappingNumbersAndRSChirality() {
     TEST_ASSERT(prods[0].size() == 1);
 
     std::cout << MolToSmiles(*prods[0][0], true) << std::endl;
-    smi = "F[C@@](Cl)(Br)O[C@@](F)(Cl)Br";
+    smi = "F[C@](Cl)(Br)O[C@](F)(Cl)Br";
     TEST_ASSERT(MolToSmiles(*prods[0][0], true) == smi);
 
     ROMOL_SPTR prod = prods[0][0];
@@ -7656,8 +7656,8 @@ void testMultiTemplateRxnQueries() {
                        << std::endl;
 
   std::string rxn_smarts =
-    "[S;v1&H0,v2&H1:1].[S;v2;H0,H1:2][S;v2;H0,H1:3]>>[S:3].[S:1][S:2]";
-  ChemicalReaction* rxn = RxnSmartsToChemicalReaction(rxn_smarts);
+      "[S;v1&H0,v2&H1:1].[S;v2;H0,H1:2][S;v2;H0,H1:3]>>[S:3].[S:1][S:2]";
+  ChemicalReaction *rxn = RxnSmartsToChemicalReaction(rxn_smarts);
   TEST_ASSERT(rxn->getNumReactantTemplates() == 2);
   TEST_ASSERT(rxn->getNumProductTemplates() == 2);
   rxn->initReactantMatchers();
@@ -7665,14 +7665,14 @@ void testMultiTemplateRxnQueries() {
   TEST_ASSERT(rxn->validate(nWarn, nError, false));
   TEST_ASSERT(nWarn == 0 && nError == 0);
 
-  ROMol* reactant = SmilesToMol("SC1=CC(CSSCC2=CC=CC=C2)=CC=C1");
-  ROMol* product = reactant;
-  ROMol* neither = SmilesToMol("c1ccccc1");
+  ROMol *reactant = SmilesToMol("SC1=CC(CSSCC2=CC=CC=C2)=CC=C1");
+  ROMol *product = reactant;
+  ROMol *neither = SmilesToMol("c1ccccc1");
 
   std::vector<unsigned int> which;
   bool is_reactant = isMoleculeReactantOfReaction(*rxn, *reactant, which);
   TEST_ASSERT(is_reactant);
-  TEST_ASSERT(which == std::vector<unsigned int>({0,1}));
+  TEST_ASSERT(which == std::vector<unsigned int>({0, 1}));
   unsigned int first_match;
   is_reactant = isMoleculeReactantOfReaction(*rxn, *reactant, first_match);
   TEST_ASSERT(is_reactant);
@@ -7691,7 +7691,7 @@ void testMultiTemplateRxnQueries() {
 
   bool is_product = isMoleculeProductOfReaction(*rxn, *product, which);
   TEST_ASSERT(is_product);
-  TEST_ASSERT(which == std::vector<unsigned int>({0,1}));
+  TEST_ASSERT(which == std::vector<unsigned int>({0, 1}));
   is_product = isMoleculeProductOfReaction(*rxn, *product, first_match);
   TEST_ASSERT(is_product);
   TEST_ASSERT(first_match == 0);
@@ -7718,8 +7718,8 @@ void testChemicalReactionCopyAssignment() {
                        << std::endl;
 
   std::string rxn_smarts1 =
-    "[C;$(C=O):1][OH1].[N;$(N[#6]);!$(N=*);!$([N-]);!$(N#*);!$([ND3]);!$([ND4]);!$(N[O,N]);!$(N[C,S]=[S,O,N]):2]>>[C:1][N+0:2]";
-  ChemicalReaction* rxn1 = RxnSmartsToChemicalReaction(rxn_smarts1);
+      "[C;$(C=O):1][OH1].[N;$(N[#6]);!$(N=*);!$([N-]);!$(N#*);!$([ND3]);!$([ND4]);!$(N[O,N]);!$(N[C,S]=[S,O,N]):2]>>[C:1][N+0:2]";
+  ChemicalReaction *rxn1 = RxnSmartsToChemicalReaction(rxn_smarts1);
   rxn1->setImplicitPropertiesFlag(true);
   rxn1->initReactantMatchers();
   unsigned int nWarn, nError;
@@ -7727,7 +7727,7 @@ void testChemicalReactionCopyAssignment() {
   TEST_ASSERT(nWarn == 0 && nError == 0);
 
   std::string rxn_smarts2 = "[O:1]>>[N:1]";
-  ChemicalReaction* rxn2 = RxnSmartsToChemicalReaction(rxn_smarts2);
+  ChemicalReaction *rxn2 = RxnSmartsToChemicalReaction(rxn_smarts2);
 
   *rxn2 = *rxn1;
 
@@ -7759,8 +7759,8 @@ void testChemicalReactionCopyAssignment() {
   }
 
   // Check that the reactions don't share resources
-  const RWMol& rxn1_reactant = *rxn1->getReactants().at(0);
-  const_cast<RWMol&>(rxn1_reactant).clear();
+  const RWMol &rxn1_reactant = *rxn1->getReactants().at(0);
+  const_cast<RWMol &>(rxn1_reactant).clear();
   ROMOL_SPTR rxn2_reactant = rxn2->getReactants().at(0);
   TEST_ASSERT(rxn2_reactant->getNumAtoms() > 0);
 

--- a/Code/GraphMol/MolHash/Wrap/testMolHash.py
+++ b/Code/GraphMol/MolHash/Wrap/testMolHash.py
@@ -40,11 +40,11 @@ class TestCase(unittest.TestCase):
       'C[C@@H](O)[C@@H](C)[C@@H](C)C[C@H](C1=CN=CN1)C1=CNC=N1 |o1:8,5,&1:1,3,r,c:11,18,t:9,15|')
 
     self.assertEqual(rdMolHash.MolHash(m, rdMolHash.HashFunction.HetAtomTautomer),
-                     'C[C@@H](CC([C]1[CH][N][CH][N]1)[C]1[CH][N][CH][N]1)[C@H](C)[C@@H](C)[O]_3_0')
+                     'C[C@H]([C@@H](C)[O])[C@@H](C)CC([C]1[CH][N][CH][N]1)[C]1[CH][N][CH][N]1_3_0')
 
     self.assertEqual(
       rdMolHash.MolHash(m, rdMolHash.HashFunction.HetAtomTautomer, True),
-      'C[C@@H](CC([C]1[CH][N][CH][N]1)[C]1[CH][N][CH][N]1)[C@H](C)[C@@H](C)[O]_3_0 |o1:1,&1:14,16|')
+      'C[C@H]([C@@H](C)[O])[C@@H](C)CC([C]1[CH][N][CH][N]1)[C]1[CH][N][CH][N]1_3_0 |o1:5,&1:1,2|')
 
 
 if __name__ == "__main__":

--- a/Code/GraphMol/MolHash/catch_tests.cpp
+++ b/Code/GraphMol/MolHash/catch_tests.cpp
@@ -242,8 +242,7 @@ TEST_CASE("MolHash with CX extensions", "[molhash]") {
       auto hsh = MolHash::MolHash(&cp, MolHash::HashFunction::HetAtomTautomer);
       CHECK(
           hsh ==
-          "C[C@@H](CC([C]1[CH][N][CH][N]1)[C]1[CH][N][CH][N]1)[C@H](C)[C@@H](C)"
-          "[O]_3_0");
+          "C[C@H]([C@@H](C)[O])[C@@H](C)CC([C]1[CH][N][CH][N]1)[C]1[CH][N][CH][N]1_3_0");
     }
     {
       RWMol cp(*mol);
@@ -252,8 +251,7 @@ TEST_CASE("MolHash with CX extensions", "[molhash]") {
           MolHash::MolHash(&cp, MolHash::HashFunction::HetAtomTautomer, true);
       CHECK(
           hsh ==
-          "C[C@@H](CC([C]1[CH][N][CH][N]1)[C]1[CH][N][CH][N]1)[C@H](C)[C@@H](C)"
-          "[O]_3_0 |o1:1,&1:14,16|");
+          "C[C@H]([C@@H](C)[O])[C@@H](C)CC([C]1[CH][N][CH][N]1)[C]1[CH][N][CH][N]1_3_0 |o1:5,&1:1,2|");
     }
   }
   SECTION("no coordinates please") {

--- a/Code/GraphMol/ScaffoldNetwork/catch_tests.cpp
+++ b/Code/GraphMol/ScaffoldNetwork/catch_tests.cpp
@@ -655,9 +655,8 @@ TEST_CASE("larger multi-mol test", "[regression][scaffold]") {
         "*c1nocc1C(=O)NC1C(=O)N2CCSC12",
         "CC1(C)SC2C(NC(=O)Cc3ccccc3)C(=O)N2C1C(=O)O.[Na]",
         "CC1(C)S[C@@H]2[C@H](NC(=O)[C@H](N)c3ccccc3)C(=O)N2[C@H]1C(=O)O",
-        "Cc1onc(-c2c(F)cccc2Cl)c1C(=O)N[C@@H]1C(=O)N2[C@@H](C(=O)O)C(C)(C)S[C@"
-        "H]12",
-        "Cc1onc(-c2ccccc2)c1C(=O)N[C@@H]1C(=O)N2[C@@H](C(=O)O)C(C)(C)S[C@H]12",
+        "Cc1onc(-c2c(F)cccc2Cl)c1C(=O)N[C@@H]1C(=O)N2[C@@H]1SC(C)(C)[C@@H]2C(=O)O",
+        "Cc1onc(-c2ccccc2)c1C(=O)N[C@@H]1C(=O)N2[C@@H]1SC(C)(C)[C@@H]2C(=O)O",
         "O=C(Cc1ccccc1)NC1C(=O)N2CCSC12",
         "O=C(NC1C(=O)N2CCSC12)c1conc1-c1ccccc1"};
     CHECK(snodes == tgt);
@@ -704,9 +703,8 @@ TEST_CASE("larger multi-mol test", "[regression][scaffold]") {
         "*c1nocc1C(=O)NC1C(=O)N2CCSC12",
         "CC1(C)SC2C(NC(=O)Cc3ccccc3)C(=O)N2C1C(=O)O.[Na]",
         "CC1(C)S[C@@H]2[C@H](NC(=O)[C@H](N)c3ccccc3)C(=O)N2[C@H]1C(=O)O",
-        "Cc1onc(-c2c(F)cccc2Cl)c1C(=O)N[C@@H]1C(=O)N2[C@@H](C(=O)O)C(C)(C)S[C@"
-        "H]12",
-        "Cc1onc(-c2ccccc2)c1C(=O)N[C@@H]1C(=O)N2[C@@H](C(=O)O)C(C)(C)S[C@H]12",
+        "Cc1onc(-c2c(F)cccc2Cl)c1C(=O)N[C@@H]1C(=O)N2[C@@H]1SC(C)(C)[C@@H]2C(=O)O",
+        "Cc1onc(-c2ccccc2)c1C(=O)N[C@@H]1C(=O)N2[C@@H]1SC(C)(C)[C@@H]2C(=O)O",
         "O=C(Cc1ccccc1)NC1C(=O)N2CCSC12",
         "O=C(NC1C(=O)N2CCSC12)c1conc1-c1ccccc1"};
     CHECK(snodes == tgt);

--- a/Code/GraphMol/SmilesParse/catch_tests.cpp
+++ b/Code/GraphMol/SmilesParse/catch_tests.cpp
@@ -1861,12 +1861,12 @@ M  END)CTAB"_ctab;
     REQUIRE(mol);
     auto csmiles = MolToSmiles(*mol);
     std::cerr << csmiles << std::endl;
+    // clang-format off
     CHECK(
         csmiles ==
-        "CC(=O)N[C@@H](CCCC/N=C/C1=C/"
-        "C[C@H]2[C@@]3(CC[C@]2(C)C[C@H]2[C@@H]1C(=O)C[C@@]2(C)O)O[C@@H](C=C(C)"
-        "C)C[C@@H]3C)C(=O)O");
+        "CC(=O)N[C@@H](CCCC/N=C/C1=C/C[C@@H]2[C@](C)(CC[C@@]23O[C@@H](C=C(C)C)C[C@@H]3C)C[C@H]2[C@@H]1C(=O)C[C@@]2(C)O)C(=O)O");
   }
+  // clang-format on
 }
 
 TEST_CASE(

--- a/Code/GraphMol/SmilesParse/catch_tests.cpp
+++ b/Code/GraphMol/SmilesParse/catch_tests.cpp
@@ -262,7 +262,7 @@ TEST_CASE("github #2257: writing cxsmiles", "[smiles][cxsmiles]") {
     auto mol = "C[C@H](F)[C@H](C)[C@@H](C)Br |a:1,o1:3,5|"_smiles;
     REQUIRE(mol);
     auto smi = MolToCXSmiles(*mol);
-    CHECK(smi == "C[C@H](F)[C@H](C)[C@@H](C)Br |a:1,o1:3,5|");
+    CHECK(smi == "C[C@@H]([C@H](C)F)[C@@H](C)Br |a:2,o1:1,5|");
   }
 
   SECTION("enhanced stereo 2") {
@@ -277,9 +277,9 @@ TEST_CASE("github #2257: writing cxsmiles", "[smiles][cxsmiles]") {
         "C[C@@H]1N[C@H](C)[C@@H]([C@H](C)[C@@H]1C)C1[C@@H](C)O[C@@H](C)[C@@H](C)[C@H]1C |a:5,o1:1,8,o2:14,16,&1:11,18,&2:3,6,r|"_smiles;
     REQUIRE(mol);
     auto smi = MolToCXSmiles(*mol);
-    CHECK(smi ==
-          "C[C@@H]1N[C@H](C)[C@H](C2[C@@H](C)O[C@@H](C)[C@@H](C)[C@H]2C)[C@H]("
-          "C)[C@@H]1C |a:5,o1:1,18,o2:10,12,&1:3,16,&2:7,14|");
+    CHECK(
+        smi ==
+        "C[C@@H]1[C@H](C)[C@H](C)N[C@H](C)[C@@H]1C1[C@@H](C)O[C@@H](C)[C@@H](C)[C@H]1C |a:9,o1:2,4,o2:14,16,&1:1,7,&2:11,18|");
   }
 
   SECTION("enhanced stereo 4") {

--- a/Code/GraphMol/catch_canon.cpp
+++ b/Code/GraphMol/catch_canon.cpp
@@ -1,0 +1,127 @@
+//
+//  Copyright (C) 2022 Greg Landrum and other RDKit contributors
+//
+//   @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
+//
+
+#include "catch.hpp"
+
+#include <GraphMol/RDKitBase.h>
+#include <GraphMol/StereoGroup.h>
+#include <GraphMol/Chirality.h>
+#include <GraphMol/new_canon.h>
+#include <GraphMol/MolOps.h>
+
+#include <GraphMol/FileParsers/FileParsers.h>
+#include <GraphMol/FileParsers/MolFileStereochem.h>
+#include <GraphMol/FileParsers/MolSupplier.h>
+#include <GraphMol/SmilesParse/SmilesParse.h>
+#include <GraphMol/SmilesParse/SmilesWrite.h>
+
+using namespace RDKit;
+
+TEST_CASE("chirality and canonicalization") {
+  SECTION("basics") {
+    auto mol = "F[C@](O)(Cl)C[C@](F)(O)Cl"_smiles;
+    REQUIRE(mol);
+    bool cleanIt = true;
+    bool force = true;
+    MolOps::assignStereochemistry(*mol, cleanIt, force);
+    std::string cip;
+    CHECK(mol->getAtomWithIdx(1)->getPropIfPresent(common_properties::_CIPCode,
+                                                   cip));
+    CHECK(cip == "S");
+    CHECK(mol->getAtomWithIdx(5)->getPropIfPresent(common_properties::_CIPCode,
+                                                   cip));
+    CHECK(cip == "R");
+    std::vector<unsigned int> ranks;
+    bool breakTies = false;
+    Canon::rankMolAtoms(*mol, ranks, breakTies);
+    CHECK(ranks[1] > ranks[5]);
+    mol->getAtomWithIdx(1)->clearProp(common_properties::_CIPCode);
+    mol->getAtomWithIdx(5)->clearProp(common_properties::_CIPCode);
+    Canon::rankMolAtoms(*mol, ranks, breakTies);
+    CHECK(ranks[1] > ranks[5]);
+  }
+  SECTION("same") {
+    auto mol = "F[C@](O)(Cl)C[C@](O)(F)Cl"_smiles;
+    REQUIRE(mol);
+    bool cleanIt = true;
+    bool force = true;
+    MolOps::assignStereochemistry(*mol, cleanIt, force);
+    std::string cip;
+    CHECK(mol->getAtomWithIdx(1)->getPropIfPresent(common_properties::_CIPCode,
+                                                   cip));
+    CHECK(cip == "S");
+    CHECK(mol->getAtomWithIdx(5)->getPropIfPresent(common_properties::_CIPCode,
+                                                   cip));
+    CHECK(cip == "S");
+    std::vector<unsigned int> ranks;
+    bool breakTies = false;
+    Canon::rankMolAtoms(*mol, ranks, breakTies);
+    CHECK(ranks[1] == ranks[5]);
+    mol->getAtomWithIdx(1)->clearProp(common_properties::_CIPCode);
+    mol->getAtomWithIdx(5)->clearProp(common_properties::_CIPCode);
+    Canon::rankMolAtoms(*mol, ranks, breakTies);
+    CHECK(ranks[1] == ranks[5]);
+  }
+  SECTION("dependent") {
+    auto mol = "F[C@](O)(Cl)[C@](F)(O)[C@](F)(O)Cl"_smiles;
+    REQUIRE(mol);
+    bool cleanIt = true;
+    bool force = true;
+    MolOps::assignStereochemistry(*mol, cleanIt, force);
+    std::string cip;
+    CHECK(mol->getAtomWithIdx(1)->getPropIfPresent(common_properties::_CIPCode,
+                                                   cip));
+    CHECK(cip == "S");
+    CHECK(mol->getAtomWithIdx(7)->getPropIfPresent(common_properties::_CIPCode,
+                                                   cip));
+    CHECK(cip == "R");
+    CHECK(mol->getAtomWithIdx(4)->getPropIfPresent(common_properties::_CIPCode,
+                                                   cip));
+    CHECK(cip == "R");
+    std::vector<unsigned int> ranks;
+    bool breakTies = false;
+    Canon::rankMolAtoms(*mol, ranks, breakTies);
+    CHECK(ranks[1] > ranks[7]);
+    mol->getAtomWithIdx(1)->clearProp(common_properties::_CIPCode);
+    mol->getAtomWithIdx(4)->clearProp(common_properties::_CIPCode);
+    mol->getAtomWithIdx(7)->clearProp(common_properties::_CIPCode);
+    Canon::rankMolAtoms(*mol, ranks, breakTies);
+    CHECK(ranks[1] > ranks[7]);
+  }
+  SECTION("dependent non-chiral") {
+    auto mol = "F[C@](O)(Cl)[C@](F)(O)[C@](O)(F)Cl"_smiles;
+    REQUIRE(mol);
+    bool cleanIt = false;
+    bool force = true;
+    mol->getAtomWithIdx(4)->setChiralTag(Atom::ChiralType::CHI_TETRAHEDRAL_CCW);
+    MolOps::assignStereochemistry(*mol, cleanIt, force);
+    std::string cip;
+    CHECK(mol->getAtomWithIdx(1)->getPropIfPresent(common_properties::_CIPCode,
+                                                   cip));
+    CHECK(cip == "S");
+    CHECK(mol->getAtomWithIdx(7)->getPropIfPresent(common_properties::_CIPCode,
+                                                   cip));
+    CHECK(cip == "S");
+    std::vector<unsigned int> ranks;
+    bool breakTies = false;
+    Canon::rankMolAtoms(*mol, ranks, breakTies);
+    // std::copy(ranks.begin(), ranks.end(),
+    //           std::ostream_iterator<unsigned int>(std::cerr, " "));
+    // std::cerr << std::endl;
+    CHECK(ranks[1] == ranks[7]);
+    mol->getAtomWithIdx(1)->clearProp(common_properties::_CIPCode);
+    mol->getAtomWithIdx(7)->clearProp(common_properties::_CIPCode);
+    Canon::rankMolAtoms(*mol, ranks, breakTies);
+    // std::copy(ranks.begin(), ranks.end(),
+    //           std::ostream_iterator<unsigned int>(std::cerr, " "));
+    // std::cerr << std::endl;
+    CHECK(ranks[1] == ranks[7]);
+  }
+}

--- a/Code/GraphMol/catch_canon.cpp
+++ b/Code/GraphMol/catch_canon.cpp
@@ -112,16 +112,39 @@ TEST_CASE("chirality and canonicalization") {
     std::vector<unsigned int> ranks;
     bool breakTies = false;
     Canon::rankMolAtoms(*mol, ranks, breakTies);
-    // std::copy(ranks.begin(), ranks.end(),
-    //           std::ostream_iterator<unsigned int>(std::cerr, " "));
-    // std::cerr << std::endl;
     CHECK(ranks[1] == ranks[7]);
     mol->getAtomWithIdx(1)->clearProp(common_properties::_CIPCode);
     mol->getAtomWithIdx(7)->clearProp(common_properties::_CIPCode);
     Canon::rankMolAtoms(*mol, ranks, breakTies);
-    // std::copy(ranks.begin(), ranks.end(),
-    //           std::ostream_iterator<unsigned int>(std::cerr, " "));
-    // std::cerr << std::endl;
     CHECK(ranks[1] == ranks[7]);
+  }
+
+  SECTION("swap parity") {
+    auto mol = "F[C@](O)(Cl)C[C@@](O)(Cl)F"_smiles;
+    REQUIRE(mol);
+    bool cleanIt = false;
+    bool force = true;
+    MolOps::assignStereochemistry(*mol, cleanIt, force);
+    std::string cip;
+    CHECK(mol->getAtomWithIdx(1)->getPropIfPresent(common_properties::_CIPCode,
+                                                   cip));
+    CHECK(cip == "S");
+    CHECK(mol->getAtomWithIdx(5)->getPropIfPresent(common_properties::_CIPCode,
+                                                   cip));
+    CHECK(cip == "S");
+    std::vector<unsigned int> ranks;
+    bool breakTies = false;
+    Canon::rankMolAtoms(*mol, ranks, breakTies);
+    std::copy(ranks.begin(), ranks.end(),
+              std::ostream_iterator<unsigned int>(std::cerr, " "));
+    std::cerr << std::endl;
+    CHECK(ranks[1] == ranks[5]);
+    mol->getAtomWithIdx(1)->clearProp(common_properties::_CIPCode);
+    mol->getAtomWithIdx(5)->clearProp(common_properties::_CIPCode);
+    Canon::rankMolAtoms(*mol, ranks, breakTies);
+    std::copy(ranks.begin(), ranks.end(),
+              std::ostream_iterator<unsigned int>(std::cerr, " "));
+    std::cerr << std::endl;
+    CHECK(ranks[1] == ranks[5]);
   }
 }

--- a/Code/GraphMol/catch_graphmol.cpp
+++ b/Code/GraphMol/catch_graphmol.cpp
@@ -2004,6 +2004,7 @@ TEST_CASE("github #4071: StereoGroups not preserved by RenumberAtoms()",
         "C[C@@H](O)[C@H](C)[C@@H](C)[C@@H](C)O |&3:3,o1:7,&1:1,&2:5,r|"_smiles;
     REQUIRE(mol);
     REQUIRE(mol->getStereoGroups().size() == 4);
+
     std::vector<unsigned int> aindices(mol->getNumAtoms());
     std::iota(aindices.begin(), aindices.end(), 0);
     std::reverse(aindices.begin(), aindices.end());
@@ -2015,7 +2016,7 @@ TEST_CASE("github #4071: StereoGroups not preserved by RenumberAtoms()",
             mol->getStereoGroups()[i].getGroupType());
     }
     CHECK(MolToCXSmiles(*nmol) ==
-          "C[C@@H](O)[C@H](C)[C@@H](C)[C@@H](C)O |o1:1,&1:3,&2:5,&3:7|");
+          "C[C@H]([C@@H](C)[C@@H](C)O)[C@@H](C)O |o1:7,&1:1,&2:2,&3:4|");
   }
 }
 

--- a/Code/GraphMol/new_canon.cpp
+++ b/Code/GraphMol/new_canon.cpp
@@ -20,6 +20,91 @@
 
 namespace RDKit {
 namespace Canon {
+
+int bondholder::compareStereo(const bondholder &o) const {
+  if (stype == Bond::BondStereo::STEREONONE) {
+    if (o.stype == Bond::BondStereo::STEREONONE) {
+      return 0;
+    } else {
+      return -1;
+    }
+  }
+  if (o.stype == Bond::BondStereo::STEREONONE) {
+    return 1;
+  }
+  if (o.stype == Bond::BondStereo::STEREOANY) {
+    if (o.stype == Bond::BondStereo::STEREOANY) {
+      return 0;
+    } else {
+      return -1;
+    }
+  }
+  if (o.stype == Bond::BondStereo::STEREOANY) {
+    return 1;
+  }
+  // we have some kind of specified stereo on each bond, work is required
+  auto st1 = stype;
+  auto st2 = o.stype;
+  // if both have absolute stereo labels we can compare them directly
+  if ((st1 == Bond::BondStereo::STEREOE || st1 == Bond::BondStereo::STEREOZ) &&
+      (st2 == Bond::BondStereo::STEREOE || st2 == Bond::BondStereo::STEREOZ)) {
+    if (st1 < st2) {
+      return -1;
+    } else if (st1 > st2) {
+      return 1;
+    }
+    return 0;
+  }
+
+  // check to see if we need to flip the controlling atoms due to atom ranks
+  {
+    CHECK_INVARIANT(controllingAtoms[0], "missing controlling atom");
+    CHECK_INVARIANT(controllingAtoms[2], "missing controlling atom");
+    bool flip = false;
+    if (controllingAtoms[1] &&
+        controllingAtoms[1]->index > controllingAtoms[0]->index) {
+      flip = !flip;
+    }
+    if (controllingAtoms[3] &&
+        controllingAtoms[3]->index > controllingAtoms[2]->index) {
+      flip = !flip;
+    }
+    if (flip) {
+      if (st1 == Bond::BondStereo::STEREOCIS) {
+        st1 = Bond::BondStereo::STEREOTRANS;
+      } else if (st1 == Bond::BondStereo::STEREOTRANS) {
+        st1 = Bond::BondStereo::STEREOCIS;
+      }
+    }
+  }
+  {
+    CHECK_INVARIANT(o.controllingAtoms[0], "missing controlling atom");
+    CHECK_INVARIANT(o.controllingAtoms[2], "missing controlling atom");
+    bool flip = false;
+    if (o.controllingAtoms[1] &&
+        o.controllingAtoms[1]->index > o.controllingAtoms[0]->index) {
+      flip = !flip;
+    }
+    if (o.controllingAtoms[3] &&
+        o.controllingAtoms[3]->index > o.controllingAtoms[2]->index) {
+      flip = !flip;
+    }
+    if (flip) {
+      if (st2 == Bond::BondStereo::STEREOCIS) {
+        st2 = Bond::BondStereo::STEREOTRANS;
+      } else if (st2 == Bond::BondStereo::STEREOTRANS) {
+        st2 = Bond::BondStereo::STEREOCIS;
+      }
+    }
+  }
+  if (st1 < st2) {
+    return -1;
+  } else if (st1 > st2) {
+    return 1;
+  }
+  return 0;
+}
+
 void CreateSinglePartition(unsigned int nAtoms, int *order, int *count,
                            canon_atom *atoms) {
   PRECONDITION(order, "bad pointer");
@@ -331,21 +416,49 @@ void getNbrs(const ROMol &mol, const Atom *at, int *ids) {
 }
 
 bondholder makeBondHolder(const Bond *bond, unsigned int otherIdx,
-                          bool includeChirality) {
+                          bool includeChirality,
+                          const std::vector<Canon::canon_atom> &atoms) {
   PRECONDITION(bond, "bad pointer");
   Bond::BondStereo stereo = Bond::STEREONONE;
   if (includeChirality) {
     stereo = bond->getStereo();
-    if (stereo == Bond::STEREOANY) {
-      stereo = Bond::STEREONONE;
-    }
   }
   Bond::BondType bt =
       bond->getIsAromatic() ? Bond::AROMATIC : bond->getBondType();
-  return bondholder(bt, stereo, otherIdx, 0);
+  bondholder res(bt, stereo, otherIdx, 0);
+  if (includeChirality) {
+    res.stype = bond->getStereo();
+    if (res.stype == Bond::BondStereo::STEREOCIS ||
+        res.stype == Bond::BondStereo::STEREOTRANS) {
+      res.controllingAtoms[0] = &atoms[bond->getStereoAtoms()[0]];
+      res.controllingAtoms[2] = &atoms[bond->getStereoAtoms()[1]];
+      if (bond->getBeginAtom()->getDegree() > 2) {
+        for (const auto nbr :
+             bond->getOwningMol().atomNeighbors(bond->getBeginAtom())) {
+          if (nbr->getIdx() != bond->getEndAtomIdx() &&
+              nbr->getIdx() !=
+                  static_cast<unsigned int>(bond->getStereoAtoms()[0])) {
+            res.controllingAtoms[1] = &atoms[nbr->getIdx()];
+          }
+        }
+      }
+      if (bond->getEndAtom()->getDegree() > 2) {
+        for (const auto nbr :
+             bond->getOwningMol().atomNeighbors(bond->getEndAtom())) {
+          if (nbr->getIdx() != bond->getBeginAtomIdx() &&
+              nbr->getIdx() !=
+                  static_cast<unsigned int>(bond->getStereoAtoms()[1])) {
+            res.controllingAtoms[3] = &atoms[nbr->getIdx()];
+          }
+        }
+      }
+    }
+  }
+  return res;
 }
 void getBonds(const ROMol &mol, const Atom *at, std::vector<bondholder> &nbrs,
-              bool includeChirality) {
+              bool includeChirality,
+              const std::vector<Canon::canon_atom> &atoms) {
   PRECONDITION(at, "bad pointer");
   ROMol::OEDGE_ITER beg, end;
   boost::tie(beg, end) = mol.getAtomBonds(at);
@@ -353,7 +466,7 @@ void getBonds(const ROMol &mol, const Atom *at, std::vector<bondholder> &nbrs,
     const Bond *bond = (mol)[*beg];
     ++beg;
     nbrs.push_back(makeBondHolder(bond, bond->getOtherAtomIdx(at->getIdx()),
-                                  includeChirality));
+                                  includeChirality, atoms));
   }
   std::sort(nbrs.begin(), nbrs.end(), bondholder::greater);
 }
@@ -449,7 +562,7 @@ void initCanonAtoms(const ROMol &mol, std::vector<Canon::canon_atom> &atoms,
     basicInitCanonAtom(mol, atoms[i], i);
     advancedInitCanonAtom(mol, atoms[i], i);
     atoms[i].bonds.reserve(atoms[i].degree);
-    getBonds(mol, atoms[i].atom, atoms[i].bonds, includeChirality);
+    getBonds(mol, atoms[i].atom, atoms[i].bonds, includeChirality, atoms);
   }
 }
 
@@ -497,9 +610,9 @@ void initFragmentCanonAtoms(const ROMol &mol,
     begAt.degree++;
     endAt.degree++;
     begAt.bonds.push_back(
-        makeBondHolder(bond, bond->getEndAtomIdx(), includeChirality));
+        makeBondHolder(bond, bond->getEndAtomIdx(), includeChirality, atoms));
     endAt.bonds.push_back(
-        makeBondHolder(bond, bond->getBeginAtomIdx(), includeChirality));
+        makeBondHolder(bond, bond->getBeginAtomIdx(), includeChirality, atoms));
     if (bondSymbols) {
       begAt.bonds.back().p_symbol = &(*bondSymbols)[bond->getIdx()];
       endAt.bonds.back().p_symbol = &(*bondSymbols)[bond->getIdx()];
@@ -700,7 +813,6 @@ void chiralRankMolAtoms(const ROMol &mol, std::vector<unsigned int> &res) {
   if (clearRings) {
     mol.getRingInfo()->reset();
   }
-
-}  // end of rankMolAtoms()
+}
 }  // namespace Canon
 }  // namespace RDKit

--- a/Code/GraphMol/new_canon.h
+++ b/Code/GraphMol/new_canon.h
@@ -27,15 +27,20 @@
 
 namespace RDKit {
 namespace Canon {
+class canon_atom;
 
 struct RDKIT_GRAPHMOL_EXPORT bondholder {
-  Bond::BondType bondType{Bond::UNSPECIFIED};
-  unsigned int bondStereo;
+  Bond::BondType bondType{Bond::BondType::UNSPECIFIED};
+  unsigned int bondStereo{
+      static_cast<unsigned int>(Bond::BondStereo::STEREONONE)};
   unsigned int nbrSymClass{0};
   unsigned int nbrIdx{0};
+  Bond::BondStereo stype{Bond::BondStereo::STEREONONE};
+  const canon_atom *controllingAtoms[4]{nullptr, nullptr, nullptr, nullptr};
   const std::string *p_symbol{
       nullptr};  // if provided, this is used to order bonds
-  bondholder() : bondStereo(static_cast<unsigned int>(Bond::STEREONONE)) {}
+
+  bondholder(){};
   bondholder(Bond::BondType bt, Bond::BondStereo bs, unsigned int ni,
              unsigned int nsc)
       : bondType(bt),
@@ -45,29 +50,12 @@ struct RDKIT_GRAPHMOL_EXPORT bondholder {
   bondholder(Bond::BondType bt, unsigned int bs, unsigned int ni,
              unsigned int nsc)
       : bondType(bt), bondStereo(bs), nbrSymClass(nsc), nbrIdx(ni) {}
-  bool operator<(const bondholder &o) const {
-    if (p_symbol && o.p_symbol) {
-      return (*p_symbol) < (*o.p_symbol);
-    }
-    if (bondType != o.bondType) {
-      return bondType < o.bondType;
-    }
-    if (bondStereo != o.bondStereo) {
-      return bondStereo < o.bondStereo;
-    }
-    return nbrSymClass < o.nbrSymClass;
-  }
+
+  int compareStereo(const bondholder &o) const;
+
+  bool operator<(const bondholder &o) const { return compare(*this, o) < 0; }
   static bool greater(const bondholder &lhs, const bondholder &rhs) {
-    if (lhs.p_symbol && rhs.p_symbol && (*lhs.p_symbol) != (*rhs.p_symbol)) {
-      return (*lhs.p_symbol) > (*rhs.p_symbol);
-    }
-    if (lhs.bondType != rhs.bondType) {
-      return lhs.bondType > rhs.bondType;
-    }
-    if (lhs.bondStereo != rhs.bondStereo) {
-      return lhs.bondStereo > rhs.bondStereo;
-    }
-    return lhs.nbrSymClass > rhs.nbrSymClass;
+    return compare(lhs, rhs) > 0;
   }
 
   static int compare(const bondholder &x, const bondholder &y,
@@ -89,7 +77,17 @@ struct RDKIT_GRAPHMOL_EXPORT bondholder {
     } else if (x.bondStereo > y.bondStereo) {
       return 1;
     }
-    return x.nbrSymClass / div - y.nbrSymClass / div;
+    auto scdiv = x.nbrSymClass / div - y.nbrSymClass / div;
+    if (scdiv) {
+      return scdiv;
+    }
+    if (x.bondStereo && y.bondStereo) {
+      auto cs = x.compareStereo(y);
+      if (cs) {
+        return cs;
+      }
+    }
+    return 0;
   }
 };
 class RDKIT_GRAPHMOL_EXPORT canon_atom {
@@ -247,6 +245,37 @@ class RDKIT_GRAPHMOL_EXPORT SpecialSymmetryAtomCompareFunctor {
   }
 };
 
+namespace {
+unsigned int getChiralRank(const ROMol *dp_mol, canon_atom *dp_atoms,
+                           unsigned int i) {
+  unsigned int res = 0;
+  std::vector<unsigned int> perm;
+  perm.reserve(dp_atoms[i].atom->getDegree());
+  for (const auto nbr : dp_mol->atomNeighbors(dp_atoms[i].atom)) {
+    auto rnk = dp_atoms[nbr->getIdx()].index;
+    // make sure we don't have duplicate ranks
+    if (std::find(perm.begin(), perm.end(), rnk) != perm.end()) {
+      break;
+    } else {
+      perm.push_back(rnk);
+    }
+  }
+  if (perm.size() == dp_atoms[i].atom->getDegree()) {
+    auto ctag = dp_atoms[i].atom->getChiralTag();
+    if (ctag == Atom::ChiralType::CHI_TETRAHEDRAL_CW ||
+        ctag == Atom::ChiralType::CHI_TETRAHEDRAL_CCW) {
+      auto sortedPerm = perm;
+      std::sort(sortedPerm.begin(), sortedPerm.end());
+      auto nswaps = countSwapsToInterconvert(perm, sortedPerm);
+      res = ctag == Atom::ChiralType::CHI_TETRAHEDRAL_CW ? 2 : 1;
+      if (nswaps % 2) {
+        res = res == 2 ? 1 : 2;
+      }
+    }
+  }
+  return res;
+}
+}  // namespace
 class RDKIT_GRAPHMOL_EXPORT AtomCompareFunctor {
   unsigned int getAtomRingNbrCode(unsigned int i) const {
     if (!dp_atoms[i].hasRingNbr) {
@@ -349,25 +378,6 @@ class RDKIT_GRAPHMOL_EXPORT AtomCompareFunctor {
       // first atom stereochem:
       ivi = 0;
       ivj = 0;
-      bool seenCIP = false;
-#if 0
-      std::string cipCode;
-      if (dp_atoms[i].atom->getPropIfPresent(common_properties::_CIPCode,
-                                             cipCode)) {
-        ivi = cipCode == "R" ? 2 : 1;
-        seenCIP = true;
-      }
-      if (dp_atoms[j].atom->getPropIfPresent(common_properties::_CIPCode,
-                                             cipCode)) {
-        ivj = cipCode == "R" ? 2 : 1;
-        seenCIP = true;
-      }
-      if (ivi < ivj) {
-        return -1;
-      } else if (ivi > ivj) {
-        return 1;
-      }
-#endif
       // can't actually use values here, because they are arbitrary
       ivi = dp_atoms[i].atom->getChiralTag() != 0;
       ivj = dp_atoms[j].atom->getChiralTag() != 0;
@@ -376,59 +386,13 @@ class RDKIT_GRAPHMOL_EXPORT AtomCompareFunctor {
       } else if (ivi > ivj) {
         return 1;
       }
-      // stereo set, but CIP not assigned
-      if (ivi && ivj && !seenCIP) {
-        std::vector<unsigned int> perm;
+      // stereo set
+      if (ivi && ivj) {
         if (ivi) {
-          perm.reserve(dp_atoms[i].atom->getDegree());
-          for (const auto nbr : dp_mol->atomNeighbors(dp_atoms[i].atom)) {
-            auto rnk = dp_atoms[nbr->getIdx()].index;
-            // make sure we don't have duplicate ranks
-            if (std::find(perm.begin(), perm.end(), rnk) != perm.end()) {
-              break;
-            } else {
-              perm.push_back(rnk);
-            }
-          }
-          if (perm.size() == dp_atoms[i].atom->getDegree()) {
-            auto ctag = dp_atoms[i].atom->getChiralTag();
-            if (ctag == Atom::ChiralType::CHI_TETRAHEDRAL_CW ||
-                ctag == Atom::ChiralType::CHI_TETRAHEDRAL_CCW) {
-              auto sortedPerm = perm;
-              std::sort(sortedPerm.begin(), sortedPerm.end());
-              auto nswaps = countSwapsToInterconvert(perm, sortedPerm);
-              ivi = ctag == Atom::ChiralType::CHI_TETRAHEDRAL_CW ? 2 : 1;
-              if (nswaps % 2) {
-                ivi = ivi == 2 ? 1 : 2;
-              }
-            }
-          }
+          ivi = getChiralRank(dp_mol, dp_atoms, i);
         }
         if (ivj) {
-          perm.clear();
-          perm.reserve(dp_atoms[j].atom->getDegree());
-          for (const auto nbr : dp_mol->atomNeighbors(dp_atoms[j].atom)) {
-            auto rnk = dp_atoms[nbr->getIdx()].index;
-            // make sure we don't have duplicate ranks
-            if (std::find(perm.begin(), perm.end(), rnk) != perm.end()) {
-              break;
-            } else {
-              perm.push_back(rnk);
-            }
-          }
-          if (perm.size() == dp_atoms[j].atom->getDegree()) {
-            auto ctag = dp_atoms[j].atom->getChiralTag();
-            if (ctag == Atom::ChiralType::CHI_TETRAHEDRAL_CW ||
-                ctag == Atom::ChiralType::CHI_TETRAHEDRAL_CCW) {
-              auto sortedPerm = perm;
-              std::sort(sortedPerm.begin(), sortedPerm.end());
-              auto nswaps = countSwapsToInterconvert(perm, sortedPerm);
-              ivj = ctag == Atom::ChiralType::CHI_TETRAHEDRAL_CW ? 2 : 1;
-              if (nswaps % 2) {
-                ivj = ivj == 2 ? 1 : 2;
-              }
-            }
-          }
+          ivj = getChiralRank(dp_mol, dp_atoms, j);
         }
         if (ivi < ivj) {
           return -1;

--- a/Code/GraphMol/testChirality.cpp
+++ b/Code/GraphMol/testChirality.cpp
@@ -870,7 +870,7 @@ void testChiralityCleanup() {
   MolOps::assignStereochemistry(*mol, true, true);
   TEST_ASSERT(chiral_center->getChiralTag() == Atom::CHI_TETRAHEDRAL_CW);
   TEST_ASSERT(MolToSmiles(*mol, true) ==
-              "C[C@H]1C[C@@H](C)C[C@H](N2CCc3ccc(N)cc3C2)C1");
+              "C[C@@H]1C[C@H](C)C[C@@H](N2CCc3ccc(N)cc3C2)C1");
   delete mol;
 
   // atom stereo dependent on bond stereo breaking symmetry

--- a/Code/PgSQL/rdkit/expected/rdkit-91.out
+++ b/Code/PgSQL/rdkit/expected/rdkit-91.out
@@ -1340,15 +1340,15 @@ select mol_to_smarts(mol_adjust_query_properties('*c1ncc(*)cc1'::qmol));
 
 -- CXSmiles
 SELECT mol_to_smiles(mol_from_smiles('C[C@H](F)[C@H](C)[C@@H](C)Br |a:1,o1:3,5|'));
-        mol_to_smiles         
-------------------------------
- C[C@H](F)[C@H](C)[C@@H](C)Br
+         mol_to_smiles         
+-------------------------------
+ C[C@@H]([C@H](C)F)[C@@H](C)Br
 (1 row)
 
 SELECT mol_to_cxsmiles(mol_from_smiles('C[C@H](F)[C@H](C)[C@@H](C)Br |a:1,o1:3,5|'));
-              mol_to_cxsmiles              
--------------------------------------------
- C[C@H](F)[C@H](C)[C@@H](C)Br |a:1,o1:3,5|
+              mol_to_cxsmiles               
+--------------------------------------------
+ C[C@@H]([C@H](C)F)[C@@H](C)Br |a:2,o1:1,5|
 (1 row)
 
 SELECT mol_to_cxsmarts(mol_from_smiles('C[C@H](F)[C@H](C)[C@@H](C)Br |a:1,o1:3,5|'));
@@ -1365,9 +1365,9 @@ SELECT mol_to_cxsmarts(qmol_from_smarts('C[C@H]([F,Cl,Br])[C@H](C)[C@@H](C)Br |a
 
 -- CXSmiles from mol_out
 SELECT mol_out(mol_from_smiles('C[C@H](F)[C@H](C)[C@@H](C)Br |a:1,o1:3,5|'));
-                  mol_out                  
--------------------------------------------
- C[C@H](F)[C@H](C)[C@@H](C)Br |a:1,o1:3,5|
+                  mol_out                   
+--------------------------------------------
+ C[C@@H]([C@H](C)F)[C@@H](C)Br |a:2,o1:1,5|
 (1 row)
 
 -- github #3688: bad input to qmol_from_ctab() crashes db

--- a/rdkit/Chem/EnumerateStereoisomers.py
+++ b/rdkit/Chem/EnumerateStereoisomers.py
@@ -229,15 +229,15 @@ def EnumerateStereoisomers(m, options=StereoEnumerationOptions(), verbose=False)
     ...     print(smi)
     ...
     F[C@@H](Cl)/C=C/C=C/[C@@H](F)Cl
-    F[C@@H](Cl)/C=C/C=C/[C@H](F)Cl
-    F[C@@H](Cl)/C=C/C=C\\[C@H](F)Cl
-    F[C@@H](Cl)/C=C\\C=C/[C@@H](F)Cl
-    F[C@@H](Cl)/C=C\\C=C/[C@H](F)Cl
-    F[C@@H](Cl)/C=C\\C=C\\[C@@H](F)Cl
-    F[C@@H](Cl)/C=C\\C=C\\[C@H](F)Cl
+    F[C@@H](Cl)/C=C\C=C/[C@@H](F)Cl
+    F[C@@H](Cl)/C=C\C=C\[C@@H](F)Cl
+    F[C@H](Cl)/C=C/C=C/[C@@H](F)Cl
     F[C@H](Cl)/C=C/C=C/[C@H](F)Cl
-    F[C@H](Cl)/C=C\\C=C/[C@H](F)Cl
-    F[C@H](Cl)/C=C\\C=C\\[C@H](F)Cl
+    F[C@H](Cl)/C=C/C=C\[C@@H](F)Cl
+    F[C@H](Cl)/C=C\C=C/[C@@H](F)Cl
+    F[C@H](Cl)/C=C\C=C/[C@H](F)Cl
+    F[C@H](Cl)/C=C\C=C\[C@@H](F)Cl
+    F[C@H](Cl)/C=C\C=C\[C@H](F)Cl
 
     By default the code only expands unspecified stereocenters:
 

--- a/rdkit/Chem/UnitTestMol3D.py
+++ b/rdkit/Chem/UnitTestMol3D.py
@@ -334,7 +334,7 @@ class TestCase(unittest.TestCase):
     smiles = set(
       Chem.MolToSmiles(i, isomericSmiles=True) for i in AllChem.EnumerateStereoisomers(mol, opts))
     self.assertEqual(
-      smiles, set(['F[C@@H](Cl)[C@@H](F)Cl', 'F[C@@H](Cl)[C@H](F)Cl', 'F[C@H](Cl)[C@H](F)Cl']))
+      smiles, set(['F[C@@H](Cl)[C@@H](F)Cl', 'F[C@H](Cl)[C@@H](F)Cl', 'F[C@H](Cl)[C@H](F)Cl']))
 
     mol = Chem.MolFromSmiles('CC=CC=CC')
     opts = AllChem.StereoEnumerationOptions(unique=False)
@@ -368,11 +368,11 @@ class TestCase(unittest.TestCase):
       smiles,
       set(
         sorted([
-          'F[C@H](Cl)/C=C\\C=C\\[C@H](F)Cl', 'F[C@@H](Cl)/C=C\\C=C/[C@H](F)Cl',
+          'F[C@H](Cl)/C=C/C=C/[C@@H](F)Cl', 'F[C@H](Cl)/C=C/C=C/[C@H](F)Cl',
           'F[C@@H](Cl)/C=C/C=C/[C@@H](F)Cl', 'F[C@@H](Cl)/C=C\\C=C\\[C@@H](F)Cl',
-          'F[C@H](Cl)/C=C\\C=C/[C@H](F)Cl', 'F[C@@H](Cl)/C=C/C=C/[C@H](F)Cl',
-          'F[C@@H](Cl)/C=C\\C=C/[C@@H](F)Cl', 'F[C@@H](Cl)/C=C/C=C\\[C@H](F)Cl',
-          'F[C@H](Cl)/C=C/C=C/[C@H](F)Cl', 'F[C@@H](Cl)/C=C\\C=C\\[C@H](F)Cl'
+          'F[C@H](Cl)/C=C\\C=C/[C@@H](F)Cl', 'F[C@H](Cl)/C=C/C=C\\[C@@H](F)Cl',
+          'F[C@H](Cl)/C=C\\C=C\\[C@H](F)Cl', 'F[C@@H](Cl)/C=C\\C=C/[C@@H](F)Cl',
+          'F[C@H](Cl)/C=C\\C=C/[C@H](F)Cl', 'F[C@H](Cl)/C=C\\C=C\\[C@@H](F)Cl'
         ])))
 
   def testEnumerateStereoisomersOnlyEnhancedStereo(self):
@@ -381,7 +381,7 @@ class TestCase(unittest.TestCase):
     mol = Chem.MolFromMolFile(filename)
     smiles = set(Chem.MolToSmiles(m) for m in AllChem.EnumerateStereoisomers(mol))
     # switches the centers linked by an "OR", but not the absolute group
-    self.assertEqual(smiles, {r'C[C@@H](F)[C@@H](C)[C@@H](C)Br', r'C[C@H](F)[C@H](C)[C@@H](C)Br'})
+    self.assertEqual(smiles, {r'C[C@H]([C@@H](C)F)[C@@H](C)Br', r'C[C@H](F)[C@H](C)[C@@H](C)Br'})
 
     original_smiles = Chem.MolToSmiles(mol)
     self.assertIn(original_smiles, smiles)

--- a/rdkit/Chem/UnitTestMol3D.py
+++ b/rdkit/Chem/UnitTestMol3D.py
@@ -381,7 +381,7 @@ class TestCase(unittest.TestCase):
     mol = Chem.MolFromMolFile(filename)
     smiles = set(Chem.MolToSmiles(m) for m in AllChem.EnumerateStereoisomers(mol))
     # switches the centers linked by an "OR", but not the absolute group
-    self.assertEqual(smiles, {r'C[C@H]([C@@H](C)F)[C@@H](C)Br', r'C[C@H](F)[C@H](C)[C@@H](C)Br'})
+    self.assertEqual(smiles, {r'C[C@H]([C@@H](C)F)[C@@H](C)Br', r'C[C@@H]([C@H](C)F)[C@@H](C)Br'})
 
     original_smiles = Chem.MolToSmiles(mol)
     self.assertIn(original_smiles, smiles)


### PR DESCRIPTION
The canonicalization code has always used CIP codes on the atoms as part of the canonicalization process. This is sub-optimal since it means we need those assignments in order to generate canonical atom ranks and it won't work at all when we try to canonicalize non-tetrahedral centers.

This PR removes the CIP usage and just takes the canonical ranks of the chiral atom's neighbors into account instead.

Unfortunately this will change the canonical SMILES which is generated in many circumstances. There's no way around that.

I had some concerns about the performance impact of these changes, but I ran some benchmarking on ~75K ChEMBL molecules which include chirality and see no appreciable change in the time to generate canonical SMILES. Here's the timing info, the molecules are parsed once but SMILES is generated 5 times per molecule:

```
master:
read: 73016 mols.
 7.685986s wall, 7.000000s user + 0.680000s system = 7.680000s CPU (99.9%)
73016 mols
 33.525670s wall, 33.510000s user + 0.010000s system = 33.520000s CPU (100.0%)

dev/drop_cip_from_canon
read: 73016 mols.
 7.688591s wall, 7.200000s user + 0.480000s system = 7.680000s CPU (99.9%)
73016 mols
 33.886207s wall, 33.880000s user + 0.010000s system = 33.890000s CPU (100.0%)

```


Completely unconnected to this substance of this: I also changed the clang-format parameters so that it no longer splits string literals. It's absurd to have to paste string literals together in order to obey column-width constraints