### PR TITLE
Fixes #5386 and #5389

### DIFF
--- a/Code/GraphMol/MolDraw2D/MolDraw2DCairo.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DCairo.cpp
@@ -14,6 +14,7 @@
 #include <fstream>
 #include <GraphMol/MolDraw2D/MolDraw2DCairo.h>
 #include <GraphMol/MolDraw2D/DrawTextCairo.h>
+#include <GraphMol/MolDraw2D/MolDraw2DDetails.h>
 #ifdef RDK_BUILD_FREETYPE_SUPPORT
 #include <GraphMol/MolDraw2D/DrawTextFTCairo.h>
 #endif
@@ -133,32 +134,25 @@ void MolDraw2DCairo::drawWavyLine(const Point2D &cds1, const Point2D &cds2,
   PRECONDITION(dp_cr, "no draw context");
   PRECONDITION(nSegments > 1, "too few segments");
 
-  if (nSegments % 2) {
-    ++nSegments;  // we're going to assume an even number of segments
-  }
-
-  Point2D delta = (cds2 - cds1);
-  Point2D perp(delta.y, -delta.x);
-  perp.normalize();
-  perp *= vertOffset;
-  delta /= nSegments;
-
-  Point2D c1 = rawCoords ? cds1 : getDrawCoords(cds1);
+  auto segments =
+      MolDraw2D_detail::getWavyLineSegments(cds1, cds2, nSegments, vertOffset);
 
   double width = getDrawLineWidth();
   cairo_set_line_width(dp_cr, width);
   cairo_set_dash(dp_cr, nullptr, 0, 0);
   setColour(col1);
+
+  auto c1 = std::get<0>(segments[0]);
+  c1 = rawCoords ? c1 : getDrawCoords(c1);
+
   cairo_move_to(dp_cr, c1.x, c1.y);
   for (unsigned int i = 0; i < nSegments; ++i) {
-    Point2D startpt = cds1 + delta * i;
-    Point2D segpt =
-        rawCoords ? startpt + delta : getDrawCoords(startpt + delta);
-    Point2D cpt1 = startpt + delta / 3. + perp * (i % 2 ? -1 : 1);
+    auto cpt1 = std::get<1>(segments[i]);
     cpt1 = rawCoords ? cpt1 : getDrawCoords(cpt1);
-    Point2D cpt2 = startpt + delta * 2. / 3. + perp * (i % 2 ? -1 : 1);
+    auto cpt2 = std::get<2>(segments[i]);
     cpt2 = rawCoords ? cpt2 : getDrawCoords(cpt2);
-    // if (i == nSegments / 2 && col2 != col1) setColour(col2);
+    auto segpt = std::get<3>(segments[i]);
+    segpt = rawCoords ? segpt : getDrawCoords(segpt);
     cairo_curve_to(dp_cr, cpt1.x, cpt1.y, cpt2.x, cpt2.y, segpt.x, segpt.y);
   }
   cairo_stroke(dp_cr);

--- a/Code/GraphMol/MolDraw2D/MolDraw2DDetails.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DDetails.cpp
@@ -381,5 +381,32 @@ bool isPointInTriangle(const Point2D &pt, const Point2D &t1, const Point2D &t2,
   return 0 <= a && a <= 1 && 0 <= b && b <= 1 && 0 <= c && c <= 1;
 }
 
+std::vector<std::tuple<Point2D, Point2D, Point2D, Point2D>> getWavyLineSegments(
+    const Point2D &p1, const Point2D &p2, unsigned int nSegments,
+    double vertOffset) {
+  std::vector<std::tuple<Point2D, Point2D, Point2D, Point2D>> res;
+
+  PRECONDITION(nSegments > 1, "too few segments");
+
+  if (nSegments % 2) {
+    ++nSegments;  // we're going to assume an even number of segments
+  }
+
+  Point2D delta = (p2 - p1);
+  Point2D perp(delta.y, -delta.x);
+  perp.normalize();
+  perp *= vertOffset;
+  delta /= nSegments;
+
+  for (unsigned int i = 0; i < nSegments; ++i) {
+    Point2D startpt = p1 + delta * i;
+    Point2D segpt = startpt + delta;
+    Point2D cpt1 = startpt + delta / 3. + perp * (i % 2 ? -1 : 1);
+    Point2D cpt2 = startpt + delta * 2. / 3. + perp * (i % 2 ? -1 : 1);
+    res.emplace_back(startpt, cpt1, cpt2, segpt);
+  }
+  return res;
+}
+
 }  // namespace MolDraw2D_detail
 }  // namespace RDKit

--- a/Code/GraphMol/MolDraw2D/MolDraw2DDetails.h
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DDetails.h
@@ -136,6 +136,12 @@ bool doLinesIntersect(const Point2D &l1s, const Point2D &l1f,
 bool isPointInTriangle(const Point2D &pt, const Point2D &t1, const Point2D &t2,
                        const Point2D &t3);
 
+// returns a vector of p1,c1,c2,p2 tuples for bezier curves
+RDKIT_MOLDRAW2D_EXPORT
+std::vector<std::tuple<Point2D, Point2D, Point2D, Point2D>> getWavyLineSegments(
+    const Point2D &p1, const Point2D &p2, unsigned int nSegments,
+    double vertOffset);
+
 }  // namespace MolDraw2D_detail
 }  // namespace RDKit
 

--- a/Code/GraphMol/MolDraw2D/MolDraw2DJS.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DJS.cpp
@@ -12,6 +12,7 @@
 #ifdef __EMSCRIPTEN__
 
 #include <GraphMol/MolDraw2D/MolDraw2DJS.h>
+#include <GraphMol/MolDraw2D/MolDraw2DDetails.h>
 
 #include <GraphMol/SmilesParse/SmilesWrite.h>
 #include <Geometry/point.h>
@@ -37,20 +38,23 @@ void MolDraw2DJS::initTextDrawer(bool noFreetype) {
   double min_fnt_sz = drawOptions().minFontSize;
 
   if (noFreetype) {
-    text_drawer_.reset(new MolDraw2D_detail::DrawTextJS(max_fnt_sz, min_fnt_sz, d_context));
+    text_drawer_.reset(
+        new MolDraw2D_detail::DrawTextJS(max_fnt_sz, min_fnt_sz, d_context));
   } else {
 #ifdef RDK_BUILD_FREETYPE_SUPPORT
     try {
-      text_drawer_.reset(new MolDraw2D_detail::DrawTextFTJS(max_fnt_sz, min_fnt_sz,
-                                          drawOptions().fontFile, d_context));
+      text_drawer_.reset(new MolDraw2D_detail::DrawTextFTJS(
+          max_fnt_sz, min_fnt_sz, drawOptions().fontFile, d_context));
     } catch (std::runtime_error &e) {
       BOOST_LOG(rdWarningLog)
           << e.what() << std::endl
           << "Falling back to native JS text handling." << std::endl;
-      text_drawer_.reset(new MolDraw2D_detail::DrawTextJS(max_fnt_sz, min_fnt_sz, d_context));
+      text_drawer_.reset(
+          new MolDraw2D_detail::DrawTextJS(max_fnt_sz, min_fnt_sz, d_context));
     }
 #else
-    text_drawer_.reset(new MolDraw2D_detail::DrawTextJS(max_fnt_sz, min_fnt_sz, d_context));
+    text_drawer_.reset(
+        new MolDraw2D_detail::DrawTextJS(max_fnt_sz, min_fnt_sz, d_context));
 #endif
   }
   if (drawOptions().baseFontSize > 0.0) {
@@ -85,8 +89,7 @@ void MolDraw2DJS::drawLine(const Point2D &cds1, const Point2D &cds2,
   }
 }
 // ****************************************************************************
-void MolDraw2DJS::drawPolygon(const std::vector<Point2D> &cds,
-                              bool rawCoords) {
+void MolDraw2DJS::drawPolygon(const std::vector<Point2D> &cds, bool rawCoords) {
   PRECONDITION(cds.size() >= 3, "must have at least three points");
 
   std::string col = DrawColourToSVG(colour());
@@ -132,6 +135,40 @@ void MolDraw2DJS::drawEllipse(const Point2D &cds1, const Point2D &cds2,
   if (fillPolys()) {
     d_context.set("fillStyle", col);
     d_context.call<void>("fill");
+  }
+  d_context.call<void>("stroke");
+}
+
+// ****************************************************************************
+void MolDraw2DJS::drawWavyLine(const Point2D &cds1, const Point2D &cds2,
+                               const DrawColour &col1, const DrawColour &,
+                               unsigned int nSegments, double vertOffset,
+                               bool rawCoords) {
+  PRECONDITION(nSegments > 1, "too few segments");
+
+  std::string col = DrawColourToSVG(colour());
+  double width = getDrawLineWidth();
+
+  auto segments =
+      MolDraw2D_detail::getWavyLineSegments(cds1, cds2, nSegments, vertOffset);
+
+  d_context.call<void>("beginPath");
+  d_context.set("lineWidth", width);
+  d_context.set("strokeStyle", col);
+
+  auto c1 = std::get<0>(segments[0]);
+  c1 = rawCoords ? c1 : getDrawCoords(c1);
+
+  d_context.call<void>("moveTo", c1.x, c1.y);
+  for (const auto &segment : segments) {
+    auto cpt1 = std::get<1>(segment);
+    cpt1 = rawCoords ? cpt1 : getDrawCoords(cpt1);
+    auto cpt2 = std::get<2>(segment);
+    cpt2 = rawCoords ? cpt2 : getDrawCoords(cpt2);
+    auto segpt = std::get<3>(segment);
+    segpt = rawCoords ? segpt : getDrawCoords(segpt);
+    d_context.call<void>("bezierCurveTo", cpt1.x, cpt1.y, cpt2.x, cpt2.y,
+                         segpt.x, segpt.y);
   }
   d_context.call<void>("stroke");
 }

--- a/Code/GraphMol/MolDraw2D/MolDraw2DJS.h
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DJS.h
@@ -51,6 +51,10 @@ class RDKIT_MOLDRAW2D_EXPORT MolDraw2DJS : public MolDraw2D {
   void drawEllipse(const Point2D &cds1, const Point2D &cds2,
                    bool rawCoords = false) override;
   void clearDrawing() override;
+  void drawWavyLine(const Point2D &cds1, const Point2D &cds2,
+                    const DrawColour &col1, const DrawColour &col2,
+                    unsigned int nSegments = 16, double vertOffset = 0.05,
+                    bool rawCoords = false) override;
 
  private:
   emscripten::val &d_context;

--- a/Code/GraphMol/MolDraw2D/MolDraw2DSVG.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DSVG.cpp
@@ -183,27 +183,24 @@ void MolDraw2DSVG::drawWavyLine(const Point2D &cds1, const Point2D &cds2,
   }
   setColour(col1);
 
-  Point2D delta = (cds2 - cds1);
-  Point2D perp(delta.y, -delta.x);
-  perp.normalize();
-  perp *= vertOffset;
-  delta /= nSegments;
-
-  Point2D c1 = rawCoords ? cds1 : getDrawCoords(cds1);
+  auto segments =
+      MolDraw2D_detail::getWavyLineSegments(cds1, cds2, nSegments, vertOffset);
 
   std::string col = DrawColourToSVG(colour());
   double width = getDrawLineWidth();
   d_os << "<path ";
   outputClasses();
+
+  auto c1 = std::get<0>(segments[0]);
+  c1 = rawCoords ? c1 : getDrawCoords(c1);
   d_os << "d='M" << c1.x << "," << c1.y;
   for (unsigned int i = 0; i < nSegments; ++i) {
-    Point2D startpt = cds1 + delta * i;
-    Point2D segpt =
-        rawCoords ? startpt + delta : getDrawCoords(startpt + delta);
-    Point2D cpt1 = startpt + delta / 3. + perp * (i % 2 ? -1 : 1);
+    auto cpt1 = std::get<1>(segments[i]);
     cpt1 = rawCoords ? cpt1 : getDrawCoords(cpt1);
-    Point2D cpt2 = startpt + delta * 2. / 3. + perp * (i % 2 ? -1 : 1);
+    auto cpt2 = std::get<2>(segments[i]);
     cpt2 = rawCoords ? cpt2 : getDrawCoords(cpt2);
+    auto segpt = std::get<3>(segments[i]);
+    segpt = rawCoords ? segpt : getDrawCoords(segpt);
     d_os << " C" << cpt1.x << "," << cpt1.y << " " << cpt2.x << "," << cpt2.y
          << " " << segpt.x << "," << segpt.y;
   }

--- a/Code/GraphMol/MolDraw2D/Qt/MolDraw2DQt.cpp
+++ b/Code/GraphMol/MolDraw2D/Qt/MolDraw2DQt.cpp
@@ -114,22 +114,32 @@ void MolDraw2DQt::drawChar(char c, const Point2D &cds) {
 // ****************************************************************************
 void MolDraw2DQt::drawPolygon(const std::vector<Point2D> &cds, bool rawCoords) {
   PRECONDITION(cds.size() >= 3, "must have at least three points");
-  d_qp->save();
-  QBrush brush = d_qp->brush();
-  if (fillPolys()) {
-    brush.setStyle(Qt::SolidPattern);
-  } else {
-    brush.setStyle(Qt::NoBrush);
-  }
-  d_qp->setBrush(brush);
-
   QPointF *points = new QPointF[cds.size()];
   for (unsigned int i = 0; i < cds.size(); ++i) {
     Point2D lc = rawCoords ? cds[i] : getDrawCoords(cds[i]);
     points[i] = QPointF(lc.x, lc.y);
   }
-  d_qp->drawConvexPolygon(points, cds.size());
-  d_qp->restore();
+  QPen pen = d_qp->pen();
+  pen.setStyle(Qt::SolidLine);
+  pen.setCapStyle(Qt::FlatCap);
+  pen.setWidth(getDrawLineWidth());
+  if (fillPolys()) {
+    d_qp->save();
+    d_qp->setPen(pen);
+    QBrush brush = d_qp->brush();
+    brush.setStyle(Qt::SolidPattern);
+    d_qp->setBrush(brush);
+
+    d_qp->drawConvexPolygon(points, cds.size());
+    d_qp->restore();
+  } else {
+    QPainterPath path;
+    path.moveTo(points[0]);
+    for (unsigned int i = 0; i < cds.size(); ++i) {
+      path.lineTo(points[i]);
+    }
+    d_qp->strokePath(path, pen);
+  }
   delete[] points;
 }
 

--- a/Code/GraphMol/MolDraw2D/Qt/MolDraw2DQt.cpp
+++ b/Code/GraphMol/MolDraw2D/Qt/MolDraw2DQt.cpp
@@ -10,6 +10,7 @@
 //
 
 #include "MolDraw2DQt.h"
+#include <GraphMol/MolDraw2D/MolDraw2DDetails.h>
 #include <QPainter>
 #include <QString>
 
@@ -18,9 +19,6 @@
 #else
 #include "DrawTextQt.h"
 #endif
-
-using namespace boost;
-using namespace std;
 
 namespace RDKit {
 
@@ -114,14 +112,15 @@ void MolDraw2DQt::drawChar(char c, const Point2D &cds) {
 }
 
 // ****************************************************************************
-void MolDraw2DQt::drawPolygon(const vector<Point2D> &cds, bool rawCoords) {
+void MolDraw2DQt::drawPolygon(const std::vector<Point2D> &cds, bool rawCoords) {
   PRECONDITION(cds.size() >= 3, "must have at least three points");
   d_qp->save();
   QBrush brush = d_qp->brush();
-  if (fillPolys())
+  if (fillPolys()) {
     brush.setStyle(Qt::SolidPattern);
-  else
+  } else {
     brush.setStyle(Qt::NoBrush);
+  }
   d_qp->setBrush(brush);
 
   QPointF *points = new QPointF[cds.size()];
@@ -135,6 +134,42 @@ void MolDraw2DQt::drawPolygon(const vector<Point2D> &cds, bool rawCoords) {
 }
 
 // ****************************************************************************
+void MolDraw2DQt::drawWavyLine(const Point2D &cds1, const Point2D &cds2,
+                               const DrawColour &col1, const DrawColour &,
+                               unsigned int nSegments, double vertOffset,
+                               bool rawCoords) {
+  PRECONDITION(nSegments > 1, "too few segments");
+
+  auto segments =
+      MolDraw2D_detail::getWavyLineSegments(cds1, cds2, nSegments, vertOffset);
+
+  QPen pen = d_qp->pen();
+  pen.setStyle(Qt::SolidLine);
+  pen.setCapStyle(Qt::FlatCap);
+  pen.setWidth(getDrawLineWidth());
+
+  setColour(col1);
+
+  QPainterPath path;
+
+  auto c1 = std::get<0>(segments[0]);
+  c1 = rawCoords ? c1 : getDrawCoords(c1);
+
+  path.moveTo(QPointF(c1.x, c1.y));
+  for (unsigned int i = 0; i < nSegments; ++i) {
+    auto cpt1 = std::get<1>(segments[i]);
+    cpt1 = rawCoords ? cpt1 : getDrawCoords(cpt1);
+    auto cpt2 = std::get<2>(segments[i]);
+    cpt2 = rawCoords ? cpt2 : getDrawCoords(cpt2);
+    auto segpt = std::get<3>(segments[i]);
+    segpt = rawCoords ? segpt : getDrawCoords(segpt);
+    path.cubicTo(QPointF(cpt1.x, cpt1.y), QPointF(cpt2.x, cpt2.y),
+                 QPointF(segpt.x, segpt.y));
+  }
+  d_qp->strokePath(path, pen);
+}
+
+// ****************************************************************************
 void MolDraw2DQt::clearDrawing() {
   QColor this_col(int(255.0 * drawOptions().backgroundColour.r),
                   int(255.0 * drawOptions().backgroundColour.g),
@@ -144,5 +179,4 @@ void MolDraw2DQt::clearDrawing() {
   d_qp->setBackground(QBrush(this_col));
   d_qp->fillRect(offset().x, offset().y, width(), height(), this_col);
 }
-
 }  // namespace RDKit

--- a/Code/GraphMol/MolDraw2D/Qt/MolDraw2DQt.h
+++ b/Code/GraphMol/MolDraw2D/Qt/MolDraw2DQt.h
@@ -38,6 +38,10 @@ class RDKIT_MOLDRAW2DQT_EXPORT MolDraw2DQt : public MolDraw2D {
   void drawPolygon(const std::vector<Point2D> &cds,
                    bool rawCoords = false) override;
   void clearDrawing() override;
+  void drawWavyLine(const Point2D &cds1, const Point2D &cds2,
+                    const DrawColour &col1, const DrawColour &col2,
+                    unsigned int nSegments = 16, double vertOffset = 0.05,
+                    bool rawCoords = false) override;
 
  private:
   QPainter *d_qp;

--- a/Code/GraphMol/MolDraw2D/Qt/catch_qt.cpp
+++ b/Code/GraphMol/MolDraw2D/Qt/catch_qt.cpp
@@ -106,6 +106,34 @@ TEST_CASE("Github #5122: bad highlighting when bondLineWidth is increased") {
   }
 }
 
+TEST_CASE("wavy bonds and Qt") {
+  {
+    auto mol = "CC=CC"_smiles;
+    REQUIRE(mol);
+    mol->getBondWithIdx(1)->setStereoAtoms(0, 3);
+    mol->getBondWithIdx(1)->setStereo(Bond::BondStereo::STEREOANY);
+    bool kekulize = true;
+    bool addChiralHs = true;
+    bool wedgeBonds = true;
+    bool forceCoords = true;
+    bool wavyBonds = true;
+    MolDraw2DUtils::prepareMolForDrawing(*mol, kekulize, addChiralHs,
+                                         wedgeBonds, forceCoords, wavyBonds);
+    CHECK(mol->getBondWithIdx(0)->getBondDir() == Bond::BondDir::UNKNOWN);
+    CHECK(mol->getBondWithIdx(1)->getStereo() == Bond::BondStereo::STEREONONE);
+
+    {
+      QImage qimg(400, 400, QImage::Format_ARGB32);
+      QPainter qpt(&qimg);
+      MolDraw2DQt drawer(qimg.width(), qimg.height(), &qpt);
+      drawer.drawOptions().bondLineWidth = 3;
+      drawer.drawOptions().scaleHighlightBondWidth = true;
+      drawer.drawMolecule(*mol, "wavy bonds");
+      qimg.save("testWavyBonds.qt.1.png");
+    }
+  }
+}
+
 int main(int argc, char* argv[]) {
   QGuiApplication app(argc, argv);
 

--- a/Code/GraphMol/MolDraw2D/Qt/catch_qt.cpp
+++ b/Code/GraphMol/MolDraw2D/Qt/catch_qt.cpp
@@ -126,14 +126,51 @@ TEST_CASE("wavy bonds and Qt") {
       QImage qimg(400, 400, QImage::Format_ARGB32);
       QPainter qpt(&qimg);
       MolDraw2DQt drawer(qimg.width(), qimg.height(), &qpt);
-      drawer.drawOptions().bondLineWidth = 3;
-      drawer.drawOptions().scaleHighlightBondWidth = true;
       drawer.drawMolecule(*mol, "wavy bonds");
       qimg.save("testWavyBonds.qt.1.png");
     }
   }
 }
 
+TEST_CASE("drawMoleculeBrackets") {
+  SECTION("basics") {
+    auto mol = R"CTAB(
+  ACCLDraw11042015112D
+
+  0  0  0     0  0            999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 5 4 1 0 0
+M  V30 BEGIN ATOM
+M  V30 1 C 7 -6.7813 0 0 
+M  V30 2 C 8.0229 -6.1907 0 0 CFG=3 
+M  V30 3 C 8.0229 -5.0092 0 0 
+M  V30 4 C 9.046 -6.7814 0 0 
+M  V30 5 C 10.0692 -6.1907 0 0 
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 1 1 2 
+M  V30 2 1 2 3 
+M  V30 3 1 2 4 
+M  V30 4 1 4 5 
+M  V30 END BOND
+M  V30 BEGIN SGROUP
+M  V30 1 SRU 1 ATOMS=(3 3 2 4) XBONDS=(2 1 4) BRKXYZ=(9 7.51 -7.08 0 7.51 -
+M  V30 -5.9 0 0 0 0) BRKXYZ=(9 9.56 -5.9 0 9.56 -7.08 0 0 0 0) -
+M  V30 CONNECT=HT LABEL=n 
+M  V30 END SGROUP
+M  V30 END CTAB
+M  END
+)CTAB"_ctab;
+    REQUIRE(mol);
+    {
+      QImage qimg(400, 400, QImage::Format_ARGB32);
+      QPainter qpt(&qimg);
+      MolDraw2DQt drawer(qimg.width(), qimg.height(), &qpt);
+      drawer.drawMolecule(*mol, "brackets");
+      qimg.save("testBrackets-qt-1a.png");
+    }
+  }
+}
 int main(int argc, char* argv[]) {
   QGuiApplication app(argc, argv);
 


### PR DESCRIPTION
Adds the missing wavy bonds to the Qt and JS drawing code and fixes the drawing of brackets in Qt.