### PR TITLE
PandasTools should not always bring in IPythonConsole

### DIFF
--- a/rdkit/Chem/PandasTools.py
+++ b/rdkit/Chem/PandasTools.py
@@ -110,6 +110,7 @@ import re
 import logging
 
 import numpy as np
+import rdkit
 from rdkit import Chem
 from rdkit import DataStructs
 from rdkit.Chem import AllChem
@@ -117,10 +118,12 @@ from rdkit.Chem import Draw
 from rdkit.Chem import SDWriter
 from rdkit.Chem import rdchem
 from rdkit.Chem.Scaffolds import MurckoScaffold
-try:
-  from rdkit.Chem.Draw.IPythonConsole import InteractiveRenderer
-except ImportError:
-  InteractiveRenderer = None
+InteractiveRenderer = None
+if hasattr(rdkit, 'IPythonConsole'):
+  try:
+    from rdkit.Chem.Draw.IPythonConsole import InteractiveRenderer
+  except ImportError:
+    pass
 
 from io import BytesIO
 from xml.dom import minidom


### PR DESCRIPTION
The PandasTools code always tries to import the IPythonConsole code. This ends up doing a bunch of monkey patching of code in `rdkit.Chem.Draw` even if things aren't being run in a notebook.

This patch checks to see if we're running in a notebook before bringing in the IPythonConsole code.
