### PR TITLE
Fix GCC 12/Qt build after #5387

### DIFF
--- a/Code/GraphMol/MolDraw2D/Qt/MolDraw2DQt.cpp
+++ b/Code/GraphMol/MolDraw2D/Qt/MolDraw2DQt.cpp
@@ -12,6 +12,7 @@
 #include "MolDraw2DQt.h"
 #include <GraphMol/MolDraw2D/MolDraw2DDetails.h>
 #include <QPainter>
+#include <QPainterPath>
 #include <QString>
 
 #ifdef RDK_BUILD_FREETYPE_SUPPORT


### PR DESCRIPTION
After merging #5387, builds using GCC 12 and Qt fail with:

```
/tmp/rdkit_builder/rdkit/Code/GraphMol/MolDraw2D/Qt/MolDraw2DQt.cpp:136:18: error: aggregate ‘QPainterPath path’ has incomplete type and cannot be defined
  136 |     QPainterPath path;

```

Adding this include fixes the build.