### PR TITLE
Allow removal of non-special H atoms in SGroups

### DIFF
--- a/Code/GraphMol/AddHs.cpp
+++ b/Code/GraphMol/AddHs.cpp
@@ -890,6 +890,38 @@ bool shouldRemoveH(const RWMol &mol, const Atom *atom,
   return removeIt;
 }
 
+// Do not remove H atoms that are part of SGroups that only contain H atoms.
+void filter_sgroup_emptying_hydrogens(const ROMol &mol,
+                                      boost::dynamic_bitset<> &atomsToRemove) {
+  for (const auto &sg : getSubstanceGroups(mol)) {
+    const auto &atoms = sg.getAtoms();
+    const auto &patoms = sg.getParentAtoms();
+
+    // If the SGroup already didn't have atoms, we don't care about it
+    if (atoms.empty() && patoms.empty()) {
+      continue;
+    }
+
+    auto would_remove_atom = [&atomsToRemove](const auto idx) {
+      return atomsToRemove[idx];
+    };
+
+    auto no_atoms = atoms.empty() ||
+                    std::all_of(atoms.begin(), atoms.end(), would_remove_atom);
+    auto no_patoms = patoms.empty() || std::all_of(patoms.begin(), patoms.end(),
+                                                   would_remove_atom);
+
+    if (no_atoms && no_patoms) {
+      for (auto atom : atoms) {
+        atomsToRemove.set(atom, false);
+      }
+      for (auto patom : patoms) {
+        atomsToRemove.set(patom, false);
+      }
+    }
+  }
+}
+
 }  // end of anonymous namespace
 
 void removeHs(RWMol &mol, const RemoveHsParameters &ps, bool sanitize) {
@@ -926,6 +958,10 @@ void removeHs(RWMol &mol, const RemoveHsParameters &ps, bool sanitize) {
       atomsToRemove.set(atom->getIdx());
     }
   }  // end of the loop over atoms
+
+  // Once we know which H atoms would be removed, filter out those that
+  // would cause any SGroups to become empty
+  filter_sgroup_emptying_hydrogens(mol, atomsToRemove);
 
   // now that we know which atoms need to be removed, go ahead and remove them
   // NOTE: there's too much complexity around stereochemistry here

--- a/Code/GraphMol/AddHs.cpp
+++ b/Code/GraphMol/AddHs.cpp
@@ -494,8 +494,9 @@ void addHs(RWMol &mol, bool explicitOnly, bool addCoords,
   // for their coordinates
   unsigned int numAddHyds = 0;
   for (auto at : mol.atoms()) {
-    if (!onlyOnAtoms || std::find(onlyOnAtoms->begin(), onlyOnAtoms->end(),
-                                  at->getIdx()) != onlyOnAtoms->end()) {
+    if (!onlyOnAtoms ||
+        std::find(onlyOnAtoms->begin(), onlyOnAtoms->end(), at->getIdx()) !=
+            onlyOnAtoms->end()) {
       numAddHyds += at->getNumExplicitHs();
       if (!explicitOnly) {
         numAddHyds += at->getNumImplicitHs();
@@ -513,8 +514,9 @@ void addHs(RWMol &mol, bool explicitOnly, bool addCoords,
 
   unsigned int stopIdx = mol.getNumAtoms();
   for (unsigned int aidx = 0; aidx < stopIdx; ++aidx) {
-    if (onlyOnAtoms && std::find(onlyOnAtoms->begin(), onlyOnAtoms->end(),
-                                 aidx) == onlyOnAtoms->end()) {
+    if (onlyOnAtoms &&
+        std::find(onlyOnAtoms->begin(), onlyOnAtoms->end(), aidx) ==
+            onlyOnAtoms->end()) {
       continue;
     }
 
@@ -918,11 +920,13 @@ void removeHs(RWMol &mol, const RemoveHsParameters &ps, bool sanitize) {
     }
   }
   boost::dynamic_bitset<> atomsToRemove{mol.getNumAtoms(), 0};
+
   for (auto atom : mol.atoms()) {
     if (shouldRemoveH(mol, atom, ps)) {
       atomsToRemove.set(atom->getIdx());
     }
   }  // end of the loop over atoms
+
   // now that we know which atoms need to be removed, go ahead and remove them
   // NOTE: there's too much complexity around stereochemistry here
   // to be able to safely use batch editing.

--- a/Code/GraphMol/MolOps.h
+++ b/Code/GraphMol/MolOps.h
@@ -245,7 +245,10 @@ struct RDKIT_GRAPHMOL_EXPORT RemoveHsParameters {
   bool removeWithWedgedBond = true; /**< hydrogens with wedged bonds to them */
   bool removeWithQuery = false;     /**< hydrogens with queries defined */
   bool removeMapped = true;         /**< mapped hydrogens */
-  bool removeInSGroups = false;     /**< part of a SubstanceGroup */
+  bool removeInSGroups = true;      /**< part of a SubstanceGroup.
+    H atoms will only be removed if it doesn't cause any SGroup to become empty,
+    and if it doesn't play a special role in the SGroup (XBOND, attach point
+    or a CState) */
   bool showWarnings = true; /**< display warnings for Hs that are not removed */
   bool removeNonimplicit = true; /**< DEPRECATED equivalent of !implicitOnly */
   bool updateExplicitCount =

--- a/Code/GraphMol/SubstanceGroup.cpp
+++ b/Code/GraphMol/SubstanceGroup.cpp
@@ -15,6 +15,17 @@
 
 namespace RDKit {
 
+namespace {
+
+template <class T>
+void remove_element(std::vector<T> &container, unsigned int element) {
+  auto pos = std::find(container.begin(), container.end(), element);
+  if (pos != container.end()) {
+    container.erase(pos);
+  }
+}
+}
+
 SubstanceGroup::SubstanceGroup(ROMol *owning_mol, const std::string &type)
     : RDProps(), dp_mol(owning_mol) {
   PRECONDITION(owning_mol, "supplied owning molecule is bad");
@@ -101,6 +112,21 @@ void SubstanceGroup::addBondWithBookmark(int mark) {
   PRECONDITION(dp_mol, "bad mol");
   Bond *bond = dp_mol->getUniqueBondWithBookmark(mark);
   d_bonds.push_back(bond->getIdx());
+}
+
+void SubstanceGroup::removeAtomWithIdx(unsigned int idx) {
+  PRECONDITION(dp_mol, "bad mol");
+  remove_element(d_atoms, idx);
+}
+
+void SubstanceGroup::removeParentAtomWithIdx(unsigned int idx) {
+  PRECONDITION(dp_mol, "bad mol");
+  remove_element(d_patoms, idx);
+}
+
+void SubstanceGroup::removeBondWithIdx(unsigned int idx) {
+  PRECONDITION(dp_mol, "bad mol");
+  remove_element(d_bonds, idx);
 }
 
 void SubstanceGroup::addBracket(const SubstanceGroup::Bracket &bracket) {

--- a/Code/GraphMol/SubstanceGroup.h
+++ b/Code/GraphMol/SubstanceGroup.h
@@ -154,6 +154,12 @@ class RDKIT_GRAPHMOL_EXPORT SubstanceGroup : public RDProps {
   void addParentAtomWithBookmark(int mark);
   void addBondWithBookmark(int mark);
 
+  // These methods should be handled with care, since they can leave
+  // Attachment points and CStates in an invalid state!
+  void removeAtomWithIdx(unsigned int idx);
+  void removeParentAtomWithIdx(unsigned int idx);
+  void removeBondWithIdx(unsigned int idx);
+
   void addBracket(const Bracket &bracket);
   void addCState(unsigned int bondIdx, const RDGeom::Point3D &vector);
   void addAttachPoint(unsigned int aIdx, int lvIdx, const std::string &idStr);

--- a/Code/GraphMol/testSGroup.cpp
+++ b/Code/GraphMol/testSGroup.cpp
@@ -12,6 +12,7 @@
 #include <RDGeneral/test.h>
 #include <RDGeneral/RDLog.h>
 #include <GraphMol/RDKitBase.h>
+#include <GraphMol/MolOps.h>
 #include <GraphMol/MolPickler.h>
 #include <GraphMol/SubstanceGroup.h>
 #include <RDGeneral/FileParseException.h>
@@ -1031,6 +1032,173 @@ void testSubstanceGroupsAndRemoveHs(const std::string &rdbase) {
   }
 }
 
+void testKeepSpecialHsOnRemoval() {
+  BOOST_LOG(rdInfoLog) << "-----------------------\n Testing github XXXX: "
+                       << "Allow removal of non-special H atoms in SGroups"
+                       << std::endl;
+
+  // Keep XBOND Hydrogens
+  {
+    auto mol = R"CTAB(
+     RDKit          2D
+
+  0  0  0  0  0  0  0  0  0  0999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 5 4 1 0 0
+M  V30 BEGIN ATOM
+M  V30 1 C -3.914286 2.714286 0.000000 0
+M  V30 2 H -2.914286 2.714286 0.000000 0
+M  V30 3 H -4.247615 1.771475 0.000000 0
+M  V30 4 H -4.491638 3.530781 0.000000 0
+M  V30 5 H -4.904803 2.576897 0.000000 0
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 1 1 2
+M  V30 2 1 1 3
+M  V30 3 1 1 4
+M  V30 4 1 1 5
+M  V30 END BOND
+M  V30 BEGIN SGROUP
+M  V30 1 SRU 0 ATOMS=(3 1 3 4) XBONDS=(2 1 4) CONNECT=HT
+M  V30 END SGROUP
+M  V30 END CTAB
+M  END)CTAB"_ctab;
+
+    TEST_ASSERT(mol);
+    TEST_ASSERT(mol->getNumAtoms() == 3);
+
+    auto sgs = getSubstanceGroups(*mol);
+    TEST_ASSERT(sgs.size() == 1);
+    std::vector<unsigned> ref_atoms{0};
+    TEST_ASSERT(sgs[0].getAtoms() == ref_atoms);
+  }
+
+  // Keep SAP aIdx (but remove lvIdx).
+  // (This molecule is completely bogus).
+  {
+    auto molblock = R"CTAB(
+     RDKit          2D
+
+  0  0  0  0  0  0  0  0  0  0999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 4 2 1 0 0
+M  V30 BEGIN ATOM
+M  V30 1 C -1.8551 -2.605 0 0
+M  V30 2 C -0.5214 -3.375 0 0
+M  V30 3 H -0.5214 -4.9149 0 0
+M  V30 4 H 0.8123 -5.6849 0 0
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 1 1 2
+M  V30 2 1 2 3
+M  V30 END BOND
+M  V30 BEGIN SGROUP
+M  V30 1 SUP 0 ATOMS=(2 3 4) SAP=(3 3 4 1) XBONDS=(1 2) LABEL="bogus"
+M  V30 END SGROUP
+M  V30 END CTAB
+M  END)CTAB";
+
+    bool sanitize = false;  // One H has a weird valence
+    bool removeHs = false;
+    std::unique_ptr<RWMol> mol(MolBlockToMol(molblock, sanitize, removeHs));
+    TEST_ASSERT(mol);
+    TEST_ASSERT(mol->getNumAtoms() == 4);
+
+    MolOps::removeAllHs(*mol);
+    TEST_ASSERT(mol->getNumAtoms() == 3);
+
+    auto sgs = getSubstanceGroups(*mol);
+    TEST_ASSERT(sgs.size() == 1);
+    std::vector<unsigned> ref_atoms{2};
+    TEST_ASSERT(sgs[0].getAtoms() == ref_atoms);
+
+    auto saps = sgs[0].getAttachPoints();
+    TEST_ASSERT(saps.size() == 1);
+    TEST_ASSERT(saps[0].lvIdx == -1);
+  }
+
+  // H atom part of a CState bond
+  {
+    auto mol = R"CTAB(
+     RDKit          2D
+
+  0  0  0  0  0  0  0  0  0  0999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 5 4 1 0 0
+M  V30 BEGIN ATOM
+M  V30 1 H 12.0001 -4.402 0 0
+M  V30 2 C 10.4601 -4.402 0 0
+M  V30 3 H 8.1485 -3.075 0 0
+M  V30 4 O 9.6883 -3.0729 0 0
+M  V30 5 O 9.6919 -5.725 0 0
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 1 1 2
+M  V30 2 1 4 3
+M  V30 3 2 2 5
+M  V30 4 1 4 2
+M  V30 END BOND
+M  V30 BEGIN SGROUP
+M  V30 1 SUP 0 ATOMS=(4 2 3 4 5) SAP=(3 1 2 1) XBONDS=(1 1) CSTATE=(4 1 0 0.82 0) LABEL=Boc
+M  V30 END SGROUP
+M  V30 END CTAB
+M  END)CTAB"_ctab;
+
+    TEST_ASSERT(mol);
+    TEST_ASSERT(mol->getNumAtoms() == 4);
+
+    auto sgs = getSubstanceGroups(*mol);
+    TEST_ASSERT(sgs.size() == 1);
+
+    std::vector<unsigned> ref_atoms{{1, 2, 3}};
+    TEST_ASSERT(sgs[0].getAtoms() == ref_atoms);
+
+    auto csts = sgs[0].getCStates();
+    TEST_ASSERT(csts.size() == 1);
+    TEST_ASSERT(csts[0].bondIdx == 0);
+  }
+
+  // SGroups with only H atoms
+  {
+    auto mol = R"CTAB(
+     RDKit          2D
+
+  0  0  0  0  0  0  0  0  0  0999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 5 4 2 0 0
+M  V30 BEGIN ATOM
+M  V30 1 C -3.514286 2.200000 0.000000 0
+M  V30 2 H -2.514286 2.200000 0.000000 0
+M  V30 3 H -3.847615 1.257190 0.000000 0
+M  V30 4 H -4.091638 3.016495 0.000000 0
+M  V30 5 H -4.504803 2.062612 0.000000 0
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 1 1 2
+M  V30 2 1 1 3
+M  V30 3 1 1 4
+M  V30 4 1 1 5
+M  V30 END BOND
+M  V30 BEGIN SGROUP
+M  V30 1 DAT 0 ATOMS=(1 4) FIELDNAME="dummy1" FIELDDATA="H1"
+M  V30 2 DAT 0 ATOMS=(1 5) FIELDNAME="dummy2" FIELDDATA="H2"
+M  V30 END SGROUP
+M  V30 END CTAB
+M  END)CTAB"_ctab;
+
+    TEST_ASSERT(mol);
+    TEST_ASSERT(mol->getNumAtoms() == 3);
+
+    auto sgs = getSubstanceGroups(*mol);
+    TEST_ASSERT(sgs.size() == 2);
+
+    for (unsigned i = 0; i < 2; ++i) {
+      std::vector<unsigned> ref_atoms{i + 1};
+      TEST_ASSERT(sgs[i].getAtoms() == ref_atoms);
+    }
+  }
+}
+
 int main() {
   std::string rdbase = std::string(getenv("RDBASE"));
   if (rdbase.empty()) {
@@ -1039,7 +1207,6 @@ int main() {
   }
 
   RDLog::InitLogs();
-#if 1
   testCreateSubstanceGroups();
   testParseSubstanceGroups(rdbase);
   testSubstanceGroupsRoundTrip(rdbase, false);  // test V2000
@@ -1047,9 +1214,9 @@ int main() {
   testPickleSubstanceGroups();
   testModifyMol();
   testSubstanceGroupChanges(rdbase);
-#endif
   testSubstanceGroupsAndRemoveAtoms(rdbase);
   testSubstanceGroupsAndRemoveHs(rdbase);
+  testKeepSpecialHsOnRemoval();
 
   return 0;
 }

--- a/Code/GraphMol/testSGroup.cpp
+++ b/Code/GraphMol/testSGroup.cpp
@@ -1007,7 +1007,9 @@ void testSubstanceGroupsAndRemoveHs(const std::string &rdbase) {
   {
     std::string fName =
         rdbase + "/Code/GraphMol/test_data/sgroups_and_remove_Hs_1.mol";
-    std::unique_ptr<RWMol> mol(MolFileToMol(fName));
+    bool sanitize = true;
+    bool removeHs = false;
+    std::unique_ptr<RWMol> mol(MolFileToMol(fName, sanitize, removeHs));
     TEST_ASSERT(mol);
     TEST_ASSERT(mol->getNumAtoms() == 8);
     TEST_ASSERT(getSubstanceGroups(*mol).size() == 1);
@@ -1018,13 +1020,13 @@ void testSubstanceGroupsAndRemoveHs(const std::string &rdbase) {
       ps.removeInSGroups = true;
       MolOps::removeHs(mol_copy, ps);
       TEST_ASSERT(mol_copy.getNumAtoms() == 6);
-      TEST_ASSERT(getSubstanceGroups(mol_copy).size() == 0);
+      TEST_ASSERT(getSubstanceGroups(mol_copy).size() == 1);
     }
     {  // check removeAllHs() too
       RWMol mol_copy = *mol;
       MolOps::removeAllHs(mol_copy);
       TEST_ASSERT(mol_copy.getNumAtoms() == 6);
-      TEST_ASSERT(getSubstanceGroups(mol_copy).size() == 0);
+      TEST_ASSERT(getSubstanceGroups(mol_copy).size() == 1);
     }
   }
 }


### PR DESCRIPTION
Up to this point, using `removeHs()` with `removeInSGroups = true` would cause the SGroups to be dropped if they contained any H atoms.

The purpose of this PR is to improve this situation, by allowing removal of "non-special" H atoms from SGroups without dropping them. It also updates the H removal options to enable `removeInSGroups` by default. H atoms that are considered "special" will not be removed.

By "special" H atoms in SGroups I mean those that:
- Are part of an XBOND, so that they define a "boundary" of the SGroup, and potentially support a Bracket being drawn on the bond.
- Are the attachment atom in a a SGroup Attachment Point (aidx in the MDL specification; we don't care about them being a "leaving atom" since these can be set "-1", meaning that no atom is leaving). I don't expect to see any of these, but just in case.
- Atom is part of a bond defining a CState.
- Are part of an SGroup that only contains H atoms, so that it would become empty if these H atoms were removed. I don't expect to see many of these either.