### PR TITLE
Fixes #5403

### DIFF
--- a/Code/GraphMol/FindStereo.cpp
+++ b/Code/GraphMol/FindStereo.cpp
@@ -436,32 +436,46 @@ std::vector<StereoInfo> findPotentialStereo(ROMol &mol, bool cleanIt,
     const auto &aring = mol.getRingInfo()->atomRings()[ridx];
     unsigned int nHere = 0;
     auto sz = aring.size();
+    bool ring_is_odd_sized = sz % 2;
+    auto half_sz = sz / 2 + ring_is_odd_sized;
+
     possibleAtomsInRing.reset();
-    for (unsigned int ai = 0; ai < aring.size(); ++ai) {
+    for (unsigned int ai = 0; ai < sz; ++ai) {
       auto aidx = aring[ai];
-      if (!(aring.size() % 2)) {
+      if (!possibleAtoms[aidx] && !knownAtoms[aidx]) {
+        continue;
+      }
+
+      if (!ring_is_odd_sized) {
         // find the index of the atom on the opposite side of the even-sized
         // ring
-        auto oppositeidx = aring[(ai + sz / 2) % sz];
-        if ((possibleAtoms[aidx] || knownAtoms[aidx]) &&
-            (possibleAtoms[oppositeidx] || knownAtoms[oppositeidx])) {
+        auto oppositeidx = aring[(ai + half_sz) % sz];
+        if (possibleAtoms[oppositeidx] || knownAtoms[oppositeidx]) {
           ++nHere;
           possibleAtomsInRing.set(aidx);
           continue;
         }
       }
-      // if the atom is in more than one bond, see if there's
-      // a possible neighbor on a fusion bond
+      // if the atom is in more than one ring, explore the common edge to see if
+      // we can find another potentially chiral atom
       if (mol.getRingInfo()->numAtomRings(aidx) > 1) {
-        auto otheridx = aring[(ai + 1) % aring.size()];
-        if (possibleAtoms[otheridx] || knownAtoms[otheridx]) {
-          auto bnd = mol.getBondBetweenAtoms(aidx, otheridx);
-          CHECK_INVARIANT(bnd, "expected ring bond not found");
-          if (mol.getRingInfo()->numBondRings(bnd->getIdx()) > 1) {
+        auto previous_otheridx = aidx;
+        for (size_t step = 1; step <= half_sz; ++step) {
+          auto otheridx = aring[(ai + step) % sz];
+          auto bnd = mol.getBondBetweenAtoms(previous_otheridx, otheridx);
+          if (mol.getRingInfo()->numBondRings(bnd->getIdx()) < 2) {
+            // We reached the end of the common edge.
+            break;
+          }
+          if (possibleAtoms[otheridx] || knownAtoms[otheridx]) {
+            // We found another potentially chiral atom, no need to keep
+            // searching.
             nHere += 2;
             possibleAtomsInRing.set(aidx);
             possibleAtomsInRing.set(otheridx);
+            break;
           }
+          previous_otheridx = otheridx;
         }
       }
     }

--- a/Code/GraphMol/catch_chirality.cpp
+++ b/Code/GraphMol/catch_chirality.cpp
@@ -2610,3 +2610,25 @@ M  END
   CHECK(m->getAtomWithIdx(0)->getChiralTag() ==
         Atom::ChiralType::CHI_UNSPECIFIED);
 }
+
+TEST_CASE(
+    "github 5403: Incorrect perception of pseudoasymmetric centers on "
+    "non-canonical molecules") {
+  auto mol1 = "N[C@@]12CC[C@@](CC1)(C2)C(F)F"_smiles;
+  REQUIRE(mol1);
+
+  bool clean = true;
+
+  auto stereoInfo1 = Chirality::findPotentialStereo(*mol1, clean);
+  REQUIRE(stereoInfo1.size() == 2);
+  REQUIRE(stereoInfo1[0].centeredOn == 1);
+  REQUIRE(stereoInfo1[1].centeredOn == 4);
+
+  auto mol2 = "C1C[C@]2(C(F)F)CC[C@@]1(N)C2"_smiles;
+  REQUIRE(mol2);
+
+  auto stereoInfo2 = Chirality::findPotentialStereo(*mol2, clean);
+  REQUIRE(stereoInfo2.size() == 2);
+  CHECK(stereoInfo2[0].centeredOn == 2);
+  CHECK(stereoInfo2[1].centeredOn == 8);
+}


### PR DESCRIPTION
Ok, I think I found the issue. This fixes #5403

It seems the problem is in the way we try to find pairs of potential chiral atoms in fused rings (for the examples, we never hit the even-sided block, since we only look at the smaller rings, the two fused 5 bond rings):

https://github.com/rdkit/rdkit/blob/73d0d82664be5322861f5afe756c70ff4868b7a7/Code/GraphMol/FindStereo.cpp#L455-L467

First of all, we never check whether `aidx` is potentially chiral, but we still mark it as such. Second, we only check 1 bond away of `aidx` for a second potentially chiral atom.

Together, these 2 issues allow to correctly identify 2 chiral centers in `m = N[C@@]12CC[C@@](CC1)(C2)C(F)F`, but only one in `nm = C1C[C@]2(C(F)F)CC[C@@]1(N)C2`.

More specifically, in `m` we add the atom pairs (7,4) for ring (2,1,7,4,3) and (7, 1) for ring (5,4,7,1,6), but atom 7 is not potentially chiral!. Still, we end up marking atoms 1 and 4 as potentially chiral.

For `nm`, we find (10, 8) for ring (0,1,2,10,8) and again (10, 8) for (6,2,10,8,7). Again, 10 is not potentially chiral here, and we missed atom 2, which is.

Since 2 is not set in `possibleAtomsInRing`, we don't resolve it later on, even though we initially detected it and gave it a chiral tag.

The fix I'm implementing here does some refactoring, adds a check to skip any atoms that are not potentially chiral, and updates the fused ring code to try to find a pair of potentially chiral atoms along a common edge, like the "bridge" in the sample mols.

Please have a good look at the new code, I've written it based mostly on intuition rather than deep reasoning.