### PR TITLE
Fix performance issue in RingUtils::checkFused

### DIFF
--- a/Code/GraphMol/Aromaticity.cpp
+++ b/Code/GraphMol/Aromaticity.cpp
@@ -68,7 +68,7 @@ bool checkFused(const INT_VECT &rids, INT_INT_VECT_MAP &ringNeighs) {
   INT_VECT fused;
 
   // mark all rings in the system other than those in rids as done
-  for (auto nci : ringNeighs) {
+  for (const auto& nci : ringNeighs) {
     rid = nci.first;
     if (std::find(rids.begin(), rids.end(), rid) == rids.end()) {
       done[rid] = 1;


### PR DESCRIPTION
We noticed a performance hit for sanitizing very ringy structures (specifically for chained bucky balls and a smaller performance hit for nanotubes) after the 2022_03_02 release and traced it back to https://github.com/rdkit/rdkit/pull/4722/. I did some profiling and found that copying all of the ring neighbors in RingUtils::checkFused seemed to be causing the performance degradation. 

Before this change:

Time to sanitize...
	Chained bucky balls (128 atoms): 0.184651 s
	Nanotube (2412 atoms): 0.361771 s


After this change: 

Time to sanitize...
	Chained bucky balls (128 atoms): 0.025208 s
	Nanotube (2412 atoms): 0.277536 s


