### PR TITLE
Fixes #5234

### DIFF
--- a/Code/PgSQL/rdkit/adapter.cpp
+++ b/Code/PgSQL/rdkit/adapter.cpp
@@ -774,7 +774,7 @@ extern "C" CROMol MolAdjustQueryProperties(CROMol i, const char *params) {
     try {
       MolOps::parseAdjustQueryParametersFromJSON(p, pstring);
     } catch (const ValueErrorException &e) {
-      elog(ERROR, e.what());
+      elog(ERROR, "MolAdjustQueryProperties: %s", e.what());
     } catch (...) {
       elog(WARNING,
            "adjustQueryProperties: Invalid argument \'params\' ignored");

--- a/Code/PgSQL/rdkit/expected/rdkit-91.out
+++ b/Code/PgSQL/rdkit/expected/rdkit-91.out
@@ -1307,7 +1307,7 @@ select 'C1C(C)C1CCCC'::mol @> mol_adjust_query_properties('C1CC1CC'::mol,'{"adju
 (1 row)
 
 select 'C1C(C)C1CCCC'::mol @> mol_adjust_query_properties('C1CC1CC'::mol,'{"adjustDegreeFlags":"bogus"}');
-ERROR:  Unknown flag value: 'BOGUS'. Flags ignored.
+ERROR:  MolAdjustQueryProperties: Unknown flag value: 'BOGUS'. Flags ignored.
 select 'C1C([2H])C1CCCC'::mol @> mol_adjust_query_properties('C1CC1CC'::mol);
  ?column? 
 ----------


### PR DESCRIPTION
One-liner fix.

The compiler can't be sure that the string being passed isn't a format string, so it complains. This PR makes the call to `elog()` in question similar to the other calls.