### PR TITLE
Github5420

### DIFF
--- a/Code/GraphMol/MolDraw2D/DrawMol.cpp
+++ b/Code/GraphMol/MolDraw2D/DrawMol.cpp
@@ -527,9 +527,9 @@ void DrawMol::extractVariableBonds() {
         --oat;
         atomsInvolved.set(oat);
         auto center = atCds_[oat];
-        Point2D offset{drawOptions_.variableAtomRadius,
-                       drawOptions_.variableAtomRadius};
-        std::vector<Point2D> points{center + offset, center - offset};
+        Point2D radii{drawOptions_.variableAtomRadius,
+                      drawOptions_.variableAtomRadius};
+        std::vector<Point2D> points{center, radii};
         DrawShapeEllipse *ell = new DrawShapeEllipse(
             points, 1, true, drawOptions_.variableAttachmentColour, true, oat);
         preShapes_.emplace_back(ell);
@@ -1607,14 +1607,14 @@ void DrawMol::makeQueryBond(Bond *bond, double doubleBondOffset) {
       } else {
         segment /= segment.length() * 10;
         auto l = segment.length();
-        Point2D p1 = midp + segment + Point2D(l, l);
-        Point2D p2 = midp + segment - Point2D(l, l);
+        Point2D p1 = midp + segment;
+        Point2D p2 = Point2D(l, l);
         std::vector<Point2D> pts{p1, p2};
         DrawShapeEllipse *ell =
             new DrawShapeEllipse(pts, 1, false, queryColour, false);
         bonds_.emplace_back(ell);
-        p1 = midp - segment + Point2D(l, l);
-        p2 = midp - segment - Point2D(l, l);
+        p1 = midp - segment;
+        p2 = Point2D(l, l);
         pts = std::vector<Point2D>{p1, p2};
         ell = new DrawShapeEllipse(pts, 1, false, queryColour, false);
         bonds_.emplace_back(ell);
@@ -1917,10 +1917,8 @@ void DrawMol::makeAtomCircleHighlights() {
       if (highlightRadii_.find(thisIdx) != highlightRadii_.end()) {
         radius = highlightRadii_.find(thisIdx)->second;
       }
-      Point2D offset(radius, radius);
-      Point2D p1 = atCds_[thisIdx] - offset;
-      Point2D p2 = atCds_[thisIdx] + offset;
-      std::vector<Point2D> pts{p1, p2};
+      Point2D radii(radius, radius);
+      std::vector<Point2D> pts{atCds_[thisIdx], radii};
       DrawShape *ell = new DrawShapeEllipse(pts, 2, false, col, true,
                                             thisIdx + activeAtmIdxOffset_);
       highlights_.push_back(std::unique_ptr<DrawShape>(ell));
@@ -1961,10 +1959,8 @@ void DrawMol::makeAtomEllipseHighlights(int lineWidth) {
         centre.x = 0.5 * (xMax + xMin);
         centre.y = 0.5 * (yMax + yMin);
       }
-      Point2D offset(xradius, yradius);
-      Point2D p1 = centre - offset;
-      Point2D p2 = centre + offset;
-      std::vector<Point2D> pts{p1, p2};
+      Point2D radii(xradius, yradius);
+      std::vector<Point2D> pts{centre, radii};
       DrawShape *ell = new DrawShapeEllipse(pts, lineWidth, true, col, true,
                                             thisIdx + activeAtmIdxOffset_);
       highlights_.push_back(std::unique_ptr<DrawShape>(ell));
@@ -2190,7 +2186,6 @@ int DrawMol::doesNoteClash(const DrawAnnotation &annot) const {
 
 // ****************************************************************************
 int DrawMol::doesRectClash(const StringRect &rect, double padding) const {
-
   // see if the rectangle clashes with any of the double bonds themselves,
   // as opposed to the draw shapes derived from them.  Github 5185 shows
   // that sometimes atom indices can just fit between the lines of a

--- a/Code/GraphMol/MolDraw2D/DrawMolMCH.cpp
+++ b/Code/GraphMol/MolDraw2D/DrawMolMCH.cpp
@@ -11,6 +11,7 @@
 //
 
 #include <GraphMol/RWMol.h>
+#include <GraphMol/MolDraw2D/MolDraw2DDetails.h>
 #include <GraphMol/MolDraw2D/DrawMolMCH.h>
 
 namespace RDKit {
@@ -38,12 +39,25 @@ void DrawMolMCH::extractHighlights() {
 
 // ****************************************************************************
 void DrawMolMCH::extractMCHighlights() {
-  makeBondHighlights();
-  makeAtomHighlights();
+  std::vector<std::unique_ptr<DrawShape>> bondHighlights;
+  makeBondHighlights(bondHighlights);
+  std::vector<std::unique_ptr<DrawShape>> atomHighlights;
+  makeAtomHighlights(atomHighlights);
+  fixHighlightJoinProblems(atomHighlights, bondHighlights);
+
+  for (auto &it : bondHighlights) {
+    highlights_.push_back(std::move(it));
+  }
+  bondHighlights.clear();
+  for (auto &it : atomHighlights) {
+    highlights_.push_back(std::move(it));
+  }
+  atomHighlights.clear();
 }
 
 // ****************************************************************************
-void DrawMolMCH::makeBondHighlights() {
+void DrawMolMCH::makeBondHighlights(
+    std::vector<std::unique_ptr<DrawShape>> &bondHighlights) {
   for (auto hb : mcHighlightBondMap_) {
     auto bond_idx = hb.first;
     auto lineWidth = drawOptions_.bondLineWidth;
@@ -67,20 +81,7 @@ void DrawMolMCH::makeBondHighlights() {
       DrawShape *pl = new DrawShapeSimpleLine(
           pts, lineWidth, drawOptions_.scaleBondWidth, col, at1_idx, at2_idx,
           bond->getIdx(), noDash);
-      highlights_.emplace_back(pl);
-    };
-    auto calc_effective_centre = [&](unsigned int atIdx, Point2D &centre)-> double {
-      double xrad = 0.7 * drawOptions_.highlightRadius;
-      double yrad = xrad;
-      if (atomLabels_[atIdx]) {
-        calcSymbolEllipse(atIdx, centre, xrad, yrad);
-      } else {
-        centre = atCds_[atIdx];
-      }
-      double disp = (atCds_[atIdx] - centre).length();
-      xrad -= disp;
-      yrad -= disp;
-      return std::min(xrad, yrad);
+      bondHighlights.emplace_back(pl);
     };
 
     if (hb.second.size() < 2) {
@@ -99,17 +100,10 @@ void DrawMolMCH::makeBondHighlights() {
         DrawShape *pl = new DrawShapePolyLine(
             line_pts, lineWidth, drawOptions_.scaleBondWidth, col, true,
             at1_idx, at2_idx, bond->getIdx(), noDash);
-        highlights_.emplace_back(pl);
+        bondHighlights.emplace_back(pl);
       } else {
-        // if the labels aren't centred on the atom coords, the lines might
-        // miss which looks messy.  So adjust.
-        Point2D atCentre1, atCentre2;
-        double rad1 = calc_effective_centre(at1_idx, atCentre1);
-        double rad2 = calc_effective_centre(at2_idx, atCentre2);
-        double thisrad = 0.7 * std::min(rad1, rad2);
-        auto perp = calcPerpendicular(atCentre1, atCentre2);
-        make_adjusted_line(at1_cds + perp * thisrad, at2_cds + perp * thisrad, col);
-        make_adjusted_line(at1_cds - perp * thisrad, at2_cds - perp * thisrad, col);
+        make_adjusted_line(at1_cds + perp * rad, at2_cds + perp * rad, col);
+        make_adjusted_line(at1_cds - perp * rad, at2_cds - perp * rad, col);
       }
     } else {
       auto col_rad = 2.0 * rad / hb.second.size();
@@ -126,7 +120,7 @@ void DrawMolMCH::makeBondHighlights() {
           DrawShape *pl = new DrawShapePolyLine(
               line_pts, lineWidth, drawOptions_.scaleBondWidth, hb.second[i],
               true, at1_idx, at2_idx, bond->getIdx(), noDash);
-          highlights_.emplace_back(pl);
+          bondHighlights.emplace_back(pl);
           p1 += perp * col_rad;
           p2 += perp * col_rad;
         }
@@ -137,13 +131,6 @@ void DrawMolMCH::makeBondHighlights() {
           cols.erase(cols.begin());
         }
         int step = 0;
-        // if the labels aren't centred on the atom coords, the lines might
-        // miss which looks messy.  So adjust.
-        Point2D atCentre1, atCentre2;
-        double rad1 = calc_effective_centre(at1_idx, atCentre1);
-        double rad2 = calc_effective_centre(at2_idx, atCentre2);
-        double thisrad = 0.7 * std::min(rad1, rad2);
-        auto perp = calcPerpendicular(atCentre1, atCentre2);
         for (size_t i = 0; i < cols.size(); ++i) {
           // draw even numbers from the bottom, odd from the top
           auto offset = perp * (rad - step * col_rad);
@@ -160,21 +147,20 @@ void DrawMolMCH::makeBondHighlights() {
 }
 
 // ****************************************************************************
-void DrawMolMCH::makeAtomHighlights() {
+void DrawMolMCH::makeAtomHighlights(
+    std::vector<std::unique_ptr<DrawShape>> &atomHighlights) {
   for (auto &ha : mcHighlightAtomMap_) {
     double xradius, yradius;
     Point2D centre;
     int lineWidth = getHighlightBondWidth(drawOptions_, -1, nullptr);
     calcSymbolEllipse(ha.first, centre, xradius, yradius);
     if (ha.second.size() == 1) {
-      Point2D offset(xradius, yradius);
-      auto p1 = centre - offset;
-      auto p2 = centre + offset;
-      std::vector<Point2D> pts{p1, p2};
+      Point2D radii(xradius, yradius);
+      std::vector<Point2D> pts{centre, radii};
       DrawShape *ell =
           new DrawShapeEllipse(pts, lineWidth, true, ha.second.front(),
                                drawOptions_.fillHighlights, ha.first);
-      highlights_.emplace_back(ell);
+      atomHighlights.emplace_back(ell);
     } else {
       auto arc_size = 360.0 / double(ha.second.size());
       auto arc_start = 270.0;
@@ -185,7 +171,7 @@ void DrawMolMCH::makeAtomHighlights() {
         DrawShape *arc = new DrawShapeArc(
             pts, arc_start, arc_stop, lineWidth, true, ha.second[i],
             drawOptions_.fillHighlights, ha.first);
-        highlights_.emplace_back(arc);
+        atomHighlights.emplace_back(arc);
         arc_start += arc_size;
         arc_start = arc_start >= 360.0 ? arc_start - 360.0 : arc_start;
       }
@@ -205,7 +191,97 @@ void DrawMolMCH::adjustLineEndForHighlight(int at_idx, Point2D p1,
   if (xradius < 1.0e-6 || yradius < 1.0e-6) {
     return;
   }
+  adjustLineEndForEllipse(centre, xradius, yradius, p1, p2);
+}
 
+// ****************************************************************************
+void DrawMolMCH::calcSymbolEllipse(unsigned int atomIdx, Point2D &centre,
+                                   double &xradius, double &yradius) const {
+  centre = atCds_[atomIdx];
+  xradius = drawOptions_.highlightRadius;
+  yradius = xradius;
+  if (highlightRadii_.find(atomIdx) != highlightRadii_.end()) {
+    xradius = highlightRadii_.find(atomIdx)->second;
+    yradius = xradius;
+  }
+
+  if (drawOptions_.atomHighlightsAreCircles || !atomLabels_[atomIdx] ||
+      atomLabels_[atomIdx]->symbol_.empty()) {
+    return;
+  }
+
+  double x_min, y_min, x_max, y_max;
+  x_min = y_min = std::numeric_limits<double>::max();
+  x_max = y_max = std::numeric_limits<double>::lowest();
+  atomLabels_[atomIdx]->findExtremes(x_min, x_max, y_min, y_max);
+
+  static const double root_2 = sqrt(2.0);
+  xradius = std::max(xradius, root_2 * 0.5 * (x_max - x_min));
+  yradius = std::max(yradius, root_2 * 0.5 * (y_max - y_min));
+  centre.x = 0.5 * (x_max + x_min);
+  centre.y = 0.5 * (y_max + y_min);
+}
+
+// ****************************************************************************
+void DrawMolMCH::fixHighlightJoinProblems(
+    std::vector<std::unique_ptr<DrawShape>> &atomHighlights,
+    std::vector<std::unique_ptr<DrawShape>> &bondHighlights) {
+  std::vector<unsigned int> fettledAtoms;
+  for (unsigned int i = 0; i < atomHighlights.size(); ++i) {
+    auto &atomHL = atomHighlights[i];
+    for (auto &bondHL : bondHighlights) {
+      if (atomHL->atom1_ == bondHL->atom1_ ||
+          atomHL->atom1_ == bondHL->atom2_) {
+        bool ins = doesLineIntersectArc(
+            atomHL->points_[0], atomHL->points_[1].x, atomHL->points_[1].y, 0.0,
+            360.0, 0.0, bondHL->points_[0], bondHL->points_[1]);
+        if (!ins) {
+          fettledAtoms.push_back(i);
+          while (!ins) {
+            double dist1 = (atomHL->points_[0] - bondHL->points_[0]).length();
+            double dist2 = (atomHL->points_[0] - bondHL->points_[1]).length();
+            double maxrad =
+                std::max(atomHL->points_[1].x, atomHL->points_[1].y);
+            double upscaler = 1.25 * std::min(dist1, dist2) / maxrad;
+            if (upscaler <= 1.0) {
+              upscaler = 1.1;
+            }
+            atomHL->points_[1] *= upscaler;
+            ins = doesLineIntersectArc(atomHL->points_[0], atomHL->points_[1].x,
+                                       atomHL->points_[1].y, 0.0, 360, 0.0,
+                                       bondHL->points_[0], bondHL->points_[1]);
+          }
+        }
+      }
+    }
+  }
+  std::sort(fettledAtoms.begin(), fettledAtoms.end());
+  fettledAtoms.erase(std::unique(fettledAtoms.begin(), fettledAtoms.end()),
+                     fettledAtoms.end());
+  for (unsigned int i = 0; i < fettledAtoms.size(); ++i) {
+    // now adjust all the other bond highlights that end on this atom
+    auto &atomHL = atomHighlights[fettledAtoms[i]];
+    for (auto &bondHL : bondHighlights) {
+      if (atomHL->atom1_ == bondHL->atom1_ ||
+          atomHL->atom1_ == bondHL->atom2_) {
+        if ((atomHL->points_[0] - bondHL->points_[0]).lengthSq() <
+            (atomHL->points_[0] - bondHL->points_[1]).lengthSq()) {
+          adjustLineEndForEllipse(atomHL->points_[0], atomHL->points_[1].x,
+                                  atomHL->points_[1].y, bondHL->points_[1],
+                                  bondHL->points_[0]);
+        } else {
+          adjustLineEndForEllipse(atomHL->points_[0], atomHL->points_[1].x,
+                                  atomHL->points_[1].y, bondHL->points_[0],
+                                  bondHL->points_[1]);
+        }
+      }
+    }
+  }
+}
+
+// ****************************************************************************
+void adjustLineEndForEllipse(const Point2D &centre, double xradius,
+                             double yradius, Point2D p1, Point2D &p2) {
   // move everything so the ellipse is centred on the origin.
   p1 -= centre;
   p2 -= centre;
@@ -253,38 +329,12 @@ void DrawMolMCH::adjustLineEndForHighlight(int at_idx, Point2D p1,
     } else {
       // the intersections are both outside the line between p1 and p2
       // so don't do anything.
+      p1 += centre;
+      p2 += centre;
       return;
     }
     p2 = t_to_point(t);
   }
-}
-
-// ****************************************************************************
-void DrawMolMCH::calcSymbolEllipse(unsigned int atomIdx, Point2D &centre,
-                                   double &xradius, double &yradius) const {
-  centre = atCds_[atomIdx];
-  xradius = drawOptions_.highlightRadius;
-  yradius = xradius;
-  if (highlightRadii_.find(atomIdx) != highlightRadii_.end()) {
-    xradius = highlightRadii_.find(atomIdx)->second;
-    yradius = xradius;
-  }
-
-  if (drawOptions_.atomHighlightsAreCircles || !atomLabels_[atomIdx] ||
-      atomLabels_[atomIdx]->symbol_.empty()) {
-    return;
-  }
-
-  double x_min, y_min, x_max, y_max;
-  x_min = y_min = std::numeric_limits<double>::max();
-  x_max = y_max = std::numeric_limits<double>::lowest();
-  atomLabels_[atomIdx]->findExtremes(x_min, x_max, y_min, y_max);
-
-  static const double root_2 = sqrt(2.0);
-  xradius = std::max(xradius, root_2 * 0.5 * (x_max - x_min));
-  yradius = std::max(yradius, root_2 * 0.5 * (y_max - y_min));
-  centre.x = 0.5 * (x_max + x_min);
-  centre.y = 0.5 * (y_max + y_min);
 }
 
 }  // namespace MolDraw2D_detail

--- a/Code/GraphMol/MolDraw2D/DrawMolMCH.cpp
+++ b/Code/GraphMol/MolDraw2D/DrawMolMCH.cpp
@@ -162,10 +162,6 @@ void DrawMolMCH::makeAtomHighlights() {
     double xradius, yradius;
     Point2D centre;
     int lineWidth = getHighlightBondWidth(drawOptions_, -1, nullptr);
-    if (!drawOptions_.fillHighlights) {
-      lineWidth = getHighlightBondWidth(drawOptions_, -1,
-                                        &highlightLinewidthMultipliers_);
-    }
     calcSymbolEllipse(ha.first, centre, xradius, yradius);
     if (ha.second.size() == 1) {
       Point2D offset(xradius, yradius);
@@ -227,7 +223,6 @@ void DrawMolMCH::adjustLineEndForHighlight(int at_idx, Point2D p1,
   double disc = B * B - 4.0 * A * C;
   if (disc < 0.0) {
     // no solutions, leave things as they are.  Bit crap, though.
-    std::cout << "fallback" << std::endl;
     p1 += centre;
     p2 += centre;
     return;

--- a/Code/GraphMol/MolDraw2D/DrawMolMCH.cpp
+++ b/Code/GraphMol/MolDraw2D/DrawMolMCH.cpp
@@ -77,6 +77,9 @@ void DrawMolMCH::makeBondHighlights() {
       } else {
         centre = atCds_[atIdx];
       }
+      double disp = (atCds_[atIdx] - centre).length();
+      xrad -= disp;
+      yrad -= disp;
       return std::min(xrad, yrad);
     };
 
@@ -105,8 +108,8 @@ void DrawMolMCH::makeBondHighlights() {
         double rad2 = calc_effective_centre(at2_idx, atCentre2);
         double thisrad = 0.7 * std::min(rad1, rad2);
         auto perp = calcPerpendicular(atCentre1, atCentre2);
-        make_adjusted_line(atCentre1 + perp * thisrad, atCentre2 + perp * thisrad, col);
-        make_adjusted_line(atCentre1 - perp * thisrad, atCentre2 - perp * thisrad, col);
+        make_adjusted_line(at1_cds + perp * thisrad, at2_cds + perp * thisrad, col);
+        make_adjusted_line(at1_cds - perp * thisrad, at2_cds - perp * thisrad, col);
       }
     } else {
       auto col_rad = 2.0 * rad / hb.second.size();
@@ -145,9 +148,9 @@ void DrawMolMCH::makeBondHighlights() {
           // draw even numbers from the bottom, odd from the top
           auto offset = perp * (rad - step * col_rad);
           if (!(i % 2)) {
-            make_adjusted_line(atCentre1- offset, atCentre2 - offset, cols[i]);
+            make_adjusted_line(at1_cds - offset, at2_cds - offset, cols[i]);
           } else {
-            make_adjusted_line(atCentre1 + offset, atCentre2 + offset, cols[i]);
+            make_adjusted_line(at1_cds + offset, at2_cds + offset, cols[i]);
             step++;
           }
         }

--- a/Code/GraphMol/MolDraw2D/DrawMolMCH.h
+++ b/Code/GraphMol/MolDraw2D/DrawMolMCH.h
@@ -62,17 +62,28 @@ class DrawMolMCH : public DrawMol {
 
   void extractHighlights() override;
   void extractMCHighlights();
-  void makeBondHighlights();
-  void makeAtomHighlights();
+  void makeBondHighlights(
+      std::vector<std::unique_ptr<DrawShape>> &bondHighlights);
+  void makeAtomHighlights(
+      std::vector<std::unique_ptr<DrawShape>> &atomHighlights);
+  // adjust p2 so that the line from p1 to p2 stops where it intersects
+  // the label ellipse for at_idx.
   void adjustLineEndForHighlight(int at_idx, Point2D p1, Point2D &p2) const;
   void calcSymbolEllipse(unsigned int atomIdx, Point2D &centre, double &xradius,
                          double &yradius) const;
+  void fixHighlightJoinProblems(
+      std::vector<std::unique_ptr<DrawShape>> &atomHighlights,
+      std::vector<std::unique_ptr<DrawShape>> &bondHighlights);
 
   const std::map<int, std::vector<DrawColour>> mcHighlightAtomMap_;
   const std::map<int, std::vector<DrawColour>> &mcHighlightBondMap_;
   const std::map<int, int> &highlightLinewidthMultipliers_;
 };
 
+// adjust p2 so that the line from p1 to p2 stops where it intersects
+// the ellipse.
+void adjustLineEndForEllipse(const Point2D &centre, double xradius,
+                             double yradius, Point2D p1, Point2D &p2);
 }  // namespace MolDraw2D_detail
 }  // namespace RDKit
 

--- a/Code/GraphMol/MolDraw2D/DrawShape.cpp
+++ b/Code/GraphMol/MolDraw2D/DrawShape.cpp
@@ -158,18 +158,18 @@ void DrawShapeEllipse::myDraw(MolDraw2D &drawer) const {
     drawer.setLineWidth(1);
     drawer.drawOptions().scaleBondWidth = false;
   }
-  drawer.drawEllipse(points_[0], points_[1], true);
+  auto p1 = points_[0] - points_[1];
+  auto p2 = points_[0] + points_[1];
+  drawer.drawEllipse(p1, p2, true);
 }
 
 // ****************************************************************************
 void DrawShapeEllipse::findExtremes(double &xmin, double &xmax, double &ymin,
                                     double &ymax) const {
-  auto wb2 = (points_[1].x - points_[0].x) / 2;
-  auto hb2 = (points_[1].y - points_[0].y) / 2;
+  auto wb2 = points_[1].x;
+  auto hb2 = points_[1].y;
   auto cx = points_[0].x + wb2;
   auto cy = points_[0].y + hb2;
-  wb2 = wb2 > 0 ? wb2 : -1 * wb2;
-  hb2 = hb2 > 0 ? hb2 : -1 * hb2;
   xmin = std::min(cx - wb2, xmin);
   xmax = std::max(cx + wb2, xmax);
   ymin = std::min(cy - hb2, ymin);
@@ -177,15 +177,17 @@ void DrawShapeEllipse::findExtremes(double &xmin, double &xmax, double &ymin,
 }
 
 // ****************************************************************************
+void DrawShapeEllipse::move(const Point2D &trans) { points_[0] += trans; }
+// ****************************************************************************
 bool DrawShapeEllipse::doesRectClash(const StringRect &rect,
                                      double padding) const {
   padding = scaleLineWidth_ ? padding * lineWidth_ : padding;
   Point2D tl, tr, br, bl;
   rect.calcCorners(tl, tr, br, bl, padding);
-  auto w = points_[1].x - points_[0].x;
-  auto h = points_[1].y - points_[0].y;
-  auto cx = points_[0].x + w / 2;
-  auto cy = points_[0].y + h / 2;
+  auto w = points_[1].x;
+  auto h = points_[1].y;
+  auto cx = points_[0].x;
+  auto cy = points_[0].y;
   w = w > 0 ? w : -1 * w;
   h = h > 0 ? h : -1 * h;
   Point2D centre{cx, cy};

--- a/Code/GraphMol/MolDraw2D/DrawShape.h
+++ b/Code/GraphMol/MolDraw2D/DrawShape.h
@@ -81,7 +81,8 @@ class DrawShapeArrow : public DrawShape {
 
 class DrawShapeEllipse : public DrawShape {
  public:
-  // points are the 2 foci of the ellipse
+  // Points should be size 2 - the first entry is the centre, the second
+  // gives the x and y radii of the ellipse.
   DrawShapeEllipse(const std::vector<Point2D> &points, int lineWidth = 2,
                    bool scaleLineWidth = false,
                    DrawColour lineColour = DrawColour(0, 0, 0),
@@ -94,6 +95,7 @@ class DrawShapeEllipse : public DrawShape {
   void myDraw(MolDraw2D &drawer) const override;
   void findExtremes(double &xmin, double &xmax, double &ymin,
                     double &ymax) const override;
+  void move(const Point2D &trans) override;
   bool doesRectClash(const StringRect &rect, double padding) const override;
 };
 

--- a/Code/GraphMol/MolDraw2D/test1.cpp
+++ b/Code/GraphMol/MolDraw2D/test1.cpp
@@ -4566,8 +4566,7 @@ int main() {
 #endif
 
   RDLog::InitLogs();
-  testGithub2931();
-#if 0
+#if 1
   test1();
   test2();
   test4();

--- a/Code/GraphMol/MolDraw2D/test1.cpp
+++ b/Code/GraphMol/MolDraw2D/test1.cpp
@@ -147,10 +147,10 @@ static const std::map<std::string, std::hash_result_t> SVG_HASHES = {
     {"testGithub2151_1.svg", 3638120408U},
     {"testGithub2151_2.svg", 3354257096U},
     {"testGithub2762.svg", 168469294U},
-    {"testGithub2931_1.svg", 2109725713U},
+    {"testGithub2931_1.svg", 2194602666U},
     {"testGithub2931_2.svg", 1835479975U},
-    {"testGithub2931_3.svg", 2732370976U},
-    {"testGithub2931_4.svg", 1385168253U},
+    {"testGithub2931_3.svg", 100069870U},
+    {"testGithub2931_4.svg", 2053973281U},
     {"test20_1.svg", 2394223373U},
     {"test20_2.svg", 3739838435U},
     {"test20_3.svg", 2641474171U},
@@ -278,10 +278,10 @@ static const std::map<std::string, std::hash_result_t> SVG_HASHES = {
     {"testGithub2151_1.svg", 519358907U},
     {"testGithub2151_2.svg", 3102378492U},
     {"testGithub2762.svg", 2006115844U},
-    {"testGithub2931_1.svg", 1336382290U},
+    {"testGithub2931_1.svg", 349557903U},
     {"testGithub2931_2.svg", 190801508U},
-    {"testGithub2931_3.svg", 3645106237U},
-    {"testGithub2931_4.svg", 314627078U},
+    {"testGithub2931_3.svg", 4188693107U},
+    {"testGithub2931_4.svg", 639496462U},
     {"test20_1.svg", 2324941307U},
     {"test20_2.svg", 457598277U},
     {"test20_3.svg", 1187217942U},
@@ -359,7 +359,7 @@ using namespace RDKit;
 // if the generated SVG hashes to the value we're expecting, delete
 // the file.  That way, only the files that need inspection will be
 // left at the end of the run.
-static const bool DELETE_WITH_GOOD_HASH = true;
+static const bool DELETE_WITH_GOOD_HASH = false;
 
 std::hash_result_t hash_file(const std::string &filename) {
   std::ifstream ifs(filename, std::ios_base::binary);

--- a/Code/GraphMol/MolDraw2D/test1.cpp
+++ b/Code/GraphMol/MolDraw2D/test1.cpp
@@ -147,10 +147,10 @@ static const std::map<std::string, std::hash_result_t> SVG_HASHES = {
     {"testGithub2151_1.svg", 3638120408U},
     {"testGithub2151_2.svg", 3354257096U},
     {"testGithub2762.svg", 168469294U},
-    {"testGithub2931_1.svg", 2194602666U},
-    {"testGithub2931_2.svg", 1835479975U},
-    {"testGithub2931_3.svg", 100069870U},
-    {"testGithub2931_4.svg", 2053973281U},
+    {"testGithub2931_1.svg", 1680082130U},
+    {"testGithub2931_2.svg", 1398841536U},
+    {"testGithub2931_3.svg", 1556934255U},
+    {"testGithub2931_4.svg", 400761615U},
     {"test20_1.svg", 2394223373U},
     {"test20_2.svg", 3739838435U},
     {"test20_3.svg", 2641474171U},
@@ -278,10 +278,10 @@ static const std::map<std::string, std::hash_result_t> SVG_HASHES = {
     {"testGithub2151_1.svg", 519358907U},
     {"testGithub2151_2.svg", 3102378492U},
     {"testGithub2762.svg", 2006115844U},
-    {"testGithub2931_1.svg", 349557903U},
-    {"testGithub2931_2.svg", 190801508U},
-    {"testGithub2931_3.svg", 4188693107U},
-    {"testGithub2931_4.svg", 639496462U},
+    {"testGithub2931_1.svg", 1577747483U},
+    {"testGithub2931_2.svg", 956220378U},
+    {"testGithub2931_3.svg", 339061924U},
+    {"testGithub2931_4.svg", 252908291U},
     {"test20_1.svg", 2324941307U},
     {"test20_2.svg", 457598277U},
     {"test20_3.svg", 1187217942U},
@@ -3024,7 +3024,7 @@ void test15ContinuousHighlightingWithGrid() {
       outs.flush();
       outs.close();
       check_file_hash("test15_2.svg");
-      TEST_ASSERT(text.find("stroke:#FF7F7F;stroke-width:4.3px") !=
+      TEST_ASSERT(text.find("stroke:#FF7F7F;stroke-width:4.4px") !=
                   std::string::npos);
     }
     for (auto &&mol : mols) {
@@ -3686,7 +3686,7 @@ void testGithub2931() {
       TEST_ASSERT(text.find("stroke:#FF8C00;stroke-width:8.0px") !=
                   std::string::npos);
       TEST_ASSERT(
-          text.find("<ellipse cx='242.6' cy='348.6' rx='9.9' ry='10.1' "
+          text.find("<ellipse cx='240.2' cy='347.7' rx='12.3' ry='12.7' "
                     "class='atom-6'  style='fill:none;stroke:#00FF00;") !=
           std::string::npos);
 #endif
@@ -3694,8 +3694,8 @@ void testGithub2931() {
       TEST_ASSERT(text.find("stroke:#FF8C00;stroke-width:8.0px") !=
                   std::string::npos);
       TEST_ASSERT(
-          text.find("<ellipse cx='242.6' cy='297.0' rx='9.8' ry='9.8' "
-                    "class='atom-5'  style='fill:none;stroke:#00FF00;") !=
+          text.find("<ellipse cx='240.6' cy='295.4' rx='12.4' ry='12.4' "
+                    "class='atom-5'  style='fill:none;stroke:#00FF00") !=
           std::string::npos);
 #endif
       check_file_hash("testGithub2931_1.svg");
@@ -3718,7 +3718,7 @@ void testGithub2931() {
       TEST_ASSERT(text.find("stroke:#FF8C00;stroke-width:8.0px") !=
                   std::string::npos);
       TEST_ASSERT(
-          text.find("<ellipse cx='242.6' cy='348.2' rx='9.9' ry='9.9' "
+          text.find("<ellipse cx='240.2' cy='347.6' rx='12.5' ry='12.5' "
                     "class='atom-6'  style='fill:none;stroke:#00FF00;") !=
           std::string::npos);
 #endif
@@ -3726,7 +3726,7 @@ void testGithub2931() {
       TEST_ASSERT(text.find("stroke:#FF8C00;stroke-width:8.0px") !=
                   std::string::npos);
       TEST_ASSERT(
-          text.find("<ellipse cx='242.6' cy='296.7' rx='9.8' ry='9.8' "
+          text.find("<ellipse cx='240.6' cy='295.4' rx='12.4' ry='12.4' "
                     "class='atom-5'  style='fill:none;stroke:#00FF00;") !=
           std::string::npos);
 #endif
@@ -3756,7 +3756,7 @@ void testGithub2931() {
       TEST_ASSERT(text.find("stroke:#FF8C00;stroke-width:40.0px") !=
                   std::string::npos);
       TEST_ASSERT(
-          text.find("<ellipse cx='242.6' cy='297.0' rx='9.8' ry='9.8' "
+          text.find("<ellipse cx='240.6' cy='295.4' rx='12.4' ry='12.4' "
                     "class='atom-5'  style='fill:none;stroke:#00FF00;") !=
           std::string::npos);
 #endif
@@ -3767,6 +3767,8 @@ void testGithub2931() {
       drawer.drawOptions().fillHighlights = false;
       drawer.drawOptions().continuousHighlight = true;
       drawer.drawOptions().fixedFontSize = 10;
+      drawer.drawOptions().addAtomIndices = true;
+      drawer.drawOptions().addBondIndices = true;
       drawer.drawMoleculeWithHighlights(*m, "Test 4", ha_map, hb_map, h_rads,
                                         h_lw_mult);
       drawer.finishDrawing();
@@ -3780,7 +3782,7 @@ void testGithub2931() {
       TEST_ASSERT(text.find("stroke:#FF8C00;stroke-width:8.0px") !=
                   std::string::npos);
       TEST_ASSERT(
-          text.find("<ellipse cx='242.6' cy='348.6' rx='9.9' ry='9.9' "
+          text.find("<ellipse cx='246.6' cy='340.2' rx='11.7' ry='11.7' "
                     "class='atom-6'  style='fill:none;stroke:#00FF00;") !=
           std::string::npos);
 #endif
@@ -3788,8 +3790,8 @@ void testGithub2931() {
       TEST_ASSERT(text.find("stroke:#FF8C00;stroke-width:8.0px") !=
                   std::string::npos);
       TEST_ASSERT(
-          text.find("<ellipse cx='242.6' cy='297.4' rx='9.8' ry='9.8' "
-                    "class='atom-5'  style='fill:none;stroke:#00FF00;") !=
+          text.find("<ellipse cx='247.7' cy='292.7' rx='11.7' ry='11.7' "
+                    "class='atom-5'  style='fill:none;stroke:#00FF00") !=
           std::string::npos);
 #endif
       check_file_hash("testGithub2931_4.svg");

--- a/Code/GraphMol/MolDraw2D/test1.cpp
+++ b/Code/GraphMol/MolDraw2D/test1.cpp
@@ -147,9 +147,10 @@ static const std::map<std::string, std::hash_result_t> SVG_HASHES = {
     {"testGithub2151_1.svg", 3638120408U},
     {"testGithub2151_2.svg", 3354257096U},
     {"testGithub2762.svg", 168469294U},
-    {"testGithub2931_1.svg", 298969290U},
-    {"testGithub2931_2.svg", 922872904U},
-    {"testGithub2931_3.svg", 2823954159U},
+    {"testGithub2931_1.svg", 2109725713U},
+    {"testGithub2931_2.svg", 1835479975U},
+    {"testGithub2931_3.svg", 2732370976U},
+    {"testGithub2931_4.svg", 1385168253U},
     {"test20_1.svg", 2394223373U},
     {"test20_2.svg", 3739838435U},
     {"test20_3.svg", 2641474171U},
@@ -277,9 +278,10 @@ static const std::map<std::string, std::hash_result_t> SVG_HASHES = {
     {"testGithub2151_1.svg", 519358907U},
     {"testGithub2151_2.svg", 3102378492U},
     {"testGithub2762.svg", 2006115844U},
-    {"testGithub2931_1.svg", 3001628989U},
-    {"testGithub2931_2.svg", 3664574077U},
-    {"testGithub2931_3.svg", 35507527U},
+    {"testGithub2931_1.svg", 1336382290U},
+    {"testGithub2931_2.svg", 190801508U},
+    {"testGithub2931_3.svg", 3645106237U},
+    {"testGithub2931_4.svg", 314627078U},
     {"test20_1.svg", 2324941307U},
     {"test20_2.svg", 457598277U},
     {"test20_3.svg", 1187217942U},
@@ -3647,7 +3649,6 @@ void testGithub2931() {
       }
     }
   };
-
   {
     std::string smiles = "CO[C@@H](O)C1=C(O[C@H](F)Cl)C(C#N)=C1ONNC[NH3+]";
     std::unique_ptr<ROMol> m(SmilesToMol(smiles));
@@ -3760,6 +3761,38 @@ void testGithub2931() {
           std::string::npos);
 #endif
       check_file_hash("testGithub2931_3.svg");
+    }
+    {
+      MolDraw2DSVG drawer(500, 500);
+      drawer.drawOptions().fillHighlights = false;
+      drawer.drawOptions().continuousHighlight = true;
+      drawer.drawOptions().fixedFontSize = 10;
+      drawer.drawMoleculeWithHighlights(*m, "Test 4", ha_map, hb_map, h_rads,
+                                        h_lw_mult);
+      drawer.finishDrawing();
+      std::string text = drawer.getDrawingText();
+      std::ofstream outs("testGithub2931_4.svg");
+      outs << text;
+      outs.flush();
+      outs.close();
+#ifdef RDK_BUILD_FREETYPE_SUPPORT
+#if DO_TEST_ASSERT
+      TEST_ASSERT(text.find("stroke:#FF8C00;stroke-width:8.0px") !=
+                  std::string::npos);
+      TEST_ASSERT(
+          text.find("<ellipse cx='242.6' cy='348.6' rx='9.9' ry='9.9' "
+                    "class='atom-6'  style='fill:none;stroke:#00FF00;") !=
+          std::string::npos);
+#endif
+#else
+      TEST_ASSERT(text.find("stroke:#FF8C00;stroke-width:8.0px") !=
+                  std::string::npos);
+      TEST_ASSERT(
+          text.find("<ellipse cx='242.6' cy='297.4' rx='9.8' ry='9.8' "
+                    "class='atom-5'  style='fill:none;stroke:#00FF00;") !=
+          std::string::npos);
+#endif
+      check_file_hash("testGithub2931_4.svg");
     }
   }
   std::cerr << " Done" << std::endl;
@@ -4533,8 +4566,8 @@ int main() {
 #endif
 
   RDLog::InitLogs();
-
-#if 1
+  testGithub2931();
+#if 0
   test1();
   test2();
   test4();

--- a/Code/GraphMol/MolDraw2D/test1.cpp
+++ b/Code/GraphMol/MolDraw2D/test1.cpp
@@ -359,7 +359,7 @@ using namespace RDKit;
 // if the generated SVG hashes to the value we're expecting, delete
 // the file.  That way, only the files that need inspection will be
 // left at the end of the run.
-static const bool DELETE_WITH_GOOD_HASH = false;
+static const bool DELETE_WITH_GOOD_HASH = true;
 
 std::hash_result_t hash_file(const std::string &filename) {
   std::ifstream ifs(filename, std::ios_base::binary);

--- a/rdkit/Chem/Draw/UnitTestDraw.py
+++ b/rdkit/Chem/Draw/UnitTestDraw.py
@@ -276,8 +276,8 @@ class TestCase(unittest.TestCase):
     svg2 = Draw._moltoSVG(m, (250, 200), ats, "", False, highlightBonds=[])
     # there are minor differences between the freetype and non-freetype versions:
     if '>O<' not in svg1:
-      self.assertIn('stroke:#FF7F7F;stroke-width:20', svg1)
-      self.assertNotIn('stroke:#FF7F7F;stroke-width:20', svg2)
+      self.assertIn('stroke:#FF7F7F;stroke-width:18', svg1)
+      self.assertNotIn('stroke:#FF7F7F;stroke-width:18', svg2)
     else:
       self.assertIn('stroke:#FF7F7F;stroke-width:18', svg1)
       self.assertNotIn('stroke:#FF7F7F;stroke-width:18', svg2)

--- a/rdkit/Chem/Draw/UnitTestDraw.py
+++ b/rdkit/Chem/Draw/UnitTestDraw.py
@@ -279,8 +279,8 @@ class TestCase(unittest.TestCase):
       self.assertIn('stroke:#FF7F7F;stroke-width:20', svg1)
       self.assertNotIn('stroke:#FF7F7F;stroke-width:20', svg2)
     else:
-      self.assertIn('stroke:#FF7F7F;stroke-width:19', svg1)
-      self.assertNotIn('stroke:#FF7F7F;stroke-width:19', svg2)
+      self.assertIn('stroke:#FF7F7F;stroke-width:18', svg1)
+      self.assertNotIn('stroke:#FF7F7F;stroke-width:18', svg2)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
#### Reference Issue
Fixes #5420


#### What does this implement/fix? Explain your changes.
The bond highlights were sometimes missing the atom highlights and the fallback position was incorrect.
Fallback now correct.
The miss was occurring in the test case because the atom highlight wasn't centred on the atom, it was centred on the centre of the atom label which for a multiple character label was off to one side.  It now uses the label centre.  Only really an issue with small fonts.

#### Any other comments?
Using the label centre now means that the bond highlights aren't always parallel with the bond, but I think that's ok.  The alternative would be to make them narrower, so they still went parallel to the bond but hit the atom highlight very much off-centre.  That could be done, but would look differently messy, I think.  It's an edge case.
