### PR TITLE
Fixes #5423

### DIFF
--- a/Code/GraphMol/FileParsers/MolFileParser.cpp
+++ b/Code/GraphMol/FileParsers/MolFileParser.cpp
@@ -2955,6 +2955,7 @@ void ProcessMolProps(RWMol *mol) {
           atom->setNumExplicitHs(ival - atom->getExplicitValence());
         }
       }
+      atom->clearProp(common_properties::molTotValence);
     }
   }
   processSGroups(mol);

--- a/Code/GraphMol/FileParsers/MolFileParser.cpp
+++ b/Code/GraphMol/FileParsers/MolFileParser.cpp
@@ -2955,8 +2955,8 @@ void ProcessMolProps(RWMol *mol) {
           atom->setNumExplicitHs(ival - atom->getExplicitValence());
         }
       }
-      atom->clearProp(common_properties::molTotValence);
     }
+    atom->clearProp(common_properties::molTotValence);
   }
   processSGroups(mol);
 }

--- a/Code/GraphMol/FileParsers/file_parsers_catch.cpp
+++ b/Code/GraphMol/FileParsers/file_parsers_catch.cpp
@@ -5015,3 +5015,21 @@ M  END
     CHECK(m->getBondWithIdx(2)->getBondDir() == Bond::BondDir::BEGINWEDGE);
   }
 }
+
+TEST_CASE(
+    "GitHub Issue #5423: Parsing a Mol block/file does not clear the "
+    "\"molTotValence\" property from atoms") {
+  auto m = R"CTAB(
+     RDKit          2D
+
+  0  0  0  0  0  0  0  0  0  0999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 1 0 0 0 0
+M  V30 BEGIN ATOM
+M  V30 1 N -3.657143 -0.742857 0.000000 0 CHG=1 VAL=4
+M  V30 END ATOM
+M  V30 END CTAB
+M  END)CTAB"_ctab;
+  REQUIRE(m);
+  CHECK(!m->getAtomWithIdx(0)->hasProp(common_properties::molTotValence));
+}


### PR DESCRIPTION
This addresses #5423 by clearing the `molTotValence` after it has been used to adjust H on the atom with the property.

