### PR TITLE
fix: specify static member variable `PrintThread::cout_mutex` inline (C++17)

### DIFF
--- a/Code/GraphMol/FileParsers/testMultithreadedMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/testMultithreadedMolSupplier.cpp
@@ -30,7 +30,7 @@ using namespace std::chrono;
 // thread safe printing for debugging
 // Usage Example: PrintThread{} << "something";
 struct PrintThread : public std::stringstream {
-  static std::mutex cout_mutex;
+  inline static std::mutex cout_mutex;
   ~PrintThread() override {
     std::lock_guard<std::mutex> l{cout_mutex};
     std::cout << rdbuf();


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! 
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->

closes #5351

#### What does this implement/fix? Explain your changes.
[`PrintThread::cout_mutex`](https://github.com/rdkit/rdkit/blob/9fa1df1cf6380a03bddb9b176dd4c9b1c0ac35af/Code/GraphMol/FileParsers/testMultithreadedMolSupplier.cpp#L30-L38) misses its definition, which results in linkage error (#5351).

A conventional alternative is:
```diff
--- a/Code/GraphMol/FileParsers/testMultithreadedMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/testMultithreadedMolSupplier.cpp
@@ -37,6 +37,8 @@ struct PrintThread : public std::stringstream {
   }
 };
 
+std::mutex PrintThread::cout_mutex;
+
 void testSmiConcurrent(std::istream *strm, bool takeOwnership,
                        std::string delimiter, int smilesColumn, int nameColumn,
                        bool titleLine, bool sanitize,
```


#### Any other comments?

Off-topic: `std::stringstream::~stringstream` is not `virtual`.