### PR TITLE
Fixes #5395

### DIFF
--- a/Code/GraphMol/Wrap/MolOps.cpp
+++ b/Code/GraphMol/Wrap/MolOps.cpp
@@ -305,10 +305,11 @@ ROMol *addHs(const ROMol &orig, bool explicitOnly, bool addCoords,
                              addResidueInfo);
   return res;
 }
-int getSSSR(ROMol &mol) {
+
+VECT_INT_VECT getSSSR(ROMol &mol) {
   VECT_INT_VECT rings;
-  int nr = MolOps::findSSSR(mol, rings);
-  return nr;
+  MolOps::findSSSR(mol, rings);
+  return rings;
 }
 
 PyObject *replaceSubstructures(const ROMol &orig, const ROMol &query,
@@ -2230,7 +2231,8 @@ ARGUMENTS:\n\
 \n";
     python::def("WedgeMolBonds", WedgeMolBonds, docString.c_str());
 
-    docString = "Set the wedging to that which was read from the original\n\
+    docString =
+        "Set the wedging to that which was read from the original\n\
      MolBlock, over-riding anything that was originally there.\n\
 \n\
           ARGUMENTS:\n\
@@ -2238,7 +2240,8 @@ ARGUMENTS:\n\
             - molecule: the molecule to update\n\
         \n\
         \n";
-    python::def("ReapplyMolBlockWedging", reapplyMolBlockWedging, docString.c_str());
+    python::def("ReapplyMolBlockWedging", reapplyMolBlockWedging,
+                docString.c_str());
     docString =
         R"DOC(Constants used to set the thresholds for which single bonds can be made wavy.)DOC";
     python::class_<StereoBondThresholds>("StereoBondThresholds",

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -346,7 +346,8 @@ class TestCase(unittest.TestCase):
     smi = Chem.MolToSmiles(mol)
     Chem.SanitizeMol(mol)
     nr = Chem.GetSymmSSSR(mol)
-
+    self.assertTrue((len(nr) == 3))
+    nr = Chem.GetSSSR(mol)
     self.assertTrue((len(nr) == 3))
 
   def test12Smarts(self):

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -14,7 +14,9 @@
   - `BUILD_COORDGEN_SUPPORT`: use `RDK_BUILD_COORDGEN_SUPPORT` instead
   - `RDK_THREADSAFE_SSS`: use `RDK_BUILD_THREADSAFE_SSS` instead
   - `USE_BUILTIN_POPCOUNT`: use `RDK_OPTIMIZE_POPCNT` instead
-
+- The Python function `Chem.GetSSSR()` now returns the SSSR rings found instead
+  of just returning the count of rings. This is consistent with
+  `Chem.GetSymmSSSR()` and more useful.
 
 
 

--- a/rdkit/Chem/QED.py
+++ b/rdkit/Chem/QED.py
@@ -255,7 +255,7 @@ def properties(mol):
     HBD=rdmd.CalcNumHBD(mol),
     PSA=MolSurf.TPSA(mol),
     ROTB=rdmd.CalcNumRotatableBonds(mol, rdmd.NumRotatableBondsOptions.Strict),
-    AROM=Chem.GetSSSR(Chem.DeleteSubstructs(Chem.Mol(mol), AliphaticRings)),
+    AROM=len(Chem.GetSSSR(Chem.DeleteSubstructs(Chem.Mol(mol), AliphaticRings))),
     ALERTS=sum(1 for alert in StructuralAlerts if mol.HasSubstructMatch(alert)),
   )
   # The replacement


### PR DESCRIPTION
This is a small change.
It does change the return type of `Chem.GetSSSR()` in order to make it consistent with `Chem.GetSymmSSSR()`. I think the consistency is good and that the new return value is more useful.
I added a backwards incompatibility note to the Release Notes about this