### PR TITLE
MolZip: add atom property labels for mol-zipping

### DIFF
--- a/Code/GraphMol/ChemTransforms/MolFragmenter.cpp
+++ b/Code/GraphMol/ChemTransforms/MolFragmenter.cpp
@@ -640,13 +640,15 @@ unsigned int get_label(const Atom *a, const MolzipParams &p) {
         return mapno ? mapno : NOLABEL;
       }
       break;
+
     case MolzipLabel::Isotope:
       if (a->getAtomicNum() == 0) {
         auto iso = a->getIsotope();
         return iso ? iso : NOLABEL;
       }
       break;
-    case MolzipLabel::AtomType: {
+
+    case MolzipLabel::AtomType:
       idx = std::distance(p.atomSymbols.begin(),
                           std::find(p.atomSymbols.begin(), p.atomSymbols.end(),
                                     a->getSymbol()));
@@ -654,14 +656,19 @@ unsigned int get_label(const Atom *a, const MolzipParams &p) {
         idx = NOLABEL;
       }
       break;
-      case MolzipLabel::FragmentOnBonds:
+  
+    case MolzipLabel::FragmentOnBonds: 
         // shouldn't ever get here
         CHECK_INVARIANT(
             0, "FragmentOnBonds is not an atom label, it is an atom index");
         break;
-      default:
+	
+    case MolzipLabel::AtomProperty:
+        a->getPropIfPresent<unsigned int>(p.atomProperty, idx);
+        break;
+
+    default:
         CHECK_INVARIANT(0, "bogus MolZipLabel value in MolZip::get_label");
-    }
   }
   return idx;
 }

--- a/Code/GraphMol/ChemTransforms/MolFragmenter.h
+++ b/Code/GraphMol/ChemTransforms/MolFragmenter.h
@@ -101,11 +101,13 @@ RDKIT_CHEMTRANSFORMS_EXPORT void constructBRICSBondTypes(
     std::vector<FragmenterBondType> &defs);
 }  // namespace MolFragmenter
 
-enum class MolzipLabel { AtomMapNumber, Isotope, FragmentOnBonds, AtomType };
+// n.b. AtomProperty must resolve to an unsigned integer value on an atom property
+enum class MolzipLabel { AtomMapNumber, Isotope, FragmentOnBonds, AtomType, AtomProperty };
 
 struct RDKIT_CHEMTRANSFORMS_EXPORT MolzipParams {
   MolzipLabel label = MolzipLabel::AtomMapNumber;
   std::vector<std::string> atomSymbols;
+  std::string atomProperty;
   bool enforceValenceRules=true;
 };
 

--- a/Code/GraphMol/ChemTransforms/catch_tests.cpp
+++ b/Code/GraphMol/ChemTransforms/catch_tests.cpp
@@ -246,6 +246,21 @@ TEST_CASE("molzip", "[]") {
     }
   }
 
+  SECTION("use atom property as label") {
+    auto a = "[C@H]([*])(F)([*])"_smiles;
+    auto b = "[*]N.[*]I"_smiles;
+    a->getAtomWithIdx(1)->setProp<unsigned int>("foo", 1);
+    a->getAtomWithIdx(3)->setProp<unsigned int>("foo", 2);
+    b->getAtomWithIdx(0)->setProp<unsigned int>("foo", 1);
+    b->getAtomWithIdx(2)->setProp<unsigned int>("foo", 2);
+    MolzipParams p;
+    p.label = MolzipLabel::AtomProperty;
+    p.atomProperty = "foo";
+    auto mol = molzip(*a, *b, p);
+    // chirality is "lost" here because [C@H]([*])(F)([*]) is considered achiral
+    CHECK(MolToSmiles(*mol) == "NC(F)I");
+  }
+  
   SECTION("test bond stereo") {
     auto a = "F/C=C/[*:1]"_smiles;
     auto b = "[*:1]F"_smiles;


### PR DESCRIPTION
Implements #5451 

This adds an option to allow unsigned integer (and integer) properties atom labels to indicate which atoms should be zipped together.

This will be primarily used in the cdxml parser.