### PR TITLE
Fix poor join between wedge and double bond.

### DIFF
--- a/Code/GraphMol/MolDraw2D/DrawMol.cpp
+++ b/Code/GraphMol/MolDraw2D/DrawMol.cpp
@@ -2836,9 +2836,6 @@ void DrawMol::findOtherBondVecs(const Atom *atom, const Atom *otherAtom,
     auto thirdAtom = otherNeighbor(atom, otherAtom, i - 1, *drawMol_);
     auto bond =
         drawMol_->getBondBetweenAtoms(atom->getIdx(), thirdAtom->getIdx());
-    if (bond->getBondType() == Bond::DOUBLE && thirdAtom->getDegree() == 1) {
-      continue;
-    }
     Point2D const &at1_cds = atCds_[atom->getIdx()];
     Point2D const &at2_cds = atCds_[thirdAtom->getIdx()];
     otherBondVecs.push_back(at1_cds.directionVector(at2_cds));

--- a/Code/GraphMol/MolDraw2D/catch_tests.cpp
+++ b/Code/GraphMol/MolDraw2D/catch_tests.cpp
@@ -227,7 +227,7 @@ static const std::map<std::string, std::hash_result_t> SVG_HASHES = {
     {"acs1996_6.svg", 4274355858U},
     {"acs1996_7.svg", 3684177026U},
     {"acs1996_8.svg", 2032371436U},
-    {"acs1996_9.svg", 1609810716U},
+    {"acs1996_9.svg", 2784034866U},
     {"acs1996_10.svg", 786861825U},
     {"acs1996_11.svg", 3065465046U},
     {"test_unspec_stereo.svg", 599119798U},
@@ -5166,7 +5166,7 @@ M  END
       check_file_hash(nameBase + "8.svg");
     }
 #endif
-#if 9
+#if 1
     {
       auto m = R"CTAB(mol9
   ChemDraw06302215142D
@@ -5229,6 +5229,7 @@ M  END
 )CTAB"_ctab;
       REQUIRE(m);
       MolDraw2DSVG drawer(-1, -1);
+      drawer.drawOptions().useMolBlockWedging = true;
       MolDraw2DUtils::drawMolACS1996(drawer, *m, "Mol 9", nullptr, nullptr);
       drawer.finishDrawing();
       std::string text = drawer.getDrawingText();


### PR DESCRIPTION
#### Reference Issue
No issue to reference


#### What does this implement/fix? Explain your changes.
The new drawing code from #5425 did a very poor job joining a wedged bond to a double bond, as seen in acs1996_9.svg.  This fixes that.

#### Any other comments?
