### PR TITLE
Fix integer overflow in RGroupDecomposition strategy GA

### DIFF
--- a/Code/GraphMol/RGroupDecomposition/RGroupGa.cpp
+++ b/Code/GraphMol/RGroupDecomposition/RGroupGa.cpp
@@ -110,9 +110,7 @@ RGroupGa::RGroupGa(const RGroupDecompData& rGroupData,
     }
     chromosomePolicy.setMax(pos, m.size());
     unsigned long count = numPermutations * m.size();
-    numPermutations = count < numeric_limits<unsigned int>::max() && count / m.size() == numPermutations
-                          ? count
-                          : numeric_limits<unsigned int>::max();
+    numPermutations = std::min(count, static_cast<unsigned long>(numeric_limits<unsigned int>::max()));
     pos++;
   }
   chromLength = pos;

--- a/Code/GraphMol/RGroupDecomposition/RGroupGa.cpp
+++ b/Code/GraphMol/RGroupDecomposition/RGroupGa.cpp
@@ -110,7 +110,7 @@ RGroupGa::RGroupGa(const RGroupDecompData& rGroupData,
     }
     chromosomePolicy.setMax(pos, m.size());
     unsigned long count = numPermutations * m.size();
-    numPermutations = count / m.size() == numPermutations
+    numPermutations = count < numeric_limits<unsigned int>::max() && count / m.size() == numPermutations
                           ? count
                           : numeric_limits<unsigned int>::max();
     pos++;


### PR DESCRIPTION
This fix an issue where the number of permutations would overflow in the GA and be set to 0.

This caused the code to fallback to the Exhaustive search which basically hangs at this point.