### PR TITLE
Fix double to float downcasting warning

### DIFF
--- a/External/CoordGen/CoordGen.h
+++ b/External/CoordGen/CoordGen.h
@@ -22,7 +22,7 @@ namespace RDKit {
 namespace CoordGen {
 
 struct CoordGenParams {
-  const float sketcherCoarsePrecision = 0.01;
+  const float sketcherCoarsePrecision = 0.01f;
   const float sketcherStandardPrecision = SKETCHER_STANDARD_PRECISION;
   const float sketcherBestPrecision = SKETCHER_BEST_PRECISION;
   const float sketcherQuickPrecision = SKETCHER_QUICK_PRECISION;


### PR DESCRIPTION
Not a big issue, but the Visual Studio compiler raises a C4305 warning when using this header. If anyone includes this header while building with the `/WX` flag (treat all compiler warnings as errors), the build will fail.

The cause of the issue is that we are using a literal double value to initialize a float value, which counts as downcasting. Making the value a literal float fixes the issue.
