### PR TITLE
Remove spurious doxygen tag

### DIFF
--- a/Code/GraphMol/Wrap/MolOps.cpp
+++ b/Code/GraphMol/Wrap/MolOps.cpp
@@ -1949,7 +1949,7 @@ to the terminal dummy atoms.\n\
   a 3D conformation.\n\
   NOTE that this does not check to see if atoms are chiral centers (i.e. all\n\
   substituents are different), it merely sets the chiral type flags based on the\n\
-  coordinates and atom ordering. Use \c AssignStereochemistryFrom3D() if you\n\
+  coordinates and atom ordering. Use AssignStereochemistryFrom3D() if you\n\
   want chiral flags only on actual stereocenters.\n\
 \n\
   ARGUMENTS:\n\


### PR DESCRIPTION
I noticed a warning during compilation caused by a spurious `\c` tag in a Python docstring.
This PR removes it.