### PR TITLE
Add deprecation warning to docstring.

### DIFF
--- a/rdkit/Chem/MCS.py
+++ b/rdkit/Chem/MCS.py
@@ -273,6 +273,11 @@ def FindMCS(mols,
             threshold=None, ):
   """Find the maximum common substructure of a set of molecules
 
+    ***************************************************
+    NB: rdkit.Chem.MCS module is deprecated; please use
+    rdkit.Chem.rdFMCS instead.
+    ***************************************************
+
     In the simplest case, pass in a list of molecules and get back
     an MCSResult object which describes the MCS:
 


### PR DESCRIPTION

#### Reference Issue
None

#### What does this implement/fix? Explain your changes.
Adds the deprecation warning to the MCS.py docstring.

#### Any other comments?
It's the first hit when you google "RDKit mcs" and it's a bit irritating when you start using it and have your IDE tell you it's deprecated.
