### PR TITLE
MolDraw2D::drawMolecules() should not crash on null molecules

### DIFF
--- a/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
@@ -191,6 +191,7 @@ void MolDraw2D::drawMolecules(
   int nCols = width() / panelWidth();
   int nRows = height() / panelHeight();
 
+  size_t j = 0;
   for (size_t i = 0; i < mols.size(); ++i) {
     if (!mols[i]) {
       continue;
@@ -231,12 +232,13 @@ void MolDraw2D::drawMolecules(
     drawMols_.back()->setOffsets(col * panelWidth(), row * panelHeight());
     drawMols_.back()->createDrawObjects();
     if (drawMols_.back()->getScale() < drawMols_[minScaleMol]->getScale()) {
-      minScaleMol = i;
+      minScaleMol = j;
     }
     if (drawMols_.back()->getFontScale() <
         drawMols_[minFontScaleMol]->getFontScale()) {
-      minFontScaleMol = i;
+      minFontScaleMol = j;
     }
+    ++j;
   }
 
   for (auto &drawMol : drawMols_) {

--- a/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
@@ -191,7 +191,6 @@ void MolDraw2D::drawMolecules(
   int nCols = width() / panelWidth();
   int nRows = height() / panelHeight();
 
-  size_t j = 0;
   for (size_t i = 0; i < mols.size(); ++i) {
     if (!mols[i]) {
       continue;
@@ -214,7 +213,7 @@ void MolDraw2D::drawMolecules(
       MolDraw2D_detail::getBondHighlightsForAtoms(
           *mols[i], (*highlight_atoms)[i], *lhighlight_bonds);
     };
-
+    auto prevSize = drawMols_.size();
     drawMols_.emplace_back(new MolDraw2D_detail::DrawMol(
         *mols[i], legend, panelWidth(), panelHeight(), drawOptions(),
         *text_drawer_, ha, lhighlight_bonds.get(), ham, hbm, nullptr, hr,
@@ -232,13 +231,12 @@ void MolDraw2D::drawMolecules(
     drawMols_.back()->setOffsets(col * panelWidth(), row * panelHeight());
     drawMols_.back()->createDrawObjects();
     if (drawMols_.back()->getScale() < drawMols_[minScaleMol]->getScale()) {
-      minScaleMol = j;
+      minScaleMol = prevSize;
     }
     if (drawMols_.back()->getFontScale() <
         drawMols_[minFontScaleMol]->getFontScale()) {
-      minFontScaleMol = j;
+      minFontScaleMol = prevSize;
     }
-    ++j;
   }
 
   for (auto &drawMol : drawMols_) {

--- a/Code/GraphMol/MolDraw2D/catch_tests.cpp
+++ b/Code/GraphMol/MolDraw2D/catch_tests.cpp
@@ -5427,3 +5427,24 @@ TEST_CASE("Colour H light blue with no atom labels", "") {
     REQUIRE(regex1Match.size() == 1);
     check_file_hash("light_blue_h_no_label_1.svg");
 }
+
+TEST_CASE("drawMolecules should not crash on null molecules",
+          "[drawing][bug]") {
+  auto m1 = "c1ccccc1"_smiles;
+  auto m2 = "c1ccncc1"_smiles;
+  REQUIRE(m1);
+  REQUIRE(m2);
+  MolDraw2DSVG drawer(1000, 200, 100, 100, NO_FREETYPE);
+  RWMol dm1(*m1);
+  RWMol dm2(*m2);
+  MOL_PTR_VECT ms{&dm1,    nullptr, nullptr, nullptr, nullptr, nullptr,
+                  nullptr, nullptr, nullptr, nullptr, &dm2};
+  drawer.drawMolecules(ms);
+  drawer.finishDrawing();
+  auto text = drawer.getDrawingText();
+  std::regex regex1("<path d=");
+  auto nMatches =
+      std::distance(std::sregex_iterator(text.begin(), text.end(), regex1),
+                    std::sregex_iterator());
+  REQUIRE(nMatches == 11);
+}


### PR DESCRIPTION
This bug was originally reported by Richard Lewis.
`MolDraw2D::drawMolecules()` under certain conditions will attempt to access non-existent vector items and hence segfault.
This simple PR fixes the problem and adds a test.