### PR TITLE
Add Substance Groups and Stereo Groups to debugMol()

### DIFF
--- a/Code/GraphMol/ROMol.cpp
+++ b/Code/GraphMol/ROMol.cpp
@@ -479,6 +479,24 @@ void ROMol::debugMol(std::ostream &str) const {
   while (bondItP.first != bondItP.second) {
     str << "\t" << *d_graph[*(bondItP.first++)] << std::endl;
   }
+
+  const auto &sgs = getSubstanceGroups(*this);
+  if (!sgs.empty()) {
+    str << "Substance Groups:" << std::endl;
+    for (const auto &sg : sgs) {
+      str << "\t" << sg << std::endl;
+    }
+  }
+
+  const auto &stgs = getStereoGroups();
+  if (!stgs.empty()) {
+    unsigned idx = 0;
+    str << "Stereo Groups:" << std::endl;
+    for (const auto &stg : stgs) {
+      str << "\t" << idx << ' ' << stg << std::endl;
+      ++idx;
+    }
+  }
 }
 
 // --------------------------------------------

--- a/Code/GraphMol/StereoGroup.cpp
+++ b/Code/GraphMol/StereoGroup.cpp
@@ -1,6 +1,7 @@
 #include <algorithm>
 #include <utility>
 #include "StereoGroup.h"
+#include "Atom.h"
 
 namespace RDKit {
 
@@ -39,3 +40,24 @@ void removeGroupsWithAtoms(const std::vector<Atom *> &atoms,
 }
 
 }  // namespace RDKit
+
+std::ostream &operator<<(std::ostream &target, const RDKit::StereoGroup &stg) {
+  switch (stg.getGroupType()) {
+    case RDKit::StereoGroupType::STEREO_ABSOLUTE:
+      target << "ABS";
+      break;
+    case RDKit::StereoGroupType::STEREO_OR:
+      target << "OR";
+      break;
+    case RDKit::StereoGroupType::STEREO_AND:
+      target << "AND";
+      break;
+  }
+  target << " Atoms: { ";
+  for (auto atom : stg.getAtoms()) {
+    target << atom->getIdx() << ' ';
+  }
+  target << '}';
+
+  return target;
+}

--- a/Code/GraphMol/StereoGroup.h
+++ b/Code/GraphMol/StereoGroup.h
@@ -18,6 +18,7 @@
 #ifndef RD_StereoGroup_092018
 #define RD_StereoGroup_092018
 
+#include <iostream>
 #include <vector>
 
 namespace RDKit {
@@ -70,5 +71,9 @@ RDKIT_GRAPHMOL_EXPORT void removeGroupsWithAtoms(
     const std::vector<Atom*>& atoms, std::vector<StereoGroup>& groups);
 
 }  // namespace RDKit
+
+//! allows StereoGroup objects to be dumped to streams
+RDKIT_GRAPHMOL_EXPORT std::ostream& operator<<(std::ostream& target,
+                                               const RDKit::StereoGroup& stg);
 
 #endif

--- a/Code/GraphMol/SubstanceGroup.cpp
+++ b/Code/GraphMol/SubstanceGroup.cpp
@@ -24,7 +24,7 @@ void remove_element(std::vector<T> &container, unsigned int element) {
     container.erase(pos);
   }
 }
-}
+}  // namespace
 
 SubstanceGroup::SubstanceGroup(ROMol *owning_mol, const std::string &type)
     : RDProps(), dp_mol(owning_mol) {
@@ -448,5 +448,48 @@ std::ostream &operator<<(std::ostream &target,
                          const RDKit::SubstanceGroup &sgroup) {
   target << sgroup.getIndexInMol() << ' '
          << sgroup.getProp<std::string>("TYPE");
+
+  auto brackets = sgroup.getBrackets();
+  if (!brackets.empty()) {
+    target << " Brk: " << brackets.size();
+  }
+
+  auto cstates = sgroup.getCStates();
+  if (!cstates.empty()) {
+    target << " CSt: " << cstates.size();
+  }
+
+  auto attachpts = sgroup.getAttachPoints();
+  if (!attachpts.empty()) {
+    target << " AtPt: " << attachpts.size();
+  }
+
+  auto atoms = sgroup.getAtoms();
+  if (!atoms.empty()) {
+    target << " Atoms: { ";
+    for (auto atom_idx : atoms) {
+      target << atom_idx << ' ';
+    }
+    target << '}';
+  }
+
+  auto patoms = sgroup.getParentAtoms();
+  if (!patoms.empty()) {
+    target << " PAtoms: { ";
+    for (auto atom_idx : patoms) {
+      target << atom_idx << ' ';
+    }
+    target << '}';
+  }
+
+  auto bonds = sgroup.getBonds();
+  if (!bonds.empty()) {
+    target << " Bonds: { ";
+    for (auto bond_idx : bonds) {
+      target << bond_idx << ' ';
+    }
+    target << '}';
+  }
+
   return target;
 }

--- a/Code/GraphMol/SubstanceGroup.h
+++ b/Code/GraphMol/SubstanceGroup.h
@@ -17,6 +17,7 @@
 #ifndef _RD_SGROUP_H
 #define _RD_SGROUP_H
 
+#include <iostream>
 #include <utility>
 #include <unordered_map>
 


### PR DESCRIPTION
I love `ROMol::debugMol()` and `Chem.Mol.Debug()`. They are very helpful in debugging, but sometimes they fall a bit short when debugging problems related to Substance Groups or Stereo Groups.

This PR adds printing some information about any Substance Groups or Stereo Groups present on the mol we are debugging.

A couple of examples, extracted from tests, of what we get with this patch (without it we just get Atoms and Bonds):

```python
smi = ("*-CNC(CC(-*)C-*)O-* "
       "|$star_e;;;;;;star_e;;star_e;;star_e$,"
       "SgD:4:internal data:val::::,SgD:7:atom value:value2::::,"
       "Sg:n:7::ht,Sg:n:2::ht,Sg:any:5,7,8,4,3,2,1,0,9::ht,"
       "SgH:4:2.3.0,2:1|")
m = Chem.MolFromSmiles(smi)
m.Debug()
-----------------------------------------------------------
Atoms:
	0 0 * chg: 0  deg: 1 exp: 1 imp: 0 hyb: 0 arom?: 0 chi: 0
	1 6 C chg: 0  deg: 2 exp: 2 imp: 2 hyb: 4 arom?: 0 chi: 0
	2 7 N chg: 0  deg: 2 exp: 2 imp: 1 hyb: 4 arom?: 0 chi: 0
	3 6 C chg: 0  deg: 3 exp: 3 imp: 1 hyb: 4 arom?: 0 chi: 0
	4 6 C chg: 0  deg: 2 exp: 2 imp: 2 hyb: 4 arom?: 0 chi: 0
	5 6 C chg: 0  deg: 3 exp: 3 imp: 1 hyb: 4 arom?: 0 chi: 0
	6 0 * chg: 0  deg: 1 exp: 1 imp: 0 hyb: 0 arom?: 0 chi: 0
	7 6 C chg: 0  deg: 2 exp: 2 imp: 2 hyb: 4 arom?: 0 chi: 0
	8 0 * chg: 0  deg: 1 exp: 1 imp: 0 hyb: 0 arom?: 0 chi: 0
	9 8 O chg: 0  deg: 2 exp: 2 imp: 0 hyb: 4 arom?: 0 chi: 0
	10 0 * chg: 0  deg: 1 exp: 1 imp: 0 hyb: 0 arom?: 0 chi: 0
Bonds:
	0 0->1 order: 1 conj?: 0 aromatic?: 0
	1 1->2 order: 1 conj?: 0 aromatic?: 0
	2 2->3 order: 1 conj?: 0 aromatic?: 0
	3 3->4 order: 1 conj?: 0 aromatic?: 0
	4 4->5 order: 1 conj?: 0 aromatic?: 0
	5 5->6 order: 1 conj?: 0 aromatic?: 0
	6 5->7 order: 1 conj?: 0 aromatic?: 0
	7 7->8 order: 1 conj?: 0 aromatic?: 0
	8 3->9 order: 1 conj?: 0 aromatic?: 0
	9 9->10 order: 1 conj?: 0 aromatic?: 0
Substance Groups:
	0 DAT Atoms: { 4 }
	1 DAT Atoms: { 7 }
	2 SRU Atoms: { 7 } Bonds: { 6 7 }
	3 SRU Atoms: { 2 } Bonds: { 1 2 }
	4 ANY Atoms: { 5 7 8 4 3 2 1 0 9 } Bonds: { 5 9 }



smi = ("C[C@@H](O)[C@H](C)[C@@H](C)[C@@H](C)O |&3:3,o1:7,&1:1,&2:5,r|")
m = Chem.MolFromSmiles(smi)
m.Debug()
-----------------------------------------------------------
Atoms:
	0 6 C chg: 0  deg: 1 exp: 1 imp: 3 hyb: 4 arom?: 0 chi: 0
	1 6 C chg: 0  deg: 3 exp: 4 imp: 0 hyb: 4 arom?: 0 chi: 1
	2 8 O chg: 0  deg: 1 exp: 1 imp: 1 hyb: 4 arom?: 0 chi: 0
	3 6 C chg: 0  deg: 3 exp: 4 imp: 0 hyb: 4 arom?: 0 chi: 2
	4 6 C chg: 0  deg: 1 exp: 1 imp: 3 hyb: 4 arom?: 0 chi: 0
	5 6 C chg: 0  deg: 3 exp: 4 imp: 0 hyb: 4 arom?: 0 chi: 1
	6 6 C chg: 0  deg: 1 exp: 1 imp: 3 hyb: 4 arom?: 0 chi: 0
	7 6 C chg: 0  deg: 3 exp: 4 imp: 0 hyb: 4 arom?: 0 chi: 1
	8 6 C chg: 0  deg: 1 exp: 1 imp: 3 hyb: 4 arom?: 0 chi: 0
	9 8 O chg: 0  deg: 1 exp: 1 imp: 1 hyb: 4 arom?: 0 chi: 0
Bonds:
	0 0->1 order: 1 conj?: 0 aromatic?: 0
	1 1->2 order: 1 conj?: 0 aromatic?: 0
	2 1->3 order: 1 conj?: 0 aromatic?: 0
	3 3->4 order: 1 conj?: 0 aromatic?: 0
	4 3->5 order: 1 conj?: 0 aromatic?: 0
	5 5->6 order: 1 conj?: 0 aromatic?: 0
	6 5->7 order: 1 conj?: 0 aromatic?: 0
	7 7->8 order: 1 conj?: 0 aromatic?: 0
	8 7->9 order: 1 conj?: 0 aromatic?: 0
Stereo Groups:
	0 AND Atoms: { 3 }
	1 OR Atoms: { 7 }
	2 AND Atoms: { 1 }
	3 AND Atoms: { 5 }

```
