### PR TITLE
Pin cmake in mac and qt in linux for azure builds

### DIFF
--- a/.azure-pipelines/linux_build.yml
+++ b/.azure-pipelines/linux_build.yml
@@ -10,7 +10,7 @@ steps:
         boost-cpp=$(boost_version) \
         py-boost=$(boost_version) \
         numpy pillow eigen pandas matplotlib-base \
-        qt cairo
+        qt=5.9.7 cairo
     conda activate rdkit_build
     conda install -c conda-forge nbval ipykernel>=6.0
   displayName: Setup build environment

--- a/.azure-pipelines/mac_build.yml
+++ b/.azure-pipelines/mac_build.yml
@@ -17,7 +17,7 @@ steps:
     echo -e "backend: TkAgg\n" > $HOME/.matplotlib/matplotlibrc
     conda config --set always_yes yes --set changeps1 no
     conda update -q conda
-    conda create --name rdkit_build $(compiler) cmake \
+    conda create --name rdkit_build $(compiler) cmake=3.19.6 \
         boost-cpp=$(boost_version) boost=$(boost_version) \
         py-boost=$(boost_version) libboost=$(boost_version) \
         qt \


### PR DESCRIPTION
This pins cmake on the Mac builds and qt on the linux builds.  There were apparently regressions in both in recent condo deployments.