### PR TITLE
fix windows dll ci builds

### DIFF
--- a/.azure-pipelines/mac_build.yml
+++ b/.azure-pipelines/mac_build.yml
@@ -17,7 +17,7 @@ steps:
     echo -e "backend: TkAgg\n" > $HOME/.matplotlib/matplotlibrc
     conda config --set always_yes yes --set changeps1 no
     conda update -q conda
-    conda create --name rdkit_build $(compiler) cmake=3.19.6 \
+    conda create --name rdkit_build $(compiler)=12.0 libcxx=12.0 cmake=3.19.6 \
         boost-cpp=$(boost_version) boost=$(boost_version) \
         py-boost=$(boost_version) libboost=$(boost_version) \
         qt \

--- a/.azure-pipelines/mac_build.yml
+++ b/.azure-pipelines/mac_build.yml
@@ -17,7 +17,7 @@ steps:
     echo -e "backend: TkAgg\n" > $HOME/.matplotlib/matplotlibrc
     conda config --set always_yes yes --set changeps1 no
     conda update -q conda
-    conda create --name rdkit_build $(compiler)=12.0 libcxx=12.0 cmake=3.19.6 \
+    conda create --name rdkit_build $(compiler)=$(compiler_version) libcxx=$(compiler_version) cmake=3.19.6 \
         boost-cpp=$(boost_version) boost=$(boost_version) \
         py-boost=$(boost_version) libboost=$(boost_version) \
         qt \

--- a/.azure-pipelines/mac_build_java.yml
+++ b/.azure-pipelines/mac_build_java.yml
@@ -17,7 +17,7 @@ steps:
     echo -e "backend: TkAgg\n" > $HOME/.matplotlib/matplotlibrc
     conda config --set always_yes yes --set changeps1 no
     conda update -q conda
-    conda create --name rdkit_build $(compiler) cmake \
+    conda create --name rdkit_build  $(compiler)=$(compiler_version) libcxx=$(compiler_version) cmake=3.19.6 \
         boost-cpp=$(boost_version) boost=$(boost_version) \
         py-boost=$(boost_version) libboost=$(boost_version) \
         cairo eigen swig=3

--- a/Code/GraphMol/MolDraw2D/MolDraw2DDetails.h
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DDetails.h
@@ -110,21 +110,27 @@ inline std::string formatDouble(double val) {
   return boost::str(boost::format("%.1f") % val);
 }
 
-bool doesLineIntersect(const StringRect &rect, const Point2D &end1,
-                       const Point2D &end2, double padding);
+RDKIT_MOLDRAW2D_EXPORT bool doesLineIntersect(const StringRect &rect,
+                                              const Point2D &end1,
+                                              const Point2D &end2,
+                                              double padding);
 // returns true if any corner of triangle is inside the rectangle.
-bool doesTriangleIntersect(const StringRect &rect, const Point2D &pt1,
-                           const Point2D &pt2, const Point2D &pt3,
-                           double padding);
-bool doesLineIntersectEllipse(const Point2D &centre, double xradius,
-                              double yradius, double padding,
-                              const Point2D &end1, const Point2D &end2);
+RDKIT_MOLDRAW2D_EXPORT bool doesTriangleIntersect(const StringRect &rect,
+                                                  const Point2D &pt1,
+                                                  const Point2D &pt2,
+                                                  const Point2D &pt3,
+                                                  double padding);
+RDKIT_MOLDRAW2D_EXPORT bool doesLineIntersectEllipse(
+    const Point2D &centre, double xradius, double yradius, double padding,
+    const Point2D &end1, const Point2D &end2);
 // angles expected in degrees, between 0 and 360.
-bool doesLineIntersectArc(const Point2D &centre, double xradius, double yradius,
-                          double start_ang, double stop_ang, double padding,
-                          const Point2D &end1, const Point2D &end2);
-bool doLinesIntersect(const Point2D &l1s, const Point2D &l1f,
-                      const Point2D &l2s, const Point2D &l2f, Point2D *ip);
+RDKIT_MOLDRAW2D_EXPORT bool doesLineIntersectArc(
+    const Point2D &centre, double xradius, double yradius, double start_ang,
+    double stop_ang, double padding, const Point2D &end1, const Point2D &end2);
+RDKIT_MOLDRAW2D_EXPORT bool doLinesIntersect(const Point2D &l1s,
+                                             const Point2D &l1f,
+                                             const Point2D &l2s,
+                                             const Point2D &l2f, Point2D *ip);
 // This uses the barycentric coordinate system method from
 // http://totologic.blogspot.com/2014/01/accurate-point-in-triangle-test.html
 // where it notes and provides a solution for instabilities when the point
@@ -133,8 +139,10 @@ bool doLinesIntersect(const Point2D &l1s, const Point2D &l1f,
 // issue when, for example, two triangles share an edge and the point is on that
 // edge, when it might give the disappointing result that the point is in
 // neither triangle.
-bool isPointInTriangle(const Point2D &pt, const Point2D &t1, const Point2D &t2,
-                       const Point2D &t3);
+RDKIT_MOLDRAW2D_EXPORT bool isPointInTriangle(const Point2D &pt,
+                                              const Point2D &t1,
+                                              const Point2D &t2,
+                                              const Point2D &t3);
 
 // returns a vector of p1,c1,c2,p2 tuples for bezier curves
 RDKIT_MOLDRAW2D_EXPORT

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -66,6 +66,7 @@ jobs:
     vmImage: macos-latest
   variables:
     compiler: clangxx_osx-64
+    compiler_version: 12.0
     boost_version: 1.71.0
     number_of_cores: sysctl -n hw.ncpu
     python_name: python38

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,6 +22,7 @@ jobs:
     vmImage: macos-latest
   variables:
     compiler: clangxx_osx-64
+    compiler_version: 12.0
     boost_version: 1.71.0
     number_of_cores: sysctl -n hw.ncpu
     python_name: python38


### PR DESCRIPTION
I merged #5493 too quickly: it has a problem which breaks the windows DLL builds.
This fixes that by adding `RDKIT_MOLDRAW2D_EXPORT` to everything in `MolDraw2DDetails.h`
