### PR TITLE
make it easy to create DAT SGroups from Python

### DIFF
--- a/Code/GraphMol/Wrap/SubstanceGroup.cpp
+++ b/Code/GraphMol/Wrap/SubstanceGroup.cpp
@@ -46,6 +46,16 @@ SubstanceGroup *createMolSubstanceGroup(ROMol &mol, std::string type) {
   return &(getSubstanceGroups(mol).back());
 }
 
+SubstanceGroup *createMolDataSubstanceGroup(ROMol &mol, std::string fieldName,
+                                            std::string value) {
+  SubstanceGroup sg(&mol, "DAT");
+  sg.setProp("FIELDNAME", fieldName);
+  STR_VECT dataFields{value};
+  sg.setProp("DATAFIELDS", dataFields);
+  addSubstanceGroup(mol, sg);
+  return &(getSubstanceGroups(mol).back());
+}
+
 SubstanceGroup *addMolSubstanceGroup(ROMol &mol, const SubstanceGroup &sgroup) {
   addSubstanceGroup(mol, sgroup);
   return &(getSubstanceGroups(mol).back());
@@ -279,6 +289,14 @@ struct sgroup_wrap {
                 python::return_value_policy<
                     python::reference_existing_object,
                     python::with_custodian_and_ward_postcall<0, 1>>());
+    python::def(
+        "CreateMolDataSubstanceGroup", &createMolDataSubstanceGroup,
+        (python::arg("mol"), python::arg("fieldName"), python::arg("value")),
+        "creates a new DATA SubstanceGroup associated with a molecule, "
+        "returns the new SubstanceGroup",
+        python::return_value_policy<
+            python::reference_existing_object,
+            python::with_custodian_and_ward_postcall<0, 1>>());
     python::def("AddMolSubstanceGroup", &addMolSubstanceGroup,
                 (python::arg("mol"), python::arg("sgroup")),
                 "adds a copy of a SubstanceGroup to a molecule, returns the "

--- a/Code/GraphMol/Wrap/testSGroups.py
+++ b/Code/GraphMol/Wrap/testSGroups.py
@@ -122,10 +122,8 @@ M  END
     self.assertTrue(sgs[0].HasProp("FIELDNAME"))
     self.assertEqual(sgs[0].GetProp("FIELDNAME"), "pH")
 
-    self.assertEqual(sorted(sgs[0].GetPropNames()), [
-      'DATAFIELDS', 'FIELDDISP', 'FIELDNAME', 'ID', 
-      'TYPE', 'index'
-    ])
+    self.assertEqual(sorted(sgs[0].GetPropNames()),
+                     ['DATAFIELDS', 'FIELDDISP', 'FIELDNAME', 'ID', 'TYPE', 'index'])
     dd = sgs[0].GetPropsAsDict()
     self.assertTrue("TYPE" in dd)
     self.assertEqual(dd["TYPE"], "DAT")
@@ -154,10 +152,8 @@ M  END
     self.assertTrue(sgs[0].HasProp("FIELDNAME"))
     self.assertEqual(sgs[0].GetProp("FIELDNAME"), "pH")
 
-    self.assertEqual(sorted(sgs[0].GetPropNames()), [
-      'DATAFIELDS', 'FIELDDISP', 'FIELDNAME',
-      'TYPE', 'index'
-    ])
+    self.assertEqual(sorted(sgs[0].GetPropNames()),
+                     ['DATAFIELDS', 'FIELDDISP', 'FIELDNAME', 'TYPE', 'index'])
     dd = sgs[0].GetPropsAsDict()
     self.assertTrue("TYPE" in dd)
     self.assertEqual(dd["TYPE"], "DAT")
@@ -598,6 +594,15 @@ M  END''')
     self.assertEqual(len(sgs[0].GetAttachPoints()), 1)
     sgs[0].ClearAttachPoints()
     self.assertEqual(len(sgs[0].GetAttachPoints()), 0)
+
+  def testCreateDataSGroup(self):
+    mol = Chem.MolFromSmiles('CC(=O)O')
+    sg = Chem.CreateMolDataSubstanceGroup(mol, "pKa", "4.5")
+    sg.SetAtoms([1, 2, 3])
+    sg = Chem.GetMolSubstanceGroups(mol)[0]
+    self.assertEqual(sg.GetProp("TYPE"), "DAT")
+    self.assertEqual(sg.GetProp("FIELDNAME"), "pKa")
+    self.assertEqual(sg.GetStringVectProp("DATAFIELDS")[0], "4.5")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
At the moment creating a DAT SGroup from python is really hard because there's no straightforward way to create the `DATAFIELDS` string vector that's required.

This adds a new function to the python API: `CreateMolDataSubstanceGroup()` (analogous to `CreateMolSubstanceGroup()`) which solves this problem.