### PR TITLE
Fixes #5505: problems when kekulizing molecules with query bonds

### DIFF
--- a/Code/GraphMol/Kekulize.cpp
+++ b/Code/GraphMol/Kekulize.cpp
@@ -8,6 +8,7 @@
 //  of the RDKit source tree.
 //
 #include <GraphMol/RDKitBase.h>
+#include <GraphMol/QueryOps.h>
 #include <GraphMol/Canon.h>
 #include <GraphMol/Rings.h>
 #include <GraphMol/SanitException.h>
@@ -516,8 +517,8 @@ void KekulizeFragment(RWMol &mol, const boost::dynamic_bitset<> &atomsToUse,
   bool foundAromatic = false;
   for (const auto bond : mol.bonds()) {
     if (bondsToUse[bond->getIdx()]) {
-      if (bond->hasQuery()) {
-        // we don't kekulize query bonds
+      if (QueryOps::hasBondTypeQuery(*bond)) {
+        // we don't kekulize bonds with bond type queries
         bondsToUse[bond->getIdx()] = 0;
       } else if (bond->getIsAromatic()) {
         foundAromatic = true;

--- a/Code/GraphMol/MolOps.h
+++ b/Code/GraphMol/MolOps.h
@@ -615,8 +615,10 @@ RDKIT_GRAPHMOL_EXPORT void adjustHs(RWMol &mol);
    double bond if we hit a wall in the kekulization process
 
    <b>Notes:</b>
-     - even if \c markAtomsBonds is \c false the \c BondType for all aromatic
-       bonds will be changed from \c RDKit::Bond::AROMATIC to \c
+     - this does not modify query bonds which have bond type queries (like those
+       which come from SMARTS) or rings containing them.
+     - even if \c markAtomsBonds is \c false the \c BondType for all modified
+       aromatic bonds will be changed from \c RDKit::Bond::AROMATIC to \c
        RDKit::Bond::SINGLE or RDKit::Bond::DOUBLE during Kekulization.
 
 */

--- a/Code/GraphMol/Wrap/MolOps.cpp
+++ b/Code/GraphMol/Wrap/MolOps.cpp
@@ -1495,20 +1495,28 @@ to the terminal dummy atoms.\n\
 
     // ------------------------------------------------------------------------
     docString =
-        "Kekulizes the molecule\n\
-\n\
-  ARGUMENTS:\n\
-\n\
-    - mol: the molecule to use\n\
-\n\
-    - clearAromaticFlags: (optional) if this toggle is set, all atoms and bonds in the \n\
-      molecule will be marked non-aromatic following the kekulization.\n\
-      Default value is False.\n\
-\n\
-  NOTES:\n\
-\n\
-    - The molecule is modified in place.\n\
-\n";
+        R"DOC(Kekulizes the molecule
+
+  ARGUMENTS:
+
+    - mol: the molecule to use
+
+    - clearAromaticFlags: (optional) if this toggle is set, all atoms and bonds in the
+      molecule will be marked non-aromatic following the kekulization.
+      Default value is False.
+
+  NOTES:
+
+    - The molecule is modified in place.
+
+    - this does not modify query bonds which have bond type queries (like those
+      which come from SMARTS) or rings containing them.
+
+    - even if clearAromaticFlags is False the BondType for all modified
+      aromatic bonds will be changed from AROMATIC to SINGLE or DOUBLE
+      Kekulization.
+
+)DOC";
     python::def("Kekulize", kekulizeMol,
                 (python::arg("mol"), python::arg("clearAromaticFlags") = false),
                 docString.c_str());

--- a/Code/GraphMol/catch_graphmol.cpp
+++ b/Code/GraphMol/catch_graphmol.cpp
@@ -18,6 +18,7 @@
 #include <GraphMol/RDKitBase.h>
 #include <GraphMol/new_canon.h>
 #include <GraphMol/RDKitQueries.h>
+#include <GraphMol/QueryOps.h>
 #include <GraphMol/Chirality.h>
 #include <GraphMol/MonomerInfo.h>
 #include <GraphMol/FileParsers/FileParsers.h>
@@ -2780,5 +2781,19 @@ TEST_CASE(
     REQUIRE(m1->getBondWithIdx(1)->getBondType() != Bond::BondType::AROMATIC);
     REQUIRE(m1->getBondWithIdx(6)->hasQuery());
     REQUIRE(m1->getBondWithIdx(6)->getBondType() == Bond::BondType::AROMATIC);
+  }
+  SECTION("kekulization with non-bond-type queries works") {
+    auto m1 = "c1ccccc1"_smiles;
+    REQUIRE(m1);
+    QueryBond qbond;
+    qbond.setBondType(Bond::BondType::AROMATIC);
+    qbond.setIsAromatic(true);
+    qbond.setQuery(makeBondIsInRingQuery());
+    m1->replaceBond(0, &qbond);
+    REQUIRE(m1->getBondWithIdx(0)->hasQuery());
+    REQUIRE(m1->getBondWithIdx(0)->getBondType() == Bond::BondType::AROMATIC);
+    MolOps::Kekulize(*m1);
+    REQUIRE(m1->getBondWithIdx(0)->hasQuery());
+    REQUIRE(m1->getBondWithIdx(0)->getBondType() != Bond::BondType::AROMATIC);
   }
 }


### PR DESCRIPTION
The solution I chose here is to not include bonds which have `BondType` queries (or rings including those bonds) in the kekulzation process. The rest of the molecule will still be kekulized.

The other option: throwing an exception of some type for those cases, would have broken any existing code which attempts (for whatever reason) to kekulize queries; this would include a fair amount of reaction drawing code.