### PR TITLE
Fixes #2984

### DIFF
--- a/Code/GraphMol/FindStereo.cpp
+++ b/Code/GraphMol/FindStereo.cpp
@@ -565,9 +565,9 @@ void flagRingStereo(ROMol &mol,
         auto opposite_atom = mol.getAtomWithIdx(oppositeidx);
         for (auto bond : mol.atomBonds(opposite_atom)) {
           auto bidx = bond->getIdx();
-          if (std::find(bring.begin(), bring.end(), bidx) == bring.end() &&
-              (knownBonds[bidx] ||
-               (possibleBonds && possibleBonds->test(bidx)))) {
+          if ( (knownBonds[bidx] ||
+               (possibleBonds && possibleBonds->test(bidx))) &&
+               std::find(bring.begin(), bring.end(), bidx) == bring.end()) {
             to_atom_opposite_possible = true;
             break;
           }


### PR DESCRIPTION
This fixes #2984.

This issue has been sitting there for a long time, and now, with the new version of `AssignStereochemistry()`, we finally have the required infrastructure to fix it!

Also, I added a couple of fixture functions to manage the Legacy Stereo Perception and Allow Non Tetrahedral Chirality settings, since there was one test ("useLegacyStereoPerception feature flag") that was leaving the new stereo algorithm enabled.

I haven't been able to find a way to automatically apply a fixture to all tests in the file, though, so we still need to manually invoke the fixture in all tests that might require it. I either haven't been able to find a way of rerunning the same test sections with a different value for one variable, so I had to add the `for (auto use_legacy : {false, true})` loops to the new test I added.