### PR TITLE
fix warnings ahead of 2022.09 release

### DIFF
--- a/Code/GraphMol/AddHs.cpp
+++ b/Code/GraphMol/AddHs.cpp
@@ -494,9 +494,8 @@ void addHs(RWMol &mol, bool explicitOnly, bool addCoords,
   // for their coordinates
   unsigned int numAddHyds = 0;
   for (auto at : mol.atoms()) {
-    if (!onlyOnAtoms ||
-        std::find(onlyOnAtoms->begin(), onlyOnAtoms->end(), at->getIdx()) !=
-            onlyOnAtoms->end()) {
+    if (!onlyOnAtoms || std::find(onlyOnAtoms->begin(), onlyOnAtoms->end(),
+                                  at->getIdx()) != onlyOnAtoms->end()) {
       numAddHyds += at->getNumExplicitHs();
       if (!explicitOnly) {
         numAddHyds += at->getNumImplicitHs();
@@ -514,9 +513,8 @@ void addHs(RWMol &mol, bool explicitOnly, bool addCoords,
 
   unsigned int stopIdx = mol.getNumAtoms();
   for (unsigned int aidx = 0; aidx < stopIdx; ++aidx) {
-    if (onlyOnAtoms &&
-        std::find(onlyOnAtoms->begin(), onlyOnAtoms->end(), aidx) ==
-            onlyOnAtoms->end()) {
+    if (onlyOnAtoms && std::find(onlyOnAtoms->begin(), onlyOnAtoms->end(),
+                                 aidx) == onlyOnAtoms->end()) {
       continue;
     }
 
@@ -767,7 +765,7 @@ void molRemoveH(RWMol &mol, unsigned int idx, bool updateExplicitCount) {
     sg.removeParentAtomWithIdx(idx);
 
     for (auto &sap : sg.getAttachPoints()) {
-      if (sap.lvIdx == idx) {
+      if (sap.lvIdx == static_cast<int>(idx)) {
         sap.lvIdx = -1;
       }
     }
@@ -928,8 +926,9 @@ void filter_sgroup_emptying_hydrogens(const ROMol &mol,
     auto no_atoms = atoms.empty() ||
                     std::all_of(atoms.begin(), atoms.end(), would_remove_atom);
     if (no_atoms) {
-      auto no_patoms = patoms.empty() || std::all_of(patoms.begin(), patoms.end(),
-                                                     would_remove_atom);
+      auto no_patoms =
+          patoms.empty() ||
+          std::all_of(patoms.begin(), patoms.end(), would_remove_atom);
       if (no_patoms) {
         for (auto atom : atoms) {
           atomsToRemove.set(atom, false);
@@ -981,9 +980,9 @@ void removeHs(RWMol &mol, const RemoveHsParameters &ps, bool sanitize) {
 
   // Once we know which H atoms would be removed, filter out those that
   // would cause any SGroups to become empty
-  if (ps.removeInSGroups)  {
+  if (ps.removeInSGroups) {
     filter_sgroup_emptying_hydrogens(mol, atomsToRemove);
- }
+  }
 
   // now that we know which atoms need to be removed, go ahead and remove them
   // NOTE: there's too much complexity around stereochemistry here

--- a/Code/GraphMol/FileParsers/ProximityBonds.cpp
+++ b/Code/GraphMol/FileParsers/ProximityBonds.cpp
@@ -259,8 +259,10 @@ void ConnectTheDots(RWMol *mol, unsigned int flags) {
 }
 
 // These are macros to allow their use in C++ constants
-constexpr int BCNAM(char A, char B, char C) { return (A << 16) | (B << 8) | C; }
-constexpr int BCATM(char A, char B, char C, char D) {
+constexpr unsigned BCNAM(char A, char B, char C) {
+  return (A << 16) | (B << 8) | C;
+}
+constexpr unsigned BCATM(char A, char B, char C, char D) {
   return (A << 24) | (B << 16) | (C << 8) | D;
 }
 

--- a/Code/GraphMol/FindStereo.cpp
+++ b/Code/GraphMol/FindStereo.cpp
@@ -841,7 +841,6 @@ std::vector<StereoInfo> runCleanup(ROMol &mol, bool flagPossible,
   ftor.df_useIsotopes = false;
   ftor.df_useChirality = false;
   auto atomOrder = new int[mol.getNumAtoms()];
-  bool needsInit = true;
   std::vector<unsigned int> aranks(mol.getNumAtoms());
   bool needAnotherRound = true;
   while (needAnotherRound) {

--- a/Code/GraphMol/MolDraw2D/DrawMol.cpp
+++ b/Code/GraphMol/MolDraw2D/DrawMol.cpp
@@ -3119,7 +3119,7 @@ void DrawMol::makeHighlightEnd(const Atom *end1, const Atom *end2,
     // vector.
     auto bvec = end1Cds.directionVector(end2Cds);
     std::vector<std::pair<int, double>> angs;
-    for (auto i = 0; i < end1HighNbrs.size(); ++i) {
+    for (unsigned i = 0; i < end1HighNbrs.size(); ++i) {
       auto ovec = end1Cds.directionVector(atCds_[end1HighNbrs[i]->getIdx()]);
       auto ang = bvec.signedAngleTo(ovec);
       angs.push_back(std::make_pair(i, ang));

--- a/Code/GraphMol/RGroupDecomposition/testRGroupDecomp.cpp
+++ b/Code/GraphMol/RGroupDecomposition/testRGroupDecomp.cpp
@@ -2858,7 +2858,7 @@ M  END
   RGroupDecompositionParameters params;
   params.matchingStrategy = GreedyChunks;
   RGroupDecomposition decomp(*core, params);
-  for (const auto smiles : smiArray) {
+  for (const auto &smiles : smiArray) {
     ROMol *mol = SmilesToMol(smiles);
     int res = decomp.add(*mol);
     TEST_ASSERT(res >= 0);
@@ -2869,7 +2869,7 @@ M  END
   std::cerr << "Best mapping" << std::endl;
   RGroupRows rows = decomp.getRGroupsAsRows();
   TEST_ASSERT(rows.size() == 11);
-  for (const auto row : rows) {
+  for (const auto &row : rows) {
     TEST_ASSERT(row.size() == 2);
     TEST_ASSERT(row.count("Core") == 1);
     TEST_ASSERT(row.count("R1") == 1);

--- a/Code/GraphMol/TautomerQuery/TautomerQuery.h
+++ b/Code/GraphMol/TautomerQuery/TautomerQuery.h
@@ -120,7 +120,7 @@ class RDKIT_TAUTOMERQUERY_EXPORT TautomerQuery {
   void save(Archive &ar, const unsigned int version) const {
     RDUNUSED_PARAM(version);
     std::vector<std::string> pkls;
-    for (const auto taut : d_tautomers) {
+    for (const auto &taut : d_tautomers) {
       std::string pkl;
       MolPickler::pickleMol(*taut, pkl);
       pkls.push_back(pkl);

--- a/Code/RDGeneral/RDLog.cpp
+++ b/Code/RDGeneral/RDLog.cpp
@@ -152,7 +152,6 @@ void InitLogs() {
 std::ostream &toStream(std::ostream &logstrm) {
   char buffer[16];
   time_t t = time(nullptr);
-  struct tm *tm;
 // localtime() is thread safe on windows, but not on *nix
 #ifdef WIN32
   strftime(buffer, 16, "[%T] ", localtime(&t));

--- a/Contrib/ConformerParser/ConformerParser.cpp
+++ b/Contrib/ConformerParser/ConformerParser.cpp
@@ -54,7 +54,7 @@ INT_VECT addConformersFromList(ROMol &mol,
   }
   // loop over the conformers
   INT_VECT confIds;
-  for (unsigned int i = 0; i < numConf; ++i) {
+  for (int i = 0; i < numConf; ++i) {
     if (coords[i].size() != numCoordPerConf) {
       throw ValueErrorException("Wrong number of coordinates");
     }


### PR DESCRIPTION
This is the traditional build warnings cleanup PR.

In this PR:
- Fix some signed vs unsigned comparison warnings.
- `Bond::BondDir bond_dir` might be used uninitialized in mol fragmenter.
- `struct tm *tm` and `bool needsInit` defined but never used.
- Some for loops using copies instead of references.
- Reformatting of AddHs.cpp and MolFragmenter.cpp.
