### PR TITLE
mergeQueryHs will not remove isotopes

### DIFF
--- a/Code/GraphMol/AddHs.cpp
+++ b/Code/GraphMol/AddHs.cpp
@@ -1137,7 +1137,7 @@ bool isQueryH(const Atom *atom) {
 //   - By default all hydrogens are removed, however if
 //     merge_unmapped_only is true, any hydrogen participating
 //     in an atom map will be retained
-void mergeQueryHs(RWMol &mol, bool mergeUnmappedOnly) {
+void mergeQueryHs(RWMol &mol, bool mergeUnmappedOnly, bool mergeIsotopes) {
   std::vector<unsigned int> atomsToRemove;
 
   boost::dynamic_bitset<> hatoms(mol.getNumAtoms());
@@ -1155,8 +1155,11 @@ void mergeQueryHs(RWMol &mol, bool mergeUnmappedOnly) {
       while (begin != end) {
         if (hatoms[*begin]) {
           Atom &bgn = *mol.getAtomWithIdx(*begin);
-          if (!mergeUnmappedOnly ||
-              !bgn.hasProp(common_properties::molAtomMapNumber)) {
+          bool checkUnmapped =
+              !mergeUnmappedOnly ||
+              !bgn.hasProp(common_properties::molAtomMapNumber);
+          bool checkIsotope = mergeIsotopes || bgn.getIsotope() == 0;
+          if (checkUnmapped && checkIsotope) {
             atomsToRemove.push_back(rdcast<unsigned int>(*begin));
             ++numHsToRemove;
           }
@@ -1201,7 +1204,7 @@ void mergeQueryHs(RWMol &mol, bool mergeUnmappedOnly) {
           auto *rsq = dynamic_cast<RecursiveStructureQuery *>(atom->getQuery());
           CHECK_INVARIANT(rsq, "could not convert recursive structure query");
           RWMol *rqm = new RWMol(*rsq->getQueryMol());
-          mergeQueryHs(*rqm, mergeUnmappedOnly);
+          mergeQueryHs(*rqm, mergeUnmappedOnly, mergeIsotopes);
           rsq->setQueryMol(rqm);
         }
 
@@ -1215,7 +1218,7 @@ void mergeQueryHs(RWMol &mol, bool mergeUnmappedOnly) {
             auto *rsq = dynamic_cast<RecursiveStructureQuery *>(qry.get());
             CHECK_INVARIANT(rsq, "could not convert recursive structure query");
             RWMol *rqm = new RWMol(*rsq->getQueryMol());
-            mergeQueryHs(*rqm, mergeUnmappedOnly);
+            mergeQueryHs(*rqm, mergeUnmappedOnly, mergeIsotopes);
             rsq->setQueryMol(rqm);
           } else if (qry->beginChildren() != qry->endChildren()) {
             childStack.insert(childStack.end(), qry->beginChildren(),
@@ -1232,9 +1235,9 @@ void mergeQueryHs(RWMol &mol, bool mergeUnmappedOnly) {
   }
   mol.commitBatchEdit();
 };
-ROMol *mergeQueryHs(const ROMol &mol, bool mergeUnmappedOnly) {
+ROMol *mergeQueryHs(const ROMol &mol, bool mergeUnmappedOnly, bool mergeIsotopes) {
   auto *res = new RWMol(mol);
-  mergeQueryHs(*res, mergeUnmappedOnly);
+  mergeQueryHs(*res, mergeUnmappedOnly, mergeIsotopes);
   return static_cast<ROMol *>(res);
 };
 

--- a/Code/GraphMol/MolOps.h
+++ b/Code/GraphMol/MolOps.h
@@ -301,11 +301,13 @@ RDKIT_GRAPHMOL_EXPORT ROMol *removeAllHs(const ROMol &mol,
 
 */
 RDKIT_GRAPHMOL_EXPORT ROMol *mergeQueryHs(const ROMol &mol,
-                                          bool mergeUnmappedOnly = false);
+                                          bool mergeUnmappedOnly = false,
+                                          bool mergeIsotopes = false);
 //! \overload
 /// modifies the molecule in place
 RDKIT_GRAPHMOL_EXPORT void mergeQueryHs(RWMol &mol,
-                                        bool mergeUnmappedOnly = false);
+                                        bool mergeUnmappedOnly = false,
+                                        bool mergeIsotopes = false);
 
 typedef enum {
   ADJUST_IGNORENONE = 0x0,

--- a/Code/GraphMol/Wrap/MolOps.cpp
+++ b/Code/GraphMol/Wrap/MolOps.cpp
@@ -1237,8 +1237,9 @@ struct molops_wrapper {
                 "Returns a copy of the molecule with all Hs removed.",
                 python::return_value_policy<python::manage_new_object>());
     python::def("MergeQueryHs",
-                (ROMol * (*)(const ROMol &, bool)) & MolOps::mergeQueryHs,
-                (python::arg("mol"), python::arg("mergeUnmappedOnly") = false),
+                (ROMol * (*)(const ROMol &, bool, bool)) & MolOps::mergeQueryHs,
+                (python::arg("mol"), python::arg("mergeUnmappedOnly") = false, 
+                 python::arg("mergeIsotopes") = false),
                 "merges hydrogens into their neighboring atoms as queries",
                 python::return_value_policy<python::manage_new_object>());
 

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -454,6 +454,23 @@ class TestCase(unittest.TestCase):
     self.assertEqual(m2.GetNumAtoms(), 2)
     self.assertTrue(m2.GetAtomWithIdx(1).HasQuery())
 
+    # test merging of isotopes, by default deuterium will not be merged
+    m = Chem.MolFromSmiles('CC[2H]', False)
+    self.assertEqual(m.GetNumAtoms(), 3)
+    m2 = Chem.MergeQueryHs(m)
+    self.assertTrue(m2 is not None)
+    self.assertEqual(m2.GetNumAtoms(), 3)
+    self.assertFalse(m2.GetAtomWithIdx(1).HasQuery())
+
+    # here deuterium is merged
+    # should be the same as merging all hydrogens
+    m = Chem.MolFromSmiles('CC[2H]', False)
+    self.assertEqual(m.GetNumAtoms(), 3)
+    m2 = Chem.MergeQueryHs(m, mergeIsotopes=True)
+    self.assertTrue(m2 is not None)
+    self.assertEqual(m2.GetNumAtoms(), 2)
+    self.assertTrue(m2.GetAtomWithIdx(1).HasQuery())
+    
     # test github758
     m = Chem.MolFromSmiles('CCC')
     self.assertEqual(m.GetNumAtoms(), 3)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! 
-->
#### Reference Issue

Implements the suggestion in https://github.com/rdkit/rdkit/issues/5568

#### What does this implement/fix? Explain your changes.

Changes `MolOps::mergeQueryHs` to have a `mergeIsotopes` argument (false by default) so that hydrogen isotopes will not normally be merged. 

