### PR TITLE
[WIP] Add rgroup decomposition option for molzip

### DIFF
--- a/Code/GraphMol/ChemTransforms/MolFragmenter.h
+++ b/Code/GraphMol/ChemTransforms/MolFragmenter.h
@@ -102,7 +102,7 @@ RDKIT_CHEMTRANSFORMS_EXPORT void constructBRICSBondTypes(
 }  // namespace MolFragmenter
 
 // n.b. AtomProperty must resolve to an unsigned integer value on an atom property
-enum class MolzipLabel { AtomMapNumber, Isotope, FragmentOnBonds, AtomType, AtomProperty };
+enum class MolzipLabel { AtomMapNumber, Isotope, FragmentOnBonds, AtomType, AtomProperty, RGroupDecomposition };
 
 struct RDKIT_CHEMTRANSFORMS_EXPORT MolzipParams {
   MolzipLabel label = MolzipLabel::AtomMapNumber;

--- a/Code/GraphMol/ChemTransforms/testChemTransforms.cpp
+++ b/Code/GraphMol/ChemTransforms/testChemTransforms.cpp
@@ -2164,6 +2164,21 @@ void testGithub4019() {
   }
 }
 
+void testRGroupMolzip() {
+    BOOST_LOG(rdInfoLog) << "-------------------------------------" << std::endl;
+    BOOST_LOG(rdInfoLog)
+        << "Testing molzip of RGroupDecompositions " << std::endl;
+    SmilesParserParams params;
+    params.sanitize = false;
+    
+    auto mol = SmilesToMol("Cc[*:1].c(cccc:[*:1]):[*:1]", params);
+    MolzipParams molzip_params;
+    molzip_params.label = MolzipLabel::RGroupDecomposition;
+    auto zipped = molzip(*mol, molzip_params);
+    auto smi = MolToSmiles(*zipped, true);
+    TEST_ASSERT(smi == "Cc1ccccc1");
+}
+
 int main() {
   RDLog::InitLogs();
 
@@ -2206,6 +2221,7 @@ int main() {
   testGithub1734();
   testGithub3206();
   testGithub4019();
+  testRGroupMolzip();
   BOOST_LOG(rdInfoLog)
       << "*******************************************************\n";
   return (0);


### PR DESCRIPTION
This is code that allows mol zip to zip up some odd rgroup decompositions such as splitting rings.

This is modeled after the following Python code:


```
def molzip_smi(smiles):
    """Fix a rgroup smiles for molzip, note that the core MUST come first
    in the smiles string, ala core.rgroup1.rgroup2 ...
    """
    dupes = set()
    sl = []
    for s in smiles.split("."):
        if s.count("*") >= 1:
            if s in dupes:
                #print("removing", s)
                continue
            else:
                dupes.add(s)
        sl.append(s)
        
    smiles = ".".join(sl)
    m = Chem.RWMol(Chem.MolFromSmiles(smiles, sanitize=False))
    frags = Chem.GetMolFrags(m)
    core = frags[0]
    atommaps = {}
    counts = defaultdict(int)
    for idx in core:
        atommap = m.GetAtomWithIdx(idx).GetAtomMapNum()
        if atommap:
            atommaps[atommap] = idx
            counts[atommap] += 1
    
    next_atommap = max(atommaps) + 1
    add_atommap = []
    for fragment in frags[1:]:
        for idx in fragment:
            atommap = m.GetAtomWithIdx(idx).GetAtomMapNum()
            if atommap:
                count = counts[atommap] = counts[atommap] + 1
                if count > 2:
                    m.GetAtomWithIdx(idx).SetAtomMapNum(next_atommap)
                    add_atommap.append((atommaps[atommap], next_atommap))
                    next_atommap += 1
                  
    for atomidx, atommap in add_atommap:
        atom = m.GetAtomWithIdx(atomidx)
        bonds = list(atom.GetBonds())
        if len(bonds) == 1:
            oatom = bonds[0].GetOtherAtom(atom)
            xatom = Chem.Atom(0)
            idx = m.AddAtom(xatom)
            xatom = m.GetAtomWithIdx(idx)
            xatom.SetAtomMapNum(atommap)
            m.AddBond(oatom.GetIdx(), xatom.GetIdx(), Chem.BondType.SINGLE)
    return Chem.molzip(m)
```