### PR TITLE
small changes to get the RDKit to build with C++20

### DIFF
--- a/Code/Catalogs/Catalog.h
+++ b/Code/Catalogs/Catalog.h
@@ -159,18 +159,18 @@ class HierarchCatalog : public Catalog<entryType, paramType> {
   typedef std::pair<DOWN_ENT_ITER, DOWN_ENT_ITER> DOWN_ENT_ITER_PAIR;
 
   //------------------------------------
-  HierarchCatalog<entryType, paramType, orderType>(){};
+  HierarchCatalog(){};
 
   //------------------------------------
   //! Construct by making a copy of the input \c params object
-  HierarchCatalog<entryType, paramType, orderType>(const paramType *params)
+  HierarchCatalog(const paramType *params)
       : Catalog<entryType, paramType>() {
     this->setCatalogParams(params);
   }
 
   //------------------------------------
   //! Construct from a \c pickle (a serialized form of the HierarchCatalog)
-  HierarchCatalog<entryType, paramType, orderType>(const std::string &pickle) {
+  HierarchCatalog(const std::string &pickle) {
     this->initFromString(pickle);
   }
 

--- a/Code/RDGeneral/ConcurrentQueue.h
+++ b/Code/RDGeneral/ConcurrentQueue.h
@@ -26,11 +26,11 @@ class ConcurrentQueue {
   std::condition_variable d_notEmpty, d_notFull;
 
  private:
-  ConcurrentQueue<E>(const ConcurrentQueue<E>&);
-  ConcurrentQueue<E>& operator=(const ConcurrentQueue<E>&);
+  ConcurrentQueue(const ConcurrentQueue<E>&);
+  ConcurrentQueue& operator=(const ConcurrentQueue<E>&);
 
  public:
-  ConcurrentQueue<E>(unsigned int capacity)
+  ConcurrentQueue(unsigned int capacity)
       : d_capacity(capacity), d_done(false), d_head(0), d_tail(0) {
     std::vector<E> elements(capacity);
     d_elements = elements;


### PR DESCRIPTION
We don't actually use C++20, but the RDKit should still build when using it. These two changes make that possible.

Here's a stackoverflow post with more detail on the issue:
https://stackoverflow.com/questions/63513984/can-class-template-constructors-have-a-redundant-template-parameter-list-in-c2
