### PR TITLE
Expose additional functionality to SWIG wrappers

### DIFF
--- a/Code/GraphMol/Chirality.cpp
+++ b/Code/GraphMol/Chirality.cpp
@@ -766,7 +766,7 @@ const Atom *findHighestCIPNeighbor(const Atom *atom, const Atom *skipAtom) {
 
 namespace Chirality {
 
-#if _MSC_VER
+#ifdef _WIN32
 int setenv(const char *name, const char *value, int) {
   return _putenv_s(name, value);
 }

--- a/Code/GraphMol/MolAlign/AlignMolecules.cpp
+++ b/Code/GraphMol/MolAlign/AlignMolecules.cpp
@@ -212,7 +212,7 @@ double getBestAlignmentTransform(const ROMol &prbMol, const ROMol &refMol,
   return bestRMS;
 }
 
-double getBestRMS(ROMol &prbMol, ROMol &refMol, int prbCid, int refCid,
+double getBestRMS(ROMol &prbMol, const ROMol &refMol, int prbCid, int refCid,
                   const std::vector<MatchVectType> &map, int maxMatches,
                   bool symmetrizeConjugatedTerminalGroups,
                   const RDNumeric::DoubleVector *weights) {

--- a/Code/GraphMol/MolAlign/AlignMolecules.h
+++ b/Code/GraphMol/MolAlign/AlignMolecules.h
@@ -170,7 +170,7 @@ RDKIT_MOLALIGN_EXPORT double getBestAlignmentTransform(
   Best RMSD value found
 */
 RDKIT_MOLALIGN_EXPORT double getBestRMS(
-    ROMol &prbMol, ROMol &refMol, int prbCid = -1, int refCid = -1,
+    ROMol &prbMol, const ROMol &refMol, int prbCid = -1, int refCid = -1,
     const std::vector<MatchVectType> &map = std::vector<MatchVectType>(),
     int maxMatches = 1e6, bool symmetrizeConjugatedTerminalGroups = true,
     const RDNumeric::DoubleVector *weights = nullptr);

--- a/Code/JavaWrappers/ROMol.i
+++ b/Code/JavaWrappers/ROMol.i
@@ -546,7 +546,7 @@ void setPreferCoordGen(bool);
     const std::vector<std::vector<std::pair<int,int> > > &map = std::vector<std::vector<std::pair<int,int> > >(),
     int maxMatches = 1e6, bool symmetrizeConjugatedTerminalGroups = true,
     const RDNumeric::DoubleVector *weights = nullptr) {
-    return RDKit::MolAlign::calcRMS(*($self), refMol, prbCid, refCid, map, maxMatches, symmetrizeConjugatedTerminalGroups, weights);
+    return RDKit::MolAlign::CalcRMS(*($self), refMol, prbCid, refCid, map, maxMatches, symmetrizeConjugatedTerminalGroups, weights);
   }
 
   double getBestRMS(

--- a/Code/JavaWrappers/ROMol.i
+++ b/Code/JavaWrappers/ROMol.i
@@ -387,6 +387,15 @@ void setPreferCoordGen(bool);
            &referencePattern,acceptFailure,forceRDKit);
   }
 
+  double normalizeDepiction(int confId=-1, int canonicalize=1,
+                            double scaleFactor=-1.0) {
+    return RDDepict::normalizeDepiction(*($self), confId, canonicalize, scaleFactor);
+  }
+
+  void straightenDepiction(int confId=-1, bool minimizeRotation=false) {
+    RDDepict::straightenDepiction(*($self), confId, minimizeRotation);
+  }
+
   /* From FindRings.cpp, MolOps.h */
   int findSSSR(RDKit::VECT_INT_VECT &res) {
     return RDKit::MolOps::findSSSR(*($self), res);
@@ -518,7 +527,34 @@ void setPreferCoordGen(bool);
                              int refCid = -1, const std::vector<std::pair<int,int> > *atomMap = 0,
                              const RDNumeric::DoubleVector *weights = 0,
                              bool reflect = false, unsigned int maxIters = 50){
-     return RDKit::MolAlign::getAlignmentTransform(*($self), refMol, trans, prbCid, refCid, atomMap, weights, reflect, maxIters);
+    return RDKit::MolAlign::getAlignmentTransform(*($self), refMol, trans, prbCid, refCid, atomMap, weights, reflect, maxIters);
+  }
+
+  double getBestAlignmentTransform(
+    const RDKit::ROMol &refMol, RDGeom::Transform3D &bestTrans,
+    std::vector<std::pair<int,int> > &bestMatch, int prbCid = -1, int refCid = -1,
+    const std::vector<std::vector<std::pair<int,int> > > &map = std::vector<std::vector<std::pair<int,int> > >(),
+    int maxMatches = 1e6, bool symmetrizeConjugatedTerminalGroups = true,
+    const RDNumeric::DoubleVector *weights = nullptr, bool reflect = false,
+    unsigned int maxIters = 50) {
+    return RDKit::MolAlign::getBestAlignmentTransform(*($self), refMol, bestTrans, bestMatch,
+      prbCid, refCid, map, maxMatches, symmetrizeConjugatedTerminalGroups, weights, reflect, maxIters);
+  }
+
+  double CalcRMS(
+    const ROMol &refMol, int prbCid = -1, int refCid = -1,
+    const std::vector<std::vector<std::pair<int,int> > > &map = std::vector<std::vector<std::pair<int,int> > >(),
+    int maxMatches = 1e6, bool symmetrizeConjugatedTerminalGroups = true,
+    const RDNumeric::DoubleVector *weights = nullptr) {
+    return RDKit::MolAlign::CalcRMS(*($self), refMol, prbCid, refCid, map, maxMatches, symmetrizeConjugatedTerminalGroups, weights);
+  }
+
+  double getBestRMS(
+    const ROMol &refMol, int prbCid = -1, int refCid = -1,
+    const std::vector<std::vector<std::pair<int,int> > > &map = std::vector<std::vector<std::pair<int,int> > >(),
+    int maxMatches = 1e6, bool symmetrizeConjugatedTerminalGroups = true,
+    const RDNumeric::DoubleVector *weights = nullptr) {
+    return RDKit::MolAlign::getBestRMS(*($self), refMol, prbCid, refCid, map, maxMatches, symmetrizeConjugatedTerminalGroups, weights);
   }
 
   /* From GraphMol/MolAlign/AlignMolecules */

--- a/Code/JavaWrappers/ROMol.i
+++ b/Code/JavaWrappers/ROMol.i
@@ -541,12 +541,12 @@ void setPreferCoordGen(bool);
       prbCid, refCid, map, maxMatches, symmetrizeConjugatedTerminalGroups, weights, reflect, maxIters);
   }
 
-  double CalcRMS(
+  double calcRMS(
     const ROMol &refMol, int prbCid = -1, int refCid = -1,
     const std::vector<std::vector<std::pair<int,int> > > &map = std::vector<std::vector<std::pair<int,int> > >(),
     int maxMatches = 1e6, bool symmetrizeConjugatedTerminalGroups = true,
     const RDNumeric::DoubleVector *weights = nullptr) {
-    return RDKit::MolAlign::CalcRMS(*($self), refMol, prbCid, refCid, map, maxMatches, symmetrizeConjugatedTerminalGroups, weights);
+    return RDKit::MolAlign::calcRMS(*($self), refMol, prbCid, refCid, map, maxMatches, symmetrizeConjugatedTerminalGroups, weights);
   }
 
   double getBestRMS(

--- a/Code/JavaWrappers/RWMol.i
+++ b/Code/JavaWrappers/RWMol.i
@@ -54,36 +54,40 @@
 %javaconst(1);
 #endif
 %include <GraphMol/FileParsers/FileParsers.h>
+%include <GraphMol/SmilesParse/SmilesParse.h>
 %include <GraphMol/RWMol.h>
 
 %extend RDKit::RWMol {
-  static RDKit::RWMOL_SPTR MolFromSmiles(std::string smi,int debugParse=0,bool sanitize=1,
+  static RDKit::RWMOL_SPTR MolFromSmiles(const std::string &smi,int debugParse=0,bool sanitize=1,
                                          std::map<std::string,std::string> *replacements=0){
     return RDKit::RWMOL_SPTR(RDKit::SmilesToMol(smi, debugParse, sanitize,replacements));
   }
-  static RDKit::RWMOL_SPTR MolFromSmarts(std::string sma,int debugParse=0,bool mergeHs=false,
+  static RDKit::RWMOL_SPTR MolFromSmiles(const std::string &smi, const RDKit::SmilesParserParams &params){
+    return RDKit::RWMOL_SPTR(RDKit::SmilesToMol(smi, params));
+  }
+  static RDKit::RWMOL_SPTR MolFromSmarts(const std::string &sma,int debugParse=0,bool mergeHs=false,
                                          std::map<std::string,std::string> *replacements=0){
     return RDKit::RWMOL_SPTR(RDKit::SmartsToMol(sma, debugParse, mergeHs,replacements));
   }
-static RDKit::RWMOL_SPTR MolFromMolBlock(std::string molB,
+static RDKit::RWMOL_SPTR MolFromMolBlock(const std::string &molB,
                                   bool sanitize=true,bool removeHs=true){
   RDKit::RWMol *mol=0;
     mol=RDKit::MolBlockToMol(molB,sanitize,removeHs);
   return RDKit::RWMOL_SPTR(mol);
 }
-static RDKit::RWMOL_SPTR MolFromMolFile(std::string filename,
+static RDKit::RWMOL_SPTR MolFromMolFile(const std::string &filename,
                                  bool sanitize=true,bool removeHs=true){
   RDKit::RWMol *mol=0;
     mol=RDKit::MolFileToMol(filename,sanitize,removeHs);
   return RDKit::RWMOL_SPTR(mol);
 }
-static RDKit::RWMOL_SPTR MolFromTPLFile(std::string fName,bool sanitize=true,
+static RDKit::RWMOL_SPTR MolFromTPLFile(const std::string &fName,bool sanitize=true,
                       bool skipFirstConf=false) {
   RDKit::RWMol *mol=0;
     mol=RDKit::TPLFileToMol(fName, sanitize, skipFirstConf);
   return RDKit::RWMOL_SPTR(mol);
 }
-static RDKit::RWMOL_SPTR MolFromMol2File(std::string fName,bool sanitize=true,bool removeHs=true,
+static RDKit::RWMOL_SPTR MolFromMol2File(const std::string &fName,bool sanitize=true,bool removeHs=true,
                        RDKit::Mol2Type variant=RDKit::CORINA, bool cleanupSubstructures=true) {
   RDKit::RWMol *mol=0;
   mol=RDKit::Mol2FileToMol(fName, sanitize, removeHs, variant, cleanupSubstructures);
@@ -96,7 +100,7 @@ static RDKit::RWMOL_SPTR MolFromMol2Block(const std::string &molBlock,bool sanit
   return RDKit::RWMOL_SPTR(mol);
 }
 
-static RDKit::RWMOL_SPTR MolFromPDBBlock(std::string molB,
+static RDKit::RWMOL_SPTR MolFromPDBBlock(const std::string &molB,
                                          bool sanitize=true,bool removeHs=true,
                                          unsigned int flavor=0,bool proximityBonding=true){
   RDKit::RWMol *mol=0;
@@ -104,33 +108,33 @@ static RDKit::RWMOL_SPTR MolFromPDBBlock(std::string molB,
   return RDKit::RWMOL_SPTR(mol);
 }
 
-static RDKit::RWMOL_SPTR MolFromPDBFile(std::string fName,
+static RDKit::RWMOL_SPTR MolFromPDBFile(const std::string &fName,
                                         bool sanitize=true,bool removeHs=true,
                                         unsigned int flavor=0,bool proximityBonding=true){
   RDKit::RWMol *mol=0;
   mol=RDKit::PDBFileToMol(fName,sanitize,removeHs,flavor,proximityBonding);
   return RDKit::RWMOL_SPTR(mol);
 }
-static RDKit::RWMOL_SPTR MolFromSequence(std::string text,
+static RDKit::RWMOL_SPTR MolFromSequence(const std::string &text,
                                   bool sanitize=true,int flavor=0){
   RDKit::RWMol *mol=0;
   mol=RDKit::SequenceToMol(text,sanitize,flavor);
   return RDKit::RWMOL_SPTR(mol);
 }
-static RDKit::RWMOL_SPTR MolFromFASTA(std::string text,
+static RDKit::RWMOL_SPTR MolFromFASTA(const std::string &text,
                                   bool sanitize=true,int flavor=0){
   RDKit::RWMol *mol=0;
   mol=RDKit::FASTAToMol(text,sanitize,flavor);
   return RDKit::RWMOL_SPTR(mol);
 }
-static RDKit::RWMOL_SPTR MolFromHELM(std::string text,
+static RDKit::RWMOL_SPTR MolFromHELM(const std::string &text,
                                   bool sanitize=true){
   RDKit::RWMol *mol=0;
   mol=RDKit::HELMToMol(text,sanitize);
   return RDKit::RWMOL_SPTR(mol);
 }
 
-static std::vector<RDKit::RWMOL_SPTR> MolsFromCDXML(std::string text,
+static std::vector<RDKit::RWMOL_SPTR> MolsFromCDXML(const std::string &text,
 						     bool sanitize=true){
   auto res = RDKit::CDXMLToMols(text, sanitize);
   std::vector<RDKit::RWMOL_SPTR> mols;
@@ -141,7 +145,7 @@ static std::vector<RDKit::RWMOL_SPTR> MolsFromCDXML(std::string text,
 
 }
 
-static std::vector<RDKit::RWMOL_SPTR> MolsFromCDXMLFile(std::string text,
+static std::vector<RDKit::RWMOL_SPTR> MolsFromCDXMLFile(const std::string &text,
 							 bool sanitize=true){
   auto res = RDKit::CDXMLFileToMols(text, sanitize);
   std::vector<RDKit::RWMOL_SPTR> mols;

--- a/Code/JavaWrappers/csharp_wrapper/CMakeLists.txt
+++ b/Code/JavaWrappers/csharp_wrapper/CMakeLists.txt
@@ -31,7 +31,9 @@ endif(APPLE)
 
 if(CMAKE_SIZEOF_VOID_P EQUAL 4)
   SET(CMAKE_SWIG_FLAGS -namespace "GraphMolWrap")
+  SET(PLATFORM "x86")
 else()
+  SET(PLATFORM "x64")
   if (WIN32)
     SET(CMAKE_SWIG_FLAGS -namespace "GraphMolWrap")
   else()
@@ -89,7 +91,7 @@ if(NOT MSVC)
      COMMAND ${CMAKE_COMMAND} -E make_directory swig_csharp
 
      ## 1. run this custom command only after swig has been run.
-     COMMAND ${GMCS_EXE} -out:RDKit2DotNet.dll -t:library "swig_csharp/*.cs"
+     COMMAND ${GMCS_EXE} -platform:${PLATFORM} -out:RDKit2DotNet.dll -t:library "swig_csharp/*.cs"
        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
      DEPENDS "${swig_generated_file_fullname}"
    )

--- a/Code/JavaWrappers/csharp_wrapper/CMakeLists.txt
+++ b/Code/JavaWrappers/csharp_wrapper/CMakeLists.txt
@@ -24,14 +24,25 @@ else()
   SET(COPY_CMD cp -p ${COPY_SOURCE} ${COPY_DEST})
 endif()
 
-# Coax SWIG into playing nicely with Apple environments
-if(APPLE)
+# Coax SWIG into playing nicely with Apple/ARM environments
+set(HAS_ARM_PROC FALSE)
+string(TOLOWER ${CMAKE_SYSTEM_PROCESSOR} LOWERCASE_SYS_PROC)
+if(LOWERCASE_SYS_PROC MATCHES "arm")
+  set(HAS_ARM_PROC TRUE)
+endif()
+# Based on https://github.com/mono/mono/blob/5d2e3bc3b3c8184d35b2f7801e88d96470d367c4/mcs/mcs/settings.cs#L54
+# Mono seems to only support 32-bit ARM
+if(APPLE OR HAS_ARM_PROC)
   SET(CMAKE_SIZEOF_VOID_P 4)
-endif(APPLE)
+endif()
 
 if(CMAKE_SIZEOF_VOID_P EQUAL 4)
   SET(CMAKE_SWIG_FLAGS -namespace "GraphMolWrap")
-  SET(PLATFORM "x86")
+  if(HAS_ARM_PROC)
+    SET(PLATFORM "arm")
+  else()
+    SET(PLATFORM "x86")
+  endif()
 else()
   SET(PLATFORM "x64")
   if (WIN32)

--- a/Code/JavaWrappers/gmwrapper/GraphMolJava.i
+++ b/Code/JavaWrappers/gmwrapper/GraphMolJava.i
@@ -245,6 +245,17 @@ typedef unsigned long long int	uintmax_t;
 %template(Point2D_Vect) std::vector<RDGeom::Point2D *>;
 %template(Point3D_Vect) std::vector<RDGeom::Point3D *>;
 %template(Atomic_Params_Vect) std::vector<const ForceFields::UFF::AtomicParams *>;
+/*
+%include <Numerics/Vector.h>
+%extend RDNumeric::DoubleVector {
+  double getVal(int i) {
+    return ($self)->getVal(i);
+  }
+  void setVal(int i, double v) {
+    ($self)->setVal(i, v);
+  }
+}
+*/
 
 /* pair */
 %template(Int_Pair) std::pair<boost::int32_t, int >;

--- a/Code/JavaWrappers/gmwrapper/GraphMolJava.i
+++ b/Code/JavaWrappers/gmwrapper/GraphMolJava.i
@@ -245,17 +245,6 @@ typedef unsigned long long int	uintmax_t;
 %template(Point2D_Vect) std::vector<RDGeom::Point2D *>;
 %template(Point3D_Vect) std::vector<RDGeom::Point3D *>;
 %template(Atomic_Params_Vect) std::vector<const ForceFields::UFF::AtomicParams *>;
-/*
-%include <Numerics/Vector.h>
-%extend RDNumeric::DoubleVector {
-  double getVal(int i) {
-    return ($self)->getVal(i);
-  }
-  void setVal(int i, double v) {
-    ($self)->setVal(i, v);
-  }
-}
-*/
 
 /* pair */
 %template(Int_Pair) std::pair<boost::int32_t, int >;

--- a/Code/JavaWrappers/gmwrapper/src-test/org/RDKit/Chemv2Tests.java
+++ b/Code/JavaWrappers/gmwrapper/src-test/org/RDKit/Chemv2Tests.java
@@ -225,11 +225,11 @@ public class Chemv2Tests extends GraphMolTest {
             Conformer conformer0 = noradrenalineMJCopy.getConformer(0);
             Conformer conformer1 = new Conformer(conformer0);
             noradrenalineMJCopy.addConformer(conformer1, true);
-            assertTrue(noradrenalineMJ.CalcRMS(noradrenalineMJCopy, 0, 0) < 1.e-5);
-            assertTrue(noradrenalineMJ.CalcRMS(noradrenalineMJCopy, 0, 1) < 1.e-5);
+            assertTrue(noradrenalineMJ.calcRMS(noradrenalineMJCopy, 0, 0) < 1.e-5);
+            assertTrue(noradrenalineMJ.calcRMS(noradrenalineMJCopy, 0, 1) < 1.e-5);
             double scalingFactor = noradrenalineMJCopy.normalizeDepiction(1);
-            assertTrue(noradrenalineMJ.CalcRMS(noradrenalineMJCopy, 0, 0) < 1.e-5);
-            assertTrue(noradrenalineMJ.CalcRMS(noradrenalineMJCopy, 0, 1) > 1.e-5);
+            assertTrue(noradrenalineMJ.calcRMS(noradrenalineMJCopy, 0, 0) < 1.e-5);
+            assertTrue(noradrenalineMJ.calcRMS(noradrenalineMJCopy, 0, 1) > 1.e-5);
             assertEquals(scalingFactor, 1.875, 1.e-3);
             Conformer conformer2 = new Conformer(conformer1);
             noradrenalineMJCopy.addConformer(conformer2, true);
@@ -263,8 +263,8 @@ public class Chemv2Tests extends GraphMolTest {
             Conformer conformer1 = new Conformer(conformer0);
             noradrenalineMJCopy.addConformer(conformer1, true);
             double scalingFactor = noradrenalineMJCopy.normalizeDepiction(1, -1);
-            assertTrue(noradrenalineMJ.CalcRMS(noradrenalineMJCopy, 0, 0) < 1.e-5);
-            assertTrue(noradrenalineMJ.CalcRMS(noradrenalineMJCopy, 0, 1) > 1.e-5);
+            assertTrue(noradrenalineMJ.calcRMS(noradrenalineMJCopy, 0, 0) < 1.e-5);
+            assertTrue(noradrenalineMJ.calcRMS(noradrenalineMJCopy, 0, 1) > 1.e-5);
             assertEquals(scalingFactor, 1.875, 1.e-3);
             Conformer conformer2 = new Conformer(conformer1);
             noradrenalineMJCopy.addConformer(conformer2, true);
@@ -292,8 +292,8 @@ public class Chemv2Tests extends GraphMolTest {
             Conformer conformer1 = new Conformer(conformer0);
             noradrenalineMJCopy.addConformer(conformer1, true);
             double scalingFactor = noradrenalineMJCopy.normalizeDepiction(1, 0, 3.0);
-            assertTrue(noradrenalineMJ.CalcRMS(noradrenalineMJCopy, 0, 0) < 1.e-5);
-            assertTrue(noradrenalineMJ.CalcRMS(noradrenalineMJCopy, 0, 1) > 1.e-5);
+            assertTrue(noradrenalineMJ.calcRMS(noradrenalineMJCopy, 0, 0) < 1.e-5);
+            assertTrue(noradrenalineMJ.calcRMS(noradrenalineMJCopy, 0, 1) > 1.e-5);
             assertEquals(scalingFactor, 3.0, 1.e-3);
             Conformer conformer2 = new Conformer(conformer1);
             noradrenalineMJCopy.addConformer(conformer2, true);
@@ -350,7 +350,7 @@ public class Chemv2Tests extends GraphMolTest {
 
         // alignMol() would return this for the rms: 2.50561
         // But the best rms is: 2.43449
-        double rmsdInPlace = prbCopy1.CalcRMS(ref);
+        double rmsdInPlace = prbCopy1.calcRMS(ref);
         assertEquals(rmsdInPlace, 2.6026, 1.e-3);
         double rmsd = prb.getBestRMS(ref);
         assertEquals(rmsd, 2.43449, 1.e-3);
@@ -384,7 +384,7 @@ public class Chemv2Tests extends GraphMolTest {
             matchesPruned.set(i, matchPruned);
             matchPruned.delete();
         }
-        rmsdInPlace = prbCopy2.CalcRMS(ref, -1, -1, matchesPruned);
+        rmsdInPlace = prbCopy2.calcRMS(ref, -1, -1, matchesPruned);
         assertEquals(rmsdInPlace, 2.5672, 1.e-3);
         rmsd = prb.getBestRMS(ref, -1, -1, matchesPruned);
         assertEquals(rmsd, 1.14329, 1.e-3);
@@ -397,7 +397,7 @@ public class Chemv2Tests extends GraphMolTest {
                 weights.setVal(i, 100.0);
             }
         }
-        rmsdInPlace = prbCopy3.CalcRMS(ref, -1, -1, matches, 1000, true, weights);
+        rmsdInPlace = prbCopy3.calcRMS(ref, -1, -1, matches, 1000, true, weights);
         assertEquals(rmsdInPlace, 17.7959, 1.e-3);
         rmsd = prb.getBestRMS(ref, -1, -1, matches, 1000, true, weights);
         assertEquals(rmsd, 10.9681, 1.e-3);

--- a/Code/JavaWrappers/gmwrapper/src-test/org/RDKit/Chemv2Tests.java
+++ b/Code/JavaWrappers/gmwrapper/src-test/org/RDKit/Chemv2Tests.java
@@ -34,232 +34,460 @@
 package org.RDKit;
 
 import static org.junit.Assert.*;
+import java.io.File;
+import java.util.Arrays;
 
 import org.junit.Test;
 
 public class Chemv2Tests extends GraphMolTest {
 
-        /* Pickling tests skipped for the time being */
-	@Test
-	public void testBasicStuff() {
-		ROMol m = RWMol.MolFromSmiles("COC(=O)O");
-		Atom a1 = m.getAtomWithIdx(1);
-		assertEquals( 8,a1.getAtomicNum() );
-		assertEquals( 6,m.getAtomWithIdx(2).getAtomicNum() );
-		Bond b1 = m.getBondWithIdx(1);
-		assertEquals( Bond.BondType.SINGLE,b1.getBondType() );
-		assertEquals( Bond.BondType.DOUBLE,m.getBondWithIdx(2).getBondType() );
-		assertEquals( Bond.BondType.SINGLE,m.getBondBetweenAtoms(0, 1).getBondType() );
-	}
+    /* Pickling tests skipped for the time being */
+    @Test
+    public void testBasicStuff() {
+        ROMol m = RWMol.MolFromSmiles("COC(=O)O");
+        Atom a1 = m.getAtomWithIdx(1);
+        assertEquals( 8,a1.getAtomicNum() );
+        assertEquals( 6,m.getAtomWithIdx(2).getAtomicNum() );
+        Bond b1 = m.getBondWithIdx(1);
+        assertEquals( Bond.BondType.SINGLE,b1.getBondType() );
+        assertEquals( Bond.BondType.DOUBLE,m.getBondWithIdx(2).getBondType() );
+        assertEquals( Bond.BondType.SINGLE,m.getBondBetweenAtoms(0, 1).getBondType() );
+    }
 
-	@Test
-	public void testEditingPersisting()	{
-		RWMol m = RWMol.MolFromSmiles("COC(=C)O");
-		Atom a1 = m.getAtomWithIdx(3);
-		assertEquals("bad atom order",6, a1.getAtomicNum());
-		a1.setAtomicNum(7);
-		assertEquals("bad atom order",7, a1.getAtomicNum());
-		assertEquals("atom order not stored",7, m.getAtomWithIdx(3).getAtomicNum());
-	}
+    @Test
+    public void testEditingPersisting()    {
+        RWMol m = RWMol.MolFromSmiles("COC(=C)O");
+        Atom a1 = m.getAtomWithIdx(3);
+        assertEquals("bad atom order",6, a1.getAtomicNum());
+        a1.setAtomicNum(7);
+        assertEquals("bad atom order",7, a1.getAtomicNum());
+        assertEquals("atom order not stored",7, m.getAtomWithIdx(3).getAtomicNum());
+    }
 
-	@Test
-	public void testSMARTSBasics () {
-		ROMol m = RWMol.MolFromSmiles("COC(=O)O");
-		ROMol p = RWMol.MolFromSmarts("CO");
-		assertTrue(m.hasSubstructMatch(p));
-		ROMol p2 = RWMol.MolFromSmarts("CS");
-		assertFalse(m.hasSubstructMatch(p2));
-		assertEquals( 2,p.getNumAtoms() );
-		assertEquals( 1,p.getNumBonds() );
-		assertTrue(m.hasSubstructMatch(p));
-		Match_Vect_Vect matches = m.getSubstructMatches(p);
-		assertEquals( 3,matches.size() );
-		Match_Vect match = matches.get(0);
-		assertEquals("bad match length", 2, match.size() );
-		matches = m.getSubstructMatches(p, false);
-		assertEquals( 3,matches.size() );
-		match = matches.get(0);
-		assertEquals("bad match length", 2, match.size() );
+    @Test
+    public void testSMARTSBasics () {
+        ROMol m = RWMol.MolFromSmiles("COC(=O)O");
+        ROMol p = RWMol.MolFromSmarts("CO");
+        assertTrue(m.hasSubstructMatch(p));
+        ROMol p2 = RWMol.MolFromSmarts("CS");
+        assertFalse(m.hasSubstructMatch(p2));
+        assertEquals( 2,p.getNumAtoms() );
+        assertEquals( 1,p.getNumBonds() );
+        assertTrue(m.hasSubstructMatch(p));
+        Match_Vect_Vect matches = m.getSubstructMatches(p);
+        assertEquals( 3,matches.size() );
+        Match_Vect match = matches.get(0);
+        assertEquals("bad match length", 2, match.size() );
+        matches = m.getSubstructMatches(p, false);
+        assertEquals( 3,matches.size() );
+        match = matches.get(0);
+        assertEquals("bad match length", 2, match.size() );
 
-		p = RWMol.MolFromSmarts("COC");
-		assertTrue(m.hasSubstructMatch(p));
-		assertEquals( 3,p.getNumAtoms() );
-		assertEquals( 2,p.getNumBonds() );
-		assertTrue(m.hasSubstructMatch(p));
-		matches = m.getSubstructMatches(p);
-		assertEquals( 1,matches.size() );
-		matches = m.getSubstructMatches(p, false);
-		assertEquals( 2,matches.size() );
-	}
+        p = RWMol.MolFromSmarts("COC");
+        assertTrue(m.hasSubstructMatch(p));
+        assertEquals( 3,p.getNumAtoms() );
+        assertEquals( 2,p.getNumBonds() );
+        assertTrue(m.hasSubstructMatch(p));
+        matches = m.getSubstructMatches(p);
+        assertEquals( 1,matches.size() );
+        matches = m.getSubstructMatches(p, false);
+        assertEquals( 2,matches.size() );
+    }
 
-	@Test
-	public void testDataGetSetSuccess() {
-		ROMol m = RWMol.MolFromSmiles("CCOC");
-		m.setProp("foo", "3");
-		String v = m.getProp("foo");
-		assertEquals("3",v);
-	}
+    @Test
+    public void testDataGetSetSuccess() {
+        ROMol m = RWMol.MolFromSmiles("CCOC");
+        m.setProp("foo", "3");
+        String v = m.getProp("foo");
+        assertEquals("3",v);
+    }
 
         @Test(expected=KeyErrorException.class)
-	public void testDataGetSetFailure() {
-		ROMol m = RWMol.MolFromSmiles("CCOC");
-		m.getProp("monkey");
-	}
+    public void testDataGetSetFailure() {
+        ROMol m = RWMol.MolFromSmiles("CCOC");
+        m.getProp("monkey");
+    }
 
-	@Test
-	public void testIssue399() {
-		ROMol m = RWMol.MolFromSmiles("[C@H]1(C)CO1");
-		m.compute2DCoords();
-		Conformer c = m.getConformer();
-		m.WedgeMolBonds(c);
-		assertEquals( Bond.BondDir.BEGINDASH,m.getBondWithIdx(0).getBondDir() );
-		assertEquals( Bond.BondDir.NONE,m.getBondWithIdx(1).getBondDir() );
-		assertEquals( Bond.BondDir.NONE,m.getBondWithIdx(2).getBondDir() );
-		assertEquals( Bond.BondDir.NONE,m.getBondWithIdx(3).getBondDir() );
-	}
+    @Test
+    public void testIssue399() {
+        ROMol m = RWMol.MolFromSmiles("[C@H]1(C)CO1");
+        m.compute2DCoords();
+        Conformer c = m.getConformer();
+        m.WedgeMolBonds(c);
+        assertEquals( Bond.BondDir.BEGINDASH,m.getBondWithIdx(0).getBondDir() );
+        assertEquals( Bond.BondDir.NONE,m.getBondWithIdx(1).getBondDir() );
+        assertEquals( Bond.BondDir.NONE,m.getBondWithIdx(2).getBondDir() );
+        assertEquals( Bond.BondDir.NONE,m.getBondWithIdx(3).getBondDir() );
+    }
 
-	@Test
-	public void test2DWithSetAtomLocs() {
-		ROMol m = RWMol.MolFromSmiles("C[C@H]1CO1");
-		Atom a0 = m.getAtomWithIdx(0);
-		Int_Point2D_Map coords = new Int_Point2D_Map();
-		coords.set((int) a0.getIdx(), new Point2D(1.0, 1.5));
-		RDKFuncs.setPreferCoordGen(false);
-		long confIdx = m.compute2DCoords(coords);
-		Conformer c = m.getConformer((int) confIdx);
-		assertEquals(1.0, c.getAtomPos(a0.getIdx()).getX(), defaultDoubleTol);
-		assertEquals(1.5, c.getAtomPos(a0.getIdx()).getY(), defaultDoubleTol);
-	}
+    @Test
+    public void test2DWithSetAtomLocs() {
+        ROMol m = RWMol.MolFromSmiles("C[C@H]1CO1");
+        Atom a0 = m.getAtomWithIdx(0);
+        Int_Point2D_Map coords = new Int_Point2D_Map();
+        coords.set((int) a0.getIdx(), new Point2D(1.0, 1.5));
+        RDKFuncs.setPreferCoordGen(false);
+        long confIdx = m.compute2DCoords(coords);
+        Conformer c = m.getConformer((int) confIdx);
+        assertEquals(1.0, c.getAtomPos(a0.getIdx()).getX(), defaultDoubleTol);
+        assertEquals(1.5, c.getAtomPos(a0.getIdx()).getY(), defaultDoubleTol);
+    }
 
+    @Test
+    public void testMatchingDepictions() {
+        ROMol template = RWMol.MolFromSmiles("c1nccc2n1ccc2");
+        template.compute2DCoords();
+        ROMol m = RWMol.MolFromSmiles("c1cccc2ncn3cccc3c21");
+        ROMol patt = RWMol.MolFromSmarts("*1****2*1***2");
+        m.generateDepictionMatching2DStructure(template,-1,patt);
 
-	@Test
-	public void testMatchingDepictions() {
-		ROMol template = RWMol.MolFromSmiles("c1nccc2n1ccc2");
-		template.compute2DCoords();
-		ROMol m = RWMol.MolFromSmiles("c1cccc2ncn3cccc3c21");
-		ROMol patt = RWMol.MolFromSmarts("*1****2*1***2");
-		m.generateDepictionMatching2DStructure(template,-1,patt);		
+        // System.out.print(template.MolToMolBlock());
+        // System.out.print(m.MolToMolBlock());
+        Conformer c1 = template.getConformer();
+        Conformer c2 = m.getConformer();
+        assertEquals(c1.getAtomPos(0).getX(), c2.getAtomPos(6).getX(), defaultDoubleTol);
+        assertEquals(c1.getAtomPos(0).getY(), c2.getAtomPos(6).getY(), defaultDoubleTol);
+        assertEquals(c1.getAtomPos(0).getZ(), c2.getAtomPos(6).getZ(), defaultDoubleTol);
+    }
 
-		// System.out.print(template.MolToMolBlock());
-		// System.out.print(m.MolToMolBlock());
-		Conformer c1 = template.getConformer();
-		Conformer c2 = m.getConformer();
-		assertEquals(c1.getAtomPos(0).getX(), c2.getAtomPos(6).getX(), defaultDoubleTol);
-		assertEquals(c1.getAtomPos(0).getY(), c2.getAtomPos(6).getY(), defaultDoubleTol);
-		assertEquals(c1.getAtomPos(0).getZ(), c2.getAtomPos(6).getZ(), defaultDoubleTol);
-	}
-
-
-	@Test
-	public void testGenerateSVG() {
-		ROMol m = RWMol.MolFromSmiles("[C@H]1(C)CO1");
-		m.compute2DCoords();
-		Conformer c = m.getConformer();
-		m.WedgeMolBonds(c);
+    @Test
+    public void testGenerateSVG() {
+        ROMol m = RWMol.MolFromSmiles("[C@H]1(C)CO1");
+        m.compute2DCoords();
+        Conformer c = m.getConformer();
+        m.WedgeMolBonds(c);
                 String svg=m.ToSVG(8,50);
                 assertTrue(svg.indexOf("<svg")>-1);
                 assertTrue(svg.indexOf("</svg>")>-1);
-	}
+    }
 
-	@Test
-	public void testMolDraw2DSVG() {
-          ROMol m = RWMol.MolFromSmiles("[C@H]1(C)CO1");
-          m.compute2DCoords();
-          Conformer c = m.getConformer();
-          m.WedgeMolBonds(c);
-          MolDraw2DSVG drawer = new MolDraw2DSVG(300, 300);
-          drawer.drawMolecule(m);
-          drawer.finishDrawing();
-          String svg = drawer.getDrawingText();
-          assertTrue(svg.indexOf("<svg") > -1);
-          assertTrue(svg.indexOf("</svg>") > -1);
+    @Test
+    public void testMolDraw2DSVG() {
+        ROMol m = RWMol.MolFromSmiles("[C@H]1(C)CO1");
+        m.compute2DCoords();
+        Conformer c = m.getConformer();
+        m.WedgeMolBonds(c);
+        MolDraw2DSVG drawer = new MolDraw2DSVG(300, 300);
+        drawer.drawMolecule(m);
+        drawer.finishDrawing();
+        String svg = drawer.getDrawingText();
+        assertTrue(svg.indexOf("<svg") > -1);
+        assertTrue(svg.indexOf("</svg>") > -1);
+    }
+
+    @Test
+    public void testMolDraw2DSVGSingleAtomMol() {
+        ROMol m = RWMol.MolFromSmiles("C");
+        m.compute2DCoords();
+        Conformer c = m.getConformer();
+        m.WedgeMolBonds(c);
+        MolDraw2DSVG drawer = new MolDraw2DSVG(300, 300);
+        drawer.drawMolecule(m);
+        drawer.finishDrawing();
+        String svg = drawer.getDrawingText();
+        assertTrue(svg.indexOf("<svg") > -1);
+        assertTrue(svg.indexOf("</svg>") > -1);
+    }
+
+    @Test
+    public void testNormalizeStraightenDepiction() {
+        ROMol noradrenalineMJ = RWMol.MolFromMolBlock("\n" +
+"  MJ201100                      \n" +
+"\n" +
+" 12 12  0  0  1  0  0  0  0  0999 V2000\n" +
+"    2.2687    1.0716    0.0000 N   0  0  0  0  0  0  0  0  0  0  0  0\n" +
+"    1.4437    1.0716    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" +
+"    1.0312    0.3572    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" +
+"    1.4437   -0.3572    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0\n" +
+"    0.2062    0.3572    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" +
+"   -0.2062   -0.3572    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" +
+"   -1.0312   -0.3572    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" +
+"   -1.4437   -1.0716    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0\n" +
+"   -1.4437    0.3572    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" +
+"   -2.2687    0.3572    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0\n" +
+"   -1.0312    1.0716    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" +
+"   -0.2062    1.0716    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" +
+"  1  2  1  0  0  0  0\n" +
+"  3  2  1  0  0  0  0\n" +
+"  3  4  1  6  0  0  0\n" +
+"  3  5  1  0  0  0  0\n" +
+"  5  6  2  0  0  0  0\n" +
+"  6  7  1  0  0  0  0\n" +
+"  7  8  1  0  0  0  0\n" +
+"  7  9  2  0  0  0  0\n" +
+"  9 10  1  0  0  0  0\n" +
+"  9 11  1  0  0  0  0\n" +
+" 11 12  2  0  0  0  0\n" +
+"  5 12  1  0  0  0  0\n" +
+"M  END");
+        {
+            ROMol noradrenalineMJCopy = new RWMol(noradrenalineMJ);
+            Conformer conformer0 = noradrenalineMJCopy.getConformer(0);
+            Conformer conformer1 = new Conformer(conformer0);
+            noradrenalineMJCopy.addConformer(conformer1, true);
+            assertTrue(noradrenalineMJ.CalcRMS(noradrenalineMJCopy, 0, 0) < 1.e-5);
+            assertTrue(noradrenalineMJ.CalcRMS(noradrenalineMJCopy, 0, 1) < 1.e-5);
+            double scalingFactor = noradrenalineMJCopy.normalizeDepiction(1);
+            assertTrue(noradrenalineMJ.CalcRMS(noradrenalineMJCopy, 0, 0) < 1.e-5);
+            assertTrue(noradrenalineMJ.CalcRMS(noradrenalineMJCopy, 0, 1) > 1.e-5);
+            assertEquals(scalingFactor, 1.875, 1.e-3);
+            Conformer conformer2 = new Conformer(conformer1);
+            noradrenalineMJCopy.addConformer(conformer2, true);
+            Point3D bond10_11Conf0 = conformer0.getAtomPos(11).minus(conformer0.getAtomPos(10));
+            assertEquals(bond10_11Conf0.getX(), 0.825, 1.e-3);
+            assertEquals(bond10_11Conf0.getY(), 0.0, 1.e-3);
+            Point3D bond10_11Conf1 = conformer1.getAtomPos(11).minus(conformer1.getAtomPos(10));
+            assertEquals(bond10_11Conf1.getX(), 1.513, 1.e-3);
+            assertEquals(bond10_11Conf1.getY(), -0.321, 1.e-3);
+            noradrenalineMJCopy.straightenDepiction(1);
+            bond10_11Conf1 = conformer1.getAtomPos(11).minus(conformer1.getAtomPos(10));
+            assertEquals(bond10_11Conf1.getX(), 1.340, 1.e-3);
+            assertEquals(bond10_11Conf1.getY(), -0.773, 1.e-3);
+            Point3D bond4_11Conf1 = conformer1.getAtomPos(11).minus(conformer1.getAtomPos(4));
+            assertEquals(bond4_11Conf1.getX(), 0.0, 1.e-3);
+            assertEquals(bond4_11Conf1.getY(), 1.547, 1.e-3);
+            noradrenalineMJCopy.straightenDepiction(2, true);
+            Point3D bond10_11Conf2 = conformer2.getAtomPos(11).minus(conformer2.getAtomPos(10));
+            assertEquals(bond10_11Conf2.getX(), 1.547, 1.e-3);
+            assertEquals(bond10_11Conf2.getY(), 0.0, 1.e-3);
+            Point3D bond4_11Conf2 = conformer2.getAtomPos(11).minus(conformer2.getAtomPos(4));
+            assertEquals(bond4_11Conf2.getX(), -0.773, 1.e-3);
+            assertEquals(bond4_11Conf2.getY(), 1.339, 1.e-3);
+            noradrenalineMJCopy.delete();
+            conformer1.delete();
+            conformer2.delete();
         }
-        @Test
-        public void testMolDraw2DSVGSingleAtomMol() {
-          ROMol m = RWMol.MolFromSmiles("C");
-          m.compute2DCoords();
-          Conformer c = m.getConformer();
-          m.WedgeMolBonds(c);
-          MolDraw2DSVG drawer = new MolDraw2DSVG(300, 300);
-          drawer.drawMolecule(m);
-          drawer.finishDrawing();
-          String svg = drawer.getDrawingText();
-          assertTrue(svg.indexOf("<svg") > -1);
-          assertTrue(svg.indexOf("</svg>") > -1);
+        {
+            ROMol noradrenalineMJCopy = new RWMol(noradrenalineMJ);
+            Conformer conformer0 = noradrenalineMJCopy.getConformer(0);
+            Conformer conformer1 = new Conformer(conformer0);
+            noradrenalineMJCopy.addConformer(conformer1, true);
+            double scalingFactor = noradrenalineMJCopy.normalizeDepiction(1, -1);
+            assertTrue(noradrenalineMJ.CalcRMS(noradrenalineMJCopy, 0, 0) < 1.e-5);
+            assertTrue(noradrenalineMJ.CalcRMS(noradrenalineMJCopy, 0, 1) > 1.e-5);
+            assertEquals(scalingFactor, 1.875, 1.e-3);
+            Conformer conformer2 = new Conformer(conformer1);
+            noradrenalineMJCopy.addConformer(conformer2, true);
+            Point3D bond10_11Conf0 = conformer0.getAtomPos(11).minus(conformer0.getAtomPos(10));
+            assertEquals(bond10_11Conf0.getX(), 0.825, 1.e-3);
+            assertEquals(bond10_11Conf0.getY(), 0.0, 1.e-3);
+            Point3D bond10_11Conf1 = conformer1.getAtomPos(11).minus(conformer1.getAtomPos(10));
+            assertEquals(bond10_11Conf1.getX(), 0.321, 1.e-3);
+            assertEquals(bond10_11Conf1.getY(), 1.513, 1.e-3);
+            noradrenalineMJCopy.straightenDepiction(1);
+            bond10_11Conf1 = conformer1.getAtomPos(11).minus(conformer1.getAtomPos(10));
+            assertEquals(bond10_11Conf1.getX(), 0.0, 1.e-3);
+            assertEquals(bond10_11Conf1.getY(), 1.547, 1.e-3);
+            noradrenalineMJCopy.straightenDepiction(2, true);
+            Point3D bond10_11Conf2 = conformer2.getAtomPos(11).minus(conformer2.getAtomPos(10));
+            assertEquals(bond10_11Conf2.getX(), bond10_11Conf1.getX(), 1.e-3);
+            assertEquals(bond10_11Conf2.getY(), bond10_11Conf1.getY(), 1.e-3);
+            noradrenalineMJCopy.delete();
+            conformer1.delete();
+            conformer2.delete();
         }
-        @Test
-        public void testPrepareMolForDrawing() {
-          RWMol m = RWMol.MolFromSmiles("c1ccccc1");
-          RDKFuncs.prepareMolForDrawing(m);
-          assertEquals(m.getNumConformers(), 1);
-          assertTrue(m.getBondBetweenAtoms(0, 1).getBondType() !=
-                     Bond.BondType.AROMATIC);
-          assertTrue(m.getBondBetweenAtoms(0, 1).getIsAromatic());
-
-          MolDraw2DSVG drawer = new MolDraw2DSVG(300, 300);
-          drawer.drawMolecule(m);
-          drawer.finishDrawing();
-          String svg = drawer.getDrawingText();
-          assertTrue(svg.indexOf("<svg") > -1);
-          assertTrue(svg.indexOf("</svg>") > -1);
+        {
+            ROMol noradrenalineMJCopy = new RWMol(noradrenalineMJ);
+            Conformer conformer0 = noradrenalineMJCopy.getConformer(0);
+            Conformer conformer1 = new Conformer(conformer0);
+            noradrenalineMJCopy.addConformer(conformer1, true);
+            double scalingFactor = noradrenalineMJCopy.normalizeDepiction(1, 0, 3.0);
+            assertTrue(noradrenalineMJ.CalcRMS(noradrenalineMJCopy, 0, 0) < 1.e-5);
+            assertTrue(noradrenalineMJ.CalcRMS(noradrenalineMJCopy, 0, 1) > 1.e-5);
+            assertEquals(scalingFactor, 3.0, 1.e-3);
+            Conformer conformer2 = new Conformer(conformer1);
+            noradrenalineMJCopy.addConformer(conformer2, true);
+            Conformer conformer3 = new Conformer(conformer1);
+            noradrenalineMJCopy.addConformer(conformer3, true);
+            Point3D bond10_11Conf0 = conformer0.getAtomPos(11).minus(conformer0.getAtomPos(10));
+            assertEquals(bond10_11Conf0.getX(), 0.825, 1.e-3);
+            assertEquals(bond10_11Conf0.getY(), 0.0, 1.e-3);
+            Point3D bond10_11Conf1 = conformer1.getAtomPos(11).minus(conformer1.getAtomPos(10));
+            assertEquals(bond10_11Conf1.getX(), 2.475, 1.e-3);
+            assertEquals(bond10_11Conf1.getY(), 0.0, 1.e-3);
+            noradrenalineMJCopy.straightenDepiction(1);
+            bond10_11Conf1 = conformer1.getAtomPos(11).minus(conformer1.getAtomPos(10));
+            assertEquals(bond10_11Conf1.getX(), 2.143, 1.e-3);
+            assertEquals(bond10_11Conf1.getY(), -1.237, 1.e-3);
+            Point3D bond4_11Conf1 = conformer1.getAtomPos(11).minus(conformer1.getAtomPos(4));
+            assertEquals(bond4_11Conf1.getX(), 0.0, 1.e-3);
+            assertEquals(bond4_11Conf1.getY(), 2.475, 1.e-3);
+            noradrenalineMJCopy.straightenDepiction(2, true);
+            Point3D bond10_11Conf2 = conformer2.getAtomPos(11).minus(conformer2.getAtomPos(10));
+            Point3D bond10_11Conf3 = conformer3.getAtomPos(11).minus(conformer3.getAtomPos(10));
+            assertEquals(bond10_11Conf2.getX(), bond10_11Conf3.getX(), 1.e-3);
+            assertEquals(bond10_11Conf2.getY(), bond10_11Conf3.getY(), 1.e-3);
+            Point3D bond4_11Conf2 = conformer2.getAtomPos(11).minus(conformer2.getAtomPos(4));
+            Point3D bond4_11Conf3 = conformer3.getAtomPos(11).minus(conformer3.getAtomPos(4));
+            assertEquals(bond4_11Conf2.getX(), bond4_11Conf3.getX(), 1.e-3);
+            assertEquals(bond4_11Conf2.getY(), bond4_11Conf3.getY(), 1.e-3);
+            noradrenalineMJCopy.delete();
+            conformer1.delete();
+            conformer2.delete();
+            conformer3.delete();
         }
-        @Test
-        public void testMolDraw2DHighlight() {
-          RWMol m = RWMol.MolFromSmiles("CCCCCOC");
-          RDKFuncs.prepareMolForDrawing(m);
-          Int_Vect hats = new Int_Vect();
-          hats.add(0);
-          hats.add(1);
-          hats.add(2);
+    }
 
-          Int_Vect hbs = new Int_Vect();
-          hbs.add(0);
-          hbs.add(1);
-          hbs.add(2);
+    @Test
+    public void testGetBestRMS() {
+        String rdpath = System.getenv("RDBASE");
+        if (rdpath == null)
+            org.junit.Assert.fail("No definition for RDBASE");
+        File base = new File(rdpath);
+        File testFile = new File(base, "Code" + File.separator + "GraphMol"
+                + File.separator + "MolAlign" + File.separator + "test_data"
+                + File.separator + "probe_mol.sdf");
+        String fName = testFile.getAbsolutePath();
+        SDMolSupplier supplier = new SDMolSupplier(fName, true, false);
+        supplier.next();
+        ROMol prb = supplier.next();
+        ROMol ref = supplier.next();
+        ROMol prbCopy1 = new ROMol(prb);
+        ROMol prbCopy2 = new ROMol(prb);
+        ROMol prbCopy3 = new ROMol(prb);
+        Transform3D bestTrans = new Transform3D();
+        Match_Vect bestMatch = new Match_Vect();
 
-          ColourPalette atCs = new ColourPalette();
-          atCs.set(0, new DrawColour(1, 1, 0));
-          atCs.set(1, new DrawColour(1, 0, 1));
-          atCs.set(2, new DrawColour(0, 1, 1));
-          ColourPalette bCs = new ColourPalette();
+        // alignMol() would return this for the rms: 2.50561
+        // But the best rms is: 2.43449
+        double rmsdInPlace = prbCopy1.CalcRMS(ref);
+        assertEquals(rmsdInPlace, 2.6026, 1.e-3);
+        double rmsd = prb.getBestRMS(ref);
+        assertEquals(rmsd, 2.43449, 1.e-3);
+        double rmsdCopy = prbCopy1.getBestAlignmentTransform(ref, bestTrans, bestMatch);
+        assertEquals(rmsd, rmsdCopy, 1.e-3);
+        assertEquals(bestMatch.size(), ref.getNumAtoms());
 
-          MolDraw2DSVG drawer = new MolDraw2DSVG(300, 300);
-          drawer.drawMolecule(m, "THE_LEGEND", hats, hbs, atCs, bCs);
-          drawer.finishDrawing();
-          String svg = drawer.getDrawingText();
-          // System.out.print(svg);
-          assertTrue(svg.indexOf("<svg") > -1);
-          assertTrue(svg.indexOf("</svg>") > -1);
-          assertTrue(svg.indexOf("fill:#FFFF00;") > -1);
-          assertTrue(svg.indexOf("fill:#FF00FF;") > -1);
-          assertTrue(svg.indexOf("fill:#00FFFF;") > -1);
-          // default line color:
-          assertTrue(svg.indexOf("stroke:#FF7F7F;") > -1);
+        SmilesParserParams params = new SmilesParserParams();
+        params.setRemoveHs(false);
+        RWMol scaffold = RWMol.MolFromSmiles("N1C([H])([H])C([H])([H])C([H])([H])[N+]([H])([H])C([H])([H])C1([H])[H]", params);
+        Match_Vect scaffoldMatch = ref.getSubstructMatch(scaffold);
+        assertFalse(scaffoldMatch.isEmpty());
+        int nAtoms = (int)ref.getNumAtoms();
+        boolean[] scaffoldIndices = new boolean[nAtoms];
+        Arrays.fill(scaffoldIndices, false);
+        for (int i = 0; i < scaffoldMatch.size(); ++i) {
+            int pairSecond = scaffoldMatch.get(i).getSecond();
+            scaffoldIndices[pairSecond] = true;
         }
-        @Test
-        public void testMolDraw2DContours() {
-		  // really just a test to make sure this can be called
-          RWMol m = RWMol.MolFromSmiles("CCCCCOC");
-		  RDKFuncs.prepareMolForDrawing(m);
-		  Point2D_Vect cents = new Point2D_Vect();
-		  Double_Vect weights = new Double_Vect();
-		  Double_Vect widths = new Double_Vect();
-		  for(int i=0;i<m.getNumAtoms();++i){
-			  cents.add(new Point2D(m.getConformer().getAtomPos(i)));
-			  weights.add(1.0);
-			  widths.add(0.4);
-		  }
-		  MolDraw2DSVG drawer = new MolDraw2DSVG(300, 300);
-		  drawer.clearDrawing();
-		  RDKFuncs.ContourAndDrawGaussians(drawer,cents,weights,widths,10);
-		  drawer.drawOptions().setClearBackground(false); 
-		  drawer.drawMolecule(m);
-		  drawer.finishDrawing();
-		  String svg = drawer.getDrawingText();
-		  System.out.print(svg);
-		}
-        public static void main(String args[]) {
-		org.junit.runner.JUnitCore.main("org.RDKit.Chemv2Tests");
-	}
+        Match_Vect_Vect matches = ref.getSubstructMatches(prb, false);
+        Match_Vect_Vect matchesPruned = new Match_Vect_Vect(matches.size());
+        for (int i = 0; i < matches.size(); ++i) {
+            Match_Vect match = matches.get(i);
+            Match_Vect matchPruned = new Match_Vect();
+            for (int j = 0; j < match.size(); ++j) {
+                int pairSecond = match.get(j).getSecond();
+                if (scaffoldIndices[pairSecond]) {
+                    matchPruned.add(match.get(j));
+                }
+            }
+            matchesPruned.set(i, matchPruned);
+            matchPruned.delete();
+        }
+        rmsdInPlace = prbCopy2.CalcRMS(ref, -1, -1, matchesPruned);
+        assertEquals(rmsdInPlace, 2.5672, 1.e-3);
+        rmsd = prb.getBestRMS(ref, -1, -1, matchesPruned);
+        assertEquals(rmsd, 1.14329, 1.e-3);
+        rmsdCopy = prbCopy2.getBestAlignmentTransform(ref, bestTrans, bestMatch, -1, -1, matchesPruned);
+        assertEquals(rmsd, rmsdCopy, 1.e-3);
+        assertEquals(bestMatch.size(), scaffoldMatch.size());
+        DoubleVector weights = new DoubleVector(nAtoms, 1.0);
+        for (int i = 0; i < nAtoms; ++i) {
+            if (scaffoldIndices[i]) {
+                weights.setVal(i, 100.0);
+            }
+        }
+        rmsdInPlace = prbCopy3.CalcRMS(ref, -1, -1, matches, 1000, true, weights);
+        assertEquals(rmsdInPlace, 17.7959, 1.e-3);
+        rmsd = prb.getBestRMS(ref, -1, -1, matches, 1000, true, weights);
+        assertEquals(rmsd, 10.9681, 1.e-3);
+        rmsdCopy = prbCopy3.getBestAlignmentTransform(ref, bestTrans, bestMatch, -1, -1, matches, 1000, true, weights);
+        assertEquals(rmsd, rmsdCopy, 1.e-3);
+        assertEquals(bestMatch.size(), ref.getNumAtoms());
+        supplier.delete();
+        prbCopy1.delete();
+        prbCopy2.delete();
+        prbCopy3.delete();
+        params.delete();
+        matchesPruned.delete();
+        weights.delete();
+    }
 
+    @Test
+    public void testPrepareMolForDrawing() {
+        RWMol m = RWMol.MolFromSmiles("c1ccccc1");
+        RDKFuncs.prepareMolForDrawing(m);
+        assertEquals(m.getNumConformers(), 1);
+        assertTrue(m.getBondBetweenAtoms(0, 1).getBondType() !=
+                    Bond.BondType.AROMATIC);
+        assertTrue(m.getBondBetweenAtoms(0, 1).getIsAromatic());
+
+        MolDraw2DSVG drawer = new MolDraw2DSVG(300, 300);
+        drawer.drawMolecule(m);
+        drawer.finishDrawing();
+        String svg = drawer.getDrawingText();
+        assertTrue(svg.indexOf("<svg") > -1);
+        assertTrue(svg.indexOf("</svg>") > -1);
+    }
+
+    @Test
+    public void testMolDraw2DHighlight() {
+        RWMol m = RWMol.MolFromSmiles("CCCCCOC");
+        RDKFuncs.prepareMolForDrawing(m);
+        Int_Vect hats = new Int_Vect();
+        hats.add(0);
+        hats.add(1);
+        hats.add(2);
+
+        Int_Vect hbs = new Int_Vect();
+        hbs.add(0);
+        hbs.add(1);
+        hbs.add(2);
+
+        ColourPalette atCs = new ColourPalette();
+        atCs.set(0, new DrawColour(1, 1, 0));
+        atCs.set(1, new DrawColour(1, 0, 1));
+        atCs.set(2, new DrawColour(0, 1, 1));
+        ColourPalette bCs = new ColourPalette();
+
+        MolDraw2DSVG drawer = new MolDraw2DSVG(300, 300);
+        drawer.drawMolecule(m, "THE_LEGEND", hats, hbs, atCs, bCs);
+        drawer.finishDrawing();
+        String svg = drawer.getDrawingText();
+        // System.out.print(svg);
+        assertTrue(svg.indexOf("<svg") > -1);
+        assertTrue(svg.indexOf("</svg>") > -1);
+        assertTrue(svg.indexOf("fill:#FFFF00;") > -1);
+        assertTrue(svg.indexOf("fill:#FF00FF;") > -1);
+        assertTrue(svg.indexOf("fill:#00FFFF;") > -1);
+        // default line color:
+        assertTrue(svg.indexOf("stroke:#FF7F7F;") > -1);
+    }
+
+    @Test
+    public void testMolDraw2DContours() {
+        // really just a test to make sure this can be called
+        RWMol m = RWMol.MolFromSmiles("CCCCCOC");
+        RDKFuncs.prepareMolForDrawing(m);
+        Point2D_Vect cents = new Point2D_Vect();
+        Double_Vect weights = new Double_Vect();
+        Double_Vect widths = new Double_Vect();
+        for(int i=0;i<m.getNumAtoms();++i){
+            cents.add(new Point2D(m.getConformer().getAtomPos(i)));
+            weights.add(1.0);
+            widths.add(0.4);
+        }
+        MolDraw2DSVG drawer = new MolDraw2DSVG(300, 300);
+        drawer.clearDrawing();
+        RDKFuncs.ContourAndDrawGaussians(drawer,cents,weights,widths,10);
+        drawer.drawOptions().setClearBackground(false);
+        drawer.drawMolecule(m);
+        drawer.finishDrawing();
+        String svg = drawer.getDrawingText();
+        System.out.print(svg);
+    }
+
+    public static void main(String args[]) {
+        org.junit.runner.JUnitCore.main("org.RDKit.Chemv2Tests");
+    }
 }

--- a/Code/JavaWrappers/transforms.i
+++ b/Code/JavaWrappers/transforms.i
@@ -53,6 +53,7 @@
 %template(IntSymmMatrix) RDNumeric::SymmMatrix<int>;
 %template(DoubleSymmMatrix) RDNumeric::SymmMatrix<double>;
 %template(DoubleSquareMatrix) RDNumeric::SquareMatrix<double>;
+%template(DoubleVector) RDNumeric::Vector<double>;
 
 %include <Geometry/Transform.h>
 %include <Geometry/Transform2D.h>


### PR DESCRIPTION
This PR exposes a few methods and classes to SWIG that were not yet exposed, plus a useful `MolFromSmiles` overload.
It also fixes an oversight in the `getBestRMS()` C++ signature, and a couple of glitches in the C# MinGW builds.

- `setenv()` should be defined also for MinGW builds, not just MSVC
- fixed `getBestRMS()` signature (`ROMol&` should be `const`)
- expose `normalizeDepiction()`, `straightenDepiction()`, `getBestRMS()`, `CalcRMS()` and `getBestAlignmentTransform()` to SWIG wrappers
- expose `MolFromSmiles()` overload taking `SmilesParserParams` parameter to SWIG wrappers
- expose `DoubleVector` class to SWIG wrappers as it is needed by alignment functions
- replace `std::string` with `const std::string&` in several SWIG wrapper signatures
- build `RDKit2DotNet.dll` as a 64-bit library on MinGW 64-bit
- add Java tests for the newly exposed SWIG functions
- fixed inconsistent indentation in `Chemv2Tests.java`