### PR TITLE
Avoid incurring into division by zero in normalizeDepiction

### DIFF
--- a/Code/GraphMol/Depictor/testDepictor.cpp
+++ b/Code/GraphMol/Depictor/testDepictor.cpp
@@ -1442,6 +1442,30 @@ M  END)RES"_ctab;
     TEST_ASSERT(RDKit::feq(bond4_11Conf2.x, bond4_11Conf3.x, 1.e-3));
     TEST_ASSERT(RDKit::feq(bond4_11Conf2.y, bond4_11Conf3.y, 1.e-3));
   }
+  {
+    std::string zeroCoordCTab = R"RES(
+     RDKit          2D
+
+  6  6  0  0  0  0  0  0  0  0999 V2000
+    0.0000    0.0000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    0.0000    0.0000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    0.0000    0.0000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    0.0000    0.0000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    0.0000    0.0000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    0.0000    0.0000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+  1  2  2  0
+  2  3  1  0
+  3  4  2  0
+  4  5  1  0
+  5  6  2  0
+  6  1  1  0
+M  END
+)RES";
+    std::unique_ptr<RWMol> zeroCoordBenzene(MolBlockToMol(zeroCoordCTab));
+    auto res = RDDepict::normalizeDepiction(*zeroCoordBenzene);
+    TEST_ASSERT(res < 0.);
+    TEST_ASSERT(MolToMolBlock(*zeroCoordBenzene) == zeroCoordCTab);
+  }
 }
 
 int main() {


### PR DESCRIPTION
Small fix to avoid incurring into division by zero, e.g., when coordinates of the molecule are all zero.