### PR TITLE
Allow properties to be displayed in jupyter when 3D rendering is enabled

### DIFF
--- a/rdkit/Chem/Draw/IPythonConsole.py
+++ b/rdkit/Chem/Draw/IPythonConsole.py
@@ -43,6 +43,7 @@ bgcolor_3d = '0xeeeeee'
 drawOptions = rdMolDraw2D.MolDrawOptions()
 InteractiveRenderer._defaultDrawOptions = drawOptions
 
+
 def addMolToView(mol, view, confId=-1, drawAs=None):
   if mol.GetNumAtoms() >= 999 or drawAs == 'cartoon':
     # py3DMol is happier with TER and MASTER records present
@@ -92,15 +93,15 @@ def _toJSON(mol):
 
 
 def _wrapHTMLIntoTable(html):
-  return InteractiveRenderer.injectHTMLHeaderBeforeTable(f'<div><table><tbody><tr><td style="width: {molSize[0]}px; ' +
-                                     f'height: {molSize[1]}px; text-align: center;">' +
-                                     html.replace(" scoped", "") +
-                                     '</td></tr></tbody></table></div>')
+  return InteractiveRenderer.injectHTMLHeaderBeforeTable(
+    f'<div><table><tbody><tr><td style="width: {molSize[0]}px; ' +
+    f'height: {molSize[1]}px; text-align: center;">' + html.replace(" scoped", "") +
+    '</td></tr></tbody></table></div>')
 
 
 def _toHTML(mol):
   useInteractiveRenderer = InteractiveRenderer.isEnabled(mol)
-  if _canUse3D and ipython_3d and mol.GetNumConformers():
+  if _canUse3D and ipython_3d and mol.GetNumConformers() and mol.GetConformer().Is3D():
     return _toJSON(mol)
   props = mol.GetPropsAsDict()
   if not ipython_showProperties or not props:


### PR DESCRIPTION
There's a bad interaction in the notebook integration between the property display and the 3D molecule rendering: if 3d molecule rendering is enabled then no properties are displayed, even if a given molecule doesn't have a 3D conformer.

This fixes that.

There's also one reformatting chunk here
