### PR TITLE
PandasTools and InteractiveRenderer improvements

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -51,6 +51,9 @@
   which used to take several individual parameters now take a single JSON string parameter.
   The overloads taking several individual parameters are now deprecated and will be
   removed in a future release.
+- The `PrintAsBase64PNGString` function in `PandasTools` is deprecated and replaced
+  by `PrintAsImageString`, which has a more appropriate name given it actually supports
+  both PNG and SVG images.
 
 # Release_2022.03.1
 (Changes relative to Release_2021.09.1)

--- a/rdkit/Chem/Draw/IPythonConsole.py
+++ b/rdkit/Chem/Draw/IPythonConsole.py
@@ -93,13 +93,16 @@ def _toJSON(mol):
 
 
 def _wrapHTMLIntoTable(html):
-  return InteractiveRenderer.injectHTMLHeaderBeforeTable(
+  return InteractiveRenderer.injectHTMLFooterAfterTable(
     f'<div><table><tbody><tr><td style="width: {molSize[0]}px; ' +
     f'height: {molSize[1]}px; text-align: center;">' + html.replace(" scoped", "") +
     '</td></tr></tbody></table></div>')
 
 
 def _toHTML(mol):
+  def escape_special_chars(s):
+    return str(s).replace('"', '&quot;').replace("'", "&apos;").replace("<", "&lt;").replace(">", "&gt;").replace("&", "&amp;")
+
   useInteractiveRenderer = InteractiveRenderer.isEnabled(mol)
   if _canUse3D and ipython_3d and mol.GetNumConformers() and mol.GetConformer().Is3D():
     return _toJSON(mol)
@@ -107,7 +110,7 @@ def _toHTML(mol):
   if not ipython_showProperties or not props:
     if useInteractiveRenderer:
       return _wrapHTMLIntoTable(
-        InteractiveRenderer.generateHTMLBody(ipython_useSVG, mol, molSize, drawOptions))
+        InteractiveRenderer.generateHTMLBody(mol, molSize, useSVG=ipython_useSVG))
     else:
       return _toSVG(mol)
   if mol.HasProp('_Name'):
@@ -117,29 +120,31 @@ def _toHTML(mol):
 
   res = []
   if useInteractiveRenderer:
-    content = InteractiveRenderer.generateHTMLBody(ipython_useSVG, mol, molSize)
+    content = InteractiveRenderer.generateHTMLBody(mol, molSize, legend=nm, useSVG=ipython_useSVG)
   else:
     if not ipython_useSVG:
-      png = Draw._moltoimg(mol, molSize, [], nm, returnPNG=True, drawOptions=drawOptions)
+      png = Draw._moltoimg(mol, molSize, [], nm, returnPNG=True,
+                           kekulize=kekulizeStructures, drawOptions=drawOptions)
       png = base64.b64encode(png)
       content = f'<image src="data:image/png;base64,{png.decode()}">'
     else:
       content = Draw._moltoSVG(mol, molSize, [], nm, kekulize=kekulizeStructures,
                                drawOptions=drawOptions)
-  res.append(f'<tr><td colspan=2 style="text-align:center">{content}</td></tr>')
+  res.append(f'<tr><td colspan="2" style="text-align: center;">{content}</td></tr>')
 
   for i, (pn, pv) in enumerate(props.items()):
     if ipython_maxProperties >= 0 and i >= ipython_maxProperties:
       res.append(
-        '<tr><td colspan=2 style="text-align:center">Property list truncated.<br />Increase IPythonConsole.ipython_maxProperties (or set it to -1) to see more properties.</td></tr>'
+        '<tr><td colspan="2" style="text-align: center">Property list truncated.<br />Increase IPythonConsole.ipython_maxProperties (or set it to -1) to see more properties.</td></tr>'
       )
       break
+    pv = escape_special_chars(pv)
     res.append(
-      f'<tr><th style="text-align:right">{pn}</th><td style="text-align:left">{pv}</td></tr>')
+      f'<tr><th style="text-align: right">{pn}</th><td style="text-align: left">{pv}</td></tr>')
   res = '\n'.join(res)
   res = f'<table>{res}</table>'
   if useInteractiveRenderer:
-    res = InteractiveRenderer.injectHTMLHeaderBeforeTable(res)
+    res = InteractiveRenderer.injectHTMLFooterAfterTable(res)
   return res
 
 
@@ -244,7 +249,9 @@ def ShowMols(mols, maxMols=50, **kwargs):
     kwargs['useSVG'] = ipython_useSVG
   if 'returnPNG' not in kwargs:
     kwargs['returnPNG'] = True
-  if _MolsToGridImageSaved is not None:
+  if InteractiveRenderer.isEnabled():
+    fn = InteractiveRenderer.MolsToHTMLTable
+  elif _MolsToGridImageSaved is not None:
     fn = _MolsToGridImageSaved
   else:
     fn = Draw.MolsToGridImage
@@ -261,9 +268,11 @@ def ShowMols(mols, maxMols=50, **kwargs):
     kwargs["drawOptions"] = drawOptions
 
   res = fn(mols, **kwargs)
-  if kwargs['useSVG']:
+  if InteractiveRenderer.isEnabled():
+    return HTML(res)
+  elif kwargs['useSVG']:
     return SVG(res)
-  if kwargs['returnPNG']:
+  elif kwargs['returnPNG']:
     return display.Image(data=res, format='png')
   return res
 

--- a/rdkit/Chem/Draw/IPythonConsole.py
+++ b/rdkit/Chem/Draw/IPythonConsole.py
@@ -101,9 +101,6 @@ def _wrapHTMLIntoTable(html):
 
 
 def _toHTML(mol):
-  def escape_special_chars(s):
-    return html.escape(str(s)).replace("&", "&amp;")
-
   useInteractiveRenderer = InteractiveRenderer.isEnabled(mol)
   if _canUse3D and ipython_3d and mol.GetNumConformers() and mol.GetConformer().Is3D():
     return _toJSON(mol)
@@ -139,7 +136,7 @@ def _toHTML(mol):
         '<tr><td colspan="2" style="text-align: center">Property list truncated.<br />Increase IPythonConsole.ipython_maxProperties (or set it to -1) to see more properties.</td></tr>'
       )
       break
-    pv = escape_special_chars(pv)
+    pv = html.escape(str(pv))
     res.append(
       f'<tr><th style="text-align: right">{pn}</th><td style="text-align: left">{pv}</td></tr>')
   res = '\n'.join(res)

--- a/rdkit/Chem/Draw/IPythonConsole.py
+++ b/rdkit/Chem/Draw/IPythonConsole.py
@@ -8,6 +8,7 @@
 #  of the RDKit source tree.
 #
 import base64
+import html
 import copy
 import warnings
 from io import BytesIO
@@ -101,7 +102,7 @@ def _wrapHTMLIntoTable(html):
 
 def _toHTML(mol):
   def escape_special_chars(s):
-    return str(s).replace('"', '&quot;').replace("'", "&apos;").replace("<", "&lt;").replace(">", "&gt;").replace("&", "&amp;")
+    return html.escape(str(s)).replace("&", "&amp;")
 
   useInteractiveRenderer = InteractiveRenderer.isEnabled(mol)
   if _canUse3D and ipython_3d and mol.GetNumConformers() and mol.GetConformer().Is3D():

--- a/rdkit/Chem/Draw/InteractiveRenderer.py
+++ b/rdkit/Chem/Draw/InteractiveRenderer.py
@@ -11,23 +11,26 @@
 """ Interactive molecule rendering through rdkit-structure-renderer.js """
 from xml.dom import minidom
 import uuid
+import base64
 import json
 import re
+import logging
 from . import rdMolDraw2D
 from IPython.display import HTML
 from rdkit import Chem
+from rdkit.Chem import Draw
+
+log = logging.getLogger(__name__)
 
 rdkitStructureRendererJsUrl = "https://unpkg.com/rdkit-structure-renderer/dist/rdkit-structure-renderer-module.js"
 minimalLibJsUrl = "https://unpkg.com/rdkit-structure-renderer/public/RDKit_minimal.js"
 parentNodeQuery = "div[class*=jp-NotebookPanel-notebook]"
-_enabled = False
+_enabled_div_uuid = None
 _camelCaseOptToTagRe = re.compile("[A-Z]")
 _opts = "__rnrOpts"
 _disabled = "_disabled"
 _defaultDrawOptions = None
 _defaultDrawOptionsDict = None
-
-_enabled = False
 
 
 def _isAcceptedKeyValue(key, value):
@@ -62,7 +65,7 @@ def _isDrawOptionEqual(v1, v2):
 def filterDefaultDrawOpts(molDrawOptions):
   global _defaultDrawOptionsDict
   if not isinstance(molDrawOptions, rdMolDraw2D.MolDrawOptions):
-    raise ValueError(f"Bad args for {__name__}.filterDefaultDrawOpts("
+    raise ValueError(f"Bad args ({str(type(molDrawOptions))}) for {__name__}.filterDefaultDrawOpts("
                      "molDrawOptions: Chem.Draw.rdMolDraw2D.MolDrawOptions)")
   molDrawOptionsAsDict = _molDrawOptionsToDict(molDrawOptions)
   if (_defaultDrawOptionsDict is None):
@@ -76,45 +79,74 @@ def filterDefaultDrawOpts(molDrawOptions):
 
 def setEnabled():
   """ Enable interactive molecule rendering """
-  global _enabled
-  if _enabled:
-    return
-  _enabled = True
-  div_uuid = str(uuid.uuid1())
-  return HTML(f"""\
-<div
-class="lm-Widget p-Widget jp-RenderedText jp-mod-trusted jp-OutputArea-output"
-id="{div_uuid}"
->Loading rdkit-structure-renderer.js...</div>
-<script type="module">
-const jsLoader = document.getElementById('{div_uuid}') || {{}};
-const setError = e => jsLoader.innerHTML = 'Failed to load rdkit-structure-renderer.js:<br>' +
-e.toString() + '<br>' +
-'Interactive molecule rendering will not be available in this Jupyter Notebook.'
-try {{
-import('{rdkitStructureRendererJsUrl}').then(
-  ({{ default: Renderer }}) =>
-    Renderer.init('{minimalLibJsUrl}').then(
-      () => jsLoader.innerHTML = 'Interactive molecule rendering is available in this Jupyter Notebook.'
-    ).catch(
-      e => setError(e)
-    )
-  ).catch(
-    e => setError(e)
+
+  def _wrapMsgIntoDiv(uuid, msg):
+    return ('<div '
+      'class="lm-Widget p-Widget jp-RenderedText jp-mod-trusted jp-OutputArea-output"'
+      f'id="{uuid}">{msg}</div>')
+
+  global _enabled_div_uuid
+  loadingMsg = "Loading rdkit-structure-renderer.js..."
+  failedToLoadMsg = "Failed to load rdkit-structure-renderer.js:"
+  renderingAvailableMsg = "Interactive molecule rendering is available in this Jupyter Notebook."
+  renderingUnavailableMsg = "Interactive molecule rendering will not be available in this Jupyter Notebook."
+  if _enabled_div_uuid:
+    return HTML(_wrapMsgIntoDiv(_enabled_div_uuid, renderingAvailableMsg))
+  _enabled_div_uuid = str(uuid.uuid1())
+  return HTML(_wrapMsgIntoDiv(_enabled_div_uuid, loadingMsg) +
+f"""<script type="module">
+const jsLoader = document.getElementById('{_enabled_div_uuid}') || {{}};
+const setError = (e, resolve) => {{
+  jsLoader.innerHTML = (
+    '{failedToLoadMsg}<br>' +
+    e.toString() + '<br>' +
+    '{renderingUnavailableMsg}'
   );
-}} catch(e) {{
-setError(e);
+  resolve && resolve();
+}};
+if (window.rdkStrRnr) {{
+  jsLoader.innerHTML = '{renderingAvailableMsg}';
+}} else {{
+  window.rdkStrRnr = new Promise(resolve => {{
+    try {{
+      fetch('{rdkitStructureRendererJsUrl}').then(
+        r => r.text().then(
+          t => import(URL.createObjectURL(new Blob([t], {{ type: 'application/javascript' }}))).then(
+            ({{ default: Renderer }}) => {{
+              const res = Renderer.init('{minimalLibJsUrl}');
+              return res.then(
+                Renderer => {{
+                  jsLoader.innerHTML = '{renderingAvailableMsg}';
+                  resolve(Renderer);
+                }}
+              ).catch(
+                e => setError(e, resolve)
+              );
+            }}
+          ).catch(
+              e => setError(e, resolve)
+          )
+        ).catch(
+          e => setError(e, resolve)
+        )
+      ).catch(
+        e => setError(e, resolve)
+      );
+    }} catch(e) {{
+      setError(e, resolve);
+    }}
+  }});
 }}
 </script>""")
 
 
 def isEnabled(mol=None):
-  return _enabled and (mol is None or not isNoInteractive(mol))
+  return _enabled_div_uuid and (mol is None or not isNoInteractive(mol))
 
 
 def getOpts(mol):
   if not isinstance(mol, Chem.Mol):
-    raise ValueError(f"Bad args for {__name__}.getOpts(mol: Chem.Mol)")
+    raise ValueError(f"Bad args ({str(type(mol))}) for {__name__}.getOpts(mol: Chem.Mol)")
   opts = {}
   if hasattr(mol, _opts):
     opts = getattr(mol, _opts)
@@ -125,7 +157,7 @@ def getOpts(mol):
 
 def setOpts(mol, opts):
   if not isinstance(mol, Chem.Mol) or not isinstance(opts, dict):
-    raise ValueError(f"Bad args for {__name__}.setOpts(mol: Chem.Mol, opts: dict)")
+    raise ValueError(f"Bad args ({str(type(mol)), str(type(opts))}) for {__name__}.setOpts(mol: Chem.Mol, opts: dict)")
   if not all(opts.keys()):
     raise ValueError(
       f"{__name__}.setOpts(mol: Chem.Mol, opts: dict): no key in opts should be null")
@@ -137,7 +169,7 @@ def setOpts(mol, opts):
 
 def setOpt(mol, key, value):
   if not isinstance(mol, Chem.Mol) or not isinstance(key, str) or not key:
-    raise ValueError(f"Bad args for {__name__}.setOpt(mol: Chem.Mol, key: str, value: Any)")
+    raise ValueError(f"Bad args ({str(type(mol))}, {str(type(key))}) for {__name__}.setOpt(mol: Chem.Mol, key: str, value: Any)")
   opts = getOpts(mol)
   opts[key] = value
   setOpts(mol, opts)
@@ -145,13 +177,13 @@ def setOpt(mol, key, value):
 
 def clearOpts(mol):
   if not isinstance(mol, Chem.Mol):
-    raise ValueError(f"Bad args for {__name__}.clearOpts(mol: Chem.Mol)")
+    raise ValueError(f"Bad args ({str(type(mol))}) for {__name__}.clearOpts(mol: Chem.Mol)")
   setOpts(mol, {})
 
 
 def clearOpt(mol, key):
   if not isinstance(mol, Chem.Mol) or not isinstance(key, str):
-    raise ValueError(f"Bad args for {__name__}.clearOpt(mol: Chem.Mol, key: str)")
+    raise ValueError(f"Bad args ({str(type(mol))}, {str(type(key))}) for {__name__}.clearOpt(mol: Chem.Mol, key: str)")
   opts = getOpts(mol)
   if key in opts:
     opts.pop(key)
@@ -172,45 +204,44 @@ def isNoInteractive(mol):
   return _disabled in opts
 
 
-def injectHTMLHeaderBeforeTable(html):
+def injectHTMLFooterAfterTable(html):
   doc = minidom.parseString(html.replace(" scoped", ""))
-  table = doc.getElementsByTagName("table")
-  if len(table) != 1:
-    return html
-  table = table.pop(0)
-  tbody = table.getElementsByTagName("tbody")
-  if tbody:
-    if len(tbody) != 1:
-      return html
-    tbody = tbody.pop(0)
-  else:
-    tbody = table
-  div_list = tbody.getElementsByTagName("div")
-  if any(div.getAttribute("class") == "rdk-str-rnr-mol-container" for div in div_list):
-    return generateHTMLHeader(doc, table)
+  tables = doc.getElementsByTagName("table")
+  for table in tables:
+    tbody = table.getElementsByTagName("tbody")
+    if tbody:
+      if len(tbody) != 1:
+        return html
+      tbody = tbody.pop(0)
+    else:
+      tbody = table
+    div_list = tbody.getElementsByTagName("div")
+    if any(div.getAttribute("class") == "rdk-str-rnr-mol-container" for div in div_list):
+      return generateHTMLFooter(doc, table)
   return html
 
-def generateHTMLHeader(doc, element):
+def generateHTMLFooter(doc, element):
   element_parent = element.parentNode
+  if element_parent.nodeName.lower() != "div":
+    element_parent = doc.createElement("div")
+    element_parent.appendChild(element)
   script = doc.createElement("script")
   script.setAttribute("type", "module")
   # avoid arrow function as minidom encodes => into HTML (grrr)
   # Also use single quotes to avoid the &quot; encoding
   cmd = doc.createTextNode(f"""\
-try {{
-import('{rdkitStructureRendererJsUrl}').then(
-  function({{ default: Renderer }}) {{
-    Renderer.init('{minimalLibJsUrl}').then(
-      function(Renderer) {{
+if (window.rdkStrRnr) {{
+  window.rdkStrRnr.then(
+    function(Renderer) {{
+      if (Renderer) {{
         Renderer.updateMolDrawDivs();
       }}
-    ).catch()
-  }}
-).catch();
-}} catch {{}}""")
+    }}
+  ).catch();
+}}""")
   script.appendChild(cmd)
   element_parent.appendChild(script)
-  html = doc.toxml()
+  html = element_parent.toxml()
   return html
 
 
@@ -223,7 +254,7 @@ def xmlToNewline(xmlblock):
 
 
 def toDataMol(mol):
-  return (mol.GetNumConformers() and newlineToXml(Chem.MolToMolBlock(mol)) or Chem.MolToSmiles(mol))
+  return "pkl_" + base64.b64encode(mol.ToBinary()).decode("utf-8")
 
 
 def _dashLower(m):
@@ -237,14 +268,28 @@ def camelCaseOptToDataTag(opt):
   return tag
 
 
-def generateHTMLBody(useSvg, mol, size, drawOptions=None):
-  if drawOptions is None:
-    drawOptions = _defaultDrawOptions
+def generateHTMLBody(mol, size, **kwargs):
+  def toJson(x):
+    return json.dumps(x, separators=(",", ":"))
+
+  drawOptions = kwargs.get("drawOptions", _defaultDrawOptions)
+  legend = kwargs.get("legend", None)
+  useSVG = kwargs.get("useSVG", False)
+  kekulize = Draw.shouldKekulize(mol, kwargs.get("kekulize", True))
+  highlightAtoms = kwargs.get("highlightAtoms", []) or []
+  highlightBonds = kwargs.get("highlightBonds", []) or []
+  if not highlightAtoms and hasattr(mol, '__sssAtoms'):
+    highlightAtoms = mol.__sssAtoms
+    highlightBonds = [
+      b.GetIdx() for b in mol.GetBonds()
+      if b.GetBeginAtomIdx() in highlightAtoms
+      and b.GetEndAtomIdx() in highlightAtoms
+    ]
   doc = minidom.Document()
   unique_id = str(uuid.uuid1())
   div = doc.createElement("div")
   for key, value in [
-    ("style", f"width: {size[0]}px; height: {size[1]}px;"),
+    ("style", f"width: {size[0]}px; height: {size[1]}px; margin: auto;"),
     ("class", "rdk-str-rnr-mol-container"),
     ("id", f"rdk-str-rnr-mol-{unique_id}"),
     ("data-mol", toDataMol(mol)),
@@ -269,16 +314,87 @@ def generateHTMLBody(useSvg, mol, size, drawOptions=None):
     addAtomIndices = userDrawOpts["addAtomIndices"]
     if addAtomIndices:
       molOptsDashed["data-atom-idx"] = True
-    userDrawOpts.pop('addAtomIndices')
+    userDrawOpts.pop("addAtomIndices")
+  if highlightAtoms or highlightBonds:
+    molOptsDashed["data-scaffold-highlight"] = True
+    userDrawOpts["atoms"] = highlightAtoms
+    userDrawOpts["bonds"] = highlightBonds
+  if not kekulize:
+    userDrawOpts["kekulize"] = False
   for key, value in molOptsDashed.items():
     if isinstance(value, Chem.Mol):
       value = toDataMol(value)
     elif not isinstance(value, str):
-      value = json.dumps(value, separators=(',', ':'))
+      value = toJson(value)
     div.setAttribute(key, value)
   if userDrawOpts:
-    div.setAttribute("data-draw-opts", json.dumps(userDrawOpts, separators=(',', ':')))
-  if useSvg:
+    div.setAttribute("data-draw-opts", toJson(userDrawOpts))
+  if useSVG:
     div.setAttribute("data-use-svg", "true")
-  doc.appendChild(div)
+  if legend:
+    outerTable = doc.createElement("table")
+    outerTable.setAttribute("style", f"margin: auto;")
+    molTr = doc.createElement("tr")
+    molTd = doc.createElement("td")
+    molTd.setAttribute("style", f"padding: 0;")
+    molTd.appendChild(div)
+    molTr.appendChild(molTd)
+    nameTr = doc.createElement("tr")
+    nameTh = doc.createElement("th")
+    legendText = doc.createTextNode(legend)
+    nameTh.appendChild(legendText)
+    nameTh.setAttribute("style", f"text-align: center; background: white;")
+    nameTr.appendChild(nameTh)
+    outerTable.appendChild(molTr)
+    outerTable.appendChild(nameTr)
+    div = outerTable
   return xmlToNewline(div.toxml())
+
+
+def MolsToHTMLTable(mols, molsPerRow=3, subImgSize=(200, 200), legends=None,
+                    highlightAtomLists=None, highlightBondLists=None, useSVG=False,
+                    drawOptions=None, **kwargs):
+  if legends and len(legends) > len(mols):
+    legends = legends[:len(mols)]
+  if highlightAtomLists and len(highlightAtomLists) > len(mols):
+    highlightAtomLists = highlightAtomLists[:len(mols)]
+  if highlightBondLists and len(highlightBondLists) > len(mols):
+    highlightBondLists = highlightBondLists[:len(mols)]
+  nRows = (len(mols) - 1) // molsPerRow + 1 if mols else 0
+  if nRows:
+    doc = minidom.Document()
+    table = doc.createElement("table")
+  res = ""
+  i = 0
+  for _ in range(nRows):
+    tr = doc.createElement("tr")
+    for _ in range(molsPerRow):
+      td = doc.createElement("td")
+      td.setAttribute("style", f"padding: 0; background-color: white;")
+      highlights = None
+      mol = mols[i]
+      legend = legends[i] if legends else None
+      highlights = highlightAtomLists[i] if highlightAtomLists else None
+      kwargs["highlightBonds"] = highlightBondLists[i] if highlightBondLists else None
+      content = None
+      if isinstance(mol, Chem.Mol):
+        if isEnabled(mol):
+          content = generateHTMLBody(mol, subImgSize, drawOptions=drawOptions, legend=legend, useSVG=useSVG,
+                                     highlightAtoms=highlights, **kwargs)
+        else:
+          fn = Draw._moltoSVG if useSVG else Draw._moltoimg
+          content = fn(mol, subImgSize, highlights, legend, **kwargs)
+      try:
+        content = minidom.parseString(content)
+        td.appendChild(content.firstChild)
+      except Exception as e:
+        log.warning("Failed to parse HTML returned by generateHTMLBody()")
+      tr.appendChild(td)
+      i += 1
+      if i == len(mols):
+        break
+    table.appendChild(tr)
+  if nRows:
+    doc.appendChild(table)
+    res = doc.toxml()
+  return injectHTMLFooterAfterTable(res)

--- a/rdkit/Chem/Draw/__init__.py
+++ b/rdkit/Chem/Draw/__init__.py
@@ -446,12 +446,9 @@ def _drawerToImage(d2d):
   return Image.open(sio)
 
 
-def _okToKekulizeMol(mol, kekulize):
+def shouldKekulize(mol, kekulize):
   if kekulize:
-    for bond in mol.GetBonds():
-      if bond.GetIsAromatic() and bond.HasQuery():
-        return False
-    return True
+    return not any(bond.GetIsAromatic() and bond.HasQuery() for bond in mol.GetBonds())
   return kekulize
 
 
@@ -462,7 +459,7 @@ def _moltoimg(mol, sz, highlights, legend, returnPNG=False, drawOptions=None, **
   except RuntimeError:
     mol.UpdatePropertyCache(False)
 
-  kekulize = _okToKekulizeMol(mol, kwargs.get('kekulize', True))
+  kekulize = shouldKekulize(mol, kwargs.get('kekulize', True))
   wedge = kwargs.get('wedgeBonds', True)
 
   try:
@@ -505,7 +502,7 @@ def _moltoSVG(mol, sz, highlights, legend, kekulize, drawOptions=None, **kwargs)
   except RuntimeError:
     mol.UpdatePropertyCache(False)
 
-  kekulize = _okToKekulizeMol(mol, kekulize)
+  kekulize = shouldKekulize(mol, kekulize)
 
   try:
     with rdBase.BlockLogs():
@@ -549,6 +546,8 @@ def _MolsToGridImage(mols, molsPerRow=3, subImgSize=(200, 200), legends=None,
       highlights = None
       if highlightAtomLists and highlightAtomLists[i]:
         highlights = highlightAtomLists[i]
+      if highlightBondLists and highlightBondLists[i]:
+        kwargs["highlightBonds"] = highlightBondLists[i]
       if mol is not None:
         img = _moltoimg(mol, subImgSize, highlights, legends[i], **kwargs)
         res.paste(img, (col * subImgSize[0], row * subImgSize[1]))

--- a/rdkit/Chem/PandasPatcher.py
+++ b/rdkit/Chem/PandasPatcher.py
@@ -1,0 +1,235 @@
+from io import StringIO
+import logging
+import re
+import importlib
+from xml.dom import minidom
+from xml.parsers.expat import ExpatError
+from rdkit.Chem import Mol
+
+log = logging.getLogger(__name__)
+RDK_MOLS_AS_IMAGE_ATTR = "__rdkitMolAsImage"
+InteractiveRenderer = None
+PrintAsImageString = None
+molJustify = None
+pandas_frame = None
+
+pandas_formats = None
+for pandas_formats_name in ("pandas.io", "pandas"):
+  try:
+    pandas_formats = importlib.import_module(f"{pandas_formats_name}.formats")
+  except ModuleNotFoundError:
+    continue
+  break
+if pandas_formats is None:
+  log.warning("Failed to import pandas formats module")
+  raise ModuleNotFoundError
+to_html_class = None
+for to_html_class_name in ("DataFrameRenderer", "DataFrameFormatter"):
+  if hasattr(pandas_formats, "format") and hasattr(pandas_formats.format, to_html_class_name):
+    to_html_class = getattr(pandas_formats.format, to_html_class_name)
+    if hasattr(to_html_class, "to_html"):
+      break
+    else:
+      to_html_class = None
+if to_html_class is None:
+  log.warning("Failed to find the pandas to_html method to patch")
+  raise AttributeError
+orig_get_adjustment = None
+for get_adjustment_name in ("get_adjustment", "_get_adjustment"):
+  if hasattr(pandas_formats.format, get_adjustment_name):
+    orig_get_adjustment = getattr(pandas_formats.format, get_adjustment_name)
+    break
+if orig_get_adjustment is None:
+  log.warning("Failed to find the pandas get_adjustment() function to patch")
+  raise AttributeError
+adj = orig_get_adjustment()
+if not hasattr(adj, "len"):
+  log.warning(f"Failed to find the pandas {adj.__class.__name__}.len() method to patch")
+  raise AttributeError
+html_formatter_module = None
+html_formatter_class = None
+for html_formatter_module_name in ("format", "html"):
+  try:
+    html_formatter_module = importlib.import_module(f"{pandas_formats.__name__}.{html_formatter_module_name}")
+  except ModuleNotFoundError:
+    continue
+  if hasattr(html_formatter_module, "HTMLFormatter"):
+    html_formatter_class = getattr(html_formatter_module, "HTMLFormatter")
+    break
+if html_formatter_class is None:
+  log.warning("Failed to find the pandas HTMLFormatter class to patch")
+  raise AttributeError
+orig_write_cell = None
+if not hasattr(html_formatter_class , "_write_cell"):
+  log.warning("Failed to find the HTMLFormatter._write_cell() method to patch")
+  raise AttributeError
+orig_write_cell = getattr(html_formatter_class , "_write_cell")
+if not (hasattr(pandas_formats, "printing") and hasattr(pandas_formats.printing, "pprint_thing")):
+  log.warning("Failed to find the pprint_thing function")
+  raise AttributeError
+try:
+  import pandas as pd
+except ImportError:
+  log.warning("Failed to import pandas")
+  raise
+
+
+orig_to_html = getattr(to_html_class, "to_html")
+pprint_thing = pandas_formats.printing.pprint_thing
+
+def is_molecule_image(s):
+  result = False
+  try:
+    # is text valid XML / HTML?
+    xml = minidom.parseString(s)
+    root_node = xml.firstChild
+    # check data-content attribute
+    if (root_node.nodeName in ['svg', 'img', 'div'] and
+        'data-content' in root_node.attributes.keys() and
+        root_node.attributes['data-content'].value == 'rdkit/molecule'):
+      result = True
+  except ExpatError:
+    pass  # parsing xml failed and text is not a molecule image
+  return result
+
+styleRegex = re.compile("^(.*style=[\"'][^\"^']*)([\"'].*)$")
+
+class MolFormatter:
+  """Format molecules as images"""
+
+  def __init__(self, orig_formatter=None):
+    """Store original formatters (if any)"""
+    self.orig_formatter = orig_formatter
+
+  @staticmethod
+  def default_formatter(x):
+    """Default formatter function"""
+    return pprint_thing(x, escape_chars=("\t", "\r", "\n"))
+
+  @staticmethod
+  def is_mol(x):
+    """Return True if x is a Chem.Mol"""
+    return isinstance(x, Mol)
+
+  @classmethod
+  def get_formatters(cls, df, orig_formatters):
+    """Return an instance of MolFormatter for each column that contains Chem.Mol objects"""
+    df_subset = df.select_dtypes("object")
+    return {
+      col: cls(orig_formatters.get(col, None))
+        for col in df_subset.columns[df_subset.applymap(MolFormatter.is_mol).any()]
+    }
+
+  def __call__(self, x):
+    """Return x formatted based on its type"""
+    if self.is_mol(x):
+      return PrintAsImageString(x)
+    if callable(self.orig_formatter):
+      return self.orig_formatter(x)
+    return self.default_formatter(x)
+
+
+def check_rdk_attr(frame, attr):
+  return hasattr(frame, attr) and getattr(frame, attr)
+
+def set_rdk_attr(frame, attr):
+  setattr(frame, attr, True)
+
+def patched_to_html(self, *args, **kwargs):
+  """A patched version of the to_html method
+     that allows rendering molecule images in data frames.
+  """
+  frame = None
+  if self.__class__.__name__ == "DataFrameRenderer":
+    fmt = self.fmt
+    frame = fmt.frame
+  elif self.__class__.__name__ == "DataFrameFormatter":
+    fmt = self
+    frame = fmt.frame
+  else:
+    raise ValueError(f"patched_to_html: unexpected class {self.__class__.__name__}")
+  if not check_rdk_attr(frame, RDK_MOLS_AS_IMAGE_ATTR):
+    return orig_to_html(self, *args, **kwargs)
+  orig_formatters = fmt.formatters
+  try:
+    formatters = orig_formatters or {}
+    if not isinstance(formatters, dict):
+      formatters = {col: formatters[i] for i, col in enumerate(self.columns)}
+    else:
+      formatters = dict(formatters)
+    formatters.update(MolFormatter.get_formatters(frame, formatters))
+    fmt.formatters = formatters
+    res = orig_to_html(self, *args, **kwargs)
+    # in pandas 0.25 DataFrameFormatter.to_html() returns None
+    if (res is None and not hasattr(html_formatter_class, "get_result")
+      and hasattr(self, "buf") and hasattr(self.buf, "getvalue")):
+      res = self.buf.getvalue()
+    should_inject = res and InteractiveRenderer and InteractiveRenderer.isEnabled()
+    if should_inject:
+      res = InteractiveRenderer.injectHTMLFooterAfterTable(res)
+      # in pandas 0.25 we need to make sure to update buf as return value will be ignored
+      if hasattr(self, "buf") and isinstance(self.buf, StringIO):
+        self.buf.seek(0)
+        self.buf.write(res)
+    return res
+  finally:
+    fmt.formatters = orig_formatters
+
+def patched_write_cell(self, s, *args, **kwargs):
+  """ Disable escaping of HTML in order to render img / svg tags """
+  styleTags = f"text-align: {molJustify};"
+  def_escape = self.escape
+  try:
+    if hasattr(self.frame, RDK_MOLS_AS_IMAGE_ATTR) and is_molecule_image(s):
+      self.escape = False
+      kind = kwargs.get('kind', None)
+      if kind == 'td':
+        tags = kwargs.get('tags', None) or ''
+        match = styleRegex.match(tags)
+        if match:
+          tags = styleRegex.sub(f'\\1 {styleTags}\\2', tags)
+        else:
+          if tags:
+            tags += ' '
+          tags += f'style="{styleTags}"'
+        kwargs['tags'] = tags
+    return orig_write_cell(self, s, *args, **kwargs)
+  finally:
+    self.escape = def_escape
+
+def patched_get_adjustment():
+  """ Avoid truncation of data frame values that contain HTML content """
+  adj = orig_get_adjustment()
+  orig_len = adj.len
+  adj.len = lambda text, *args, **kwargs: (
+    0 if is_molecule_image(text) else orig_len(text, *args, **kwargs)
+  )
+  return adj
+
+def renderImagesInAllDataFrames(images=True):
+  if images:
+    set_rdk_attr(pd.core.frame.DataFrame, RDK_MOLS_AS_IMAGE_ATTR)
+  elif hasattr(pd.core.frame.DataFrame, RDK_MOLS_AS_IMAGE_ATTR):
+    delattr(pd.core.frame.DataFrame, RDK_MOLS_AS_IMAGE_ATTR)
+
+def changeMoleculeRendering(frame, renderer='image'):
+  if not renderer.lower().startswith('str'):
+    set_rdk_attr(frame, RDK_MOLS_AS_IMAGE_ATTR)
+  elif hasattr(frame, RDK_MOLS_AS_IMAGE_ATTR):
+    delattr(frame, RDK_MOLS_AS_IMAGE_ATTR)
+
+def patchPandas():
+  if getattr(to_html_class, "to_html") != patched_to_html:
+    setattr(to_html_class, "to_html", patched_to_html)
+  if getattr(html_formatter_class, "_write_cell") != patched_write_cell:
+    setattr(html_formatter_class, "_write_cell", patched_write_cell)
+  if getattr(pandas_formats.format, get_adjustment_name) != patched_get_adjustment:
+    setattr(pandas_formats.format, get_adjustment_name, patched_get_adjustment)
+
+def unpatchPandas():
+  if orig_to_html:
+    setattr(to_html_class, "to_html", orig_to_html)
+  if orig_write_cell:
+    setattr(html_formatter_class, "_write_cell", orig_write_cell)
+  if orig_get_adjustment:
+    setattr(pandas_formats.format, get_adjustment_name, orig_get_adjustment)

--- a/rdkit/Chem/PandasPatcher.py
+++ b/rdkit/Chem/PandasPatcher.py
@@ -142,12 +142,11 @@ def patched_to_html(self, *args, **kwargs):
   frame = None
   if self.__class__.__name__ == "DataFrameRenderer":
     fmt = self.fmt
-    frame = fmt.frame
   elif self.__class__.__name__ == "DataFrameFormatter":
     fmt = self
-    frame = fmt.frame
   else:
     raise ValueError(f"patched_to_html: unexpected class {self.__class__.__name__}")
+  frame = fmt.frame
   if not check_rdk_attr(frame, RDK_MOLS_AS_IMAGE_ATTR):
     return orig_to_html(self, *args, **kwargs)
   orig_formatters = fmt.formatters

--- a/rdkit/Chem/PandasTools.py
+++ b/rdkit/Chem/PandasTools.py
@@ -118,20 +118,9 @@ Conversion to html is quite easy:
 >>> str(htm[:36])
 '<table border="1" class="dataframe">'
 
-In order to support rendering the molecules as images in the HTML export of the dataframe,
-the __str__ method is monkey-patched to return a base64 encoded PNG:
-
->>> molX = Chem.MolFromSmiles('Fc1cNc2ccccc12')
->>> print(molX) # doctest: +SKIP
-<img src="data:image/png;base64,..." alt="Mol"/>
-This can be reverted using the ChangeMoleculeRendering method
->>> ChangeMoleculeRendering(renderer='String')
->>> print(molX) # doctest: +SKIP
-<rdkit.Chem.rdchem.Mol object at 0x10d179440>
->>> ChangeMoleculeRendering(renderer='PNG')
->>> print(molX) # doctest: +SKIP
-<img src="data:image/png;base64,..." alt="Mol"/>
-
+In order to support rendering the molecules as images in the HTML export of the
+dataframe, we use a custom formatter for columns containing RDKit molecules,
+and also disable escaping of HTML where needed.
 '''
 
 from base64 import b64encode


### PR DESCRIPTION
1. Avoid that Jupyter Notebooks become painfully slow when using PandasTools with hundreds of molecules by using `pandas` formatters rather than patching `Chem.Mol.__str__`
2. Make sure that static PNG images in `pandas` `DataDrames` honor `PandasTools.molSize`
3. Make sure that `PandasTools` works on the whole range of `pandas` versions
4. Improved and more robust loading of `rdkit-structure-renderer` in Jupyter Notebooks
5. `MolsToGridImage` is now also interactive
6. Interactive rendering now displays highlights and query molecules correctly

Take a look at the gists linked below to see how the new `PandasTools` works correctly on a wide range of `pandas` versions and avoids incurring in the sluggishness that currently affects notebooks using `PandasTools` on hundreds of molecules.

This PR `PandasTools` on various versions of `pandas`:
[1.5.0](https://gist.github.com/ptosco/c53d3dad1275e59cd129b90ba52aea11)
[1.4.3](https://gist.github.com/ptosco/989e5995c39bf64769781d6379a1477f)
[1.3.5](https://gist.github.com/ptosco/a049c08e1603e0ff723b15b181ae8158)
[1.2.5](https://gist.github.com/ptosco/69fdc01b03de3fedb9c61812e6dfa331)
[1.1.5](https://gist.github.com/ptosco/ad2e7b4ea73256e8760fafa1823adab4)
[1.0.5](https://gist.github.com/ptosco/459e3cbb4356e48c9dd2df144b4733fd)
[0.25.3](https://gist.github.com/ptosco/d06a3c1354fff6f8bb44f38b0f3df3a2)

`master` `PandasTools` performance issues with many molecules in the notebook and other visualization issues:
[Jupyter painfully slow with many molecules](https://gist.github.com/ptosco/807215ae3f329d3d9a48403511d269ff)
[PandasTools visualization issues](https://gist.github.com/ptosco/85d24e3f3476d98987af99134fc80f9d)