### PR TITLE
Add updateMolDrawOptionsFromJSON()

### DIFF
--- a/Code/GraphMol/MolDraw2D/MolDraw2DUtils.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DUtils.cpp
@@ -104,10 +104,16 @@ void prepareAndDrawMolecule(MolDraw2D &drawer, const ROMol &mol,
   drawer.drawOptions().prepareMolsBeforeDrawing = old_prep_mol;
 }
 
-void updateDrawerParamsFromJSON(MolDraw2D &drawer, const char *json) {
+void updateMolDrawOptionsFromJSON(MolDrawOptions &opts, const char *json) {
   PRECONDITION(json, "no parameter string");
-  updateDrawerParamsFromJSON(drawer, std::string(json));
+  updateMolDrawOptionsFromJSON(opts, std::string(json));
 };
+
+RDKIT_MOLDRAW2D_EXPORT void updateDrawerParamsFromJSON(MolDraw2D &drawer,
+                                                       const char *json) {
+  updateMolDrawOptionsFromJSON(drawer.drawOptions(), json);
+}
+
 #define PT_OPT_GET(opt) opts.opt = pt.get(#opt, opts.opt)
 
 void get_rgba(const boost::property_tree::ptree &node, DrawColour &colour) {
@@ -150,13 +156,13 @@ void get_colour_palette_option(boost::property_tree::ptree *pt, const char *pnm,
   }
 }
 
-void updateDrawerParamsFromJSON(MolDraw2D &drawer, const std::string &json) {
+void updateMolDrawOptionsFromJSON(MolDrawOptions &opts,
+                                  const std::string &json) {
   if (json == "") {
     return;
   }
   std::istringstream ss;
   ss.str(json);
-  MolDrawOptions &opts = drawer.drawOptions();
   boost::property_tree::ptree pt;
   boost::property_tree::read_json(ss, pt);
   PT_OPT_GET(atomLabelDeuteriumTritium);
@@ -224,6 +230,11 @@ void updateDrawerParamsFromJSON(MolDraw2D &drawer, const std::string &json) {
           item.second.get_value<std::string>();
     }
   }
+}
+
+RDKIT_MOLDRAW2D_EXPORT void updateDrawerParamsFromJSON(
+    MolDraw2D &drawer, const std::string &json) {
+  updateMolDrawOptionsFromJSON(drawer.drawOptions(), json);
 }
 
 void contourAndDrawGrid(MolDraw2D &drawer, const double *grid,

--- a/Code/GraphMol/MolDraw2D/MolDraw2DUtils.h
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DUtils.h
@@ -76,6 +76,10 @@ RDKIT_MOLDRAW2D_EXPORT void updateDrawerParamsFromJSON(MolDraw2D &drawer,
                                                        const char *json);
 RDKIT_MOLDRAW2D_EXPORT void updateDrawerParamsFromJSON(MolDraw2D &drawer,
                                                        const std::string &json);
+RDKIT_MOLDRAW2D_EXPORT void updateMolDrawOptionsFromJSON(MolDrawOptions &opts,
+                                                         const char *json);
+RDKIT_MOLDRAW2D_EXPORT void updateMolDrawOptionsFromJSON(
+    MolDrawOptions &opts, const std::string &json);
 
 struct ContourParams {
   bool setScale = true;           // assumes the grid is drawn first

--- a/Code/GraphMol/MolDraw2D/Wrap/rdMolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/Wrap/rdMolDraw2D.cpp
@@ -636,8 +636,12 @@ void setDrawerColour(RDKit::MolDraw2D &self, python::tuple tpl) {
   self.setColour(pyTupleToDrawColour(tpl));
 }
 
-void updateParamsHelper(MolDraw2D *obj, std::string json) {
-  MolDraw2DUtils::updateDrawerParamsFromJSON(*obj, json);
+void updateMolDrawOptionsHelper(RDKit::MolDrawOptions &obj, std::string json) {
+  MolDraw2DUtils::updateMolDrawOptionsFromJSON(obj, json);
+}
+
+void updateDrawerParamsHelper(RDKit::MolDraw2D &obj, std::string json) {
+  MolDraw2DUtils::updateDrawerParamsFromJSON(obj, json);
 }
 
 std::string molToSVG(const ROMol &mol, unsigned int width, unsigned int height,
@@ -1263,7 +1267,9 @@ BOOST_PYTHON_MODULE(rdMolDraw2D) {
        python::arg("mol") = python::object()),
       docString.c_str());
 
-  python::def("UpdateDrawerParamsFromJSON", RDKit::updateParamsHelper,
+  python::def("UpdateMolDrawOptionsFromJSON", RDKit::updateMolDrawOptionsHelper,
+              (python::arg("opts"), python::arg("json")));
+  python::def("UpdateDrawerParamsFromJSON", RDKit::updateDrawerParamsHelper,
               (python::arg("drawer"), python::arg("json")));
 
   // ------------------------------------------------------------------------

--- a/Code/GraphMol/MolDraw2D/Wrap/testMolDraw2D.py
+++ b/Code/GraphMol/MolDraw2D/Wrap/testMolDraw2D.py
@@ -631,13 +631,23 @@ M  END''')
     nm = Chem.MolFromPNGString(txt)
     self.assertEqual(Chem.MolToSmiles(m), Chem.MolToSmiles(nm))
 
-  def testUpdateParamsFromJSON(self):
+  def testUpdateMolDrawOptionsAndDrawerParamsFromJSON(self):
     m = Chem.MolFromSmiles('c1ccccc1NC(=O)C1COC1')
     d2d = Draw.MolDraw2DSVG(250, 200, -1, -1, True)
     d2d.DrawMolecule(m)
     d2d.FinishDrawing()
     txt = d2d.GetDrawingText()
     self.assertFalse('>8</text>' in txt)
+
+    drawOptions = rdMolDraw2D.MolDrawOptions()
+    Draw.UpdateMolDrawOptionsFromJSON(drawOptions, '{"addAtomIndices": 1}')
+    self.assertTrue(drawOptions.addAtomIndices)
+    d2d = Draw.MolDraw2DSVG(250, 200, -1, -1, True)
+    d2d.SetDrawOptions(drawOptions)
+    d2d.DrawMolecule(m)
+    d2d.FinishDrawing()
+    txt = d2d.GetDrawingText()
+    self.assertTrue('>8</text>' in txt)
 
     d2d = Draw.MolDraw2DSVG(250, 200, -1, -1, True)
     Draw.UpdateDrawerParamsFromJSON(d2d, '{"addAtomIndices": 1}')


### PR DESCRIPTION
Currently it is a bit cumbersome to set `IPythonConsole.drawOptions` to options read from a JSON file.
In fact, I have to instantiate a dummy `MolDraw2D` object that I do not actually need:
```
from rdkit.Chem.Draw import rdMolDraw2D, IPythonConsole

with open("JupyterDrawOptions.json") as hnd:
    jupyter_draw_options = hnd.read()
drawer = rdMolDraw2D.MolDraw2DSVG(300, 200)
rdMolDraw2D.UpdateDrawerParamsFromJSON(drawer, jupyter_draw_options)
IPythonConsole.drawOptions = jupyter_draw_options
```
This PR simplifies the above to
```
from rdkit.Chem.Draw import rdMolDraw2D, IPythonConsole

with open("JupyterDrawOptions.json") as hnd:
    rdMolDraw2D.UpdateMolDrawOptionsFromJSON(IPythonConsole.drawOptions, hnd.read())
```
Also, it seems more logical to have a function that takes directly `MolDrawOptions` as parameter. given that JSON settings are all about `MolDrawOptions` and not about `MolDraw2D`.