### PR TITLE
add stop condition for arom calc of large ringysystems

### DIFF
--- a/Code/GraphMol/Aromaticity.cpp
+++ b/Code/GraphMol/Aromaticity.cpp
@@ -365,6 +365,13 @@ void applyHuckelToFused(
   std::set<unsigned int> doneBonds;
   while (1) {
     if (pos == -1) {
+      // If a ring system has more than 300 rings and a ring combination search larger than 2 is reached,
+      // the calculation becomes exponentially longer, in some case it never completes.
+      if ((curSize == 2) && (nrings > 300)) {
+        BOOST_LOG(rdWarningLog) << "Ring system too large for aromaticity detection." << std::endl;
+        break;
+      }
+
       ++curSize;
       // check if we are done with all the atoms in the fused
       // system, if so quit. This is a fix for Issue252 REVIEW: is


### PR DESCRIPTION
Possible ring combinations expand combinatorially, so for large ring systems, just checking for ring fusions may be slow. For a reported example of 900 rings, the calculation never completes. 300 is about 2 million iterations, which takes approximately 1 minute.

###

From Hackathon RDkit UGM 2022.
Co-authors: @rachelnwalker @d-b-w

