### PR TITLE
Speed up ring detection by reducing allocations

### DIFF
--- a/Code/GraphMol/FindRings.cpp
+++ b/Code/GraphMol/FindRings.cpp
@@ -258,7 +258,8 @@ void removeExtraRings(VECT_INT_VECT &res, unsigned int, const ROMol &mol) {
       }
     }
 
-    // std::cerr<<">>> "<<i<<" "<<consider.count()<<std::endl;
+    // optimization - don't reallocate a new one each loop
+    boost::dynamic_bitset<> workspace(mol.getNumBonds());
     while (consider.count()) {
       unsigned int bestJ = i + 1;
       int bestOverlap = -1;
@@ -271,7 +272,9 @@ void removeExtraRings(VECT_INT_VECT &res, unsigned int, const ROMol &mol) {
         if (!consider[j] || !availRings[j]) {
           continue;
         }
-        int overlap = rdcast<int>((bitBrings[j] & munion).count());
+        workspace = bitBrings[j];
+        workspace &= munion;
+        int overlap = rdcast<int>(workspace.count());
         if (overlap > bestOverlap) {
           bestOverlap = overlap;
           bestJ = j;


### PR DESCRIPTION
For an example large system, getSymmSSSR() took 3minutes. After this trivial change, it went down to 2min 30s. I recognize that's not much, but the change is _so_ minor I think that it's still worth pushing.

(speed-up is because a memory allocation was pulled out of a loop)

Unfortunately, I can't share the structure :( It has about 1K rings. For what it's worth, our ring-finding code finishes this molecule in 19s, so I don't think the current perf is a floor.
