### PR TITLE
Update obsolete SWIG definitions

### DIFF
--- a/Code/JavaWrappers/ROMol.i
+++ b/Code/JavaWrappers/ROMol.i
@@ -373,18 +373,26 @@ void setPreferCoordGen(bool);
 
   }
 
-  void generateDepictionMatching2DStructure(RDKit::ROMol &reference,
+  void generateDepictionMatching2DStructure(const RDKit::ROMol &reference,
+                                          const RDKit::MatchVectType &refMatchVect,
                                           int confId=-1,
-                                           bool acceptFailure=false, bool forceRDKit=false) {
-    RDDepict::generateDepictionMatching2DStructure(*($self),reference,confId,nullptr,
-            acceptFailure,forceRDKit);
+                                          bool forceRDKit=false) {
+    RDDepict::generateDepictionMatching2DStructure(*($self),reference,refMatchVect,confId,forceRDKit);
   }
-  void generateDepictionMatching2DStructure(RDKit::ROMol &reference,
+  RDKit::MatchVectType generateDepictionMatching2DStructure(const RDKit::ROMol &reference,
+                                          int confId=-1,
+                                          bool acceptFailure=false, bool forceRDKit=false,
+                                          bool allowOptionalAttachments=false) {
+    return RDDepict::generateDepictionMatching2DStructure(*($self),reference,confId,nullptr,
+            acceptFailure,forceRDKit,allowOptionalAttachments);
+  }
+  RDKit::MatchVectType generateDepictionMatching2DStructure(const RDKit::ROMol &reference,
                                           int confId,
-                                          RDKit::ROMol referencePattern,
-                                          bool acceptFailure=false, bool forceRDKit=false) {
-    RDDepict::generateDepictionMatching2DStructure(*($self),reference,confId,
-           &referencePattern,acceptFailure,forceRDKit);
+                                          const RDKit::ROMol &referencePattern,
+                                          bool acceptFailure=false, bool forceRDKit=false,
+                                          bool allowOptionalAttachments=false) {
+    return RDDepict::generateDepictionMatching2DStructure(*($self),reference,confId,
+           &referencePattern,acceptFailure,forceRDKit,allowOptionalAttachments);
   }
 
   double normalizeDepiction(int confId=-1, int canonicalize=1,

--- a/Code/JavaWrappers/RWMol.i
+++ b/Code/JavaWrappers/RWMol.i
@@ -70,15 +70,13 @@
     return RDKit::RWMOL_SPTR(RDKit::SmartsToMol(sma, debugParse, mergeHs,replacements));
   }
 static RDKit::RWMOL_SPTR MolFromMolBlock(const std::string &molB,
-                                  bool sanitize=true,bool removeHs=true){
-  RDKit::RWMol *mol=0;
-    mol=RDKit::MolBlockToMol(molB,sanitize,removeHs);
+                                  bool sanitize=true,bool removeHs=true,bool strictParsing=true){
+  RDKit::RWMol *mol=RDKit::MolBlockToMol(molB,sanitize,removeHs,strictParsing);
   return RDKit::RWMOL_SPTR(mol);
 }
 static RDKit::RWMOL_SPTR MolFromMolFile(const std::string &filename,
-                                 bool sanitize=true,bool removeHs=true){
-  RDKit::RWMol *mol=0;
-    mol=RDKit::MolFileToMol(filename,sanitize,removeHs);
+                                 bool sanitize=true,bool removeHs=true,bool strictParsing=true){
+  RDKit::RWMol *mol=RDKit::MolFileToMol(filename,sanitize,removeHs,strictParsing);
   return RDKit::RWMOL_SPTR(mol);
 }
 static RDKit::RWMOL_SPTR MolFromTPLFile(const std::string &fName,bool sanitize=true,

--- a/Code/JavaWrappers/gmwrapper/src-test/org/RDKit/Chemv2Tests.java
+++ b/Code/JavaWrappers/gmwrapper/src-test/org/RDKit/Chemv2Tests.java
@@ -139,7 +139,13 @@ public class Chemv2Tests extends GraphMolTest {
         template.compute2DCoords();
         ROMol m = RWMol.MolFromSmiles("c1cccc2ncn3cccc3c21");
         ROMol patt = RWMol.MolFromSmarts("*1****2*1***2");
-        m.generateDepictionMatching2DStructure(template,-1,patt);
+        Match_Vect mv = m.generateDepictionMatching2DStructure(template,-1,patt);
+        assertTrue(mv.size() == 9);
+        int[] expected = new int[]{ 6, 5, 4, 12, 11, 7, 8, 9, 10 };
+        for (int i = 0; i < mv.size(); ++i) {
+            assertTrue(mv.get(i).getFirst() == i);
+            assertTrue(mv.get(i).getSecond() == expected[i]);
+        }
 
         // System.out.print(template.MolToMolBlock());
         // System.out.print(m.MolToMolBlock());

--- a/Code/JavaWrappers/gmwrapper/src-test/org/RDKit/Chemv2Tests.java
+++ b/Code/JavaWrappers/gmwrapper/src-test/org/RDKit/Chemv2Tests.java
@@ -493,6 +493,53 @@ public class Chemv2Tests extends GraphMolTest {
         System.out.print(svg);
     }
 
+    @Test
+    public void testStrictParsing() {
+        String badMolBlock = "\n" +
+            "  MJ201100                      \n" +
+            "\n" +
+            "  3  2  0  0  0  0  0  0  0  0999 V2000\n" +
+            "   -0.3572   -0.2062    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" +
+            "    0.3572    0.2062    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" +
+            "    1.0717    0.6187    0.0000 N   0  0  0  0  0  0  0  0  0  0  0  0\n" +
+            "  1  2  1  0  0  0  0\n" +
+            "  2  3  3  0  0  0  0\n" +
+            "M  STY  1   1 SUP\n" +
+            "M  SAL   1  2   2   3\n" +
+            "M  SMT   1 CN\n" +
+            "M  SBL   1  1   1\n" +
+            "M  SAP   1  1   2\n" +
+            "M  END\n";
+        boolean exceptionThrown = false;
+        boolean molIsValid = false;
+        ROMol mol = null;
+        try {
+            mol = RWMol.MolFromMolBlock(badMolBlock);
+        } catch(Exception e) {
+            exceptionThrown = true;
+        } finally {
+            if (mol != null) {
+                molIsValid = true;
+                mol.delete();
+            }
+        }
+        assertTrue(exceptionThrown);
+        assertFalse(molIsValid);
+        exceptionThrown = false;
+        try {
+            mol = RWMol.MolFromMolBlock(badMolBlock, true, true, false);
+        } catch(Exception e) {
+            exceptionThrown = true;
+        } finally {
+            if (mol != null) {
+                molIsValid = true;
+                mol.delete();
+            }
+        }
+        assertFalse(exceptionThrown);
+        assertTrue(molIsValid);
+    }
+
     public static void main(String args[]) {
         org.junit.runner.JUnitCore.main("org.RDKit.Chemv2Tests");
     }


### PR DESCRIPTION
This PR updates some SWIG definitions which are obsolete/incomplete with respect to the current C++ codebase.

- updated outdated SWIG definitions of `ROMol.generateDepictionMatching2DStructure`
- updated outdated SWIG definitions of `RWMol.MolFromMolBlock` and `RWMol.MolFromMolFile`
- added unit test
