### PR TITLE
Speed up ring detection by reducing count() calls

### DIFF
--- a/Code/GraphMol/FindRings.cpp
+++ b/Code/GraphMol/FindRings.cpp
@@ -235,6 +235,9 @@ void removeExtraRings(VECT_INT_VECT &res, unsigned int, const ROMol &mol) {
   boost::dynamic_bitset<> keepRings(res.size());
   boost::dynamic_bitset<> munion(mol.getNumBonds());
 
+  // optimization - don't reallocate a new one each loop
+  boost::dynamic_bitset<> workspace(mol.getNumBonds());
+
   for (unsigned int i = 0; i < res.size(); ++i) {
     // skip this ring if we've already seen all of its bonds
     if (bitBrings[i].is_subset_of(munion)) {
@@ -258,16 +261,14 @@ void removeExtraRings(VECT_INT_VECT &res, unsigned int, const ROMol &mol) {
       }
     }
 
-    // optimization - don't reallocate a new one each loop
-    boost::dynamic_bitset<> workspace(mol.getNumBonds());
-    while (consider.count()) {
+    while (consider.any()) {
       unsigned int bestJ = i + 1;
       int bestOverlap = -1;
       // loop over the available other rings in consideration and pick the one
       // that has the most overlapping bonds with what we've done so far.
       // this is the fix to github #526
       for (unsigned int j = i + 1;
-           j < res.size() && bitBrings[j].count() == bitBrings[i].count();
+           j < res.size() && brings[j].size() == brings[i].size();
            ++j) {
         if (!consider[j] || !availRings[j]) {
           continue;


### PR DESCRIPTION
Counting the "on" bits in a bitset is a calculation - finding the size of a std::vector requires only a lookup! For my example system from https://github.com/rdkit/rdkit/pull/5654 , this reduces the duration by another minute or so.

Here's an example profile from before this change. The "big" `count()` calls are the two removed here. I think they're usually close to 30s each, or 25 with SSE4.2 enabled (on my computer):
<img width="893" alt="ringfinding_profile" src="https://user-images.githubusercontent.com/3013277/196339526-0f1bd4d1-41d3-4463-afb2-f4fb47c6c8a6.png">

(I think that there's more clever stuff that could be done, but this seems like another trivial change with an inarguably positive effect.)