### PR TITLE
Add a Python Context Manager for SetPreferCoordGen

### DIFF
--- a/Code/GraphMol/Depictor/Wrap/rdDepictor.cpp
+++ b/Code/GraphMol/Depictor/Wrap/rdDepictor.cpp
@@ -147,6 +147,36 @@ void setPreferCoordGen(bool value) {
   RDDepict::preferCoordGen = value;
 #endif
 }
+bool getPreferCoordGen() {
+#ifdef RDK_BUILD_COORDGEN_SUPPORT
+  return RDDepict::preferCoordGen;
+#else
+  return false;
+#endif
+}
+
+class UsingCoordGen : public boost::noncopyable {
+ public:
+  UsingCoordGen() = delete;
+  UsingCoordGen(bool temp_state)
+      : m_initial_state{getPreferCoordGen()}, m_temp_state(temp_state) {}
+  ~UsingCoordGen() = default;
+
+  void enter() { setPreferCoordGen(m_temp_state); }
+
+  void exit(python::object exc_type, python::object exc_val,
+            python::object traceback) {
+    RDUNUSED_PARAM(exc_type);
+    RDUNUSED_PARAM(exc_val);
+    RDUNUSED_PARAM(traceback);
+    setPreferCoordGen(m_initial_state);
+  }
+
+ private:
+  bool m_initial_state;
+  bool m_temp_state;
+};
+
 }  // namespace RDDepict
 
 BOOST_PYTHON_MODULE(rdDepictor) {
@@ -166,6 +196,23 @@ BOOST_PYTHON_MODULE(rdDepictor) {
               "Has no effect (CoordGen support not enabled)"
 #endif
   );
+  python::def(
+      "GetPreferCoordGen", getPreferCoordGen,
+#ifdef RDK_BUILD_COORDGEN_SUPPORT
+      "Return whether or not the CoordGen library is used for coordinate "
+      "generation in the RDKit depiction library."
+#else
+      "Always returns False (CoordGen support not enabled)"
+#endif
+  );
+
+  python::class_<UsingCoordGen, boost::noncopyable>(
+      "UsingCoordGen",
+      "Context manager to temporarily set CoordGen library preference in RDKit depiction.",
+      python::init<bool>("Constructor"))
+      .def("__enter__", &UsingCoordGen::enter)
+      .def("__exit__", &UsingCoordGen::exit);
+
   std::string docString;
   docString =
       "Compute 2D coordinates for a molecule. \n\

--- a/Code/GraphMol/Depictor/Wrap/rdDepictor.cpp
+++ b/Code/GraphMol/Depictor/Wrap/rdDepictor.cpp
@@ -142,6 +142,15 @@ void GenerateDepictionMatching3DStructure(RDKit::ROMol &mol,
   RDDepict::generateDepictionMatching3DStructure(
       mol, reference, confId, referencePattern, acceptFailure, forceRDKit);
 }
+
+bool isCoordGenSupportAvailable() {
+#ifdef RDK_BUILD_COORDGEN_SUPPORT
+  return true;
+#else
+  return false;
+#endif
+}
+
 void setPreferCoordGen(bool value) {
 #ifdef RDK_BUILD_COORDGEN_SUPPORT
   RDDepict::preferCoordGen = value;
@@ -187,6 +196,9 @@ BOOST_PYTHON_MODULE(rdDepictor) {
       &rdDepictExceptionTranslator);
 
   rdkit_import_array();
+
+  python::def("IsCoordGenSupportAvailable", isCoordGenSupportAvailable,
+              "Returns whether RDKit was built with CoordGen support.");
 
   python::def("SetPreferCoordGen", setPreferCoordGen, python::arg("val"),
 #ifdef RDK_BUILD_COORDGEN_SUPPORT

--- a/Code/GraphMol/Depictor/Wrap/testDepictor.py
+++ b/Code/GraphMol/Depictor/Wrap/testDepictor.py
@@ -1,18 +1,19 @@
 # Automatically adapted for numpy.oldnumeric Jun 27, 2008 by -c
 
+import os
+import sys
 #
 #  $Id: testDepictor.py 2112 2012-07-02 09:47:45Z glandrum $
 #
 # pylint:disable=E1101,C0111,C0103,R0904
 import unittest
-import os
-import sys
-import numpy as np
 
+import numpy as np
 from rdkit import Chem
-from rdkit.Chem import rdDepictor, rdMolAlign
 from rdkit import Geometry
 from rdkit import RDConfig
+from rdkit.Chem import rdDepictor
+from rdkit.Chem import rdMolAlign
 from rdkit.Chem.ChemUtils import AlignDepict
 
 
@@ -532,6 +533,31 @@ M  END)""")
         self.assertAlmostEqual(bond4_11Conf2.x, bond4_11Conf3.x, 3)
         self.assertAlmostEqual(bond4_11Conf2.y, bond4_11Conf3.y, 3)
 
+    @unittest.skipIf(not rdDepictor.IsCoordGenSupportAvailable(), "CoordGen not available, skipping")
+    def testUsingCoordGenCtxtMgr(self):
+        default_status = rdDepictor.GetPreferCoordGen()
+
+        # This is the default; we shouldn't have changed it
+        self.assertEqual(default_status, False)
+
+        with rdDepictor.UsingCoordGen(True):
+            current_status = rdDepictor.GetPreferCoordGen()
+            self.assertEqual(current_status, True)
+
+        current_status = rdDepictor.GetPreferCoordGen()
+        self.assertEqual(current_status, False)
+
+        rdDepictor.SetPreferCoordGen(True)
+
+        with rdDepictor.UsingCoordGen(False):
+            current_status = rdDepictor.GetPreferCoordGen()
+            self.assertEqual(current_status, False)
+
+        current_status = rdDepictor.GetPreferCoordGen()
+        self.assertEqual(current_status, True)
+
+        rdDepictor.SetPreferCoordGen(default_status)
+
+
 if __name__ == '__main__':
-    rdDepictor.SetPreferCoordGen(False)
     unittest.main()

--- a/Code/GraphMol/Depictor/Wrap/testDepictor.py
+++ b/Code/GraphMol/Depictor/Wrap/testDepictor.py
@@ -1,4 +1,3 @@
-
 # Automatically adapted for numpy.oldnumeric Jun 27, 2008 by -c
 
 import os
@@ -561,5 +560,4 @@ M  END)""")
 
 
 if __name__ == '__main__':
-    rdDepictor.SetPreferCoordGen(False)
     unittest.main()

--- a/Code/GraphMol/Depictor/Wrap/testDepictor.py
+++ b/Code/GraphMol/Depictor/Wrap/testDepictor.py
@@ -1,3 +1,4 @@
+
 # Automatically adapted for numpy.oldnumeric Jun 27, 2008 by -c
 
 import os
@@ -560,4 +561,5 @@ M  END)""")
 
 
 if __name__ == '__main__':
+    rdDepictor.SetPreferCoordGen(False)
     unittest.main()

--- a/Docs/Book/data/test_multi_colours.py
+++ b/Docs/Book/data/test_multi_colours.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python
 
-from rdkit import Chem, rdBase
-from rdkit.Chem import rdDepictor
-from rdkit.Chem import Draw
-from rdkit.Chem import AllChem
-from rdkit.Chem.Draw import rdMolDraw2D
 from json import dumps
+
+from rdkit import Chem
+from rdkit import rdBase
+from rdkit.Chem import AllChem
+from rdkit.Chem import Draw
+from rdkit.Chem import rdDepictor
+from rdkit.Chem.Draw import rdMolDraw2D
 
 COLS = [(1.0, 0.0, 0.0), (0.0, 1.0, 0.0),
         (0.0, 0.0, 1.0), (1.0, 0.55, 1.0)]
@@ -24,7 +26,7 @@ def get_hit_atoms_and_bonds(mol, smt):
                 b = mol.GetBondBetweenAtoms(ha1, ha2)
                 if b:
                     blist.append(b.GetIdx())
-    
+
     return alist, blist
 
 
@@ -38,37 +40,37 @@ def add_colours_to_map(els, cols, col_num):
 
 def do_a_picture(smi, smarts, filename, label, fmt='svg'):
 
-    rdDepictor.SetPreferCoordGen(True)
-    mol = Chem.MolFromSmiles(smi)
-    mol = Draw.PrepareMolForDrawing(mol)
+    with rdDepictor.UsingCoordGen(True):
+        mol = Chem.MolFromSmiles(smi)
+        mol = Draw.PrepareMolForDrawing(mol)
 
-    acols = {}
-    bcols = {}
-    h_rads = {}
-    h_lw_mult = {}
+        acols = {}
+        bcols = {}
+        h_rads = {}
+        h_lw_mult = {}
 
-    for i, smt in enumerate(smarts):
-        alist, blist = get_hit_atoms_and_bonds(mol, smt)
-        col = i % 4
-        add_colours_to_map(alist, acols, col)
-        add_colours_to_map(blist, bcols, col)
-    
-    if fmt == 'svg':
-        d = rdMolDraw2D.MolDraw2DSVG(300, 300)
-        mode = 'w'
-    elif fmt == 'png':
-        d = rdMolDraw2D.MolDraw2DCairo(300, 300)
-        mode = 'wb'
-    else:
-        print('unknown format {}'.format(fmt))
-        return
-    
-    d.drawOptions().fillHighlights = False
-    d.DrawMoleculeWithHighlights(mol, label, acols, bcols, h_rads, h_lw_mult, -1)
-    d.FinishDrawing()
-        
-    with open(filename, mode) as f:
-        f.write(d.GetDrawingText())
+        for i, smt in enumerate(smarts):
+            alist, blist = get_hit_atoms_and_bonds(mol, smt)
+            col = i % 4
+            add_colours_to_map(alist, acols, col)
+            add_colours_to_map(blist, bcols, col)
+
+        if fmt == 'svg':
+            d = rdMolDraw2D.MolDraw2DSVG(300, 300)
+            mode = 'w'
+        elif fmt == 'png':
+            d = rdMolDraw2D.MolDraw2DCairo(300, 300)
+            mode = 'wb'
+        else:
+            print('unknown format {}'.format(fmt))
+            return
+
+        d.drawOptions().fillHighlights = False
+        d.DrawMoleculeWithHighlights(mol, label, acols, bcols, h_rads, h_lw_mult, -1)
+        d.FinishDrawing()
+
+        with open(filename, mode) as f:
+            f.write(d.GetDrawingText())
 
 
 smi = 'CO[C@@H](O)C1=C(O[C@H](F)Cl)C(C#N)=C1ONNC[NH3+]'

--- a/Docs/Book/data/test_multi_colours.py
+++ b/Docs/Book/data/test_multi_colours.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python
 
-from rdkit import Chem, rdBase
-from rdkit.Chem import rdDepictor
-from rdkit.Chem import Draw
-from rdkit.Chem import AllChem
-from rdkit.Chem.Draw import rdMolDraw2D
 from json import dumps
+
+from rdkit import Chem
+from rdkit import rdBase
+from rdkit.Chem import AllChem
+from rdkit.Chem import Draw
+from rdkit.Chem import rdDepictor
+from rdkit.Chem.Draw import rdMolDraw2D
 
 COLS = [(1.0, 0.0, 0.0), (0.0, 1.0, 0.0),
         (0.0, 0.0, 1.0), (1.0, 0.55, 1.0)]
@@ -24,7 +26,7 @@ def get_hit_atoms_and_bonds(mol, smt):
                 b = mol.GetBondBetweenAtoms(ha1, ha2)
                 if b:
                     blist.append(b.GetIdx())
-    
+
     return alist, blist
 
 
@@ -38,41 +40,37 @@ def add_colours_to_map(els, cols, col_num):
 
 def do_a_picture(smi, smarts, filename, label, fmt='svg'):
 
-    # This should use rdDepictor.UsingCoordGen(True) so that
-    # we restore state after leaving, but this breaks some
-    # tests right now!
-    rdDepictor.SetPreferCoordGen(True)
+    with rdDepictor.UsingCoordGen(True):
+        mol = Chem.MolFromSmiles(smi)
+        mol = Draw.PrepareMolForDrawing(mol)
 
-    mol = Chem.MolFromSmiles(smi)
-    mol = Draw.PrepareMolForDrawing(mol)
+        acols = {}
+        bcols = {}
+        h_rads = {}
+        h_lw_mult = {}
 
-    acols = {}
-    bcols = {}
-    h_rads = {}
-    h_lw_mult = {}
+        for i, smt in enumerate(smarts):
+            alist, blist = get_hit_atoms_and_bonds(mol, smt)
+            col = i % 4
+            add_colours_to_map(alist, acols, col)
+            add_colours_to_map(blist, bcols, col)
 
-    for i, smt in enumerate(smarts):
-        alist, blist = get_hit_atoms_and_bonds(mol, smt)
-        col = i % 4
-        add_colours_to_map(alist, acols, col)
-        add_colours_to_map(blist, bcols, col)
-    
-    if fmt == 'svg':
-        d = rdMolDraw2D.MolDraw2DSVG(300, 300)
-        mode = 'w'
-    elif fmt == 'png':
-        d = rdMolDraw2D.MolDraw2DCairo(300, 300)
-        mode = 'wb'
-    else:
-        print('unknown format {}'.format(fmt))
-        return
-    
-    d.drawOptions().fillHighlights = False
-    d.DrawMoleculeWithHighlights(mol, label, acols, bcols, h_rads, h_lw_mult, -1)
-    d.FinishDrawing()
-        
-    with open(filename, mode) as f:
-        f.write(d.GetDrawingText())
+        if fmt == 'svg':
+            d = rdMolDraw2D.MolDraw2DSVG(300, 300)
+            mode = 'w'
+        elif fmt == 'png':
+            d = rdMolDraw2D.MolDraw2DCairo(300, 300)
+            mode = 'wb'
+        else:
+            print('unknown format {}'.format(fmt))
+            return
+
+        d.drawOptions().fillHighlights = False
+        d.DrawMoleculeWithHighlights(mol, label, acols, bcols, h_rads, h_lw_mult, -1)
+        d.FinishDrawing()
+
+        with open(filename, mode) as f:
+            f.write(d.GetDrawingText())
 
 
 smi = 'CO[C@@H](O)C1=C(O[C@H](F)Cl)C(C#N)=C1ONNC[NH3+]'


### PR DESCRIPTION
We have recently seen some mysterious test failure that ended up happening because of a `rdDepictor.SetPreferCoordGen(True)` that was never reset back to `False`. This PR adds a `UsingCoordGen` context manager to automatically reset the CoordGen preference and make it harder to hit bugs as the one we had.

This also adds a `IsCoordGenSupportAvailable()` function to allow checks for CoordGen Support from Python, and `getPreferCoordGen()` to check the current state of the setting.