### PR TITLE
Update warning message about aromaticity detection

### DIFF
--- a/Code/GraphMol/Aromaticity.cpp
+++ b/Code/GraphMol/Aromaticity.cpp
@@ -368,7 +368,7 @@ void applyHuckelToFused(
       // If a ring system has more than 300 rings and a ring combination search larger than 2 is reached,
       // the calculation becomes exponentially longer, in some case it never completes.
       if ((curSize == 2) && (nrings > 300)) {
-        BOOST_LOG(rdWarningLog) << "Ring system too large for aromaticity detection." << std::endl;
+        BOOST_LOG(rdWarningLog) << "Aromaticity detection halted on some rings due to ring system size." << std::endl;
         break;
       }
 


### PR DESCRIPTION
An internal user encountered the existing error message and became alarmed by the implication that no aromaticity detection was even attempted.

I think that the new error message more accurately reflects the logic - we halt the search eventually if the ring system is too large.