### PR TITLE
Fix invocation of pytest

### DIFF
--- a/.azure-pipelines/linux_build.yml
+++ b/.azure-pipelines/linux_build.yml
@@ -69,7 +69,7 @@ steps:
 - bash: |
     source ${CONDA}/etc/profile.d/conda.sh
     conda activate rdkit_build
-    conda install ipython matplotlib-base sphinx=3.1.2 recommonmark 
+    conda install ipython matplotlib-base sphinx=3.1.2 "jinja2<3.1" recommonmark 
     export RDBASE=`pwd`
     export PYTHONPATH=${RDBASE}:${PYTHONPATH}
     export LD_LIBRARY_PATH=${RDBASE}/lib:${LD_LIBRARY_PATH}

--- a/.azure-pipelines/vs_build.yml
+++ b/.azure-pipelines/vs_build.yml
@@ -8,7 +8,7 @@ steps:
         boost-cpp=$(boost_version) boost=$(boost_version) ^
         py-boost=$(boost_version) libboost=$(boost_version) ^
         numpy matplotlib cairo pillow eigen pandas ^
-        sphinx=3.1.2 recommonmark
+        sphinx=3.1.2  "jinja2<3.1" recommonmark
     call activate rdkit_build
     conda install -c conda-forge cmake nbval
   displayName: Install dependencies

--- a/Code/cmake/Modules/RDKitUtils.cmake
+++ b/Code/cmake/Modules/RDKitUtils.cmake
@@ -217,7 +217,7 @@ endmacro(add_pytest)
 
 function(add_jupytertest testname workingdir notebook)
   if(RDK_BUILD_PYTHON_WRAPPERS AND RDK_NBVAL_AVAILABLE)
-    add_test(NAME ${testname}  COMMAND ${PYTHON_EXECUTABLE} -m py.test --nbval ${notebook}
+    add_test(NAME ${testname}  COMMAND ${PYTHON_EXECUTABLE} -m pytest --nbval ${notebook}
        WORKING_DIRECTORY ${workingdir} )
     SET(RDKIT_JUPYTERTEST_CACHE "${testname};${RDKIT_JUPYTERTEST_CACHE}" CACHE INTERNAL "Global list of jupyter tests")
   endif()

--- a/rdkit/Chem/PandasTools.py
+++ b/rdkit/Chem/PandasTools.py
@@ -333,7 +333,7 @@ else:
       del groups['Core']
     groups['Mol'] = mols
     frame = pd.DataFrame(groups, columns=cols)
-    ChangeMoleculeRendering(df)
+    ChangeMoleculeRendering(frame)
     return frame
 
 

--- a/rdkit/Chem/PandasTools.py
+++ b/rdkit/Chem/PandasTools.py
@@ -333,6 +333,7 @@ else:
       del groups['Core']
     groups['Mol'] = mols
     frame = pd.DataFrame(groups, columns=cols)
+    ChangeMoleculeRendering(df)
     return frame
 
 


### PR DESCRIPTION
We've been using a deprecated approach to invoke pytest in `add_jupytertest()`. That approach no longer works in pytest and the CI builds are breaking because of it. This resolves that.

This also fixes #5702