### PR TITLE
Fixes #5704

### DIFF
--- a/Code/GraphMol/MolDraw2D/DrawMol.cpp
+++ b/Code/GraphMol/MolDraw2D/DrawMol.cpp
@@ -2042,7 +2042,8 @@ void DrawMol::makeBondHighlightLines(double lineWidth, double scale) {
           // These effects can be seen in bond_highlights_8.svg produced
           // by catch_tests.cpp.
           DrawColour col = getHighlightBondColour(
-              bond->getIdx(), drawOptions_, highlightBonds_, highlightBondMap_);
+              bond, drawOptions_, highlightBonds_, highlightBondMap_,
+              highlightAtoms_, highlightAtomMap_);
           std::vector<Atom *> thisHighNbrs;
           std::vector<Atom *> nbrHighNbrs;
           auto nbr = drawMol_->getAtomWithIdx(nbrIdx);
@@ -2059,13 +2060,13 @@ void DrawMol::makeBondHighlightLines(double lineWidth, double scale) {
           // (see Github5592).  Make a convex hull, using a simplified
           // form of Graham's scan algorithm - all the points
           // are in the convex hull so it's easier.  Grahsm's scan normally
-	  // has a second step that removes inner points, and this takes
-	  // care of any problems with floating point errors in the
-	  // comparisons below.  The shapes here are at most hexagons with
-	  // sharp angles so such issues have been deemed unlikely to
-	  // occur in practice.
+          // has a second step that removes inner points, and this takes
+          // care of any problems with floating point errors in the
+          // comparisons below.  The shapes here are at most hexagons with
+          // sharp angles so such issues have been deemed unlikely to
+          // occur in practice.
           // Sort so the lowest y point is first, with lowest x as
-	  // tie-breaker.
+          // tie-breaker.
           std::sort(points.begin(), points.end(),
                     [](Point2D &p1, Point2D &p2) -> bool {
                       if (p1.y < p2.y) {
@@ -3213,7 +3214,8 @@ DrawColour DrawMol::getColour(int atom_idx) const {
                       nbr->getIdx()) != highlightBonds_.end() ||
             highlightBondMap_.find(nbr->getIdx()) != highlightBondMap_.end()) {
           DrawColour hc = getHighlightBondColour(
-              nbr->getIdx(), drawOptions_, highlightBonds_, highlightBondMap_);
+              nbr, drawOptions_, highlightBonds_, highlightBondMap_,
+              highlightAtoms_, highlightAtomMap_);
           if (!highCol) {
             highCol.reset(new DrawColour(hc));
           } else {
@@ -3322,15 +3324,36 @@ DrawColour getColourByAtomicNum(int atomic_num,
 
 // ****************************************************************************
 DrawColour getHighlightBondColour(
-    int bondIdx, const MolDrawOptions &drawOptions,
+    const Bond *bond, const MolDrawOptions &drawOptions,
     const std::vector<int> &highlightBonds,
-    const std::map<int, DrawColour> &highlightBondMap) {
+    const std::map<int, DrawColour> &highlightBondMap,
+    const std::vector<int> &highlightAtoms,
+    const std::map<int, DrawColour> &highlightAtomMap) {
+  PRECONDITION(bond, "no bond provided");
+  RDUNUSED_PARAM(highlightAtoms);
+
   DrawColour col(0.0, 0.0, 0.0);
-  if (std::find(highlightBonds.begin(), highlightBonds.end(), bondIdx) !=
+  if (std::find(highlightBonds.begin(), highlightBonds.end(), bond->getIdx()) !=
       highlightBonds.end()) {
     col = drawOptions.highlightColour;
-    if (highlightBondMap.find(bondIdx) != highlightBondMap.end()) {
-      col = highlightBondMap.find(bondIdx)->second;
+    if (highlightBondMap.find(bond->getIdx()) != highlightBondMap.end()) {
+      col = highlightBondMap.find(bond->getIdx())->second;
+    } else {
+      // the highlight color of the bond is not explicitly provided. What about
+      // the highlight colors of the begin/end atoms? Ideally these will both be
+      // the same, but we want to set the coloring even if that's not the
+      // case, so we'll use:
+      //  - begin atom color if that is set
+      //  - end atom color if that is set
+      //  - the default highlight color otherwise
+      if (highlightAtomMap.find(bond->getBeginAtomIdx()) !=
+          highlightAtomMap.end()) {
+        col = highlightAtomMap.find(bond->getBeginAtomIdx())->second;
+
+      } else if (highlightAtomMap.find(bond->getEndAtomIdx()) !=
+                 highlightAtomMap.end()) {
+        col = highlightAtomMap.find(bond->getEndAtomIdx())->second;
+      }
     }
   }
   return col;

--- a/Code/GraphMol/MolDraw2D/DrawMol.h
+++ b/Code/GraphMol/MolDraw2D/DrawMol.h
@@ -309,9 +309,11 @@ std::string getAtomListText(const Atom &atom);
 DrawColour getColourByAtomicNum(int atomicNum,
                                 const MolDrawOptions &drawOptions);
 DrawColour getHighlightBondColour(
-    int bondIdx, const MolDrawOptions &drawOptions,
+    const Bond *bond, const MolDrawOptions &drawOptions,
     const std::vector<int> &highlightBonds,
-    const std::map<int, DrawColour> &highlightBondMap);
+    const std::map<int, DrawColour> &highlightBondMap,
+    const std::vector<int> &highlightAtoms,
+    const std::map<int, DrawColour> &highlightAtomMap);
 double getHighlightBondWidth(
     const MolDrawOptions &drawOptions, int bond_idx,
     const std::map<int, int> *highlight_linewidth_multipliers);

--- a/Code/GraphMol/MolDraw2D/Wrap/testMolDraw2D.py
+++ b/Code/GraphMol/MolDraw2D/Wrap/testMolDraw2D.py
@@ -186,7 +186,7 @@ M  END""")
     drawer.FinishDrawing()
     svg = drawer.GetDrawingText()
     # 4 molecules, 6 bonds each:
-    re_str = r"path class='bond-\d+ atom-\d+ atom-\d+' d='M \d+.\d+,\d+.\d+ L \d+.\d+,\d+.\d+ L \d+.\d+,\d+.\d+ L \d+.\d+,\d+.\d+ Z' style='fill:#FF7F7F;"
+    re_str = r"path class='bond-\d+ atom-\d+ atom-\d+' d='M \d+.\d+,\d+.\d+ L \d+.\d+,\d+.\d+ L \d+.\d+,\d+.\d+ L \d+.\d+,\d+.\d+ Z' style='fill:"
     patt = re.compile(re_str)
     self.assertEqual(len(patt.findall(svg)), 24)
     # 4 molecules, one atom each:

--- a/Code/GraphMol/MolDraw2D/catch_tests.cpp
+++ b/Code/GraphMol/MolDraw2D/catch_tests.cpp
@@ -5993,3 +5993,86 @@ M  END
     }
   }
 }
+
+TEST_CASE(
+    "Github5704: set bond highlight color when atom highlight color changes") {
+  std::string nameBase = "test_github5704";
+
+  auto m =
+      "CCCO |(-1.97961,-0.1365,;-0.599379,0.450827,;0.599379,-0.450827,;1.97961,0.1365,)|"_smiles;
+  REQUIRE(m);
+  std::regex redline(R"RE(<path .*fill:#FF7F7F)RE");
+  std::regex blueline(R"RE(<path .*fill:#4C4CFF)RE");
+
+  SECTION("no atom colors specified, default behavior") {
+    MolDraw2DSVG drawer(300, 300, 300, 300, NO_FREETYPE);
+    std::vector<int> aids{0, 1, 2};
+    drawer.drawMolecule(*m, "red bond highlight", &aids);
+    drawer.finishDrawing();
+    std::string text = drawer.getDrawingText();
+
+    std::smatch rematch;
+    CHECK(std::regex_search(text, rematch, redline));
+    CHECK(!std::regex_search(text, rematch, blueline));
+
+    std::ofstream outs(nameBase + "_1.svg");
+    outs << text;
+    outs.flush();
+    outs.close();
+  }
+
+  SECTION("both ends specified") {
+    MolDraw2DSVG drawer(300, 300, 300, 300, NO_FREETYPE);
+    std::vector<int> aids{0, 1, 2};
+    std::map<int, DrawColour> acolors{
+        {0, {.3, .3, 1}}, {1, {.3, .3, 1}}, {2, {.3, .3, 1}}};
+    drawer.drawMolecule(*m, "blue bond highlight", &aids, &acolors);
+    drawer.finishDrawing();
+    std::string text = drawer.getDrawingText();
+
+    std::smatch rematch;
+    CHECK(!std::regex_search(text, rematch, redline));
+    CHECK(std::regex_search(text, rematch, blueline));
+
+    std::ofstream outs(nameBase + "_2.svg");
+    outs << text;
+    outs.flush();
+    outs.close();
+  }
+
+  SECTION("color just on begin") {
+    MolDraw2DSVG drawer(300, 300, 300, 300, NO_FREETYPE);
+    std::vector<int> aids{0, 1};
+    std::map<int, DrawColour> acolors{{0, {.3, .3, 1}}};
+    drawer.drawMolecule(*m, "blue bond highlight", &aids, &acolors);
+    drawer.finishDrawing();
+    std::string text = drawer.getDrawingText();
+
+    std::smatch rematch;
+    CHECK(!std::regex_search(text, rematch, redline));
+    CHECK(std::regex_search(text, rematch, blueline));
+
+    std::ofstream outs(nameBase + "_3.svg");
+    outs << text;
+    outs.flush();
+    outs.close();
+  }
+  SECTION("color just on end") {
+    MolDraw2DSVG drawer(300, 300, 300, 300, NO_FREETYPE);
+    std::vector<int> aids{0, 1};
+    std::map<int, DrawColour> acolors{{1, {.3, .3, 1}}};
+    drawer.drawMolecule(*m, "blue bond highlight", &aids, &acolors);
+    drawer.finishDrawing();
+    std::string text = drawer.getDrawingText();
+
+    std::smatch rematch;
+
+    CHECK(!std::regex_search(text, rematch, redline));
+    CHECK(std::regex_search(text, rematch, blueline));
+
+    std::ofstream outs(nameBase + "_4.svg");
+    outs << text;
+    outs.flush();
+    outs.close();
+  }
+}

--- a/Code/JavaWrappers/gmwrapper/src-test/org/RDKit/Chemv2Tests.java
+++ b/Code/JavaWrappers/gmwrapper/src-test/org/RDKit/Chemv2Tests.java
@@ -467,7 +467,9 @@ public class Chemv2Tests extends GraphMolTest {
         assertTrue(svg.indexOf("fill:#FF00FF;") > -1);
         assertTrue(svg.indexOf("fill:#00FFFF;") > -1);
         // default line color:
-        assertTrue(svg.indexOf("stroke:#FF7F7F;") > -1);
+        assertTrue(svg.indexOf("stroke:#FF7F7F;") == -1);
+        assertTrue(svg.indexOf("stroke:#FFFF00;") > -1);
+        assertTrue(svg.indexOf("stroke:#FF00FF;") > -1);
     }
 
     @Test


### PR DESCRIPTION
This is easy for cases where the begin and end atoms of the bond have the same color, but we need to make an arbitrary decision about which to pick if they differ or if one is color is specified and not the other.

Here we use the following logic to pick the bond highlight color:
1. Use the highlight color of the begin atom if it is set (this also covers the case when both atoms are set)
2. Use the highlight color of the end atom if it is set
3. Otherwise use the default highlight color
