### PR TITLE
Fixes #5692

### DIFF
--- a/Code/GraphMol/FileParsers/MolSupplier.h
+++ b/Code/GraphMol/FileParsers/MolSupplier.h
@@ -296,9 +296,9 @@ class RDKIT_FILEPARSERS_EXPORT SmilesMolSupplier : public MolSupplier {
   void checkForEnd();
 
   bool df_end = false;  // have we reached the end of the file?
-  int d_len = 0;        // total number of smiles in the file
-  int d_next = 0;       // the  molecule we are ready to read
-  int d_line = 0;       // line number we are currently on
+  long d_len = 0;       // total number of smiles in the file
+  long d_next = 0;      // the  molecule we are ready to read
+  size_t d_line = 0;    // line number we are currently on
   std::vector<std::streampos>
       d_molpos;  // vector of positions in the file for molecules
   std::vector<int> d_lineNums;

--- a/Code/GraphMol/FileParsers/SmilesMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/SmilesMolSupplier.cpp
@@ -390,7 +390,7 @@ void SmilesMolSupplier::moveTo(unsigned int idx) {
 
   // the stream pointer is now at the last thing we read in
   while (d_molpos.size() <= idx) {
-    int nextP = this->skipComments();
+    std::streampos nextP = this->skipComments();
     if (nextP < 0) {
       std::ostringstream errout;
       errout << "ERROR: Index error (idx = " << idx << "): "


### PR DESCRIPTION
We're still limited by using an int as the molecule index in the API; fixing that is a minor API break.
I think that's reasonable to do, but if we decide to go that way it should be in a separate PR so that we can get this fix out as a bug fix.


