### PR TITLE
Compile clang bytecode with -std=c++17 (#5685)

### DIFF
--- a/Code/PgSQL/rdkit/Makefile
+++ b/Code/PgSQL/rdkit/Makefile
@@ -103,7 +103,7 @@ CC = $(CXX)
 	$(CXX) $(CPLUSPLUSFLAGS) $(CPPFLAGS) -fPIC -c -o $@ $<
 
 
-COMPILE.cxx.bc = $(CLANG) -xc++ -Wno-ignored-attributes $(BITCODE_CXXFLAGS) $(CPPFLAGS) -emit-llvm -c
+COMPILE.cxx.bc = $(CLANG) -std=c++17 -xc++ -Wno-ignored-attributes $(BITCODE_CXXFLAGS) $(CPPFLAGS) -emit-llvm -c
 
 %.bc : %.cpp
 	$(COMPILE.cxx.bc) -o $@ $<


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! 
-->
#### Reference Issue
Fixes: #5685


#### What does this implement/fix? Explain your changes.
The clang Postgres bytecode needs to be compiled with `-std=c++17` or else fails with the build error mentioned in the issue.

#### Any other comments?

