### PR TITLE
Use correct `_WIN32` macro for checking Windows target

### DIFF
--- a/Code/RDGeneral/RDExportMacros.h
+++ b/Code/RDGeneral/RDExportMacros.h
@@ -20,7 +20,7 @@
 
 // RDKit export macro definitions
 #ifdef RDKIT_DYN_LINK
-#if defined(WIN32) && defined(BOOST_HAS_DECLSPEC)
+#if defined(_WIN32) && defined(BOOST_HAS_DECLSPEC)
 #define RDKIT_EXPORT_API __declspec(dllexport)
 #define RDKIT_IMPORT_API __declspec(dllimport)
 #elif __GNUC__ >= 4 || defined(__clang__)


### PR DESCRIPTION
The correct macro to identify Windows target is `_WIN32`, not `WIN32`: https://learn.microsoft.com/en-us/cpp/preprocessor/predefined-macros?view=msvc-170#microsoft-specific-predefined-macros.  Besides, according to C standard, compilers can't predefine macros without one leading underscore (or two if the the first letter is lowercase).