### PR TITLE
windows.h header should be lowercase

### DIFF
--- a/Code/GraphMol/MMPA/MMPA_UnitTest.cpp
+++ b/Code/GraphMol/MMPA/MMPA_UnitTest.cpp
@@ -37,7 +37,7 @@
 #include <sys/time.h>
 #endif
 #ifdef _WIN32
-#include <Windows.h>
+#include <windows.h>
 #else
 #include <sys/resource.h>
 #endif


### PR DESCRIPTION
`windows.h` header should be lowercase to avoid issues when cross-compiling on Linux. In fact, `windows.h` is lowercase on Linux and since the filesystem is case sensitive it will fail if it is uppercase. On Windows it will make no difference since the filesystem is not case sensitive.