### PR TITLE
Add stub files generation and installation

### DIFF
--- a/.azure-pipelines/linux_build.yml
+++ b/.azure-pipelines/linux_build.yml
@@ -10,7 +10,7 @@ steps:
         boost-cpp=$(boost_version) \
         py-boost=$(boost_version) \
         numpy pillow eigen pandas matplotlib-base \
-        qt=5.9.7 cairo
+        qt=5.9.7 cairo mypy
     conda activate rdkit_build
     conda install -c conda-forge nbval ipykernel>=6.0
   displayName: Setup build environment
@@ -69,7 +69,7 @@ steps:
 - bash: |
     source ${CONDA}/etc/profile.d/conda.sh
     conda activate rdkit_build
-    conda install ipython matplotlib-base sphinx=3.1.2 "jinja2<3.1" recommonmark 
+    conda install ipython matplotlib-base sphinx=3.1.2 "jinja2<3.1" recommonmark
     export RDBASE=`pwd`
     export PYTHONPATH=${RDBASE}:${PYTHONPATH}
     export LD_LIBRARY_PATH=${RDBASE}/lib:${LD_LIBRARY_PATH}

--- a/.azure-pipelines/linux_build_limitexternal.yml
+++ b/.azure-pipelines/linux_build_limitexternal.yml
@@ -10,7 +10,7 @@ steps:
         boost-cpp=$(boost_version) \
         py-boost=$(boost_version) \
         numpy pillow eigen pandas \
-        qt
+        qt mypy
     conda activate rdkit_build
     conda install -c rdkit nox cairo=1.14.6
   displayName: Setup build environment

--- a/.azure-pipelines/linux_build_py37.yml
+++ b/.azure-pipelines/linux_build_py37.yml
@@ -9,7 +9,7 @@ steps:
         boost-cpp=$(boost_version) boost=$(boost_version) \
         py-boost=$(boost_version) libboost=$(boost_version) \
         numpy matplotlib pillow eigen pandas \
-        sphinx=3.1.2 recommonmark jupyter
+        sphinx=3.1.2 recommonmark jupyter mypy
     conda activate rdkit_build
     conda install -c rdkit nox cairo=1.14.6
   displayName: Setup build environment

--- a/.azure-pipelines/mac_build.yml
+++ b/.azure-pipelines/mac_build.yml
@@ -22,7 +22,7 @@ steps:
         py-boost=$(boost_version) libboost=$(boost_version) \
         qt \
         numpy matplotlib cairo pillow eigen pandas  \
-        sphinx=3.1.2 recommonmark jupyter
+        sphinx=3.1.2 recommonmark jupyter mypy
     conda activate rdkit_build
     conda install -c conda-forge nbval
   displayName: Setup build environment

--- a/.azure-pipelines/mac_build_java.yml
+++ b/.azure-pipelines/mac_build_java.yml
@@ -20,7 +20,7 @@ steps:
     conda create --name rdkit_build  $(compiler)=$(compiler_version) libcxx=$(compiler_version) cmake=3.19.6 \
         boost-cpp=$(boost_version) boost=$(boost_version) \
         py-boost=$(boost_version) libboost=$(boost_version) \
-        cairo eigen swig=3
+        cairo eigen swig=3 mypy
   displayName: Setup build environment
 - bash: |
     source ${CONDA}/etc/profile.d/conda.sh

--- a/.azure-pipelines/vs_build.yml
+++ b/.azure-pipelines/vs_build.yml
@@ -8,7 +8,7 @@ steps:
         boost-cpp=$(boost_version) boost=$(boost_version) ^
         py-boost=$(boost_version) libboost=$(boost_version) ^
         numpy matplotlib cairo pillow eigen pandas ^
-        sphinx=3.1.2  "jinja2<3.1" recommonmark
+        sphinx=3.1.2  "jinja2<3.1" recommonmark mypy
     call activate rdkit_build
     conda install -c conda-forge cmake nbval
   displayName: Install dependencies

--- a/.azure-pipelines/vs_build_dll.yml
+++ b/.azure-pipelines/vs_build_dll.yml
@@ -7,7 +7,7 @@ steps:
     conda create --name rdkit_build ^
         boost-cpp=$(boost_version) boost=$(boost_version) ^
         py-boost=$(boost_version) libboost=$(boost_version) ^
-        numpy matplotlib cairo pillow eigen pandas
+        numpy matplotlib cairo pillow eigen pandas mypy
     call activate rdkit_build
     conda install -c conda-forge cmake nbval
   displayName: Install dependencies

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@
 __pycache__/
 *.so
 *.pyc
+*.pyi
 /lib/
 *.pyd
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,7 @@ option(RDK_USE_BOOST_IOSTREAMS "use boost::iostreams" ON)
 option(RDK_BUILD_MINIMAL_LIB "build the minimal RDKit wrapper (for the JS bindings)" OFF)
 option(RDK_BUILD_CFFI_LIB "build the CFFI wrapper (for use in other programming languges)" OFF)
 option(RDK_BUILD_FUZZ_TARGETS "build the fuzz targets" OFF)
+option(RDK_GENERATE_PYTHON_STUBS "build Python stub files" ON)
 
 set(RDK_BOOST_VERSION "1.58.0")
 
@@ -286,7 +287,7 @@ if(RDK_BUILD_PYTHON_WRAPPERS)
   if(WIN32 OR "${Py_ENABLE_SHARED}" STREQUAL "1")
     target_link_libraries(rdkit_py_base INTERFACE ${PYTHON_LIBRARIES} )
   endif()
-  
+
   find_package(NumPy REQUIRED)
   target_include_directories(rdkit_base INTERFACE ${PYTHON_NUMPY_INCLUDE_PATH})
 

--- a/rdkit/CMakeLists.txt
+++ b/rdkit/CMakeLists.txt
@@ -1,4 +1,4 @@
-file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/RDPaths.py 
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/RDPaths.py
 "import os
 # unset so to trigger exceptions and track use: RDBaseDir=os.environ['RDBASE']
 RDCodeDir=os.path.join(r'${PYTHON_INSTDIR}','rdkit')
@@ -9,7 +9,7 @@ RDDocsDir=os.path.join(_share,'Docs')
 RDProjDir=os.path.join(_share,'Projects')
 RDContribDir=os.path.join(_share,'Contrib')
 ")
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/RDPaths.py 
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/RDPaths.py
   DESTINATION ${RDKit_PythonDir}
   COMPONENT python)
 
@@ -29,3 +29,15 @@ add_pytest(pythonTestSping
          ${CMAKE_CURRENT_SOURCE_DIR}/Chem/test_list.py --testDir ${CMAKE_CURRENT_SOURCE_DIR}/sping )
 
 add_subdirectory(Chem)
+
+if(RDK_GENERATE_PYTHON_STUBS)
+  # Check the `stubgen` command exists and fails otherwise.
+  find_program(STUBGEN_PATH "stubgen" REQUIRED)
+
+  # Execute `stubgen ...` after the installation of the RDKit Python library.
+  # It will generate the `*.pyi` stub files directly in the Python install directory.
+  set(STUBGEN_CMD stubgen -p rdkit --quiet --output ${PYTHON_INSTDIR})
+  install(CODE "execute_process(COMMAND ${STUBGEN_CMD})"
+    COMPONENT python
+    )
+endif(RDK_GENERATE_PYTHON_STUBS)

--- a/rdkit/CMakeLists.txt
+++ b/rdkit/CMakeLists.txt
@@ -31,13 +31,21 @@ add_pytest(pythonTestSping
 add_subdirectory(Chem)
 
 if(RDK_GENERATE_PYTHON_STUBS)
+
   # Check the `stubgen` command exists and fails otherwise.
   find_program(STUBGEN_PATH "stubgen" REQUIRED)
 
   # Execute `stubgen ...` after the installation of the RDKit Python library.
   # It will generate the `*.pyi` stub files directly in the Python install directory.
-  set(STUBGEN_CMD stubgen -p rdkit --quiet --output ${PYTHON_INSTDIR})
+
+  if(RDK_INSTALL_INTREE)
+    set(STUBGEN_CMD stubgen -p rdkit --quiet --output ${CMAKE_SOURCE_DIR})
+  else(RDK_INSTALL_INTREE)
+    set(STUBGEN_CMD stubgen -p rdkit --quiet --output ${PYTHON_INSTDIR})
+  endif(RDK_INSTALL_INTREE)
+
   install(CODE "execute_process(COMMAND ${STUBGEN_CMD})"
     COMPONENT python
     )
+
 endif(RDK_GENERATE_PYTHON_STUBS)


### PR DESCRIPTION
See https://github.com/rdkit/rdkit/issues/3591 and https://github.com/rdkit/rdkit/issues/5588 for context.

The goal of this PR is to generate stub files for the RDKit Python library. The generation is done with the command called `stubgen` coming from the [`mypy`](https://mypy.readthedocs.io/en/stable/stubgen.html) library. This is the only dependency that must be added to the rdkit local env and CI env (`mamba install mypy`).

The generated `*.pyi` files can be then used by any text editor or checker tool to provide things like autocompletion, type checking, etc.

The default logic is to build the stub files, and it can be turned `OFF` with `-DRDK_GENERATE_PYTHON_STUBS=OFF`.

---

I tried hard to do it the "CMake way" using `add_custom_target`, `add_dependencies` and `add_custom_command` but I could not make it work. I think the complexity here comes from the need to call `stubgen` on an installed Python module.

That being said, the current logic is probably good enough: it executes the `stubgen` command after all the Python-related targets have been installed. The generation is performed directly into the installed Python rdkit module.

