### PR TITLE
Fixes bond index parsing for w/c/t/ctu labels in CXSMILES/CXSMARTS

### DIFF
--- a/Code/GraphMol/SmilesParse/CXSmilesOps.cpp
+++ b/Code/GraphMol/SmilesParse/CXSmilesOps.cpp
@@ -476,7 +476,7 @@ bool parse_coordinate_bonds(Iterator &first, Iterator last, RDKit::RWMol &mol,
     unsigned int aidx;
     unsigned int bidx;
     if (read_int_pair(first, last, aidx, bidx)) {
-      if (VALID_ATIDX(aidx) && VALID_BNDIDX(bondIdx)) {
+      if (VALID_ATIDX(aidx) && VALID_BNDIDX(bidx)) {
         auto bnd = get_bond_with_smiles_idx(mol, bidx - startBondIdx);
         if (!bnd || (bnd->getBeginAtomIdx() != aidx - startAtomIdx &&
                      bnd->getEndAtomIdx() != aidx - startAtomIdx)) {

--- a/Code/GraphMol/SmilesParse/CXSmilesOps.cpp
+++ b/Code/GraphMol/SmilesParse/CXSmilesOps.cpp
@@ -476,8 +476,7 @@ bool parse_coordinate_bonds(Iterator &first, Iterator last, RDKit::RWMol &mol,
     unsigned int aidx;
     unsigned int bidx;
     if (read_int_pair(first, last, aidx, bidx)) {
-      if (VALID_ATIDX(aidx) && bidx >= startBondIdx &&
-          bidx < startBondIdx + mol.getNumBonds()) {
+      if (VALID_ATIDX(aidx) && VALID_BNDIDX(bondIdx)) {
         auto bnd = get_bond_with_smiles_idx(mol, bidx - startBondIdx);
         if (!bnd || (bnd->getBeginAtomIdx() != aidx - startAtomIdx &&
                      bnd->getEndAtomIdx() != aidx - startAtomIdx)) {

--- a/Code/GraphMol/SmilesParse/CXSmilesOps.cpp
+++ b/Code/GraphMol/SmilesParse/CXSmilesOps.cpp
@@ -298,6 +298,17 @@ void finalizePolymerSGroup(RWMol &mol, SubstanceGroup &sgroup) {
   sgroup.setProp("XBCORR", xbcorr);
 }
 
+Bond *get_bond_with_smiles_idx(const ROMol &mol, unsigned idx) {
+  for (auto bnd : mol.bonds()) {
+    unsigned int smilesIdx;
+    if (bnd->getPropIfPresent("_cxsmilesBondIdx", smilesIdx) &&
+        smilesIdx == idx) {
+      return bnd;
+    }
+  }
+  return nullptr;
+}
+
 }  // end of anonymous namespace
 
 // we use this pattern a lot and it's a long function call, but a very short
@@ -467,15 +478,7 @@ bool parse_coordinate_bonds(Iterator &first, Iterator last, RDKit::RWMol &mol,
     if (read_int_pair(first, last, aidx, bidx)) {
       if (VALID_ATIDX(aidx) && bidx >= startBondIdx &&
           bidx < startBondIdx + mol.getNumBonds()) {
-        Bond *bnd = nullptr;
-        for (auto bond : mol.bonds()) {
-          unsigned int smilesIdx;
-          if (bond->getPropIfPresent("_cxsmilesBondIdx", smilesIdx) &&
-              smilesIdx + startBondIdx == bidx) {
-            bnd = bond;
-            break;
-          }
-        }
+        auto bnd = get_bond_with_smiles_idx(mol, bidx - startBondIdx);
         if (!bnd || (bnd->getBeginAtomIdx() != aidx - startAtomIdx &&
                      bnd->getEndAtomIdx() != aidx - startAtomIdx)) {
           BOOST_LOG(rdWarningLog) << "BOND NOT FOUND! " << bidx
@@ -1064,7 +1067,14 @@ bool parse_wedged_bonds(Iterator &first, Iterator last, RDKit::RWMol &mol,
 
     if (VALID_ATIDX(atomIdx) && VALID_BNDIDX(bondIdx)) {
       auto atom = mol.getAtomWithIdx(atomIdx - startAtomIdx);
-      auto bond = mol.getBondWithIdx(bondIdx - startBondIdx);
+      auto bond = get_bond_with_smiles_idx(mol, bondIdx - startBondIdx);
+
+      if (!bond) {
+        BOOST_LOG(rdWarningLog)
+            << "bond " << bondIdx << " not found, wedge from atom " << atomIdx
+            << " cannot be applied." << std::endl;
+        return false;
+      }
 
       // we can't set wedging twice:
       if (bond->hasProp(common_properties::_MolFileBondCfg)) {
@@ -1126,7 +1136,14 @@ bool parse_doublebond_stereo(Iterator &first, Iterator last, RDKit::RWMol &mol,
       return false;
     }
     if (VALID_BNDIDX(bondIdx)) {
-      auto bond = mol.getBondWithIdx(bondIdx - startBondIdx);
+      auto bond = get_bond_with_smiles_idx(mol, bondIdx - startBondIdx);
+
+      if (!bond) {
+        BOOST_LOG(rdWarningLog)
+            << "bond " << bondIdx
+            << " not found, cannot mark as stereo double bond." << std::endl;
+        return false;
+      }
 
       // the cis/trans/unknown marker is relative to the lowest numbered atom
       // connected to the lowest numbered double bond atom and the

--- a/Code/GraphMol/SmilesParse/catch_tests.cpp
+++ b/Code/GraphMol/SmilesParse/catch_tests.cpp
@@ -2278,3 +2278,44 @@ TEST_CASE("ring bond stereochemistry in CXSMILES") {
   }
   Chirality::setUseLegacyStereoPerception(oval);
 }
+
+TEST_CASE("Github #5683", "[SMILES][bug]") {
+  SECTION("'w:' label") {
+    auto m = "CC1CN1C=CC1CC1 |w:4.5|"_smiles;
+    REQUIRE(m);
+    auto b = m->getBondWithIdx(4);
+    REQUIRE(b->getBondType() == Bond::BondType::DOUBLE);
+    CHECK(b->getBondDir() == Bond::BondDir::UNKNOWN);
+  }
+  SECTION("'ctu:' label") {
+    auto m = "CC1CN1C=CC1CC1 |ctu:5|"_smiles;
+    REQUIRE(m);
+    auto b = m->getBondWithIdx(4);
+    REQUIRE(b->getBondType() == Bond::BondType::DOUBLE);
+    CHECK(b->getStereo() == Bond::STEREOANY);
+  }
+  SECTION("'c:' label") {
+    auto oval = Chirality::getUseLegacyStereoPerception();
+    Chirality::setUseLegacyStereoPerception(false);
+
+    auto m = "CC1CN1C=CC1CC1 |c:5|"_smiles;
+    REQUIRE(m);
+    auto b = m->getBondWithIdx(4);
+    REQUIRE(b->getBondType() == Bond::BondType::DOUBLE);
+    CHECK(b->getStereo() == Bond::STEREOCIS);
+
+    Chirality::setUseLegacyStereoPerception(oval);
+  }
+  SECTION("'t:' label") {
+    auto oval = Chirality::getUseLegacyStereoPerception();
+    Chirality::setUseLegacyStereoPerception(false);
+
+    auto m = "CC1CN1C=CC1CC1 |t:5|"_smiles;
+    REQUIRE(m);
+    auto b = m->getBondWithIdx(4);
+    REQUIRE(b->getBondType() == Bond::BondType::DOUBLE);
+    CHECK(b->getStereo() == Bond::STEREOTRANS);
+
+    Chirality::setUseLegacyStereoPerception(oval);
+  }
+}

--- a/Code/GraphMol/SmilesParse/catch_tests.cpp
+++ b/Code/GraphMol/SmilesParse/catch_tests.cpp
@@ -2279,7 +2279,9 @@ TEST_CASE("ring bond stereochemistry in CXSMILES") {
   Chirality::setUseLegacyStereoPerception(oval);
 }
 
-TEST_CASE("Github #5683", "[SMILES][bug]") {
+TEST_CASE(
+    "Github #5722: check w/c/t/ctu CX labels use bond positions from SMILES",
+    "[SMILES][bug]") {
   SECTION("'w:' label") {
     auto m = "CC1CN1C=CC1CC1 |w:4.5|"_smiles;
     REQUIRE(m);


### PR DESCRIPTION
In functions `parse_coordinate_bonds()`, `parse_doublebond_stereo()` and `parse_wedged_bonds()` we attempt to apply the corresponding features on bonds which have the specified indexes in the RDKit mol, instead of those that in the SMILES string. These do match for simple SMILES, but in cases where rings are involved, these might not match.

The issue was discovered and described for wiggly bonds, since these are specified using both an atom and a bond, and an error was raised when bond wasn't connected to the atom.

This is an example of the issue:
```python
mb = """
     RDKit          2D

  0  0  0  0  0  0  0  0  0  0999 V3000
M  V30 BEGIN CTAB
M  V30 COUNTS 9 10 0 0 0
M  V30 BEGIN ATOM
M  V30 1 C 2.366025 0.000000 0.000000 0
M  V30 2 C 0.866025 0.000000 0.000000 0
M  V30 3 C -0.433013 0.750000 0.000000 0
M  V30 4 N -0.433013 -0.750000 0.000000 0
M  V30 5 C -1.183013 -2.049038 0.000000 0
M  V30 6 C -2.683013 -2.049038 0.000000 0
M  V30 7 C -3.433013 -3.348076 0.000000 0
M  V30 8 C -3.433013 -4.848076 0.000000 0
M  V30 9 C -4.732051 -4.098076 0.000000 0
M  V30 END ATOM
M  V30 BEGIN BOND
M  V30 1 1 1 2
M  V30 2 1 2 3
M  V30 3 1 3 4
M  V30 4 1 4 5
M  V30 5 2 5 6 CFG=2
M  V30 6 1 6 7
M  V30 7 1 7 8
M  V30 8 1 8 9
M  V30 9 1 4 2
M  V30 10 1 9 7
M  V30 END BOND
M  V30 END CTAB
M  END
"""

m = Chem.MolFromMolBlock(mb)

# The crossed double bond will be encoded as "w:" CX extension
# which requires an atom and a bond index.
b = m.GetBondWithIdx(4)
assert b.GetBondType() == Chem.BondType.DOUBLE
assert b.HasProp('_MolFileBondCfg')
assert b.GetIntProp('_MolFileBondCfg') == 2

m.RemoveAllConformers()  # Don't write coords to CXSMILES
cxsmi = Chem.MolToCXSmiles(m)
print(cxsmi)
# CC1CN1C=CC1CC1 |w:4.5|

m2 = Chem.MolFromSmiles(cxsmi)
# [11:32:52] atom 4 is not associated with bond 5 in w block
```


The issue is easily fixed if we can find the indexes of the bonds in the original SMILES string.

Note that the test for "t:" and "c:" labels make use of the new stereo algorithm. This is because with the legacy one these stereo labels are reset during the "clean up" stage of `assignStereochemistry()`: since there isn't a conformation available, these bonds never receive bond directions in https://github.com/rdkit/rdkit/blob/812568eb29a28ba6d0fbf40f8c4fca5d909d04ed/Code/GraphMol/SmilesParse/SmilesParse.cpp#L440-L446

