### PR TITLE
Fix a deprecation warning in pythonTestDirRoot

### DIFF
--- a/rdkit/UnitTestLogging.py
+++ b/rdkit/UnitTestLogging.py
@@ -87,7 +87,7 @@ class CaptureLogger(logging.Handler):
 
 class CaptureOutput:
   """Helper class that captures all output"""
-  timeexpr = re.compile('^\[.*?\]')
+  timeexpr = re.compile(r'^\[.*?\]')
   timereplacement = '[timestamp]'
 
   def __init__(self):


### PR DESCRIPTION
While working on #5722 one unrelated test kep failing:
```
210: Test timeout computed to be: 1500
210: F........................
210: ======================================================================
210: FAIL: testAsynchronous1 (__main__.TestLogToCppStreams)
210: ----------------------------------------------------------------------
210: Traceback (most recent call last):
210:   File "UnitTestLogging.py", line 261, in testAsynchronous1
210:     self.assertEqual(cerr.count('Warning'), nthreads * nlogs)
210: AssertionError: 251 != 250
210: 
210: ----------------------------------------------------------------------
210: Ran 25 tests in 0.372s
210: 
210: FAILED (failures=1)
210: !!! TEST FAILURE:  python UnitTestLogging.py {}
1/1 Test #210: pythonTestDirRoot ................***Failed    0.74 sec

0% tests passed, 1 tests failed out of 1

Total Test time (real) =   0.76 sec

The following tests FAILED:
	210 - pythonTestDirRoot (Failed)
Errors while running CTest
```

As stated by the failure message, the cause was one extra instrance of "Warning", a `DeprecationWarning` in the test logging:
```
210: UnitTestLogging.py:90: DeprecationWarning: invalid escape sequence \[
210:   timeexpr = re.compile('^\[.*?\]')
210: [16:55:06] Debug 1.1: My dog has fleas!
210: [16:55:06] Debug 1.2: My dog has fleas!
210: [16:55:06] Debug 1.3: My dog has fleas!
210: [16:55:06] Debug 1.4: My dog has fleas!
210: [16:55:06] Debug 1.5: My dog has fleas!
```

This properly escapes the regex expression, so that the deprecation warning is no longer thrown.