### PR TITLE
MinimalLib build fixes and an improvement

### DIFF
--- a/Code/GraphMol/MolDraw2D/MolDraw2DUtils.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DUtils.cpp
@@ -92,9 +92,11 @@ void prepareAndDrawMolecule(MolDraw2D &drawer, const ROMol &mol,
                             const std::map<int, DrawColour> *highlight_atom_map,
                             const std::map<int, DrawColour> *highlight_bond_map,
                             const std::map<int, double> *highlight_radii,
-                            int confId, bool kekulize) {
+                            int confId, bool kekulize, bool addChiralHs,
+                            bool wedgeBonds, bool forceCoords, bool wavyBonds) {
   RWMol cpy(mol);
-  prepareMolForDrawing(cpy, kekulize);
+  prepareMolForDrawing(cpy, kekulize, addChiralHs, wedgeBonds, forceCoords,
+                       wavyBonds);
   // having done the prepare, we don't want to do it again in drawMolecule.
   bool old_prep_mol = drawer.drawOptions().prepareMolsBeforeDrawing;
   drawer.drawOptions().prepareMolsBeforeDrawing = false;

--- a/Code/GraphMol/MolDraw2D/MolDraw2DUtils.h
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DUtils.h
@@ -70,7 +70,8 @@ RDKIT_MOLDRAW2D_EXPORT void prepareAndDrawMolecule(
     const std::map<int, DrawColour> *highlight_atom_map = nullptr,
     const std::map<int, DrawColour> *highlight_bond_map = nullptr,
     const std::map<int, double> *highlight_radii = nullptr, int confId = -1,
-    bool kekulize = true);
+    bool kekulize = true, bool addChiralHs = true, bool wedgeBonds = true,
+    bool forceCoords = false, bool wavyBonds = false);
 
 RDKIT_MOLDRAW2D_EXPORT void updateDrawerParamsFromJSON(MolDraw2D &drawer,
                                                        const char *json);

--- a/Code/MinimalLib/cffi_test.c
+++ b/Code/MinimalLib/cffi_test.c
@@ -236,7 +236,55 @@ void test_svg() {
   free(svg);
 
   free(pkl);
-  pkl = NULL;
+
+  pkl = get_mol(
+      "\n\
+  MJ201100                      \n\
+\n\
+  9 10  0  0  1  0  0  0  0  0999 V2000\n\
+    1.4885   -4.5513    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0\n\
+    2.0405   -3.9382    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n\
+    2.8610   -4.0244    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n\
+    3.1965   -3.2707    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n\
+    3.0250   -2.4637    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n\
+    2.2045   -2.3775    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n\
+    1.7920   -1.6630    0.0000 N   0  0  0  0  0  0  0  0  0  0  0  0\n\
+    1.8690   -3.1311    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n\
+    2.5834   -2.7186    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n\
+  2  1  1  1  0  0  0\n\
+  2  3  1  0  0  0  0\n\
+  4  3  1  0  0  0  0\n\
+  4  5  1  0  0  0  0\n\
+  6  5  1  0  0  0  0\n\
+  6  7  1  1  0  0  0\n\
+  6  8  1  0  0  0  0\n\
+  8  9  1  1  0  0  0\n\
+  8  2  1  0  0  0  0\n\
+  4  9  1  1  0  0  0\n\
+M  END\n",
+      &pkl_size, "");
+  assert(pkl);
+  assert(pkl_size > 0);
+  char *svg1 = get_svg(pkl, pkl_size, "{\"width\":350,\"height\":300}");
+  assert(strstr(svg1, "width='350px'"));
+  assert(strstr(svg1, "height='300px'"));
+  assert(strstr(svg1, "</svg>"));
+  assert(strstr(svg1, "atom-8"));
+  assert(strstr(svg1, "atom-9"));
+  assert(strstr(svg1, "atom-10"));
+  char *svg2 = get_svg(
+      pkl, pkl_size,
+      "{\"width\":350,\"height\":300,\"useMolBlockWedging\":true,\"wedgeBonds\":false,\"addChiralHs\":false}");
+  assert(strstr(svg2, "width='350px'"));
+  assert(strstr(svg2, "height='300px'"));
+  assert(strstr(svg2, "</svg>"));
+  assert(strstr(svg2, "atom-8"));
+  assert(!strstr(svg2, "atom-9"));
+  assert(!strstr(svg2, "atom-10"));
+  free(svg1);
+  free(svg2);
+
+  free(pkl);
   printf("  done\n");
   printf("--------------------------\n");
 }
@@ -478,13 +526,13 @@ void test_fingerprints() {
   assert(nbytes == 8);
   free(fp);
 
-  assert(!get_maccs_fp(NULL, 0, NULL));
-  fp = get_maccs_fp(mpkl, mpkl_size, NULL);
+  assert(!get_maccs_fp(NULL, 0));
+  fp = get_maccs_fp(mpkl, mpkl_size);
   assert(!strcmp(
       fp, "00000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000001100000000000000100000001000001000000000101000100000000100001000111110"));
   free(fp);
-  assert(!get_maccs_fp_as_bytes(NULL, 0, &nbytes, NULL));
-  fp = get_maccs_fp_as_bytes(mpkl, mpkl_size, &nbytes, NULL);
+  assert(!get_maccs_fp_as_bytes(NULL, 0, &nbytes));
+  fp = get_maccs_fp_as_bytes(mpkl, mpkl_size, &nbytes);
   assert(nbytes == 21);
   free(fp);
 #ifdef RDK_BUILD_AVALON_SUPPORT

--- a/Code/MinimalLib/cffiwrapper.cpp
+++ b/Code/MinimalLib/cffiwrapper.cpp
@@ -552,25 +552,21 @@ extern "C" char *get_atom_pair_fp_as_bytes(const char *mol_pkl,
   return str_to_c(res, nbytes);
 }
 
-extern "C" char *get_maccs_fp(const char *mol_pkl, size_t mol_pkl_sz,
-                                  const char *details_json) {
+extern "C" char *get_maccs_fp(const char *mol_pkl, size_t mol_pkl_sz) {
   if (!mol_pkl || !mol_pkl_sz) {
     return nullptr;
   }
-  auto fp = MinimalLib::maccs_fp_as_bitvect(
-      mol_from_pkl(mol_pkl, mol_pkl_sz), details_json);
+  auto fp = MinimalLib::maccs_fp_as_bitvect(mol_from_pkl(mol_pkl, mol_pkl_sz));
   auto res = BitVectToText(*fp);
   return str_to_c(res);
 }
 
-extern "C" char *get_maccs_fp_as_bytes(const char *mol_pkl,
-                                           size_t mol_pkl_sz, size_t *nbytes,
-                                           const char *details_json) {
+extern "C" char *get_maccs_fp_as_bytes(const char *mol_pkl, size_t mol_pkl_sz,
+                                       size_t *nbytes) {
   if (!mol_pkl || !mol_pkl_sz) {
     return nullptr;
   }
-  auto fp = MinimalLib::maccs_fp_as_bitvect(
-      mol_from_pkl(mol_pkl, mol_pkl_sz), details_json);
+  auto fp = MinimalLib::maccs_fp_as_bitvect(mol_from_pkl(mol_pkl, mol_pkl_sz));
   auto res = BitVectToBinaryText(*fp);
   return str_to_c(res, nbytes);
 }

--- a/Code/MinimalLib/cffiwrapper.h
+++ b/Code/MinimalLib/cffiwrapper.h
@@ -91,10 +91,10 @@ RDKIT_RDKITCFFI_EXPORT char *get_atom_pair_fp(const char *pkl, size_t pkl_sz,
                                               const char *details_json);
 RDKIT_RDKITCFFI_EXPORT char *get_atom_pair_fp_as_bytes(
     const char *pkl, size_t pkl_sz, size_t *nbytes, const char *details_json);
-RDKIT_RDKITCFFI_EXPORT char *get_maccs_fp(const char *pkl, size_t pkl_sz,
-                                              const char *details_json);
-RDKIT_RDKITCFFI_EXPORT char *get_maccs_fp_as_bytes(
-    const char *pkl, size_t pkl_sz, size_t *nbytes, const char *details_json);
+RDKIT_RDKITCFFI_EXPORT char *get_maccs_fp(const char *pkl, size_t pkl_sz);
+RDKIT_RDKITCFFI_EXPORT char *get_maccs_fp_as_bytes(const char *pkl,
+                                                   size_t pkl_sz,
+                                                   size_t *nbytes);
 
 #ifdef RDK_BUILD_AVALON_SUPPORT
 RDKIT_RDKITCFFI_EXPORT char *get_avalon_fp(const char *pkl, size_t pkl_sz,

--- a/Code/MinimalLib/common.h
+++ b/Code/MinimalLib/common.h
@@ -27,6 +27,7 @@
 #include <GraphMol/Fingerprints/Fingerprints.h>
 #include <GraphMol/Fingerprints/MorganFingerprints.h>
 #include <GraphMol/Fingerprints/AtomPairs.h>
+#include <GraphMol/Fingerprints/MACCS.h>
 #ifdef RDK_BUILD_AVALON_SUPPORT
 #include <External/AvalonTools/AvalonTools.h>
 #endif
@@ -322,7 +323,9 @@ std::string parse_highlight_colors(const rj::Document &doc,
 std::string process_details(rj::Document &doc, const std::string &details,
                             int &width, int &height, int &offsetx, int &offsety,
                             std::string &legend, std::vector<int> &atomIds,
-                            std::vector<int> &bondIds, bool &kekulize) {
+                            std::vector<int> &bondIds, bool &kekulize,
+                            bool &addChiralHs, bool &wedgeBonds,
+                            bool &forceCoords, bool &wavyBonds) {
   doc.Parse(details.c_str());
   if (!doc.IsObject()) {
     return "Invalid JSON";
@@ -388,6 +391,46 @@ std::string process_details(rj::Document &doc, const std::string &details,
     kekulize = true;
   }
 
+  const auto addChiralHsIt = doc.FindMember("addChiralHs");
+  if (addChiralHsIt != doc.MemberEnd()) {
+    if (!addChiralHsIt->value.IsBool()) {
+      return "JSON contains 'addChiralHs' field, but it is not a bool";
+    }
+    addChiralHs = addChiralHsIt->value.GetBool();
+  } else {
+    addChiralHs = true;
+  }
+
+  const auto wedgeBondsIt = doc.FindMember("wedgeBonds");
+  if (wedgeBondsIt != doc.MemberEnd()) {
+    if (!wedgeBondsIt->value.IsBool()) {
+      return "JSON contains 'wedgeBonds' field, but it is not a bool";
+    }
+    wedgeBonds = wedgeBondsIt->value.GetBool();
+  } else {
+    wedgeBonds = true;
+  }
+
+  const auto forceCoordsIt = doc.FindMember("forceCoords");
+  if (forceCoordsIt != doc.MemberEnd()) {
+    if (!forceCoordsIt->value.IsBool()) {
+      return "JSON contains 'forceCoords' field, but it is not a bool";
+    }
+    forceCoords = forceCoordsIt->value.GetBool();
+  } else {
+    forceCoords = false;
+  }
+
+  const auto wavyBondsIt = doc.FindMember("wavyBonds");
+  if (wavyBondsIt != doc.MemberEnd()) {
+    if (!wavyBondsIt->value.IsBool()) {
+      return "JSON contains 'wavyBonds' field, but it is not a bool";
+    }
+    wavyBonds = wavyBondsIt->value.GetBool();
+  } else {
+    wavyBonds = false;
+  }
+
   return "";
 }
 
@@ -397,11 +440,13 @@ std::string process_mol_details(const std::string &details, int &width,
                                 std::vector<int> &bondIds,
                                 std::map<int, DrawColour> &atomMap,
                                 std::map<int, DrawColour> &bondMap,
-                                std::map<int, double> &radiiMap,
-                                bool &kekulize) {
+                                std::map<int, double> &radiiMap, bool &kekulize,
+                                bool &addChiralHs, bool &wedgeBonds,
+                                bool &forceCoords, bool &wavyBonds) {
   rj::Document doc;
-  auto problems = process_details(doc, details, width, height, offsetx, offsety,
-                                  legend, atomIds, bondIds, kekulize);
+  auto problems = process_details(
+      doc, details, width, height, offsetx, offsety, legend, atomIds, bondIds,
+      kekulize, addChiralHs, wedgeBonds, forceCoords, wavyBonds);
   if (!problems.empty()) {
     return problems;
   }
@@ -439,8 +484,13 @@ std::string process_rxn_details(
     std::vector<int> &bondIds, bool &kekulize, bool &highlightByReactant,
     std::vector<DrawColour> &highlightColorsReactants) {
   rj::Document doc;
-  auto problems = process_details(doc, details, width, height, offsetx, offsety,
-                                  legend, atomIds, bondIds, kekulize);
+  bool addChiralHs;
+  bool wedgeBonds;
+  bool forceCoords;
+  bool wavyBonds;
+  auto problems = process_details(
+      doc, details, width, height, offsetx, offsety, legend, atomIds, bondIds,
+      kekulize, addChiralHs, wedgeBonds, forceCoords, wavyBonds);
   if (!problems.empty()) {
     return problems;
   }
@@ -509,10 +559,15 @@ std::string mol_to_svg(const ROMol &m, int w, int h,
   int offsetx = 0;
   int offsety = 0;
   bool kekulize = true;
+  bool addChiralHs = true;
+  bool wedgeBonds = true;
+  bool forceCoords = false;
+  bool wavyBonds = false;
   if (!details.empty()) {
     problems =
         process_mol_details(details, w, h, offsetx, offsety, legend, atomIds,
-                            bondIds, atomMap, bondMap, radiiMap, kekulize);
+                            bondIds, atomMap, bondMap, radiiMap, kekulize,
+                            addChiralHs, wedgeBonds, forceCoords, wavyBonds);
     if (!problems.empty()) {
       return problems;
     }
@@ -527,7 +582,8 @@ std::string mol_to_svg(const ROMol &m, int w, int h,
                                          atomMap.empty() ? nullptr : &atomMap,
                                          bondMap.empty() ? nullptr : &bondMap,
                                          radiiMap.empty() ? nullptr : &radiiMap,
-                                         -1, kekulize);
+                                         -1, kekulize, addChiralHs, wedgeBonds,
+                                         forceCoords, wavyBonds);
   drawer.finishDrawing();
 
   return drawer.getDrawingText();
@@ -787,8 +843,7 @@ std::unique_ptr<ExplicitBitVect> atom_pair_fp_as_bitvect(
   return std::unique_ptr<ExplicitBitVect>{fp};
 }
 
-std::unique_ptr<ExplicitBitVect> maccs_fp_as_bitvect(
-    const RWMol &mol, const char *details_json) {
+std::unique_ptr<ExplicitBitVect> maccs_fp_as_bitvect(const RWMol &mol) {
   auto fp = MACCSFingerprints::getFingerprintAsBitVect(mol);
   return std::unique_ptr<ExplicitBitVect>{fp};
 }

--- a/Code/MinimalLib/jswrapper.cpp
+++ b/Code/MinimalLib/jswrapper.cpp
@@ -25,7 +25,8 @@ extern std::string process_mol_details(
     int &offsety, std::string &legend, std::vector<int> &atomIds,
     std::vector<int> &bondIds, std::map<int, DrawColour> &atomMap,
     std::map<int, DrawColour> &bondMap, std::map<int, double> &radiiMap,
-    bool &kekulize);
+    bool &kekulize, bool &addChiralHs, bool &wedgeBonds, bool &forceCoords,
+    bool &wavyBonds);
 extern std::string process_rxn_details(
     const std::string &details, int &width, int &height, int &offsetx,
     int &offsety, std::string &legend, std::vector<int> &atomIds,
@@ -77,10 +78,15 @@ std::string draw_to_canvas_with_highlights(JSMol &self, emscripten::val canvas,
   int offsetx = 0;
   int offsety = 0;
   bool kekulize = true;
+  bool addChiralHs = true;
+  bool wedgeBonds = true;
+  bool forceCoords = false;
+  bool wavyBonds = false;
   if (!details.empty()) {
     auto problems = MinimalLib::process_mol_details(
         details, w, h, offsetx, offsety, legend, atomIds, bondIds, atomMap,
-        bondMap, radiiMap, kekulize);
+        bondMap, radiiMap, kekulize, addChiralHs, wedgeBonds, forceCoords,
+        wavyBonds);
     if (!problems.empty()) {
       return problems;
     }
@@ -96,7 +102,8 @@ std::string draw_to_canvas_with_highlights(JSMol &self, emscripten::val canvas,
       *d2d, *self.d_mol, legend, &atomIds, &bondIds,
       atomMap.empty() ? nullptr : &atomMap,
       bondMap.empty() ? nullptr : &bondMap,
-      radiiMap.empty() ? nullptr : &radiiMap, -1, kekulize);
+      radiiMap.empty() ? nullptr : &radiiMap, -1, kekulize, addChiralHs,
+      wedgeBonds, forceCoords, wavyBonds);
   return "";
 }
 
@@ -285,6 +292,11 @@ emscripten::val get_atom_pair_fp_as_uint8array(const JSMol &self) {
   return get_atom_pair_fp_as_uint8array(self, "{}");
 }
 
+emscripten::val get_maccs_fp_as_uint8array(const JSMol &self) {
+  auto fp = self.get_maccs_fp_as_binary_text();
+  return binary_string_to_uint8array(fp);
+}
+
 #ifdef RDK_BUILD_AVALON_SUPPORT
 emscripten::val get_avalon_fp_as_uint8array(const JSMol &self,
                                             const std::string &details) {
@@ -369,6 +381,7 @@ EMSCRIPTEN_BINDINGS(RDKit_minimal) {
           "get_atom_pair_fp_as_uint8array",
           select_overload<emscripten::val(const JSMol &, const std::string &)>(
               get_atom_pair_fp_as_uint8array))
+      .function("get_maccs_fp_as_uint8array", &get_maccs_fp_as_uint8array)
 #ifdef RDK_BUILD_AVALON_SUPPORT
       .function("get_avalon_fp_as_uint8array",
                 select_overload<emscripten::val(const JSMol &)>(
@@ -406,6 +419,7 @@ EMSCRIPTEN_BINDINGS(RDKit_minimal) {
       .function("get_atom_pair_fp",
                 select_overload<std::string(const std::string &) const>(
                     &JSMol::get_atom_pair_fp))
+      .function("get_maccs_fp", &JSMol::get_maccs_fp)
 #ifdef RDK_BUILD_AVALON_SUPPORT
       .function("get_avalon_fp",
                 select_overload<std::string() const>(&JSMol::get_avalon_fp))
@@ -446,9 +460,6 @@ EMSCRIPTEN_BINDINGS(RDKit_minimal) {
                 select_overload<bool(const std::string &, const std::string &)>(
                     &JSMol::set_prop))
       .function("get_prop", &JSMol::get_prop)
-      .function("generate_aligned_coords",
-                select_overload<std::string(const JSMol &)>(
-                    &JSMol::generate_aligned_coords))
       .function("condense_abbreviations",
                 select_overload<std::string()>(&JSMol::condense_abbreviations))
       .function("condense_abbreviations",

--- a/Code/MinimalLib/minilib.cpp
+++ b/Code/MinimalLib/minilib.cpp
@@ -145,7 +145,7 @@ std::string JSMol::get_pickle() const {
     return "";
   }
   std::string pickle;
-  MolPickler::pickleMol(*d_mol, pickle);
+  MolPickler::pickleMol(*d_mol, pickle, PicklerOps::AllProps);
   return pickle;
 }
 
@@ -300,21 +300,20 @@ std::string JSMol::get_atom_pair_fp_as_binary_text(
   return res;
 }
 
-std::string JSMol::get_maccs_fp(const std::string &details) const {
+std::string JSMol::get_maccs_fp() const {
   if (!d_mol) {
     return "";
   }
-  auto fp = MinimalLib::maccs_fp_as_bitvect(*d_mol, details.c_str());
+  auto fp = MinimalLib::maccs_fp_as_bitvect(*d_mol);
   std::string res = BitVectToText(*fp);
   return res;
 }
 
-std::string JSMol::get_maccs_fp_as_binary_text(
-    const std::string &details) const {
+std::string JSMol::get_maccs_fp_as_binary_text() const {
   if (!d_mol) {
     return "";
   }
-  auto fp = MinimalLib::maccs_fp_as_bitvect(*d_mol, details.c_str());
+  auto fp = MinimalLib::maccs_fp_as_bitvect(*d_mol);
   std::string res = BitVectToBinaryText(*fp);
   return res;
 }

--- a/Code/MinimalLib/minilib.h
+++ b/Code/MinimalLib/minilib.h
@@ -68,12 +68,8 @@ class JSMol {
   std::string get_atom_pair_fp_as_binary_text() const {
     return get_atom_pair_fp_as_binary_text("{}");
   }
-  std::string get_maccs_fp(const std::string &details) const;
-  std::string get_maccs_fp() const { return get_atom_pair_fp("{}"); }
-  std::string get_maccs_fp_as_binary_text(const std::string &details) const;
-  std::string get_maccs_fp_as_binary_text() const {
-    return get_maccs_fp_as_binary_text("{}");
-  }
+  std::string get_maccs_fp() const;
+  std::string get_maccs_fp_as_binary_text() const;
 #ifdef RDK_BUILD_AVALON_SUPPORT
   std::string get_avalon_fp(const std::string &details) const;
   std::string get_avalon_fp() const { return get_avalon_fp("{}"); }

--- a/Code/MinimalLib/tests/tests.js
+++ b/Code/MinimalLib/tests/tests.js
@@ -52,7 +52,7 @@ function test_basics() {
     assert.equal(descrs.amw,94.11299);
 
     var checkStringBinaryFpIdentity = (stringFp, binaryFp) => {
-        assert.equal(binaryFp.length, stringFp.length / 8);
+        assert.equal(binaryFp.length, Math.ceil(stringFp.length / 8));
         for (var i = 0, c = 0; i < binaryFp.length; ++i) {
             var byte = 0;
             for (var j = 0; j < 8; ++j, ++c) {
@@ -147,6 +147,14 @@ function test_basics() {
         assert.equal((fp4.match(/1/g)||[]).length, 12);
         var fp4Uint8Array = mol.get_atom_pair_fp_as_uint8array(JSON.stringify({ nBits: 512, minLength: 2, maxLength: 3 }));
         checkStringBinaryFpIdentity(fp4, fp4Uint8Array);
+    }
+
+    {
+        var fp1 = mol.get_maccs_fp();
+        assert.equal(fp1.length, 167);
+        assert.equal((fp1.match(/1/g)||[]).length, 10);
+        var fp1Uint8Array = mol.get_maccs_fp_as_uint8array();
+        checkStringBinaryFpIdentity(fp1, fp1Uint8Array);
     }
 
     if (typeof Object.getPrototypeOf(mol).get_avalon_fp === 'function') {
@@ -393,7 +401,7 @@ function test_generate_aligned_coords() {
     var mol = RDKitModule.get_mol(smiles);
     var template = "CC";
     var qmol = RDKitModule.get_mol(template);
-    assert.equal(mol.generate_aligned_coords(qmol, true), "");
+    assert.equal(mol.generate_aligned_coords(qmol, JSON.stringify({useCoordGen: true})), "");
 }
 
 function test_isotope_labels() {
@@ -455,7 +463,7 @@ M  END`;
     var biphenyl = RDKitModule.get_mol(biphenyl_smiles);
     var phenyl = RDKitModule.get_mol(phenyl_smiles);
     assert.equal(JSON.parse(ortho_meta.generate_aligned_coords(
-        template_ref, false, true)).atoms.length, 9);
+        template_ref, JSON.stringify({ useCoordGen: false, allowRGroups: true}))).atoms.length, 9);
     [ true, false ].forEach(alignOnly => {
         var opts = JSON.stringify({ useCoordGen: false, allowRGroups: true, alignOnly })
         assert.equal(JSON.parse(ortho_meta.generate_aligned_coords(
@@ -523,13 +531,10 @@ M  END
 `;
     var template_ref = RDKitModule.get_mol(template_molblock);
     var mol = RDKitModule.get_mol(mol_molblock);
-    var res = mol.generate_aligned_coords(template_ref, false, true, false);
-    assert(res === "");
-    assert.equal(mol.get_molblock(), mol_molblock);
-    res = mol.generate_aligned_coords(template_ref, JSON.stringify({
+    var res = mol.generate_aligned_coords(template_ref, JSON.stringify({
         useCoordGen: false,
         allowRGroups: true,
-        acceptFailure: false,
+        acceptFailure: false
     }));
     assert(res === "");
     assert.equal(mol.get_molblock(), mol_molblock);


### PR DESCRIPTION
- extend `prepareAndDrawMolecule()` with missing optional parameters already supported by `prepareMolForDrawing()`
- enable `useMolBlockWedging`, `wedgeBonds`, `addChiralHs`, `forceCoords`, `wavyBonds` in CFFI/MinimalLib
- add relevant CFFI and JS unit tests
- fix a number of inconsistencies and one mistake in the `get_maccs_fp()` interface
- fix the broken JS build/tests caused by #5707 and #5675
