### PR TITLE
CFFI/MinimalLib fixes

### DIFF
--- a/Code/MinimalLib/cffi_test.c
+++ b/Code/MinimalLib/cffi_test.c
@@ -478,13 +478,13 @@ void test_fingerprints() {
   assert(nbytes == 8);
   free(fp);
 
-  assert(!get_maccs_fp(NULL, 0, NULL));
-  fp = get_maccs_fp(mpkl, mpkl_size, NULL);
+  assert(!get_maccs_fp(NULL, 0));
+  fp = get_maccs_fp(mpkl, mpkl_size);
   assert(!strcmp(
       fp, "00000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000001100000000000000100000001000001000000000101000100000000100001000111110"));
   free(fp);
-  assert(!get_maccs_fp_as_bytes(NULL, 0, &nbytes, NULL));
-  fp = get_maccs_fp_as_bytes(mpkl, mpkl_size, &nbytes, NULL);
+  assert(!get_maccs_fp_as_bytes(NULL, 0, &nbytes));
+  fp = get_maccs_fp_as_bytes(mpkl, mpkl_size, &nbytes);
   assert(nbytes == 21);
   free(fp);
 #ifdef RDK_BUILD_AVALON_SUPPORT

--- a/Code/MinimalLib/cffiwrapper.cpp
+++ b/Code/MinimalLib/cffiwrapper.cpp
@@ -552,25 +552,21 @@ extern "C" char *get_atom_pair_fp_as_bytes(const char *mol_pkl,
   return str_to_c(res, nbytes);
 }
 
-extern "C" char *get_maccs_fp(const char *mol_pkl, size_t mol_pkl_sz,
-                                  const char *details_json) {
+extern "C" char *get_maccs_fp(const char *mol_pkl, size_t mol_pkl_sz) {
   if (!mol_pkl || !mol_pkl_sz) {
     return nullptr;
   }
-  auto fp = MinimalLib::maccs_fp_as_bitvect(
-      mol_from_pkl(mol_pkl, mol_pkl_sz), details_json);
+  auto fp = MinimalLib::maccs_fp_as_bitvect(mol_from_pkl(mol_pkl, mol_pkl_sz));
   auto res = BitVectToText(*fp);
   return str_to_c(res);
 }
 
-extern "C" char *get_maccs_fp_as_bytes(const char *mol_pkl,
-                                           size_t mol_pkl_sz, size_t *nbytes,
-                                           const char *details_json) {
+extern "C" char *get_maccs_fp_as_bytes(const char *mol_pkl, size_t mol_pkl_sz,
+                                       size_t *nbytes) {
   if (!mol_pkl || !mol_pkl_sz) {
     return nullptr;
   }
-  auto fp = MinimalLib::maccs_fp_as_bitvect(
-      mol_from_pkl(mol_pkl, mol_pkl_sz), details_json);
+  auto fp = MinimalLib::maccs_fp_as_bitvect(mol_from_pkl(mol_pkl, mol_pkl_sz));
   auto res = BitVectToBinaryText(*fp);
   return str_to_c(res, nbytes);
 }

--- a/Code/MinimalLib/cffiwrapper.h
+++ b/Code/MinimalLib/cffiwrapper.h
@@ -91,10 +91,10 @@ RDKIT_RDKITCFFI_EXPORT char *get_atom_pair_fp(const char *pkl, size_t pkl_sz,
                                               const char *details_json);
 RDKIT_RDKITCFFI_EXPORT char *get_atom_pair_fp_as_bytes(
     const char *pkl, size_t pkl_sz, size_t *nbytes, const char *details_json);
-RDKIT_RDKITCFFI_EXPORT char *get_maccs_fp(const char *pkl, size_t pkl_sz,
-                                              const char *details_json);
-RDKIT_RDKITCFFI_EXPORT char *get_maccs_fp_as_bytes(
-    const char *pkl, size_t pkl_sz, size_t *nbytes, const char *details_json);
+RDKIT_RDKITCFFI_EXPORT char *get_maccs_fp(const char *pkl, size_t pkl_sz);
+RDKIT_RDKITCFFI_EXPORT char *get_maccs_fp_as_bytes(const char *pkl,
+                                                   size_t pkl_sz,
+                                                   size_t *nbytes);
 
 #ifdef RDK_BUILD_AVALON_SUPPORT
 RDKIT_RDKITCFFI_EXPORT char *get_avalon_fp(const char *pkl, size_t pkl_sz,

--- a/Code/MinimalLib/common.h
+++ b/Code/MinimalLib/common.h
@@ -27,6 +27,7 @@
 #include <GraphMol/Fingerprints/Fingerprints.h>
 #include <GraphMol/Fingerprints/MorganFingerprints.h>
 #include <GraphMol/Fingerprints/AtomPairs.h>
+#include <GraphMol/Fingerprints/MACCS.h>
 #ifdef RDK_BUILD_AVALON_SUPPORT
 #include <External/AvalonTools/AvalonTools.h>
 #endif
@@ -787,8 +788,7 @@ std::unique_ptr<ExplicitBitVect> atom_pair_fp_as_bitvect(
   return std::unique_ptr<ExplicitBitVect>{fp};
 }
 
-std::unique_ptr<ExplicitBitVect> maccs_fp_as_bitvect(
-    const RWMol &mol, const char *details_json) {
+std::unique_ptr<ExplicitBitVect> maccs_fp_as_bitvect(const RWMol &mol) {
   auto fp = MACCSFingerprints::getFingerprintAsBitVect(mol);
   return std::unique_ptr<ExplicitBitVect>{fp};
 }

--- a/Code/MinimalLib/jswrapper.cpp
+++ b/Code/MinimalLib/jswrapper.cpp
@@ -285,6 +285,11 @@ emscripten::val get_atom_pair_fp_as_uint8array(const JSMol &self) {
   return get_atom_pair_fp_as_uint8array(self, "{}");
 }
 
+emscripten::val get_maccs_fp_as_uint8array(const JSMol &self) {
+  auto fp = self.get_maccs_fp_as_binary_text();
+  return binary_string_to_uint8array(fp);
+}
+
 #ifdef RDK_BUILD_AVALON_SUPPORT
 emscripten::val get_avalon_fp_as_uint8array(const JSMol &self,
                                             const std::string &details) {
@@ -369,6 +374,7 @@ EMSCRIPTEN_BINDINGS(RDKit_minimal) {
           "get_atom_pair_fp_as_uint8array",
           select_overload<emscripten::val(const JSMol &, const std::string &)>(
               get_atom_pair_fp_as_uint8array))
+      .function("get_maccs_fp_as_uint8array", &get_maccs_fp_as_uint8array)
 #ifdef RDK_BUILD_AVALON_SUPPORT
       .function("get_avalon_fp_as_uint8array",
                 select_overload<emscripten::val(const JSMol &)>(
@@ -406,6 +412,7 @@ EMSCRIPTEN_BINDINGS(RDKit_minimal) {
       .function("get_atom_pair_fp",
                 select_overload<std::string(const std::string &) const>(
                     &JSMol::get_atom_pair_fp))
+      .function("get_maccs_fp", &JSMol::get_maccs_fp)
 #ifdef RDK_BUILD_AVALON_SUPPORT
       .function("get_avalon_fp",
                 select_overload<std::string() const>(&JSMol::get_avalon_fp))
@@ -446,9 +453,6 @@ EMSCRIPTEN_BINDINGS(RDKit_minimal) {
                 select_overload<bool(const std::string &, const std::string &)>(
                     &JSMol::set_prop))
       .function("get_prop", &JSMol::get_prop)
-      .function("generate_aligned_coords",
-                select_overload<std::string(const JSMol &)>(
-                    &JSMol::generate_aligned_coords))
       .function("condense_abbreviations",
                 select_overload<std::string()>(&JSMol::condense_abbreviations))
       .function("condense_abbreviations",

--- a/Code/MinimalLib/minilib.cpp
+++ b/Code/MinimalLib/minilib.cpp
@@ -300,21 +300,20 @@ std::string JSMol::get_atom_pair_fp_as_binary_text(
   return res;
 }
 
-std::string JSMol::get_maccs_fp(const std::string &details) const {
+std::string JSMol::get_maccs_fp() const {
   if (!d_mol) {
     return "";
   }
-  auto fp = MinimalLib::maccs_fp_as_bitvect(*d_mol, details.c_str());
+  auto fp = MinimalLib::maccs_fp_as_bitvect(*d_mol);
   std::string res = BitVectToText(*fp);
   return res;
 }
 
-std::string JSMol::get_maccs_fp_as_binary_text(
-    const std::string &details) const {
+std::string JSMol::get_maccs_fp_as_binary_text() const {
   if (!d_mol) {
     return "";
   }
-  auto fp = MinimalLib::maccs_fp_as_bitvect(*d_mol, details.c_str());
+  auto fp = MinimalLib::maccs_fp_as_bitvect(*d_mol);
   std::string res = BitVectToBinaryText(*fp);
   return res;
 }

--- a/Code/MinimalLib/minilib.h
+++ b/Code/MinimalLib/minilib.h
@@ -68,12 +68,8 @@ class JSMol {
   std::string get_atom_pair_fp_as_binary_text() const {
     return get_atom_pair_fp_as_binary_text("{}");
   }
-  std::string get_maccs_fp(const std::string &details) const;
-  std::string get_maccs_fp() const { return get_atom_pair_fp("{}"); }
-  std::string get_maccs_fp_as_binary_text(const std::string &details) const;
-  std::string get_maccs_fp_as_binary_text() const {
-    return get_maccs_fp_as_binary_text("{}");
-  }
+  std::string get_maccs_fp() const;
+  std::string get_maccs_fp_as_binary_text() const;
 #ifdef RDK_BUILD_AVALON_SUPPORT
   std::string get_avalon_fp(const std::string &details) const;
   std::string get_avalon_fp() const { return get_avalon_fp("{}"); }

--- a/Code/MinimalLib/tests/tests.js
+++ b/Code/MinimalLib/tests/tests.js
@@ -52,7 +52,7 @@ function test_basics() {
     assert.equal(descrs.amw,94.11299);
 
     var checkStringBinaryFpIdentity = (stringFp, binaryFp) => {
-        assert.equal(binaryFp.length, stringFp.length / 8);
+        assert.equal(binaryFp.length, Math.ceil(stringFp.length / 8));
         for (var i = 0, c = 0; i < binaryFp.length; ++i) {
             var byte = 0;
             for (var j = 0; j < 8; ++j, ++c) {
@@ -147,6 +147,14 @@ function test_basics() {
         assert.equal((fp4.match(/1/g)||[]).length, 12);
         var fp4Uint8Array = mol.get_atom_pair_fp_as_uint8array(JSON.stringify({ nBits: 512, minLength: 2, maxLength: 3 }));
         checkStringBinaryFpIdentity(fp4, fp4Uint8Array);
+    }
+
+    {
+        var fp1 = mol.get_maccs_fp();
+        assert.equal(fp1.length, 167);
+        assert.equal((fp1.match(/1/g)||[]).length, 10);
+        var fp1Uint8Array = mol.get_maccs_fp_as_uint8array();
+        checkStringBinaryFpIdentity(fp1, fp1Uint8Array);
     }
 
     if (typeof Object.getPrototypeOf(mol).get_avalon_fp === 'function') {
@@ -393,7 +401,7 @@ function test_generate_aligned_coords() {
     var mol = RDKitModule.get_mol(smiles);
     var template = "CC";
     var qmol = RDKitModule.get_mol(template);
-    assert.equal(mol.generate_aligned_coords(qmol, true), "");
+    assert.equal(mol.generate_aligned_coords(qmol, JSON.stringify({useCoordGen: true})), "");
 }
 
 function test_isotope_labels() {
@@ -455,7 +463,7 @@ M  END`;
     var biphenyl = RDKitModule.get_mol(biphenyl_smiles);
     var phenyl = RDKitModule.get_mol(phenyl_smiles);
     assert.equal(JSON.parse(ortho_meta.generate_aligned_coords(
-        template_ref, false, true)).atoms.length, 9);
+        template_ref, JSON.stringify({ useCoordGen: false, allowRGroups: true}))).atoms.length, 9);
     [ true, false ].forEach(alignOnly => {
         var opts = JSON.stringify({ useCoordGen: false, allowRGroups: true, alignOnly })
         assert.equal(JSON.parse(ortho_meta.generate_aligned_coords(
@@ -523,13 +531,10 @@ M  END
 `;
     var template_ref = RDKitModule.get_mol(template_molblock);
     var mol = RDKitModule.get_mol(mol_molblock);
-    var res = mol.generate_aligned_coords(template_ref, false, true, false);
-    assert(res === "");
-    assert.equal(mol.get_molblock(), mol_molblock);
-    res = mol.generate_aligned_coords(template_ref, JSON.stringify({
+    var res = mol.generate_aligned_coords(template_ref, JSON.stringify({
         useCoordGen: false,
         allowRGroups: true,
-        acceptFailure: false,
+        acceptFailure: false
     }));
     assert(res === "");
     assert.equal(mol.get_molblock(), mol_molblock);


### PR DESCRIPTION
- added missing `#include` that caused the emscripten build to break
- removed details from `get_maccs_fp` calls since there are no adjustable parameters
- exposed `get_maccs_fp` to JS
- added tests and adjusted existing ones since some deprecated functions were removed and do not need testing anymore
