### PR TITLE
add includeRedundantEnvironments support to GetMorganGenerator

### DIFF
--- a/Code/GraphMol/Fingerprints/CMakeLists.txt
+++ b/Code/GraphMol/Fingerprints/CMakeLists.txt
@@ -32,6 +32,7 @@ rdkit_test(testFingerprintGenerators testFingerprintGenerators.cpp LINK_LIBRARIE
 
 rdkit_catch_test(fpTestCatch catch_tests.cpp LINK_LIBRARIES Fingerprints FileParsers)
 
+rdkit_catch_test(fpGenTestCatch fpgen_catch_tests.cpp LINK_LIBRARIES Fingerprints FileParsers)
 
 if(RDK_BUILD_PYTHON_WRAPPERS)
 add_subdirectory(Wrap)

--- a/Code/GraphMol/Fingerprints/MorganGenerator.cpp
+++ b/Code/GraphMol/Fingerprints/MorganGenerator.cpp
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2018 Boran Adas, Google Summer of Code
+//  Copyright (C) 2018-2022 Boran Adas and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -114,16 +114,6 @@ template <typename OutputType>
 OutputType MorganArguments<OutputType>::getResultSize() const {
   return std::numeric_limits<OutputType>::max();
 }
-
-template <typename OutputType>
-MorganArguments<OutputType>::MorganArguments(
-    const unsigned int radius, const bool countSimulation,
-    const bool includeChirality, const bool onlyNonzeroInvariants,
-    const std::vector<std::uint32_t> countBounds, const std::uint32_t fpSize)
-    : FingerprintArguments<OutputType>(countSimulation, countBounds, fpSize),
-      df_includeChirality(includeChirality),
-      df_onlyNonzeroInvariants(onlyNonzeroInvariants),
-      d_radius(radius) {}
 
 template <typename OutputType>
 std::string MorganArguments<OutputType>::infoString() const {
@@ -348,7 +338,8 @@ MorganEnvGenerator<OutputType>::getEnvironments(
          iter != allNeighborhoodsThisRound.end(); ++iter) {
       // if we haven't seen this exact environment before, add it to the
       // result
-      if (std::find(neighborhoods.begin(), neighborhoods.end(),
+      if (morganArguments->df_includeRedundantEnvironments ||
+          std::find(neighborhoods.begin(), neighborhoods.end(),
                     iter->get<0>()) == neighborhoods.end()) {
         if (!morganArguments->df_onlyNonzeroInvariants ||
             (*atomInvariants)[iter->get<2>()]) {
@@ -384,20 +375,20 @@ std::string MorganEnvGenerator<OutputType>::infoString() const {
 
 template <typename OutputType>
 FingerprintGenerator<OutputType> *getMorganGenerator(
-    const unsigned int radius, const bool countSimulation,
-    const bool includeChirality, const bool useBondTypes,
-    const bool onlyNonzeroInvariants,
+    unsigned int radius, bool countSimulation, bool includeChirality,
+    bool useBondTypes, bool onlyNonzeroInvariants,
+    bool includeRedundantEnvironments,
     AtomInvariantsGenerator *atomInvariantsGenerator,
-    BondInvariantsGenerator *bondInvariantsGenerator,
-    const std::uint32_t fpSize, const std::vector<std::uint32_t> countBounds,
-    const bool ownsAtomInvGen, const bool  // ownsBondInvGen
+    BondInvariantsGenerator *bondInvariantsGenerator, std::uint32_t fpSize,
+    std::vector<std::uint32_t> countBounds, bool ownsAtomInvGen,
+    bool  // ownsBondInvGen
 ) {
   AtomEnvironmentGenerator<OutputType> *morganEnvGenerator =
       new MorganEnvGenerator<OutputType>();
   FingerprintArguments<OutputType> *morganArguments =
       new MorganArguments<OutputType>(radius, countSimulation, includeChirality,
                                       onlyNonzeroInvariants, countBounds,
-                                      fpSize);
+                                      fpSize, includeRedundantEnvironments);
 
   bool ownsAtomInvGenerator = ownsAtomInvGen;
   if (!atomInvariantsGenerator) {
@@ -417,25 +408,25 @@ FingerprintGenerator<OutputType> *getMorganGenerator(
       bondInvariantsGenerator, ownsAtomInvGenerator, ownsBondInvGenerator);
 }
 
-template RDKIT_FINGERPRINTS_EXPORT FingerprintGenerator<std::uint32_t>
-    *getMorganGenerator(const unsigned int radius, const bool countSimulation,
-                        const bool includeChirality, const bool useBondTypes,
-                        const bool onlyNonzeroInvariants,
-                        AtomInvariantsGenerator *atomInvariantsGenerator,
-                        BondInvariantsGenerator *bondInvariantsGenerator,
-                        const std::uint32_t fpSize,
-                        const std::vector<std::uint32_t> countBounds,
-                        const bool ownsAtomInvGen, const bool ownsBondInvGen);
+template RDKIT_FINGERPRINTS_EXPORT FingerprintGenerator<std::uint32_t> *
+getMorganGenerator(unsigned int radius, bool countSimulation,
+                   bool includeChirality, bool useBondTypes,
+                   bool onlyNonzeroInvariants,
+                   bool includeRedundantEnvironments,
+                   AtomInvariantsGenerator *atomInvariantsGenerator,
+                   BondInvariantsGenerator *bondInvariantsGenerator,
+                   std::uint32_t fpSize, std::vector<std::uint32_t> countBounds,
+                   bool ownsAtomInvGen, bool ownsBondInvGen);
 
-template RDKIT_FINGERPRINTS_EXPORT FingerprintGenerator<std::uint64_t>
-    *getMorganGenerator(const unsigned int radius, const bool countSimulation,
-                        const bool includeChirality, const bool useBondTypes,
-                        const bool onlyNonzeroInvariants,
-                        AtomInvariantsGenerator *atomInvariantsGenerator,
-                        BondInvariantsGenerator *bondInvariantsGenerator,
-                        const std::uint32_t fpSize,
-                        const std::vector<std::uint32_t> countBounds,
-                        const bool ownsAtomInvGen, const bool ownsBondInvGen);
+template RDKIT_FINGERPRINTS_EXPORT FingerprintGenerator<std::uint64_t> *
+getMorganGenerator(unsigned int radius, bool countSimulation,
+                   bool includeChirality, bool useBondTypes,
+                   bool onlyNonzeroInvariants,
+                   bool includeRedundantEnvironments,
+                   AtomInvariantsGenerator *atomInvariantsGenerator,
+                   BondInvariantsGenerator *bondInvariantsGenerator,
+                   std::uint32_t fpSize, std::vector<std::uint32_t> countBounds,
+                   bool ownsAtomInvGen, bool ownsBondInvGen);
 
 }  // namespace MorganFingerprint
 }  // namespace RDKit

--- a/Code/GraphMol/Fingerprints/MorganGenerator.h
+++ b/Code/GraphMol/Fingerprints/MorganGenerator.h
@@ -302,7 +302,7 @@ This generator supports the following \c AdditionalOutput types:
 
  */
 template <typename OutputType>
-RDKIT_FINGERPRINTS_EXPORT FingerprintGenerator<OutputType> *getMorganGenerator(
+FingerprintGenerator<OutputType> *getMorganGenerator(
     unsigned int radius, bool countSimulation = false,
     bool includeChirality = false, bool useBondTypes = true,
     bool onlyNonzeroInvariants = false,

--- a/Code/GraphMol/Fingerprints/MorganGenerator.h
+++ b/Code/GraphMol/Fingerprints/MorganGenerator.h
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2018 Boran Adas, Google Summer of Code
+//  Copyright (C) 2018-2022 Boran Adas and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -108,9 +108,10 @@ template <typename OutputType>
 class RDKIT_FINGERPRINTS_EXPORT MorganArguments
     : public FingerprintArguments<OutputType> {
  public:
-  const bool df_includeChirality;
-  const bool df_onlyNonzeroInvariants;
-  const unsigned int d_radius;
+  const bool df_includeChirality = false;
+  const bool df_onlyNonzeroInvariants = false;
+  const unsigned int d_radius = 3;
+  const bool df_includeRedundantEnvironments = false;
 
   OutputType getResultSize() const override;
 
@@ -130,12 +131,20 @@ class RDKIT_FINGERPRINTS_EXPORT MorganArguments
    be set if the count is higher than the number provided for that spot
    \param fpSize size of the generated fingerprint, does not affect the sparse
    versions
-   */
-  MorganArguments(const unsigned int radius, const bool countSimulation = false,
-                  const bool includeChirality = false,
-                  const bool onlyNonzeroInvariants = false,
-                  const std::vector<std::uint32_t> countBounds = {1, 2, 4, 8},
-                  const std::uint32_t fpSize = 2048);
+   \param includeRedundantEnvironments if set redundant environments will be
+   included in the fingerprint
+  */
+  MorganArguments(unsigned int radius, bool countSimulation = false,
+                  bool includeChirality = false,
+                  bool onlyNonzeroInvariants = false,
+                  std::vector<std::uint32_t> countBounds = {1, 2, 4, 8},
+                  std::uint32_t fpSize = 2048,
+                  bool includeRedundantEnvironments = false)
+      : FingerprintArguments<OutputType>(countSimulation, countBounds, fpSize),
+        df_includeChirality(includeChirality),
+        df_onlyNonzeroInvariants(onlyNonzeroInvariants),
+        d_radius(radius),
+        df_includeRedundantEnvironments(includeRedundantEnvironments){};
 };
 
 /**
@@ -219,6 +228,8 @@ class RDKIT_FINGERPRINTS_EXPORT MorganEnvGenerator
  default bond invariants
  \param onlyNonzeroInvariants if set, bits will only be set from atoms that
  have a nonzero invariant
+ \param includeRedundantEnvironments if set redundant environments will be
+ included in the fingerprint
  \param atomInvariantsGenerator custom atom invariants generator to use
  \param bondInvariantsGenerator custom  bond invariants generator to use
  \param ownsAtomInvGen  if set atom invariants  generator is destroyed with the
@@ -236,14 +247,76 @@ This generator supports the following \c AdditionalOutput types:
  */
 template <typename OutputType>
 RDKIT_FINGERPRINTS_EXPORT FingerprintGenerator<OutputType> *getMorganGenerator(
-    const unsigned int radius, const bool countSimulation = false,
-    const bool includeChirality = false, const bool useBondTypes = true,
-    const bool onlyNonzeroInvariants = false,
+    unsigned int radius, bool countSimulation, bool includeChirality,
+    bool useBondTypes, bool onlyNonzeroInvariants,
+    bool includeRedundantEnvironments,
     AtomInvariantsGenerator *atomInvariantsGenerator = nullptr,
     BondInvariantsGenerator *bondInvariantsGenerator = nullptr,
-    const std::uint32_t fpSize = 2048,
-    const std::vector<std::uint32_t> countBounds = {1, 2, 4, 8},
-    const bool ownsAtomInvGen = false, const bool ownsBondInvGen = false);
+    std::uint32_t fpSize = 2048,
+    std::vector<std::uint32_t> countBounds = {1, 2, 4, 8},
+    bool ownsAtomInvGen = false, bool ownsBondInvGen = false);
+
+/**
+ \brief Get a fingerprint generator for Morgan fingerprint
+
+ \tparam OutputType determines the size of the bitIds and the result, can be 32
+ or 64 bit unsigned integer
+
+ \param radius the number of iterations to grow the fingerprint
+
+ \param countSimulation if set, use count simulation while generating the
+ fingerprint
+
+ \param includeChirality if set, chirality information will be added to the
+ generated bit id, independently from bond invariants
+
+ \param onlyNonzeroInvariants if set, bits will only be set from atoms that
+ have a nonzero invariant
+
+ \param countBounds boundaries for count simulation, corresponding bit will be
+ set if the count is higher than the number provided for that spot
+
+ \param fpSize size of the generated fingerprint, does not affect the sparse
+ versions
+ \param countSimulation if set, use count simulation while generating the
+ fingerprint
+ \param includeChirality sets includeChirality flag for both MorganArguments
+ and the default bond generator MorganBondInvGenerator
+ \param useBondTypes if set, bond types will be included as a part of the
+ default bond invariants
+ \param onlyNonzeroInvariants if set, bits will only be set from atoms that
+ have a nonzero invariant
+ \param atomInvariantsGenerator custom atom invariants generator to use
+ \param bondInvariantsGenerator custom  bond invariants generator to use
+ \param ownsAtomInvGen  if set atom invariants  generator is destroyed with the
+ fingerprint generator
+ \param ownsBondInvGen  if set bond invariants generator is destroyed with the
+ fingerprint generator
+
+ \return FingerprintGenerator<OutputType>* that generates Morgan fingerprints
+
+This generator supports the following \c AdditionalOutput types:
+  - \c atomToBits : which bits each atom is the central atom for
+  - \c atomCounts : how many bits each atom sets
+  - \c bitInfoMap : map from bitId to (atomId, radius) pairs
+
+ */
+template <typename OutputType>
+RDKIT_FINGERPRINTS_EXPORT FingerprintGenerator<OutputType> *getMorganGenerator(
+    unsigned int radius, bool countSimulation = false,
+    bool includeChirality = false, bool useBondTypes = true,
+    bool onlyNonzeroInvariants = false,
+    AtomInvariantsGenerator *atomInvariantsGenerator = nullptr,
+    BondInvariantsGenerator *bondInvariantsGenerator = nullptr,
+    std::uint32_t fpSize = 2048,
+    std::vector<std::uint32_t> countBounds = {1, 2, 4, 8},
+    bool ownsAtomInvGen = false, bool ownsBondInvGen = false) {
+  return getMorganGenerator<OutputType>(
+      radius, countSimulation, includeChirality, useBondTypes,
+      onlyNonzeroInvariants, false, atomInvariantsGenerator,
+      bondInvariantsGenerator, fpSize, countBounds, ownsAtomInvGen,
+      ownsBondInvGen);
+};
 
 }  // namespace MorganFingerprint
 }  // namespace RDKit

--- a/Code/GraphMol/Fingerprints/Wrap/MorganWrapper.cpp
+++ b/Code/GraphMol/Fingerprints/Wrap/MorganWrapper.cpp
@@ -24,7 +24,8 @@ FingerprintGenerator<OutputType> *getMorganGenerator(
     bool useBondTypes, bool onlyNonzeroInvariants,
     bool,  // includeRingMembership
     python::object &py_countBounds, std::uint32_t fpSize,
-    python::object &py_atomInvGen, python::object &py_bondInvGen) {
+    python::object &py_atomInvGen, python::object &py_bondInvGen,
+    bool includeRedundantEnvironments) {
   AtomInvariantsGenerator *atomInvariantsGenerator = nullptr;
   BondInvariantsGenerator *bondInvariantsGenerator = nullptr;
 
@@ -46,8 +47,9 @@ FingerprintGenerator<OutputType> *getMorganGenerator(
 
   return MorganFingerprint::getMorganGenerator<OutputType>(
       radius, countSimulation, includeChirality, useBondTypes,
-      onlyNonzeroInvariants, atomInvariantsGenerator, bondInvariantsGenerator,
-      fpSize, countBounds, true, true);
+      onlyNonzeroInvariants, includeRedundantEnvironments,
+      atomInvariantsGenerator, bondInvariantsGenerator, fpSize, countBounds,
+      true, true);
 }
 
 AtomInvariantsGenerator *getMorganAtomInvGen(const bool includeRingMembership) {
@@ -83,7 +85,8 @@ void exportMorgan() {
        python::arg("countBounds") = python::object(),
        python::arg("fpSize") = 2048,
        python::arg("atomInvariantsGenerator") = python::object(),
-       python::arg("bondInvariantsGenerator") = python::object()),
+       python::arg("bondInvariantsGenerator") = python::object(),
+       python::arg("includeRedundantEnvironments") = false),
       "Get a morgan fingerprint generator\n\n"
       "  ARGUMENTS:\n"
       "    - radius:  the number of iterations to grow the fingerprint\n"

--- a/Code/GraphMol/Fingerprints/Wrap/testGenerators.py
+++ b/Code/GraphMol/Fingerprints/Wrap/testGenerators.py
@@ -283,6 +283,19 @@ class TestCase(unittest.TestCase):
       arr = gen.GetCountFingerprintAsNumPy(m)
       np.testing.assert_array_equal(oarr, arr)
 
+  def testMorganRedundantEnvironments(self):
+    m = Chem.MolFromSmiles('CC(=O)O')
+   
+    g = rdFingerprintGenerator.GetMorganGenerator(2)
+    fp = g.GetSparseCountFingerprint(m)
+    self.assertEqual(fp.GetTotalVal(),8)
+   
+    g = rdFingerprintGenerator.GetMorganGenerator(2,includeRedundantEnvironments=True)
+    fp = g.GetSparseCountFingerprint(m)
+    self.assertEqual(fp.GetTotalVal(),12)
+
+
+
 
 if __name__ == '__main__':
   unittest.main()

--- a/Code/GraphMol/Fingerprints/fpgen_catch_tests.cpp
+++ b/Code/GraphMol/Fingerprints/fpgen_catch_tests.cpp
@@ -1,0 +1,63 @@
+//
+//  Copyright (C) 2022 Greg Landrum
+//
+//   @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
+//
+
+#include "catch.hpp"
+
+#include <RDGeneral/RDLog.h>
+#include <GraphMol/RDKitBase.h>
+#include <RDGeneral/test.h>
+#include <GraphMol/Fingerprints/AtomPairs.h>
+#include <GraphMol/Fingerprints/MorganFingerprints.h>
+#include <GraphMol/Fingerprints/Fingerprints.h>
+#include <GraphMol/SmilesParse/SmilesParse.h>
+#include <GraphMol/Fingerprints/AtomPairGenerator.h>
+#include <GraphMol/Fingerprints/MorganGenerator.h>
+#include <GraphMol/Fingerprints/RDKitFPGenerator.h>
+#include <GraphMol/Fingerprints/TopologicalTorsionGenerator.h>
+#include <GraphMol/Fingerprints/FingerprintGenerator.h>
+
+#include <GraphMol/FileParsers/MolSupplier.h>
+#include <GraphMol/FileParsers/FileParsers.h>
+
+using namespace RDKit;
+
+TEST_CASE("includeRedundantEnvironments") {
+  auto mol = "CC(=O)O"_smiles;
+  REQUIRE(mol);
+  SECTION("basics") {
+    {
+      std::unique_ptr<FingerprintGenerator<std::uint32_t>> fpgen{
+          MorganFingerprint::getMorganGenerator<std::uint32_t>(2)};
+      REQUIRE(fpgen);
+      std::unique_ptr<SparseIntVect<std::uint32_t>> fp{
+          fpgen->getCountFingerprint(*mol)};
+      REQUIRE(fp);
+      CHECK(fp->getTotalVal() == 8);
+    }
+    {
+      // turn on inclusion of redundant bits
+      unsigned int radius = 2;
+      bool countSimulation = false;
+      bool includeChirality = false;
+      bool useBondTypes = true;
+      bool onlyNonzeroInvariants = false;
+      bool includeRedundantEnvironments = true;
+      std::unique_ptr<FingerprintGenerator<std::uint32_t>> fpgen{
+          MorganFingerprint::getMorganGenerator<std::uint32_t>(
+              2, countSimulation, includeChirality, useBondTypes,
+              onlyNonzeroInvariants, includeRedundantEnvironments)};
+      REQUIRE(fpgen);
+      std::unique_ptr<SparseIntVect<std::uint32_t>> fp{
+          fpgen->getCountFingerprint(*mol)};
+      REQUIRE(fp);
+      CHECK(fp->getTotalVal() == 12);
+    }
+  }
+}


### PR DESCRIPTION
This is connected with the discussion #5665

As an aside: we're reaching a number of arguments to some of these functions that may make it worth making the data members of `FingerprintArguments` and derived classes non-const and adding a form of the generator factory functions which takes a FingerprintArguments structure directly.