### PR TITLE
Avoid passing a NULL pointer to CanSmiles()

### DIFF
--- a/External/AvalonTools/AvalonTools.cpp
+++ b/External/AvalonTools/AvalonTools.cpp
@@ -322,8 +322,10 @@ std::string getCanonSmiles(const std::string &data, bool isSmiles, int flags) {
     if (mp) {
       smiles = MOLToSMI(mp, ISOMERIC_SMILES);
       FreeMolecule(mp);
-      canSmiles = CanSmiles(smiles, flags);
-      MyFree(smiles);
+      if (smiles) {
+        canSmiles = CanSmiles(smiles, flags);
+        MyFree(smiles);
+      }
     }
   } else {
     canSmiles = CanSmiles((char *)data.c_str(), flags);

--- a/External/AvalonTools/test1.cpp
+++ b/External/AvalonTools/test1.cpp
@@ -519,6 +519,16 @@ void testGithub4330() {
   BOOST_LOG(rdInfoLog) << "done" << std::endl;
 }
 
+void testNoAtomCTAB() {
+  BOOST_LOG(rdInfoLog) << "testing CTAB with no atoms"
+                       << std::endl;
+  std::string data = "NullMol\r\n  ChemDraw04291110502D\r\n\r\n  0  0  0  0  0  0  0  0  0  0999 V2000\r\nM  END";
+  bool isSmiles = false;
+  int flags = 0x01 | 0x02 | 0x20;
+  auto res = AvalonTools::getCanonSmiles(data, isSmiles, flags);
+  TEST_ASSERT(res.empty());
+}
+
 int main() {
   RDLog::InitLogs();
 #if 1
@@ -538,6 +548,7 @@ int main() {
 #endif
   testGithub4075();
   testGithub4330();
+  testNoAtomCTAB();
 
   return 0;
 }


### PR DESCRIPTION
Avoid passing a NULL pointer to CanSmiles (which will happen if there are not atoms in the molblock and hence a NULL SMILES) as undefined behavior will arise.
While I have already reported the problem to Bernd and submitted a patch for Avalon, this has not yet been incorporated upstream, so meanwhile it is better to make sure that RDKit is robust against this condition.