### PR TITLE
Draw type of SGroups (STY) in picture.

### DIFF
--- a/Code/GraphMol/MolDraw2D/DrawMol.cpp
+++ b/Code/GraphMol/MolDraw2D/DrawMol.cpp
@@ -568,6 +568,31 @@ void DrawMol::extractVariableBonds() {
 }
 
 // ****************************************************************************
+namespace {
+// function to draw a label at the bottom of the bracket.
+DrawAnnotation *drawBottomLabel(const std::string &label,
+                                const DrawShape &brkShp,
+                                const MolDrawOptions &drawOptions,
+                                DrawText &textDrawer, bool horizontal) {
+  // annotations go on the last bracket of an sgroup
+  // LABEL goes at the bottom which is now the top
+  auto topPt = brkShp.points_[1];
+  auto brkPt = brkShp.points_[0];
+  if ((!horizontal && brkShp.points_[2].y > topPt.y) ||
+      (horizontal && brkShp.points_[2].x < topPt.x)) {
+    topPt = brkShp.points_[2];
+    brkPt = brkShp.points_[3];
+  }
+  DrawAnnotation *da = new DrawAnnotation(
+      label, TextAlignType::MIDDLE, "connect", drawOptions.annotationFontScale,
+      topPt + (topPt - brkPt), DrawColour(0.0, 0.0, 0.0), textDrawer);
+  if (brkPt.x < topPt.x) {
+    da->align_ = TextAlignType::START;
+  }
+  return da;
+}
+}  // namespace
+
 void DrawMol::extractBrackets() {
   auto &sgs = getSubstanceGroups(*drawMol_);
   if (sgs.empty()) {
@@ -669,32 +694,11 @@ void DrawMol::extractBrackets() {
         }
         annotations_.emplace_back(da);
       }
-      // function to draw a label at the bottom of the bracket.
-      auto drawBottomLabel = [&](const std::string &label,
-                                 const DrawShape &brkShp,
-                                 bool horizontal) -> DrawAnnotation * {
-        // annotations go on the last bracket of an sgroup
-        // LABEL goes at the bottom which is now the top
-        auto topPt = brkShp.points_[1];
-        auto brkPt = brkShp.points_[0];
-        if ((!horizontal && brkShp.points_[2].y > topPt.y) ||
-            (horizontal && brkShp.points_[2].x < topPt.x)) {
-          topPt = brkShp.points_[2];
-          brkPt = brkShp.points_[3];
-        }
-        DrawAnnotation *da = new DrawAnnotation(
-            label, TextAlignType::MIDDLE, "connect",
-            drawOptions_.annotationFontScale, topPt + (topPt - brkPt),
-            DrawColour(0.0, 0.0, 0.0), textDrawer_);
-        if (brkPt.x < topPt.x) {
-          da->align_ = TextAlignType::START;
-        }
-        return da;
-      };
 
       std::string label;
       if (sg.getPropIfPresent("LABEL", label)) {
-        auto da = drawBottomLabel(label, *postShapes_[labelBrk], horizontal);
+        auto da = drawBottomLabel(label, *postShapes_[labelBrk], drawOptions_,
+                                  textDrawer_, horizontal);
         annotations_.emplace_back(da);
       } else if (sg.getPropIfPresent("TYPE", label)) {
         if (label == "GEN") {
@@ -703,7 +707,8 @@ void DrawMol::extractBrackets() {
         }
         // draw the lowercase type if there's no label to go there.
         std::transform(label.begin(), label.end(), label.begin(), ::tolower);
-        auto da = drawBottomLabel(label, *postShapes_[labelBrk], horizontal);
+        auto da = drawBottomLabel(label, *postShapes_[labelBrk], drawOptions_,
+                                  textDrawer_, horizontal);
         annotations_.emplace_back(da);
       }
     }

--- a/Code/GraphMol/MolDraw2D/catch_tests.cpp
+++ b/Code/GraphMol/MolDraw2D/catch_tests.cpp
@@ -248,7 +248,8 @@ static const std::map<std::string, std::hash_result_t> SVG_HASHES = {
     {"bond_highlights_9.svg", 2915809284U},
     {"testGithub5486_1.svg", 1149144091U},
     {"testGithub5511_1.svg", 940106456U},
-    {"testGithub5511_2.svg", 1448975272U}};
+    {"testGithub5511_2.svg", 1448975272U},
+    {"test_github5767.svg", 3153964439U}};
 
 // These PNG hashes aren't completely reliable due to floating point cruft,
 // but they can still reduce the number of drawings that need visual
@@ -6074,5 +6075,67 @@ TEST_CASE(
     outs << text;
     outs.flush();
     outs.close();
+  }
+}
+
+TEST_CASE("Github5767: monomer label missing for MON SGroups ") {
+  std::string nameBase = "test_github5767";
+  auto m = R"CTAB(
+  Marvin  06091012252D
+
+ 13 11  0  0  0  0            999 V2000
+   -3.5063    2.1509    0.0000 N   0  0  0  0  0  0  0  0  0  0  0  0
+   -2.7918    2.5634    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -2.0773    2.1509    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -1.3628    2.5634    0.0000 N   0  0  0  0  0  0  0  0  0  0  0  0
+   -0.6484    2.1509    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    0.0661    2.5634    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    0.7806    2.1509    0.0000 N   0  0  0  0  0  0  0  0  0  0  0  0
+   -2.9984   -0.4714    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -2.2839   -0.0589    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -1.5695   -0.4714    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -0.8550   -0.0589    0.0000 Cl  0  0  0  0  0  0  0  0  0  0  0  0
+   -2.9984    0.3536    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
+    0.6777   -0.1775    0.0000 Cl  0  0  0  0  0  0  0  0  0  0  0  0
+  1  2  1  0  0  0  0
+  2  3  1  0  0  0  0
+  3  4  1  0  0  0  0
+  4  5  1  0  0  0  0
+  5  6  1  0  0  0  0
+  6  7  1  0  0  0  0
+  8  9  1  0  0  0  0
+  9 10  1  0  0  0  0
+ 10 11  1  0  0  0  0
+  9 12  1  0  0  0  0
+ 12  8  1  0  0  0  0
+M  STY  2   1 MON   2 MON
+M  SAL   1  7   1   2   3   4   5   6   7
+M  SDI   1  4   -3.9263    1.7309   -3.9263    2.9834
+M  SDI   1  4    1.2006    2.9834    1.2006    1.7309
+M  SAL   2  5   8   9  10  11  12
+M  SDI   2  4   -3.4184   -0.8914   -3.4184    0.7736
+M  SDI   2  4   -0.4350    0.7736   -0.4350   -0.8914
+M  END
+)CTAB"_ctab;
+  REQUIRE(m);
+  {
+    MolDraw2DSVG drawer(300, 300, 300, 300, true);
+    drawer.drawMolecule(*m);
+    drawer.finishDrawing();
+    std::string text = drawer.getDrawingText();
+    std::ofstream outs(nameBase + ".svg");
+    outs << text;
+    outs.flush();
+    outs.close();
+    // there should be 2 each of " >[mon]</text>"
+    std::vector<std::string> needed{" >m</text>", " >o</text>", " >n</text>"};
+    for (const auto &n : needed) {
+      std::regex rn(n);
+      std::ptrdiff_t const match_count(
+          std::distance(std::sregex_iterator(text.begin(), text.end(), rn),
+                        std::sregex_iterator()));
+      REQUIRE(match_count == 2);
+    }
+    check_file_hash(nameBase + ".svg");
   }
 }


### PR DESCRIPTION

#### Reference Issue
Fixes #5767


#### What does this implement/fix? Explain your changes.
This draws the contents of the STY type label for the bracket on an Group.

#### Any other comments?
It certainly fixes the issue filed (missing 'mon' label) but it may be too enthusiastic about what other STY types it puts on the drawing.  I don't know enough about CTFiles to know what should and what shouldn't be drawn.  It doesn't draw GEN/gen types because ChemDraw doesn't.
