### PR TITLE
Adjust LocaleSwitcher on Windows when RDK_BUILD_THREADSAFE_SSS not set

### DIFF
--- a/Code/RDGeneral/LocaleSwitcher.cpp
+++ b/Code/RDGeneral/LocaleSwitcher.cpp
@@ -96,6 +96,7 @@ class LocaleSwitcherImpl {
       old_locale = ::setlocale(LC_ALL, nullptr);
       ::setlocale(LC_ALL, "C");  // thread safe on windows
 #else
+      old_locale = std::setlocale(LC_ALL, nullptr);
       std::setlocale(LC_ALL, "C");
 #endif  // RDK_BUILD_THREADSAFE_SSS
       recurseLocale(SwitchLocale);


### PR DESCRIPTION
When `_WIN32` is defined but `RDK_BUILD_THREADSAFE_SSS` is not, the `old_locale` variable is not initialized in the LocaleSwitcherImpl constructor . This means that when the variable is consulted in the destructor, it returns an empty (default constructed) string.

When `std::setlocale()` is called with an empty string, this causes the locale to be set to "the user-preferred locale". This value is determined from environment variables/system settings and is not necessarily the previous locale that was used by the program.

Best I can tell from PR #1892, the non-RDK_BUILD_THREADSAFE_SSS path was simply missed when `old_locale` was added. (There's no indication that the omission was deliberate, though @ptosco may need to confirm.) Adding an analogous initialization as in the RDK_BUILD_THREADSAFE_SSS-defined path should cause both paths to behave similarly.