### PR TITLE
Addresses #5792

### DIFF
--- a/Code/MinimalLib/docker/Dockerfile
+++ b/Code/MinimalLib/docker/Dockerfile
@@ -9,7 +9,8 @@ RUN apt-get update && apt-get upgrade -y && apt install -y \
   g++ \
   libeigen3-dev \
   git \
-  nodejs
+  nodejs \
+  libfreetype6-dev
 
 ENV LANG C
 
@@ -26,8 +27,8 @@ RUN git clone https://github.com/emscripten-core/emsdk.git
 
 WORKDIR /opt/emsdk
 RUN ./emsdk update-tags && \
-  ./emsdk install latest && \
-  ./emsdk activate latest
+  ./emsdk install 3.1.3 && \
+  ./emsdk activate 3.1.3
 
 #RUN source ./emsdk_env.sh
 
@@ -51,6 +52,8 @@ RUN emcmake cmake -DBoost_INCLUDE_DIR=/opt/boost/include -DRDK_BUILD_FREETYPE_SU
   -DRDK_BUILD_DESCRIPTORS3D=OFF -DRDK_TEST_MULTITHREADED=OFF \
   -DRDK_BUILD_MAEPARSER_SUPPORT=OFF -DRDK_BUILD_COORDGEN_SUPPORT=ON \
   -DRDK_BUILD_SLN_SUPPORT=OFF -DRDK_USE_BOOST_IOSTREAMS=OFF \
+  -DFREETYPE_INCLUDE_DIRS=/usr/include/freetype2 \
+  -DFREETYPE_LIBRARY=/usr/lib/x86_64-linux-gnu/libfreetype.so.6 \
   -DCMAKE_CXX_FLAGS="-s DISABLE_EXCEPTION_CATCHING=0" \
   -DCMAKE_C_FLAGS="-DCOMPILE_ANSI_ONLY" \
   -DCMAKE_EXE_LINKER_FLAGS="-s MODULARIZE=1 -s EXPORT_NAME=\"'initRDKitModule'\"" ..


### PR DESCRIPTION
There are two problems here:
1) The Debian `buster` distribution does not seem to include `freetype` headers. Adding `libfreetype6-dev` to the installed packages and configuring the `FREETYPE_*` cmake variables solves the problem. I think this is somehow connected to #5730; however, given that the `freetype` headers are not available in the distribution, I am not sure how the Docker container could find `freetype` before #5730.
2) The current `emsdk` throws a number of errors with `boost`. Updating `boost` does not fix the problem, downgrading `emsdk` does. Currently I do not have time to investigate further; there might be ways to get the latest `emsdk` to work.