### PR TITLE
Fixes #5784

### DIFF
--- a/Code/GraphMol/MolStandardize/Tautomer.cpp
+++ b/Code/GraphMol/MolStandardize/Tautomer.cpp
@@ -436,12 +436,16 @@ TautomerEnumeratorResult TautomerEnumerator::enumerate(const ROMol &mol) const {
 #endif
 
           unsigned int failedOp;
-          MolOps::sanitizeMol(*product, failedOp,
-                              MolOps::SANITIZE_KEKULIZE |
-                                  MolOps::SANITIZE_SETAROMATICITY |
-                                  MolOps::SANITIZE_SETCONJUGATION |
-                                  MolOps::SANITIZE_SETHYBRIDIZATION |
-                                  MolOps::SANITIZE_ADJUSTHS);
+          try {
+            MolOps::sanitizeMol(*product, failedOp,
+                                MolOps::SANITIZE_KEKULIZE |
+                                    MolOps::SANITIZE_SETAROMATICITY |
+                                    MolOps::SANITIZE_SETCONJUGATION |
+                                    MolOps::SANITIZE_SETHYBRIDIZATION |
+                                    MolOps::SANITIZE_ADJUSTHS);
+          } catch (const KekulizeException &ke) {
+            continue;
+          }
 #ifdef VERBOSE_ENUMERATION
           SmilesWriteParams smilesWriteParams;
           smilesWriteParams.allBondsExplicit = true;

--- a/Code/GraphMol/MolStandardize/catch_tests.cpp
+++ b/Code/GraphMol/MolStandardize/catch_tests.cpp
@@ -1025,3 +1025,16 @@ TEST_CASE("Github #5402: order dependence of tautomer transforms") {
     CHECK(MolToSmiles(*res1) == MolToSmiles(*res2));
   }
 }
+
+TEST_CASE("Github 5784: kekulization error when enumerating tautomers") {
+  std::vector<std::string> smis{"NC1=NC=NC(C)=C1", "CC1N=CN(C)C(=O)C=1",
+                                "CC1=CC=CC(=O)N1C"};
+  for (const auto &smi : smis) {
+    INFO(smi);
+    std::unique_ptr<ROMol> m{SmilesToMol(smi)};
+    REQUIRE(m);
+    MolStandardize::TautomerEnumerator te;
+    std::unique_ptr<ROMol> res(te.canonicalize(*m));
+    REQUIRE(res);
+  }
+}


### PR DESCRIPTION
As suggested by @d-b-w : we just catch kekulization errors during the tautomer enumeration

I have tested this on ~100K ChEMBL molecules and encountered no further problems.
