### PR TITLE
Fixes #5718

### DIFF
--- a/Code/GraphMol/FileParsers/MolFileParser.cpp
+++ b/Code/GraphMol/FileParsers/MolFileParser.cpp
@@ -2840,6 +2840,7 @@ void processSMARTSQ(RWMol &mol, const SubstanceGroup &sg) {
       query = new RecursiveStructureQuery(m.release());
     }
     at->setQuery(query);
+    at->setProp(common_properties::MRV_SMA, sma);
     at->setProp(common_properties::_MolFileAtomQuery, 1);
   }
 }

--- a/Code/GraphMol/FileParsers/MolFileWriter.cpp
+++ b/Code/GraphMol/FileParsers/MolFileWriter.cpp
@@ -1057,8 +1057,28 @@ int BondStereoCodeV2000ToV3000(int dirCode) {
   }
 }
 
+namespace {
+void createSMARTSQSubstanceGroups(ROMol &mol) {
+  for (const auto atom : mol.atoms()) {
+    std::string sma;
+    if (atom->hasQuery() &&
+        atom->getPropIfPresent(common_properties::MRV_SMA, sma) &&
+        !sma.empty()) {
+      SubstanceGroup sg(&mol, "DAT");
+      sg.setProp("QUERYTYPE", "SMARTSQ");
+      sg.setProp("QUERYOP", "=");
+      std::vector<std::string> dataFields{sma};
+      sg.setProp("DATAFIELDS", dataFields);
+      sg.addAtomWithIdx(atom->getIdx());
+      addSubstanceGroup(mol, sg);
+    }
+  }
+}
+}  // namespace
+
 void moveAdditionalPropertiesToSGroups(RWMol &mol) {
   GenericGroups::convertGenericQueriesToSubstanceGroups(mol);
+  createSMARTSQSubstanceGroups(mol);
 }
 
 const std::string GetV3000MolFileBondLine(const Bond *bond,

--- a/Code/GraphMol/FileParsers/file_parsers_catch.cpp
+++ b/Code/GraphMol/FileParsers/file_parsers_catch.cpp
@@ -5214,3 +5214,33 @@ M  END)CTAB"_ctab;
     CHECK(!m->getAtomWithIdx(2)->hasProp(common_properties::dummyLabel));
   }
 }
+
+TEST_CASE("github #5718: ") {
+  SECTION("as reported") {
+    auto m = R"CTAB(
+
+  Mrv2108 07152116012D          
+  0  0  0     0  0            999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 2 1 1 0 0
+M  V30 BEGIN ATOM
+M  V30 1 C -0.8333 4.5421 0 0
+M  V30 2 C 0.5003 5.3121 0 0
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 1 1 2
+M  V30 END BOND
+M  V30 BEGIN SGROUP
+M  V30 1 DAT 0 ATOMS=(1 2) -
+M  V30 FIELDDISP="    0.0000    0.0000    DR    ALL  0       0" -
+M  V30 QUERYTYPE=SMARTSQ QUERYOP== FIELDDATA=[#6;R]
+M  V30 END SGROUP
+M  V30 END CTAB
+M  END")CTAB"_ctab;
+    REQUIRE(m);
+    CHECK(!m->getAtomWithIdx(0)->hasQuery());
+    CHECK(m->getAtomWithIdx(1)->hasQuery());
+    auto ctab = MolToV3KMolBlock(*m);
+    CHECK(ctab.find("SMARTSQ") != std::string::npos);
+  }
+}

--- a/Code/GraphMol/FileParsers/file_parsers_catch.cpp
+++ b/Code/GraphMol/FileParsers/file_parsers_catch.cpp
@@ -5242,5 +5242,6 @@ M  END")CTAB"_ctab;
     CHECK(m->getAtomWithIdx(1)->hasQuery());
     auto ctab = MolToV3KMolBlock(*m);
     CHECK(ctab.find("SMARTSQ") != std::string::npos);
+    CHECK(ctab.find("[#6;R]") != std::string::npos);
   }
 }


### PR DESCRIPTION
For the bug-fix version of this we focus on making sure that information which is read in from a SMARTSQ is written back out to a SMARTSQ.

The implementation is simple: we set the `MRV_SMA` property on the atom when processing the SMARTSQ and just look for that property when generating the output CTAB.

We should add the (optional) ability to automatically include other SMARTS queries in SMARTSQ blocks, but that's clearly an enhancement. And it's more work.