### PR TITLE
Chemical drawings should be automatically enabled on Colab

### DIFF
--- a/rdkit/__init__.py
+++ b/rdkit/__init__.py
@@ -16,8 +16,9 @@ logger = logging.getLogger("rdkit")
 # if we are running in a jupyter notebook, enable the extensions
 try:
   kernel_name = get_ipython().__class__.__name__
+  module_name = get_ipython().__class__.__module__ 
 
-  if kernel_name == 'ZMQInteractiveShell':
+  if kernel_name == 'ZMQInteractiveShell' or module_name == 'google.colab._shell':
     logger.info("Enabling RDKit %s jupyter extensions" % __version__)
     from rdkit.Chem.Draw import IPythonConsole
     rdBase.LogToPythonStderr()

--- a/rdkit/__init__.py
+++ b/rdkit/__init__.py
@@ -16,7 +16,7 @@ logger = logging.getLogger("rdkit")
 # if we are running in a jupyter notebook, enable the extensions
 try:
   kernel_name = get_ipython().__class__.__name__
-  module_name = get_ipython().__class__.__module__ 
+  module_name = get_ipython().__class__.__module__
 
   if kernel_name == 'ZMQInteractiveShell' or module_name == 'google.colab._shell':
     logger.info("Enabling RDKit %s jupyter extensions" % __version__)


### PR DESCRIPTION
`rdkit.Chem.rdchem.Mol`  objects are missing the functions `_repr_svg_` and `__repr_png_` on Colab notebooks. Chemical drawings are not automatically shown.

`IPythonConsole` is not imported in `rdkit/__init__.py` for colab notebooks because the `kernel_name` is `Shell` on Colab and not `ZMQInteractiveShell`. 


#### What does this implement/fix? Explain your changes.

Additionally check if `get_ipython().__class__.__module__`  is set to `google.colab._shell`. 

