### PR TITLE
fixes #5827

### DIFF
--- a/Code/GraphMol/FileParsers/SDWriter.cpp
+++ b/Code/GraphMol/FileParsers/SDWriter.cpp
@@ -91,7 +91,8 @@ void _writePropToStream(std::ostream *dp_ostream, const ROMol &mol,
         << " because the name includes a newline" << std::endl;
     return;
   }
-  if (pval.find("\n\n") != std::string::npos) {
+  if (pval.find("\r\n\r\n") != std::string::npos ||
+      pval.find("\n\n") != std::string::npos) {
     BOOST_LOG(rdWarningLog)
         << "WARNING: Skipping property " << name
         << " because the value includes an illegal blank line" << std::endl;

--- a/Code/GraphMol/FileParsers/SDWriter.cpp
+++ b/Code/GraphMol/FileParsers/SDWriter.cpp
@@ -84,6 +84,19 @@ void _writePropToStream(std::ostream *dp_ostream, const ROMol &mol,
     return;
   }
 
+  // warn and skip if we include a new line
+  if (name.find("\n") != std::string::npos) {
+    BOOST_LOG(rdWarningLog)
+        << "WARNING: Skipping property " << name
+        << " because the name includes a newline" << std::endl;
+    return;
+  }
+  if (pval.find("\n\n") != std::string::npos) {
+    BOOST_LOG(rdWarningLog)
+        << "WARNING: Skipping property " << name
+        << " because the value includes an illegal blank line" << std::endl;
+    return;
+  }
   // write the property header line
   (*dp_ostream) << ">  <" << name << ">  ";
   if (d_molid >= 0) {

--- a/Code/GraphMol/FileParsers/file_parsers_catch.cpp
+++ b/Code/GraphMol/FileParsers/file_parsers_catch.cpp
@@ -23,6 +23,7 @@
 #include <GraphMol/FileParsers/SequenceWriters.h>
 #include <GraphMol/FileParsers/PNGParser.h>
 #include <GraphMol/FileParsers/MolFileStereochem.h>
+#include <GraphMol/FileParsers/MolWriters.h>
 #include <RDGeneral/FileParseException.h>
 #include <boost/algorithm/string.hpp>
 
@@ -5213,7 +5214,7 @@ M  END)CTAB"_ctab;
     REQUIRE(m);
     CHECK(m->getAtomWithIdx(2)->hasProp(common_properties::dummyLabel));
     CHECK(m->getAtomWithIdx(2)->getProp<std::string>(
-              common_properties::dummyLabel) == "R#");    
+              common_properties::dummyLabel) == "R#");
   }
   SECTION("R# also gets the tag (V2000, #5810)") {
     auto m = R"CTAB(
@@ -5226,11 +5227,11 @@ M  END)CTAB"_ctab;
   1  3  1  0
   1  2  1  0
 M  END)CTAB"_ctab;
-      REQUIRE(m);
-      CHECK(m->getAtomWithIdx(2)->hasProp(common_properties::dummyLabel));
-      CHECK(m->getAtomWithIdx(2)->getProp<std::string>(
-                common_properties::dummyLabel) == "R#");    
-    }
+    REQUIRE(m);
+    CHECK(m->getAtomWithIdx(2)->hasProp(common_properties::dummyLabel));
+    CHECK(m->getAtomWithIdx(2)->getProp<std::string>(
+              common_properties::dummyLabel) == "R#");
+  }
 }
 
 TEST_CASE("github #5718: ") {
@@ -5261,5 +5262,38 @@ M  END")CTAB"_ctab;
     auto ctab = MolToV3KMolBlock(*m);
     CHECK(ctab.find("SMARTSQ") != std::string::npos);
     CHECK(ctab.find("[#6;R]") != std::string::npos);
+  }
+}
+
+TEST_CASE("github #5827: do not write properties with new lines to SDF") {
+  SECTION("basics") {
+    auto m = R"CTAB(
+  Mrv2211 12152210292D          
+
+  0  0  0     0  0            999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 2 1 0 0 0
+M  V30 BEGIN ATOM
+M  V30 1 C 0.5 6.0833 0 0
+M  V30 2 O 1.8337 6.8533 0 0
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 1 1 2
+M  V30 END BOND
+M  V30 END CTAB
+M  END
+)CTAB"_ctab;
+    REQUIRE(m);
+    m->setProp("foo", "fooprop");
+    m->setProp("bar", "foo\n\nprop");
+    m->setProp("bletch\nnope", "fooprop");
+    std::ostringstream oss;
+    SDWriter sdw(&oss);
+    sdw.write(*m);
+    sdw.flush();
+    auto sdf = oss.str();
+    CHECK(sdf.find("<foo>") != std::string::npos);
+    CHECK(sdf.find("<bar>") == std::string::npos);
+    CHECK(sdf.find("<bletch") == std::string::npos);
   }
 }

--- a/Code/GraphMol/FileParsers/file_parsers_catch.cpp
+++ b/Code/GraphMol/FileParsers/file_parsers_catch.cpp
@@ -5266,8 +5266,7 @@ M  END")CTAB"_ctab;
 }
 
 TEST_CASE("github #5827: do not write properties with new lines to SDF") {
-  SECTION("basics") {
-    auto m = R"CTAB(
+  auto m = R"CTAB(
   Mrv2211 12152210292D          
 
   0  0  0     0  0            999 V3000
@@ -5283,10 +5282,13 @@ M  V30 END BOND
 M  V30 END CTAB
 M  END
 )CTAB"_ctab;
-    REQUIRE(m);
+  REQUIRE(m);
+  SECTION("basics") {
     m->setProp("foo", "fooprop");
     m->setProp("bar", "foo\n\nprop");
+    m->setProp("baz", "foo\r\n\r\nprop");
     m->setProp("bletch\nnope", "fooprop");
+    m->setProp("bletch\r\nnope2", "fooprop");
     std::ostringstream oss;
     SDWriter sdw(&oss);
     sdw.write(*m);
@@ -5294,6 +5296,7 @@ M  END
     auto sdf = oss.str();
     CHECK(sdf.find("<foo>") != std::string::npos);
     CHECK(sdf.find("<bar>") == std::string::npos);
+    CHECK(sdf.find("<baz>") == std::string::npos);
     CHECK(sdf.find("<bletch") == std::string::npos);
   }
 }


### PR DESCRIPTION
Straightforward fix:
if a property name includes a newline or a property value includes a blank line then generate warning message and skip the property for that molecule.
 