### PR TITLE
use enhanced stereo when uniquifying in SimpleEnum

### DIFF
--- a/rdkit/Chem/SimpleEnum/Enumerator.py
+++ b/rdkit/Chem/SimpleEnum/Enumerator.py
@@ -206,9 +206,11 @@ def EnumerateReaction(
 
   def _uniqueOnly(lst):
     seen = []
+    ps = Chem.SmilesWriteParams()
+    cxflags = Chem.CXSmilesFields.CX_ENHANCEDSTEREO
     for entry in lst:
       if entry:
-        smi = '.'.join(sorted([Chem.MolToSmiles(x, True) for x in entry]))
+        smi = '.'.join(sorted([Chem.MolToCXSmiles(x, ps, cxflags) for x in entry]))
         if smi not in seen:
           seen.append(smi)
           yield entry

--- a/rdkit/Chem/SimpleEnum/UnitTestEnumerator.py
+++ b/rdkit/Chem/SimpleEnum/UnitTestEnumerator.py
@@ -29,6 +29,17 @@ class TestCase(unittest.TestCase):
 
     self.assertRaises(ValueError, Enumerator.EnumerateReaction, rxn, (reacts1, ))
 
+  def test_UniquifyingEnhancedStereo(self):
+    rxn = AllChem.ReactionFromSmarts('[C:1]-[O:2]>>[C:1]-[N:2]')
+    rxn.Initialize()
+    reacts1 = ['C[C@@H](F)CO','C[C@@H](F)CO |a:1|','C[C@@H](F)CO |o1:1|','C[C@@H](F)CO |&1:1|']
+    reacts1 = [Chem.MolFromSmiles(x) for x in reacts1]
+
+    prods = list(Enumerator.EnumerateReaction(rxn,(reacts1,),uniqueProductsOnly=True))
+    ps = Chem.SmilesWriteParams()
+    print([Chem.MolToCXSmiles(tpl[0],ps,Chem.CXSmilesFields.CX_ENHANCEDSTEREO) for tpl in prods])
+    self.assertEqual(len(prods),len(reacts1))
+
 
 if __name__ == '__main__':  # pragma: nocover
   unittest.main()


### PR DESCRIPTION
Enhanced stereo information was not being used when `SimpleEnum.Enumerate()` is run with `uniqueProducts=True`:
```
In [1]: from rdkit import Chem

In [2]: from rdkit.Chem import rdChemReactions

In [3]: rxn = rdChemReactions.ReactionFromSmarts('[C:1]-[O:2]>>[C:1]-[N:2]')

In [4]: reacts1 = ['C[C@@H](F)CO','C[C@@H](F)CO |a:1|','C[C@@H](F)CO |o1:1|','C[C@@H](F)CO |&1:1|']

In [5]: reacts1 = [Chem.MolFromSmiles(x) for x in reacts1]

In [7]: from rdkit.Chem.SimpleEnum import Enumerator

In [8]: prods = list(Enumerator.EnumerateReaction(rxn,(reacts1,),uniqueProductsOnly=True))

In [9]: len(prods)
Out[9]: 1
```
The fix in this PR is easy: just use the CXSmiles for the molecule when uniquifying.

