### PR TITLE
Fix documentation example for KeyFromPropHolder

### DIFF
--- a/Code/GraphMol/SubstructLibrary/Wrap/SubstructLibraryWrap.cpp
+++ b/Code/GraphMol/SubstructLibrary/Wrap/SubstructLibraryWrap.cpp
@@ -407,6 +407,7 @@ const char *SubstructLibraryDoc =
     "Finally, the KeyFromPropHolder can be used to use external keys such as\n"
     "compound names.  By default the holder uses the '_Name' property but can\n"
     "be changed to any property.\n"
+    "\n"
     ">>> library = "
     "rdSubstructLibrary.SubstructLibrary(rdSubstructLibrary.MolHolder(), "
     "rdSubstructLibrary.KeyFromPropHolder())\n"


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! 
-->
#### Reference Issue
Not applicable


#### What does this implement/fix? Explain your changes.
The example for KeyFromPropHolder in the documentation here:

https://www.rdkit.org/docs/source/rdkit.Chem.rdSubstructLibrary.html

doesn't render the example correctly. I don't know if the extra new line fixes it, but it looks like that is the only difference to the previous code blocks. 

#### Any other comments?

