### PR TITLE
Allow unrecognized atom types when strictParsing=False

### DIFF
--- a/Code/GraphMol/FileParsers/MolFileParser.cpp
+++ b/Code/GraphMol/FileParsers/MolFileParser.cpp
@@ -1378,6 +1378,21 @@ void setRGPProps(const std::string_view symb, Atom *res) {
   std::string symbc(symb);
   res->setProp(common_properties::dummyLabel, symbc);
 }
+
+void lookupAtomicNumber(Atom *res, const std::string &symb, bool strictParsing) {
+  try {
+    res->setAtomicNum(PeriodicTable::getTable()->getAtomicNumber(symb));
+  } catch (const Invar::Invariant &e) {
+    if (strictParsing || symb.empty()) {
+      delete res;
+      throw FileParseException(e.what());
+    } else {
+      res->setAtomicNum(0);
+      res->setProp(common_properties::dummyLabel, symb);
+    }
+  }
+}
+
 }  // namespace
 
 Atom *ParseMolFileAtomLine(const std::string_view text, RDGeom::Point3D &pos,
@@ -1494,12 +1509,7 @@ Atom *ParseMolFileAtomLine(const std::string_view text, RDGeom::Point3D &pos,
     if (symb.size() == 2 && symb[1] >= 'A' && symb[1] <= 'Z') {
       symb[1] = static_cast<char>(tolower(symb[1]));
     }
-    try {
-      res->setAtomicNum(PeriodicTable::getTable()->getAtomicNumber(symb));
-    } catch (const Invar::Invariant &e) {
-      delete res;
-      throw FileParseException(e.what());
-    }
+    lookupAtomicNumber(res, symb, strictParsing);
   }
 
   // res->setPos(pX,pY,pZ);
@@ -2067,7 +2077,8 @@ bool ParseMolBlockProperties(std::istream *inStream, unsigned int &line,
   return fileComplete;
 }
 
-Atom *ParseV3000AtomSymbol(std::string_view token, unsigned int &line) {
+Atom *ParseV3000AtomSymbol(std::string_view token, unsigned int &line,
+                           bool strictParsing) {
   bool negate = false;
   token = FileParserUtils::strip(token);
   if (token.size() > 3 && (token[0] == 'N' || token[0] == 'n') &&
@@ -2172,8 +2183,8 @@ Atom *ParseV3000AtomSymbol(std::string_view token, unsigned int &line) {
       if (token.size() == 2 && token[1] >= 'A' && token[1] <= 'Z') {
         tcopy[1] = static_cast<char>(tolower(token[1]));
       }
-
-      res = new Atom(PeriodicTable::getTable()->getAtomicNumber(tcopy));
+      res = new Atom(0);
+      lookupAtomicNumber(res, tcopy, strictParsing);
     }
   }
 
@@ -2473,7 +2484,7 @@ void ParseV3000AtomBlock(std::istream *inStream, unsigned int &line,
       errout << "Bad atom line : '" << tempStr << "' on line " << line;
       throw FileParseException(errout.str());
     }
-    Atom *atom = ParseV3000AtomSymbol(*token, line);
+    Atom *atom = ParseV3000AtomSymbol(*token, line, strictParsing);
 
     // now the position;
     RDGeom::Point3D pos;

--- a/Code/GraphMol/FileParsers/file_parsers_catch.cpp
+++ b/Code/GraphMol/FileParsers/file_parsers_catch.cpp
@@ -5300,3 +5300,55 @@ M  END
     CHECK(sdf.find("<bletch") == std::string::npos);
   }
 }
+
+TEST_CASE(
+    "accept unrecognized atom names in CTABs when strictParsing is false") {
+  SECTION("V3000") {
+    std::string mb = R"CTAB(
+  Mrv2211 12152210292D          
+
+  0  0  0     0  0            999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 2 1 0 0 0
+M  V30 BEGIN ATOM
+M  V30 1 C 0.5 6.0833 0 0
+M  V30 2 ARY 1.8337 6.8533 0 0
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 1 1 2
+M  V30 END BOND
+M  V30 END CTAB
+M  END
+)CTAB";
+    std::unique_ptr<RWMol> m;
+    CHECK_THROWS_AS(m.reset(MolBlockToMol(mb)), FileParseException);
+    bool sanitize = true;
+    bool removeHs = true;
+    bool strictParsing = false;
+    m.reset(MolBlockToMol(mb, sanitize, removeHs, strictParsing));
+    REQUIRE(m);
+    CHECK(m->getAtomWithIdx(1)->getAtomicNum() == 0);
+    CHECK(m->getAtomWithIdx(1)->hasProp(common_properties::dummyLabel));
+  }
+
+  SECTION("V2000") {
+    std::string mb = R"CTAB(
+  Mrv1810 02111915042D          
+
+  2  1  0  0  0  0            999 V2000
+   -1.5625    1.6071    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -0.8480    2.0196    0.0000 ARY 0  0  0  0  0  0  0  0  0  0  0  0
+  1  2  1  0  0  0  0
+M  END
+      )CTAB";
+    std::unique_ptr<RWMol> m;
+    CHECK_THROWS_AS(m.reset(MolBlockToMol(mb)), FileParseException);
+    bool sanitize = true;
+    bool removeHs = true;
+    bool strictParsing = false;
+    m.reset(MolBlockToMol(mb, sanitize, removeHs, strictParsing));
+    REQUIRE(m);
+    CHECK(m->getAtomWithIdx(1)->getAtomicNum() == 0);
+    CHECK(m->getAtomWithIdx(1)->hasProp(common_properties::dummyLabel));
+  }
+}


### PR DESCRIPTION
We should just read them in as dummies instead of throwing an exception. 

There's a light bit of refactoring in here as well.

