### PR TITLE
Make it easy to calculate all 2D descriptors

### DIFF
--- a/Docs/Book/GettingStartedInPython.rst
+++ b/Docs/Book/GettingStartedInPython.rst
@@ -2050,6 +2050,37 @@ centralized :py:mod:`rdkit.Chem.Descriptors` module :
   >>> Descriptors.MolLogP(m)
   1.3848
 
+Calculating All Descriptors
+===========================
+
+The :py:mod:`rdkit.Chem.Descriptors` module provides a convenience function, ``CalcMolDescriptors()``, to calculate all available descriptors for a molecule. ``CalcMolDescriptors()`` returns a dictionary with descriptor names as the keys and descriptor values as the values:
+
+.. doctest::
+
+  >>> vals = Descriptors.CalcMolDescriptors(m)
+  >>> vals['TPSA']
+  37.3
+  >>> vals['NumHDonors']
+  1
+
+``CalcMolDescriptors()`` makes it easy to generate descriptors for a set of molecules and get the values into a pandas DataFrame:
+
+  >>> descrs = [Descriptors.CalcMolDescriptors(mol) for mol in mols]
+  >>> df = pandas.DataFrame(descrs)
+  >>> df.head()
+  >>> df.head(3)
+    MaxEStateIndex  MinEStateIndex  MaxAbsEStateIndex  ...  fr_thiophene  fr_unbrch_alkane  fr_urea
+  0        8.361111       -0.115741           8.361111  ...             0                 0        0
+  1        8.361111       -0.115741           8.361111  ...             0                 0        0
+  2        8.334769        0.329861           8.334769  ...             0                 0        0
+
+  [3 rows x 208 columns]
+
+
+
+Calculating Partial Charges
+===========================
+
 Partial charges are handled a bit differently:
 
 .. doctest::
@@ -2058,7 +2089,6 @@ Partial charges are handled a bit differently:
   >>> AllChem.ComputeGasteigerCharges(m)
   >>> m.GetAtomWithIdx(0).GetDoubleProp('_GasteigerCharge')
   -0.047...
-
 
 Visualization of Descriptors
 ============================

--- a/rdkit/Chem/Descriptors.py
+++ b/rdkit/Chem/Descriptors.py
@@ -267,6 +267,35 @@ class PropertyFunctor(rdMolDescriptors.PythonPropertyFunctor):
   def __call__(self, mol):
     raise NotImplementedError("Please implement the __call__ method")
 
+def CalcMolDescriptors(mol, missingVal=None, silent=True):
+    ''' calculate the full set of descriptors for a molecule
+    
+    Parameters
+    ----------
+    mol : RDKit molecule
+    missingVal : float, optional
+                 This will be used if a particular descriptor cannot be calculated
+    silent : bool, optional
+             if True then exception messages from descriptors will be displayed
+
+    Returns
+    -------
+    dict 
+         A dictionary with decriptor names as keys and the descriptor values as values
+    '''
+    res = {}
+    for nm,fn in _descList:
+        # some of the descriptor fucntions can throw errors if they fail, catch those here:
+        try:
+            val = fn(mol)
+        except:
+            if not silent:
+              import traceback
+              traceback.print_exc()
+            val = missingVal
+        res[nm] = val
+    return res
+
 
 # ------------------------------------
 #

--- a/rdkit/Chem/Descriptors.py
+++ b/rdkit/Chem/Descriptors.py
@@ -267,25 +267,6 @@ class PropertyFunctor(rdMolDescriptors.PythonPropertyFunctor):
   def __call__(self, mol):
     raise NotImplementedError("Please implement the __call__ method")
 
-# machinery to add all the descriptors here to the Properties interface:
-def _propCtor(self,name,func):
-  PropertyFunctor.__init__(self,name,getattr(func,'version','1.0.0'))
-  self._func = func
-
-def _registerDescriptorsAsProperties():
-  # the cases in property names are sometimes weird, so normalize that
-  ps = rdMolDescriptors.Properties()
-  allProps = [x.lower() for x in ps.GetPropertyNames()]  
-  for nm,func in _descList:
-    if nm.lower() in allProps:
-      continue
-    cls = type("_"+nm+"Prop",(PropertyFunctor,),
-        {'__init__':lambda self,name=nm,func=func:_propCtor(self,name,func),
-         '__call__':lambda self,mol:self._func(mol)})
-    rdMolDescriptors.Properties.RegisterProperty(cls())    
-
-_registerDescriptorsAsProperties()
-
 def CalcMolDescriptors(mol, missingVal=None, silent=True):
     ''' calculate the full set of descriptors for a molecule
     

--- a/rdkit/Chem/Graphs.py
+++ b/rdkit/Chem/Graphs.py
@@ -1,6 +1,5 @@
-# $Id$
 #
-# Copyright (C) 2001-2008 greg landrum and rational discovery llc
+# Copyright (C) 2001-2022 Greg Landrum and other RDKit contributors
 #
 #   @@ All Rights Reserved @@
 #  This file is part of the RDKit.
@@ -40,7 +39,7 @@ def CharacteristicPolynomial(mol, mat=None):
         A = mat
     I = 1. * numpy.identity(nAtoms)
     An = A
-    res = numpy.zeros(nAtoms + 1, numpy.float)
+    res = numpy.zeros(nAtoms + 1, float)
     res[0] = 1.0
     for n in range(1, nAtoms + 1):
         res[n] = 1. / n * numpy.trace(An)

--- a/rdkit/Chem/UnitTestDescriptors.py
+++ b/rdkit/Chem/UnitTestDescriptors.py
@@ -205,11 +205,5 @@ class TestCase(unittest.TestCase):
     self.assertTrue('MolLogP' in descs)
     self.assertEqual(descs['NumHDonors'],1)
   
-  def testRegisterPythonProperties(self):
-    ps = rdMolDescriptors.Properties()
-    self.assertIn('MaxEStateIndex',ps.GetPropertyNames())
-
-
-
 if __name__ == '__main__':
   unittest.main()

--- a/rdkit/Chem/UnitTestDescriptors.py
+++ b/rdkit/Chem/UnitTestDescriptors.py
@@ -199,6 +199,13 @@ class TestCase(unittest.TestCase):
     mol = AllChem.MolFromSmiles('[HH]')
     self.assertEqual(Descriptors.FpDensityMorgan1(mol), 0)
 
+  def testGetMolDescriptors(self):
+    mol = Chem.MolFromSmiles('CCCO')
+    descs = Descriptors.CalcMolDescriptors(mol)
+    self.assertTrue('MolLogP' in descs)
+    self.assertEqual(descs['NumHDonors'],1)
+
+
 
 if __name__ == '__main__':
   unittest.main()

--- a/rdkit/Chem/UnitTestDescriptors.py
+++ b/rdkit/Chem/UnitTestDescriptors.py
@@ -204,6 +204,10 @@ class TestCase(unittest.TestCase):
     descs = Descriptors.CalcMolDescriptors(mol)
     self.assertTrue('MolLogP' in descs)
     self.assertEqual(descs['NumHDonors'],1)
+  
+  def testRegisterPythonProperties(self):
+    ps = rdMolDescriptors.Properties()
+    self.assertIn('MaxEStateIndex',ps.GetPropertyNames())
 
 
 


### PR DESCRIPTION
Adds `Descriptors.CalcMolDescriptors()`
Also adds a section to the documentation for this use case.

I really should have added this function years ago.