### PR TITLE
Introduces AvgIpc descriptor

### DIFF
--- a/rdkit/Chem/GraphDescriptors.py
+++ b/rdkit/Chem/GraphDescriptors.py
@@ -100,13 +100,13 @@ def _pyHallKierAlpha(m):
 # HallKierAlpha.version="1.0.2"
 
 
-def Ipc(mol, avg=0, dMat=None, forceDMat=0):
+def Ipc(mol, avg=False, dMat=None, forceDMat=False):
   """This returns the information content of the coefficients of the characteristic
     polynomial of the adjacency matrix of a hydrogen-suppressed graph of a molecule.
 
-    'avg = 1' returns the information content divided by the total population.
+    'avg = True' returns the information content divided by the total population.
 
-    From D. Bonchev & N. Trinajstic, J. Chem. Phys. vol 67, 4517-4533 (1977)
+    From Eq 6 of D. Bonchev & N. Trinajstic, J. Chem. Phys. vol 67, 4517-4533 (1977)
 
   """
   if forceDMat or dMat is None:
@@ -129,6 +129,17 @@ def Ipc(mol, avg=0, dMat=None, forceDMat=0):
 
 
 Ipc.version = "1.0.0"
+
+def AvgIpc(mol, dMat=None, forceDMat=False):
+  """This returns the average information content of the coefficients of the characteristic
+    polynomial of the adjacency matrix of a hydrogen-suppressed graph of a molecule.
+
+    From Eq 7 of D. Bonchev & N. Trinajstic, J. Chem. Phys. vol 67, 4517-4533 (1977)
+
+  """
+  return Ipc(mol,avg=True,dMat=dMat,forceDMat=forceDMat)
+
+AvgIpc.version = "1.0.0"
 
 
 def _pyKappa1(mol):

--- a/rdkit/Chem/UnitTestGraphDescriptors_2.py
+++ b/rdkit/Chem/UnitTestGraphDescriptors_2.py
@@ -114,6 +114,9 @@ class TestCase(unittest.TestCase):
       self.assertAlmostEqual(Ipc_avg, res1, delta=1e-3,
                              msg='mol %s (Ipc_avg=%f) should have Ipc_avg=%f' % (smi, Ipc_avg,
                                                                                  res1))
+      avgIpc = GraphDescriptors.AvgIpc(m, forceDMat=1)
+      self.assertEqual(Ipc_avg,avgIpc)
+      
       self.assertAlmostEqual(Ipc, res2, delta=1e-3,
                              msg='mol %s (Ipc=%f) should have Ipc=%f' % (smi, Ipc, res2))
 


### PR DESCRIPTION
The Ipc descriptor goes up very quickly with the size/complexity of the molecule.
It's always been possible to dial this back by using the `avg=True` keyword argument, but most people don't do that. We can't change the default value of `avg` (that results in a different descriptor value), so this adds a new descriptor with that set.

See more discussion in #1527


