### PR TITLE
clear MDL Rgroup labels from core atoms when we aren't using them

### DIFF
--- a/Code/GraphMol/RGroupDecomposition/RGroupDecompData.h
+++ b/Code/GraphMol/RGroupDecomposition/RGroupDecompData.h
@@ -100,6 +100,8 @@ struct RGroupDecompData {
       std::string dLabel = "R" + std::to_string(rlabel);
       atom->setProp(common_properties::dummyLabel, dLabel);
       setAtomRLabel(atom, rlabel);
+    } else {
+      atom->clearProp(common_properties::dummyLabel);
     }
 
     if (params.rgroupLabelling & Isotope) {

--- a/Code/GraphMol/RGroupDecomposition/catch_rgd.cpp
+++ b/Code/GraphMol/RGroupDecomposition/catch_rgd.cpp
@@ -732,3 +732,50 @@ TEST_CASE("rgroupLabelling") {
     }
   }
 }
+
+TEST_CASE("MDL R labels from original core") {
+  std::vector<std::string> smis = {"C1CN[C@H]1F", "C1CN[C@]1(O)F",
+                                   "C1CN[C@@H]1F", "C1CN[CH]1F"};
+  auto mols = smisToMols(smis);
+  std::vector<std::string> csmis = {"[*]C1CCN1 |$_R1;;;;$|"};
+  auto cores = smisToMols(csmis);
+  SECTION("Map") {
+    RGroupRows rows;
+    std::vector<unsigned> unmatched;
+    RGroupDecompositionParameters params;
+    params.allowMultipleRGroupsOnUnlabelled = true;
+    params.rgroupLabelling = RGroupLabelling::AtomMap;
+    {
+      auto n = RGroupDecompose(cores, mols, rows, &unmatched, params);
+      CHECK(n == mols.size());
+      CHECK(rows.size() == n);
+      CHECK(unmatched.empty());
+      CHECK(rows[0]["Core"]->getAtomWithIdx(4)->getAtomicNum() == 0);
+      CHECK(!rows[0]["Core"]->getAtomWithIdx(4)->hasProp(
+          common_properties::dummyLabel));
+      CHECK(rows[0]["Core"]->getAtomWithIdx(5)->getAtomicNum() == 0);
+      CHECK(!rows[0]["Core"]->getAtomWithIdx(5)->hasProp(
+          common_properties::dummyLabel));
+    }
+  }
+  SECTION("Map | MDL") {
+    RGroupRows rows;
+    std::vector<unsigned> unmatched;
+    RGroupDecompositionParameters params;
+    params.allowMultipleRGroupsOnUnlabelled = true;
+    params.rgroupLabelling =
+        RGroupLabelling::AtomMap | RGroupLabelling::MDLRGroup;
+    {
+      auto n = RGroupDecompose(cores, mols, rows, &unmatched, params);
+      CHECK(n == mols.size());
+      CHECK(rows.size() == n);
+      CHECK(unmatched.empty());
+      CHECK(rows[0]["Core"]->getAtomWithIdx(4)->getAtomicNum() == 0);
+      CHECK(rows[0]["Core"]->getAtomWithIdx(4)->hasProp(
+          common_properties::dummyLabel));
+      CHECK(rows[0]["Core"]->getAtomWithIdx(5)->getAtomicNum() == 0);
+      CHECK(rows[0]["Core"]->getAtomWithIdx(5)->hasProp(
+          common_properties::dummyLabel));
+    }
+  }
+}


### PR DESCRIPTION
This is a simple fix to stop propagating RGroup labels from the input core to the output cores in cases when we haven't requested that this should happen.

Here's an example.

The core used for RGD:
![image](https://user-images.githubusercontent.com/540511/209776958-bb6e036b-9163-428a-bf25-14d432ed49f9.png)

And then the `"Core"` element from one of the result rows after doing an RGD with `rgdps.rgroupLabelling = rdRGroupDecomposition.RGroupLabelling.AtomMap`:
![image](https://user-images.githubusercontent.com/540511/209777139-5dae0daa-5574-4382-a408-19b67d0da34d.png)

Notice that the two "extra" attachment points are correct: they just have the atom map, but the three original attachments are still carrying the R group labels from the input core. What we should get is this:
![image](https://user-images.githubusercontent.com/540511/209777643-42c160b9-03f3-45e0-8ddf-3dc59880ac1e.png)
