### PR TITLE
Add info about mergeHs to README.

### DIFF
--- a/Data/Pains/README.md
+++ b/Data/Pains/README.md
@@ -10,3 +10,8 @@ Cheminformatics Libraries. Mol. Inform. 30, 847–850 (2011).
 Many of the individual SMARTS definitions have been edited in order to
 get them working properly with the RDKit.
 
+Note that these SMARTS contain explicit hydrogen atoms, so are best
+used with merged H queries, such as with the mergeHs=True option in
+MolFromSmarts.  See Greg's blogpost
+http://rdkit.blogspot.com/2015/08/curating-pains-filters.html for more
+information.


### PR DESCRIPTION
#### Reference Issue
No issue


#### What does this implement/fix? Explain your changes.
Adds a note to the PAINS README about explicit Hs.

#### Any other comments?
When I came to use the PAINS SMARTS recently, I got bad results because I hadn't realised that the SMARTS have explicit H atoms that need extra treatment.  This is so other people have less excuse for making the same error.
