### PR TITLE
Fix computation of distance betwen MHFP fingerprints

### DIFF
--- a/Code/GraphMol/Fingerprints/MHFP.h
+++ b/Code/GraphMol/Fingerprints/MHFP.h
@@ -228,13 +228,13 @@ class RDKIT_FINGERPRINTS_EXPORT MHFPEncoder {
       unsigned char min_radius = 1, size_t length = 2048);
 
   /*!
-    \brief Calculates the Jaccard / Tanimoto distance between two MHFP
+    \brief Calculates the Hamming distance between two MHFP
            fingerprints.
 
     \param a an MHFP fingerprint vector.
     \param b an MHFP fingerprint vector.
 
-    \returns the Jaccard / Tanimoto distance between the two fingerprints.
+    \returns the Hamming distance between the two fingerprints.
    */
   static double Distance(const std::vector<uint32_t>& a,
                          const std::vector<uint32_t>& b) {

--- a/Code/GraphMol/Fingerprints/MHFP.h
+++ b/Code/GraphMol/Fingerprints/MHFP.h
@@ -238,15 +238,15 @@ class RDKIT_FINGERPRINTS_EXPORT MHFPEncoder {
    */
   static double Distance(const std::vector<uint32_t>& a,
                          const std::vector<uint32_t>& b) {
-    size_t matches = 0;
+    size_t mismatches = 0;
 
     for (size_t i = 0; i < a.size(); i++) {
-      if (a[i] == b[i]) {
-        matches++;
+      if (a[i] != b[i]) {
+        mismatches++;
       }
     }
 
-    return matches / (double)a.size();
+    return mismatches / (double)a.size();
   }
 
  private:

--- a/Code/GraphMol/Fingerprints/Wrap/testMHFP.py
+++ b/Code/GraphMol/Fingerprints/Wrap/testMHFP.py
@@ -20,7 +20,7 @@ class TestCase(unittest.TestCase):
   def testMHFPDistance(self):
     s = "CN1C=NC2=C1C(=O)N(C(=O)N2C)C"
     enc = rdMHFPFingerprint.MHFPEncoder(128, 42)
-    fp = enc.EncodeSmiles(m)
+    fp = enc.EncodeSmiles(s)
     dist = enc.Distance(fp, fp)
     self.assertEqual(dist, 0.0)
 

--- a/Code/GraphMol/Fingerprints/Wrap/testMHFP.py
+++ b/Code/GraphMol/Fingerprints/Wrap/testMHFP.py
@@ -17,6 +17,13 @@ class TestCase(unittest.TestCase):
   def setUp(self):
     pass
 
+  def testMHFPDistance(self):
+    s = "CN1C=NC2=C1C(=O)N(C(=O)N2C)C"
+    enc = rdMHFPFingerprint.MHFPEncoder(128, 42)
+    fp = enc.EncodeSmiles(m)
+    dist = enc.Distance(fp, fp)
+    self.assertEqual(dist, 0.0)
+
   def testMHFPFingerprint(self):
     s = "CN1C=NC2=C1C(=O)N(C(=O)N2C)C"
     t = "Cn1cnc2c1c(=O)[nH]c(=O)n2C"

--- a/Code/GraphMol/Fingerprints/Wrap/testMHFP.py
+++ b/Code/GraphMol/Fingerprints/Wrap/testMHFP.py
@@ -47,7 +47,7 @@ class TestCase(unittest.TestCase):
 
     fp_c = enc.EncodeSmiles(t)
     dist = rdMHFPFingerprint.MHFPEncoder.Distance(fp_a, fp_c)
-    self.assertEqual(dist, 0.4609375)
+    self.assertEqual(dist, 0.5390625)
 
 
 if __name__ == "__main__":

--- a/Code/GraphMol/Fingerprints/testMHFPFingerprint.cpp
+++ b/Code/GraphMol/Fingerprints/testMHFPFingerprint.cpp
@@ -139,7 +139,10 @@ void testMHFPDistance() {
   auto fp_t = enc.Encode(t);
 
   TEST_ASSERT(
-      feq(MHFPFingerprints::MHFPEncoder::Distance(fp_s, fp_t), 0.2890625));
+      feq(MHFPFingerprints::MHFPEncoder::Distance(fp_s, fp_s), 0.0));
+
+  TEST_ASSERT(
+      feq(MHFPFingerprints::MHFPEncoder::Distance(fp_s, fp_t), 0.7109375));
 
   BOOST_LOG(rdErrorLog) << "  done" << std::endl;
 }


### PR DESCRIPTION
#### Reference Issue

Fixes #5919.

#### What does this implement/fix? Explain your changes.

This PR makes the `MHFPEncoder::Distance` compute a proper distance between two fingerprints, instead of a similarity like it currently does. The docstring was changed to indicate that it computes a Hamming distance rather than a Jaccard distance.

#### Any other comments?

I added a test to make sure the distance from a fingerprint to itself is zero.
