### PR TITLE
Draw atom index

### DIFF
--- a/Code/GraphMol/MolDraw2D/DrawMol.cpp
+++ b/Code/GraphMol/MolDraw2D/DrawMol.cpp
@@ -171,10 +171,10 @@ void DrawMol::initDrawMolecule(const ROMol &mol) {
     addStereoAnnotation(*drawMol_);
   }
   if (drawOptions_.addAtomIndices) {
-    addAtomIndices(*drawMol_);
+    addAtomIndices(*drawMol_, drawOptions_.atomIndexOffset);
   }
   if (drawOptions_.addBondIndices) {
-    addBondIndices(*drawMol_);
+    addBondIndices(*drawMol_, drawOptions_.bondIndexOffset);
   }
 }
 

--- a/Code/GraphMol/MolDraw2D/MolDraw2DDetails.h
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DDetails.h
@@ -61,7 +61,8 @@ RDKIT_MOLDRAW2D_EXPORT void addStereoAnnotation(
     const ROMol &mol, bool includeRelativeCIP = false);
 
 //! add annotations with atom indices.
-RDKIT_MOLDRAW2D_EXPORT inline void addAtomIndices(const ROMol &mol) {
+RDKIT_MOLDRAW2D_EXPORT inline void addAtomIndices(const ROMol &mol,
+                                                  unsigned int offset = 0) {
   // we don't need this in the global set of tags since it will only be used
   // here
   if (mol.hasProp("_atomIndicesAdded")) {
@@ -70,7 +71,7 @@ RDKIT_MOLDRAW2D_EXPORT inline void addAtomIndices(const ROMol &mol) {
   bool computed = true;
   mol.setProp("_atomIndicesAdded", 1, computed);
   for (auto atom : mol.atoms()) {
-    auto lab = std::to_string(atom->getIdx());
+    auto lab = std::to_string(atom->getIdx() + offset);
     if (atom->hasProp(common_properties::atomNote)) {
       lab += "," + atom->getProp<std::string>(common_properties::atomNote);
     }
@@ -79,7 +80,8 @@ RDKIT_MOLDRAW2D_EXPORT inline void addAtomIndices(const ROMol &mol) {
 };
 
 //! add annotations with bond indices.
-RDKIT_MOLDRAW2D_EXPORT inline void addBondIndices(const ROMol &mol) {
+RDKIT_MOLDRAW2D_EXPORT inline void addBondIndices(const ROMol &mol,
+                                                  unsigned int offset = 0) {
   // we don't need this in the global set of tags since it will only be used
   // here
   if (mol.hasProp("_bondIndicesAdded")) {
@@ -88,7 +90,7 @@ RDKIT_MOLDRAW2D_EXPORT inline void addBondIndices(const ROMol &mol) {
   bool computed = true;
   mol.setProp("_bondIndicesAdded", 1, computed);
   for (auto bond : mol.bonds()) {
-    auto lab = std::to_string(bond->getIdx());
+    auto lab = std::to_string(bond->getIdx() + offset);
     if (bond->hasProp(common_properties::bondNote)) {
       lab += "," + bond->getProp<std::string>(common_properties::bondNote);
     }

--- a/Code/GraphMol/MolDraw2D/MolDraw2DHelpers.h
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DHelpers.h
@@ -228,10 +228,12 @@ struct RDKIT_MOLDRAW2D_EXPORT MolDrawOptions {
                         // 0.0, fixedScale wins.
   double rotate = 0.0;  // angle in degrees to rotate coords by about centre
                         // before drawing.
-  bool addAtomIndices = false;     // adds atom indices to drawings.
-  bool addBondIndices = false;     // adds bond indices to drawings.
-  bool isotopeLabels = true;       // adds isotope to non-dummy atoms.
-  bool dummyIsotopeLabels = true;  // adds isotope labels to dummy atoms.
+  bool addAtomIndices = false;       // adds atom indices to drawings.
+  unsigned int atomIndexOffset = 0;  // offset for the atom indices
+  bool addBondIndices = false;       // adds bond indices to drawings.
+  unsigned int bondIndexOffset = 0;  // offset for the atom indices
+  bool isotopeLabels = true;         // adds isotope to non-dummy atoms.
+  bool dummyIsotopeLabels = true;    // adds isotope labels to dummy atoms.
 
   bool addStereoAnnotation = false;       // adds E/Z and R/S to drawings.
   bool atomHighlightsAreCircles = false;  // forces atom highlights always to be

--- a/Code/GraphMol/MolDraw2D/MolDraw2DUtils.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DUtils.cpp
@@ -198,7 +198,9 @@ void updateMolDrawOptionsFromJSON(MolDrawOptions &opts,
   PT_OPT_GET(fixedBondLength);
   PT_OPT_GET(rotate);
   PT_OPT_GET(addAtomIndices);
+  PT_OPT_GET(atomIndexOffset);
   PT_OPT_GET(addBondIndices);
+  PT_OPT_GET(bondIndexOffset);
   PT_OPT_GET(isotopeLabels);
   PT_OPT_GET(dummyIsotopeLabels);
   PT_OPT_GET(addStereoAnnotation);

--- a/Code/GraphMol/MolDraw2D/Wrap/rdMolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/Wrap/rdMolDraw2D.cpp
@@ -848,8 +848,14 @@ BOOST_PYTHON_MODULE(rdMolDraw2D) {
                      "adds R/S and E/Z to drawings. Default False.")
       .def_readwrite("addAtomIndices", &RDKit::MolDrawOptions::addAtomIndices,
                      "adds atom indices to drawings. Default False.")
+      .def_readwrite("atomIndexOffset", &RDKit::MolDrawOptions::atomIndexOffset,
+                     "Offset added to all indices drawn as a result of"
+                     " addAtomIndices. Default 0.")
       .def_readwrite("addBondIndices", &RDKit::MolDrawOptions::addBondIndices,
                      "adds bond indices to drawings. Default False.")
+      .def_readwrite("bondIndexOffset", &RDKit::MolDrawOptions::bondIndexOffset,
+                     "Offset added to all indices drawn as a result of"
+                     " addBondIndices. Default 0.")
       .def_readwrite("isotopeLabels", &RDKit::MolDrawOptions::isotopeLabels,
                      "adds isotope labels on non-dummy atoms. Default True.")
       .def_readwrite("dummyIsotopeLabels",

--- a/Code/GraphMol/MolDraw2D/Wrap/testMolDraw2D.py
+++ b/Code/GraphMol/MolDraw2D/Wrap/testMolDraw2D.py
@@ -758,9 +758,7 @@ M  END''')
     m = Chem.MolFromSmiles("CS(=O)(=O)COC(=N)c1cc(Cl)cnc1[NH3+]")
     AllChem.Compute2DCoords(m)
     rdMolDraw2D.PrepareMolForDrawing(m)
-    print('prepped')
     svg = rdMolDraw2D.MolToACS1996SVG(m, "ACS Mode")
-    print(svg)
     with open("testACSMode_1.svg", 'w') as f:
       f.write(svg)
 

--- a/Code/GraphMol/MolDraw2D/Wrap/testMolDraw2D.py
+++ b/Code/GraphMol/MolDraw2D/Wrap/testMolDraw2D.py
@@ -758,7 +758,9 @@ M  END''')
     m = Chem.MolFromSmiles("CS(=O)(=O)COC(=N)c1cc(Cl)cnc1[NH3+]")
     AllChem.Compute2DCoords(m)
     rdMolDraw2D.PrepareMolForDrawing(m)
+    print('prepped')
     svg = rdMolDraw2D.MolToACS1996SVG(m, "ACS Mode")
+    print(svg)
     with open("testACSMode_1.svg", 'w') as f:
       f.write(svg)
 
@@ -783,6 +785,20 @@ M  END''')
       drawer.FinishDrawing()
       drawer.WriteDrawingText('testACSMode_1.png')
 
+  def testIndexOffset(self):
+    m = Chem.MolFromSmiles('CCc1ccccc1')
+    AllChem.Compute2DCoords(m)
+    rdMolDraw2D.PrepareMolForDrawing(m)
+    d2d = Draw.MolDraw2DSVG(300, 300, 500, 500, True)
+    d2d.drawOptions().addAtomIndices = True
+    d2d.drawOptions().atomIndexOffset = 11
+    d2d.drawOptions().addBondIndices = True
+    d2d.drawOptions().bondIndexOffset = 1
+    d2d.DrawMolecule(m)
+    svg = d2d.GetDrawingText()
+    re_str = r">0</text>"
+    patt = re.compile(re_str)
+    self.assertEqual(len(patt.findall(svg)), 0)
 
 if __name__ == "__main__":
   unittest.main()

--- a/Code/GraphMol/MolDraw2D/catch_tests.cpp
+++ b/Code/GraphMol/MolDraw2D/catch_tests.cpp
@@ -250,7 +250,9 @@ static const std::map<std::string, std::hash_result_t> SVG_HASHES = {
     {"testGithub5486_1.svg", 1149144091U},
     {"testGithub5511_1.svg", 940106456U},
     {"testGithub5511_2.svg", 1448975272U},
-    {"test_github5767.svg", 3153964439U}};
+    {"test_github5767.svg", 3153964439U},
+    {"indexOffsets_1.svg", 3071987767U},
+    {"indexOffsets_2.svg", 3207690302U}};
 
 // These PNG hashes aren't completely reliable due to floating point cruft,
 // but they can still reduce the number of drawings that need visual
@@ -6208,5 +6210,50 @@ M  END
       REQUIRE(match_count == 2);
     }
     check_file_hash(nameBase + ".svg");
+  }
+}
+
+TEST_CASE("Add offset to atom and bond indices") {
+  std::string nameBase("indexOffsets_");
+  std::regex zeroes(">0</text>");
+  SECTION("Default") {
+    auto m1 = "CCc1ccccc1"_smiles;
+    REQUIRE(m1);
+    MolDraw2DSVG drawer(500, 500, 500, 500, NO_FREETYPE);
+    drawer.drawOptions().addAtomIndices = true;
+    drawer.drawOptions().addBondIndices = true;
+    drawer.drawMolecule(*m1);
+    drawer.finishDrawing();
+    std::string text = drawer.getDrawingText();
+    std::ofstream outs(nameBase + "1.svg");
+    outs << text;
+    outs.flush();
+    outs.close();
+    check_file_hash(nameBase + "1.svg");
+    std::ptrdiff_t const match_count(
+        std::distance(std::sregex_iterator(text.begin(), text.end(), zeroes),
+                      std::sregex_iterator()));
+    REQUIRE(match_count == 2);
+  }
+  SECTION("Test") {
+    auto m1 = "CCc1ccccc1"_smiles;
+    REQUIRE(m1);
+    MolDraw2DSVG drawer(500, 500, 500, 500, NO_FREETYPE);
+    drawer.drawOptions().addAtomIndices = true;
+    drawer.drawOptions().atomIndexOffset = 11;
+    drawer.drawOptions().addBondIndices = true;
+    drawer.drawOptions().bondIndexOffset = 1;
+    drawer.drawMolecule(*m1);
+    drawer.finishDrawing();
+    std::string text = drawer.getDrawingText();
+    std::ofstream outs(nameBase + "2.svg");
+    outs << text;
+    outs.flush();
+    outs.close();
+    check_file_hash(nameBase + "2.svg");
+    std::ptrdiff_t const match_count(
+        std::distance(std::sregex_iterator(text.begin(), text.end(), zeroes),
+                      std::sregex_iterator()));
+    REQUIRE(match_count == 0);
   }
 }


### PR DESCRIPTION
#### Reference Issue
No issue

#### What does this implement/fix? Explain your changes.
Adds the drawOptions atomIndexOffset and bondAtomOffset so that you can change the start point of the indices when using drawOptions().addAtomIndices and .addBondIndices.

#### Any other comments?
When comparing a drawing with a file, it is very irritating when one is numbered from 0 and the other from 1!
