### PR TITLE
Fix drawing of circles in extractVariableBonds.

### DIFF
--- a/Code/GraphMol/MolDraw2D/DrawMol.cpp
+++ b/Code/GraphMol/MolDraw2D/DrawMol.cpp
@@ -538,7 +538,7 @@ void DrawMol::extractVariableBonds() {
         auto center = atCds_[oat];
         Point2D offset{drawOptions_.variableAtomRadius,
                        drawOptions_.variableAtomRadius};
-        std::vector<Point2D> points{center + offset, center - offset};
+        std::vector<Point2D> points{center, offset};
         DrawShapeEllipse *ell = new DrawShapeEllipse(
             points, 1, true, drawOptions_.variableAttachmentColour, true, oat);
         preShapes_.emplace_back(ell);

--- a/Code/GraphMol/MolDraw2D/catch_tests.cpp
+++ b/Code/GraphMol/MolDraw2D/catch_tests.cpp
@@ -251,7 +251,7 @@ static const std::map<std::string, std::hash_result_t> SVG_HASHES = {
     {"testGithub5511_1.svg", 940106456U},
     {"testGithub5511_2.svg", 1448975272U},
     {"test_github5767.svg", 3153964439U},
-    {"test_github5943.svg", 2605298574U}};
+    {"test_github5943.svg", 3591000538U}};
 
 // These PNG hashes aren't completely reliable due to floating point cruft,
 // but they can still reduce the number of drawings that need visual
@@ -6277,8 +6277,8 @@ M  END
     auto match_end = std::sregex_iterator();
     for (std::sregex_iterator i = match_begin; i != match_end; ++i) {
       std::smatch match = *i;
-      REQUIRE_THAT(stod(match[1]), Catch::Matchers::WithinRel(25.2, 0.1));
-      REQUIRE_THAT(stod(match[2]), Catch::Matchers::WithinRel(25.2, 0.1));
+      REQUIRE_THAT(stod(match[1]), Catch::Matchers::WithinAbs(25.2, 0.1));
+      REQUIRE_THAT(stod(match[2]), Catch::Matchers::WithinAbs(25.2, 0.1));
     }
     check_file_hash(nameBase + ".svg");
   }


### PR DESCRIPTION

#### Reference Issue
Fixes issue #5943


#### What does this implement/fix? Explain your changes.
The ellipses weren't being drawn correctly.

#### Any other comments?
When I changed the interface for DrawEllipse to take a centre and radii, I obviously failed to fix this instance which was still using the old foci method.  Sorry.
When looking at the output, I saw that DrawEllipse::findExtremes() is also living in the old world, so the ferrocene picture is still wrong - the upper circles are cutoff.  I will do this as a separate PR as it feels like a separate bug to me.
