### PR TITLE
Fix ellipse extremes calculation.

### DIFF
--- a/Code/GraphMol/MolDraw2D/DrawShape.cpp
+++ b/Code/GraphMol/MolDraw2D/DrawShape.cpp
@@ -168,14 +168,11 @@ void DrawShapeEllipse::myDraw(MolDraw2D &drawer) const {
 // ****************************************************************************
 void DrawShapeEllipse::findExtremes(double &xmin, double &xmax, double &ymin,
                                     double &ymax) const {
-  auto wb2 = points_[1].x;
-  auto hb2 = points_[1].y;
-  auto cx = points_[0].x + wb2;
-  auto cy = points_[0].y + hb2;
-  xmin = std::min(cx - wb2, xmin);
-  xmax = std::max(cx + wb2, xmax);
-  ymin = std::min(cy - hb2, ymin);
-  ymax = std::max(cy + hb2, ymax);
+  // points_[0] is the centre, points_[1] the radii
+  xmin = std::min(points_[0].x - points_[1].x, xmin);
+  xmax = std::max(points_[0].x + points_[1].x, xmax);
+  ymin = std::min(points_[0].y - points_[1].y, ymin);
+  ymax = std::max(points_[0].y + points_[1].y, ymax);
 }
 
 // ****************************************************************************

--- a/Code/GraphMol/MolDraw2D/catch_tests.cpp
+++ b/Code/GraphMol/MolDraw2D/catch_tests.cpp
@@ -204,9 +204,9 @@ static const std::map<std::string, std::hash_result_t> SVG_HASHES = {
     {"testFlexiCanvas.7b.svg", 4094511140U},
     {"testFlexiCanvas.7c.svg", 918094125U},
     {"testFlexiCanvas.7d.svg", 918094125U},
-    {"testGithub4764.sz1.svg", 493786705U},
-    {"testGithub4764.sz2.svg", 2704253898U},
-    {"testGithub4764.sz3.svg", 1328896014U},
+    {"testGithub4764.sz1.svg", 1112373450U},
+    {"testGithub4764.sz2.svg", 3676136052U},
+    {"testGithub4764.sz3.svg", 2565894452U},
     {"testDrawArc1.svg", 4039810147U},
     {"testMetalWedges.svg", 3278785383U},
     {"testVariableLegend_1.svg", 3914441319U},
@@ -214,8 +214,8 @@ static const std::map<std::string, std::hash_result_t> SVG_HASHES = {
     {"testVariableLegend_3.svg", 1996551457U},
     {"testGithub_5061.svg", 1947248304U},
     {"testGithub_5185.svg", 2944445711U},
-    {"testGithub_5269_1.svg", 2368496794U},
-    {"testGithub_5269_2.svg", 567813292U},
+    {"testGithub_5269_1.svg", 2884233026U},
+    {"testGithub_5269_2.svg", 2987891082U},
     {"test_classes_wavy_bonds.svg", 1271445012U},
     {"testGithub_5383_1.svg", 1391972140U},
     {"github5156_1.svg", 695855770U},
@@ -229,11 +229,11 @@ static const std::map<std::string, std::hash_result_t> SVG_HASHES = {
     {"acs1996_4.svg", 3372558370U},
     {"acs1996_5.svg", 2883542240U},
     {"acs1996_6.svg", 1380727178U},
-    {"acs1996_7.svg", 763391533U},
+    {"acs1996_7.svg", 2718384395U},
     {"acs1996_8.svg", 939325262U},
     {"acs1996_9.svg", 2607143500U},
     {"acs1996_10.svg", 199499735U},
-    {"acs1996_11.svg", 2121789178U},
+    {"acs1996_11.svg", 3821838912U},
     {"acs1996_12.svg", 2233727631U},
     {"test_unspec_stereo.svg", 599119798U},
     {"light_blue_h_no_label_1.svg", 3735371135U},
@@ -241,7 +241,7 @@ static const std::map<std::string, std::hash_result_t> SVG_HASHES = {
     {"bond_highlights_1.svg", 1426179967U},
     {"bond_highlights_2.svg", 3654242474U},
     {"bond_highlights_3.svg", 2068128924U},
-    {"bond_highlights_4.svg", 4115973245U},
+    {"bond_highlights_4.svg", 2068128924U},
     {"bond_highlights_5.svg", 4115973245U},
     {"bond_highlights_6.svg", 1566801788U},
     {"bond_highlights_7.svg", 2101261688U},
@@ -250,7 +250,8 @@ static const std::map<std::string, std::hash_result_t> SVG_HASHES = {
     {"testGithub5486_1.svg", 1149144091U},
     {"testGithub5511_1.svg", 940106456U},
     {"testGithub5511_2.svg", 1448975272U},
-    {"test_github5767.svg", 3153964439U}};
+    {"test_github5767.svg", 3153964439U},
+    {"test_github5944.svg", 2858910387U}};
 
 // These PNG hashes aren't completely reliable due to floating point cruft,
 // but they can still reduce the number of drawings that need visual
@@ -6209,4 +6210,41 @@ M  END
     }
     check_file_hash(nameBase + ".svg");
   }
+}
+
+TEST_CASE("Github5944: Ellipse extremes not calculated correctly.") {
+  std::string nameBase = "test_github5944";
+  auto m = "c1ccccn1"_smiles;
+  TEST_ASSERT(m);
+  RDDepict::compute2DCoords(*m);
+  std::vector<int> highlight_atoms{0, 1, 2, 3, 4, 5};
+  MolDraw2DSVG drawer(400, 400);
+  drawer.drawOptions().highlightRadius = 1.0;
+  drawer.drawMolecule(*m, &highlight_atoms);
+  drawer.finishDrawing();
+  std::string text = drawer.getDrawingText();
+  std::ofstream outs(nameBase + ".svg");
+  outs << text;
+  outs.flush();
+  outs.close();
+  std::regex r1("<ellipse cx=.*rx='(\\d+\\.\\d+)' ry='(\\d+\\.\\d+)'");
+  std::ptrdiff_t const match_count(
+      std::distance(std::sregex_iterator(text.begin(), text.end(), r1),
+                    std::sregex_iterator()));
+  REQUIRE(match_count == 6);
+  // all the ellipses should have a radius of roughly 28.8
+  auto match_begin = std::sregex_iterator(text.begin(), text.end(), r1);
+  auto match_end = std::sregex_iterator();
+  for (std::sregex_iterator i = match_begin; i != match_end; ++i) {
+    std::smatch match = *i;
+    REQUIRE_THAT(stod(match[1]), Catch::Matchers::WithinAbs(72.7, 0.1));
+    REQUIRE_THAT(stod(match[2]), Catch::Matchers::WithinAbs(72.7, 0.1));
+  }
+
+  // check that the first ellipse is in the right place
+  std::regex r2("<ellipse cx='(\\d+\\.\\d+)' cy='(\\d+\\.\\d+)'");
+  auto ell1 = *std::sregex_iterator(text.begin(), text.end(), r2);
+  REQUIRE_THAT(stod(ell1[1]), Catch::Matchers::WithinAbs(309.1, 0.1));
+  REQUIRE_THAT(stod(ell1[2]), Catch::Matchers::WithinAbs(200.0, 0.1));
+  check_file_hash(nameBase + ".svg");
 }

--- a/Code/GraphMol/MolDraw2D/catch_tests.cpp
+++ b/Code/GraphMol/MolDraw2D/catch_tests.cpp
@@ -251,7 +251,7 @@ static const std::map<std::string, std::hash_result_t> SVG_HASHES = {
     {"testGithub5511_1.svg", 940106456U},
     {"testGithub5511_2.svg", 1448975272U},
     {"test_github5767.svg", 3153964439U},
-    {"test_github5944.svg", 2858910387U}};
+    {"test_github5944.svg", 2858910387U},
     {"test_github5943.svg", 3591000538U}};
 
 // These PNG hashes aren't completely reliable due to floating point cruft,

--- a/Code/GraphMol/MolDraw2D/test1.cpp
+++ b/Code/GraphMol/MolDraw2D/test1.cpp
@@ -147,9 +147,9 @@ static const std::map<std::string, std::hash_result_t> SVG_HASHES = {
     {"testGithub2151_1.svg", 1918752877U},
     {"testGithub2151_2.svg", 1083134500U},
     {"testGithub2762.svg", 3596783817U},
-    {"testGithub2931_1.svg", 142684703U},
-    {"testGithub2931_2.svg", 2810684425U},
-    {"testGithub2931_3.svg", 1660359809U},
+    {"testGithub2931_1.svg", 693663479U},
+    {"testGithub2931_2.svg", 3778210869U},
+    {"testGithub2931_3.svg", 193145443U},
     {"testGithub2931_4.svg", 482738203U},
     {"test20_1.svg", 2825906479U},
     {"test20_2.svg", 4276100014U},
@@ -166,10 +166,10 @@ static const std::map<std::string, std::hash_result_t> SVG_HASHES = {
     {"testGithub3305_1.svg", 3716192373U},
     {"testGithub3305_2.svg", 3910798383U},
     {"testGithub3305_3.svg", 2665156605U},
-    {"testGithub3305_4.svg", 2728740111U},
+    {"testGithub3305_4.svg", 1670626902U},
     {"testGithub3305_5.svg", 1179617427U},
-    {"testGithub3305_6.svg", 1519168307U},
-    {"testGithub3305_7.svg", 1630290653U},
+    {"testGithub3305_6.svg", 3054235056U},
+    {"testGithub3305_7.svg", 1596380276U},
     {"testGithub3391_1.svg", 288775907U},
     {"testGithub3391_2.svg", 1622649910U},
     {"testGithub3391_3.svg", 1181362285U},
@@ -204,11 +204,11 @@ static const std::map<std::string, std::hash_result_t> SVG_HASHES = {
     {"testGithub781_4.svg", 1077101569U},
     {"testGithub781_5.svg", 2840696942U},
     {"testGithub781_6.svg", 2700448827U},
-    {"test3_1.svg", 1363605249U},
-    {"test3_2.svg", 2318238862U},
-    {"test3_3.svg", 4168477373U},
-    {"test3_4.svg", 1709145620U},
-    {"test3_5.svg", 964166328U},
+    {"test3_1.svg", 1241966223U},
+    {"test3_2.svg", 927906254U},
+    {"test3_3.svg", 3988208781U},
+    {"test3_4.svg", 3027798833U},
+    {"test3_5.svg", 2661072681U},
     {"test3_6.svg", 256911461U},
     {"test3_7.svg", 66698678U},
     {"test774_1.svg", 2029651525U},
@@ -241,7 +241,7 @@ static const std::map<std::string, std::hash_result_t> SVG_HASHES = {
     {"test11_1.svg", 1028126625U},
     {"test11_2.svg", 477557493U},
     {"test12_1.svg", 631306156U},
-    {"test12_5.svg", 2201316408U},
+    {"test12_5.svg", 1750509173U},
     {"test12_3.svg", 16113602U},
     {"test12_4.svg", 16113602U},
     {"test12_2.svg", 1452987726U},
@@ -256,31 +256,31 @@ static const std::map<std::string, std::hash_result_t> SVG_HASHES = {
     {"test1322_2.svg", 1382784658U},
     {"test14_1.svg", 1475926171U},
     {"test14_2.svg", 3223472512U},
-    {"test15_1.svg", 325436032U},
-    {"test15_2.svg", 352325982U},
+    {"test15_1.svg", 3113318468U},
+    {"test15_2.svg", 1455694564U},
     {"test17_1.svg", 1811940907U},
     {"test17_2.svg", 3757523250U},
     {"test17_3.svg", 2059010246U},
     {"test17_4.svg", 42680801U},
     {"test18_1.svg", 493222951U},
     {"test18_2.svg", 2876018791U},
-    {"test18_3.svg", 4007812293U},
+    {"test18_3.svg", 4036951369U},
     {"test18_4.svg", 1284506858U},
-    {"test18_5.svg", 3557731891U},
+    {"test18_5.svg", 218831462U},
     {"test18_6.svg", 1820858874U},
     {"test18_7.svg", 3518982455U},
     {"test19_1.svg", 3328535680U},
-    {"test19_2.svg", 1269204426U},
+    {"test19_2.svg", 3224482391U},
     {"test16_1.svg", 1272585497U},
     {"test16_2.svg", 3272808667U},
     {"testGithub2063_1.svg", 109222729U},
     {"testGithub2063_2.svg", 109222729U},
-    {"testGithub2151_1.svg", 3217916286U},
-    {"testGithub2151_2.svg", 1577439214U},
+    {"testGithub2151_1.svg", 3702926947U},
+    {"testGithub2151_2.svg", 3046330798U},
     {"testGithub2762.svg", 2006115844U},
-    {"testGithub2931_1.svg", 2507461278U},
-    {"testGithub2931_2.svg", 1387494760U},
-    {"testGithub2931_3.svg", 3836523103U},
+    {"testGithub2931_1.svg", 613551468U},
+    {"testGithub2931_2.svg", 1553937629U},
+    {"testGithub2931_3.svg", 2638492704U},
     {"testGithub2931_4.svg", 3767525325U},
     {"test20_1.svg", 2210504223U},
     {"test20_2.svg", 3688247726U},
@@ -295,10 +295,10 @@ static const std::map<std::string, std::hash_result_t> SVG_HASHES = {
     {"testGithub3305_1.svg", 3716192373U},
     {"testGithub3305_2.svg", 3910798383U},
     {"testGithub3305_3.svg", 2665156605U},
-    {"testGithub3305_4.svg", 964166328U},
-    {"testGithub3305_5.svg", 4136341695U},
-    {"testGithub3305_6.svg", 427385222U},
-    {"testGithub3305_7.svg", 4144134285U},
+    {"testGithub3305_4.svg", 2661072681U},
+    {"testGithub3305_5.svg", 3349185727U},
+    {"testGithub3305_6.svg", 4236899489U},
+    {"testGithub3305_7.svg", 3822551667U},
     {"testGithub3391_1.svg", 4243890317U},
     {"testGithub3391_2.svg", 2537862118U},
     {"testGithub3391_3.svg", 1822726140U},
@@ -3718,22 +3718,26 @@ void testGithub2931() {
       outs << text;
       outs.flush();
       outs.close();
+      std::regex r1("<ellipse cx='(\\d+\\.\\d+)' cy='(\\d+\\.\\d+)'"
+          " rx='(\\d+\\.\\d+)' ry='(\\d+\\.\\d+)' class='atom-6'");
+      std::smatch match = *std::sregex_iterator(text.begin(), text.end(), r1);
 #ifdef RDK_BUILD_FREETYPE_SUPPORT
 #if DO_TEST_ASSERT
       TEST_ASSERT(text.find("stroke:#FF8C00;stroke-width:8.0px") !=
                   std::string::npos);
-      TEST_ASSERT(
-          text.find("<ellipse cx='240.2' cy='347.7' rx='12.3' ry='12.7' "
-                    "class='atom-6'  style='fill:none;stroke:#00FF00;") !=
-          std::string::npos);
+      // it's an ellipse, so different radii
+      TEST_ASSERT(fabs(stod(match[1]) - 243.8) < 0.1);
+      TEST_ASSERT(fabs(stod(match[2]) - 348.7) < 0.1);
+      TEST_ASSERT(fabs(stod(match[3]) - 12.2) < 0.1);
+      TEST_ASSERT(fabs(stod(match[4]) - 12.5) < 0.1);
 #endif
 #else
       TEST_ASSERT(text.find("stroke:#FF8C00;stroke-width:8.0px") !=
                   std::string::npos);
-      TEST_ASSERT(
-          text.find("<ellipse cx='240.6' cy='295.4' rx='12.4' ry='12.4' "
-                    "class='atom-5'  style='fill:none;stroke:#00FF00") !=
-          std::string::npos);
+      TEST_ASSERT(fabs(stod(match[1]) - 243.3) < 0.1);
+      TEST_ASSERT(fabs(stod(match[2]) - 348.1) < 0.1);
+      TEST_ASSERT(fabs(stod(match[3]) - 9.8) < 0.1);
+      TEST_ASSERT(fabs(stod(match[4]) - 11.1) < 0.1);
 #endif
       check_file_hash("testGithub2931_1.svg");
     }
@@ -3750,22 +3754,26 @@ void testGithub2931() {
       outs << text;
       outs.flush();
       outs.close();
+      std::regex r1("<ellipse cx='(\\d+\\.\\d+)' cy='(\\d+\\.\\d+)'"
+          " rx='(\\d+\\.\\d+)' ry='(\\d+\\.\\d+)' class='atom-6'");
+      std::smatch match = *std::sregex_iterator(text.begin(), text.end(), r1);
 #ifdef RDK_BUILD_FREETYPE_SUPPORT
 #if DO_TEST_ASSERT
       TEST_ASSERT(text.find("stroke:#FF8C00;stroke-width:8.0px") !=
                   std::string::npos);
-      TEST_ASSERT(
-          text.find("<ellipse cx='240.2' cy='347.6' rx='12.5' ry='12.5' "
-                    "class='atom-6'  style='fill:none;stroke:#00FF00;") !=
-          std::string::npos);
+      // it's a circle
+      TEST_ASSERT(fabs(stod(match[1]) - 243.8) < 0.1);
+      TEST_ASSERT(fabs(stod(match[2]) - 348.7) < 0.1);
+      TEST_ASSERT(fabs(stod(match[3]) - 12.3) < 0.1);
+      TEST_ASSERT(fabs(stod(match[4]) - 12.3) < 0.1);
 #endif
 #else
       TEST_ASSERT(text.find("stroke:#FF8C00;stroke-width:8.0px") !=
                   std::string::npos);
-      TEST_ASSERT(
-          text.find("<ellipse cx='240.6' cy='295.4' rx='12.4' ry='12.4' "
-                    "class='atom-5'  style='fill:none;stroke:#00FF00;") !=
-          std::string::npos);
+      TEST_ASSERT(fabs(stod(match[1]) - 243.9) < 0.1);
+      TEST_ASSERT(fabs(stod(match[2]) - 346.4) < 0.1);
+      TEST_ASSERT(fabs(stod(match[3]) - 12.2) < 0.1);
+      TEST_ASSERT(fabs(stod(match[4]) - 12.2) < 0.1);
 #endif
       check_file_hash("testGithub2931_2.svg");
     }
@@ -3792,10 +3800,6 @@ void testGithub2931() {
 #else
       TEST_ASSERT(text.find("stroke:#FF8C00;stroke-width:40.0px") !=
                   std::string::npos);
-      TEST_ASSERT(
-          text.find("<ellipse cx='240.6' cy='295.4' rx='12.4' ry='12.4' "
-                    "class='atom-5'  style='fill:none;stroke:#00FF00;") !=
-          std::string::npos);
 #endif
       check_file_hash("testGithub2931_3.svg");
     }


### PR DESCRIPTION
#### Reference Issue
Fixes #5944


#### What does this implement/fix? Explain your changes.
As mentioned in PR5946, the ellipse extremes calculation was wrong, meaning that ellipses at the edge of a drawing might be cut off.

#### Any other comments?
This will break the tests for #5946
