### PR TITLE
stop caching ring-finding results

### DIFF
--- a/Code/GraphMol/ChemReactions/ReactionWriter.cpp
+++ b/Code/GraphMol/ChemReactions/ReactionWriter.cpp
@@ -136,14 +136,18 @@ std::string ChemicalReactionToV3KRxnBlock(const ChemicalReaction &rxn,
   for (const auto &rt : boost::make_iterator_range(
            rxn.beginReactantTemplates(), rxn.endReactantTemplates())) {
     // to write the mol block, we need ring information:
-    MolOps::findSSSR(*rt);
+    if (!rt->getRingInfo()->isInitialized()) {
+      MolOps::findSSSR(*rt);
+    }
     res << FileParserUtils::getV3000CTAB(*rt, -1);
   }
   if (!separateAgents) {
     for (const auto &rt : boost::make_iterator_range(rxn.beginAgentTemplates(),
                                                      rxn.endAgentTemplates())) {
       // to write the mol block, we need ring information:
-      MolOps::findSSSR(*rt);
+      if (!rt->getRingInfo()->isInitialized()) {
+        MolOps::findSSSR(*rt);
+      }
       res << FileParserUtils::getV3000CTAB(*rt, -1);
     }
   }
@@ -152,7 +156,9 @@ std::string ChemicalReactionToV3KRxnBlock(const ChemicalReaction &rxn,
   for (const auto &rt : boost::make_iterator_range(rxn.beginProductTemplates(),
                                                    rxn.endProductTemplates())) {
     // to write the mol block, we need ring information:
-    MolOps::findSSSR(*rt);
+    if (!rt->getRingInfo()->isInitialized()) {
+      MolOps::findSSSR(*rt);
+    }
     res << FileParserUtils::getV3000CTAB(*rt, -1);
   }
   res << "M  V30 END PRODUCT\n";
@@ -192,6 +198,9 @@ std::string ChemicalReactionToRxnBlock(const ChemicalReaction &rxn,
   for (auto iter = rxn.beginReactantTemplates();
        iter != rxn.endReactantTemplates(); ++iter) {
     // to write the mol block, we need ring information:
+    if (!(*iter)->getRingInfo()->isInitialized()) {
+      MolOps::findSSSR(**iter);
+    }
     MolOps::findSSSR(**iter);
     res << "$MOL\n";
     res << MolToMolBlock(**iter, true, -1, false);
@@ -200,7 +209,9 @@ std::string ChemicalReactionToRxnBlock(const ChemicalReaction &rxn,
     for (auto iter = rxn.beginAgentTemplates(); iter != rxn.endAgentTemplates();
          ++iter) {
       // to write the mol block, we need ring information:
-      MolOps::findSSSR(**iter);
+      if (!(*iter)->getRingInfo()->isInitialized()) {
+        MolOps::findSSSR(**iter);
+      }
       res << "$MOL\n";
       res << MolToMolBlock(**iter, true, -1, false);
     }
@@ -208,7 +219,9 @@ std::string ChemicalReactionToRxnBlock(const ChemicalReaction &rxn,
   for (auto iter = rxn.beginProductTemplates();
        iter != rxn.endProductTemplates(); ++iter) {
     // to write the mol block, we need ring information:
-    MolOps::findSSSR(**iter);
+    if (!(*iter)->getRingInfo()->isInitialized()) {
+      MolOps::findSSSR(**iter);
+    }
     res << "$MOL\n";
     res << MolToMolBlock(**iter, true, -1, false);
   }

--- a/Code/GraphMol/FindRings.cpp
+++ b/Code/GraphMol/FindRings.cpp
@@ -858,14 +858,10 @@ int findSSSR(const ROMol &mol, VECT_INT_VECT *res) {
 
 int findSSSR(const ROMol &mol, VECT_INT_VECT &res) {
   res.resize(0);
-  // check if SSSR's are already on the molecule
   if (mol.getRingInfo()->isInitialized()) {
-    res = mol.getRingInfo()->atomRings();
-    return rdcast<int>(res.size());
-  } else {
-    mol.getRingInfo()->initialize();
+    mol.getRingInfo()->reset();
   }
-
+  mol.getRingInfo()->initialize();
   RINGINVAR_SET invars;
 
   unsigned int nats = mol.getNumAtoms();
@@ -1132,11 +1128,7 @@ int symmetrizeSSSR(ROMol &mol, VECT_INT_VECT &res) {
 
   // FIX: need to set flag here the symmetrization has been done in order to
   // avoid repeating this work
-  if (!mol.getRingInfo()->isInitialized()) {
-    findSSSR(mol, sssrs);
-  } else {
-    sssrs = mol.getRingInfo()->atomRings();
-  }
+  findSSSR(mol, sssrs);
 
   res.reserve(sssrs.size());
   for (const auto &r : sssrs) {
@@ -1265,13 +1257,12 @@ void _DFS(const ROMol &mol, const Atom *atom, INT_VECT &atomColors,
 }
 }  // end of anonymous namespace
 void fastFindRings(const ROMol &mol) {
-  // std::cerr<<"ffr"<<std::endl;
-  // check if SSSR's are already on the molecule
   if (mol.getRingInfo()->isInitialized()) {
-    return;
-  } else {
-    mol.getRingInfo()->initialize();
+    mol.getRingInfo()->reset();
   }
+
+  mol.getRingInfo()->initialize();
+
   VECT_INT_VECT res;
   res.resize(0);
 

--- a/Code/GraphMol/MolHash/hashfunctions.cpp
+++ b/Code/GraphMol/MolHash/hashfunctions.cpp
@@ -475,7 +475,9 @@ bool HasNbrInScaffold(Atom *aptr, unsigned char *is_in_scaffold) {
 
 std::string ExtendedMurckoScaffold(RWMol *mol, bool useCXSmiles) {
   PRECONDITION(mol, "bad molecule");
-  RDKit::MolOps::fastFindRings(*mol);
+  if (!mol->getRingInfo()->isInitialized()) {
+    MolOps::fastFindRings(*mol);
+  }
 
   unsigned int maxatomidx = mol->getNumAtoms();
   auto *is_in_scaffold = (unsigned char *)alloca(maxatomidx);
@@ -690,8 +692,10 @@ std::string RegioisomerHash(RWMol *mol, bool useCXSmiles) {
 
   // we need a copy of the molecule so that we can loop over the bonds of
   // something while modifying something else
-  RDKit::MolOps::fastFindRings(*mol);
   RDKit::ROMol molcpy(*mol);
+  if (molcpy.getRingInfo()->isInitialized()) {
+    MolOps::fastFindRings(molcpy);
+  }
   for (int i = molcpy.getNumBonds() - 1; i >= 0; --i) {
     auto bptr = molcpy.getBondWithIdx(i);
     int split = RegioisomerBond(bptr);

--- a/Code/GraphMol/MolStandardize/Normalize.cpp
+++ b/Code/GraphMol/MolStandardize/Normalize.cpp
@@ -119,8 +119,9 @@ ROMOL_SPTR Normalizer::normalizeFragment(
     const ROMol &mol,
     const std::vector<std::shared_ptr<ChemicalReaction>> &transforms) const {
   ROMOL_SPTR nfrag(new ROMol(mol));
-  MolOps::fastFindRings(
-      *nfrag);  // this doesn't do anything if rings are already there
+  if (!nfrag->getRingInfo()->isInitialized()) {
+    MolOps::fastFindRings(*nfrag);
+  }
   std::set<std::string> seenProductSmiles;
   for (unsigned int i = 0; i < MAX_RESTARTS; ++i) {
     bool loop_break = false;

--- a/Code/GraphMol/RingInfo.cpp
+++ b/Code/GraphMol/RingInfo.cpp
@@ -229,6 +229,10 @@ void RingInfo::reset() {
   d_bondMembers.clear();
   d_atomRings.clear();
   d_bondRings.clear();
+#ifdef RDK_USE_URF
+  d_atomRingFamilies.clear();
+  d_bondRingFamilies.clear();
+#endif
 }
 void RingInfo::preallocate(unsigned int numAtoms, unsigned int numBonds) {
   d_atomMembers.resize(numAtoms);

--- a/Code/GraphMol/catch_graphmol.cpp
+++ b/Code/GraphMol/catch_graphmol.cpp
@@ -2895,3 +2895,20 @@ TEST_CASE("Github #5849: aromatic tag allows bad valences to pass") {
     }
   }
 }
+
+TEST_CASE("Stop caching ring finding results") {
+  SECTION("basics") {
+    auto m = "C1C2CC1CCC2"_smiles;
+    REQUIRE(m);
+    // symmetrized result
+    CHECK(m->getRingInfo()->numRings() == 3);
+    auto rcount = MolOps::findSSSR(*m);
+    CHECK(rcount == 2);
+    CHECK(m->getRingInfo()->numRings() == 2);
+    rcount = MolOps::symmetrizeSSSR(*m);
+    CHECK(rcount == 3);
+    CHECK(m->getRingInfo()->numRings() == 3);
+    MolOps::fastFindRings(*m);
+    CHECK(m->getRingInfo()->numRings() == 2);
+  }
+}

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -7,6 +7,8 @@
 
 ## Backwards incompatible changes
 
+- The ring-finding functions will now run even if the molecule already has ring information. Older versions of the RDKit would return whatever ring information was present, even if it had been generated using a different algorithm.
+
 ## Bug Fixes:
 
 ## Cleanup work:


### PR DESCRIPTION
Currently the ring-finding code caches its results, which leads to delightful confusion like this:
```
In [5]: m = Chem.MolFromSmiles('C1C2CC1CCC2')

In [6]: m.GetRingInfo().NumRings()
Out[6]: 3

In [7]: Chem.GetSSSR(m)
Out[7]: <rdkit.rdBase._vectclass std::vector<int,class std::allocator<int> > at 0x20583b62fc0>

In [8]: m.GetRingInfo().NumRings()
Out[8]: 3

In [9]: m = Chem.MolFromSmiles('C1C2CC1CCC2',sanitize=False)

In [10]: m.UpdatePropertyCache()

In [11]: Chem.GetSSSR(m)
Out[11]: <rdkit.rdBase._vectclass std::vector<int,class std::allocator<int> > at 0x20583ca1840>

In [12]: m.GetRingInfo().NumRings()
Out[12]: 2
```
That mess is by design, but it seems like a bug.

This removes the caching so that things are a bit less surprising.

We could add something to be more specific about what we cache, but there's really no reason for people to be calling the ring finding code multiple times on the same molecule, so this seems like wasted effort to me.

Thanks to @fwaibl for pointing out the problem