### PR TITLE
Refactor RGD moving function implementations from header to source files

### DIFF
--- a/Code/GraphMol/RGroupDecomposition/CMakeLists.txt
+++ b/Code/GraphMol/RGroupDecomposition/CMakeLists.txt
@@ -7,9 +7,8 @@ rdkit_library(RGroupDecomposition RGroupDecomp.cpp RGroupDecompData.cpp RGroupDa
 target_compile_definitions(RGroupDecomposition PRIVATE RDKIT_RGROUPDECOMPOSITION_BUILD)
 
 rdkit_headers(
-   RGroupDecomp.h
+   RGroupDecomp.h RGroupDecompParams.h
    DEST GraphMol/RGroupDecomposition)
-
 
 if(RDK_BUILD_PYTHON_WRAPPERS)
 add_subdirectory(Wrap)
@@ -24,11 +23,9 @@ rdkit_test(testRGroupDecompInternals testRGroupInternals.cpp
 rdkit_catch_test(rgroupCatchTests catch_rgd.cpp 
 		LINK_LIBRARIES RGroupDecomposition )
 
-
-
 find_package(Boost ${RDK_BOOST_VERSION} COMPONENTS program_options)
 if(RDK_BUILD_CPP_TESTS AND Boost_FOUND)
-	add_executable(gaExample GaExample.cpp RGroupDecompParams.h)
+	add_executable(gaExample GaExample.cpp)
 	if(NOT Boost_USE_STATIC_LIBS)
 		target_compile_definitions(gaExample PUBLIC -DBOOST_PROGRAM_OPTIONS_DYN_LINK)
 	endif()

--- a/Code/GraphMol/RGroupDecomposition/CMakeLists.txt
+++ b/Code/GraphMol/RGroupDecomposition/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-rdkit_library(RGroupDecomposition RGroupDecomp.cpp RGroupUtils.cpp RGroupCore.cpp
+rdkit_library(RGroupDecomposition RGroupDecomp.cpp RGroupDecompData.cpp RGroupData.cpp RGroupUtils.cpp RGroupCore.cpp
 				  RGroupDecompParams.cpp RGroupScore.cpp RGroupFingerprintScore.cpp RGroupGa.cpp
   LINK_LIBRARIES
   FMCS ChemTransforms SubstructMatch SmilesParse Fingerprints
@@ -28,7 +28,7 @@ rdkit_catch_test(rgroupCatchTests catch_rgd.cpp
 
 find_package(Boost ${RDK_BOOST_VERSION} COMPONENTS program_options)
 if(RDK_BUILD_CPP_TESTS AND Boost_FOUND)
-	add_executable(gaExample GaExample.cpp)
+	add_executable(gaExample GaExample.cpp RGroupDecompParams.h)
 	if(NOT Boost_USE_STATIC_LIBS)
 		target_compile_definitions(gaExample PUBLIC -DBOOST_PROGRAM_OPTIONS_DYN_LINK)
 	endif()

--- a/Code/GraphMol/RGroupDecomposition/RGroupData.cpp
+++ b/Code/GraphMol/RGroupDecomposition/RGroupData.cpp
@@ -1,0 +1,134 @@
+//
+//  Copyright (c) 2017-2023, Novartis Institutes for BioMedical Research Inc.
+//  and other RDKit contributors
+//
+//   @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
+//
+
+#include "RGroupData.h"
+#include <GraphMol/SmilesParse/SmilesWrite.h>
+#include <GraphMol/Substruct/SubstructMatch.h>
+#include <GraphMol/ChemTransforms/ChemTransforms.h>
+#include <regex>
+
+namespace RDKit {
+
+
+void RGroupData::add(boost::shared_ptr<ROMol> newMol,
+         const std::vector<int> &rlabel_attachments) {
+  // some fragments can be add multiple times if they are cyclic
+  for (auto &mol : mols) {
+    if (newMol.get() == mol.get()) {
+      return;
+    }
+  }
+
+  if (mols.size() > 0) {
+    // don't add extraneous hydrogens
+    if (isMolHydrogen(*newMol)) {
+      return;
+    }
+    if (is_hydrogen) {
+      // if we are adding a heavy attachment to hydrogens, discard the
+      // hydrogen and start over
+      combinedMol = nullptr;
+      smilesVect.clear();
+      attachments.clear();
+      mols.clear();
+    }
+  }
+
+  labelled = false;
+  std::copy(rlabel_attachments.begin(), rlabel_attachments.end(),
+            std::inserter(attachments, attachments.end()));
+
+  mols.push_back(newMol);
+  static const std::regex remove_isotopes_regex("\\[\\d*\\*\\]");
+  // remove the isotope labels from the SMILES string to avoid
+  // that identical R-group are perceived as different when
+  // MCS alignment is not used (NoAlign flag)
+  smilesVect.push_back(std::regex_replace(MolToSmiles(*newMol, true),
+                                          remove_isotopes_regex, "*"));
+  if (!combinedMol.get()) {
+    combinedMol = boost::shared_ptr<RWMol>(new RWMol(*mols[0].get()));
+  } else {
+    ROMol *m = combineMols(*combinedMol.get(), *newMol.get());
+    single_fragment = false;
+    m->updateProps(*combinedMol.get());
+    combinedMol.reset(new RWMol(*m));
+    delete m;
+  }
+  smiles = getSmiles();
+  combinedMol->setProp(common_properties::internalRgroupSmiles, smiles);
+  computeIsHydrogen();
+  is_linker = single_fragment && attachments.size() > 1;
+}
+
+std::map<int, int> RGroupData::getNumBondsToRlabels() const {
+  std::map<int, int> rlabelsUsedCount;
+
+  for (ROMol::AtomIterator atIt = combinedMol->beginAtoms();
+       atIt != combinedMol->endAtoms(); ++atIt) {
+    Atom *atom = *atIt;
+    int rlabel;
+    if (atom->getPropIfPresent<int>(RLABEL, rlabel)) {
+      rlabelsUsedCount[rlabel] += 1;
+    }
+  }
+  return rlabelsUsedCount;
+}
+
+std::string RGroupData::toString() const {
+  auto attachmentString = std::accumulate(
+      attachments.cbegin(), attachments.cend(), std::string(),
+      [](std::string s, int a) {
+        return s.empty() ? std::to_string(a)
+                         : std::move(s) + ',' + std::to_string(a);
+      });
+  std::stringstream ss;
+  ss << "RG " << attachmentString << " " << getSmiles();
+  return ss.str();
+}
+
+void RGroupData::computeIsHydrogen() {  // is the rgroup all Hs
+  for (const auto &mol : mols) {
+    if (!isMolHydrogen(*mol)) {
+      is_hydrogen = false;
+      return;
+    }
+  }
+  is_hydrogen = true;
+}
+
+bool RGroupData::isMolHydrogen(ROMol &mol) {
+  for (ROMol::AtomIterator atIt = mol.beginAtoms(); atIt != mol.endAtoms();
+       ++atIt) {
+    auto atom = *atIt;
+    if (atom->getAtomicNum() > 1) {
+      return false;
+    } else if (atom->getAtomicNum() == 0 &&
+               !atom->hasProp(SIDECHAIN_RLABELS)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+//! compute the canonical smiles for the attachments (bug: removes dupes since
+//! we are using a set...)
+std::string RGroupData::getSmiles() const {
+  std::string s;
+  for (const auto &it : smilesVect) {
+    if (s.length()) {
+      s += ".";
+    }
+    s += it;
+  }
+  return s;
+}
+
+}  // namespace RDKit

--- a/Code/GraphMol/RGroupDecomposition/RGroupData.h
+++ b/Code/GraphMol/RGroupDecomposition/RGroupData.h
@@ -19,7 +19,7 @@
 namespace RDKit {
 
 //! A single rgroup attached to a given core.
-struct RGroupData {
+struct RDKIT_RGROUPDECOMPOSITION_EXPORT RGroupData {
   boost::shared_ptr<RWMol> combinedMol;
   std::vector<boost::shared_ptr<ROMol>> mols;  // All the mols in the rgroup
   std::vector<std::string> smilesVect;         // used for rgroup equivalence

--- a/Code/GraphMol/RGroupDecomposition/RGroupData.h
+++ b/Code/GraphMol/RGroupDecomposition/RGroupData.h
@@ -34,9 +34,6 @@ struct RDKIT_RGROUPDECOMPOSITION_EXPORT RGroupData {
   bool is_linker = false;
   bool labelled = false;
 
- private:
-  RGroupData(const RGroupData &rhs);
-
  public:
   RGroupData() {}
 

--- a/Code/GraphMol/RGroupDecomposition/RGroupData.h
+++ b/Code/GraphMol/RGroupDecomposition/RGroupData.h
@@ -12,14 +12,9 @@
 
 #include "../RDKitBase.h"
 #include "RGroupUtils.h"
-#include <GraphMol/SmilesParse/SmilesWrite.h>
-#include <GraphMol/Substruct/SubstructMatch.h>
-#include <GraphMol/ChemTransforms/ChemTransforms.h>
 #include <DataStructs/ExplicitBitVect.h>
-#include <boost/scoped_ptr.hpp>
 #include <set>
 #include <vector>
-#include <regex>
 
 namespace RDKit {
 
@@ -36,7 +31,6 @@ struct RGroupData {
   std::vector<int> fingerprintOnBits;
   bool is_hydrogen = false;
   bool single_fragment = true;
-  bool multiple_attachments = false;
   bool is_linker = false;
   bool labelled = false;
 
@@ -47,118 +41,20 @@ struct RGroupData {
   RGroupData() {}
 
   void add(boost::shared_ptr<ROMol> newMol,
-           const std::vector<int> &rlabel_attachments) {
-    // some fragments can be add multiple times if they are cyclic
-    for (auto &mol : mols) {
-      if (newMol.get() == mol.get()) {
-        return;
-      }
-    }
+           const std::vector<int> &rlabel_attachments);
 
-    if (mols.size() > 0) {
-      // don't add extraneous hydrogens
-      if (isMolHydrogen(*newMol)) {
-        return;
-      }
-      if (is_hydrogen) {
-        // if we are adding a heavy attachment to hydrogens, discard the
-        // hydrogen and start over
-        combinedMol = nullptr;
-        smilesVect.clear();
-        attachments.clear();
-        mols.clear();
-      }
-    }
+  std::map<int, int> getNumBondsToRlabels() const;
 
-    labelled = false;
-    std::copy(rlabel_attachments.begin(), rlabel_attachments.end(),
-              std::inserter(attachments, attachments.end()));
-
-    mols.push_back(newMol);
-    static const std::regex remove_isotopes_regex("\\[\\d*\\*\\]");
-    // remove the isotope labels from the SMILES string to avoid
-    // that identical R-group are perceived as different when
-    // MCS alignment is not used (NoAlign flag)
-    smilesVect.push_back(std::regex_replace(MolToSmiles(*newMol, true),
-                                            remove_isotopes_regex, "*"));
-    if (!combinedMol.get()) {
-      combinedMol = boost::shared_ptr<RWMol>(new RWMol(*mols[0].get()));
-    } else {
-      ROMol *m = combineMols(*combinedMol.get(), *newMol.get());
-      single_fragment = false;
-      m->updateProps(*combinedMol.get());
-      combinedMol.reset(new RWMol(*m));
-      delete m;
-    }
-    smiles = getSmiles();
-    combinedMol->setProp(common_properties::internalRgroupSmiles, smiles);
-    computeIsHydrogen();
-    is_linker = single_fragment && attachments.size() > 1;
-  }
-
-  std::map<int, int> getNumBondsToRlabels() const {
-    std::map<int, int> rlabelsUsedCount;
-
-    for (ROMol::AtomIterator atIt = combinedMol->beginAtoms();
-         atIt != combinedMol->endAtoms(); ++atIt) {
-      Atom *atom = *atIt;
-      int rlabel;
-      if (atom->getPropIfPresent<int>(RLABEL, rlabel)) {
-        rlabelsUsedCount[rlabel] += 1;
-      }
-    }
-    return rlabelsUsedCount;
-  }
-
-  std::string toString() const {
-    auto attachmentString = std::accumulate(
-        attachments.cbegin(), attachments.cend(), std::string(),
-        [](std::string s, int a) {
-          return s.empty() ? std::to_string(a)
-                           : std::move(s) + ',' + std::to_string(a);
-        });
-    std::stringstream ss;
-    ss << "RG " << attachmentString << " " << getSmiles();
-    return ss.str();
-  }
+  std::string toString() const;
 
  private:
-  void computeIsHydrogen() {  // is the rgroup all Hs
-    for (const auto &mol : mols) {
-      if (!isMolHydrogen(*mol)) {
-        is_hydrogen = false;
-        return;
-      }
-    }
-    is_hydrogen = true;
-  }
+  void computeIsHydrogen();
 
-  bool isMolHydrogen(ROMol &mol) {
-    for (ROMol::AtomIterator atIt = mol.beginAtoms(); atIt != mol.endAtoms();
-         ++atIt) {
-      auto atom = *atIt;
-      if (atom->getAtomicNum() > 1) {
-        return false;
-      } else if (atom->getAtomicNum() == 0 &&
-                 !atom->hasProp(SIDECHAIN_RLABELS)) {
-        return false;
-      }
-    }
-    return true;
-  }
+  bool isMolHydrogen(ROMol &mol);
 
   //! compute the canonical smiles for the attachments (bug: removes dupes since
   //! we are using a set...)
-  std::string getSmiles() const {
-    std::string s;
-    for (const auto &it : smilesVect) {
-      if (s.length()) {
-        s += ".";
-      }
-      s += it;
-    }
-    return s;
-  }
+  std::string getSmiles() const;
 };
 }  // namespace RDKit
 

--- a/Code/GraphMol/RGroupDecomposition/RGroupDecomp.h
+++ b/Code/GraphMol/RGroupDecomposition/RGroupDecomp.h
@@ -13,55 +13,11 @@
 #define RDKIT_RGROUPDECOMP_H
 
 #include "../RDKitBase.h"
+#include "RGroupDecompParams.h"
 #include <GraphMol/Substruct/SubstructMatch.h>
 #include <chrono>
 
 namespace RDKit {
-
-//! Compute the isomorphic degenerative points in the
-//!  molecule.  These are points that are symmetrically
-//!  equivalent.
-/*!
-   \param mol     Molecule to compute the degenerative points
-
-   \return the set of degenerative points (set<unsigned int>)
-*/
-
-typedef enum {
-  IsotopeLabels = 0x01,
-  AtomMapLabels = 0x02,
-  AtomIndexLabels = 0x04,
-  RelabelDuplicateLabels = 0x08,
-  MDLRGroupLabels = 0x10,
-  DummyAtomLabels = 0x20,  // These are rgroups but will get relabelled
-  AutoDetect = 0xFF,
-} RGroupLabels;
-
-typedef enum {
-  Greedy = 0x01,
-  GreedyChunks = 0x02,
-  Exhaustive = 0x04,  // not really useful for large sets
-  NoSymmetrization = 0x08,
-  GA = 0x10,
-} RGroupMatching;
-
-typedef enum {
-  AtomMap = 0x01,
-  Isotope = 0x02,
-  MDLRGroup = 0x04,
-} RGroupLabelling;
-
-typedef enum {
-  // DEPRECATED, remove the following line in release 2021.03
-  None = 0x0,
-  NoAlignment = 0x0,
-  MCS = 0x01,
-} RGroupCoreAlignment;
-
-typedef enum {
-  Match = 0x1,
-  FingerprintVariance = 0x4,
-} RGroupScore;
 
 struct RDKIT_RGROUPDECOMPOSITION_EXPORT RGroupDecompositionProcessResult {
   const bool success;
@@ -71,68 +27,6 @@ struct RDKIT_RGROUPDECOMPOSITION_EXPORT RGroupDecompositionProcessResult {
 };
 
 struct RGroupMatch;
-
-struct RDKIT_RGROUPDECOMPOSITION_EXPORT RGroupDecompositionParameters {
-  unsigned int labels = AutoDetect;
-  unsigned int matchingStrategy = GreedyChunks;
-  unsigned int scoreMethod = Match;
-  unsigned int rgroupLabelling = AtomMap | MDLRGroup;
-  unsigned int alignment = MCS;
-
-  unsigned int chunkSize = 5;
-  //! only allow rgroup decomposition at the specified rgroups
-  bool onlyMatchAtRGroups = false;
-  //! remove all user-defined rgroups that only have hydrogens
-  bool removeAllHydrogenRGroups = true;
-  //! remove all user-defined rgroups that only have hydrogens,
-  //! and also remove the corresponding labels from the core
-  bool removeAllHydrogenRGroupsAndLabels = true;
-  //! remove all hydrogens from the output molecules
-  bool removeHydrogensPostMatch = true;
-  //! allow labelled Rgroups of degree 2 or more
-  bool allowNonTerminalRGroups = false;
-  // unlabelled core atoms can have multiple rgroups
-  bool allowMultipleRGroupsOnUnlabelled = false;
-
-  double timeout = -1.0;  ///< timeout in seconds. <=0 indicates no timeout
-
-  // Determine how to assign the rgroup labels from the given core
-  unsigned int autoGetLabels(const RWMol &);
-
-  // Prepare the core for substructure searching and rgroup assignment
-  bool prepareCore(RWMol &, const RWMol *alignCore);
-
-  // Add r groups to unlabelled atoms if allowMultipleRGroupsOnUnlabelled is set
-  void addDummyAtomsToUnlabelledCoreAtoms(RWMol &core);
-
-  // Parameters specific to GA
-
-  // GA population size or -1 to use best guess
-  int gaPopulationSize = -1;
-  // GA maximum number of operations or -1 to use best guess
-  int gaMaximumOperations = -1;
-  // GA number of operations permitted without improvement before exiting (-1
-  // for best guess)
-  int gaNumberOperationsWithoutImprovement = -1;
-  // GA random number seed (-1 for default, -2 for random seed)
-  int gaRandomSeed = -1;
-  // Number of runs
-  int gaNumberRuns = 1;
-  // Sequential or parallel runs?
-#ifdef RDK_BUILD_THREADSAFE_SSS
-  bool gaParallelRuns = true;
-#else
-  bool gaParallelRuns = false;
-#endif
-  // Controls the way substructure matching with the core is done
-  SubstructMatchParameters substructmatchParams;
-
-  RGroupDecompositionParameters() { substructmatchParams.useChirality = true; }
-
- private:
-  int indexOffset{-1};
-  void checkNonTerminal(const Atom &atom) const;
-};
 
 typedef std::map<std::string, ROMOL_SPTR> RGroupRow;
 typedef std::vector<ROMOL_SPTR> RGroupColumn;
@@ -165,7 +59,6 @@ class RDKIT_RGROUPDECOMPOSITION_EXPORT RGroupDecomposition {
       const RGroupDecomposition &);  // Prevent assignment
   RWMOL_SPTR outputCoreMolecule(const RGroupMatch &match,
                                 const UsedLabelMap &usedRGroupMap) const;
-  std::map<int, bool> getBlankRGroupMap() const;
 
  public:
   RGroupDecomposition(const ROMol &core,

--- a/Code/GraphMol/RGroupDecomposition/RGroupDecompData.cpp
+++ b/Code/GraphMol/RGroupDecomposition/RGroupDecompData.cpp
@@ -1,0 +1,720 @@
+//
+//  Copyright (c) 2017-2023, Novartis Institutes for BioMedical Research Inc.
+//  and other RDKit contributors
+//
+//   @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
+//
+
+#include "RGroupDecompData.h"
+
+#include "RGroupDecomp.h"
+#include "RGroupMatch.h"
+#include "RGroupGa.h"
+
+// #define VERBOSE 1
+
+namespace RDKit {
+
+RGroupDecompData::RGroupDecompData(const RWMol &inputCore,
+                                   RGroupDecompositionParameters inputParams)
+    : params(std::move(inputParams)) {
+  addCore(inputCore);
+  prepareCores();
+}
+
+RGroupDecompData::RGroupDecompData(const std::vector<ROMOL_SPTR> &inputCores,
+                                   RGroupDecompositionParameters inputParams)
+    : params(std::move(inputParams)) {
+  for (const auto &core : inputCores) {
+    addCore(*core);
+  }
+  prepareCores();
+}
+
+void RGroupDecompData::addCore(const ROMol &inputCore) {
+  if (params.allowMultipleRGroupsOnUnlabelled && !params.onlyMatchAtRGroups) {
+    RWMol core(inputCore);
+    params.addDummyAtomsToUnlabelledCoreAtoms(core);
+    cores[cores.size()] = RCore(core);
+  } else {
+    cores[cores.size()] = RCore(inputCore);
+  }
+}
+
+void RGroupDecompData::prepareCores() {
+  for (auto &core : cores) {
+    RWMol *alignCore = core.first ? cores[0].core.get() : nullptr;
+    CHECK_INVARIANT(params.prepareCore(*core.second.core, alignCore),
+                    "Could not prepare at least one core");
+    core.second.init();
+    core.second.labelledCore.reset(new RWMol(*core.second.core));
+  }
+}
+
+void RGroupDecompData::setRlabel(Atom *atom, int rlabel) {
+  PRECONDITION(rlabel > 0, "RLabels must be >0");
+  if (params.rgroupLabelling & AtomMap) {
+    atom->setAtomMapNum(rlabel);
+  }
+
+  if (params.rgroupLabelling & MDLRGroup) {
+    std::string dLabel = "R" + std::to_string(rlabel);
+    atom->setProp(common_properties::dummyLabel, dLabel);
+    setAtomRLabel(atom, rlabel);
+  } else {
+    atom->clearProp(common_properties::dummyLabel);
+  }
+
+  if (params.rgroupLabelling & Isotope) {
+    atom->setIsotope(rlabel);
+  }
+}
+
+int RGroupDecompData::getRlabel(Atom *atom) const {
+  if (params.rgroupLabelling & AtomMap) {
+    return atom->getAtomMapNum();
+  }
+  if (params.rgroupLabelling & Isotope) {
+    return atom->getIsotope();
+  }
+
+  if (params.rgroupLabelling & MDLRGroup) {
+    unsigned int label = 0;
+    if (atom->getPropIfPresent(common_properties::_MolFileRLabel, label)) {
+      return label;
+    }
+  }
+
+  CHECK_INVARIANT(0, "no valid r label found");
+}
+
+double RGroupDecompData::scoreFromPrunedData(
+    const std::vector<size_t> &permutation, bool reset) {
+  PRECONDITION(
+      static_cast<RGroupScore>(params.scoreMethod) == FingerprintVariance,
+      "Scoring method is not fingerprint variance!");
+
+  PRECONDITION(permutation.size() >= pruneLength,
+               "Illegal permutation prune length");
+  if (permutation.size() < pruneLength * 1.5) {
+    for (unsigned int pos = pruneLength; pos < permutation.size(); ++pos) {
+      prunedFingerprintVarianceScoreData.addVarianceData(pos, permutation[pos],
+                                                         matches, labels);
+    }
+    double score =
+        prunedFingerprintVarianceScoreData.fingerprintVarianceGroupScore();
+    if (reset) {
+      for (unsigned int pos = pruneLength; pos < permutation.size(); ++pos) {
+        prunedFingerprintVarianceScoreData.removeVarianceData(
+            pos, permutation[pos], matches, labels);
+      }
+    } else {
+      pruneLength = permutation.size();
+    }
+    return score;
+  } else {
+    if (reset) {
+      return fingerprintVarianceScore(permutation, matches, labels);
+    } else {
+      prunedFingerprintVarianceScoreData.clear();
+      pruneLength = permutation.size();
+      return fingerprintVarianceScore(permutation, matches, labels,
+                                      &prunedFingerprintVarianceScoreData);
+    }
+  }
+}
+
+void RGroupDecompData::prune() {  // prune all but the current "best"
+                                  // permutation of matches
+  PRECONDITION(permutation.size() <= matches.size(),
+               "permutation.size() should be <= matches.size()");
+  size_t offset = matches.size() - permutation.size();
+  for (size_t mol_idx = 0; mol_idx < permutation.size(); ++mol_idx) {
+    std::vector<RGroupMatch> keepVector;
+    size_t mi = mol_idx + offset;
+    keepVector.push_back(matches[mi].at(permutation[mol_idx]));
+    matches[mi] = keepVector;
+  }
+
+  permutation = std::vector<size_t>(permutation.size(), 0);
+  if (params.scoreMethod == FingerprintVariance &&
+      params.matchingStrategy != GA) {
+    scoreFromPrunedData(permutation, false);
+  }
+}
+
+// Return the RGroups with the current "best" permutation
+//  of matches.
+std::vector<RGroupMatch> RGroupDecompData::GetCurrentBestPermutation() const {
+  const bool removeAllHydrogenRGroups =
+      params.removeAllHydrogenRGroups ||
+      params.removeAllHydrogenRGroupsAndLabels;
+
+  std::vector<RGroupMatch> results;  // std::map<int, RGroup> > result;
+  bool isPruned = (permutation.size() < matches.size());
+  for (size_t i = 0; i < matches.size(); ++i) {
+    size_t pi = (isPruned ? 0 : permutation.at(i));
+    results.push_back(matches[i].at(pi));
+  }
+
+  // * if a dynamically-added RGroup (i.e., when onlyMatchAtRGroups=false)
+  //   is all hydrogens, remove it
+  // * if a user-defined RGroup is all hydrogens and either
+  //   params.removeAllHydrogenRGroups==true or
+  //   params.removeAllHydrogenRGroupsAndLabels==true, remove it
+
+  // This logic is a bit tricky, find all labels that have common cores
+  //  and analyze those sets independently.
+  //  i.e. if core 1 doesn't have R1 then don't analyze it in when looking
+  //  at label 1
+  std::map<int, std::set<int>> labelCores;  // map from label->cores
+  std::set<int> coresVisited;
+  for (auto &position : results) {
+    int core_idx = position.core_idx;
+    if (coresVisited.find(core_idx) == coresVisited.end()) {
+      coresVisited.insert(core_idx);
+      auto core = cores.find(core_idx);
+      if (core != cores.end()) {
+        for (auto rlabels : getRlabels(*core->second.core)) {
+          int rlabel = rlabels.first;
+          labelCores[rlabel].insert(core_idx);
+        }
+      }
+    }
+  }
+
+  std::set<int> labelsToErase;
+  for (int label : labels) {
+    if (label > 0 && !removeAllHydrogenRGroups) {
+      continue;
+    }
+    bool allH = true;
+    for (auto &position : results) {
+      R_DECOMP::const_iterator rgroup = position.rgroups.find(label);
+      bool labelHasCore =
+          labelCores[label].find(position.core_idx) != labelCores[label].end();
+      if (labelHasCore && rgroup != position.rgroups.end() &&
+          !rgroup->second->is_hydrogen) {
+        allH = false;
+        break;
+      }
+    }
+
+    if (allH) {
+      labelsToErase.insert(label);
+      for (auto &position : results) {
+        position.rgroups.erase(label);
+      }
+    }
+  }
+
+  for (auto &position : results) {
+    for (auto atom : position.matchedCore->atoms()) {
+      if (int atomLabel; atom->getAtomicNum() == 0 &&
+                         atom->getPropIfPresent(RLABEL, atomLabel)) {
+        if (atomLabel > 0 && !params.removeAllHydrogenRGroupsAndLabels) {
+          continue;
+        }
+        if (labelsToErase.find(atomLabel) != labelsToErase.end()) {
+          atom->setAtomicNum(1);
+          atom->clearProp(RLABEL);
+          if (atom->hasProp(RLABEL_TYPE)) {
+            atom->clearProp(RLABEL_TYPE);
+          }
+          if (atom->hasProp(UNLABELED_CORE_ATTACHMENT)) {
+            atom->clearProp(UNLABELED_CORE_ATTACHMENT);
+          }
+          atom->updatePropertyCache(false);
+        }
+      }
+    }
+  }
+
+  return results;
+}
+
+bool RGroupDecompData::UsedLabels::add(int rlabel) {
+  if (labels_used.find(rlabel) != labels_used.end()) {
+    return false;
+  }
+  labels_used.insert(rlabel);
+  return true;
+}
+
+int RGroupDecompData::UsedLabels::next() {
+  int i = 1;
+  while (labels_used.find(i) != labels_used.end()) {
+    ++i;
+  }
+  labels_used.insert(i);
+  return i;
+}
+
+void RGroupDecompData::addCoreUserLabels(const RWMol &core,
+                                         std::set<int> &userLabels) {
+  auto atoms = getRlabels(core);
+  for (const auto &p : atoms) {
+    if (p.first > 0) {
+      userLabels.insert(p.first);
+    }
+  }
+}
+
+void RGroupDecompData::addAtoms(
+    RWMol &mol, const std::vector<std::pair<Atom *, Atom *>> &atomsToAdd) {
+  for (const auto &i : atomsToAdd) {
+    mol.addAtom(i.second, false, true);
+    mol.addBond(i.first, i.second, Bond::SINGLE);
+    if (mol.getNumConformers()) {
+      MolOps::setTerminalAtomCoords(mol, i.second->getIdx(), i.first->getIdx());
+    }
+  }
+}
+
+bool RGroupDecompData::replaceHydrogenCoreDummy(const RGroupMatch &match,
+                                                RWMol &core, const Atom &atom,
+                                                const int currentLabel,
+                                                const int rLabel) {
+  // if the R group is just a hydrogen then the attachment point should
+  // replace an existing hydrogen neighbor since all hydrogen neighbors
+  // are copied from the input molecule to the extracted core.
+  if (const auto group = match.rgroups.find(currentLabel);
+      group != match.rgroups.end()) {
+    if (group->second->is_hydrogen) {
+      for (auto &neighbor : core.atomNeighbors(&atom)) {
+        if (neighbor->getAtomicNum() == 1) {
+          neighbor->setAtomicNum(0);
+          setRlabel(neighbor, rLabel);
+          return true;
+        }
+      }
+    }
+  }
+  return false;
+}
+
+void RGroupDecompData::relabelCore(
+    RWMol &core, std::map<int, int> &mappings, UsedLabels &used_labels,
+    const std::set<int> &indexLabels,
+    const std::map<int, std::vector<int>> &extraAtomRLabels,
+    const RGroupMatch *const match) {
+  // Now remap to proper rlabel ids
+  //  if labels are positive, they come from User labels
+  //  if they are negative, they come from indices and should be
+  //  numbered *after* the user labels.
+  //
+  //  Some indices are attached to multiple bonds,
+  //   these rlabels should be incrementally added last
+  std::map<int, Atom *> atoms = getRlabels(core);
+  // a core only has one labelled index
+  //  a secondary structure extraAtomRLabels contains the number
+  //  of bonds between this atom and the side chain
+
+  // a sidechain atom has a vector of the attachments back to the
+  //  core that takes the place of numBondsToRlabel
+
+  std::vector<std::pair<Atom *, Atom *>> atomsToAdd;  // adds -R if necessary
+
+  // Deal with user supplied labels
+  for (const auto &rlabels : atoms) {
+    int userLabel = rlabels.first;
+    if (userLabel < 0) {
+      continue;  // not a user specified label
+    }
+    Atom *atom = rlabels.second;
+    mappings[userLabel] = userLabel;
+    used_labels.add(userLabel);
+
+    if (atom->getAtomicNum() == 0 &&
+        atom->getDegree() == 1) {  // add to existing dummy/rlabel
+      setRlabel(atom, userLabel);
+    } else {
+      // A non-terminal RGroup. Create a dummy by replacing an existing
+      // hydrogen for hydrogen side chains, or a new dummy atom for heavy side
+      // chains.
+      bool addNew = true;
+      if (match != nullptr) {
+        addNew = !replaceHydrogenCoreDummy(*match, core, *atom, userLabel,
+                                           userLabel);
+        // If we can't replace a hydrogen only add the dummy if it exists in
+        // the decomp This is unexpected.
+        if (addNew && match->rgroups.find(userLabel) == match->rgroups.end()) {
+          addNew = false;
+        }
+      }
+      if (addNew) {
+        auto *newAt = new Atom(0);
+        setRlabel(newAt, userLabel);
+        atomsToAdd.emplace_back(atom, newAt);
+      }
+    }
+  }
+
+  // Deal with non-user supplied labels
+  for (auto newLabel : indexLabels) {
+    auto atm = atoms.find(newLabel);
+    if (atm == atoms.end()) {
+      continue;
+    }
+
+    Atom *atom = atm->second;
+
+    int rlabel;
+    auto mapping = mappings.find(newLabel);
+    if (mapping == mappings.end()) {
+      rlabel = used_labels.next();
+      mappings[newLabel] = rlabel;
+    } else {
+      rlabel = mapping->second;
+    }
+
+    if (atom->getAtomicNum() == 0 &&
+        !isAnyAtomWithMultipleNeighborsOrNotUserRLabel(
+            *atom)) {  // add to dummy
+      setRlabel(atom, rlabel);
+    } else {
+      bool addNew = true;
+      if (match != nullptr) {
+        addNew =
+            !replaceHydrogenCoreDummy(*match, core, *atom, newLabel, rlabel);
+        // If we can't replace a hydrogen only add the dummy if it exists in
+        // the decomp This is unexpected.
+        if (addNew && match->rgroups.find(newLabel) == match->rgroups.end()) {
+          addNew = false;
+        }
+      }
+      if (addNew) {
+        auto *newAt = new Atom(0);
+        setRlabel(newAt, rlabel);
+        atomsToAdd.emplace_back(atom, newAt);
+      }
+    }
+  }
+
+  // Deal with multiple bonds to the same label
+  for (const auto &extraAtomRLabel : extraAtomRLabels) {
+    auto atm = atoms.find(extraAtomRLabel.first);
+    if (atm == atoms.end()) {
+      continue;  // label not used in the rgroup
+    }
+    Atom *atom = atm->second;
+
+    for (size_t i = 0; i < extraAtomRLabel.second.size(); ++i) {
+      int rlabel = used_labels.next();
+      // Is this necessary?
+      CHECK_INVARIANT(
+          atom->getAtomicNum() > 1,
+          "Multiple attachments to a dummy (or hydrogen) is weird.");
+      auto *newAt = new Atom(0);
+      setRlabel(newAt, rlabel);
+      atomsToAdd.emplace_back(atom, newAt);
+    }
+  }
+
+  addAtoms(core, atomsToAdd);
+  for (const auto &rlabels : atoms) {
+    auto atom = rlabels.second;
+    atom->clearProp(RLABEL);
+    atom->clearProp(RLABEL_TYPE);
+  }
+
+  // Delay removing hydrogens from core until outputCoreMolecule is called,
+  // If hydrogens are removed now and more dummies removed in
+  // outputCoreMolecule then aromaticity perception in the core may be broken.
+
+  core.updatePropertyCache(false);  // this was github #1550
+}
+
+void RGroupDecompData::relabelRGroup(RGroupData &rgroup,
+                                     const std::map<int, int> &mappings) {
+  PRECONDITION(rgroup.combinedMol.get(), "Unprocessed rgroup");
+
+  RWMol &mol = *rgroup.combinedMol.get();
+
+  if (rgroup.combinedMol->hasProp(done)) {
+    rgroup.labelled = true;
+    return;
+  }
+
+  mol.setProp(done, true);
+  std::vector<std::pair<Atom *, Atom *>> atomsToAdd;  // adds -R if necessary
+  std::map<int, int> rLabelCoreIndexToAtomicWt;
+
+  for (RWMol::AtomIterator atIt = mol.beginAtoms(); atIt != mol.endAtoms();
+       ++atIt) {
+    Atom *atom = *atIt;
+    if (atom->hasProp(SIDECHAIN_RLABELS)) {
+      atom->setIsotope(0);
+      const std::vector<int> &rlabels =
+          atom->getProp<std::vector<int>>(SIDECHAIN_RLABELS);
+      // switch on atom mappings or rlabels....
+
+      for (int rlabel : rlabels) {
+        auto label = mappings.find(rlabel);
+        CHECK_INVARIANT(label != mappings.end(), "Unprocessed mapping");
+
+        if (atom->getAtomicNum() == 0) {
+          if (!atom->hasProp(_rgroupInputDummy)) {
+            setRlabel(atom, label->second);
+          }
+        } else if (atom->hasProp(RLABEL_CORE_INDEX)) {
+          atom->setAtomicNum(0);
+          setRlabel(atom, label->second);
+        } else {
+          auto *newAt = new Atom(0);
+          setRlabel(newAt, label->second);
+          atomsToAdd.emplace_back(atom, newAt);
+        }
+      }
+    }
+    if (atom->hasProp(RLABEL_CORE_INDEX)) {
+      // convert to dummy as we don't want to collapse hydrogens onto the core
+      // match
+      auto rLabelCoreIndex = atom->getProp<int>(RLABEL_CORE_INDEX);
+      rLabelCoreIndexToAtomicWt[rLabelCoreIndex] = atom->getAtomicNum();
+      atom->setAtomicNum(0);
+    }
+  }
+
+  addAtoms(mol, atomsToAdd);
+
+  if (params.removeHydrogensPostMatch) {
+    RDLog::LogStateSetter blocker;
+    bool implicitOnly = false;
+    bool updateExplicitCount = false;
+    bool sanitize = false;
+    MolOps::removeHs(mol, implicitOnly, updateExplicitCount, sanitize);
+  }
+
+  mol.updatePropertyCache(false);  // this was github #1550
+  rgroup.labelled = true;
+
+  // Restore any core matches that we have set to dummy
+  for (RWMol::AtomIterator atIt = mol.beginAtoms(); atIt != mol.endAtoms();
+       ++atIt) {
+    Atom *atom = *atIt;
+    if (atom->hasProp(RLABEL_CORE_INDEX)) {
+      // don't need to set IsAromatic on atom - that seems to have been saved
+      atom->setAtomicNum(
+          rLabelCoreIndexToAtomicWt[atom->getProp<int>(RLABEL_CORE_INDEX)]);
+      atom->setNoImplicit(true);
+      atom->clearProp(RLABEL_CORE_INDEX);
+    }
+    atom->clearProp(SIDECHAIN_RLABELS);
+  }
+
+#ifdef VERBOSE
+  std::cerr << "Relabel Rgroup smiles " << MolToSmiles(mol) << std::endl;
+#endif
+}
+
+// relabel the core and sidechains using the specified user labels
+//  if matches exist for non labelled atoms, these are added as well
+void RGroupDecompData::relabel() {
+  std::vector<RGroupMatch> best = GetCurrentBestPermutation();
+
+  // get the labels used
+  std::set<int> userLabels;
+  std::set<int> indexLabels;
+
+  // Go through all the RGroups and find out which labels were
+  //  actually used.
+
+  // some atoms will have multiple attachment points, i.e. cycles
+  //  split these up into new rlabels if necessary
+  //  These are detected at match time
+  //  This vector will hold the extra (new) labels required
+  std::map<int, std::vector<int>> extraAtomRLabels;
+
+  for (auto &it : best) {
+    for (auto &rgroup : it.rgroups) {
+      if (rgroup.first > 0) {
+        userLabels.insert(rgroup.first);
+      }
+      if (rgroup.first < 0 && !params.onlyMatchAtRGroups) {
+        indexLabels.insert(rgroup.first);
+      }
+
+      std::map<int, int> rlabelsUsedInRGroup =
+          rgroup.second->getNumBondsToRlabels();
+      for (auto &numBondsUsed : rlabelsUsedInRGroup) {
+        // Make space for the extra labels
+        if (numBondsUsed.second > 1) {  // multiple rgroup bonds to same atom
+          extraAtomRLabels[numBondsUsed.first].resize(numBondsUsed.second - 1);
+        }
+      }
+    }
+  }
+
+  // find user labels that are not present in the decomposition
+  for (auto &core : cores) {
+    core.second.labelledCore.reset(new RWMol(*core.second.core));
+    addCoreUserLabels(*core.second.labelledCore, userLabels);
+  }
+
+  // Assign final RGroup labels to the cores and propagate these to
+  //  the scaffold
+  finalRlabelMapping.clear();
+
+  UsedLabels used_labels;
+  // Add all the user labels now to prevent an index label being assigned to a
+  // user label when multiple cores are present (e.g. the user label is
+  // present in the second core, but not the first).
+  for (auto userLabel : userLabels) {
+    used_labels.add(userLabel);
+  }
+  for (auto &core : cores) {
+    relabelCore(*core.second.labelledCore, finalRlabelMapping, used_labels,
+                indexLabels, extraAtomRLabels);
+  }
+
+  for (auto &it : best) {
+    for (auto &rgroup : it.rgroups) {
+      relabelRGroup(*rgroup.second, finalRlabelMapping);
+    }
+#ifdef VERBOSE
+    std::cerr << "relabel core mol1 " << MolToSmiles(*it.matchedCore)
+              << std::endl;
+#endif
+    relabelCore(*it.matchedCore, finalRlabelMapping, used_labels, indexLabels,
+                extraAtomRLabels, &it);
+#ifdef VERBOSE
+    std::cerr << "relabel core mol2 " << MolToSmiles(*it.matchedCore)
+              << std::endl;
+#endif
+  }
+
+  std::set<int> uniqueMappedValues;
+  std::transform(finalRlabelMapping.cbegin(), finalRlabelMapping.cend(),
+                 std::inserter(uniqueMappedValues, uniqueMappedValues.end()),
+                 [](const std::pair<int, int> &p) { return p.second; });
+  CHECK_INVARIANT(finalRlabelMapping.size() == uniqueMappedValues.size(),
+                  "Error in uniqueness of final RLabel mapping");
+  CHECK_INVARIANT(
+      uniqueMappedValues.size() == userLabels.size() + indexLabels.size(),
+      "Error in final RMapping size");
+}
+
+double RGroupDecompData::score(
+    const std::vector<size_t> &permutation,
+    FingerprintVarianceScoreData *fingerprintVarianceScoreData) const {
+  RGroupScore scoreMethod = static_cast<RGroupScore>(params.scoreMethod);
+  switch (scoreMethod) {
+    case Match:
+      return rGroupScorer.matchScore(permutation, matches, labels);
+      break;
+    case FingerprintVariance:
+      return fingerprintVarianceScore(permutation, matches, labels,
+                                      fingerprintVarianceScoreData);
+      break;
+    default:;
+  }
+  return NAN;
+}
+
+RGroupDecompositionProcessResult RGroupDecompData::process(
+    bool pruneMatches, bool finalize) {
+  if (matches.empty()) {
+    return RGroupDecompositionProcessResult(false, -1);
+  }
+  auto t0 = std::chrono::steady_clock::now();
+  std::unique_ptr<CartesianProduct> iterator;
+  rGroupScorer.startProcessing();
+
+  if (params.matchingStrategy == GA) {
+    RGroupGa ga(*this, params.timeout >= 0 ? &t0 : nullptr);
+    if (ga.numberPermutations() < 100 * ga.getPopsize()) {
+      params.matchingStrategy = Exhaustive;
+    } else {
+      if (params.gaNumberRuns > 1) {
+        auto results = ga.runBatch();
+        auto best = max_element(results.begin(), results.end(),
+                                [](const GaResult &a, const GaResult &b) {
+                                  return a.rGroupScorer.getBestScore() <
+                                         b.rGroupScorer.getBestScore();
+                                });
+        rGroupScorer = best->rGroupScorer;
+      } else {
+        auto result = ga.run();
+        rGroupScorer = result.rGroupScorer;
+      }
+    }
+  }
+  size_t offset = 0;
+  if (params.matchingStrategy != GA) {
+    // Exhaustive search, get the MxN matrix
+    // (M = matches.size(): number of molecules
+    //  N = iterator.maxPermutations)
+    std::vector<size_t> permutations;
+
+    if (pruneMatches && params.scoreMethod != FingerprintVariance) {
+      offset = previousMatchSize;
+    }
+    previousMatchSize = matches.size();
+    std::transform(matches.begin() + offset, matches.end(),
+                   std::back_inserter(permutations),
+                   [](const std::vector<RGroupMatch> &m) { return m.size(); });
+    permutation = std::vector<size_t>(permutations.size(), 0);
+
+    // run through all possible matches and score each
+    //  set
+    size_t count = 0;
+#ifdef DEBUG
+    std::cerr << "Processing" << std::endl;
+#endif
+    std::unique_ptr<CartesianProduct> it(new CartesianProduct(permutations));
+    iterator = std::move(it);
+    // Iterates through the permutation idx, i.e.
+    //  [m1_permutation_idx,  m2_permutation_idx, m3_permutation_idx]
+
+    while (iterator->next()) {
+      if (count > iterator->maxPermutations) {
+        throw ValueErrorException("next() did not finish");
+      }
+#ifdef DEBUG
+      std::cerr << "**************************************************"
+                << std::endl;
+#endif
+      double newscore = params.scoreMethod == FingerprintVariance
+                            ? scoreFromPrunedData(iterator->permutation)
+                            : score(iterator->permutation);
+
+      if (fabs(newscore - rGroupScorer.getBestScore()) <
+          1e-6) {  // heuristic to overcome floating point comparison issues
+        rGroupScorer.pushTieToStore(iterator->permutation);
+      } else if (newscore > rGroupScorer.getBestScore()) {
+#ifdef DEBUG
+        std::cerr << " ===> current best:" << newscore << ">"
+                  << rGroupScorer.getBestScore() << std::endl;
+#endif
+        rGroupScorer.setBestPermutation(iterator->permutation, newscore);
+        rGroupScorer.clearTieStore();
+        rGroupScorer.pushTieToStore(iterator->permutation);
+      }
+      ++count;
+    }
+  }
+
+  if (rGroupScorer.tieStoreSize() > 1) {
+    rGroupScorer.breakTies(matches, labels, iterator, t0, params.timeout);
+    rGroupScorer.clearTieStore();
+  } else {
+    checkForTimeout(t0, params.timeout);
+  }
+  permutation = rGroupScorer.getBestPermutation();
+  if (pruneMatches || finalize) {
+    prune();
+  }
+
+  if (finalize) {
+    relabel();
+  }
+
+  return RGroupDecompositionProcessResult(true, rGroupScorer.getBestScore());
+}
+
+}  // namespace RDKit

--- a/Code/GraphMol/RGroupDecomposition/RGroupDecompData.h
+++ b/Code/GraphMol/RGroupDecomposition/RGroupDecompData.h
@@ -12,15 +12,10 @@
 #define RGROUP_DECOMP_DATA
 
 #include "RGroupCore.h"
-#include "RGroupDecomp.h"
-#include "RGroupMatch.h"
 #include "RGroupScore.h"
 #include "RGroupFingerprintScore.h"
-#include "RGroupGa.h"
 #include <vector>
 #include <map>
-
-// #define VERBOSE 1
 
 namespace RDKit {
 
@@ -55,705 +50,63 @@ struct RGroupDecompData {
   mutable RGroupScorer rGroupScorer;
 
   RGroupDecompData(const RWMol &inputCore,
-                   RGroupDecompositionParameters inputParams)
-      : params(std::move(inputParams)) {
-    addCore(inputCore);
-    prepareCores();
-  }
+                   RGroupDecompositionParameters inputParams);
 
   RGroupDecompData(const std::vector<ROMOL_SPTR> &inputCores,
-                   RGroupDecompositionParameters inputParams)
-      : params(std::move(inputParams)) {
-    for (const auto &core : inputCores) {
-      addCore(*core);
-    }
-    prepareCores();
-  }
+                   RGroupDecompositionParameters inputParams);
 
-  void addCore(const ROMol &inputCore) {
-    if (params.allowMultipleRGroupsOnUnlabelled && !params.onlyMatchAtRGroups) {
-      RWMol core(inputCore);
-      params.addDummyAtomsToUnlabelledCoreAtoms(core);
-      cores[cores.size()] = RCore(core);
-    } else {
-      cores[cores.size()] = RCore(inputCore);
-    }
-  }
+  void addCore(const ROMol &inputCore);
 
-  void prepareCores() {
-    for (auto &core : cores) {
-      RWMol *alignCore = core.first ? cores[0].core.get() : nullptr;
-      CHECK_INVARIANT(params.prepareCore(*core.second.core, alignCore),
-                      "Could not prepare at least one core");
-      core.second.init();
-      core.second.labelledCore.reset(new RWMol(*core.second.core));
-    }
-  }
+  void prepareCores();
 
-  void setRlabel(Atom *atom, int rlabel) {
-    PRECONDITION(rlabel > 0, "RLabels must be >0");
-    if (params.rgroupLabelling & AtomMap) {
-      atom->setAtomMapNum(rlabel);
-    }
+  void setRlabel(Atom *atom, int rlabel);
 
-    if (params.rgroupLabelling & MDLRGroup) {
-      std::string dLabel = "R" + std::to_string(rlabel);
-      atom->setProp(common_properties::dummyLabel, dLabel);
-      setAtomRLabel(atom, rlabel);
-    } else {
-      atom->clearProp(common_properties::dummyLabel);
-    }
-
-    if (params.rgroupLabelling & Isotope) {
-      atom->setIsotope(rlabel);
-    }
-  }
-
-  int getRlabel(Atom *atom) const {
-    if (params.rgroupLabelling & AtomMap) {
-      return atom->getAtomMapNum();
-    }
-    if (params.rgroupLabelling & Isotope) {
-      return atom->getIsotope();
-    }
-
-    if (params.rgroupLabelling & MDLRGroup) {
-      unsigned int label = 0;
-      if (atom->getPropIfPresent(common_properties::_MolFileRLabel, label)) {
-        return label;
-      }
-    }
-
-    CHECK_INVARIANT(0, "no valid r label found");
-  }
+  int getRlabel(Atom *atom) const;
 
   double scoreFromPrunedData(const std::vector<size_t> &permutation,
-                             bool reset = true) {
-    PRECONDITION(
-        static_cast<RGroupScore>(params.scoreMethod) == FingerprintVariance,
-        "Scoring method is not fingerprint variance!");
+                             bool reset = true);
 
-    PRECONDITION(permutation.size() >= pruneLength,
-                 "Illegal permutation prune length");
-    if (permutation.size() < pruneLength * 1.5) {
-      for (unsigned int pos = pruneLength; pos < permutation.size(); ++pos) {
-        prunedFingerprintVarianceScoreData.addVarianceData(
-            pos, permutation[pos], matches, labels);
-      }
-      double score =
-          prunedFingerprintVarianceScoreData.fingerprintVarianceGroupScore();
-      if (reset) {
-        for (unsigned int pos = pruneLength; pos < permutation.size(); ++pos) {
-          prunedFingerprintVarianceScoreData.removeVarianceData(
-              pos, permutation[pos], matches, labels);
-        }
-      } else {
-        pruneLength = permutation.size();
-      }
-      return score;
-    } else {
-      if (reset) {
-        return fingerprintVarianceScore(permutation, matches, labels);
-      } else {
-        prunedFingerprintVarianceScoreData.clear();
-        pruneLength = permutation.size();
-        return fingerprintVarianceScore(permutation, matches, labels,
-                                        &prunedFingerprintVarianceScoreData);
-      }
-    }
-  }
-
-  void prune() {  // prune all but the current "best" permutation of matches
-    PRECONDITION(permutation.size() <= matches.size(),
-                 "permutation.size() should be <= matches.size()");
-    size_t offset = matches.size() - permutation.size();
-    for (size_t mol_idx = 0; mol_idx < permutation.size(); ++mol_idx) {
-      std::vector<RGroupMatch> keepVector;
-      size_t mi = mol_idx + offset;
-      keepVector.push_back(matches[mi].at(permutation[mol_idx]));
-      matches[mi] = keepVector;
-    }
-
-    permutation = std::vector<size_t>(permutation.size(), 0);
-    if (params.scoreMethod == FingerprintVariance &&
-        params.matchingStrategy != GA) {
-      scoreFromPrunedData(permutation, false);
-    }
-  }
+  void prune();
 
   // Return the RGroups with the current "best" permutation
   //  of matches.
-  std::vector<RGroupMatch> GetCurrentBestPermutation() const {
-    const bool removeAllHydrogenRGroups =
-        params.removeAllHydrogenRGroups ||
-        params.removeAllHydrogenRGroupsAndLabels;
-
-    std::vector<RGroupMatch> results;  // std::map<int, RGroup> > result;
-    bool isPruned = (permutation.size() < matches.size());
-    for (size_t i = 0; i < matches.size(); ++i) {
-      size_t pi = (isPruned ? 0 : permutation.at(i));
-      results.push_back(matches[i].at(pi));
-    }
-
-    // * if a dynamically-added RGroup (i.e., when onlyMatchAtRGroups=false)
-    //   is all hydrogens, remove it
-    // * if a user-defined RGroup is all hydrogens and either
-    //   params.removeAllHydrogenRGroups==true or
-    //   params.removeAllHydrogenRGroupsAndLabels==true, remove it
-
-    // This logic is a bit tricky, find all labels that have common cores
-    //  and analyze those sets independently.
-    //  i.e. if core 1 doesn't have R1 then don't analyze it in when looking
-    //  at label 1
-    std::map<int, std::set<int>> labelCores;  // map from label->cores
-    std::set<int> coresVisited;
-    for (auto &position : results) {
-      int core_idx = position.core_idx;
-      if (coresVisited.find(core_idx) == coresVisited.end()) {
-        coresVisited.insert(core_idx);
-        auto core = cores.find(core_idx);
-        if (core != cores.end()) {
-          for (auto rlabels : getRlabels(*core->second.core)) {
-            int rlabel = rlabels.first;
-            labelCores[rlabel].insert(core_idx);
-          }
-        }
-      }
-    }
-
-    std::set<int> labelsToErase;
-    for (int label : labels) {
-      if (label > 0 && !removeAllHydrogenRGroups) {
-        continue;
-      }
-      bool allH = true;
-      for (auto &position : results) {
-        R_DECOMP::const_iterator rgroup = position.rgroups.find(label);
-        bool labelHasCore = labelCores[label].find(position.core_idx) !=
-                            labelCores[label].end();
-        if (labelHasCore && rgroup != position.rgroups.end() &&
-            !rgroup->second->is_hydrogen) {
-          allH = false;
-          break;
-        }
-      }
-
-      if (allH) {
-        labelsToErase.insert(label);
-        for (auto &position : results) {
-          position.rgroups.erase(label);
-        }
-      }
-    }
-
-    for (auto &position : results) {
-      for (auto atom : position.matchedCore->atoms()) {
-        if (int atomLabel; atom->getAtomicNum() == 0 &&
-                           atom->getPropIfPresent(RLABEL, atomLabel)) {
-          if (atomLabel > 0 && !params.removeAllHydrogenRGroupsAndLabels) {
-            continue;
-          }
-          if (labelsToErase.find(atomLabel) != labelsToErase.end()) {
-            atom->setAtomicNum(1);
-            atom->clearProp(RLABEL);
-            if (atom->hasProp(RLABEL_TYPE)) {
-              atom->clearProp(RLABEL_TYPE);
-            }
-            if (atom->hasProp(UNLABELED_CORE_ATTACHMENT)) {
-              atom->clearProp(UNLABELED_CORE_ATTACHMENT);
-            }
-            atom->updatePropertyCache(false);
-          }
-        }
-      }
-    }
-
-    return results;
-  }
+  std::vector<RGroupMatch> GetCurrentBestPermutation() const;
 
   class UsedLabels {
    public:
     std::set<int> labels_used;
-    bool add(int rlabel) {
-      if (labels_used.find(rlabel) != labels_used.end()) {
-        return false;
-      }
-      labels_used.insert(rlabel);
-      return true;
-    }
 
-    int next() {
-      int i = 1;
-      while (labels_used.find(i) != labels_used.end()) {
-        ++i;
-      }
-      labels_used.insert(i);
-      return i;
-    }
+    bool add(int rlabel);
+
+    int next();
   };
 
-  void addCoreUserLabels(const RWMol &core, std::set<int> &userLabels) {
-    auto atoms = getRlabels(core);
-    for (const auto &p : atoms) {
-      if (p.first > 0) {
-        userLabels.insert(p.first);
-      }
-    }
-  }
+  void addCoreUserLabels(const RWMol &core, std::set<int> &userLabels);
 
   void addAtoms(RWMol &mol,
-                const std::vector<std::pair<Atom *, Atom *>> &atomsToAdd) {
-    for (const auto &i : atomsToAdd) {
-      mol.addAtom(i.second, false, true);
-      mol.addBond(i.first, i.second, Bond::SINGLE);
-      if (mol.getNumConformers()) {
-        MolOps::setTerminalAtomCoords(mol, i.second->getIdx(),
-                                      i.first->getIdx());
-      }
-    }
-  }
+                const std::vector<std::pair<Atom *, Atom *>> &atomsToAdd);
 
   bool replaceHydrogenCoreDummy(const RGroupMatch &match, RWMol &core,
                                 const Atom &atom, const int currentLabel,
-                                const int rLabel) {
-    // if the R group is just a hydrogen then the attachment point should
-    // replace an existing hydrogen neighbor since all hydrogen neighbors
-    // are copied from the input molecule to the extracted core.
-    if (const auto group = match.rgroups.find(currentLabel);
-        group != match.rgroups.end()) {
-      if (group->second->is_hydrogen) {
-        for (auto &neighbor : core.atomNeighbors(&atom)) {
-          if (neighbor->getAtomicNum() == 1) {
-            neighbor->setAtomicNum(0);
-            setRlabel(neighbor, rLabel);
-            return true;
-          }
-        }
-      }
-    }
-    return false;
-  }
+                                const int rLabel);
 
   void relabelCore(RWMol &core, std::map<int, int> &mappings,
                    UsedLabels &used_labels, const std::set<int> &indexLabels,
                    const std::map<int, std::vector<int>> &extraAtomRLabels,
-                   const RGroupMatch *const match = nullptr) {
-    // Now remap to proper rlabel ids
-    //  if labels are positive, they come from User labels
-    //  if they are negative, they come from indices and should be
-    //  numbered *after* the user labels.
-    //
-    //  Some indices are attached to multiple bonds,
-    //   these rlabels should be incrementally added last
-    std::map<int, Atom *> atoms = getRlabels(core);
-    // a core only has one labelled index
-    //  a secondary structure extraAtomRLabels contains the number
-    //  of bonds between this atom and the side chain
+                   const RGroupMatch *const match = nullptr);
 
-    // a sidechain atom has a vector of the attachments back to the
-    //  core that takes the place of numBondsToRlabel
-
-    std::vector<std::pair<Atom *, Atom *>> atomsToAdd;  // adds -R if necessary
-
-    // Deal with user supplied labels
-    for (const auto &rlabels : atoms) {
-      int userLabel = rlabels.first;
-      if (userLabel < 0) {
-        continue;  // not a user specified label
-      }
-      Atom *atom = rlabels.second;
-      mappings[userLabel] = userLabel;
-      used_labels.add(userLabel);
-
-      if (atom->getAtomicNum() == 0 &&
-          atom->getDegree() == 1) {  // add to existing dummy/rlabel
-        setRlabel(atom, userLabel);
-      } else {
-        // A non-terminal RGroup. Create a dummy by replacing an existing
-        // hydrogen for hydrogen side chains, or a new dummy atom for heavy side
-        // chains.
-        bool addNew = true;
-        if (match != nullptr) {
-          addNew = !replaceHydrogenCoreDummy(*match, core, *atom, userLabel,
-                                             userLabel);
-          // If we can't replace a hydrogen only add the dummy if it exists in
-          // the decomp This is unexpected.
-          if (addNew &&
-              match->rgroups.find(userLabel) == match->rgroups.end()) {
-            addNew = false;
-          }
-        }
-        if (addNew) {
-          auto *newAt = new Atom(0);
-          setRlabel(newAt, userLabel);
-          atomsToAdd.emplace_back(atom, newAt);
-        }
-      }
-    }
-
-    // Deal with non-user supplied labels
-    for (auto newLabel : indexLabels) {
-      auto atm = atoms.find(newLabel);
-      if (atm == atoms.end()) {
-        continue;
-      }
-
-      Atom *atom = atm->second;
-
-      int rlabel;
-      auto mapping = mappings.find(newLabel);
-      if (mapping == mappings.end()) {
-        rlabel = used_labels.next();
-        mappings[newLabel] = rlabel;
-      } else {
-        rlabel = mapping->second;
-      }
-
-      if (atom->getAtomicNum() == 0 &&
-          !isAnyAtomWithMultipleNeighborsOrNotUserRLabel(
-              *atom)) {  // add to dummy
-        setRlabel(atom, rlabel);
-      } else {
-        bool addNew = true;
-        if (match != nullptr) {
-          addNew =
-              !replaceHydrogenCoreDummy(*match, core, *atom, newLabel, rlabel);
-          // If we can't replace a hydrogen only add the dummy if it exists in
-          // the decomp This is unexpected.
-          if (addNew && match->rgroups.find(newLabel) == match->rgroups.end()) {
-            addNew = false;
-          }
-        }
-        if (addNew) {
-          auto *newAt = new Atom(0);
-          setRlabel(newAt, rlabel);
-          atomsToAdd.emplace_back(atom, newAt);
-        }
-      }
-    }
-
-    // Deal with multiple bonds to the same label
-    for (const auto &extraAtomRLabel : extraAtomRLabels) {
-      auto atm = atoms.find(extraAtomRLabel.first);
-      if (atm == atoms.end()) {
-        continue;  // label not used in the rgroup
-      }
-      Atom *atom = atm->second;
-
-      for (size_t i = 0; i < extraAtomRLabel.second.size(); ++i) {
-        int rlabel = used_labels.next();
-        // Is this necessary?
-        CHECK_INVARIANT(
-            atom->getAtomicNum() > 1,
-            "Multiple attachments to a dummy (or hydrogen) is weird.");
-        auto *newAt = new Atom(0);
-        setRlabel(newAt, rlabel);
-        atomsToAdd.emplace_back(atom, newAt);
-      }
-    }
-
-    addAtoms(core, atomsToAdd);
-    for (const auto &rlabels : atoms) {
-      auto atom = rlabels.second;
-      atom->clearProp(RLABEL);
-      atom->clearProp(RLABEL_TYPE);
-    }
-
-    // Delay removing hydrogens from core until outputCoreMolecule is called,
-    // If hydrogens are removed now and more dummies removed in
-    // outputCoreMolecule then aromaticity perception in the core may be broken.
-
-    core.updatePropertyCache(false);  // this was github #1550
-  }
-
-  void relabelRGroup(RGroupData &rgroup, const std::map<int, int> &mappings) {
-    PRECONDITION(rgroup.combinedMol.get(), "Unprocessed rgroup");
-
-    RWMol &mol = *rgroup.combinedMol.get();
-
-    if (rgroup.combinedMol->hasProp(done)) {
-      rgroup.labelled = true;
-      return;
-    }
-
-    mol.setProp(done, true);
-    std::vector<std::pair<Atom *, Atom *>> atomsToAdd;  // adds -R if necessary
-    std::map<int, int> rLabelCoreIndexToAtomicWt;
-
-    for (RWMol::AtomIterator atIt = mol.beginAtoms(); atIt != mol.endAtoms();
-         ++atIt) {
-      Atom *atom = *atIt;
-      if (atom->hasProp(SIDECHAIN_RLABELS)) {
-        atom->setIsotope(0);
-        const std::vector<int> &rlabels =
-            atom->getProp<std::vector<int>>(SIDECHAIN_RLABELS);
-        // switch on atom mappings or rlabels....
-
-        for (int rlabel : rlabels) {
-          auto label = mappings.find(rlabel);
-          CHECK_INVARIANT(label != mappings.end(), "Unprocessed mapping");
-
-          if (atom->getAtomicNum() == 0) {
-            if (!atom->hasProp(_rgroupInputDummy)) {
-              setRlabel(atom, label->second);
-            }
-          } else if (atom->hasProp(RLABEL_CORE_INDEX)) {
-            atom->setAtomicNum(0);
-            setRlabel(atom, label->second);
-          } else {
-            auto *newAt = new Atom(0);
-            setRlabel(newAt, label->second);
-            atomsToAdd.emplace_back(atom, newAt);
-          }
-        }
-      }
-      if (atom->hasProp(RLABEL_CORE_INDEX)) {
-        // convert to dummy as we don't want to collapse hydrogens onto the core
-        // match
-        auto rLabelCoreIndex = atom->getProp<int>(RLABEL_CORE_INDEX);
-        rLabelCoreIndexToAtomicWt[rLabelCoreIndex] = atom->getAtomicNum();
-        atom->setAtomicNum(0);
-      }
-    }
-
-    addAtoms(mol, atomsToAdd);
-
-    if (params.removeHydrogensPostMatch) {
-      RDLog::LogStateSetter blocker;
-      bool implicitOnly = false;
-      bool updateExplicitCount = false;
-      bool sanitize = false;
-      MolOps::removeHs(mol, implicitOnly, updateExplicitCount, sanitize);
-    }
-
-    mol.updatePropertyCache(false);  // this was github #1550
-    rgroup.labelled = true;
-
-    // Restore any core matches that we have set to dummy
-    for (RWMol::AtomIterator atIt = mol.beginAtoms(); atIt != mol.endAtoms();
-         ++atIt) {
-      Atom *atom = *atIt;
-      if (atom->hasProp(RLABEL_CORE_INDEX)) {
-        // don't need to set IsAromatic on atom - that seems to have been saved
-        atom->setAtomicNum(
-            rLabelCoreIndexToAtomicWt[atom->getProp<int>(RLABEL_CORE_INDEX)]);
-        atom->setNoImplicit(true);
-        atom->clearProp(RLABEL_CORE_INDEX);
-      }
-      atom->clearProp(SIDECHAIN_RLABELS);
-    }
-
-#ifdef VERBOSE
-    std::cerr << "Relabel Rgroup smiles " << MolToSmiles(mol) << std::endl;
-#endif
-  }
+  void relabelRGroup(RGroupData &rgroup, const std::map<int, int> &mappings);
 
   // relabel the core and sidechains using the specified user labels
   //  if matches exist for non labelled atoms, these are added as well
-  void relabel() {
-    std::vector<RGroupMatch> best = GetCurrentBestPermutation();
-
-    // get the labels used
-    std::set<int> userLabels;
-    std::set<int> indexLabels;
-
-    // Go through all the RGroups and find out which labels were
-    //  actually used.
-
-    // some atoms will have multiple attachment points, i.e. cycles
-    //  split these up into new rlabels if necessary
-    //  These are detected at match time
-    //  This vector will hold the extra (new) labels required
-    std::map<int, std::vector<int>> extraAtomRLabels;
-
-    for (auto &it : best) {
-      for (auto &rgroup : it.rgroups) {
-        if (rgroup.first > 0) {
-          userLabels.insert(rgroup.first);
-        }
-        if (rgroup.first < 0 && !params.onlyMatchAtRGroups) {
-          indexLabels.insert(rgroup.first);
-        }
-
-        std::map<int, int> rlabelsUsedInRGroup =
-            rgroup.second->getNumBondsToRlabels();
-        for (auto &numBondsUsed : rlabelsUsedInRGroup) {
-          // Make space for the extra labels
-          if (numBondsUsed.second > 1) {  // multiple rgroup bonds to same atom
-            extraAtomRLabels[numBondsUsed.first].resize(numBondsUsed.second -
-                                                        1);
-          }
-        }
-      }
-    }
-
-    // find user labels that are not present in the decomposition
-    for (auto &core : cores) {
-      core.second.labelledCore.reset(new RWMol(*core.second.core));
-      addCoreUserLabels(*core.second.labelledCore, userLabels);
-    }
-
-    // Assign final RGroup labels to the cores and propagate these to
-    //  the scaffold
-    finalRlabelMapping.clear();
-
-    UsedLabels used_labels;
-    // Add all the user labels now to prevent an index label being assigned to a
-    // user label when multiple cores are present (e.g. the user label is
-    // present in the second core, but not the first).
-    for (auto userLabel : userLabels) {
-      used_labels.add(userLabel);
-    }
-    for (auto &core : cores) {
-      relabelCore(*core.second.labelledCore, finalRlabelMapping, used_labels,
-                  indexLabels, extraAtomRLabels);
-    }
-
-    for (auto &it : best) {
-      for (auto &rgroup : it.rgroups) {
-        relabelRGroup(*rgroup.second, finalRlabelMapping);
-      }
-#ifdef VERBOSE
-      std::cerr << "relabel core mol1 " << MolToSmiles(*it.matchedCore)
-                << std::endl;
-#endif
-      relabelCore(*it.matchedCore, finalRlabelMapping, used_labels, indexLabels,
-                  extraAtomRLabels, &it);
-#ifdef VERBOSE
-      std::cerr << "relabel core mol2 " << MolToSmiles(*it.matchedCore)
-                << std::endl;
-#endif
-    }
-
-    std::set<int> uniqueMappedValues;
-    std::transform(finalRlabelMapping.cbegin(), finalRlabelMapping.cend(),
-                   std::inserter(uniqueMappedValues, uniqueMappedValues.end()),
-                   [](const std::pair<int, int> &p) { return p.second; });
-    CHECK_INVARIANT(finalRlabelMapping.size() == uniqueMappedValues.size(),
-                    "Error in uniqueness of final RLabel mapping");
-    CHECK_INVARIANT(
-        uniqueMappedValues.size() == userLabels.size() + indexLabels.size(),
-        "Error in final RMapping size");
-  }
+  void relabel();
 
   double score(const std::vector<size_t> &permutation,
                FingerprintVarianceScoreData *fingerprintVarianceScoreData =
-                   nullptr) const {
-    RGroupScore scoreMethod = static_cast<RGroupScore>(params.scoreMethod);
-    switch (scoreMethod) {
-      case Match:
-        return rGroupScorer.matchScore(permutation, matches, labels);
-        break;
-      case FingerprintVariance:
-        return fingerprintVarianceScore(permutation, matches, labels,
-                                        fingerprintVarianceScoreData);
-        break;
-      default:;
-    }
-    return NAN;
-  }
+                   nullptr) const;
 
   RGroupDecompositionProcessResult process(bool pruneMatches,
-                                           bool finalize = false) {
-    if (matches.empty()) {
-      return RGroupDecompositionProcessResult(false, -1);
-    }
-    auto t0 = std::chrono::steady_clock::now();
-    std::unique_ptr<CartesianProduct> iterator;
-    rGroupScorer.startProcessing();
-
-    if (params.matchingStrategy == GA) {
-      RGroupGa ga(*this, params.timeout >= 0 ? &t0 : nullptr);
-      if (ga.numberPermutations() < 100 * ga.getPopsize()) {
-        params.matchingStrategy = Exhaustive;
-      } else {
-        if (params.gaNumberRuns > 1) {
-          auto results = ga.runBatch();
-          auto best = max_element(results.begin(), results.end(),
-                                  [](const GaResult &a, const GaResult &b) {
-                                    return a.rGroupScorer.getBestScore() <
-                                           b.rGroupScorer.getBestScore();
-                                  });
-          rGroupScorer = best->rGroupScorer;
-        } else {
-          auto result = ga.run();
-          rGroupScorer = result.rGroupScorer;
-        }
-      }
-    }
-    size_t offset = 0;
-    if (params.matchingStrategy != GA) {
-      // Exhaustive search, get the MxN matrix
-      // (M = matches.size(): number of molecules
-      //  N = iterator.maxPermutations)
-      std::vector<size_t> permutations;
-
-      if (pruneMatches && params.scoreMethod != FingerprintVariance) {
-        offset = previousMatchSize;
-      }
-      previousMatchSize = matches.size();
-      std::transform(
-          matches.begin() + offset, matches.end(),
-          std::back_inserter(permutations),
-          [](const std::vector<RGroupMatch> &m) { return m.size(); });
-      permutation = std::vector<size_t>(permutations.size(), 0);
-
-      // run through all possible matches and score each
-      //  set
-      size_t count = 0;
-#ifdef DEBUG
-      std::cerr << "Processing" << std::endl;
-#endif
-      std::unique_ptr<CartesianProduct> it(new CartesianProduct(permutations));
-      iterator = std::move(it);
-      // Iterates through the permutation idx, i.e.
-      //  [m1_permutation_idx,  m2_permutation_idx, m3_permutation_idx]
-
-      while (iterator->next()) {
-        if (count > iterator->maxPermutations) {
-          throw ValueErrorException("next() did not finish");
-        }
-#ifdef DEBUG
-        std::cerr << "**************************************************"
-                  << std::endl;
-#endif
-        double newscore = params.scoreMethod == FingerprintVariance
-                              ? scoreFromPrunedData(iterator->permutation)
-                              : score(iterator->permutation);
-
-        if (fabs(newscore - rGroupScorer.getBestScore()) <
-            1e-6) {  // heuristic to overcome floating point comparison issues
-          rGroupScorer.pushTieToStore(iterator->permutation);
-        } else if (newscore > rGroupScorer.getBestScore()) {
-#ifdef DEBUG
-          std::cerr << " ===> current best:" << newscore << ">"
-                    << rGroupScorer.getBestScore() << std::endl;
-#endif
-          rGroupScorer.setBestPermutation(iterator->permutation, newscore);
-          rGroupScorer.clearTieStore();
-          rGroupScorer.pushTieToStore(iterator->permutation);
-        }
-        ++count;
-      }
-    }
-
-    if (rGroupScorer.tieStoreSize() > 1) {
-      rGroupScorer.breakTies(matches, labels, iterator, t0, params.timeout);
-      rGroupScorer.clearTieStore();
-    } else {
-      checkForTimeout(t0, params.timeout);
-    }
-    permutation = rGroupScorer.getBestPermutation();
-    if (pruneMatches || finalize) {
-      prune();
-    }
-
-    if (finalize) {
-      relabel();
-    }
-
-    return RGroupDecompositionProcessResult(true, rGroupScorer.getBestScore());
-  }
+                                           bool finalize = false);
 };
 }  // namespace RDKit
 

--- a/Code/GraphMol/RGroupDecomposition/RGroupDecompParams.cpp
+++ b/Code/GraphMol/RGroupDecomposition/RGroupDecompParams.cpp
@@ -8,7 +8,7 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-#include "RGroupDecomp.h"
+#include "RGroupDecompParams.h"
 #include "RGroupUtils.h"
 #include <GraphMol/RDKitBase.h>
 #include <GraphMol/Substruct/SubstructMatch.h>

--- a/Code/GraphMol/RGroupDecomposition/RGroupDecompParams.h
+++ b/Code/GraphMol/RGroupDecomposition/RGroupDecompParams.h
@@ -1,0 +1,120 @@
+//
+//  Copyright (c) 2017-2023, Novartis Institutes for BioMedical Research Inc.
+//  and other RDKit contributors
+//
+//   @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
+//
+
+#ifndef RDKIT_RGROUPDECOMPPARAMS_H
+#define RDKIT_RGROUPDECOMPPARAMS_H
+
+#include "../RDKitBase.h"
+#include <GraphMol/Substruct/SubstructMatch.h>
+
+namespace RDKit {
+
+typedef enum {
+  IsotopeLabels = 0x01,
+  AtomMapLabels = 0x02,
+  AtomIndexLabels = 0x04,
+  RelabelDuplicateLabels = 0x08,
+  MDLRGroupLabels = 0x10,
+  DummyAtomLabels = 0x20,  // These are rgroups but will get relabelled
+  AutoDetect = 0xFF,
+} RGroupLabels;
+
+typedef enum {
+  Greedy = 0x01,
+  GreedyChunks = 0x02,
+  Exhaustive = 0x04,  // not really useful for large sets
+  NoSymmetrization = 0x08,
+  GA = 0x10,
+} RGroupMatching;
+
+typedef enum {
+  AtomMap = 0x01,
+  Isotope = 0x02,
+  MDLRGroup = 0x04,
+} RGroupLabelling;
+
+typedef enum {
+  // DEPRECATED, remove the following line in release 2021.03
+  None = 0x0,
+  NoAlignment = 0x0,
+  MCS = 0x01,
+} RGroupCoreAlignment;
+
+typedef enum {
+  Match = 0x1,
+  FingerprintVariance = 0x4,
+} RGroupScore;
+
+struct RDKIT_RGROUPDECOMPOSITION_EXPORT RGroupDecompositionParameters {
+  unsigned int labels = AutoDetect;
+  unsigned int matchingStrategy = GreedyChunks;
+  unsigned int scoreMethod = Match;
+  unsigned int rgroupLabelling = AtomMap | MDLRGroup;
+  unsigned int alignment = MCS;
+
+  unsigned int chunkSize = 5;
+  //! only allow rgroup decomposition at the specified rgroups
+  bool onlyMatchAtRGroups = false;
+  //! remove all user-defined rgroups that only have hydrogens
+  bool removeAllHydrogenRGroups = true;
+  //! remove all user-defined rgroups that only have hydrogens,
+  //! and also remove the corresponding labels from the core
+  bool removeAllHydrogenRGroupsAndLabels = true;
+  //! remove all hydrogens from the output molecules
+  bool removeHydrogensPostMatch = true;
+  //! allow labelled Rgroups of degree 2 or more
+  bool allowNonTerminalRGroups = false;
+  // unlabelled core atoms can have multiple rgroups
+  bool allowMultipleRGroupsOnUnlabelled = false;
+
+  double timeout = -1.0;  ///< timeout in seconds. <=0 indicates no timeout
+
+  // Determine how to assign the rgroup labels from the given core
+  unsigned int autoGetLabels(const RWMol &);
+
+  // Prepare the core for substructure searching and rgroup assignment
+  bool prepareCore(RWMol &, const RWMol *alignCore);
+
+  // Add r groups to unlabelled atoms if allowMultipleRGroupsOnUnlabelled is set
+  void addDummyAtomsToUnlabelledCoreAtoms(RWMol &core);
+
+  // Parameters specific to GA
+
+  // GA population size or -1 to use best guess
+  int gaPopulationSize = -1;
+  // GA maximum number of operations or -1 to use best guess
+  int gaMaximumOperations = -1;
+  // GA number of operations permitted without improvement before exiting (-1
+  // for best guess)
+  int gaNumberOperationsWithoutImprovement = -1;
+  // GA random number seed (-1 for default, -2 for random seed)
+  int gaRandomSeed = -1;
+  // Number of runs
+  int gaNumberRuns = 1;
+  // Sequential or parallel runs?
+#ifdef RDK_BUILD_THREADSAFE_SSS
+  bool gaParallelRuns = true;
+#else
+  bool gaParallelRuns = false;
+#endif
+  // Controls the way substructure matching with the core is done
+  SubstructMatchParameters substructmatchParams;
+
+  RGroupDecompositionParameters() { substructmatchParams.useChirality = true; }
+
+ private:
+  int indexOffset{-1};
+  void checkNonTerminal(const Atom &atom) const;
+};
+
+}  // namespace RDKit
+
+#endif  // RDKIT_RGROUPDECOMPPARAMS_H

--- a/Code/GraphMol/RGroupDecomposition/testRGroupDecomp.cpp
+++ b/Code/GraphMol/RGroupDecomposition/testRGroupDecomp.cpp
@@ -36,6 +36,7 @@
 #include <iostream>
 #include <GraphMol/SmilesParse/SmilesParse.h>
 #include <GraphMol/SmilesParse/SmilesWrite.h>
+#include <GraphMol/ChemTransforms/ChemTransforms.h>
 #include <GraphMol/RGroupDecomposition/RGroupDecomp.h>
 #include <GraphMol/RGroupDecomposition/RGroupDecompData.h>
 #include <GraphMol/FileParsers/FileParsers.h>

--- a/Code/GraphMol/RGroupDecomposition/testRGroupInternals.cpp
+++ b/Code/GraphMol/RGroupDecomposition/testRGroupInternals.cpp
@@ -40,6 +40,7 @@
 #define private public
 #include <GraphMol/RGroupDecomposition/RGroupDecomp.h>
 #include <GraphMol/RGroupDecomposition/RGroupDecompData.h>
+#include <GraphMol/RGroupDecomposition/RGroupGa.h>
 
 using namespace RDKit;
 

--- a/Code/JavaWrappers/RGroupDecomposition.i
+++ b/Code/JavaWrappers/RGroupDecomposition.i
@@ -10,6 +10,7 @@
 *
 */
 %{
+#include <GraphMol/RGroupDecomposition/RGroupDecompParams.h>
 #include <GraphMol/RGroupDecomposition/RGroupDecomp.h>
 typedef std::vector<std::string> STR_VECT;
 %}
@@ -46,4 +47,5 @@ typedef std::vector<std::string> STR_VECT;
   }
 }
 
+%include <GraphMol/RGroupDecomposition/RGroupDecompParams.h>
 %include <GraphMol/RGroupDecomposition/RGroupDecomp.h>


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! 
-->
#### Reference Issue
None


#### What does this implement/fix? Explain your changes.

RDG has a lot of code in header files.  I've created implementations in cpp files for functions previously defined in `RGroupData.h` and `RGroupDecompData.h`.  I also created a `RGroupDecompParams.h` to match `RGroupDecompParams.cpp`


