### PR TITLE
Fixes #5838

### DIFF
--- a/Code/GraphMol/Fingerprints/FingerprintGenerator.cpp
+++ b/Code/GraphMol/Fingerprints/FingerprintGenerator.cpp
@@ -283,6 +283,24 @@ void duplicateAdditionalOutputBit(AdditionalOutput &oldAO,
     }
   }
 }
+
+void setupTempAdditionalOutput(RDKit::FingerprintFuncArguments &args,
+                               AdditionalOutput &countSimulationOutput,
+                               size_t numAtoms) {
+  if (args.additionalOutput->atomToBits) {
+    countSimulationOutput.allocateAtomToBits();
+  }
+  if (args.additionalOutput->atomCounts) {
+    countSimulationOutput.allocateAtomCounts();
+  }
+  if (args.additionalOutput->bitInfoMap) {
+    countSimulationOutput.allocateBitInfoMap();
+  }
+  if (args.additionalOutput->bitPaths) {
+    countSimulationOutput.allocateBitPaths();
+  }
+  reinitAdditionalOutput(*args.additionalOutput, numAtoms);
+}
 }  // namespace
 
 template <typename OutputType>
@@ -315,18 +333,7 @@ FingerprintGenerator<OutputType>::getSparseFingerprint(
   AdditionalOutput countSimulationOutput;
   AdditionalOutput *origAO = nullptr;
   if (dp_fingerprintArguments->df_countSimulation && args.additionalOutput) {
-    if (args.additionalOutput->atomToBits) {
-      countSimulationOutput.allocateAtomToBits();
-    }
-    if (args.additionalOutput->atomCounts) {
-      countSimulationOutput.allocateAtomCounts();
-    }
-    if (args.additionalOutput->bitInfoMap) {
-      countSimulationOutput.allocateBitInfoMap();
-    }
-    if (args.additionalOutput->bitPaths) {
-      countSimulationOutput.allocateBitPaths();
-    }
+    setupTempAdditionalOutput(args, countSimulationOutput, mol.getNumAtoms());
     origAO = args.additionalOutput;
     args.additionalOutput = &countSimulationOutput;
   }
@@ -397,21 +404,7 @@ FingerprintGenerator<OutputType>::getFingerprint(
   AdditionalOutput countSimulationOutput;
   AdditionalOutput *origAO = nullptr;
   if (dp_fingerprintArguments->df_countSimulation && args.additionalOutput) {
-    if (args.additionalOutput->atomToBits) {
-      countSimulationOutput.allocateAtomToBits();
-    }
-    if (args.additionalOutput->atomCounts) {
-      countSimulationOutput.allocateAtomCounts();
-    }
-    if (args.additionalOutput->bitInfoMap) {
-      countSimulationOutput.allocateBitInfoMap();
-    }
-    if (args.additionalOutput->bitPaths) {
-      countSimulationOutput.allocateBitPaths();
-    }
-    reinitAdditionalOutput(countSimulationOutput, mol.getNumAtoms());
-    reinitAdditionalOutput(*args.additionalOutput, mol.getNumAtoms());
-
+    setupTempAdditionalOutput(args, countSimulationOutput, mol.getNumAtoms());
     origAO = args.additionalOutput;
     args.additionalOutput = &countSimulationOutput;
   }

--- a/Code/GraphMol/Fingerprints/FingerprintGenerator.h
+++ b/Code/GraphMol/Fingerprints/FingerprintGenerator.h
@@ -43,7 +43,7 @@ struct RDKIT_FINGERPRINTS_EXPORT AdditionalOutput {
   bitPathsType *bitPaths = nullptr;
 
   // number of paths that set bits for each atom, must have the same size as
-  // atom count for molecule
+  // atom count for molecule.
   atomCountsType *atomCounts = nullptr;
 
   void allocateAtomToBits() {

--- a/Code/GraphMol/Fingerprints/Wrap/testGenerators.py
+++ b/Code/GraphMol/Fingerprints/Wrap/testGenerators.py
@@ -228,7 +228,7 @@ class TestCase(unittest.TestCase):
     ao.AllocateAtomToBits()
     fp = g.GetFingerprint(m1, additionalOutput=ao)
     self.assertIsNone(ao.GetAtomCounts())
-    self.assertEqual(ao.GetAtomToBits(), ((351, 479), (351, 399), (479, 399)))
+    self.assertEqual(ao.GetAtomToBits(), ((1404, 1916), (1404, 1596), (1596, 1916)))
     self.assertIsNone(ao.GetBitInfoMap())
     self.assertIsNone(ao.GetBitPaths())
 
@@ -237,7 +237,7 @@ class TestCase(unittest.TestCase):
     fp = g.GetFingerprint(m1, additionalOutput=ao)
     self.assertIsNone(ao.GetAtomCounts())
     self.assertIsNone(ao.GetAtomToBits())
-    self.assertEqual(ao.GetBitInfoMap(), {351: ((0, 1), ), 399: ((1, 2), ), 479: ((0, 2), )})
+    self.assertEqual(ao.GetBitInfoMap(), {1404: ((0, 1), ), 1596: ((1, 2), ), 1916: ((0, 2), )})
     self.assertIsNone(ao.GetBitPaths())
 
   def testCountBounds(self):

--- a/Code/GraphMol/Fingerprints/catch_tests.cpp
+++ b/Code/GraphMol/Fingerprints/catch_tests.cpp
@@ -416,7 +416,7 @@ TEST_CASE("TopologicalTorsionGenerator bit info", "[fpgenerator][TT]") {
       // clang-format off
       AdditionalOutput::bitPathsType expected = {
           {0, {{0, 1, 2, 3}}},
-          {384, {{1, 2, 3, 4}}}
+          {1536, {{1, 2, 3, 4}}}
       };
       // clang-format on
       AdditionalOutput ao;
@@ -447,7 +447,7 @@ TEST_CASE("TopologicalTorsionGenerator bit info", "[fpgenerator][TT]") {
 
     {
       AdditionalOutput::atomToBitsType expected1 = {
-          {0}, {0, 384}, {0, 384}, {0, 384}, {384}};
+          {0}, {0, 1536}, {0, 1536}, {0, 1536}, {1536}};
       AdditionalOutput ao;
       ao.allocateAtomCounts();
       ao.allocateAtomToBits();
@@ -474,8 +474,8 @@ TEST_CASE("TopologicalTorsionGenerator bit info", "[fpgenerator][TT]") {
     {
       // clang-format off
       AdditionalOutput::bitPathsType expected = {
-          {261685121, {{1, 2, 3, 4}}},
-          {262078465, {{0, 1, 2, 3}}},
+          {1046740484, {{1, 2, 3, 4}}},
+          {1048313860, {{0, 1, 2, 3}}},
       };
       // clang-format on
       AdditionalOutput ao;
@@ -505,11 +505,11 @@ TEST_CASE("TopologicalTorsionGenerator bit info", "[fpgenerator][TT]") {
     AdditionalOutput::atomCountsType expected2 = {1, 2, 2, 2, 1};
 
     {
-      AdditionalOutput::atomToBitsType expected1 = {{262078465},
-                                                    {262078465, 261685121},
-                                                    {262078465, 261685121},
-                                                    {262078465, 261685121},
-                                                    {261685121}};
+      AdditionalOutput::atomToBitsType expected1 = {{1048313860},
+                                                    {1046740484, 1048313860},
+                                                    {1046740484, 1048313860},
+                                                    {1046740484, 1048313860},
+                                                    {1046740484}};
       AdditionalOutput ao;
       ao.allocateAtomCounts();
       ao.allocateAtomToBits();
@@ -549,9 +549,9 @@ TEST_CASE("AtomPairGenerator bit info", "[fpgenerator][AP]") {
   SECTION("folded bitInfo") {
     {
       AdditionalOutput::bitInfoMapType expected = {
-          {351, {{0, 1}}},
-          {479, {{0, 2}}},
-          {399, {{1, 2}}},
+          {1404, {{0, 1}}},
+          {1916, {{0, 2}}},
+          {1596, {{1, 2}}},
       };
       AdditionalOutput ao;
       ao.allocateBitInfoMap();
@@ -579,9 +579,9 @@ TEST_CASE("AtomPairGenerator bit info", "[fpgenerator][AP]") {
 
     {
       AdditionalOutput::atomToBitsType expected1 = {
-          {351, 479},
-          {351, 399},
-          {479, 399},
+          {1404, 1916},
+          {1404, 1596},
+          {1596, 1916},
       };
       AdditionalOutput ao;
       ao.allocateAtomCounts();
@@ -611,9 +611,9 @@ TEST_CASE("AtomPairGenerator bit info", "[fpgenerator][AP]") {
   SECTION("unfolded bitInfo") {
     {
       AdditionalOutput::bitInfoMapType expected = {
-          {1979743, {{0, 1}}},
-          {1979871, {{0, 2}}},
-          {2016655, {{1, 2}}},
+          {7918972, {{0, 1}}},
+          {7919484, {{0, 2}}},
+          {8066620, {{1, 2}}},
       };
       AdditionalOutput ao;
       ao.allocateBitInfoMap();
@@ -641,7 +641,7 @@ TEST_CASE("AtomPairGenerator bit info", "[fpgenerator][AP]") {
 
     {
       AdditionalOutput::atomToBitsType expected1 = {
-          {1979743, 1979871}, {1979743, 2016655}, {1979871, 2016655}};
+          {7918972, 7919484}, {7918972, 8066620}, {7919484, 8066620}};
       AdditionalOutput ao;
       ao.allocateAtomCounts();
       ao.allocateAtomToBits();

--- a/Code/GraphMol/Fingerprints/fpgen_catch_tests.cpp
+++ b/Code/GraphMol/Fingerprints/fpgen_catch_tests.cpp
@@ -147,12 +147,6 @@ TEST_CASE(
       }
       std::vector<unsigned int> atomCounts{2, 3, 3, 3, 3, 3, 3, 2};
       CHECK(*ao.atomCounts == atomCounts);
-      for (auto i = 0u; i < m->getNumAtoms(); ++i) {
-        std::cerr << " {";
-        std::copy(ao.atomToBits->at(i).begin(), ao.atomToBits->at(i).end(),
-                  std::ostream_iterator<int>(std::cerr, ", "));
-        std::cerr << " }," << std::endl;
-      }
       std::vector<std::vector<std::uint64_t>> atomToBits = {
           {888, 1180},
           {320, 321, 322, 424, 1892},
@@ -177,27 +171,34 @@ TEST_CASE(
       CHECK(fp->getNumOnBits() == ao.bitInfoMap->size());
       std::vector<int> obl;
       fp->getOnBits(obl);
-      for (const auto bid : obl) {
-        INFO(bid);
-        CHECK(ao.bitInfoMap->find(bid) != ao.bitInfoMap->end());
+      // there's an unfortunate bit of information loss happening here
+      // due to the fact that the SparseBitVect uses ints, so we have to
+      // do this test backwards:
+      for (auto pr : *ao.bitInfoMap) {
+        INFO(pr.first);
+        CHECK(std::find(obl.begin(), obl.end(), (int)(pr.first)) != obl.end());
       }
-      for (auto i = 0u; i < m->getNumAtoms(); ++i) {
-        std::cerr << " {";
-        std::copy(ao.atomToBits->at(i).begin(), ao.atomToBits->at(i).end(),
-                  std::ostream_iterator<int>(std::cerr, ", "));
-        std::cerr << " }," << std::endl;
-      }
+      // for (auto i = 0u; i < m->getNumAtoms(); ++i) {
+      //   std::cerr << " {";
+      //   std::copy(ao.atomToBits->at(i).begin(), ao.atomToBits->at(i).end(),
+      //             std::ostream_iterator<std::uint64_t>(std::cerr, ", "));
+      //   std::cerr << " }," << std::endl;
+      // }
       std::vector<unsigned int> atomCounts{2, 3, 3, 3, 3, 3, 3, 2};
       CHECK(*ao.atomCounts == atomCounts);
       std::vector<std::vector<std::uint64_t>> atomToBits = {
-          {1046732804},
-          {1046732804, 1046733088, 1046733089},
-          {1046732804, 1046733088, 1046733089},
-          {1046732804, 1046733088, 1046733089},
-          {1046733088, 1046733089, 1046733188},
-          {1046733088, 1046733089, 1046733188},
-          {1046733088, 1046733089, 1046733188},
-          {1046733188}};
+          {1845699452, 3458649244},
+          {391602504, 391602505, 391602506, 3018396076, 3209717616},
+          {391602504, 391602505, 391602506, 1746877920, 1746877921, 1746877922,
+           3245328504},
+          {391602504, 391602505, 391602506, 647852508, 647852509, 1746877920,
+           1746877921, 1746877922},
+          {391602504, 391602505, 391602506, 647852508, 647852509, 1746877920,
+           1746877921, 1746877922},
+          {391602504, 391602505, 391602506, 1746877920, 1746877921, 1746877922,
+           4225765616},
+          {10672060, 391602504, 391602505, 391602506, 3149364416},
+          {1781206876, 3391828556}};
       CHECK(*ao.atomToBits == atomToBits);
     }
   }

--- a/Code/GraphMol/Fingerprints/fpgen_catch_tests.cpp
+++ b/Code/GraphMol/Fingerprints/fpgen_catch_tests.cpp
@@ -52,3 +52,153 @@ TEST_CASE("includeRedundantEnvironments") {
     }
   }
 }
+
+TEST_CASE(
+    "github #5838: FP count simulation is not accounted for when additional output is requested") {
+  SECTION("as reported") {
+    auto m = "OCCCCCCN"_smiles;
+    REQUIRE(m);
+
+    std::unique_ptr<FingerprintGenerator<std::uint64_t>> fpgen(
+        TopologicalTorsion::getTopologicalTorsionGenerator<std::uint64_t>());
+    REQUIRE(fpgen);
+    CHECK(fpgen->getOptions()->df_countSimulation);
+    {
+      AdditionalOutput ao;
+      ao.allocateBitPaths();
+      ao.allocateAtomToBits();
+      ao.allocateAtomCounts();
+      FingerprintFuncArguments args;
+      args.additionalOutput = &ao;
+      std::unique_ptr<ExplicitBitVect> fp{fpgen->getFingerprint(*m, args)};
+      REQUIRE(fp);
+      CHECK(fp->getNumOnBits() == ao.bitPaths->size());
+      std::vector<int> obl;
+      fp->getOnBits(obl);
+      for (const auto bid : obl) {
+        INFO(bid);
+        CHECK(ao.bitPaths->find(bid) != ao.bitPaths->end());
+      }
+      std::vector<unsigned int> atomCounts{1, 2, 3, 4, 4, 3, 2, 1};
+      CHECK(*ao.atomCounts == atomCounts);
+      std::vector<std::vector<std::uint64_t>> atomToBits = {{0},
+                                                            {0, 284, 285},
+                                                            {0, 284, 285},
+                                                            {0, 284, 285},
+                                                            {284, 285, 384},
+                                                            {284, 285, 384},
+                                                            {284, 285, 384},
+                                                            {384}};
+      CHECK(*ao.atomToBits == atomToBits);
+    }
+    {
+      AdditionalOutput ao;
+      ao.allocateBitPaths();
+      ao.allocateAtomToBits();
+      ao.allocateAtomCounts();
+      FingerprintFuncArguments args;
+      args.additionalOutput = &ao;
+      std::unique_ptr<SparseBitVect> fp{fpgen->getSparseFingerprint(*m, args)};
+      REQUIRE(fp);
+      CHECK(fp->getNumOnBits() == ao.bitPaths->size());
+      std::vector<int> obl;
+      fp->getOnBits(obl);
+      for (const auto bid : obl) {
+        INFO(bid);
+        CHECK(ao.bitPaths->find(bid) != ao.bitPaths->end());
+      }
+      std::vector<unsigned int> atomCounts{1, 2, 3, 4, 4, 3, 2, 1};
+      CHECK(*ao.atomCounts == atomCounts);
+      std::vector<std::vector<std::uint64_t>> atomToBits = {
+          {1046732804},
+          {1046732804, 1046733088, 1046733089},
+          {1046732804, 1046733088, 1046733089},
+          {1046732804, 1046733088, 1046733089},
+          {1046733088, 1046733089, 1046733188},
+          {1046733088, 1046733089, 1046733188},
+          {1046733088, 1046733089, 1046733188},
+          {1046733188}};
+      CHECK(*ao.atomToBits == atomToBits);
+    }
+  }
+  SECTION("morgan") {
+    auto m = "OCCCCCCN"_smiles;
+    REQUIRE(m);
+
+    std::unique_ptr<FingerprintGenerator<std::uint64_t>> fpgen(
+        MorganFingerprint::getMorganGenerator<std::uint64_t>(2));
+    REQUIRE(fpgen);
+    fpgen->getOptions()->df_countSimulation = true;
+    {
+      AdditionalOutput ao;
+      ao.allocateBitInfoMap();
+      ao.allocateAtomToBits();
+      ao.allocateAtomCounts();
+      FingerprintFuncArguments args;
+      args.additionalOutput = &ao;
+      std::unique_ptr<ExplicitBitVect> fp{fpgen->getFingerprint(*m, args)};
+      REQUIRE(fp);
+      CHECK(fp->getNumOnBits() == ao.bitInfoMap->size());
+      std::vector<int> obl;
+      fp->getOnBits(obl);
+      for (const auto bid : obl) {
+        INFO(bid);
+        CHECK(ao.bitInfoMap->find(bid) != ao.bitInfoMap->end());
+      }
+      std::vector<unsigned int> atomCounts{2, 3, 3, 3, 3, 3, 3, 2};
+      CHECK(*ao.atomCounts == atomCounts);
+      for (auto i = 0u; i < m->getNumAtoms(); ++i) {
+        std::cerr << " {";
+        std::copy(ao.atomToBits->at(i).begin(), ao.atomToBits->at(i).end(),
+                  std::ostream_iterator<int>(std::cerr, ", "));
+        std::cerr << " }," << std::endl;
+      }
+      std::vector<std::vector<std::uint64_t>> atomToBits = {
+          {888, 1180},
+          {320, 321, 322, 424, 1892},
+          {116, 320, 321, 322, 1500, 1501, 1502},
+          {320, 321, 322, 476, 477, 1500, 1501, 1502},
+          {320, 321, 322, 476, 477, 1500, 1501, 1502},
+          {232, 320, 321, 322, 1500, 1501, 1502},
+          {320, 321, 322, 1216, 1972},
+          {588, 1876},
+      };
+      CHECK(*ao.atomToBits == atomToBits);
+    }
+    {
+      AdditionalOutput ao;
+      ao.allocateBitInfoMap();
+      ao.allocateAtomToBits();
+      ao.allocateAtomCounts();
+      FingerprintFuncArguments args;
+      args.additionalOutput = &ao;
+      std::unique_ptr<SparseBitVect> fp{fpgen->getSparseFingerprint(*m, args)};
+      REQUIRE(fp);
+      CHECK(fp->getNumOnBits() == ao.bitInfoMap->size());
+      std::vector<int> obl;
+      fp->getOnBits(obl);
+      for (const auto bid : obl) {
+        INFO(bid);
+        CHECK(ao.bitInfoMap->find(bid) != ao.bitInfoMap->end());
+      }
+      for (auto i = 0u; i < m->getNumAtoms(); ++i) {
+        std::cerr << " {";
+        std::copy(ao.atomToBits->at(i).begin(), ao.atomToBits->at(i).end(),
+                  std::ostream_iterator<int>(std::cerr, ", "));
+        std::cerr << " }," << std::endl;
+      }
+      std::vector<unsigned int> atomCounts{2, 3, 3, 3, 3, 3, 3, 2};
+      CHECK(*ao.atomCounts == atomCounts);
+      std::vector<std::vector<std::uint64_t>> atomToBits = {
+          {1046732804},
+          {1046732804, 1046733088, 1046733089},
+          {1046732804, 1046733088, 1046733089},
+          {1046732804, 1046733088, 1046733089},
+          {1046733088, 1046733089, 1046733188},
+          {1046733088, 1046733089, 1046733188},
+          {1046733088, 1046733089, 1046733188},
+          {1046733188}};
+      CHECK(*ao.atomToBits == atomToBits);
+    }
+  }
+}


### PR DESCRIPTION
Adds logic to copy the additional info from the non-count-simulation bits over into the corresponding slots for the count-simulation bits.

