### PR TITLE
Allow the sources of conformer generation failures to be retrieved

### DIFF
--- a/Code/GraphMol/DistGeomHelpers/Embedder.cpp
+++ b/Code/GraphMol/DistGeomHelpers/Embedder.cpp
@@ -772,17 +772,17 @@ bool embedPoints(RDGeom::PointPtrVect *positions, detail::EmbedArgs eargs,
           std::lock_guard<std::mutex> lock(GetFailMutex());
 #endif
           embedParams.failures[EmbedFailureCauses::FIRST_MINIMIZATION]++;
-        } else {
-          gotCoords = EmbeddingOps::checkTetrahedralCenters(positions, eargs,
-                                                            embedParams);
-          if (!gotCoords) {
-            if (embedParams.trackFailures) {
+        }
+      } else {
+        gotCoords = EmbeddingOps::checkTetrahedralCenters(positions, eargs,
+                                                          embedParams);
+        if (!gotCoords) {
+          if (embedParams.trackFailures) {
 #ifdef RDK_BUILD_THREADSAFE_SSS
-              std::lock_guard<std::mutex> lock(GetFailMutex());
+            std::lock_guard<std::mutex> lock(GetFailMutex());
 #endif
-              embedParams
-                  .failures[EmbedFailureCauses::CHECK_TETRAHEDRAL_CENTERS]++;
-            }
+            embedParams
+                .failures[EmbedFailureCauses::CHECK_TETRAHEDRAL_CENTERS]++;
           }
         }
       }
@@ -840,7 +840,7 @@ bool embedPoints(RDGeom::PointPtrVect *positions, detail::EmbedArgs eargs,
       }
     }
 
-  }    // while
+  }  // while
   if (seed > -1) {
     delete rng;
     delete generator;

--- a/Code/GraphMol/DistGeomHelpers/Embedder.cpp
+++ b/Code/GraphMol/DistGeomHelpers/Embedder.cpp
@@ -7,7 +7,7 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-//#define DEBUG_EMBEDDING 1
+// #define DEBUG_EMBEDDING 0
 #include "Embedder.h"
 #include <DistGeom/BoundsMatrix.h>
 #include <DistGeom/DistGeomUtils.h>
@@ -37,6 +37,7 @@
 
 #ifdef RDK_BUILD_THREADSAFE_SSS
 #include <future>
+#include <mutex>
 #endif
 
 //#define DEBUG_EMBEDDING 1
@@ -52,6 +53,27 @@ const double MAX_MINIMIZED_E_CONTRIB = 0.20;
 const double MIN_TETRAHEDRAL_CHIRAL_VOL = 0.50;
 const double TETRAHEDRAL_CENTERINVOLUME_TOL = 0.30;
 }  // namespace
+
+#ifdef RDK_BUILD_THREADSAFE_SSS
+namespace {
+std::mutex &failmutex_get() {
+  // create on demand
+  static std::mutex _mutex;
+  return _mutex;
+}
+
+void failmutex_create() {
+  std::mutex &mutex = failmutex_get();
+  std::lock_guard<std::mutex> test_lock(mutex);
+}
+
+std::mutex &GetFailMutex() {
+  static std::once_flag flag;
+  std::call_once(flag, failmutex_create);
+  return failmutex_get();
+}
+}  // namespace
+#endif
 
 namespace RDKit {
 namespace DGeomHelpers {
@@ -638,7 +660,7 @@ bool minimizeWithExpTorsions(RDGeom::PointPtrVect &positions,
 
 bool finalChiralChecks(RDGeom::PointPtrVect *positions,
                        const detail::EmbedArgs &eargs,
-                       const EmbedParameters &) {
+                       EmbedParameters &embedParams) {
   // "distance matrix" chirality test
   std::set<int> atoms;
   for (const auto &chiralSet : *eargs.chiralCenters) {
@@ -657,6 +679,13 @@ bool finalChiralChecks(RDGeom::PointPtrVect *positions,
       std::cerr << " fail3a! (" << atomsToCheck[0] << ") iter: "  //<< iter
                 << std::endl;
 #endif
+      if (embedParams.trackFailures) {
+#ifdef RDK_BUILD_THREADSAFE_SSS
+        std::lock_guard<std::mutex> lock(GetFailMutex());
+#endif
+        embedParams.failures[EmbedFailureCauses::FINAL_CHIRAL_BOUNDS]++;
+      }
+
       return false;
     }
   }
@@ -670,6 +699,12 @@ bool finalChiralChecks(RDGeom::PointPtrVect *positions,
       std::cerr << " fail3b! (" << chiralSet->d_idx0 << ") iter: "  //<< iter
                 << std::endl;
 #endif
+      if (embedParams.trackFailures) {
+#ifdef RDK_BUILD_THREADSAFE_SSS
+        std::lock_guard<std::mutex> lock(GetFailMutex());
+#endif
+        embedParams.failures[EmbedFailureCauses::FINAL_CENTER_IN_VOLUME]++;
+      }
       return false;
     }
   }
@@ -678,7 +713,7 @@ bool finalChiralChecks(RDGeom::PointPtrVect *positions,
 }
 
 bool embedPoints(RDGeom::PointPtrVect *positions, detail::EmbedArgs eargs,
-                 EmbedParameters embedParams, int seed) {
+                 EmbedParameters &embedParams, int seed) {
   PRECONDITION(positions, "bogus positions");
   if (embedParams.maxIterations == 0) {
     embedParams.maxIterations = 10 * positions->size();
@@ -721,12 +756,35 @@ bool embedPoints(RDGeom::PointPtrVect *positions, detail::EmbedArgs eargs,
       std::cerr << "Initial embedding failed!, Iter: " << iter << std::endl;
     }
 #endif
-    if (gotCoords) {
+    if (!gotCoords) {
+      if (embedParams.trackFailures) {
+#ifdef RDK_BUILD_THREADSAFE_SSS
+        std::lock_guard<std::mutex> lock(GetFailMutex());
+#endif
+        embedParams.failures[EmbedFailureCauses::INITIAL_COORDS]++;
+      }
+    } else {
       gotCoords =
           EmbeddingOps::firstMinimization(positions, eargs, embedParams);
-      if (gotCoords) {
-        gotCoords = EmbeddingOps::checkTetrahedralCenters(positions, eargs,
-                                                          embedParams);
+      if (!gotCoords) {
+        if (embedParams.trackFailures) {
+#ifdef RDK_BUILD_THREADSAFE_SSS
+          std::lock_guard<std::mutex> lock(GetFailMutex());
+#endif
+          embedParams.failures[EmbedFailureCauses::FIRST_MINIMIZATION]++;
+        } else {
+          gotCoords = EmbeddingOps::checkTetrahedralCenters(positions, eargs,
+                                                            embedParams);
+          if (!gotCoords) {
+            if (embedParams.trackFailures) {
+#ifdef RDK_BUILD_THREADSAFE_SSS
+              std::lock_guard<std::mutex> lock(GetFailMutex());
+#endif
+              embedParams
+                  .failures[EmbedFailureCauses::CHECK_TETRAHEDRAL_CENTERS]++;
+            }
+          }
+        }
       }
 
       // Check if any of our chiral centers are badly out of whack.
@@ -734,6 +792,14 @@ bool embedPoints(RDGeom::PointPtrVect *positions, detail::EmbedArgs eargs,
           eargs.chiralCenters->size() > 0) {
         gotCoords =
             EmbeddingOps::checkChiralCenters(positions, eargs, embedParams);
+        if (!gotCoords) {
+          if (embedParams.trackFailures) {
+#ifdef RDK_BUILD_THREADSAFE_SSS
+            std::lock_guard<std::mutex> lock(GetFailMutex());
+#endif
+            embedParams.failures[EmbedFailureCauses::CHECK_CHIRAL_CENTERS]++;
+          }
+        }
       }
       // redo the minimization if we have a chiral center
       // or have started from random coords.
@@ -741,6 +807,15 @@ bool embedPoints(RDGeom::PointPtrVect *positions, detail::EmbedArgs eargs,
           (eargs.chiralCenters->size() > 0 || embedParams.useRandomCoords)) {
         gotCoords = EmbeddingOps::minimizeFourthDimension(positions, eargs,
                                                           embedParams);
+        if (!gotCoords) {
+          if (embedParams.trackFailures) {
+#ifdef RDK_BUILD_THREADSAFE_SSS
+            std::lock_guard<std::mutex> lock(GetFailMutex());
+#endif
+            embedParams
+                .failures[EmbedFailureCauses::MINIMIZE_FOURTH_DIMENSION]++;
+          }
+        }
       }
 
       // (ET)(K)DG
@@ -748,6 +823,14 @@ bool embedPoints(RDGeom::PointPtrVect *positions, detail::EmbedArgs eargs,
                         embedParams.useBasicKnowledge)) {
         gotCoords = EmbeddingOps::minimizeWithExpTorsions(*positions, eargs,
                                                           embedParams);
+        if (!gotCoords) {
+          if (embedParams.trackFailures) {
+#ifdef RDK_BUILD_THREADSAFE_SSS
+            std::lock_guard<std::mutex> lock(GetFailMutex());
+#endif
+            embedParams.failures[EmbedFailureCauses::ETK_MINIMIZATION]++;
+          }
+        }
       }
       // test if chirality is correct
       if (embedParams.enforceChirality && gotCoords &&
@@ -755,7 +838,8 @@ bool embedPoints(RDGeom::PointPtrVect *positions, detail::EmbedArgs eargs,
         gotCoords =
             EmbeddingOps::finalChiralChecks(positions, eargs, embedParams);
       }
-    }  // if(gotCoords)
+    }
+
   }    // while
   if (seed > -1) {
     delete rng;
@@ -964,7 +1048,7 @@ bool multiplication_overflows_(T a, T b) {
 }
 
 void embedHelper_(int threadId, int numThreads, EmbedArgs *eargs,
-                  const EmbedParameters *params) {
+                  EmbedParameters *params) {
   PRECONDITION(eargs, "bogus eargs");
   PRECONDITION(params, "bogus params");
   unsigned int nAtoms = eargs->mmat->numRows();
@@ -1091,7 +1175,14 @@ std::vector<std::vector<unsigned int>> getMolSelfMatches(
 }  // end of namespace detail
 
 void EmbedMultipleConfs(ROMol &mol, INT_VECT &res, unsigned int numConfs,
-                        const EmbedParameters &params) {
+                        EmbedParameters &params) {
+  if (params.trackFailures) {
+#ifdef RDK_BUILD_THREADSAFE_SSS
+    std::lock_guard<std::mutex> lock(GetFailMutex());
+#endif
+    params.failures.resize(10);
+    std::fill(params.failures.begin(), params.failures.end(), 0);
+  }
   if (!mol.getNumAtoms()) {
     throw ValueErrorException("molecule has no atoms");
   }

--- a/Code/GraphMol/DistGeomHelpers/Embedder.h
+++ b/Code/GraphMol/DistGeomHelpers/Embedder.h
@@ -22,6 +22,18 @@
 namespace RDKit {
 namespace DGeomHelpers {
 
+enum EmbedFailureCauses {
+  INITIAL_COORDS = 0,
+  FIRST_MINIMIZATION = 1,
+  CHECK_TETRAHEDRAL_CENTERS = 2,
+  CHECK_CHIRAL_CENTERS = 3,
+  MINIMIZE_FOURTH_DIMENSION = 4,
+  ETK_MINIMIZATION = 5,
+  FINAL_CHIRAL_BOUNDS = 6,
+  FINAL_CENTER_IN_VOLUME = 7,
+
+};
+
 //! Parameter object for controlling embedding
 /*!
   numConfs       Number of conformations to be generated
@@ -96,8 +108,9 @@ namespace DGeomHelpers {
                           NOTE that for reasons of computational efficiency,
                           setting this will also set onlyHeavyAtomsForRMS to
                           true.
-
-
+  trackFailures    keep track of which checks during the embedding process fail
+  failures         if trackFailures is true, this is used to track the number
+                   of times each embedding check fails
 */
 struct RDKIT_DISTGEOMHELPERS_EXPORT EmbedParameters {
   unsigned int maxIterations{0};
@@ -129,6 +142,9 @@ struct RDKIT_DISTGEOMHELPERS_EXPORT EmbedParameters {
   bool forceTransAmides{true};
   bool useSymmetryForPruning{true};
   double boundsMatForceScaling{1.0};
+  bool trackFailures{false};
+  std::vector<unsigned int> failures;
+
   EmbedParameters() : boundsMat(nullptr), CPCI(nullptr), callback(nullptr) {}
   EmbedParameters(
       unsigned int maxIterations, int numThreads, int randomSeed,
@@ -178,11 +194,11 @@ RDKIT_DISTGEOMHELPERS_EXPORT void updateEmbedParametersFromJSON(
     EmbedParameters &params, const std::string &json);
 
 //! Embed multiple conformations for a molecule
-RDKIT_DISTGEOMHELPERS_EXPORT void EmbedMultipleConfs(
-    ROMol &mol, INT_VECT &res, unsigned int numConfs,
-    const EmbedParameters &params);
+RDKIT_DISTGEOMHELPERS_EXPORT void EmbedMultipleConfs(ROMol &mol, INT_VECT &res,
+                                                     unsigned int numConfs,
+                                                     EmbedParameters &params);
 inline INT_VECT EmbedMultipleConfs(ROMol &mol, unsigned int numConfs,
-                                   const EmbedParameters &params) {
+                                   EmbedParameters &params) {
   INT_VECT res;
   EmbedMultipleConfs(mol, res, numConfs, params);
   return res;
@@ -190,7 +206,7 @@ inline INT_VECT EmbedMultipleConfs(ROMol &mol, unsigned int numConfs,
 
 //! Compute an embedding (in 3D) for the specified molecule using Distance
 /// Geometry
-inline int EmbedMolecule(ROMol &mol, const EmbedParameters &params) {
+inline int EmbedMolecule(ROMol &mol, EmbedParameters &params) {
   INT_VECT confIds;
   EmbedMultipleConfs(mol, confIds, 1, params);
 

--- a/Code/GraphMol/DistGeomHelpers/Wrap/rdDistGeom.cpp
+++ b/Code/GraphMol/DistGeomHelpers/Wrap/rdDistGeom.cpp
@@ -184,6 +184,14 @@ void setCPCI(DGeomHelpers::EmbedParameters *self, python::dict &CPCIdict) {
   self->CPCI = CPCI;
 }
 
+python::tuple getFailureCounts(DGeomHelpers::EmbedParameters *self) {
+  python::list lst;
+  for (auto i = 0u; i < self->failures.size(); i++) {
+    lst.append(self->failures[i]);
+  }
+  return python::tuple(lst);
+}
+
 void setBoundsMatrix(DGeomHelpers::EmbedParameters *self,
                      python::object boundsMatArg) {
   PyObject *boundsMatObj = boundsMatArg.ptr();
@@ -351,6 +359,25 @@ BOOST_PYTHON_MODULE(rdDistGeom) {
        python::arg("ETversion") = 1),
       docString.c_str());
 
+  python::enum_<RDKit::DGeomHelpers::EmbedFailureCauses>("EmbedFailureCauses")
+      .value("INITIAL_COORDS",
+             RDKit::DGeomHelpers::EmbedFailureCauses::INITIAL_COORDS)
+      .value("FIRST_MINIMIZATION",
+             RDKit::DGeomHelpers::EmbedFailureCauses::FIRST_MINIMIZATION)
+      .value("CHECK_TETRAHEDRAL_CENTERS",
+             RDKit::DGeomHelpers::EmbedFailureCauses::CHECK_TETRAHEDRAL_CENTERS)
+      .value("CHECK_CHIRAL_CENTERS",
+             RDKit::DGeomHelpers::EmbedFailureCauses::CHECK_CHIRAL_CENTERS)
+      .value("MINIMIZE_FOURTH_DIMENSION",
+             RDKit::DGeomHelpers::EmbedFailureCauses::MINIMIZE_FOURTH_DIMENSION)
+      .value("ETK_MINIMIZATION",
+             RDKit::DGeomHelpers::EmbedFailureCauses::ETK_MINIMIZATION)
+      .value("FINAL_CHIRAL_BOUNDS",
+             RDKit::DGeomHelpers::EmbedFailureCauses::FINAL_CHIRAL_BOUNDS)
+      .value("FINAL_CENTER_IN_VOLUME",
+             RDKit::DGeomHelpers::EmbedFailureCauses::FINAL_CENTER_IN_VOLUME)
+      .export_values();
+
   python::class_<RDKit::DGeomHelpers::EmbedParameters, boost::noncopyable>(
       "EmbedParameters", "Parameters controlling embedding")
       .def_readwrite("maxIterations",
@@ -443,7 +470,12 @@ BOOST_PYTHON_MODULE(rdDistGeom) {
            "used during structural minimisation stage")
       .def_readwrite("forceTransAmides",
                      &RDKit::DGeomHelpers::EmbedParameters::forceTransAmides,
-                     "constrain amide bonds to be trans");
+                     "constrain amide bonds to be trans")
+      .def_readwrite(
+          "trackFailures", &RDKit::DGeomHelpers::EmbedParameters::trackFailures,
+          "keep track of which checks during the embedding process fail")
+      .def("GetFailureCounts", &RDKit::getFailureCounts,
+           "returns the counts of eacu");
   docString =
       "Use distance geometry to obtain multiple sets of \n\
  coordinates for a molecule\n\

--- a/Code/GraphMol/DistGeomHelpers/Wrap/testDistGeom.py
+++ b/Code/GraphMol/DistGeomHelpers/Wrap/testDistGeom.py
@@ -657,7 +657,7 @@ class TestCase(unittest.TestCase):
         smiles_mol = Chem.MolFromSmiles(smiles)
         mol = Chem.AddHs(smiles_mol)
         params = AllChem.ETKDGv3()
-        params.randomSeen = 42
+        params.randomSeed = 42
         AllChem.EmbedMolecule(mol, params)
         conf = mol.GetConformer(0)
         for torsion in get_atom_mapping(mol):

--- a/Code/GraphMol/DistGeomHelpers/Wrap/testDistGeom.py
+++ b/Code/GraphMol/DistGeomHelpers/Wrap/testDistGeom.py
@@ -657,12 +657,24 @@ class TestCase(unittest.TestCase):
         smiles_mol = Chem.MolFromSmiles(smiles)
         mol = Chem.AddHs(smiles_mol)
         params = AllChem.ETKDGv3()
-        params.seed = 42
+        params.randomSeen = 42
         AllChem.EmbedMolecule(mol, params)
         conf = mol.GetConformer(0)
         for torsion in get_atom_mapping(mol):
             a1,a2,a3,a4 = [conf.GetAtomPosition(i) for i in torsion]
-            self.assertAlmostEqual(abs(ComputeSignedDihedralAngle(a1,a2,a3,a4)), 3.14, delta = 0.1)
+            self.assertAlmostEqual(abs(ComputeSignedDihedralAngle(a1,a2,a3,a4)), 3.02, delta = 0.1)
+
+    def testTrackFailures(self):
+        params = AllChem.ETKDGv3()
+        params.trackFailures = True
+        params.maxIterations = 50
+        params.randomSeed = 42
+        mol = Chem.MolFromSmiles('C=CC1=C(N)Oc2cc1c(-c1cc(C(C)O)cc(=O)cc1C1NCC(=O)N1)c(OC)c2OC')
+        mol = Chem.AddHs(mol)
+        AllChem.EmbedMolecule(mol, params)
+        cnts  = params.GetFailureCounts()
+        self.assertGreater(cnts[AllChem.EmbedFailureCauses.INITIAL_COORDS],5)
+        self.assertGreater(cnts[AllChem.EmbedFailureCauses.ETK_MINIMIZATION],10)
 
 
 if __name__ == '__main__':

--- a/Code/GraphMol/DistGeomHelpers/catch_tests.cpp
+++ b/Code/GraphMol/DistGeomHelpers/catch_tests.cpp
@@ -492,3 +492,100 @@ M  END)CTAB"_ctab;
     }
   }
 }
+
+TEST_CASE("tracking failure causes") {
+  SECTION("basics") {
+    // auto mol = "CCNS(=O)(=O)c1ccccc1"_smiles;
+    // auto mol = "c2cccc3c2OC2=CC=CC[C@H]23"_smiles;
+    auto mol =
+        "C=CC1=C(N)Oc2cc1c(-c1cc(C(C)O)cc(=O)cc1C1NCC(=O)N1)c(OC)c2OC"_smiles;
+    REQUIRE(mol);
+    MolOps::addHs(*mol);
+    DGeomHelpers::EmbedParameters ps = DGeomHelpers::ETKDGv3;
+    ps.randomSeed = 0xf00d;
+    ps.trackFailures = true;
+    ps.maxIterations = 50;
+    ps.randomSeed = 42;
+    auto cid = DGeomHelpers::EmbedMolecule(*mol, ps);
+    CHECK(cid < 0);
+
+    std::cerr << "fails: ";
+    std::copy(ps.failures.begin(), ps.failures.end(),
+              std::ostream_iterator<unsigned int>(std::cerr, " "));
+    std::cerr << std::endl;
+    CHECK(ps.failures[DGeomHelpers::EmbedFailureCauses::INITIAL_COORDS] > 5);
+    CHECK(ps.failures[DGeomHelpers::EmbedFailureCauses::ETK_MINIMIZATION] > 10);
+
+    auto fail_cp = ps.failures;
+    // make sure we reset the counts each time
+    cid = DGeomHelpers::EmbedMolecule(*mol, ps);
+    CHECK(ps.failures == fail_cp);
+  }
+  SECTION("chirality") {
+    auto mol = R"CTAB(
+  Ketcher  1102315302D 1   1.00000     0.00000     0
+
+ 10 11  0  0  1  0  0  0  0  0999 V2000
+   10.1340  -11.0250    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   10.1340  -12.0250    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   11.0000  -12.5250    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   11.8660  -12.0250    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   11.8660  -11.0250    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   11.0000  -10.5250    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
+   11.0000  -11.5250    0.0000 N   0  0  0  0  0  0  0  0  0  0  0  0
+   11.2588  -12.4909    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    9.2680  -10.5250    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   12.7629  -12.4673    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+  1  6  1  0     0  0
+  1  2  1  0     0  0
+  2  3  1  0     0  0
+  3  4  1  0     0  0
+  4  5  1  0     0  0
+  5  6  1  0     0  0
+  1  7  1  0     0  0
+  7  8  1  0     0  0
+  8  4  1  0     0  0
+  1  9  1  1     0  0
+  4 10  1  1     0  0
+M  END
+)CTAB"_ctab;
+    REQUIRE(mol);
+    MolOps::addHs(*mol);
+    DGeomHelpers::EmbedParameters ps = DGeomHelpers::ETKDGv3;
+    ps.randomSeed = 0xf00d;
+    ps.trackFailures = true;
+    ps.maxIterations = 50;
+    auto cid = DGeomHelpers::EmbedMolecule(*mol, ps);
+    CHECK(cid < 0);
+    std::cerr << "fails: ";
+    std::copy(ps.failures.begin(), ps.failures.end(),
+              std::ostream_iterator<unsigned int>(std::cerr, " "));
+    std::cerr << std::endl;
+    CHECK(ps.failures[DGeomHelpers::EmbedFailureCauses::INITIAL_COORDS] > 5);
+    CHECK(ps.failures[DGeomHelpers::EmbedFailureCauses::FINAL_CHIRAL_BOUNDS] >
+          10);
+  }
+
+#ifdef RDK_TEST_MULTITHREADED
+  SECTION("multithreaded") {
+    auto mol =
+        "C=CC1=C(N)Oc2cc1c(-c1cc(C(C)O)cc(=O)cc1C1NCC(=O)N1)c(OC)c2OC"_smiles;
+    REQUIRE(mol);
+    MolOps::addHs(*mol);
+    DGeomHelpers::EmbedParameters ps = DGeomHelpers::ETKDGv3;
+    ps.randomSeed = 0xf00d;
+    ps.trackFailures = true;
+    ps.maxIterations = 10;
+    ps.randomSeed = 42;
+    auto cids = DGeomHelpers::EmbedMultipleConfs(*mol, 50, ps);
+
+    DGeomHelpers::EmbedParameters ps2 = ps;
+    ps2.numThreads = 4;
+
+    auto cids2 = DGeomHelpers::EmbedMultipleConfs(*mol, 50, ps2);
+    CHECK(cids2 == cids);
+
+    CHECK(ps.failures == ps2.failures);
+  }
+#endif
+}

--- a/Code/GraphMol/DistGeomHelpers/catch_tests.cpp
+++ b/Code/GraphMol/DistGeomHelpers/catch_tests.cpp
@@ -555,7 +555,7 @@ M  END
     CHECK(cid < 0);
     CHECK(ps.failures[DGeomHelpers::EmbedFailureCauses::INITIAL_COORDS] > 5);
     CHECK(ps.failures[DGeomHelpers::EmbedFailureCauses::FINAL_CHIRAL_BOUNDS] >
-          10);
+          5);
   }
 
 #ifdef RDK_TEST_MULTITHREADED
@@ -569,12 +569,12 @@ M  END
     ps.trackFailures = true;
     ps.maxIterations = 10;
     ps.randomSeed = 42;
-    auto cids = DGeomHelpers::EmbedMultipleConfs(*mol, 50, ps);
+    auto cids = DGeomHelpers::EmbedMultipleConfs(*mol, 20, ps);
 
     DGeomHelpers::EmbedParameters ps2 = ps;
     ps2.numThreads = 4;
 
-    auto cids2 = DGeomHelpers::EmbedMultipleConfs(*mol, 50, ps2);
+    auto cids2 = DGeomHelpers::EmbedMultipleConfs(*mol, 20, ps2);
     CHECK(cids2 == cids);
 
     CHECK(ps.failures == ps2.failures);

--- a/Code/GraphMol/DistGeomHelpers/catch_tests.cpp
+++ b/Code/GraphMol/DistGeomHelpers/catch_tests.cpp
@@ -509,10 +509,6 @@ TEST_CASE("tracking failure causes") {
     auto cid = DGeomHelpers::EmbedMolecule(*mol, ps);
     CHECK(cid < 0);
 
-    std::cerr << "fails: ";
-    std::copy(ps.failures.begin(), ps.failures.end(),
-              std::ostream_iterator<unsigned int>(std::cerr, " "));
-    std::cerr << std::endl;
     CHECK(ps.failures[DGeomHelpers::EmbedFailureCauses::INITIAL_COORDS] > 5);
     CHECK(ps.failures[DGeomHelpers::EmbedFailureCauses::ETK_MINIMIZATION] > 10);
 
@@ -557,10 +553,6 @@ M  END
     ps.maxIterations = 50;
     auto cid = DGeomHelpers::EmbedMolecule(*mol, ps);
     CHECK(cid < 0);
-    std::cerr << "fails: ";
-    std::copy(ps.failures.begin(), ps.failures.end(),
-              std::ostream_iterator<unsigned int>(std::cerr, " "));
-    std::cerr << std::endl;
     CHECK(ps.failures[DGeomHelpers::EmbedFailureCauses::INITIAL_COORDS] > 5);
     CHECK(ps.failures[DGeomHelpers::EmbedFailureCauses::FINAL_CHIRAL_BOUNDS] >
           10);

--- a/Code/GraphMol/DistGeomHelpers/testDgeomHelpers.cpp
+++ b/Code/GraphMol/DistGeomHelpers/testDgeomHelpers.cpp
@@ -928,11 +928,11 @@ void testRandomCoords() {
       const Conformer &conf1 = m->getConformer(0);
       const Conformer &conf2 = m2->getConformer(0);
 #if 0
-      BOOST_LOG(rdInfoLog) << "-----------------------" << std::endl;
-      BOOST_LOG(rdInfoLog) << MolToMolBlock(*m2) << std::endl;
-      BOOST_LOG(rdInfoLog) << "---" << std::endl;
-      BOOST_LOG(rdInfoLog) << MolToMolBlock(*m) << std::endl;
-      BOOST_LOG(rdInfoLog) << "-----------------------" << std::endl;
+      BOOST_LOG(rdWarningLog) << "-----------------------" << std::endl;
+      BOOST_LOG(rdWarningLog) << MolToMolBlock(*m2) << std::endl;
+      BOOST_LOG(rdWarningLog) << "---" << std::endl;
+      BOOST_LOG(rdWarningLog) << MolToMolBlock(*m) << std::endl;
+      BOOST_LOG(rdWarningLog) << "-----------------------" << std::endl;
 #endif
       for (unsigned int i = 0; i < nat; i++) {
         RDGeom::Point3D pt1i = conf1.getAtomPos(i);

--- a/Code/JavaWrappers/DistGeom.i
+++ b/Code/JavaWrappers/DistGeom.i
@@ -141,7 +141,7 @@
           basinThresh);
       }
 
-      static int EmbedMolecule(RDKit::ROMol &mol,const RDKit::DGeomHelpers::EmbedParameters &params) {
+      static int EmbedMolecule(RDKit::ROMol &mol,RDKit::DGeomHelpers::EmbedParameters &params) {
         return RDKit::DGeomHelpers::EmbedMolecule(mol,params);
       }
 
@@ -179,7 +179,7 @@
       }
       static RDKit::INT_VECT EmbedMultipleConfs(RDKit::ROMol &mol,
                                                 unsigned int numConfs,
-                                                const RDKit::DGeomHelpers::EmbedParameters &params) {
+                                                RDKit::DGeomHelpers::EmbedParameters &params) {
         return RDKit::DGeomHelpers::EmbedMultipleConfs(mol, numConfs, params);
       }
 


### PR DESCRIPTION
The conformer generation code has a number of internal tests that it does to make sure the output conformers are reasonable. This PR makes it possible for client code to determine how often each of those tests fail.

This is mainly useful for debugging purposes, so it's not necessarily super well documented at the moment.