### PR TITLE
Expand function description.

### DIFF
--- a/Code/GraphMol/RWMol.cpp
+++ b/Code/GraphMol/RWMol.cpp
@@ -8,9 +8,13 @@
 //  of the RDKit source tree.
 //
 
+#include <boost/tokenizer.hpp>
+#include <algorithm>
+
 // our stuff
 #include <RDGeneral/Invariant.h>
 #include <RDGeneral/RDLog.h>
+#include "FileParsers/MolSGroupParsing.h"
 #include "RWMol.h"
 #include "Atom.h"
 #include "Bond.h"
@@ -223,7 +227,7 @@ void RWMol::removeAtom(Atom *atom) {
   PRECONDITION(atom, "NULL atom provided");
   PRECONDITION(static_cast<RWMol *>(&atom->getOwningMol()) == this,
                "atom not owned by this molecule");
-  unsigned int idx = atom->getIdx();
+  const unsigned int idx = atom->getIdx();
   if (dp_delAtoms) {
     // we're in a batch edit
     // if atoms have been added since we started, resize dp_delAtoms
@@ -281,12 +285,51 @@ void RWMol::removeAtom(Atom *atom) {
   }
   // now deal with bonds:
   //   their end indices may need to be decremented and their
-  //   indices will need to be handled
+  //   indices will need to be handled and if they have an
+  //   ENDPTS prop that includes idx, it will need updating.
   unsigned int nBonds = 0;
   EDGE_ITER beg, end;
   boost::tie(beg, end) = getEdges();
+  std::string sprop;
   while (beg != end) {
     Bond *bond = d_graph[*beg++];
+    if (bond->getPropIfPresent(RDKit::common_properties::_MolFileBondEndPts,
+                               sprop)) {
+      // This would ideally use ParseV3000Array but I'm buggered if I can get
+      // the linker to find it.
+      //      std::vector<unsigned int> oats =
+      //          RDKit::SGroupParsing::ParseV3000Array<unsigned int>(sprop);
+      if ('(' == sprop.front() && ')' == sprop.back()) {
+        sprop = sprop.substr(1, sprop.length() - 2);
+        boost::char_separator<char> sep(" ");
+        boost::tokenizer<boost::char_separator<char>> tokens(sprop, sep);
+        unsigned int num_ats = std::stod(*tokens.begin());
+        std::vector<unsigned int> oats;
+        auto beg = tokens.begin();
+        ++beg;
+        std::transform(beg, tokens.end(), std::back_inserter(oats),
+                       [](const std::string &a) { return std::stod(a); });
+        auto idx_pos = std::find(oats.begin(), oats.end(), idx + 1);
+        if (idx_pos != oats.end()) {
+          oats.erase(idx_pos);
+          --num_ats;
+        }
+        if (!num_ats) {
+          bond->clearProp(RDKit::common_properties::_MolFileBondEndPts);
+          bond->clearProp(common_properties::_MolFileBondAttach);
+        } else {
+          sprop = "(" + std::to_string(num_ats) + " ";
+          for (auto &i : oats) {
+            if (i > idx + 1) {
+              --i;
+            }
+            sprop += std::to_string(i) + " ";
+          }
+          sprop[sprop.length() - 1] = ')';
+          bond->setProp(RDKit::common_properties::_MolFileBondEndPts, sprop);
+        }
+      }
+    }
     unsigned int tmpIdx = bond->getBeginAtomIdx();
     if (tmpIdx > idx) {
       bond->setBeginAtomIdx(tmpIdx - 1);

--- a/Code/GraphMol/RWMol.h
+++ b/Code/GraphMol/RWMol.h
@@ -110,7 +110,7 @@ class RDKIT_GRAPHMOL_EXPORT RWMol : public ROMol {
   void setActiveAtom(Atom *atom);
   //! \overload
   void setActiveAtom(unsigned int idx);
-  //! removes an Atom from the molecule
+  //! removes an Atom from the molecule and any associated Bonds
   void removeAtom(unsigned int idx);
   //! \overload
   void removeAtom(Atom *atom);

--- a/Code/GraphMol/catch_graphmol.cpp
+++ b/Code/GraphMol/catch_graphmol.cpp
@@ -2895,3 +2895,81 @@ TEST_CASE("Github #5849: aromatic tag allows bad valences to pass") {
     }
   }
 }
+
+TEST_CASE("Remove atom updates bond ENDPTS prop") {
+  auto m = R"CTAB(ferrocene-ish
+     RDKit          2D
+
+  0  0  0  0  0  0  0  0  0  0999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 15 14 0 0 0
+M  V30 BEGIN ATOM
+M  V30 1 C 0.619616 1.206807 0.000000 0 CHG=-1
+M  V30 2 C 0.211483 1.768553 0.000000 0
+M  V30 3 C -1.283936 1.861329 0.000000 0
+M  V30 4 C -1.796429 1.358429 0.000000 0
+M  V30 5 C -0.634726 0.966480 0.000000 0
+M  V30 6 C 0.654379 -1.415344 0.000000 0 CHG=-1
+M  V30 7 C 0.249886 -0.858607 0.000000 0
+M  V30 8 C -1.232145 -0.766661 0.000000 0
+M  V30 9 C -1.740121 -1.265073 0.000000 0
+M  V30 10 C -0.580425 -1.662922 0.000000 0
+M  V30 11 C 1.759743 0.755930 0.000000 0
+M  V30 12 C 1.796429 -1.861329 0.000000 0
+M  V30 13 Fe -0.554442 0.032137 0.000000 0 VAL=2
+M  V30 14 * -0.601210 1.478619 0.000000 0
+M  V30 15 * -0.537835 -1.172363 0.000000 0
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 1 1 5
+M  V30 2 2 4 5
+M  V30 3 1 4 3
+M  V30 4 2 2 3
+M  V30 5 1 1 2
+M  V30 6 1 6 10
+M  V30 7 2 9 10
+M  V30 8 1 9 8
+M  V30 9 2 7 8
+M  V30 10 1 6 7
+M  V30 11 1 1 11
+M  V30 12 1 6 12
+M  V30 13 9 14 13 ENDPTS=(5 1 2 3 4 5) ATTACH=ANY
+M  V30 14 9 15 13 ENDPTS=(5 9 10 7 8 6) ATTACH=ANY
+M  V30 END BOND
+M  V30 END CTAB
+M  END
+)CTAB"_ctab;
+  REQUIRE(m);
+  std::string sprop;
+  auto bond = m->getBondWithIdx(12U);
+  CHECK(bond->getPropIfPresent(RDKit::common_properties::_MolFileBondEndPts,
+                               sprop));
+  CHECK(std::string("(5 1 2 3 4 5)") == sprop);
+  m->removeAtom(2U);
+  bond = m->getBondWithIdx(10U);
+  CHECK(bond->getPropIfPresent(RDKit::common_properties::_MolFileBondEndPts,
+                               sprop));
+  CHECK(std::string("(4 1 2 3 4)") == sprop);
+  m->removeAtom(0U);
+  m->removeAtom(0U);
+  m->removeAtom(0U);
+  m->removeAtom(0U);
+  CHECK(!bond->getPropIfPresent(RDKit::common_properties::_MolFileBondEndPts,
+                                sprop));
+  CHECK(!bond->getPropIfPresent(RDKit::common_properties::_MolFileBondAttach,
+                                sprop));
+  // the original bond should now have index 6
+  CHECK(bond->getIdx() == 6);
+
+  // the other dative bond is now attached to different atom indices
+  bond = m->getBondWithIdx(7U);
+  CHECK(bond->getPropIfPresent(RDKit::common_properties::_MolFileBondEndPts,
+                               sprop));
+  CHECK(std::string("(5 4 5 2 3 1)") == sprop);
+  // remove atom 5 (6 in the file - the final methyl off the first
+  // methyl-cyclopentadiene ring
+  m->removeAtom(5U);
+  CHECK(bond->getPropIfPresent(RDKit::common_properties::_MolFileBondEndPts,
+                               sprop));
+  CHECK(std::string("(5 4 5 2 3 1)") == sprop);
+}


### PR DESCRIPTION
#### Reference Issue
No issue


#### What does this implement/fix? Explain your changes.
When an atom is removed, the ENDPTS props need updating to reflect the changes to indices in the molecule.
Expands the description of that RWMol::removeAtom does.

#### Any other comments?
I had to dig into the source to satisfy myself that bonds were tidied up when an atom is removed.  
In the process, I realised the more significant problem.
