### PR TITLE
Updated the GetMolHash docstring for accuracy

### DIFF
--- a/rdkit/Chem/RegistrationHash.py
+++ b/rdkit/Chem/RegistrationHash.py
@@ -101,7 +101,7 @@ def GetMolHash(all_layers, hash_scheme: HashScheme = HashScheme.ALL_LAYERS) -> s
   """
     Generate a molecular hash using a specified set of layers.
 
-    :param mol: the molecule to generate the hash for
+    :param all_layers: a dictionary of layers
     :param hash_scheme: enum encoding information layers for the hash
     :return: hash for the given scheme constructed from the input layers
     """


### PR DESCRIPTION

This change addresses a minor issue in the docstring of the GetMolHash in RegistrationHash.py. The first a argument of the function appears to be a mol, while it is actually a dictionary of layers. 



