### PR TITLE
Add depiction coordinates to molzip

### DIFF
--- a/Code/GraphMol/ChemTransforms/CMakeLists.txt
+++ b/Code/GraphMol/ChemTransforms/CMakeLists.txt
@@ -1,6 +1,6 @@
 
 rdkit_library(ChemTransforms ChemTransforms.cpp MolFragmenter.cpp LINK_LIBRARIES
-  GraphMol SubstructMatch SmilesParse )
+  GraphMol SubstructMatch SmilesParse Depictor)
 target_compile_definitions(ChemTransforms PRIVATE -DRDKIT_CHEMTRANSFORMS_BUILD)
 
 rdkit_headers(ChemTransforms.h

--- a/Code/GraphMol/ChemTransforms/MolFragmenter.cpp
+++ b/Code/GraphMol/ChemTransforms/MolFragmenter.cpp
@@ -14,6 +14,7 @@
 #include <RDGeneral/Invariant.h>
 #include <RDGeneral/RDLog.h>
 #include <RDGeneral/Exceptions.h>
+#include <GraphMol/Depictor/RDDepictor.h>
 #include <GraphMol/RDKitBase.h>
 #include <boost/dynamic_bitset.hpp>
 #include <boost/tokenizer.hpp>
@@ -920,8 +921,14 @@ struct ZipBond {
 };
 }  // namespace
 
-std::unique_ptr<ROMol> molzip(const ROMol &a, const ROMol &b,
-                              const MolzipParams &params) {
+static const std::string indexPropName("__zipIndex");
+
+std::unique_ptr<ROMol> molzip(
+    const ROMol &a, const ROMol &b, const MolzipParams &params,
+    std::optional<std::map<int, int>> &attachmentMapping) {
+  if (attachmentMapping) {
+    attachmentMapping->clear();
+  }
   std::unique_ptr<RWMol> newmol;
   if (b.getNumAtoms()) {
     newmol.reset(static_cast<RWMol *>(combineMols(a, b)));
@@ -958,6 +965,13 @@ std::unique_ptr<ROMol> molzip(const ROMol &a, const ROMol &b,
         }
         mappings_by_atom[atom].push_back(&bond);
         deletions.push_back(atom);
+        if (attachmentMapping) {
+          if (int otherIndex, dummyIndex;
+              atom->getPropIfPresent(indexPropName, dummyIndex) &&
+              bond.b->getPropIfPresent(indexPropName, otherIndex)) {
+            (*attachmentMapping)[dummyIndex] = otherIndex;
+          }
+        }
       }
     }
   } else {
@@ -986,6 +1000,18 @@ std::unique_ptr<ROMol> molzip(const ROMol &a, const ROMol &b,
           bond.b = attached_atom;
           bond.b_dummy = atom;
           mappings_by_atom[bond.a].push_back(&bond);
+          if (attachmentMapping) {
+            if (int otherIndex, dummyIndex;
+                bond.a_dummy->getPropIfPresent(indexPropName, dummyIndex) &&
+                bond.b->getPropIfPresent(indexPropName, otherIndex)) {
+              (*attachmentMapping)[dummyIndex] = otherIndex;
+            }
+            if (int otherIndex, dummyIndex;
+                bond.b_dummy->getPropIfPresent(indexPropName, dummyIndex) &&
+                bond.a->getPropIfPresent(indexPropName, otherIndex)) {
+              (*attachmentMapping)[dummyIndex] = otherIndex;
+            }
+          }
         }
         deletions.push_back(atom);
       }
@@ -1013,6 +1039,7 @@ std::unique_ptr<ROMol> molzip(const ROMol &a, const ROMol &b,
       bond->restore_chirality(already_checked);
     }
   }
+
   // remove all molzip tags
   for (auto *atom : newmol->atoms()) {
     auto propnames = atom->getPropList();
@@ -1035,8 +1062,75 @@ std::unique_ptr<ROMol> molzip(const ROMol &a, const ROMol &b,
   return newmol;
 }
 
+RDKIT_CHEMTRANSFORMS_EXPORT std::unique_ptr<ROMol> molzip(
+    const ROMol &a, const ROMol &b, const MolzipParams &params) {
+  std::optional<std::map<int, int>> opt(std::nullopt);
+  return molzip(a, b, params, opt);
+}
+
 std::unique_ptr<ROMol> molzip(const ROMol &a, const MolzipParams &params) {
   const static ROMol b;
   return molzip(a, b, params);
 }
+
+std::unique_ptr<ROMol> molzip(std::vector<ROMOL_SPTR> &decomposition,
+                              const MolzipParams &params) {
+  if (params.generateCoordinates) {
+    int index = 0;
+    for (const auto &mol : decomposition) {
+      for (const auto atom : mol->atoms()) {
+        atom->setProp(indexPropName, index++);
+      }
+    }
+  }
+
+  const auto combinedMol = std::accumulate(
+      decomposition.begin() + 1, decomposition.end(), decomposition[0],
+      [](const auto &combined, const auto &mol) {
+        auto c = combineMols(*combined, *mol);
+        ROMOL_SPTR ptr(c);
+        return ptr;
+      });
+
+  const static ROMol b;
+  std::optional attachmentMappingOption = std::map<int, int>();
+  auto zippedMol = molzip(*combinedMol, b, params, attachmentMappingOption);
+
+  if (params.generateCoordinates && zippedMol->getNumAtoms() > 0) {
+    const auto confId = RDDepict::compute2DCoords(*zippedMol);
+    const auto zippedConf = zippedMol->getConformer(confId);
+    auto attachmentMapping = *attachmentMappingOption;
+    for (auto &mol : decomposition) {
+      const auto newConf = new Conformer(mol->getNumAtoms());
+      newConf->set3D(false);
+      for (const auto atom : mol->atoms()) {
+        int zippedIndex = atom->getProp<int>(indexPropName);
+        atom->clearProp(indexPropName);
+        if (const auto attachment = attachmentMapping.find(zippedIndex);
+            attachment != attachmentMapping.end()) {
+          zippedIndex = (*attachment).second;
+        }
+        auto zipppedAtoms = zippedMol->atoms();
+        auto zippedAtom = std::find_if(
+            zipppedAtoms.begin(), zipppedAtoms.end(),
+            [zippedIndex](const Atom *zippedAtom) {
+              const auto index = zippedAtom->getProp<int>(indexPropName);
+              return index == zippedIndex;
+            });
+
+        newConf->setAtomPos(atom->getIdx(),
+                            zippedConf.getAtomPos((*zippedAtom)->getIdx()));
+      }
+      mol->addConformer(newConf, true);
+    }
+    for (const auto atom : zippedMol->atoms()) {
+      atom->clearProp(indexPropName);
+    }
+
+    return zippedMol;
+  }
+
+  return zippedMol;
+}
+
 }  // end of namespace RDKit

--- a/Code/GraphMol/ChemTransforms/MolFragmenter.h
+++ b/Code/GraphMol/ChemTransforms/MolFragmenter.h
@@ -109,6 +109,7 @@ struct RDKIT_CHEMTRANSFORMS_EXPORT MolzipParams {
   std::vector<std::string> atomSymbols;
   std::string atomProperty;
   bool enforceValenceRules=true;
+  bool generateCoordinates=false;
 };
 
 RDKIT_CHEMTRANSFORMS_EXPORT std::unique_ptr<ROMol> molzip(
@@ -118,5 +119,7 @@ RDKIT_CHEMTRANSFORMS_EXPORT std::unique_ptr<ROMol> molzip(
 RDKIT_CHEMTRANSFORMS_EXPORT std::unique_ptr<ROMol> molzip(
     const ROMol &a, const MolzipParams &params = MolzipParams());
 
+RDKIT_CHEMTRANSFORMS_EXPORT std::unique_ptr<ROMol> molzip(std::vector<ROMOL_SPTR> &decomposition,
+                              const MolzipParams &params = MolzipParams());
 }  // namespace RDKit
 #endif

--- a/Code/GraphMol/ChemTransforms/MolFragmenter.h
+++ b/Code/GraphMol/ChemTransforms/MolFragmenter.h
@@ -119,6 +119,19 @@ RDKIT_CHEMTRANSFORMS_EXPORT std::unique_ptr<ROMol> molzip(
 RDKIT_CHEMTRANSFORMS_EXPORT std::unique_ptr<ROMol> molzip(
     const ROMol &a, const MolzipParams &params = MolzipParams());
 
+//! \brief Creates a molecule from an R group decomposition
+/*!
+ *
+ * @param decomposition - A list of molecules that comprises an R group
+ * decomposition.  The core must be the first molecule in the list. If
+ * generateCoordinates is set in the parameters then aligned depiction
+ * coordinates will be set on the returned molecule and the input decomposition
+ *
+ * optional:
+ * @param params - molzip parameters
+ *
+ * @return the zipped molecule
+ */
 RDKIT_CHEMTRANSFORMS_EXPORT std::unique_ptr<ROMol> molzip(std::vector<ROMOL_SPTR> &decomposition,
                               const MolzipParams &params = MolzipParams());
 }  // namespace RDKit

--- a/Code/GraphMol/ChemTransforms/catch_tests.cpp
+++ b/Code/GraphMol/ChemTransforms/catch_tests.cpp
@@ -18,6 +18,7 @@
 #include <GraphMol/Substruct/SubstructMatch.h>
 
 #include <algorithm>
+#include <regex>
 
 using namespace RDKit;
 using std::unique_ptr;
@@ -504,11 +505,58 @@ TEST_CASE(
   }
 }
 
-TEST_CASE("ReplaceCore handles chiral center with multiple bonds from core to chiral center", "[]") {
+TEST_CASE(
+    "ReplaceCore handles chiral center with multiple bonds from core to chiral center",
+    "[]") {
   auto structure = "C1CSCN[C@@]12(NCCCO2)"_smiles;
   auto core = "NCSCC"_smarts;
   std::unique_ptr<ROMol> res{replaceCore(*structure, *core, true, true)};
   REQUIRE(res);
   auto resultSmiles = MolToSmiles(*res);
   REQUIRE(resultSmiles == "*[C@]1([4*])NCCCO1");
+}
+
+TEST_CASE("Molzip with 2D coordinates", "[molzip]") {
+  std::vector<std::string> frags = {
+      "c1nc([1*:1])c([2*:2])c([3*:3])n1",
+      "CC(C)(C#N)c1ccc([1*:1])cc1",
+      "Nc1ccc(C#C[2*:2])cn1",
+      "OCC[3*:3]"
+  };
+  std::vector<ROMOL_SPTR> mols = {
+    ROMOL_SPTR(SmilesToMol(frags[0])),
+    ROMOL_SPTR(SmilesToMol(frags[1])),
+    ROMOL_SPTR(SmilesToMol(frags[2])),
+    ROMOL_SPTR(SmilesToMol(frags[3]))
+  };
+  MolzipParams params;
+  params.generateCoordinates = true;
+  const auto zippedMol = molzip(mols, params);
+  for (auto &mol: mols) {
+    for (auto  &atom: mol->atoms()) {
+      atom->setIsotope(0);
+      atom->setAtomMapNum(0);
+    }
+  }
+  const auto &zippedConformer = zippedMol->getConformer();
+  for (size_t i=0; i<frags.size(); i++) {
+    const auto sma = std::regex_replace(frags[i], std::regex(R"(\[\d\*\:\d\])"), "*");
+    const auto query = SmartsToMol(sma);
+    const auto &mol = mols[i];
+    const auto &molConformer = mol->getConformer();
+    const auto molMatches = SubstructMatch(*mol, *query);
+    const auto zippedMatches = SubstructMatch(*zippedMol, *query);
+    REQUIRE(molMatches.size() == 1);
+    REQUIRE(zippedMatches.size() == 1);
+    const auto molMatch = molMatches[0];
+    const auto zippedMatch = zippedMatches[0];
+    for (size_t j=0; j<molMatch.size(); j++) {
+      const auto &position1 = molConformer.getAtomPos(molMatch[i].second);
+      const auto &position2 = zippedConformer.getAtomPos(zippedMatch[i].second);
+      CHECK(position1.x == position2.x);
+      CHECK(position1.y == position2.y);
+      CHECK(position1.z == position2.z);
+    }
+    delete query;
+  }
 }

--- a/Code/GraphMol/Wrap/MolOps.cpp
+++ b/Code/GraphMol/Wrap/MolOps.cpp
@@ -2551,7 +2551,7 @@ EXAMPLES:\n\n\
 Setting this to false allows assembling chemically incorrect fragments.")
         .def_readwrite("generateCoordinates", &MolzipParams::generateCoordinates,
                        "If true will add depiction coordinates to input molecules and\n\
-zipped molecule (using molzip function with list input only)")
+zipped molecule (for molzipFragments only)")
         .def("setAtomSymbols", &RDKit::setAtomSymbols,
              "Set the atom symbols used to zip mols together when using "
              "AtomType labeling");
@@ -2596,7 +2596,7 @@ The atoms to zip can be specified with the MolzipParams class.\n\
         python::return_value_policy<python::manage_new_object>());
 
     python::def(
-        "molzip",
+        "molzipFragments",
         (ROMol * (*)(python::object &, const MolzipParams &)) & molzipHelper,
         (python::arg("mols"), python::arg("params") = MolzipParams()),
         "zip together multiple molecules using the given matching parameters",

--- a/Code/GraphMol/Wrap/MolOps.cpp
+++ b/Code/GraphMol/Wrap/MolOps.cpp
@@ -2600,7 +2600,7 @@ The atoms to zip can be specified with the MolzipParams class.\n\
         (ROMol * (*)(python::object &, const MolzipParams &)) & molzipHelper,
         (python::arg("mols"), python::arg("params") = MolzipParams()),
         "zip together multiple molecules from an R group decomposition \n\
-using the given matching parameters.  The first molecule in \n\
+using the given matching parameters.  The first molecule in the list\n\
 must be the core",
         python::return_value_policy<python::manage_new_object>());
 

--- a/Code/GraphMol/Wrap/MolOps.cpp
+++ b/Code/GraphMol/Wrap/MolOps.cpp
@@ -2599,7 +2599,9 @@ The atoms to zip can be specified with the MolzipParams class.\n\
         "molzipFragments",
         (ROMol * (*)(python::object &, const MolzipParams &)) & molzipHelper,
         (python::arg("mols"), python::arg("params") = MolzipParams()),
-        "zip together multiple molecules using the given matching parameters",
+        "zip together multiple molecules from an R group decomposition \n\
+using the given matching parameters.  The first molecule in \n\
+must be the core",
         python::return_value_policy<python::manage_new_object>());
 
     // ------------------------------------------------------------------------

--- a/Code/GraphMol/Wrap/MolOps.cpp
+++ b/Code/GraphMol/Wrap/MolOps.cpp
@@ -932,6 +932,14 @@ ROMol *molzip_new(const ROMol &a, const MolzipParams &p) {
   return molzip(a, p).release();
 }
 
+ROMol *molzipHelper(python::object &pmols, const MolzipParams &p) {
+  auto mols = pythonObjectToVect<ROMOL_SPTR>(pmols);
+  if (mols == nullptr || mols->empty()) {
+    return nullptr;
+  }
+  return molzip(*mols, p).release();
+}
+
 struct molops_wrapper {
   static void wrap() {
     std::string docString;
@@ -2541,6 +2549,9 @@ EXAMPLES:\n\n\
                        &MolzipParams::enforceValenceRules,
                        "If true (default) enforce valences after zipping\n\
 Setting this to false allows assembling chemically incorrect fragments.")
+        .def_readwrite("generateCoordinates", &MolzipParams::generateCoordinates,
+                       "If true will add depiction coordinates to input molecules and\n\
+zipped molecule (using molzip function with list input only)")
         .def("setAtomSymbols", &RDKit::setAtomSymbols,
              "Set the atom symbols used to zip mols together when using "
              "AtomType labeling");
@@ -2582,6 +2593,13 @@ The atoms to zip can be specified with the MolzipParams class.\n\
         (ROMol * (*)(const ROMol &, const MolzipParams &)) & molzip_new,
         (python::arg("a"), python::arg("params") = MolzipParams()),
         "zip together two molecules using the given matching parameters",
+        python::return_value_policy<python::manage_new_object>());
+
+    python::def(
+        "molzip",
+        (ROMol * (*)(python::object &, const MolzipParams &)) & molzipHelper,
+        (python::arg("mols"), python::arg("params") = MolzipParams()),
+        "zip together multiple molecules using the given matching parameters",
         python::return_value_policy<python::manage_new_object>());
 
     // ------------------------------------------------------------------------

--- a/Code/JavaWrappers/ChemTransforms.i
+++ b/Code/JavaWrappers/ChemTransforms.i
@@ -68,9 +68,15 @@ RDKit::ROMol * new_molzip(
   return RDKit::molzip(a, params).release();
 }
 
+RDKit::ROMol * new_molzip(
+               std::vector<RDKit::ROMOL_SPTR> &mols,
+               const RDKit::MolzipParams &params=RDKit::MolzipParams()) {
+  return RDKit::molzip(mols, params).release();
+}
 %}
 
 %include "std_string.i"
+%include "std_vector.i"
 
 %newobject deleteSubstructs;
 %newobject replaceSidechains;
@@ -101,7 +107,11 @@ RDKit::ROMol * new_molzip(
 			  const RDKit::ROMol &a,
 			  const RDKit::MolzipParams &params=RDKit::MolzipParams());
 
-          
+
+RDKit::ROMol * new_molzip(
+                          std::vector<RDKit::ROMOL_SPTR> &mols,
+                          const RDKit::MolzipParams &params=RDKit::MolzipParams());
+
 %ignore fragmentOnSomeBonds;
 %ignore constructFragmenterAtomTypes;
 %ignore constructBRICSAtomTypes;


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! 
-->

#### What does this implement/fix? Explain your changes.

When performing molecule zipping from fragments/decomposition it would be nice if the fragments could be depicted aligned to the zipped molecule.

I've added a `generateCoordinates` option  for `MolzipParams` and a new `molzipFragments` function that takes a vector of molecules (the fragments) and parameters.  On zipping depiction coordinates are set on the output molecule and input fragments.

```python

# %%
import os
from rdkit import Chem
from rdkit import IPythonConsole
IPythonConsole.ipython_useSVG = True
from rdkit.Chem.Draw import IPythonConsole
from rdkit.Chem import PandasTools
from rdkit.Chem import Draw
# %%

smiles = ["c1nc([1*:1])c([2*:2])c([3*:3])n1", "CC(C)(C#N)c1ccc([1*:1])cc1", "Nc1ccc(C#C[2*:2])cn1", "CC[3*:3]"]
mols = [Chem.MolFromSmiles(s) for s in smiles]
Draw.MolsToGridImage(mols, 4)

# %%
p = Chem.MolzipParams()
p.generateCoordinates = True
zipped_mol = Chem.molzipFragments(mols, p)
zipped_mol
# %%
Draw.MolsToGridImage(mols, 4)
```

After zipping the fragments are aligned to the zipped molecule:

![image](https://user-images.githubusercontent.com/24233741/213580450-f75eb274-704b-4750-a9ec-f9c7bdf993f7.png)


#### Any other comments?

