### PR TITLE
Enable using STL algorithms on ROMol atoms and bonds

### DIFF
--- a/Code/GraphMol/ROMol.h
+++ b/Code/GraphMol/ROMol.h
@@ -138,6 +138,7 @@ struct CXXAtomIterator {
       ++pos;
       return *this;
     }
+    bool operator==(const CXXAtomIter &it) const { return pos == it.pos; }
     bool operator!=(const CXXAtomIter &it) const { return pos != it.pos; }
   };
 
@@ -180,6 +181,7 @@ struct CXXBondIterator {
       ++pos;
       return *this;
     }
+    bool operator==(const CXXBondIter &it) const { return pos == it.pos; }
     bool operator!=(const CXXBondIter &it) const { return pos != it.pos; }
   };
 

--- a/Code/GraphMol/catch_moliterators.cpp
+++ b/Code/GraphMol/catch_moliterators.cpp
@@ -27,6 +27,36 @@ TEST_CASE("mol.atoms()") {
     }
   }
   CHECK(ccount == 4);
+  auto atoms = m->atoms();
+  auto hasCarbon = std::any_of(atoms.begin(), atoms.end(), [](const auto atom) {
+    return atom->getAtomicNum() == 6;
+  });
+  CHECK(hasCarbon);
+  ccount = std::count_if(atoms.begin(), atoms.end(), [](const auto atom) {
+    return atom->getAtomicNum() == 6;
+  });
+  CHECK(ccount == 4);
+}
+
+TEST_CASE("mol.bonds()") {
+  const auto m = "OC(=O)C(=O)O"_smiles;
+  REQUIRE(m);
+  unsigned int doubleBondCount = 0;
+  for (const auto bond : m->bonds()) {
+    if (bond->getBondType() == Bond::DOUBLE) {
+      ++doubleBondCount;
+    }
+  }
+  CHECK(doubleBondCount == 2);
+  auto bonds = m->bonds();
+  auto hasDoubleBond = std::any_of(bonds.begin(), bonds.end(), [](const auto bond) {
+    return bond->getBondType() == Bond::DOUBLE;
+  });
+  CHECK(hasDoubleBond);
+  doubleBondCount = std::count_if(bonds.begin(), bonds.end(), [](const auto bond) {
+    return bond->getBondType() == Bond::DOUBLE;
+  });
+  CHECK(doubleBondCount == 2);
 }
 
 TEST_CASE("mol.atomNeighbors()") {


### PR DESCRIPTION
Small PR that enables using STL algorithms on `ROMol` atoms and bonds which were previously failing to compile due to missing `==` operator on the `CXXAtomIter` and `CXXBondIter` classes.