### PR TITLE
Remove `and` from C++ headers

### DIFF
--- a/Code/Geometry/point.h
+++ b/Code/Geometry/point.h
@@ -44,7 +44,7 @@ class RDKIT_RDGEOMETRYLIB_EXPORT Point {
 #ifndef _MSC_VER
 // g++ (at least as of v9.3.0) generates some spurious warnings from here.
 // disable them
-#if !defined(__clang__) and defined(__GNUC__)
+#if !defined(__clang__) && defined(__GNUC__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 #endif
@@ -523,7 +523,7 @@ class RDKIT_RDGEOMETRYLIB_EXPORT PointND : public Point {
   }
 };
 #ifndef _MSC_VER
-#if !defined(__clang__) and defined(__GNUC__)
+#if !defined(__clang__) && defined(__GNUC__)
 #pragma GCC diagnostic pop
 #endif
 #endif

--- a/Code/MinimalLib/common.h
+++ b/Code/MinimalLib/common.h
@@ -55,7 +55,7 @@
 
 #ifndef _MSC_VER
 // shutoff some warnings from rapidjson
-#if !defined(__clang__) and defined(__GNUC__)
+#if !defined(__clang__) && defined(__GNUC__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wclass-memaccess"
 #endif
@@ -64,7 +64,7 @@
 #include <rapidjson/stringbuffer.h>
 #include <rapidjson/writer.h>
 #ifndef _MSC_VER
-#if !defined(__clang__) and defined(__GNUC__)
+#if !defined(__clang__) && defined(__GNUC__)
 #pragma GCC diagnostic pop
 #endif
 #endif


### PR DESCRIPTION
`and` is a C++ keyword, but it isn't supported by default on some compilers (msvc). I'd like to disable it on _all_ platforms in Schrödinger builds so that developers don't accidentally post code that fails on a single platform.

However, that means external headers need to use `&&` and `||` instead of `and` and `or`, even in platform-specific code.