### PR TITLE
Allow WriteSDF to create v3000 SDF files

### DIFF
--- a/rdkit/Chem/PandasTools.py
+++ b/rdkit/Chem/PandasTools.py
@@ -395,7 +395,7 @@ def ChangeMoleculeRendering(frame=None, renderer='image'):
     log.warning("Failed to patch pandas - unable to change molecule rendering")
 
 
-def WriteSDF(df, out, molColName='ROMol', idName=None, properties=None, allNumeric=False):
+def WriteSDF(df, out, molColName='ROMol', idName=None, properties=None, allNumeric=False, forceV3000=False):
   '''Write an SD file for the molecules in the dataframe. Dataframe columns can be exported as
     SDF tags if specified in the "properties" list. "properties=list(df.columns)" would export
     all columns.
@@ -412,6 +412,9 @@ def WriteSDF(df, out, molColName='ROMol', idName=None, properties=None, allNumer
       close = out.close
 
   writer = SDWriter(out)
+  if forceV3000:
+    writer.SetForceV3000(True)
+
   if properties is None:
     properties = []
   else:

--- a/rdkit/Chem/UnitTestPandasTools.py
+++ b/rdkit/Chem/UnitTestPandasTools.py
@@ -339,7 +339,7 @@ class TestWriteSDF(unittest.TestCase):
       self.assertEqual(s.split("\n", 1)[0], "Methane")
 
       # check file is V2000
-      self.assertEqual(s.count("V2000"), 1)
+      self.assertGreaterEqual(s.count("V2000"), 1)
       self.assertEqual(s.count("V3000"), 0)
     finally:
       shutil.rmtree(dirname)
@@ -356,7 +356,7 @@ class TestWriteSDF(unittest.TestCase):
 
       # check file is V3000
       self.assertEqual(s.count("V2000"), 0)
-      self.assertEqual(s.count("V3000"), 1)
+      self.assertGreaterEqual(s.count("V3000"), 1)
     finally:
       shutil.rmtree(dirname)
 

--- a/rdkit/Chem/UnitTestPandasTools.py
+++ b/rdkit/Chem/UnitTestPandasTools.py
@@ -337,6 +337,26 @@ class TestWriteSDF(unittest.TestCase):
         s = f.read()
       self.assertEqual(s.count("\n$$$$\n"), 2)
       self.assertEqual(s.split("\n", 1)[0], "Methane")
+
+      # check file is V2000
+      self.assertEqual(s.count("V2000"), 1)
+      self.assertEqual(s.count("V3000"), 0)
+    finally:
+      shutil.rmtree(dirname)
+
+  def test_write_V3000_to_sdf(self):
+    dirname = tempfile.mkdtemp()
+    try:
+      filename = os.path.join(dirname, "test.sdf")
+      PandasTools.WriteSDF(self.df, filename, forceV3000=True)
+      with open(filename) as f:
+        s = f.read()
+      self.assertEqual(s.count("\n$$$$\n"), 2)
+      self.assertEqual(s.split("\n", 1)[0], "Methane")
+
+      # check file is V3000
+      self.assertEqual(s.count("V2000"), 0)
+      self.assertEqual(s.count("V3000"), 1)
     finally:
       shutil.rmtree(dirname)
 


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

This allows the sdf files to be saved to v3000 files


