### PR TITLE
Fix #6011 and #6012

### DIFF
--- a/Code/GraphMol/catch_chirality.cpp
+++ b/Code/GraphMol/catch_chirality.cpp
@@ -3253,3 +3253,44 @@ TEST_CASE("double bond stereo with new chirality perception") {
     }
   }
 }
+
+TEST_CASE("false positives from new stereo code") {
+  SECTION("elements") {
+    std::vector<std::string> examples{"P", "PC", "S", "SC", "S(F)C"};
+    for (auto &smi : examples) {
+      INFO(smi);
+      std::unique_ptr<RWMol> m{SmilesToMol(smi)};
+      REQUIRE(m);
+      auto si = Chirality::findPotentialStereo(*m);
+      CHECK(si.empty());
+    }
+  }
+  SECTION("non-tetrahedral and implicit Hs") {
+    std::vector<std::string> examples{
+        "[SiH4]",       "[SiH3]C",   "[PH5]",        "[PH4]C",
+        "[SH6]",        "[SH5]C",    "[SiH2](C)C",   "[PH3](C)C",
+        "[PH2](C)(C)C", "[SH4](C)C", "[SH3](C)(C)C", "[SH2](C)(C)(C)C"};
+    {
+      AllowNontetrahedralChiralityFixture reset_non_tetrahedral_allowed;
+      Chirality::setAllowNontetrahedralChirality(false);
+      for (auto &smi : examples) {
+        INFO(smi);
+        std::unique_ptr<RWMol> m{SmilesToMol(smi)};
+        REQUIRE(m);
+        auto si = Chirality::findPotentialStereo(*m);
+        CHECK(si.empty());
+      }
+    }
+    {
+      AllowNontetrahedralChiralityFixture reset_non_tetrahedral_allowed;
+      Chirality::setAllowNontetrahedralChirality(true);
+      for (auto &smi : examples) {
+        INFO(smi);
+        std::unique_ptr<RWMol> m{SmilesToMol(smi)};
+        REQUIRE(m);
+        auto si = Chirality::findPotentialStereo(*m);
+        CHECK(si.size() == 1);
+      }
+    }
+  }
+}

--- a/Code/GraphMol/catch_chirality.cpp
+++ b/Code/GraphMol/catch_chirality.cpp
@@ -3267,9 +3267,10 @@ TEST_CASE("false positives from new stereo code") {
   }
   SECTION("non-tetrahedral and implicit Hs") {
     std::vector<std::string> examples{
-        "[SiH4]",       "[SiH3]C",   "[PH5]",        "[PH4]C",
-        "[SH6]",        "[SH5]C",    "[SiH2](C)C",   "[PH3](C)C",
-        "[PH2](C)(C)C", "[SH4](C)C", "[SH3](C)(C)C", "[SH2](C)(C)(C)C"};
+        "[SiH4]",         "[SiH3]C",      "[SH4]",     "[PH5]",
+        "[PH4]C",         "[SH6]",        "[SH5]C",    "[SiH2](C)C",
+        "[PH3](C)C",      "[PH2](C)(C)C", "[SH4](C)C", "[SH3](C)(C)C",
+        "[SH2](C)(C)(C)C"};
     {
       AllowNontetrahedralChiralityFixture reset_non_tetrahedral_allowed;
       Chirality::setAllowNontetrahedralChirality(false);


### PR DESCRIPTION
Fixes #6011 

This is a straightforward fix: do not flag atoms with degree zero as potential tetrahedral stereo atoms.

Fixes #6012 

Anothe simple one: make sure that atoms which are not eligible for tetrahedral stereo do not end up getting flagged as potential stereo atoms when allowNontetrahedralChirality is false 