### PR TITLE
Fixes #888

### DIFF
--- a/Code/GraphMol/Substruct/SubstructMatch.cpp
+++ b/Code/GraphMol/Substruct/SubstructMatch.cpp
@@ -213,11 +213,16 @@ bool MolMatchFinalCheckFunctor::operator()(const std::uint32_t q_c[],
     }
   }
 
-  boost::dynamic_bitset<> match;
+  HashedStorageType match;
   if (d_params.uniquify) {
     match.resize(d_mol.getNumAtoms());
+#ifdef RDK_INTERNAL_BITSET_HAS_HASH
+    match.reset();
+#else
+    std::fill(match.begin(), match.end(), 0);
+#endif
     for (unsigned int i = 0; i < d_query.getNumAtoms(); ++i) {
-      match.set(m_c[i]);
+      match[m_c[i]] = 1;
     }
     if (matchesSeen.find(match) != matchesSeen.end()) {
       return false;

--- a/Code/GraphMol/Substruct/SubstructMatch.cpp
+++ b/Code/GraphMol/Substruct/SubstructMatch.cpp
@@ -619,7 +619,7 @@ unsigned int RecursiveMatcher(const ROMol &mol, const ROMol &query,
   SubstructMatchParameters lparams = params;
   // NOTE: maxMatches and recursive queries is problematic. To make this really
   // cover all cases we'd need a separate parameter for the number of possible
-  // recursive matches. We will add that for the 2022.09 release; for now
+  // recursive matches. We will add that for the 2023.03 release; for now
   // we can still fix #888 without introducing any new problems using this
   // heuristic:
   lparams.maxMatches = std::max(1000u, params.maxMatches);

--- a/Code/GraphMol/Substruct/SubstructMatch.h
+++ b/Code/GraphMol/Substruct/SubstructMatch.h
@@ -19,7 +19,12 @@
 #include <unordered_map>
 #include <cstdint>
 #include <string>
+
 #include <boost/dynamic_bitset.hpp>
+#if BOOST_VERSION >= 107100
+#define RDK_INTERNAL_BITSET_HAS_HASH
+#endif
+
 #include <GraphMol/StereoGroup.h>
 
 namespace RDKit {
@@ -228,7 +233,14 @@ class RDKIT_SUBSTRUCTMATCH_EXPORT MolMatchFinalCheckFunctor {
   const ROMol &d_mol;
   const SubstructMatchParameters &d_params;
   std::unordered_map<unsigned int, StereoGroup const *> d_molStereoGroups;
-  std::unordered_set<boost::dynamic_bitset<>> matchesSeen;
+#ifdef RDK_INTERNAL_BITSET_HAS_HASH
+  // Boost 1.71 added support for std::hash with dynamic_bitset.
+  using HashedStorageType = boost::dynamic_bitset<>;
+#else
+  // otherwise we use a less elegant solution
+  using HashedStorageType = std::string;
+#endif
+  std::unordered_set<HashedStorageType> matchesSeen;
 };
 
 }  // namespace RDKit

--- a/Code/GraphMol/Substruct/SubstructMatch.h
+++ b/Code/GraphMol/Substruct/SubstructMatch.h
@@ -13,11 +13,14 @@
 
 // std bits
 #include <vector>
+
+#include <unordered_set>
 #include <functional>
 #include <unordered_map>
 #include <cstdint>
-#include "GraphMol/StereoGroup.h"
 #include <string>
+#include <boost/dynamic_bitset.hpp>
+#include <GraphMol/StereoGroup.h>
 
 namespace RDKit {
 class ROMol;
@@ -218,13 +221,14 @@ class RDKIT_SUBSTRUCTMATCH_EXPORT MolMatchFinalCheckFunctor {
   MolMatchFinalCheckFunctor(const ROMol &query, const ROMol &mol,
                             const SubstructMatchParameters &ps);
 
-  bool operator()(const std::uint32_t q_c[], const std::uint32_t m_c[]) const;
+  bool operator()(const std::uint32_t q_c[], const std::uint32_t m_c[]);
 
  private:
   const ROMol &d_query;
   const ROMol &d_mol;
   const SubstructMatchParameters &d_params;
   std::unordered_map<unsigned int, StereoGroup const *> d_molStereoGroups;
+  std::unordered_set<boost::dynamic_bitset<>> matchesSeen;
 };
 
 }  // namespace RDKit


### PR DESCRIPTION
This was more straightforward than I had originally thought it would be.
The fix moves the uniqueness check for the solutions to substructure matching into the final check functor instead of doing after solutions are identified.

I've benchmarked this change using the `new_timings.py` script and it's actually a few percent faster than the older approach. I'm not sure I believe that, but it should at least tell us that there's no significant negative performance impact. This is true with both newer versions of boost (where we using `dynamic_bitset` for the hashing) and older versions (where we use `std::string`).

Doing the fix did highlight that we should also have a seperate parameter for governing the maximum number of recursive substructMatches. This is captured in #6017.
