### PR TITLE
Fix some minor leaks

### DIFF
--- a/Code/GraphMol/Fingerprints/AtomPairGenerator.cpp
+++ b/Code/GraphMol/Fingerprints/AtomPairGenerator.cpp
@@ -25,8 +25,7 @@ AtomPairAtomInvGenerator::AtomPairAtomInvGenerator(
 
 std::vector<std::uint32_t> *AtomPairAtomInvGenerator::getAtomInvariants(
     const ROMol &mol) const {
-  std::vector<std::uint32_t> *atomInvariants =
-      new std::vector<std::uint32_t>(mol.getNumAtoms());
+  auto *atomInvariants = new std::vector<std::uint32_t>(mol.getNumAtoms());
 
   for (ROMol::ConstAtomIterator atomItI = mol.beginAtoms();
        atomItI != mol.endAtoms(); ++atomItI) {

--- a/Code/GraphMol/MolStandardize/test1.cpp
+++ b/Code/GraphMol/MolStandardize/test1.cpp
@@ -36,7 +36,7 @@ void testCleanup() {
   {
     // Github 5997
     auto m = "CC(=O)O[Mg]OC(=O)C"_smiles;
-    auto res(MolStandardize::cleanup(*m, params));
+    RWMOL_SPTR res(MolStandardize::cleanup(*m, params));
     TEST_ASSERT(MolToSmiles(*res) == "CC(=O)[O-].CC(=O)[O-].[Mg+2]");
   }
 

--- a/Code/GraphMol/ROMol.cpp
+++ b/Code/GraphMol/ROMol.cpp
@@ -705,7 +705,9 @@ void ROMol::load(Archive &ar, const unsigned int) {
   std::string pkl;
   ar >> pkl;
 
+  delete dp_ringInfo;
   initMol();
+
   numBonds = 0;
   MolPickler::molFromPickle(pkl, *this, PicklerOps::AllProps);
   numBonds = rdcast<unsigned int>(boost::num_edges(d_graph));


### PR DESCRIPTION
This fixes some minor leaks I found running asan on the tests:

- `Code/GraphMol/MolStandardize/test1.cpp`: just one Mol that wasn't being deallocated.
- `Code/GraphMol/Fingerprints/FingerprintGenerator.cpp`: `atomInvariants` and `bondInvariants` were not being cleaned up when something fails in downstream code.
- `Code/GraphMol/ROMol.cpp`: `ROMol::load()` is not a constructor, so it can only be called on already initialized mols, so when we call `initMol()` (I assume that to reset properties and ring info, `dp_ringInfo` is already allocated, and leaks.
