### PR TITLE
Fixes typo in PandasTools (Chem.Mol should have been str)

### DIFF
--- a/rdkit/Chem/PandasTools.py
+++ b/rdkit/Chem/PandasTools.py
@@ -511,7 +511,7 @@ def SaveXlsxFromFrame(frame, outFile, molCol='ROMol', size=(300, 300), formats=N
   import xlsxwriter  # don't want to make this a RDKit dependency
 
   cols = list(frame.columns)
-  if isinstance(molCol, Chem.Mol):
+  if isinstance(molCol, str):
     molCol = [molCol]
   molCol = list(set(molCol))
   dataTypes = dict(frame.dtypes)


### PR DESCRIPTION
This fixes a typo that I inadvertently introduced in #5835: `molCol` can either be an iterable of `str` or a single `str`, certainly not a `Chem.Mol`.