### PR TITLE
Fixes #6034

### DIFF
--- a/Code/GraphMol/ChemTransforms/MolFragmenter.cpp
+++ b/Code/GraphMol/ChemTransforms/MolFragmenter.cpp
@@ -541,6 +541,8 @@ ROMol *fragmentOnBonds(
             tatom->getNoImplicit() ||
             (tatom->getIsAromatic() && tatom->getAtomicNum() != 6)) {
           tatom->setNumExplicitHs(tatom->getNumExplicitHs() + 1);
+        } else {
+          tatom->updatePropertyCache(false);
         }
       }
     }

--- a/Code/GraphMol/ChemTransforms/MolFragmenter.cpp
+++ b/Code/GraphMol/ChemTransforms/MolFragmenter.cpp
@@ -535,14 +535,13 @@ ROMol *fragmentOnBonds(
         conf->setAtomPos(idx2, conf->getAtomPos(eidx));
       }
     } else {
-      // was github issue 429
-      Atom *tatom = res->getAtomWithIdx(bidx);
-      if (tatom->getIsAromatic() && tatom->getAtomicNum() != 6) {
-        tatom->setNumExplicitHs(tatom->getNumExplicitHs() + 1);
-      }
-      tatom = res->getAtomWithIdx(eidx);
-      if (tatom->getIsAromatic() && tatom->getAtomicNum() != 6) {
-        tatom->setNumExplicitHs(tatom->getNumExplicitHs() + 1);
+      // was github issues 429, 6034
+      for (auto idx : {bidx, eidx}) {
+        if (auto tatom = res->getAtomWithIdx(idx);
+            tatom->getNoImplicit() ||
+            (tatom->getIsAromatic() && tatom->getAtomicNum() != 6)) {
+          tatom->setNumExplicitHs(tatom->getNumExplicitHs() + 1);
+        }
       }
     }
   }

--- a/Code/GraphMol/ChemTransforms/catch_tests.cpp
+++ b/Code/GraphMol/ChemTransforms/catch_tests.cpp
@@ -560,3 +560,31 @@ TEST_CASE("Molzip with 2D coordinates", "[molzip]") {
     delete query;
   }
 }
+
+TEST_CASE("Github #6034: FragmentOnBonds may create unexpected radicals") {
+  auto m = "C[C@H](Cl)c1ccccc1"_smiles;
+
+  REQUIRE(m);
+  REQUIRE(m->getNumAtoms() == 9);
+
+  REQUIRE(m->getAtomWithIdx(1)->getNoImplicit() == true);
+
+  bool add_dummies = false;
+  std::vector<unsigned int> bonds = {0};
+  std::vector<std::pair<unsigned, unsigned>> *dummyLabels = nullptr;
+  const std::vector<Bond::BondType> *bondTypes = nullptr;
+  std::vector<unsigned> nCutsPerAtom(m->getNumAtoms(), 0);
+  std::unique_ptr<ROMol> pieces(MolFragmenter::fragmentOnBonds(
+      *m, bonds, add_dummies, dummyLabels, bondTypes, &nCutsPerAtom));
+  REQUIRE(pieces);
+  REQUIRE(nCutsPerAtom == std::vector<unsigned>{1, 1, 0, 0, 0, 0, 0, 0, 0});
+
+  pieces->updatePropertyCache(false);
+
+  for (auto at : pieces->atoms()) {
+    if (at->getAtomicNum() == 6) {
+      CHECK(at->getNoImplicit() == (at->getIdx() == 1));
+      CHECK(at->getTotalValence() == 4);
+    }
+  }
+}

--- a/Code/GraphMol/ChemTransforms/catch_tests.cpp
+++ b/Code/GraphMol/ChemTransforms/catch_tests.cpp
@@ -579,9 +579,8 @@ TEST_CASE("Github #6034: FragmentOnBonds may create unexpected radicals") {
   REQUIRE(pieces);
   REQUIRE(nCutsPerAtom == std::vector<unsigned>{1, 1, 0, 0, 0, 0, 0, 0, 0});
 
-  pieces->updatePropertyCache(false);
-
   for (auto at : pieces->atoms()) {
+    INFO("atom " + std::to_string(at->getIdx()));
     if (at->getAtomicNum() == 6) {
       CHECK(at->getNoImplicit() == (at->getIdx() == 1));
       CHECK(at->getTotalValence() == 4);


### PR DESCRIPTION
This fixes #6034.

The fix is simple: it just adds `getNoImplicit()` to the conditions we check to know if we need to update an atom's number of explicit Hs when breaking a bond.