### PR TITLE
Allow SMARTS of zero order bonds to match zero order bonds

### DIFF
--- a/Code/GraphMol/SmilesParse/SmartsWrite.cpp
+++ b/Code/GraphMol/SmilesParse/SmartsWrite.cpp
@@ -365,6 +365,9 @@ std::string getBasicBondRepr(Bond::BondType typ, Bond::BondDir dir,
         res = "->";
       }
       break;
+    case Bond::ZERO:
+      res = "~"; // Actually means "any", but we use ~ for unknown bond types in SMILES,
+      break;     // and this will match a ZOB.
     default:
       res = "";
   }

--- a/Code/GraphMol/SmilesParse/catch_tests.cpp
+++ b/Code/GraphMol/SmilesParse/catch_tests.cpp
@@ -1728,7 +1728,7 @@ M  END)CTAB"_ctab;
 TEST_CASE("Github #4582 continued: double bonds and ring closures") {
   SECTION("basics") {
     auto mol = R"CTAB(
-  Mrv2108 10072106112D          
+  Mrv2108 10072106112D
 
  11 11  0  0  0  0            999 V2000
     1.2097   -1.0517    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
@@ -1958,7 +1958,7 @@ TEST_CASE("empty atom label block", "[cxsmiles]") {
   SECTION("basics") {
     auto m = R"CTAB(
   MJ201100
-                        
+
   8  8  0  0  0  0  0  0  0  0999 V2000
    -1.0491    1.5839    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
    -1.7635    1.1714    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
@@ -2155,7 +2155,7 @@ TEST_CASE("wiggly and wedged bonds in CXSMILES") {
 
   SECTION("writing wedges and dashes") {
     auto m = R"CTAB(
-  RDKit             2D          
+  RDKit             2D
 
   0  0  0     0  0            999 V3000
 M  V30 BEGIN CTAB
@@ -2200,7 +2200,7 @@ M  END
 
   SECTION("double bond stereo") {
     auto m_from_ctab = R"CTAB(
-  Mrv2211 09152216122D          
+  Mrv2211 09152216122D
 
   0  0  0     0  0            999 V3000
 M  V30 BEGIN CTAB
@@ -2355,4 +2355,15 @@ TEST_CASE("Github #5683: SMARTS bond ordering should be the same as SMILES") {
     auto sma = "O=C(C=CCC1CCCCC1)N1N=Cc2ccccc2C1c1ccccc1 |w:3.1|";
     CHECK_THROWS_AS(SmartsToMol(sma), SmilesParseException);
   }
+}
+
+TEST_CASE("SMARTS for molecule with zero order bond should match itself")
+{
+    auto m = "CN(<-[Li+])C"_smiles;
+    m->getBondBetweenAtoms(1, 2)->setBondType(Bond::BondType::ZERO);
+    const auto sma = MolToSmarts(*m);
+    std::unique_ptr<ROMol> q{SmartsToMol(sma)};
+    SubstructMatchParameters ps;
+    ps.maxMatches = 1;
+    CHECK(SubstructMatch(*m, *q, ps).size() == 1);
 }


### PR DESCRIPTION
Before this commit, if you run MolToSmarts on a molecule with a zero order bond (ZOB), the SMARTS won't match the ZOB! It's a bit weird for a molecule not to be its own substructure...

This came up because in Schödinger we see ZOBs somewhat frequently in organometallics.
