### PR TITLE
Replace the broken, commented out test for legacy stereo with a test that works

### DIFF
--- a/Code/MinimalLib/tests/tests.js
+++ b/Code/MinimalLib/tests/tests.js
@@ -973,14 +973,14 @@ M  END`);
 
 function test_legacy_stereochem() {
     RDKitModule.use_legacy_stereo_perception(true);
-    var mol = RDKitModule.get_mol("C[C@H]1CCC2(CC1)CC[C@H](C)C(C)C2");
+    var mol = RDKitModule.get_mol("O[C@@]1(C)C/C(/C1)=C(/C)\\CC");
     assert.equal(mol.is_valid(),1);
-    assert.equal(mol.get_smiles(),"CC1CCC2(CC1)CC[C@H](C)C(C)C2");
+    assert.equal(mol.get_smiles(),"CCC(C)=C1CC(C)(O)C1");
 
     RDKitModule.use_legacy_stereo_perception(false);
-    mol = RDKitModule.get_mol("C[C@H]1CCC2(CC1)CC[C@H](C)C(C)C2");
+    mol = RDKitModule.get_mol("O[C@@]1(C)C/C(/C1)=C(/C)\\CC");
     assert.equal(mol.is_valid(),1);
-    //assert.equal(mol.get_smiles(),"CC1CC2(CC[C@H](C)CC2)CC[C@@H]1C");
+    assert.equal(mol.get_smiles(),"CC/C(C)=C1\\C[C@](C)(O)C1");
 }
 
 function test_prop() {


### PR DESCRIPTION
Small PR to replace a test that does not actually work (same stereochemistry is perceived regardless of whether legacy is used or not, same happens from Python), and hence is commented out, with a test that actually yields different results depending on the legacy stereo setting, and hence actually tests the underlying code.