### PR TITLE
run the BRICS tests and EnumerateStereoisomers doctests

### DIFF
--- a/rdkit/Chem/EnumerateStereoisomers.py
+++ b/rdkit/Chem/EnumerateStereoisomers.py
@@ -355,3 +355,18 @@ def EnumerateStereoisomers(m, options=StereoEnumerationOptions(), verbose=False)
         break
     elif verbose:
       print("%s    failed to embed" % (Chem.MolToSmiles(isomer, isomericSmiles=True)))
+
+
+#------------------------------------
+#
+#  doctest boilerplate
+#
+def _test():
+  import doctest, sys
+  return doctest.testmod(sys.modules["__main__"])
+
+
+if __name__ == '__main__':
+  import sys
+  failed, tried = _test()
+  sys.exit(failed)

--- a/rdkit/Chem/test_list.py
+++ b/rdkit/Chem/test_list.py
@@ -10,7 +10,9 @@ tests = [("python", "UnitTestChem.py", {}), ("python", "UnitTestChemv2.py", {}),
          ("python", "UnitTestFunctionalGroups.py", {}), ("python", "UnitTestCrippen.py", {}),
          ("python", "UnitTestPandasTools.py", {}), ("python", "UnitTestDocTestsChem.py", {}),
          ("python", "UnitTestFeatFinderCLI.py", {}), ("python", "UnitTestQED.py", {}),
-         ("python", "UnitTestSaltRemover.py", {}), ("python", "test_list.py", {
+         ("python", "UnitTestSaltRemover.py", {}), ("python", "BRICS.py", {}),
+         ("python", "EnumerateStereoisomers.py",{}),
+         ("python", "test_list.py", {
            'dir': 'AtomPairs'
          }), ("python", "test_list.py", {
            'dir': 'ChemUtils'


### PR DESCRIPTION
While working on the giant canonicalization PR, I noticed that the BRICS tests aren't being run and that, though EnumerateStereoisomers has doctests, they aren't being run either.

This fixes that.

