### PR TITLE
WIP - Disable alpha channel support on legacy browsers

### DIFF
--- a/Code/GraphMol/MolDraw2D/MolDraw2DSVG.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DSVG.cpp
@@ -58,7 +58,11 @@ void outputMetaData(const t_obj *obj, std::ostream &d_os) {
 
 std::string DrawColourToSVG(const DrawColour &col) {
   const char *convert = "0123456789ABCDEF";
+#ifndef RDK_MINIMAL_LIB_SUPPORT_LEGACY_BROWSERS
   bool hasAlpha = 1.0 - col.a > 1e-3;
+#else
+  bool hasAlpha = false;
+#endif
   std::string res(hasAlpha ? 9 : 7, ' ');
   res[0] = '#';
   unsigned int v;


### PR DESCRIPTION
Small PR to disable alpha channel when generating SVG and `canvas` images since it is not supported by legacy browsers.