### PR TITLE
Fixes #6049

### DIFF
--- a/Code/GraphMol/Descriptors/Lipinski.cpp
+++ b/Code/GraphMol/Descriptors/Lipinski.cpp
@@ -462,7 +462,7 @@ unsigned int calcNumSpiroAtoms(const ROMol &mol,
   return atoms->size();
 }
 
-const std::string NumBridgeheadAtomsVersion = "1.0.0";
+const std::string NumBridgeheadAtomsVersion = "2.0.0";
 unsigned int calcNumBridgeheadAtoms(const ROMol &mol,
                                     std::vector<unsigned int> *atoms) {
   if (!mol.getRingInfo() || !mol.getRingInfo()->isInitialized()) {

--- a/Code/GraphMol/QueryOps.cpp
+++ b/Code/GraphMol/QueryOps.cpp
@@ -35,10 +35,26 @@ int queryIsAtomBridgehead(Atom const *at) {
   if (!ri || !ri->isInitialized()) {
     return 0;
   }
-  // track which bonds involve this atom
+#if 1
+  unsigned int numSharedRingBonds = 0;
+  for (const auto bnd : mol.atomBonds(at)) {
+    auto nBondRings = ri->numBondRings(bnd->getIdx());
+    if (nBondRings == 1) {
+      numSharedRingBonds = 0;
+      break;
+    } else if (nBondRings > 1) {
+      ++numSharedRingBonds;
+    }
+  }
+  if (numSharedRingBonds >= 3) {
+    return 1;
+  }
+  return 0;
+
+#else
+  // track which ring bonds involve this atom
   boost::dynamic_bitset<> atomRingBonds(mol.getNumBonds());
-  for (const auto &nbri : boost::make_iterator_range(mol.getAtomBonds(at))) {
-    const auto &bnd = mol[nbri];
+  for (const auto bnd : mol.atomBonds(at)) {
     if (ri->numBondRings(bnd->getIdx())) {
       atomRingBonds.set(bnd->getIdx());
     }
@@ -79,6 +95,7 @@ int queryIsAtomBridgehead(Atom const *at) {
       }
     }
   }
+#endif
   return 0;
 }
 

--- a/Code/GraphMol/QueryOps.cpp
+++ b/Code/GraphMol/QueryOps.cpp
@@ -35,23 +35,6 @@ int queryIsAtomBridgehead(Atom const *at) {
   if (!ri || !ri->isInitialized()) {
     return 0;
   }
-#if 1
-  unsigned int numSharedRingBonds = 0;
-  for (const auto bnd : mol.atomBonds(at)) {
-    auto nBondRings = ri->numBondRings(bnd->getIdx());
-    if (nBondRings == 1) {
-      numSharedRingBonds = 0;
-      break;
-    } else if (nBondRings > 1) {
-      ++numSharedRingBonds;
-    }
-  }
-  if (numSharedRingBonds >= 3) {
-    return 1;
-  }
-  return 0;
-
-#else
   // track which ring bonds involve this atom
   boost::dynamic_bitset<> atomRingBonds(mol.getNumBonds());
   for (const auto bnd : mol.atomBonds(at)) {
@@ -64,14 +47,15 @@ int queryIsAtomBridgehead(Atom const *at) {
   }
 
   boost::dynamic_bitset<> bondsInRing(mol.getNumBonds());
+  std::vector<unsigned int> numSharedRings(mol.getNumBonds(), 0);
   for (unsigned int i = 0; i < ri->bondRings().size(); ++i) {
     bondsInRing.reset();
     bool atomInRingI = false;
-
     for (const auto bidx : ri->bondRings()[i]) {
       bondsInRing.set(bidx);
       if (atomRingBonds[bidx]) {
         atomInRingI = true;
+        break;
       }
     }
     if (!atomInRingI) {
@@ -95,7 +79,6 @@ int queryIsAtomBridgehead(Atom const *at) {
       }
     }
   }
-#endif
   return 0;
 }
 

--- a/Code/GraphMol/catch_chirality.cpp
+++ b/Code/GraphMol/catch_chirality.cpp
@@ -3295,3 +3295,15 @@ TEST_CASE("false positives from new stereo code") {
     }
   }
 }
+
+TEST_CASE(
+    "Github #6049: Cyclobutyl group in a macrocycle triggers a stereo center") {
+  SECTION("as reported") {
+    auto mol = "O=S1(=O)C=CC=C2CCCCC3CC(C3)N21"_smiles;
+    REQUIRE(mol);
+    auto stereoInfo = Chirality::findPotentialStereo(*mol);
+    for (const auto &sg : stereoInfo) {
+      CHECK(sg.centeredOn != 15);
+    }
+  }
+}

--- a/Code/GraphMol/catch_graphmol.cpp
+++ b/Code/GraphMol/catch_graphmol.cpp
@@ -1970,6 +1970,14 @@ TEST_CASE("bridgehead queries", "[query]") {
       }
     }
   }
+  SECTION("Github #6049") {
+    auto m = "C1C=CC=C2CCCCC3CC(C3)N21"_smiles;
+    REQUIRE(m);
+    CHECK(!queryIsAtomBridgehead(m->getAtomWithIdx(13)));
+    CHECK(!queryIsAtomBridgehead(m->getAtomWithIdx(4)));
+    CHECK(queryIsAtomBridgehead(m->getAtomWithIdx(11)));
+    CHECK(queryIsAtomBridgehead(m->getAtomWithIdx(9)));
+  }
 }
 
 TEST_CASE("replaceAtom/Bond should not screw up bookmarks", "[RWMol]") {


### PR DESCRIPTION
Updates the query for bridgehead atoms to resolve the issue.
This also impacts the `NumBridgeheadAtoms` descriptors, so the version on that gets bumped as well.
