### PR TITLE
Correct docstring for minFontSize.

### DIFF
--- a/Code/GraphMol/MolDraw2D/Wrap/rdMolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/Wrap/rdMolDraw2D.cpp
@@ -790,7 +790,7 @@ BOOST_PYTHON_MODULE(rdMolDraw2D) {
                      "maximum font size in pixels. default=40, -1 means no"
                      " maximum.")
       .def_readwrite("minFontSize", &RDKit::MolDrawOptions::minFontSize,
-                     "minimum font size in pixels. default=12, -1 means no"
+                     "minimum font size in pixels. default=6, -1 means no"
                      " minimum.")
       .def_readwrite(
           "fixedFontSize", &RDKit::MolDrawOptions::fixedFontSize,


### PR DESCRIPTION
#### Reference Issue
No issue.


#### What does this implement/fix? Explain your changes.
Corrects the default value for minFontSize in the python doctoring.

#### Any other comments?
And that took longer and much more typing than the fix itself!
