### PR TITLE
Start a Maestro file (.mae) writer.

### DIFF
--- a/Code/GraphMol/CMakeLists.txt
+++ b/Code/GraphMol/CMakeLists.txt
@@ -2,7 +2,7 @@ if(RDK_USE_BOOST_SERIALIZATION AND Boost_SERIALIZATION_LIBRARY)
     set(RDKit_SERIALIZATION_LIBS ${Boost_SERIALIZATION_LIBRARY})
 else()
     message("== Making SubstructLibrary without boost Serialization support")
-    set(RDKit_SERIALIZATION_LIBS )
+    set(RDKit_SERIALIZATION_LIBS)
 endif()
 
 rdkit_library(GraphMol
@@ -16,7 +16,7 @@ rdkit_library(GraphMol
               new_canon.cpp SubstanceGroup.cpp FindStereo.cpp MonomerInfo.cpp
               NontetrahedralStereo.cpp
               SHARED
-              LINK_LIBRARIES RDGeometryLib RDGeneral ${RDKit_SERIALIZATION_LIBS} )
+              LINK_LIBRARIES RDGeometryLib RDGeneral ${RDKit_SERIALIZATION_LIBS})
 target_compile_definitions(GraphMol PRIVATE RDKIT_GRAPHMOL_BUILD)
 if(RDK_USE_URF)
   target_link_libraries(GraphMol PUBLIC ${RDK_URF_LIBS})
@@ -135,26 +135,23 @@ rdkit_test(graphmolcpTest cptest.cpp LINK_LIBRARIES  SmilesParse GraphMol)
 rdkit_test(graphmolqueryTest querytest.cpp LINK_LIBRARIES SubstructMatch SmilesParse GraphMol)
 
 rdkit_test(graphmolMolOpsTest molopstest.cpp
-           LINK_LIBRARIES SubstructMatch FileParsers
-	   SmilesParse GraphMol )
+           LINK_LIBRARIES SubstructMatch FileParsers SmilesParse GraphMol)
 
 rdkit_test(graphmoltestChirality testChirality.cpp
-           LINK_LIBRARIES SmilesParse FileParsers
-	   GraphMol )
+           LINK_LIBRARIES SmilesParse FileParsers GraphMol)
 
 rdkit_test(graphmoltestPickler testPickler.cpp
-           LINK_LIBRARIES SmilesParse SubstructMatch FileParsers GraphMol )
+           LINK_LIBRARIES SmilesParse SubstructMatch FileParsers GraphMol)
 
 rdkit_test(graphmoltestPicklerGlobalSetting testPicklerGlobalSettings.cpp
-           LINK_LIBRARIES SmilesParse SubstructMatch FileParsers GraphMol )
+           LINK_LIBRARIES SmilesParse SubstructMatch FileParsers GraphMol)
 
-rdkit_test(graphmolIterTest itertest.cpp LINK_LIBRARIES SmilesParse GraphMol )
+rdkit_test(graphmolIterTest itertest.cpp LINK_LIBRARIES SmilesParse GraphMol)
 
 rdkit_test(hanoiTest hanoitest.cpp LINK_LIBRARIES
-     SubstructMatch SmilesParse FileParsers GraphMol
-      )
+     SubstructMatch SmilesParse FileParsers GraphMol)
 
-rdkit_test(graphmolMemTest1 memtest1.cpp LINK_LIBRARIES SmilesParse GraphMol )
+rdkit_test(graphmolMemTest1 memtest1.cpp LINK_LIBRARIES SmilesParse GraphMol)
 
 rdkit_test(resMolSupplierTest resMolSupplierTest.cpp
            LINK_LIBRARIES SmilesParse GraphMol SubstructMatch FileParsers)
@@ -164,22 +161,22 @@ rdkit_test(molBundleTest testMolBundle.cpp
 
 rdkit_test(testSGroup testSGroup.cpp LINK_LIBRARIES FileParsers GraphMol)
 
-rdkit_test(test-valgrind test-valgrind.cpp LINK_LIBRARIES SmilesParse GraphMol )
+rdkit_test(test-valgrind test-valgrind.cpp LINK_LIBRARIES FileParsers SmilesParse GraphMol)
 
-rdkit_catch_test(graphmolTestsCatch catch_graphmol.cpp 
-           LINK_LIBRARIES SubstructMatch FileParsers SmilesParse GraphMol )
+rdkit_catch_test(graphmolTestsCatch catch_graphmol.cpp
+           LINK_LIBRARIES SubstructMatch FileParsers SmilesParse GraphMol)
 
-rdkit_catch_test(graphmolSGroupCatch catch_sgroups.cpp  
-           LINK_LIBRARIES SmilesParse FileParsers GraphMol )
+rdkit_catch_test(graphmolSGroupCatch catch_sgroups.cpp
+           LINK_LIBRARIES SmilesParse FileParsers GraphMol)
 
-rdkit_catch_test(graphmolAdjustQueryCatch catch_adjustquery.cpp 
-           LINK_LIBRARIES SubstructMatch FileParsers SmilesParse GraphMol )
-           
-rdkit_catch_test(chiralityTestsCatch catch_chirality.cpp 
-           LINK_LIBRARIES FileParsers SmilesParse GraphMol )
+rdkit_catch_test(graphmolAdjustQueryCatch catch_adjustquery.cpp
+           LINK_LIBRARIES SubstructMatch FileParsers SmilesParse GraphMol)
 
-rdkit_catch_test(canonTestsCatch catch_canon.cpp 
-           LINK_LIBRARIES FileParsers SmilesParse GraphMol )
+rdkit_catch_test(chiralityTestsCatch catch_chirality.cpp
+           LINK_LIBRARIES FileParsers SmilesParse GraphMol)
 
-rdkit_catch_test(moliteratorTestsCatch catch_moliterators.cpp 
-           LINK_LIBRARIES SubstructMatch SmilesParse GraphMol )
+rdkit_catch_test(canonTestsCatch catch_canon.cpp
+           LINK_LIBRARIES FileParsers SmilesParse GraphMol)
+
+rdkit_catch_test(moliteratorTestsCatch catch_moliterators.cpp
+           LINK_LIBRARIES SubstructMatch SmilesParse GraphMol)

--- a/Code/GraphMol/CMakeLists.txt
+++ b/Code/GraphMol/CMakeLists.txt
@@ -2,7 +2,7 @@ if(RDK_USE_BOOST_SERIALIZATION AND Boost_SERIALIZATION_LIBRARY)
     set(RDKit_SERIALIZATION_LIBS ${Boost_SERIALIZATION_LIBRARY})
 else()
     message("== Making SubstructLibrary without boost Serialization support")
-    set(RDKit_SERIALIZATION_LIBS)
+    set(RDKit_SERIALIZATION_LIBS )
 endif()
 
 rdkit_library(GraphMol
@@ -16,7 +16,7 @@ rdkit_library(GraphMol
               new_canon.cpp SubstanceGroup.cpp FindStereo.cpp MonomerInfo.cpp
               NontetrahedralStereo.cpp
               SHARED
-              LINK_LIBRARIES RDGeometryLib RDGeneral ${RDKit_SERIALIZATION_LIBS})
+              LINK_LIBRARIES RDGeometryLib RDGeneral ${RDKit_SERIALIZATION_LIBS} )
 target_compile_definitions(GraphMol PRIVATE RDKIT_GRAPHMOL_BUILD)
 if(RDK_USE_URF)
   target_link_libraries(GraphMol PUBLIC ${RDK_URF_LIBS})
@@ -135,23 +135,26 @@ rdkit_test(graphmolcpTest cptest.cpp LINK_LIBRARIES  SmilesParse GraphMol)
 rdkit_test(graphmolqueryTest querytest.cpp LINK_LIBRARIES SubstructMatch SmilesParse GraphMol)
 
 rdkit_test(graphmolMolOpsTest molopstest.cpp
-           LINK_LIBRARIES SubstructMatch FileParsers SmilesParse GraphMol)
+           LINK_LIBRARIES SubstructMatch FileParsers
+	   SmilesParse GraphMol )
 
 rdkit_test(graphmoltestChirality testChirality.cpp
-           LINK_LIBRARIES SmilesParse FileParsers GraphMol)
+           LINK_LIBRARIES SmilesParse FileParsers
+	   GraphMol )
 
 rdkit_test(graphmoltestPickler testPickler.cpp
-           LINK_LIBRARIES SmilesParse SubstructMatch FileParsers GraphMol)
+           LINK_LIBRARIES SmilesParse SubstructMatch FileParsers GraphMol )
 
 rdkit_test(graphmoltestPicklerGlobalSetting testPicklerGlobalSettings.cpp
-           LINK_LIBRARIES SmilesParse SubstructMatch FileParsers GraphMol)
+           LINK_LIBRARIES SmilesParse SubstructMatch FileParsers GraphMol )
 
-rdkit_test(graphmolIterTest itertest.cpp LINK_LIBRARIES SmilesParse GraphMol)
+rdkit_test(graphmolIterTest itertest.cpp LINK_LIBRARIES SmilesParse GraphMol )
 
 rdkit_test(hanoiTest hanoitest.cpp LINK_LIBRARIES
-     SubstructMatch SmilesParse FileParsers GraphMol)
+     SubstructMatch SmilesParse FileParsers GraphMol
+      )
 
-rdkit_test(graphmolMemTest1 memtest1.cpp LINK_LIBRARIES SmilesParse GraphMol)
+rdkit_test(graphmolMemTest1 memtest1.cpp LINK_LIBRARIES SmilesParse GraphMol )
 
 rdkit_test(resMolSupplierTest resMolSupplierTest.cpp
            LINK_LIBRARIES SmilesParse GraphMol SubstructMatch FileParsers)
@@ -161,22 +164,22 @@ rdkit_test(molBundleTest testMolBundle.cpp
 
 rdkit_test(testSGroup testSGroup.cpp LINK_LIBRARIES FileParsers GraphMol)
 
-rdkit_test(test-valgrind test-valgrind.cpp LINK_LIBRARIES FileParsers SmilesParse GraphMol)
+rdkit_test(test-valgrind test-valgrind.cpp LINK_LIBRARIES SmilesParse GraphMol )
 
-rdkit_catch_test(graphmolTestsCatch catch_graphmol.cpp
-           LINK_LIBRARIES SubstructMatch FileParsers SmilesParse GraphMol)
+rdkit_catch_test(graphmolTestsCatch catch_graphmol.cpp 
+           LINK_LIBRARIES SubstructMatch FileParsers SmilesParse GraphMol )
 
-rdkit_catch_test(graphmolSGroupCatch catch_sgroups.cpp
-           LINK_LIBRARIES SmilesParse FileParsers GraphMol)
+rdkit_catch_test(graphmolSGroupCatch catch_sgroups.cpp  
+           LINK_LIBRARIES SmilesParse FileParsers GraphMol )
 
-rdkit_catch_test(graphmolAdjustQueryCatch catch_adjustquery.cpp
-           LINK_LIBRARIES SubstructMatch FileParsers SmilesParse GraphMol)
+rdkit_catch_test(graphmolAdjustQueryCatch catch_adjustquery.cpp 
+           LINK_LIBRARIES SubstructMatch FileParsers SmilesParse GraphMol )
+           
+rdkit_catch_test(chiralityTestsCatch catch_chirality.cpp 
+           LINK_LIBRARIES FileParsers SmilesParse GraphMol )
 
-rdkit_catch_test(chiralityTestsCatch catch_chirality.cpp
-           LINK_LIBRARIES FileParsers SmilesParse GraphMol)
+rdkit_catch_test(canonTestsCatch catch_canon.cpp 
+           LINK_LIBRARIES FileParsers SmilesParse GraphMol )
 
-rdkit_catch_test(canonTestsCatch catch_canon.cpp
-           LINK_LIBRARIES FileParsers SmilesParse GraphMol)
-
-rdkit_catch_test(moliteratorTestsCatch catch_moliterators.cpp
-           LINK_LIBRARIES SubstructMatch SmilesParse GraphMol)
+rdkit_catch_test(moliteratorTestsCatch catch_moliterators.cpp 
+           LINK_LIBRARIES SubstructMatch SmilesParse GraphMol )

--- a/Code/GraphMol/FileParsers/CMakeLists.txt
+++ b/Code/GraphMol/FileParsers/CMakeLists.txt
@@ -32,7 +32,7 @@ endif(RDK_USE_BOOST_IOSTREAMS)
 
 if(RDK_BUILD_MAEPARSER_SUPPORT)
     include_directories(${maeparser_INCLUDE_DIRS})
-    set (maesupplier MaeMolSupplier.cpp)
+    set (maesupplier MaeMolSupplier.cpp MaeWriter.cpp)
 endif()
 
 if(RDK_USE_BOOST_REGEX)
@@ -56,9 +56,9 @@ rdkit_library(FileParsers
               ProximityBonds.cpp
               SequenceParsers.cpp SequenceWriters.cpp
               SVGParser.cpp PNGParser.cpp
-							MultithreadedMolSupplier.cpp
-							MultithreadedSmilesMolSupplier.cpp
-							MultithreadedSDMolSupplier.cpp
+              MultithreadedMolSupplier.cpp
+              MultithreadedSmilesMolSupplier.cpp
+              MultithreadedSDMolSupplier.cpp
               LINK_LIBRARIES GenericGroups Depictor SmilesParse ChemTransforms GraphMol ${RDK_MAEPARSER_LIBS} ${regex_lib} ${link_iostreams} ${zlib_lib})
 target_compile_definitions(FileParsers PRIVATE RDKIT_FILEPARSERS_BUILD)
 
@@ -70,14 +70,14 @@ rdkit_headers(CDXMLParser.h
               MolWriters.h
               SequenceParsers.h SequenceWriters.h
               GeneralFileReader.h
-							MultithreadedMolSupplier.h
-							MultithreadedSmilesMolSupplier.h
-							MultithreadedSDMolSupplier.h
+              MultithreadedMolSupplier.h
+              MultithreadedSmilesMolSupplier.h
+              MultithreadedSDMolSupplier.h
               PNGParser.h
               DEST GraphMol/FileParsers)
 
 rdkit_test(fileParsersTest1 test1.cpp
-           LINK_LIBRARIES FileParsers SubstructMatch )
+           LINK_LIBRARIES FileParsers SubstructMatch)
 
 
 
@@ -85,36 +85,36 @@ rdkit_test(testMolSupplier testMolSupplier.cpp
            LINK_LIBRARIES  FileParsers RDStreams)
 
 rdkit_test(testGeneralFileReader testGeneralFileReader.cpp
-					LINK_LIBRARIES FileParsers RDStreams)
+          LINK_LIBRARIES FileParsers RDStreams)
 
 if(RDK_TEST_MULTITHREADED)
 rdkit_test(testMultithreadedMolSupplier testMultithreadedMolSupplier.cpp
-					LINK_LIBRARIES FileParsers Fingerprints RDStreams)
+          LINK_LIBRARIES FileParsers Fingerprints RDStreams)
 endif(RDK_TEST_MULTITHREADED)
 
-rdkit_test(testMolWriter testMolWriter.cpp LINK_LIBRARIES FileParsers )
+rdkit_test(testMolWriter testMolWriter.cpp LINK_LIBRARIES FileParsers)
 
-rdkit_test(testTplParser testTpls.cpp LINK_LIBRARIES FileParsers )
+rdkit_test(testTplParser testTpls.cpp LINK_LIBRARIES FileParsers)
 
-rdkit_test(testMol2ToMol testMol2ToMol.cpp LINK_LIBRARIES FileParsers )
+rdkit_test(testMol2ToMol testMol2ToMol.cpp LINK_LIBRARIES FileParsers)
 
-rdkit_test(testSequence testSequence.cpp LINK_LIBRARIES FileParsers )
+rdkit_test(testSequence testSequence.cpp LINK_LIBRARIES FileParsers)
 
 rdkit_test(testExtendedStereoParsing testExtendedStereoParsing.cpp
-           LINK_LIBRARIES FileParsers )
+           LINK_LIBRARIES FileParsers)
 
-rdkit_catch_test(fileParsersCatchTest file_parsers_catch.cpp 
-           LINK_LIBRARIES FileParsers )
+rdkit_catch_test(fileParsersCatchTest file_parsers_catch.cpp
+           LINK_LIBRARIES FileParsers)
 
 rdkit_catch_test(testPropertyLists testPropertyLists.cpp
-           LINK_LIBRARIES FileParsers )
+           LINK_LIBRARIES FileParsers)
 
 rdkit_catch_test(XYZFileParserCatchTest XYZFileParserCatchTest.cpp
-           LINK_LIBRARIES FileParsers )
+           LINK_LIBRARIES FileParsers)
 
 rdkit_catch_test(cdxmlParserCatchTest cdxml_parser_catch.cpp
-           LINK_LIBRARIES FileParsers )
+           LINK_LIBRARIES FileParsers)
 
-rdkit_catch_test(molfileStereoCatchTest molfile_stereo_catch.cpp 
+rdkit_catch_test(molfileStereoCatchTest molfile_stereo_catch.cpp
            LINK_LIBRARIES FileParsers Subgraphs)
 

--- a/Code/GraphMol/FileParsers/CMakeLists.txt
+++ b/Code/GraphMol/FileParsers/CMakeLists.txt
@@ -31,8 +31,7 @@ ADD_DEFINITIONS("-DRDK_USE_BOOST_IOSTREAMS")
 endif(RDK_USE_BOOST_IOSTREAMS)
 
 if(RDK_BUILD_MAEPARSER_SUPPORT)
-    include_directories(${maeparser_INCLUDE_DIRS})
-    set (maesupplier MaeMolSupplier.cpp MaeWriter.cpp)
+  set (maesupplier MaeMolSupplier.cpp MaeWriter.cpp)
 endif()
 
 if(RDK_USE_BOOST_REGEX)
@@ -61,6 +60,10 @@ rdkit_library(FileParsers
               MultithreadedSDMolSupplier.cpp
               LINK_LIBRARIES GenericGroups Depictor SmilesParse ChemTransforms GraphMol ${RDK_MAEPARSER_LIBS} ${regex_lib} ${link_iostreams} ${zlib_lib})
 target_compile_definitions(FileParsers PRIVATE RDKIT_FILEPARSERS_BUILD)
+
+if(RDK_BUILD_MAEPARSER_SUPPORT)
+  target_include_directories(FileParsers PUBLIC ${maeparser_INCLUDE_DIRS})
+endif()
 
 rdkit_headers(CDXMLParser.h
               FileParsers.h

--- a/Code/GraphMol/FileParsers/CMakeLists.txt
+++ b/Code/GraphMol/FileParsers/CMakeLists.txt
@@ -31,7 +31,8 @@ ADD_DEFINITIONS("-DRDK_USE_BOOST_IOSTREAMS")
 endif(RDK_USE_BOOST_IOSTREAMS)
 
 if(RDK_BUILD_MAEPARSER_SUPPORT)
-  set (maesupplier MaeMolSupplier.cpp MaeWriter.cpp)
+    include_directories(${maeparser_INCLUDE_DIRS})
+    set (maesupplier MaeMolSupplier.cpp MaeWriter.cpp)
 endif()
 
 if(RDK_USE_BOOST_REGEX)
@@ -60,10 +61,6 @@ rdkit_library(FileParsers
               MultithreadedSDMolSupplier.cpp
               LINK_LIBRARIES GenericGroups Depictor SmilesParse ChemTransforms GraphMol ${RDK_MAEPARSER_LIBS} ${regex_lib} ${link_iostreams} ${zlib_lib})
 target_compile_definitions(FileParsers PRIVATE RDKIT_FILEPARSERS_BUILD)
-
-if(RDK_BUILD_MAEPARSER_SUPPORT)
-  target_include_directories(FileParsers PUBLIC ${maeparser_INCLUDE_DIRS})
-endif()
 
 rdkit_headers(CDXMLParser.h
               FileParsers.h

--- a/Code/GraphMol/FileParsers/MaeMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/MaeMolSupplier.cpp
@@ -7,6 +7,7 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
+#include <cstring>
 #include <iostream>
 #include <fstream>
 #include <map>
@@ -208,6 +209,15 @@ void parseStereoBondLabel(RWMol &mol, const std::string &stereo_prop) {
   bond->setStereo(type);
 }
 
+std::string strip_prefix_from_mae_property(const std::string &propName) {
+  const char &first = propName[0];
+  if ((first == 'b' || first == 'i' || first == 'r' || first == 's') &&
+      (strncmp(&propName.c_str()[1], "_rdk_", 5) == 0)) {
+    return propName.substr(6);
+  }
+  return propName;
+}
+
 //! Copy over the structure properties, including stereochemistry.
 void set_mol_properties(RWMol &mol, const mae::Block &ct_block) {
   for (const auto &prop : ct_block.getProperties<std::string>()) {
@@ -219,17 +229,21 @@ void set_mol_properties(RWMol &mol, const mae::Block &ct_block) {
     } else if (prop.first.find(mae::CT_EZ_PROP_PREFIX) == 0) {
       parseStereoBondLabel(mol, prop.second);
     } else {
-      mol.setProp(prop.first, prop.second);
+      auto propName = strip_prefix_from_mae_property(prop.first);
+      mol.setProp(propName, prop.second);
     }
   }
   for (const auto &prop : ct_block.getProperties<double>()) {
-    mol.setProp(prop.first, prop.second);
+    auto propName = strip_prefix_from_mae_property(prop.first);
+    mol.setProp(propName, prop.second);
   }
   for (const auto &prop : ct_block.getProperties<int>()) {
-    mol.setProp(prop.first, prop.second);
+    auto propName = strip_prefix_from_mae_property(prop.first);
+    mol.setProp(propName, prop.second);
   }
   for (const auto &prop : ct_block.getProperties<mae::BoolProperty>()) {
-    mol.setProp(prop.first, static_cast<bool>(prop.second));
+    auto propName = strip_prefix_from_mae_property(prop.first);
+    mol.setProp(propName, static_cast<bool>(prop.second));
   }
 }
 
@@ -247,7 +261,8 @@ void set_atom_properties(Atom &atom, const mae::IndexedBlock &atom_block,
       continue;
     }
 
-    atom.setProp(prop.first, prop.second->at(i));
+    auto propName = strip_prefix_from_mae_property(prop.first);
+    atom.setProp(propName, prop.second->at(i));
   }
 
   for (const auto &prop : atom_block.getProperties<double>()) {
@@ -263,7 +278,8 @@ void set_atom_properties(Atom &atom, const mae::IndexedBlock &atom_block,
       continue;
     }
 
-    atom.setProp(prop.first, prop.second->at(i));
+    auto propName = strip_prefix_from_mae_property(prop.first);
+    atom.setProp(propName, prop.second->at(i));
   }
   for (const auto &prop : atom_block.getProperties<int>()) {
     if (prop.first == mae::ATOM_ATOMIC_NUM) {
@@ -280,7 +296,8 @@ void set_atom_properties(Atom &atom, const mae::IndexedBlock &atom_block,
       // Formal charge has a specific setter
       atom.setFormalCharge(prop.second->at(i));
     } else {
-      atom.setProp(prop.first, prop.second->at(i));
+      auto propName = strip_prefix_from_mae_property(prop.first);
+      atom.setProp(propName, prop.second->at(i));
     }
   }
   for (const auto &prop : atom_block.getProperties<mae::BoolProperty>()) {
@@ -288,7 +305,8 @@ void set_atom_properties(Atom &atom, const mae::IndexedBlock &atom_block,
       continue;
     }
 
-    atom.setProp(prop.first, static_cast<bool>(prop.second->at(i)));
+    auto propName = strip_prefix_from_mae_property(prop.first);
+    atom.setProp(propName, static_cast<bool>(prop.second->at(i)));
   }
 }
 
@@ -339,7 +357,14 @@ void addBonds(const mae::IndexedBlock &bond_block, RWMol &mol) {
     const auto from_atom = from_atoms->at(i) - 1;
     const auto to_atom = to_atoms->at(i) - 1;
     const auto order = bolookup.find(orders->at(i))->second;
-    if (from_atom > to_atom) {
+    if (auto bond = mol.getBondBetweenAtoms(from_atom, to_atom);
+        bond != nullptr) {
+      if (order != bond->getBondType()) {
+        BOOST_LOG(rdWarningLog)
+            << "WARNING: bond between atoms " << from_atom << " and " << to_atom
+            << " is defined more than once with different bond orders. "
+            << "The first definition will be honored, and the rest will be ignored.";
+      }
       continue;  // Maestro files may double-list some bonds
     }
 

--- a/Code/GraphMol/FileParsers/MaeWriter.cpp
+++ b/Code/GraphMol/FileParsers/MaeWriter.cpp
@@ -1,0 +1,92 @@
+//
+//
+//  Copyright (C) 2023 Schrödinger, LLC
+//
+//   @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
+//
+#include "MolWriters.h"
+
+#include <fstream>
+#include <memory>
+#include <string>
+
+#include <maeparser/Writer.hpp>
+
+#include <RDGeneral/BadFileException.h>
+#include <RDGeneral/FileParseException.h>
+#include <RDGeneral/RDLog.h>
+
+using namespace schrodinger;
+
+namespace RDKit {
+
+MaeWriter::MaeWriter(const std::string &fileName) {
+  auto *tmpStream = new std::ofstream(fileName.c_str());
+  if (!(*tmpStream) || (tmpStream->bad())) {
+    delete tmpStream;
+    std::ostringstream errout;
+    errout << "Bad output file " << fileName;
+    throw BadFileException(errout.str());
+  }
+  dp_ostream.reset(static_cast<std::ostream *>(tmpStream));
+  dp_writer.reset(new mae::Writer(dp_ostream));
+}
+
+MaeWriter::MaeWriter(std::ostream *outStream) : dp_ostream{outStream} {
+  PRECONDITION(outStream, "null stream");
+  if (outStream->bad()) {
+    throw FileParseException("Bad output stream");
+  }
+  dp_writer.reset(new mae::Writer(dp_ostream));
+}
+
+MaeWriter::MaeWriter(std::shared_ptr<std::ostream> outStream)
+    : dp_ostream{std::move(outStream)} {
+  PRECONDITION(outStream, "null stream");
+  if (outStream->bad()) {
+    throw FileParseException("Bad output stream");
+  }
+  dp_writer.reset(new mae::Writer(dp_ostream));
+}
+
+void MaeWriter::setProps(const STR_VECT &propNames) {
+  if (d_molid > 0) {
+    BOOST_LOG(rdWarningLog) << "WARNING: Setting property list after a few "
+                               "molecules have been written\n";
+  }
+
+  d_props = propNames;
+}
+
+void MaeWriter::flush() {
+  PRECONDITION(dp_ostream, "no output stream");
+  try {
+    dp_ostream->flush();
+  } catch (...) {
+    try {
+      if (dp_ostream->good()) {
+        dp_ostream->setstate(std::ios::badbit);
+      }
+    } catch (const std::runtime_error &) {
+    }
+  }
+}
+
+void MaeWriter::close() {
+  if (dp_ostream) {
+    flush();
+  }
+  dp_ostream.reset();
+  dp_writer.reset();
+}
+
+void MaeWriter::write(const ROMol &mol, int confId) {
+  (void)mol;
+  (void)confId;
+}
+
+}  // namespace RDKit

--- a/Code/GraphMol/FileParsers/MaeWriter.cpp
+++ b/Code/GraphMol/FileParsers/MaeWriter.cpp
@@ -395,6 +395,12 @@ void mapBonds(const ROMol& mol, const STR_VECT& propNames,
     auto bondTo = static_cast<int>(bond->getBeginAtomIdx()) + 1;
     auto bondFrom = static_cast<int>(bond->getEndAtomIdx()) + 1;
 
+    // There is no bond directionality in Maestro, and atom indexes
+    // in bonds are usually written in ascending order
+    if (bondFrom > bondTo) {
+      std::swap(bondFrom, bondTo);
+    }
+
     setPropertyValue(*bondBlock, mae::BOND_ATOM_1, numBonds, idx, bondTo);
     setPropertyValue(*bondBlock, mae::BOND_ATOM_2, numBonds, idx, bondFrom);
     setPropertyValue(*bondBlock, mae::BOND_ORDER, numBonds, idx,

--- a/Code/GraphMol/FileParsers/MaeWriter.cpp
+++ b/Code/GraphMol/FileParsers/MaeWriter.cpp
@@ -13,9 +13,15 @@
 #include <fstream>
 #include <memory>
 #include <string>
+#include <vector>
 
+#include <maeparser/MaeBlock.hpp>
+#include <maeparser/MaeConstants.hpp>
 #include <maeparser/Writer.hpp>
 
+#include <GraphMol/Depictor/RDDepictor.h>
+#include <GraphMol/MolOps.h>
+#include <GraphMol/RDKitBase.h>
 #include <RDGeneral/BadFileException.h>
 #include <RDGeneral/FileParseException.h>
 #include <RDGeneral/RDLog.h>
@@ -24,8 +30,295 @@ using namespace schrodinger;
 
 namespace RDKit {
 
-MaeWriter::MaeWriter(const std::string &fileName) {
-  auto *tmpStream = new std::ofstream(fileName.c_str());
+namespace {
+
+template <typename T>
+std::shared_ptr<mae::IndexedProperty<T>> getIndexedProperty(
+    mae::IndexedBlock& indexedBlock, const std::string& propName,
+    size_t numAtoms,
+    std::shared_ptr<mae::IndexedProperty<T>> (mae::IndexedBlock::*getterFunc)(
+        const std::string&) const,
+    void (mae::IndexedBlock::*setterFunc)(
+        const std::string&, std::shared_ptr<mae::IndexedProperty<T>>)) {
+  auto prop = (indexedBlock.*getterFunc)(propName);
+  if (prop != nullptr) {
+    return prop;
+  }
+
+  std::vector<T> boolValues(numAtoms);
+  auto nullsBitset = new boost::dynamic_bitset<>(numAtoms);
+  nullsBitset->set();
+  auto newProp =
+      std::make_shared<mae::IndexedProperty<T>>(boolValues, nullsBitset);
+
+  (indexedBlock.*setterFunc)(propName, newProp);
+  return newProp;
+}
+
+template <typename T>
+std::shared_ptr<mae::IndexedProperty<T>> getIndexedProperty(
+    mae::IndexedBlock& indexedBlock, const std::string& propName,
+    size_t numAtoms);
+
+template <>
+std::shared_ptr<mae::IndexedProperty<mae::BoolProperty>>
+getIndexedProperty<mae::BoolProperty>(mae::IndexedBlock& indexedBlock,
+                                      const std::string& propName,
+                                      size_t numAtoms) {
+  if (propName[0] != 'b') {
+    auto msg =
+        std::string("Property '") + propName + "' is not a boolean value";
+    throw std::runtime_error(msg);
+  }
+
+  return getIndexedProperty<mae::BoolProperty>(
+      indexedBlock, propName, numAtoms, &mae::IndexedBlock::getBoolProperty,
+      &mae::IndexedBlock::setBoolProperty);
+}
+
+template <>
+std::shared_ptr<mae::IndexedProperty<int>> getIndexedProperty<int>(
+    mae::IndexedBlock& indexedBlock, const std::string& propName,
+    size_t numAtoms) {
+  if (propName[0] != 'i') {
+    auto msg =
+        std::string("Property '") + propName + "' is not an integer value";
+    throw std::runtime_error(msg);
+  }
+
+  return getIndexedProperty<int>(indexedBlock, propName, numAtoms,
+                                 &mae::IndexedBlock::getIntProperty,
+                                 &mae::IndexedBlock::setIntProperty);
+}
+
+template <>
+std::shared_ptr<mae::IndexedProperty<double>> getIndexedProperty<double>(
+    mae::IndexedBlock& indexedBlock, const std::string& propName,
+    size_t numAtoms) {
+  if (propName[0] != 'r') {
+    auto msg = std::string("Property '") + propName + "' is not a real value";
+    throw std::runtime_error(msg);
+  }
+
+  return getIndexedProperty<double>(indexedBlock, propName, numAtoms,
+                                    &mae::IndexedBlock::getRealProperty,
+                                    &mae::IndexedBlock::setRealProperty);
+}
+
+template <>
+std::shared_ptr<mae::IndexedProperty<std::string>>
+getIndexedProperty<std::string>(mae::IndexedBlock& indexedBlock,
+                                const std::string& propName, size_t numAtoms) {
+  if (propName[0] != 's') {
+    auto msg = std::string("Property '") + propName + "' is not a string value";
+    throw std::runtime_error(msg);
+  }
+
+  return getIndexedProperty<std::string>(indexedBlock, propName, numAtoms,
+                                         &mae::IndexedBlock::getStringProperty,
+                                         &mae::IndexedBlock::setStringProperty);
+}
+
+class UnsupportedBondException : public std::runtime_error {
+ public:
+  UnsupportedBondException(const char* msg) : std::runtime_error(msg) {}
+  UnsupportedBondException(const std::string& msg) : std::runtime_error(msg) {}
+};
+
+unsigned bondTypeToOrder(const Bond& bond) {
+  switch (bond.getBondType()) {
+    case Bond::BondType::SINGLE:
+      return 1;
+    case Bond::BondType::DOUBLE:
+      return 2;
+    case Bond::BondType::TRIPLE:
+      return 3;
+    case Bond::BondType::ZERO:
+    case Bond::BondType::DATIVE:
+      return 0;
+    default:
+      throw UnsupportedBondException(
+          "Bond " + std::to_string(bond.getIdx()) +
+          " has a type that is not supported by maeparser.");
+  }
+}
+
+void mapMolProperties(const ROMol& mol, const STR_VECT& propNames,
+                      mae::Block& stBlock) {
+  (void)mol;
+  (void)propNames;
+  (void)stBlock;
+
+#if 0
+  for (auto& prop : propNames) {
+    if (!mol.hasProp(prop)) {
+      // We don't raise any warnings if we don't find a property because it
+      // might be an atom property
+      continue;
+    }
+
+    auto prop = mol.getProp(prop)
+  }
+
+  for (const auto& propName : st.getPropertyNames(PropertyType::Bool)) {
+    stBlock.setBoolProperty(propName, st.getProperty<bool>(propName));
+  }
+  for (const auto& propName : st.getPropertyNames(PropertyType::Int)) {
+    stBlock.setIntProperty(propName, st.getProperty<int>(propName));
+  }
+  for (const auto& propName : st.getPropertyNames(PropertyType::Real)) {
+    stBlock.setRealProperty(propName, st.getProperty<double>(propName));
+  }
+  for (const auto& propName : st.getPropertyNames(PropertyType::String)) {
+    stBlock.setStringProperty(propName,
+                               st.getProperty<std::string>(propName));
+  }
+#endif
+}
+
+void mapAtom(const Conformer& conformer, const Atom& atom,
+             const STR_VECT& propNames, mae::IndexedBlock& atomBlock,
+             size_t numAtoms) {
+  auto idx = atom.getIdx();
+  auto coordinates = conformer.getAtomPos(idx);
+
+  auto xCoord =
+      getIndexedProperty<double>(atomBlock, mae::ATOM_X_COORD, numAtoms);
+  xCoord->set(idx, coordinates.x);
+
+  auto yCoord =
+      getIndexedProperty<double>(atomBlock, mae::ATOM_Y_COORD, numAtoms);
+  yCoord->set(idx, coordinates.y);
+
+  auto zCoord =
+      getIndexedProperty<double>(atomBlock, mae::ATOM_Z_COORD, numAtoms);
+  zCoord->set(idx, coordinates.z);
+
+  auto atomicNum =
+      getIndexedProperty<int>(atomBlock, mae::ATOM_ATOMIC_NUM, numAtoms);
+  atomicNum->set(idx, atom.getAtomicNum());
+
+  // Default heavy atoms to be drawn in grey in Maestro, and H atoms in white.
+  std::string color = (atom.getAtomicNum() == 1 ? "FFFFFF" : "A0A0A0");
+  auto atomRgbColor =
+      getIndexedProperty<std::string>(atomBlock, "s_m_color_rgb", numAtoms);
+  atomRgbColor->set(idx, color);
+
+  auto formalCharge =
+      getIndexedProperty<int>(atomBlock, mae::ATOM_FORMAL_CHARGE, numAtoms);
+  formalCharge->set(idx, atom.getFormalCharge());
+
+#if 0
+  auto residue_id = atom.getResidueId();
+  auto residue_num =
+      getIndexedProperty<int>(atomBlock, M2IO_DATA_RES_NUM, numAtoms);
+  residue_num->set(idx, residue_id.residue_number);
+  auto insertion_code = getIndexedProperty<std::string>(
+      atomBlock, M2IO_DATA_INSERTION_CODE, numAtoms);
+  insertion_code->set(idx, std::string{residue_id.insertion_code});
+
+  auto mmod_residue = getIndexedProperty<std::string>(
+      atomBlock, M2IO_DATA_MMOD_RES, numAtoms);
+  mmod_residue->set(idx, std::string{atom.getMacromodelResidue()});
+
+  auto chain_name =
+      getIndexedProperty<std::string>(atomBlock, M2IO_DATA_CHAIN, numAtoms);
+  chain_name->set(idx, atom.getChain());
+
+
+  auto pdb_residue = getIndexedProperty<std::string>(
+      atomBlock, M2IO_DATA_PDB_RES, numAtoms);
+  pdb_residue->set(idx, atom.getPDBResidue());
+
+  auto pdb_atom = getIndexedProperty<std::string>(
+      atomBlock, M2IO_DATA_PDB_ATOM, numAtoms);
+  pdb_atom->set(idx, atom.getPDBAtomName());
+
+
+
+  // Custom properties
+  for (const auto& propName : atom.getPropertyNames(PropertyType::Bool)) {
+    auto idxd_prop = getIndexedProperty<mae::BoolProperty>(
+        atomBlock, propName, numAtoms);
+    idxd_prop->set(idx, atom.getProperty<bool>(propName));
+  }
+  for (const auto& propName : atom.getPropertyNames(PropertyType::Int)) {
+    // M2IO_DATA_ATOM_CHIRALITY should not be written to .mae files
+    // (see mmct_ct_m2io_close_atomBlock in mmct.cpp)
+    if (propName == M2IO_DATA_ATOM_CHIRALITY) {
+      continue;
+    }
+
+    auto idxd_prop =
+        getIndexedProperty<int>(atomBlock, propName, numAtoms);
+    idxd_prop->set(idx, atom.getProperty<int>(propName));
+  }
+  for (const auto& propName : atom.getPropertyNames(PropertyType::Real)) {
+    auto idxd_prop =
+        getIndexedProperty<double>(atomBlock, propName, numAtoms);
+    idxd_prop->set(idx, atom.getProperty<double>(propName));
+  }
+  for (const auto& propName : atom.getPropertyNames(PropertyType::String)) {
+    auto idxd_prop =
+        getIndexedProperty<std::string>(atomBlock, propName, numAtoms);
+    idxd_prop->set(idx, atom.getProperty<std::string>(propName));
+  }
+
+#endif
+}
+
+void mapAtoms(const ROMol& mol, const STR_VECT& propNames, int confId,
+              mae::IndexedBlockMap& indexedBlockMap) {
+  auto atomBlock = std::make_shared<mae::IndexedBlock>(mae::ATOM_BLOCK);
+  auto conformer = mol.getConformer(confId);
+
+  auto numAtoms = mol.getNumAtoms();
+  for (auto& atom : mol.atoms()) {
+    mapAtom(conformer, *atom, propNames, *atomBlock, numAtoms);
+  }
+
+  indexedBlockMap.addIndexedBlock(mae::ATOM_BLOCK, atomBlock);
+}
+
+void mapBonds(const ROMol& mol, const STR_VECT& propNames,
+              mae::IndexedBlockMap& indexedBlockMap) {
+  auto bondBlock = std::make_shared<mae::IndexedBlock>(mae::BOND_BLOCK);
+
+  auto numBonds = mol.getNumBonds();
+  auto bondAtomFrom =
+      getIndexedProperty<int>(*bondBlock, mae::BOND_ATOM_1, numBonds);
+  auto bondAtomTo =
+      getIndexedProperty<int>(*bondBlock, mae::BOND_ATOM_2, numBonds);
+  auto bondOrder =
+      getIndexedProperty<int>(*bondBlock, mae::BOND_ORDER, numBonds);
+
+  std::shared_ptr<mae::IndexedProperty<mae::BoolProperty>> dativeBondMark =
+      nullptr;
+  for (auto& bond : mol.bonds()) {
+    if (bond->getBondType() == Bond::BondType::DATIVE) {
+      dativeBondMark = getIndexedProperty<mae::BoolProperty>(
+          *bondBlock, "b_sPrivate_dative_bond", numBonds);
+      break;
+    }
+  }
+
+  for (auto& bond : mol.bonds()) {
+    auto idx = bond->getIdx();
+    bondAtomFrom->set(idx, bond->getBeginAtomIdx());
+    bondAtomTo->set(idx, bond->getEndAtomIdx());
+    bondOrder->set(idx, bondTypeToOrder(*bond));
+
+    if (dativeBondMark != nullptr) {
+      dativeBondMark->set(idx, (bond->getBondType() == Bond::BondType::DATIVE));
+    }
+  }
+
+  indexedBlockMap.addIndexedBlock(mae::BOND_BLOCK, bondBlock);
+}
+}  // namespace
+
+MaeWriter::MaeWriter(const std::string& fileName) {
+  auto* tmpStream = new std::ofstream(fileName.c_str());
   if (!(*tmpStream) || (tmpStream->bad())) {
     delete tmpStream;
     std::ostringstream errout;
@@ -49,6 +342,8 @@ MaeWriter::MaeWriter(std::shared_ptr<std::ostream> outStream)
     throw FileParseException("Bad output stream");
   }
 }
+
+MaeWriter::~MaeWriter() { close(); };
 
 void MaeWriter::open() { dp_writer.reset(new mae::Writer(dp_ostream)); }
 
@@ -84,9 +379,45 @@ void MaeWriter::close() {
   dp_ostream.reset();
 }
 
-void MaeWriter::write(const ROMol &mol, int confId) {
-  (void)mol;
-  (void)confId;
+void MaeWriter::write(const ROMol& mol, int confId) {
+  PRECONDITION(dp_ostream, "no output stream");
+
+  RWMol tmpMol(mol);
+  if (!MolOps::KekulizeIfPossible(tmpMol)) {
+    BOOST_LOG(rdErrorLog)
+        << "ERROR: the mol cannot be kekulized, and will not be written to the output file.\n";
+    return;
+  }
+  if (mol.getNumConformers() == 0) {
+    // make sure there's at least one conformer we can write
+    RDDepict::compute2DCoords(tmpMol);
+  }
+
+  auto stBlock = std::make_shared<mae::Block>(mae::CT_BLOCK);
+
+  mapMolProperties(tmpMol, d_props, *stBlock);
+
+  auto indexedBlockMap = std::make_shared<mae::IndexedBlockMap>();
+
+  mapAtoms(tmpMol, d_props, confId, *indexedBlockMap);
+
+  try {
+    mapBonds(tmpMol, d_props, *indexedBlockMap);
+  } catch (const UnsupportedBondException& exc) {
+    BOOST_LOG(rdErrorLog)
+        << "ERROR: " << exc.what()
+        << " The mol will not be written to the output file.\n";
+    return;
+  }
+
+  stBlock->setIndexedBlockMap(indexedBlockMap);
+
+  if (!dp_writer) {
+    open();
+  }
+
+  dp_writer->write(stBlock);
+  ++d_molid;
 }
 
 }  // namespace RDKit

--- a/Code/GraphMol/FileParsers/MaeWriter.cpp
+++ b/Code/GraphMol/FileParsers/MaeWriter.cpp
@@ -32,16 +32,14 @@ MaeWriter::MaeWriter(const std::string &fileName) {
     errout << "Bad output file " << fileName;
     throw BadFileException(errout.str());
   }
-  dp_ostream.reset(static_cast<std::ostream *>(tmpStream));
-  dp_writer.reset(new mae::Writer(dp_ostream));
+  dp_ostream.reset(static_cast<std::ostream*>(tmpStream));
 }
 
-MaeWriter::MaeWriter(std::ostream *outStream) : dp_ostream{outStream} {
+MaeWriter::MaeWriter(std::ostream* outStream) : dp_ostream{outStream} {
   PRECONDITION(outStream, "null stream");
   if (outStream->bad()) {
     throw FileParseException("Bad output stream");
   }
-  dp_writer.reset(new mae::Writer(dp_ostream));
 }
 
 MaeWriter::MaeWriter(std::shared_ptr<std::ostream> outStream)
@@ -50,15 +48,15 @@ MaeWriter::MaeWriter(std::shared_ptr<std::ostream> outStream)
   if (outStream->bad()) {
     throw FileParseException("Bad output stream");
   }
-  dp_writer.reset(new mae::Writer(dp_ostream));
 }
 
-void MaeWriter::setProps(const STR_VECT &propNames) {
+void MaeWriter::open() { dp_writer.reset(new mae::Writer(dp_ostream)); }
+
+void MaeWriter::setProps(const STR_VECT& propNames) {
   if (d_molid > 0) {
     BOOST_LOG(rdWarningLog) << "WARNING: Setting property list after a few "
                                "molecules have been written\n";
   }
-
   d_props = propNames;
 }
 
@@ -71,17 +69,19 @@ void MaeWriter::flush() {
       if (dp_ostream->good()) {
         dp_ostream->setstate(std::ios::badbit);
       }
-    } catch (const std::runtime_error &) {
+    } catch (const std::runtime_error&) {
     }
   }
 }
 
 void MaeWriter::close() {
+  if (dp_writer) {
+    dp_writer.reset();
+  }
   if (dp_ostream) {
     flush();
   }
   dp_ostream.reset();
-  dp_writer.reset();
 }
 
 void MaeWriter::write(const ROMol &mol, int confId) {

--- a/Code/GraphMol/FileParsers/MaeWriter.cpp
+++ b/Code/GraphMol/FileParsers/MaeWriter.cpp
@@ -148,14 +148,14 @@ void copyProperties(
 
     // Also skip the property if we have a list of properties we want to export
     // and this one is not one of them.
+    if (!propNames.empty() && (std::find(propNames.begin(), propNames.end(),
+                                         prop.key) == propNames.end())) {
+      continue;
+    }
 
     switch (prop.val.getTag()) {
       case RDTypeTag::BoolTag: {
         auto propName = std::string("b_rdk_") + prop.key;
-        if (!propNames.empty() && (std::find(propNames.begin(), propNames.end(),
-                                             propName) == propNames.end())) {
-          continue;
-        }
         boolSetter(propName, idx, rdvalue_cast<bool>(prop.val));
         break;
       }
@@ -163,10 +163,6 @@ void copyProperties(
       case RDTypeTag::IntTag:
       case RDTypeTag::UnsignedIntTag: {
         auto propName = std::string("i_rdk_") + prop.key;
-        if (!propNames.empty() && (std::find(propNames.begin(), propNames.end(),
-                                             propName) == propNames.end())) {
-          continue;
-        }
         intSetter(propName, idx, rdvalue_cast<int>(prop.val));
         break;
       }
@@ -174,20 +170,12 @@ void copyProperties(
       case RDTypeTag::DoubleTag:
       case RDTypeTag::FloatTag: {
         auto propName = std::string("r_rdk_") + prop.key;
-        if (!propNames.empty() && (std::find(propNames.begin(), propNames.end(),
-                                             propName) == propNames.end())) {
-          continue;
-        }
         realSetter(propName, idx, rdvalue_cast<double>(prop.val));
         break;
       }
 
       case RDTypeTag::StringTag: {
         auto propName = std::string("s_rdk_") + prop.key;
-        if (!propNames.empty() && (std::find(propNames.begin(), propNames.end(),
-                                             propName) == propNames.end())) {
-          continue;
-        }
         stringSetter(propName, idx, rdvalue_cast<std::string>(prop.val));
         break;
       }

--- a/Code/GraphMol/FileParsers/MaeWriter.cpp
+++ b/Code/GraphMol/FileParsers/MaeWriter.cpp
@@ -391,12 +391,12 @@ void mapBonds(const ROMol& mol, const STR_VECT& propNames,
   for (auto& bond : mol.bonds()) {
     auto idx = bond->getIdx();
 
-    auto bondTo = static_cast<int>(bond->getBeginAtomIdx());
+    // Indexes in the atom block are 1-based
+    auto bondTo = static_cast<int>(bond->getBeginAtomIdx()) + 1;
+    auto bondFrom = static_cast<int>(bond->getEndAtomIdx()) + 1;
+
     setPropertyValue(*bondBlock, mae::BOND_ATOM_1, numBonds, idx, bondTo);
-
-    auto bondFrom = static_cast<int>(bond->getEndAtomIdx());
     setPropertyValue(*bondBlock, mae::BOND_ATOM_2, numBonds, idx, bondFrom);
-
     setPropertyValue(*bondBlock, mae::BOND_ORDER, numBonds, idx,
                      bondTypeToOrder(*bond));
 

--- a/Code/GraphMol/FileParsers/MaeWriter.cpp
+++ b/Code/GraphMol/FileParsers/MaeWriter.cpp
@@ -149,14 +149,14 @@ void copyProperties(
 
     // Also skip the property if we have a list of properties we want to export
     // and this one is not one of them.
-    if (!propNames.empty() && (std::find(propNames.begin(), propNames.end(),
-                                         prop.key) == propNames.end())) {
-      continue;
-    }
 
     switch (prop.val.getTag()) {
       case RDTypeTag::BoolTag: {
         auto propName = std::string("b_rdk_") + prop.key;
+        if (!propNames.empty() && (std::find(propNames.begin(), propNames.end(),
+                                             propName) == propNames.end())) {
+          continue;
+        }
         boolSetter(propName, idx, rdvalue_cast<bool>(prop.val));
         break;
       }
@@ -164,6 +164,10 @@ void copyProperties(
       case RDTypeTag::IntTag:
       case RDTypeTag::UnsignedIntTag: {
         auto propName = std::string("i_rdk_") + prop.key;
+        if (!propNames.empty() && (std::find(propNames.begin(), propNames.end(),
+                                             propName) == propNames.end())) {
+          continue;
+        }
         intSetter(propName, idx, rdvalue_cast<int>(prop.val));
         break;
       }
@@ -171,12 +175,20 @@ void copyProperties(
       case RDTypeTag::DoubleTag:
       case RDTypeTag::FloatTag: {
         auto propName = std::string("r_rdk_") + prop.key;
+        if (!propNames.empty() && (std::find(propNames.begin(), propNames.end(),
+                                             propName) == propNames.end())) {
+          continue;
+        }
         realSetter(propName, idx, rdvalue_cast<double>(prop.val));
         break;
       }
 
       case RDTypeTag::StringTag: {
         auto propName = std::string("s_rdk_") + prop.key;
+        if (!propNames.empty() && (std::find(propNames.begin(), propNames.end(),
+                                             propName) == propNames.end())) {
+          continue;
+        }
         stringSetter(propName, idx, rdvalue_cast<std::string>(prop.val));
         break;
       }

--- a/Code/GraphMol/FileParsers/MolWriters.h
+++ b/Code/GraphMol/FileParsers/MolWriters.h
@@ -391,6 +391,12 @@ class RDKIT_FILEPARSERS_EXPORT MaeWriter : public MolWriter {
   //! written out for each molecule
   void setProps(const STR_VECT &propNames) override;
 
+  //! \brief return the text that would be written to the file
+  static std::string getText(
+      const ROMol &mol,
+      const std::string &heavyAtomColor = defaultMaeHeavyAtomColor,
+      int confId = defaultConfId, const STR_VECT &propNames = STR_VECT());
+
   //! \brief write a new molecule to the file
   void write(const ROMol &mol, int confId = defaultConfId) override;
 

--- a/Code/GraphMol/FileParsers/MolWriters.h
+++ b/Code/GraphMol/FileParsers/MolWriters.h
@@ -29,6 +29,8 @@
 namespace RDKit {
 
 static int defaultConfId = -1;
+static const std::string defaultMaeHeavyAtomColor = "A0A0A0";
+
 class RDKIT_FILEPARSERS_EXPORT MolWriter : private boost::noncopyable {
  public:
   virtual ~MolWriter() {}
@@ -387,6 +389,11 @@ class RDKIT_FILEPARSERS_EXPORT MaeWriter : public MolWriter {
 
   //! \brief write a new molecule to the file
   void write(const ROMol &mol, int confId = defaultConfId) override;
+
+  //! \brief write a new molecule to the file, specifying the HTML color string
+  //! which should be used for heavy atoms when the file is opened in Maestro.
+  void write(const ROMol &mol, const std::string &heavyAtomColor,
+             int confId = defaultConfId);
 
   //! \brief flush the ostream
   void flush() override;

--- a/Code/GraphMol/FileParsers/MolWriters.h
+++ b/Code/GraphMol/FileParsers/MolWriters.h
@@ -18,6 +18,8 @@
 #include <memory>
 #include <string>
 
+#include <boost/noncopyable.hpp>
+
 #ifdef RDK_BUILD_MAEPARSER_SUPPORT
 #include <maeparser/Writer.hpp>
 #endif  // RDK_BUILD_MAEPARSER_SUPPORT
@@ -27,7 +29,7 @@
 namespace RDKit {
 
 static int defaultConfId = -1;
-class RDKIT_FILEPARSERS_EXPORT MolWriter {
+class RDKIT_FILEPARSERS_EXPORT MolWriter : private boost::noncopyable {
  public:
   virtual ~MolWriter() {}
   virtual void write(const ROMol &mol, int confId = defaultConfId) = 0;

--- a/Code/GraphMol/FileParsers/MolWriters.h
+++ b/Code/GraphMol/FileParsers/MolWriters.h
@@ -18,15 +18,11 @@
 #include <memory>
 #include <string>
 
-#include <GraphMol/ROMol.h>
-
 #ifdef RDK_BUILD_MAEPARSER_SUPPORT
-namespace schrodinger {
-namespace mae {
-class Writer;
-}  // namespace mae
-}  // namespace schrodinger
+#include <maeparser/Writer.hpp>
 #endif  // RDK_BUILD_MAEPARSER_SUPPORT
+
+#include <GraphMol/ROMol.h>
 
 namespace RDKit {
 
@@ -398,10 +394,12 @@ class RDKIT_FILEPARSERS_EXPORT MaeWriter : public MolWriter {
  protected:
   MaeWriter() = default;  // used in the Python wrapper
 
+  std::shared_ptr<std::ostream> dp_ostream = nullptr;
+
+ private:
   void open();
 
-  std::shared_ptr<schrodinger::mae::Writer> dp_writer = nullptr;
-  std::shared_ptr<std::ostream> dp_ostream = nullptr;
+  std::unique_ptr<schrodinger::mae::Writer> dp_writer = nullptr;
   unsigned d_molid = 0;  // the number of the molecules we wrote so far
   STR_VECT d_props;      // list of property name that need to be written out
 };

--- a/Code/GraphMol/FileParsers/MolWriters.h
+++ b/Code/GraphMol/FileParsers/MolWriters.h
@@ -372,6 +372,9 @@ class RDKIT_FILEPARSERS_EXPORT MaeWriter : public MolWriter {
    */
   MaeWriter(const std::string &fileName);
 
+  /*!
+  \note Note that this takes ownership of the output stream.
+  */
   MaeWriter(std::ostream *outStream);
 
   MaeWriter(std::shared_ptr<std::ostream> outStream);

--- a/Code/GraphMol/FileParsers/MolWriters.h
+++ b/Code/GraphMol/FileParsers/MolWriters.h
@@ -21,7 +21,11 @@
 #include <boost/noncopyable.hpp>
 
 #ifdef RDK_BUILD_MAEPARSER_SUPPORT
-#include <maeparser/Writer.hpp>
+namespace schrodinger {
+namespace mae {
+class Writer;
+}  // namespace mae
+}  // namespace schrodinger
 #endif  // RDK_BUILD_MAEPARSER_SUPPORT
 
 #include <GraphMol/ROMol.h>
@@ -406,12 +410,12 @@ class RDKIT_FILEPARSERS_EXPORT MaeWriter : public MolWriter {
  protected:
   MaeWriter() = default;  // used in the Python wrapper
 
-  std::shared_ptr<std::ostream> dp_ostream = nullptr;
+  std::shared_ptr<std::ostream> dp_ostream;
 
  private:
   void open();
 
-  std::unique_ptr<schrodinger::mae::Writer> dp_writer = nullptr;
+  std::unique_ptr<schrodinger::mae::Writer> dp_writer;
   unsigned d_molid = 0;  // the number of the molecules we wrote so far
   STR_VECT d_props;      // list of property name that need to be written out
 };

--- a/Code/GraphMol/FileParsers/MolWriters.h
+++ b/Code/GraphMol/FileParsers/MolWriters.h
@@ -369,7 +369,7 @@ class RDKIT_FILEPARSERS_EXPORT MaeWriter : public MolWriter {
 
   MaeWriter(std::shared_ptr<std::ostream> outStream);
 
-  ~MaeWriter() override = default;
+  ~MaeWriter() override;
 
   //! \brief set a vector of property names that are need to be
   //! written out for each molecule

--- a/Code/GraphMol/FileParsers/MolWriters.h
+++ b/Code/GraphMol/FileParsers/MolWriters.h
@@ -408,7 +408,7 @@ class RDKIT_FILEPARSERS_EXPORT MaeWriter : public MolWriter {
   //! \brief flush the ostream
   void flush() override;
   //! \brief close our stream (the writer cannot be used again)
-  void close();
+  void close() override;
 
   //! \brief get the number of molecules written so far
   unsigned int numMols() const override { return d_molid; }

--- a/Code/GraphMol/FileParsers/MolWriters.h
+++ b/Code/GraphMol/FileParsers/MolWriters.h
@@ -348,17 +348,26 @@ class RDKIT_FILEPARSERS_EXPORT PDBWriter : public MolWriter {
 
 class RDKIT_FILEPARSERS_EXPORT MaeWriter : public MolWriter {
   /**************************************************************************************
-   * A Maestro file (or stream) writer - this is how it is used
-   *  - create a MaeWriter with a output file name (or a ostream),
-   *     and a list of properties that need to be written out.
-   *  - then a call is made to the write function for each molecule
+   * A highly experimental Maestro file (or stream) writer. Many features are
+   * not supported yet, e.g. chirality and bond stereo, stereo groups, substance
+   * groups, isotopes or dummy atoms. Note that except for stereochemistry
+   * labels these aren't supported by the MaeMolSupplier either.
+   *
+   * Usage:
+   *  - create a MaeWriter with an output file name (or a ostream),
+   *     and a list of mol/atom/bond properties that need to be written out.
+   *     If no property names are specified, all properties will be exported.
+   *     Properties that are specified, but are not present will be ignored.
+   *  - then, a call is made to the write function for each molecule
    *     that needs to be written out.
+   *
+   * Notes:
    *  - kekulization is mandatory, as the Maestro format does not
    *     have the concept of an aromatic bond.
    *  - Ownership of the output stream is mandatory, since it needs
    *     to be managed though a shared_ptr, as this is what maeparser
-   *     uses to manage the writing.
-   **********************************************************************************************/
+   *     writer takes.
+   ***************************************************************************************/
  public:
   /*!
     \param fileName       : filename to write to (stdout is *not* supported)

--- a/Code/GraphMol/FileParsers/MolWriters.h
+++ b/Code/GraphMol/FileParsers/MolWriters.h
@@ -386,7 +386,11 @@ class RDKIT_FILEPARSERS_EXPORT MaeWriter : public MolWriter {
   //! \brief get the number of molecules written so far
   unsigned int numMols() const override { return d_molid; }
 
- private:
+ protected:
+  MaeWriter() = default;  // used in the Python wrapper
+
+  void open();
+
   std::shared_ptr<schrodinger::mae::Writer> dp_writer = nullptr;
   std::shared_ptr<std::ostream> dp_ostream = nullptr;
   unsigned d_molid = 0;  // the number of the molecules we wrote so far

--- a/Code/GraphMol/FileParsers/PDBWriter.cpp
+++ b/Code/GraphMol/FileParsers/PDBWriter.cpp
@@ -7,24 +7,28 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
+#include <algorithm>
+#include <fstream>
+#include <iostream>
+#include <map>
 #include <string>
 #include <vector>
-#include <map>
-#include <iostream>
-#include <fstream>
-#include <algorithm>
+
+#ifdef RDK_BUILD_MAEPARSER_SUPPORT
+#include <maeparser/Writer.hpp>
+#endif  // RDK_BUILD_MAEPARSER_SUPPORT
+
 #include <RDGeneral/BoostStartInclude.h>
 #include <boost/format.hpp>
 #include <RDGeneral/BoostEndInclude.h>
 
+#include <GraphMol/FileParsers/MolWriters.h>
+#include <GraphMol/FileParsers/FileParsers.h>
+#include <GraphMol/MonomerInfo.h>
+#include <GraphMol/RDKitBase.h>
 #include <RDGeneral/BadFileException.h>
 #include <RDGeneral/FileParseException.h>
 #include <RDGeneral/LocaleSwitcher.h>
-#include <GraphMol/RDKitBase.h>
-#include <GraphMol/FileParsers/MolWriters.h>
-#include <GraphMol/FileParsers/FileParsers.h>
-
-#include <GraphMol/MonomerInfo.h>
 
 // PDBWriter support multiple "flavors" of PDB output
 // flavor & 1 : Write MODEL/ENDMDL lines around each record

--- a/Code/GraphMol/FileParsers/PDBWriter.cpp
+++ b/Code/GraphMol/FileParsers/PDBWriter.cpp
@@ -14,14 +14,13 @@
 #include <string>
 #include <vector>
 
-#ifdef RDK_BUILD_MAEPARSER_SUPPORT
-#include <maeparser/Writer.hpp>
-#endif  // RDK_BUILD_MAEPARSER_SUPPORT
-
 #include <RDGeneral/BoostStartInclude.h>
 #include <boost/format.hpp>
 #include <RDGeneral/BoostEndInclude.h>
 
+#ifdef RDK_BUILD_MAEPARSER_SUPPORT
+#undef RDK_BUILD_MAEPARSER_SUPPORT
+#endif
 #include <GraphMol/FileParsers/MolWriters.h>
 #include <GraphMol/FileParsers/FileParsers.h>
 #include <GraphMol/MonomerInfo.h>

--- a/Code/GraphMol/FileParsers/SDWriter.cpp
+++ b/Code/GraphMol/FileParsers/SDWriter.cpp
@@ -15,14 +15,13 @@
 
 #include <boost/any.hpp>
 
-#ifdef RDK_BUILD_MAEPARSER_SUPPORT
-#include <maeparser/Writer.hpp>
-#endif  // RDK_BUILD_MAEPARSER_SUPPORT
-
 #include <RDGeneral/BadFileException.h>
 #include <RDGeneral/FileParseException.h>
 #include <RDGeneral/RDLog.h>
 
+#ifdef RDK_BUILD_MAEPARSER_SUPPORT
+#undef RDK_BUILD_MAEPARSER_SUPPORT
+#endif
 #include "MolWriters.h"
 #include "FileParsers.h"
 

--- a/Code/GraphMol/FileParsers/SDWriter.cpp
+++ b/Code/GraphMol/FileParsers/SDWriter.cpp
@@ -7,18 +7,24 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
+
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+
+#include <boost/any.hpp>
+
+#ifdef RDK_BUILD_MAEPARSER_SUPPORT
+#include <maeparser/Writer.hpp>
+#endif  // RDK_BUILD_MAEPARSER_SUPPORT
+
 #include <RDGeneral/BadFileException.h>
 #include <RDGeneral/FileParseException.h>
 #include <RDGeneral/RDLog.h>
 
 #include "MolWriters.h"
 #include "FileParsers.h"
-
-#include <fstream>
-#include <iostream>
-#include <sstream>
-#include <string>
-#include <boost/any.hpp>
 
 namespace RDKit {
 SDWriter::SDWriter(const std::string &fileName) {

--- a/Code/GraphMol/FileParsers/SmilesWriter.cpp
+++ b/Code/GraphMol/FileParsers/SmilesWriter.cpp
@@ -8,17 +8,22 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-#include <RDGeneral/BadFileException.h>
-#include <RDGeneral/FileParseException.h>
-#include <RDGeneral/RDLog.h>
-#include <GraphMol/SmilesParse/SmilesWrite.h>
-#include "MolWriters.h"
-#include "FileParsers.h"
-
 #include <fstream>
 #include <iostream>
 #include <sstream>
 #include <string>
+
+#ifdef RDK_BUILD_MAEPARSER_SUPPORT
+#include <maeparser/Writer.hpp>
+#endif  // RDK_BUILD_MAEPARSER_SUPPORT
+
+#include <GraphMol/SmilesParse/SmilesWrite.h>
+#include <RDGeneral/BadFileException.h>
+#include <RDGeneral/FileParseException.h>
+#include <RDGeneral/RDLog.h>
+
+#include "MolWriters.h"
+#include "FileParsers.h"
 
 namespace RDKit {
 

--- a/Code/GraphMol/FileParsers/SmilesWriter.cpp
+++ b/Code/GraphMol/FileParsers/SmilesWriter.cpp
@@ -13,15 +13,14 @@
 #include <sstream>
 #include <string>
 
-#ifdef RDK_BUILD_MAEPARSER_SUPPORT
-#include <maeparser/Writer.hpp>
-#endif  // RDK_BUILD_MAEPARSER_SUPPORT
-
 #include <GraphMol/SmilesParse/SmilesWrite.h>
 #include <RDGeneral/BadFileException.h>
 #include <RDGeneral/FileParseException.h>
 #include <RDGeneral/RDLog.h>
 
+#ifdef RDK_BUILD_MAEPARSER_SUPPORT
+#undef RDK_BUILD_MAEPARSER_SUPPORT
+#endif
 #include "MolWriters.h"
 #include "FileParsers.h"
 

--- a/Code/GraphMol/FileParsers/TDTWriter.cpp
+++ b/Code/GraphMol/FileParsers/TDTWriter.cpp
@@ -8,20 +8,25 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-#include <RDGeneral/BadFileException.h>
-#include <RDGeneral/FileParseException.h>
-#include <RDGeneral/RDLog.h>
-#include <GraphMol/SmilesParse/SmilesWrite.h>
-
-#include "MolWriters.h"
-#include "FileParsers.h"
-
 #include <fstream>
 #include <iostream>
 #include <iomanip>
 #include <sstream>
 #include <string>
+
 #include <boost/algorithm/string.hpp>
+
+#ifdef RDK_BUILD_MAEPARSER_SUPPORT
+#include <maeparser/Writer.hpp>
+#endif  // RDK_BUILD_MAEPARSER_SUPPORT
+
+#include <GraphMol/SmilesParse/SmilesWrite.h>
+#include <RDGeneral/BadFileException.h>
+#include <RDGeneral/FileParseException.h>
+#include <RDGeneral/RDLog.h>
+
+#include "MolWriters.h"
+#include "FileParsers.h"
 
 namespace RDKit {
 TDTWriter::TDTWriter(const std::string &fileName) {

--- a/Code/GraphMol/FileParsers/TDTWriter.cpp
+++ b/Code/GraphMol/FileParsers/TDTWriter.cpp
@@ -16,15 +16,14 @@
 
 #include <boost/algorithm/string.hpp>
 
-#ifdef RDK_BUILD_MAEPARSER_SUPPORT
-#include <maeparser/Writer.hpp>
-#endif  // RDK_BUILD_MAEPARSER_SUPPORT
-
 #include <GraphMol/SmilesParse/SmilesWrite.h>
 #include <RDGeneral/BadFileException.h>
 #include <RDGeneral/FileParseException.h>
 #include <RDGeneral/RDLog.h>
 
+#ifdef RDK_BUILD_MAEPARSER_SUPPORT
+#undef RDK_BUILD_MAEPARSER_SUPPORT
+#endif
 #include "MolWriters.h"
 #include "FileParsers.h"
 

--- a/Code/GraphMol/FileParsers/file_parsers_catch.cpp
+++ b/Code/GraphMol/FileParsers/file_parsers_catch.cpp
@@ -5930,6 +5930,30 @@ TEST_CASE("MaeWriter basic testing", "[mae][MaeWriter][writer]") {
     }
     // Maeparser does not parse bond properties, so don't check them.
   }
+
+  SECTION("getText()") {
+    mol->setProp(common_properties::_Name, "test mol 4");
+
+    // The writer always takes ownership of the stream!
+    auto oss = new std::ostringstream;
+    std::string mae;
+    {
+      MaeWriter w(oss);
+      w.write(*mol);
+      mae = oss->str();
+    }
+
+    // Check for the Maestro file header
+    REQUIRE(mae.find("s_m_m2io_version") != std::string::npos);
+
+    // Check the CT header and Structure properties
+    auto ctBlockStart = mae.find("f_m_ct");
+    REQUIRE(ctBlockStart != std::string::npos);
+
+    std::string_view ctBlock(&mae[ctBlockStart]);
+
+    CHECK(ctBlock == MaeWriter::getText(*mol));
+  }
 }
 
 TEST_CASE("MaeWriter edge case testing", "[mae][MaeWriter][writer]") {

--- a/Code/GraphMol/FileParsers/file_parsers_catch.cpp
+++ b/Code/GraphMol/FileParsers/file_parsers_catch.cpp
@@ -5818,9 +5818,9 @@ TEST_CASE("MaeWriter basic testing", "[mae][MaeWriter][writer]") {
 
   SECTION("Check Property filtering") {
     std::vector<std::string> keptProps{
-        "b_rdk_mol_bool_prop",
-        "i_rdk_atom_int_prop",
-        "r_rdk_bond_real_prop",
+        "mol_bool_prop",
+        "atom_int_prop",
+        "bond_real_prop",
         "non_existent_property",
     };
 

--- a/Code/GraphMol/FileParsers/file_parsers_catch.cpp
+++ b/Code/GraphMol/FileParsers/file_parsers_catch.cpp
@@ -5832,7 +5832,8 @@ TEST_CASE("MaeWriter basic testing", "[mae][MaeWriter][writer]") {
 
     w.setProps(keptProps);
 
-    w.write(*mol);
+    std::string heavyAtomColor = "131313";
+    w.write(*mol, heavyAtomColor);
     w.flush();
 
     auto mae = oss->str();
@@ -5888,6 +5889,15 @@ TEST_CASE("MaeWriter basic testing", "[mae][MaeWriter][writer]") {
     CHECK(bondBlock.find("b_rdk_bond_bool_prop") == std::string::npos);
     CHECK(bondBlock.find("i_rdk_bond_int_prop") == std::string::npos);
     CHECK(bondBlock.find("s_rdk_bond_string_prop") == std::string::npos);
+
+    size_t pos = 0;
+    unsigned atom_color_count = 0;
+    while (pos < std::string::npos) {
+      pos = atomBlock.find(heavyAtomColor, pos + 1);
+      atom_color_count += (pos != std::string::npos);
+    }
+
+    CHECK(atom_color_count == mol->getNumAtoms());
   }
 
   SECTION("Check roundtrip") {

--- a/Code/GraphMol/Wrap/CMakeLists.txt
+++ b/Code/GraphMol/Wrap/CMakeLists.txt
@@ -9,22 +9,22 @@ rdkit_python_extension(rdchem
                        SmilesParse ChemTransforms SubstructMatch GraphMol)
 
 rdkit_python_extension(rdmolops
-                       rdmolops.cpp MolOps.cpp 
+                       rdmolops.cpp MolOps.cpp
                        ChiralityOps.cpp
                        DEST Chem
                        LINK_LIBRARIES
                        ChemReactions Depictor
                        FileParsers SubstructMatch Fingerprints ChemTransforms
-                       Subgraphs SmilesParse MolTransforms GraphMol )
+                       Subgraphs SmilesParse MolTransforms GraphMol)
 
 rdkit_python_extension(rdqueries
                        rdqueries.cpp Queries.cpp
                        DEST Chem
                        LINK_LIBRARIES
-                       GraphMol  )
+                       GraphMol)
 
 if(RDK_BUILD_MAEPARSER_SUPPORT)
-    set (maesupplier MaeMolSupplier.cpp)
+    set (maesupplier MaeMolSupplier.cpp MaeWriter.cpp)
     include_directories(${maeparser_INCLUDE_DIRS})
 endif()
 
@@ -39,17 +39,17 @@ set(rdmolfiles_sources rdmolfiles.cpp
                        SmilesMolSupplier.cpp SmilesWriter.cpp SDWriter.cpp
                        TDTWriter.cpp CompressedSDMolSupplier.cpp
                        PDBWriter.cpp
-											 MultithreadedSmilesMolSupplier.cpp
-											 MultithreadedSDMolSupplier.cpp)
+                       MultithreadedSmilesMolSupplier.cpp
+                       MultithreadedSDMolSupplier.cpp)
 else(RDK_BUILD_COMPRESSED_SUPPLIERS)
 set(rdmolfiles_sources rdmolfiles.cpp
                        ForwardSDMolSupplier.cpp ${maesupplier}
                        SDMolSupplier.cpp TDTMolSupplier.cpp
                        SmilesMolSupplier.cpp SmilesWriter.cpp SDWriter.cpp
                        TDTWriter.cpp
-                       PDBWriter.cpp 
-											 MultithreadedSmilesMolSupplier.cpp
-											 MultithreadedSDMolSupplier.cpp)
+                       PDBWriter.cpp
+                       MultithreadedSmilesMolSupplier.cpp
+                       MultithreadedSDMolSupplier.cpp)
 
 endif(RDK_BUILD_COMPRESSED_SUPPLIERS)
 
@@ -57,7 +57,7 @@ rdkit_python_extension(rdmolfiles
                        ${rdmolfiles_sources}
                        DEST Chem
                        LINK_LIBRARIES  SubstructMatch
-		       SmilesParse FileParsers GraphMol
+                       SmilesParse FileParsers GraphMol
                        RDGeometryLib RDGeneral RDBoost)
 
 rdkit_python_extension(rdtrajectory
@@ -66,7 +66,7 @@ rdkit_python_extension(rdtrajectory
                        LINK_LIBRARIES Trajectory RDGeometryLib RDGeneral RDBoost GraphMol)
 
 if(RDK_BUILD_COMPRESSED_SUPPLIERS)
-  set_target_properties(rdmolfiles PROPERTIES DEFINE_SYMBOL SUPPORT_COMPRESSED_SUPPLIERS )
+  set_target_properties(rdmolfiles PROPERTIES DEFINE_SYMBOL SUPPORT_COMPRESSED_SUPPLIERS)
 endif(RDK_BUILD_COMPRESSED_SUPPLIERS)
 
 add_pytest(pyGraphMolWrap
@@ -84,7 +84,7 @@ add_pytest(pyTestSGroups
 if (RDK_TEST_MULTITHREADED)
   add_pytest(pyTestThreads
            ${CMAKE_CURRENT_SOURCE_DIR}/testThreads.py)
-	add_pytest(pyTestMultithreadedMolSupplier
+  add_pytest(pyTestMultithreadedMolSupplier
          ${CMAKE_CURRENT_SOURCE_DIR}/testMultithreadedMolSupplier.py)
 endif (RDK_TEST_MULTITHREADED)
 

--- a/Code/GraphMol/Wrap/MaeWriter.cpp
+++ b/Code/GraphMol/Wrap/MaeWriter.cpp
@@ -46,7 +46,7 @@ class LocalMaeWriter : public MaeWriter {
 struct wrap_maewriter {
   static void wrap() {
     std::string docStr =
-        "A class for writing molecules to Maestro files.\n\
+        "An experimental class for writing molecules to Maestro files.\n\
 \n\
   Usage examples:\n\
 \n\
@@ -64,11 +64,18 @@ struct wrap_maewriter {
        >>> writer.close()\n\
        >>> outf.close()\n\
 \n\
-  By default all non-private molecular and atomic properties are written\n\
+  By default all non-private molecule, atom and bond properties are written\n\
   to the Maestro file. This can be changed using the SetProps method:\n\n\
        >>> writer = MaeWriter('out.mae')\n\
-       >>> writer.SetProps(['prop1','prop2'])\n\
-\n";
+       >>> writer.SetProps(['prop1','prop2'])\n\n\
+  Properties that are specified, but are not present will be ignored.\n\n\
+  Kekulization is mandatory, as the Maestro format does not have\n\
+  the concept of an aromatic bond\n\n\
+  As this is an experimental writer, many features are not supported yet,\n\
+  e.g. chirality and bond stereo labels, stereo groups, substance groups,\n\
+  isotopes, or even dummy atoms. Note that these aren't supported by\n\
+  MaeMolSupplier either.\n\
+\n ";
     python::class_<LocalMaeWriter, boost::noncopyable>(
         "MaeWriter", docStr.c_str(), python::no_init)
         .def(python::init<python::object &>(python::arg("fileobj")))

--- a/Code/GraphMol/Wrap/MaeWriter.cpp
+++ b/Code/GraphMol/Wrap/MaeWriter.cpp
@@ -14,6 +14,8 @@
 #include <memory>
 #include <string>
 
+#include <maeparser/Writer.hpp>
+
 #include <GraphMol/FileParsers/MolWriters.h>
 #include <RDBoost/python.h>
 #include <RDBoost/python_streambuf.h>

--- a/Code/GraphMol/Wrap/MaeWriter.cpp
+++ b/Code/GraphMol/Wrap/MaeWriter.cpp
@@ -90,13 +90,19 @@ struct wrap_maewriter {
             "Sets the atom and mol properties to be written to the output file\n\n"
             "  ARGUMENTS:\n\n"
             "    - props: a list or tuple of atom and mol property names\n\n")
-        .def("write", &LocalMaeWriter::write,
-             (python::arg("self"), python::arg("mol"),
-              python::arg("confId") = defaultConfId),
-             "Writes a molecule to the output file.\n\n"
-             "  ARGUMENTS:\n\n"
-             "    - mol: the Mol to be written\n"
-             "    - confId: (optional) ID of the conformation to write\n\n")
+        .def(
+            "write",
+            (void(LocalMaeWriter::*)(const ROMol &, const std::string &, int)) &
+                LocalMaeWriter::write,
+            (python::arg("self"), python::arg("mol"),
+             python::arg("heavyAtomColor") = defaultMaeHeavyAtomColor,
+             python::arg("confId") = defaultConfId),
+            "Writes a molecule to the output file.\n\n"
+            "  ARGUMENTS:\n\n"
+            "    - mol: the Mol to be written\n"
+            "    - heavyAtomColor: (optional) color which heavy atoms will have in Maestro\n"
+            "    - confId: (optional) ID of the conformation to write\n\n")
+
         .def("flush", &LocalMaeWriter::flush,
              "Flushes the output file (forces the disk file to be "
              "updated).\n\n")

--- a/Code/GraphMol/Wrap/MaeWriter.cpp
+++ b/Code/GraphMol/Wrap/MaeWriter.cpp
@@ -1,0 +1,107 @@
+//
+//
+//  Copyright (C) 2023 Schrödinger, LLC
+//
+//   @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
+//
+
+#define NO_IMPORT_ARRAY
+
+#include <memory>
+#include <string>
+
+#include <GraphMol/FileParsers/MolWriters.h>
+#include <RDBoost/python.h>
+#include <RDBoost/python_streambuf.h>
+#include <RDBoost/Wrap.h>
+
+#include "ContextManagers.h"
+
+namespace python = boost::python;
+using boost_adaptbx::python::streambuf;
+
+namespace RDKit {
+
+class LocalMaeWriter : public MaeWriter {
+ public:
+  LocalMaeWriter(python::object &fileobj)
+      : dp_streambuf(new streambuf(fileobj, 't')) {
+    dp_ostream.reset(new streambuf::ostream(*dp_streambuf));
+  }
+
+  LocalMaeWriter(streambuf &output) {
+    dp_ostream.reset(new streambuf::ostream(output));
+  }
+
+  LocalMaeWriter(const std::string &fname) : RDKit::MaeWriter(fname) {}
+
+ private:
+  std::unique_ptr<streambuf> dp_streambuf = nullptr;
+};
+
+struct wrap_maewriter {
+  static void wrap() {
+    std::string docStr =
+        "A class for writing molecules to Maestro files.\n\
+\n\
+  Usage examples:\n\
+\n\
+    1) writing to a named file:\n\n\
+       >>> writer = MaeWriter('out.mae')\n\
+       >>> for mol in list_of_mols:\n\
+       ...    writer.write(mol)\n\
+\n\
+    2) writing to a file-like object: \n\n\
+       >>> import gzip\n\
+       >>> outf=gzip.open('out.mae.gz','wt+')\n\
+       >>> writer = MaeWriter(outf)\n\
+       >>> for mol in list_of_mols:\n\
+       ...   writer.write(mol)\n\
+       >>> writer.close()\n\
+       >>> outf.close()\n\
+\n\
+  By default all non-private molecular and atomic properties are written\n\
+  to the Maestro file. This can be changed using the SetProps method:\n\n\
+       >>> writer = MaeWriter('out.mae')\n\
+       >>> writer.SetProps(['prop1','prop2'])\n\
+\n";
+    python::class_<LocalMaeWriter, boost::noncopyable>(
+        "MaeWriter", docStr.c_str(), python::no_init)
+        .def(python::init<python::object &>(python::arg("fileobj")))
+        .def(python::init<streambuf &>(python::arg("streambuf")))
+        .def(python::init<std::string>(python::arg("filename")))
+        .def("__enter__", &MolIOEnter<LocalMaeWriter>,
+             python::return_internal_reference<>())
+        .def("__exit__", &MolIOExit<LocalMaeWriter>)
+        .def(
+            "SetProps", &LocalMaeWriter::setProps,
+            (python::arg("self"), python::args("props_list")),
+            "Sets the atom and mol properties to be written to the output file\n\n"
+            "  ARGUMENTS:\n\n"
+            "    - props: a list or tuple of atom and mol property names\n\n")
+        .def("write", &LocalMaeWriter::write,
+             (python::arg("self"), python::arg("mol"),
+              python::arg("confId") = defaultConfId),
+             "Writes a molecule to the output file.\n\n"
+             "  ARGUMENTS:\n\n"
+             "    - mol: the Mol to be written\n"
+             "    - confId: (optional) ID of the conformation to write\n\n")
+        .def("flush", &LocalMaeWriter::flush,
+             "Flushes the output file (forces the disk file to be "
+             "updated).\n\n")
+        .def("close", &LocalMaeWriter::close,
+             "Flushes the output file and closes it. The Writer cannot be used "
+             "after this.\n\n")
+        .def("NumMols", &LocalMaeWriter::numMols,
+             "Returns the number of molecules written so far.\n\n");
+
+    iterable_converter().from_python<std::vector<std::string>>();
+  };
+};
+}  // namespace RDKit
+
+void wrap_maewriter() { RDKit::wrap_maewriter::wrap(); }

--- a/Code/GraphMol/Wrap/MaeWriter.cpp
+++ b/Code/GraphMol/Wrap/MaeWriter.cpp
@@ -112,7 +112,14 @@ struct wrap_maewriter {
              "Flushes the output file and closes it. The Writer cannot be used "
              "after this.\n\n")
         .def("NumMols", &LocalMaeWriter::numMols,
-             "Returns the number of molecules written so far.\n\n");
+             "Returns the number of molecules written so far.\n\n")
+        .def("GetText", &LocalMaeWriter::getText,
+             (python::arg("mol"),
+              python::arg("heavyAtomColor") = defaultMaeHeavyAtomColor,
+              python::arg("confId") = -1,
+              python::arg("props_list") = std::vector<std::string>()),
+             "returns the Maestro ct block text for a molecule")
+        .staticmethod("GetText");
 
     iterable_converter().from_python<std::vector<std::string>>();
   };

--- a/Code/GraphMol/Wrap/PDBWriter.cpp
+++ b/Code/GraphMol/Wrap/PDBWriter.cpp
@@ -38,9 +38,9 @@ std::string pdbwDocStr =
     "     - flavor: (optional) \n\n";
 struct pdbwriter_wrap {
   static void wrap() {
-    python::class_<PDBWriter>("PDBWriter",
-                              "A class for writing molecules to PDB files.",
-                              python::no_init)
+    python::class_<PDBWriter, boost::noncopyable>(
+        "PDBWriter", "A class for writing molecules to PDB files.",
+        python::no_init)
         .def("__init__",
              python::make_constructor(
                  &getPDBWriter, python::default_call_policies(),

--- a/Code/GraphMol/Wrap/SmilesWriter.cpp
+++ b/Code/GraphMol/Wrap/SmilesWriter.cpp
@@ -64,9 +64,9 @@ std::string swDocStr =
     "aromatic bonds for molecules that have been kekulized).\n\n";
 struct smiwriter_wrap {
   static void wrap() {
-    python::class_<SmilesWriter>("SmilesWriter",
-                                 "A class for writing molecules to text files.",
-                                 python::no_init)
+    python::class_<SmilesWriter, boost::noncopyable>(
+        "SmilesWriter", "A class for writing molecules to text files.",
+        python::no_init)
         .def("__init__",
              python::make_constructor(
                  &getSmilesWriter, python::default_call_policies(),

--- a/Code/GraphMol/Wrap/rdmolfiles.cpp
+++ b/Code/GraphMol/Wrap/rdmolfiles.cpp
@@ -681,6 +681,9 @@ void wrap_smiwriter();
 void wrap_sdwriter();
 void wrap_tdtwriter();
 void wrap_pdbwriter();
+#ifdef RDK_BUILD_MAEPARSER_SUPPORT
+void wrap_maewriter();
+#endif
 
 // MultithreadedMolSupplier stuff
 void wrap_multiSmiSupplier();
@@ -2153,6 +2156,9 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
   wrap_sdwriter();
   wrap_tdtwriter();
   wrap_pdbwriter();
+#ifdef RDK_BUILD_MAEPARSER_SUPPORT
+  wrap_maewriter();
+#endif
 
 #ifdef RDK_BUILD_THREADSAFE_SSS
   /********************************************************

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -7147,6 +7147,36 @@ CAS<~>
 
     self.assertEqual(Chem.MolToSmiles(roundtrip_mol), smiles)
 
+  @unittest.skipIf(not hasattr(Chem, 'MaeWriter'), "not build with MAEParser support")
+  def testMaeWriterGetText(self):
+    smiles = "C1CCCCC1"
+    mol = Chem.MolFromSmiles(smiles)
+    self.assertTrue(mol)
+
+    dummy_prop = 'dummy_prop'
+    another_dummy_prop = 'another_dummy_prop'
+    mol.SetProp(dummy_prop, dummy_prop)
+    mol.SetProp(another_dummy_prop, another_dummy_prop)
+
+    heavyAtomColor = "767676"
+
+    osio = StringIO()
+    with Chem.MaeWriter(osio) as w:
+      w.SetProps([dummy_prop])
+      w.write(mol, heavyAtomColor=heavyAtomColor)
+
+    iomae = osio.getvalue()
+
+    ctBlockStart = iomae.find('f_m_ct')
+    self.assertNotEqual(ctBlockStart, -1)
+
+    self.assertIn(dummy_prop, iomae)
+    self.assertNotIn(another_dummy_prop, iomae)
+
+    mae = Chem.MaeWriter.GetText(mol, heavyAtomColor, -1, [dummy_prop])
+
+    self.assertEqual(mae, iomae[ctBlockStart:])
+
 
 if __name__ == '__main__':
   if "RDTESTCASE" in os.environ:

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -20,7 +20,7 @@ import tempfile
 import unittest
 from contextlib import contextmanager
 from datetime import datetime, timedelta
-from io import StringIO
+from io import BytesIO, StringIO
 
 import rdkit.Chem.rdDepictor
 from rdkit import Chem, DataStructs, RDConfig, __version__, rdBase
@@ -2994,7 +2994,6 @@ CAS<~>
   def test67StreamSupplierStringIO(self):
     fileN = os.path.join(RDConfig.RDBaseDir, 'Code', 'GraphMol', 'FileParsers', 'test_data',
                          'NCI_aids_few.sdf.gz')
-    from io import BytesIO
     sio = BytesIO(gzip.open(fileN).read())
     suppl = Chem.ForwardSDMolSupplier(sio)
     molNames = [
@@ -3043,8 +3042,6 @@ CAS<~>
     self.assertEqual(i, 16)
 
   def test70StreamSDWriter(self):
-    from io import BytesIO, StringIO
-
     fileN = os.path.join(RDConfig.RDBaseDir, 'Code', 'GraphMol', 'FileParsers', 'test_data',
                          'NCI_aids_few.sdf.gz')
     inf = gzip.open(fileN)
@@ -3075,7 +3072,6 @@ CAS<~>
     self.assertEqual(i, 16)
 
   def test71StreamSmilesWriter(self):
-    from io import StringIO
     fileN = os.path.join(RDConfig.RDBaseDir, 'Code', 'GraphMol', 'FileParsers', 'test_data',
                          'esters.sdf')
     suppl = Chem.ForwardSDMolSupplier(fileN)
@@ -3096,7 +3092,6 @@ CAS<~>
     self.assertEqual(txt.count('\n'), 7)
 
   def test72StreamTDTWriter(self):
-    from io import StringIO
     fileN = os.path.join(RDConfig.RDBaseDir, 'Code', 'GraphMol', 'FileParsers', 'test_data',
                          'esters.sdf')
     suppl = Chem.ForwardSDMolSupplier(fileN)
@@ -5730,7 +5725,6 @@ $$$$
     self.assertTrue(l[1] is None)
     self.assertTrue(l[2] is None)
 
-    from io import BytesIO
     sio = BytesIO(sdf)
     suppl3 = Chem.ForwardSDMolSupplier(sio)
     l = [x for x in suppl3]
@@ -5772,7 +5766,6 @@ M  END
     self.assertTrue(l[0] is not None)
     self.assertTrue(l[1] is not None)
 
-    from io import BytesIO
     sio = BytesIO(sdf)
     suppl3 = Chem.ForwardSDMolSupplier(sio)
     l = [x for x in suppl3]
@@ -6553,7 +6546,6 @@ M  END
     self.assertAlmostEqual(sq_dist(pos[0], pos[1]), sq_dist(pos[1], pos[2]))
 
   def test_github3553(self):
-    from io import StringIO
     fileN = os.path.join(RDConfig.RDBaseDir, 'Code', 'GraphMol', 'Wrap', 'test_data',
                          'github3553.sdf')
     sdSup = Chem.SDMolSupplier(fileN)
@@ -6625,7 +6617,6 @@ M  END
   def testContextManagers(self):
     from rdkit import RDLogger
     RDLogger.DisableLog('rdApp.*')
-    from io import StringIO
     fileN = os.path.join(RDConfig.RDBaseDir, 'Code', 'GraphMol', 'Wrap', 'test_data',
                          'github3553.sdf')
     with Chem.SDMolSupplier(fileN) as suppl:
@@ -7004,13 +6995,157 @@ CAS<~>
     # test of unpickling
     props = Chem.GetDefaultPickleProperties()
     try:
-      Chem.SetDefaultPickleProperties(Chem.PropertyPickleOptions.AllProps) 
-      mols = [Chem.MolFromSmiles(s) for s in ["C","CC"]]
+      Chem.SetDefaultPickleProperties(Chem.PropertyPickleOptions.AllProps)
+      mols = [Chem.MolFromSmiles(s) for s in ["C", "CC"]]
       scaffolds = [MurckoScaffold.GetScaffoldForMol(m) for m in mols]
       # this shouldn't throw an exception
       unpickler = [pickle.loads(pickle.dumps(m)) for m in mols]
     finally:
       Chem.SetDefaultPickleProperties(props)
+
+  @unittest.skipIf(not hasattr(Chem, 'MaeWriter'), "not build with MAEParser support")
+  def testMaeWriter(self):
+    mol = Chem.MolFromSmiles("C1CCCCC1")
+    self.assertTrue(mol)
+    title = "random test mol"
+    mol.SetProp('_Name', title)
+
+    ofile = os.path.join(RDConfig.RDBaseDir, 'Code', 'GraphMol', 'Wrap', 'test_data',
+                         'outMaeWriter.mae')
+    writer1 = Chem.MaeWriter(ofile)
+
+    osio = StringIO()
+    writer2 = Chem.MaeWriter(osio)
+
+    for writer in (writer1, writer2):
+      writer.write(mol)
+      writer.close()
+      del writer
+
+    with open(ofile) as f:
+      maefile = f.read()
+
+    self.assertEqual(maefile, osio.getvalue())
+
+    self.assertIn('s_m_m2io_version', maefile)
+
+    self.assertIn('f_m_ct', maefile)
+
+    self.assertIn('s_m_title', maefile)
+    self.assertIn(title, maefile)
+
+    self.assertIn(f' m_atom[{mol.GetNumAtoms()}] {{', maefile)
+
+    self.assertEqual(maefile.count("A0A0A0"), 6)  # 6 grey-colored heavy atoms
+
+    self.assertTrue(f' m_bond[{mol.GetNumBonds()}] {{', maefile)
+
+  @unittest.skipIf(not hasattr(Chem, 'MaeWriter'), "not build with MAEParser support")
+  def testMaeWriterProps(self):
+    mol = Chem.MolFromSmiles("C1CCCCC1")
+    self.assertTrue(mol)
+
+    title = "random test mol"
+    mol.SetProp('_Name', title)
+
+    boolProp = False
+    intProp = 123454321
+    realProp = 2.718282  # Mae files have a predefined precision of 6 digits!
+    strProp = r"This is a dummy prop, yay!"
+
+    ignored_prop = 'ignored_prop'
+    str_dummy_prop = 'str_dummy_prop'
+    mol_prop = 'mol_prop'
+    atom_prop = 'atom_prop'
+    bond_prop = 'bond_prop'
+    exported_props = [str_dummy_prop, mol_prop, atom_prop, bond_prop]
+
+    mol.SetIntProp(mol_prop, intProp)
+    mol.SetProp(str_dummy_prop, strProp)
+    mol.SetProp(ignored_prop, ignored_prop)
+
+    atomIdx = 2
+    at = mol.GetAtomWithIdx(atomIdx)
+    at.SetDoubleProp(atom_prop, realProp)
+    at.SetProp(str_dummy_prop, strProp)
+    at.SetProp(ignored_prop, ignored_prop)
+
+    bondIdx = 4
+    b = mol.GetBondWithIdx(bondIdx)
+    b.SetBoolProp(bond_prop, boolProp)
+    b.SetProp(str_dummy_prop, strProp)
+    b.SetProp(ignored_prop, ignored_prop)
+
+    heavyAtomColor = "767676"
+
+    osio = StringIO()
+    with Chem.MaeWriter(osio) as w:
+      w.SetProps(exported_props)
+      w.write(mol, heavyAtomColor=heavyAtomColor)
+
+    maestr = osio.getvalue()
+
+    ctBlockStart = maestr.find('f_m_ct')
+    atomBlockStart = maestr.find(' m_atom[')
+    bondBlockStart = maestr.find(' m_bond[')
+
+    self.assertNotEqual(ctBlockStart, -1)
+    self.assertNotEqual(atomBlockStart, -1)
+    self.assertNotEqual(bondBlockStart, -1)
+
+    self.assertGreater(bondBlockStart, atomBlockStart)
+    self.assertGreater(atomBlockStart, ctBlockStart)
+
+    # structure properties
+    self.assertIn(mol_prop, maestr[ctBlockStart:atomBlockStart])
+    self.assertIn(str(intProp), maestr[ctBlockStart:atomBlockStart])
+
+    self.assertIn(str_dummy_prop, maestr[ctBlockStart:atomBlockStart])
+    self.assertIn(strProp, maestr[ctBlockStart:atomBlockStart])
+
+    self.assertNotIn(ignored_prop, maestr[ctBlockStart:atomBlockStart])
+
+    # atom properties
+    self.assertIn(atom_prop, maestr[atomBlockStart:bondBlockStart])
+    self.assertIn(str_dummy_prop, maestr[atomBlockStart:bondBlockStart])
+
+    self.assertNotIn(ignored_prop, maestr[atomBlockStart:bondBlockStart])
+
+    for line in maestr[atomBlockStart:bondBlockStart].split('\n'):
+      if line.strip().startswith(str(atomIdx + 1)):
+        break
+    self.assertIn(str(realProp), line)
+    self.assertIn(strProp, line)
+    self.assertIn(heavyAtomColor, line)
+
+    # bond properties
+    self.assertIn(bond_prop, maestr[bondBlockStart:])
+    self.assertIn(str_dummy_prop, maestr[bondBlockStart:])
+
+    self.assertNotIn(ignored_prop, maestr[bondBlockStart:])
+
+    for line in maestr[bondBlockStart:].split('\n'):
+      if line.strip().startswith(str(bondIdx + 1)):
+        break
+    self.assertIn(str(int(boolProp)), line)
+    self.assertIn(strProp, line)
+
+  @unittest.skipIf(not hasattr(Chem, 'MaeWriter'), "not build with MAEParser support")
+  def testMaeWriterRoundtrip(self):
+    smiles = "C1CCCCC1"
+    mol = Chem.MolFromSmiles(smiles)
+    self.assertTrue(mol)
+
+    osio = StringIO()
+    with Chem.MaeWriter(osio) as w:
+      w.write(mol)
+
+    isio = BytesIO(osio.getvalue().encode())
+    with Chem.MaeMolSupplier(isio) as r:
+      roundtrip_mol = next(r)
+    self.assertTrue(roundtrip_mol)
+
+    self.assertEqual(Chem.MolToSmiles(roundtrip_mol), smiles)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION

This adds an initial implementation of the `MaeWriter` class, which allows exporting mols to Maestro files (.mae). It is based on the `MolWriter` class, and works in a way similar to the other existing "Writer" classes. The implementation is still very basic, but we hope to improve it soon.

Some things to take into account when using this class:

- The writer does not yet support stereochemistry: Maestro files use absolute stereochemical labels (R/S/E/Z), which require knowledge of the CIP ranks of the atoms around the stereo feature. The new stereo algorithm in RDKit does not provide this information, and while the CIP labeler can calculate the labels, it doesn't currently provide CIP ranks information.

- Kekulization is always required, as there is no concept of aromatic bonds in the Maestro format. Molecules that fail kekulization will not be exported.

- Only single, double, triple, zero and dative bonds are supported in Maestro files.

- Due to the underlying maeparser infrastructure, and same as with `MaeMolSupplier`, `MaeWriter` always requires ownership of the steam it writes to.

- Some other things that neither `MaeMolSupplier` nor `MaeWriter` support are: dummy atoms, isotopes, queries, enhanced stereo, substance groups. There's probably more than these, but we hope to at least add some of them soon.

- The usage of the `setProps()` method is a bit particular, since Maestro files support properties for molecules, atoms and bonds. By default, `propNames` is empty, and `MaeWriter` will export all properties. If `propNames` is not empty, `MaeWriter` will export the required properties (structure title, atom x/y/z coordinates, atomic number, charge, color in Maestro, pdb residue information, bond from/to and bond order) plus any mol/atom/bond property that matches any of the names in `propNames`. Entries in `propNames` that don't match any property will be ignored. 

- Only boolean, integer, real and string properties can be exported.

- Properties in Maestro files must follow a specific formatting rule. To honor this formatting, exported properties will be prefixed with "X_rdk_", where "X" can be 'b', 'i', 'r' or 's', depending on the value type of the property.

- For a structure to be exported, it must have at least one atom, although it is allowed not to have any bonds.

This PR also adds a couple of changes in `MaeMolSupplier` we noticed while adding the tests: a fix in the handling of duplicate bonds in Maestro files, and an update to strip the "X_rdk_" prefixes from properties imported from .mae files.

Pinging @cdvonbargen and @d-b-w here too so they can comment too.