### PR TITLE
Properly check for boost::any in rdvalue_is

### DIFF
--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -25,6 +25,7 @@ from io import StringIO
 import rdkit.Chem.rdDepictor
 from rdkit import Chem, DataStructs, RDConfig, __version__, rdBase
 from rdkit.Chem import rdqueries
+from rdkit.Chem.Scaffolds import MurckoScaffold
 
 # Boost functions are NOT found by doctest, this "fixes" them
 #  by adding the doctests to a fake module

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -6999,7 +6999,7 @@ CAS<~>
     self.assertEqual(nm.GetIntProp("bar"), 2)
     self.assertEqual(nm.foo, 1)
 
-  def testGithubIssue(self):
+  def testGithubIssue6306(self):
     # test of unpickling
     props = Chem.GetDefaultPickleProperties()
     try:

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -6999,6 +6999,18 @@ CAS<~>
     self.assertEqual(nm.GetIntProp("bar"), 2)
     self.assertEqual(nm.foo, 1)
 
+  def testGithubIssue(self):
+    # test of unpickling
+    props = Chem.GetDefaultPickleProperties()
+    try:
+      Chem.SetDefaultPickleProperties(Chem.PropertyPickleOptions.AllProps) 
+      mols = [Chem.MolFromSmiles(s) for s in ["C","CC"]]
+      scaffolds = [MurckoScaffold.GetScaffoldForMol(m) for m in mols]
+      # this shouldn't throw an exception
+      unpickler = [pickle.loads(pickle.dumps(m)) for m in mols]
+    finally:
+      Chem.SetDefaultPickleProperties(props)
+
 
 if __name__ == '__main__':
   if "RDTESTCASE" in os.environ:

--- a/Code/GraphMol/testPickler.cpp
+++ b/Code/GraphMol/testPickler.cpp
@@ -20,7 +20,6 @@
 #include <GraphMol/SmilesParse/SmilesWrite.h>
 #include <GraphMol/SmilesParse/SmartsWrite.h>
 #include <GraphMol/Substruct/SubstructMatch.h>
-#include <GraphMol/ChemTransforms/ChemTransforms.h>
 
 #ifdef RDK_USE_BOOST_SERIALIZATION
 #include <RDGeneral/BoostStartInclude.h>

--- a/Code/GraphMol/testPickler.cpp
+++ b/Code/GraphMol/testPickler.cpp
@@ -20,6 +20,7 @@
 #include <GraphMol/SmilesParse/SmilesWrite.h>
 #include <GraphMol/SmilesParse/SmartsWrite.h>
 #include <GraphMol/Substruct/SubstructMatch.h>
+#include <GraphMol/ChemTransforms/ChemTransforms.h>
 
 #ifdef RDK_USE_BOOST_SERIALIZATION
 #include <RDGeneral/BoostStartInclude.h>
@@ -842,6 +843,22 @@ void testIssue3316407() {
   }
 
   BOOST_LOG(rdErrorLog) << "\tdone" << std::endl;
+}
+
+void testGithubIssue6036() {
+  BOOST_LOG(rdErrorLog) << "-------------------------------------" << std::endl;
+  BOOST_LOG(rdErrorLog) << "Testing github issue 6036" << std::endl;
+  // Root cause
+  //  MurckoDecompose sets a boost::any as a distance matrix as well as
+  //  setting an explicit bit vector.  This checks to ensure that
+  //  rdvalue_is correctly works for ExplicitBitVectors and doesn't return
+  //  true when a boost::any has been set that isn't an explicit bit vector
+  auto m = "C"_smiles;
+  boost::shared_array<double> sptr;
+  m->setProp("shared_array", sptr);
+  std::string pkl;
+  MolPickler::pickleMol(*m, pkl, PicklerOps::AllProps);
+  std::unique_ptr<RWMol> roundTripped(new RWMol(pkl));  
 }
 
 void testIssue3496759() {
@@ -1866,4 +1883,5 @@ int main(int argc, char *argv[]) {
   testPropertyOptions();
   testAdditionalQueryPickling();
   testBoostSerialization();
+  testGithubIssue6036();
 }

--- a/Code/RDGeneral/RDValue-taggedunion.h
+++ b/Code/RDGeneral/RDValue-taggedunion.h
@@ -350,18 +350,29 @@ template <class T>
 inline bool rdvalue_is(RDValue_cast_t v) {
   const short tag =
       RDTypeTag::GetTag<typename boost::remove_reference<T>::type>();
-  if (v.getTag() == tag) {
-    return true;
-  }
 
   // If we are an Any tag, check the any type info
+  //  see the template specialization below if we are
+  //  looking for a boost any directly
   if (v.getTag() == RDTypeTag::AnyTag) {
     return v.value.a->type() == typeid(T);
   }
 
+  if (v.getTag() == tag) {
+    return true;
+  }
+  
   return false;
 }
 
+template <>
+inline bool rdvalue_is<boost::any>(RDValue_cast_t v) {
+  // If we are explicitly looking for a boost::any
+  //  then just check the top level tag
+  const short tag =
+      RDTypeTag::GetTag<boost::any>();
+  return v.getTag() == tag;
+}
 /////////////////////////////////////////////////////////////////////////////////////
 // rdvalue_cast<T>
 //


### PR DESCRIPTION
Fixes #6036 

This fixes an issue where the serializer for ExplicitBitVector thought any dynamic rdvalue (aka boost::any) was an explicit bit vector and just plain did the wrong thing.

The issue was the rdvalue_is<T> wasn't properly checking the subtype of the boost::any.  This was due to the fact that rdvalue_is<boost::any>(value) also had to work.  This specializes the check for boost::any and allows rdvalue_is to do the right thing.

