### PR TITLE
Add option to only include shortest paths for topological torsion fingerprints

### DIFF
--- a/Code/GraphMol/Fingerprints/TopologicalTorsionGenerator.cpp
+++ b/Code/GraphMol/Fingerprints/TopologicalTorsionGenerator.cpp
@@ -42,7 +42,7 @@ OutputType TopologicalTorsionEnvGenerator<OutputType>::getResultSize() const {
 std::string TopologicalTorsionArguments::infoString() const {
   return "TopologicalTorsionArguments torsionAtomCount=" +
              std::to_string(d_torsionAtomCount) + " onlyShortestPaths="
-         << std::to_string(df_onlyShortestPaths);
+         + std::to_string(df_onlyShortestPaths);
 };
 
 template <typename OutputType>
@@ -108,8 +108,12 @@ TopologicalTorsionEnvGenerator<OutputType>::getEnvironments(
     }
   }
   boost::dynamic_bitset<> pAtoms(mol.getNumAtoms());
+  bool useBonds = false;
+  bool useHs = false;
+  int rootedAtAtom = -1;
   PATH_LIST paths = findAllPathsOfLengthN(
-      mol, topologicalTorsionArguments->d_torsionAtomCount, false);
+      mol, topologicalTorsionArguments->d_torsionAtomCount, useBonds, useHs,
+      rootedAtAtom, topologicalTorsionArguments->df_onlyShortestPaths);
   for (PATH_LIST::const_iterator pathIt = paths.begin(); pathIt != paths.end();
        ++pathIt) {
     bool keepIt = true;

--- a/Code/GraphMol/Fingerprints/TopologicalTorsionGenerator.cpp
+++ b/Code/GraphMol/Fingerprints/TopologicalTorsionGenerator.cpp
@@ -41,7 +41,8 @@ OutputType TopologicalTorsionEnvGenerator<OutputType>::getResultSize() const {
 
 std::string TopologicalTorsionArguments::infoString() const {
   return "TopologicalTorsionArguments torsionAtomCount=" +
-         std::to_string(d_torsionAtomCount);
+             std::to_string(d_torsionAtomCount) + " onlyShortestPaths="
+         << std::to_string(df_onlyShortestPaths);
 };
 
 template <typename OutputType>

--- a/Code/GraphMol/Fingerprints/TopologicalTorsionGenerator.h
+++ b/Code/GraphMol/Fingerprints/TopologicalTorsionGenerator.h
@@ -21,7 +21,8 @@ namespace TopologicalTorsion {
 class RDKIT_FINGERPRINTS_EXPORT TopologicalTorsionArguments
     : public FingerprintArguments {
  public:
-  uint32_t d_torsionAtomCount;
+  uint32_t d_torsionAtomCount = 4;
+  bool df_onlyShortestPaths = false;
 
   std::string infoString() const override;
 

--- a/Code/GraphMol/Fingerprints/Wrap/TopologicalTorsionWrapper.cpp
+++ b/Code/GraphMol/Fingerprints/Wrap/TopologicalTorsionWrapper.cpp
@@ -50,7 +50,13 @@ void exportTopologicalTorsion() {
       .def_readwrite(
           "torsionAtomCount",
           &TopologicalTorsion::TopologicalTorsionArguments::d_torsionAtomCount,
-          "number of atoms to be included in the paths");
+          "number of atoms to be included in the paths")
+      .def_readwrite(
+          "onlyShortestPaths",
+          &TopologicalTorsion::TopologicalTorsionArguments::
+              df_onlyShortestPaths,
+          "whether or not to only include paths which are the shortest path between the start and end atoms");
+
   python::def(
       "GetTopologicalTorsionGenerator",
       &getTopologicalTorsionFPGenerator<std::uint64_t>,

--- a/Code/GraphMol/Fingerprints/Wrap/testGenerators.py
+++ b/Code/GraphMol/Fingerprints/Wrap/testGenerators.py
@@ -328,6 +328,17 @@ class TestCase(unittest.TestCase):
     fp = g.GetFingerprint(m)
     self.assertEqual(fp.GetNumOnBits(), 10)
 
+  def testTopologicalTorsionShortestPaths(self):
+    m = Chem.MolFromSmiles('CC1CCC1')
+    g = rdFingerprintGenerator.GetTopologicalTorsionGenerator()
+    fp = g.GetSparseCountFingerprint(m)
+    nz = fp.GetNonzeroElements()
+    self.assertEqual(len(nz), 3)
+
+    g.GetOptions().onlyShortestPaths = True
+    fp = g.GetSparseCountFingerprint(m)
+    nz = fp.GetNonzeroElements()
+    self.assertEqual(len(nz), 1)
 
 if __name__ == '__main__':
   unittest.main()

--- a/Code/GraphMol/Fingerprints/catch_tests.cpp
+++ b/Code/GraphMol/Fingerprints/catch_tests.cpp
@@ -751,3 +751,19 @@ TEST_CASE(
     CHECK(invars[1] == invars[0]);
   }
 }
+
+TEST_CASE("topological torsions shorted paths") {
+  SECTION("basics") {
+    auto mol = "CC1CCC1"_smiles;
+    REQUIRE(mol);
+    std::unique_ptr<FingerprintGenerator<std::uint64_t>> fpGenerator(
+        TopologicalTorsion::getTopologicalTorsionGenerator<std::uint64_t>());
+    REQUIRE(fpGenerator);
+    static_cast<TopologicalTorsion::TopologicalTorsionArguments *>(fpGenerator->getOptions())->df_countSimulation = false;
+    std::unique_ptr<SparseBitVect> fp(fpGenerator->getSparseFingerprint(*mol));
+    CHECK(fp->getNumOnBits()==2);
+    static_cast<TopologicalTorsion::TopologicalTorsionArguments *>(fpGenerator->getOptions())->df_onlyShortestPaths = true;
+    fp.reset(fpGenerator->getSparseFingerprint(*mol));
+    CHECK(fp->getNumOnBits()==0);
+  }
+}

--- a/Code/GraphMol/Fingerprints/catch_tests.cpp
+++ b/Code/GraphMol/Fingerprints/catch_tests.cpp
@@ -759,11 +759,15 @@ TEST_CASE("topological torsions shorted paths") {
     std::unique_ptr<FingerprintGenerator<std::uint64_t>> fpGenerator(
         TopologicalTorsion::getTopologicalTorsionGenerator<std::uint64_t>());
     REQUIRE(fpGenerator);
-    static_cast<TopologicalTorsion::TopologicalTorsionArguments *>(fpGenerator->getOptions())->df_countSimulation = false;
+    static_cast<TopologicalTorsion::TopologicalTorsionArguments *>(
+        fpGenerator->getOptions())
+        ->df_countSimulation = false;
     std::unique_ptr<SparseBitVect> fp(fpGenerator->getSparseFingerprint(*mol));
-    CHECK(fp->getNumOnBits()==2);
-    static_cast<TopologicalTorsion::TopologicalTorsionArguments *>(fpGenerator->getOptions())->df_onlyShortestPaths = true;
+    CHECK(fp->getNumOnBits() == 3);
+    static_cast<TopologicalTorsion::TopologicalTorsionArguments *>(
+        fpGenerator->getOptions())
+        ->df_onlyShortestPaths = true;
     fp.reset(fpGenerator->getSparseFingerprint(*mol));
-    CHECK(fp->getNumOnBits()==0);
+    CHECK(fp->getNumOnBits() == 1);
   }
 }

--- a/Code/GraphMol/Subgraphs/CMakeLists.txt
+++ b/Code/GraphMol/Subgraphs/CMakeLists.txt
@@ -10,3 +10,4 @@ target_include_directories(Subgraphs PUBLIC $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR
 
 rdkit_test(testSubgraphs1 test1.cpp LINK_LIBRARIES Subgraphs SmilesParse )
 rdkit_test(testSubgraphs2 test2.cpp LINK_LIBRARIES SmilesParse Subgraphs )
+rdkit_catch_test(subgraphsCatch catch_tests.cpp LINK_LIBRARIES SmilesParse Subgraphs)

--- a/Code/GraphMol/Subgraphs/Subgraphs.cpp
+++ b/Code/GraphMol/Subgraphs/Subgraphs.cpp
@@ -455,11 +455,8 @@ findAllPathsOfLengthsMtoN(const ROMol &mol, unsigned int lowerLen,
   //
   PRECONDITION(lowerLen <= upperLen, "");
 
-  double *distMat = nullptr;
-  if (onlyShortestPaths) {
-    // the molecule owns this pointer
-    distMat = MolOps::getDistanceMat(mol);
-  }
+  // the molecule owns the distance matrix pointer (if we need to get it)
+  double *distMat = onlyShortestPaths ? MolOps::getDistanceMat(mol) : nullptr;
   int *adjMat, dim;
   dim = mol.getNumAtoms();
   adjMat = new int[dim * dim];

--- a/Code/GraphMol/Subgraphs/Subgraphs.cpp
+++ b/Code/GraphMol/Subgraphs/Subgraphs.cpp
@@ -1,4 +1,3 @@
-// $Id$
 //
 //  Copyright (C) 2003-2022 Greg Landrum and other RDKit contributors
 //
@@ -190,7 +189,7 @@ void dumpVIV(VECT_INT_VECT v) {
 
 PATH_LIST
 extendPaths(int *adjMat, unsigned int dim, const PATH_LIST &paths,
-            int allowRingClosures = -1) {
+            int allowRingClosures = -1, double *distMat = nullptr) {
   PRECONDITION(adjMat, "no matrix");
   //
   //  extend each of the currently active paths by adding
@@ -198,15 +197,19 @@ extendPaths(int *adjMat, unsigned int dim, const PATH_LIST &paths,
   //
   PATH_LIST res;
   PATH_LIST::const_iterator path;
-  for (path = paths.begin(); path != paths.end(); path++) {
+  for (path = paths.begin(); path != paths.end(); ++path) {
     unsigned int endIdx = (*path)[path->size() - 1];
     unsigned int iTab = endIdx * dim;
     for (unsigned int otherIdx = 0; otherIdx < dim; otherIdx++) {
       if (adjMat[iTab + otherIdx] == 1) {
+        if (distMat &&
+            distMat[path->front() * dim + otherIdx] - path->size() < -0.001) {
+          continue;
+        }
         // test 1: make sure the new atom is not already
         //   in the path
-        PATH_TYPE::const_iterator loc;
-        loc = std::find(path->begin(), path->end(), static_cast<int>(otherIdx));
+        auto loc =
+            std::find(path->begin(), path->end(), static_cast<int>(otherIdx));
         // The two conditions for adding the atom are:
         //   1) it's not there already
         //   2) it's there, but ring closures are allowed and this
@@ -241,7 +244,7 @@ extendPaths(int *adjMat, unsigned int dim, const PATH_LIST &paths,
 
 INT_PATH_LIST_MAP
 pathFinderHelper(int *adjMat, unsigned int dim, unsigned int minLen,
-                 unsigned int maxLen, int rootedAtAtom) {
+                 unsigned int maxLen, int rootedAtAtom, double *distMat) {
   PRECONDITION(adjMat, "no matrix");
   PRECONDITION(minLen <= maxLen, "bad lengths provided");
   // finds all paths of length N using an adjacency matrix,
@@ -272,7 +275,7 @@ pathFinderHelper(int *adjMat, unsigned int dim, unsigned int minLen,
     if (length >= minLen) {
       res[length] = paths;
     }
-    paths = extendPaths(adjMat, dim, paths, maxLen);
+    paths = extendPaths(adjMat, dim, paths, maxLen, distMat);
   }
   res[maxLen] = paths;
 
@@ -440,7 +443,7 @@ PATH_LIST findUniqueSubgraphsOfLengthN(const ROMol &mol, unsigned int targetLen,
 INT_PATH_LIST_MAP
 findAllPathsOfLengthsMtoN(const ROMol &mol, unsigned int lowerLen,
                           unsigned int upperLen, bool useBonds, bool useHs,
-                          int rootedAtAtom) {
+                          int rootedAtAtom, bool onlyShortestPaths) {
   //
   //  We can't be clever here and just use the bond adjacency matrix
   //  to solve this problem when useBonds is true.  This is because
@@ -452,20 +455,37 @@ findAllPathsOfLengthsMtoN(const ROMol &mol, unsigned int lowerLen,
   //
   PRECONDITION(lowerLen <= upperLen, "");
 
+  double *distMat = nullptr;
+  if (onlyShortestPaths) {
+    // the molecule owns this pointer
+    distMat = MolOps::getDistanceMat(mol);
+  }
   int *adjMat, dim;
   dim = mol.getNumAtoms();
   adjMat = new int[dim * dim];
   memset((void *)adjMat, 0, dim * dim * sizeof(int));
 
-  // generate the adjacency matrix by hand by looping over the bonds
-  ROMol::ConstBondIterator bondIt;
-  for (bondIt = mol.beginBonds(); bondIt != mol.endBonds(); bondIt++) {
-    Atom *beg = (*bondIt)->getBeginAtom();
-    Atom *end = (*bondIt)->getEndAtom();
-    // check for H, which we might be skipping
-    if (useHs || (beg->getAtomicNum() != 1 && end->getAtomicNum() != 1)) {
-      adjMat[beg->getIdx() * dim + end->getIdx()] = 1;
-      adjMat[end->getIdx() * dim + beg->getIdx()] = 1;
+  if (!distMat) {
+    // generate the adjacency matrix by hand by looping over the bonds
+    ROMol::ConstBondIterator bondIt;
+    for (bondIt = mol.beginBonds(); bondIt != mol.endBonds(); bondIt++) {
+      Atom *beg = (*bondIt)->getBeginAtom();
+      Atom *end = (*bondIt)->getEndAtom();
+      // check for H, which we might be skipping
+      if (useHs || (beg->getAtomicNum() != 1 && end->getAtomicNum() != 1)) {
+        adjMat[beg->getIdx() * dim + end->getIdx()] = 1;
+        adjMat[end->getIdx() * dim + beg->getIdx()] = 1;
+      }
+    }
+  } else {
+    // if we have the distance matrix, we can just loop over that:
+    for (auto i = 0; i < dim; ++i) {
+      for (auto j = i + 1; j < dim; ++j) {
+        if (fabs(distMat[i * dim + j] - 1) < 1e-4) {
+          adjMat[i * dim + j] = 1;
+          adjMat[j * dim + i] = 1;
+        }
+      }
     }
   }
 
@@ -478,7 +498,7 @@ findAllPathsOfLengthsMtoN(const ROMol &mol, unsigned int lowerLen,
 
   // find the paths themselves
   INT_PATH_LIST_MAP atomPaths = Subgraphs::pathFinderHelper(
-      adjMat, dim, lowerLen, upperLen, rootedAtAtom);
+      adjMat, dim, lowerLen, upperLen, rootedAtAtom, distMat);
 
   // clean up the adjacency matrix
   delete[] adjMat;
@@ -533,9 +553,9 @@ findAllPathsOfLengthsMtoN(const ROMol &mol, unsigned int lowerLen,
 }
 PATH_LIST
 findAllPathsOfLengthN(const ROMol &mol, unsigned int targetLen, bool useBonds,
-                      bool useHs, int rootedAtAtom) {
+                      bool useHs, int rootedAtAtom, bool onlyShortestPaths) {
   return findAllPathsOfLengthsMtoN(mol, targetLen, targetLen, useBonds, useHs,
-                                   rootedAtAtom)[targetLen];
+                                   rootedAtAtom, onlyShortestPaths)[targetLen];
 }
 
 PATH_TYPE findAtomEnvironmentOfRadiusN(

--- a/Code/GraphMol/Subgraphs/Subgraphs.h
+++ b/Code/GraphMol/Subgraphs/Subgraphs.h
@@ -115,17 +115,19 @@ RDKIT_SUBGRAPHS_EXPORT PATH_LIST findUniqueSubgraphsOfLengthN(
  *                      Hs to the graph.
  *   \param rootedAtAtom - if non-negative, only subgraphs that start at
  *                         this atom will be returned.
+ *   \param onlyShortestPaths - if set then only paths which are <= the shortest
+ *                              path between the begin and end atoms will be
+ *                              included in the results
  *
  *   The result is a list of paths (i.e. list of list of bond indices)
  */
-RDKIT_SUBGRAPHS_EXPORT PATH_LIST findAllPathsOfLengthN(const ROMol &mol,
-                                                       unsigned int targetLen,
-                                                       bool useBonds = true,
-                                                       bool useHs = false,
-                                                       int rootedAtAtom = -1);
+RDKIT_SUBGRAPHS_EXPORT PATH_LIST findAllPathsOfLengthN(
+    const ROMol &mol, unsigned int targetLen, bool useBonds = true,
+    bool useHs = false, int rootedAtAtom = -1, bool onlyShortestPaths = false);
 RDKIT_SUBGRAPHS_EXPORT INT_PATH_LIST_MAP findAllPathsOfLengthsMtoN(
     const ROMol &mol, unsigned int lowerLen, unsigned int upperLen,
-    bool useBonds = true, bool useHs = false, int rootedAtAtom = -1);
+    bool useBonds = true, bool useHs = false, int rootedAtAtom = -1, 
+    bool onlyShortestPaths = false);
 
 //! \brief Find bond subgraphs of a particular radius around an atom.
 //!        Return empty result if there is no bond at the requested radius.
@@ -146,8 +148,8 @@ RDKIT_SUBGRAPHS_EXPORT INT_PATH_LIST_MAP findAllPathsOfLengthsMtoN(
  */
 RDKIT_SUBGRAPHS_EXPORT PATH_TYPE findAtomEnvironmentOfRadiusN(
     const ROMol &mol, unsigned int radius, unsigned int rootedAtAtom,
-    bool useHs=false, bool enforceSize=true,
-    std::unordered_map<unsigned int, unsigned int> *atomMap=nullptr);
+    bool useHs = false, bool enforceSize = true,
+    std::unordered_map<unsigned int, unsigned int> *atomMap = nullptr);
 
 }  // namespace RDKit
 

--- a/Code/GraphMol/Subgraphs/catch_tests.cpp
+++ b/Code/GraphMol/Subgraphs/catch_tests.cpp
@@ -1,0 +1,61 @@
+//
+//  Copyright (C) 2023 Greg Landrum
+//
+//   @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
+//
+#include "catch.hpp"
+#include <RDGeneral/test.h>
+#include <GraphMol/RDKitBase.h>
+#include <GraphMol/SmilesParse/SmilesParse.h>
+#include <GraphMol/Subgraphs/Subgraphs.h>
+#include <GraphMol/Subgraphs/SubgraphUtils.h>
+
+#include <iostream>
+#include <algorithm>
+
+using namespace RDKit;
+
+TEST_CASE("shortestPathsOnly") {
+  SECTION("basics, findAllPathsOfLengthN") {
+    auto m = "CC1CCC1"_smiles;
+    REQUIRE(m);
+    bool useBonds = true;
+    bool useHs = false;
+    int rootedAt = -1;
+    bool onlyShortestPaths = true;
+    auto ps = findAllPathsOfLengthN(*m, 4);
+    CHECK(ps.size() == 3);
+
+    ps = findAllPathsOfLengthN(*m, 4, useBonds, useHs, rootedAt,
+                               onlyShortestPaths);
+    CHECK(ps.empty());
+
+    ps = findAllPathsOfLengthN(*m, 3);
+    CHECK(ps.size() == 6);
+    std::cerr << "---------" << std::endl;
+    ps = findAllPathsOfLengthN(*m, 3, useBonds, useHs, rootedAt,
+                               onlyShortestPaths);
+    CHECK(ps.size() == 2);
+  }
+  SECTION("basics, findAllPathsOfLengthsMtoN") {
+    auto m = "CC1CCC1"_smiles;
+    REQUIRE(m);
+    bool useBonds = true;
+    bool useHs = false;
+    int rootedAt = -1;
+    bool onlyShortestPaths = true;
+    auto ps = findAllPathsOfLengthsMtoN(*m, 3, 4);
+    CHECK(ps.size() == 2);
+    CHECK(ps[3].size() == 6);
+    CHECK(ps[4].size() == 3);
+
+    ps = findAllPathsOfLengthsMtoN(*m, 3, 4, useBonds, useHs, rootedAt,
+                                   onlyShortestPaths);
+    CHECK(ps.size() == 1);
+    CHECK(ps[3].size() == 2);
+  }
+}

--- a/Code/GraphMol/Wrap/MolOps.cpp
+++ b/Code/GraphMol/Wrap/MolOps.cpp
@@ -1748,6 +1748,9 @@ to the terminal dummy atoms.\n\
     - rootedAtAtom: (optional) if nonzero, only paths from the specified\n\
       atom will be returned.\n\
 \n\
+    - onlyShortestPaths: (optional) if set then only paths which are <= the shortest\n\
+      path between the begin and end atoms will be included in the results\n\
+\n\
   RETURNS: a tuple of tuples with IDs for the bonds.\n\
 \n\
   NOTES: \n\
@@ -1769,7 +1772,8 @@ to the terminal dummy atoms.\n\
     python::def("FindAllPathsOfLengthN", &findAllPathsOfLengthN,
                 (python::arg("mol"), python::arg("length"),
                  python::arg("useBonds") = true, python::arg("useHs") = false,
-                 python::arg("rootedAtAtom") = -1),
+                 python::arg("rootedAtAtom") = -1,
+                 python::arg("onlyShortestPaths") = false),
                 docString.c_str());
 
     // ------------------------------------------------------------------------


### PR DESCRIPTION
@gedeck pointed out that the topological torsion fingerprints can set bits corresponding to paths which do not correspond to the shortest path between the start and end atom. This PR adds an option to the `TopologicalTorsionGenerator` to only set bits for shortest paths.

This also adds a similar option to `findAllPathsOfLengthN()` and `findAllPathsOfLengthsMtoN()`, both of which are used by the topological torsion code.

The new options are disabled by default, so there is no backwards incompatibility.

Usage from Python:
```
    g = rdFingerprintGenerator.GetTopologicalTorsionGenerator()
    g.GetOptions().onlyShortestPaths = True
```

