### PR TITLE
Fixes #6100

### DIFF
--- a/Code/GraphMol/MolOps.cpp
+++ b/Code/GraphMol/MolOps.cpp
@@ -189,9 +189,9 @@ void metalBondCleanup(RWMol &mol, Atom *atom) {
 
   auto isMetal = [](const Atom *a) -> bool {
     // This is the list of not metal atoms from QueryOps.cpp
-    static const std::set<int> notMetals{1,  2,  5,  6,  7,  8,  9,  10,
-                                         14, 15, 16, 17, 18, 33, 34, 35,
-                                         36, 52, 53, 54, 85, 86};
+    static const std::set<int> notMetals{0,  1,  2,  5,  6,  7,  8,  9,
+                                         10, 14, 15, 16, 17, 18, 33, 34,
+                                         35, 36, 52, 53, 54, 85, 86};
     return (notMetals.find(a->getAtomicNum()) == notMetals.end());
   };
   auto noDative = [](const Atom *a) -> bool {

--- a/Code/GraphMol/catch_graphmol.cpp
+++ b/Code/GraphMol/catch_graphmol.cpp
@@ -2966,6 +2966,5 @@ TEST_CASE("github #6100: bonds to dummy atoms considered as dative") {
   SECTION("as reported") {
     auto m = "C[O](C)*"_smiles;
     REQUIRE(!m);
-    // CHECK(m->getBondWithIdx(2)->getBondType() == Bond::BondType::SINGLE);
   }
 }

--- a/Code/GraphMol/catch_graphmol.cpp
+++ b/Code/GraphMol/catch_graphmol.cpp
@@ -2961,3 +2961,11 @@ TEST_CASE("molecules with single bond to metal atom use dative instead") {
     TEST_ASSERT(MolToSmiles(*m) == test_vals[i].second);
   }
 }
+
+TEST_CASE("github #6100: bonds to dummy atoms considered as dative") {
+  SECTION("as reported") {
+    auto m = "C[O](C)*"_smiles;
+    REQUIRE(!m);
+    // CHECK(m->getBondWithIdx(2)->getBondType() == Bond::BondType::SINGLE);
+  }
+}


### PR DESCRIPTION
A simple fix.
We should think about (though not as part of this PR) also modifying the definition of the M atom query in QueryOps.cpp to excludes dummies: https://github.com/rdkit/rdkit/blob/1e1ff0b08406c1a6164ceb21d4a23d1d98dc7fa3/Code/GraphMol/QueryOps.cpp#L477
