### PR TITLE
A few SWIG tweaks

### DIFF
--- a/Code/JavaWrappers/Conformer.i
+++ b/Code/JavaWrappers/Conformer.i
@@ -37,6 +37,11 @@
 #include <Geometry/point.h>
 %}
 
+// no point in wrapping something that can't be accessed
+// getAtomPos() and setAtomPos() are convenient accessors
+%ignore RDKit::Conformer::getPositions();
+%ignore RDKit::Conformer::getPositions() const;
+
 %typemap(javacode) RDKit::Conformer %{
   public void setSwigCMemOwn(boolean cMemoryOwn) {
     swigCMemOwn = cMemoryOwn;

--- a/Code/JavaWrappers/MolDraw2D.i
+++ b/Code/JavaWrappers/MolDraw2D.i
@@ -53,13 +53,15 @@
 %template(Int_String_Map) std::map< int, std::string >;
 
 %template(ColourPalette) std::map< int, RDKit::DrawColour >;
+%template(Colour_Vect) std::vector< RDKit::DrawColour >;
+%template(MultipleColourPalette) std::map< int, std::vector< RDKit::DrawColour > >;
 
 %template(Int_Double_Map) std::map< int, double >;
 %template(Float_Pair) std::pair<float,float>;
 %template(Float_Pair_Vect) std::vector< std::pair<float,float> >;
 %template(ROMol_Ptr_Vect) std::vector<RDKit::ROMol*>;
-%template(Point2D_Vect) std::vector<RDGeom::Point2D *>;
 %template(ColourPalette_Vect) std::vector< std::map< int, RDKit::DrawColour > >;
+%template(Int_Double_Map_Vect) std::vector< std::map< int, double > >;
 
 %ignore RDKit::MolDraw2DSVG::MolDraw2DSVG(int,int,std::ostream &);
 %ignore RDKit::MolDraw2DUtils::contourAndDrawGaussians(


### PR DESCRIPTION
- wrap types that are otherwise not accessible from SWIG wrappers
- remove redundant `Point2D_Vect` definition (already defined in `Code/JavaWrappers/*/GraphMol*.`i)
- blacklist `Conformer::getPositions()` whose return type is not accessible from SWIG (and is anyway not necessary since `Conformer::getAtomPos()` and `Conformer::setAtomPos()` serve the same purpose just fine)
