### PR TITLE
Github6112

### DIFF
--- a/Code/GraphMol/MolDraw2D/MolDraw2DUtils.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DUtils.cpp
@@ -439,23 +439,19 @@ void drawMolACS1996(MolDraw2D &drawer, const ROMol &mol,
         << std::endl;
   }
   double meanBondLen = 1.0;
-  const ROMol *draw_mol = nullptr;
   if (drawer.drawOptions().prepareMolsBeforeDrawing &&
       not mol.getNumConformers()) {
-    // compute 2D coordinates in a standard orientation.  Taking a pointer
-    // to the copy and drawing that means there won't be another 2D coord
-    // calculation in drawMolecule.
+    // compute 2D coordinates in a standard orientation.  This needs to be
+    // done on a copy because mol is const.
     const bool canonOrient = true;
     RWMol cpy(mol);
     RDDepict::compute2DCoords(cpy, nullptr, canonOrient);
     meanBondLen = MolDraw2DUtils::meanBondLength(cpy, confId);
-    draw_mol = &cpy;
   } else {
     meanBondLen = MolDraw2DUtils::meanBondLength(mol, confId);
-    draw_mol = &mol;
   }
   setACS1996Options(drawer.drawOptions(), meanBondLen);
-  drawer.drawMolecule(*draw_mol, legend, highlight_atoms, highlight_bonds,
+  drawer.drawMolecule(mol, legend, highlight_atoms, highlight_bonds,
                       highlight_atom_map, highlight_bond_map, highlight_radii,
                       confId);
 }

--- a/Code/GraphMol/MolDraw2D/MolDraw2DUtils.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DUtils.cpp
@@ -439,19 +439,23 @@ void drawMolACS1996(MolDraw2D &drawer, const ROMol &mol,
         << std::endl;
   }
   double meanBondLen = 1.0;
+  const ROMol *draw_mol = nullptr;
   if (drawer.drawOptions().prepareMolsBeforeDrawing &&
       not mol.getNumConformers()) {
-    // compute 2D coordinates in a standard orientation.  This needs to be
-    // done on a copy because mol is const.
+    // compute 2D coordinates in a standard orientation.  Taking a pointer
+    // to the copy and drawing that means there won't be another 2D coord
+    // calculation in drawMolecule.
     const bool canonOrient = true;
     RWMol cpy(mol);
     RDDepict::compute2DCoords(cpy, nullptr, canonOrient);
     meanBondLen = MolDraw2DUtils::meanBondLength(cpy, confId);
+    draw_mol = &cpy;
   } else {
     meanBondLen = MolDraw2DUtils::meanBondLength(mol, confId);
+    draw_mol = &mol;
   }
   setACS1996Options(drawer.drawOptions(), meanBondLen);
-  drawer.drawMolecule(mol, legend, highlight_atoms, highlight_bonds,
+  drawer.drawMolecule(*draw_mol, legend, highlight_atoms, highlight_bonds,
                       highlight_atom_map, highlight_bond_map, highlight_radii,
                       confId);
 }

--- a/Code/GraphMol/MolDraw2D/MolDraw2DUtils.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DUtils.cpp
@@ -438,7 +438,18 @@ void drawMolACS1996(MolDraw2D &drawer, const ROMol &mol,
         << " and that may not look great with a pre-determined size."
         << std::endl;
   }
-  double meanBondLen = MolDraw2DUtils::meanBondLength(mol, confId);
+  double meanBondLen = 1.0;
+  if (drawer.drawOptions().prepareMolsBeforeDrawing &&
+      not mol.getNumConformers()) {
+    // compute 2D coordinates in a standard orientation.  This needs to be
+    // done on a copy because mol is const.
+    const bool canonOrient = true;
+    RWMol cpy(mol);
+    RDDepict::compute2DCoords(cpy, nullptr, canonOrient);
+    meanBondLen = MolDraw2DUtils::meanBondLength(cpy, confId);
+  } else {
+    meanBondLen = MolDraw2DUtils::meanBondLength(mol, confId);
+  }
   setACS1996Options(drawer.drawOptions(), meanBondLen);
   drawer.drawMolecule(mol, legend, highlight_atoms, highlight_bonds,
                       highlight_atom_map, highlight_bond_map, highlight_radii,

--- a/Code/GraphMol/MolDraw2D/MolDraw2DUtils.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DUtils.cpp
@@ -438,6 +438,13 @@ void drawMolACS1996(MolDraw2D &drawer, const ROMol &mol,
         << " and that may not look great with a pre-determined size."
         << std::endl;
   }
+  auto setAndGo = [&](const ROMol &theMol) -> void {
+    auto meanBondLen = MolDraw2DUtils::meanBondLength(theMol, confId);
+    setACS1996Options(drawer.drawOptions(), meanBondLen);
+    drawer.drawMolecule(theMol, legend, highlight_atoms, highlight_bonds,
+                        highlight_atom_map, highlight_bond_map, highlight_radii,
+                        confId);
+  };
   double meanBondLen = 1.0;
   if (drawer.drawOptions().prepareMolsBeforeDrawing &&
       !mol.getNumConformers()) {
@@ -446,14 +453,11 @@ void drawMolACS1996(MolDraw2D &drawer, const ROMol &mol,
     const bool canonOrient = true;
     RWMol cpy(mol);
     RDDepict::compute2DCoords(cpy, nullptr, canonOrient);
-    meanBondLen = MolDraw2DUtils::meanBondLength(cpy, confId);
+    setAndGo(cpy);
   } else {
     meanBondLen = MolDraw2DUtils::meanBondLength(mol, confId);
+    setAndGo(mol);
   }
-  setACS1996Options(drawer.drawOptions(), meanBondLen);
-  drawer.drawMolecule(mol, legend, highlight_atoms, highlight_bonds,
-                      highlight_atom_map, highlight_bond_map, highlight_radii,
-                      confId);
 }
 
 // ****************************************************************************

--- a/Code/GraphMol/MolDraw2D/MolDraw2DUtils.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DUtils.cpp
@@ -440,7 +440,7 @@ void drawMolACS1996(MolDraw2D &drawer, const ROMol &mol,
   }
   double meanBondLen = 1.0;
   if (drawer.drawOptions().prepareMolsBeforeDrawing &&
-      not mol.getNumConformers()) {
+      !mol.getNumConformers()) {
     // compute 2D coordinates in a standard orientation.  This needs to be
     // done on a copy because mol is const.
     const bool canonOrient = true;

--- a/Code/GraphMol/MolDraw2D/MolDraw2DUtils.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DUtils.cpp
@@ -446,8 +446,7 @@ void drawMolACS1996(MolDraw2D &drawer, const ROMol &mol,
                         confId);
   };
   double meanBondLen = 1.0;
-  if (drawer.drawOptions().prepareMolsBeforeDrawing &&
-      !mol.getNumConformers()) {
+  if (!mol.getNumConformers()) {
     // compute 2D coordinates in a standard orientation.  This needs to be
     // done on a copy because mol is const.
     const bool canonOrient = true;
@@ -455,7 +454,6 @@ void drawMolACS1996(MolDraw2D &drawer, const ROMol &mol,
     RDDepict::compute2DCoords(cpy, nullptr, canonOrient);
     setAndGo(cpy);
   } else {
-    meanBondLen = MolDraw2DUtils::meanBondLength(mol, confId);
     setAndGo(mol);
   }
 }

--- a/Code/GraphMol/MolDraw2D/catch_tests.cpp
+++ b/Code/GraphMol/MolDraw2D/catch_tests.cpp
@@ -282,7 +282,9 @@ static const std::map<std::string, std::hash_result_t> SVG_HASHES = {
     {"test_complex_query_atoms_14.svg", 3566661047U},
     {"test_complex_query_atoms_15.svg", 4188921077U},
     {"test_complex_query_atoms_16.svg", 1980695915U},
-    {"test_github6041b.svg", 3485054881U}};
+    {"test_github6041b.svg", 3485054881U},
+    {"test_github6112.svg", 908847383U},
+};
 
 // These PNG hashes aren't completely reliable due to floating point cruft,
 // but they can still reduce the number of drawings that need visual
@@ -7223,6 +7225,12 @@ TEST_CASE("ACS1996 should not throw exception with no coords - Github 6112") {
   m->setProp<std::string>("_Name", "mol1");
   REQUIRE(m);
   MolDraw2DSVG drawer(-1, -1);
-  CHECK_NOTHROW(
-      MolDraw2DUtils::drawMolACS1996(drawer, *m, "Mol 1", nullptr, nullptr));
+  MolDraw2DUtils::drawMolACS1996(drawer, *m, "Mol 1", nullptr, nullptr);
+  drawer.finishDrawing();
+  std::string text = drawer.getDrawingText();
+  std::ofstream outs(nameBase + ".svg");
+  outs << text;
+  outs.flush();
+  outs.close();
+  check_file_hash(nameBase + ".svg");
 }

--- a/Code/GraphMol/MolDraw2D/catch_tests.cpp
+++ b/Code/GraphMol/MolDraw2D/catch_tests.cpp
@@ -7216,3 +7216,13 @@ M  END
     }
   }
 }
+
+TEST_CASE("ACS1996 should not throw exception with no coords - Github 6112") {
+  std::string nameBase = "test_github6112";
+  auto m = "C[C@H](I)CC(Cl)C[C@@H](F)C"_smiles;
+  m->setProp<std::string>("_Name", "mol1");
+  REQUIRE(m);
+  MolDraw2DSVG drawer(-1, -1);
+  CHECK_NOTHROW(
+      MolDraw2DUtils::drawMolACS1996(drawer, *m, "Mol 1", nullptr, nullptr));
+}


### PR DESCRIPTION

#### Reference Issue
Fixes issue 6112.


#### What does this implement/fix? Explain your changes.
If the 2D molecule comes into drawMolACS1996 without coords, it threw an exception as it tried to compute the mean bond length, required in the ACS setup.  It now generates for this purpose.

#### Any other comments?

