### PR TITLE
Fix small ACS1996 drawing being cropped.

### DIFF
--- a/Code/GraphMol/MolDraw2D/DrawMol.cpp
+++ b/Code/GraphMol/MolDraw2D/DrawMol.cpp
@@ -125,6 +125,22 @@ void DrawMol::createDrawObjects() {
       ignoreFontLimits) {
     // in either of these cases, the relative font size isn't what we were
     // expecting, so we need to rebuild everything.
+
+    // furthermore, if it's a fully flexible canvas and the font scale is
+    // greater than the global scale, there's a possibility that the
+    // characters might go off the sides of the canvas (Github6111)
+    if (flexiCanvasX_ && flexiCanvasY_ && (fontScale_ - scale_) > 1e-4) {
+      width_ = -1;
+      height_ = -1;
+      auto currScale = textDrawer_.fontScale();
+      auto relScale = fontScale_ / scale_;
+      resetEverything();
+      fontScale_ = relScale;
+      textDrawer_.setFontScale(relScale, true);
+      extractAll(scale_);
+      calculateScale();
+      textDrawer_.setFontScale(currScale, true);
+    }
     setScale(scale_, textDrawer_.fontScale(), ignoreFontLimits);
   } else {
     finishCreateDrawObjects();

--- a/Code/GraphMol/MolDraw2D/DrawMol.cpp
+++ b/Code/GraphMol/MolDraw2D/DrawMol.cpp
@@ -127,8 +127,9 @@ void DrawMol::createDrawObjects() {
     // expecting, so we need to rebuild everything.
 
     // furthermore, if it's a fully flexible canvas and the font scale is
-    // greater than the global scale, there's a possibility that the
-    // characters might go off the sides of the canvas (Github6111)
+    // greater than the global scale, if there are characters at the edge
+    // of the image, the canvas won't be big enough (Github6111). Rebuild
+    // with an appropriate relative font size.
     if (flexiCanvasX_ && flexiCanvasY_ && (fontScale_ - scale_) > 1e-4) {
       width_ = -1;
       height_ = -1;

--- a/Code/GraphMol/MolDraw2D/catch_tests.cpp
+++ b/Code/GraphMol/MolDraw2D/catch_tests.cpp
@@ -226,15 +226,15 @@ static const std::map<std::string, std::hash_result_t> SVG_HASHES = {
     {"github5383_1.svg", 2353351393U},
     {"acs1996_1.svg", 51426601U},
     {"acs1996_2.svg", 833573044U},
-    {"acs1996_3.svg", 4007912653U},
-    {"acs1996_4.svg", 3372558370U},
+    {"acs1996_3.svg", 580751118U},
+    {"acs1996_4.svg", 1695920511U},
     {"acs1996_5.svg", 2883542240U},
     {"acs1996_6.svg", 1380727178U},
     {"acs1996_7.svg", 2718384395U},
     {"acs1996_8.svg", 939325262U},
     {"acs1996_9.svg", 2607143500U},
     {"acs1996_10.svg", 199499735U},
-    {"acs1996_11.svg", 3821838912U},
+    {"acs1996_11.svg", 2028939343U},
     {"acs1996_12.svg", 2233727631U},
     {"test_unspec_stereo.svg", 599119798U},
     {"light_blue_h_no_label_1.svg", 3735371135U},
@@ -245,7 +245,7 @@ static const std::map<std::string, std::hash_result_t> SVG_HASHES = {
     {"bond_highlights_4.svg", 2068128924U},
     {"bond_highlights_5.svg", 4115973245U},
     {"bond_highlights_6.svg", 1566801788U},
-    {"bond_highlights_7.svg", 2101261688U},
+    {"bond_highlights_7.svg", 3347700584U},
     {"bond_highlights_8.svg", 3826056528U},
     {"bond_highlights_9.svg", 2915809284U},
     {"testGithub5486_1.svg", 1149144091U},
@@ -282,7 +282,8 @@ static const std::map<std::string, std::hash_result_t> SVG_HASHES = {
     {"test_complex_query_atoms_14.svg", 3566661047U},
     {"test_complex_query_atoms_15.svg", 4188921077U},
     {"test_complex_query_atoms_16.svg", 1980695915U},
-    {"test_github6041b.svg", 3485054881U}};
+    {"test_github6041b.svg", 3485054881U},
+    {"test_github6111_1.svg", 3458417163U}};
 
 // These PNG hashes aren't completely reliable due to floating point cruft,
 // but they can still reduce the number of drawings that need visual
@@ -7214,5 +7215,40 @@ M  END
       CHECK(extractQueryAtomSymbol(text) == "MH");
       check_file_hash(nameBase + "_16.svg");
     }
+  }
+}
+
+TEST_CASE("ACS1996 mode crops small molecules - Github 6111") {
+  std::string nameBase = "test_github6111";
+  {
+    auto m = "[*:1]N[*:2]"_smiles;
+    RDDepict::compute2DCoords(*m);
+    m->setProp<std::string>("_Name", "mol1");
+    REQUIRE(m);
+    MolDraw2DSVG drawer(-1, -1);
+    MolDraw2DUtils::drawMolACS1996(drawer, *m, "", nullptr, nullptr);
+    drawer.finishDrawing();
+    std::string text = drawer.getDrawingText();
+    std::ofstream outs(nameBase + "_1.svg");
+    outs << text;
+    outs.flush();
+    outs.close();
+
+    // check that selected y coords don't go outside of the viewBox.
+    std::regex vbox(R"(viewBox='(\d+)\s+(\d+)\s+(\d+)\s+(\d+)'>)");
+    auto match1_begin = std::sregex_iterator(text.begin(), text.end(), vbox);
+    std::smatch match = *match1_begin;
+    auto ymin = std::stod(match[2]);
+    auto ymax = std::stod(match[4]);
+
+    std::regex atom0(R"(class='atom-\d+' d='M\s+(\d+\.\d+)\s+(\d+\.\d+))");
+    auto match2_begin = std::sregex_iterator(text.begin(), text.end(), atom0);
+    auto match2_end = std::sregex_iterator();
+    for (std::sregex_iterator i = match2_begin; i != match2_end; ++i) {
+      std::smatch match = *i;
+      auto y = std::stod(match[2]);
+      CHECK((y >= ymin && y <= ymax));
+    }
+    check_file_hash(nameBase + "_1.svg");
   }
 }


### PR DESCRIPTION

#### Reference Issue
Fixes #6111


#### What does this implement/fix? Explain your changes.
When drawing into a flexi canvas in ACS1996 mode, if there is a character on the edge of the drawing, the canvas isn't big enough.

#### Any other comments?

