### PR TITLE
Stereochemistry-related SWIG updates

### DIFF
--- a/Code/JavaWrappers/ROMol.i
+++ b/Code/JavaWrappers/ROMol.i
@@ -163,10 +163,18 @@ bool getUseLegacyStereoPerception() {
 void setUseLegacyStereoPerception(bool val) {
   RDKit::Chirality::setUseLegacyStereoPerception(val);
 }
+bool getAllowNontetrahedralChirality() {
+  return RDKit::Chirality::getAllowNontetrahedralChirality();
+}
+void setAllowNontetrahedralChirality(bool val) {
+  RDKit::Chirality::setAllowNontetrahedralChirality(val);
+}
 %}
 
 bool getUseLegacyStereoPerception();
 void setUseLegacyStereoPerception(bool);
+bool getAllowNontetrahedralChirality();
+void setAllowNontetrahedralChirality(bool);
 
 %extend RDKit::ROMol {
   std::string getProp(const std::string key){

--- a/Code/JavaWrappers/ROMol.i
+++ b/Code/JavaWrappers/ROMol.i
@@ -64,6 +64,7 @@
 #include <GraphMol/PartialCharges/GasteigerCharges.h>
 #include <GraphMol/new_canon.h>
 #include <GraphMol/MolBundle.h>
+#include <GraphMol/Chirality.h>
 #include <sstream>
 %}
 
@@ -155,6 +156,18 @@ void setPreferCoordGen(bool val) {
 bool getPreferCoordGen();
 void setPreferCoordGen(bool);
 
+%{
+bool getUseLegacyStereoPerception() {
+  return RDKit::Chirality::getUseLegacyStereoPerception();
+}
+void setUseLegacyStereoPerception(bool val) {
+  RDKit::Chirality::setUseLegacyStereoPerception(val);
+}
+%}
+
+bool getUseLegacyStereoPerception();
+void setUseLegacyStereoPerception(bool);
+
 %extend RDKit::ROMol {
   std::string getProp(const std::string key){
     std::string res;
@@ -167,14 +180,18 @@ void setPreferCoordGen(bool);
     return self->addConformer(ownedConf, assignId);
   }
 
-  std::string MolToSmiles(bool doIsomericSmiles=false,bool doKekule=false, int rootedAtAtom=-1){
-    return RDKit::MolToSmiles(*($self),doIsomericSmiles,doKekule,rootedAtAtom);
+  std::string MolToSmiles(bool doIsomericSmiles=true, bool doKekule=false, int rootedAtAtom=-1, bool canonical=true,
+                          bool allBondsExplicit=false, bool allHsExplicit=false, bool doRandom=false) {
+    return RDKit::MolToSmiles(*($self), doIsomericSmiles, doKekule, rootedAtAtom, canonical, allBondsExplicit, allHsExplicit, doRandom);
   }
-  std::string MolToMolBlock(bool includeStereo=true, int confId=-1) {
-    return RDKit::MolToMolBlock(*($self),includeStereo,confId);
+  std::string MolToSmiles(const RDKit::SmilesWriteParams &params) {
+    return RDKit::MolToSmiles(*($self), params);
   }
-  void MolToMolFile(std::string fName,bool includeStereo=true, int confId=-1,bool kekulize=true) {
-    RDKit::MolToMolFile(*($self), fName, includeStereo, confId, kekulize);
+  std::string MolToMolBlock(bool includeStereo=true, int confId=-1, bool kekulize=true, bool forceV3000=false) {
+    return RDKit::MolToMolBlock(*($self), includeStereo, confId, kekulize, forceV3000);
+  }
+  void MolToMolFile(std::string fName,bool includeStereo=true, int confId=-1, bool kekulize=true, bool forceV3000=false) {
+    RDKit::MolToMolFile(*($self), fName, includeStereo, confId, kekulize, forceV3000);
   }
   std::string MolToTPLText(std::string partialChargeProp="_GasteigerCharge", bool writeFirstConfTwice=false) {
     return RDKit::MolToTPLText(*($self), partialChargeProp, writeFirstConfTwice);

--- a/Code/JavaWrappers/gmwrapper/src-test/org/RDKit/ChemReactionTests.java
+++ b/Code/JavaWrappers/gmwrapper/src-test/org/RDKit/ChemReactionTests.java
@@ -462,9 +462,9 @@ public class ChemReactionTests extends GraphMolTest {
           
           assertEquals( 1, prods0.size() );
           assertEquals( 1, prods0.get(0).size() );    
-          assertEquals( expected_result0.MolToSmiles(), prods0.get(0).get(0).MolToSmiles() );
-          assertEquals( expected_sidechain0.MolToSmiles(),
-                        ChemicalReaction.ReduceProductToSideChains(prods0.get(0).get(0)).MolToSmiles());
+          assertEquals( expected_result0.MolToSmiles(false), prods0.get(0).get(0).MolToSmiles(false) );
+          assertEquals( expected_sidechain0.MolToSmiles(false),
+                        ChemicalReaction.ReduceProductToSideChains(prods0.get(0).get(0)).MolToSmiles(false));
               
           ROMol_Vect_Vect prods1 = rxn.runReactant(reag2, 1);
           ROMol expected_result1 = RWMol.MolFromSmiles("NCNCc1ncc(Cl)cc1Br");
@@ -476,12 +476,12 @@ public class ChemReactionTests extends GraphMolTest {
           
           assertEquals( 1, prods1.size() );
           assertEquals( 1, prods1.get(0).size() );    
-          assertEquals( expected_result1.MolToSmiles(), prods1.get(0).get(0).MolToSmiles() );
-          assertEquals( expected_sidechain1.MolToSmiles(),
-                        ChemicalReaction.ReduceProductToSideChains(prods1.get(0).get(0)).MolToSmiles());
-          assertEquals( expected_sidechain1_nodummies.MolToSmiles(),
+          assertEquals( expected_result1.MolToSmiles(false), prods1.get(0).get(0).MolToSmiles(false) );
+          assertEquals( expected_sidechain1.MolToSmiles(false),
+                        ChemicalReaction.ReduceProductToSideChains(prods1.get(0).get(0)).MolToSmiles(false));
+          assertEquals( expected_sidechain1_nodummies.MolToSmiles(false),
                         ChemicalReaction.ReduceProductToSideChains(
-                            prods1.get(0).get(0),false).MolToSmiles());
+                            prods1.get(0).get(0),false).MolToSmiles(false));
           
           
         }

--- a/Code/JavaWrappers/gmwrapper/src-test/org/RDKit/Chemv2Tests.java
+++ b/Code/JavaWrappers/gmwrapper/src-test/org/RDKit/Chemv2Tests.java
@@ -623,6 +623,7 @@ public class Chemv2Tests extends GraphMolTest {
     @Test
     public void testStereoChemFunctions() {
         boolean useLegacyStereo = RDKFuncs.getUseLegacyStereoPerception();
+        boolean allowNonTetrahedralChirality = RDKFuncs.getAllowNontetrahedralChirality();
         try {
             RWMol m = RWMol.MolFromSmiles("CC(O)Cl |(-3.9163,5.4767,;-3.9163,3.9367,;-2.5826,3.1667,;-5.25,3.1667,),wU:1.0|");
             assertTrue(m != null);
@@ -659,8 +660,36 @@ public class Chemv2Tests extends GraphMolTest {
             m = RWMol.MolFromSmiles("O[C@@]1(C)C/C(/C1)=C(/C)\\CC");
             assertTrue(m != null);
             assertEquals(m.MolToSmiles(), "CC/C(C)=C1\\C[C@](C)(O)C1");
+            m.delete();
+            RDKFuncs.setUseLegacyStereoPerception(useLegacyStereo);
+            String ctab = "\n" +
+                "  Mrv2108 09132105183D          \n" +
+                "\n" +
+                "  5  4  0  0  0  0            999 V2000\n" +
+                "   -1.2500    1.4518    0.0000 Pt  0  0  0  0  0  0  0  0  0  0  0  0\n" +
+                "   -1.2500    2.2768    0.0000 F   0  0  0  0  0  0  0  0  0  0  0  0\n" +
+                "   -0.4250    1.4518    0.0000 Cl  0  0  0  0  0  0  0  0  0  0  0  0\n" +
+                "   -2.0750    1.4518    0.0000 F   0  0  0  0  0  0  0  0  0  0  0  0\n" +
+                "   -1.2500    0.6268    0.0000 Cl  0  0  0  0  0  0  0  0  0  0  0  0\n" +
+                "  1  2  1  0  0  0  0\n" +
+                "  1  3  1  0  0  0  0\n" +
+                "  1  4  1  0  0  0  0\n" +
+                "  1  5  1  0  0  0  0\n" +
+                "M  END\n";
+            RDKFuncs.setAllowNontetrahedralChirality(true);
+            m = RWMol.MolFromMolBlock(ctab);
+            assertTrue(m != null);
+            assertEquals(m.MolToSmiles(), "F[Pt@SP3](F)(Cl)Cl");
+            m.delete();
+            RDKFuncs.setAllowNontetrahedralChirality(false);
+            m = RWMol.MolFromMolBlock(ctab);
+            assertTrue(m != null);
+            assertEquals(m.MolToSmiles(), "F[Pt](F)(Cl)Cl");
+            m.delete();
+            RDKFuncs.setAllowNontetrahedralChirality(allowNonTetrahedralChirality);
         } finally {
             RDKFuncs.setUseLegacyStereoPerception(useLegacyStereo);
+            RDKFuncs.setAllowNontetrahedralChirality(allowNonTetrahedralChirality);
         }
     }
     

--- a/Code/JavaWrappers/gmwrapper/src-test/org/RDKit/Chemv2Tests.java
+++ b/Code/JavaWrappers/gmwrapper/src-test/org/RDKit/Chemv2Tests.java
@@ -622,31 +622,46 @@ public class Chemv2Tests extends GraphMolTest {
 
     @Test
     public void testStereoChemFunctions() {
-        RWMol m = RWMol.MolFromSmiles("CC(O)Cl |(-3.9163,5.4767,;-3.9163,3.9367,;-2.5826,3.1667,;-5.25,3.1667,),wU:1.0|");
-        assertTrue(m != null);
-        int bondcfg;
-        assertEquals(m.getBondWithIdx(0).getProp("_MolFileBondCfg"), "1");
-        assertEquals(m.getAtomWithIdx(1).getChiralTag(), Atom.ChiralType.CHI_TETRAHEDRAL_CW);
-        m = RWMol.MolFromSmiles("CC(O)Cl |(-3.9163,5.4767,;-3.9163,3.9367,;-2.5826,3.1667,;-5.25,3.1667,),wD:1.0|");
-        assertTrue(m != null);
-        assertEquals(m.getBondWithIdx(0).getProp("_MolFileBondCfg"), "3");
-        assertEquals(m.getAtomWithIdx(1).getChiralTag(), Atom.ChiralType.CHI_TETRAHEDRAL_CCW);
-        m.invertMolBlockWedgingInfo();
-        assertEquals(m.getBondWithIdx(0).getProp("_MolFileBondCfg"), "1");
-        m.reapplyMolBlockWedging();
-        RDKFuncs.assignChiralTypesFromBondDirs(m);
-        assertEquals(m.getAtomWithIdx(1).getChiralTag(), Atom.ChiralType.CHI_TETRAHEDRAL_CW);
-        m.invertMolBlockWedgingInfo();
-        assertEquals(m.getBondWithIdx(0).getProp("_MolFileBondCfg"), "3");
-        m.reapplyMolBlockWedging();
-        RDKFuncs.assignChiralTypesFromBondDirs(m);
-        assertEquals(m.getAtomWithIdx(1).getChiralTag(), Atom.ChiralType.CHI_TETRAHEDRAL_CCW);
-        m.clearMolBlockWedgingInfo();
-        m.getAtomWithIdx(1).setChiralTag(Atom.ChiralType.CHI_UNSPECIFIED);
-        assertFalse(m.getBondWithIdx(0).hasProp("_MolFileBondCfg"));
-        m.reapplyMolBlockWedging();
-        RDKFuncs.assignChiralTypesFromBondDirs(m);
-        assertEquals(m.getAtomWithIdx(1).getChiralTag(), Atom.ChiralType.CHI_UNSPECIFIED);
+        boolean useLegacyStereo = RDKFuncs.getUseLegacyStereoPerception();
+        try {
+            RWMol m = RWMol.MolFromSmiles("CC(O)Cl |(-3.9163,5.4767,;-3.9163,3.9367,;-2.5826,3.1667,;-5.25,3.1667,),wU:1.0|");
+            assertTrue(m != null);
+            assertEquals(m.getBondWithIdx(0).getProp("_MolFileBondCfg"), "1");
+            assertEquals(m.getAtomWithIdx(1).getChiralTag(), Atom.ChiralType.CHI_TETRAHEDRAL_CW);
+            m.delete();
+            m = RWMol.MolFromSmiles("CC(O)Cl |(-3.9163,5.4767,;-3.9163,3.9367,;-2.5826,3.1667,;-5.25,3.1667,),wD:1.0|");
+            assertTrue(m != null);
+            assertEquals(m.getBondWithIdx(0).getProp("_MolFileBondCfg"), "3");
+            assertEquals(m.getAtomWithIdx(1).getChiralTag(), Atom.ChiralType.CHI_TETRAHEDRAL_CCW);
+            m.invertMolBlockWedgingInfo();
+            assertEquals(m.getBondWithIdx(0).getProp("_MolFileBondCfg"), "1");
+            m.reapplyMolBlockWedging();
+            RDKFuncs.assignChiralTypesFromBondDirs(m);
+            assertEquals(m.getAtomWithIdx(1).getChiralTag(), Atom.ChiralType.CHI_TETRAHEDRAL_CW);
+            m.invertMolBlockWedgingInfo();
+            assertEquals(m.getBondWithIdx(0).getProp("_MolFileBondCfg"), "3");
+            m.reapplyMolBlockWedging();
+            RDKFuncs.assignChiralTypesFromBondDirs(m);
+            assertEquals(m.getAtomWithIdx(1).getChiralTag(), Atom.ChiralType.CHI_TETRAHEDRAL_CCW);
+            m.clearMolBlockWedgingInfo();
+            m.getAtomWithIdx(1).setChiralTag(Atom.ChiralType.CHI_UNSPECIFIED);
+            assertFalse(m.getBondWithIdx(0).hasProp("_MolFileBondCfg"));
+            m.reapplyMolBlockWedging();
+            RDKFuncs.assignChiralTypesFromBondDirs(m);
+            assertEquals(m.getAtomWithIdx(1).getChiralTag(), Atom.ChiralType.CHI_UNSPECIFIED);
+            m.delete();
+            RDKFuncs.setUseLegacyStereoPerception(true);
+            m = RWMol.MolFromSmiles("O[C@@]1(C)C/C(/C1)=C(/C)\\CC");
+            assertTrue(m != null);
+            assertEquals(m.MolToSmiles(), "CCC(C)=C1CC(C)(O)C1");
+            m.delete();
+            RDKFuncs.setUseLegacyStereoPerception(false);
+            m = RWMol.MolFromSmiles("O[C@@]1(C)C/C(/C1)=C(/C)\\CC");
+            assertTrue(m != null);
+            assertEquals(m.MolToSmiles(), "CC/C(C)=C1\\C[C@](C)(O)C1");
+        } finally {
+            RDKFuncs.setUseLegacyStereoPerception(useLegacyStereo);
+        }
     }
     
     public static void main(String args[]) {

--- a/Code/MinimalLib/cffi_test.c
+++ b/Code/MinimalLib/cffi_test.c
@@ -1791,6 +1791,68 @@ M  END\n", &tpkl_size, "");
   free(tpkl);
 }
 
+void test_use_legacy_stereo() {
+  printf("--------------------------\n");
+  printf("  test_use_legacy_stereo\n");
+  short orig_setting = use_legacy_stereo_perception(1);
+  char *mpkl;
+  size_t mpkl_size;
+  mpkl = get_mol("O[C@@]1(C)C/C(/C1)=C(/C)\\CC", &mpkl_size, "");
+  assert(mpkl);
+  assert(mpkl_size > 0);
+  char *smiles = get_smiles(mpkl, mpkl_size, NULL);
+  assert(!strcmp(smiles, "CCC(C)=C1CC(C)(O)C1"));
+  free(smiles);
+  free(mpkl);
+  use_legacy_stereo_perception(0);
+  mpkl = get_mol("O[C@@]1(C)C/C(/C1)=C(/C)\\CC", &mpkl_size, "");
+  assert(mpkl);
+  assert(mpkl_size > 0);
+  smiles = get_smiles(mpkl, mpkl_size, NULL);
+  assert(!strcmp(smiles, "CC/C(C)=C1\\C[C@](C)(O)C1"));
+  free(smiles);
+  free(mpkl);
+  use_legacy_stereo_perception(orig_setting);
+}
+
+void test_allow_non_tetrahedral_chirality() {
+  printf("--------------------------\n");
+  printf("  test_allow_non_tetrahedral_chirality\n");
+  char ctab[] = "\n\
+  Mrv2108 09132105183D          \n\
+\n\
+  5  4  0  0  0  0            999 V2000\n\
+   -1.2500    1.4518    0.0000 Pt  0  0  0  0  0  0  0  0  0  0  0  0\n\
+   -1.2500    2.2768    0.0000 F   0  0  0  0  0  0  0  0  0  0  0  0\n\
+   -0.4250    1.4518    0.0000 Cl  0  0  0  0  0  0  0  0  0  0  0  0\n\
+   -2.0750    1.4518    0.0000 F   0  0  0  0  0  0  0  0  0  0  0  0\n\
+   -1.2500    0.6268    0.0000 Cl  0  0  0  0  0  0  0  0  0  0  0  0\n\
+  1  2  1  0  0  0  0\n\
+  1  3  1  0  0  0  0\n\
+  1  4  1  0  0  0  0\n\
+  1  5  1  0  0  0  0\n\
+M  END\n";
+  short orig_setting = allow_non_tetrahedral_chirality(1);
+  char *mpkl;
+  size_t mpkl_size;
+  mpkl = get_mol(ctab, &mpkl_size, "");
+  assert(mpkl);
+  assert(mpkl_size > 0);
+  char *smiles = get_smiles(mpkl, mpkl_size, NULL);
+  assert(!strcmp(smiles, "F[Pt@SP3](F)(Cl)Cl"));
+  free(smiles);
+  free(mpkl);
+  allow_non_tetrahedral_chirality(0);
+  mpkl = get_mol(ctab, &mpkl_size, "");
+  assert(mpkl);
+  assert(mpkl_size > 0);
+  smiles = get_smiles(mpkl, mpkl_size, NULL);
+  assert(!strcmp(smiles, "F[Pt](F)(Cl)Cl"));
+  free(smiles);
+  free(mpkl);
+  allow_non_tetrahedral_chirality(orig_setting);
+}
+
 
 int main() {
   enable_logging();
@@ -1812,5 +1874,7 @@ int main() {
   test_wedging_all_within_scaffold();
   test_wedging_outside_scaffold();
   test_wedging_if_no_match();
+  test_use_legacy_stereo();
+  test_allow_non_tetrahedral_chirality();
   return 0;
 }

--- a/Code/MinimalLib/cffiwrapper.cpp
+++ b/Code/MinimalLib/cffiwrapper.cpp
@@ -36,6 +36,7 @@
 #include <GraphMol/DistGeomHelpers/Embedder.h>
 #include <GraphMol/ChemReactions/Reaction.h>
 #include <GraphMol/ChemReactions/ReactionPickler.h>
+#include <GraphMol/Chirality.h>
 #include <DataStructs/BitOps.h>
 
 #include "common.h"
@@ -795,6 +796,19 @@ extern "C" short fragment_parent(char **mol_pkl, size_t *mol_pkl_sz,
   return standardize_func(mol_pkl, mol_pkl_sz, details_json,
                           MinimalLib::do_fragment_parent);
 };
+
+// chirality
+extern "C" short use_legacy_stereo_perception(short value) {
+  short was = Chirality::getUseLegacyStereoPerception();
+  Chirality::setUseLegacyStereoPerception(value);
+  return was;
+}
+
+extern "C" short allow_non_tetrahedral_chirality(short value) {
+  short was = Chirality::getAllowNontetrahedralChirality();
+  Chirality::setAllowNontetrahedralChirality(value);
+  return was;
+}
 
 #if (defined(__GNUC__) || defined(__GNUG__))
 #pragma GCC diagnostic pop

--- a/Code/MinimalLib/cffiwrapper.h
+++ b/Code/MinimalLib/cffiwrapper.h
@@ -149,6 +149,10 @@ RDKIT_RDKITCFFI_EXPORT char *version();
 RDKIT_RDKITCFFI_EXPORT void enable_logging();
 RDKIT_RDKITCFFI_EXPORT void disable_logging();
 
+// chirality
+RDKIT_RDKITCFFI_EXPORT short use_legacy_stereo_perception(short value);
+RDKIT_RDKITCFFI_EXPORT short allow_non_tetrahedral_chirality(short value);
+
 #ifdef __cplusplus
 }
 #endif

--- a/Code/MinimalLib/jswrapper.cpp
+++ b/Code/MinimalLib/jswrapper.cpp
@@ -551,6 +551,7 @@ EMSCRIPTEN_BINDINGS(RDKit_minimal) {
   function("version", &version);
   function("prefer_coordgen", &prefer_coordgen);
   function("use_legacy_stereo_perception", &use_legacy_stereo_perception);
+  function("allow_non_tetrahedral_chirality", &allow_non_tetrahedral_chirality);
   function("get_inchikey_for_inchi", &get_inchikey_for_inchi);
   function("get_mol", &get_mol, allow_raw_pointers());
   function("get_mol", &get_mol_no_details, allow_raw_pointers());

--- a/Code/MinimalLib/minilib.cpp
+++ b/Code/MinimalLib/minilib.cpp
@@ -756,6 +756,14 @@ void prefer_coordgen(bool useCoordGen) {
 #endif
 }
 
-void use_legacy_stereo_perception(bool value) {
+bool use_legacy_stereo_perception(bool value) {
+  bool was = Chirality::getUseLegacyStereoPerception();
   Chirality::setUseLegacyStereoPerception(value);
+  return was;
+}
+
+bool allow_non_tetrahedral_chirality(bool value) {
+  bool was = Chirality::getAllowNontetrahedralChirality();
+  Chirality::setAllowNontetrahedralChirality(value);
+  return was;
 }

--- a/Code/MinimalLib/minilib.h
+++ b/Code/MinimalLib/minilib.h
@@ -227,4 +227,5 @@ JSMol *get_qmol(const std::string &input);
 JSReaction *get_rxn(const std::string &input, const std::string &details_json);
 std::string version();
 void prefer_coordgen(bool prefer);
-void use_legacy_stereo_perception(bool value);
+bool use_legacy_stereo_perception(bool value);
+bool allow_non_tetrahedral_chirality(bool value);

--- a/Code/MinimalLib/tests/tests.js
+++ b/Code/MinimalLib/tests/tests.js
@@ -972,15 +972,51 @@ M  END`);
 }
 
 function test_legacy_stereochem() {
-    RDKitModule.use_legacy_stereo_perception(true);
-    var mol = RDKitModule.get_mol("O[C@@]1(C)C/C(/C1)=C(/C)\\CC");
-    assert.equal(mol.is_valid(),1);
-    assert.equal(mol.get_smiles(),"CCC(C)=C1CC(C)(O)C1");
+    var origSetting;
+    try {
+        origSetting = RDKitModule.use_legacy_stereo_perception(true);
+        var mol = RDKitModule.get_mol("O[C@@]1(C)C/C(/C1)=C(/C)\\CC");
+        assert.equal(mol.is_valid(),1);
+        assert.equal(mol.get_smiles(),"CCC(C)=C1CC(C)(O)C1");
 
-    RDKitModule.use_legacy_stereo_perception(false);
-    mol = RDKitModule.get_mol("O[C@@]1(C)C/C(/C1)=C(/C)\\CC");
-    assert.equal(mol.is_valid(),1);
-    assert.equal(mol.get_smiles(),"CC/C(C)=C1\\C[C@](C)(O)C1");
+        RDKitModule.use_legacy_stereo_perception(false);
+        mol = RDKitModule.get_mol("O[C@@]1(C)C/C(/C1)=C(/C)\\CC");
+        assert.equal(mol.is_valid(),1);
+        assert.equal(mol.get_smiles(),"CC/C(C)=C1\\C[C@](C)(O)C1");
+    } finally {
+        RDKitModule.use_legacy_stereo_perception(origSetting);
+    }
+}
+
+function test_allow_non_tetrahedral_chirality() {
+    var ctab = `
+  Mrv2108 09132105183D          
+
+  5  4  0  0  0  0            999 V2000
+   -1.2500    1.4518    0.0000 Pt  0  0  0  0  0  0  0  0  0  0  0  0
+   -1.2500    2.2768    0.0000 F   0  0  0  0  0  0  0  0  0  0  0  0
+   -0.4250    1.4518    0.0000 Cl  0  0  0  0  0  0  0  0  0  0  0  0
+   -2.0750    1.4518    0.0000 F   0  0  0  0  0  0  0  0  0  0  0  0
+   -1.2500    0.6268    0.0000 Cl  0  0  0  0  0  0  0  0  0  0  0  0
+  1  2  1  0  0  0  0
+  1  3  1  0  0  0  0
+  1  4  1  0  0  0  0
+  1  5  1  0  0  0  0
+M  END
+`;
+    var origSetting;
+    try {
+        origSetting = RDKitModule.allow_non_tetrahedral_chirality(true);
+        var mol = RDKitModule.get_mol(ctab);
+        assert.equal(mol.is_valid(),1);
+        assert.equal(mol.get_smiles(), "F[Pt@SP3](F)(Cl)Cl");
+        RDKitModule.allow_non_tetrahedral_chirality(false);
+        var mol = RDKitModule.get_mol(ctab);
+        assert.equal(mol.is_valid(),1);
+        assert.equal(mol.get_smiles(), "F[Pt](F)(Cl)Cl");
+    } finally {
+        RDKitModule.allow_non_tetrahedral_chirality(origSetting);
+    }
 }
 
 function test_prop() {
@@ -1767,6 +1803,7 @@ initRDKitModule().then(function(instance) {
     test_flexicanvas();
     test_rxn_drawing();
     test_legacy_stereochem();
+    test_allow_non_tetrahedral_chirality();
     test_prop();
     test_highlights();
     test_add_chiral_hs();

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -9,6 +9,7 @@
 
 - The ring-finding functions will now run even if the molecule already has ring information. Older versions of the RDKit would return whatever ring information was present, even if it had been generated using a different algorithm.
 - The canonical SMILES and CXSMILES generated for molecules with enhanced stereochemistry (stereo groups) is different than in previous releases. The enhanced stereochemistry information and the stereo groups themselves are now canonical. This does *not* affect molecules which do not have enhanced stereo and will not have any effect if you generate non-isomeric SMILES. This change also affects the output of the MolHash and RegistrationHash code when applied to molecules with enhanced stereo.
+- The doIsomericSmiles parameter in Java and C# ROMol.MolToSmiles() now defaults to true (previously it was false), thus aligning to the C++ and Python behavior.
 
 ## Bug Fixes:
 


### PR DESCRIPTION
- expose `[sg]etUseLegacyStereo()`
- In `MolToSmiles()` `doIsomericSmiles` should default to `true` as in C++ and Python
- added missing parameters to `MolToSmiles()` and `MolToMolBlock()`
- added `SmilesWriteParams` `MolToSmiles()` overload
- added and updated Java tests
