### PR TITLE
MinimalLib: avoid that assignStereochemistry() fails when removeHs=true

### DIFF
--- a/Code/MinimalLib/cffi_test.c
+++ b/Code/MinimalLib/cffi_test.c
@@ -1791,6 +1791,18 @@ M  END\n", &tpkl_size, "");
   free(tpkl);
 }
 
+void test_removehs() {
+  printf("--------------------------\n");
+  printf("  test_removehs\n");
+  size_t mpkl_size;
+  char *mpkl = get_mol("N1C=CC(=O)c2ccc(N(C)(C)(C)(C)C)cc12", &mpkl_size, "{\"sanitize\":false,\"removeHs\":false}");
+  char *smi = get_smiles(mpkl, mpkl_size, "");
+  assert(mpkl);
+  assert(!strcmp(smi, "CN(C)(C)(C)(C)c1ccc2c(c1)NC=CC2=O"));
+  free(smi);
+  free(mpkl);
+}
+
 
 int main() {
   enable_logging();
@@ -1812,5 +1824,6 @@ int main() {
   test_wedging_all_within_scaffold();
   test_wedging_outside_scaffold();
   test_wedging_if_no_match();
+  test_removehs();
   return 0;
 }

--- a/Code/MinimalLib/common.h
+++ b/Code/MinimalLib/common.h
@@ -143,12 +143,15 @@ RWMol *mol_from_input(const std::string &input,
     unsigned int sanitizeOps = MolOps::SANITIZE_ADJUSTHS;
     try {
       if (sanitize) {
-        sanitizeOps = MolOps::SANITIZE_ALL;
+        unsigned int failedOp;
+        unsigned int sanitizeOps = MolOps::SANITIZE_ALL;
         if (!kekulize) {
           sanitizeOps ^= MolOps::SANITIZE_KEKULIZE;
         }
+        MolOps::sanitizeMol(*res, failedOp, sanitizeOps);
+      } else {
+        res->updatePropertyCache(false);
       }
-      MolOps::sanitizeMol(*res, failedOp, sanitizeOps);
       MolOps::assignStereochemistry(*res, true, true, true);
       if (mergeQueryHs) {
         MolOps::mergeQueryHs(*res);

--- a/Code/MinimalLib/common.h
+++ b/Code/MinimalLib/common.h
@@ -139,8 +139,6 @@ RWMol *mol_from_input(const std::string &input,
     res = nullptr;
   }
   if (res) {
-    unsigned int failedOp;
-    unsigned int sanitizeOps = MolOps::SANITIZE_ADJUSTHS;
     try {
       if (sanitize) {
         unsigned int failedOp;

--- a/Code/MinimalLib/common.h
+++ b/Code/MinimalLib/common.h
@@ -139,15 +139,16 @@ RWMol *mol_from_input(const std::string &input,
     res = nullptr;
   }
   if (res) {
+    unsigned int failedOp;
+    unsigned int sanitizeOps = MolOps::SANITIZE_ADJUSTHS;
     try {
       if (sanitize) {
-        unsigned int failedOp;
-        unsigned int sanitizeOps = MolOps::SANITIZE_ALL;
+        sanitizeOps = MolOps::SANITIZE_ALL;
         if (!kekulize) {
           sanitizeOps ^= MolOps::SANITIZE_KEKULIZE;
         }
-        MolOps::sanitizeMol(*res, failedOp, sanitizeOps);
       }
+      MolOps::sanitizeMol(*res, failedOp, sanitizeOps);
       MolOps::assignStereochemistry(*res, true, true, true);
       if (mergeQueryHs) {
         MolOps::mergeQueryHs(*res);

--- a/Code/MinimalLib/tests/tests.js
+++ b/Code/MinimalLib/tests/tests.js
@@ -863,6 +863,12 @@ function test_sanitize() {
     assert(mol.is_valid());
 }
 
+function test_removehs() {
+    const badValenceSmiles = 'N1C=CC(=O)c2ccc(N(C)(C)(C)(C)C)cc12';
+    mol = RDKitModule.get_mol(badValenceSmiles, JSON.stringify({ sanitize: false, removeHs: false }));
+    assert(mol.is_valid());
+}
+
 function test_flexicanvas() {
     var mol = RDKitModule.get_mol("CCCC");
     assert.equal(mol.is_valid(),1);
@@ -1762,6 +1768,7 @@ initRDKitModule().then(function(instance) {
     test_has_coords();
     test_kekulize();
     test_sanitize();
+    test_removehs();
     test_normalize_depiction();
     test_straighten_depiction();
     test_flexicanvas();


### PR DESCRIPTION
This PR fixes a problem in `MinimalLib`, where the combination of `sanitize=false` and `removeHs=false` causes `assignStereochemistry()` to fail because implicit valence has not been computed.