### PR TITLE
Issue 6091: Cleaning up unreachable code after return statement

### DIFF
--- a/rdkit/Chem/UnitTestRegistrationHash.py
+++ b/rdkit/Chem/UnitTestRegistrationHash.py
@@ -280,7 +280,7 @@ M  END
             csmis = set()
             for smi in mols_smis:
                 mol = Chem.MolFromSmiles(smi)
-                csmi, _ = RegistrationHash._CanonicalizeStereoGroups(mol)
+                csmi = Chem.CanonicalizeEnhancedStereo(mol)
                 csmis.add(csmi)
             self.assertEqual(len(csmis), 1)
 
@@ -293,7 +293,8 @@ M  END
         csmis = set()
         for smi in (s1, s3):
             mol = Chem.MolFromSmiles(smi)
-            csmi, _ = RegistrationHash._CanonicalizeStereoGroups(mol)
+            Chem.CanonicalizeEnhancedStereo(mol)
+            csmi = Chem.MolToCXSmiles(mol)
             csmis.add(csmi)
 
         self.assertEqual(len(csmis), 2)


### PR DESCRIPTION
Fixes #6091 


#### What does this implement/fix? Explain your changes.
This change deletes unreachable code after the return statement in RegistrationHash.py#_CanonicalizeStereoGroups

After carrying out the above change, it became apparent that the existance of _CanonicalizeStereoGroups was unnecessary since we already call  Chem.CanonicalizeEnhancedStereo(mol) in get mol layers (which is the only remaining functionality of _CanonicalizeStereoGroups after my initial changes.) With _CanonicalizeStereoGroups deleted, _UpdateEnhancedStereoGroupWeights was also unused, which I also deleted. I finally made changes to the tests to reflect this change.

Local Testing Done:
All the tests in UnitTestRegistrationHash.py passed after my changes.




