### PR TITLE
Continuing Issue #6091: Fixing a test that was not passing for the right reason

### DIFF
--- a/rdkit/Chem/UnitTestRegistrationHash.py
+++ b/rdkit/Chem/UnitTestRegistrationHash.py
@@ -276,13 +276,15 @@ M  END
             ),
         )
         for mols_smis in groups:
-            print()
             csmis = set()
             for smi in mols_smis:
                 mol = Chem.MolFromSmiles(smi)
-                csmi = Chem.CanonicalizeEnhancedStereo(mol)
+                Chem.CanonicalizeEnhancedStereo(mol)
+                csmi = Chem.MolToCXSmiles(mol)
                 csmis.add(csmi)
             self.assertEqual(len(csmis), 1)
+            self.assertNotEqual(list(csmis)[0], None)
+
 
     def test_enhanced_stereo_canonicalizer_non_matching(self):
         # Uncorrected example in SHARED-7811. These are NOT equivalent,
@@ -296,7 +298,6 @@ M  END
             Chem.CanonicalizeEnhancedStereo(mol)
             csmi = Chem.MolToCXSmiles(mol)
             csmis.add(csmi)
-
         self.assertEqual(len(csmis), 2)
 
     def test_enhanced_stereo_regex(self):

--- a/rdkit/Chem/UnitTestRegistrationHash.py
+++ b/rdkit/Chem/UnitTestRegistrationHash.py
@@ -279,11 +279,10 @@ M  END
             csmis = set()
             for smi in mols_smis:
                 mol = Chem.MolFromSmiles(smi)
-                Chem.CanonicalizeEnhancedStereo(mol)
                 csmi = Chem.MolToCXSmiles(mol)
+                self.assertIsNotNone(csmi)
                 csmis.add(csmi)
             self.assertEqual(len(csmis), 1)
-            self.assertNotEqual(list(csmis)[0], None)
 
 
     def test_enhanced_stereo_canonicalizer_non_matching(self):
@@ -295,7 +294,6 @@ M  END
         csmis = set()
         for smi in (s1, s3):
             mol = Chem.MolFromSmiles(smi)
-            Chem.CanonicalizeEnhancedStereo(mol)
             csmi = Chem.MolToCXSmiles(mol)
             csmis.add(csmi)
         self.assertEqual(len(csmis), 2)


### PR DESCRIPTION

Continuing Issue #6091: Fixing a test that was not passing for the right reason
I reviewed my pull request after it was merged to make sure we did not miss anything and saw an issue with one of the tests.

#### What does this implement/fix? Explain your changes.
What I was intending to do was to first canonicalize the mol, and then turn this mol into smiles. However, I mistakenly only did smi=Chem.CanonicalizeEnhancedStereo(mol).

Chem.CanonicalizeEnhancedStereo(mol) returns none always. Therefore, csmi=Chem.CanonicalizeEnhancedStereo(mol) was setting the smiles of both of the molecules to be "None". Even if these molecules had different smiles, they would both have "None" due to this error, which means the size of the set would still be 1, making the test pass but not for the right reason. 

What I did to address this situation:

- I called MolToCXSmiles to actually get the smiles of the canonicalized molecules.
- Added an additional assert to the test to make sure that the element that the set contains is not None
- Removed a print statement that looked unintentional



