### PR TITLE
Fixes #6153

### DIFF
--- a/Code/GraphMol/FileParsers/MaeMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/MaeMolSupplier.cpp
@@ -381,8 +381,15 @@ void build_mol(RWMol &mol, mae::Block &structure_block, bool sanitize,
   const auto &atom_block = structure_block.getIndexedBlock(mae::ATOM_BLOCK);
   addAtoms(*atom_block, mol);
 
-  const auto &bond_block = structure_block.getIndexedBlock(mae::BOND_BLOCK);
-  addBonds(*bond_block, mol);
+  std::shared_ptr<const mae::IndexedBlock> bond_block{nullptr};
+  try {
+    bond_block = structure_block.getIndexedBlock(mae::BOND_BLOCK);
+  } catch (const std::out_of_range &) {
+    // In Maestro files, the atom block is mandatory, but the bond block is not.
+  }
+  if (bond_block != nullptr) {
+    addBonds(*bond_block, mol);
+  }
 
   // These properties need to be set last, as stereochemistry is defined here,
   // and it requires atoms and bonds to be available.
@@ -466,7 +473,7 @@ void MaeMolSupplier::init() {
 
   try {
     d_next_struct = d_reader->next(mae::CT_BLOCK);
-  } catch (const mae::read_exception &e) {
+  } catch (const std::exception &e) {
     throw FileParseException(e.what());
   }
 }
@@ -503,10 +510,10 @@ ROMol *MaeMolSupplier::next() {
 
   try {
     build_mol(*mol, *d_next_struct, df_sanitize, df_removeHs);
-  } catch (...) {
+  } catch (const std::exception &e) {
     delete mol;
     moveToNextBlock();
-    throw;
+    throw FileParseException(e.what());
   }
 
   moveToNextBlock();
@@ -517,7 +524,7 @@ ROMol *MaeMolSupplier::next() {
 void MaeMolSupplier::moveToNextBlock() {
   try {
     d_next_struct = d_reader->next(mae::CT_BLOCK);
-  } catch (const mae::read_exception &e) {
+  } catch (const std::exception &e) {
     d_stored_exc = e.what();
   }
   ++d_position;

--- a/Code/GraphMol/FileParsers/MaeMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/MaeMolSupplier.cpp
@@ -473,7 +473,7 @@ void MaeMolSupplier::init() {
 
   try {
     d_next_struct = d_reader->next(mae::CT_BLOCK);
-  } catch (const std::exception &e) {
+  } catch (const mae::read_exception &e) {
     throw FileParseException(e.what());
   }
 }
@@ -524,7 +524,7 @@ ROMol *MaeMolSupplier::next() {
 void MaeMolSupplier::moveToNextBlock() {
   try {
     d_next_struct = d_reader->next(mae::CT_BLOCK);
-  } catch (const std::exception &e) {
+  } catch (const mae::read_exception &e) {
     d_stored_exc = e.what();
   }
   ++d_position;

--- a/Code/GraphMol/FileParsers/file_parsers_catch.cpp
+++ b/Code/GraphMol/FileParsers/file_parsers_catch.cpp
@@ -5578,7 +5578,7 @@ TEST_CASE("MaeMolSupplier setData and reset methods",
     std::unique_ptr<ROMol> molptr;
     try {
       molptr.reset(supplier.next());
-    } catch (const Invar::Invariant &) {
+    } catch (const FileParseException &) {
       // the 4th structure is intentionally bad.
     }
 

--- a/Code/GraphMol/FileParsers/testMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/testMolSupplier.cpp
@@ -218,7 +218,7 @@ int testMolSup() {
       std::unique_ptr<ROMol> nmol;
       try {
         nmol.reset(maesup.next());
-      } catch (const Invar::Invariant &) {
+      } catch (const FileParseException &) {
         // just ignore this failure
       }
       TEST_ASSERT(!nmol);
@@ -2816,7 +2816,7 @@ void testGitHub2881() {
     ROMol *mol = nullptr;
     try {
       mol = suppl.next();
-    } catch (const Invar::Invariant &) {
+    } catch (const FileParseException &) {
     }
     TEST_ASSERT(!mol);
   }

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -2842,7 +2842,7 @@ CAS<~>
       i += 1
     self.assertEqual(i, 16)
 
-  @unittest.skipIf(not hasattr(Chem, 'MaeMolSupplier'), "not build with MAEParser support")
+  @unittest.skipIf(not hasattr(Chem, 'MaeMolSupplier'), "not built with MAEParser support")
   def testMaeStreamSupplier(self):
     fileN = os.path.join(RDConfig.RDBaseDir, 'Code', 'GraphMol', 'FileParsers', 'test_data',
                          'NCI_aids_few.maegz')
@@ -2873,7 +2873,7 @@ CAS<~>
       i += 1
     self.assertEqual(i, 16)
 
-  @unittest.skipIf(not hasattr(Chem, 'MaeMolSupplier'), "not build with MAEParser support")
+  @unittest.skipIf(not hasattr(Chem, 'MaeMolSupplier'), "not built with MAEParser support")
   def testMaeFileSupplier(self):
     fileN = os.path.join(RDConfig.RDBaseDir, 'Code', 'GraphMol', 'FileParsers', 'test_data',
                          'NCI_aids_few.mae')
@@ -2891,7 +2891,7 @@ CAS<~>
       i += 1
     self.assertEqual(i, 16)
 
-  @unittest.skipIf(not hasattr(Chem, 'MaeMolSupplier'), "not build with MAEParser support")
+  @unittest.skipIf(not hasattr(Chem, 'MaeMolSupplier'), "not built with MAEParser support")
   def testMaeFileSupplierException(self):
     fileN = os.path.join(RDConfig.RDBaseDir, 'Code', 'GraphMol', 'FileParsers', 'test_data',
                          'bad_ppty.mae')
@@ -2915,7 +2915,7 @@ CAS<~>
     self.assertFalse(suppl.atEnd())
     self.assertTrue(ok)
 
-  @unittest.skipIf(not hasattr(Chem, 'MaeMolSupplier'), "not build with MAEParser support")
+  @unittest.skipIf(not hasattr(Chem, 'MaeMolSupplier'), "not built with MAEParser support")
   def testMaeFileSupplierSetData(self):
     fileN = os.path.join(RDConfig.RDBaseDir, 'Code', 'GraphMol', 'FileParsers', 'test_data',
                          'NCI_aids_few.mae')
@@ -2949,7 +2949,7 @@ CAS<~>
 
     self.assertEqual(i, 15)
 
-  @unittest.skipIf(not hasattr(Chem, 'MaeMolSupplier'), "not build with MAEParser support")
+  @unittest.skipIf(not hasattr(Chem, 'MaeMolSupplier'), "not built with MAEParser support")
   def testMaeFileSupplierGetItem(self):
     fileN = os.path.join(RDConfig.RDBaseDir, 'Code', 'GraphMol', 'FileParsers', 'test_data',
                          'NCI_aids_few.mae')
@@ -2969,6 +2969,15 @@ CAS<~>
 
       for i in (num_mols, 2 * num_mols, -(num_mols + 1), -2 * (num_mols + 1)):
         self.assertRaises(IndexError, lambda: suppl[i])
+
+  @unittest.skipIf(not hasattr(Chem, 'MaeMolSupplier'), "not built with MAEParser support")
+  def testMaeFileSupplierExceptionMsgs(self):
+    maeBlock = "f_m_ct {\n  s_m_title\n  :::\n  " "\n  }\n}"
+
+    with Chem.MaeMolSupplier() as suppl:
+      suppl.SetData(maeBlock)
+      self.assertRaisesRegex(RuntimeError, r'File parsing error: Indexed block not found: m_atom',
+                             lambda: next(suppl))
 
   def test66StreamSupplierIter(self):
     fileN = os.path.join(RDConfig.RDBaseDir, 'Code', 'GraphMol', 'FileParsers', 'test_data',
@@ -7003,7 +7012,7 @@ CAS<~>
     finally:
       Chem.SetDefaultPickleProperties(props)
 
-  @unittest.skipIf(not hasattr(Chem, 'MaeWriter'), "not build with MAEParser support")
+  @unittest.skipIf(not hasattr(Chem, 'MaeWriter'), "not built with MAEParser support")
   def testMaeWriter(self):
     mol = Chem.MolFromSmiles("C1CCCCC1")
     self.assertTrue(mol)
@@ -7040,7 +7049,7 @@ CAS<~>
 
     self.assertTrue(f' m_bond[{mol.GetNumBonds()}] {{', maefile)
 
-  @unittest.skipIf(not hasattr(Chem, 'MaeWriter'), "not build with MAEParser support")
+  @unittest.skipIf(not hasattr(Chem, 'MaeWriter'), "not built with MAEParser support")
   def testMaeWriterProps(self):
     mol = Chem.MolFromSmiles("C1CCCCC1")
     self.assertTrue(mol)
@@ -7130,7 +7139,7 @@ CAS<~>
     self.assertIn(str(int(boolProp)), line)
     self.assertIn(strProp, line)
 
-  @unittest.skipIf(not hasattr(Chem, 'MaeWriter'), "not build with MAEParser support")
+  @unittest.skipIf(not hasattr(Chem, 'MaeWriter'), "not built with MAEParser support")
   def testMaeWriterRoundtrip(self):
     smiles = "C1CCCCC1"
     mol = Chem.MolFromSmiles(smiles)
@@ -7147,7 +7156,7 @@ CAS<~>
 
     self.assertEqual(Chem.MolToSmiles(roundtrip_mol), smiles)
 
-  @unittest.skipIf(not hasattr(Chem, 'MaeWriter'), "not build with MAEParser support")
+  @unittest.skipIf(not hasattr(Chem, 'MaeWriter'), "not built with MAEParser support")
   def testMaeWriterGetText(self):
     smiles = "C1CCCCC1"
     mol = Chem.MolFromSmiles(smiles)


### PR DESCRIPTION
This fixes #6153 by catching the exception that is raised when maeparser fails to find a bond block.

Also, I noticed that some of the errors we can hit when parsing Maestro files, including the one being fixed, cause a failure without reporting any information on the error, just returning `None` in Python. On the C++ side we were getting different types of exceptions, depending on what failed. This patch catches different types of exceptions at the C++ and rethrows them as `FileParseException`, which gets translated into a Python `RuntimeError` with a proper error message. Note this is a change in behavior.