### PR TITLE
expose two missing QueryAtom types to python

### DIFF
--- a/Code/GraphMol/Wrap/Queries.cpp
+++ b/Code/GraphMol/Wrap/Queries.cpp
@@ -61,6 +61,7 @@ QAFUNC1(ExplicitValence, makeAtomExplicitValenceQuery, int);
 QAFUNC1(TotalValence, makeAtomTotalValenceQuery, int);
 QAFUNC1(ExplicitDegree, makeAtomExplicitDegreeQuery, int);
 QAFUNC1(TotalDegree, makeAtomTotalDegreeQuery, int);
+QAFUNC1(NonHydrogenDegree, makeAtomNonHydrogenDegreeQuery, int);
 
 QAFUNC1(HCount, makeAtomHCountQuery, int);
 QAFUNC1(Mass, makeAtomMassQuery, int);
@@ -82,6 +83,7 @@ QAFUNC2(IsAliphaticQueryAtom, makeAtomAliphaticQuery, int);
 QAFUNC2(IsInRingQueryAtom, makeAtomInRingQuery, int);
 QAFUNC2(HasChiralTagQueryAtom, makeAtomHasChiralTagQuery, int);
 QAFUNC2(MissingChiralTagQueryAtom, makeAtomMissingChiralTagQuery, int);
+QAFUNC2(IsBridgeheadQueryAtom, makeAtomIsBridgeheadQuery, int);
 
 QAFUNC2(AAtomQueryAtom, makeAAtomQuery, int);
 QAFUNC2(AHAtomQueryAtom, makeAHAtomQuery, int);
@@ -187,6 +189,7 @@ struct queries_wrapper {
     QADEF1(NumRadicalElectrons)
     QADEF1(NumHeteroatomNeighbors)
     QADEF1(NumAliphaticHeteroatomNeighbors)
+    QADEF1(NonHydrogenDegree)
 
     QADEF2(IsUnsaturated);
     QADEF2(IsAromatic);
@@ -194,6 +197,7 @@ struct queries_wrapper {
     QADEF2(IsInRing);
     QADEF2(HasChiralTag);
     QADEF2(MissingChiralTag);
+    QADEF2(IsBridgehead);
 
     QADEF2(AAtom);
     QADEF2(AHAtom);

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -3536,6 +3536,16 @@ CAS<~>
     l = tuple([x.GetIdx() for x in m.GetAtomsMatchingQuery(qa)])
     self.assertEqual(l, (0, 2, 3, 4))
 
+    m = Chem.MolFromSmiles('CC12CCN(CC1)C2')
+    qa = rdqueries.IsBridgeheadQueryAtom()
+    l = tuple([x.GetIdx() for x in m.GetAtomsMatchingQuery(qa)])
+    self.assertEqual(l, (1, 4))
+
+    m = Chem.MolFromSmiles('OCCOC')
+    qa = rdqueries.NonHydrogenDegreeEqualsQueryAtom(2)
+    l = tuple([x.GetIdx() for x in m.GetAtomsMatchingQuery(qa)])
+    self.assertEqual(l, (1, 2, 3))
+
   def test89UnicodeInput(self):
     m = Chem.MolFromSmiles(u'c1ccccc1')
     self.assertTrue(m is not None)


### PR DESCRIPTION
The "recently" added `NonHydrogenDegree` and `BridgheadAtom` queries were never exposed to Python.
This remedies that.