### PR TITLE
BondDir not cleared from bonds that aren't stereoactive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 /Code/JavaWrappers/csharp_wrapper/swig_csharp
 /Data/Fonts/ComicNeue-*
 /Data/Fonts/OFL.txt
-
+/vcpkg/*
 #- Eclipse files
 /.project
 /.pydevproject

--- a/Code/GraphMol/Chirality.cpp
+++ b/Code/GraphMol/Chirality.cpp
@@ -1699,16 +1699,6 @@ std::pair<bool, bool> assignBondStereoCodes(ROMol &mol, UINT_VECT &ranks) {
               }
             }
             --unassignedBonds;
-          } else {
-            // we get here if we either don't have neighbors or if there were
-            // duplicate neighbors. In either case there should definitely be no
-            // stereo on the bond
-            dblBond->setBondDir(Bond::BondDir::NONE);
-            dblBond->getStereoAtoms().clear();
-            dblBond->clearProp(common_properties::_UnknownStereo);
-            dblBond->setStereo(Bond::STEREONONE);
-            assignedABond = true;
-            --unassignedBonds;
           }
         }
       }

--- a/Code/GraphMol/Chirality.cpp
+++ b/Code/GraphMol/Chirality.cpp
@@ -2065,6 +2065,8 @@ void legacyStereoPerception(ROMol &mol, bool cleanIt,
       } else if (bond->getBondType() == Bond::DOUBLE) {
         if (bond->getBondDir() == Bond::EITHERDOUBLE) {
           bond->setStereo(Bond::STEREOANY);
+          bond->getStereoAtoms().clear();
+          bond->setBondDir(Bond::NONE);
         } else if (bond->getStereo() != Bond::STEREOANY) {
           bond->setStereo(Bond::STEREONONE);
           bond->getStereoAtoms().clear();
@@ -2268,8 +2270,14 @@ void stereoPerception(ROMol &mol, bool cleanIt,
       atom->clearProp(common_properties::_CIPCode);
       atom->clearProp(common_properties::_ChiralityPossible);
     }
+    for (auto bond : mol.bonds()) {
+      if (bond->getBondDir() == Bond::BondDir::EITHERDOUBLE) {
+        bond->setStereo(Bond::BondStereo::STEREOANY);
+        bond->getStereoAtoms().clear();
+        bond->setBondDir(Bond::BondDir::NONE);
+      }
+    }
   }
-
   // we need cis/trans markers on the double bonds... set those now:
   MolOps::setBondStereoFromDirections(mol);
 

--- a/Code/GraphMol/Chirality.cpp
+++ b/Code/GraphMol/Chirality.cpp
@@ -2064,10 +2064,6 @@ void legacyStereoPerception(ROMol &mol, bool cleanIt,
       }
     }
     if (!hasStereoBonds && bond->getBondType() == Bond::DOUBLE) {
-      if (bond->getBondDir() == Bond::BondDir::EITHERDOUBLE) {
-        hasStereoBonds = true;
-        continue;
-      }
       for (auto nbond : mol.atomBonds(bond->getBeginAtom())) {
         if (nbond->getBondDir() == Bond::ENDDOWNRIGHT ||
             nbond->getBondDir() == Bond::ENDUPRIGHT) {

--- a/Code/GraphMol/FileParsers/cdxml_parser_catch.cpp
+++ b/Code/GraphMol/FileParsers/cdxml_parser_catch.cpp
@@ -721,8 +721,8 @@ TEST_CASE("CDXML") {
       int i = 0;
       for (auto &mol : mols) {
         if (i == 0) {
-          CHECK(mol->getBondWithIdx(11)->getBondDir() ==
-                Bond::BondDir::EITHERDOUBLE);
+          CHECK(mol->getBondWithIdx(11)->getStereo() ==
+                Bond::BondStereo::STEREOANY);
         }
         CHECK(MolToSmiles(*mol) == expected[i++]);
       }

--- a/Code/GraphMol/FileParsers/file_parsers_catch.cpp
+++ b/Code/GraphMol/FileParsers/file_parsers_catch.cpp
@@ -3578,7 +3578,7 @@ TEST_CASE("double bond stereo should not be set when the coords are all zero") {
 M  END)CTAB"_ctab;
   REQUIRE(m);
   REQUIRE(m->getBondBetweenAtoms(1, 2));
-  CHECK(m->getBondBetweenAtoms(1, 2)->getBondDir() == Bond::EITHERDOUBLE);
+  CHECK(m->getBondBetweenAtoms(1, 2)->getStereo() == Bond::STEREOANY);
 }
 
 TEST_CASE("Handle MRV_COORDINATE_BOND_TYPE data Substance Groups") {

--- a/Code/GraphMol/FileParsers/test1.cpp
+++ b/Code/GraphMol/FileParsers/test1.cpp
@@ -954,7 +954,6 @@ void testDblBondStereochem() {
     m1 = MolFileToMol(fName);
     TEST_ASSERT(m1);
     TEST_ASSERT(m1->getBondWithIdx(0)->getStereo() == Bond::STEREOANY);
-    TEST_ASSERT(m1->getBondWithIdx(0)->getBondDir() == Bond::EITHERDOUBLE);
     delete m1;
   }
 
@@ -3180,8 +3179,7 @@ void testIssue3375684() {
     RWMol *m = MolFileToMol(fName);
 
     TEST_ASSERT(m->getBondBetweenAtoms(6, 7)->getBondType() == Bond::DOUBLE);
-    TEST_ASSERT(m->getBondBetweenAtoms(6, 7)->getBondDir() ==
-                Bond::EITHERDOUBLE);
+    TEST_ASSERT(m->getBondBetweenAtoms(6, 7)->getStereo() == Bond::STEREOANY);
     delete m;
   }
   {

--- a/Code/GraphMol/FindStereo.cpp
+++ b/Code/GraphMol/FindStereo.cpp
@@ -840,10 +840,10 @@ bool updateBonds(ROMol &mol, const std::vector<unsigned int> &aranks,
   return needAnotherRound;
 }
 
-void cleanMolStereo(ROMol &mol, boost::dynamic_bitset<> &fixedAtoms,
-                    boost::dynamic_bitset<> &knownAtoms,
-                    boost::dynamic_bitset<> &fixedBonds,
-                    boost::dynamic_bitset<> &knownBonds) {
+void cleanMolStereo(ROMol &mol, const boost::dynamic_bitset<> &fixedAtoms,
+                    const boost::dynamic_bitset<> &knownAtoms,
+                    const boost::dynamic_bitset<> &fixedBonds,
+                    const boost::dynamic_bitset<> &knownBonds) {
   for (auto i = 0u; i < mol.getNumAtoms(); ++i) {
     if (!fixedAtoms[i] && knownAtoms[i]) {
       switch (mol.getAtomWithIdx(i)->getChiralTag()) {
@@ -865,9 +865,11 @@ void cleanMolStereo(ROMol &mol, boost::dynamic_bitset<> &fixedAtoms,
     }
   }
   for (auto i = 0u; i < mol.getNumBonds(); ++i) {
+    auto bond = mol.getBondWithIdx(i);
     if (!fixedBonds[i] && knownBonds[i]) {
-      // FIX only does known double bonds
-      mol.getBondWithIdx(i)->setStereo(Bond::BondStereo::STEREONONE);
+      bond->setStereo(Bond::BondStereo::STEREONONE);
+      bond->setBondDir(Bond::BondDir::NONE);
+      bond->getStereoAtoms().clear();
     }
   }
 }

--- a/Code/GraphMol/catch_chirality.cpp
+++ b/Code/GraphMol/catch_chirality.cpp
@@ -3346,14 +3346,18 @@ TEST_CASE(
       Chirality::setUseLegacyStereoPerception(false);
       auto cp(*m);
       RDKit::MolOps::assignStereochemistry(cp, clean, force, flag);
-      CHECK(cp.getBondWithIdx(1)->getBondDir() == Bond::BondDir::EITHERDOUBLE);
+      // the crossed bond dir has been translated to unknown stereo:
+      CHECK(cp.getBondWithIdx(1)->getBondDir() == Bond::BondDir::NONE);
+      CHECK(cp.getBondWithIdx(1)->getStereo() == Bond::BondStereo::STEREOANY);
     }
     {
       UseLegacyStereoPerceptionFixture reset_stereo_perception;
       Chirality::setUseLegacyStereoPerception(true);
       auto cp(*m);
       RDKit::MolOps::assignStereochemistry(cp, clean, force, flag);
-      CHECK(cp.getBondWithIdx(1)->getBondDir() == Bond::BondDir::EITHERDOUBLE);
+      // the crossed bond dir has been translated to unknown stereo:
+      CHECK(cp.getBondWithIdx(1)->getBondDir() == Bond::BondDir::NONE);
+      CHECK(cp.getBondWithIdx(1)->getStereo() == Bond::BondStereo::STEREOANY);
     }
   }
   SECTION("make sure stereoatoms are also cleared") {

--- a/Code/GraphMol/catch_chirality.cpp
+++ b/Code/GraphMol/catch_chirality.cpp
@@ -3307,3 +3307,78 @@ TEST_CASE(
     }
   }
 }
+
+TEST_CASE(
+    "assignStereochemistry should clear crossed double bonds that can't have stereo") {
+  SECTION("basics") {
+    auto m = "CC=C(C)C"_smiles;
+    REQUIRE(m);
+    m->getBondWithIdx(1)->setBondDir(Bond::BondDir::EITHERDOUBLE);
+    // m->getBondWithIdx(1)->setStereoAtoms(0, 3);
+    // m->getBondWithIdx(1)->setStereo(Bond::BondStereo::STEREOCIS);
+    bool clean = true;
+    bool flag = true;
+    bool force = true;
+    {
+      UseLegacyStereoPerceptionFixture reset_stereo_perception;
+      Chirality::setUseLegacyStereoPerception(false);
+      auto cp(*m);
+      RDKit::MolOps::assignStereochemistry(cp, clean, force, flag);
+      CHECK(cp.getBondWithIdx(1)->getBondDir() == Bond::BondDir::NONE);
+    }
+    {
+      UseLegacyStereoPerceptionFixture reset_stereo_perception;
+      Chirality::setUseLegacyStereoPerception(true);
+      auto cp(*m);
+      RDKit::MolOps::assignStereochemistry(cp, clean, force, flag);
+      CHECK(cp.getBondWithIdx(1)->getBondDir() == Bond::BondDir::NONE);
+    }
+  }
+  SECTION("make sure we don't mess with actual potential stereosystems") {
+    auto m = "CC=C(C)[13CH3]"_smiles;
+    REQUIRE(m);
+    m->getBondWithIdx(1)->setBondDir(Bond::BondDir::EITHERDOUBLE);
+    bool clean = true;
+    bool flag = true;
+    bool force = true;
+    {
+      UseLegacyStereoPerceptionFixture reset_stereo_perception;
+      Chirality::setUseLegacyStereoPerception(false);
+      auto cp(*m);
+      RDKit::MolOps::assignStereochemistry(cp, clean, force, flag);
+      CHECK(cp.getBondWithIdx(1)->getBondDir() == Bond::BondDir::EITHERDOUBLE);
+    }
+    {
+      UseLegacyStereoPerceptionFixture reset_stereo_perception;
+      Chirality::setUseLegacyStereoPerception(true);
+      auto cp(*m);
+      RDKit::MolOps::assignStereochemistry(cp, clean, force, flag);
+      CHECK(cp.getBondWithIdx(1)->getBondDir() == Bond::BondDir::EITHERDOUBLE);
+    }
+  }
+  SECTION("make sure stereoatoms are also cleared") {
+    auto m = "CC=C(C)C"_smiles;
+    REQUIRE(m);
+    m->getBondWithIdx(1)->setBondDir(Bond::BondDir::EITHERDOUBLE);
+    m->getBondWithIdx(1)->setStereoAtoms(0, 3);
+    bool clean = true;
+    bool flag = true;
+    bool force = true;
+    {
+      UseLegacyStereoPerceptionFixture reset_stereo_perception;
+      Chirality::setUseLegacyStereoPerception(false);
+      auto cp(*m);
+      RDKit::MolOps::assignStereochemistry(cp, clean, force, flag);
+      CHECK(cp.getBondWithIdx(1)->getBondDir() == Bond::BondDir::NONE);
+      CHECK(cp.getBondWithIdx(1)->getStereoAtoms().empty());
+    }
+    {
+      UseLegacyStereoPerceptionFixture reset_stereo_perception;
+      Chirality::setUseLegacyStereoPerception(true);
+      auto cp(*m);
+      RDKit::MolOps::assignStereochemistry(cp, clean, force, flag);
+      CHECK(cp.getBondWithIdx(1)->getBondDir() == Bond::BondDir::NONE);
+      CHECK(cp.getBondWithIdx(1)->getStereoAtoms().empty());
+    }
+  }
+}

--- a/Code/GraphMol/catch_chirality.cpp
+++ b/Code/GraphMol/catch_chirality.cpp
@@ -3314,8 +3314,6 @@ TEST_CASE(
     auto m = "CC=C(C)C"_smiles;
     REQUIRE(m);
     m->getBondWithIdx(1)->setBondDir(Bond::BondDir::EITHERDOUBLE);
-    // m->getBondWithIdx(1)->setStereoAtoms(0, 3);
-    // m->getBondWithIdx(1)->setStereo(Bond::BondStereo::STEREOCIS);
     bool clean = true;
     bool flag = true;
     bool force = true;

--- a/Code/GraphMol/molopstest.cpp
+++ b/Code/GraphMol/molopstest.cpp
@@ -7735,6 +7735,7 @@ void testGithub1614() {
       // nm.debugMol(std::cerr);
       bool force = true, cleanIt = true;
       MolOps::assignStereochemistry(nm, cleanIt, force);
+      // nm.debugMol(std::cerr);
       TEST_ASSERT(nm.getBondBetweenAtoms(4, 5)->getStereo() == Bond::STEREOE);
       TEST_ASSERT(nm.getBondBetweenAtoms(8, 9)->getStereo() == Bond::STEREOZ);
       TEST_ASSERT(nm.getBondBetweenAtoms(1, 2)->getStereo() == Bond::STEREOE);

--- a/Code/GraphMol/molopstest.cpp
+++ b/Code/GraphMol/molopstest.cpp
@@ -7732,10 +7732,8 @@ void testGithub1614() {
     {
       RWMol nm(*m);
       MolOps::setDoubleBondNeighborDirections(nm);
-      // nm.debugMol(std::cerr);
       bool force = true, cleanIt = true;
       MolOps::assignStereochemistry(nm, cleanIt, force);
-      // nm.debugMol(std::cerr);
       TEST_ASSERT(nm.getBondBetweenAtoms(4, 5)->getStereo() == Bond::STEREOE);
       TEST_ASSERT(nm.getBondBetweenAtoms(8, 9)->getStereo() == Bond::STEREOZ);
       TEST_ASSERT(nm.getBondBetweenAtoms(1, 2)->getStereo() == Bond::STEREOE);
@@ -7755,7 +7753,6 @@ void testGithub1614() {
     {
       RWMol nm(*m);
       MolOps::setDoubleBondNeighborDirections(nm);
-      // nm.debugMol(std::cerr);
       bool force = true, cleanIt = true;
       MolOps::assignStereochemistry(nm, cleanIt, force);
       TEST_ASSERT(nm.getBondBetweenAtoms(4, 5)->getStereo() == Bond::STEREOE);

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -10,6 +10,7 @@
 - The ring-finding functions will now run even if the molecule already has ring information. Older versions of the RDKit would return whatever ring information was present, even if it had been generated using a different algorithm.
 - The canonical SMILES and CXSMILES generated for molecules with enhanced stereochemistry (stereo groups) is different than in previous releases. The enhanced stereochemistry information and the stereo groups themselves are now canonical. This does *not* affect molecules which do not have enhanced stereo and will not have any effect if you generate non-isomeric SMILES. This change also affects the output of the MolHash and RegistrationHash code when applied to molecules with enhanced stereo.
 - The doIsomericSmiles parameter in Java and C# ROMol.MolToSmiles() now defaults to true (previously it was false), thus aligning to the C++ and Python behavior.
+- Double bonds which are marked as crossed (i.e. `bond.GetBondDir() == Bond.BondDir.EITHERDOUBLE`) now have their BondStereo set to `Bond.BondStereo.STEREOANY` and the BondDir information removed by default when molecules are parsed or `AssignStereochemistry()` is called with the `cleanIt` argument set to True.
 
 ## Bug Fixes:
 


### PR DESCRIPTION
The problem this addresses is that neither the old stereo code nor the new stereo code would remove the bond dir information which marks the double bond in this molecule as being "either":
![image](https://user-images.githubusercontent.com/540511/222880164-da510744-5ec8-4b7b-a1e2-22776d6e2964.png)

This PR clears that up.

The main idea is to recognize `BondDir` information when doing `assignStereochemistry()` (either version) with `cleanIt=true`  and set the corresponding double bond stereo to `STEREOANY`. Some small changes to the rest of the `assignStereochemistry()` code then makes sure that this is interpreted correctly and also clears the `stereoAtoms` on non-stereo bonds.

The backwards incompatible change is that crossed double bonds will no longer have their BondDir set after standard parsing or calls to `assignStereochemistry()`.
