### PR TITLE
Fix drawing of Aminosulfimine Take 2

### DIFF
--- a/Code/GraphMol/MolDraw2D/DrawMol.cpp
+++ b/Code/GraphMol/MolDraw2D/DrawMol.cpp
@@ -1593,9 +1593,6 @@ void DrawMol::makeStandardBond(Bond *bond, double doubleBondOffset) {
   int endAt = bond->getEndAtomIdx();
   std::pair<DrawColour, DrawColour> cols = getBondColours(bond);
 
-  if (bond->getIdx() == 12) {
-    std::cout << "bond 12" << std::endl;
-  }
   auto bt = bond->getBondType();
   if (bt == Bond::DOUBLE || bt == Bond::AROMATIC) {
     makeDoubleBondLines(bond, doubleBondOffset, cols);

--- a/Code/GraphMol/MolDraw2D/DrawMol.cpp
+++ b/Code/GraphMol/MolDraw2D/DrawMol.cpp
@@ -2895,12 +2895,12 @@ void DrawMol::bondNonRing(const Bond &bond, double offset, Point2D &l2s,
   const Atom *thirdAtom = nullptr;
   const Atom *fourthAtom = nullptr;
 
-  bool begTrunc(!atomLabels_[begAt->getIdx()]);
-  bool endTrunc(!atomLabels_[endAt->getIdx()]);
+  bool begTrunc = !atomLabels_[begAt->getIdx()];
+  bool endTrunc = !atomLabels_[endAt->getIdx()];
 
   // find a neighbour of at1 that isn't at2 and if possible isn't directly
   // opposite at1 to at2.
-  auto goodOtherNbor = [&](Atom *at1, Atom *at2) -> const Atom * {
+  auto nonColinearNbor = [&](Atom *at1, Atom *at2) -> const Atom * {
     const Atom *thirdAtom = nullptr;
     for (auto i = 1; i < at1->getDegree(); ++i) {
       thirdAtom = otherNeighbor(at1, at2, i, *drawMol_);
@@ -2942,7 +2942,7 @@ void DrawMol::bondNonRing(const Bond &bond, double offset, Point2D &l2s,
         areBondsTrans(atCds_[thirdAtom->getIdx()], atCds_[begAt->getIdx()],
                       atCds_[endAt->getIdx()], atCds_[fourthAtom->getIdx()]);
     if (isTrans) {
-      fourthAtom = goodOtherNbor(endAt, begAt);
+      fourthAtom = nonColinearNbor(endAt, begAt);
     }
     l2f = doubleBondEnd(fourthAtom->getIdx(), endAt->getIdx(), begAt->getIdx(),
                         offset, endTrunc);
@@ -2956,7 +2956,7 @@ void DrawMol::bondNonRing(const Bond &bond, double offset, Point2D &l2s,
         areBondsTrans(atCds_[thirdAtom->getIdx()], atCds_[begAt->getIdx()],
                       atCds_[endAt->getIdx()], atCds_[fourthAtom->getIdx()]);
     if (isTrans) {
-      thirdAtom = goodOtherNbor(begAt, endAt);
+      thirdAtom = nonColinearNbor(begAt, endAt);
       l2s = doubleBondEnd(thirdAtom->getIdx(), begAt->getIdx(), endAt->getIdx(),
                           offset, endTrunc);
     }
@@ -2971,7 +2971,7 @@ void DrawMol::bondNonRing(const Bond &bond, double offset, Point2D &l2s,
         areBondsTrans(atCds_[thirdAtom->getIdx()], atCds_[begAt->getIdx()],
                       atCds_[endAt->getIdx()], atCds_[fourthAtom->getIdx()]);
     if (isTrans) {
-      fourthAtom = goodOtherNbor(endAt, begAt);
+      fourthAtom = nonColinearNbor(endAt, begAt);
     }
     l2f = doubleBondEnd(fourthAtom->getIdx(), endAt->getIdx(), begAt->getIdx(),
                         offset, endTrunc);
@@ -3683,12 +3683,10 @@ bool areBondsTrans(const Point2D &at1, const Point2D &at2, const Point2D &at3,
 
 // ****************************************************************************
 bool areBondsLinear(const Point2D &at1, const Point2D &at2, const Point2D &at3,
-                    const Point2D &at4) {
-  Point2D v21 = at1 - at2;
-  v21.normalize();
-  Point2D v34 = at4 - at3;
-  v34.normalize();
-  return (fabs(1.0 - fabs(v21.dotProduct(v34))) < 0.0004);
+                    const Point2D &at4, double tol) {
+  Point2D v21 = at1.directionVector(at2);
+  Point2D v34 = at4.directionVector(at3);
+  return (fabs(1.0 - fabs(v21.dotProduct(v34))) < tol);
 }
 
 // ****************************************************************************

--- a/Code/GraphMol/MolDraw2D/DrawMol.cpp
+++ b/Code/GraphMol/MolDraw2D/DrawMol.cpp
@@ -2793,6 +2793,12 @@ void DrawMol::calcDoubleBondLines(double offset, const Bond &bond, Point2D &l1s,
       // in a ring, we need to draw the bond inside the ring
       bondInsideRing(bond, offset, l2s, l2f);
     } else {
+      // if there are atom labels at both ends, straddle the atom-atom vector
+      // rather than the normal 1 line on the vector, the other to the side.
+      if (atomLabels_[at1->getIdx()] && atomLabels_[at2->getIdx()]) {
+        doubleBondTerminal(at1, at2, offset, l1s, l1f, l2s, l2f);
+        offset /= 2.0;
+      }
       bondNonRing(bond, offset, l2s, l2f);
     }
     if ((Bond::EITHERDOUBLE == bond.getBondDir()) ||

--- a/Code/GraphMol/MolDraw2D/DrawMol.cpp
+++ b/Code/GraphMol/MolDraw2D/DrawMol.cpp
@@ -2892,6 +2892,9 @@ void DrawMol::bondNonRing(const Bond &bond, double offset, Point2D &l2s,
   const Atom *thirdAtom = nullptr;
   const Atom *fourthAtom = nullptr;
 
+  bool begTrunc(!atomLabels_[begAt->getIdx()]);
+  bool endTrunc(!atomLabels_[endAt->getIdx()]);
+
   // find a neighbour of at1 that isn't at2 and if possible isn't directly
   // opposite at1 to at2.
   auto goodOtherNbor = [&](Atom *at1, Atom *at2) -> const Atom * {
@@ -2914,7 +2917,7 @@ void DrawMol::bondNonRing(const Bond &bond, double offset, Point2D &l2s,
     thirdAtom = otherNeighbor(begAt, endAt, 0, *drawMol_);
     fourthAtom = otherNeighbor(endAt, begAt, 0, *drawMol_);
     l2s = doubleBondEnd(thirdAtom->getIdx(), begAt->getIdx(), endAt->getIdx(),
-                        offset, true);
+                        offset, begTrunc);
     bool isTrans =
         areBondsTrans(atCds_[thirdAtom->getIdx()], atCds_[begAt->getIdx()],
                       atCds_[endAt->getIdx()], atCds_[fourthAtom->getIdx()]);
@@ -2925,13 +2928,13 @@ void DrawMol::bondNonRing(const Bond &bond, double offset, Point2D &l2s,
       l2f = atCds_[endAt->getIdx()] + perp * offset;
     } else {
       l2f = doubleBondEnd(fourthAtom->getIdx(), endAt->getIdx(),
-                          begAt->getIdx(), offset, true);
+                          begAt->getIdx(), offset, endTrunc);
     }
   } else if (begAt->getDegree() == 2 && endAt->getDegree() > 2) {
     thirdAtom = otherNeighbor(begAt, endAt, 0, *drawMol_);
     fourthAtom = otherNeighbor(endAt, begAt, 0, *drawMol_);
     l2s = doubleBondEnd(thirdAtom->getIdx(), begAt->getIdx(), endAt->getIdx(),
-                        offset, true);
+                        offset, begTrunc);
     bool isTrans =
         areBondsTrans(atCds_[thirdAtom->getIdx()], atCds_[begAt->getIdx()],
                       atCds_[endAt->getIdx()], atCds_[fourthAtom->getIdx()]);
@@ -2939,27 +2942,27 @@ void DrawMol::bondNonRing(const Bond &bond, double offset, Point2D &l2s,
       fourthAtom = goodOtherNbor(endAt, begAt);
     }
     l2f = doubleBondEnd(fourthAtom->getIdx(), endAt->getIdx(), begAt->getIdx(),
-                        offset, true);
+                        offset, endTrunc);
 
   } else if (begAt->getDegree() > 2 && endAt->getDegree() == 2) {
     thirdAtom = otherNeighbor(begAt, endAt, 0, *drawMol_);
     fourthAtom = otherNeighbor(endAt, begAt, 0, *drawMol_);
     l2s = doubleBondEnd(thirdAtom->getIdx(), begAt->getIdx(), endAt->getIdx(),
-                        offset, true);
+                        offset, begTrunc);
     bool isTrans =
         areBondsTrans(atCds_[thirdAtom->getIdx()], atCds_[begAt->getIdx()],
                       atCds_[endAt->getIdx()], atCds_[fourthAtom->getIdx()]);
     if (isTrans) {
       thirdAtom = goodOtherNbor(begAt, endAt);
       l2s = doubleBondEnd(thirdAtom->getIdx(), begAt->getIdx(), endAt->getIdx(),
-                          offset, true);
+                          offset, endTrunc);
     }
     l2f = doubleBondEnd(fourthAtom->getIdx(), endAt->getIdx(), begAt->getIdx(),
-                        offset, true);
+                        offset, endTrunc);
   } else if (begAt->getDegree() > 2 && endAt->getDegree() > 2) {
     thirdAtom = otherNeighbor(begAt, endAt, 0, *drawMol_);
     l2s = doubleBondEnd(thirdAtom->getIdx(), begAt->getIdx(), endAt->getIdx(),
-                        offset, true);
+                        offset, begTrunc);
     fourthAtom = otherNeighbor(endAt, begAt, 0, *drawMol_);
     bool isTrans =
         areBondsTrans(atCds_[thirdAtom->getIdx()], atCds_[begAt->getIdx()],
@@ -2968,7 +2971,7 @@ void DrawMol::bondNonRing(const Bond &bond, double offset, Point2D &l2s,
       fourthAtom = goodOtherNbor(endAt, begAt);
     }
     l2f = doubleBondEnd(fourthAtom->getIdx(), endAt->getIdx(), begAt->getIdx(),
-                        offset, true);
+                        offset, endTrunc);
   }
 }
 

--- a/Code/GraphMol/MolDraw2D/DrawMol.h
+++ b/Code/GraphMol/MolDraw2D/DrawMol.h
@@ -339,9 +339,10 @@ void getBondHighlightsForAtoms(const ROMol &mol,
 bool areBondsTrans(const Point2D &at1, const Point2D &at2, const Point2D &at3,
                    const Point2D &at4);
 // returns true if the vector at2->at1 points is roughly linear with
-// direction of at3->at4.  Basically, if the dot product is 1.0.
+// direction of at3->at4.  Basically, if the dot product is 1.0 within the
+// given tolerance.
 bool areBondsLinear(const Point2D &at1, const Point2D &at2, const Point2D &at3,
-                    const Point2D &at4);
+                    const Point2D &at4, double tol = 1.0e-4);
 
 // find the nborNum'th neighbour of firstAtom that isn't secondAtom
 const Atom *otherNeighbor(const Atom *firstAtom, const Atom *secondAtom,

--- a/Code/GraphMol/MolDraw2D/DrawMol.h
+++ b/Code/GraphMol/MolDraw2D/DrawMol.h
@@ -338,6 +338,10 @@ void getBondHighlightsForAtoms(const ROMol &mol,
 // direction to at3->at4.  Basically, if the dot product is negative.
 bool areBondsTrans(const Point2D &at1, const Point2D &at2, const Point2D &at3,
                    const Point2D &at4);
+// returns true if the vector at2->at1 points is roughly linear with
+// direction of at3->at4.  Basically, if the dot product is 1.0.
+bool areBondsLinear(const Point2D &at1, const Point2D &at2, const Point2D &at3,
+                    const Point2D &at4);
 
 // find the nborNum'th neighbour of firstAtom that isn't secondAtom
 const Atom *otherNeighbor(const Atom *firstAtom, const Atom *secondAtom,

--- a/Code/GraphMol/MolDraw2D/catch_tests.cpp
+++ b/Code/GraphMol/MolDraw2D/catch_tests.cpp
@@ -7269,3 +7269,19 @@ TEST_CASE("ACS1996 should not throw exception with no coords - Github 6112") {
   outs.close();
   check_file_hash(nameBase + ".svg");
 }
+
+TEST_CASE("Bad double bond - Github 6160") {
+  std::string nameBase = "test_github6160";
+  auto m = "c1ccccc1NC=NCCS(=O)(=NC)N"_smiles;
+  m->setProp<std::string>("_Name", "mol1");
+  REQUIRE(m);
+  MolDraw2DSVG drawer(300, 300);
+  MolDraw2DUtils::prepareAndDrawMolecule(drawer, *m);
+  drawer.finishDrawing();
+  std::string text = drawer.getDrawingText();
+  std::ofstream outs(nameBase + ".svg");
+  outs << text;
+  outs.flush();
+  outs.close();
+  check_file_hash(nameBase + ".svg");
+}

--- a/Code/GraphMol/MolDraw2D/catch_tests.cpp
+++ b/Code/GraphMol/MolDraw2D/catch_tests.cpp
@@ -7314,7 +7314,7 @@ TEST_CASE("Bad double bond - Github 6160") {
     }
     auto vec1 = points[0].directionVector(points[1]);
     auto vec2 = points[2].directionVector(points[3]);
-    REQUIRE(fabs(1.0 - vec1.dotProduct((vec2))) < 1.0e-4);
+    CHECK(vec1.dotProduct(vec2) == Approx(1.0).margin(1.0e-4));
     check_file_hash(svgName);
   }
 }

--- a/Code/GraphMol/MolDraw2D/catch_tests.cpp
+++ b/Code/GraphMol/MolDraw2D/catch_tests.cpp
@@ -284,7 +284,10 @@ static const std::map<std::string, std::hash_result_t> SVG_HASHES = {
     {"test_complex_query_atoms_16.svg", 1980695915U},
     {"test_github6041b.svg", 3485054881U},
     {"test_github6111_1.svg", 3458417163U},
-    {"test_github6112.svg", 908847383U}};
+    {"test_github6112.svg", 908847383U},
+    {"test_github6160_1.svg", 3669327545U},
+    {"test_github6160_2.svg", 3704672111U},
+    {"test_github6160_3.svg", 2431440968U}};
 
 // These PNG hashes aren't completely reliable due to floating point cruft,
 // but they can still reduce the number of drawings that need visual
@@ -7279,7 +7282,7 @@ TEST_CASE("Bad double bond - Github 6160") {
     std::unique_ptr<ROMol> m(SmilesToMol(smiles[i]));
     m->setProp<std::string>("_Name", "mol" + std::to_string(i + 1));
     REQUIRE(m);
-    MolDraw2DSVG drawer(300, 300);
+    MolDraw2DSVG drawer(300, 300, -1, -1, NO_FREETYPE);
     // it's a bit easier to deal with in BW.
     assignBWPalette(drawer.drawOptions().atomColourPalette);
     drawer.drawOptions().addBondIndices = true;
@@ -7309,13 +7312,9 @@ TEST_CASE("Bad double bond - Github 6160") {
       points.push_back(Point2D(stod(match[1]), stod(match[2])));
       points.push_back(Point2D(stod(match[3]), stod(match[4])));
     }
-    std::cout << points[0] << " -> " << points[1] << " :: " << points[2]
-              << " -> " << points[3] << std::endl;
     auto vec1 = points[0].directionVector(points[1]);
     auto vec2 = points[2].directionVector(points[3]);
-    std::cout << vec1 << " : " << vec2 << " : " << vec1.dotProduct(vec2)
-              << std::endl;
     REQUIRE(fabs(1.0 - vec1.dotProduct((vec2))) < 1.0e-4);
-    check_file_hash(svgName + ".svg");
+    check_file_hash(svgName);
   }
 }

--- a/Code/GraphMol/MolDraw2D/catch_tests.cpp
+++ b/Code/GraphMol/MolDraw2D/catch_tests.cpp
@@ -7273,7 +7273,8 @@ TEST_CASE("ACS1996 should not throw exception with no coords - Github 6112") {
 TEST_CASE("Bad double bond - Github 6160") {
   std::string nameBase = "test_github6160";
   std::vector<std::string> smiles{"c1ccccc1NC=NCCS(=O)(=NC)N",
-                                  "c1ccccc1NC=NCCS(=O)(=NCC(Cl)(F)C)N"};
+                                  "c1ccccc1NC=NCCS(=O)(=NCC(Cl)(F)C)N",
+                                  "c1ccccc1NC=NCCS(=O)(=CCC(Cl)(F)C)N"};
   for (auto i = 0; i < smiles.size(); ++i) {
     std::unique_ptr<ROMol> m(SmilesToMol(smiles[i]));
     m->setProp<std::string>("_Name", "mol" + std::to_string(i + 1));
@@ -7286,7 +7287,8 @@ TEST_CASE("Bad double bond - Github 6160") {
     MolDraw2DUtils::prepareAndDrawMolecule(drawer, *m);
     drawer.finishDrawing();
     std::string text = drawer.getDrawingText();
-    std::ofstream outs(nameBase + "_" + std::to_string(i + 1) + ".svg");
+    std::string svgName = nameBase + "_" + std::to_string(i + 1) + ".svg";
+    std::ofstream outs(svgName);
     outs << text;
     outs.flush();
     outs.close();
@@ -7304,13 +7306,16 @@ TEST_CASE("Bad double bond - Github 6160") {
     std::vector<Point2D> points;
     for (std::sregex_iterator i = match_begin; i != match_end; ++i) {
       std::smatch match = *i;
-      points.push_back(Point2D(stod(match[4]), stod(match[2])));
+      points.push_back(Point2D(stod(match[1]), stod(match[2])));
       points.push_back(Point2D(stod(match[3]), stod(match[4])));
     }
+    std::cout << points[0] << " -> " << points[1] << " :: " << points[2]
+              << " -> " << points[3] << std::endl;
     auto vec1 = points[0].directionVector(points[1]);
     auto vec2 = points[2].directionVector(points[3]);
-    REQUIRE(!MolDraw2D_detail::doLinesIntersect(points[0], points[1], points[2],
-                                                points[3], nullptr));
+    std::cout << vec1 << " : " << vec2 << " : " << vec1.dotProduct(vec2)
+              << std::endl;
+    REQUIRE(fabs(1.0 - vec1.dotProduct((vec2))) < 1.0e-4);
+    check_file_hash(svgName + ".svg");
   }
-  check_file_hash(nameBase + ".svg");
 }


### PR DESCRIPTION
Reference Issue

Fixes https://github.com/rdkit/rdkit/issues/6160

What does this implement/fix? Explain your changes.

The drawing of aminosulfimines went badly because the drawing code assumed that there would only be 2 bonds off an atom had a double bond incident on it. In the examples supplied, this meant it was using as references 3 atoms in a straight line which made the geometry calculations blow up. It now looks through the neighbour list until it finds a non-linear triplet.

Any other comments?

Having made a complete mess of the last PR (6164) this replaces it.  Sorry for the incompetence.

Having fixed the bug itself, it was apparent that the bonds were being drawn in an ugly manner in this case where there are atomic symbols at both ends of the double bond, so I've tidied that up as well.
