### PR TITLE
Github6121

### DIFF
--- a/Code/GraphMol/DetermineBonds/DetermineBonds.cpp
+++ b/Code/GraphMol/DetermineBonds/DetermineBonds.cpp
@@ -441,6 +441,9 @@ void determineBondOrders(RWMol &mol, int charge, bool allowChargedFragments,
 void determineBonds(RWMol &mol, bool useHueckel, int charge, double covFactor,
                     bool allowChargedFragments, bool embedChiral,
                     bool useAtomMap) {
+  if(mol->getNumAtoms() <= 1){
+    return;
+  }
   determineConnectivity(mol, useHueckel, charge, covFactor);
   determineBondOrders(mol, charge, allowChargedFragments, embedChiral,
                       useAtomMap);

--- a/Code/GraphMol/DetermineBonds/catch_tests.cpp
+++ b/Code/GraphMol/DetermineBonds/catch_tests.cpp
@@ -341,6 +341,7 @@ H	  20.371657	   2.180532	   1.492305
     CHECK(m->getNumAtoms() == 102);
   }
 }
+
 TEST_CASE("Github #6121: Single Atom in DetermineBonds") {
   SECTION("as reported") {
     std::string xyz = R"XYZ(1
@@ -349,7 +350,6 @@ H   0.0         0.0           0.0
 )XYZ";
     auto m(XYZBlockToMol(xyz));
     REQUIRE(m);
-    determineBonds(*m);
-    CHECK(m->getNumAtoms() == 1);
+    CHECK(determineBonds(*m));
   }
 }

--- a/Code/GraphMol/DetermineBonds/catch_tests.cpp
+++ b/Code/GraphMol/DetermineBonds/catch_tests.cpp
@@ -14,6 +14,7 @@
 
 using namespace RDKit;
 
+
 TEST_CASE("Determine Connectivity") {
   SECTION("Van der Waals") {
     unsigned int numTests = 39;
@@ -338,5 +339,16 @@ H	  20.371657	   2.180532	   1.492305
     REQUIRE(m);
     determineBonds(*m);
     CHECK(m->getNumAtoms() == 102);
+  }
+}
+TEST_CASE("Github #6121: Single Atom in DetermineBonds") {
+  SECTION("as reported") {
+    std::string xyz = R"XYZ(1
+    H 0.0 0.0 0.0
+)XYZ";
+    auto m(XYZBlockToMol(xyz));
+    REQUIRE(m);
+    determineBonds(*m);
+    CHECK(m->getNumAtoms() == 1);
   }
 }

--- a/Code/GraphMol/DetermineBonds/catch_tests.cpp
+++ b/Code/GraphMol/DetermineBonds/catch_tests.cpp
@@ -344,7 +344,8 @@ H	  20.371657	   2.180532	   1.492305
 TEST_CASE("Github #6121: Single Atom in DetermineBonds") {
   SECTION("as reported") {
     std::string xyz = R"XYZ(1
-    H 0.0 0.0 0.0
+
+H   0.0         0.0           0.0
 )XYZ";
     auto m(XYZBlockToMol(xyz));
     REQUIRE(m);


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! 
-->
#### Reference Issue
<!-- Example: Fixes #6121  -->


#### What does this implement/fix? Explain your changes.

##### The Issue
`rdDetermineBonds.DetermineBonds()` throws an error `ValueError: Final molecular charge does not match input; could not find valid bond ordering` when used for a single atom. 

##### The Fix
When a single atom is inputted into the determineBonds() function it will now check the number of atoms in the mol object and if it is <= 1 it will return to prevent an error from being thrown.

I have also included a test specific to this issue in DetermineBonds/catch_tests.cpp

#### Any other comments?
This is my first official commit to an open-source project, so if there is ANYTHING I can do better please tell me. Nothing will be taken to heart but I want to get better at programming.

