### PR TITLE
Fixes #5883

### DIFF
--- a/Code/GraphMol/DistGeomHelpers/Wrap/testDistGeom.py
+++ b/Code/GraphMol/DistGeomHelpers/Wrap/testDistGeom.py
@@ -274,7 +274,7 @@ class TestCase(unittest.TestCase):
     self.assertTrue(nPos > 0)
     self.assertTrue(nNeg > 0)
 
-    tgtVol = 5.0
+    tgtVol = 3.0
     for i in range(10):
       smiles = "Cl[C@H](F)Br"
       mol = Chem.MolFromSmiles(smiles)

--- a/Code/GraphMol/DistGeomHelpers/catch_tests.cpp
+++ b/Code/GraphMol/DistGeomHelpers/catch_tests.cpp
@@ -589,10 +589,8 @@ TEST_CASE("double bond stereo not honored in conformer generator") {
   }
 }
 
-TEST_CASE("tracking failure causes") {
-  SECTION("basics") {
-    // auto mol = "CCNS(=O)(=O)c1ccccc1"_smiles;
-    // auto mol = "c2cccc3c2OC2=CC=CC[C@H]23"_smiles;
+TEST_CASE("tracking failure causes"){
+  SECTION("basics"){
     auto mol =
         "C=CC1=C(N)Oc2cc1c(-c1cc(C(C)O)cc(=O)cc1C1NCC(=O)N1)c(OC)c2OC"_smiles;
     REQUIRE(mol);
@@ -615,32 +613,32 @@ TEST_CASE("tracking failure causes") {
   }
   SECTION("chirality") {
     auto mol = R"CTAB(
-  Ketcher  1102315302D 1   1.00000     0.00000     0
+    Ketcher  1102315302D 1   1.00000     0.00000     0
 
- 10 11  0  0  1  0  0  0  0  0999 V2000
-   10.1340  -11.0250    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
-   10.1340  -12.0250    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
-   11.0000  -12.5250    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
-   11.8660  -12.0250    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
-   11.8660  -11.0250    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
-   11.0000  -10.5250    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
-   11.0000  -11.5250    0.0000 N   0  0  0  0  0  0  0  0  0  0  0  0
-   11.2588  -12.4909    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
-    9.2680  -10.5250    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
-   12.7629  -12.4673    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
-  1  6  1  0     0  0
-  1  2  1  0     0  0
-  2  3  1  0     0  0
-  3  4  1  0     0  0
-  4  5  1  0     0  0
-  5  6  1  0     0  0
-  1  7  1  0     0  0
-  7  8  1  0     0  0
-  8  4  1  0     0  0
-  1  9  1  1     0  0
-  4 10  1  1     0  0
-M  END
-)CTAB"_ctab;
+  10 11  0  0  1  0  0  0  0  0999 V2000
+    10.1340  -11.0250    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    10.1340  -12.0250    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    11.0000  -12.5250    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    11.8660  -12.0250    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    11.8660  -11.0250    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    11.0000  -10.5250    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
+    11.0000  -11.5250    0.0000 N   0  0  0  0  0  0  0  0  0  0  0  0
+    11.2588  -12.4909    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+      9.2680  -10.5250    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    12.7629  -12.4673    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    1  6  1  0     0  0
+    1  2  1  0     0  0
+    2  3  1  0     0  0
+    3  4  1  0     0  0
+    4  5  1  0     0  0
+    5  6  1  0     0  0
+    1  7  1  0     0  0
+    7  8  1  0     0  0
+    8  4  1  0     0  0
+    1  9  1  1     0  0
+    4 10  1  1     0  0
+  M  END
+  )CTAB"_ctab;
     REQUIRE(mol);
     MolOps::addHs(*mol);
     DGeomHelpers::EmbedParameters ps = DGeomHelpers::ETKDGv3;
@@ -650,8 +648,7 @@ M  END
     auto cid = DGeomHelpers::EmbedMolecule(*mol, ps);
     CHECK(cid < 0);
     CHECK(ps.failures[DGeomHelpers::EmbedFailureCauses::INITIAL_COORDS] > 5);
-    CHECK(ps.failures[DGeomHelpers::EmbedFailureCauses::FINAL_CHIRAL_BOUNDS] >
-          5);
+    CHECK(ps.failures[DGeomHelpers::EmbedFailureCauses::FINAL_CHIRAL_BOUNDS] > 5);
   }
 
 #ifdef RDK_TEST_MULTITHREADED
@@ -676,4 +673,40 @@ M  END
     CHECK(ps.failures == ps2.failures);
   }
 #endif
+}
+
+TEST_CASE("Github #5883: confgen failing for chiral N in a three ring") {
+  SECTION("basics1") {
+    auto mol = "N1[C@H-]C1"_smiles;
+    REQUIRE(mol);
+    MolOps::addHs(*mol);
+    mol->getAtomWithIdx(1)->setChiralTag(Atom::ChiralType::CHI_TETRAHEDRAL_CCW);
+    DGeomHelpers::EmbedParameters ps = DGeomHelpers::ETKDGv3;
+    ps.randomSeed = 42;
+    ps.maxIterations = 1;
+    auto cid = DGeomHelpers::EmbedMolecule(*mol, ps);
+    CHECK(cid >= 0);
+  }
+  SECTION("basics2") {
+    auto mol = "N1[N@H]C1"_smiles;
+    REQUIRE(mol);
+    MolOps::addHs(*mol);
+    mol->getAtomWithIdx(1)->setChiralTag(Atom::ChiralType::CHI_TETRAHEDRAL_CCW);
+    DGeomHelpers::EmbedParameters ps = DGeomHelpers::ETKDGv3;
+    ps.randomSeed = 42;
+    ps.maxIterations = 1;
+    auto cid = DGeomHelpers::EmbedMolecule(*mol, ps);
+    CHECK(cid >= 0);
+  }
+  SECTION("no ring") {
+    auto mol = "N[C@H-]C"_smiles;
+    REQUIRE(mol);
+    MolOps::addHs(*mol);
+    mol->getAtomWithIdx(1)->setChiralTag(Atom::ChiralType::CHI_TETRAHEDRAL_CCW);
+    DGeomHelpers::EmbedParameters ps = DGeomHelpers::ETKDGv3;
+    ps.randomSeed = 42;
+    ps.maxIterations = 1;
+    auto cid = DGeomHelpers::EmbedMolecule(*mol, ps);
+    CHECK(cid >= 0);
+  }
 }

--- a/Code/GraphMol/DistGeomHelpers/catch_tests.cpp
+++ b/Code/GraphMol/DistGeomHelpers/catch_tests.cpp
@@ -589,89 +589,88 @@ TEST_CASE("double bond stereo not honored in conformer generator") {
   }
 }
 
-TEST_CASE("tracking failure causes"){
-  SECTION("basics"){
+TEST_CASE("tracking failure causes"){SECTION("basics"){
     auto mol =
         "C=CC1=C(N)Oc2cc1c(-c1cc(C(C)O)cc(=O)cc1C1NCC(=O)N1)c(OC)c2OC"_smiles;
-    REQUIRE(mol);
-    MolOps::addHs(*mol);
-    DGeomHelpers::EmbedParameters ps = DGeomHelpers::ETKDGv3;
-    ps.randomSeed = 0xf00d;
-    ps.trackFailures = true;
-    ps.maxIterations = 50;
-    ps.randomSeed = 42;
-    auto cid = DGeomHelpers::EmbedMolecule(*mol, ps);
-    CHECK(cid < 0);
+REQUIRE(mol);
+MolOps::addHs(*mol);
+DGeomHelpers::EmbedParameters ps = DGeomHelpers::ETKDGv3;
+ps.randomSeed = 0xf00d;
+ps.trackFailures = true;
+ps.maxIterations = 50;
+ps.randomSeed = 42;
+auto cid = DGeomHelpers::EmbedMolecule(*mol, ps);
+CHECK(cid < 0);
 
-    CHECK(ps.failures[DGeomHelpers::EmbedFailureCauses::INITIAL_COORDS] > 5);
-    CHECK(ps.failures[DGeomHelpers::EmbedFailureCauses::ETK_MINIMIZATION] > 10);
+CHECK(ps.failures[DGeomHelpers::EmbedFailureCauses::INITIAL_COORDS] > 5);
+CHECK(ps.failures[DGeomHelpers::EmbedFailureCauses::ETK_MINIMIZATION] > 10);
 
-    auto fail_cp = ps.failures;
-    // make sure we reset the counts each time
-    cid = DGeomHelpers::EmbedMolecule(*mol, ps);
-    CHECK(ps.failures == fail_cp);
-  }
-  SECTION("chirality") {
-    auto mol = R"CTAB(
-    Ketcher  1102315302D 1   1.00000     0.00000     0
+auto fail_cp = ps.failures;
+// make sure we reset the counts each time
+cid = DGeomHelpers::EmbedMolecule(*mol, ps);
+CHECK(ps.failures == fail_cp);
+}
+SECTION("chirality") {
+  auto mol = R"CTAB(
+  Ketcher  1102315302D 1   1.00000     0.00000     0
 
-  10 11  0  0  1  0  0  0  0  0999 V2000
-    10.1340  -11.0250    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
-    10.1340  -12.0250    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
-    11.0000  -12.5250    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
-    11.8660  -12.0250    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
-    11.8660  -11.0250    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
-    11.0000  -10.5250    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
-    11.0000  -11.5250    0.0000 N   0  0  0  0  0  0  0  0  0  0  0  0
-    11.2588  -12.4909    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
-      9.2680  -10.5250    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
-    12.7629  -12.4673    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
-    1  6  1  0     0  0
-    1  2  1  0     0  0
-    2  3  1  0     0  0
-    3  4  1  0     0  0
-    4  5  1  0     0  0
-    5  6  1  0     0  0
-    1  7  1  0     0  0
-    7  8  1  0     0  0
-    8  4  1  0     0  0
-    1  9  1  1     0  0
-    4 10  1  1     0  0
-  M  END
-  )CTAB"_ctab;
-    REQUIRE(mol);
-    MolOps::addHs(*mol);
-    DGeomHelpers::EmbedParameters ps = DGeomHelpers::ETKDGv3;
-    ps.randomSeed = 0xf00d;
-    ps.trackFailures = true;
-    ps.maxIterations = 50;
-    auto cid = DGeomHelpers::EmbedMolecule(*mol, ps);
-    CHECK(cid < 0);
-    CHECK(ps.failures[DGeomHelpers::EmbedFailureCauses::INITIAL_COORDS] > 5);
-    CHECK(ps.failures[DGeomHelpers::EmbedFailureCauses::FINAL_CHIRAL_BOUNDS] > 5);
-  }
+ 10 11  0  0  1  0  0  0  0  0999 V2000
+   10.1340  -11.0250    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   10.1340  -12.0250    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   11.0000  -12.5250    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   11.8660  -12.0250    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   11.8660  -11.0250    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   11.0000  -10.5250    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
+   11.0000  -11.5250    0.0000 N   0  0  0  0  0  0  0  0  0  0  0  0
+   11.2588  -12.4909    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    9.2680  -10.5250    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   12.7629  -12.4673    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+  1  6  1  0     0  0
+  1  2  1  0     0  0
+  2  3  1  0     0  0
+  3  4  1  0     0  0
+  4  5  1  0     0  0
+  5  6  1  0     0  0
+  1  7  1  0     0  0
+  7  8  1  0     0  0
+  8  4  1  0     0  0
+  1  9  1  1     0  0
+  4 10  1  1     0  0
+M  END
+)CTAB"_ctab;
+  REQUIRE(mol);
+  MolOps::addHs(*mol);
+  DGeomHelpers::EmbedParameters ps = DGeomHelpers::ETKDGv3;
+  ps.randomSeed = 0xf00d;
+  ps.trackFailures = true;
+  ps.maxIterations = 50;
+  auto cid = DGeomHelpers::EmbedMolecule(*mol, ps);
+  CHECK(cid < 0);
+  CHECK(ps.failures[DGeomHelpers::EmbedFailureCauses::INITIAL_COORDS] > 5);
+  CHECK(ps.failures[DGeomHelpers::EmbedFailureCauses::FINAL_CHIRAL_BOUNDS] > 5);
+}
 
 #ifdef RDK_TEST_MULTITHREADED
-  SECTION("multithreaded") {
-    auto mol =
-        "C=CC1=C(N)Oc2cc1c(-c1cc(C(C)O)cc(=O)cc1C1NCC(=O)N1)c(OC)c2OC"_smiles;
-    REQUIRE(mol);
-    MolOps::addHs(*mol);
-    DGeomHelpers::EmbedParameters ps = DGeomHelpers::ETKDGv3;
-    ps.randomSeed = 0xf00d;
-    ps.trackFailures = true;
-    ps.maxIterations = 10;
-    ps.randomSeed = 42;
-    auto cids = DGeomHelpers::EmbedMultipleConfs(*mol, 20, ps);
+SECTION("multithreaded") {
+  auto mol =
+      "C=CC1=C(N)Oc2cc1c(-c1cc(C(C)O)cc(=O)cc1C1NCC(=O)N1)c(OC)c2OC"_smiles;
+  REQUIRE(mol);
+  MolOps::addHs(*mol);
+  DGeomHelpers::EmbedParameters ps = DGeomHelpers::ETKDGv3;
+  ps.randomSeed = 0xf00d;
+  ps.trackFailures = true;
+  ps.maxIterations = 10;
+  ps.randomSeed = 42;
+  auto cids = DGeomHelpers::EmbedMultipleConfs(*mol, 20, ps);
 
-    DGeomHelpers::EmbedParameters ps2 = ps;
-    ps2.numThreads = 4;
+  DGeomHelpers::EmbedParameters ps2 = ps;
+  ps2.numThreads = 4;
 
-    auto cids2 = DGeomHelpers::EmbedMultipleConfs(*mol, 20, ps2);
-    CHECK(cids2 == cids);
+  auto cids2 = DGeomHelpers::EmbedMultipleConfs(*mol, 20, ps2);
+  CHECK(cids2 == cids);
 
-    CHECK(ps.failures == ps2.failures);
-  }
+  CHECK(ps.failures == ps2.failures);
+}
 #endif
 }
 

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -11,6 +11,8 @@
 - The canonical SMILES and CXSMILES generated for molecules with enhanced stereochemistry (stereo groups) is different than in previous releases. The enhanced stereochemistry information and the stereo groups themselves are now canonical. This does *not* affect molecules which do not have enhanced stereo and will not have any effect if you generate non-isomeric SMILES. This change also affects the output of the MolHash and RegistrationHash code when applied to molecules with enhanced stereo.
 - The doIsomericSmiles parameter in Java and C# ROMol.MolToSmiles() now defaults to true (previously it was false), thus aligning to the C++ and Python behavior.
 - Double bonds which are marked as crossed (i.e. `bond.GetBondDir() == Bond.BondDir.EITHERDOUBLE`) now have their BondStereo set to `Bond.BondStereo.STEREOANY` and the BondDir information removed by default when molecules are parsed or `AssignStereochemistry()` is called with the `cleanIt` argument set to True.
+- The conformers generated for molecules with three-coordinate chiral centers will be somewhat different due to the fix for #5883.
+
 
 ## Bug Fixes:
 


### PR DESCRIPTION
The fix here is to recognize that the expected chiral volume for three-coordinate atoms is smaller than that for four-coordinate atoms.
The corrected value here is empirical