### PR TITLE
Fix/github6138

### DIFF
--- a/Code/GraphMol/ChemReactions/ReactionPickler.cpp
+++ b/Code/GraphMol/ChemReactions/ReactionPickler.cpp
@@ -146,16 +146,18 @@ void ReactionPickler::_pickle(const ChemicalReaction *rxn, std::ostream &ss,
   streamWrite(ss, BEGINREACTANTS);
   for (auto tmpl = rxn->beginReactantTemplates();
        tmpl != rxn->endReactantTemplates(); ++tmpl) {
-    MolPickler::pickleMol(tmpl->get(), ss,
-                          PicklerOps::PropertyPickleOptions::AllProps);
+    auto props = rxn->df_needsInit ? PicklerOps::PropertyPickleOptions::NoProps :
+      PicklerOps::PropertyPickleOptions::AllProps;
+    MolPickler::pickleMol(tmpl->get(), ss, props);
   }
   streamWrite(ss, ENDREACTANTS);
 
   streamWrite(ss, BEGINPRODUCTS);
   for (auto tmpl = rxn->beginProductTemplates();
        tmpl != rxn->endProductTemplates(); ++tmpl) {
-    MolPickler::pickleMol(tmpl->get(), ss,
-                          PicklerOps::PropertyPickleOptions::AllProps);
+    auto props = rxn->df_needsInit ? PicklerOps::PropertyPickleOptions::AtomProps :
+      PicklerOps::PropertyPickleOptions::AllProps;
+    MolPickler::pickleMol(tmpl->get(), ss, props);
   }
   streamWrite(ss, ENDPRODUCTS);
 

--- a/Code/GraphMol/ChemReactions/ReactionPickler.cpp
+++ b/Code/GraphMol/ChemReactions/ReactionPickler.cpp
@@ -165,7 +165,8 @@ void ReactionPickler::_pickle(const ChemicalReaction *rxn, std::ostream &ss,
     streamWrite(ss, BEGINAGENTS);
     for (auto tmpl = rxn->beginAgentTemplates();
          tmpl != rxn->endAgentTemplates(); ++tmpl) {
-      MolPickler::pickleMol(tmpl->get(), ss);
+      // reagents don't have private properties set during initialization
+      MolPickler::pickleMol(tmpl->get(), ss, PicklerOps::PropertyPickleOptions::AtomProps);
     }
     streamWrite(ss, ENDAGENTS);
   }

--- a/Code/GraphMol/ChemReactions/ReactionPickler.cpp
+++ b/Code/GraphMol/ChemReactions/ReactionPickler.cpp
@@ -146,7 +146,8 @@ void ReactionPickler::_pickle(const ChemicalReaction *rxn, std::ostream &ss,
   streamWrite(ss, BEGINREACTANTS);
   for (auto tmpl = rxn->beginReactantTemplates();
        tmpl != rxn->endReactantTemplates(); ++tmpl) {
-    MolPickler::pickleMol(tmpl->get(), ss);
+    MolPickler::pickleMol(tmpl->get(), ss,
+                          PicklerOps::PropertyPickleOptions::AllProps);
   }
   streamWrite(ss, ENDREACTANTS);
 
@@ -154,7 +155,7 @@ void ReactionPickler::_pickle(const ChemicalReaction *rxn, std::ostream &ss,
   for (auto tmpl = rxn->beginProductTemplates();
        tmpl != rxn->endProductTemplates(); ++tmpl) {
     MolPickler::pickleMol(tmpl->get(), ss,
-                          PicklerOps::PropertyPickleOptions::AtomProps);
+                          PicklerOps::PropertyPickleOptions::AllProps);
   }
   streamWrite(ss, ENDPRODUCTS);
 

--- a/Code/GraphMol/ChemReactions/Wrap/testReactionWrapper.py
+++ b/Code/GraphMol/ChemReactions/Wrap/testReactionWrapper.py
@@ -38,7 +38,7 @@ import pickle
 
 from rdkit import rdBase
 from rdkit import Chem
-from rdkit.Chem import rdChemReactions
+from rdkit.Chem import AllChem, rdChemReactions
 from rdkit import Geometry
 from rdkit import RDConfig
 from rdkit.Chem.SimpleEnum import Enumerator

--- a/Code/GraphMol/ChemReactions/Wrap/testReactionWrapper.py
+++ b/Code/GraphMol/ChemReactions/Wrap/testReactionWrapper.py
@@ -1082,6 +1082,21 @@ M  END
 
     self.assertEqual(reaction.GetNumReactantTemplates(), reaction2.GetNumReactantTemplates())
 
+  def testGithub6138(self):
+    mol = Chem.MolFromSmiles("COc1ccccc1Oc1nc(Nc2cc(C)[nH]n2)cc2ccccc12")
+    rxn = AllChem.ReactionFromSmarts("([c:1]:[n&H1&+0&D2:3]:[n:2])>>([c:1]:[n&H0&+0&D3:3](:[n:2])-C1-C-C-C-C-O-1)")
+
+    def run(r):
+      return Chem.MolToSmiles(r.RunReactants((mol,))[0][0])
+
+    rxn_reloaded = pickle.loads(pickle.dumps(rxn))
+
+    res1 = Chem.MolToSmiles(rxn.RunReactants((mol,))[0][0])
+    res2 = Chem.MolToSmiles(rxn_reloaded.RunReactants((mol,))[0][0])
+    rxn_reloaded_after_use = pickle.loads(pickle.dumps(rxn))
+    res3 = Chem.MolToSmiles(rxn_reloaded_after_use.RunReactants((mol,))[0][0])
+    self.assertEqual(res1, res2)
+    self.assertEqual(res1, res3)
 
 if __name__ == '__main__':
   unittest.main(verbosity=True)

--- a/Code/GraphMol/ChemReactions/testReaction.cpp
+++ b/Code/GraphMol/ChemReactions/testReaction.cpp
@@ -7775,6 +7775,26 @@ void testChemicalReactionCopyAssignment() {
   delete rxn2;
 }
 
+void testGithub6138() {
+  // Pickling reactions removed some of their properties set after reaction
+    // initialization
+  auto rxn_smarts = "[c:1]:[n&H1&+0&D2:3]:[n:2]>>[c:1]:[3n&H0&+0&D3:3]:[2n:2]";
+  std::unique_ptr<ChemicalReaction> rxn(RxnSmartsToChemicalReaction(rxn_smarts));
+  ROMOL_SPTR mol("c1cn[nH]c1"_smiles);
+  rxn->initReactantMatchers();
+  MOL_SPTR_VECT reacts;
+  reacts.push_back(mol);
+  auto prods = rxn->runReactants(reacts);
+  std::string pkl;
+  ReactionPickler::pickleReaction(*rxn, pkl);
+  std::unique_ptr<ChemicalReaction> lrxn(new ChemicalReaction());
+  ReactionPickler::reactionFromPickle(pkl, lrxn.get());
+  auto prods2 = lrxn->runReactants(reacts);
+  auto s1 =MolToSmiles(*prods[0][0]);
+  auto s2 =MolToSmiles(*prods2[0][0]);
+  TEST_ASSERT(s1 == s2);
+}
+
 int main() {
   RDLog::InitLogs();
 
@@ -7874,6 +7894,7 @@ int main() {
   testGithub4410();
   testMultiTemplateRxnQueries();
   testChemicalReactionCopyAssignment();
+  testGithub6138();
 
   BOOST_LOG(rdInfoLog)
       << "*******************************************************\n";


### PR DESCRIPTION
Fixed #6138 

There are a few atom properties that are not pickled properly after ChemReaction::validate has been called.

These are 

 _QueryIsotope
 _QueryFormalCharge

and the like.

This ensures they are pickled if the reaction has been initialized.