### PR TITLE
ReactionFromRxnBlock fails on bond with reacting center status set 

### DIFF
--- a/Code/GraphMol/ChemReactions/catch_tests.cpp
+++ b/Code/GraphMol/ChemReactions/catch_tests.cpp
@@ -1413,3 +1413,49 @@ TEST_CASE("Github #6015: Reactions do not propagate query information to product
    
   }
 }
+
+TEST_CASE(
+  "Github #6195: Failed to parse reaction with reacting center status set on bond") {
+  SECTION("check parse") {
+    std::string rxnBlock = R"RXN($RXN
+ACS Document 1996
+  ChemDraw03132312282D
+
+  1  1
+$MOL
+
+
+
+  4  3  0  0  0  0  0  0  0  0999 V2000
+   -0.0000    0.6187    0.0000 O   0  0  0  0  0  0  0  0  0  1  0  0
+   -0.0000   -0.2062    0.0000 C   0  0  0  0  0  0  0  0  0  2  0  0
+   -0.7145   -0.6187    0.0000 C   0  0  0  0  0  0  0  0  0  3  0  0
+    0.7145   -0.6187    0.0000 O   0  0  0  0  0  0  0  0  0  4  0  0
+  1  2  2  0        0
+  2  3  1  0        0
+  2  4  1  0        0
+M  END
+$MOL
+
+
+
+  5  4  0  0  0  0  0  0  0  0999 V2000
+   -0.3572    0.6187    0.0000 O   0  0  0  0  0  0  0  0  0  1  0  0
+   -0.3572   -0.2062    0.0000 C   0  0  0  0  0  0  0  0  0  2  0  0
+   -1.0717   -0.6187    0.0000 C   0  0  0  0  0  0  0  0  0  3  0  0
+    0.3572   -0.6187    0.0000 O   0  0  0  0  0  0  0  0  0  4  0  0
+    1.0717   -0.2062    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+  1  2  2  0        0
+  2  3  1  0        0
+  2  4  1  0        0
+  4  5  1  0        4
+M  END
+)RXN";
+    std::unique_ptr<ChemicalReaction> rxn(RxnBlockToChemicalReaction(rxnBlock));
+    REQUIRE(rxn);
+    CHECK(rxn->getNumReactantTemplates()==1);
+    CHECK(rxn->getNumProductTemplates()==1);
+    CHECK(rxn->getNumAgentTemplates()==0);
+    CHECK(rxn->getProducts()[0]->getBondWithIdx(3)->getProp<int>("molReactStatus") == 4);
+  }
+}

--- a/Code/GraphMol/FileParsers/MolFileParser.cpp
+++ b/Code/GraphMol/FileParsers/MolFileParser.cpp
@@ -81,7 +81,9 @@ int toInt(const std::string_view input, bool acceptSpaces) {
       --sz;
       // have we run off the end of the view?
       if (sz < 1U) {
-        throw boost::bad_lexical_cast();
+        // If we have a blank input string, should this throw or return 0?
+        // throw boost::bad_lexical_cast();
+        return 0;
       }
     }
   }
@@ -116,7 +118,9 @@ unsigned int toUnsigned(const std::string_view input, bool acceptSpaces) {
       --sz;
       // have we run off the end of the view?
       if (sz < 1U) {
-        throw boost::bad_lexical_cast();
+        // If we have a blank input string, should this throw or return 0?
+        // throw boost::bad_lexical_cast();
+        return 0;
       }
     }
   }

--- a/Code/GraphMol/FileParsers/MolFileParser.cpp
+++ b/Code/GraphMol/FileParsers/MolFileParser.cpp
@@ -79,10 +79,15 @@ int toInt(const std::string_view input, bool acceptSpaces) {
     while (*txt == ' ') {
       ++txt;
       --sz;
+      // have we run off the end of the view?
+      if (sz < 1U) {
+        throw boost::bad_lexical_cast();
+      }
     }
   }
   int res = 0;
   std::from_chars(txt, txt + sz, res);
+
   return res;
 }
 int toInt(const std::string &input, bool acceptSpaces) {

--- a/Code/GraphMol/FileParsers/MolFileParser.cpp
+++ b/Code/GraphMol/FileParsers/MolFileParser.cpp
@@ -81,8 +81,6 @@ int toInt(const std::string_view input, bool acceptSpaces) {
       --sz;
       // have we run off the end of the view?
       if (sz < 1U) {
-        // If we have a blank input string, should this throw or return 0?
-        // throw boost::bad_lexical_cast();
         return 0;
       }
     }

--- a/Code/GraphMol/FileParsers/MolFileParser.cpp
+++ b/Code/GraphMol/FileParsers/MolFileParser.cpp
@@ -116,8 +116,6 @@ unsigned int toUnsigned(const std::string_view input, bool acceptSpaces) {
       --sz;
       // have we run off the end of the view?
       if (sz < 1U) {
-        // If we have a blank input string, should this throw or return 0?
-        // throw boost::bad_lexical_cast();
         return 0;
       }
     }

--- a/Code/GraphMol/FileParsers/MolFileParser.cpp
+++ b/Code/GraphMol/FileParsers/MolFileParser.cpp
@@ -114,6 +114,10 @@ unsigned int toUnsigned(const std::string_view input, bool acceptSpaces) {
     while (*txt == ' ') {
       ++txt;
       --sz;
+      // have we run off the end of the view?
+      if (sz < 1U) {
+        throw boost::bad_lexical_cast();
+      }
     }
   }
   unsigned int res = 0;


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! 
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->

Fixes #6195

#### What does this implement/fix? Explain your changes.

There is a bug in ` MolFileParser::toInt` that this PR fixes.  Here
```C++
  // remove leading spaces
  txt = input.data();
  unsigned int sz = input.size();
  if (acceptSpaces) {
    while (*txt == ' ') {
      ++txt;
      --sz;
    }
  }
  int res = 0;
  std::from_chars(txt, txt + sz, res);

  return res;

```
`sz` can end up being negative if the `input` string view is all spaces.

This is what happens when parsing the topology entry for the bond line
```
  4  5  1  0        4
```

The topology entry is all spaces and `txt` ends up pointing to 4 (the bond reaction center) with `sz` negative. 4 is returned and an exception thrown.

#### Any other comments?

