### PR TITLE
add features to allow drawing molecules in arbitrary positions on a large canvas

### DIFF
--- a/Code/GraphMol/MolDraw2D/DrawMol.cpp
+++ b/Code/GraphMol/MolDraw2D/DrawMol.cpp
@@ -63,8 +63,8 @@ DrawMol::DrawMol(
       yMax_(std::numeric_limits<double>::lowest() / 2.0),
       xRange_(std::numeric_limits<double>::max()),
       yRange_(std::numeric_limits<double>::max()),
-      flexiCanvasX_(width_ < 0.0),
-      flexiCanvasY_(height_ < 0.0) {
+      flexiCanvasX_(width < 0.0),
+      flexiCanvasY_(height < 0.0) {
   if (highlight_atoms) {
     highlightAtoms_ = *highlight_atoms;
   }

--- a/Code/GraphMol/MolDraw2D/DrawMol.cpp
+++ b/Code/GraphMol/MolDraw2D/DrawMol.cpp
@@ -2911,7 +2911,7 @@ void DrawMol::bondNonRing(const Bond &bond, double offset, Point2D &l2s,
   // opposite at1 to at2.
   auto nonColinearNbor = [&](Atom *at1, Atom *at2) -> const Atom * {
     const Atom *thirdAtom = nullptr;
-    for (auto i = 1; i < at1->getDegree(); ++i) {
+    for (auto i = 1u; i < at1->getDegree(); ++i) {
       thirdAtom = otherNeighbor(at1, at2, i, *drawMol_);
       if (!areBondsParallel(atCds_[at1->getIdx()], atCds_[at2->getIdx()],
                             atCds_[at1->getIdx()],

--- a/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
@@ -1179,7 +1179,6 @@ std::pair<int, int> MolDraw2D::getMolSize(
       mol, legend, panelWidth(), panelHeight(), drawOptions(), *text_drawer_,
       highlight_atoms, highlight_bonds, highlight_atom_map, highlight_bond_map,
       nullptr, highlight_radii, supportsAnnotations(), confId);
-  dm.setOffsets(x_offset_, y_offset_);
   dm.createDrawObjects();
   return std::make_pair(dm.width_, dm.height_);
 }

--- a/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
@@ -774,10 +774,16 @@ void MolDraw2D::setActiveAtmIdx(int at_idx1, int at_idx2) {
 void MolDraw2D::fixVariableDimensions(
     const MolDraw2D_detail::DrawMol &drawMol) {
   if (panel_width_ == -1) {
-    width_ = panel_width_ = drawMol.width_;
+    width_ = drawMol.width_;
+    if (!flexiMode_) {
+      panel_width_ = width_;
+    }
   }
   if (panel_height_ == -1) {
-    height_ = panel_height_ = drawMol.height_;
+    height_ = drawMol.height_;
+    if (!flexiMode_) {
+      panel_height_ = height_;
+    }
   }
 }
 
@@ -1159,6 +1165,23 @@ void MolDraw2D::setupTextDrawer() {
     BOOST_LOG(rdWarningLog) << "Falling back to original font file "
                             << text_drawer_->getFontFile() << "." << std::endl;
   }
+}
+
+std::pair<int, int> MolDraw2D::getMolSize(
+    const ROMol &mol, const std::string &legend,
+    const std::vector<int> *highlight_atoms,
+    const std::vector<int> *highlight_bonds,
+    const std::map<int, DrawColour> *highlight_atom_map,
+    const std::map<int, DrawColour> *highlight_bond_map,
+    const std::map<int, double> *highlight_radii, int confId) {
+  setupTextDrawer();
+  MolDraw2D_detail::DrawMol dm(
+      mol, legend, panelWidth(), panelHeight(), drawOptions(), *text_drawer_,
+      highlight_atoms, highlight_bonds, highlight_atom_map, highlight_bond_map,
+      nullptr, highlight_radii, supportsAnnotations(), confId);
+  dm.setOffsets(x_offset_, y_offset_);
+  dm.createDrawObjects();
+  return std::make_pair(dm.width_, dm.height_);
 }
 
 }  // namespace RDKit

--- a/Code/GraphMol/MolDraw2D/MolDraw2D.h
+++ b/Code/GraphMol/MolDraw2D/MolDraw2D.h
@@ -331,7 +331,7 @@ class RDKIT_MOLDRAW2D_EXPORT MolDraw2D {
   //! return the height of the drawing panels.
   int panelHeight() const { return panel_height_; }
 
-  //! when FlexiMode is set, molecules will always been drawn
+  //! when FlexiMode is set, molecules will always be drawn
   //! with the default values for bond length, font size, etc.
   void setFlexiMode(bool mode) {
     flexiMode_ = mode;

--- a/Code/GraphMol/MolDraw2D/MolDraw2D.h
+++ b/Code/GraphMol/MolDraw2D/MolDraw2D.h
@@ -85,7 +85,7 @@ class RDKIT_MOLDRAW2D_EXPORT MolDraw2D {
     coordinates
 
   */
-  virtual void drawMolecule(
+  void drawMolecule(
       const ROMol &mol, const std::string &legend,
       const std::vector<int> *highlight_atoms,
       const std::vector<int> *highlight_bonds,
@@ -94,20 +94,21 @@ class RDKIT_MOLDRAW2D_EXPORT MolDraw2D {
       const std::map<int, double> *highlight_radii = nullptr, int confId = -1);
 
   //! \overload
-  virtual void drawMolecule(
-      const ROMol &mol, const std::vector<int> *highlight_atoms = nullptr,
-      const std::map<int, DrawColour> *highlight_map = nullptr,
-      const std::map<int, double> *highlight_radii = nullptr, int confId = -1);
+  void drawMolecule(const ROMol &mol,
+                    const std::vector<int> *highlight_atoms = nullptr,
+                    const std::map<int, DrawColour> *highlight_map = nullptr,
+                    const std::map<int, double> *highlight_radii = nullptr,
+                    int confId = -1);
 
   //! \overload
-  virtual void drawMolecule(
-      const ROMol &mol, const std::string &legend,
-      const std::vector<int> *highlight_atoms = nullptr,
-      const std::map<int, DrawColour> *highlight_map = nullptr,
-      const std::map<int, double> *highlight_radii = nullptr, int confId = -1);
+  void drawMolecule(const ROMol &mol, const std::string &legend,
+                    const std::vector<int> *highlight_atoms = nullptr,
+                    const std::map<int, DrawColour> *highlight_map = nullptr,
+                    const std::map<int, double> *highlight_radii = nullptr,
+                    int confId = -1);
 
   //! \overload
-  virtual void drawMolecule(
+  void drawMolecule(
       const ROMol &mol, const std::vector<int> *highlight_atoms,
       const std::vector<int> *highlight_bonds,
       const std::map<int, DrawColour> *highlight_atom_map = nullptr,
@@ -131,7 +132,7 @@ class RDKIT_MOLDRAW2D_EXPORT MolDraw2D {
     \param confId          : (optional) conformer ID to be used for atomic
     coordinates
   */
-  virtual void drawMoleculeWithHighlights(
+  void drawMoleculeWithHighlights(
       const ROMol &mol, const std::string &legend,
       const std::map<int, std::vector<DrawColour>> &highlight_atom_map,
       const std::map<int, std::vector<DrawColour>> &highlight_bond_map,
@@ -165,7 +166,7 @@ class RDKIT_MOLDRAW2D_EXPORT MolDraw2D {
     If the number of rows or columns ends up being <= 1, molecules will be
     being drawn in a single row/column.
   */
-  virtual void drawMolecules(
+  void drawMolecules(
       const std::vector<ROMol *> &mols,
       const std::vector<std::string> *legends = nullptr,
       const std::vector<std::vector<int>> *highlight_atoms = nullptr,
@@ -189,7 +190,7 @@ class RDKIT_MOLDRAW2D_EXPORT MolDraw2D {
     \param confIds   : (optional) vector of confIds to use for rendering. These
     are numbered by reactants, then agents, then products.
   */
-  virtual void drawReaction(
+  void drawReaction(
       const ChemicalReaction &rxn, bool highlightByReactant = false,
       const std::vector<DrawColour> *highlightColorsReactants = nullptr,
       const std::vector<int> *confIds = nullptr);
@@ -358,7 +359,9 @@ class RDKIT_MOLDRAW2D_EXPORT MolDraw2D {
   virtual const DashPattern &dash() const { return curr_dash_; }
 
   //! sets the current line width
-  virtual void setLineWidth(double width) { drawOptions().bondLineWidth = width; }
+  virtual void setLineWidth(double width) {
+    drawOptions().bondLineWidth = width;
+  }
   //! returns the current line width
   virtual double lineWidth() const { return drawOptions().bondLineWidth; }
 

--- a/Code/GraphMol/MolDraw2D/MolDraw2D.h
+++ b/Code/GraphMol/MolDraw2D/MolDraw2D.h
@@ -195,6 +195,15 @@ class RDKIT_MOLDRAW2D_EXPORT MolDraw2D {
       const std::vector<DrawColour> *highlightColorsReactants = nullptr,
       const std::vector<int> *confIds = nullptr);
 
+  //! returns the size of the box for the molecule with current drawing settings
+  std::pair<int, int> getMolSize(
+      const ROMol &mol, const std::string &legend = "",
+      const std::vector<int> *highlight_atoms = nullptr,
+      const std::vector<int> *highlight_bonds = nullptr,
+      const std::map<int, DrawColour> *highlight_atom_map = nullptr,
+      const std::map<int, DrawColour> *highlight_bond_map = nullptr,
+      const std::map<int, double> *highlight_radii = nullptr, int confId = -1);
+
   //! clears the contents of the drawing
   virtual void clearDrawing() {
     if (needs_init_) {
@@ -314,16 +323,28 @@ class RDKIT_MOLDRAW2D_EXPORT MolDraw2D {
       &atomSyms() const;
 
   //! return the width of the drawing area.
-  virtual int width() const { return width_; }
+  int width() const { return width_; }
   //! return the height of the drawing area.
-  virtual int height() const { return height_; }
+  int height() const { return height_; }
   //! return the width of the drawing panels.
-  virtual int panelWidth() const { return panel_width_; }
+  int panelWidth() const { return panel_width_; }
   //! return the height of the drawing panels.
-  virtual int panelHeight() const { return panel_height_; }
-  virtual int drawHeight() const { return panel_height_ - legend_height_; }
+  int panelHeight() const { return panel_height_; }
+
+  //! when FlexiMode is set, molecules will always been drawn
+  //! with the default values for bond length, font size, etc.
+  void setFlexiMode(bool mode) {
+    flexiMode_ = mode;
+    if (mode) {
+      panel_width_ = -1;
+      panel_height_ = -1;
+    }
+  }
+  bool flexiMode() const { return flexiMode_; }
+
+  int drawHeight() const { return panel_height_ - legend_height_; }
   // returns the width to draw a line in draw coords.
-  virtual double getDrawLineWidth() const;
+  double getDrawLineWidth() const;
 
   //! returns the drawing scale (conversion from molecular coords -> drawing
   /// coords)
@@ -483,6 +504,7 @@ class RDKIT_MOLDRAW2D_EXPORT MolDraw2D {
   // if the user calls setScale() to explicitly force a scale on the
   // DrawMols, this is set to true.
   bool forceScale_ = false;
+  bool flexiMode_ = false;
   double scale_, fontScale_;
   int x_offset_, y_offset_;  // translation in screen coordinates
   bool fill_polys_;

--- a/Code/GraphMol/MolDraw2D/MolDraw2DUtils.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DUtils.cpp
@@ -445,7 +445,6 @@ void drawMolACS1996(MolDraw2D &drawer, const ROMol &mol,
                         highlight_atom_map, highlight_bond_map, highlight_radii,
                         confId);
   };
-  double meanBondLen = 1.0;
   if (!mol.getNumConformers()) {
     // compute 2D coordinates in a standard orientation.  This needs to be
     // done on a copy because mol is const.

--- a/Code/GraphMol/MolDraw2D/Wrap/testMolDraw2D.py
+++ b/Code/GraphMol/MolDraw2D/Wrap/testMolDraw2D.py
@@ -783,6 +783,18 @@ M  END''')
       drawer.FinishDrawing()
       drawer.WriteDrawingText('testACSMode_1.png')
 
+  def testMolSize(self):
+    m = Chem.MolFromSmiles("CS(=O)(=O)COC(=N)c1cc(Cl)cnc1[NH3+]")
+    AllChem.Compute2DCoords(m)
+    rdMolDraw2D.PrepareMolForDrawing(m)
+    d2d = rdMolDraw2D.MolDraw2DSVG(-1, -1)
+    d2d.DrawMolecule(m)
+    sz = d2d.Width(), d2d.Height()
+
+    d2d = rdMolDraw2D.MolDraw2DSVG(-1, -1)
+    sz2 = d2d.GetMolSize(m)
+    self.assertEqual(sz, sz2)
+
 
 if __name__ == "__main__":
   unittest.main()


### PR DESCRIPTION
Introduces:
- `getMolSize()` to return the dimensions a molecule will be drawn to
- `flexiMode`: to ensure that molecules are always drawn with the current settings and font sizes