### PR TITLE
Fixes #6217

### DIFF
--- a/Code/GraphMol/FindStereo.cpp
+++ b/Code/GraphMol/FindStereo.cpp
@@ -275,7 +275,8 @@ StereoInfo getStereoInfo(const Atom *atom) {
         default:
           UNDER_CONSTRUCTION("unrecognized chiral flag");
       }
-    } else if (isAtomPotentialNontetrahedralCenter(atom)) {
+    } else if (getAllowNontetrahedralChirality() &&
+               isAtomPotentialNontetrahedralCenter(atom)) {
       if (stereo == Atom::CHI_UNSPECIFIED) {
         switch (atom->getTotalDegree()) {
           case 4:


### PR DESCRIPTION
Fixes #6217.

A very straightforward fix: just add a check to see if non-tetrahedral stereo is allowed before checking and assigning it.