### PR TITLE
Changing flags if doIsomericSmiles is false

### DIFF
--- a/Code/GraphMol/SmilesParse/SmilesWrite.cpp
+++ b/Code/GraphMol/SmilesParse/SmilesWrite.cpp
@@ -652,6 +652,10 @@ std::string MolToCXSmiles(const ROMol &mol, const SmilesWriteParams &params,
                           std::uint32_t flags) {
   auto res = MolToSmiles(mol, params);
   if (!res.empty()) {
+    if (!params.doIsomericSmiles && flags & SmilesWrite::CXSmilesFields::CX_ENHANCEDSTEREO) {
+      flags ^= (SmilesWrite::CXSmilesFields::CX_ENHANCEDSTEREO);
+    }
+
     auto cxext = SmilesWrite::getCXExtensions(mol, flags);
     if (!cxext.empty()) {
       res += " " + cxext;

--- a/Code/GraphMol/SmilesParse/SmilesWrite.cpp
+++ b/Code/GraphMol/SmilesParse/SmilesWrite.cpp
@@ -24,7 +24,7 @@
 #include <map>
 #include <list>
 
-//#define VERBOSE_CANON 1
+// #define VERBOSE_CANON 1
 
 namespace RDKit {
 
@@ -652,8 +652,9 @@ std::string MolToCXSmiles(const ROMol &mol, const SmilesWriteParams &params,
                           std::uint32_t flags) {
   auto res = MolToSmiles(mol, params);
   if (!res.empty()) {
-    if (!params.doIsomericSmiles && flags & SmilesWrite::CXSmilesFields::CX_ENHANCEDSTEREO) {
-      flags ^= (SmilesWrite::CXSmilesFields::CX_ENHANCEDSTEREO);
+    if (!params.doIsomericSmiles) {
+      flags &= ~(SmilesWrite::CXSmilesFields::CX_ENHANCEDSTEREO |
+                 SmilesWrite::CXSmilesFields::CX_BOND_CFG);
     }
 
     auto cxext = SmilesWrite::getCXExtensions(mol, flags);

--- a/Code/GraphMol/SmilesParse/cxsmiles_test.cpp
+++ b/Code/GraphMol/SmilesParse/cxsmiles_test.cpp
@@ -642,3 +642,26 @@ TEST_CASE("github #6050: stereogroups not combined") {
     CHECK(m->getStereoGroups()[0].getAtoms().size() == 4);
   }
 }
+
+TEST_CASE("github #6225: removes enhanced stereo if doIsomericSmiles is false") {
+  { // Gets rid of chiral centers
+    std::string smiles = "O[C@H](Br)[C@H](F)C |&1:1,3|";
+    ROMol *m = SmilesToMol(smiles);
+    SmilesWriteParams params;
+    params.doIsomericSmiles = false;
+    REQUIRE(m);
+    CHECK(MolToCXSmiles(*m, params) == "CC(F)C(O)Br");
+    delete m;
+  }
+
+  // cis-trans flags
+  {
+    std::string smiles = "C1CCCC/C=C/CCC1 |ctu:5|";
+    ROMol *m = SmilesToMol(smiles);
+    SmilesWriteParams params;
+    params.doIsomericSmiles = false;
+    REQUIRE(m);
+    CHECK(MolToCXSmiles(*m, params) == "C1=CCCCCCCCC1");
+    delete m;
+  }
+}


### PR DESCRIPTION
#### Reference Issue
Fixes #6040 


#### What does this implement/fix? Explain your changes.
Checks the doIsomericSmiles param in `MolToCXSmiles` and changing the flags variable that gets passed to `getCXExtensions`

#### Any other comments?
I wasn't able to find anywhere that it's possible for users to define their own flags variable, but I just wanted to makke sure that there is no concern with overwriting flags.

