### PR TITLE
Fix TorsionFingerprints for 15 membered rings

### DIFF
--- a/rdkit/Chem/TorsionFingerprints.py
+++ b/rdkit/Chem/TorsionFingerprints.py
@@ -272,7 +272,7 @@ def CalculateTorsionLists(mol, maxDev='equal', symmRadius=2, ignoreColinearBonds
     # get the torsions
     tmp = []
     num = len(r)
-    maxdev = 180.0 * math.exp(-0.025 * (num - 14) * (num - 14))
+    maxdev = 180.0 if 14 <= num else 180.0 * math.exp(-0.025 * (num - 14) * (num - 14))
     for i in range(len(r)):
       tmp.append((r[i], r[(i + 1) % num], r[(i + 2) % num], r[(i + 3) % num]))
     tors_list_rings.append((tmp, maxdev))

--- a/rdkit/Chem/TorsionFingerprints.py
+++ b/rdkit/Chem/TorsionFingerprints.py
@@ -272,7 +272,10 @@ def CalculateTorsionLists(mol, maxDev='equal', symmRadius=2, ignoreColinearBonds
     # get the torsions
     tmp = []
     num = len(r)
-    maxdev = 180.0 if 14 <= num else 180.0 * math.exp(-0.025 * (num - 14) * (num - 14))
+    if 14 <= num:
+      maxdev = 180.0
+    else:
+      maxdev = 180.0 * math.exp(-0.025 * (num - 14) * (num - 14))
     for i in range(len(r)):
       tmp.append((r[i], r[(i + 1) % num], r[(i + 2) % num], r[(i + 3) % num]))
     tors_list_rings.append((tmp, maxdev))

--- a/rdkit/Chem/UnitTestMol3D.py
+++ b/rdkit/Chem/UnitTestMol3D.py
@@ -163,6 +163,12 @@ class TestCase(unittest.TestCase):
     tors_list, tors_list_rings = TorsionFingerprints.CalculateTorsionLists(mol)
     self.assertEqual(len(tors_list), 1)
 
+  def testTorsionAngleLeargerThan14(self):
+    # incorrect value from more than 15-membered ring
+    mol = Chem.MolFromSmiles('C1' + 'C' * 13 + 'C1')
+    tors_list, tors_list_rings = TorsionFingerprints.CalculateTorsionLists(mol)
+    self.assertAlmostEqual(tors_list_rings[-1][1], 180.0, 4)
+
   def assertBondStereoRoundTrips(self, fname):
     path = os.path.join(RDConfig.RDCodeDir, 'Chem', 'test_data', fname)
     mol = Chem.MolFromMolFile(path)


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

The TFD paper, [_J. Chem. Inf. Model._ 2012, 52, 1499-1512](https://doi.org/10.1021/ci2002318), states that "The maximal derivation for rings of size 14 or greater is 180 degrees.", but the current implementation ignores it.
This PR fixes it.
