### PR TITLE
Do not include dative bonds in ring finding by default

### DIFF
--- a/Code/GraphMol/Depictor/RDDepictor.cpp
+++ b/Code/GraphMol/Depictor/RDDepictor.cpp
@@ -269,8 +269,8 @@ void embedFusedSystems(const RDKit::ROMol &mol,
     bool allowRingTemplates = useRingTemplates;
     if (useRingTemplates && coordMap) {
       boost::dynamic_bitset<> coordMapAtoms(mol.getNumAtoms());
-      for (const auto& ring : frings) {
-        for (const auto& aid : ring) {
+      for (const auto &ring : frings) {
+        for (const auto &aid : ring) {
           if (coordMap->find(aid) != coordMap->end()) {
             coordMapAtoms.set(aid);
           }
@@ -420,7 +420,8 @@ void computeInitialCoords(RDKit::ROMol &mol,
   RDKit::VECT_INT_VECT arings;
 
   // first find all the rings
-  RDKit::MolOps::symmetrizeSSSR(mol, arings);
+  bool includeDativeBonds = true;
+  RDKit::MolOps::symmetrizeSSSR(mol, arings, includeDativeBonds);
 
   // do stereochemistry
   RDKit::MolOps::assignStereochemistry(mol, false);
@@ -439,7 +440,8 @@ void computeInitialCoords(RDKit::ROMol &mol,
 
   if (arings.size() > 0) {
     // first deal with the fused rings
-    DepictorLocal::embedFusedSystems(mol, arings, efrags, coordMap, useRingTemplates);
+    DepictorLocal::embedFusedSystems(mol, arings, efrags, coordMap,
+                                     useRingTemplates);
   }
 
   // do non-tetrahedral stereo
@@ -555,7 +557,7 @@ unsigned int compute2DCoords(RDKit::ROMol &mol,
 //
 //
 unsigned int compute2DCoords(RDKit::ROMol &mol,
-                             const Compute2DCoordParameters& params) {
+                             const Compute2DCoordParameters &params) {
   if (mol.needsUpdatePropertyCache()) {
     mol.updatePropertyCache(false);
   }
@@ -581,9 +583,9 @@ unsigned int compute2DCoords(RDKit::ROMol &mol,
     // bonds in the structure or flip only bonds along the shortest
     // path between colliding atoms - don't do both
     if ((params.nSamples > 0) && (params.nFlipsPerSample > 0)) {
-      eri.randomSampleFlipsAndPermutations(params.nFlipsPerSample, params.nSamples,
-                                           params.sampleSeed, nullptr, 0.0,
-                                           params.permuteDeg4Nodes);
+      eri.randomSampleFlipsAndPermutations(
+          params.nFlipsPerSample, params.nSamples, params.sampleSeed, nullptr,
+          0.0, params.permuteDeg4Nodes);
     } else {
       eri.removeCollisionsBondFlip();
     }

--- a/Code/GraphMol/Depictor/RDDepictor.cpp
+++ b/Code/GraphMol/Depictor/RDDepictor.cpp
@@ -572,9 +572,11 @@ unsigned int compute2DCoords(RDKit::ROMol &mol,
     return cid;
   };
 #endif
+
+  RDKit::ROMol cp(mol);
   // storage for pieces of a molecule/s that are embedded in 2D
   std::list<EmbeddedFrag> efrags;
-  computeInitialCoords(mol, params.coordMap, efrags, params.useRingTemplates);
+  computeInitialCoords(cp, params.coordMap, efrags, params.useRingTemplates);
 
 #if 1
   // perform random sampling here to improve the density

--- a/Code/GraphMol/Depictor/catch_tests.cpp
+++ b/Code/GraphMol/Depictor/catch_tests.cpp
@@ -227,11 +227,12 @@ TEST_CASE("use ring system templates") {
 TEST_CASE("dative bonds and rings") {
   auto mol = "O->[Pt]1(<-O)<-NC2CCC2N->1"_smiles;
   REQUIRE(mol);
+  auto rings = mol->getRingInfo();
+  CHECK(rings->numRings() == 1);  // the dative bonds are ignored
   RDDepict::compute2DCoords(*mol);
-  std::cerr << MolToV3KMolBlock(*mol) << std::endl;
+  CHECK(rings->numRings() == 1);  // ensure the ring count hasn't changed
   auto conf = mol->getConformer();
   auto v1 = conf.getAtomPos(1) - conf.getAtomPos(3);
   auto v2 = conf.getAtomPos(1) - conf.getAtomPos(8);
   CHECK_THAT(v1.length(), Catch::Matchers::WithinAbs(v2.length(), 0.01));
-  mol->debugMol(std::cerr);
 }

--- a/Code/GraphMol/Depictor/catch_tests.cpp
+++ b/Code/GraphMol/Depictor/catch_tests.cpp
@@ -212,12 +212,26 @@ TEST_CASE("use ring system templates") {
   auto mol = "C1CCC2C(C1)C1CCN2NN1"_smiles;
   RDDepict::Compute2DCoordParameters params;
   RDDepict::compute2DCoords(*mol, params);
-  auto diff = mol->getConformer().getAtomPos(10) - mol->getConformer().getAtomPos(11);
+  auto diff =
+      mol->getConformer().getAtomPos(10) - mol->getConformer().getAtomPos(11);
   // when templates are not used, bond from 10-11 is very short
   TEST_ASSERT(RDKit::feq(diff.length(), 0.116, .1));
 
   params.useRingTemplates = true;
   RDDepict::compute2DCoords(*mol, params);
-  diff = mol->getConformer().getAtomPos(10) - mol->getConformer().getAtomPos(11);
+  diff =
+      mol->getConformer().getAtomPos(10) - mol->getConformer().getAtomPos(11);
   TEST_ASSERT(RDKit::feq(diff.length(), 1.0, .1))
+}
+
+TEST_CASE("dative bonds and rings") {
+  auto mol = "O->[Pt]1(<-O)<-NC2CCC2N->1"_smiles;
+  REQUIRE(mol);
+  RDDepict::compute2DCoords(*mol);
+  std::cerr << MolToV3KMolBlock(*mol) << std::endl;
+  auto conf = mol->getConformer();
+  auto v1 = conf.getAtomPos(1) - conf.getAtomPos(3);
+  auto v2 = conf.getAtomPos(1) - conf.getAtomPos(8);
+  CHECK_THAT(v1.length(), Catch::Matchers::WithinAbs(v2.length(), 0.01));
+  mol->debugMol(std::cerr);
 }

--- a/Code/GraphMol/Depictor/testDepictor.cpp
+++ b/Code/GraphMol/Depictor/testDepictor.cpp
@@ -821,13 +821,12 @@ void testGitHubIssue1073() {
     RWMol *m = SmartsToMol(smarts);
     TEST_ASSERT(m);
 
+    // compute2DCoords does ring finding internally, so there's no error
     RDDepict::compute2DCoords(*m);
 
+    // but the molecule itself is not modified
     RingInfo *ri = m->getRingInfo();
-    TEST_ASSERT(ri->isInitialized());
-    TEST_ASSERT(ri->isAtomInRingOfSize(0, 6));
-    TEST_ASSERT(ri->isAtomInRingOfSize(0, 5));
-    TEST_ASSERT(!ri->isAtomInRingOfSize(0, 9));
+    TEST_ASSERT(!ri->isInitialized());
 
     delete m;
   }

--- a/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
@@ -81,8 +81,14 @@ void MolDraw2D::drawMolecule(const ROMol &mol, const std::string &legend,
                              const std::map<int, double> *highlight_radii,
                              int confId) {
   setupTextDrawer();
+  // we need ring info for drawing, so copy the molecule
+  // in order to add it
+  ROMol lmol(mol);
+  if (!lmol.getRingInfo()->isInitialized()) {
+    MolOps::symmetrizeSSSR(lmol);
+  }
   drawMols_.emplace_back(new MolDraw2D_detail::DrawMol(
-      mol, legend, panelWidth(), panelHeight(), drawOptions(), *text_drawer_,
+      lmol, legend, panelWidth(), panelHeight(), drawOptions(), *text_drawer_,
       highlight_atoms, highlight_bonds, highlight_atom_map, highlight_bond_map,
       nullptr, highlight_radii, supportsAnnotations(), confId));
   drawMols_.back()->setOffsets(x_offset_, y_offset_);

--- a/Code/GraphMol/MolDraw2D/catch_tests.cpp
+++ b/Code/GraphMol/MolDraw2D/catch_tests.cpp
@@ -58,7 +58,7 @@ static const std::map<std::string, std::hash_result_t> SVG_HASHES = {
     {"contourMol_3.svg", 3493070184U},
     {"contourMol_4.svg", 764999893U},
     {"testDativeBonds_1.svg", 555607912U},
-    {"testDativeBonds_2.svg", 93109626U},
+    {"testDativeBonds_2.svg", 2355686690U},
     {"testDativeBonds_3.svg", 3944956974U},
     {"testDativeBonds_2a.svg", 1026259021U},
     {"testDativeBonds_2b.svg", 3842058701U},
@@ -718,7 +718,7 @@ TEST_CASE("dative bonds", "[drawing][organometallics]") {
     outs.close();
     check_file_hash("testDativeBonds_2.svg");
 
-    CHECK(text.find("-8' d='M 101.1,79.8 L 95.8,87.1' "
+    CHECK(text.find("-8' d='M 101.1,77.2 L 95.8,84.5' "
                     "style='fill:none;fill-rule:evenodd;stroke:#0000FF;") !=
           std::string::npos);
   }
@@ -7476,8 +7476,8 @@ TEST_CASE(
     auto &atomRings = rings->atomRings();
     std::map<int, std::vector<DrawColour>> atomCols;
     std::map<int, double> atomRads;
-    for (auto i = 0; i < atomRings.size(); ++i) {
-      for (auto j = 0; j < atomRings[i].size(); ++j) {
+    for (auto i = 0u; i < atomRings.size(); ++i) {
+      for (auto j = 0u; j < atomRings[i].size(); ++j) {
         auto ex = atomCols.find(atomRings[i][j]);
         if (ex == atomCols.end()) {
           std::vector<DrawColour> cvec(1, colours[i]);
@@ -7495,8 +7495,8 @@ TEST_CASE(
     auto &bondRings = rings->bondRings();
     std::map<int, int> bondMults;
     std::map<int, std::vector<DrawColour>> bondCols;
-    for (auto i = 0; i < bondRings.size(); ++i) {
-      for (auto j = 0; j < bondRings[i].size(); ++j) {
+    for (auto i = 0u; i < bondRings.size(); ++i) {
+      for (auto j = 0u; j < bondRings[i].size(); ++j) {
         auto ex = bondCols.find(bondRings[i][j]);
         if (ex == bondCols.end()) {
           std::vector<DrawColour> cvec(1, colours[i]);

--- a/Code/GraphMol/MolOps.h
+++ b/Code/GraphMol/MolOps.h
@@ -688,6 +688,8 @@ RDKIT_GRAPHMOL_EXPORT void setHybridization(ROMol &mol);
   \param res used to return the vector of rings. Each entry is a vector with
       atom indices.  This information is also stored in the molecule's
       RingInfo structure, so this argument is optional (see overload)
+  \param includeDativeBonds - determines whether or not dative bonds are used in
+      the ring finding.
 
   \return number of smallest rings found
 
@@ -723,10 +725,12 @@ RDKIT_GRAPHMOL_EXPORT void setHybridization(ROMol &mol);
   done. The extra rings this process adds can be quite useful.
 */
 RDKIT_GRAPHMOL_EXPORT int findSSSR(const ROMol &mol,
-                                   std::vector<std::vector<int>> &res);
+                                   std::vector<std::vector<int>> &res,
+                                   bool includeDativeBonds = false);
 //! \overload
-RDKIT_GRAPHMOL_EXPORT int findSSSR(
-    const ROMol &mol, std::vector<std::vector<int>> *res = nullptr);
+RDKIT_GRAPHMOL_EXPORT int findSSSR(const ROMol &mol,
+                                   std::vector<std::vector<int>> *res = nullptr,
+                                   bool includeDativeBonds = false);
 
 //! use a DFS algorithm to identify ring bonds and atoms in a molecule
 /*!
@@ -756,6 +760,8 @@ RDKIT_GRAPHMOL_EXPORT void findRingFamilies(const ROMol &mol);
   \param res used to return the vector of rings. Each entry is a vector with
       atom indices.  This information is also stored in the molecule's
       RingInfo structure, so this argument is optional (see overload)
+  \param includeDativeBonds - determines whether or not dative bonds are used in
+      the ring finding.
 
   \return the total number of rings = (new rings + old SSSRs)
 
@@ -764,9 +770,11 @@ RDKIT_GRAPHMOL_EXPORT void findRingFamilies(const ROMol &mol);
   first
 */
 RDKIT_GRAPHMOL_EXPORT int symmetrizeSSSR(ROMol &mol,
-                                         std::vector<std::vector<int>> &res);
+                                         std::vector<std::vector<int>> &res,
+                                         bool includeDativeBonds = false);
 //! \overload
-RDKIT_GRAPHMOL_EXPORT int symmetrizeSSSR(ROMol &mol);
+RDKIT_GRAPHMOL_EXPORT int symmetrizeSSSR(ROMol &mol,
+                                         bool includeDativeBonds = false);
 
 //! @}
 

--- a/Code/GraphMol/Wrap/MolOps.cpp
+++ b/Code/GraphMol/Wrap/MolOps.cpp
@@ -306,9 +306,9 @@ ROMol *addHs(const ROMol &orig, bool explicitOnly, bool addCoords,
   return res;
 }
 
-VECT_INT_VECT getSSSR(ROMol &mol) {
+VECT_INT_VECT getSSSR(ROMol &mol, bool includeDativeBonds) {
   VECT_INT_VECT rings;
-  MolOps::findSSSR(mol, rings);
+  MolOps::findSSSR(mol, rings, includeDativeBonds);
   return rings;
 }
 
@@ -466,9 +466,9 @@ void setHybridizationMol(ROMol &mol) {
   MolOps::setHybridization(wmol);
 }
 
-VECT_INT_VECT getSymmSSSR(ROMol &mol) {
+VECT_INT_VECT getSymmSSSR(ROMol &mol, bool includeDativeBonds) {
   VECT_INT_VECT rings;
-  MolOps::symmetrizeSSSR(mol, rings);
+  MolOps::symmetrizeSSSR(mol, rings, includeDativeBonds);
   return rings;
 }
 PyObject *getDistanceMatrix(ROMol &mol, bool useBO = false,
@@ -1055,11 +1055,14 @@ struct molops_wrapper {
   ARGUMENTS:\n\
 \n\
     - mol: the molecule to use.\n\
+    - includeDativeBonds: whether or not dative bonds should be included in the ring finding.\n\
 \n\
   RETURNS: a sequence of sequences containing the rings found as atom ids\n\
          The length of this will be equal to NumBonds-NumAtoms+1 for single-fragment molecules.\n\
 \n";
-    python::def("GetSSSR", getSSSR, docString.c_str());
+    python::def("GetSSSR", getSSSR,
+                (python::arg("mol"), python::arg("includeDativeBonds") = false),
+                docString.c_str());
 
     // ------------------------------------------------------------------------
     docString =
@@ -1072,10 +1075,13 @@ struct molops_wrapper {
   ARGUMENTS:\n\
 \n\
     - mol: the molecule to use.\n\
+    - includeDativeBonds: whether or not dative bonds should be included in the ring finding.\n\
 \n\
   RETURNS: a sequence of sequences containing the rings found as atom ids\n\
 \n";
-    python::def("GetSymmSSSR", getSymmSSSR, docString.c_str());
+    python::def("GetSymmSSSR", getSymmSSSR,
+                (python::arg("mol"), python::arg("includeDativeBonds") = false),
+                docString.c_str());
 
     // ------------------------------------------------------------------------
     docString =

--- a/Code/GraphMol/catch_organometallics.cpp
+++ b/Code/GraphMol/catch_organometallics.cpp
@@ -12,6 +12,7 @@
 
 #include <GraphMol/RWMol.h>
 #include <GraphMol/FileParsers/FileParsers.h>
+#include <GraphMol/SmilesParse/SmilesParse.h>
 #include <GraphMol/SmilesParse/SmilesWrite.h>
 
 using namespace RDKit;
@@ -127,4 +128,27 @@ TEST_CASE("get haptic bond end points") {
   bond = mol->getBondWithIdx(1);
   endPts = MolOps::details::hapticBondEndpoints(bond);
   CHECK(std::vector<int>{} == endPts);
+}
+
+TEST_CASE("Rings and dative bonds") {
+  SECTION("ferrocene") {
+    auto m =
+        "C12->[Fe+2]3456789(<-C1=C->3[CH-]->4C->5=2)<-C1=C->6[CH-]->7C->8=C->91"_smiles;
+    REQUIRE(m);
+    std::vector<std::vector<int>> rings;
+    auto nrings = MolOps::symmetrizeSSSR(*m, rings);
+    CHECK(nrings == 2);
+    CHECK(rings[0].size() == 5);
+    CHECK(rings[1].size() == 5);
+  }
+}
+
+TEST_CASE("aromaticity and dative bonds") {
+  SECTION("ferrocene") {
+    auto m =
+        "C12->[Fe+2]3456789(<-C1=C->3[CH-]->4C->5=2)<-C1=C->6[CH-]->7C->8=C->91"_smiles;
+    REQUIRE(m);
+    CHECK(m->getAtomWithIdx(0)->getIsAromatic());
+    CHECK(!m->getAtomWithIdx(1)->getIsAromatic());
+  }
 }

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -9,6 +9,7 @@
 
 - The ring-finding functions will now run even if the molecule already has ring information. Older versions of the RDKit would return whatever ring information was present, even if it had been generated using a different algorithm.
 - The ring-finding functions now no longer consider dative bonds as possible ring bonds by default. All of the ring-finding functions have a new optional argument `includeDativeBonds` which can be used to change this behavior
+- Generating 2D coordinates no longer has the side effect of running ring finding on molecules.
 - The canonical SMILES and CXSMILES generated for molecules with enhanced stereochemistry (stereo groups) is different than in previous releases. The enhanced stereochemistry information and the stereo groups themselves are now canonical. This does *not* affect molecules which do not have enhanced stereo and will not have any effect if you generate non-isomeric SMILES. This change also affects the output of the MolHash and RegistrationHash code when applied to molecules with enhanced stereo.
 - The doIsomericSmiles parameter in Java and C# ROMol.MolToSmiles() now defaults to true (previously it was false), thus aligning to the C++ and Python behavior.
 - Double bonds which are marked as crossed (i.e. `bond.GetBondDir() == Bond.BondDir.EITHERDOUBLE`) now have their BondStereo set to `Bond.BondStereo.STEREOANY` and the BondDir information removed by default when molecules are parsed or `AssignStereochemistry()` is called with the `cleanIt` argument set to True.

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -8,6 +8,7 @@
 ## Backwards incompatible changes
 
 - The ring-finding functions will now run even if the molecule already has ring information. Older versions of the RDKit would return whatever ring information was present, even if it had been generated using a different algorithm.
+- The ring-finding functions now no longer consider dative bonds as possible ring bonds by default. All of the ring-finding functions have a new optional argument `includeDativeBonds` which can be used to change this behavior
 - The canonical SMILES and CXSMILES generated for molecules with enhanced stereochemistry (stereo groups) is different than in previous releases. The enhanced stereochemistry information and the stereo groups themselves are now canonical. This does *not* affect molecules which do not have enhanced stereo and will not have any effect if you generate non-isomeric SMILES. This change also affects the output of the MolHash and RegistrationHash code when applied to molecules with enhanced stereo.
 - The doIsomericSmiles parameter in Java and C# ROMol.MolToSmiles() now defaults to true (previously it was false), thus aligning to the C++ and Python behavior.
 - Double bonds which are marked as crossed (i.e. `bond.GetBondDir() == Bond.BondDir.EITHERDOUBLE`) now have their BondStereo set to `Bond.BondStereo.STEREOANY` and the BondDir information removed by default when molecules are parsed or `AssignStereochemistry()` is called with the `cleanIt` argument set to True.


### PR DESCRIPTION
Fixes #6058 

The fix here is to add a new `includeDativeBonds` option to the ring-finding code which is disabled by default (i.e. dative bonds are not included in ring finding by default).

This necessitates a small tweak to the 2D coordinate generation code, which should take dative bonds into account (at least for some systems, it might be worth coming back to this at some point and ignoring the three-rings formed by haptic systems in the depiction code).
