### PR TITLE
Fix build warnings

### DIFF
--- a/Code/GraphMol/Depictor/EmbeddedFrag.cpp
+++ b/Code/GraphMol/Depictor/EmbeddedFrag.cpp
@@ -346,8 +346,10 @@ void EmbeddedFrag::setupAttachmentPoints() {
   }
 }
 
-bool EmbeddedFrag::matchToTemplate(const RDKit::INT_VECT &ringSystemAtoms, unsigned int ring_count) {
-  CoordinateTemplates& coordinate_templates = CoordinateTemplates::getRingSystemTemplates();
+bool EmbeddedFrag::matchToTemplate(const RDKit::INT_VECT &ringSystemAtoms,
+                                   unsigned int ring_count) {
+  CoordinateTemplates &coordinate_templates =
+      CoordinateTemplates::getRingSystemTemplates();
 
   // only look for an exact match to the ring system because our method of
   // completing rings from a template isn't reliably better than not using
@@ -357,20 +359,20 @@ bool EmbeddedFrag::matchToTemplate(const RDKit::INT_VECT &ringSystemAtoms, unsig
   }
 
   // make a mol out of the induced subgraph using the ring system atoms
-  RDKit::RWMol rs_mol (*dp_mol);
+  RDKit::RWMol rs_mol(*dp_mol);
 
   // track original indices so that we can map template coordinates correctly
-  for (auto& at : rs_mol.atoms()) {
+  for (auto &at : rs_mol.atoms()) {
     at->setProp(RDKit::common_properties::molAtomMapNumber, at->getIdx());
   }
 
-  boost::dynamic_bitset<> rs_atoms (dp_mol->getNumAtoms());
+  boost::dynamic_bitset<> rs_atoms(dp_mol->getNumAtoms());
   for (auto aidx : ringSystemAtoms) {
     rs_atoms.set(aidx);
   }
 
   rs_mol.beginBatchEdit();
-  for (auto& at : dp_mol->atoms()) {
+  for (auto &at : dp_mol->atoms()) {
     if (!rs_atoms.test(at->getIdx())) {
       rs_mol.removeAtom(at->getIdx());
     }
@@ -380,9 +382,10 @@ bool EmbeddedFrag::matchToTemplate(const RDKit::INT_VECT &ringSystemAtoms, unsig
   // find template that this mol matches to, if any
   RDKit::MatchVectType match;
   std::shared_ptr<RDKit::ROMol> template_mol(nullptr);
-  for (const auto mol : coordinate_templates.getMatchingTemplates(ringSystemAtoms.size())) {
-    // To reduce how often we have to do substructure matches, check ring info and
-    // bond count first
+  for (const auto &mol :
+       coordinate_templates.getMatchingTemplates(ringSystemAtoms.size())) {
+    // To reduce how often we have to do substructure matches, check ring info
+    // and bond count first
     if (mol->getNumBonds() != rs_mol.getNumBonds()) {
       continue;
     } else if (mol->getRingInfo()->numRings() != ring_count) {
@@ -404,10 +407,10 @@ bool EmbeddedFrag::matchToTemplate(const RDKit::INT_VECT &ringSystemAtoms, unsig
 
   // copy over new coordinates
   auto conf = template_mol->getConformer();
-  for (auto& [template_aidx, rs_aidx] : match) {
+  for (auto &[template_aidx, rs_aidx] : match) {
     auto mol_aidx = rs_mol.getAtomWithIdx(rs_aidx)->getAtomMapNum();
-    RDGeom::Point2D loc (conf.getAtomPos(template_aidx));
-    EmbeddedAtom new_at (mol_aidx, loc);
+    RDGeom::Point2D loc(conf.getAtomPos(template_aidx));
+    EmbeddedAtom new_at(mol_aidx, loc);
     new_at.df_fixed = true;
     d_eatoms.emplace(mol_aidx, new_at);
   }
@@ -420,7 +423,8 @@ bool EmbeddedFrag::matchToTemplate(const RDKit::INT_VECT &ringSystemAtoms, unsig
 // NOTE: the individual rings in fusedRings must appear in traversal order.
 //    This is what is provided by the current ring-finding code.
 //
-void EmbeddedFrag::embedFusedRings(const RDKit::VECT_INT_VECT &fusedRings, bool useRingTemplates) {
+void EmbeddedFrag::embedFusedRings(const RDKit::VECT_INT_VECT &fusedRings,
+                                   bool useRingTemplates) {
   PRECONDITION(dp_mol, "");
   // ok this is what we are going to do here
   // embed each of the individual rings. Then

--- a/Code/GraphMol/Descriptors/catch_tests.cpp
+++ b/Code/GraphMol/Descriptors/catch_tests.cpp
@@ -259,7 +259,7 @@ TEST_CASE("Oxidation numbers") {
       std::vector<std::string> smis{"CO", "C=O", "C(=O)O", "S(=O)(=O)(O)O"};
       std::vector<std::vector<int>> expected{
           {-2, -2}, {0, -2}, {2, -2, -2}, {6, -2, -2, -2, -2}};
-      for (auto i = 0; i < smis.size(); ++i) {
+      for (auto i = 0u; i < smis.size(); ++i) {
         std::unique_ptr<RWMol> mol(RDKit::SmilesToMol(smis[i]));
         Descriptors::calcOxidationNumbers(*mol);
         for (const auto &a : mol->atoms()) {

--- a/Code/GraphMol/DetermineBonds/DetermineBonds.cpp
+++ b/Code/GraphMol/DetermineBonds/DetermineBonds.cpp
@@ -26,7 +26,6 @@ using boost::multiprecision::uint1024_t;
 
 namespace {
 
-
 // see http://phrogz.net/lazy-cartesian-product
 template <typename T>
 struct LazyCartesianProduct {
@@ -60,9 +59,9 @@ template <typename T>
 std::vector<T> LazyCartesianProduct<T>::entryAt(uint1024_t pos) const {
   auto length = d_listOfLists.size();
   std::vector<T> res(length);
-  for (auto i = 0; i < length; ++i) {
-    res[i] = d_listOfLists[i][static_cast<size_t>(static_cast<uint1024_t>(pos / d_divs[i]) %
-                                                 d_mods[i])];
+  for (auto i = 0u; i < length; ++i) {
+    res[i] = d_listOfLists[i][static_cast<size_t>(
+        static_cast<uint1024_t>(pos / d_divs[i]) % d_mods[i])];
   }
   return res;
 }
@@ -74,7 +73,7 @@ std::vector<unsigned int> possibleValences(
   auto numBonds = atom->getDegree();
 
   auto valences = atomicValence.find(atomNum);
-  if(valences == atomicValence.end()){
+  if (valences == atomicValence.end()) {
     std::stringstream ss;
     ss << "determineBondOrdering() does not work with element "
        << RDKit::PeriodicTable::getTable()->getElementSymbol(atomNum);
@@ -441,7 +440,7 @@ void determineBondOrders(RWMol &mol, int charge, bool allowChargedFragments,
 void determineBonds(RWMol &mol, bool useHueckel, int charge, double covFactor,
                     bool allowChargedFragments, bool embedChiral,
                     bool useAtomMap) {
-  if(mol.getNumAtoms() <= 1){
+  if (mol.getNumAtoms() <= 1) {
     return;
   }
   determineConnectivity(mol, useHueckel, charge, covFactor);

--- a/Code/GraphMol/FileParsers/CDXMLParser.cpp
+++ b/Code/GraphMol/FileParsers/CDXMLParser.cpp
@@ -388,9 +388,9 @@ bool parse_fragment(RWMol &mol, ptree &frag,
       } else {
         bonds.push_back(bond);
       }
-      // end if atom or bond 
-    } 
-  }    // for node
+      // end if atom or bond
+    }
+  }  // for node
 
   // add bonds
   if (!skip_fragment) {
@@ -423,18 +423,18 @@ bool parse_fragment(RWMol &mol, ptree &frag,
                  bond.display == "WedgedHashEnd") {
         bnd->setBondDir(Bond::BondDir::BEGINWEDGE);
       } else if (bond.display == "Wavy") {
-        switch(bond.getBondType()) {
-            case Bond::BondType::SINGLE:
-              bnd->setBondDir(Bond::BondDir::UNKNOWN);
-              break;
-            case Bond::BondType::DOUBLE:
-              bnd->setBondDir(Bond::BondDir::EITHERDOUBLE);
-              bnd->setStereo(Bond::STEREOANY);
-              break;
-            default:
-              BOOST_LOG(rdWarningLog)
+        switch (bond.getBondType()) {
+          case Bond::BondType::SINGLE:
+            bnd->setBondDir(Bond::BondDir::UNKNOWN);
+            break;
+          case Bond::BondType::DOUBLE:
+            bnd->setBondDir(Bond::BondDir::EITHERDOUBLE);
+            bnd->setStereo(Bond::STEREOANY);
+            break;
+          default:
+            BOOST_LOG(rdWarningLog)
                 << "ignoring Wavy bond set on a non double bond id: "
-                << bond.bond_id  << std::endl;
+                << bond.bond_id << std::endl;
         }
       }
     }
@@ -521,7 +521,7 @@ std::vector<std::unique_ptr<RWMol>> CDXMLDataStreamToMols(
                 mol->clearProp(NEEDS_FUSE);
                 std::unique_ptr<ROMol> fused;
                 try {
-                  fused = std::move(molzip(*mol, molzip_params));
+                  fused = molzip(*mol, molzip_params);
                 } catch (Invar::Invariant &) {
                   BOOST_LOG(rdWarningLog)
                       << "Failed fusion of fragment skipping... " << frag_id

--- a/Code/GraphMol/FilterCatalog/filtercatalogtest.cpp
+++ b/Code/GraphMol/FilterCatalog/filtercatalogtest.cpp
@@ -244,99 +244,102 @@ void testFilterCatalogThreadedRunner() {
 }
 
 void testFilterCatalogCHEMBL() {
+  FilterCatalogParams params;
+  auto catalogs = {FilterCatalogParams::CHEMBL_BMS,
+                   FilterCatalogParams::CHEMBL_LINT,
+                   FilterCatalogParams::CHEMBL_Glaxo,
+                   FilterCatalogParams::CHEMBL_MLSMR,
+                   FilterCatalogParams::CHEMBL_Dundee,
+                   FilterCatalogParams::CHEMBL_Inpharmatica,
+                   FilterCatalogParams::CHEMBL_SureChEMBL};
+  std::vector<unsigned> entries = {180, 57, 55, 116, 105, 91, 166};
+  int i = 0;
+  for (auto catalog : catalogs) {
     FilterCatalogParams params;
-    auto catalogs = {FilterCatalogParams::CHEMBL_BMS,
-        FilterCatalogParams::CHEMBL_LINT,
-        FilterCatalogParams::CHEMBL_Glaxo,
-        FilterCatalogParams::CHEMBL_MLSMR,
-        FilterCatalogParams::CHEMBL_Dundee,
-        FilterCatalogParams::CHEMBL_Inpharmatica,
-        FilterCatalogParams::CHEMBL_SureChEMBL};
-    std::vector<int> entries = {180, 57, 55, 116, 105, 91, 166};
-    int i=0;
-    for (auto catalog : catalogs) {
-        FilterCatalogParams params;
-        params.addCatalog(catalog);
-        FilterCatalog filtercat(params);
-        TEST_ASSERT(entries[i++] == filtercat.getNumEntries());
+    params.addCatalog(catalog);
+    FilterCatalog filtercat(params);
+    TEST_ASSERT(entries[i++] == filtercat.getNumEntries());
+  }
+
+  {  // Test inpharmatica merge hydrogens
+    const std::vector<std::pair<std::string, std::string>> tests = {
+        {"CN=NC", "Filter5_azo"},
+        {"CN=N", "Filter5_azo"},
+        {"N=N", "Filter5_azo"},
+        {"NN=N", ""},
+        {"CC(=O)CCBr",
+         "Filter26_alkyl_halide|Filter30_beta_halo_carbonyl|Filter75_alkyl_Br_I"},
+        {"CC(=O)CCI",
+         "Filter26_alkyl_halide|Filter30_beta_halo_carbonyl|Filter75_alkyl_Br_I"},
+        {"C(=O)CCI",
+         "Filter26_alkyl_halide|Filter30_beta_halo_carbonyl|Filter38_aldehyde|Filter75_alkyl_Br_I"},
+        {"NC(=O)CCI", "Filter26_alkyl_halide|Filter75_alkyl_Br_I"},
+        {"CC=NOS(=O)N", "Filter18_oxime_ester|Filter89_hydroxylamine"},
+        {"NC=NOP(=O)N", "Filter89_hydroxylamine"},
+        {"C=NOP(=O)N", "Filter18_oxime_ester|Filter89_hydroxylamine"},
+        {"NC=NO", "Filter89_hydroxylamine"},
+        {"CC(=O)NOC", ""},
+        {"[Fe]C", "Filter9_metal"},
+        {"[FeH]", "Filter9_metal"},
+        {"[Fe]", ""},
+        {"CN=O", "Filter12_nitroso"},
+        {"N=O", "Filter12_nitroso"},
+        {"S=P",
+         "Filter13_PS_double_bond|Filter61_phosphor_halide_and_P_S_bond"},
+        {"S=PC",
+         "Filter13_PS_double_bond|Filter61_phosphor_halide_and_P_S_bond"},
+        {"CC(=O)SC", "Filter29_thioester"},
+        {"CC(=S)SC", "Filter29_thioester"},
+        {"CC(=N)SC", "Filter29_thioester"},
+        {"CC(=O)S", "Filter29_thioester|Filter74_thiol"},
+        {"CC(=S)S", "Filter29_thioester|Filter74_thiol"},
+        {"CC(=N)S", "Filter29_thioester|Filter74_thiol"},
+        {"SO", "Filter31_so_bond|Filter74_thiol"},
+        {"SOC", "Filter31_so_bond|Filter74_thiol"},
+        {"c1csocc1", ""},
+        {"OO", "Filter32_oo_bond"},
+        {"COO", "Filter32_oo_bond"},
+        {"c1coocc1", ""},
+        {"CC(=O)C=C", "Filter44_michael_acceptor2"},
+        {"C(=O)C=C", "Filter38_aldehyde|Filter44_michael_acceptor2"},
+        {"OC(=O)C=C", "Filter44_michael_acceptor2"},
+        {"C1(=O)C=CC(=O)C=C1", "Filter53_para_quinones"},
+        {"CIC", "Filter49_halogen|Filter75_alkyl_Br_I"},
+        {"CI(C)C", "Filter49_halogen|Filter75_alkyl_Br_I"}};
+    FilterCatalogParams params;
+    params.addCatalog(FilterCatalogParams::CHEMBL_Inpharmatica);
+    FilterCatalog catalog(params);
+    for (auto &test : tests) {
+      std::unique_ptr<RWMol> mol(SmilesToMol(test.first));
+      std::string matches;
+      for (auto &match : catalog.getMatches(*mol)) {
+        if (matches.size()) matches += "|";
+        matches += match->getDescription();
+      }
+
+      TEST_ASSERT(matches == test.second);
     }
-    
-    { // Test inpharmatica merge hydrogens
-        const std::vector<std::pair<std::string, std::string>> tests = {
-            {"CN=NC", "Filter5_azo"},
-            {"CN=N", "Filter5_azo"},
-            {"N=N", "Filter5_azo"},
-            {"NN=N", ""},
-            {"CC(=O)CCBr", "Filter26_alkyl_halide|Filter30_beta_halo_carbonyl|Filter75_alkyl_Br_I"},
-            {"CC(=O)CCI", "Filter26_alkyl_halide|Filter30_beta_halo_carbonyl|Filter75_alkyl_Br_I"},
-            {"C(=O)CCI", "Filter26_alkyl_halide|Filter30_beta_halo_carbonyl|Filter38_aldehyde|Filter75_alkyl_Br_I"},
-            {"NC(=O)CCI", "Filter26_alkyl_halide|Filter75_alkyl_Br_I"},
-            {"CC=NOS(=O)N", "Filter18_oxime_ester|Filter89_hydroxylamine"},
-            {"NC=NOP(=O)N", "Filter89_hydroxylamine"},
-            {"C=NOP(=O)N", "Filter18_oxime_ester|Filter89_hydroxylamine"},
-            {"NC=NO", "Filter89_hydroxylamine"},
-            {"CC(=O)NOC", ""},
-            {"[Fe]C", "Filter9_metal"},
-            {"[FeH]", "Filter9_metal"},
-            {"[Fe]", ""},
-            {"CN=O", "Filter12_nitroso"},
-            {"N=O", "Filter12_nitroso"},
-            {"S=P", "Filter13_PS_double_bond|Filter61_phosphor_halide_and_P_S_bond"},
-            {"S=PC", "Filter13_PS_double_bond|Filter61_phosphor_halide_and_P_S_bond"},
-            {"CC(=O)SC", "Filter29_thioester"},
-            {"CC(=S)SC", "Filter29_thioester"},
-            {"CC(=N)SC", "Filter29_thioester"},
-            {"CC(=O)S", "Filter29_thioester|Filter74_thiol"},
-            {"CC(=S)S", "Filter29_thioester|Filter74_thiol"},
-            {"CC(=N)S", "Filter29_thioester|Filter74_thiol"},
-            {"SO", "Filter31_so_bond|Filter74_thiol"},
-            {"SOC", "Filter31_so_bond|Filter74_thiol"},
-            {"c1csocc1", ""},
-            {"OO", "Filter32_oo_bond"},
-            {"COO", "Filter32_oo_bond"},
-            {"c1coocc1", ""},
-            {"CC(=O)C=C", "Filter44_michael_acceptor2"},
-            {"C(=O)C=C", "Filter38_aldehyde|Filter44_michael_acceptor2"},
-            {"OC(=O)C=C", "Filter44_michael_acceptor2"},
-            {"C1(=O)C=CC(=O)C=C1", "Filter53_para_quinones"},
-            {"CIC", "Filter49_halogen|Filter75_alkyl_Br_I"},
-            {"CI(C)C", "Filter49_halogen|Filter75_alkyl_Br_I"}
-        };
-        FilterCatalogParams params;
-        params.addCatalog(FilterCatalogParams::CHEMBL_Inpharmatica);
-        FilterCatalog catalog(params);
-        for(auto &test: tests) {
-            std::unique_ptr<RWMol> mol(SmilesToMol(test.first));
-            std::string matches;
-            for (auto &match: catalog.getMatches(*mol)) {
-                if (matches.size()) matches += "|";
-                matches += match->getDescription();
-            }
-            
-            TEST_ASSERT(matches == test.second);
-        }
+  }
+  {
+    // Test Lint merge hydrogens
+    const std::vector<std::pair<std::string, std::string>> tests = {
+        {"CN=C", ""},
+        {"CN=CC", "acyclic imines"},
+        {"CN=C(C)", "acyclic imines"},
+        {"C1N=CC1", ""}};
+    FilterCatalogParams params;
+    params.addCatalog(FilterCatalogParams::CHEMBL_LINT);
+    FilterCatalog catalog(params);
+    for (auto &test : tests) {
+      std::unique_ptr<RWMol> mol(SmilesToMol(test.first));
+      std::string matches;
+      for (auto &match : catalog.getMatches(*mol)) {
+        if (matches.size()) matches += "|";
+        matches += match->getDescription();
+      }
+      TEST_ASSERT(matches == test.second);
     }
-    {
-        // Test Lint merge hydrogens
-        const std::vector<std::pair<std::string, std::string>> tests = {
-            {"CN=C", ""},
-            {"CN=CC", "acyclic imines"},
-            {"CN=C(C)", "acyclic imines"},
-            {"C1N=CC1", ""}
-        };
-        FilterCatalogParams params;
-        params.addCatalog(FilterCatalogParams::CHEMBL_LINT);
-        FilterCatalog catalog(params);
-        for(auto &test: tests) {
-            std::unique_ptr<RWMol> mol(SmilesToMol(test.first));
-            std::string matches;
-            for (auto &match: catalog.getMatches(*mol)) {
-                if (matches.size()) matches += "|";
-                matches += match->getDescription();
-            }
-            TEST_ASSERT(matches == test.second);
-        }
-    }
+  }
 }
 
 int main() {

--- a/Code/GraphMol/MolDraw2D/catch_tests.cpp
+++ b/Code/GraphMol/MolDraw2D/catch_tests.cpp
@@ -7476,8 +7476,8 @@ TEST_CASE(
     auto &atomRings = rings->atomRings();
     std::map<int, std::vector<DrawColour>> atomCols;
     std::map<int, double> atomRads;
-    for (auto i = 0; i < atomRings.size(); ++i) {
-      for (auto j = 0; j < atomRings[i].size(); ++j) {
+    for (auto i = 0u; i < atomRings.size(); ++i) {
+      for (auto j = 0u; j < atomRings[i].size(); ++j) {
         auto ex = atomCols.find(atomRings[i][j]);
         if (ex == atomCols.end()) {
           std::vector<DrawColour> cvec(1, colours[i]);
@@ -7495,8 +7495,8 @@ TEST_CASE(
     auto &bondRings = rings->bondRings();
     std::map<int, int> bondMults;
     std::map<int, std::vector<DrawColour>> bondCols;
-    for (auto i = 0; i < bondRings.size(); ++i) {
-      for (auto j = 0; j < bondRings[i].size(); ++j) {
+    for (auto i = 0u; i < bondRings.size(); ++i) {
+      for (auto j = 0u; j < bondRings[i].size(); ++j) {
         auto ex = bondCols.find(bondRings[i][j]);
         if (ex == bondCols.end()) {
           std::vector<DrawColour> cvec(1, colours[i]);

--- a/Code/GraphMol/MolInterchange/Writer.cpp
+++ b/Code/GraphMol/MolInterchange/Writer.cpp
@@ -111,7 +111,7 @@ void addStringVal(rj::Value &dest, const char *tag, const std::string &val,
 }
 
 void addAtom(const Atom &atom, rj::Value &rjAtom, rj::Document &doc,
-             const rj::Value &rjDefaults, const JSONWriteParameters &params) {
+             const rj::Value &rjDefaults) {
   addIntVal(rjAtom, rjDefaults, "z", atom.getAtomicNum(), doc);
   if (!atom.hasQuery()) {
     addIntVal(rjAtom, rjDefaults, "impHs", atom.getTotalNumHs(), doc);
@@ -290,8 +290,7 @@ void addProperties(const T &obj, const std::vector<std::string> &propNames,
   }
 }
 
-void addStereoGroup(const StereoGroup &sg, rj::Value &rjSG, rj::Document &doc,
-                    const JSONWriteParameters &params) {
+void addStereoGroup(const StereoGroup &sg, rj::Value &rjSG, rj::Document &doc) {
   if (inv_stereoGrouplookup.find(sg.getGroupType()) ==
       inv_stereoGrouplookup.end()) {
     throw ValueErrorException("unrecognized StereoGroup type");
@@ -306,7 +305,7 @@ void addStereoGroup(const StereoGroup &sg, rj::Value &rjSG, rj::Document &doc,
 }
 
 void addSubstanceGroup(const SubstanceGroup &sg, rj::Value &rjSG,
-                       rj::Document &doc, const JSONWriteParameters &params) {
+                       rj::Document &doc) {
   bool includePrivate = false, includeComputed = false;
   auto propNames = sg.getPropList(includePrivate, includeComputed);
   if (propNames.size()) {
@@ -389,8 +388,7 @@ void addSubstanceGroup(const SubstanceGroup &sg, rj::Value &rjSG,
   }
 }
 
-void addConformer(const Conformer &conf, rj::Value &rjConf, rj::Document &doc,
-                  const JSONWriteParameters &params) {
+void addConformer(const Conformer &conf, rj::Value &rjConf, rj::Document &doc) {
   int dim = 2;
   if (conf.is3D()) {
     dim = 3;
@@ -439,7 +437,7 @@ void addMol(const T &imol, rj::Value &rjMol, rj::Document &doc,
   bool hasQueryAtoms = false;
   for (const auto &at : mol.atoms()) {
     rj::Value rjAtom(rj::kObjectType);
-    addAtom(*at, rjAtom, doc, atomDefaults, params);
+    addAtom(*at, rjAtom, doc, atomDefaults);
     rjAtoms.PushBack(rjAtom, doc.GetAllocator());
     if (at->hasQuery()) {
       hasQueryAtoms = true;
@@ -463,7 +461,7 @@ void addMol(const T &imol, rj::Value &rjMol, rj::Document &doc,
     rj::Value rjStereoGroups(rj::kArrayType);
     for (const auto &sg : mol.getStereoGroups()) {
       rj::Value rjSG(rj::kObjectType);
-      addStereoGroup(sg, rjSG, doc, params);
+      addStereoGroup(sg, rjSG, doc);
       rjStereoGroups.PushBack(rjSG, doc.GetAllocator());
     }
     rjMol.AddMember("stereoGroups", rjStereoGroups, doc.GetAllocator());
@@ -473,7 +471,7 @@ void addMol(const T &imol, rj::Value &rjMol, rj::Document &doc,
     rj::Value rjSubstanceGroups(rj::kArrayType);
     for (const auto &sg : getSubstanceGroups(mol)) {
       rj::Value rjSG(rj::kObjectType);
-      addSubstanceGroup(sg, rjSG, doc, params);
+      addSubstanceGroup(sg, rjSG, doc);
       rjSubstanceGroups.PushBack(rjSG, doc.GetAllocator());
     }
     rjMol.AddMember("substanceGroups", rjSubstanceGroups, doc.GetAllocator());
@@ -484,7 +482,7 @@ void addMol(const T &imol, rj::Value &rjMol, rj::Document &doc,
     for (auto conf = mol.beginConformers(); conf != mol.endConformers();
          ++conf) {
       rj::Value rjConf(rj::kObjectType);
-      addConformer(*(conf->get()), rjConf, doc, params);
+      addConformer(*(conf->get()), rjConf, doc);
       rjConfs.PushBack(rjConf, doc.GetAllocator());
     }
 

--- a/Code/GraphMol/MolOps.cpp
+++ b/Code/GraphMol/MolOps.cpp
@@ -677,7 +677,7 @@ std::vector<ROMOL_SPTR> getMolFrags(const ROMol &mol, bool sanitizeFrags,
         for (auto &sg : mol.getStereoGroups()) {
           std::vector<Atom *> sgats;
           for (auto sga : sg.getAtoms()) {
-            if ((*mapping)[sga->getIdx()] == frag) {
+            if ((*mapping)[sga->getIdx()] == static_cast<int>(frag)) {
               sgats.push_back(re->getAtomWithIdx(ids[sga->getIdx()]));
             }
           }
@@ -985,7 +985,7 @@ void addHapticBond(RWMol &mol, unsigned int metalIdx,
   dummyAt->setQuery(makeAtomNullQuery());
 
   unsigned int dummyIdx = mol.addAtom(dummyAt);
-  for (auto i = 0; i < mol.getNumConformers(); ++i) {
+  for (auto i = 0u; i < mol.getNumConformers(); ++i) {
     auto &conf = mol.getConformer(i);
     RDGeom::Point3D dummyPos;
     for (auto ha : hapticAtoms) {

--- a/Code/GraphMol/Subgraphs/SubgraphUtils.cpp
+++ b/Code/GraphMol/Subgraphs/SubgraphUtils.cpp
@@ -135,7 +135,6 @@ DiscrimTuple calcPathDiscriminators(const ROMol &mol, const PATH_TYPE &path,
     CHECK_INVARIANT(extraInvars->size() == mol.getNumAtoms(),
                     "bad extra invars");
   }
-  DiscrimTuple res;
 
   // Start by collecting the atoms in the path and their degrees
   std::vector<int32_t> atomsUsed(mol.getNumAtoms(),

--- a/Code/GraphMol/SubstructLibrary/Wrap/SubstructLibraryWrap.cpp
+++ b/Code/GraphMol/SubstructLibrary/Wrap/SubstructLibraryWrap.cpp
@@ -168,8 +168,8 @@ class SubstructLibraryWrap {
                             bool useQueryQueryMatches = false,
                             int numThreads = -1) const {
     NOGIL h;
-    return countMatches(query, startIdx, endIdx, recursionPossible,
-                        useChirality, useQueryQueryMatches, numThreads);
+    return ss.countMatches(query, startIdx, endIdx, recursionPossible,
+                           useChirality, useQueryQueryMatches, numThreads);
   };
 
   unsigned int countMatches(const ROMol &query, unsigned int startIdx,


### PR DESCRIPTION
Yet another commit fixing build warnings. Most of them are about signed/unsigned comparisons, but there's also an unused variable, an unused argument, and even an infinite recursion loop! (that one actually looks like a bug!).

The diff looks huge, but it is mostly because of clang-format, there aren't that many real changes.
