### PR TITLE
Fixes #6211

### DIFF
--- a/Code/GraphMol/ChemReactions/Reaction.cpp
+++ b/Code/GraphMol/ChemReactions/Reaction.cpp
@@ -343,8 +343,8 @@ bool isMoleculeReactantOfReaction(const ChemicalReaction &rxn, const ROMol &mol,
   unsigned int reactant_template_idx = 0;
   for (auto iter = rxn.beginReactantTemplates();
        iter != rxn.endReactantTemplates(); ++iter, ++reactant_template_idx) {
-    MatchVectType tvect;
-    if (SubstructMatch(mol, **iter, tvect)) {
+    auto tvect = SubstructMatch(mol, **iter, rxn.getSubstructParams());
+    if (!tvect.empty()) {
       which.push_back(reactant_template_idx);
       if (stopAtFirstMatch) {
         return true;
@@ -383,8 +383,8 @@ bool isMoleculeProductOfReaction(const ChemicalReaction &rxn, const ROMol &mol,
   unsigned int product_template_idx = 0;
   for (auto iter = rxn.beginProductTemplates();
        iter != rxn.endProductTemplates(); ++iter, ++product_template_idx) {
-    MatchVectType tvect;
-    if (SubstructMatch(mol, **iter, tvect)) {
+    auto tvect = SubstructMatch(mol, **iter, rxn.getSubstructParams());
+    if (!tvect.empty()) {
       which.push_back(product_template_idx);
       if (stopAtFirstMatch) {
         return true;
@@ -436,8 +436,8 @@ bool isMoleculeAgentOfReaction(const ChemicalReaction &rxn, const ROMol &mol,
         RDKit::Descriptors::calcAMW(mol)) {
       continue;
     }
-    MatchVectType tvect;
-    if (SubstructMatch(mol, **iter, tvect)) {
+    auto tvect = SubstructMatch(mol, **iter, rxn.getSubstructParams());
+    if (!tvect.empty()) {
       return true;
     }
   }

--- a/Code/GraphMol/ChemReactions/Reaction.h
+++ b/Code/GraphMol/ChemReactions/Reaction.h
@@ -141,15 +141,14 @@ class RDKIT_CHEMREACTIONS_EXPORT ChemicalReaction : public RDProps {
     for (ROMOL_SPTR agent_template : other.m_agentTemplates) {
       m_agentTemplates.emplace_back(new RWMol(*agent_template));
     }
+    d_substructParams = other.d_substructParams;
   }
 
  public:
   ChemicalReaction() : RDProps() {}
   //! construct a reaction from a pickle string
   ChemicalReaction(const std::string &binStr);
-  ChemicalReaction(const ChemicalReaction &other) : RDProps() {
-    copy(other);
-  }
+  ChemicalReaction(const ChemicalReaction &other) : RDProps() { copy(other); }
   ChemicalReaction &operator=(const ChemicalReaction &other) {
     if (this != &other) {
       copy(other);
@@ -364,10 +363,16 @@ class RDKIT_CHEMREACTIONS_EXPORT ChemicalReaction : public RDProps {
   //! getImplicitProertiesFlag() for a discussion of what this means.
   void setImplicitPropertiesFlag(bool val) { df_implicitProperties = val; }
 
+  const SubstructMatchParameters &getSubstructParams() const {
+    return d_substructParams;
+  }
+  SubstructMatchParameters &getSubstructParams() { return d_substructParams; }
+
  private:
   bool df_needsInit{true};
   bool df_implicitProperties{false};
   MOL_SPTR_VECT m_reactantTemplates, m_productTemplates, m_agentTemplates;
+  SubstructMatchParameters d_substructParams;
 };
 
 //! tests whether or not the molecule has a substructure match

--- a/Code/GraphMol/ChemReactions/ReactionPickler.h
+++ b/Code/GraphMol/ChemReactions/ReactionPickler.h
@@ -58,7 +58,9 @@ class RDKIT_CHEMREACTIONS_EXPORT ReactionPickler {
     ENDAGENTS,
     ENDREACTION,
     BEGINPROPS,
-    ENDPROPS
+    ENDPROPS,
+    BEGINSSSPARAMS,
+    ENDSSSPARAMS
   } Tags;
 
   //! pickles a reaction and sends the results to stream \c ss

--- a/Code/GraphMol/ChemReactions/ReactionRunner.cpp
+++ b/Code/GraphMol/ChemReactions/ReactionRunner.cpp
@@ -154,9 +154,9 @@ class StereoBondEndCap {
 };
 }  // namespace
 
-VectMatchVectType getReactantMatchesToTemplate(const ROMol &reactant,
-                                               const ROMol &templ,
-                                               unsigned int maxMatches) {
+VectMatchVectType getReactantMatchesToTemplate(
+    const ROMol &reactant, const ROMol &templ, unsigned int maxMatches,
+    const SubstructMatchParameters &ssparams) {
   // NOTE that we are *not* uniquifying the results.
   //   This is because we need multiple matches in reactions. For example,
   //   The ring-closure coded as:
@@ -177,7 +177,7 @@ VectMatchVectType getReactantMatchesToTemplate(const ROMol &reactant,
   //   with uniquifying their results.
   VectMatchVectType res;
 
-  SubstructMatchParameters ssps;
+  SubstructMatchParameters ssps = ssparams;
   ssps.uniquify = false;
   ssps.maxMatches = maxMatches;
   auto matchesHere = SubstructMatch(reactant, templ, ssps);
@@ -214,8 +214,9 @@ bool getReactantMatches(const MOL_SPTR_VECT &reactants,
   for (auto iter = rxn.beginReactantTemplates();
        iter != rxn.endReactantTemplates(); ++iter, i++) {
     if (matchSingleReactant == MatchAll || matchSingleReactant == i) {
-      auto matches = getReactantMatchesToTemplate(*reactants[i].get(),
-                                                  *iter->get(), maxMatches);
+      auto matches =
+          getReactantMatchesToTemplate(*reactants[i].get(), *iter->get(),
+                                       maxMatches, rxn.getSubstructParams());
       if (matches.empty()) {
         // no point continuing if we don't match one of the reactants:
         res = false;
@@ -1781,7 +1782,7 @@ bool run_Reactant(const ChemicalReaction &rxn, RWMol &reactant) {
   }
 
   auto reactantMatch = ReactionRunnerUtils::getReactantMatchesToTemplate(
-      reactant, *reactantTemplate, 1);
+      reactant, *reactantTemplate, 1, rxn.getSubstructParams());
   if (reactantMatch.empty()) {
     return false;
   }

--- a/Code/GraphMol/ChemReactions/ReactionUtils.cpp
+++ b/Code/GraphMol/ChemReactions/ReactionUtils.cpp
@@ -80,8 +80,9 @@ bool hasReactionMoleculeTemplateSubstructMatch(
        ++begin) {
     for (auto begin_query = getStartIterator(query_rxn, t);
          begin_query != getEndIterator(query_rxn, t); ++begin_query) {
-      MatchVectType tvect;
-      if (SubstructMatch(*begin->get(), *begin_query->get(), tvect)) {
+      auto tvect = SubstructMatch(*begin->get(), *begin_query->get(),
+                                  rxn.getSubstructParams());
+      if (!tvect.empty()) {
         return true;
       }
     }

--- a/Code/GraphMol/ChemReactions/Wrap/rdChemReactions.cpp
+++ b/Code/GraphMol/ChemReactions/Wrap/rdChemReactions.cpp
@@ -439,6 +439,10 @@ python::object addReactionToPNGFileHelper(const ChemicalReaction &rxn,
   return retval;
 }
 
+SubstructMatchParameters *getParamsHelper(ChemicalReaction &rxn) {
+  return &rxn.getSubstructParams();
+}
+
 }  // namespace RDKit
 
 void wrap_enumeration();
@@ -631,6 +635,11 @@ Sample Usage:
       .def("GetAgents", &RDKit::ChemicalReaction::getAgents,
            python::return_value_policy<python::reference_existing_object>(),
            "get the agent templates")
+      .def("GetSubstructParams", RDKit::getParamsHelper,
+           python::return_value_policy<
+               python::reference_existing_object,
+               python::with_custodian_and_ward_postcall<0, 1>>(),
+           "get the parameter object controlling the substructure matching")
 
       // properties
       .def("SetProp", RDKit::MolSetProp<RDKit::ChemicalReaction, std::string>,

--- a/Code/GraphMol/ChemReactions/Wrap/testReactionWrapper.py
+++ b/Code/GraphMol/ChemReactions/Wrap/testReactionWrapper.py
@@ -1098,5 +1098,13 @@ M  END
     self.assertEqual(res1, res2)
     self.assertEqual(res1, res3)
 
+  def testGithub6211(self):
+    rxn = AllChem.ReactionFromSmarts("[C:1][C@:2]([N:3])[O:4]>>[C:1][C@@:2]([N:3])[O:4]")
+    mol = Chem.MolFromSmiles("CC[C@@H](N)O")
+    self.assertEqual(Chem.MolToSmiles(rxn.RunReactants((mol, ))[0][0]), "CC[C@H](N)O")
+    rxn.GetSubstructParams().useChirality = True
+    self.assertEqual(len(rxn.RunReactants((mol, ))), 0)
+
+
 if __name__ == '__main__':
   unittest.main(verbosity=True)

--- a/Code/GraphMol/ChemReactions/Wrap/testReactionWrapper.py
+++ b/Code/GraphMol/ChemReactions/Wrap/testReactionWrapper.py
@@ -935,9 +935,8 @@ class StereoGroupTests(unittest.TestCase):
     products = _reactAndSummarize('[O:1].[C:2]=O>>[O:1][C:2][O:1]',
                                   'Cl[C@@H](Br)C[C@H](Br)CCO |&1:1,4|', 'CC(=O)C')
     # stereogroup manually checked, product SMILES assumed correct.
-    self.assertEqual(
-      products,
-      'CC(C)(OCC[C@H](Br)C[C@H](Cl)Br)OCC[C@H](Br)C[C@H](Cl)Br |&1:6,9,15,18|')
+    self.assertEqual(products,
+                     'CC(C)(OCC[C@H](Br)C[C@H](Cl)Br)OCC[C@H](Br)C[C@H](Cl)Br |&1:6,9,15,18|')
 
     # Stereogroup atoms are not in the reaction, but have multiple copies in the
     # product.
@@ -1084,17 +1083,18 @@ M  END
 
   def testGithub6138(self):
     mol = Chem.MolFromSmiles("COc1ccccc1Oc1nc(Nc2cc(C)[nH]n2)cc2ccccc12")
-    rxn = AllChem.ReactionFromSmarts("([c:1]:[n&H1&+0&D2:3]:[n:2])>>([c:1]:[n&H0&+0&D3:3](:[n:2])-C1-C-C-C-C-O-1)")
+    rxn = AllChem.ReactionFromSmarts(
+      "([c:1]:[n&H1&+0&D2:3]:[n:2])>>([c:1]:[n&H0&+0&D3:3](:[n:2])-C1-C-C-C-C-O-1)")
 
     def run(r):
-      return Chem.MolToSmiles(r.RunReactants((mol,))[0][0])
+      return Chem.MolToSmiles(r.RunReactants((mol, ))[0][0])
 
     rxn_reloaded = pickle.loads(pickle.dumps(rxn))
 
-    res1 = Chem.MolToSmiles(rxn.RunReactants((mol,))[0][0])
-    res2 = Chem.MolToSmiles(rxn_reloaded.RunReactants((mol,))[0][0])
+    res1 = Chem.MolToSmiles(rxn.RunReactants((mol, ))[0][0])
+    res2 = Chem.MolToSmiles(rxn_reloaded.RunReactants((mol, ))[0][0])
     rxn_reloaded_after_use = pickle.loads(pickle.dumps(rxn))
-    res3 = Chem.MolToSmiles(rxn_reloaded_after_use.RunReactants((mol,))[0][0])
+    res3 = Chem.MolToSmiles(rxn_reloaded_after_use.RunReactants((mol, ))[0][0])
     self.assertEqual(res1, res2)
     self.assertEqual(res1, res3)
 

--- a/Code/GraphMol/ChemReactions/catch_tests.cpp
+++ b/Code/GraphMol/ChemReactions/catch_tests.cpp
@@ -23,6 +23,7 @@
 #include <GraphMol/ChemReactions/ReactionParser.h>
 #include <GraphMol/ChemReactions/ReactionRunner.h>
 #include <GraphMol/ChemReactions/ReactionUtils.h>
+#include <GraphMol/ChemReactions/ReactionPickler.h>
 #include <GraphMol/FileParsers/PNGParser.h>
 #include <GraphMol/FileParsers/FileParserUtils.h>
 
@@ -1518,5 +1519,18 @@ TEST_CASE("Github #6211: substructmatchparams for chemical reactions") {
         }
       }
     }
+  }
+
+  SECTION("serialization") {
+    auto rxn = "[C:1][C@:2]([N:3])[O:4]>>[C:1][C@@:2]([N:3])[O:4]"_rxnsmarts;
+    REQUIRE(rxn);
+    rxn->initReactantMatchers();
+    rxn->getSubstructParams().useChirality = true;
+    std::string pkl;
+    ReactionPickler::pickleReaction(*rxn,pkl);
+    ChemicalReaction rxn2;
+    ReactionPickler::reactionFromPickle(pkl,rxn2);
+    CHECK(rxn2.getSubstructParams().useChirality == true);
+
   }
 }

--- a/Code/GraphMol/ChemReactions/catch_tests.cpp
+++ b/Code/GraphMol/ChemReactions/catch_tests.cpp
@@ -1480,8 +1480,13 @@ TEST_CASE("Github #6211: substructmatchparams for chemical reactions") {
         if (outSmi != "") {
           REQUIRE(prods.size() == 1);
           CHECK(MolToSmiles(*prods[0][0]) == outSmi);
+          CHECK(isMoleculeReactantOfReaction(*rxn,*reacts.front()));
+          std::unique_ptr<RWMol> prod{SmilesToMol(outSmi)};
+          REQUIRE(prod);
+          CHECK(isMoleculeProductOfReaction(*rxn,*prod));
         } else {
           CHECK(prods.empty());
+          CHECK(!isMoleculeReactantOfReaction(*rxn,*reacts.front()));
         }
       }
     }
@@ -1500,8 +1505,13 @@ TEST_CASE("Github #6211: substructmatchparams for chemical reactions") {
         if (outSmi != "") {
           REQUIRE(prods.size() == 1);
           CHECK(MolToSmiles(*prods[0][0]) == outSmi);
+          CHECK(isMoleculeReactantOfReaction(*rxn,*reacts.front()));
+          std::unique_ptr<RWMol> prod{SmilesToMol(outSmi)};
+          REQUIRE(prod);
+          CHECK(isMoleculeProductOfReaction(*rxn,*prod));
         } else {
           CHECK(prods.empty());
+          CHECK(!isMoleculeReactantOfReaction(*rxn,*reacts.front()));
         }
       }
       // make sure the parameters are copied

--- a/Code/GraphMol/Substruct/SubstructMatch.h
+++ b/Code/GraphMol/Substruct/SubstructMatch.h
@@ -67,6 +67,8 @@ struct RDKIT_SUBSTRUCTMATCH_EXPORT SubstructMatchParameters {
 
 RDKIT_SUBSTRUCTMATCH_EXPORT void updateSubstructMatchParamsFromJSON(
     SubstructMatchParameters &params, const std::string &json);
+RDKIT_SUBSTRUCTMATCH_EXPORT std::string substructMatchParamsToJSON(
+    const SubstructMatchParameters &params);
 
 //! Find a substructure match for a query in a molecule
 /*!

--- a/Code/GraphMol/Substruct/SubstructUtils.cpp
+++ b/Code/GraphMol/Substruct/SubstructUtils.cpp
@@ -218,6 +218,7 @@ std::vector<MatchVectType> sortMatchesByDegreeOfCoreSubstitution(
 }
 
 #define PT_OPT_GET(opt) params.opt = pt.get(#opt, params.opt)
+#define PT_OPT_PUT(opt) pt.put(#opt, params.opt);
 
 void updateSubstructMatchParamsFromJSON(SubstructMatchParameters &params,
                                         const std::string &json) {
@@ -236,6 +237,23 @@ void updateSubstructMatchParamsFromJSON(SubstructMatchParameters &params,
   PT_OPT_GET(uniquify);
   PT_OPT_GET(maxMatches);
   PT_OPT_GET(numThreads);
+}
+
+std::string substructMatchParamsToJSON(const SubstructMatchParameters &params) {
+  boost::property_tree::ptree pt;
+
+  PT_OPT_PUT(useChirality);
+  PT_OPT_PUT(useEnhancedStereo);
+  PT_OPT_PUT(aromaticMatchesConjugated);
+  PT_OPT_PUT(useQueryQueryMatches);
+  PT_OPT_PUT(recursionPossible);
+  PT_OPT_PUT(uniquify);
+  PT_OPT_PUT(maxMatches);
+  PT_OPT_PUT(numThreads);
+
+  std::stringstream ss;
+  boost::property_tree::json_parser::write_json(ss, pt);
+  return ss.str();
 }
 
 }  // namespace RDKit


### PR DESCRIPTION
This adds a `SubstructMatchParams` object to `ChemicalReaction` and uses that to control substructure matching.

It also adds a `substructMatchParamsToJSON()` function so that we can easily and flexibly serialize those parameter objects.

Fixes #6211 