### PR TITLE
Fixes #6241

### DIFF
--- a/Code/GraphMol/FileParsers/MolFileParser.cpp
+++ b/Code/GraphMol/FileParsers/MolFileParser.cpp
@@ -1388,7 +1388,8 @@ void setRGPProps(const std::string_view symb, Atom *res) {
   res->setProp(common_properties::dummyLabel, symbc);
 }
 
-void lookupAtomicNumber(Atom *res, const std::string &symb, bool strictParsing) {
+void lookupAtomicNumber(Atom *res, const std::string &symb,
+                        bool strictParsing) {
   try {
     res->setAtomicNum(PeriodicTable::getTable()->getAtomicNumber(symb));
   } catch (const Invar::Invariant &e) {
@@ -3057,9 +3058,7 @@ bool ParseV3000CTAB(std::istream *inStream, unsigned int &line, RWMol *mol,
     chiralFlag = FileParserUtils::toUnsigned(splitLine[4]);
   }
 
-  if (chiralFlag) {
-    mol->setProp(common_properties::_MolFileChiralFlag, chiralFlag);
-  }
+  mol->setProp(common_properties::_MolFileChiralFlag, chiralFlag);
 
   if (nAtoms) {
     ParseV3000AtomBlock(inStream, line, nAtoms, mol, conf, strictParsing);
@@ -3440,9 +3439,7 @@ RWMol *MolDataStreamToMol(std::istream *inStream, unsigned int &line,
     }
   }
 
-  if (chiralFlag) {
-    res->setProp(common_properties::_MolFileChiralFlag, chiralFlag);
-  }
+  res->setProp(common_properties::_MolFileChiralFlag, chiralFlag);
 
   Conformer *conf = nullptr;
   try {

--- a/Code/GraphMol/FileParsers/MolFileStereochem.h
+++ b/Code/GraphMol/FileParsers/MolFileStereochem.h
@@ -83,8 +83,26 @@ RDKIT_FILEPARSERS_EXPORT void markUnspecifiedStereoAsUnknown(ROMol &mol,
                                                              int confId = -1);
 
 //! generate enhanced stereo groups based on the status of the chiral flag
-//! property
-RDKIT_FILEPARSERS_EXPORT void translateChiralFlagToStereoGroups(ROMol &mol);
+/// property
+/*
+ \param mol: molecule to be modified
+ \param zeroFlagGroupType: how to handle non-grouped stereo centers when the
+        chiral flag is set to zero
+
+  If the chiral flag is set to a value of 1 then all specified tetrahedral
+  chiral centers which are not already in StereoGroups will be added to an
+  ABS StereoGroup.
+
+  If the chiral flag is set to a value of 0 then all specified tetrahedral
+  chiral centers will be added to a StereoGroup of the type zeroFlagGroupType
+
+  If there is no chiral flag set (i.e. the property is not present), the
+  molecule will not be modified.
+
+*/
+RDKIT_FILEPARSERS_EXPORT void translateChiralFlagToStereoGroups(
+    ROMol &mol,
+    StereoGroupType zeroFlagGroupType = StereoGroupType::STEREO_AND);
 
 }  // namespace RDKit
 #endif

--- a/Code/GraphMol/FileParsers/MolFileStereochem.h
+++ b/Code/GraphMol/FileParsers/MolFileStereochem.h
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2004-2021 Greg Landrum and other RDKit contributors
+//  Copyright (C) 2004-2023 Greg Landrum and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -81,6 +81,10 @@ RDKIT_FILEPARSERS_EXPORT void invertMolBlockWedgingInfo(ROMol &mol);
 ///  potential stereocenters with unspecified chirality
 RDKIT_FILEPARSERS_EXPORT void markUnspecifiedStereoAsUnknown(ROMol &mol,
                                                              int confId = -1);
+
+//! generate enhanced stereo groups based on the status of the chiral flag
+//! property
+RDKIT_FILEPARSERS_EXPORT void translateChiralFlagToStereoGroups(ROMol &mol);
 
 }  // namespace RDKit
 #endif

--- a/Code/GraphMol/FileParsers/molfile_stereo_catch.cpp
+++ b/Code/GraphMol/FileParsers/molfile_stereo_catch.cpp
@@ -32,8 +32,87 @@ TEST_CASE("Github #5863: failure in WedgeMolBonds") {
     std::unique_ptr<ROMol> frag(Subgraphs::pathToSubmol(*mol, env));
     REQUIRE(frag);
     WedgeMolBonds(*frag, &frag->getConformer());
+    INFO(MolToV3KMolBlock(*frag));
     CHECK(frag->getBondBetweenAtoms(9, 10)->getBondDir() !=
           Bond::BondDir::NONE);
-    std::cerr << MolToV3KMolBlock(*frag) << std::endl;
+  }
+}
+
+TEST_CASE("translating the chiral flag to stereo groups") {
+  SECTION("basics") {
+    auto withFlag = R"CTAB(
+  Mrv2211 03302308372D          
+
+  5  4  0  0  1  0            999 V2000
+   -6.5625    3.9286    0.0000 N   0  0  0  0  0  0  0  0  0  0  0  0
+   -5.8480    4.3411    0.0000 C   0  0  1  0  0  0  0  0  0  0  0  0
+   -5.1336    3.9286    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
+   -6.1775    5.0826    0.0000 F   0  0  0  0  0  0  0  0  0  0  0  0
+   -5.4384    5.0893    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+  1  2  1  0  0  0  0
+  2  3  1  0  0  0  0
+  2  5  1  1  0  0  0
+  2  4  1  6  0  0  0
+M  END
+)CTAB"_ctab;
+    REQUIRE(withFlag);
+    int flag;
+    CHECK(withFlag->getPropIfPresent(common_properties::_MolFileChiralFlag,
+                                     flag));
+    CHECK(flag == 1);
+    RWMol zeroFlag(*withFlag);
+    zeroFlag.setProp(common_properties::_MolFileChiralFlag, 0);
+    RWMol noFlag(*withFlag);
+    noFlag.clearProp(common_properties::_MolFileChiralFlag);
+    CHECK(withFlag->getStereoGroups().empty());
+
+    translateChiralFlagToStereoGroups(*withFlag);
+    CHECK(!withFlag->hasProp(common_properties::_MolFileChiralFlag));
+    auto sgs = withFlag->getStereoGroups();
+    REQUIRE(sgs.size() == 1);
+    CHECK(sgs[0].getGroupType() == StereoGroupType::STEREO_ABSOLUTE);
+    CHECK(sgs[0].getAtoms().size() == 1);
+    CHECK(sgs[0].getAtoms()[0]->getIdx() == 1);
+
+    translateChiralFlagToStereoGroups(zeroFlag);
+    CHECK(!zeroFlag.hasProp(common_properties::_MolFileChiralFlag));
+    CHECK(zeroFlag.getStereoGroups().empty());
+
+    translateChiralFlagToStereoGroups(noFlag);
+    CHECK(!noFlag.hasProp(common_properties::_MolFileChiralFlag));
+    CHECK(noFlag.getStereoGroups().empty());
+  }
+
+  SECTION("multiple stereocenters") {
+    auto noFlag = "C[C@@](N)(F)C[C@](C)(O)F"_smiles;
+    REQUIRE(noFlag);
+    RWMol withFlag(*noFlag);
+    withFlag.setProp(common_properties::_MolFileChiralFlag, 1);
+
+    CHECK(withFlag.getStereoGroups().empty());
+    translateChiralFlagToStereoGroups(withFlag);
+    CHECK(!withFlag.hasProp(common_properties::_MolFileChiralFlag));
+    auto sgs = withFlag.getStereoGroups();
+    REQUIRE(sgs.size() == 1);
+    CHECK(sgs[0].getGroupType() == StereoGroupType::STEREO_ABSOLUTE);
+    CHECK(sgs[0].getAtoms().size() == 2);
+    CHECK(sgs[0].getAtoms()[0]->getIdx() == 1);
+    CHECK(sgs[0].getAtoms()[1]->getIdx() == 5);
+  }
+
+  SECTION("pre-existing ABS stereogroup") {
+    auto withFlag = "C[C@@](N)(F)C[C@](C)(O)F |a:1|"_smiles;
+    REQUIRE(withFlag);
+    withFlag->setProp(common_properties::_MolFileChiralFlag, 1);
+
+    CHECK(withFlag->getStereoGroups().size() == 1);
+    translateChiralFlagToStereoGroups(*withFlag);
+    CHECK(!withFlag->hasProp(common_properties::_MolFileChiralFlag));
+    auto sgs = withFlag->getStereoGroups();
+    REQUIRE(sgs.size() == 1);
+    CHECK(sgs[0].getGroupType() == StereoGroupType::STEREO_ABSOLUTE);
+    CHECK(sgs[0].getAtoms().size() == 2);
+    CHECK(sgs[0].getAtoms()[0]->getIdx() == 1);
+    CHECK(sgs[0].getAtoms()[1]->getIdx() == 5);
   }
 }

--- a/Code/GraphMol/FileParsers/molfile_stereo_catch.cpp
+++ b/Code/GraphMol/FileParsers/molfile_stereo_catch.cpp
@@ -100,6 +100,39 @@ M  END
     CHECK(noFlag.getStereoGroups().empty());
   }
 
+  SECTION("explicit zero chiral flag") {
+    auto zeroFlag = R"CTAB(
+  Mrv2211 03302308372D          
+
+  5  4  0  0  o  0            999 V2000
+   -6.5625    3.9286    0.0000 N   0  0  0  0  0  0  0  0  0  0  0  0
+   -5.8480    4.3411    0.0000 C   0  0  1  0  0  0  0  0  0  0  0  0
+   -5.1336    3.9286    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
+   -6.1775    5.0826    0.0000 F   0  0  0  0  0  0  0  0  0  0  0  0
+   -5.4384    5.0893    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+  1  2  1  0  0  0  0
+  2  3  1  0  0  0  0
+  2  5  1  1  0  0  0
+  2  4  1  6  0  0  0
+M  END
+)CTAB"_ctab;
+    REQUIRE(zeroFlag);
+    int flag;
+    CHECK(zeroFlag->getPropIfPresent(common_properties::_MolFileChiralFlag,
+                                     flag));
+    CHECK(flag == 0);
+    {
+      RWMol cp(*zeroFlag);
+      translateChiralFlagToStereoGroups(cp);
+      CHECK(!cp.hasProp(common_properties::_MolFileChiralFlag));
+      auto sgs = cp.getStereoGroups();
+      REQUIRE(sgs.size() == 1);
+      CHECK(sgs[0].getGroupType() == StereoGroupType::STEREO_AND);
+      CHECK(sgs[0].getAtoms().size() == 1);
+      CHECK(sgs[0].getAtoms()[0]->getIdx() == 1);
+    }
+  }
+
   SECTION("multiple stereocenters") {
     auto noFlag = "C[C@@](N)(F)C[C@](C)(O)F"_smiles;
     REQUIRE(noFlag);

--- a/Code/GraphMol/FileParsers/molfile_stereo_catch.cpp
+++ b/Code/GraphMol/FileParsers/molfile_stereo_catch.cpp
@@ -74,9 +74,26 @@ M  END
     CHECK(sgs[0].getAtoms().size() == 1);
     CHECK(sgs[0].getAtoms()[0]->getIdx() == 1);
 
-    translateChiralFlagToStereoGroups(zeroFlag);
-    CHECK(!zeroFlag.hasProp(common_properties::_MolFileChiralFlag));
-    CHECK(zeroFlag.getStereoGroups().empty());
+    {
+      RWMol cp(zeroFlag);
+      translateChiralFlagToStereoGroups(cp);
+      CHECK(!cp.hasProp(common_properties::_MolFileChiralFlag));
+      auto sgs = cp.getStereoGroups();
+      REQUIRE(sgs.size() == 1);
+      CHECK(sgs[0].getGroupType() == StereoGroupType::STEREO_AND);
+      CHECK(sgs[0].getAtoms().size() == 1);
+      CHECK(sgs[0].getAtoms()[0]->getIdx() == 1);
+    }
+    {
+      RWMol cp(zeroFlag);
+      translateChiralFlagToStereoGroups(cp, StereoGroupType::STEREO_OR);
+      CHECK(!cp.hasProp(common_properties::_MolFileChiralFlag));
+      auto sgs = cp.getStereoGroups();
+      REQUIRE(sgs.size() == 1);
+      CHECK(sgs[0].getGroupType() == StereoGroupType::STEREO_OR);
+      CHECK(sgs[0].getAtoms().size() == 1);
+      CHECK(sgs[0].getAtoms()[0]->getIdx() == 1);
+    }
 
     translateChiralFlagToStereoGroups(noFlag);
     CHECK(!noFlag.hasProp(common_properties::_MolFileChiralFlag));
@@ -98,6 +115,19 @@ M  END
     CHECK(sgs[0].getAtoms().size() == 2);
     CHECK(sgs[0].getAtoms()[0]->getIdx() == 1);
     CHECK(sgs[0].getAtoms()[1]->getIdx() == 5);
+
+    {
+      RWMol zeroFlag(*noFlag);
+      zeroFlag.setProp(common_properties::_MolFileChiralFlag, 0);
+      translateChiralFlagToStereoGroups(zeroFlag);
+      CHECK(!zeroFlag.hasProp(common_properties::_MolFileChiralFlag));
+      auto sgs = zeroFlag.getStereoGroups();
+      REQUIRE(sgs.size() == 1);
+      CHECK(sgs[0].getGroupType() == StereoGroupType::STEREO_AND);
+      CHECK(sgs[0].getAtoms().size() == 2);
+      CHECK(sgs[0].getAtoms()[0]->getIdx() == 1);
+      CHECK(sgs[0].getAtoms()[1]->getIdx() == 5);
+    }
   }
 
   SECTION("pre-existing ABS stereogroup") {

--- a/Code/GraphMol/FileParsers/testMolWriter.cpp
+++ b/Code/GraphMol/FileParsers/testMolWriter.cpp
@@ -697,7 +697,8 @@ void testMolFileChiralFlag() {
     std::string mb = MolToMolBlock(*m1);
     delete m1;
     m1 = MolBlockToMol(mb);
-    TEST_ASSERT(!m1->hasProp(common_properties::_MolFileChiralFlag));
+    TEST_ASSERT(m1->hasProp(common_properties::_MolFileChiralFlag));
+    TEST_ASSERT(m1->getProp<int>(common_properties::_MolFileChiralFlag) == 0);
     delete m1;
   }
   {

--- a/Code/GraphMol/Wrap/MolOps.cpp
+++ b/Code/GraphMol/Wrap/MolOps.cpp
@@ -2878,6 +2878,27 @@ A note on the flags controlling which atoms/bonds are modified:
                 Chirality::getUseLegacyStereoPerception,
                 "returns whether or not the legacy stereo perception code is "
                 "being used");
+
+    python::def(
+        "TranslateChiralFlagToStereoGroups", translateChiralFlagToStereoGroups,
+        (python::arg("mol"),
+         python::arg("zeroFlagGroupType") = StereoGroupType::STEREO_AND),
+        R"DOC(Generate enhanced stereo groups based on the status of the chiral flag property.
+
+  Arguments:
+   - mol: molecule to be modified
+   - zeroFlagGroupType: how to handle non-grouped stereo centers when the
+          chiral flag is set to zero
+
+  If the chiral flag is set to a value of 1 then all specified tetrahedral
+  chiral centers which are not already in StereoGroups will be added to an
+  ABS StereoGroup.
+
+  If the chiral flag is set to a value of 0 then all specified tetrahedral
+  chiral centers will be added to a StereoGroup of the type zeroFlagGroupType
+
+  If there is no chiral flag set (i.e. the property is not present), the
+  molecule will not be modified.)DOC");
   }
 };
 }  // namespace RDKit

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2003-2021  Greg Landrum and other RDKit contributors
+#  Copyright (C) 2003-2023  Greg Landrum and other RDKit contributors
 #         All Rights Reserved
 #
 """ This is a rough coverage test of the python wrapper
@@ -7214,6 +7214,38 @@ CAS<~>
     backfemol = Chem.rdmolops.DativeBondsToHaptic(newfemol)
     self.assertEqual(Chem.MolToSmiles(femol), Chem.MolToSmiles(backfemol))
     
+  def testTranslateChiralFlag(self):
+    mol = Chem.MolFromSmiles("C[C@@](N)(F)C[C@](C)(O)F |a:1|")
+    flagMol = Chem.Mol(mol)
+    flagMol.SetIntProp("_MolFileChiralFlag",1)
+    Chem.TranslateChiralFlagToStereoGroups(flagMol)
+    sgs = flagMol.GetStereoGroups()
+    self.assertEqual(len(sgs),1)
+    self.assertEqual(len(sgs[0].GetAtoms()), 2)
+    self.assertEqual(sgs[0].GetGroupType(), Chem.StereoGroupType.STEREO_ABSOLUTE)
+
+    flagMol = Chem.Mol(mol)
+    flagMol.SetIntProp("_MolFileChiralFlag",0)
+    Chem.TranslateChiralFlagToStereoGroups(flagMol)
+    sgs = flagMol.GetStereoGroups()
+    self.assertEqual(len(sgs),2)
+    self.assertEqual(sgs[0].GetGroupType(), Chem.StereoGroupType.STEREO_ABSOLUTE)
+    self.assertEqual(len(sgs[0].GetAtoms()), 1)
+
+    self.assertEqual(sgs[1].GetGroupType(), Chem.StereoGroupType.STEREO_AND)
+    self.assertEqual(len(sgs[1].GetAtoms()), 1)
+
+    flagMol = Chem.Mol(mol)
+    flagMol.SetIntProp("_MolFileChiralFlag",0)
+    Chem.TranslateChiralFlagToStereoGroups(flagMol, Chem.StereoGroupType.STEREO_OR)
+    sgs = flagMol.GetStereoGroups()
+    self.assertEqual(len(sgs),2)
+    self.assertEqual(sgs[0].GetGroupType(), Chem.StereoGroupType.STEREO_ABSOLUTE)
+    self.assertEqual(len(sgs[0].GetAtoms()), 1)
+
+    self.assertEqual(sgs[1].GetGroupType(), Chem.StereoGroupType.STEREO_OR)
+    self.assertEqual(len(sgs[1].GetAtoms()), 1)
+
 
 if __name__ == '__main__':
   if "RDTESTCASE" in os.environ:

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -4376,6 +4376,7 @@ $$$$
         'NCI_AIDS_Antiviral_Screen_IC50': '2.00E-04\tM\t=\t2.46E-05\t3',
         '_Name': 48,
         'CAS_RN': '15716-70-8',
+        '_MolFileChiralFlag': 0,
         '_MolFileComments': '15716-70-8',
         'NCI_AIDS_Antiviral_Screen_EC50': '2.00E-04\tM\t>\t2.00E-04\t3',
         'NCI_AIDS_Antiviral_Screen_Conclusion': 'CI'
@@ -4386,6 +4387,7 @@ $$$$
         'NCI_AIDS_Antiviral_Screen_IC50': '2.00E-04\tM\t=\t9.80E-05\t3',
         '_Name': 78,
         'CAS_RN': '6290-84-2',
+        '_MolFileChiralFlag': 0,
         '_MolFileComments': '6290-84-2',
         'NCI_AIDS_Antiviral_Screen_EC50': '2.00E-04\tM\t>\t2.00E-04\t3',
         'NCI_AIDS_Antiviral_Screen_Conclusion': 'CI'
@@ -4396,6 +4398,7 @@ $$$$
         'NCI_AIDS_Antiviral_Screen_IC50': '2.00E-04\tM\t=\t4.60E-05\t4',
         '_Name': 128,
         'CAS_RN': '5395-10-8',
+        '_MolFileChiralFlag': 0,
         '_MolFileComments': '5395-10-8',
         'NCI_AIDS_Antiviral_Screen_EC50': '2.00E-04\tM\t>\t2.00E-04\t4',
         'NCI_AIDS_Antiviral_Screen_Conclusion': 'CI'
@@ -4406,6 +4409,7 @@ $$$$
         'NCI_AIDS_Antiviral_Screen_IC50': '6.75E-04\tM\t>\t6.75E-04\t2',
         '_Name': 163,
         'CAS_RN': '81-11-8',
+        '_MolFileChiralFlag': 0,
         '_MolFileComments': '81-11-8',
         'NCI_AIDS_Antiviral_Screen_EC50': '6.75E-04\tM\t>\t6.75E-04\t2',
         'NCI_AIDS_Antiviral_Screen_Conclusion': 'CI'
@@ -4416,6 +4420,7 @@ $$$$
         'NCI_AIDS_Antiviral_Screen_IC50': '2.00E-04\tM\t>\t2.00E-04\t2',
         '_Name': 164,
         'CAS_RN': '5325-43-9',
+        '_MolFileChiralFlag': 0,
         '_MolFileComments': '5325-43-9',
         'NCI_AIDS_Antiviral_Screen_EC50': '2.00E-04\tM\t>\t2.00E-04\t2',
         'NCI_AIDS_Antiviral_Screen_Conclusion': 'CI'
@@ -4425,6 +4430,7 @@ $$$$
         'NSC': 170,
         '_Name': 170,
         'CAS_RN': '999-99-9',
+        '_MolFileChiralFlag': 0,
         '_MolFileComments': '999-99-9',
         'NCI_AIDS_Antiviral_Screen_EC50': '9.47E-04\tM\t>\t9.47E-04\t1',
         'NCI_AIDS_Antiviral_Screen_Conclusion': 'CI'
@@ -4436,6 +4442,7 @@ $$$$
         '6.46E-04\tM\t=\t5.80E-04\t2\n1.81E-03\tM\t=\t6.90E-04\t2',
         '_Name': 180,
         'CAS_RN': '69-72-7',
+        '_MolFileChiralFlag': 0,
         '_MolFileComments': '69-72-7',
         'NCI_AIDS_Antiviral_Screen_EC50':
         '6.46E-04\tM\t>\t6.46E-04\t2\n1.81E-03\tM\t>\t1.81E-03\t2',
@@ -4447,6 +4454,7 @@ $$$$
         'NCI_AIDS_Antiviral_Screen_IC50': '1.44E-04\tM\t=\t2.49E-05\t2',
         '_Name': 186,
         'CAS_RN': '518-75-2',
+        '_MolFileChiralFlag': 0,
         '_MolFileComments': '518-75-2',
         'NCI_AIDS_Antiviral_Screen_EC50': '1.44E-04\tM\t>\t1.44E-04\t2',
         'NCI_AIDS_Antiviral_Screen_Conclusion': 'CI'
@@ -4457,6 +4465,7 @@ $$$$
         'NCI_AIDS_Antiviral_Screen_IC50': '2.00E-04\tM\t=\t3.38E-06\t2',
         '_Name': 192,
         'CAS_RN': '2217-55-2',
+        '_MolFileChiralFlag': 0,
         '_MolFileComments': '2217-55-2',
         'NCI_AIDS_Antiviral_Screen_EC50': '2.00E-04\tM\t>\t2.00E-04\t2',
         'NCI_AIDS_Antiviral_Screen_Conclusion': 'CI'
@@ -4466,6 +4475,7 @@ $$$$
         'NSC': 203,
         '_Name': 203,
         'CAS_RN': '1155-00-6',
+        '_MolFileChiralFlag': 0,
         '_MolFileComments': '1155-00-6',
         'NCI_AIDS_Antiviral_Screen_Conclusion': 'CI'
       },
@@ -4475,6 +4485,7 @@ $$$$
         'NCI_AIDS_Antiviral_Screen_IC50': '1.33E-03\tM\t>\t1.33E-03\t2',
         '_Name': 210,
         'CAS_RN': '5325-75-7',
+        '_MolFileChiralFlag': 0,
         '_MolFileComments': '5325-75-7',
         'NCI_AIDS_Antiviral_Screen_EC50': '1.33E-03\tM\t>\t1.33E-03\t2',
         'NCI_AIDS_Antiviral_Screen_Conclusion': 'CI'
@@ -4486,6 +4497,7 @@ $$$$
         '2.00E-04\tM\t>\t2.00E-04\t8\n2.00E-03\tM\t=\t1.12E-03\t2',
         '_Name': 211,
         'CAS_RN': '5325-76-8',
+        '_MolFileChiralFlag': 0,
         '_MolFileComments': '5325-76-8',
         'NCI_AIDS_Antiviral_Screen_EC50':
         '2.00E-04\tM\t>\t7.42E-05\t8\n2.00E-03\tM\t=\t6.35E-05\t2',
@@ -4497,6 +4509,7 @@ $$$$
         'NCI_AIDS_Antiviral_Screen_IC50': '2.00E-04\tM\t>\t2.00E-04\t4',
         '_Name': 213,
         'CAS_RN': '119-80-2',
+        '_MolFileChiralFlag': 0,
         '_MolFileComments': '119-80-2',
         'NCI_AIDS_Antiviral_Screen_EC50': '2.00E-04\tM\t>\t2.00E-04\t4',
         'NCI_AIDS_Antiviral_Screen_Conclusion': 'CI'
@@ -4507,6 +4520,7 @@ $$$$
         'NCI_AIDS_Antiviral_Screen_IC50': '2.00E-04\tM\t>\t2.00E-04\t4',
         '_Name': 220,
         'CAS_RN': '5325-83-7',
+        '_MolFileChiralFlag': 0,
         '_MolFileComments': '5325-83-7',
         'NCI_AIDS_Antiviral_Screen_EC50': '2.00E-04\tM\t>\t2.00E-04\t4',
         'NCI_AIDS_Antiviral_Screen_Conclusion': 'CI'
@@ -4517,6 +4531,7 @@ $$$$
         'NCI_AIDS_Antiviral_Screen_IC50': '2.00E-04\tM\t>\t2.00E-04\t2',
         '_Name': 229,
         'CAS_RN': '5325-88-2',
+        '_MolFileChiralFlag': 0,
         '_MolFileComments': '5325-88-2',
         'NCI_AIDS_Antiviral_Screen_EC50': '2.00E-04\tM\t>\t2.00E-04\t2',
         'NCI_AIDS_Antiviral_Screen_Conclusion': 'CI'
@@ -4527,6 +4542,7 @@ $$$$
         'NCI_AIDS_Antiviral_Screen_IC50': '2.00E-04\tM\t>\t2.00E-04\t4',
         '_Name': 256,
         'CAS_RN': '5326-06-7',
+        '_MolFileChiralFlag': 0,
         '_MolFileComments': '5326-06-7',
         'NCI_AIDS_Antiviral_Screen_EC50': '2.00E-04\tM\t>\t2.00E-04\t4',
         'NCI_AIDS_Antiviral_Screen_Conclusion': 'CI'

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -12,6 +12,7 @@
 - The doIsomericSmiles parameter in Java and C# ROMol.MolToSmiles() now defaults to true (previously it was false), thus aligning to the C++ and Python behavior.
 - Double bonds which are marked as crossed (i.e. `bond.GetBondDir() == Bond.BondDir.EITHERDOUBLE`) now have their BondStereo set to `Bond.BondStereo.STEREOANY` and the BondDir information removed by default when molecules are parsed or `AssignStereochemistry()` is called with the `cleanIt` argument set to True.
 - The conformers generated for molecules with three-coordinate chiral centers will be somewhat different due to the fix for #5883.
+- Molecules which come from Mol or SDF files will now always have the "_MolFileChiralFlag" property set to the value of the chiral flag in the CTAB. In previous versions the property was not set if the chiral flag was 0.
 
 
 ## Bug Fixes:


### PR DESCRIPTION
Adds a new function to `MolFileStereochem.h` and the python wrapper to apply the "standard" semantics of the chiral flag