### PR TITLE
Update assignSubstructureFilters.py

### DIFF
--- a/Contrib/NIBRSubstructureFilters/assignSubstructureFilters.py
+++ b/Contrib/NIBRSubstructureFilters/assignSubstructureFilters.py
@@ -8,13 +8,14 @@ import sys
 from rdkit import Chem
 from rdkit.Chem import FilterCatalog
 from rdkit.Chem import rdMolDescriptors
+from rdkit.Chem import RDConfig
     
 FilterMatch = namedtuple('FilterMatch', ('SubstructureMatches', 'Min_N_O_filter', 'Frac_N_O', 'Covalent', 'SpecialMol', 'SeverityScore'))
 
 # Build the filter catalog using the RDKit filterCatalog module
 def buildFilterCatalog():
 
-    inhousefilter = pd.read_csv('SubstructureFilter_HitTriaging_wPubChemExamples.csv')
+    inhousefilter = pd.read_csv(f'{RDConfig.RDContribDir}/NIBRSubstructureFilters/SubstructureFilter_HitTriaging_wPubChemExamples.csv')
     inhouseFiltersCat = FilterCatalog.FilterCatalog()
     for i in range(inhousefilter.shape[0]):
         mincount=1


### PR DESCRIPTION
importable package from another directory

<!--
Thanks for contributing a pull request! 
-->
#### Reference Issue
Static file path for inhousefilter makes it useable only when in the same directory.


#### What does this implement/fix? Explain your changes.
This might make this contribution more readily usable, eg. in scripts
```
import sys
from rdkit.Chem import RDConfig
sys.path.append(RDConfig.RDContribDir)
from NIBRSubstructureFilters import assignSubstructureFilters

# run filter on Pandas DataFrame with column 'smiles'
assignSubstructureFilters.assignFilters(df, nameSmilesColumn='smiles')
```