### PR TITLE
Fix incorrect bond check in #6266

### DIFF
--- a/Code/GraphMol/Descriptors/OxidationNumbers.cpp
+++ b/Code/GraphMol/Descriptors/OxidationNumbers.cpp
@@ -60,9 +60,11 @@ int calcOxidationNumberByEN(const Atom *atom) {
   float parEN = get_en(atom->getAtomicNum());
 
   for (const auto &bond : atom->getOwningMol().atomBonds(atom)) {
-    if (bond->getBondType() == Bond::DATIVE || bond->getBondType() == Bond::DATIVEONE
-        || bond->getBondType() == Bond::DATIVEL || bond->getBondType() == Bond::DATIVER
-        || bond->getBondType() == Bond::NONE) {
+    if (bond->getBondType() == Bond::DATIVE ||
+        bond->getBondType() == Bond::DATIVEONE ||
+        bond->getBondType() == Bond::DATIVEL ||
+        bond->getBondType() == Bond::DATIVER ||
+        bond->getBondType() == Bond::ZERO) {
       continue;
     }
     auto otherAtom = bond->getOtherAtom(atom);


### PR DESCRIPTION
After merging #6266, builds started showing this warning:
```
rdkit/Code/GraphMol/Descriptors/OxidationNumbers.cpp:65:32: warning: comparison between
 ‘enum RDKit::Bond::BondType’ and ‘enum RDKit::Bond::BondDir’ [-Wenum-compare]
   65 |         || bond->getBondType() == Bond::NONE) {
      |            ~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~

```

This is because we don't have a `Bond::NONE` bond type, that's in the `BondDir` enum, so the comparison won't ever hit. I think @DavidACosgrove might have been thinking of a `Bond::ZERO` bond ?
