### PR TITLE
Exposed queryColour in MolDrawOptions

### DIFF
--- a/Code/GraphMol/MolDraw2D/DrawMol.cpp
+++ b/Code/GraphMol/MolDraw2D/DrawMol.cpp
@@ -1638,7 +1638,7 @@ void DrawMol::makeQueryBond(Bond *bond, double doubleBondOffset) {
   const Point2D &at2_cds = atCds_[endAt->getIdx()];
   auto midp = (at2_cds + at1_cds) / 2.;
   auto tdash = shortDashes;
-  DrawColour queryColour{0.5, 0.5, 0.5};
+  const DrawColour &queryColour = drawOptions_.queryColour;
 
   bool drawGenericQuery = false;
   int at1Idx = begAt->getIdx();

--- a/Code/GraphMol/MolDraw2D/MolDraw2D.h
+++ b/Code/GraphMol/MolDraw2D/MolDraw2D.h
@@ -542,11 +542,11 @@ class RDKIT_MOLDRAW2D_EXPORT MolDraw2D {
 
 inline void setDarkMode(MolDrawOptions &opts) {
   assignDarkModePalette(opts.atomColourPalette);
-  opts.backgroundColour = DrawColour{0, 0, 0, 1};
-  opts.annotationColour = DrawColour{0.9, 0.9, 0.9, 1};
-  opts.legendColour = DrawColour{0.9, 0.9, 0.9, 1};
-  opts.symbolColour = DrawColour{0.9, 0.9, 0.9, 1};
-  opts.variableAttachmentColour = DrawColour{0.3, 0.3, 0.3, 1};
+  opts.backgroundColour = DrawColour{0.0, 0.0, 0.0, 1.0};
+  opts.annotationColour = DrawColour{0.9, 0.9, 0.9, 1.0};
+  opts.legendColour = DrawColour{0.9, 0.9, 0.9, 1.0};
+  opts.symbolColour = DrawColour{0.9, 0.9, 0.9, 1.0};
+  opts.variableAttachmentColour = DrawColour{0.3, 0.3, 0.3, 1.0};
 }
 inline void setDarkMode(MolDraw2D &d2d) { setDarkMode(d2d.drawOptions()); }
 inline void setMonochromeMode(MolDrawOptions &opts, const DrawColour &fgColour,

--- a/Code/GraphMol/MolDraw2D/MolDraw2DHelpers.h
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DHelpers.h
@@ -151,7 +151,7 @@ struct RDKIT_MOLDRAW2D_EXPORT MolDrawOptions {
   bool splitBonds = false;             // split bonds into per atom segments
                             // most useful for dynamic manipulation of drawing
                             // especially for svg
-  DrawColour highlightColour{1, 0.5, 0.5, 1.0};  // default highlight color
+  DrawColour highlightColour{1.0, 0.5, 0.5, 1.0};  // default highlight color
   bool continuousHighlight = true;  // highlight by drawing an outline
                                     // *underneath* the molecule
   bool fillHighlights = true;     // fill the areas used to highlight atoms and
@@ -166,7 +166,9 @@ struct RDKIT_MOLDRAW2D_EXPORT MolDrawOptions {
   bool clearBackground = true;  // toggles clearing the background before
                                 // drawing a molecule
   DrawColour backgroundColour{
-      1, 1, 1, 1};          // color to be used while clearing the background
+      1.0, 1.0, 1.0, 1.0};  // color to be used while clearing the background
+  DrawColour queryColour{0.5, 0.5, 0.5,
+                         1.0};  // color to be used for query bonds
   int legendFontSize = 16;  // font size (in pixels) to be used for the legend
                             // (if present)
   double legendFraction =
@@ -198,8 +200,10 @@ struct RDKIT_MOLDRAW2D_EXPORT MolDrawOptions {
       false;  // disables inclusion of atom labels in the rendering
   std::vector<std::vector<int>> atomRegions;  // regions
   DrawColour symbolColour{
-      0, 0, 0, 1};  // color to be used for the symbols and arrows in reactions
-  DrawColour annotationColour{0, 0, 0, 1};  // color to be used for annotations
+      0.0, 0.0, 0.0,
+      1.0};  // color to be used for the symbols and arrows in reactions
+  DrawColour annotationColour{0.0, 0.0, 0.0,
+                              1.0};  // color to be used for annotations
   double bondLineWidth = 2.0;   // default line width when drawing bonds
   bool scaleBondWidth = false;  // whether to apply scale() to the bond width
   bool scaleHighlightBondWidth = true;   // likewise with bond highlights.

--- a/Code/GraphMol/MolDraw2D/MolDraw2DUtils.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DUtils.cpp
@@ -219,6 +219,7 @@ void updateMolDrawOptionsFromJSON(MolDrawOptions &opts,
 
   get_colour_option(&pt, "highlightColour", opts.highlightColour);
   get_colour_option(&pt, "backgroundColour", opts.backgroundColour);
+  get_colour_option(&pt, "queryColour", opts.queryColour);
   get_colour_option(&pt, "legendColour", opts.legendColour);
   get_colour_option(&pt, "symbolColour", opts.symbolColour);
   get_colour_option(&pt, "annotationColour", opts.annotationColour);

--- a/Code/GraphMol/MolDraw2D/Wrap/rdMolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/Wrap/rdMolDraw2D.cpp
@@ -447,11 +447,17 @@ python::tuple colourToPyTuple(const DrawColour &clr) {
 python::object getBgColour(const RDKit::MolDrawOptions &self) {
   return colourToPyTuple(self.backgroundColour);
 }
+python::object getQyColour(const RDKit::MolDrawOptions &self) {
+  return colourToPyTuple(self.queryColour);
+}
 python::object getHighlightColour(const RDKit::MolDrawOptions &self) {
   return colourToPyTuple(self.highlightColour);
 }
 void setBgColour(RDKit::MolDrawOptions &self, python::tuple tpl) {
   self.backgroundColour = pyTupleToDrawColour(tpl);
+}
+void setQyColour(RDKit::MolDrawOptions &self, python::tuple tpl) {
+  self.queryColour = pyTupleToDrawColour(tpl);
 }
 void setHighlightColour(RDKit::MolDrawOptions &self, python::tuple tpl) {
   self.highlightColour = pyTupleToDrawColour(tpl);
@@ -757,10 +763,14 @@ BOOST_PYTHON_MODULE(rdMolDraw2D) {
       .def_readwrite("splitBonds", &RDKit::MolDrawOptions::splitBonds)
       .def("getBackgroundColour", &RDKit::getBgColour,
            "method returning the background colour")
+      .def("getQueryColour", &RDKit::getQyColour,
+           "method returning the query colour")
       .def("getHighlightColour", &RDKit::getHighlightColour,
            "method returning the highlight colour")
       .def("setBackgroundColour", &RDKit::setBgColour,
            "method for setting the background colour")
+      .def("setQueryColour", &RDKit::setQyColour,
+           "method for setting the query colour")
       .def("setHighlightColour", &RDKit::setHighlightColour,
            "method for setting the highlight colour")
       .def("getSymbolColour", &RDKit::getSymbolColour,

--- a/Code/GraphMol/MolDraw2D/Wrap/testMolDraw2D.py
+++ b/Code/GraphMol/MolDraw2D/Wrap/testMolDraw2D.py
@@ -795,6 +795,24 @@ M  END''')
     sz2 = d2d.GetMolSize(m)
     self.assertEqual(sz, sz2)
 
+  def testQueryColour(self):
+    m = Chem.MolFromSmarts("c1ccc2nc([*:1])nc([*:2])c2c1")
+    self.assertIsNotNone(m)
+    # Check that default queryColour is #7F7F7F.
+    d2d = rdMolDraw2D.MolDraw2DSVG(-1, -1)
+    d2d.DrawMolecule(m)
+    d2d.FinishDrawing()
+    text = d2d.GetDrawingText()
+    self.assertTrue("#7F7F7F" in text)
+
+    # Check that queryColour can be set to black.
+    query_colour = (0.0, 0.0, 0.0)
+    d2d = rdMolDraw2D.MolDraw2DSVG(-1, -1)
+    d2d.drawOptions().setQueryColour(query_colour)
+    d2d.DrawMolecule(m)
+    d2d.FinishDrawing()
+    text = d2d.GetDrawingText()
+    self.assertTrue("#7F7F7F" not in text)
 
 if __name__ == "__main__":
   unittest.main()

--- a/Code/GraphMol/MolDraw2D/catch_tests.cpp
+++ b/Code/GraphMol/MolDraw2D/catch_tests.cpp
@@ -291,7 +291,9 @@ static const std::map<std::string, std::hash_result_t> SVG_HASHES = {
     {"test_github6170.svg", 865612473U},
     {"test_getMolSize.svg", 3574937936U},
     {"test_github6200_1.svg", 1827224658U},
-    {"test_github6200_2.svg", 661919921U}};
+    {"test_github6200_2.svg", 661919921U},
+    {"test_queryColour_1.svg", 3758375489U},
+    {"test_queryColour_2.svg", 2426598062U}};
 
 // These PNG hashes aren't completely reliable due to floating point cruft,
 // but they can still reduce the number of drawings that need visual
@@ -7562,6 +7564,43 @@ TEST_CASE(
         " L\\s+(\\d+\\.\\d+),(\\d+\\.\\d+) L\\s+(\\d+\\.\\d+),(\\d+\\.\\d+)");
     // there are 2 arcs on atom-2, for a 2 colour highlight.
     testArcs(text, atom2, 2, 2.15);
+    check_file_hash(nameBase + "_2.svg");
+  }
+}
+
+TEST_CASE("queryColour can be set to a non-default value") {
+  std::string nameBase = "test_queryColour";
+  auto m = "c1ccc2nc([*:1])nc([*:2])c2c1"_smarts;
+  REQUIRE(m);
+
+  {
+    // Check that default queryColour is #7F7F7F.
+    MolDraw2DSVG drawer(300, 300, -1, -1, NO_FREETYPE);
+    drawer.drawMolecule(*m);
+    drawer.finishDrawing();
+    std::string text = drawer.getDrawingText();
+    std::string svgName = nameBase + "_1.svg";
+    std::ofstream outs(svgName);
+    outs << text;
+    outs.flush();
+    outs.close();
+    CHECK(text.find("#7F7F7F") != std::string::npos);
+    check_file_hash(nameBase + "_1.svg");
+  }
+  {
+    // Check that queryColour can be set to black.
+    DrawColour queryColour(0.0, 0.0, 0.0);
+    MolDraw2DSVG drawer(300, 300, -1, -1, NO_FREETYPE);
+    drawer.drawOptions().queryColour = queryColour;
+    drawer.drawMolecule(*m);
+    drawer.finishDrawing();
+    std::string text = drawer.getDrawingText();
+    std::string svgName = nameBase + "_2.svg";
+    std::ofstream outs(svgName);
+    outs << text;
+    outs.flush();
+    outs.close();
+    CHECK(text.find("#7F7F7F") == std::string::npos);
     check_file_hash(nameBase + "_2.svg");
   }
 }

--- a/Code/MinimalLib/cffi_test.c
+++ b/Code/MinimalLib/cffi_test.c
@@ -1865,6 +1865,26 @@ M  END\n";
   allow_non_tetrahedral_chirality(orig_setting);
 }
 
+void test_query_colour() {
+  printf("--------------------------\n");
+  printf("  test_queryColour\n");
+  char smarts[] = "c1ccc2nc([*:1])nc([*:2])c2c1";
+  char *pkl;
+  size_t pkl_size;
+  pkl = get_qmol(smarts, &pkl_size, "");
+  assert(pkl);
+  assert(pkl_size > 0);
+  char *svg = get_svg(pkl, pkl_size, "{\"width\":350,\"height\":300}");
+  assert(strstr(svg, "#7F7F7F"));
+  assert(strstr(svg, "</svg>"));
+  free(svg);
+  svg = get_svg(pkl, pkl_size,
+                "{\"width\":350,\"height\":300,\"queryColour\":[0.0,0.0,0.0]}");
+  assert(!strstr(svg, "#7F7F7F"));
+  assert(strstr(svg, "</svg>"));
+  free(svg);
+  free(pkl);
+}
 
 int main() {
   enable_logging();
@@ -1889,5 +1909,6 @@ int main() {
   test_removehs();
   test_use_legacy_stereo();
   test_allow_non_tetrahedral_chirality();
+  test_query_colour();
   return 0;
 }

--- a/Code/MinimalLib/tests/tests.js
+++ b/Code/MinimalLib/tests/tests.js
@@ -1767,6 +1767,24 @@ M  END
     }
 }
 
+function test_query_colour() {
+    var mol = RDKitModule.get_qmol('c1ccc2nc([*:1])nc([*:2])c2c1');
+    try {
+        var svg1 = mol.get_svg_with_highlights(JSON.stringify({width: 350, height: 300}));
+        assert(svg1.includes("width='350px'"));
+        assert(svg1.includes("height='300px'"));
+        assert(svg1.includes("</svg>"));
+        assert(svg1.includes("#7F7F7F"));
+        var svg2 = mol.get_svg_with_highlights(JSON.stringify({width: 350, height: 300, queryColour: [0.0, 0.0, 0.0]}));
+        assert(svg2.includes("width='350px'"));
+        assert(svg2.includes("height='300px'"));
+        assert(svg2.includes("</svg>"));
+        assert(!svg2.includes("#7F7F7F"));
+    } finally {
+        mol.delete();
+    }
+}
+
 initRDKitModule().then(function(instance) {
     var done = {};
     const waitAllTestsFinished = () => {
@@ -1819,6 +1837,7 @@ initRDKitModule().then(function(instance) {
     test_wedging_if_no_match();
     test_get_frags();
     test_hs_in_place();
+    test_query_colour();
     waitAllTestsFinished().then(() =>
         console.log("Tests finished successfully")
     );


### PR DESCRIPTION
Currently `queryColour` is hardcoded to `(0.5, 0.5, 0.5)`.
This simple PR exposes it as part of `MolDrawOptions` such that it can be modified by users.
In passing, I have also converted some `int` values to `float` for clarity.
I also added C++, Python, `cffi` and JS unit tests.