### PR TITLE
Fixes #6287

### DIFF
--- a/Code/GraphMol/ChemTransforms/MolFragmenter.cpp
+++ b/Code/GraphMol/ChemTransforms/MolFragmenter.cpp
@@ -535,10 +535,10 @@ ROMol *fragmentOnBonds(
         conf->setAtomPos(idx2, conf->getAtomPos(eidx));
       }
     } else {
-      // was github issues 429, 6034
+      // was github issues 429, 6034, 6287
       for (auto idx : {bidx, eidx}) {
         if (auto tatom = res->getAtomWithIdx(idx);
-            tatom->getNoImplicit() ||
+            tatom->getNoImplicit() && bT != 17 ||
             (tatom->getIsAromatic() && tatom->getAtomicNum() != 6)) {
           tatom->setNumExplicitHs(tatom->getNumExplicitHs() + 1);
         } else {

--- a/Code/GraphMol/ChemTransforms/testChemTransforms.cpp
+++ b/Code/GraphMol/ChemTransforms/testChemTransforms.cpp
@@ -1657,6 +1657,28 @@ void testFragmentOnBonds() {
     delete mol;
     delete nmol;
   }
+  {
+    std::string smi = "CN1C=CN(C)[C]1->[Pd]<-[C]1N(C)C=CN1C";
+    RWMol *mol = SmilesToMol(smi);
+    TEST_ASSERT(mol);
+    TEST_ASSERT(mol->getNumAtoms() == 15);
+    unsigned int indices[] = {6, 7};
+    std::vector<unsigned int> bindices(
+        indices, indices + (sizeof(indices) / sizeof(indices[0])));
+    std::vector<unsigned int> cutsPerAtom(mol->getNumAtoms());
+    ROMol *nmol = MolFragmenter::fragmentOnBonds(*mol, bindices, false, nullptr,
+                                                 nullptr, &cutsPerAtom);
+    TEST_ASSERT(nmol);
+    TEST_ASSERT(nmol->getNumAtoms() == 15);
+    TEST_ASSERT(cutsPerAtom[6] == 1);
+    TEST_ASSERT(cutsPerAtom[7] == 2);
+    TEST_ASSERT(cutsPerAtom[8] == 1);
+    TEST_ASSERT(nmol->getAtomWithIdx(6)->getNumExplicitHs() == 0);
+    TEST_ASSERT(nmol->getAtomWithIdx(7)->getNumExplicitHs() == 0);
+    TEST_ASSERT(nmol->getAtomWithIdx(8)->getNumExplicitHs() == 0);
+    delete mol;
+    delete nmol;
+  }
 
   BOOST_LOG(rdInfoLog) << "\tdone" << std::endl;
 }


### PR DESCRIPTION

#### Reference Issue
Fixes #6287 


#### What does this implement/fix? Explain your changes.
The number of explicit hydrogens on the atoms that were connected by a bond does not get increased by one when the bond that was fragmented was a dative bond.

Before:
![before](https://user-images.githubusercontent.com/40689084/231805114-a44153c4-9965-4137-a513-50055a9105bc.png)
After:
![after](https://user-images.githubusercontent.com/40689084/231805118-c6b7954e-dea8-4805-9234-33e64aecd1b8.png)

#### Any other comments?

