### PR TITLE
remove cleanupOrganometallics() from the default sanitization

### DIFF
--- a/Code/GraphMol/FileParsers/test1.cpp
+++ b/Code/GraphMol/FileParsers/test1.cpp
@@ -4677,8 +4677,7 @@ void testParseCHG() {
 
   TEST_ASSERT(m);
   // Write it out in V3000 format, which makes counting the different charges
-  // easier but is really because of a change that caused it always to write
-  // V3000 but which is no longer extant.
+  // easier
   bool forceV3000(true);
   std::string out = MolToMolBlock(*m, true, -1, true, forceV3000);
   std::regex chg_all("CHG="), chg_m1("CHG=-1"), chg_p1("CHG=1"),

--- a/Code/GraphMol/MolOps.cpp
+++ b/Code/GraphMol/MolOps.cpp
@@ -391,12 +391,6 @@ void sanitizeMol(RWMol &mol, unsigned int &operationThatFailed,
     cleanUp(mol);
   }
 
-  operationThatFailed = SANITIZE_CLEANUP_ORGANOMETALLICS;
-  if (sanitizeOps & operationThatFailed) {
-    // clean up things like nitro groups
-    cleanUpOrganometallics(mol);
-  }
-
   // update computed properties on atoms and bonds:
   operationThatFailed = SANITIZE_PROPERTIES;
   if (sanitizeOps & operationThatFailed) {

--- a/Code/GraphMol/MolOps.h
+++ b/Code/GraphMol/MolOps.h
@@ -441,7 +441,6 @@ typedef enum {
   SANITIZE_SETHYBRIDIZATION = 0x80,
   SANITIZE_CLEANUPCHIRALITY = 0x100,
   SANITIZE_ADJUSTHS = 0x200,
-  SANITIZE_CLEANUP_ORGANOMETALLICS = 0x400,
   SANITIZE_ALL = 0xFFFFFFF
 } SanitizeFlags;
 
@@ -450,7 +449,6 @@ typedef enum {
 /*!
    This functions calls the following in sequence
      -# MolOps::cleanUp()
-     -# MolOps::cleanUpOrganometallics()
      -# mol.updatePropertyCache()
      -# MolOps::symmetrizeSSSR()
      -# MolOps::Kekulize()

--- a/Code/GraphMol/MolOps.h
+++ b/Code/GraphMol/MolOps.h
@@ -587,6 +587,9 @@ RDKIT_GRAPHMOL_EXPORT void cleanUp(RWMol &mol);
 //! organometallic species before valence is perceived
 /*!
 
+    \b Note that this function is experimental and may either change in behavior
+   or be replaced with something else in future releases.
+
     Currently this:
      - replaces single bonds between "hypervalent" organic atoms and metals with
        dative bonds (this is following an IUPAC recommendation:

--- a/Code/GraphMol/Wrap/MolOps.cpp
+++ b/Code/GraphMol/Wrap/MolOps.cpp
@@ -1588,14 +1588,14 @@ to the terminal dummy atoms.\n\
     docString =
         "cleans up certain common bad functionalities in the organometallic molecule\n\
 \n\
-  ARGUMENTS:\n\
+  Note that this function is experimental and may either change in behavior\n\
+  or be replaced with something else in future releases.\n\
 \n\
-    - mol: the molecule to use\n\
-\n\
-  NOTES:\n\
-\n\
-    - The molecule is modified in place.\n\
-\n";
+        ARGUMENTS :\n\
+\n - mol : the molecule to use\n\
+\n NOTES :\n\
+\n - The molecule is modified in place.\n\
+\n ";
     python::def("CleanupOrganometallics", cleanUpOrganometallicsMol,
                 (python::arg("mol")), docString.c_str());
 

--- a/Code/GraphMol/Wrap/MolOps.cpp
+++ b/Code/GraphMol/Wrap/MolOps.cpp
@@ -961,8 +961,6 @@ struct molops_wrapper {
     python::enum_<MolOps::SanitizeFlags>("SanitizeFlags")
         .value("SANITIZE_NONE", MolOps::SANITIZE_NONE)
         .value("SANITIZE_CLEANUP", MolOps::SANITIZE_CLEANUP)
-        .value("SANITIZE_CLEANUP_ORGANOMETALLICS",
-               MolOps::SANITIZE_CLEANUP_ORGANOMETALLICS)
         .value("SANITIZE_PROPERTIES", MolOps::SANITIZE_PROPERTIES)
         .value("SANITIZE_SYMMRINGS", MolOps::SANITIZE_SYMMRINGS)
         .value("SANITIZE_KEKULIZE", MolOps::SANITIZE_KEKULIZE)

--- a/Code/GraphMol/catch_graphmol.cpp
+++ b/Code/GraphMol/catch_graphmol.cpp
@@ -2957,7 +2957,12 @@ TEST_CASE("molecules with single bond to metal atom use dative instead") {
       {"CCC1=[O+][Cu]2([O+]=C(CC)C1)[O+]=C(CC)CC(CC)=[O+]2",
        "CCC1=[O+][Cu]2([O+]=C(CC)C1)[O+]=C(CC)CC(CC)=[O+]2"}};
   for (size_t i = 0; i < test_vals.size(); ++i) {
-    RWMOL_SPTR m(RDKit::SmilesToMol(test_vals[i].first));
+    SmilesParserParams ps;
+    ps.sanitize = false;
+    RWMOL_SPTR m(RDKit::SmilesToMol(test_vals[i].first, ps));
+    // MolOps::cleanUp(*m);
+    MolOps::cleanUpOrganometallics(*m);
+    MolOps::sanitizeMol(*m);
     TEST_ASSERT(MolToSmiles(*m) == test_vals[i].second);
   }
 }

--- a/Docs/Book/RDKit_Book.rst
+++ b/Docs/Book/RDKit_Book.rst
@@ -1604,44 +1604,37 @@ Here are the steps involved, in order.
 
      This step should not generate exceptions.
 
-  3. ``cleanUpOrganometallics``: standardizes a small number of non-standard
-     situations encountered in organometallics. The cleanup operations are:
-     
-       - replaces single bonds from hypervalent atoms to metals with dative bonds.
-
-     This step should not generate exceptions.
-
-  4. ``updatePropertyCache``: calculates the explicit and implicit valences on
+  3. ``updatePropertyCache``: calculates the explicit and implicit valences on
      all atoms. This generates exceptions for atoms in higher-than-allowed
      valence states. This step is always performed, but if it is "skipped"
      the test for non-standard valences will not be carried out.
 
-  5. ``symmetrizeSSSR``: calls the symmetrized smallest set of smallest rings
+  4. ``symmetrizeSSSR``: calls the symmetrized smallest set of smallest rings
      algorithm (discussed in the Getting Started document).
 
-  6. ``Kekulize``: converts aromatic rings to their Kekule form. Will raise an
+  5. ``Kekulize``: converts aromatic rings to their Kekule form. Will raise an
      exception if a ring cannot be kekulized or if aromatic bonds are found
      outside of rings.
 
-  7. ``assignRadicals``: determines the number of radical electrons (if any) on
+  6. ``assignRadicals``: determines the number of radical electrons (if any) on
      each atom.
 
-  8. ``setAromaticity``: identifies the aromatic rings and ring systems
+  7. ``setAromaticity``: identifies the aromatic rings and ring systems
      (see above), sets the aromatic flag on atoms and bonds, sets bond orders
      to aromatic.
 
-  9. ``setConjugation``: identifies which bonds are conjugated
+  8. ``setConjugation``: identifies which bonds are conjugated
 
-  10. ``setHybridization``: calculates the hybridization state of each atom
+  9. ``setHybridization``: calculates the hybridization state of each atom
 
-  11. ``cleanupChirality``: removes chiral tags from atoms that are not sp3
+  10. ``cleanupChirality``: removes chiral tags from atoms that are not sp3
       hybridized.
 
-  12. ``adjustHs``: adds explicit Hs where necessary to preserve the chemistry.
+  11. ``adjustHs``: adds explicit Hs where necessary to preserve the chemistry.
       This is typically needed for heteroatoms in aromatic rings. The classic
       example is the nitrogen atom in pyrrole.
 
-  13. ``updatePropertyCache``: re-calculates the explicit and implicit valences on
+  12. ``updatePropertyCache``: re-calculates the explicit and implicit valences on
      all atoms. This generates exceptions for atoms in higher-than-allowed
      valence states. This step is required to catch some edge cases where input 
      atoms with non-physical valences are accepted if they are flagged as aromatic.


### PR DESCRIPTION
This reverts some of the changes in #6038: `cleanUpOrganometallics()` is no longer part of the default sanitization process. The function is still available for people who choose to use it, though I've flagged it as experimental for this release.

There are two reasons for the change, both arising from the fact that the current implementation makes an arbitrary bond from a hypervalent atom to a metal to make dative:
1. The choice of bond to change is not canonical, so providing the same molecule with different atom orderings will produce different results and, thus, different SMILES. Here's a simple example of that:
```
In [3]: Chem.MolToSmiles(Chem.MolFromSmiles('F[Pd](Cl)(Cl1)Cl[Pd]1(Cl)Cl'))
Out[3]: 'F[Pd]1(Cl)<-Cl[Pd](Cl)(Cl)Cl->1'

In [4]: Chem.MolToSmiles(Chem.MolFromSmiles('Cl[Pd](Cl)(Cl1)Cl[Pd]1(Cl)F'))
Out[4]: 'F[Pd]1(Cl)Cl->[Pd](Cl)(Cl)<-Cl1'
```
2. Sometimes the choices of which bond to change are just wrong. The above examples both demonstrate that. Here's an example output:
![image](https://user-images.githubusercontent.com/540511/231938367-c3e46a8d-4aac-4663-aa99-d86fe6f3cc2d.png)
That structure should have one dative bond to each metal atom, not two bonds to the same metal.

Once we've come up with  solutions to these we can consider re-adding `cleanUpOrganometallics()` to the default sanitization path.

Thanks to @ricrogz for noticing the problem.