### PR TITLE
(WIP) Feature/topological steric effect index

### DIFF
--- a/Code/GraphMol/Descriptors/CMakeLists.txt
+++ b/Code/GraphMol/Descriptors/CMakeLists.txt
@@ -13,6 +13,7 @@ rdkit_library(Descriptors
               AUTOCORR2D.cpp Data3Ddescriptors.cpp MolData3Ddescriptors.cpp
               USRDescriptor.cpp AtomFeat.cpp
               OxidationNumbers.cpp
+              TSEI.cpp
               ${DESC3D_SOURCES}
               LINK_LIBRARIES PartialCharges SmilesParse FileParsers Subgraphs SubstructMatch MolTransforms GraphMol
                  EigenSolvers RDGeneral)
@@ -27,6 +28,7 @@ rdkit_headers(Crippen.h BCUT.h Lipinski.h
               AUTOCORR2D.h Data3Ddescriptors.h MolData3Ddescriptors.h
               USRDescriptor.h AtomFeat.h
               OxidationNumbers.h
+              TSEI.h
               ${DESC3D_HDRS}
               DEST GraphMol/Descriptors)
 

--- a/Code/GraphMol/Descriptors/MolDescriptors.h
+++ b/Code/GraphMol/Descriptors/MolDescriptors.h
@@ -17,6 +17,7 @@
 #include <GraphMol/Descriptors/Lipinski.h>
 #include <GraphMol/Descriptors/ConnectivityDescriptors.h>
 #include <GraphMol/Descriptors/MQN.h>
+#include <GraphMol/Descriptors/TSEI.h>
 #include <GraphMol/Descriptors/AUTOCORR2D.h>
 
 namespace RDKit {

--- a/Code/GraphMol/Descriptors/TSEI.cpp
+++ b/Code/GraphMol/Descriptors/TSEI.cpp
@@ -5,6 +5,8 @@
 #include <GraphMol/RDKitBase.h>
 #include <GraphMol/Descriptors/MolDescriptors.h>
 
+
+
 namespace RDKit {
 namespace Descriptors {
 
@@ -20,21 +22,21 @@ std::vector<double> calcTSEI(const ROMol& mol, bool force) {
   auto nAtoms = mol.getNumAtoms();
   auto table = RDKit::PeriodicTable::getTable();
 
-  for (auto a1Idx = 0; a1Idx < nAtoms; ++a1Idx) {
+  for (auto idx1 = 0; idx1 < nAtoms; ++idx1) {
     auto val = 0.0;
-    auto iR = table->getRcovalent(mol.getAtomWithIdx(a1Idx)->getAtomicNum());
-    for (auto j = 0; j < nAtoms; ++j) {
-      if (pathMat[a1Idx * nAtoms + j] == -1) {
+    auto iR = table->getRcovalent(mol.getAtomWithIdx(idx1)->getAtomicNum());
+    for (auto idx2 = 0; idx2 < nAtoms; ++idx2) {
+      if (pathMat[idx1 * nAtoms + idx2] == -1) {
         continue;
       }
       auto distance = 0.0;
-      auto jR = table->getRcovalent(mol.getAtomWithIdx(j)->getAtomicNum());
-      auto k = j;
+      auto jR = table->getRcovalent(mol.getAtomWithIdx(idx2)->getAtomicNum());
+      auto k = idx2;
       while (k > -1) {
         // for every step on the path add twice the covalent radius
         distance +=
             2 * (table->getRcovalent(mol.getAtomWithIdx(k)->getAtomicNum()));
-        k = pathMat[a1Idx * nAtoms + k];
+        k = pathMat[idx1 * nAtoms + k];
       }
       distance = distance - iR - jR;  // correct for the endpoints
       val += pow(jR, 3) / pow(distance, 3);

--- a/Code/GraphMol/Descriptors/TSEI.cpp
+++ b/Code/GraphMol/Descriptors/TSEI.cpp
@@ -20,11 +20,11 @@ std::vector<double> calcTSEI(const ROMol& mol, bool force) {
   auto nAtoms = mol.getNumAtoms();
   auto table = RDKit::PeriodicTable::getTable();
 
-  for (auto i = 0; i < nAtoms; ++i) {
+  for (auto a1Idx = 0; a1Idx < nAtoms; ++a1Idx) {
     auto val = 0.0;
-    auto iR = table->getRcovalent(mol.getAtomWithIdx(i)->getAtomicNum());
+    auto iR = table->getRcovalent(mol.getAtomWithIdx(a1Idx)->getAtomicNum());
     for (auto j = 0; j < nAtoms; ++j) {
-      if (pathMat[i * nAtoms + j] == -1) {
+      if (pathMat[a1Idx * nAtoms + j] == -1) {
         continue;
       }
       auto distance = 0.0;
@@ -34,7 +34,7 @@ std::vector<double> calcTSEI(const ROMol& mol, bool force) {
         // for every step on the path add twice the covalent radius
         distance +=
             2 * (table->getRcovalent(mol.getAtomWithIdx(k)->getAtomicNum()));
-        k = pathMat[i * nAtoms + k];
+        k = pathMat[a1Idx * nAtoms + k];
       }
       distance = distance - iR - jR;  // correct for the endpoints
       val += pow(jR, 3) / pow(distance, 3);

--- a/Code/GraphMol/Descriptors/TSEI.cpp
+++ b/Code/GraphMol/Descriptors/TSEI.cpp
@@ -1,0 +1,51 @@
+//
+// Created by Jason Biggs on 4/15/23.
+//
+
+#include <GraphMol/RDKitBase.h>
+#include <GraphMol/Descriptors/MolDescriptors.h>
+
+namespace RDKit {
+namespace Descriptors {
+
+std::vector<double> calcTSEI(const ROMol& mol, bool force) {
+  std::vector<double> res;
+  if (!force && mol.getPropIfPresent("_TSEI", res)) {
+    return res;
+  }
+  RDKit::MolOps::getDistanceMat(mol, false, false, force);
+  boost::shared_array<int> pathMat;
+  mol.getProp(RDKit::common_properties::DistanceMatrix_Paths, pathMat);
+
+  auto nAtoms = mol.getNumAtoms();
+  auto table = RDKit::PeriodicTable::getTable();
+
+  for (auto i = 0; i < nAtoms; ++i) {
+    auto val = 0.0;
+    auto iR = table->getRcovalent(mol.getAtomWithIdx(i)->getAtomicNum());
+    for (auto j = 0; j < nAtoms; ++j) {
+      if (pathMat[i * nAtoms + j] == -1) {
+        continue;
+      }
+      auto distance = 0.0;
+      auto jR = table->getRcovalent(mol.getAtomWithIdx(j)->getAtomicNum());
+      auto k = j;
+      while (k > -1) {
+        // for every step on the path add twice the covalent radius
+        distance +=
+            2 * (table->getRcovalent(mol.getAtomWithIdx(k)->getAtomicNum()));
+        k = pathMat[i * nAtoms + k];
+      }
+      distance = distance - iR - jR;  // correct for the endpoints
+      val += pow(jR, 3) / pow(distance, 3);
+    }
+    res.push_back(8.0 * val);
+  }
+
+  mol.setProp("_TSEI", res, true);
+
+  return res;
+}
+
+}  // end of namespace Descriptors
+}  // end of namespace RDKit

--- a/Code/GraphMol/Descriptors/TSEI.h
+++ b/Code/GraphMol/Descriptors/TSEI.h
@@ -1,0 +1,36 @@
+//
+// Created by Jason Biggs on 4/15/23.
+//
+
+#include <RDGeneral/export.h>
+#ifndef RDKIT_TSEI_H
+#define RDKIT_TSEI_H
+
+#include <vector>
+#include <string>
+
+namespace RDKit {
+class ROMol;
+namespace Descriptors {
+const std::string TSEIVersion = "1.0.0";
+
+//! calculates MQN descriptors
+/*!
+  Chenzhong Cao and Li Liu
+  "Topological steric effect index and its application"
+  CJ Chem Inf Comput Sci 44(2), 678-687, 2004.
+
+
+  \param mol        the molecule of interest
+  \param force      (optional) calculate the values even if they are cached.
+
+  \return a vector with the TSEIs
+
+*/
+RDKIT_DESCRIPTORS_EXPORT std::vector<double> calcTSEI(const ROMol &mol,
+                                                      bool force = false);
+
+}  // end of namespace Descriptors
+}  // end of namespace RDKit
+
+#endif  // RDKIT_TSEI_H

--- a/Code/GraphMol/Descriptors/TSEI.h
+++ b/Code/GraphMol/Descriptors/TSEI.h
@@ -14,11 +14,11 @@ class ROMol;
 namespace Descriptors {
 const std::string TSEIVersion = "1.0.0";
 
-//! calculates MQN descriptors
+//! calculates TSEI descriptors
 /*!
   Chenzhong Cao and Li Liu
   "Topological steric effect index and its application"
-  CJ Chem Inf Comput Sci 44(2), 678-687, 2004.
+  J Chem Inf Comput Sci 44(2), 678-687, 2004.
 
 
   \param mol        the molecule of interest

--- a/Code/GraphMol/Descriptors/catch_tests.cpp
+++ b/Code/GraphMol/Descriptors/catch_tests.cpp
@@ -548,3 +548,38 @@ TEST_CASE("Oxidation numbers") {
     }
   }
 }
+
+
+TEST_CASE("Topological Steric Effect Index") {
+  SECTION("propane") {
+    auto m = "CCC"_smiles;
+    REQUIRE(m);
+    std::vector<double> expected{1.125, 2., 1.125};
+    auto res = Descriptors::calcTSEI(*m);
+    CHECK(res.size() == expected.size());
+    for(auto i = 0; i < res.size(); ++i) {
+      CHECK(expected[i] == Approx(res[i]).epsilon(0.0001));
+    }
+  }
+  SECTION("straight chain alkanes") {
+    std::vector<std::pair<std::string, double>> data = {
+        // table 1 from the paper
+        {"CC", 1.0000},
+        {"CCC", 1.1250},
+        {"CCCC", 1.1620},
+        {"CCCCC", 1.1777},
+        {"CCCCCC", 1.1857},
+        {"CCCCCCC", 1.1903},
+        {"CCCCCCCC", 1.1932},
+        {"CCCCCCCCC", 1.1952},
+        {"CCCCCCCCCC", 1.1965},
+        {"CCCCCCCCCCC", 1.1975}
+    };
+    for(auto molData : data) {
+      std::unique_ptr<ROMol> m(SmilesToMol(molData.first));
+      REQUIRE(m);
+      CHECK(molData.second == Approx(Descriptors::calcTSEI(*m).front()).epsilon(0.0001));
+    }
+
+  }
+}


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! 
-->
#### Reference Issue
implements #4229


#### What does this implement/fix? Explain your changes.

Topological steric effect index (TSEI)

Cao and Liu, J Chem Inf Comput Sci 44(2), 678-687, 2004.
[dx.doi.org/10.1021/ci034266b](https://pubmed.ncbi.nlm.nih.gov/15032550/)

This is a per-atom numerical descriptor meant to describe the steric hindrance around a given atom - how hard would it be to add a substituent there.

This descriptor was requested by a user of our product, and I threw together an implementation at the time. What I put together seems to match the values in the paper given for alkyl groups, but I don't have access to another implementation in order to check the results.


#### Any other comments?
The test I added just checks the value of the descriptor for the terminal carbon in a straight alkane.  I could add some regression tests for more complex molecules but would have to compute the values and not get them from the original source.

The values for this descriptor change depending on whether the molecule has explicit hydrogen atoms.

This is c++ only, other wrappers will have to come from another contributor.

You could also make a 3D variant on this descriptor just using the through-space distance rather than the bond-path distance.