### PR TITLE
has_coords() now reports whether coords are 2D or 3D if present

### DIFF
--- a/Code/MinimalLib/cffi_test.c
+++ b/Code/MinimalLib/cffi_test.c
@@ -930,9 +930,11 @@ M  END\n",
   assert(set_3d_coords(&mpkl, &mpkl_size, "") > 0);
   char *cxsmi3 = get_cxsmiles(mpkl, mpkl_size, NULL);
   assert(set_3d_coords(&mpkl, &mpkl_size, "{\"randomSeed\":123}") > 0);
+  assert(has_coords(mpkl, mpkl_size) == 3);
   assert(set_3d_coords(&mpkl, &mpkl_size,
                        "{\"randomSeed\":123,\"coordMap\":{\"3\":[0,0,0],\"4\":["
                        "0,0,1.5],\"5\":[0,1.5,1.5]}}") > 0);
+  assert(has_coords(mpkl, mpkl_size) == 3);
   cxsmi = get_cxsmiles(mpkl, mpkl_size, NULL);
   // since we have coords there's something there:
   assert(strstr(cxsmi, "|"));
@@ -1114,7 +1116,7 @@ M  END\n",
     assert(!strcmp(match_json, "{\"atoms\":[11,10,7,8,9,6],\"bonds\":[10,18,7,8,9,6]}"));
     free(match_json);
     // coordinates should be present as alignment has taken place anyway
-    assert(has_coords(mpkl_smi, mpkl_smi_size));
+    assert(has_coords(mpkl_smi, mpkl_smi_size) == 2);
     free(mpkl_smi);
 
     mpkl2_size = mpkl_size;
@@ -1164,14 +1166,14 @@ M  END\n",
     memcpy(mpkl2, mpkl_smi, mpkl2_size);
     assert(!has_coords(mpkl2, mpkl2_size));
     set_2d_coords(&mpkl2, &mpkl2_size);
-    assert(has_coords(mpkl2, mpkl2_size));
+    assert(has_coords(mpkl2, mpkl2_size) == 2);
     mpkl2_molblock_before = get_molblock(mpkl2, mpkl2_size, "");
     // This should fail
     assert(!set_2d_coords_aligned(
         &mpkl2, &mpkl2_size, tpkl, tpkl_size, details, &match_json));
     assert(!match_json);
     // coordinates should be unchanged since alignment has not taken place
-    assert(has_coords(mpkl2, mpkl2_size));
+    assert(has_coords(mpkl2, mpkl2_size) == 2);
     mpkl2_molblock_after = get_molblock(mpkl2, mpkl2_size, "");
     assert(!strcmp(mpkl2_molblock_before, mpkl2_molblock_after));
     free(mpkl2_molblock_after);
@@ -1184,7 +1186,7 @@ M  END\n",
     assert(!strcmp(match_json, "{}"));
     free(match_json);
     // coordinates should have changed since coordinate generation has taken place anyway using CoordGen
-    assert(has_coords(mpkl2, mpkl2_size));
+    assert(has_coords(mpkl2, mpkl2_size) == 2);
     mpkl2_molblock_after = get_molblock(mpkl2, mpkl2_size, "");
     assert(strcmp(mpkl2_molblock_before, mpkl2_molblock_after));
     free(mpkl2_molblock_before);
@@ -1197,7 +1199,7 @@ M  END\n",
     assert(!strcmp(match_json, "{}"));
     free(match_json);
     // coordinates should be present since coordinate generation has taken place anyway using CoordGen
-    assert(has_coords(mpkl_smi, mpkl_smi_size));
+    assert(has_coords(mpkl_smi, mpkl_smi_size) == 2);
     free(mpkl_smi);
 
     memset(details, 0, 200);

--- a/Code/MinimalLib/cffiwrapper.cpp
+++ b/Code/MinimalLib/cffiwrapper.cpp
@@ -643,6 +643,9 @@ extern "C" short has_coords(char *mol_pkl, size_t mol_pkl_sz) {
   if (mol_pkl && mol_pkl_sz) {
     auto mol = mol_from_pkl(mol_pkl, mol_pkl_sz);
     res = (mol.getNumConformers() > 0);
+    if (res) {
+      res = mol.getConformer().is3D() ? 3 : 2;
+    }
   }
   return res;
 }

--- a/Code/MinimalLib/minilib.cpp
+++ b/Code/MinimalLib/minilib.cpp
@@ -587,6 +587,13 @@ std::string JSMol::generate_aligned_coords(const JSMol &templateMol,
                                              details.c_str());
 }
 
+int JSMol::has_coords() const {
+  if (!d_mol || !d_mol->getNumConformers()) {
+    return 0;
+  }
+  return (d_mol->getConformer().is3D() ? 3 : 2);
+}
+
 double JSMol::normalize_depiction(int canonicalize, double scaleFactor) {
   if (!d_mol || !d_mol->getNumConformers()) {
     return -1.;

--- a/Code/MinimalLib/minilib.h
+++ b/Code/MinimalLib/minilib.h
@@ -99,9 +99,7 @@ class JSMol {
     return generate_aligned_coords(templateMol, "{}");
   }
   bool is_valid() const { return d_mol.get() != nullptr; }
-  bool has_coords() const {
-    return d_mol.get() != nullptr && d_mol->getNumConformers() != 0;
-  }
+  int has_coords() const;
 
   std::string get_stereo_tags() const;
   std::string get_aromatic_form() const;

--- a/Code/MinimalLib/tests/tests.js
+++ b/Code/MinimalLib/tests/tests.js
@@ -823,12 +823,38 @@ M  END
 
 function test_has_coords() {
     var mol = RDKitModule.get_mol('CC');
+    console.log(`1) test_has_coords`);
     assert(!mol.has_coords());
     var mol2 = RDKitModule.get_mol(mol.get_new_coords());
-    assert(mol2.has_coords());
+    assert(mol2.has_coords() === 2);
     assert(!mol.has_coords());
     mol.set_new_coords();
-    assert(mol.has_coords());
+    assert(mol.has_coords() === 2);
+    var mol3 = RDKitModule.get_mol(`
+     RDKit          3D
+
+  9  9  0  0  0  0  0  0  0  0999 V2000
+   -0.5909   -0.6086    0.0018 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -0.2459    0.8185   -0.0936 C   0  0  0  0  0  0  0  0  0  0  0  0
+    0.8271   -0.1760    0.1017 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -1.1425   -0.9648    0.9113 H   0  0  0  0  0  0  0  0  0  0  0  0
+   -0.8767   -1.2011   -0.8967 H   0  0  0  0  0  0  0  0  0  0  0  0
+   -0.5849    1.4596    0.7584 H   0  0  0  0  0  0  0  0  0  0  0  0
+   -0.2393    1.3618   -1.0674 H   0  0  0  0  0  0  0  0  0  0  0  0
+    1.4853   -0.4161   -0.7761 H   0  0  0  0  0  0  0  0  0  0  0  0
+    1.3678   -0.2732    1.0608 H   0  0  0  0  0  0  0  0  0  0  0  0
+  1  2  1  0
+  2  3  1  0
+  3  1  1  0
+  1  4  1  0
+  1  5  1  0
+  2  6  1  0
+  2  7  1  0
+  3  8  1  0
+  3  9  1  0
+M  END
+`);
+assert(mol3.has_coords() === 3);
 }
 
 function test_kekulize() {


### PR DESCRIPTION
With this PR `has_coords()` will return `2` or `3` depending whether coordinates are 2D or 3D, if present, rather than just returning `1` (CFFI) or `true` (JS).
Note that the perception of 2D/3D is only based on the return value of `Conformer::is3D()` - no attempt is made to perceive the actual 3D character. This is still very useful in many circumstances, and this change should not break existing code relying on `has_coords()`.