### PR TITLE
Improve the installation/testing instructions for linux/conda

### DIFF
--- a/Docs/Book/Install.md
+++ b/Docs/Book/Install.md
@@ -119,6 +119,12 @@ cmake -DPy_ENABLE_SHARED=1 \
 
 And finally, `make`, `make install` and `ctest`
 
+The `ctest` build requires that the installation path (the root of the source tree with RDK_INSTALL_INTREE=ON as above) be set in the RDBASE environment variable, and that the location of the installed Python files and shared library files to use for the tests be properly specified. This can be done by setting environment variables for the ctest run as follows:
+
+```
+RDBASE=$PWD/.. PYTHONPATH=$RDBASE LD_LIBRARY_PATH=$RDBASE/lib:$LD_LIBRARY_PATH ctest
+```
+
 
 ### Installing and using PostgreSQL and the RDKit PostgreSQL cartridge from a conda environment
 


### PR DESCRIPTION
The stated `make`, `make install` and `ctest` aren't sufficient to get ctest to run properly without errors, and there's only limited indication in the output about what's needed to fix the errors you get. Add more information about the needed settings to get ctest to run properly. 
