### PR TITLE
Fix UnitTestPandasTools for running without pandas installed.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,18 +88,33 @@ __pycache__/
 
 
 /Code/GraphMol/FileParsers/test_data/blah.sdf
+/Code/GraphMol/FileParsers/test_data/blah_molsupplier.sdf
 /Code/GraphMol/FileParsers/test_data/cdk2_stereo.sdf
+/Code/GraphMol/FileParsers/test_data/cdk2_stereo_molsupplier.sdf
 /Code/GraphMol/FileParsers/test_data/outNCI_few.sdf
 /Code/GraphMol/FileParsers/test_data/outNCI_few.tdt
+/Code/GraphMol/FileParsers/test_data/outNCI_few.sdf_molwriter.sdf
+/Code/GraphMol/FileParsers/test_data/outNCI_few_molsupplier.sdf
+/Code/GraphMol/FileParsers/test_data/outNCI_few_molwriter.sdf
+/Code/GraphMol/FileParsers/test_data/outNCI_few_molwriter.tdt
 /Code/GraphMol/FileParsers/test_data/outNCI_first_200.props.sdf
+/Code/GraphMol/FileParsers/test_data/outNCI_first_200.props_molwriter.sdf
 /Code/GraphMol/FileParsers/test_data/outSmiles.csv
+/Code/GraphMol/FileParsers/test_data/outSmiles_molsupplier.csv
+/Code/GraphMol/FileParsers/test_data/outSmiles_molwriter.csv
 /Code/GraphMol/FileParsers/test_data/testSGroupsSample_V?000.mol
+/Code/GraphMol/FileParsers/test_data/testSubstanceGroupsSample_V?000.mol
 
 /Code/GraphMol/ForceFieldHelpers/UFF/test_data/Issue62.sdf
 
 /Code/GraphMol/MolAlign/test_data/ref_e2_pyCrippenO3A.sdf
 
+/Code/GraphMol/MolDraw2D/Comic_Neue.zip
+
+/Code/GraphMol/MolTransforms/test_data/github4302_canon.sdf
+
 /Code/GraphMol/Wrap/test_data/bilastine_trajectory.sdf
+/Code/GraphMol/Wrap/test_data/outMaeWriter.mae
 /Code/GraphMol/Wrap/test_data/outNCI_few.sdf
 /Code/GraphMol/Wrap/test_data/outSmiles.txt
 
@@ -107,6 +122,10 @@ __pycache__/
 /Code/GraphMol/test_data/prop.pkl
 
 /Projects/DbCLI/testData/bzr/
+
+/rdkit/Chem/Draw/similarityMap1_out.svg
+/rdkit/Chem/Draw/similarityMap1_out2.svg
+/rdkit/Chem/Draw/similarityMap1_out3.svg
 
 /rdkit/sping/tests/testallps.ps
 

--- a/rdkit/Chem/UnitTestPandasTools.py
+++ b/rdkit/Chem/UnitTestPandasTools.py
@@ -20,15 +20,22 @@ except ImportError:
 PandasTools.UninstallPandasTools()
 
 
-@unittest.skipIf(PandasTools.pd is None, 'Pandas not installed, skipping')
+@unittest.skipIf( (not hasattr(PandasTools, 'pd')) or PandasTools.pd is None, 'Pandas not installed, skipping')
 class TestPandasTools(unittest.TestCase):
 
   def __init__(self, methodName='runTest'):
-    self.df = getTestFrame()
-    self.df.index.name = 'IndexName'
+    self.df = None
     super(TestPandasTools, self).__init__(methodName=methodName)
 
+  def initialize_dataframe(self):
+    # We only need to initialize the dataframe once, but we defer to actual running of the tests,
+    # as getTestFrame() needs pandas installed, and __init__() is run even in the absence of pandas.
+    if self.df is None:
+        self.df = getTestFrame()
+        self.df.index.name = 'IndexName'
+
   def setUp(self):
+    self.initialize_dataframe()
     PandasTools.InstallPandasTools()
     PandasTools.ChangeMoleculeRendering(renderer='PNG')
     PandasTools.pd.set_option('display.max_columns', None)
@@ -204,7 +211,7 @@ class TestPandasTools(unittest.TestCase):
                      ['F[*:2]', 'Cl[*:2]', 'O[*:2]', 'F[*:2]', 'F[*:2]'])
 
 
-@unittest.skipIf(PandasTools.pd is None, 'Pandas not installed, skipping')
+@unittest.skipIf( (not hasattr(PandasTools, 'pd')) or PandasTools.pd is None, 'Pandas not installed, skipping')
 class TestLoadSDF(unittest.TestCase):
   gz_filename = os.path.join(RDConfig.RDCodeDir, 'Chem', 'test_data', 'pandas_load.sdf.gz')
 
@@ -267,7 +274,7 @@ class TestLoadSDF(unittest.TestCase):
     self.assertEqual(set(df.columns), set("ID prop1 prop2 prop3".split()))
 
 
-@unittest.skipIf(PandasTools.pd is None, 'Pandas not installed, skipping')
+@unittest.skipIf( (not hasattr(PandasTools, 'pd')) or PandasTools.pd is None, 'Pandas not installed, skipping')
 class TestWriteSDF(unittest.TestCase):
 
   def setUp(self):


### PR DESCRIPTION
There's some existing code for making the UnitTestPandasTools tests robust to running in an environment where pandas is not present. (e.g. like the new conda environment one would make according to Docs/Book/Install.md). However, those precautions don't quite work with the current codebase.

Update the skip-test logic to check for the current situation. Also, defer using functionality which is only loaded in the presence of pandas until test running time. (As `__init__()` is called even when the test is being skipped.)

As a bonus, I added more test-generated files to the .gitignore file. (The files are not related to UnitTestPandasTools, but I figured it was close enough to not require a separate PR. )

