### PR TITLE
Aromatic dashes look bad

### DIFF
--- a/Code/GraphMol/MolDraw2D/DrawShape.h
+++ b/Code/GraphMol/MolDraw2D/DrawShape.h
@@ -25,7 +25,7 @@ namespace RDKit {
 class MolDraw2D;
 const DashPattern noDash;
 const DashPattern dots{2.0, 6.0};
-const DashPattern dashes{6, 3};
+const DashPattern dashes{6, 4};
 const DashPattern shortDashes{2.0, 2.0};
 
 namespace MolDraw2D_detail {

--- a/Code/GraphMol/MolDraw2D/DrawShape.h
+++ b/Code/GraphMol/MolDraw2D/DrawShape.h
@@ -25,7 +25,7 @@ namespace RDKit {
 class MolDraw2D;
 const DashPattern noDash;
 const DashPattern dots{2.0, 6.0};
-const DashPattern dashes{6, 4};
+const DashPattern dashes{6.0, 4.0};
 const DashPattern shortDashes{2.0, 2.0};
 
 namespace MolDraw2D_detail {

--- a/Code/GraphMol/MolDraw2D/DrawShape.h
+++ b/Code/GraphMol/MolDraw2D/DrawShape.h
@@ -25,7 +25,7 @@ namespace RDKit {
 class MolDraw2D;
 const DashPattern noDash;
 const DashPattern dots{2.0, 6.0};
-const DashPattern dashes{6, 0, 6.0};
+const DashPattern dashes{6, 3};
 const DashPattern shortDashes{2.0, 2.0};
 
 namespace MolDraw2D_detail {


### PR DESCRIPTION
The current drawing code does a poor job with aromatic dashes.

Here are three example molecules:
default rendering of non-kekulized benzene:
![image](https://user-images.githubusercontent.com/540511/233552418-72f28c22-47e5-4c7f-bdc4-378fadd35464.png)
ACS1996 version of that:
![image](https://user-images.githubusercontent.com/540511/233552483-42c802f1-6d4c-48af-b5b1-84630f5eac6a.png)
ferrocene:
![image](https://user-images.githubusercontent.com/540511/233552528-ac3828ad-1f14-40ad-9f9a-fab69f1a5f8e.png)

There's an argument that the first case isn't too terrible, but I think in general both the dashes and the gaps are too long.


Here are the three test cases with the new dashes:
default rendering:
![image](https://user-images.githubusercontent.com/540511/233552134-4a88ddfe-41a2-4cac-ac08-2d124291b14f.png)
ACS 1996:
![image](https://user-images.githubusercontent.com/540511/233552220-2620c997-454e-4d5d-a4db-15a80ba941e7.png)
ferrocene:
![image](https://user-images.githubusercontent.com/540511/233552244-dbb1aa92-2cae-404f-9881-2635afcb7972.png)

